### PR TITLE
Add support for the HIVE_FILE_PATTERN option - that allows partitioned files to be written without writing them to a hive-style directory structure

### DIFF
--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -78,6 +78,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile &op) {
 	cast_copy.expected_types = op.expected_types;
 	cast_copy.parallel = mode == CopyFunctionExecutionMode::PARALLEL_COPY_TO_FILE;
 	cast_copy.write_empty_file = op.write_empty_file;
+	cast_copy.hive_file_pattern = op.hive_file_pattern;
 
 	cast_copy.children.push_back(plan);
 	return copy;

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -52,6 +52,7 @@ public:
 	bool partition_output;
 	bool write_partition_columns;
 	bool write_empty_file;
+	bool hive_file_pattern;
 	vector<idx_t> partition_columns;
 	vector<string> names;
 	vector<LogicalType> expected_types;

--- a/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
+++ b/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
@@ -44,6 +44,7 @@ public:
 	bool partition_output;
 	bool write_partition_columns;
 	bool write_empty_file = true;
+	bool hive_file_pattern = true;
 	PreserveOrderType preserve_order = PreserveOrderType::AUTOMATIC;
 	vector<idx_t> partition_columns;
 	vector<string> names;

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -57,6 +57,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type) 
 	bool seen_filepattern = false;
 	bool write_partition_columns = false;
 	bool write_empty_file = true;
+	bool hive_file_pattern = true;
 	PreserveOrderType preserve_order = PreserveOrderType::AUTOMATIC;
 	CopyFunctionReturnType return_type = CopyFunctionReturnType::CHANGED_ROWS;
 
@@ -137,6 +138,8 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type) 
 			write_partition_columns = GetBooleanArg(context, option.second);
 		} else if (loption == "write_empty_file") {
 			write_empty_file = GetBooleanArg(context, option.second);
+		} else if (loption == "hive_file_pattern") {
+			hive_file_pattern = GetBooleanArg(context, option.second);
 		} else {
 			stmt.info->options[option.first] = option.second;
 		}
@@ -271,6 +274,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type) 
 	copy->write_empty_file = write_empty_file;
 	copy->return_type = return_type;
 	copy->preserve_order = preserve_order;
+	copy->hive_file_pattern = hive_file_pattern;
 
 	copy->names = unique_column_names;
 	copy->expected_types = select_node.types;

--- a/src/planner/operator/logical_copy_to_file.cpp
+++ b/src/planner/operator/logical_copy_to_file.cpp
@@ -68,6 +68,7 @@ void LogicalCopyToFile::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault(216, "write_partition_columns", write_partition_columns, true);
 	serializer.WritePropertyWithDefault(217, "write_empty_file", write_empty_file, true);
 	serializer.WritePropertyWithDefault(218, "preserve_order", preserve_order, PreserveOrderType::AUTOMATIC);
+	serializer.WritePropertyWithDefault(219, "hive_file_pattern", hive_file_pattern, true);
 }
 
 unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(Deserializer &deserializer) {
@@ -115,6 +116,7 @@ unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(Deserializer &deseria
 	auto write_empty_file = deserializer.ReadPropertyWithExplicitDefault(217, "write_empty_file", true);
 	auto preserve_order =
 	    deserializer.ReadPropertyWithExplicitDefault(218, "preserve_order", PreserveOrderType::AUTOMATIC);
+	auto hive_file_pattern = deserializer.ReadPropertyWithExplicitDefault(219, "hive_file_pattern", true);
 
 	if (!has_serialize) {
 		// If not serialized, re-bind with the copy info
@@ -144,6 +146,7 @@ unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(Deserializer &deseria
 	result->write_partition_columns = write_partition_columns;
 	result->write_empty_file = write_empty_file;
 	result->preserve_order = preserve_order;
+	result->hive_file_pattern = hive_file_pattern;
 
 	return std::move(result);
 }

--- a/test/sql/copy/parquet/writer/partition_without_hive.test
+++ b/test/sql/copy/parquet/writer/partition_without_hive.test
@@ -1,0 +1,24 @@
+# name: test/sql/copy/parquet/writer/partition_without_hive.test
+# description: Test writing partitioned files WITHOUT hive partitioning
+# group: [writer]
+
+require parquet
+
+statement ok
+CREATE TABLE t1(part_key INT, val INT);
+
+statement ok
+INSERT INTO t1 SELECT i%2, i FROM range(10) t(i);
+
+statement ok
+COPY t1 TO '__TEST_DIR__/hive_filters' (FORMAT PARQUET, PARTITION_BY part_key, HIVE_FILE_PATTERN false, WRITE_PARTITION_COLUMNS true);
+
+query I
+SELECT file.replace('__TEST_DIR__', '').replace('\', '/') FROM GLOB('__TEST_DIR__/hive_filters/*.parquet') ORDER BY ALL
+----
+/hive_filters/data_0.parquet
+/hive_filters/data_1.parquet
+
+query II
+FROM '__TEST_DIR__/hive_filters/*.parquet' EXCEPT ALL FROM t1
+----


### PR DESCRIPTION
For example, the following query:

```sql
CREATE TABLE t1(part_key INT, val INT);
INSERT INTO t1 SELECT i%2, i FROM range(10) t(i);

COPY t1 TO 'hive_filters' (FORMAT PARQUET, PARTITION_BY part_key, HIVE_FILE_PATTERN false, WRITE_PARTITION_COLUMNS true);
```

Now writes the files:

```
hive_filters/data_0.parquet
hive_filters/data_1.parquet
```

Instead of:

```
hive_filters/part_key=0/data_0.parquet
hive_filters/part_key=1/data_0.parquet
```