### PR TITLE
Add support for BENCHMARK_ROOT_DIRECTORY cmake option to change benchmark runner root directory, and add support for cache_file and reload options to enable better caching for non-DuckDB databases

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -11,7 +11,18 @@ if(${_index} GREATER -1)
 endif()
 
 add_extension_definitions()
-add_definitions(-DDUCKDB_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
+set(BENCHMARK_ROOT_DIRECTORY
+    ""
+    CACHE
+      STRING
+      "The benchmark runner root directory (defaults to the project source directory)"
+)
+if(DEFINED BENCHMARK_ROOT_DIRECTORY AND NOT BENCHMARK_ROOT_DIRECTORY STREQUAL
+                                        "")
+  add_definitions(-DDUCKDB_ROOT_DIRECTORY="${BENCHMARK_ROOT_DIRECTORY}")
+else()
+  add_definitions(-DDUCKDB_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
+endif()
 
 add_executable(benchmark_runner benchmark_runner.cpp interpreted_benchmark.cpp
                                 ${BENCHMARK_OBJECT_FILES})


### PR DESCRIPTION
The `BENCHMARK_ROOT_DIRECTORY` can be set to change the root directory of the benchmark runner (similar to https://github.com/duckdb/duckdb/pull/16540 for the unit tester).

In addition, this PR adds two new options:

* `cache_file` - specifies a non-database file to use as a caching point - `load` is run only when the cache file does not exist
* `reload` - specifies a query to run to initialize the system when reloading (i.e. when the `cache_file` exists)
