### PR TITLE
Handle both ENCRYPTION_KEY and STORAGE_VERSION passed as options

### DIFF
--- a/src/parser/parsed_data/attach_info.cpp
+++ b/src/parser/parsed_data/attach_info.cpp
@@ -9,6 +9,7 @@ namespace duckdb {
 
 StorageOptions AttachInfo::GetStorageOptions() const {
 	StorageOptions storage_options;
+	string storage_version_user_provided = "";
 	for (auto &entry : options) {
 		if (entry.first == "block_size") {
 			// Extract the block allocation size. This is NOT the actual memory available on a block (block_size),
@@ -17,14 +18,24 @@ StorageOptions AttachInfo::GetStorageOptions() const {
 		} else if (entry.first == "encryption_key") {
 			storage_options.block_header_size = DEFAULT_ENCRYPTION_BLOCK_HEADER_SIZE;
 			storage_options.encryption = true;
-			// set storage version to v1.3.0
-			storage_options.storage_version = SerializationCompatibility::FromString("v1.3.0").serialization_version;
 		} else if (entry.first == "row_group_size") {
 			storage_options.row_group_size = entry.second.GetValue<uint64_t>();
 		} else if (entry.first == "storage_version") {
+			storage_version_user_provided = entry.second.ToString();
 			storage_options.storage_version =
 			    SerializationCompatibility::FromString(entry.second.ToString()).serialization_version;
 		}
+	}
+	if (storage_options.encryption && (!storage_options.storage_version.IsValid() ||
+	                                   storage_options.storage_version.GetIndex() <
+	                                       SerializationCompatibility::FromString("v1.3.0").serialization_version)) {
+		if (!storage_version_user_provided.empty()) {
+			throw InvalidInputException(
+			    "Explicit provided STORAGE_VERSION (\"%s\") and ENCRYPTION_KEY (storage >= v1.3.0) are not compatible",
+			    storage_version_user_provided);
+		}
+		// set storage version to v1.3.0
+		storage_options.storage_version = SerializationCompatibility::FromString("v1.3.0").serialization_version;
 	}
 	return storage_options;
 }

--- a/test/sql/attach/attach_encryption_block_header.test
+++ b/test/sql/attach/attach_encryption_block_header.test
@@ -68,3 +68,10 @@ DETACH encrypted
 statement ok
 DETACH unencrypted
 
+statement error
+ATTACH '__TEST_DIR__/incompatible_parameters.duckdb' (ENCRYPTION_KEY 'asdf', STORAGE_VERSION 'v1.2.0');
+----
+Explicit provided STORAGE_VERSION ("v1.2.0") and ENCRYPTION_KEY (storage >= v1.3.0) are not compatible
+
+statement ok
+ATTACH '__TEST_DIR__/compatible_parameters.duckdb' (ENCRYPTION_KEY 'asdf', STORAGE_VERSION 'v1.3.0');


### PR DESCRIPTION
Pre this PR `GetStorageOptions` would possibly set the same settings via 2 different paths via `ENCRYPTION_KEY` or `STORAGE_VERSION`, potentially ending up discarding user input and leading to confusing situations.

This should fix that, and add a relevant test.