### PR TITLE
Fixup amalgamation: reqlen is only used with assert enabled

### DIFF
--- a/third_party/hyperloglog/sds.cpp
+++ b/third_party/hyperloglog/sds.cpp
@@ -226,6 +226,7 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
 
     hdrlen = sdsHdrSize(type);
     assert(hdrlen + newlen + 1 > reqlen);  /* Catch size_t overflow */
+    (void)reqlen;
     if (oldtype==type) {
         newsh = realloc(sh, hdrlen+newlen+1);
         if (newsh == NULL) return NULL;


### PR DESCRIPTION
Trivial fix up after https://github.com/duckdb/duckdb/pull/17339, restoring amalgamation CI run.