### PR TITLE
Single read attach via BufferedFileHandle

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library_unity(
   cgroups.cpp
   complex_json.cpp
   compressed_file_system.cpp
+  buffered_file_handle.cpp
   constants.cpp
   checksum.cpp
   encryption_state.cpp

--- a/src/common/buffered_file_handle.cpp
+++ b/src/common/buffered_file_handle.cpp
@@ -1,0 +1,43 @@
+
+#include "duckdb/common/buffered_file_handle.hpp"
+
+namespace duckdb {
+
+BufferedFileHandle::BufferedFileHandle(unique_ptr<FileHandle> inner_handle, size_t start, size_t end,
+                                       Allocator &allocator)
+    : WrappedFileHandle(std::move(inner_handle)), start(start), end(end) {
+	if (start > end) {
+		throw InvalidInputException("Range in BufferedFileHandle constructor wrongly set");
+	}
+	auto file_size = GetInner().GetFileSize();
+	if (end > file_size) {
+		end = file_size;
+	}
+	buffered = allocator.Allocate(end - start);
+	GetInner().Read(buffered.get(), end - start, start);
+}
+
+BufferedFileHandle::~BufferedFileHandle() {
+	// buffered is RAII managed
+}
+
+void BufferedFileHandle::Read(void *buffer, idx_t nr_bytes, idx_t location) {
+	data_ptr_t ptr = static_cast<data_ptr_t>(buffer);
+	idx_t current_location = location;
+
+	if (current_location < start) {
+		GetInner().Read(ptr, start - current_location, current_location);
+		ptr += start - current_location;
+		current_location = start;
+	}
+	if (current_location < end) {
+		memcpy(ptr, buffered.get() + current_location, nr_bytes);
+		ptr += nr_bytes;
+		current_location += nr_bytes;
+	}
+	if (location + nr_bytes > end) {
+		GetInner().Read(ptr, location + nr_bytes - current_location, current_location);
+	}
+}
+
+} // namespace duckdb

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -671,6 +671,10 @@ FileHandle::FileHandle(FileSystem &file_system, string path_p, FileOpenFlags fla
     : file_system(file_system), path(std::move(path_p)), flags(flags) {
 }
 
+WrappedFileHandle::WrappedFileHandle(unique_ptr<FileHandle> handle)
+    : FileHandle(handle->GetFileSystem(), handle->GetPath(), handle->GetFlags()), inner(std::move(handle)) {
+}
+
 FileHandle::~FileHandle() {
 }
 
@@ -714,6 +718,10 @@ FileCompressionType FileHandle::GetFileCompressionType() {
 	return FileCompressionType::UNCOMPRESSED;
 }
 
+FileCompressionType WrappedFileHandle::GetFileCompressionType() {
+	return inner->GetFileCompressionType();
+}
+
 bool FileHandle::IsPipe() {
 	return file_system.IsPipe(path);
 }
@@ -740,6 +748,10 @@ idx_t FileHandle::GetFileSize() {
 	return NumericCast<idx_t>(file_system.GetFileSize(*this));
 }
 
+idx_t WrappedFileHandle::GetFileSize() {
+	return inner->GetFileSize();
+}
+
 void FileHandle::Sync() {
 	file_system.FileSync(*this);
 }
@@ -753,6 +765,10 @@ FileType FileHandle::GetType() {
 }
 
 idx_t FileHandle::GetProgress() {
+	throw NotImplementedException("GetProgress is not implemented for this file handle");
+}
+
+idx_t WrappedFileHandle::GetProgress() {
 	throw NotImplementedException("GetProgress is not implemented for this file handle");
 }
 

--- a/src/include/duckdb/common/buffered_file_handle.hpp
+++ b/src/include/duckdb/common/buffered_file_handle.hpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/buffered_file_handle.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/allocator.hpp"
+
+namespace duckdb {
+class Allocator;
+class AllocatedData;
+struct FileHandle;
+
+struct BufferedFileHandle : public WrappedFileHandle {
+	DUCKDB_API BufferedFileHandle(unique_ptr<FileHandle> inner_handle, size_t start, size_t end, Allocator &allocator);
+	DUCKDB_API ~BufferedFileHandle() override;
+
+	DUCKDB_API int64_t Read(void *buffer, idx_t nr_bytes) override {
+		throw InternalException("Unsupported");
+	}
+	DUCKDB_API void Read(void *buffer, idx_t nr_bytes, idx_t location) override;
+	DUCKDB_API void Close() override {
+		inner->Close();
+	}
+	DUCKDB_API void Truncate(int64_t new_size) override {
+		buffered.Reset();
+		start = 0;
+		end = 0;
+		inner->Truncate(new_size);
+	}
+	DUCKDB_API int64_t Write(void *buffer, idx_t nr_bytes) override {
+		buffered.Reset();
+		start = 0;
+		end = 0;
+		return inner->Write(buffer, nr_bytes);
+	}
+	DUCKDB_API void Write(void *buffer, idx_t nr_bytes, idx_t location) override {
+		buffered.Reset();
+		start = 0;
+		end = 0;
+		inner->Write(buffer, nr_bytes, location);
+	}
+	size_t start;
+	size_t end;
+	AllocatedData buffered;
+};
+
+} // namespace duckdb

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -44,11 +44,11 @@ void MainHeader::Write(WriteStream &ser) {
 void MainHeader::CheckMagicBytes(FileHandle &handle) {
 	data_t magic_bytes[MAGIC_BYTE_SIZE];
 	if (handle.GetFileSize() < MainHeader::MAGIC_BYTE_SIZE + MainHeader::MAGIC_BYTE_OFFSET) {
-		throw IOException("The file \"%s\" exists, but it is not a valid DuckDB database file!", handle.path);
+		throw IOException("The file \"%s\" exists, but it is not a valid DuckDB database file!", handle.GetPath());
 	}
 	handle.Read(magic_bytes, MainHeader::MAGIC_BYTE_SIZE, MainHeader::MAGIC_BYTE_OFFSET);
 	if (memcmp(magic_bytes, MainHeader::MAGIC_BYTES, MainHeader::MAGIC_BYTE_SIZE) != 0) {
-		throw IOException("The file \"%s\" exists, but it is not a valid DuckDB database file!", handle.path);
+		throw IOException("The file \"%s\" exists, but it is not a valid DuckDB database file!", handle.GetPath());
 	}
 }
 

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/storage/single_file_block_manager.hpp"
 
 #include "duckdb/common/allocator.hpp"
+#include "duckdb/common/buffered_file_handle.hpp"
 #include "duckdb/common/checksum.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
@@ -271,6 +272,9 @@ void SingleFileBlockManager::LoadExistingDatabase() {
 		// this can only happen in read-only mode - as that is when we set FILE_FLAGS_NULL_IF_NOT_EXISTS
 		throw IOException("Cannot open database \"%s\" in read-only mode: database does not exist", path);
 	}
+
+	handle =
+	    make_uniq<BufferedFileHandle>(std::move(handle), (size_t)0, Storage::FILE_HEADER_SIZE * 3, Allocator::Get(db));
 
 	MainHeader::CheckMagicBytes(*handle);
 	// otherwise, we check the metadata of the file

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -203,6 +203,10 @@ void SingleFileBlockManager::CreateNewDatabase() {
 	// open the RDBMS handle
 	auto &fs = FileSystem::Get(db);
 	handle = fs.OpenFile(path, flags);
+	if (!handle) {
+		throw IOException("Cannot create database \"%s\" due to problems opening the file handle", path);
+	}
+
 	header_buffer.Clear();
 
 	options.version_number = GetVersionNumber();


### PR DESCRIPTION
Currently performing `ATTACH 'file.db';` on an existing DuckDB file with empty WAL triggers the following file system operations:

1. Open with no locks on `file.db`
2. Read of bytes 0-15 on `file.db`
3. Open with read [and write] lock on `file.db`
4. Read of bytes 8-11 on `file.db`
5. Read of bytes 0-4095 on `file.db`
6. Read of bytes 4096-8191 on `file.db`
7. Read of bytes 8192-12287 on `file.db`
8. Depends on DB file, 0+ blocks holding metadata are read from `file.db`
9. Open of `file.db.wal` (that fails given it's missing. If WAL were to be present, it's then read in chunks of size 4096 via the BufferedFileReader)

In the case of remote databases, open translates to a HEAD request, Read to a GET request, so this is requires 3 HEAD and 5+ GET request (with range), that is 8 roundtrips. Remote case is the case where latency will be more visible.

Step 1 and 2 can be already avoided by explicitly specifying the database type, so either `ATTACH 'file.db' (TYPE duckdb);` or `ATTACH 'duckdb:file.db';` incurs only 2 HEAD and 4+ GET.

After this PR, steps 3 to 7 are buffered in a single read, that should move the untyped case to 3 HEAD and 2+ GET and when type is specified to 2 HEAD and 1+ GET.

Note that metadata still needs to be read, and that spans multiple blocks, so this is only a lower bound. In an example database holding tpch (sf=10), 5 blocks where read during initialization (that is, 5 extra GET).

---

Idea is somewhat straightforward: buffer the reads on the first 12288 bytes in one request (steps 4-7, step 2 could be also handled by similar infra, but outside the scope).

Implementation I was unsure if templating or making FileHandle virtual, I went with the second, adding two classes: WrapperFileHandle, that delegates calls to the wrapped FileHandle, and BufferedFileHandle that on initialization reads a range, on Read respond from the buffer when possible, and invalidates the buffer on Write operations.

Main question here is whether implementation make sense.
WrappedFileHandle is not good for general usage, given it's used in a single location, so I would expect whoever might want to make use of it might need to fiddle infrastructure a bit, but it was not super clear direction to generalize that.

It would have been less code going with template, but I think (if the idea makes sense), allowing to wrap FileHandle could be used also in other contexts (in particular, duckdb-wasm).

PR is almost all infrastructure, with only change basically as:
```c++
        unique_ptr<FileHandle> handle;
        // initialize handle, via OpenFile
        handle = OpenFile(/*...*/);
        // wrap original handle:
	handle =
	    make_uniq<BufferedFileHandle>(std::move(handle), (size_t)0, Storage::FILE_HEADER_SIZE * 3, Allocator::Get(db));
```
(this in turns change the type of `handle`, so this relies on the two classes to have the same capabilities)

---

Python is expected to fail.