### PR TITLE
Fix two off-by-one errors in row estimate of range and generate_series

### DIFF
--- a/test/sql/function/list/generate_series.test
+++ b/test/sql/function/list/generate_series.test
@@ -218,3 +218,50 @@ SELECT * FROM (SELECT 1 UNION ALL SELECT 0 UNION ALL SELECT 2) AS _(x), generate
 1	1
 2	1
 2	2
+
+# Check that explain cardinalities are correct
+query II
+EXPLAIN FROM range(0);
+----
+physical_plan	<REGEX>:.*~0 Rows.*
+
+query II
+EXPLAIN FROM range(-1);
+----
+physical_plan	<REGEX>:.*~0 Rows.*
+
+query II
+EXPLAIN FROM range(-5, -20, -1);
+----
+physical_plan	<REGEX>:.*~15 Rows.*
+
+query II
+EXPLAIN FROM range(1, 4, 2);
+----
+physical_plan	<REGEX>:.*~2 Rows.*
+
+query II
+EXPLAIN FROM range(1, 5, 2);
+----
+physical_plan	<REGEX>:.*~2 Rows.*
+
+query II
+EXPLAIN FROM generate_series(0);
+----
+physical_plan	<REGEX>:.*~1 Rows.*
+
+query II
+EXPLAIN FROM generate_series(1);
+----
+physical_plan	<REGEX>:.*~2 Rows.*
+
+query II
+EXPLAIN FROM generate_series(1, 4, 2);
+----
+physical_plan	<REGEX>:.*~2 Rows.*
+
+query II
+EXPLAIN FROM generate_series(1, 5, 2);
+----
+physical_plan	<REGEX>:.*~3 Rows.*
+


### PR DESCRIPTION
While playing around with `range` and `generate_series` I noticed the
expected number of rows was often off-by-one from the real cardinality.
It turned out that there were two issues which were causing this, this
PR fixes both.
