### PR TITLE
fix #17258: Allow to open database in readonly mode within cli

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3629,7 +3629,7 @@ bool ShellState::OpenDatabase(const char **azArg, idx_t nArg) {
 	openFlags = openFlags & ~(SQLITE_OPEN_NOFOLLOW); // don't overwrite settings loaded in the command line
 	szMax = 0;
 	/* Check for command-line arguments */
-	for (idx_t iName = 1; iName < nArg && azArg[iName][0] == '-'; iName++) {
+	for (iName = 1; iName < nArg && azArg[iName][0] == '-'; iName++) {
 		const char *z = azArg[iName];
 		if (optionMatch(z, "new")) {
 			newFlag = true;


### PR DESCRIPTION
Since the iName variable declared before the for loop was shadowed by a new one inside the loop, its value remained unchanged after the loop. As a result, when it was later used to retrieve the database name, it still held the initial value 1, which pointed to the --readonly parameter.