### PR TITLE
On COPY TO/FROM check the format during binding.

### DIFF
--- a/extension/json/json_extension.cpp
+++ b/extension/json/json_extension.cpp
@@ -68,7 +68,13 @@ void JsonExtension::Load(DuckDB &db) {
 
 	// JSON copy function
 	auto copy_fun = JSONFunctions::GetJSONCopyFunction();
-	ExtensionUtil::RegisterFunction(db_instance, std::move(copy_fun));
+	ExtensionUtil::RegisterFunction(db_instance, copy_fun);
+	copy_fun.extension = "ndjson";
+	copy_fun.name = "ndjson";
+	ExtensionUtil::RegisterFunction(db_instance, copy_fun);
+	copy_fun.extension = "jsonl";
+	copy_fun.name = "jsonl";
+	ExtensionUtil::RegisterFunction(db_instance, copy_fun);
 
 	// JSON macro's
 	for (idx_t index = 0; json_macros[index].name != nullptr; index++) {

--- a/src/include/duckdb/parser/parsed_data/copy_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/copy_info.hpp
@@ -23,7 +23,7 @@ public:
 	static constexpr const ParseInfoType TYPE = ParseInfoType::COPY_INFO;
 
 public:
-	CopyInfo() : ParseInfo(TYPE), catalog(INVALID_CATALOG), schema(DEFAULT_SCHEMA) {
+	CopyInfo() : ParseInfo(TYPE), catalog(INVALID_CATALOG), schema(DEFAULT_SCHEMA), is_format_auto_detected(true) {
 	}
 
 	//! The catalog name to copy to/from
@@ -38,15 +38,18 @@ public:
 	bool is_from;
 	//! The file format of the external file
 	string format;
+	//! If the format is manually set (i.e., via the format parameter) or was discovered by inspecting the file path
+	bool is_format_auto_detected;
 	//! The file path to copy to/from
 	string file_path;
 	//! Set of (key, value) options
 	case_insensitive_map_t<vector<Value>> options;
-	// The SQL statement used instead of a table when copying data out to a file
+	//! The SQL statement used instead of a table when copying data out to a file
 	unique_ptr<QueryNode> select_statement;
 
 public:
-	static string CopyOptionsToString(const string &format, const case_insensitive_map_t<vector<Value>> &options);
+	static string CopyOptionsToString(const string &format, bool is_format_auto_detected,
+	                                  const case_insensitive_map_t<vector<Value>> &options);
 
 public:
 	unique_ptr<CopyInfo> Copy() const;

--- a/src/include/duckdb/parser/parsed_data/copy_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/copy_info.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/parser/query_node.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/storage/serialization/parse_info.json
+++ b/src/include/duckdb/storage/serialization/parse_info.json
@@ -494,6 +494,11 @@
         "id": 208,
         "name": "select_statement",
         "type": "QueryNode*"
+      },
+      {
+        "id": 209,
+        "name": "is_format_auto_detected",
+        "type": "bool"
       }
     ]
   },

--- a/src/parser/statement/export_statement.cpp
+++ b/src/parser/statement/export_statement.cpp
@@ -27,7 +27,7 @@ string ExportStatement::ToString() const {
 	auto &options = info->options;
 	auto &format = info->format;
 	result += StringUtil::Format(" '%s'", path);
-	result += CopyInfo::CopyOptionsToString(format, options);
+	result += CopyInfo::CopyOptionsToString(format, info->is_format_auto_detected, options);
 	result += ";";
 	return result;
 }

--- a/src/parser/transform/statement/transform_copy.cpp
+++ b/src/parser/transform/statement/transform_copy.cpp
@@ -68,6 +68,7 @@ void Transformer::TransformCopyOptions(CopyInfo &info, optional_ptr<duckdb_libpg
 				throw ParserException("Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'parquet'");
 			}
 			info.format = StringUtil::Lower(format_val->val.str);
+			info.is_format_auto_detected = false;
 			continue;
 		}
 
@@ -87,12 +88,12 @@ string ExtractFormat(const string &file_path) {
 	}
 	// Now lets check for the last .
 	size_t dot_pos = format.rfind('.');
-    if (dot_pos == std::string::npos || dot_pos == format.length() - 1) {
-    	// No format found
-        return "";
-    }
+	if (dot_pos == std::string::npos || dot_pos == format.length() - 1) {
+		// No format found
+		return "";
+	}
 	// We found something
-    return format.substr(dot_pos + 1);
+	return format.substr(dot_pos + 1);
 }
 
 unique_ptr<CopyStatement> Transformer::TransformCopy(duckdb_libpgquery::PGCopyStmt &stmt) {

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -30,12 +30,14 @@ static bool GetBooleanArg(ClientContext &context, const vector<Value> &arg) {
 
 BoundStatement Binder::BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type) {
 	// Let's first bind our format
-	auto entry =
-		    Catalog::GetEntry<CopyFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, stmt.info->format, OnEntryNotFound::RETURN_NULL);
-	if (!entry){
+	auto on_entry_do =
+	    stmt.info->is_format_auto_detected ? OnEntryNotFound::RETURN_NULL : OnEntryNotFound::THROW_EXCEPTION;
+	auto entry = Catalog::GetEntry<CopyFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA,
+	                                                         stmt.info->format, on_entry_do);
+	if (!entry) {
 		// If we did not find an entry, we default to a CSV
-		entry =
-		    Catalog::GetEntry<CopyFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, "csv", OnEntryNotFound::THROW_EXCEPTION);
+		entry = Catalog::GetEntry<CopyFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, "csv",
+		                                                    OnEntryNotFound::THROW_EXCEPTION);
 	}
 	// lookup the format in the catalog
 	auto &copy_function = *entry;
@@ -329,13 +331,15 @@ BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 
 	// lookup the format in the catalog
 	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto on_entry_do =
+	    stmt.info->is_format_auto_detected ? OnEntryNotFound::RETURN_NULL : OnEntryNotFound::THROW_EXCEPTION;
 	// Let's first bind our format
-	auto entry =
-		    catalog.GetEntry<CopyFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, stmt.info->format, OnEntryNotFound::RETURN_NULL);
-	if (!entry){
+	auto entry = catalog.GetEntry<CopyFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, stmt.info->format,
+	                                                        on_entry_do);
+	if (!entry) {
 		// If we did not find an entry, we default to a CSV
-		entry =
-		    catalog.GetEntry<CopyFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, "csv", OnEntryNotFound::THROW_EXCEPTION);
+		entry = catalog.GetEntry<CopyFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, "csv",
+		                                                   OnEntryNotFound::THROW_EXCEPTION);
 	}
 	// lookup the format in the catalog
 	auto &copy_function = *entry;

--- a/src/storage/serialization/serialize_parse_info.cpp
+++ b/src/storage/serialization/serialize_parse_info.cpp
@@ -338,6 +338,7 @@ void CopyInfo::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(206, "file_path", file_path);
 	serializer.WritePropertyWithDefault<case_insensitive_map_t<vector<Value>>>(207, "options", options);
 	serializer.WritePropertyWithDefault<unique_ptr<QueryNode>>(208, "select_statement", select_statement);
+	serializer.WritePropertyWithDefault<bool>(209, "is_format_auto_detected", is_format_auto_detected);
 }
 
 unique_ptr<ParseInfo> CopyInfo::Deserialize(Deserializer &deserializer) {
@@ -351,6 +352,7 @@ unique_ptr<ParseInfo> CopyInfo::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadPropertyWithDefault<string>(206, "file_path", result->file_path);
 	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<vector<Value>>>(207, "options", result->options);
 	deserializer.ReadPropertyWithDefault<unique_ptr<QueryNode>>(208, "select_statement", result->select_statement);
+	deserializer.ReadPropertyWithDefault<bool>(209, "is_format_auto_detected", result->is_format_auto_detected);
 	return std::move(result);
 }
 


### PR DESCRIPTION
We previously had the format options hardcoded in the transformer. This code changes this to attempt to get the proper COPY FROM/TO options from the catalog during binding.

This change allows us to pick the correct COPY function on extensions, based on the extension format, without having to explicitly set the `(FORMAT ...)` option.