### PR TITLE
Improve error message reporting for cast failures

### DIFF
--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -46,11 +46,11 @@ ConversionException TryCast::UnimplementedErrorMessage(PhysicalType source, Phys
 			                           UnimplementedCastMessage(source_expr.return_type, target_expr.return_type));
 		}
 	}
-	return ConversionException(query_location, "Unsupported type for cast (%s -> %s)", source, target);
+	return ConversionException(query_location, "Unimplemented type for cast (%s -> %s)", source, target);
 }
 
 string TryCast::UnimplementedCastMessage(const LogicalType &source, const LogicalType &target) {
-	return StringUtil::Format("Unsupported type for cast (%s -> %s)", source, target);
+	return StringUtil::Format("Unimplemented type for cast (%s -> %s)", source, target);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -42,20 +42,15 @@ ConversionException TryCast::UnimplementedErrorMessage(PhysicalType source, Phys
 		if (parameters->cast_source && parameters->cast_target) {
 			auto &source_expr = *parameters->cast_source;
 			auto &target_expr = *parameters->cast_target;
-			return ConversionException(query_location, UnimplementedCastMessage(source_expr.return_type,
-			                                                                    target_expr.return_type, *parameters));
+			return ConversionException(query_location,
+			                           UnimplementedCastMessage(source_expr.return_type, target_expr.return_type));
 		}
 	}
 	return ConversionException(query_location, "Unsupported type for cast (%s -> %s)", source, target);
 }
 
-string TryCast::UnimplementedCastMessage(const LogicalType &source, const LogicalType &target,
-                                         CastParameters &parameters) {
-	string column;
-	if (parameters.cast_target && parameters.cast_target->HasAlias()) {
-		column = " from source column " + parameters.cast_target->alias;
-	}
-	return StringUtil::Format("Unsupported type for cast (%s -> %s)%s", source, target, column);
+string TryCast::UnimplementedCastMessage(const LogicalType &source, const LogicalType &target) {
+	return StringUtil::Format("Unsupported type for cast (%s -> %s)", source, target);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -26,11 +26,11 @@
 #include "duckdb/common/types/bit.hpp"
 #include "duckdb/common/operator/integer_cast_operator.hpp"
 #include "duckdb/common/operator/double_cast_operator.hpp"
+#include "duckdb/planner/expression.hpp"
 
 #include <cctype>
 #include <cmath>
 #include <cstdlib>
-#include <duckdb/planner/expression.hpp>
 
 namespace duckdb {
 

--- a/src/execution/expression_executor/execute_cast.cpp
+++ b/src/execution/expression_executor/execute_cast.cpp
@@ -30,18 +30,14 @@ void ExpressionExecutor::Execute(const BoundCastExpression &expr, ExpressionStat
 	auto child_state = state->child_states[0].get();
 
 	Execute(*expr.child, child_state, sel, count, child);
-	if (expr.try_cast) {
-		string error_message;
-		CastParameters parameters(expr.bound_cast.cast_data.get(), false, &error_message, lstate);
-		parameters.query_location = expr.GetQueryLocation();
-		expr.bound_cast.function(child, result, count, parameters);
-	} else {
-		// cast it to the type specified by the cast expression
-		D_ASSERT(result.GetType() == expr.return_type);
-		CastParameters parameters(expr.bound_cast.cast_data.get(), false, nullptr, lstate);
-		parameters.query_location = expr.GetQueryLocation();
-		expr.bound_cast.function(child, result, count, parameters);
-	}
+
+	string error_message;
+	auto error_ref = expr.try_cast ? &error_message : nullptr;
+	CastParameters parameters(expr.bound_cast.cast_data.get(), false, error_ref, lstate);
+	parameters.query_location = expr.GetQueryLocation();
+	parameters.cast_source = expr.child.get();
+	parameters.cast_target = expr;
+	expr.bound_cast.function(child, result, count, parameters);
 }
 
 } // namespace duckdb

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -33,15 +33,28 @@ bool DefaultCasts::NopCast(Vector &source, Vector &result, idx_t count, CastPara
 }
 
 void HandleCastError::AssignError(const string &error_message, CastParameters &parameters) {
-	AssignError(error_message, parameters.error_message, parameters.query_location);
+	AssignError(error_message, parameters.error_message, parameters.cast_source, parameters.query_location);
+}
+
+void HandleCastError::AssignError(const string &error_message, string *error_message_ptr,
+                                  optional_ptr<const Expression> cast_source, optional_idx error_location) {
+	string column;
+	if (cast_source && cast_source->HasAlias()) {
+		column = " when casting from source column " + cast_source->alias;
+	}
+	if (!error_message_ptr) {
+		throw ConversionException(error_location, error_message + column);
+	}
+	if (error_message_ptr->empty()) {
+		*error_message_ptr = error_message + column;
+	}
 }
 
 // NULL cast only works if all values in source are NULL, otherwise an unimplemented cast exception is thrown
 bool DefaultCasts::TryVectorNullCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	bool success = true;
 	if (VectorOperations::HasNotNull(source, count)) {
-		HandleCastError::AssignError(TryCast::UnimplementedCastMessage(source.GetType(), result.GetType(), parameters),
-		                             parameters);
+		HandleCastError::AssignError(TryCast::UnimplementedCastMessage(source.GetType(), result.GetType()), parameters);
 		success = false;
 	}
 	result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -36,15 +36,12 @@ void HandleCastError::AssignError(const string &error_message, CastParameters &p
 	AssignError(error_message, parameters.error_message, parameters.query_location);
 }
 
-static string UnimplementedCastMessage(const LogicalType &source_type, const LogicalType &target_type) {
-	return StringUtil::Format("Unimplemented type for cast (%s -> %s)", source_type.ToString(), target_type.ToString());
-}
-
 // NULL cast only works if all values in source are NULL, otherwise an unimplemented cast exception is thrown
 bool DefaultCasts::TryVectorNullCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	bool success = true;
 	if (VectorOperations::HasNotNull(source, count)) {
-		HandleCastError::AssignError(UnimplementedCastMessage(source.GetType(), result.GetType()), parameters);
+		HandleCastError::AssignError(TryCast::UnimplementedCastMessage(source.GetType(), result.GetType(), parameters),
+		                             parameters);
 		success = false;
 	}
 	result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/types/null_value.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/function/cast/vector_cast_helpers.hpp"
+#include "duckdb/planner/expression.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -29,25 +29,28 @@ struct ValidityMask;
 class Vector;
 
 struct TryCast {
+	static ConversionException UnimplementedErrorMessage(PhysicalType source, PhysicalType target,
+	                                                     optional_ptr<CastParameters> parameters);
+	static string UnimplementedCastMessage(const LogicalType &source, const LogicalType &target,
+	                                       CastParameters &parameters);
+
 	template <class SRC, class DST>
 	static inline bool Operation(SRC input, DST &result, bool strict = false) {
-		throw NotImplementedException("Unimplemented type for cast (%s -> %s)", GetTypeId<SRC>(), GetTypeId<DST>());
+		throw UnimplementedErrorMessage(GetTypeId<SRC>(), GetTypeId<DST>(), nullptr);
 	}
 };
 
 struct TryCastErrorMessage {
 	template <class SRC, class DST>
 	static inline bool Operation(SRC input, DST &result, CastParameters &parameters) {
-		throw NotImplementedException(parameters.query_location, "Unimplemented type for cast (%s -> %s)",
-		                              GetTypeId<SRC>(), GetTypeId<DST>());
+		throw TryCast::UnimplementedErrorMessage(GetTypeId<SRC>(), GetTypeId<DST>(), parameters);
 	}
 };
 
 struct TryCastErrorMessageCommaSeparated {
 	template <class SRC, class DST>
 	static inline bool Operation(SRC input, DST &result, CastParameters &parameters) {
-		throw NotImplementedException(parameters.query_location, "Unimplemented type for cast (%s -> %s)",
-		                              GetTypeId<SRC>(), GetTypeId<DST>());
+		throw TryCast::UnimplementedErrorMessage(GetTypeId<SRC>(), GetTypeId<DST>(), parameters);
 	}
 };
 

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -31,8 +31,7 @@ class Vector;
 struct TryCast {
 	static ConversionException UnimplementedErrorMessage(PhysicalType source, PhysicalType target,
 	                                                     optional_ptr<CastParameters> parameters);
-	static string UnimplementedCastMessage(const LogicalType &source, const LogicalType &target,
-	                                       CastParameters &parameters);
+	static string UnimplementedCastMessage(const LogicalType &source, const LogicalType &target);
 
 	template <class SRC, class DST>
 	static inline bool Operation(SRC input, DST &result, bool strict = false) {
@@ -83,14 +82,8 @@ struct Cast {
 struct HandleCastError {
 	static void AssignError(const string &error_message, CastParameters &parameters);
 	static void AssignError(const string &error_message, string *error_message_ptr,
-	                        optional_idx error_location = optional_idx()) {
-		if (!error_message_ptr) {
-			throw ConversionException(error_location, error_message);
-		}
-		if (error_message_ptr->empty()) {
-			*error_message_ptr = error_message;
-		}
-	}
+	                        optional_ptr<const Expression> cast_source = nullptr,
+	                        optional_idx error_location = optional_idx());
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -75,6 +75,10 @@ struct CastParameters {
 	bool strict = false;
 	// out: error message in case cast has failed
 	string *error_message = nullptr;
+	//! Source expression
+	optional_ptr<const Expression> cast_source;
+	//! Target expression
+	optional_ptr<const Expression> cast_target;
 	//! Local state
 	optional_ptr<FunctionLocalState> local_state;
 	//! Query location (if any)

--- a/test/sql/cast/cast_error_location.test
+++ b/test/sql/cast/cast_error_location.test
@@ -178,6 +178,9 @@ statement ok
 CREATE TABLE int_tbl AS SELECT 42 my_integer
 
 statement ok
+CREATE TABLE str_tbl AS SELECT 'hello' my_str
+
+statement ok
 CREATE TABLE ts_tbl(ts TIMESTAMP)
 
 statement error
@@ -194,3 +197,8 @@ statement error
 INSERT INTO ts_tbl FROM int_tbl
 ----
 my_integer
+
+statement error
+INSERT INTO ts_tbl FROM str_tbl
+----
+my_str

--- a/test/sql/cast/cast_error_location.test
+++ b/test/sql/cast/cast_error_location.test
@@ -172,3 +172,25 @@ statement error
 SELECT invalid_blob_str::BYTEA FROM cast_table
 ----
 ^
+
+# inserts into a table
+statement ok
+CREATE TABLE int_tbl AS SELECT 42 my_integer
+
+statement ok
+CREATE TABLE ts_tbl(ts TIMESTAMP)
+
+statement error
+INSERT INTO ts_tbl SELECT my_integer FROM int_tbl
+----
+^
+
+statement error
+INSERT INTO ts_tbl SELECT my_integer * 2 FROM int_tbl
+----
+^
+
+statement error
+INSERT INTO ts_tbl FROM int_tbl
+----
+my_integer


### PR DESCRIPTION
When inserting data into a table, the system inserts casts automatically. These casts can fail for various reasons. Normally we will point to the location in the string where the error occurred:

```sql
D insert into ints select 'hello';
Conversion Error:
Could not convert string 'hello' to INT32

LINE 1: insert into ints select 'hello';
                                ^
```

However, this does not happen if we are reading all columns from a file, e.g.:

```sql
D copy (select 'hello' str_col) to file.parquet;
D insert into ints from file.parquet;
-- Conversion Error:
-- Could not convert string 'hello' to INT32
```

This PR makes it so that the source column alias is reported if one is set. For example, in the above example:

```sql
D insert into ints from file.parquet;
-- Conversion Error:
-- Could not convert string 'hello' to INT32 when casting from source column str_col
```

This is particularly useful when reading into tables from files with many columns - as it can be hard to track down in which column a casting failure occurred otherwise.