### PR TITLE
Function chaining: report missing column instead of missing function if function exists

### DIFF
--- a/test/sql/cast/dot_function_missing_error.test
+++ b/test/sql/cast/dot_function_missing_error.test
@@ -1,0 +1,23 @@
+# name: test/sql/cast/dot_function_missing_error.test
+# description: Test reporting of dot with missing identifier
+# group: [cast]
+
+statement ok
+PRAGMA enable_verification
+
+# file does not exist
+statement error
+select file.replace('a', 'b') from (values ('xxxx')) t("filename");
+----
+"file" not found in FROM clause
+
+# function does not exist
+statement error
+select filename.replacezxcv('a', 'b') from (values ('xxxx')) t("filename");
+----
+replacezxcv does not exist
+
+statement error
+select replacezxcv('a', 'b') from (values ('xxxx')) t("filename");
+----
+replacezxcv does not exist

--- a/test/sql/parser/function_chaining.test
+++ b/test/sql/parser/function_chaining.test
@@ -14,7 +14,7 @@ INSERT INTO varchars VALUES ('Hello'), ('World')
 statement error
 SELECT x.lower() FROM varchars
 ----
-Function with name lower does not exist
+not found in FROM clause
 
 # conflict
 statement error


### PR DESCRIPTION
When doing column function chaining error messages are confusing when the wrong column name is used:

```sql
D select l_coment.replace('a', 'b') from lineitem;
-- Catalog Error:
-- Scalar Function with name "replace" is not in the catalog, but it exists in the core_functions extension.
```

Clearly the `replace` function exists - the error message the user is looking for is reporting that there is a typo in `l_comment`. 

This PR resolves this by checking if the function exists - and if it exists, we throw the missing column error message instead. 