### PR TITLE
Improve error messages in UPDATE ... SET

### DIFF
--- a/src/parser/transform/statement/transform_update.cpp
+++ b/src/parser/transform/statement/transform_update.cpp
@@ -11,6 +11,9 @@ unique_ptr<UpdateSetInfo> Transformer::TransformUpdateSetInfo(duckdb_libpgquery:
 
 	for (auto cell = root->head; cell != nullptr; cell = cell->next) {
 		auto target = PGPointerCast<duckdb_libpgquery::PGResTarget>(cell->data.ptr_value);
+		if (target->indirection) {
+			throw ParserException("Qualified column names in UPDATE .. SET not supported");
+		}
 		result->columns.emplace_back(target->name);
 		result->expressions.push_back(TransformExpression(target->val));
 	}

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -33,7 +33,12 @@ unique_ptr<LogicalOperator> Binder::BindUpdateSet(LogicalOperator &op, unique_pt
 		auto &colname = set_info.columns[i];
 		auto &expr = set_info.expressions[i];
 		if (!table.ColumnExists(colname)) {
-			throw BinderException("Referenced update column %s not found in table!", colname);
+			vector<string> column_names;
+			for (auto &col : table.GetColumns().Physical()) {
+				column_names.push_back(col.Name());
+			}
+			auto candidates = StringUtil::CandidatesErrorMessage(column_names, colname, "Did you mean");
+			throw BinderException("Referenced update column %s not found in table!\n%s", colname, candidates);
 		}
 		auto &column = table.GetColumn(colname);
 		if (column.Generated()) {

--- a/test/sql/update/update_error_suggestions.test
+++ b/test/sql/update/update_error_suggestions.test
@@ -1,0 +1,19 @@
+# name: test/sql/update/update_error_suggestions.test
+# description: Test suggestions on UPDATE statement
+# group: [update]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE tbl(mycol INTEGER)
+
+statement error
+UPDATE tbl SET myco=42
+----
+"mycol"
+
+statement error
+UPDATE tbl SET tbl.mycol=42
+----
+not supported


### PR DESCRIPTION
This PR improves `UPDATE .. SET` in two different manners:

* SET statements on missing columns now provide suggestions for column names.
* Qualified SET statements are no longer silently ignored. Previously `UPDATE tbl SET tbl.x = 5` would try to set the column `"tbl"` while silently ignoring the `"x"` part. This now throws an error.