### PR TITLE
Add candidates suggestion when COLUMNS regex does not match any columns

### DIFF
--- a/src/planner/binder/expression/bind_star_expression.cpp
+++ b/src/planner/binder/expression/bind_star_expression.cpp
@@ -300,7 +300,21 @@ void Binder::ExpandStarExpression(unique_ptr<ParsedExpression> expr,
 				new_list.push_back(std::move(expanded_expr));
 			}
 			if (new_list.empty()) {
-				auto err = StringUtil::Format("No matching columns found that match regex \"%s\"", regex_str);
+				vector<string> candidates;
+				for (auto &expanded_expr : star_list) {
+					auto child_expr = GetResolvedColumnExpression(*expanded_expr);
+					if (!child_expr) {
+						continue;
+					}
+					auto &colref = child_expr->Cast<ColumnRefExpression>();
+					candidates.push_back(colref.GetColumnName());
+				}
+				string candidate_str;
+				if (!candidates.empty()) {
+					candidate_str = "\n" + StringUtil::CandidatesErrorMessage(candidates, regex_str, "Did you mean");
+				}
+				auto err =
+				    StringUtil::Format("No matching columns found that match regex \"%s\"%s", regex_str, candidate_str);
 				throw BinderException(*star, err);
 			}
 			star_list = std::move(new_list);

--- a/test/sql/parser/test_columns.test
+++ b/test/sql/parser/test_columns.test
@@ -46,6 +46,11 @@ SELECT COLUMNS(*) + COLUMNS(*) FROM integers
 statement ok
 CREATE TABLE grouped_table AS SELECT  1 id, 42 index1, 84 index2 UNION ALL SELECT 2, 13, 14
 
+statement error
+SELECT COLUMNS('indxe.*') FROM grouped_table
+----
+"index1"
+
 query III
 SELECT id, MIN(COLUMNS('index[0-9]')) FROM grouped_table GROUP BY all ORDER BY ALL
 ----


### PR DESCRIPTION
When `COLUMNS('<regex>')` does not match any columns, we find the columns that most closely match the regular expression and provide them as suggestions.