### PR TITLE
add step to clean up the disc space to fix `No space left on device`

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -274,6 +274,15 @@ jobs:
       GEN: ninja
 
     steps:
+      - name: Clean up the disc space
+        shell: bash
+        run: |
+          echo "Disk usage before clean up:"
+          df -h
+          rm -rf /opt/hostedtoolcache/CodeQL Java* Pypy Ruby go node
+          echo "Disk usage after clean up:"
+          df -h
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0


### PR DESCRIPTION
This PR should fix https://github.com/duckdblabs/duckdb-internal/issues/4753

There are two cases of this issue - when it runs out the space on Build and on `temp_directory_enable_external_access.test`.

This fix should help to clean up at least 5GB additional space by removing tools preinstalled in the GH runner (except for Python).

There are more preinstalled stuff to remove, so it this fix don't help, we can remove more things.