### PR TITLE
VirtualFileSystem to take an input, allowing to customize behaviour

### DIFF
--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -5,7 +5,10 @@
 
 namespace duckdb {
 
-VirtualFileSystem::VirtualFileSystem() : default_fs(FileSystem::CreateLocal()) {
+VirtualFileSystem::VirtualFileSystem() : VirtualFileSystem(FileSystem::CreateLocal()) {
+}
+
+VirtualFileSystem::VirtualFileSystem(unique_ptr<FileSystem> &&inner) : default_fs(std::move(inner)) {
 	VirtualFileSystem::RegisterSubSystem(FileCompressionType::GZIP, make_uniq<GZipFileSystem>());
 }
 

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -18,6 +18,7 @@ namespace duckdb {
 class VirtualFileSystem : public FileSystem {
 public:
 	VirtualFileSystem();
+	explicit VirtualFileSystem(unique_ptr<FileSystem> &&inner_file_system);
 
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -431,7 +431,7 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 	if (new_config.file_system) {
 		config.file_system = std::move(new_config.file_system);
 	} else {
-		config.file_system = make_uniq<VirtualFileSystem>();
+		config.file_system = make_uniq<VirtualFileSystem>(FileSystem::CreateLocal());
 	}
 	if (database_path && !config.options.enable_external_access) {
 		config.AddAllowedPath(database_path);


### PR DESCRIPTION
Bumped against this in the duckdb-wasm side, I think it's useful to allow customize inner file system (and skip default creating a LocalFileSystem).

Unsure on keeping both constructors (default one that relies on Local one), or forcing a to provide an input.