### PR TITLE
Improve error reporting for missing qualified columns

### DIFF
--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -301,32 +301,36 @@ unique_ptr<ParsedExpression> ExpressionBinder::QualifyColumnNameWithManyDotsInte
 	// -> 4. resolve "part1" as a column
 
 	// first check if part1 is a catalog
+	ErrorData fully_qualified_error;
 	optional_ptr<Binding> binding;
 	if (col_ref.column_names.size() > 3) {
 		binding = binder.GetMatchingBinding(col_ref.column_names[0], col_ref.column_names[1], col_ref.column_names[2],
-		                                    col_ref.column_names[3], error);
+		                                    col_ref.column_names[3], fully_qualified_error);
 		if (binding) {
 			// part1 is a catalog - the column reference is "catalog.schema.table.column"
 			struct_extract_start = 4;
 			return binder.bind_context.CreateColumnReference(binding->alias, col_ref.column_names[3]);
 		}
 	}
+	ErrorData catalog_table_error;
 	binding = binder.GetMatchingBinding(col_ref.column_names[0], INVALID_SCHEMA, col_ref.column_names[1],
-	                                    col_ref.column_names[2], error);
+	                                    col_ref.column_names[2], catalog_table_error);
 	if (binding) {
 		// part1 is a catalog - the column reference is "catalog.table.column"
 		struct_extract_start = 3;
 		return binder.bind_context.CreateColumnReference(binding->alias, col_ref.column_names[2]);
 	}
-	binding =
-	    binder.GetMatchingBinding(col_ref.column_names[0], col_ref.column_names[1], col_ref.column_names[2], error);
+	ErrorData schema_table_error;
+	binding = binder.GetMatchingBinding(col_ref.column_names[0], col_ref.column_names[1], col_ref.column_names[2],
+	                                    schema_table_error);
 	if (binding) {
 		// part1 is a schema - the column reference is "schema.table.column"
 		// any additional fields are turned into struct_extract calls
 		struct_extract_start = 3;
 		return binder.bind_context.CreateColumnReference(binding->alias, col_ref.column_names[2]);
 	}
-	binding = binder.GetMatchingBinding(col_ref.column_names[0], col_ref.column_names[1], error);
+	ErrorData table_column_error;
+	binding = binder.GetMatchingBinding(col_ref.column_names[0], col_ref.column_names[1], table_column_error);
 	if (binding) {
 		// part1 is a table
 		// the column reference is "table.column"
@@ -335,15 +339,95 @@ unique_ptr<ParsedExpression> ExpressionBinder::QualifyColumnNameWithManyDotsInte
 		return binder.bind_context.CreateColumnReference(binding->alias, col_ref.column_names[1]);
 	}
 	// part1 could be a column
-	ErrorData col_error;
-	auto result_expr = QualifyColumnName(col_ref.column_names[0], col_error);
+	ErrorData unused_error;
+	auto result_expr = QualifyColumnName(col_ref.column_names[0], unused_error);
 	if (result_expr) {
 		// it is! add the struct extract calls
 		struct_extract_start = 1;
 		return result_expr;
 	}
-	return CreateStructPack(col_ref);
+	auto struct_pack = CreateStructPack(col_ref);
+	if (struct_pack) {
+		return struct_pack;
+	}
+
+	// we could not find the column - return an error
+	// try to find out which error to return
+	optional_idx catalog_pos;
+	optional_idx schema_pos;
+	optional_idx table_pos;
+	for (const auto &binding_entry : binder.bind_context.GetBindingsList()) {
+		auto &alias = binding_entry->alias;
+		string catalog = alias.GetCatalog();
+		string schema = alias.GetSchema();
+		string table = alias.GetAlias();
+		auto entry = binding_entry->GetStandardEntry();
+		if (entry) {
+			catalog = entry->ParentCatalog().GetName();
+			schema = entry->ParentSchema().name;
+		}
+
+		for (idx_t i = 0; i < 3; i++) {
+			if (catalog == col_ref.column_names[i]) {
+				catalog_pos = i;
+			}
+			if (schema == col_ref.column_names[i]) {
+				schema_pos = i;
+			}
+			if (table == col_ref.column_names[i]) {
+				table_pos = i;
+			}
+		}
+	}
+
+	error = std::move(table_column_error);
+	if (table_pos.IsValid()) {
+		// we have a valid table
+		if (table_pos.GetIndex() == 0) {
+			// the first column is a valid table - return the error as if we were binding the column as the second
+
+		} else if (table_pos.GetIndex() == 1) {
+			// the first column is a valid table
+			// this means either the first column is a catalog OR the first column is a schema
+			if (catalog_pos.IsValid()) {
+				// catalog.table
+				error = std::move(catalog_table_error);
+			} else {
+				// assume schema.table otherwise
+				error = std::move(schema_table_error);
+			}
+		} else if (col_ref.column_names.size() > 3) {
+			// the second column is a valid table
+			// return the fully qualified error if we have enough components
+			error = std::move(fully_qualified_error);
+		}
+	} else if (catalog_pos.IsValid()) {
+		// the first column is a catalog
+		if (schema_pos.IsValid()) {
+			// AND a valid schema - this is likely "catalog.schema.table"
+			if (col_ref.column_names.size() > 3) {
+				error = std::move(fully_qualified_error);
+			} else {
+				error = std::move(catalog_table_error);
+			}
+		} else {
+			// but no valid schema - this could be either "catalog.schema.table" or "catalog.table"
+			// return "catalog.table" for now
+			error = std::move(catalog_table_error);
+		}
+	} else if (schema_pos.IsValid()) {
+		// we did not find a catalog or a table, but we did find a schema
+		if (schema_pos.GetIndex() == 0) {
+			// "schema.table"
+			error = std::move(schema_table_error);
+		} else if (schema_pos.GetIndex() == 1 && col_ref.column_names.size() > 3) {
+			// catalog.schema.table
+			error = std::move(fully_qualified_error);
+		}
+	}
+	return nullptr;
 }
+
 unique_ptr<ParsedExpression> ExpressionBinder::QualifyColumnNameWithManyDots(ColumnRefExpression &col_ref,
                                                                              ErrorData &error) {
 	idx_t struct_extract_start = col_ref.column_names.size();

--- a/test/sql/binder/table_view_alias.test
+++ b/test/sql/binder/table_view_alias.test
@@ -28,7 +28,7 @@ SELECT s1.t.c, t.c, c FROM s1.t
 statement error
 SELECT s1.t.c, t.c, c FROM s1.t AS t
 ----
-Referenced table "s1" not found
+Referenced table "s1.t" not found
 
 statement error
 SELECT s1.x.c FROM s1.v AS x

--- a/test/sql/error/qualified_column_error.test
+++ b/test/sql/error/qualified_column_error.test
@@ -1,0 +1,50 @@
+# name: test/sql/error/qualified_column_error.test
+# description: Test errors on qualified columns
+# group: [error]
+
+require skip_reload
+
+statement ok
+create schema "dbt_temp"
+
+statement ok
+create or replace table "dbt_temp"."foo_2" as (select 42 as num_2);
+
+statement error
+select "dbt_temp"."foo_2".num_3 FROM  "dbt_temp"."foo_2"
+----
+"num_2"
+
+statement error
+select "dbt_temp"."foo_1".num_2 FROM  "dbt_temp"."foo_2"
+----
+"foo_2"
+
+statement ok
+attach ':memory:' as cat
+
+statement ok
+create schema cat.schema
+
+statement ok
+create table cat.schema.tbl(col struct(v1 int));
+
+statement error
+select cat.schema.tbl.col.v2 from cat.schema.tbl
+----
+"v1"
+
+statement error
+select cat.schema.tbl.cxl.v1 from cat.schema.tbl
+----
+"col"
+
+statement error
+select cat.schema.txl.col.v1 from cat.schema.tbl
+----
+"cat.schema.tbl"
+
+statement error
+select cat.schxma.tbl.col.v1 from cat.schema.tbl
+----
+"cat.schema.tbl"


### PR DESCRIPTION
When binding qualified columns (e.g. `catalog.schema.table.column`) we have several different methods of binding, e.g.:

```
catalog.schema.table.column.[fields]
catalog.table.column.[fields]
schema.table.column.[fields]
table.column.[fields]
column.[fields]
```

When binding, we are clever about figuring out which configuration is used to find the "right" one, allowing users to flexibly qualify columns. 

When columns are not present, however, this gets more difficult. Currently, we always fall back to assuming the first field is the table (i.e. the qualification is `[table].[column].[fields]`). In this PR, we expand this so that we improve the error message by figuring out which qualifications are possible. For example, if there is a typo in a table name, but `[catalog].[schema]` exists in the query - we report an error as if we are binding `catalog.schema.table.column`. This provides better error messages, e.g.:

```sql

attach ':memory:' as cat;
create schema cat.schema;
create table cat.schema.tbl(col struct(field int));


select cxt.schema.tbl.col.field from cat.schema.tbl;
-- Referenced table "cxt.schema.tbl" not found!
-- Candidate tables: "cat.schema.tbl"

select cat.schxma.tbl.col.field from cat.schema.tbl;
-- Referenced table "cat.schxma.tbl" not found!
-- Candidate tables: "cat.schema.tbl"

select cat.schema.txl.col.field from cat.schema.tbl;
-- Referenced table "cat.schema.txl" not found!
-- Candidate tables: "cat.schema.tbl"

select cat.schema.tbl.cxl.field from cat.schema.tbl;
-- Table "tbl" does not have a column named "cxl"
-- Candidate bindings: : "col"

select cat.schema.tbl.col.feild from cat.schema.tbl;
-- Could not find key "feild" in struct
-- Candidate Entries: "field"


```