### PR TITLE
Provide suggestions and a link to the documentation for OOM errors

### DIFF
--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -355,7 +355,23 @@ InvalidConfigurationException::InvalidConfigurationException(const string &msg,
     : Exception(ExceptionType::INVALID_CONFIGURATION, msg, extra_info) {
 }
 
-OutOfMemoryException::OutOfMemoryException(const string &msg) : Exception(ExceptionType::OUT_OF_MEMORY, msg) {
+OutOfMemoryException::OutOfMemoryException(const string &msg)
+    : Exception(ExceptionType::OUT_OF_MEMORY, ExtendOutOfMemoryError(msg)) {
+}
+
+string OutOfMemoryException::ExtendOutOfMemoryError(const string &msg) {
+	string link = "https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads";
+	if (StringUtil::Contains(msg, link)) {
+		// already extended
+		return msg;
+	}
+	string new_msg = msg;
+	new_msg += "\n\nPossible solutions:\n";
+	new_msg += "* Reducing the number of threads (SET threads=X)\n";
+	new_msg += "* Disabling insertion-order preservation (SET preserve_insertion_order=false)\n";
+	new_msg += "* Increasing the memory limit (SET memory_limit='...GB')\n";
+	new_msg += "\nSee also " + link;
+	return new_msg;
 }
 
 ParameterNotAllowedException::ParameterNotAllowedException(const string &msg)

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -192,6 +192,9 @@ public:
 	explicit OutOfMemoryException(const string &msg, ARGS... params)
 	    : OutOfMemoryException(ConstructMessage(msg, params...)) {
 	}
+
+private:
+	string ExtendOutOfMemoryError(const string &msg);
 };
 
 class SyntaxException : public Exception {


### PR DESCRIPTION
This PR extends the `OutOfMemoryException` with extra text that can help the user to remedy the issue, e.g.:

```sql
D set memory_limit='100mb';
D select list(l_orderkey) from lineitemsf10.parquet;
```

```
Out of Memory Error:
failed to allocate data of size 4.0 MiB (93.7 MiB/95.3 MiB used)

Possible solutions:
* Reducing the number of threads (SET threads=X)
* Disabling insertion-order preservation (SET preserve_insertion_order=false)
* Increasing the memory limit (SET memory_limit='...GB')

See also https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads

```