### PR TITLE
[Dev] Add `QualifiedName::ParseComponents`, add input to the error messages

### DIFF
--- a/src/include/duckdb/parser/qualified_name.hpp
+++ b/src/include/duckdb/parser/qualified_name.hpp
@@ -24,6 +24,7 @@ struct QualifiedName {
 	//! Parse the (optional) schema and a name from a string in the format of e.g. "schema"."table"; if there is no dot
 	//! the schema will be set to INVALID_SCHEMA
 	static QualifiedName Parse(const string &input);
+	static vector<string> ParseComponents(const string &input);
 	string ToString() const;
 };
 


### PR DESCRIPTION
I'm slightly abusing the `QualifiedName::Parse` method in iceberg (https://github.com/duckdb/duckdb-iceberg/pull/224), which causes a problem when the path contains multiple dots.
I'm adding `QualifiedName::ParseComponents` so we can make use of the parsing logic safely.

One other thing that stood out to me was that an empty input is not invalid, which feels wrong, but I preserved the behavior in this change.