### PR TITLE
Enable `SYSTEM_PEAK_BUFFER_MEMORY` and `SYSTEM_PEAK_TEMP_DIR_SIZE` profiling by default

### DIFF
--- a/src/main/profiling_info.cpp
+++ b/src/main/profiling_info.cpp
@@ -39,6 +39,8 @@ ProfilingInfo::ProfilingInfo(const profiler_settings_t &n_settings, const idx_t 
 profiler_settings_t ProfilingInfo::DefaultSettings() {
 	return {MetricsType::QUERY_NAME,
 	        MetricsType::BLOCKED_THREAD_TIME,
+	        MetricsType::SYSTEM_PEAK_BUFFER_MEMORY,
+	        MetricsType::SYSTEM_PEAK_TEMP_DIR_SIZE,
 	        MetricsType::CPU_TIME,
 	        MetricsType::EXTRA_INFO,
 	        MetricsType::CUMULATIVE_CARDINALITY,

--- a/test/sql/pragma/profiling/test_custom_profiling_memory_and_temp_dir.test_slow
+++ b/test/sql/pragma/profiling/test_custom_profiling_memory_and_temp_dir.test_slow
@@ -14,13 +14,10 @@ statement ok
 PRAGMA profiling_output = '__TEST_DIR__/profiling_output.json';
 
 statement ok
-PRAGMA custom_profiling_settings='{"SYSTEM_PEAK_BUFFER_MEMORY": "true", "SYSTEM_PEAK_TEMP_DIR_SIZE": "true"}';
-
-statement ok
 SET memory_limit = '0.7gb';
 
 statement ok
-CREATE TABLE test AS SELECT hash(range) i FROM range(100_000_000);
+CREATE OR REPLACE TABLE test AS SELECT hash(range) i FROM range(100_000_000);
 
 statement ok
 PRAGMA disable_profiling;
@@ -37,3 +34,29 @@ SELECT
 FROM metrics_output;
 ----
 true	true	1.0
+
+# disabling should omit them from output
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"SYSTEM_PEAK_BUFFER_MEMORY": "false", "SYSTEM_PEAK_TEMP_DIR_SIZE": "false"}';
+
+statement ok
+CREATE OR REPLACE TABLE test AS SELECT hash(range) i FROM range(100_000_000);
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '__TEST_DIR__/profiling_output.json';
+
+statement error
+SELECT system_peak_buffer_memory FROM metrics_output;
+----
+Binder Error
+
+statement error
+SELECT system_peak_temp_dir_size FROM metrics_output;
+----
+Binder Error

--- a/test/sql/pragma/profiling/test_custom_profiling_optimizer.test
+++ b/test/sql/pragma/profiling/test_custom_profiling_optimizer.test
@@ -171,3 +171,5 @@ SELECT unnest(res) FROM (
 "QUERY_NAME": "true"
 "RESULT_SET_SIZE": "true"
 "ROWS_RETURNED": "true"
+"SYSTEM_PEAK_BUFFER_MEMORY": "true"
+"SYSTEM_PEAK_TEMP_DIR_SIZE": "true"

--- a/test/sql/pragma/profiling/test_default_profiling_settings.test
+++ b/test/sql/pragma/profiling/test_default_profiling_settings.test
@@ -42,6 +42,8 @@ SELECT unnest(res) FROM (
 "QUERY_NAME": "true"
 "RESULT_SET_SIZE": "true"
 "ROWS_RETURNED": "true"
+"SYSTEM_PEAK_BUFFER_MEMORY": "true"
+"SYSTEM_PEAK_TEMP_DIR_SIZE": "true"
 
 statement ok
 CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '__TEST_DIR__/profiling_output.json';


### PR DESCRIPTION
This PR implements always collecting these statistics (introduced in https://github.com/duckdb/duckdb/pull/17164) when profiling is enabled.