### PR TITLE
Avoid generating default views and macros in the temporary catalog

### DIFF
--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -75,8 +75,7 @@ DuckSchemaEntry::DuckSchemaEntry(Catalog &catalog, CreateSchemaInfo &info)
                       catalog.IsSystemCatalog() ? make_uniq<DefaultTableFunctionGenerator>(catalog, *this) : nullptr),
       copy_functions(catalog), pragma_functions(catalog),
       functions(catalog, catalog.IsSystemCatalog() ? make_uniq<DefaultFunctionGenerator>(catalog, *this) : nullptr),
-      sequences(catalog), collations(catalog),
-      types(catalog, catalog.IsSystemCatalog() ? make_uniq<DefaultTypeGenerator>(catalog, *this) : nullptr) {
+      sequences(catalog), collations(catalog), types(catalog, make_uniq<DefaultTypeGenerator>(catalog, *this)) {
 }
 
 unique_ptr<CatalogEntry> DuckSchemaEntry::Copy(ClientContext &context) const {

--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -68,11 +68,15 @@ static void FindForeignKeyInformation(TableCatalogEntry &table, AlterForeignKeyT
 }
 
 DuckSchemaEntry::DuckSchemaEntry(Catalog &catalog, CreateSchemaInfo &info)
-    : SchemaCatalogEntry(catalog, info), tables(catalog, make_uniq<DefaultViewGenerator>(catalog, *this)),
-      indexes(catalog), table_functions(catalog, make_uniq<DefaultTableFunctionGenerator>(catalog, *this)),
+    : SchemaCatalogEntry(catalog, info),
+      tables(catalog, catalog.IsSystemCatalog() ? make_uniq<DefaultViewGenerator>(catalog, *this) : nullptr),
+      indexes(catalog),
+      table_functions(catalog,
+                      catalog.IsSystemCatalog() ? make_uniq<DefaultTableFunctionGenerator>(catalog, *this) : nullptr),
       copy_functions(catalog), pragma_functions(catalog),
-      functions(catalog, make_uniq<DefaultFunctionGenerator>(catalog, *this)), sequences(catalog), collations(catalog),
-      types(catalog, make_uniq<DefaultTypeGenerator>(catalog, *this)) {
+      functions(catalog, catalog.IsSystemCatalog() ? make_uniq<DefaultFunctionGenerator>(catalog, *this) : nullptr),
+      sequences(catalog), collations(catalog),
+      types(catalog, catalog.IsSystemCatalog() ? make_uniq<DefaultTypeGenerator>(catalog, *this) : nullptr) {
 }
 
 unique_ptr<CatalogEntry> DuckSchemaEntry::Copy(ClientContext &context) const {

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -1020,7 +1020,7 @@ TEST_CASE("Test ADBC ConnectionGetTableSchema", "[adbc]") {
 	REQUIRE(StringUtil::Contains(adbc_error.message, "Catalog \"bla\" does not exist"));
 	adbc_error.release(&adbc_error);
 
-	REQUIRE(SUCCESS(AdbcConnectionGetTableSchema(&adbc_connection, "memory", "main", "duckdb_indexes", &arrow_schema,
+	REQUIRE(SUCCESS(AdbcConnectionGetTableSchema(&adbc_connection, "system", "main", "duckdb_indexes", &arrow_schema,
 	                                             &adbc_error)));
 	REQUIRE((arrow_schema.n_children == 14));
 	arrow_schema.release(&arrow_schema);

--- a/test/sql/pg_catalog/system_functions.test
+++ b/test/sql/pg_catalog/system_functions.test
@@ -93,3 +93,8 @@ query I
 select pg_typeof(1);
 ----
 integer
+
+statement error
+SELECT temp.current_user()
+----
+main.current_user

--- a/test/sql/table_function/duckdb_tables.test
+++ b/test/sql/table_function/duckdb_tables.test
@@ -34,3 +34,8 @@ memory	main	integers	False	False	0	1	0	0
 memory	myschema	mytable	False	False	0	1	0	0
 temp	main	mytemp	True	False	0	1	0	0
 memory	main	pk	False	True	0	2	1	1
+
+statement error
+SELECT * FROM temp.duckdb_tables
+----
+main.duckdb_tables


### PR DESCRIPTION
We should only be generating these in the `system` catalog - there is no need to generate them in the `temp` catalog.