### PR TITLE
WAL replay index fixes

### DIFF
--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -43,6 +43,22 @@ public:
 	optional_ptr<TableCatalogEntry> current_table;
 	MetaBlockPointer checkpoint_id;
 	idx_t wal_version = 1;
+
+	struct ReplayIndexInfo {
+		ReplayIndexInfo(TableIndexList &index_list, unique_ptr<Index> index, const string &table_schema,
+		                const string &table_name)
+		    : index_list(index_list), index(std::move(index)), table_schema(table_schema), table_name(table_name) {};
+
+		reference<TableIndexList> index_list;
+		unique_ptr<Index> index;
+		string table_schema;
+		string table_name;
+
+		//		ReplayIndexInfo(ReplayIndexInfo &&other) noexcept = default;
+		//		ReplayIndexInfo& operator=(ReplayIndexInfo &&other) noexcept = default;
+		//		~ReplayIndexInfo() noexcept = default;
+	};
+	vector<ReplayIndexInfo> replay_index_infos;
 };
 
 class WriteAheadLogDeserializer {
@@ -242,6 +258,13 @@ unique_ptr<WriteAheadLog> WriteAheadLog::ReplayInternal(AttachedDatabase &databa
 			auto deserializer = WriteAheadLogDeserializer::Open(state, reader);
 			if (deserializer.ReplayEntry()) {
 				con.Commit();
+
+				// Commit any outstanding indexes.
+				for (auto &info : state.replay_index_infos) {
+					info.index_list.get().AddIndex(std::move(info.index));
+				}
+				state.replay_index_infos.clear();
+
 				successful_offset = reader.offset;
 				// check if the file is exhausted
 				if (reader.Finished()) {
@@ -390,6 +413,14 @@ void WriteAheadLogDeserializer::ReplayDropTable() {
 		return;
 	}
 
+	// Remove any potential replay indexes.
+	state.replay_index_infos.erase(std::remove_if(state.replay_index_infos.begin(), state.replay_index_infos.end(),
+	                                              [&info](const ReplayState::ReplayIndexInfo &replay_info) {
+		                                              return replay_info.table_schema == info.schema &&
+		                                                     replay_info.table_name == info.name;
+	                                              }),
+	                               state.replay_index_infos.end());
+
 	catalog.DropEntry(context, info);
 }
 
@@ -488,7 +519,10 @@ void WriteAheadLogDeserializer::ReplayAlter() {
 
 	auto index_type = context.db->config.GetIndexTypes().FindByName(ART::TYPE_NAME);
 	auto index_instance = index_type->create_instance(input);
-	storage.AddIndex(std::move(index_instance));
+
+	auto &table_index_list = storage.GetDataTableInfo()->GetIndexes();
+	state.replay_index_infos.emplace_back(table_index_list, std::move(index_instance), table_info.schema,
+	                                      table_info.name);
 
 	catalog.Alter(context, alter_info);
 }
@@ -665,7 +699,11 @@ void WriteAheadLogDeserializer::ReplayCreateIndex() {
 		info.index_type = ART::TYPE_NAME;
 	}
 
-	auto &table = catalog.GetEntry<TableCatalogEntry>(context, create_info->schema, info.table).Cast<DuckTableEntry>();
+	const auto schema_name = create_info->schema;
+	const auto table_name = info.table;
+
+	auto &entry = catalog.GetEntry<TableCatalogEntry>(context, schema_name, table_name);
+	auto &table = entry.Cast<DuckTableEntry>();
 	auto &storage = table.GetStorage();
 	auto &io_manager = TableIOManager::Get(storage);
 
@@ -674,7 +712,9 @@ void WriteAheadLogDeserializer::ReplayCreateIndex() {
 
 	// add the index to the storage
 	auto unbound_index = make_uniq<UnboundIndex>(std::move(create_info), std::move(index_info), io_manager, db);
-	storage.AddIndex(std::move(unbound_index));
+
+	auto &table_index_list = storage.GetDataTableInfo()->GetIndexes();
+	state.replay_index_infos.emplace_back(table_index_list, std::move(unbound_index), schema_name, table_name);
 }
 
 void WriteAheadLogDeserializer::ReplayDropIndex() {
@@ -685,6 +725,14 @@ void WriteAheadLogDeserializer::ReplayDropIndex() {
 	if (DeserializeOnly()) {
 		return;
 	}
+
+	// Remove any potential replay indexes.
+	state.replay_index_infos.erase(std::remove_if(state.replay_index_infos.begin(), state.replay_index_infos.end(),
+	                                              [&info](const ReplayState::ReplayIndexInfo &replay_info) {
+		                                              return replay_info.table_schema == info.schema &&
+		                                                     replay_info.index->GetIndexName() == info.name;
+	                                              }),
+	                               state.replay_index_infos.end());
 
 	catalog.DropEntry(context, info);
 }

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -53,10 +53,6 @@ public:
 		unique_ptr<Index> index;
 		string table_schema;
 		string table_name;
-
-		//		ReplayIndexInfo(ReplayIndexInfo &&other) noexcept = default;
-		//		ReplayIndexInfo& operator=(ReplayIndexInfo &&other) noexcept = default;
-		//		~ReplayIndexInfo() noexcept = default;
 	};
 	vector<ReplayIndexInfo> replay_index_infos;
 };
@@ -413,7 +409,7 @@ void WriteAheadLogDeserializer::ReplayDropTable() {
 		return;
 	}
 
-	// Remove any potential replay indexes.
+	// Remove any replay indexes of this table.
 	state.replay_index_infos.erase(std::remove_if(state.replay_index_infos.begin(), state.replay_index_infos.end(),
 	                                              [&info](const ReplayState::ReplayIndexInfo &replay_info) {
 		                                              return replay_info.table_schema == info.schema &&
@@ -726,7 +722,7 @@ void WriteAheadLogDeserializer::ReplayDropIndex() {
 		return;
 	}
 
-	// Remove any potential replay indexes.
+	// Remove the replay index, if any.
 	state.replay_index_infos.erase(std::remove_if(state.replay_index_infos.begin(), state.replay_index_infos.end(),
 	                                              [&info](const ReplayState::ReplayIndexInfo &replay_info) {
 		                                              return replay_info.table_schema == info.schema &&

--- a/test/sql/index/art/storage/test_art_wal_replay_drop_table.test
+++ b/test/sql/index/art/storage/test_art_wal_replay_drop_table.test
@@ -1,0 +1,60 @@
+# name: test/sql/index/art/storage/test_art_wal_replay_drop_table.test
+# description: Test replaying the WAL after creating an index in a transaction, and then dropping the table.
+# group: [storage]
+
+load __TEST_DIR__/art_wal_replay_drop_table.db
+
+statement ok
+SET threads=1;
+
+statement ok
+SET wal_autocheckpoint='1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+CREATE TABLE test (a INTEGER);
+
+statement ok
+INSERT INTO test SELECT range + 42 FROM range(100);
+
+statement ok
+CREATE TABLE alter_test (a INTEGER);
+
+statement ok
+INSERT INTO alter_test SELECT range + 42 FROM range(100);
+
+# Let's also have an index outside the transaction.
+statement ok
+CREATE INDEX other_idx ON test(a);
+
+statement ok
+BEGIN TRANSACTION
+
+# We add this to the UndoBuffer on commit.
+statement ok
+INSERT INTO test VALUES (0), (1);
+
+statement ok
+INSERT INTO alter_test VALUES (0), (1);
+
+# We add this to the UndoBuffer immediately.
+statement ok
+CREATE UNIQUE INDEX i_index ON test(a);
+
+statement ok
+ALTER TABLE alter_test ADD PRIMARY KEY(a);
+
+# Now drop the tables in the transaction.
+
+statement ok
+DROP TABLE test;
+
+statement ok
+DROP TABLE alter_test;
+
+statement ok
+COMMIT;
+
+restart

--- a/test/sql/index/art/storage/test_art_wal_replay_in_tx.test
+++ b/test/sql/index/art/storage/test_art_wal_replay_in_tx.test
@@ -1,0 +1,92 @@
+# name: test/sql/index/art/storage/test_art_wal_replay_in_tx.test
+# description: Test replaying the WAL after creating an index in a transaction.
+# group: [storage]
+
+load __TEST_DIR__/art_wal_replay_tx.db
+
+statement ok
+SET threads=1;
+
+statement ok
+SET wal_autocheckpoint='1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+CREATE TABLE test (a INTEGER);
+
+statement ok
+INSERT INTO test SELECT range + 42 FROM range(100);
+
+statement ok
+CREATE TABLE alter_test (a INTEGER);
+
+statement ok
+INSERT INTO alter_test SELECT range + 42 FROM range(100);
+
+statement ok
+CREATE TABLE drop_test (a INTEGER);
+
+statement ok
+INSERT INTO drop_test SELECT range + 42 FROM range(100);
+
+# Let's also have an index outside the transaction.
+statement ok
+CREATE INDEX other_idx ON test(a);
+
+statement ok
+BEGIN TRANSACTION
+
+# We add this to the UndoBuffer on commit.
+statement ok
+INSERT INTO test VALUES (0), (1);
+
+statement ok
+INSERT INTO alter_test VALUES (0), (1);
+
+statement ok
+INSERT INTO drop_test VALUES (0), (1);
+
+# We add this to the UndoBuffer immediately.
+statement ok
+CREATE UNIQUE INDEX i_index ON test(a);
+
+statement ok
+ALTER TABLE alter_test ADD PRIMARY KEY(a);
+
+statement ok
+CREATE INDEX drop_idx ON drop_test(a);
+
+statement ok
+DROP INDEX drop_idx;
+
+statement ok
+DELETE FROM test WHERE a = 1;
+
+statement ok
+DELETE FROM alter_test WHERE a = 1;
+
+statement ok
+COMMIT;
+
+restart
+
+statement error
+INSERT INTO test VALUES (0);
+----
+<REGEX>:Constraint Error.*violates unique constraint.*
+
+statement error
+INSERT INTO alter_test VALUES (0);
+----
+<REGEX>:Constraint Error.*violates primary key constraint.*
+
+statement ok
+INSERT INTO test VALUES (1);
+
+statement ok
+INSERT INTO alter_test VALUES (1);
+
+statement ok
+CREATE INDEX drop_idx ON test(a);


### PR DESCRIPTION
Fixes a bug where we replay insertions after `CREATE INDEX`, if inside a transaction.

Closes https://github.com/duckdblabs/duckdb-internal/issues/4716