### PR TITLE
unittest: improve detection of whether or not we can run `--force-restart` tests

### DIFF
--- a/scripts/sqllogictest/parser/parser.py
+++ b/scripts/sqllogictest/parser/parser.py
@@ -336,7 +336,7 @@ class SQLLogicParser:
         parameters = header.parameters
         if len(parameters) < 1:
             self.fail("set requires at least 1 parameter (e.g. set ignore_error_messages HTTP Error)")
-        accepted_options = ['ignore_error_messages', 'always_fail_error_messages']
+        accepted_options = ['ignore_error_messages', 'always_fail_error_messages', 'seed']
         if parameters[0] in accepted_options:
             error_messages = []
             # Parse the parameter list as a comma separated list of strings that can contain spaces

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -68,6 +68,8 @@ public:
 	//! Scans the catalog set and adds each committed database entry, and each database entry of the current
 	//! transaction, to a vector holding AttachedDatabase references
 	vector<reference<AttachedDatabase>> GetDatabases(ClientContext &context);
+	//! Scans the catalog set and returns each committed database entry
+	vector<reference<AttachedDatabase>> GetDatabases();
 	//! Removes all databases from the catalog set. This is necessary for the database instance's destructor,
 	//! as the database manager has to be alive when destroying the catalog set objects.
 	void ResetDatabases(unique_ptr<TaskScheduler> &scheduler);

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -230,6 +230,13 @@ vector<reference<AttachedDatabase>> DatabaseManager::GetDatabases(ClientContext 
 	return result;
 }
 
+vector<reference<AttachedDatabase>> DatabaseManager::GetDatabases() {
+	vector<reference<AttachedDatabase>> result;
+	databases->Scan([&](CatalogEntry &entry) { result.push_back(entry.Cast<AttachedDatabase>()); });
+	result.push_back(*system);
+	return result;
+}
+
 void DatabaseManager::ResetDatabases(unique_ptr<TaskScheduler> &scheduler) {
 	vector<reference<AttachedDatabase>> result;
 	databases->Scan([&](CatalogEntry &entry) { result.push_back(entry.Cast<AttachedDatabase>()); });

--- a/test/fuzzer/pedro/incomplete_checkpoint.test
+++ b/test/fuzzer/pedro/incomplete_checkpoint.test
@@ -2,9 +2,9 @@
 # description: Issue #4644: Incomplete checkpoints issue
 # group: [pedro]
 
-load __TEST_DIR__/incomplete_checkpoint.db
-
 require skip_reload
+
+load __TEST_DIR__/incomplete_checkpoint.db
 
 statement ok
 PRAGMA wal_autocheckpoint='1TB';

--- a/test/fuzzer/pedro/prepared_statement_recursive_cte.test
+++ b/test/fuzzer/pedro/prepared_statement_recursive_cte.test
@@ -2,8 +2,6 @@
 # description: Issue #4681: Prepared statement recursive CTE heap-use-after-free
 # group: [pedro]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/fuzzer/pedro/temp_sequence_durability.test
+++ b/test/fuzzer/pedro/temp_sequence_durability.test
@@ -4,9 +4,6 @@
 
 load __TEST_DIR__/temp_sequence_durability.db
 
-# temp sequence
-require skip_reload
-
 statement ok
 PRAGMA DISABLE_CHECKPOINT_ON_SHUTDOWN;
 

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -80,6 +80,11 @@ void TestCreateDirectory(string path) {
 	fs->CreateDirectory(path);
 }
 
+string TestJoinPath(string path1, string path2) {
+	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
+	return fs->JoinPath(path1, path2);
+}
+
 void SetTestDirectory(string path) {
 	custom_test_directory = path;
 }
@@ -157,8 +162,7 @@ void ClearTestDirectory() {
 }
 
 string TestCreatePath(string suffix) {
-	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
-	return fs->JoinPath(TestDirectoryPath(), suffix);
+	return TestJoinPath(TestDirectoryPath(), suffix);
 }
 
 bool TestIsInternalError(unordered_set<string> &internal_error_messages, const string &error) {

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -35,6 +35,7 @@ void RegisterSqllogictests();
 void DeleteDatabase(string path);
 void TestDeleteDirectory(string path);
 void TestCreateDirectory(string path);
+string TestJoinPath(string path1, string path2);
 void TestDeleteFile(string path);
 void TestChangeDirectory(string path);
 void SetDeleteTestPath(bool delete_path);

--- a/test/issues/general/test_4165.test
+++ b/test/issues/general/test_4165.test
@@ -2,8 +2,7 @@
 # description: Issue 4165: SIGSEGV on Debian Buster amd64
 # group: [general]
 
-statement ok
-SELECT setseed(0.42);
+set seed 0.42
 
 statement ok
 CREATE TABLE df_a AS

--- a/test/issues/general/test_9399.test_slow
+++ b/test/issues/general/test_9399.test_slow
@@ -2,15 +2,12 @@
 # description: Issue 9399: Incorrect query output from group by query (regression in 0.9.0)
 # group: [general]
 
-require skip_reload
-
 # happened with > 8 threads
 statement ok
 SET threads=10
 
 # seed so it's deterministic
-statement ok
-SELECT SETSEED(0.8765309);
+set seed 0.8765309
 
 # create table that's has just one row group, and just a few duplicates
 statement ok

--- a/test/optimizer/pushdown/table_filter_pushdown.test
+++ b/test/optimizer/pushdown/table_filter_pushdown.test
@@ -2,9 +2,6 @@
 # description: Test Table Filter Push Down
 # group: [pushdown]
 
-require skip_reload
-
-
 statement ok
 CREATE TABLE integers(i integer, j integer, k integer)
 

--- a/test/optimizer/topn/complex_top_n.test
+++ b/test/optimizer/topn/complex_top_n.test
@@ -2,12 +2,9 @@
 # description: topN
 # group: [topn]
 
-require skip_reload
-
 require vector_size 1024
 
-statement ok
-SELECT SETSEED(0.42);
+set seed 0.42
 
 statement ok
 create table CUSTOMERVIEW as select range customer_id, range*random()::INT % 3 as customer_priority from range(1000, 4000); 

--- a/test/optimizer/zonemaps.test
+++ b/test/optimizer/zonemaps.test
@@ -2,9 +2,6 @@
 # description: Test if zonemaps are correctly used
 # group: [optimizer]
 
-require skip_reload
-
-
 statement ok
 PRAGMA explain_output = PHYSICAL_ONLY;
 

--- a/test/sql/aggregate/aggregates/bitstring_agg_empty.test
+++ b/test/sql/aggregate/aggregates/bitstring_agg_empty.test
@@ -5,8 +5,6 @@
 statement ok
 PRAGMA verify_external
 
-require skip_reload
-
 statement ok
 CREATE TABLE t1 (k VARCHAR, el VARCHAR);
 

--- a/test/sql/aggregate/aggregates/test_approx_quantile.test
+++ b/test/sql/aggregate/aggregates/test_approx_quantile.test
@@ -2,16 +2,13 @@
 # description: Test approx quantile operator
 # group: [aggregates]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 
 statement ok
 PRAGMA verify_external
 
-statement ok
-SELECT SETSEED(0.8675309);
+set seed 0.8675309
 
 statement ok
 create table quantile as select range r, random() from range(10000) union all values (NULL, 0.1), (NULL, 0.5), (NULL, 0.9) order by 2;

--- a/test/sql/aggregate/aggregates/test_arg_min_max_nested.test_slow
+++ b/test/sql/aggregate/aggregates/test_arg_min_max_nested.test_slow
@@ -8,8 +8,7 @@ PRAGMA enable_verification
 statement ok
 PRAGMA verify_external
 
-statement ok
-SELECT SETSEED(0.8675309);
+set seed 0.8675309
 
 statement ok
 CREATE TABLE tbl(

--- a/test/sql/aggregate/aggregates/test_arg_min_max_null_nested.test_slow
+++ b/test/sql/aggregate/aggregates/test_arg_min_max_null_nested.test_slow
@@ -8,8 +8,7 @@ PRAGMA enable_verification
 statement ok
 PRAGMA verify_external
 
-statement ok
-SELECT SETSEED(0.8675309);
+set seed 0.8675309
 
 statement ok
 CREATE TABLE tbl(

--- a/test/sql/aggregate/aggregates/test_avg.test
+++ b/test/sql/aggregate/aggregates/test_avg.test
@@ -2,8 +2,6 @@
 # description: Test AVG operator
 # group: [aggregates]
 
-require skip_reload
-
 # scalar average
 query RR
 SELECT AVG(3), AVG(NULL)

--- a/test/sql/aggregate/aggregates/test_bit_and.test
+++ b/test/sql/aggregate/aggregates/test_bit_and.test
@@ -2,8 +2,6 @@
 # description: Test BIT_AND operator
 # group: [aggregates]
 
-require skip_reload
-
 # test on scalar values
 query II
 SELECT BIT_AND(3), BIT_AND(NULL)

--- a/test/sql/aggregate/aggregates/test_bit_or.test
+++ b/test/sql/aggregate/aggregates/test_bit_or.test
@@ -2,8 +2,6 @@
 # description: Test BIT_OR operator
 # group: [aggregates]
 
-require skip_reload
-
 # test on scalar values
 query II
 SELECT BIT_OR(3), BIT_OR(NULL)

--- a/test/sql/aggregate/aggregates/test_bit_xor.test
+++ b/test/sql/aggregate/aggregates/test_bit_xor.test
@@ -2,8 +2,6 @@
 # description: Test BIT_XOR operator
 # group: [aggregates]
 
-require skip_reload
-
 # test on scalar values
 query II
 SELECT BIT_XOR(3), BIT_XOR(NULL)

--- a/test/sql/aggregate/aggregates/test_bitstring_agg.test
+++ b/test/sql/aggregate/aggregates/test_bitstring_agg.test
@@ -5,8 +5,6 @@
 statement ok
 PRAGMA verify_external
 
-require skip_reload
-
 # test tinyints
 statement ok
 CREATE TABLE tinyints(i TINYINT)

--- a/test/sql/aggregate/group/test_group_by_parallel.test_slow
+++ b/test/sql/aggregate/group/test_group_by_parallel.test_slow
@@ -2,8 +2,6 @@
 # description: Test parallel group by
 # group: [group]
 
-require skip_reload
-
 statement ok
 PRAGMA threads=4
 

--- a/test/sql/aggregate/qualify/test_qualify_macro.test
+++ b/test/sql/aggregate/qualify/test_qualify_macro.test
@@ -2,8 +2,6 @@
 # description: Test QUALIFY clause in the subquery of a macro function
 # group: [qualify]
 
-require skip_reload
-
 # load the DB from disk
 load __TEST_DIR__/macro_storage.db
 

--- a/test/sql/aggregate/qualify/test_qualify_view_no_view_dependencies.test
+++ b/test/sql/aggregate/qualify/test_qualify_view_no_view_dependencies.test
@@ -2,8 +2,6 @@
 # description: Test QUALIFY clause in a view over different runs
 # group: [qualify]
 
-require skip_reload
-
 # load the DB from disk
 load __TEST_DIR__/view_storage.db
 

--- a/test/sql/alter/alter_type/test_alter_type_dependencies.test
+++ b/test/sql/alter/alter_type/test_alter_type_dependencies.test
@@ -2,8 +2,6 @@
 # description: Test ALTER TABLE ALTER TYPE and dependencies
 # group: [alter_type]
 
-require skip_reload
-
 statement ok
 CREATE TABLE test(i INTEGER, j INTEGER)
 

--- a/test/sql/alter/rename_col/test_rename_col_dependencies.test
+++ b/test/sql/alter/rename_col/test_rename_col_dependencies.test
@@ -2,9 +2,6 @@
 # description: Test ALTER TABLE RENAME COLUMN and dependencies
 # group: [rename_col]
 
-require skip_reload
-
-
 statement ok
 CREATE TABLE test(i INTEGER, j INTEGER)
 

--- a/test/sql/alter/rename_table/test_rename_table_chain_commit.test
+++ b/test/sql/alter/rename_table/test_rename_table_chain_commit.test
@@ -2,9 +2,6 @@
 # description: test a chain of table creates and renames in a transaction, followed by a commit
 # group: [rename_table]
 
-require skip_reload
-
-
 statement ok con1
 CREATE TABLE entry(i INTEGER);
 

--- a/test/sql/attach/attach_all_types.test
+++ b/test/sql/attach/attach_all_types.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH of a database with all types
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 ATTACH '__TEST_DIR__/attach_all_types.db' AS db1
 

--- a/test/sql/attach/attach_checkpoint_deadlock.test_slow
+++ b/test/sql/attach/attach_checkpoint_deadlock.test_slow
@@ -2,10 +2,6 @@
 # description: Deadlock when checkpointing multiple databases
 # group: [attach]
 
-require noforcestorage
-
-require skip_reload
-
 concurrentforeach dbname foo bar i1 i2 i3 i4 i5 i6 i7 i8 i9
 
 statement ok

--- a/test/sql/attach/attach_checkpoint_vacuum.test
+++ b/test/sql/attach/attach_checkpoint_vacuum.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH with CHECKPOINT and VACUUM
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_concurrent_checkpoint.test_slow
+++ b/test/sql/attach/attach_concurrent_checkpoint.test_slow
@@ -2,10 +2,6 @@
 # description: Concurrently checkpoint the same database
 # group: [attach]
 
-require noforcestorage
-
-require skip_reload
-
 statement ok
 ATTACH '__TEST_DIR__/concurrent_checkpoint.db' AS db
 

--- a/test/sql/attach/attach_copy.test
+++ b/test/sql/attach/attach_copy.test
@@ -2,8 +2,6 @@
 # description: Test attach mixed with the COPY statement
 # group: [attach]
 
-require skip_reload
-
 statement ok
 ATTACH DATABASE ':memory:' AS db1;
 

--- a/test/sql/attach/attach_create_index.test
+++ b/test/sql/attach/attach_create_index.test
@@ -2,8 +2,6 @@
 # description: Test create index on an attached database with an alias
 # group: [attach]
 
-require skip_reload
-
 statement ok
 ATTACH '' AS tmp;
 

--- a/test/sql/attach/attach_cross_catalog.test
+++ b/test/sql/attach/attach_cross_catalog.test
@@ -2,8 +2,6 @@
 # description: Cross catalog dependencies should not be allowed
 # group: [attach]
 
-require skip_reload
-
 statement ok
 ATTACH DATABASE ':memory:' AS db1;
 

--- a/test/sql/attach/attach_custom_block_size.test
+++ b/test/sql/attach/attach_custom_block_size.test
@@ -2,8 +2,6 @@
 # description: Tests attaching database files with different block allocation sizes.
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_database_size.test
+++ b/test/sql/attach/attach_database_size.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH mixed with database size
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_dbname_quotes.test
+++ b/test/sql/attach/attach_dbname_quotes.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH with a quoted database name
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 ATTACH ':memory:' as "my""db";
 

--- a/test/sql/attach/attach_default_table.test
+++ b/test/sql/attach/attach_default_table.test
@@ -4,8 +4,6 @@
 
 require parquet
 
-require noforcestorage
-
 statement ok
 attach '__TEST_DIR__/test.db' as ddb (default_table 'my_table')
 

--- a/test/sql/attach/attach_defaults.test
+++ b/test/sql/attach/attach_defaults.test
@@ -2,8 +2,6 @@
 # description: Test default behavior of ATTACH statement
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_did_you_mean.test
+++ b/test/sql/attach/attach_did_you_mean.test
@@ -2,8 +2,6 @@
 # description: The error messages that suggest possible alternative mixed with ATTACH
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 ATTACH DATABASE ':memory:' AS db1;
 

--- a/test/sql/attach/attach_different_alias.test
+++ b/test/sql/attach/attach_different_alias.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH of a database with a different alias
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_duckdb_type.test
+++ b/test/sql/attach/attach_duckdb_type.test
@@ -2,8 +2,6 @@
 # description: Test attaching a file with type DUCKDB
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_enable_external_access.test
+++ b/test/sql/attach/attach_enable_external_access.test
@@ -2,8 +2,6 @@
 # description: enable_external_access with attached  databases
 # group: [attach]
 
-require skip_reload
-
 # attach multiple different databases
 statement ok
 ATTACH '__TEST_DIR__/attach_access1.db' AS a1

--- a/test/sql/attach/attach_encryption_block_header.test
+++ b/test/sql/attach/attach_encryption_block_header.test
@@ -1,8 +1,6 @@
 # name: test/sql/attach/attach_encryption_block_header.test
 # group: [attach]
 
-require noforcestorage
-
 # workaround - alternative verify always forces the latest storage
 require no_alternative_verify
 

--- a/test/sql/attach/attach_enums.test
+++ b/test/sql/attach/attach_enums.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH of a database with custom enums
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_export_import.test
+++ b/test/sql/attach/attach_export_import.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH with export and import
 # group: [attach]
 
-require skip_reload
-
 statement ok
 ATTACH ':memory:' AS db1
 

--- a/test/sql/attach/attach_external_access.test
+++ b/test/sql/attach/attach_external_access.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH with enable external access set to false
 # group: [attach]
 
-require skip_reload
-
 statement ok
 SET enable_external_access=false
 

--- a/test/sql/attach/attach_filepath_roundtrip.test
+++ b/test/sql/attach/attach_filepath_roundtrip.test
@@ -2,8 +2,6 @@
 # description: Test file path roundtripping and concurrency
 # group: [attach]
 
-require noforcestorage
-
 require notwindows
 
 statement ok

--- a/test/sql/attach/attach_force_checkpoint_deadlock.test_slow
+++ b/test/sql/attach/attach_force_checkpoint_deadlock.test_slow
@@ -2,10 +2,6 @@
 # description: Deadlock when force checkpointing multiple databases
 # group: [attach]
 
-require noforcestorage
-
-require skip_reload
-
 concurrentforeach dbname foo bar i1 i2 i3 i4 i5 i6 i7 i8 i9
 
 statement ok

--- a/test/sql/attach/attach_foreign_key.test
+++ b/test/sql/attach/attach_foreign_key.test
@@ -2,8 +2,6 @@
 # description: Test attach mixed with foreign key constraints
 # group: [attach]
 
-require skip_reload
-
 statement ok
 ATTACH DATABASE ':memory:' AS db1;
 

--- a/test/sql/attach/attach_httpfs.test
+++ b/test/sql/attach/attach_httpfs.test
@@ -2,8 +2,6 @@
 # description: Test attach using httpfs
 # group: [attach]
 
-require skip_reload
-
 require httpfs
 
 require-env S3_TEST_SERVER_AVAILABLE 1

--- a/test/sql/attach/attach_huggingface_index.test
+++ b/test/sql/attach/attach_huggingface_index.test
@@ -2,8 +2,6 @@
 # description: Test attach mixed with sequences and default values
 # group: [attach]
 
-require skip_reload
-
 # The database is written with a vector size of 2048.
 require vector_size 2048
 

--- a/test/sql/attach/attach_icu_collation.test
+++ b/test/sql/attach/attach_icu_collation.test
@@ -2,8 +2,6 @@
 # description: ATTACH to a database that uses ICU collations in types
 # group: [attach]
 
-require skip_reload
-
 require icu
 
 # The database is written with a vector size of 2048.

--- a/test/sql/attach/attach_if_not_exists.test
+++ b/test/sql/attach/attach_if_not_exists.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH IF NOT EXISTS
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_index.test
+++ b/test/sql/attach/attach_index.test
@@ -2,11 +2,6 @@
 # description: Issue #6666 - ATTACH fails on duckdb database with INDEX
 # group: [attach]
 
-# USE memory is no longer correct when we load a different database
-require noforcestorage
-
-require skip_reload
-
 statement ok
 ATTACH '__TEST_DIR__/attach_index_db.db'
 

--- a/test/sql/attach/attach_issue16122.test
+++ b/test/sql/attach/attach_issue16122.test
@@ -2,10 +2,7 @@
 # description: Issue #16122 - Attach binding to incorrect table
 # group: [attach]
 
-require noforcestorage
-
 load __TEST_DIR__/issue16122.db
-
 
 statement ok
 create table mytable (C1 VARCHAR(10));

--- a/test/sql/attach/attach_issue7567.test
+++ b/test/sql/attach/attach_issue7567.test
@@ -2,8 +2,6 @@
 # description: Issue #7567 - Setting the current schema should not change the current database
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 attach ':memory:' as test;
 

--- a/test/sql/attach/attach_issue7711.test
+++ b/test/sql/attach/attach_issue7711.test
@@ -2,8 +2,6 @@
 # description: Issue #7711 - Detaching the current database prevents from using another one
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 attach ':memory:' as test;
 

--- a/test/sql/attach/attach_issue_7660.test
+++ b/test/sql/attach/attach_issue_7660.test
@@ -2,8 +2,6 @@
 # description: Issue #7660 - USE databases causes export database to produce duplicate data
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_macros.test
+++ b/test/sql/attach/attach_macros.test
@@ -2,8 +2,6 @@
 # description: Tests for macro functions in attached databases
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_modify_multiple_databases.test
+++ b/test/sql/attach/attach_modify_multiple_databases.test
@@ -2,8 +2,6 @@
 # description: Modify multiple databases in one transaction
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_multi_identifiers.test
+++ b/test/sql/attach/attach_multi_identifiers.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH with complex identifiers
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_nested_types.test
+++ b/test/sql/attach/attach_nested_types.test
@@ -2,8 +2,6 @@
 # description: Test attach with nested types
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_new_compression.test
+++ b/test/sql/attach/attach_new_compression.test
@@ -2,8 +2,6 @@
 # description: Tests attaching database files and using new compression methods
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_or_replace.test
+++ b/test/sql/attach/attach_or_replace.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH OR REPLACE
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_persistent.test
+++ b/test/sql/attach/attach_persistent.test
@@ -2,8 +2,6 @@
 # description: Test attaching of a persistent database
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_pragma_storage_info.test
+++ b/test/sql/attach/attach_pragma_storage_info.test
@@ -1,8 +1,6 @@
 # name: test/sql/attach/attach_pragma_storage_info.test
 # group: [attach]
 
-require skip_reload
-
 load __TEST_DIR__/alter_dependency_conflict.db
 
 statement ok

--- a/test/sql/attach/attach_read_only.test
+++ b/test/sql/attach/attach_read_only.test
@@ -2,8 +2,6 @@
 # description: Test attaching of a read-only database
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_read_only_transaction.test
+++ b/test/sql/attach/attach_read_only_transaction.test
@@ -2,8 +2,6 @@
 # description: Test attach with explicit READ ONLY transactions
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_reserved.test
+++ b/test/sql/attach/attach_reserved.test
@@ -2,8 +2,6 @@
 # description: Test ATTACH of reserved names
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_row_group_size.test
+++ b/test/sql/attach/attach_row_group_size.test
@@ -2,8 +2,6 @@
 # description: Tests attaching database files and using new compression methods
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_s3.test
+++ b/test/sql/attach/attach_s3.test
@@ -2,8 +2,6 @@
 # description: Test attach using httpfs
 # group: [attach]
 
-require skip_reload
-
 require httpfs
 
 require-env S3_TEST_SERVER_AVAILABLE 1

--- a/test/sql/attach/attach_s3_tpch.test_slow
+++ b/test/sql/attach/attach_s3_tpch.test_slow
@@ -2,8 +2,6 @@
 # description: Test running TPC-H over a database attached over S3
 # group: [attach]
 
-require skip_reload
-
 require httpfs
 
 require tpch

--- a/test/sql/attach/attach_same_db.test
+++ b/test/sql/attach/attach_same_db.test
@@ -2,8 +2,6 @@
 # description: Test attaching of the same database
 # group: [attach]
 
-require skip_reload
-
 require notwindows
 
 statement ok

--- a/test/sql/attach/attach_schema.test
+++ b/test/sql/attach/attach_schema.test
@@ -2,8 +2,6 @@
 # description: Test various DDL statements on an attached database
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_sequence.test
+++ b/test/sql/attach/attach_sequence.test
@@ -2,8 +2,6 @@
 # description: Test attach mixed with sequences and default values
 # group: [attach]
 
-require skip_reload
-
 statement ok
 ATTACH DATABASE '__TEST_DIR__/attach_seq.db' AS db1;
 

--- a/test/sql/attach/attach_serialize_dependency.test
+++ b/test/sql/attach/attach_serialize_dependency.test
@@ -2,8 +2,6 @@
 # description: Test attach and re-attach with serialized dependencies
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 set storage_compatibility_version='latest';
 

--- a/test/sql/attach/attach_show_all_tables.test
+++ b/test/sql/attach/attach_show_all_tables.test
@@ -2,8 +2,6 @@
 # description: Test various DDL statements on an attached database
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_show_table.test
+++ b/test/sql/attach/attach_show_table.test
@@ -2,8 +2,6 @@
 # description: Show table should respect current scope
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_storage_version.test
+++ b/test/sql/attach/attach_storage_version.test
@@ -2,8 +2,6 @@
 # description: Tests attaching database files with different block allocation sizes.
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_table_constraints.test
+++ b/test/sql/attach/attach_table_constraints.test
@@ -2,8 +2,6 @@
 # description: Test information_schema.table_constraints with attach
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_table_ddl.test
+++ b/test/sql/attach/attach_table_ddl.test
@@ -2,8 +2,6 @@
 # description: Test various DDL statements on an attached database
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_table_info.test
+++ b/test/sql/attach/attach_table_info.test
@@ -2,9 +2,6 @@
 # description: Test ATTACH with table info
 # group: [attach]
 
-# avoid loading a storage database because it changes the initial database name
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_transactionality.test
+++ b/test/sql/attach/attach_transactionality.test
@@ -2,8 +2,6 @@
 # description: Test transactionality of attach
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_view_search_path.test
+++ b/test/sql/attach/attach_view_search_path.test
@@ -2,9 +2,6 @@
 # description: Test ATTACH with search path
 # group: [attach]
 
-# avoid loading a storage database because it changes the initial database name
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_views.test
+++ b/test/sql/attach/attach_views.test
@@ -2,8 +2,6 @@
 # description: Test views in an attached database
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_wal_alter.test
+++ b/test/sql/attach/attach_wal_alter.test
@@ -2,8 +2,6 @@
 # description: WAL cannot alter table
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_wal_alter_sequence.test
+++ b/test/sql/attach/attach_wal_alter_sequence.test
@@ -2,8 +2,6 @@
 # description: Test binding of a WAL with a sequence entry in it
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA disable_checkpoint_on_shutdown
 

--- a/test/sql/attach/detach_keyword.test
+++ b/test/sql/attach/detach_keyword.test
@@ -2,8 +2,6 @@
 # description: Test DETACH with keywords
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/in_memory_attach.test
+++ b/test/sql/attach/in_memory_attach.test
@@ -2,8 +2,6 @@
 # description: Test in-memory attach
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/reattach_schema.test
+++ b/test/sql/attach/reattach_schema.test
@@ -2,8 +2,6 @@
 # description: Re-attach a database with a non-standard schema and re-name the database
 # group: [attach]
 
-require skip_reload
-
 statement ok
 ATTACH '__TEST_DIR__/reattach_schema.db' AS new_db;
 

--- a/test/sql/attach/show_databases.test
+++ b/test/sql/attach/show_databases.test
@@ -2,8 +2,6 @@
 # description: Test SHOW DATABASES and USE
 # group: [attach]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/system_catalog.test
+++ b/test/sql/attach/system_catalog.test
@@ -2,8 +2,6 @@
 # description: Test interactions with the SYSTEM catalog
 # group: [attach]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/catalog/case_insensitive_operations.test
+++ b/test/sql/catalog/case_insensitive_operations.test
@@ -5,9 +5,6 @@
 statement ok
 SET default_null_order='nulls_first';
 
-require skip_reload
-
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/catalog/comment_on_extended.test
+++ b/test/sql/catalog/comment_on_extended.test
@@ -2,8 +2,6 @@
 # description: Test COMMENT ON to add comment on database
 # group: [catalog]
 
-require skip_reload
-
 ### Create some test data
 statement ok
 ATTACH '__TEST_DIR__/comment_on_extended_1.db' AS db1

--- a/test/sql/catalog/did_you_mean.test
+++ b/test/sql/catalog/did_you_mean.test
@@ -2,8 +2,6 @@
 # description: The error messages suggest possible alternative
 # group: [catalog]
 
-require skip_reload
-
 statement ok
 CREATE TABLE hello(i INTEGER);
 

--- a/test/sql/catalog/function/test_cross_catalog_macros.test
+++ b/test/sql/catalog/function/test_cross_catalog_macros.test
@@ -2,8 +2,6 @@
 # description: Test cross-catalog dependencies in macros
 # group: [function]
 
-require skip_reload
-
 statement ok
 CREATE MACRO my_first_macro() AS (84)
 

--- a/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
+++ b/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
@@ -1,8 +1,6 @@
 # name: test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
 # group: [function]
 
-require skip_reload
-
 statement ok
 ATTACH '__TEST_DIR__/macro_default_arg.db' (STORAGE_VERSION 'v1.0.0');
 

--- a/test/sql/catalog/function/test_macro_relpersistence_conflict.test
+++ b/test/sql/catalog/function/test_macro_relpersistence_conflict.test
@@ -2,8 +2,6 @@
 # description: Test Macro temporary/if exists/or replace
 # group: [function]
 
-require skip_reload
-
 # load the DB from disk
 load __TEST_DIR__/my_macro_database.db
 

--- a/test/sql/catalog/function/test_sequence_macro.test
+++ b/test/sql/catalog/function/test_sequence_macro.test
@@ -2,9 +2,6 @@
 # description: Test Sequence Macro
 # group: [function]
 
-require skip_reload
-
-
 statement ok
 CREATE TABLE integers (i INT)
 

--- a/test/sql/catalog/function/test_table_macro_copy.test
+++ b/test/sql/catalog/function/test_table_macro_copy.test
@@ -5,8 +5,6 @@
 statement ok
 PRAGMA enable_verification
 
-require skip_reload
-
 load __TEST_DIR__/table_macro.db
 
 statement ok

--- a/test/sql/catalog/sequence/sequence_offset_increment.test
+++ b/test/sql/catalog/sequence/sequence_offset_increment.test
@@ -2,8 +2,6 @@
 # description: Issue #9252: Sequences defined with offset and custom increment always start with 1 instead of using the offset
 # group: [sequence]
 
-require skip_reload
-
 statement ok
 create sequence xx start 100 increment by 2;
 

--- a/test/sql/catalog/test_querying_from_detached_catalog.test
+++ b/test/sql/catalog/test_querying_from_detached_catalog.test
@@ -2,8 +2,6 @@
 # description: Test switching from detached catalog to another catalog
 # group: [catalog]
 
-require skip_reload
-
 statement ok con1
 ATTACH ':memory:' AS db1;
 

--- a/test/sql/catalog/test_set_schema.test
+++ b/test/sql/catalog/test_set_schema.test
@@ -5,8 +5,6 @@
 # This test focuses on actual name lookup.
 # See also test_set_search_path.test
 
-require skip_reload
-
 statement ok
 CREATE SCHEMA test;
 

--- a/test/sql/collate/test_collate_and_grouping_sets.test
+++ b/test/sql/collate/test_collate_and_grouping_sets.test
@@ -4,8 +4,6 @@
 
 require icu
 
-require skip_reload
-
 statement ok
 set default_collation=c;
 

--- a/test/sql/constraints/foreignkey/test_fk_eager_constraint_checking.test
+++ b/test/sql/constraints/foreignkey/test_fk_eager_constraint_checking.test
@@ -2,10 +2,6 @@
 # description: Test over-eager constraint checking for foreign keys.
 # group: [foreignkey]
 
-require noforcestorage
-
-require skip_reload
-
 statement ok
 PRAGMA enable_verification;
 

--- a/test/sql/constraints/foreignkey/test_fk_temporary.test
+++ b/test/sql/constraints/foreignkey/test_fk_temporary.test
@@ -2,8 +2,6 @@
 # description: Test foreign key constraint
 # group: [foreignkey]
 
-require skip_reload
-
 statement ok
 CREATE TEMPORARY TABLE album(artistid INTEGER, albumname TEXT, albumcover TEXT, UNIQUE (artistid, albumname));
 

--- a/test/sql/constraints/unique/test_unique_error.test
+++ b/test/sql/constraints/unique/test_unique_error.test
@@ -2,8 +2,6 @@
 # description: UNIQUE constraint on temporary tables with duplicate data
 # group: [unique]
 
-require skip_reload
-
 statement ok
 CREATE TEMPORARY TABLE integers(i INTEGER, j VARCHAR)
 

--- a/test/sql/constraints/unique/test_unique_multi_column.test
+++ b/test/sql/constraints/unique/test_unique_multi_column.test
@@ -5,8 +5,6 @@
 statement ok
 SET default_null_order='nulls_first';
 
-require skip_reload
-
 statement ok
 CREATE TEMPORARY TABLE integers(i INTEGER, j INTEGER)
 

--- a/test/sql/constraints/unique/test_unique_string.test
+++ b/test/sql/constraints/unique/test_unique_string.test
@@ -2,8 +2,6 @@
 # description: UNIQUE constraint on temporary tables with Strings
 # group: [unique]
 
-require skip_reload
-
 statement ok
 CREATE TEMPORARY TABLE integers(i INTEGER, j VARCHAR)
 

--- a/test/sql/constraints/unique/test_unique_temp.test
+++ b/test/sql/constraints/unique/test_unique_temp.test
@@ -5,8 +5,6 @@
 statement ok
 SET default_null_order='nulls_first';
 
-require skip_reload
-
 statement ok
 CREATE TEMPORARY TABLE integers(i INTEGER, j INTEGER)
 

--- a/test/sql/copy/parquet/batched_write/batch_memory_usage.test_slow
+++ b/test/sql/copy/parquet/batched_write/batch_memory_usage.test_slow
@@ -4,8 +4,7 @@
 
 require parquet
 
-statement ok
-SELECT setseed(0.72)
+set seed 0.72
 
 statement ok
 COPY (SELECT uuid()::VARCHAR as varchar, uuid() AS uuid FROM range(10000000) t(i)) TO '__TEST_DIR__/random_uuids.parquet'

--- a/test/sql/copy/parquet/batched_write/batch_memory_usage_small.test_slow
+++ b/test/sql/copy/parquet/batched_write/batch_memory_usage_small.test_slow
@@ -4,8 +4,7 @@
 
 require parquet
 
-statement ok
-SELECT setseed(0.72)
+set seed 0.72
 
 statement ok
 COPY (SELECT uuid()::VARCHAR as varchar, uuid() AS uuid FROM range(10000000) t(i)) TO '__TEST_DIR__/random_uuids.parquet'

--- a/test/sql/copy/parquet/hive_timestamps.test
+++ b/test/sql/copy/parquet/hive_timestamps.test
@@ -4,16 +4,13 @@
 
 require parquet
 
-require skip_reload
-
 # requires notwindows for embedded spaces in the path
 require notwindows
 
 statement ok
 PRAGMA enable_verification
 
-statement ok
-SELECT SETSEED(0.8675309);
+set seed 0.8675309
 
 statement ok
 CREATE TABLE raw_data (

--- a/test/sql/copy/parquet/test_parquet_stats.test
+++ b/test/sql/copy/parquet/test_parquet_stats.test
@@ -4,9 +4,6 @@
 
 require parquet
 
-require skip_reload
-
-
 statement ok
 PRAGMA explain_output = PHYSICAL_ONLY
 

--- a/test/sql/copy_database/copy_database_gen_col.test
+++ b/test/sql/copy_database/copy_database_gen_col.test
@@ -1,8 +1,6 @@
 # name: test/sql/copy_database/copy_database_gen_col.test
 # group: [copy_database]
 
-require skip_reload
-
 load __TEST_DIR__/mydb.db
 
 statement ok

--- a/test/sql/delete/test_segment_deletes.test
+++ b/test/sql/delete/test_segment_deletes.test
@@ -2,8 +2,6 @@
 # description: Test deletions
 # group: [delete]
 
-require skip_reload
-
 statement ok con1
 CREATE TABLE a(i INTEGER);
 

--- a/test/sql/error/qualified_column_error.test
+++ b/test/sql/error/qualified_column_error.test
@@ -2,8 +2,6 @@
 # description: Test errors on qualified columns
 # group: [error]
 
-require skip_reload
-
 statement ok
 create schema "dbt_temp"
 

--- a/test/sql/export/export_indexes.test
+++ b/test/sql/export/export_indexes.test
@@ -2,9 +2,6 @@
 # description: Test export of macro's
 # group: [export]
 
-# FIXME: see duckdb-internal/146
-require skip_reload
-
 statement ok
 BEGIN TRANSACTION
 

--- a/test/sql/filter/test_filter_clause.test_slow
+++ b/test/sql/filter/test_filter_clause.test_slow
@@ -2,9 +2,6 @@
 # description: Test aggregation with filter clause
 # group: [filter]
 
-require skip_reload
-
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/function/autocomplete/create_schema.test
+++ b/test/sql/function/autocomplete/create_schema.test
@@ -24,8 +24,6 @@ FROM sql_auto_complete('CREATE SCHEMA IF NOT EX') LIMIT 1;
 ----
 EXISTS 	21
 
-require skip_reload
-
 # attached database
 # suggest a catalog
 statement ok

--- a/test/sql/function/autocomplete/create_table.test
+++ b/test/sql/function/autocomplete/create_table.test
@@ -109,8 +109,6 @@ FROM sql_auto_complete('CREATE TABLE SC') LIMIT 1;
 ----
 "SCHEMA".	13
 
-require skip_reload
-
 # suggest a catalog
 statement ok
 ATTACH ':memory:' AS attached_in_memory;

--- a/test/sql/function/list/aggregates/avg.test
+++ b/test/sql/function/list/aggregates/avg.test
@@ -2,9 +2,6 @@
 # description: Test the list_avg aggregate function
 # group: [aggregates]
 
-require skip_reload
-
-
 # list_avg on a sequence
 statement ok
 CREATE SEQUENCE seq;

--- a/test/sql/function/list/aggregates/bit_and.test
+++ b/test/sql/function/list/aggregates/bit_and.test
@@ -2,9 +2,6 @@
 # description: Test the list_bit_and aggregate function
 # group: [aggregates]
 
-require skip_reload
-
-
 # bit_and on a sequence
 statement ok
 CREATE SEQUENCE seq;

--- a/test/sql/function/list/aggregates/bit_or.test
+++ b/test/sql/function/list/aggregates/bit_or.test
@@ -2,9 +2,6 @@
 # description: Test the list_bit_or aggregate function
 # group: [aggregates]
 
-require skip_reload
-
-
 # bit_or on a sequence
 statement ok
 CREATE SEQUENCE seq;

--- a/test/sql/function/list/aggregates/bit_xor.test
+++ b/test/sql/function/list/aggregates/bit_xor.test
@@ -2,9 +2,6 @@
 # description: Test the list_bit_xor aggregate function
 # group: [aggregates]
 
-require skip_reload
-
-
 # bit_xor on a sequence
 statement ok
 CREATE SEQUENCE seq;

--- a/test/sql/function/numeric/set_seed_for_sample.test
+++ b/test/sql/function/numeric/set_seed_for_sample.test
@@ -2,20 +2,16 @@
 # description: Test setseed for samples
 # group: [numeric]
 
-require skip_reload
-
 statement ok
 create table t1 as select * from generate_series(1,50) as t(number);
 
-statement ok
-select setseed(0.1);
+set seed 0.1
 
 query I rowsort result_1
 select * from t1 using sample 5;
 ----
 
-statement ok
-select setseed(0.1);
+set seed 0.1
 
 query I rowsort result_1
 select * from t1 using sample 5;

--- a/test/sql/index/art/insert_update_delete/test_art_update_other_column.test
+++ b/test/sql/index/art/insert_update_delete/test_art_update_other_column.test
@@ -5,8 +5,6 @@
 statement ok
 PRAGMA enable_verification
 
-require skip_reload
-
 statement ok con1
 CREATE TABLE integers(i BIGINT, j INTEGER, k VARCHAR)
 

--- a/test/sql/join/iejoin/iejoin_projection_maps.test
+++ b/test/sql/join/iejoin/iejoin_projection_maps.test
@@ -2,13 +2,10 @@
 # description: Test IEJoin projection mapping
 # group: [iejoin]
 
-require skip_reload
-
 statement ok
 PRAGMA threads=1
 
-statement ok
-SELECT SETSEED(0.8765309);
+set seed 0.8765309
 
 statement ok
 CREATE TABLE df (id INTEGER, id2 INTEGER, id3 INTEGER, value_double DOUBLE, value as (value_double::DECIMAL(4,3)), one_min_value as ((1.0 - value_double)::DECIMAL(4,3)))

--- a/test/sql/join/iejoin/test_iejoin_events.test
+++ b/test/sql/join/iejoin/test_iejoin_events.test
@@ -14,8 +14,7 @@ statement ok
 SET merge_join_threshold=0
 
 # Use small 1K table to test Q2 because it melts down the other operators at larger scales
-statement ok
-SELECT SETSEED(0.8675309);
+set seed 0.8675309
 
 statement ok
 CREATE TABLE events AS (

--- a/test/sql/json/issues/test_json_temp_8062.test
+++ b/test/sql/json/issues/test_json_temp_8062.test
@@ -2,9 +2,6 @@
 # description: Test JSON fields in temporary tables for issue 8062
 # group: [issues]
 
-# Can't do reload tests with temp tables
-require skip_reload
-
 require json
 
 statement ok

--- a/test/sql/json/test_json_persistence.test
+++ b/test/sql/json/test_json_persistence.test
@@ -4,8 +4,6 @@
 
 require json
 
-require skip_reload
-
 # load the DB from disk
 load __TEST_DIR__/json_type.db
 

--- a/test/sql/keywords/escaped_quotes_expressions.test
+++ b/test/sql/keywords/escaped_quotes_expressions.test
@@ -2,9 +2,6 @@
 # description: Test escaped quotes in expressions
 # group: [keywords]
 
-require skip_reload
-
-
 statement ok
 PRAGMA enable_verification;
 

--- a/test/sql/keywords/keywords_in_expressions.test
+++ b/test/sql/keywords/keywords_in_expressions.test
@@ -2,9 +2,6 @@
 # description: Test keywords in expressions
 # group: [keywords]
 
-require skip_reload
-
-
 statement ok
 PRAGMA enable_verification;
 

--- a/test/sql/order/limit_parameter.test
+++ b/test/sql/order/limit_parameter.test
@@ -2,8 +2,6 @@
 # description: Test LIMIT with a parameter
 # group: [order]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/order/order_parallel_ctas.test_slow
+++ b/test/sql/order/order_parallel_ctas.test_slow
@@ -2,8 +2,6 @@
 # description: Test parallel CREATE TABLE AS with ORDER BY
 # group: [order]
 
-require skip_reload
-
 # load the DB from disk
 load __TEST_DIR__/order_parallel_ctas.db
 

--- a/test/sql/order/test_limit.test
+++ b/test/sql/order/test_limit.test
@@ -2,8 +2,6 @@
 # description: Test LIMIT keyword
 # group: [order]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/order/test_limit_parameter.test
+++ b/test/sql/order/test_limit_parameter.test
@@ -2,8 +2,6 @@
 # description: Test LIMIT with a parameter (issue 1866)
 # group: [order]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/order/test_limit_percent.test
+++ b/test/sql/order/test_limit_percent.test
@@ -5,9 +5,6 @@
 statement ok
 SET default_null_order='nulls_first';
 
-require skip_reload
-
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/order/test_limit_percent_large.test_slow
+++ b/test/sql/order/test_limit_percent_large.test_slow
@@ -2,8 +2,6 @@
 # description: Test LIMIT keyword {% | PERCENT}
 # group: [order]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/order/test_order_nested.test_slow
+++ b/test/sql/order/test_order_nested.test_slow
@@ -5,11 +5,6 @@
 statement ok
 SET default_null_order='nulls_first';
 
-require skip_reload
-
-statement ok
-SET default_null_order='nulls_first';
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/pivot/pivot_databricks.test
+++ b/test/sql/pivot/pivot_databricks.test
@@ -2,9 +2,6 @@
 # description: Tests from the databricks docs
 # group: [pivot]
 
-# temp table
-require skip_reload
-
 # https://docs.databricks.com/sql/language-manual/sql-ref-syntax-qry-select-pivot.html
 
 statement ok

--- a/test/sql/pragma/test_metadata_info.test
+++ b/test/sql/pragma/test_metadata_info.test
@@ -2,9 +2,6 @@
 # description: Test metadata info
 # group: [pragma]
 
-# skip reload because of attach
-require skip_reload
-
 load __TEST_DIR__/test_metadata_info.db
 
 statement ok

--- a/test/sql/pragma/test_pragma_database_size.test
+++ b/test/sql/pragma/test_pragma_database_size.test
@@ -2,8 +2,6 @@
 # description: Test PRAGMA database_size
 # group: [pragma]
 
-require skip_reload
-
 statement ok
 PRAGMA database_size;
 

--- a/test/sql/prepared/test_issue_4042.test
+++ b/test/sql/prepared/test_issue_4042.test
@@ -5,8 +5,6 @@
 statement ok
 PRAGMA enable_verification
 
-require skip_reload
-
 statement ok
 CREATE TABLE stringliterals AS SELECT 1 AS ID, 1::BIGINT AS a1,'value-1' AS a2,'value-1' AS a3,10::BIGINT AS a4
 

--- a/test/sql/sample/bernoulli_sampling.test
+++ b/test/sql/sample/bernoulli_sampling.test
@@ -2,14 +2,10 @@
 # description: Test reservoir sample crash on large data sets
 # group: [sample]
 
-# seed does not persist across restarts
-require skip_reload
-
 statement ok
 create table output (num_rows INT);
 
-statement ok
-select setseed(0.3);
+set seed 0.3
 
 loop i 0 500
 
@@ -42,8 +38,7 @@ NULL	NULL	NULL
 statement ok
 create table t1 as select range id from range(1000);
 
-statement ok
-select setseed(0.6);
+set seed 0.6
 
 query I nosort result_1
 select id from t1 USING SAMPLE 1% (bernoulli, 5);

--- a/test/sql/select/test_multi_column_reference.test
+++ b/test/sql/select/test_multi_column_reference.test
@@ -2,9 +2,6 @@
 # description: Test multi column reference
 # group: [select]
 
-require skip_reload
-
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/storage/bc/internal_schemas_0102.test
+++ b/test/sql/storage/bc/internal_schemas_0102.test
@@ -2,8 +2,6 @@
 # description: Verify internal schemas are not duplicated in the main schema when reading older databases
 # group: [bc]
 
-require skip_reload
-
 # The database is written with a vector size of 2048.
 require vector_size 2048
 

--- a/test/sql/storage/buffer_manager_temp_dir.test
+++ b/test/sql/storage/buffer_manager_temp_dir.test
@@ -4,8 +4,6 @@
 
 require noforcestorage
 
-require skip_reload
-
 # Set the temporary directory to an empty directory.
 statement ok
 PRAGMA temp_directory=''

--- a/test/sql/storage/catalog/test_macro_storage.test
+++ b/test/sql/storage/catalog/test_macro_storage.test
@@ -2,9 +2,6 @@
 # description: Create and drop a macro over different runs
 # group: [catalog]
 
-require skip_reload
-
-
 # load the DB from disk
 load __TEST_DIR__/macro_storage.db
 

--- a/test/sql/storage/catalog/test_prepared_storage.test
+++ b/test/sql/storage/catalog/test_prepared_storage.test
@@ -2,9 +2,6 @@
 # description: PREPARE and WAL
 # group: [catalog]
 
-require skip_reload
-
-
 # load the DB from disk
 load __TEST_DIR__/prepared_storage.db
 

--- a/test/sql/storage/catalog/test_store_sequences.test
+++ b/test/sql/storage/catalog/test_store_sequences.test
@@ -2,9 +2,6 @@
 # description: Use sequences over different runs
 # group: [catalog]
 
-require skip_reload
-
-
 load __TEST_DIR__/store_sequences.db
 
 # standard sequence

--- a/test/sql/storage/catalog/test_store_temporary.test
+++ b/test/sql/storage/catalog/test_store_temporary.test
@@ -2,8 +2,6 @@
 # description: Temporary tables are not written to disk
 # group: [catalog]
 
-require skip_reload
-
 # load the DB from disk
 load __TEST_DIR__/test_store_temporary.db
 

--- a/test/sql/storage/checkpoint_abort.test_slow
+++ b/test/sql/storage/checkpoint_abort.test_slow
@@ -2,9 +2,6 @@
 # description: Test correct behavior if we unexpectedly abort during a checkpoint
 # group: [storage]
 
-require skip_reload
-
-
 load __TEST_DIR__/checkpoint_abort.db
 
 statement ok

--- a/test/sql/storage/checkpoint_abort_after_free_list.test_slow
+++ b/test/sql/storage/checkpoint_abort_after_free_list.test_slow
@@ -2,8 +2,6 @@
 # description: Test correct behavior if we unexpectedly abort after a checkpoint right after the free list is written
 # group: [storage]
 
-require skip_reload
-
 load __TEST_DIR__/checkpoint_abort.db
 
 statement ok

--- a/test/sql/storage/checkpoint_abort_before_header.test_slow
+++ b/test/sql/storage/checkpoint_abort_before_header.test_slow
@@ -2,8 +2,6 @@
 # description: Test correct behavior if we unexpectedly abort after a checkpoint but before the WAL is successfully truncated
 # group: [storage]
 
-require skip_reload
-
 load __TEST_DIR__/checkpoint_abort.db
 
 statement ok

--- a/test/sql/storage/checkpoint_abort_before_truncate.test_slow
+++ b/test/sql/storage/checkpoint_abort_before_truncate.test_slow
@@ -2,8 +2,6 @@
 # description: Test correct behavior if we unexpectedly abort after a checkpoint but before the WAL is successfully truncated
 # group: [storage]
 
-require skip_reload
-
 load __TEST_DIR__/checkpoint_abort.db
 
 statement ok

--- a/test/sql/storage/checkpointed_self_append.test
+++ b/test/sql/storage/checkpointed_self_append.test
@@ -2,8 +2,6 @@
 # description: Test appending to a checkpointed table from itself
 # group: [storage]
 
-require skip_reload
-
 # load the DB from disk
 load __TEST_DIR__/checkpointed_self_append.db
 

--- a/test/sql/storage/commit_abort.test
+++ b/test/sql/storage/commit_abort.test
@@ -2,9 +2,6 @@
 # description: Test abort of commit with persistent storage
 # group: [storage]
 
-require skip_reload
-
-
 # load the DB from disk
 load __TEST_DIR__/commit_abort.db
 

--- a/test/sql/storage/compact_block_size/compact_block_size.test
+++ b/test/sql/storage/compact_block_size/compact_block_size.test
@@ -2,10 +2,6 @@
 # description: Various tests with a compact block size of 16384 bytes
 # group: [compact_block_size]
 
-require noforcestorage
-
-require skip_reload
-
 require exact_vector_size 2048
 
 statement ok

--- a/test/sql/storage/compact_block_size/create_table_compression.test
+++ b/test/sql/storage/compact_block_size/create_table_compression.test
@@ -6,8 +6,6 @@
 # because the bitpacking groups fit the blocks.
 require block_size 16384
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/storage/compact_block_size/ensure_bitpacking.test
+++ b/test/sql/storage/compact_block_size/ensure_bitpacking.test
@@ -2,10 +2,6 @@
 # description: Ensure that we serialize a bitpacking segment for 256KB databases.
 # group: [compact_block_size]
 
-require skip_reload
-
-require noforcestorage
-
 statement ok
 SET threads=1;
 

--- a/test/sql/storage/compact_block_size/ensure_no_bitpacking.test
+++ b/test/sql/storage/compact_block_size/ensure_no_bitpacking.test
@@ -2,10 +2,6 @@
 # description: Ensure that we do not serialize a bitpacking segment for 16KB databases.
 # group: [compact_block_size]
 
-require skip_reload
-
-require noforcestorage
-
 statement ok
 SET threads=1;
 

--- a/test/sql/storage/compact_block_size/mixed_block_sizes.test
+++ b/test/sql/storage/compact_block_size/mixed_block_sizes.test
@@ -2,10 +2,6 @@
 # description: Tests queries with mixed block sizes.
 # group: [compact_block_size]
 
-require noforcestorage
-
-require skip_reload
-
 statement ok
 ATTACH '__TEST_DIR__/small.db' (BLOCK_SIZE 16384);
 

--- a/test/sql/storage/compression/string/big_strings.test
+++ b/test/sql/storage/compression/string/big_strings.test
@@ -2,8 +2,6 @@
 # description: Test string compression with big strings, which are currently unsupported by the compression algorithms
 # group: [string]
 
-require skip_reload
-
 statement ok
 pragma verify_fetch_row
 

--- a/test/sql/storage/compression/string/blob.test
+++ b/test/sql/storage/compression/string/blob.test
@@ -2,8 +2,6 @@
 # description: blob tests
 # group: [string]
 
-require skip_reload
-
 statement ok
 pragma verify_fetch_row
 

--- a/test/sql/storage/compression/string/empty.test
+++ b/test/sql/storage/compression/string/empty.test
@@ -2,8 +2,6 @@
 # description: Test empty strings with string compression
 # group: [string]
 
-require skip_reload
-
 require no_latest_storage
 
 require vector_size 512

--- a/test/sql/storage/compression/string/filter_pushdown.test
+++ b/test/sql/storage/compression/string/filter_pushdown.test
@@ -2,8 +2,6 @@
 # description: Filter pushdown with string compressed columns
 # group: [string]
 
-require skip_reload
-
 statement ok
 pragma verify_fetch_row
 

--- a/test/sql/storage/compression/string/index_fetch.test
+++ b/test/sql/storage/compression/string/index_fetch.test
@@ -2,8 +2,6 @@
 # description: Fetch from compressed string column with index
 # group: [string]
 
-require skip_reload
-
 statement ok
 pragma verify_fetch_row
 

--- a/test/sql/storage/compression/string/simple.test
+++ b/test/sql/storage/compression/string/simple.test
@@ -2,8 +2,6 @@
 # description: Test dictionary compression
 # group: [string]
 
-require skip_reload
-
 statement ok
 ATTACH '__TEST_DIR__/test_blob_new.db' AS db_v13 (STORAGE_VERSION 'v1.3.0');
 

--- a/test/sql/storage/compression/zstd/test_skipping.test
+++ b/test/sql/storage/compression/zstd/test_skipping.test
@@ -9,8 +9,7 @@ load __TEST_DIR__/zstd_vector_skipping.db
 statement ok
 pragma force_compression='zstd';
 
-statement ok
-select setseed(0.42);
+set seed 0.42
 
 statement ok
 create table tbl as

--- a/test/sql/storage/compression/zstd/zstd_compression_ratio.test_slow
+++ b/test/sql/storage/compression/zstd/zstd_compression_ratio.test_slow
@@ -18,8 +18,7 @@ set logging_level='info';
 statement ok
 PRAGMA force_compression='zstd'
 
-statement ok
-select setseed(0.42);
+set seed 0.42
 
 statement ok
 set variable dataset_size = 100_000;
@@ -48,8 +47,7 @@ FinalAnalyze(COMPRESSION_ZSTD) result for main.test_compressed.0(VARCHAR): 23080
 statement ok
 PRAGMA force_compression='uncompressed'
 
-statement ok
-select setseed(0.42);
+set seed 0.42
 
 statement ok
 CREATE TABLE test_uncompressed as (

--- a/test/sql/storage/icu_collation.test
+++ b/test/sql/storage/icu_collation.test
@@ -2,8 +2,6 @@
 # description: ATTACH to a database that uses ICU collations in types
 # group: [storage]
 
-require skip_reload
-
 require icu
 
 # The database is written with a vector size of 2048.

--- a/test/sql/storage/many_checkpoints_leak.test_slow
+++ b/test/sql/storage/many_checkpoints_leak.test_slow
@@ -2,8 +2,6 @@
 # description: Verify that dropping tables with multi-use blocks does not leak memory
 # group: [storage]
 
-require skip_reload
-
 load __TEST_DIR__/many_checkpoints.db
 
 # verify that doing this in a loop doesn't increase database size (i.e. blocks properly get added to the free list)

--- a/test/sql/storage/optimistic_write/optimistic_write_abort.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_abort.test_slow
@@ -26,9 +26,6 @@ SELECT SUM(a) FROM test
 ----
 999999000000
 
-# temp table
-require skip_reload
-
 statement ok
 CREATE TEMPORARY TABLE blocks AS SELECT total_blocks FROM pragma_database_size();
 

--- a/test/sql/storage/optimistic_write/optimistic_write_temp_table.test
+++ b/test/sql/storage/optimistic_write/optimistic_write_temp_table.test
@@ -2,9 +2,6 @@
 # description: Test large writes on temporary tables
 # group: [optimistic_write]
 
-# temp table
-require skip_reload
-
 # load the DB from disk
 load __TEST_DIR__/optimistic_write_temp.db
 

--- a/test/sql/storage/partial_blocks/many_columns_drop_table_leak.test_slow
+++ b/test/sql/storage/partial_blocks/many_columns_drop_table_leak.test_slow
@@ -2,8 +2,6 @@
 # description: Verify that dropping tables with multi-use blocks does not leak memory
 # group: [partial_blocks]
 
-require skip_reload
-
 load __TEST_DIR__/many_columns.db
 
 # verify that doing this in a loop doesn't increase database size (i.e. blocks properly get added to the free list)

--- a/test/sql/storage/storage_enable_external_access.test
+++ b/test/sql/storage/storage_enable_external_access.test
@@ -2,8 +2,6 @@
 # description: enable_external_access with persistent databases
 # group: [storage]
 
-require skip_reload
-
 # load the DB from disk
 load __TEST_DIR__/external_access_test.db
 

--- a/test/sql/storage/storage_version_65.test
+++ b/test/sql/storage/storage_version_65.test
@@ -4,8 +4,6 @@
 
 require no_alternative_verify
 
-require skip_reload
-
 # The database is written with a vector size of 2048.
 require vector_size 2048
 

--- a/test/sql/storage/storage_versions.test
+++ b/test/sql/storage/storage_versions.test
@@ -2,8 +2,6 @@
 # description: Test attach storage various versions
 # group: [storage]
 
-require skip_reload
-
 # These files were created with vector-size 2048
 require vector_size 2048
 

--- a/test/sql/storage/test_index_checkpoint.test
+++ b/test/sql/storage/test_index_checkpoint.test
@@ -2,8 +2,6 @@
 # description: Verify that database footprint remains within expected bounds when writing index data.
 # group: [storage]
 
-require skip_reload
-
 load __TEST_DIR__/index_checkpoint.db
 
 # ensure we do not checkpoint early

--- a/test/sql/storage/test_purge_queue.test_slow
+++ b/test/sql/storage/test_purge_queue.test_slow
@@ -4,8 +4,6 @@
 
 require noforcestorage
 
-require skip_reload
-
 require 64bit
 
 # attach files

--- a/test/sql/storage/types/struct/default_struct.test
+++ b/test/sql/storage/types/struct/default_struct.test
@@ -2,9 +2,6 @@
 # description: Test struct storage with default values
 # group: [struct]
 
-require skip_reload
-
-
 # load the DB from disk
 load __TEST_DIR__/struct_default_test.db
 

--- a/test/sql/storage/types/struct/nested_struct_storage.test
+++ b/test/sql/storage/types/struct/nested_struct_storage.test
@@ -2,9 +2,6 @@
 # description: Test structs with persistent storage
 # group: [struct]
 
-require skip_reload
-
-
 # load the DB from disk
 load __TEST_DIR__/struct_storage_test.db
 

--- a/test/sql/storage/types/struct/struct_reclaim_space_drop.test_slow
+++ b/test/sql/storage/types/struct/struct_reclaim_space_drop.test_slow
@@ -2,8 +2,6 @@
 # description: Test that we reclaim space when dropping tables with struct columns
 # group: [struct]
 
-require skip_reload
-
 load __TEST_DIR__/test_reclaim_space.db
 
 statement ok

--- a/test/sql/storage/types/struct/wal_struct_storage.test
+++ b/test/sql/storage/types/struct/wal_struct_storage.test
@@ -2,9 +2,6 @@
 # description: Test structs with persistent storage
 # group: [struct]
 
-require skip_reload
-
-
 # load the DB from disk
 load __TEST_DIR__/struct_storage_test.db
 

--- a/test/sql/storage/update/larger_than_memory_update_transactions.test_slow
+++ b/test/sql/storage/update/larger_than_memory_update_transactions.test_slow
@@ -2,8 +2,6 @@
 # description: Test larger than memory updates with transactions
 # group: [update]
 
-require skip_reload
-
 load __TEST_DIR__/larger_than_memory_update_transactions.db
 
 statement ok

--- a/test/sql/table_function/duckdb_constraints.test
+++ b/test/sql/table_function/duckdb_constraints.test
@@ -2,9 +2,6 @@
 # description: Test duckdb_constraints function
 # group: [table_function]
 
-require skip_reload
-
-
 statement ok
 create table integers(i int primary key, check (i < 10));
 

--- a/test/sql/table_function/information_schema_issue12867.test
+++ b/test/sql/table_function/information_schema_issue12867.test
@@ -2,8 +2,6 @@
 # description: Issue #12867: INFORMATION_SCHEMA.KEY_COLUMN_USAGE only lists first column of composite keys
 # group: [table_function]
 
-require skip_reload
-
 statement ok
 CREATE TABLE a (a1 int, a2 int, PRIMARY KEY (a1, a2));
 

--- a/test/sql/tpcds/dsdgen_readonly.test
+++ b/test/sql/tpcds/dsdgen_readonly.test
@@ -4,8 +4,6 @@
 
 require tpcds
 
-require skip_reload
-
 load __TEST_DIR__/test_dsdgen_ro.db
 
 statement ok

--- a/test/sql/transactions/test_index_large_aborted_append.test
+++ b/test/sql/transactions/test_index_large_aborted_append.test
@@ -2,8 +2,6 @@
 # description: Test that index entries are properly removed after aborted append
 # group: [transactions]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/transactions/test_index_rollback_flushed_data.test
+++ b/test/sql/transactions/test_index_rollback_flushed_data.test
@@ -2,8 +2,6 @@
 # description: Test that we revert the global storage correctly after a constraint violation
 # group: [transactions]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/transactions/test_index_versioned_deletes.test
+++ b/test/sql/transactions/test_index_versioned_deletes.test
@@ -2,9 +2,6 @@
 # description: Test index with versioned data from deletes
 # group: [transactions]
 
-require skip_reload
-
-
 statement ok con1
 CREATE TABLE integers(i INTEGER PRIMARY KEY)
 

--- a/test/sql/transactions/test_interleaved_versions.test
+++ b/test/sql/transactions/test_interleaved_versions.test
@@ -2,9 +2,6 @@
 # description: Test interleaved versions of tuples
 # group: [transactions]
 
-require skip_reload
-
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/transactions/test_multi_transaction_append.test
+++ b/test/sql/transactions/test_multi_transaction_append.test
@@ -2,9 +2,6 @@
 # description: Test appends with multiple transactions
 # group: [transactions]
 
-require skip_reload
-
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/transactions/test_multi_version.test
+++ b/test/sql/transactions/test_multi_version.test
@@ -2,9 +2,6 @@
 # description: Test multiple versions of the same data
 # group: [transactions]
 
-require skip_reload
-
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/transactions/test_null_version.test
+++ b/test/sql/transactions/test_null_version.test
@@ -2,8 +2,6 @@
 # description: Test NULL versions
 # group: [transactions]
 
-require skip_reload
-
 statement ok
 SET immediate_transaction_mode=true
 

--- a/test/sql/transactions/test_transactional_sequences.test
+++ b/test/sql/transactions/test_transactional_sequences.test
@@ -2,9 +2,6 @@
 # description: Test that sequences are transactional
 # group: [transactions]
 
-require skip_reload
-
-
 # start a transaction for both nodes
 statement ok con1
 BEGIN TRANSACTION

--- a/test/sql/types/alias/test_alias_map.test
+++ b/test/sql/types/alias/test_alias_map.test
@@ -2,8 +2,6 @@
 # description: Test alias with map
 # group: [alias]
 
-require skip_reload
-
 statement ok
 CREATE TYPE MAPPOINT AS MAP(INTEGER,INTEGER);
 

--- a/test/sql/types/alias/test_alias_struct.test
+++ b/test/sql/types/alias/test_alias_struct.test
@@ -2,8 +2,6 @@
 # description: Test creates alias for struct type
 # group: [alias]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/alias/test_alias_struct_nested_alias.test
+++ b/test/sql/types/alias/test_alias_struct_nested_alias.test
@@ -2,8 +2,6 @@
 # description: Test creates alias for struct type
 # group: [alias]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/enum/test_enum_temp_tbl.test
+++ b/test/sql/types/enum/test_enum_temp_tbl.test
@@ -2,9 +2,6 @@
 # description: ENUM types used in temporary table
 # group: [enum]
 
-# Can't do reload tests with temp tables
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/nested/map/map_storage.test
+++ b/test/sql/types/nested/map/map_storage.test
@@ -2,8 +2,6 @@
 # description: Test maps with in-memory storage
 # group: [map]
 
-require skip_reload
-
 statement ok
 CREATE TABLE a(b MAP(INTEGER,INTEGER));
 

--- a/test/sql/types/struct/nested_structs.test
+++ b/test/sql/types/struct/nested_structs.test
@@ -2,8 +2,6 @@
 # description: Test storing nested structs in tables
 # group: [struct]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/struct/remap_struct.test
+++ b/test/sql/types/struct/remap_struct.test
@@ -2,8 +2,6 @@
 # description: Test struct remapping
 # group: [struct]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/struct/struct_cast.test
+++ b/test/sql/types/struct/struct_cast.test
@@ -2,8 +2,6 @@
 # description: Test struct cast
 # group: [struct]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/struct/struct_tables.test
+++ b/test/sql/types/struct/struct_tables.test
@@ -5,8 +5,6 @@
 statement ok
 SET default_null_order='nulls_first';
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/struct/struct_updates.test
+++ b/test/sql/types/struct/struct_updates.test
@@ -2,8 +2,6 @@
 # description: Test updates on struct tables
 # group: [struct]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/struct/unnest_struct.test
+++ b/test/sql/types/struct/unnest_struct.test
@@ -2,8 +2,6 @@
 # description: Test UNNEST of struct fields
 # group: [struct]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/test_null_type.test
+++ b/test/sql/types/test_null_type.test
@@ -2,8 +2,6 @@
 # description: Test null type
 # group: [types]
 
-require skip_reload
-
 statement ok
 pragma enable_verification
 

--- a/test/sql/update/test_big_string_update.test
+++ b/test/sql/update/test_big_string_update.test
@@ -2,8 +2,6 @@
 # description: Test update of big string
 # group: [update]
 
-require skip_reload
-
 # create a table
 statement ok con1
 CREATE TABLE test (a VARCHAR);

--- a/test/sql/update/test_big_table_update.test_slow
+++ b/test/sql/update/test_big_table_update.test_slow
@@ -2,8 +2,6 @@
 # description: Update big table of even and odd values
 # group: [update]
 
-require skip_reload
-
 # create a table with the values [0, ..., 3K]
 statement ok con1
 BEGIN TRANSACTION

--- a/test/sql/update/test_null_update.test
+++ b/test/sql/update/test_null_update.test
@@ -5,8 +5,6 @@
 statement ok
 SET default_null_order='nulls_first';
 
-require skip_reload
-
 # create a table
 statement ok con1
 CREATE TABLE test (a INTEGER);

--- a/test/sql/update/test_update.test
+++ b/test/sql/update/test_update.test
@@ -2,8 +2,6 @@
 # description: Test standard update behavior
 # group: [update]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/update/test_update_same_value.test
+++ b/test/sql/update/test_update_same_value.test
@@ -2,8 +2,6 @@
 # description: Update the same value multiple times in one transaction
 # group: [update]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/window/test_over_grouping.test_slow
+++ b/test/sql/window/test_over_grouping.test_slow
@@ -2,11 +2,6 @@
 # description: Grouping OVER clauses to reduce unnecessary sorting
 # group: [window]
 
-require skip_reload
-
-#statement ok
-#PRAGMA enable_verification
-
 statement ok
 PRAGMA threads=4
 
@@ -32,8 +27,7 @@ create table image  (
 statement ok
 insert into image (id, width, height) values (1, 500, 297);
 
-statement ok
-SELECT SETSEED(0.8675309);
+set seed 0.8675309
 
 statement ok
 create table pixel (

--- a/test/sql/window/test_volatile_independence.test
+++ b/test/sql/window/test_volatile_independence.test
@@ -2,10 +2,7 @@
 # description: Window Sharing should distiguish identical volatile expressions
 # group: [window]
 
-require skip_reload
-
-statement ok
-SELECT SETSEED(0.8675309);
+set seed 0.8675309
 
 query II
 SELECT 

--- a/test/sql/window/test_window_cse.test
+++ b/test/sql/window/test_window_cse.test
@@ -8,8 +8,7 @@ PRAGMA enable_verification
 statement ok
 PRAGMA explain_output = PHYSICAL_ONLY;
 
-statement ok
-SELECT SETSEED(0.867309);
+set seed 0.8675309
 
 statement ok
 CREATE TABLE eventlog AS

--- a/test/sql/window/test_window_wide_frame.test_slow
+++ b/test/sql/window/test_window_wide_frame.test_slow
@@ -2,13 +2,10 @@
 # description: Test wide temporal range frames
 # group: [window]
 
-require skip_reload
-
 statement ok
 PRAGMA enable_verification
 
-statement ok
-select setseed(0.618033)
+set seed 0.618033
 
 statement ok
 CREATE TABLE flog AS

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -129,7 +129,7 @@ void Command::RestartDatabase(ExecuteContext &context, Connection *&connection, 
 		query_fail = true;
 	}
 	bool can_restart = CanRestart(*connection);
-	if (!query_fail && can_restart && !runner.skip_reload) {
+	if (!query_fail && can_restart && !runner.skip_reload && !runner.dbpath.empty()) {
 		// We basically restart the database if no transaction is active and if the query is valid
 		auto command = make_uniq<RestartCommand>(runner, true);
 		runner.ExecuteCommand(std::move(command));

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -7,6 +7,8 @@
 #include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/main/stream_query_result.hpp"
 #include "duckdb/main/attached_database.hpp"
+#include "duckdb/catalog/duck_catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_schema_entry.hpp"
 #include "test_helpers.hpp"
 #include "sqllogic_test_logger.hpp"
 #include "catch.hpp"
@@ -61,6 +63,7 @@ bool CanRestart(Connection &conn) {
 	auto &db_manager = DatabaseManager::Get(*conn.context->db);
 	auto &connection_list = connection_manager.GetConnectionListReference();
 
+	// do we have any databases attached (aside from the main database)?
 	auto databases = db_manager.GetDatabases();
 	idx_t database_count = 0;
 	for (auto &db_ref : databases) {
@@ -75,11 +78,39 @@ bool CanRestart(Connection &conn) {
 	}
 	for (auto &conn_ref : connection_list) {
 		auto &conn = conn_ref.first.get();
+		// do we have any prepared statements?
 		if (!conn.client_data->prepared_statements.empty()) {
 			return false;
 		}
+		// we are currently inside a transaction?
 		if (conn.transaction.HasActiveTransaction()) {
 			return false;
+		}
+		// do we have any temporary objects?
+		auto &temp = conn.client_data->temporary_objects;
+		auto &temp_catalog = temp->GetCatalog().Cast<DuckCatalog>();
+		vector<reference<DuckSchemaEntry>> schemas;
+		temp_catalog.ScanSchemas(
+		    [&](SchemaCatalogEntry &schema) { schemas.push_back(schema.Cast<DuckSchemaEntry>()); });
+		if (schemas.size() != 1) {
+			return false;
+		}
+		auto &temp_schema = schemas[0].get();
+		vector<CatalogType> catalog_types {CatalogType::TABLE_ENTRY,     CatalogType::VIEW_ENTRY,
+		                                   CatalogType::INDEX_ENTRY,     CatalogType::SEQUENCE_ENTRY,
+		                                   CatalogType::COLLATION_ENTRY, CatalogType::TYPE_ENTRY,
+		                                   CatalogType::MACRO_ENTRY,     CatalogType::TABLE_MACRO_ENTRY};
+		bool found_temp_object = false;
+		for (auto &catalog_type : catalog_types) {
+			temp_schema.Scan(catalog_type, [&](CatalogEntry &entry) {
+				if (entry.internal) {
+					return;
+				}
+				found_temp_object = true;
+			});
+			if (found_temp_object) {
+				return false;
+			}
 		}
 	}
 	return true;

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -43,7 +43,9 @@ static void testRunner() {
 		auto storage_name = StringUtil::Replace(name, "/", "_");
 		storage_name = StringUtil::Replace(storage_name, ".", "_");
 		storage_name = StringUtil::Replace(storage_name, "\\", "_");
-		initial_dbpath = TestCreatePath(storage_name + ".db");
+		auto db_directory = TestCreatePath(storage_name);
+		TestCreateDirectory(db_directory);
+		initial_dbpath = TestJoinPath(db_directory, "memory.db");
 	}
 	SQLLogicTestRunner runner(std::move(initial_dbpath));
 	runner.output_sql = Catch::getCurrentContext().getConfig()->outputSQL();


### PR DESCRIPTION
The `--force-restart` tests are useful to stress test database restarts by restarting in between each statement - but we cannot always restart since we have transient state (e.g. attached databases, prepared statements, etc). Restarting will then lead to failing the test. For tests that have this transient state we have been accumulating a lot of `require skip_reload` flags. This is undesirable since this often breaks CI only in the final stages of a PR (at which point these skips are added).

This PR instead improves detection on when we can restart, allowing almost all of the `require skip_reload` flags in tests to be removed. In particular:

* We cannot restart if there are any attached databases (**new**)
* We cannot restart if there are any `TEMPORARY` structures (tables, views, etc) (**new**)
* We cannot restart if a random seed has been set (**new**)
* We cannot restart if there are any prepared statements 
* We cannot restart if we are in the middle of a transaction

We introduce new syntax for specifying seeds in the tests:

```sql
set seed 0.42
```

This syntax sets the seed, and also disables the force restart tests.