### PR TITLE
Give tasks a `TaskType` with a name

### DIFF
--- a/extension/json/json_functions/read_json.cpp
+++ b/extension/json/json_functions/read_json.cpp
@@ -132,6 +132,10 @@ public:
 		}
 	}
 
+	string TaskType() const override {
+		return "JSONSchemaTask";
+	}
+
 private:
 	AutoDetectState &auto_detect_state;
 	JSONStructureNode &node;

--- a/src/common/sort/partition_state.cpp
+++ b/src/common/sort/partition_state.cpp
@@ -581,6 +581,10 @@ public:
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override;
 
+	string TaskType() const override {
+		return "PartitionMergeTask";
+	}
+
 private:
 	struct ExecutorCallback : public PartitionGlobalMergeStates::Callback {
 		explicit ExecutorCallback(Executor &executor) : executor(executor) {

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -488,6 +488,10 @@ public:
 public:
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override;
 
+	string TaskType() const override {
+		return "HashAggregateFinalizeTask";
+	}
+
 private:
 	ClientContext &context;
 	Pipeline &pipeline;
@@ -546,6 +550,10 @@ public:
 
 public:
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override;
+
+	string TaskType() const override {
+		return "HashAggregateDistinctFinalizeTask";
+	}
 
 private:
 	TaskExecutionResult AggregateDistinctGrouping(const idx_t grouping_idx);

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -445,6 +445,10 @@ public:
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override;
 
+	string TaskType() const override {
+		return "UngroupedDistinctAggregateFinalizeTask";
+	}
+
 private:
 	TaskExecutionResult AggregateDistinct();
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -469,6 +469,10 @@ public:
 		return TaskExecutionResult::TASK_FINISHED;
 	}
 
+	string TaskType() const override {
+		return "HashJoinTableInitTask";
+	}
+
 private:
 	HashJoinGlobalSinkState &sink;
 	idx_t entry_idx_from;
@@ -523,6 +527,9 @@ public:
 		sink.hash_table->Finalize(chunk_idx_from, chunk_idx_to, parallel);
 		event->FinishTask();
 		return TaskExecutionResult::TASK_FINISHED;
+	}
+	string TaskType() const override {
+		return "HashJoinFinalizeTask";
 	}
 
 private:
@@ -605,6 +612,10 @@ public:
 		local_ht.Repartition(global_ht);
 		event->FinishTask();
 		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+	string TaskType() const override {
+		return "HashJoinRepartitionTask";
 	}
 
 private:

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -102,6 +102,10 @@ public:
 		return TaskExecutionResult::TASK_FINISHED;
 	}
 
+	string TaskType() const override {
+		return "RangeJoinMergeTask";
+	}
+
 private:
 	ClientContext &context;
 	GlobalSortedTable &table;

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -127,6 +127,10 @@ public:
 		return TaskExecutionResult::TASK_FINISHED;
 	}
 
+	string TaskType() const override {
+		return "PhysicalOrderMergeTask";
+	}
+
 private:
 	ClientContext &context;
 	OrderGlobalSinkState &state;

--- a/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -265,6 +265,10 @@ public:
 		return TaskExecutionResult::TASK_FINISHED;
 	}
 
+	string TaskType() const override {
+		return "ProcessRemainingBatchesTask";
+	}
+
 private:
 	const PhysicalBatchCopyToFile &op;
 	FixedBatchCopyGlobalState &gstate;

--- a/src/include/duckdb/common/arrow/arrow_merge_event.hpp
+++ b/src/include/duckdb/common/arrow/arrow_merge_event.hpp
@@ -34,6 +34,10 @@ public:
 	void ProduceRecordBatches();
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override;
 
+	string TaskType() const override {
+		return "ArrowBatchTask";
+	}
+
 private:
 	ArrowQueryResult &result;
 	vector<idx_t> record_batch_indices;

--- a/src/include/duckdb/common/multi_file/union_by_name.hpp
+++ b/src/include/duckdb/common/multi_file/union_by_name.hpp
@@ -32,6 +32,10 @@ public:
 		readers[file_idx] = OP::GetUnionData(std::move(reader), file_idx);
 	}
 
+	string TaskType() const override {
+		return "UnionByReaderTask";
+	}
+
 private:
 	ClientContext &context;
 	const OpenFileInfo &file;

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -33,6 +33,10 @@ public:
 	Pipeline &pipeline;
 	unique_ptr<PipelineExecutor> pipeline_executor;
 
+	string TaskType() const override {
+		return "PipelineTask";
+	}
+
 public:
 	const PipelineExecutor &GetPipelineExecutor() const;
 	bool TaskBlockedOnResult() const override;

--- a/src/include/duckdb/parallel/task.hpp
+++ b/src/include/duckdb/parallel/task.hpp
@@ -52,7 +52,9 @@ public:
 		return false;
 	}
 
-	virtual string TaskType() const = 0;
+	virtual string TaskType() const {
+		return "UnnamedTask";
+	}
 
 public:
 	optional_ptr<ProducerToken> token;

--- a/src/include/duckdb/parallel/task.hpp
+++ b/src/include/duckdb/parallel/task.hpp
@@ -52,6 +52,8 @@ public:
 		return false;
 	}
 
+	virtual string TaskType() const = 0;
+
 public:
 	optional_ptr<ProducerToken> token;
 };

--- a/src/parallel/pipeline_finish_event.cpp
+++ b/src/parallel/pipeline_finish_event.cpp
@@ -46,6 +46,10 @@ public:
 		return TaskExecutionResult::TASK_FINISHED;
 	}
 
+	string TaskType() const override {
+		return "PipelineFinishTask";
+	}
+
 private:
 #ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
 	//! Debugging state: number of times blocked

--- a/src/parallel/pipeline_initialize_event.cpp
+++ b/src/parallel/pipeline_initialize_event.cpp
@@ -22,6 +22,10 @@ public:
 		event->FinishTask();
 		return TaskExecutionResult::TASK_FINISHED;
 	}
+
+	string TaskType() const override {
+		return "PipelineInitializeTask";
+	}
 };
 
 void PipelineInitializeEvent::Schedule() {

--- a/src/parallel/pipeline_prepare_finish_event.cpp
+++ b/src/parallel/pipeline_prepare_finish_event.cpp
@@ -20,6 +20,10 @@ public:
 		event->FinishTask();
 		return TaskExecutionResult::TASK_FINISHED;
 	}
+
+	string TaskType() const override {
+		return "PipelinePreFinishTask";
+	}
 };
 
 void PipelinePrepareFinishEvent::Schedule() {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -787,6 +787,10 @@ public:
 		checkpoint_state.write_data[index] = row_group.WriteToDisk(*checkpoint_state.writers[index]);
 	}
 
+	string TaskType() const override {
+		return "CheckpointTask";
+	}
+
 private:
 	idx_t index;
 };
@@ -906,6 +910,10 @@ public:
 			auto checkpoint_task = collection.GetCheckpointTask(checkpoint_state, segment_idx + i);
 			checkpoint_task->ExecuteTask();
 		}
+	}
+
+	string TaskType() const override {
+		return "VacuumTask";
 	}
 
 private:


### PR DESCRIPTION
This allows tasks executed by the task scheduler to be uniquely identified for e.g. logging purposes

CC @bleskes 