### PR TITLE
Fixes filter pruning use the statistics updated by the same filter

### DIFF
--- a/src/optimizer/statistics/operator/propagate_filter.cpp
+++ b/src/optimizer/statistics/operator/propagate_filter.cpp
@@ -230,6 +230,11 @@ FilterPropagateResult StatisticsPropagator::HandleFilter(unique_ptr<Expression> 
 	if (ExpressionIsConstant(*condition, Value::BOOLEAN(true))) {
 		return FilterPropagateResult::FILTER_ALWAYS_TRUE;
 	}
+
+	if (ExpressionIsConstantOrNull(*condition, Value::BOOLEAN(true))) {
+		return FilterPropagateResult::FILTER_TRUE_OR_NULL;
+	}
+
 	if (ExpressionIsConstant(*condition, Value::BOOLEAN(false)) ||
 	    ExpressionIsConstantOrNull(*condition, Value::BOOLEAN(false))) {
 		return FilterPropagateResult::FILTER_FALSE_OR_NULL;

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -1,8 +1,10 @@
+#include "duckdb/common/helper.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/table_filter.hpp"
 
@@ -14,8 +16,11 @@ FilterPropagateResult StatisticsPropagator::PropagateTableFilter(ColumnBinding s
 		auto &expr_filter = filter.Cast<ExpressionFilter>();
 		auto column_ref = make_uniq<BoundColumnRefExpression>(stats.GetType(), stats_binding);
 		auto filter_expr = expr_filter.ToExpression(*column_ref);
-		UpdateFilterStatistics(*filter_expr);
-		return HandleFilter(filter_expr);
+		// handle the filter before updating the statistics
+		// otherwise the filter can be pruned by the updated statistics
+		auto propagate_result = HandleFilter(filter_expr);
+		UpdateFilterStatistics(*filter_expr->Copy());
+		return propagate_result;
 	}
 	return filter.CheckStatistics(stats);
 }
@@ -92,6 +97,10 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 			// filter is always true; it is useless to execute it
 			// erase this condition
 			get.table_filters.filters.erase(table_filter_column);
+			break;
+		case FilterPropagateResult::FILTER_TRUE_OR_NULL:
+			// filter is true or null; we can replace this with a not null filter
+			get.table_filters.filters[table_filter_column] = make_uniq<IsNotNullFilter>();
 			break;
 		case FilterPropagateResult::FILTER_FALSE_OR_NULL:
 		case FilterPropagateResult::FILTER_ALWAYS_FALSE:

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -18,8 +18,9 @@ FilterPropagateResult StatisticsPropagator::PropagateTableFilter(ColumnBinding s
 		auto filter_expr = expr_filter.ToExpression(*column_ref);
 		// handle the filter before updating the statistics
 		// otherwise the filter can be pruned by the updated statistics
+		auto copy_expr = filter_expr->Copy();
 		auto propagate_result = HandleFilter(filter_expr);
-		UpdateFilterStatistics(*filter_expr->Copy());
+		UpdateFilterStatistics(*copy_expr);
 		return propagate_result;
 	}
 	return filter.CheckStatistics(stats);

--- a/test/optimizer/statistics/statistics_null_comparison.test
+++ b/test/optimizer/statistics/statistics_null_comparison.test
@@ -9,6 +9,12 @@ statement ok
 CREATE TABLE integers2 AS SELECT * FROM (VALUES (1), (2), (NULL)) tbl(i);
 
 statement ok
+CREATE TABLE t1 AS SELECT * FROM (VALUES (1)) tbl(c0);
+
+statement ok
+CREATE TABLE t2 AS SELECT * FROM (VALUES (NULL)) tbl(c0);
+
+statement ok
 PRAGMA enable_verification
 
 statement ok
@@ -38,6 +44,12 @@ query II
 EXPLAIN SELECT * FROM integers WHERE i>j ORDER BY i;
 ----
 logical_opt	<REGEX>:.*constant_or_null.*
+
+# t2.c0>=t2.c0 means always true or null which is equals to is not null
+query II
+EXPLAIN SELECT * FROM t1 INNER JOIN t2 ON ((t2.c0)>=(t2.c0));
+----
+logical_opt	<REGEX>:.*IS NOT NULL.*
 
 # now verify that the results are correct
 query I
@@ -70,3 +82,16 @@ SELECT * FROM integers WHERE i>j ORDER BY i;
 ----
 10	1
 20	2
+
+# relate issue 17338
+query II
+SELECT * FROM t1 INNER JOIN t2 ON ((t2.c0)>=(t2.c0));
+----
+
+statement ok
+INSERT INTO t2 VALUES(1);
+
+query II
+SELECT * FROM t1 INNER JOIN t2 ON ((t2.c0)>=(t2.c0));
+----
+1	1


### PR DESCRIPTION
This PR fixes #17338, which prunes filter by using the statistics updated by the same filter. Also replacing filter returning true or null with is_not_null filter.