### PR TITLE
Add support for statically loading extensions to autoload

### DIFF
--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -253,6 +253,8 @@ private:
 	//! Version tags occur with and without 'v', tag in extension path is always with 'v'
 	static const string NormalizeVersionTag(const string &version_tag);
 
+	static ExtensionLoadResult TryLoadStaticExtension(DatabaseInstance &db, const std::string &extension);
+
 private:
 	static ExtensionLoadResult LoadExtensionInternal(DuckDB &db, const std::string &extension, bool initial_load);
 };

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -439,11 +439,13 @@ ExtensionLoadResult ExtensionHelper::LoadExtension(DuckDB &db, const std::string
 }
 
 ExtensionLoadResult ExtensionHelper::TryLoadStaticExtension(DatabaseInstance &db, const std::string &extension) {
+#if defined(DUCKDB_BUILD_LIBRARY) && !defined(DUCKDB_BUILD_LOADABLE_EXTENSION)
 #if defined(GENERATED_EXTENSION_HEADERS) && GENERATED_EXTENSION_HEADERS
 	DuckDB ddb(db);
 	if (TryLoadLinkedExtension(ddb, extension)) {
 		return ExtensionLoadResult::LOADED_EXTENSION;
 	}
+#endif
 #endif
 	return ExtensionLoadResult::NOT_LOADED;
 }


### PR DESCRIPTION
There's a number of places where we auto-load extensions but do not check statically loaded extensions - this causes statically loaded extensions to not work for many cases (e.g. when attaching over HTTPS). This PR fixes that by calling `TryLoadStaticExtension` in code paths where auto-loading is triggered.