### PR TITLE
BufferedFileWriter does not lock by default

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -905,7 +905,7 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 		share_mode = FILE_SHARE_READ;
 		break;
 	case FileLockType::WRITE_LOCK:
-		share_mode = 0;
+		share_mode = FILE_SHARE_READ;
 		break;
 	default:
 		throw InternalException("Unknown FileLockType");

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -14,7 +14,7 @@ constexpr FileOpenFlags BufferedFileWriter::DEFAULT_OPEN_FLAGS;
 BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, FileOpenFlags open_flags)
     : fs(fs), path(path_p), data(make_unsafe_uniq_array_uninitialized<data_t>(FILE_BUFFER_SIZE)), offset(0),
       total_written(0) {
-	handle = fs.OpenFile(path, open_flags | FileLockType::WRITE_LOCK);
+	handle = fs.OpenFile(path, open_flags);
 }
 
 idx_t BufferedFileWriter::GetFileSize() {

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -45,7 +45,7 @@ BufferedFileWriter &WriteAheadLog::Initialize() {
 	if (!writer) {
 		writer = make_uniq<BufferedFileWriter>(FileSystem::Get(database), wal_path,
 		                                       FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE |
-		                                           FileFlags::FILE_FLAGS_APPEND);
+		                                           FileFlags::FILE_FLAGS_APPEND | FileLockType::WRITE_LOCK);
 		if (init_state == WALInitState::UNINITIALIZED_REQUIRES_TRUNCATE) {
 			writer->Truncate(wal_size);
 		}


### PR DESCRIPTION
Caller will have to specify the precise locking they need.

On windows, mutual exclusion is enforced as follows:

| Process1 | Process2 | Outcome |
|----------|-----------|----------|
| GENERIC_WRITE, WRITE_LOCK | GENERIC_WRITE, WRITE_LOCK | one fails |
| GENERIC_WRITE, WRITE_LOCK | GENERIC_READ, READ_LOCK   | both pass |
| GENERIC_WRITE, WRITE_LOCK | GENERIC_READ, NO_LOCK     | both pass |
| GENERIC_READ, READ_LOCK   | GENERIC_READ, READ_LOCK   | both pass |

PR #17423 for details on file locking behavior across platforms.