### PR TITLE
Fix JSON extension compilation on Ubuntu 22.04

### DIFF
--- a/extension/json/json_functions/json_table_in_out.cpp
+++ b/extension/json/json_functions/json_table_in_out.cpp
@@ -97,7 +97,7 @@ static unique_ptr<GlobalTableFunctionState> JSONTableInOutInitGlobal(ClientConte
 			}
 		}
 	}
-	return result;
+	return std::move(result);
 }
 
 struct JSONTableInOutRecursionNode {


### PR DESCRIPTION
After #17406 the JSON extension fails compilation with GCC 11.0.4 on Ubuntu 22.04:

```
$ CORE_EXTENSIONS='json' BUILD_EXTENSIONS_ONLY=1 GEN=ninja make
mkdir -p ./build/release && \
cd build/release && \
cmake -G "Ninja" -DFORCE_COLORED_OUTPUT=1        -DENABLE_EXTENSION_AUTOLOADING= -DENABLE_EXTENSION_AUTOINSTALL= -DBUILD_EXTENSIONS_ONLY=1 -DCORE_EXTENSIONS="json" -DLOCAL_EXTENSION_REPO=""  -DOVERRIDE_GIT_DESCRIBE=""  -DCMAKE_BUILD_TYPE=Release ../.. && \
cmake --build . --config Release
-- Could NOT find Python3 (missing: Python3_EXECUTABLE Interpreter)
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
[...]
-- Load extension 'json' from '/home/duck/duckdb/extensions' @ 30e907b52f
-- Load extension 'core_functions' from '/home/duck/duckdb/extensions' @ 30e907b52f
-- Load extension 'parquet' from '/home/duck/duckdb/extensions' @ 30e907b52f
-- Load extension 'jemalloc' from '/home/duck/duckdb/extensions' @ 30e907b52f
-- Extensions linked into DuckDB: [json, core_functions, parquet, jemalloc]
-- Configuring done
-- Generating done
-- Build files have been written to: /home/duck/duckdb/build/release
[19/380] Building CXX object extension/json/CMak...nsion.dir/json_functions/json_table_in_out.cpp.o
FAILED: extension/json/CMakeFiles/json_extension.dir/json_functions/json_table_in_out.cpp.o
/usr/bin/c++ -DDUCKDB_BUILD_LIBRARY -DEXT_VERSION_JSON=\"30e907b52f\" -I/home/duck/duckdb/src/include -I/home/duck/duckdb/third_party/fsst -I/home/duck/duckdb/third_party/fmt/include -I/home/duck/duckdb/third_party/hyperloglog -I/home/duck/duckdb/third_party/fastpforlib -I/home/duck/duckdb/third_party/skiplist -I/home/duck/duckdb/third_party/fast_float -I/home/duck/duckdb/third_party/re2 -I/home/duck/duckdb/third_party/miniz -I/home/duck/duckdb/third_party/utf8proc/include -I/home/duck/duckdb/third_party/concurrentqueue -I/home/duck/duckdb/third_party/pcg -I/home/duck/duckdb/third_party/tdigest -I/home/duck/duckdb/third_party/mbedtls/include -I/home/duck/duckdb/third_party/jaro_winkler -I/home/duck/duckdb/third_party/yyjson/include -I/home/duck/duckdb/third_party/zstd/include -I/home/duck/duckdb/extension/json/include -O3 -DNDEBUG -O3 -DNDEBUG   -fPIC -fdiagnostics-color=always -std=c++11 -MD -MT extension/json/CMakeFiles/json_extension.dir/json_functions/json_table_in_out.cpp.o -MF extension/json/CMakeFiles/json_extension.dir/json_functions/json_table_in_out.cpp.o.d -o extension/json/CMakeFiles/json_extension.dir/json_functions/json_table_in_out.cpp.o -c /home/duck/duckdb/extension/json/json_functions/json_table_in_out.cpp
/home/duck/duckdb/extension/json/json_functions/json_table_in_out.cpp: In function 'duckdb::unique_ptr<duckdb::GlobalTableFunctionState, std::default_delete<duckdb::GlobalTableFunctionState>, true> duckdb::JSONTableInOutInitGlobal(duckdb::ClientContext&, duckdb::TableFunctionInitInput&)':
/home/duck/duckdb/extension/json/json_functions/json_table_in_out.cpp:100:16: error: could not convert 'result' from 'unique_ptr<duckdb::JSONTableInOutGlobalState,default_delete<duckdb::JSONTableInOutGlobalState>,[...]>' to 'unique_ptr<duckdb::GlobalTableFunctionState,default_delete<duckdb::GlobalTableFunctionState>,[...]>'
  100 |         return result;
      |                ^~~~~~
      |                |
      |                unique_ptr<duckdb::JSONTableInOutGlobalState,default_delete<duckdb::JSONTableInOutGlobalState>,[...]>
```

The problem does not happen on later version of GCC or on CLang/MSVC.

Proposed change adds explicit `std::move()` cast to the result to satisfy GCC 11.