### PR TITLE
Fix: pyproject.toml does not contain a tool.setuptools_scm section

### DIFF
--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -28,6 +28,9 @@ Source = "https://github.com/duckdb/duckdb/blob/main/tools/pythonpkg"
 Issues = "https://github.com/duckdb/duckdb/issues"
 Changelog = "https://github.com/duckdb/duckdb/releases"
 
+[tool.setuptools_scm]
+root = "../.."
+
 ### CI Builwheel configurations ###
 
 # Default config runs all tests and requires at least one extension to be tested against


### PR DESCRIPTION
Fix "pyproject.toml does not contain a tool.setuptools_scm section" by adding a minimal entry to pyproject.toml