### PR TITLE
Recurse into `MAP` and `LIST` with the `remap_struct` and the MFR ColumnMapper

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -301,7 +301,11 @@ ColumnMapResult MapColumnList(ClientContext &context, const MultiFileColumnDefin
 	return result;
 }
 
-static ColumnMapResult MapColumnMapComponent(ClientContext &context, const unordered_map<idx_t, const_reference<ColumnIndex>> &selected_children, const ColumnIndex &global_index, const ColumnMapper &nested_mapper, idx_t component_idx, const MultiFileColumnDefinition &component, const MultiFileColumnDefinition &local_map_column) {
+static ColumnMapResult
+MapColumnMapComponent(ClientContext &context,
+                      const unordered_map<idx_t, const_reference<ColumnIndex>> &selected_children,
+                      const ColumnIndex &global_index, const ColumnMapper &nested_mapper, idx_t component_idx,
+                      const MultiFileColumnDefinition &component, const MultiFileColumnDefinition &local_map_column) {
 	bool is_selected = true;
 	const_reference<ColumnIndex> child_index = global_index;
 	if (!selected_children.empty()) {
@@ -326,9 +330,9 @@ static ColumnMapResult MapColumnMapComponent(ClientContext &context, const unord
 }
 
 ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefinition &global_column,
-                              const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
-                              const MultiFileLocalColumnId &local_id, const ColumnMapper &mapper,
-                              unique_ptr<MultiFileIndexMapping> mapping, const bool is_root) {
+                             const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
+                             const MultiFileLocalColumnId &local_id, const ColumnMapper &mapper,
+                             unique_ptr<MultiFileIndexMapping> mapping, const bool is_root) {
 	const idx_t expected_map_children = 2;
 	if (global_column.children.size() != expected_map_children) {
 		throw InvalidInputException(
@@ -357,7 +361,8 @@ ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefini
 
 	//! Key mapping
 	{
-		auto key_map_result = MapColumnMapComponent(context, selected_children, global_index, *nested_mapper, 0, global_key, local_key_value);
+		auto key_map_result = MapColumnMapComponent(context, selected_children, global_index, *nested_mapper, 0,
+		                                            global_key, local_key_value);
 		if (key_map_result.column_index) {
 			child_indexes.push_back(std::move(*key_map_result.column_index));
 			mapping->child_mapping.insert(make_pair(0, std::move(key_map_result.mapping)));
@@ -369,7 +374,8 @@ ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefini
 	}
 	//! Value mapping
 	{
-		auto value_map_result = MapColumnMapComponent(context, selected_children, global_index, *nested_mapper, 1, global_value, local_key_value);
+		auto value_map_result = MapColumnMapComponent(context, selected_children, global_index, *nested_mapper, 1,
+		                                              global_value, local_key_value);
 		if (value_map_result.column_index) {
 			child_indexes.push_back(std::move(*value_map_result.column_index));
 			mapping->child_mapping.insert(make_pair(1, std::move(value_map_result.mapping)));
@@ -538,12 +544,13 @@ static ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDe
 		                     is_root);
 	case LogicalTypeId::MAP:
 		return MapColumnMap(context, global_column, global_index, local_column, local_id, mapper, std::move(mapping),
-		                     is_root);
+		                    is_root);
 	case LogicalTypeId::ARRAY: {
 		throw NotImplementedException("Can't map an ARRAY with nested children!");
 	}
 	default:
-		throw NotImplementedException("MapColumn for children of type %s not implemented", global_column.type.ToString());
+		throw NotImplementedException("MapColumn for children of type %s not implemented",
+		                              global_column.type.ToString());
 	}
 }
 

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -367,7 +367,8 @@ ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefini
 		auto &name = map_components[i].first;
 		auto &global_component = map_components[i].second;
 
-		auto map_result = MapColumnMapComponent(context, selected_children, global_index, *nested_mapper, i, global_component, local_key_value);
+		auto map_result = MapColumnMapComponent(context, selected_children, global_index, *nested_mapper, i,
+		                                        global_component, local_key_value);
 		if (map_result.column_index) {
 			child_indexes.push_back(std::move(*map_result.column_index));
 			mapping->child_mapping.insert(make_pair(i, std::move(map_result.mapping)));

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -67,6 +67,7 @@ public:
 };
 
 struct ColumnMapResult {
+	//! Contains the name of the local column that corresponds to this field
 	Value column_map;
 	unique_ptr<Expression> default_value;
 	optional_ptr<const MultiFileColumnDefinition> local_column;
@@ -222,45 +223,106 @@ bool IsTriviallyMappable(const MultiFileColumnDefinition &global_column,
 	return true;
 }
 
-ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDefinition &global_column,
+static ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDefinition &global_column,
                           const ColumnIndex &global_index, const vector<MultiFileColumnDefinition> &local_columns,
-                          const ColumnMapper &mapper, optional_idx top_level_index = optional_idx()) {
-	bool is_root = top_level_index.IsValid();
-	ColumnMapResult result;
-	auto entry = mapper.Find(global_column);
-	if (!entry.IsValid()) {
-		// entry not present in map, use default value
-		result.default_value = mapper.GetDefaultExpression(global_column, is_root);
-		return result;
+                          const ColumnMapper &mapper, optional_idx top_level_index = optional_idx());
+
+ColumnMapResult MapColumnList(
+	ClientContext &context,
+	const MultiFileColumnDefinition &global_column,
+	const ColumnIndex &global_index,
+	const MultiFileColumnDefinition &local_column,
+	const MultiFileLocalColumnId &local_id,
+	const ColumnMapper &mapper,
+	unique_ptr<MultiFileIndexMapping> mapping,
+	const bool is_root
+) {
+	const idx_t expected_list_children = 1;
+	if (global_column.children.size() != expected_list_children) {
+		throw InvalidInputException(
+			"Mismatch between field id children in global_column.children (%d) and list child in type", global_column.children.size());
 	}
-	// the field exists! get the local column
-	MultiFileLocalColumnId local_id(entry.GetIndex());
-	auto &local_column = local_columns[local_id.GetId()];
-	unique_ptr<MultiFileIndexMapping> mapping;
-	idx_t mapping_idx;
-	if (is_root) {
-		// root expression - refer to it directly
-		mapping_idx = top_level_index.GetIndex();
-	} else {
-		// extract the field from the parent
-		mapping_idx = local_id.GetId();
-	}
-	result.local_column = local_column;
-	mapping = make_uniq<MultiFileIndexMapping>(mapping_idx);
-	if (global_column.type.id() != LogicalTypeId::STRUCT || global_column.children.empty()) {
-		// not a struct - map the column directly
-		result.column_map = Value(local_column.name);
-		result.column_index = make_uniq<ColumnIndex>(local_id.GetId());
-		result.mapping = std::move(mapping);
-		return result;
-	}
-	// nested type - check if the field identifiers match and if we need to remap
+
 	auto nested_mapper = mapper.Create(local_column.children);
+	child_list_t<Value> column_mapping;
+	unique_ptr<Expression> default_expression;
+	unordered_map<idx_t, const_reference<ColumnIndex>> selected_children;
+	if (global_index.HasChildren()) {
+		//! FIXME: is this expected for lists??
+		for (auto &index : global_index.GetChildIndexes()) {
+			selected_children.emplace(index.GetPrimaryIndex(), index);
+		}
+	}
+
+	vector<ColumnIndex> child_indexes;
+	auto &global_child = global_column.children[0];
+
+	bool is_selected = true;
+	const_reference<ColumnIndex> global_child_index = global_index;
+	if (!selected_children.empty()) {
+		auto entry = selected_children.find(0);
+		if (entry != selected_children.end()) {
+			// the column is relevent - set the child index
+			global_child_index = entry->second;
+		} else {
+			// not relevant - ignore the column
+			is_selected = false;
+		}
+	}
+
+	ColumnMapResult child_map;
+	if (is_selected) {
+		child_map =
+			MapColumn(context, global_child, global_child_index.get(), local_column.children, *nested_mapper);
+	} else {
+		// column is not relevant for the query - push a NULL value
+		child_map.default_value = make_uniq<BoundConstantExpression>(Value(global_child.type));
+	}
+
+	if (child_map.column_index) {
+		child_indexes.push_back(std::move(*child_map.column_index));
+		mapping->child_mapping.insert(make_pair(0, std::move(child_map.mapping)));
+	}
+	if (!child_map.column_map.IsNull()) {
+		// found a column mapping for this child - emplace it
+		column_mapping.emplace_back("list", std::move(child_map.column_map));
+	}
+
+	ColumnMapResult result;
+	result.local_column = local_column;
+	if (!column_mapping.empty()) {
+		// we have column mappings at this level - construct the struct
+		result.column_map = Value::STRUCT(std::move(column_mapping));
+		if (!is_root) {
+			// if this is nested we need to refer to the current column at this level
+			child_list_t<Value> child_list;
+			child_list.emplace_back(string(), Value(local_column.name));
+			child_list.emplace_back(string(), std::move(result.column_map));
+			result.column_map = Value::STRUCT(std::move(child_list));
+		}
+	}
+	result.column_index = make_uniq<ColumnIndex>(local_id.GetId(), std::move(child_indexes));
+	result.mapping = std::move(mapping);
+	return result;
+}
+
+ColumnMapResult MapColumnStruct(
+	ClientContext &context,
+	const MultiFileColumnDefinition &global_column,
+	const ColumnIndex &global_index,
+	const MultiFileColumnDefinition &local_column,
+	const MultiFileLocalColumnId &local_id,
+	const ColumnMapper &mapper,
+	unique_ptr<MultiFileIndexMapping> mapping,
+	const bool is_root
+) {
 	auto &struct_children = StructType::GetChildTypes(global_column.type);
 	if (struct_children.size() != global_column.children.size()) {
 		throw InvalidInputException(
-		    "Mismatch between field id children in global_column.children and struct children in type");
+			"Mismatch between field id children in global_column.children and struct children in type");
 	}
+
+	auto nested_mapper = mapper.Create(local_column.children);
 	child_list_t<Value> column_mapping;
 	vector<unique_ptr<Expression>> default_expressions;
 	unordered_map<idx_t, const_reference<ColumnIndex>> selected_children;
@@ -293,6 +355,7 @@ ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDefinitio
 			// column is not relevant for the query - push a NULL value
 			child_map.default_value = make_uniq<BoundConstantExpression>(Value(global_child.type));
 		}
+
 		if (child_map.column_index) {
 			child_indexes.push_back(std::move(*child_map.column_index));
 			mapping->child_mapping.insert(make_pair(i, std::move(child_map.mapping)));
@@ -301,12 +364,16 @@ ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDefinitio
 			// found a column mapping for this child - emplace it
 			column_mapping.emplace_back(global_child.name, std::move(child_map.column_map));
 		}
+		//! FIXME: the 'default_value' should only be used if the STRUCT's default value is not NULL
 		if (child_map.default_value) {
 			// found a default value for this child - emplace it
 			child_map.default_value->alias = global_child.name;
 			default_expressions.push_back(std::move(child_map.default_value));
 		}
 	}
+
+	ColumnMapResult result;
+	result.local_column = local_column;
 	if (!column_mapping.empty()) {
 		// we have column mappings at this level - construct the struct
 		result.column_map = Value::STRUCT(std::move(column_mapping));
@@ -318,6 +385,7 @@ ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDefinitio
 			result.column_map = Value::STRUCT(std::move(child_list));
 		}
 	}
+
 	if (!default_expressions.empty()) {
 		// we have default values at this level - construct the struct pack
 		child_list_t<LogicalType> default_type_list;
@@ -335,13 +403,62 @@ ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDefinitio
 	return result;
 }
 
+static ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDefinition &global_column,
+                          const ColumnIndex &global_index, const vector<MultiFileColumnDefinition> &local_columns,
+                          const ColumnMapper &mapper, optional_idx top_level_index) {
+	bool is_root = top_level_index.IsValid();
+	ColumnMapResult result;
+	auto entry = mapper.Find(global_column);
+	if (!entry.IsValid()) {
+		// entry not present in map, use default value
+		result.default_value = mapper.GetDefaultExpression(global_column, is_root);
+		return result;
+	}
+	// the field exists! get the local column
+	MultiFileLocalColumnId local_id(entry.GetIndex());
+	auto &local_column = local_columns[local_id.GetId()];
+	unique_ptr<MultiFileIndexMapping> mapping;
+	idx_t mapping_idx;
+	if (is_root) {
+		// root expression - refer to it directly
+		mapping_idx = top_level_index.GetIndex();
+	} else {
+		// extract the field from the parent
+		mapping_idx = local_id.GetId();
+	}
+
+	mapping = make_uniq<MultiFileIndexMapping>(mapping_idx);
+	if (global_column.children.empty()) {
+		// not a struct - map the column directly
+		result.column_map = Value(local_column.name);
+		result.column_index = make_uniq<ColumnIndex>(local_id.GetId());
+		result.mapping = std::move(mapping);
+		result.local_column = local_column;
+		return result;
+	}
+
+	// nested type - check if the field identifiers match and if we need to remap
+	D_ASSERT(global_column.type.IsNested());
+	switch (global_column.type.InternalType()) {
+		case PhysicalType::STRUCT:
+			return MapColumnStruct(context, global_column, global_index, local_column, local_id, mapper, std::move(mapping), is_root);
+		case PhysicalType::LIST:
+			return MapColumnList(context, global_column, global_index, local_column, local_id, mapper, std::move(mapping), is_root);
+		case PhysicalType::ARRAY: {
+			throw NotImplementedException("Can't map an ARRAY with nested children!");
+		}
+		default:
+			throw InternalException("MapColumn for children of type %s not implemented", global_column.type.ToString());
+	}
+}
+
 unique_ptr<Expression> ConstructMapExpression(ClientContext &context, idx_t local_idx, ColumnMapResult &mapping,
                                               const MultiFileColumnDefinition &global_column,
                                               bool is_trivially_mappable) {
 	auto &local_column = *mapping.local_column;
 	unique_ptr<Expression> expr;
 	expr = make_uniq<BoundReferenceExpression>(local_column.type, local_idx);
-	if (global_column.type.id() != LogicalTypeId::STRUCT ||
+	if (!global_column.type.IsNested() ||
 	    (!mapping.column_map.IsNull() && mapping.column_map.type().id() != LogicalTypeId::STRUCT) ||
 	    is_trivially_mappable) {
 		// not a struct - potentially add a cast

--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -39,7 +39,10 @@ public:
 static void RemapNested(Vector &input, Vector &default_vector, Vector &result, idx_t result_size,
                         const vector<RemapColumnInfo> &remap_info);
 
-static void RemapChildVectors(const Vector &result, const vector<reference<Vector>> &input_vectors, const vector<reference<Vector>> &result_vectors, const vector<RemapColumnInfo> &remap_info, Vector &default_vector, const bool has_top_level_null, idx_t count) {
+static void RemapChildVectors(const Vector &result, const vector<reference<Vector>> &input_vectors,
+                              const vector<reference<Vector>> &result_vectors,
+                              const vector<RemapColumnInfo> &remap_info, Vector &default_vector,
+                              const bool has_top_level_null, idx_t count) {
 	// set up the correct vector references
 	for (idx_t i = 0; i < remap_info.size(); i++) {
 		auto &remap = remap_info[i];
@@ -74,7 +77,7 @@ static void RemapChildVectors(const Vector &result, const vector<reference<Vecto
 }
 
 static void RemapMap(Vector &input, Vector &default_vector, Vector &result, idx_t result_size,
-                      const vector<RemapColumnInfo> &remap_info) {
+                     const vector<RemapColumnInfo> &remap_info) {
 	auto &input_key_vector = MapVector::GetKeys(input);
 	auto &input_value_vector = MapVector::GetValues(input);
 
@@ -207,7 +210,8 @@ static void RemapStruct(Vector &input, Vector &default_vector, Vector &result, i
 		result_vectors.emplace_back(*child);
 	}
 
-	RemapChildVectors(result, input_vectors, result_vectors, remap_info, default_vector, has_top_level_null, result_size);
+	RemapChildVectors(result, input_vectors, result_vectors, remap_info, default_vector, has_top_level_null,
+	                  result_size);
 }
 
 static void RemapNested(Vector &input, Vector &default_vector, Vector &result, idx_t result_size,
@@ -389,7 +393,8 @@ struct RemapEntry {
 		}
 	}
 
-	static vector<RemapColumnInfo> ConstructMapFromChildren(const child_list_t<LogicalType> target_children, const case_insensitive_map_t<RemapEntry> &remap_map) {
+	static vector<RemapColumnInfo> ConstructMapFromChildren(const child_list_t<LogicalType> target_children,
+	                                                        const case_insensitive_map_t<RemapEntry> &remap_map) {
 		vector<RemapColumnInfo> result;
 		for (idx_t target_idx = 0; target_idx < target_children.size(); target_idx++) {
 			auto &target_name = target_children[target_idx].first;
@@ -437,7 +442,9 @@ struct RemapEntry {
 		}
 	}
 
-	static child_list_t<LogicalType> RemapCastChildren(const child_list_t<LogicalType> source_children, const case_insensitive_map_t<RemapEntry> &remap_map, const unordered_map<idx_t, string> &source_name_map) {
+	static child_list_t<LogicalType> RemapCastChildren(const child_list_t<LogicalType> source_children,
+	                                                   const case_insensitive_map_t<RemapEntry> &remap_map,
+	                                                   const unordered_map<idx_t, string> &source_name_map) {
 		child_list_t<LogicalType> new_source_children;
 		for (idx_t source_idx = 0; source_idx < source_children.size(); source_idx++) {
 			auto &child_name = source_children[source_idx].first;
@@ -450,7 +457,7 @@ struct RemapEntry {
 				if (child_type.IsNested()) {
 					// nested - recurse
 					new_source_children.emplace_back(child_name,
-														RemapCast(child_type, *remap_entry->second.child_remaps));
+					                                 RemapCast(child_type, *remap_entry->second.child_remaps));
 				} else {
 					new_source_children.emplace_back(child_name, remap_entry->second.target_type);
 				}

--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -393,7 +393,7 @@ struct RemapEntry {
 		}
 	}
 
-	static vector<RemapColumnInfo> ConstructMapFromChildren(const child_list_t<LogicalType> target_children,
+	static vector<RemapColumnInfo> ConstructMapFromChildren(const child_list_t<LogicalType> &target_children,
 	                                                        const case_insensitive_map_t<RemapEntry> &remap_map) {
 		vector<RemapColumnInfo> result;
 		for (idx_t target_idx = 0; target_idx < target_children.size(); target_idx++) {
@@ -442,7 +442,7 @@ struct RemapEntry {
 		}
 	}
 
-	static child_list_t<LogicalType> RemapCastChildren(const child_list_t<LogicalType> source_children,
+	static child_list_t<LogicalType> RemapCastChildren(const child_list_t<LogicalType> &source_children,
 	                                                   const case_insensitive_map_t<RemapEntry> &remap_map,
 	                                                   const unordered_map<idx_t, string> &source_name_map) {
 		child_list_t<LogicalType> new_source_children;

--- a/test/sql/types/struct/remap_struct.test
+++ b/test/sql/types/struct/remap_struct.test
@@ -5,6 +5,12 @@
 statement ok
 PRAGMA enable_verification
 
+# basic binding error
+statement error
+select remap_struct(42, NULL::ROW(v1 INT, v2 INT, v3 INT), {'v1': 'j', 'v3': 'i'}, {'v2': NULL::INTEGER})
+----
+Binder Error: Struct remap can only remap nested types
+
 # basic remap usage
 query I
 SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v1 INT, v2 INT, v3 INT), {'v1': 'j', 'v3': 'i'}, {'v2': NULL::INTEGER});
@@ -17,13 +23,47 @@ SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v1 VARCHAR, v2 VARCHAR, v3 VARCH
 ----
 {'v1': 2, 'v2': hello, 'v3': 1}
 
+# Remapping operations:
+# - rename 'i' -> 'v1'
+# - rename 'j' -> 'v2'
+# - add column 'v2.y'
+# - add column 'v3'
+
 # remap nested types
 query I
 SELECT remap_struct(
- {'i': 1, 'j': {'x': 42, 'z': 100}},
- NULL::ROW(v1 INT, v2 STRUCT(x INT, y INT, z INT), v3 VARCHAR),
- {'v1': 'i', 'v2': ROW('j', {'x': 'x', 'z': 'z'})},
- {'v2': {'y': NULL::INT}, 'v3': NULL::VARCHAR});
+	{
+		'i': 1,
+		'j': {
+			'x': 42,
+			'z': 100
+		}
+	}, -- data
+	NULL::ROW(
+		v1 INT,
+		v2 STRUCT(
+			x INT,
+			y INT,
+			z INT
+		),
+		v3 VARCHAR
+	), -- target type
+	{
+		'v1': 'i',
+		'v2': ROW(
+			'j', {
+				'x': 'x',
+				'z': 'z'
+			}
+		)
+	}, -- remapping data -> target_type
+	{
+		'v2': {
+			'y': NULL::INT
+		},
+		'v3': NULL::VARCHAR
+	}
+); -- defaults
 ----
 {'v1': 1, 'v2': {'x': 42, 'y': NULL, 'z': 100}, 'v3': NULL}
 
@@ -99,7 +139,7 @@ Target value v2 not found
 statement error
 SELECT remap_struct({'i': 1, 'j': 2}, NULL, {'v2': 'i'}, NULL);
 ----
-Struct remap can only remap structs
+Struct remap can only remap nested types
 
 statement error
 SELECT remap_struct(ROW(1, 2), NULL::ROW(v1 VARCHAR), {'v2': 'i'}, NULL);

--- a/test/sql/types/struct/remap_struct_in_list.test
+++ b/test/sql/types/struct/remap_struct_in_list.test
@@ -1,0 +1,58 @@
+# name: test/sql/types/struct/remap_struct_in_list.test
+# description: Test struct remapping
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+# Remapping operations:
+# - rename 'list.i' -> 'list.v1'
+# - rename 'list.j' -> 'list.v2'
+# - add column 'list.v2.y'
+# - add column 'list.v3'
+
+# remap nested types
+query I
+SELECT remap_struct(
+	[
+		{
+			'i': 1,
+			'j': {
+				'x': 42,
+				'z': 100
+			}
+		}
+	], -- data
+	NULL::STRUCT(
+		v1 INT,
+		v2 STRUCT(
+			x INT,
+			y INT,
+			z INT
+		),
+		v3 VARCHAR
+	)[], -- target type
+	{
+		'list': ROW(
+			'list', {
+				'v1': 'i',
+				'v2': ROW(
+					'j', {
+						'x': 'x',
+						'z': 'z'
+					}
+				)
+			}
+		)
+	}, -- remapping data -> target_type
+	{
+		'list': {
+			'v2': {
+				'y': NULL::INT
+			},
+			'v3': NULL::VARCHAR
+		}
+	}
+); -- defaults
+----
+[{'v1': 1, 'v2': {'x': 42, 'y': NULL, 'z': 100}, 'v3': NULL}]

--- a/test/sql/types/struct/remap_struct_in_map.test
+++ b/test/sql/types/struct/remap_struct_in_map.test
@@ -1,0 +1,66 @@
+# name: test/sql/types/struct/remap_struct_in_map.test
+# description: Test struct remapping
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+# Remapping operations:
+# - rename 'value.i' -> 'value.v1'
+# - rename 'value.j' -> 'value.v2'
+# - add column 'value.v2.y'
+# - add column 'value.v3'
+
+# remap nested types
+query I
+SELECT remap_struct(
+	MAP {
+		'my_key1' : {
+			'i': 10,
+			'j': {
+				'x': 42,
+				'z': 100
+			}
+		},
+		'my_key2' : {
+			'i': 20,
+			'j': {
+				'x': 21,
+				'z': 50
+			}
+		}
+	}, -- data
+	NULL::MAP(VARCHAR, STRUCT(
+		v1 INT,
+		v2 STRUCT(
+			x INT,
+			y INT,
+			z INT
+		),
+		v3 VARCHAR
+	)), -- target type
+	{
+		'key': 'key',
+		'value': ROW(
+			'value', {
+				'v1': 'i',
+				'v2': ROW(
+					'j', {
+						'x': 'x',
+						'z': 'z'
+					}
+				)
+			}
+		)
+	}, -- remapping data -> target_type
+	{
+		'value': {
+			'v2': {
+				'y': NULL::INT
+			},
+			'v3': NULL::VARCHAR
+		}
+	}
+); -- defaults
+----
+{my_key1={'v1': 10, 'v2': {'x': 42, 'y': NULL, 'z': 100}, 'v3': NULL}, my_key2={'v1': 20, 'v2': {'x': 21, 'y': NULL, 'z': 50}, 'v3': NULL}}

--- a/test/sql/types/struct/remap_struct_in_map.test
+++ b/test/sql/types/struct/remap_struct_in_map.test
@@ -64,3 +64,92 @@ SELECT remap_struct(
 ); -- defaults
 ----
 {my_key1={'v1': 10, 'v2': {'x': 42, 'y': NULL, 'z': 100}, 'v3': NULL}, my_key2={'v1': 20, 'v2': {'x': 21, 'y': NULL, 'z': 50}, 'v3': NULL}}
+
+# Entirely a no-op, no defaults are given, mapping is directly the same
+query I
+SELECT remap_struct(
+	MAP {
+		[1,2,3] : 'test',
+		[6,4,5] : 'world'
+	}, -- data
+	NULL::MAP(INT[], VARCHAR), -- target type
+	{
+		'key': 'key',
+		'value': 'value'
+	}, -- remapping data -> target_type
+	NULL -- defaults
+);
+----
+{[1, 2, 3]=test, [6, 4, 5]=world}
+
+# Type modification of the key in any way is not allowed
+query I
+SELECT remap_struct(
+	MAP {
+		[1,2,3] : 'test',
+		[6,4,5] : 'world'
+	}, -- data
+	NULL::MAP(BIGINT[], VARCHAR), -- target type
+	{
+		'key': 'key',
+		'value': 'value'
+	}, -- remapping data -> target_type
+	NULL -- defaults
+);
+----
+{[1, 2, 3]=test, [6, 4, 5]=world}
+
+# Type modification from MAP -> STRUCT is not allowed
+statement error
+SELECT remap_struct(
+	MAP {
+		[1,2,3] : 'test',
+		[6,4,5] : 'world'
+	}, -- data
+	NULL::STRUCT("key" BIGINT[], "value" VARCHAR), -- target type
+	{
+		'key': 'key',
+		'value': 'value'
+	}, -- remapping data -> target_type
+	NULL -- defaults
+);
+----
+Can't change source type
+
+# Type modification of LIST -> MAP is not allowed (nested type this time)
+statement error
+SELECT remap_struct(
+	MAP {
+		[1,2,3] : ['test'],
+		[6,4,5] : ['world']
+	}, -- data
+	NULL::MAP(BIGINT[], MAP(VARCHAR, VARCHAR)), -- target type
+	{
+		'key': 'key',
+		'value': 'value'
+	}, -- remapping data -> target_type
+	NULL -- defaults
+);
+----
+Can't change source type
+
+# Type remapping the 'key', as a no-op
+query I
+SELECT remap_struct(
+	MAP {
+		[1,2,3] : ['test'],
+		[6,4,5] : ['world']
+	}, -- data
+	NULL::MAP(INT[], VARCHAR[]), -- target type
+	{
+		'key': ROW(
+			'key', {
+				'list': 'list'
+			}
+		),
+		'value': 'value'
+	}, -- remapping data -> target_type
+	NULL -- defaults
+);
+----
+{[1, 2, 3]=[test], [6, 4, 5]=[world]}


### PR DESCRIPTION
This PR solves the issue that we don't traverse into LIST and MAP in the MultiFileReader, so schema evolutions to a STRUCT inside a LIST/MAP currently don't get applied properly.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/4846

Now we properly traverse these types just like we already do for STRUCT.