### PR TITLE
[C API] Expose the client context, connection id and scalar function bind data

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -550,12 +550,13 @@ typedef struct _duckdb_extension_info {
 // Function types
 //===--------------------------------------------------------------------===//
 
-//! Additional function info. When setting this info, it is necessary to pass a destroy-callback function.
+//! Additional function info.
+//! When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_function_info {
 	void *internal_ptr;
 } * duckdb_function_info;
 
-//! The bind info of the function.
+//! The bind info of a function.
 //! When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_bind_info {
 	void *internal_ptr;
@@ -575,7 +576,7 @@ typedef struct _duckdb_scalar_function_set {
 	void *internal_ptr;
 } * duckdb_scalar_function_set;
 
-//! The bind function of the table function.
+//! The bind function of the scalar function.
 typedef void (*duckdb_scalar_function_bind_t)(duckdb_bind_info info);
 
 //! The main function of the scalar function.
@@ -819,10 +820,10 @@ DUCKDB_C_API void duckdb_connection_get_client_context(duckdb_connection connect
                                                        duckdb_client_context *out_context);
 
 /*!
-Returns the connection id of the client context's connection.
+Returns the connection id of the client context.
 
 * @param context The client context.
-* @return The connection id of the client context's connection.
+* @return The connection id of the client context.
 */
 DUCKDB_C_API idx_t duckdb_client_context_get_connection_id(duckdb_client_context context);
 
@@ -3281,7 +3282,7 @@ DUCKDB_C_API void duckdb_scalar_function_set_bind(duckdb_scalar_function scalar_
 
 /*!
 Sets the user-provided bind data in the bind object of the scalar function.
- This object can be retrieved again during execution.
+This object can be retrieved again during execution.
 
 * @param info The bind info of the scalar function.
 * @param bind_data The bind data object.
@@ -3332,7 +3333,7 @@ DUCKDB_C_API void *duckdb_scalar_function_get_extra_info(duckdb_function_info in
 /*!
 Gets the scalar function's bind data set by `duckdb_scalar_function_set_bind_data`.
 
-Note that the bind data should be considered as read-only.
+Note that the bind data is read-only.
 
 * @param info The function info.
 * @return The bind data object.
@@ -3741,7 +3742,7 @@ DUCKDB_C_API duckdb_value duckdb_bind_get_named_parameter(duckdb_bind_info info,
 
 /*!
 Sets the user-provided bind data in the bind object of the table function.
- This object can be retrieved again during execution.
+This object can be retrieved again during execution.
 
 * @param info The bind info of the table function.
 * @param bind_data The bind data object.
@@ -3849,7 +3850,7 @@ DUCKDB_C_API void *duckdb_function_get_extra_info(duckdb_function_info info);
 /*!
 Gets the table function's bind data set by `duckdb_bind_set_bind_data`.
 
-Note that the bind data should be considered as read-only.
+Note that the bind data is read-only.
 For tracking state, use the init data instead.
 
 * @param info The function info object.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -468,6 +468,11 @@ typedef struct _duckdb_connection {
 	void *internal_ptr;
 } * duckdb_connection;
 
+//! A client context of a duckdb connection. Must be destroyed with `duckdb_destroy_context`.
+typedef struct _duckdb_client_context {
+	void *internal_ptr;
+} * duckdb_client_context;
+
 //! A prepared statement is a parameterized query that allows you to bind parameters to it.
 //! Must be destroyed with `duckdb_destroy_prepare`.
 typedef struct _duckdb_prepared_statement {
@@ -535,6 +540,7 @@ typedef struct _duckdb_profiling_info {
 //===--------------------------------------------------------------------===//
 // C API Extension info
 //===--------------------------------------------------------------------===//
+
 //! Holds state during the C API extension intialization process
 typedef struct _duckdb_extension_info {
 	void *internal_ptr;
@@ -543,14 +549,22 @@ typedef struct _duckdb_extension_info {
 //===--------------------------------------------------------------------===//
 // Function types
 //===--------------------------------------------------------------------===//
+
 //! Additional function info. When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_function_info {
 	void *internal_ptr;
 } * duckdb_function_info;
 
+//! The bind info of the function.
+//! When setting this info, it is necessary to pass a destroy-callback function.
+typedef struct _duckdb_bind_info {
+	void *internal_ptr;
+} * duckdb_bind_info;
+
 //===--------------------------------------------------------------------===//
 // Scalar function types
 //===--------------------------------------------------------------------===//
+
 //! A scalar function. Must be destroyed with `duckdb_destroy_scalar_function`.
 typedef struct _duckdb_scalar_function {
 	void *internal_ptr;
@@ -560,6 +574,9 @@ typedef struct _duckdb_scalar_function {
 typedef struct _duckdb_scalar_function_set {
 	void *internal_ptr;
 } * duckdb_scalar_function_set;
+
+//! The bind function of the table function.
+typedef void (*duckdb_scalar_function_bind_t)(duckdb_bind_info info);
 
 //! The main function of the scalar function.
 typedef void (*duckdb_scalar_function_t)(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
@@ -606,11 +623,6 @@ typedef void (*duckdb_aggregate_finalize_t)(duckdb_function_info info, duckdb_ag
 typedef struct _duckdb_table_function {
 	void *internal_ptr;
 } * duckdb_table_function;
-
-//! The bind info of the function. When setting this info, it is necessary to pass a destroy-callback function.
-typedef struct _duckdb_bind_info {
-	void *internal_ptr;
-} * duckdb_bind_info;
 
 //! Additional function init info. When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_init_info {
@@ -796,6 +808,30 @@ Closes the specified connection and de-allocates all memory allocated for that c
 * @param connection The connection to close.
 */
 DUCKDB_C_API void duckdb_disconnect(duckdb_connection *connection);
+
+/*!
+Retrieves the client context of the connection.
+
+* @param connection The connection.
+* @param out_context The client context of the connection. Must be destroyed with `duckdb_destroy_client_context`.
+*/
+DUCKDB_C_API void duckdb_connection_get_client_context(duckdb_connection connection,
+                                                       duckdb_client_context *out_context);
+
+/*!
+Returns the connection id of the client context's connection.
+
+* @param context The client context.
+* @return The connection id of the client context's connection.
+*/
+DUCKDB_C_API idx_t duckdb_client_context_get_connection_id(duckdb_client_context context);
+
+/*!
+Destroys the client context and deallocates its memory.
+
+* @param context The client context to destroy.
+*/
+DUCKDB_C_API void duckdb_destroy_client_context(duckdb_client_context *context);
 
 /*!
 Returns the version of the linked DuckDB, with a version postfix for dev versions
@@ -3160,7 +3196,7 @@ DUCKDB_C_API void duckdb_validity_set_row_valid(uint64_t *validity, idx_t row);
 /*!
 Creates a new empty scalar function.
 
-The return value should be destroyed with `duckdb_destroy_scalar_function`.
+The return value must be destroyed with `duckdb_destroy_scalar_function`.
 
 * @return The scalar function object.
 */
@@ -3235,6 +3271,34 @@ DUCKDB_C_API void duckdb_scalar_function_set_extra_info(duckdb_scalar_function s
                                                         duckdb_delete_callback_t destroy);
 
 /*!
+Sets the (optional) bind function of the scalar function.
+
+* @param scalar_function The scalar function
+* @param bind The bind function
+*/
+DUCKDB_C_API void duckdb_scalar_function_set_bind(duckdb_scalar_function scalar_function,
+                                                  duckdb_scalar_function_bind_t bind);
+
+/*!
+Sets the user-provided bind data in the bind object of the scalar function.
+ This object can be retrieved again during execution.
+
+* @param info The bind info of the scalar function.
+* @param bind_data The bind data object.
+* @param destroy The callback to destroy the bind data (if any).
+*/
+DUCKDB_C_API void duckdb_scalar_function_set_bind_data(duckdb_bind_info info, void *bind_data,
+                                                       duckdb_delete_callback_t destroy);
+
+/*!
+Report that an error has occurred while calling bind on a scalar function.
+
+* @param info The bind info object
+* @param error The error message
+*/
+DUCKDB_C_API void duckdb_scalar_function_bind_set_error(duckdb_bind_info info, const char *error);
+
+/*!
 Sets the main function of the scalar function.
 
 * @param scalar_function The scalar function
@@ -3266,6 +3330,24 @@ Retrieves the extra info of the function as set in `duckdb_scalar_function_set_e
 DUCKDB_C_API void *duckdb_scalar_function_get_extra_info(duckdb_function_info info);
 
 /*!
+Gets the scalar function's bind data set by `duckdb_scalar_function_set_bind_data`.
+
+Note that the bind data should be considered as read-only.
+
+* @param info The function info.
+* @return The bind data object.
+*/
+DUCKDB_C_API void *duckdb_scalar_function_get_bind_data(duckdb_function_info info);
+
+/*!
+Retrieves the client context of the bind info of a scalar function.
+
+* @param info The bind info object of the scalar function.
+* @param out_context The client context of the bind info. Must be destroyed with `duckdb_destroy_client_context`.
+*/
+DUCKDB_C_API void duckdb_scalar_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);
+
+/*!
 Report that an error has occurred while executing the scalar function.
 
 * @param info The info object.
@@ -3276,7 +3358,7 @@ DUCKDB_C_API void duckdb_scalar_function_set_error(duckdb_function_info info, co
 /*!
 Creates a new empty scalar function set.
 
-The return value should be destroyed with `duckdb_destroy_scalar_function_set`.
+The return value must be destroyed with `duckdb_destroy_scalar_function_set`.
 
 * @return The scalar function set object.
 */
@@ -3658,11 +3740,12 @@ The result must be destroyed with `duckdb_destroy_value`.
 DUCKDB_C_API duckdb_value duckdb_bind_get_named_parameter(duckdb_bind_info info, const char *name);
 
 /*!
-Sets the user-provided bind data in the bind object. This object can be retrieved again during execution.
+Sets the user-provided bind data in the bind object of the table function.
+ This object can be retrieved again during execution.
 
-* @param info The info object
+* @param info The bind info of the table function.
 * @param bind_data The bind data object.
-* @param destroy The callback that will be called to destroy the bind data (if any)
+* @param destroy The callback to destroy the bind data (if any).
 */
 DUCKDB_C_API void duckdb_bind_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
 
@@ -3675,7 +3758,7 @@ Sets the cardinality estimate for the table function, used for optimization.
 DUCKDB_C_API void duckdb_bind_set_cardinality(duckdb_bind_info info, idx_t cardinality, bool is_exact);
 
 /*!
-Report that an error has occurred while calling bind.
+Report that an error has occurred while calling bind on a table function.
 
 * @param info The info object
 * @param error The error message
@@ -3764,13 +3847,13 @@ Retrieves the extra info of the function as set in `duckdb_table_function_set_ex
 DUCKDB_C_API void *duckdb_function_get_extra_info(duckdb_function_info info);
 
 /*!
-Gets the bind data set by `duckdb_bind_set_bind_data` during the bind.
+Gets the table function's bind data set by `duckdb_bind_set_bind_data`.
 
 Note that the bind data should be considered as read-only.
 For tracking state, use the init data instead.
 
-* @param info The info object
-* @return The bind data object
+* @param info The function info object.
+* @return The bind data object.
 */
 DUCKDB_C_API void *duckdb_function_get_bind_data(duckdb_function_info info);
 

--- a/src/include/duckdb/main/capi/capi_internal.hpp
+++ b/src/include/duckdb/main/capi/capi_internal.hpp
@@ -37,6 +37,11 @@ struct DatabaseWrapper {
 	shared_ptr<DuckDB> database;
 };
 
+struct CClientContextWrapper {
+	explicit CClientContextWrapper(ClientContext &context) : context(context) {};
+	ClientContext &context;
+};
+
 struct PreparedStatementWrapper {
 	//! Map of name -> values
 	case_insensitive_map_t<BoundParameterData> values;

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -471,6 +471,19 @@ typedef struct {
 
 	duckdb_state (*duckdb_append_default_to_chunk)(duckdb_appender appender, duckdb_data_chunk chunk, idx_t col,
 	                                               idx_t row);
+	// New functions around the client context
+
+	idx_t (*duckdb_client_context_get_connection_id)(duckdb_client_context context);
+	void (*duckdb_destroy_client_context)(duckdb_client_context *context);
+	void (*duckdb_connection_get_client_context)(duckdb_connection connection, duckdb_client_context *out_context);
+	// New functions around scalar function binding
+
+	void (*duckdb_scalar_function_set_bind)(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind);
+	void (*duckdb_scalar_function_bind_set_error)(duckdb_bind_info info, const char *error);
+	void (*duckdb_scalar_function_get_client_context)(duckdb_bind_info info, duckdb_client_context *out_context);
+	void (*duckdb_scalar_function_set_bind_data)(duckdb_bind_info info, void *bind_data,
+	                                             duckdb_delete_callback_t destroy);
+	void *(*duckdb_scalar_function_get_bind_data)(duckdb_function_info info);
 	// New string functions that are added
 
 	char *(*duckdb_value_to_string)(duckdb_value value);
@@ -904,6 +917,14 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_get_or_create_from_cache = duckdb_get_or_create_from_cache;
 	result.duckdb_destroy_instance_cache = duckdb_destroy_instance_cache;
 	result.duckdb_append_default_to_chunk = duckdb_append_default_to_chunk;
+	result.duckdb_client_context_get_connection_id = duckdb_client_context_get_connection_id;
+	result.duckdb_destroy_client_context = duckdb_destroy_client_context;
+	result.duckdb_connection_get_client_context = duckdb_connection_get_client_context;
+	result.duckdb_scalar_function_set_bind = duckdb_scalar_function_set_bind;
+	result.duckdb_scalar_function_bind_set_error = duckdb_scalar_function_bind_set_error;
+	result.duckdb_scalar_function_get_client_context = duckdb_scalar_function_get_client_context;
+	result.duckdb_scalar_function_set_bind_data = duckdb_scalar_function_set_bind_data;
+	result.duckdb_scalar_function_get_bind_data = duckdb_scalar_function_get_bind_data;
 	result.duckdb_value_to_string = duckdb_value_to_string;
 	result.duckdb_create_map_value = duckdb_create_map_value;
 	result.duckdb_create_union_value = duckdb_create_union_value;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_open_connect_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_open_connect_functions.json
@@ -1,0 +1,9 @@
+{
+  "version": "unstable_new_open_connect_functions",
+  "description": "New functions around the client context",
+  "entries": [
+    "duckdb_client_context_get_connection_id",
+    "duckdb_destroy_client_context",
+    "duckdb_connection_get_client_context"
+  ]
+}

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_scalar_function_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_scalar_function_functions.json
@@ -1,0 +1,11 @@
+{
+  "version": "unstable_new_scalar_function_functions",
+  "description": "New functions around scalar function binding",
+  "entries": [
+    "duckdb_scalar_function_set_bind",
+    "duckdb_scalar_function_bind_set_error",
+    "duckdb_scalar_function_get_client_context",
+    "duckdb_scalar_function_set_bind_data",
+    "duckdb_scalar_function_get_bind_data"
+  ]
+}

--- a/src/include/duckdb/main/capi/header_generation/functions/open_connect.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/open_connect.json
@@ -237,11 +237,11 @@
                 }
             ],
             "comment": {
-                "description": "Returns the connection id of the client context's connection.\n\n",
+                "description": "Returns the connection id of the client context.\n\n",
                 "param_comments": {
                     "context": "The client context."
                 },
-                "return_value": "The connection id of the client context's connection."
+                "return_value": "The connection id of the client context."
             }
         },
         {

--- a/src/include/duckdb/main/capi/header_generation/functions/open_connect.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/open_connect.json
@@ -207,6 +207,60 @@
             }
         },
         {
+            "name": "duckdb_connection_get_client_context",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_connection",
+                    "name": "connection"
+                },
+                {
+                    "type": "duckdb_client_context *",
+                    "name": "out_context"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the client context of the connection.\n\n",
+                "param_comments": {
+                    "connection": "The connection.",
+                    "out_context": "The client context of the connection. Must be destroyed with `duckdb_destroy_client_context`."
+                }
+            }
+        },
+        {
+            "name": "duckdb_client_context_get_connection_id",
+            "return_type": "idx_t",
+            "params": [
+                {
+                    "type": "duckdb_client_context",
+                    "name": "context"
+                }
+            ],
+            "comment": {
+                "description": "Returns the connection id of the client context's connection.\n\n",
+                "param_comments": {
+                    "context": "The client context."
+                },
+                "return_value": "The connection id of the client context's connection."
+            }
+        },
+        {
+            "name": "duckdb_destroy_client_context",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_client_context *",
+                    "name": "context"
+                }
+            ],
+            "comment": {
+                "description": "Destroys the client context and deallocates its memory.\n\n",
+                "param_comments": {
+                    "context": "The client context to destroy."
+                }
+            }
+        },
+        {
             "name": "duckdb_library_version",
             "return_type": "const char *",
             "params": [],

--- a/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
@@ -209,7 +209,7 @@
                 }
             ],
             "comment": {
-                "description": "Sets the user-provided bind data in the bind object of the scalar function. \n This object can be retrieved again during execution.\n\n",
+                "description": "Sets the user-provided bind data in the bind object of the scalar function. \nThis object can be retrieved again during execution.\n\n",
                 "param_comments": {
                     "info": "The bind info of the scalar function.",
                     "bind_data": "The bind data object.",
@@ -308,7 +308,7 @@
                 }
             ],
             "comment": {
-                "description": "Gets the scalar function's bind data set by `duckdb_scalar_function_set_bind_data`. \n\nNote that the bind data should be considered as read-only.\n\n",
+                "description": "Gets the scalar function's bind data set by `duckdb_scalar_function_set_bind_data`. \n\nNote that the bind data is read-only.\n\n",
                 "param_comments": {
                     "info": "The function info."
                 },

--- a/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
@@ -7,7 +7,7 @@
             "return_type": "duckdb_scalar_function",
             "params": [],
             "comment": {
-                "description": "Creates a new empty scalar function.\n\nThe return value should be destroyed with `duckdb_destroy_scalar_function`.\n\n",
+                "description": "Creates a new empty scalar function.\n\nThe return value must be destroyed with `duckdb_destroy_scalar_function`.\n\n",
                 "return_value": "The scalar function object."
             }
         },
@@ -171,6 +171,74 @@
             }
         },
         {
+            "name": "duckdb_scalar_function_set_bind",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_scalar_function",
+                    "name": "scalar_function"
+                },
+                {
+                    "type": "duckdb_scalar_function_bind_t",
+                    "name": "bind"
+                }
+            ],
+            "comment": {
+                "description": "Sets the (optional) bind function of the scalar function.\n\n",
+                "param_comments": {
+                    "scalar_function": "The scalar function",
+                    "bind": "The bind function"
+                }
+            }
+        },
+        {
+            "name": "duckdb_scalar_function_set_bind_data",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_bind_info",
+                    "name": "info"
+                },
+                {
+                    "type": "void *",
+                    "name": "bind_data"
+                },
+                {
+                    "type": "duckdb_delete_callback_t",
+                    "name": "destroy"
+                }
+            ],
+            "comment": {
+                "description": "Sets the user-provided bind data in the bind object of the scalar function. \n This object can be retrieved again during execution.\n\n",
+                "param_comments": {
+                    "info": "The bind info of the scalar function.",
+                    "bind_data": "The bind data object.",
+                    "destroy": "The callback to destroy the bind data (if any)."
+                }
+            }
+        },
+        {
+            "name": "duckdb_scalar_function_bind_set_error",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_bind_info",
+                    "name": "info"
+                },
+                {
+                    "type": "const char *",
+                    "name": "error"
+                }
+            ],
+            "comment": {
+                "description": "Report that an error has occurred while calling bind on a scalar function.\n\n",
+                "param_comments": {
+                    "info": "The bind info object",
+                    "error": "The error message"
+                }
+            }
+        },
+        {
             "name": "duckdb_scalar_function_set_function",
             "return_type": "void",
             "params": [
@@ -231,6 +299,44 @@
             }
         },
         {
+            "name": "duckdb_scalar_function_get_bind_data",
+            "return_type": "void *",
+            "params": [
+                {
+                    "type": "duckdb_function_info",
+                    "name": "info"
+                }
+            ],
+            "comment": {
+                "description": "Gets the scalar function's bind data set by `duckdb_scalar_function_set_bind_data`. \n\nNote that the bind data should be considered as read-only.\n\n",
+                "param_comments": {
+                    "info": "The function info."
+                },
+                "return_value": "The bind data object."
+            }
+        },
+        {
+            "name": "duckdb_scalar_function_get_client_context",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_bind_info",
+                    "name": "info"
+                },
+                {
+                    "type": "duckdb_client_context *",
+                    "name": "out_context"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the client context of the bind info of a scalar function.\n\n",
+                "param_comments": {
+                    "info": "The bind info object of the scalar function.",
+                    "out_context": "The client context of the bind info. Must be destroyed with `duckdb_destroy_client_context`."
+                }
+            }
+        },
+        {
             "name": "duckdb_scalar_function_set_error",
             "return_type": "void ",
             "params": [
@@ -261,7 +367,7 @@
                 }
             ],
             "comment": {
-                "description": "Creates a new empty scalar function set.\n\nThe return value should be destroyed with `duckdb_destroy_scalar_function_set`.\n\n",
+                "description": "Creates a new empty scalar function set.\n\nThe return value must be destroyed with `duckdb_destroy_scalar_function_set`.\n\n",
                 "return_value": "The scalar function set object."
             }
         },

--- a/src/include/duckdb/main/capi/header_generation/functions/table_function.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_function.json
@@ -29,11 +29,11 @@
                 }
             ],
             "comment": {
-                "description": "Gets the bind data set by `duckdb_bind_set_bind_data` during the bind.\n\nNote that the bind data should be considered as read-only.\nFor tracking state, use the init data instead.\n\n",
+                "description": "Gets the table function's bind data set by `duckdb_bind_set_bind_data`. \n\nNote that the bind data should be considered as read-only.\nFor tracking state, use the init data instead.\n\n",
                 "param_comments": {
-                    "info": "The info object"
+                    "info": "The function info object."
                 },
-                "return_value": "The bind data object"
+                "return_value": "The bind data object."
             }
         },
         {

--- a/src/include/duckdb/main/capi/header_generation/functions/table_function.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_function.json
@@ -29,7 +29,7 @@
                 }
             ],
             "comment": {
-                "description": "Gets the table function's bind data set by `duckdb_bind_set_bind_data`. \n\nNote that the bind data should be considered as read-only.\nFor tracking state, use the init data instead.\n\n",
+                "description": "Gets the table function's bind data set by `duckdb_bind_set_bind_data`. \n\nNote that the bind data is read-only.\nFor tracking state, use the init data instead.\n\n",
                 "param_comments": {
                     "info": "The function info object."
                 },

--- a/src/include/duckdb/main/capi/header_generation/functions/table_function_bind.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_function_bind.json
@@ -124,7 +124,7 @@
                 }
             ],
             "comment": {
-                "description": "Sets the user-provided bind data in the bind object of the table function. \n This object can be retrieved again during execution.\n\n",
+                "description": "Sets the user-provided bind data in the bind object of the table function. \nThis object can be retrieved again during execution.\n\n",
                 "param_comments": {
                     "info": "The bind info of the table function.",
                     "bind_data": "The bind data object.",

--- a/src/include/duckdb/main/capi/header_generation/functions/table_function_bind.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_function_bind.json
@@ -124,11 +124,11 @@
                 }
             ],
             "comment": {
-                "description": "Sets the user-provided bind data in the bind object. This object can be retrieved again during execution.\n\n",
+                "description": "Sets the user-provided bind data in the bind object of the table function. \n This object can be retrieved again during execution.\n\n",
                 "param_comments": {
-                    "info": "The info object",
+                    "info": "The bind info of the table function.",
                     "bind_data": "The bind data object.",
-                    "destroy": "The callback that will be called to destroy the bind data (if any)"
+                    "destroy": "The callback to destroy the bind data (if any)."
                 }
             }
         },
@@ -171,7 +171,7 @@
                 }
             ],
             "comment": {
-                "description": "Report that an error has occurred while calling bind.\n\n",
+                "description": "Report that an error has occurred while calling bind on a table function.\n\n",
                 "param_comments": {
                     "info": "The info object",
                     "error": "The error message"

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -547,12 +547,13 @@ typedef struct _duckdb_extension_info {
 // Function types
 //===--------------------------------------------------------------------===//
 
-//! Additional function info. When setting this info, it is necessary to pass a destroy-callback function.
+//! Additional function info.
+//! When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_function_info {
 	void *internal_ptr;
 } * duckdb_function_info;
 
-//! The bind info of the function.
+//! The bind info of a function.
 //! When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_bind_info {
 	void *internal_ptr;
@@ -572,7 +573,7 @@ typedef struct _duckdb_scalar_function_set {
 	void *internal_ptr;
 } * duckdb_scalar_function_set;
 
-//! The bind function of the table function.
+//! The bind function of the scalar function.
 typedef void (*duckdb_scalar_function_bind_t)(duckdb_bind_info info);
 
 //! The main function of the scalar function.

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -465,6 +465,11 @@ typedef struct _duckdb_connection {
 	void *internal_ptr;
 } * duckdb_connection;
 
+//! A client context of a duckdb connection. Must be destroyed with `duckdb_destroy_context`.
+typedef struct _duckdb_client_context {
+	void *internal_ptr;
+} * duckdb_client_context;
+
 //! A prepared statement is a parameterized query that allows you to bind parameters to it.
 //! Must be destroyed with `duckdb_destroy_prepare`.
 typedef struct _duckdb_prepared_statement {
@@ -532,6 +537,7 @@ typedef struct _duckdb_profiling_info {
 //===--------------------------------------------------------------------===//
 // C API Extension info
 //===--------------------------------------------------------------------===//
+
 //! Holds state during the C API extension intialization process
 typedef struct _duckdb_extension_info {
 	void *internal_ptr;
@@ -540,14 +546,22 @@ typedef struct _duckdb_extension_info {
 //===--------------------------------------------------------------------===//
 // Function types
 //===--------------------------------------------------------------------===//
+
 //! Additional function info. When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_function_info {
 	void *internal_ptr;
 } * duckdb_function_info;
 
+//! The bind info of the function.
+//! When setting this info, it is necessary to pass a destroy-callback function.
+typedef struct _duckdb_bind_info {
+	void *internal_ptr;
+} * duckdb_bind_info;
+
 //===--------------------------------------------------------------------===//
 // Scalar function types
 //===--------------------------------------------------------------------===//
+
 //! A scalar function. Must be destroyed with `duckdb_destroy_scalar_function`.
 typedef struct _duckdb_scalar_function {
 	void *internal_ptr;
@@ -557,6 +571,9 @@ typedef struct _duckdb_scalar_function {
 typedef struct _duckdb_scalar_function_set {
 	void *internal_ptr;
 } * duckdb_scalar_function_set;
+
+//! The bind function of the table function.
+typedef void (*duckdb_scalar_function_bind_t)(duckdb_bind_info info);
 
 //! The main function of the scalar function.
 typedef void (*duckdb_scalar_function_t)(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
@@ -603,11 +620,6 @@ typedef void (*duckdb_aggregate_finalize_t)(duckdb_function_info info, duckdb_ag
 typedef struct _duckdb_table_function {
 	void *internal_ptr;
 } * duckdb_table_function;
-
-//! The bind info of the function. When setting this info, it is necessary to pass a destroy-callback function.
-typedef struct _duckdb_bind_info {
-	void *internal_ptr;
-} * duckdb_bind_info;
 
 //! Additional function init info. When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_init_info {

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -542,6 +542,23 @@ typedef struct {
 	                                               idx_t row);
 #endif
 
+// New functions around the client context
+#ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
+	idx_t (*duckdb_client_context_get_connection_id)(duckdb_client_context context);
+	void (*duckdb_destroy_client_context)(duckdb_client_context *context);
+	void (*duckdb_connection_get_client_context)(duckdb_connection connection, duckdb_client_context *out_context);
+#endif
+
+// New functions around scalar function binding
+#ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
+	void (*duckdb_scalar_function_set_bind)(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind);
+	void (*duckdb_scalar_function_bind_set_error)(duckdb_bind_info info, const char *error);
+	void (*duckdb_scalar_function_get_client_context)(duckdb_bind_info info, duckdb_client_context *out_context);
+	void (*duckdb_scalar_function_set_bind_data)(duckdb_bind_info info, void *bind_data,
+	                                             duckdb_delete_callback_t destroy);
+	void *(*duckdb_scalar_function_get_bind_data)(duckdb_function_info info);
+#endif
+
 // New string functions that are added
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
 	char *(*duckdb_value_to_string)(duckdb_value value);
@@ -987,6 +1004,18 @@ typedef struct {
 
 // Version unstable_new_append_functions
 #define duckdb_append_default_to_chunk duckdb_ext_api.duckdb_append_default_to_chunk
+
+// Version unstable_new_open_connect_functions
+#define duckdb_connection_get_client_context    duckdb_ext_api.duckdb_connection_get_client_context
+#define duckdb_client_context_get_connection_id duckdb_ext_api.duckdb_client_context_get_connection_id
+#define duckdb_destroy_client_context           duckdb_ext_api.duckdb_destroy_client_context
+
+// Version unstable_new_scalar_function_functions
+#define duckdb_scalar_function_set_bind           duckdb_ext_api.duckdb_scalar_function_set_bind
+#define duckdb_scalar_function_set_bind_data      duckdb_ext_api.duckdb_scalar_function_set_bind_data
+#define duckdb_scalar_function_bind_set_error     duckdb_ext_api.duckdb_scalar_function_bind_set_error
+#define duckdb_scalar_function_get_bind_data      duckdb_ext_api.duckdb_scalar_function_get_bind_data
+#define duckdb_scalar_function_get_client_context duckdb_ext_api.duckdb_scalar_function_get_client_context
 
 // Version unstable_new_string_functions
 #define duckdb_value_to_string duckdb_ext_api.duckdb_value_to_string

--- a/src/main/capi/duckdb-c.cpp
+++ b/src/main/capi/duckdb-c.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/main/capi/capi_internal.hpp"
 
+using duckdb::CClientContextWrapper;
 using duckdb::Connection;
 using duckdb::DatabaseWrapper;
 using duckdb::DBConfig;
@@ -138,6 +139,28 @@ void duckdb_disconnect(duckdb_connection *connection) {
 		Connection *conn = reinterpret_cast<Connection *>(*connection);
 		delete conn;
 		*connection = nullptr;
+	}
+}
+
+void duckdb_connection_get_client_context(duckdb_connection connection, duckdb_client_context *out_context) {
+	if (!connection || !out_context) {
+		return;
+	}
+	Connection *conn = reinterpret_cast<Connection *>(connection);
+	auto wrapper = new CClientContextWrapper(*conn->context);
+	*out_context = reinterpret_cast<duckdb_client_context>(wrapper);
+}
+
+idx_t duckdb_client_context_get_connection_id(duckdb_client_context context) {
+	auto wrapper = reinterpret_cast<CClientContextWrapper *>(context);
+	return wrapper->context.GetConnectionId();
+}
+
+void duckdb_destroy_client_context(duckdb_client_context *context) {
+	if (context && *context) {
+		auto wrapper = reinterpret_cast<CClientContextWrapper *>(*context);
+		delete wrapper;
+		*context = nullptr;
 	}
 }
 

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -19,22 +19,21 @@ struct CScalarFunctionInfo : public ScalarFunctionInfo {
 		delete_callback = nullptr;
 	}
 
+	duckdb_scalar_function_bind_t bind = nullptr;
 	duckdb_scalar_function_t function = nullptr;
 	duckdb_function_info extra_info = nullptr;
 	duckdb_delete_callback_t delete_callback = nullptr;
 };
 
-struct CScalarExecuteInfo {
-	explicit CScalarExecuteInfo(CScalarFunctionInfo &info) : info(info) {
-	}
-
-	CScalarFunctionInfo &info;
-	bool success = true;
-	string error;
-};
-
 struct CScalarFunctionBindData : public FunctionData {
 	explicit CScalarFunctionBindData(CScalarFunctionInfo &info) : info(info) {
+	}
+	~CScalarFunctionBindData() override {
+		if (bind_data && delete_callback) {
+			delete_callback(bind_data);
+		}
+		bind_data = nullptr;
+		delete_callback = nullptr;
 	}
 
 	unique_ptr<FunctionData> Copy() const override {
@@ -46,7 +45,38 @@ struct CScalarFunctionBindData : public FunctionData {
 	}
 
 	CScalarFunctionInfo &info;
+	void *bind_data = nullptr;
+	duckdb_delete_callback_t delete_callback = nullptr;
 };
+
+struct CScalarFunctionInternalBindInfo {
+	CScalarFunctionInternalBindInfo(ClientContext &context, ScalarFunction &bound_function,
+	                                vector<unique_ptr<Expression>> &arguments, CScalarFunctionBindData &bind_data)
+	    : context(context), bound_function(bound_function), arguments(arguments), bind_data(bind_data) {
+	}
+
+	ClientContext &context;
+	ScalarFunction &bound_function;
+	vector<unique_ptr<Expression>> &arguments;
+	CScalarFunctionBindData &bind_data;
+
+	bool success = true;
+	string error = "";
+};
+
+struct CScalarFunctionInternalFunctionInfo {
+	explicit CScalarFunctionInternalFunctionInfo(const CScalarFunctionBindData &bind_data)
+	    : bind_data(bind_data), success(true) {};
+
+	const CScalarFunctionBindData &bind_data;
+
+	bool success;
+	string error = "";
+};
+
+//===--------------------------------------------------------------------===//
+// Helper Functions
+//===--------------------------------------------------------------------===//
 
 duckdb::ScalarFunction &GetCScalarFunction(duckdb_scalar_function function) {
 	return *reinterpret_cast<duckdb::ScalarFunction *>(function);
@@ -56,10 +86,43 @@ duckdb::ScalarFunctionSet &GetCScalarFunctionSet(duckdb_scalar_function_set set)
 	return *reinterpret_cast<duckdb::ScalarFunctionSet *>(set);
 }
 
-unique_ptr<FunctionData> BindCAPIScalarFunction(ClientContext &, ScalarFunction &bound_function,
-                                                vector<unique_ptr<Expression>> &arguments) {
+duckdb::CScalarFunctionInternalBindInfo &GetCScalarFunctionBindInfo(duckdb_bind_info info) {
+	D_ASSERT(info);
+	return *reinterpret_cast<duckdb::CScalarFunctionInternalBindInfo *>(info);
+}
+
+duckdb_bind_info ToCScalarFunctionBindInfo(duckdb::CScalarFunctionInternalBindInfo &info) {
+	return reinterpret_cast<duckdb_bind_info>(&info);
+}
+
+duckdb::CScalarFunctionInternalFunctionInfo &GetCScalarFunctionInfo(duckdb_function_info info) {
+	D_ASSERT(info);
+	return *reinterpret_cast<duckdb::CScalarFunctionInternalFunctionInfo *>(info);
+}
+
+duckdb_function_info ToCScalarFunctionInfo(duckdb::CScalarFunctionInternalFunctionInfo &info) {
+	return reinterpret_cast<duckdb_function_info>(&info);
+}
+
+//===--------------------------------------------------------------------===//
+// Scalar Function Callbacks
+//===--------------------------------------------------------------------===//
+
+unique_ptr<FunctionData> CScalarFunctionBind(ClientContext &context, ScalarFunction &bound_function,
+                                             vector<unique_ptr<Expression>> &arguments) {
 	auto &info = bound_function.function_info->Cast<CScalarFunctionInfo>();
-	return make_uniq<CScalarFunctionBindData>(info);
+	D_ASSERT(info.function);
+
+	auto result = make_uniq<CScalarFunctionBindData>(info);
+	if (info.bind) {
+		CScalarFunctionInternalBindInfo bind_info(context, bound_function, arguments, *result);
+		info.bind(ToCScalarFunctionBindInfo(bind_info));
+		if (!bind_info.success) {
+			throw BinderException(bind_info.error);
+		}
+	}
+
+	return std::move(result);
 }
 
 void CAPIScalarFunction(DataChunk &input, ExpressionState &state, Vector &result) {
@@ -72,11 +135,11 @@ void CAPIScalarFunction(DataChunk &input, ExpressionState &state, Vector &result
 	auto c_input = reinterpret_cast<duckdb_data_chunk>(&input);
 	auto c_result = reinterpret_cast<duckdb_vector>(&result);
 
-	CScalarExecuteInfo exec_info(c_bind_info.info);
-	auto c_function_info = reinterpret_cast<duckdb_function_info>(&exec_info);
+	CScalarFunctionInternalFunctionInfo function_info(c_bind_info);
+	auto c_function_info = ToCScalarFunctionInfo(function_info);
 	c_bind_info.info.function(c_function_info, c_input, c_result);
-	if (!exec_info.success) {
-		throw InvalidInputException(exec_info.error);
+	if (!function_info.success) {
+		throw InvalidInputException(function_info.error);
 	}
 	if (all_const && (input.size() == 1 || function.function.stability != FunctionStability::VOLATILE)) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
@@ -86,11 +149,13 @@ void CAPIScalarFunction(DataChunk &input, ExpressionState &state, Vector &result
 } // namespace duckdb
 
 using duckdb::GetCScalarFunction;
+using duckdb::GetCScalarFunctionBindInfo;
+using duckdb::GetCScalarFunctionInfo;
 using duckdb::GetCScalarFunctionSet;
 
 duckdb_scalar_function duckdb_create_scalar_function() {
 	auto function = new duckdb::ScalarFunction("", {}, duckdb::LogicalType::INVALID, duckdb::CAPIScalarFunction,
-	                                           duckdb::BindCAPIScalarFunction);
+	                                           duckdb::CScalarFunctionBind);
 	function->function_info = duckdb::make_shared_ptr<duckdb::CScalarFunctionInfo>();
 	return reinterpret_cast<duckdb_scalar_function>(function);
 }
@@ -154,26 +219,47 @@ void duckdb_scalar_function_set_return_type(duckdb_scalar_function function, duc
 	scalar_function.return_type = *logical_type;
 }
 
-duckdb::CScalarExecuteInfo &GetCScalarExecInfo(duckdb_function_info info) {
-	D_ASSERT(info);
-	return *reinterpret_cast<duckdb::CScalarExecuteInfo *>(info);
-}
-
 void *duckdb_scalar_function_get_extra_info(duckdb_function_info info) {
 	if (!info) {
 		return nullptr;
 	}
-	auto &scalar_function = GetCScalarExecInfo(info);
-	return scalar_function.info.extra_info;
+	auto &function_info = GetCScalarFunctionInfo(info);
+	return function_info.bind_data.info.extra_info;
+}
+
+void *duckdb_scalar_function_get_bind_data(duckdb_function_info info) {
+	if (!info) {
+		return nullptr;
+	}
+	auto &function_info = GetCScalarFunctionInfo(info);
+	return function_info.bind_data.bind_data;
+}
+
+void duckdb_scalar_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context) {
+	if (!info || !out_context) {
+		return;
+	}
+	auto &bind_info = GetCScalarFunctionBindInfo(info);
+	auto wrapper = new CClientContextWrapper(bind_info.context);
+	*out_context = reinterpret_cast<duckdb_client_context>(wrapper);
 }
 
 void duckdb_scalar_function_set_error(duckdb_function_info info, const char *error) {
 	if (!info || !error) {
 		return;
 	}
-	auto &scalar_function = GetCScalarExecInfo(info);
+	auto &scalar_function = duckdb::GetCScalarFunctionInfo(info);
 	scalar_function.error = error;
 	scalar_function.success = false;
+}
+
+void duckdb_scalar_function_bind_set_error(duckdb_bind_info info, const char *error) {
+	if (!info || !error) {
+		return;
+	}
+	auto &bind_info = GetCScalarFunctionBindInfo(info);
+	bind_info.error = error;
+	bind_info.success = false;
 }
 
 void duckdb_scalar_function_set_extra_info(duckdb_scalar_function function, void *extra_info,
@@ -185,6 +271,24 @@ void duckdb_scalar_function_set_extra_info(duckdb_scalar_function function, void
 	auto &info = scalar_function.function_info->Cast<duckdb::CScalarFunctionInfo>();
 	info.extra_info = reinterpret_cast<duckdb_function_info>(extra_info);
 	info.delete_callback = destroy;
+}
+
+void duckdb_scalar_function_set_bind(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind) {
+	if (!scalar_function || !bind) {
+		return;
+	}
+	auto &sf = GetCScalarFunction(scalar_function);
+	auto &info = sf.function_info->Cast<duckdb::CScalarFunctionInfo>();
+	info.bind = bind;
+}
+
+void duckdb_scalar_function_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy) {
+	if (!info) {
+		return;
+	}
+	auto &bind_info = GetCScalarFunctionBindInfo(info);
+	bind_info.bind_data.bind_data = bind_data;
+	bind_info.bind_data.delete_callback = destroy;
 }
 
 void duckdb_scalar_function_set_function(duckdb_scalar_function function, duckdb_scalar_function_t execute_func) {

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -240,7 +240,7 @@ void duckdb_scalar_function_get_client_context(duckdb_bind_info info, duckdb_cli
 		return;
 	}
 	auto &bind_info = GetCScalarFunctionBindInfo(info);
-	auto wrapper = new CClientContextWrapper(bind_info.context);
+	auto wrapper = new duckdb::CClientContextWrapper(bind_info.context);
 	*out_context = reinterpret_cast<duckdb_client_context>(wrapper);
 }
 

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -405,3 +405,84 @@ TEST_CASE("Test Scalar Function Overloads C API", "[capi]") {
 		REQUIRE(result->Fetch<int64_t>(0, row) == static_cast<int64_t>(1000000 + row + row));
 	}
 }
+
+struct ConnectionIdStruct {
+	idx_t connection_id;
+};
+
+void GetConnectionIdBind(duckdb_bind_info info) {
+	duckdb_client_context context;
+	duckdb_scalar_function_get_client_context(info, &context);
+
+	auto connection_id = duckdb_client_context_get_connection_id(context);
+	duckdb_destroy_client_context(&context);
+
+	auto bind_data = reinterpret_cast<ConnectionIdStruct *>(malloc(sizeof(ConnectionIdStruct)));
+	bind_data->connection_id = connection_id;
+	duckdb_scalar_function_set_bind_data(info, bind_data, free);
+}
+
+void GetConnectionId(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
+	auto bind_data_ptr = duckdb_scalar_function_get_bind_data(info);
+	auto bind_data = reinterpret_cast<ConnectionIdStruct *>(bind_data_ptr);
+	auto input_size = duckdb_data_chunk_get_size(input);
+
+	auto result_data = reinterpret_cast<uint64_t *>(duckdb_vector_get_data(output));
+	for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
+		result_data[row_idx] = bind_data->connection_id;
+	}
+}
+
+static void CAPIRegisterGetConnectionId(duckdb_connection connection) {
+	duckdb_state status;
+
+	auto function = duckdb_create_scalar_function();
+	duckdb_scalar_function_set_name(function, "get_connection_id");
+
+	// Set the return type to UBIGINT.
+	auto type = duckdb_create_logical_type(DUCKDB_TYPE_UBIGINT);
+	duckdb_scalar_function_set_return_type(function, type);
+	duckdb_destroy_logical_type(&type);
+
+	// Set up the bind and function callbacks.
+	duckdb_scalar_function_set_bind(function, GetConnectionIdBind);
+	duckdb_scalar_function_set_function(function, GetConnectionId);
+
+	// Register and cleanup.
+	status = duckdb_register_scalar_function(connection, function);
+	REQUIRE(status == DuckDBSuccess);
+	duckdb_destroy_scalar_function(&function);
+}
+
+TEST_CASE("Test Scalar Function with Bind Info", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	CAPIRegisterGetConnectionId(tester.connection);
+
+	result = tester.Query("SELECT get_connection_id()");
+	REQUIRE_NO_FAIL(*result);
+	auto first_connection_id = result->Fetch<int64_t>(0, 0);
+	REQUIRE(first_connection_id != 0);
+
+	duckdb_client_context context;
+	duckdb_connection_get_client_context(tester.connection, &context);
+	auto first_conn_id = duckdb_client_context_get_connection_id(context);
+	duckdb_destroy_client_context(&context);
+	REQUIRE(first_conn_id == first_connection_id);
+
+	tester.ChangeConnection();
+
+	result = tester.Query("SELECT get_connection_id()");
+	REQUIRE_NO_FAIL(*result);
+	auto second_connection_id = result->Fetch<int64_t>(0, 0);
+	REQUIRE(second_connection_id != 0);
+
+	duckdb_connection_get_client_context(tester.connection, &context);
+	auto second_conn_id = duckdb_client_context_get_connection_id(context);
+	duckdb_destroy_client_context(&context);
+	REQUIRE(second_conn_id == second_connection_id);
+
+	REQUIRE(first_connection_id != second_connection_id);
+}

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -463,7 +463,7 @@ TEST_CASE("Test Scalar Function with Bind Info", "[capi]") {
 
 	result = tester.Query("SELECT get_connection_id()");
 	REQUIRE_NO_FAIL(*result);
-	auto first_connection_id = result->Fetch<int64_t>(0, 0);
+	auto first_connection_id = result->Fetch<uint64_t>(0, 0);
 	REQUIRE(first_connection_id != 0);
 
 	duckdb_client_context context;
@@ -476,7 +476,7 @@ TEST_CASE("Test Scalar Function with Bind Info", "[capi]") {
 
 	result = tester.Query("SELECT get_connection_id()");
 	REQUIRE_NO_FAIL(*result);
-	auto second_connection_id = result->Fetch<int64_t>(0, 0);
+	auto second_connection_id = result->Fetch<uint64_t>(0, 0);
 	REQUIRE(second_connection_id != 0);
 
 	duckdb_connection_get_client_context(tester.connection, &context);

--- a/test/include/capi_tester.hpp
+++ b/test/include/capi_tester.hpp
@@ -259,10 +259,12 @@ public:
 		if (duckdb_open(path, &database) != DuckDBSuccess) {
 			return false;
 		}
-		if (duckdb_connect(database, &connection) != DuckDBSuccess) {
-			return false;
-		}
-		return true;
+		return duckdb_connect(database, &connection) == DuckDBSuccess;
+	}
+
+	bool ChangeConnection() {
+		duckdb_disconnect(&connection);
+		return duckdb_connect(database, &connection) == DuckDBSuccess;
 	}
 
 	duckdb::unique_ptr<CAPIResult> Query(string query) {


### PR DESCRIPTION
This PR adds new functionality to the C API. Below is a list.

- A new `struct`: `duckdb_client_context`, which wraps `ClientContext`.

```cpp
void duckdb_connection_get_client_context(duckdb_connection connection, duckdb_client_context *out_context);
idx_t duckdb_client_context_get_connection_id(duckdb_client_context context);
void duckdb_destroy_client_context(duckdb_client_context *context);

void duckdb_scalar_function_set_bind(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind);
void duckdb_scalar_function_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
void duckdb_scalar_function_bind_set_error(duckdb_bind_info info, const char *error);
void *duckdb_scalar_function_get_bind_data(duckdb_function_info info);

void duckdb_scalar_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);
```
