### PR TITLE
[Fix] Switch between constant and flat vector in C API

### DIFF
--- a/src/main/capi/data_chunk-c.cpp
+++ b/src/main/capi/data_chunk-c.cpp
@@ -113,7 +113,14 @@ uint64_t *duckdb_vector_get_validity(duckdb_vector vector) {
 		return nullptr;
 	}
 	auto v = reinterpret_cast<duckdb::Vector *>(vector);
-	return duckdb::FlatVector::Validity(*v).GetData();
+	switch (v->GetVectorType()) {
+	case duckdb::VectorType::CONSTANT_VECTOR:
+		return duckdb::ConstantVector::Validity(*v).GetData();
+	case duckdb::VectorType::FLAT_VECTOR:
+		return duckdb::FlatVector::Validity(*v).GetData();
+	default:
+		return nullptr;
+	}
 }
 
 void duckdb_vector_ensure_validity_writable(duckdb_vector vector) {


### PR DESCRIPTION
The scalar function callback sets the vector type to constant, if all input arguments are constant - so we need to add that open when retrieving validity masks.

Close https://github.com/duckdb/duckdb/issues/17298.