### PR TITLE
If distinct count from stats is 0, do not use it in Join Order Optimizer

### DIFF
--- a/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
+++ b/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
@@ -69,6 +69,7 @@ public:
 	static void CopyRelationStats(RelationStats &to, const RelationStats &from);
 
 private:
+	static idx_t GetDistinctCount(LogicalGet &get, ClientContext &context, idx_t column_id);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -138,7 +138,7 @@ private:
 	bool has_null;
 	//! Whether or not the segment can contain values that are not null
 	bool has_no_null;
-	// estimate that one may have even if distinct_stats==nullptr
+	//! estimate that one may have even if distinct_stats==nullptr
 	idx_t distinct_count;
 	//! Numeric and String stats
 	union {

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -86,7 +86,6 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 		auto column_id = column_ids[i].GetPrimaryIndex();
 		auto distinct_count = GetDistinctCount(get, context, column_id);
 		if (distinct_count > 0) {
-			distinct_count = MaxValue<idx_t>(1, distinct_count);
 			auto column_distinct_count = DistinctCount({distinct_count, true});
 			return_stats.column_distinct_count.push_back(column_distinct_count);
 			return_stats.column_names.push_back(name + "." + get.names.at(column_id));

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -54,6 +54,18 @@ static ExpressionBinding GetChildColumnBinding(Expression &expr) {
 	return ret;
 }
 
+idx_t RelationStatisticsHelper::GetDistinctCount(LogicalGet &get, ClientContext &context, idx_t column_id) {
+	if (!get.function.statistics) {
+		return 0;
+	}
+	auto column_statistics = get.function.statistics(context, get.bind_data.get(), column_id);
+	if (!column_statistics) {
+		return 0;
+	}
+	auto distinct_count = column_statistics->GetDistinctCount();
+	return distinct_count;
+}
+
 RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientContext &context) {
 	auto return_stats = RelationStats();
 
@@ -68,33 +80,18 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 		return_stats.table_name = name;
 	}
 
-	// if we can get the catalog table, then our column statistics will be accurate
-	// parquet readers etc. will still return statistics, but they initialize distinct column
-	// counts to 0.
-	// TODO: fix this, some file formats can encode distinct counts, we don't want to rely on
-	//  getting a catalog table to know that we can use statistics.
-	bool have_catalog_table_statistics = false;
-	if (get.GetTable()) {
-		have_catalog_table_statistics = true;
-	}
-
 	// first push back basic distinct counts for each column (if we have them).
 	auto &column_ids = get.GetColumnIds();
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		auto column_id = column_ids[i].GetPrimaryIndex();
-		bool have_distinct_count_stats = false;
-		if (get.function.statistics) {
-			column_statistics = get.function.statistics(context, get.bind_data.get(), column_id);
-			if (column_statistics && have_catalog_table_statistics) {
-				auto distinct_count = MaxValue<idx_t>(1, column_statistics->GetDistinctCount());
-				auto column_distinct_count = DistinctCount({distinct_count, true});
-				return_stats.column_distinct_count.push_back(column_distinct_count);
-				return_stats.column_names.push_back(name + "." + get.names.at(column_id));
-				have_distinct_count_stats = true;
-			}
-		}
-		if (!have_distinct_count_stats) {
-			// currently treating the cardinality as the distinct count.
+		auto distinct_count = GetDistinctCount(get, context, column_id);
+		if (distinct_count > 0) {
+			distinct_count = MaxValue<idx_t>(1, distinct_count);
+			auto column_distinct_count = DistinctCount({distinct_count, true});
+			return_stats.column_distinct_count.push_back(column_distinct_count);
+			return_stats.column_names.push_back(name + "." + get.names.at(column_id));
+		} else {
+			// treat the cardinality as the distinct count.
 			// the cardinality estimator will update these distinct counts based
 			// on the extra columns that are joined on.
 			auto column_distinct_count = DistinctCount({cardinality_after_filters, false});


### PR DESCRIPTION
This causes bad join orderings when reading from scanners that provide 0 as a distinct count.
If a table truly has a distinct count of 0, then the cardinality is also 0, so falling back to the cardinality count is fine in this case.