### PR TITLE
Fix TIMETZ cast in example

### DIFF
--- a/extension/core_functions/include/core_functions/scalar/date_functions.hpp
+++ b/extension/core_functions/include/core_functions/scalar/date_functions.hpp
@@ -465,7 +465,7 @@ struct TimeTZSortKeyFun {
 	static constexpr const char *Name = "timetz_byte_comparable";
 	static constexpr const char *Parameters = "time_tz";
 	static constexpr const char *Description = "Converts a TIME WITH TIME ZONE to an integer sort key";
-	static constexpr const char *Example = "timetz_byte_comparable('18:18:16.21-07:00'::TIME_TZ)";
+	static constexpr const char *Example = "timetz_byte_comparable('18:18:16.21-07:00'::TIMETZ)";
 	static constexpr const char *Categories = "";
 
 	static ScalarFunction GetFunction();

--- a/extension/core_functions/scalar/date/functions.json
+++ b/extension/core_functions/scalar/date/functions.json
@@ -325,7 +325,7 @@
         "name": "timetz_byte_comparable",
         "parameters": "time_tz",
         "description": "Converts a TIME WITH TIME ZONE to an integer sort key",
-        "example": "timetz_byte_comparable('18:18:16.21-07:00'::TIME_TZ)",
+        "example": "timetz_byte_comparable('18:18:16.21-07:00'::TIMETZ)",
         "type": "scalar_function"
     },
     {


### PR DESCRIPTION
The previous example was failing:

```
D select timetz_byte_comparable('18:18:16.21-07:00'::TIME_TZ);
Catalog Error:
Type with name TIME_TZ does not exist!
Did you mean "timestamp_ms"?
```