### PR TITLE
Emit dictionary vectors with unaligned start index

### DIFF
--- a/src/storage/compression/dictionary/decompression.cpp
+++ b/src/storage/compression/dictionary/decompression.cpp
@@ -90,11 +90,11 @@ void CompressedStringScanState::ScanToFlatVector(Vector &result, idx_t result_of
 
 void CompressedStringScanState::ScanToDictionaryVector(ColumnSegment &segment, Vector &result, idx_t result_offset,
                                                        idx_t start, idx_t scan_count) {
-	D_ASSERT(start % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE == 0);
 	D_ASSERT(scan_count == STANDARD_VECTOR_SIZE);
 	D_ASSERT(result_offset == 0);
 
-	idx_t decompress_count = BitpackingPrimitives::RoundUpToAlgorithmGroupSize(scan_count);
+	idx_t start_offset = start % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE;
+	idx_t decompress_count = BitpackingPrimitives::RoundUpToAlgorithmGroupSize(scan_count + start_offset);
 
 	// Create a selection vector of sufficient size if we don't already have one.
 	if (!sel_vec || sel_vec_size < decompress_count) {
@@ -104,9 +104,15 @@ void CompressedStringScanState::ScanToDictionaryVector(ColumnSegment &segment, V
 
 	// Scanning 2048 values, emitting a dict vector
 	data_ptr_t dst = data_ptr_cast(sel_vec->data());
-	data_ptr_t src = data_ptr_cast(&base_data[(start * current_width) / 8]);
+	data_ptr_t src = data_ptr_cast(&base_data[((start - start_offset) * current_width) / 8]);
 
-	BitpackingPrimitives::UnPackBuffer<sel_t>(dst, src, scan_count, current_width);
+	BitpackingPrimitives::UnPackBuffer<sel_t>(dst, src, decompress_count, current_width);
+
+	if (start_offset != 0) {
+		for (idx_t i = 0; i < scan_count; i++) {
+			sel_vec->set_index(i, sel_vec->get_index(i + start_offset));
+		}
+	}
 
 	result.Dictionary(*(dictionary), dictionary_size, *sel_vec, scan_count);
 	DictionaryVector::SetDictionaryId(result, to_string(CastPointerToValue(&segment)));

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -135,8 +135,7 @@ void DictionaryCompressionStorage::StringScanPartial(ColumnSegment &segment, Col
 	auto &scan_state = state.scan_state->Cast<CompressedStringScanState>();
 
 	auto start = segment.GetRelativeIndex(state.row_index);
-	if (!ALLOW_DICT_VECTORS || scan_count != STANDARD_VECTOR_SIZE ||
-	    start % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE != 0) {
+	if (!ALLOW_DICT_VECTORS || scan_count != STANDARD_VECTOR_SIZE) {
 		scan_state.ScanToFlatVector(result, result_offset, start, scan_count);
 	} else {
 		scan_state.ScanToDictionaryVector(segment, result, result_offset, start, scan_count);


### PR DESCRIPTION
Hi,

This PR enables emitting Dictionary Vectors even if the start index is not aligned with `BITPACKING_ALGORITHM_GROUP_SIZE`. The logic is similar to `ScanToFlatVector` in the sense that it might read extra values and, at the end, it corrects the emitted selection vector.

When looking into the `Title` and `URL` column of Clickbench, I noticed that the number of Dictionary Vectors emitted was far less than I expected (~68% of the values are dictionary encoded in the URL column for example). With this change, the number of emitted Dictionary Vector is almost three times higher for the mentioned columns. Therefore, it results in less memory usage and better utilization of `TryAddCompressedGroups` in Aggregate HashTable.

Performance results for queries 33, 34, 36, 37, and 38 of Clickbench:
![emit_dict_comparison](https://github.com/user-attachments/assets/0a72c13f-33c2-4b11-8cf6-4ba01cd5d010)

The benchmark was ran on a MacBook Air M2, 16GB memory with 1 thread on 10% of the data. 

The most notable performance gain was for query 33 with 10-12% speedup as it contains no filtering and is a single column `GROUP BY`.

Are there any implicit behavior can be caused by this change? I have not encountered any so far.
Please let me know if you'd like me to adjust anything!

Thanks