### PR TITLE
Expose qualified table names in GetTableNames and add duckdb_get_table_names to C API

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -579,19 +579,20 @@ const StringUtil::EnumStringLiteral *GetBindingModeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(BindingMode::STANDARD_BINDING), "STANDARD_BINDING" },
 		{ static_cast<uint32_t>(BindingMode::EXTRACT_NAMES), "EXTRACT_NAMES" },
-		{ static_cast<uint32_t>(BindingMode::EXTRACT_REPLACEMENT_SCANS), "EXTRACT_REPLACEMENT_SCANS" }
+		{ static_cast<uint32_t>(BindingMode::EXTRACT_REPLACEMENT_SCANS), "EXTRACT_REPLACEMENT_SCANS" },
+		{ static_cast<uint32_t>(BindingMode::EXTRACT_QUALIFIED_NAMES), "EXTRACT_QUALIFIED_NAMES" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<BindingMode>(BindingMode value) {
-	return StringUtil::EnumToString(GetBindingModeValues(), 3, "BindingMode", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetBindingModeValues(), 4, "BindingMode", static_cast<uint32_t>(value));
 }
 
 template<>
 BindingMode EnumUtil::FromString<BindingMode>(const char *value) {
-	return static_cast<BindingMode>(StringUtil::StringToEnum(GetBindingModeValues(), 3, "BindingMode", value));
+	return static_cast<BindingMode>(StringUtil::StringToEnum(GetBindingModeValues(), 4, "BindingMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetBitpackingModeValues() {

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -841,6 +841,16 @@ Usually used for developing C extensions that must return this for a compatibili
 */
 DUCKDB_C_API const char *duckdb_library_version();
 
+/*!
+Get the list of (qualified) table names of the query.
+
+* @param connection The connection for which to get the table names.
+* @param query The query for which to get the table names.
+* @param qualified Returns qualified table names (catalog.schema.table), if set to true, else only the table names.
+* @return A duckdb_value of type VARCHAR[] containing the (qualified) table names of the query.
+*/
+DUCKDB_C_API duckdb_value duckdb_get_table_names(duckdb_connection connection, const char *query, bool qualified);
+
 //===--------------------------------------------------------------------===//
 // Configuration
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -842,14 +842,14 @@ Usually used for developing C extensions that must return this for a compatibili
 DUCKDB_C_API const char *duckdb_library_version();
 
 /*!
-Get the list of (qualified) table names of the query.
+Get the list of (fully qualified) table names of the query.
 
 * @param connection The connection for which to get the table names.
 * @param query The query for which to get the table names.
-* @param qualified Returns qualified, escaped table names (catalog.schema.table), if set to true, else only the (not
+* @param qualified Returns fully qualified table names (catalog.schema.table), if set to true, else only the (not
 escaped) table names.
-* @return A duckdb_value of type VARCHAR[] containing the (qualified) table names of the query. Must be destroyed with
-duckdb_destroy_value.
+* @return A duckdb_value of type VARCHAR[] containing the (fully qualified) table names of the query. Must be destroyed
+with duckdb_destroy_value.
 */
 DUCKDB_C_API duckdb_value duckdb_get_table_names(duckdb_connection connection, const char *query, bool qualified);
 

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -846,8 +846,10 @@ Get the list of (qualified) table names of the query.
 
 * @param connection The connection for which to get the table names.
 * @param query The query for which to get the table names.
-* @param qualified Returns qualified table names (catalog.schema.table), if set to true, else only the table names.
-* @return A duckdb_value of type VARCHAR[] containing the (qualified) table names of the query.
+* @param qualified Returns qualified, escaped table names (catalog.schema.table), if set to true, else only the (not
+escaped) table names.
+* @return A duckdb_value of type VARCHAR[] containing the (qualified) table names of the query. Must be destroyed with
+duckdb_destroy_value.
 */
 DUCKDB_C_API duckdb_value duckdb_get_table_names(duckdb_connection connection, const char *query, bool qualified);
 

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -476,6 +476,7 @@ typedef struct {
 	idx_t (*duckdb_client_context_get_connection_id)(duckdb_client_context context);
 	void (*duckdb_destroy_client_context)(duckdb_client_context *context);
 	void (*duckdb_connection_get_client_context)(duckdb_connection connection, duckdb_client_context *out_context);
+	duckdb_value (*duckdb_get_table_names)(duckdb_connection connection, const char *query, bool qualified);
 	// New functions around scalar function binding
 
 	void (*duckdb_scalar_function_set_bind)(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind);
@@ -920,6 +921,7 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_client_context_get_connection_id = duckdb_client_context_get_connection_id;
 	result.duckdb_destroy_client_context = duckdb_destroy_client_context;
 	result.duckdb_connection_get_client_context = duckdb_connection_get_client_context;
+	result.duckdb_get_table_names = duckdb_get_table_names;
 	result.duckdb_scalar_function_set_bind = duckdb_scalar_function_set_bind;
 	result.duckdb_scalar_function_bind_set_error = duckdb_scalar_function_bind_set_error;
 	result.duckdb_scalar_function_get_client_context = duckdb_scalar_function_get_client_context;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_open_connect_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_open_connect_functions.json
@@ -4,6 +4,7 @@
   "entries": [
     "duckdb_client_context_get_connection_id",
     "duckdb_destroy_client_context",
-    "duckdb_connection_get_client_context"
+    "duckdb_connection_get_client_context",
+    "duckdb_get_table_names"
   ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/open_connect.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/open_connect.json
@@ -267,6 +267,33 @@
             "comment": {
                 "description": "Returns the version of the linked DuckDB, with a version postfix for dev versions\n\nUsually used for developing C extensions that must return this for a compatibility check.\n"
             }
+        },
+        {
+            "name": "duckdb_get_table_names",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_connection",
+                    "name": "connection"
+                },
+                {
+                    "type": "const char *",
+                    "name": "query"
+                },
+                {
+                    "type": "bool",
+                    "name": "qualified"
+                }
+            ],
+            "comment": {
+                "description": "Get the list of (qualified) table names of the query.\n\n",
+                "param_comments": {
+                    "connection": "The connection for which to get the table names.",
+                    "query": "The query for which to get the table names.",
+                    "qualified": "Returns qualified table names (catalog.schema.table), if set to true, else only the table names."
+                },
+                "return_value": "A duckdb_value of type VARCHAR[] containing the (qualified) table names of the query.\nMust be destroyed with duckdb_destroy_value."
+            }
         }
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/open_connect.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/open_connect.json
@@ -290,9 +290,9 @@
                 "param_comments": {
                     "connection": "The connection for which to get the table names.",
                     "query": "The query for which to get the table names.",
-                    "qualified": "Returns qualified table names (catalog.schema.table), if set to true, else only the table names."
+                    "qualified": "Returns qualified, escaped table names (catalog.schema.table), if set to true, else only the (not escaped) table names."
                 },
-                "return_value": "A duckdb_value of type VARCHAR[] containing the (qualified) table names of the query.\nMust be destroyed with duckdb_destroy_value."
+                "return_value": "A duckdb_value of type VARCHAR[] containing the (qualified) table names of the query. Must be destroyed with duckdb_destroy_value."
             }
         }
     ]

--- a/src/include/duckdb/main/capi/header_generation/functions/open_connect.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/open_connect.json
@@ -286,13 +286,13 @@
                 }
             ],
             "comment": {
-                "description": "Get the list of (qualified) table names of the query.\n\n",
+                "description": "Get the list of (fully qualified) table names of the query.\n\n",
                 "param_comments": {
                     "connection": "The connection for which to get the table names.",
                     "query": "The query for which to get the table names.",
-                    "qualified": "Returns qualified, escaped table names (catalog.schema.table), if set to true, else only the (not escaped) table names."
+                    "qualified": "Returns fully qualified table names (catalog.schema.table), if set to true, else only the (not escaped) table names."
                 },
-                "return_value": "A duckdb_value of type VARCHAR[] containing the (qualified) table names of the query. Must be destroyed with duckdb_destroy_value."
+                "return_value": "A duckdb_value of type VARCHAR[] containing the (fully qualified) table names of the query. Must be destroyed with duckdb_destroy_value."
             }
         }
     ]

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -210,7 +210,7 @@ public:
 	connection_t GetConnectionId() const;
 
 	//! Fetch the set of tables names of the query.
-	//! Returns the qualified, escaped table names, if qualified is set to true,
+	//! Returns the fully qualified, escaped table names, if qualified is set to true,
 	//! else returns the not qualified, not escaped table names.
 	DUCKDB_API unordered_set<string> GetTableNames(const string &query, const bool qualified = false);
 

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -210,7 +210,7 @@ public:
 	connection_t GetConnectionId() const;
 
 	//! Fetch a list of table names that are required for a given query
-	DUCKDB_API unordered_set<string> GetTableNames(const string &query);
+	DUCKDB_API unordered_set<string> GetTableNames(const string &query, const bool qualified = false);
 
 	DUCKDB_API ClientProperties GetClientProperties();
 

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -209,7 +209,9 @@ public:
 
 	connection_t GetConnectionId() const;
 
-	//! Fetch a list of table names that are required for a given query
+	//! Fetch the set of tables names of the query.
+	//! Returns the qualified, escaped table names, if qualified is set to true,
+	//! else returns the not qualified, not escaped table names.
 	DUCKDB_API unordered_set<string> GetTableNames(const string &query, const bool qualified = false);
 
 	DUCKDB_API ClientProperties GetClientProperties();

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -179,7 +179,7 @@ public:
 	DUCKDB_API bool HasActiveTransaction();
 
 	//! Fetch a list of table names that are required for a given query
-	DUCKDB_API unordered_set<string> GetTableNames(const string &query);
+	DUCKDB_API unordered_set<string> GetTableNames(const string &query, const bool qualified = false);
 
 	// NOLINTBEGIN
 	template <typename TR, typename... ARGS>

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -179,7 +179,7 @@ public:
 	DUCKDB_API bool HasActiveTransaction();
 
 	//! Fetch the set of tables names of the query.
-	//! Returns the qualified, escaped table names, if qualified is set to true,
+	//! Returns the fully qualified, escaped table names, if qualified is set to true,
 	//! else returns the not qualified, not escaped table names.
 	DUCKDB_API unordered_set<string> GetTableNames(const string &query, const bool qualified = false);
 

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -178,7 +178,9 @@ public:
 	DUCKDB_API bool IsAutoCommit();
 	DUCKDB_API bool HasActiveTransaction();
 
-	//! Fetch a list of table names that are required for a given query
+	//! Fetch the set of tables names of the query.
+	//! Returns the qualified, escaped table names, if qualified is set to true,
+	//! else returns the not qualified, not escaped table names.
 	DUCKDB_API unordered_set<string> GetTableNames(const string &query, const bool qualified = false);
 
 	// NOLINTBEGIN

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -66,7 +66,12 @@ struct EntryLookupInfo;
 struct PivotColumnEntry;
 struct UnpivotEntry;
 
-enum class BindingMode : uint8_t { STANDARD_BINDING, EXTRACT_NAMES, EXTRACT_REPLACEMENT_SCANS };
+enum class BindingMode : uint8_t {
+	STANDARD_BINDING,
+	EXTRACT_NAMES,
+	EXTRACT_REPLACEMENT_SCANS,
+	EXTRACT_QUALIFIED_NAMES
+};
 enum class BinderType : uint8_t { REGULAR_BINDER, VIEW_BINDER };
 
 struct CorrelatedColumnInfo {
@@ -254,7 +259,7 @@ private:
 	optional_ptr<SQLStatement> root_statement;
 	//! Binding mode
 	BindingMode mode = BindingMode::STANDARD_BINDING;
-	//! Table names extracted for BindingMode::EXTRACT_NAMES
+	//! Table names extracted for BindingMode::EXTRACT_NAMES or BindingMode::EXTRACT_QUALIFIED_NAMES.
 	unordered_set<string> table_names;
 	//! Replacement Scans extracted for BindingMode::EXTRACT_REPLACEMENT_SCANS
 	case_insensitive_map_t<unique_ptr<TableRef>> replacement_scans;

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -547,6 +547,7 @@ typedef struct {
 	idx_t (*duckdb_client_context_get_connection_id)(duckdb_client_context context);
 	void (*duckdb_destroy_client_context)(duckdb_client_context *context);
 	void (*duckdb_connection_get_client_context)(duckdb_connection connection, duckdb_client_context *out_context);
+	duckdb_value (*duckdb_get_table_names)(duckdb_connection connection, const char *query, bool qualified);
 #endif
 
 // New functions around scalar function binding
@@ -1009,6 +1010,7 @@ typedef struct {
 #define duckdb_connection_get_client_context    duckdb_ext_api.duckdb_connection_get_client_context
 #define duckdb_client_context_get_connection_id duckdb_ext_api.duckdb_client_context_get_connection_id
 #define duckdb_destroy_client_context           duckdb_ext_api.duckdb_destroy_client_context
+#define duckdb_get_table_names                  duckdb_ext_api.duckdb_get_table_names
 
 // Version unstable_new_scalar_function_functions
 #define duckdb_scalar_function_set_bind           duckdb_ext_api.duckdb_scalar_function_set_bind

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1243,7 +1243,7 @@ void ClientContext::TryBindRelation(Relation &relation, vector<ColumnDefinition>
 	RunFunctionInTransaction([&]() { InternalTryBindRelation(relation, result_columns); });
 }
 
-unordered_set<string> ClientContext::GetTableNames(const string &query) {
+unordered_set<string> ClientContext::GetTableNames(const string &query, const bool qualified) {
 	auto lock = LockContext();
 
 	auto statements = ParseStatementsInternal(*lock, query);
@@ -1255,7 +1255,8 @@ unordered_set<string> ClientContext::GetTableNames(const string &query) {
 	RunFunctionInTransactionInternal(*lock, [&]() {
 		// bind the expressions
 		auto binder = Binder::CreateBinder(*this);
-		binder->SetBindingMode(BindingMode::EXTRACT_NAMES);
+		auto mode = qualified ? BindingMode::EXTRACT_QUALIFIED_NAMES : BindingMode::EXTRACT_NAMES;
+		binder->SetBindingMode(mode);
 		binder->Bind(*statements[0]);
 		result = binder->GetTableNames();
 	});

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -323,8 +323,8 @@ shared_ptr<Relation> Connection::ReadParquet(const string &parquet_file, bool bi
 	return TableFunction("parquet_scan", params, named_parameters)->Alias(parquet_file);
 }
 
-unordered_set<string> Connection::GetTableNames(const string &query) {
-	return context->GetTableNames(query);
+unordered_set<string> Connection::GetTableNames(const string &query, const bool qualified) {
+	return context->GetTableNames(query, qualified);
 }
 
 shared_ptr<Relation> Connection::RelationFromQuery(const string &query, const string &alias, const string &error) {

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -584,7 +584,8 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 		}
 	}
 
-	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES) {
+	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES ||
+	    binder.GetBindingMode() == BindingMode::EXTRACT_QUALIFIED_NAMES) {
 		//! We only care about extracting the names of the referenced columns
 		//! remove the exclude + replace lists
 		expr.exclude_list.clear();

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -505,7 +505,8 @@ BindResult ExpressionBinder::BindExpression(LambdaRefExpression &lambda_ref, idx
 }
 
 BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_t depth, bool root_expression) {
-	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES) {
+	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES ||
+	    binder.GetBindingMode() == BindingMode::EXTRACT_QUALIFIED_NAMES) {
 		return BindResult(make_uniq<BoundConstantExpression>(Value(LogicalType::SQLNULL)));
 	}
 

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -160,7 +160,8 @@ BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFu
 	if (error.HasError()) {
 		return BindResult(std::move(error));
 	}
-	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES) {
+	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES ||
+	    binder.GetBindingMode() == BindingMode::EXTRACT_QUALIFIED_NAMES) {
 		return BindResult(make_uniq<BoundConstantExpression>(Value(LogicalType::SQLNULL)));
 	}
 

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -234,17 +234,21 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 	auto table_or_view =
 	    entry_retriever.GetEntry(ref.catalog_name, ref.schema_name, table_lookup, OnEntryNotFound::RETURN_NULL);
 	// we still didn't find the table
-	if (GetBindingMode() == BindingMode::EXTRACT_NAMES) {
+	if (GetBindingMode() == BindingMode::EXTRACT_NAMES || GetBindingMode() == BindingMode::EXTRACT_QUALIFIED_NAMES) {
 		if (!table_or_view || table_or_view->type == CatalogType::TABLE_ENTRY) {
-			// if we are in EXTRACT_NAMES, we create a dummy table ref
-			AddTableName(ref.table_name);
+			// if we are in EXTRACT_NAMES or EXTRACT_QUALIFIED_NAMES, we create a dummy table ref
+			if (GetBindingMode() == BindingMode::EXTRACT_QUALIFIED_NAMES) {
+				AddTableName(ref.ToString());
+			} else {
+				AddTableName(ref.table_name);
+			}
 
 			// add a bind context entry
 			auto table_index = GenerateTableIndex();
-			auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
+			auto ref_alias = ref.alias.empty() ? ref.table_name : ref.alias;
 			vector<LogicalType> types {LogicalType::INTEGER};
 			vector<string> names {"__dummy_col" + to_string(table_index)};
-			bind_context.AddGenericBinding(table_index, alias, names, types);
+			bind_context.AddGenericBinding(table_index, ref_alias, names, types);
 			return make_uniq_base<BoundTableRef, BoundEmptyTableRef>(table_index);
 		}
 	}

--- a/test/api/capi/test_capi_table_description.cpp
+++ b/test/api/capi/test_capi_table_description.cpp
@@ -89,19 +89,20 @@ TEST_CASE("Test getting the table names of a query in the C API", "[capi]") {
 	tester.Query("CREATE TABLE \"schema.2\".\"table.2\"(i INT)");
 
 	string query = "SELECT * FROM schema1.\"table.1\", \"schema.2\".\"table.2\"";
-	auto table_names_value = duckdb_get_table_names(tester.connection, query.c_str(), true);
+	auto table_name_values = duckdb_get_table_names(tester.connection, query.c_str(), true);
 
-	duckdb::vector<string> expected_names = {"schema1.\"table.1\"", "\"schema.2\".\"table.2\""};
-	auto size = duckdb_get_list_size(table_names_value);
+	auto size = duckdb_get_list_size(table_name_values);
 	REQUIRE(size == 2);
+
+	duckdb::unordered_set<string> expected_names = {"schema1.\"table.1\"", "\"schema.2\".\"table.2\""};
 	for (idx_t i = 0; i < size; i++) {
-		auto name_value = duckdb_get_list_child(table_names_value, i);
+		auto name_value = duckdb_get_list_child(table_name_values, i);
 		auto name = duckdb_get_varchar(name_value);
-		REQUIRE(StringUtil::Equals(name, expected_names[i].c_str()));
+		REQUIRE(expected_names.count(name) == 1);
 		duckdb_free(name);
 		duckdb_destroy_value(&name_value);
 	}
 
-	duckdb_destroy_value(&table_names_value);
+	duckdb_destroy_value(&table_name_values);
 	tester.Cleanup();
 }

--- a/test/api/capi/test_capi_table_description.cpp
+++ b/test/api/capi/test_capi_table_description.cpp
@@ -103,4 +103,5 @@ TEST_CASE("Test getting the table names of a query in the C API", "[capi]") {
 	}
 
 	duckdb_destroy_value(&table_names_value);
+	tester.Cleanup();
 }


### PR DESCRIPTION
Related discussion here: https://github.com/duckdb/duckdb/discussions/11019.

As a follow-up to this PR, we can propagate the (optional) qualified boolean to the Python API.

Related issue: https://github.com/duckdblabs/duckdb-internal/issues/4158