### PR TITLE
DROP of missing entry should fail in binding

### DIFF
--- a/src/planner/binder/statement/bind_drop.cpp
+++ b/src/planner/binder/statement/bind_drop.cpp
@@ -41,8 +41,8 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 			properties.RegisterDBRead(*catalog, context);
 		}
 		EntryLookupInfo entry_lookup(stmt.info->type, stmt.info->name);
-		auto entry = Catalog::GetEntry(context, stmt.info->catalog, stmt.info->schema, entry_lookup,
-		                               OnEntryNotFound::RETURN_NULL);
+		auto entry =
+		    Catalog::GetEntry(context, stmt.info->catalog, stmt.info->schema, entry_lookup, stmt.info->if_not_found);
 		if (!entry) {
 			break;
 		}


### PR DESCRIPTION
`DROP` statements should fail during bind if we fail to find an entry. Only `DROP <CATALOG TYPE> IF NOT EXISTS` statements should be tolerant to missing entries.