### PR TITLE
Multi File Reader Rework (Part 19): Make `MultiFileReaderInterface` virtual, and move reading methods to the `BaseFileReader`

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -30,6 +30,7 @@ if (NOT MINGW)
             LOAD_TESTS DONT_LINK
             GIT_URL https://github.com/duckdb/duckdb-avro
             GIT_TAG 712514078247b4b71f51d0c9eb862bec3928742c
+            APPLY_PATCHES
     )
 endif()
 

--- a/.github/patches/extensions/avro/fix.patch
+++ b/.github/patches/extensions/avro/fix.patch
@@ -1,0 +1,260 @@
+diff --git a/src/avro_multi_file_info.cpp b/src/avro_multi_file_info.cpp
+index b8b358c..3f63e95 100644
+--- a/src/avro_multi_file_info.cpp
++++ b/src/avro_multi_file_info.cpp
+@@ -21,11 +21,6 @@ bool AvroMultiFileInfo::ParseOption(ClientContext &context, const string &key, c
+ 	return false;
+ }
+ 
+-void AvroMultiFileInfo::FinalizeCopyBind(ClientContext &context, BaseFileReaderOptions &options_p,
+-                                         const vector<string> &expected_names,
+-                                         const vector<LogicalType> &expected_types) {
+-}
+-
+ struct AvroMultiFileData final : public TableFunctionData {
+ public:
+ 	AvroMultiFileData() = default;
+@@ -42,16 +37,10 @@ void AvroMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &
+ 	if (bind_data.file_options.union_by_name) {
+ 		throw NotImplementedException("'union_by_name' not implemented for Avro reader yet");
+ 	}
+-	bind_data.reader_bind = bind_data.multi_file_reader->BindReader<AvroMultiFileInfo>( context, return_types, names, *bind_data.file_list, bind_data, options, bind_data.file_options);
++	bind_data.reader_bind = bind_data.multi_file_reader->BindReader( context, return_types, names, *bind_data.file_list, bind_data, options, bind_data.file_options);
+ 	D_ASSERT(names.size() == return_types.size());
+ }
+ 
+-void AvroMultiFileInfo::FinalizeBindData(MultiFileBindData &multi_file_data) {
+-}
+-
+-void AvroMultiFileInfo::GetBindInfo(const TableFunctionData &bind_data, BindInfo &info) {
+-}
+-
+ optional_idx AvroMultiFileInfo::MaxThreads(const MultiFileBindData &bind_data_p,
+                                            const MultiFileGlobalState &global_state, FileExpandResult expand_result) {
+ 	if (expand_result == FileExpandResult::MULTIPLE_FILES) {
+@@ -106,47 +95,29 @@ shared_ptr<BaseFileReader> AvroMultiFileInfo::CreateReader(ClientContext &contex
+ }
+ 
+ shared_ptr<BaseFileReader> AvroMultiFileInfo::CreateReader(ClientContext &context, const OpenFileInfo &file,
+-                                                           AvroFileReaderOptions &options,
++                                                           BaseFileReaderOptions &options,
+                                                            const MultiFileOptions &file_options) {
+ 	return make_shared_ptr<AvroReader>(context, file.path);
+ }
+ 
+-shared_ptr<BaseUnionData> AvroMultiFileInfo::GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx) {
+-	throw NotImplementedException("'union_by_name' is not implemented");
+-}
+-
+-void AvroMultiFileInfo::FinalizeReader(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &) {
+-}
+-
+-bool AvroMultiFileInfo::TryInitializeScan(ClientContext &context, const shared_ptr<BaseFileReader> &reader_p,
++bool AvroReader::TryInitializeScan(ClientContext &context,
+                                           GlobalTableFunctionState &gstate_p, LocalTableFunctionState &lstate_p) {
+ 	auto &gstate = gstate_p.Cast<AvroFileGlobalState>();
+ 	auto &lstate = lstate_p.Cast<AvroFileLocalState>();
+-	auto &reader = reader_p->Cast<AvroReader>();
+-	if (gstate.files.count(reader.file_list_idx.GetIndex())) {
++	if (gstate.files.count(file_list_idx.GetIndex())) {
+ 		// Return false because we don't currently support more than one thread
+ 		// scanning a file.
+ 		return false;
+ 	}
+-	gstate.files.insert(reader.file_list_idx.GetIndex());
+-	lstate.file_scan = shared_ptr_cast<BaseFileReader, AvroReader>(reader_p);
++	gstate.files.insert(file_list_idx.GetIndex());
++	throw InternalException("FIXME: CAST");
++//	lstate.file_scan = shared_ptr_cast<BaseFileReader, AvroReader>(shared_from_this());
+ 	return true;
+ }
+ 
+-void AvroMultiFileInfo::Scan(ClientContext &context, BaseFileReader &reader_p, GlobalTableFunctionState &global_state,
++void AvroReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                              LocalTableFunctionState &local_state_p, DataChunk &chunk) {
+-	auto &reader = reader_p.Cast<AvroReader>();
+-	reader.Read(chunk);
+-}
+-
+-void AvroMultiFileInfo::FinishFile(ClientContext &context, GlobalTableFunctionState &global_state,
+-                                   BaseFileReader &reader) {
+-	//! FIXME: this is where the state of the current file being read would be reset
+-	//! once we support parallelizing over a single file.
+-}
+-
+-void AvroMultiFileInfo::FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
+-                                      LocalTableFunctionState &local_state) {
++	Read(chunk);
+ }
+ 
+ unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) {
+@@ -154,17 +125,4 @@ unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBind
+ 	return make_uniq<NodeStatistics>();
+ }
+ 
+-unique_ptr<BaseStatistics> AvroMultiFileInfo::GetStatistics(ClientContext &context, BaseFileReader &reader,
+-                                                            const string &name) {
+-	return nullptr;
+-}
+-
+-double AvroMultiFileInfo::GetProgressInFile(ClientContext &context, const BaseFileReader &reader) {
+-	//! TODO: interrogate the avro reader to figure out the progress of the memory reader
+-	return 0;
+-}
+-
+-void AvroMultiFileInfo::GetVirtualColumns(ClientContext &, MultiFileBindData &, virtual_column_map_t &result) {
+-}
+-
+ } // namespace duckdb
+diff --git a/src/include/avro_multi_file_info.hpp b/src/include/avro_multi_file_info.hpp
+index 4ae1d21..2abf87e 100644
+--- a/src/include/avro_multi_file_info.hpp
++++ b/src/include/avro_multi_file_info.hpp
+@@ -15,74 +15,48 @@ namespace duckdb {
+ //! We might have avro specific options one day
+ class AvroFileReaderOptions : public BaseFileReaderOptions {};
+ 
+-struct AvroMultiFileInfo {
+-	static unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
+-	                                                           optional_ptr<TableFunctionInfo> info);
++struct AvroMultiFileInfo : MultiFileReaderInterface {
++	static unique_ptr<MultiFileReaderInterface> InitializeInterface(ClientContext &context, MultiFileReader &reader,
++																	MultiFileList &file_list);
+ 
+-	static bool ParseCopyOption(ClientContext &context, const string &key, const vector<Value> &values,
++	unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
++	                                                           optional_ptr<TableFunctionInfo> info) override;
++	bool ParseCopyOption(ClientContext &context, const string &key, const vector<Value> &values,
+ 	                            BaseFileReaderOptions &options, vector<string> &expected_names,
+-	                            vector<LogicalType> &expected_types);
++	                            vector<LogicalType> &expected_types) override;
+ 
+-	static bool ParseOption(ClientContext &context, const string &key, const Value &val, MultiFileOptions &file_options,
+-	                        BaseFileReaderOptions &options);
++	bool ParseOption(ClientContext &context, const string &key, const Value &val, MultiFileOptions &file_options,
++	                        BaseFileReaderOptions &options) override;
+ 
+-	static void FinalizeCopyBind(ClientContext &context, BaseFileReaderOptions &options,
+-	                             const vector<string> &expected_names, const vector<LogicalType> &expected_types);
+-
+-	static unique_ptr<TableFunctionData> InitializeBindData(MultiFileBindData &multi_file_data,
+-	                                                        unique_ptr<BaseFileReaderOptions> options);
++	unique_ptr<TableFunctionData> InitializeBindData(MultiFileBindData &multi_file_data,
++	                                                        unique_ptr<BaseFileReaderOptions> options) override;
+ 
+ 	//! This is where the actual binding must happen, so in this function we either:
+ 	//! 1. union_by_name = False. We set the schema/name depending on the first file
+ 	//! 2. union_by_name = True.
+-	static void BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,
+-	                       MultiFileBindData &bind_data);
+-
+-	static void FinalizeBindData(MultiFileBindData &multi_file_data);
+-
+-	static void GetBindInfo(const TableFunctionData &bind_data, BindInfo &info);
++	void BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,
++	                       MultiFileBindData &bind_data) override;
+ 
+-	static optional_idx MaxThreads(const MultiFileBindData &bind_data_p, const MultiFileGlobalState &global_state,
+-	                               FileExpandResult expand_result);
++	optional_idx MaxThreads(const MultiFileBindData &bind_data_p, const MultiFileGlobalState &global_state,
++	                               FileExpandResult expand_result) override;
+ 
+-	static unique_ptr<GlobalTableFunctionState>
+-	InitializeGlobalState(ClientContext &context, MultiFileBindData &bind_data, MultiFileGlobalState &global_state);
++	unique_ptr<GlobalTableFunctionState>
++	InitializeGlobalState(ClientContext &context, MultiFileBindData &bind_data, MultiFileGlobalState &global_state) override;
+ 
+-	static unique_ptr<LocalTableFunctionState> InitializeLocalState(ExecutionContext &context,
+-	                                                                GlobalTableFunctionState &function_state);
++	unique_ptr<LocalTableFunctionState> InitializeLocalState(ExecutionContext &context,
++	                                                                GlobalTableFunctionState &function_state) override;
+ 
+-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
+-	                                               BaseUnionData &union_data, const MultiFileBindData &bind_data_p);
++	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
++	                                               BaseUnionData &union_data, const MultiFileBindData &bind_data_p) override;
+ 
+-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
++	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
+ 	                                               const OpenFileInfo &file, idx_t file_idx,
+-	                                               const MultiFileBindData &bind_data);
+-
+-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
+-	                                               AvroFileReaderOptions &options, const MultiFileOptions &file_options);
+-
+-	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
+-
+-	static void FinalizeReader(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &);
+-
+-	static bool TryInitializeScan(ClientContext &context, const shared_ptr<BaseFileReader> &reader,
+-	                              GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
+-
+-	static void Scan(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &global_state,
+-	                 LocalTableFunctionState &local_state, DataChunk &chunk);
+-
+-	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);
+-
+-	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
+-	                          LocalTableFunctionState &local_state);
+-
+-	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);
+-
+-	static unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, BaseFileReader &reader, const string &name);
++	                                               const MultiFileBindData &bind_data) override;
+ 
+-	static double GetProgressInFile(ClientContext &context, const BaseFileReader &reader);
++	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
++	                                        BaseFileReaderOptions &options, const MultiFileOptions &file_options) override;
+ 
+-	static void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
++	unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) override;
+ };
+ 
+ } // namespace duckdb
+diff --git a/src/include/avro_reader.hpp b/src/include/avro_reader.hpp
+index 5d731c4..dd347f6 100644
+--- a/src/include/avro_reader.hpp
++++ b/src/include/avro_reader.hpp
+@@ -6,29 +6,7 @@
+ 
+ namespace duckdb {
+ 
+-struct AvroReader;
+-
+-// this is just a dummy to make the multi file reader compile
+-struct AvroUnionData {
+-public:
+-	AvroUnionData() {
+-		throw InternalException("union_by_name not supported");
+-	}
+-
+-public:
+-	const string &GetFileName() {
+-		return file_name;
+-	}
+-
+-public:
+-	string file_name;
+-	vector<string> names;
+-	vector<LogicalType> types;
+-	// AvroOptions options;
+-	unique_ptr<AvroReader> reader;
+-};
+-
+-struct AvroReader : public BaseFileReader {
++class AvroReader : public BaseFileReader {
+ public:
+ 	AvroReader(ClientContext &context, const string filename_p);
+ 
+@@ -43,6 +21,11 @@ public:
+ 		return "Avro";
+ 	}
+ 
++	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
++								   LocalTableFunctionState &lstate) override;
++	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
++					  LocalTableFunctionState &local_state, DataChunk &chunk) override;
++
+ public:
+ 	avro_file_reader_t reader;
+ 	avro_value_t value;

--- a/.github/patches/extensions/avro/fix.patch
+++ b/.github/patches/extensions/avro/fix.patch
@@ -1,8 +1,20 @@
 diff --git a/src/avro_multi_file_info.cpp b/src/avro_multi_file_info.cpp
-index b8b358c..3f63e95 100644
+index b8b358c..9e105f4 100644
 --- a/src/avro_multi_file_info.cpp
 +++ b/src/avro_multi_file_info.cpp
-@@ -21,11 +21,6 @@ bool AvroMultiFileInfo::ParseOption(ClientContext &context, const string &key, c
+@@ -3,6 +3,11 @@
+ 
+ namespace duckdb {
+ 
++unique_ptr<MultiFileReaderInterface> AvroMultiFileInfo::InitializeInterface(ClientContext &context, MultiFileReader &reader,
++																MultiFileList &file_list) {
++	return make_uniq<AvroMultiFileInfo>();
++}
++
+ unique_ptr<BaseFileReaderOptions> AvroMultiFileInfo::InitializeOptions(ClientContext &context,
+                                                                        optional_ptr<TableFunctionInfo> info) {
+ 	return make_uniq<AvroFileReaderOptions>();
+@@ -21,11 +26,6 @@ bool AvroMultiFileInfo::ParseOption(ClientContext &context, const string &key, c
  	return false;
  }
  
@@ -14,7 +26,7 @@ index b8b358c..3f63e95 100644
  struct AvroMultiFileData final : public TableFunctionData {
  public:
  	AvroMultiFileData() = default;
-@@ -42,16 +37,10 @@ void AvroMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &
+@@ -42,16 +42,10 @@ void AvroMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &
  	if (bind_data.file_options.union_by_name) {
  		throw NotImplementedException("'union_by_name' not implemented for Avro reader yet");
  	}
@@ -32,7 +44,7 @@ index b8b358c..3f63e95 100644
  optional_idx AvroMultiFileInfo::MaxThreads(const MultiFileBindData &bind_data_p,
                                             const MultiFileGlobalState &global_state, FileExpandResult expand_result) {
  	if (expand_result == FileExpandResult::MULTIPLE_FILES) {
-@@ -106,47 +95,29 @@ shared_ptr<BaseFileReader> AvroMultiFileInfo::CreateReader(ClientContext &contex
+@@ -106,47 +100,29 @@ shared_ptr<BaseFileReader> AvroMultiFileInfo::CreateReader(ClientContext &contex
  }
  
  shared_ptr<BaseFileReader> AvroMultiFileInfo::CreateReader(ClientContext &context, const OpenFileInfo &file,
@@ -88,7 +100,7 @@ index b8b358c..3f63e95 100644
  }
  
  unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) {
-@@ -154,17 +125,4 @@ unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBind
+@@ -154,17 +130,4 @@ unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBind
  	return make_uniq<NodeStatistics>();
  }
  

--- a/.github/patches/extensions/avro/fix.patch
+++ b/.github/patches/extensions/avro/fix.patch
@@ -1,5 +1,5 @@
 diff --git a/src/avro_multi_file_info.cpp b/src/avro_multi_file_info.cpp
-index b8b358c..9e105f4 100644
+index b8b358c..756202e 100644
 --- a/src/avro_multi_file_info.cpp
 +++ b/src/avro_multi_file_info.cpp
 @@ -3,6 +3,11 @@
@@ -44,7 +44,7 @@ index b8b358c..9e105f4 100644
  optional_idx AvroMultiFileInfo::MaxThreads(const MultiFileBindData &bind_data_p,
                                             const MultiFileGlobalState &global_state, FileExpandResult expand_result) {
  	if (expand_result == FileExpandResult::MULTIPLE_FILES) {
-@@ -106,47 +100,29 @@ shared_ptr<BaseFileReader> AvroMultiFileInfo::CreateReader(ClientContext &contex
+@@ -106,47 +100,28 @@ shared_ptr<BaseFileReader> AvroMultiFileInfo::CreateReader(ClientContext &contex
  }
  
  shared_ptr<BaseFileReader> AvroMultiFileInfo::CreateReader(ClientContext &context, const OpenFileInfo &file,
@@ -76,8 +76,7 @@ index b8b358c..9e105f4 100644
 -	gstate.files.insert(reader.file_list_idx.GetIndex());
 -	lstate.file_scan = shared_ptr_cast<BaseFileReader, AvroReader>(reader_p);
 +	gstate.files.insert(file_list_idx.GetIndex());
-+	throw InternalException("FIXME: CAST");
-+//	lstate.file_scan = shared_ptr_cast<BaseFileReader, AvroReader>(shared_from_this());
++	lstate.file_scan = shared_ptr_cast<BaseFileReader, AvroReader>(shared_from_this());
  	return true;
  }
  
@@ -100,7 +99,7 @@ index b8b358c..9e105f4 100644
  }
  
  unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) {
-@@ -154,17 +130,4 @@ unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBind
+@@ -154,17 +129,4 @@ unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBind
  	return make_uniq<NodeStatistics>();
  }
  

--- a/extension/json/include/json_multi_file_info.hpp
+++ b/extension/json/include/json_multi_file_info.hpp
@@ -51,8 +51,6 @@ struct JSONMultiFileInfo {
 	static void FinalizeReader(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &gstate_p);
 	static bool TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
 	                              GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
-	static void Scan(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &global_state,
-	                 LocalTableFunctionState &local_state, DataChunk &chunk);
 	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);

--- a/extension/json/include/json_multi_file_info.hpp
+++ b/extension/json/include/json_multi_file_info.hpp
@@ -18,9 +18,11 @@ public:
 	JSONReaderOptions options;
 };
 
-struct JSONMultiFileInfo {
-	static unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
-	                                                           optional_ptr<TableFunctionInfo> info);
+struct JSONMultiFileInfo : public MultiFileReaderInterface {
+	static unique_ptr<MultiFileReaderInterface> InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list);
+
+	unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
+	                                                           optional_ptr<TableFunctionInfo> info) override;
 	static bool ParseCopyOption(ClientContext &context, const string &key, const vector<Value> &values,
 	                            BaseFileReaderOptions &options, vector<string> &expected_names,
 	                            vector<LogicalType> &expected_types);

--- a/extension/json/include/json_multi_file_info.hpp
+++ b/extension/json/include/json_multi_file_info.hpp
@@ -48,8 +48,6 @@ struct JSONMultiFileInfo {
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               JSONReaderOptions &options, const MultiFileOptions &file_options);
 	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
-	static bool TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
-	                              GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
 	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);

--- a/extension/json/include/json_multi_file_info.hpp
+++ b/extension/json/include/json_multi_file_info.hpp
@@ -48,7 +48,6 @@ struct JSONMultiFileInfo {
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               JSONReaderOptions &options, const MultiFileOptions &file_options);
 	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
-	static void FinalizeReader(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &gstate_p);
 	static bool TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
 	                              GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
 	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);

--- a/extension/json/include/json_multi_file_info.hpp
+++ b/extension/json/include/json_multi_file_info.hpp
@@ -51,7 +51,6 @@ struct JSONMultiFileInfo {
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);
-	static unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, BaseFileReader &reader, const string &name);
 	static void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
 };
 

--- a/extension/json/include/json_multi_file_info.hpp
+++ b/extension/json/include/json_multi_file_info.hpp
@@ -47,7 +47,6 @@ struct JSONMultiFileInfo {
 	                                               const MultiFileBindData &bind_data);
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               JSONReaderOptions &options, const MultiFileOptions &file_options);
-	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);

--- a/extension/json/include/json_multi_file_info.hpp
+++ b/extension/json/include/json_multi_file_info.hpp
@@ -52,7 +52,6 @@ struct JSONMultiFileInfo {
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);
 	static unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, BaseFileReader &reader, const string &name);
-	static double GetProgressInFile(ClientContext &context, const BaseFileReader &reader);
 	static void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
 };
 

--- a/extension/json/include/json_multi_file_info.hpp
+++ b/extension/json/include/json_multi_file_info.hpp
@@ -18,41 +18,37 @@ public:
 	JSONReaderOptions options;
 };
 
-struct JSONMultiFileInfo : public MultiFileReaderInterface {
-	static unique_ptr<MultiFileReaderInterface> InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list);
+struct JSONMultiFileInfo : MultiFileReaderInterface {
+	static unique_ptr<MultiFileReaderInterface> InitializeInterface(ClientContext &context, MultiFileReader &reader,
+	                                                                MultiFileList &file_list);
 
 	unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
-	                                                           optional_ptr<TableFunctionInfo> info) override;
-	static bool ParseCopyOption(ClientContext &context, const string &key, const vector<Value> &values,
-	                            BaseFileReaderOptions &options, vector<string> &expected_names,
-	                            vector<LogicalType> &expected_types);
-	static bool ParseOption(ClientContext &context, const string &key, const Value &val, MultiFileOptions &file_options,
-	                        BaseFileReaderOptions &options);
-	static void FinalizeCopyBind(ClientContext &context, BaseFileReaderOptions &options,
-	                             const vector<string> &expected_names, const vector<LogicalType> &expected_types);
-	static unique_ptr<TableFunctionData> InitializeBindData(MultiFileBindData &multi_file_data,
-	                                                        unique_ptr<BaseFileReaderOptions> options);
-	static void BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,
-	                       MultiFileBindData &bind_data);
-	static void FinalizeBindData(MultiFileBindData &multi_file_data);
-	static void GetBindInfo(const TableFunctionData &bind_data, BindInfo &info);
-	static optional_idx MaxThreads(const MultiFileBindData &bind_data, const MultiFileGlobalState &global_state,
-	                               FileExpandResult expand_result);
-	static unique_ptr<GlobalTableFunctionState>
-	InitializeGlobalState(ClientContext &context, MultiFileBindData &bind_data, MultiFileGlobalState &global_state);
-	static unique_ptr<LocalTableFunctionState> InitializeLocalState(ExecutionContext &context,
-	                                                                GlobalTableFunctionState &global_state);
-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
-	                                               BaseUnionData &union_data, const MultiFileBindData &bind_data_p);
-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
-	                                               const OpenFileInfo &file, idx_t file_idx,
-	                                               const MultiFileBindData &bind_data);
-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
-	                                               JSONReaderOptions &options, const MultiFileOptions &file_options);
-	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
-	                          LocalTableFunctionState &local_state);
-	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);
-	static void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
+	                                                    optional_ptr<TableFunctionInfo> info) override;
+	bool ParseCopyOption(ClientContext &context, const string &key, const vector<Value> &values,
+	                     BaseFileReaderOptions &options, vector<string> &expected_names,
+	                     vector<LogicalType> &expected_types) override;
+	bool ParseOption(ClientContext &context, const string &key, const Value &val, MultiFileOptions &file_options,
+	                 BaseFileReaderOptions &options) override;
+	void FinalizeCopyBind(ClientContext &context, BaseFileReaderOptions &options, const vector<string> &expected_names,
+	                      const vector<LogicalType> &expected_types) override;
+	unique_ptr<TableFunctionData> InitializeBindData(MultiFileBindData &multi_file_data,
+	                                                 unique_ptr<BaseFileReaderOptions> options) override;
+	void BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,
+	                MultiFileBindData &bind_data) override;
+	optional_idx MaxThreads(const MultiFileBindData &bind_data, const MultiFileGlobalState &global_state,
+	                        FileExpandResult expand_result) override;
+	unique_ptr<GlobalTableFunctionState> InitializeGlobalState(ClientContext &context, MultiFileBindData &bind_data,
+	                                                           MultiFileGlobalState &global_state) override;
+	unique_ptr<LocalTableFunctionState> InitializeLocalState(ExecutionContext &context,
+	                                                         GlobalTableFunctionState &global_state) override;
+	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
+	                                        BaseUnionData &union_data, const MultiFileBindData &bind_data_p) override;
+	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
+	                                        const OpenFileInfo &file, idx_t file_idx,
+	                                        const MultiFileBindData &bind_data) override;
+	void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
+	                   LocalTableFunctionState &local_state) override;
+	unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) override;
 };
 
 } // namespace duckdb

--- a/extension/json/include/json_multi_file_info.hpp
+++ b/extension/json/include/json_multi_file_info.hpp
@@ -48,7 +48,6 @@ struct JSONMultiFileInfo {
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               JSONReaderOptions &options, const MultiFileOptions &file_options);
 	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
-	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);

--- a/extension/json/include/json_reader.hpp
+++ b/extension/json/include/json_reader.hpp
@@ -210,6 +210,7 @@ public:
 	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
+	double GetProgressInFile(ClientContext &context) override;
 
 public:
 	//! Get a new buffer index (must hold the lock)

--- a/extension/json/include/json_reader.hpp
+++ b/extension/json/include/json_reader.hpp
@@ -205,9 +205,10 @@ public:
 		return "JSON";
 	}
 
+	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
+	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate) override;
 	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
-	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
 
 public:
 	//! Get a new buffer index (must hold the lock)

--- a/extension/json/include/json_reader.hpp
+++ b/extension/json/include/json_reader.hpp
@@ -201,6 +201,13 @@ public:
 	JSONFileHandle &GetFileHandle() const;
 
 public:
+	string GetReaderType() const override {
+		return "JSON";
+	}
+
+	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+public:
 	//! Get a new buffer index (must hold the lock)
 	idx_t GetBufferIndex();
 	//! Set line count for a buffer that is done (grabs the lock)
@@ -226,10 +233,6 @@ public:
 	double GetProgress() const;
 
 	void DecrementBufferUsage(JSONBufferHandle &handle, idx_t lines_or_object_in_buffer, AllocatedData &buffer);
-
-	string GetReaderType() const override {
-		return "JSON";
-	}
 
 private:
 	void SkipOverArrayStart(JSONReaderScanState &scan_state);

--- a/extension/json/include/json_reader.hpp
+++ b/extension/json/include/json_reader.hpp
@@ -209,6 +209,7 @@ public:
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate) override;
 	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 
 public:
 	//! Get a new buffer index (must hold the lock)

--- a/extension/json/include/json_reader.hpp
+++ b/extension/json/include/json_reader.hpp
@@ -206,9 +206,10 @@ public:
 	}
 
 	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
-	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
+	                       LocalTableFunctionState &lstate) override;
+	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
+	          DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 

--- a/extension/json/include/json_reader.hpp
+++ b/extension/json/include/json_reader.hpp
@@ -207,6 +207,8 @@ public:
 
 	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
+
 public:
 	//! Get a new buffer index (must hold the lock)
 	idx_t GetBufferIndex();

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -4,6 +4,10 @@
 
 namespace duckdb {
 
+unique_ptr<MultiFileReaderInterface> JSONMultiFileInfo::InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list) {
+	return make_uniq<JSONMultiFileInfo>();
+}
+
 unique_ptr<BaseFileReaderOptions> JSONMultiFileInfo::InitializeOptions(ClientContext &context,
                                                                        optional_ptr<TableFunctionInfo> info) {
 	auto reader_options = make_uniq<JSONFileReaderOptions>();

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -455,8 +455,8 @@ void JSONReader::PrepareReader(ClientContext &context, GlobalTableFunctionState 
 	}
 }
 
-bool JSONReader::TryInitializeScan(ClientContext &context,
-                                          GlobalTableFunctionState &gstate_p, LocalTableFunctionState &lstate_p) {
+bool JSONReader::TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+                                   LocalTableFunctionState &lstate_p) {
 	auto &gstate = gstate_p.Cast<JSONGlobalTableFunctionState>().state;
 	auto &lstate = lstate_p.Cast<JSONLocalTableFunctionState>().state;
 
@@ -535,7 +535,7 @@ void ReadJSONObjectsFunction(ClientContext &context, JSONReader &json_reader, JS
 }
 
 void JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-                             LocalTableFunctionState &local_state, DataChunk &output) {
+                      LocalTableFunctionState &local_state, DataChunk &output) {
 	auto &gstate = global_state.Cast<JSONGlobalTableFunctionState>().state;
 	auto &lstate = local_state.Cast<JSONLocalTableFunctionState>().state;
 	auto &json_data = gstate.bind_data.bind_data->Cast<JSONScanData>();

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -456,14 +456,13 @@ void JSONReader::PrepareReader(ClientContext &context, GlobalTableFunctionState 
 	}
 }
 
-bool JSONMultiFileInfo::TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
+bool JSONReader::TryInitializeScan(ClientContext &context,
                                           GlobalTableFunctionState &gstate_p, LocalTableFunctionState &lstate_p) {
 	auto &gstate = gstate_p.Cast<JSONGlobalTableFunctionState>().state;
 	auto &lstate = lstate_p.Cast<JSONLocalTableFunctionState>().state;
-	auto &json_reader = reader->Cast<JSONReader>();
 
 	lstate.GetScanState().ResetForNextBuffer();
-	return lstate.TryInitializeScan(gstate, json_reader);
+	return lstate.TryInitializeScan(gstate, *this);
 }
 
 void ReadJSONFunction(ClientContext &context, JSONReader &json_reader, JSONScanGlobalState &gstate,

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -552,8 +552,7 @@ void JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &global_s
 	}
 }
 
-void JSONMultiFileInfo::FinishFile(ClientContext &context, GlobalTableFunctionState &global_state,
-                                   BaseFileReader &reader) {
+void JSONReader::FinishFile(ClientContext &context, GlobalTableFunctionState &global_state) {
 	auto &gstate = global_state.Cast<JSONGlobalTableFunctionState>().state;
 	gstate.file_is_assigned = false;
 }

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -4,7 +4,8 @@
 
 namespace duckdb {
 
-unique_ptr<MultiFileReaderInterface> JSONMultiFileInfo::InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list) {
+unique_ptr<MultiFileReaderInterface>
+JSONMultiFileInfo::InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list) {
 	return make_uniq<JSONMultiFileInfo>();
 }
 
@@ -356,9 +357,6 @@ void JSONMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &
 	}
 }
 
-void JSONMultiFileInfo::FinalizeBindData(MultiFileBindData &multi_file_data) {
-}
-
 void JSONMultiFileInfo::FinalizeCopyBind(ClientContext &context, BaseFileReaderOptions &options_p,
                                          const vector<string> &expected_names,
                                          const vector<LogicalType> &expected_types) {
@@ -444,11 +442,6 @@ shared_ptr<BaseFileReader> JSONMultiFileInfo::CreateReader(ClientContext &contex
 	auto reader = make_shared_ptr<JSONReader>(context, json_data.options, file.path);
 	reader->columns = MultiFileColumnDefinition::ColumnsFromNamesAndTypes(bind_data.names, bind_data.types);
 	return std::move(reader);
-}
-shared_ptr<BaseFileReader> JSONMultiFileInfo::CreateReader(ClientContext &context, const OpenFileInfo &file,
-                                                           JSONReaderOptions &options,
-                                                           const MultiFileOptions &file_options) {
-	throw InternalException("Create reader from file not implemented");
 }
 
 void JSONReader::PrepareReader(ClientContext &context, GlobalTableFunctionState &gstate_p) {
@@ -566,9 +559,6 @@ void JSONMultiFileInfo::FinishReading(ClientContext &context, GlobalTableFunctio
 	lstate.GetScanState().ResetForNextBuffer();
 }
 
-void JSONMultiFileInfo::GetBindInfo(const TableFunctionData &bind_data, BindInfo &info) {
-}
-
 unique_ptr<NodeStatistics> JSONMultiFileInfo::GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) {
 	auto &json_data = bind_data.bind_data->Cast<JSONScanData>();
 	idx_t per_file_cardinality = 42;
@@ -577,10 +567,6 @@ unique_ptr<NodeStatistics> JSONMultiFileInfo::GetCardinality(const MultiFileBind
 		per_file_cardinality = json_data.estimated_cardinality_per_file.GetIndex();
 	}
 	return make_uniq<NodeStatistics>(per_file_cardinality * file_count);
-}
-
-void JSONMultiFileInfo::GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data,
-                                          virtual_column_map_t &result) {
 }
 
 optional_idx JSONMultiFileInfo::MaxThreads(const MultiFileBindData &bind_data, const MultiFileGlobalState &global_state,

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -448,13 +448,11 @@ shared_ptr<BaseFileReader> JSONMultiFileInfo::CreateReader(ClientContext &contex
 	throw InternalException("Create reader from file not implemented");
 }
 
-void JSONMultiFileInfo::FinalizeReader(ClientContext &context, BaseFileReader &reader_p,
-                                       GlobalTableFunctionState &gstate_p) {
-	auto &reader = reader_p.Cast<JSONReader>();
+void JSONReader::PrepareReader(ClientContext &context, GlobalTableFunctionState &gstate_p) {
 	auto &gstate = gstate_p.Cast<JSONGlobalTableFunctionState>().state;
 	if (gstate.enable_parallel_scans) {
 		// if we are doing parallel scans we need to open the file here
-		reader.Initialize(gstate.allocator, gstate.buffer_capacity);
+		Initialize(gstate.allocator, gstate.buffer_capacity);
 	}
 }
 

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -420,9 +420,8 @@ unique_ptr<LocalTableFunctionState> JSONMultiFileInfo::InitializeLocalState(Exec
 	return std::move(result);
 }
 
-double JSONMultiFileInfo::GetProgressInFile(ClientContext &context, const BaseFileReader &reader) {
-	auto &json_reader = reader.Cast<JSONReader>();
-	return json_reader.GetProgress();
+double JSONReader::GetProgressInFile(ClientContext &context) {
+	return GetProgress();
 }
 
 shared_ptr<BaseFileReader> JSONMultiFileInfo::CreateReader(ClientContext &context, GlobalTableFunctionState &gstate_p,

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -538,18 +538,17 @@ void ReadJSONObjectsFunction(ClientContext &context, JSONReader &json_reader, JS
 	output.SetCardinality(count);
 }
 
-void JSONMultiFileInfo::Scan(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &global_state,
+void JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
                              LocalTableFunctionState &local_state, DataChunk &output) {
 	auto &gstate = global_state.Cast<JSONGlobalTableFunctionState>().state;
 	auto &lstate = local_state.Cast<JSONLocalTableFunctionState>().state;
 	auto &json_data = gstate.bind_data.bind_data->Cast<JSONScanData>();
-	auto &json_reader = reader.Cast<JSONReader>();
 	switch (json_data.options.type) {
 	case JSONScanType::READ_JSON:
-		ReadJSONFunction(context, json_reader, gstate, lstate, output);
+		ReadJSONFunction(context, *this, gstate, lstate, output);
 		break;
 	case JSONScanType::READ_JSON_OBJECTS:
-		ReadJSONObjectsFunction(context, json_reader, gstate, lstate, output);
+		ReadJSONObjectsFunction(context, *this, gstate, lstate, output);
 		break;
 	default:
 		throw InternalException("Unsupported scan type for JSONMultiFileInfo::Scan");

--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -58,7 +58,6 @@ struct ParquetMultiFileInfo {
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);
 	static unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, BaseFileReader &reader, const string &name);
-	static double GetProgressInFile(ClientContext &context, const BaseFileReader &reader);
 	static void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
 };
 

--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -23,40 +23,38 @@ public:
 	ParquetOptions options;
 };
 
-struct ParquetMultiFileInfo : public MultiFileReaderInterface {
-	static unique_ptr<MultiFileReaderInterface> InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list);
+struct ParquetMultiFileInfo : MultiFileReaderInterface {
+	static unique_ptr<MultiFileReaderInterface> InitializeInterface(ClientContext &context, MultiFileReader &reader,
+	                                                                MultiFileList &file_list);
 
 	unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
-	                                                           optional_ptr<TableFunctionInfo> info) override;
-	static bool ParseCopyOption(ClientContext &context, const string &key, const vector<Value> &values,
-	                            BaseFileReaderOptions &options, vector<string> &expected_names,
-	                            vector<LogicalType> &expected_types);
-	static bool ParseOption(ClientContext &context, const string &key, const Value &val, MultiFileOptions &file_options,
-	                        BaseFileReaderOptions &options);
-	static void FinalizeCopyBind(ClientContext &context, BaseFileReaderOptions &options_p,
-	                             const vector<string> &expected_names, const vector<LogicalType> &expected_types);
-	static void BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,
-	                       MultiFileBindData &bind_data);
-	static unique_ptr<TableFunctionData> InitializeBindData(MultiFileBindData &multi_file_data,
-	                                                        unique_ptr<BaseFileReaderOptions> options);
-	static void FinalizeBindData(MultiFileBindData &multi_file_data);
-	static void GetBindInfo(const TableFunctionData &bind_data, BindInfo &info);
-	static optional_idx MaxThreads(const MultiFileBindData &bind_data, const MultiFileGlobalState &global_state,
-	                               FileExpandResult expand_result);
-	static unique_ptr<GlobalTableFunctionState>
-	InitializeGlobalState(ClientContext &context, MultiFileBindData &bind_data, MultiFileGlobalState &global_state);
-	static unique_ptr<LocalTableFunctionState> InitializeLocalState(ExecutionContext &, GlobalTableFunctionState &);
-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
-	                                               BaseUnionData &union_data, const MultiFileBindData &bind_data_p);
-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
-	                                               const OpenFileInfo &file, idx_t file_idx,
-	                                               const MultiFileBindData &bind_data);
+	                                                    optional_ptr<TableFunctionInfo> info) override;
+	bool ParseCopyOption(ClientContext &context, const string &key, const vector<Value> &values,
+	                     BaseFileReaderOptions &options, vector<string> &expected_names,
+	                     vector<LogicalType> &expected_types) override;
+	bool ParseOption(ClientContext &context, const string &key, const Value &val, MultiFileOptions &file_options,
+	                 BaseFileReaderOptions &options) override;
+	void BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,
+	                MultiFileBindData &bind_data) override;
+	unique_ptr<TableFunctionData> InitializeBindData(MultiFileBindData &multi_file_data,
+	                                                 unique_ptr<BaseFileReaderOptions> options) override;
+	void FinalizeBindData(MultiFileBindData &multi_file_data) override;
+	void GetBindInfo(const TableFunctionData &bind_data, BindInfo &info) override;
+	optional_idx MaxThreads(const MultiFileBindData &bind_data, const MultiFileGlobalState &global_state,
+	                        FileExpandResult expand_result) override;
+	unique_ptr<GlobalTableFunctionState> InitializeGlobalState(ClientContext &context, MultiFileBindData &bind_data,
+	                                                           MultiFileGlobalState &global_state) override;
+	unique_ptr<LocalTableFunctionState> InitializeLocalState(ExecutionContext &, GlobalTableFunctionState &) override;
+	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
+	                                        BaseUnionData &union_data, const MultiFileBindData &bind_data_p) override;
+	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
+	                                        const OpenFileInfo &file, idx_t file_idx,
+	                                        const MultiFileBindData &bind_data) override;
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               ParquetOptions &options, const MultiFileOptions &file_options);
-	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
-	                          LocalTableFunctionState &local_state);
-	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);
-	static void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
+	unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) override;
+	void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result) override;
+	unique_ptr<MultiFileReaderInterface> Copy() override;
 };
 
 class ParquetScanFunction {

--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -53,8 +53,6 @@ struct ParquetMultiFileInfo {
 	                                               ParquetOptions &options, const MultiFileOptions &file_options);
 	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
 	static void FinalizeReader(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &);
-	static void Scan(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &global_state,
-	                 LocalTableFunctionState &local_state, DataChunk &chunk);
 	static bool TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
 	                              GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
 	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);

--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -51,7 +51,6 @@ struct ParquetMultiFileInfo {
 	                                               const MultiFileBindData &bind_data);
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               ParquetOptions &options, const MultiFileOptions &file_options);
-	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);

--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -23,9 +23,11 @@ public:
 	ParquetOptions options;
 };
 
-struct ParquetMultiFileInfo {
-	static unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
-	                                                           optional_ptr<TableFunctionInfo> info);
+struct ParquetMultiFileInfo : public MultiFileReaderInterface {
+	static unique_ptr<MultiFileReaderInterface> InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list);
+
+	unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
+	                                                           optional_ptr<TableFunctionInfo> info) override;
 	static bool ParseCopyOption(ClientContext &context, const string &key, const vector<Value> &values,
 	                            BaseFileReaderOptions &options, vector<string> &expected_names,
 	                            vector<LogicalType> &expected_types);

--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -52,12 +52,9 @@ struct ParquetMultiFileInfo {
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               ParquetOptions &options, const MultiFileOptions &file_options);
 	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
-	static bool TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
-	                              GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);
-	static unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, BaseFileReader &reader, const string &name);
 	static void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
 };
 

--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -52,7 +52,6 @@ struct ParquetMultiFileInfo {
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               ParquetOptions &options, const MultiFileOptions &file_options);
 	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
-	static void FinalizeReader(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &);
 	static bool TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
 	                              GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
 	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);

--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -50,8 +50,9 @@ struct ParquetMultiFileInfo : MultiFileReaderInterface {
 	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
 	                                        const OpenFileInfo &file, idx_t file_idx,
 	                                        const MultiFileBindData &bind_data) override;
-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
-	                                               ParquetOptions &options, const MultiFileOptions &file_options);
+	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
+	                                        BaseFileReaderOptions &options,
+	                                        const MultiFileOptions &file_options) override;
 	unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) override;
 	void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result) override;
 	unique_ptr<MultiFileReaderInterface> Copy() override;

--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -54,7 +54,6 @@ struct ParquetMultiFileInfo {
 	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
 	static bool TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
 	                              GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
-	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -153,6 +153,7 @@ public:
 		return "Parquet";
 	}
 
+	shared_ptr<BaseUnionData> GetUnionData(idx_t file_idx) override;
 	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, const string &name) override;
 
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -157,6 +157,7 @@ public:
 	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
+	double GetProgressInFile(ClientContext &context) override;
 
 public:
 	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, vector<idx_t> groups_to_read);

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -153,9 +153,12 @@ public:
 		return "Parquet";
 	}
 
-	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, const string &name) override;
+
+	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
+	                       LocalTableFunctionState &lstate) override;
+	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
+	          DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -149,6 +149,14 @@ public:
 	atomic<idx_t> rows_read;
 
 public:
+	string GetReaderType() const override {
+		return "Parquet";
+	}
+
+	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+
+public:
 	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, vector<idx_t> groups_to_read);
 	void Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
 
@@ -171,10 +179,6 @@ public:
 	                                                 shared_ptr<ParquetFileMetadataCache> metadata, const string &name);
 
 	LogicalType DeriveLogicalType(const SchemaElement &s_ele, ParquetColumnSchema &schema) const;
-
-	string GetReaderType() const override {
-		return "Parquet";
-	}
 
 	void AddVirtualColumn(column_t virtual_column_id) override;
 

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -156,6 +156,7 @@ public:
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate) override;
 	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 
 public:
 	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, vector<idx_t> groups_to_read);

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -153,6 +153,7 @@ public:
 		return "Parquet";
 	}
 
+	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate) override;
 	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -140,7 +140,7 @@ void ParquetMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType
 	} else {
 		bind_data.reader_bind =
 		    bind_data.multi_file_reader->BindReader(context, return_types, names, *bind_data.file_list, bind_data,
-		                                            *parquet_bind.options, bind_data.file_options, *this);
+		                                            *parquet_bind.options, bind_data.file_options);
 	}
 }
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -522,9 +522,6 @@ shared_ptr<BaseUnionData> ParquetMultiFileInfo::GetUnionData(shared_ptr<BaseFile
 	return std::move(result);
 }
 
-void ParquetMultiFileInfo::FinalizeReader(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &) {
-}
-
 unique_ptr<GlobalTableFunctionState> ParquetMultiFileInfo::InitializeGlobalState(ClientContext &, MultiFileBindData &,
                                                                                  MultiFileGlobalState &) {
 	return make_uniq<ParquetReadGlobalState>();

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -547,8 +547,7 @@ bool ParquetReader::TryInitializeScan(ClientContext &context,
 	return true;
 }
 
-void ParquetMultiFileInfo::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p,
-                                      BaseFileReader &reader) {
+void ParquetReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) {
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	gstate.row_group_index = 0;
 }

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -532,18 +532,17 @@ unique_ptr<LocalTableFunctionState> ParquetMultiFileInfo::InitializeLocalState(E
 	return make_uniq<ParquetReadLocalState>();
 }
 
-bool ParquetMultiFileInfo::TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader_p,
+bool ParquetReader::TryInitializeScan(ClientContext &context,
                                              GlobalTableFunctionState &gstate_p, LocalTableFunctionState &lstate_p) {
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
-	auto &reader = reader_p->Cast<ParquetReader>();
-	if (gstate.row_group_index >= reader.NumRowGroups()) {
+	if (gstate.row_group_index >= NumRowGroups()) {
 		// scanned all row groups in this file
 		return false;
 	}
 	// The current reader has rowgroups left to be scanned
 	vector<idx_t> group_indexes {gstate.row_group_index};
-	reader.InitializeScan(context, lstate.scan_state, group_indexes);
+	InitializeScan(context, lstate.scan_state, group_indexes);
 	gstate.row_group_index++;
 	return true;
 }

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -468,10 +468,9 @@ unique_ptr<BaseStatistics> ParquetMultiFileInfo::GetStatistics(ClientContext &co
 	return reader.ReadStatistics(name);
 }
 
-double ParquetMultiFileInfo::GetProgressInFile(ClientContext &context, const BaseFileReader &reader) {
-	auto &parquet_reader = reader.Cast<ParquetReader>();
-	auto read_rows = parquet_reader.rows_read.load();
-	return 100.0 * (static_cast<double>(read_rows) / static_cast<double>(parquet_reader.NumRows()));
+double ParquetReader::GetProgressInFile(ClientContext &context) {
+	auto read_rows = rows_read.load();
+	return 100.0 * (static_cast<double>(read_rows) / static_cast<double>(NumRows()));
 }
 
 void ParquetMultiFileInfo::GetVirtualColumns(ClientContext &, MultiFileBindData &, virtual_column_map_t &result) {

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -119,6 +119,10 @@ static void BindSchema(ClientContext &context, vector<LogicalType> &return_types
 	D_ASSERT(names.size() == return_types.size());
 }
 
+unique_ptr<MultiFileReaderInterface> ParquetMultiFileInfo::InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list) {
+	return make_uniq<ParquetMultiFileInfo>();
+}
+
 void ParquetMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,
                                       MultiFileBindData &bind_data) {
 	auto &parquet_bind = bind_data.bind_data->Cast<ParquetReadBindData>();

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -561,11 +561,10 @@ void ParquetMultiFileInfo::FinishReading(ClientContext &context, GlobalTableFunc
                                          LocalTableFunctionState &local_state) {
 }
 
-void ParquetMultiFileInfo::Scan(ClientContext &context, BaseFileReader &reader_p, GlobalTableFunctionState &gstate_p,
-                                LocalTableFunctionState &local_state_p, DataChunk &chunk) {
+void ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+								LocalTableFunctionState &local_state_p, DataChunk &chunk) {
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
-	auto &reader = reader_p.Cast<ParquetReader>();
-	reader.Scan(context, local_state.scan_state, chunk);
+	Scan(context, local_state.scan_state, chunk);
 }
 
 } // namespace duckdb

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -462,10 +462,8 @@ unique_ptr<NodeStatistics> ParquetMultiFileInfo::GetCardinality(const MultiFileB
 	return make_uniq<NodeStatistics>(MaxValue(bind_data.initial_file_cardinality, (idx_t)1) * file_count);
 }
 
-unique_ptr<BaseStatistics> ParquetMultiFileInfo::GetStatistics(ClientContext &context, BaseFileReader &reader_p,
-                                                               const string &name) {
-	auto &reader = reader_p.Cast<ParquetReader>();
-	return reader.ReadStatistics(name);
+unique_ptr<BaseStatistics> ParquetReader::GetStatistics(ClientContext &context, const string &name) {
+	return ReadStatistics(name);
 }
 
 double ParquetReader::GetProgressInFile(ClientContext &context) {
@@ -531,8 +529,8 @@ unique_ptr<LocalTableFunctionState> ParquetMultiFileInfo::InitializeLocalState(E
 	return make_uniq<ParquetReadLocalState>();
 }
 
-bool ParquetReader::TryInitializeScan(ClientContext &context,
-                                             GlobalTableFunctionState &gstate_p, LocalTableFunctionState &lstate_p) {
+bool ParquetReader::TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+                                      LocalTableFunctionState &lstate_p) {
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
 	if (gstate.row_group_index >= NumRowGroups()) {
@@ -556,7 +554,7 @@ void ParquetMultiFileInfo::FinishReading(ClientContext &context, GlobalTableFunc
 }
 
 void ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
-								LocalTableFunctionState &local_state_p, DataChunk &chunk) {
+                         LocalTableFunctionState &local_state_p, DataChunk &chunk) {
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	Scan(context, local_state.scan_state, chunk);
 }

--- a/src/common/multi_file/CMakeLists.txt
+++ b/src/common/multi_file/CMakeLists.txt
@@ -1,5 +1,11 @@
-add_library_unity(duckdb_common_multi_file OBJECT base_file_reader.cpp multi_file_list.cpp
-                  multi_file_reader.cpp multi_file_column_mapper.cpp)
+add_library_unity(
+  duckdb_common_multi_file
+  OBJECT
+  base_file_reader.cpp
+  multi_file_function.cpp
+  multi_file_list.cpp
+  multi_file_reader.cpp
+  multi_file_column_mapper.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_common_multi_file>
     PARENT_SCOPE)

--- a/src/common/multi_file/CMakeLists.txt
+++ b/src/common/multi_file/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library_unity(duckdb_common_multi_file OBJECT multi_file_list.cpp
+add_library_unity(duckdb_common_multi_file OBJECT base_file_reader.cpp multi_file_list.cpp
                   multi_file_reader.cpp multi_file_column_mapper.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_common_multi_file>

--- a/src/common/multi_file/CMakeLists.txt
+++ b/src/common/multi_file/CMakeLists.txt
@@ -5,7 +5,8 @@ add_library_unity(
   multi_file_function.cpp
   multi_file_list.cpp
   multi_file_reader.cpp
-  multi_file_column_mapper.cpp)
+  multi_file_column_mapper.cpp
+  union_by_name.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_common_multi_file>
     PARENT_SCOPE)

--- a/src/common/multi_file/base_file_reader.cpp
+++ b/src/common/multi_file/base_file_reader.cpp
@@ -1,9 +1,20 @@
 #include "duckdb/common/multi_file/base_file_reader.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 
 namespace duckdb {
 
+unique_ptr<BaseStatistics> BaseFileReader::GetStatistics(ClientContext &context, const string &name) {
+	return nullptr;
+}
+
 shared_ptr<BaseUnionData> BaseFileReader::GetUnionData(idx_t file_idx) {
 	throw NotImplementedException("Union by name not supported for reader of type %s", GetReaderType());
+}
+
+void BaseFileReader::PrepareReader(ClientContext &context, GlobalTableFunctionState &) {
+}
+
+void BaseFileReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) {
 }
 
 } // namespace duckdb

--- a/src/common/multi_file/base_file_reader.cpp
+++ b/src/common/multi_file/base_file_reader.cpp
@@ -6,4 +6,4 @@ shared_ptr<BaseUnionData> BaseFileReader::GetUnionData(idx_t file_idx) {
 	throw NotImplementedException("Union by name not supported for reader of type %s", GetReaderType());
 }
 
-}
+} // namespace duckdb

--- a/src/common/multi_file/base_file_reader.cpp
+++ b/src/common/multi_file/base_file_reader.cpp
@@ -17,4 +17,8 @@ void BaseFileReader::PrepareReader(ClientContext &context, GlobalTableFunctionSt
 void BaseFileReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) {
 }
 
+double BaseFileReader::GetProgressInFile(ClientContext &context) {
+	return 0;
+}
+
 } // namespace duckdb

--- a/src/common/multi_file/base_file_reader.cpp
+++ b/src/common/multi_file/base_file_reader.cpp
@@ -1,0 +1,9 @@
+#include "duckdb/common/multi_file/base_file_reader.hpp"
+
+namespace duckdb {
+
+shared_ptr<BaseUnionData> BaseFileReader::GetUnionData(idx_t file_idx) {
+	throw NotImplementedException("Union by name not supported for reader of type %s", GetReaderType());
+}
+
+}

--- a/src/common/multi_file/multi_file_function.cpp
+++ b/src/common/multi_file/multi_file_function.cpp
@@ -1,0 +1,37 @@
+#include "duckdb/common/multi_file/multi_file_function.hpp"
+
+namespace duckdb {
+
+MultiFileReaderInterface::~MultiFileReaderInterface() {
+}
+
+void MultiFileReaderInterface::FinalizeCopyBind(ClientContext &context, BaseFileReaderOptions &options,
+                                                const vector<string> &expected_names,
+                                                const vector<LogicalType> &expected_types) {
+}
+
+optional_idx MultiFileReaderInterface::MaxThreads(const MultiFileBindData &bind_data_p,
+                                                  const MultiFileGlobalState &global_state,
+                                                  FileExpandResult expand_result) {
+	return optional_idx();
+}
+
+void MultiFileReaderInterface::FinalizeBindData(MultiFileBindData &multi_file_data) {
+}
+
+void MultiFileReaderInterface::GetBindInfo(const TableFunctionData &bind_data, BindInfo &info) {
+}
+
+void MultiFileReaderInterface::GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data,
+                                                 virtual_column_map_t &result) {
+}
+
+void MultiFileReaderInterface::FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
+                                             LocalTableFunctionState &local_state) {
+}
+
+unique_ptr<MultiFileReaderInterface> MultiFileReaderInterface::Copy() {
+	throw InternalException("MultiFileReaderInterface::Copy is not implemented for this file interface");
+}
+
+} // namespace duckdb

--- a/src/common/multi_file/multi_file_function.cpp
+++ b/src/common/multi_file/multi_file_function.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/multi_file/multi_file_function.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 
 namespace duckdb {
 

--- a/src/common/multi_file/multi_file_function.cpp
+++ b/src/common/multi_file/multi_file_function.cpp
@@ -19,6 +19,12 @@ optional_idx MultiFileReaderInterface::MaxThreads(const MultiFileBindData &bind_
 void MultiFileReaderInterface::FinalizeBindData(MultiFileBindData &multi_file_data) {
 }
 
+shared_ptr<BaseFileReader> MultiFileReaderInterface::CreateReader(ClientContext &context, const OpenFileInfo &file,
+                                                                  BaseFileReaderOptions &options,
+                                                                  const MultiFileOptions &file_options) {
+	throw InternalException("MultiFileReaderInterface::CreateReader is not implemented for this file interface");
+}
+
 void MultiFileReaderInterface::GetBindInfo(const TableFunctionData &bind_data, BindInfo &info) {
 }
 

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/multi_file/multi_file_function.hpp"
+#include "duckdb/common/multi_file/union_by_name.hpp"
 #include <algorithm>
 
 namespace duckdb {

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/multi_file/multi_file_function.hpp"
 #include <algorithm>
 
 namespace duckdb {
@@ -46,6 +47,9 @@ unique_ptr<MultiFileReader> MultiFileReader::Copy() const {
 	return CreateDefault(function_name);
 }
 
+MultiFileBindData::~MultiFileBindData() {
+}
+
 unique_ptr<FunctionData> MultiFileBindData::Copy() const {
 	auto result = make_uniq<MultiFileBindData>();
 	if (bind_data) {
@@ -53,6 +57,7 @@ unique_ptr<FunctionData> MultiFileBindData::Copy() const {
 	}
 	result->file_list = make_uniq<SimpleMultiFileList>(file_list->GetAllFiles());
 	result->multi_file_reader = multi_file_reader->Copy();
+	result->interface = interface->Copy();
 	result->columns = columns;
 	result->reader_bind = reader_bind;
 	result->file_options = file_options;

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -524,6 +524,103 @@ unique_ptr<Expression> MultiFileReader::GetVirtualColumnExpression(ClientContext
 	return make_uniq<BoundReferenceExpression>(type, local_idx.GetIndex());
 }
 
+MultiFileReaderBindData MultiFileReader::BindUnionReader(ClientContext &context, vector<LogicalType> &return_types,
+                                                         vector<string> &names, MultiFileList &files,
+                                                         MultiFileBindData &result, BaseFileReaderOptions &options,
+                                                         MultiFileOptions &file_options,
+                                                         MultiFileReaderInterface &interface) {
+	D_ASSERT(file_options.union_by_name);
+	vector<string> union_col_names;
+	vector<LogicalType> union_col_types;
+
+	// obtain the set of union column names + types by unifying the types of all of the files
+	// note that this requires opening readers for each file and reading the metadata of each file
+	// note also that it requires fully expanding the MultiFileList
+	auto materialized_file_list = files.GetAllFiles();
+	auto union_readers = UnionByName::UnionCols(context, materialized_file_list, union_col_types, union_col_names,
+	                                            options, file_options, interface);
+
+	std::move(union_readers.begin(), union_readers.end(), std::back_inserter(result.union_readers));
+	// perform the binding on the obtained set of names + types
+	MultiFileReaderBindData bind_data;
+	BindOptions(file_options, files, union_col_types, union_col_names, bind_data);
+	names = union_col_names;
+	return_types = union_col_types;
+	result.Initialize(context, *result.union_readers[0]);
+	D_ASSERT(names.size() == return_types.size());
+	return bind_data;
+}
+
+MultiFileReaderBindData MultiFileReader::BindReader(ClientContext &context, vector<LogicalType> &return_types,
+                                                    vector<string> &names, MultiFileList &files,
+                                                    MultiFileBindData &result, BaseFileReaderOptions &options,
+                                                    MultiFileOptions &file_options,
+                                                    MultiFileReaderInterface &interface) {
+	if (file_options.union_by_name) {
+		return BindUnionReader(context, return_types, names, files, result, options, file_options, interface);
+	} else {
+		shared_ptr<BaseFileReader> reader;
+		reader = interface.CreateReader(context, files.GetFirstFile(), options, file_options);
+		auto &columns = reader->GetColumns();
+		for (auto &column : columns) {
+			return_types.emplace_back(column.type);
+			names.emplace_back(column.name);
+		}
+		result.Initialize(std::move(reader));
+		MultiFileReaderBindData bind_data;
+		BindOptions(file_options, files, return_types, names, bind_data);
+		return bind_data;
+	}
+}
+
+ReaderInitializeType MultiFileReader::InitializeReader(MultiFileReaderData &reader_data,
+                                                       const MultiFileBindData &bind_data,
+                                                       const vector<MultiFileColumnDefinition> &global_columns,
+                                                       const vector<ColumnIndex> &global_column_ids,
+                                                       optional_ptr<TableFilterSet> table_filters,
+                                                       ClientContext &context,
+                                                       optional_ptr<MultiFileReaderGlobalState> global_state) {
+	FinalizeBind(reader_data, bind_data.file_options, bind_data.reader_bind, global_columns, global_column_ids, context,
+	             global_state);
+	return CreateMapping(context, reader_data, global_columns, global_column_ids, table_filters,
+	                     bind_data.file_list->GetFirstFile(), bind_data.reader_bind, bind_data.virtual_columns);
+}
+
+void MultiFileReader::PruneReaders(MultiFileBindData &data, MultiFileList &file_list) {
+	unordered_set<string> file_set;
+
+	// Avoid materializing the file list if there's nothing to prune
+	if (!data.initial_reader && data.union_readers.empty()) {
+		return;
+	}
+
+	for (const auto &file : file_list.Files()) {
+		file_set.insert(file.path);
+	}
+
+	if (data.initial_reader) {
+		// check if the initial reader should still be read
+		auto entry = file_set.find(data.initial_reader->GetFileName());
+		if (entry == file_set.end()) {
+			data.initial_reader.reset();
+		}
+	}
+	for (idx_t r = 0; r < data.union_readers.size(); r++) {
+		if (!data.union_readers[r]) {
+			data.union_readers.erase_at(r);
+			r--;
+			continue;
+		}
+		// check if the union reader should still be read or not
+		auto entry = file_set.find(data.union_readers[r]->GetFileName());
+		if (entry == file_set.end()) {
+			data.union_readers.erase_at(r);
+			r--;
+			continue;
+		}
+	}
+}
+
 HivePartitioningIndex::HivePartitioningIndex(string value_p, idx_t index) : value(std::move(value_p)), index(index) {
 }
 

--- a/src/common/multi_file/union_by_name.cpp
+++ b/src/common/multi_file/union_by_name.cpp
@@ -1,0 +1,62 @@
+#include "duckdb/common/multi_file/union_by_name.hpp"
+#include "duckdb/common/multi_file/multi_file_function.hpp"
+
+namespace duckdb {
+
+class UnionByReaderTask : public BaseExecutorTask {
+public:
+	UnionByReaderTask(TaskExecutor &executor, ClientContext &context, const OpenFileInfo &file, idx_t file_idx,
+	                  vector<shared_ptr<BaseUnionData>> &readers, BaseFileReaderOptions &options,
+	                  MultiFileOptions &file_options, MultiFileReaderInterface &interface)
+	    : BaseExecutorTask(executor), context(context), file(file), file_idx(file_idx), readers(readers),
+	      options(options), file_options(file_options), interface(interface) {
+	}
+
+	void ExecuteTask() override {
+		auto reader = interface.CreateReader(context, file, options, file_options);
+		readers[file_idx] = reader->GetUnionData(file_idx);
+	}
+
+	string TaskType() const override {
+		return "UnionByReaderTask";
+	}
+
+private:
+	ClientContext &context;
+	const OpenFileInfo &file;
+	idx_t file_idx;
+	vector<shared_ptr<BaseUnionData>> &readers;
+	BaseFileReaderOptions &options;
+	MultiFileOptions &file_options;
+	MultiFileReaderInterface &interface;
+};
+
+vector<shared_ptr<BaseUnionData>> UnionByName::UnionCols(ClientContext &context, const vector<OpenFileInfo> &files,
+                                                         vector<LogicalType> &union_col_types,
+                                                         vector<string> &union_col_names,
+                                                         BaseFileReaderOptions &options, MultiFileOptions &file_options,
+                                                         MultiFileReaderInterface &interface) {
+	vector<shared_ptr<BaseUnionData>> union_readers;
+	union_readers.resize(files.size());
+
+	TaskExecutor executor(context);
+	// schedule tasks for all files
+	for (idx_t file_idx = 0; file_idx < files.size(); ++file_idx) {
+		auto task = make_uniq<UnionByReaderTask>(executor, context, files[file_idx], file_idx, union_readers, options,
+		                                         file_options, interface);
+		executor.ScheduleTask(std::move(task));
+	}
+	// complete all tasks
+	executor.WorkOnTasks();
+
+	// now combine the result schemas
+	case_insensitive_map_t<idx_t> union_names_map;
+	for (auto &reader : union_readers) {
+		auto &col_names = reader->names;
+		auto &sql_types = reader->types;
+		CombineUnionTypes(col_names, sql_types, union_col_types, union_col_names, union_names_map);
+	}
+	return union_readers;
+}
+
+} // namespace duckdb

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -336,11 +336,11 @@ void CSVFileScan::PrepareReader(ClientContext &context, GlobalTableFunctionState
 	SetStart();
 }
 
-bool CSVMultiFileInfo::TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
+bool CSVFileScan::TryInitializeScan(ClientContext &context,
                                          GlobalTableFunctionState &gstate_p, LocalTableFunctionState &lstate_p) {
 	auto &gstate = gstate_p.Cast<CSVGlobalState>();
 	auto &lstate = lstate_p.Cast<CSVLocalState>();
-	auto csv_reader_ptr = shared_ptr_cast<BaseFileReader, CSVFileScan>(reader);
+	auto csv_reader_ptr = shared_ptr_cast<BaseFileReader, CSVFileScan>(shared_from_this());
 	gstate.FinishScan(std::move(lstate.csv_reader));
 	lstate.csv_reader = gstate.Next(csv_reader_ptr);
 	if (!lstate.csv_reader) {

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -336,8 +336,8 @@ void CSVFileScan::PrepareReader(ClientContext &context, GlobalTableFunctionState
 	SetStart();
 }
 
-bool CSVFileScan::TryInitializeScan(ClientContext &context,
-                                         GlobalTableFunctionState &gstate_p, LocalTableFunctionState &lstate_p) {
+bool CSVFileScan::TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+                                    LocalTableFunctionState &lstate_p) {
 	auto &gstate = gstate_p.Cast<CSVGlobalState>();
 	auto &lstate = lstate_p.Cast<CSVLocalState>();
 	auto csv_reader_ptr = shared_ptr_cast<BaseFileReader, CSVFileScan>(shared_from_this());
@@ -351,7 +351,7 @@ bool CSVFileScan::TryInitializeScan(ClientContext &context,
 }
 
 void CSVFileScan::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-                            LocalTableFunctionState &local_state, DataChunk &chunk) {
+                       LocalTableFunctionState &local_state, DataChunk &chunk) {
 	auto &lstate = local_state.Cast<CSVLocalState>();
 	if (lstate.csv_reader->FinishedIterator()) {
 		return;
@@ -380,11 +380,6 @@ unique_ptr<NodeStatistics> CSVMultiFileInfo::GetCardinality(const MultiFileBindD
 		per_file_cardinality = csv_data.buffer_manager->file_handle->FileSize() / estimated_row_width;
 	}
 	return make_uniq<NodeStatistics>(file_count * per_file_cardinality);
-}
-
-unique_ptr<BaseStatistics> CSVMultiFileInfo::GetStatistics(ClientContext &context, BaseFileReader &reader,
-                                                           const string &name) {
-	throw InternalException("Unimplemented CSVMultiFileInfo method");
 }
 
 double CSVFileScan::GetProgressInFile(ClientContext &context) {

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -181,7 +181,7 @@ void CSVMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &r
 		CSVFileReaderOptions csv_options(options);
 		bind_data.reader_bind =
 		    bind_data.multi_file_reader->BindUnionReader(context, return_types, names, multi_file_list, bind_data,
-		                                                 csv_options, bind_data.file_options, *bind_data.interface);
+		                                                 csv_options, bind_data.file_options);
 		if (bind_data.union_readers.size() > 1) {
 			for (idx_t i = 0; i < bind_data.union_readers.size(); i++) {
 				auto &csv_union_data = bind_data.union_readers[i]->Cast<CSVUnionData>();

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -314,18 +314,15 @@ shared_ptr<BaseFileReader> CSVMultiFileInfo::CreateReader(ClientContext &context
 	return make_shared_ptr<CSVFileScan>(context, file, options, file_options);
 }
 
-shared_ptr<BaseUnionData> CSVMultiFileInfo::GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx) {
-	auto &scan = scan_p->Cast<CSVFileScan>();
-	auto data = make_shared_ptr<CSVUnionData>(scan_p->file);
+shared_ptr<BaseUnionData> CSVFileScan::GetUnionData(idx_t file_idx) {
+	auto data = make_shared_ptr<CSVUnionData>(file);
+	data->names = GetNames();
+	data->types = GetTypes();
 	if (file_idx == 0) {
-		data->options = scan.options;
-		data->names = scan.GetNames();
-		data->types = scan.GetTypes();
-		data->reader = std::move(scan_p);
+		data->options = options;
+		data->reader = shared_from_this();
 	} else {
-		data->options = std::move(scan.options);
-		data->names = scan.GetNames();
-		data->types = scan.GetTypes();
+		data->options = std::move(options);
 	}
 	data->options.auto_detect = false;
 	return data;

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -178,8 +178,10 @@ void CSVMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &r
 		bind_data.multi_file_reader->BindOptions(bind_data.file_options, multi_file_list, return_types, names,
 		                                         bind_data.reader_bind);
 	} else {
-		bind_data.reader_bind = bind_data.multi_file_reader->BindUnionReader<CSVMultiFileInfo>(
-		    context, return_types, names, multi_file_list, bind_data, options, bind_data.file_options);
+		CSVFileReaderOptions csv_options(options);
+		bind_data.reader_bind =
+		    bind_data.multi_file_reader->BindUnionReader(context, return_types, names, multi_file_list, bind_data,
+		                                                 csv_options, bind_data.file_options, *bind_data.interface);
 		if (bind_data.union_readers.size() > 1) {
 			for (idx_t i = 0; i < bind_data.union_readers.size(); i++) {
 				auto &csv_union_data = bind_data.union_readers[i]->Cast<CSVUnionData>();
@@ -311,9 +313,10 @@ shared_ptr<BaseFileReader> CSVMultiFileInfo::CreateReader(ClientContext &context
 }
 
 shared_ptr<BaseFileReader> CSVMultiFileInfo::CreateReader(ClientContext &context, const OpenFileInfo &file,
-                                                          CSVReaderOptions &options,
+                                                          BaseFileReaderOptions &options_p,
                                                           const MultiFileOptions &file_options) {
-	return make_shared_ptr<CSVFileScan>(context, file, options, file_options);
+	auto &csv_options = options_p.Cast<CSVFileReaderOptions>();
+	return make_shared_ptr<CSVFileScan>(context, file, csv_options.options, file_options);
 }
 
 shared_ptr<BaseUnionData> CSVFileScan::GetUnionData(idx_t file_idx) {

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -179,9 +179,8 @@ void CSVMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &r
 		                                         bind_data.reader_bind);
 	} else {
 		CSVFileReaderOptions csv_options(options);
-		bind_data.reader_bind =
-		    bind_data.multi_file_reader->BindUnionReader(context, return_types, names, multi_file_list, bind_data,
-		                                                 csv_options, bind_data.file_options);
+		bind_data.reader_bind = bind_data.multi_file_reader->BindUnionReader(
+		    context, return_types, names, multi_file_list, bind_data, csv_options, bind_data.file_options);
 		if (bind_data.union_readers.size() > 1) {
 			for (idx_t i = 0; i < bind_data.union_readers.size(); i++) {
 				auto &csv_union_data = bind_data.union_readers[i]->Cast<CSVUnionData>();

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -8,6 +8,10 @@
 
 namespace duckdb {
 
+unique_ptr<MultiFileReaderInterface> CSVMultiFileInfo::InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list) {
+	return make_uniq<CSVMultiFileInfo>();
+}
+
 unique_ptr<BaseFileReaderOptions> CSVMultiFileInfo::InitializeOptions(ClientContext &context,
                                                                       optional_ptr<TableFunctionInfo> info) {
 	return make_uniq<CSVFileReaderOptions>();

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -331,10 +331,9 @@ shared_ptr<BaseUnionData> CSVMultiFileInfo::GetUnionData(shared_ptr<BaseFileRead
 	return data;
 }
 
-void CSVMultiFileInfo::FinalizeReader(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &) {
-	auto &csv_file_scan = reader.Cast<CSVFileScan>();
-	csv_file_scan.InitializeFileNamesTypes();
-	csv_file_scan.SetStart();
+void CSVFileScan::PrepareReader(ClientContext &context, GlobalTableFunctionState &) {
+	InitializeFileNamesTypes();
+	SetStart();
 }
 
 bool CSVMultiFileInfo::TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -8,7 +8,8 @@
 
 namespace duckdb {
 
-unique_ptr<MultiFileReaderInterface> CSVMultiFileInfo::InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list) {
+unique_ptr<MultiFileReaderInterface>
+CSVMultiFileInfo::InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list) {
 	return make_uniq<CSVMultiFileInfo>();
 }
 
@@ -229,9 +230,6 @@ void CSVMultiFileInfo::FinalizeBindData(MultiFileBindData &multi_file_data) {
 	csv_data.Finalize();
 }
 
-void CSVMultiFileInfo::GetBindInfo(const TableFunctionData &bind_data, BindInfo &info) {
-}
-
 optional_idx CSVMultiFileInfo::MaxThreads(const MultiFileBindData &bind_data, const MultiFileGlobalState &global_state,
                                           FileExpandResult expand_result) {
 	auto &csv_data = bind_data.bind_data->Cast<ReadCSVData>();
@@ -400,9 +398,6 @@ double CSVFileScan::GetProgressInFile(ClientContext &context) {
 	}
 	double file_progress = total_bytes_read / static_cast<double>(file_size);
 	return file_progress * 100.0;
-}
-
-void CSVMultiFileInfo::GetVirtualColumns(ClientContext &, MultiFileBindData &, virtual_column_map_t &result) {
 }
 
 } // namespace duckdb

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -359,10 +359,9 @@ void CSVFileScan::Scan(ClientContext &context, GlobalTableFunctionState &global_
 	lstate.csv_reader->Flush(chunk);
 }
 
-void CSVMultiFileInfo::FinishFile(ClientContext &context, GlobalTableFunctionState &global_state,
-                                  BaseFileReader &reader) {
+void CSVFileScan::FinishFile(ClientContext &context, GlobalTableFunctionState &global_state) {
 	auto &gstate = global_state.Cast<CSVGlobalState>();
-	gstate.FinishLaunchingTasks(reader.Cast<CSVFileScan>());
+	gstate.FinishLaunchingTasks(*this);
 }
 
 void CSVMultiFileInfo::FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -351,7 +351,7 @@ bool CSVMultiFileInfo::TryInitializeScan(ClientContext &context, shared_ptr<Base
 	return true;
 }
 
-void CSVMultiFileInfo::Scan(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &global_state,
+void CSVFileScan::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
                             LocalTableFunctionState &local_state, DataChunk &chunk) {
 	auto &lstate = local_state.Cast<CSVLocalState>();
 	if (lstate.csv_reader->FinishedIterator()) {

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -68,20 +68,17 @@ public:
 public:
 	virtual shared_ptr<BaseUnionData> GetUnionData(idx_t file_idx);
 	//! Get statistics for a specific column
-	virtual unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, const string &name) {
-		return nullptr;
-	}
+	virtual unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, const string &name);
 	//! Prepare reader for scanning
-	virtual void PrepareReader(ClientContext &context, GlobalTableFunctionState &) {
-	}
+	virtual void PrepareReader(ClientContext &context, GlobalTableFunctionState &);
+
 	virtual bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                               LocalTableFunctionState &lstate) = 0;
 	//! Scan a chunk from the read state
 	virtual void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                  LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
 	//! Finish scanning a given file
-	virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) {
-	}
+	virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate);
 	//! Get progress within a given file
 	virtual double GetProgressInFile(ClientContext &context) = 0;
 

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -55,7 +55,6 @@ public:
 	const string &GetFileName() {
 		return file.path;
 	}
-	virtual string GetReaderType() const = 0;
 	virtual bool UseCastMap() const {
 		//! Whether or not to push casts into the cast map
 		return false;
@@ -64,6 +63,12 @@ public:
 	virtual void AddVirtualColumn(column_t virtual_column_id) {
 		throw InternalException("Reader %s does not support AddVirtualColumn", GetReaderType());
 	}
+
+public:
+	virtual void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+			 LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
+
+	virtual string GetReaderType() const = 0;
 
 public:
 	template <class TARGET>

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -74,6 +74,9 @@ public:
 	virtual void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
 
+	virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) {
+	}
+
 	virtual string GetReaderType() const = 0;
 
 public:

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -76,6 +76,7 @@ public:
 
 	virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) {
 	}
+	virtual double GetProgressInFile(ClientContext &context) = 0;
 
 	virtual string GetReaderType() const = 0;
 

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -19,6 +19,8 @@
 
 namespace duckdb {
 class BaseUnionData;
+struct GlobalTableFunctionState;
+struct LocalTableFunctionState;
 
 //! Parent class of single-file readers - this must be inherited from for readers implementing the MultiFileReader
 //! interface
@@ -66,11 +68,11 @@ public:
 	}
 
 public:
-	virtual shared_ptr<BaseUnionData> GetUnionData(idx_t file_idx);
+	DUCKDB_API virtual shared_ptr<BaseUnionData> GetUnionData(idx_t file_idx);
 	//! Get statistics for a specific column
-	virtual unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, const string &name);
+	DUCKDB_API virtual unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, const string &name);
 	//! Prepare reader for scanning
-	virtual void PrepareReader(ClientContext &context, GlobalTableFunctionState &);
+	DUCKDB_API virtual void PrepareReader(ClientContext &context, GlobalTableFunctionState &);
 
 	virtual bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                               LocalTableFunctionState &lstate) = 0;
@@ -78,9 +80,9 @@ public:
 	virtual void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                  LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
 	//! Finish scanning a given file
-	virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate);
+	DUCKDB_API virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate);
 	//! Get progress within a given file
-	virtual double GetProgressInFile(ClientContext &context) = 0;
+	DUCKDB_API virtual double GetProgressInFile(ClientContext &context);
 
 	virtual string GetReaderType() const = 0;
 

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -65,17 +65,22 @@ public:
 	}
 
 public:
+	//! Get statistics for a specific column
+	virtual unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, const string &name) {
+		return nullptr;
+	}
 	//! Prepare reader for scanning
 	virtual void PrepareReader(ClientContext &context, GlobalTableFunctionState &) {
 	}
-	virtual bool TryInitializeScan(ClientContext &context,
-				      GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate) = 0;
+	virtual bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
+	                               LocalTableFunctionState &lstate) = 0;
 	//! Scan a chunk from the read state
 	virtual void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-			 LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
-
-	virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) {
+	                  LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
+	//! Finish scanning a given file
+	virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) {
 	}
+	//! Get progress within a given file
 	virtual double GetProgressInFile(ClientContext &context) = 0;
 
 	virtual string GetReaderType() const = 0;

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -18,6 +18,7 @@
 #include "duckdb/common/open_file_info.hpp"
 
 namespace duckdb {
+class BaseUnionData;
 
 //! Parent class of single-file readers - this must be inherited from for readers implementing the MultiFileReader
 //! interface
@@ -65,6 +66,7 @@ public:
 	}
 
 public:
+	virtual shared_ptr<BaseUnionData> GetUnionData(idx_t file_idx);
 	//! Get statistics for a specific column
 	virtual unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, const string &name) {
 		return nullptr;

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -21,7 +21,7 @@ namespace duckdb {
 
 //! Parent class of single-file readers - this must be inherited from for readers implementing the MultiFileReader
 //! interface
-class BaseFileReader {
+class BaseFileReader : public enable_shared_from_this<BaseFileReader> {
 public:
 	explicit BaseFileReader(OpenFileInfo file_p) : file(std::move(file_p)) {
 	}
@@ -68,6 +68,8 @@ public:
 	//! Prepare reader for scanning
 	virtual void PrepareReader(ClientContext &context, GlobalTableFunctionState &) {
 	}
+	virtual bool TryInitializeScan(ClientContext &context,
+				      GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate) = 0;
 	//! Scan a chunk from the read state
 	virtual void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) = 0;

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -65,6 +65,10 @@ public:
 	}
 
 public:
+	//! Prepare reader for scanning
+	virtual void PrepareReader(ClientContext &context, GlobalTableFunctionState &) {
+	}
+	//! Scan a chunk from the read state
 	virtual void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
 

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -543,7 +543,7 @@ public:
 			auto &scan_chunk = data.scan_chunk;
 			scan_chunk.Reset();
 
-			OP::Scan(context, *data.reader, *gstate.global_state, *data.local_state, scan_chunk);
+			data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
 			output.SetCardinality(scan_chunk.size());
 			if (scan_chunk.size() > 0) {
 				bind_data.multi_file_reader->FinalizeChunk(context, bind_data, *data.reader, *data.reader_data,

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -598,7 +598,7 @@ public:
 			double progress_in_file;
 			if (reader_data.file_state == MultiFileFileState::OPEN) {
 				// file is currently open - get the progress within the file
-				progress_in_file = OP::GetProgressInFile(context, *reader_data.reader);
+				progress_in_file = reader_data.reader->GetProgressInFile(context);
 			} else if (reader_data.file_state == MultiFileFileState::CLOSED) {
 				// file has been closed - check if the reader is still in use
 				auto reader = reader_data.closed_reader.lock();
@@ -607,7 +607,7 @@ public:
 					progress_in_file = 100.0;
 				} else {
 					// file is still being read
-					progress_in_file = OP::GetProgressInFile(context, *reader);
+					progress_in_file = reader->GetProgressInFile(context);
 				}
 			} else {
 				// file has not been opened yet - progress in this file is zero

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -376,7 +376,7 @@ public:
 					current_reader_data.file_state = MultiFileFileState::CLOSED;
 
 					//! Finish processing the file
-					OP::FinishFile(context, *gstate.global_state, *current_reader_data.reader);
+					current_reader_data.reader->FinishFile(context, *gstate.global_state);
 					current_reader_data.closed_reader = current_reader_data.reader;
 					current_reader_data.reader = nullptr;
 					continue;

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -284,10 +284,10 @@ public:
 				try {
 					if (current_reader_data.union_data) {
 						auto &union_data = *current_reader_data.union_data;
-						current_reader_data.reader = bind_data.interface->CreateReader(
+						current_reader_data.reader = bind_data.multi_file_reader->CreateReader(
 						    context, *global_state.global_state, union_data, bind_data);
 					} else {
-						current_reader_data.reader = bind_data.interface->CreateReader(
+						current_reader_data.reader = bind_data.multi_file_reader->CreateReader(
 						    context, *global_state.global_state, current_reader_data.file_to_be_opened,
 						    current_file_index, bind_data);
 					}

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -47,6 +47,9 @@ struct MultiFileReaderInterface {
 	virtual shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
 	                                                const OpenFileInfo &file, idx_t file_idx,
 	                                                const MultiFileBindData &bind_data) = 0;
+	virtual shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
+	                                                BaseFileReaderOptions &options,
+	                                                const MultiFileOptions &file_options);
 	virtual void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                           LocalTableFunctionState &local_state);
 	virtual unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) = 0;

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -356,7 +356,7 @@ public:
 			auto &current_reader_data = *gstate.readers[gstate.file_index];
 			if (current_reader_data.file_state == MultiFileFileState::OPEN) {
 				if (current_reader_data.reader->TryInitializeScan(context, *gstate.global_state,
-				                          *scan_data.local_state)) {
+				                                                  *scan_data.local_state)) {
 					if (!current_reader_data.reader) {
 						throw InternalException("MultiFileReader was moved");
 					}
@@ -575,7 +575,7 @@ public:
 		if (IsVirtualColumn(column_index)) {
 			return nullptr;
 		}
-		return OP::GetStatistics(context, *bind_data.initial_reader, bind_data.names[column_index]);
+		return bind_data.initial_reader->GetStatistics(context, bind_data.names[column_index]);
 	}
 
 	static double MultiFileProgress(ClientContext &context, const FunctionData *bind_data_p,

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -249,7 +249,7 @@ public:
 						//! File can be skipped entirely, close it and move on
 						can_skip_file = true;
 					} else {
-						OP::FinalizeReader(context, *current_reader_data.reader, *global_state.global_state);
+						current_reader_data.reader->PrepareReader(context, *global_state.global_state);
 					}
 				} catch (...) {
 					parallel_lock.lock();

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -355,7 +355,7 @@ public:
 
 			auto &current_reader_data = *gstate.readers[gstate.file_index];
 			if (current_reader_data.file_state == MultiFileFileState::OPEN) {
-				if (OP::TryInitializeScan(context, current_reader_data.reader, *gstate.global_state,
+				if (current_reader_data.reader->TryInitializeScan(context, *gstate.global_state,
 				                          *scan_data.local_state)) {
 					if (!current_reader_data.reader) {
 						throw InternalException("MultiFileReader was moved");

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -138,13 +138,24 @@ public:
 	                                   MultiFileList &files, MultiFileBindData &result, BaseFileReaderOptions &options,
 	                                   MultiFileOptions &file_options, MultiFileReaderInterface &interface);
 
-	virtual ReaderInitializeType InitializeReader(MultiFileReaderData &reader_data, const MultiFileBindData &bind_data,
-	                                              const vector<MultiFileColumnDefinition> &global_columns,
-	                                              const vector<ColumnIndex> &global_column_ids,
-	                                              optional_ptr<TableFilterSet> table_filters, ClientContext &context,
-	                                              optional_ptr<MultiFileReaderGlobalState> global_state);
+	DUCKDB_API virtual ReaderInitializeType
+	InitializeReader(MultiFileReaderData &reader_data, const MultiFileBindData &bind_data,
+	                 const vector<MultiFileColumnDefinition> &global_columns,
+	                 const vector<ColumnIndex> &global_column_ids, optional_ptr<TableFilterSet> table_filters,
+	                 ClientContext &context, optional_ptr<MultiFileReaderGlobalState> global_state);
 
 	static void PruneReaders(MultiFileBindData &data, MultiFileList &file_list);
+
+	DUCKDB_API virtual shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
+	                                                           BaseUnionData &union_data,
+	                                                           const MultiFileBindData &bind_data);
+	DUCKDB_API virtual shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
+	                                                           const OpenFileInfo &file, idx_t file_idx,
+	                                                           const MultiFileBindData &bind_data);
+	DUCKDB_API virtual shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
+	                                                           BaseFileReaderOptions &options,
+	                                                           const MultiFileOptions &file_options,
+	                                                           MultiFileReaderInterface &interfac);
 
 	//! Get partition info
 	DUCKDB_API virtual TablePartitionInfo GetPartitionInfo(ClientContext &context,

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/file_glob_options.hpp"
 #include "duckdb/common/multi_file/multi_file_options.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
@@ -130,99 +129,22 @@ public:
 	DUCKDB_API static void GetVirtualColumns(ClientContext &context, MultiFileReaderBindData &bind_data,
 	                                         virtual_column_map_t &result);
 
-	template <class OP, class OPTIONS_TYPE>
 	MultiFileReaderBindData BindUnionReader(ClientContext &context, vector<LogicalType> &return_types,
 	                                        vector<string> &names, MultiFileList &files, MultiFileBindData &result,
-	                                        OPTIONS_TYPE &options, MultiFileOptions &file_options) {
-		D_ASSERT(file_options.union_by_name);
-		vector<string> union_col_names;
-		vector<LogicalType> union_col_types;
+	                                        BaseFileReaderOptions &options, MultiFileOptions &file_options,
+	                                        MultiFileReaderInterface &interface);
 
-		// obtain the set of union column names + types by unifying the types of all of the files
-		// note that this requires opening readers for each file and reading the metadata of each file
-		// note also that it requires fully expanding the MultiFileList
-		auto materialized_file_list = files.GetAllFiles();
-		auto union_readers = UnionByName::UnionCols<OP>(context, materialized_file_list, union_col_types,
-		                                                union_col_names, options, file_options);
-
-		std::move(union_readers.begin(), union_readers.end(), std::back_inserter(result.union_readers));
-		// perform the binding on the obtained set of names + types
-		MultiFileReaderBindData bind_data;
-		BindOptions(file_options, files, union_col_types, union_col_names, bind_data);
-		names = union_col_names;
-		return_types = union_col_types;
-		result.Initialize(context, *result.union_readers[0]);
-		D_ASSERT(names.size() == return_types.size());
-		return bind_data;
-	}
-
-	template <class OP, class OPTIONS_TYPE>
 	MultiFileReaderBindData BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,
-	                                   MultiFileList &files, MultiFileBindData &result, OPTIONS_TYPE &options,
-	                                   MultiFileOptions &file_options) {
-		if (file_options.union_by_name) {
-			return BindUnionReader<OP>(context, return_types, names, files, result, options, file_options);
-		} else {
-			shared_ptr<BaseFileReader> reader;
-			reader = OP::CreateReader(context, files.GetFirstFile(), options, file_options);
-			auto &columns = reader->GetColumns();
-			for (auto &column : columns) {
-				return_types.emplace_back(column.type);
-				names.emplace_back(column.name);
-			}
-			result.Initialize(std::move(reader));
-			MultiFileReaderBindData bind_data;
-			BindOptions(file_options, files, return_types, names, bind_data);
-			return bind_data;
-		}
-	}
+	                                   MultiFileList &files, MultiFileBindData &result, BaseFileReaderOptions &options,
+	                                   MultiFileOptions &file_options, MultiFileReaderInterface &interface);
 
 	virtual ReaderInitializeType InitializeReader(MultiFileReaderData &reader_data, const MultiFileBindData &bind_data,
 	                                              const vector<MultiFileColumnDefinition> &global_columns,
 	                                              const vector<ColumnIndex> &global_column_ids,
 	                                              optional_ptr<TableFilterSet> table_filters, ClientContext &context,
-	                                              optional_ptr<MultiFileReaderGlobalState> global_state) {
-		FinalizeBind(reader_data, bind_data.file_options, bind_data.reader_bind, global_columns, global_column_ids,
-		             context, global_state);
-		return CreateMapping(context, reader_data, global_columns, global_column_ids, table_filters,
-		                     bind_data.file_list->GetFirstFile(), bind_data.reader_bind, bind_data.virtual_columns);
-	}
+	                                              optional_ptr<MultiFileReaderGlobalState> global_state);
 
-	template <class BIND_DATA>
-	static void PruneReaders(BIND_DATA &data, MultiFileList &file_list) {
-		unordered_set<string> file_set;
-
-		// Avoid materializing the file list if there's nothing to prune
-		if (!data.initial_reader && data.union_readers.empty()) {
-			return;
-		}
-
-		for (const auto &file : file_list.Files()) {
-			file_set.insert(file.path);
-		}
-
-		if (data.initial_reader) {
-			// check if the initial reader should still be read
-			auto entry = file_set.find(data.initial_reader->GetFileName());
-			if (entry == file_set.end()) {
-				data.initial_reader.reset();
-			}
-		}
-		for (idx_t r = 0; r < data.union_readers.size(); r++) {
-			if (!data.union_readers[r]) {
-				data.union_readers.erase_at(r);
-				r--;
-				continue;
-			}
-			// check if the union reader should still be read or not
-			auto entry = file_set.find(data.union_readers[r]->GetFileName());
-			if (entry == file_set.end()) {
-				data.union_readers.erase_at(r);
-				r--;
-				continue;
-			}
-		}
-	}
+	static void PruneReaders(MultiFileBindData &data, MultiFileList &file_list);
 
 	//! Get partition info
 	DUCKDB_API virtual TablePartitionInfo GetPartitionInfo(ClientContext &context,

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -131,12 +131,11 @@ public:
 
 	MultiFileReaderBindData BindUnionReader(ClientContext &context, vector<LogicalType> &return_types,
 	                                        vector<string> &names, MultiFileList &files, MultiFileBindData &result,
-	                                        BaseFileReaderOptions &options, MultiFileOptions &file_options,
-	                                        MultiFileReaderInterface &interface);
+	                                        BaseFileReaderOptions &options, MultiFileOptions &file_options);
 
 	MultiFileReaderBindData BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,
 	                                   MultiFileList &files, MultiFileBindData &result, BaseFileReaderOptions &options,
-	                                   MultiFileOptions &file_options, MultiFileReaderInterface &interface);
+	                                   MultiFileOptions &file_options);
 
 	DUCKDB_API virtual ReaderInitializeType
 	InitializeReader(MultiFileReaderData &reader_data, const MultiFileBindData &bind_data,

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -13,7 +13,6 @@
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/types/value.hpp"
-#include "duckdb/common/multi_file/union_by_name.hpp"
 #include "duckdb/common/multi_file/base_file_reader.hpp"
 #include "duckdb/common/multi_file/multi_file_states.hpp"
 

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -60,7 +60,7 @@ struct MultiFileReaderGlobalState {
 };
 
 struct MultiFileBindData : public TableFunctionData {
-	virtual ~MultiFileBindData() override;
+	~MultiFileBindData() override;
 
 	unique_ptr<TableFunctionData> bind_data;
 	shared_ptr<MultiFileList> file_list;

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 
 namespace duckdb {
+struct MultiFileReaderInterface;
 
 //! The bind data for the multi-file reader, obtained through MultiFileReader::BindReader
 struct MultiFileReaderBindData {
@@ -59,9 +60,12 @@ struct MultiFileReaderGlobalState {
 };
 
 struct MultiFileBindData : public TableFunctionData {
+	virtual ~MultiFileBindData() override;
+
 	unique_ptr<TableFunctionData> bind_data;
 	shared_ptr<MultiFileList> file_list;
 	unique_ptr<MultiFileReader> multi_file_reader;
+	unique_ptr<MultiFileReaderInterface> interface;
 	vector<MultiFileColumnDefinition> columns;
 	MultiFileReaderBindData reader_bind;
 	MultiFileOptions file_options;

--- a/src/include/duckdb/common/multi_file/union_by_name.hpp
+++ b/src/include/duckdb/common/multi_file/union_by_name.hpp
@@ -29,7 +29,7 @@ public:
 
 	void ExecuteTask() override {
 		auto reader = OP::CreateReader(context, file, options, file_options);
-		readers[file_idx] = OP::GetUnionData(std::move(reader), file_idx);
+		readers[file_idx] = reader->GetUnionData(file_idx);
 	}
 
 	string TaskType() const override {

--- a/src/include/duckdb/common/multi_file/union_by_name.hpp
+++ b/src/include/duckdb/common/multi_file/union_by_name.hpp
@@ -17,6 +17,7 @@
 #include "duckdb/common/multi_file/multi_file_options.hpp"
 
 namespace duckdb {
+struct MultiFileReader;
 struct MultiFileReaderInterface;
 
 class UnionByName {

--- a/src/include/duckdb/common/multi_file/union_by_name.hpp
+++ b/src/include/duckdb/common/multi_file/union_by_name.hpp
@@ -26,11 +26,10 @@ public:
 	                              case_insensitive_map_t<idx_t> &union_names_map);
 
 	//! Union all files(readers) by their col names
-	static vector<shared_ptr<BaseUnionData>> UnionCols(ClientContext &context, const vector<OpenFileInfo> &files,
-	                                                   vector<LogicalType> &union_col_types,
-	                                                   vector<string> &union_col_names, BaseFileReaderOptions &options,
-	                                                   MultiFileOptions &file_options,
-	                                                   MultiFileReaderInterface &interface);
+	static vector<shared_ptr<BaseUnionData>>
+	UnionCols(ClientContext &context, const vector<OpenFileInfo> &files, vector<LogicalType> &union_col_types,
+	          vector<string> &union_col_names, BaseFileReaderOptions &options, MultiFileOptions &file_options,
+	          MultiFileReader &multi_file_reader, MultiFileReaderInterface &interface);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/multi_file/union_by_name.hpp
+++ b/src/include/duckdb/common/multi_file/union_by_name.hpp
@@ -17,33 +17,7 @@
 #include "duckdb/common/multi_file/multi_file_options.hpp"
 
 namespace duckdb {
-
-template <class OP, class OPTIONS_TYPE>
-class UnionByReaderTask : public BaseExecutorTask {
-public:
-	UnionByReaderTask(TaskExecutor &executor, ClientContext &context, const OpenFileInfo &file, idx_t file_idx,
-	                  vector<shared_ptr<BaseUnionData>> &readers, OPTIONS_TYPE &options, MultiFileOptions &file_options)
-	    : BaseExecutorTask(executor), context(context), file(file), file_idx(file_idx), readers(readers),
-	      options(options), file_options(file_options) {
-	}
-
-	void ExecuteTask() override {
-		auto reader = OP::CreateReader(context, file, options, file_options);
-		readers[file_idx] = reader->GetUnionData(file_idx);
-	}
-
-	string TaskType() const override {
-		return "UnionByReaderTask";
-	}
-
-private:
-	ClientContext &context;
-	const OpenFileInfo &file;
-	idx_t file_idx;
-	vector<shared_ptr<BaseUnionData>> &readers;
-	OPTIONS_TYPE &options;
-	MultiFileOptions &file_options;
-};
+struct MultiFileReaderInterface;
 
 class UnionByName {
 public:
@@ -52,32 +26,11 @@ public:
 	                              case_insensitive_map_t<idx_t> &union_names_map);
 
 	//! Union all files(readers) by their col names
-	template <class OP, class OPTIONS_TYPE>
-	static vector<shared_ptr<BaseUnionData>>
-	UnionCols(ClientContext &context, const vector<OpenFileInfo> &files, vector<LogicalType> &union_col_types,
-	          vector<string> &union_col_names, OPTIONS_TYPE &options, MultiFileOptions &file_options) {
-		vector<shared_ptr<BaseUnionData>> union_readers;
-		union_readers.resize(files.size());
-
-		TaskExecutor executor(context);
-		// schedule tasks for all files
-		for (idx_t file_idx = 0; file_idx < files.size(); ++file_idx) {
-			auto task = make_uniq<UnionByReaderTask<OP, OPTIONS_TYPE>>(executor, context, files[file_idx], file_idx,
-			                                                           union_readers, options, file_options);
-			executor.ScheduleTask(std::move(task));
-		}
-		// complete all tasks
-		executor.WorkOnTasks();
-
-		// now combine the result schemas
-		case_insensitive_map_t<idx_t> union_names_map;
-		for (auto &reader : union_readers) {
-			auto &col_names = reader->names;
-			auto &sql_types = reader->types;
-			CombineUnionTypes(col_names, sql_types, union_col_types, union_col_names, union_names_map);
-		}
-		return union_readers;
-	}
+	static vector<shared_ptr<BaseUnionData>> UnionCols(ClientContext &context, const vector<OpenFileInfo> &files,
+	                                                   vector<LogicalType> &union_col_types,
+	                                                   vector<string> &union_col_names, BaseFileReaderOptions &options,
+	                                                   MultiFileOptions &file_options,
+	                                                   MultiFileReaderInterface &interface);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/windows_undefs.hpp
+++ b/src/include/duckdb/common/windows_undefs.hpp
@@ -43,4 +43,8 @@
 #undef UUID
 #endif
 
+#ifdef interface
+#undef interface
+#endif
+
 #endif

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -55,9 +55,10 @@ public:
 		return true;
 	}
 
+	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
+	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate) override;
 	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
-	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
 
 public:
 	idx_t GetFileIndex() const {

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -46,6 +46,18 @@ public:
 	void SetNamesAndTypes(const vector<string> &names, const vector<LogicalType> &types);
 
 public:
+	string GetReaderType() const override {
+		return "CSV";
+	}
+
+	bool UseCastMap() const override {
+		//! Whether or not to push casts into the cast map
+		return true;
+	}
+
+	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+public:
 	idx_t GetFileIndex() const {
 		return file_list_idx.GetIndex();
 	}
@@ -56,15 +68,6 @@ public:
 
 	//! Initialize the actual names and types to be scanned from the file
 	void InitializeFileNamesTypes();
-
-	string GetReaderType() const override {
-		return "CSV";
-	}
-
-	bool UseCastMap() const override {
-		//! Whether or not to push casts into the cast map
-		return true;
-	}
 
 public:
 	//! Buffer Manager for the CSV File

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -55,6 +55,7 @@ public:
 		return true;
 	}
 
+	shared_ptr<BaseUnionData> GetUnionData(idx_t file_idx) override;
 	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -60,6 +60,7 @@ public:
 	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
+	double GetProgressInFile(ClientContext &context) override;
 
 public:
 	idx_t GetFileIndex() const {

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -59,6 +59,7 @@ public:
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate) override;
 	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 
 public:
 	idx_t GetFileIndex() const {

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -56,9 +56,10 @@ public:
 	}
 
 	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
-	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
+	                       LocalTableFunctionState &lstate) override;
+	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
+	          DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -57,6 +57,8 @@ public:
 
 	void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 			 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
+
 public:
 	idx_t GetFileIndex() const {
 		return file_list_idx.GetIndex();

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
@@ -15,6 +15,10 @@ namespace duckdb {
 
 class CSVFileReaderOptions : public BaseFileReaderOptions {
 public:
+	CSVFileReaderOptions() = default;
+	explicit CSVFileReaderOptions(CSVReaderOptions options_p) : options(std::move(options_p)) {
+	}
+
 	CSVReaderOptions options;
 };
 
@@ -46,8 +50,9 @@ struct CSVMultiFileInfo : public MultiFileReaderInterface {
 	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
 	                                        const OpenFileInfo &file, idx_t file_idx,
 	                                        const MultiFileBindData &bind_data) override;
-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
-	                                               CSVReaderOptions &options, const MultiFileOptions &file_options);
+	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
+	                                        BaseFileReaderOptions &options,
+	                                        const MultiFileOptions &file_options) override;
 	void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                   LocalTableFunctionState &local_state) override;
 	unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) override;

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
@@ -51,7 +51,6 @@ struct CSVMultiFileInfo {
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);
 	static unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, BaseFileReader &reader, const string &name);
-	static double GetProgressInFile(ClientContext &context, const BaseFileReader &reader);
 	static void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
 };
 

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
@@ -18,9 +18,11 @@ public:
 	CSVReaderOptions options;
 };
 
-struct CSVMultiFileInfo {
-	static unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
-	                                                           optional_ptr<TableFunctionInfo> info);
+struct CSVMultiFileInfo : public MultiFileReaderInterface {
+	static unique_ptr<MultiFileReaderInterface> InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list);
+
+	unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
+	                                                           optional_ptr<TableFunctionInfo> info) override;
 	static bool ParseCopyOption(ClientContext &context, const string &key, const vector<Value> &values,
 	                            BaseFileReaderOptions &options, vector<string> &expected_names,
 	                            vector<LogicalType> &expected_types);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
@@ -19,39 +19,38 @@ public:
 };
 
 struct CSVMultiFileInfo : public MultiFileReaderInterface {
-	static unique_ptr<MultiFileReaderInterface> InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list);
+	static unique_ptr<MultiFileReaderInterface> InitializeInterface(ClientContext &context, MultiFileReader &reader,
+	                                                                MultiFileList &file_list);
 
 	unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
-	                                                           optional_ptr<TableFunctionInfo> info) override;
-	static bool ParseCopyOption(ClientContext &context, const string &key, const vector<Value> &values,
-	                            BaseFileReaderOptions &options, vector<string> &expected_names,
-	                            vector<LogicalType> &expected_types);
-	static bool ParseOption(ClientContext &context, const string &key, const Value &val, MultiFileOptions &file_options,
-	                        BaseFileReaderOptions &options);
-	static void FinalizeCopyBind(ClientContext &context, BaseFileReaderOptions &options,
-	                             const vector<string> &expected_names, const vector<LogicalType> &expected_types);
-	static unique_ptr<TableFunctionData> InitializeBindData(MultiFileBindData &multi_file_data,
-	                                                        unique_ptr<BaseFileReaderOptions> options);
-	static void BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,
-	                       MultiFileBindData &bind_data);
-	static void FinalizeBindData(MultiFileBindData &multi_file_data);
-	static void GetBindInfo(const TableFunctionData &bind_data, BindInfo &info);
-	static optional_idx MaxThreads(const MultiFileBindData &bind_data_p, const MultiFileGlobalState &global_state,
-	                               FileExpandResult expand_result);
-	static unique_ptr<GlobalTableFunctionState>
-	InitializeGlobalState(ClientContext &context, MultiFileBindData &bind_data, MultiFileGlobalState &global_state);
-	static unique_ptr<LocalTableFunctionState> InitializeLocalState(ExecutionContext &, GlobalTableFunctionState &);
-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
-	                                               BaseUnionData &union_data, const MultiFileBindData &bind_data_p);
-	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
-	                                               const OpenFileInfo &file, idx_t file_idx,
-	                                               const MultiFileBindData &bind_data);
+	                                                    optional_ptr<TableFunctionInfo> info) override;
+	bool ParseCopyOption(ClientContext &context, const string &key, const vector<Value> &values,
+	                     BaseFileReaderOptions &options, vector<string> &expected_names,
+	                     vector<LogicalType> &expected_types) override;
+	bool ParseOption(ClientContext &context, const string &key, const Value &val, MultiFileOptions &file_options,
+	                 BaseFileReaderOptions &options) override;
+	void FinalizeCopyBind(ClientContext &context, BaseFileReaderOptions &options, const vector<string> &expected_names,
+	                      const vector<LogicalType> &expected_types) override;
+	unique_ptr<TableFunctionData> InitializeBindData(MultiFileBindData &multi_file_data,
+	                                                 unique_ptr<BaseFileReaderOptions> options) override;
+	void BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,
+	                MultiFileBindData &bind_data) override;
+	void FinalizeBindData(MultiFileBindData &multi_file_data) override;
+	optional_idx MaxThreads(const MultiFileBindData &bind_data_p, const MultiFileGlobalState &global_state,
+	                        FileExpandResult expand_result) override;
+	unique_ptr<GlobalTableFunctionState> InitializeGlobalState(ClientContext &context, MultiFileBindData &bind_data,
+	                                                           MultiFileGlobalState &global_state) override;
+	unique_ptr<LocalTableFunctionState> InitializeLocalState(ExecutionContext &, GlobalTableFunctionState &) override;
+	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
+	                                        BaseUnionData &union_data, const MultiFileBindData &bind_data_p) override;
+	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,
+	                                        const OpenFileInfo &file, idx_t file_idx,
+	                                        const MultiFileBindData &bind_data) override;
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               CSVReaderOptions &options, const MultiFileOptions &file_options);
-	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
-	                          LocalTableFunctionState &local_state);
-	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);
-	static void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
+	void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
+	                   LocalTableFunctionState &local_state) override;
+	unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
@@ -50,7 +50,6 @@ struct CSVMultiFileInfo {
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);
-	static unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, BaseFileReader &reader, const string &name);
 	static void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
 };
 

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
@@ -47,7 +47,6 @@ struct CSVMultiFileInfo {
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               CSVReaderOptions &options, const MultiFileOptions &file_options);
 	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
-	static void FinalizeReader(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &);
 	static bool TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
 	                              GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
 	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
@@ -47,7 +47,6 @@ struct CSVMultiFileInfo {
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               CSVReaderOptions &options, const MultiFileOptions &file_options);
 	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
-	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
@@ -46,7 +46,6 @@ struct CSVMultiFileInfo {
 	                                               const MultiFileBindData &bind_data);
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               CSVReaderOptions &options, const MultiFileOptions &file_options);
-	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);
 	static unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
@@ -50,8 +50,6 @@ struct CSVMultiFileInfo {
 	static void FinalizeReader(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &);
 	static bool TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
 	                              GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
-	static void Scan(ClientContext &context, BaseFileReader &reader, GlobalTableFunctionState &global_state,
-	                 LocalTableFunctionState &local_state, DataChunk &chunk);
 	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
@@ -47,8 +47,6 @@ struct CSVMultiFileInfo {
 	static shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                               CSVReaderOptions &options, const MultiFileOptions &file_options);
 	static shared_ptr<BaseUnionData> GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx);
-	static bool TryInitializeScan(ClientContext &context, shared_ptr<BaseFileReader> &reader,
-	                              GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
 	static void FinishFile(ClientContext &context, GlobalTableFunctionState &global_state, BaseFileReader &reader);
 	static void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                          LocalTableFunctionState &local_state);

--- a/src/main/relation/read_csv_relation.cpp
+++ b/src/main/relation/read_csv_relation.cpp
@@ -54,7 +54,7 @@ CSVReaderOptions ReadCSVRelationBind(const shared_ptr<ClientContext> &context, c
 		result->interface = make_uniq<CSVMultiFileInfo>();
 
 		multi_file_reader->BindUnionReader(*context, types, names, multi_file_list, *result, csv_file_options,
-		                                   file_options, *result->interface);
+		                                   file_options);
 		if (!csv_options.sql_types_per_column.empty()) {
 			const auto exception = CSVError::ColumnTypesError(csv_options.sql_types_per_column, names);
 			if (!exception.error_message.empty()) {

--- a/src/main/relation/read_csv_relation.cpp
+++ b/src/main/relation/read_csv_relation.cpp
@@ -37,7 +37,8 @@ CSVReaderOptions ReadCSVRelationBind(const shared_ptr<ClientContext> &context, c
 	D_ASSERT(!files.empty());
 
 	auto &file_name = files[0];
-	CSVReaderOptions csv_options;
+	CSVFileReaderOptions csv_file_options;
+	auto &csv_options = csv_file_options.options;
 	csv_options.file_path = file_name.path;
 	vector<string> empty;
 	csv_options.FromNamedParameters(options, *context, file_options);
@@ -50,9 +51,10 @@ CSVReaderOptions ReadCSVRelationBind(const shared_ptr<ClientContext> &context, c
 		vector<string> names;
 		auto result = make_uniq<MultiFileBindData>();
 		auto csv_data = make_uniq<ReadCSVData>();
+		result->interface = make_uniq<CSVMultiFileInfo>();
 
-		multi_file_reader->BindUnionReader<CSVMultiFileInfo>(*context, types, names, multi_file_list, *result,
-		                                                     csv_options, file_options);
+		multi_file_reader->BindUnionReader(*context, types, names, multi_file_list, *result, csv_file_options,
+		                                   file_options, *result->interface);
 		if (!csv_options.sql_types_per_column.empty()) {
 			const auto exception = CSVError::ColumnTypesError(csv_options.sql_types_per_column, names);
 			if (!exception.error_message.empty()) {


### PR DESCRIPTION
This PR reworks the multi-file reader so that the `MultiFileReaderInterface` is a virtual class that must be inherited from instead of a class filled with static methods. This has a number of advantages:

* The interface is well defined (virtual methods that must be implemented)
* We can provide default implementations for methods that might not need to be overloaded by all implementations
* This is extensible - we can add methods without needing to implement them to all implementations by providing a default

The interface is obtained through a single static method that must be defined on the interface object:

```cpp
static unique_ptr<MultiFileReaderInterface> InitializeInterface(ClientContext &context, MultiFileReader &reader, MultiFileList &file_list);
```

Several methods are also moved from the `MultiFileInterface` to the `BaseFileReader`. This allows potentially different types of `BaseFileReader` objects to be used within the same multi-file reader.