### PR TITLE
Remove duplicated arrow fetch test

### DIFF
--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch.py
@@ -19,18 +19,6 @@ def check_equal(duckdb_conn):
 
 
 class TestArrowFetch(object):
-    def test_over_vector_size(self, duckdb_cursor):
-        if not can_run:
-            return
-
-        duckdb_conn = duckdb.connect()
-        duckdb_conn.execute("CREATE TABLE test (a  INTEGER)")
-        for value in range(10000):
-            duckdb_conn.execute("INSERT INTO  test VALUES (" + str(value) + ");")
-        duckdb_conn.execute("INSERT INTO  test VALUES(NULL);")
-
-        check_equal(duckdb_conn)
-
     def test_empty_table(self, duckdb_cursor):
         if not can_run:
             return


### PR DESCRIPTION
# PR Summary
Small PR - removes the duplicated `test_over_vector_size` test - both contain the same logic so one of them is redundant. 