### PR TITLE
Fix GeoParquet ExpressionColumnReader schema

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -105,7 +105,7 @@ jobs:
     needs: linux-memory-leaks
     env:
       GEN: ninja
-      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;httpfs"
+      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;httpfs;spatial"
       DISABLE_SANITIZER: 1
       CRASH_ON_ASSERT: 1
       RUN_SLOW_VERIFIERS: 1

--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -225,7 +225,7 @@ void ColumnWriter::HandleDefineLevels(ColumnWriterState &state, ColumnWriterStat
 //===--------------------------------------------------------------------===//
 // Used to store the metadata for a WKB-encoded geometry column when writing
 // GeoParquet files.
-class WKBColumnWriterState final : public StandardColumnWriterState<string_t, string_t, ParquetCastOperator> {
+class WKBColumnWriterState final : public StandardColumnWriterState<string_t, string_t, ParquetStringOperator> {
 public:
 	WKBColumnWriterState(ParquetWriter &writer, duckdb_parquet::RowGroup &row_group, idx_t col_idx)
 	    : StandardColumnWriterState(writer, row_group, col_idx), geo_data(), geo_data_writer(writer.GetContext()) {

--- a/extension/parquet/geo_parquet.cpp
+++ b/extension/parquet/geo_parquet.cpp
@@ -413,7 +413,7 @@ unique_ptr<ColumnReader> GeoParquetFileMetadata::CreateColumnReader(ParquetReade
 		auto child_reader = ColumnReader::CreateReader(reader, schema.children[0]);
 
 		// Create an expression reader that applies the conversion function to the child reader
-		return make_uniq<ExpressionColumnReader>(context, std::move(child_reader), std::move(expr));
+		return make_uniq<ExpressionColumnReader>(context, std::move(child_reader), std::move(expr), schema);
 	}
 
 	// Otherwise, unrecognized encoding

--- a/extension/parquet/include/reader/expression_column_reader.hpp
+++ b/extension/parquet/include/reader/expression_column_reader.hpp
@@ -19,17 +19,18 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	ExpressionColumnReader(ClientContext &context, unique_ptr<ColumnReader> child_reader, unique_ptr<Expression> expr);
 	ExpressionColumnReader(ClientContext &context, unique_ptr<ColumnReader> child_reader, unique_ptr<Expression> expr,
-	                       unique_ptr<ParquetColumnSchema> expression_schema);
-
-	unique_ptr<ParquetColumnSchema> cast_schema;
+	                       const ParquetColumnSchema &schema);
+	ExpressionColumnReader(ClientContext &context, unique_ptr<ColumnReader> child_reader, unique_ptr<Expression> expr,
+	                       unique_ptr<ParquetColumnSchema> owned_schema);
 
 	unique_ptr<ColumnReader> child_reader;
 	DataChunk intermediate_chunk;
 	unique_ptr<Expression> expr;
 	ExpressionExecutor executor;
-	unique_ptr<ParquetColumnSchema> expression_schema;
+
+	// If this reader was created on top of a child reader, after-the-fact, the schema needs to live somewhere
+	unique_ptr<ParquetColumnSchema> owned_schema;
 
 public:
 	void InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns, TProtocol &protocol_p) override;

--- a/extension/parquet/reader/expression_column_reader.cpp
+++ b/extension/parquet/reader/expression_column_reader.cpp
@@ -7,8 +7,8 @@ namespace duckdb {
 // Expression Column Reader
 //===--------------------------------------------------------------------===//
 ExpressionColumnReader::ExpressionColumnReader(ClientContext &context, unique_ptr<ColumnReader> child_reader_p,
-                                               unique_ptr<Expression> expr_p)
-    : ColumnReader(child_reader_p->Reader(), child_reader_p->Schema()), child_reader(std::move(child_reader_p)),
+                                               unique_ptr<Expression> expr_p, const ParquetColumnSchema &schema_p)
+    : ColumnReader(child_reader_p->Reader(), schema_p), child_reader(std::move(child_reader_p)),
       expr(std::move(expr_p)), executor(context, expr.get()) {
 	vector<LogicalType> intermediate_types {child_reader->Type()};
 	intermediate_chunk.Initialize(reader.allocator, intermediate_types);
@@ -16,9 +16,9 @@ ExpressionColumnReader::ExpressionColumnReader(ClientContext &context, unique_pt
 
 ExpressionColumnReader::ExpressionColumnReader(ClientContext &context, unique_ptr<ColumnReader> child_reader_p,
                                                unique_ptr<Expression> expr_p,
-                                               unique_ptr<ParquetColumnSchema> expression_schema_p)
-    : ColumnReader(child_reader_p->Reader(), *expression_schema_p), child_reader(std::move(child_reader_p)),
-      expr(std::move(expr_p)), executor(context, expr.get()), expression_schema(std::move(expression_schema_p)) {
+                                               unique_ptr<ParquetColumnSchema> owned_schema_p)
+    : ColumnReader(child_reader_p->Reader(), *owned_schema_p), child_reader(std::move(child_reader_p)),
+      expr(std::move(expr_p)), executor(context, expr.get()), owned_schema(std::move(owned_schema_p)) {
 	vector<LogicalType> intermediate_types {child_reader->Type()};
 	intermediate_chunk.Initialize(reader.allocator, intermediate_types);
 }


### PR DESCRIPTION
This PR fixes an issue where GeoParquet support broke due to changes made to the parquet expression column reader. 

Previously, if no schema was provided when creating a ExpressionColumnReader, the schema of the child column reader was used, but this no longer works as GEOMETRY columns now create a nested child schema for the underlying blob column, meaning that the resulting expression reader would have the same return type as the child, i.e. BLOB, not GEOMETRY. The fix here is simply to pass the schema in the ExpressionColumnReader constructor, and not copy the child schema. 

However, there are other places where we add an expression reader on top of an existing reader/schema, and create a new column schema. In these cases its important that this new schema lives as long as the ExpressionColumnReader, hence the ExpressionColumnReader now takes a schema either as a const reference (if it already has a corresponding schema, as is the case for GeoParquet), or as a "owning" unique pointer (if its added on top of an existing schema afterwards).

Additionally, this PR also adds spatial to the nightly test CI to avoid this breaking again unnoticed in the future.