### PR TITLE
add regression_threshold_seconds argument to `regression/test_runner.py`

### DIFF
--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -26,14 +26,6 @@ def geomean(xs):
             return entry
     return math.exp(math.fsum(math.log(float(x)) for x in xs) / len(xs))
 
-
-# how many times we will run the experiment, to be sure of the regression
-NUMBER_REPETITIONS = 5
-# the threshold at which we consider something a regression (percentage)
-REGRESSION_THRESHOLD_PERCENTAGE = 0.1
-# minimal seconds diff for something to be a regression (for very fast benchmarks)
-REGRESSION_THRESHOLD_SECONDS = 0.05
-
 import argparse
 
 # Set up the argument parser
@@ -50,6 +42,7 @@ parser.add_argument("--disable-timeout", action="store_true", help="Disable time
 parser.add_argument("--max-timeout", type=int, default=3600, help="Set maximum timeout in seconds (default: 3600).")
 parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
 parser.add_argument("--no-summary", type=str, default=False, help="No summary in the end.")
+parser.add_argument("--regression-threshold-seconds", type=float, default=0.05, help="REGRESSION_THRESHOLD_SECONDS value for large benchmarks.")
 
 # Parse the arguments
 args = parser.parse_args()
@@ -65,6 +58,15 @@ disable_timeout = args.disable_timeout
 max_timeout = args.max_timeout
 root_dir = args.root_dir
 no_summary = args.no_summary
+regression_threshold_seconds = args.regression_threshold_seconds
+
+
+# how many times we will run the experiment, to be sure of the regression
+NUMBER_REPETITIONS = 5
+# the threshold at which we consider something a regression (percentage)
+REGRESSION_THRESHOLD_PERCENTAGE = 0.1
+# minimal seconds diff for something to be a regression (for very fast benchmarks)
+REGRESSION_THRESHOLD_SECONDS = regression_threshold_seconds
 
 if not os.path.isfile(old_runner_path):
     print(f"Failed to find old runner {old_runner_path}")

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -26,6 +26,7 @@ def geomean(xs):
             return entry
     return math.exp(math.fsum(math.log(float(x)) for x in xs) / len(xs))
 
+
 import argparse
 
 # Set up the argument parser
@@ -42,7 +43,12 @@ parser.add_argument("--disable-timeout", action="store_true", help="Disable time
 parser.add_argument("--max-timeout", type=int, default=3600, help="Set maximum timeout in seconds (default: 3600).")
 parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
 parser.add_argument("--no-summary", type=str, default=False, help="No summary in the end.")
-parser.add_argument("--regression-threshold-seconds", type=float, default=0.05, help="REGRESSION_THRESHOLD_SECONDS value for large benchmarks.")
+parser.add_argument(
+    "--regression-threshold-seconds",
+    type=float,
+    default=0.05,
+    help="REGRESSION_THRESHOLD_SECONDS value for large benchmarks.",
+)
 
 # Parse the arguments
 args = parser.parse_args()


### PR DESCRIPTION
Current value of the `regression_threshold_seconds` is for very fast benchmarks (e.g. sf=0.1). Which more likely causes false positive regressions on large scale factor (sf=100) regression tests.

When run large scale factor (sf=100) regression tests, we'd like to define a bigger `regression_threshold_seconds` value.

Run the `regression/test_runner.py --regression-threshold-seconds=2.0` when with large scale factor. There is a default value of the regression threshold in seconds for very fast benchmarks, so run it without passing `regression-threshold-seconds` parameter to the test runner.