### PR TITLE
HTTPUtil Fix: correctly pass in on_retry

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -246,6 +246,6 @@ public:
 public:
 	static duckdb::unique_ptr<HTTPResponse>
 	RunRequestWithRetry(const std::function<unique_ptr<HTTPResponse>(void)> &on_request, const BaseRequest &request,
-	                    const std::function<void(void)> &retry_cb = {});
+	                    const std::function<void(void)> &retry_cb);
 };
 } // namespace duckdb

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -235,7 +235,7 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 	// Refresh the client on retries
 	std::function<void(void)> on_retry([&]() { client = InitializeClient(request.params, request.proto_host_port); });
 
-	return RunRequestWithRetry(on_request, request);
+	return RunRequestWithRetry(on_request, request, on_retry);
 }
 
 void HTTPUtil::ParseHTTPProxyHost(string &proxy_value, string &hostname_out, idx_t &port_out, idx_t default_port) {


### PR DESCRIPTION
This method was accidentally left unused