### PR TITLE
Minor nightly fixes

### DIFF
--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -29,7 +29,6 @@ PartialBlockForCheckpoint::PartialBlockForCheckpoint(ColumnData &data, ColumnSeg
 }
 
 PartialBlockForCheckpoint::~PartialBlockForCheckpoint() {
-	D_ASSERT(IsFlushed() || Exception::UncaughtException());
 }
 
 bool PartialBlockForCheckpoint::IsFlushed() {

--- a/test/sql/storage/compression/dict_fsst/dictionary_covers_validity.test
+++ b/test/sql/storage/compression/dict_fsst/dictionary_covers_validity.test
@@ -1,6 +1,10 @@
 # name: test/sql/storage/compression/dict_fsst/dictionary_covers_validity.test
 # group: [dict_fsst]
 
+# This test defaults to another compression function for smaller block sizes,
+# because the bitpacking groups no longer fit the blocks.
+require block_size 262144
+
 load __TEST_DIR__/dictionary_covers_validity readwrite v1.3.0
 
 statement ok


### PR DESCRIPTION
* Require `block_size` for new DICT_FSST test
* Remove incorrect assertion