### PR TITLE
Add FileSystem::TryRemoveFile - that only removes a file if it exists

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -551,6 +551,14 @@ void FileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> ope
 	throw NotImplementedException("%s: RemoveFile is not implemented!", GetName());
 }
 
+bool FileSystem::TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
+	if (FileExists(filename, opener)) {
+		RemoveFile(filename, opener);
+		return true;
+	}
+	return false;
+}
+
 void FileSystem::FileSync(FileHandle &handle) {
 	throw NotImplementedException("%s: FileSync is not implemented!", GetName());
 }

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -120,6 +120,10 @@ void VirtualFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpen
 	FindFileSystem(filename).RemoveFile(filename, opener);
 }
 
+bool VirtualFileSystem::TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
+	return FindFileSystem(filename).TryRemoveFile(filename, opener);
+}
+
 string VirtualFileSystem::PathSeparator(const string &path) {
 	return FindFileSystem(path).PathSeparator(path);
 }

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -458,9 +458,7 @@ unique_ptr<GlobalSinkState> PhysicalCopyToFile::GetGlobalSinkState(ClientContext
 void PhysicalCopyToFile::MoveTmpFile(ClientContext &context, const string &tmp_file_path) {
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto file_path = GetNonTmpFile(context, tmp_file_path);
-	if (fs.FileExists(file_path)) {
-		fs.RemoveFile(file_path);
-	}
+	fs.TryRemoveFile(file_path);
 	fs.MoveFile(tmp_file_path, file_path);
 }
 

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -178,6 +178,8 @@ public:
 	DUCKDB_API virtual bool IsPipe(const string &filename, optional_ptr<FileOpener> opener = nullptr);
 	//! Remove a file from disk
 	DUCKDB_API virtual void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr);
+	//! Remvoe a file from disk if it exists - if it does not exist, return false
+	DUCKDB_API virtual bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr);
 	//! Sync a file handle to disk
 	DUCKDB_API virtual void FileSync(FileHandle &handle);
 	//! Sets the working directory

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -107,6 +107,12 @@ public:
 		GetFileSystem().RemoveFile(filename, GetOpener());
 	}
 
+	bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) override {
+		VerifyNoOpener(opener);
+		VerifyCanAccessFile(filename);
+		return GetFileSystem().TryRemoveFile(filename, GetOpener());
+	}
+
 	string PathSeparator(const string &path) override {
 		return GetFileSystem().PathSeparator(path);
 	}

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -48,6 +48,7 @@ public:
 
 	bool IsPipe(const string &filename, optional_ptr<FileOpener> opener) override;
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener) override;
+	bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) override;
 
 	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -250,14 +250,10 @@ static void WriteExtensionFiles(FileSystem &fs, const string &temp_path, const s
 	WriteExtensionMetadataFileToDisk(fs, metadata_tmp_path, info);
 
 	// First remove the local extension we are about to replace
-	if (fs.FileExists(local_extension_path)) {
-		fs.RemoveFile(local_extension_path);
-	}
+	fs.TryRemoveFile(local_extension_path);
 
 	// Then remove the old metadata file
-	if (fs.FileExists(metadata_file_path)) {
-		fs.RemoveFile(metadata_file_path);
-	}
+	fs.TryRemoveFile(metadata_file_path);
 
 	fs.MoveFile(metadata_tmp_path, metadata_file_path);
 	fs.MoveFile(temp_path, local_extension_path);
@@ -495,9 +491,7 @@ ExtensionHelper::InstallExtensionInternal(DatabaseInstance &db, FileSystem &fs, 
 		return nullptr;
 	}
 
-	if (fs.FileExists(temp_path)) {
-		fs.RemoveFile(temp_path);
-	}
+	fs.TryRemoveFile(temp_path);
 
 	if (ExtensionHelper::IsFullPath(extension) && options.repository) {
 		throw InvalidInputException("Cannot pass both a repository and a full path url");

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -220,13 +220,9 @@ void LocalFileSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConfl
 	string temp_path = file_path + ".tmp-" + UUID::ToString(UUID::GenerateRandomUUID());
 
 	// If persistent file already exists remove
-	if (fs.FileExists(file_path)) {
-		fs.RemoveFile(file_path);
-	}
+	fs.TryRemoveFile(file_path);
 	// If temporary file already exists remove
-	if (fs.FileExists(temp_path)) {
-		fs.RemoveFile(temp_path);
-	}
+	fs.TryRemoveFile(temp_path);
 
 	WriteSecretFileToDisk(fs, temp_path, secret);
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -168,13 +168,9 @@ void SingleFileStorageManager::LoadDatabase(StorageOptions storage_options) {
 		// file does not exist and we are in read-write mode
 		// create a new file
 
-		// check if a WAL file already exists
 		auto wal_path = GetWALPath();
-		if (fs.FileExists(wal_path)) {
-			// WAL file exists but database file does not
-			// remove the WAL
-			fs.RemoveFile(wal_path);
-		}
+		// try to remove the WAL file if it exists
+		fs.TryRemoveFile(wal_path);
 
 		// Set the block allocation size for the new database file.
 		if (storage_options.block_alloc_size.IsValid()) {

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -93,7 +93,7 @@ void WriteAheadLog::Delete() {
 	}
 	writer.reset();
 	auto &fs = FileSystem::Get(database);
-	fs.RemoveFile(wal_path);
+	fs.TryRemoveFile(wal_path);
 	init_state = WALInitState::NO_WAL;
 	wal_size = 0;
 }

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -51,9 +51,7 @@ void TestDeleteDirectory(string path) {
 void TestDeleteFile(string path) {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
 	try {
-		if (fs->FileExists(path)) {
-			fs->RemoveFile(path);
-		}
+		fs->TryRemoveFile(path);
 	} catch (...) {
 	}
 }


### PR DESCRIPTION
Many places in the code have the following pattern:

```cpp
if (fs.FileExists(local_extension_path)) {
	fs.RemoveFile(local_extension_path);
}
```

This is both racy (what if the file is removed after the `FileExists` call) and inefficient (need to do two syscalls/round-trips). This PR provides a new method `TryRemoveFile` that only removes files if it exists. Currently it still falls back to the original implementation, but we can pull it through to the various file system layers in follow-up PRs to avoid having to do two round-trips.