### PR TITLE
Add OperatorFinalize callback to operators - which is called after a pipeline is finished

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -2801,6 +2801,24 @@ OnEntryNotFound EnumUtil::FromString<OnEntryNotFound>(const char *value) {
 	return static_cast<OnEntryNotFound>(StringUtil::StringToEnum(GetOnEntryNotFoundValues(), 2, "OnEntryNotFound", value));
 }
 
+const StringUtil::EnumStringLiteral *GetOperatorFinalResultTypeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(OperatorFinalResultType::FINISHED), "FINISHED" },
+		{ static_cast<uint32_t>(OperatorFinalResultType::BLOCKED), "BLOCKED" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<OperatorFinalResultType>(OperatorFinalResultType value) {
+	return StringUtil::EnumToString(GetOperatorFinalResultTypeValues(), 2, "OperatorFinalResultType", static_cast<uint32_t>(value));
+}
+
+template<>
+OperatorFinalResultType EnumUtil::FromString<OperatorFinalResultType>(const char *value) {
+	return static_cast<OperatorFinalResultType>(StringUtil::StringToEnum(GetOperatorFinalResultTypeValues(), 2, "OperatorFinalResultType", value));
+}
+
 const StringUtil::EnumStringLiteral *GetOperatorFinalizeResultTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(OperatorFinalizeResultType::HAVE_MORE_OUTPUT), "HAVE_MORE_OUTPUT" },

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -96,6 +96,11 @@ OperatorFinalizeResultType PhysicalOperator::FinalExecute(ExecutionContext &cont
                                                           GlobalOperatorState &gstate, OperatorState &state) const {
 	throw InternalException("Calling FinalExecute on a node that is not an operator!");
 }
+
+OperatorFinalResultType PhysicalOperator::OperatorFinalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                           OperatorFinalizeInput &input) const {
+	throw InternalException("Calling FinalExecute on a node that is not an operator!");
+}
 // LCOV_EXCL_STOP
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -256,6 +256,8 @@ enum class OnCreateConflict : uint8_t;
 
 enum class OnEntryNotFound : uint8_t;
 
+enum class OperatorFinalResultType : uint8_t;
+
 enum class OperatorFinalizeResultType : uint8_t;
 
 enum class OperatorResultType : uint8_t;
@@ -748,6 +750,9 @@ const char* EnumUtil::ToChars<OnCreateConflict>(OnCreateConflict value);
 
 template<>
 const char* EnumUtil::ToChars<OnEntryNotFound>(OnEntryNotFound value);
+
+template<>
+const char* EnumUtil::ToChars<OperatorFinalResultType>(OperatorFinalResultType value);
 
 template<>
 const char* EnumUtil::ToChars<OperatorFinalizeResultType>(OperatorFinalizeResultType value);
@@ -1319,6 +1324,9 @@ OnCreateConflict EnumUtil::FromString<OnCreateConflict>(const char *value);
 
 template<>
 OnEntryNotFound EnumUtil::FromString<OnEntryNotFound>(const char *value);
+
+template<>
+OperatorFinalResultType EnumUtil::FromString<OperatorFinalResultType>(const char *value);
 
 template<>
 OperatorFinalizeResultType EnumUtil::FromString<OperatorFinalizeResultType>(const char *value);

--- a/src/include/duckdb/common/enums/operator_result_type.hpp
+++ b/src/include/duckdb/common/enums/operator_result_type.hpp
@@ -31,6 +31,9 @@ enum class OperatorResultType : uint8_t { NEED_MORE_INPUT, HAVE_MORE_OUTPUT, FIN
 //! HAVE_MORE_OUTPUT means the operator contains more results.
 enum class OperatorFinalizeResultType : uint8_t { HAVE_MORE_OUTPUT, FINISHED };
 
+//! OperatorFinalResultType is used for the final call
+enum class OperatorFinalResultType : uint8_t { FINISHED, BLOCKED };
+
 //! SourceResultType is used to indicate the result of data being pulled out of a source.
 //! There are three possible results:
 //! HAVE_MORE_OUTPUT means the source has more output, this flag should only be set when data is returned, empty results

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -153,7 +153,7 @@ public:
 	DUCKDB_API virtual shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                                           BaseFileReaderOptions &options,
 	                                                           const MultiFileOptions &file_options,
-	                                                           MultiFileReaderInterface &interfac);
+	                                                           MultiFileReaderInterface &interface);
 
 	//! Get partition info
 	DUCKDB_API virtual TablePartitionInfo GetPartitionInfo(ClientContext &context,

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -98,12 +98,18 @@ public:
 	                                   GlobalOperatorState &gstate, OperatorState &state) const;
 	virtual OperatorFinalizeResultType FinalExecute(ExecutionContext &context, DataChunk &chunk,
 	                                                GlobalOperatorState &gstate, OperatorState &state) const;
+	virtual OperatorFinalResultType OperatorFinalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                                                 OperatorFinalizeInput &input) const;
 
 	virtual bool ParallelOperator() const {
 		return false;
 	}
 
 	virtual bool RequiresFinalExecute() const {
+		return false;
+	}
+
+	virtual bool RequiresOperatorFinalize() const {
 		return false;
 	}
 

--- a/src/include/duckdb/execution/physical_operator_states.hpp
+++ b/src/include/duckdb/execution/physical_operator_states.hpp
@@ -171,6 +171,11 @@ struct OperatorSinkFinalizeInput {
 	InterruptState &interrupt_state;
 };
 
+struct OperatorFinalizeInput {
+	GlobalOperatorState &global_state;
+	InterruptState &interrupt_state;
+};
+
 struct OperatorSinkNextBatchInput {
 	GlobalSinkState &global_state;
 	LocalSinkState &local_state;

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -105,6 +105,7 @@ public:
 	//! Returns a list of all operators (including source and sink) involved in this pipeline
 	vector<reference<PhysicalOperator>> GetOperators();
 	vector<const_reference<PhysicalOperator>> GetOperators() const;
+	const vector<reference<PhysicalOperator>> &GetIntermediateOperators() const;
 
 	optional_ptr<PhysicalOperator> GetSink() {
 		return sink;

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -292,6 +292,10 @@ vector<const_reference<PhysicalOperator>> Pipeline::GetOperators() const {
 	return result;
 }
 
+const vector<reference<PhysicalOperator>> &Pipeline::GetIntermediateOperators() const {
+	return operators;
+}
+
 void Pipeline::ClearSource() {
 	source_state.reset();
 	batch_indexes.clear();

--- a/src/parallel/pipeline_finish_event.cpp
+++ b/src/parallel/pipeline_finish_event.cpp
@@ -19,7 +19,6 @@ public:
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
 		auto sink = pipeline.GetSink();
 		InterruptState interrupt_state(shared_from_this());
-		OperatorSinkFinalizeInput finalize_input {*sink->sink_state, interrupt_state};
 
 #ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
 		if (debug_blocked_count < debug_blocked_target_count) {
@@ -35,6 +34,21 @@ public:
 			return TaskExecutionResult::TASK_BLOCKED;
 		}
 #endif
+		// call finalize on the intermediate operators
+		auto &&operators = pipeline.GetIntermediateOperators();
+		for (; operator_idx < operators.size(); operator_idx++) {
+			auto &op = operators[operator_idx].get();
+			if (!op.RequiresOperatorFinalize()) {
+				continue;
+			}
+			OperatorFinalizeInput op_finalize_input {*op.op_state, interrupt_state};
+			auto op_state = op.OperatorFinalize(pipeline, *event, executor.context, op_finalize_input);
+			if (op_state == OperatorFinalResultType::BLOCKED) {
+				return TaskExecutionResult::TASK_BLOCKED;
+			}
+		}
+
+		OperatorSinkFinalizeInput finalize_input {*sink->sink_state, interrupt_state};
 		auto sink_state = sink->Finalize(pipeline, *event, executor.context, finalize_input);
 
 		if (sink_state == SinkFinalizeType::BLOCKED) {
@@ -51,6 +65,7 @@ public:
 	}
 
 private:
+	idx_t operator_idx = 0;
 #ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
 	//! Debugging state: number of times blocked
 	int debug_blocked_count = 0;


### PR DESCRIPTION
This PR adds the `OperatorFinalize` callback. This callback is called after execution of a pipeline is fully finished - similar to the Sink `Finalize` call. This makes operators more powerful as we have a "final" co-ordination point, which will allow for more flexible/powerful operations to be implemented as (partially) streaming.