### PR TITLE
Fix: Optional Probe Selection

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -320,6 +320,7 @@ static void GetRowPointersInternal(DataChunk &keys, TupleDataChunkState &key_sta
 			auto ht_offset = ht_offsets[row_index];
 			IncrementAndWrap(ht_offset, ht.bitmask);
 
+			// Get original hash from unified vector format to extract the salt if hashes_dense was populated that way
 			hash_t hash;
 			if (uses_unified) {
 				const auto uvf_index = hashes_unified_v.sel->get_index(row_index);

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -158,19 +158,19 @@ static void ApplyBitmaskAndGetSaltBuild(Vector &hashes_v, Vector &salt_v, const 
 }
 
 template <bool HAS_SEL>
-idx_t GetOptionalIndex(const SelectionVector *sel, idx_t idx) {
+idx_t GetOptionalIndex(const SelectionVector *sel, const idx_t idx) {
 	return HAS_SEL ? sel->get_index(idx) : idx;
 }
 
 static void AddPointerToCompare(JoinHashTable::ProbeState &state, const ht_entry_t &entry, Vector &pointers_result_v,
-                                idx_t ht_offset, idx_t &keys_to_compare_count, const idx_t &row_index) {
+                                idx_t row_ht_offset, idx_t &keys_to_compare_count, const idx_t &row_index) {
 
 	const auto row_ptr_insert_to = FlatVector::GetData<data_ptr_t>(pointers_result_v);
 	const auto ht_offsets = FlatVector::GetData<idx_t>(state.ht_offsets_v);
 
 	state.keys_to_compare_sel.set_index(keys_to_compare_count, row_index);
 	row_ptr_insert_to[row_index] = entry.GetPointer();
-	ht_offsets[row_index] = ht_offset;
+	ht_offsets[row_index] = row_ht_offset;
 	keys_to_compare_count += 1;
 }
 
@@ -251,17 +251,24 @@ static void GetRowPointersInternal(DataChunk &keys, TupleDataChunkState &key_sta
                                    Vector &hashes_v, const SelectionVector *row_sel, idx_t &count, JoinHashTable &ht,
                                    ht_entry_t *entries, Vector &pointers_result_v, SelectionVector &match_sel,
                                    bool has_row_sel) {
-	// densify hashes: If there is no sel, simply flatten the hashes, else densify via UnifiedVectorFormat
+
+	// in case of a hash collision, we need this information to correctly retrieve the salt of this hash
+	bool uses_unified = false;
+	UnifiedVectorFormat hashes_unified_v;
+
+	// densify hashes: If there is no sel, flatten the hashes, else densify via UnifiedVectorFormat
 	if (has_row_sel) {
-		UnifiedVectorFormat hashes_v_unified;
-		hashes_v.ToUnifiedFormat(count, hashes_v_unified);
-		auto hashes = UnifiedVectorFormat::GetData<hash_t>(hashes_v_unified);
+
+		hashes_v.ToUnifiedFormat(count, hashes_unified_v);
+		uses_unified = true;
+
+		auto hashes_unified = UnifiedVectorFormat::GetData<hash_t>(hashes_unified_v);
 		auto hashes_dense = FlatVector::GetData<idx_t>(state.hashes_dense_v);
 
 		for (idx_t i = 0; i < count; i++) {
 			const auto row_index = row_sel->get_index(i);
-			const auto uvf_index = hashes_v_unified.sel->get_index(row_index);
-			hashes_dense[i] = hashes[uvf_index];
+			const auto uvf_index = hashes_unified_v.sel->get_index(row_index);
+			hashes_dense[i] = hashes_unified[uvf_index];
 		}
 	} else {
 		hashes_v.Flatten(count);
@@ -284,7 +291,7 @@ static void GetRowPointersInternal(DataChunk &keys, TupleDataChunkState &key_sta
 			break;
 		}
 
-		// Perform row comparisons, after function call salt_match_sel will point to the keys that match
+		// Perform row comparisons, after Match function call salt_match_sel will point to the keys that match
 		keys_no_match_count = 0;
 		const idx_t keys_match_count = ht.row_matcher_build.Match(
 		    keys, key_state.vector_data, state.keys_to_compare_sel, keys_to_compare_count, *ht.layout_ptr,
@@ -300,19 +307,27 @@ static void GetRowPointersInternal(DataChunk &keys, TupleDataChunkState &key_sta
 		}
 
 		// Linear probing for collisions: Move to the next entry in the HT
+		auto hashes_unified = UnifiedVectorFormat::GetData<hash_t>(hashes_unified_v);
 		auto hashes_dense = FlatVector::GetData<hash_t>(state.hashes_dense_v);
 		auto ht_offsets = FlatVector::GetData<idx_t>(state.ht_offsets_v);
 
 		for (idx_t i = 0; i < keys_no_match_count; i++) {
 			const auto row_index = state.keys_no_match_sel.get_index(i);
-			// the ProbeForPointers function calculates the ht_offset from the hash, therefore we have to write the
-			// new offset into the hashes_v, otherwise the next iteration will start at the old position. This might
+			// The ProbeForPointers function calculates the ht_offset from the hash; therefore, we have to write the
+			// new offset into the hashes_v; otherwise the next iteration will start at the old position. This might
 			// seem as an overhead but assures that the first call of ProbeForPointers is optimized as conceding
 			// calls are unlikely (Max 1-(65535/65536)^VectorSize = 3.1%)
 			auto ht_offset = ht_offsets[row_index];
 			IncrementAndWrap(ht_offset, ht.bitmask);
 
-			const auto hash = hashes_dense[row_index];
+			hash_t hash;
+			if (uses_unified) {
+				const auto uvf_index = hashes_unified_v.sel->get_index(row_index);
+				hash = hashes_unified[uvf_index];
+			} else {
+				hash = hashes_dense[row_index];
+			}
+
 			const auto offset_and_salt = ht_offset | (hash & ht_entry_t::SALT_MASK);
 
 			hashes_dense[i] = offset_and_salt; // populate dense again
@@ -672,7 +687,7 @@ static void InsertHashesLoop(atomic<ht_entry_t> entries[], Vector &row_locations
 				if (PARALLEL) {
 					// if the insertion was not successful, the entry was occupied in the meantime, so we have to
 					// compare the keys and insert the row to the next entry
-					if (potential_collided_ptr) {
+					if (DUCKDB_UNLIKELY(potential_collided_ptr != nullptr)) {
 						// if the entry was occupied, we need to compare the keys and insert the row to the next entry
 						// we need to compare the keys and insert the row to the next entry
 						state.keys_to_compare_sel.set_index(salt_match_count, row_index);

--- a/test/sql/join/inner/test_join_with_nulls.test_slow
+++ b/test/sql/join/inner/test_join_with_nulls.test_slow
@@ -1,0 +1,36 @@
+# name: test/sql/join/inner/test_joins_with_nulls.test
+# description: Test joins on uint64 columns with NULL values
+# group: [inner]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+SELECT setseed(0.42);
+
+statement ok
+PRAGMA disable_optimizer;
+
+statement ok
+CREATE OR REPLACE TABLE build AS (SELECT if(random() < 0.1,null, CAST(round(random() * 1_000_000) as INT64)) as key FROM range(1_000_000))
+
+statement ok
+CREATE OR REPLACE TABLE probe AS (SELECT if(random() < 0.1,null, CAST(round(random() * 1_000_000) as INT64)) as key FROM range(4_000_000))
+
+query II
+SELECT COUNT(*), SUM(probe.key) FROM probe JOIN build ON probe.key = build.key;
+----
+3239239	1617830750716
+
+statement ok
+CREATE OR REPLACE TABLE build2 AS (SELECT if(CAST(round(random() * 400_000) as INT64) < 10, null, CAST(round(random() * 400_000) as INT64)) as key FROM range(500_000));
+
+query II
+SELECT COUNT(*), SUM(probe.key) FROM probe JOIN build2 ON probe.key = build2.key;
+----
+1801809	360752228491
+
+query II
+SELECT COUNT(*), SUM(probe.key) FROM probe JOIN build2 ON probe.key IS NOT DISTINCT FROM build2.key;
+----
+5393349	360752228491

--- a/test/sql/join/inner/test_join_with_nulls.test_slow
+++ b/test/sql/join/inner/test_join_with_nulls.test_slow
@@ -2,11 +2,10 @@
 # description: Test joins on uint64 columns with NULL values
 # group: [inner]
 
-statement ok
-PRAGMA enable_verification
+set seed 0.42
 
 statement ok
-SELECT setseed(0.42);
+PRAGMA enable_verification
 
 statement ok
 PRAGMA disable_optimizer;

--- a/test/sql/join/inner/test_join_with_nulls.test_slow
+++ b/test/sql/join/inner/test_join_with_nulls.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/join/inner/test_joins_with_nulls.test
+# name: test/sql/join/inner/test_join_with_nulls.test_slow
 # description: Test joins on uint64 columns with NULL values
 # group: [inner]
 


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/duckdb/duckdb/pull/17062, which occurred during hash table probing when resolving hash collisions. The issue arose specifically when NULL values on the build side were filtered out before probing.

The PR also adds a test that can reproduces the issue. Since hash collisions are relatively rare, the test uses a large join to increase the likelihood of collisions. It takes about 40 seconds in debug mode and 0.3 seconds in release mode.