### PR TITLE
Adding additional authenticated data for encryption

### DIFF
--- a/.github/patches/extensions/httpfs/add_aad.patch
+++ b/.github/patches/extensions/httpfs/add_aad.patch
@@ -1,0 +1,56 @@
+diff --git a/extension/httpfs/crypto.cpp b/extension/httpfs/crypto.cpp
+index 04bd795..0fe6be8 100644
+--- a/extension/httpfs/crypto.cpp
++++ b/extension/httpfs/crypto.cpp
+@@ -78,20 +78,34 @@ void AESStateSSL::GenerateRandomData(data_ptr_t data, idx_t len) {
+ 	RAND_bytes(data, len);
+ }
+ 
+-void AESStateSSL::InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const string *key) {
++void AESStateSSL::InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const string *key, const_data_ptr_t aad, idx_t aad_len) {
+ 	mode = ENCRYPT;
+ 
+ 	if (1 != EVP_EncryptInit_ex(context, GetCipher(*key), NULL, const_data_ptr_cast(key->data()), iv)) {
+ 		throw InternalException("EncryptInit failed");
+ 	}
++	
++	int len;
++	if (aad_len > 0){
++		if (!EVP_DecryptUpdate(context, NULL, &len, aad, aad_len)) {
++    			throw InternalException("Setting Additional Authenticated Data  failed");
++		}
++	}	
+ }
+ 
+-void AESStateSSL::InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const string *key) {
++void AESStateSSL::InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const string *key, const_data_ptr_t aad, idx_t aad_len) {
+ 	mode = DECRYPT;
+ 
+ 	if (1 != EVP_DecryptInit_ex(context, GetCipher(*key), NULL, const_data_ptr_cast(key->data()), iv)) {
+ 		throw InternalException("DecryptInit failed");
+ 	}
++
++	int len;
++        if (aad_len > 0){
++                if (!EVP_DecryptUpdate(context, NULL, &len, aad, aad_len)) {
++                        throw InternalException("Setting Additional Authenticated Data  failed");
++                }
++	}
+ }
+ 
+ size_t AESStateSSL::Process(const_data_ptr_t in, idx_t in_len, data_ptr_t out, idx_t out_len) {
+diff --git a/extension/httpfs/include/crypto.hpp b/extension/httpfs/include/crypto.hpp
+index f819356..eaa850e 100644
+--- a/extension/httpfs/include/crypto.hpp
++++ b/extension/httpfs/include/crypto.hpp
+@@ -29,8 +29,8 @@ public:
+ 	~AESStateSSL() override;
+ 
+ public:
+-	void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key) override;
+-	void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key) override;
++	void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key, const_data_ptr_t aad, idx_t aad_len) override;
++	void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key, const_data_ptr_t aad, idx_t aad_len) override;
+ 	size_t Process(const_data_ptr_t in, idx_t in_len, data_ptr_t out, idx_t out_len) override;
+ 	size_t Finalize(data_ptr_t out, idx_t out_len, data_ptr_t tag, idx_t tag_len) override;
+ 	void GenerateRandomData(data_ptr_t data, idx_t len) override;

--- a/src/common/encryption_state.cpp
+++ b/src/common/encryption_state.cpp
@@ -9,11 +9,13 @@ EncryptionState::EncryptionState(const std::string *key) {
 EncryptionState::~EncryptionState() {
 }
 
-void EncryptionState::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key) {
+void EncryptionState::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key,
+                                           const_data_ptr_t aad, idx_t aad_len) {
 	throw NotImplementedException("EncryptionState Abstract Class is called");
 }
 
-void EncryptionState::InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key) {
+void EncryptionState::InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key,
+                                           const_data_ptr_t aad, idx_t aad_len) {
 	throw NotImplementedException("EncryptionState Abstract Class is called");
 }
 

--- a/src/include/duckdb/common/encryption_state.hpp
+++ b/src/include/duckdb/common/encryption_state.hpp
@@ -20,8 +20,10 @@ public:
 	DUCKDB_API virtual ~EncryptionState();
 
 public:
-	DUCKDB_API virtual void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key);
-	DUCKDB_API virtual void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key);
+	DUCKDB_API virtual void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key,
+	                                             const_data_ptr_t aad = nullptr, idx_t aad_len = 0);
+	DUCKDB_API virtual void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key,
+	                                             const_data_ptr_t aad = nullptr, idx_t aad_len = 0);
 	DUCKDB_API virtual size_t Process(const_data_ptr_t in, idx_t in_len, data_ptr_t out, idx_t out_len);
 	DUCKDB_API virtual size_t Finalize(data_ptr_t out, idx_t out_len, data_ptr_t tag, idx_t tag_len);
 	DUCKDB_API virtual void GenerateRandomData(data_ptr_t data, idx_t len);

--- a/third_party/mbedtls/include/mbedtls_wrapper.hpp
+++ b/third_party/mbedtls/include/mbedtls_wrapper.hpp
@@ -64,8 +64,9 @@ class AESStateMBEDTLS : public duckdb::EncryptionState {
 		DUCKDB_API ~AESStateMBEDTLS() override;
 
 	public:
-		DUCKDB_API void InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key) override;
-		DUCKDB_API void InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key) override;
+		DUCKDB_API void InitializeInternal(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len);
+		DUCKDB_API void InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) override;
+		DUCKDB_API void InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) override;
 		DUCKDB_API size_t Process(duckdb::const_data_ptr_t in, duckdb::idx_t in_len, duckdb::data_ptr_t out,
 		                          duckdb::idx_t out_len) override;
 		DUCKDB_API size_t Finalize(duckdb::data_ptr_t out, duckdb::idx_t out_len, duckdb::data_ptr_t tag, duckdb::idx_t tag_len) override;

--- a/third_party/mbedtls/mbedtls_wrapper.cpp
+++ b/third_party/mbedtls/mbedtls_wrapper.cpp
@@ -271,28 +271,38 @@ void MbedTlsWrapper::AESStateMBEDTLS::GenerateRandomData(duckdb::data_ptr_t data
 	GenerateRandomDataStatic(data, len);
 }
 
-void MbedTlsWrapper::AESStateMBEDTLS::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key) {
+void MbedTlsWrapper::AESStateMBEDTLS::InitializeInternal(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len){
+	if (mbedtls_cipher_set_iv(context.get(), iv, iv_len) != 0) {
+		runtime_error("Failed to set IV for encryption");
+	}
+
+	size_t result;
+	if (aad_len > 0) {
+		auto ret = mbedtls_cipher_update_ad(context.get(), aad, aad_len);
+		if (ret != 0) {
+			throw std::runtime_error("Failed to set AAD");
+		}
+	}
+}
+
+void MbedTlsWrapper::AESStateMBEDTLS::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) {
 	mode = ENCRYPT;
 
 	if (mbedtls_cipher_setkey(context.get(), reinterpret_cast<const unsigned char *>(key->data()), key->length() * 8, MBEDTLS_ENCRYPT) != 0) {
 		runtime_error("Failed to set AES key for encryption");
 	}
 
-	if (mbedtls_cipher_set_iv(context.get(), iv, iv_len) != 0) {
-		runtime_error("Failed to set IV for encryption");
-	}
+	InitializeInternal(iv, iv_len, key, aad, aad_len);
 }
 
-void MbedTlsWrapper::AESStateMBEDTLS::InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key) {
+void MbedTlsWrapper::AESStateMBEDTLS::InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key,  duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) {
 	mode = DECRYPT;
 
 	if (mbedtls_cipher_setkey(context.get(), reinterpret_cast<const unsigned char *>(key->data()), key->length() * 8, MBEDTLS_DECRYPT) != 0) {
 		runtime_error("Failed to set AES key for decryption");
 	}
 
-	if (mbedtls_cipher_set_iv(context.get(), iv, iv_len) != 0) {
-		runtime_error("Failed to set IV for decryption");
-	}
+	InitializeInternal(iv, iv_len, key, aad, aad_len);
 }
 
 size_t MbedTlsWrapper::AESStateMBEDTLS::Process(duckdb::const_data_ptr_t in, duckdb::idx_t in_len, duckdb::data_ptr_t out,

--- a/third_party/mbedtls/mbedtls_wrapper.cpp
+++ b/third_party/mbedtls/mbedtls_wrapper.cpp
@@ -275,8 +275,7 @@ void MbedTlsWrapper::AESStateMBEDTLS::InitializeInternal(duckdb::const_data_ptr_
 	if (mbedtls_cipher_set_iv(context.get(), iv, iv_len) != 0) {
 		runtime_error("Failed to set IV for encryption");
 	}
-
-	size_t result;
+	
 	if (aad_len > 0) {
 		auto ret = mbedtls_cipher_update_ad(context.get(), aad, aad_len);
 		if (ret != 0) {


### PR DESCRIPTION
This PR adds the possibility to include Additional Authenticated Data (AAD) data for encryption. For some ciphers like AES GCM, AAD can be used to make sure that the ciphertext is not tampered with. This is e.g. used in the Parquet encryption spec, and we might want to use it for our own encryption.