### PR TITLE
feat: include catalog and schema names in function serialization

### DIFF
--- a/src/catalog/catalog_entry/scalar_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/scalar_function_catalog_entry.cpp
@@ -1,12 +1,17 @@
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/parser/parsed_data/alter_scalar_function_info.hpp"
+#include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
 
 ScalarFunctionCatalogEntry::ScalarFunctionCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema,
                                                        CreateScalarFunctionInfo &info)
     : FunctionEntry(CatalogType::SCALAR_FUNCTION_ENTRY, catalog, schema, info), functions(info.functions) {
+	for (auto &function : functions.functions) {
+		function.catalog_name = catalog.GetAttached().GetName();
+		function.schema_name = schema.name;
+	}
 }
 
 unique_ptr<CatalogEntry> ScalarFunctionCatalogEntry::AlterEntry(CatalogTransaction transaction, AlterInfo &info) {

--- a/src/catalog/catalog_entry/table_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_function_catalog_entry.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/parser/parsed_data/alter_table_function_info.hpp"
+#include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
 
@@ -7,6 +8,10 @@ TableFunctionCatalogEntry::TableFunctionCatalogEntry(Catalog &catalog, SchemaCat
                                                      CreateTableFunctionInfo &info)
     : FunctionEntry(CatalogType::TABLE_FUNCTION_ENTRY, catalog, schema, info), functions(std::move(info.functions)) {
 	D_ASSERT(this->functions.Size() > 0);
+	for (auto &function : functions.functions) {
+		function.catalog_name = catalog.GetAttached().GetName();
+		function.schema_name = schema.name;
+	}
 }
 
 unique_ptr<CatalogEntry> TableFunctionCatalogEntry::AlterEntry(CatalogTransaction transaction, AlterInfo &info) {

--- a/src/common/exception/binder_exception.cpp
+++ b/src/common/exception/binder_exception.cpp
@@ -23,16 +23,23 @@ BinderException BinderException::ColumnNotFound(const string &name, const vector
 	    StringUtil::Format("Referenced column \"%s\" not found in FROM clause!%s", name, candidate_str), extra_info);
 }
 
-BinderException BinderException::NoMatchingFunction(const string &name, const vector<LogicalType> &arguments,
+BinderException BinderException::NoMatchingFunction(const string &catalog_name, const string &schema_name,
+                                                    const string &name, const vector<LogicalType> &arguments,
                                                     const vector<string> &candidates) {
 	auto extra_info = Exception::InitializeExtraInfo("NO_MATCHING_FUNCTION", optional_idx());
 	// no matching function was found, throw an error
-	string call_str = Function::CallToString(name, arguments);
+	string call_str = Function::CallToString(catalog_name, schema_name, name, arguments);
 	string candidate_str;
 	for (auto &candidate : candidates) {
 		candidate_str += "\t" + candidate + "\n";
 	}
 	extra_info["name"] = name;
+	if (!catalog_name.empty()) {
+		extra_info["catalog"] = catalog_name;
+	}
+	if (!schema_name.empty()) {
+		extra_info["schema"] = schema_name;
+	}
 	extra_info["call"] = call_str;
 	if (!candidates.empty()) {
 		extra_info["candidates"] = StringUtil::Join(candidates, ",");

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -49,7 +49,7 @@ SimpleFunction::~SimpleFunction() {
 }
 
 string SimpleFunction::ToString() const {
-	return Function::CallToString(name, arguments, varargs);
+	return Function::CallToString(catalog_name, schema_name, name, arguments, varargs);
 }
 
 bool SimpleFunction::HasVarArgs() const {
@@ -65,7 +65,7 @@ SimpleNamedParameterFunction::~SimpleNamedParameterFunction() {
 }
 
 string SimpleNamedParameterFunction::ToString() const {
-	return Function::CallToString(name, arguments, named_parameters);
+	return Function::CallToString(catalog_name, schema_name, name, arguments, named_parameters);
 }
 
 bool SimpleNamedParameterFunction::HasNamedParameters() const {
@@ -84,7 +84,7 @@ BaseScalarFunction::~BaseScalarFunction() {
 }
 
 string BaseScalarFunction::ToString() const {
-	return Function::CallToString(name, arguments, varargs, return_type);
+	return Function::CallToString(catalog_name, schema_name, name, arguments, varargs, return_type);
 }
 
 // add your initializer for new functions here
@@ -113,8 +113,18 @@ hash_t BaseScalarFunction::Hash() const {
 	return hash;
 }
 
-string Function::CallToString(const string &name, const vector<LogicalType> &arguments, const LogicalType &varargs) {
-	string result = name + "(";
+static bool RequiresCatalogAndSchemaNamePrefix(const string &catalog_name, const string &schema_name) {
+	return !catalog_name.empty() && catalog_name != SYSTEM_CATALOG && !schema_name.empty() &&
+	       schema_name != DEFAULT_SCHEMA;
+}
+
+string Function::CallToString(const string &catalog_name, const string &schema_name, const string &name,
+                              const vector<LogicalType> &arguments, const LogicalType &varargs) {
+	string result;
+	if (RequiresCatalogAndSchemaNamePrefix(catalog_name, schema_name)) {
+		result += catalog_name + "." + schema_name + ".";
+	}
+	result += name + "(";
 	vector<string> string_arguments;
 	for (auto &arg : arguments) {
 		string_arguments.push_back(arg.ToString());
@@ -126,14 +136,16 @@ string Function::CallToString(const string &name, const vector<LogicalType> &arg
 	return result + ")";
 }
 
-string Function::CallToString(const string &name, const vector<LogicalType> &arguments, const LogicalType &varargs,
+string Function::CallToString(const string &catalog_name, const string &schema_name, const string &name,
+                              const vector<LogicalType> &arguments, const LogicalType &varargs,
                               const LogicalType &return_type) {
-	string result = CallToString(name, arguments, varargs);
+	string result = CallToString(catalog_name, schema_name, name, arguments, varargs);
 	result += " -> " + return_type.ToString();
 	return result;
 }
 
-string Function::CallToString(const string &name, const vector<LogicalType> &arguments,
+string Function::CallToString(const string &catalog_name, const string &schema_name, const string &name,
+                              const vector<LogicalType> &arguments,
                               const named_parameter_type_map_t &named_parameters) {
 	vector<string> input_arguments;
 	input_arguments.reserve(arguments.size() + named_parameters.size());
@@ -143,7 +155,11 @@ string Function::CallToString(const string &name, const vector<LogicalType> &arg
 	for (auto &kv : named_parameters) {
 		input_arguments.push_back(StringUtil::Format("%s : %s", kv.first, kv.second.ToString()));
 	}
-	return StringUtil::Format("%s(%s)", name, StringUtil::Join(input_arguments, ", "));
+	string prefix = "";
+	if (RequiresCatalogAndSchemaNamePrefix(catalog_name, schema_name)) {
+		prefix = StringUtil::Format("%s.%s.", catalog_name, schema_name);
+	}
+	return StringUtil::Format("%s%s(%s)", prefix, name, StringUtil::Join(input_arguments, ", "));
 }
 
 void Function::EraseArgument(SimpleFunction &bound_function, vector<unique_ptr<Expression>> &arguments,

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -106,10 +106,18 @@ vector<idx_t> FunctionBinder::BindFunctionsFromArguments(const string &name, Fun
 	if (!best_function.IsValid()) {
 		// no matching function was found, throw an error
 		vector<string> candidates;
+		string catalog_name;
+		string schema_name;
 		for (auto &f : functions.functions) {
+			if (catalog_name.empty() && !f.catalog_name.empty()) {
+				catalog_name = f.catalog_name;
+			}
+			if (schema_name.empty() && !f.schema_name.empty()) {
+				schema_name = f.schema_name;
+			}
 			candidates.push_back(f.ToString());
 		}
-		error = ErrorData(BinderException::NoMatchingFunction(name, arguments, candidates));
+		error = ErrorData(BinderException::NoMatchingFunction(catalog_name, schema_name, name, arguments, candidates));
 		return candidate_functions;
 	}
 	candidate_functions.push_back(best_function.GetIndex());
@@ -117,13 +125,14 @@ vector<idx_t> FunctionBinder::BindFunctionsFromArguments(const string &name, Fun
 }
 
 template <class T>
-optional_idx FunctionBinder::MultipleCandidateException(const string &name, FunctionSet<T> &functions,
+optional_idx FunctionBinder::MultipleCandidateException(const string &catalog_name, const string &schema_name,
+                                                        const string &name, FunctionSet<T> &functions,
                                                         vector<idx_t> &candidate_functions,
                                                         const vector<LogicalType> &arguments, ErrorData &error) {
 	D_ASSERT(functions.functions.size() > 1);
 	// there are multiple possible function definitions
 	// throw an exception explaining which overloads are there
-	string call_str = Function::CallToString(name, arguments);
+	string call_str = Function::CallToString(catalog_name, schema_name, name, arguments);
 	string candidate_str;
 	for (auto &conf : candidate_functions) {
 		T f = functions.GetFunctionByOffset(conf);
@@ -153,7 +162,10 @@ optional_idx FunctionBinder::BindFunctionFromArguments(const string &name, Funct
 				throw ParameterNotResolvedException();
 			}
 		}
-		return MultipleCandidateException(name, functions, candidate_functions, arguments, error);
+		auto catalog_name = functions.functions.size() > 0 ? functions.functions[0].catalog_name : "";
+		auto schema_name = functions.functions.size() > 0 ? functions.functions[0].schema_name : "";
+		return MultipleCandidateException(catalog_name, schema_name, name, functions, candidate_functions, arguments,
+		                                  error);
 	}
 	return candidate_functions[0];
 }

--- a/src/include/duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/catalog/catalog_set.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
+#include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
 
@@ -24,6 +25,10 @@ public:
 public:
 	AggregateFunctionCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateAggregateFunctionInfo &info)
 	    : FunctionEntry(CatalogType::AGGREGATE_FUNCTION_ENTRY, catalog, schema, info), functions(info.functions) {
+		for (auto &function : functions.functions) {
+			function.catalog_name = catalog.GetAttached().GetName();
+			function.schema_name = schema.name;
+		}
 	}
 
 	//! The aggregate functions

--- a/src/include/duckdb/common/exception/binder_exception.hpp
+++ b/src/include/duckdb/common/exception/binder_exception.hpp
@@ -44,8 +44,8 @@ public:
 
 	static BinderException ColumnNotFound(const string &name, const vector<string> &similar_bindings,
 	                                      QueryErrorContext context = QueryErrorContext());
-	static BinderException NoMatchingFunction(const string &name, const vector<LogicalType> &arguments,
-	                                          const vector<string> &candidates);
+	static BinderException NoMatchingFunction(const string &catalog_name, const string &schema_name, const string &name,
+	                                          const vector<LogicalType> &arguments, const vector<string> &candidates);
 	static BinderException Unsupported(ParsedExpression &expr, const string &message);
 };
 

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -105,15 +105,24 @@ public:
 	//! Additional Information to specify function from it's name
 	string extra_info;
 
+	// Optional catalog name of the function
+	string catalog_name;
+
+	// Optional schema name of the function
+	string schema_name;
+
 public:
 	//! Returns the formatted string name(arg1, arg2, ...)
-	DUCKDB_API static string CallToString(const string &name, const vector<LogicalType> &arguments,
+	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
+	                                      const vector<LogicalType> &arguments,
 	                                      const LogicalType &varargs = LogicalType::INVALID);
 	//! Returns the formatted string name(arg1, arg2..) -> return_type
-	DUCKDB_API static string CallToString(const string &name, const vector<LogicalType> &arguments,
-	                                      const LogicalType &varargs, const LogicalType &return_type);
+	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
+	                                      const vector<LogicalType> &arguments, const LogicalType &varargs,
+	                                      const LogicalType &return_type);
 	//! Returns the formatted string name(arg1, arg2.., np1=a, np2=b, ...)
-	DUCKDB_API static string CallToString(const string &name, const vector<LogicalType> &arguments,
+	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
+	                                      const vector<LogicalType> &arguments,
 	                                      const named_parameter_type_map_t &named_parameters);
 
 	//! Used in the bind to erase an argument from a function

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -84,9 +84,9 @@ private:
 	                                         const vector<LogicalType> &arguments, ErrorData &error);
 
 	template <class T>
-	optional_idx MultipleCandidateException(const string &name, FunctionSet<T> &functions,
-	                                        vector<idx_t> &candidate_functions, const vector<LogicalType> &arguments,
-	                                        ErrorData &error);
+	optional_idx MultipleCandidateException(const string &catalog_name, const string &schema_name, const string &name,
+	                                        FunctionSet<T> &functions, vector<idx_t> &candidate_functions,
+	                                        const vector<LogicalType> &arguments, ErrorData &error);
 
 	template <class T>
 	optional_idx BindFunctionFromArguments(const string &name, FunctionSet<T> &functions,

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -23,6 +23,11 @@ public:
 		serializer.WriteProperty(500, "name", function.name);
 		serializer.WriteProperty(501, "arguments", function.arguments);
 		serializer.WriteProperty(502, "original_arguments", function.original_arguments);
+		// These are optional fields that are written out of numeric order, older
+		// databases won't contain the fields, so the defaults will be used, but if
+		// the fields are present, they will be used.
+		serializer.WritePropertyWithDefault<string>(505, "catalog_name", function.catalog_name, "");
+		serializer.WritePropertyWithDefault<string>(506, "schema_name", function.schema_name, "");
 		bool has_serialize = function.serialize;
 		serializer.WriteProperty(503, "has_serialize", has_serialize);
 		if (has_serialize) {
@@ -33,10 +38,14 @@ public:
 	}
 
 	template <class FUNC, class CATALOG_ENTRY>
-	static FUNC DeserializeFunction(ClientContext &context, CatalogType catalog_type, const string &name,
-	                                vector<LogicalType> arguments, vector<LogicalType> original_arguments) {
+	static FUNC DeserializeFunction(ClientContext &context, CatalogType catalog_type, const string &catalog_name,
+	                                const string &schema_name, const string &name, vector<LogicalType> arguments,
+	                                vector<LogicalType> original_arguments) {
 		EntryLookupInfo lookup_info(catalog_type, name);
-		auto &func_catalog = Catalog::GetEntry(context, SYSTEM_CATALOG, DEFAULT_SCHEMA, lookup_info);
+		auto &func_catalog =
+		    Catalog::GetEntry(context, catalog_type, catalog_name.empty() ? SYSTEM_CATALOG : catalog_name,
+		                      schema_name.empty() ? DEFAULT_SCHEMA : schema_name, name);
+
 		if (func_catalog.type != catalog_type) {
 			throw InternalException("DeserializeFunction - cant find catalog entry for function %s", name);
 		}
@@ -54,8 +63,16 @@ public:
 		auto name = deserializer.ReadProperty<string>(500, "name");
 		auto arguments = deserializer.ReadProperty<vector<LogicalType>>(501, "arguments");
 		auto original_arguments = deserializer.ReadProperty<vector<LogicalType>>(502, "original_arguments");
-		auto function = DeserializeFunction<FUNC, CATALOG_ENTRY>(context, catalog_type, name, std::move(arguments),
-		                                                         std::move(original_arguments));
+		auto catalog_name = deserializer.ReadPropertyWithDefault<string>(505, "catalog_name");
+		auto schema_name = deserializer.ReadPropertyWithDefault<string>(506, "schema_name");
+		if (catalog_name.empty()) {
+			catalog_name = SYSTEM_CATALOG;
+		}
+		if (schema_name.empty()) {
+			schema_name = DEFAULT_SCHEMA;
+		}
+		auto function = DeserializeFunction<FUNC, CATALOG_ENTRY>(context, catalog_type, catalog_name, schema_name, name,
+		                                                         std::move(arguments), std::move(original_arguments));
 		auto has_serialize = deserializer.ReadProperty<bool>(503, "has_serialize");
 		return make_pair(std::move(function), has_serialize);
 	}


### PR DESCRIPTION
Functions created in custom catalogs and schemas cannot be located during serialization because `FunctionSerializer` only searches in the `SYSTEM_CATALOG` and `DEFAULT_SCHEMA`. As a result, serialization fails for functions outside these defaults catalog entries.

This PR adds `catalog_name` and `schema_name` fields to function serialization. These fields are serialized as strings with empty string defaults for backward compatibility.

These fields use default values (empty strings), so older databases (which lack these fields) will continue to work as expected. Although the field IDs are not in numeric order, they are newly added and do not affect backward compatibility.

This PR should supersede #15547.