### PR TITLE
Fix python nightly build

### DIFF
--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -28,9 +28,6 @@ Source = "https://github.com/duckdb/duckdb/blob/main/tools/pythonpkg"
 Issues = "https://github.com/duckdb/duckdb/issues"
 Changelog = "https://github.com/duckdb/duckdb/releases"
 
-[tool.setuptools_scm]
-root = "../.."
-
 ### CI Builwheel configurations ###
 
 # Default config runs all tests and requires at least one extension to be tested against

--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
 	"setuptools>=60",
-	"setuptools_scm>=6.4",
+	"setuptools_scm>=6.4,<8.0",
 	"pybind11>=2.6.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Revert #17443 

They (setuptool_scm) have not fixed their problem, all they've done is upgrade the warning into an error, so we won't use those newer versions until they fix it 👍 