### PR TITLE
Resolve GitHub workflow `set-output` deprecation warnings

### DIFF
--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -68,11 +68,10 @@ runs:
           echo "CXX=${{ inputs.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || '' }}" >> docker_env.txt 
 
       - name: Generate timestamp for Ccache entry
-        shell: cmake -P {0}
+        shell: bash
         id: ccache_timestamp
         run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          date --utc +'timestamp=%Y-%m-%d-%H;%M;%S' >> "$GITHUB_OUTPUT"
 
       - name: Create Ccache directory
         shell: bash


### PR DESCRIPTION
In 2022 GitHub deprecated the `set-output` commands:

https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/

`set-output` is used in the `build_extensions_dockerized` workflow and triggers warnings when the `LinuxRelease.yml` workflow runs [[recent example](https://github.com/duckdb/duckdb/actions/runs/15063088936)]:

> ![image](https://github.com/user-attachments/assets/9cc1d25e-c9de-4c26-b387-1748b5c6bc3b)



This change resolves the warning.