### PR TITLE
Add (de)serialization for `ExtraOperatorInfo`

### DIFF
--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -18,7 +18,7 @@ PhysicalTableScan::PhysicalTableScan(vector<LogicalType> types, TableFunction fu
     : PhysicalOperator(PhysicalOperatorType::TABLE_SCAN, std::move(types), estimated_cardinality),
       function(std::move(function_p)), bind_data(std::move(bind_data_p)), returned_types(std::move(returned_types_p)),
       column_ids(std::move(column_ids_p)), projection_ids(std::move(projection_ids_p)), names(std::move(names_p)),
-      table_filters(std::move(table_filters_p)), extra_info(extra_info), parameters(std::move(parameters_p)),
+      table_filters(std::move(table_filters_p)), extra_info(std::move(extra_info)), parameters(std::move(parameters_p)),
       virtual_columns(std::move(virtual_columns_p)) {
 }
 

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -139,10 +139,10 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	// create the table scan node
 	if (!op.function.projection_pushdown) {
 		// function does not support projection pushdown
-		auto &table_scan = Make<PhysicalTableScan>(op.returned_types, op.function, std::move(op.bind_data),
-		                                           op.returned_types, column_ids, vector<column_t>(), op.names,
-		                                           std::move(table_filters), op.estimated_cardinality, op.extra_info,
-		                                           std::move(op.parameters), std::move(op.virtual_columns));
+		auto &table_scan = Make<PhysicalTableScan>(
+		    op.returned_types, op.function, std::move(op.bind_data), op.returned_types, column_ids, vector<column_t>(),
+		    op.names, std::move(table_filters), op.estimated_cardinality, std::move(op.extra_info),
+		    std::move(op.parameters), std::move(op.virtual_columns));
 		// first check if an additional projection is necessary
 		if (column_ids.size() == op.returned_types.size()) {
 			bool projection_necessary = false;
@@ -188,7 +188,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	auto &table_scan =
 	    Make<PhysicalTableScan>(op.types, op.function, std::move(op.bind_data), op.returned_types, column_ids,
 	                            op.projection_ids, op.names, std::move(table_filters), op.estimated_cardinality,
-	                            op.extra_info, std::move(op.parameters), std::move(op.virtual_columns));
+	                            std::move(op.extra_info), std::move(op.parameters), std::move(op.virtual_columns));
 	auto &cast_table_scan = table_scan.Cast<PhysicalTableScan>();
 	cast_table_scan.dynamic_filters = op.dynamic_filters;
 	if (filter) {

--- a/src/include/duckdb/common/extra_operator_info.hpp
+++ b/src/include/duckdb/common/extra_operator_info.hpp
@@ -30,6 +30,28 @@ public:
 			filtered_files = extra_info.filtered_files.GetIndex();
 		}
 	}
+	ExtraOperatorInfo(ExtraOperatorInfo &&extra_info)
+	    : file_filters(extra_info.file_filters), sample_options(std::move(extra_info.sample_options)) {
+		if (extra_info.total_files.IsValid()) {
+			total_files = extra_info.total_files.GetIndex();
+		}
+		if (extra_info.filtered_files.IsValid()) {
+			filtered_files = extra_info.filtered_files.GetIndex();
+		}
+	}
+	ExtraOperatorInfo& operator=(ExtraOperatorInfo &&extra_info) {
+		if (this != &extra_info) {
+			file_filters = extra_info.file_filters;
+			if (extra_info.total_files.IsValid()) {
+				total_files = extra_info.total_files.GetIndex();
+			}
+			if (extra_info.filtered_files.IsValid()) {
+				filtered_files = extra_info.filtered_files.GetIndex();
+			}
+			sample_options = std::move(extra_info.sample_options);
+		}
+		return *this;
+	}
 
 	//! Filters that have been pushed down into the main file list
 	string file_filters;
@@ -39,6 +61,9 @@ public:
 	optional_idx filtered_files;
 	//! Sample options that have been pushed down into the table scan
 	unique_ptr<SampleOptions> sample_options;
+
+	void Serialize(Serializer &serializer) const;
+	static ExtraOperatorInfo Deserialize(Deserializer &deserializer);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/extra_operator_info.hpp
+++ b/src/include/duckdb/common/extra_operator_info.hpp
@@ -21,15 +21,6 @@ class ExtraOperatorInfo {
 public:
 	ExtraOperatorInfo() : file_filters(""), sample_options(nullptr) {
 	}
-	ExtraOperatorInfo(ExtraOperatorInfo &extra_info)
-	    : file_filters(extra_info.file_filters), sample_options(std::move(extra_info.sample_options)) {
-		if (extra_info.total_files.IsValid()) {
-			total_files = extra_info.total_files.GetIndex();
-		}
-		if (extra_info.filtered_files.IsValid()) {
-			filtered_files = extra_info.filtered_files.GetIndex();
-		}
-	}
 	ExtraOperatorInfo(ExtraOperatorInfo &&extra_info)
 	    : file_filters(extra_info.file_filters), sample_options(std::move(extra_info.sample_options)) {
 		if (extra_info.total_files.IsValid()) {
@@ -39,7 +30,7 @@ public:
 			filtered_files = extra_info.filtered_files.GetIndex();
 		}
 	}
-	ExtraOperatorInfo& operator=(ExtraOperatorInfo &&extra_info) {
+	ExtraOperatorInfo &operator=(ExtraOperatorInfo &&extra_info) {
 		if (this != &extra_info) {
 			file_filters = extra_info.file_filters;
 			if (extra_info.total_files.IsValid()) {

--- a/src/include/duckdb/common/extra_operator_info.hpp
+++ b/src/include/duckdb/common/extra_operator_info.hpp
@@ -21,7 +21,7 @@ class ExtraOperatorInfo {
 public:
 	ExtraOperatorInfo() : file_filters(""), sample_options(nullptr) {
 	}
-	ExtraOperatorInfo(ExtraOperatorInfo &&extra_info)
+	ExtraOperatorInfo(ExtraOperatorInfo &&extra_info) noexcept
 	    : file_filters(extra_info.file_filters), sample_options(std::move(extra_info.sample_options)) {
 		if (extra_info.total_files.IsValid()) {
 			total_files = extra_info.total_files.GetIndex();
@@ -30,7 +30,7 @@ public:
 			filtered_files = extra_info.filtered_files.GetIndex();
 		}
 	}
-	ExtraOperatorInfo &operator=(ExtraOperatorInfo &&extra_info) {
+	ExtraOperatorInfo &operator=(ExtraOperatorInfo &&extra_info) noexcept {
 		if (this != &extra_info) {
 			file_filters = extra_info.file_filters;
 			if (extra_info.total_files.IsValid()) {

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -1106,5 +1106,34 @@
     ],
     "pointer_type": "none",
     "constructor": ["name", "type"]
+  },
+  {
+    "class": "ExtraOperatorInfo",
+    "includes": [
+      "duckdb/common/extra_operator_info.hpp"
+    ],
+    "members": [
+      {
+        "id": 100,
+        "name": "file_filters",
+        "type": "string"
+      },
+      {
+        "id": 101,
+        "name": "total_files",
+        "type": "optional_idx"
+      },
+      {
+        "id": 102,
+        "name": "filtered_files",
+        "type": "optional_idx"
+      },
+      {
+        "id": 103,
+        "name": "sample_options",
+        "type": "unique_ptr<SampleOptions>"
+      }
+    ],
+    "pointer_type": "none"
   }
 ]

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -219,6 +219,7 @@ void LogicalGet::Serialize(Serializer &serializer) const {
 	}
 	serializer.WriteProperty(210, "projected_input", projected_input);
 	serializer.WritePropertyWithDefault(211, "column_indexes", column_ids);
+	serializer.WriteProperty(212, "extra_info", extra_info);
 }
 
 unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) {
@@ -256,6 +257,7 @@ unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) 
 			result->column_ids.emplace_back(col_id);
 		}
 	}
+	result->extra_info = deserializer.ReadProperty<ExtraOperatorInfo>(212, "extra_info");
 	auto &context = deserializer.Get<ClientContext &>();
 	virtual_column_map_t virtual_columns;
 	if (!has_serialize) {

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -35,6 +35,7 @@
 #include "duckdb/parser/parsed_data/exported_table_data.hpp"
 #include "duckdb/common/column_index.hpp"
 #include "duckdb/common/table_column.hpp"
+#include "duckdb/common/extra_operator_info.hpp"
 
 namespace duckdb {
 
@@ -299,6 +300,22 @@ void ExportedTableInfo::Serialize(Serializer &serializer) const {
 ExportedTableInfo ExportedTableInfo::Deserialize(Deserializer &deserializer) {
 	auto table_data = deserializer.ReadProperty<ExportedTableData>(1, "table_data");
 	ExportedTableInfo result(deserializer.Get<ClientContext &>(), table_data);
+	return result;
+}
+
+void ExtraOperatorInfo::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<string>(100, "file_filters", file_filters);
+	serializer.WriteProperty<optional_idx>(101, "total_files", total_files);
+	serializer.WriteProperty<optional_idx>(102, "filtered_files", filtered_files);
+	serializer.WritePropertyWithDefault<unique_ptr<SampleOptions>>(103, "sample_options", sample_options);
+}
+
+ExtraOperatorInfo ExtraOperatorInfo::Deserialize(Deserializer &deserializer) {
+	ExtraOperatorInfo result;
+	deserializer.ReadPropertyWithDefault<string>(100, "file_filters", result.file_filters);
+	deserializer.ReadProperty<optional_idx>(101, "total_files", result.total_files);
+	deserializer.ReadProperty<optional_idx>(102, "filtered_files", result.filtered_files);
+	deserializer.ReadPropertyWithDefault<unique_ptr<SampleOptions>>(103, "sample_options", result.sample_options);
 	return result;
 }
 


### PR DESCRIPTION
In the sample pushdown, the `SampleOptions` are added to the `extra_infos` of the `LogicalGet`, but go missing when serializing the operator. This PR fixes this by adding serialization and deserialization for `ExtraOperatorInfo`. I hope that _nodes.json_ is the right place to define the serialization for this type.

Furthermore, I changed the constructor of `ExtraOperatorInfo` to be a move constructor because it is moving a `unique_ptr`.