### PR TITLE
fix: remove this assertion that size > 0 for ExpressionExecutor construction

### DIFF
--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -25,7 +25,6 @@ ExpressionExecutor::ExpressionExecutor(ClientContext &context, const Expression 
 
 ExpressionExecutor::ExpressionExecutor(ClientContext &context, const vector<unique_ptr<Expression>> &exprs)
     : ExpressionExecutor(context) {
-	D_ASSERT(exprs.size() > 0);
 	for (auto &expr : exprs) {
 		AddExpression(*expr);
 	}


### PR DESCRIPTION
Hi DuckDB Team,

I came across this assertion and was wondering if it's strictly necessary—it seems to prevent the use of an ExpressionExecutor when there are no expressions, which I was hoping to support in my use case.

If it's alright with you, I’d like you to merge this PR to remove it.

Thanks!
Rusty