### PR TITLE
[Python Dev] Using `reinterpret_steal` breaks the refcount of the passed-in object

### DIFF
--- a/tools/pythonpkg/src/typing/pytype.cpp
+++ b/tools/pythonpkg/src/typing/pytype.cpp
@@ -272,7 +272,7 @@ static LogicalType FromGenericAlias(const py::object &obj) {
 }
 
 static LogicalType FromDictionary(const py::object &obj) {
-	auto dict = py::reinterpret_steal<py::dict>(obj);
+	auto dict = py::reinterpret_borrow<py::dict>(obj);
 	child_list_t<LogicalType> children;
 	if (dict.size() == 0) {
 		throw InvalidInputException("Could not convert empty dictionary to a duckdb STRUCT type");


### PR DESCRIPTION
Fix #17523 

Fixes the corruption of the refcount of the passed-in object