### PR TITLE
Fix update extensions

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -21,6 +21,7 @@ duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG eb1b04907c419d576f5fa4b34303810e8802e2f8
     INCLUDE_DIR extension/httpfs/include
+    APPLY_PATCHES
     )
 
 ################# AVRO

--- a/.github/patches/extensions/httpfs/no_follow_no_keep_alive.patch
+++ b/.github/patches/extensions/httpfs/no_follow_no_keep_alive.patch
@@ -1,0 +1,13 @@
+diff --git a/extension/httpfs/httpfs_client.cpp b/extension/httpfs/httpfs_client.cpp
+index 7a779ef..84eb457 100644
+--- a/extension/httpfs/httpfs_client.cpp
++++ b/extension/httpfs/httpfs_client.cpp
+@@ -10,7 +10,7 @@ class HTTPFSClient : public HTTPClient {
+ public:
+ 	HTTPFSClient(HTTPFSParams &http_params, const string &proto_host_port) {
+ 		client = make_uniq<duckdb_httplib_openssl::Client>(proto_host_port);
+-		client->set_follow_location(true);
++		client->set_follow_location(http_params.follow_location);
+ 		client->set_keep_alive(http_params.keep_alive);
+ 		if (!http_params.ca_cert_file.empty()) {
+ 			client->set_ca_cert_path(http_params.ca_cert_file.c_str());

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -39,6 +39,7 @@ struct HTTPParams {
 	uint64_t retry_wait_ms = DEFAULT_RETRY_WAIT_MS;
 	float retry_backoff = DEFAULT_RETRY_BACKOFF;
 	bool keep_alive = DEFAULT_KEEP_ALIVE;
+	bool follow_location = true;
 
 	string http_proxy;
 	idx_t http_proxy_port;

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -367,6 +367,11 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 		params = http_util.InitializeParameters(db, url);
 	}
 
+	// Unclear what's peculiar about extension install flow, but those two parameters are needed
+	// to avoid lengthy retry on 304
+	params->follow_location = false;
+	params->keep_alive = false;
+
 	GetRequestInfo get_request(url, headers, *params, nullptr, nullptr);
 	get_request.try_request = true;
 

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -130,7 +130,7 @@ public:
 		auto sec = static_cast<time_t>(http_params.timeout);
 		auto usec = static_cast<time_t>(http_params.timeout_usec);
 		client = make_uniq<duckdb_httplib::Client>(proto_host_port);
-		client->set_follow_location(true);
+		client->set_follow_location(http_params.follow_location);
 		client->set_keep_alive(http_params.keep_alive);
 		client->set_write_timeout(sec, usec);
 		client->set_read_timeout(sec, usec);


### PR DESCRIPTION
This restore the following workflows to work as intended:
```
FORCE INSTALL spatial;
--- not relevant which extension, this should trigger a full download
UPDATE EXTENSIONS (spatial);
--- this should be a single GET request with "If-Not-Match" header
```
and the same with `httpfs` loaded:
```
FORCE INSTALL httpfs;
LOAD httpfs;
FORCE INSTALL spatial;
--- not relevant which extension, this should trigger a full download
UPDATE EXTENSIONS (spatial);
--- this should be a single GET request with "If-Not-Match" header
```

Note that this is relevant only for UPDATE EXTENSIONS or for the INSTALL codepath for an already installed extension.

Also, without this PR the behaviour would be long waits on `UPDATE EXTENSIONS`, that would eventually timeout and resume normal execution.

It's not completely clear to me why both `follow_location` and `keep_alive` needs to be set to false, whether this has something to do with our current setup to serve extensions or else, but this restore to the defaults in place before the HTTPUtil rework.