### PR TITLE
Minor fixes to exception error messages

### DIFF
--- a/src/main/extension.cpp
+++ b/src/main/extension.cpp
@@ -75,7 +75,7 @@ string ParsedExtensionMetaData::GetInvalidMetadataError() {
 			                       DUCKDB_EXTENSION_API_VERSION_MINOR, DUCKDB_EXTENSION_API_VERSION_PATCH);
 		}
 	} else {
-		throw InternalException("Unknown ABI type for extension: " + extension_abi_metadata);
+		throw InternalException("Unknown ABI type for extension: '%s'", extension_abi_metadata);
 	}
 
 	if (engine_platform != platform) {

--- a/src/parallel/executor_task.cpp
+++ b/src/parallel/executor_task.cpp
@@ -55,7 +55,7 @@ TaskExecutionResult ExecutorTask::Execute(TaskExecutionMode mode) {
 	} catch (std::exception &ex) {
 		executor.PushError(ErrorData(ex));
 	} catch (...) { // LCOV_EXCL_START
-		executor.PushError(ErrorData("Unknown exception in Finalize!"));
+		executor.PushError(ErrorData("Unknown exception in ExecutorTask::Execute"));
 	} // LCOV_EXCL_STOP
 	return TaskExecutionResult::TASK_ERROR;
 }

--- a/src/parallel/pipeline_event.cpp
+++ b/src/parallel/pipeline_event.cpp
@@ -15,7 +15,7 @@ void PipelineEvent::Schedule() {
 	} catch (std::exception &ex) {
 		executor.PushError(ErrorData(ex));
 	} catch (...) { // LCOV_EXCL_START
-		executor.PushError(ErrorData("Unknown exception in Finalize!"));
+		executor.PushError(ErrorData("Unknown exception while calling pipeline->Schedule(event)!"));
 	} // LCOV_EXCL_STOP
 }
 


### PR DESCRIPTION
Minor, I bumped on those, they can be as well be fixed.

The fix at [src/main/extension.cpp](https://github.com/duckdb/duckdb/compare/v1.3-ossivalis...carlopi:duckdb:minor_fixes_exceptions?expand=1#diff-d3d8bf6f19341657a048550f00e3bb1cc0f8d75c9d66d29296999d63d3e25696) would need to be generalized, there might be other places where we construct exception messages from unsanitized strings, and while that is handled by Format function, then error that is then re-throw bumps to InternalError and it's not super clear.
My proposal would be to change exceptions to take a `const char *` instead of a string, so that string concatenation is forbidden while constant strings are still allowed.
But this requires changes in many places, and not a point fix.

---

Either `v1.3-ossivalis` or `main`, both are fine, this is minor.