### PR TITLE
CreateDirectoriesRecursive with budged

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -473,7 +473,7 @@ void FileSystem::CreateDirectoriesRecursive(const string &path, idx_t max_to_be_
 
 		if (current_to_be_created + 1 > max_to_be_created) {
 			throw IOException("CreateDirectoriesRecursive could not find base existing folder at \"%s\" (with path "
-			                  "\"%s\" and allowed %d created directories)",
+			                  "\"%s\" and allowed %d created directories). Consider creating the missing directory explcitly.",
 			                  current_prefix, path, max_to_be_created);
 		}
 

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -472,9 +472,10 @@ void FileSystem::CreateDirectoriesRecursive(const string &path, idx_t max_to_be_
 		auto found = current_prefix.find_last_of(sep);
 
 		if (current_to_be_created + 1 > max_to_be_created) {
-			throw IOException("CreateDirectoriesRecursive could not find base existing folder at \"%s\" (with path "
-			                  "\"%s\" and allowed %d created directories). Consider creating the missing directory explcitly.",
-			                  current_prefix, path, max_to_be_created);
+			throw IOException(
+			    "CreateDirectoriesRecursive could not find base existing folder at \"%s\" (with path "
+			    "\"%s\" and allowed %d created directories). Consider creating the missing directory explcitly.",
+			    current_prefix, path, max_to_be_created);
 		}
 
 		current_to_be_created++;

--- a/src/function/table/system/duckdb_extensions.cpp
+++ b/src/function/table/system/duckdb_extensions.cpp
@@ -97,7 +97,8 @@ unique_ptr<GlobalTableFunctionState> DuckDBExtensionsInit(ClientContext &context
 
 	// Secondly we scan all installed extensions and their install info
 #ifndef WASM_LOADABLE_EXTENSIONS
-	auto ext_directory = ExtensionHelper::GetExtensionDirectoryPath(context);
+	idx_t how_deep = 0;
+	auto ext_directory = ExtensionHelper::GetExtensionDirectoryPath(context, how_deep);
 	fs.ListFiles(ext_directory, [&](const string &path, bool is_directory) {
 		if (!StringUtil::EndsWith(path, ".duckdb_extension")) {
 			return;

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -163,7 +163,8 @@ public:
 	//! Create a directory if it does not exist
 	DUCKDB_API virtual void CreateDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr);
 	//! Helper function that uses DirectoryExists and CreateDirectory to ensure all directories in path are created
-	DUCKDB_API virtual void CreateDirectoriesRecursive(const string &path, optional_ptr<FileOpener> opener = nullptr);
+	DUCKDB_API virtual void CreateDirectoriesRecursive(const string &path, idx_t max_to_be_created,
+	                                                   optional_ptr<FileOpener> opener = nullptr);
 	//! Recursively remove a directory and all files in it
 	DUCKDB_API virtual void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr);
 

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -123,8 +123,8 @@ public:
 	static string ExtensionDirectory(DatabaseInstance &db, FileSystem &fs);
 
 	// Get the extension directory path
-	static string GetExtensionDirectoryPath(ClientContext &context);
-	static string GetExtensionDirectoryPath(DatabaseInstance &db, FileSystem &fs);
+	static string GetExtensionDirectoryPath(ClientContext &context, idx_t &how_deep);
+	static string GetExtensionDirectoryPath(DatabaseInstance &db, FileSystem &fs, idx_t &how_deep);
 
 	static bool CheckExtensionSignature(FileHandle &handle, ParsedExtensionMetaData &parsed_metadata,
 	                                    const bool allow_community_extensions);
@@ -243,7 +243,7 @@ private:
 	                                                                 ExtensionInstallOptions &options,
 	                                                                 optional_ptr<ClientContext> context = nullptr);
 	static const vector<string> PathComponents();
-	static string DefaultExtensionFolder(FileSystem &fs);
+	static pair<string, idx_t> DefaultExtensionFolder(FileSystem &fs);
 	static bool AllowAutoInstall(const string &extension);
 	static ExtensionInitResult InitialLoad(DatabaseInstance &db, FileSystem &fs, const string &extension);
 	static bool TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const string &extension,

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -64,7 +64,8 @@ duckdb::pair<duckdb::string, idx_t> ExtensionHelper::DefaultExtensionFolder(File
 	res = fs.JoinPath(res, ".duckdb");
 	res = fs.JoinPath(res, "extensions");
 
-	// Use a budget of 2, that is maximum 2 created directories, so that home_directory is never actually created if not existing
+	// Use a budget of 2, that is maximum 2 created directories, so that home_directory is never actually created if not
+	// existing
 	return {res, 2};
 }
 

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -352,7 +352,7 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 
 		string local_path = !db.config.options.extension_directory.empty()
 		                        ? db.config.options.extension_directory
-		                        : ExtensionHelper::DefaultExtensionFolder(fs);
+		                        : ExtensionHelper::DefaultExtensionFolder(fs).first;
 
 		// convert random separators to platform-canonic
 		local_path = fs.ConvertSeparators(local_path);

--- a/test/extension/install_extension.test_slow
+++ b/test/extension/install_extension.test_slow
@@ -94,6 +94,10 @@ statement error
 INSTALL '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
 ----
 
+# we can't install because we will not create a non-existing home directory, but we should succeed at querying extensions
+statement ok
+FROM duckdb_extensions()
+
 # but this one should exist
 statement ok
 SET home_directory='__TEST_DIR__'

--- a/test/extension/install_extension.test_slow
+++ b/test/extension/install_extension.test_slow
@@ -62,13 +62,43 @@ LOAD 'loadable_extension_demo';
 statement ok
 INSTALL '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
 
-# can load now
 statement ok
-LOAD 'loadable_extension_demo';
+SET extension_directory='__TEST_DIR__/extension_directory/with/lot/of/nesting'
+
+# can't install after setting directory, too many level deep
+statement error
+INSTALL '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
+----
+IO Error: CreateDirectoriesRecursive could not find base existing folder
+
+statement ok
+SET extension_directory='__TEST_DIR__/extension_directory/with/lot/of'
+
+# can't install after setting directory, too many level deep
+statement error
+INSTALL '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
+----
+IO Error: CreateDirectoriesRecursive could not find base existing folder
+
+statement ok
+SET extension_directory='__TEST_DIR__/extension_directory/with/lot'
+
+# can't install after setting directory, too many level deep
+statement error
+INSTALL '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
+----
+IO Error: CreateDirectoriesRecursive could not find base existing folder
+
+statement ok
+SET extension_directory='__TEST_DIR__/extension_directory/with'
+
+# can now install after setting directory, extension_directory exist alredy, only with is created
+statement ok
+INSTALL '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
 
 # ensure file is there
 query I
-select count(*) from glob('__TEST_DIR__/extension_directory/**/loadable_extension_demo.duckdb_extension')
+select count(*) from glob('__TEST_DIR__/extension_directory/with/**/loadable_extension_demo.duckdb_extension')
 ----
 1
 


### PR DESCRIPTION
Currently:
```sql
SET home_directory = 'nonsense';
FROM duckdb_extensions();
```
fails like:
```
Can't find the home directory at 'nonsense'
Specify a home directory using the SET home_directory='/path/to/dir' option.
```
while after this PR it succeeds in listing extensions.

This is handy in the context of DuckDB-Wasm, where some custom code-path can be simplified (concept of home_directory is somewhat different).

LOAD and INSTALL path remains similar, in the sense that it needs a valid extension_directory OR a valid home-directory to be set, but now message is not thrown by DefaultExtensionFolder but by CreateDirectoriesRecursive.

Relevant functionality was added in https://github.com/duckdb/duckdb/pull/17316.