### PR TITLE
Generate data for tpch sf100 in steps

### DIFF
--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -87,7 +87,7 @@ void sleep_thread(Benchmark *benchmark, BenchmarkRunner *runner, BenchmarkState 
 			if (!hotrun) {
 				runner->Log(StringUtil::Format("%s\t%d\t", benchmark->name, 0));
 			}
-			runner->LogResult("KILLED");
+			runner->LogResult("Benchmark timeout reached; Interrupt failed. Benchmark killed by benchmark runner");
 			exit(1);
 		}
 	}

--- a/benchmark/large/tpch-sf100/load.sql
+++ b/benchmark/large/tpch-sf100/load.sql
@@ -1,1 +1,10 @@
-CALL dbgen(sf=100);
+CALL dbgen(sf=100, children=10, step=1);
+CALL dbgen(sf=100, children=10, step=2);
+CALL dbgen(sf=100, children=10, step=3);
+CALL dbgen(sf=100, children=10, step=4);
+CALL dbgen(sf=100, children=10, step=5);
+CALL dbgen(sf=100, children=10, step=6);
+CALL dbgen(sf=100, children=10, step=7);
+CALL dbgen(sf=100, children=10, step=8);
+CALL dbgen(sf=100, children=10, step=9);
+CALL dbgen(sf=100, children=10, step=10);


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/4905
Also changes "KILLED" message to more DuckDB-specific action instead of something that sounds like the OS is killing the benchmark runner