### PR TITLE
[HTTPUtil] Let requests made through the `HTTPUtil` interface accept URI's without a scheme.

### DIFF
--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -264,10 +264,76 @@ void HTTPUtil::ParseHTTPProxyHost(string &proxy_value, string &hostname_out, idx
 	}
 }
 
-void HTTPUtil::DecomposeURL(const string &url, string &path_out, string &proto_host_port_out) {
-	if (url.rfind("http://", 0) != 0 && url.rfind("https://", 0) != 0) {
-		throw IOException("URL needs to start with http:// or https://");
+namespace {
+
+enum class URISchemeType { HTTP, HTTPS, NONE, OTHER };
+
+struct URISchemeDetectionResult {
+	string lower_scheme;
+	URISchemeType scheme_type = URISchemeType::NONE;
+};
+
+bool IsValidSchemeChar(char c) {
+	return std::isalnum(c) || c == '+' || c == '.' || c == '-';
+}
+
+//! See https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
+URISchemeDetectionResult DetectURIScheme(const string &uri) {
+	URISchemeDetectionResult result;
+	auto colon_pos = uri.find(':');
+
+	// No colon or it's before any non-scheme content
+	if (colon_pos == string::npos || colon_pos == 0) {
+		result.lower_scheme = "";
+		result.scheme_type = URISchemeType::NONE;
+		return result;
 	}
+
+	if (!std::isalpha(uri[0])) {
+		//! Scheme names consist of a sequence of characters beginning with a letter
+		result.lower_scheme = "";
+		result.scheme_type = URISchemeType::NONE;
+		return result;
+	}
+
+	// Validate scheme characters
+	for (size_t i = 1; i < colon_pos; ++i) {
+		if (!IsValidSchemeChar(uri[i])) {
+			//! Scheme can't contain this character, assume the URI has no scheme
+			result.lower_scheme = "";
+			result.scheme_type = URISchemeType::NONE;
+			return result;
+		}
+	}
+
+	string scheme = uri.substr(0, colon_pos);
+	result.lower_scheme = StringUtil::Lower(scheme);
+
+	if (result.lower_scheme == "http") {
+		result.scheme_type = URISchemeType::HTTP;
+		return result;
+	}
+	if (result.lower_scheme == "https") {
+		result.scheme_type = URISchemeType::HTTPS;
+		return result;
+	}
+	result.scheme_type = URISchemeType::OTHER;
+	return result;
+}
+
+} // namespace
+
+void HTTPUtil::DecomposeURL(const string &input, string &path_out, string &proto_host_port_out) {
+	auto detection_result = DetectURIScheme(input);
+	auto url = input;
+	if (detection_result.scheme_type == URISchemeType::NONE) {
+		//! Assume it's HTTP
+		url = "http://" + url;
+	} else if (detection_result.scheme_type == URISchemeType::OTHER) {
+		throw IOException("Can't read from URI's with scheme: '%s', only http and httpfs are expected",
+		                  detection_result.lower_scheme);
+	}
+
 	auto slash_pos = url.find('/', 8);
 	if (slash_pos == string::npos) {
 		throw IOException("URL needs to contain a '/' after the host");

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -329,9 +329,6 @@ void HTTPUtil::DecomposeURL(const string &input, string &path_out, string &proto
 	if (detection_result.scheme_type == URISchemeType::NONE) {
 		//! Assume it's HTTP
 		url = "http://" + url;
-	} else if (detection_result.scheme_type == URISchemeType::OTHER) {
-		throw IOException("Can't read from URI's with scheme: '%s', only http and httpfs are expected",
-		                  detection_result.lower_scheme);
 	}
 
 	auto slash_pos = url.find('/', 8);


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/4902

When a URI without a scheme is passed, we default to the  `http` scheme.
Unknown schemes are let through, so paths like `localhost` and other defined hosts continue to be allowed.