### PR TITLE
[Dev] Fix `allowed_directories` crash

### DIFF
--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -196,6 +196,9 @@ void AllowedDirectoriesSetting::SetGlobal(DatabaseInstance *db, DBConfig &config
 	if (!config.options.enable_external_access) {
 		throw InvalidInputException("Cannot change allowed_directories when enable_external_access is disabled");
 	}
+	if (!config.file_system) {
+		throw InvalidInputException("Cannot change/set allowed_directories before the database is started");
+	}
 	config.options.allowed_directories.clear();
 	auto &list = ListValue::GetChildren(input);
 	for (auto &val : list) {
@@ -226,6 +229,10 @@ void AllowedPathsSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, cons
 	if (!config.options.enable_external_access) {
 		throw InvalidInputException("Cannot change allowed_paths when enable_external_access is disabled");
 	}
+	if (!config.file_system) {
+		throw InvalidInputException("Cannot change/set allowed_paths before the database is started");
+	}
+
 	config.options.allowed_paths.clear();
 	auto &list = ListValue::GetChildren(input);
 	for (auto &val : list) {

--- a/test/api/test_config.cpp
+++ b/test/api/test_config.cpp
@@ -38,6 +38,29 @@ TEST_CASE("Test DB config configuration", "[api]") {
 	}
 }
 
+TEST_CASE("Test allowed options", "[api]") {
+	case_insensitive_map_t<Value> config_dict;
+	string option;
+
+	SECTION("allowed_directories") {
+		config_dict.emplace("allowed_directories", Value::LIST({Value("test")}));
+		option = "allowed_directories";
+	}
+	SECTION("allowed_paths") {
+		config_dict.emplace("allowed_paths", Value::LIST({Value("test")}));
+		option = "allowed_paths";
+	}
+
+	try {
+		DBConfig config(config_dict, false);
+	} catch (std::exception &ex) {
+		ErrorData error_data(ex);
+		REQUIRE(error_data.Type() == ExceptionType::INVALID_INPUT);
+		REQUIRE(error_data.RawMessage() ==
+		        StringUtil::Format("Cannot change/set %s before the database is started", option));
+	}
+}
+
 TEST_CASE("Test user_agent", "[api]") {
 	{
 		// Default duckdb_api is cpp


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb/issues/17128

Problem is that we were assuming the `config.file_system` to be set, which is not the case when the DBConfig is not associated with a database yet.