### PR TITLE
Pass MultiFileGlobalState to InitializeReader, and pass file list to CreateMapping instead of eagerly getting the first file

### DIFF
--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -68,11 +68,10 @@ runs:
           echo "CXX=${{ inputs.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || '' }}" >> docker_env.txt 
 
       - name: Generate timestamp for Ccache entry
-        shell: cmake -P {0}
+        shell: bash
         id: ccache_timestamp
         run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          date --utc +'timestamp=%Y-%m-%d-%H;%M;%S' >> "$GITHUB_OUTPUT"
 
       - name: Create Ccache directory
         shell: bash

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -17,12 +17,12 @@ MultiFileColumnMapper::MultiFileColumnMapper(ClientContext &context, MultiFileRe
                                              MultiFileReaderData &reader_data,
                                              const vector<MultiFileColumnDefinition> &global_columns,
                                              const vector<ColumnIndex> &global_column_ids,
-                                             optional_ptr<TableFilterSet> filters, const OpenFileInfo &initial_file,
+                                             optional_ptr<TableFilterSet> filters, MultiFileList &multi_file_list,
                                              const MultiFileReaderBindData &bind_data,
                                              const virtual_column_map_t &virtual_columns)
-    : context(context), multi_file_reader(multi_file_reader), reader_data(reader_data), global_columns(global_columns),
-      global_column_ids(global_column_ids), global_filters(filters), initial_file(initial_file), bind_data(bind_data),
-      virtual_columns(virtual_columns) {
+    : context(context), multi_file_reader(multi_file_reader), multi_file_list(multi_file_list),
+      reader_data(reader_data), global_columns(global_columns), global_column_ids(global_column_ids),
+      global_filters(filters), bind_data(bind_data), virtual_columns(virtual_columns) {
 }
 
 struct MultiFileIndexMapping {
@@ -189,7 +189,8 @@ void MultiFileColumnMapper::ThrowColumnNotFoundError(const string &global_column
 	                            "the original file \"%s\", but could not be found in file \"%s\".\nCandidate names: "
 	                            "%s\nIf you are trying to "
 	                            "read files with different schemas, try setting union_by_name=True",
-	                            file_name, global_column_name, initial_file.path, file_name, candidate_names);
+	                            file_name, global_column_name, multi_file_list.GetFirstFile().path, file_name,
+	                            candidate_names);
 }
 
 //! Check if a column is trivially mappable (i.e. the column is effectively identical to the global column)

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -371,15 +371,12 @@ MultiFileReader::InitializeGlobalState(ClientContext &context, const MultiFileOp
 	return nullptr;
 }
 
-ReaderInitializeType MultiFileReader::CreateMapping(ClientContext &context, MultiFileReaderData &reader_data,
-                                                    const vector<MultiFileColumnDefinition> &global_columns,
-                                                    const vector<ColumnIndex> &global_column_ids,
-                                                    optional_ptr<TableFilterSet> filters,
-                                                    const OpenFileInfo &initial_file,
-                                                    const MultiFileReaderBindData &bind_data,
-                                                    const virtual_column_map_t &virtual_columns) {
+ReaderInitializeType MultiFileReader::CreateMapping(
+    ClientContext &context, MultiFileReaderData &reader_data, const vector<MultiFileColumnDefinition> &global_columns,
+    const vector<ColumnIndex> &global_column_ids, optional_ptr<TableFilterSet> filters, MultiFileList &multi_file_list,
+    const MultiFileReaderBindData &bind_data, const virtual_column_map_t &virtual_columns) {
 	MultiFileColumnMapper column_mapper(context, *this, reader_data, global_columns, global_column_ids, filters,
-	                                    initial_file, bind_data, virtual_columns);
+	                                    multi_file_list, bind_data, virtual_columns);
 	return column_mapper.CreateMapping();
 }
 
@@ -577,12 +574,11 @@ ReaderInitializeType MultiFileReader::InitializeReader(MultiFileReaderData &read
                                                        const vector<MultiFileColumnDefinition> &global_columns,
                                                        const vector<ColumnIndex> &global_column_ids,
                                                        optional_ptr<TableFilterSet> table_filters,
-                                                       ClientContext &context,
-                                                       optional_ptr<MultiFileReaderGlobalState> global_state) {
+                                                       ClientContext &context, MultiFileGlobalState &gstate) {
 	FinalizeBind(reader_data, bind_data.file_options, bind_data.reader_bind, global_columns, global_column_ids, context,
-	             global_state);
-	return CreateMapping(context, reader_data, global_columns, global_column_ids, table_filters,
-	                     bind_data.file_list->GetFirstFile(), bind_data.reader_bind, bind_data.virtual_columns);
+	             gstate.multi_file_reader_state.get());
+	return CreateMapping(context, reader_data, global_columns, global_column_ids, table_filters, gstate.file_list,
+	                     bind_data.reader_bind, bind_data.virtual_columns);
 }
 
 shared_ptr<BaseFileReader> MultiFileReader::CreateReader(ClientContext &context, GlobalTableFunctionState &gstate,

--- a/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
@@ -19,7 +19,7 @@ public:
 	MultiFileColumnMapper(ClientContext &context, MultiFileReader &multi_file_reader, MultiFileReaderData &reader_data,
 	                      const vector<MultiFileColumnDefinition> &global_columns,
 	                      const vector<ColumnIndex> &global_column_ids, optional_ptr<TableFilterSet> filters,
-	                      const OpenFileInfo &initial_file, const MultiFileReaderBindData &bind_data,
+	                      MultiFileList &multi_file_list, const MultiFileReaderBindData &bind_data,
 	                      const virtual_column_map_t &virtual_columns);
 
 public:
@@ -40,11 +40,11 @@ private:
 private:
 	ClientContext &context;
 	MultiFileReader &multi_file_reader;
+	MultiFileList &multi_file_list;
 	MultiFileReaderData &reader_data;
 	const vector<MultiFileColumnDefinition> &global_columns;
 	const vector<ColumnIndex> &global_column_ids;
 	optional_ptr<TableFilterSet> global_filters;
-	const OpenFileInfo &initial_file;
 	const MultiFileReaderBindData &bind_data;
 	const virtual_column_map_t &virtual_columns;
 };

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -109,7 +109,7 @@ public:
 	DUCKDB_API virtual ReaderInitializeType
 	CreateMapping(ClientContext &context, MultiFileReaderData &reader_data,
 	              const vector<MultiFileColumnDefinition> &global_columns, const vector<ColumnIndex> &global_column_ids,
-	              optional_ptr<TableFilterSet> filters, const OpenFileInfo &initial_file,
+	              optional_ptr<TableFilterSet> filters, MultiFileList &multi_file_list,
 	              const MultiFileReaderBindData &bind_data, const virtual_column_map_t &virtual_columns);
 
 	//! Finalize the reading of a chunk - applying any constants that are required
@@ -136,11 +136,12 @@ public:
 	                                   MultiFileList &files, MultiFileBindData &result, BaseFileReaderOptions &options,
 	                                   MultiFileOptions &file_options);
 
-	DUCKDB_API virtual ReaderInitializeType
-	InitializeReader(MultiFileReaderData &reader_data, const MultiFileBindData &bind_data,
-	                 const vector<MultiFileColumnDefinition> &global_columns,
-	                 const vector<ColumnIndex> &global_column_ids, optional_ptr<TableFilterSet> table_filters,
-	                 ClientContext &context, optional_ptr<MultiFileReaderGlobalState> global_state);
+	DUCKDB_API virtual ReaderInitializeType InitializeReader(MultiFileReaderData &reader_data,
+	                                                         const MultiFileBindData &bind_data,
+	                                                         const vector<MultiFileColumnDefinition> &global_columns,
+	                                                         const vector<ColumnIndex> &global_column_ids,
+	                                                         optional_ptr<TableFilterSet> table_filters,
+	                                                         ClientContext &context, MultiFileGlobalState &gstate);
 
 	static void PruneReaders(MultiFileBindData &data, MultiFileList &file_list);
 


### PR DESCRIPTION
This allows the global state to be referenced in these callbacks