### PR TITLE
Issue 17335

### DIFF
--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -657,6 +657,8 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		plan->children[0] =
 		    PushDownDependentJoinInternal(std::move(plan->children[0]), parent_propagate_null_values, lateral_depth);
 		auto left_binding = this->base_binding;
+		auto left_delim_offset = delim_offset;
+
 		plan->children[1] =
 		    PushDownDependentJoinInternal(std::move(plan->children[1]), parent_propagate_null_values, lateral_depth);
 		auto right_binding = this->base_binding;
@@ -665,6 +667,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		// because the RIGHT binding might contain NULL values
 		if (join.join_type == JoinType::LEFT) {
 			this->base_binding = left_binding;
+			delim_offset = left_delim_offset;
 		} else if (join.join_type == JoinType::RIGHT) {
 			this->base_binding = right_binding;
 			delim_offset += plan->children[0]->GetColumnBindings().size();

--- a/test/fuzzer/public/correlate_left_join.test
+++ b/test/fuzzer/public/correlate_left_join.test
@@ -1,0 +1,23 @@
+# name: test/fuzzer/public/correlate_left_join.test
+# description: correlate subquery followed by a right join
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE t1(c0 BOOLEAN);
+
+statement ok
+CREATE TABLE t2(c0 DOUBLE);
+
+statement ok
+INSERT INTO t1(c0) VALUES (true);
+
+statement ok
+INSERT INTO t2(c0) VALUES (0.2);
+
+# The build_side_probe_side optimizer will turn the right join into left join
+query IIIII
+SELECT * FROM t2, (SELECT 0) RIGHT JOIN ( SELECT 0 AS col_0, t2.c0 AS col_2) as subQuery1 ON ((subQuery1.col_0)>(subQuery1.col_2)) RIGHT JOIN t1 ON true;
+0.2	NULL	0	0.2	true

--- a/test/fuzzer/public/correlate_left_join.test
+++ b/test/fuzzer/public/correlate_left_join.test
@@ -20,4 +20,5 @@ INSERT INTO t2(c0) VALUES (0.2);
 # The build_side_probe_side optimizer will turn the right join into left join
 query IIIII
 SELECT * FROM t2, (SELECT 0) RIGHT JOIN ( SELECT 0 AS col_0, t2.c0 AS col_2) as subQuery1 ON ((subQuery1.col_0)>(subQuery1.col_2)) RIGHT JOIN t1 ON true;
+----
 0.2	NULL	0	0.2	true


### PR DESCRIPTION
This PR fixes #17335. The issue occurs because the `delim_offset` is updated by the right child operator for left join, causing join conditions to obtain incorrect bindings.