### PR TITLE
Fix issue with `ExternalFileCache` when data is evicted

### DIFF
--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -119,6 +119,7 @@ struct ReadAheadBuffer {
 				throw std::runtime_error("Prefetch registered requested for bytes outside file");
 			}
 			read_head.buffer_handle = file_handle.Read(read_head.buffer_ptr, read_head.size, read_head.location);
+			D_ASSERT(read_head.buffer_handle.IsValid());
 			read_head.data_isset = true;
 		}
 	}
@@ -141,8 +142,10 @@ public:
 			if (!prefetch_buffer->data_isset) {
 				prefetch_buffer->buffer_handle =
 				    file_handle.Read(prefetch_buffer->buffer_ptr, prefetch_buffer->size, prefetch_buffer->location);
+				D_ASSERT(prefetch_buffer->buffer_handle.IsValid());
 				prefetch_buffer->data_isset = true;
 			}
+			D_ASSERT(prefetch_buffer->buffer_handle.IsValid());
 			memcpy(buf, prefetch_buffer->buffer_ptr + location - prefetch_buffer->location, len);
 		} else if (prefetch_mode && len < PREFETCH_FALLBACK_BUFFERSIZE && len > 0) {
 			Prefetch(location, MinValue<uint64_t>(PREFETCH_FALLBACK_BUFFERSIZE, file_handle.GetFileSize() - location));

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -294,7 +294,7 @@ BufferHandle CachingFileHandle::TryInsertFileRange(BufferHandle &pin, data_ptr_t
 			// Another thread has read a range that fully contains the requested range in the meantime
 			auto other_pin = TryReadFromFileRange(guard, *it->second, buffer, nr_bytes, location);
 			if (other_pin.IsValid()) {
-				return std::move(other_pin);
+				return other_pin;
 			}
 			it = ranges.erase(it);
 			continue;

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -236,7 +236,7 @@ BufferHandle CachingFileHandle::TryReadFromCache(data_ptr_t &buffer, idx_t nr_by
 	if (it != ranges.begin()) {
 		--it;
 	}
-	for (it = ranges.begin(); it != ranges.end();) {
+	while (it != ranges.end()) {
 		if (it->second->location >= this_end) {
 			// We're past the requested location
 			break;
@@ -285,12 +285,16 @@ BufferHandle CachingFileHandle::TryInsertFileRange(BufferHandle &pin, data_ptr_t
 	auto &ranges = cached_file.Ranges(guard);
 
 	// Start at lower_bound (first range with location not less than location of newly created range)
-	for (auto it = ranges.lower_bound(location); it != ranges.end();) {
+	auto it = ranges.lower_bound(location);
+	if (it != ranges.begin()) {
+		--it;
+	}
+	while (it != ranges.end()) {
 		if (it->second->GetOverlap(*new_file_range) == CachedFileRangeOverlap::FULL) {
 			// Another thread has read a range that fully contains the requested range in the meantime
-			pin = TryReadFromFileRange(guard, *it->second, buffer, nr_bytes, location);
-			if (pin.IsValid()) {
-				return std::move(pin);
+			auto other_pin = TryReadFromFileRange(guard, *it->second, buffer, nr_bytes, location);
+			if (other_pin.IsValid()) {
+				return std::move(other_pin);
 			}
 			it = ranges.erase(it);
 			continue;
@@ -314,8 +318,10 @@ BufferHandle CachingFileHandle::TryInsertFileRange(BufferHandle &pin, data_ptr_t
 		if (break_loop) {
 			break;
 		}
+
 		++it;
 	}
+	D_ASSERT(pin.IsValid());
 
 	// Finally, insert newly created buffer into the map
 	new_file_range->AddCheckSum();

--- a/src/storage/external_file_cache.cpp
+++ b/src/storage/external_file_cache.cpp
@@ -50,6 +50,9 @@ void ExternalFileCache::CachedFileRange::VerifyCheckSum() {
 		return;
 	}
 	auto buffer_handle = block_handle->block_manager.buffer_manager.Pin(block_handle);
+	if (!buffer_handle.IsValid()) {
+		return;
+	}
 	D_ASSERT(checksum == Checksum(buffer_handle.Ptr(), nr_bytes));
 #endif
 }
@@ -61,7 +64,7 @@ void ExternalFileCache::CachedFile::Verify(const unique_ptr<StorageLockKey> &gua
 #ifdef DEBUG
 	for (const auto &range1 : ranges) {
 		for (const auto &range2 : ranges) {
-			if (range1 == range2) {
+			if (range1.first == range2.first) {
 				continue;
 			}
 			D_ASSERT(range1.second->GetOverlap(*range2.second) != CachedFileRangeOverlap::FULL);

--- a/test/sql/storage/external_file_cache/external_file_cache_low_mem.test_slow
+++ b/test/sql/storage/external_file_cache/external_file_cache_low_mem.test_slow
@@ -1,0 +1,38 @@
+# name: test/sql/storage/external_file_cache/external_file_cache_low_mem.test_slow
+# description: Test the external file cache with low memory limit
+# group: [external_file_cache]
+
+require tpch
+
+require parquet
+
+statement ok
+call dbgen(sf=1);
+
+statement ok
+export database '__TEST_DIR__/efc_tpch_sf1' (format parquet)
+
+foreach table customer lineitem nation orders part partsupp region supplier
+
+statement ok
+drop table ${table};
+
+statement ok
+CREATE VIEW ${table} AS FROM '__TEST_DIR__/efc_tpch_sf1/${table}.parquet';
+
+endloop
+
+statement ok
+set prefetch_all_parquet_files=true;
+
+statement ok
+pragma tpch(9);
+
+statement ok
+set threads=1;
+
+statement ok
+set memory_limit='100mb';
+
+statement ok
+pragma tpch(9);


### PR DESCRIPTION
Issue found internally while stress-testing