### PR TITLE
WIP to move the operator children out of a vector

### DIFF
--- a/src/common/arrow/physical_arrow_collector.cpp
+++ b/src/common/arrow/physical_arrow_collector.cpp
@@ -8,17 +8,18 @@
 
 namespace duckdb {
 
-unique_ptr<PhysicalResultCollector> PhysicalArrowCollector::Create(ClientContext &context, PreparedStatementData &data,
-                                                                   idx_t batch_size) {
-	if (!PhysicalPlanGenerator::PreserveInsertionOrder(context, data.physical_plan->Root())) {
-		// the plan is not order preserving, so we just use the parallel materialized collector
-		return make_uniq_base<PhysicalResultCollector, PhysicalArrowCollector>(data, true, batch_size);
-	} else if (!PhysicalPlanGenerator::UseBatchIndex(context, data.physical_plan->Root())) {
-		// the plan is order preserving, but we cannot use the batch index: use a single-threaded result collector
-		return make_uniq_base<PhysicalResultCollector, PhysicalArrowCollector>(data, false, batch_size);
-	} else {
-		return make_uniq_base<PhysicalResultCollector, PhysicalArrowBatchCollector>(data, batch_size);
-	}
+unique_ptr<PhysicalResultCollector> PhysicalArrowCollector::Createe(ClientContext &context, PreparedStatementData &data,
+                                                                    idx_t batch_size) {
+	// TODO.
+	//	if (!PhysicalPlanGenerator::PreserveInsertionOrder(context, data.physical_plan->Root())) {
+	//		// the plan is not order preserving, so we just use the parallel materialized collector
+	//		return make_uniq_base<PhysicalResultCollector, PhysicalArrowCollector>(data, true, batch_size);
+	//	} else if (!PhysicalPlanGenerator::UseBatchIndex(context, data.physical_plan->Root())) {
+	//		// the plan is order preserving, but we cannot use the batch index: use a single-threaded result collector
+	//		return make_uniq_base<PhysicalResultCollector, PhysicalArrowCollector>(data, false, batch_size);
+	//	} else {
+	//		return make_uniq_base<PhysicalResultCollector, PhysicalArrowBatchCollector>(data, batch_size);
+	//	}
 }
 
 SinkResultType PhysicalArrowCollector::Sink(ExecutionContext &context, DataChunk &chunk,

--- a/src/execution/index/art/plan_art.cpp
+++ b/src/execution/index/art/plan_art.cpp
@@ -24,7 +24,7 @@ PhysicalOperator &ART::CreatePlan(PlanIndexInput &input) {
 	select_list.push_back(make_uniq<BoundReferenceExpression>(LogicalType::ROW_TYPE, op.info->scan_types.size() - 1));
 
 	auto &proj = planner.Make<PhysicalProjection>(new_column_types, std::move(select_list), op.estimated_cardinality);
-	proj.children.push_back(input.table_scan);
+	proj.children.Append(planner.GetArena(), input.table_scan);
 
 	// Optional NOT NULL filter.
 	reference<PhysicalOperator> prev_op(proj);
@@ -45,7 +45,7 @@ PhysicalOperator &ART::CreatePlan(PlanIndexInput &input) {
 		prev_op = planner.Make<PhysicalFilter>(std::move(filter_types), std::move(filter_select_list),
 		                                       op.estimated_cardinality);
 		prev_op.get().types.emplace_back(LogicalType::ROW_TYPE);
-		prev_op.get().children.push_back(proj);
+		prev_op.get().children.Append(planner.GetArena(), proj);
 	}
 
 	// Determine whether to push an ORDER BY operator.
@@ -62,7 +62,7 @@ PhysicalOperator &ART::CreatePlan(PlanIndexInput &input) {
 	                                                        sort, std::move(op.alter_table_info));
 
 	if (!sort) {
-		create_idx.children.push_back(prev_op);
+		create_idx.children.Append(planner.GetArena(), prev_op);
 		return create_idx;
 	}
 
@@ -78,8 +78,8 @@ PhysicalOperator &ART::CreatePlan(PlanIndexInput &input) {
 
 	auto &order = planner.Make<PhysicalOrder>(new_column_types, std::move(orders), std::move(projections),
 	                                          op.estimated_cardinality);
-	order.children.push_back(prev_op);
-	create_idx.children.push_back(order);
+	order.children.Append(planner.GetArena(), prev_op);
+	create_idx.children.Append(planner.GetArena(), order);
 	return create_idx;
 }
 

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -103,26 +103,28 @@ bool PhysicalHashAggregate::CanSkipRegularSink() const {
 	return true;
 }
 
-PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
+PhysicalHashAggregate::PhysicalHashAggregate(ArenaAllocator &arena, ClientContext &context,
+                                             optional_ptr<PhysicalOperator> child, vector<LogicalType> types,
                                              vector<unique_ptr<Expression>> expressions, idx_t estimated_cardinality)
-    : PhysicalHashAggregate(context, std::move(types), std::move(expressions), {}, estimated_cardinality) {
-}
-
-PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
-                                             vector<unique_ptr<Expression>> expressions,
-                                             vector<unique_ptr<Expression>> groups_p, idx_t estimated_cardinality)
-    : PhysicalHashAggregate(context, std::move(types), std::move(expressions), std::move(groups_p), {}, {},
+    : PhysicalHashAggregate(arena, context, child, std::move(types), std::move(expressions), {},
                             estimated_cardinality) {
 }
 
-PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
+PhysicalHashAggregate::PhysicalHashAggregate(ArenaAllocator &arena, ClientContext &context,
+                                             optional_ptr<PhysicalOperator> child, vector<LogicalType> types,
                                              vector<unique_ptr<Expression>> expressions,
-                                             vector<unique_ptr<Expression>> groups_p,
-                                             vector<GroupingSet> grouping_sets_p,
-                                             vector<unsafe_vector<idx_t>> grouping_functions_p,
-                                             idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::HASH_GROUP_BY, std::move(types), estimated_cardinality),
+                                             vector<unique_ptr<Expression>> groups_p, idx_t estimated_cardinality)
+    : PhysicalHashAggregate(arena, context, child, std::move(types), std::move(expressions), std::move(groups_p), {},
+                            {}, estimated_cardinality) {
+}
+
+PhysicalHashAggregate::PhysicalHashAggregate(
+    ArenaAllocator &arena, ClientContext &context, optional_ptr<PhysicalOperator> child, vector<LogicalType> types,
+    vector<unique_ptr<Expression>> expressions, vector<unique_ptr<Expression>> groups_p,
+    vector<GroupingSet> grouping_sets_p, vector<unsafe_vector<idx_t>> grouping_functions_p, idx_t estimated_cardinality)
+    : PhysicalOperator(arena, PhysicalOperatorType::HASH_GROUP_BY, std::move(types), estimated_cardinality),
       grouping_sets(std::move(grouping_sets_p)) {
+
 	// get a list of all aggregates to be computed
 	const idx_t group_count = groups_p.size();
 	if (grouping_sets.empty()) {
@@ -172,6 +174,10 @@ PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<Logi
 
 	for (idx_t i = 0; i < grouping_sets.size(); i++) {
 		groupings.emplace_back(grouping_sets[i], grouped_aggregate_data, distinct_collection_info);
+	}
+
+	if (child) {
+		children.Append(*child);
 	}
 }
 

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -9,9 +9,12 @@
 
 namespace duckdb {
 
-PhysicalStreamingWindow::PhysicalStreamingWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+PhysicalStreamingWindow::PhysicalStreamingWindow(ArenaAllocator &arena, PhysicalOperator &child,
+                                                 vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
                                                  idx_t estimated_cardinality, PhysicalOperatorType type)
-    : PhysicalOperator(type, std::move(types), estimated_cardinality), select_list(std::move(select_list)) {
+    : PhysicalOperator(arena, type, std::move(types), estimated_cardinality), select_list(std::move(select_list)) {
+
+	children.Append(child);
 }
 
 class StreamingWindowGlobalState : public GlobalOperatorState {
@@ -486,7 +489,7 @@ void PhysicalStreamingWindow::ExecuteFunctions(ExecutionContext &context, DataCh
 
 	// Compute window functions
 	const idx_t count = output.size();
-	const column_t input_width = children[0].get().GetTypes().size();
+	const column_t input_width = Child().GetTypes().size();
 	for (column_t expr_idx = 0; expr_idx < select_list.size(); expr_idx++) {
 		column_t col_idx = input_width + expr_idx;
 		auto &expr = *select_list[expr_idx];

--- a/src/execution/operator/filter/physical_filter.cpp
+++ b/src/execution/operator/filter/physical_filter.cpp
@@ -4,19 +4,24 @@
 #include "duckdb/parallel/thread_context.hpp"
 namespace duckdb {
 
-PhysicalFilter::PhysicalFilter(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
-                               idx_t estimated_cardinality)
-    : CachingPhysicalOperator(PhysicalOperatorType::FILTER, std::move(types), estimated_cardinality) {
-	D_ASSERT(select_list.size() > 0);
-	if (select_list.size() > 1) {
-		// create a big AND out of the expressions
-		auto conjunction = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
-		for (auto &expr : select_list) {
-			conjunction->children.push_back(std::move(expr));
-		}
-		expression = std::move(conjunction);
-	} else {
+PhysicalFilter::PhysicalFilter(ArenaAllocator &arena, optional_ptr<PhysicalOperator> child, vector<LogicalType> types,
+                               vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality)
+    : CachingPhysicalOperator(arena, PhysicalOperatorType::FILTER, std::move(types), estimated_cardinality) {
+
+	D_ASSERT(!select_list.empty());
+	if (select_list.size() == 1) {
 		expression = std::move(select_list[0]);
+		return;
+	}
+
+	// Create a conjunction from the select list.
+	auto conjunction = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+	for (auto &expr : select_list) {
+		conjunction->children.push_back(std::move(expr));
+	}
+	expression = std::move(conjunction);
+	if (child) {
+		children.Append(*child);
 	}
 }
 

--- a/src/execution/operator/helper/physical_batch_collector.cpp
+++ b/src/execution/operator/helper/physical_batch_collector.cpp
@@ -6,7 +6,8 @@
 
 namespace duckdb {
 
-PhysicalBatchCollector::PhysicalBatchCollector(PreparedStatementData &data) : PhysicalResultCollector(data) {
+PhysicalBatchCollector::PhysicalBatchCollector(ArenaAllocator &arena, PreparedStatementData &data)
+    : PhysicalResultCollector(arena, data) {
 }
 
 SinkResultType PhysicalBatchCollector::Sink(ExecutionContext &context, DataChunk &chunk,

--- a/src/execution/operator/helper/physical_buffered_batch_collector.cpp
+++ b/src/execution/operator/helper/physical_buffered_batch_collector.cpp
@@ -9,8 +9,8 @@
 
 namespace duckdb {
 
-PhysicalBufferedBatchCollector::PhysicalBufferedBatchCollector(PreparedStatementData &data)
-    : PhysicalResultCollector(data) {
+PhysicalBufferedBatchCollector::PhysicalBufferedBatchCollector(ArenaAllocator &arena, PreparedStatementData &data)
+    : PhysicalResultCollector(arena, data) {
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/helper/physical_buffered_collector.cpp
+++ b/src/execution/operator/helper/physical_buffered_collector.cpp
@@ -4,8 +4,8 @@
 
 namespace duckdb {
 
-PhysicalBufferedCollector::PhysicalBufferedCollector(PreparedStatementData &data, bool parallel)
-    : PhysicalResultCollector(data), parallel(parallel) {
+PhysicalBufferedCollector::PhysicalBufferedCollector(ArenaAllocator &arena, PreparedStatementData &data, bool parallel)
+    : PhysicalResultCollector(arena, data), parallel(parallel) {
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/helper/physical_execute.cpp
+++ b/src/execution/operator/helper/physical_execute.cpp
@@ -4,8 +4,8 @@
 
 namespace duckdb {
 
-PhysicalExecute::PhysicalExecute(PhysicalOperator &plan)
-    : PhysicalOperator(PhysicalOperatorType::EXECUTE, plan.types, idx_t(-1)), plan(plan) {
+PhysicalExecute::PhysicalExecute(ArenaAllocator &arena, PhysicalOperator &plan)
+    : PhysicalOperator(arena, PhysicalOperatorType::EXECUTE, plan.types, idx_t(-1)), plan(plan) {
 }
 
 vector<const_reference<PhysicalOperator>> PhysicalExecute::GetChildren() const {

--- a/src/execution/operator/helper/physical_limit.cpp
+++ b/src/execution/operator/helper/physical_limit.cpp
@@ -8,10 +8,11 @@
 
 namespace duckdb {
 
-PhysicalLimit::PhysicalLimit(vector<LogicalType> types, BoundLimitNode limit_val_p, BoundLimitNode offset_val_p,
-                             idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::LIMIT, std::move(types), estimated_cardinality),
+PhysicalLimit::PhysicalLimit(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+                             BoundLimitNode limit_val_p, BoundLimitNode offset_val_p, idx_t estimated_cardinality)
+    : PhysicalOperator(arena, PhysicalOperatorType::LIMIT, std::move(types), estimated_cardinality),
       limit_val(std::move(limit_val_p)), offset_val(std::move(offset_val_p)) {
+	children.Append(child);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/helper/physical_limit_percent.cpp
+++ b/src/execution/operator/helper/physical_limit_percent.cpp
@@ -7,12 +7,14 @@
 
 namespace duckdb {
 
-PhysicalLimitPercent::PhysicalLimitPercent(vector<LogicalType> types, BoundLimitNode limit_val_p,
-                                           BoundLimitNode offset_val_p, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::LIMIT_PERCENT, std::move(types), estimated_cardinality),
+PhysicalLimitPercent::PhysicalLimitPercent(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+                                           BoundLimitNode limit_val_p, BoundLimitNode offset_val_p,
+                                           idx_t estimated_cardinality)
+    : PhysicalOperator(arena, PhysicalOperatorType::LIMIT_PERCENT, std::move(types), estimated_cardinality),
       limit_val(std::move(limit_val_p)), offset_val(std::move(offset_val_p)) {
 	D_ASSERT(limit_val.Type() == LimitNodeType::CONSTANT_PERCENTAGE ||
 	         limit_val.Type() == LimitNodeType::EXPRESSION_PERCENTAGE);
+	children.Append(child);
 }
 //===--------------------------------------------------------------------===//
 // Sink

--- a/src/execution/operator/helper/physical_materialized_collector.cpp
+++ b/src/execution/operator/helper/physical_materialized_collector.cpp
@@ -5,8 +5,9 @@
 
 namespace duckdb {
 
-PhysicalMaterializedCollector::PhysicalMaterializedCollector(PreparedStatementData &data, bool parallel)
-    : PhysicalResultCollector(data), parallel(parallel) {
+PhysicalMaterializedCollector::PhysicalMaterializedCollector(ArenaAllocator &arena, PreparedStatementData &data,
+                                                             bool parallel)
+    : PhysicalResultCollector(arena, data), parallel(parallel) {
 }
 
 SinkResultType PhysicalMaterializedCollector::Sink(ExecutionContext &context, DataChunk &chunk,

--- a/src/execution/operator/helper/physical_result_collector.cpp
+++ b/src/execution/operator/helper/physical_result_collector.cpp
@@ -13,35 +13,36 @@
 
 namespace duckdb {
 
-PhysicalResultCollector::PhysicalResultCollector(PreparedStatementData &data)
-    : PhysicalOperator(PhysicalOperatorType::RESULT_COLLECTOR, {LogicalType::BOOLEAN}, 0),
+PhysicalResultCollector::PhysicalResultCollector(ArenaAllocator &arena, PreparedStatementData &data)
+    : PhysicalOperator(arena, PhysicalOperatorType::RESULT_COLLECTOR, {LogicalType::BOOLEAN}, 0),
       statement_type(data.statement_type), properties(data.properties), plan(data.physical_plan->Root()),
       names(data.names) {
-	this->types = data.types;
+	types = data.types;
 }
 
-unique_ptr<PhysicalResultCollector> PhysicalResultCollector::GetResultCollector(ClientContext &context,
-                                                                                PreparedStatementData &data) {
-	if (!PhysicalPlanGenerator::PreserveInsertionOrder(context, data.physical_plan->Root())) {
-		// the plan is not order preserving, so we just use the parallel materialized collector
-		if (data.is_streaming) {
-			return make_uniq_base<PhysicalResultCollector, PhysicalBufferedCollector>(data, true);
-		}
-		return make_uniq_base<PhysicalResultCollector, PhysicalMaterializedCollector>(data, true);
-	} else if (!PhysicalPlanGenerator::UseBatchIndex(context, data.physical_plan->Root())) {
-		// the plan is order preserving, but we cannot use the batch index: use a single-threaded result collector
-		if (data.is_streaming) {
-			return make_uniq_base<PhysicalResultCollector, PhysicalBufferedCollector>(data, false);
-		}
-		return make_uniq_base<PhysicalResultCollector, PhysicalMaterializedCollector>(data, false);
-	} else {
-		// we care about maintaining insertion order and the sources all support batch indexes
-		// use a batch collector
-		if (data.is_streaming) {
-			return make_uniq_base<PhysicalResultCollector, PhysicalBufferedBatchCollector>(data);
-		}
-		return make_uniq_base<PhysicalResultCollector, PhysicalBatchCollector>(data);
-	}
+unique_ptr<PhysicalResultCollector> PhysicalResultCollector::GetResultCollectorr(ClientContext &context,
+                                                                                 PreparedStatementData &data) {
+	// TODO.
+	//	if (!PhysicalPlanGenerator::PreserveInsertionOrder(context, data.physical_plan->Root())) {
+	//		// the plan is not order preserving, so we just use the parallel materialized collector
+	//		if (data.is_streaming) {
+	//			return make_uniq_base<PhysicalResultCollector, PhysicalBufferedCollector>(data, true);
+	//		}
+	//		return make_uniq_base<PhysicalResultCollector, PhysicalMaterializedCollector>(data, true);
+	//	} else if (!PhysicalPlanGenerator::UseBatchIndex(context, data.physical_plan->Root())) {
+	//		// the plan is order preserving, but we cannot use the batch index: use a single-threaded result collector
+	//		if (data.is_streaming) {
+	//			return make_uniq_base<PhysicalResultCollector, PhysicalBufferedCollector>(data, false);
+	//		}
+	//		return make_uniq_base<PhysicalResultCollector, PhysicalMaterializedCollector>(data, false);
+	//	} else {
+	//		// we care about maintaining insertion order and the sources all support batch indexes
+	//		// use a batch collector
+	//		if (data.is_streaming) {
+	//			return make_uniq_base<PhysicalResultCollector, PhysicalBufferedBatchCollector>(data);
+	//		}
+	//		return make_uniq_base<PhysicalResultCollector, PhysicalBatchCollector>(data);
+	//	}
 }
 
 vector<const_reference<PhysicalOperator>> PhysicalResultCollector::GetChildren() const {

--- a/src/execution/operator/helper/physical_set_variable.cpp
+++ b/src/execution/operator/helper/physical_set_variable.cpp
@@ -3,9 +3,11 @@
 
 namespace duckdb {
 
-PhysicalSetVariable::PhysicalSetVariable(string name_p, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::SET_VARIABLE, {LogicalType::BOOLEAN}, estimated_cardinality),
+PhysicalSetVariable::PhysicalSetVariable(ArenaAllocator &arena, PhysicalOperator &child, string name_p,
+                                         idx_t estimated_cardinality)
+    : PhysicalOperator(arena, PhysicalOperatorType::SET_VARIABLE, {LogicalType::BOOLEAN}, estimated_cardinality),
       name(std::move(name_p)) {
+	children.Append(child);
 }
 
 SourceResultType PhysicalSetVariable::GetData(ExecutionContext &context, DataChunk &chunk,

--- a/src/execution/operator/helper/physical_streaming_limit.cpp
+++ b/src/execution/operator/helper/physical_streaming_limit.cpp
@@ -3,10 +3,12 @@
 
 namespace duckdb {
 
-PhysicalStreamingLimit::PhysicalStreamingLimit(vector<LogicalType> types, BoundLimitNode limit_val_p,
+PhysicalStreamingLimit::PhysicalStreamingLimit(ArenaAllocator &arena, PhysicalOperator &child,
+                                               vector<LogicalType> types, BoundLimitNode limit_val_p,
                                                BoundLimitNode offset_val_p, idx_t estimated_cardinality, bool parallel)
-    : PhysicalOperator(PhysicalOperatorType::STREAMING_LIMIT, std::move(types), estimated_cardinality),
+    : PhysicalOperator(arena, PhysicalOperatorType::STREAMING_LIMIT, std::move(types), estimated_cardinality),
       limit_val(std::move(limit_val_p)), offset_val(std::move(offset_val_p)), parallel(parallel) {
+	children.Append(child);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/helper/physical_streaming_sample.cpp
+++ b/src/execution/operator/helper/physical_streaming_sample.cpp
@@ -5,11 +5,13 @@
 
 namespace duckdb {
 
-PhysicalStreamingSample::PhysicalStreamingSample(vector<LogicalType> types, unique_ptr<SampleOptions> options,
+PhysicalStreamingSample::PhysicalStreamingSample(ArenaAllocator &arena, PhysicalOperator &child,
+                                                 vector<LogicalType> types, unique_ptr<SampleOptions> options,
                                                  idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::STREAMING_SAMPLE, std::move(types), estimated_cardinality),
+    : PhysicalOperator(arena, PhysicalOperatorType::STREAMING_SAMPLE, std::move(types), estimated_cardinality),
       sample_options(std::move(options)) {
 	percentage = sample_options->sample_size.GetValue<double>() / 100;
+	children.Append(child);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/helper/physical_vacuum.cpp
+++ b/src/execution/operator/helper/physical_vacuum.cpp
@@ -7,9 +7,10 @@
 
 namespace duckdb {
 
-PhysicalVacuum::PhysicalVacuum(unique_ptr<VacuumInfo> info_p, optional_ptr<TableCatalogEntry> table,
+PhysicalVacuum::PhysicalVacuum(ArenaAllocator &arena, optional_ptr<PhysicalOperator> child,
+                               unique_ptr<VacuumInfo> info_p, optional_ptr<TableCatalogEntry> table,
                                unordered_map<idx_t, idx_t> column_id_map, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::VACUUM, {LogicalType::BOOLEAN}, estimated_cardinality),
+    : PhysicalOperator(arena, PhysicalOperatorType::VACUUM, {LogicalType::BOOLEAN}, estimated_cardinality),
       info(std::move(info_p)), table(table), column_id_map(std::move(column_id_map)) {
 }
 

--- a/src/execution/operator/helper/physical_verify_vector.cpp
+++ b/src/execution/operator/helper/physical_verify_vector.cpp
@@ -5,10 +5,10 @@
 
 namespace duckdb {
 
-PhysicalVerifyVector::PhysicalVerifyVector(ArenaAllocator &arena, PhysicalOperator &child, DebugVectorVerification verification)
+PhysicalVerifyVector::PhysicalVerifyVector(PhysicalOperator &child, DebugVectorVerification verification)
     : PhysicalOperator(PhysicalOperatorType::VERIFY_VECTOR, child.GetTypes(), child.estimated_cardinality),
       verification(verification) {
-	children.Append(arena, child);
+	children.push_back(child);
 }
 
 class VerifyVectorState : public OperatorState {

--- a/src/execution/operator/helper/physical_verify_vector.cpp
+++ b/src/execution/operator/helper/physical_verify_vector.cpp
@@ -5,10 +5,11 @@
 
 namespace duckdb {
 
-PhysicalVerifyVector::PhysicalVerifyVector(PhysicalOperator &child, DebugVectorVerification verification)
-    : PhysicalOperator(PhysicalOperatorType::VERIFY_VECTOR, child.GetTypes(), child.estimated_cardinality),
+PhysicalVerifyVector::PhysicalVerifyVector(ArenaAllocator &arena, PhysicalOperator &child,
+                                           DebugVectorVerification verification)
+    : PhysicalOperator(arena, PhysicalOperatorType::VERIFY_VECTOR, child.GetTypes(), child.estimated_cardinality),
       verification(verification) {
-	children.push_back(child);
+	children.Append(child);
 }
 
 class VerifyVectorState : public OperatorState {

--- a/src/execution/operator/helper/physical_verify_vector.cpp
+++ b/src/execution/operator/helper/physical_verify_vector.cpp
@@ -5,10 +5,10 @@
 
 namespace duckdb {
 
-PhysicalVerifyVector::PhysicalVerifyVector(PhysicalOperator &child, DebugVectorVerification verification)
+PhysicalVerifyVector::PhysicalVerifyVector(ArenaAllocator &arena, PhysicalOperator &child, DebugVectorVerification verification)
     : PhysicalOperator(PhysicalOperatorType::VERIFY_VECTOR, child.GetTypes(), child.estimated_cardinality),
       verification(verification) {
-	children.push_back(child);
+	children.Append(arena, child);
 }
 
 class VerifyVectorState : public OperatorState {

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -76,7 +76,7 @@ bool PerfectHashJoinExecutor::CanDoPerfectHashJoin(const PhysicalHashJoin &op, c
 	}
 
 	// We bail out if there are nested types on the RHS
-	for (auto &type : op.children[1].get().GetTypes()) {
+	for (auto &type : op.ChildAt(1).GetTypes()) {
 		switch (type.InternalType()) {
 		case PhysicalType::STRUCT:
 		case PhysicalType::LIST:

--- a/src/execution/operator/join/physical_asof_join.cpp
+++ b/src/execution/operator/join/physical_asof_join.cpp
@@ -12,7 +12,8 @@
 
 namespace duckdb {
 
-PhysicalAsOfJoin::PhysicalAsOfJoin(ArenaAllocator &arena, LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right)
+PhysicalAsOfJoin::PhysicalAsOfJoin(ArenaAllocator &arena, LogicalComparisonJoin &op, PhysicalOperator &left,
+                                   PhysicalOperator &right)
     : PhysicalComparisonJoin(op, PhysicalOperatorType::ASOF_JOIN, std::move(op.conditions), op.join_type,
                              op.estimated_cardinality),
       comparison_type(ExpressionType::INVALID), predicate(std::move(op.predicate)) {
@@ -54,8 +55,9 @@ PhysicalAsOfJoin::PhysicalAsOfJoin(ArenaAllocator &arena, LogicalComparisonJoin 
 	D_ASSERT(!lhs_orders.empty());
 	D_ASSERT(!rhs_orders.empty());
 
-	children.Append(arena, left);
-	children.Append(arena, right);
+	children.Init(arena);
+	children.push_back(left);
+	children.push_back(right);
 
 	//	Fill out the right projection map.
 	right_projection_map = op.right_projection_map;

--- a/src/execution/operator/join/physical_asof_join.cpp
+++ b/src/execution/operator/join/physical_asof_join.cpp
@@ -12,7 +12,7 @@
 
 namespace duckdb {
 
-PhysicalAsOfJoin::PhysicalAsOfJoin(LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right)
+PhysicalAsOfJoin::PhysicalAsOfJoin(ArenaAllocator &arena, LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right)
     : PhysicalComparisonJoin(op, PhysicalOperatorType::ASOF_JOIN, std::move(op.conditions), op.join_type,
                              op.estimated_cardinality),
       comparison_type(ExpressionType::INVALID), predicate(std::move(op.predicate)) {
@@ -22,30 +22,30 @@ PhysicalAsOfJoin::PhysicalAsOfJoin(LogicalComparisonJoin &op, PhysicalOperator &
 		D_ASSERT(cond.left->return_type == cond.right->return_type);
 		join_key_types.push_back(cond.left->return_type);
 
-		auto left = cond.left->Copy();
-		auto right = cond.right->Copy();
+		auto left_cond = cond.left->Copy();
+		auto right_cond = cond.right->Copy();
 		switch (cond.comparison) {
 		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
 		case ExpressionType::COMPARE_GREATERTHAN:
 			null_sensitive.emplace_back(lhs_orders.size());
-			lhs_orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, std::move(left));
-			rhs_orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, std::move(right));
+			lhs_orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, std::move(left_cond));
+			rhs_orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, std::move(right_cond));
 			comparison_type = cond.comparison;
 			break;
 		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
 		case ExpressionType::COMPARE_LESSTHAN:
 			//	Always put NULLS LAST so they can be ignored.
 			null_sensitive.emplace_back(lhs_orders.size());
-			lhs_orders.emplace_back(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, std::move(left));
-			rhs_orders.emplace_back(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, std::move(right));
+			lhs_orders.emplace_back(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, std::move(left_cond));
+			rhs_orders.emplace_back(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, std::move(right_cond));
 			comparison_type = cond.comparison;
 			break;
 		case ExpressionType::COMPARE_EQUAL:
 			null_sensitive.emplace_back(lhs_orders.size());
 			DUCKDB_EXPLICIT_FALLTHROUGH;
 		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
-			lhs_partitions.emplace_back(std::move(left));
-			rhs_partitions.emplace_back(std::move(right));
+			lhs_partitions.emplace_back(std::move(left_cond));
+			rhs_partitions.emplace_back(std::move(right_cond));
 			break;
 		default:
 			throw NotImplementedException("Unsupported join condition for ASOF join");
@@ -54,8 +54,8 @@ PhysicalAsOfJoin::PhysicalAsOfJoin(LogicalComparisonJoin &op, PhysicalOperator &
 	D_ASSERT(!lhs_orders.empty());
 	D_ASSERT(!rhs_orders.empty());
 
-	children.push_back(left);
-	children.push_back(right);
+	children.Append(arena, left);
+	children.Append(arena, right);
 
 	//	Fill out the right projection map.
 	right_projection_map = op.right_projection_map;

--- a/src/execution/operator/join/physical_blockwise_nl_join.cpp
+++ b/src/execution/operator/join/physical_blockwise_nl_join.cpp
@@ -10,11 +10,12 @@
 
 namespace duckdb {
 
-PhysicalBlockwiseNLJoin::PhysicalBlockwiseNLJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
-                                                 unique_ptr<Expression> condition, JoinType join_type,
-                                                 idx_t estimated_cardinality)
+PhysicalBlockwiseNLJoin::PhysicalBlockwiseNLJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperator &left,
+                                                 PhysicalOperator &right, unique_ptr<Expression> condition,
+                                                 JoinType join_type, idx_t estimated_cardinality)
     : PhysicalJoin(op, PhysicalOperatorType::BLOCKWISE_NL_JOIN, join_type, estimated_cardinality),
       condition(std::move(condition)) {
+	children.Init(arena);
 	children.push_back(left);
 	children.push_back(right);
 	// MARK and SINGLE joins not handled

--- a/src/execution/operator/join/physical_comparison_join.cpp
+++ b/src/execution/operator/join/physical_comparison_join.cpp
@@ -4,10 +4,10 @@
 
 namespace duckdb {
 
-PhysicalComparisonJoin::PhysicalComparisonJoin(LogicalOperator &op, PhysicalOperatorType type,
+PhysicalComparisonJoin::PhysicalComparisonJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperatorType type,
                                                vector<JoinCondition> conditions_p, JoinType join_type,
                                                idx_t estimated_cardinality)
-    : PhysicalJoin(op, type, join_type, estimated_cardinality), conditions(std::move(conditions_p)) {
+    : PhysicalJoin(arena, op, type, join_type, estimated_cardinality), conditions(std::move(conditions_p)) {
 	ReorderConditions(conditions);
 }
 

--- a/src/execution/operator/join/physical_cross_product.cpp
+++ b/src/execution/operator/join/physical_cross_product.cpp
@@ -6,9 +6,10 @@
 
 namespace duckdb {
 
-PhysicalCrossProduct::PhysicalCrossProduct(vector<LogicalType> types, PhysicalOperator &left, PhysicalOperator &right,
-                                           idx_t estimated_cardinality)
+PhysicalCrossProduct::PhysicalCrossProduct(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &left,
+                                           PhysicalOperator &right, idx_t estimated_cardinality)
     : CachingPhysicalOperator(PhysicalOperatorType::CROSS_PRODUCT, std::move(types), estimated_cardinality) {
+	children.Init(arena);
 	children.push_back(left);
 	children.push_back(right);
 }

--- a/src/execution/operator/join/physical_cross_product.cpp
+++ b/src/execution/operator/join/physical_cross_product.cpp
@@ -8,10 +8,10 @@ namespace duckdb {
 
 PhysicalCrossProduct::PhysicalCrossProduct(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &left,
                                            PhysicalOperator &right, idx_t estimated_cardinality)
-    : CachingPhysicalOperator(PhysicalOperatorType::CROSS_PRODUCT, std::move(types), estimated_cardinality) {
-	children.Init(arena);
-	children.push_back(left);
-	children.push_back(right);
+    : CachingPhysicalOperator(arena, PhysicalOperatorType::CROSS_PRODUCT, std::move(types), estimated_cardinality) {
+
+	children.Append(left);
+	children.Append(right);
 }
 
 //===--------------------------------------------------------------------===//
@@ -20,7 +20,7 @@ PhysicalCrossProduct::PhysicalCrossProduct(ArenaAllocator &arena, vector<Logical
 class CrossProductGlobalState : public GlobalSinkState {
 public:
 	explicit CrossProductGlobalState(ClientContext &context, const PhysicalCrossProduct &op)
-	    : rhs_materialized(context, op.children[1].get().GetTypes()) {
+	    : rhs_materialized(context, op.ChildAt(1).GetTypes()) {
 		rhs_materialized.InitializeAppend(append_state);
 	}
 
@@ -141,7 +141,7 @@ void PhysicalCrossProduct::BuildPipelines(Pipeline &current, MetaPipeline &meta_
 }
 
 vector<const_reference<PhysicalOperator>> PhysicalCrossProduct::GetSources() const {
-	return children[0].get().GetSources();
+	return Child().GetSources();
 }
 
 } // namespace duckdb

--- a/src/execution/operator/join/physical_delim_join.cpp
+++ b/src/execution/operator/join/physical_delim_join.cpp
@@ -4,11 +4,11 @@
 
 namespace duckdb {
 
-PhysicalDelimJoin::PhysicalDelimJoin(PhysicalOperatorType type, vector<LogicalType> types,
+PhysicalDelimJoin::PhysicalDelimJoin(ArenaAllocator &arena, PhysicalOperatorType type, vector<LogicalType> types,
                                      PhysicalOperator &original_join, PhysicalOperator &distinct,
                                      const vector<const_reference<PhysicalOperator>> &delim_scans,
                                      idx_t estimated_cardinality, optional_idx delim_idx)
-    : PhysicalOperator(type, std::move(types), estimated_cardinality), join(original_join),
+    : PhysicalOperator(arena, type, std::move(types), estimated_cardinality), join(original_join),
       distinct(distinct.Cast<PhysicalHashAggregate>()), delim_scans(delim_scans), delim_idx(delim_idx) {
 	D_ASSERT(type == PhysicalOperatorType::LEFT_DELIM_JOIN || type == PhysicalOperatorType::RIGHT_DELIM_JOIN);
 }

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -29,8 +29,8 @@
 
 namespace duckdb {
 
-PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
-                                   vector<JoinCondition> cond, JoinType join_type,
+PhysicalHashJoin::PhysicalHashJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperator &left,
+                                   PhysicalOperator &right, vector<JoinCondition> cond, JoinType join_type,
                                    const vector<idx_t> &left_projection_map, const vector<idx_t> &right_projection_map,
                                    vector<LogicalType> delim_types, idx_t estimated_cardinality,
                                    unique_ptr<JoinFilterPushdownInfo> pushdown_info_p)
@@ -39,6 +39,7 @@ PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, PhysicalOperator &left, 
 
 	filter_pushdown = std::move(pushdown_info_p);
 
+	children.Init(arena);
 	children.push_back(left);
 	children.push_back(right);
 
@@ -102,9 +103,10 @@ PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, PhysicalOperator &left, 
 	}
 }
 
-PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
-                                   vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality)
-    : PhysicalHashJoin(op, left, right, std::move(cond), join_type, {}, {}, {}, estimated_cardinality, nullptr) {
+PhysicalHashJoin::PhysicalHashJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperator &left,
+                                   PhysicalOperator &right, vector<JoinCondition> cond, JoinType join_type,
+                                   idx_t estimated_cardinality)
+    : PhysicalHashJoin(arena, op, left, right, std::move(cond), join_type, {}, {}, {}, estimated_cardinality, nullptr) {
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -34,14 +34,14 @@ PhysicalHashJoin::PhysicalHashJoin(ArenaAllocator &arena, LogicalOperator &op, P
                                    const vector<idx_t> &left_projection_map, const vector<idx_t> &right_projection_map,
                                    vector<LogicalType> delim_types, idx_t estimated_cardinality,
                                    unique_ptr<JoinFilterPushdownInfo> pushdown_info_p)
-    : PhysicalComparisonJoin(op, PhysicalOperatorType::HASH_JOIN, std::move(cond), join_type, estimated_cardinality),
+    : PhysicalComparisonJoin(arena, op, PhysicalOperatorType::HASH_JOIN, std::move(cond), join_type,
+                             estimated_cardinality),
       delim_types(std::move(delim_types)) {
 
 	filter_pushdown = std::move(pushdown_info_p);
 
-	children.Init(arena);
-	children.push_back(left);
-	children.push_back(right);
+	children.Append(left);
+	children.Append(right);
 
 	// Collect condition types, and which conditions are just references (so we won't duplicate them in the payload)
 	unordered_map<idx_t, idx_t> build_columns_in_conditions;
@@ -53,7 +53,7 @@ PhysicalHashJoin::PhysicalHashJoin(ArenaAllocator &arena, LogicalOperator &op, P
 		}
 	}
 
-	auto &lhs_input_types = children[0].get().GetTypes();
+	auto &lhs_input_types = Child().GetTypes();
 
 	// Create a projection map for the LHS (if it was empty), for convenience
 	lhs_output_columns.col_idxs = left_projection_map;
@@ -74,7 +74,7 @@ PhysicalHashJoin::PhysicalHashJoin(ArenaAllocator &arena, LogicalOperator &op, P
 		return;
 	}
 
-	auto &rhs_input_types = children[1].get().GetTypes();
+	auto &rhs_input_types = ChildAt(1).GetTypes();
 
 	// Create a projection map for the RHS (if it was empty), for convenience
 	auto right_projection_map_copy = right_projection_map;
@@ -152,7 +152,7 @@ public:
 		// For external hash join
 		external = ClientConfig::GetConfig(context).GetSetting<DebugForceExternalSetting>(context);
 		// Set probe types
-		probe_types = op.children[0].get().GetTypes();
+		probe_types = op.Child().GetTypes();
 		probe_types.emplace_back(LogicalType::HASH);
 
 		if (op.filter_pushdown) {
@@ -447,13 +447,13 @@ void PhysicalHashJoin::PrepareFinalize(ClientContext &context, GlobalSinkState &
 	gstate.total_size =
 	    ht.GetTotalSize(gstate.local_hash_tables, gstate.max_partition_size, gstate.max_partition_count);
 	gstate.probe_side_requirement =
-	    GetPartitioningSpaceRequirement(context, children[0].get().GetTypes(), ht.GetRadixBits(), gstate.num_threads);
+	    GetPartitioningSpaceRequirement(context, Child().GetTypes(), ht.GetRadixBits(), gstate.num_threads);
 	const auto max_partition_ht_size =
 	    gstate.max_partition_size + gstate.hash_table->PointerTableSize(gstate.max_partition_count);
 	gstate.temporary_memory_state->SetMinimumReservation(max_partition_ht_size + gstate.probe_side_requirement);
 
 	bool all_constant;
-	gstate.temporary_memory_state->SetMaterializationPenalty(GetTupleWidth(children[0].get().GetTypes(), all_constant));
+	gstate.temporary_memory_state->SetMaterializationPenalty(GetTupleWidth(Child().GetTypes(), all_constant));
 	gstate.temporary_memory_state->SetRemainingSize(gstate.total_size);
 }
 
@@ -1150,7 +1150,7 @@ unique_ptr<LocalSourceState> PhysicalHashJoin::GetLocalSourceState(ExecutionCont
 
 HashJoinGlobalSourceState::HashJoinGlobalSourceState(const PhysicalHashJoin &op, const ClientContext &context)
     : op(op), global_stage(HashJoinSourceStage::INIT), build_chunk_count(0), build_chunk_done(0), probe_chunk_count(0),
-      probe_chunk_done(0), probe_count(op.children[0].get().estimated_cardinality),
+      probe_chunk_done(0), probe_count(op.Child().estimated_cardinality),
       parallel_scan_chunk_count(context.config.verify_parallelism ? 1 : 120) {
 }
 

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -19,10 +19,10 @@
 
 namespace duckdb {
 
-PhysicalIEJoin::PhysicalIEJoin(LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right,
-                               vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality,
-                               unique_ptr<JoinFilterPushdownInfo> pushdown_info)
-    : PhysicalRangeJoin(op, PhysicalOperatorType::IE_JOIN, left, right, std::move(cond), join_type,
+PhysicalIEJoin::PhysicalIEJoin(ArenaAllocator &arena, LogicalComparisonJoin &op, PhysicalOperator &left,
+                               PhysicalOperator &right, vector<JoinCondition> cond, JoinType join_type,
+                               idx_t estimated_cardinality, unique_ptr<JoinFilterPushdownInfo> pushdown_info)
+    : PhysicalRangeJoin(arena, op, PhysicalOperatorType::IE_JOIN, left, right, std::move(cond), join_type,
                         estimated_cardinality) {
 
 	filter_pushdown = std::move(pushdown_info);
@@ -66,9 +66,10 @@ PhysicalIEJoin::PhysicalIEJoin(LogicalComparisonJoin &op, PhysicalOperator &left
 	}
 }
 
-PhysicalIEJoin::PhysicalIEJoin(LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right,
-                               vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality)
-    : PhysicalIEJoin(op, left, right, std::move(cond), join_type, estimated_cardinality, nullptr) {
+PhysicalIEJoin::PhysicalIEJoin(ArenaAllocator &arena, LogicalComparisonJoin &op, PhysicalOperator &left,
+                               PhysicalOperator &right, vector<JoinCondition> cond, JoinType join_type,
+                               idx_t estimated_cardinality)
+    : PhysicalIEJoin(arena, op, left, right, std::move(cond), join_type, estimated_cardinality, nullptr) {
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -85,13 +85,13 @@ public:
 	IEJoinGlobalState(ClientContext &context, const PhysicalIEJoin &op) : child(1) {
 		tables.resize(2);
 		RowLayout lhs_layout;
-		lhs_layout.Initialize(op.children[0].get().GetTypes());
+		lhs_layout.Initialize(op.Child().GetTypes());
 		vector<BoundOrderByNode> lhs_order;
 		lhs_order.emplace_back(op.lhs_orders[0].Copy());
 		tables[0] = make_uniq<GlobalSortedTable>(context, lhs_order, lhs_layout, op);
 
 		RowLayout rhs_layout;
-		rhs_layout.Initialize(op.children[1].get().GetTypes());
+		rhs_layout.Initialize(op.ChildAt(1).GetTypes());
 		vector<BoundOrderByNode> rhs_order;
 		rhs_order.emplace_back(op.rhs_orders[0].Copy());
 		tables[1] = make_uniq<GlobalSortedTable>(context, rhs_order, rhs_layout, op);
@@ -730,7 +730,7 @@ void PhysicalIEJoin::ResolveComplexJoin(ExecutionContext &context, DataChunk &re
 	auto &left_table = *ie_sink.tables[0];
 	auto &right_table = *ie_sink.tables[1];
 
-	const auto left_cols = children[0].get().GetTypes().size();
+	const auto left_cols = Child().GetTypes().size();
 	auto &chunk = state.unprojected;
 	do {
 		SelectionVector lsel(STANDARD_VECTOR_SIZE);
@@ -1011,7 +1011,7 @@ SourceResultType PhysicalIEJoin::GetData(ExecutionContext &context, DataChunk &r
 	}
 
 	// Process LEFT OUTER results
-	const auto left_cols = children[0].get().GetTypes().size();
+	const auto left_cols = Child().GetTypes().size();
 	while (ie_lstate.left_matches) {
 		const idx_t count = ie_lstate.SelectOuterRows(ie_lstate.left_matches);
 		if (!count) {
@@ -1082,11 +1082,11 @@ void PhysicalIEJoin::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeli
 
 	// Build out RHS first because that is the order the join planner expects.
 	auto rhs_pipeline = child_meta_pipeline.GetBasePipeline();
-	children[1].get().BuildPipelines(*rhs_pipeline, child_meta_pipeline);
+	ChildAt(1).BuildPipelines(*rhs_pipeline, child_meta_pipeline);
 
 	// Build out LHS
 	auto &lhs_pipeline = child_meta_pipeline.CreatePipeline();
-	children[0].get().BuildPipelines(lhs_pipeline, child_meta_pipeline);
+	Child().BuildPipelines(lhs_pipeline, child_meta_pipeline);
 
 	// Despite having the same sink, LHS and everything created after it need their own (same) PipelineFinishEvent
 	child_meta_pipeline.AddFinishEvent(lhs_pipeline);

--- a/src/execution/operator/join/physical_join.cpp
+++ b/src/execution/operator/join/physical_join.cpp
@@ -6,9 +6,9 @@
 
 namespace duckdb {
 
-PhysicalJoin::PhysicalJoin(LogicalOperator &op, PhysicalOperatorType type, JoinType join_type,
+PhysicalJoin::PhysicalJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperatorType type, JoinType join_type,
                            idx_t estimated_cardinality)
-    : CachingPhysicalOperator(type, op.types, estimated_cardinality), join_type(join_type) {
+    : CachingPhysicalOperator(arena, type, op.types, estimated_cardinality), join_type(join_type) {
 }
 
 bool PhysicalJoin::EmptyResultIfRHSIsEmpty() const {
@@ -47,8 +47,8 @@ void PhysicalJoin::BuildJoinPipelines(Pipeline &current, MetaPipeline &meta_pipe
 	if (build_rhs) {
 		// on the RHS (build side), we construct a child MetaPipeline with this operator as its sink
 		auto &child_meta_pipeline = meta_pipeline.CreateChildMetaPipeline(current, op, MetaPipelineType::JOIN_BUILD);
-		child_meta_pipeline.Build(op.children[1]);
-		if (op.children[1].get().CanSaturateThreads(current.GetClientContext())) {
+		child_meta_pipeline.Build(op.ChildAt(1));
+		if (op.ChildAt(1).CanSaturateThreads(current.GetClientContext())) {
 			// if the build side can saturate all available threads,
 			// we don't just make the LHS pipeline depend on the RHS, but recursively all LHS children too.
 			// this prevents breadth-first plan evaluation
@@ -58,7 +58,7 @@ void PhysicalJoin::BuildJoinPipelines(Pipeline &current, MetaPipeline &meta_pipe
 	}
 
 	// continue building the current pipeline on the LHS (probe side)
-	op.children[0].get().BuildPipelines(current, meta_pipeline);
+	op.Child().BuildPipelines(current, meta_pipeline);
 
 	if (last_child_ptr) {
 		// the pointer was set, set up the dependencies
@@ -87,7 +87,7 @@ void PhysicalJoin::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline
 }
 
 vector<const_reference<PhysicalOperator>> PhysicalJoin::GetSources() const {
-	auto result = children[0].get().GetSources();
+	auto result = Child().GetSources();
 	if (IsSource()) {
 		result.push_back(*this);
 	}

--- a/src/execution/operator/join/physical_left_delim_join.cpp
+++ b/src/execution/operator/join/physical_left_delim_join.cpp
@@ -9,8 +9,9 @@
 
 namespace duckdb {
 
-PhysicalLeftDelimJoin::PhysicalLeftDelimJoin(PhysicalPlanGenerator &planner, vector<LogicalType> types,
-                                             PhysicalOperator &original_join, PhysicalOperator &distinct,
+PhysicalLeftDelimJoin::PhysicalLeftDelimJoin(ArenaAllocator &arena, PhysicalPlanGenerator &planner,
+                                             vector<LogicalType> types, PhysicalOperator &original_join,
+                                             PhysicalOperator &distinct,
                                              const vector<const_reference<PhysicalOperator>> &delim_scans,
                                              idx_t estimated_cardinality, optional_idx delim_idx)
     : PhysicalDelimJoin(PhysicalOperatorType::LEFT_DELIM_JOIN, std::move(types), original_join, distinct, delim_scans,
@@ -18,6 +19,7 @@ PhysicalLeftDelimJoin::PhysicalLeftDelimJoin(PhysicalPlanGenerator &planner, vec
 	D_ASSERT(join.children.size() == 2);
 	// now for the original join
 	// we take its left child, this is the side that we will duplicate eliminate
+	children.Init(arena);
 	children.push_back(join.children[0]);
 
 	// we replace it with a PhysicalColumnDataScan, that scans the ColumnDataCollection that we keep cached

--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -9,8 +9,8 @@
 
 namespace duckdb {
 
-PhysicalNestedLoopJoin::PhysicalNestedLoopJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
-                                               vector<JoinCondition> cond, JoinType join_type,
+PhysicalNestedLoopJoin::PhysicalNestedLoopJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperator &left,
+                                               PhysicalOperator &right, vector<JoinCondition> cond, JoinType join_type,
                                                idx_t estimated_cardinality,
                                                unique_ptr<JoinFilterPushdownInfo> pushdown_info_p)
     : PhysicalComparisonJoin(op, PhysicalOperatorType::NESTED_LOOP_JOIN, std::move(cond), join_type,
@@ -18,14 +18,15 @@ PhysicalNestedLoopJoin::PhysicalNestedLoopJoin(LogicalOperator &op, PhysicalOper
 
 	filter_pushdown = std::move(pushdown_info_p);
 
+	children.Init(arena);
 	children.push_back(left);
 	children.push_back(right);
 }
 
-PhysicalNestedLoopJoin::PhysicalNestedLoopJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
-                                               vector<JoinCondition> cond, JoinType join_type,
+PhysicalNestedLoopJoin::PhysicalNestedLoopJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperator &left,
+                                               PhysicalOperator &right, vector<JoinCondition> cond, JoinType join_type,
                                                idx_t estimated_cardinality)
-    : PhysicalNestedLoopJoin(op, left, right, std::move(cond), join_type, estimated_cardinality, nullptr) {
+    : PhysicalNestedLoopJoin(arena, op, left, right, std::move(cond), join_type, estimated_cardinality, nullptr) {
 }
 
 bool PhysicalJoin::HasNullValues(DataChunk &chunk) {

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -69,7 +69,7 @@ public:
 public:
 	MergeJoinGlobalState(ClientContext &context, const PhysicalPiecewiseMergeJoin &op) {
 		RowLayout rhs_layout;
-		rhs_layout.Initialize(op.children[1].get().GetTypes());
+		rhs_layout.Initialize(op.ChildAt(1).GetTypes());
 		vector<BoundOrderByNode> rhs_order;
 		rhs_order.emplace_back(op.rhs_orders[0].Copy());
 		table = make_uniq<GlobalSortedTable>(context, rhs_order, rhs_layout, op);
@@ -204,8 +204,8 @@ public:
 			condition_types.push_back(order.expression->return_type);
 		}
 		left_outer.Initialize(STANDARD_VECTOR_SIZE);
-		lhs_layout.Initialize(op.children[0].get().GetTypes());
-		lhs_payload.Initialize(allocator, op.children[0].get().GetTypes());
+		lhs_layout.Initialize(op.Child().GetTypes());
+		lhs_payload.Initialize(allocator, op.Child().GetTypes());
 
 		lhs_order.emplace_back(op.lhs_orders[0].Copy());
 
@@ -780,12 +780,12 @@ SourceResultType PhysicalPiecewiseMergeJoin::GetData(ExecutionContext &context, 
 
 		if (result_count > 0) {
 			// if there were any tuples that didn't find a match, output them
-			const idx_t left_column_count = children[0].get().GetTypes().size();
+			const idx_t left_column_count = Child().GetTypes().size();
 			for (idx_t col_idx = 0; col_idx < left_column_count; ++col_idx) {
 				result.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
 				ConstantVector::SetNull(result.data[col_idx], true);
 			}
-			const idx_t right_column_count = children[1].get().GetTypes().size();
+			const idx_t right_column_count = ChildAt(1).GetTypes().size();
 			for (idx_t col_idx = 0; col_idx < right_column_count; ++col_idx) {
 				result.data[left_column_count + col_idx].Slice(rhs_chunk.data[col_idx], rsel, result_count);
 			}

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -14,39 +14,40 @@
 
 namespace duckdb {
 
-PhysicalPiecewiseMergeJoin::PhysicalPiecewiseMergeJoin(LogicalComparisonJoin &op, PhysicalOperator &left,
-                                                       PhysicalOperator &right, vector<JoinCondition> cond,
-                                                       JoinType join_type, idx_t estimated_cardinality,
+PhysicalPiecewiseMergeJoin::PhysicalPiecewiseMergeJoin(ArenaAllocator &arena, LogicalComparisonJoin &op,
+                                                       PhysicalOperator &left, PhysicalOperator &right,
+                                                       vector<JoinCondition> cond, JoinType join_type,
+                                                       idx_t estimated_cardinality,
                                                        unique_ptr<JoinFilterPushdownInfo> pushdown_info_p)
-    : PhysicalRangeJoin(op, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, left, right, std::move(cond), join_type,
+    : PhysicalRangeJoin(arena, op, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, left, right, std::move(cond), join_type,
                         estimated_cardinality) {
 
 	filter_pushdown = std::move(pushdown_info_p);
 
-	for (auto &cond : conditions) {
-		D_ASSERT(cond.left->return_type == cond.right->return_type);
-		join_key_types.push_back(cond.left->return_type);
+	for (auto &join_cond : conditions) {
+		D_ASSERT(join_cond.left->return_type == join_cond.right->return_type);
+		join_key_types.push_back(join_cond.left->return_type);
 
 		// Convert the conditions to sort orders
-		auto left = cond.left->Copy();
-		auto right = cond.right->Copy();
-		switch (cond.comparison) {
+		auto left_expr = join_cond.left->Copy();
+		auto right_expr = join_cond.right->Copy();
+		switch (join_cond.comparison) {
 		case ExpressionType::COMPARE_LESSTHAN:
 		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-			lhs_orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, std::move(left));
-			rhs_orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, std::move(right));
+			lhs_orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, std::move(left_expr));
+			rhs_orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, std::move(right_expr));
 			break;
 		case ExpressionType::COMPARE_GREATERTHAN:
 		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-			lhs_orders.emplace_back(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, std::move(left));
-			rhs_orders.emplace_back(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, std::move(right));
+			lhs_orders.emplace_back(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, std::move(left_expr));
+			rhs_orders.emplace_back(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, std::move(right_expr));
 			break;
 		case ExpressionType::COMPARE_NOTEQUAL:
 		case ExpressionType::COMPARE_DISTINCT_FROM:
 			// Allowed in multi-predicate joins, but can't be first/sort.
 			D_ASSERT(!lhs_orders.empty());
-			lhs_orders.emplace_back(OrderType::INVALID, OrderByNullType::NULLS_LAST, std::move(left));
-			rhs_orders.emplace_back(OrderType::INVALID, OrderByNullType::NULLS_LAST, std::move(right));
+			lhs_orders.emplace_back(OrderType::INVALID, OrderByNullType::NULLS_LAST, std::move(left_expr));
+			rhs_orders.emplace_back(OrderType::INVALID, OrderByNullType::NULLS_LAST, std::move(right_expr));
 			break;
 
 		default:

--- a/src/execution/operator/join/physical_positional_join.cpp
+++ b/src/execution/operator/join/physical_positional_join.cpp
@@ -5,9 +5,10 @@
 
 namespace duckdb {
 
-PhysicalPositionalJoin::PhysicalPositionalJoin(vector<LogicalType> types, PhysicalOperator &left,
+PhysicalPositionalJoin::PhysicalPositionalJoin(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &left,
                                                PhysicalOperator &right, idx_t estimated_cardinality)
     : PhysicalOperator(PhysicalOperatorType::POSITIONAL_JOIN, std::move(types), estimated_cardinality) {
+	children.Init(arena);
 	children.push_back(left);
 	children.push_back(right);
 }

--- a/src/execution/operator/join/physical_positional_join.cpp
+++ b/src/execution/operator/join/physical_positional_join.cpp
@@ -7,10 +7,10 @@ namespace duckdb {
 
 PhysicalPositionalJoin::PhysicalPositionalJoin(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &left,
                                                PhysicalOperator &right, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::POSITIONAL_JOIN, std::move(types), estimated_cardinality) {
-	children.Init(arena);
-	children.push_back(left);
-	children.push_back(right);
+    : PhysicalOperator(arena, PhysicalOperatorType::POSITIONAL_JOIN, std::move(types), estimated_cardinality) {
+
+	children.Append(left);
+	children.Append(right);
 }
 
 //===--------------------------------------------------------------------===//
@@ -19,7 +19,7 @@ PhysicalPositionalJoin::PhysicalPositionalJoin(ArenaAllocator &arena, vector<Log
 class PositionalJoinGlobalState : public GlobalSinkState {
 public:
 	explicit PositionalJoinGlobalState(ClientContext &context, const PhysicalPositionalJoin &op)
-	    : rhs(context, op.children[1].get().GetTypes()), initialized(false), source_offset(0), exhausted(false) {
+	    : rhs(context, op.ChildAt(1).GetTypes()), initialized(false), source_offset(0), exhausted(false) {
 		rhs.InitializeAppend(append_state);
 	}
 
@@ -187,7 +187,7 @@ void PhysicalPositionalJoin::BuildPipelines(Pipeline &current, MetaPipeline &met
 }
 
 vector<const_reference<PhysicalOperator>> PhysicalPositionalJoin::GetSources() const {
-	auto result = children[0].get().GetSources();
+	auto result = Child().GetSources();
 	if (IsSource()) {
 		result.push_back(*this);
 	}

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -165,9 +165,9 @@ void PhysicalRangeJoin::GlobalSortedTable::Finalize(Pipeline &pipeline, Event &e
 	}
 }
 
-PhysicalRangeJoin::PhysicalRangeJoin(LogicalComparisonJoin &op, PhysicalOperatorType type, PhysicalOperator &left,
-                                     PhysicalOperator &right, vector<JoinCondition> cond, JoinType join_type,
-                                     idx_t estimated_cardinality)
+PhysicalRangeJoin::PhysicalRangeJoin(ArenaAllocator &arena, LogicalComparisonJoin &op, PhysicalOperatorType type,
+                                     PhysicalOperator &left, PhysicalOperator &right, vector<JoinCondition> cond,
+                                     JoinType join_type, idx_t estimated_cardinality)
     : PhysicalComparisonJoin(op, type, std::move(cond), join_type, estimated_cardinality) {
 	// Reorder the conditions so that ranges are at the front.
 	// TODO: use stats to improve the choice?
@@ -192,6 +192,7 @@ PhysicalRangeJoin::PhysicalRangeJoin(LogicalComparisonJoin &op, PhysicalOperator
 		}
 	}
 
+	children.Init(arena);
 	children.push_back(left);
 	children.push_back(right);
 

--- a/src/execution/operator/join/physical_right_delim_join.cpp
+++ b/src/execution/operator/join/physical_right_delim_join.cpp
@@ -10,8 +10,9 @@
 
 namespace duckdb {
 
-PhysicalRightDelimJoin::PhysicalRightDelimJoin(PhysicalPlanGenerator &planner, vector<LogicalType> types,
-                                               PhysicalOperator &original_join, PhysicalOperator &distinct,
+PhysicalRightDelimJoin::PhysicalRightDelimJoin(ArenaAllocator &arena, PhysicalPlanGenerator &planner,
+                                               vector<LogicalType> types, PhysicalOperator &original_join,
+                                               PhysicalOperator &distinct,
                                                const vector<const_reference<PhysicalOperator>> &delim_scans,
                                                idx_t estimated_cardinality, optional_idx delim_idx)
     : PhysicalDelimJoin(PhysicalOperatorType::RIGHT_DELIM_JOIN, std::move(types), original_join, distinct, delim_scans,
@@ -19,6 +20,7 @@ PhysicalRightDelimJoin::PhysicalRightDelimJoin(PhysicalPlanGenerator &planner, v
 	D_ASSERT(join.children.size() == 2);
 	// now for the original join
 	// we take its right child, this is the side that we will duplicate eliminate
+	children.Init(arena);
 	children.push_back(join.children[1]);
 
 	// we replace it with a PhysicalDummyScan, which contains no data, just the types, it won't be scanned anyway

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -10,10 +10,11 @@
 
 namespace duckdb {
 
-PhysicalOrder::PhysicalOrder(vector<LogicalType> types, vector<BoundOrderByNode> orders, vector<idx_t> projections,
-                             idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::ORDER_BY, std::move(types), estimated_cardinality),
+PhysicalOrder::PhysicalOrder(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+                             vector<BoundOrderByNode> orders, vector<idx_t> projections, idx_t estimated_cardinality)
+    : PhysicalOperator(arena, PhysicalOperatorType::ORDER_BY, std::move(types), estimated_cardinality),
       orders(std::move(orders)), projections(std::move(projections)) {
+	children.Append(child);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -8,10 +8,12 @@
 
 namespace duckdb {
 
-PhysicalTopN::PhysicalTopN(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t limit, idx_t offset,
+PhysicalTopN::PhysicalTopN(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+                           vector<BoundOrderByNode> orders, idx_t limit, idx_t offset,
                            shared_ptr<DynamicFilterData> dynamic_filter_p, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::TOP_N, std::move(types), estimated_cardinality), orders(std::move(orders)),
-      limit(limit), offset(offset), dynamic_filter(std::move(dynamic_filter_p)) {
+    : PhysicalOperator(arena, PhysicalOperatorType::TOP_N, std::move(types), estimated_cardinality),
+      orders(std::move(orders)), limit(limit), offset(offset), dynamic_filter(std::move(dynamic_filter_p)) {
+	children.Append(child);
 }
 
 PhysicalTopN::~PhysicalTopN() {

--- a/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -26,14 +26,17 @@ struct ActiveFlushGuard {
 	atomic<bool> &bool_value;
 };
 
-PhysicalBatchCopyToFile::PhysicalBatchCopyToFile(vector<LogicalType> types, CopyFunction function_p,
+PhysicalBatchCopyToFile::PhysicalBatchCopyToFile(ArenaAllocator &arena, PhysicalOperator &child,
+                                                 vector<LogicalType> types, CopyFunction function_p,
                                                  unique_ptr<FunctionData> bind_data_p, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::BATCH_COPY_TO_FILE, std::move(types), estimated_cardinality),
+    : PhysicalOperator(arena, PhysicalOperatorType::BATCH_COPY_TO_FILE, std::move(types), estimated_cardinality),
       function(std::move(function_p)), bind_data(std::move(bind_data_p)) {
+
 	if (!function.flush_batch || !function.prepare_batch) {
 		throw InternalException("PhysicalFixedBatchCopy created for copy function that does not have "
 		                        "prepare_batch/flush_batch defined");
 	}
+	children.Append(child);
 }
 
 //===--------------------------------------------------------------------===//
@@ -164,7 +167,7 @@ public:
 	FixedBatchCopyState current_task = FixedBatchCopyState::SINKING_DATA;
 
 	void InitializeCollection(ClientContext &context, const PhysicalOperator &op) {
-		collection = make_uniq<ColumnDataCollection>(context, op.children[0].get().GetTypes());
+		collection = make_uniq<ColumnDataCollection>(context, op.Child().GetTypes());
 		collection->SetPartitionIndex(0); // Makes the buffer manager less likely to spill this data
 		collection->InitializeAppend(append_state);
 		local_memory_usage = 0;
@@ -463,7 +466,7 @@ void PhysicalBatchCopyToFile::RepartitionBatches(ClientContext &context, GlobalS
 			} else {
 				// the collection is too large for a batch - we need to repartition
 				// create an empty collection
-				auto new_collection = make_uniq<ColumnDataCollection>(context, children[0].get().GetTypes());
+				auto new_collection = make_uniq<ColumnDataCollection>(context, Child().GetTypes());
 				new_collection->SetPartitionIndex(0); // Makes the buffer manager less likely to spill this data
 				append_batch = make_uniq<FixedRawBatchData>(0U, std::move(new_collection));
 			}
@@ -488,7 +491,7 @@ void PhysicalBatchCopyToFile::RepartitionBatches(ClientContext &context, GlobalS
 			// the collection is full - move it to the result and create a new one
 			task_manager.AddTask(make_uniq<PrepareBatchTask>(gstate.scheduled_batch_index++, std::move(append_batch)));
 
-			auto new_collection = make_uniq<ColumnDataCollection>(context, children[0].get().GetTypes());
+			auto new_collection = make_uniq<ColumnDataCollection>(context, Child().GetTypes());
 			new_collection->SetPartitionIndex(0); // Makes the buffer manager less likely to spill this data
 			append_batch = make_uniq<FixedRawBatchData>(0U, std::move(new_collection));
 			append_batch->collection->InitializeAppend(append_state);
@@ -625,7 +628,7 @@ unique_ptr<LocalSinkState> PhysicalBatchCopyToFile::GetLocalSinkState(ExecutionC
 unique_ptr<GlobalSinkState> PhysicalBatchCopyToFile::GetGlobalSinkState(ClientContext &context) const {
 	// request memory based on the minimum amount of memory per column
 	auto minimum_memory_per_thread =
-	    FixedBatchCopyGlobalState::MINIMUM_MEMORY_PER_COLUMN_PER_THREAD * children[0].get().GetTypes().size();
+	    FixedBatchCopyGlobalState::MINIMUM_MEMORY_PER_COLUMN_PER_THREAD * Child().GetTypes().size();
 	auto result = make_uniq<FixedBatchCopyGlobalState>(context, minimum_memory_per_thread);
 	if (write_empty_file) {
 		// if we are writing the file also if it is empty - initialize now

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -14,18 +14,22 @@
 
 namespace duckdb {
 
-PhysicalBatchInsert::PhysicalBatchInsert(vector<LogicalType> types_p, TableCatalogEntry &table,
+PhysicalBatchInsert::PhysicalBatchInsert(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types_p,
+                                         TableCatalogEntry &table,
                                          vector<unique_ptr<BoundConstraint>> bound_constraints_p,
                                          idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::BATCH_INSERT, std::move(types_p), estimated_cardinality),
+    : PhysicalOperator(arena, PhysicalOperatorType::BATCH_INSERT, std::move(types_p), estimated_cardinality),
       insert_table(&table), insert_types(table.GetTypes()), bound_constraints(std::move(bound_constraints_p)) {
+	children.Append(child);
 }
 
-PhysicalBatchInsert::PhysicalBatchInsert(LogicalOperator &op, SchemaCatalogEntry &schema,
-                                         unique_ptr<BoundCreateTableInfo> info_p, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::BATCH_CREATE_TABLE_AS, op.types, estimated_cardinality),
+PhysicalBatchInsert::PhysicalBatchInsert(ArenaAllocator &arena, PhysicalOperator &child, LogicalOperator &op,
+                                         SchemaCatalogEntry &schema, unique_ptr<BoundCreateTableInfo> info_p,
+                                         idx_t estimated_cardinality)
+    : PhysicalOperator(arena, PhysicalOperatorType::BATCH_CREATE_TABLE_AS, op.types, estimated_cardinality),
       insert_table(nullptr), schema(&schema), info(std::move(info_p)) {
 	PhysicalInsert::GetInsertInfo(*info, insert_types);
+	children.Append(child);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/persistent/physical_copy_database.cpp
+++ b/src/execution/operator/persistent/physical_copy_database.cpp
@@ -16,9 +16,9 @@
 
 namespace duckdb {
 
-PhysicalCopyDatabase::PhysicalCopyDatabase(vector<LogicalType> types, idx_t estimated_cardinality,
-                                           unique_ptr<CopyDatabaseInfo> info_p)
-    : PhysicalOperator(PhysicalOperatorType::COPY_DATABASE, std::move(types), estimated_cardinality),
+PhysicalCopyDatabase::PhysicalCopyDatabase(ArenaAllocator &arena, vector<LogicalType> types,
+                                           idx_t estimated_cardinality, unique_ptr<CopyDatabaseInfo> info_p)
+    : PhysicalOperator(arena, PhysicalOperatorType::COPY_DATABASE, std::move(types), estimated_cardinality),
       info(std::move(info_p)) {
 }
 

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -476,10 +476,13 @@ string PhysicalCopyToFile::GetNonTmpFile(ClientContext &context, const string &t
 	return fs.JoinPath(path, base);
 }
 
-PhysicalCopyToFile::PhysicalCopyToFile(vector<LogicalType> types, CopyFunction function_p,
-                                       unique_ptr<FunctionData> bind_data, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::COPY_TO_FILE, std::move(types), estimated_cardinality),
+PhysicalCopyToFile::PhysicalCopyToFile(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+                                       CopyFunction function_p, unique_ptr<FunctionData> bind_data,
+                                       idx_t estimated_cardinality)
+    : PhysicalOperator(arena, PhysicalOperatorType::COPY_TO_FILE, std::move(types), estimated_cardinality),
       function(std::move(function_p)), bind_data(std::move(bind_data)), parallel(false) {
+
+	children.Append(child);
 }
 
 void PhysicalCopyToFile::WriteRotateInternal(ExecutionContext &context, GlobalSinkState &global_state,

--- a/src/execution/operator/persistent/physical_delete.cpp
+++ b/src/execution/operator/persistent/physical_delete.cpp
@@ -12,12 +12,14 @@
 
 namespace duckdb {
 
-PhysicalDelete::PhysicalDelete(vector<LogicalType> types, TableCatalogEntry &tableref, DataTable &table,
+PhysicalDelete::PhysicalDelete(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+                               TableCatalogEntry &tableref, DataTable &table,
                                vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t row_id_index,
                                idx_t estimated_cardinality, bool return_chunk)
-    : PhysicalOperator(PhysicalOperatorType::DELETE_OPERATOR, std::move(types), estimated_cardinality),
+    : PhysicalOperator(arena, PhysicalOperatorType::DELETE_OPERATOR, std::move(types), estimated_cardinality),
       tableref(tableref), table(table), bound_constraints(std::move(bound_constraints)), row_id_index(row_id_index),
       return_chunk(return_chunk) {
+	children.Append(child);
 }
 //===--------------------------------------------------------------------===//
 // Sink

--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -21,10 +21,14 @@ void ReorderTableEntries(catalog_entry_vector_t &tables);
 
 using std::stringstream;
 
-PhysicalExport::PhysicalExport(vector<LogicalType> types, CopyFunction function, unique_ptr<CopyInfo> info,
-                               idx_t estimated_cardinality, unique_ptr<BoundExportData> exported_tables)
-    : PhysicalOperator(PhysicalOperatorType::EXPORT, std::move(types), estimated_cardinality),
+PhysicalExport::PhysicalExport(ArenaAllocator &arena, optional_ptr<PhysicalOperator> child, vector<LogicalType> types,
+                               CopyFunction function, unique_ptr<CopyInfo> info, idx_t estimated_cardinality,
+                               unique_ptr<BoundExportData> exported_tables)
+    : PhysicalOperator(arena, PhysicalOperatorType::EXPORT, std::move(types), estimated_cardinality),
       function(std::move(function)), info(std::move(info)), exported_tables(std::move(exported_tables)) {
+	if (child) {
+		children.Append(*child);
+	}
 }
 
 static void WriteCatalogEntries(stringstream &ss, catalog_entry_vector_t &entries) {

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -15,8 +15,9 @@
 
 namespace duckdb {
 
-PhysicalUpdate::PhysicalUpdate(vector<LogicalType> types, TableCatalogEntry &tableref, DataTable &table,
-                               vector<PhysicalIndex> columns, vector<unique_ptr<Expression>> expressions,
+PhysicalUpdate::PhysicalUpdate(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+                               TableCatalogEntry &tableref, DataTable &table, vector<PhysicalIndex> columns,
+                               vector<unique_ptr<Expression>> expressions,
                                vector<unique_ptr<Expression>> bound_defaults,
                                vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t estimated_cardinality,
                                bool return_chunk)
@@ -43,6 +44,8 @@ PhysicalUpdate::PhysicalUpdate(vector<LogicalType> types, TableCatalogEntry &tab
 		index_update = true;
 		break;
 	}
+
+	children.Append(child);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/projection/physical_pivot.cpp
+++ b/src/execution/operator/projection/physical_pivot.cpp
@@ -5,11 +5,10 @@ namespace duckdb {
 
 PhysicalPivot::PhysicalPivot(ArenaAllocator &arena, vector<LogicalType> types_p, PhysicalOperator &child,
                              BoundPivotInfo bound_pivot_p)
-    : PhysicalOperator(PhysicalOperatorType::PIVOT, std::move(types_p), child.estimated_cardinality),
+    : PhysicalOperator(arena, PhysicalOperatorType::PIVOT, std::move(types_p), child.estimated_cardinality),
       bound_pivot(std::move(bound_pivot_p)) {
 
-	children.Init(arena);
-	children.push_back(child);
+	children.Append(child);
 	for (idx_t p = 0; p < bound_pivot.pivot_values.size(); p++) {
 		auto entry = pivot_map.find(bound_pivot.pivot_values[p]);
 		if (entry != pivot_map.end()) {

--- a/src/execution/operator/projection/physical_pivot.cpp
+++ b/src/execution/operator/projection/physical_pivot.cpp
@@ -3,10 +3,11 @@
 
 namespace duckdb {
 
-PhysicalPivot::PhysicalPivot(vector<LogicalType> types_p, PhysicalOperator &child, BoundPivotInfo bound_pivot_p)
+PhysicalPivot::PhysicalPivot(ArenaAllocator &arena, vector<LogicalType> types_p, PhysicalOperator &child, BoundPivotInfo bound_pivot_p)
     : PhysicalOperator(PhysicalOperatorType::PIVOT, std::move(types_p), child.estimated_cardinality),
       bound_pivot(std::move(bound_pivot_p)) {
-	children.push_back(child);
+
+	children.Append(arena, child);
 	for (idx_t p = 0; p < bound_pivot.pivot_values.size(); p++) {
 		auto entry = pivot_map.find(bound_pivot.pivot_values[p]);
 		if (entry != pivot_map.end()) {

--- a/src/execution/operator/projection/physical_pivot.cpp
+++ b/src/execution/operator/projection/physical_pivot.cpp
@@ -3,11 +3,13 @@
 
 namespace duckdb {
 
-PhysicalPivot::PhysicalPivot(ArenaAllocator &arena, vector<LogicalType> types_p, PhysicalOperator &child, BoundPivotInfo bound_pivot_p)
+PhysicalPivot::PhysicalPivot(ArenaAllocator &arena, vector<LogicalType> types_p, PhysicalOperator &child,
+                             BoundPivotInfo bound_pivot_p)
     : PhysicalOperator(PhysicalOperatorType::PIVOT, std::move(types_p), child.estimated_cardinality),
       bound_pivot(std::move(bound_pivot_p)) {
 
-	children.Append(arena, child);
+	children.Init(arena);
+	children.push_back(child);
 	for (idx_t p = 0; p < bound_pivot.pivot_values.size(); p++) {
 		auto entry = pivot_map.find(bound_pivot.pivot_values[p]);
 		if (entry != pivot_map.end()) {

--- a/src/execution/operator/projection/physical_projection.cpp
+++ b/src/execution/operator/projection/physical_projection.cpp
@@ -19,10 +19,12 @@ public:
 	}
 };
 
-PhysicalProjection::PhysicalProjection(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
-                                       idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::PROJECTION, std::move(types), estimated_cardinality),
+PhysicalProjection::PhysicalProjection(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+                                       vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality)
+    : PhysicalOperator(arena, PhysicalOperatorType::PROJECTION, std::move(types), estimated_cardinality),
       select_list(std::move(select_list)) {
+
+	children.Append(child);
 }
 
 OperatorResultType PhysicalProjection::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,

--- a/src/execution/operator/projection/physical_projection.cpp
+++ b/src/execution/operator/projection/physical_projection.cpp
@@ -36,39 +36,6 @@ unique_ptr<OperatorState> PhysicalProjection::GetOperatorState(ExecutionContext 
 	return make_uniq<ProjectionState>(context, select_list);
 }
 
-unique_ptr<PhysicalOperator>
-PhysicalProjection::CreateJoinProjection(vector<LogicalType> proj_types, const vector<LogicalType> &lhs_types,
-                                         const vector<LogicalType> &rhs_types, const vector<idx_t> &left_projection_map,
-                                         const vector<idx_t> &right_projection_map, const idx_t estimated_cardinality) {
-
-	vector<unique_ptr<Expression>> proj_selects;
-	proj_selects.reserve(proj_types.size());
-
-	if (left_projection_map.empty()) {
-		for (storage_t i = 0; i < lhs_types.size(); ++i) {
-			proj_selects.emplace_back(make_uniq<BoundReferenceExpression>(lhs_types[i], i));
-		}
-	} else {
-		for (auto i : left_projection_map) {
-			proj_selects.emplace_back(make_uniq<BoundReferenceExpression>(lhs_types[i], i));
-		}
-	}
-	const auto left_cols = lhs_types.size();
-
-	if (right_projection_map.empty()) {
-		for (storage_t i = 0; i < rhs_types.size(); ++i) {
-			proj_selects.emplace_back(make_uniq<BoundReferenceExpression>(rhs_types[i], left_cols + i));
-		}
-
-	} else {
-		for (auto i : right_projection_map) {
-			proj_selects.emplace_back(make_uniq<BoundReferenceExpression>(rhs_types[i], left_cols + i));
-		}
-	}
-
-	return make_uniq<PhysicalProjection>(std::move(proj_types), std::move(proj_selects), estimated_cardinality);
-}
-
 InsertionOrderPreservingMap<string> PhysicalProjection::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
 	string projections;

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -62,9 +62,10 @@ void UnnestOperatorState::Reset() {
 	first_fetch = true;
 }
 
-PhysicalUnnest::PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
-                               idx_t estimated_cardinality, PhysicalOperatorType type)
-    : PhysicalOperator(type, std::move(types), estimated_cardinality), select_list(std::move(select_list)) {
+PhysicalUnnest::PhysicalUnnest(ArenaAllocator &arena, vector<LogicalType> types,
+                               vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality,
+                               PhysicalOperatorType type)
+    : PhysicalOperator(arena, type, std::move(types), estimated_cardinality), select_list(std::move(select_list)) {
 	D_ASSERT(!this->select_list.empty());
 }
 

--- a/src/execution/operator/scan/physical_column_data_scan.cpp
+++ b/src/execution/operator/scan/physical_column_data_scan.cpp
@@ -8,16 +8,18 @@
 
 namespace duckdb {
 
-PhysicalColumnDataScan::PhysicalColumnDataScan(vector<LogicalType> types, PhysicalOperatorType op_type,
-                                               idx_t estimated_cardinality,
+PhysicalColumnDataScan::PhysicalColumnDataScan(ArenaAllocator &arena, vector<LogicalType> types,
+                                               PhysicalOperatorType op_type, idx_t estimated_cardinality,
                                                optionally_owned_ptr<ColumnDataCollection> collection_p)
-    : PhysicalOperator(op_type, std::move(types), estimated_cardinality), collection(std::move(collection_p)),
+    : PhysicalOperator(arena, op_type, std::move(types), estimated_cardinality), collection(std::move(collection_p)),
       cte_index(DConstants::INVALID_INDEX) {
 }
 
-PhysicalColumnDataScan::PhysicalColumnDataScan(vector<LogicalType> types, PhysicalOperatorType op_type,
-                                               idx_t estimated_cardinality, idx_t cte_index)
-    : PhysicalOperator(op_type, std::move(types), estimated_cardinality), collection(nullptr), cte_index(cte_index) {
+PhysicalColumnDataScan::PhysicalColumnDataScan(ArenaAllocator &arena, vector<LogicalType> types,
+                                               PhysicalOperatorType op_type, idx_t estimated_cardinality,
+                                               idx_t cte_index)
+    : PhysicalOperator(arena, op_type, std::move(types), estimated_cardinality), collection(nullptr),
+      cte_index(cte_index) {
 }
 
 class PhysicalColumnDataGlobalScanState : public GlobalSourceState {

--- a/src/execution/operator/scan/physical_positional_scan.cpp
+++ b/src/execution/operator/scan/physical_positional_scan.cpp
@@ -10,9 +10,9 @@
 
 namespace duckdb {
 
-PhysicalPositionalScan::PhysicalPositionalScan(vector<LogicalType> types, PhysicalOperator &left,
+PhysicalPositionalScan::PhysicalPositionalScan(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &left,
                                                PhysicalOperator &right)
-    : PhysicalOperator(PhysicalOperatorType::POSITIONAL_SCAN, std::move(types),
+    : PhysicalOperator(arena, PhysicalOperatorType::POSITIONAL_SCAN, std::move(types),
                        MaxValue(left.estimated_cardinality, right.estimated_cardinality)) {
 
 	// Manage the children ourselves

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -9,13 +9,13 @@
 
 namespace duckdb {
 
-PhysicalTableScan::PhysicalTableScan(vector<LogicalType> types, TableFunction function_p,
+PhysicalTableScan::PhysicalTableScan(ArenaAllocator &arena, vector<LogicalType> types, TableFunction function_p,
                                      unique_ptr<FunctionData> bind_data_p, vector<LogicalType> returned_types_p,
                                      vector<ColumnIndex> column_ids_p, vector<idx_t> projection_ids_p,
                                      vector<string> names_p, unique_ptr<TableFilterSet> table_filters_p,
                                      idx_t estimated_cardinality, ExtraOperatorInfo extra_info,
                                      vector<Value> parameters_p, virtual_column_map_t virtual_columns_p)
-    : PhysicalOperator(PhysicalOperatorType::TABLE_SCAN, std::move(types), estimated_cardinality),
+    : PhysicalOperator(arena, PhysicalOperatorType::TABLE_SCAN, std::move(types), estimated_cardinality),
       function(std::move(function_p)), bind_data(std::move(bind_data_p)), returned_types(std::move(returned_types_p)),
       column_ids(std::move(column_ids_p)), projection_ids(std::move(projection_ids_p)), names(std::move(names_p)),
       table_filters(std::move(table_filters_p)), extra_info(extra_info), parameters(std::move(parameters_p)),

--- a/src/execution/operator/schema/physical_create_art_index.cpp
+++ b/src/execution/operator/schema/physical_create_art_index.cpp
@@ -14,12 +14,13 @@
 
 namespace duckdb {
 
-PhysicalCreateARTIndex::PhysicalCreateARTIndex(LogicalOperator &op, TableCatalogEntry &table_p,
-                                               const vector<column_t> &column_ids, unique_ptr<CreateIndexInfo> info,
+PhysicalCreateARTIndex::PhysicalCreateARTIndex(ArenaAllocator &arena, PhysicalOperator &child, LogicalOperator &op,
+                                               TableCatalogEntry &table_p, const vector<column_t> &column_ids,
+                                               unique_ptr<CreateIndexInfo> info,
                                                vector<unique_ptr<Expression>> unbound_expressions,
                                                idx_t estimated_cardinality, const bool sorted,
                                                unique_ptr<AlterTableInfo> alter_table_info)
-    : PhysicalOperator(PhysicalOperatorType::CREATE_INDEX, op.types, estimated_cardinality),
+    : PhysicalOperator(arena, PhysicalOperatorType::CREATE_INDEX, op.types, estimated_cardinality),
       table(table_p.Cast<DuckTableEntry>()), info(std::move(info)), unbound_expressions(std::move(unbound_expressions)),
       sorted(sorted), alter_table_info(std::move(alter_table_info)) {
 
@@ -27,6 +28,8 @@ PhysicalCreateARTIndex::PhysicalCreateARTIndex(LogicalOperator &op, TableCatalog
 	for (auto &column_id : column_ids) {
 		storage_ids.push_back(table.GetColumns().LogicalToPhysical(LogicalIndex(column_id)).index);
 	}
+
+	children.Append(child);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/schema/physical_create_table.cpp
+++ b/src/execution/operator/schema/physical_create_table.cpp
@@ -7,9 +7,9 @@
 
 namespace duckdb {
 
-PhysicalCreateTable::PhysicalCreateTable(LogicalOperator &op, SchemaCatalogEntry &schema,
+PhysicalCreateTable::PhysicalCreateTable(ArenaAllocator &arena, LogicalOperator &op, SchemaCatalogEntry &schema,
                                          unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::CREATE_TABLE, op.types, estimated_cardinality), schema(schema),
+    : PhysicalOperator(arena, PhysicalOperatorType::CREATE_TABLE, op.types, estimated_cardinality), schema(schema),
       info(std::move(info)) {
 }
 

--- a/src/execution/operator/schema/physical_create_type.cpp
+++ b/src/execution/operator/schema/physical_create_type.cpp
@@ -7,8 +7,9 @@
 
 namespace duckdb {
 
-PhysicalCreateType::PhysicalCreateType(unique_ptr<CreateTypeInfo> info_p, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::CREATE_TYPE, {LogicalType::BIGINT}, estimated_cardinality),
+PhysicalCreateType::PhysicalCreateType(ArenaAllocator &arena, unique_ptr<CreateTypeInfo> info_p,
+                                       idx_t estimated_cardinality)
+    : PhysicalOperator(arena, PhysicalOperatorType::CREATE_TYPE, {LogicalType::BIGINT}, estimated_cardinality),
       info(std::move(info_p)) {
 }
 

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -9,12 +9,13 @@
 
 namespace duckdb {
 
-PhysicalCTE::PhysicalCTE(ArenaAllocator &arena, string ctename, idx_t table_index, vector<LogicalType> types, PhysicalOperator &top,
-                         PhysicalOperator &bottom, idx_t estimated_cardinality)
+PhysicalCTE::PhysicalCTE(ArenaAllocator &arena, string ctename, idx_t table_index, vector<LogicalType> types,
+                         PhysicalOperator &top, PhysicalOperator &bottom, idx_t estimated_cardinality)
     : PhysicalOperator(PhysicalOperatorType::CTE, std::move(types), estimated_cardinality), table_index(table_index),
       ctename(std::move(ctename)) {
-	children.Append(arena, top);
-	children.Append(arena, bottom);
+	children.Init(arena);
+	children.push_back(top);
+	children.push_back(bottom);
 }
 
 PhysicalCTE::~PhysicalCTE() {

--- a/src/execution/operator/set/physical_cte.cpp
+++ b/src/execution/operator/set/physical_cte.cpp
@@ -9,12 +9,12 @@
 
 namespace duckdb {
 
-PhysicalCTE::PhysicalCTE(string ctename, idx_t table_index, vector<LogicalType> types, PhysicalOperator &top,
+PhysicalCTE::PhysicalCTE(ArenaAllocator &arena, string ctename, idx_t table_index, vector<LogicalType> types, PhysicalOperator &top,
                          PhysicalOperator &bottom, idx_t estimated_cardinality)
     : PhysicalOperator(PhysicalOperatorType::CTE, std::move(types), estimated_cardinality), table_index(table_index),
       ctename(std::move(ctename)) {
-	children.push_back(top);
-	children.push_back(bottom);
+	children.Append(arena, top);
+	children.Append(arena, bottom);
 }
 
 PhysicalCTE::~PhysicalCTE() {

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -15,12 +15,14 @@
 
 namespace duckdb {
 
-PhysicalRecursiveCTE::PhysicalRecursiveCTE(ArenaAllocator &arena, string ctename, idx_t table_index, vector<LogicalType> types, bool union_all,
-                                           PhysicalOperator &top, PhysicalOperator &bottom, idx_t estimated_cardinality)
+PhysicalRecursiveCTE::PhysicalRecursiveCTE(ArenaAllocator &arena, string ctename, idx_t table_index,
+                                           vector<LogicalType> types, bool union_all, PhysicalOperator &top,
+                                           PhysicalOperator &bottom, idx_t estimated_cardinality)
     : PhysicalOperator(PhysicalOperatorType::RECURSIVE_CTE, std::move(types), estimated_cardinality),
       ctename(std::move(ctename)), table_index(table_index), union_all(union_all) {
-	children.Append(arena, top);
-	children.Append(arena, bottom);
+	children.Init(arena);
+	children.push_back(top);
+	children.push_back(bottom);
 }
 
 PhysicalRecursiveCTE::~PhysicalRecursiveCTE() {

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -15,12 +15,12 @@
 
 namespace duckdb {
 
-PhysicalRecursiveCTE::PhysicalRecursiveCTE(string ctename, idx_t table_index, vector<LogicalType> types, bool union_all,
+PhysicalRecursiveCTE::PhysicalRecursiveCTE(ArenaAllocator &arena, string ctename, idx_t table_index, vector<LogicalType> types, bool union_all,
                                            PhysicalOperator &top, PhysicalOperator &bottom, idx_t estimated_cardinality)
     : PhysicalOperator(PhysicalOperatorType::RECURSIVE_CTE, std::move(types), estimated_cardinality),
       ctename(std::move(ctename)), table_index(table_index), union_all(union_all) {
-	children.push_back(top);
-	children.push_back(bottom);
+	children.Append(arena, top);
+	children.Append(arena, bottom);
 }
 
 PhysicalRecursiveCTE::~PhysicalRecursiveCTE() {

--- a/src/execution/operator/set/physical_union.cpp
+++ b/src/execution/operator/set/physical_union.cpp
@@ -6,12 +6,13 @@
 
 namespace duckdb {
 
-PhysicalUnion::PhysicalUnion(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &top, PhysicalOperator &bottom,
-                             idx_t estimated_cardinality, bool allow_out_of_order)
+PhysicalUnion::PhysicalUnion(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &top,
+                             PhysicalOperator &bottom, idx_t estimated_cardinality, bool allow_out_of_order)
     : PhysicalOperator(PhysicalOperatorType::UNION, std::move(types), estimated_cardinality),
       allow_out_of_order(allow_out_of_order) {
-	children.Append(arena, top);
-	children.Append(arena, bottom);
+	children.Init(arena);
+	children.push_back(top);
+	children.push_back(bottom);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/operator/set/physical_union.cpp
+++ b/src/execution/operator/set/physical_union.cpp
@@ -6,12 +6,12 @@
 
 namespace duckdb {
 
-PhysicalUnion::PhysicalUnion(vector<LogicalType> types, PhysicalOperator &top, PhysicalOperator &bottom,
+PhysicalUnion::PhysicalUnion(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &top, PhysicalOperator &bottom,
                              idx_t estimated_cardinality, bool allow_out_of_order)
     : PhysicalOperator(PhysicalOperatorType::UNION, std::move(types), estimated_cardinality),
       allow_out_of_order(allow_out_of_order) {
-	children.push_back(top);
-	children.push_back(bottom);
+	children.Append(arena, top);
+	children.Append(arena, bottom);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -202,50 +202,53 @@ void PhysicalOperator::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipe
 	op_state.reset();
 
 	auto &state = meta_pipeline.GetState();
-	if (IsSink()) {
-		// operator is a sink, build a pipeline
-		sink_state.reset();
-		D_ASSERT(children.size() == 1);
+	if (!IsSink() && children.empty()) {
+		// Operator is a source.
+		state.SetPipelineSource(current, *this);
+		return;
+	}
 
-		// single operator: the operator becomes the data source of the current pipeline
+	if (children.size() != 1) {
+		throw InternalException("Operator not supported in BuildPipelines");
+	}
+
+	if (IsSink()) {
+		// Operator is a sink.
+		sink_state.reset();
+
+		// It becomes the data source of the current pipeline.
 		state.SetPipelineSource(current, *this);
 
-		// we create a new pipeline starting from the child
+		// Create a new pipeline starting at the child.
 		auto &child_meta_pipeline = meta_pipeline.CreateChildMetaPipeline(current, *this);
-		child_meta_pipeline.Build(children[0]);
-	} else {
-		// operator is not a sink! recurse in children
-		if (children.empty()) {
-			// source
-			state.SetPipelineSource(current, *this);
-		} else {
-			if (children.size() != 1) {
-				throw InternalException("Operator not supported in BuildPipelines");
-			}
-			state.AddPipelineOperator(current, *this);
-			children[0].get().BuildPipelines(current, meta_pipeline);
-		}
+		child_meta_pipeline.Build(Child());
+		return;
 	}
+
+	// Recurse into the child.
+	state.AddPipelineOperator(current, *this);
+	Child().BuildPipelines(current, meta_pipeline);
 }
 
 vector<const_reference<PhysicalOperator>> PhysicalOperator::GetSources() const {
 	vector<const_reference<PhysicalOperator>> result;
-	if (IsSink()) {
-		D_ASSERT(children.size() == 1);
+	if (!IsSink() && children.empty()) {
+		// Operator is a source.
 		result.push_back(*this);
 		return result;
-	} else {
-		if (children.empty()) {
-			// source
-			result.push_back(*this);
-			return result;
-		} else {
-			if (children.size() != 1) {
-				throw InternalException("Operator not supported in GetSource");
-			}
-			return children[0].get().GetSources();
-		}
 	}
+
+	if (children.size() != 1) {
+		throw InternalException("Operator not supported in GetSource");
+	}
+
+	if (IsSink()) {
+		result.push_back(*this);
+		return result;
+	}
+
+	// Recurse into the child.
+	return Child().GetSources();
 }
 
 bool PhysicalOperator::AllSourcesSupportBatchIndex() const {
@@ -288,9 +291,9 @@ bool CachingPhysicalOperator::CanCacheType(const LogicalType &type) {
 	}
 }
 
-CachingPhysicalOperator::CachingPhysicalOperator(PhysicalOperatorType type, vector<LogicalType> types_p,
-                                                 idx_t estimated_cardinality)
-    : PhysicalOperator(type, std::move(types_p), estimated_cardinality) {
+CachingPhysicalOperator::CachingPhysicalOperator(ArenaAllocator &arena, PhysicalOperatorType type,
+                                                 vector<LogicalType> types_p, idx_t estimated_cardinality)
+    : PhysicalOperator(arena, type, std::move(types_p), estimated_cardinality) {
 
 	caching_supported = true;
 	for (auto &col_type : types) {

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -255,12 +255,12 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalAggregate &op) {
 		if (can_use_simple_aggregation) {
 			auto &group_by =
 			    Make<PhysicalUngroupedAggregate>(op.types, std::move(op.expressions), op.estimated_cardinality);
-			group_by.children.Append(GetArena(), plan);
+			group_by.children.push_back(plan);
 			return group_by;
 		}
 		auto &group_by =
 		    Make<PhysicalHashAggregate>(context, op.types, std::move(op.expressions), op.estimated_cardinality);
-		group_by.children.Append(GetArena(), plan);
+		group_by.children.push_back(plan);
 		return group_by;
 	}
 
@@ -272,7 +272,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalAggregate &op) {
 		auto &group_by =
 		    Make<PhysicalPartitionedAggregate>(context, op.types, std::move(op.expressions), std::move(op.groups),
 		                                       std::move(partition_columns), op.estimated_cardinality);
-		group_by.children.Append(GetArena(), plan);
+		group_by.children.push_back(plan);
 		return group_by;
 	}
 
@@ -280,14 +280,14 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalAggregate &op) {
 		auto &group_by = Make<PhysicalPerfectHashAggregate>(context, op.types, std::move(op.expressions),
 		                                                    std::move(op.groups), std::move(op.group_stats),
 		                                                    std::move(required_bits), op.estimated_cardinality);
-		group_by.children.Append(GetArena(), plan);
+		group_by.children.push_back(plan);
 		return group_by;
 	}
 
 	auto &group_by = Make<PhysicalHashAggregate>(context, op.types, std::move(op.expressions), std::move(op.groups),
 	                                             std::move(op.grouping_sets), std::move(op.grouping_functions),
 	                                             op.estimated_cardinality);
-	group_by.children.Append(GetArena(), plan);
+	group_by.children.push_back(plan);
 	return group_by;
 }
 
@@ -331,7 +331,7 @@ PhysicalOperator &PhysicalPlanGenerator::ExtractAggregateExpressions(PhysicalOpe
 		return child;
 	}
 	auto &proj = Make<PhysicalProjection>(std::move(types), std::move(expressions), child.estimated_cardinality);
-	proj.children.Append(GetArena(), child);
+	proj.children.push_back(child);
 	return proj;
 }
 

--- a/src/execution/physical_plan/plan_any_join.cpp
+++ b/src/execution/physical_plan/plan_any_join.cpp
@@ -12,7 +12,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalAnyJoin &op) {
 	auto &right = CreatePlan(*op.children[1]);
 
 	// Create the blockwise NL join.
-	return Make<PhysicalBlockwiseNLJoin>(GetArena(), op, left, right, std::move(op.condition), op.join_type,
+	return Make<PhysicalBlockwiseNLJoin>(op, left, right, std::move(op.condition), op.join_type,
 	                                     op.estimated_cardinality);
 }
 

--- a/src/execution/physical_plan/plan_any_join.cpp
+++ b/src/execution/physical_plan/plan_any_join.cpp
@@ -12,7 +12,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalAnyJoin &op) {
 	auto &right = CreatePlan(*op.children[1]);
 
 	// Create the blockwise NL join.
-	return Make<PhysicalBlockwiseNLJoin>(op, left, right, std::move(op.condition), op.join_type,
+	return Make<PhysicalBlockwiseNLJoin>(GetArena(), op, left, right, std::move(op.condition), op.join_type,
 	                                     op.estimated_cardinality);
 }
 

--- a/src/execution/physical_plan/plan_asof_join.cpp
+++ b/src/execution/physical_plan/plan_asof_join.cpp
@@ -206,8 +206,8 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 	auto &window = Make<PhysicalStreamingWindow>(window_types, std::move(window_select), probe_cardinality);
 	window.children.emplace_back(probe);
 
-	auto &join = Make<PhysicalNestedLoopJoin>(join_op, build, window, std::move(join_op.conditions), join_op.join_type,
-	                                          probe_cardinality);
+	auto &join = Make<PhysicalNestedLoopJoin>(GetArena(), join_op, build, window, std::move(join_op.conditions),
+	                                          join_op.join_type, probe_cardinality);
 
 	// Plan a projection of the compare column
 	auto &comp_proj = Make<PhysicalProjection>(std::move(comp_types), std::move(comp_list), probe_cardinality);
@@ -277,7 +277,7 @@ PhysicalOperator &PhysicalPlanGenerator::PlanAsOfJoin(LogicalComparisonJoin &op)
 				return *result;
 			}
 		}
-		return Make<PhysicalAsOfJoin>(op, left, right);
+		return Make<PhysicalAsOfJoin>(GetArena(), op, left, right);
 	}
 
 	//	Strip extra column from rhs projections
@@ -351,7 +351,7 @@ PhysicalOperator &PhysicalPlanGenerator::PlanAsOfJoin(LogicalComparisonJoin &op)
 	}
 
 	op.conditions.emplace_back(std::move(asof_upper));
-	return Make<PhysicalIEJoin>(op, left, window, std::move(op.conditions), op.join_type, lhs_cardinality);
+	return Make<PhysicalIEJoin>(GetArena(), op, left, window, std::move(op.conditions), op.join_type, lhs_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -37,7 +37,7 @@ PhysicalOperator &PhysicalPlanGenerator::PlanComparisonJoin(LogicalComparisonJoi
 
 	if (op.conditions.empty()) {
 		// no conditions: insert a cross product
-		return Make<PhysicalCrossProduct>(op.types, left, right, op.estimated_cardinality);
+		return Make<PhysicalCrossProduct>(GetArena(), op.types, left, right, op.estimated_cardinality);
 	}
 
 	idx_t has_range = 0;
@@ -62,7 +62,7 @@ PhysicalOperator &PhysicalPlanGenerator::PlanComparisonJoin(LogicalComparisonJoi
 	const auto prefer_range_joins = client_config.prefer_range_joins && can_iejoin;
 	if (has_equality && !prefer_range_joins) {
 		// Equality join with small number of keys : possible perfect join optimization
-		auto &join = Make<PhysicalHashJoin>(op, left, right, std::move(op.conditions), op.join_type,
+		auto &join = Make<PhysicalHashJoin>(GetArena(), op, left, right, std::move(op.conditions), op.join_type,
 		                                    op.left_projection_map, op.right_projection_map, std::move(op.mark_types),
 		                                    op.estimated_cardinality, std::move(op.filter_pushdown));
 		join.Cast<PhysicalHashJoin>().join_stats = std::move(op.join_stats);
@@ -84,17 +84,17 @@ PhysicalOperator &PhysicalPlanGenerator::PlanComparisonJoin(LogicalComparisonJoi
 	}
 
 	if (can_iejoin) {
-		return Make<PhysicalIEJoin>(op, left, right, std::move(op.conditions), op.join_type, op.estimated_cardinality,
-		                            std::move(op.filter_pushdown));
+		return Make<PhysicalIEJoin>(GetArena(), op, left, right, std::move(op.conditions), op.join_type,
+		                            op.estimated_cardinality, std::move(op.filter_pushdown));
 	}
 	if (can_merge) {
 		// range join: use piecewise merge join
-		return Make<PhysicalPiecewiseMergeJoin>(op, left, right, std::move(op.conditions), op.join_type,
+		return Make<PhysicalPiecewiseMergeJoin>(GetArena(), op, left, right, std::move(op.conditions), op.join_type,
 		                                        op.estimated_cardinality, std::move(op.filter_pushdown));
 	}
 	if (PhysicalNestedLoopJoin::IsSupported(op.conditions, op.join_type)) {
 		// inequality join: use nested loop
-		return Make<PhysicalNestedLoopJoin>(op, left, right, std::move(op.conditions), op.join_type,
+		return Make<PhysicalNestedLoopJoin>(GetArena(), op, left, right, std::move(op.conditions), op.join_type,
 		                                    op.estimated_cardinality, std::move(op.filter_pushdown));
 	}
 
@@ -102,7 +102,8 @@ PhysicalOperator &PhysicalPlanGenerator::PlanComparisonJoin(LogicalComparisonJoi
 		RewriteJoinCondition(*cond.right, left.types.size());
 	}
 	auto condition = JoinCondition::CreateExpression(std::move(op.conditions));
-	return Make<PhysicalBlockwiseNLJoin>(op, left, right, std::move(condition), op.join_type, op.estimated_cardinality);
+	return Make<PhysicalBlockwiseNLJoin>(GetArena(), op, left, right, std::move(condition), op.join_type,
+	                                     op.estimated_cardinality);
 }
 
 PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalComparisonJoin &op) {

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -42,20 +42,20 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile &op) {
 			throw InternalException("BATCH_COPY_TO_FILE can only be used if batch indexes are supported");
 		}
 		// batched copy to file
-		auto &copy =
-		    Make<PhysicalBatchCopyToFile>(op.types, op.function, std::move(op.bind_data), op.estimated_cardinality);
+		auto &copy = Make<PhysicalBatchCopyToFile>(plan, op.types, op.function, std::move(op.bind_data),
+		                                           op.estimated_cardinality);
 
 		auto &cast_copy = copy.Cast<PhysicalBatchCopyToFile>();
 		cast_copy.file_path = op.file_path;
 		cast_copy.use_tmp_file = op.use_tmp_file;
-		cast_copy.children.push_back(plan);
 		cast_copy.return_type = op.return_type;
 		cast_copy.write_empty_file = op.write_empty_file;
 		return copy;
 	}
 
 	// COPY from select statement to file
-	auto &copy = Make<PhysicalCopyToFile>(op.types, op.function, std::move(op.bind_data), op.estimated_cardinality);
+	auto &copy =
+	    Make<PhysicalCopyToFile>(plan, op.types, op.function, std::move(op.bind_data), op.estimated_cardinality);
 
 	auto &cast_copy = copy.Cast<PhysicalCopyToFile>();
 	cast_copy.file_path = op.file_path;
@@ -80,7 +80,6 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile &op) {
 	cast_copy.write_empty_file = op.write_empty_file;
 	cast_copy.hive_file_pattern = op.hive_file_pattern;
 
-	cast_copy.children.push_back(plan);
 	return copy;
 }
 

--- a/src/execution/physical_plan/plan_create.cpp
+++ b/src/execution/physical_plan/plan_create.cpp
@@ -30,7 +30,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCreate &op) {
 		if (!op.children.empty()) {
 			D_ASSERT(op.children.size() == 1);
 			auto &plan = CreatePlan(*op.children[0]);
-			create.children.push_back(plan);
+			create.children.Append(plan);
 		}
 		return create;
 	}

--- a/src/execution/physical_plan/plan_create_table.cpp
+++ b/src/execution/physical_plan/plan_create_table.cpp
@@ -21,17 +21,11 @@ PhysicalOperator &DuckCatalog::PlanCreateTableAs(ClientContext &context, Physica
 	bool use_batch_index = PhysicalPlanGenerator::UseBatchIndex(context, plan);
 	auto num_threads = TaskScheduler::GetScheduler(context).NumberOfThreads();
 	if (!parallel_streaming_insert && use_batch_index) {
-		auto &insert = planner.Make<PhysicalBatchInsert>(op, op.schema, std::move(op.info), 0U);
-		D_ASSERT(op.children.size() == 1);
-		insert.children.push_back(plan);
-		return insert;
+		return planner.Make<PhysicalBatchInsert>(plan, op, op.schema, std::move(op.info), 0U);
 	}
 
 	auto parallel = parallel_streaming_insert && num_threads > 1;
-	auto &insert = planner.Make<PhysicalInsert>(op, op.schema, std::move(op.info), 0U, parallel);
-	D_ASSERT(op.children.size() == 1);
-	insert.children.push_back(plan);
-	return insert;
+	return planner.Make<PhysicalInsert>(plan, op, op.schema, std::move(op.info), 0U, parallel);
 }
 
 PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCreateTable &op) {

--- a/src/execution/physical_plan/plan_cross_product.cpp
+++ b/src/execution/physical_plan/plan_cross_product.cpp
@@ -8,7 +8,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCrossProduct &op) {
 	D_ASSERT(op.children.size() == 2);
 	auto &left = CreatePlan(*op.children[0]);
 	auto &right = CreatePlan(*op.children[1]);
-	return Make<PhysicalCrossProduct>(op.types, left, right, op.estimated_cardinality);
+	return Make<PhysicalCrossProduct>(GetArena(), op.types, left, right, op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_cross_product.cpp
+++ b/src/execution/physical_plan/plan_cross_product.cpp
@@ -8,7 +8,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCrossProduct &op) {
 	D_ASSERT(op.children.size() == 2);
 	auto &left = CreatePlan(*op.children[0]);
 	auto &right = CreatePlan(*op.children[1]);
-	return Make<PhysicalCrossProduct>(GetArena(), op.types, left, right, op.estimated_cardinality);
+	return Make<PhysicalCrossProduct>(op.types, left, right, op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_cte.cpp
+++ b/src/execution/physical_plan/plan_cte.cpp
@@ -23,7 +23,8 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalMaterializedCTE &op) 
 	// Initialize an empty vector to collect the scan operators.
 	auto &right = CreatePlan(*op.children[1]);
 
-	auto &cte = Make<PhysicalCTE>(op.ctename, op.table_index, right.types, left, right, op.estimated_cardinality);
+	auto &cte =
+	    Make<PhysicalCTE>(GetArena(), op.ctename, op.table_index, right.types, left, right, op.estimated_cardinality);
 	auto &cast_cte = cte.Cast<PhysicalCTE>();
 	cast_cte.working_table = working_table;
 	cast_cte.cte_scans = materialized_ctes[op.table_index];

--- a/src/execution/physical_plan/plan_delete.cpp
+++ b/src/execution/physical_plan/plan_delete.cpp
@@ -11,10 +11,9 @@ PhysicalOperator &DuckCatalog::PlanDelete(ClientContext &context, PhysicalPlanGe
                                           PhysicalOperator &plan) {
 	// Get the row_id column index.
 	auto &bound_ref = op.expressions[0]->Cast<BoundReferenceExpression>();
-	auto &del = planner.Make<PhysicalDelete>(op.types, op.table, op.table.GetStorage(), std::move(op.bound_constraints),
-	                                         bound_ref.index, op.estimated_cardinality, op.return_chunk);
-	del.children.push_back(plan);
-	return del;
+	return planner.Make<PhysicalDelete>(plan, op.types, op.table, op.table.GetStorage(),
+	                                    std::move(op.bound_constraints), bound_ref.index, op.estimated_cardinality,
+	                                    op.return_chunk);
 }
 
 PhysicalOperator &Catalog::PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op) {

--- a/src/execution/physical_plan/plan_delim_join.cpp
+++ b/src/execution/physical_plan/plan_delim_join.cpp
@@ -55,11 +55,11 @@ PhysicalOperator &PhysicalPlanGenerator::PlanDelimJoin(LogicalComparisonJoin &op
 
 	// Create the duplicate eliminated join.
 	if (op.delim_flipped) {
-		return Make<PhysicalRightDelimJoin>(*this, op.types, plan, distinct, delim_scans, op.estimated_cardinality,
-		                                    optional_idx(this->delim_index));
+		return Make<PhysicalRightDelimJoin>(GetArena(), *this, op.types, plan, distinct, delim_scans,
+		                                    op.estimated_cardinality, optional_idx(this->delim_index));
 	}
-	return Make<PhysicalLeftDelimJoin>(*this, op.types, plan, distinct, delim_scans, op.estimated_cardinality,
-	                                   optional_idx(this->delim_index));
+	return Make<PhysicalLeftDelimJoin>(GetArena(), *this, op.types, plan, distinct, delim_scans,
+	                                   op.estimated_cardinality, optional_idx(this->delim_index));
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_delim_join.cpp
+++ b/src/execution/physical_plan/plan_delim_join.cpp
@@ -32,7 +32,7 @@ PhysicalOperator &PhysicalPlanGenerator::PlanDelimJoin(LogicalComparisonJoin &op
 	// first gather the scans on the duplicate eliminated data set from the delim side
 	const idx_t delim_idx = op.delim_flipped ? 0 : 1;
 	vector<const_reference<PhysicalOperator>> delim_scans;
-	GatherDelimScans(plan.children[delim_idx], delim_scans, ++this->delim_index);
+	GatherDelimScans(plan.ChildAt(delim_idx), delim_scans, ++this->delim_index);
 	if (delim_scans.empty()) {
 		// no duplicate eliminated scans in the delim side!
 		// in this case we don't need to create a delim join
@@ -50,16 +50,16 @@ PhysicalOperator &PhysicalPlanGenerator::PlanDelimJoin(LogicalComparisonJoin &op
 
 	// we still have to create the DISTINCT clause that is used to generate the duplicate eliminated chunk
 	auto &distinct =
-	    Make<PhysicalHashAggregate>(context, delim_types, std::move(distinct_expressions), std::move(distinct_groups),
-	                                delim_scans[0].get().estimated_cardinality);
+	    Make<PhysicalHashAggregate>(context, nullptr, delim_types, std::move(distinct_expressions),
+	                                std::move(distinct_groups), delim_scans[0].get().estimated_cardinality);
 
 	// Create the duplicate eliminated join.
 	if (op.delim_flipped) {
-		return Make<PhysicalRightDelimJoin>(GetArena(), *this, op.types, plan, distinct, delim_scans,
-		                                    op.estimated_cardinality, optional_idx(this->delim_index));
+		return Make<PhysicalRightDelimJoin>(*this, op.types, plan, distinct, delim_scans, op.estimated_cardinality,
+		                                    optional_idx(this->delim_index));
 	}
-	return Make<PhysicalLeftDelimJoin>(GetArena(), *this, op.types, plan, distinct, delim_scans,
-	                                   op.estimated_cardinality, optional_idx(this->delim_index));
+	return Make<PhysicalLeftDelimJoin>(*this, op.types, plan, distinct, delim_scans, op.estimated_cardinality,
+	                                   optional_idx(this->delim_index));
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_explain.cpp
+++ b/src/execution/physical_plan/plan_explain.cpp
@@ -13,9 +13,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalExplain &op) {
 	auto logical_plan_opt = op.children[0]->ToString(op.explain_format);
 	auto &plan = CreatePlan(*op.children[0]);
 	if (op.explain_type == ExplainType::EXPLAIN_ANALYZE) {
-		auto &explain = Make<PhysicalExplainAnalyze>(op.types, op.explain_format);
-		explain.children.push_back(plan);
-		return explain;
+		return Make<PhysicalExplainAnalyze>(plan, op.types, op.explain_format);
 	}
 
 	// Format the plan and set the output of the EXPLAIN.

--- a/src/execution/physical_plan/plan_export.cpp
+++ b/src/execution/physical_plan/plan_export.cpp
@@ -6,14 +6,13 @@
 namespace duckdb {
 
 PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalExport &op) {
-	auto &export_op = Make<PhysicalExport>(op.types, op.function, std::move(op.copy_info), op.estimated_cardinality,
-	                                       std::move(op.exported_tables));
+	optional_ptr<PhysicalOperator> child;
 	// Plan the underlying copy statements, if any.
 	if (!op.children.empty()) {
-		auto &plan = CreatePlan(*op.children[0]);
-		export_op.children.push_back(plan);
+		child = CreatePlan(*op.children[0]);
 	}
-	return export_op;
+	return Make<PhysicalExport>(child, op.types, op.function, std::move(op.copy_info), op.estimated_cardinality,
+	                            std::move(op.exported_tables));
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_filter.cpp
+++ b/src/execution/physical_plan/plan_filter.cpp
@@ -16,8 +16,8 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalFilter &op) {
 	if (!op.expressions.empty()) {
 		D_ASSERT(!plan.get().GetTypes().empty());
 		// create a filter if there is anything to filter
-		auto &filter = Make<PhysicalFilter>(plan.get().GetTypes(), std::move(op.expressions), op.estimated_cardinality);
-		filter.children.push_back(plan);
+		auto &filter =
+		    Make<PhysicalFilter>(plan, plan.get().GetTypes(), std::move(op.expressions), op.estimated_cardinality);
 		plan = filter;
 	}
 	if (op.HasProjectionMap()) {
@@ -26,8 +26,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalFilter &op) {
 		for (idx_t i = 0; i < op.projection_map.size(); i++) {
 			select_list.push_back(make_uniq<BoundReferenceExpression>(op.types[i], op.projection_map[i]));
 		}
-		auto &proj = Make<PhysicalProjection>(op.types, std::move(select_list), op.estimated_cardinality);
-		proj.children.push_back(plan);
+		auto &proj = Make<PhysicalProjection>(plan, op.types, std::move(select_list), op.estimated_cardinality);
 		plan = proj;
 	}
 	return plan;

--- a/src/execution/physical_plan/plan_order.cpp
+++ b/src/execution/physical_plan/plan_order.cpp
@@ -20,10 +20,9 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalOrder &op) {
 			projection_map.push_back(i);
 		}
 	}
-	auto &order =
-	    Make<PhysicalOrder>(op.types, std::move(op.orders), std::move(projection_map), op.estimated_cardinality);
-	order.children.push_back(plan);
-	return order;
+
+	return Make<PhysicalOrder>(plan, op.types, std::move(op.orders), std::move(projection_map),
+	                           op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_pivot.cpp
+++ b/src/execution/physical_plan/plan_pivot.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalPivot &op) {
 	D_ASSERT(op.children.size() == 1);
 	auto &plan = CreatePlan(*op.children[0]);
-	return Make<PhysicalPivot>(GetArena(), std::move(op.types), plan, std::move(op.bound_pivot));
+	return Make<PhysicalPivot>(std::move(op.types), plan, std::move(op.bound_pivot));
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_pivot.cpp
+++ b/src/execution/physical_plan/plan_pivot.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalPivot &op) {
 	D_ASSERT(op.children.size() == 1);
 	auto &plan = CreatePlan(*op.children[0]);
-	return Make<PhysicalPivot>(std::move(op.types), plan, std::move(op.bound_pivot));
+	return Make<PhysicalPivot>(GetArena(), std::move(op.types), plan, std::move(op.bound_pivot));
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_positional_join.cpp
+++ b/src/execution/physical_plan/plan_positional_join.cpp
@@ -24,7 +24,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalPositionalJoin &op) {
 	default:
 		break;
 	}
-	return Make<PhysicalPositionalJoin>(GetArena(), op.types, left, right, op.estimated_cardinality);
+	return Make<PhysicalPositionalJoin>(op.types, left, right, op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_positional_join.cpp
+++ b/src/execution/physical_plan/plan_positional_join.cpp
@@ -24,7 +24,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalPositionalJoin &op) {
 	default:
 		break;
 	}
-	return Make<PhysicalPositionalJoin>(op.types, left, right, op.estimated_cardinality);
+	return Make<PhysicalPositionalJoin>(GetArena(), op.types, left, right, op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_projection.cpp
+++ b/src/execution/physical_plan/plan_projection.cpp
@@ -36,9 +36,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalProjection &op) {
 		}
 	}
 
-	auto &proj = Make<PhysicalProjection>(op.types, std::move(op.expressions), op.estimated_cardinality);
-	proj.children.push_back(plan);
-	return proj;
+	return Make<PhysicalProjection>(plan, op.types, std::move(op.expressions), op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_recursive_cte.cpp
+++ b/src/execution/physical_plan/plan_recursive_cte.cpp
@@ -27,8 +27,8 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
 	// then we create a normal recursive CTE operator.
 	if (op.key_targets.empty()) {
 		auto &right = CreatePlan(*op.children[1]);
-		auto &cte = Make<PhysicalRecursiveCTE>(op.ctename, op.table_index, op.types, op.union_all, left, right,
-		                                       op.estimated_cardinality);
+		auto &cte = Make<PhysicalRecursiveCTE>(GetArena(), op.ctename, op.table_index, op.types, op.union_all, left,
+		                                       right, op.estimated_cardinality);
 		auto &cast_cte = cte.Cast<PhysicalRecursiveCTE>();
 		cast_cte.distinct_types = op.types;
 		cast_cte.working_table = working_table;
@@ -85,7 +85,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
 	recurring_cte_tables[op.table_index] = recurring_table;
 
 	auto &right = CreatePlan(*op.children[1]);
-	auto &cte = Make<PhysicalRecursiveCTE>(op.ctename, op.table_index, op.types, op.union_all, left, right,
+	auto &cte = Make<PhysicalRecursiveCTE>(GetArena(), op.ctename, op.table_index, op.types, op.union_all, left, right,
 	                                       op.estimated_cardinality);
 	auto &cast_cte = cte.Cast<PhysicalRecursiveCTE>();
 	cast_cte.using_key = true;

--- a/src/execution/physical_plan/plan_sample.cpp
+++ b/src/execution/physical_plan/plan_sample.cpp
@@ -17,22 +17,16 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalSample &op) {
 	}
 
 	switch (op.sample_options->method) {
-	case SampleMethod::RESERVOIR_SAMPLE: {
-		auto &sample = Make<PhysicalReservoirSample>(op.types, std::move(op.sample_options), op.estimated_cardinality);
-		sample.children.push_back(plan);
-		return sample;
-	}
+	case SampleMethod::RESERVOIR_SAMPLE:
+		return Make<PhysicalReservoirSample>(plan, op.types, std::move(op.sample_options), op.estimated_cardinality);
 	case SampleMethod::SYSTEM_SAMPLE:
-	case SampleMethod::BERNOULLI_SAMPLE: {
+	case SampleMethod::BERNOULLI_SAMPLE:
 		if (!op.sample_options->is_percentage) {
 			throw ParserException("Sample method %s cannot be used with a discrete sample count, either switch to "
 			                      "reservoir sampling or use a sample_size",
 			                      EnumUtil::ToString(op.sample_options->method));
 		}
-		auto &sample = Make<PhysicalStreamingSample>(op.types, std::move(op.sample_options), op.estimated_cardinality);
-		sample.children.push_back(plan);
-		return sample;
-	}
+		return Make<PhysicalStreamingSample>(plan, op.types, std::move(op.sample_options), op.estimated_cardinality);
 	default:
 		throw InternalException("Unimplemented sample method");
 	}

--- a/src/execution/physical_plan/plan_set.cpp
+++ b/src/execution/physical_plan/plan_set.cpp
@@ -13,9 +13,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalSet &op) {
 
 	// Set a variable.
 	auto &plan = CreatePlan(*op.children[0]);
-	auto &set_variable = Make<PhysicalSetVariable>(std::move(op.name), op.estimated_cardinality);
-	set_variable.children.push_back(plan);
-	return set_variable;
+	return Make<PhysicalSetVariable>(plan, std::move(op.name), op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_set_operation.cpp
+++ b/src/execution/physical_plan/plan_set_operation.cpp
@@ -45,7 +45,8 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalSetOperation &op) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_UNION:
 		// UNION
-		result = Make<PhysicalUnion>(op.types, left, right, op.estimated_cardinality, op.allow_out_of_order);
+		result =
+		    Make<PhysicalUnion>(GetArena(), op.types, left, right, op.estimated_cardinality, op.allow_out_of_order);
 		break;
 	case LogicalOperatorType::LOGICAL_EXCEPT:
 	case LogicalOperatorType::LOGICAL_INTERSECT: {
@@ -83,7 +84,8 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalSetOperation &op) {
 		// INTERSECT is SEMI join
 
 		JoinType join_type = op.type == LogicalOperatorType::LOGICAL_EXCEPT ? JoinType::ANTI : JoinType::SEMI;
-		result = Make<PhysicalHashJoin>(op, left, right, std::move(conditions), join_type, op.estimated_cardinality);
+		result = Make<PhysicalHashJoin>(GetArena(), op, left, right, std::move(conditions), join_type,
+		                                op.estimated_cardinality);
 
 		// For EXCEPT ALL / INTERSECT ALL we need to remove the row number column again
 		if (op.setop_all) {

--- a/src/execution/physical_plan/plan_top_n.cpp
+++ b/src/execution/physical_plan/plan_top_n.cpp
@@ -7,11 +7,8 @@ namespace duckdb {
 PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalTopN &op) {
 	D_ASSERT(op.children.size() == 1);
 	auto &plan = CreatePlan(*op.children[0]);
-	auto &top_n =
-	    Make<PhysicalTopN>(op.types, std::move(op.orders), NumericCast<idx_t>(op.limit), NumericCast<idx_t>(op.offset),
-	                       std::move(op.dynamic_filter), op.estimated_cardinality);
-	top_n.children.push_back(plan);
-	return top_n;
+	return Make<PhysicalTopN>(plan, op.types, std::move(op.orders), NumericCast<idx_t>(op.limit),
+	                          NumericCast<idx_t>(op.offset), std::move(op.dynamic_filter), op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_update.cpp
+++ b/src/execution/physical_plan/plan_update.cpp
@@ -9,11 +9,10 @@ namespace duckdb {
 PhysicalOperator &DuckCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
                                           PhysicalOperator &plan) {
 	auto &update = planner.Make<PhysicalUpdate>(
-	    op.types, op.table, op.table.GetStorage(), op.columns, std::move(op.expressions), std::move(op.bound_defaults),
-	    std::move(op.bound_constraints), op.estimated_cardinality, op.return_chunk);
+	    plan, op.types, op.table, op.table.GetStorage(), op.columns, std::move(op.expressions),
+	    std::move(op.bound_defaults), std::move(op.bound_constraints), op.estimated_cardinality, op.return_chunk);
 	auto &cast_update = update.Cast<PhysicalUpdate>();
 	cast_update.update_is_del_and_insert = op.update_is_del_and_insert;
-	cast_update.children.push_back(plan);
 	return update;
 }
 

--- a/src/execution/physical_plan/plan_vacuum.cpp
+++ b/src/execution/physical_plan/plan_vacuum.cpp
@@ -6,13 +6,12 @@
 namespace duckdb {
 
 PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalVacuum &op) {
-	auto &vacuum = Make<PhysicalVacuum>(unique_ptr_cast<ParseInfo, VacuumInfo>(std::move(op.info)), op.table,
-	                                    std::move(op.column_id_map), op.estimated_cardinality);
+	optional_ptr<PhysicalOperator> plan;
 	if (!op.children.empty()) {
-		auto &plan = CreatePlan(*op.children[0]);
-		vacuum.children.push_back(plan);
+		plan = CreatePlan(*op.children[0]);
 	}
-	return vacuum;
+	return Make<PhysicalVacuum>(plan, unique_ptr_cast<ParseInfo, VacuumInfo>(std::move(op.info)), op.table,
+	                            std::move(op.column_id_map), op.estimated_cardinality);
 }
 
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_window.cpp
+++ b/src/execution/physical_plan/plan_window.cpp
@@ -123,13 +123,9 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalWindow &op) {
 
 		// Chain the new window operator on top of the plan
 		if (i < blocking_count) {
-			auto &window = Make<PhysicalWindow>(types, std::move(select_list), op.estimated_cardinality);
-			window.children.push_back(plan);
-			plan = window;
+			plan = Make<PhysicalWindow>(plan, types, std::move(select_list), op.estimated_cardinality);
 		} else {
-			auto &window = Make<PhysicalStreamingWindow>(types, std::move(select_list), op.estimated_cardinality);
-			window.children.push_back(plan);
-			plan = window;
+			plan = Make<PhysicalStreamingWindow>(plan, types, std::move(select_list), op.estimated_cardinality);
 		}
 	}
 
@@ -144,9 +140,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalWindow &op) {
 		for (const auto &p : projection_map) {
 			select_list[p.first] = make_uniq<BoundReferenceExpression>(op.types[p.first], p.second);
 		}
-		auto &proj = Make<PhysicalProjection>(op.types, std::move(select_list), op.estimated_cardinality);
-		proj.children.push_back(plan);
-		plan = proj;
+		plan = Make<PhysicalProjection>(plan, op.types, std::move(select_list), op.estimated_cardinality);
 	}
 
 	return plan;

--- a/src/execution/physical_plan_generator.cpp
+++ b/src/execution/physical_plan_generator.cpp
@@ -60,7 +60,7 @@ unique_ptr<PhysicalPlan> PhysicalPlanGenerator::PlanInternal(LogicalOperator &op
 	if (config.options.debug_verify_vector != DebugVectorVerification::NONE) {
 		if (config.options.debug_verify_vector != DebugVectorVerification::DICTIONARY_EXPRESSION) {
 			physical_plan->SetRoot(
-			    Make<PhysicalVerifyVector>(GetArena(), physical_plan->Root(), config.options.debug_verify_vector));
+			    Make<PhysicalVerifyVector>(physical_plan->Root(), config.options.debug_verify_vector));
 		}
 	}
 	return std::move(physical_plan);

--- a/src/execution/physical_plan_generator.cpp
+++ b/src/execution/physical_plan_generator.cpp
@@ -60,7 +60,7 @@ unique_ptr<PhysicalPlan> PhysicalPlanGenerator::PlanInternal(LogicalOperator &op
 	if (config.options.debug_verify_vector != DebugVectorVerification::NONE) {
 		if (config.options.debug_verify_vector != DebugVectorVerification::DICTIONARY_EXPRESSION) {
 			physical_plan->SetRoot(
-			    Make<PhysicalVerifyVector>(physical_plan->Root(), config.options.debug_verify_vector));
+			    Make<PhysicalVerifyVector>(GetArena(), physical_plan->Root(), config.options.debug_verify_vector));
 		}
 	}
 	return std::move(physical_plan);

--- a/src/include/duckdb/common/arena_linked_list.hpp
+++ b/src/include/duckdb/common/arena_linked_list.hpp
@@ -12,7 +12,8 @@ public:
 	static_assert(std::is_trivially_destructible<T>::value, "T must be trivially destructible");
 
 public:
-	ArenaLinkedList() = default;
+	explicit ArenaLinkedList(ArenaAllocator &arena) : arena(arena) {
+	}
 
 	ArenaLinkedList(const ArenaLinkedList &) = delete;
 	ArenaLinkedList &operator=(const ArenaLinkedList &) = delete;
@@ -32,13 +33,6 @@ public:
 	}
 
 public:
-	void Init(ArenaAllocator &arena_p) {
-		if (arena) {
-			return;
-		}
-		arena = arena_p;
-	}
-
 	bool empty() const {
 		return head == nullptr;
 	}
@@ -46,40 +40,8 @@ public:
 	idx_t size() const {
 		return _size;
 	}
-
-	T &operator[](const idx_t index) {
-		idx_t i = 0;
-		for (auto &elem : *this) {
-			if (i == index) {
-				return elem;
-			}
-			i++;
-		}
-		throw InternalException("index out of bounds in ArenaLinkedList");
-	}
-
-	T operator[](const idx_t index) const {
-		idx_t i = 0;
-		for (const auto &elem : *this) {
-			if (i == index) {
-				return elem;
-			}
-			i++;
-		}
-		throw InternalException("index out of bounds in ArenaLinkedList");
-	}
-
-	void push_back(const T &value) {
+	void Append(const T &value) {
 		auto node = arena->Make<Node>(value);
-		auto ptr = head ? &tail->next : &head;
-		*ptr = node;
-		tail = node;
-		_size++;
-	}
-
-	template <class... ARGS>
-	void emplace_back(ARGS &&... args) {
-		auto node = arena->Make<Node>(std::forward<ARGS>(args)...);
 		auto ptr = head ? &tail->next : &head;
 		*ptr = node;
 		tail = node;

--- a/src/include/duckdb/common/arena_linked_list.hpp
+++ b/src/include/duckdb/common/arena_linked_list.hpp
@@ -30,19 +30,44 @@ public:
 		return *this;
 	}
 public:
-	void push_back(ArenaAllocator &arena, const T& value) {
+	bool empty() const {
+		return head == nullptr;
+	}
+
+	idx_t size() const {
+		return _size;
+	}
+
+	// TODO: do we want to expose [], or make it more explicit that this can be O(n)?
+
+	T& operator[](const idx_t index) {
+		idx_t i = 0;
+		for (auto &elem : *this) {
+			if (i == index) {
+				return elem;
+			}
+			i++;
+		}
+		throw InternalException("index out of bounds in ArenaLinkedList");
+	}
+
+	T operator[](const idx_t index) const {
+		idx_t i = 0;
+		for (const auto &elem : *this) {
+			if (i == index) {
+				return elem;
+			}
+			i++;
+		}
+		throw InternalException("index out of bounds in ArenaLinkedList");
+	}
+
+	void Append(ArenaAllocator &arena, const T& value) {
 		auto node = arena.Make<Node>(value);
 		auto ptr = head ? &tail->next : &head;
 		*ptr = node;
 		tail = node;
-	}
-
-	template<class ...ARGS>
-	void emplace_back(ArenaAllocator &arena, ARGS&&... args) {
-		auto node = arena.Make<Node>(std::forward<ARGS>(args)...);
-		auto ptr = head ? &tail->next : &head;
-		*ptr = node;
-		tail = node;
+		_size++;
 	}
 
 	struct Iterator;
@@ -62,6 +87,7 @@ private:
 
 	Node* head = nullptr;
 	Node* tail = nullptr;
+	idx_t _size = 0;
 };
 
 

--- a/src/include/duckdb/common/arena_linked_list.hpp
+++ b/src/include/duckdb/common/arena_linked_list.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include "duckdb/storage/arena_allocator.hpp"
+
+#include <type_traits>
+
+namespace duckdb {
+
+template<class T>
+class ArenaLinkedList {
+public:
+	static_assert(std::is_trivially_destructible<T>::value, "T must be trivially destructible");
+
+	ArenaLinkedList() = default;
+	ArenaLinkedList(const ArenaLinkedList &) = delete;
+	ArenaLinkedList &operator=(const ArenaLinkedList &) = delete;
+
+	ArenaLinkedList(ArenaLinkedList &&other) noexcept : head(other.head), tail(other.tail) {
+		other.head = nullptr;
+		other.tail = nullptr;
+	}
+
+	ArenaLinkedList &operator=(ArenaLinkedList &&other) noexcept {
+		if (this != &other) {
+			head = other.head;
+			tail = other.tail;
+			other.head = nullptr;
+			other.tail = nullptr;
+		}
+		return *this;
+	}
+public:
+	void push_back(ArenaAllocator &arena, const T& value) {
+		auto node = arena.Make<Node>(value);
+		auto ptr = head ? &tail->next : &head;
+		*ptr = node;
+		tail = node;
+	}
+
+	template<class ...ARGS>
+	void emplace_back(ArenaAllocator &arena, ARGS&&... args) {
+		auto node = arena.Make<Node>(std::forward<ARGS>(args)...);
+		auto ptr = head ? &tail->next : &head;
+		*ptr = node;
+		tail = node;
+	}
+
+	struct Iterator;
+	struct ConstIterator;
+
+	Iterator begin();
+	Iterator end();
+	ConstIterator begin() const;
+	ConstIterator end() const;
+
+private:
+	struct Node {
+		explicit Node(const T& value_p) : next(nullptr), value(value_p) {}
+		Node *next;
+		T value;
+	};
+
+	Node* head = nullptr;
+	Node* tail = nullptr;
+};
+
+
+template<class T>
+struct ArenaLinkedList<T>::Iterator {
+	Node* node;
+
+	explicit Iterator(Node* node_p) : node(node_p) {}
+
+	T& operator*() {
+		return node->value;
+	}
+
+	Iterator& operator++() {
+		node = node->next;
+		return *this;
+	}
+
+	bool operator!=(const Iterator& other) const {
+		return node != other.node;
+	}
+};
+
+template<class T>
+struct ArenaLinkedList<T>::ConstIterator {
+	const Node* node;
+
+	explicit ConstIterator(const Node* node_p) : node(node_p) {}
+
+	const T& operator*() const {
+		return node->value;
+	}
+
+	ConstIterator& operator++() {
+		node = node->next;
+		return *this;
+	}
+
+	bool operator!=(const ConstIterator& other) const {
+		return node != other.node;
+	}
+};
+
+template<class T>
+typename ArenaLinkedList<T>::Iterator ArenaLinkedList<T>::begin() {
+	return Iterator(head);
+}
+
+template<class T>
+typename ArenaLinkedList<T>::Iterator ArenaLinkedList<T>::end() {
+	return Iterator(nullptr);
+}
+
+template<class T>
+typename ArenaLinkedList<T>::ConstIterator ArenaLinkedList<T>::begin() const {
+	return ConstIterator(head);
+}
+
+template<class T>
+typename ArenaLinkedList<T>::ConstIterator ArenaLinkedList<T>::end() const {
+	return ConstIterator(nullptr);
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/common/arrow/physical_arrow_batch_collector.hpp
+++ b/src/include/duckdb/common/arrow/physical_arrow_batch_collector.hpp
@@ -13,8 +13,8 @@ public:
 
 class PhysicalArrowBatchCollector : public PhysicalBatchCollector {
 public:
-	PhysicalArrowBatchCollector(PreparedStatementData &data, idx_t batch_size)
-	    : PhysicalBatchCollector(data), record_batch_size(batch_size) {
+	PhysicalArrowBatchCollector(ArenaAllocator &arena, PreparedStatementData &data, idx_t batch_size)
+	    : PhysicalBatchCollector(arena, data), record_batch_size(batch_size) {
 	}
 
 public:

--- a/src/include/duckdb/common/arrow/physical_arrow_collector.hpp
+++ b/src/include/duckdb/common/arrow/physical_arrow_collector.hpp
@@ -39,13 +39,13 @@ public:
 
 class PhysicalArrowCollector : public PhysicalResultCollector {
 public:
-	PhysicalArrowCollector(PreparedStatementData &data, bool parallel, idx_t batch_size)
-	    : PhysicalResultCollector(data), record_batch_size(batch_size), parallel(parallel) {
+	PhysicalArrowCollector(ArenaAllocator &arena, PreparedStatementData &data, bool parallel, idx_t batch_size)
+	    : PhysicalResultCollector(arena, data), record_batch_size(batch_size), parallel(parallel) {
 	}
 
 public:
-	static unique_ptr<PhysicalResultCollector> Create(ClientContext &context, PreparedStatementData &data,
-	                                                  idx_t batch_size);
+	static unique_ptr<PhysicalResultCollector> Createe(ClientContext &context, PreparedStatementData &data,
+	                                                   idx_t batch_size);
 	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
 	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const override;
 	unique_ptr<QueryResult> GetResult(GlobalSinkState &state) override;

--- a/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
@@ -62,11 +62,14 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::HASH_GROUP_BY;
 
 public:
-	PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
+	PhysicalHashAggregate(ArenaAllocator &arena, ClientContext &context, optional_ptr<PhysicalOperator> child,
+	                      vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
 	                      idx_t estimated_cardinality);
-	PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
+	PhysicalHashAggregate(ArenaAllocator &arena, ClientContext &context, optional_ptr<PhysicalOperator> child,
+	                      vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
 	                      vector<unique_ptr<Expression>> groups, idx_t estimated_cardinality);
-	PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
+	PhysicalHashAggregate(ArenaAllocator &arena, ClientContext &context, optional_ptr<PhysicalOperator> child,
+	                      vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
 	                      vector<unique_ptr<Expression>> groups, vector<GroupingSet> grouping_sets,
 	                      vector<unsafe_vector<idx_t>> grouping_functions, idx_t estimated_cardinality);
 

--- a/src/include/duckdb/execution/operator/aggregate/physical_partitioned_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_partitioned_aggregate.hpp
@@ -24,9 +24,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::PARTITIONED_AGGREGATE;
 
 public:
-	PhysicalPartitionedAggregate(ClientContext &context, vector<LogicalType> types,
+	PhysicalPartitionedAggregate(ArenaAllocator &arena, ClientContext &context, vector<LogicalType> types,
 	                             vector<unique_ptr<Expression>> expressions, vector<unique_ptr<Expression>> groups,
-	                             vector<column_t> partitions, idx_t estimated_cardinality);
+	                             vector<column_t> partitions, idx_t estimated_cardinality, PhysicalOperator &child);
 
 	//! The partitions over which this is grouped
 	vector<column_t> partitions;

--- a/src/include/duckdb/execution/operator/aggregate/physical_perfecthash_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_perfecthash_aggregate.hpp
@@ -21,10 +21,10 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::PERFECT_HASH_GROUP_BY;
 
 public:
-	PhysicalPerfectHashAggregate(ClientContext &context, vector<LogicalType> types,
+	PhysicalPerfectHashAggregate(ArenaAllocator &arena, ClientContext &context, vector<LogicalType> types,
 	                             vector<unique_ptr<Expression>> aggregates, vector<unique_ptr<Expression>> groups,
 	                             const vector<unique_ptr<BaseStatistics>> &group_stats, vector<idx_t> required_bits,
-	                             idx_t estimated_cardinality);
+	                             idx_t estimated_cardinality, PhysicalOperator &child);
 
 	//! The groups
 	vector<unique_ptr<Expression>> groups;

--- a/src/include/duckdb/execution/operator/aggregate/physical_streaming_window.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_streaming_window.hpp
@@ -21,8 +21,8 @@ public:
 	static bool IsStreamingFunction(ClientContext &context, unique_ptr<Expression> &expr);
 
 public:
-	PhysicalStreamingWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
-	                        idx_t estimated_cardinality,
+	PhysicalStreamingWindow(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	                        vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality,
 	                        PhysicalOperatorType type = PhysicalOperatorType::STREAMING_WINDOW);
 
 	//! The projection list of the WINDOW statement

--- a/src/include/duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp
@@ -24,8 +24,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::UNGROUPED_AGGREGATE;
 
 public:
-	PhysicalUngroupedAggregate(vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
-	                           idx_t estimated_cardinality);
+	PhysicalUngroupedAggregate(ArenaAllocator &arena, vector<LogicalType> types,
+	                           vector<unique_ptr<Expression>> expressions, idx_t estimated_cardinality,
+	                           PhysicalOperator &child);
 
 	//! The aggregates that have to be computed
 	vector<unique_ptr<Expression>> aggregates;

--- a/src/include/duckdb/execution/operator/aggregate/physical_window.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_window.hpp
@@ -20,7 +20,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::WINDOW;
 
 public:
-	PhysicalWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality,
+	PhysicalWindow(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	               vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality,
 	               PhysicalOperatorType type = PhysicalOperatorType::WINDOW);
 
 	//! The projection list of the WINDOW statement (may contain aggregates)

--- a/src/include/duckdb/execution/operator/filter/physical_filter.hpp
+++ b/src/include/duckdb/execution/operator/filter/physical_filter.hpp
@@ -21,7 +21,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::FILTER;
 
 public:
-	PhysicalFilter(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality);
+	PhysicalFilter(ArenaAllocator &arena, optional_ptr<PhysicalOperator> child, vector<LogicalType> types,
+	               vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality);
 
 	//! The filter expression
 	unique_ptr<Expression> expression;

--- a/src/include/duckdb/execution/operator/helper/physical_batch_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_batch_collector.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 
 class PhysicalBatchCollector : public PhysicalResultCollector {
 public:
-	explicit PhysicalBatchCollector(PreparedStatementData &data);
+	PhysicalBatchCollector(ArenaAllocator &arena, PreparedStatementData &data);
 
 public:
 	unique_ptr<QueryResult> GetResult(GlobalSinkState &state) override;

--- a/src/include/duckdb/execution/operator/helper/physical_buffered_batch_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_buffered_batch_collector.hpp
@@ -23,7 +23,7 @@ public:
 
 class PhysicalBufferedBatchCollector : public PhysicalResultCollector {
 public:
-	explicit PhysicalBufferedBatchCollector(PreparedStatementData &data);
+	PhysicalBufferedBatchCollector(ArenaAllocator &arena, PreparedStatementData &data);
 
 public:
 	unique_ptr<QueryResult> GetResult(GlobalSinkState &state) override;

--- a/src/include/duckdb/execution/operator/helper/physical_buffered_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_buffered_collector.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 
 class PhysicalBufferedCollector : public PhysicalResultCollector {
 public:
-	PhysicalBufferedCollector(PreparedStatementData &data, bool parallel);
+	PhysicalBufferedCollector(ArenaAllocator &arena, PreparedStatementData &data, bool parallel);
 
 	bool parallel;
 

--- a/src/include/duckdb/execution/operator/helper/physical_create_secret.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_create_secret.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::CREATE_SECRET;
 
 public:
-	PhysicalCreateSecret(CreateSecretInput input_p, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_SECRET, {LogicalType::BOOLEAN}, estimated_cardinality),
+	PhysicalCreateSecret(ArenaAllocator &arena, CreateSecretInput input_p, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::CREATE_SECRET, {LogicalType::BOOLEAN}, estimated_cardinality),
 	      create_input(std::move(input_p)) {
 	}
 

--- a/src/include/duckdb/execution/operator/helper/physical_execute.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_execute.hpp
@@ -18,7 +18,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXECUTE;
 
 public:
-	explicit PhysicalExecute(PhysicalOperator &plan);
+	PhysicalExecute(ArenaAllocator &arena, PhysicalOperator &plan);
 
 	PhysicalOperator &plan;
 	shared_ptr<PreparedStatementData> prepared;

--- a/src/include/duckdb/execution/operator/helper/physical_explain_analyze.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_explain_analyze.hpp
@@ -19,8 +19,11 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXPLAIN_ANALYZE;
 
 public:
-	explicit PhysicalExplainAnalyze(vector<LogicalType> types, ExplainFormat format)
-	    : PhysicalOperator(PhysicalOperatorType::EXPLAIN_ANALYZE, std::move(types), 1), format(format) {
+	explicit PhysicalExplainAnalyze(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	                                ExplainFormat format)
+	    : PhysicalOperator(arena, PhysicalOperatorType::EXPLAIN_ANALYZE, std::move(types), 1), format(format) {
+
+		children.Append(child);
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/helper/physical_limit.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_limit.hpp
@@ -22,8 +22,8 @@ public:
 	static constexpr const idx_t MAX_LIMIT_VALUE = 1ULL << 62ULL;
 
 public:
-	PhysicalLimit(vector<LogicalType> types, BoundLimitNode limit_val, BoundLimitNode offset_val,
-	              idx_t estimated_cardinality);
+	PhysicalLimit(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types, BoundLimitNode limit_val,
+	              BoundLimitNode offset_val, idx_t estimated_cardinality);
 
 	BoundLimitNode limit_val;
 	BoundLimitNode offset_val;

--- a/src/include/duckdb/execution/operator/helper/physical_limit_percent.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_limit_percent.hpp
@@ -20,8 +20,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::LIMIT_PERCENT;
 
 public:
-	PhysicalLimitPercent(vector<LogicalType> types, BoundLimitNode limit_val_p, BoundLimitNode offset_val_p,
-	                     idx_t estimated_cardinality);
+	PhysicalLimitPercent(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	                     BoundLimitNode limit_val_p, BoundLimitNode offset_val_p, idx_t estimated_cardinality);
 
 	BoundLimitNode limit_val;
 	BoundLimitNode offset_val;

--- a/src/include/duckdb/execution/operator/helper/physical_load.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_load.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::LOAD;
 
 public:
-	explicit PhysicalLoad(unique_ptr<LoadInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::LOAD, {LogicalType::BOOLEAN}, estimated_cardinality),
+	explicit PhysicalLoad(ArenaAllocator &arena, unique_ptr<LoadInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::LOAD, {LogicalType::BOOLEAN}, estimated_cardinality),
 	      info(std::move(info)) {
 	}
 

--- a/src/include/duckdb/execution/operator/helper/physical_materialized_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_materialized_collector.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 
 class PhysicalMaterializedCollector : public PhysicalResultCollector {
 public:
-	PhysicalMaterializedCollector(PreparedStatementData &data, bool parallel);
+	PhysicalMaterializedCollector(ArenaAllocator &arena, PreparedStatementData &data, bool parallel);
 
 	bool parallel;
 

--- a/src/include/duckdb/execution/operator/helper/physical_pragma.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_pragma.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::PRAGMA;
 
 public:
-	PhysicalPragma(unique_ptr<BoundPragmaInfo> info_p, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::PRAGMA, {LogicalType::BOOLEAN}, estimated_cardinality),
+	PhysicalPragma(ArenaAllocator &arena, unique_ptr<BoundPragmaInfo> info_p, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::PRAGMA, {LogicalType::BOOLEAN}, estimated_cardinality),
 	      info(std::move(info_p)) {
 	}
 

--- a/src/include/duckdb/execution/operator/helper/physical_prepare.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_prepare.hpp
@@ -19,8 +19,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::PREPARE;
 
 public:
-	PhysicalPrepare(string name_p, shared_ptr<PreparedStatementData> prepared, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::PREPARE, {LogicalType::BOOLEAN}, estimated_cardinality),
+	PhysicalPrepare(ArenaAllocator &arena, string name_p, shared_ptr<PreparedStatementData> prepared,
+	                idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::PREPARE, {LogicalType::BOOLEAN}, estimated_cardinality),
 	      name(std::move(name_p)), prepared(std::move(prepared)) {
 	}
 

--- a/src/include/duckdb/execution/operator/helper/physical_reservoir_sample.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_reservoir_sample.hpp
@@ -18,9 +18,11 @@ namespace duckdb {
 
 class PhysicalReservoirSample : public PhysicalOperator {
 public:
-	PhysicalReservoirSample(vector<LogicalType> types, unique_ptr<SampleOptions> options, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::RESERVOIR_SAMPLE, std::move(types), estimated_cardinality),
+	PhysicalReservoirSample(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	                        unique_ptr<SampleOptions> options, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::RESERVOIR_SAMPLE, std::move(types), estimated_cardinality),
 	      options(std::move(options)) {
+		children.Append(child);
 	}
 
 	unique_ptr<SampleOptions> options;

--- a/src/include/duckdb/execution/operator/helper/physical_reset.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_reset.hpp
@@ -23,9 +23,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::RESET;
 
 public:
-	PhysicalReset(const std::string &name_p, SetScope scope_p, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::RESET, {LogicalType::BOOLEAN}, estimated_cardinality), name(name_p),
-	      scope(scope_p) {
+	PhysicalReset(ArenaAllocator &arena, const std::string &name_p, SetScope scope_p, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::RESET, {LogicalType::BOOLEAN}, estimated_cardinality),
+	      name(name_p), scope(scope_p) {
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/helper/physical_result_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_result_collector.hpp
@@ -21,7 +21,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::RESULT_COLLECTOR;
 
 public:
-	explicit PhysicalResultCollector(PreparedStatementData &data);
+	PhysicalResultCollector(ArenaAllocator &arena, PreparedStatementData &data);
 
 	StatementType statement_type;
 	StatementProperties properties;
@@ -29,7 +29,7 @@ public:
 	vector<string> names;
 
 public:
-	static unique_ptr<PhysicalResultCollector> GetResultCollector(ClientContext &context, PreparedStatementData &data);
+	static unique_ptr<PhysicalResultCollector> GetResultCollectorr(ClientContext &context, PreparedStatementData &data);
 
 public:
 	//! The final method used to fetch the query result from this operator

--- a/src/include/duckdb/execution/operator/helper/physical_set.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_set.hpp
@@ -23,9 +23,10 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::SET;
 
 public:
-	PhysicalSet(const string &name_p, Value value_p, SetScope scope_p, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::SET, {LogicalType::BOOLEAN}, estimated_cardinality), name(name_p),
-	      value(std::move(value_p)), scope(scope_p) {
+	PhysicalSet(ArenaAllocator &arena, const string &name_p, Value value_p, SetScope scope_p,
+	            idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::SET, {LogicalType::BOOLEAN}, estimated_cardinality),
+	      name(name_p), value(std::move(value_p)), scope(scope_p) {
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/helper/physical_set_variable.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_set_variable.hpp
@@ -18,7 +18,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::SET_VARIABLE;
 
 public:
-	PhysicalSetVariable(string name, idx_t estimated_cardinality);
+	PhysicalSetVariable(ArenaAllocator &arena, PhysicalOperator &child, string name, idx_t estimated_cardinality);
 
 public:
 	// Source interface

--- a/src/include/duckdb/execution/operator/helper/physical_streaming_limit.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_streaming_limit.hpp
@@ -19,8 +19,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::STREAMING_LIMIT;
 
 public:
-	PhysicalStreamingLimit(vector<LogicalType> types, BoundLimitNode limit_val_p, BoundLimitNode offset_val_p,
-	                       idx_t estimated_cardinality, bool parallel);
+	PhysicalStreamingLimit(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	                       BoundLimitNode limit_val_p, BoundLimitNode offset_val_p, idx_t estimated_cardinality,
+	                       bool parallel);
 
 	BoundLimitNode limit_val;
 	BoundLimitNode offset_val;

--- a/src/include/duckdb/execution/operator/helper/physical_streaming_sample.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_streaming_sample.hpp
@@ -19,7 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::STREAMING_SAMPLE;
 
 public:
-	PhysicalStreamingSample(vector<LogicalType> types, unique_ptr<SampleOptions> options, idx_t estimated_cardinality);
+	PhysicalStreamingSample(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	                        unique_ptr<SampleOptions> options, idx_t estimated_cardinality);
 
 	unique_ptr<SampleOptions> sample_options;
 	double percentage;

--- a/src/include/duckdb/execution/operator/helper/physical_transaction.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_transaction.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::TRANSACTION;
 
 public:
-	explicit PhysicalTransaction(unique_ptr<TransactionInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::TRANSACTION, {LogicalType::BOOLEAN}, estimated_cardinality),
+	explicit PhysicalTransaction(ArenaAllocator &arena, unique_ptr<TransactionInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::TRANSACTION, {LogicalType::BOOLEAN}, estimated_cardinality),
 	      info(std::move(info)) {
 	}
 

--- a/src/include/duckdb/execution/operator/helper/physical_update_extensions.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_update_extensions.hpp
@@ -28,8 +28,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::UPDATE_EXTENSIONS;
 
 public:
-	explicit PhysicalUpdateExtensions(unique_ptr<UpdateExtensionsInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::UPDATE_EXTENSIONS,
+	explicit PhysicalUpdateExtensions(ArenaAllocator &arena, unique_ptr<UpdateExtensionsInfo> info,
+	                                  idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::UPDATE_EXTENSIONS,
 	                       {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 	                        LogicalType::VARCHAR},
 	                       estimated_cardinality),

--- a/src/include/duckdb/execution/operator/helper/physical_vacuum.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_vacuum.hpp
@@ -20,8 +20,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::VACUUM;
 
 public:
-	PhysicalVacuum(unique_ptr<VacuumInfo> info, optional_ptr<TableCatalogEntry> table,
-	               unordered_map<idx_t, idx_t> column_id_map, idx_t estimated_cardinality);
+	PhysicalVacuum(ArenaAllocator &arena, optional_ptr<PhysicalOperator> child, unique_ptr<VacuumInfo> info,
+	               optional_ptr<TableCatalogEntry> table, unordered_map<idx_t, idx_t> column_id_map,
+	               idx_t estimated_cardinality);
 
 	unique_ptr<VacuumInfo> info;
 	optional_ptr<TableCatalogEntry> table;

--- a/src/include/duckdb/execution/operator/helper/physical_verify_vector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_verify_vector.hpp
@@ -37,7 +37,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::VERIFY_VECTOR;
 
 public:
-	explicit PhysicalVerifyVector(PhysicalOperator &child, DebugVectorVerification verification);
+	explicit PhysicalVerifyVector(ArenaAllocator &arena, PhysicalOperator &child, DebugVectorVerification verification);
 
 	DebugVectorVerification verification;
 

--- a/src/include/duckdb/execution/operator/helper/physical_verify_vector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_verify_vector.hpp
@@ -37,7 +37,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::VERIFY_VECTOR;
 
 public:
-	explicit PhysicalVerifyVector(PhysicalOperator &child, DebugVectorVerification verification);
+	PhysicalVerifyVector(ArenaAllocator &arena, PhysicalOperator &child, DebugVectorVerification verification);
 
 	DebugVectorVerification verification;
 

--- a/src/include/duckdb/execution/operator/helper/physical_verify_vector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_verify_vector.hpp
@@ -37,7 +37,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::VERIFY_VECTOR;
 
 public:
-	explicit PhysicalVerifyVector(ArenaAllocator &arena, PhysicalOperator &child, DebugVectorVerification verification);
+	explicit PhysicalVerifyVector(PhysicalOperator &child, DebugVectorVerification verification);
 
 	DebugVectorVerification verification;
 

--- a/src/include/duckdb/execution/operator/join/physical_asof_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_asof_join.hpp
@@ -19,7 +19,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::ASOF_JOIN;
 
 public:
-	PhysicalAsOfJoin(LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right);
+	PhysicalAsOfJoin(ArenaAllocator &arena, LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right);
 
 	vector<LogicalType> join_key_types;
 	vector<column_t> null_sensitive;

--- a/src/include/duckdb/execution/operator/join/physical_blockwise_nl_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_blockwise_nl_join.hpp
@@ -20,7 +20,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::BLOCKWISE_NL_JOIN;
 
 public:
-	PhysicalBlockwiseNLJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
+	PhysicalBlockwiseNLJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
 	                        unique_ptr<Expression> condition, JoinType join_type, idx_t estimated_cardinality);
 
 	unique_ptr<Expression> condition;

--- a/src/include/duckdb/execution/operator/join/physical_comparison_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_comparison_join.hpp
@@ -20,8 +20,8 @@ class LogicalGet;
 //! PhysicalJoin represents the base class of the join operators
 class PhysicalComparisonJoin : public PhysicalJoin {
 public:
-	PhysicalComparisonJoin(LogicalOperator &op, PhysicalOperatorType type, vector<JoinCondition> cond,
-	                       JoinType join_type, idx_t estimated_cardinality);
+	PhysicalComparisonJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperatorType type,
+	                       vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality);
 
 	vector<JoinCondition> conditions;
 	//! Scans where we should push generated filters into (if any)

--- a/src/include/duckdb/execution/operator/join/physical_cross_product.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_cross_product.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::CROSS_PRODUCT;
 
 public:
-	PhysicalCrossProduct(vector<LogicalType> types, PhysicalOperator &left, PhysicalOperator &right,
-	                     idx_t estimated_cardinality);
+	PhysicalCrossProduct(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &left,
+	                     PhysicalOperator &right, idx_t estimated_cardinality);
 
 public:
 	// Operator Interface

--- a/src/include/duckdb/execution/operator/join/physical_delim_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_delim_join.hpp
@@ -18,9 +18,10 @@ class PhysicalHashAggregate;
 //! PhysicalColumnDataScan in the other side. Implementations are PhysicalLeftDelimJoin and PhysicalRightDelimJoin
 class PhysicalDelimJoin : public PhysicalOperator {
 public:
-	PhysicalDelimJoin(PhysicalOperatorType type, vector<LogicalType> types, PhysicalOperator &original_join,
-	                  PhysicalOperator &distinct, const vector<const_reference<PhysicalOperator>> &delim_scans,
-	                  idx_t estimated_cardinality, optional_idx delim_idx);
+	PhysicalDelimJoin(ArenaAllocator &arena, PhysicalOperatorType type, vector<LogicalType> types,
+	                  PhysicalOperator &original_join, PhysicalOperator &distinct,
+	                  const vector<const_reference<PhysicalOperator>> &delim_scans, idx_t estimated_cardinality,
+	                  optional_idx delim_idx);
 
 	PhysicalOperator &join;
 	PhysicalHashAggregate &distinct;

--- a/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -28,12 +28,12 @@ public:
 	};
 
 public:
-	PhysicalHashJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right, vector<JoinCondition> cond,
-	                 JoinType join_type, const vector<idx_t> &left_projection_map,
+	PhysicalHashJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
+	                 vector<JoinCondition> cond, JoinType join_type, const vector<idx_t> &left_projection_map,
 	                 const vector<idx_t> &right_projection_map, vector<LogicalType> delim_types,
 	                 idx_t estimated_cardinality, unique_ptr<JoinFilterPushdownInfo> pushdown_info);
-	PhysicalHashJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right, vector<JoinCondition> cond,
-	                 JoinType join_type, idx_t estimated_cardinality);
+	PhysicalHashJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
+	                 vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality);
 
 	//! Initialize HT for this operator
 	unique_ptr<JoinHashTable> InitializeHashTable(ClientContext &context) const;

--- a/src/include/duckdb/execution/operator/join/physical_iejoin.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_iejoin.hpp
@@ -20,10 +20,10 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::IE_JOIN;
 
 public:
-	PhysicalIEJoin(LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right,
+	PhysicalIEJoin(ArenaAllocator &arena, LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right,
 	               vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality,
 	               unique_ptr<JoinFilterPushdownInfo> pushdown_info);
-	PhysicalIEJoin(LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right,
+	PhysicalIEJoin(ArenaAllocator &arena, LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right,
 	               vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality);
 
 	vector<LogicalType> join_key_types;

--- a/src/include/duckdb/execution/operator/join/physical_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_join.hpp
@@ -19,7 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::INVALID;
 
 public:
-	PhysicalJoin(LogicalOperator &op, PhysicalOperatorType type, JoinType join_type, idx_t estimated_cardinality);
+	PhysicalJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperatorType type, JoinType join_type,
+	             idx_t estimated_cardinality);
 
 	JoinType join_type;
 

--- a/src/include/duckdb/execution/operator/join/physical_left_delim_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_left_delim_join.hpp
@@ -19,9 +19,10 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::LEFT_DELIM_JOIN;
 
 public:
-	PhysicalLeftDelimJoin(PhysicalPlanGenerator &planner, vector<LogicalType> types, PhysicalOperator &original_join,
-	                      PhysicalOperator &distinct, const vector<const_reference<PhysicalOperator>> &delim_scans,
-	                      idx_t estimated_cardinality, optional_idx delim_idx);
+	PhysicalLeftDelimJoin(ArenaAllocator &arena, PhysicalPlanGenerator &planner, vector<LogicalType> types,
+	                      PhysicalOperator &original_join, PhysicalOperator &distinct,
+	                      const vector<const_reference<PhysicalOperator>> &delim_scans, idx_t estimated_cardinality,
+	                      optional_idx delim_idx);
 
 public:
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;

--- a/src/include/duckdb/execution/operator/join/physical_nested_loop_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_nested_loop_join.hpp
@@ -18,10 +18,10 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::NESTED_LOOP_JOIN;
 
 public:
-	PhysicalNestedLoopJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
+	PhysicalNestedLoopJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
 	                       vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality,
 	                       unique_ptr<JoinFilterPushdownInfo> pushdown_info);
-	PhysicalNestedLoopJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
+	PhysicalNestedLoopJoin(ArenaAllocator &arena, LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
 	                       vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality);
 
 public:

--- a/src/include/duckdb/execution/operator/join/physical_piecewise_merge_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_piecewise_merge_join.hpp
@@ -22,9 +22,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::PIECEWISE_MERGE_JOIN;
 
 public:
-	PhysicalPiecewiseMergeJoin(LogicalComparisonJoin &op, PhysicalOperator &left, PhysicalOperator &right,
-	                           vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality,
-	                           unique_ptr<JoinFilterPushdownInfo> pushdown_info);
+	PhysicalPiecewiseMergeJoin(ArenaAllocator &arena, LogicalComparisonJoin &op, PhysicalOperator &left,
+	                           PhysicalOperator &right, vector<JoinCondition> cond, JoinType join_type,
+	                           idx_t estimated_cardinality, unique_ptr<JoinFilterPushdownInfo> pushdown_info);
 
 	vector<LogicalType> join_key_types;
 	vector<BoundOrderByNode> lhs_orders;

--- a/src/include/duckdb/execution/operator/join/physical_positional_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_positional_join.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::POSITIONAL_JOIN;
 
 public:
-	PhysicalPositionalJoin(vector<LogicalType> types, PhysicalOperator &left, PhysicalOperator &right,
-	                       idx_t estimated_cardinality);
+	PhysicalPositionalJoin(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &left,
+	                       PhysicalOperator &right, idx_t estimated_cardinality);
 
 public:
 	// Operator Interface

--- a/src/include/duckdb/execution/operator/join/physical_range_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_range_join.hpp
@@ -92,8 +92,8 @@ public:
 	};
 
 public:
-	PhysicalRangeJoin(LogicalComparisonJoin &op, PhysicalOperatorType type, PhysicalOperator &left,
-	                  PhysicalOperator &right, vector<JoinCondition> cond, JoinType join_type,
+	PhysicalRangeJoin(ArenaAllocator &arena, LogicalComparisonJoin &op, PhysicalOperatorType type,
+	                  PhysicalOperator &left, PhysicalOperator &right, vector<JoinCondition> cond, JoinType join_type,
 	                  idx_t estimated_cardinality);
 
 	// Projection mappings

--- a/src/include/duckdb/execution/operator/join/physical_right_delim_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_right_delim_join.hpp
@@ -19,9 +19,10 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::RIGHT_DELIM_JOIN;
 
 public:
-	PhysicalRightDelimJoin(PhysicalPlanGenerator &planner, vector<LogicalType> types, PhysicalOperator &original_join,
-	                       PhysicalOperator &distinct, const vector<const_reference<PhysicalOperator>> &delim_scans,
-	                       idx_t estimated_cardinality, optional_idx delim_idx);
+	PhysicalRightDelimJoin(ArenaAllocator &arena, PhysicalPlanGenerator &planner, vector<LogicalType> types,
+	                       PhysicalOperator &original_join, PhysicalOperator &distinct,
+	                       const vector<const_reference<PhysicalOperator>> &delim_scans, idx_t estimated_cardinality,
+	                       optional_idx delim_idx);
 
 public:
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;

--- a/src/include/duckdb/execution/operator/order/physical_order.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_order.hpp
@@ -22,8 +22,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::ORDER_BY;
 
 public:
-	PhysicalOrder(vector<LogicalType> types, vector<BoundOrderByNode> orders, vector<idx_t> projections,
-	              idx_t estimated_cardinality);
+	PhysicalOrder(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	              vector<BoundOrderByNode> orders, vector<idx_t> projections, idx_t estimated_cardinality);
 
 	//! Input data
 	vector<BoundOrderByNode> orders;

--- a/src/include/duckdb/execution/operator/order/physical_top_n.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_top_n.hpp
@@ -21,7 +21,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::TOP_N;
 
 public:
-	PhysicalTopN(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t limit, idx_t offset,
+	PhysicalTopN(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	             vector<BoundOrderByNode> orders, idx_t limit, idx_t offset,
 	             shared_ptr<DynamicFilterData> dynamic_filter, idx_t estimated_cardinality);
 	~PhysicalTopN() override;
 

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
@@ -22,8 +22,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::BATCH_COPY_TO_FILE;
 
 public:
-	PhysicalBatchCopyToFile(vector<LogicalType> types, CopyFunction function, unique_ptr<FunctionData> bind_data,
-	                        idx_t estimated_cardinality);
+	PhysicalBatchCopyToFile(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	                        CopyFunction function, unique_ptr<FunctionData> bind_data, idx_t estimated_cardinality);
 
 	CopyFunction function;
 	unique_ptr<FunctionData> bind_data;

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
@@ -18,11 +18,12 @@ public:
 
 public:
 	//! INSERT INTO
-	PhysicalBatchInsert(vector<LogicalType> types, TableCatalogEntry &table,
-	                    vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t estimated_cardinality);
-	//! CREATE TABLE AS
-	PhysicalBatchInsert(LogicalOperator &op, SchemaCatalogEntry &schema, unique_ptr<BoundCreateTableInfo> info,
+	PhysicalBatchInsert(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	                    TableCatalogEntry &table, vector<unique_ptr<BoundConstraint>> bound_constraints,
 	                    idx_t estimated_cardinality);
+	//! CREATE TABLE AS
+	PhysicalBatchInsert(ArenaAllocator &arena, PhysicalOperator &child, LogicalOperator &op, SchemaCatalogEntry &schema,
+	                    unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality);
 
 	//! The table to insert into
 	optional_ptr<TableCatalogEntry> insert_table;

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_database.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_database.hpp
@@ -18,7 +18,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::COPY_DATABASE;
 
 public:
-	PhysicalCopyDatabase(vector<LogicalType> types, idx_t estimated_cardinality, unique_ptr<CopyDatabaseInfo> info_p);
+	PhysicalCopyDatabase(ArenaAllocator &arena, vector<LogicalType> types, idx_t estimated_cardinality,
+	                     unique_ptr<CopyDatabaseInfo> info_p);
 	~PhysicalCopyDatabase() override;
 
 	unique_ptr<CopyDatabaseInfo> info;

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -33,8 +33,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::COPY_TO_FILE;
 
 public:
-	PhysicalCopyToFile(vector<LogicalType> types, CopyFunction function, unique_ptr<FunctionData> bind_data,
-	                   idx_t estimated_cardinality);
+	PhysicalCopyToFile(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types, CopyFunction function,
+	                   unique_ptr<FunctionData> bind_data, idx_t estimated_cardinality);
 
 	CopyFunction function;
 	unique_ptr<FunctionData> bind_data;

--- a/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
@@ -20,9 +20,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::DELETE_OPERATOR;
 
 public:
-	PhysicalDelete(vector<LogicalType> types, TableCatalogEntry &tableref, DataTable &table,
-	               vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t row_id_index,
-	               idx_t estimated_cardinality, bool return_chunk);
+	PhysicalDelete(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	               TableCatalogEntry &tableref, DataTable &table, vector<unique_ptr<BoundConstraint>> bound_constraints,
+	               idx_t row_id_index, idx_t estimated_cardinality, bool return_chunk);
 
 	TableCatalogEntry &tableref;
 	DataTable &table;

--- a/src/include/duckdb/execution/operator/persistent/physical_export.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_export.hpp
@@ -34,8 +34,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXPORT;
 
 public:
-	PhysicalExport(vector<LogicalType> types, CopyFunction function, unique_ptr<CopyInfo> info,
-	               idx_t estimated_cardinality, unique_ptr<BoundExportData> exported_tables);
+	PhysicalExport(ArenaAllocator &arena, optional_ptr<PhysicalOperator> child, vector<LogicalType> types,
+	               CopyFunction function, unique_ptr<CopyInfo> info, idx_t estimated_cardinality,
+	               unique_ptr<BoundExportData> exported_tables);
 
 	//! The copy function to use to read the file
 	CopyFunction function;

--- a/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_insert.hpp
@@ -69,7 +69,7 @@ public:
 
 public:
 	//! INSERT INTO
-	PhysicalInsert(vector<LogicalType> types, TableCatalogEntry &table,
+	PhysicalInsert(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types, TableCatalogEntry &table,
 	               vector<unique_ptr<BoundConstraint>> bound_constraints,
 	               vector<unique_ptr<Expression>> set_expressions, vector<PhysicalIndex> set_columns,
 	               vector<LogicalType> set_types, idx_t estimated_cardinality, bool return_chunk, bool parallel,
@@ -77,8 +77,8 @@ public:
 	               unique_ptr<Expression> do_update_condition, unordered_set<column_t> on_conflict_filter,
 	               vector<column_t> columns_to_fetch, bool update_is_del_and_insert);
 	//! CREATE TABLE AS
-	PhysicalInsert(LogicalOperator &op, SchemaCatalogEntry &schema, unique_ptr<BoundCreateTableInfo> info,
-	               idx_t estimated_cardinality, bool parallel);
+	PhysicalInsert(ArenaAllocator &arena, PhysicalOperator &child, LogicalOperator &op, SchemaCatalogEntry &schema,
+	               unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality, bool parallel);
 
 	//! The table to insert into
 	optional_ptr<TableCatalogEntry> insert_table;

--- a/src/include/duckdb/execution/operator/persistent/physical_update.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_update.hpp
@@ -21,10 +21,11 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::UPDATE;
 
 public:
-	PhysicalUpdate(vector<LogicalType> types, TableCatalogEntry &tableref, DataTable &table,
-	               vector<PhysicalIndex> columns, vector<unique_ptr<Expression>> expressions,
-	               vector<unique_ptr<Expression>> bound_defaults, vector<unique_ptr<BoundConstraint>> bound_constraints,
-	               idx_t estimated_cardinality, bool return_chunk);
+	PhysicalUpdate(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	               TableCatalogEntry &tableref, DataTable &table, vector<PhysicalIndex> columns,
+	               vector<unique_ptr<Expression>> expressions, vector<unique_ptr<Expression>> bound_defaults,
+	               vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t estimated_cardinality,
+	               bool return_chunk);
 
 	TableCatalogEntry &tableref;
 	DataTable &table;

--- a/src/include/duckdb/execution/operator/projection/physical_pivot.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_pivot.hpp
@@ -18,7 +18,8 @@ namespace duckdb {
 //! PhysicalPivot implements the physical PIVOT operation
 class PhysicalPivot : public PhysicalOperator {
 public:
-	PhysicalPivot(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &child, BoundPivotInfo bound_pivot);
+	PhysicalPivot(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &child,
+	              BoundPivotInfo bound_pivot);
 
 	BoundPivotInfo bound_pivot;
 	//! The map for pivot value -> column index

--- a/src/include/duckdb/execution/operator/projection/physical_pivot.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_pivot.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 //! PhysicalPivot implements the physical PIVOT operation
 class PhysicalPivot : public PhysicalOperator {
 public:
-	PhysicalPivot(vector<LogicalType> types, PhysicalOperator &child, BoundPivotInfo bound_pivot);
+	PhysicalPivot(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &child, BoundPivotInfo bound_pivot);
 
 	BoundPivotInfo bound_pivot;
 	//! The map for pivot value -> column index

--- a/src/include/duckdb/execution/operator/projection/physical_projection.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_projection.hpp
@@ -33,11 +33,6 @@ public:
 	}
 
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
-
-	static unique_ptr<PhysicalOperator>
-	CreateJoinProjection(vector<LogicalType> proj_types, const vector<LogicalType> &lhs_types,
-	                     const vector<LogicalType> &rhs_types, const vector<idx_t> &left_projection_map,
-	                     const vector<idx_t> &right_projection_map, const idx_t estimated_cardinality);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/projection/physical_projection.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_projection.hpp
@@ -18,8 +18,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::PROJECTION;
 
 public:
-	PhysicalProjection(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
-	                   idx_t estimated_cardinality);
+	PhysicalProjection(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	                   vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality);
 
 	vector<unique_ptr<Expression>> select_list;
 

--- a/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
@@ -19,9 +19,10 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::INOUT_FUNCTION;
 
 public:
-	PhysicalTableInOutFunction(vector<LogicalType> types, TableFunction function_p,
-	                           unique_ptr<FunctionData> bind_data_p, vector<ColumnIndex> column_ids_p,
-	                           idx_t estimated_cardinality, vector<column_t> projected_input);
+	PhysicalTableInOutFunction(ArenaAllocator &arena, PhysicalOperator &child, vector<LogicalType> types,
+	                           TableFunction function_p, unique_ptr<FunctionData> bind_data_p,
+	                           vector<ColumnIndex> column_ids_p, idx_t estimated_cardinality,
+	                           vector<column_t> projected_input);
 
 public:
 	unique_ptr<OperatorState> GetOperatorState(ExecutionContext &context) const override;

--- a/src/include/duckdb/execution/operator/projection/physical_unnest.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_unnest.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::UNNEST;
 
 public:
-	PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality,
-	               PhysicalOperatorType type = PhysicalOperatorType::UNNEST);
+	PhysicalUnnest(ArenaAllocator &arena, vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+	               idx_t estimated_cardinality, PhysicalOperatorType type = PhysicalOperatorType::UNNEST);
 
 	//! The projection list of the UNNEST
 	//! E.g. SELECT 1, UNNEST([1]), UNNEST([2, 3]); has two UNNESTs in its select_list

--- a/src/include/duckdb/execution/operator/scan/physical_column_data_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_column_data_scan.hpp
@@ -20,11 +20,11 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::INVALID;
 
 public:
-	PhysicalColumnDataScan(vector<LogicalType> types, PhysicalOperatorType op_type, idx_t estimated_cardinality,
-	                       optionally_owned_ptr<ColumnDataCollection> collection);
+	PhysicalColumnDataScan(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperatorType op_type,
+	                       idx_t estimated_cardinality, optionally_owned_ptr<ColumnDataCollection> collection);
 
-	PhysicalColumnDataScan(vector<LogicalType> types, PhysicalOperatorType op_type, idx_t estimated_cardinality,
-	                       idx_t cte_index);
+	PhysicalColumnDataScan(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperatorType op_type,
+	                       idx_t estimated_cardinality, idx_t cte_index);
 
 	//! (optionally owned) column data collection to scan
 	optionally_owned_ptr<ColumnDataCollection> collection;

--- a/src/include/duckdb/execution/operator/scan/physical_dummy_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_dummy_scan.hpp
@@ -17,8 +17,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::DUMMY_SCAN;
 
 public:
-	explicit PhysicalDummyScan(vector<LogicalType> types, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::DUMMY_SCAN, std::move(types), estimated_cardinality) {
+	explicit PhysicalDummyScan(ArenaAllocator &arena, vector<LogicalType> types, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::DUMMY_SCAN, std::move(types), estimated_cardinality) {
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/scan/physical_empty_result.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_empty_result.hpp
@@ -17,8 +17,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EMPTY_RESULT;
 
 public:
-	explicit PhysicalEmptyResult(vector<LogicalType> types, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::EMPTY_RESULT, std::move(types), estimated_cardinality) {
+	explicit PhysicalEmptyResult(ArenaAllocator &arena, vector<LogicalType> types, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::EMPTY_RESULT, std::move(types), estimated_cardinality) {
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/scan/physical_expression_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_expression_scan.hpp
@@ -19,9 +19,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXPRESSION_SCAN;
 
 public:
-	PhysicalExpressionScan(vector<LogicalType> types, vector<vector<unique_ptr<Expression>>> expressions,
-	                       idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::EXPRESSION_SCAN, std::move(types), estimated_cardinality),
+	PhysicalExpressionScan(ArenaAllocator &arena, vector<LogicalType> types,
+	                       vector<vector<unique_ptr<Expression>>> expressions, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::EXPRESSION_SCAN, std::move(types), estimated_cardinality),
 	      expressions(std::move(expressions)) {
 	}
 

--- a/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
@@ -22,7 +22,8 @@ public:
 
 public:
 	//! Regular Table Scan
-	PhysicalPositionalScan(vector<LogicalType> types, PhysicalOperator &left, PhysicalOperator &right);
+	PhysicalPositionalScan(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &left,
+	                       PhysicalOperator &right);
 
 	//! The child table functions
 	vector<reference<PhysicalOperator>> child_tables;

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -24,9 +24,10 @@ public:
 
 public:
 	//! Table scan that immediately projects out filter columns that are unused in the remainder of the query plan
-	PhysicalTableScan(vector<LogicalType> types, TableFunction function, unique_ptr<FunctionData> bind_data,
-	                  vector<LogicalType> returned_types, vector<ColumnIndex> column_ids, vector<idx_t> projection_ids,
-	                  vector<string> names, unique_ptr<TableFilterSet> table_filters, idx_t estimated_cardinality,
+	PhysicalTableScan(ArenaAllocator &arena, vector<LogicalType> types, TableFunction function,
+	                  unique_ptr<FunctionData> bind_data, vector<LogicalType> returned_types,
+	                  vector<ColumnIndex> column_ids, vector<idx_t> projection_ids, vector<string> names,
+	                  unique_ptr<TableFilterSet> table_filters, idx_t estimated_cardinality,
 	                  ExtraOperatorInfo extra_info, vector<Value> parameters, virtual_column_map_t virtual_columns);
 
 	//! The table function

--- a/src/include/duckdb/execution/operator/schema/physical_alter.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_alter.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::ALTER;
 
 public:
-	explicit PhysicalAlter(unique_ptr<AlterInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::ALTER, {LogicalType::BOOLEAN}, estimated_cardinality),
+	explicit PhysicalAlter(ArenaAllocator &arena, unique_ptr<AlterInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::ALTER, {LogicalType::BOOLEAN}, estimated_cardinality),
 	      info(std::move(info)) {
 	}
 

--- a/src/include/duckdb/execution/operator/schema/physical_attach.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_attach.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::ATTACH;
 
 public:
-	explicit PhysicalAttach(unique_ptr<AttachInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::ATTACH, {LogicalType::BOOLEAN}, estimated_cardinality),
+	explicit PhysicalAttach(ArenaAllocator &arena, unique_ptr<AttachInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::ATTACH, {LogicalType::BOOLEAN}, estimated_cardinality),
 	      info(std::move(info)) {
 	}
 

--- a/src/include/duckdb/execution/operator/schema/physical_create_art_index.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_art_index.hpp
@@ -25,7 +25,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::CREATE_INDEX;
 
 public:
-	PhysicalCreateARTIndex(LogicalOperator &op, TableCatalogEntry &table, const vector<column_t> &column_ids,
+	PhysicalCreateARTIndex(ArenaAllocator &arena, PhysicalOperator &child, LogicalOperator &op,
+	                       TableCatalogEntry &table, const vector<column_t> &column_ids,
 	                       unique_ptr<CreateIndexInfo> info, vector<unique_ptr<Expression>> unbound_expressions,
 	                       idx_t estimated_cardinality, const bool sorted,
 	                       unique_ptr<AlterTableInfo> alter_table_info = nullptr);

--- a/src/include/duckdb/execution/operator/schema/physical_create_function.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_function.hpp
@@ -19,8 +19,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::CREATE_MACRO;
 
 public:
-	explicit PhysicalCreateFunction(unique_ptr<CreateMacroInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_MACRO, {LogicalType::BIGINT}, estimated_cardinality),
+	explicit PhysicalCreateFunction(ArenaAllocator &arena, unique_ptr<CreateMacroInfo> info,
+	                                idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::CREATE_MACRO, {LogicalType::BIGINT}, estimated_cardinality),
 	      info(std::move(info)) {
 	}
 

--- a/src/include/duckdb/execution/operator/schema/physical_create_schema.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_schema.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::CREATE_SCHEMA;
 
 public:
-	explicit PhysicalCreateSchema(unique_ptr<CreateSchemaInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_SCHEMA, {LogicalType::BIGINT}, estimated_cardinality),
+	explicit PhysicalCreateSchema(ArenaAllocator &arena, unique_ptr<CreateSchemaInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::CREATE_SCHEMA, {LogicalType::BIGINT}, estimated_cardinality),
 	      info(std::move(info)) {
 	}
 

--- a/src/include/duckdb/execution/operator/schema/physical_create_sequence.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_sequence.hpp
@@ -19,8 +19,9 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::CREATE_SEQUENCE;
 
 public:
-	explicit PhysicalCreateSequence(unique_ptr<CreateSequenceInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_SEQUENCE, {LogicalType::BIGINT}, estimated_cardinality),
+	explicit PhysicalCreateSequence(ArenaAllocator &arena, unique_ptr<CreateSequenceInfo> info,
+	                                idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::CREATE_SEQUENCE, {LogicalType::BIGINT}, estimated_cardinality),
 	      info(std::move(info)) {
 	}
 

--- a/src/include/duckdb/execution/operator/schema/physical_create_table.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_table.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::CREATE_TABLE;
 
 public:
-	PhysicalCreateTable(LogicalOperator &op, SchemaCatalogEntry &schema, unique_ptr<BoundCreateTableInfo> info,
-	                    idx_t estimated_cardinality);
+	PhysicalCreateTable(ArenaAllocator &arena, LogicalOperator &op, SchemaCatalogEntry &schema,
+	                    unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality);
 
 	//! Schema to insert to
 	SchemaCatalogEntry &schema;

--- a/src/include/duckdb/execution/operator/schema/physical_create_type.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_type.hpp
@@ -19,7 +19,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::CREATE_TYPE;
 
 public:
-	explicit PhysicalCreateType(unique_ptr<CreateTypeInfo> info, idx_t estimated_cardinality);
+	explicit PhysicalCreateType(ArenaAllocator &arena, unique_ptr<CreateTypeInfo> info, idx_t estimated_cardinality);
 
 	unique_ptr<CreateTypeInfo> info;
 

--- a/src/include/duckdb/execution/operator/schema/physical_create_view.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_create_view.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::CREATE_VIEW;
 
 public:
-	explicit PhysicalCreateView(unique_ptr<CreateViewInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_VIEW, {LogicalType::BIGINT}, estimated_cardinality),
+	explicit PhysicalCreateView(ArenaAllocator &arena, unique_ptr<CreateViewInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::CREATE_VIEW, {LogicalType::BIGINT}, estimated_cardinality),
 	      info(std::move(info)) {
 	}
 

--- a/src/include/duckdb/execution/operator/schema/physical_detach.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_detach.hpp
@@ -18,8 +18,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::DETACH;
 
 public:
-	explicit PhysicalDetach(unique_ptr<DetachInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::DETACH, {LogicalType::BOOLEAN}, estimated_cardinality),
+	explicit PhysicalDetach(ArenaAllocator &arena, unique_ptr<DetachInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::DETACH, {LogicalType::BOOLEAN}, estimated_cardinality),
 	      info(std::move(info)) {
 	}
 

--- a/src/include/duckdb/execution/operator/schema/physical_drop.hpp
+++ b/src/include/duckdb/execution/operator/schema/physical_drop.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::DROP;
 
 public:
-	explicit PhysicalDrop(unique_ptr<DropInfo> info, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::DROP, {LogicalType::BOOLEAN}, estimated_cardinality),
+	explicit PhysicalDrop(ArenaAllocator &arena, unique_ptr<DropInfo> info, idx_t estimated_cardinality)
+	    : PhysicalOperator(arena, PhysicalOperatorType::DROP, {LogicalType::BOOLEAN}, estimated_cardinality),
 	      info(std::move(info)) {
 	}
 

--- a/src/include/duckdb/execution/operator/set/physical_cte.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_cte.hpp
@@ -20,8 +20,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::CTE;
 
 public:
-	PhysicalCTE(ArenaAllocator &arena, string ctename, idx_t table_index, vector<LogicalType> types, PhysicalOperator &top,
-	            PhysicalOperator &bottom, idx_t estimated_cardinality);
+	PhysicalCTE(ArenaAllocator &arena, string ctename, idx_t table_index, vector<LogicalType> types,
+	            PhysicalOperator &top, PhysicalOperator &bottom, idx_t estimated_cardinality);
 	~PhysicalCTE() override;
 
 	vector<const_reference<PhysicalOperator>> cte_scans;

--- a/src/include/duckdb/execution/operator/set/physical_cte.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_cte.hpp
@@ -20,7 +20,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::CTE;
 
 public:
-	PhysicalCTE(string ctename, idx_t table_index, vector<LogicalType> types, PhysicalOperator &top,
+	PhysicalCTE(ArenaAllocator &arena, string ctename, idx_t table_index, vector<LogicalType> types, PhysicalOperator &top,
 	            PhysicalOperator &bottom, idx_t estimated_cardinality);
 	~PhysicalCTE() override;
 

--- a/src/include/duckdb/execution/operator/set/physical_recursive_cte.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_recursive_cte.hpp
@@ -21,8 +21,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::RECURSIVE_CTE;
 
 public:
-	PhysicalRecursiveCTE(ArenaAllocator &arena, string ctename, idx_t table_index, vector<LogicalType> types, bool union_all,
-	                     PhysicalOperator &top, PhysicalOperator &bottom, idx_t estimated_cardinality);
+	PhysicalRecursiveCTE(ArenaAllocator &arena, string ctename, idx_t table_index, vector<LogicalType> types,
+	                     bool union_all, PhysicalOperator &top, PhysicalOperator &bottom, idx_t estimated_cardinality);
 	~PhysicalRecursiveCTE() override;
 
 	string ctename;

--- a/src/include/duckdb/execution/operator/set/physical_recursive_cte.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_recursive_cte.hpp
@@ -21,7 +21,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::RECURSIVE_CTE;
 
 public:
-	PhysicalRecursiveCTE(string ctename, idx_t table_index, vector<LogicalType> types, bool union_all,
+	PhysicalRecursiveCTE(ArenaAllocator &arena, string ctename, idx_t table_index, vector<LogicalType> types, bool union_all,
 	                     PhysicalOperator &top, PhysicalOperator &bottom, idx_t estimated_cardinality);
 	~PhysicalRecursiveCTE() override;
 

--- a/src/include/duckdb/execution/operator/set/physical_union.hpp
+++ b/src/include/duckdb/execution/operator/set/physical_union.hpp
@@ -17,7 +17,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::UNION;
 
 public:
-	PhysicalUnion(vector<LogicalType> types, PhysicalOperator &top, PhysicalOperator &bottom,
+	PhysicalUnion(ArenaAllocator &arena, vector<LogicalType> types, PhysicalOperator &top, PhysicalOperator &bottom,
 	              idx_t estimated_cardinality, bool allow_out_of_order);
 
 	bool allow_out_of_order;

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -40,7 +40,7 @@ public:
 
 public:
 	PhysicalOperator(PhysicalOperatorType type, vector<LogicalType> types, idx_t estimated_cardinality)
-	    : type(type), types(std::move(types)), estimated_cardinality(estimated_cardinality) {
+	    : type(type), children(), types(std::move(types)), estimated_cardinality(estimated_cardinality) {
 	}
 
 	virtual ~PhysicalOperator() {

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/arena_linked_list.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/operator_result_type.hpp"
 #include "duckdb/common/enums/physical_operator_type.hpp"
@@ -52,7 +53,7 @@ public:
 	//! The physical operator type
 	PhysicalOperatorType type;
 	//! The set of children of the operator
-	vector<reference<PhysicalOperator>> children;
+	ArenaLinkedList<reference<PhysicalOperator>> children;
 	//! The types returned by this physical operator
 	vector<LogicalType> types;
 	//! The estimated cardinality of this physical operator

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -37,10 +37,14 @@ public:
 	template <class T, class... ARGS>
 	PhysicalOperator &Make(ARGS &&... args) {
 		static_assert(std::is_base_of<PhysicalOperator, T>::value, "T must be a physical operator");
-		auto mem = arena.AllocateAligned(sizeof(T));
-		auto ptr = new (mem) T(std::forward<ARGS>(args)...);
+		auto ptr = arena.Make<T>(std::forward<ARGS>(args)...);
+		ptr->children.Init(arena);
 		ops.push_back(*ptr);
 		return *ptr;
+	}
+
+	ArenaAllocator &GetArena() {
+		return arena;
 	}
 
 	PhysicalOperator &Root() {
@@ -49,9 +53,6 @@ public:
 	}
 	void SetRoot(PhysicalOperator &op) {
 		root = op;
-	}
-	ArenaAllocator &GetArena() {
-		return arena;
 	}
 
 private:

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -50,6 +50,9 @@ public:
 	void SetRoot(PhysicalOperator &op) {
 		root = op;
 	}
+	ArenaAllocator &GetArena() {
+		return arena;
+	}
 
 private:
 	//! The arena allocator storing the physical operator memory.
@@ -93,6 +96,10 @@ public:
 	template <class T, class... ARGS>
 	PhysicalOperator &Make(ARGS &&... args) {
 		return physical_plan->Make<T>(std::forward<ARGS>(args)...);
+	}
+
+	ArenaAllocator &GetArena() {
+		return physical_plan->GetArena();
 	}
 
 public:

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -37,14 +37,9 @@ public:
 	template <class T, class... ARGS>
 	PhysicalOperator &Make(ARGS &&... args) {
 		static_assert(std::is_base_of<PhysicalOperator, T>::value, "T must be a physical operator");
-		auto ptr = arena.Make<T>(std::forward<ARGS>(args)...);
-		ptr->children.Init(arena);
+		auto ptr = arena.Make<T>(arena, std::forward<ARGS>(args)...);
 		ops.push_back(*ptr);
 		return *ptr;
-	}
-
-	ArenaAllocator &GetArena() {
-		return arena;
 	}
 
 	PhysicalOperator &Root() {
@@ -97,10 +92,6 @@ public:
 	template <class T, class... ARGS>
 	PhysicalOperator &Make(ARGS &&... args) {
 		return physical_plan->Make<T>(std::forward<ARGS>(args)...);
-	}
-
-	ArenaAllocator &GetArena() {
-		return physical_plan->GetArena();
 	}
 
 public:

--- a/src/include/duckdb/storage/arena_allocator.hpp
+++ b/src/include/duckdb/storage/arena_allocator.hpp
@@ -78,9 +78,9 @@ public:
 	}
 
 	template<class T, class ...ARGS>
-	T& Make(ARGS &&... args) {
-		auto ptr = AllocateAligned(sizeof(T), alignof(T));
-		return *new (ptr) T(std::forward<ARGS>(args)...);
+	T* Make(ARGS &&... args) {
+		auto ptr = AllocateAligned(sizeof(T));
+		return new (ptr) T(std::forward<ARGS>(args)...);
 	}
 
 private:

--- a/src/include/duckdb/storage/arena_allocator.hpp
+++ b/src/include/duckdb/storage/arena_allocator.hpp
@@ -77,10 +77,10 @@ public:
 		return arena_allocator;
 	}
 
-	template<class T, class ...ARGS>
-	T* Make(ARGS &&... args) {
-		auto ptr = AllocateAligned(sizeof(T));
-		return new (ptr) T(std::forward<ARGS>(args)...);
+	template <class T, class... ARGS>
+	T *Make(ARGS &&... args) {
+		auto mem = AllocateAligned(sizeof(T));
+		return new (mem) T(std::forward<ARGS>(args)...);
 	}
 
 private:

--- a/src/include/duckdb/storage/arena_allocator.hpp
+++ b/src/include/duckdb/storage/arena_allocator.hpp
@@ -77,6 +77,12 @@ public:
 		return arena_allocator;
 	}
 
+	template<class T, class ...ARGS>
+	T& Make(ARGS &&... args) {
+		auto ptr = AllocateAligned(sizeof(T), alignof(T));
+		return *new (ptr) T(std::forward<ARGS>(args)...);
+	}
+
 private:
 	void AllocateNewBlock(idx_t min_size);
 


### PR DESCRIPTION
As discussed with @Mytherin and @Maxxen, here is a first draft on a possible solution to move the operator children out of a vector. 

I don't think this is pretty enough yet to go with it. Initially, I wanted to make no changes to the operator constructors and planning functions. However, since some operators `push_back` to their children in their constructors (instead of in the planning functions), I ended up passing the arena to those operators.

I think moving forward, we have three options to finish up this PR, with varying levels of prettiness.

1. Intrusive linked list.
   - Plus, Max's and my favourite. We completely omit the arena, and also the `ArenaLinkedList`.
   - Downside, significant code changes.

2. We do not store the arena in the `ArenaLinkedList`. Instead of `push_back(elem)`, we add `Append(arena, elem)`.
   - Plus, we solve the ugly `Init` situation, which currently has to sometimes happen in the constructors AND `Make`.
   - Downside, we need to pass the arena everywhere.
   - Downside, semantically, an `ArenaLinkedList` can have nodes from multiple arenas.

3. We explicitly construct the `ArenaLinkedList(ArenaAllocator &arena)` in `PhysicalOperator`, instead of optionally initiliazing it.
   - Plus, we don't have to touch any `push_back`.
   - Downside, we need to pass the arena to **every** operator constructor. That's A LOT, and many of them have no children.

Let me know how to best move forward with this. :)