### PR TITLE
[Nested] Fix incorrect type casting in list_reduce lambda expressions

### DIFF
--- a/extension/core_functions/scalar/list/list_filter.cpp
+++ b/extension/core_functions/scalar/list/list_filter.cpp
@@ -30,9 +30,9 @@ static unique_ptr<FunctionData> ListFilterBind(ClientContext &context, ScalarFun
 	return LambdaFunctions::ListLambdaBind(context, bound_function, arguments, has_index);
 }
 
-static LogicalType ListFilterBindLambda(const idx_t parameter_idx, ClientContext &context,
-                                        const vector<LogicalType> &function_child_types) {
-	return LambdaFunctions::BindBinaryLambda(parameter_idx, context, function_child_types);
+static LogicalType ListFilterBindLambda(ClientContext &context, const vector<LogicalType> &function_child_types,
+                                        const idx_t parameter_idx) {
+	return LambdaFunctions::BindBinaryChildren(function_child_types, parameter_idx);
 }
 
 ScalarFunction ListFilterFun::GetFunction() {

--- a/extension/core_functions/scalar/list/list_filter.cpp
+++ b/extension/core_functions/scalar/list/list_filter.cpp
@@ -30,8 +30,9 @@ static unique_ptr<FunctionData> ListFilterBind(ClientContext &context, ScalarFun
 	return LambdaFunctions::ListLambdaBind(context, bound_function, arguments, has_index);
 }
 
-static LogicalType ListFilterBindLambda(const idx_t parameter_idx, const LogicalType &list_child_type) {
-	return LambdaFunctions::BindBinaryLambda(parameter_idx, list_child_type);
+static LogicalType ListFilterBindLambda(const idx_t parameter_idx, ClientContext &context,
+                                        const vector<LogicalType> &function_child_types) {
+	return LambdaFunctions::BindBinaryLambda(parameter_idx, context, function_child_types);
 }
 
 ScalarFunction ListFilterFun::GetFunction() {

--- a/extension/core_functions/scalar/list/list_reduce.cpp
+++ b/extension/core_functions/scalar/list/list_reduce.cpp
@@ -262,10 +262,9 @@ static unique_ptr<FunctionData> ListReduceBind(ClientContext &context, ScalarFun
 	                                     has_initial);
 }
 
-
-LogicalType LambdaFunctions::BindReduce(const idx_t parameter_idx, ClientContext &context,
-                                        const vector<LogicalType> &function_child_types) {
-	auto list_child_type = DetermineListChildType(function_child_types);
+LogicalType BindReduceChildren(ClientContext &context, const vector<LogicalType> &function_child_types,
+                               const idx_t parameter_idx) {
+	auto list_child_type = LambdaFunctions::DetermineListChildType(function_child_types[0]);
 
 	// if there is an initial value, find the max logical type
 	if (function_child_types.size() == 3) {
@@ -276,11 +275,11 @@ LogicalType LambdaFunctions::BindReduce(const idx_t parameter_idx, ClientContext
 		if (initial_value_type != list_child_type) {
 			// we need to check if the initial value type is the same as the return type of the lambda expression
 			LogicalType max_logical_type;
-			const auto has_max_logical_type = LogicalType::TryGetMaxLogicalType(
-				context, list_child_type, initial_value_type, max_logical_type);
+			const auto has_max_logical_type =
+			    LogicalType::TryGetMaxLogicalType(context, list_child_type, initial_value_type, max_logical_type);
 			if (!has_max_logical_type) {
 				throw BinderException(
-					"The initial value type must be the same as the list child type or a common super type");
+				    "The initial value type must be the same as the list child type or a common super type");
 			}
 
 			list_child_type = max_logical_type;
@@ -288,20 +287,20 @@ LogicalType LambdaFunctions::BindReduce(const idx_t parameter_idx, ClientContext
 	}
 
 	switch (parameter_idx) {
-		case 0:
-			return list_child_type;
-		case 1:
-			return list_child_type;
-		case 2:
-			return LogicalType::BIGINT;
-		default:
-			throw BinderException("This lambda function only supports up to three lambda parameters!");
+	case 0:
+		return list_child_type;
+	case 1:
+		return list_child_type;
+	case 2:
+		return LogicalType::BIGINT;
+	default:
+		throw BinderException("This lambda function only supports up to three lambda parameters!");
 	}
 }
 
-static LogicalType ListReduceBindLambda(const idx_t parameter_idx, ClientContext &context,
-                                        const vector<LogicalType> &function_child_types) {
-	return LambdaFunctions::BindReduce(parameter_idx, context, function_child_types);
+static LogicalType ListReduceBindLambda(ClientContext &context, const vector<LogicalType> &function_child_types,
+                                        const idx_t parameter_idx) {
+	return BindReduceChildren(context, function_child_types, parameter_idx);
 }
 
 ScalarFunctionSet ListReduceFun::GetFunctions() {

--- a/extension/core_functions/scalar/list/list_reduce.cpp
+++ b/extension/core_functions/scalar/list/list_reduce.cpp
@@ -1,7 +1,6 @@
 #include "core_functions/scalar/list_functions.hpp"
 #include "duckdb/function/lambda_functions.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
 
@@ -219,12 +218,6 @@ static unique_ptr<FunctionData> ListReduceBind(ClientContext &context, ScalarFun
 
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 
-	auto &bound_lambda_expr = arguments[1]->Cast<BoundLambdaExpression>();
-	if (bound_lambda_expr.parameter_count < 2 || bound_lambda_expr.parameter_count > 3) {
-		throw BinderException("list_reduce expects a function with 2 or 3 arguments");
-	}
-	auto has_index = bound_lambda_expr.parameter_count == 3;
-
 	unique_ptr<FunctionData> bind_data = LambdaFunctions::ListLambdaPrepareBind(arguments, context, bound_function);
 	if (bind_data) {
 		return bind_data;
@@ -236,7 +229,7 @@ static unique_ptr<FunctionData> ListReduceBind(ClientContext &context, ScalarFun
 	bool has_initial = arguments.size() == 3;
 	if (has_initial) {
 		const auto initial_value_type = arguments[2]->return_type;
-		// Check if the initial value type is the same as the list child type and if not find the max logical type
+		// Check if the initial value type is the same as the return type of the lambda expression
 		if (list_child_type != initial_value_type) {
 			LogicalType max_logical_type;
 			const auto has_max_logical_type =
@@ -253,6 +246,12 @@ static unique_ptr<FunctionData> ListReduceBind(ClientContext &context, ScalarFun
 		}
 	}
 
+	auto &bound_lambda_expr = arguments[1]->Cast<BoundLambdaExpression>();
+	if (bound_lambda_expr.parameter_count < 2 || bound_lambda_expr.parameter_count > 3) {
+		throw BinderException("list_reduce expects a function with 2 or 3 arguments");
+	}
+	auto has_index = bound_lambda_expr.parameter_count == 3;
+
 	auto cast_lambda_expr =
 	    BoundCastExpression::AddCastToType(context, std::move(bound_lambda_expr.lambda_expr), list_child_type);
 	if (!cast_lambda_expr) {
@@ -263,8 +262,46 @@ static unique_ptr<FunctionData> ListReduceBind(ClientContext &context, ScalarFun
 	                                     has_initial);
 }
 
-static LogicalType ListReduceBindLambda(const idx_t parameter_idx, const LogicalType &list_child_type) {
-	return LambdaFunctions::BindTernaryLambda(parameter_idx, list_child_type);
+
+LogicalType LambdaFunctions::BindReduce(const idx_t parameter_idx, ClientContext &context,
+                                        const vector<LogicalType> &function_child_types) {
+	auto list_child_type = DetermineListChildType(function_child_types);
+
+	// if there is an initial value, find the max logical type
+	if (function_child_types.size() == 3) {
+		// the initial value is the third child
+		constexpr idx_t initial_idx = 2;
+
+		const LogicalType initial_value_type = function_child_types[initial_idx];
+		if (initial_value_type != list_child_type) {
+			// we need to check if the initial value type is the same as the return type of the lambda expression
+			LogicalType max_logical_type;
+			const auto has_max_logical_type = LogicalType::TryGetMaxLogicalType(
+				context, list_child_type, initial_value_type, max_logical_type);
+			if (!has_max_logical_type) {
+				throw BinderException(
+					"The initial value type must be the same as the list child type or a common super type");
+			}
+
+			list_child_type = max_logical_type;
+		}
+	}
+
+	switch (parameter_idx) {
+		case 0:
+			return list_child_type;
+		case 1:
+			return list_child_type;
+		case 2:
+			return LogicalType::BIGINT;
+		default:
+			throw BinderException("This lambda function only supports up to three lambda parameters!");
+	}
+}
+
+static LogicalType ListReduceBindLambda(const idx_t parameter_idx, ClientContext &context,
+                                        const vector<LogicalType> &function_child_types) {
+	return LambdaFunctions::BindReduce(parameter_idx, context, function_child_types);
 }
 
 ScalarFunctionSet ListReduceFun::GetFunctions() {

--- a/extension/core_functions/scalar/list/list_transform.cpp
+++ b/extension/core_functions/scalar/list/list_transform.cpp
@@ -22,8 +22,9 @@ static unique_ptr<FunctionData> ListTransformBind(ClientContext &context, Scalar
 	return LambdaFunctions::ListLambdaBind(context, bound_function, arguments, has_index);
 }
 
-static LogicalType ListTransformBindLambda(const idx_t parameter_idx, const LogicalType &list_child_type) {
-	return LambdaFunctions::BindBinaryLambda(parameter_idx, list_child_type);
+static LogicalType ListTransformBindLambda(const idx_t parameter_idx, ClientContext &context,
+                                           const vector<LogicalType> &function_child_types) {
+	return LambdaFunctions::BindBinaryLambda(parameter_idx, context, function_child_types);
 }
 
 ScalarFunction ListTransformFun::GetFunction() {

--- a/extension/core_functions/scalar/list/list_transform.cpp
+++ b/extension/core_functions/scalar/list/list_transform.cpp
@@ -22,9 +22,9 @@ static unique_ptr<FunctionData> ListTransformBind(ClientContext &context, Scalar
 	return LambdaFunctions::ListLambdaBind(context, bound_function, arguments, has_index);
 }
 
-static LogicalType ListTransformBindLambda(const idx_t parameter_idx, ClientContext &context,
-                                           const vector<LogicalType> &function_child_types) {
-	return LambdaFunctions::BindBinaryLambda(parameter_idx, context, function_child_types);
+static LogicalType ListTransformBindLambda(ClientContext &context, const vector<LogicalType> &function_child_types,
+                                           const idx_t parameter_idx) {
+	return LambdaFunctions::BindBinaryChildren(function_child_types, parameter_idx);
 }
 
 ScalarFunction ListTransformFun::GetFunction() {

--- a/src/include/duckdb/function/lambda_functions.hpp
+++ b/src/include/duckdb/function/lambda_functions.hpp
@@ -54,15 +54,10 @@ public:
 class LambdaFunctions {
 public:
 	//! Returns the list child type
-	static LogicalType DetermineListChildType(const vector<LogicalType> &function_child_types);
+	static LogicalType DetermineListChildType(const LogicalType &child_type);
 
 	//! Returns the parameter type for binary lambdas
-	static LogicalType BindBinaryLambda(const idx_t parameter_idx, ClientContext &context,
-	                                    const vector<LogicalType> &function_child_types);
-
-	//! Returns the parameter type for ListReduce
-	static LogicalType BindReduce(const idx_t parameter_idx, ClientContext &context,
-	                              const vector<LogicalType> &function_child_types);
+	static LogicalType BindBinaryChildren(const vector<LogicalType> &function_child_types, const idx_t parameter_idx);
 
 	//! Checks for NULL list parameter and prepared statements and adds bound cast expression
 	static unique_ptr<FunctionData> ListLambdaPrepareBind(vector<unique_ptr<Expression>> &arguments,

--- a/src/include/duckdb/function/lambda_functions.hpp
+++ b/src/include/duckdb/function/lambda_functions.hpp
@@ -53,10 +53,16 @@ public:
 
 class LambdaFunctions {
 public:
+	//! Returns the list child type
+	static LogicalType DetermineListChildType(const vector<LogicalType> &function_child_types);
+
 	//! Returns the parameter type for binary lambdas
-	static LogicalType BindBinaryLambda(const idx_t parameter_idx, const LogicalType &list_child_type);
-	//! Returns the parameter type for ternary lambdas
-	static LogicalType BindTernaryLambda(const idx_t parameter_idx, const LogicalType &list_child_type);
+	static LogicalType BindBinaryLambda(const idx_t parameter_idx, ClientContext &context,
+	                                    const vector<LogicalType> &function_child_types);
+
+	//! Returns the parameter type for ListReduce
+	static LogicalType BindReduce(const idx_t parameter_idx, ClientContext &context,
+	                              const vector<LogicalType> &function_child_types);
 
 	//! Checks for NULL list parameter and prepared statements and adds bound cast expression
 	static unique_ptr<FunctionData> ListLambdaPrepareBind(vector<unique_ptr<Expression>> &arguments,

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -109,8 +109,8 @@ typedef unique_ptr<FunctionLocalState> (*init_local_state_t)(ExpressionState &st
 //! The type to propagate statistics for this scalar function
 typedef unique_ptr<BaseStatistics> (*function_statistics_t)(ClientContext &context, FunctionStatisticsInput &input);
 //! The type to bind lambda-specific parameter types
-typedef LogicalType (*bind_lambda_function_t)(const idx_t parameter_idx, ClientContext &context,
-                                              const vector<LogicalType> &function_child_types);
+typedef LogicalType (*bind_lambda_function_t)(ClientContext &context, const vector<LogicalType> &function_child_types,
+                                              idx_t parameter_idx);
 
 //! The type to bind lambda-specific parameter types
 typedef void (*get_modified_databases_t)(ClientContext &context, FunctionModifiedDatabasesInput &input);

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -109,7 +109,9 @@ typedef unique_ptr<FunctionLocalState> (*init_local_state_t)(ExpressionState &st
 //! The type to propagate statistics for this scalar function
 typedef unique_ptr<BaseStatistics> (*function_statistics_t)(ClientContext &context, FunctionStatisticsInput &input);
 //! The type to bind lambda-specific parameter types
-typedef LogicalType (*bind_lambda_function_t)(const idx_t parameter_idx, const LogicalType &list_child_type);
+typedef LogicalType (*bind_lambda_function_t)(const idx_t parameter_idx, ClientContext &context,
+                                              const vector<LogicalType> &function_child_types);
+
 //! The type to bind lambda-specific parameter types
 typedef void (*get_modified_databases_t)(ClientContext &context, FunctionModifiedDatabasesInput &input);
 

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -175,7 +175,8 @@ protected:
 	BindResult BindExpression(ConjunctionExpression &expr, idx_t depth);
 	BindResult BindExpression(ConstantExpression &expr, idx_t depth);
 	BindResult BindExpression(FunctionExpression &expr, idx_t depth, unique_ptr<ParsedExpression> &expr_ptr);
-	BindResult BindExpression(LambdaExpression &expr, idx_t depth, const LogicalType &list_child_type,
+
+	BindResult BindExpression(LambdaExpression &expr, idx_t depth, const vector<LogicalType> &function_child_types,
 	                          optional_ptr<bind_lambda_function_t> bind_lambda_function);
 	BindResult BindExpression(OperatorExpression &expr, idx_t depth);
 	BindResult BindExpression(ParameterExpression &expr, idx_t depth);
@@ -185,10 +186,11 @@ protected:
 	void TransformCapturedLambdaColumn(unique_ptr<Expression> &original, unique_ptr<Expression> &replacement,
 	                                   BoundLambdaExpression &bound_lambda_expr,
 	                                   const optional_ptr<bind_lambda_function_t> bind_lambda_function,
-	                                   const LogicalType &list_child_type);
+	                                   const vector<LogicalType> &function_child_types);
+
 	void CaptureLambdaColumns(BoundLambdaExpression &bound_lambda_expr, unique_ptr<Expression> &expr,
 	                          const optional_ptr<bind_lambda_function_t> bind_lambda_function,
-	                          const LogicalType &list_child_type);
+	                          const vector<LogicalType> &function_child_types);
 
 	virtual unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name);
 

--- a/src/planner/binder/expression/bind_lambda.cpp
+++ b/src/planner/binder/expression/bind_lambda.cpp
@@ -62,7 +62,8 @@ void ExtractParameters(LambdaExpression &expr, vector<string> &column_names, vec
 	D_ASSERT(!column_names.empty());
 }
 
-BindResult ExpressionBinder::BindExpression(LambdaExpression &expr, idx_t depth, const LogicalType &list_child_type,
+BindResult ExpressionBinder::BindExpression(LambdaExpression &expr, idx_t depth,
+                                            const vector<LogicalType> &function_child_types,
                                             optional_ptr<bind_lambda_function_t> bind_lambda_function) {
 	if (expr.syntax_type == LambdaSyntaxType::LAMBDA_KEYWORD && !bind_lambda_function) {
 		return BindResult("invalid lambda expression");
@@ -93,7 +94,7 @@ BindResult ExpressionBinder::BindExpression(LambdaExpression &expr, idx_t depth,
 	vector<string> column_aliases;
 	ExtractParameters(expr, column_names, column_aliases);
 	for (idx_t i = 0; i < column_names.size(); i++) {
-		column_types.push_back((*bind_lambda_function)(i, list_child_type));
+		column_types.push_back((*bind_lambda_function)(i, context, function_child_types));
 	}
 
 	// base table alias
@@ -134,7 +135,7 @@ void ExpressionBinder::TransformCapturedLambdaColumn(unique_ptr<Expression> &ori
                                                      unique_ptr<Expression> &replacement,
                                                      BoundLambdaExpression &bound_lambda_expr,
                                                      const optional_ptr<bind_lambda_function_t> bind_lambda_function,
-                                                     const LogicalType &list_child_type) {
+                                                     const vector<LogicalType> &function_child_types) {
 
 	// check if the original expression is a lambda parameter
 	if (original->GetExpressionClass() == ExpressionClass::BOUND_LAMBDA_REF) {
@@ -164,9 +165,8 @@ void ExpressionBinder::TransformCapturedLambdaColumn(unique_ptr<Expression> &ori
 			// error resolving the lambda index
 			throw InternalException("Failed to bind lambda parameter internally");
 		}
-
 		// refers to a lambda parameter inside the current lambda function
-		auto logical_type = (*bind_lambda_function)(bound_lambda_ref.binding.column_index, list_child_type);
+		auto logical_type = (*bind_lambda_function)(bound_lambda_ref.binding.column_index, context, function_child_types);
 		auto index = bound_lambda_expr.parameter_count - bound_lambda_ref.binding.column_index - 1;
 		replacement = make_uniq<BoundReferenceExpression>(alias, logical_type, index);
 		return;
@@ -186,7 +186,7 @@ void ExpressionBinder::TransformCapturedLambdaColumn(unique_ptr<Expression> &ori
 
 void ExpressionBinder::CaptureLambdaColumns(BoundLambdaExpression &bound_lambda_expr, unique_ptr<Expression> &expr,
                                             const optional_ptr<bind_lambda_function_t> bind_lambda_function,
-                                            const LogicalType &list_child_type) {
+                                            const vector<LogicalType> &function_child_types) {
 
 	if (expr->GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY) {
 		throw BinderException("subqueries in lambda expressions are not supported");
@@ -216,7 +216,7 @@ void ExpressionBinder::CaptureLambdaColumns(BoundLambdaExpression &bound_lambda_
 		auto original = std::move(expr);
 		unique_ptr<Expression> replacement;
 
-		TransformCapturedLambdaColumn(original, replacement, bound_lambda_expr, bind_lambda_function, list_child_type);
+		TransformCapturedLambdaColumn(original, replacement, bound_lambda_expr, bind_lambda_function, function_child_types);
 
 		// replace the expression
 		expr = std::move(replacement);
@@ -224,7 +224,7 @@ void ExpressionBinder::CaptureLambdaColumns(BoundLambdaExpression &bound_lambda_
 	} else {
 		// recursively enumerate the children of the expression
 		ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
-			CaptureLambdaColumns(bound_lambda_expr, child, bind_lambda_function, list_child_type);
+			CaptureLambdaColumns(bound_lambda_expr, child, bind_lambda_function, function_child_types);
 		});
 	}
 

--- a/src/planner/binder/expression/bind_lambda.cpp
+++ b/src/planner/binder/expression/bind_lambda.cpp
@@ -94,7 +94,7 @@ BindResult ExpressionBinder::BindExpression(LambdaExpression &expr, idx_t depth,
 	vector<string> column_aliases;
 	ExtractParameters(expr, column_names, column_aliases);
 	for (idx_t i = 0; i < column_names.size(); i++) {
-		column_types.push_back((*bind_lambda_function)(i, context, function_child_types));
+		column_types.push_back((*bind_lambda_function)(context, function_child_types, i));
 	}
 
 	// base table alias
@@ -166,7 +166,8 @@ void ExpressionBinder::TransformCapturedLambdaColumn(unique_ptr<Expression> &ori
 			throw InternalException("Failed to bind lambda parameter internally");
 		}
 		// refers to a lambda parameter inside the current lambda function
-		auto logical_type = (*bind_lambda_function)(bound_lambda_ref.binding.column_index, context, function_child_types);
+		auto logical_type =
+		    (*bind_lambda_function)(context, function_child_types, bound_lambda_ref.binding.column_index);
 		auto index = bound_lambda_expr.parameter_count - bound_lambda_ref.binding.column_index - 1;
 		replacement = make_uniq<BoundReferenceExpression>(alias, logical_type, index);
 		return;
@@ -216,7 +217,8 @@ void ExpressionBinder::CaptureLambdaColumns(BoundLambdaExpression &bound_lambda_
 		auto original = std::move(expr);
 		unique_ptr<Expression> replacement;
 
-		TransformCapturedLambdaColumn(original, replacement, bound_lambda_expr, bind_lambda_function, function_child_types);
+		TransformCapturedLambdaColumn(original, replacement, bound_lambda_expr, bind_lambda_function,
+		                              function_child_types);
 
 		// replace the expression
 		expr = std::move(replacement);

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -88,8 +88,10 @@ BindResult ExpressionBinder::BindExpression(unique_ptr<ParsedExpression> &expr, 
 		// binding a function expression requires an extra parameter for macros
 		return BindExpression(function, depth, expr);
 	}
-	case ExpressionClass::LAMBDA:
-		return BindExpression(expr_ref.Cast<LambdaExpression>(), depth, LogicalTypeId::INVALID, nullptr);
+	case ExpressionClass::LAMBDA: {
+		const vector<LogicalType> function_child_types;
+		return BindExpression(expr_ref.Cast<LambdaExpression>(), depth, function_child_types, nullptr);
+	}
 	case ExpressionClass::OPERATOR:
 		return BindExpression(expr_ref.Cast<OperatorExpression>(), depth);
 	case ExpressionClass::SUBQUERY:

--- a/test/sql/function/list/lambdas/reduce_initial.test
+++ b/test/sql/function/list/lambdas/reduce_initial.test
@@ -489,6 +489,34 @@ SELECT list_reduce([1, 2, 3], lambda x, y: x * y, 2.5);
 ----
 15.0
 
+statement ok
+CREATE TABLE cast_test (l int[], initial float);
+
+statement ok
+INSERT INTO cast_test VALUES ([1, 2, 3], 100.0), ([0], 3.1), ([3, 2, 1], 10.5);
+
+query I 
+SELECT list_reduce(l, lambda x, y: x > 3, initial) FROM cast_test;
+----
+0.0
+1.0
+0.0
+
+query I
+SELECT list_reduce(l, lambda x, y: x + y, initial) FROM cast_test;
+----
+106.0
+3.1
+16.5
+
+query I
+SELECT list_reduce(l, lambda x, y: x * y, initial) FROM cast_test;
+----
+600.0
+0.0
+63.0
+
+
 # Test errors with incompatible types
 statement error
 SELECT list_reduce([1, 2, 3], lambda x, y: x + y, [1, 2]);

--- a/test/sql/function/list/lambdas/reduce_initial.test
+++ b/test/sql/function/list/lambdas/reduce_initial.test
@@ -472,3 +472,54 @@ SELECT a FROM where_clause WHERE list_reduce(a, lambda x, y: x - y, initial) > 0
 [3, 4, 5]
 [11, 2, 3, 4, 5]
 [5, 4, 3, 2, 1]
+
+# where the initial value has a different type of the list
+query I
+SELECT list_reduce([0], lambda x, y: x > 3, 3.1);
+----
+1.0
+
+query I
+SELECT list_reduce([1, 2, 3], lambda x, y: x + y, 10.5);
+----
+16.5
+
+query I
+SELECT list_reduce([1, 2, 3], lambda x, y: x * y, 2.5);
+----
+15.0
+
+# Test errors with incompatible types
+statement error
+SELECT list_reduce([1, 2, 3], lambda x, y: x + y, [1, 2]);
+----
+The initial value type must be the same as the list child type or a common super type
+
+statement error
+SELECT list_reduce([BLOB 'hello'], lambda x, y: x, 'text');
+----
+The initial value type must be the same as the list child type or a common super type
+
+query I
+SELECT list_reduce([NULL, NULL]::INTEGER[], lambda x, y: x + y, 3.14);
+----
+NULL
+
+# Test using ENUM types
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+
+query I
+SELECT list_reduce(['sad', 'happy']::mood[], lambda x, y: y::text, 'Mood:');
+----
+happy
+
+query I
+SELECT list_reduce([[1, 2], [3, 4]], lambda x, y: array_append(x, list_aggregate(y, 'sum')), [0]);
+----
+[0, 3, 7]
+
+query I
+SELECT list_reduce([5, 10, 15], lambda x, y: x * y, 1 + 1);
+----
+1500


### PR DESCRIPTION
Fixes: https://github.com/duckdb/duckdb/issues/17008

This PR fixes an issue with type casting in lambda expressions used in the `list_reduce` function. 

For example, in the following query:
```sql
select list_reduce([0], (x, y) -> x > 3, 3.1)
```

The lambda expression was incorrectly bound as:
```sql
CAST((x > CAST(3 AS INTEGER)) AS DECIMAL(11,1))
```

Now proper type casting is implemented to match the max logical type of both the list child type and the initial value type:
```sql
CAST((x > CAST(3 AS DECIMAL(11,1))) AS DECIMAL(11,1))
```

### Test Cases
Added tests to verify the correct casting behaviour