### PR TITLE
MultiFileReader: Fix for handling nested list/map default values

### DIFF
--- a/extension/parquet/reader/struct_column_reader.cpp
+++ b/extension/parquet/reader/struct_column_reader.cpp
@@ -118,12 +118,21 @@ static bool TypeHasExactRowCount(const LogicalType &type) {
 }
 
 idx_t StructColumnReader::GroupRowsAvailable() {
-	for (idx_t i = 0; i < child_readers.size(); i++) {
-		if (TypeHasExactRowCount(child_readers[i]->Type())) {
-			return child_readers[i]->GroupRowsAvailable();
+	for (auto &child : child_readers) {
+		if (!child) {
+			continue;
+		}
+		if (TypeHasExactRowCount(child->Type())) {
+			return child->GroupRowsAvailable();
 		}
 	}
-	return child_readers[0]->GroupRowsAvailable();
+	for (auto &child : child_readers) {
+		if (!child) {
+			continue;
+		}
+		return child->GroupRowsAvailable();
+	}
+	throw InternalException("No projected columns in struct?");
 }
 
 } // namespace duckdb

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -10,7 +10,6 @@
 #include "duckdb/function/scalar/struct_functions.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
-#include "core_functions/scalar/list_functions.hpp"
 
 namespace duckdb {
 

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -308,9 +308,8 @@ ColumnMapResult MapColumnList(ClientContext &context, const MultiFileColumnDefin
 		auto default_type = LogicalType::STRUCT(std::move(default_type_list));
 		auto struct_pack_fun = StructPackFun::GetFunction();
 		auto bind_data = make_uniq<VariableReturnBindData>(default_type);
-		result.default_value =
-		    make_uniq<BoundFunctionExpression>(std::move(default_type), std::move(struct_pack_fun),
-		                                       std::move(default_expressions), std::move(bind_data));
+		result.default_value = make_uniq<BoundFunctionExpression>(std::move(default_type), std::move(struct_pack_fun),
+		                                                          std::move(default_expressions), std::move(bind_data));
 	}
 	result.column_index = make_uniq<ColumnIndex>(local_id.GetId(), std::move(child_indexes));
 	result.mapping = std::move(mapping);
@@ -421,9 +420,8 @@ ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefini
 		auto default_type = LogicalType::STRUCT(std::move(default_type_list));
 		auto struct_pack_fun = StructPackFun::GetFunction();
 		auto bind_data = make_uniq<VariableReturnBindData>(default_type);
-		result.default_value =
-		    make_uniq<BoundFunctionExpression>(std::move(default_type), std::move(struct_pack_fun),
-		                                       std::move(default_expressions), std::move(bind_data));
+		result.default_value = make_uniq<BoundFunctionExpression>(std::move(default_type), std::move(struct_pack_fun),
+		                                                          std::move(default_expressions), std::move(bind_data));
 	}
 	vector<ColumnIndex> map_indexes;
 	map_indexes.emplace_back(0, std::move(child_indexes));

--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -401,6 +401,9 @@ struct RemapEntry {
 			auto &child_types = StructType::GetChildTypes(default_type);
 			for (idx_t child_idx = 0; child_idx < child_types.size(); child_idx++) {
 				auto &child_default = child_types[child_idx];
+				if (!result_entry->second.child_remaps || !entry->second.child_map) {
+					throw BinderException("No child remaps found");
+				}
 				HandleDefault(child_idx, child_default.first, child_default.second, *entry->second.child_map,
 				              *result_entry->second.child_remaps);
 			}
@@ -542,6 +545,10 @@ static unique_ptr<FunctionData> RemapStructBind(ClientContext &context, ScalarFu
 		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
+		if (arg->return_type.id() == LogicalTypeId::SQLNULL && arg_idx == 2) {
+			// remap target can be NULL
+			continue;
+		}
 		if (!arg->return_type.IsNested()) {
 			throw BinderException("Struct remap can only remap nested types, not '%s'", arg->return_type.ToString());
 		} else if (arg->return_type.id() == LogicalTypeId::STRUCT && StructType::IsUnnamed(arg->return_type)) {
@@ -571,11 +578,11 @@ static unique_ptr<FunctionData> RemapStructBind(ClientContext &context, ScalarFu
 	auto target_map = RemapIndex::GetMap(to_type);
 
 	Value remap_val = ExpressionExecutor::EvaluateScalar(context, *arguments[2]);
-	auto &remap_types = StructType::GetChildTypes(arguments[2]->return_type);
 
 	// (recursively) generate the remap entries
 	case_insensitive_map_t<RemapEntry> remap_map;
 	if (!remap_val.IsNull()) {
+		auto &remap_types = StructType::GetChildTypes(arguments[2]->return_type);
 		auto &remap_values = StructValue::GetChildren(remap_val);
 		for (idx_t remap_idx = 0; remap_idx < remap_values.size(); remap_idx++) {
 			auto &remap_val = remap_values[remap_idx];

--- a/test/sql/types/struct/remap_struct.test
+++ b/test/sql/types/struct/remap_struct.test
@@ -5,6 +5,12 @@
 statement ok
 PRAGMA enable_verification
 
+# remap without targets
+query I
+SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v2 INT), NULL, {'v2': NULL::INTEGER});
+----
+{'v2': NULL}
+
 # basic binding error
 statement error
 select remap_struct(42, NULL::ROW(v1 INT, v2 INT, v3 INT), {'v1': 'j', 'v3': 'i'}, {'v2': NULL::INTEGER})
@@ -195,3 +201,21 @@ SELECT remap_struct(
  {'v2': NULL, 'v3': NULL::VARCHAR});
 ----
 Binder Error: Default key v2 does not match target type STRUCT(x INTEGER, y INTEGER) - add a cast
+
+statement error
+SELECT remap_struct(
+      [
+          {
+              'i': 1,
+              'j': 42
+          }
+      ],
+      NULL::STRUCT(k INT)[],
+      {'list': 'list'},
+      {
+          'list': {
+              'k': NULL
+          }
+      }
+  );
+----


### PR DESCRIPTION
Follow-up fixes from https://github.com/duckdb/duckdb/pull/17448

Nested default values were ignored, which caused this code not to correctly handle missing fields.

In addition, we can no longer directly emit the default value as the result since the default value is no longer equivalent to the actual value (e.g. the default value might be `{'list': {'k': NULL}}` when the actual value should be `[{'k': NULL}]`.) We fix this by allowing `remap_struct` to take `NULL` as remap target, in case there are zero columns used from the source struct.