### PR TITLE
[Dev][CLI] Use an unused bit for `DUCKDB_LATEST_STORAGE_VERSION`

### DIFF
--- a/tools/sqlite3_api_wrapper/include/sqlite3.h
+++ b/tools/sqlite3_api_wrapper/include/sqlite3.h
@@ -579,7 +579,7 @@ SQLITE_API int sqlite3_exec(
 // we need to somehow communicate this through open_v2
 #define DUCKDB_UNSIGNED_EXTENSIONS   0x10000000
 #define DUCKDB_UNREDACTED_SECRETS    0x20000000
-#define DUCKDB_LATEST_STORAGE_VERSION 0x30000000
+#define DUCKDB_LATEST_STORAGE_VERSION 0x40000000
 
 /*
 ** CAPI3REF: Device Characteristics


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/4938