### PR TITLE
Main branch versioning set to false

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,8 @@ endif()
 
 set(VERSIONING_TAG_MATCH "v*.*.*")
 ######
+# MAIN_BRANCH_VERSIONING default should be 'TRUE' for main branch and feature branches
+# MAIN_BRANCH_VERSIONING default should be 'FALSE' for release branches
 # MAIN_BRANCH_VERSIONING default value needs to keep in sync between:
 # - CMakeLists.txt
 # - scripts/amalgamation.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ set(VERSIONING_TAG_MATCH "v*.*.*")
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-option(MAIN_BRANCH_VERSIONING "Versioning scheme for main branch" TRUE)
+option(MAIN_BRANCH_VERSIONING "Versioning scheme for main branch" FALSE)
 if(${MAIN_BRANCH_VERSIONING})
   set(VERSIONING_TAG_MATCH "v*.*.0")
 endif()

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -271,13 +271,19 @@ def git_commit_hash():
 
 
 ######
+# MAIN_BRANCH_VERSIONING default should be 'True' for main branch and feature branches
+# MAIN_BRANCH_VERSIONING default should be 'False' for release branches
 # MAIN_BRANCH_VERSIONING default value needs to keep in sync between:
 # - CMakeLists.txt
 # - scripts/amalgamation.py
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-main_branch_versioning = False if os.getenv('MAIN_BRANCH_VERSIONING') == "0" else True
+MAIN_BRANCH_VERSIONING = True
+if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
+    MAIN_BRANCH_VERSIONING = False
+if os.getenv('MAIN_BRANCH_VERSIONING') == "1":
+    MAIN_BRANCH_VERSIONING = True
 
 
 def git_dev_version():
@@ -291,7 +297,7 @@ def git_dev_version():
         else:
             # not on a tag: increment the version by one and add a -devX suffix
             # this needs to keep in sync with changes to CMakeLists.txt
-            if main_branch_versioning == True:
+            if MAIN_BRANCH_VERSIONING == True:
                 # increment minor version
                 version_splits[1] = str(int(version_splits[1]) + 1)
             else:

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -279,7 +279,7 @@ def git_commit_hash():
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-MAIN_BRANCH_VERSIONING = True
+MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
     MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "1":

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -145,7 +145,7 @@ def get_relative_path(source_dir, target_file):
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-MAIN_BRANCH_VERSIONING = True
+MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
     MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "1":

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -137,19 +137,25 @@ def get_relative_path(source_dir, target_file):
 
 
 ######
+# MAIN_BRANCH_VERSIONING default should be 'True' for main branch and feature branches
+# MAIN_BRANCH_VERSIONING default should be 'False' for release branches
 # MAIN_BRANCH_VERSIONING default value needs to keep in sync between:
 # - CMakeLists.txt
 # - scripts/amalgamation.py
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-main_branch_versioning = False if os.getenv('MAIN_BRANCH_VERSIONING') == "0" else True
+MAIN_BRANCH_VERSIONING = True
+if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
+    MAIN_BRANCH_VERSIONING = False
+if os.getenv('MAIN_BRANCH_VERSIONING') == "1":
+    MAIN_BRANCH_VERSIONING = True
 
 
 def get_git_describe():
     override_git_describe = os.getenv('OVERRIDE_GIT_DESCRIBE') or ''
     versioning_tag_match = 'v*.*.*'
-    if main_branch_versioning:
+    if MAIN_BRANCH_VERSIONING:
         versioning_tag_match = 'v*.*.0'
     # empty override_git_describe, either since env was empty string or not existing
     # -> ask git (that can fail, so except in place)
@@ -210,7 +216,7 @@ def git_dev_version():
         else:
             # not on a tag: increment the version by one and add a -devX suffix
             # this needs to keep in sync with changes to CMakeLists.txt
-            if main_branch_versioning == True:
+            if MAIN_BRANCH_VERSIONING == True:
                 # increment minor version
                 version_splits[1] = str(int(version_splits[1]) + 1)
             else:

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -381,15 +381,19 @@ from pathlib import Path
 import os
 
 ######
+# MAIN_BRANCH_VERSIONING default should be 'True' for main branch and feature branches
+# MAIN_BRANCH_VERSIONING default should be 'False' for release branches
 # MAIN_BRANCH_VERSIONING default value needs to keep in sync between:
 # - CMakeLists.txt
 # - scripts/amalgamation.py
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-
-# Whether to use main branch versioning logic, defaults to True
-MAIN_BRANCH_VERSIONING = False if os.getenv('MAIN_BRANCH_VERSIONING') == "0" else True
+MAIN_BRANCH_VERSIONING = True
+if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
+    MAIN_BRANCH_VERSIONING = False
+if os.getenv('MAIN_BRANCH_VERSIONING') == "1":
+    MAIN_BRANCH_VERSIONING = True
 
 
 def parse(root: str | Path, config: Configuration) -> ScmVersion | None:

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -389,7 +389,7 @@ import os
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-MAIN_BRANCH_VERSIONING = True
+MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
     MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "1":


### PR DESCRIPTION
Set default value for `MAIN_BRANCH_VERSIONING` to false.
NOTE: needs to be reverted on main branch:
```
git revert 7cd2e2439017200753d120ec74b5575639b3844b
```

This PR is part of a 2 step code change:
1. minor resturcture, no logical change (https://github.com/duckdb/duckdb/pull/17601)
2. set default for MAIN_BRANCH_VERSIONING to false (revert on main branch) **<----- this PR**