### PR TITLE
fix extension troubleshooting link

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -52,7 +52,7 @@ string ExtensionHelper::ExtensionInstallDocumentationLink(const string &extensio
 	string link = "https://duckdb.org/docs/stable/extensions/troubleshooting";
 
 	if (components.size() >= 2) {
-		link += "/?version=" + components[0] + "&platform=" + components[1] + "&extension=" + extension_name;
+		link += "?version=" + components[0] + "&platform=" + components[1] + "&extension=" + extension_name;
 	}
 
 	return link;


### PR DESCRIPTION
Fix extensions troubleshooting link which had an extra `/` which resulted in a 404.

Before: https://duckdb.org/docs/stable/extensions/troubleshooting/?version=1f0067f1a5&platform=osx_arm64&extension=aws

After: https://duckdb.org/docs/stable/extensions/troubleshooting?version=1f0067f1a5&platform=osx_arm64&extension=aws