### PR TITLE
Improve Windows lock conflict error

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -838,13 +838,13 @@ static string AdditionalLockInfo(const std::wstring path) {
 
 	status = RmStartSession(&session, 0, session_key);
 	if (status != ERROR_SUCCESS) {
-		return "";
+		return string();
 	}
 
 	PCWSTR path_ptr = path.c_str();
 	status = RmRegisterResources(session, 1, &path_ptr, 0, NULL, 0, NULL);
 	if (status != ERROR_SUCCESS) {
-		return "";
+		return string();
 	}
 	UINT process_info_size_needed, process_info_size;
 
@@ -852,7 +852,7 @@ static string AdditionalLockInfo(const std::wstring path) {
 	process_info_size = 0;
 	status = RmGetList(session, &process_info_size_needed, &process_info_size, NULL, &reason);
 	if (status != ERROR_MORE_DATA || process_info_size_needed == 0) {
-		return "";
+		return string();
 	}
 
 	// allocate
@@ -866,8 +866,7 @@ static string AdditionalLockInfo(const std::wstring path) {
 		return "";
 	}
 
-	string conflict_string = "File is already open in ";
-
+	string conflict_string;
 	for (UINT process_idx = 0; process_idx < process_info_size; process_idx++) {
 		string process_name = WindowsUtil::UnicodeToUTF8(process_info[process_idx].strAppName);
 		auto pid = process_info[process_idx].Process.dwProcessId;
@@ -886,7 +885,10 @@ static string AdditionalLockInfo(const std::wstring path) {
 	}
 
 	RmEndSession(session);
-	return conflict_string;
+	if (conflict_string.empty()) {
+		return string();
+	}
+	return "File is already open in " + conflict_string;
 }
 
 bool LocalFileSystem::IsPrivateFile(const string &path_p, FileOpener *opener) {
@@ -950,12 +952,11 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 		}
 		auto error = LocalFileSystem::GetLastErrorAsString();
 
-		auto better_error = AdditionalLockInfo(unicode_path);
-		if (!better_error.empty()) {
-			throw IOException(better_error);
-		} else {
-			throw IOException("Cannot open file \"%s\": %s", path.c_str(), error);
+		auto extended_error = AdditionalLockInfo(unicode_path);
+		if (!extended_error.empty()) {
+			extended_error = "\n" + extended_error;
 		}
+		throw IOException("Cannot open file \"%s\": %s%s", path.c_str(), error, extended_error);
 	}
 	auto handle = make_uniq<WindowsFileHandle>(*this, path.c_str(), hFile, flags);
 	if (flags.OpenForAppending()) {


### PR DESCRIPTION
Previously the `AdditionalLockInfo` would *override* the original error, instead of providing extra info. In addition, when no PIDs were found, the error was replaced with `File is already open in `. This would cause the lock error to be rather non-descriptive:

```
IOException: File is already open in
```

This PR fixes it so this is actually used as extra information in the error, and we only report PIDs if any are found.