### PR TITLE
Actually initialize in batch copy to file

### DIFF
--- a/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -118,6 +118,7 @@ public:
 			op.function.copy_to_get_written_statistics(context, *op.bind_data, *global_state,
 			                                           *written_file_info->file_stats);
 		}
+		initialized = true;
 	}
 
 	void AddBatchData(idx_t batch_index, unique_ptr<PreparedBatchData> new_batch, idx_t memory_usage) {


### PR DESCRIPTION
Otherwise the Parquet writer opens multiple file handles when `WRITE_EMPTY_FILE` is set to true