### PR TITLE
DefaultSecretGenerator: require lock for modifying persistent_secrets

### DIFF
--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -222,6 +222,7 @@ protected:
 	unique_ptr<CatalogEntry> CreateDefaultEntryInternal(const string &entry_name);
 
 	SecretManager &secret_manager;
+	mutex lock;
 	case_insensitive_set_t persistent_secrets;
 };
 

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -646,6 +646,7 @@ DefaultSecretGenerator::DefaultSecretGenerator(Catalog &catalog, SecretManager &
 }
 
 unique_ptr<CatalogEntry> DefaultSecretGenerator::CreateDefaultEntryInternal(const string &entry_name) {
+	lock_guard<mutex> guard(lock);
 	auto secret_lu = persistent_secrets.find(entry_name);
 	if (secret_lu == persistent_secrets.end()) {
 		return nullptr;
@@ -718,6 +719,7 @@ unique_ptr<CatalogEntry> DefaultSecretGenerator::CreateDefaultEntry(ClientContex
 vector<string> DefaultSecretGenerator::GetDefaultEntries() {
 	vector<string> ret;
 
+	lock_guard<mutex> guard(lock);
 	for (const auto &res : persistent_secrets) {
 		ret.push_back(res);
 	}


### PR DESCRIPTION
`persistent_secrets` are modified - and we can load secrets from multiple connections, so this needs a lock.