### PR TITLE
initialize the read with the OpenFile info and not just the path

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1116,7 +1116,7 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 			state.prefetch_mode = false;
 		}
 
-		state.file_handle = fs.OpenFile(file_handle->GetPath(), flags);
+		state.file_handle = fs.OpenFile(file, flags);
 	}
 	state.adaptive_filter.reset();
 	state.scan_filters.clear();


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/4961

Another part of the fix is to fix the HTTPFileCache, but that needs to be done in the httpfs extension. 
This uses the OpenFileInfo `file` to create the new file handle. This way, we also copy all of the extended properties of the OpenFileInfo like `validate_external_cache` and `file_size`. This makes it easier to prevent unnecessary extra (1) head requests on large files. But if there are multiple files that are all a bit larger, this these HEAD requests add up