### PR TITLE
Don't bail on TopN optimization if we don't have a cardinality

### DIFF
--- a/src/include/duckdb/optimizer/topn_optimizer.hpp
+++ b/src/include/duckdb/optimizer/topn_optimizer.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/common/constants.hpp"
 
 namespace duckdb {
@@ -17,13 +18,18 @@ class Optimizer;
 
 class TopN {
 public:
+	explicit TopN(ClientContext &context);
+
 	//! Optimize ORDER BY + LIMIT to TopN
 	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op);
 	//! Whether we can perform the optimization on this operator
-	static bool CanOptimize(LogicalOperator &op);
+	static bool CanOptimize(LogicalOperator &op, optional_ptr<ClientContext> context = nullptr);
 
 private:
 	void PushdownDynamicFilters(LogicalTopN &op);
+
+private:
+	ClientContext &context;
 };
 
 } // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -224,7 +224,7 @@ void Optimizer::RunBuiltInOptimizers() {
 
 	// transform ORDER BY + LIMIT to TopN
 	RunOptimizer(OptimizerType::TOP_N, [&]() {
-		TopN topn;
+		TopN topn(context);
 		plan = topn.Optimize(std::move(plan));
 	});
 

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -14,7 +14,10 @@
 
 namespace duckdb {
 
-bool TopN::CanOptimize(LogicalOperator &op) {
+TopN::TopN(ClientContext &context_p) : context(context_p) {
+}
+
+bool TopN::CanOptimize(LogicalOperator &op, optional_ptr<ClientContext> context) {
 	if (op.type == LogicalOperatorType::LOGICAL_LIMIT) {
 		auto &limit = op.Cast<LogicalLimit>();
 
@@ -28,14 +31,21 @@ bool TopN::CanOptimize(LogicalOperator &op) {
 		}
 
 		auto child_op = op.children[0].get();
+		if (context) {
+			// estimate child cardinality if the context is available
+			child_op->EstimateCardinality(*context);
+		}
 
-		auto constant_limit = static_cast<double>(limit.limit_val.GetConstantValue());
-		auto child_card = static_cast<double>(child_op->estimated_cardinality);
+		if (child_op->has_estimated_cardinality) {
+			// only bail if we have an estimated cardinality
+			auto constant_limit = static_cast<double>(limit.limit_val.GetConstantValue());
+			auto child_card = static_cast<double>(child_op->estimated_cardinality);
 
-		// if the child cardinality is not 98 times more than the
-		bool limit_is_large = constant_limit > 5000;
-		if (constant_limit > child_card * 0.007 && limit_is_large) {
-			return false;
+			// if the child cardinality is not 98 times more than the
+			bool limit_is_large = constant_limit > 5000;
+			if (constant_limit > child_card * 0.007 && limit_is_large) {
+				return false;
+			}
 		}
 
 		while (child_op->type == LogicalOperatorType::LOGICAL_PROJECTION) {
@@ -116,7 +126,7 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 }
 
 unique_ptr<LogicalOperator> TopN::Optimize(unique_ptr<LogicalOperator> op) {
-	if (CanOptimize(*op)) {
+	if (CanOptimize(*op, &context)) {
 
 		vector<unique_ptr<LogicalOperator>> projections;
 

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -37,11 +37,11 @@ bool TopN::CanOptimize(LogicalOperator &op, optional_ptr<ClientContext> context)
 		}
 
 		if (child_op->has_estimated_cardinality) {
-			// only bail if we have an estimated cardinality
+			// only check if we should switch to full sorting if we have estimated cardinality
 			auto constant_limit = static_cast<double>(limit.limit_val.GetConstantValue());
 			auto child_card = static_cast<double>(child_op->estimated_cardinality);
 
-			// if the child cardinality is not 98 times more than the
+			// if the limit is > 0.7% of the child cardinality, sorting the whole table is faster
 			bool limit_is_large = constant_limit > 5000;
 			if (constant_limit > child_card * 0.007 && limit_is_large) {
 				return false;


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/duckdb/duckdb/pull/17140

The computation was wrong because it did not check `has_estimated_cardinality` before grabbing it. This PR computes the cardinality if it was not yet there. These fields should probably be changed to `optional_idx` in the future so this doesn't happen.