### PR TITLE
Give a default value to `HTTPUtil::InitializeParameters`

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -229,10 +229,10 @@ public:
 
 	virtual string GetName() const;
 
-	virtual unique_ptr<HTTPParams> InitializeParameters(DatabaseInstance &db, const string &path);
-	virtual unique_ptr<HTTPParams> InitializeParameters(ClientContext &context, const string &path);
+	virtual unique_ptr<HTTPParams> InitializeParameters(DatabaseInstance &db, const string &path = "");
+	virtual unique_ptr<HTTPParams> InitializeParameters(ClientContext &context, const string &path = "");
 	virtual unique_ptr<HTTPParams> InitializeParameters(optional_ptr<FileOpener> opener,
-	                                                    optional_ptr<FileOpenerInfo> info);
+	                                                    optional_ptr<FileOpenerInfo> info = nullptr);
 
 	virtual unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port);
 


### PR DESCRIPTION
When working on related code I realized that `optional_ptr<FileOpenerInfo>` was not used in the `HTTPUtil::InitializeParameters` method and hence the `url` wasn't either in the related helper.

This PR simply removes any unused parameters.