### PR TITLE
[Python][Dev] Ignore `DYNAMIC_FILTER` TableFilters in filter pushdown

### DIFF
--- a/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
@@ -447,6 +447,10 @@ py::object TransformFilterRecursive(TableFilter &filter, vector<string> column_r
 		}
 		return TransformFilterRecursive(or_filter, column_ref, timezone_config, type);
 	}
+	case TableFilterType::DYNAMIC_FILTER: {
+		//! Ignore dynamic filters for now, not necessary for correctness
+		return py::none();
+	}
 	default:
 		throw NotImplementedException("Pushdown Filter Type %s is not currently supported in PyArrow Scans",
 		                              EnumUtil::ToString(filter.filter_type));

--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -1013,3 +1013,9 @@ class TestArrowFilterPushdown(object):
         assert_equal_results(duckdb_cursor, arrow_table, "select * from {table} where a <= 'NaN'::FLOAT")
         assert_equal_results(duckdb_cursor, arrow_table, "select * from {table} where a = 'NaN'::FLOAT")
         assert_equal_results(duckdb_cursor, arrow_table, "select * from {table} where a != 'NaN'::FLOAT")
+
+    def test_dynamic_filter(self, duckdb_cursor):
+        t = pa.Table.from_pydict({"a": [3, 24, 234, 234, 234, 234, 234, 234, 234, 45, 2, 5, 2, 45]})
+        duckdb_cursor.register("t", t)
+        res = duckdb_cursor.sql("SELECT a FROM t ORDER BY a LIMIT 11").fetchall()
+        assert len(res) == 11


### PR DESCRIPTION
This PR fixes #17638 