### PR TITLE
Output hashes in unittest and fix order

### DIFF
--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -229,16 +229,18 @@ bool TestResultHelper::CheckQueryResult(const Query &query, ExecuteContext &cont
 				hash_compare_error = entry->second != hash_value;
 			}
 		}
+		string expected_hash;
 		if (result_is_hash) {
+			expected_hash = values[0];
 			D_ASSERT(values.size() == 1);
-			hash_compare_error = values[0] != hash_value;
+			hash_compare_error = expected_hash != hash_value;
 		}
 		if (hash_compare_error) {
 			QueryResult *expected_result = nullptr;
 			if (runner.result_label_map.find(query_label) != runner.result_label_map.end()) {
 				expected_result = runner.result_label_map[query_label].get();
 			}
-			logger.WrongResultHash(expected_result, result);
+			logger.WrongResultHash(expected_result, result, expected_hash, hash_value);
 			return false;
 		}
 		REQUIRE(!hash_compare_error);

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -243,7 +243,8 @@ void SQLLogicTestLogger::SplitMismatch(idx_t row_number, idx_t expected_column_c
 	PrintLineSep();
 }
 
-void SQLLogicTestLogger::WrongResultHash(QueryResult *expected_result, MaterializedQueryResult &result, string &expected_hash, string &actual_hash) {
+void SQLLogicTestLogger::WrongResultHash(QueryResult *expected_result, MaterializedQueryResult &result,
+                                         const string &expected_hash, const string &actual_hash) {
 	PrintErrorHeader("Wrong result hash!");
 	PrintLineSep();
 	PrintSQL();

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -243,21 +243,28 @@ void SQLLogicTestLogger::SplitMismatch(idx_t row_number, idx_t expected_column_c
 	PrintLineSep();
 }
 
-void SQLLogicTestLogger::WrongResultHash(QueryResult *expected_result, MaterializedQueryResult &result) {
-	if (expected_result) {
-		expected_result->Print();
-	} else {
-		std::cerr << "???" << std::endl;
-	}
+void SQLLogicTestLogger::WrongResultHash(QueryResult *expected_result, MaterializedQueryResult &result, string &expected_hash, string &actual_hash) {
 	PrintErrorHeader("Wrong result hash!");
 	PrintLineSep();
 	PrintSQL();
 	PrintLineSep();
 	PrintHeader("Expected result:");
 	PrintLineSep();
+	if (expected_result) {
+		expected_result->Print();
+	} else {
+		std::cerr << "???" << std::endl;
+	}
+	PrintLineSep();
+	PrintHeader("Expected result hash:");
+	std::cerr << expected_hash << std::endl;
+	PrintLineSep();
 	PrintHeader("Actual result:");
 	PrintLineSep();
 	result.Print();
+	PrintLineSep();
+	PrintHeader("Actual result hash");
+	std::cerr << actual_hash << std::endl;
 }
 
 void SQLLogicTestLogger::UnexpectedStatement(bool expect_ok, MaterializedQueryResult &result) {

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -46,7 +46,7 @@ public:
 	void ColumnCountMismatchCorrectResult(idx_t original_expected_columns, idx_t expected_column_count,
 	                                      MaterializedQueryResult &result);
 	void SplitMismatch(idx_t row_number, idx_t expected_column_count, idx_t split_count);
-	void WrongResultHash(QueryResult *expected_result, MaterializedQueryResult &result);
+	void WrongResultHash(QueryResult *expected_result, MaterializedQueryResult &result, string &expected_hash, string &actual_hash);
 	void UnexpectedStatement(bool expect_ok, MaterializedQueryResult &result);
 	void ExpectedErrorMismatch(const string &expected_error, MaterializedQueryResult &result);
 	void InternalException(MaterializedQueryResult &result);

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -46,7 +46,8 @@ public:
 	void ColumnCountMismatchCorrectResult(idx_t original_expected_columns, idx_t expected_column_count,
 	                                      MaterializedQueryResult &result);
 	void SplitMismatch(idx_t row_number, idx_t expected_column_count, idx_t split_count);
-	void WrongResultHash(QueryResult *expected_result, MaterializedQueryResult &result, string &expected_hash, string &actual_hash);
+	void WrongResultHash(QueryResult *expected_result, MaterializedQueryResult &result, const string &expected_hash,
+	                     const string &actual_hash);
 	void UnexpectedStatement(bool expect_ok, MaterializedQueryResult &result);
 	void ExpectedErrorMismatch(const string &expected_error, MaterializedQueryResult &result);
 	void InternalException(MaterializedQueryResult &result);


### PR DESCRIPTION
Currently, no information about the hashes is shown when a unittest fails because of a hash value mismatch, even though this information is readily available.

This small PR aims to include this information in the output while also making it less confusing: before, it printed an 'Expected result' header without supplying any results (or rather, printing it in the previous lines before the introductory header). 

```
	PrintHeader("Expected result:");
	PrintLineSep();        <--- There should be a result here
	PrintHeader("Actual result:");
```
