### PR TITLE
[C API] Expose duckdb_scalar_function_bind_get_extra_info

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -3343,6 +3343,14 @@ Retrieves the extra info of the function as set in `duckdb_scalar_function_set_e
 DUCKDB_C_API void *duckdb_scalar_function_get_extra_info(duckdb_function_info info);
 
 /*!
+Retrieves the extra info of the function as set in the bind info.
+
+* @param info The info object.
+* @return The extra info.
+*/
+DUCKDB_C_API void *duckdb_scalar_function_bind_get_extra_info(duckdb_bind_info info);
+
+/*!
 Gets the scalar function's bind data set by `duckdb_scalar_function_set_bind_data`.
 
 Note that the bind data is read-only.

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -485,6 +485,7 @@ typedef struct {
 	void (*duckdb_scalar_function_set_bind_data)(duckdb_bind_info info, void *bind_data,
 	                                             duckdb_delete_callback_t destroy);
 	void *(*duckdb_scalar_function_get_bind_data)(duckdb_function_info info);
+	void *(*duckdb_scalar_function_bind_get_extra_info)(duckdb_bind_info info);
 	// New string functions that are added
 
 	char *(*duckdb_value_to_string)(duckdb_value value);
@@ -927,6 +928,7 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_scalar_function_get_client_context = duckdb_scalar_function_get_client_context;
 	result.duckdb_scalar_function_set_bind_data = duckdb_scalar_function_set_bind_data;
 	result.duckdb_scalar_function_get_bind_data = duckdb_scalar_function_get_bind_data;
+	result.duckdb_scalar_function_bind_get_extra_info = duckdb_scalar_function_bind_get_extra_info;
 	result.duckdb_value_to_string = duckdb_value_to_string;
 	result.duckdb_create_map_value = duckdb_create_map_value;
 	result.duckdb_create_union_value = duckdb_create_union_value;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_scalar_function_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_scalar_function_functions.json
@@ -6,6 +6,7 @@
     "duckdb_scalar_function_bind_set_error",
     "duckdb_scalar_function_get_client_context",
     "duckdb_scalar_function_set_bind_data",
-    "duckdb_scalar_function_get_bind_data"
+    "duckdb_scalar_function_get_bind_data",
+    "duckdb_scalar_function_bind_get_extra_info"
   ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
@@ -299,6 +299,23 @@
             }
         },
         {
+            "name": "duckdb_scalar_function_bind_get_extra_info",
+            "return_type": "void *",
+            "params": [
+                {
+                    "type": "duckdb_bind_info",
+                    "name": "info"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the extra info of the function as set in the bind info.\n\n",
+                "param_comments": {
+                    "info": "The info object."
+                },
+                "return_value": "The extra info."
+            }
+        },
+        {
             "name": "duckdb_scalar_function_get_bind_data",
             "return_type": "void *",
             "params": [

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -558,6 +558,7 @@ typedef struct {
 	void (*duckdb_scalar_function_set_bind_data)(duckdb_bind_info info, void *bind_data,
 	                                             duckdb_delete_callback_t destroy);
 	void *(*duckdb_scalar_function_get_bind_data)(duckdb_function_info info);
+	void *(*duckdb_scalar_function_bind_get_extra_info)(duckdb_bind_info info);
 #endif
 
 // New string functions that are added
@@ -1013,11 +1014,12 @@ typedef struct {
 #define duckdb_get_table_names                  duckdb_ext_api.duckdb_get_table_names
 
 // Version unstable_new_scalar_function_functions
-#define duckdb_scalar_function_set_bind           duckdb_ext_api.duckdb_scalar_function_set_bind
-#define duckdb_scalar_function_set_bind_data      duckdb_ext_api.duckdb_scalar_function_set_bind_data
-#define duckdb_scalar_function_bind_set_error     duckdb_ext_api.duckdb_scalar_function_bind_set_error
-#define duckdb_scalar_function_get_bind_data      duckdb_ext_api.duckdb_scalar_function_get_bind_data
-#define duckdb_scalar_function_get_client_context duckdb_ext_api.duckdb_scalar_function_get_client_context
+#define duckdb_scalar_function_set_bind            duckdb_ext_api.duckdb_scalar_function_set_bind
+#define duckdb_scalar_function_set_bind_data       duckdb_ext_api.duckdb_scalar_function_set_bind_data
+#define duckdb_scalar_function_bind_set_error      duckdb_ext_api.duckdb_scalar_function_bind_set_error
+#define duckdb_scalar_function_bind_get_extra_info duckdb_ext_api.duckdb_scalar_function_bind_get_extra_info
+#define duckdb_scalar_function_get_bind_data       duckdb_ext_api.duckdb_scalar_function_get_bind_data
+#define duckdb_scalar_function_get_client_context  duckdb_ext_api.duckdb_scalar_function_get_client_context
 
 // Version unstable_new_string_functions
 #define duckdb_value_to_string duckdb_ext_api.duckdb_value_to_string

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -227,6 +227,14 @@ void *duckdb_scalar_function_get_extra_info(duckdb_function_info info) {
 	return function_info.bind_data.info.extra_info;
 }
 
+void *duckdb_scalar_function_bind_get_extra_info(duckdb_bind_info info) {
+	if (!info) {
+		return nullptr;
+	}
+	auto &bind_info = GetCScalarFunctionBindInfo(info);
+	return bind_info.bind_data.info.extra_info;
+}
+
 void *duckdb_scalar_function_get_bind_data(duckdb_function_info info) {
 	if (!info) {
 		return nullptr;


### PR DESCRIPTION
```c
/*!
Retrieves the extra info of the function as set in the bind info.
* @param info The info object.
* @return The extra info.
*/
DUCKDB_C_API void *duckdb_scalar_function_bind_get_extra_info(duckdb_bind_info info);
```