### PR TITLE
Add rowsort in generate_series test #43

### DIFF
--- a/test/sql/table_function/test_range_function.test
+++ b/test/sql/table_function/test_range_function.test
@@ -223,9 +223,9 @@ select * from generate_series(0, 10, 9223372036854775807);
 ----
 0
 
-query II
+query II rowsort
 select * FROM generate_series(1, 3, 1) AS _(x), generate_series(x, 2, 1) AS __(y);
 ----
-2	2
 1	1
 1	2
+2	2


### PR DESCRIPTION
Make the test non-sensitive to ordering, as set threads=1 gives correct answer but in different order. (discussed [here](https://github.com/duckdblabs/motherduck/issues/317))