### PR TITLE
Issue #17040: FILL Window Function 

### DIFF
--- a/benchmark/micro/window/window_fill.benchmark
+++ b/benchmark/micro/window/window_fill.benchmark
@@ -1,0 +1,33 @@
+# name: benchmark/micro/window/window_fill.benchmark
+# description: Measure the perfomance of FILL
+# group: [window]
+
+name FillPerformance
+group micro
+subgroup window
+
+argument sf 10
+argument errors 0.1
+argument keys 4
+
+load
+select setseed(0.8675309);
+create or replace table data as (
+	select
+		k::TINYINT as k,
+		(case when random() > ${errors} then m - 1704067200000 else null end) as v,
+		m,
+	from range(1704067200000, 1704067200000 + ${sf} * 1_000_000 * 10, 10) times(m)
+	cross join range(${keys}) keys(k)
+);
+
+run
+SELECT
+	m,
+	k,
+	fill(v) OVER (PARTITION BY k ORDER BY m) as v
+FROM
+	data
+qualify v <> m - 1704067200000;
+
+result III

--- a/extension/core_functions/aggregate/holistic/mad.cpp
+++ b/extension/core_functions/aggregate/holistic/mad.cpp
@@ -1,4 +1,3 @@
-#include "duckdb/execution/expression_executor.hpp"
 #include "core_functions/aggregate/holistic_functions.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
@@ -182,7 +181,7 @@ struct MedianAbsoluteDeviationOperation : QuantileOperation {
 		auto &bind_data = finalize_data.input.bind_data->Cast<QuantileBindData>();
 		D_ASSERT(bind_data.quantiles.size() == 1);
 		const auto &q = bind_data.quantiles[0];
-		Interpolator<false> interp(q, state.v.size(), false);
+		QuantileInterpolator<false> interp(q, state.v.size(), false);
 		const auto med = interp.template Operation<INPUT_TYPE, MEDIAN_TYPE>(state.v.data(), finalize_data.result);
 
 		MadAccessor<INPUT_TYPE, T, MEDIAN_TYPE> accessor(med);
@@ -237,7 +236,7 @@ struct MedianAbsoluteDeviationOperation : QuantileOperation {
 		ReuseIndexes(index2, frames, prevs);
 		std::partition(index2, index2 + window_state.count, included);
 
-		Interpolator<false> interp(quantile, n, false);
+		QuantileInterpolator<false> interp(quantile, n, false);
 
 		// Compute mad from the second index
 		using ID = QuantileIndirect<INPUT_TYPE>;

--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -137,59 +137,15 @@ unique_ptr<FunctionData> QuantileBindData::Deserialize(Deserializer &deserialize
 }
 
 //===--------------------------------------------------------------------===//
-// Cast Interpolation
+// Quantile Casts
 //===--------------------------------------------------------------------===//
 template <>
-interval_t CastInterpolation::Cast(const dtime_t &src, Vector &result) {
+interval_t QuantileCast::Operation(const dtime_t &src, Vector &result) {
 	return {0, 0, src.micros};
 }
 
 template <>
-double CastInterpolation::Interpolate(const double &lo, const double d, const double &hi) {
-	return lo * (1.0 - d) + hi * d;
-}
-
-template <>
-dtime_t CastInterpolation::Interpolate(const dtime_t &lo, const double d, const dtime_t &hi) {
-	return dtime_t(std::llround(static_cast<double>(lo.micros) * (1.0 - d) + static_cast<double>(hi.micros) * d));
-}
-
-template <>
-timestamp_t CastInterpolation::Interpolate(const timestamp_t &lo, const double d, const timestamp_t &hi) {
-	return timestamp_t(std::llround(static_cast<double>(lo.value) * (1.0 - d) + static_cast<double>(hi.value) * d));
-}
-
-template <>
-hugeint_t CastInterpolation::Interpolate(const hugeint_t &lo, const double d, const hugeint_t &hi) {
-	return Hugeint::Convert(Interpolate(Hugeint::Cast<double>(lo), d, Hugeint::Cast<double>(hi)));
-}
-
-template <>
-uhugeint_t CastInterpolation::Interpolate(const uhugeint_t &lo, const double d, const uhugeint_t &hi) {
-	return Hugeint::Convert(Interpolate(Uhugeint::Cast<double>(lo), d, Uhugeint::Cast<double>(hi)));
-}
-
-static interval_t MultiplyByDouble(const interval_t &i, const double &d) { // NOLINT
-	D_ASSERT(d >= 0 && d <= 1);
-	return Interval::FromMicro(std::llround(static_cast<double>(Interval::GetMicro(i)) * d));
-}
-
-inline interval_t operator+(const interval_t &lhs, const interval_t &rhs) {
-	return Interval::FromMicro(Interval::GetMicro(lhs) + Interval::GetMicro(rhs));
-}
-
-inline interval_t operator-(const interval_t &lhs, const interval_t &rhs) {
-	return Interval::FromMicro(Interval::GetMicro(lhs) - Interval::GetMicro(rhs));
-}
-
-template <>
-interval_t CastInterpolation::Interpolate(const interval_t &lo, const double d, const interval_t &hi) {
-	const interval_t delta = hi - lo;
-	return lo + MultiplyByDouble(delta, d);
-}
-
-template <>
-string_t CastInterpolation::Cast(const string_t &src, Vector &result) {
+string_t QuantileCast::Operation(const string_t &src, Vector &result) {
 	return StringVector::AddStringOrBlob(result, src);
 }
 
@@ -207,7 +163,7 @@ struct QuantileScalarOperation : public QuantileOperation {
 		D_ASSERT(finalize_data.input.bind_data);
 		auto &bind_data = finalize_data.input.bind_data->Cast<QuantileBindData>();
 		D_ASSERT(bind_data.quantiles.size() == 1);
-		Interpolator<DISCRETE> interp(bind_data.quantiles[0], state.v.size(), bind_data.desc);
+		QuantileInterpolator<DISCRETE> interp(bind_data.quantiles[0], state.v.size(), bind_data.desc);
 		target = interp.template Operation<typename STATE::InputType, T>(state.v.data(), finalize_data.result);
 	}
 
@@ -269,7 +225,7 @@ struct QuantileScalarFallback : QuantileOperation {
 		D_ASSERT(finalize_data.input.bind_data);
 		auto &bind_data = finalize_data.input.bind_data->Cast<QuantileBindData>();
 		D_ASSERT(bind_data.quantiles.size() == 1);
-		Interpolator<true> interp(bind_data.quantiles[0], state.v.size(), bind_data.desc);
+		QuantileInterpolator<true> interp(bind_data.quantiles[0], state.v.size(), bind_data.desc);
 		auto interpolation_result = interp.InterpolateInternal<string_t>(state.v.data());
 		CreateSortKeyHelpers::DecodeSortKey(interpolation_result, finalize_data.result, finalize_data.result_idx,
 		                                    OrderModifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST));
@@ -304,7 +260,7 @@ struct QuantileListOperation : QuantileOperation {
 		idx_t lower = 0;
 		for (const auto &q : bind_data.order) {
 			const auto &quantile = bind_data.quantiles[q];
-			Interpolator<DISCRETE> interp(quantile, state.v.size(), bind_data.desc);
+			QuantileInterpolator<DISCRETE> interp(quantile, state.v.size(), bind_data.desc);
 			interp.begin = lower;
 			rdata[ridx + q] = interp.template Operation<typename STATE::InputType, CHILD_TYPE>(v_t, result);
 			lower = interp.FRN;
@@ -375,7 +331,7 @@ struct QuantileListFallback : QuantileOperation {
 		idx_t lower = 0;
 		for (const auto &q : bind_data.order) {
 			const auto &quantile = bind_data.quantiles[q];
-			Interpolator<true> interp(quantile, state.v.size(), bind_data.desc);
+			QuantileInterpolator<true> interp(quantile, state.v.size(), bind_data.desc);
 			interp.begin = lower;
 			auto interpolation_result = interp.InterpolateInternal<string_t>(state.v.data());
 			CreateSortKeyHelpers::DecodeSortKey(interpolation_result, result, ridx + q,

--- a/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "core_functions/aggregate/quantile_helpers.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/operator/interpolate.hpp"
 #include "duckdb/common/operator/multiply.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/function/window/window_index_tree.hpp"
@@ -148,39 +149,22 @@ struct QuantileCompare {
 	}
 };
 
-struct CastInterpolation {
+struct QuantileCast {
 	template <class INPUT_TYPE, class TARGET_TYPE>
-	static inline TARGET_TYPE Cast(const INPUT_TYPE &src, Vector &result) {
+	static inline TARGET_TYPE Operation(const INPUT_TYPE &src, Vector &result) {
 		return Cast::Operation<INPUT_TYPE, TARGET_TYPE>(src);
-	}
-	template <typename TARGET_TYPE>
-	static inline TARGET_TYPE Interpolate(const TARGET_TYPE &lo, const double d, const TARGET_TYPE &hi) {
-		const auto delta = hi - lo;
-		return LossyNumericCast<TARGET_TYPE>(lo + delta * d);
 	}
 };
 
 template <>
-interval_t CastInterpolation::Cast(const dtime_t &src, Vector &result);
+interval_t QuantileCast::Operation(const dtime_t &src, Vector &result);
 template <>
-double CastInterpolation::Interpolate(const double &lo, const double d, const double &hi);
-template <>
-dtime_t CastInterpolation::Interpolate(const dtime_t &lo, const double d, const dtime_t &hi);
-template <>
-timestamp_t CastInterpolation::Interpolate(const timestamp_t &lo, const double d, const timestamp_t &hi);
-template <>
-hugeint_t CastInterpolation::Interpolate(const hugeint_t &lo, const double d, const hugeint_t &hi);
-template <>
-uhugeint_t CastInterpolation::Interpolate(const uhugeint_t &lo, const double d, const uhugeint_t &hi);
-template <>
-interval_t CastInterpolation::Interpolate(const interval_t &lo, const double d, const interval_t &hi);
-template <>
-string_t CastInterpolation::Cast(const string_t &src, Vector &result);
+string_t QuantileCast::Operation(const string_t &src, Vector &result);
 
 // Continuous interpolation
 template <bool DISCRETE>
-struct Interpolator {
-	Interpolator(const QuantileValue &q, const idx_t n_p, const bool desc_p)
+struct QuantileInterpolator {
+	QuantileInterpolator(const QuantileValue &q, const idx_t n_p, const bool desc_p)
 	    : desc(desc_p), RN((double)(n_p - 1) * q.dbl), FRN(ExactNumericCast<idx_t>(floor(RN))),
 	      CRN(ExactNumericCast<idx_t>(ceil(RN))), begin(0), end(n_p) {
 	}
@@ -189,11 +173,11 @@ struct Interpolator {
 	TARGET_TYPE Interpolate(INPUT_TYPE lidx, INPUT_TYPE hidx, Vector &result, const ACCESSOR &accessor) const {
 		using ACCESS_TYPE = typename ACCESSOR::RESULT_TYPE;
 		if (lidx == hidx) {
-			return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(lidx), result);
+			return QuantileCast::Operation<ACCESS_TYPE, TARGET_TYPE>(accessor(lidx), result);
 		} else {
-			auto lo = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(lidx), result);
-			auto hi = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(hidx), result);
-			return CastInterpolation::Interpolate<TARGET_TYPE>(lo, RN - FRN, hi);
+			auto lo = QuantileCast::Operation<ACCESS_TYPE, TARGET_TYPE>(accessor(lidx), result);
+			auto hi = QuantileCast::Operation<ACCESS_TYPE, TARGET_TYPE>(accessor(hidx), result);
+			return InterpolateOperator::Operation<TARGET_TYPE>(lo, RN - FRN, hi);
 		}
 	}
 
@@ -203,24 +187,24 @@ struct Interpolator {
 		QuantileCompare<ACCESSOR> comp(accessor, desc);
 		if (CRN == FRN) {
 			std::nth_element(v_t + begin, v_t + FRN, v_t + end, comp);
-			return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+			return QuantileCast::Operation<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
 		} else {
 			std::nth_element(v_t + begin, v_t + FRN, v_t + end, comp);
 			std::nth_element(v_t + FRN, v_t + CRN, v_t + end, comp);
-			auto lo = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
-			auto hi = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[CRN]), result);
-			return CastInterpolation::Interpolate<TARGET_TYPE>(lo, RN - FRN, hi);
+			auto lo = QuantileCast::Operation<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+			auto hi = QuantileCast::Operation<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[CRN]), result);
+			return InterpolateOperator::Operation<TARGET_TYPE>(lo, RN - FRN, hi);
 		}
 	}
 
 	template <class INPUT_TYPE, class TARGET_TYPE>
 	inline TARGET_TYPE Extract(const INPUT_TYPE *dest, Vector &result) const {
 		if (CRN == FRN) {
-			return CastInterpolation::Cast<INPUT_TYPE, TARGET_TYPE>(dest[0], result);
+			return QuantileCast::Operation<INPUT_TYPE, TARGET_TYPE>(dest[0], result);
 		} else {
-			auto lo = CastInterpolation::Cast<INPUT_TYPE, TARGET_TYPE>(dest[0], result);
-			auto hi = CastInterpolation::Cast<INPUT_TYPE, TARGET_TYPE>(dest[1], result);
-			return CastInterpolation::Interpolate<TARGET_TYPE>(lo, RN - FRN, hi);
+			auto lo = QuantileCast::Operation<INPUT_TYPE, TARGET_TYPE>(dest[0], result);
+			auto hi = QuantileCast::Operation<INPUT_TYPE, TARGET_TYPE>(dest[1], result);
+			return InterpolateOperator::Operation<TARGET_TYPE>(lo, RN - FRN, hi);
 		}
 	}
 
@@ -235,7 +219,7 @@ struct Interpolator {
 
 // Discrete "interpolation"
 template <>
-struct Interpolator<true> {
+struct QuantileInterpolator<true> {
 	static inline idx_t Index(const QuantileValue &q, const idx_t n) {
 		idx_t floored;
 		switch (q.val.type().id()) {
@@ -259,14 +243,14 @@ struct Interpolator<true> {
 		return MaxValue<idx_t>(1, n - floored) - 1;
 	}
 
-	Interpolator(const QuantileValue &q, const idx_t n_p, bool desc_p)
+	QuantileInterpolator(const QuantileValue &q, const idx_t n_p, bool desc_p)
 	    : desc(desc_p), FRN(Index(q, n_p)), CRN(FRN), begin(0), end(n_p) {
 	}
 
 	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
 	TARGET_TYPE Interpolate(INPUT_TYPE lidx, INPUT_TYPE hidx, Vector &result, const ACCESSOR &accessor) const {
 		using ACCESS_TYPE = typename ACCESSOR::RESULT_TYPE;
-		return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(lidx), result);
+		return QuantileCast::Operation<ACCESS_TYPE, TARGET_TYPE>(accessor(lidx), result);
 	}
 
 	template <class INPUT_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
@@ -279,12 +263,12 @@ struct Interpolator<true> {
 	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
 	TARGET_TYPE Operation(INPUT_TYPE *v_t, Vector &result, const ACCESSOR &accessor = ACCESSOR()) const {
 		using ACCESS_TYPE = typename ACCESSOR::RESULT_TYPE;
-		return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(InterpolateInternal(v_t, accessor), result);
+		return QuantileCast::Operation<ACCESS_TYPE, TARGET_TYPE>(InterpolateInternal(v_t, accessor), result);
 	}
 
 	template <class INPUT_TYPE, class TARGET_TYPE>
 	TARGET_TYPE Extract(const INPUT_TYPE *dest, Vector &result) const {
-		return CastInterpolation::Cast<INPUT_TYPE, TARGET_TYPE>(dest[0], result);
+		return QuantileCast::Operation<INPUT_TYPE, TARGET_TYPE>(dest[0], result);
 	}
 
 	const bool desc;
@@ -375,7 +359,7 @@ struct QuantileSortTree {
 		index_tree->Build();
 
 		//	Find the interpolated indicies within the frame
-		Interpolator<DISCRETE> interp(q, n, false);
+		QuantileInterpolator<DISCRETE> interp(q, n, false);
 		const auto lo_data = SelectNth(frames, interp.FRN);
 		auto hi_data = lo_data;
 		if (interp.CRN != interp.FRN) {
@@ -411,7 +395,7 @@ struct QuantileSortTree {
 		ID indirect(data);
 		for (const auto &q : bind_data.order) {
 			const auto &quantile = bind_data.quantiles[q];
-			Interpolator<DISCRETE> interp(quantile, n, false);
+			QuantileInterpolator<DISCRETE> interp(quantile, n, false);
 
 			const auto lo_data = SelectNth(frames, interp.FRN);
 			auto hi_data = lo_data;

--- a/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
@@ -171,6 +171,8 @@ timestamp_t CastInterpolation::Interpolate(const timestamp_t &lo, const double d
 template <>
 hugeint_t CastInterpolation::Interpolate(const hugeint_t &lo, const double d, const hugeint_t &hi);
 template <>
+uhugeint_t CastInterpolation::Interpolate(const uhugeint_t &lo, const double d, const uhugeint_t &hi);
+template <>
 interval_t CastInterpolation::Interpolate(const interval_t &lo, const double d, const interval_t &hi);
 template <>
 string_t CastInterpolation::Cast(const string_t &src, Vector &result);

--- a/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
@@ -201,7 +201,7 @@ struct WindowQuantileState {
 		} else if (s) {
 			// Find the position(s) needed
 			try {
-				Interpolator<DISCRETE> interp(q, s->size(), false);
+				QuantileInterpolator<DISCRETE> interp(q, s->size(), false);
 				s->at(interp.FRN, interp.CRN - interp.FRN + 1, skips);
 				array<INPUT_TYPE, 2> dest;
 				dest[0] = skips[0].second;

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1543,6 +1543,7 @@ const StringUtil::EnumStringLiteral *GetExpressionTypeValues() {
 		{ static_cast<uint32_t>(ExpressionType::WINDOW_LEAD), "WINDOW_LEAD" },
 		{ static_cast<uint32_t>(ExpressionType::WINDOW_LAG), "WINDOW_LAG" },
 		{ static_cast<uint32_t>(ExpressionType::WINDOW_NTH_VALUE), "WINDOW_NTH_VALUE" },
+		{ static_cast<uint32_t>(ExpressionType::WINDOW_FILL), "WINDOW_FILL" },
 		{ static_cast<uint32_t>(ExpressionType::FUNCTION), "FUNCTION" },
 		{ static_cast<uint32_t>(ExpressionType::BOUND_FUNCTION), "BOUND_FUNCTION" },
 		{ static_cast<uint32_t>(ExpressionType::CASE_EXPR), "CASE_EXPR" },
@@ -1577,12 +1578,12 @@ const StringUtil::EnumStringLiteral *GetExpressionTypeValues() {
 
 template<>
 const char* EnumUtil::ToChars<ExpressionType>(ExpressionType value) {
-	return StringUtil::EnumToString(GetExpressionTypeValues(), 71, "ExpressionType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetExpressionTypeValues(), 72, "ExpressionType", static_cast<uint32_t>(value));
 }
 
 template<>
 ExpressionType EnumUtil::FromString<ExpressionType>(const char *value) {
-	return static_cast<ExpressionType>(StringUtil::StringToEnum(GetExpressionTypeValues(), 71, "ExpressionType", value));
+	return static_cast<ExpressionType>(StringUtil::StringToEnum(GetExpressionTypeValues(), 72, "ExpressionType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetExtensionABITypeValues() {

--- a/src/common/enums/expression_type.cpp
+++ b/src/common/enums/expression_type.cpp
@@ -79,6 +79,8 @@ string ExpressionTypeToString(ExpressionType type) {
 		return "LAG";
 	case ExpressionType::WINDOW_NTILE:
 		return "NTILE";
+	case ExpressionType::WINDOW_FILL:
+		return "FILL";
 	case ExpressionType::FUNCTION:
 		return "FUNCTION";
 	case ExpressionType::CASE_EXPR:

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -259,6 +259,8 @@ static unique_ptr<WindowExecutor> WindowExecutorFactory(BoundWindowExpression &w
 	case ExpressionType::WINDOW_LEAD:
 	case ExpressionType::WINDOW_LAG:
 		return make_uniq<WindowLeadLagExecutor>(wexpr, context, shared);
+	case ExpressionType::WINDOW_FILL:
+		return make_uniq<WindowFillExecutor>(wexpr, context, shared);
 	case ExpressionType::WINDOW_FIRST_VALUE:
 		return make_uniq<WindowFirstValueExecutor>(wexpr, context, shared);
 	case ExpressionType::WINDOW_LAST_VALUE:

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/operator/add.hpp"
+#include "duckdb/common/operator/interpolate.hpp"
 #include "duckdb/common/operator/multiply.hpp"
 #include "duckdb/common/operator/numeric_binary_operators.hpp"
 #include "duckdb/common/operator/subtract.hpp"
@@ -1114,6 +1115,54 @@ ScalarFunctionSet OperatorModuloFun::GetFunctions() {
 	}
 
 	return modulo;
+}
+
+//===--------------------------------------------------------------------===//
+// Linear Interpolation
+//===--------------------------------------------------------------------===//
+
+template <>
+double InterpolateOperator::Operation(const double &lo, const double d, const double &hi) {
+	return lo * (1.0 - d) + hi * d;
+}
+
+template <>
+dtime_t InterpolateOperator::Operation(const dtime_t &lo, const double d, const dtime_t &hi) {
+	return dtime_t(std::llround(static_cast<double>(lo.micros) * (1.0 - d) + static_cast<double>(hi.micros) * d));
+}
+
+template <>
+timestamp_t InterpolateOperator::Operation(const timestamp_t &lo, const double d, const timestamp_t &hi) {
+	return timestamp_t(std::llround(static_cast<double>(lo.value) * (1.0 - d) + static_cast<double>(hi.value) * d));
+}
+
+template <>
+hugeint_t InterpolateOperator::Operation(const hugeint_t &lo, const double d, const hugeint_t &hi) {
+	return Hugeint::Convert(Operation(Hugeint::Cast<double>(lo), d, Hugeint::Cast<double>(hi)));
+}
+
+template <>
+uhugeint_t InterpolateOperator::Operation(const uhugeint_t &lo, const double d, const uhugeint_t &hi) {
+	return Hugeint::Convert(Operation(Uhugeint::Cast<double>(lo), d, Uhugeint::Cast<double>(hi)));
+}
+
+static interval_t MultiplyByDouble(const interval_t &i, const double &d) { // NOLINT
+	D_ASSERT(d >= 0 && d <= 1);
+	return Interval::FromMicro(std::llround(static_cast<double>(Interval::GetMicro(i)) * d));
+}
+
+inline interval_t operator+(const interval_t &lhs, const interval_t &rhs) {
+	return Interval::FromMicro(Interval::GetMicro(lhs) + Interval::GetMicro(rhs));
+}
+
+inline interval_t operator-(const interval_t &lhs, const interval_t &rhs) {
+	return Interval::FromMicro(Interval::GetMicro(lhs) - Interval::GetMicro(rhs));
+}
+
+template <>
+interval_t InterpolateOperator::Operation(const interval_t &lo, const double d, const interval_t &hi) {
+	const interval_t delta = hi - lo;
+	return lo + MultiplyByDouble(delta, d);
 }
 
 } // namespace duckdb

--- a/src/function/window/window_boundaries_state.cpp
+++ b/src/function/window/window_boundaries_state.cpp
@@ -388,6 +388,12 @@ WindowBoundsSet WindowBoundariesState::GetWindowBounds(const BoundWindowExpressi
 			result.insert(FRAME_END);
 		}
 		break;
+	case ExpressionType::WINDOW_FILL:
+		result.insert(FRAME_BEGIN);
+		result.insert(FRAME_END);
+		result.insert(VALID_BEGIN);
+		result.insert(VALID_END);
+		break;
 	case ExpressionType::WINDOW_FIRST_VALUE:
 	case ExpressionType::WINDOW_LAST_VALUE:
 	case ExpressionType::WINDOW_NTH_VALUE:
@@ -687,7 +693,7 @@ void WindowBoundariesState::ValidBegin(DataChunk &bounds, idx_t row_idx, const i
 			valid_start = partition_begin_data[chunk_idx];
 			const auto valid_end = partition_end_data[chunk_idx];
 
-			if ((valid_start < valid_end) && has_preceding_range) {
+			if (valid_start < valid_end) {
 				// Exclude any leading NULLs
 				if (range->CellIsNull(0, valid_start)) {
 					idx_t n = 1;
@@ -720,7 +726,7 @@ void WindowBoundariesState::ValidEnd(DataChunk &bounds, idx_t row_idx, const idx
 			const auto valid_start = valid_begin_data[chunk_idx];
 			valid_end = partition_end_data[chunk_idx];
 
-			if ((valid_start < valid_end) && has_following_range) {
+			if (valid_start < valid_end) {
 				// Exclude any trailing NULLs
 				if (range->CellIsNull(0, valid_end - 1)) {
 					idx_t n = 1;

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -647,14 +647,12 @@ double LossyFillCast(uhugeint_t val) {
 
 template <typename T>
 static double FillSlopeFunc(WindowCursor &cursor, idx_t row_idx, idx_t prev_valid, idx_t next_valid) {
-	const auto x = cursor.GetCell<T>(0, row_idx);
-	const auto x0 = cursor.GetCell<T>(0, prev_valid);
-	const auto x1 = cursor.GetCell<T>(0, next_valid);
+	//	Cast everything to doubles immediately so we can interpolate backwards (x < x0)
+	const auto x = LossyFillCast<double>(cursor.GetCell<T>(0, row_idx));
+	const auto x0 = LossyFillCast<double>(cursor.GetCell<T>(0, prev_valid));
+	const auto x1 = LossyFillCast<double>(cursor.GetCell<T>(0, next_valid));
 
-	const auto num = LossyFillCast<double>(x - x0);
-	const auto den = LossyFillCast<double>(x1 - x0);
-
-	return num / den;
+	return (x - x0) / (x1 - x0);
 }
 
 typedef double (*fill_slope_t)(WindowCursor &cursor, idx_t row_idx, idx_t prev_valid, idx_t next_valid);

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/function/window/window_token_tree.hpp"
 #include "duckdb/function/window/window_value_function.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
+#include "core_functions/aggregate/quantile_sort_tree.hpp"
 
 namespace duckdb {
 
@@ -620,6 +621,256 @@ void WindowNthValueExecutor::EvaluateInternal(WindowExecutorGlobalState &gstate,
 		}
 		FlatVector::SetNull(result, i, true);
 	});
+}
+
+//===--------------------------------------------------------------------===//
+// WindowFillExecutor
+//===--------------------------------------------------------------------===//
+template <class TO, class FROM>
+TO LossyFillCast(FROM val) {
+	return LossyNumericCast<TO, FROM>(val);
+}
+
+template <>
+double LossyFillCast(hugeint_t val) {
+	double d;
+	(void)Hugeint::TryCast(val, d);
+	return d;
+}
+
+template <>
+double LossyFillCast(uhugeint_t val) {
+	double d;
+	(void)Hugeint::TryCast(val, d);
+	return d;
+}
+
+template <typename T>
+static double FillSlopeFunc(WindowCursor &cursor, idx_t row_idx, idx_t prev_valid, idx_t next_valid) {
+	const auto x = cursor.GetCell<T>(0, row_idx);
+	const auto x0 = cursor.GetCell<T>(0, prev_valid);
+	const auto x1 = cursor.GetCell<T>(0, next_valid);
+
+	const auto num = LossyFillCast<double>(x - x0);
+	const auto den = LossyFillCast<double>(x1 - x0);
+
+	return num / den;
+}
+
+typedef double (*fill_slope_t)(WindowCursor &cursor, idx_t row_idx, idx_t prev_valid, idx_t next_valid);
+
+static fill_slope_t GetFillSlopeFunction(const LogicalType &type) {
+	switch (type.InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::UINT8:
+		return FillSlopeFunc<uint8_t>;
+	case PhysicalType::UINT16:
+		return FillSlopeFunc<uint16_t>;
+	case PhysicalType::UINT32:
+		return FillSlopeFunc<uint32_t>;
+	case PhysicalType::UINT64:
+		return FillSlopeFunc<uint64_t>;
+	case PhysicalType::UINT128:
+		return FillSlopeFunc<uhugeint_t>;
+	case PhysicalType::INT8:
+		return FillSlopeFunc<int8_t>;
+	case PhysicalType::INT16:
+		return FillSlopeFunc<int16_t>;
+	case PhysicalType::INT32:
+		return FillSlopeFunc<int32_t>;
+	case PhysicalType::INT64:
+		return FillSlopeFunc<int64_t>;
+	case PhysicalType::INT128:
+		return FillSlopeFunc<hugeint_t>;
+	case PhysicalType::FLOAT:
+		return FillSlopeFunc<float>;
+	case PhysicalType::DOUBLE:
+		return FillSlopeFunc<double>;
+	default:
+		throw InternalException("Unsupported FILL slow ordering type.");
+	}
+}
+
+typedef void (*fill_interpolate_t)(Vector &result, idx_t i, WindowCursor &cursor, idx_t lo, idx_t hi, double slope);
+
+template <typename T>
+static void FillInterpolateFunc(Vector &result, idx_t i, WindowCursor &cursor, idx_t lo, idx_t hi, double slope) {
+	const auto y0 = cursor.GetCell<T>(0, lo);
+	const auto y1 = cursor.GetCell<T>(0, hi);
+
+	FlatVector::SetNull(result, i, false);
+	auto data = FlatVector::GetData<T>(result);
+	data[i] = CastInterpolation::Interpolate<T>(y0, slope, y1);
+}
+
+static fill_interpolate_t GetFillInterpolateFunction(const LogicalType &type) {
+	switch (type.InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::UINT8:
+		return FillInterpolateFunc<uint8_t>;
+	case PhysicalType::UINT16:
+		return FillInterpolateFunc<uint16_t>;
+	case PhysicalType::UINT32:
+		return FillInterpolateFunc<uint32_t>;
+	case PhysicalType::UINT64:
+		return FillInterpolateFunc<uint64_t>;
+	case PhysicalType::UINT128:
+		return FillInterpolateFunc<uhugeint_t>;
+	case PhysicalType::INT8:
+		return FillInterpolateFunc<int8_t>;
+	case PhysicalType::INT16:
+		return FillInterpolateFunc<int16_t>;
+	case PhysicalType::INT32:
+		return FillInterpolateFunc<int32_t>;
+	case PhysicalType::INT64:
+		return FillInterpolateFunc<int64_t>;
+	case PhysicalType::INT128:
+		return FillInterpolateFunc<hugeint_t>;
+	case PhysicalType::FLOAT:
+		return FillInterpolateFunc<float>;
+	case PhysicalType::DOUBLE:
+		return FillInterpolateFunc<double>;
+	default:
+		throw InternalException("Unsupported FILL slow ordering type.");
+	}
+}
+
+WindowFillExecutor::WindowFillExecutor(BoundWindowExpression &wexpr, ClientContext &context,
+                                       WindowSharedExpressions &shared)
+    : WindowValueExecutor(wexpr, context, shared) {
+
+	//	We use the range ordering, even if it has not been defined
+	//	We don't need the validity mask because we have also requested the valid range for the ordering.
+	if (!range_expr) {
+		range_idx = shared.RegisterCollection(wexpr.orders[0].expression, false);
+	}
+}
+
+static void WindowFillCopy(WindowCursor &cursor, Vector &result, idx_t count, idx_t row_idx, column_t col_idx = 0) {
+	for (idx_t target_offset = 0; target_offset < count;) {
+		const auto source_offset = cursor.Seek(row_idx);
+		auto &source = cursor.chunk.data[col_idx];
+		const auto copied = MinValue<idx_t>(cursor.chunk.size() - source_offset, count - target_offset);
+		VectorOperations::Copy(source, result, source_offset + copied, source_offset, target_offset);
+		target_offset += copied;
+		row_idx += copied;
+	}
+}
+
+void WindowFillExecutor::EvaluateInternal(WindowExecutorGlobalState &gstate, WindowExecutorLocalState &lstate,
+                                          DataChunk &, Vector &result, idx_t count, idx_t row_idx) const {
+
+	auto &lvstate = lstate.Cast<WindowValueLocalState>();
+	auto &cursor = *lvstate.cursor;
+
+	//	Assume the best and just batch copy all the values
+	WindowFillCopy(cursor, result, count, row_idx, 0);
+
+	//	If all are valid, we are done
+	UnifiedVectorFormat arg_data;
+	result.ToUnifiedFormat(count, arg_data);
+	if (arg_data.validity.AllValid()) {
+		return;
+	}
+
+	//	Missing values - linear interpolation
+	// auto &gvstate = gstate.Cast<WindowValueGlobalState>();
+	auto partition_begin = FlatVector::GetData<const idx_t>(lvstate.bounds.data[PARTITION_BEGIN]);
+	auto partition_end = FlatVector::GetData<const idx_t>(lvstate.bounds.data[PARTITION_END]);
+	auto valid_begin = FlatVector::GetData<const idx_t>(lvstate.bounds.data[VALID_BEGIN]);
+	auto valid_end = FlatVector::GetData<const idx_t>(lvstate.bounds.data[VALID_END]);
+
+	auto fill_slope_func = GetFillSlopeFunction(wexpr.orders[0].expression->return_type);
+	auto &range_cursor = *lvstate.range_cursor;
+
+	auto fill_interpolate_func = GetFillInterpolateFunction(wexpr.children[0]->return_type);
+
+	idx_t prev_partition = DConstants::INVALID_INDEX;
+	idx_t prev_valid = DConstants::INVALID_INDEX;
+	idx_t next_valid = DConstants::INVALID_INDEX;
+
+	for (idx_t i = 0; i < count; ++i, ++row_idx) {
+		//	Did we change partitions?
+		if (prev_partition != partition_begin[i]) {
+			prev_partition = partition_begin[i];
+			prev_valid = DConstants::INVALID_INDEX;
+			next_valid = DConstants::INVALID_INDEX;
+		}
+
+		//	If we are outside the validity range of the sort column, we can't use this value.
+		if (row_idx < valid_begin[i] || valid_end[i] <= row_idx) {
+			continue;
+		}
+
+		//	If this value is valid, track it for the next gap.
+		const auto idx = arg_data.sel->get_index(i);
+		if (arg_data.validity.RowIsValid(idx)) {
+			prev_valid = row_idx;
+			continue;
+		}
+
+		//	Missing value, so look for interpolation values
+
+		//	Find the previous valid value, scanning backwards from the current row
+		if (prev_valid == DConstants::INVALID_INDEX) {
+			for (idx_t j = row_idx; j > valid_begin[i];) {
+				if (!cursor.CellIsNull(0, --j)) {
+					prev_valid = j;
+					break;
+				}
+			}
+		}
+
+		//	If there is nothing beind us (missing early value) then scan forward
+		if (prev_valid == DConstants::INVALID_INDEX) {
+			for (idx_t j = row_idx + 1; j < valid_end[i]; ++j) {
+				if (!cursor.CellIsNull(0, j)) {
+					prev_valid = j;
+					break;
+				}
+			}
+		}
+
+		//	No valid values!
+		if (prev_valid == DConstants::INVALID_INDEX) {
+			//	Skip to the next partition
+			i += partition_end[i] - row_idx - 1;
+			row_idx = partition_end[i] - 1;
+			continue;
+		}
+
+		//	Find the next valid value after the previous
+		next_valid = DConstants::INVALID_INDEX;
+		for (idx_t j = prev_valid + 1; j < valid_end[i]; ++j) {
+			if (!cursor.CellIsNull(0, j)) {
+				next_valid = j;
+				break;
+			}
+		}
+
+		//	Nothing after, so scan backwards
+		if (next_valid == DConstants::INVALID_INDEX) {
+			for (idx_t j = prev_valid; j > valid_begin[i];) {
+				if (!cursor.CellIsNull(0, --j)) {
+					next_valid = j;
+					//	Restore ordering
+					std::swap(prev_valid, next_valid);
+					break;
+				}
+			}
+		}
+
+		//	If we only have one value, then just copy it
+		if (next_valid == DConstants::INVALID_INDEX) {
+			cursor.CopyCell(0, prev_valid, result, i);
+			continue;
+		}
+
+		//	Two values, so interpolate
+		//	y = y0 + (x - x0) / (x1 - x0) * (y1 - y0)
+		const auto slope = fill_slope_func(range_cursor, row_idx, prev_valid, next_valid);
+		fill_interpolate_func(result, i, cursor, prev_valid, next_valid, slope);
+	}
 }
 
 } // namespace duckdb

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/operator/add.hpp"
+#include "duckdb/common/operator/interpolate.hpp"
 #include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/function/window/window_aggregator.hpp"
 #include "duckdb/function/window/window_collection.hpp"
@@ -7,7 +8,6 @@
 #include "duckdb/function/window/window_token_tree.hpp"
 #include "duckdb/function/window/window_value_function.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
-#include "core_functions/aggregate/quantile_sort_tree.hpp"
 
 namespace duckdb {
 
@@ -700,7 +700,7 @@ static void FillInterpolateFunc(Vector &result, idx_t i, WindowCursor &cursor, i
 
 	FlatVector::SetNull(result, i, false);
 	auto data = FlatVector::GetData<T>(result);
-	data[i] = CastInterpolation::Interpolate<T>(y0, slope, y1);
+	data[i] = InterpolateOperator::Operation<T>(y0, slope, y1);
 }
 
 static fill_interpolate_t GetFillInterpolateFunction(const LogicalType &type) {

--- a/src/include/duckdb/common/enums/expression_type.hpp
+++ b/src/include/duckdb/common/enums/expression_type.hpp
@@ -102,6 +102,7 @@ enum class ExpressionType : uint8_t {
 	WINDOW_LEAD = 132,
 	WINDOW_LAG = 133,
 	WINDOW_NTH_VALUE = 134,
+	WINDOW_FILL = 135,
 
 	// -----------------------------
 	// Functions

--- a/src/include/duckdb/common/operator/interpolate.hpp
+++ b/src/include/duckdb/common/operator/interpolate.hpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/operator/interpolate.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/types/interval.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+
+namespace duckdb {
+
+//	Linear interpolation between two values
+struct InterpolateOperator {
+	template <typename TARGET_TYPE>
+	static inline TARGET_TYPE Operation(const TARGET_TYPE &lo, const double d, const TARGET_TYPE &hi) {
+		const auto delta = hi - lo;
+		return LossyNumericCast<TARGET_TYPE>(lo + delta * d);
+	}
+};
+
+template <>
+double InterpolateOperator::Operation(const double &lo, const double d, const double &hi);
+template <>
+dtime_t InterpolateOperator::Operation(const dtime_t &lo, const double d, const dtime_t &hi);
+template <>
+timestamp_t InterpolateOperator::Operation(const timestamp_t &lo, const double d, const timestamp_t &hi);
+template <>
+hugeint_t InterpolateOperator::Operation(const hugeint_t &lo, const double d, const hugeint_t &hi);
+template <>
+uhugeint_t InterpolateOperator::Operation(const uhugeint_t &lo, const double d, const uhugeint_t &hi);
+template <>
+interval_t InterpolateOperator::Operation(const interval_t &lo, const double d, const interval_t &hi);
+
+} // namespace duckdb

--- a/src/include/duckdb/function/window/window_value_function.hpp
+++ b/src/include/duckdb/function/window/window_value_function.hpp
@@ -76,4 +76,13 @@ protected:
 	                      Vector &result, idx_t count, idx_t row_idx) const override;
 };
 
+class WindowFillExecutor : public WindowValueExecutor {
+public:
+	WindowFillExecutor(BoundWindowExpression &wexpr, ClientContext &context, WindowSharedExpressions &shared);
+
+protected:
+	void EvaluateInternal(WindowExecutorGlobalState &gstate, WindowExecutorLocalState &lstate, DataChunk &eval_chunk,
+	                      Vector &result, idx_t count, idx_t row_idx) const override;
+};
+
 } // namespace duckdb

--- a/src/parser/expression/window_expression.cpp
+++ b/src/parser/expression/window_expression.cpp
@@ -28,6 +28,7 @@ WindowExpression::WindowExpression(ExpressionType type, string catalog_name, str
 	case ExpressionType::WINDOW_LEAD:
 	case ExpressionType::WINDOW_LAG:
 	case ExpressionType::WINDOW_NTILE:
+	case ExpressionType::WINDOW_FILL:
 		break;
 	default:
 		throw NotImplementedException("Window aggregate type %s not supported", ExpressionTypeToString(type).c_str());
@@ -57,6 +58,8 @@ ExpressionType WindowExpression::WindowToExpressionType(string &fun_name) {
 		return ExpressionType::WINDOW_LAG;
 	} else if (fun_name == "ntile") {
 		return ExpressionType::WINDOW_NTILE;
+	} else if (fun_name == "fill") {
+		return ExpressionType::WINDOW_FILL;
 	}
 	return ExpressionType::WINDOW_AGGREGATE;
 }

--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -60,6 +60,7 @@ static bool IsExcludableWindowFunction(ExpressionType type) {
 	case ExpressionType::WINDOW_CUME_DIST:
 	case ExpressionType::WINDOW_LEAD:
 	case ExpressionType::WINDOW_LAG:
+	case ExpressionType::WINDOW_FILL:
 		return false;
 	default:
 		throw InternalException("Unknown excludable window type %s", ExpressionTypeToString(type).c_str());
@@ -163,6 +164,7 @@ static bool IsOrderableWindowFunction(ExpressionType type) {
 	case ExpressionType::WINDOW_AGGREGATE:
 		return true;
 	case ExpressionType::WINDOW_RANK_DENSE:
+	case ExpressionType::WINDOW_FILL:
 		return false;
 	default:
 		throw InternalException("Unknown orderable window type %s", ExpressionTypeToString(type).c_str());

--- a/test/sql/window/test_fill.test
+++ b/test/sql/window/test_fill.test
@@ -1,0 +1,122 @@
+# name: test/sql/window/test_fill.test
+# description: Test Lead/Lag function
+# group: [window]
+
+#
+# Error checks
+#
+
+# Secondary orderings not supported
+statement error
+select fill(i order by 10-i) over (order by i) from range(3) tbl(i);
+----
+ORDER BY is not supported for the window function "fill"
+
+# Only one ordering allowed
+statement error
+select fill(i) over (order by i, 10-i) from range(3) tbl(i);
+----
+FILL functions must have only one ORDER BY expression
+
+# Streaming not supported because the interpolation values might be too far away.
+statement error
+select fill(i) over () from range(3) tbl(i);
+----
+FILL functions must have only one ORDER BY expression
+
+# Ordering must be numeric
+statement error
+select fill(i) over (order by i::VARCHAR) from range(3) tbl(i);
+----
+FILL orderings must support subtraction
+
+#
+# Simple interpolation coverage tests
+#
+
+# Between values
+query II
+select 
+	i,
+	fill(if(i = 1, NULL, i)) over(order by i)
+from range(3) tbl(i);
+----
+0	0
+1	1
+2	2
+
+# Before values
+query II
+select 
+	i,
+	fill(if(i = 0, NULL, i)) over(order by i)
+from range(3) tbl(i);
+----
+0	0
+1	1
+2	2
+
+# After values
+query II
+select 
+	i,
+	fill(if(i = 2, NULL, i)) over(order by i)
+from range(3) tbl(i);
+----
+0	0
+1	1
+2	2
+
+# Single values
+query II
+select 
+	i,
+	fill(if(i > 0, NULL, i)) over(order by i)
+from range(3) tbl(i);
+----
+0	0
+1	0
+2	0
+
+# Previous in another chunk
+query II
+select 
+	i,
+	fill(if(i = 2048, NULL, i)) over(order by i) f
+from range(2060) tbl(i)
+qualify i <> f
+----
+
+# No values in partition
+query II
+select 
+	i,
+	fill(if(i < 4, NULL, i)) over(partition by i // 2 order by i) f
+from range(8) tbl(i)
+order by i
+----
+0	NULL
+1	NULL
+2	NULL
+3	NULL
+4	4
+5	5
+6	6
+7	7
+
+# Outside valid sort values
+query II
+select 
+	i,
+	fill(if(i = 2, NULL, i)) over(order by if(i < 4, NULL, i)) f
+from range(8) tbl(i)
+order by i
+----
+0	0
+1	1
+2	NULL
+3	3
+4	4
+5	5
+6	6
+7	7

--- a/test/sql/window/test_fill.test
+++ b/test/sql/window/test_fill.test
@@ -34,11 +34,13 @@ FILL orderings must support subtraction
 # Simple interpolation coverage tests
 #
 
+foreach filltype tinyint smallint integer bigint hugeint float double utinyint usmallint uinteger ubigint uhugeint
+
 # Between values
 query II
 select 
 	i,
-	fill(if(i = 1, NULL, i)) over(order by i)
+	fill(if(i = 1, NULL, i)::${filltype}) over(order by i)
 from range(3) tbl(i);
 ----
 0	0
@@ -49,7 +51,7 @@ from range(3) tbl(i);
 query II
 select 
 	i,
-	fill(if(i = 0, NULL, i)) over(order by i)
+	fill(if(i = 0, NULL, i)::${filltype}) over(order by i)
 from range(3) tbl(i);
 ----
 0	0
@@ -60,7 +62,7 @@ from range(3) tbl(i);
 query II
 select 
 	i,
-	fill(if(i = 2, NULL, i)) over(order by i)
+	fill(if(i = 2, NULL, i)::${filltype}) over(order by i)
 from range(3) tbl(i);
 ----
 0	0
@@ -71,27 +73,18 @@ from range(3) tbl(i);
 query II
 select 
 	i,
-	fill(if(i > 0, NULL, i)) over(order by i)
+	fill(if(i > 0, NULL, i)::${filltype}) over(order by i)
 from range(3) tbl(i);
 ----
 0	0
 1	0
 2	0
 
-# Previous in another chunk
-query II
-select 
-	i,
-	fill(if(i = 2048, NULL, i)) over(order by i) f
-from range(2060) tbl(i)
-qualify i <> f
-----
-
 # No values in partition
 query II
 select 
 	i,
-	fill(if(i < 4, NULL, i)) over(partition by i // 2 order by i) f
+	fill(if(i < 4, NULL, i)::${filltype}) over(partition by i // 2 order by i) f
 from range(8) tbl(i)
 order by i
 ----
@@ -108,7 +101,7 @@ order by i
 query II
 select 
 	i,
-	fill(if(i = 2, NULL, i)) over(order by if(i < 4, NULL, i)) f
+	fill(if(i = 2, NULL, i)::${filltype}) over(order by if(i < 4, NULL, i)) f
 from range(8) tbl(i)
 order by i
 ----
@@ -120,3 +113,169 @@ order by i
 5	5
 6	6
 7	7
+
+endloop
+
+foreach filltype smallint integer bigint hugeint float double usmallint uinteger ubigint uhugeint
+
+# Previous in another chunk
+query II
+select 
+	i,
+	fill(if(i = 2048, NULL, i)::${filltype}) over(order by i) f
+from range(2060) tbl(i)
+qualify i <> f
+----
+
+endloop
+
+#
+# Temporal coverage
+#
+
+foreach filltype date timestamp timestamptz
+
+# Between values
+query II
+select 
+	i,
+	fill(if(day(i) = 2, NULL, i)::${filltype}) over(order by i) f
+from range('2025-01-01'::DATE, '2025-01-04'::DATE, INTERVAL 1 DAY) tbl(i)
+qualify f <> i
+----
+
+# Before values
+query II
+select 
+	i,
+	fill(if(day(i) = 1, NULL, i)::${filltype}) over(order by i) f
+from range('2025-01-01'::DATE, '2025-01-04'::DATE, INTERVAL 1 DAY) tbl(i)
+qualify f <> i
+----
+
+# After values
+query II
+select 
+	i,
+	fill(if(day(i) = 3, NULL, i)::${filltype}) over(order by i) f
+from range('2025-01-01'::DATE, '2025-01-04'::DATE, INTERVAL 1 DAY) tbl(i)
+qualify f <> i
+----
+
+# Single values
+query II
+select 
+	i,
+	fill(if(day(i) > 1, NULL, i)::${filltype}) over(order by i) f
+from range('2025-01-01'::DATE, '2025-01-04'::DATE, INTERVAL 1 DAY) tbl(i)
+qualify f <> '2025-01-01'::DATE
+----
+
+# No values in partition
+query II
+select 
+	i,
+	fill(if(day(i) < 5, NULL, i)::${filltype}) over(partition by (day(i) - 1) // 2 order by i) f
+from range('2025-01-01'::DATE, '2025-01-09'::DATE, INTERVAL 1 DAY) tbl(i)
+qualify i is distinct from f
+order by i
+----
+2025-01-01 00:00:00	NULL
+2025-01-02 00:00:00	NULL
+2025-01-03 00:00:00	NULL
+2025-01-04 00:00:00	NULL
+
+# Outside valid sort values
+query II
+select 
+	i,
+	fill(if(day(i) = 3, NULL, i)::${filltype}) over(order by if(day(i) < 5, NULL, i)) f
+from range('2025-01-01'::DATE, '2025-01-09'::DATE, INTERVAL 1 DAY) tbl(i)
+qualify i is distinct from f
+order by i
+----
+2025-01-03 00:00:00	NULL
+
+# Previous in another chunk
+query II
+select 
+	i,
+	fill(if(i = '2015-01-01'::DATE + 2048, NULL, i)::${filltype}) over(order by i) f
+from range('2025-01-01'::DATE, '2020-08-22'::DATE, INTERVAL 1 DAY) tbl(i)
+qualify i <> f
+----
+
+endloop
+
+# Time
+
+# Between values
+query II
+select 
+	i::TIME t,
+	fill(if(minute(i) = 2, NULL, i)::TIME) over(order by i) f
+from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:03'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
+qualify f <> t
+----
+
+# Before values
+query II
+select 
+	i::TIME t,
+	fill(if(minute(i) = 1, NULL, i)::TIME) over(order by i) f
+from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:03'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
+qualify f <> t
+----
+
+# After values
+query II
+select 
+	i::TIME t,
+	fill(if(minute(i) = 3, NULL, i)::TIME) over(order by i) f
+from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:03'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
+qualify f <> t
+----
+
+# Single values
+query II
+select 
+	i::TIME t,
+	fill(if(minute(i) > 0, NULL, i)::TIME) over(order by i) f
+from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:03'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
+qualify f <> '00:00:00'::TIME
+----
+
+# No values in partition
+query II
+select 
+	i::TIME t,
+	fill(if(minute(i) < 4, NULL, i)::TIME) over(partition by minute(i) // 2 order by i) f
+from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:09'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
+qualify t is distinct from f
+order by t
+----
+00:00:00	NULL
+00:01:00	NULL
+00:02:00	NULL
+00:03:00	NULL
+
+# Outside valid sort values
+query II
+select 
+	i::TIME t,
+	fill(if(minute(i) = 3, NULL, i)::TIME) over(order by if(minute(i) < 4, NULL, i)) f
+from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:09'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
+qualify t is distinct from f
+order by t
+----
+00:03:00	NULL
+
+# Previous in another chunk
+query II
+select 
+	i::TIME t,
+	fill(if(i = '2015-01-01'::TIMESTAMP + INTERVAL 2048 SECOND, NULL, i)::TIME) over(order by i) f
+from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:34:20'::TIMESTAMP, INTERVAL 1 SECOND) tbl(i)
+qualify t <> f
+----
+

--- a/test/sql/window/test_fill.test
+++ b/test/sql/window/test_fill.test
@@ -34,13 +34,15 @@ FILL orderings must support subtraction
 # Simple interpolation coverage tests
 #
 
+foreach ordertype tinyint smallint integer bigint hugeint float double utinyint usmallint uinteger ubigint uhugeint
+
 foreach filltype tinyint smallint integer bigint hugeint float double utinyint usmallint uinteger ubigint uhugeint
 
 # Between values
 query II
 select 
 	i,
-	fill(if(i = 1, NULL, i)::${filltype}) over(order by i)
+	fill(if(i = 1, NULL, i)::${filltype}) over(order by i::${ordertype})
 from range(3) tbl(i);
 ----
 0	0
@@ -51,7 +53,7 @@ from range(3) tbl(i);
 query II
 select 
 	i,
-	fill(if(i = 0, NULL, i)::${filltype}) over(order by i)
+	fill(if(i = 0, NULL, i)::${filltype}) over(order by i::${ordertype})
 from range(3) tbl(i);
 ----
 0	0
@@ -62,7 +64,7 @@ from range(3) tbl(i);
 query II
 select 
 	i,
-	fill(if(i = 2, NULL, i)::${filltype}) over(order by i)
+	fill(if(i = 2, NULL, i)::${filltype}) over(order by i::${ordertype})
 from range(3) tbl(i);
 ----
 0	0
@@ -73,7 +75,7 @@ from range(3) tbl(i);
 query II
 select 
 	i,
-	fill(if(i > 0, NULL, i)::${filltype}) over(order by i)
+	fill(if(i > 0, NULL, i)::${filltype}) over(order by i::${ordertype})
 from range(3) tbl(i);
 ----
 0	0
@@ -84,7 +86,7 @@ from range(3) tbl(i);
 query II
 select 
 	i,
-	fill(if(i < 4, NULL, i)::${filltype}) over(partition by i // 2 order by i) f
+	fill(if(i < 4, NULL, i)::${filltype}) over(partition by i // 2 order by i::${ordertype}) f
 from range(8) tbl(i)
 order by i
 ----
@@ -101,7 +103,7 @@ order by i
 query II
 select 
 	i,
-	fill(if(i = 2, NULL, i)::${filltype}) over(order by if(i < 4, NULL, i)) f
+	fill(if(i = 2, NULL, i)::${filltype}) over(order by if(i < 4, NULL, i)::${ordertype}) f
 from range(8) tbl(i)
 order by i
 ----
@@ -116,16 +118,22 @@ order by i
 
 endloop
 
+endloop
+
+foreach ordertype smallint integer bigint hugeint float double usmallint uinteger ubigint uhugeint
+
 foreach filltype smallint integer bigint hugeint float double usmallint uinteger ubigint uhugeint
 
 # Previous in another chunk
 query II
 select 
 	i,
-	fill(if(i = 2048, NULL, i)::${filltype}) over(order by i) f
+	fill(if(i = 2048, NULL, i)::${filltype}) over(order by i::${ordertype}) f
 from range(2060) tbl(i)
 qualify i <> f
 ----
+
+endloop
 
 endloop
 
@@ -133,13 +141,15 @@ endloop
 # Temporal coverage
 #
 
+foreach ordertype date timestamp timestamptz
+
 foreach filltype date timestamp timestamptz
 
 # Between values
 query II
 select 
 	i,
-	fill(if(day(i) = 2, NULL, i)::${filltype}) over(order by i) f
+	fill(if(day(i) = 2, NULL, i)::${filltype}) over(order by i::${ordertype}) f
 from range('2025-01-01'::DATE, '2025-01-04'::DATE, INTERVAL 1 DAY) tbl(i)
 qualify f <> i
 ----
@@ -148,7 +158,7 @@ qualify f <> i
 query II
 select 
 	i,
-	fill(if(day(i) = 1, NULL, i)::${filltype}) over(order by i) f
+	fill(if(day(i) = 1, NULL, i)::${filltype}) over(order by i::${ordertype}) f
 from range('2025-01-01'::DATE, '2025-01-04'::DATE, INTERVAL 1 DAY) tbl(i)
 qualify f <> i
 ----
@@ -157,7 +167,7 @@ qualify f <> i
 query II
 select 
 	i,
-	fill(if(day(i) = 3, NULL, i)::${filltype}) over(order by i) f
+	fill(if(day(i) = 3, NULL, i)::${filltype}) over(order by i::${ordertype}) f
 from range('2025-01-01'::DATE, '2025-01-04'::DATE, INTERVAL 1 DAY) tbl(i)
 qualify f <> i
 ----
@@ -166,7 +176,7 @@ qualify f <> i
 query II
 select 
 	i,
-	fill(if(day(i) > 1, NULL, i)::${filltype}) over(order by i) f
+	fill(if(day(i) > 1, NULL, i)::${filltype}) over(order by i::${ordertype}) f
 from range('2025-01-01'::DATE, '2025-01-04'::DATE, INTERVAL 1 DAY) tbl(i)
 qualify f <> '2025-01-01'::DATE
 ----
@@ -175,7 +185,7 @@ qualify f <> '2025-01-01'::DATE
 query II
 select 
 	i,
-	fill(if(day(i) < 5, NULL, i)::${filltype}) over(partition by (day(i) - 1) // 2 order by i) f
+	fill(if(day(i) < 5, NULL, i)::${filltype}) over(partition by (day(i) - 1) // 2 order by i::${ordertype}) f
 from range('2025-01-01'::DATE, '2025-01-09'::DATE, INTERVAL 1 DAY) tbl(i)
 qualify i is distinct from f
 order by i
@@ -189,7 +199,7 @@ order by i
 query II
 select 
 	i,
-	fill(if(day(i) = 3, NULL, i)::${filltype}) over(order by if(day(i) < 5, NULL, i)) f
+	fill(if(day(i) = 3, NULL, i)::${filltype}) over(order by if(day(i) < 5, NULL, i)::${ordertype}) f
 from range('2025-01-01'::DATE, '2025-01-09'::DATE, INTERVAL 1 DAY) tbl(i)
 qualify i is distinct from f
 order by i
@@ -200,10 +210,12 @@ order by i
 query II
 select 
 	i,
-	fill(if(i = '2015-01-01'::DATE + 2048, NULL, i)::${filltype}) over(order by i) f
+	fill(if(i = '2015-01-01'::DATE + 2048, NULL, i)::${filltype}) over(order by i::${ordertype}) f
 from range('2025-01-01'::DATE, '2020-08-22'::DATE, INTERVAL 1 DAY) tbl(i)
 qualify i <> f
 ----
+
+endloop
 
 endloop
 
@@ -213,7 +225,7 @@ endloop
 query II
 select 
 	i::TIME t,
-	fill(if(minute(i) = 2, NULL, i)::TIME) over(order by i) f
+	fill(if(minute(i) = 2, NULL, i)::TIME) over(order by i::TIME) f
 from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:03'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
 qualify f <> t
 ----
@@ -222,7 +234,7 @@ qualify f <> t
 query II
 select 
 	i::TIME t,
-	fill(if(minute(i) = 1, NULL, i)::TIME) over(order by i) f
+	fill(if(minute(i) = 1, NULL, i)::TIME) over(order by i::TIME) f
 from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:03'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
 qualify f <> t
 ----
@@ -231,7 +243,7 @@ qualify f <> t
 query II
 select 
 	i::TIME t,
-	fill(if(minute(i) = 3, NULL, i)::TIME) over(order by i) f
+	fill(if(minute(i) = 3, NULL, i)::TIME) over(order by i::TIME) f
 from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:03'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
 qualify f <> t
 ----
@@ -240,7 +252,7 @@ qualify f <> t
 query II
 select 
 	i::TIME t,
-	fill(if(minute(i) > 0, NULL, i)::TIME) over(order by i) f
+	fill(if(minute(i) > 0, NULL, i)::TIME) over(order by i::TIME) f
 from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:03'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
 qualify f <> '00:00:00'::TIME
 ----
@@ -249,7 +261,7 @@ qualify f <> '00:00:00'::TIME
 query II
 select 
 	i::TIME t,
-	fill(if(minute(i) < 4, NULL, i)::TIME) over(partition by minute(i) // 2 order by i) f
+	fill(if(minute(i) < 4, NULL, i)::TIME) over(partition by minute(i) // 2 order by i::TIME) f
 from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:09'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
 qualify t is distinct from f
 order by t
@@ -263,7 +275,7 @@ order by t
 query II
 select 
 	i::TIME t,
-	fill(if(minute(i) = 3, NULL, i)::TIME) over(order by if(minute(i) < 4, NULL, i)) f
+	fill(if(minute(i) = 3, NULL, i)::TIME) over(order by if(minute(i) < 4, NULL, i)::TIME) f
 from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:09'::TIMESTAMP, INTERVAL 1 MINUTE) tbl(i)
 qualify t is distinct from f
 order by t
@@ -274,7 +286,7 @@ order by t
 query II
 select 
 	i::TIME t,
-	fill(if(i = '2015-01-01'::TIMESTAMP + INTERVAL 2048 SECOND, NULL, i)::TIME) over(order by i) f
+	fill(if(i = '2015-01-01'::TIMESTAMP + INTERVAL 2048 SECOND, NULL, i)::TIME) over(order by i::TIME) f
 from range('2025-01-01'::TIMESTAMP, '2025-01-01 00:34:20'::TIMESTAMP, INTERVAL 1 SECOND) tbl(i)
 qualify t <> f
 ----


### PR DESCRIPTION
* Implement basic linear interpolation fill function
* Add simple coverage tests
* Add missing interpolator for uhugeint_t
* Add tests for all interpolatable types
* Pull interpolation code out of quantile into core for reuse.
* Test all ordering types
* Switch to doubles for slope interpolation to enable backwards projection
* Add parameterised benchmark
* At SF 10, benchmark vs 4 window functions is 2.44s vs 3.46s
* At SF 50, benchmark vs 4 window functions is 12.22s vs 18.51s
