### PR TITLE
Partitioned copy: don't check if file exists for remote files

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -408,12 +408,9 @@ void CheckDirectory(FileSystem &fs, const string &file_path, CopyOverwriteMode o
 unique_ptr<GlobalSinkState> PhysicalCopyToFile::GetGlobalSinkState(ClientContext &context) const {
 	if (partition_output || per_thread_output || rotate) {
 		auto &fs = FileSystem::GetFileSystem(context);
-		if (fs.FileExists(file_path)) {
-			// the target file exists AND is a file (not a directory)
-			if (fs.IsRemoteFile(file_path)) {
-				// for remote files we cannot do anything - as we cannot delete the file
-				throw IOException("Cannot write to \"%s\" - it exists and is a file, not a directory!", file_path);
-			} else {
+		if (!fs.IsRemoteFile(file_path)) {
+			if (fs.FileExists(file_path)) {
+				// the target file exists AND is a file (not a directory)
 				// for local files we can remove the file if OVERWRITE_OR_IGNORE is enabled
 				if (overwrite_mode == CopyOverwriteMode::COPY_OVERWRITE) {
 					fs.RemoveFile(file_path);


### PR DESCRIPTION
`FileExists` returns true for root buckets on S3 (e.g. `s3://root-bucket/`). This causes partitioned copy operations like the following to fail currently:

```sql
copy (select 42 i, 1 p) to 's3://root-bucket/' (format parquet, partition_by p);
-- Cannot write to "s3://root-bucket/" - it exists and is a file, not a directory!
```

The check ("is this a file or is this a directory") doesn't really make sense on blob stores to begin with - so just skip it for remote files.
