### PR TITLE
Bugfixes

### DIFF
--- a/extension/parquet/include/writer/templated_column_writer.hpp
+++ b/extension/parquet/include/writer/templated_column_writer.hpp
@@ -403,7 +403,7 @@ private:
 			break;
 		}
 		case duckdb_parquet::Encoding::BYTE_STREAM_SPLIT: {
-			if (page_state.bss_initialized) {
+			if (!page_state.bss_initialized) {
 				page_state.bss_encoder.BeginWrite(BufferAllocator::Get(writer.GetContext()));
 				page_state.bss_initialized = true;
 			}


### PR DESCRIPTION
Fixes:
1. https://github.com/duckdb/duckdb/issues/17682 (missed a `!`, used uninitialized variable in Parquet BSS encoder)
2. https://github.com/duckdblabs/duckdb-internal/issues/4999 (`ExternalFileCache` assertion failure because we exited loop too early)