### PR TITLE
Allow table functions to disable statement caching

### DIFF
--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -36,6 +36,10 @@ bool TableFunctionData::Equals(const FunctionData &other) const {
 	return false;
 }
 
+bool FunctionData::SupportStatementCache() const {
+	return true;
+}
+
 Function::Function(string name_p) : name(std::move(name_p)) {
 }
 Function::~Function() {

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -84,6 +84,9 @@ struct MultiFileBindData : public TableFunctionData {
 	void Initialize(ClientContext &, BaseUnionData &union_data) {
 		Initialize(std::move(union_data.reader));
 	}
+	bool SupportStatementCache() const override {
+		return false;
+	}
 
 	unique_ptr<FunctionData> Copy() const override;
 };

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -61,6 +61,7 @@ struct FunctionData {
 	DUCKDB_API virtual unique_ptr<FunctionData> Copy() const = 0;
 	DUCKDB_API virtual bool Equals(const FunctionData &other) const = 0;
 	DUCKDB_API static bool Equals(const FunctionData *left, const FunctionData *right);
+	DUCKDB_API virtual bool SupportStatementCache() const;
 
 	template <class TARGET>
 	TARGET &Cast() {

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -298,6 +298,9 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 
 		unique_ptr<FunctionData> bind_data;
 		auto scan_function = table.GetScanFunction(context, bind_data, table_lookup);
+		if (bind_data && !bind_data->SupportStatementCache()) {
+			SetAlwaysRequireRebind();
+		}
 		// TODO: bundle the type and name vector in a struct (e.g PackedColumnMetadata)
 		vector<LogicalType> table_types;
 		vector<string> table_names;

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -240,6 +240,9 @@ unique_ptr<LogicalOperator> Binder::BindTableFunctionInternal(TableFunction &tab
 		throw InvalidInputException("Cannot call function \"%s\" directly - it has no bind function",
 		                            table_function.name);
 	}
+	if (bind_data && !bind_data->SupportStatementCache()) {
+		SetAlwaysRequireRebind();
+	}
 	if (return_types.size() != return_names.size()) {
 		throw InternalException("Failed to bind \"%s\": return_types/names must have same size", table_function.name);
 	}


### PR DESCRIPTION
Currently we assume all plans can be cached - this allows table functions to opt out of statement caching. If this is opted out of we will always rebind when re-executing a prepared statement instead.