### PR TITLE
Revert "set default for MAIN_BRANCH_VERSIONING to false"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ set(VERSIONING_TAG_MATCH "v*.*.*")
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-option(MAIN_BRANCH_VERSIONING "Versioning scheme for main branch" FALSE)
+option(MAIN_BRANCH_VERSIONING "Versioning scheme for main branch" TRUE)
 if(${MAIN_BRANCH_VERSIONING})
   set(VERSIONING_TAG_MATCH "v*.*.0")
 endif()

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -279,7 +279,7 @@ def git_commit_hash():
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-MAIN_BRANCH_VERSIONING = False
+MAIN_BRANCH_VERSIONING = True
 if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
     MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "1":

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -148,7 +148,7 @@ def get_relative_path(source_dir, target_file):
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-MAIN_BRANCH_VERSIONING = False
+MAIN_BRANCH_VERSIONING = True
 if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
     MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "1":

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -389,7 +389,7 @@ import os
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-MAIN_BRANCH_VERSIONING = False
+MAIN_BRANCH_VERSIONING = True
 if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
     MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "1":


### PR DESCRIPTION
This reverts commit 7cd2e2439017200753d120ec74b5575639b3844b.

After this `main` branch, and branch on top of that, should get named like `v1.4.0-devX` where X is the distance, in commits from v1.3.0, while `v1.3-ossivalis` and derived branches will get a numbering like `v1.3.N-devX`, where X is the distance in commits from v1.3.0 while N is basically 1 for now, and 2 after 1.3.1.

This unlocks publishing nightly builds also on `main`.

With @c-herrewijn 