### PR TITLE
Sorting followup

### DIFF
--- a/extension/core_functions/scalar/list/list_sort.cpp
+++ b/extension/core_functions/scalar/list/list_sort.cpp
@@ -6,7 +6,8 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/main/config.hpp"
-#include "duckdb/common/sort/sort.hpp"
+#include "duckdb/common/sorting/sort.hpp"
+#include "duckdb/parallel/thread_context.hpp"
 
 namespace duckdb {
 
@@ -22,11 +23,9 @@ struct ListSortBindData : public FunctionData {
 	bool is_grade_up;
 
 	vector<LogicalType> types;
-	vector<LogicalType> payload_types;
 
 	ClientContext &context;
-	RowLayout payload_layout;
-	vector<BoundOrderByNode> orders;
+	unique_ptr<Sort> sort;
 
 public:
 	bool Equals(const FunctionData &other_p) const override;
@@ -42,20 +41,17 @@ ListSortBindData::ListSortBindData(OrderType order_type_p, OrderByNullType null_
 	// get the vector types
 	types.emplace_back(LogicalType::USMALLINT);
 	types.emplace_back(child_type);
-	D_ASSERT(types.size() == 2);
-
-	// get the payload types
-	payload_types.emplace_back(LogicalType::UINTEGER);
-	D_ASSERT(payload_types.size() == 1);
-
-	// initialize the payload layout
-	payload_layout.Initialize(payload_types);
+	types.emplace_back(LogicalType::UINTEGER);
+	D_ASSERT(types.size() == 3);
 
 	// get the BoundOrderByNode
 	auto idx_col_expr = make_uniq_base<Expression, BoundReferenceExpression>(LogicalType::USMALLINT, 0U);
 	auto lists_col_expr = make_uniq_base<Expression, BoundReferenceExpression>(child_type, 1U);
+	vector<BoundOrderByNode> orders;
 	orders.emplace_back(OrderType::ASCENDING, OrderByNullType::ORDER_DEFAULT, std::move(idx_col_expr));
 	orders.emplace_back(order_type, null_order, std::move(lists_col_expr));
+	sort =
+	    unique_ptr<Sort>(new Sort(context, orders, {LogicalType::USMALLINT, child_type, LogicalType::UINTEGER}, {2}));
 }
 
 unique_ptr<FunctionData> ListSortBindData::Copy() const {
@@ -71,32 +67,25 @@ ListSortBindData::~ListSortBindData() {
 }
 
 // create the key_chunk and the payload_chunk and sink them into the local_sort_state
-void SinkDataChunk(Vector *child_vector, SelectionVector &sel, idx_t offset_lists_indices, vector<LogicalType> &types,
-                   vector<LogicalType> &payload_types, Vector &payload_vector, LocalSortState &local_sort_state,
+void SinkDataChunk(const Sort &sort, ExecutionContext &context, OperatorSinkInput &sink_input, Vector *child_vector,
+                   SelectionVector &sel, idx_t offset_lists_indices, vector<LogicalType> &types, Vector &payload_vector,
                    bool &data_to_sort, Vector &lists_indices) {
 
 	// slice the child vector
 	Vector slice(*child_vector, sel, offset_lists_indices);
 
-	// initialize and fill key_chunk
-	DataChunk key_chunk;
-	key_chunk.InitializeEmpty(types);
-	key_chunk.data[0].Reference(lists_indices);
-	key_chunk.data[1].Reference(slice);
-	key_chunk.SetCardinality(offset_lists_indices);
-
-	// initialize and fill key_chunk and payload_chunk
-	DataChunk payload_chunk;
-	payload_chunk.InitializeEmpty(payload_types);
-	payload_chunk.data[0].Reference(payload_vector);
-	payload_chunk.SetCardinality(offset_lists_indices);
-
-	key_chunk.Verify();
-	payload_chunk.Verify();
+	// initialize and fill chunk
+	DataChunk chunk;
+	chunk.InitializeEmpty(types);
+	chunk.data[0].Reference(lists_indices);
+	chunk.data[1].Reference(slice);
+	chunk.data[2].Reference(payload_vector);
+	chunk.SetCardinality(offset_lists_indices);
+	chunk.Verify();
 
 	// sink
-	key_chunk.Flatten();
-	local_sort_state.SinkChunk(key_chunk, payload_chunk);
+	chunk.Flatten();
+	sort.Sink(context, chunk, sink_input);
 	data_to_sort = true;
 }
 
@@ -117,10 +106,12 @@ static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &re
 	auto &info = func_expr.bind_info->Cast<ListSortBindData>();
 
 	// initialize the global and local sorting state
-	auto &buffer_manager = BufferManager::GetBufferManager(info.context);
-	GlobalSortState global_sort_state(info.context, info.orders, info.payload_layout);
-	LocalSortState local_sort_state;
-	local_sort_state.Initialize(global_sort_state, buffer_manager);
+	auto global_sink_state = info.sort->GetGlobalSinkState(info.context);
+	ThreadContext thread_context(info.context);
+	ExecutionContext execution_context(info.context, thread_context, nullptr);
+	auto local_sink_state = info.sort->GetLocalSinkState(execution_context);
+	InterruptState interrupt_state;
+	OperatorSinkInput sink_input {*global_sink_state, *local_sink_state, interrupt_state};
 
 	Vector sort_result_vec = info.is_grade_up ? Vector(input_lists.GetType()) : result;
 
@@ -174,8 +165,8 @@ static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &re
 		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
 			// lists_indices vector is full, sink
 			if (offset_lists_indices == STANDARD_VECTOR_SIZE) {
-				SinkDataChunk(&child_vector, sel, offset_lists_indices, info.types, info.payload_types, payload_vector,
-				              local_sort_state, data_to_sort, lists_indices);
+				SinkDataChunk(*info.sort, execution_context, sink_input, &child_vector, sel, offset_lists_indices,
+				              info.types, payload_vector, data_to_sort, lists_indices);
 				offset_lists_indices = 0;
 			}
 
@@ -189,8 +180,8 @@ static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &re
 	}
 
 	if (offset_lists_indices != 0) {
-		SinkDataChunk(&child_vector, sel, offset_lists_indices, info.types, info.payload_types, payload_vector,
-		              local_sort_state, data_to_sort, lists_indices);
+		SinkDataChunk(*info.sort, execution_context, sink_input, &child_vector, sel, offset_lists_indices, info.types,
+		              payload_vector, data_to_sort, lists_indices);
 	}
 
 	if (info.is_grade_up) {
@@ -202,20 +193,25 @@ static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &re
 
 	if (data_to_sort) {
 		// add local state to global state, which sorts the data
-		global_sort_state.AddLocalState(local_sort_state);
-		global_sort_state.PrepareMergePhase();
+		OperatorSinkCombineInput combine_input {*global_sink_state, *local_sink_state, interrupt_state};
+		info.sort->Combine(execution_context, combine_input);
+
+		OperatorSinkFinalizeInput finalize_input {*global_sink_state, interrupt_state};
+		info.sort->Finalize(info.context, finalize_input);
 
 		// selection vector that is to be filled with the 'sorted' payload
 		SelectionVector sel_sorted(incr_payload_count);
 		idx_t sel_sorted_idx = 0;
 
 		// scan the sorted row data
-		PayloadScanner scanner(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state);
+		auto global_source_state = info.sort->GetGlobalSourceState(info.context, *global_sink_state);
+		auto local_source_state = info.sort->GetLocalSourceState(execution_context, *global_source_state);
+		OperatorSourceInput source_input {*global_source_state, *local_source_state, interrupt_state};
 		for (;;) {
 			DataChunk result_chunk;
-			result_chunk.Initialize(Allocator::DefaultAllocator(), info.payload_types);
+			result_chunk.Initialize(Allocator::DefaultAllocator(), {LogicalType::UINTEGER});
 			result_chunk.SetCardinality(0);
-			scanner.Scan(result_chunk);
+			info.sort->GetData(execution_context, result_chunk, source_input);
 			if (result_chunk.size() == 0) {
 				break;
 			}

--- a/src/common/sorting/sort.cpp
+++ b/src/common/sorting/sort.cpp
@@ -138,10 +138,9 @@ public:
 public:
 	void InitializeSortedRun(const Sort &sort, ClientContext &context) {
 		D_ASSERT(!sorted_run);
-		auto &buffer_manager = BufferManager::GetBufferManager(context);
 		// TODO: we want to pass "sort.is_index_sort" instead of just "false" here
 		//  so that we can do an approximate sort, but that causes issues in the ART
-		sorted_run = make_uniq<SortedRun>(buffer_manager, sort.key_layout, sort.payload_layout, false);
+		sorted_run = make_uniq<SortedRun>(context, sort.key_layout, sort.payload_layout, false);
 	}
 
 public:

--- a/src/common/sorting/sort.cpp
+++ b/src/common/sorting/sort.cpp
@@ -330,7 +330,7 @@ SinkCombineResultType Sort::Combine(ExecutionContext &context, OperatorSinkCombi
 	return SinkCombineResultType::FINISHED;
 }
 
-SinkFinalizeType Sort::Finalize(Pipeline &, Event &, ClientContext &context, OperatorSinkFinalizeInput &input) const {
+SinkFinalizeType Sort::Finalize(ClientContext &context, OperatorSinkFinalizeInput &input) const {
 	auto &gstate = input.global_state.Cast<SortGlobalSinkState>();
 	if (gstate.sorted_runs.empty()) {
 		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;

--- a/src/common/sorting/sorted_run.cpp
+++ b/src/common/sorting/sorted_run.cpp
@@ -9,12 +9,14 @@
 
 namespace duckdb {
 
-SortedRun::SortedRun(BufferManager &buffer_manager, shared_ptr<TupleDataLayout> key_layout,
+SortedRun::SortedRun(ClientContext &context_p, shared_ptr<TupleDataLayout> key_layout,
                      shared_ptr<TupleDataLayout> payload_layout, bool is_index_sort_p)
-    : key_data(make_uniq<TupleDataCollection>(buffer_manager, std::move(key_layout))),
-      payload_data(payload_layout->ColumnCount() != 0
-                       ? make_uniq<TupleDataCollection>(buffer_manager, std::move(payload_layout))
-                       : nullptr),
+    : context(context_p),
+      key_data(make_uniq<TupleDataCollection>(BufferManager::GetBufferManager(context), std::move(key_layout))),
+      payload_data(
+          payload_layout->ColumnCount() != 0
+              ? make_uniq<TupleDataCollection>(BufferManager::GetBufferManager(context), std::move(payload_layout))
+              : nullptr),
       is_index_sort(is_index_sort_p), finalized(false) {
 	key_data->InitializeAppend(key_append_state, TupleDataPinProperties::KEEP_EVERYTHING_PINNED);
 	if (payload_data) {
@@ -67,9 +69,10 @@ void SortedRun::Sink(DataChunk &key, DataChunk &payload) {
 template <class SORT_KEY>
 struct SkaExtractKey {
 	using result_type = uint64_t;
-	SkaExtractKey(bool requires_next_sort_p, idx_t ska_sort_width_p, const vector<idx_t> &sort_skippable_bytes_p)
+	SkaExtractKey(bool requires_next_sort_p, idx_t ska_sort_width_p, const vector<idx_t> &sort_skippable_bytes_p,
+	              atomic<bool> &interrupted_p)
 	    : requires_next_sort(requires_next_sort_p), ska_sort_width(ska_sort_width_p),
-	      sort_skippable_bytes(sort_skippable_bytes_p) {
+	      sort_skippable_bytes(sort_skippable_bytes_p), interrupted(interrupted_p) {
 	}
 
 	const result_type &operator()(const SORT_KEY &key) const {
@@ -81,13 +84,18 @@ struct SkaExtractKey {
 		       sort_skippable_bytes.end();
 	}
 
+	bool Interrupted() const {
+		return interrupted.load(std::memory_order_relaxed);
+	}
+
 	bool requires_next_sort;
 	idx_t ska_sort_width;
 	const vector<idx_t> &sort_skippable_bytes;
+	atomic<bool> &interrupted;
 };
 
 template <SortKeyType SORT_KEY_TYPE>
-static void TemplatedSort(const TupleDataCollection &key_data, const bool is_index_sort) {
+static void TemplatedSort(ClientContext &context, const TupleDataCollection &key_data, const bool is_index_sort) {
 	const auto &layout = key_data.GetLayout();
 	D_ASSERT(SORT_KEY_TYPE == layout.GetSortKeyType());
 	using SORT_KEY = SortKey<SORT_KEY_TYPE>;
@@ -102,35 +110,40 @@ static void TemplatedSort(const TupleDataCollection &key_data, const bool is_ind
 	    is_index_sort ? false : !SORT_KEY::CONSTANT_SIZE || SORT_KEY::INLINE_LENGTH != sizeof(uint64_t);
 	const auto ska_sort_width = MinValue<idx_t>(layout.GetSortWidth(), sizeof(uint64_t));
 	const auto &sort_skippable_bytes = layout.GetSortSkippableBytes();
-	auto ska_extract_key = SkaExtractKey<SORT_KEY>(requires_next_sort, ska_sort_width, sort_skippable_bytes);
+	auto ska_extract_key =
+	    SkaExtractKey<SORT_KEY>(requires_next_sort, ska_sort_width, sort_skippable_bytes, context.interrupted);
 
 	const auto fallback = [ska_extract_key](const BLOCK_ITERATOR &fb_begin, const BLOCK_ITERATOR &fb_end) {
 		duckdb_ska_sort::ska_sort(fb_begin, fb_end, ska_extract_key);
 	};
 	duckdb_vergesort::vergesort(begin, end, std::less<SORT_KEY>(), fallback);
+
+	if (context.interrupted.load(std::memory_order_relaxed)) {
+		throw InterruptException();
+	}
 }
 
-static void SortSwitch(const TupleDataCollection &key_data, bool is_index_sort) {
+static void SortSwitch(ClientContext &context, const TupleDataCollection &key_data, bool is_index_sort) {
 	const auto sort_key_type = key_data.GetLayout().GetSortKeyType();
 	switch (sort_key_type) {
 	case SortKeyType::NO_PAYLOAD_FIXED_8:
-		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_8>(key_data, is_index_sort);
+		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_8>(context, key_data, is_index_sort);
 	case SortKeyType::NO_PAYLOAD_FIXED_16:
-		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_16>(key_data, is_index_sort);
+		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_16>(context, key_data, is_index_sort);
 	case SortKeyType::NO_PAYLOAD_FIXED_24:
-		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_24>(key_data, is_index_sort);
+		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_24>(context, key_data, is_index_sort);
 	case SortKeyType::NO_PAYLOAD_FIXED_32:
-		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_32>(key_data, is_index_sort);
+		return TemplatedSort<SortKeyType::NO_PAYLOAD_FIXED_32>(context, key_data, is_index_sort);
 	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		return TemplatedSort<SortKeyType::NO_PAYLOAD_VARIABLE_32>(key_data, is_index_sort);
+		return TemplatedSort<SortKeyType::NO_PAYLOAD_VARIABLE_32>(context, key_data, is_index_sort);
 	case SortKeyType::PAYLOAD_FIXED_16:
-		return TemplatedSort<SortKeyType::PAYLOAD_FIXED_16>(key_data, is_index_sort);
+		return TemplatedSort<SortKeyType::PAYLOAD_FIXED_16>(context, key_data, is_index_sort);
 	case SortKeyType::PAYLOAD_FIXED_24:
-		return TemplatedSort<SortKeyType::PAYLOAD_FIXED_24>(key_data, is_index_sort);
+		return TemplatedSort<SortKeyType::PAYLOAD_FIXED_24>(context, key_data, is_index_sort);
 	case SortKeyType::PAYLOAD_FIXED_32:
-		return TemplatedSort<SortKeyType::PAYLOAD_FIXED_32>(key_data, is_index_sort);
+		return TemplatedSort<SortKeyType::PAYLOAD_FIXED_32>(context, key_data, is_index_sort);
 	case SortKeyType::PAYLOAD_VARIABLE_32:
-		return TemplatedSort<SortKeyType::PAYLOAD_VARIABLE_32>(key_data, is_index_sort);
+		return TemplatedSort<SortKeyType::PAYLOAD_VARIABLE_32>(context, key_data, is_index_sort);
 	default:
 		throw NotImplementedException("TemplatedSort for %s", EnumUtil::ToString(sort_key_type));
 	}
@@ -177,7 +190,8 @@ static void ReorderPayloadData(TupleDataCollection &new_payload_data,
 }
 
 template <SortKeyType SORT_KEY_TYPE>
-static void TemplatedReorder(unique_ptr<TupleDataCollection> &key_data, unique_ptr<TupleDataCollection> &payload_data) {
+static void TemplatedReorder(ClientContext &context, unique_ptr<TupleDataCollection> &key_data,
+                             unique_ptr<TupleDataCollection> &payload_data) {
 	using SORT_KEY = SortKey<SORT_KEY_TYPE>;
 	using BLOCK_ITERATOR_STATE = BlockIteratorState<BlockIteratorStateType::IN_MEMORY>;
 
@@ -210,6 +224,10 @@ static void TemplatedReorder(unique_ptr<TupleDataCollection> &key_data, unique_p
 
 	idx_t index = 0;
 	while (index < total_count) {
+		if (context.interrupted.load(std::memory_order_relaxed)) {
+			throw InterruptException();
+		}
+
 		const auto next = MinValue<idx_t>(total_count - index, STANDARD_VECTOR_SIZE);
 		for (idx_t i = 0; i < next; i++) {
 			key_ptrs[i] = &*it++;
@@ -238,19 +256,20 @@ static void TemplatedReorder(unique_ptr<TupleDataCollection> &key_data, unique_p
 	}
 }
 
-static void Reorder(unique_ptr<TupleDataCollection> &key_data, unique_ptr<TupleDataCollection> &payload_data) {
+static void Reorder(ClientContext &context, unique_ptr<TupleDataCollection> &key_data,
+                    unique_ptr<TupleDataCollection> &payload_data) {
 	const auto sort_key_type = key_data->GetLayout().GetSortKeyType();
 	switch (sort_key_type) {
 	case SortKeyType::NO_PAYLOAD_VARIABLE_32:
-		return TemplatedReorder<SortKeyType::NO_PAYLOAD_VARIABLE_32>(key_data, payload_data);
+		return TemplatedReorder<SortKeyType::NO_PAYLOAD_VARIABLE_32>(context, key_data, payload_data);
 	case SortKeyType::PAYLOAD_FIXED_16:
-		return TemplatedReorder<SortKeyType::PAYLOAD_FIXED_16>(key_data, payload_data);
+		return TemplatedReorder<SortKeyType::PAYLOAD_FIXED_16>(context, key_data, payload_data);
 	case SortKeyType::PAYLOAD_FIXED_24:
-		return TemplatedReorder<SortKeyType::PAYLOAD_FIXED_24>(key_data, payload_data);
+		return TemplatedReorder<SortKeyType::PAYLOAD_FIXED_24>(context, key_data, payload_data);
 	case SortKeyType::PAYLOAD_FIXED_32:
-		return TemplatedReorder<SortKeyType::PAYLOAD_FIXED_32>(key_data, payload_data);
+		return TemplatedReorder<SortKeyType::PAYLOAD_FIXED_32>(context, key_data, payload_data);
 	case SortKeyType::PAYLOAD_VARIABLE_32:
-		return TemplatedReorder<SortKeyType::PAYLOAD_VARIABLE_32>(key_data, payload_data);
+		return TemplatedReorder<SortKeyType::PAYLOAD_VARIABLE_32>(context, key_data, payload_data);
 	default:
 		throw NotImplementedException("TemplatedReorderPayload for %s", EnumUtil::ToString(sort_key_type));
 	}
@@ -269,13 +288,13 @@ void SortedRun::Finalize(bool external) {
 	}
 
 	// Sort the fixed-size portion of the keys
-	SortSwitch(*key_data, is_index_sort);
+	SortSwitch(context, *key_data, is_index_sort);
 
 	if (external) {
 		// Reorder variable-size portion of keys and/or payload data (if necessary)
 		const auto sort_key_type = key_data->GetLayout().GetSortKeyType();
 		if (!SortKeyUtils::IsConstantSize(sort_key_type) || SortKeyUtils::HasPayload(sort_key_type)) {
-			Reorder(key_data, payload_data);
+			Reorder(context, key_data, payload_data);
 		}
 	}
 

--- a/src/common/types/row/tuple_data_layout.cpp
+++ b/src/common/types/row/tuple_data_layout.cpp
@@ -148,6 +148,7 @@ void TupleDataLayout::Initialize(const vector<BoundOrderByNode> &orders, const L
 	data_width = DConstants::INVALID_INDEX;
 	aggr_width = DConstants::INVALID_INDEX;
 	offsets.clear();
+	sort_skippable_bytes.clear();
 	all_constant = true;
 	heap_size_offset = DConstants::INVALID_INDEX;
 	aggr_destructor_idxs.clear();

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -858,7 +858,7 @@ void GroupedAggregateHashTable::Combine(TupleDataCollection &other_data, optiona
 	const auto chunk_count = other_data.ChunkCount();
 	while (fm_state.Scan()) {
 		// Check for interrupts with each chunk
-		if (context.interrupted) {
+		if (context.interrupted.load(std::memory_order_relaxed)) {
 			throw InterruptException();
 		}
 		const auto input_chunk_size = fm_state.groups.size();

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -66,7 +66,7 @@ SinkFinalizeType PhysicalOrder::Finalize(Pipeline &pipeline, Event &event, Clien
                                          OperatorSinkFinalizeInput &input) const {
 	auto &gstate = input.global_state.Cast<OrderGlobalSinkState>();
 	OperatorSinkFinalizeInput sort_input {*gstate.state, input.interrupt_state};
-	return gstate.sort.Finalize(pipeline, event, context, sort_input);
+	return gstate.sort.Finalize(context, sort_input);
 }
 
 ProgressData PhysicalOrder::GetSinkProgress(ClientContext &context, GlobalSinkState &gstate_p,

--- a/src/include/duckdb/common/sorting/sort.hpp
+++ b/src/include/duckdb/common/sorting/sort.hpp
@@ -55,8 +55,7 @@ public:
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const;
 	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const;
 	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const;
-	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
-	                          OperatorSinkFinalizeInput &input) const;
+	SinkFinalizeType Finalize(ClientContext &context, OperatorSinkFinalizeInput &input) const;
 	ProgressData GetSinkProgress(ClientContext &context, GlobalSinkState &gstate,
 	                             const ProgressData source_progress) const;
 

--- a/src/include/duckdb/common/sorting/sorted_run.hpp
+++ b/src/include/duckdb/common/sorting/sorted_run.hpp
@@ -19,7 +19,7 @@ class TupleDataLayout;
 
 class SortedRun {
 public:
-	SortedRun(BufferManager &buffer_manager, shared_ptr<TupleDataLayout> key_layout,
+	SortedRun(ClientContext &context, shared_ptr<TupleDataLayout> key_layout,
 	          shared_ptr<TupleDataLayout> payload_layout, bool is_index_sort);
 
 	~SortedRun();
@@ -37,6 +37,8 @@ public:
 	idx_t SizeInBytes() const;
 
 public:
+	ClientContext &context;
+
 	//! Key and payload collections (and associated append states)
 	unique_ptr<TupleDataCollection> key_data;
 	unique_ptr<TupleDataCollection> payload_data;

--- a/src/include/duckdb/common/types/row/tuple_data_layout.hpp
+++ b/src/include/duckdb/common/types/row/tuple_data_layout.hpp
@@ -92,6 +92,10 @@ public:
 		D_ASSERT(IsSortKeyLayout());
 		return sort_width;
 	}
+	inline const vector<idx_t> &GetSortSkippableBytes() const {
+		D_ASSERT(IsSortKeyLayout());
+		return sort_skippable_bytes;
+	}
 	//! Returns the column offsets into each row
 	inline const vector<idx_t> &GetOffsets() const {
 		return offsets;
@@ -133,6 +137,8 @@ private:
 	idx_t aggr_width;
 	//! The width of the sort key
 	idx_t sort_width;
+	//! Bytes that are skippable during sorting
+	vector<idx_t> sort_skippable_bytes;
 	//! The width of the entire row
 	idx_t row_width;
 	//! The offsets to the columns and aggregate data in each row

--- a/third_party/ska_sort/ska_sort.hpp
+++ b/third_party/ska_sort/ska_sort.hpp
@@ -1107,7 +1107,9 @@ struct UnsignedInplaceSorter
     template<typename It, typename ExtractKey>
     static void sort(It begin, It end, size_t num_elements, ExtractKey & extract_key, void (*next_sort)(It, It, size_t, ExtractKey &, void *), void * sort_data)
     {
-        if (num_elements < AmericanFlagSortThreshold)
+    	if (extract_key.ByteIsSkippable(Offset))
+    		UnsignedInplaceSorter<StdSortThreshold, AmericanFlagSortThreshold, CurrentSubKey, NumBytes, Offset + 1>::sort(begin, end, num_elements, extract_key, next_sort, sort_data);
+        else if (num_elements < AmericanFlagSortThreshold)
             american_flag_sort(begin, end, extract_key, next_sort, sort_data);
         else
             ska_byte_sort(begin, end, extract_key, next_sort, sort_data);

--- a/third_party/ska_sort/ska_sort.hpp
+++ b/third_party/ska_sort/ska_sort.hpp
@@ -1107,7 +1107,9 @@ struct UnsignedInplaceSorter
     template<typename It, typename ExtractKey>
     static void sort(It begin, It end, size_t num_elements, ExtractKey & extract_key, void (*next_sort)(It, It, size_t, ExtractKey &, void *), void * sort_data)
     {
-    	if (extract_key.ByteIsSkippable(Offset))
+    	if (extract_key.Interrupted())
+    		return;
+    	else if (extract_key.ByteIsSkippable(Offset))
     		UnsignedInplaceSorter<StdSortThreshold, AmericanFlagSortThreshold, CurrentSubKey, NumBytes, Offset + 1>::sort(begin, end, num_elements, extract_key, next_sort, sort_data);
         else if (num_elements < AmericanFlagSortThreshold)
             american_flag_sort(begin, end, extract_key, next_sort, sort_data);


### PR DESCRIPTION
 * Integrate new sorting code into `list_sort` (replacing the old sort code used there)
 * Skip `NULL` bytes during radix sort if statistics tell us that they're all valid (~5% raw integer sorting performance gain over previous PR)
 * Check for interrupts during sorted run generation. This happens during recursive calls to radix sort, and while reordering payload data (if external sort). This is especially useful if you change your mind during a long-running sort query. No need to spam CTRL+C anymore, the interrupt is quite snappy now
 * Unpin key data even if we're sorting fixed keys without a payload (edge case that prevented external sorting), fixes https://github.com/duckdb/duckdb/issues/15449