### PR TITLE
Parquet Reader: only read strings as fixed length strings if the type is FIXED_LEN_BYTE_ARRAY

### DIFF
--- a/extension/parquet/reader/decimal_column_reader.cpp
+++ b/extension/parquet/reader/decimal_column_reader.cpp
@@ -46,7 +46,7 @@ double ParquetDecimalUtils::ReadDecimalValue(const_data_ptr_t pointer, idx_t siz
 }
 
 unique_ptr<ColumnReader> ParquetDecimalUtils::CreateReader(ParquetReader &reader, const ParquetColumnSchema &schema) {
-	if (schema.type_length > 0) {
+	if (schema.parquet_type == Type::FIXED_LEN_BYTE_ARRAY) {
 		return CreateDecimalReaderInternal<true>(reader, schema);
 	} else {
 		return CreateDecimalReaderInternal<false>(reader, schema);

--- a/extension/parquet/reader/string_column_reader.cpp
+++ b/extension/parquet/reader/string_column_reader.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 StringColumnReader::StringColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
     : ColumnReader(reader, schema) {
 	fixed_width_string_length = 0;
-	if (schema.type_length > 0) {
+	if (schema.parquet_type == Type::FIXED_LEN_BYTE_ARRAY) {
 		fixed_width_string_length = schema.type_length;
 	}
 }


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/duckdb/duckdb/pull/16161

Type length may also be set for variable-length byte arrays (in which case it should be ignored).