### PR TITLE
Fix windows-2025 build errors

### DIFF
--- a/src/common/types/uuid.cpp
+++ b/src/common/types/uuid.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/types/uuid.hpp"
+#include "duckdb/common/chrono.hpp"
 #include "duckdb/common/random_engine.hpp"
 
 namespace duckdb {


### PR DESCRIPTION
GHA is retiring windows-2019 runner image. This commit fixes a build error on windows-2025

> The Windows Server 2019 runner image will be fully unsupported by June 30, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Windows Server 2019. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
> 
> June 3 13:00-21:00 UTC
> June 10 13:00-21:00 UTC
> June 17 13:00-21:00 UTC
> June 24 13:00-21:00 UTC