### PR TITLE
Internal #4995: Commutative INTERVAL Multiply

### DIFF
--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -883,8 +883,14 @@ ScalarFunctionSet OperatorMultiplyFun::GetFunctions() {
 	    ScalarFunction({LogicalType::INTERVAL, LogicalType::DOUBLE}, LogicalType::INTERVAL,
 	                   ScalarFunction::BinaryFunction<interval_t, double, interval_t, MultiplyOperator>));
 	multiply.AddFunction(
+	    ScalarFunction({LogicalType::DOUBLE, LogicalType::INTERVAL}, LogicalType::INTERVAL,
+	                   ScalarFunction::BinaryFunction<double, interval_t, interval_t, MultiplyOperator>));
+	multiply.AddFunction(
 	    ScalarFunction({LogicalType::BIGINT, LogicalType::INTERVAL}, LogicalType::INTERVAL,
 	                   ScalarFunction::BinaryFunction<int64_t, interval_t, interval_t, MultiplyOperator>));
+	multiply.AddFunction(
+	    ScalarFunction({LogicalType::INTERVAL, LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                   ScalarFunction::BinaryFunction<interval_t, int64_t, interval_t, MultiplyOperator>));
 	for (auto &func : multiply.functions) {
 		ScalarFunction::SetReturnsError(func);
 	}

--- a/test/fuzzer/sqlsmith/interval_multiply_overflow.test
+++ b/test/fuzzer/sqlsmith/interval_multiply_overflow.test
@@ -11,4 +11,4 @@ statement error
 SELECT multiply("interval", "bigint") 
 FROM all_types;
 ----
-Overflow in multiplication of INTERVAL
+can't be cast because the value is out of range for the destination type INT32

--- a/test/sql/function/interval/test_interval_muldiv.test
+++ b/test/sql/function/interval/test_interval_muldiv.test
@@ -79,3 +79,25 @@ FROM INTERVAL_MULDIV_TBL;
 1 day 04:48:00
 4 days 04:48:00
 9 months 39 days 16:33:36
+
+# Commutativity
+query I
+select (interval '1 days') * 0.5::DOUBLE;
+----
+12:00:00
+
+query I
+select 0.5::DOUBLE * (interval '1 days');
+----
+12:00:00
+
+query I
+select 2::BIGINT * (interval '1 days');
+----
+2 days
+
+query I
+select (interval '1 days') * 2::BIGINT;
+----
+2 days
+


### PR DESCRIPTION
* Add missing commutative variants for DOUBLE and BIGINT
* Fix broken test that no one seemed to have noticed...

fixes: duckdblabs/duckdb-internal#4995