### PR TITLE
csv_scanner: correct code comment

### DIFF
--- a/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
@@ -79,7 +79,7 @@ struct CSVReaderOptions {
 	vector<string> name_list;
 	//! If the names and types were set by the columns parameter
 	bool columns_set = false;
-	//! Types considered as candidates for auto-detection ordered by descending specificity (~ from high to low)
+	//! Types considered as candidates for auto-detection ordered by ascending specificity (~ from low to high)
 	vector<LogicalType> auto_type_candidates = {
 	    LogicalType::VARCHAR,      LogicalType::DOUBLE,    LogicalType::BIGINT,
 	    LogicalType::TIMESTAMP_TZ, LogicalType::TIMESTAMP, LogicalType::DATE,


### PR DESCRIPTION
correct explanation about specificity by inverting it

SQLNULL has the highest specificity not the lowest VARCHAR is the fallback and has therefore the lowest specificity

See https://github.com/duckdb/duckdb/blob/dcf0e1c8936d74be48fd1cc0309638117b43aa47/src/execution/operator/csv_scanner/util/csv_reader_options.cpp#L523-L530

I was confused by the code comment in the header file while improving the documentation since it contradicts the actual specifity weights in the cpp file.
https://github.com/duckdb/duckdb-web/pull/5459