### PR TITLE
Deprecate windows-2019 runners 

### DIFF
--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -105,7 +105,7 @@ jobs:
 
   bundle-mingw-static-lib:
     name: Windows MingW static libs
-    runs-on: windows-2019
+    runs-on: windows-latest
     env:
       ENABLE_EXTENSION_AUTOLOADING: 1
       ENABLE_EXTENSION_AUTOINSTALL: 1

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -294,7 +294,7 @@ jobs:
 
   win-python3:
       name: Python 3 Windows
-      runs-on: windows-2019
+      runs-on: windows-latest
       needs: linux-python3-10
       strategy:
        matrix:

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -43,7 +43,7 @@ jobs:
   rstats-windows-extensions:
     # Builds extensions for windows_amd64_rtools
     name: R Package Windows (Extensions)
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -60,7 +60,7 @@ jobs:
  win-release-64:
     # Builds binaries for windows_amd64
     name: Windows (64 Bit)
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -150,7 +150,7 @@ jobs:
  win-release-32:
     name: Windows (32 Bit)
     if: github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' || inputs.run_all == 'true'
-    runs-on: windows-2019
+    runs-on: windows-latest
     needs: win-release-64
 
     steps:
@@ -190,7 +190,7 @@ jobs:
  win-release-arm64:
    name: Windows (ARM64)
    if: github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' || inputs.run_all == 'true'
-   runs-on: windows-2019
+   runs-on: windows-latest
    needs: win-release-64
 
    steps:
@@ -253,7 +253,7 @@ jobs:
 
  mingw:
      name: MinGW (64 Bit)
-     runs-on: windows-2019
+     runs-on: windows-latest
      if: ${{ inputs.skip_tests != 'true' }}
      needs: win-release-64
      steps:
@@ -297,7 +297,7 @@ jobs:
  win-extensions-64:
    # Builds extensions for windows_amd64
    name: Windows Extensions (64-bit)
-   runs-on: windows-2019
+   runs-on: windows-latest
    needs: win-release-64
    steps:
      - name: Keep \n line endings
@@ -343,7 +343,7 @@ jobs:
       duckdb_sha: ${{ github.sha }}
 
  win-packaged-upload:
-   runs-on: windows-2019
+   runs-on: windows-latest
    needs:
      - win-release-64
      - win-release-arm64


### PR DESCRIPTION
> The Windows Server 2019 runner image will be fully unsupported by June 30, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Windows Server 2019. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
