### PR TITLE
Fix wrong assertion in Parquet DBP encoder

### DIFF
--- a/extension/parquet/include/parquet_dbp_encoder.hpp
+++ b/extension/parquet/include/parquet_dbp_encoder.hpp
@@ -155,8 +155,8 @@ private:
 			int64_t verification_data[NUMBER_OF_VALUES_IN_A_MINIBLOCK];
 			ByteBuffer byte_buffer(data_ptr_cast(data_packed), write_size);
 			bitpacking_width_t bitpack_pos = 0;
-			ParquetDecodeUtils::BitUnpack(byte_buffer, bitpack_pos, verification_data, NUMBER_OF_VALUES_IN_A_MINIBLOCK,
-			                              width);
+			ParquetDecodeUtils::BitUnpack(byte_buffer, bitpack_pos, reinterpret_cast<uint64_t *>(verification_data),
+			                              NUMBER_OF_VALUES_IN_A_MINIBLOCK, width);
 			for (idx_t i = 0; i < NUMBER_OF_VALUES_IN_A_MINIBLOCK; i++) {
 				D_ASSERT(src[i] == verification_data[i]);
 			}

--- a/test/parquet/bss_roundtrip.test_slow
+++ b/test/parquet/bss_roundtrip.test_slow
@@ -23,7 +23,7 @@ from doubles
 
 
 statement ok
-copy doubles to '__TEST_DIR__/bss.parquet';
+copy doubles to '__TEST_DIR__/bss.parquet' (PARQUET_VERSION V2);
 
 query IIII nosort q0
 from '__TEST_DIR__/bss.parquet';
@@ -44,7 +44,7 @@ from floats
 
 
 statement ok
-copy floats to '__TEST_DIR__/bss.parquet';
+copy floats to '__TEST_DIR__/bss.parquet' (PARQUET_VERSION V2);
 
 query IIII nosort q1
 from '__TEST_DIR__/bss.parquet';

--- a/test/parquet/test_internal_5021.test
+++ b/test/parquet/test_internal_5021.test
@@ -2,6 +2,8 @@
 # description: Internal issue 5021: Assertion failure in DbpEncoder when writing Parquet V2
 # group: [parquet]
 
+require parquet
+
 statement ok
 CREATE TABLE tbl AS SELECT 'hello world' || i str FROM range(11) t(i);
 

--- a/test/parquet/test_internal_5021.test
+++ b/test/parquet/test_internal_5021.test
@@ -1,0 +1,9 @@
+# name: test/parquet/test_internal_5021.test
+# description: Internal issue 5021: Assertion failure in DbpEncoder when writing Parquet V2
+# group: [parquet]
+
+statement ok
+CREATE TABLE tbl AS SELECT 'hello world' || i str FROM range(11) t(i);
+
+statement ok
+COPY tbl TO '__TEST_DIR__/file.parquet' (PARQUET_VERSION 'V2', DICTIONARY_SIZE_LIMIT 1);


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/5021

We accidentally used an `int64_t` instead of a `uint64_t` during verification, so while the behavior was correct, the verification ran into an issue.