### PR TITLE
Expose file_size_bytes and footer_size in parquet_file_metadata

### DIFF
--- a/extension/parquet/include/parquet_file_metadata_cache.hpp
+++ b/extension/parquet/include/parquet_file_metadata_cache.hpp
@@ -20,7 +20,7 @@ enum class ParquetCacheValidity { VALID, INVALID, UNKNOWN };
 class ParquetFileMetadataCache : public ObjectCacheEntry {
 public:
 	ParquetFileMetadataCache(unique_ptr<duckdb_parquet::FileMetaData> file_metadata, CachingFileHandle &handle,
-	                         unique_ptr<GeoParquetFileMetadata> geo_metadata);
+	                         unique_ptr<GeoParquetFileMetadata> geo_metadata, idx_t footer_size);
 	~ParquetFileMetadataCache() override = default;
 
 	//! Parquet file metadata
@@ -28,6 +28,9 @@ public:
 
 	//! GeoParquet metadata
 	unique_ptr<GeoParquetFileMetadata> geo_metadata;
+
+	//! Parquet footer size
+	idx_t footer_size;
 
 public:
 	static string ObjectType();

--- a/extension/parquet/parquet_file_metadata_cache.cpp
+++ b/extension/parquet/parquet_file_metadata_cache.cpp
@@ -6,9 +6,10 @@ namespace duckdb {
 
 ParquetFileMetadataCache::ParquetFileMetadataCache(unique_ptr<duckdb_parquet::FileMetaData> file_metadata,
                                                    CachingFileHandle &handle,
-                                                   unique_ptr<GeoParquetFileMetadata> geo_metadata)
+                                                   unique_ptr<GeoParquetFileMetadata> geo_metadata,
+                                                   idx_t footer_size)
     : metadata(std::move(file_metadata)), geo_metadata(std::move(geo_metadata)), validate(handle.Validate()),
-      last_modified(handle.GetLastModifiedTime()), version_tag(handle.GetVersionTag()) {
+      last_modified(handle.GetLastModifiedTime()), version_tag(handle.GetVersionTag()), footer_size(footer_size) {
 }
 
 string ParquetFileMetadataCache::ObjectType() {

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -113,17 +113,6 @@ Value ParquetElementBoolean(bool value, bool is_iset) {
 	return Value::BOOLEAN(value);
 }
 
-Value ParquetElementFromFileInfo(shared_ptr<ExtendedOpenFileInfo> extended_info, string option_name) {
-	if (extended_info) {
-		auto &open_options = extended_info->options;
-		const auto entry = open_options.find(option_name);
-		if (entry != open_options.end()) {
-			return entry->second;
-		}
-	}
-	return Value();
-}
-
 //===--------------------------------------------------------------------===//
 // Row Group Meta Data
 //===--------------------------------------------------------------------===//
@@ -598,7 +587,7 @@ void ParquetMetaDataOperatorData::BindFileMetaData(vector<LogicalType> &return_t
 	return_types.emplace_back(LogicalType::UBIGINT);
 
 	names.emplace_back("footer_size");
-	return_types.emplace_back(LogicalType::UINTEGER);
+	return_types.emplace_back(LogicalType::UBIGINT);
 }
 
 void ParquetMetaDataOperatorData::LoadFileMetaData(ClientContext &context, const vector<LogicalType> &return_types,
@@ -628,9 +617,9 @@ void ParquetMetaDataOperatorData::LoadFileMetaData(ClientContext &context, const
 	                       ParquetElementStringVal(meta_data->footer_signing_key_metadata,
 	                                               meta_data->__isset.footer_signing_key_metadata));
 	//  file_size_bytes
-	current_chunk.SetValue(7, 0, ParquetElementFromFileInfo(reader->file.extended_info, "file_size"));
+	current_chunk.SetValue(7, 0, Value::UBIGINT(reader->GetHandle().GetFileSize()));
 	//  footer_size
-	current_chunk.SetValue(8, 0, ParquetElementFromFileInfo(reader->file.extended_info, "footer_size"));
+	current_chunk.SetValue(8, 0, Value::UBIGINT(reader->metadata->footer_size));
 
 	current_chunk.SetCardinality(1);
 	collection.Append(current_chunk);

--- a/test/sql/copy/parquet/file_metadata.test
+++ b/test/sql/copy/parquet/file_metadata.test
@@ -3,6 +3,14 @@
 
 require parquet
 
+statement ok
+SET parquet_metadata_cache = true;
+
+query IIIIIIIII
+SELECT * FROM parquet_file_metadata('data/parquet-testing/arrow/alltypes_dictionary.parquet')
+----
+data/parquet-testing/arrow/alltypes_dictionary.parquet	impala version 1.3.0-INTERNAL (build 8a48ddb1eff84592b3fc06bc6f51ec120e1fffc9)	2	1	1	NULL	NULL	1698	723
+
 query IIIIIIIII
 SELECT * FROM parquet_file_metadata('data/parquet-testing/arrow/alltypes_dictionary.parquet')
 ----

--- a/test/sql/copy/parquet/file_metadata.test
+++ b/test/sql/copy/parquet/file_metadata.test
@@ -3,7 +3,7 @@
 
 require parquet
 
-query IIIIIII
+query IIIIIIIII
 SELECT * FROM parquet_file_metadata('data/parquet-testing/arrow/alltypes_dictionary.parquet')
 ----
-data/parquet-testing/arrow/alltypes_dictionary.parquet	impala version 1.3.0-INTERNAL (build 8a48ddb1eff84592b3fc06bc6f51ec120e1fffc9)	2	1	1	NULL	NULL
+data/parquet-testing/arrow/alltypes_dictionary.parquet	impala version 1.3.0-INTERNAL (build 8a48ddb1eff84592b3fc06bc6f51ec120e1fffc9)	2	1	1	NULL	NULL	1698	723


### PR DESCRIPTION
Hi, like many others I have been playing around with DuckLake in the last couple of days, and I was trying to figure out if I could create the required tables from a set of Parquet files I already had laying around. I found that it was tricky to create the `ducklake_data_file` table because (as far as I'm aware) there is no easy way to get the total size and footer size of Parquet files at the moment. I've tried to implement that functionality in this PR, by adding `file_size_bytes` and `footer_size` columns to the `parquet_file_metadata` function.

```
D SELECT file_name, file_size_bytes, footer_size FROM parquet_file_metadata('data/parquet-testing/arrow/alltypes_dictionary.parquet');
┌────────────────────────────────────────────────────────┬─────────────────┬─────────────┐
│                       file_name                        │ file_size_bytes │ footer_size │
│                        varchar                         │     uint64      │   uint32    │
├────────────────────────────────────────────────────────┼─────────────────┼─────────────┤
│ data/parquet-testing/arrow/alltypes_dictionary.parquet │      1698       │     723     │
└────────────────────────────────────────────────────────┴─────────────────┴─────────────┘
```
I'm not fully sure whether exposing this information through `OpenFileInfo` is the right way to go, so I'm happy to hear any feedback!