### PR TITLE
Issue #17725: Quantile NaN Compare

### DIFF
--- a/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -6,7 +6,6 @@
 #include "duckdb/common/operator/abs.hpp"
 #include "core_functions/aggregate/quantile_state.hpp"
 #include "duckdb/common/types/timestamp.hpp"
-#include "duckdb/common/queue.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/function/aggregate/sort_key_helpers.hpp"
@@ -588,7 +587,7 @@ AggregateFunction GetContinuousQuantileList(const LogicalType &type) {
 //===--------------------------------------------------------------------===//
 // Quantile binding
 //===--------------------------------------------------------------------===//
-static const Value &CheckQuantile(const Value &quantile_val) {
+static Value CheckQuantile(const Value &quantile_val) {
 	if (quantile_val.IsNull()) {
 		throw BinderException("QUANTILE parameter cannot be NULL");
 	}
@@ -820,7 +819,7 @@ struct ContinuousQuantileListFunction {
 };
 
 template <class OP>
-AggregateFunction EmptyQuantileFunction(LogicalType input, LogicalType result, const LogicalType &extra_arg) {
+AggregateFunction EmptyQuantileFunction(LogicalType input, const LogicalType &result, const LogicalType &extra_arg) {
 	AggregateFunction fun({std::move(input)}, std::move(result), nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
 	                      OP::Bind);
 	if (extra_arg.id() != LogicalTypeId::INVALID) {

--- a/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
@@ -144,7 +144,7 @@ struct QuantileCompare {
 		const auto lval = accessor_l(lhs);
 		const auto rval = accessor_r(rhs);
 
-		return desc ? (rval < lval) : (lval < rval);
+		return desc ? LessThan::Operation(rval, lval) : LessThan::Operation(lval, rval);
 	}
 };
 

--- a/test/sql/aggregate/aggregates/test_quantile_disc.test
+++ b/test/sql/aggregate/aggregates/test_quantile_disc.test
@@ -268,3 +268,25 @@ query I
 SELECT quantile_disc(r, 0.1) FROM quantile WHERE 1=0
 ----
 NULL
+
+# NaNs
+foreach fp float double
+
+loop i 0 10
+
+query I
+with a as (
+	select 'NaN'::${fp} as num 
+	union all 
+	select num::${fp} as num from generate_series(1,99) as tbl(num)
+	union all 
+	select 'NaN'::${fp} as num
+) 
+select quantile_disc(num, 0.9) c1 
+from a;
+----
+91.0
+
+endloop
+
+endloop


### PR DESCRIPTION
* Use LessThan operator instead of naked C++ compares

fixes: duckdb#17725
fixes: duckdblabs/duckdb-internal#5036