### PR TITLE
Mark Upper/LowerComparisonType as const

### DIFF
--- a/src/include/duckdb/planner/expression/bound_between_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_between_expression.hpp
@@ -37,10 +37,10 @@ public:
 	static unique_ptr<Expression> Deserialize(Deserializer &deserializer);
 
 public:
-	ExpressionType LowerComparisonType() {
+	ExpressionType LowerComparisonType() const {
 		return lower_inclusive ? ExpressionType::COMPARE_GREATERTHANOREQUALTO : ExpressionType::COMPARE_GREATERTHAN;
 	}
-	ExpressionType UpperComparisonType() {
+	ExpressionType UpperComparisonType() const {
 		return upper_inclusive ? ExpressionType::COMPARE_LESSTHANOREQUALTO : ExpressionType::COMPARE_LESSTHAN;
 	}
 


### PR DESCRIPTION
I wanted to use these methods on a `const` reference to a
`BoundBetweenExpression` in pg_duckdb, but was unable to.
