### PR TITLE
Support glibc 2.28 environments

### DIFF
--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -189,8 +189,17 @@ jobs:
           -e BUILD_BENCHMARK=1                                                   \
           -e FORCE_WARN_UNUSED=1                                                 \
           quay.io/pypa/manylinux_2_28_${{ matrix.config.image }}                  \
-          bash -c "yum install -y perl-IPC-Cmd && git config --global --add safe.directory $PWD && make gather-libs -C $PWD"
+          bash -c "
+            set -e
+            yum install -y perl-IPC-Cmd gcc-toolset-12 gcc-toolset-12-gcc-c++
+            
+            source /opt/rh/gcc-toolset-12/enable
+            export CC=gcc
+            export CXX=g++
 
+            git config --global --add safe.directory $PWD
+            make gather-libs -C $PWD
+          "
       - name: Print platform
         shell: bash
         run: ./build/release/duckdb -c "PRAGMA platform;"

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -84,7 +84,17 @@ jobs:
         -e BUILD_BENCHMARK=1                                                   \
         -e FORCE_WARN_UNUSED=1                                                 \
         quay.io/pypa/manylinux_2_28_${{ matrix.config.image }}                  \
-        bash -c "yum install -y perl-IPC-Cmd && git config --global --add safe.directory $PWD && make -C $PWD"
+        bash -c "
+          set -e
+          yum install -y perl-IPC-Cmd gcc-toolset-12 gcc-toolset-12-gcc-c++
+        
+          source /opt/rh/gcc-toolset-12/enable
+          export CC=gcc
+          export CXX=g++
+
+          git config --global --add safe.directory $PWD
+          make -C $PWD
+        "
 
     - name: Print platform
       shell: bash


### PR DESCRIPTION
Ref: Issue #17632

This builds with GCC 12 explicitly instead of GCC 14. Building with GCC 14 creates binaries incompatible with mainstream Linux distributions using glibc 2.28.

cc: @taniabogatsch 