### PR TITLE
add ducklake to out_of_tree_extensions.cmake

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -64,6 +64,14 @@ if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux" AND NOT ${WASM_ENABLED})
 endif()
 endif()
 
+################# DUCKLAKE
+duckdb_extension_load(ducklake
+        APPLY_PATCHES
+        LOAD_TESTS
+        GIT_URL https://github.com/duckdb/ducklake
+        GIT_TAG d4e144737bc3f88aef1d8768cb2ef162b0db9f09
+        )
+
 ################# EXCEL
 duckdb_extension_load(excel
     LOAD_TESTS

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -66,7 +66,6 @@ endif()
 
 ################# DUCKLAKE
 duckdb_extension_load(ducklake
-        APPLY_PATCHES
         LOAD_TESTS
         GIT_URL https://github.com/duckdb/ducklake
         GIT_TAG d4e144737bc3f88aef1d8768cb2ef162b0db9f09


### PR DESCRIPTION
This PR adds `ducklake` extension bumped to the latest verified GIT_TAG to the `OOTE.cmake` file.