### PR TITLE
arrow_output_version option to produce arrow depending on a format version.

### DIFF
--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -243,7 +243,7 @@ static void InitializeFunctionPointers(ArrowAppendData &append_data, const Logic
 		}
 		break;
 	case LogicalTypeId::VARCHAR:
-		if (append_data.options.produce_arrow_string_view) {
+		if (append_data.options.produce_arrow_string_view && append_data.options.arrow_output_version >= 14) {
 			InitializeAppenderForType<ArrowVarcharToStringViewData>(append_data);
 		} else {
 			if (append_data.options.arrow_offset_size == ArrowOffsetSize::LARGE) {
@@ -290,7 +290,7 @@ static void InitializeFunctionPointers(ArrowAppendData &append_data, const Logic
 		InitializeAppenderForType<ArrowFixedSizeListData>(append_data);
 		break;
 	case LogicalTypeId::LIST: {
-		if (append_data.options.arrow_use_list_view) {
+		if (append_data.options.arrow_use_list_view && append_data.options.arrow_output_version >= 14) {
 			if (append_data.options.arrow_offset_size == ArrowOffsetSize::LARGE) {
 				InitializeAppenderForType<ArrowListViewData<>>(append_data);
 			} else {

--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -215,13 +215,25 @@ static void InitializeFunctionPointers(ArrowAppendData &append_data, const Logic
 	case LogicalTypeId::DECIMAL:
 		switch (type.InternalType()) {
 		case PhysicalType::INT16:
-			InitializeAppenderForType<ArrowScalarData<int32_t, int16_t>>(append_data);
+			if (append_data.options.arrow_output_version > 14) {
+				InitializeAppenderForType<ArrowScalarData<int32_t, int16_t>>(append_data);
+			} else {
+				InitializeAppenderForType<ArrowScalarData<hugeint_t, int16_t>>(append_data);
+			}
 			break;
 		case PhysicalType::INT32:
-			InitializeAppenderForType<ArrowScalarData<int32_t>>(append_data);
+			if (append_data.options.arrow_output_version > 14) {
+				InitializeAppenderForType<ArrowScalarData<int32_t>>(append_data);
+			} else {
+				InitializeAppenderForType<ArrowScalarData<hugeint_t, int32_t>>(append_data);
+			}
 			break;
 		case PhysicalType::INT64:
-			InitializeAppenderForType<ArrowScalarData<int64_t>>(append_data);
+			if (append_data.options.arrow_output_version > 14) {
+				InitializeAppenderForType<ArrowScalarData<int64_t>>(append_data);
+			} else {
+				InitializeAppenderForType<ArrowScalarData<hugeint_t, int64_t>>(append_data);
+			}
 			break;
 		case PhysicalType::INT128:
 			InitializeAppenderForType<ArrowScalarData<hugeint_t>>(append_data);

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -235,7 +235,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	case LogicalTypeId::DECIMAL: {
 		uint8_t width, scale, bit_width;
-		if (options.arrow_output_version < 14) {
+		if (options.arrow_output_version <= 14) {
 			// Before version 1.4 all decimals were int128
 			bit_width = 128;
 		} else {

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -173,7 +173,8 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		if (options.arrow_lossless_conversion) {
 			SetArrowExtension(root_holder, child, type, context);
 		} else {
-			if (options.produce_arrow_string_view) {
+			if (options.produce_arrow_string_view && options.arrow_output_version >= 14) {
+				// List views are only introduced in arrow format v1.4
 				child.format = "vu";
 			} else {
 				if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
@@ -186,7 +187,8 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	}
 	case LogicalTypeId::VARCHAR:
-		if (options.produce_arrow_string_view) {
+		if (options.produce_arrow_string_view && options.arrow_output_version >= 14) {
+			// List views are only introduced in arrow format v1.4
 			child.format = "vu";
 		} else {
 			if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
@@ -233,19 +235,24 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	case LogicalTypeId::DECIMAL: {
 		uint8_t width, scale, bit_width;
-		switch (type.InternalType()) {
-		case PhysicalType::INT16:
-		case PhysicalType::INT32:
-			bit_width = 32;
-			break;
-		case PhysicalType::INT64:
-			bit_width = 64;
-			break;
-		case PhysicalType::INT128:
+		if (options.arrow_output_version < 14) {
+			// Before version 1.4 all decimals were int128
 			bit_width = 128;
-			break;
-		default:
-			throw NotImplementedException("Unsupported internal type For DUCKDB Decimal -> Arrow ");
+		} else {
+			switch (type.InternalType()) {
+			case PhysicalType::INT16:
+			case PhysicalType::INT32:
+				bit_width = 32;
+				break;
+			case PhysicalType::INT64:
+				bit_width = 64;
+				break;
+			case PhysicalType::INT128:
+				bit_width = 128;
+				break;
+			default:
+				throw NotImplementedException("Unsupported internal type For DUCKDB Decimal -> Arrow ");
+			}
 		}
 
 		type.GetDecimalProperties(width, scale);
@@ -279,7 +286,8 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	}
 	case LogicalTypeId::LIST: {
-		if (options.arrow_use_list_view) {
+		if (options.arrow_use_list_view && options.arrow_output_version >= 14) {
+			// List views are only introduced in arrow format v1.4
 			if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
 				child.format = "+vL";
 			} else {

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -115,6 +115,17 @@
         "scope": "global"
     },
     {
+        "name": "arrow_output_version",
+        "description": "Whether strings should be produced by DuckDB in Utf8View format instead of Utf8",
+        "type": "VARCHAR",
+        "scope": "global",
+        "internal_setting": "arrow_output_version",
+        "custom_implementation": [
+            "set",
+            "get"
+        ]
+    },
+    {
         "name": "asof_loop_join_threshold",
         "description": "The maximum number of rows we need on the left side of an ASOF join to use a nested loop join",
         "type": "UBIGINT",

--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/types.hpp"
 
@@ -16,30 +15,31 @@ namespace duckdb {
 
 enum class ArrowOffsetSize : uint8_t { REGULAR, LARGE };
 
-	enum ArrowFormatVersion {
+enum ArrowFormatVersion : uint8_t {
 	//! Base Version
-	V1_0,
+	V1_0 = 10,
 	//! Added 256-bit Decimal type.
-	V1_1,
+	V1_1 = 11,
 	//! Added MonthDayNano interval type.
-	V1_2,
+	V1_2 = 12,
 	//! Added Run-End Encoded Layout.
-	V1_3,
+	V1_3 = 13,
 	//! Added Variable-size Binary View Layout and the associated BinaryView and Utf8View types.
 	//! Added ListView Layout and the associated ListView and LargeListView types. Added Variadic buffers.
-	V1_4,
+	V1_4 = 14,
 	//! Expanded Decimal type bit widths to allow 32-bit and 64-bit types.
-	V1_5
+	V1_5 = 15
 };
 
 //! A set of properties from the client context that can be used to interpret the query result
 struct ClientProperties {
 	ClientProperties(string time_zone_p, const ArrowOffsetSize arrow_offset_size_p, const bool arrow_use_list_view_p,
-	                 const bool produce_arrow_string_view_p, const bool lossless_conversion,const ArrowFormatVersion arrow_output_version,
-	                 const optional_ptr<ClientContext> client_context)
+	                 const bool produce_arrow_string_view_p, const bool lossless_conversion,
+	                 const ArrowFormatVersion arrow_output_version, const optional_ptr<ClientContext> client_context)
 	    : time_zone(std::move(time_zone_p)), arrow_offset_size(arrow_offset_size_p),
 	      arrow_use_list_view(arrow_use_list_view_p), produce_arrow_string_view(produce_arrow_string_view_p),
-	      arrow_lossless_conversion(lossless_conversion), arrow_output_version(arrow_output_version), client_context(client_context) {
+	      arrow_lossless_conversion(lossless_conversion), arrow_output_version(arrow_output_version),
+	      client_context(client_context) {
 	}
 
 	string time_zone = "UTC";

--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -47,7 +47,7 @@ struct ClientProperties {
 	bool arrow_use_list_view = false;
 	bool produce_arrow_string_view = false;
 	bool arrow_lossless_conversion = false;
-	ArrowFormatVersion arrow_output_version = V1_5;
+	ArrowFormatVersion arrow_output_version = V1_0;
 	optional_ptr<ClientContext> client_context;
 };
 } // namespace duckdb

--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <utility>
 
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/types.hpp"
@@ -17,14 +16,30 @@ namespace duckdb {
 
 enum class ArrowOffsetSize : uint8_t { REGULAR, LARGE };
 
+	enum ArrowFormatVersion {
+	//! Base Version
+	V1_0,
+	//! Added 256-bit Decimal type.
+	V1_1,
+	//! Added MonthDayNano interval type.
+	V1_2,
+	//! Added Run-End Encoded Layout.
+	V1_3,
+	//! Added Variable-size Binary View Layout and the associated BinaryView and Utf8View types.
+	//! Added ListView Layout and the associated ListView and LargeListView types. Added Variadic buffers.
+	V1_4,
+	//! Expanded Decimal type bit widths to allow 32-bit and 64-bit types.
+	V1_5
+};
+
 //! A set of properties from the client context that can be used to interpret the query result
 struct ClientProperties {
-	ClientProperties(string time_zone_p, ArrowOffsetSize arrow_offset_size_p, bool arrow_use_list_view_p,
-	                 bool produce_arrow_string_view_p, bool lossless_conversion,
-	                 optional_ptr<ClientContext> client_context)
+	ClientProperties(string time_zone_p, const ArrowOffsetSize arrow_offset_size_p, const bool arrow_use_list_view_p,
+	                 const bool produce_arrow_string_view_p, const bool lossless_conversion,const ArrowFormatVersion arrow_output_version,
+	                 const optional_ptr<ClientContext> client_context)
 	    : time_zone(std::move(time_zone_p)), arrow_offset_size(arrow_offset_size_p),
 	      arrow_use_list_view(arrow_use_list_view_p), produce_arrow_string_view(produce_arrow_string_view_p),
-	      arrow_lossless_conversion(lossless_conversion), client_context(client_context) {
+	      arrow_lossless_conversion(lossless_conversion), arrow_output_version(arrow_output_version), client_context(client_context) {
 	}
 
 	string time_zone = "UTC";
@@ -32,6 +47,7 @@ struct ClientProperties {
 	bool arrow_use_list_view = false;
 	bool produce_arrow_string_view = false;
 	bool arrow_lossless_conversion = false;
+	ArrowFormatVersion arrow_output_version = V1_5;
 	optional_ptr<ClientContext> client_context;
 };
 } // namespace duckdb

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -124,7 +124,19 @@ public:
 protected:
 	SerializationCompatibility() = default;
 };
-
+enum ArrowFormatVersion {
+	//! Added 256-bit Decimal type.
+	V1_1,
+	//! Added MonthDayNano interval type.
+	V1_2,
+	//! Added Run-End Encoded Layout.
+	V1_3,
+	//! Added Variable-size Binary View Layout and the associated BinaryView and Utf8View types.
+	//! Added ListView Layout and the associated ListView and LargeListView types. Added Variadic buffers.
+	V1_4,
+	//! Expanded Decimal type bit widths to allow 32-bit and 64-bit types.
+	V1_5
+};
 struct DBConfigOptions {
 	//! Database file path. May be empty for in-memory mode
 	string database_path;
@@ -296,6 +308,7 @@ struct DBConfigOptions {
 	LogConfig log_config = LogConfig();
 	//! Whether to enable external file caching using CachingFileSystem
 	bool enable_external_file_cache = true;
+	ArrowFormatVersion arrow_output_version = ArrowFormatVersion::V1_5;
 	//! Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries
 #ifdef DUCKDB_ALTERNATIVE_VERIFY
 	bool scheduler_process_partial = true;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -297,7 +297,7 @@ struct DBConfigOptions {
 	//! Whether to enable external file caching using CachingFileSystem
 	bool enable_external_file_cache = true;
 	//! Output version of arrow depending on the format version
-	ArrowFormatVersion arrow_output_version = V1_5;
+	ArrowFormatVersion arrow_output_version = V1_0;
 	//! Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries
 #ifdef DUCKDB_ALTERNATIVE_VERIFY
 	bool scheduler_process_partial = true;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -124,19 +124,7 @@ public:
 protected:
 	SerializationCompatibility() = default;
 };
-enum ArrowFormatVersion {
-	//! Added 256-bit Decimal type.
-	V1_1,
-	//! Added MonthDayNano interval type.
-	V1_2,
-	//! Added Run-End Encoded Layout.
-	V1_3,
-	//! Added Variable-size Binary View Layout and the associated BinaryView and Utf8View types.
-	//! Added ListView Layout and the associated ListView and LargeListView types. Added Variadic buffers.
-	V1_4,
-	//! Expanded Decimal type bit widths to allow 32-bit and 64-bit types.
-	V1_5
-};
+
 struct DBConfigOptions {
 	//! Database file path. May be empty for in-memory mode
 	string database_path;
@@ -308,7 +296,8 @@ struct DBConfigOptions {
 	LogConfig log_config = LogConfig();
 	//! Whether to enable external file caching using CachingFileSystem
 	bool enable_external_file_cache = true;
-	ArrowFormatVersion arrow_output_version = ArrowFormatVersion::V1_5;
+	//! Output version of arrow depending on the format version
+	ArrowFormatVersion arrow_output_version = V1_5;
 	//! Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries
 #ifdef DUCKDB_ALTERNATIVE_VERIFY
 	bool scheduler_process_partial = true;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -218,6 +218,17 @@ struct ArrowOutputListViewSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct ArrowOutputVersionSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "arrow_output_version";
+	static constexpr const char *Description =
+	    "Whether strings should be produced by DuckDB in Utf8View format instead of Utf8";
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct AsofLoopJoinThresholdSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "asof_loop_join_threshold";

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1382,6 +1382,7 @@ ClientProperties ClientContext::GetClientProperties() {
 	        db->config.options.arrow_use_list_view,
 	        db->config.options.produce_arrow_string_views,
 	        db->config.options.arrow_lossless_conversion,
+			db->config.options.arrow_output_version,
 	        this};
 }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1382,7 +1382,7 @@ ClientProperties ClientContext::GetClientProperties() {
 	        db->config.options.arrow_use_list_view,
 	        db->config.options.produce_arrow_string_views,
 	        db->config.options.arrow_lossless_conversion,
-			db->config.options.arrow_output_version,
+	        db->config.options.arrow_output_version,
 	        this};
 }
 

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -72,6 +72,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(ArrowLargeBufferSizeSetting),
     DUCKDB_GLOBAL(ArrowLosslessConversionSetting),
     DUCKDB_GLOBAL(ArrowOutputListViewSetting),
+    DUCKDB_GLOBAL(ArrowOutputVersionSetting),
     DUCKDB_LOCAL(AsofLoopJoinThresholdSetting),
     DUCKDB_GLOBAL(AutoinstallExtensionRepositorySetting),
     DUCKDB_GLOBAL(AutoinstallKnownExtensionsSetting),

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -62,7 +62,7 @@ QueryResult::QueryResult(QueryResultType type, StatementType statement_type, Sta
 
 QueryResult::QueryResult(QueryResultType type, ErrorData error)
     : BaseQueryResult(type, std::move(error)),
-      client_properties("UTC", ArrowOffsetSize::REGULAR, false, false, false, nullptr) {
+      client_properties("UTC", ArrowOffsetSize::REGULAR, false, false, false,V1_5, nullptr) {
 }
 
 QueryResult::~QueryResult() {

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -62,7 +62,7 @@ QueryResult::QueryResult(QueryResultType type, StatementType statement_type, Sta
 
 QueryResult::QueryResult(QueryResultType type, ErrorData error)
     : BaseQueryResult(type, std::move(error)),
-      client_properties("UTC", ArrowOffsetSize::REGULAR, false, false, false, V1_5, nullptr) {
+      client_properties("UTC", ArrowOffsetSize::REGULAR, false, false, false, V1_0, nullptr) {
 }
 
 QueryResult::~QueryResult() {

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -62,7 +62,7 @@ QueryResult::QueryResult(QueryResultType type, StatementType statement_type, Sta
 
 QueryResult::QueryResult(QueryResultType type, ErrorData error)
     : BaseQueryResult(type, std::move(error)),
-      client_properties("UTC", ArrowOffsetSize::REGULAR, false, false, false,V1_5, nullptr) {
+      client_properties("UTC", ArrowOffsetSize::REGULAR, false, false, false, V1_5, nullptr) {
 }
 
 QueryResult::~QueryResult() {

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -178,6 +178,13 @@ Value ArrowOutputListViewSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
+// Arrow Output Version
+//===----------------------------------------------------------------------===//
+void ArrowOutputVersionSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.arrow_output_version = DBConfig().options.arrow_output_version;
+}
+
+//===----------------------------------------------------------------------===//
 // Asof Loop Join Threshold
 //===----------------------------------------------------------------------===//
 void AsofLoopJoinThresholdSetting::SetLocal(ClientContext &context, const Value &input) {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -300,7 +300,7 @@ void ArrowOutputVersionSetting::SetGlobal(DatabaseInstance *db, DBConfig &config
 	} else if (arrow_version == "1.5") {
 		config.options.arrow_output_version = V1_5;
 	} else {
-		throw NotImplementedException("Unrecognized parameter for option ARROW_OUTPUT_VERSION, expected either "
+		throw NotImplementedException("Unrecognized parameter for option arrow_output_version, expected either "
 		                              "\'1.0\', \'1.1\', \'1.2\', \'1.3\', \'1.4\', \'1.5\'");
 	}
 }

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -300,35 +300,35 @@ void ArrowOutputVersionSetting::SetGlobal(DatabaseInstance *db, DBConfig &config
 	} else if (arrow_version == "1.5") {
 		config.options.arrow_output_version = V1_5;
 	} else {
-		throw NotImplementedException("Unrecognized parameter for option ARROW_OUTPUT_VERSION, expected either \'1.0\', \'1.1\', \'1.2\', \'1.3\', \'1.4\', \'1.5\'");
+		throw NotImplementedException("Unrecognized parameter for option ARROW_OUTPUT_VERSION, expected either "
+		                              "\'1.0\', \'1.1\', \'1.2\', \'1.3\', \'1.4\', \'1.5\'");
 	}
-
 }
 
 Value ArrowOutputVersionSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	string arrow_version;
 	switch (config.options.arrow_output_version) {
-		case V1_0:
-			arrow_version = "1.0";
-			break;
-		case V1_1:
-			arrow_version = "1.1";
-			break;
-		case V1_2:
-			arrow_version = "1.2";
-			break;
-		case V1_3:
-			arrow_version = "1.3";
-			break;
-		case V1_4:
-			arrow_version = "1.4";
-			break;
-		case V1_5:
-			arrow_version = "1.5";
-			break;
-		default:
-			throw InternalException("Unrecognized arrow output version");
+	case V1_0:
+		arrow_version = "1.0";
+		break;
+	case V1_1:
+		arrow_version = "1.1";
+		break;
+	case V1_2:
+		arrow_version = "1.2";
+		break;
+	case V1_3:
+		arrow_version = "1.3";
+		break;
+	case V1_4:
+		arrow_version = "1.4";
+		break;
+	case V1_5:
+		arrow_version = "1.5";
+		break;
+	default:
+		throw InternalException("Unrecognized arrow output version");
 	}
 	return Value(arrow_version);
 }

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -283,6 +283,20 @@ Value ArrowLargeBufferSizeSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
+// Arrow Output Format Version
+//===----------------------------------------------------------------------===//
+void ArrowOutputVersionSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto arrow_version = input.GetValue<string_t>();
+	config.options.arrow_offset_size = export_large_buffers_arrow ? ArrowOffsetSize::LARGE : ArrowOffsetSize::REGULAR;
+}
+
+Value ArrowOutputVersionSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	bool export_large_buffers_arrow = config.options.arrow_offset_size == ArrowOffsetSize::LARGE;
+	return Value::BOOLEAN(export_large_buffers_arrow);
+}
+
+//===----------------------------------------------------------------------===//
 // Checkpoint Threshold
 //===----------------------------------------------------------------------===//
 void CheckpointThresholdSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -286,14 +286,51 @@ Value ArrowLargeBufferSizeSetting::GetSetting(const ClientContext &context) {
 // Arrow Output Format Version
 //===----------------------------------------------------------------------===//
 void ArrowOutputVersionSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
-	auto arrow_version = input.GetValue<string_t>();
-	config.options.arrow_offset_size = export_large_buffers_arrow ? ArrowOffsetSize::LARGE : ArrowOffsetSize::REGULAR;
+	auto arrow_version = input.ToString();
+	if (arrow_version == "1.0") {
+		config.options.arrow_output_version = V1_0;
+	} else if (arrow_version == "1.1") {
+		config.options.arrow_output_version = V1_1;
+	} else if (arrow_version == "1.2") {
+		config.options.arrow_output_version = V1_2;
+	} else if (arrow_version == "1.3") {
+		config.options.arrow_output_version = V1_3;
+	} else if (arrow_version == "1.4") {
+		config.options.arrow_output_version = V1_4;
+	} else if (arrow_version == "1.5") {
+		config.options.arrow_output_version = V1_5;
+	} else {
+		throw NotImplementedException("Unrecognized parameter for option ARROW_OUTPUT_VERSION, expected either \'1.0\', \'1.1\', \'1.2\', \'1.3\', \'1.4\', \'1.5\'");
+	}
+
 }
 
 Value ArrowOutputVersionSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
-	bool export_large_buffers_arrow = config.options.arrow_offset_size == ArrowOffsetSize::LARGE;
-	return Value::BOOLEAN(export_large_buffers_arrow);
+	string arrow_version;
+	switch (config.options.arrow_output_version) {
+		case V1_0:
+			arrow_version = "1.0";
+			break;
+		case V1_1:
+			arrow_version = "1.1";
+			break;
+		case V1_2:
+			arrow_version = "1.2";
+			break;
+		case V1_3:
+			arrow_version = "1.3";
+			break;
+		case V1_4:
+			arrow_version = "1.4";
+			break;
+		case V1_5:
+			arrow_version = "1.5";
+			break;
+		default:
+			throw InternalException("Unrecognized arrow output version");
+	}
+	return Value(arrow_version);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -118,6 +118,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"http_logging_output", {"my_cool_outputfile"}},
 	    {"allocator_flush_threshold", {"4.0 GiB"}},
 	    {"allocator_bulk_deallocation_flush_threshold", {"4.0 GiB"}},
+	    {"arrow_output_version", {"1.0"}},
 	    {"enable_external_file_cache", {false}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -118,7 +118,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"http_logging_output", {"my_cool_outputfile"}},
 	    {"allocator_flush_threshold", {"4.0 GiB"}},
 	    {"allocator_bulk_deallocation_flush_threshold", {"4.0 GiB"}},
-	    {"arrow_output_version", {"1.0"}},
+	    {"arrow_output_version", {"1.5"}},
 	    {"enable_external_file_cache", {false}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_decimal_32_64.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_decimal_32_64.py
@@ -8,6 +8,7 @@ pa = pytest.importorskip("pyarrow")
 class TestArrowDecimalTypes(object):
     def test_decimal_32(self, duckdb_cursor):
         duckdb_cursor = duckdb.connect()
+        duckdb_cursor.execute('SET arrow_output_version = 1.5')
         decimal_32 = pa.Table.from_pylist(
             [
                 {"data": Decimal("100.20")},
@@ -36,6 +37,7 @@ class TestArrowDecimalTypes(object):
 
     def test_decimal_64(self, duckdb_cursor):
         duckdb_cursor = duckdb.connect()
+        duckdb_cursor.execute('SET arrow_output_version = 1.5')
         decimal_64 = pa.Table.from_pylist(
             [
                 {"data": Decimal("1000.231")},

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_version_format.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_version_format.py
@@ -8,6 +8,7 @@ pa = pytest.importorskip("pyarrow")
 class TestArrowDecimalTypes(object):
     def test_decimal_v1_5(self, duckdb_cursor):
         duckdb_cursor = duckdb.connect()
+        duckdb_cursor.execute(f"SET arrow_output_version = 1.5")
         decimal_32 = pa.Table.from_pylist(
             [
                 {"data": Decimal("100.20")},
@@ -56,6 +57,7 @@ class TestArrowDecimalTypes(object):
 
     def test_view_v1_4(self, duckdb_cursor):
         duckdb_cursor = duckdb.connect()
+        duckdb_cursor.execute(f"SET arrow_output_version = 1.5")
         duckdb_cursor.execute("SET produce_arrow_string_view=True")
         duckdb_cursor.execute("SET arrow_output_list_view=True")
         col_type = duckdb_cursor.execute("SELECT 'string' as data ").arrow().schema.field("data").type

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_version_format.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_version_format.py
@@ -1,0 +1,48 @@
+import duckdb
+import pytest
+from decimal import Decimal
+
+pa = pytest.importorskip("pyarrow")
+
+
+class TestArrowDecimalTypes(object):
+    def test_v1_5(self, duckdb_cursor):
+        duckdb_cursor = duckdb.connect()
+        decimal_32 = pa.Table.from_pylist(
+            [
+                {"data": Decimal("100.20")},
+                {"data": Decimal("110.21")},
+                {"data": Decimal("31.20")},
+                {"data": Decimal("500.20")},
+            ],
+            pa.schema([("data", pa.decimal32(5, 2))]),
+        )
+        col_type = duckdb_cursor.execute("FROM decimal_32").arrow().schema.field("data").type
+        assert col_type.bit_width == 32 and pa.types.is_decimal(col_type)
+
+        decimal_64 = pa.Table.from_pylist(
+            [
+                {"data": Decimal("1000.231")},
+                {"data": Decimal("1100.231")},
+                {"data": Decimal("999999999999.231")},
+                {"data": Decimal("500.20")},
+            ],
+            pa.schema([("data", pa.decimal64(16, 3))]),
+        )
+        col_type = duckdb_cursor.execute("FROM decimal_64").arrow().schema.field("data").type
+        assert col_type.bit_width == 64 and pa.types.is_decimal(col_type)
+        for version in ['1.0', '1.1', '1.2', '1.3', '1.4']:
+            duckdb_cursor.execute(f"SET arrow_output_version = {version}")
+            result = duckdb_cursor.execute("FROM decimal_32").arrow()
+            col_type = result.schema.field("data").type
+            assert col_type.bit_width == 128 and pa.types.is_decimal(col_type)
+            assert result.to_pydict() == {
+                'data': [Decimal('100.20'), Decimal('110.21'), Decimal('31.20'), Decimal('500.20')]
+            }
+
+            result = duckdb_cursor.execute("FROM decimal_64").arrow()
+            col_type = result.schema.field("data").type
+            assert col_type.bit_width == 128 and pa.types.is_decimal(col_type)
+            assert result.to_pydict() == {
+                'data': [Decimal('1000.231'), Decimal('1100.231'), Decimal('999999999999.231'), Decimal('500.200')]
+            }

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_version_format.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_version_format.py
@@ -6,7 +6,7 @@ pa = pytest.importorskip("pyarrow")
 
 
 class TestArrowDecimalTypes(object):
-    def test_v1_5(self, duckdb_cursor):
+    def test_decimal_v1_5(self, duckdb_cursor):
         duckdb_cursor = duckdb.connect()
         decimal_32 = pa.Table.from_pylist(
             [
@@ -46,3 +46,43 @@ class TestArrowDecimalTypes(object):
             assert result.to_pydict() == {
                 'data': [Decimal('1000.231'), Decimal('1100.231'), Decimal('999999999999.231'), Decimal('500.200')]
             }
+
+    def test_invalide_opt(self, duckdb_cursor):
+        duckdb_cursor = duckdb.connect()
+        with pytest.raises(
+            duckdb.NotImplementedException, match=" Unrecognized parameter for option arrow_output_version"
+        ):
+            duckdb_cursor.execute(f"SET arrow_output_version = 999.9")
+
+    def test_view_v1_4(self, duckdb_cursor):
+        duckdb_cursor = duckdb.connect()
+        duckdb_cursor.execute("SET produce_arrow_string_view=True")
+        duckdb_cursor.execute("SET arrow_output_list_view=True")
+        col_type = duckdb_cursor.execute("SELECT 'string' as data ").arrow().schema.field("data").type
+        assert pa.types.is_string_view(col_type)
+        col_type = duckdb_cursor.execute("SELECT ['string'] as data ").arrow().schema.field("data").type
+        assert pa.types.is_list_view(col_type)
+
+        for version in ['1.0', '1.1', '1.2', '1.3']:
+            duckdb_cursor.execute(f"SET arrow_output_version = {version}")
+            col_type = duckdb_cursor.execute("SELECT 'string' as data ").arrow().schema.field("data").type
+            assert not pa.types.is_string_view(col_type)
+            col_type = duckdb_cursor.execute("SELECT ['string'] as data ").arrow().schema.field("data").type
+            assert not pa.types.is_list_view(col_type)
+
+        for version in ['1.4', '1.5']:
+            duckdb_cursor.execute(f"SET arrow_output_version = {version}")
+            col_type = duckdb_cursor.execute("SELECT 'string' as data ").arrow().schema.field("data").type
+            assert pa.types.is_string_view(col_type)
+
+            col_type = duckdb_cursor.execute("SELECT ['string'] as data ").arrow().schema.field("data").type
+            assert pa.types.is_list_view(col_type)
+
+        duckdb_cursor.execute("SET produce_arrow_string_view=False")
+        duckdb_cursor.execute("SET arrow_output_list_view=False")
+        for version in ['1.4', '1.5']:
+            duckdb_cursor.execute(f"SET arrow_output_version = {version}")
+            col_type = duckdb_cursor.execute("SELECT 'string' as data ").arrow().schema.field("data").type
+            assert not pa.types.is_string_view(col_type)
+            col_type = duckdb_cursor.execute("SELECT ['string'] as data ").arrow().schema.field("data").type
+            assert not pa.types.is_list_view(col_type)


### PR DESCRIPTION
This PR introduces a new option, the `arrow_output_version`, which allows us to specify a format version to which we should output our data to. We default to V1.0.

This new variable kind of makes the `produce_arrow_string_view` `arrow_output_list_view` useless, but I guess that removing them might be slightly controversial, since it might break ppl's scripts. Hence I went with inter-op.

https://arrow.apache.org/docs/format/Versioning.html#post-1-0-0-format-versions

Fix: https://github.com/duckdblabs/duckdb-internal/issues/5058