### PR TITLE
Fix propagatesNullValues for case expr

### DIFF
--- a/src/planner/expression.cpp
+++ b/src/planner/expression.cpp
@@ -68,7 +68,7 @@ bool Expression::PropagatesNullValues() const {
 	if (type == ExpressionType::OPERATOR_IS_NULL || type == ExpressionType::OPERATOR_IS_NOT_NULL ||
 	    type == ExpressionType::COMPARE_NOT_DISTINCT_FROM || type == ExpressionType::COMPARE_DISTINCT_FROM ||
 	    type == ExpressionType::CONJUNCTION_OR || type == ExpressionType::CONJUNCTION_AND ||
-	    type == ExpressionType::OPERATOR_COALESCE) {
+	    type == ExpressionType::OPERATOR_COALESCE || type == ExpressionType::CASE_EXPR) {
 		return false;
 	}
 	bool propagate_null_values = true;

--- a/test/sql/subquery/scalar/test_correlated_subquery.test
+++ b/test/sql/subquery/scalar/test_correlated_subquery.test
@@ -192,3 +192,10 @@ NULL	NULL
 2	42
 3	42
 
+query II
+SELECT i, (SELECT CASE WHEN sum(i) > 1 THEN 0 ELSE 1 END FROM integers WHERE i=i1.i) FROM integers i1;
+----
+1	1
+2	0
+3	0
+NULL	1


### PR DESCRIPTION
The following query returned unexpected results:
```sql
INSERT INTO integers VALUES (1), (2), (3), (NULL);

SELECT i, (SELECT CASE WHEN sum(i) > 1 THEN 0 ELSE 1 END FROM integers WHERE i=i1.i) FROM integers i1;
```
```
Expected result:
----
1       1
2       0
3       0
NULL    1

Actual result:
----
1       1
2       0
3       0
NULL    NULL
```

This is because `PropagatesNullValues` does not strictly account for `case_expr`. A simple fix is to make it return `false` (Perhaps we can return more precise results based on the child).