### PR TITLE
Add STRUCT to MAP cast function

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1067,7 +1067,7 @@ static bool CombineStructTypes(const LogicalType &left, const LogicalType &right
 
 	// Create a super-set of the STRUCT fields.
 	// First, create a name->index map of the right children.
-	case_insensitive_map_t<idx_t> right_children_map;
+	InsertionOrderPreservingMap<idx_t> right_children_map;
 	for (idx_t i = 0; i < right_children.size(); i++) {
 		auto &name = right_children[i].first;
 		right_children_map[name] = i;

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -229,6 +229,120 @@ static bool StructToVarcharCast(Vector &source, Vector &result, idx_t count, Cas
 	return true;
 }
 
+unique_ptr<BoundCastData> StructToMapBoundCastData::BindStructToMapCast(BindCastInput &input, const LogicalType &source,
+                                                                        const LogicalType &target) {
+	if (StructType::IsUnnamed(source)) {
+		throw TypeMismatchException(input.query_location, source, target, "Cannot cast unnamed STRUCTs to MAP");
+	}
+	// Get a cast function for the keys (struct has varchar keys, map has single-type keys)
+	auto key_cast = input.GetCastFunction(LogicalType::VARCHAR, MapType::KeyType(target));
+	// Get cast function for the values (struct may have different value types per key, map has single-type values)
+	vector<BoundCastInfo> value_casts;
+	auto target_value_type = MapType::ValueType(target);
+	for (idx_t i = 0; i < StructType::GetChildCount(source); i++) {
+		auto value_cast = input.GetCastFunction(StructType::GetChildType(source, i), target_value_type);
+		value_casts.push_back(std::move(value_cast));
+	}
+	return make_uniq<StructToMapBoundCastData>(std::move(key_cast), std::move(value_casts));
+}
+
+unique_ptr<FunctionLocalState>
+StructToMapBoundCastData::InitStructToMapCastLocalState(CastLocalStateParameters &parameters) {
+	auto &cast_data = parameters.cast_data->Cast<StructToMapBoundCastData>();
+	auto result = make_uniq<StructToMapCastLocalState>();
+
+	if (cast_data.key_cast.init_local_state) {
+		CastLocalStateParameters child_params(parameters, cast_data.key_cast.cast_data);
+		result->key_state = cast_data.key_cast.init_local_state(child_params);
+	}
+
+	for (auto &entry : cast_data.value_casts) {
+		unique_ptr<FunctionLocalState> child_state;
+		if (entry.init_local_state) {
+			CastLocalStateParameters child_params(parameters, entry.cast_data);
+			child_state = entry.init_local_state(child_params);
+		}
+		result->value_states.push_back(std::move(child_state));
+	}
+	return std::move(result);
+}
+
+static bool StructToMapCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+
+	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// If the source is a constant vector the result may be as well
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		// No need to do anything with null structs
+		if (ConstantVector::IsNull(source)) {
+			ConstantVector::SetNull(result, true);
+			return true;
+		}
+	}
+
+	auto &cast_data = parameters.cast_data->Cast<StructToMapBoundCastData>();
+	auto &local_state = parameters.local_state->Cast<StructToMapCastLocalState>();
+
+	// Grab all struct columns
+	auto &source_children = StructVector::GetEntries(source);
+	idx_t field_count = source_children.size();
+	idx_t total_count = count * field_count;
+
+	// Allocate result
+	ListVector::Reserve(result, total_count);
+
+	// Create key vector with VARCHAR keys (could make this a dictionary vector...?)
+	Vector varchar_keys(LogicalType::VARCHAR, total_count);
+	auto key_data = FlatVector::GetData<string_t>(varchar_keys);
+	auto &field_types = StructType::GetChildTypes(source.GetType());
+	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+		for (idx_t field_idx = 0; field_idx < field_count; field_idx++) {
+			auto global_idx = row_idx * field_count + field_idx;
+			auto &field_name = field_types[field_idx].first;
+			key_data[global_idx] = StringVector::AddString(varchar_keys, field_name);
+		}
+	}
+
+	// Cast keys to result
+	auto &map_keys = MapVector::GetKeys(result);
+	CastParameters key_parameters(parameters, cast_data.key_cast.cast_data, local_state.key_state);
+	auto keys_converted = cast_data.key_cast.function(varchar_keys, map_keys, total_count, key_parameters);
+
+	// Fill the values vector
+	bool values_converted = true;
+	auto &map_values = MapVector::GetValues(result);
+	for (idx_t field_idx = 0; field_idx < field_count; field_idx++) {
+		auto &source_field = *source_children[field_idx];
+		Vector temp_converted(MapType::ValueType(result.GetType()), count);
+		CastParameters child_params(parameters, cast_data.value_casts[field_idx].cast_data,
+		                            local_state.value_states[field_idx]);
+		auto success = cast_data.value_casts[field_idx].function(source_field, temp_converted, count, child_params);
+		if (!success) {
+			values_converted = false;
+		}
+
+		// Interleave results
+		for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+			auto target_idx = row_idx * field_count + field_idx;
+			// Copy also does a validity check
+			VectorOperations::Copy(temp_converted, map_values, row_idx + 1, row_idx, target_idx);
+		}
+	}
+
+	// Create list data
+	auto list_data = ListVector::GetData(result);
+	for (idx_t i = 0; i < count; i++) {
+		if (source.GetVectorType() == VectorType::FLAT_VECTOR && FlatVector::IsNull(source, i)) {
+			FlatVector::SetNull(result, i, true);
+		} else {
+			list_data[i] = list_entry_t(i * field_count, field_count);
+		}
+	}
+	// Set the size
+	ListVector::SetListSize(result, total_count);
+
+	return keys_converted && values_converted;
+}
+
 BoundCastInfo DefaultCasts::StructCastSwitch(BindCastInput &input, const LogicalType &source,
                                              const LogicalType &target) {
 	switch (target.id()) {
@@ -246,6 +360,10 @@ BoundCastInfo DefaultCasts::StructCastSwitch(BindCastInput &input, const Logical
 		return BoundCastInfo(StructToVarcharCast,
 		                     StructBoundCastData::BindStructToStructCast(input, source, varchar_type),
 		                     StructBoundCastData::InitStructCastLocalState);
+	}
+	case LogicalTypeId::MAP: {
+		return BoundCastInfo(StructToMapCast, StructToMapBoundCastData::BindStructToMapCast(input, source, target),
+		                     StructToMapBoundCastData::InitStructToMapCastLocalState);
 	}
 	default:
 		return TryVectorNullCast;

--- a/test/sql/cast/struct_to_map.test
+++ b/test/sql/cast/struct_to_map.test
@@ -1,0 +1,328 @@
+# name: test/sql/cast/struct_to_map.test
+# group: [cast]
+
+# enable query verification
+statement ok
+PRAGMA enable_verification
+
+# Basic functionality tests
+
+# Simple cast - VARCHAR keys to VARCHAR values
+query I
+SELECT {"name": 'Alice', "city": 'NYC'}::MAP(VARCHAR, VARCHAR);
+----
+{name=Alice, city=NYC}
+
+# Simple cast - VARCHAR keys to INT values
+query I
+SELECT {"age": 25, "score": 100}::MAP(VARCHAR, INT);
+----
+{age=25, score=100}
+
+# Multiple rows with same field structure
+query I
+SELECT col::MAP(VARCHAR, INT)
+FROM VALUES ({"duck": 1}),({"duck": 2}),({"duck": 3}),({"duck": 4}),({"duck": 5})
+AS tab(col);
+----
+{duck=1}
+{duck=2}
+{duck=3}
+{duck=4}
+{duck=5}
+
+# Multiple fields in a single struct
+query I
+SELECT {"name": 'Alice', "age": 25, "score": 95}::MAP(VARCHAR, VARCHAR);
+----
+{name=Alice, age=25, score=95}
+
+# Key type casting tests
+
+# Cast VARCHAR keys to INT keys (keeps null values)
+query I
+SELECT col::MAP(INT, INT)
+FROM VALUES ({"1": 1}),({"2": 2}),({"3": 3}),({"4": 4}),({"5": 5})
+AS tab(col);
+----
+{1=1, 2=NULL, 3=NULL, 4=NULL, 5=NULL}
+{1=NULL, 2=2, 3=NULL, 4=NULL, 5=NULL}
+{1=NULL, 2=NULL, 3=3, 4=NULL, 5=NULL}
+{1=NULL, 2=NULL, 3=NULL, 4=4, 5=NULL}
+{1=NULL, 2=NULL, 3=NULL, 4=NULL, 5=5}
+
+# Cast VARCHAR keys to BIGINT keys
+query I
+SELECT {"123456789": 42}::MAP(BIGINT, INT);
+----
+{123456789=42}
+
+# Cast VARCHAR keys to DOUBLE keys
+query I
+SELECT {"3.14": 100}::MAP(DOUBLE, INT);
+----
+{3.14=100}
+
+# Value type casting tests
+
+# Cast INT values to VARCHAR
+query I
+SELECT {"age": 25, "score": 100}::MAP(VARCHAR, VARCHAR);
+----
+{age=25, score=100}
+
+# Cast different numeric types to BIGINT
+query I
+SELECT {"small": 1, "big": 999999999}::MAP(VARCHAR, BIGINT);
+----
+{small=1, big=999999999}
+
+# Cast to DOUBLE values
+query I
+SELECT {"pi": 3, "e": 2}::MAP(VARCHAR, DOUBLE);
+----
+{pi=3.0, e=2.0}
+
+# Mixed type casting - both keys and values
+query I
+SELECT {"1": 100, "2": 200}::MAP(INT, BIGINT);
+----
+{1=100, 2=200}
+
+# NULL handling tests
+
+# NULL struct becomes NULL map
+query I
+SELECT (NULL::STRUCT(name VARCHAR, age INT))::MAP(VARCHAR, VARCHAR);
+----
+NULL
+
+# NULL field values are preserved
+query I
+SELECT {"name": 'Alice', "age": NULL}::MAP(VARCHAR, VARCHAR);
+----
+{name=Alice, age=NULL}
+
+# Multiple NULL values
+query I
+SELECT {"a": NULL, "b": NULL, "c": 'value'}::MAP(VARCHAR, VARCHAR);
+----
+{a=NULL, b=NULL, c=value}
+
+# Constant vector tests
+
+# Single constant struct
+query I
+SELECT x::MAP(VARCHAR, INT) FROM (SELECT {"constant": 42} as x FROM range(5));
+----
+{constant=42}
+{constant=42}
+{constant=42}
+{constant=42}
+{constant=42}
+
+# Complex nested type tests
+
+# STRUCT values to STRUCT values
+query I
+SELECT {"person": {"name": 'Alice', "age": 25}}::MAP(VARCHAR, STRUCT(name VARCHAR, age INT));
+----
+{person={'name': Alice, 'age': 25}}
+
+# LIST values to LIST values
+query I
+SELECT {"numbers": [1,2,3], "letters": ['a','b']}::MAP(VARCHAR, VARCHAR[]);
+----
+{numbers=[1, 2, 3], letters=[a, b]}
+
+# Nested MAP values
+query I
+SELECT {meta: MAP{'key': 'value'}}::MAP(VARCHAR, MAP(VARCHAR, VARCHAR));
+----
+{meta={key=value}}
+
+# Complex nested structure
+query I
+SELECT col::MAP(VARCHAR, MAP(VARCHAR, INT))
+FROM VALUES ({ data: MAP{'count': 10, 'total': 100} })
+AS tab(col);
+----
+{data={count=10, total=100}}
+
+# Edge cases
+
+# Empty struct (if supported)
+# Note: This might fail depending on how empty structs are handled
+# query I
+# SELECT {}::MAP(VARCHAR, INT);
+# ----
+# {}
+
+# Single field struct
+query I
+SELECT {"single": 'value'}::MAP(VARCHAR, VARCHAR);
+----
+{single=value}
+
+# Large number of fields
+query I
+SELECT {
+    "f1": 1, "f2": 2, "f3": 3, "f4": 4, "f5": 5,
+    "f6": 6, "f7": 7, "f8": 8, "f9": 9, "f10": 10
+}::MAP(VARCHAR, INT);
+----
+{f1=1, f2=2, f3=3, f4=4, f5=5, f6=6, f7=7, f8=8, f9=9, f10=10}
+
+# Error cases
+
+# Cannot cast unnamed struct to MAP
+statement error
+SELECT (1, 2, 3)::MAP(INT, INT);
+----
+Cannot cast unnamed STRUCTs to MAP
+
+# Key casting can fail
+statement error
+SELECT col::MAP(INT, INT)
+FROM VALUES ({"duck": 1}),({"goose": 2})
+AS tab(col);
+----
+Conversion Error: Could not convert string 'duck' to INT32
+
+# Value casting can fail  
+statement error
+SELECT {"number": 'not_a_number'}::MAP(VARCHAR, INT);
+----
+Conversion Error: Could not convert string 'not_a_number' to INT32
+
+# Special character handling in keys
+
+# Keys with spaces
+query I
+SELECT {"first name": 'Alice', "last name": 'Smith'}::MAP(VARCHAR, VARCHAR);
+----
+{first name=Alice, last name=Smith}
+
+# Keys with special characters
+query I
+SELECT {"key-with-dashes": 1, "key_with_underscores": 2, "key.with.dots": 3}::MAP(VARCHAR, INT);
+----
+{key-with-dashes=1, key_with_underscores=2, key.with.dots=3}
+
+# Unicode keys
+query I
+SELECT {"测试": 'test', "🦆": 'duck'}::MAP(VARCHAR, VARCHAR);
+----
+{测试=test, 🦆=duck}
+
+# Case sensitivity preservation
+query I
+SELECT {"CamelCase": 1, "lowercase": 2, "UPPERCASE": 3}::MAP(VARCHAR, INT);
+----
+{CamelCase=1, lowercase=2, UPPERCASE=3}
+
+# Performance and batching tests
+
+# Large batch of rows
+query I
+SELECT col::MAP(VARCHAR, INT)
+FROM (
+    SELECT {"value": i} as col 
+    FROM range(1, 1001) t(i)
+) 
+LIMIT 5;
+----
+{value=1}
+{value=2}
+{value=3}
+{value=4}
+{value=5}
+
+# Mixed field counts across rows
+query I
+SELECT col::MAP(VARCHAR, VARCHAR)
+FROM VALUES 
+    ({"a": '1'}),
+    ({"A": '1', "b": '2'}),
+    ({"a": '1', "B": '2', "c": '3'}),
+    ({"x": 'single'}),
+    ({"many": '1', "fields": '2', "here": '3', "total": '4', "five": '5'})
+AS tab(col);
+----
+{a=1, b=NULL, c=NULL, x=NULL, many=NULL, fields=NULL, here=NULL, total=NULL, five=NULL}
+{a=1, b=2, c=NULL, x=NULL, many=NULL, fields=NULL, here=NULL, total=NULL, five=NULL}
+{a=1, b=2, c=3, x=NULL, many=NULL, fields=NULL, here=NULL, total=NULL, five=NULL}
+{a=NULL, b=NULL, c=NULL, x=single, many=NULL, fields=NULL, here=NULL, total=NULL, five=NULL}
+{a=NULL, b=NULL, c=NULL, x=NULL, many=1, fields=2, here=3, total=4, five=5}
+
+# Type compatibility tests
+
+# All numeric types as values
+query I
+SELECT {
+    "tinyint": 1::TINYINT,
+    "smallint": 2::SMALLINT, 
+    "int": 3::INT,
+    "bigint": 4::BIGINT
+}::MAP(VARCHAR, BIGINT);
+----
+{tinyint=1, smallint=2, int=3, bigint=4}
+
+# String types as values
+query I
+SELECT {
+    "varchar": 'hello'::VARCHAR,
+    "text": 'world'::TEXT
+}::MAP(VARCHAR, VARCHAR);
+----
+{varchar=hello, text=world}
+
+# Date/time types as values
+query I
+SELECT {
+    "date": '2023-01-01'::DATE,
+    "time": '12:00:00'::TIME
+}::MAP(VARCHAR, VARCHAR);
+----
+{date=2023-01-01, time='12:00:00'}
+
+# Boolean values
+query I
+SELECT {"true_val": true, "false_val": false}::MAP(VARCHAR, VARCHAR);
+----
+{true_val=true, false_val=false}
+
+# Decimal values
+query I
+SELECT {"price": 19.99::DECIMAL(10,2)}::MAP(VARCHAR, VARCHAR);
+----
+{price=19.99}
+
+# Interoperability tests
+
+# Use in WHERE clause
+query I
+SELECT *
+FROM VALUES ({"status": 'active'}), ({"status": 'inactive'})
+AS tab(col)
+WHERE (col::MAP(VARCHAR, VARCHAR))['status'] = 'active';
+----
+{'status': active}
+
+# Use in aggregations
+query I
+SELECT COUNT(*)
+FROM VALUES ({"type": 'A'}), ({"type": 'B'}), ({"type": 'A'})
+AS tab(col)
+WHERE (col::MAP(VARCHAR, VARCHAR))['type'] = 'A';
+----
+2
+
+# Complex nested example from original test
+query I
+SELECT col::MAP(VARCHAR, MAP(VARCHAR, INT))
+FROM VALUES ({ nested: MAP { 'inner_key': 707 } })
+AS tab(col);
+----
+{nested={inner_key=707}}
+

--- a/test/sql/cast/struct_to_map.test
+++ b/test/sql/cast/struct_to_map.test
@@ -182,7 +182,7 @@ LIMIT 5;
 NULL
 
 statement ok
-pragma debug_verify_vector='none' # revert
+pragma debug_verify_vector='none'
 
 # Single field struct
 query I

--- a/test/sql/cast/struct_to_map.test
+++ b/test/sql/cast/struct_to_map.test
@@ -151,12 +151,38 @@ AS tab(col);
 
 # Edge cases
 
-# Empty struct (if supported)
-# Note: This might fail depending on how empty structs are handled
-# query I
-# SELECT {}::MAP(VARCHAR, INT);
-# ----
-# {}
+# Constant vector select
+query I
+SELECT {"value": 42}::MAP(VARCHAR, INT)
+FROM range(1, 1001)
+LIMIT 5;
+----
+{value=42}
+{value=42}
+{value=42}
+{value=42}
+{value=42}
+
+# Make sure nothing breaks if we change the vector type
+statement ok
+pragma debug_verify_vector='dictionary_expression'
+
+query I
+SELECT TRY_CAST(col AS MAP(VARCHAR, integer))
+FROM (
+    SELECT CASE WHEN (i % 5 == 0) THEN NULL else {'a': i::varchar} END as col
+    FROM range(1, 1001) t(i)
+)
+LIMIT 5;
+----
+{a=1}
+{a=2}
+{a=3}
+{a=4}
+NULL
+
+statement ok
+pragma debug_verify_vector='none' # revert
 
 # Single field struct
 query I


### PR DESCRIPTION
- Implement StructToMapCast function that converts named structs to maps
- Add StructToMapBoundCastData and StructToMapCastLocalState for cast binding
- Support casting struct field names (VARCHAR) to target map key types
- Support casting struct field values to target map value types
- Handle NULL values, constant vectors, and nested types properly
- Add extensive test coverage for edge cases and type combinations
- Validate that only named structs can be cast to maps

Also fixes https://github.com/duckdb/duckdb/issues/17615

Sideways related: also fixes a small bug that made the order of merged structs unpredictable