### PR TITLE
Pushdown pivot filter

### DIFF
--- a/src/optimizer/pushdown/pushdown_aggregate.cpp
+++ b/src/optimizer/pushdown/pushdown_aggregate.cpp
@@ -50,8 +50,8 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownAggregate(unique_ptr<Logical
 		}
 		// no aggregate! we are filtering on a group
 		// we can only push this down if the filter is in all grouping sets
-		if (aggr.grouping_sets.empty()) {
-			// empty grouping set - we cannot pushdown the filter
+		if (aggr.groups.empty()) {
+			// empty group - we cannot pushdown the filter
 			continue;
 		}
 

--- a/test/sql/tpcds/tpcds_sf001.test_slow
+++ b/test/sql/tpcds/tpcds_sf001.test_slow
@@ -153,3 +153,7 @@ PRAGMA tpcds(${i})
 
 endloop
 
+query II
+explain select * from (pivot store_sales on ss_store_sk in (1,2,4,7,8,10) using sum(ss_ext_list_price) group by ss_item_sk) where ss_item_sk<20000;
+----
+physical_plan	<REGEX>:.*SEQ_SCAN.*~5762 Rows.*

--- a/test/sql/tpcds/tpcds_sf001.test_slow
+++ b/test/sql/tpcds/tpcds_sf001.test_slow
@@ -154,6 +154,6 @@ PRAGMA tpcds(${i})
 endloop
 
 query II
-explain select * from (pivot store_sales on ss_store_sk in (1,2,4,7,8,10) using sum(ss_ext_list_price) group by ss_item_sk) where ss_item_sk<20000;
+explain select * from (pivot store_sales on ss_store_sk in (1,2,4,7,8,10) using sum(ss_ext_list_price) group by ss_item_sk) where ss_item_sk<100;
 ----
-physical_plan	<REGEX>:.*SEQ_SCAN.*~5762 Rows.*
+physical_plan	<REGEX>:.*SEQ_SCAN.*Filters.*


### PR DESCRIPTION
This pr try to implement Pivot filter pushdown mentioned in #17458.

Pivot convert to Aggregate and not set grouping_set, but this should be still safe to pushdown filter in such condition. Maybe entire code below could remove.
```
if (aggr.grouping_set.empty()) {
	// empty grouping set - we cannot pushdown the filter
	continue;
}
```