### PR TITLE
Support file rotation with WRITE_EMPTY_FILE false

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -439,7 +439,7 @@ unique_ptr<GlobalSinkState> PhysicalCopyToFile::GetGlobalSinkState(ClientContext
 		}
 
 		auto state = make_uniq<CopyToFunctionGlobalState>(context);
-		if (!per_thread_output && rotate) {
+		if (!per_thread_output && rotate && write_empty_file) {
 			auto global_lock = state->lock.GetExclusiveLock();
 			state->global_state = CreateFileState(context, *state, *global_lock);
 		}
@@ -497,6 +497,9 @@ void PhysicalCopyToFile::WriteRotateInternal(ExecutionContext &context, GlobalSi
 	while (true) {
 		// Grab global lock and dereference the current file state (and corresponding lock)
 		auto global_guard = g.lock.GetExclusiveLock();
+		if (!g.global_state) {
+			g.global_state = CreateFileState(context.client, *sink_state, *global_guard);
+		}
 		auto &file_state = *g.global_state;
 		auto &file_lock = *g.file_write_lock_if_rotating;
 		if (rotate && function.rotate_next_file(file_state, *bind_data, file_size_bytes)) {
@@ -530,7 +533,7 @@ SinkResultType PhysicalCopyToFile::Sink(ExecutionContext &context, DataChunk &ch
 	auto &g = input.global_state.Cast<CopyToFunctionGlobalState>();
 	auto &l = input.local_state.Cast<CopyToFunctionLocalState>();
 
-	if (!write_empty_file) {
+	if (!write_empty_file && !rotate) {
 		// if we are only writing the file when there are rows to write we need to initialize here
 		g.Initialize(context.client, *this);
 	}

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -266,10 +266,6 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type) 
 		}
 	}
 	if (!write_empty_file) {
-		if (rotate) {
-			throw NotImplementedException(
-			    "Can't combine WRITE_EMPTY_FILE false with file rotation (e.g., ROW_GROUPS_PER_FILE)");
-		}
 		if (per_thread_output) {
 			throw NotImplementedException("Can't combine WRITE_EMPTY_FILE false with PER_THREAD_OUTPUT");
 		}

--- a/test/sql/copy/parquet/writer/skip_empty_write.test
+++ b/test/sql/copy/parquet/writer/skip_empty_write.test
@@ -48,13 +48,21 @@ copy (from tbl where i = 20000) to '__TEST_DIR__/empty.parquet' (WRITE_EMPTY_FIL
 
 endloop
 
+# write_empty_file with file_size_bytes
+query I
+copy (select 42 where 42=84) to '__TEST_DIR__/empty_file_size_bytes/' (FORMAT PARQUET, WRITE_EMPTY_FILE false, FILENAME_PATTERN '{uuidv7}.parquet', FILE_SIZE_BYTES 128)
+----
+0
+
+query I
+SELECT COUNT(*) FROM glob('__TEST_DIR__/empty_file_size_bytes/*.parquet')
+----
+0
+
+statement ok
+copy tbl to '__TEST_DIR__/empty_row_groups_per_file.parquet' (WRITE_EMPTY_FILE false, ROW_GROUPS_PER_FILE 1)
 
 # these combinations are not allowed
-statement error
-copy tbl to '__TEST_DIR__/empty.parquet' (WRITE_EMPTY_FILE false, ROW_GROUPS_PER_FILE 1)
-----
-Can't combine
-
 statement error
 copy empty_tbl to '__TEST_DIR__/empty.parquet' (WRITE_EMPTY_FILE false, PARTITION_BY (i))
 ----

--- a/test/sql/copy/row_groups_per_file.test
+++ b/test/sql/copy/row_groups_per_file.test
@@ -54,6 +54,13 @@ SELECT count(*) FROM glob('__TEST_DIR__/row_groups_per_file3/*.parquet')
 ----
 3
 
+# file rotation with return stats
+query IIIIII
+COPY bigdata TO '__TEST_DIR__/row_groups_per_file_stats/' (FORMAT PARQUET, WRITE_EMPTY_FILE false, FILENAME_PATTERN '{uuid}', ROW_GROUP_SIZE 3000, ROW_GROUPS_PER_FILE 2, RETURN_STATS);
+----
+<REGEX>:.*row_groups_per_file_stats.*[a-zA-Z0-9-]{36}.parquet	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:{'"col_a"'={column_size_bytes=\d+, max=\d+, min=\d+, null_count=0}, '"col_b"'={column_size_bytes=\d+, max=\d+, min=\d+, null_count=0}}	NULL
+<REGEX>:.*row_groups_per_file_stats.*[a-zA-Z0-9-]{36}.parquet	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:{'"col_a"'={column_size_bytes=\d+, max=\d+, min=\d+, null_count=0}, '"col_b"'={column_size_bytes=\d+, max=\d+, min=\d+, null_count=0}}	NULL
+
 # now we crank up the threads
 statement ok
 PRAGMA verify_parallelism


### PR DESCRIPTION
This PR adds support for file rotation (setting `file_size_bytes` or `row_groups_per_file`) together with the `write_empty_file false` flag. 