### PR TITLE
GetLocalAgnostic<T> to construct streams with std::locale::classic

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/common/algorithm.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/locale_agnostic.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/parser/constraints/list.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
@@ -79,7 +80,7 @@ unique_ptr<CreateInfo> TableCatalogEntry::GetInfo() const {
 }
 
 string TableCatalogEntry::ColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<Constraint>> &constraints) {
-	std::stringstream ss;
+	auto ss = GetLocalAgnostic<std::stringstream>();
 
 	ss << "(";
 
@@ -185,7 +186,7 @@ string TableCatalogEntry::ColumnNamesToSQL(const ColumnList &columns) {
 		return "";
 	}
 
-	std::stringstream ss;
+	auto ss = GetLocalAgnostic<std::stringstream>();
 	ss << "(";
 
 	for (auto &column : columns.Logical()) {

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/string_util.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/locale_agnostic.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/stack.hpp"
 #include "duckdb/common/to_string.hpp"
@@ -27,7 +28,7 @@ namespace duckdb {
 
 string StringUtil::GenerateRandomName(idx_t length) {
 	RandomEngine engine;
-	std::stringstream ss;
+	auto ss = GetLocalAgnostic<std::stringstream>();
 	for (idx_t i = 0; i < length; i++) {
 		ss << "0123456789abcdef"[engine.NextRandomInteger(0, 15)];
 	}
@@ -95,7 +96,8 @@ bool StringUtil::EndsWith(const string &str, const string &suffix) {
 }
 
 string StringUtil::Repeat(const string &str, idx_t n) {
-	std::ostringstream os;
+	auto os = GetLocalAgnostic<std::ostringstream>();
+
 	for (idx_t i = 0; i < n; i++) {
 		os << str;
 	}
@@ -342,7 +344,7 @@ idx_t StringUtil::CIFind(vector<string> &vector, const string &search_string) {
 }
 
 vector<string> StringUtil::Split(const string &str, char delimiter) {
-	std::stringstream ss(str);
+	auto ss = GetLocalAgnostic<std::stringstream>(str);
 	vector<string> lines;
 	string temp;
 	while (getline(ss, temp, delimiter)) {

--- a/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/locale_agnostic.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/execution/operator/csv_scanner/sniffer/csv_sniffer.hpp"
 #include "duckdb/main/client_data.hpp"
@@ -28,7 +29,7 @@ vector<char> DialectCandidates::GetDefaultComment() {
 }
 
 string DialectCandidates::Print() {
-	std::ostringstream search_space;
+	auto search_space = GetLocalAgnostic<std::ostringstream>();
 
 	search_space << "Delimiter Candidates: ";
 	for (idx_t i = 0; i < delim_candidates.size(); i++) {

--- a/src/execution/operator/csv_scanner/sniffer/set_columns.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/set_columns.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/locale_agnostic.hpp"
 #include "duckdb/execution/operator/csv_scanner/set_columns.hpp"
 
 namespace duckdb {
@@ -52,7 +53,7 @@ bool SetColumns::IsCandidateUnacceptable(const idx_t num_cols, bool null_padding
 }
 
 string SetColumns::ToString() const {
-	stringstream ss;
+	auto ss = GetLocalAgnostic<std::stringstream>();
 	ss << "columns = { ";
 	for (idx_t i = 0; i < Size(); ++i) {
 		ss << "'" << names->at(i) << "'"

--- a/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
+++ b/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/locale_agnostic.hpp"
 #include "duckdb/execution/operator/csv_scanner/global_csv_state.hpp"
 #include "duckdb/execution/operator/csv_scanner/sniffer/csv_sniffer.hpp"
 #include "duckdb/execution/operator/csv_scanner/scanner_boundary.hpp"
@@ -133,7 +134,7 @@ void FillScanErrorTable(InternalAppender &scan_appender, idx_t scan_idx, idx_t f
 	auto &names = file.GetNames();
 
 	// 10. List<Struct<Column-Name:Types>> {'col1': 'INTEGER', 'col2': 'VARCHAR'}
-	std::ostringstream columns;
+	auto columns = GetLocalAgnostic<std::ostringstream>();
 	columns << "{";
 	for (idx_t i = 0; i < types.size(); i++) {
 		columns << "'" << names[i] << "': '" << types[i].ToString() << "'";

--- a/src/include/duckdb/common/locale_agnostic.hpp
+++ b/src/include/duckdb/common/locale_agnostic.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <locale>
+
+namespace duckdb {
+
+template <class STREAM, class... ARGS>
+STREAM GetLocalAgnostic(ARGS... args) {
+	STREAM stream(args...);
+	stream.imbue(std::locale::classic());
+	return stream;
+}
+
+} // namespace duckdb

--- a/src/parser/parsed_data/create_sequence_info.cpp
+++ b/src/parser/parsed_data/create_sequence_info.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/locale_agnostic.hpp"
 #include "duckdb/parser/parsed_data/create_sequence_info.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
@@ -25,7 +26,7 @@ unique_ptr<CreateInfo> CreateSequenceInfo::Copy() const {
 }
 
 string CreateSequenceInfo::ToString() const {
-	std::stringstream ss;
+	auto ss = GetLocalAgnostic<std::stringstream>();
 	ss << "CREATE";
 	if (on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
 		ss << " OR REPLACE";


### PR DESCRIPTION
Unsure on the implementation choice, I think adding a function on top is somewhat cleaner, but that might be me, feedback welcome.

Problem I had bumped in duckdb-wasm, where there would be some yet to be properly understood factor that would change the global static default locale to an unsupported one that would, via a SQL call to `duckdb_tables` end up calling a locale-influenced stringstream that would then thow.

I covered the places (together with a follow up PR on `isspace`) that were needed to have the standard set of tests pass even injecting a random locale from the one I had available via the following diff:
```diff
diff --git a/test/unittest.cpp b/test/unittest.cpp
index 1c04f9836b..a70847a2a6 100644
--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -30,6 +30,8 @@ int main(int argc, char *argv[]) {
        duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
        string test_directory = DUCKDB_ROOT_DIRECTORY;
 
+       std::locale::global(std::locale("ja_JP.SJIS"));
+
        int new_argc = 0;
        auto new_argv = duckdb::unique_ptr<char *[]>(new char *[argc]);
        for (int i = 0; i < argc; i++) {
```

TODO, but I think they could be submitted as follow ups, are increasing both testing and the surface moved to locale-independent functions.