### PR TITLE
local_agnostic::isspace to avoid spaces be depending on locale

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -105,7 +105,7 @@ string StringUtil::Repeat(const string &str, idx_t n) {
 namespace string_util_internal {
 
 inline void SkipSpaces(const string &str, idx_t &index) {
-	while (index < str.size() && std::isspace(str[index])) {
+	while (index < str.size() && StringUtil::CharacterIsSpace(str[index])) {
 		index++;
 	}
 }
@@ -136,7 +136,9 @@ inline string TakePossiblyQuotedItem(const string &str, idx_t &index, char delim
 		ConsumeLetter(str, index, quote);
 	} else {
 		TakeWhile(
-		    str, index, [delimiter, quote](char c) { return c != delimiter && c != quote && !std::isspace(c); }, entry);
+		    str, index,
+		    [delimiter, quote](char c) { return c != delimiter && c != quote && !StringUtil::CharacterIsSpace(c); },
+		    entry);
 	}
 
 	return entry;

--- a/src/include/duckdb/function/cast/vector_cast_helpers.hpp
+++ b/src/include/duckdb/function/cast/vector_cast_helpers.hpp
@@ -197,9 +197,9 @@ struct VectorCastHelpers {
 
 		if (STRUCT_KEY) {
 			needs_quotes = true;
-		} else if (isspace(string_data[0])) {
+		} else if (StringUtil::CharacterIsSpace(string_data[0])) {
 			needs_quotes = true;
-		} else if (base_length >= 2 && isspace(string_data[base_length - 1])) {
+		} else if (base_length >= 2 && StringUtil::CharacterIsSpace(string_data[base_length - 1])) {
 			needs_quotes = true;
 		} else if (StringUtil::CIEquals(string_data, base_length, "null", 4)) {
 			needs_quotes = true;

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -471,7 +471,7 @@ int sqlite3_exec(sqlite3 *db,                /* The database on which the SQL ex
 				rc = sqlite3_finalize(pStmt);
 				pStmt = nullptr;
 				zSql = zLeftover;
-				while (isspace(zSql[0]))
+				while (StringUtil::CharacterIsSpace(zSql[0]))
 					zSql++;
 				break;
 			} else if (rc != SQLITE_ROW) {


### PR DESCRIPTION
Similar to https://github.com/duckdb/duckdb/pull/17807, this adds locale-independent handling for isspace.

I have to say I don't remember exactly if I manage to reproduce a problem with this or just looked right to have.

Feedback on the implementation welcome.