### PR TITLE
Value: do std::move also for value_

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -168,7 +168,7 @@ Value::Value(const Value &other)
 }
 
 Value::Value(Value &&other) noexcept
-    : type_(std::move(other.type_)), is_null(other.is_null), value_(other.value_),
+    : type_(std::move(other.type_)), is_null(other.is_null), value_(std::move(other.value_)),
       value_info_(std::move(other.value_info_)) {
 }
 


### PR DESCRIPTION
I stumbled on this while on a rabbit hole around std::locale, I am not really sure if there is any benefit to having a move, but might be? Feel free to close, it's minor either way, this might result in more optimized code-generation but hard to say.

Potentially counting allocations (over the same workload) might show a difference, but again, I have not checked.