### PR TITLE
Avoid saving ccache on pull_requests

### DIFF
--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -17,6 +17,9 @@ inputs:
   build_complete_extensions_set:
     description: 'Whether all extensions needs to be built'
     default: 1
+  save_cache:
+    description: 'Should cache be saved'
+    default: 1
 
 runs:
   using: "composite"
@@ -79,7 +82,7 @@ runs:
           mkdir ccache_dir
 
       - name: Load Ccache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ./ccache_dir
           key: ccache-extension-distribution-${{ inputs.duckdb_arch }}-${{ steps.ccache_timestamp.outputs.timestamp }}
@@ -95,6 +98,13 @@ runs:
         shell: bash
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ inputs.duckdb_arch }} make release
+
+      - name: Save Ccache
+        if: ${{ inputs.save_cache }}
+        uses: actions/cache/save@v4
+        with:
+          path: ./ccache_dir
+          key: ccache-extension-distribution-${{ inputs.duckdb_arch }}-${{ steps.ccache_timestamp.outputs.timestamp }}
 
       - name: Test extension (inside docker)
         shell: bash

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -152,6 +152,7 @@ jobs:
           override_git_describe: ${{ inputs.override_git_describe }}
           build_complete_extensions_set: 1
           # Note that build_complete_extensions_set needs to be 1 (that is also the default value) for 'Checks extension entries' to work correctly
+          save_cache: ${{ github.event_name != 'pull_request' && 1 || 0 }}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -196,6 +197,7 @@ jobs:
           run_tests: ${{ inputs.skip_tests != 'true' }}
           override_git_describe: ${{ inputs.override_git_describe }}
           build_complete_extensions_set: ${{ github.event_name != 'pull_request' && 1 || 0 }}
+          save_cache: ${{ github.event_name != 'pull_request' && 1 || 0 }}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -239,6 +241,7 @@ jobs:
           run_tests: ${{ inputs.skip_tests != 'true' }}
           override_git_describe: ${{ inputs.override_git_describe }}
           build_complete_extensions_set: ${{ github.event_name != 'pull_request' && 1 || 0 }}
+          save_cache: ${{ github.event_name != 'pull_request' && 1 || 0 }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Step further bringing github caching back to be functional, that should translate to faster evaluation cycles on PRs.

Problem is that currently for the 3 set of linux extensions, that are a bulk of CI time, cache items are added on every PR, making so that cache items from base branches will get evicted, and means less effective caching.

Basic is as follows:
* PR can access cache items from any predecessor. Cache items produced by PRs can only be reused by the exact same PR
* Base branches (say `v1.3-ossivalis` or `main`) can access cache only from other base branches, but their cache items can be used by anyone.
* When total cache size grows past 10 GB, GitHub will evict older items (that are likely to be the base branches one)

Current situation that happens somewhat frequently is that PR pollute the cache, keep invalidating it, eventually removing the only valuable items in there. This PR aims at producing less items in the global cache.