### PR TITLE
Support glibc 2.28 environments in 1.3.x

### DIFF
--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -189,7 +189,16 @@ jobs:
           -e BUILD_BENCHMARK=1                                                   \
           -e FORCE_WARN_UNUSED=1                                                 \
           quay.io/pypa/manylinux_2_28_${{ matrix.config.image }}                  \
-          bash -c "yum install -y perl-IPC-Cmd && git config --global --add safe.directory $PWD && make gather-libs -C $PWD"
+          bash -c "
+            set -e
+            yum install -y perl-IPC-Cmd gcc-toolset-12 gcc-toolset-12-gcc-c++
+          
+            source /opt/rh/gcc-toolset-12/enable
+            export CC=gcc
+            export CXX=g++
+            git config --global --add safe.directory $PWD
+            make gather-libs -C $PWD
+          "
 
       - name: Print platform
         shell: bash

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -84,7 +84,16 @@ jobs:
         -e BUILD_BENCHMARK=1                                                   \
         -e FORCE_WARN_UNUSED=1                                                 \
         quay.io/pypa/manylinux_2_28_${{ matrix.config.image }}                  \
-        bash -c "yum install -y perl-IPC-Cmd && git config --global --add safe.directory $PWD && make -C $PWD"
+        bash -c "
+          set -e
+          yum install -y perl-IPC-Cmd gcc-toolset-12 gcc-toolset-12-gcc-c++
+        
+          source /opt/rh/gcc-toolset-12/enable
+          export CC=gcc
+          export CXX=g++
+          git config --global --add safe.directory $PWD
+          make -C $PWD
+        "
 
     - name: Print platform
       shell: bash


### PR DESCRIPTION
Backport the changes in https://github.com/duckdb/duckdb/pull/17776 so we build with GCC 12 explicitly in the next bug fix release, instead of only in 1.4.