### PR TITLE
MultiFileReader: Make column mapping mode configurable per-file, instead of requiring it to be set globally

### DIFF
--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -371,13 +371,23 @@ MultiFileReader::InitializeGlobalState(ClientContext &context, const MultiFileOp
 	return nullptr;
 }
 
+ReaderInitializeType
+MultiFileReader::CreateMapping(ClientContext &context, MultiFileReaderData &reader_data,
+                               const vector<MultiFileColumnDefinition> &global_columns,
+                               const vector<ColumnIndex> &global_column_ids, optional_ptr<TableFilterSet> filters,
+                               MultiFileList &multi_file_list, const MultiFileReaderBindData &bind_data,
+                               const virtual_column_map_t &virtual_columns, MultiFileColumnMappingMode mapping_mode) {
+	MultiFileColumnMapper column_mapper(context, *this, reader_data, global_columns, global_column_ids, filters,
+	                                    multi_file_list, virtual_columns);
+	return column_mapper.CreateMapping(mapping_mode);
+}
+
 ReaderInitializeType MultiFileReader::CreateMapping(
     ClientContext &context, MultiFileReaderData &reader_data, const vector<MultiFileColumnDefinition> &global_columns,
     const vector<ColumnIndex> &global_column_ids, optional_ptr<TableFilterSet> filters, MultiFileList &multi_file_list,
     const MultiFileReaderBindData &bind_data, const virtual_column_map_t &virtual_columns) {
-	MultiFileColumnMapper column_mapper(context, *this, reader_data, global_columns, global_column_ids, filters,
-	                                    multi_file_list, bind_data, virtual_columns);
-	return column_mapper.CreateMapping();
+	return CreateMapping(context, reader_data, global_columns, global_column_ids, filters, multi_file_list, bind_data,
+	                     virtual_columns, bind_data.mapping);
 }
 
 string GetExtendedMultiFileError(const MultiFileBindData &bind_data, const Expression &expr, BaseFileReader &reader,

--- a/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
@@ -19,16 +19,15 @@ public:
 	MultiFileColumnMapper(ClientContext &context, MultiFileReader &multi_file_reader, MultiFileReaderData &reader_data,
 	                      const vector<MultiFileColumnDefinition> &global_columns,
 	                      const vector<ColumnIndex> &global_column_ids, optional_ptr<TableFilterSet> filters,
-	                      MultiFileList &multi_file_list, const MultiFileReaderBindData &bind_data,
-	                      const virtual_column_map_t &virtual_columns);
+	                      MultiFileList &multi_file_list, const virtual_column_map_t &virtual_columns);
 
 public:
-	ReaderInitializeType CreateMapping();
+	ReaderInitializeType CreateMapping(MultiFileColumnMappingMode mapping_mode);
 
 	void ThrowColumnNotFoundError(const string &global_column_name) const;
 
 private:
-	ResultColumnMapping CreateColumnMapping();
+	ResultColumnMapping CreateColumnMapping(MultiFileColumnMappingMode mapping_mode);
 	ResultColumnMapping CreateColumnMappingByMapper(const ColumnMapper &mapper);
 
 	unique_ptr<TableFilterSet> CreateFilters(map<idx_t, reference<TableFilter>> &filters, ResultColumnMapping &mapping);
@@ -45,7 +44,6 @@ private:
 	const vector<MultiFileColumnDefinition> &global_columns;
 	const vector<ColumnIndex> &global_column_ids;
 	optional_ptr<TableFilterSet> global_filters;
-	const MultiFileReaderBindData &bind_data;
 	const virtual_column_map_t &virtual_columns;
 };
 

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -110,6 +110,13 @@ public:
 	CreateMapping(ClientContext &context, MultiFileReaderData &reader_data,
 	              const vector<MultiFileColumnDefinition> &global_columns, const vector<ColumnIndex> &global_column_ids,
 	              optional_ptr<TableFilterSet> filters, MultiFileList &multi_file_list,
+	              const MultiFileReaderBindData &bind_data, const virtual_column_map_t &virtual_columns,
+	              MultiFileColumnMappingMode mapping_mode);
+
+	DUCKDB_API virtual ReaderInitializeType
+	CreateMapping(ClientContext &context, MultiFileReaderData &reader_data,
+	              const vector<MultiFileColumnDefinition> &global_columns, const vector<ColumnIndex> &global_column_ids,
+	              optional_ptr<TableFilterSet> filters, MultiFileList &multi_file_list,
 	              const MultiFileReaderBindData &bind_data, const virtual_column_map_t &virtual_columns);
 
 	//! Finalize the reading of a chunk - applying any constants that are required


### PR DESCRIPTION
This allows the column mapping mode to be modified on a per-file basis by the MultiFileReader