### PR TITLE
Internal #5069: Win32 Cast Simplification

### DIFF
--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -108,7 +108,7 @@ public:
 
 	struct LeadLagState {
 		//	Fixed size
-		static constexpr idx_t MAX_BUFFER = 2048U;
+		static constexpr int64_t MAX_BUFFER = 2048;
 
 		static bool ComputeOffset(ClientContext &context, BoundWindowExpression &wexpr, int64_t &offset) {
 			offset = 1;
@@ -131,7 +131,7 @@ public:
 			if (wexpr.GetExpressionType() == ExpressionType::WINDOW_LEAD) {
 				offset = -offset;
 			}
-			return idx_t(std::abs(offset)) < MAX_BUFFER;
+			return std::abs(offset) < MAX_BUFFER;
 		}
 
 		static bool ComputeDefault(ClientContext &context, BoundWindowExpression &wexpr, Value &result) {


### PR DESCRIPTION
* Just do signed compares to fix Win32 test failure