### PR TITLE
Replace string for const data ptr in encryption api

### DIFF
--- a/.github/patches/extensions/httpfs/httpfs_loader.patch
+++ b/.github/patches/extensions/httpfs/httpfs_loader.patch
@@ -1,3 +1,17 @@
+diff --git a/duckdb b/duckdb
+index 71c5c07..7b25345 160000
+--- a/duckdb
++++ b/duckdb
+@@ -1 +1 @@
+-Subproject commit 71c5c07cdd295e9409c0505885033ae9eb6b5ddd
++Subproject commit 7b253450b6f91ac3c35d16f994361bffebbdc639
+diff --git a/extension-ci-tools b/extension-ci-tools
+index 555f1c8..cca140d 160000
+--- a/extension-ci-tools
++++ b/extension-ci-tools
+@@ -1 +1 @@
+-Subproject commit 555f1c857dbe27f87b3e9c7656354d37c239ffaf
++Subproject commit cca140d4cc47f3f3e40f29b49c305bd92845771f
 diff --git a/extension/httpfs/create_secret_functions.cpp b/extension/httpfs/create_secret_functions.cpp
 index b3984b3..476bc14 100644
 --- a/extension/httpfs/create_secret_functions.cpp
@@ -72,18 +86,42 @@ index b3984b3..476bc14 100644
  
  unique_ptr<BaseSecret> CreateBearerTokenFunctions::CreateSecretFunctionInternal(ClientContext &context,
 diff --git a/extension/httpfs/crypto.cpp b/extension/httpfs/crypto.cpp
-index 04bd795..0fe6be8 100644
+index 04bd795..917e567 100644
 --- a/extension/httpfs/crypto.cpp
 +++ b/extension/httpfs/crypto.cpp
+@@ -42,11 +42,11 @@ AESStateSSL::~AESStateSSL() {
+ 	EVP_CIPHER_CTX_free(context);
+ }
+ 
+-const EVP_CIPHER *AESStateSSL::GetCipher(const string &key) {
++const EVP_CIPHER *AESStateSSL::GetCipher(idx_t key_len) {
+ 
+ 	switch (cipher) {
+ 	case GCM:
+-		switch (key.size()) {
++		switch (key_len) {
+ 		case 16:
+ 			return EVP_aes_128_gcm();
+ 		case 24:
+@@ -57,7 +57,7 @@ const EVP_CIPHER *AESStateSSL::GetCipher(const string &key) {
+ 			throw InternalException("Invalid AES key length");
+ 		}
+ 	case CTR:
+-		switch (key.size()) {
++		switch (key_len) {
+ 		case 16:
+ 			return EVP_aes_128_ctr();
+ 		case 24:
 @@ -78,20 +78,34 @@ void AESStateSSL::GenerateRandomData(data_ptr_t data, idx_t len) {
  	RAND_bytes(data, len);
  }
  
 -void AESStateSSL::InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const string *key) {
-+void AESStateSSL::InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const string *key, const_data_ptr_t aad, idx_t aad_len) {
++void AESStateSSL::InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key, idx_t key_len, const_data_ptr_t aad, idx_t aad_len) {
  	mode = ENCRYPT;
  
- 	if (1 != EVP_EncryptInit_ex(context, GetCipher(*key), NULL, const_data_ptr_cast(key->data()), iv)) {
+-	if (1 != EVP_EncryptInit_ex(context, GetCipher(*key), NULL, const_data_ptr_cast(key->data()), iv)) {
++	if (1 != EVP_EncryptInit_ex(context, GetCipher(key_len), NULL, key, iv)) {
  		throw InternalException("EncryptInit failed");
  	}
 +	
@@ -96,10 +134,11 @@ index 04bd795..0fe6be8 100644
  }
  
 -void AESStateSSL::InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const string *key) {
-+void AESStateSSL::InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const string *key, const_data_ptr_t aad, idx_t aad_len) {
++void AESStateSSL::InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key, idx_t key_len, const_data_ptr_t aad, idx_t aad_len) {
  	mode = DECRYPT;
  
- 	if (1 != EVP_DecryptInit_ex(context, GetCipher(*key), NULL, const_data_ptr_cast(key->data()), iv)) {
+-	if (1 != EVP_DecryptInit_ex(context, GetCipher(*key), NULL, const_data_ptr_cast(key->data()), iv)) {
++	if (1 != EVP_DecryptInit_ex(context, GetCipher(key_len), NULL, key, iv)) {
  		throw InternalException("DecryptInit failed");
  	}
 +
@@ -206,20 +245,55 @@ index 54b7566..bd3bc4a 100644
  protected:
  	//! Internal function to create bearer token
 diff --git a/extension/httpfs/include/crypto.hpp b/extension/httpfs/include/crypto.hpp
-index f819356..eaa850e 100644
+index f819356..7d7f1ee 100644
 --- a/extension/httpfs/include/crypto.hpp
 +++ b/extension/httpfs/include/crypto.hpp
-@@ -29,8 +29,8 @@ public:
+@@ -29,13 +29,13 @@ public:
  	~AESStateSSL() override;
  
  public:
 -	void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key) override;
 -	void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key) override;
-+	void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key, const_data_ptr_t aad, idx_t aad_len) override;
-+	void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key, const_data_ptr_t aad, idx_t aad_len) override;
++	void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key, duckdb::idx_t key_len, const_data_ptr_t aad, idx_t aad_len) override;
++	void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key, duckdb::idx_t key_len, const_data_ptr_t aad, idx_t aad_len) override;
  	size_t Process(const_data_ptr_t in, idx_t in_len, data_ptr_t out, idx_t out_len) override;
  	size_t Finalize(data_ptr_t out, idx_t out_len, data_ptr_t tag, idx_t tag_len) override;
  	void GenerateRandomData(data_ptr_t data, idx_t len) override;
+ 
+-	const EVP_CIPHER *GetCipher(const string &key);
++	const EVP_CIPHER *GetCipher(idx_t key_len);
+ 	size_t FinalizeGCM(data_ptr_t out, idx_t out_len, data_ptr_t tag, idx_t tag_len);
+ 
+ private:
+@@ -48,16 +48,16 @@ private:
+ 
+ extern "C" {
+ 
+-class DUCKDB_EXTENSION_API AESStateSSLFactory : public duckdb::EncryptionUtil {
+-public:
+-	explicit AESStateSSLFactory() {
+-	}
++	class DUCKDB_EXTENSION_API AESStateSSLFactory : public duckdb::EncryptionUtil {
++	public:
++		explicit AESStateSSLFactory() {
++		}
+ 
+-	duckdb::shared_ptr<duckdb::EncryptionState> CreateEncryptionState(const std::string *key = nullptr) const override {
+-		return duckdb::make_shared_ptr<duckdb::AESStateSSL>();
+-	}
++		duckdb::shared_ptr<duckdb::EncryptionState> CreateEncryptionState(const unsigned char *key = nullptr, duckdb::idx_t key_len = 0) const override {
++			return duckdb::make_shared_ptr<duckdb::AESStateSSL>();
++		}
+ 
+-	~AESStateSSLFactory() override {
+-	}
+-};
+-}
++		~AESStateSSLFactory() override {
++		}
++	};
++}
+\ No newline at end of file
 diff --git a/extension/httpfs/include/httpfs_extension.hpp b/extension/httpfs/include/httpfs_extension.hpp
 index 3c4f3a1..eeca2c9 100644
 --- a/extension/httpfs/include/httpfs_extension.hpp

--- a/.github/patches/extensions/httpfs/httpfs_loader.patch
+++ b/.github/patches/extensions/httpfs/httpfs_loader.patch
@@ -1,17 +1,3 @@
-diff --git a/duckdb b/duckdb
-index 71c5c07..7b25345 160000
---- a/duckdb
-+++ b/duckdb
-@@ -1 +1 @@
--Subproject commit 71c5c07cdd295e9409c0505885033ae9eb6b5ddd
-+Subproject commit 7b253450b6f91ac3c35d16f994361bffebbdc639
-diff --git a/extension-ci-tools b/extension-ci-tools
-index 555f1c8..cca140d 160000
---- a/extension-ci-tools
-+++ b/extension-ci-tools
-@@ -1 +1 @@
--Subproject commit 555f1c857dbe27f87b3e9c7656354d37c239ffaf
-+Subproject commit cca140d4cc47f3f3e40f29b49c305bd92845771f
 diff --git a/extension/httpfs/create_secret_functions.cpp b/extension/httpfs/create_secret_functions.cpp
 index b3984b3..476bc14 100644
 --- a/extension/httpfs/create_secret_functions.cpp
@@ -86,7 +72,7 @@ index b3984b3..476bc14 100644
  
  unique_ptr<BaseSecret> CreateBearerTokenFunctions::CreateSecretFunctionInternal(ClientContext &context,
 diff --git a/extension/httpfs/crypto.cpp b/extension/httpfs/crypto.cpp
-index 04bd795..917e567 100644
+index 04bd795..3a3e89e 100644
 --- a/extension/httpfs/crypto.cpp
 +++ b/extension/httpfs/crypto.cpp
 @@ -42,11 +42,11 @@ AESStateSSL::~AESStateSSL() {
@@ -117,7 +103,7 @@ index 04bd795..917e567 100644
  }
  
 -void AESStateSSL::InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const string *key) {
-+void AESStateSSL::InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key, idx_t key_len, const_data_ptr_t aad, idx_t aad_len) {
++void AESStateSSL::InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const_data_ptr_t key, idx_t key_len, const_data_ptr_t aad, idx_t aad_len) {
  	mode = ENCRYPT;
  
 -	if (1 != EVP_EncryptInit_ex(context, GetCipher(*key), NULL, const_data_ptr_cast(key->data()), iv)) {
@@ -134,7 +120,7 @@ index 04bd795..917e567 100644
  }
  
 -void AESStateSSL::InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const string *key) {
-+void AESStateSSL::InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key, idx_t key_len, const_data_ptr_t aad, idx_t aad_len) {
++void AESStateSSL::InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const_data_ptr_t key, idx_t key_len, const_data_ptr_t aad, idx_t aad_len) {
  	mode = DECRYPT;
  
 -	if (1 != EVP_DecryptInit_ex(context, GetCipher(*key), NULL, const_data_ptr_cast(key->data()), iv)) {
@@ -245,7 +231,7 @@ index 54b7566..bd3bc4a 100644
  protected:
  	//! Internal function to create bearer token
 diff --git a/extension/httpfs/include/crypto.hpp b/extension/httpfs/include/crypto.hpp
-index f819356..7d7f1ee 100644
+index f819356..aa6ad70 100644
 --- a/extension/httpfs/include/crypto.hpp
 +++ b/extension/httpfs/include/crypto.hpp
 @@ -29,13 +29,13 @@ public:
@@ -254,8 +240,8 @@ index f819356..7d7f1ee 100644
  public:
 -	void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key) override;
 -	void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key) override;
-+	void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key, duckdb::idx_t key_len, const_data_ptr_t aad, idx_t aad_len) override;
-+	void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key, duckdb::idx_t key_len, const_data_ptr_t aad, idx_t aad_len) override;
++	void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const_data_ptr_t key, idx_t key_len, const_data_ptr_t aad, idx_t aad_len) override;
++	void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const_data_ptr_t key, idx_t key_len, const_data_ptr_t aad, idx_t aad_len) override;
  	size_t Process(const_data_ptr_t in, idx_t in_len, data_ptr_t out, idx_t out_len) override;
  	size_t Finalize(data_ptr_t out, idx_t out_len, data_ptr_t tag, idx_t tag_len) override;
  	void GenerateRandomData(data_ptr_t data, idx_t len) override;
@@ -281,7 +267,7 @@ index f819356..7d7f1ee 100644
 -	duckdb::shared_ptr<duckdb::EncryptionState> CreateEncryptionState(const std::string *key = nullptr) const override {
 -		return duckdb::make_shared_ptr<duckdb::AESStateSSL>();
 -	}
-+		duckdb::shared_ptr<duckdb::EncryptionState> CreateEncryptionState(const unsigned char *key = nullptr, duckdb::idx_t key_len = 0) const override {
++		duckdb::shared_ptr<duckdb::EncryptionState> CreateEncryptionState(duckdb::const_data_ptr_t key = nullptr, duckdb::idx_t key_len = 0) const override {
 +			return duckdb::make_shared_ptr<duckdb::AESStateSSL>();
 +		}
  

--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -11,11 +11,6 @@
 duckdb_extension_load(core_functions)
 duckdb_extension_load(parquet)
 
-duckdb_extension_load(httpfs
-        DONT_LINK
-        SOURCE_DIR /Users/lottefeliuscwi/Documents/Projects/duckdb-httpfs
-)
-
 # The Linux allocator has issues so we use jemalloc, but only on x86 because page sizes are fixed at 4KB.
 # Configuring jemalloc properly for 32bit is a hassle, and not worth it so we only enable on 64bit
 if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT FORCE_32_BIT AND OS_NAME STREQUAL "linux" AND NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})

--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -11,6 +11,11 @@
 duckdb_extension_load(core_functions)
 duckdb_extension_load(parquet)
 
+duckdb_extension_load(httpfs
+        DONT_LINK
+        SOURCE_DIR /Users/lottefeliuscwi/Documents/Projects/duckdb-httpfs
+)
+
 # The Linux allocator has issues so we use jemalloc, but only on x86 because page sizes are fixed at 4KB.
 # Configuring jemalloc properly for 32bit is a hassle, and not worth it so we only enable on 64bit
 if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT FORCE_32_BIT AND OS_NAME STREQUAL "linux" AND NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})

--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -91,7 +91,8 @@ using duckdb_apache::thrift::transport::TTransport;
 class EncryptionTransport : public TTransport {
 public:
 	EncryptionTransport(TProtocol &prot_p, const string &key, const EncryptionUtil &encryption_util_p)
-	    : prot(prot_p), trans(*prot.getTransport()), aes(encryption_util_p.CreateEncryptionState(&key)),
+	    : prot(prot_p), trans(*prot.getTransport()),
+	      aes(encryption_util_p.CreateEncryptionState(reinterpret_cast<const unsigned char *>(&key), key.size())),
 	      allocator(Allocator::DefaultAllocator(), ParquetCrypto::CRYPTO_BLOCK_SIZE) {
 		Initialize(key);
 	}
@@ -150,7 +151,8 @@ private:
 		// Generate Nonce
 		aes->GenerateRandomData(nonce, ParquetCrypto::NONCE_BYTES);
 		// Initialize Encryption
-		aes->InitializeEncryption(nonce, ParquetCrypto::NONCE_BYTES, &key);
+		aes->InitializeEncryption(nonce, ParquetCrypto::NONCE_BYTES,
+		                          reinterpret_cast<const unsigned char *>(key.data()), key.size());
 	}
 
 private:
@@ -172,7 +174,8 @@ private:
 class DecryptionTransport : public TTransport {
 public:
 	DecryptionTransport(TProtocol &prot_p, const string &key, const EncryptionUtil &encryption_util_p)
-	    : prot(prot_p), trans(*prot.getTransport()), aes(encryption_util_p.CreateEncryptionState(&key)),
+	    : prot(prot_p), trans(*prot.getTransport()),
+	      aes(encryption_util_p.CreateEncryptionState(reinterpret_cast<const unsigned char *>(&key), key.size())),
 	      read_buffer_size(0), read_buffer_offset(0) {
 		Initialize(key);
 	}
@@ -235,7 +238,8 @@ private:
 		// Read nonce and initialize AES
 		transport_remaining -= trans.read(nonce, ParquetCrypto::NONCE_BYTES);
 		// check whether context is initialized
-		aes->InitializeDecryption(nonce, ParquetCrypto::NONCE_BYTES, &key);
+		aes->InitializeDecryption(nonce, ParquetCrypto::NONCE_BYTES,
+		                          reinterpret_cast<const unsigned char *>(key.data()), key.size());
 	}
 
 	void ReadBlock(uint8_t *buf) {

--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -153,8 +153,6 @@ private:
 		// Initialize Encryption
 		aes->InitializeEncryption(nonce, ParquetCrypto::NONCE_BYTES, reinterpret_cast<const_data_ptr_t>(key.data()),
 		                          key.size());
-
-		auto key_sz = key.size();
 	}
 
 private:
@@ -232,7 +230,6 @@ public:
 
 private:
 	void Initialize(const string &key) {
-		auto key_sz = key.size();
 		// Read encoded length (don't add to read_bytes)
 		data_t length_buf[ParquetCrypto::LENGTH_BYTES];
 		trans.read(length_buf, ParquetCrypto::LENGTH_BYTES);

--- a/src/common/encryption_state.cpp
+++ b/src/common/encryption_state.cpp
@@ -2,20 +2,20 @@
 
 namespace duckdb {
 
-EncryptionState::EncryptionState(const std::string *key) {
+EncryptionState::EncryptionState(const unsigned char *key, idx_t key_len) {
 	// abstract class, no implementation needed
 }
 
 EncryptionState::~EncryptionState() {
 }
 
-void EncryptionState::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key,
-                                           const_data_ptr_t aad, idx_t aad_len) {
+void EncryptionState::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char *key,
+                                           duckdb::idx_t key_len, const_data_ptr_t aad, idx_t aad_len) {
 	throw NotImplementedException("EncryptionState Abstract Class is called");
 }
 
-void EncryptionState::InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key,
-                                           const_data_ptr_t aad, idx_t aad_len) {
+void EncryptionState::InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char *key,
+                                           duckdb::idx_t key_len, const_data_ptr_t aad, idx_t aad_len) {
 	throw NotImplementedException("EncryptionState Abstract Class is called");
 }
 

--- a/src/common/encryption_state.cpp
+++ b/src/common/encryption_state.cpp
@@ -2,34 +2,32 @@
 
 namespace duckdb {
 
-EncryptionState::EncryptionState(const unsigned char *key, idx_t key_len) {
+EncryptionState::EncryptionState(const_data_ptr_t key, idx_t key_len) {
 	// abstract class, no implementation needed
 }
 
 EncryptionState::~EncryptionState() {
 }
 
-void EncryptionState::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char *key,
-                                           duckdb::idx_t key_len, const_data_ptr_t aad, idx_t aad_len) {
+void EncryptionState::InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const_data_ptr_t key, idx_t key_len,
+                                           const_data_ptr_t aad, idx_t aad_len) {
 	throw NotImplementedException("EncryptionState Abstract Class is called");
 }
 
-void EncryptionState::InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char *key,
-                                           duckdb::idx_t key_len, const_data_ptr_t aad, idx_t aad_len) {
+void EncryptionState::InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const_data_ptr_t key, idx_t key_len,
+                                           const_data_ptr_t aad, idx_t aad_len) {
 	throw NotImplementedException("EncryptionState Abstract Class is called");
 }
 
-size_t EncryptionState::Process(duckdb::const_data_ptr_t in, duckdb::idx_t in_len, duckdb::data_ptr_t out,
-                                duckdb::idx_t out_len) {
+size_t EncryptionState::Process(const_data_ptr_t in, idx_t in_len, data_ptr_t out, idx_t out_len) {
 	throw NotImplementedException("EncryptionState Abstract Class is called");
 }
 
-size_t EncryptionState::Finalize(duckdb::data_ptr_t out, duckdb::idx_t out_len, duckdb::data_ptr_t tag,
-                                 duckdb::idx_t tag_len) {
+size_t EncryptionState::Finalize(data_ptr_t out, idx_t out_len, data_ptr_t tag, idx_t tag_len) {
 	throw NotImplementedException("EncryptionState Abstract Class is called");
 }
 
-void EncryptionState::GenerateRandomData(duckdb::data_ptr_t data, duckdb::idx_t len) {
+void EncryptionState::GenerateRandomData(data_ptr_t data, idx_t len) {
 	throw NotImplementedException("EncryptionState Abstract Class is called");
 }
 

--- a/src/include/duckdb/common/encryption_state.hpp
+++ b/src/include/duckdb/common/encryption_state.hpp
@@ -16,14 +16,16 @@ namespace duckdb {
 class EncryptionState {
 
 public:
-	DUCKDB_API explicit EncryptionState(const std::string *key = nullptr);
+	DUCKDB_API explicit EncryptionState(const unsigned char *key = nullptr, idx_t key_len = 0);
 	DUCKDB_API virtual ~EncryptionState();
 
 public:
-	DUCKDB_API virtual void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key,
-	                                             const_data_ptr_t aad = nullptr, idx_t aad_len = 0);
-	DUCKDB_API virtual void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const std::string *key,
-	                                             const_data_ptr_t aad = nullptr, idx_t aad_len = 0);
+	DUCKDB_API virtual void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key,
+	                                             duckdb::idx_t key_len, const_data_ptr_t aad = nullptr,
+	                                             idx_t aad_len = 0);
+	DUCKDB_API virtual void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key,
+	                                             duckdb::idx_t key_len, const_data_ptr_t aad = nullptr,
+	                                             idx_t aad_len = 0);
 	DUCKDB_API virtual size_t Process(const_data_ptr_t in, idx_t in_len, data_ptr_t out, idx_t out_len);
 	DUCKDB_API virtual size_t Finalize(data_ptr_t out, idx_t out_len, data_ptr_t tag, idx_t tag_len);
 	DUCKDB_API virtual void GenerateRandomData(data_ptr_t data, idx_t len);
@@ -39,7 +41,8 @@ public:
 	DUCKDB_API explicit EncryptionUtil() {};
 
 public:
-	virtual shared_ptr<EncryptionState> CreateEncryptionState(const std::string *key = nullptr) const {
+	virtual shared_ptr<EncryptionState> CreateEncryptionState(const unsigned char *key = nullptr,
+	                                                          idx_t key_len = 0) const {
 		return make_shared_ptr<EncryptionState>();
 	}
 

--- a/src/include/duckdb/common/encryption_state.hpp
+++ b/src/include/duckdb/common/encryption_state.hpp
@@ -16,16 +16,14 @@ namespace duckdb {
 class EncryptionState {
 
 public:
-	DUCKDB_API explicit EncryptionState(const unsigned char *key = nullptr, idx_t key_len = 0);
+	DUCKDB_API explicit EncryptionState(const_data_ptr_t key = nullptr, idx_t key_len = 0);
 	DUCKDB_API virtual ~EncryptionState();
 
 public:
-	DUCKDB_API virtual void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key,
-	                                             duckdb::idx_t key_len, const_data_ptr_t aad = nullptr,
-	                                             idx_t aad_len = 0);
-	DUCKDB_API virtual void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const unsigned char *key,
-	                                             duckdb::idx_t key_len, const_data_ptr_t aad = nullptr,
-	                                             idx_t aad_len = 0);
+	DUCKDB_API virtual void InitializeEncryption(const_data_ptr_t iv, idx_t iv_len, const_data_ptr_t key, idx_t key_len,
+	                                             const_data_ptr_t aad = nullptr, idx_t aad_len = 0);
+	DUCKDB_API virtual void InitializeDecryption(const_data_ptr_t iv, idx_t iv_len, const_data_ptr_t key, idx_t key_len,
+	                                             const_data_ptr_t aad = nullptr, idx_t aad_len = 0);
 	DUCKDB_API virtual size_t Process(const_data_ptr_t in, idx_t in_len, data_ptr_t out, idx_t out_len);
 	DUCKDB_API virtual size_t Finalize(data_ptr_t out, idx_t out_len, data_ptr_t tag, idx_t tag_len);
 	DUCKDB_API virtual void GenerateRandomData(data_ptr_t data, idx_t len);
@@ -41,8 +39,7 @@ public:
 	DUCKDB_API explicit EncryptionUtil() {};
 
 public:
-	virtual shared_ptr<EncryptionState> CreateEncryptionState(const unsigned char *key = nullptr,
-	                                                          idx_t key_len = 0) const {
+	virtual shared_ptr<EncryptionState> CreateEncryptionState(const_data_ptr_t key = nullptr, idx_t key_len = 0) const {
 		return make_shared_ptr<EncryptionState>();
 	}
 

--- a/third_party/mbedtls/include/mbedtls_wrapper.hpp
+++ b/third_party/mbedtls/include/mbedtls_wrapper.hpp
@@ -60,12 +60,12 @@ public:
 
 class AESStateMBEDTLS : public duckdb::EncryptionState {
 	public:
-		DUCKDB_API explicit AESStateMBEDTLS(const unsigned char *key = nullptr, duckdb::idx_t key_len = 0);
+		DUCKDB_API explicit AESStateMBEDTLS(duckdb::const_data_ptr_t key = nullptr, duckdb::idx_t key_len = 0);
 		DUCKDB_API ~AESStateMBEDTLS() override;
 
 	public:
-		DUCKDB_API void InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char* key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) override;
-		DUCKDB_API void InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char* key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) override;
+		DUCKDB_API void InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, duckdb::const_data_ptr_t key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) override;
+		DUCKDB_API void InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, duckdb::const_data_ptr_t key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) override;
 
 		DUCKDB_API size_t Process(duckdb::const_data_ptr_t in, duckdb::idx_t in_len, duckdb::data_ptr_t out,
 		                          duckdb::idx_t out_len) override;
@@ -88,8 +88,8 @@ class AESStateMBEDTLS : public duckdb::EncryptionState {
 	class AESStateMBEDTLSFactory : public duckdb::EncryptionUtil {
 
 	public:
-		duckdb::shared_ptr<duckdb::EncryptionState> CreateEncryptionState(const unsigned char *key = nullptr, duckdb::idx_t key_len = 0) const override {
-			return duckdb::make_shared_ptr<MbedTlsWrapper::AESStateMBEDTLS>(key);
+		duckdb::shared_ptr<duckdb::EncryptionState> CreateEncryptionState(duckdb::const_data_ptr_t key = nullptr, duckdb::idx_t key_len = 0) const override {
+			return duckdb::make_shared_ptr<MbedTlsWrapper::AESStateMBEDTLS>(key, key_len);
 		}
 
 		~AESStateMBEDTLSFactory() override {} //

--- a/third_party/mbedtls/include/mbedtls_wrapper.hpp
+++ b/third_party/mbedtls/include/mbedtls_wrapper.hpp
@@ -60,13 +60,13 @@ public:
 
 class AESStateMBEDTLS : public duckdb::EncryptionState {
 	public:
-		DUCKDB_API explicit AESStateMBEDTLS(const std::string *key = nullptr);
+		DUCKDB_API explicit AESStateMBEDTLS(const unsigned char *key = nullptr, duckdb::idx_t key_len = 0);
 		DUCKDB_API ~AESStateMBEDTLS() override;
 
 	public:
-		DUCKDB_API void InitializeInternal(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len);
-		DUCKDB_API void InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) override;
-		DUCKDB_API void InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) override;
+		DUCKDB_API void InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char* key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) override;
+		DUCKDB_API void InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char* key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) override;
+
 		DUCKDB_API size_t Process(duckdb::const_data_ptr_t in, duckdb::idx_t in_len, duckdb::data_ptr_t out,
 		                          duckdb::idx_t out_len) override;
 		DUCKDB_API size_t Finalize(duckdb::data_ptr_t out, duckdb::idx_t out_len, duckdb::data_ptr_t tag, duckdb::idx_t tag_len) override;
@@ -77,6 +77,9 @@ class AESStateMBEDTLS : public duckdb::EncryptionState {
 		DUCKDB_API const mbedtls_cipher_info_t *GetCipher(size_t key_len);
 
 	private:
+		DUCKDB_API void InitializeInternal(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len);
+
+	private:
 		Mode mode;
 		Cipher cipher = GCM;
 		duckdb::unique_ptr<mbedtls_cipher_context_t> context;
@@ -85,7 +88,7 @@ class AESStateMBEDTLS : public duckdb::EncryptionState {
 	class AESStateMBEDTLSFactory : public duckdb::EncryptionUtil {
 
 	public:
-		duckdb::shared_ptr<duckdb::EncryptionState> CreateEncryptionState(const std::string *key = nullptr) const override {
+		duckdb::shared_ptr<duckdb::EncryptionState> CreateEncryptionState(const unsigned char *key = nullptr, duckdb::idx_t key_len = 0) const override {
 			return duckdb::make_shared_ptr<MbedTlsWrapper::AESStateMBEDTLS>(key);
 		}
 

--- a/third_party/mbedtls/mbedtls_wrapper.cpp
+++ b/third_party/mbedtls/mbedtls_wrapper.cpp
@@ -236,10 +236,11 @@ const mbedtls_cipher_info_t *MbedTlsWrapper::AESStateMBEDTLS::GetCipher(size_t k
 	}
 }
 
-MbedTlsWrapper::AESStateMBEDTLS::AESStateMBEDTLS(const std::string *key) : context(duckdb::make_uniq<mbedtls_cipher_context_t>()) {
+MbedTlsWrapper::AESStateMBEDTLS::AESStateMBEDTLS(const unsigned char *key, duckdb::idx_t key_len) : context(duckdb::make_uniq<mbedtls_cipher_context_t>()) {
 	mbedtls_cipher_init(context.get());
 
-	auto cipher_info = GetCipher(key->length());
+	auto cipher_info = GetCipher(key_len);
+
 	if (!cipher_info) {
 		runtime_error("Failed to get Cipher");
 	}
@@ -271,7 +272,7 @@ void MbedTlsWrapper::AESStateMBEDTLS::GenerateRandomData(duckdb::data_ptr_t data
 	GenerateRandomDataStatic(data, len);
 }
 
-void MbedTlsWrapper::AESStateMBEDTLS::InitializeInternal(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len){
+void MbedTlsWrapper::AESStateMBEDTLS::InitializeInternal(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len){
 	if (mbedtls_cipher_set_iv(context.get(), iv, iv_len) != 0) {
 		runtime_error("Failed to set IV for encryption");
 	}
@@ -284,24 +285,25 @@ void MbedTlsWrapper::AESStateMBEDTLS::InitializeInternal(duckdb::const_data_ptr_
 	}
 }
 
-void MbedTlsWrapper::AESStateMBEDTLS::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) {
+
+void MbedTlsWrapper::AESStateMBEDTLS::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char* key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) {
 	mode = ENCRYPT;
 
-	if (mbedtls_cipher_setkey(context.get(), reinterpret_cast<const unsigned char *>(key->data()), key->length() * 8, MBEDTLS_ENCRYPT) != 0) {
+	if (mbedtls_cipher_setkey(context.get(), key, key_len * 8, MBEDTLS_ENCRYPT) != 0) {
 		runtime_error("Failed to set AES key for encryption");
 	}
 
-	InitializeInternal(iv, iv_len, key, aad, aad_len);
+	InitializeInternal(iv, iv_len, aad, aad_len);
 }
 
-void MbedTlsWrapper::AESStateMBEDTLS::InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key,  duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) {
-	mode = DECRYPT;
+void MbedTlsWrapper::AESStateMBEDTLS::InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char* key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) {
+	mode = ENCRYPT;
 
-	if (mbedtls_cipher_setkey(context.get(), reinterpret_cast<const unsigned char *>(key->data()), key->length() * 8, MBEDTLS_DECRYPT) != 0) {
-		runtime_error("Failed to set AES key for decryption");
+	if (mbedtls_cipher_setkey(context.get(), key, key_len * 8, MBEDTLS_DECRYPT) != 0) {
+		runtime_error("Failed to set AES key for encryption");
 	}
 
-	InitializeInternal(iv, iv_len, key, aad, aad_len);
+	InitializeInternal(iv, iv_len, aad, aad_len);
 }
 
 size_t MbedTlsWrapper::AESStateMBEDTLS::Process(duckdb::const_data_ptr_t in, duckdb::idx_t in_len, duckdb::data_ptr_t out,

--- a/third_party/mbedtls/mbedtls_wrapper.cpp
+++ b/third_party/mbedtls/mbedtls_wrapper.cpp
@@ -236,7 +236,7 @@ const mbedtls_cipher_info_t *MbedTlsWrapper::AESStateMBEDTLS::GetCipher(size_t k
 	}
 }
 
-MbedTlsWrapper::AESStateMBEDTLS::AESStateMBEDTLS(const unsigned char *key, duckdb::idx_t key_len) : context(duckdb::make_uniq<mbedtls_cipher_context_t>()) {
+MbedTlsWrapper::AESStateMBEDTLS::AESStateMBEDTLS(duckdb::const_data_ptr_t key, duckdb::idx_t key_len) : context(duckdb::make_uniq<mbedtls_cipher_context_t>()) {
 	mbedtls_cipher_init(context.get());
 
 	auto cipher_info = GetCipher(key_len);
@@ -286,7 +286,7 @@ void MbedTlsWrapper::AESStateMBEDTLS::InitializeInternal(duckdb::const_data_ptr_
 }
 
 
-void MbedTlsWrapper::AESStateMBEDTLS::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char* key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) {
+void MbedTlsWrapper::AESStateMBEDTLS::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, duckdb::const_data_ptr_t key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) {
 	mode = ENCRYPT;
 
 	if (mbedtls_cipher_setkey(context.get(), key, key_len * 8, MBEDTLS_ENCRYPT) != 0) {
@@ -296,8 +296,8 @@ void MbedTlsWrapper::AESStateMBEDTLS::InitializeEncryption(duckdb::const_data_pt
 	InitializeInternal(iv, iv_len, aad, aad_len);
 }
 
-void MbedTlsWrapper::AESStateMBEDTLS::InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const unsigned char* key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) {
-	mode = ENCRYPT;
+void MbedTlsWrapper::AESStateMBEDTLS::InitializeDecryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, duckdb::const_data_ptr_t key, duckdb::idx_t key_len, duckdb::const_data_ptr_t aad, duckdb::idx_t aad_len) {
+	mode = DECRYPT;
 
 	if (mbedtls_cipher_setkey(context.get(), key, key_len * 8, MBEDTLS_DECRYPT) != 0) {
 		runtime_error("Failed to set AES key for encryption");


### PR DESCRIPTION
The encryption API took a string for the key as input, meaning that we are forced to cast bytes to a string (which is not  safe). This PR changes the API slightly such that we don't have to cast bytes to a string before using encryption functions and is necessary to avoid storing keys in strings.