### PR TITLE
`remap_struct`: Correctly reserve list vectors to deal with remapping larger-than-vector-size lists/maps

### DIFF
--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -84,6 +84,7 @@ static void RemapMap(Vector &input, Vector &default_vector, Vector &result, idx_
 	auto &result_key_vector = MapVector::GetKeys(result);
 	auto &result_value_vector = MapVector::GetValues(result);
 	auto list_size = ListVector::GetListSize(input);
+	ListVector::Reserve(result, list_size);
 	ListVector::SetListSize(result, list_size);
 
 	bool has_top_level_null = false;
@@ -136,6 +137,7 @@ static void RemapList(Vector &input, Vector &default_vector, Vector &result, idx
 	auto &input_vector = ListVector::GetEntry(input);
 	auto &result_vector = ListVector::GetEntry(result);
 	auto list_size = ListVector::GetListSize(input);
+	ListVector::Reserve(result, list_size);
 	ListVector::SetListSize(result, list_size);
 
 	bool has_top_level_null = false;

--- a/test/sql/types/struct/remap_struct_in_list.test
+++ b/test/sql/types/struct/remap_struct_in_list.test
@@ -56,3 +56,18 @@ SELECT remap_struct(
 ); -- defaults
 ----
 [{'v1': 1, 'v2': {'x': 42, 'y': NULL, 'z': 100}, 'v3': NULL}]
+
+# remap large list
+statement ok
+CREATE TABLE large_list(s STRUCT(i INTEGER)[]);
+
+statement ok
+INSERT INTO large_list (SELECT LIST(CASE WHEN i%2=0 THEN {'i': i} ELSE NULL END) FROM range(5000) t(i));
+
+query III
+SELECT COUNT(*), COUNT(j), SUM(j)
+FROM (
+	SELECT UNNEST(remap_struct(s, NULL::ROW(j INTEGER)[], {'list': ROW('list', {'j': 'i'})}, NULL), recursive := True) FROM large_list
+)
+----
+5000	2500	6247500


### PR DESCRIPTION
Fixes https://github.com/duckdb/ducklake/issues/157