### PR TITLE
Fixup `unique_ptr<T[], deleter>`, now with working custom deleters

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -696,7 +696,7 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 	}
 
 	// RAII wrapper around DIR to automatically free on exceptions in callback
-	std::unique_ptr<DIR, std::function<void(DIR *)>> dir_unique_ptr(dir, [](DIR *d) { closedir(d); });
+	duckdb::unique_ptr<DIR, std::function<void(DIR *)>> dir_unique_ptr(dir, [](DIR *d) { closedir(d); });
 
 	struct dirent *ent;
 	// loop over all files in the directory

--- a/src/execution/operator/csv_scanner/encode/csv_encoder.cpp
+++ b/src/execution/operator/csv_scanner/encode/csv_encoder.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 
 void CSVEncoderBuffer::Initialize(idx_t encoded_size) {
 	encoded_buffer_size = encoded_size;
-	encoded_buffer = std::unique_ptr<char[]>(new char[encoded_size]);
+	encoded_buffer = duckdb::unique_ptr<char[]>(new char[encoded_size]);
 }
 
 char *CSVEncoderBuffer::Ptr() const {

--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -82,31 +82,31 @@ make_unsafe_uniq(ARGS&&... args) // NOLINT: mimic std style
 }
 
 template<class DATA_TYPE>
-inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>
+inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, true>
 make_uniq_array(size_t n) // NOLINT: mimic std style
 {
-	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>(new DATA_TYPE[n]());
+	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, true>(new DATA_TYPE[n]());
 }
 
 template<class DATA_TYPE>
-inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>
+inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, true>
 make_uniq_array_uninitialized(size_t n) // NOLINT: mimic std style
 {
-	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>(new DATA_TYPE[n]);
+	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, true>(new DATA_TYPE[n]);
 }
 
 template<class DATA_TYPE>
-inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>
+inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, false>
 make_unsafe_uniq_array(size_t n) // NOLINT: mimic std style
 {
-	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>(new DATA_TYPE[n]());
+	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, false>(new DATA_TYPE[n]());
 }
 
 template<class DATA_TYPE>
-inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>
+inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, false>
 make_unsafe_uniq_array_uninitialized(size_t n) // NOLINT: mimic std style
 {
-	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>(new DATA_TYPE[n]);
+	return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>, false>(new DATA_TYPE[n]);
 }
 
 template<class DATA_TYPE, class... ARGS>

--- a/src/include/duckdb/execution/operator/csv_scanner/encode/csv_encoder.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/encode/csv_encoder.hpp
@@ -40,7 +40,7 @@ struct CSVEncoderBuffer {
 
 private:
 	//! The encoded buffer, we only have one per file, so we cache it and make sure to pass over unused bytes.
-	std::unique_ptr<char[]> encoded_buffer;
+	duckdb::unique_ptr<char[]> encoded_buffer;
 	//! The encoded buffer size is defined as buffer_size/GetRatio()
 	idx_t encoded_buffer_size;
 };


### PR DESCRIPTION
Resolve a `FIXME` in `unique_ptr.hpp` by properly propagating deleter, and remove three instances of unchecked std::unique_ptr in the codebase.