### PR TITLE
Fix ICE with Windows ARM64 (1.3)

### DIFF
--- a/extension/core_functions/scalar/date/CMakeLists.txt
+++ b/extension/core_functions/scalar/date/CMakeLists.txt
@@ -14,3 +14,14 @@ add_library_unity(
 set(CORE_FUNCTION_FILES
     ${CORE_FUNCTION_FILES} $<TARGET_OBJECTS:duckdb_core_functions_date>
     PARENT_SCOPE)
+
+# https://learn.microsoft.com/en-us/cpp/build/reference/ob-inline-function-expansion?view=msvc-170
+# Lower functions inlining, /Ob2 causes ICE with ARM64 toolchain (both
+# cross-compile and native): error MSB6006: "CL.exe" exited with code -529706956
+if(MSVC
+   AND (CMAKE_VS_PLATFORM_NAME STREQUAL "ARM64")
+   AND (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL
+                                               "RelWithDebInfo"))
+  set_source_files_properties(ub_duckdb_core_functions_date
+                              PROPERTIES COMPILE_OPTIONS /Ob1)
+endif()


### PR DESCRIPTION
This is a 1.3 backport of PR #17844.

This change attempts to fix the ICE that happens on Windows with MSVC ARM64 toolchains - with both cross-compiling and native ones.

Abbreviated example (stacktrace can differ):

```
 CL.exe /c /IC:[...] /nologo /W1 /WX- /diagnostics:column
   /O2 /Ob2 /Oy- /D[...] /EHsc /MD /GS /fp:precise /Zc:[...] /Fo"[...]"
   /Fd"[...]" /external:W1 /Gd /TP /wd[...] /analyze- /errorReport:queue
   /utf-8 /bigobj
   C:\a\duckdb\duckdb\extension\core_functions\scalar\date\ub_duckdb_core_functions_date.cpp
   base type 1 bad size 16
   base type 1 bad size 16
   base type 1 bad size 16
   base type 1 bad size 16
     CL!RaiseException()+0x60
     CL!RaiseException()+0x60
     CL!InvokeCompilerPass()+0x7f7f
     CL!InvokeCompilerPass()+0x171
[...]Microsoft.CppCommon.targets(781,5):
    error MSB6006: "CL.exe" exited with code -529706956. [[...].vcxproj]
```

It lowers inlining requirements for `ub_duckdb_core_functions_date.cpp` on MSVC ARM64 `Release` and `RelWithDebInfo` builds from `/Ob2`:

> The default value under /O1 and /O2. Allows the compiler to expand
> any function not explicitly marked for no inlining.

to `/Ob1`:

> Allows expansion only of functions marked inline, __inline, or
> __forceinline, or in a C++ member function defined in a class
> declaration.

Testing: cannot reproduce this locally with cross-compiling, only tested with partial build on GH actions (native and cross).

Fixes: duckdblabs/duckdb-internal#5079