### PR TITLE
Add memory-efficient read_json_auto_chunked table function

### DIFF
--- a/src/function/table/read_json_auto_chunked.cpp
+++ b/src/function/table/read_json_auto_chunked.cpp
@@ -1,0 +1,64 @@
+#include "duckdb.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+using namespace duckdb;
+using json = nlohmann::json;
+
+struct ChunkedJSONReaderState : public TableFunctionState {
+	std::ifstream file;
+	idx_t lines_read = 0;
+	idx_t chunk_size = 100;
+	vector<json> buffered_lines;
+	idx_t current_index = 0;
+};
+
+static unique_ptr<FunctionData> BindChunkedJSON(ClientContext &context, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	names.push_back("json_line");
+	return_types.push_back(LogicalType::VARCHAR);
+	return nullptr;
+}
+
+static unique_ptr<TableFunctionState> InitChunkedJSON(ClientContext &context, TableFunctionInitInput &input) {
+	auto state = make_uniq<ChunkedJSONReaderState>();
+	string path = input.inputs[0].GetValue<string>();
+
+	state->file.open(path);
+	if (!state->file.is_open()) {
+		throw IOException("Could not open file: " + path);
+	}
+
+	return std::move(state);
+}
+
+static void ChunkedJSONFunc(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
+	auto &state = (ChunkedJSONReaderState &)*input.state;
+
+	idx_t count = 0;
+	std::string line;
+	while (count < STANDARD_VECTOR_SIZE && std::getline(state.file, line)) {
+		if (line.empty()) continue;
+		try {
+			json parsed = json::parse(line);
+			output.SetValue(0, count, Value(parsed.dump()));
+			count++;
+		} catch (...) {
+			continue; 
+		}
+	}
+
+	output.SetCardinality(count);
+}
+
+void LoadInternalChunkedReaderFunction(BuiltinFunctions &set) {
+	TableFunction func("read_json_auto_chunked", {LogicalType::VARCHAR}, ChunkedJSONFunc, BindChunkedJSON,
+	                   InitChunkedJSON);
+	set.AddFunction(func);
+}

--- a/test/sql/large_sample.json
+++ b/test/sql/large_sample.json
@@ -1,0 +1,3 @@
+{ "id": 1, "name": "Deniz" }
+{ "id": 2, "name": "Batuhan" }
+{ "id": 3, "name": "Ahmet Feyzi" }

--- a/test/sql/test_read_json_auto_chunked.test
+++ b/test/sql/test_read_json_auto_chunked.test
@@ -1,0 +1,10 @@
+statement ok
+CREATE TABLE json_result AS
+SELECT * FROM read_json_auto_chunked('test/sql/large_sample.json');
+
+query I
+SELECT COUNT(*) FROM json_result;
+
+----
+
+3


### PR DESCRIPTION
This PR adds a new table function called read_json_auto_chunked, which reads JSON files line by line instead of loading the whole file into memory. It's a lightweight and practical solution for handling large JSON datasets, especially on machines with limited RAM. Parses each JSON object per line, Works well with line-delimited (newline-separated) JSON files, Added a simple test under test/sql/ , Helps avoid out-of-memory errors on big files. The chunk size is currently fixed, but I’m planning to make it configurable in a future update.