### PR TITLE
Add `duckdb_type` column to parquet_schema

### DIFF
--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -402,6 +402,9 @@ void ParquetMetaDataOperatorData::BindSchema(vector<LogicalType> &return_types, 
 
 	names.emplace_back("logical_type");
 	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("duckdb_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
 }
 
 Value ParquetLogicalTypeToString(const duckdb_parquet::LogicalType &type, bool is_set) {
@@ -497,6 +500,14 @@ void ParquetMetaDataOperatorData::LoadSchemaData(ClientContext &context, const v
 
 		// logical_type, LogicalType::VARCHAR
 		current_chunk.SetValue(10, count, ParquetLogicalTypeToString(column.logicalType, column.__isset.logicalType));
+
+		// duckdb_type, LogicalType::VARCHAR
+		ParquetColumnSchema column_schema;
+		Value duckdb_type;
+		if (column.__isset.type) {
+			duckdb_type = reader->DeriveLogicalType(column, column_schema).ToString();
+		}
+		current_chunk.SetValue(11, count, duckdb_type);
 
 		count++;
 		if (count >= STANDARD_VECTOR_SIZE) {

--- a/test/sql/copy/parquet/parquet_metadata.test
+++ b/test/sql/copy/parquet/parquet_metadata.test
@@ -36,3 +36,23 @@ select * from parquet_schema('data/parquet-testing/glob/*.parquet');
 # list parameters
 statement ok
 select * from parquet_schema(['data/parquet-testing/decimal/int64_decimal.parquet', 'data/parquet-testing/decimal/int64_decimal.parquet']);
+
+query III
+SELECT name, type, duckdb_type FROM parquet_schema('data/parquet-testing/lineitem-top10000.gzip.parquet') WHERE type IS NOT NULL;
+----
+l_orderkey	INT64	BIGINT
+l_partkey	INT64	BIGINT
+l_suppkey	INT64	BIGINT
+l_linenumber	INT32	INTEGER
+l_quantity	INT32	INTEGER
+l_extendedprice	DOUBLE	DOUBLE
+l_discount	DOUBLE	DOUBLE
+l_tax	DOUBLE	DOUBLE
+l_returnflag	BYTE_ARRAY	VARCHAR
+l_linestatus	BYTE_ARRAY	VARCHAR
+l_shipdate	BYTE_ARRAY	VARCHAR
+l_commitdate	BYTE_ARRAY	VARCHAR
+l_receiptdate	BYTE_ARRAY	VARCHAR
+l_shipinstruct	BYTE_ARRAY	VARCHAR
+l_shipmode	BYTE_ARRAY	VARCHAR
+l_comment	BYTE_ARRAY	VARCHAR


### PR DESCRIPTION
This PR adds the `duckdb_type` column to be emitted from the `parquet_schema` function, e.g.:

```sql
SELECT name, type, duckdb_type FROM parquet_schema('data/parquet-testing/lineitem-top10000.gzip.parquet') WHERE type IS NOT NULL;
```

```
l_orderkey	INT64	BIGINT
l_partkey	INT64	BIGINT
l_suppkey	INT64	BIGINT
l_linenumber	INT32	INTEGER
l_quantity	INT32	INTEGER
l_extendedprice	DOUBLE	DOUBLE
l_discount	DOUBLE	DOUBLE
l_tax	DOUBLE	DOUBLE
l_returnflag	BYTE_ARRAY	VARCHAR
l_linestatus	BYTE_ARRAY	VARCHAR
l_shipdate	BYTE_ARRAY	VARCHAR
l_commitdate	BYTE_ARRAY	VARCHAR
l_receiptdate	BYTE_ARRAY	VARCHAR
l_shipinstruct	BYTE_ARRAY	VARCHAR
l_shipmode	BYTE_ARRAY	VARCHAR
l_comment	BYTE_ARRAY	VARCHAR
```