### PR TITLE
Convert UUIDs to arrow.uuid using existing extension

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -170,20 +170,9 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		child.format = "g";
 		break;
 	case LogicalTypeId::UUID: {
-		if (options.arrow_lossless_conversion) {
-			SetArrowExtension(root_holder, child, type, context);
-		} else {
-			if (options.produce_arrow_string_view && options.arrow_output_version >= 14) {
-				// List views are only introduced in arrow format v1.4
-				child.format = "vu";
-			} else {
-				if (options.arrow_offset_size == ArrowOffsetSize::LARGE) {
-					child.format = "U";
-				} else {
-					child.format = "u";
-				}
-			}
-		}
+		auto &config = DBConfig::GetConfig(context);
+		ArrowTypeExtension uuid_extension = config.GetArrowExtension(LogicalType::UUID);
+		ArrowTypeExtension::PopulateArrowSchema(root_holder, child, type, context, uuid_extension);
 		break;
 	}
 	case LogicalTypeId::VARCHAR:


### PR DESCRIPTION
This is an attempt at fixing https://github.com/duckdb/duckdb/issues/17842

This change currently compiles, but fails with a weird error I'm not sure how to debug.

I need to add a test. I would love to write this in python, because that's what I'm familiar with. I can do that with no help. But if you want this test to be in the C++ codebase, I can do that too, but I would need some help.

Testing with

```python
import duckdb

duckdb.sql("SELECT uuid() as myuuid").arrow()
```

which gives (on my commit 4027c228ea)

```
---------------------------------------------------------------------------
ArrowInvalid                              Traceback (most recent call last)
Cell In[3], line 3
      1 import duckdb
----> 3 duckdb.sql("SELECT uuid() as myuuid").arrow()

File ~/code/duckdb/.venv/lib/python3.11/site-packages/pyarrow/table.pxi:3625, in pyarrow.lib.RecordBatch._import_from_c()

File ~/code/duckdb/.venv/lib/python3.11/site-packages/pyarrow/error.pxi:155, in pyarrow.lib.pyarrow_internal_check_status()

File ~/code/duckdb/.venv/lib/python3.11/site-packages/pyarrow/error.pxi:92, in pyarrow.lib.check_status()

ArrowInvalid: Expected 2 buffers for imported type fixed_size_binary[16], ArrowArray struct has 3
```

I'm not sure what to do about this yet.

This uses the extension that is registered at https://github.com/duckdb/duckdb/blob/114dfe11b2183de8803551f811e3dbb4d04b37a7/src/common/arrow/arrow_type_extension.cpp#L368.

Notes for me to develop:
- Delete tools/pythonpkg/build/ directory between builds for the python to pick up the new version. please comment if you know how to skip this step
- run `GEN=ninja BUILD_PYTHON=1 make debug`