### PR TITLE
Use boolean operators instead of bitwise operators for (`u`)`hugeint`

### DIFF
--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -137,7 +137,7 @@ BenchmarkQuery InterpretedBenchmark::ReadQueryFromReader(BenchmarkFileReader &re
 			break;
 		}
 		auto result_splits = StringUtil::Split(line, "\t");
-		if ((int64_t)result_splits.size() != query.column_count) {
+		if (result_splits.size() != query.column_count) {
 			throw std::runtime_error(reader.FormatException("expected " + std::to_string(result_splits.size()) +
 			                                                " values but got " + std::to_string(query.column_count)));
 		}
@@ -689,7 +689,7 @@ string InterpretedBenchmark::VerifyInternal(BenchmarkState *state_p, const Bench
 
 	auto &result_values = query.expected_result;
 	D_ASSERT(query.column_count >= 1);
-	if (query.column_count != (int64_t)result.ColumnCount()) {
+	if (query.column_count != result.ColumnCount()) {
 		return StringUtil::Format("Error in result: expected %lld columns but got %lld\nObtained result: %s",
 		                          (int64_t)query.column_count, (int64_t)result.ColumnCount(), result.ToString());
 	}
@@ -700,8 +700,8 @@ string InterpretedBenchmark::VerifyInternal(BenchmarkState *state_p, const Bench
 		                          (int64_t)result_values.size(), (int64_t)result.RowCount(), result.ToString());
 	}
 	// compare values
-	for (int64_t r = 0; r < (int64_t)result_values.size(); r++) {
-		for (int64_t c = 0; c < query.column_count; c++) {
+	for (idx_t r = 0; r < result_values.size(); r++) {
+		for (idx_t c = 0; c < query.column_count; c++) {
 			auto value = result.GetValue(c, r);
 			if (result_values[r][c] == "NULL" && value.IsNull()) {
 				continue;

--- a/extension/json/json_reader.cpp
+++ b/extension/json/json_reader.cpp
@@ -737,7 +737,7 @@ bool JSONReader::CopyRemainderFromPreviousBuffer(JSONReaderScanState &scan_state
 	idx_t prev_buffer_size = previous_buffer_handle->buffer_size - previous_buffer_handle->buffer_start;
 	auto prev_buffer_ptr = char_ptr_cast(previous_buffer_handle->buffer.get()) + previous_buffer_handle->buffer_size;
 	auto prev_object_start = PreviousNewline(prev_buffer_ptr, prev_buffer_size);
-	auto prev_object_size = prev_buffer_ptr - prev_object_start;
+	auto prev_object_size = NumericCast<idx_t>(prev_buffer_ptr - prev_object_start);
 
 	D_ASSERT(scan_state.buffer_offset == options.maximum_object_size);
 	if (prev_object_size > scan_state.buffer_offset) {

--- a/src/include/duckdb/common/types/hugeint.hpp
+++ b/src/include/duckdb/common/types/hugeint.hpp
@@ -129,46 +129,42 @@ public:
 	static int Sign(hugeint_t n);
 	static hugeint_t Abs(hugeint_t n);
 	// comparison operators
-	// note that everywhere here we intentionally use bitwise ops
-	// this is because they seem to be consistently much faster (benchmarked on a Macbook Pro)
 	static bool Equals(hugeint_t lhs, hugeint_t rhs) {
-		int lower_equals = lhs.lower == rhs.lower;
-		int upper_equals = lhs.upper == rhs.upper;
-		return lower_equals & upper_equals;
+		bool lower_equals = lhs.lower == rhs.lower;
+		bool upper_equals = lhs.upper == rhs.upper;
+		return lower_equals && upper_equals;
 	}
 
 	static bool NotEquals(hugeint_t lhs, hugeint_t rhs) {
-		int lower_not_equals = lhs.lower != rhs.lower;
-		int upper_not_equals = lhs.upper != rhs.upper;
-		return lower_not_equals | upper_not_equals;
+		return !Equals(lhs, rhs);
 	}
 
 	static bool GreaterThan(hugeint_t lhs, hugeint_t rhs) {
-		int upper_bigger = lhs.upper > rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_bigger = lhs.lower > rhs.lower;
-		return upper_bigger | (upper_equal & lower_bigger);
+		bool upper_bigger = lhs.upper > rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_bigger = lhs.lower > rhs.lower;
+		return upper_bigger || (upper_equal && lower_bigger);
 	}
 
 	static bool GreaterThanEquals(hugeint_t lhs, hugeint_t rhs) {
-		int upper_bigger = lhs.upper > rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_bigger_equals = lhs.lower >= rhs.lower;
-		return upper_bigger | (upper_equal & lower_bigger_equals);
+		bool upper_bigger = lhs.upper > rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_bigger_equals = lhs.lower >= rhs.lower;
+		return upper_bigger || (upper_equal && lower_bigger_equals);
 	}
 
 	static bool LessThan(hugeint_t lhs, hugeint_t rhs) {
-		int upper_smaller = lhs.upper < rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_smaller = lhs.lower < rhs.lower;
-		return upper_smaller | (upper_equal & lower_smaller);
+		bool upper_smaller = lhs.upper < rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_smaller = lhs.lower < rhs.lower;
+		return upper_smaller || (upper_equal && lower_smaller);
 	}
 
 	static bool LessThanEquals(hugeint_t lhs, hugeint_t rhs) {
-		int upper_smaller = lhs.upper < rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_smaller_equals = lhs.lower <= rhs.lower;
-		return upper_smaller | (upper_equal & lower_smaller_equals);
+		bool upper_smaller = lhs.upper < rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_smaller_equals = lhs.lower <= rhs.lower;
+		return upper_smaller || (upper_equal && lower_smaller_equals);
 	}
 
 	static constexpr uint8_t CACHED_POWERS_OF_TEN = 39;

--- a/src/include/duckdb/common/types/uhugeint.hpp
+++ b/src/include/duckdb/common/types/uhugeint.hpp
@@ -118,46 +118,42 @@ public:
 	static hugeint_t Abs(hugeint_t n);
 
 	// comparison operators
-	// note that everywhere here we intentionally use bitwise ops
-	// this is because they seem to be consistently much faster (benchmarked on a Macbook Pro)
 	static bool Equals(uhugeint_t lhs, uhugeint_t rhs) {
-		int lower_equals = lhs.lower == rhs.lower;
-		int upper_equals = lhs.upper == rhs.upper;
-		return lower_equals & upper_equals;
+		bool lower_equals = lhs.lower == rhs.lower;
+		bool upper_equals = lhs.upper == rhs.upper;
+		return lower_equals && upper_equals;
 	}
 
 	static bool NotEquals(uhugeint_t lhs, uhugeint_t rhs) {
-		int lower_not_equals = lhs.lower != rhs.lower;
-		int upper_not_equals = lhs.upper != rhs.upper;
-		return lower_not_equals | upper_not_equals;
+		return !Equals(lhs, rhs);
 	}
 
 	static bool GreaterThan(uhugeint_t lhs, uhugeint_t rhs) {
-		int upper_bigger = lhs.upper > rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_bigger = lhs.lower > rhs.lower;
-		return upper_bigger | (upper_equal & lower_bigger);
+		bool upper_bigger = lhs.upper > rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_bigger = lhs.lower > rhs.lower;
+		return upper_bigger || (upper_equal && lower_bigger);
 	}
 
 	static bool GreaterThanEquals(uhugeint_t lhs, uhugeint_t rhs) {
-		int upper_bigger = lhs.upper > rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_bigger_equals = lhs.lower >= rhs.lower;
-		return upper_bigger | (upper_equal & lower_bigger_equals);
+		bool upper_bigger = lhs.upper > rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_bigger_equals = lhs.lower >= rhs.lower;
+		return upper_bigger || (upper_equal && lower_bigger_equals);
 	}
 
 	static bool LessThan(uhugeint_t lhs, uhugeint_t rhs) {
-		int upper_smaller = lhs.upper < rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_smaller = lhs.lower < rhs.lower;
-		return upper_smaller | (upper_equal & lower_smaller);
+		bool upper_smaller = lhs.upper < rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_smaller = lhs.lower < rhs.lower;
+		return upper_smaller || (upper_equal && lower_smaller);
 	}
 
 	static bool LessThanEquals(uhugeint_t lhs, uhugeint_t rhs) {
-		int upper_smaller = lhs.upper < rhs.upper;
-		int upper_equal = lhs.upper == rhs.upper;
-		int lower_smaller_equals = lhs.lower <= rhs.lower;
-		return upper_smaller | (upper_equal & lower_smaller_equals);
+		bool upper_smaller = lhs.upper < rhs.upper;
+		bool upper_equal = lhs.upper == rhs.upper;
+		bool lower_smaller_equals = lhs.lower <= rhs.lower;
+		return upper_smaller || (upper_equal && lower_smaller_equals);
 	}
 
 	static constexpr uint8_t CACHED_POWERS_OF_TEN = 39;

--- a/test/issues/general/test_17446.test
+++ b/test/issues/general/test_17446.test
@@ -5,8 +5,8 @@
 statement ok
 pragma disable_optimizer;
 
-# statement ok
-# PRAGMA enable_verification;
+statement ok
+PRAGMA enable_verification;
 
 statement ok
 CREATE TABLE t0(c0 varchar);

--- a/test/issues/general/test_17757.test
+++ b/test/issues/general/test_17757.test
@@ -1,0 +1,44 @@
+# name: test/issues/general/test_17757.test
+# description: Issue 17757 - Aggregation filter not working all the time on Linux, but working on MacOS
+# group: [general]
+
+statement ok
+CREATE TABLE id_mapping (
+  id HUGEINT NOT NULL,
+  child_id HUGEINT NOT NULL
+) ;
+
+statement ok
+INSERT INTO id_mapping (id, child_id)
+SELECT id, UNNEST(child_ids)
+FROM (
+  SELECT
+    i AS id,
+    [10000 + i, 20000 + i, 30000 + i] AS child_ids
+  FROM generate_series(1000) t(i)
+) ;
+
+statement ok
+INSERT INTO id_mapping (id, child_id)
+SELECT id, id FROM id_mapping ;
+
+query II
+SELECT
+  id,
+  ARRAY_AGG(child_id) FILTER ( child_id != id )
+   AS child_ids
+FROM id_mapping
+GROUP BY id
+HAVING LENGTH(child_ids) != 3;
+----
+
+
+query II
+SELECT
+  id,
+  ARRAY_AGG(child_id) FILTER ( child_id != id )
+   AS child_ids
+FROM id_mapping
+GROUP BY id
+HAVING LENGTH(child_ids) != 3;
+----


### PR DESCRIPTION
Hopefully fixes #17757

We cannot reproduce when compiling ourselves, so we'll have to try and reproduce with a CI-built binary.

I also fixed some warnings I encountered while compiling with GCC and uncommented a `PRAGMA enable_verification;` in a test that shouldn't have been there.