### PR TITLE
Add FinalizeLoad callback to catalogs, which can be called after the database is fully instantiated

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1201,6 +1201,9 @@ void Catalog::Initialize(optional_ptr<ClientContext> context, bool load_builtin)
 	Initialize(load_builtin);
 }
 
+void Catalog::FinalizeLoad(optional_ptr<ClientContext> context) {
+}
+
 void Catalog::OnDetach(ClientContext &context) {
 }
 

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -149,10 +149,16 @@ string CatalogSearchPath::GetSetName(CatalogSetPathType set_type) {
 }
 
 void CatalogSearchPath::Set(vector<CatalogSearchEntry> new_paths, CatalogSetPathType set_type) {
-	if (set_type != CatalogSetPathType::SET_SCHEMAS && new_paths.size() != 1) {
+	if (set_type == CatalogSetPathType::SET_SCHEMA && new_paths.size() != 1) {
 		throw CatalogException("%s can set only 1 schema. This has %d", GetSetName(set_type), new_paths.size());
 	}
 	for (auto &path : new_paths) {
+		if (set_type == CatalogSetPathType::SET_DIRECTLY) {
+			if (path.catalog.empty() || path.schema.empty()) {
+				throw InternalException("SET_WITHOUT_VERIFICATION requires a fully qualified set path");
+			}
+			continue;
+		}
 		auto schema_entry = Catalog::GetSchema(context, path.catalog, path.schema, OnEntryNotFound::RETURN_NULL);
 		if (schema_entry) {
 			// we are setting a schema - update the catalog and schema

--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -72,6 +72,7 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 	if (!options.default_table.name.empty()) {
 		attached_db->GetCatalog().SetDefaultTable(options.default_table.schema, options.default_table.name);
 	}
+	attached_db->FinalizeLoad(context.client);
 	return SourceResultType::FINISHED;
 }
 

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -109,6 +109,7 @@ public:
 	}
 	virtual void Initialize(bool load_builtin) = 0;
 	virtual void Initialize(optional_ptr<ClientContext> context, bool load_builtin);
+	virtual void FinalizeLoad(optional_ptr<ClientContext> context);
 
 	bool IsSystemCatalog() const;
 	bool IsTemporaryCatalog() const;

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -35,7 +35,7 @@ private:
 	static string WriteOptionallyQuoted(const string &input);
 };
 
-enum class CatalogSetPathType { SET_SCHEMA, SET_SCHEMAS };
+enum class CatalogSetPathType { SET_SCHEMA, SET_SCHEMAS, SET_DIRECTLY };
 
 //! The schema search path, in order by which entries are searched if no schema entry is provided
 class CatalogSearchPath {

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -64,6 +64,7 @@ public:
 
 	//! Initializes the catalog and storage of the attached database.
 	void Initialize(optional_ptr<ClientContext> context = nullptr, StorageOptions options = StorageOptions());
+	void FinalizeLoad(optional_ptr<ClientContext> context);
 	void Close();
 
 	Catalog &ParentCatalog() override;

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -43,6 +43,8 @@ public:
 
 	//! Initializes the system catalog of the attached SYSTEM_DATABASE.
 	void InitializeSystemCatalog();
+	//! Finalize starting up the system
+	void FinalizeStartup();
 	//! Get an attached database by its name
 	optional_ptr<AttachedDatabase> GetDatabase(ClientContext &context, const string &name);
 	//! Attach a new database

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -185,6 +185,10 @@ void AttachedDatabase::Initialize(optional_ptr<ClientContext> context, StorageOp
 	}
 }
 
+void AttachedDatabase::FinalizeLoad(optional_ptr<ClientContext> context) {
+	catalog->FinalizeLoad(context);
+}
+
 StorageManager &AttachedDatabase::GetStorageManager() {
 	if (!storage) {
 		throw InternalException("Internal system catalog does not have storage");

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -345,6 +345,7 @@ DuckDB::DuckDB(const char *path, DBConfig *new_config) : instance(make_shared_pt
 	if (instance->config.options.load_extensions) {
 		ExtensionHelper::LoadAllExtensions(*this);
 	}
+	instance->db_manager->FinalizeStartup();
 }
 
 DuckDB::DuckDB(const string &path, DBConfig *config) : DuckDB(path.c_str(), config) {

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -29,6 +29,13 @@ void DatabaseManager::InitializeSystemCatalog() {
 	system->Initialize();
 }
 
+void DatabaseManager::FinalizeStartup() {
+	auto databases = GetDatabases();
+	for (auto &db : databases) {
+		db.get().FinalizeLoad(nullptr);
+	}
+}
+
 optional_ptr<AttachedDatabase> DatabaseManager::GetDatabase(ClientContext &context, const string &name) {
 	if (StringUtil::Lower(name) == TEMP_CATALOG) {
 		return context.client_data->temporary_objects.get();


### PR DESCRIPTION
This is necessary to support the `duckdb ducklake:...` syntax, since attaching DuckLake runs a bunch of queries that rely on the database to be mostly instantiated to run successfully (i.e. it requires amongst others `core_functions` to be loaded). This callback is called after this has finished. 

In addition, we allow setting search paths directly without looking up whether or not they are valid - which is also useful when running queries *prior* to attaching a database you want to refer to.