### PR TITLE
Add `GenericExecutor::Execute*WithNulls`

### DIFF
--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -37,11 +37,11 @@ struct PrimitiveType {
 
 	static bool ConstructType(STRUCT_STATE &state, idx_t i, PrimitiveType<INPUT_TYPE> &result) {
 		auto &vdata = state.main_data;
+		auto idx = vdata.sel->get_index(i);
 		if (!vdata.validity.RowIsValid(idx)) {
 			result.is_null = true;
 			return false;
 		}
-		auto idx = vdata.sel->get_index(i);
 		auto ptr = UnifiedVectorFormat::GetData<INPUT_TYPE>(vdata);
 		result.val = ptr[idx];
 		return true;

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -35,16 +35,18 @@ struct PrimitiveType {
 
 	using STRUCT_STATE = PrimitiveTypeState;
 
-	static bool ConstructType(STRUCT_STATE &state, idx_t i, PrimitiveType<INPUT_TYPE> &result) {
+	static PrimitiveType<INPUT_TYPE> ConstructType(STRUCT_STATE &state, idx_t i) {
 		auto &vdata = state.main_data;
 		auto idx = vdata.sel->get_index(i);
+		PrimitiveType<INPUT_TYPE> result;
 		if (!vdata.validity.RowIsValid(idx)) {
 			result.is_null = true;
-			return false;
+			return result;
 		}
 		auto ptr = UnifiedVectorFormat::GetData<INPUT_TYPE>(vdata);
 		result.val = ptr[idx];
-		return true;
+		result.is_null = false;
+		return result;
 	}
 
 	static void AssignResult(Vector &result, idx_t i, PrimitiveType<INPUT_TYPE> value) {
@@ -79,16 +81,18 @@ struct StructTypeUnary {
 
 	using STRUCT_STATE = StructTypeState<1>;
 
-	static bool ConstructType(STRUCT_STATE &state, idx_t i, StructTypeUnary<A_TYPE> &result) {
+	static StructTypeUnary<A_TYPE> ConstructType(STRUCT_STATE &state, idx_t i) {
 		auto &a_data = state.child_data[0];
 		auto a_idx = a_data.sel->get_index(i);
+		StructTypeUnary<A_TYPE> result;
 		if (!a_data.validity.RowIsValid(a_idx)) {
 			result.is_null = true;
-			return false;
+			return result;
 		}
 		auto a_ptr = UnifiedVectorFormat::GetData<A_TYPE>(a_data);
 		result.a_val = a_ptr[a_idx];
-		return true;
+		result.is_null = false;
+		return result;
 	}
 
 	static void AssignResult(Vector &result, idx_t i, StructTypeUnary<A_TYPE> value) {
@@ -110,21 +114,23 @@ struct StructTypeBinary {
 
 	using STRUCT_STATE = StructTypeState<2>;
 
-	static bool ConstructType(STRUCT_STATE &state, idx_t i, StructTypeBinary<A_TYPE, B_TYPE> &result) {
+	static StructTypeBinary<A_TYPE, B_TYPE> ConstructType(STRUCT_STATE &state, idx_t i) {
 		auto &a_data = state.child_data[0];
 		auto &b_data = state.child_data[1];
 
 		auto a_idx = a_data.sel->get_index(i);
 		auto b_idx = b_data.sel->get_index(i);
+		StructTypeBinary<A_TYPE, B_TYPE> result;
 		if (!a_data.validity.RowIsValid(a_idx) || !b_data.validity.RowIsValid(b_idx)) {
 			result.is_null = true;
-			return false;
+			return result;
 		}
 		auto a_ptr = UnifiedVectorFormat::GetData<A_TYPE>(a_data);
 		auto b_ptr = UnifiedVectorFormat::GetData<B_TYPE>(b_data);
 		result.a_val = a_ptr[a_idx];
 		result.b_val = b_ptr[b_idx];
-		return true;
+		result.is_null = false;
+		return result;
 	}
 
 	static void AssignResult(Vector &result, idx_t i, StructTypeBinary<A_TYPE, B_TYPE> value) {
@@ -150,7 +156,7 @@ struct StructTypeTernary {
 
 	using STRUCT_STATE = StructTypeState<3>;
 
-	static bool ConstructType(STRUCT_STATE &state, idx_t i, StructTypeTernary<A_TYPE, B_TYPE, C_TYPE> &result) {
+	static StructTypeTernary<A_TYPE, B_TYPE, C_TYPE> ConstructType(STRUCT_STATE &state, idx_t i) {
 		auto &a_data = state.child_data[0];
 		auto &b_data = state.child_data[1];
 		auto &c_data = state.child_data[2];
@@ -158,10 +164,11 @@ struct StructTypeTernary {
 		auto a_idx = a_data.sel->get_index(i);
 		auto b_idx = b_data.sel->get_index(i);
 		auto c_idx = c_data.sel->get_index(i);
+		StructTypeTernary<A_TYPE, B_TYPE, C_TYPE> result;
 		if (!a_data.validity.RowIsValid(a_idx) || !b_data.validity.RowIsValid(b_idx) ||
 		    !c_data.validity.RowIsValid(c_idx)) {
 			result.is_null = true;
-			return false;
+			return result;
 		}
 		auto a_ptr = UnifiedVectorFormat::GetData<A_TYPE>(a_data);
 		auto b_ptr = UnifiedVectorFormat::GetData<B_TYPE>(b_data);
@@ -169,7 +176,8 @@ struct StructTypeTernary {
 		result.a_val = a_ptr[a_idx];
 		result.b_val = b_ptr[b_idx];
 		result.c_val = c_ptr[c_idx];
-		return true;
+		result.is_null = false;
+		return result;
 	}
 
 	static void AssignResult(Vector &result, idx_t i, StructTypeTernary<A_TYPE, B_TYPE, C_TYPE> value) {
@@ -199,8 +207,7 @@ struct StructTypeQuaternary {
 
 	using STRUCT_STATE = StructTypeState<4>;
 
-	static bool ConstructType(STRUCT_STATE &state, idx_t i,
-	                          StructTypeQuaternary<A_TYPE, B_TYPE, C_TYPE, D_TYPE> &result) {
+	static StructTypeQuaternary<A_TYPE, B_TYPE, C_TYPE, D_TYPE> ConstructType(STRUCT_STATE &state, idx_t i) {
 		auto &a_data = state.child_data[0];
 		auto &b_data = state.child_data[1];
 		auto &c_data = state.child_data[2];
@@ -210,10 +217,11 @@ struct StructTypeQuaternary {
 		auto b_idx = b_data.sel->get_index(i);
 		auto c_idx = c_data.sel->get_index(i);
 		auto d_idx = d_data.sel->get_index(i);
+		StructTypeQuaternary<A_TYPE, B_TYPE, C_TYPE, D_TYPE> result;
 		if (!a_data.validity.RowIsValid(a_idx) || !b_data.validity.RowIsValid(b_idx) ||
 		    !c_data.validity.RowIsValid(c_idx) || !d_data.validity.RowIsValid(d_idx)) {
 			result.is_null = true;
-			return false;
+			return result;
 		}
 		auto a_ptr = UnifiedVectorFormat::GetData<A_TYPE>(a_data);
 		auto b_ptr = UnifiedVectorFormat::GetData<B_TYPE>(b_data);
@@ -223,7 +231,8 @@ struct StructTypeQuaternary {
 		result.b_val = b_ptr[b_idx];
 		result.c_val = c_ptr[c_idx];
 		result.d_val = d_ptr[d_idx];
-		return true;
+		result.is_null = false;
+		return result;
 	}
 
 	static void AssignResult(Vector &result, idx_t i, StructTypeQuaternary<A_TYPE, B_TYPE, C_TYPE, D_TYPE> value) {
@@ -255,7 +264,7 @@ struct GenericListType {
 
 	using STRUCT_STATE = PrimitiveTypeState;
 
-	static bool ConstructType(STRUCT_STATE &state, idx_t i, GenericListType<CHILD_TYPE> &result) {
+	static GenericListType<CHILD_TYPE> ConstructType(STRUCT_STATE &state, idx_t i) {
 		throw InternalException("FIXME: implement ConstructType for lists");
 	}
 
@@ -297,8 +306,8 @@ private:
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
-			A_TYPE input;
-			if (!A_TYPE::ConstructType(state, i, input)) {
+			auto input = A_TYPE::ConstructType(state, i);
+			if (input.is_null) {
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
@@ -326,9 +335,9 @@ private:
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
-			A_TYPE a_val;
-			B_TYPE b_val;
-			if (!A_TYPE::ConstructType(a_state, i, a_val) || !B_TYPE::ConstructType(b_state, i, b_val)) {
+			auto a_val = A_TYPE::ConstructType(a_state, i);
+			auto b_val = B_TYPE::ConstructType(b_state, i);
+			if (a_val.is_null || b_val.is_null) {
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
@@ -362,11 +371,10 @@ private:
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
-			A_TYPE a_val;
-			B_TYPE b_val;
-			C_TYPE c_val;
-			if (!A_TYPE::ConstructType(a_state, i, a_val) || !B_TYPE::ConstructType(b_state, i, b_val) ||
-			    !C_TYPE::ConstructType(c_state, i, c_val)) {
+			auto a_val = A_TYPE::ConstructType(a_state, i);
+			auto b_val = B_TYPE::ConstructType(b_state, i);
+			auto c_val = C_TYPE::ConstructType(c_state, i);
+			if (a_val.is_null || b_val.is_null || c_val.is_null) {
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
@@ -404,12 +412,11 @@ private:
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
-			A_TYPE a_val;
-			B_TYPE b_val;
-			C_TYPE c_val;
-			D_TYPE d_val;
-			if (!A_TYPE::ConstructType(a_state, i, a_val) || !B_TYPE::ConstructType(b_state, i, b_val) ||
-			    !C_TYPE::ConstructType(c_state, i, c_val) || !D_TYPE::ConstructType(d_state, i, d_val)) {
+			auto a_val = A_TYPE::ConstructType(a_state, i);
+			auto b_val = B_TYPE::ConstructType(b_state, i);
+			auto c_val = C_TYPE::ConstructType(c_state, i);
+			auto d_val = D_TYPE::ConstructType(d_state, i);
+			if (a_val.is_null || b_val.is_null || c_val.is_null || d_val.is_null) {
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -73,6 +73,13 @@ struct PrimitiveType : ExecutorBaseType {
 	INPUT_TYPE val;
 
 	using STRUCT_STATE = PrimitiveTypeState;
+	
+	// Implicit conversion to INPUT_TYPE for transparent access
+	operator INPUT_TYPE() const { return val; }
+	
+	// Pointer accessor for when addresses are needed
+	INPUT_TYPE* ptr() { return &val; }
+	const INPUT_TYPE* ptr() const { return &val; }
 
 	bool ContainsNull() {
 		return is_null;

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -94,7 +94,7 @@ struct StructTypeUnary {
 		auto a_idx = a_data.sel->get_index(i);
 		StructTypeUnary<A_TYPE> result;
 		result.is_null = !a_data.validity.RowIsValid(a_idx);
-		if (!result.is_null) {
+		if (!result.ContainsNull()) {
 			auto a_ptr = UnifiedVectorFormat::GetData<A_TYPE>(a_data);
 			result.a_val = a_ptr[a_idx];
 		}
@@ -104,7 +104,7 @@ struct StructTypeUnary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeUnary<A_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		if (value.is_null) {
+		if (value.ContainsNull()) {
 			FlatVector::SetNull(*entries[0], i, true);
 		}
 		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
@@ -134,12 +134,10 @@ struct StructTypeBinary {
 		StructTypeBinary<A_TYPE, B_TYPE> result;
 		result.a_is_null = !a_data.validity.RowIsValid(a_idx);
 		result.b_is_null = !b_data.validity.RowIsValid(b_idx);
-		if (!result.a_is_null) {
+		if (!result.ContainsNull()) {
 			auto a_ptr = UnifiedVectorFormat::GetData<A_TYPE>(a_data);
-			result.a_val = a_ptr[a_idx];
-		}
-		if (!result.b_is_null) {
 			auto b_ptr = UnifiedVectorFormat::GetData<B_TYPE>(b_data);
+			result.a_val = a_ptr[a_idx];
 			result.b_val = b_ptr[b_idx];
 		}
 		return result;
@@ -148,10 +146,8 @@ struct StructTypeBinary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeBinary<A_TYPE, B_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		if (value.a_is_null) {
+		if (value.ContainsNull()) {
 			FlatVector::SetNull(*entries[0], i, true);
-		}
-		if (value.b_is_null) {
 			FlatVector::SetNull(*entries[1], i, true);
 		}
 		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
@@ -188,16 +184,12 @@ struct StructTypeTernary {
 		result.a_is_null = !a_data.validity.RowIsValid(a_idx);
 		result.b_is_null = !b_data.validity.RowIsValid(b_idx);
 		result.c_is_null = !c_data.validity.RowIsValid(c_idx);
-		if (!result.a_is_null) {
+		if (!result.ContainsNull()) {
 			auto a_ptr = UnifiedVectorFormat::GetData<A_TYPE>(a_data);
-			result.a_val = a_ptr[a_idx];
-		}
-		if (!result.b_is_null) {
 			auto b_ptr = UnifiedVectorFormat::GetData<B_TYPE>(b_data);
-			result.b_val = b_ptr[b_idx];
-		}
-		if (!result.c_is_null) {
 			auto c_ptr = UnifiedVectorFormat::GetData<C_TYPE>(c_data);
+			result.a_val = a_ptr[a_idx];
+			result.b_val = b_ptr[b_idx];
 			result.c_val = c_ptr[c_idx];
 		}
 		return result;
@@ -206,13 +198,9 @@ struct StructTypeTernary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeTernary<A_TYPE, B_TYPE, C_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		if (value.a_is_null) {
+		if (value.ContainsNull()) {
 			FlatVector::SetNull(*entries[0], i, true);
-		}
-		if (value.b_is_null) {
 			FlatVector::SetNull(*entries[1], i, true);
-		}
-		if (value.c_is_null) {
 			FlatVector::SetNull(*entries[2], i, true);
 		}
 		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
@@ -256,20 +244,14 @@ struct StructTypeQuaternary {
 		result.b_is_null = !b_data.validity.RowIsValid(b_idx);
 		result.c_is_null = !c_data.validity.RowIsValid(c_idx);
 		result.d_is_null = !d_data.validity.RowIsValid(d_idx);
-		if (!result.a_is_null) {
+		if (!result.ContainsNull()) {
 			auto a_ptr = UnifiedVectorFormat::GetData<A_TYPE>(a_data);
-			result.a_val = a_ptr[a_idx];
-		}
-		if (!result.b_is_null) {
 			auto b_ptr = UnifiedVectorFormat::GetData<B_TYPE>(b_data);
-			result.b_val = b_ptr[b_idx];
-		}
-		if (!result.c_is_null) {
 			auto c_ptr = UnifiedVectorFormat::GetData<C_TYPE>(c_data);
-			result.c_val = c_ptr[c_idx];
-		}
-		if (!result.d_is_null) {
 			auto d_ptr = UnifiedVectorFormat::GetData<D_TYPE>(d_data);
+			result.a_val = a_ptr[a_idx];
+			result.b_val = b_ptr[b_idx];
+			result.c_val = c_ptr[c_idx];
 			result.d_val = d_ptr[d_idx];
 		}
 		return result;
@@ -278,16 +260,10 @@ struct StructTypeQuaternary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeQuaternary<A_TYPE, B_TYPE, C_TYPE, D_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		if (value.a_is_null) {
+		if (value.ContainsNull()) {
 			FlatVector::SetNull(*entries[0], i, true);
-		}
-		if (value.b_is_null) {
 			FlatVector::SetNull(*entries[1], i, true);
-		}
-		if (value.c_is_null) {
 			FlatVector::SetNull(*entries[2], i, true);
-		}
-		if (value.d_is_null) {
 			FlatVector::SetNull(*entries[3], i, true);
 		}
 
@@ -326,7 +302,7 @@ struct GenericListType {
 		auto list_size = value.values.size();
 		ListVector::Reserve(result, current_size + list_size);
 
-		if (value.is_null) {
+		if (value.ContainsNull()) {
 			FlatVector::SetNull(result, i, true);
 		}
 		auto list_entries = FlatVector::GetData<list_entry_t>(result);

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
 #include <functional>
+#include <type_traits>
 
 namespace duckdb {
 
@@ -84,6 +85,8 @@ struct StructTypeState {
 
 template <class A_TYPE>
 struct StructTypeUnary : ExecutorBaseType {
+	static_assert(std::is_base_of<ExecutorBaseType, A_TYPE>::value, "A_TYPE must inherit from ExecutorBaseType");
+
 	A_TYPE a_val;
 
 	StructTypeUnary() = default;
@@ -122,6 +125,9 @@ struct StructTypeUnary : ExecutorBaseType {
 
 template <class A_TYPE, class B_TYPE>
 struct StructTypeBinary : ExecutorBaseType {
+	static_assert(std::is_base_of<ExecutorBaseType, A_TYPE>::value, "A_TYPE must inherit from ExecutorBaseType");
+	static_assert(std::is_base_of<ExecutorBaseType, B_TYPE>::value, "B_TYPE must inherit from ExecutorBaseType");
+
 	A_TYPE a_val;
 	B_TYPE b_val;
 
@@ -169,6 +175,10 @@ struct StructTypeBinary : ExecutorBaseType {
 
 template <class A_TYPE, class B_TYPE, class C_TYPE>
 struct StructTypeTernary : ExecutorBaseType {
+	static_assert(std::is_base_of<ExecutorBaseType, A_TYPE>::value, "A_TYPE must inherit from ExecutorBaseType");
+	static_assert(std::is_base_of<ExecutorBaseType, B_TYPE>::value, "B_TYPE must inherit from ExecutorBaseType");
+	static_assert(std::is_base_of<ExecutorBaseType, C_TYPE>::value, "C_TYPE must inherit from ExecutorBaseType");
+
 	A_TYPE a_val;
 	B_TYPE b_val;
 	C_TYPE c_val;
@@ -225,6 +235,11 @@ struct StructTypeTernary : ExecutorBaseType {
 
 template <class A_TYPE, class B_TYPE, class C_TYPE, class D_TYPE>
 struct StructTypeQuaternary : ExecutorBaseType {
+	static_assert(std::is_base_of<ExecutorBaseType, A_TYPE>::value, "A_TYPE must inherit from ExecutorBaseType");
+	static_assert(std::is_base_of<ExecutorBaseType, B_TYPE>::value, "B_TYPE must inherit from ExecutorBaseType");
+	static_assert(std::is_base_of<ExecutorBaseType, C_TYPE>::value, "C_TYPE must inherit from ExecutorBaseType");
+	static_assert(std::is_base_of<ExecutorBaseType, D_TYPE>::value, "D_TYPE must inherit from ExecutorBaseType");
+
 	A_TYPE a_val;
 	B_TYPE b_val;
 	C_TYPE c_val;
@@ -291,6 +306,9 @@ struct StructTypeQuaternary : ExecutorBaseType {
 
 template <class CHILD_TYPE>
 struct GenericListType : ExecutorBaseType {
+	static_assert(std::is_base_of<ExecutorBaseType, CHILD_TYPE>::value,
+	              "CHILD_TYPE must inherit from ExecutorBaseType");
+
 	vector<CHILD_TYPE> values;
 
 	GenericListType() = default;

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -45,7 +45,9 @@ struct PrimitiveType {
 	}
 
 	static void AssignResult(Vector &result, idx_t i, PrimitiveType<INPUT_TYPE> value) {
-		FlatVector::SetNull(result, i, value.is_null);
+		if (value.is_null) {
+			FlatVector::SetNull(result, i, true);
+		}
 		auto result_data = FlatVector::GetData<INPUT_TYPE>(result);
 		result_data[i] = value.val;
 	}
@@ -89,7 +91,9 @@ struct StructTypeUnary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeUnary<A_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		FlatVector::SetNull(*entries[0], i, value.is_null);
+		if (value.is_null) {
+			FlatVector::SetNull(*entries[0], i, true);
+		}
 		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
 		a_data[i] = value.a_val;
 	}
@@ -123,8 +127,10 @@ struct StructTypeBinary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeBinary<A_TYPE, B_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		FlatVector::SetNull(*entries[0], i, value.is_null);
-		FlatVector::SetNull(*entries[1], i, value.is_null);
+		if (value.is_null) {
+			FlatVector::SetNull(*entries[0], i, true);
+			FlatVector::SetNull(*entries[1], i, true);
+		}
 		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
 		auto b_data = FlatVector::GetData<B_TYPE>(*entries[1]);
 		a_data[i] = value.a_val;
@@ -167,9 +173,11 @@ struct StructTypeTernary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeTernary<A_TYPE, B_TYPE, C_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		FlatVector::SetNull(*entries[0], i, value.is_null);
-		FlatVector::SetNull(*entries[1], i, value.is_null);
-		FlatVector::SetNull(*entries[2], i, value.is_null);
+		if (value.is_null) {
+			FlatVector::SetNull(*entries[0], i, true);
+			FlatVector::SetNull(*entries[1], i, true);
+			FlatVector::SetNull(*entries[2], i, true);
+		}
 		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
 		auto b_data = FlatVector::GetData<B_TYPE>(*entries[1]);
 		auto c_data = FlatVector::GetData<C_TYPE>(*entries[2]);
@@ -219,10 +227,12 @@ struct StructTypeQuaternary {
 	static void AssignResult(Vector &result, idx_t i, StructTypeQuaternary<A_TYPE, B_TYPE, C_TYPE, D_TYPE> value) {
 		auto &entries = StructVector::GetEntries(result);
 
-		FlatVector::SetNull(*entries[0], i, value.is_null);
-		FlatVector::SetNull(*entries[1], i, value.is_null);
-		FlatVector::SetNull(*entries[2], i, value.is_null);
-		FlatVector::SetNull(*entries[3], i, value.is_null);
+		if (value.is_null) {
+			FlatVector::SetNull(*entries[0], i, true);
+			FlatVector::SetNull(*entries[1], i, true);
+			FlatVector::SetNull(*entries[2], i, true);
+			FlatVector::SetNull(*entries[3], i, true);
+		}
 
 		auto a_data = FlatVector::GetData<A_TYPE>(*entries[0]);
 		auto b_data = FlatVector::GetData<B_TYPE>(*entries[1]);
@@ -255,7 +265,9 @@ struct GenericListType {
 		auto list_size = value.values.size();
 		ListVector::Reserve(result, current_size + list_size);
 
-		FlatVector::SetNull(result, i, value.is_null);
+		if (value.is_null) {
+			FlatVector::SetNull(result, i, true);
+		}
 		auto list_entries = FlatVector::GetData<list_entry_t>(result);
 		list_entries[i].offset = current_size;
 		list_entries[i].length = list_size;

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -351,11 +351,6 @@ private:
 		state.PrepareVector(input, count);
 
 		for (idx_t i = 0; i < (constant ? 1 : count); i++) {
-			auto idx = state.main_data.sel->get_index(i);
-			if (!state.main_data.validity.RowIsValid(idx)) {
-				FlatVector::SetNull(result, i, true);
-				continue;
-			}
 			auto input = A_TYPE::ConstructType(state, i);
 			if (input.ContainsNull()) {
 				FlatVector::SetNull(result, i, true);
@@ -379,15 +374,9 @@ private:
 		b_state.PrepareVector(b, count);
 
 		for (idx_t i = 0; i < (constant ? 1 : count); i++) {
-			auto a_idx = a_state.main_data.sel->get_index(i);
-			auto b_idx = b_state.main_data.sel->get_index(i);
-			if (!a_state.main_data.validity.RowIsValid(a_idx) || !b_state.main_data.validity.RowIsValid(b_idx)) {
-				FlatVector::SetNull(result, i, true);
-				continue;
-			}
 			auto a_val = A_TYPE::ConstructType(a_state, i);
 			auto b_val = B_TYPE::ConstructType(b_state, i);
-			if (a_val.ContaisNull() || b_val.ContainsNull()) {
+			if (a_val.ContainsNull() || b_val.ContainsNull()) {
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
@@ -413,14 +402,6 @@ private:
 		c_state.PrepareVector(c, count);
 
 		for (idx_t i = 0; i < (constant ? 1 : count); i++) {
-			auto a_idx = a_state.main_data.sel->get_index(i);
-			auto b_idx = b_state.main_data.sel->get_index(i);
-			auto c_idx = c_state.main_data.sel->get_index(i);
-			if (!a_state.main_data.validity.RowIsValid(a_idx) || !b_state.main_data.validity.RowIsValid(b_idx) ||
-			    !c_state.main_data.validity.RowIsValid(c_idx)) {
-				FlatVector::SetNull(result, i, true);
-				continue;
-			}
 			auto a_val = A_TYPE::ConstructType(a_state, i);
 			auto b_val = B_TYPE::ConstructType(b_state, i);
 			auto c_val = C_TYPE::ConstructType(c_state, i);
@@ -453,15 +434,6 @@ private:
 		d_state.PrepareVector(d, count);
 
 		for (idx_t i = 0; i < (constant ? 1 : count); i++) {
-			auto a_idx = a_state.main_data.sel->get_index(i);
-			auto b_idx = b_state.main_data.sel->get_index(i);
-			auto c_idx = c_state.main_data.sel->get_index(i);
-			auto d_idx = d_state.main_data.sel->get_index(i);
-			if (!a_state.main_data.validity.RowIsValid(a_idx) || !b_state.main_data.validity.RowIsValid(b_idx) ||
-			    !c_state.main_data.validity.RowIsValid(c_idx) || !d_state.main_data.validity.RowIsValid(d_idx)) {
-				FlatVector::SetNull(result, i, true);
-				continue;
-			}
 			auto a_val = A_TYPE::ConstructType(a_state, i);
 			auto b_val = B_TYPE::ConstructType(b_state, i);
 			auto c_val = C_TYPE::ConstructType(c_state, i);

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -86,6 +86,10 @@ template <class A_TYPE>
 struct StructTypeUnary : ExecutorBaseType {
 	A_TYPE a_val;
 
+	StructTypeUnary() = default;
+	StructTypeUnary(A_TYPE a) : a_val(a) {
+	}
+
 	using STRUCT_STATE = StructTypeState<1>;
 
 	bool ContainsNull() {
@@ -120,6 +124,10 @@ template <class A_TYPE, class B_TYPE>
 struct StructTypeBinary : ExecutorBaseType {
 	A_TYPE a_val;
 	B_TYPE b_val;
+
+	StructTypeBinary() = default;
+	StructTypeBinary(A_TYPE a, B_TYPE b) : a_val(a), b_val(b) {
+	}
 
 	using STRUCT_STATE = StructTypeState<2>;
 
@@ -164,6 +172,10 @@ struct StructTypeTernary : ExecutorBaseType {
 	A_TYPE a_val;
 	B_TYPE b_val;
 	C_TYPE c_val;
+
+	StructTypeTernary() = default;
+	StructTypeTernary(A_TYPE a, B_TYPE b, C_TYPE c) : a_val(a), b_val(b), c_val(c) {
+	}
 
 	using STRUCT_STATE = StructTypeState<3>;
 
@@ -217,6 +229,10 @@ struct StructTypeQuaternary : ExecutorBaseType {
 	B_TYPE b_val;
 	C_TYPE c_val;
 	D_TYPE d_val;
+
+	StructTypeQuaternary() = default;
+	StructTypeQuaternary(A_TYPE a, B_TYPE b, C_TYPE c, D_TYPE d) : a_val(a), b_val(b), c_val(c), d_val(d) {
+	}
 
 	using STRUCT_STATE = StructTypeState<4>;
 
@@ -276,6 +292,10 @@ struct StructTypeQuaternary : ExecutorBaseType {
 template <class CHILD_TYPE>
 struct GenericListType : ExecutorBaseType {
 	vector<CHILD_TYPE> values;
+
+	GenericListType() = default;
+	GenericListType(vector<CHILD_TYPE> values) : values(values) {
+	}
 
 	using STRUCT_STATE = PrimitiveTypeState;
 

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -357,7 +357,7 @@ private:
 				continue;
 			}
 			auto input = A_TYPE::ConstructType(state, i);
-			if (input.is_null) {
+			if (input.ContainsNull()) {
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
@@ -387,7 +387,7 @@ private:
 			}
 			auto a_val = A_TYPE::ConstructType(a_state, i);
 			auto b_val = B_TYPE::ConstructType(b_state, i);
-			if (a_val.is_null || b_val.is_null) {
+			if (a_val.ContaisNull() || b_val.ContainsNull()) {
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
@@ -424,7 +424,7 @@ private:
 			auto a_val = A_TYPE::ConstructType(a_state, i);
 			auto b_val = B_TYPE::ConstructType(b_state, i);
 			auto c_val = C_TYPE::ConstructType(c_state, i);
-			if (a_val.is_null || b_val.is_null || c_val.is_null) {
+			if (a_val.ContainsNull() || b_val.ContainsNull() || c_val.ContainsNull()) {
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
@@ -466,7 +466,7 @@ private:
 			auto b_val = B_TYPE::ConstructType(b_state, i);
 			auto c_val = C_TYPE::ConstructType(c_state, i);
 			auto d_val = D_TYPE::ConstructType(d_state, i);
-			if (a_val.is_null || b_val.is_null || c_val.is_null || d_val.is_null) {
+			if (a_val.ContainsNull() || b_val.ContainsNull() || c_val.ContainsNull() || d_val.ContainsNull()) {
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -242,15 +242,31 @@ struct GenericListType {
 	}
 };
 
+struct GenericLambdaWrapper {
+	template <class FUNC, class RESULT_TYPE, class... ARGS>
+	static inline RESULT_TYPE Operation(FUNC fun, ValidityMask &mask, idx_t idx, ARGS... args) {
+		return fun(args...);
+	}
+};
+
+struct GenericLambdaWrapperWithNulls {
+	template <class FUNC, class RESULT_TYPE, class... ARGS>
+	static inline RESULT_TYPE Operation(FUNC fun, ValidityMask &mask, idx_t idx, ARGS... args) {
+		return fun(args..., mask, idx);
+	}
+};
+
 //! The GenericExecutor can handle struct types in addition to primitive types
 struct GenericExecutor {
 private:
-	template <class A_TYPE, class RESULT_TYPE, class FUNC>
+	template <class A_TYPE, class RESULT_TYPE, class OPWRAPPER, class FUNC>
 	static void ExecuteUnaryInternal(Vector &input, Vector &result, idx_t count, FUNC &fun) {
 		auto constant = input.GetVectorType() == VectorType::CONSTANT_VECTOR;
 
 		typename A_TYPE::STRUCT_STATE state;
 		state.PrepareVector(input, count);
+
+		auto &result_validity = FlatVector::Validity(result);
 
 		for (idx_t i = 0; i < (constant ? 1 : count); i++) {
 			auto idx = state.main_data.sel->get_index(i);
@@ -263,14 +279,14 @@ private:
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
-			RESULT_TYPE::AssignResult(result, i, fun(input));
+			RESULT_TYPE::AssignResult(result, i, OPWRAPPER::template Operation<FUNC, RESULT_TYPE>(fun, result_validity, i, input));
 		}
 		if (constant) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		}
 	}
 
-	template <class A_TYPE, class B_TYPE, class RESULT_TYPE, class FUNC>
+	template <class A_TYPE, class B_TYPE, class RESULT_TYPE, class OPWRAPPER, class FUNC>
 	static void ExecuteBinaryInternal(Vector &a, Vector &b, Vector &result, idx_t count, FUNC &fun) {
 		auto constant =
 		    a.GetVectorType() == VectorType::CONSTANT_VECTOR && b.GetVectorType() == VectorType::CONSTANT_VECTOR;
@@ -279,6 +295,8 @@ private:
 		typename B_TYPE::STRUCT_STATE b_state;
 		a_state.PrepareVector(a, count);
 		b_state.PrepareVector(b, count);
+
+		auto &result_validity = FlatVector::Validity(result);
 
 		for (idx_t i = 0; i < (constant ? 1 : count); i++) {
 			auto a_idx = a_state.main_data.sel->get_index(i);
@@ -293,14 +311,14 @@ private:
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
-			RESULT_TYPE::AssignResult(result, i, fun(a_val, b_val));
+			RESULT_TYPE::AssignResult(result, i, OPWRAPPER::template Operation<FUNC, RESULT_TYPE>(fun, result_validity, i, a_val, b_val));
 		}
 		if (constant) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		}
 	}
 
-	template <class A_TYPE, class B_TYPE, class C_TYPE, class RESULT_TYPE, class FUNC>
+	template <class A_TYPE, class B_TYPE, class C_TYPE, class RESULT_TYPE, class OPWRAPPER, class FUNC>
 	static void ExecuteTernaryInternal(Vector &a, Vector &b, Vector &c, Vector &result, idx_t count, FUNC &fun) {
 		auto constant = a.GetVectorType() == VectorType::CONSTANT_VECTOR &&
 		                b.GetVectorType() == VectorType::CONSTANT_VECTOR &&
@@ -313,6 +331,8 @@ private:
 		a_state.PrepareVector(a, count);
 		b_state.PrepareVector(b, count);
 		c_state.PrepareVector(c, count);
+
+		auto &result_validity = FlatVector::Validity(result);
 
 		for (idx_t i = 0; i < (constant ? 1 : count); i++) {
 			auto a_idx = a_state.main_data.sel->get_index(i);
@@ -331,14 +351,14 @@ private:
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
-			RESULT_TYPE::AssignResult(result, i, fun(a_val, b_val, c_val));
+			RESULT_TYPE::AssignResult(result, i, OPWRAPPER::template Operation<FUNC, RESULT_TYPE>(fun, result_validity, i, a_val, b_val, c_val));
 		}
 		if (constant) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		}
 	}
 
-	template <class A_TYPE, class B_TYPE, class C_TYPE, class D_TYPE, class RESULT_TYPE, class FUNC>
+	template <class A_TYPE, class B_TYPE, class C_TYPE, class D_TYPE, class RESULT_TYPE, class OPWRAPPER, class FUNC>
 	static void ExecuteQuaternaryInternal(Vector &a, Vector &b, Vector &c, Vector &d, Vector &result, idx_t count,
 	                                      FUNC &fun) {
 		auto constant =
@@ -354,6 +374,8 @@ private:
 		b_state.PrepareVector(b, count);
 		c_state.PrepareVector(c, count);
 		d_state.PrepareVector(d, count);
+
+		auto &result_validity = FlatVector::Validity(result);
 
 		for (idx_t i = 0; i < (constant ? 1 : count); i++) {
 			auto a_idx = a_state.main_data.sel->get_index(i);
@@ -374,31 +396,51 @@ private:
 				FlatVector::SetNull(result, i, true);
 				continue;
 			}
-			RESULT_TYPE::AssignResult(result, i, fun(a_val, b_val, c_val, d_val));
+			RESULT_TYPE::AssignResult(result, i, OPWRAPPER::template Operation<FUNC, RESULT_TYPE>(fun, result_validity, i, a_val, b_val, c_val, d_val));
 		}
 		if (constant) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		}
 	}
 
+
 public:
 	template <class A_TYPE, class RESULT_TYPE, class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
 	static void ExecuteUnary(Vector &input, Vector &result, idx_t count, FUNC fun) {
-		ExecuteUnaryInternal<A_TYPE, RESULT_TYPE, FUNC>(input, result, count, fun);
+		ExecuteUnaryInternal<A_TYPE, RESULT_TYPE, GenericLambdaWrapper, FUNC>(input, result, count, fun);
 	}
-	template <class A_TYPE, class B_TYPE, class RESULT_TYPE, class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
+	template <class A_TYPE, class B_TYPE, class RESULT_TYPE, class FUNC = std::function<RESULT_TYPE(A_TYPE, B_TYPE)>>
 	static void ExecuteBinary(Vector &a, Vector &b, Vector &result, idx_t count, FUNC fun) {
-		ExecuteBinaryInternal<A_TYPE, B_TYPE, RESULT_TYPE, FUNC>(a, b, result, count, fun);
+		ExecuteBinaryInternal<A_TYPE, B_TYPE, RESULT_TYPE, GenericLambdaWrapper, FUNC>(a, b, result, count, fun);
 	}
 	template <class A_TYPE, class B_TYPE, class C_TYPE, class RESULT_TYPE,
-	          class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
+	          class FUNC = std::function<RESULT_TYPE(A_TYPE, B_TYPE, C_TYPE)>>
 	static void ExecuteTernary(Vector &a, Vector &b, Vector &c, Vector &result, idx_t count, FUNC fun) {
-		ExecuteTernaryInternal<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC>(a, b, c, result, count, fun);
+		ExecuteTernaryInternal<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, GenericLambdaWrapper, FUNC>(a, b, c, result, count, fun);
 	}
 	template <class A_TYPE, class B_TYPE, class C_TYPE, class D_TYPE, class RESULT_TYPE,
-	          class FUNC = std::function<RESULT_TYPE(A_TYPE)>>
+	          class FUNC = std::function<RESULT_TYPE(A_TYPE, B_TYPE, C_TYPE, D_TYPE)>>
 	static void ExecuteQuaternary(Vector &a, Vector &b, Vector &c, Vector &d, Vector &result, idx_t count, FUNC fun) {
-		ExecuteQuaternaryInternal<A_TYPE, B_TYPE, C_TYPE, D_TYPE, RESULT_TYPE, FUNC>(a, b, c, d, result, count, fun);
+		ExecuteQuaternaryInternal<A_TYPE, B_TYPE, C_TYPE, D_TYPE, RESULT_TYPE, GenericLambdaWrapper, FUNC>(a, b, c, d, result, count, fun);
+	}
+
+	template <class A_TYPE, class RESULT_TYPE, class FUNC = std::function<RESULT_TYPE(A_TYPE, ValidityMask &, idx_t)>>
+	static void ExecuteUnaryWithNulls(Vector &input, Vector &result, idx_t count, FUNC fun) {
+		ExecuteUnaryInternal<A_TYPE, RESULT_TYPE, GenericLambdaWrapperWithNulls, FUNC>(input, result, count, fun);
+	}
+	template <class A_TYPE, class B_TYPE, class RESULT_TYPE, class FUNC = std::function<RESULT_TYPE(A_TYPE, B_TYPE, ValidityMask &, idx_t)>>
+	static void ExecuteBinaryWithNulls(Vector &a, Vector &b, Vector &result, idx_t count, FUNC fun) {
+		ExecuteBinaryInternal<A_TYPE, B_TYPE, RESULT_TYPE, GenericLambdaWrapperWithNulls, FUNC>(a, b, result, count, fun);
+	}
+	template <class A_TYPE, class B_TYPE, class C_TYPE, class RESULT_TYPE,
+	          class FUNC = std::function<RESULT_TYPE(A_TYPE, B_TYPE, C_TYPE, ValidityMask &, idx_t)>>
+	static void ExecuteTernaryWithNulls(Vector &a, Vector &b, Vector &c, Vector &result, idx_t count, FUNC fun) {
+		ExecuteTernaryInternal<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, GenericLambdaWrapperWithNulls, FUNC>(a, b, c, result, count, fun);
+	}
+	template <class A_TYPE, class B_TYPE, class C_TYPE, class D_TYPE, class RESULT_TYPE,
+	          class FUNC = std::function<RESULT_TYPE(A_TYPE, B_TYPE, C_TYPE, D_TYPE, ValidityMask &, idx_t)>>
+	static void ExecuteQuaternaryWithNulls(Vector &a, Vector &b, Vector &c, Vector &d, Vector &result, idx_t count, FUNC fun) {
+		ExecuteQuaternaryInternal<A_TYPE, B_TYPE, C_TYPE, D_TYPE, RESULT_TYPE, GenericLambdaWrapperWithNulls, FUNC>(a, b, c, d, result, count, fun);
 	}
 };
 


### PR DESCRIPTION
Currently, `GenericExecutor` cannot return the results containing `NULL`s unlike `UnaryExecutor`, `BinaryExecutor`, and `TernaryExecutor`. I found this inconvenience when I tried to contribute to duckdb-spatial; @Maxxen kindly suggested that I could use `GenericExecutor` (https://github.com/duckdb/duckdb-spatial/pull/596#discussion_r2119022991), but I found I couldn't because of this limitation.

To improve the API, this pull request adds `WithNulls` variants to `GenericExecutor`.

Regarding testing, I don't know how to add a test about `GenericExecutor`, but I confirmed the implementation works if I use this in duckdb-spatial. Please let me know if there's an appropriate location to add some tests.

https://github.com/duckdb/duckdb-spatial/compare/v1.3.0...yutannihilation:tmp-confirm-GenericExecutor-WithNulls