### PR TITLE
Add support for `option.scheduler_process_partial` to the Executor 

### DIFF
--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -589,6 +589,11 @@ PendingExecutionResult Executor::ExecuteTask(bool dry_run) {
 		if (!HasError()) {
 			// we (partially) processed a task and no exceptions were thrown
 			// give back control to the caller
+			if (task && DBConfig::GetConfig(context).options.scheduler_process_partial) {
+				auto &token = *task->token;
+				TaskScheduler::GetScheduler(context).ScheduleTask(token, task);
+				task.reset();
+			}
 			return PendingExecutionResult::RESULT_NOT_READY;
 		}
 		execution_result = PendingExecutionResult::EXECUTION_ERROR;


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/16973 add a setting for tasks to be returned to the scheduler after partially processing them. This PRs makes the executor (which is used on application threads) respect that setting as well.