### PR TITLE
Add urllib3 dependency and improve fixture download reliability

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -399,7 +399,7 @@ jobs:
 
      - name: Install Packages
        shell: bash
-       run: python3 -m pip install pyotp requests
+       run: python3 -m pip install pyotp requests urllib3
 
      - name: Cleanup Releases
        shell: bash

--- a/tools/pythonpkg/requirements-dev.txt
+++ b/tools/pythonpkg/requirements-dev.txt
@@ -9,6 +9,7 @@ pytest-timeout
 mypy<=1.13
 psutil>=5.9.0
 requests>=2.26
+urllib3
 fsspec
 pyarrow>=8.0
 torch


### PR DESCRIPTION
- Add urllib3 to CI workflow pip installs and requirements-dev.txt
- Refactor test_h2oai_arrow.py to use robust HTTP session with retry logic
- Related to https://github.com/duckdblabs/duckdb-internal/issues/5099