### PR TITLE
Leverage `VectorType` in `ColumnDataCollection`

### DIFF
--- a/src/common/types/column/column_data_allocator.cpp
+++ b/src/common/types/column/column_data_allocator.cpp
@@ -217,8 +217,9 @@ void ColumnDataAllocator::UnswizzlePointers(ChunkManagementState &state, Vector 
 	// at least one string must be non-inlined, otherwise this function should not be called
 	D_ASSERT(i < end);
 
-	auto base_ptr = char_ptr_cast(GetDataPointer(state, block_id, offset));
-	if (strings[i].GetData() == base_ptr) {
+	const auto old_base_ptr = strings[i].GetData();
+	const auto new_base_ptr = char_ptr_cast(GetDataPointer(state, block_id, offset));
+	if (old_base_ptr == new_base_ptr) {
 		// pointers are still valid
 		return;
 	}
@@ -228,11 +229,12 @@ void ColumnDataAllocator::UnswizzlePointers(ChunkManagementState &state, Vector 
 		if (!validity.RowIsValid(i)) {
 			continue;
 		}
-		if (strings[i].IsInlined()) {
+		auto &str = strings[i];
+		if (str.IsInlined()) {
 			continue;
 		}
-		strings[i].SetPointer(base_ptr);
-		base_ptr += strings[i].GetSize();
+		const auto str_offset = str.GetPointer() - old_base_ptr;
+		str.SetPointer(new_base_ptr + str_offset);
 	}
 }
 

--- a/src/common/types/column/column_data_allocator.cpp
+++ b/src/common/types/column/column_data_allocator.cpp
@@ -195,47 +195,38 @@ data_ptr_t ColumnDataAllocator::GetDataPointer(ChunkManagementState &state, uint
 	return state.handles[block_id].Ptr() + offset;
 }
 
-void ColumnDataAllocator::UnswizzlePointers(ChunkManagementState &state, Vector &result, idx_t v_offset, uint16_t count,
-                                            uint32_t block_id, uint32_t offset) {
+void ColumnDataAllocator::UnswizzlePointers(ChunkManagementState &state, Vector &result,
+                                            SwizzleMetaData &swizzle_segment, const VectorMetaData &string_heap_segment,
+                                            const idx_t &v_offset) {
 	D_ASSERT(result.GetType().InternalType() == PhysicalType::VARCHAR);
 	lock_guard<mutex> guard(lock);
-
-	auto &validity = FlatVector::Validity(result);
-	auto strings = FlatVector::GetData<string_t>(result);
-
-	// find first non-inlined string
-	auto i = NumericCast<uint32_t>(v_offset);
-	const uint32_t end = NumericCast<uint32_t>(v_offset + count);
-	for (; i < end; i++) {
-		if (!validity.RowIsValid(i)) {
-			continue;
-		}
-		if (!strings[i].IsInlined()) {
-			break;
-		}
-	}
-	// at least one string must be non-inlined, otherwise this function should not be called
-	D_ASSERT(i < end);
-
-	const auto old_base_ptr = strings[i].GetData();
-	const auto new_base_ptr = char_ptr_cast(GetDataPointer(state, block_id, offset));
+	const auto old_base_ptr = char_ptr_cast(swizzle_segment.ptr);
+	const auto new_base_ptr =
+	    char_ptr_cast(GetDataPointer(state, string_heap_segment.block_id, string_heap_segment.offset));
 	if (old_base_ptr == new_base_ptr) {
-		// pointers are still valid
-		return;
+		return; // pointers are still valid
 	}
 
-	// pointer mismatch! pointers are invalid, set them correctly
-	for (; i < end; i++) {
-		if (!validity.RowIsValid(i)) {
-			continue;
-		}
+	const auto &validity = FlatVector::Validity(result);
+	const auto strings = FlatVector::GetData<string_t>(result);
+
+	// recompute pointers
+	const auto start = NumericCast<idx_t>(v_offset);
+	const auto end = NumericCast<idx_t>(v_offset + swizzle_segment.count);
+	for (idx_t i = start; i < end; i++) {
 		auto &str = strings[i];
-		if (str.IsInlined()) {
+		if (!validity.RowIsValidUnsafe(i) || str.IsInlined()) {
 			continue;
 		}
 		const auto str_offset = str.GetPointer() - old_base_ptr;
 		str.SetPointer(new_base_ptr + str_offset);
+#ifdef D_ASSERT_IS_ENABLED
+		str.VerifyCharacters();
+#endif
 	}
+
+	// store the new base ptr
+	swizzle_segment.ptr = data_ptr_cast(new_base_ptr);
 }
 
 void ColumnDataAllocator::SetDestroyBufferUponUnpin(uint32_t block_id) {

--- a/src/common/types/column/column_data_allocator.cpp
+++ b/src/common/types/column/column_data_allocator.cpp
@@ -197,7 +197,7 @@ data_ptr_t ColumnDataAllocator::GetDataPointer(ChunkManagementState &state, uint
 
 void ColumnDataAllocator::UnswizzlePointers(ChunkManagementState &state, Vector &result,
                                             SwizzleMetaData &swizzle_segment, const VectorMetaData &string_heap_segment,
-                                            const idx_t &v_offset) {
+                                            const idx_t &v_offset, const bool &copied) {
 	D_ASSERT(result.GetType().InternalType() == PhysicalType::VARCHAR);
 	lock_guard<mutex> guard(lock);
 	const auto old_base_ptr = char_ptr_cast(swizzle_segment.ptr);
@@ -228,8 +228,10 @@ void ColumnDataAllocator::UnswizzlePointers(ChunkManagementState &state, Vector 
 #endif
 	}
 
-	// store the new base ptr
-	swizzle_segment.ptr = data_ptr_cast(new_base_ptr);
+	if (!copied) {
+		// if the data was not copied, we modified data on the blocks. store the new base ptr
+		swizzle_segment.ptr = data_ptr_cast(new_base_ptr);
+	}
 }
 
 void ColumnDataAllocator::SetDestroyBufferUponUnpin(uint32_t block_id) {

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -557,7 +557,7 @@ bool ColumnDataCopyCompressedStrings(ColumnDataMetaData &meta_data, const Vector
 			const auto &dictionary_string = dictionary_strings[i];
 			if (dictionary_validity.RowIsValid(i) && !dictionary_string.IsInlined()) {
 				string_offsets[i] = current_string_offset;
-				memcpy(heap_ptr, dictionary_string.GetPointer(), dictionary_string.GetSize());
+				memcpy(heap_ptr + current_string_offset, dictionary_string.GetPointer(), dictionary_string.GetSize());
 				current_string_offset += dictionary_string.GetSize();
 			}
 		}

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -454,6 +454,136 @@ static void ColumnDataCopy(ColumnDataMetaData &meta_data, const UnifiedVectorFor
 	TemplatedColumnDataCopy<StandardValueCopy<T>>(meta_data, source_data, source, offset, copy_count);
 }
 
+bool ColumnDataCopyCompressedStrings(ColumnDataMetaData &meta_data, const VectorDataIndex &current_index,
+                                     VectorDataIndex &child_index, const UnifiedVectorFormat &source_data,
+                                     Vector &source, const idx_t &offset, const idx_t &vector_remaining,
+                                     idx_t &append_count, idx_t &heap_size) {
+	// check if we can do the optimization at all
+	switch (source.GetVectorType()) {
+	case VectorType::CONSTANT_VECTOR: {
+		const auto &constant_string = ConstantVector::GetData<string_t>(source)[0];
+		if (ConstantVector::IsNull(source) || constant_string.IsInlined()) {
+			return false; // regular path is OK
+		}
+		heap_size = constant_string.GetSize();
+		break;
+	}
+	case VectorType::DICTIONARY_VECTOR: {
+		const auto dictionary_size = DictionaryVector::DictionarySize(source);
+		if (!dictionary_size.IsValid() || dictionary_size.GetIndex() >= vector_remaining / 2) {
+			return false; // not a dictionary from storage or dictionary too large
+		}
+
+		const auto &dictionary_vector = DictionaryVector::Child(source);
+		const auto dictionary_strings = FlatVector::GetData<string_t>(dictionary_vector);
+		const auto &dictionary_validity = FlatVector::Validity(dictionary_vector);
+
+		// Compute total size needed for dictionary strings
+		const auto dictionary_size_idx = dictionary_size.GetIndex();
+		if (dictionary_validity.AllValid()) {
+			for (idx_t i = 0; i < dictionary_size_idx; i++) {
+				const auto &dictionary_string = dictionary_strings[i];
+				heap_size += !dictionary_string.IsInlined() * dictionary_string.GetSize();
+			}
+		} else {
+			for (idx_t i = 0; i < dictionary_size_idx; i++) {
+				const auto &dictionary_string = dictionary_strings[i];
+				const auto add_size = dictionary_validity.RowIsValidUnsafe(i) && !dictionary_string.IsInlined();
+				heap_size += add_size * dictionary_string.GetSize();
+			}
+		}
+
+		if (heap_size == 0) {
+			return false; // regular path is OK
+		}
+		break;
+	}
+	default:
+		return false;
+	}
+	D_ASSERT(heap_size != 0);
+
+	auto &segment = meta_data.segment;
+	auto &append_state = meta_data.state;
+
+	// allocate string heap for the compressed strings
+	child_index = segment.AllocateStringHeap(heap_size, meta_data.chunk_data, append_state, child_index);
+	if (!meta_data.GetVectorMetaData().child_index.IsValid()) {
+		meta_data.GetVectorMetaData().child_index = meta_data.segment.AddChildIndex(child_index);
+	}
+	auto &child_segment = segment.GetVectorData(child_index);
+	const auto heap_ptr = segment.allocator->GetDataPointer(append_state.current_chunk_state, child_segment.block_id,
+	                                                        child_segment.offset);
+
+	auto &current_segment = segment.GetVectorData(current_index);
+	const auto base_ptr = segment.allocator->GetDataPointer(append_state.current_chunk_state, current_segment.block_id,
+	                                                        current_segment.offset);
+
+	// initialize validity mask
+	auto validity_data = ColumnDataCollectionSegment::GetValidityPointerForWriting(base_ptr, sizeof(string_t));
+	ValidityMask target_validity(validity_data, STANDARD_VECTOR_SIZE);
+	if (current_segment.count == 0) {
+		// first time appending to this vector
+		// all data here is still uninitialized
+		// initialize the validity mask to set all to valid
+		target_validity.SetAllValid(STANDARD_VECTOR_SIZE);
+	}
+
+	// now write the compressed data
+	const auto target_entries = reinterpret_cast<string_t *>(base_ptr);
+	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// copy over the constant string
+		auto constant_string = ConstantVector::GetData<string_t>(source)[0];
+		memcpy(heap_ptr, constant_string.GetData(), constant_string.GetSize());
+		constant_string.SetPointer(char_ptr_cast(heap_ptr));
+
+		// duplicate it
+		for (idx_t i = 0; i < vector_remaining; i++) {
+			const auto target_idx = current_segment.count + i;
+			target_entries[target_idx] = constant_string;
+		}
+	} else {
+		D_ASSERT(source.GetVectorType() == VectorType::DICTIONARY_VECTOR);
+		const auto dictionary_size = DictionaryVector::DictionarySize(source);
+		const auto &dictionary_vector = DictionaryVector::Child(source);
+		const auto dictionary_strings = FlatVector::GetData<string_t>(dictionary_vector);
+		const auto &dictionary_validity = FlatVector::Validity(dictionary_vector);
+
+		// Copy over dictionary, computing offsets as we go
+		idx_t current_string_offset = 0;
+		idx_t string_offsets[STANDARD_VECTOR_SIZE];
+		const auto dictionary_size_idx = dictionary_size.GetIndex();
+		for (idx_t i = 0; i < dictionary_size_idx; i++) {
+			const auto &dictionary_string = dictionary_strings[i];
+			if (dictionary_validity.RowIsValid(i) && !dictionary_string.IsInlined()) {
+				string_offsets[i] = current_string_offset;
+				memcpy(heap_ptr, dictionary_string.GetPointer(), dictionary_string.GetSize());
+				current_string_offset += dictionary_string.GetSize();
+			}
+		}
+
+		// Now copy over the string vector, pointing to the new dictionary
+		const auto source_entries = UnifiedVectorFormat::GetData<string_t>(source_data);
+		for (idx_t i = 0; i < vector_remaining; i++) {
+			const auto source_idx = UnsafeNumericCast<idx_t>((*source_data.sel)[offset + i]);
+			const auto target_idx = current_segment.count + i;
+			if (!source_data.validity.RowIsValid(source_idx)) {
+				target_validity.SetInvalid(target_idx);
+				continue;
+			}
+			const auto &source_entry = source_entries[source_idx];
+			auto &target_entry = target_entries[target_idx];
+			target_entry = source_entry;
+			if (!source_entry.IsInlined()) {
+				target_entry.SetPointer(char_ptr_cast(heap_ptr + string_offsets[source_idx]));
+			}
+		}
+	}
+
+	append_count = vector_remaining;
+	return true;
+}
+
 template <>
 void ColumnDataCopy<string_t>(ColumnDataMetaData &meta_data, const UnifiedVectorFormat &source_data, Vector &source,
                               idx_t offset, idx_t copy_count) {
@@ -486,83 +616,89 @@ void ColumnDataCopy<string_t>(ColumnDataMetaData &meta_data, const UnifiedVector
 	auto block_size = meta_data.segment.allocator->GetBufferManager().GetBlockSize();
 	while (remaining > 0) {
 		// how many values fit in the current string vector
-		idx_t vector_remaining =
+		const auto vector_remaining =
 		    MinValue<idx_t>(STANDARD_VECTOR_SIZE - segment.GetVectorData(current_index).count, remaining);
 
-		// 'append_count' is less if we cannot fit that amount of non-inlined strings on one buffer-managed block
-		idx_t append_count;
+		idx_t append_count = 0;
 		idx_t heap_size = 0;
-		const auto source_entries = UnifiedVectorFormat::GetData<string_t>(source_data);
-		for (append_count = 0; append_count < vector_remaining; append_count++) {
-			auto source_idx = source_data.sel->get_index(offset + append_count);
-			if (!source_data.validity.RowIsValid(source_idx)) {
-				continue;
+		if (!ColumnDataCopyCompressedStrings(meta_data, current_index, child_index, source_data, source, offset,
+		                                     vector_remaining, append_count, heap_size)) {
+			// 'append_count' is less if we cannot fit that amount of non-inlined strings on one buffer-managed block
+			const auto source_entries = UnifiedVectorFormat::GetData<string_t>(source_data);
+			for (; append_count < vector_remaining; append_count++) {
+				auto source_idx = source_data.sel->get_index(offset + append_count);
+				if (!source_data.validity.RowIsValid(source_idx)) {
+					continue;
+				}
+				const auto &entry = source_entries[source_idx];
+				if (entry.IsInlined()) {
+					continue;
+				}
+				if (heap_size + entry.GetSize() > block_size) {
+					break;
+				}
+				heap_size += entry.GetSize();
 			}
-			const auto &entry = source_entries[source_idx];
-			if (entry.IsInlined()) {
-				continue;
-			}
-			if (heap_size + entry.GetSize() > block_size) {
-				break;
-			}
-			heap_size += entry.GetSize();
-		}
 
-		if (vector_remaining != 0 && append_count == 0) {
-			// The string exceeds Storage::DEFAULT_BLOCK_SIZE, so we allocate one block at a time for long strings.
-			auto source_idx = source_data.sel->get_index(offset + append_count);
-			D_ASSERT(source_data.validity.RowIsValid(source_idx));
-			D_ASSERT(!source_entries[source_idx].IsInlined());
-			D_ASSERT(source_entries[source_idx].GetSize() > block_size);
-			heap_size += source_entries[source_idx].GetSize();
-			append_count++;
-		}
-
-		// allocate string heap for the next 'append_count' strings
-		data_ptr_t heap_ptr = nullptr;
-		if (heap_size != 0) {
-			child_index = segment.AllocateStringHeap(heap_size, meta_data.chunk_data, append_state, child_index);
-			if (!meta_data.GetVectorMetaData().child_index.IsValid()) {
-				meta_data.GetVectorMetaData().child_index = meta_data.segment.AddChildIndex(child_index);
+			if (vector_remaining != 0 && append_count == 0) {
+				// The string exceeds Storage::DEFAULT_BLOCK_SIZE, so we allocate one block at a time for long strings.
+				auto source_idx = source_data.sel->get_index(offset + append_count);
+				D_ASSERT(source_data.validity.RowIsValid(source_idx));
+				D_ASSERT(!source_entries[source_idx].IsInlined());
+				D_ASSERT(source_entries[source_idx].GetSize() > block_size);
+				heap_size += source_entries[source_idx].GetSize();
+				append_count++;
 			}
-			auto &child_segment = segment.GetVectorData(child_index);
-			heap_ptr = segment.allocator->GetDataPointer(append_state.current_chunk_state, child_segment.block_id,
-			                                             child_segment.offset);
+
+			// allocate string heap for the next 'append_count' strings
+			data_ptr_t heap_ptr = nullptr;
+			if (heap_size != 0) {
+				child_index = segment.AllocateStringHeap(heap_size, meta_data.chunk_data, append_state, child_index);
+				if (!meta_data.GetVectorMetaData().child_index.IsValid()) {
+					meta_data.GetVectorMetaData().child_index = meta_data.segment.AddChildIndex(child_index);
+				}
+				auto &child_segment = segment.GetVectorData(child_index);
+				heap_ptr = segment.allocator->GetDataPointer(append_state.current_chunk_state, child_segment.block_id,
+				                                             child_segment.offset);
+			}
+
+			// We get a reference to the "current_segment" only after allocating the string heap above,
+			// because this can resize the vector holding the segments, moving it somewhere else
+			auto &current_segment = segment.GetVectorData(current_index);
+			auto base_ptr = segment.allocator->GetDataPointer(append_state.current_chunk_state,
+			                                                  current_segment.block_id, current_segment.offset);
+			auto validity_data = ColumnDataCollectionSegment::GetValidityPointerForWriting(base_ptr, sizeof(string_t));
+			ValidityMask target_validity(validity_data, STANDARD_VECTOR_SIZE);
+			if (current_segment.count == 0) {
+				// first time appending to this vector
+				// all data here is still uninitialized
+				// initialize the validity mask to set all to valid
+				target_validity.SetAllValid(STANDARD_VECTOR_SIZE);
+			}
+
+			auto target_entries = reinterpret_cast<string_t *>(base_ptr);
+			for (idx_t i = 0; i < append_count; i++) {
+				auto source_idx = source_data.sel->get_index(offset + i);
+				auto target_idx = current_segment.count + i;
+				if (!source_data.validity.RowIsValid(source_idx)) {
+					target_validity.SetInvalid(target_idx);
+					continue;
+				}
+				const auto &source_entry = source_entries[source_idx];
+				auto &target_entry = target_entries[target_idx];
+				if (source_entry.IsInlined()) {
+					target_entry = source_entry;
+				} else {
+					D_ASSERT(heap_ptr != nullptr);
+					memcpy(heap_ptr, source_entry.GetData(), source_entry.GetSize());
+					target_entry =
+					    string_t(const_char_ptr_cast(heap_ptr), UnsafeNumericCast<uint32_t>(source_entry.GetSize()));
+					heap_ptr += source_entry.GetSize();
+				}
+			}
 		}
 
 		auto &current_segment = segment.GetVectorData(current_index);
-		auto base_ptr = segment.allocator->GetDataPointer(append_state.current_chunk_state, current_segment.block_id,
-		                                                  current_segment.offset);
-		auto validity_data = ColumnDataCollectionSegment::GetValidityPointerForWriting(base_ptr, sizeof(string_t));
-		ValidityMask target_validity(validity_data, STANDARD_VECTOR_SIZE);
-		if (current_segment.count == 0) {
-			// first time appending to this vector
-			// all data here is still uninitialized
-			// initialize the validity mask to set all to valid
-			target_validity.SetAllValid(STANDARD_VECTOR_SIZE);
-		}
-
-		auto target_entries = reinterpret_cast<string_t *>(base_ptr);
-		for (idx_t i = 0; i < append_count; i++) {
-			auto source_idx = source_data.sel->get_index(offset + i);
-			auto target_idx = current_segment.count + i;
-			if (!source_data.validity.RowIsValid(source_idx)) {
-				target_validity.SetInvalid(target_idx);
-				continue;
-			}
-			const auto &source_entry = source_entries[source_idx];
-			auto &target_entry = target_entries[target_idx];
-			if (source_entry.IsInlined()) {
-				target_entry = source_entry;
-			} else {
-				D_ASSERT(heap_ptr != nullptr);
-				memcpy(heap_ptr, source_entry.GetData(), source_entry.GetSize());
-				target_entry =
-				    string_t(const_char_ptr_cast(heap_ptr), UnsafeNumericCast<uint32_t>(source_entry.GetSize()));
-				heap_ptr += source_entry.GetSize();
-			}
-		}
-
 		if (heap_size != 0) {
 			current_segment.swizzle_data.emplace_back(child_index, current_segment.count, append_count);
 		}

--- a/src/common/types/column/column_data_collection_segment.cpp
+++ b/src/common/types/column/column_data_collection_segment.cpp
@@ -237,8 +237,7 @@ idx_t ColumnDataCollectionSegment::ReadVector(ChunkManagementState &state, Vecto
 				auto &current_vdata = GetVectorData(next_index);
 				for (auto &swizzle_segment : current_vdata.swizzle_data) {
 					auto &string_heap_segment = GetVectorData(swizzle_segment.child_index);
-					allocator->UnswizzlePointers(state, result, offset + swizzle_segment.offset, swizzle_segment.count,
-					                             string_heap_segment.block_id, string_heap_segment.offset);
+					allocator->UnswizzlePointers(state, result, swizzle_segment, string_heap_segment, offset);
 				}
 				offset += current_vdata.count;
 				next_index = current_vdata.next_data;

--- a/src/common/types/column/column_data_collection_segment.cpp
+++ b/src/common/types/column/column_data_collection_segment.cpp
@@ -232,12 +232,14 @@ idx_t ColumnDataCollectionSegment::ReadVector(ChunkManagementState &state, Vecto
 	} else if (internal_type == PhysicalType::VARCHAR) {
 		if (allocator->GetType() == ColumnDataAllocatorType::BUFFER_MANAGER_ALLOCATOR) {
 			auto next_index = vector_index;
+			const auto copied =
+			    vdata.next_data.IsValid() || state.properties == ColumnDataScanProperties::DISALLOW_ZERO_COPY;
 			idx_t offset = 0;
 			while (next_index.IsValid()) {
 				auto &current_vdata = GetVectorData(next_index);
 				for (auto &swizzle_segment : current_vdata.swizzle_data) {
 					auto &string_heap_segment = GetVectorData(swizzle_segment.child_index);
-					allocator->UnswizzlePointers(state, result, swizzle_segment, string_heap_segment, offset);
+					allocator->UnswizzlePointers(state, result, swizzle_segment, string_heap_segment, offset, copied);
 				}
 				offset += current_vdata.count;
 				next_index = current_vdata.next_data;

--- a/src/include/duckdb/common/types/column/column_data_allocator.hpp
+++ b/src/include/duckdb/common/types/column/column_data_allocator.hpp
@@ -77,7 +77,7 @@ public:
 	void InitializeChunkState(ChunkManagementState &state, ChunkMetaData &meta_data);
 	data_ptr_t GetDataPointer(ChunkManagementState &state, uint32_t block_id, uint32_t offset);
 	void UnswizzlePointers(ChunkManagementState &state, Vector &result, SwizzleMetaData &swizzle_segment,
-	                       const VectorMetaData &string_heap_segment, const idx_t &v_offset);
+	                       const VectorMetaData &string_heap_segment, const idx_t &v_offset, const bool &copied);
 
 	//! Prevents the block with the given id from being added to the eviction queue
 	void SetDestroyBufferUponUnpin(uint32_t block_id);

--- a/src/include/duckdb/common/types/column/column_data_allocator.hpp
+++ b/src/include/duckdb/common/types/column/column_data_allocator.hpp
@@ -14,6 +14,7 @@ namespace duckdb {
 
 struct ChunkMetaData;
 struct VectorMetaData;
+struct SwizzleMetaData;
 
 struct BlockMetaData {
 	//! The underlying block handle
@@ -75,8 +76,8 @@ public:
 	void Initialize(ColumnDataAllocator &other);
 	void InitializeChunkState(ChunkManagementState &state, ChunkMetaData &meta_data);
 	data_ptr_t GetDataPointer(ChunkManagementState &state, uint32_t block_id, uint32_t offset);
-	void UnswizzlePointers(ChunkManagementState &state, Vector &result, idx_t v_offset, uint16_t count,
-	                       uint32_t block_id, uint32_t offset);
+	void UnswizzlePointers(ChunkManagementState &state, Vector &result, SwizzleMetaData &swizzle_segment,
+	                       const VectorMetaData &string_heap_segment, const idx_t &v_offset);
 
 	//! Prevents the block with the given id from being added to the eviction queue
 	void SetDestroyBufferUponUnpin(uint32_t block_id);

--- a/src/include/duckdb/common/types/column/column_data_collection_segment.hpp
+++ b/src/include/duckdb/common/types/column/column_data_collection_segment.hpp
@@ -36,11 +36,13 @@ struct VectorDataIndex {
 };
 
 struct SwizzleMetaData {
-	SwizzleMetaData(VectorDataIndex child_index_p, uint16_t offset_p, uint16_t count_p)
-	    : child_index(child_index_p), offset(offset_p), count(count_p) {
+	SwizzleMetaData(VectorDataIndex child_index_p, data_ptr_t ptr_p, uint16_t offset_p, uint16_t count_p)
+	    : child_index(child_index_p), ptr(ptr_p), offset(offset_p), count(count_p) {
 	}
 	//! Index of block storing heap
 	VectorDataIndex child_index;
+	//! Last-known pointer
+	data_ptr_t ptr;
 	//! Offset into the string_t vector
 	uint16_t offset;
 	//! Number of strings starting at 'offset' that have strings stored in the block with index 'child_index'

--- a/test/parquet/constant_dictionary_vector_parquet.test
+++ b/test/parquet/constant_dictionary_vector_parquet.test
@@ -1,0 +1,24 @@
+# name: test/parquet/constant_dictionary_vector_parquet.test
+# description: Test that we retain constant/dictionary compression for strings when writing to Parquet (small data)
+# group: [parquet]
+
+require parquet
+
+# low memory limit to test that we don't blow up intermediates
+statement ok
+set memory_limit='10mb'
+
+# we should be able to do this without spilling
+statement ok
+set temp_directory=null
+
+# 1k strings of ~50kb = ~50 MB
+# the ColumnDataCollection should keep the constant string compressed
+# and the Parquet writer will use dictionary compression, not blowing them up there either
+statement ok
+copy (select repeat('a', 50_000) s from range(1000)) to '__TEST_DIR__/cdc_constant.parquet'
+
+# the written file has dictionary compression
+# when we copy it over to another file we should still be able to avoid blowing it up
+statement ok
+copy (from '__TEST_DIR__/cdc_constant.parquet') to '__TEST_DIR__/cdc_dictionary.parquet'

--- a/test/parquet/constant_dictionary_vector_parquet.test
+++ b/test/parquet/constant_dictionary_vector_parquet.test
@@ -2,6 +2,8 @@
 # description: Test that we retain constant/dictionary compression for strings when writing to Parquet (small data)
 # group: [parquet]
 
+require vector_size 2048
+
 require parquet
 
 # low memory limit to test that we don't blow up intermediates

--- a/test/parquet/constant_dictionary_vector_parquet.test_slow
+++ b/test/parquet/constant_dictionary_vector_parquet.test_slow
@@ -2,6 +2,8 @@
 # description: Test that we retain constant/dictionary compression for strings when writing to Parquet (big data)
 # group: [parquet]
 
+require vector_size 2048
+
 require parquet
 
 # low memory limit to test that we don't blow up intermediates

--- a/test/parquet/constant_dictionary_vector_parquet.test_slow
+++ b/test/parquet/constant_dictionary_vector_parquet.test_slow
@@ -1,0 +1,24 @@
+# name: test/parquet/constant_dictionary_vector_parquet.test_slow
+# description: Test that we retain constant/dictionary compression for strings when writing to Parquet (big data)
+# group: [parquet]
+
+require parquet
+
+# low memory limit to test that we don't blow up intermediates
+statement ok
+set memory_limit='100mb'
+
+# we should be able to do this without spilling
+statement ok
+set temp_directory=null
+
+# 100k strings of ~50kb = ~5 GB
+# the ColumnDataCollection should keep the constant string compressed
+# and the Parquet writer will use dictionary compression, not blowing them up there either
+statement ok
+copy (select repeat('a', 50_000) s from range(100_000)) to '__TEST_DIR__/cdc_constant.parquet'
+
+# the written file has dictionary compression
+# when we copy it over to another file we should still be able to avoid blowing it up
+statement ok
+copy (from '__TEST_DIR__/cdc_constant.parquet') to '__TEST_DIR__/cdc_dictionary.parquet'


### PR DESCRIPTION
When materializing data in columnar format in the `ColumnDataCollection`, we (almost) always go to the `FLAT` representation, i.e., `CONSTANT` and `DICTIONARY` `Vector`s are flattened. For most data types this is OK, but for strings, this can cause the size of the intermediates to increase drastically.

Keeping the `VectorType` the same would be ideal, but when we scan, we expect the `Vector`s to be `FLAT`, so this would be a big (and bug-prone) effort, so it's not really feasible (for now). Instead, this PR copies over just the unique strings, and creates a `FLAT` `Vector` of strings that point into it. This solves most of the problem while keeping a very low code footprint.

This optimization will trigger always for `CONSTANT` `Vector`s, but for `DICTIONARY` `Vector`s only if the dictionary size is less than half of our `STANDARD_VECTOR_SIZE`. The dictionary is copied once per `Vector`. This can be improved in the future by copying the dictionary just once. This is totally feasible, but more effort to implement. What I've implemented here are the first steps in that direction, but I've chosen to keep this PR simple for now, as I think this solves 80% of the problem with just 20% of the effort.

I did a quick benchmark by copying the `l_shipinstruct` column from `lineitem` from TPC-H at SF100 from Parquet to Parquet, and this reduced the peak RSS from 5.1 GB to 3.5 GB. The speed was pretty much the same. I can come up with a lot more degenerate examples where memory usage would be reduced by orders of magnitude.