### PR TITLE
Add option to control parquet NaN pruning

### DIFF
--- a/extension/parquet/include/parquet.json
+++ b/extension/parquet/include/parquet.json
@@ -102,6 +102,13 @@
         "type": "idx_t",
         "default": "0",
         "property": "parquet_options.explicit_cardinality"
+      },
+      {
+        "id": 107,
+        "name": "can_have_nan",
+        "type": "bool",
+        "default": "false",
+        "property": "parquet_options.can_have_nan"
       }
     ],
     "pointer_type": "none"

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -108,6 +108,7 @@ struct ParquetOptions {
 
 	vector<ParquetColumnDefinition> schema;
 	idx_t explicit_cardinality = 0;
+	bool can_have_nan = false; // if floats or doubles can contain NaN values
 };
 
 struct ParquetOptionsSerialization {

--- a/extension/parquet/include/parquet_statistics.hpp
+++ b/extension/parquet/include/parquet_statistics.hpp
@@ -27,7 +27,7 @@ class ResizeableBuffer;
 struct ParquetStatisticsUtils {
 
 	static unique_ptr<BaseStatistics> TransformColumnStatistics(const ParquetColumnSchema &reader,
-	                                                            const vector<ColumnChunk> &columns);
+	                                                            const vector<ColumnChunk> &columns, bool can_have_nan);
 
 	static Value ConvertValue(const LogicalType &type, const ParquetColumnSchema &schema_ele, const std::string &stats);
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -318,6 +318,7 @@ TableFunctionSet ParquetScanFunction::GetFunctionSet() {
 	table_function.named_parameters["schema"] = LogicalTypeId::ANY;
 	table_function.named_parameters["encryption_config"] = LogicalTypeId::ANY;
 	table_function.named_parameters["parquet_version"] = LogicalType::VARCHAR;
+	table_function.named_parameters["can_have_nan"] = LogicalType::BOOLEAN;
 	table_function.statistics = MultiFileFunction<ParquetMultiFileInfo>::MultiFileScanStats;
 	table_function.serialize = ParquetScanSerialize;
 	table_function.deserialize = ParquetScanDeserialize;
@@ -365,6 +366,13 @@ bool ParquetMultiFileInfo::ParseCopyOption(ClientContext &context, const string 
 		options.encryption_config = ParquetEncryptionConfig::Create(context, values[0]);
 		return true;
 	}
+	if (key == "can_have_nan") {
+		if (values.size() != 1) {
+			throw BinderException("Parquet can_have_nan cannot be empty!");
+		}
+		options.can_have_nan = GetBooleanArgument(key, values);
+		return true;
+	}
 	return false;
 }
 
@@ -391,6 +399,10 @@ bool ParquetMultiFileInfo::ParseOption(ClientContext &context, const string &ori
 	}
 	if (key == "debug_use_openssl") {
 		options.debug_use_openssl = BooleanValue::Get(val);
+		return true;
+	}
+	if (key == "can_have_nan") {
+		options.can_have_nan = BooleanValue::Get(val);
 		return true;
 	}
 	if (key == "schema") {

--- a/extension/parquet/serialize_parquet.cpp
+++ b/extension/parquet/serialize_parquet.cpp
@@ -73,6 +73,7 @@ void ParquetOptionsSerialization::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<shared_ptr<ParquetEncryptionConfig>>(104, "encryption_config", parquet_options.encryption_config, nullptr);
 	serializer.WritePropertyWithDefault<bool>(105, "debug_use_openssl", parquet_options.debug_use_openssl, true);
 	serializer.WritePropertyWithDefault<idx_t>(106, "explicit_cardinality", parquet_options.explicit_cardinality, 0);
+	serializer.WritePropertyWithDefault<bool>(107, "can_have_nan", parquet_options.can_have_nan, false);
 }
 
 ParquetOptionsSerialization ParquetOptionsSerialization::Deserialize(Deserializer &deserializer) {
@@ -84,6 +85,7 @@ ParquetOptionsSerialization ParquetOptionsSerialization::Deserialize(Deserialize
 	deserializer.ReadPropertyWithExplicitDefault<shared_ptr<ParquetEncryptionConfig>>(104, "encryption_config", result.parquet_options.encryption_config, nullptr);
 	deserializer.ReadPropertyWithExplicitDefault<bool>(105, "debug_use_openssl", result.parquet_options.debug_use_openssl, true);
 	deserializer.ReadPropertyWithExplicitDefault<idx_t>(106, "explicit_cardinality", result.parquet_options.explicit_cardinality, 0);
+	deserializer.ReadPropertyWithExplicitDefault<bool>(107, "can_have_nan", result.parquet_options.can_have_nan, false);
 	return result;
 }
 

--- a/test/sql/copy/parquet/parquet_nan.test
+++ b/test/sql/copy/parquet/parquet_nan.test
@@ -12,21 +12,21 @@ select * from parquet_scan('data/parquet-testing/nan-float.parquet') order by 1
 inf	bar	0
 
 query II
-select * from parquet_scan('data/parquet-testing/arrow_nan.parquet') where f='nan';
+select * from parquet_scan('data/parquet-testing/arrow_nan.parquet', can_have_nan := true) where f='nan';
 ----
 nan	nan
 
 query II
-select * from parquet_scan('data/parquet-testing/arrow_nan.parquet') where f>10;
+select * from parquet_scan('data/parquet-testing/arrow_nan.parquet', can_have_nan := true) where f>10;
 ----
 nan	nan
 
 query II
-select * from parquet_scan('data/parquet-testing/arrow_nan.parquet') where d='nan';
+select * from parquet_scan('data/parquet-testing/arrow_nan.parquet', can_have_nan := true) where d='nan';
 ----
 nan	nan
 
 query II
-select * from parquet_scan('data/parquet-testing/arrow_nan.parquet') where d>10;
+select * from parquet_scan('data/parquet-testing/arrow_nan.parquet', can_have_nan := true) where d>10;
 ----
 nan	nan


### PR DESCRIPTION
This is a follow-up to https://github.com/duckdb/duckdb/pull/16962, which partly reverts the newly introduced nan-handling behavior by putting it behind a new boolean named parameter `can_have_nan` in the `parquet_scan` and `COPY ... FROM (FORMAT PARQUET)` functions.

Until the parquet spec decides on how to deal with NaN values from the perspective of floating-point filter pruning, this is probably the better option to avoid performance regression in the common case, closing: #17855 