### PR TITLE
Issue #17861: FILL Argument Types

### DIFF
--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -789,7 +789,7 @@ static fill_interpolate_t GetFillInterpolateFunction(const LogicalType &type) {
 	case PhysicalType::DOUBLE:
 		return FillInterpolateFunc<double>;
 	default:
-		throw InternalException("Unsupported FILL interpolationtype.");
+		throw InternalException("Unsupported FILL interpolation type.");
 	}
 }
 

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/function/function_binder.hpp"
-#include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
@@ -9,9 +8,8 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
-#include "duckdb/planner/expression_binder/select_binder.hpp"
+#include "duckdb/planner/expression_binder/base_select_binder.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 
 namespace duckdb {
@@ -107,6 +105,10 @@ static bool IsRangeType(const LogicalType &type) {
 	default:
 		return false;
 	}
+}
+
+static bool IsFillType(const LogicalType &type) {
+	return type.IsNumeric() || (type.IsTemporal() && type.id() != LogicalTypeId::TIME_TZ);
 }
 
 static LogicalType BindRangeExpression(ClientContext &context, const string &name, unique_ptr<ParsedExpression> &expr,
@@ -379,8 +381,12 @@ BindResult BaseSelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 		result->arg_orders.emplace_back(type, null_order, std::move(expression));
 	}
 
-	//	Check FILL orderings support subtraction
+	//	Check FILL arguments support subtraction
 	if (window.GetExpressionType() == ExpressionType::WINDOW_FILL) {
+		D_ASSERT(!result->children.empty());
+		if (!IsFillType(result->children[0]->return_type)) {
+			throw BinderException(error_context, "FILL argument must support subtraction");
+		}
 		LogicalType order_type;
 		if (window.arg_orders.empty()) {
 			D_ASSERT(!result->orders.empty());
@@ -388,8 +394,8 @@ BindResult BaseSelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 		} else {
 			order_type = result->arg_orders[0].expression->return_type;
 		}
-		if (!order_type.IsNumeric() && (!order_type.IsTemporal() || order_type.id() == LogicalTypeId::TIME_TZ)) {
-			throw BinderException(error_context, "FILL orderings must support subtraction");
+		if (!IsFillType(order_type)) {
+			throw BinderException(error_context, "FILL ordering must support subtraction");
 		}
 	}
 

--- a/test/sql/window/test_fill.test
+++ b/test/sql/window/test_fill.test
@@ -18,11 +18,17 @@ select fill(i) over () from range(3) tbl(i);
 ----
 FILL functions must have only one ORDER BY expression
 
+# Argument must be numeric
+statement error
+select fill(i::VARCHAR) over (order by i) from range(3) tbl(i);
+----
+FILL argument must support subtraction
+
 # Ordering must be numeric
 statement error
 select fill(i) over (order by i::VARCHAR) from range(3) tbl(i);
 ----
-FILL orderings must support subtraction
+FILL ordering must support subtraction
 
 #
 # Simple interpolation coverage tests

--- a/test/sql/window/test_fill_orderby.test
+++ b/test/sql/window/test_fill_orderby.test
@@ -12,11 +12,17 @@ select fill(i order by 10-i, i * i) over (order by i) from range(3) tbl(i);
 ----
 FILL functions must have only one ORDER BY expression
 
+# Argument must be numeric
+statement error
+select fill(i::VARCHAR order by i) over (order by i) from range(3) tbl(i);
+----
+FILL argument must support subtraction
+
 # Ordering must be numeric
 statement error
 select fill(i order by i::VARCHAR) over (order by i) from range(3) tbl(i);
 ----
-FILL orderings must support subtraction
+FILL ordering must support subtraction
 
 #
 # Simple interpolation coverage tests


### PR DESCRIPTION
* Disallow FILL for non-numeric arguments as well as orderings.

fixes: duckdb#17861
fixes: duckdblabs/duckdb-internal#5104