### PR TITLE
Issue #17781: ASOF Predicate Binding

### DIFF
--- a/test/sql/join/asof/test_asof_join_pushdown.test
+++ b/test/sql/join/asof/test_asof_join_pushdown.test
@@ -1,5 +1,5 @@
 # name: test/sql/join/asof/test_asof_join_pushdown.test
-# description: Test prericate pushdown for ASOF joins
+# description: Test predicate pushdown for ASOF joins
 # group: [asof]
 
 statement ok
@@ -182,3 +182,23 @@ ORDER BY 1
 ----
 1	2	1	3
 2	4	NULL	NULL
+
+statement error
+WITH t1 AS (
+	FROM VALUES
+		(1::INT, '2020-01-01 00:00:00'::TIMESTAMP), 
+		(2, '2020-01-02 00:00:00')
+	AS t1(a, b)
+), t2 AS (
+	FROM VALUES
+		(1::INT, '2020-01-01 00:01:00'::TIMESTAMP), 
+		(2, '2020-01-02 00:00:00')
+	t2(c, d)
+)
+SELECT * 
+FROM t1 
+ASOF JOIN t2 
+  ON t1=b == t2.d 
+  AND t1.b >= t2.d - INTERVAL '1' SECOND;
+----
+Unimplemented type for cast


### PR DESCRIPTION
* Non-comparison predicates need to be bound against both sides, not just the LHS

fixes: duckdb#17781
fixes: duckdblabs/duckdb-internal#5066