### PR TITLE
Update `MemoryTag` when converting block to persistent

### DIFF
--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -206,6 +206,14 @@ bool BlockHandle::CanUnload() const {
 void BlockHandle::ConvertToPersistent(BlockLock &l, BlockHandle &new_block, unique_ptr<FileBuffer> new_buffer) {
 	VerifyMutex(l);
 
+	D_ASSERT(tag == memory_charge.tag);
+	if (tag != new_block.tag) {
+		const auto memory_charge_size = memory_charge.size;
+		memory_charge.Resize(0);
+		memory_charge.tag = new_block.tag;
+		memory_charge.Resize(memory_charge_size);
+	}
+
 	// move the data from the old block into data for the new block
 	new_block.state = BlockState::BLOCK_LOADED;
 	new_block.buffer = std::move(new_buffer);

--- a/test/sql/table_function/duckdb_memory_convert_to_persistent.test
+++ b/test/sql/table_function/duckdb_memory_convert_to_persistent.test
@@ -1,0 +1,17 @@
+# name: test/sql/table_function/duckdb_memory_convert_to_persistent.test
+# group: [table_function]
+
+load __TEST_DIR__/convert_to_persistent.duckdb
+
+# create a persistent table
+# this first allocates memory with the tag 'IN_MEMORY_TABLE'
+# the memory is converted to persistent data after the query is done
+# so all of the memory should be 'BASE_TABLE', no longer 'IN_MEMORY_TABLE'
+statement ok
+create table test as select range i from range(1_000_000);
+
+# this is
+query I
+select memory_usage_bytes from duckdb_memory() where tag = 'IN_MEMORY_TABLE'
+----
+0


### PR DESCRIPTION
The tag of the block changes when this conversion happens, but the tag of the `MemoryCharge` was not changed accordingly, which this PR fixes.