### PR TITLE
Deprecated std::stringstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,6 @@ else()
   endif()
 endif()
 
-if (SHADOW_FORBIDDEN_FUNCTIONS)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include 'duckdb/common/shadow_forbidden_functions.hpp'")
-endif()
-
 # Determine install paths
 # default to gnu standard installation directories (lib, bin, include)
 # https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
@@ -83,6 +79,10 @@ if (EXTENSION_STATIC_BUILD AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   endif()
 endif()
 
+option(SHADOW_FORBIDDEN_FUNCTIONS "Compile time test on usage of deprecated functions" FALSE)
+if (SHADOW_FORBIDDEN_FUNCTIONS)
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include 'duckdb/common/shadow_forbidden_functions.hpp'")
+endif()
 
 option(DISABLE_UNITY "Disable unity builds." FALSE)
 option(USE_WASM_THREADS "Should threads be used" FALSE)

--- a/extension/icu/icu_extension.cpp
+++ b/extension/icu/icu_extension.cpp
@@ -261,7 +261,7 @@ unique_ptr<icu::TimeZone> ICUHelpers::GetTimeZone(string &tz_str, string *error_
 	string candidate_str =
 	    StringUtil::CandidatesMessage(StringUtil::TopNJaroWinkler(candidates, tz_str), "Candidate time zones");
 	if (error_message) {
-		std::stringstream ss;
+		duckdb::stringstream ss;
 		ss << "Unknown TimeZone '" << tz_str << "'!\n" << candidate_str;
 		*error_message = ss.str();
 		return nullptr;

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -412,7 +412,7 @@ void ColumnReader::DecompressInternal(CompressionCodec::type codec, const_data_p
 	}
 
 	default: {
-		std::stringstream codec_name;
+		duckdb::stringstream codec_name;
 		codec_name << codec;
 		throw std::runtime_error("Unsupported compression codec \"" + codec_name.str() +
 		                         "\". Supported options are uncompressed, brotli, gzip, lz4_raw, snappy or zstd");

--- a/extension/parquet/include/parquet_bss_decoder.hpp
+++ b/extension/parquet/include/parquet_bss_decoder.hpp
@@ -23,7 +23,7 @@ public:
 	template <typename T>
 	void GetBatch(data_ptr_t values_target_ptr, uint32_t batch_size) {
 		if (buffer_.len % sizeof(T) != 0) {
-			std::stringstream error;
+			duckdb::stringstream error;
 			error << "Data buffer size for the BYTE_STREAM_SPLIT encoding (" << buffer_.len
 			      << ") should be a multiple of the type size (" << sizeof(T) << ")";
 			throw std::runtime_error(error.str());
@@ -44,7 +44,7 @@ public:
 	template <typename T>
 	void Skip(uint32_t batch_size) {
 		if (buffer_.len % sizeof(T) != 0) {
-			std::stringstream error;
+			duckdb::stringstream error;
 			error << "Data buffer size for the BYTE_STREAM_SPLIT encoding (" << buffer_.len
 			      << ") should be a multiple of the type size (" << sizeof(T) << ")";
 			throw std::runtime_error(error.str());

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -63,14 +63,14 @@ public:
 
 template <class T>
 string ConvertParquetElementToString(T &&entry) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	ss << entry;
 	return ss.str();
 }
 
 template <class T>
 string PrintParquetElementToString(T &&entry) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	entry.printTo(ss);
 	return ss.str();
 }

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -6,8 +6,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/catalog/dependency_list.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
-
-#include <sstream>
+#include "duckdb/original/std/sstream.hpp"
 
 namespace duckdb {
 

--- a/src/catalog/catalog_entry/sequence_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/sequence_catalog_entry.cpp
@@ -108,7 +108,7 @@ unique_ptr<CreateInfo> SequenceCatalogEntry::GetInfo() const {
 string SequenceCatalogEntry::ToSQL() const {
 	auto seq_data = GetData();
 
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	ss << "CREATE SEQUENCE ";
 	ss << name;
 	ss << " INCREMENT BY " << seq_data.increment;

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -79,7 +79,7 @@ unique_ptr<CreateInfo> TableCatalogEntry::GetInfo() const {
 }
 
 string TableCatalogEntry::ColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<Constraint>> &constraints) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 
 	ss << "(";
 
@@ -185,7 +185,7 @@ string TableCatalogEntry::ColumnNamesToSQL(const ColumnList &columns) {
 		return "";
 	}
 
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	ss << "(";
 
 	for (auto &column : columns.Logical()) {

--- a/src/catalog/catalog_entry/type_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/type_catalog_entry.cpp
@@ -40,7 +40,7 @@ unique_ptr<CreateInfo> TypeCatalogEntry::GetInfo() const {
 }
 
 string TypeCatalogEntry::ToSQL() const {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	ss << "CREATE TYPE ";
 	ss << KeywordHelper::WriteOptionallyQuoted(name);
 	ss << " AS ";

--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -1067,7 +1067,7 @@ AdbcStatusCode StatementSetOption(struct AdbcStatement *statement, const char *k
 			return ADBC_STATUS_INVALID_ARGUMENT;
 		}
 	}
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	ss << "Statement Set Option " << key << " is not yet accepted by DuckDB";
 	SetError(error, ss.str());
 	return ADBC_STATUS_INVALID_ARGUMENT;

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -3,9 +3,8 @@
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/original/std/sstream.hpp"
 #include "utf8proc_wrapper.hpp"
-
-#include <sstream>
 
 namespace duckdb {
 

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/exception/parser_exception.hpp"
 #include "duckdb/common/random_engine.hpp"
+#include "duckdb/original/std/sstream.hpp"
 #include "jaro_winkler.hpp"
 #include "utf8proc_wrapper.hpp"
 
@@ -14,7 +15,6 @@
 #include <cctype>
 #include <iomanip>
 #include <memory>
-#include <sstream>
 #include <stdarg.h>
 #include <string.h>
 #include <stack>
@@ -27,7 +27,7 @@ namespace duckdb {
 
 string StringUtil::GenerateRandomName(idx_t length) {
 	RandomEngine engine;
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	for (idx_t i = 0; i < length; i++) {
 		ss << "0123456789abcdef"[engine.NextRandomInteger(0, 15)];
 	}
@@ -344,7 +344,7 @@ idx_t StringUtil::CIFind(vector<string> &vector, const string &search_string) {
 }
 
 vector<string> StringUtil::Split(const string &str, char delimiter) {
-	std::stringstream ss(str);
+	duckdb::stringstream ss(str);
 	vector<string> lines;
 	string temp;
 	while (getline(ss, temp, delimiter)) {

--- a/src/common/tree_renderer/graphviz_tree_renderer.cpp
+++ b/src/common/tree_renderer/graphviz_tree_renderer.cpp
@@ -16,25 +16,25 @@
 namespace duckdb {
 
 string GRAPHVIZTreeRenderer::ToString(const LogicalOperator &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string GRAPHVIZTreeRenderer::ToString(const PhysicalOperator &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string GRAPHVIZTreeRenderer::ToString(const ProfilingNode &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string GRAPHVIZTreeRenderer::ToString(const Pipeline &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }

--- a/src/common/tree_renderer/html_tree_renderer.cpp
+++ b/src/common/tree_renderer/html_tree_renderer.cpp
@@ -15,25 +15,25 @@
 namespace duckdb {
 
 string HTMLTreeRenderer::ToString(const LogicalOperator &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string HTMLTreeRenderer::ToString(const PhysicalOperator &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string HTMLTreeRenderer::ToString(const ProfilingNode &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string HTMLTreeRenderer::ToString(const Pipeline &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }

--- a/src/common/tree_renderer/json_tree_renderer.cpp
+++ b/src/common/tree_renderer/json_tree_renderer.cpp
@@ -19,25 +19,25 @@ using namespace duckdb_yyjson; // NOLINT
 namespace duckdb {
 
 string JSONTreeRenderer::ToString(const LogicalOperator &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string JSONTreeRenderer::ToString(const PhysicalOperator &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string JSONTreeRenderer::ToString(const ProfilingNode &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string JSONTreeRenderer::ToString(const Pipeline &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }

--- a/src/common/tree_renderer/text_tree_renderer.cpp
+++ b/src/common/tree_renderer/text_tree_renderer.cpp
@@ -283,25 +283,25 @@ void TextTreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_
 }
 
 string TextTreeRenderer::ToString(const LogicalOperator &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string TextTreeRenderer::ToString(const PhysicalOperator &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string TextTreeRenderer::ToString(const ProfilingNode &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }
 
 string TextTreeRenderer::ToString(const Pipeline &op) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	Render(op, ss);
 	return ss.str();
 }

--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -19,7 +19,7 @@ namespace duckdb {
 
 void ReorderTableEntries(catalog_entry_vector_t &tables);
 
-using std::stringstream;
+using duckdb::stringstream;
 
 PhysicalExport::PhysicalExport(vector<LogicalType> types, CopyFunction function, unique_ptr<CopyInfo> info,
                                idx_t estimated_cardinality, unique_ptr<BoundExportData> exported_tables)

--- a/src/include/duckdb/common/hive_partitioning.hpp
+++ b/src/include/duckdb/common/hive_partitioning.hpp
@@ -15,9 +15,9 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/common/open_file_info.hpp"
+#include "duckdb/original/std/sstream.hpp"
 
 #include <iostream>
-#include <sstream>
 
 namespace duckdb {
 struct MultiFilePushdownInfo;

--- a/src/include/duckdb/common/shadow_forbidden_functions.hpp
+++ b/src/include/duckdb/common/shadow_forbidden_functions.hpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 
+#ifndef DUCKDB_CLANG_TIDY
 namespace std {
 template <class C>
 bool isspace(C c) {
@@ -26,9 +27,13 @@ static std::shared_ptr<T> make_shared(ARGS &&...__args) { // NOLINT: mimic std s
 }
 #endif // DUCKDB_ENABLE_DEPRECATED_API
 
+template <class charT, class traits = char_traits<charT>, class Allocator = allocator<charT>>
+class basic_stringstream_mock;
+
+typedef basic_stringstream_mock<char> stringstream;
+
 } // namespace std
 
-#ifndef DUCKDB_CLANG_TIDY
 using std::isspace;
 using std::make_shared;
 using std::make_unique;

--- a/src/include/duckdb/common/string.hpp
+++ b/src/include/duckdb/common/string.hpp
@@ -8,10 +8,33 @@
 
 #pragma once
 
-#include <sstream>
+#include "duckdb/original/std/sstream.hpp"
 #include <string>
+#include <locale>
 
 namespace duckdb {
 using std::string;
-using std::stringstream;
+} // namespace duckdb
+
+namespace duckdb {
+
+template <class charT, class traits = std::char_traits<charT>, class Allocator = std::allocator<charT>>
+class basic_stringstream : public duckdb_base_std::basic_stringstream<charT, traits, Allocator> {
+public:
+	using original = duckdb_base_std::basic_stringstream<charT, traits, Allocator>;
+
+	explicit basic_stringstream(std::ios_base::openmode which = std::ios_base::out | std::ios_base::in)
+	    : original(which) {
+		this->imbue(std::locale::classic());
+	}
+	explicit basic_stringstream(const std::basic_string<charT, traits, Allocator> &s,
+	                            std::ios_base::openmode which = std::ios_base::out | std::ios_base::in)
+	    : original(s, which) {
+		this->imbue(std::locale::classic());
+	}
+	basic_stringstream(const basic_stringstream &) = delete;
+	basic_stringstream(basic_stringstream &&rhs) noexcept;
+};
+
+typedef basic_stringstream<char> stringstream;
 } // namespace duckdb

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -312,7 +312,7 @@ string QueryProfiler::ToString(ProfilerPrintFormat format) const {
 			return "";
 		}
 		auto renderer = TreeRenderer::CreateRenderer(GetExplainFormat(format));
-		std::stringstream str;
+		duckdb::stringstream str;
 		auto &info = root->GetProfilingInfo();
 		if (info.Enabled(info.expanded_settings, MetricsType::OPERATOR_TIMING)) {
 			info.metrics[MetricsType::OPERATOR_TIMING] = main_query.Elapsed();
@@ -586,7 +586,7 @@ static string RenderTiming(double timing) {
 }
 
 string QueryProfiler::QueryTreeToString() const {
-	std::stringstream str;
+	duckdb::stringstream str;
 	QueryTreeToStream(str);
 	return str.str();
 }

--- a/src/parser/parsed_data/create_sequence_info.cpp
+++ b/src/parser/parsed_data/create_sequence_info.cpp
@@ -25,7 +25,7 @@ unique_ptr<CreateInfo> CreateSequenceInfo::Copy() const {
 }
 
 string CreateSequenceInfo::ToString() const {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	ss << "CREATE";
 	if (on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
 		ss << " OR REPLACE";

--- a/src/planner/logical_operator.cpp
+++ b/src/planner/logical_operator.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/planner/logical_operator.hpp"
 
+#include "duckdb/original/std/sstream.hpp"
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
@@ -126,7 +127,7 @@ vector<ColumnBinding> LogicalOperator::MapBindings(const vector<ColumnBinding> &
 
 string LogicalOperator::ToString(ExplainFormat format) const {
 	auto renderer = TreeRenderer::CreateRenderer(format);
-	stringstream ss;
+	duckdb::stringstream ss;
 	auto tree = RenderTree::CreateRenderTree(*this);
 	renderer->ToStream(*tree, ss);
 	return ss.str();

--- a/test/mbedtls/test_mbedtls.cpp
+++ b/test/mbedtls/test_mbedtls.cpp
@@ -11,7 +11,7 @@ using namespace std;
 
 static string file_to_string(string filename) {
 	std::ifstream stream(filename, ios_base::binary);
-	std::stringstream buffer;
+	duckdb::stringstream buffer;
 	buffer << stream.rdbuf();
 	return buffer.str();
 }

--- a/test/ossfuzz/test_ossfuzz.cpp
+++ b/test/ossfuzz/test_ossfuzz.cpp
@@ -20,7 +20,7 @@ static void test_runner() {
 	DuckDB db(nullptr);
 	Connection con(db);
 	std::ifstream t(file_name);
-	std::stringstream buffer;
+	duckdb::stringstream buffer;
 	buffer << t.rdbuf();
 	auto query = buffer.str();
 	result = con.Query(query.c_str());

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -18,6 +18,7 @@ namespace duckdb_base_std {
 	using ::std::unique_ptr;
 	using ::std::shared_ptr;
 	using ::std::make_shared;
+	using ::std::stringstream;
 } // namespace duckdb_base_std
 #endif
 // optional support for printing stacktraces on a crash -- using the backtrace support in DuckDB 
@@ -9120,7 +9121,8 @@ namespace detail {
 
     template<typename T>
     inline auto convertInto( std::string const &source, T& target ) -> ParserResult {
-        std::stringstream ss;
+        duckdb_base_std::stringstream ss;
+	ss.imbue(std::locale::classic());
         ss << source;
         ss >> target;
         if( ss.fail() )
@@ -11693,7 +11695,8 @@ namespace Floating {
 #endif
 
     std::string WithinUlpsMatcher::describe() const {
-        std::stringstream ret;
+        duckdb_base_std::stringstream ret;
+	ret.imbue(std::locale::classic());
 
         ret << "is within " << m_ulps << " ULPs of ";
 
@@ -12219,7 +12222,8 @@ namespace Catch {
     }
 
     std::string TempFile::getContents() {
-        std::stringstream sstr;
+        duckdb_base_std::stringstream sstr;
+	sstr.imbue(std::locale::classic());
         char buffer[100] = {};
         std::rewind(m_file);
         while (std::fgets(buffer, sizeof(buffer), m_file)) {

--- a/third_party/fmt/include/fmt/format.h
+++ b/third_party/fmt/include/fmt/format.h
@@ -34,6 +34,7 @@
 #define FMT_FORMAT_H_
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/original/std/memory.hpp"
 #include "fmt/core.h"
 
 #include <algorithm>

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -14,6 +14,7 @@
 #define CPPHTTPLIB_VERSION "0.14.3"
 
 #include "duckdb/original/std/memory.hpp"
+#include "duckdb/common/string.hpp"
 
 /*
  * Configuration
@@ -4872,7 +4873,7 @@ inline std::string message_digest(const std::string &s, const EVP_MD *algo) {
   EVP_DigestUpdate(context.get(), s.c_str(), s.size());
   EVP_DigestFinal_ex(context.get(), hash, &hash_length);
 
-  std::stringstream ss;
+  duckdb::stringstream ss;
   for (auto i = 0u; i < hash_length; ++i) {
     ss << std::hex << std::setw(2) << std::setfill('0')
        << static_cast<unsigned int>(hash[i]);
@@ -5040,7 +5041,7 @@ inline std::pair<std::string, std::string> make_digest_authentication_header(
     const std::string &password, bool is_proxy = false) {
   std::string nc;
   {
-    std::stringstream ss;
+    duckdb::stringstream ss;
     ss << std::setfill('0') << std::setw(8) << std::hex << cnonce_count;
     nc = ss.str();
   }
@@ -5967,7 +5968,7 @@ inline bool Server::write_response_core(Stream &strm, bool close_connection,
   if (close_connection || req.get_header_value("Connection") == "close") {
     res.set_header("Connection", "close");
   } else {
-    std::stringstream ss;
+    duckdb::stringstream ss;
     ss << "timeout=" << keep_alive_timeout_sec_
        << ", max=" << keep_alive_max_count_;
     res.set_header("Keep-Alive", ss.str());

--- a/tools/shell/linenoise/highlighting.cpp
+++ b/tools/shell/linenoise/highlighting.cpp
@@ -1,8 +1,8 @@
 #include "linenoise.hpp"
 #include "linenoise.h"
 #include "highlighting.hpp"
-#include <sstream>
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/common/string.hpp"
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 // disable highlighting on windows (for now?)
@@ -206,7 +206,7 @@ vector<highlightToken> Highlighting::Tokenize(char *buf, size_t len, bool is_dot
 
 string Highlighting::HighlightText(char *buf, size_t len, size_t start_pos, size_t end_pos,
                                    const vector<highlightToken> &tokens) {
-	std::stringstream ss;
+	duckdb::stringstream ss;
 	size_t prev_pos = 0;
 	for (size_t i = 0; i < tokens.size(); i++) {
 		size_t next = i + 1 < tokens.size() ? tokens[i + 1].start : len;


### PR DESCRIPTION
Improved version of https://github.com/duckdb/duckdb/pull/17807, using infrastructure from https://github.com/duckdb/duckdb/pull/17866 to check `std::stringstream` are not used anymore at compile time.

Original problem I had bumped in duckdb-wasm, where there would be some yet to be properly understood factor that would change the global static default locale to an unsupported one that would, via a SQL call to `duckdb_tables` end up calling a locale-influenced stringstream that would then throw.

Testing can also be done on native applying the following diff, yet to be added as testing mode
```diff
diff --git a/test/unittest.cpp b/test/unittest.cpp
index 1c04f9836b..a70847a2a6 100644
--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -30,6 +30,8 @@ int main(int argc, char *argv[]) {
        duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
        string test_directory = DUCKDB_ROOT_DIRECTORY;
 
+       std::locale::global(std::locale("ja_JP.SJIS"));
+
        int new_argc = 0;
        auto new_argv = duckdb::unique_ptr<char *[]>(new char *[argc]);
        for (int i = 0; i < argc; i++) {
```

Also cleans up comment from previous PR review at https://github.com/duckdb/duckdb/pull/17866#discussion_r2141787514

Note that other streams might (and will) have the same problems, so it would be handy to expand this further, here taking it one step further.