### PR TITLE
Fix mismatch between idx_t (64 bits) and size_t (implementation dependent)

### DIFF
--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -27,7 +27,7 @@ public:
 	JSONReadFunctionData(bool constant, string path_p, idx_t len, JSONCommon::JSONPathType path_type);
 	unique_ptr<FunctionData> Copy() const override;
 	bool Equals(const FunctionData &other_p) const override;
-	static JSONCommon::JSONPathType CheckPath(const Value &path_val, string &path, size_t &len);
+	static JSONCommon::JSONPathType CheckPath(const Value &path_val, string &path, idx_t &len);
 	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
 	                                     vector<unique_ptr<Expression>> &arguments);
 
@@ -36,12 +36,12 @@ public:
 	const string path;
 	const JSONCommon::JSONPathType path_type;
 	const char *ptr;
-	const size_t len;
+	const idx_t len;
 };
 
 struct JSONReadManyFunctionData : public FunctionData {
 public:
-	JSONReadManyFunctionData(vector<string> paths_p, vector<size_t> lens_p);
+	JSONReadManyFunctionData(vector<string> paths_p, vector<idx_t> lens_p);
 	unique_ptr<FunctionData> Copy() const override;
 	bool Equals(const FunctionData &other_p) const override;
 	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
@@ -50,7 +50,7 @@ public:
 public:
 	const vector<string> paths;
 	vector<const char *> ptrs;
-	const vector<size_t> lens;
+	const vector<idx_t> lens;
 };
 
 struct JSONFunctionLocalState : public FunctionLocalState {

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 using JSONPathType = JSONCommon::JSONPathType;
 
-JSONPathType JSONReadFunctionData::CheckPath(const Value &path_val, string &path, size_t &len) {
+JSONPathType JSONReadFunctionData::CheckPath(const Value &path_val, string &path, idx_t &len) {
 	if (path_val.IsNull()) {
 		throw BinderException("JSON path cannot be NULL");
 	}
@@ -60,7 +60,7 @@ unique_ptr<FunctionData> JSONReadFunctionData::Bind(ClientContext &context, Scal
 	D_ASSERT(bound_function.arguments.size() == 2);
 	bool constant = false;
 	string path;
-	size_t len = 0;
+	idx_t len = 0;
 	JSONPathType path_type = JSONPathType::REGULAR;
 	if (arguments[1]->IsFoldable()) {
 		const auto path_val = ExpressionExecutor::EvaluateScalar(context, *arguments[1]);
@@ -80,7 +80,7 @@ unique_ptr<FunctionData> JSONReadFunctionData::Bind(ClientContext &context, Scal
 	return make_uniq<JSONReadFunctionData>(constant, std::move(path), len, path_type);
 }
 
-JSONReadManyFunctionData::JSONReadManyFunctionData(vector<string> paths_p, vector<size_t> lens_p)
+JSONReadManyFunctionData::JSONReadManyFunctionData(vector<string> paths_p, vector<idx_t> lens_p)
     : paths(std::move(paths_p)), lens(std::move(lens_p)) {
 	for (const auto &path : paths) {
 		ptrs.push_back(path.c_str());
@@ -107,7 +107,7 @@ unique_ptr<FunctionData> JSONReadManyFunctionData::Bind(ClientContext &context, 
 	}
 
 	vector<string> paths;
-	vector<size_t> lens;
+	vector<idx_t> lens;
 	auto paths_val = ExpressionExecutor::EvaluateScalar(context, *arguments[1]);
 
 	for (auto &path_val : ListValue::GetChildren(paths_val)) {

--- a/extension/json/json_functions/json_table_in_out.cpp
+++ b/extension/json/json_functions/json_table_in_out.cpp
@@ -138,7 +138,7 @@ struct JSONTableInOutLocalState : LocalTableFunctionState {
 	yyjson_alc *alc;
 
 	string path;
-	size_t len;
+	idx_t len;
 	yyjson_doc *doc;
 	bool initialized;
 


### PR DESCRIPTION
I think this should be somehow trivial, solves a warning on duckdb-wasm (where size_t is 32 bits).