### PR TITLE
Add support for deserializing multiple json-serialized statements

### DIFF
--- a/extension/json/include/json_common.hpp
+++ b/extension/json/include/json_common.hpp
@@ -360,4 +360,23 @@ inline char *JSONCommon::WriteVal(yyjson_mut_val *val, yyjson_alc *alc, idx_t &l
 	return yyjson_mut_val_write_opts(val, JSONCommon::WRITE_FLAG, alc, reinterpret_cast<size_t *>(&len), nullptr);
 }
 
+struct yyjson_doc_deleter {
+	void operator()(yyjson_doc *doc) {
+		if (doc) {
+			yyjson_doc_free(doc);
+		}
+	}
+};
+
+struct yyjson_mut_doc_deleter {
+	void operator()(yyjson_mut_doc *doc) {
+		if (doc) {
+			yyjson_mut_doc_free(doc);
+		}
+	}
+};
+
+using yyjson_doc_ptr = unique_ptr<yyjson_doc, yyjson_doc_deleter>;
+using yyjson_mut_doc_ptr = unique_ptr<yyjson_mut_doc, yyjson_mut_doc_deleter>;
+
 } // namespace duckdb

--- a/extension/json/include/json_deserializer.hpp
+++ b/extension/json/include/json_deserializer.hpp
@@ -6,12 +6,9 @@ namespace duckdb {
 
 class JsonDeserializer : public Deserializer {
 public:
-	JsonDeserializer(yyjson_val *val, yyjson_doc *doc) : doc(doc) {
+	JsonDeserializer(yyjson_val *val, const yyjson_doc_ptr &doc) : doc(doc.get()) {
 		deserialize_enum_from_string = true;
 		stack.emplace_back(val);
-	}
-	~JsonDeserializer() {
-		yyjson_doc_free(doc);
 	}
 
 private:

--- a/test/sql/json/test_json_serialize_sql.test
+++ b/test/sql/json/test_json_serialize_sql.test
@@ -105,3 +105,9 @@ statement error
 SELECT * FROM json_execute_serialized_sql('{ "statements": [ {"expression_class": "BOUND_COMPARISON"}]}');
 ----
 Parser Error: Error parsing json: no select node found in json
+
+# Test execute json serialized sql with multiple select nodes
+query I
+SELECT json_deserialize_sql(json_serialize_sql('SELECT 1;SELECT 2'));
+----
+SELECT 1; SELECT 2


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/17887

The `JsonDeserializer` no longer takes ownership of the yyjson_doc, and I've changed the constructor to take a const reference to an owning pointer to make this change explicit. 