### PR TITLE
Add v1.3-ossivalis to Cross version workflow

### DIFF
--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -83,7 +83,7 @@ jobs:
       - linux-step-1
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -236,7 +236,7 @@ jobs:
       - linux-step-1
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -19,7 +19,7 @@ on:
       - '!.github/workflows/CrossVersion.yml'
 
 concurrency:
-  group: cross-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
+  group: crossversion-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3-ossivalis', 'main' ]
       fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
@@ -91,7 +91,7 @@ jobs:
       - linux-step-1
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3-ossivalis', 'main' ]
       fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
@@ -140,10 +140,6 @@ jobs:
           path: osx_v1_2_1
       - uses: actions/download-artifact@v4
         with:
-          name: files-osx-v1.2-histrionicus
-          path: osx_v1_2-histrionicus
-      - uses: actions/download-artifact@v4
-        with:
           name: files-osx-v1.3-ossivalis
           path: osx_v1_3-ossivalis
       - uses: actions/download-artifact@v4
@@ -162,10 +158,6 @@ jobs:
         with:
           name: files-linux-v1.2.1
           path: linux_v1_2_1
-      - uses: actions/download-artifact@v4
-        with:
-          name: files-linux-v1.2-histrionicus
-          path: linux_v1_2-histrionicus
       - uses: actions/download-artifact@v4
         with:
           name: files-linux-v1.3-ossivalis
@@ -197,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3-ossivalis', 'main' ]
       fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
@@ -254,7 +246,7 @@ jobs:
       - linux-step-1
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3-ossivalis', 'main' ]
       fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
@@ -304,10 +296,6 @@ jobs:
           path: osx_v1_2_1
       - uses: actions/download-artifact@v4
         with:
-          name: files-osx-v1.2-histrionicus
-          path: osx_v1_2-histrionicus
-      - uses: actions/download-artifact@v4
-        with:
           name: files-osx-v1.3-ossivalis
           path: osx_v1_3-ossivalis
       - uses: actions/download-artifact@v4
@@ -328,10 +316,6 @@ jobs:
           path: linux_v1_2_1
       - uses: actions/download-artifact@v4
         with:
-          name: files-linux-v1.2-histrionicus
-          path: linux_v1_2-histrionicus
-      - uses: actions/download-artifact@v4
-        with:
           name: files-linux-v1.3-ossivalis
           path: linux_v1_3-ossivalis
       - uses: actions/download-artifact@v4
@@ -343,7 +327,7 @@ jobs:
         shell: bash
         run: |
           touch report
-          for folder in osx_v1_0_0 osx_v1_1_3 osx_main linux_main linux_v1_0_0 linux_v1_1_3 linux_v1_2_1 linux_v1_2 osx_v1_2_1 osx_v1_2; do
+          for folder in osx_v1_0_0 osx_v1_1_3 osx_main osx_v1_3-ossivalis linux_main linux_v1_3-ossivalis linux_v1_0_0 linux_v1_1_3 linux_v1_2_1 linux_v1_2 osx_v1_2_1 osx_v1_2; do
             for filename in $folder/*; do
               touch $filename.wal && cp $filename.wal a.db.wal 2>/dev/null && cp $filename a.db 2>/dev/null && (./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out || (grep "but it is not a valid DuckDB database file!" out 2>/dev/null || ( echo "--> " $filename && cat out && echo "" && (grep -i "internal error" out && echo "--> " $filename >> report && cat out >> report && echo "" >> report)))) || true
               rm -f b.db a.db b.db.wal a.db.wal

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.2', 'v1.3-ossivalis', 'main' ]
       fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
@@ -88,7 +88,7 @@ jobs:
       - linux-step-1
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.2', 'v1.3-ossivalis', 'main' ]
       fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
@@ -133,7 +133,7 @@ jobs:
           path: osx_v1_1_3
       - uses: actions/download-artifact@v4
         with:
-          name: files-osx-v1.2.1
+          name: files-osx-v1.2.2
           path: osx_v1_2_1
       - uses: actions/download-artifact@v4
         with:
@@ -153,7 +153,7 @@ jobs:
           path: linux_v1_1_3
       - uses: actions/download-artifact@v4
         with:
-          name: files-linux-v1.2.1
+          name: files-linux-v1.2.2
           path: linux_v1_2_1
       - uses: actions/download-artifact@v4
         with:
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.2', 'v1.3-ossivalis', 'main' ]
       fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
@@ -243,7 +243,7 @@ jobs:
       - linux-step-1
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.2', 'v1.3-ossivalis', 'main' ]
       fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
@@ -289,7 +289,7 @@ jobs:
           path: osx_v1_1_3
       - uses: actions/download-artifact@v4
         with:
-          name: files-osx-v1.2.1
+          name: files-osx-v1.2.2
           path: osx_v1_2_1
       - uses: actions/download-artifact@v4
         with:
@@ -309,7 +309,7 @@ jobs:
           path: linux_v1_1_3
       - uses: actions/download-artifact@v4
         with:
-          name: files-linux-v1.2.1
+          name: files-linux-v1.2.2
           path: linux_v1_2_1
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -83,7 +83,7 @@ jobs:
       - linux-step-1
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -135,6 +135,10 @@ jobs:
           path: osx_v1_2-histrionicus
       - uses: actions/download-artifact@v4
         with:
+          name: files-osx-v1.3-ossivalis
+          path: osx_v1_3-ossivalis
+      - uses: actions/download-artifact@v4
+        with:
           name: files-osx-main
           path: osx_main
       - uses: actions/download-artifact@v4
@@ -153,6 +157,10 @@ jobs:
         with:
           name: files-linux-v1.2-histrionicus
           path: linux_v1_2-histrionicus
+      - uses: actions/download-artifact@v4
+        with:
+          name: files-linux-v1.3-ossivalis
+          path: linux_v1_3-ossivalis
       - uses: actions/download-artifact@v4
         with:
           name: files-linux-main
@@ -180,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -236,7 +244,7 @@ jobs:
       - linux-step-1
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -285,10 +293,6 @@ jobs:
           path: osx_v1_2_1
       - uses: actions/download-artifact@v4
         with:
-          name: files-osx-v1.3.1
-          path: osx_v1_3_1
-      - uses: actions/download-artifact@v4
-        with:
           name: files-osx-v1.2-histrionicus
           path: osx_v1_2-histrionicus
       - uses: actions/download-artifact@v4
@@ -313,10 +317,6 @@ jobs:
           path: linux_v1_2_1
       - uses: actions/download-artifact@v4
         with:
-          name: files-linux-v1.3.1
-          path: linux_v1_3_1
-      - uses: actions/download-artifact@v4
-        with:
           name: files-linux-v1.2-histrionicus
           path: linux_v1_2-histrionicus
       - uses: actions/download-artifact@v4
@@ -332,7 +332,7 @@ jobs:
         shell: bash
         run: |
           touch report
-          for folder in osx_v1_0_0 osx_v1_1_3 osx_main linux_main linux_v1_0_0 linux_v1_1_3 linux_v1_2_1 linux_v1_2 linux_v1_3_1 osx_v1_2_1 osx_v1_2 osx_v1_3_1; do
+          for folder in osx_v1_0_0 osx_v1_1_3 osx_main linux_main linux_v1_0_0 linux_v1_1_3 linux_v1_2_1 linux_v1_2 osx_v1_2_1 osx_v1_2; do
             for filename in $folder/*; do
               touch $filename.wal && cp $filename.wal a.db.wal 2>/dev/null && cp $filename a.db 2>/dev/null && (./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out || (grep "but it is not a valid DuckDB database file!" out 2>/dev/null || ( echo "--> " $filename && cat out && echo "" && (grep -i "internal error" out && echo "--> " $filename >> report && cat out >> report && echo "" >> report)))) || true
               rm -f b.db a.db b.db.wal a.db.wal

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: files-osx-v1.2.2
-          path: osx_v1_2_1
+          path: osx_v1_2_2
       - uses: actions/download-artifact@v4
         with:
           name: files-osx-v1.3-ossivalis
@@ -154,7 +154,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: files-linux-v1.2.2
-          path: linux_v1_2_1
+          path: linux_v1_2_2
       - uses: actions/download-artifact@v4
         with:
           name: files-linux-v1.3-ossivalis
@@ -168,7 +168,7 @@ jobs:
         shell: bash
         run: |
           touch report
-          for folder in osx_v1_0_0 osx_v1_1_3 osx_main linux_main linux_v1_0_0 linux_v1_1_3 linux_v1_2_1 linux_v1_2 osx_v1_2_1 osx_v1_2; do
+          for folder in osx_v1_0_0 osx_v1_1_3 osx_main linux_main linux_v1_0_0 linux_v1_1_3 linux_v1_2_2 linux_v1_2 osx_v1_2_2 osx_v1_2; do
             for filename in $folder/*; do
               touch $filename.wal && cp $filename.wal a.db.wal 2>/dev/null && cp $filename a.db 2>/dev/null && (./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out || (grep "but it is not a valid DuckDB database file!" out 2>/dev/null || ( echo "--> " $filename && cat out && echo "" && (grep -i "internal error" out && echo "--> " $filename >> report && cat out >> report && echo "" >> report)))) || true
               rm -f b.db a.db b.db.wal a.db.wal
@@ -290,7 +290,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: files-osx-v1.2.2
-          path: osx_v1_2_1
+          path: osx_v1_2_2
       - uses: actions/download-artifact@v4
         with:
           name: files-osx-v1.3-ossivalis
@@ -310,7 +310,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: files-linux-v1.2.2
-          path: linux_v1_2_1
+          path: linux_v1_2_2
       - uses: actions/download-artifact@v4
         with:
           name: files-linux-v1.3-ossivalis
@@ -324,7 +324,7 @@ jobs:
         shell: bash
         run: |
           touch report
-          for folder in osx_v1_0_0 osx_v1_1_3 osx_main osx_v1_3-ossivalis linux_main linux_v1_3-ossivalis linux_v1_0_0 linux_v1_1_3 linux_v1_2_1 linux_v1_2 osx_v1_2_1 osx_v1_2; do
+          for folder in osx_v1_0_0 osx_v1_1_3 osx_main osx_v1_3-ossivalis linux_main linux_v1_3-ossivalis linux_v1_0_0 linux_v1_1_3 linux_v1_2_2 linux_v1_2 osx_v1_2_2 osx_v1_2; do
             for filename in $folder/*; do
               touch $filename.wal && cp $filename.wal a.db.wal 2>/dev/null && cp $filename a.db 2>/dev/null && (./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out || (grep "but it is not a valid DuckDB database file!" out 2>/dev/null || ( echo "--> " $filename && cat out && echo "" && (grep -i "internal error" out && echo "--> " $filename >> report && cat out >> report && echo "" >> report)))) || true
               rm -f b.db a.db b.db.wal a.db.wal

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -22,9 +22,6 @@ concurrency:
   group: crossversion-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -22,6 +22,9 @@ concurrency:
   group: crossversion-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -18,6 +18,10 @@ on:
       - '**'
       - '!.github/workflows/CrossVersion.yml'
 
+concurrency:
+  group: cross-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
+  cancel-in-progress: true
+
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -29,6 +33,7 @@ jobs:
     strategy:
       matrix:
         version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+      fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -84,6 +89,7 @@ jobs:
     strategy:
       matrix:
         version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+      fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -189,6 +195,7 @@ jobs:
     strategy:
       matrix:
         version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+      fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -245,6 +252,7 @@ jobs:
     strategy:
       matrix:
         version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+      fail-fast: false
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -83,7 +83,7 @@ jobs:
       - linux-step-1
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -236,7 +236,7 @@ jobs:
       - linux-step-1
     strategy:
       matrix:
-        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
+        version: [ 'v1.0.0', 'v1.1.3', 'v1.2.1', 'v1.3.1', 'v1.2-histrionicus', 'v1.3-ossivalis', 'main' ]
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -285,8 +285,16 @@ jobs:
           path: osx_v1_2_1
       - uses: actions/download-artifact@v4
         with:
+          name: files-osx-v1.3.1
+          path: osx_v1_3_1
+      - uses: actions/download-artifact@v4
+        with:
           name: files-osx-v1.2-histrionicus
           path: osx_v1_2-histrionicus
+      - uses: actions/download-artifact@v4
+        with:
+          name: files-osx-v1.3-ossivalis
+          path: osx_v1_3-ossivalis
       - uses: actions/download-artifact@v4
         with:
           name: files-osx-main
@@ -305,8 +313,16 @@ jobs:
           path: linux_v1_2_1
       - uses: actions/download-artifact@v4
         with:
+          name: files-linux-v1.3.1
+          path: linux_v1_3_1
+      - uses: actions/download-artifact@v4
+        with:
           name: files-linux-v1.2-histrionicus
           path: linux_v1_2-histrionicus
+      - uses: actions/download-artifact@v4
+        with:
+          name: files-linux-v1.3-ossivalis
+          path: linux_v1_3-ossivalis
       - uses: actions/download-artifact@v4
         with:
           name: files-linux-main
@@ -316,7 +332,7 @@ jobs:
         shell: bash
         run: |
           touch report
-          for folder in osx_v1_0_0 osx_v1_1_3 osx_main linux_main linux_v1_0_0 linux_v1_1_3 linux_v1_2_1 linux_v1_2 osx_v1_2_1 osx_v1_2; do
+          for folder in osx_v1_0_0 osx_v1_1_3 osx_main linux_main linux_v1_0_0 linux_v1_1_3 linux_v1_2_1 linux_v1_2 linux_v1_3_1 osx_v1_2_1 osx_v1_2 osx_v1_3_1; do
             for filename in $folder/*; do
               touch $filename.wal && cp $filename.wal a.db.wal 2>/dev/null && cp $filename a.db 2>/dev/null && (./build/release/duckdb a.db -c "ATTACH 'b.db'; COPY FROM DATABASE a TO b;" 2>out || (grep "but it is not a valid DuckDB database file!" out 2>/dev/null || ( echo "--> " $filename && cat out && echo "" && (grep -i "internal error" out && echo "--> " $filename >> report && cat out >> report && echo "" >> report)))) || true
               rm -f b.db a.db b.db.wal a.db.wal


### PR DESCRIPTION
I was adding a `SUMMARIZE_FAILURES` env variable into the steps running unit tests without python runner and found that `v1.3-ossivalis` is not present in the versions matrix of this workflow. Probably we'd like to have it in test matrix of `CrossVersion.yml`.

This PR adds `v1.3-ossivalis` into the test matrix, adds a concurrency group ~~and read permission (which [recommended](https://github.com/actions/checkout?tab=readme-ov-file#recommended-permissions) to set when using action/checkout)~~.