### PR TITLE
Enable Test extension (inside docker) step in build_extensions_dockerized

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -4,10 +4,10 @@ inputs:
   # Test config
   run_tests:
     description: 'Run extension tests after build'
-    default: 1
+    default: '1'
   run_autoload_tests:
     description: 'Runs the autoloading tests'
-    default: 1
+    default: '1'
 
   # Deploy config
   deploy_as:
@@ -32,19 +32,19 @@ inputs:
     default: ''
   static_link_build:
     description: 'Links DuckDB statically to the loadable extensions'
-    default: 1
+    default: '1'
   no_static_linking:
     description: 'Disables linking extensions into DuckDB for testing'
-    default: 0
+    default: '0'
   vcpkg_build:
     description: 'Installs vcpkg and pass its toolchain to CMakes'
-    default: 1
+    default: '1'
   build_dir:
     description: 'DuckDB source directory to run the build in'
     default: '.'
   ninja:
     description: 'Use ninja for building'
-    default: 0
+    default: '0'
   openssl_path:
     description: 'Directory of OpenSSL installation'
     default: ''
@@ -53,28 +53,28 @@ inputs:
     default: ''
   treat_warn_as_error:
     description: 'Treat compilation warnings as errors'
-    default: 1
+    default: '1'
   build_in_tree_extensions:
     description: 'Build in-tree extensions'
-    default: 1
+    default: '1'
   build_out_of_tree_extensions:
     description: 'Build out-of-tree extensions'
-    default: 1
+    default: '1'
   build_complete_extensions_set:
     description: 'Whether all extensions needs to be built'
-    default: 1
+    default: '1'
   bundle_static_lib_mode:
     description: 'Build the default bundled extensions to publish the static libs'
-    default: 0
+    default: '0'
   osx_universal:
     description: 'Build Universal Binary for OSX'
-    default: 0
+    default: '0'
   osx_arch:
     description: 'Build specific architecture for OSX'
     default: ''
   aarch64_cross_compile:
     description: 'Enable Linux aarch64 cross-compiling'
-    default: 0
+    default: '0'
   vcpkg_target_triplet:
     description: 'Target triplet for installing vcpkg dependencies'
     default: ''
@@ -103,13 +103,13 @@ runs:
         echo "EXTENSION_CONFIGS=$EXTENSION_CONFIGS" >> $GITHUB_ENV
 
     - name: Setup vcpkg
-      if: inputs.vcpkg_build == 1
+      if: ${{ inputs.vcpkg_build == 1 }}
       uses: lukka/run-vcpkg@v11.1
       with:
         vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
 
     - name: Set vcpkg env variables
-      if: inputs.vcpkg_build == 1
+      if: ${{ inputs.vcpkg_build == 1 }}
       shell: bash
       run: |
         echo "VCPKG_TOOLCHAIN_PATH=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
@@ -134,7 +134,7 @@ runs:
         echo "OPENSSL_ROOT_DIR=${{ inputs.openssl_path }}" >> $GITHUB_ENV
 
     - name: Create combined vcpkg manifest
-      if: inputs.vcpkg_build == 1 && inputs.build_out_of_tree_extensions == 1
+      if: ${{ inputs.vcpkg_build == '1' && inputs.build_out_of_tree_extensions == '1' }}
       shell: bash
       run: |
         make extension_configuration
@@ -174,7 +174,7 @@ runs:
     # - statically linked extensions are disable on startup but a sqlogictest require will call their load function
     # - loadable-only extensions have their loadable extension loaded with the LOAD statement on a sqlogictest require
     - name: Test statically linked extensions
-      if: ${{ inputs.run_tests == 1 && inputs.no_static_linking == 0}}
+      if: ${{ inputs.run_tests == '1' && inputs.no_static_linking == '0' }}
       shell: bash
       run: |
         ${{ inputs.unittest_script }}
@@ -184,19 +184,19 @@ runs:
       shell: bash
       run: |
         ls
-        cd  ${{ inputs.build_dir}}
+        cd  ${{ inputs.build_dir }}
         ${{ inputs.post_install }}
 
     # The reason we need to rebuild is we need to test auto-loading extensions: this is only possible without the other
     # extensions linked
     - name: Rebuild DuckDB without any extensions, but with all extension tests
-      if: ${{ inputs.run_autoload_tests == 1 }}
+      if: ${{ inputs.run_autoload_tests == '1' }}
       shell: bash
       env:
         EXTENSION_TESTS_ONLY: 1
         ENABLE_EXTENSION_AUTOLOADING: 1
         ENABLE_EXTENSION_AUTOINSTALL: 1
-        GEN: ${{ inputs.ninja == 1 && 'ninja' || '' }}
+        GEN: ${{ inputs.ninja == '1' && 'ninja' || '' }}
         USE_MERGED_VCPKG_MANIFEST: 1
       run: |
         cd  ${{ inputs.build_dir}}
@@ -207,10 +207,10 @@ runs:
 
     # Run all unittests (including the out-of-tree tests) without any extensions linked, relying on the autoloader
     - name: Run tests with auto loading
-      if: ${{ inputs.run_autoload_tests == 1 }}
+      if: ${{ inputs.run_autoload_tests == '1' }}
       shell: bash
       env:
-        LOCAL_EXTENSION_REPO: ${{ inputs.run_autoload_tests == 1 && github.workspace || ''}}
+        LOCAL_EXTENSION_REPO: ${{ inputs.run_autoload_tests == '1' && github.workspace || ''}}
       run: |
         cd  ${{ inputs.build_dir}}
         python3 scripts/get_test_list.py --file-contains 'require ' --list '"*.test"' > test.list

--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -16,10 +16,10 @@ inputs:
     default: ''
   build_complete_extensions_set:
     description: 'Whether all extensions needs to be built'
-    default: 1
+    default: '1'
   save_cache:
     description: 'Should cache be saved'
-    default: 1
+    default: '1'
 
 runs:
   using: "composite"
@@ -100,7 +100,7 @@ runs:
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ inputs.duckdb_arch }} make release
 
       - name: Save Ccache
-        if: ${{ inputs.save_cache }}
+        if: ${{ inputs.save_cache == '1' }}
         uses: actions/cache/save@v4
         with:
           path: ./ccache_dir

--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -4,7 +4,7 @@ inputs:
   # Build config
   run_tests:
     description: 'Run extension tests after build'
-    default: 1
+    default: '1'
   duckdb_arch:
     description: 'Provide DUCKDB_PLATFORM to build system for cross compilation'
     default: ''
@@ -108,6 +108,6 @@ runs:
 
       - name: Test extension (inside docker)
         shell: bash
-        if: ${{ inputs.run_tests == 1 }}
+        if: ${{ inputs.run_tests == '1' && inputs.duckdb_arch != 'linux_arm64'}}
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ inputs.duckdb_arch }} make test_release

--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -4,7 +4,7 @@ inputs:
   # Build config
   run_tests:
     description: 'Run extension tests after build'
-    default: '1'
+    default: 'true'
   duckdb_arch:
     description: 'Provide DUCKDB_PLATFORM to build system for cross compilation'
     default: ''
@@ -108,6 +108,6 @@ runs:
 
       - name: Test extension (inside docker)
         shell: bash
-        if: ${{ inputs.run_tests == '1' && inputs.duckdb_arch != 'linux_arm64'}}
+        if: ${{ inputs.run_tests == 'true' && inputs.duckdb_arch != 'linux_arm64'}}
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ inputs.duckdb_arch }} make test_release

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -36,6 +36,7 @@ endif()
 if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(aws
             ### TODO: re-enable LOAD_TESTS
+            LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
             GIT_TAG 4f318ebd088e464266c511abe2f70bbdeee2fcd8
             )
@@ -90,6 +91,7 @@ endif()
 if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
+           ${LOAD_ICEBERG_TESTS}
             GIT_URL https://github.com/duckdb/duckdb-iceberg
             GIT_TAG 24dd874bee165661f6c3c79ee2a823f02941ed94
             )

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -61,6 +61,7 @@ profile = args.profile
 assertions = args.no_assertions
 time_execution = args.time_execution
 timeout = args.timeout
+tests_per_invocation = args.tests_per_invocation
 
 # Use the '-l' parameter to output the list of tests to run
 proc = subprocess.run([unittest_program, '-l'] + extra_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
This is a replacement of the pr https://github.com/duckdb/duckdb/pull/17721 rebased with v1.3-ossivalis and added a fix of Save Cache step suggested by @carlopi 


Copied from the original pr:
`Test extension (inside docker)` step couldn't run on [Linux Extensions (x64) (linux_amd64, x64-linux)](https://github.com/duckdb/duckdb/compare/main...hmeriann:duckdb:increase-testing-around-extensions?expand=1#logs). Most likely it go skipped because the `inputs.run_tests` was expecting a different input, but got default boolean value 1 in it's `if:` condition:
https://github.com/duckdb/duckdb/blob/05acd1e7c5f45c7a6aa913e4d7db8ee1cbec49b3/.github/actions/build_extensions_dockerized/action.yml#L7
and later uses it like this:
https://github.com/duckdb/duckdb/blob/05acd1e7c5f45c7a6aa913e4d7db8ee1cbec49b3/.github/actions/build_extensions_dockerized/action.yml#L101

`LinuxRelease.yml` passes a value `true` which is not evaluated by GH Actions as a boolean value, but as a string:
https://github.com/duckdb/duckdb/blob/05acd1e7c5f45c7a6aa913e4d7db8ee1cbec49b3/.github/workflows/LinuxRelease.yml#L153

This PR changes the condition to run tests and also enables `LOAD_TESTS` for `aws` and `iceberg`