### PR TITLE
Make sure distance is always an int when doing version bumps in setup.py

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -35,6 +35,9 @@ def bump_version(base_version: str, distance: int, dirty: bool = False):
 
     major, minor, patch = map(int, base_version_match.groups())
 
+    # Make sure distance is set correctly
+    distance = int(distance or 0)
+
     # If we're exactly on a tag (distance = 0, dirty=False)
     if distance == 0 and not dirty:
         return f"{major}.{minor}.{patch}"


### PR DESCRIPTION
Fix for https://github.com/duckdblabs/duckdb-internal/issues/5121