### PR TITLE
fix use after free in adbc on invalid stmt

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -914,8 +914,8 @@ AdbcStatusCode StatementSetSqlQuery(struct AdbcStatement *statement, const char 
 	auto error_msg_extract_statements = duckdb_extract_statements_error(extracted_statements);
 	if (error_msg_extract_statements != nullptr) {
 		// Things went wrong when executing internal prepared statement
-		duckdb_destroy_extracted(&extracted_statements);
 		SetError(error, error_msg_extract_statements);
+		duckdb_destroy_extracted(&extracted_statements);
 		return ADBC_STATUS_INTERNAL;
 	}
 	// Now lets loop over the statements, and execute every one


### PR DESCRIPTION
👋 

Right now DuckDB ADBC driver returns "garbage" error messages like `40 40 11 5b d4 d8 00` on invalid statements like "select" (instead of the expected "Parser Error: SELECT clause without selection list") because it seems to free the actual error message before setting it into the ADBC error struct.