### PR TITLE
Fix empty BP block when writing parquet

### DIFF
--- a/extension/parquet/include/parquet_rle_bp_encoder.hpp
+++ b/extension/parquet/include/parquet_rle_bp_encoder.hpp
@@ -142,6 +142,9 @@ private:
 	}
 
 	void WriteCurrentBlockBP(WriteStream &writer) {
+		if (bp_block_count == 0) {
+			return;
+		}
 		ParquetDecodeUtils::VarintEncode(BP_BLOCK_SIZE / 8 << 1 | 1, writer); // (... | 1) signals BP run
 		ParquetDecodeUtils::BitPackAligned(bp_block, data_ptr_cast(bp_block_packed), BP_BLOCK_SIZE, bit_width);
 		writer.WriteData(data_ptr_cast(bp_block_packed), BP_BLOCK_SIZE * bit_width / 8);


### PR DESCRIPTION
In rare circumstances, duckdb will write an empty bit-packed block when writing a parquet file. This PR fixes #17926

At the end of a `RleBpEncoder` run, `FinishWrite` gets called. And in rare cases, this results in `WriteCurrentBlockBP` being called with `bp_block_count = 0`. In other words, it writes an empty BP block for no reason! 33 wasted bytes.

99% of the time this doesn't happen. I did some debugging and found that it happens when the previously written BP block was _exactly_ 256 entries, and then `FinishRun` gets called. There are no more entries left to write, but `WriteCurrentBlockBP` still gets called.

This PR simply adds a check for `bp_block_count == 0` and returns if so.
