### PR TITLE
Rename imdb library to follow libduckdb_x naming convention

### DIFF
--- a/third_party/imdb/CMakeLists.txt
+++ b/third_party/imdb/CMakeLists.txt
@@ -4,11 +4,11 @@ if(POLICY CMP0063)
     cmake_policy(SET CMP0063 NEW)
 endif()
 
-project(imdb CXX)
+project(duckdb_imdb CXX)
 
 include_directories(include)
 
 set(CMAKE_BUILD_TYPE "Release")
-add_library(imdb STATIC imdb.cpp ${ALL_OBJECT_FILES})
+add_library(duckdb_imdb STATIC imdb.cpp ${ALL_OBJECT_FILES})
 
-disable_target_warnings(imdb)
+disable_target_warnings(duckdb_imdb)


### PR DESCRIPTION
This PR renames the imdb library target to duckdb_imdb to align with the naming convention used across DuckDB's third-party libraries (e.g., libduckdb_re2.a, libduckdb_zstd.a). This improves consistency in the codebase.

No other dependencies or source references required modification, as the target was isolated within its own CMake configuration.