### PR TITLE
[chore] Skip 2 tests in autoloading mode (parquet + ZSTD) plus improve error message

### DIFF
--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -41,6 +41,11 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 	} else if (compression != FileCompressionType::UNCOMPRESSED) {
 		auto entry = compressed_fs.find(compression);
 		if (entry == compressed_fs.end()) {
+			if (compression == FileCompressionType::ZSTD) {
+				throw NotImplementedException(
+				    "Attempting to open a compressed file, but the compression type is not supported.\nConsider "
+				    "explicitly \"INSTALL parquet; LOAD parquet;\" to support this compression scheme");
+			}
 			throw NotImplementedException(
 			    "Attempting to open a compressed file, but the compression type is not supported");
 		}

--- a/test/sql/copy/csv/csv_write_zstd.test_slow
+++ b/test/sql/copy/csv/csv_write_zstd.test_slow
@@ -4,6 +4,8 @@
 
 require parquet
 
+require no_extension_autoloading "FIXME: Autoloading on zstd compression (parquet) not yet there"
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/json/test_json_copy.test_slow
+++ b/test/sql/json/test_json_copy.test_slow
@@ -4,6 +4,10 @@
 
 require json
 
+require parquet
+
+require no_extension_autoloading "FIXME: Autoloading on zstd compression (parquet) not yet there"
+
 # test automatic detection even with .gz
 statement ok
 create table integers as select 42 i


### PR DESCRIPTION
Very minor, given `parquet` is basically always statically linked in.

This points users to `INSTALL parquet; LOAD parquet;` in the cases such as duckdb-wasm where that's not linked in.

Actual autoloading would be arguably better, but a bit too minor and I didn't had a clear path.