### PR TITLE
Do not dispatch JDBC/ODBC jobs in release CI runs

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -130,6 +130,7 @@ jobs:
       duckdb-sha: ${{ github.sha }}
       triggering-event: ${{ github.event_name }}
       should-publish: 'true'
+      override-git-describe: ${{ inputs.override_git_describe }}
 
   notify-specific-branch-on-external-repos:
     uses: ./.github/workflows/NotifyExternalRepositories.yml
@@ -142,3 +143,4 @@ jobs:
       duckdb-sha: ${{ github.sha }}
       triggering-event: ${{ github.event_name }}
       should-publish: 'true'
+      override-git-describe: ${{ inputs.override_git_describe }}

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -24,6 +24,11 @@ on:
         description: 'True, if all the builds in InvokeCI had succeeded'
         default: 'false'
         type: 'string'
+      override-git-describe:
+        description: 'The name of the release tag, used for release builds'
+        required: false
+        default: ''
+        type: string
   workflow_dispatch:
     inputs:
       duckdb-sha:
@@ -48,6 +53,11 @@ on:
         description: 'True, if all the builds in InvokeCI had succeeded'
         default: 'false'
         type: 'string'
+      override-git-describe:
+        description: 'The name of the release tag, used for release builds'
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -57,7 +67,7 @@ jobs:
   notify-odbc-run:
     name: Run ODBC Vendor
     runs-on: ubuntu-latest
-    if: ${{ inputs.is-success == 'true' }}
+    if: ${{ inputs.is-success == 'true' && inputs.override-git-describe == '' }}
     env:
       PAT_USER: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
@@ -72,7 +82,7 @@ jobs:
   notify-jdbc-run:
     name: Run JDBC Vendor
     runs-on: ubuntu-latest
-    if: ${{ inputs.is-success == 'true' }}
+    if: ${{ inputs.is-success == 'true' && inputs.override-git-describe == '' }}
     env:
       PAT_USER: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
`InvokeCI.yml` is triggered in a different mode for building stuff for releases: there is an override version that is logically equivalent of running `git tag vx.x.x` during the build.

For JDBC and ODBC releases it is expected that engine sources import job is run manually (a step added to both JDBC and ODBC release instructions). Thus the JDBC/ODBC jobs dispatched by `InvokeCI.yml` are not prepared to handle `OVERRIDE_GIT_DESCRIBE`, so version macros in `pragma_version.cpp` are generated incorrectly (should not have `-dev` suffix for releases) and these jobs fail on extensions load check like this:

```
The file was built specifically for DuckDB version 'v1.3.1' and can only
be loaded with that version of DuckDB.
(this version of DuckDB is '2063dda3e6')
```

Where `2063dda3e6` is the correct revision for the prospective `v1.3.1` engine tag, but the tag itself does not yet exist at the time of the run.

It is possible to add support for `OVERRIDE_GIT_DESCRIBE` to JDBC/ODBC import jobs, but the import logic lives in the `package_build.py` in the engine (in the same source tree that is being imported), so it gives very little control over this logic (the script is fixed for the release tag - cannot be easily updated from JDBC/ODBC side if micro-update is requred).

Thus this change is proposed to add a check to `NotifyExternalRepositories.yml` to not dispatch JDBC/ODBC jobs automatically for release builds.