### PR TITLE
[Fix] Reset profiling info before preparing a query

### DIFF
--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -146,7 +146,7 @@ public:
 
 	DUCKDB_API static QueryProfiler &Get(ClientContext &context);
 
-	DUCKDB_API void Start(string query);
+	DUCKDB_API void Start(const string &query);
 	DUCKDB_API void Reset();
 	DUCKDB_API void StartQuery(const string &query, bool is_explain_analyze = false, bool start_at_optimizer = false);
 	DUCKDB_API void EndQuery();

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -146,6 +146,7 @@ public:
 
 	DUCKDB_API static QueryProfiler &Get(ClientContext &context);
 
+	DUCKDB_API void Reset(const bool running_p, string query = "");
 	DUCKDB_API void StartQuery(string query, bool is_explain_analyze = false, bool start_at_optimizer = false);
 	DUCKDB_API void EndQuery();
 

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -146,8 +146,9 @@ public:
 
 	DUCKDB_API static QueryProfiler &Get(ClientContext &context);
 
-	DUCKDB_API void Reset(const bool running_p, string query = "");
-	DUCKDB_API void StartQuery(string query, bool is_explain_analyze = false, bool start_at_optimizer = false);
+	DUCKDB_API void Start(string query);
+	DUCKDB_API void Reset();
+	DUCKDB_API void StartQuery(const string &query, bool is_explain_analyze = false, bool start_at_optimizer = false);
 	DUCKDB_API void EndQuery();
 
 	DUCKDB_API void StartExplainAnalyze();

--- a/src/main/capi/profiling_info-c.cpp
+++ b/src/main/capi/profiling_info-c.cpp
@@ -12,15 +12,17 @@ duckdb_profiling_info duckdb_get_profiling_info(duckdb_connection connection) {
 		return nullptr;
 	}
 	Connection *conn = reinterpret_cast<Connection *>(connection);
-	optional_ptr<ProfilingNode> profiling_info;
+	optional_ptr<ProfilingNode> profiling_node;
 	try {
-		profiling_info = conn->GetProfilingTree();
+		profiling_node = conn->GetProfilingTree();
 	} catch (std::exception &ex) {
 		return nullptr;
 	}
 
-	ProfilingNode *profiling_info_ptr = profiling_info.get();
-	return reinterpret_cast<duckdb_profiling_info>(profiling_info_ptr);
+	if (!profiling_node) {
+		return nullptr;
+	}
+	return reinterpret_cast<duckdb_profiling_info>(profiling_node.get());
 }
 
 duckdb_value duckdb_profiling_info_get_value(duckdb_profiling_info info, const char *key) {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -630,8 +630,6 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 void ClientContext::InitialCleanup(ClientContextLock &lock) {
 	//! Cleanup any open results and reset the interrupted flag
 	CleanupInternal(lock);
-	auto &profiler = QueryProfiler::Get(*this);
-	profiler.Reset(false);
 	interrupted = false;
 }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -630,6 +630,8 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 void ClientContext::InitialCleanup(ClientContextLock &lock) {
 	//! Cleanup any open results and reset the interrupted flag
 	CleanupInternal(lock);
+	auto &profiler = QueryProfiler::Get(*this);
+	profiler.Reset(false);
 	interrupted = false;
 }
 

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -87,9 +87,9 @@ QueryProfiler &QueryProfiler::Get(ClientContext &context) {
 	return *ClientData::Get(context).profiler;
 }
 
-void QueryProfiler::Start(string query) {
+void QueryProfiler::Start(const string &query) {
 	Reset();
-	query_info.query_name = std::move(query);
+	query_info.query_name = query;
 	running = true;
 	main_query.Start();
 }
@@ -120,7 +120,7 @@ void QueryProfiler::StartQuery(const string &query, bool is_explain_analyze_p, b
 		D_ASSERT(PrintOptimizerOutput());
 		return;
 	}
-	Start(std::move(query));
+	Start(query);
 }
 
 bool QueryProfiler::OperatorRequiresProfiling(const PhysicalOperatorType op_type) {

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -92,10 +92,10 @@ void QueryProfiler::Reset(const bool running_p, string query) {
 	root = nullptr;
 	phase_timings.clear();
 	phase_stack.clear();
+	query_info.query_name = std::move(query);
+	running = running_p;
 
 	if (running_p) {
-		query_info.query_name = std::move(query);
-		running = true;
 		main_query.Start();
 	}
 }

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -87,6 +87,19 @@ QueryProfiler &QueryProfiler::Get(ClientContext &context) {
 	return *ClientData::Get(context).profiler;
 }
 
+void QueryProfiler::Reset(const bool running_p, string query) {
+	tree_map.clear();
+	root = nullptr;
+	phase_timings.clear();
+	phase_stack.clear();
+
+	if (running_p) {
+		query_info.query_name = std::move(query);
+		running = true;
+		main_query.Start();
+	}
+}
+
 void QueryProfiler::StartQuery(string query, bool is_explain_analyze_p, bool start_at_optimizer) {
 	lock_guard<std::mutex> guard(lock);
 	if (is_explain_analyze_p) {
@@ -104,14 +117,7 @@ void QueryProfiler::StartQuery(string query, bool is_explain_analyze_p, bool sta
 		D_ASSERT(PrintOptimizerOutput());
 		return;
 	}
-
-	running = true;
-	query_info.query_name = std::move(query);
-	tree_map.clear();
-	root = nullptr;
-	phase_timings.clear();
-	phase_stack.clear();
-	main_query.Start();
+	Reset(true, std::move(query));
 }
 
 bool QueryProfiler::OperatorRequiresProfiling(const PhysicalOperatorType op_type) {

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -76,6 +76,8 @@ void TransactionContext::Rollback(optional_ptr<ErrorData> error) {
 	}
 	auto transaction = std::move(current_transaction);
 	ClearTransaction();
+	context.client_data->profiler->Reset(false);
+
 	ErrorData rollback_error;
 	try {
 		transaction->Rollback();

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -73,7 +73,7 @@ void TransactionContext::Rollback(optional_ptr<ErrorData> error) {
 	}
 	auto transaction = std::move(current_transaction);
 	ClearTransaction();
-	context.client_data->profiler->Reset(false);
+	context.client_data->profiler->Reset();
 
 	ErrorData rollback_error;
 	try {

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -3,12 +3,9 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/main/client_context_state.hpp"
-#include "duckdb/main/config.hpp"
+#include "duckdb/main/client_data.hpp"
 #include "duckdb/main/database.hpp"
-#include "duckdb/main/database_manager.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
-#include "duckdb/transaction/transaction_manager.hpp"
 
 namespace duckdb {
 

--- a/test/api/capi/test_capi_profiling.cpp
+++ b/test/api/capi/test_capi_profiling.cpp
@@ -234,3 +234,35 @@ TEST_CASE("Test invalid use of profiling API", "[capi]") {
 	duckdb_destroy_value(&map);
 	tester.Cleanup();
 }
+
+TEST_CASE("Test profiling after throwing an error", "[capi]") {
+	CAPITester tester;
+	CAPIPrepared prepared;
+	CAPIPending pending;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	auto main_db = TestCreatePath("profiling_error.db");
+	REQUIRE(tester.OpenDatabase(main_db.c_str()));
+
+	auto path = TestCreatePath("profiling_error.db");
+	REQUIRE_NO_FAIL(tester.Query("ATTACH IF NOT EXISTS '" + path + "' (TYPE DUCKDB)"));
+	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE profiling_error.tbl AS SELECT range AS id FROM range(10)"));
+
+	REQUIRE_NO_FAIL(tester.Query("SET enable_profiling = 'no_output'"));
+	REQUIRE_NO_FAIL(tester.Query("SET profiling_mode = 'standard'"));
+
+	REQUIRE(prepared.Prepare(tester, "SELECT * FROM profiling_error.tbl"));
+	REQUIRE(pending.Pending(prepared));
+	result = pending.Execute();
+	REQUIRE(result);
+	REQUIRE(!result->HasError());
+
+	auto info = duckdb_get_profiling_info(tester.connection);
+	REQUIRE(info != nullptr);
+
+	REQUIRE(!prepared.Prepare(tester, "SELECT * FROM profiling_error.does_not_exist"));
+	info = duckdb_get_profiling_info(tester.connection);
+	REQUIRE(info == nullptr);
+
+	tester.Cleanup();
+}


### PR DESCRIPTION
Reset the profiling information before preparing a query. Otherwise, if the prepare operation fails, we persist the profiling information of the previous query, which can lead to confusing behavior.

Related issue: https://github.com/duckdblabs/duckdb-internal/issues/5108