### PR TITLE
Visual Studio 17 (2022) fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,7 @@ option(EXTENSION_STATIC_BUILD
 
 if(WIN32 OR ZOS)
   set(EXTENSION_STATIC_BUILD TRUE)
+  add_definitions(-D_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS=1)
 endif()
 
 option(BUILD_EXTENSIONS_ONLY "Build all extension as linkable, overriding DONT_LINK, and don't build core." FALSE)

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/common/serializer/binary_serializer.hpp"
+#include "duckdb/catalog/catalog_entry/dependency/dependency_entry.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/parsed_data/alter_table_info.hpp"

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/window_expression.hpp"

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -703,7 +703,7 @@ const char *sqlite3_bind_parameter_name(sqlite3_stmt *stmt, int idx) {
 		return nullptr;
 	}
 	if (!stmt->prepared) {
-		throw InternalException("Called sqlite3_bind_parameter_name on a eagerly executed prepared query");
+		return nullptr;
 	}
 	if (idx < 1 || idx > (int)stmt->prepared->named_param_map.size()) {
 		return nullptr;


### PR DESCRIPTION
This PR fixes the following issues preventing building duckdb on Visual Studio 2022:

* Add missing includes preventing the dynamic_cast validation
* Silence deprecation warnings with  `_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS`
* Remove invalid throw from the function sqlite3_bind_parameter_name which is a C function (and thus automatically noexcept)