### PR TITLE
Revert toolchain downgrade

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -98,17 +98,7 @@ jobs:
         -e BUILD_BENCHMARK=1                                                   \
         -e FORCE_WARN_UNUSED=1                                                 \
         quay.io/pypa/manylinux_2_28_${{ matrix.config.image }}                  \
-        bash -c "
-          set -e
-          yum install -y perl-IPC-Cmd gcc-toolset-12 gcc-toolset-12-gcc-c++
-        
-          source /opt/rh/gcc-toolset-12/enable
-          export CC=gcc
-          export CXX=g++
-
-          git config --global --add safe.directory $PWD
-          make -C $PWD
-        "
+        bash -c "yum install -y perl-IPC-Cmd && git config --global --add safe.directory $PWD && make gather-libs -C $PWD"
 
     - name: Print platform
       shell: bash


### PR DESCRIPTION
This PR aims to revert https://github.com/duckdb/duckdb/pull/17776. I think this PR might not be what we want and would like to propose to revert it. 

I made this draft PR to spark a discussion exploring how to move forward here.

## Background
DuckDB uses the [manylinux](https://github.com/pypa/manylinux) images to build the linux binaries. These binaries are a battle-tested way to build binaries that are binary compatible with many linux distro's. Recently we migrated to the `manylinux_2_28` image for both the `linux_arm64` and `linux_amd64` builds, removing the `manylinux2014`-based `linux_amd64_gcc4` builds. 

The `manylinux_2_28` image is an AlmaLinux 8 based image that uses the a GCC14 based toolchain to produce binaries compatible with GLIBC2.28. This is why it's called `manylinux_2_28`. Binaries built with this image *should* be compatible with distro's that have glibc versions of >=2.28 like:

Debian 10+
Ubuntu 18.10+
Fedora 29+
CentOS/RHEL 8+

[source](https://github.com/pypa/manylinux?tab=readme-ov-file#manylinux_2_28-almalinux-8-based)

## PR #17776
This PR states that `Building with GCC 14 creates binaries incompatible with mainstream Linux distributions using glibc 2.28.`. In this PR The proposed and accepted solution here is to override the default toolchain in the image by downgrading to a lower GCC version. 

To start off, I feel l modifying the `manylinux_2_28` image which is designed to be glibc2.28 compatible to provide glibc2.28  compatibility seems like it should not be necessary and makes me doubt the correctness of the fix.

Another problem I have with this is that this change was not propagates through all DuckDB's CI, meaning that we now compile our libraries and binaries with a different toolchain (GCC12) than we do our extensions (GCC14).  While this might actually be fine in most cases, it could cause subtle and hard to find bugs. We ideally produce all our linux binaries using a consistent toolchain.

Finally, another problem I have with this is that it deviates from the standardised toolchain that we strive to leverage by using the `manylinux_2_28` image. I think our goal should be to stay as close to the original image as possible to keep things as simple as possible.

## How to move forward
There are two paths:
- We accept the fact that the toolchain downgrade is required and propagate it throughout all linux builds/images
- We look for another solution for the issues mentioned and revert the toolchain downgrade

Would love to hear your input here @James-Gilbert- @taniabogatsch!


