### PR TITLE
[CI] adding DONT_LINK parameter to the test extension configuration for `inet` extension

### DIFF
--- a/scripts/run_extension_medata_tests.sh
+++ b/scripts/run_extension_medata_tests.sh
@@ -54,6 +54,7 @@ else
   duckdb_extension_load(tpch DONT_LINK EXTENSION_VERSION v0.0.1)
   duckdb_extension_load(tpcds DONT_LINK EXTENSION_VERSION v0.0.1)
   duckdb_extension_load(inet
+      DONT_LINK
       GIT_URL https://github.com/duckdb/duckdb_inet
       GIT_TAG eca867b2517af06eabc89ccd6234266e9a7d6d71
       INCLUDE_DIR src/include
@@ -83,6 +84,7 @@ EOL
   duckdb_extension_load(json DONT_LINK EXTENSION_VERSION v0.0.1)
   duckdb_extension_load(tpch DONT_LINK EXTENSION_VERSION v0.0.2)
   duckdb_extension_load(inet
+      DONT_LINK
       GIT_URL https://github.com/duckdb/duckdb_inet
       GIT_TAG eca867b2517af06eabc89ccd6234266e9a7d6d71
       INCLUDE_DIR src/include


### PR DESCRIPTION
This PR should fix CI failure when it [cannot remove inet.duckdb_extension.info](https://github.com/duckdb/duckdb/actions/runs/15721093262/job/44302574029#step:9:819) by adding `DONT_LINK` parameter to the extensions config for `inet` extension as well.

