### PR TITLE
Issue #5144: AsOf Join Threshold

### DIFF
--- a/src/execution/physical_plan/plan_asof_join.cpp
+++ b/src/execution/physical_plan/plan_asof_join.cpp
@@ -271,7 +271,7 @@ PhysicalOperator &PhysicalPlanGenerator::PlanAsOfJoin(LogicalComparisonJoin &op)
 
 	auto &config = ClientConfig::GetConfig(context);
 	if (!config.force_asof_iejoin) {
-		if (op.children[0]->has_estimated_cardinality && lhs_cardinality <= config.asof_loop_join_threshold) {
+		if (op.children[0]->has_estimated_cardinality && lhs_cardinality < config.asof_loop_join_threshold) {
 			auto result = PlanAsOfLoopJoin(op, left, right);
 			if (result) {
 				return *result;


### PR DESCRIPTION
* Use an inequality for the cardinality test to defend against zero LHS cardinalities

fixes: duckdblabs/duckdb-internal#5144