### PR TITLE
Use SharedLockTable in DataTable::Fetch

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -415,7 +415,7 @@ TableStorageInfo DataTable::GetStorageInfo() {
 //===--------------------------------------------------------------------===//
 void DataTable::Fetch(DuckTransaction &transaction, DataChunk &result, const vector<StorageIndex> &column_ids,
                       const Vector &row_identifiers, idx_t fetch_count, ColumnFetchState &state) {
-	auto lock = info->checkpoint_lock.GetSharedLock();
+	auto lock = transaction.SharedLockTable(*info);
 	row_groups->Fetch(transaction, result, column_ids, row_identifiers, fetch_count, state);
 }
 


### PR DESCRIPTION
We need all table locks to go through `SharedLockTable` otherwise a transaction can try to obtain the same lock for the same table multiple times. Not using this can cause deadlocks in rare scenarios where we have connections running queries that refer to the same table multiple times while other transactions are trying to checkpoint.