### PR TITLE
Fix for IsDenseRange check in filter_combiner

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -242,7 +242,7 @@ bool FilterCombiner::IsDenseRange(vector<Value> &in_list) {
 	if (in_list.empty()) {
 		return true;
 	}
-	if (!in_list[0].type().IsIntegral()) {
+	if (!in_list[0].type().IsIntegral() || in_list[0].type() == LogicalType::UHUGEINT) {
 		return false;
 	}
 	// sort the input list


### PR DESCRIPTION
We cast the data to `HUGEINT` but if our data is `UHUGEINT` there is no guarantee we can cast it to `HUGEINT`

Fix: https://github.com/duckdb/duckdb/issues/17827