### PR TITLE
Disable constexpr std::mutex on Windows

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -98,6 +98,15 @@ jobs:
       run: |
         test/Release/unittest.exe
 
+    - name: Test with VS2019 C++ stdlib
+      shell: bash
+      if: ${{ inputs.skip_tests != 'true' }}
+      run: |
+        choco install wget -y --no-progress
+        wget -P test/Release https://blobs.duckdb.org/ci/msvcp140.dll
+        test/Release/unittest.exe
+        rm test/Release/msvcp140.dll
+
     - name: Tools Test
       shell: bash
       if: ${{ inputs.skip_tests != 'true' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -642,8 +642,11 @@ if(NOT MSVC)
     message(WARNING "Please use a recent compiler for debug builds")
   endif()
 else()
+  # we don't use "constexpr static std::mutex", so we can use the
+  # _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR definition that is required
+  # to keep the compatibility with C++ stdlib version 14.29 from MSVC 2019
   set(CMAKE_CXX_WINDOWS_FLAGS
-      "/wd4244 /wd4267 /wd4200 /wd26451 /wd26495 /D_CRT_SECURE_NO_WARNINGS /utf-8")
+      "/wd4244 /wd4267 /wd4200 /wd26451 /wd26495 /D_CRT_SECURE_NO_WARNINGS /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR /utf-8")
   if(TREAT_WARNINGS_AS_ERRORS)
     set(CMAKE_CXX_WINDOWS_FLAGS "${CMAKE_CXX_WINDOWS_FLAGS} /WX")
   endif()


### PR DESCRIPTION
On Windows the `constexpr` constructor of `std::mutex`, that was supposed to be there since C++11, was not implemented until VS2022. Its implementation has required to use Slim Reader/Writer (SRW) Locks ([ref](https://learn.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks)) that are only supported since Window 7, but VS2019 was still supporting Windows Vista as a target ([more details from SO](https://stackoverflow.com/a/74255773)).

The implementation of `constexpr std::mutex` in MSVC has required the ABI breakage in C++ STL that was eventually added in VS2022 17.10 ([commit](https://github.com/microsoft/STL/commit/4aad4b84d69e033d47215ff7d35bdee3e3b66b62)). This commit has introduced the macro
`_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` that can be defined to stay ABI compatible with older versions of C++ stdlib. Thus the binaries built with VS2022 17.10 or later and without this macro cannot be run with older versions of C++ stdlib `msvcp140.dll` even if they do not use `constexpr std::mutex` - any mutex usage will crash with something like this ([more examples and comments from MSFT](https://web.archive.org/web/20250618223106/https://developercommunity.visualstudio.com/t/Access-violation-in-_Thrd_yield-after-up/10664660)):

```
Faulting application name: duckdb.exe, version: 1.3.1.0, time stamp: 0x684fdb82
Faulting module name: MSVCP140.dll, version: 14.36.32532.0, time stamp: 0x04a30cf0
Exception code: 0xc0000005
```

This PR adds the `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` macro definition to Windows builds assuming that we are not going to use `constexpr` constructor of `std::mutex` and we want to be able to run with `msvcp140.dll` while being compiled with newer toolchains.

Note, that running binaries, that were built against `msvcp140.dll` version `14.40+`, in environment with earlier versions `msvcp140.dll` is not officially supported by MSFT ([ref](https://learn.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-170)). But we don't really have a choice here (unless we want to keep DuckDB itself on VS2019). Extensions (which build should include the engine CMake file being update by this PR) are going to be loaded though JDBC into JVM processes. As of mid 2025, OpenJDK builds from some of major vendors (e.g. Amazon Corretto), including the latest stable JDK 24 (released in March 2025) are still using VS2019 (likely the topic of this issue is one of the reasons for that). And all these JDKs include a vendored copy of `msvcp140.dll` version `14.29`. Due to the way, how Windows shared lib loader works, this vendored C++ stdlib will be loaded by the JVM instead of any system one. And then later when the JVM will load DuckDB extensions shared libs through JDBC - these extensions will also use this pre-loaded version of C++ stdlib, as we do not do static linking for it. In general, LTS JDK versions have 10+ years of production support (for example, JDK 6 released in late 2006 is still supported by some vendors). And even if later updates of LTS JDKs (11, 17, 21, 24 etc) will move to a newer version of MSVC toolchain - the old JDK binaries are going to be still in use for a long time.

Thus this change is proposed as a permanent change - not a temporary workaround.

Testing: additional test run of `unittest.exe` is added that uses `msvcp140.dll` from VS2019 instead of the system-provided one.

Fixes: #17971

Edit: added `wget` installation on Windows CI, removed "1.3" labels as this PR is intended to be the mainline one when `v1.3-ossivalis` will be merged into the `main` branch later.