### PR TITLE
add ClientContext to the get_bind_info_t hook in TableFunction

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -677,7 +677,7 @@ vector<PartitionStatistics> TableScanGetPartitionStats(ClientContext &context, G
 	return storage.GetPartitionStats(context);
 }
 
-BindInfo TableScanGetBindInfo(const optional_ptr<FunctionData> bind_data_p) {
+BindInfo TableScanGetBindInfo(ClientContext &, const optional_ptr<FunctionData> bind_data_p) {
 	auto &bind_data = bind_data_p->Cast<TableScanBindData>();
 	return BindInfo(bind_data.table);
 }

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -695,7 +695,7 @@ public:
 		}
 	}
 
-	static BindInfo MultiFileGetBindInfo(const optional_ptr<FunctionData> bind_data_p) {
+	static BindInfo MultiFileGetBindInfo(ClientContext &, const optional_ptr<FunctionData> bind_data_p) {
 		BindInfo bind_info(ScanType::EXTERNAL);
 		auto &bind_data = bind_data_p->Cast<MultiFileBindData>();
 

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -284,7 +284,7 @@ typedef OperatorFinalizeResultType (*table_in_out_function_final_t)(ExecutionCon
 typedef OperatorPartitionData (*table_function_get_partition_data_t)(ClientContext &context,
                                                                      TableFunctionGetPartitionInput &input);
 
-typedef BindInfo (*table_function_get_bind_info_t)(const optional_ptr<FunctionData> bind_data);
+typedef BindInfo (*table_function_get_bind_info_t)(ClientContext &context, const optional_ptr<FunctionData> bind_data);
 
 typedef unique_ptr<MultiFileReader> (*table_function_get_multi_file_reader_t)(const TableFunction &);
 

--- a/src/include/duckdb/planner/expression_binder/index_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/index_binder.hpp
@@ -30,7 +30,7 @@ public:
 	                                            TableCatalogEntry &table_entry, unique_ptr<LogicalOperator> plan,
 	                                            unique_ptr<AlterTableInfo> alter_table_info);
 
-	static void InitCreateIndexInfo(LogicalGet &get, CreateIndexInfo &info, const string &schema);
+	static void InitCreateIndexInfo(LogicalGet &get, ClientContext &, CreateIndexInfo &info, const string &schema);
 
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,

--- a/src/include/duckdb/planner/operator/logical_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_get.hpp
@@ -62,7 +62,7 @@ public:
 	string GetName() const override;
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
 	//! Returns the underlying table that is being scanned, or nullptr if there is none
-	optional_ptr<TableCatalogEntry> GetTable() const;
+	optional_ptr<TableCatalogEntry> GetTable(ClientContext &context) const;
 	//! Returns any column to query - preferably the cheapest column
 	//! This is used when we are running e.g. a COUNT(*) and don't care about the contents of any columns in the table
 	column_t GetAnyColumn() const;

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -73,7 +73,7 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 	auto cardinality_after_filters = base_table_cardinality;
 	unique_ptr<BaseStatistics> column_statistics;
 
-	auto catalog_table = get.GetTable();
+	auto catalog_table = get.GetTable(context);
 	auto name = string("some table");
 	if (catalog_table) {
 		name = catalog_table->name;

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -305,7 +305,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		auto logical_get =
 		    make_uniq<LogicalGet>(table_index, scan_function, std::move(bind_data), std::move(return_types),
 		                          std::move(return_names), std::move(virtual_columns));
-		auto table_entry = logical_get->GetTable();
+		auto table_entry = logical_get->GetTable(context);
 		auto &col_ids = logical_get->GetMutableColumnIds();
 		if (!table_entry) {
 			bind_context.AddBaseTable(table_index, ref.alias, table_names, table_types, col_ids, ref.table_name);

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -277,7 +277,7 @@ unique_ptr<LogicalOperator> Binder::BindTableFunctionInternal(TableFunction &tab
 	}
 	// now add the table function to the bind context so its columns can be bound
 	bind_context.AddTableFunction(bind_index, function_name, return_names, return_types, get->GetMutableColumnIds(),
-	                              get->GetTable().get(), std::move(virtual_columns));
+	                              get->GetTable(context).get(), std::move(virtual_columns));
 	return std::move(get);
 }
 

--- a/src/planner/expression_binder/index_binder.cpp
+++ b/src/planner/expression_binder/index_binder.cpp
@@ -48,7 +48,8 @@ unique_ptr<BoundIndex> IndexBinder::BindIndex(const UnboundIndex &unbound_index)
 	return index_type->create_instance(input);
 }
 
-void IndexBinder::InitCreateIndexInfo(LogicalGet &get, CreateIndexInfo &info, const string &schema) {
+void IndexBinder::InitCreateIndexInfo(LogicalGet &get, ClientContext &context, CreateIndexInfo &info,
+                                      const string &schema) {
 	auto &column_ids = get.GetColumnIds();
 	for (auto &column_id : column_ids) {
 		if (column_id.IsRowIdColumn()) {
@@ -62,7 +63,7 @@ void IndexBinder::InitCreateIndexInfo(LogicalGet &get, CreateIndexInfo &info, co
 	info.scan_types.emplace_back(LogicalType::ROW_TYPE);
 	info.names = get.names;
 	info.schema = schema;
-	info.catalog = get.GetTable()->catalog.GetName();
+	info.catalog = get.GetTable(context)->catalog.GetName();
 	get.AddColumnId(COLUMN_IDENTIFIER_ROW_ID);
 }
 
@@ -88,7 +89,7 @@ unique_ptr<LogicalOperator> IndexBinder::BindCreateIndex(ClientContext &context,
 	}
 
 	auto &get = plan->Cast<LogicalGet>();
-	InitCreateIndexInfo(get, *create_index_info, table_entry.schema.name);
+	InitCreateIndexInfo(get, context, *create_index_info, table_entry.schema.name);
 	auto &bind_data = get.bind_data->Cast<TableScanBindData>();
 	bind_data.is_create_index = true;
 

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -24,11 +24,11 @@ LogicalGet::LogicalGet(idx_t table_index, TableFunction function, unique_ptr<Fun
       virtual_columns(std::move(virtual_columns_p)), extra_info() {
 }
 
-optional_ptr<TableCatalogEntry> LogicalGet::GetTable() const {
+optional_ptr<TableCatalogEntry> LogicalGet::GetTable(ClientContext &context) const {
 	if (!function.get_bind_info) {
 		return nullptr;
 	}
-	return function.get_bind_info(bind_data.get()).table;
+	return function.get_bind_info(context, bind_data.get()).table;
 }
 
 InsertionOrderPreservingMap<string> LogicalGet::ParamsToString() const {


### PR DESCRIPTION
motherduck overloads the planning-hooks of TableFunction and would like to use ClientContext to find back the overloaded hook if the TF executes locally -> the new CopyBindInfo did not have this param (yet)

this PR adds it.