### PR TITLE
add the from-table-function as parameter to copy-from-bind

### DIFF
--- a/.github/patches/extensions/excel/excel_copy.patch
+++ b/.github/patches/extensions/excel/excel_copy.patch
@@ -1,26 +1,34 @@
 diff --git a/src/excel/xlsx/copy_xlsx.cpp b/src/excel/xlsx/copy_xlsx.cpp
-index 33890b5..8105a7e 100644
+index 33890b5..b80b8fd 100644
 --- a/src/excel/xlsx/copy_xlsx.cpp
 +++ b/src/excel/xlsx/copy_xlsx.cpp
-@@ -421,16 +421,17 @@ static void ParseCopyFromOptions(XLSXReadData &data, case_insensitive_map_t<vect
- 	ReadXLSX::ParseOptions(data.options, named_parameters);
+@@ -392,7 +392,7 @@ static void SetVarcharValue(named_parameter_map_t &params, const string &key, co
+        params[key] = val.back();
+ }
+ 
+-static void ParseCopyFromOptions(XLSXReadData &data, case_insensitive_map_t<vector<Value>> &options) {
++static void ParseCopyFromOptions(XLSXReadData &data, const case_insensitive_map_t<vector<Value>> &options) {
+ 
+        // Just make it really easy for us, extract everything into a named parameter map
+        named_parameter_map_t named_parameters;
+@@ -421,16 +421,16 @@ static void ParseCopyFromOptions(XLSXReadData &data, case_insensitive_map_t<vect
+        ReadXLSX::ParseOptions(data.options, named_parameters);
  }
  
 -static unique_ptr<FunctionData> CopyFromBind(ClientContext &context, CopyInfo &info, vector<string> &expected_names,
 +static unique_ptr<FunctionData> CopyFromBind(ClientContext &context, CopyFromFunctionBindInput &input, vector<string> &expected_names,
                                               vector<LogicalType> &expected_types) {
  
- 	auto result = make_uniq<XLSXReadData>();
--	result->file_path = info.file_path;
-+	result->file_path = input.info.file_path;
+        auto result = make_uniq<XLSXReadData>();
+-       result->file_path = info.file_path;
++       result->file_path = input.info.file_path;
  
- 	// TODO: Parse options
--	ParseCopyFromOptions(*result, info.options);
-+	auto options_copy = input.info.options;
-+	ParseCopyFromOptions(*result, options_copy);
+        // TODO: Parse options
+-       ParseCopyFromOptions(*result, info.options);
++       ParseCopyFromOptions(*result, input.info.options);
  
--	ZipFileReader archive(context, info.file_path);
-+	ZipFileReader archive(context, input.info.file_path);
- 	ReadXLSX::ResolveSheet(result, archive);
+-       ZipFileReader archive(context, info.file_path);
++       ZipFileReader archive(context, input.info.file_path);
+        ReadXLSX::ResolveSheet(result, archive);
  
- 	// Column count mismatch!
+        // Column count mismatch!

--- a/.github/patches/extensions/excel/excel_copy.patch
+++ b/.github/patches/extensions/excel/excel_copy.patch
@@ -1,25 +1,26 @@
 diff --git a/src/excel/xlsx/copy_xlsx.cpp b/src/excel/xlsx/copy_xlsx.cpp
-index 33890b5..9c41e47 100644
+index 33890b5..8105a7e 100644
 --- a/src/excel/xlsx/copy_xlsx.cpp
 +++ b/src/excel/xlsx/copy_xlsx.cpp
-@@ -421,16 +421,16 @@ static void ParseCopyFromOptions(XLSXReadData &data, case_insensitive_map_t<vect
-        ReadXLSX::ParseOptions(data.options, named_parameters);
+@@ -421,16 +421,17 @@ static void ParseCopyFromOptions(XLSXReadData &data, case_insensitive_map_t<vect
+ 	ReadXLSX::ParseOptions(data.options, named_parameters);
  }
  
 -static unique_ptr<FunctionData> CopyFromBind(ClientContext &context, CopyInfo &info, vector<string> &expected_names,
 +static unique_ptr<FunctionData> CopyFromBind(ClientContext &context, CopyFromFunctionBindInput &input, vector<string> &expected_names,
                                               vector<LogicalType> &expected_types) {
  
-        auto result = make_uniq<XLSXReadData>();
--       result->file_path = info.file_path;
-+       result->file_path = input.info.file_path;
+ 	auto result = make_uniq<XLSXReadData>();
+-	result->file_path = info.file_path;
++	result->file_path = input.info.file_path;
  
-        // TODO: Parse options
--       ParseCopyFromOptions(*result, info.options);
-+       ParseCopyFromOptions(*result, input.info.options);
+ 	// TODO: Parse options
+-	ParseCopyFromOptions(*result, info.options);
++	auto options_copy = input.info.options;
++	ParseCopyFromOptions(*result, options_copy);
  
--       ZipFileReader archive(context, info.file_path);
-+       ZipFileReader archive(context, input.info.file_path);
-        ReadXLSX::ResolveSheet(result, archive);
+-	ZipFileReader archive(context, info.file_path);
++	ZipFileReader archive(context, input.info.file_path);
+ 	ReadXLSX::ResolveSheet(result, archive);
  
-        // Column count mismatch!
+ 	// Column count mismatch!

--- a/.github/patches/extensions/excel/excel_copy.patch
+++ b/.github/patches/extensions/excel/excel_copy.patch
@@ -1,34 +1,34 @@
 diff --git a/src/excel/xlsx/copy_xlsx.cpp b/src/excel/xlsx/copy_xlsx.cpp
-index 33890b5..b80b8fd 100644
+index 33890b5..f91adf6 100644
 --- a/src/excel/xlsx/copy_xlsx.cpp
 +++ b/src/excel/xlsx/copy_xlsx.cpp
 @@ -392,7 +392,7 @@ static void SetVarcharValue(named_parameter_map_t &params, const string &key, co
-        params[key] = val.back();
+ 	params[key] = val.back();
  }
  
 -static void ParseCopyFromOptions(XLSXReadData &data, case_insensitive_map_t<vector<Value>> &options) {
 +static void ParseCopyFromOptions(XLSXReadData &data, const case_insensitive_map_t<vector<Value>> &options) {
  
-        // Just make it really easy for us, extract everything into a named parameter map
-        named_parameter_map_t named_parameters;
+ 	// Just make it really easy for us, extract everything into a named parameter map
+ 	named_parameter_map_t named_parameters;
 @@ -421,16 +421,16 @@ static void ParseCopyFromOptions(XLSXReadData &data, case_insensitive_map_t<vect
-        ReadXLSX::ParseOptions(data.options, named_parameters);
+ 	ReadXLSX::ParseOptions(data.options, named_parameters);
  }
  
 -static unique_ptr<FunctionData> CopyFromBind(ClientContext &context, CopyInfo &info, vector<string> &expected_names,
 +static unique_ptr<FunctionData> CopyFromBind(ClientContext &context, CopyFromFunctionBindInput &input, vector<string> &expected_names,
                                               vector<LogicalType> &expected_types) {
  
-        auto result = make_uniq<XLSXReadData>();
--       result->file_path = info.file_path;
-+       result->file_path = input.info.file_path;
+ 	auto result = make_uniq<XLSXReadData>();
+-	result->file_path = info.file_path;
++	result->file_path = input.info.file_path;
  
-        // TODO: Parse options
--       ParseCopyFromOptions(*result, info.options);
-+       ParseCopyFromOptions(*result, input.info.options);
+ 	// TODO: Parse options
+-	ParseCopyFromOptions(*result, info.options);
++	ParseCopyFromOptions(*result, input.info.options);
  
--       ZipFileReader archive(context, info.file_path);
-+       ZipFileReader archive(context, input.info.file_path);
-        ReadXLSX::ResolveSheet(result, archive);
+-	ZipFileReader archive(context, info.file_path);
++	ZipFileReader archive(context, input.info.file_path);
+ 	ReadXLSX::ResolveSheet(result, archive);
  
-        // Column count mismatch!
+ 	// Column count mismatch!

--- a/.github/patches/extensions/excel/excel_copy.patch
+++ b/.github/patches/extensions/excel/excel_copy.patch
@@ -1,0 +1,25 @@
+diff --git a/src/excel/xlsx/copy_xlsx.cpp b/src/excel/xlsx/copy_xlsx.cpp
+index 33890b5..9c41e47 100644
+--- a/src/excel/xlsx/copy_xlsx.cpp
++++ b/src/excel/xlsx/copy_xlsx.cpp
+@@ -421,16 +421,16 @@ static void ParseCopyFromOptions(XLSXReadData &data, case_insensitive_map_t<vect
+        ReadXLSX::ParseOptions(data.options, named_parameters);
+ }
+ 
+-static unique_ptr<FunctionData> CopyFromBind(ClientContext &context, CopyInfo &info, vector<string> &expected_names,
++static unique_ptr<FunctionData> CopyFromBind(ClientContext &context, CopyFromFunctionBindInput &input, vector<string> &expected_names,
+                                              vector<LogicalType> &expected_types) {
+ 
+        auto result = make_uniq<XLSXReadData>();
+-       result->file_path = info.file_path;
++       result->file_path = input.info.file_path;
+ 
+        // TODO: Parse options
+-       ParseCopyFromOptions(*result, info.options);
++       ParseCopyFromOptions(*result, input.info.options);
+ 
+-       ZipFileReader archive(context, info.file_path);
++       ZipFileReader archive(context, input.info.file_path);
+        ReadXLSX::ResolveSheet(result, archive);
+ 
+        // Column count mismatch!

--- a/.github/patches/extensions/excel/excel_copy.patch
+++ b/.github/patches/extensions/excel/excel_copy.patch
@@ -21,7 +21,7 @@ index 33890b5..f91adf6 100644
  
  	auto result = make_uniq<XLSXReadData>();
 -	result->file_path = info.file_path;
-+	result->file_path = input.info.file_path;
++	result->file_path = input.info.file_path; 
  
  	// TODO: Parse options
 -	ParseCopyFromOptions(*result, info.options);

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -181,7 +181,7 @@ public:
 		                             std::move(file_options), std::move(options), std::move(interface));
 	}
 
-	static unique_ptr<FunctionData> MultiFileBindCopy(ClientContext &context, CopyInfo &info,
+	static unique_ptr<FunctionData> MultiFileBindCopy(ClientContext &context, CopyInfo &info, TableFunction &,
 	                                                  vector<string> &expected_names,
 	                                                  vector<LogicalType> &expected_types) {
 		auto multi_file_reader = MultiFileReader::CreateDefault("COPY");

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -181,11 +181,11 @@ public:
 		                             std::move(file_options), std::move(options), std::move(interface));
 	}
 
-	static unique_ptr<FunctionData> MultiFileBindCopy(ClientContext &context, CopyInfo &info, TableFunction &,
+	static unique_ptr<FunctionData> MultiFileBindCopy(ClientContext &context, CopyFromFunctionBindInput &input,
 	                                                  vector<string> &expected_names,
 	                                                  vector<LogicalType> &expected_types) {
 		auto multi_file_reader = MultiFileReader::CreateDefault("COPY");
-		vector<string> paths = {info.file_path};
+		vector<string> paths = {input.info.file_path};
 		auto file_list = multi_file_reader->CreateFileList(context, paths);
 
 		auto interface = OP::InitializeInterface(context, *multi_file_reader, *file_list);
@@ -193,7 +193,7 @@ public:
 		auto options = interface->InitializeOptions(context, nullptr);
 		MultiFileOptions file_options;
 
-		for (auto &option : info.options) {
+		for (auto &option : input.info.options) {
 			auto loption = StringUtil::Lower(option.first);
 			if (interface->ParseCopyOption(context, loption, option.second, *options, expected_names, expected_types)) {
 				continue;

--- a/src/include/duckdb/function/copy_function.hpp
+++ b/src/include/duckdb/function/copy_function.hpp
@@ -76,6 +76,14 @@ struct CopyFunctionBindInput {
 	string file_extension;
 };
 
+struct CopyFromFunctionBindInput {
+	explicit CopyFromFunctionBindInput(const CopyInfo &info_p, TableFunction &tf_p) : info(info_p), tf(tf_p) {
+	}
+
+	const CopyInfo &info;
+	TableFunction &tf;
+};
+
 struct CopyToSelectInput {
 	ClientContext &context;
 	case_insensitive_map_t<vector<Value>> &options;
@@ -102,7 +110,7 @@ typedef void (*copy_to_serialize_t)(Serializer &serializer, const FunctionData &
 
 typedef unique_ptr<FunctionData> (*copy_to_deserialize_t)(Deserializer &deserializer, CopyFunction &function);
 
-typedef unique_ptr<FunctionData> (*copy_from_bind_t)(ClientContext &context, CopyInfo &info, TableFunction &fcn,
+typedef unique_ptr<FunctionData> (*copy_from_bind_t)(ClientContext &context, CopyFromFunctionBindInput &info,
                                                      vector<string> &expected_names,
                                                      vector<LogicalType> &expected_types);
 typedef CopyFunctionExecutionMode (*copy_to_execution_mode_t)(bool preserve_insertion_order, bool supports_batch_index);

--- a/src/include/duckdb/function/copy_function.hpp
+++ b/src/include/duckdb/function/copy_function.hpp
@@ -102,7 +102,7 @@ typedef void (*copy_to_serialize_t)(Serializer &serializer, const FunctionData &
 
 typedef unique_ptr<FunctionData> (*copy_to_deserialize_t)(Deserializer &deserializer, CopyFunction &function);
 
-typedef unique_ptr<FunctionData> (*copy_from_bind_t)(ClientContext &context, CopyInfo &info,
+typedef unique_ptr<FunctionData> (*copy_from_bind_t)(ClientContext &context, CopyInfo &info, TableFunction &fcn,
                                                      vector<string> &expected_names,
                                                      vector<LogicalType> &expected_types);
 typedef CopyFunctionExecutionMode (*copy_to_execution_mode_t)(bool preserve_insertion_order, bool supports_batch_index);

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -383,9 +383,9 @@ BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 			expected_names.push_back(col.Name());
 		}
 	}
-
-	auto function_data =
-	    copy_function.function.copy_from_bind(context, *stmt.info, expected_names, bound_insert.expected_types);
+	auto function_data = copy_function.function.copy_from_bind(context, *stmt.info, 
+	                                                           copy_function.function.copy_from_function,
+	                                                           expected_names, bound_insert.expected_types);
 	auto get = make_uniq<LogicalGet>(GenerateTableIndex(), copy_function.function.copy_from_function,
 	                                 std::move(function_data), bound_insert.expected_types, expected_names);
 	for (idx_t i = 0; i < bound_insert.expected_types.size(); i++) {

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -383,8 +383,9 @@ BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 			expected_names.push_back(col.Name());
 		}
 	}
-	auto function_data = copy_function.function.copy_from_bind(
-	    context, *stmt.info, copy_function.function.copy_from_function, expected_names, bound_insert.expected_types);
+	CopyFromFunctionBindInput input(*stmt.info, copy_function.function.copy_from_function);
+	auto function_data =
+	    copy_function.function.copy_from_bind(context, input, expected_names, bound_insert.expected_types);
 	auto get = make_uniq<LogicalGet>(GenerateTableIndex(), copy_function.function.copy_from_function,
 	                                 std::move(function_data), bound_insert.expected_types, expected_names);
 	for (idx_t i = 0; i < bound_insert.expected_types.size(); i++) {

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -383,9 +383,8 @@ BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 			expected_names.push_back(col.Name());
 		}
 	}
-	auto function_data = copy_function.function.copy_from_bind(context, *stmt.info, 
-	                                                           copy_function.function.copy_from_function,
-	                                                           expected_names, bound_insert.expected_types);
+	auto function_data = copy_function.function.copy_from_bind(
+	    context, *stmt.info, copy_function.function.copy_from_function, expected_names, bound_insert.expected_types);
 	auto get = make_uniq<LogicalGet>(GenerateTableIndex(), copy_function.function.copy_from_function,
 	                                 std::move(function_data), bound_insert.expected_types, expected_names);
 	for (idx_t i = 0; i < bound_insert.expected_types.size(); i++) {


### PR DESCRIPTION
MotherDuck overloads TableFunctions (and CopyFunctions) but would look to to so in a more inobtrusive manner, changing nothing if the functions execute locally. This change allows the copy-from-bind to make changes to the from-table-function in case it executes remotely (more precisely, it will change some callback hooks to RPC stubs).