### PR TITLE
[FIX] Arrow ArrowBool8 Extension Type Add Validity Type Check

### DIFF
--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -358,7 +358,9 @@ struct ArrowBool8 {
 		auto source_ptr = reinterpret_cast<bool *>(format.data);
 		auto result_ptr = reinterpret_cast<int8_t *>(FlatVector::GetData(result));
 		for (idx_t i = 0; i < count; i++) {
-			result_ptr[i] = static_cast<int8_t>(source_ptr[i]);
+			if (format.validity.RowIsValid(i)) {
+				result_ptr[i] = static_cast<int8_t>(source_ptr[i]);
+			}
 		}
 	}
 };


### PR DESCRIPTION
Hi DuckDB Team, 

I discovered an issue where the validity mask wasn't being properly checked when using the ArrowBool8 Arrow extension type. This causes a runtime error in debug mode.

The following undefined behavior error occurs in debug builds:

```
/Users/rusty/Development/airport/duckdb/src/common/arrow/arrow_type_extension.cpp:361:40: runtime error: load of value 190, which is not a valid value for type 'bool'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/rusty/Development/airport/duckdb/src/common/arrow/arrow_type_extension.cpp:361:40 
```

**Reproduction Steps:**

This can be reproduced during Airport extension testing with the following SQL:

```sql
use test1.test_schema;
set arrow_lossless_conversion = true;
CREATE TABLE switches (
    status boolean
);
insert into switches values (false), (true), (false), (true), (null);
```

The issue stems from not validating the Arrow validity mask before loading values in the result vector.  This PR adds the missing check.  Please merge this back to main as well.
