### PR TITLE
fix: Change `BIT`/`BITSTRING` serialization to use 0/1-based format, change `VARINT` to be serialized as string.

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -2056,6 +2056,12 @@ void Value::SerializeInternal(Serializer &serializer, bool serialize_type) const
 		if (type_.id() == LogicalTypeId::BLOB) {
 			auto blob_str = Blob::ToString(StringValue::Get(*this));
 			serializer.WriteProperty(102, "value", blob_str);
+		} else if (type_.id() == LogicalTypeId::BIT) {
+			auto bit_str = Bit::ToString(StringValue::Get(*this));
+			serializer.WriteProperty(102, "value", bit_str);
+		} else if (type_.id() == LogicalTypeId::VARINT) {
+			auto varint_str = Varint::VarIntToVarchar(StringValue::Get(*this));
+			serializer.WriteProperty(102, "value", varint_str);
 		} else {
 			serializer.WriteProperty(102, "value", StringValue::Get(*this));
 		}
@@ -2139,6 +2145,10 @@ Value Value::Deserialize(Deserializer &deserializer) {
 		auto str = deserializer.ReadProperty<string>(102, "value");
 		if (type.id() == LogicalTypeId::BLOB) {
 			new_value.value_info_ = make_shared_ptr<StringValueInfo>(Blob::ToBlob(str));
+		} else if (type.id() == LogicalTypeId::BIT) {
+			new_value.value_info_ = make_shared_ptr<StringValueInfo>(Bit::ToBit(str));
+		} else if (type.id() == LogicalTypeId::VARINT) {
+			new_value.value_info_ = make_shared_ptr<StringValueInfo>(Varint::VarcharToVarInt(str));
 		} else {
 			new_value.value_info_ = make_shared_ptr<StringValueInfo>(str);
 		}


### PR DESCRIPTION
This PR updates the serialization behavior for the `BIT`, `BITSTRING` and `VARINT` types.

Previously, these types were serialized using their raw binary representation. This resulted in outputs that were not valid UTF-8, making them difficult to work with and potentially problematic in systems expecting UTF-8 encoded data (such as JSON serializations of expressions).

To address this, the serialization now follows the established precedent for handling binary data, as seen with the `BLOB` type. The `BIT` and `BITSTRING` types are now encoded using `0` and `1` and the `VARINT` type is serialized as a string, ensuring consistency and improved usability.

These were discovered during testing the Airport extension.