### PR TITLE
Remove Linux (32 Bit) job

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -247,37 +247,6 @@ jobs:
       run: |
           python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit --timeout 1200
 
-  linux-compile-32:
-    name: Linux (32 Bit)
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2_28_x86_64
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
-    needs: linux-memory-leaks
-    env:
-      CC: /usr/bin/gcc
-      CXX: /usr/bin/g++
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/manylinux_2014_setup
-        with:
-          ninja-build: 1
-          ccache: 1
-          glibc32: 1
-
-      - name: Build
-        shell: bash
-        run: |
-          mkdir -p build/release
-          (cd build/release && cmake -G "Ninja" -DSTATIC_LIBCPP=1 -DCORE_EXTENSIONS='icu;parquet;fts;json' -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)
-
-      - name: Test
-        shell: bash
-        run: build/release/test/unittest
-
   linux-tarball:
      name: Python 3 Tarball
      runs-on: ubuntu-22.04


### PR DESCRIPTION
This job was failing on container init (preconditions) step (because of missing underscore in the container image name: was `quay.io/pypa/manylinux2_28_x86_64`, when needed to be [`quay.io/pypa/manylinux_2_28_x86_64`](https://github.com/pypa/manylinux).

Also it appeared that we don't have an action the job referred to (`.github/actions/manylinux_2014_setup`) and the job would fail anyway. 

According to the [DuckDB docs](https://duckdb.org/docs/stable/dev/building/unofficial_and_unsupported_platforms.html#32-bit-architectures), 32 bit architectures are not officially supported, so we can just remove the `Linux (32 Bit)` job.

In `v1.3` we just skip running it, but maybe should remove it there as well.