### PR TITLE
constant or null can be replaced when argument is a bound column reg

### DIFF
--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -80,10 +80,7 @@ bool ConstantOrNull::IsConstantOrNull(BoundFunctionExpression &expr, const Value
 	D_ASSERT(expr.bind_info);
 	auto &bind_data = expr.bind_info->Cast<ConstantOrNullBindData>();
 	D_ASSERT(bind_data.value.type() == val.type());
-	if (expr.children.size() == 2 && expr.children.at(1)->type == ExpressionType::BOUND_COLUMN_REF) {
-		return bind_data.value == val;
-	}
-	return false;
+	return bind_data.value == val;
 }
 
 unique_ptr<FunctionData> ConstantOrNullBind(ClientContext &context, ScalarFunction &bound_function,

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -80,7 +80,10 @@ bool ConstantOrNull::IsConstantOrNull(BoundFunctionExpression &expr, const Value
 	D_ASSERT(expr.bind_info);
 	auto &bind_data = expr.bind_info->Cast<ConstantOrNullBindData>();
 	D_ASSERT(bind_data.value.type() == val.type());
-	return bind_data.value == val;
+	if (expr.children.size() == 2 && expr.children.at(1)->type == ExpressionType::BOUND_COLUMN_REF) {
+		return bind_data.value == val;
+	}
+	return false;
 }
 
 unique_ptr<FunctionData> ConstantOrNullBind(ClientContext &context, ScalarFunction &bound_function,

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/table_filter.hpp"
+#include "duckdb/function/scalar/generic_common.hpp"
 #include "duckdb/function/scalar/generic_functions.hpp"
 
 namespace duckdb {

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -8,154 +8,156 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/function/scalar/generic_functions.hpp"
+"
 
-namespace duckdb {
+    namespace duckdb {
 
-FilterPropagateResult StatisticsPropagator::PropagateTableFilter(ColumnBinding stats_binding, BaseStatistics &stats,
-                                                                 TableFilter &filter) {
-	if (filter.filter_type == TableFilterType::EXPRESSION_FILTER) {
-		auto &expr_filter = filter.Cast<ExpressionFilter>();
-		auto column_ref = make_uniq<BoundColumnRefExpression>(stats.GetType(), stats_binding);
-		auto filter_expr = expr_filter.ToExpression(*column_ref);
-		// handle the filter before updating the statistics
-		// otherwise the filter can be pruned by the updated statistics
-		auto copy_expr = filter_expr->Copy();
-		auto propagate_result = HandleFilter(filter_expr);
-		UpdateFilterStatistics(*copy_expr);
-		return propagate_result;
-	}
-	return filter.CheckStatistics(stats);
-}
-
-void StatisticsPropagator::UpdateFilterStatistics(BaseStatistics &input, TableFilter &filter) {
-	// FIXME: update stats...
-	switch (filter.filter_type) {
-	case TableFilterType::CONJUNCTION_AND: {
-		auto &conjunction_and = filter.Cast<ConjunctionAndFilter>();
-		for (auto &child_filter : conjunction_and.child_filters) {
-			UpdateFilterStatistics(input, *child_filter);
+	FilterPropagateResult StatisticsPropagator::PropagateTableFilter(ColumnBinding stats_binding,
+	                                                                 BaseStatistics & stats, TableFilter & filter) {
+		if (filter.filter_type == TableFilterType::EXPRESSION_FILTER) {
+			auto &expr_filter = filter.Cast<ExpressionFilter>();
+			auto column_ref = make_uniq<BoundColumnRefExpression>(stats.GetType(), stats_binding);
+			auto filter_expr = expr_filter.ToExpression(*column_ref);
+			// handle the filter before updating the statistics
+			// otherwise the filter can be pruned by the updated statistics
+			auto copy_expr = filter_expr->Copy();
+			auto propagate_result = HandleFilter(filter_expr);
+			UpdateFilterStatistics(*copy_expr);
+			return propagate_result;
 		}
-		break;
+		return filter.CheckStatistics(stats);
 	}
-	case TableFilterType::CONSTANT_COMPARISON: {
-		auto &constant_filter = filter.Cast<ConstantFilter>();
-		UpdateFilterStatistics(input, constant_filter.comparison_type, constant_filter.constant);
-		break;
-	}
-	default:
-		break;
-	}
-}
 
-static bool IsConstantOrNullFilter(TableFilter &table_filter) {
-	if (table_filter.filter_type != TableFilterType::EXPRESSION_FILTER) {
-		return false;
+	void StatisticsPropagator::UpdateFilterStatistics(BaseStatistics & input, TableFilter & filter) {
+		// FIXME: update stats...
+		switch (filter.filter_type) {
+		case TableFilterType::CONJUNCTION_AND: {
+			auto &conjunction_and = filter.Cast<ConjunctionAndFilter>();
+			for (auto &child_filter : conjunction_and.child_filters) {
+				UpdateFilterStatistics(input, *child_filter);
+			}
+			break;
+		}
+		case TableFilterType::CONSTANT_COMPARISON: {
+			auto &constant_filter = filter.Cast<ConstantFilter>();
+			UpdateFilterStatistics(input, constant_filter.comparison_type, constant_filter.constant);
+			break;
+		}
+		default:
+			break;
+		}
 	}
-	auto &expr_filter = table_filter.Cast<ExpressionFilter>();
-	if (expr_filter.expr->type != ExpressionType::BOUND_FUNCTION) {
-		return false;
-	}
-	auto &func = expr_filter.expr->Cast<BoundFunctionExpression>();
-	return ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true));
-}
 
-static bool CanReplaceConstantOrNull(TableFilter &table_filter) {
-	if (!IsConstantOrNullFilter(table_filter)) {
-		throw InternalException("CanReplaceConstantOrNull() called on unexepected Table Filter");
+	static bool IsConstantOrNullFilter(TableFilter & table_filter) {
+		if (table_filter.filter_type != TableFilterType::EXPRESSION_FILTER) {
+			return false;
+		}
+		auto &expr_filter = table_filter.Cast<ExpressionFilter>();
+		if (expr_filter.expr->type != ExpressionType::BOUND_FUNCTION) {
+			return false;
+		}
+		auto &func = expr_filter.expr->Cast<BoundFunctionExpression>();
+		return ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true));
 	}
-	D_ASSERT(table_filter.filter_type == TableFilterType::EXPRESSION_FILTER);
-	auto &expr_filter = table_filter.Cast<ExpressionFilter>();
-	auto &func = expr_filter.expr->Cast<BoundFunctionExpression>();
-	if (ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true))) {
-		for (auto child = ++func.children.begin(); child != func.children.end(); child++) {
-			switch (child->get()->type) {
-			case ExpressionType::BOUND_REF:
-			case ExpressionType::VALUE_CONSTANT:
-				continue;
-			default:
-				// expression type could be a function like Coalesce
-				return false;
+
+	static bool CanReplaceConstantOrNull(TableFilter & table_filter) {
+		if (!IsConstantOrNullFilter(table_filter)) {
+			throw InternalException("CanReplaceConstantOrNull() called on unexepected Table Filter");
+		}
+		D_ASSERT(table_filter.filter_type == TableFilterType::EXPRESSION_FILTER);
+		auto &expr_filter = table_filter.Cast<ExpressionFilter>();
+		auto &func = expr_filter.expr->Cast<BoundFunctionExpression>();
+		if (ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true))) {
+			for (auto child = ++func.children.begin(); child != func.children.end(); child++) {
+				switch (child->get()->type) {
+				case ExpressionType::BOUND_REF:
+				case ExpressionType::VALUE_CONSTANT:
+					continue;
+				default:
+					// expression type could be a function like Coalesce
+					return false;
+				}
 			}
 		}
+		// all children of constant or null are bound refs to the table filter column
+		return true;
 	}
-	// all children of constant or null are bound refs to the table filter column
-	return true;
-}
 
-unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet &get,
-                                                                     unique_ptr<LogicalOperator> &node_ptr) {
-	if (get.function.cardinality) {
-		node_stats = get.function.cardinality(context, get.bind_data.get());
-	}
-	if (!get.function.statistics) {
-		// no column statistics to get
+	unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet & get,
+	                                                                     unique_ptr<LogicalOperator> & node_ptr) {
+		if (get.function.cardinality) {
+			node_stats = get.function.cardinality(context, get.bind_data.get());
+		}
+		if (!get.function.statistics) {
+			// no column statistics to get
+			return std::move(node_stats);
+		}
+		auto &column_ids = get.GetColumnIds();
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			auto stats = get.function.statistics(context, get.bind_data.get(), column_ids[i].GetPrimaryIndex());
+			if (stats) {
+				ColumnBinding binding(get.table_index, i);
+				statistics_map.insert(make_pair(binding, std::move(stats)));
+			}
+		}
+		// push table filters into the statistics
+		vector<idx_t> column_indexes;
+		column_indexes.reserve(get.table_filters.filters.size());
+		for (auto &kv : get.table_filters.filters) {
+			column_indexes.push_back(kv.first);
+		}
+
+		for (auto &table_filter_column : column_indexes) {
+			idx_t column_index;
+			for (column_index = 0; column_index < column_ids.size(); column_index++) {
+				if (column_ids[column_index].GetPrimaryIndex() == table_filter_column) {
+					break;
+				}
+			}
+			D_ASSERT(column_index < column_ids.size());
+			D_ASSERT(column_ids[column_index].GetPrimaryIndex() == table_filter_column);
+
+			// find the stats
+			ColumnBinding stats_binding(get.table_index, column_index);
+			auto entry = statistics_map.find(stats_binding);
+			if (entry == statistics_map.end()) {
+				// no stats for this entry
+				continue;
+			}
+			auto &stats = *entry->second;
+
+			// fetch the table filter
+			D_ASSERT(get.table_filters.filters.count(table_filter_column) > 0);
+			auto &filter = get.table_filters.filters[table_filter_column];
+			auto propagate_result = PropagateTableFilter(stats_binding, stats, *filter);
+			switch (propagate_result) {
+			case FilterPropagateResult::FILTER_ALWAYS_TRUE:
+				// filter is always true; it is useless to execute it
+				// erase this condition
+				get.table_filters.filters.erase(table_filter_column);
+				break;
+			case FilterPropagateResult::FILTER_TRUE_OR_NULL: {
+				if (IsConstantOrNullFilter(*get.table_filters.filters[table_filter_column]) &&
+				    !CanReplaceConstantOrNull(*get.table_filters.filters[table_filter_column])) {
+					break;
+				}
+				// filter is true or null; we can replace this with a not null filter
+				get.table_filters.filters[table_filter_column] = make_uniq<IsNotNullFilter>();
+				break;
+			}
+			case FilterPropagateResult::FILTER_FALSE_OR_NULL:
+			case FilterPropagateResult::FILTER_ALWAYS_FALSE:
+				// filter is always false; this entire filter should be replaced by an empty result block
+				ReplaceWithEmptyResult(node_ptr);
+				return make_uniq<NodeStatistics>(0U, 0U);
+			default:
+				// general case: filter can be true or false, update this columns' statistics
+				UpdateFilterStatistics(stats, *filter);
+				break;
+			}
+		}
 		return std::move(node_stats);
 	}
-	auto &column_ids = get.GetColumnIds();
-	for (idx_t i = 0; i < column_ids.size(); i++) {
-		auto stats = get.function.statistics(context, get.bind_data.get(), column_ids[i].GetPrimaryIndex());
-		if (stats) {
-			ColumnBinding binding(get.table_index, i);
-			statistics_map.insert(make_pair(binding, std::move(stats)));
-		}
-	}
-	// push table filters into the statistics
-	vector<idx_t> column_indexes;
-	column_indexes.reserve(get.table_filters.filters.size());
-	for (auto &kv : get.table_filters.filters) {
-		column_indexes.push_back(kv.first);
-	}
-
-	for (auto &table_filter_column : column_indexes) {
-		idx_t column_index;
-		for (column_index = 0; column_index < column_ids.size(); column_index++) {
-			if (column_ids[column_index].GetPrimaryIndex() == table_filter_column) {
-				break;
-			}
-		}
-		D_ASSERT(column_index < column_ids.size());
-		D_ASSERT(column_ids[column_index].GetPrimaryIndex() == table_filter_column);
-
-		// find the stats
-		ColumnBinding stats_binding(get.table_index, column_index);
-		auto entry = statistics_map.find(stats_binding);
-		if (entry == statistics_map.end()) {
-			// no stats for this entry
-			continue;
-		}
-		auto &stats = *entry->second;
-
-		// fetch the table filter
-		D_ASSERT(get.table_filters.filters.count(table_filter_column) > 0);
-		auto &filter = get.table_filters.filters[table_filter_column];
-		auto propagate_result = PropagateTableFilter(stats_binding, stats, *filter);
-		switch (propagate_result) {
-		case FilterPropagateResult::FILTER_ALWAYS_TRUE:
-			// filter is always true; it is useless to execute it
-			// erase this condition
-			get.table_filters.filters.erase(table_filter_column);
-			break;
-		case FilterPropagateResult::FILTER_TRUE_OR_NULL: {
-			if (IsConstantOrNullFilter(*get.table_filters.filters[table_filter_column]) &&
-			    !CanReplaceConstantOrNull(*get.table_filters.filters[table_filter_column])) {
-				break;
-			}
-			// filter is true or null; we can replace this with a not null filter
-			get.table_filters.filters[table_filter_column] = make_uniq<IsNotNullFilter>();
-			break;
-		}
-		case FilterPropagateResult::FILTER_FALSE_OR_NULL:
-		case FilterPropagateResult::FILTER_ALWAYS_FALSE:
-			// filter is always false; this entire filter should be replaced by an empty result block
-			ReplaceWithEmptyResult(node_ptr);
-			return make_uniq<NodeStatistics>(0U, 0U);
-		default:
-			// general case: filter can be true or false, update this columns' statistics
-			UpdateFilterStatistics(stats, *filter);
-			break;
-		}
-	}
-	return std::move(node_stats);
-}
 
 } // namespace duckdb

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/table_filter.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
 

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -10,7 +10,6 @@
 #include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/table_filter.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/function/scalar/generic_functions.hpp"
 
 namespace duckdb {
@@ -25,7 +24,7 @@ static void GetColumnIndex(unique_ptr<Expression> &expr, idx_t &index) {
 }
 
 FilterPropagateResult StatisticsPropagator::PropagateTableFilter(ColumnBinding stats_binding, BaseStatistics &stats,
-																 TableFilter &filter) {
+                                                                 TableFilter &filter) {
 	if (filter.filter_type == TableFilterType::EXPRESSION_FILTER) {
 		auto &expr_filter = filter.Cast<ExpressionFilter>();
 
@@ -71,7 +70,7 @@ void StatisticsPropagator::UpdateFilterStatistics(BaseStatistics &input, TableFi
 	}
 }
 
-static bool IsConstantOrNullFilter(TableFilter & table_filter) {
+static bool IsConstantOrNullFilter(TableFilter &table_filter) {
 	if (table_filter.filter_type != TableFilterType::EXPRESSION_FILTER) {
 		return false;
 	}
@@ -83,7 +82,7 @@ static bool IsConstantOrNullFilter(TableFilter & table_filter) {
 	return ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true));
 }
 
-static bool CanReplaceConstantOrNull(TableFilter & table_filter) {
+static bool CanReplaceConstantOrNull(TableFilter &table_filter) {
 	if (!IsConstantOrNullFilter(table_filter)) {
 		throw InternalException("CanReplaceConstantOrNull() called on unexepected Table Filter");
 	}
@@ -106,8 +105,8 @@ static bool CanReplaceConstantOrNull(TableFilter & table_filter) {
 	return true;
 }
 
-unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet & get,
-                                                                     unique_ptr<LogicalOperator> & node_ptr) {
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet &get,
+                                                                     unique_ptr<LogicalOperator> &node_ptr) {
 	if (get.function.cardinality) {
 		node_stats = get.function.cardinality(context, get.bind_data.get());
 	}

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -46,6 +46,41 @@ void StatisticsPropagator::UpdateFilterStatistics(BaseStatistics &input, TableFi
 	}
 }
 
+static bool IsConstantOrNullFilter(TableFilter &table_filter) {
+	if (table_filter.filter_type != TableFilterType::EXPRESSION_FILTER) {
+		return false;
+	}
+	auto &expr_filter = table_filter.Cast<ExpressionFilter>();
+	if (expr_filter.expr->type != ExpressionType::BOUND_FUNCTION) {
+		return false;
+	}
+	auto &func = expr_filter.expr->Cast<BoundFunctionExpression>();
+	return ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true));
+}
+
+static bool CanReplaceConstantOrNull(TableFilter &table_filter) {
+	if (!IsConstantOrNullFilter(table_filter)) {
+		throw InternalException("CanReplaceConstantOrNull() called on unexepected Table Filter");
+	}
+	D_ASSERT(table_filter->filter_type == TableFilterType::EXPRESSION_FILTER);
+	auto &expr_filter = table_filter.Cast<ExpressionFilter>();
+	auto &func = expr_filter.expr->Cast<BoundFunctionExpression>();
+	if (ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true))) {
+		for (auto child = ++func.children.begin(); child != func.children.end(); child++) {
+			switch (child->get()->type) {
+			case ExpressionType::BOUND_REF:
+			case ExpressionType::VALUE_CONSTANT:
+				continue;
+			default:
+				// expression type could be a function like Coalesce
+				return false;
+			}
+		}
+	}
+	// all children of constant or null are bound refs to the table filter column
+	return true;
+}
+
 unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet &get,
                                                                      unique_ptr<LogicalOperator> &node_ptr) {
 	if (get.function.cardinality) {
@@ -99,10 +134,15 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 			// erase this condition
 			get.table_filters.filters.erase(table_filter_column);
 			break;
-		case FilterPropagateResult::FILTER_TRUE_OR_NULL:
+		case FilterPropagateResult::FILTER_TRUE_OR_NULL: {
+			if (IsConstantOrNullFilter(*get.table_filters.filters[table_filter_column]) &&
+			    !CanReplaceConstantOrNull(*get.table_filters.filters[table_filter_column])) {
+				break;
+			}
 			// filter is true or null; we can replace this with a not null filter
 			get.table_filters.filters[table_filter_column] = make_uniq<IsNotNullFilter>();
 			break;
+		}
 		case FilterPropagateResult::FILTER_FALSE_OR_NULL:
 		case FilterPropagateResult::FILTER_ALWAYS_FALSE:
 			// filter is always false; this entire filter should be replaced by an empty result block

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -62,7 +62,7 @@ static bool CanReplaceConstantOrNull(TableFilter &table_filter) {
 	if (!IsConstantOrNullFilter(table_filter)) {
 		throw InternalException("CanReplaceConstantOrNull() called on unexepected Table Filter");
 	}
-	D_ASSERT(table_filter->filter_type == TableFilterType::EXPRESSION_FILTER);
+	D_ASSERT(table_filter.filter_type == TableFilterType::EXPRESSION_FILTER);
 	auto &expr_filter = table_filter.Cast<ExpressionFilter>();
 	auto &func = expr_filter.expr->Cast<BoundFunctionExpression>();
 	if (ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true))) {

--- a/test/optimizer/pushdown/test_constant_or_null_pushdown.test
+++ b/test/optimizer/pushdown/test_constant_or_null_pushdown.test
@@ -1,0 +1,25 @@
+# name: test/optimizer/pushdown/test_constant_or_null_pushdown.test
+# description: Test Table OR Filter Push Down
+# group: [pushdown]
+
+statement ok
+create table t1 (ts_stop TIMESTAMPTZ);
+
+statement ok
+insert into t1 values (NULL), (NULL);
+
+query II
+explain select count(*) from t1 where constant_or_null(true, COALESCE(ts_stop, '9999-09-09 07:09:09+00'::TIMESTAMPTZ), '2025-06-23 10:32:02.216+00'::TIMESTAMPTZ);
+----
+physical_plan	<REGEX>:.*constant_or_null.*
+
+statement ok
+create table t2 as select range%2 a, range b from range(100);
+
+statement ok
+insert into t2 values (NULL, NULL), (NULL, NULL), (NULL, NULL);
+
+query II
+explain select * from t2 where constant_or_null(true, a);
+----
+physical_plan	<REGEX>:.*a IS NOT NULL.*


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/5141

https://github.com/duckdb/duckdb/pull/17425 introduced an optimization to replace `constant_or_null(true, X)` with an `is_not_null(X)` filter. This was not tested well and assumes that `X` is just a BOUND_COLUMN_REF. If `X` is a function (for example `coalesce(X, 'value')`) then this optimization does not produce the same results. 

In the coalesce example, the column X may only contain `NULLS`, but since it is coalesced with a constant value, the `IS NOT NULL` filter will produce a different result. 

I thought about adding an `IsNotNull()` filter on top of the ExpressionFilter when propagating the statistics (@propagate_get.cpp:104). This turns the optimization into a `constant_or_null` into `Is not NULL (Coalesce('X', 'value'))`. The problem there is that `constant_or_null` can have multiple children, so it would turn into a conjunction and with all of the children. 

There is definitely still room to optimize the `constant_or_null` function, but since this is a bug fix, I tried to keep the diff small.