### PR TITLE
Print internal exception stack traces on failed transaction rollback 

### DIFF
--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -65,6 +65,13 @@ string ErrorData::ConstructFinalMessage() const {
 		error += "\nThis error signals an assertion failure within DuckDB. This usually occurs due to "
 		         "unexpected conditions or errors in the program's logic.\nFor more information, see "
 		         "https://duckdb.org/docs/stable/dev/internal_errors";
+
+		// Ensure that we print the stack trace for internal exceptions.
+		auto entry = extra_info.find("stack_trace_pointers");
+		if (entry != extra_info.end()) {
+			auto stack_trace = StackTrace::ResolveStacktraceSymbols(entry->second);
+			error += "\n\n" + stack_trace;
+		}
 	}
 	return error;
 }

--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -198,7 +198,7 @@ public:
 			error += StringUtil::Format("Node %lld: Start %lld, Count %lld", i, nodes[i].row_start,
 			                            nodes[i].node->count.load());
 		}
-		throw InternalException("Could not find node in column segment tree!\n%s%s", error, Exception::GetStackTrace());
+		throw InternalException("Could not find node in column segment tree!\n%s", error);
 	}
 
 	bool TryGetSegmentIndex(SegmentLock &l, idx_t row_number, idx_t &result) {


### PR DESCRIPTION
Also ensures that `ErrorData::ConstructFinalMessage()` always appends the stack trace.

Close https://github.com/duckdblabs/duckdb-internal/issues/5166.