### PR TITLE
Unittest: Add skip_compiled option that can be used to skip built-in C++ tests

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -32,6 +32,7 @@ static const TestConfigOption test_config_options[] = {
     {"debug_initialize", "Initialize buffers with all 0 or all 1", LogicalTypeId::VARCHAR, nullptr},
     {"init_script", "Script to execute on init", LogicalTypeId::VARCHAR, TestConfiguration::ParseConnectScript},
     {"on_init", "Script to execute on init", LogicalTypeId::VARCHAR, nullptr},
+    {"skip_compiled", "Skip compiled tests", LogicalTypeId::BOOLEAN, nullptr},
     {nullptr, nullptr, LogicalTypeId::INVALID, nullptr},
 };
 
@@ -239,6 +240,10 @@ bool TestConfiguration::GetTestMemoryLeaks() {
 
 bool TestConfiguration::GetSummarizeFailures() {
 	return GetOptionOrDefault("summarize_failures", false);
+}
+
+bool TestConfiguration::GetSkipCompiledTests() {
+	return GetOptionOrDefault("skip_compiled", false);
 }
 
 DebugVectorVerification TestConfiguration::GetVectorVerification() {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -39,6 +39,7 @@ public:
 	bool GetCheckpointOnShutdown();
 	bool GetTestMemoryLeaks();
 	bool GetSummarizeFailures();
+	bool GetSkipCompiledTests();
 	DebugVectorVerification GetVectorVerification();
 	DebugInitialize GetDebugInitialize();
 	string OnConnectCommand();

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -52,6 +52,9 @@ int main(int argc_in, char *argv[]) {
 		return 1;
 	}
 
+	if (test_config.GetSkipCompiledTests()) {
+		Catch::getMutableRegistryHub().clearTests();
+	}
 	RegisterSqllogictests();
 	int result = Catch::Session().run(new_argc, new_argv.get());
 

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -3013,6 +3013,7 @@ namespace Catch {
         virtual void registerTranslator( const IExceptionTranslator* translator ) = 0;
         virtual void registerTagAlias( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) = 0;
         virtual void registerStartupException() noexcept = 0;
+        virtual void clearTests() = 0;
         virtual IMutableEnumValuesRegistry& getMutableEnumValuesRegistry() = 0;
     };
 
@@ -12385,6 +12386,7 @@ namespace Catch {
         virtual ~TestRegistry() = default;
 
         virtual void registerTest( TestCase const& testCase );
+        virtual void clearTests();
 
         std::vector<TestCase> const& getAllTests() const override;
         std::vector<TestCase> const& getAllTestsSorted( IConfig const& config ) const override;
@@ -12566,6 +12568,9 @@ namespace Catch {
             }
             void registerTest( TestCase const& testInfo ) override {
                 m_testCaseRegistry.registerTest( testInfo );
+            }
+            void clearTests() override {
+                m_testCaseRegistry.clearTests();
             }
             void registerTranslator( const IExceptionTranslator* translator ) override {
                 m_exceptionTranslatorRegistry.registerTranslator( translator );
@@ -14448,6 +14453,10 @@ namespace Catch {
             return registerTest( testCase.withName( rss.str() ) );
         }
         m_functions.push_back( testCase );
+    }
+
+    void TestRegistry::clearTests() {
+        m_functions.clear();
     }
 
     std::vector<TestCase> const& TestRegistry::getAllTests() const {


### PR DESCRIPTION
This flag skips C++ tests. This can be useful when injecting test configurations, as these generally only work for sqllogic tests.

Usage:

```
unittest --skip-compiled
```


CC @carlopi 