### PR TITLE
Issue #18035: Zero Fill TIMESTAMP_NS

### DIFF
--- a/src/common/operator/string_cast.cpp
+++ b/src/common/operator/string_cast.cpp
@@ -161,6 +161,9 @@ duckdb::string_t StringFromTimestamp(timestamp_t input, Vector &vector) {
 	idx_t nano_length = 0;
 	if (picos) {
 		//	If there are ps, we need all the µs
+		if (!time[3]) {
+			TimeToStringCast::FormatMicros(time[3], micro_buffer);
+		}
 		time_length = 15;
 		nano_length = 6;
 		nano_length -= NumericCast<idx_t>(TimeToStringCast::FormatMicros(picos, nano_buffer));

--- a/test/sql/types/timestamp/test_timestamp_types.test
+++ b/test/sql/types/timestamp/test_timestamp_types.test
@@ -85,6 +85,12 @@ select '1969-01-01T23:59:59.9999999'::timestamp_ns;
 ----
 1969-01-01 23:59:59.9999999
 
+# Zero µs witn non-zero ns
+query I
+SELECT '1970-01-01 00:00:00.000000123'::TIMESTAMP_NS;
+----
+1970-01-01 00:00:00.000000123
+
 # TIME conversions are now supported
 query I
 select sec::TIME from timestamp;


### PR DESCRIPTION
* Make sure that zero µss  are filled in for non-zero ns

fixes: duckdb#18035