### PR TITLE
Unittester: add `extension_install` and `extension_loading` options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ FORCE_WARN_UNUSED_FLAG ?=
 DISABLE_UNITY_FLAG ?=
 DISABLE_SANITIZER_FLAG ?=
 FORCE_32_BIT_FLAG ?=
+CONFIGS_DIR = ./test/configs
+
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJ_DIR := $(dir $(MKFILE_PATH))
@@ -478,6 +480,10 @@ format-main:
 
 format-feature:
 	python3 scripts/format.py feature --fix --noconfirm
+
+format-configs:
+	$(foreach file, $(wildcard $(CONFIGS_DIR)/*), jq . < "$(file)" > "$(file).tmp" && mv "$(file).tmp" "$(file)" ;)
+
 
 third_party/sqllogictest:
 	git clone --depth=1 --branch hawkfish-statistical-rounding https://github.com/duckdb/sqllogictest.git third_party/sqllogictest

--- a/test/configs/autoload_local.json
+++ b/test/configs/autoload_local.json
@@ -1,0 +1,6 @@
+{
+  "description": "Run test in autoloading mode, local extensions only",
+  "extension_loading": "all",
+  "extension_install": "local",
+  "skip_compiled": "true"
+}

--- a/test/configs/autoload_signed.json
+++ b/test/configs/autoload_signed.json
@@ -1,0 +1,6 @@
+{
+  "description": "Run test in autoloading mode on remote deployed extensions",
+  "extension_loading": "all",
+  "extension_install": "remote",
+  "skip_compiled": "true"
+}

--- a/test/extension/autoloading_base.test
+++ b/test/extension/autoloading_base.test
@@ -2,6 +2,8 @@
 # description: Base tests for the autoloading mechanism for extensions
 # group: [extension]
 
+require httpfs
+
 # This test assumes icu and json to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO

--- a/test/extension/autoloading_current_setting.test
+++ b/test/extension/autoloading_current_setting.test
@@ -6,6 +6,8 @@
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO
 
+require httpfs
+
 statement ok
 set extension_directory='__TEST_DIR__/autoloading_current_setting'
 

--- a/test/extension/autoloading_filesystems.test
+++ b/test/extension/autoloading_filesystems.test
@@ -2,6 +2,8 @@
 # description: Tests for autoloading with filesystems
 # group: [extension]
 
+require httpfs
+
 # This test assumes icu and json to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO

--- a/test/extension/autoloading_load_only.test
+++ b/test/extension/autoloading_load_only.test
@@ -2,6 +2,8 @@
 # description: Tests for autoloading with no autoinstall
 # group: [extension]
 
+require httpfs
+
 # This test assumes icu and json to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO

--- a/test/extension/autoloading_reset_setting.test
+++ b/test/extension/autoloading_reset_setting.test
@@ -2,6 +2,8 @@
 # description: Testing reset setting that lives in an extension that can be autoloaded
 # group: [extension]
 
+require httpfs
+
 # This test assumes httpfs and json to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO

--- a/test/extension/duckdb_extension_settings.test
+++ b/test/extension/duckdb_extension_settings.test
@@ -2,6 +2,8 @@
 # description: settings for extensions
 # group: [extension]
 
+require httpfs
+
 statement ok
 SET autoinstall_known_extensions = true;
 

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -188,6 +188,8 @@ TestConfiguration::ExtensionInstallMode TestConfiguration::GetExtensionInstallMo
 		return TestConfiguration::ExtensionInstallMode::LOCAL_ONLY;
 	} else if (res == "remote" || res == "remote_only") {
 		return TestConfiguration::ExtensionInstallMode::REMOTE_ONLY;
+	} else if (res == "remote_no_checks" || res == "release_mode") {
+		return TestConfiguration::ExtensionInstallMode::REMOTE_NO_CHECKS;
 	} else if (res == "either") {
 		return TestConfiguration::ExtensionInstallMode::EITHER;
 	}

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -22,7 +22,7 @@ namespace duckdb {
 class TestConfiguration {
 public:
 	enum class ExtensionLoadingMode { NONE = 0, AUTOLOAD_ONLY = 1, ALL = 2 };
-	enum class ExtensionInstallMode { NONE = 0, LOCAL_ONLY = 1, REMOTE_ONLY = 2, EITHER = 3 };
+	enum class ExtensionInstallMode { NONE = 0, LOCAL_ONLY = 1, REMOTE_ONLY = 2, EITHER = 3, REMOTE_NO_CHECKS = 4 };
 
 	static TestConfiguration &Get();
 

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -21,6 +21,9 @@ namespace duckdb {
 
 class TestConfiguration {
 public:
+	enum class ExtensionLoadingMode { NONE = 0, AUTOLOAD_ONLY = 1, ALL = 2 };
+	enum class ExtensionInstallMode { NONE = 0, LOCAL_ONLY = 1, REMOTE_ONLY = 2, EITHER = 3 };
+
 	static TestConfiguration &Get();
 
 	void Initialize();
@@ -42,6 +45,8 @@ public:
 	bool GetSkipCompiledTests();
 	DebugVectorVerification GetVectorVerification();
 	DebugInitialize GetDebugInitialize();
+	ExtensionLoadingMode GetExtensionLoadingMode();
+	ExtensionInstallMode GetExtensionInstallMode();
 	bool ShouldSkipTest(const string &test_name);
 	string OnInitCommand();
 	string OnLoadCommand();

--- a/test/sql/function/list/lambdas/incorrect.test
+++ b/test/sql/function/list/lambdas/incorrect.test
@@ -2,6 +2,8 @@
 # description: Test incorrect usage of the lambda functions
 # group: [lambdas]
 
+require no_extension_autoloading "EXPECTED: This tests is not compatible with JSON extension, that will otherwise be autoloaded"
+
 statement ok
 PRAGMA enable_verification;
 

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -11,6 +11,7 @@
 #include "duckdb.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "sqllogic_command.hpp"
+#include "test_config.hpp"
 
 namespace duckdb {
 
@@ -68,6 +69,8 @@ public:
 	bool skip_reload = false;
 	unordered_map<string, string> environment_variables;
 	string local_extension_repo;
+	TestConfiguration::ExtensionLoadingMode loading_mode;
+	TestConfiguration::ExtensionInstallMode install_mode;
 
 	// If these error msgs occur in a test, the test will abort but still count as passed
 	unordered_set<string> ignore_error_messages = {"HTTP", "Unable to connect"};


### PR DESCRIPTION
PR on top of https://github.com/duckdb/duckdb/pull/18042, now adding logic for configuring extension install and load behaviour.

Adds to unittest configurations two new parameters:

#### `extension_loading`
Options:
* `none` (the default)
* `autoload` or `autoload_only`
* `all`

Decides when to perform loading of extensions. Current default is the same as now, that is never do it, while one can opt in to do so only for autoloadable extensions (that is currently possible by setting `LOCAL_EXTENSION_REPO`) and always, that was currently not implemented.

#### `extension_install`
Options:
* `none` (the default)
* `local` or `local_only`
* `remote` or `remote_only`
* `either`
* `release_mode` or `remote_no_checks`

Decide how to perform install of extensions. Currrent default is the same as now, that is never do it, while one can opt to allow: available local extensions (checked, so one of them missing skip the relevant tests), remote extensions (checked), either local or, if not present, remote.
A `release_mode` or alternatively `remote_no_checks` is added that forces loading only of remote extensions, and perform no checks on them being available, that means a missing extension will be a missing test (instead of a skipped test) AND autoinstall is more thoroughly tested.

#### How to use them
```
GEN=ninja make
./build/release/test/unittest --test-config test/configs/autoload_local.json
```
Should run all tests using either the statically linked in extensions OR the one available in the  in the local repository at `build/release/repository` (can be overridden via `LOCAL_EXTENSION_REPO`).
Take a note of the skipped tests, where for example the geoparquet one will be skipped to due spatial missing (given in the default config it should not have been built).

```
GEN=ninja make
./build/release/test/unittest --test-config test/configs/autoload_signed.json
```
Should run all tests using either the statically linked in extensions OR the one available in the default remote repository at `http://extensions.duckdb.org`.
Take a note of the skipped tests, where if you are on a commit which has extensions built then you should see geoparquet tests with a `require spatial` being performed.
Note that on a commit with no-remote extensions this might not be super useful, but it's intended to get most usage for extension developers (that might be tied to a recent `duckdb` version where extensions have been built).
Also this forces extensions to be signed, so if you have installed an unsigned extension to the default extension folder, if that's picked up it might be a cause for errors.

Note that this will consume network. But if this works as intended running `autoload_signed` while removed from the network should still succeed.

These new options and the connected configurations are currently used only in a single CI job that basically only checks they make sense. More widespread usage in duckdb/duckdb or making this easily usable from extensions is to be considered as follow ups.

#### Behaviour changes
There should be none, current behaviour, included `LOCAL_EXTENSION_REPO` is unchanged when not using a test configuration, and it should be composable in a reasonable way when using both (that is, `LOCAL_EXTENSION_REPO` is used as the folder).
`LOCAL_EXTENSION_REPO` can be considered to be removed after this PR, but I wanted to keep scope limited.

#### TODO
1. currently `LOCAL_EXTENSION_REPO` is assumed to be `build/release/repository`, if one would like to use a different one it needs to be overridden like: `LOCAL_EXTENSION_REPO='build/reldebug/repository`. The default path could be constructed automatically, to be done in a follow up.
2. proposal to add `require extension_name no_autoload` has not been addressed as part of this PR, but this has been made in a way that is simple to plug in

#### Bonus
Performed some cleanup such as:
* adding `skip_compiled` to the existing configs
* add a `make format-configs` to format (using `jq` the configuration files in `test/configs`)
* adding `require httpfs` where needed in some tests
* fixup `test/sql/function/list/lambdas/incorrect.test` that will not work the same if JSON is present (testing logic is still not completely correct, but should hide the problem)