### PR TITLE
Avoid adding commands read from a file to the shell history

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -56,6 +56,8 @@ enum class RenderMode : uint32_t {
 
 enum class PrintOutput { STDOUT, STDERR };
 
+enum class InputMode { STANDARD, FILE };
+
 enum class LargeNumberRendering { NONE = 0, FOOTER = 1, ALL = 2, DEFAULT = 3 };
 
 /*
@@ -203,11 +205,11 @@ public:
 	void NewTempFile(const char *zSuffix);
 	int DoMetaCommand(char *zLine);
 
-	int RunOneSqlLine(char *zSql);
+	int RunOneSqlLine(InputMode mode, char *zSql);
 	string GetDefaultDuckDBRC();
 	bool ProcessDuckDBRC(const char *file);
 	bool ProcessFile(const string &file, bool is_duckdb_rc = false);
-	int ProcessInput();
+	int ProcessInput(InputMode mode);
 };
 
 } // namespace duckdb_shell

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3856,7 +3856,7 @@ bool ShellState::ReadFromFile(const string &file) {
 		utf8_printf(stderr, "Error: cannot open \"%s\"\n", file.c_str());
 		rc = 1;
 	} else {
-		rc = ProcessInput();
+		rc = ProcessInput(InputMode::FILE);
 		fclose(in);
 	}
 	in = inSaved;
@@ -4391,7 +4391,7 @@ static bool _all_whitespace(const char *z) {
 /*
 ** Run a single line of SQL.  Return the number of errors.
 */
-int ShellState::RunOneSqlLine(char *zSql) {
+int ShellState::RunOneSqlLine(InputMode mode, char *zSql) {
 	int rc;
 	char *zErrMsg = nullptr;
 
@@ -4400,7 +4400,7 @@ int ShellState::RunOneSqlLine(char *zSql) {
 		resolve_backslashes(zSql);
 	}
 #ifndef SHELL_USE_LOCAL_GETLINE
-	if (zSql && *zSql && *zSql != '\3') {
+	if (mode == InputMode::STANDARD && zSql && *zSql && *zSql != '\3') {
 		shell_add_history(zSql);
 	}
 #endif
@@ -4431,7 +4431,7 @@ int ShellState::RunOneSqlLine(char *zSql) {
 **
 ** Return the number of errors.
 */
-int ShellState::ProcessInput() {
+int ShellState::ProcessInput(InputMode mode) {
 	char *zLine = nullptr; /* A single input line */
 	char *zSql = nullptr;  /* Accumulated SQL text */
 	idx_t nLine;           /* Length of current line */
@@ -4486,7 +4486,7 @@ int ShellState::ProcessInput() {
 			}
 			if (zLine[0] == '.') {
 #ifndef SHELL_USE_LOCAL_GETLINE
-				if (zLine && *zLine && *zLine != '\3')
+				if (mode == InputMode::STANDARD && zLine && *zLine && *zLine != '\3')
 					shell_add_history(zLine);
 #endif
 				rc = DoMetaCommand(zLine);
@@ -4520,7 +4520,7 @@ int ShellState::ProcessInput() {
 			nSql += nLine;
 		}
 		if (nSql && line_contains_semicolon(&zSql[nSqlPrior], nSql - nSqlPrior) && sqlite3_complete(zSql)) {
-			errCnt += RunOneSqlLine(zSql);
+			errCnt += RunOneSqlLine(mode, zSql);
 			nSql = 0;
 			if (outCount) {
 				ResetOutput();
@@ -4536,7 +4536,7 @@ int ShellState::ProcessInput() {
 		}
 	}
 	if (nSql && !_all_whitespace(zSql)) {
-		errCnt += RunOneSqlLine(zSql);
+		errCnt += RunOneSqlLine(mode, zSql);
 	}
 	free(zSql);
 	free(zLine);
@@ -4641,7 +4641,7 @@ bool ShellState::ProcessFile(const string &file, bool is_duckdb_rc) {
 		if (stdin_is_interactive && is_duckdb_rc) {
 			utf8_printf(stderr, "-- Loading resources from %s\n", file.c_str());
 		}
-		rc = ProcessInput();
+		rc = ProcessInput(InputMode::FILE);
 		fclose(in);
 	} else if (!is_duckdb_rc) {
 		utf8_printf(stderr, "Failed to read file \"%s\"\n", file.c_str());
@@ -5160,7 +5160,7 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 			linenoiseSetCompletionCallback(linenoise_completion);
 #endif
 			data.in = 0;
-			rc = data.ProcessInput();
+			rc = data.ProcessInput(InputMode::STANDARD);
 			if (zHistory) {
 				shell_stifle_history(2000);
 				shell_write_history(zHistory);
@@ -5168,7 +5168,7 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 			}
 		} else {
 			data.in = stdin;
-			rc = data.ProcessInput();
+			rc = data.ProcessInput(InputMode::STANDARD);
 		}
 	}
 	data.SetTableName(0);


### PR DESCRIPTION
Previously when executing files, through e.g. `.read file.sql`, the content of those files would be added to the shell history.

This is rather confusing and can fill up the history with large statements quickly. It also does not match the behavior of other shells (e.g. sqlite or postgres). 

This PR makes it so that commands that are read from a file are not added to the shell history.