### PR TITLE
set ::error:: annotations for test runners

### DIFF
--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -214,8 +214,12 @@ if summary and not no_summary:
         if failure_message["old_failure"] != failure_message["new_failure"]:
             print("Old:\n", failure_message["old_failure"])
             print("New:\n", failure_message["new_failure"])
+            # set warnings
+            subprocess.run(f'echo "::warning::{i}: {failure_message["benchmark"]}::"Old::", {failure_message["old_failure"]}::New::", {failure_message["new_failure"]}"', shell=True)
         else:
             print(failure_message["old_failure"])
+            # set warnings
+            subprocess.run(f'echo "::warning::{i}: {failure_message["benchmark"]}::"Old::", {failure_message["old_failure"]}"', shell=True)
         print("-", 52)
 
 exit(exit_code)

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -215,11 +215,17 @@ if summary and not no_summary:
             print("Old:\n", failure_message["old_failure"])
             print("New:\n", failure_message["new_failure"])
             # set warnings
-            subprocess.run(f'echo "::warning::{i}: {failure_message["benchmark"]}::Old:: {failure_message["old_failure"]}::New:: {failure_message["new_failure"]}"', shell=True)
+            subprocess.run(
+                f'echo "::warning::{i}: {failure_message["benchmark"]}::Old:: {failure_message["old_failure"]}::New:: {failure_message["new_failure"]}"',
+                shell=True,
+            )
         else:
             print(failure_message["old_failure"])
             # set warnings
-            subprocess.run(f'echo "::warning::{i}: {failure_message["benchmark"]}::"Old:: {failure_message["old_failure"]}"', shell=True)
+            subprocess.run(
+                f'echo "::warning::{i}: {failure_message["benchmark"]}::"Old:: {failure_message["old_failure"]}"',
+                shell=True,
+            )
         print("-", 52)
 
 exit(exit_code)

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -211,7 +211,7 @@ if summary and not no_summary:
 '''
     )
     # check the value is "true" otherwise you'll see the prefix in local run outputs
-    prefix = "::warning::" if ('CI' in os.environ and os.getenv('CI') == 'true') else ""
+    prefix = "::error::" if ('CI' in os.environ and os.getenv('CI') == 'true') else ""
     for i, failure_message in enumerate(summary, start=1):
         prefix_str = f"{prefix}{i}" if len(prefix) > 0 else f"{i}"
         print(f"{prefix_str}: ", failure_message["benchmark"])

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -215,17 +215,19 @@ if summary and not no_summary:
             print("Old:\n", failure_message["old_failure"])
             print("New:\n", failure_message["new_failure"])
             # set warnings
-            subprocess.run(
-                f'echo "::warning::{i}: {failure_message["benchmark"]}::Old:: {failure_message["old_failure"]}::New:: {failure_message["new_failure"]}"',
-                shell=True,
-            )
+            if 'CI' in os.environ:
+                subprocess.run(
+                    f'echo "::warning::{i}: {failure_message["benchmark"]}::Old:: {failure_message["old_failure"]}::New:: {failure_message["new_failure"]}"',
+                    shell=True,
+                )
         else:
             print(failure_message["old_failure"])
             # set warnings
-            subprocess.run(
-                f'echo "::warning::{i}: {failure_message["benchmark"]}::"Old:: {failure_message["old_failure"]}"',
-                shell=True,
-            )
+            if 'CI' in os.environ:
+                subprocess.run(
+                    f'echo "::warning::{i}: {failure_message["benchmark"]}::"Old:: {failure_message["old_failure"]}"',
+                    shell=True,
+                )
         print("-", 52)
 
 exit(exit_code)

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -215,11 +215,11 @@ if summary and not no_summary:
             print("Old:\n", failure_message["old_failure"])
             print("New:\n", failure_message["new_failure"])
             # set warnings
-            subprocess.run(f'echo "::warning::{i}: {failure_message["benchmark"]}::"Old::", {failure_message["old_failure"]}::New::", {failure_message["new_failure"]}"', shell=True)
+            subprocess.run(f'echo "::warning::{i}: {failure_message["benchmark"]}::Old:: {failure_message["old_failure"]}::New:: {failure_message["new_failure"]}"', shell=True)
         else:
             print(failure_message["old_failure"])
             # set warnings
-            subprocess.run(f'echo "::warning::{i}: {failure_message["benchmark"]}::"Old::", {failure_message["old_failure"]}"', shell=True)
+            subprocess.run(f'echo "::warning::{i}: {failure_message["benchmark"]}::"Old:: {failure_message["old_failure"]}"', shell=True)
         print("-", 52)
 
 exit(exit_code)

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -5,6 +5,7 @@ import shutil
 from benchmark import BenchmarkRunner, BenchmarkRunnerConfig
 from dataclasses import dataclass
 from typing import Optional, List, Union
+import subprocess
 
 print = functools.partial(print, flush=True)
 
@@ -209,25 +210,16 @@ if summary and not no_summary:
 ====================================================
 '''
     )
+    # check the value is "true" otherwise you'll see the prefix in local run outputs
+    prefix = "::warning::" if ('CI' in os.environ and os.getenv('CI') == 'true') else ""
     for i, failure_message in enumerate(summary, start=1):
-        print(f"{i}: ", failure_message["benchmark"])
+        prefix_str = f"{prefix}{i}" if len(prefix) > 0 else f"{i}"
+        print(f"{prefix_str}: ", failure_message["benchmark"])
         if failure_message["old_failure"] != failure_message["new_failure"]:
             print("Old:\n", failure_message["old_failure"])
             print("New:\n", failure_message["new_failure"])
-            # set warnings
-            if 'CI' in os.environ:
-                subprocess.run(
-                    f'echo "::warning::{i}: {failure_message["benchmark"]}::Old:: {failure_message["old_failure"]}::New:: {failure_message["new_failure"]}"',
-                    shell=True,
-                )
         else:
             print(failure_message["old_failure"])
-            # set warnings
-            if 'CI' in os.environ:
-                subprocess.run(
-                    f'echo "::warning::{i}: {failure_message["benchmark"]}::"Old:: {failure_message["old_failure"]}"',
-                    shell=True,
-                )
         print("-", 52)
 
 exit(exit_code)

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -315,4 +315,8 @@ if summarize_failures and len(error_container):
     for i, error in enumerate(error_container.get_errors(), start=1):
         print(f"\n{i}:", error["test"], "\n")
         print(error["stderr"])
+        # set warnings
+        subprocess.run(f'echo "::warning::{i}: {error["test"]}"', shell=True)
+        subprocess.run(f'echo "::warning::{i}: {error["stderr"]}"', shell=True)
+
 exit(1)

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -316,7 +316,6 @@ if summarize_failures and len(error_container):
         print(f"\n{i}:", error["test"], "\n")
         print(error["stderr"])
         # set warnings
-        subprocess.run(f'echo "::warning::{i}: {error["test"]}"', shell=True)
-        subprocess.run(f'echo "::warning::{i}: {error["stderr"]}"', shell=True)
+        subprocess.run(f'echo "::warning::{i}: {error["test"]}"::{error["stderr"]}"', shell=True)
 
 exit(1)

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -315,7 +315,8 @@ if summarize_failures and len(error_container):
     for i, error in enumerate(error_container.get_errors(), start=1):
         print(f"\n{i}:", error["test"], "\n")
         print(error["stderr"])
-        # set warnings
-        subprocess.run(f'echo "::warning::{i}: {error["test"]}"::{error["stderr"]}"', shell=True)
+        # set warnings if in CI
+        if 'CI' in os.environ:
+            subprocess.run(f'echo "::warning::{i}: {error["test"]}"::{error["stderr"]}"', shell=True)
 
 exit(1)

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -315,8 +315,5 @@ if summarize_failures and len(error_container):
     for i, error in enumerate(error_container.get_errors(), start=1):
         print(f"\n{i}:", error["test"], "\n")
         print(error["stderr"])
-        # set warnings if in CI
-        if 'CI' in os.environ:
-            subprocess.run(f'echo "::warning::{i}: {error["test"]}"::{error["stderr"]}"', shell=True)
 
 exit(1)

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -35,10 +35,6 @@ void SQLLogicTestLogger::PrintSummaryHeader(const std::string &file_name) {
 		LogFailure("\n" + failures_count + ". " + file_name + "\n");
 		PrintLineSep();
 	}
-	// const char *ci = std::getenv("CI");
-	// if (ci) {
-	// 	std::cout << "::warning::" << file_name << std::endl;
-	// }
 }
 
 void SQLLogicTestLogger::PrintExpectedResult(const vector<string> &values, idx_t columns, bool row_wise) {

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -35,6 +35,10 @@ void SQLLogicTestLogger::PrintSummaryHeader(const std::string &file_name) {
 		LogFailure("\n" + failures_count + ". " + file_name + "\n");
 		PrintLineSep();
 	}
+	// const char *ci = std::getenv("CI");
+	// if (ci) {
+	// 	std::cout << "::warning::" << file_name << std::endl;
+	// }
 }
 
 void SQLLogicTestLogger::PrintExpectedResult(const vector<string> &values, idx_t columns, bool row_wise) {
@@ -130,6 +134,10 @@ void SQLLogicTestLogger::PrintErrorHeader(const string &file_name, idx_t query_l
 	oss << termcolor::red << termcolor::bold << description << " " << termcolor::reset;
 	if (!file_name.empty()) {
 		oss << termcolor::bold << "(" << file_name << ":" << query_line << ")!" << termcolor::reset;
+	}
+	const char *ci = std::getenv("CI");
+	if (ci) {
+		std::cout << "::warning::" << oss.str() << std::endl;
 	}
 	LogFailure(oss.str() + "\n");
 }

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -136,10 +136,9 @@ void SQLLogicTestLogger::PrintErrorHeader(const string &file_name, idx_t query_l
 		oss << termcolor::bold << "(" << file_name << ":" << query_line << ")!" << termcolor::reset;
 	}
 	const char *ci = std::getenv("CI");
-	if (ci) {
-		std::cout << "::warning::" << oss.str() << std::endl;
-	}
-	LogFailure(oss.str() + "\n");
+	// check the value is "true" otherwise you'll see the prefix in local run outputs
+	auto prefix = (ci && string(ci) == "true") ? "\n::warning::" : "";
+	LogFailure(prefix + oss.str() + "\n");
 }
 
 void SQLLogicTestLogger::PrintErrorHeader(const string &description) {

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -138,7 +138,7 @@ void SQLLogicTestLogger::PrintErrorHeader(const string &file_name, idx_t query_l
 void SQLLogicTestLogger::LogFailureAnnotation(const string header) {
 	const char *ci = std::getenv("CI");
 	// check the value is "true" otherwise you'll see the prefix in local run outputs
-	auto prefix = (ci && string(ci) == "true") ? "\n::warning::" : "";
+	auto prefix = (ci && string(ci) == "true") ? "\n::error::" : "";
 	std::cout << prefix << header << std::endl;
 }
 

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -131,10 +131,15 @@ void SQLLogicTestLogger::PrintErrorHeader(const string &file_name, idx_t query_l
 	if (!file_name.empty()) {
 		oss << termcolor::bold << "(" << file_name << ":" << query_line << ")!" << termcolor::reset;
 	}
+	LogFailure(oss.str() + "\n");
+	LogFailureAnnotation(oss.str());
+}
+
+void SQLLogicTestLogger::LogFailureAnnotation(const string header) {
 	const char *ci = std::getenv("CI");
 	// check the value is "true" otherwise you'll see the prefix in local run outputs
 	auto prefix = (ci && string(ci) == "true") ? "\n::warning::" : "";
-	LogFailure(prefix + oss.str() + "\n");
+	std::cout << prefix << header << std::endl;
 }
 
 void SQLLogicTestLogger::PrintErrorHeader(const string &description) {

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -57,7 +57,7 @@ public:
 
 	static void AppendFailure(const string &log_message);
 	static void LogFailure(const string &log_message);
-	// static string GetFailureSummary();
+	static void LogFailureAnnotation(const string header);
 
 private:
 	lock_guard<mutex> log_lock;


### PR DESCRIPTION
We can have [warning annotations](url) for the `FAILURES SUMMARY` items on the Summary page of the workflow.

<img width="557" alt="Screenshot 2025-06-26 at 17 24 59" src="https://github.com/user-attachments/assets/af7903cf-eefe-4ec8-98b4-67ce29c0c8fc" />

GH Actions allows to set warnings using `echo` command, but it has to be executed in shell. We'd like to set them dynamically, so for the workflows using Python test runners like `scripts/run_tests_one_by_one.py` we can use `subprocess.run` to have these annotation on workflow's summary page.