### PR TITLE
Implement `replace_type` function

### DIFF
--- a/extension/core_functions/function_list.cpp
+++ b/extension/core_functions/function_list.cpp
@@ -318,6 +318,7 @@ static const StaticFunctionDefinition core_functions[] = {
 	DUCKDB_AGGREGATE_FUNCTION(RegrSYYFun),
 	DUCKDB_SCALAR_FUNCTION_SET(RepeatFun),
 	DUCKDB_SCALAR_FUNCTION(ReplaceFun),
+	DUCKDB_SCALAR_FUNCTION(ReplaceTypeFun),
 	DUCKDB_AGGREGATE_FUNCTION_SET(ReservoirQuantileFun),
 	DUCKDB_SCALAR_FUNCTION(ReverseFun),
 	DUCKDB_SCALAR_FUNCTION(RightFun),

--- a/extension/core_functions/include/core_functions/scalar/generic_functions.hpp
+++ b/extension/core_functions/include/core_functions/scalar/generic_functions.hpp
@@ -195,4 +195,14 @@ struct CastToTypeFun {
 	static ScalarFunction GetFunction();
 };
 
+struct ReplaceTypeFun {
+	static constexpr const char *Name = "replace_type";
+	static constexpr const char *Parameters = "param,type1,type2";
+	static constexpr const char *Description = "Casts all fields of type1 to type2";
+	static constexpr const char *Example = "replace_type({duck: 3.141592653589793::DOUBLE}, NULL::DOUBLE, NULL::DECIMAL(15,2))";
+	static constexpr const char *Categories = "";
+
+	static ScalarFunction GetFunction();
+};
+
 } // namespace duckdb

--- a/extension/core_functions/scalar/generic/CMakeLists.txt
+++ b/extension/core_functions/scalar/generic/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library_unity(
   current_setting.cpp
   hash.cpp
   least.cpp
+  replace_type.cpp
   stats.cpp
   typeof.cpp
   system_functions.cpp)

--- a/extension/core_functions/scalar/generic/functions.json
+++ b/extension/core_functions/scalar/generic/functions.json
@@ -129,5 +129,12 @@
         "description": "Casts the first argument to the type of the second argument",
         "example": "cast_to_type('42', NULL::INTEGER)",
         "type": "scalar_function"
+    },
+    {
+        "name": "replace_type",
+        "parameters": "param,type1,type2",
+        "description": "Casts all fields of type1 to type2",
+        "example": "replace_type({duck: 3.141592653589793::DOUBLE}, NULL::DOUBLE, NULL::DECIMAL(15,2))",
+        "type": "scalar_function"
     }
 ]

--- a/extension/core_functions/scalar/generic/replace_type.cpp
+++ b/extension/core_functions/scalar/generic/replace_type.cpp
@@ -1,0 +1,34 @@
+#include "core_functions/scalar/generic_functions.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/common/type_visitor.hpp"
+
+namespace duckdb {
+
+static void ReplaceTypeFunction(DataChunk &, ExpressionState &, Vector &) {
+	throw InternalException("ReplaceTypeFunction function cannot be executed directly");
+}
+
+unique_ptr<Expression> BindReplaceTypeFunction(FunctionBindExpressionInput &input) {
+	const auto &from = input.children[1]->return_type;
+	const auto &to = input.children[2]->return_type;
+	if (from.id() == LogicalTypeId::UNKNOWN || to.id() == LogicalTypeId::UNKNOWN) {
+		// parameters - unknown return type
+		throw ParameterNotResolvedException();
+	}
+	if (to.id() == LogicalTypeId::SQLNULL) {
+		throw InvalidInputException("replace_type cannot be used to replace type with NULL");
+	}
+	const auto return_type = TypeVisitor::VisitReplace(
+	    input.children[0]->return_type, [&from, &to](const LogicalType &type) { return type == from ? to : type; });
+	return BoundCastExpression::AddCastToType(input.context, std::move(input.children[0]), return_type);
+}
+
+ScalarFunction ReplaceTypeFun::GetFunction() {
+	auto fun =
+	    ScalarFunction({LogicalType::ANY, LogicalType::ANY, LogicalType::ANY}, LogicalType::ANY, ReplaceTypeFunction);
+	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	fun.bind_expression = BindReplaceTypeFunction;
+	return fun;
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -516,6 +516,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"regr_syy", "core_functions", CatalogType::AGGREGATE_FUNCTION_ENTRY},
     {"repeat", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"replace", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"replace_type", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"reservoir_quantile", "core_functions", CatalogType::AGGREGATE_FUNCTION_ENTRY},
     {"reverse", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"right", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},

--- a/test/sql/function/generic/replace_type.test
+++ b/test/sql/function/generic/replace_type.test
@@ -1,0 +1,81 @@
+# name: test/sql/function/generic/replace_type.test
+# description: Test replace_type function
+# group: [generic]
+
+statement ok
+PRAGMA enable_verification
+
+# start off with mirrorring all cast_to_type tests as these functions are so similar
+query I
+SELECT replace_type('  42', NULL::VARCHAR, NULL::INT)
+----
+42
+
+statement error
+SELECT replace_type('hello', NULL::VARCHAR, NULL::INT)
+----
+Conversion Error
+
+statement ok
+CREATE OR REPLACE MACRO try_trim_null(s) AS CASE WHEN typeof(s)=='VARCHAR' THEN replace_type(nullif(trim(s::VARCHAR), ''), NULL::VARCHAR, s) ELSE s END;
+
+query III
+SELECT try_trim_null(42) as trim_int, try_trim_null('  col  ') as trim_varchar, try_trim_null('') as trim_empty;
+----
+42	col	NULL
+
+statement ok
+create table tbl(i int, v varchar);
+
+statement ok
+insert into tbl values (42, ' hello '), (100, '   ');
+
+query II
+SELECT try_trim_null(COLUMNS(*)) FROM tbl
+----
+42	hello
+100	NULL
+
+# prepared statements
+statement ok
+PREPARE v1 AS SELECT replace_type(' 42', NULL::VARCHAR, ?);
+
+query I
+EXECUTE v1(NULL::INT)
+----
+42
+
+query I
+EXECUTE v1(NULL::VARCHAR)
+----
+ 42
+
+# cast to NULL
+statement error
+SELECT replace_type(42, NULL::INTEGER, NULL);
+----
+cannot be used to replace type with NULL
+
+# works within struct
+query I
+select replace_type({duck: 3.141592653589793::DOUBLE, goose: 2.718281828459045::DOUBLE}, NULL::DOUBLE, NULL::DECIMAL(15,2))
+----
+{'duck': 3.14, 'goose': 2.72}
+
+# map
+query I
+select replace_type(map {'duck': 3.141592653589793::DOUBLE, 'goose': 2.718281828459045::DOUBLE}, NULL::DOUBLE, NULL::DECIMAL(15,2))
+----
+{duck=3.14, goose=2.72}
+
+# list
+query I
+select replace_type([3.141592653589793, 2.718281828459045]::DOUBLE[], NULL::DOUBLE, NULL::DECIMAL(15,2))
+----
+[3.14, 2.72]
+
+# array
+query I
+select replace_type([3.141592653589793, 2.718281828459045]::DOUBLE[2], NULL::DOUBLE, NULL::DECIMAL(15,2))
+----
+[3.14, 2.72]


### PR DESCRIPTION
Similar to the `cast_to_type` utility function, this PR implements the `replace_type` function, which can replace types _within_ nested types. For example:
```sql
SELECT replace_type({
    duck: 3.141592653589793::DOUBLE,
    goose: 2.718281828459045::DOUBLE
}, NULL::DOUBLE, NULL::DECIMAL(15,2)) AS r;
┌─────────────────────────────────────────────────┐
│                        r                        │
│ struct(duck decimal(15,2), goose decimal(15,2)) │
├─────────────────────────────────────────────────┤
│ {'duck': 3.14, 'goose': 2.72}                   │
└─────────────────────────────────────────────────┘
```
It conditionally casts a column of a specified type to a column of another specified type, in this case, it casts from `DOUBLE` to `DECIMAL(15,2)`. It also works on non-nested types, in which case it pretty much does this:
```sql
SELECT CASE WHEN (c) == '<TYPE1>' THEN C::<TYPE2> ELSE C END;
```
