### PR TITLE
Reduce lock contention for the instance cache

### DIFF
--- a/src/include/duckdb/main/db_instance_cache.hpp
+++ b/src/include/duckdb/main/db_instance_cache.hpp
@@ -50,7 +50,8 @@ private:
 
 private:
 	shared_ptr<DuckDB> GetInstanceInternal(const string &database, const DBConfig &config_dict);
-	shared_ptr<DuckDB> CreateInstanceInternal(const string &database, DBConfig &config_dict, bool cache_instance, std::unique_lock<std::mutex> lock,
+	shared_ptr<DuckDB> CreateInstanceInternal(const string &database, DBConfig &config_dict, bool cache_instance,
+	                                          std::unique_lock<std::mutex> lock,
 	                                          const std::function<void(DuckDB &)> &on_create);
 };
 } // namespace duckdb

--- a/src/include/duckdb/main/db_instance_cache.hpp
+++ b/src/include/duckdb/main/db_instance_cache.hpp
@@ -50,9 +50,9 @@ private:
 
 private:
 	shared_ptr<DuckDB> GetInstanceInternal(const string &database, const DBConfig &config,
-	                                       std::unique_lock<std::mutex> &lock);
+	                                       std::unique_lock<std::mutex> &db_instances_lock);
 	shared_ptr<DuckDB> CreateInstanceInternal(const string &database, DBConfig &config_dict, bool cache_instance,
-	                                          std::unique_lock<std::mutex> lock,
+	                                          std::unique_lock<std::mutex> db_instances_lock,
 	                                          const std::function<void(DuckDB &)> &on_create);
 };
 } // namespace duckdb

--- a/src/include/duckdb/main/db_instance_cache.hpp
+++ b/src/include/duckdb/main/db_instance_cache.hpp
@@ -11,8 +11,8 @@
 #include "duckdb/main/connection_manager.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/common/unordered_map.hpp"
-#include "duckdb/function/replacement_scan.hpp"
 #include <functional>
+#include <future>
 
 namespace duckdb {
 class DBInstanceCache;
@@ -43,14 +43,14 @@ public:
 
 private:
 	//! A map with the cached instances <absolute_path/instance>
-	unordered_map<string, weak_ptr<DatabaseCacheEntry>> db_instances;
+	unordered_map<string, std::promise<weak_ptr<DatabaseCacheEntry>>> db_instances;
 
 	//! Lock to alter cache
 	mutex cache_lock;
 
 private:
 	shared_ptr<DuckDB> GetInstanceInternal(const string &database, const DBConfig &config_dict);
-	shared_ptr<DuckDB> CreateInstanceInternal(const string &database, DBConfig &config_dict, bool cache_instance,
+	shared_ptr<DuckDB> CreateInstanceInternal(const string &database, DBConfig &config_dict, bool cache_instance, std::unique_lock<std::mutex> lock,
 	                                          const std::function<void(DuckDB &)> &on_create);
 };
 } // namespace duckdb

--- a/src/include/duckdb/main/db_instance_cache.hpp
+++ b/src/include/duckdb/main/db_instance_cache.hpp
@@ -43,7 +43,7 @@ public:
 
 private:
 	//! A map with the cached instances <absolute_path/instance>
-	unordered_map<string, std::promise<weak_ptr<DatabaseCacheEntry>>> db_instances;
+	unordered_map<string, std::shared_future<weak_ptr<DatabaseCacheEntry>>> db_instances;
 
 	//! Lock to alter cache
 	mutex cache_lock;

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -312,7 +312,8 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	// initialize the system catalog
 	db_manager->InitializeSystemCatalog();
 
-	if (!config.options.database_type.empty()) {
+	if (!config.options.database_type.empty() &&
+	    config.storage_extensions.find(config.options.database_type) == config.storage_extensions.end()) {
 		// if we are opening an extension database - load the extension
 		if (!config.file_system) {
 			throw InternalException("No file system!?");
@@ -442,6 +443,9 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 	}
 	if (new_config.secret_manager) {
 		config.secret_manager = std::move(new_config.secret_manager);
+	}
+	if (!new_config.storage_extensions.empty()) {
+		config.storage_extensions = std::move(new_config.storage_extensions);
 	}
 	if (config.options.maximum_memory == DConstants::INVALID_INDEX) {
 		config.SetDefaultMaxMemory();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -317,7 +317,10 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 		if (!config.file_system) {
 			throw InternalException("No file system!?");
 		}
-		ExtensionHelper::LoadExternalExtension(*this, *config.file_system, config.options.database_type);
+		auto entry = config.storage_extensions.find(config.options.database_type);
+		if (entry == config.storage_extensions.end()) {
+			ExtensionHelper::LoadExternalExtension(*this, *config.file_system, config.options.database_type);
+		}
 	}
 
 	LoadExtensionSettings();
@@ -442,6 +445,9 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 	}
 	if (new_config.secret_manager) {
 		config.secret_manager = std::move(new_config.secret_manager);
+	}
+	if (!new_config.storage_extensions.empty()) {
+		config.storage_extensions = std::move(new_config.storage_extensions);
 	}
 	if (config.options.maximum_memory == DConstants::INVALID_INDEX) {
 		config.SetDefaultMaxMemory();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -312,8 +312,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	// initialize the system catalog
 	db_manager->InitializeSystemCatalog();
 
-	if (!config.options.database_type.empty() &&
-	    config.storage_extensions.find(config.options.database_type) == config.storage_extensions.end()) {
+	if (!config.options.database_type.empty()) {
 		// if we are opening an extension database - load the extension
 		if (!config.file_system) {
 			throw InternalException("No file system!?");
@@ -443,9 +442,6 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 	}
 	if (new_config.secret_manager) {
 		config.secret_manager = std::move(new_config.secret_manager);
-	}
-	if (!new_config.storage_extensions.empty()) {
-		config.storage_extensions = std::move(new_config.storage_extensions);
 	}
 	if (config.options.maximum_memory == DConstants::INVALID_INDEX) {
 		config.SetDefaultMaxMemory();

--- a/src/main/db_instance_cache.cpp
+++ b/src/main/db_instance_cache.cpp
@@ -52,9 +52,9 @@ shared_ptr<DuckDB> DBInstanceCache::GetInstanceInternal(const string &database, 
 	shared_ptr<DuckDB> db_instance;
 	{
 		std::unique_lock<mutex> create_db_lock(cache_entry->update_database_mutex);
-		// cache entry exists - check if the actual database still exists
 		db_instance = cache_entry->database.lock();
 	}
+	// cache entry exists - check if the actual database still exists
 	if (!db_instance) {
 		// if the database does not exist, but the cache entry still exists, the database is being shut down
 		// we need to wait until the database is fully shut down to safely proceed
@@ -122,8 +122,7 @@ shared_ptr<DuckDB> DBInstanceCache::CreateInstanceInternal(const string &databas
 
 shared_ptr<DuckDB> DBInstanceCache::CreateInstance(const string &database, DBConfig &config, bool cache_instance,
                                                    const std::function<void(DuckDB &)> &on_create) {
-	unique_lock<mutex> lock(cache_lock);
-	return CreateInstanceInternal(database, config, cache_instance, std::move(lock), on_create);
+	return CreateInstanceInternal(database, config, cache_instance, unique_lock<mutex>(cache_lock), on_create);
 }
 
 shared_ptr<DuckDB> DBInstanceCache::GetOrCreateInstance(const string &database, DBConfig &config_dict,

--- a/src/main/db_instance_cache.cpp
+++ b/src/main/db_instance_cache.cpp
@@ -83,7 +83,8 @@ shared_ptr<DuckDB> DBInstanceCache::GetInstance(const string &database, const DB
 }
 
 shared_ptr<DuckDB> DBInstanceCache::CreateInstanceInternal(const string &database, DBConfig &config,
-                                                           const bool cache_instance, std::unique_lock<std::mutex> db_instances_lock,
+                                                           const bool cache_instance,
+                                                           std::unique_lock<std::mutex> db_instances_lock,
                                                            const std::function<void(DuckDB &)> &on_create) {
 	D_ASSERT(db_instances_lock.owns_lock());
 	string abs_database_path;

--- a/src/main/db_instance_cache.cpp
+++ b/src/main/db_instance_cache.cpp
@@ -71,9 +71,8 @@ shared_ptr<DuckDB> DBInstanceCache::GetInstanceInternal(const string &database, 
 	}
 	// the database instance exists - check that the config matches
 	if (db_instance->instance->config != config) {
-		throw ConnectionException(
-		    "Can't open a connection to same database file with a different configuration "
-		    "than existing connections");
+		throw ConnectionException("Can't open a connection to same database file with a different configuration "
+		                          "than existing connections");
 	}
 	return db_instance;
 }

--- a/test/api/test_instance_cache.cpp
+++ b/test/api/test_instance_cache.cpp
@@ -51,7 +51,7 @@ struct DelayingStorageExtension : StorageExtension {
 	}
 };
 
-TEST_CASE("Test db creation does not block instance cache", "[integration]") {
+TEST_CASE("Test db creation does not block instance cache", "[api]") {
 	DBInstanceCache instance_cache;
 	using namespace std::chrono;
 

--- a/test/api/test_instance_cache.cpp
+++ b/test/api/test_instance_cache.cpp
@@ -1,12 +1,15 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
 #include "duckdb/main/db_instance_cache.hpp"
+#include "duckdb/storage/storage_extension.hpp"
+#include "duckdb/transaction/duck_transaction_manager.hpp"
+#include "duckdb/catalog/duck_catalog.hpp"
 
 #include <chrono>
+#include <iostream>
 #include <thread>
 
 using namespace duckdb;
-using namespace std;
 
 static void background_thread_connect(DBInstanceCache *instance_cache, std::string *path) {
 	try {
@@ -27,10 +30,53 @@ TEST_CASE("Test parallel connection and destruction of connections with database
 		DBConfig config;
 		auto shared_db = instance_cache.GetOrCreateInstance(path, config, true);
 
-		thread background_thread(background_thread_connect, &instance_cache, &path);
+		std::thread background_thread(background_thread_connect, &instance_cache, &path);
 		shared_db.reset();
 		background_thread.join();
 		TestDeleteFile(path);
 		REQUIRE(1);
 	}
+}
+struct DelayingStorageExtension : StorageExtension {
+	DelayingStorageExtension() {
+		attach = [](StorageExtensionInfo *, ClientContext &, AttachedDatabase &db, const string &, AttachInfo &info,
+		            AccessMode) -> unique_ptr<Catalog> {
+			std::this_thread::sleep_for(std::chrono::seconds(5));
+			return make_uniq_base<Catalog, DuckCatalog>(db);
+		};
+		create_transaction_manager = [](StorageExtensionInfo *, AttachedDatabase &db,
+		                                Catalog &) -> unique_ptr<TransactionManager> {
+			return make_uniq<DuckTransactionManager>(db);
+		};
+	}
+};
+
+void log_time(const std::string &message) {
+	auto now = system_clock::now();
+	auto now_time_t = system_clock::to_time_t(now);
+	std::tm now_tm = *std::localtime(&now_time_t);
+	char buffer[20];
+	std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &now_tm);
+	std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &now_tm);
+	Printer::Print("[" + std::string(buffer) + "] " + message);
+}
+
+TEST_CASE("Test duckdb in memory database queued up after hanging md connection - with instance cache",
+          "[integration]") {
+
+	DBInstanceCache instance_cache;
+	DBConfig db_config;
+	db_config.storage_extensions["delay"] = make_uniq<DelayingStorageExtension>();
+
+	std::thread t1 {[&] {
+		instance_cache.GetOrCreateInstance("delay::memory:", db_config, true);
+	}};
+	std::this_thread::sleep_for(std::chrono::seconds(1));
+	std::thread t2 {[&] {
+		log_time("Create second DB");
+		instance_cache.GetOrCreateInstance(":memory:", db_config, false);
+		log_time("Finished creation");
+	}};
+	t1.join();
+	t2.join();
 }

--- a/test/api/test_instance_cache.cpp
+++ b/test/api/test_instance_cache.cpp
@@ -56,11 +56,12 @@ TEST_CASE("Test db creation does not block instance cache", "[api]") {
 	using namespace std::chrono;
 
 	auto second_creation_was_quick = false;
-	std::thread t1 {[&instance_cache, &second_creation_was_quick]() {
+	shared_ptr<DuckDB> stick_around;
+	std::thread t1 {[&instance_cache, &second_creation_was_quick, &stick_around]() {
 		DBConfig db_config;
 
 		db_config.storage_extensions["delay"] = make_uniq<DelayingStorageExtension>();
-		auto stick_around = instance_cache.GetOrCreateInstance("delay::memory:", db_config, true);
+		stick_around = instance_cache.GetOrCreateInstance("delay::memory:", db_config, true);
 
 		const auto start_time = steady_clock::now();
 		for (idx_t i = 0; i < 10; i++) {


### PR DESCRIPTION
Previously, the instance cache lock was held for the entire duration of a new DuckDB instance's creation. This blocked the creation of any other instances, causing significant contention, especially for slower connections like those to MotherDuck.

This PR resolves the issue by introducing futures to the cache. Now, a future is immediately placed in the cache and the lock is released. The database instance is then created after releasing the lock, with the result being used to populate the future upon completion. This allows multiple instances to be initialized concurrently without blocking.