### PR TITLE
Run Python workflow against both Python 3.9 and 3.13 on PR to ensure …

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -143,8 +143,6 @@ jobs:
         exclude:
           # Speed things up a bit for non-releases
           - isRelease: false
-            python_build: 'cp39-*'
-          - isRelease: false
             python_build: 'cp310-*'
           - isRelease: false
             python_build: 'cp311-*'


### PR DESCRIPTION
…minimum version compatibility

See https://github.com/duckdblabs/duckdb-internal/issues/5192