### PR TITLE
Main.yml: Move very long job from debug to release with `-DDEBUG` and `FORCE_ASSERT`

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
  linux-debug:
-    name: Linux Debug (${{ matrix.tag }})
+    name: Linux RelDebug (${{ matrix.tag }})
     if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-22.04
     strategy:
@@ -73,11 +73,11 @@ jobs:
 
     - name: Build
       shell: bash
-      run:  make debug
+      run:  make reldebug
 
     - name: Output version info
       shell: bash
-      run: ./build/debug/duckdb -c "PRAGMA version;"
+      run: ./build/reldebug/duckdb -c "PRAGMA version;"
 
     - name: Set DUCKDB_INSTALL_LIB for ADBC tests
       shell: bash
@@ -89,7 +89,7 @@ jobs:
     - name: Test
       shell: bash
       run: |
-        python3 scripts/run_tests_one_by_one.py build/debug/test/unittest --tests-per-invocation 100 ${{ matrix.start_offset }} ${{ matrix.end_offset }}
+        python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest --tests-per-invocation 100 ${{ matrix.start_offset }} ${{ matrix.end_offset }}
 
  linux-release:
     name: Linux Release (full suite)

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -35,25 +35,17 @@ env:
 
 jobs:
  linux-debug:
-    name: Linux RelDebug (${{ matrix.tag }})
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    name: Linux DEBUG + sanitizers
+    # This tests release build while enabling slow verifiers (masked by #ifdef DEBUG) and sanitizers
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - tag: 1
-            start_offset: ""
-            end_offset: "--end-offset 2000"
-          - tag: 2
-            start_offset: "--start-offset 2000"
-            end_offset: ""
     env:
       CC: gcc-10
       CXX: g++-10
       TREAT_WARNINGS_AS_ERRORS: 1
       GEN: ninja
       CRASH_ON_ASSERT: 1
+      CMAKE_CXX_FLAGS: '-DDEBUG'
+      FORCE_ASSERT: 1
 
     steps:
     - uses: actions/checkout@v4
@@ -73,11 +65,11 @@ jobs:
 
     - name: Build
       shell: bash
-      run:  make reldebug
+      run:  make release
 
     - name: Output version info
       shell: bash
-      run: ./build/reldebug/duckdb -c "PRAGMA version;"
+      run: ./build/release/duckdb -c "PRAGMA version;"
 
     - name: Set DUCKDB_INSTALL_LIB for ADBC tests
       shell: bash
@@ -89,7 +81,7 @@ jobs:
     - name: Test
       shell: bash
       run: |
-        python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest --tests-per-invocation 100 ${{ matrix.start_offset }} ${{ matrix.end_offset }}
+        python3 scripts/run_tests_one_by_one.py build/release/test/unittest --tests-per-invocation 100
 
  linux-release:
     name: Linux Release (full suite)


### PR DESCRIPTION
Currently we run the standard test suite in `debug` mode, with the aim of testing slow verifiers masked by `#ifdef DEBUG`, enabling D_ASSERT, and running additional sanitizers.
This works, but has a drawback that compiling for `debug` is tied to `-O0`, that is no optimizations performed.

Proposal here is to run this particular step in `release` mode, while:
* passing down `-DDEBUG`, so that slow verifiers masked by `#ifdef DEBUG` are still included
* enabling assertions (those are also turned on when DEBUG is defined or in `relassert` mode)
* enabling extra sanitizers, currently via the `FORCE_ASSERT` CMake flag

Changes as done here are local to the workflow, but we could consider adding another compilation mode, since this might be of general usage.

Currently, on each PR iteration: 2* (15 minutes building + 1h45' testing)
Moving to release + `-DDEBUG -DFORCE_ASSERT`: 20 minutes building + 25 minutes testing

Build step might also be cached, this is 10x improvement for this step, that is at the moment the most expensive one run on every PR.