### PR TITLE
Unittest: Configure skip error messages

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -377,6 +377,12 @@ jobs:
       run: |
         ./build/release/test/unittest --test-config test/configs/prefetch_all_parquet_files.json
 
+    - name: test/configs/no_local_filesystem.json
+      if: (success() || failure()) && steps.build.conclusion == 'success'
+      shell: bash
+      run: |
+        ./build/release/test/unittest --test-config test/configs/no_local_filesystem.json
+
     - name: Test dictionary_expression
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash

--- a/test/configs/no_local_filesystem.json
+++ b/test/configs/no_local_filesystem.json
@@ -1,0 +1,11 @@
+{
+  "description": "Check duckdb without LocalFileSystem enabled",
+  "on_init": "SET disabled_filesystems = 'LocalFileSystem';",
+  "skip_compiled": "true",
+  "skip_error_messages": [
+    "LocalFileSystem"
+  ],
+  "skip_tests": [
+    "test/sql/attach/attach_filepath_roundtrip.test"
+  ]
+}

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -37,6 +37,7 @@ static const TestConfigOption test_config_options[] = {
     {"on_new_connection", "SQL statements to execute on connection", LogicalType::VARCHAR, nullptr},
     {"skip_tests", "Tests to be skipped", LogicalType::LIST(LogicalType::VARCHAR), nullptr},
     {"skip_compiled", "Skip compiled tests", LogicalType::BOOLEAN, nullptr},
+    {"skip_error_messages", "Skip compiled tests", LogicalType::LIST(LogicalType::VARCHAR), nullptr},
     {"statically_loaded_extensions", "Extensions to be loaded (from the statically available one)",
      LogicalType::LIST(LogicalType::VARCHAR), nullptr},
     {nullptr, nullptr, LogicalType::INVALID, nullptr},
@@ -197,6 +198,22 @@ vector<string> TestConfiguration::ExtensionToBeLoadedOnLoad() {
 		}
 	} else {
 		res.push_back("core_functions");
+	}
+	return res;
+}
+
+vector<string> TestConfiguration::ErrorMessagesToBeSkipped() {
+	vector<string> res;
+	auto entry = options.find("skip_error_messages");
+	if (entry != options.end()) {
+		vector<Value> ext_list = ListValue::GetChildren(entry->second);
+
+		for (auto ext : ext_list) {
+			res.push_back(ext.GetValue<string>());
+		}
+	} else {
+		res.push_back("HTTP");
+		res.push_back("Unable to connect");
 	}
 	return res;
 }

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -47,6 +47,7 @@ public:
 	string OnLoadCommand();
 	string OnConnectionCommand();
 	vector<string> ExtensionToBeLoadedOnLoad();
+	vector<string> ErrorMessagesToBeSkipped();
 
 	static bool TestForceStorage();
 	static bool TestForceReload();

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -25,11 +25,11 @@ bool TestResultHelper::CheckQueryResult(const Query &query, ExecuteContext &cont
 
 	SQLLogicTestLogger logger(context, query);
 	if (result.HasError()) {
-		logger.UnexpectedFailure(result);
 		if (SkipErrorMessage(result.GetError())) {
 			runner.finished_processing_file = true;
 			return true;
 		}
+		logger.UnexpectedFailure(result);
 		return false;
 	}
 	idx_t row_count = result.RowCount();
@@ -289,8 +289,10 @@ bool TestResultHelper::CheckStatementResult(const Statement &statement, ExecuteC
 					success = MatchesRegex(logger, result.ToString(), statement.expected_error);
 				}
 				if (!success) {
-					logger.ExpectedErrorMismatch(statement.expected_error, result);
-					return false;
+					if (!SkipErrorMessage(result.GetError())) {
+						logger.ExpectedErrorMismatch(statement.expected_error, result);
+						return false;
+					}
 				}
 				string success_log =
 				    StringUtil::Format("CheckStatementResult: %s:%d", statement.file_name, statement.query_line);
@@ -302,11 +304,11 @@ bool TestResultHelper::CheckStatementResult(const Statement &statement, ExecuteC
 
 	/* Report an error if the results do not match expectation */
 	if (error) {
-		logger.UnexpectedStatement(expected_result == ExpectedResult::RESULT_SUCCESS, result);
 		if (expected_result == ExpectedResult::RESULT_SUCCESS && SkipErrorMessage(result.GetError())) {
 			runner.finished_processing_file = true;
 			return true;
 		}
+		logger.UnexpectedStatement(expected_result == ExpectedResult::RESULT_SUCCESS, result);
 		return false;
 	}
 	if (error) {

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -363,6 +363,7 @@ vector<string> TestResultHelper::LoadResultFromFile(string fname, vector<string>
 bool TestResultHelper::SkipErrorMessage(const string &message) {
 	for (auto &error_message : runner.ignore_error_messages) {
 		if (StringUtil::Contains(message, error_message)) {
+			SKIP_TEST(string("skip on error_message matching '") + error_message + string("'"));
 			return true;
 		}
 	}

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -662,6 +662,11 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 		DeleteDatabase(dbpath);
 	}
 
+	ignore_error_messages.clear();
+	for (auto ignore : test_config.ErrorMessagesToBeSkipped()) {
+		ignore_error_messages.insert(ignore);
+	}
+
 	// initialize the database with the default dbpath
 	LoadDatabase(dbpath, true);
 


### PR DESCRIPTION
One usability feature for config-based usage of unittest is ability to provide an array that overrides `ignore_error_messages`, meaning that one can say turn of failures for say "Not Implemented Exception" or other cases of controlled failure modes. Or maybe if the goal is stability of the system, most exceptions but for Internal or Fatal ones can potentially be discarded.

While touching the code, fixed some current limitations:
* summarization would happen before checking whether something is to be skipped
* in case of mismatched error messages `ignore_error_messages` was not used
* tests skipped due to `ignore_error_messages` would count as success. Now they are logged as `skipped`. Of this one I am less sure, and it's independent, so can be reverted. But my reasoning is that the test is still not performed to completion, so should probably count as a `skip`

Result summarization will include the cause for the `skip`, like see last 3 lines:
```
Skipped tests for the following reasons:
require autocomplete: 15
require block_size: 2
require exact_vector_size: 1
require icu: 37
require inet: 1
...
require-env TEST_PERSISTENT_SECRETS_AVAILABLE: 2
skip on error_message matching 'Memory': 396
skip on error_message matching 'could not allocate block of size': 147
skip on error_message matching 'failed to pin block of size': 45
```

I added a test configuration, that is not super relevant, but demonstrate usage of `skip_error_messages` parameter.