### PR TITLE
Add Stack Trace marker to stack trace

### DIFF
--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -70,7 +70,7 @@ string ErrorData::ConstructFinalMessage() const {
 		auto entry = extra_info.find("stack_trace_pointers");
 		if (entry != extra_info.end()) {
 			auto stack_trace = StackTrace::ResolveStacktraceSymbols(entry->second);
-			error += "\n\n" + stack_trace;
+			error += "\n\nStack Trace:\n" + stack_trace;
 		}
 	}
 	return error;


### PR DESCRIPTION
Since https://github.com/duckdb/duckdb/pull/18023 stack traces are now being added in ConstructFinalMessage. However they were not using the "Stack trace:" prefix that is used for all other stack traces. This makes it hard extract/remove these specific stack traces from the resulting error message. This adds that same prefix.
