### PR TITLE
[CSV Reader] Prohibit options delim and sep in same read_csv call

### DIFF
--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -125,6 +125,10 @@ void CSVReaderOptions::SetDelimiter(const string &input) {
 	if (delim_str.size() > 4) {
 		throw InvalidInputException("The delimiter option cannot exceed a size of 4 bytes.");
 	}
+	if (this->dialect_options.state_machine_options.delimiter.IsSetByUser()) {
+		// we can't know in which order delim and sep were specified, so we throw an exception here
+		throw BinderException("CSV Reader function option delim and sep are aliases, only one can be supplied");
+	}
 	this->dialect_options.state_machine_options.delimiter.Set(delim_str);
 }
 

--- a/test/sql/copy/csv/csv_names.test
+++ b/test/sql/copy/csv/csv_names.test
@@ -75,6 +75,12 @@ select l_orderkey, l_partkey, column02, column03 from read_csv_auto('data/csv/re
 ----
 Failed to cast value: Unimplemented type for cast (INTEGER -> VARCHAR[])
 
+# specify options delim and sep
+statement error
+select column00 from read_csv_auto('data/csv/real/lineitem_sample.csv', delim='|', sep='|') LIMIT 1;
+----
+CSV Reader function option delim and sep are aliases, only one can be supplied
+
 # duplicate names
 statement error
 select l_orderkey, l_partkey, column02, column03 from read_csv_auto('data/csv/real/lineitem_sample.csv', names=['l_orderkey', 'l_orderkey']) LIMIT 1;


### PR DESCRIPTION
Issue at hand:

```sql
D select column00 from read_csv_auto('./data/csv/real/lineitem_sample.csv', delim='|', sep='|');
INTERNAL Error:
Assertion triggered in file "duckdb/src/include/duckdb/execution/operator/csv_scanner/csv_option.hpp" on line 41: !(by_user && set_by_user)

Stack Trace:
[...]
```