### PR TITLE
Fix copy constructor in SetVariableStatement

### DIFF
--- a/src/parser/statement/set_statement.cpp
+++ b/src/parser/statement/set_statement.cpp
@@ -14,7 +14,7 @@ SetVariableStatement::SetVariableStatement(string name_p, unique_ptr<ParsedExpre
 }
 
 SetVariableStatement::SetVariableStatement(const SetVariableStatement &other)
-    : SetVariableStatement(other.name, other.value->Copy(), other.scope) {
+    : SetStatement(other), value(other.value->Copy()) {
 }
 
 unique_ptr<SQLStatement> SetVariableStatement::Copy() const {


### PR DESCRIPTION
This change fixes the copy constructor of the `SetVariableStatement` by adding there a call to the superclass copy constructor. Previously this constructor was using non-copy constructor of the superclass and thus was failing to copy `named_param_map` field (and some other fields).

When the `postgres_scanner` extension is loaded the result of the `Prepare()` call for queries like `SET VARIABLE v = ?` was gettng an empty `named_param_map` field and the execution of this statement was failing with:

> Binder Error: Parameter/argument count mismatch for prepared statement. Expected 0, got 1

Testing: new test is added that uses `CanRequestRebind()` API to check [the code path](https://github.com/duckdb/duckdb/blob/3b9012fbbafd6d65a08c0050e2ed36a0019ce3f4/src/main/client_context.cpp#L421-L424) on which `SQLStatement`'s copy constructor is invoked.

Fixes: duckdb/duckdb-java#294