### PR TITLE
OSX.yml: Move from using debug builds to release + DDEBUG + FORCE_ASSERT

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -49,6 +49,8 @@ jobs:
 
     env:
       TREAT_WARNINGS_AS_ERRORS: 1
+      CMAKE_CXX_FLAGS: '-DDEBUG'
+      FORCE_ASSERT: 1
 
     steps:
     - uses: actions/checkout@v4
@@ -72,7 +74,7 @@ jobs:
 
     - name: Build
       shell: bash
-      run: GEN=ninja make debug
+      run: GEN=ninja make release
 
     - name: Set DUCKDB_INSTALL_LIB for ADBC tests
       shell: bash
@@ -84,7 +86,7 @@ jobs:
     - name: Test
       if: ${{ inputs.skip_tests != 'true' }}
       shell: bash
-      run: make unittestci
+      run: make unittest_release
 
     - name: Amalgamation
       if: ${{ inputs.skip_tests != 'true' }}


### PR DESCRIPTION
Very minor, should have no real impact but shortening a bit CI checks on forks and InvokeCI runs.

Equivalent to https://github.com/duckdb/duckdb/pull/18081