### PR TITLE
Wrap http_util into a http_util_container object, so that in-use HTTPUtil can be reached from FileOpener

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -21,6 +21,7 @@ duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG 39779f89b16d0a35f04d3cfaf868e6366a2102f0
     INCLUDE_DIR extension/httpfs/include
+    APPLY_PATCHES
     )
 
 ################# AVRO

--- a/.github/patches/extensions/httpfs/httpfs.patch
+++ b/.github/patches/extensions/httpfs/httpfs.patch
@@ -1,0 +1,46 @@
+diff --git a/extension/httpfs/httpfs.cpp b/extension/httpfs/httpfs.cpp
+index 4881e9d..a031893 100644
+--- a/extension/httpfs/httpfs.cpp
++++ b/extension/httpfs/httpfs.cpp
+@@ -23,13 +23,10 @@ namespace duckdb {
+ 
+ shared_ptr<HTTPUtil> HTTPFSUtil::GetHTTPUtil(optional_ptr<FileOpener> opener) {
+ 	if (opener) {
+-		auto db = opener->TryGetDatabase();
+-		if (db) {
+-			auto &config = DBConfig::GetConfig(*db);
+-			return config.http_util;
+-		}
++		return opener->http_util_container.get()->http_util;
+ 	}
+-	return make_shared_ptr<HTTPFSUtil>();
++	// TODO: Actually provide a backup plan
++	throw InternalException("FileOpener not provided, can't get HTTPUtil");
+ }
+ 
+ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener> opener,
+diff --git a/extension/httpfs/httpfs_extension.cpp b/extension/httpfs/httpfs_extension.cpp
+index c9bc985..dca3cb8 100644
+--- a/extension/httpfs/httpfs_extension.cpp
++++ b/extension/httpfs/httpfs_extension.cpp
+@@ -61,7 +61,7 @@ static void LoadInternal(DatabaseInstance &instance) {
+ 	// HuggingFace options
+ 	config.AddExtensionOption("hf_max_per_page", "Debug option to limit number of items returned in list requests",
+ 	                          LogicalType::UBIGINT, Value::UBIGINT(0));
+-	config.http_util = make_shared_ptr<HTTPFSUtil>();
++	config.http_util_container->http_util = make_shared_ptr<HTTPFSUtil>(config.http_util_container);
+ 
+ 	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
+ 	provider->SetAll();
+diff --git a/extension/httpfs/include/httpfs_client.hpp b/extension/httpfs/include/httpfs_client.hpp
+index 1d7620c..f4a4148 100644
+--- a/extension/httpfs/include/httpfs_client.hpp
++++ b/extension/httpfs/include/httpfs_client.hpp
+@@ -26,6 +26,7 @@ struct HTTPFSParams : public HTTPParams {
+ 
+ class HTTPFSUtil : public HTTPUtil {
+ public:
++	explicit HTTPFSUtil(shared_ptr<HTTPUtilContainer> parent_) : HTTPUtil(parent_) {}
+ 	unique_ptr<HTTPParams> InitializeParameters(optional_ptr<FileOpener> opener,
+ 	                                            optional_ptr<FileOpenerInfo> info) override;
+ 	unique_ptr<HTTPClient> InitializeClient(HTTPParams &http_params, const string &proto_host_port) override;

--- a/src/include/duckdb/common/file_opener.hpp
+++ b/src/include/duckdb/common/file_opener.hpp
@@ -27,7 +27,7 @@ struct FileOpenerInfo {
 //! Abstract type that provide client-specific context to FileSystem.
 class FileOpener {
 public:
-	FileOpener() {
+	explicit FileOpener(shared_ptr<HTTPUtilContainer> http_util_) : http_util_container(http_util_) {
 	}
 	virtual ~FileOpener() {};
 
@@ -63,6 +63,7 @@ public:
 		}
 		return lookup_result;
 	}
+	shared_ptr<HTTPUtilContainer> http_util_container;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -17,6 +17,7 @@ namespace duckdb {
 class DatabaseInstance;
 class Logger;
 class HTTPUtil;
+struct HTTPUtilContainer;
 class FileOpener;
 struct FileOpenerInfo;
 
@@ -220,9 +221,14 @@ public:
 	unique_ptr<HTTPResponse> Request(BaseRequest &request);
 };
 
+struct HTTPUtilContainer;
+
 class HTTPUtil {
 public:
 	virtual ~HTTPUtil() = default;
+
+	explicit HTTPUtil(shared_ptr<HTTPUtilContainer> parent_) : parent(parent_) {
+	}
 
 public:
 	static HTTPUtil &Get(DatabaseInstance &db);
@@ -251,5 +257,12 @@ public:
 	static duckdb::unique_ptr<HTTPResponse>
 	RunRequestWithRetry(const std::function<unique_ptr<HTTPResponse>(void)> &on_request, const BaseRequest &request,
 	                    const std::function<void(void)> &retry_cb);
+
+	weak_ptr<HTTPUtilContainer> parent;
 };
+
+struct HTTPUtilContainer {
+	shared_ptr<HTTPUtil> http_util;
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/main/client_context_file_opener.hpp
+++ b/src/include/duckdb/main/client_context_file_opener.hpp
@@ -18,7 +18,8 @@ class ClientContext;
 //! This object is owned by ClientContext and never outlives it.
 class ClientContextFileOpener : public FileOpener {
 public:
-	explicit ClientContextFileOpener(ClientContext &context_p) : context(context_p) {
+	explicit ClientContextFileOpener(shared_ptr<HTTPUtilContainer> http_util, ClientContext &context_p)
+	    : FileOpener(http_util), context(context_p) {
 	}
 
 	Logger &GetLogger() const override;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -57,6 +57,7 @@ class SecretManager;
 class CompressionInfo;
 class EncryptionUtil;
 class HTTPUtil;
+struct HTTPUtilContainer;
 
 struct CompressionFunctionSet;
 struct DatabaseCacheEntry;
@@ -354,7 +355,7 @@ public:
 	//! Encryption Util for OpenSSL
 	shared_ptr<EncryptionUtil> encryption_util;
 	//! HTTP Request utility functions
-	shared_ptr<HTTPUtil> http_util;
+	shared_ptr<HTTPUtilContainer> http_util_container;
 	//! Reference to the database cache entry (if any)
 	shared_ptr<DatabaseCacheEntry> db_cache_entry;
 

--- a/src/include/duckdb/main/database_file_opener.hpp
+++ b/src/include/duckdb/main/database_file_opener.hpp
@@ -18,7 +18,8 @@ class DatabaseInstance;
 
 class DatabaseFileOpener : public FileOpener {
 public:
-	explicit DatabaseFileOpener(DatabaseInstance &db_p) : db(db_p) {
+	explicit DatabaseFileOpener(shared_ptr<HTTPUtilContainer> http_util, DatabaseInstance &db_p)
+	    : FileOpener(http_util), db(db_p) {
 	}
 
 	Logger &GetLogger() const override {
@@ -43,7 +44,8 @@ private:
 
 class DatabaseFileSystem : public OpenerFileSystem {
 public:
-	explicit DatabaseFileSystem(DatabaseInstance &db_p) : db(db_p), database_opener(db_p) {
+	explicit DatabaseFileSystem(DatabaseInstance &db_p)
+	    : db(db_p), database_opener(db_p.config.http_util_container, db_p) {
 	}
 
 	FileSystem &GetFileSystem() const override {

--- a/src/main/client_data.cpp
+++ b/src/main/client_data.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/main/query_profiler.hpp"
+#include "duckdb/common/http_util.hpp"
 
 namespace duckdb {
 
@@ -38,7 +39,7 @@ ClientData::ClientData(ClientContext &context) : catalog_search_path(make_uniq<C
 	temporary_objects = make_shared_ptr<AttachedDatabase>(db, AttachedDatabaseType::TEMP_DATABASE);
 	temporary_objects->oid = DatabaseManager::Get(db).NextOid();
 	random_engine = make_uniq<RandomEngine>();
-	file_opener = make_uniq<ClientContextFileOpener>(context);
+	file_opener = make_uniq<ClientContextFileOpener>(db.config.http_util_container, context);
 	client_file_system = make_uniq<ClientFileSystem>(context);
 	temporary_objects->Initialize();
 }

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -48,7 +48,8 @@ DBConfig::DBConfig() {
 	index_types = make_uniq<IndexTypeSet>();
 	error_manager = make_uniq<ErrorManager>();
 	secret_manager = make_uniq<SecretManager>();
-	http_util = make_shared_ptr<HTTPUtil>();
+	http_util_container = make_shared_ptr<HTTPUtilContainer>();
+	http_util_container->http_util = make_shared_ptr<HTTPUtil>(http_util_container);
 	storage_extensions["__open_file__"] = OpenFileStorageExtension::Create();
 }
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -359,12 +359,12 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 		headers.Insert("If-None-Match", StringUtil::Format("%s", install_info->etag));
 	}
 
-	auto &http_util = HTTPUtil::Get(db);
+	auto &http_util_co = *db.config.http_util_container;
 	unique_ptr<HTTPParams> params;
 	if (context) {
-		params = http_util.InitializeParameters(*context, url);
+		params = http_util_co.http_util->InitializeParameters(*context, url);
 	} else {
-		params = http_util.InitializeParameters(db, url);
+		params = http_util_co.http_util->InitializeParameters(db, url);
 	}
 
 	// Unclear what's peculiar about extension install flow, but those two parameters are needed
@@ -375,7 +375,7 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 	GetRequestInfo get_request(url, headers, *params, nullptr, nullptr);
 	get_request.try_request = true;
 
-	auto response = http_util.Request(get_request);
+	auto response = http_util_co.http_util->Request(get_request);
 	if (!response->Success()) {
 		// if we should not retry or exceeded the number of retries - bubble up the error
 		string message;

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -85,7 +85,7 @@ const string &HTTPResponse::GetError() const {
 }
 
 HTTPUtil &HTTPUtil::Get(DatabaseInstance &db) {
-	return *db.config.http_util;
+	return *db.config.http_util_container->http_util;
 }
 
 string HTTPUtil::GetName() const {
@@ -448,14 +448,14 @@ void HTTPParams::Initialize(optional_ptr<FileOpener> opener) {
 }
 
 unique_ptr<HTTPParams> HTTPUtil::InitializeParameters(DatabaseInstance &db, const string &url) {
-	DatabaseFileOpener opener(db);
+	DatabaseFileOpener opener(parent.lock(), db);
 	FileOpenerInfo info;
 	info.file_path = url;
 	return InitializeParameters(&opener, &info);
 }
 
 unique_ptr<HTTPParams> HTTPUtil::InitializeParameters(ClientContext &context, const string &url) {
-	ClientContextFileOpener opener(context);
+	ClientContextFileOpener opener(parent.lock(), context);
 	FileOpenerInfo info;
 	info.file_path = url;
 	return InitializeParameters(&opener, &info);


### PR DESCRIPTION
Without this PR, there are situations where `httpfs` extension defaults to own HTTPFSUtil, instead of using the global registered one. I think while this currently work, it's somewhat of a code smell, and basically prevent other extensions (or clients, such as duckdb-wasm) to have a clean path to override the default http_util to be used.

This is possibly also a problem connected to introduction of curl in the `httpfs` extension, since it's not possible for `httpfs` to offer two interfaces, and register one or the other depending on settings.

Solution is adding a layer of indirection, where the `http_util` shared_ptr is moved from DBConfig to an inner class HTTPUtilContainer. DBConfig keeps then a shared_ptr to HTTPUtilContainer, that keeps a shared_ptr to HTTPUtil currently in use. HTTPUtil keeps a weak_ptr back to the HTTPUtilContainer, since this makes so that having a HTTPUtil object in hand allows to walk back to the default HTTPUtil (and possibly setting it to a different value).

HTTPUtilContainer is also make compulsory for constructing a FileOpener, so that with a FileOpener it's always possible to get the currently in-use HTTPUtil class.

There are some layers of pointers, but this allows to remove a current limitation that is that HTTPFSUtil can be the only one to override HTTPUtil (and this needs to be 1 way only).

Main question is whether this is feasible.
Secondary questions are:
* are there other objects that should be moved from DBConfig to HTTPUtilContainer?
* how HTTPUtilContainer should be actually named? GlobalFileSystemProperties?

Main relevant change is the patch to HTTPFS, that goes from:
```c++
 	if (opener) {
		auto db = opener->TryGetDatabase();
		if (db) {
			auto &config = DBConfig::GetConfig(*db);
			return config.http_util;
		}
 	}
	return make_shared_ptr<HTTPFSUtil>();
```
to
```c++
 	if (opener) {
		return opener->http_util_container.get()->http_util;
        }
	// TODO: Actually provide a backup plan
	throw InternalException("FileOpener not provided, can't get HTTPUtil");
```
throw is there for testing, but haven't managed to trigger. I would think the opener is always present, but to limit damages if this is not correct would be to add a logging line + add back `return make_shared_ptr<HTTPFSUtil>();`, so that worst case same behavior is kept.