### PR TITLE
Add missing `INT128` to decimal Parquet reader switch

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -763,6 +763,8 @@ unique_ptr<ColumnReader> CreateDecimalReader(ParquetReader &reader, const Parque
 		return make_uniq<TemplatedColumnReader<int32_t, TemplatedParquetValueConversion<T>>>(reader, schema);
 	case PhysicalType::INT64:
 		return make_uniq<TemplatedColumnReader<int64_t, TemplatedParquetValueConversion<T>>>(reader, schema);
+	case PhysicalType::INT128:
+		return make_uniq<TemplatedColumnReader<hugeint_t, TemplatedParquetValueConversion<T>>>(reader, schema);
 	default:
 		throw NotImplementedException("Unimplemented internal type for CreateDecimalReader");
 	}


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/5218

I can't use the reproducible example for a test, and DuckDB cannot create such a file, so this sadly will have to do without a test.