### PR TITLE
shared_ptr<HTTPUtil>& must be reached from FileOpener

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -21,6 +21,7 @@ duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG 39779f89b16d0a35f04d3cfaf868e6366a2102f0
     INCLUDE_DIR extension/httpfs/include
+    APPLY_PATCHES
     )
 
 ################# AVRO

--- a/.github/patches/extensions/httpfs/httpfs.patch
+++ b/.github/patches/extensions/httpfs/httpfs.patch
@@ -1,0 +1,20 @@
+diff --git a/extension/httpfs/httpfs.cpp b/extension/httpfs/httpfs.cpp
+index 4881e9d..56c8b8e 100644
+--- a/extension/httpfs/httpfs.cpp
++++ b/extension/httpfs/httpfs.cpp
+@@ -23,13 +23,9 @@ namespace duckdb {
+ 
+ shared_ptr<HTTPUtil> HTTPFSUtil::GetHTTPUtil(optional_ptr<FileOpener> opener) {
+ 	if (opener) {
+-		auto db = opener->TryGetDatabase();
+-		if (db) {
+-			auto &config = DBConfig::GetConfig(*db);
+-			return config.http_util;
+-		}
++		return opener->GetHTTPUtil();
+ 	}
+-	return make_shared_ptr<HTTPFSUtil>();
++	throw InternalException("FileOpener not provided, can't get HTTPUtil");
+ }
+ 
+ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener> opener,

--- a/src/include/duckdb/common/file_opener.hpp
+++ b/src/include/duckdb/common/file_opener.hpp
@@ -35,6 +35,7 @@ public:
 	virtual SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) = 0;
 	virtual optional_ptr<ClientContext> TryGetClientContext() = 0;
 	virtual optional_ptr<DatabaseInstance> TryGetDatabase() = 0;
+	virtual shared_ptr<HTTPUtil> &GetHTTPUtil() = 0;
 
 	DUCKDB_API virtual Logger &GetLogger() const = 0;
 	DUCKDB_API static unique_ptr<CatalogTransaction> TryGetCatalogTransaction(optional_ptr<FileOpener> opener);

--- a/src/include/duckdb/main/client_context_file_opener.hpp
+++ b/src/include/duckdb/main/client_context_file_opener.hpp
@@ -29,6 +29,7 @@ public:
 		return &context;
 	}
 	optional_ptr<DatabaseInstance> TryGetDatabase() override;
+	shared_ptr<HTTPUtil> &GetHTTPUtil() override;
 
 private:
 	ClientContext &context;

--- a/src/include/duckdb/main/database_file_opener.hpp
+++ b/src/include/duckdb/main/database_file_opener.hpp
@@ -36,6 +36,9 @@ public:
 	optional_ptr<DatabaseInstance> TryGetDatabase() override {
 		return &db;
 	}
+	shared_ptr<HTTPUtil> &GetHTTPUtil() override {
+		return TryGetDatabase()->config.http_util;
+	}
 
 private:
 	DatabaseInstance &db;

--- a/src/main/client_context_file_opener.cpp
+++ b/src/main/client_context_file_opener.cpp
@@ -24,6 +24,10 @@ optional_ptr<DatabaseInstance> ClientContextFileOpener::TryGetDatabase() {
 	return context.db.get();
 }
 
+shared_ptr<HTTPUtil> &ClientContextFileOpener::GetHTTPUtil() {
+	return TryGetDatabase()->config.http_util;
+}
+
 unique_ptr<CatalogTransaction> FileOpener::TryGetCatalogTransaction(optional_ptr<FileOpener> opener) {
 	if (!opener) {
 		return nullptr;


### PR DESCRIPTION
Without this PR, there are situations where `httpfs` extension defaults to own HTTPFSUtil, instead of using the global registered one. I think while this currently work, it's somewhat of a code smell, and basically prevent other extensions (or clients, such as duckdb-wasm) to have a clean path to override the default http_util to be used.

This is possibly also a problem connected to introduction of curl in the `httpfs` extension, since it's not possible for `httpfs` to offer two interfaces, and register one or the other depending on settings.

This commit forces FileOpener to have a way to return a reference to the original shared_ptr<HTTPUtil> (possibly caching on costructor / other ways). Then the main improvement is the change (currently via a patch) that allows in duckdb-httpfs.

This is a less clunky / slimmer version of https://github.com/duckdb/duckdb/pull/18103, thanks to feedback from @Mytherin.