### PR TITLE
Cleanup on correct branch (1.3-ossivalis) instead of v1.2-histrionicus

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -376,7 +376,7 @@ jobs:
           ./scripts/upload-assets-to-staging.sh twine_upload tools/pythonpkg/wheelhouse/*.whl
 
   linux-release-cleanup:
-     if: github.ref == 'refs/heads/v1.2-histrionicus' || github.ref == 'refs/heads/main'
+     if: github.ref == 'refs/heads/v1.3-ossivalis' || github.ref == 'refs/heads/main'
      name: PyPi Release Cleanup
      needs: twine-upload
      runs-on: ubuntu-22.04


### PR DESCRIPTION
Fixes the fact that otherwise we will eventually fill all available space on pypi.