### PR TITLE
Allow .tsv as an accepted db file

### DIFF
--- a/src/main/database_path_and_type.cpp
+++ b/src/main/database_path_and_type.cpp
@@ -26,7 +26,7 @@ void DBPathAndType::CheckMagicBytes(FileSystem &fs, string &path, string &db_typ
 	case DataFileType::PARQUET_FILE:
 	case DataFileType::UNKNOWN_FILE: {
 		// FIXME: we should get this from the registered replacement scans instead of hardcoding it here
-		vector<string> supported_suffixes {"parquet", "csv", "json", "jsonl", "ndjson"};
+		vector<string> supported_suffixes {"parquet", "csv", "tsv", "json", "jsonl", "ndjson"};
 		if (ReplacementScan::CanReplace(path, supported_suffixes)) {
 			db_type = "__open_file__";
 			break;


### PR DESCRIPTION
Fix: https://github.com/duckdb/duckdb/issues/18086

Fix: https://github.com/duckdblabs/duckdb-internal/issues/5223