### PR TITLE
Detect when updates have no effect, and skip performing the actual updates if we encounter these nop updates

### DIFF
--- a/src/include/duckdb/storage/table/update_segment.hpp
+++ b/src/include/duckdb/storage/table/update_segment.hpp
@@ -81,6 +81,8 @@ public:
 	typedef void (*rollback_update_function_t)(UpdateInfo &base_info, UpdateInfo &rollback_info);
 	typedef idx_t (*statistics_update_function_t)(UpdateSegment *segment, SegmentStatistics &stats,
 	                                              UnifiedVectorFormat &update, idx_t count, SelectionVector &sel);
+	typedef idx_t (*get_effective_updates_t)(UnifiedVectorFormat &update_format, row_t *ids, idx_t count,
+	                                         SelectionVector &sel, Vector &base_data, idx_t id_offset);
 
 private:
 	initialize_update_function_t initialize_update_function;
@@ -91,6 +93,7 @@ private:
 	fetch_row_function_t fetch_row_function;
 	rollback_update_function_t rollback_update_function;
 	statistics_update_function_t statistics_update_function;
+	get_effective_updates_t get_effective_updates;
 
 private:
 	UndoBufferPointer GetUpdateNode(StorageLockKey &lock, idx_t vector_idx) const;

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -21,6 +21,7 @@ static UpdateSegment::merge_update_function_t GetMergeUpdateFunction(PhysicalTyp
 static UpdateSegment::rollback_update_function_t GetRollbackUpdateFunction(PhysicalType type);
 static UpdateSegment::statistics_update_function_t GetStatisticsUpdateFunction(PhysicalType type);
 static UpdateSegment::fetch_row_function_t GetFetchRowFunction(PhysicalType type);
+static UpdateSegment::get_effective_updates_t GetEffectiveUpdatesFunction(PhysicalType type);
 
 UpdateSegment::UpdateSegment(ColumnData &column_data)
     : column_data(column_data), stats(column_data.type), heap(BufferAllocator::Get(column_data.GetDatabase())) {
@@ -36,6 +37,7 @@ UpdateSegment::UpdateSegment(ColumnData &column_data)
 	this->merge_update_function = GetMergeUpdateFunction(physical_type);
 	this->rollback_update_function = GetRollbackUpdateFunction(physical_type);
 	this->statistics_update_function = GetStatisticsUpdateFunction(physical_type);
+	this->get_effective_updates = GetEffectiveUpdatesFunction(physical_type);
 }
 
 UpdateSegment::~UpdateSegment() {
@@ -1053,6 +1055,9 @@ idx_t UpdateStringStatistics(UpdateSegment *segment, SegmentStatistics &stats, U
 				}
 			}
 		}
+		if (not_null_count == count) {
+			sel.Initialize(nullptr);
+		}
 		return not_null_count;
 	}
 }
@@ -1090,6 +1095,96 @@ UpdateSegment::statistics_update_function_t GetStatisticsUpdateFunction(Physical
 		return TemplatedUpdateNumericStatistics<interval_t>;
 	case PhysicalType::VARCHAR:
 		return UpdateStringStatistics;
+	default:
+		throw NotImplementedException("Unimplemented type for uncompressed segment");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Get Effective Updates
+//===--------------------------------------------------------------------===//
+idx_t GetEffectiveUpdatesValidity(UnifiedVectorFormat &update, row_t *ids, idx_t count, SelectionVector &sel,
+                                  Vector &base_data, idx_t id_offset) {
+	auto &original_validity = FlatVector::Validity(base_data);
+
+	SelectionVector new_sel;
+	new_sel.Initialize(STANDARD_VECTOR_SIZE);
+
+	idx_t effective_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto sel_idx = sel.get_index(i);
+		auto update_idx = update.sel->get_index(sel_idx);
+		auto original_idx = UnsafeNumericCast<idx_t>(ids[sel_idx]) - id_offset;
+		if (original_validity.RowIsValid(original_idx) == update.validity.RowIsValid(update_idx)) {
+			continue;
+		}
+		new_sel.set_index(effective_count++, sel_idx);
+	}
+	sel.Initialize(new_sel);
+	return effective_count;
+}
+
+template <class T>
+idx_t TemplatedGetEffectiveUpdates(UnifiedVectorFormat &update, row_t *ids, idx_t count, SelectionVector &sel,
+                                   Vector &base_data, idx_t id_offset) {
+	auto data = UnifiedVectorFormat::GetData<T>(update);
+
+	auto original_data = FlatVector::GetData<T>(base_data);
+	auto &original_validity = FlatVector::Validity(base_data);
+
+	SelectionVector new_sel;
+	new_sel.Initialize(STANDARD_VECTOR_SIZE);
+
+	idx_t effective_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto sel_idx = sel.get_index(i);
+		auto update_idx = update.sel->get_index(sel_idx);
+		auto original_idx = UnsafeNumericCast<idx_t>(ids[sel_idx]) - id_offset;
+		// NULL values in the updates should have been filtered out before
+		D_ASSERT(update.validity.RowIsValid(update_idx));
+		if (original_validity.RowIsValid(original_idx) && data[update_idx] == original_data[original_idx]) {
+			// data is equivalent - skip
+			continue;
+		}
+		new_sel.set_index(effective_count++, sel_idx);
+	}
+	sel.Initialize(new_sel);
+	return effective_count;
+}
+
+UpdateSegment::get_effective_updates_t GetEffectiveUpdatesFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+		return GetEffectiveUpdatesValidity;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedGetEffectiveUpdates<int8_t>;
+	case PhysicalType::INT16:
+		return TemplatedGetEffectiveUpdates<int16_t>;
+	case PhysicalType::INT32:
+		return TemplatedGetEffectiveUpdates<int32_t>;
+	case PhysicalType::INT64:
+		return TemplatedGetEffectiveUpdates<int64_t>;
+	case PhysicalType::UINT8:
+		return TemplatedGetEffectiveUpdates<uint8_t>;
+	case PhysicalType::UINT16:
+		return TemplatedGetEffectiveUpdates<uint16_t>;
+	case PhysicalType::UINT32:
+		return TemplatedGetEffectiveUpdates<uint32_t>;
+	case PhysicalType::UINT64:
+		return TemplatedGetEffectiveUpdates<uint64_t>;
+	case PhysicalType::INT128:
+		return TemplatedGetEffectiveUpdates<hugeint_t>;
+	case PhysicalType::UINT128:
+		return TemplatedGetEffectiveUpdates<uhugeint_t>;
+	case PhysicalType::FLOAT:
+		return TemplatedGetEffectiveUpdates<float>;
+	case PhysicalType::DOUBLE:
+		return TemplatedGetEffectiveUpdates<double>;
+	case PhysicalType::INTERVAL:
+		return TemplatedGetEffectiveUpdates<interval_t>;
+	case PhysicalType::VARCHAR:
+		return TemplatedGetEffectiveUpdates<string_t>;
 	default:
 		throw NotImplementedException("Unimplemented type for uncompressed segment");
 	}
@@ -1249,6 +1344,13 @@ void UpdateSegment::Update(TransactionData transaction, idx_t column_index, Vect
 		base_info.Verify();
 		node->Verify();
 	} else {
+		// get a list of effective updates - i.e. updates that actually change rows
+		// if updates have the same value as the base row we can skip them
+		count = get_effective_updates(update_format, ids, count, sel, base_data, vector_offset);
+		if (count == 0) {
+			return;
+		}
+
 		// there is no version info yet: create the top level update info and fill it with the updates
 		// allocate space for the UpdateInfo in the allocator
 		idx_t alloc_size = UpdateInfo::GetAllocSize(type_size);

--- a/test/sql/storage/checkpoint_abort_before_truncate.test_slow
+++ b/test/sql/storage/checkpoint_abort_before_truncate.test_slow
@@ -49,7 +49,10 @@ statement ok
 PRAGMA debug_checkpoint_abort='before_truncate';
 
 statement ok
-UPDATE integers SET i=i;
+UPDATE integers SET i=i+1;
+
+statement ok
+UPDATE integers SET i=i-1;
 
 statement error
 CHECKPOINT;

--- a/test/sql/storage/parallel/reclaim_space_insert_unique_idx_optimistic.test_slow
+++ b/test/sql/storage/parallel/reclaim_space_insert_unique_idx_optimistic.test_slow
@@ -5,9 +5,6 @@
 load __TEST_DIR__/reclaim_space_unique_index.db
 
 statement ok
-SET preserve_insertion_order=false;
-
-statement ok
 CREATE TABLE integers AS SELECT * FROM range(1_000_000) t(i);
 
 statement ok

--- a/test/sql/storage/update/nop_update_tpch.test_slow
+++ b/test/sql/storage/update/nop_update_tpch.test_slow
@@ -1,0 +1,23 @@
+# name: test/sql/storage/update/nop_update_tpch.test_slow
+# description: Test nop updates with TPC-H
+# group: [update]
+
+require tpch
+
+# load the DB from disk
+load __TEST_DIR__/nop_updates_sf1.db
+
+statement ok
+CALL dbgen(sf=1);
+
+query I nosort expected_blocks
+SELECT total_blocks FROM pragma_database_size();
+
+statement ok
+UPDATE lineitem SET l_orderkey = l_orderkey,l_partkey = l_partkey,l_suppkey = l_suppkey,l_linenumber = l_linenumber,l_quantity = l_quantity,l_extendedprice = l_extendedprice,l_discount = l_discount,l_tax = l_tax,l_returnflag = l_returnflag,l_linestatus = l_linestatus,l_shipdate = l_shipdate,l_commitdate = l_commitdate,l_receiptdate = l_receiptdate,l_shipinstruct = l_shipinstruct,l_shipmode = l_shipmode,l_comment = l_comment;
+
+statement ok
+CHECKPOINT
+
+query I nosort expected_blocks
+SELECT total_blocks FROM pragma_database_size();

--- a/test/sql/storage/update/nop_updates.test_slow
+++ b/test/sql/storage/update/nop_updates.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/storage/update/update_same_value.test_slow
+# name: test/sql/storage/update/nop_updates.test_slow
 # description: Test nop updates
 # group: [update]
 

--- a/test/sql/storage/update/nop_updates.test_slow
+++ b/test/sql/storage/update/nop_updates.test_slow
@@ -28,3 +28,12 @@ SELECT total_blocks FROM pragma_database_size();
 
 statement ok
 CHECKPOINT
+
+# ALMOST nop update
+statement ok
+UPDATE integers SET i=CASE WHEN i=9999997 THEN 42 ELSE i END
+
+query I
+select sum(i) from integers
+----
+49999995000045

--- a/test/sql/storage/update/nop_updates.test_slow
+++ b/test/sql/storage/update/nop_updates.test_slow
@@ -1,0 +1,30 @@
+# name: test/sql/storage/update/update_same_value.test_slow
+# description: Test nop updates
+# group: [update]
+
+# load the DB from disk
+load __TEST_DIR__/nop_updates.db
+
+statement ok
+create table integers as select * from generate_series(0, 10000000, 1) tbl(i);
+
+query I
+select sum(i) from integers
+----
+50000005000000
+
+query I nosort expected_blocks
+SELECT total_blocks FROM pragma_database_size();
+
+loop i 0 2
+
+statement ok
+UPDATE integers SET i=i
+
+endloop
+
+query I nosort expected_blocks
+SELECT total_blocks FROM pragma_database_size();
+
+statement ok
+CHECKPOINT


### PR DESCRIPTION
Currently when running a "nop" update, like:

```sql
UPDATE tbl SET col=col;
```

We perform the actual update. This is wasteful. While the above example is clearly rather pointless - nop updates can be performed accidentally quite easily, especially when updating many columns.

This PR adds in detection for when an update leaves a value unchanged - and when it leaves a value unchanged, it will skip the update for that value. In the best case scenario that means we can skip applying the entire update (and also skip subsequent operations, such as rewriting row groups).