### PR TITLE
Bump iceberg for 1.3.2, from @Tishj, and bumping also httpfs

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -23,12 +23,12 @@ duckdb_extension_load(httpfs
     INCLUDE_DIR extension/httpfs/include
     )
 
-################# AVRO
+################## AVRO
 if (NOT MINGW)
     duckdb_extension_load(avro
             LOAD_TESTS DONT_LINK
             GIT_URL https://github.com/duckdb/duckdb-avro
-            GIT_TAG 73e97c0f28888f804ed1361313a1dae623f1a4d2
+            GIT_TAG 180e41e8ad13b8712d207785a6bca0aa39341040
     )
 endif()
 
@@ -92,7 +92,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(iceberg
            ${LOAD_ICEBERG_TESTS}
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 2746c589c12d0a8f6b77986ca12a1fc14ef463a4
+            GIT_TAG 06d499cf1c7568fd496f55c34586a419084e2e52
             )
 endif()
 

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -28,7 +28,7 @@ if (NOT MINGW)
     duckdb_extension_load(avro
             LOAD_TESTS DONT_LINK
             GIT_URL https://github.com/duckdb/duckdb-avro
-            GIT_TAG 1b53c8af9973b0267406ca5a24d7e0b52f22cec3
+            GIT_TAG 73e97c0f28888f804ed1361313a1dae623f1a4d2
     )
 endif()
 

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -93,7 +93,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
            ${LOAD_ICEBERG_TESTS}
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 76fd8b092f9986f994ece37bb396dc89adf7b2cc
+            GIT_TAG 2746c589c12d0a8f6b77986ca12a1fc14ef463a4
             )
 endif()
 

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -90,7 +90,6 @@ endif()
 
 if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(iceberg
-#            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
            ${LOAD_ICEBERG_TESTS}
             GIT_URL https://github.com/duckdb/duckdb-iceberg
             GIT_TAG 2746c589c12d0a8f6b77986ca12a1fc14ef463a4

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -19,7 +19,7 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 64f3bfa2743c0d10b05e0e2e137520a5e2e182b3
+    GIT_TAG da2821906eb42f7255d969be3e073bc1b45a71a8
     INCLUDE_DIR extension/httpfs/include
     )
 
@@ -92,7 +92,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(iceberg
            ${LOAD_ICEBERG_TESTS}
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 06d499cf1c7568fd496f55c34586a419084e2e52
+            GIT_TAG 74f0b1d8f385ae82265b62d59c05fcd76ac2564b
             )
 endif()
 

--- a/scripts/merge_vcpkg_deps.py
+++ b/scripts/merge_vcpkg_deps.py
@@ -68,7 +68,7 @@ if merged_overlay_ports:
 else:
     data['vcpkg-configuration'] = {}
 
-REGISTRY_BASELINE = '9989b8b4707261ce77425ae5364b7de7139a2030'
+REGISTRY_BASELINE = '02558971ebafdbaa697a0704a3ed7ba365cd5495'
 # NOTE: use 'scripts/list_vcpkg_registry_packages.py --baseline <baseline>' to generate the list of packages
 data['vcpkg-configuration']['registries'] = [
     {

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -221,6 +221,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"iceberg_metadata", "iceberg", CatalogType::TABLE_FUNCTION_ENTRY},
     {"iceberg_scan", "iceberg", CatalogType::TABLE_FUNCTION_ENTRY},
     {"iceberg_snapshots", "iceberg", CatalogType::TABLE_FUNCTION_ENTRY},
+    {"iceberg_to_ducklake", "iceberg", CatalogType::TABLE_FUNCTION_ENTRY},
     {"icu_calendar_names", "icu", CatalogType::TABLE_FUNCTION_ENTRY},
     {"icu_collate_af", "icu", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"icu_collate_am", "icu", CatalogType::SCALAR_FUNCTION_ENTRY},


### PR DESCRIPTION
This takes from https://github.com/duckdb/duckdb/pull/18140, fixing built time issues.