### PR TITLE
Enable extensions test run with VS2019 C++ stdlib

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -216,8 +216,27 @@ runs:
         python3 scripts/get_test_list.py --file-contains 'require ' --list '"*.test"' > test.list
         python3 scripts/get_test_list.py --file-contains 'require-env LOCAL_EXTENSION_REPO' --list '"*.test"' >> test.list
         ${{ inputs.unittest_script }} '-f test.list'
-        rm -rf build/release/extension
-        mv build/extension_tmp build/release/extension
+
+    - name: Run tests with auto loading with VS2019 C++ stdlib
+      if: ${{ inputs.run_autoload_tests == '1' && inputs.vcpkg_target_triplet == 'x64-windows-static-md' }}
+      shell: bash
+      env:
+        LOCAL_EXTENSION_REPO: ${{ inputs.run_autoload_tests == '1' && github.workspace || ''}}
+      run: |
+        choco install wget -y --no-progress
+        cd  ${{ inputs.build_dir }}
+        TEST_RUNNER_DIR=./build/release/test/Release
+        if [ ! -f ${TEST_RUNNER_DIR}/unittest.exe ]; then
+          echo "Invalid unit tests runner dir: ${TEST_RUNNER_DIR}, check 'inputs.unittest_script' argument"
+          exit 1
+        fi
+        wget -P ${TEST_RUNNER_DIR} https://blobs.duckdb.org/ci/msvcp140.dll
+        ls ${TEST_RUNNER_DIR}
+        # test.list is generated on the previous step
+        ${{ inputs.unittest_script }} '-f test.list'
+        rm ${TEST_RUNNER_DIR}/msvcp140.dll
+        rm -rf ./build/release/extension
+        mv ./build/extension_tmp ./build/release/extension
 
     - name: Deploy
       if: ${{ inputs.deploy_as != '' }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -103,9 +103,10 @@ jobs:
       if: ${{ inputs.skip_tests != 'true' }}
       run: |
         choco install wget -y --no-progress
-        wget -P test/Release https://blobs.duckdb.org/ci/msvcp140.dll
-        test/Release/unittest.exe
-        rm test/Release/msvcp140.dll
+        wget -P ./test/Release https://blobs.duckdb.org/ci/msvcp140.dll
+        ls ./test/Release
+        ./test/Release/unittest.exe
+        rm ./test/Release/msvcp140.dll
 
     - name: Tools Test
       shell: bash


### PR DESCRIPTION
This change enbales additional run of the test suite for all extensions using C++ stdlib DLL from Visual Studion 2019. This is done to check the compatibility with older versions of C++ stdlib introduced in #17991.

New workflow step is only run for `x64-windows-static-md` build arch.

Testing: it was checked in manual CI runs, that added unit test run actually causes a crash when `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` is not used.