### PR TITLE
partially restore deprecated http logging settings

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -364,10 +364,11 @@
     },
     {
         "name": "enable_http_logging",
-        "description": "Enables HTTP logging",
+        "description": "(deprecated) Enables HTTP logging",
         "type": "BOOLEAN",
         "scope": "local",
-        "struct": "EnableHTTPLoggingSetting"
+        "struct": "EnableHTTPLoggingSetting",
+        "custom_implementation": true
     },
     {
         "name": "enable_http_metadata_cache",
@@ -500,10 +501,11 @@
     },
     {
         "name": "http_logging_output",
-        "description": "The file to which HTTP logging output should be saved, or empty to print to the terminal",
+        "description": "(deprecated) The file to which HTTP logging output should be saved, or empty to print to the terminal",
         "type": "VARCHAR",
         "scope": "local",
-        "struct": "HTTPLoggingOutputSetting"
+        "struct": "HTTPLoggingOutputSetting",
+        "custom_implementation": true
     },
     {
         "name": "http_proxy",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -560,7 +560,7 @@ struct EnableFSSTVectorsSetting {
 struct EnableHTTPLoggingSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "enable_http_logging";
-	static constexpr const char *Description = "Enables HTTP logging";
+	static constexpr const char *Description = "(deprecated) Enables HTTP logging";
 	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
@@ -750,7 +750,7 @@ struct HTTPLoggingOutputSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "http_logging_output";
 	static constexpr const char *Description =
-	    "The file to which HTTP logging output should be saved, or empty to print to the terminal";
+	    "(deprecated) The file to which HTTP logging output should be saved, or empty to print to the terminal";
 	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -506,23 +506,6 @@ Value EnableFSSTVectorsSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
-// Enable H T T P Logging
-//===----------------------------------------------------------------------===//
-void EnableHTTPLoggingSetting::SetLocal(ClientContext &context, const Value &input) {
-	auto &config = ClientConfig::GetConfig(context);
-	config.enable_http_logging = input.GetValue<bool>();
-}
-
-void EnableHTTPLoggingSetting::ResetLocal(ClientContext &context) {
-	ClientConfig::GetConfig(context).enable_http_logging = ClientConfig().enable_http_logging;
-}
-
-Value EnableHTTPLoggingSetting::GetSetting(const ClientContext &context) {
-	auto &config = ClientConfig::GetConfig(context);
-	return Value::BOOLEAN(config.enable_http_logging);
-}
-
-//===----------------------------------------------------------------------===//
 // Enable H T T P Metadata Cache
 //===----------------------------------------------------------------------===//
 void EnableHTTPMetadataCacheSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
@@ -676,23 +659,6 @@ void HomeDirectorySetting::ResetLocal(ClientContext &context) {
 Value HomeDirectorySetting::GetSetting(const ClientContext &context) {
 	auto &config = ClientConfig::GetConfig(context);
 	return Value(config.home_directory);
-}
-
-//===----------------------------------------------------------------------===//
-// H T T P Logging Output
-//===----------------------------------------------------------------------===//
-void HTTPLoggingOutputSetting::SetLocal(ClientContext &context, const Value &input) {
-	auto &config = ClientConfig::GetConfig(context);
-	config.http_logging_output = input.GetValue<string>();
-}
-
-void HTTPLoggingOutputSetting::ResetLocal(ClientContext &context) {
-	ClientConfig::GetConfig(context).http_logging_output = ClientConfig().http_logging_output;
-}
-
-Value HTTPLoggingOutputSetting::GetSetting(const ClientContext &context) {
-	auto &config = ClientConfig::GetConfig(context);
-	return Value(config.http_logging_output);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1089,6 +1089,55 @@ void HomeDirectorySetting::SetLocal(ClientContext &context, const Value &input) 
 }
 
 //===----------------------------------------------------------------------===//
+// Enable H T T P Logging
+//===----------------------------------------------------------------------===//
+void EnableHTTPLoggingSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto &config = ClientConfig::GetConfig(context);
+	config.enable_http_logging = input.GetValue<bool>();
+
+	// NOTE: this is a deprecated setting: we mimick the old behaviour by setting the log storage output to STDOUT and
+	// enabling logging for http only. Note that this behaviour is slightly wonky in that it sets all sorts of logging
+	// config
+	auto &log_manager = LogManager::Get(context);
+	if (config.enable_http_logging) {
+		log_manager.SetEnableLogging(true);
+		log_manager.SetLogLevel(HTTPLogType::LEVEL);
+		unordered_set<string> enabled_log_types = {HTTPLogType::NAME};
+		log_manager.SetEnabledLogTypes(enabled_log_types);
+		log_manager.SetLogStorage(*context.db, LogConfig::STDOUT_STORAGE_NAME);
+	} else {
+		log_manager.SetEnableLogging(false);
+	}
+}
+
+void EnableHTTPLoggingSetting::ResetLocal(ClientContext &context) {
+	ClientConfig::GetConfig(context).enable_http_logging = ClientConfig().enable_http_logging;
+}
+
+Value EnableHTTPLoggingSetting::GetSetting(const ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	return Value::BOOLEAN(config.enable_http_logging);
+}
+
+//===----------------------------------------------------------------------===//
+// H T T P Logging Output
+//===----------------------------------------------------------------------===//
+void HTTPLoggingOutputSetting::SetLocal(ClientContext &context, const Value &input) {
+	throw NotImplementedException("This setting is deprecated and can no longer be used. Check out the DuckDB docs on "
+	                              "logging for more information");
+}
+
+void HTTPLoggingOutputSetting::ResetLocal(ClientContext &context) {
+	throw NotImplementedException("This setting is deprecated and can no longer be used. Check out the DuckDB docs on "
+	                              "logging for more information");
+}
+
+Value HTTPLoggingOutputSetting::GetSetting(const ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	return Value(config.http_logging_output);
+}
+
+//===----------------------------------------------------------------------===//
 // Index Scan Percentage
 //===----------------------------------------------------------------------===//
 bool IndexScanPercentageSetting::OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -115,7 +115,6 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"http_proxy", {"localhost:80"}},
 	    {"http_proxy_username", {"john"}},
 	    {"http_proxy_password", {"doe"}},
-	    {"http_logging_output", {"my_cool_outputfile"}},
 	    {"allocator_flush_threshold", {"4.0 GiB"}},
 	    {"allocator_bulk_deallocation_flush_threshold", {"4.0 GiB"}},
 	    {"arrow_output_version", {"1.5"}},
@@ -172,6 +171,7 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "default_block_size",
 	    "index_scan_percentage",
 	    "scheduler_process_partial",
+	    "http_logging_output",
 	    "index_scan_max_count"};
 	return excluded_options.count(name) == 1;
 }

--- a/test/sql/pragma/test_enable_http_logging.test
+++ b/test/sql/pragma/test_enable_http_logging.test
@@ -10,9 +10,7 @@ statement ok
 SET enable_http_logging=true
 
 # select the location of where to save the http logging output (instead of printing to stdout)
-statement ok
+statement error
 SET http_logging_output='__TEST_DIR__/httplog.txt'
-
-# but we can clear it again
-statement ok
-SET http_logging_output=''
+----
+Not implemented Error: This setting is deprecated and can no longer be used. Check out the DuckDB docs on logging for more information


### PR DESCRIPTION
Partially fixes https://github.com/duckdb/duckdb/issues/17714.

The problem was that we broke the existing http logging infrastructure when moving to the new logger.

In this PR i partially the old behaviour for stdout logging by enabling the new http logger with the `stdout` storage whenever the `enable_http_logging` setting is set. This means that the stdout logging now works similarly to how it did before.

I did not manage to find a good way to restore the http logging to a file though. However in DuckDB v1.4 we will be able to do this by using https://github.com/duckdb/duckdb/pull/17692