### PR TITLE
fix typo

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4708,7 +4708,7 @@ static const char zOptions[] =
 static void usage(int showDetail) {
 	utf8_printf(stderr,
 	            "Usage: %s [OPTIONS] FILENAME [SQL]\n"
-	            "FILENAME is the name of an DuckDB database. A new database is created\n"
+	            "FILENAME is the name of a DuckDB database. A new database is created\n"
 	            "if the file does not previously exist.\n",
 	            program_name);
 	if (showDetail) {


### PR DESCRIPTION
"an DuckDB database" --> "a DuckDB database"

It's the first thing one reads when running `duckdb --help`.