### PR TITLE
Bump spatial again: include re-linking for handling global objects in Wasm

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -122,7 +122,7 @@ if (NOT MINGW AND ${BUILD_COMPLETE_EXTENSION_SET})
 duckdb_extension_load(spatial
     DONT_LINK LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-spatial
-    GIT_TAG d1ffa8c21fe1f90064956a119491e6d6d993192a
+    GIT_TAG bef22c4b109d235c2b5725ff9ccf191485d14fd8
     INCLUDE_DIR spatial/include
     TEST_DIR test/sql
     )


### PR DESCRIPTION
On top of https://github.com/duckdb/duckdb/pull/18161 (now merged), small bump further to handle limitation of linking in duckb-wasm solved via (https://github.com/duckdb/duckdb-spatial/pull/634)