### PR TITLE
ci(pyodide): enable WASM exceptions on the latest pyodide build

### DIFF
--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -46,23 +46,28 @@ jobs:
             node: "16"
             other_deps: "'pydantic<2'"
             perform_tests: true
+            flags: "-fexceptions"
           - python: "3.11"
             pyodide-build: "0.25.1"
             node: "18"
             other_deps: "'pydantic<2'"
             perform_tests: true
+            flags: "-fexceptions"
           - python: "3.12"
             pyodide-build: "0.26.1"
             node: "20"
             perform_tests: true
+            flags: "-fexceptions"
           - python: "3.12"
             pyodide-build: "0.27.2"
             node: "20"
             perform_tests: false # It's unclear why this fails in test setup, possibly missing dependencies, not investigated yet
+            flags: "-fexceptions"
           - python: "3.13"
             pyodide-build: "0.30.5"
             node: "22"
             perform_tests: true
+            flags: "-fwasm-exceptions"
 
     steps:
       - uses: actions/checkout@v4
@@ -106,8 +111,8 @@ jobs:
         working-directory: ./tools/pythonpkg
         env:
           DUCKDB_CUSTOM_PLATFORM: wasm_eh_pyodide
-          CFLAGS: "-fexceptions"
-          LDFLAGS: "-fexceptions"
+          CFLAGS: "${{ matrix.version.flags }}"
+          LDFLAGS: "${{ matrix.version.flags }}"
 
       - name: install node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Build latest-pyodide duckdb wheels using WASM native exceptions, per https://github.com/duckdb/duckdb-pyodide/issues/5#issuecomment-2692991965
