### PR TITLE
Avoid `realloc` in CSV writer

### DIFF
--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -328,8 +328,8 @@ static void WriteQuotedString(WriteStream &writer, WriteCSVData &csv_data, const
 //===--------------------------------------------------------------------===//
 struct LocalWriteCSVData : public LocalFunctionData {
 public:
-	LocalWriteCSVData(ClientContext &context, vector<unique_ptr<Expression>> &expressions)
-	    : executor(context, expressions), stream(Allocator::Get(context)) {
+	LocalWriteCSVData(ClientContext &context, vector<unique_ptr<Expression>> &expressions, const idx_t &flush_size)
+	    : executor(context, expressions), stream(BufferAllocator::Get(context), flush_size) {
 	}
 
 public:
@@ -387,7 +387,7 @@ struct GlobalWriteCSVData : public GlobalFunctionData {
 
 static unique_ptr<LocalFunctionData> WriteCSVInitializeLocal(ExecutionContext &context, FunctionData &bind_data) {
 	auto &csv_data = bind_data.Cast<WriteCSVData>();
-	auto local_data = make_uniq<LocalWriteCSVData>(context.client, csv_data.cast_expressions);
+	auto local_data = make_uniq<LocalWriteCSVData>(context.client, csv_data.cast_expressions, csv_data.flush_size);
 
 	// create the chunk with VARCHAR types
 	vector<LogicalType> types;
@@ -409,7 +409,7 @@ static unique_ptr<GlobalFunctionData> WriteCSVInitializeGlobal(ClientContext &co
 	}
 
 	if (!(options.dialect_options.header.IsSetByUser() && !options.dialect_options.header.GetValue())) {
-		MemoryStream stream(Allocator::Get(context));
+		MemoryStream stream(BufferAllocator::Get(context), csv_data.flush_size);
 		// write the header line to the file
 		for (idx_t i = 0; i < csv_data.options.name_list.size(); i++) {
 			if (i != 0) {
@@ -512,7 +512,7 @@ void WriteCSVFinalize(ClientContext &context, FunctionData &bind_data, GlobalFun
 	auto &csv_data = bind_data.Cast<WriteCSVData>();
 	auto &options = csv_data.options;
 
-	MemoryStream stream(Allocator::Get(context));
+	MemoryStream stream(BufferAllocator::Get(context), csv_data.flush_size);
 	if (!options.suffix.empty()) {
 		stream.WriteData(const_data_ptr_cast(options.suffix.c_str()), options.suffix.size());
 	} else if (global_state.written_anything) {
@@ -540,7 +540,7 @@ CopyFunctionExecutionMode WriteCSVExecutionMode(bool preserve_insertion_order, b
 // Prepare Batch
 //===--------------------------------------------------------------------===//
 struct WriteCSVBatchData : public PreparedBatchData {
-	explicit WriteCSVBatchData(Allocator &allocator) : stream(allocator) {
+	explicit WriteCSVBatchData(Allocator &allocator, const idx_t flush_size) : stream(allocator, flush_size) {
 	}
 
 	//! The thread-local buffer to write data into
@@ -564,7 +564,7 @@ unique_ptr<PreparedBatchData> WriteCSVPrepareBatch(ClientContext &context, Funct
 
 	// write CSV chunks to the batch data
 	bool written_anything = false;
-	auto batch = make_uniq<WriteCSVBatchData>(Allocator::Get(context));
+	auto batch = make_uniq<WriteCSVBatchData>(BufferAllocator::Get(context), NextPowerOfTwo(collection->SizeInBytes()));
 	for (auto &chunk : collection->Chunks()) {
 		WriteCSVChunkInternal(context, bind_data, cast_chunk, batch->stream, chunk, written_anything, executor);
 	}


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/18139

Initializes the `MemoryStream` in various places with the flush size, and uses the `BufferAllocator` so we keep track of memory usage.

The main culprit was batch flushing (which is enabled when preserving insertion order), where many threads were flushing large batches (e.g., many megabytes), while the initial buffer was only 512 bytes, causing it to double in size many times, causing many `realloc`s, which caused the MacOS allocator to kinda freeze. This doesn't happen when compiling with jemalloc.