### PR TITLE
fix bug with allowed_paths

### DIFF
--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -713,19 +713,15 @@ bool DBConfig::CanAccessFile(const string &input_path, FileType type) {
 			path += "/";
 		}
 	}
-	auto start_bound = options.allowed_directories.lower_bound(path);
-	if (start_bound != options.allowed_directories.begin()) {
-		--start_bound;
-	}
-	auto end_bound = options.allowed_directories.upper_bound(path);
 
 	string prefix;
-	for (auto it = start_bound; it != end_bound; ++it) {
-		if (StringUtil::StartsWith(path, *it)) {
-			prefix = *it;
+	for (const auto &allowed_directory : options.allowed_directories) {
+		if (StringUtil::StartsWith(path, allowed_directory)) {
+			prefix = allowed_directory;
 			break;
 		}
 	}
+
 	if (prefix.empty()) {
 		// no common prefix found - path is not inside an allowed directory
 		return false;

--- a/test/sql/settings/allowed_directories.test
+++ b/test/sql/settings/allowed_directories.test
@@ -19,7 +19,7 @@ statement ok
 RESET allowed_directories
 
 statement ok
-SET allowed_directories=['data/csv/glob', 'data/parquet-testing/glob', 'data/json', '__TEST_DIR__']
+SET allowed_directories=['data/csv/glob', 'data/csv/glob/1', 'data/parquet-testing/glob', 'data/json', '__TEST_DIR__']
 
 statement ok
 SET enable_external_access=false


### PR DESCRIPTION
### Problem
The `allowed_directories` values was not searched correctly leading to permissions errors in certain cases.

### Fix
Current behaviour tried to use an `std::set ` to efficiently do prefix matches. The implementation was actually wrong though.  It used the `set::upper_bound` and `set::lower_bound` to limit which paths should be compared for a prefix match. However this does not work. These functions return the exact same value unless the exact path you search for is in the set.

I think the `set` can not be used for efficient prefix matching like this. Because this is not performance critical code anyway I've just switched to a O(N) search over the set of prefixes. Proper solution would be to use a trie, but we don't have a simple implementation handy afaik.

Made a small tweak to one of the tests to trigger this error and confirm the fix 