### PR TITLE
Add support for table_constraints of AdbcConnectionGetObjects()

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -1423,6 +1423,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 								constraint_name: constraint_name,
 								constraint_type: constraint_type,
 								constraint_column_names: column_names,
+								-- TODO: USAGE_SCHEMA isn't implemented yet
 								constraint_column_usage: []::STRUCT(fk_catalog VARCHAR, fk_db_schema VARCHAR, fk_table VARCHAR, fk_column_name VARCHAR)[],
 							}
 						) table_constraints

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -1339,15 +1339,24 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		db.Query("Drop table result;");
 
 		// table_name
-		string select_catalog_db_schema = R"(
-			Select list_sort(catalog_db_schemas) as catalog_db_schemas
-			from result
-			where catalog_name == 'test_table_depth'
+		string select_catalog_db_schemas = R"(
+			SELECT
+				list_sort(
+					list_transform(
+						catalog_db_schemas,
+						lambda catalog_db_schema: {
+							db_schema_name: catalog_db_schema.db_schema_name,
+							db_schema_tables: list_sort(catalog_db_schema.db_schema_tables),
+						}
+					)
+				) as catalog_db_schemas
+			FROM result
+			WHERE catalog_name == 'test_table_depth'
         )";
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, nullptr, nullptr, "bla", nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
 		db.CreateTable("result", arrow_stream);
-		res = db.Query(select_catalog_db_schema);
+		res = db.Query(select_catalog_db_schemas);
 		REQUIRE((res->ColumnCount() == 1));
 		REQUIRE((res->RowCount() == 1));
 		string expected = "[{'db_schema_name': main, 'db_schema_tables': NULL}]";
@@ -1360,7 +1369,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 			AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, nullptr, nullptr, nullptr,
 			                         table_type.data(), nullptr, &arrow_stream, &adbc_error);
 			db.CreateTable("result", arrow_stream);
-			res = db.Query(select_catalog_db_schema);
+			res = db.Query(select_catalog_db_schemas);
 			REQUIRE((res->ColumnCount() == 1));
 			REQUIRE((res->RowCount() == 1));
 			REQUIRE(
@@ -1374,7 +1383,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 			AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, nullptr, nullptr, nullptr,
 			                         table_type.data(), nullptr, &arrow_stream, &adbc_error);
 			db.CreateTable("result", arrow_stream);
-			res = db.Query(select_catalog_db_schema);
+			res = db.Query(select_catalog_db_schemas);
 			REQUIRE((res->ColumnCount() == 1));
 			REQUIRE((res->RowCount() == 1));
 			REQUIRE(
@@ -1388,7 +1397,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 			AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, nullptr, nullptr, nullptr,
 			                         table_type.data(), nullptr, &arrow_stream, &adbc_error);
 			db.CreateTable("result", arrow_stream);
-			res = db.Query(select_catalog_db_schema);
+			res = db.Query(select_catalog_db_schemas);
 			REQUIRE((res->ColumnCount() == 1));
 			REQUIRE((res->RowCount() == 1));
 			string expected_result = R"([{
@@ -1414,7 +1423,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 			AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, nullptr, nullptr, nullptr,
 			                         table_type.data(), nullptr, &arrow_stream, &adbc_error);
 			db.CreateTable("result", arrow_stream);
-			res = db.Query(select_catalog_db_schema);
+			res = db.Query(select_catalog_db_schemas);
 			REQUIRE((res->ColumnCount() == 1));
 			REQUIRE((res->RowCount() == 1));
 			string expected_result = R"([{
@@ -1566,9 +1575,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 
 		// table_name
 		string select_catalog_db_schemas = R"(
-			Select list_sort(catalog_db_schemas) as catalog_db_schemas
-			from result
-			where catalog_name == 'test_column_depth'
+			SELECT
+				list_sort(
+					list_transform(
+						catalog_db_schemas,
+						lambda catalog_db_schema: {
+							db_schema_name: catalog_db_schema.db_schema_name,
+							db_schema_tables: list_sort(catalog_db_schema.db_schema_tables),
+						}
+					)
+				) as catalog_db_schemas
+			FROM result
+			WHERE catalog_name == 'test_column_depth'
         )";
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, "bla", nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
@@ -1719,10 +1737,8 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 	// 5. Test ADBC_OBJECT_DEPTH_ALL
 	{
 		ADBCTestDatabase db("test_all_depth");
-		// Create Arrow Result
-		auto &input_data = db.QueryArrow("SELECT 42 as value");
-		// Create Table 'my_table' from the Arrow Result
-		db.CreateTable("my_table", input_data);
+		// Create Table 'my_table' with primary key
+		db.Query("Create table my_table (a int, b int, primary key (a, b))");
 		// Create View 'my_view'
 		db.Query("Create view my_view as from my_table;");
 
@@ -1732,7 +1748,21 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_ALL, nullptr, nullptr, nullptr, nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
 		db.CreateTable("result", arrow_stream);
-		auto res = db.Query("Select * from result order by catalog_name asc");
+		auto res = db.Query(R"(
+			SELECT
+				catalog_name,
+				list_sort(
+					list_transform(
+						catalog_db_schemas,
+						lambda catalog_db_schema: {
+							db_schema_name: catalog_db_schema.db_schema_name,
+							db_schema_tables: list_sort(catalog_db_schema.db_schema_tables),
+						}
+					)
+				)
+			FROM result
+			ORDER BY catalog_name ASC
+		)");
 		REQUIRE((res->RowCount() == 3));
 		REQUIRE((res->GetValue(0, 0).ToString() == "system"));
 		REQUIRE((res->GetValue(0, 1).ToString() == "temp"));
@@ -1756,8 +1786,29 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                         'table_type': BASE TABLE,
                         'table_columns': [
                             {
-                                'column_name': value,
+                                'column_name': a,
                                 'ordinal_position': 1,
+                                'remarks': '',
+                                'xdbc_data_type': NULL,
+                                'xdbc_type_name': NULL,
+                                'xdbc_column_size': NULL,
+                                'xdbc_decimal_digits': NULL,
+                                'xdbc_num_prec_radix': NULL,
+                                'xdbc_nullable': NULL,
+                                'xdbc_column_def': NULL,
+                                'xdbc_sql_data_type': NULL,
+                                'xdbc_datetime_sub': NULL,
+                                'xdbc_char_octet_length': NULL,
+                                'xdbc_is_nullable': NULL,
+                                'xdbc_scope_catalog': NULL,
+                                'xdbc_scope_schema': NULL,
+                                'xdbc_scope_table': NULL,
+                                'xdbc_is_autoincrement': NULL,
+                                'xdbc_is_generatedcolumn': NULL
+                            },
+                            {
+                                'column_name': b,
+                                'ordinal_position': 2,
                                 'remarks': '',
                                 'xdbc_data_type': NULL,
                                 'xdbc_type_name': NULL,
@@ -1777,7 +1828,14 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                                 'xdbc_is_generatedcolumn': NULL
                             }
                         ],
-                        'table_constraints': NULL
+                        'table_constraints': [
+                            {
+                                'constraint_name': my_table_a_b_pkey,
+                                'constraint_type': PRIMARY KEY,
+                                'constraint_column_names': [a, b],
+                                'constraint_column_usage': []
+                            }
+                        ]
                     },
                     {
                         'table_name': my_view,
@@ -1786,6 +1844,27 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': value,
                                 'ordinal_position': 1,
+                                'remarks': '',
+                                'xdbc_data_type': NULL,
+                                'xdbc_type_name': NULL,
+                                'xdbc_column_size': NULL,
+                                'xdbc_decimal_digits': NULL,
+                                'xdbc_num_prec_radix': NULL,
+                                'xdbc_nullable': NULL,
+                                'xdbc_column_def': NULL,
+                                'xdbc_sql_data_type': NULL,
+                                'xdbc_datetime_sub': NULL,
+                                'xdbc_char_octet_length': NULL,
+                                'xdbc_is_nullable': NULL,
+                                'xdbc_scope_catalog': NULL,
+                                'xdbc_scope_schema': NULL,
+                                'xdbc_scope_table': NULL,
+                                'xdbc_is_autoincrement': NULL,
+                                'xdbc_is_generatedcolumn': NULL
+                            },
+                            {
+                                'column_name': b,
+                                'ordinal_position': 2,
                                 'remarks': '',
                                 'xdbc_data_type': NULL,
                                 'xdbc_type_name': NULL,
@@ -1845,9 +1924,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 
 		// table_name
 		string select_catalog_db_schemas = R"(
-			Select list_sort(catalog_db_schemas) as catalog_db_schemas
-			from result
-			where catalog_name == 'test_all_depth'
+			SELECT
+				list_sort(
+					list_transform(
+						catalog_db_schemas,
+						lambda catalog_db_schema: {
+							db_schema_name: catalog_db_schema.db_schema_name,
+							db_schema_tables: list_sort(catalog_db_schema.db_schema_tables),
+						}
+					)
+				) as catalog_db_schemas
+			FROM result
+			WHERE catalog_name == 'test_all_depth'
         )";
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, "bla", nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
@@ -1864,11 +1952,27 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		db.CreateTable("result", arrow_stream);
 		res = db.Query(select_catalog_db_schemas);
 		REQUIRE((res->RowCount() == 1));
-		expected = "[{'db_schema_name': main, "
-		           "'db_schema_tables': [{'table_name': my_table, 'table_type': BASE TABLE, "
-		           "'table_columns': NULL, 'table_constraints': NULL}, "
-		           "{'table_name': my_view, 'table_type': VIEW, "
-		           "'table_columns': NULL, 'table_constraints': NULL}]}]";
+		// clang-format off
+		expected = "["
+			"{"
+				"'db_schema_name': main, "
+				"'db_schema_tables': ["
+					"{"
+						"'table_name': my_table, "
+						"'table_type': BASE TABLE, "
+						"'table_columns': NULL, "
+						"'table_constraints': NULL"
+					"}, "
+					"{"
+						"'table_name': my_view, "
+						"'table_type': VIEW, "
+						"'table_columns': NULL, "
+						"'table_constraints': NULL"
+					"}"
+				"]"
+			"}"
+		"]";
+		// clang-format on
 		REQUIRE((res->GetValue(0, 0).ToString() == expected));
 		db.Query("Drop table result;");
 
@@ -1915,8 +2019,29 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                         'table_type': BASE TABLE,
                         'table_columns': [
                             {
-                                'column_name': value,
+                                'column_name': a,
                                 'ordinal_position': 1,
+                                'remarks': '',
+                                'xdbc_data_type': NULL,
+                                'xdbc_type_name': NULL,
+                                'xdbc_column_size': NULL,
+                                'xdbc_decimal_digits': NULL,
+                                'xdbc_num_prec_radix': NULL,
+                                'xdbc_nullable': NULL,
+                                'xdbc_column_def': NULL,
+                                'xdbc_sql_data_type': NULL,
+                                'xdbc_datetime_sub': NULL,
+                                'xdbc_char_octet_length': NULL,
+                                'xdbc_is_nullable': NULL,
+                                'xdbc_scope_catalog': NULL,
+                                'xdbc_scope_schema': NULL,
+                                'xdbc_scope_table': NULL,
+                                'xdbc_is_autoincrement': NULL,
+                                'xdbc_is_generatedcolumn': NULL
+                            },
+                            {
+                                'column_name': b,
+                                'ordinal_position': 2,
                                 'remarks': '',
                                 'xdbc_data_type': NULL,
                                 'xdbc_type_name': NULL,
@@ -1936,7 +2061,14 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                                 'xdbc_is_generatedcolumn': NULL
                             }
                         ],
-                        'table_constraints': NULL
+                        'table_constraints': [
+                            {
+                                'constraint_name': my_table_a_b_pkey,
+                                'constraint_type': PRIMARY KEY,
+                                'constraint_column_names': [a, b],
+                                'constraint_column_usage': []
+                            }
+                        ]
                     }
                 ]
             }])";
@@ -1965,6 +2097,27 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                             {
                                 'column_name': value,
                                 'ordinal_position': 1,
+                                'remarks': '',
+                                'xdbc_data_type': NULL,
+                                'xdbc_type_name': NULL,
+                                'xdbc_column_size': NULL,
+                                'xdbc_decimal_digits': NULL,
+                                'xdbc_num_prec_radix': NULL,
+                                'xdbc_nullable': NULL,
+                                'xdbc_column_def': NULL,
+                                'xdbc_sql_data_type': NULL,
+                                'xdbc_datetime_sub': NULL,
+                                'xdbc_char_octet_length': NULL,
+                                'xdbc_is_nullable': NULL,
+                                'xdbc_scope_catalog': NULL,
+                                'xdbc_scope_schema': NULL,
+                                'xdbc_scope_table': NULL,
+                                'xdbc_is_autoincrement': NULL,
+                                'xdbc_is_generatedcolumn': NULL
+                            },
+                            {
+                                'column_name': b,
+                                'ordinal_position': 2,
                                 'remarks': '',
                                 'xdbc_data_type': NULL,
                                 'xdbc_type_name': NULL,

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -1869,7 +1869,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                         'table_type': VIEW,
                         'table_columns': [
                             {
-                                'column_name': value,
+                                'column_name': a,
                                 'ordinal_position': 1,
                                 'remarks': '',
                                 'xdbc_data_type': NULL,
@@ -2122,7 +2122,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
                         'table_type': VIEW,
                         'table_columns': [
                             {
-                                'column_name': value,
+                                'column_name': a,
                                 'ordinal_position': 1,
                                 'remarks': '',
                                 'xdbc_data_type': NULL,
@@ -2221,7 +2221,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 				) as catalog_db_schemas
 			FROM result
 			WHERE catalog_name == 'test_constraints'
-        )";
+		)";
 		auto res = db.Query(select_catalog_db_schemas);
 		REQUIRE((res->RowCount() == 1));
 		// clang-format off
@@ -2239,7 +2239,12 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 							"'constraint_name': my_table_foreign_id_id_fkey, "
 							"'constraint_type': FOREIGN KEY, "
 							"'constraint_column_names': [foreign_id], "
-							"'constraint_column_usage': []" // TODO: USAGE_SCHEMA isn't implemented yet
+							"'constraint_column_usage': [{"
+								"'fk_catalog': test_constraints, "
+								"'fk_db_schema': main, "
+								"'fk_table': foreign_table, "
+								"'fk_column_name': id"
+							"}]"
 						"}, {"
 							"'constraint_name': my_table_primary_key_pkey, "
 							"'constraint_type': PRIMARY KEY, "

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -2182,13 +2182,18 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		// Create table 'foreign_table'
 		db.Query("CREATE TABLE foreign_table (id INTEGER PRIMARY KEY)");
 		// Create table 'my_table' with constraints
-		db.Query("CREATE TABLE my_table ("                         //
-		         "primary_key INTEGER PRIMARY KEY, "               //
-		         "not_null INTEGER NOT NULL, "                     //
-		         "custom_check INTEGER CHECK (custom_check > 0), " //
-		         "unique_value INTEGER UNIQUE, "                   //
-		         "foreign_id INTEGER REFERENCES foreign_table(id)" //
-		         ")");
+		db.Query(R"(
+			CREATE TABLE my_table (
+				primary_key INTEGER PRIMARY KEY,
+				not_null INTEGER NOT NULL,
+				custom_check INTEGER CHECK (custom_check > 0),
+				unique_single INTEGER UNIQUE,
+				unique_multi1 INTEGER,
+				unique_multi2 INTEGER,
+				UNIQUE (unique_multi2, unique_multi1),
+				foreign_id INTEGER REFERENCES foreign_table(id)
+			)
+		)");
 
 		AdbcError adbc_error;
 		InitializeADBCError(&adbc_error);
@@ -2241,9 +2246,14 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 							"'constraint_column_names': [primary_key], "
 							"'constraint_column_usage': []"
 						"}, {"
-							"'constraint_name': my_table_unique_value_key, "
+							"'constraint_name': my_table_unique_multi2_unique_multi1_key, "
 							"'constraint_type': UNIQUE, "
-							"'constraint_column_names': [unique_value], "
+							"'constraint_column_names': [unique_multi2, unique_multi1], "
+							"'constraint_column_usage': []"
+						"}, {"
+							"'constraint_name': my_table_unique_single_key, "
+							"'constraint_type': UNIQUE, "
+							"'constraint_column_names': [unique_single], "
 							"'constraint_column_usage': []"
 						"}]"
 					"}"


### PR DESCRIPTION
See
https://arrow.apache.org/adbc/19/cpp/api/group__adbc-connection-metadata.html#ga32f64f4cfc86140e2d8d02b328215dbf for `AdbcConnectionGetObjects()` and `table_constraints` specification.
