### PR TITLE
Connect relations that are not in a subgraph, but are still part of the new relation set

### DIFF
--- a/src/optimizer/join_order/cardinality_estimator.cpp
+++ b/src/optimizer/join_order/cardinality_estimator.cpp
@@ -11,7 +11,6 @@
 
 #include <math.h>
 
-
 namespace duckdb {
 
 // The filter was made on top of a logical sample or other projection,

--- a/src/optimizer/join_order/cardinality_estimator.cpp
+++ b/src/optimizer/join_order/cardinality_estimator.cpp
@@ -11,6 +11,7 @@
 
 #include <math.h>
 
+
 namespace duckdb {
 
 // The filter was made on top of a logical sample or other projection,
@@ -355,7 +356,7 @@ DenomInfo CardinalityEstimator::GetDenominator(JoinRelationSet &set) {
 	auto denom_multiplier = 1.0 + static_cast<double>(unused_edge_tdoms.size());
 
 	// It's possible cross-products were added and are not present in the filters in the relation_2_tdom
-	// structures. When that's the case, merge all remaining subgraphs.
+	// structures. When that's the case, merge all remaining subgraphs as if they are connected by a cross product
 	if (subgraphs.size() > 1) {
 		auto final_subgraph = subgraphs.at(0);
 		for (auto merge_with = subgraphs.begin() + 1; merge_with != subgraphs.end(); merge_with++) {
@@ -367,6 +368,23 @@ DenomInfo CardinalityEstimator::GetDenominator(JoinRelationSet &set) {
 			final_subgraph.denom *= merge_with->denom;
 		}
 	}
+	if (!subgraphs.empty()) {
+		// Some relations are connected by cross products and will not end up in a subgraph
+		// Check and make sure all relations were considered, if not, they are connected to the graph by cross products
+		auto &returning_subgraph = subgraphs.at(0);
+		if (returning_subgraph.relations->count != set.count) {
+			for (idx_t rel_index = 0; rel_index < set.count; rel_index++) {
+				auto relation_id = set.relations[rel_index];
+				auto &rel = set_manager.GetJoinRelation(relation_id);
+				if (!JoinRelationSet::IsSubset(*returning_subgraph.relations, rel)) {
+					returning_subgraph.numerator_relations =
+					    &set_manager.Union(*returning_subgraph.numerator_relations, rel);
+					returning_subgraph.relations = &set_manager.Union(*returning_subgraph.relations, rel);
+				}
+			}
+		}
+	}
+
 	// can happen if a table has cardinality 0, a tdom is set to 0, or if a cross product is used.
 	if (subgraphs.empty() || subgraphs.at(0).denom == 0) {
 		// denominator is 1 and numerators are a cross product of cardinalities.
@@ -377,7 +395,6 @@ DenomInfo CardinalityEstimator::GetDenominator(JoinRelationSet &set) {
 
 template <>
 double CardinalityEstimator::EstimateCardinalityWithSet(JoinRelationSet &new_set) {
-
 	if (relation_set_2_cardinality.find(new_set.ToString()) != relation_set_2_cardinality.end()) {
 		return relation_set_2_cardinality[new_set.ToString()].cardinality_before_filters;
 	}

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -103,6 +103,7 @@ void Optimizer::RunBuiltInOptimizers() {
 	case LogicalOperatorType::LOGICAL_TRANSACTION:
 	case LogicalOperatorType::LOGICAL_PRAGMA:
 	case LogicalOperatorType::LOGICAL_SET:
+	case LogicalOperatorType::LOGICAL_ATTACH:
 	case LogicalOperatorType::LOGICAL_UPDATE_EXTENSIONS:
 	case LogicalOperatorType::LOGICAL_CREATE_SECRET:
 	case LogicalOperatorType::LOGICAL_EXTENSION_OPERATOR:

--- a/test/optimizer/joins/test_issue_5265.test_slow
+++ b/test/optimizer/joins/test_issue_5265.test_slow
@@ -1,0 +1,53 @@
+# name: test/optimizer/joins/test_issue_5265.test_slow
+# description: Verify expected cardinality of multiple cross products
+# group: [joins]
+
+statement ok
+call dbgen(sf=0.1);
+
+# this should run quickly
+statement ok
+SELECT n.n_name,
+       SUM(l.l_extendedprice * (1 - l.l_discount)) AS revenue
+FROM region r
+JOIN nation n
+  ON n.n_regionkey = r.r_regionkey
+JOIN supplier s
+  ON s.s_nationkey = n.n_nationkey
+JOIN lineitem l
+  ON l.l_suppkey = s.s_suppkey
+JOIN orders o
+  ON o.o_orderkey = l.l_orderkey
+JOIN customer c
+  ON c.c_custkey = o.o_custkey
+ AND c.c_nationkey = s.s_nationkey
+JOIN (SELECT 1 AS dummy) single_row ON 1 = 1
+WHERE r.r_name = 'ASIA'
+  AND o.o_orderdate >= DATE '1994-01-01'
+  AND o.o_orderdate < DATE '1995-01-01'
+GROUP BY n.n_name
+ORDER BY revenue DESC;
+
+query II
+explain SELECT n.n_name,
+       SUM(l.l_extendedprice * (1 - l.l_discount)) AS revenue
+FROM region r
+JOIN nation n
+  ON n.n_regionkey = r.r_regionkey
+JOIN supplier s
+  ON s.s_nationkey = n.n_nationkey
+JOIN lineitem l
+  ON l.l_suppkey = s.s_suppkey
+JOIN orders o
+  ON o.o_orderkey = l.l_orderkey
+JOIN customer c
+  ON c.c_custkey = o.o_custkey
+ AND c.c_nationkey = s.s_nationkey
+JOIN (SELECT 1 AS dummy) single_row ON 1 = 1
+WHERE r.r_name = 'ASIA'
+  AND o.o_orderdate >= DATE '1994-01-01'
+  AND o.o_orderdate < DATE '1995-01-01'
+GROUP BY n.n_name
+ORDER BY revenue DESC;
+----
+physical_plan	<!REGEX>:.*CROSS_PRODUCT.*CROSS_PRODUCT.*

--- a/test/optimizer/joins/test_issue_5265.test_slow
+++ b/test/optimizer/joins/test_issue_5265.test_slow
@@ -2,6 +2,8 @@
 # description: Verify expected cardinality of multiple cross products
 # group: [joins]
 
+require tpch
+
 statement ok
 call dbgen(sf=0.1);
 


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/5265

we weren't considering come relations when estimating cardinality because they were connected by a cross product. Now whenever we estimate the cardinality of a set, we make sure all relations are considered, if not we assume missing relations are connected by a cross product.