### PR TITLE
Include pyodide build configuration

### DIFF
--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -67,3 +67,10 @@ test-command = "python -m pytest {project}/tests/fast --verbose"
 # See https://github.com/duckdblabs/duckdb-internal/issues/1923 for context
 [tool.cibuildwheel.macos]
 before-test = 'python scripts/optional_requirements.py --exclude polars --exclude tensorflow'
+
+### Pyodide build configuration
+
+# See https://github.com/duckdb/duckdb-pyodide/issues/7 for context
+
+[tool.pyodide.build]
+default_cross_build_env_url = "https://github.com/pyodide/pyodide/releases/download/0.28.0a3/xbuildenv-0.28.0a3.tar.bz2"


### PR DESCRIPTION
This adds build support for the latest ABI version of pyodide.

I wasn't sure how to get `duckdb/duckdb-pyodide` to build for the latest ABI version of pyodide / emcripten so I figured I'd make this PR to bring it to your attention: https://github.com/duckdb/duckdb-pyodide/issues/7