### PR TITLE
Add VS2019 compat flag to Python wheel build

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -252,7 +252,16 @@ os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 if os.name == 'nt':
     # windows:
-    toolchain_args = ['/wd4244', '/wd4267', '/wd4200', '/wd26451', '/wd26495', '/D_CRT_SECURE_NO_WARNINGS', '/utf-8']
+    toolchain_args = [
+        '/wd4244',
+        '/wd4267',
+        '/wd4200',
+        '/wd26451',
+        '/wd26495',
+        '/D_CRT_SECURE_NO_WARNINGS',
+        '/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR',
+        '/utf-8',
+    ]
 else:
     # macos/linux
     toolchain_args = ['-std=c++11', '-g0']


### PR DESCRIPTION
This change adds `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` preprocessor definition to Python wheel builds on Windows.

For details see #17991, where the same definition was added for CLI builds.

Fixes: #17971