### PR TITLE
Skip logging test for smaller block sizes

### DIFF
--- a/test/sql/logging/file_system_logging_attach.test
+++ b/test/sql/logging/file_system_logging_attach.test
@@ -1,6 +1,10 @@
 # name: test/sql/logging/file_system_logging_attach.test
 # group: [logging]
 
+# We directly compare to the number of bytes written in the last statement,
+# which is the block size.
+require block_size 262144
+
 require parquet
 
 require noforcestorage
@@ -8,13 +12,13 @@ require noforcestorage
 require no_alternative_verify
 
 statement ok
-set enable_logging=true;
+SET enable_logging=true;
 
 statement ok
-set logging_level='trace';
+SET logging_level='trace';
 
 statement ok
-attach '__TEST_DIR__/filehandle_logging.db' as db;
+ATTACH '__TEST_DIR__/filehandle_logging.db' AS db;
 
 statement ok
 CREATE TABLE db.test AS SELECT 1;
@@ -24,7 +28,7 @@ DETACH db;
 
 # Note: regex for test stability
 query IIII
-SELECT scope, type, log_level, regexp_replace(message, '\"path\":.*filehandle_logging.db"', '"path":"filehandle_logging.db"') as msg
+SELECT scope, type, log_level, regexp_replace(message, '\"path\":.*filehandle_logging.db"', '"path":"filehandle_logging.db"') AS msg
 FROM duckdb_logs
 WHERE type = 'FileSystem' AND contains(msg, '"path":"filehandle_logging.db"')
 ORDER BY timestamp


### PR DESCRIPTION
Same changes like here: https://github.com/duckdb/duckdb/pull/17957

So we can run the storage tests in the nightly run.

```
python3 scripts/run_tests_one_by_one.py ./build/relassert/test/unittest "test/sql/storage/*" --no-exit --time_execution
```