### PR TITLE
[Fix] Don't write empty (partial) blocks for FSST dictionary compression

### DIFF
--- a/src/include/duckdb/storage/table/column_segment.hpp
+++ b/src/include/duckdb/storage/table/column_segment.hpp
@@ -97,9 +97,9 @@ public:
 	//! Revert an append made to this segment
 	void RevertAppend(idx_t start_row);
 
-	//! Convert a transient in-memory segment into a persistent segment blocked by an on-disk block.
+	//! Convert a transient in-memory segment to a persistent segment backed by an on-disk block.
 	//! Only used during checkpointing.
-	void ConvertToPersistent(optional_ptr<BlockManager> block_manager, block_id_t block_id);
+	void ConvertToPersistent(optional_ptr<BlockManager> block_manager, const block_id_t block_id);
 	//! Updates pointers to refer to the given block and offset. This is only used
 	//! when sharing a block among segments. This is invoked only AFTER the block is written.
 	void MarkAsPersistent(shared_ptr<BlockHandle> block, uint32_t offset_in_block);

--- a/src/storage/partial_block_manager.cpp
+++ b/src/storage/partial_block_manager.cpp
@@ -118,6 +118,7 @@ void PartialBlockManager::RegisterPartialBlock(PartialBlockAllocation allocation
 		// check if the block is STILL partially filled after adding the segment_size
 		if (new_space_left >= block_manager.GetBlockSize() - max_partial_block_size) {
 			// the block is still partially filled: add it to the partially_filled_blocks list
+			D_ASSERT(allocation.partial_block->state.offset > 0);
 			partially_filled_blocks.insert(make_pair(new_space_left, std::move(allocation.partial_block)));
 		}
 	}

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -126,22 +126,25 @@ void ColumnCheckpointState::FlushSegmentInternal(unique_ptr<ColumnSegment> segme
 		return;
 	} // LCOV_EXCL_STOP
 
-	// merge the segment stats into the global stats
+	// Merge the segment statistics into the global statistics.
 	global_stats->Merge(segment->stats.statistics);
 
-	// get the buffer of the segment and pin it
-	auto &db = column_data.GetDatabase();
-	auto &buffer_manager = BufferManager::GetBufferManager(db);
 	block_id_t block_id = INVALID_BLOCK;
 	uint32_t offset_in_block = 0;
 
 	unique_lock<mutex> partial_block_lock;
-	if (!segment->stats.statistics.IsConstant()) {
+	if (segment->stats.statistics.IsConstant()) {
+		// Constant block.
+		segment->ConvertToPersistent(nullptr, INVALID_BLOCK);
+
+	} else if (segment_size != 0) {
+		// Non-constant block with data that has to go to disk.
+		auto &db = column_data.GetDatabase();
+		auto &buffer_manager = BufferManager::GetBufferManager(db);
 		partial_block_lock = partial_block_manager.GetLock();
 
-		// non-constant block
-		PartialBlockAllocation allocation =
-		    partial_block_manager.GetBlockAllocation(NumericCast<uint32_t>(segment_size));
+		auto cast_segment_size = NumericCast<uint32_t>(segment_size);
+		auto allocation = partial_block_manager.GetBlockAllocation(cast_segment_size);
 		block_id = allocation.state.block_id;
 		offset_in_block = allocation.state.offset;
 
@@ -170,8 +173,10 @@ void ColumnCheckpointState::FlushSegmentInternal(unique_ptr<ColumnSegment> segme
 		}
 		// Writer will decide whether to reuse this block.
 		partial_block_manager.RegisterPartialBlock(std::move(allocation));
+
 	} else {
-		segment->ConvertToPersistent(nullptr, INVALID_BLOCK);
+		segment->segment_type = ColumnSegmentType::PERSISTENT;
+		segment->block.reset();
 	}
 
 	// construct the data pointer

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -175,6 +175,8 @@ void ColumnCheckpointState::FlushSegmentInternal(unique_ptr<ColumnSegment> segme
 		partial_block_manager.RegisterPartialBlock(std::move(allocation));
 
 	} else {
+		// Empty segment, which does not have to go to disk.
+		// We still need to change its type to persistent, because we need to write its metadata.
 		segment->segment_type = ColumnSegmentType::PERSISTENT;
 		segment->block.reset();
 	}

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -35,10 +35,8 @@ unique_ptr<ColumnSegment> ColumnSegment::CreatePersistentSegment(DatabaseInstanc
 	optional_ptr<CompressionFunction> function;
 	shared_ptr<BlockHandle> block;
 
-	if (block_id == INVALID_BLOCK) {
-		function = config.GetCompressionFunction(CompressionType::COMPRESSION_CONSTANT, type.InternalType());
-	} else {
-		function = config.GetCompressionFunction(compression_type, type.InternalType());
+	function = config.GetCompressionFunction(compression_type, type.InternalType());
+	if (block_id != INVALID_BLOCK) {
 		block = block_manager.RegisterBlock(block_id);
 	}
 

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -223,34 +223,33 @@ void ColumnSegment::RevertAppend(idx_t start_row) {
 //===--------------------------------------------------------------------===//
 // Convert To Persistent
 //===--------------------------------------------------------------------===//
-void ColumnSegment::ConvertToPersistent(optional_ptr<BlockManager> block_manager, block_id_t block_id_p) {
+void ColumnSegment::ConvertToPersistent(optional_ptr<BlockManager> block_manager, const block_id_t block_id_p) {
 	D_ASSERT(segment_type == ColumnSegmentType::TRANSIENT);
 	segment_type = ColumnSegmentType::PERSISTENT;
-
 	block_id = block_id_p;
 	offset = 0;
 
-	if (block_id == INVALID_BLOCK) {
-		// constant block: no need to write anything to disk besides the stats
-		// set up the compression function to constant
-		D_ASSERT(stats.statistics.IsConstant());
-		auto &config = DBConfig::GetConfig(db);
-		function = *config.GetCompressionFunction(CompressionType::COMPRESSION_CONSTANT, type.InternalType());
-		// reset the block buffer
-		block.reset();
-	} else {
+	if (block_id != INVALID_BLOCK) {
 		D_ASSERT(!stats.statistics.IsConstant());
-		// non-constant block: write the block to disk
-		// the data for the block already exists in-memory of our block
-		// instead of copying the data we alter some metadata so the buffer points to an on-disk block
+		// Non-constant block: write the block to disk.
+		// The block data already exists in memory, so we alter the metadata,
+		// which ensures that the buffer points to an on-disk block.
 		block = block_manager->ConvertToPersistent(block_id, std::move(block));
+		return;
 	}
+
+	// Constant block: no need to write anything to disk besides the stats (metadata).
+	// I.e., we do not need to write an actual block.
+	// Thus, we set the compression function to constant and reset the block buffer.
+	D_ASSERT(stats.statistics.IsConstant());
+	auto &config = DBConfig::GetConfig(db);
+	function = *config.GetCompressionFunction(CompressionType::COMPRESSION_CONSTANT, type.InternalType());
+	block.reset();
 }
 
 void ColumnSegment::MarkAsPersistent(shared_ptr<BlockHandle> block_p, uint32_t offset_p) {
 	D_ASSERT(segment_type == ColumnSegmentType::TRANSIENT);
 	segment_type = ColumnSegmentType::PERSISTENT;
-
 	block_id = block_p->BlockId();
 	offset = offset_p;
 	block = std::move(block_p);

--- a/test/sql/storage/compression/dict_fsst/fetch_row.test
+++ b/test/sql/storage/compression/dict_fsst/fetch_row.test
@@ -2,19 +2,13 @@
 # description: Test storage with Dictionary compression
 # group: [dict_fsst]
 
-require block_size 262144
-
-# load the DB from disk
 load __TEST_DIR__/test_dictionary_fetchrow.db readwrite v1.3.0
 
 statement ok
-PRAGMA force_compression = 'dict_fsst'
+PRAGMA force_compression = 'dict_fsst';
 
 statement ok
-CREATE TABLE test (
-	a INTEGER,
-	b VARCHAR
-);
+CREATE TABLE test (a INTEGER, b VARCHAR);
 
 statement ok
 INSERT INTO test (a, b)
@@ -40,7 +34,7 @@ SELECT compression FROM pragma_storage_info('test') WHERE segment_type ILIKE 'VA
 DICT_FSST
 
 query I
-select distinct b from test order by a % 5;
+SELECT DISTINCT b FROM test ORDER BY a % 5;
 ----
 aaaa
 bbbb
@@ -49,10 +43,10 @@ this is not an inlined string
 NULL
 
 statement ok
-pragma verify_fetch_row;
+PRAGMA verify_fetch_row;
 
 query I
-select distinct b from test order by a % 5;
+SELECT DISTINCT b FROM test ORDER BY a % 5;
 ----
 aaaa
 bbbb

--- a/test/sql/storage/compression/dict_fsst/test_dict_fsst_with_smaller_block_size.test
+++ b/test/sql/storage/compression/dict_fsst/test_dict_fsst_with_smaller_block_size.test
@@ -10,3 +10,22 @@ ATTACH '__TEST_DIR__/partial_manager.db' AS db (BLOCK_SIZE 16384);
 
 statement ok
 CREATE TABLE db.t AS FROM read_csv('data/csv/rabo-anon.csv.gz', strict_mode=FALSE);
+
+statement ok
+DETACH db;
+
+statement ok
+ATTACH '__TEST_DIR__/partial_manager.db' AS db;
+
+query I
+SELECT COUNT("XXX XXX/XXX") FROM db.t WHERE "XXX XXX/XXX" IS NOT NULL;
+----
+3767
+
+query I
+SELECT COUNT(*) FROM db.t WHERE "XXX XXX/XXX" IS NULL;
+----
+5460
+
+statement ok
+SELECT * FROM db.t;

--- a/test/sql/storage/compression/dict_fsst/test_dict_fsst_with_smaller_block_size.test
+++ b/test/sql/storage/compression/dict_fsst/test_dict_fsst_with_smaller_block_size.test
@@ -1,0 +1,12 @@
+# name: test/sql/storage/compression/dict_fsst/test_dict_fsst_with_smaller_block_size.test
+# description: Test storage with dictionary compression and a smaller block size.
+# group: [dict_fsst]
+
+statement ok
+SET storage_compatibility_version='latest';
+
+statement ok
+ATTACH '__TEST_DIR__/partial_manager.db' AS db (BLOCK_SIZE 16384);
+
+statement ok
+CREATE TABLE db.t AS FROM read_csv('data/csv/rabo-anon.csv.gz', strict_mode=FALSE);


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/5256.