### PR TITLE
Bump vcpkg-duckdb-ports and test extensions on Windows 10 default stdlib

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -216,8 +216,27 @@ runs:
         python3 scripts/get_test_list.py --file-contains 'require ' --list '"*.test"' > test.list
         python3 scripts/get_test_list.py --file-contains 'require-env LOCAL_EXTENSION_REPO' --list '"*.test"' >> test.list
         ${{ inputs.unittest_script }} '-f test.list'
-        rm -rf build/release/extension
-        mv build/extension_tmp build/release/extension
+
+    - name: Run tests with auto loading with VS2019 C++ stdlib
+      if: ${{ inputs.run_autoload_tests == '1' && inputs.vcpkg_target_triplet == 'x64-windows-static-md' }}
+      shell: bash
+      env:
+        LOCAL_EXTENSION_REPO: ${{ inputs.run_autoload_tests == '1' && github.workspace || ''}}
+      run: |
+        choco install wget -y --no-progress
+        cd  ${{ inputs.build_dir }}
+        TEST_RUNNER_DIR=./build/release/test/Release
+        if [ ! -f ${TEST_RUNNER_DIR}/unittest.exe ]; then
+          echo "Invalid unit tests runner dir: ${TEST_RUNNER_DIR}, check 'inputs.unittest_script' argument"
+          exit 1
+        fi
+        wget -P ${TEST_RUNNER_DIR} https://blobs.duckdb.org/ci/msvcp140.dll
+        ls ${TEST_RUNNER_DIR}
+        # test.list is generated on the previous step
+        ${{ inputs.unittest_script }} '-f test.list'
+        rm ${TEST_RUNNER_DIR}/msvcp140.dll
+        rm -rf ./build/release/extension
+        mv ./build/extension_tmp ./build/release/extension
 
     - name: Deploy
       if: ${{ inputs.deploy_as != '' }}

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -47,7 +47,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(azure
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-azure
-            GIT_TAG 8a68c313e7dbd22962db0de1bec466f8d1f8b0ca
+            GIT_TAG dc66aa879c5e6a8cf60b2e9856e04e88a2e0c315
             )
 endif()
 
@@ -153,7 +153,7 @@ duckdb_extension_load(vss
         LOAD_TESTS
         DONT_LINK
         GIT_URL https://github.com/duckdb/duckdb-vss
-        GIT_TAG ccfa7c9c1f1f540fa7f433a93d32bed772aa44f4
+        GIT_TAG bfb2cbad7d5e5658b0a3193454b3919832b31d11
         TEST_DIR test/sql
     )
 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -103,9 +103,10 @@ jobs:
       if: ${{ inputs.skip_tests != 'true' }}
       run: |
         choco install wget -y --no-progress
-        wget -P test/Release https://blobs.duckdb.org/ci/msvcp140.dll
-        test/Release/unittest.exe
-        rm test/Release/msvcp140.dll
+        wget -P ./test/Release https://blobs.duckdb.org/ci/msvcp140.dll
+        ls ./test/Release
+        ./test/Release/unittest.exe
+        rm ./test/Release/msvcp140.dll
 
     - name: Tools Test
       shell: bash

--- a/scripts/merge_vcpkg_deps.py
+++ b/scripts/merge_vcpkg_deps.py
@@ -68,7 +68,7 @@ if merged_overlay_ports:
 else:
     data['vcpkg-configuration'] = {}
 
-REGISTRY_BASELINE = 'fcdaf72f87714b25e52fe2d93977e3bd8532846d'
+REGISTRY_BASELINE = '4b058f01326c786934daef7fe81c93f7d32bec4a'
 # NOTE: use 'scripts/list_vcpkg_registry_packages.py --baseline <baseline>' to generate the list of packages
 data['vcpkg-configuration']['registries'] = [
     {

--- a/scripts/merge_vcpkg_deps.py
+++ b/scripts/merge_vcpkg_deps.py
@@ -68,7 +68,7 @@ if merged_overlay_ports:
 else:
     data['vcpkg-configuration'] = {}
 
-REGISTRY_BASELINE = '02558971ebafdbaa697a0704a3ed7ba365cd5495'
+REGISTRY_BASELINE = 'fcdaf72f87714b25e52fe2d93977e3bd8532846d'
 # NOTE: use 'scripts/list_vcpkg_registry_packages.py --baseline <baseline>' to generate the list of packages
 data['vcpkg-configuration']['registries'] = [
     {


### PR DESCRIPTION
Two not so independent changes:
* bump `vcpkg-duckdb-ports` commit to include https://github.com/duckdb/vcpkg-duckdb-ports/commit/fcdaf72f87714b25e52fe2d93977e3bd8532846d, that adds:
```cmake
set(CMAKE_CXX_WINDOWS_FLAGS
      "${CMAKE_CXX_WINDOWS_FLAGS} /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")
```
to `vcpkg-cmake` port.
* cherry-picks a tests by @staticlibs test to check whether correct flags are passed down to VCPKG (part of  https://github.com/duckdb/duckdb/pull/18149)
* remove `vss` and `azure` (PR that adapt them are ready, needs to be merged and then bumped, see https://github.com/duckdb/duckdb-vss/pull/64 and https://github.com/duckdb/duckdb-azure/pull/111)

If Windows CI for this PR passes, then good to be merged.