### PR TITLE
Bug#18163 Fix STDDEV_SAMP undeterminism

### DIFF
--- a/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
@@ -65,8 +65,8 @@ struct STDDevBaseOperation {
 			const double target_count = static_cast<double>(target.count);
 			const double source_count = static_cast<double>(source.count);
 			const double total_count = static_cast<double>(count);
-			const auto mean = (source_count * source.mean + target_count * target.mean) / total_count;
 			const auto delta = source.mean - target.mean;
+			const auto mean = std::fma(source_count / total_count, delta, target.mean);
 			target.dsquared =
 			    source.dsquared + target.dsquared + delta * delta * source_count * target_count / total_count;
 			target.mean = mean;

--- a/test/issues/general/test_18163.test
+++ b/test/issues/general/test_18163.test
@@ -1,0 +1,23 @@
+# name: test/issues/general/test_18163.test
+# description: Issue 18163 - Deterministic query return undeterministic results
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t90(c0 VARCHAR);
+
+statement ok
+INSERT INTO t90(c0) VALUES ('1'), ('2'), ('3'), ('4'), ('5'), ('6'), (0.4501927109298812), (0.55577448732208);
+
+statement ok
+CREATE VIEW v0(c0) AS SELECT TAN('1944920781') FROM t90 GROUP BY t90.c0;
+
+loop i 0 15
+
+query T
+SELECT '' FROM v0 HAVING STDDEV_SAMP(0.8716885601427876);
+----
+
+endloop


### PR DESCRIPTION
More details in https://github.com/duckdb/duckdb/issues/18163.
The query was returning undeterministic results with STDDEV_SAMP when containing only one element.