### PR TITLE
Allow for static libs from extension dependencies to be bundled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -527,6 +527,7 @@ bundle-setup:
 	cp src/libduckdb_static.a bundle/. && \
 	cp third_party/*/libduckdb_*.a bundle/. && \
 	cp extension/*/lib*_extension.a bundle/. && \
+	find vcpkg_installed -name '*.a' -exec cp {} bundle/. \; && \
 	cd bundle && \
 	find . -name '*.a' -exec mkdir -p {}.objects \; -exec mv {} {}.objects \; && \
 	find . -name '*.a' -execdir ${AR} -x {} \;


### PR DESCRIPTION
If extensions have dependencies and one wants to statically link those dependencies, then the bundle target should include those. 