### PR TITLE
Skip test/parquet/parquet_null_compressed_materialization.test_slow

### DIFF
--- a/test/parquet/parquet_null_compressed_materialization.test_slow
+++ b/test/parquet/parquet_null_compressed_materialization.test_slow
@@ -4,6 +4,10 @@
 
 require parquet
 
+# Unclear why this started failing, we could tweak the parameters, but I think it's more appropriate to
+# skip, investigate what has changed, and remove the skip plus fix the test
+mode skip
+
 statement ok
 SET preserve_insertion_order=false;
 


### PR DESCRIPTION
Unclear why this started failing, we could tweak the parameters, but I think it's more appropriate to skip, investigate what has changed, and remove the skip together with fixing the test.

See this comment https://github.com/duckdb/duckdb/pull/18230#issuecomment-3068105264 for the list of failures on main / PRs I had observed.