### PR TITLE
Re-add string -> hugeint compressed materialization function

### DIFF
--- a/src/function/function_list.cpp
+++ b/src/function/function_list.cpp
@@ -53,6 +53,7 @@ static const StaticFunctionDefinition function[] = {
 	DUCKDB_SCALAR_FUNCTION_SET(InternalCompressIntegralUintegerFun),
 	DUCKDB_SCALAR_FUNCTION_SET(InternalCompressIntegralUsmallintFun),
 	DUCKDB_SCALAR_FUNCTION_SET(InternalCompressIntegralUtinyintFun),
+	DUCKDB_SCALAR_FUNCTION(InternalCompressStringHugeintFun),
 	DUCKDB_SCALAR_FUNCTION(InternalCompressStringUbigintFun),
 	DUCKDB_SCALAR_FUNCTION(InternalCompressStringUhugeintFun),
 	DUCKDB_SCALAR_FUNCTION(InternalCompressStringUintegerFun),

--- a/src/function/scalar/compressed_materialization/compress_string.cpp
+++ b/src/function/scalar/compressed_materialization/compress_string.cpp
@@ -95,6 +95,9 @@ static scalar_function_t GetStringCompressFunctionSwitch(const LogicalType &resu
 		return GetStringCompressFunction<uint64_t>(result_type);
 	case LogicalTypeId::UHUGEINT:
 		return GetStringCompressFunction<uhugeint_t>(result_type);
+	case LogicalTypeId::HUGEINT:
+		// Never generated, only for backwards compatibility
+		return GetStringCompressFunction<hugeint_t>(result_type);
 	default:
 		throw InternalException("Unexpected type in GetStringCompressFunctionSwitch");
 	}
@@ -260,6 +263,11 @@ ScalarFunction InternalCompressStringUintegerFun::GetFunction() {
 
 ScalarFunction InternalCompressStringUbigintFun::GetFunction() {
 	return CMStringCompressFun::GetFunction(LogicalType(LogicalTypeId::UBIGINT));
+}
+
+ScalarFunction InternalCompressStringHugeintFun::GetFunction() {
+	// We never generate this, but it's needed for backwards compatibility
+	return CMStringCompressFun::GetFunction(LogicalType(LogicalTypeId::HUGEINT));
 }
 
 ScalarFunction InternalCompressStringUhugeintFun::GetFunction() {

--- a/src/function/scalar/compressed_materialization/functions.json
+++ b/src/function/scalar/compressed_materialization/functions.json
@@ -63,6 +63,13 @@
         "type": "scalar_function"
     },
     {
+        "name": "__internal_compress_string_hugeint",
+        "parameters": "",
+        "description": "",
+        "example": "",
+        "type": "scalar_function"
+    },
+    {
         "name": "__internal_decompress_integral_smallint",
         "parameters": "",
         "description": "",

--- a/src/include/duckdb/function/scalar/compressed_materialization_functions.hpp
+++ b/src/include/duckdb/function/scalar/compressed_materialization_functions.hpp
@@ -105,6 +105,16 @@ struct InternalCompressStringUhugeintFun {
 	static ScalarFunction GetFunction();
 };
 
+struct InternalCompressStringHugeintFun {
+	static constexpr const char *Name = "__internal_compress_string_hugeint";
+	static constexpr const char *Parameters = "";
+	static constexpr const char *Description = "";
+	static constexpr const char *Example = "";
+	static constexpr const char *Categories = "";
+
+	static ScalarFunction GetFunction();
+};
+
 struct InternalDecompressIntegralSmallintFun {
 	static constexpr const char *Name = "__internal_decompress_integral_smallint";
 	static constexpr const char *Parameters = "";


### PR DESCRIPTION
For backwards compatibility, but we never generate it. I can't add a test because we can only use this function internally, and while I can generate a plan that has it using `json_serialize_plan`, we don't have a `json_execute_serialized_plan` function.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/5306