### PR TITLE
Improved assertion error message

### DIFF
--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -10,7 +10,7 @@ void DuckDBAssertInternal(bool condition, const char *condition_name, const char
 	if (condition) {
 		return;
 	}
-	throw InternalException("Assertion triggered in file \"%s\" on line %d: %s", file, linenr, condition_name);
+	throw InternalException("Assertion triggered in file \"%s#%d\": %s", file, linenr, condition_name);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
This allows you to directly copy the file and line number into the _open file_ dialog of the IDE of your choice (CLion, VSCode, Cursor, ...) and it will jump to the affected line number.

New error message:
```
Assertion triggered in file "..../duckdb/foo/bar.hpp#620": true == false
```

---
Feel free to close this if you don't want this change, I just thought it might improve the dev experience. 