### PR TITLE
fix timetravel for default tables

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -889,8 +889,8 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, con
 				error_data = std::move(result.error);
 			}
 		} else {
-			// Ambiguity lookup is slightly different to allow `FROM <table_name> AT <version>` to be considered
-			// ambiguous with a table in a catalog that supports timetravel
+			// allow_ignore_at_clause set to true to ensure `FROM <table_name> AT <version>` is considered
+			// ambiguous with a default table lookup in a catalog that does not support time travel
 			auto ambiguity_lookup = TryLookupDefaultTable(retriever, lookup_info, true);
 			if (ambiguity_lookup.Found()) {
 				ThrowDefaultTableAmbiguityException(result, ambiguity_lookup, lookup_info.GetEntryName());

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -838,17 +838,37 @@ CatalogEntryLookup Catalog::LookupEntry(CatalogEntryRetriever &retriever, const 
 	return res;
 }
 
+static void ThrowDefaultTableAmbiguityException(CatalogEntryLookup &base_lookup, CatalogEntryLookup &default_table,
+                                                const string &name) {
+	auto entry_type = CatalogTypeToString(base_lookup.entry->type);
+	string fully_qualified_name_hint;
+	if (base_lookup.schema) {
+		fully_qualified_name_hint = StringUtil::Format(": '%s.%s.%s'", base_lookup.schema->catalog.GetName(),
+		                                               base_lookup.schema->name, base_lookup.entry->name);
+	}
+	string fully_qualified_catalog_name_hint = StringUtil::Format(
+	    ": '%s.%s.%s'", default_table.schema->catalog.GetName(), default_table.schema->name, default_table.entry->name);
+	throw CatalogException(
+	    "Ambiguity detected for '%s': this could either refer to the '%s' '%s', or the "
+	    "attached catalog '%s' which has a default table. To avoid this error, either detach the catalog and "
+	    "reattach under a different name, or use a fully qualified name for the '%s'%s or for the Catalog "
+	    "Default Table%s.",
+	    name, entry_type, name, name, entry_type, fully_qualified_name_hint, fully_qualified_catalog_name_hint);
+}
+
 CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, const vector<CatalogLookup> &lookups,
-                                           const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found) {
+                                           const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found,
+                                           bool allow_default_table_lookup) {
 	auto &context = retriever.GetContext();
 	reference_set_t<SchemaCatalogEntry> schemas;
 	bool all_errors = true;
 	ErrorData error_data;
+	CatalogEntryLookup result;
 	for (auto &lookup : lookups) {
 		auto transaction = lookup.catalog.GetCatalogTransaction(context);
-		auto result = lookup.catalog.TryLookupEntryInternal(transaction, lookup.schema, lookup.lookup_info);
+		result = lookup.catalog.TryLookupEntryInternal(transaction, lookup.schema, lookup.lookup_info);
 		if (result.Found()) {
-			return result;
+			break;
 		}
 		if (result.schema) {
 			schemas.insert(*result.schema);
@@ -859,6 +879,24 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, con
 			error_data = std::move(result.error);
 		}
 	}
+
+	// Special case for tables: we do a second lookup searching for catalogs with default tables that also match this
+	// lookup
+	if (lookup_info.GetCatalogType() == CatalogType::TABLE_ENTRY && allow_default_table_lookup) {
+		auto default_table_lookup = TryLookupDefaultTable(retriever, lookup_info);
+
+		if (default_table_lookup.Found()) {
+			if (result.Found()) {
+				ThrowDefaultTableAmbiguityException(result, default_table_lookup, lookup_info.GetEntryName());
+			}
+			return default_table_lookup;
+		}
+	}
+
+	if (result.Found()) {
+		return result;
+	}
+
 	if (all_errors && error_data.HasError()) {
 		error_data.Throw();
 	}
@@ -878,41 +916,24 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, con
 	}
 }
 
-CatalogEntryLookup Catalog::TryLookupDefaultTable(CatalogEntryRetriever &retriever, const string &catalog,
-                                                  const string &schema, const EntryLookupInfo &lookup_info,
-                                                  OnEntryNotFound if_not_found) {
-	// Default tables of catalogs can only be accessed by the catalog name directly
-	if (!schema.empty() || !catalog.empty()) {
-		return {nullptr, nullptr, ErrorData()};
-	}
-
-	vector<CatalogLookup> catalog_by_name_lookups;
+CatalogEntryLookup Catalog::TryLookupDefaultTable(CatalogEntryRetriever &retriever,
+                                                  const EntryLookupInfo &lookup_info) {
 	auto catalog_by_name = GetCatalogEntry(retriever, lookup_info.GetEntryName());
+
 	if (catalog_by_name && catalog_by_name->HasDefaultTable()) {
-		catalog_by_name_lookups.emplace_back(*catalog_by_name, CatalogType::TABLE_ENTRY,
-		                                     catalog_by_name->GetDefaultTableSchema(),
-		                                     catalog_by_name->GetDefaultTable());
+		auto transaction = catalog_by_name->GetCatalogTransaction(retriever.GetContext());
+		QueryErrorContext context;
+
+		string table_schema = catalog_by_name->GetDefaultTableSchema();
+		string table_name = catalog_by_name->GetDefaultTable();
+		optional_ptr<BoundAtClause> at_clause =
+		    catalog_by_name->SupportsTimeTravel() ? lookup_info.GetAtClause() : nullptr;
+
+		EntryLookupInfo info = EntryLookupInfo(CatalogType::TABLE_ENTRY, table_name, at_clause, context);
+		return catalog_by_name->TryLookupEntryInternal(transaction, table_schema, info);
 	}
 
-	return TryLookupEntry(retriever, catalog_by_name_lookups, lookup_info, if_not_found);
-}
-
-static void ThrowDefaultTableAmbiguityException(CatalogEntryLookup &base_lookup, CatalogEntryLookup &default_table,
-                                                const string &name) {
-	auto entry_type = CatalogTypeToString(base_lookup.entry->type);
-	string fully_qualified_name_hint;
-	if (base_lookup.schema) {
-		fully_qualified_name_hint = StringUtil::Format(": '%s.%s.%s'", base_lookup.schema->catalog.GetName(),
-		                                               base_lookup.schema->name, base_lookup.entry->name);
-	}
-	string fully_qualified_catalog_name_hint = StringUtil::Format(
-	    ": '%s.%s.%s'", default_table.schema->catalog.GetName(), default_table.schema->name, default_table.entry->name);
-	throw CatalogException(
-	    "Ambiguity detected for '%s': this could either refer to the '%s' '%s', or the "
-	    "attached catalog '%s' which has a default table. To avoid this error, either detach the catalog and "
-	    "reattach under a different name, or use a fully qualified name for the '%s'%s or for the Catalog "
-	    "Default Table%s.",
-	    name, entry_type, name, name, entry_type, fully_qualified_name_hint, fully_qualified_catalog_name_hint);
+	return {nullptr, nullptr, ErrorData()};
 }
 
 CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, const string &catalog,
@@ -945,25 +966,9 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, con
 		lookups.emplace_back(std::move(lookup));
 	}
 
-	// Do the main lookup
-	auto lookup_result = TryLookupEntry(retriever, lookups, lookup_info, if_not_found);
+	bool allow_default_table_lookup = catalog.empty() && schema.empty();
 
-	// Special case for tables: we do a second lookup searching for catalogs with default tables that also match this
-	// lookup
-	if (lookup_info.GetCatalogType() == CatalogType::TABLE_ENTRY) {
-		auto lookup_result_default_table =
-		    TryLookupDefaultTable(retriever, catalog, schema, lookup_info, OnEntryNotFound::RETURN_NULL);
-
-		if (lookup_result_default_table.Found() && lookup_result.Found()) {
-			ThrowDefaultTableAmbiguityException(lookup_result, lookup_result_default_table, lookup_info.GetEntryName());
-		}
-
-		if (lookup_result_default_table.Found()) {
-			return lookup_result_default_table;
-		}
-	}
-
-	return lookup_result;
+	return TryLookupEntry(retriever, lookups, lookup_info, if_not_found, allow_default_table_lookup);
 }
 
 CatalogEntry &Catalog::GetEntry(ClientContext &context, CatalogType catalog_type, const string &catalog_name,

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -399,15 +399,15 @@ private:
 	CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, const string &schema,
 	                                  const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found);
 	static CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, const vector<CatalogLookup> &lookups,
-	                                         const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found);
+	                                         const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found,
+	                                         bool allow_default_table_lookup);
 	static CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, const string &catalog,
 	                                         const string &schema, const EntryLookupInfo &lookup_info,
 	                                         OnEntryNotFound if_not_found);
 
 	//! Looks for a Catalog with a DefaultTable that matches the lookup
-	static CatalogEntryLookup TryLookupDefaultTable(CatalogEntryRetriever &retriever, const string &catalog,
-	                                                const string &schema, const EntryLookupInfo &lookup_info,
-	                                                OnEntryNotFound if_not_found);
+	static CatalogEntryLookup TryLookupDefaultTable(CatalogEntryRetriever &retriever,
+	                                                const EntryLookupInfo &lookup_info);
 
 	//! Return an exception with did-you-mean suggestion.
 	static CatalogException CreateMissingEntryException(CatalogEntryRetriever &retriever,

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -407,7 +407,8 @@ private:
 
 	//! Looks for a Catalog with a DefaultTable that matches the lookup
 	static CatalogEntryLookup TryLookupDefaultTable(CatalogEntryRetriever &retriever,
-	                                                const EntryLookupInfo &lookup_info, bool allow_ignore_at_clause);
+	                                                const EntryLookupInfo &lookup_info,
+	                                                bool allow_ignore_at_clause = false);
 
 	//! Return an exception with did-you-mean suggestion.
 	static CatalogException CreateMissingEntryException(CatalogEntryRetriever &retriever,

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -407,7 +407,7 @@ private:
 
 	//! Looks for a Catalog with a DefaultTable that matches the lookup
 	static CatalogEntryLookup TryLookupDefaultTable(CatalogEntryRetriever &retriever,
-	                                                const EntryLookupInfo &lookup_info);
+	                                                const EntryLookupInfo &lookup_info, bool allow_ignore_at_clause);
 
 	//! Return an exception with did-you-mean suggestion.
 	static CatalogException CreateMissingEntryException(CatalogEntryRetriever &retriever,


### PR DESCRIPTION
Default tables are used in the Delta extension as syntactic sugar to allow attaching and querying delta table like so:

```SQL
ATTACH './delta/table' as dt (TYPE delta);
SELECT * FROM dt;
```

Note that we are providing the catalog name here and interpreting this as the table name, i.e. by `SELECT * FROM dt;` we actually mean `SELECT * FROM dt.dt;`

Now for time travel the current code is problematic, when we query:

```SQL
SELECT * FROM dt AT (VERSION => 0);
```

The current code will attempt to lookup `dt` in the current catalog, which will run into an error because the DuckCatalog does not support timetravel right now. 

The solution is to change how we do the default table lookups, doing the lookup in the inner lookup function before the error is thrown.

### Querying a default table with an AT clause
We now avoid throwing an error when we have an AT clause on a default table:
```SQL
ATTACH './duckdb.db' as duckdb; # does not contain dt table
ATTACH './delta/table' as dt;
USE duckdb;
SELECT * FROM dt AT (VERSION => 1); 
# Lookup in `duckdb.db`  will actually error, but we still allow the query 
# since the lookup in `duckdb.db` without the AT clause does not error and has no results.
```

### Ambiguous table with timetravel
```SQL
ATTACH './duckdb.db' as duckdb; # does not contain dt table
ATTACH './delta/table' as dt;
CREATE TABLE IF NOT EXISTS duckdb.dt;
SELECT * FROM dt AT (VERSION => 1); 
# This time we do actually have an ambiguous name. The error thrown here will be a 
# CatalogException: Ambiguity detected for .... just like it was before this PR. 
```

## Testing
This change is a little hard to test, because we don't have catalogs with timetravel support in core duckdb. I am planning to add delta back in to duckdb CI soon though so that we can at least rely on delta's tests for this feature. For now at least the `test/sql/attach/attach_default_table.test` test confirms that the default tables still work.