### PR TITLE
Expanded autocomplete suggestions

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -250,7 +250,6 @@ static vector<AutoCompleteCandidate> SuggestScalarFunctionName(ClientContext &co
 	auto scalar_functions = Catalog::GetAllScalarFunctions(context);
 	for (const auto &scalar_function : scalar_functions) {
 		AutoCompleteCandidate candidate(scalar_function.get().name, 0);
-		candidate.extra_char = '(';
 		suggestions.push_back(std::move(candidate));
 	}
 
@@ -262,7 +261,6 @@ static vector<AutoCompleteCandidate> SuggestTableFunctionName(ClientContext &con
 	auto table_functions = Catalog::GetAllTableFunctions(context);
 	for (const auto &scalar_function : table_functions) {
 		AutoCompleteCandidate candidate(scalar_function.get().name, 0);
-		candidate.extra_char = '(';
 		suggestions.push_back(std::move(candidate));
 	}
 

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -222,7 +222,7 @@ static bool KnownExtension(const string &fname) {
 }
 
 
-static vector<AutoCompleteCandidate> SuggestPragmaName(ClientContext &context, string &prefix) {
+static vector<AutoCompleteCandidate> SuggestPragmaName(ClientContext &context) {
 	vector<AutoCompleteCandidate> suggestions;
 	auto all_pragmas = Catalog::GetAllPragmaFunctions(context);
 	for (auto &pragma : all_pragmas) {
@@ -351,7 +351,7 @@ static duckdb::unique_ptr<SQLAutoCompleteFunctionData> GenerateSuggestions(Clien
 		case SuggestionState::SUGGEST_TABLE_FUNCTION_NAME:
 			break;
 		case SuggestionState::SUGGEST_PRAGMA_NAME:
-			new_suggestions = SuggestPragmaName(context, tokenizer.last_word);
+			new_suggestions = SuggestPragmaName(context);
 			break;
 		case SuggestionState::SUGGEST_SETTING_NAME:
 			break;

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -372,6 +372,7 @@ static duckdb::unique_ptr<SQLAutoCompleteFunctionData> GenerateSuggestions(Clien
 			break;
 		case SuggestionState::SUGGEST_SCALAR_FUNCTION_NAME:
 			new_suggestions = SuggestScalarFunctionName(context);
+			break;
 		case SuggestionState::SUGGEST_TABLE_FUNCTION_NAME:
 			break;
 		case SuggestionState::SUGGEST_PRAGMA_NAME:

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -232,6 +232,17 @@ static vector<AutoCompleteCandidate> SuggestPragmaName(ClientContext &context) {
 	return suggestions;
 }
 
+static vector<AutoCompleteCandidate> SuggestSettingName(ClientContext &context) {
+	auto &db_config = DBConfig::GetConfig(context);
+	const auto &options = db_config.GetOptions();
+	vector<AutoCompleteCandidate> suggestions;
+	for (const auto &option : options) {
+		AutoCompleteCandidate candidate(option.name, 0);
+		suggestions.push_back(std::move(candidate));
+	}
+	return suggestions;
+}
+
 static vector<AutoCompleteCandidate> SuggestFileName(ClientContext &context, string &prefix, idx_t &last_pos) {
 	vector<AutoCompleteCandidate> result;
 	auto &config = DBConfig::GetConfig(context);
@@ -353,6 +364,7 @@ static duckdb::unique_ptr<SQLAutoCompleteFunctionData> GenerateSuggestions(Clien
 			new_suggestions = SuggestPragmaName(context);
 			break;
 		case SuggestionState::SUGGEST_SETTING_NAME:
+			new_suggestions = SuggestSettingName(context);
 			break;
 		default:
 			throw InternalException("Unrecognized suggestion state");

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -226,7 +226,6 @@ static vector<AutoCompleteCandidate> SuggestPragmaName(ClientContext &context) {
 	vector<AutoCompleteCandidate> suggestions;
 	auto all_pragmas = Catalog::GetAllPragmaFunctions(context);
 	for (auto &pragma : all_pragmas) {
-		auto pragma_name = pragma.get().name;
 		AutoCompleteCandidate candidate(pragma.get().name, 0);
 		suggestions.push_back(std::move(candidate));
 	}

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -226,7 +226,7 @@ static bool KnownExtension(const string &fname) {
 
 static vector<AutoCompleteCandidate> SuggestPragmaName(ClientContext &context) {
 	vector<AutoCompleteCandidate> suggestions;
-	auto all_pragmas = Catalog::GetAllPragmaFunctions(context);
+	auto all_pragmas = Catalog::GetAllEntries(context, CatalogType::PRAGMA_FUNCTION_ENTRY);
 	for (const auto &pragma : all_pragmas) {
 		AutoCompleteCandidate candidate(pragma.get().name, 0);
 		suggestions.push_back(std::move(candidate));
@@ -247,7 +247,7 @@ static vector<AutoCompleteCandidate> SuggestSettingName(ClientContext &context) 
 
 static vector<AutoCompleteCandidate> SuggestScalarFunctionName(ClientContext &context) {
 	vector<AutoCompleteCandidate> suggestions;
-	auto scalar_functions = Catalog::GetAllScalarFunctions(context);
+	auto scalar_functions = Catalog::GetAllEntries(context, CatalogType::SCALAR_FUNCTION_ENTRY);
 	for (const auto &scalar_function : scalar_functions) {
 		AutoCompleteCandidate candidate(scalar_function.get().name, 0);
 		suggestions.push_back(std::move(candidate));
@@ -258,9 +258,9 @@ static vector<AutoCompleteCandidate> SuggestScalarFunctionName(ClientContext &co
 
 static vector<AutoCompleteCandidate> SuggestTableFunctionName(ClientContext &context) {
 	vector<AutoCompleteCandidate> suggestions;
-	auto table_functions = Catalog::GetAllTableFunctions(context);
-	for (const auto &scalar_function : table_functions) {
-		AutoCompleteCandidate candidate(scalar_function.get().name, 0);
+	auto table_functions = Catalog::GetAllEntries(context, CatalogType::TABLE_FUNCTION_ENTRY);
+	for (const auto &table_function : table_functions) {
+		AutoCompleteCandidate candidate(table_function.get().name, 0);
 		suggestions.push_back(std::move(candidate));
 	}
 

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -223,7 +223,6 @@ static bool KnownExtension(const string &fname) {
 	return false;
 }
 
-
 static vector<AutoCompleteCandidate> SuggestPragmaName(ClientContext &context) {
 	vector<AutoCompleteCandidate> suggestions;
 	auto all_pragmas = Catalog::GetAllEntries(context, CatalogType::PRAGMA_FUNCTION_ENTRY);

--- a/extension/autocomplete/grammar/expression.gram
+++ b/extension/autocomplete/grammar/expression.gram
@@ -1,10 +1,12 @@
-ColumnReference <- CatalogQualification? SchemaQualification? TableQualification? ColumnName
-FunctionExpression <- FunctionIdentifier Parens(DistinctOrAll? List(FunctionArgument)? OrderByClause?) WithinGroupClause? FilterClause? ExportClause? OverClause?
-FunctionIdentifier <- CatalogQualification? SchemaQualification? FunctionName
+ColumnReference <- DottedIdentifier / (CatalogQualification? SchemaQualification? TableQualification? ColumnName)
+FunctionExpression <- FunctionIdentifier Parens(DistinctOrAll? List(FunctionArgument)? OrderByClause? IgnoreNulls?) WithinGroupClause? FilterClause? ExportClause? OverClause?
+FunctionIdentifier <- CatalogQualification? SchemaQualification? (FuncName / DottedIdentifier)
+
 DistinctOrAll <- 'DISTINCT'i / 'ALL'i
 ExportClause <- 'EXPORT_STATE'i
 WithinGroupClause <- 'WITHIN'i 'GROUP'i Parens(OrderByClause)
 FilterClause <- 'FILTER' Parens('WHERE'i? Expression)
+IgnoreNulls <- ('IGNORE'i 'NULLS'i) / ('RESPECT'i 'NULLS'i)
 
 ParenthesisExpression <- Parens(List(Expression))
 LiteralExpression <- StringLiteral / NumberLiteral / 'NULL'i / 'TRUE'i / 'FALSE'i

--- a/extension/autocomplete/grammar/expression.gram
+++ b/extension/autocomplete/grammar/expression.gram
@@ -1,12 +1,12 @@
-ColumnReference <- DottedIdentifier / (CatalogQualification? SchemaQualification? TableQualification? ColumnName)
-FunctionExpression <- FunctionIdentifier Parens(DistinctOrAll? List(FunctionArgument)? OrderByClause? IgnoreNulls?) WithinGroupClause? FilterClause? ExportClause? OverClause?
-FunctionIdentifier <- CatalogQualification? SchemaQualification? (FuncName / DottedIdentifier)
+ColumnReference <- CatalogQualification? SchemaQualification? TableQualification? ColumnName
+FunctionExpression <- FunctionIdentifier Parens(DistinctOrAll? List(FunctionArgument)? OrderByClause?) WithinGroupClause? FilterClause? ExportClause? OverClause?
+
+FunctionIdentifier <- CatalogQualification? SchemaQualification? FunctionName
 
 DistinctOrAll <- 'DISTINCT'i / 'ALL'i
 ExportClause <- 'EXPORT_STATE'i
 WithinGroupClause <- 'WITHIN'i 'GROUP'i Parens(OrderByClause)
 FilterClause <- 'FILTER' Parens('WHERE'i? Expression)
-IgnoreNulls <- ('IGNORE'i 'NULLS'i) / ('RESPECT'i 'NULLS'i)
 
 ParenthesisExpression <- Parens(List(Expression))
 LiteralExpression <- StringLiteral / NumberLiteral / 'NULL'i / 'TRUE'i / 'FALSE'i

--- a/extension/autocomplete/matcher.cpp
+++ b/extension/autocomplete/matcher.cpp
@@ -1114,7 +1114,6 @@ Matcher &MatcherFactory::CreateMatcher(const char *grammar, const char *root_rul
 	AddRuleOverride("SchemaName", SchemaName());
 	AddRuleOverride("ColumnName", ColumnName());
 	AddRuleOverride("FunctionName", ScalarFunctionName());
-	AddRuleOverride("FunctionName", ScalarFunctionName());
 	AddRuleOverride("TableFunctionName", TableFunctionName());
 	AddRuleOverride("PragmaName", PragmaName());
 	AddRuleOverride("SettingName", SettingName());

--- a/extension/autocomplete/matcher.cpp
+++ b/extension/autocomplete/matcher.cpp
@@ -1110,6 +1110,7 @@ Matcher &MatcherFactory::CreateMatcher(const char *grammar, const char *root_rul
 	AddRuleOverride("Identifier", Variable());
 	AddRuleOverride("TypeName", TypeName());
 	AddRuleOverride("TableName", TableName());
+	AddRuleOverride("FunctionName", ScalarFunctionName());
 	AddRuleOverride("CatalogName", CatalogName());
 	AddRuleOverride("SchemaName", SchemaName());
 	AddRuleOverride("ColumnName", ColumnName());

--- a/extension/autocomplete/matcher.cpp
+++ b/extension/autocomplete/matcher.cpp
@@ -1110,10 +1110,10 @@ Matcher &MatcherFactory::CreateMatcher(const char *grammar, const char *root_rul
 	AddRuleOverride("Identifier", Variable());
 	AddRuleOverride("TypeName", TypeName());
 	AddRuleOverride("TableName", TableName());
-	AddRuleOverride("FunctionName", ScalarFunctionName());
 	AddRuleOverride("CatalogName", CatalogName());
 	AddRuleOverride("SchemaName", SchemaName());
 	AddRuleOverride("ColumnName", ColumnName());
+	AddRuleOverride("FunctionName", ScalarFunctionName());
 	AddRuleOverride("FunctionName", ScalarFunctionName());
 	AddRuleOverride("TableFunctionName", TableFunctionName());
 	AddRuleOverride("PragmaName", PragmaName());

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1145,12 +1145,10 @@ template <class T>
 vector<reference<T>> Catalog::GetAllEntries(ClientContext &context, CatalogType catalog_type) {
 	vector<reference<T>> result;
 	auto schemas = GetAllSchemas(context);
-	for (const auto &schema : schemas) {
-		auto &duck_schema = schema.get().Cast<DuckSchemaEntry>();
-		auto &catalog_set = duck_schema.GetCatalogSet(catalog_type);
-		auto system_transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
-		auto entries = catalog_set.GetEntries<T>(system_transaction);
-		result.insert(result.end(), entries.begin(), entries.end());
+	for (const auto &schema_ref : schemas) {
+		auto &schema = schema_ref.get();
+		schema.Scan(context, catalog_type,
+								[&](CatalogEntry &entry) { result.push_back(entry); });
 	}
 	return result;
 }

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1145,8 +1145,7 @@ vector<reference<CatalogEntry>> Catalog::GetAllEntries(ClientContext &context, C
 	auto schemas = GetAllSchemas(context);
 	for (const auto &schema_ref : schemas) {
 		auto &schema = schema_ref.get();
-		schema.Scan(context, catalog_type,
-								[&](CatalogEntry &entry) { result.push_back(entry); });
+		schema.Scan(context, catalog_type, [&](CatalogEntry &entry) { result.push_back(entry); });
 	}
 	return result;
 }

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -38,7 +38,6 @@
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/function/built_in_functions.hpp"
 #include "duckdb/catalog/similar_catalog_entry.hpp"
-#include "duckdb/catalog/catalog_entry/duck_schema_entry.hpp"
 #include "duckdb/storage/database_size.hpp"
 #include <algorithm>
 

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1154,6 +1154,18 @@ vector<reference<PragmaFunctionCatalogEntry>> Catalog::GetAllPragmaFunctions(Cli
 	return result;
 }
 
+vector<reference<ScalarFunctionCatalogEntry>> Catalog::GetAllScalarFunctions(ClientContext &context) {
+	vector<reference<ScalarFunctionCatalogEntry>> result;
+	auto schemas = GetAllSchemas(context);
+	for (const auto &schema : schemas) {
+		auto &duck_schema = schema.get().Cast<DuckSchemaEntry>();
+		auto &scalar_function_set = duck_schema.GetCatalogSet(CatalogType::SCALAR_FUNCTION_ENTRY);
+		auto system_transaction = CatalogTransaction::GetSystemTransaction(context.db->GetDatabase(context));
+		auto pragma_entries = scalar_function_set.GetEntries<ScalarFunctionCatalogEntry>(system_transaction);
+		result.insert(result.end(), pragma_entries.begin(), pragma_entries.end());
+	}
+	return result;
+}
 
 void Catalog::Alter(CatalogTransaction transaction, AlterInfo &info) {
 	if (transaction.HasContext()) {

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1141,30 +1141,30 @@ vector<reference<SchemaCatalogEntry>> Catalog::GetAllSchemas(ClientContext &cont
 	return result;
 }
 
-vector<reference<PragmaFunctionCatalogEntry>> Catalog::GetAllPragmaFunctions(ClientContext &context) {
-	vector<reference<PragmaFunctionCatalogEntry>> result;
+template <class T>
+vector<reference<T>> Catalog::GetAllEntries(ClientContext &context, CatalogType catalog_type) {
+	vector<reference<T>> result;
 	auto schemas = GetAllSchemas(context);
 	for (const auto &schema : schemas) {
 		auto &duck_schema = schema.get().Cast<DuckSchemaEntry>();
-		auto &pragma_function_set = duck_schema.GetCatalogSet(CatalogType::PRAGMA_FUNCTION_ENTRY);
-	 	auto system_transaction = CatalogTransaction::GetSystemTransaction(context.db->GetDatabase(context));
-		auto pragma_entries = pragma_function_set.GetEntries<PragmaFunctionCatalogEntry>(system_transaction);
-		result.insert(result.end(), pragma_entries.begin(), pragma_entries.end());
+		auto &catalog_set = duck_schema.GetCatalogSet(catalog_type);
+		auto system_transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+		auto entries = catalog_set.GetEntries<T>(system_transaction);
+		result.insert(result.end(), entries.begin(), entries.end());
 	}
 	return result;
 }
 
+vector<reference<PragmaFunctionCatalogEntry>> Catalog::GetAllPragmaFunctions(ClientContext &context) {
+	return GetAllEntries<PragmaFunctionCatalogEntry>(context, CatalogType::PRAGMA_FUNCTION_ENTRY);
+}
+
 vector<reference<ScalarFunctionCatalogEntry>> Catalog::GetAllScalarFunctions(ClientContext &context) {
-	vector<reference<ScalarFunctionCatalogEntry>> result;
-	auto schemas = GetAllSchemas(context);
-	for (const auto &schema : schemas) {
-		auto &duck_schema = schema.get().Cast<DuckSchemaEntry>();
-		auto &scalar_function_set = duck_schema.GetCatalogSet(CatalogType::SCALAR_FUNCTION_ENTRY);
-		auto system_transaction = CatalogTransaction::GetSystemTransaction(context.db->GetDatabase(context));
-		auto pragma_entries = scalar_function_set.GetEntries<ScalarFunctionCatalogEntry>(system_transaction);
-		result.insert(result.end(), pragma_entries.begin(), pragma_entries.end());
-	}
-	return result;
+	return GetAllEntries<ScalarFunctionCatalogEntry>(context, CatalogType::SCALAR_FUNCTION_ENTRY);
+}
+
+vector<reference<TableFunctionCatalogEntry>> Catalog::GetAllTableFunctions(ClientContext &context) {
+	return GetAllEntries<TableFunctionCatalogEntry>(context, CatalogType::TABLE_FUNCTION_ENTRY);
 }
 
 void Catalog::Alter(CatalogTransaction transaction, AlterInfo &info) {

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -38,6 +38,7 @@
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/function/built_in_functions.hpp"
 #include "duckdb/catalog/similar_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/duck_schema_entry.hpp"
 #include "duckdb/storage/database_size.hpp"
 #include <algorithm>
 
@@ -1139,6 +1140,20 @@ vector<reference<SchemaCatalogEntry>> Catalog::GetAllSchemas(ClientContext &cont
 
 	return result;
 }
+
+vector<reference<PragmaFunctionCatalogEntry>> Catalog::GetAllPragmaFunctions(ClientContext &context) {
+	vector<reference<PragmaFunctionCatalogEntry>> result;
+	auto schemas = GetAllSchemas(context);
+	for (const auto &schema : schemas) {
+		auto &duck_schema = schema.get().Cast<DuckSchemaEntry>();
+		auto &pragma_function_set = duck_schema.GetCatalogSet(CatalogType::PRAGMA_FUNCTION_ENTRY);
+	 	auto system_transaction = CatalogTransaction::GetSystemTransaction(context.db->GetDatabase(context));
+		auto pragma_entries = pragma_function_set.GetEntries<PragmaFunctionCatalogEntry>(system_transaction);
+		result.insert(result.end(), pragma_entries.begin(), pragma_entries.end());
+	}
+	return result;
+}
+
 
 void Catalog::Alter(CatalogTransaction transaction, AlterInfo &info) {
 	if (transaction.HasContext()) {

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1141,9 +1141,8 @@ vector<reference<SchemaCatalogEntry>> Catalog::GetAllSchemas(ClientContext &cont
 	return result;
 }
 
-template <class T>
-vector<reference<T>> Catalog::GetAllEntries(ClientContext &context, CatalogType catalog_type) {
-	vector<reference<T>> result;
+vector<reference<CatalogEntry>> Catalog::GetAllEntries(ClientContext &context, CatalogType catalog_type) {
+	vector<reference<CatalogEntry>> result;
 	auto schemas = GetAllSchemas(context);
 	for (const auto &schema_ref : schemas) {
 		auto &schema = schema_ref.get();
@@ -1151,18 +1150,6 @@ vector<reference<T>> Catalog::GetAllEntries(ClientContext &context, CatalogType 
 								[&](CatalogEntry &entry) { result.push_back(entry); });
 	}
 	return result;
-}
-
-vector<reference<PragmaFunctionCatalogEntry>> Catalog::GetAllPragmaFunctions(ClientContext &context) {
-	return GetAllEntries<PragmaFunctionCatalogEntry>(context, CatalogType::PRAGMA_FUNCTION_ENTRY);
-}
-
-vector<reference<ScalarFunctionCatalogEntry>> Catalog::GetAllScalarFunctions(ClientContext &context) {
-	return GetAllEntries<ScalarFunctionCatalogEntry>(context, CatalogType::SCALAR_FUNCTION_ENTRY);
-}
-
-vector<reference<TableFunctionCatalogEntry>> Catalog::GetAllTableFunctions(ClientContext &context) {
-	return GetAllEntries<TableFunctionCatalogEntry>(context, CatalogType::TABLE_FUNCTION_ENTRY);
 }
 
 void Catalog::Alter(CatalogTransaction transaction, AlterInfo &info) {

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -369,9 +369,14 @@ public:
 	                                                                   const string &catalog_name);
 	DUCKDB_API static vector<reference<SchemaCatalogEntry>> GetAllSchemas(ClientContext &context);
 
+	template <class T>
+	static vector<reference<T>> GetAllEntries(ClientContext &context, CatalogType catalog_type);
+
 	DUCKDB_API static vector<reference<PragmaFunctionCatalogEntry>> GetAllPragmaFunctions(ClientContext &context);
 
 	DUCKDB_API static vector<reference<ScalarFunctionCatalogEntry>> GetAllScalarFunctions(ClientContext &context);
+
+	DUCKDB_API static vector<reference<TableFunctionCatalogEntry>> GetAllTableFunctions(ClientContext &context);
 
 	virtual void Verify();
 

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -369,14 +369,7 @@ public:
 	                                                                   const string &catalog_name);
 	DUCKDB_API static vector<reference<SchemaCatalogEntry>> GetAllSchemas(ClientContext &context);
 
-	template <class T>
-	static vector<reference<T>> GetAllEntries(ClientContext &context, CatalogType catalog_type);
-
-	DUCKDB_API static vector<reference<PragmaFunctionCatalogEntry>> GetAllPragmaFunctions(ClientContext &context);
-
-	DUCKDB_API static vector<reference<ScalarFunctionCatalogEntry>> GetAllScalarFunctions(ClientContext &context);
-
-	DUCKDB_API static vector<reference<TableFunctionCatalogEntry>> GetAllTableFunctions(ClientContext &context);
+	static vector<reference<CatalogEntry>> GetAllEntries(ClientContext &context, CatalogType catalog_type);
 
 	virtual void Verify();
 

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -368,6 +368,8 @@ public:
 	                                                                   const string &catalog_name);
 	DUCKDB_API static vector<reference<SchemaCatalogEntry>> GetAllSchemas(ClientContext &context);
 
+	DUCKDB_API static vector<reference<PragmaFunctionCatalogEntry>> GetAllPragmaFunctions(ClientContext &context);
+
 	virtual void Verify();
 
 	static CatalogException UnrecognizedConfigurationError(ClientContext &context, const string &name);

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -50,6 +50,7 @@ class AggregateFunctionCatalogEntry;
 class CollateCatalogEntry;
 class SchemaCatalogEntry;
 class TableCatalogEntry;
+class ScalarFunctionCatalogEntry;
 class ViewCatalogEntry;
 class SequenceCatalogEntry;
 class TableFunctionCatalogEntry;
@@ -369,6 +370,8 @@ public:
 	DUCKDB_API static vector<reference<SchemaCatalogEntry>> GetAllSchemas(ClientContext &context);
 
 	DUCKDB_API static vector<reference<PragmaFunctionCatalogEntry>> GetAllPragmaFunctions(ClientContext &context);
+
+	DUCKDB_API static vector<reference<ScalarFunctionCatalogEntry>> GetAllScalarFunctions(ClientContext &context);
 
 	virtual void Verify();
 

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -50,7 +50,6 @@ class AggregateFunctionCatalogEntry;
 class CollateCatalogEntry;
 class SchemaCatalogEntry;
 class TableCatalogEntry;
-class ScalarFunctionCatalogEntry;
 class ViewCatalogEntry;
 class SequenceCatalogEntry;
 class TableFunctionCatalogEntry;

--- a/test/sql/function/autocomplete/pragma.test
+++ b/test/sql/function/autocomplete/pragma.test
@@ -1,4 +1,4 @@
-# name: test/sql/function/autocomplete/select.test
+# name: test/sql/function/autocomplete/pragma.test
 # description: Test sql_auto_complete
 # group: [autocomplete]
 

--- a/test/sql/function/autocomplete/pragma.test
+++ b/test/sql/function/autocomplete/pragma.test
@@ -1,0 +1,12 @@
+# name: test/sql/function/autocomplete/select.test
+# description: Test sql_auto_complete
+# group: [autocomplete]
+
+require autocomplete
+
+# main keywords
+query II
+FROM sql_auto_complete('PRAGMA show_t') LIMIT 1;
+----
+show_tables	7
+

--- a/test/sql/function/autocomplete/pragma.test
+++ b/test/sql/function/autocomplete/pragma.test
@@ -21,3 +21,9 @@ query II
 FROM sql_auto_complete('PRAGMA disable_che') LIMIT 1;
 ----
 disable_checkpoint_on_shutdown	7
+
+# main keywords
+query II
+FROM sql_auto_complete('PRAGMA thre') LIMIT 1;
+----
+threads	7

--- a/test/sql/function/autocomplete/pragma.test
+++ b/test/sql/function/autocomplete/pragma.test
@@ -10,3 +10,14 @@ FROM sql_auto_complete('PRAGMA show_t') LIMIT 1;
 ----
 show_tables	7
 
+# main keywords
+query II
+FROM sql_auto_complete('PRAGMA enable_che') LIMIT 1;
+----
+enable_checkpoint_on_shutdown	7
+
+# main keywords
+query II
+FROM sql_auto_complete('PRAGMA disable_che') LIMIT 1;
+----
+disable_checkpoint_on_shutdown	7

--- a/test/sql/function/autocomplete/scalar_functions.test
+++ b/test/sql/function/autocomplete/scalar_functions.test
@@ -1,4 +1,4 @@
-# name: test/sql/function/autocomplete/select.test
+# name: test/sql/function/autocomplete/scalar_functions.test
 # description: Test sql_auto_complete
 # group: [autocomplete]
 

--- a/test/sql/function/autocomplete/scalar_functions.test
+++ b/test/sql/function/autocomplete/scalar_functions.test
@@ -1,0 +1,20 @@
+# name: test/sql/function/autocomplete/select.test
+# description: Test sql_auto_complete
+# group: [autocomplete]
+
+require autocomplete
+
+query II
+FROM sql_auto_complete('select gam') LIMIT 1;
+----
+gamma	7
+
+query II
+FROM sql_auto_complete('select nexta') LIMIT 1;
+----
+nextafter	7
+
+query II
+FROM sql_auto_complete('select bit_l') LIMIT 1;
+----
+bit_length	7

--- a/test/sql/function/autocomplete/setting.test
+++ b/test/sql/function/autocomplete/setting.test
@@ -1,4 +1,4 @@
-# name: test/sql/function/autocomplete/select.test
+# name: test/sql/function/autocomplete/setting.test
 # description: Test sql_auto_complete
 # group: [autocomplete]
 

--- a/test/sql/function/autocomplete/setting.test
+++ b/test/sql/function/autocomplete/setting.test
@@ -1,0 +1,25 @@
+# name: test/sql/function/autocomplete/select.test
+# description: Test sql_auto_complete
+# group: [autocomplete]
+
+require autocomplete
+
+# main keywords
+query II
+FROM sql_auto_complete('set thr') LIMIT 1;
+----
+threads	4
+
+# main keywords
+query II
+FROM sql_auto_complete('set allowe') LIMIT 1;
+----
+allowed_paths	4
+
+# main keywords
+query II
+FROM sql_auto_complete('set wal') LIMIT 1;
+----
+wal_encryption	4
+
+

--- a/test/sql/function/autocomplete/table_functions.test
+++ b/test/sql/function/autocomplete/table_functions.test
@@ -13,3 +13,38 @@ query II
 FROM sql_auto_complete('call histogram_') LIMIT 1;
 ----
 histogram_values	5
+
+query II
+FROM sql_auto_complete('call duckdb_t') LIMIT 1;
+----
+duckdb_types	5
+
+query II
+FROM sql_auto_complete('FROM duckdb_c') LIMIT 1;
+----
+duckdb_columns	5
+
+query II
+FROM sql_auto_complete('call read_cs') LIMIT 1;
+----
+read_csv	5
+
+query II
+FROM sql_auto_complete('FROM read_csv_a') LIMIT 1;
+----
+read_csv_auto	5
+
+query II
+FROM sql_auto_complete('call unnes') LIMIT 1;
+----
+unnest	5
+
+query II
+FROM sql_auto_complete('CALL glo') LIMIT 1;
+----
+"glob"	5
+
+query II
+FROM sql_auto_complete('from ran') LIMIT 1;
+----
+"range"	5

--- a/test/sql/function/autocomplete/table_functions.test
+++ b/test/sql/function/autocomplete/table_functions.test
@@ -7,4 +7,9 @@ require autocomplete
 query II
 FROM sql_auto_complete('call histo') LIMIT 1;
 ----
-histogram	7
+histogram	5
+
+query II
+FROM sql_auto_complete('call histogram_') LIMIT 1;
+----
+histogram_values	5

--- a/test/sql/function/autocomplete/table_functions.test
+++ b/test/sql/function/autocomplete/table_functions.test
@@ -1,0 +1,10 @@
+# name: test/sql/function/autocomplete/select.test
+# description: Test sql_auto_complete
+# group: [autocomplete]
+
+require autocomplete
+
+query II
+FROM sql_auto_complete('call histo') LIMIT 1;
+----
+gamma	7

--- a/test/sql/function/autocomplete/table_functions.test
+++ b/test/sql/function/autocomplete/table_functions.test
@@ -7,4 +7,4 @@ require autocomplete
 query II
 FROM sql_auto_complete('call histo') LIMIT 1;
 ----
-histogram(	7
+histogram	7

--- a/test/sql/function/autocomplete/table_functions.test
+++ b/test/sql/function/autocomplete/table_functions.test
@@ -7,4 +7,4 @@ require autocomplete
 query II
 FROM sql_auto_complete('call histo') LIMIT 1;
 ----
-gamma	7
+histogram(	7

--- a/test/sql/function/autocomplete/table_functions.test
+++ b/test/sql/function/autocomplete/table_functions.test
@@ -1,4 +1,4 @@
-# name: test/sql/function/autocomplete/select.test
+# name: test/sql/function/autocomplete/table_functions.test
 # description: Test sql_auto_complete
 # group: [autocomplete]
 


### PR DESCRIPTION
This PR introduces autocomplete suggestions for: 
- Pragma
- Settings (Using `SET` syntax)
- Scalar functions
- Table functions

This resolves some open TODOs. 

The PR doesn't introduce any changes to the grammar and is separate from https://github.com/duckdb/duckdb/pull/18221

To provide these suggestions, I needed a way to get a complete list of each type of entry. My current approach adds a new method to the `Catalog` class (`GetAllEntries`). This works, but I don't want to convolute the class with unneeded methods, so happy to hear feedback regarding this :)
