### PR TITLE
Fix integer overflow in sequence vector

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -586,7 +586,8 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 		case VectorType::SEQUENCE_VECTOR: {
 			int64_t start, increment;
 			SequenceVector::GetSequence(*vector, start, increment);
-			return Value::Numeric(vector->GetType(), start + increment * NumericCast<int64_t>(index));
+			return Value::Numeric(vector->GetType(),
+			                      static_cast<int64_t>(start + static_cast<uint64_t>(increment) * index));
 		}
 		default:
 			throw InternalException("Unimplemented vector type for Vector::GetValue");
@@ -836,7 +837,8 @@ string Vector::ToString(idx_t count) const {
 		int64_t start, increment;
 		SequenceVector::GetSequence(*this, start, increment);
 		for (idx_t i = 0; i < count; i++) {
-			retval += to_string(start + increment * UnsafeNumericCast<int64_t>(i)) + (i == count - 1 ? "" : ", ");
+			retval += to_string(static_cast<int64_t>(start + static_cast<uint64_t>(increment) * i)) +
+			          (i == count - 1 ? "" : ", ");
 		}
 		break;
 	}


### PR DESCRIPTION
It can be reproduced by 
```
./build/debug/test/unittest  --verify-vector sequence_operator --skip-compiled test/sql/table_function/test_range_function.test
vector.cpp:589:63: runtime error: signed integer overflow: 2 * 9223372036854775807 cannot be represented in type 'long int'
```