### PR TITLE
Fixes for gcc 15

### DIFF
--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -1439,26 +1439,6 @@ double DatePart::JulianDayOperator::Operation(date_t input) {
 }
 
 template <>
-double DatePart::JulianDayOperator::Operation(interval_t input) {
-	throw NotImplementedException("interval units \"julian\" not recognized");
-}
-
-template <>
-double DatePart::JulianDayOperator::Operation(dtime_t input) {
-	throw NotImplementedException("\"time\" units \"julian\" not recognized");
-}
-
-template <>
-double DatePart::JulianDayOperator::Operation(dtime_ns_t input) {
-	return JulianDayOperator::Operation<dtime_t, double>(input.time());
-}
-
-template <>
-double DatePart::JulianDayOperator::Operation(dtime_tz_t input) {
-	return JulianDayOperator::Operation<dtime_t, double>(input.time());
-}
-
-template <>
 void DatePart::StructOperator::Operation(bigint_vec &bigint_values, double_vec &double_values, const dtime_t &input,
                                          const idx_t idx, const part_mask_t mask) {
 	int64_t *part_data;

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -590,7 +590,7 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 			int64_t start, increment;
 			SequenceVector::GetSequence(*vector, start, increment);
 			return Value::Numeric(vector->GetType(),
-			                      static_cast<int64_t>(start + static_cast<uint64_t>(increment) * index));
+			                      start + static_cast<int64_t>(static_cast<uint64_t>(increment) * index));
 		}
 		default:
 			throw InternalException("Unimplemented vector type for Vector::GetValue");
@@ -840,7 +840,7 @@ string Vector::ToString(idx_t count) const {
 		int64_t start, increment;
 		SequenceVector::GetSequence(*this, start, increment);
 		for (idx_t i = 0; i < count; i++) {
-			retval += to_string(static_cast<int64_t>(start + static_cast<uint64_t>(increment) * i)) +
+			retval += to_string(start + static_cast<int64_t>(static_cast<uint64_t>(increment) * i)) +
 			          (i == count - 1 ? "" : ", ");
 		}
 		break;

--- a/src/common/value_operations/comparison_operations.cpp
+++ b/src/common/value_operations/comparison_operations.cpp
@@ -65,36 +65,9 @@ inline bool ValuePositionComparator::Final<duckdb::NotEquals>(const Value &lhs, 
 	return ValueOperations::NotDistinctFrom(lhs, rhs);
 }
 
-// Non-strict inequalities must use strict comparisons for Definite
-template <>
-bool ValuePositionComparator::Definite<duckdb::LessThanEquals>(const Value &lhs, const Value &rhs) {
-	return !ValuePositionComparator::Definite<duckdb::GreaterThan>(lhs, rhs);
-}
-
 template <>
 bool ValuePositionComparator::Final<duckdb::GreaterThan>(const Value &lhs, const Value &rhs) {
 	return ValueOperations::DistinctGreaterThan(lhs, rhs);
-}
-
-template <>
-bool ValuePositionComparator::Final<duckdb::LessThanEquals>(const Value &lhs, const Value &rhs) {
-	return !ValuePositionComparator::Final<duckdb::GreaterThan>(lhs, rhs);
-}
-
-template <>
-bool ValuePositionComparator::Definite<duckdb::GreaterThanEquals>(const Value &lhs, const Value &rhs) {
-	return !ValuePositionComparator::Definite<duckdb::GreaterThan>(rhs, lhs);
-}
-
-template <>
-bool ValuePositionComparator::Final<duckdb::GreaterThanEquals>(const Value &lhs, const Value &rhs) {
-	return !ValuePositionComparator::Final<duckdb::GreaterThan>(rhs, lhs);
-}
-
-// Strict inequalities just use strict for both Definite and Final
-template <>
-bool ValuePositionComparator::Final<duckdb::LessThan>(const Value &lhs, const Value &rhs) {
-	return ValuePositionComparator::Final<duckdb::GreaterThan>(rhs, lhs);
 }
 
 template <class OP>

--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -446,61 +446,6 @@ idx_t PositionComparator::Final<duckdb::DistinctFrom>(Vector &left, Vector &righ
 	return VectorOperations::NestedNotEquals(left, right, &sel, count, true_sel, false_sel, null_mask);
 }
 
-// Non-strict inequalities must use strict comparisons for Definite
-template <>
-idx_t PositionComparator::Definite<duckdb::DistinctLessThanEquals>(Vector &left, Vector &right,
-                                                                   const SelectionVector &sel, idx_t count,
-                                                                   optional_ptr<SelectionVector> true_sel,
-                                                                   SelectionVector &false_sel,
-                                                                   optional_ptr<ValidityMask> null_mask) {
-	return VectorOperations::DistinctGreaterThan(right, left, &sel, count, true_sel, &false_sel, null_mask);
-}
-
-template <>
-idx_t PositionComparator::Final<duckdb::DistinctLessThanEquals>(Vector &left, Vector &right, const SelectionVector &sel,
-                                                                idx_t count, optional_ptr<SelectionVector> true_sel,
-                                                                optional_ptr<SelectionVector> false_sel,
-                                                                optional_ptr<ValidityMask> null_mask) {
-	return VectorOperations::DistinctGreaterThanEquals(right, left, &sel, count, true_sel, false_sel, null_mask);
-}
-
-template <>
-idx_t PositionComparator::Definite<duckdb::DistinctGreaterThanEquals>(Vector &left, Vector &right,
-                                                                      const SelectionVector &sel, idx_t count,
-                                                                      optional_ptr<SelectionVector> true_sel,
-                                                                      SelectionVector &false_sel,
-                                                                      optional_ptr<ValidityMask> null_mask) {
-	return VectorOperations::DistinctGreaterThan(left, right, &sel, count, true_sel, &false_sel, null_mask);
-}
-
-template <>
-idx_t PositionComparator::Final<duckdb::DistinctGreaterThanEquals>(Vector &left, Vector &right,
-                                                                   const SelectionVector &sel, idx_t count,
-                                                                   optional_ptr<SelectionVector> true_sel,
-                                                                   optional_ptr<SelectionVector> false_sel,
-                                                                   optional_ptr<ValidityMask> null_mask) {
-	return VectorOperations::DistinctGreaterThanEquals(left, right, &sel, count, true_sel, false_sel, null_mask);
-}
-
-// Strict inequalities just use strict for both Definite and Final
-template <>
-idx_t PositionComparator::Final<duckdb::DistinctLessThan>(Vector &left, Vector &right, const SelectionVector &sel,
-                                                          idx_t count, optional_ptr<SelectionVector> true_sel,
-                                                          optional_ptr<SelectionVector> false_sel,
-                                                          optional_ptr<ValidityMask> null_mask) {
-	return VectorOperations::DistinctGreaterThan(right, left, &sel, count, true_sel, false_sel, null_mask);
-}
-
-template <>
-idx_t PositionComparator::Final<duckdb::DistinctLessThanNullsFirst>(Vector &left, Vector &right,
-                                                                    const SelectionVector &sel, idx_t count,
-                                                                    optional_ptr<SelectionVector> true_sel,
-                                                                    optional_ptr<SelectionVector> false_sel,
-                                                                    optional_ptr<ValidityMask> null_mask) {
-	// DistinctGreaterThan has NULLs last
-	return VectorOperations::DistinctGreaterThan(right, left, &sel, count, true_sel, false_sel, null_mask);
-}
-
 template <>
 idx_t PositionComparator::Final<duckdb::DistinctGreaterThan>(Vector &left, Vector &right, const SelectionVector &sel,
                                                              idx_t count, optional_ptr<SelectionVector> true_sel,

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -419,7 +419,7 @@ idx_t TaskScheduler::GetEstimatedCPUId() {
 	/* Other oses most likely use tpidr_el0 instead */
 	uintptr_t c;
 	asm volatile("mrs %x0, tpidrro_el0" : "=r"(c)::"memory");
-	return (idx_t)(c & (1 << 3) - 1);
+	return (idx_t)(c & ((1 << 3) - 1));
 #else
 #ifndef DUCKDB_NO_THREADS
 	// fallback to thread id


### PR DESCRIPTION
I'm not 100% it's safe to remove those template specializations, however, they were flagged as unused by GCC 15.