### PR TITLE
backport 'Unit Tester Configuration'

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -211,6 +211,7 @@ runs:
       shell: bash
       env:
         LOCAL_EXTENSION_REPO: ${{ inputs.run_autoload_tests == '1' && github.workspace || ''}}
+        DUCKDB_TEST_DESCRIPTION: 'Extension autoloading tests. All `require` calls are ignored and auto-loading is tested. Use require no_extension_autoloading in the test to skip tests.'
       run: |
         cd  ${{ inputs.build_dir}}
         python3 scripts/get_test_list.py --file-contains 'require ' --list '"*.test"' > test.list

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -124,6 +124,7 @@ jobs:
       BUILD_JEMALLOC: 1
       CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;json"
       RUN_SLOW_VERIFIERS: 1
+      DUCKDB_TEST_DESCRIPTION: 'Tests run with --force-storage'
 
     steps:
     - uses: actions/checkout@v4
@@ -161,6 +162,7 @@ jobs:
       GEN: ninja
       BUILD_JEMALLOC: 1
       CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;json"
+      DUCKDB_TEST_DESCRIPTION: 'Tests run with --force-storage --force-restart'
 
     steps:
     - uses: actions/checkout@v4
@@ -199,6 +201,7 @@ jobs:
       ALTERNATIVE_VERIFY: 1
       DISABLE_POINTER_SALT: 1
       LSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-leak-suppressions.txt
+      DUCKDB_TEST_DESCRIPTION: 'Compiled with ALTERNATIVE_VERIFY=1 DISABLE_STRING_INLINE=1 DESTROY_UNPINNED_BLOCKS=1 DISABLE_POINTER_SALT=1. Use require no_alternative_verify to skip.'
 
     steps:
       - uses: actions/checkout@v3
@@ -264,6 +267,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
+      DUCKDB_TEST_DESCRIPTION: 'Compiled with STANDARD_VECTOR_SIZE=2. Use require vector_size 2048 to skip tests.'
 
     steps:
       - name: Clean up the disc space
@@ -365,36 +369,37 @@ jobs:
         shell: bash
         env:
           DISABLE_CPP_UNITTESTS: 1
+          DUCKDB_TEST_DESCRIPTION: 'Tests run with --verify_vector=[VECTOR]. Use require no_vector_verification to skip tests.'
         run: make reldebug
 
       - name: Test dictionary_expression
         shell: bash
         env:
-          DUCKDB_DEBUG_VERIFY_VECTOR: dictionary_expression
+          DUCKDB_TEST_VERIFY_VECTOR: dictionary_expression
         run: python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest --no-exit
 
       - name: Test dictionary_operator
         shell: bash
         env:
-          DUCKDB_DEBUG_VERIFY_VECTOR: dictionary_operator
+          DUCKDB_TEST_VERIFY_VECTOR: dictionary_operator
         run: python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest --no-exit
 
       - name: Test constant_operator
         shell: bash
         env:
-          DUCKDB_DEBUG_VERIFY_VECTOR: constant_operator
+          DUCKDB_TEST_VERIFY_VECTOR: constant_operator
         run: python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest --no-exit
 
       - name: Test sequence_operator
         shell: bash
         env:
-          DUCKDB_DEBUG_VERIFY_VECTOR: sequence_operator
+          DUCKDB_TEST_VERIFY_VECTOR: sequence_operator
         run: python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest --no-exit
 
       - name: Test nested_shuffle
         shell: bash
         env:
-          DUCKDB_DEBUG_VERIFY_VECTOR: nested_shuffle
+          DUCKDB_TEST_VERIFY_VECTOR: nested_shuffle
         run: python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest --no-exit
 
  latest-storage:
@@ -442,6 +447,7 @@ jobs:
       BUILD_JEMALLOC: 1
       CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
       TSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-thread-suppressions.txt
+      DUCKDB_TEST_DESCRIPTION: 'Tests run with thread sanitizer.'
 
     steps:
     - uses: actions/checkout@v3

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 import subprocess
 import time
@@ -5,8 +6,28 @@ import threading
 import tempfile
 import os
 import shutil
+import re
 
-import argparse
+
+class ErrorContainer:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._errors = []
+
+    def append(self, item):
+        with self._lock:
+            self._errors.append(item)
+
+    def get_errors(self):
+        with self._lock:
+            return list(self._errors)
+
+    def __len__(self):
+        with self._lock:
+            return len(self._errors)
+
+
+error_container = ErrorContainer()
 
 
 def valid_timeout(value):
@@ -27,6 +48,7 @@ parser.add_argument('--profile', action='store_true', help='Enable profiling')
 parser.add_argument('--no-assertions', action='store_false', help='Disable assertions')
 parser.add_argument('--time_execution', action='store_true', help='Measure and print the execution time of each test')
 parser.add_argument('--list', action='store_true', help='Print the list of tests to run')
+parser.add_argument('--summarize-failures', action='store_true', help='Summarize failures', default=None)
 parser.add_argument(
     '--tests-per-invocation', type=int, help='The amount of tests to run per invocation of the runner', default=1
 )
@@ -51,6 +73,7 @@ if not args.unittest_program:
 unittest_program = args.unittest_program
 no_exit = args.no_exit
 fast_fail = args.fast_fail
+tests_per_invocation = args.tests_per_invocation
 
 if no_exit:
     if fast_fail:
@@ -61,7 +84,16 @@ profile = args.profile
 assertions = args.no_assertions
 time_execution = args.time_execution
 timeout = args.timeout
-tests_per_invocation = args.tests_per_invocation
+summarize_failures = args.summarize_failures
+if summarize_failures is None:
+    # get from env
+    summarize_failures = False
+    if 'SUMMARIZE_FAILURES' in os.environ:
+        summarize_failures = os.environ['SUMMARIZE_FAILURES'] == '1'
+    elif 'CI' in os.environ:
+        # enable by default in CI if not set explicitly
+        summarize_failures = True
+
 
 # Use the '-l' parameter to output the list of tests to run
 proc = subprocess.run([unittest_program, '-l'] + extra_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -121,6 +153,16 @@ def parse_assertions(stdout):
 is_active = False
 
 
+def get_test_name_from(text):
+    match = re.findall(r'\((.*?)\)\!', text)
+    return match[0] if match else ''
+
+
+def get_clean_error_message_from(text):
+    match = re.split(r'^=+\n', text, maxsplit=1, flags=re.MULTILINE)
+    return match[1] if len(match) > 1 else text
+
+
 def print_interval_background(interval):
     global is_active
     current_ticker = 0.0
@@ -140,28 +182,43 @@ def launch_test(test, list_of_tests=False):
     background_print_thread.start()
 
     unittest_stdout = sys.stdout if list_of_tests else subprocess.PIPE
-    unittest_stderr = sys.stderr if list_of_tests else subprocess.PIPE
+    unittest_stderr = subprocess.PIPE
 
     start = time.time()
     try:
         test_cmd = [unittest_program] + test
         if args.valgrind:
             test_cmd = ['valgrind'] + test_cmd
-        res = subprocess.run(test_cmd, stdout=unittest_stdout, stderr=unittest_stderr, timeout=timeout)
+        # should unset SUMMARIZE_FAILURES to avoid producing exceeding failure logs
+        env = os.environ.copy()
+        # pass env variables globally
+        if list_of_tests or no_exit or tests_per_invocation:
+            env['SUMMARIZE_FAILURES'] = '0'
+            env['NO_DUPLICATING_HEADERS'] = '1'
+        else:
+            env['SUMMARIZE_FAILURES'] = '0'
+        res = subprocess.run(test_cmd, stdout=unittest_stdout, stderr=unittest_stderr, timeout=timeout, env=env)
     except subprocess.TimeoutExpired as e:
         if list_of_tests:
             print("[TIMED OUT]", flush=True)
         else:
             print(" (TIMED OUT)", flush=True)
+        test_name = test[0] if not list_of_tests else str(test)
+        error_msg = f'TIMEOUT - exceeded specified timeout of {timeout} seconds'
+        new_data = {"test": test_name, "return_code": 1, "stdout": '', "stderr": error_msg}
+        error_container.append(new_data)
         fail()
         return
 
-    if list_of_tests:
-        stdout = ''
-        stderr = ''
-    else:
-        stdout = res.stdout.decode('utf8')
-        stderr = res.stderr.decode('utf8')
+    stdout = res.stdout.decode('utf8') if not list_of_tests else ''
+    stderr = res.stderr.decode('utf8')
+
+    if len(stderr) > 0:
+        # when list_of_tests test name gets transformed, but we can get it from stderr
+        test_name = test[0] if not list_of_tests else get_test_name_from(stderr)
+        error_message = get_clean_error_message_from(stderr)
+        new_data = {"test": test_name, "return_code": res.returncode, "stdout": stdout, "stderr": error_message}
+        error_container.append(new_data)
 
     end = time.time()
 
@@ -187,19 +244,18 @@ RETURNCODE
 --------------------"""
     )
     print(res.returncode)
-    if not list_of_tests:
-        print(
-            """--------------------
+    print(
+        """--------------------
 STDOUT
 --------------------"""
-        )
-        print(stdout)
-        print(
-            """--------------------
+    )
+    print(stdout)
+    print(
+        """--------------------
 STDERR
 --------------------"""
-        )
-        print(stderr)
+    )
+    print(stderr)
 
     # if a test closes unexpectedly (e.g., SEGV), test cleanup doesn't happen,
     # causing us to run out of space on subsequent tests in GH Actions (not much disk space there)
@@ -248,4 +304,14 @@ else:
 
 if all_passed:
     exit(0)
+if summarize_failures and len(error_container):
+    print(
+        '''\n\n====================================================
+================  FAILURES SUMMARY  ================
+====================================================\n
+'''
+    )
+    for i, error in enumerate(error_container.get_errors(), start=1):
+        print(f"\n{i}:", error["test"], "\n")
+        print(error["stderr"])
 exit(1)

--- a/src/include/duckdb/storage/compression/patas/patas_scan.hpp
+++ b/src/include/duckdb/storage/compression/patas/patas_scan.hpp
@@ -10,6 +10,10 @@
 
 #include "duckdb/storage/compression/chimp/chimp.hpp"
 #include "duckdb/storage/compression/chimp/algorithm/chimp_utils.hpp"
+#include "duckdb/storage/compression/chimp/algorithm/byte_reader.hpp"
+#include "duckdb/storage/compression/patas/shared.hpp"
+#include "duckdb/storage/compression/patas/algorithm/patas.hpp"
+#include "duckdb/storage/compression/patas/patas.hpp"
 
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/types/null_value.hpp"

--- a/test/helpers/CMakeLists.txt
+++ b/test/helpers/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(DUCKDB_TEST_HELPERS_UNITS test_helpers.cpp capi_tester.cpp pid.cpp)
+set(DUCKDB_TEST_HELPERS_UNITS test_helpers.cpp capi_tester.cpp pid.cpp
+                              test_config.cpp)
 
 add_library(test_helpers STATIC ${DUCKDB_TEST_HELPERS_UNITS})
 

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -1,0 +1,300 @@
+#include "test_config.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/enum_util.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include <fstream>
+#include <sstream>
+
+namespace duckdb {
+
+typedef void (*on_set_option_t)(const Value &input);
+
+struct TestConfigOption {
+	const char *name;
+	const char *description;
+	LogicalTypeId type;
+	on_set_option_t on_set_option;
+};
+
+static const TestConfigOption test_config_options[] = {
+    {"description", "Config description", LogicalTypeId::VARCHAR, nullptr},
+    {"initial_db", "Initial database path", LogicalTypeId::VARCHAR, nullptr},
+    {"max_threads", "Max threads to use during tests", LogicalTypeId::BIGINT, nullptr},
+    {"checkpoint_wal_size", "Size in bytes after which to trigger automatic checkpointing", LogicalTypeId::BIGINT,
+     nullptr},
+    {"checkpoint_on_shutdown", "Whether or not to checkpoint on database shutdown", LogicalTypeId::BOOLEAN, nullptr},
+    {"force_restart", "Force restart the database between runs", LogicalTypeId::BOOLEAN, nullptr},
+    {"summarize_failures", "Print a summary of all test failures after running", LogicalTypeId::BOOLEAN, nullptr},
+    {"test_memory_leaks", "Run memory leak tests", LogicalTypeId::BOOLEAN, nullptr},
+    {"verify_vector", "Run vector verification for a specific vector type", LogicalTypeId::VARCHAR, nullptr},
+    {"debug_initialize", "Initialize buffers with all 0 or all 1", LogicalTypeId::VARCHAR, nullptr},
+    {"init_script", "Script to execute on init", LogicalTypeId::VARCHAR, TestConfiguration::ParseConnectScript},
+    {"on_init", "Script to execute on init", LogicalTypeId::VARCHAR, nullptr},
+    {nullptr, nullptr, LogicalTypeId::INVALID, nullptr},
+};
+
+TestConfiguration &TestConfiguration::Get() {
+	static TestConfiguration instance;
+	return instance;
+}
+
+void TestConfiguration::Initialize() {
+	// load config file
+	auto config_file = std::getenv("DUCKDB_TEST_CONFIG");
+	if (config_file) {
+		LoadConfig(config_file);
+	}
+
+	// load configuration options from the environment
+	for (idx_t index = 0; test_config_options[index].name != nullptr; index++) {
+		auto &config = test_config_options[index];
+		string env_name = "DUCKDB_TEST_" + StringUtil::Upper(config.name);
+		auto env_arg = std::getenv(env_name.c_str());
+		if (!env_arg) {
+			continue;
+		}
+		ParseOption(config.name, Value(env_arg));
+	}
+
+	// load summarize failures
+	const char *summarize = std::getenv("SUMMARIZE_FAILURES");
+	if (summarize) {
+		if (std::string(summarize) == "1") {
+			ParseOption("summarize_failures", Value(true));
+		}
+	} else {
+		// SUMMARIZE_FAILURES not passed in explicitly - enable by default on CI
+		const char *ci = std::getenv("CI");
+		if (ci) {
+			ParseOption("summarize_failures", Value(true));
+		}
+	}
+}
+
+bool TestConfiguration::ParseArgument(const string &arg, idx_t argc, char **argv, idx_t &i) {
+	if (arg == "--test-config") {
+		if (i >= argc) {
+			throw std::runtime_error("--test-config expected a path to a configuration file");
+		}
+		auto config_path = string(argv[++i]);
+		LoadConfig(config_path);
+		return true;
+	}
+	if (arg == "--force-storage") {
+		ParseOption("initial_db", Value("{TEST_DIR}/{BASE_TEST_NAME}/memory.db"));
+		return true;
+	}
+	if (arg == "--force-reload") {
+		ParseOption("force_restart", Value(true));
+		return true;
+	}
+	if (arg == "--single-threaded") {
+		ParseOption("max_threads", Value::BIGINT(1));
+		return true;
+	}
+	if (arg == "--zero-initialize") {
+		ParseOption("debug_initialize", Value("DEBUG_ZERO_INITIALIZE"));
+		return true;
+	}
+	if (arg == "--one-initialize") {
+		ParseOption("debug_initialize", Value("DEBUG_ONE_INITIALIZE"));
+		return true;
+	}
+	if (StringUtil::StartsWith(arg, "--memory-leak") || StringUtil::StartsWith(arg, "--test-memory-leak")) {
+		ParseOption("test_memory_leaks", Value(true));
+		return true;
+	}
+
+	for (idx_t index = 0; test_config_options[index].name != nullptr; index++) {
+		auto &config_option = test_config_options[index];
+		string option_name = "--" + StringUtil::Replace(config_option.name, "_", "-");
+		if (config_option.type == LogicalTypeId::BOOLEAN) {
+			// for booleans we allow "--[option]" and "--no-[option]"
+			string no_option_name = "--no-" + StringUtil::Replace(config_option.name, "_", "-");
+			if (arg == option_name) {
+				ParseOption(config_option.name, Value(true));
+				return true;
+			} else if (arg == no_option_name) {
+				ParseOption(config_option.name, Value(false));
+				return true;
+			}
+		} else if (arg == option_name) {
+			if (i >= argc) {
+				throw std::runtime_error(option_name + " expected an argument");
+			}
+			auto option_value = string(argv[++i]);
+			ParseOption(config_option.name, option_value);
+			return true;
+		}
+	}
+	return false;
+}
+
+bool TestConfiguration::TryParseOption(const string &name, const Value &value) {
+	// find the option
+	optional_idx config_index;
+	for (idx_t index = 0; test_config_options[index].name != nullptr; index++) {
+		if (StringUtil::CIEquals(test_config_options[index].name, name)) {
+			config_index = index;
+			break;
+		}
+	}
+	if (!config_index.IsValid()) {
+		return false;
+	}
+	auto &test_config = test_config_options[config_index.GetIndex()];
+	auto parameter = value.DefaultCastAs(test_config.type);
+	if (test_config.on_set_option) {
+		test_config.on_set_option(parameter);
+	}
+	options.insert(make_pair(test_config.name, parameter));
+	return true;
+}
+
+void TestConfiguration::ParseOption(const string &name, const Value &value) {
+	if (!TryParseOption(name, value)) {
+		throw std::runtime_error("Failed to find option " + name + " - it does not exist");
+	}
+}
+
+string TestConfiguration::OnConnectCommand() {
+	return GetOptionOrDefault("on_init", string());
+}
+
+void TestConfiguration::ParseConnectScript(const Value &input) {
+	auto init_cmd = ReadFileToString(input.ToString());
+
+	auto &test_config = TestConfiguration::Get();
+	test_config.ParseOption("on_init", Value(init_cmd));
+}
+
+string TestConfiguration::ReadFileToString(const string &path) {
+	std::ifstream infile(path);
+	if (infile.bad() || infile.fail()) {
+		throw std::runtime_error("Failed to open configuration file " + path);
+	}
+	std::stringstream buffer;
+	buffer << infile.rdbuf();
+	return buffer.str();
+}
+
+void TestConfiguration::LoadConfig(const string &config_path) {
+	// read the config file
+	auto buffer = ReadFileToString(config_path);
+	// parse json
+	auto json = StringUtil::ParseJSONMap(buffer);
+	auto json_values = json->Flatten();
+	for (auto &entry : json_values) {
+		ParseOption(entry.first, Value(entry.second));
+	}
+}
+
+void TestConfiguration::ProcessPath(string &path, const string &test_name) {
+	path = StringUtil::Replace(path, "{TEST_DIR}", TestDirectoryPath());
+	path = StringUtil::Replace(path, "{UUID}", UUID::ToString(UUID::GenerateRandomUUID()));
+	path = StringUtil::Replace(path, "{TEST_NAME}", test_name);
+
+	auto base_test_name = StringUtil::Replace(test_name, "/", "_");
+	path = StringUtil::Replace(path, "{BASE_TEST_NAME}", base_test_name);
+}
+
+template <class T, class VAL_T>
+T TestConfiguration::GetOptionOrDefault(const string &name, T default_val) {
+	auto entry = options.find(name);
+	if (entry == options.end()) {
+		return default_val;
+	}
+	return entry->second.GetValue<VAL_T>();
+}
+
+string TestConfiguration::GetDescription() {
+	return GetOptionOrDefault("description", string());
+}
+
+string TestConfiguration::GetInitialDBPath() {
+	return GetOptionOrDefault("initial_db", string());
+}
+
+optional_idx TestConfiguration::GetMaxThreads() {
+	return GetOptionOrDefault<optional_idx, idx_t>("max_threads", optional_idx());
+}
+
+idx_t TestConfiguration::GetCheckpointWALSize() {
+	return GetOptionOrDefault<idx_t>("checkpoint_wal_size", 0);
+}
+
+bool TestConfiguration::GetForceRestart() {
+	return GetOptionOrDefault("force_restart", false);
+}
+
+bool TestConfiguration::GetCheckpointOnShutdown() {
+	return GetOptionOrDefault("checkpoint_on_shutdown", true);
+}
+
+bool TestConfiguration::GetTestMemoryLeaks() {
+	return GetOptionOrDefault("test_memory_leaks", false);
+}
+
+bool TestConfiguration::GetSummarizeFailures() {
+	return GetOptionOrDefault("summarize_failures", false);
+}
+
+DebugVectorVerification TestConfiguration::GetVectorVerification() {
+	return EnumUtil::FromString<DebugVectorVerification>(GetOptionOrDefault<string>("verify_vector", "NONE"));
+}
+
+DebugInitialize TestConfiguration::GetDebugInitialize() {
+	return EnumUtil::FromString<DebugInitialize>(GetOptionOrDefault<string>("debug_initialize", "NO_INITIALIZE"));
+}
+
+bool TestConfiguration::TestForceStorage() {
+	auto &test_config = TestConfiguration::Get();
+	return !test_config.GetInitialDBPath().empty();
+}
+
+bool TestConfiguration::TestForceReload() {
+	auto &test_config = TestConfiguration::Get();
+	return test_config.GetForceRestart();
+}
+
+bool TestConfiguration::TestMemoryLeaks() {
+	auto &test_config = TestConfiguration::Get();
+	return test_config.GetTestMemoryLeaks();
+}
+
+FailureSummary::FailureSummary() : failures_summary_counter(0) {
+}
+
+FailureSummary &FailureSummary::Instance() {
+	static FailureSummary instance;
+	return instance;
+}
+
+string FailureSummary::GetFailureSummary() {
+	auto &test_config = TestConfiguration::Get();
+	if (!test_config.GetSummarizeFailures()) {
+		return string();
+	}
+	auto &summary = FailureSummary::Instance();
+	lock_guard<mutex> guard(summary.failures_lock);
+	std::ostringstream oss;
+	for (auto &line : summary.failures_summary) {
+		oss << line;
+	}
+	return oss.str();
+}
+
+void FailureSummary::Log(string log_message) {
+	auto &summary = FailureSummary::Instance();
+	lock_guard<mutex> lock(summary.failures_lock);
+	summary.failures_summary.push_back(std::move(log_message));
+}
+
+idx_t FailureSummary::GetSummaryCounter() {
+	auto &summary = FailureSummary::Instance();
+	return ++summary.failures_summary_counter;
+}
+
+} // namespace duckdb

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -10,7 +10,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/execution/operator/csv_scanner/string_value_scanner.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
-
+#include "test_config.hpp"
 #include "pid.hpp"
 #include "duckdb/function/table/read_csv.hpp"
 #include <cmath>
@@ -22,8 +22,6 @@ using namespace std;
 
 namespace duckdb {
 static string custom_test_directory;
-static int debug_initialize_value = -1;
-static bool single_threaded = false;
 static case_insensitive_set_t required_requires;
 static bool delete_test_path = true;
 
@@ -85,14 +83,6 @@ string TestJoinPath(string path1, string path2) {
 
 void SetTestDirectory(string path) {
 	custom_test_directory = path;
-}
-
-void SetDebugInitialize(int value) {
-	debug_initialize_value = value;
-}
-
-void SetSingleThreaded() {
-	single_threaded = true;
 }
 
 void AddRequire(string require) {
@@ -173,9 +163,12 @@ bool TestIsInternalError(unordered_set<string> &internal_error_messages, const s
 }
 
 unique_ptr<DBConfig> GetTestConfig() {
+	auto &test_config = TestConfiguration::Get();
+
 	auto result = make_uniq<DBConfig>();
 #ifndef DUCKDB_ALTERNATIVE_VERIFY
-	result->options.checkpoint_wal_size = 0;
+	result->options.checkpoint_wal_size = test_config.GetCheckpointWALSize();
+	result->options.checkpoint_on_shutdown = test_config.GetCheckpointOnShutdown();
 #else
 	result->options.checkpoint_on_shutdown = false;
 #endif
@@ -186,45 +179,14 @@ unique_ptr<DBConfig> GetTestConfig() {
 	result->options.trim_free_blocks = true;
 #endif
 	result->options.allow_unsigned_extensions = true;
-	if (single_threaded) {
-		result->options.maximum_threads = 1;
+
+	auto max_threads = test_config.GetMaxThreads();
+	if (max_threads.IsValid()) {
+		result->options.maximum_threads = max_threads.GetIndex();
 	}
-	switch (debug_initialize_value) {
-	case -1:
-		break;
-	case 0:
-		result->options.debug_initialize = DebugInitialize::DEBUG_ZERO_INITIALIZE;
-		break;
-	case 0xFF:
-		result->options.debug_initialize = DebugInitialize::DEBUG_ONE_INITIALIZE;
-		break;
-	default:
-		fprintf(stderr, "Invalid value for debug_initialize_value\n");
-		exit(1);
-	}
+	result->options.debug_initialize = test_config.GetDebugInitialize();
+	result->options.debug_verify_vector = test_config.GetVectorVerification();
 	return result;
-}
-
-string GetCSVPath() {
-	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
-	string csv_path = TestCreatePath("csv_files");
-	if (fs->DirectoryExists(csv_path)) {
-		fs->RemoveDirectory(csv_path);
-	}
-	fs->CreateDirectory(csv_path);
-	return csv_path;
-}
-
-void WriteCSV(string path, const char *csv) {
-	ofstream csv_writer(path);
-	csv_writer << csv;
-	csv_writer.close();
-}
-
-void WriteBinary(string path, const uint8_t *data, uint64_t length) {
-	ofstream binary_writer(path, ios::binary);
-	binary_writer.write((const char *)data, length);
-	binary_writer.close();
 }
 
 bool CHECK_COLUMN(QueryResult &result_, size_t column_number, vector<duckdb::Value> values) {
@@ -404,4 +366,5 @@ bool compare_result(string csv, ColumnDataCollection &collection, vector<Logical
 	}
 	return true;
 }
+
 } // namespace duckdb

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+//                         DuckDB
+//
+// test_config.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/enums/debug_vector_verification.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/enums/debug_initialize.hpp"
+
+namespace duckdb {
+
+class TestConfiguration {
+public:
+	static TestConfiguration &Get();
+
+	void Initialize();
+	bool ParseArgument(const string &arg, idx_t argc, char **argv, idx_t &i);
+	bool TryParseOption(const string &name, const Value &value);
+	void ParseOption(const string &name, const Value &value);
+	void LoadConfig(const string &config_path);
+
+	void ProcessPath(string &path, const string &test_name);
+
+	string GetDescription();
+	string GetInitialDBPath();
+	optional_idx GetMaxThreads();
+	idx_t GetCheckpointWALSize();
+	bool GetForceRestart();
+	bool GetCheckpointOnShutdown();
+	bool GetTestMemoryLeaks();
+	bool GetSummarizeFailures();
+	DebugVectorVerification GetVectorVerification();
+	DebugInitialize GetDebugInitialize();
+	string OnConnectCommand();
+
+	static bool TestForceStorage();
+	static bool TestForceReload();
+	static bool TestMemoryLeaks();
+
+	static void ParseConnectScript(const Value &input);
+
+private:
+	case_insensitive_map_t<Value> options;
+
+private:
+	template <class T, class VAL_T = T>
+	T GetOptionOrDefault(const string &name, T default_val);
+
+	static string ReadFileToString(const string &path);
+};
+
+class FailureSummary {
+public:
+	FailureSummary();
+
+	static void Log(string message);
+	static string GetFailureSummary();
+	static idx_t GetSummaryCounter();
+
+private:
+	static FailureSummary &Instance();
+
+private:
+	mutex failures_lock;
+	atomic<idx_t> failures_summary_counter;
+	vector<string> failures_summary;
+};
+
+} // namespace duckdb

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -25,11 +25,12 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/types.hpp"
+#include "test_config.hpp"
+#include <sstream>
+#include <iostream>
+
 namespace duckdb {
 
-bool TestForceStorage();
-bool TestForceReload();
-bool TestMemoryLeaks();
 void RegisterSqllogictests();
 
 void DeleteDatabase(string path);
@@ -38,6 +39,7 @@ void TestCreateDirectory(string path);
 string TestJoinPath(string path1, string path2);
 void TestDeleteFile(string path);
 void TestChangeDirectory(string path);
+
 void SetDeleteTestPath(bool delete_path);
 bool DeleteTestPath();
 void ClearTestDirectory();
@@ -48,12 +50,8 @@ unique_ptr<DBConfig> GetTestConfig();
 bool TestIsInternalError(unordered_set<string> &internal_error_messages, const string &error);
 void SetTestDirectory(string path);
 void SetDebugInitialize(int value);
-void SetSingleThreaded();
 void AddRequire(string require);
 bool IsRequired(string require);
-string GetCSVPath();
-void WriteCSV(string path, const char *csv);
-void WriteBinary(string path, const uint8_t *data, uint64_t length);
 
 bool NO_FAIL(QueryResult &result);
 bool NO_FAIL(duckdb::unique_ptr<QueryResult> result);

--- a/test/memoryleak/test_appender.cpp
+++ b/test/memoryleak/test_appender.cpp
@@ -1,6 +1,7 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
 #include "duckdb/main/config.hpp"
+#include "test_config.hpp"
 
 using namespace duckdb;
 using namespace std;
@@ -18,7 +19,7 @@ void rand_str(char *dest, idx_t length) {
 }
 
 TEST_CASE("Test repeated appending small chunks to a table", "[memoryleak]") {
-	if (!TestMemoryLeaks()) {
+	if (!TestConfiguration::TestMemoryLeaks()) {
 		return;
 	}
 	duckdb_database db;

--- a/test/memoryleak/test_temporary_tables.cpp
+++ b/test/memoryleak/test_temporary_tables.cpp
@@ -5,12 +5,13 @@
 #include "test_helpers.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/config.hpp"
+#include "test_config.hpp"
 
 using namespace duckdb;
 using namespace std;
 
 TEST_CASE("Test in-memory database scanning from tables", "[memoryleak]") {
-	if (!TestMemoryLeaks()) {
+	if (!TestConfiguration::TestMemoryLeaks()) {
 		return;
 	}
 	DuckDB db;
@@ -23,7 +24,7 @@ TEST_CASE("Test in-memory database scanning from tables", "[memoryleak]") {
 }
 
 TEST_CASE("Rollback create table", "[memoryleak]") {
-	if (!TestMemoryLeaks()) {
+	if (!TestConfiguration::TestMemoryLeaks()) {
 		return;
 	}
 	DBConfig config;
@@ -38,7 +39,7 @@ TEST_CASE("Rollback create table", "[memoryleak]") {
 }
 
 TEST_CASE("DB temporary table insertion", "[memoryleak]") {
-	if (!TestMemoryLeaks()) {
+	if (!TestConfiguration::TestMemoryLeaks()) {
 		return;
 	}
 	auto db_path = TestCreatePath("memory_leak_temp_table.db");

--- a/test/sql/alter/add_pk/test_add_pk_attach.test
+++ b/test/sql/alter/add_pk/test_add_pk_attach.test
@@ -2,8 +2,6 @@
 # description: Test adding a PRIMARY KEY combined with ATTACH/DETACH.
 # group: [add_pk]
 
-require noforcestorage
-
 require skip_reload
 
 load __TEST_DIR__/test_add_pk_attach.db

--- a/test/sql/catalog/function/attached_macro.test
+++ b/test/sql/catalog/function/attached_macro.test
@@ -1,8 +1,6 @@
 # name: test/sql/catalog/function/attached_macro.test
 # group: [function]
 
-require noforcestorage
-
 statement ok
 ATTACH ':memory:' AS checksum_macro;
 

--- a/test/sql/catalog/test_temporary.test
+++ b/test/sql/catalog/test_temporary.test
@@ -2,8 +2,6 @@
 # description: Test temporary catalog entry creation
 # group: [catalog]
 
-require noforcestorage
-
 # basic temp table creation works
 statement ok
 CREATE TEMPORARY TABLE integers(i INTEGER) ON COMMIT PRESERVE ROWS
@@ -158,4 +156,3 @@ SELECT i from integers3
 statement error con2
 INSERT INTO integers VALUES (42)
 ----
-

--- a/test/sql/copy/parquet/parquet_encryption_httpfs.test
+++ b/test/sql/copy/parquet/parquet_encryption_httpfs.test
@@ -7,8 +7,6 @@ require parquet
 require httpfs
 
 # parquet keys are not persisted across restarts
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test
+++ b/test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test
@@ -7,8 +7,6 @@ require parquet
 require httpfs
 
 # parquet keys are not persisted across restarts
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy_database/copy_database_different_types.test
+++ b/test/sql/copy_database/copy_database_different_types.test
@@ -2,8 +2,6 @@
 # description: Test attach mixed with the COPY statement
 # group: [copy_database]
 
-require noforcestorage
-
 statement ok
 ATTACH DATABASE ':memory:' AS db1;
 

--- a/test/sql/copy_database/copy_database_errors.test
+++ b/test/sql/copy_database/copy_database_errors.test
@@ -2,8 +2,6 @@
 # description: Test COPY DATABASE errors
 # group: [copy_database]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy_database/copy_database_fk.test
+++ b/test/sql/copy_database/copy_database_fk.test
@@ -2,8 +2,6 @@
 # description: Test COPY DATABASE with foreign key constraint
 # group: [copy_database]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy_database/copy_database_index.test
+++ b/test/sql/copy_database/copy_database_index.test
@@ -2,8 +2,6 @@
 # description: Test COPY DATABASE with indexes
 # group: [copy_database]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy_database/copy_database_multiple.test
+++ b/test/sql/copy_database/copy_database_multiple.test
@@ -2,8 +2,6 @@
 # description: Run the same COPY FROM DATABASE multiple times
 # group: [copy_database]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy_database/copy_database_simple.test
+++ b/test/sql/copy_database/copy_database_simple.test
@@ -2,8 +2,6 @@
 # description: Test attach mixed with the COPY statement
 # group: [copy_database]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy_database/copy_database_tpch.test_slow
+++ b/test/sql/copy_database/copy_database_tpch.test_slow
@@ -2,8 +2,6 @@
 # description: Test COPY statement with TPC-H database
 # group: [copy_database]
 
-require noforcestorage
-
 require tpch
 
 statement ok

--- a/test/sql/copy_database/copy_database_with_index.test
+++ b/test/sql/copy_database/copy_database_with_index.test
@@ -2,8 +2,6 @@
 # description: Test the COPY DATABASE statement with an index.
 # group: [copy_database]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification;
 

--- a/test/sql/copy_database/copy_database_with_unique_index.test
+++ b/test/sql/copy_database/copy_database_with_unique_index.test
@@ -2,8 +2,6 @@
 # description: Test the COPY DATABASE statement with unique indexes.
 # group: [copy_database]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification;
 

--- a/test/sql/copy_database/copy_table_with_sequence.test
+++ b/test/sql/copy_database/copy_table_with_sequence.test
@@ -1,8 +1,6 @@
 # name: test/sql/copy_database/copy_table_with_sequence.test
 # group: [copy_database]
 
-require noforcestorage
-
 statement ok
 pragma enable_verification;
 

--- a/test/sql/create/create_database.test
+++ b/test/sql/create/create_database.test
@@ -2,8 +2,6 @@
 # description: The binder error from the feature not yet being supported in DuckDB
 # group: [create]
 
-require noforcestorage
-
 statement error
 CREATE DATABASE mydb;
 ----

--- a/test/sql/create/create_table_with_arraybounds.test
+++ b/test/sql/create/create_table_with_arraybounds.test
@@ -1,8 +1,6 @@
 # name: test/sql/create/create_table_with_arraybounds.test
 # group: [create]
 
-require noforcestorage
-
 # Create a table with an ENUM[] type
 statement ok
 create table T (

--- a/test/sql/filter/test_or_pushdown.test
+++ b/test/sql/filter/test_or_pushdown.test
@@ -3,8 +3,6 @@
 # group: [filter]
 
 # no force storage otherwise test to check scanned tupls fails
-require noforcestorage
-
 statement ok
 PRAGMA explain_output = PHYSICAL_ONLY;
 

--- a/test/sql/function/list/lambdas/arrow/test_lambda_arrow_storage_deprecated.test
+++ b/test/sql/function/list/lambdas/arrow/test_lambda_arrow_storage_deprecated.test
@@ -2,8 +2,6 @@
 # description: Test creating a macro with the lambda arrow and loading that from storage.
 # group: [arrow]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification;
 

--- a/test/sql/index/art/memory/test_art_non_linear.test_slow
+++ b/test/sql/index/art/memory/test_art_non_linear.test_slow
@@ -2,8 +2,6 @@
 # description: Test the memory usage of the ART for various workloads
 # group: [memory]
 
-require noforcestorage
-
 require skip_reload
 
 statement ok

--- a/test/sql/json/test_json_serialize_plan.test
+++ b/test/sql/json/test_json_serialize_plan.test
@@ -1,8 +1,6 @@
 # name: test/sql/json/test_json_serialize_plan.test
 # group: [json]
 
-require noforcestorage
-
 require json
 
 statement ok

--- a/test/sql/logging/http_logging.test
+++ b/test/sql/logging/http_logging.test
@@ -3,8 +3,6 @@
 
 require parquet
 
-require noforcestorage
-
 require httpfs
 
 statement ok
@@ -14,7 +12,7 @@ statement ok
 FROM 'https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv'
 
 query IIII
-SELECT 
+SELECT
 	request.type,
 	request.url,
 	response.status,

--- a/test/sql/logging/physical_operator_logging.test_slow
+++ b/test/sql/logging/physical_operator_logging.test_slow
@@ -2,8 +2,6 @@
 # description: Test physical operator logging
 # group: [logging]
 
-require noforcestorage
-
 require parquet
 
 statement ok

--- a/test/sql/logging/test_logging_function_large.test_slow
+++ b/test/sql/logging/test_logging_function_large.test_slow
@@ -2,8 +2,6 @@
 # description: Use test_logging function with 1 million log entries
 # group: [logging]
 
-require noforcestorage
-
 mode skip
 
 query IIIIIIIII

--- a/test/sql/pg_catalog/sqlalchemy.test
+++ b/test/sql/pg_catalog/sqlalchemy.test
@@ -4,8 +4,6 @@
 
 # https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/dialects/postgresql/base.py
 
-require noforcestorage
-
 statement ok
 CREATE TYPE greeting AS ENUM('hi', 'bonjour', 'konnichiwa', 'howdy')
 

--- a/test/sql/pg_catalog/system_functions.test
+++ b/test/sql/pg_catalog/system_functions.test
@@ -3,8 +3,6 @@
 # group: [pg_catalog]
 
 # avoid loading a storage database because it changes the initial database name
-require noforcestorage
-
 query I
 SELECT CURRENT_USER
 ----

--- a/test/sql/pragma/test_show_tables_temp_views.test
+++ b/test/sql/pragma/test_show_tables_temp_views.test
@@ -2,8 +2,6 @@
 # description: Test SHOW/DESCRIBE tables with views
 # group: [pragma]
 
-require noforcestorage
-
 statement ok
 CREATE TEMPORARY VIEW v1 AS SELECT 42 AS a
 

--- a/test/sql/sample/table_samples/sample_stores_rows_from_later_on.test_slow
+++ b/test/sql/sample/table_samples/sample_stores_rows_from_later_on.test_slow
@@ -7,8 +7,6 @@ mode skip
 # required when testing table samples. See basic_sample_test.test
 require vector_size 2048
 
-require noforcestorage
-
 load __TEST_DIR__/test_sample_conversion.db
 
 statement ok

--- a/test/sql/sample/table_samples/table_sample_converts_to_block_sample.test
+++ b/test/sql/sample/table_samples/table_sample_converts_to_block_sample.test
@@ -7,8 +7,6 @@ mode skip
 # required when testing table samples. See basic_sample_test.test
 require vector_size 2048
 
-require noforcestorage
-
 # table samples first collect only 1% of the table, until the table has a cardinality of 2048.
 # then the sample stays at a fixed 2048 values.
 

--- a/test/sql/sample/table_samples/table_sample_is_stored.test_slow
+++ b/test/sql/sample/table_samples/table_sample_is_stored.test_slow
@@ -7,8 +7,6 @@ mode skip
 # required when testing table samples. See basic_sample_test.test
 require vector_size 2048
 
-require noforcestorage
-
 require icu
 
 load __TEST_DIR__/test_samples.db

--- a/test/sql/show_select/test_describe_all.test
+++ b/test/sql/show_select/test_describe_all.test
@@ -2,8 +2,6 @@
 # description: Test describe all
 # group: [show_select]
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/storage/optimistic_write/optimistic_write.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write.test_slow
@@ -2,8 +2,6 @@
 # description: Test large appends within individual transactions
 # group: [optimistic_write]
 
-require noforcestorage
-
 foreach skip_checkpoint true false
 
 load __TEST_DIR__/optimistic_write_${skip_checkpoint}.db

--- a/test/sql/storage/temp_directory/max_swap_space_error.test
+++ b/test/sql/storage/temp_directory/max_swap_space_error.test
@@ -4,8 +4,6 @@
 
 require skip_reload
 
-require noforcestorage
-
 # This test performs comparisons against the DEFAULT_BLOCK_ALLOC_SIZE of 256KiB.
 require block_size 262144
 

--- a/test/sql/storage/temp_directory/max_swap_space_error.test
+++ b/test/sql/storage/temp_directory/max_swap_space_error.test
@@ -2,6 +2,8 @@
 # description: Test the maximum swap space.
 # group: [temp_directory]
 
+require noforcestorage
+
 require skip_reload
 
 # This test performs comparisons against the DEFAULT_BLOCK_ALLOC_SIZE of 256KiB.

--- a/test/sql/storage/temp_directory/max_swap_space_inmemory.test
+++ b/test/sql/storage/temp_directory/max_swap_space_inmemory.test
@@ -1,8 +1,6 @@
 # name: test/sql/storage/temp_directory/max_swap_space_inmemory.test
 # group: [temp_directory]
 
-require noforcestorage
-
 require skip_reload
 
 # In in-memory mode, the 'temp_directory' defaults to '.tmp'

--- a/test/sql/storage/temp_directory/max_swap_space_unlimited.test
+++ b/test/sql/storage/temp_directory/max_swap_space_unlimited.test
@@ -3,8 +3,6 @@
 
 require skip_reload
 
-require noforcestorage
-
 # Set a temp_directory to offload data
 statement ok
 set temp_directory='__TEST_DIR__/max_swap_space_reached'

--- a/test/sql/storage/test_purge_queue.test_slow
+++ b/test/sql/storage/test_purge_queue.test_slow
@@ -2,8 +2,6 @@
 # description: Test purging the eviction queue
 # group: [storage]
 
-require noforcestorage
-
 require 64bit
 
 # attach files

--- a/test/sql/storage/wal/wal_lazy_creation.test
+++ b/test/sql/storage/wal/wal_lazy_creation.test
@@ -6,8 +6,6 @@
 # Thus, we'll keep the WAL alive when detaching the database.
 require no_alternative_verify
 
-require noforcestorage
-
 require skip_reload
 
 statement ok

--- a/test/sql/table_function/database_oid.test
+++ b/test/sql/table_function/database_oid.test
@@ -2,8 +2,6 @@
 # description: Issue #5836: Test database oid
 # group: [table_function]
 
-require noforcestorage
-
 statement ok
 CREATE TEMP TABLE x (x INT);
 

--- a/test/sql/table_function/duckdb_columns.test
+++ b/test/sql/table_function/duckdb_columns.test
@@ -5,8 +5,6 @@
 statement ok
 set storage_compatibility_version='v0.10.2'
 
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/table_function/duckdb_constraints_fk.test
+++ b/test/sql/table_function/duckdb_constraints_fk.test
@@ -2,8 +2,6 @@
 # description: Test duckdb_constraints function
 # group: [table_function]
 
-require noforcestorage
-
 statement ok
 CREATE TABLE tf_1 (
   a integer, "b c" integer, "d e" integer,

--- a/test/sql/table_function/duckdb_databases.test
+++ b/test/sql/table_function/duckdb_databases.test
@@ -3,8 +3,6 @@
 # group: [table_function]
 
 # avoid loading a storage database because it changes the initial database name
-require noforcestorage
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/table_function/duckdb_databases.test
+++ b/test/sql/table_function/duckdb_databases.test
@@ -2,7 +2,8 @@
 # description: Test duckdb_databases function
 # group: [table_function]
 
-# avoid loading a storage database because it changes the initial database name
+require noforcestorage
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/table_function/duckdb_memory.test_slow
+++ b/test/sql/table_function/duckdb_memory.test_slow
@@ -1,8 +1,6 @@
 # name: test/sql/table_function/duckdb_memory.test_slow
 # group: [table_function]
 
-require noforcestorage
-
 require vector_size 2048
 
 statement ok

--- a/test/sql/table_function/duckdb_sequences.test
+++ b/test/sql/table_function/duckdb_sequences.test
@@ -2,8 +2,6 @@
 # description: Test duckdb_sequences function
 # group: [table_function]
 
-require noforcestorage
-
 query I
 SELECT COUNT(*) FROM duckdb_sequences();
 ----
@@ -20,5 +18,3 @@ SELECT database_name, schema_name, sequence_name, temporary, start_value, min_va
 ----
 memory	main	seq	False	1	1	9223372036854775807	1	False
 temp	main	seq2	True	4	3	5	1	True
-
-

--- a/test/sql/table_function/duckdb_tables.test
+++ b/test/sql/table_function/duckdb_tables.test
@@ -2,8 +2,6 @@
 # description: Test duckdb_tables function
 # group: [table_function]
 
-require noforcestorage
-
 query I
 SELECT COUNT(*) FROM duckdb_tables();
 ----

--- a/test/sql/table_function/duckdb_views.test
+++ b/test/sql/table_function/duckdb_views.test
@@ -2,8 +2,6 @@
 # description: Test duckdb_views function
 # group: [table_function]
 
-require noforcestorage
-
 query I
 SELECT COUNT(*) FROM duckdb_views;
 ----

--- a/test/sql/table_function/information_schema.test
+++ b/test/sql/table_function/information_schema.test
@@ -2,8 +2,6 @@
 # description: Test information_schema functions
 # group: [table_function]
 
-require noforcestorage
-
 statement ok
 SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
 

--- a/test/sql/transactions/test_alter_sequence_ownership_conflict3.test
+++ b/test/sql/transactions/test_alter_sequence_ownership_conflict3.test
@@ -2,8 +2,6 @@
 # description: Test DROP and OWNED BY transactionality | drop commits first
 # group: [transactions]
 
-require noforcestorage
-
 load __TEST_DIR__/alter_sequence_ownership3.db;
 
 statement ok

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/catalog/duck_catalog.hpp"
 #include "duckdb/catalog/catalog_entry/duck_schema_entry.hpp"
 #include "test_helpers.hpp"
+#include "test_config.hpp"
 #include "sqllogic_test_logger.hpp"
 #include "catch.hpp"
 #include <list>
@@ -140,9 +141,10 @@ void Command::RestartDatabase(ExecuteContext &context, Connection *&connection, 
 unique_ptr<MaterializedQueryResult> Command::ExecuteQuery(ExecuteContext &context, Connection *connection,
                                                           string file_name, idx_t query_line) const {
 	query_break(query_line);
-	if (TestForceReload() && TestForceStorage()) {
+	if (TestConfiguration::TestForceReload() && TestConfiguration::TestForceStorage()) {
 		RestartDatabase(context, connection, context.sql_query);
 	}
+
 #ifdef DUCKDB_ALTERNATIVE_VERIFY
 	auto ccontext = connection->context;
 	auto result = ccontext->Query(context.sql_query, true);
@@ -601,7 +603,7 @@ void LoadCommand::ExecuteInternal(ExecuteContext &context) const {
 				runner.config->options.serialization_compatibility = SerializationCompatibility::FromString(version);
 			} catch (std::exception &ex) {
 				ErrorData err(ex);
-				SQLLogicTestLogger::LoadDatabaseFail(dbpath, err.Message());
+				SQLLogicTestLogger::LoadDatabaseFail(runner.file_name, dbpath, err.Message());
 				FAIL();
 			}
 		}

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -1,7 +1,9 @@
 #include "sqllogic_test_logger.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "termcolor.hpp"
+#include "result_helper.hpp"
 #include "sqllogic_test_runner.hpp"
+#include "test_helpers.hpp"
 
 namespace duckdb {
 
@@ -13,38 +15,61 @@ SQLLogicTestLogger::SQLLogicTestLogger(ExecuteContext &context, const Command &c
 SQLLogicTestLogger::~SQLLogicTestLogger() {
 }
 
+void SQLLogicTestLogger::AppendFailure(const string &log_message) {
+	FailureSummary::Log(log_message);
+}
+
+void SQLLogicTestLogger::LogFailure(const string &log_message) {
+	std::cerr << log_message;
+	AppendFailure(log_message);
+}
+
 void SQLLogicTestLogger::Log(const string &str) {
 	std::cerr << str;
+	AppendFailure(str);
+}
+
+void SQLLogicTestLogger::PrintSummaryHeader(const std::string &file_name) {
+	auto failures_count = to_string(FailureSummary::GetSummaryCounter());
+	if (std::getenv("NO_DUPLICATING_HEADERS") == 0) {
+		LogFailure("\n" + failures_count + ". " + file_name + "\n");
+		PrintLineSep();
+	}
 }
 
 void SQLLogicTestLogger::PrintExpectedResult(const vector<string> &values, idx_t columns, bool row_wise) {
 	if (row_wise) {
 		for (idx_t r = 0; r < values.size(); r++) {
-			fprintf(stderr, "%s\n", values[r].c_str());
+			LogFailure("\n" + values[r]);
 		}
 	} else {
 		idx_t c = 0;
 		for (idx_t r = 0; r < values.size(); r++) {
 			if (c != 0) {
-				fprintf(stderr, "\t");
+				LogFailure("\t");
 			}
-			fprintf(stderr, "%s", values[r].c_str());
+			LogFailure(values[r]);
 			c++;
 			if (c >= columns) {
-				fprintf(stderr, "\n");
+				LogFailure("\n");
 				c = 0;
 			}
 		}
 	}
+	LogFailure("\n");
 }
 
 void SQLLogicTestLogger::PrintLineSep() {
 	string line_sep = string(80, '=');
-	std::cerr << termcolor::color<128, 128, 128> << line_sep << termcolor::reset << std::endl;
+	std::ostringstream oss;
+	oss << termcolor::color<128, 128, 128> << line_sep << termcolor::reset << std::endl;
+	LogFailure(oss.str());
 }
 
 void SQLLogicTestLogger::PrintHeader(string header) {
-	std::cerr << termcolor::bold << header << termcolor::reset << std::endl;
+	std::ostringstream oss;
+	oss << termcolor::bold << header << termcolor::reset << std::endl;
+	LogFailure(oss.str());
 }
 
 void SQLLogicTestLogger::PrintFileHeader() {
@@ -58,15 +83,13 @@ void SQLLogicTestLogger::PrintSQL() {
 		if (!StringUtil::EndsWith(sql_query, ";\n")) {
 			// no semicolon though
 			query[query.size() - 1] = ';';
-			query += "\n";
 		}
 	} else {
 		if (!StringUtil::EndsWith(sql_query, ";")) {
 			query += ";";
 		}
-		query += "\n";
 	}
-	Log(query);
+	Log(query + "\n");
 }
 
 void SQLLogicTestLogger::PrintSQLFormatted() {
@@ -102,12 +125,13 @@ void SQLLogicTestLogger::PrintSQLFormatted() {
 }
 
 void SQLLogicTestLogger::PrintErrorHeader(const string &file_name, idx_t query_line, const string &description) {
-	PrintLineSep();
-	std::cerr << termcolor::red << termcolor::bold << description << " " << termcolor::reset;
+	std::ostringstream oss;
+	PrintSummaryHeader(file_name);
+	oss << termcolor::red << termcolor::bold << description << " " << termcolor::reset;
 	if (!file_name.empty()) {
-		std::cerr << termcolor::bold << "(" << file_name << ":" << query_line << ")!" << termcolor::reset;
+		oss << termcolor::bold << "(" << file_name << ":" << query_line << ")!" << termcolor::reset;
 	}
-	std::cerr << std::endl;
+	LogFailure(oss.str() + "\n");
 }
 
 void SQLLogicTestLogger::PrintErrorHeader(const string &description) {
@@ -125,6 +149,10 @@ void SQLLogicTestLogger::PrintResultError(const vector<string> &result_values, c
 	PrintExpectedResult(result_values, expected_column_count, false);
 }
 
+void SQLLogicTestLogger::PrintResultString(MaterializedQueryResult &result) {
+	LogFailure(result.ToString());
+}
+
 void SQLLogicTestLogger::PrintResultError(MaterializedQueryResult &result, const vector<string> &values,
                                           idx_t expected_column_count, bool row_wise) {
 	PrintHeader("Expected result:");
@@ -133,44 +161,46 @@ void SQLLogicTestLogger::PrintResultError(MaterializedQueryResult &result, const
 	PrintLineSep();
 	PrintHeader("Actual result:");
 	PrintLineSep();
-	result.Print();
+	PrintResultString(result);
 }
 
 void SQLLogicTestLogger::UnexpectedFailure(MaterializedQueryResult &result) {
-	PrintLineSep();
-	std::cerr << "Query unexpectedly failed (" << file_name.c_str() << ":" << query_line << ")\n";
+	std::ostringstream oss;
+	PrintErrorHeader("Query unexpectedly failed (" + file_name + ":" + to_string(query_line) + ")\n");
+	LogFailure(oss.str());
 	PrintLineSep();
 	PrintSQL();
 	PrintLineSep();
 	PrintHeader("Actual result:");
-	result.Print();
+	PrintLineSep();
+	PrintResultString(result);
 }
 void SQLLogicTestLogger::OutputResult(MaterializedQueryResult &result, const vector<string> &result_values_string) {
 	// names
 	for (idx_t c = 0; c < result.ColumnCount(); c++) {
 		if (c != 0) {
-			std::cerr << "\t";
+			LogFailure("\t");
 		}
-		std::cerr << result.names[c];
+		LogFailure(result.names[c]);
 	}
-	std::cerr << std::endl;
+	LogFailure("\n");
 	// types
 	for (idx_t c = 0; c < result.ColumnCount(); c++) {
 		if (c != 0) {
-			std::cerr << "\t";
+			LogFailure("\t");
 		}
-		std::cerr << result.types[c].ToString();
+		LogFailure(result.types[c].ToString());
 	}
-	std::cerr << std::endl;
+	LogFailure("\n");
 	PrintLineSep();
 	for (idx_t r = 0; r < result.RowCount(); r++) {
 		for (idx_t c = 0; c < result.ColumnCount(); c++) {
 			if (c != 0) {
-				std::cerr << "\t";
+				LogFailure("\t");
 			}
-			std::cerr << result_values_string[r * result.ColumnCount() + c];
+			LogFailure(result_values_string[r * result.ColumnCount() + c]);
 		}
-		std::cerr << std::endl;
+		LogFailure("\n");
 	}
 }
 
@@ -178,16 +208,18 @@ void SQLLogicTestLogger::OutputHash(const string &hash_value) {
 	PrintLineSep();
 	PrintSQL();
 	PrintLineSep();
-	std::cerr << hash_value << std::endl;
+	LogFailure(hash_value + "\n");
 	PrintLineSep();
 }
 
 void SQLLogicTestLogger::ColumnCountMismatch(MaterializedQueryResult &result,
                                              const vector<string> &result_values_string, idx_t expected_column_count,
                                              bool row_wise) {
+	std::ostringstream oss;
 	PrintErrorHeader("Wrong column count in query!");
-	std::cerr << "Expected " << termcolor::bold << expected_column_count << termcolor::reset << " columns, but got "
-	          << termcolor::bold << result.ColumnCount() << termcolor::reset << " columns" << std::endl;
+	oss << "Expected " << termcolor::bold << expected_column_count << termcolor::reset << " columns, but got "
+	    << termcolor::bold << result.ColumnCount() << termcolor::reset << " columns" << std::endl;
+	LogFailure(oss.str());
 	PrintLineSep();
 	PrintSQL();
 	PrintLineSep();
@@ -195,19 +227,21 @@ void SQLLogicTestLogger::ColumnCountMismatch(MaterializedQueryResult &result,
 }
 
 void SQLLogicTestLogger::NotCleanlyDivisible(idx_t expected_column_count, idx_t actual_column_count) {
+	PrintLineSep();
 	PrintErrorHeader("Error in test!");
 	PrintLineSep();
-	fprintf(stderr, "Expected %d columns, but %d values were supplied\n", (int)expected_column_count,
-	        (int)actual_column_count);
-	fprintf(stderr, "This is not cleanly divisible (i.e. the last row does not have enough values)\n");
+	LogFailure("Expected " + to_string(expected_column_count) + " columns, but " + to_string(actual_column_count) +
+	           " values were supplied\nThis is not cleanly divisible (i.e. the last row does not have enough values)");
 }
 
 void SQLLogicTestLogger::WrongRowCount(idx_t expected_rows, MaterializedQueryResult &result,
                                        const vector<string> &comparison_values, idx_t expected_column_count,
                                        bool row_wise) {
+	std::ostringstream oss;
 	PrintErrorHeader("Wrong row count in query!");
-	std::cerr << "Expected " << termcolor::bold << expected_rows << termcolor::reset << " rows, but got "
-	          << termcolor::bold << result.RowCount() << termcolor::reset << " rows" << std::endl;
+	oss << "Expected " << termcolor::bold << expected_rows << termcolor::reset << " rows, but got " << termcolor::bold
+	    << result.RowCount() << termcolor::reset << " rows" << std::endl;
+	LogFailure(oss.str());
 	PrintLineSep();
 	PrintSQL();
 	PrintLineSep();
@@ -216,28 +250,39 @@ void SQLLogicTestLogger::WrongRowCount(idx_t expected_rows, MaterializedQueryRes
 
 void SQLLogicTestLogger::ColumnCountMismatchCorrectResult(idx_t original_expected_columns, idx_t expected_column_count,
                                                           MaterializedQueryResult &result) {
-	PrintLineSep();
+
+	std::ostringstream oss;
 	PrintErrorHeader("Wrong column count in query!");
-	std::cerr << "Expected " << termcolor::bold << original_expected_columns << termcolor::reset << " columns, but got "
-	          << termcolor::bold << expected_column_count << termcolor::reset << " columns" << std::endl;
+	oss << "Expected " << termcolor::bold << original_expected_columns << termcolor::reset << " columns, but got "
+	    << termcolor::bold << expected_column_count << termcolor::reset << " columns" << std::endl;
+	LogFailure(oss.str());
+	oss.str("");
+	oss.clear();
 	PrintLineSep();
 	PrintSQL();
 	PrintLineSep();
-	std::cerr << "The expected result " << termcolor::bold << "matched" << termcolor::reset << " the query result."
-	          << std::endl;
-	std::cerr << termcolor::bold << "Suggested fix: modify header to \"" << termcolor::green << "query "
-	          << string(result.ColumnCount(), 'I') << termcolor::reset << termcolor::bold << "\"" << termcolor::reset
-	          << std::endl;
+	oss << "The expected result " << termcolor::bold << "matched" << termcolor::reset << " the query result."
+	    << std::endl;
+	LogFailure(oss.str());
+	oss.str("");
+	oss.clear();
+	oss << termcolor::bold << "Suggested fix: modify header to \"" << termcolor::green << "query "
+	    << string(result.ColumnCount(), 'I') << termcolor::reset << termcolor::bold << "\"" << termcolor::reset
+	    << std::endl;
+	LogFailure(oss.str());
 	PrintLineSep();
 }
 
 void SQLLogicTestLogger::SplitMismatch(idx_t row_number, idx_t expected_column_count, idx_t split_count) {
+
+	std::ostringstream oss;
 	PrintLineSep();
 	PrintErrorHeader("Error in test! Column count mismatch after splitting on tab on row " + to_string(row_number) +
 	                 "!");
-	std::cerr << "Expected " << termcolor::bold << expected_column_count << termcolor::reset << " columns, but got "
-	          << termcolor::bold << split_count << termcolor::reset << " columns" << std::endl;
-	std::cerr << "Does the result contain tab values? In that case, place every value on a single row." << std::endl;
+	oss << "Expected " << termcolor::bold << expected_column_count << termcolor::reset << " columns, but got "
+	    << termcolor::bold << split_count << termcolor::reset << " columns" << std::endl;
+	LogFailure(oss.str());
+	LogFailure("Does the result contain tab values? In that case, place every value on a single row.\n");
 	PrintLineSep();
 	PrintSQL();
 	PrintLineSep();
@@ -247,7 +292,7 @@ void SQLLogicTestLogger::WrongResultHash(QueryResult *expected_result, Materiali
 	if (expected_result) {
 		expected_result->Print();
 	} else {
-		std::cerr << "???" << std::endl;
+		LogFailure("???\n");
 	}
 	PrintErrorHeader("Wrong result hash!");
 	PrintLineSep();
@@ -257,7 +302,7 @@ void SQLLogicTestLogger::WrongResultHash(QueryResult *expected_result, Materiali
 	PrintLineSep();
 	PrintHeader("Actual result:");
 	PrintLineSep();
-	result.Print();
+	PrintResultString(result);
 }
 
 void SQLLogicTestLogger::UnexpectedStatement(bool expect_ok, MaterializedQueryResult &result) {
@@ -265,16 +310,17 @@ void SQLLogicTestLogger::UnexpectedStatement(bool expect_ok, MaterializedQueryRe
 	PrintLineSep();
 	PrintSQL();
 	PrintLineSep();
-	result.Print();
+	PrintResultString(result);
 }
 
 void SQLLogicTestLogger::ExpectedErrorMismatch(const string &expected_error, MaterializedQueryResult &result) {
 	PrintErrorHeader("Query failed, but error message did not match expected error message: " + expected_error);
 	PrintLineSep();
 	PrintSQL();
+	PrintLineSep();
 	PrintHeader("Actual result:");
 	PrintLineSep();
-	result.Print();
+	PrintResultString(result);
 }
 
 void SQLLogicTestLogger::InternalException(MaterializedQueryResult &result) {
@@ -283,13 +329,13 @@ void SQLLogicTestLogger::InternalException(MaterializedQueryResult &result) {
 	PrintSQL();
 	PrintHeader("Actual result:");
 	PrintLineSep();
-	result.Print();
+	PrintResultString(result);
 }
 
-void SQLLogicTestLogger::LoadDatabaseFail(const string &dbpath, const string &message) {
-	PrintErrorHeader(string(), 0, "Failed to load database " + dbpath);
+void SQLLogicTestLogger::LoadDatabaseFail(const string &file_name, const string &dbpath, const string &message) {
+	PrintErrorHeader(file_name, 0, "Failed to load database " + dbpath);
 	PrintLineSep();
-	Log("Error message: " + message + "\n");
+	LogFailure("Error message: " + message + "\n");
 	PrintLineSep();
 }
 

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -33,8 +33,10 @@ public:
 	static void PrintErrorHeader(const string &file_name, idx_t query_line, const string &description);
 	void PrintResultError(const vector<string> &result_values, const vector<string> &values,
 	                      idx_t expected_column_count, bool row_wise);
+	static void PrintSummaryHeader(const std::string &file_name);
 	void PrintResultError(MaterializedQueryResult &result, const vector<string> &values, idx_t expected_column_count,
 	                      bool row_wise);
+	void PrintResultString(MaterializedQueryResult &result);
 	void UnexpectedFailure(MaterializedQueryResult &result);
 	void OutputResult(MaterializedQueryResult &result, const vector<string> &result_values_string);
 	void OutputHash(const string &hash_value);
@@ -50,7 +52,11 @@ public:
 	void UnexpectedStatement(bool expect_ok, MaterializedQueryResult &result);
 	void ExpectedErrorMismatch(const string &expected_error, MaterializedQueryResult &result);
 	void InternalException(MaterializedQueryResult &result);
-	static void LoadDatabaseFail(const string &dbpath, const string &message);
+	static void LoadDatabaseFail(const string &file_name, const string &dbpath, const string &message);
+
+	static void AppendFailure(const string &log_message);
+	static void LogFailure(const string &log_message);
+	// static string GetFailureSummary();
 
 private:
 	lock_guard<mutex> log_lock;

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -30,10 +30,6 @@ SQLLogicTestRunner::SQLLogicTestRunner(string dbpath) : dbpath(std::move(dbpath)
 		local_extension_repo = env_var;
 		config->options.autoload_known_extensions = true;
 	}
-	auto verify_vector = std::getenv("DUCKDB_DEBUG_VERIFY_VECTOR");
-	if (verify_vector) {
-		config->options.debug_verify_vector = EnumUtil::FromString<DebugVectorVerification>(verify_vector);
-	}
 }
 
 SQLLogicTestRunner::~SQLLogicTestRunner() {
@@ -104,7 +100,7 @@ void SQLLogicTestRunner::LoadDatabase(string dbpath, bool load_extensions) {
 		ExtensionHelper::LoadExtension(*db, "core_functions");
 	} catch (std::exception &ex) {
 		ErrorData err(ex);
-		SQLLogicTestLogger::LoadDatabaseFail(dbpath, err.Message());
+		SQLLogicTestLogger::LoadDatabaseFail(file_name, dbpath, err.Message());
 		FAIL();
 	}
 	Reconnect();
@@ -135,6 +131,16 @@ void SQLLogicTestRunner::Reconnect() {
 	// Set the local extension repo for autoinstalling extensions
 	if (!local_extension_repo.empty()) {
 		auto res1 = con->Query("SET autoinstall_extension_repository='" + local_extension_repo + "'");
+	}
+
+	auto &test_config = TestConfiguration::Get();
+	auto init_cmd = test_config.OnConnectCommand();
+	if (!init_cmd.empty()) {
+		test_config.ProcessPath(init_cmd, file_name);
+		auto res = con->Query(ReplaceKeywords(init_cmd));
+		if (res->HasError()) {
+			FAIL("Startup queries provided via on_init failed: " + res->GetError());
+		}
 	}
 }
 
@@ -390,7 +396,7 @@ RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vec
 	}
 
 	if (param == "noforcestorage") {
-		if (TestForceStorage()) {
+		if (TestConfiguration::TestForceStorage()) {
 			return RequireResult::MISSING;
 		}
 		return RequireResult::PRESENT;
@@ -516,8 +522,8 @@ RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vec
 	}
 
 	if (param == "no_vector_verification") {
-		auto verify_vector = std::getenv("DUCKDB_DEBUG_VERIFY_VECTOR");
-		if (verify_vector) {
+		auto &test_config = TestConfiguration::Get();
+		if (test_config.GetVectorVerification() != DebugVectorVerification::NONE) {
 			return RequireResult::MISSING;
 		}
 		return RequireResult::PRESENT;
@@ -628,6 +634,7 @@ bool TryParseConditions(SQLLogicParser &parser, const string &condition_text, ve
 }
 
 void SQLLogicTestRunner::ExecuteFile(string script) {
+	file_name = script;
 	SQLLogicParser parser;
 	idx_t skip_level = 0;
 

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -25,6 +25,7 @@ public:
 	SQLLogicTestRunner(string dbpath);
 	~SQLLogicTestRunner();
 
+	string file_name;
 	string dbpath;
 	vector<string> loaded_databases;
 	duckdb::unique_ptr<DuckDB> db;

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/parser/parser.hpp"
 #include "sqllogic_test_runner.hpp"
 #include "test_helpers.hpp"
+#include "test_config.hpp"
 
 #include <functional>
 #include <string>
@@ -37,15 +38,24 @@ static void testRunner() {
 	// this is an ugly hack that uses the test case name to pass the script file
 	// name if someone has a better idea...
 	auto name = Catch::getResultCapture().getCurrentTestName();
-	// fprintf(stderr, "%s\n", name.c_str());
-	string initial_dbpath;
-	if (TestForceStorage()) {
-		auto storage_name = StringUtil::Replace(name, "/", "_");
-		storage_name = StringUtil::Replace(storage_name, ".", "_");
-		storage_name = StringUtil::Replace(storage_name, "\\", "_");
-		auto db_directory = TestCreatePath(storage_name);
-		TestCreateDirectory(db_directory);
-		initial_dbpath = TestJoinPath(db_directory, "memory.db");
+
+	auto &test_config = TestConfiguration::Get();
+
+	string initial_dbpath = test_config.GetInitialDBPath();
+	test_config.ProcessPath(initial_dbpath, name);
+	if (!initial_dbpath.empty()) {
+		auto test_path = StringUtil::Replace(initial_dbpath, TestDirectoryPath(), string());
+		test_path = StringUtil::Replace(test_path, "\\", "/");
+		auto components = StringUtil::Split(test_path, "/");
+		components.pop_back();
+		string total_path = TestDirectoryPath();
+		for (auto &component : components) {
+			if (component.empty()) {
+				continue;
+			}
+			total_path = TestJoinPath(total_path, component);
+			TestCreateDirectory(total_path);
+		}
 	}
 	SQLLogicTestRunner runner(std::move(initial_dbpath));
 	runner.output_sql = Catch::getCurrentContext().getConfig()->outputSQL();

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -3,46 +3,27 @@
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "sqlite/sqllogic_test_logger.hpp"
 #include "test_helpers.hpp"
+#include "test_config.hpp"
 
 using namespace duckdb;
 
-namespace duckdb {
-static bool test_force_storage = false;
-static bool test_force_reload = false;
-static bool test_memory_leaks = false;
-
-bool TestForceStorage() {
-	return test_force_storage;
-}
-
-bool TestForceReload() {
-	return test_force_reload;
-}
-
-bool TestMemoryLeaks() {
-	return test_memory_leaks;
-}
-
-} // namespace duckdb
-
-int main(int argc, char *argv[]) {
+int main(int argc_in, char *argv[]) {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
 	string test_directory = DUCKDB_ROOT_DIRECTORY;
 
+	auto &test_config = TestConfiguration::Get();
+	test_config.Initialize();
+
+	idx_t argc = NumericCast<idx_t>(argc_in);
 	int new_argc = 0;
 	auto new_argv = duckdb::unique_ptr<char *[]>(new char *[argc]);
-	for (int i = 0; i < argc; i++) {
-		if (string(argv[i]) == "--force-storage") {
-			test_force_storage = true;
-		} else if (string(argv[i]) == "--force-reload" || string(argv[i]) == "--force-restart") {
-			test_force_reload = true;
-		} else if (StringUtil::StartsWith(string(argv[i]), "--memory-leak") ||
-		           StringUtil::StartsWith(string(argv[i]), "--test-memory-leak")) {
-			test_memory_leaks = true;
-		} else if (string(argv[i]) == "--test-dir") {
+	for (idx_t i = 0; i < argc; i++) {
+		string argument(argv[i]);
+		if (argument == "--test-dir") {
 			test_directory = string(argv[++i]);
-		} else if (string(argv[i]) == "--test-temp-dir") {
+		} else if (argument == "--test-temp-dir") {
 			SetDeleteTestPath(false);
 			auto test_dir = string(argv[++i]);
 			if (fs->DirectoryExists(test_dir)) {
@@ -51,15 +32,9 @@ int main(int argc, char *argv[]) {
 				return 1;
 			}
 			SetTestDirectory(test_dir);
-		} else if (string(argv[i]) == "--require") {
+		} else if (argument == "--require") {
 			AddRequire(string(argv[++i]));
-		} else if (string(argv[i]) == "--zero-initialize") {
-			SetDebugInitialize(0);
-		} else if (string(argv[i]) == "--one-initialize") {
-			SetDebugInitialize(0xFF);
-		} else if (string(argv[i]) == "--single-threaded") {
-			SetSingleThreaded();
-		} else {
+		} else if (!test_config.ParseArgument(argument, argc, argv, i)) {
 			new_argv[new_argc] = argv[i];
 			new_argc++;
 		}
@@ -78,8 +53,22 @@ int main(int argc, char *argv[]) {
 	}
 
 	RegisterSqllogictests();
-
 	int result = Catch::Session().run(new_argc, new_argv.get());
+
+	std::string failures_summary = FailureSummary::GetFailureSummary();
+	if (!failures_summary.empty()) {
+		auto description = test_config.GetDescription();
+		if (!description.empty()) {
+			std::cerr << "\n====================================================" << std::endl;
+			std::cerr << "====================  TEST INFO  ===================" << std::endl;
+			std::cerr << "====================================================\n" << std::endl;
+			std::cerr << description << std::endl;
+		}
+		std::cerr << "\n====================================================" << std::endl;
+		std::cerr << "================  FAILURES SUMMARY  ================" << std::endl;
+		std::cerr << "====================================================\n" << std::endl;
+		std::cerr << failures_summary;
+	}
 
 	if (DeleteTestPath()) {
 		TestDeleteDirectory(dir);


### PR DESCRIPTION
Backported 'Unit Tester Configuration' functionality from https://github.com/duckdb/duckdb/pull/17972

Note that the `FailureSummary` logic introduced in https://github.com/duckdb/duckdb/pull/16833 is also in.
The reason is that https://github.com/duckdb/duckdb/pull/17972 builds on top of that logic.
