### PR TITLE
Reduce copy in Vector::Reinterpret

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -147,10 +147,9 @@ void Vector::ReferenceAndSetType(const Vector &other) {
 
 void Vector::Reinterpret(const Vector &other) {
 	vector_type = other.vector_type;
-#ifdef DEBUG
 	auto &this_type = GetType();
 	auto &other_type = other.GetType();
-
+#ifdef DEBUG
 	auto type_is_same = other_type == this_type;
 	bool this_is_nested = this_type.IsNested();
 	bool other_is_nested = other_type.IsNested();
@@ -163,7 +162,7 @@ void Vector::Reinterpret(const Vector &other) {
 	D_ASSERT((not_nested && type_size_equal) || type_is_same);
 #endif
 	AssignSharedPointer(buffer, other.buffer);
-	if (vector_type == VectorType::DICTIONARY_VECTOR) {
+	if (vector_type == VectorType::DICTIONARY_VECTOR && other_type != this_type) {
 		Vector new_vector(GetType(), nullptr);
 		new_vector.Reinterpret(DictionaryVector::Child(other));
 		auxiliary = make_shared_ptr<VectorChildBuffer>(std::move(new_vector));


### PR DESCRIPTION
#16957 fixed the bug in `Vector::Reinterpret` for dictionary vectors by creating a new child buffer every time. However, creating a new child buffer is much more expensive than copying a shared_ptr, which results in about 3% performance regression in TPC-H benchmarks.

The main issue is that a dictionary vector cannot directly copy the child buffer if the types don't match, as this would make the child vector's type inconsistent. So we can check whether the types are different and only create a new child buffer when the types are not equal - which isn't the case in most scenarios. 

benchmark result:
```
python scripts/regression/test_runner.py --old build/release-old/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/tpch.csv --threads 2
Old timing geometric mean: 0.02501917589777838
New timing geometric mean: 0.024095980407583723, roughly 3% faster

python scripts/regression/test_runner.py --old build/release-old/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/tpcds.csv --threads 2
Old timing geometric mean: 0.021899101352704627
New timing geometric mean: 0.021254155592682008, roughly 2% faster
```