### PR TITLE
Bump vcpkg-duckdb-ports to solve OSX linking

### DIFF
--- a/scripts/merge_vcpkg_deps.py
+++ b/scripts/merge_vcpkg_deps.py
@@ -68,7 +68,7 @@ if merged_overlay_ports:
 else:
     data['vcpkg-configuration'] = {}
 
-REGISTRY_BASELINE = '4b058f01326c786934daef7fe81c93f7d32bec4a'
+REGISTRY_BASELINE = '43e8fec50b84e68d1731ff265564084e193cba16'
 # NOTE: use 'scripts/list_vcpkg_registry_packages.py --baseline <baseline>' to generate the list of packages
 data['vcpkg-configuration']['registries'] = [
     {


### PR DESCRIPTION
Tested locally with:
```
OSX_BUILD_UNIVERSAL=1 VCPKG_TOOLCHAIN_PATH=/Users/carlo/vcpkg/scripts/buildsystems/vcpkg.cmake USE_MERGED_VCPKG_MANIFEST=1 CORE_EXTENSIONS="avro" GEN=ninja make
```
on `v1.3-ossivalis` or with this commit in.

Difference is that a bunch of lines like:
```
ld: warning: object file (/Users/carlo/duckdb_main_clone/build/release/vcpkg_installed/arm64-osx/lib/libavro.a[2](allocation.c.o)) was built for newer 'macOS' version (15.0) than being linked (11.0)
ld: warning: object file (/Users/carlo/duckdb_main_clone/build/release/vcpkg_installed/arm64-osx/lib/libavro.a[3](array.c.o)) was built for newer 'macOS' version (15.0) than being linked (11.0)
ld: warning: object file (/Users/carlo/duckdb_main_clone/build/release/vcpkg_installed/arm64-osx/lib/libavro.a[4](codec.c.o)) was built for newer 'macOS' version (15.0) than being linked (11.0)
```
will (rightly) not be there anymore, meaning the vcpkg dependencies have been built with correct target option taken from https://github.com/duckdb/vcpkg-duckdb-ports/commit/43e8fec50b84e68d1731ff265564084e193cba16