### PR TITLE
[Parquet][Write] Fix timestamp sec writes to parquet

### DIFF
--- a/extension/parquet/include/writer/templated_column_writer.hpp
+++ b/extension/parquet/include/writer/templated_column_writer.hpp
@@ -20,8 +20,9 @@ namespace duckdb {
 template <class SRC, class TGT, class OP = ParquetCastOperator, bool ALL_VALID>
 static void TemplatedWritePlain(Vector &col, ColumnWriterStatistics *stats, const idx_t chunk_start,
                                 const idx_t chunk_end, const ValidityMask &mask, WriteStream &ser) {
-	static constexpr bool COPY_DIRECTLY_FROM_VECTOR =
-	    ALL_VALID && std::is_same<SRC, TGT>::value && std::is_arithmetic<TGT>::value;
+	static constexpr bool COPY_DIRECTLY_FROM_VECTOR = ALL_VALID && std::is_same<SRC, TGT>::value &&
+	                                                  std::is_arithmetic<TGT>::value &&
+	                                                  std::is_same<OP, ParquetCastOperator>::value;
 
 	const auto *const ptr = FlatVector::GetData<SRC>(col);
 

--- a/test/sql/copy/parquet/timestamp_s.test
+++ b/test/sql/copy/parquet/timestamp_s.test
@@ -1,0 +1,38 @@
+# name: test/sql/copy/parquet/timestamp_s.test
+# group: [parquet]
+
+require parquet
+
+statement ok
+create table t (ts TIMESTAMP_S);
+
+# Populate with timestamps 6 minutes apart, just to produce some mock data
+statement ok
+insert into t select make_timestamp((1706961600 + (360 * i))::BIGINT * 1000000) from range(10000) range(i);
+
+query I
+select * from t limit 3;
+----
+2024-02-03 12:00:00
+2024-02-03 12:06:00
+2024-02-03 12:12:00
+
+statement ok
+copy (select * from t) to '__TEST_DIR__/t.parquet' (format parquet);
+
+query I
+select * from '__TEST_DIR__/t.parquet' limit 3;
+----
+2024-02-03 12:00:00
+2024-02-03 12:06:00
+2024-02-03 12:12:00
+
+statement ok
+copy (select * from t) to '__TEST_DIR__/t.parquet' (format parquet);
+
+query I
+select * from '__TEST_DIR__/t.parquet' limit 3;
+----
+2024-02-03 12:00:00
+2024-02-03 12:06:00
+2024-02-03 12:12:00


### PR DESCRIPTION
This PR fixes #18248

Since `timestamp_sec_t` and `timestamp_t` both use `int64_t` under the hood, this set the `COPY_DIRECTLY_FROM_VECTOR` to true, which caused it to skip the `OP` that is provided to convert from seconds to microseconds.
```c++
	case LogicalTypeId::TIMESTAMP_SEC:
		return make_uniq<StandardColumnWriter<int64_t, int64_t, ParquetTimestampSOperator>>(
		    writer, schema, std::move(path_in_schema), can_have_nulls);
```

Now we add the additional requirement for `COPY_DIRECTLY_FROM_VECTOR` that the `OP` has to be a no-op (ParquetCastOperator)


There are a couple other conversions affected, that are presumably wrong currently:
```c++
class WKBColumnWriter final : public StandardColumnWriter<string_t, string_t, ParquetStringOperator> {
public:
	WKBColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema, vector<string> schema_path_p,
	                bool can_have_nulls, string name)
	    : StandardColumnWriter(writer, column_schema, std::move(schema_path_p), can_have_nulls),
	      column_name(std::move(name)) {

		this->writer.GetGeoParquetData().RegisterGeometryColumn(column_name);
	}
```

```c++
	case LogicalTypeId::TIMESTAMP_NS:
		return make_uniq<StandardColumnWriter<int64_t, int64_t, ParquetTimestampNSOperator>>(
		    writer, schema, std::move(path_in_schema), can_have_nulls);
```

(this is probably not wrong, and might be slower now?)
```c++
	case LogicalTypeId::BLOB:
		return make_uniq<StandardColumnWriter<string_t, string_t, ParquetBlobOperator>>(
		    writer, schema, std::move(path_in_schema), can_have_nulls);
	case LogicalTypeId::VARCHAR:
		return make_uniq<StandardColumnWriter<string_t, string_t, ParquetStringOperator>>(
		    writer, schema, std::move(path_in_schema), can_have_nulls);
```

Hmm I guess the `WKBColumnWriter` is not wrong either, we could extend the check to include the `ParquetStringOperator` and `ParquetBlobOperator` as the "no-op" operators?