### PR TITLE
[Arrow] Fix unused static function warning

### DIFF
--- a/src/common/arrow/appender/CMakeLists.txt
+++ b/src/common/arrow/appender/CMakeLists.txt
@@ -5,7 +5,8 @@ add_library_unity(
   fixed_size_list_data.cpp
   null_data.cpp
   struct_data.cpp
-  union_data.cpp)
+  union_data.cpp
+  append_data.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_common_arrow_appender>
     PARENT_SCOPE)

--- a/src/common/arrow/appender/append_data.cpp
+++ b/src/common/arrow/appender/append_data.cpp
@@ -1,0 +1,29 @@
+#include "duckdb/common/arrow/appender/append_data.hpp"
+
+namespace duckdb {
+
+void ArrowAppendData::AppendValidity(UnifiedVectorFormat &format, idx_t from, idx_t to) {
+	// resize the buffer, filling the validity buffer with all valid values
+	idx_t size = to - from;
+	ResizeValidity(GetValidityBuffer(), row_count + size);
+	if (format.validity.AllValid()) {
+		// if all values are valid we don't need to do anything else
+		return;
+	}
+
+	// otherwise we iterate through the validity mask
+	auto validity_data = (uint8_t *)GetValidityBuffer().data();
+	uint8_t current_bit;
+	idx_t current_byte;
+	GetBitPosition(row_count, current_byte, current_bit);
+	for (idx_t i = from; i < to; i++) {
+		auto source_idx = format.sel->get_index(i);
+		// append the validity mask
+		if (!format.validity.RowIsValid(source_idx)) {
+			SetNull(validity_data, current_byte, current_bit);
+		}
+		NextBit(current_byte, current_bit);
+	}
+}
+
+} // namespace duckdb

--- a/src/common/arrow/appender/bool_data.cpp
+++ b/src/common/arrow/appender/bool_data.cpp
@@ -6,7 +6,6 @@ namespace duckdb {
 void ArrowBoolData::Initialize(ArrowAppendData &result, const LogicalType &type, idx_t capacity) {
 	auto byte_count = (capacity + 7) / 8;
 	result.GetMainBuffer().reserve(byte_count);
-	(void)AppendValidity; // silence a compiler warning about unused static function
 }
 
 void ArrowBoolData::Append(ArrowAppendData &append_data, Vector &input, idx_t from, idx_t to, idx_t input_size) {
@@ -16,24 +15,24 @@ void ArrowBoolData::Append(ArrowAppendData &append_data, Vector &input, idx_t fr
 	auto &main_buffer = append_data.GetMainBuffer();
 	auto &validity_buffer = append_data.GetValidityBuffer();
 	// we initialize both the validity and the bit set to 1's
-	ResizeValidity(validity_buffer, append_data.row_count + size);
-	ResizeValidity(main_buffer, append_data.row_count + size);
+	ArrowAppendData::ResizeValidity(validity_buffer, append_data.row_count + size);
+	ArrowAppendData::ResizeValidity(main_buffer, append_data.row_count + size);
 	auto data = UnifiedVectorFormat::GetData<bool>(format);
 
 	auto result_data = main_buffer.GetData<uint8_t>();
 	auto validity_data = validity_buffer.GetData<uint8_t>();
 	uint8_t current_bit;
 	idx_t current_byte;
-	GetBitPosition(append_data.row_count, current_byte, current_bit);
+	ArrowAppendData::GetBitPosition(append_data.row_count, current_byte, current_bit);
 	for (idx_t i = from; i < to; i++) {
 		auto source_idx = format.sel->get_index(i);
 		// append the validity mask
 		if (!format.validity.RowIsValid(source_idx)) {
-			SetNull(append_data, validity_data, current_byte, current_bit);
+			append_data.SetNull(validity_data, current_byte, current_bit);
 		} else if (!data[source_idx]) {
-			UnsetBit(result_data, current_byte, current_bit);
+			ArrowAppendData::UnsetBit(result_data, current_byte, current_bit);
 		}
-		NextBit(current_byte, current_bit);
+		ArrowAppendData::NextBit(current_byte, current_bit);
 	}
 	append_data.row_count += size;
 }

--- a/src/common/arrow/appender/fixed_size_list_data.cpp
+++ b/src/common/arrow/appender/fixed_size_list_data.cpp
@@ -18,7 +18,7 @@ void ArrowFixedSizeListData::Append(ArrowAppendData &append_data, Vector &input,
 	UnifiedVectorFormat format;
 	input.ToUnifiedFormat(input_size, format);
 	idx_t size = to - from;
-	AppendValidity(append_data, format, from, to);
+	append_data.AppendValidity(format, from, to);
 	input.Flatten(input_size);
 	auto array_size = ArrayType::GetSize(input.GetType());
 	auto &child_vector = ArrayVector::GetEntry(input);

--- a/src/common/arrow/appender/struct_data.cpp
+++ b/src/common/arrow/appender/struct_data.cpp
@@ -18,7 +18,7 @@ void ArrowStructData::Append(ArrowAppendData &append_data, Vector &input, idx_t 
 	UnifiedVectorFormat format;
 	input.ToUnifiedFormat(input_size, format);
 	idx_t size = to - from;
-	AppendValidity(append_data, format, from, to);
+	append_data.AppendValidity(format, from, to);
 	// append the children of the struct
 	auto &children = StructVector::GetEntries(input);
 	for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {

--- a/src/common/arrow/appender/union_data.cpp
+++ b/src/common/arrow/appender/union_data.cpp
@@ -14,7 +14,6 @@ void ArrowUnionData::Initialize(ArrowAppendData &result, const LogicalType &type
 		auto child_buffer = ArrowAppender::InitializeChild(child.second, capacity, result.options);
 		result.child_data.push_back(std::move(child_buffer));
 	}
-	(void)AppendValidity; // silence a compiler warning about unused static functiondep
 }
 
 void ArrowUnionData::Append(ArrowAppendData &append_data, Vector &input, idx_t from, idx_t to, idx_t input_size) {

--- a/src/include/duckdb/common/arrow/appender/append_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/append_data.hpp
@@ -42,6 +42,7 @@ struct ArrowAppendData {
 		arrow_buffers.resize(3);
 	}
 
+public:
 	//! Getters for the Buffers
 	ArrowBuffer &GetValidityBuffer() {
 		return arrow_buffers[0];
@@ -63,6 +64,36 @@ struct ArrowAppendData {
 		return arrow_buffers[3];
 	}
 
+public:
+	static void GetBitPosition(idx_t row_idx, idx_t &current_byte, uint8_t &current_bit) {
+		current_byte = row_idx / 8;
+		current_bit = row_idx % 8;
+	}
+
+	static void UnsetBit(uint8_t *data, idx_t current_byte, uint8_t current_bit) {
+		data[current_byte] &= ~((uint64_t)1 << current_bit);
+	}
+
+	static void NextBit(idx_t &current_byte, uint8_t &current_bit) {
+		current_bit++;
+		if (current_bit == 8) {
+			current_byte++;
+			current_bit = 0;
+		}
+	}
+
+	static void ResizeValidity(ArrowBuffer &buffer, idx_t row_count) {
+		auto byte_count = (row_count + 7) / 8;
+		buffer.resize(byte_count, 0xFF);
+	}
+
+	void SetNull(uint8_t *validity_data, idx_t current_byte, uint8_t current_bit) {
+		UnsetBit(validity_data, current_byte, current_bit);
+		null_count++;
+	}
+	void AppendValidity(UnifiedVectorFormat &format, idx_t from, idx_t to);
+
+public:
 	idx_t row_count = 0;
 	idx_t null_count = 0;
 
@@ -92,60 +123,5 @@ private:
 	//! The buffers of the arrow vector
 	vector<ArrowBuffer> arrow_buffers;
 };
-
-//===--------------------------------------------------------------------===//
-// Append Helper Functions
-//===--------------------------------------------------------------------===//
-
-static void GetBitPosition(idx_t row_idx, idx_t &current_byte, uint8_t &current_bit) {
-	current_byte = row_idx / 8;
-	current_bit = row_idx % 8;
-}
-
-static void UnsetBit(uint8_t *data, idx_t current_byte, uint8_t current_bit) {
-	data[current_byte] &= ~((uint64_t)1 << current_bit);
-}
-
-static void NextBit(idx_t &current_byte, uint8_t &current_bit) {
-	current_bit++;
-	if (current_bit == 8) {
-		current_byte++;
-		current_bit = 0;
-	}
-}
-
-static void ResizeValidity(ArrowBuffer &buffer, idx_t row_count) {
-	auto byte_count = (row_count + 7) / 8;
-	buffer.resize(byte_count, 0xFF);
-}
-
-static void SetNull(ArrowAppendData &append_data, uint8_t *validity_data, idx_t current_byte, uint8_t current_bit) {
-	UnsetBit(validity_data, current_byte, current_bit);
-	append_data.null_count++;
-}
-
-static void AppendValidity(ArrowAppendData &append_data, UnifiedVectorFormat &format, idx_t from, idx_t to) {
-	// resize the buffer, filling the validity buffer with all valid values
-	idx_t size = to - from;
-	ResizeValidity(append_data.GetValidityBuffer(), append_data.row_count + size);
-	if (format.validity.AllValid()) {
-		// if all values are valid we don't need to do anything else
-		return;
-	}
-
-	// otherwise we iterate through the validity mask
-	auto validity_data = (uint8_t *)append_data.GetValidityBuffer().data();
-	uint8_t current_bit;
-	idx_t current_byte;
-	GetBitPosition(append_data.row_count, current_byte, current_bit);
-	for (idx_t i = from; i < to; i++) {
-		auto source_idx = format.sel->get_index(i);
-		// append the validity mask
-		if (!format.validity.RowIsValid(source_idx)) {
-			SetNull(append_data, validity_data, current_byte, current_bit);
-		}
-		NextBit(current_byte, current_bit);
-	}
-}
 
 } // namespace duckdb

--- a/src/include/duckdb/common/arrow/appender/enum_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/enum_data.hpp
@@ -35,7 +35,7 @@ struct ArrowEnumData : public ArrowScalarBaseData<TGT> {
 		auto &main_buffer = append_data.GetMainBuffer();
 		auto &aux_buffer = append_data.GetAuxBuffer();
 		// resize the validity mask and set up the validity buffer for iteration
-		ResizeValidity(append_data.GetValidityBuffer(), append_data.row_count + size);
+		ArrowAppendData::ResizeValidity(append_data.GetValidityBuffer(), append_data.row_count + size);
 
 		// resize the offset buffer - the offset buffer holds the offsets into the child array
 		main_buffer.resize(main_buffer.size() + sizeof(int32_t) * (size + 1));

--- a/src/include/duckdb/common/arrow/appender/list_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/list_data.hpp
@@ -28,7 +28,7 @@ public:
 		input.ToUnifiedFormat(input_size, format);
 		idx_t size = to - from;
 		vector<sel_t> child_indices;
-		AppendValidity(append_data, format, from, to);
+		append_data.AppendValidity(format, from, to);
 		AppendOffsets(append_data, format, from, to, child_indices);
 
 		// append the child vector of the list

--- a/src/include/duckdb/common/arrow/appender/list_view_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/list_view_data.hpp
@@ -30,7 +30,7 @@ public:
 		input.ToUnifiedFormat(input_size, format);
 		idx_t size = to - from;
 		vector<sel_t> child_indices;
-		AppendValidity(append_data, format, from, to);
+		append_data.AppendValidity(format, from, to);
 		AppendListMetadata(append_data, format, from, to, child_indices);
 
 		// append the child vector of the list

--- a/src/include/duckdb/common/arrow/appender/map_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/map_data.hpp
@@ -39,7 +39,7 @@ public:
 		UnifiedVectorFormat format;
 		input.ToUnifiedFormat(input_size, format);
 		idx_t size = to - from;
-		AppendValidity(append_data, format, from, to);
+		append_data.AppendValidity(format, from, to);
 		vector<sel_t> child_indices;
 		ArrowListData<BUFTYPE>::AppendOffsets(append_data, format, from, to, child_indices);
 

--- a/src/include/duckdb/common/arrow/appender/scalar_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/scalar_data.hpp
@@ -96,7 +96,7 @@ struct ArrowScalarBaseData {
 		input.ToUnifiedFormat(input_size, format);
 
 		// append the validity mask
-		AppendValidity(append_data, format, from, to);
+		append_data.AppendValidity(format, from, to);
 
 		// append the main data
 		auto &main_buffer = append_data.GetMainBuffer();

--- a/src/include/duckdb/common/arrow/appender/varchar_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/varchar_data.hpp
@@ -59,7 +59,7 @@ struct ArrowVarcharData {
 		auto &aux_buffer = append_data.GetAuxBuffer();
 
 		// resize the validity mask and set up the validity buffer for iteration
-		ResizeValidity(validity_buffer, append_data.row_count + size);
+		ArrowAppendData::ResizeValidity(validity_buffer, append_data.row_count + size);
 		auto validity_data = (uint8_t *)validity_buffer.data();
 
 		// resize the offset buffer - the offset buffer holds the offsets into the child array
@@ -80,8 +80,8 @@ struct ArrowVarcharData {
 			if (!format.validity.RowIsValid(source_idx)) {
 				uint8_t current_bit;
 				idx_t current_byte;
-				GetBitPosition(append_data.row_count + i - from, current_byte, current_bit);
-				SetNull(append_data, validity_data, current_byte, current_bit);
+				ArrowAppendData::GetBitPosition(append_data.row_count + i - from, current_byte, current_bit);
+				append_data.SetNull(validity_data, current_byte, current_bit);
 				offset_data[offset_idx] = last_offset;
 				continue;
 			}
@@ -141,7 +141,7 @@ struct ArrowVarcharToStringViewData {
 		auto &validity_buffer = append_data.GetValidityBuffer();
 		auto &aux_buffer = append_data.GetAuxBuffer();
 		// resize the validity mask and set up the validity buffer for iteration
-		ResizeValidity(validity_buffer, append_data.row_count + size);
+		ArrowAppendData::ResizeValidity(validity_buffer, append_data.row_count + size);
 		auto validity_data = (uint8_t *)validity_buffer.data();
 
 		main_buffer.resize(main_buffer.size() + sizeof(arrow_string_view_t) * (size));
@@ -155,8 +155,8 @@ struct ArrowVarcharToStringViewData {
 				// Null value
 				uint8_t current_bit;
 				idx_t current_byte;
-				GetBitPosition(result_idx, current_byte, current_bit);
-				SetNull(append_data, validity_data, current_byte, current_bit);
+				ArrowAppendData::GetBitPosition(result_idx, current_byte, current_bit);
+				append_data.SetNull(validity_data, current_byte, current_bit);
 				// We have to set these bytes to 0, for some reason
 				arrow_data[result_idx] = arrow_string_view_t(0, "");
 				continue;


### PR DESCRIPTION
We defined these methods as `static` in the header, causing them to be duplicated across every translation unit it's included into.

I've moved these to the `ArrowAppendData` struct and made `SetNull` and `AppendValidity` no longer static (because they received an `ArrowAppendData` as their first argument.