### PR TITLE
[Unittester] Add autoloading option

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -276,7 +276,7 @@ jobs:
 
  linux-httpfs:
     name: Linux HTTPFS
-    needs: force-storage
+    needs: linux-configs
     runs-on: ubuntu-22.04
     env:
       CORE_EXTENSIONS: "json;parquet;tpch;tpcds;httpfs"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ FORCE_WARN_UNUSED_FLAG ?=
 DISABLE_UNITY_FLAG ?=
 DISABLE_SANITIZER_FLAG ?=
 FORCE_32_BIT_FLAG ?=
+CONFIGS_DIR = ./test/configs
+
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJ_DIR := $(dir $(MKFILE_PATH))
@@ -475,6 +477,10 @@ format-main:
 
 format-feature:
 	python3 scripts/format.py feature --fix --noconfirm
+
+format-configs:
+	$(foreach file, $(wildcard $(CONFIGS_DIR)/*), jq . < "$(file)" > "$(file).tmp" && mv "$(file).tmp" "$(file)" ;)
+
 
 third_party/sqllogictest:
 	git clone --depth=1 --branch hawkfish-statistical-rounding https://github.com/duckdb/sqllogictest.git third_party/sqllogictest

--- a/test/extension/autoloading_copy_function.test
+++ b/test/extension/autoloading_copy_function.test
@@ -2,9 +2,11 @@
 # description: Tests for autoloading with copy functions
 # group: [extension]
 
-# This test assumes icu and json to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
+# This test assumes parquet to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO
+
+require parquet
 
 # Ensure we have a clean extension directory without any preinstalled extensions
 statement ok
@@ -17,7 +19,7 @@ set autoload_known_extensions=false
 statement ok
 set autoinstall_known_extensions=false
 
-statement error
+statement maybe
 copy (select 1337 as edgy_hacker_number) TO '__TEST_DIR__/test1337.parquet'
 ----
 Catalog Error: Copy Function with name "parquet" is not in the catalog, but it exists in the parquet extension.

--- a/test/extension/autoloading_types.test
+++ b/test/extension/autoloading_types.test
@@ -6,6 +6,10 @@
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO
 
+require json
+
+require icu
+
 # Ensure we have a clean extension directory without any preinstalled extensions
 statement ok
 set extension_directory='__TEST_DIR__/autoloading_types'
@@ -17,7 +21,7 @@ set autoload_known_extensions=false
 statement ok
 set autoinstall_known_extensions=false
 
-statement error
+statement maybe
 SELECT '{}'::JSON;
 ----
 Catalog Error: Type with name "JSON" is not in the catalog, but it exists in the json extension.

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -31,6 +31,7 @@ static const TestConfigOption test_config_options[] = {
     {"test_memory_leaks", "Run memory leak tests", LogicalType::BOOLEAN, nullptr},
     {"verify_vector", "Run vector verification for a specific vector type", LogicalType::VARCHAR, nullptr},
     {"debug_initialize", "Initialize buffers with all 0 or all 1", LogicalType::VARCHAR, nullptr},
+    {"autoloading", "Loading strategy for extensions not bundled in", LogicalType::VARCHAR, nullptr},
     {"init_script", "Script to execute on init", LogicalType::VARCHAR, TestConfiguration::ParseConnectScript},
     {"on_init", "SQL statements to execute on init", LogicalType::VARCHAR, nullptr},
     {"on_load", "SQL statements to execute on explicit load", LogicalType::VARCHAR, nullptr},
@@ -167,8 +168,20 @@ void TestConfiguration::ParseOption(const string &name, const Value &value) {
 	}
 }
 
-bool TestConfiguration::ShouldSkipTest(const string &test) {
-	return tests_to_be_skipped.count(test);
+TestConfiguration::ExtensionAutoLoadingMode TestConfiguration::GetExtensionAutoLoadingMode() {
+	string res = StringUtil::Lower(GetOptionOrDefault("autoloading", string("default")));
+	if (res == "none") {
+		return TestConfiguration::ExtensionAutoLoadingMode::NONE;
+	} else if (res == "available" || res == "default") {
+		return TestConfiguration::ExtensionAutoLoadingMode::AVAILABLE;
+	} else if (res == "all") {
+		return TestConfiguration::ExtensionAutoLoadingMode::ALL;
+	}
+	throw std::runtime_error("Unknown autoloading mode");
+}
+
+bool TestConfiguration::ShouldSkipTest(const string &test_name) {
+	return tests_to_be_skipped.count(test_name);
 }
 
 string TestConfiguration::OnInitCommand() {

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -170,9 +170,9 @@ void TestConfiguration::ParseOption(const string &name, const Value &value) {
 
 TestConfiguration::ExtensionAutoLoadingMode TestConfiguration::GetExtensionAutoLoadingMode() {
 	string res = StringUtil::Lower(GetOptionOrDefault("autoloading", string("default")));
-	if (res == "none") {
+	if (res == "none" || res == "default") {
 		return TestConfiguration::ExtensionAutoLoadingMode::NONE;
-	} else if (res == "available" || res == "default") {
+	} else if (res == "available") {
 		return TestConfiguration::ExtensionAutoLoadingMode::AVAILABLE;
 	} else if (res == "all") {
 		return TestConfiguration::ExtensionAutoLoadingMode::ALL;

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -21,6 +21,8 @@ namespace duckdb {
 
 class TestConfiguration {
 public:
+	enum class ExtensionAutoLoadingMode { NONE = 0, AVAILABLE = 1, ALL = 2 };
+
 	static TestConfiguration &Get();
 
 	void Initialize();
@@ -42,6 +44,7 @@ public:
 	bool GetSkipCompiledTests();
 	DebugVectorVerification GetVectorVerification();
 	DebugInitialize GetDebugInitialize();
+	ExtensionAutoLoadingMode GetExtensionAutoLoadingMode();
 	bool ShouldSkipTest(const string &test_name);
 	string OnInitCommand();
 	string OnLoadCommand();

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -604,6 +604,10 @@ RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vec
 			return RequireResult::MISSING;
 		}
 	} else if (excluded_from_autoloading) {
+		if (autoloading_mode == TestConfiguration::ExtensionAutoLoadingMode::NONE) {
+			// This is needed to still support LOCAL_EXTENSION_REPO
+			return RequireResult::MISSING;
+		}
 		perform_install = true;
 		perform_load = true;
 	} else if (autoinstall_is_checked) {

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -1010,7 +1010,15 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			}
 
 			auto env_var = token.parameters[0];
-			auto env_actual = std::getenv(env_var.c_str());
+			const char *env_actual = std::getenv(env_var.c_str());
+			string default_local_repo = string(DUCKDB_BUILD_DIRECTORY) + "/repository";
+			if (env_actual == nullptr && env_var == "LOCAL_EXTENSION_REPO" &&
+			    config->options.autoload_known_extensions) {
+				// Overriding LOCAL_EXTENSION_REPO here is a hacky
+				// More proper solution is wrapping std::getenv in a duckdb::test_getenv, and having a way to inject env
+				// variables
+				env_actual = default_local_repo.c_str();
+			}
 			if (env_actual == nullptr) {
 				// Environment variable was not found, this test should not be run
 				SKIP_TEST("require-env " + token.parameters[0]);

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -30,6 +30,7 @@ SQLLogicTestRunner::SQLLogicTestRunner(string dbpath) : dbpath(std::move(dbpath)
 	config->options.autoinstall_known_extensions = false;
 	config->options.allow_unsigned_extensions = true;
 	local_extension_repo = "";
+	autoinstall_is_checked = false;
 
 	switch (autoloading_mode) {
 	case TestConfiguration::ExtensionAutoLoadingMode::NONE: {
@@ -52,6 +53,7 @@ SQLLogicTestRunner::SQLLogicTestRunner(string dbpath) : dbpath(std::move(dbpath)
 	if (env_var) {
 		local_extension_repo = env_var;
 		config->options.autoload_known_extensions = true;
+		config->options.autoinstall_known_extensions = true;
 	} else if (config->options.autoload_known_extensions) {
 		local_extension_repo = string(DUCKDB_BUILD_DIRECTORY) + "/repository";
 	}
@@ -610,7 +612,7 @@ RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vec
 		}
 		perform_install = true;
 		perform_load = true;
-	} else if (autoinstall_is_checked) {
+	} else if (autoloading_mode != TestConfiguration::ExtensionAutoLoadingMode::NONE && autoinstall_is_checked) {
 		perform_install = true;
 	}
 	if (perform_install) {

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -11,6 +11,7 @@
 #include "duckdb.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "sqllogic_command.hpp"
+#include "test_config.hpp"
 
 namespace duckdb {
 
@@ -46,6 +47,8 @@ public:
 	bool skip_reload = false;
 	unordered_map<string, string> environment_variables;
 	string local_extension_repo;
+	TestConfiguration::ExtensionAutoLoadingMode autoloading_mode;
+	bool autoinstall_is_checked;
 
 	// If these error msgs occur in a test, the test will abort but still count as passed
 	unordered_set<string> ignore_error_messages = {"HTTP", "Unable to connect"};


### PR DESCRIPTION
This is https://github.com/duckdb/duckdb/pull/18266 on `v1.3-ossivalis`, plus fix from https://github.com/duckdb/duckdb/pull/18289.
This is a stripped down version of https://github.com/duckdb/duckdb/pull/18230, that adds support for `--autoloading none|available|all` to unittester, without removing support for previous mode (via env variable `LOCAL_EXTENSION_REPO`). Keeping both possibility in place is somehow less nice, but has the big advantage that can disentangle fixing issues connected to rolling-in this in CI and allows for easier backport of this if deemed useful.

After this PR, the following modes are available for running unittester:

#### `--autoloading none` or `` (this is the default)
Same as current default, only statically linked extensions are ever used.
`require` in test will run a test only if the needed extension is statically linked-in.

#### `LOCAL_EXTENSION_REPO=path/to/repo`
This stays as now.
`LOCAL_EXTENSION_REPO` points to the repository folder.
`require` in tests will run a test only if the needed extension is statically linked-in OR if the extension is autoloadable
No checks are performed, so setting LOCAL_EXTENSION_REPO will fail tests at runtime where a given extension is not present on the local machine.

#### `--autoloading available`
This is similar to the previous, but:
If defined `LOCAL_EXTENSION_REPO` points to the repository folder, otherwise `build/$BUILD_MODE/repository` will be used (the default where builds place extensions)
`require` in tests will run a test only if:
* the needed extension is statically linked-in
* OR if the extension is autoloadable and available (in this case INSTALL will be performed on require, LOAD via autoloading)
* OR if the extension is not autoloadable and available (in this case both INSTALL and LOAD to be performed on require)

#### `--autoloading all`
This is similar to the previous with regard to `LOCAL_EXTENSION_REPO`
`require` in tests will run a test always:
* if the extension is autoloadable, both INSTALL and LOAD to happen at runtime
* if the extension is not autoloadable, both INSTALL and LOAD to be performed on `require`
This mode require either to have a complete set of extensions or pre-filtering the tests to be executed, since `require aws` with aws extension not available will be a test failure.

An interesting usage for `--autoloading all` is paired with setting `LOCAL_EXTENSION_REPO=http://extensions.duckdb.org`, since this will correspond to use the remote available extensions (if there).

---

Limitation of current PR:
* information about whether a PR is statically linked in is implied from the fact that a given extension can be installed, and NOT from the list of statically linked in extensions. This can be improved on.
* this is currently not run on CI due to 3 issues:
   * run_tests_one_by_one.py needs to be adapted to take more arguments
   * some `vss` and `spatial` tests needs to be adapted due to missing `requires`
   * this allow easier to backport this PR, if one would find that handy