### PR TITLE
feat: Parquet extension add row_group_compressed_size

### DIFF
--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -200,6 +200,9 @@ void ParquetMetaDataOperatorData::BindMetaData(vector<LogicalType> &return_types
 
 	names.emplace_back("max_is_exact");
 	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("row_group_compressed_bytes");
+	return_types.emplace_back(LogicalType::BIGINT);
 }
 
 static Value ConvertParquetStats(const LogicalType &type, const ParquetColumnSchema &schema_ele, bool stats_is_set,
@@ -349,6 +352,11 @@ void ParquetMetaDataOperatorData::LoadRowGroupMetadata(ClientContext &context, c
 			// max_is_exact, LogicalType::BOOLEAN
 			current_chunk.SetValue(27, count,
 			                       ParquetElementBoolean(stats.is_max_value_exact, stats.__isset.is_max_value_exact));
+
+			// row_group_compressed_bytes
+			current_chunk.SetValue(
+			    28, count,
+			    ParquetElementBigint(row_group.__isset.total_compressed_size, row_group.__isset.total_compressed_size));
 
 			count++;
 			if (count >= STANDARD_VECTOR_SIZE) {

--- a/test/sql/copy/parquet/parquet_stats.test
+++ b/test/sql/copy/parquet/parquet_stats.test
@@ -206,3 +206,14 @@ query II
 select stats_min_value is null c0, stats_max_value is null c1 from parquet_metadata('__TEST_DIR__/test.parquet');
 ----
 false	false
+
+query II
+select row_group_bytes, row_group_compressed_bytes from parquet_metadata('__TEST_DIR__/test.parquet');
+----
+43	NULL
+
+query II
+select row_group_bytes, row_group_compressed_bytes from parquet_metadata('data/parquet-testing/varchar_stats.parquet');
+----
+200	1
+200	1


### PR DESCRIPTION
See https://github.com/duckdb/duckdb/discussions/18288

Currently parquet have `total_compressed_size`, `total_uncompressed_size` for column chunk, and `row_group_bytes` for RowGroup.

The parquet format has a total_compressed_size, see: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L1024 . We can support a `row_group_compressed_bytes`, so that we can acquire the ratio of size by each column used in each rowgroup in a Parquet file