### PR TITLE
Backport #18254

### DIFF
--- a/test/extension/autoloading_base.test
+++ b/test/extension/autoloading_base.test
@@ -2,6 +2,8 @@
 # description: Base tests for the autoloading mechanism for extensions
 # group: [extension]
 
+require httpfs
+
 # This test assumes icu and json to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO

--- a/test/extension/autoloading_current_setting.test
+++ b/test/extension/autoloading_current_setting.test
@@ -6,6 +6,8 @@
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO
 
+require httpfs
+
 statement ok
 set extension_directory='__TEST_DIR__/autoloading_current_setting'
 

--- a/test/extension/autoloading_filesystems.test
+++ b/test/extension/autoloading_filesystems.test
@@ -2,6 +2,8 @@
 # description: Tests for autoloading with filesystems
 # group: [extension]
 
+require httpfs
+
 # This test assumes icu and json to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO

--- a/test/extension/autoloading_load_only.test
+++ b/test/extension/autoloading_load_only.test
@@ -2,6 +2,8 @@
 # description: Tests for autoloading with no autoinstall
 # group: [extension]
 
+require httpfs
+
 # This test assumes icu and json to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO

--- a/test/extension/autoloading_reset_setting.test
+++ b/test/extension/autoloading_reset_setting.test
@@ -2,6 +2,8 @@
 # description: Testing reset setting that lives in an extension that can be autoloaded
 # group: [extension]
 
+require httpfs
+
 # This test assumes httpfs and json to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO

--- a/test/extension/duckdb_extension_settings.test
+++ b/test/extension/duckdb_extension_settings.test
@@ -2,6 +2,8 @@
 # description: settings for extensions
 # group: [extension]
 
+require httpfs
+
 statement ok
 SET autoinstall_known_extensions = true;
 

--- a/test/issues/general/test_16213.test_slow
+++ b/test/issues/general/test_16213.test_slow
@@ -2,6 +2,8 @@
 # description: Issue 16213 - Specific query not finishing since v1.1.0 and filling up all temp disk space
 # group: [general]
 
+require no_extension_autoloading "EXPECTED: ICU casts to Date do not trigger autoloading"
+
 require icu
 
 # replicate date generation in issue, but in SQL

--- a/test/sql/function/list/lambdas/incorrect.test
+++ b/test/sql/function/list/lambdas/incorrect.test
@@ -2,6 +2,8 @@
 # description: Test incorrect usage of the lambda functions
 # group: [lambdas]
 
+require no_extension_autoloading "EXPECTED: This tests is not compatible with JSON extension, that will otherwise be autoloaded"
+
 statement ok
 PRAGMA enable_verification;
 

--- a/test/sql/logging/file_system_logging.test
+++ b/test/sql/logging/file_system_logging.test
@@ -49,7 +49,7 @@ FROM 'https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv'
 query IIII
 SELECT scope, type, log_level, regexp_replace(message, '\"path\":.*test.csv"', '"test.csv"')
 FROM duckdb_logs
-WHERE type = 'FileSystem'
+WHERE type = 'FileSystem' AND message NOT LIKE '%duckdb_extension%'
 ORDER BY timestamp
 ----
 CONNECTION	FileSystem	TRACE	{"fs":"HTTPFileSystem","path":"https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv","op":"OPEN"}

--- a/test/sql/pragma/test_enable_http_logging.test
+++ b/test/sql/pragma/test_enable_http_logging.test
@@ -2,15 +2,15 @@
 # description: Test PRAGMA enable_http_logging parsing
 # group: [pragma]
 
+# select the location of where to save the http logging output (instead of printing to stdout)
+statement error
+SET http_logging_output='__TEST_DIR__/httplog.txt'
+----
+Not implemented Error: This setting is deprecated and can no longer be used. Check out the DuckDB docs on logging for more information
+
 # disable/enable
 statement ok
 SET enable_http_logging=false
 
 statement ok
 SET enable_http_logging=true
-
-# select the location of where to save the http logging output (instead of printing to stdout)
-statement error
-SET http_logging_output='__TEST_DIR__/httplog.txt'
-----
-Not implemented Error: This setting is deprecated and can no longer be used. Check out the DuckDB docs on logging for more information


### PR DESCRIPTION
Backport of https://github.com/duckdb/duckdb/pull/18254, without https://github.com/duckdb/duckdb/pull/18254/commits/4adee1b8c4624eaef6894a6730bb77914c14a4aa (not relevant on 1.3) and adding
https://github.com/duckdb/duckdb/pull/18306/commits/81dbbbf4cd8cb756b3affc0ccabdb6a38f67c815 has been added, 

This should allow for example, after changing a bunch of extensions to DONT_LINK, to do:
```
USE_MERGED_VCPKG_MANIFEST=1 VCPKG_TOOLCHAIN_PATH=/Users/carlo/vcpkg/scripts/buildsystems/vcpkg.cmake CORE_EXTENSIONS="tpch;tpcds;httpfs;icu;json;parquet;autocomplete;httpfs;excel;avro" GEN=ninja make
./build/release/test/unittest --autoloading available "*"
```
to complete successfully like:
```
% ./build/release/test/unittest --autoloading available "*"
Filters: *
[4689/4689] (100%): /Users/carlo/duckdb_main_clone/build/release/_deps/excel_...    
===============================================================================
All tests passed (93 skipped tests, 6275273 assertions in 4596 test cases)

Skipped tests for the following reasons:
require block_size: 2
require exact_vector_size: 2
require inet: 2
require longdouble: 2
require no_extension_autoloading: 36
require spatial: 5
require sqlite_scanner: 2
require windows: 3
require-env HUGGING_FACE_TOKEN: 1
require-env RUN_EXTENSION_UPDATE_TEST: 1
require-env S3_TEST_SERVER_AVAILABLE: 33
require-env TEST_PERSISTENT_SECRETS_AVAILABLE: 2
skip on error_message matching 'HTTP': 1
skip on error_message matching 'Unable to connect': 1
```