### PR TITLE
feat: making Parquet write RowGroup.total_compressed_size

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -989,8 +989,8 @@ const ParquetRowGroup &ParquetReader::GetGroup(ParquetReaderScanState &state) {
 }
 
 uint64_t ParquetReader::GetGroupCompressedSize(ParquetReaderScanState &state) {
-	auto &group = GetGroup(state);
-	auto total_compressed_size = group.total_compressed_size;
+	const auto &group = GetGroup(state);
+	int64_t total_compressed_size = group.__isset.total_compressed_size ? group.total_compressed_size : 0;
 
 	idx_t calc_compressed_size = 0;
 

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -543,12 +543,15 @@ void ParquetWriter::FlushRowGroup(PreparedRowGroup &prepared) {
 	// let's make sure all offsets are ay-okay
 	ValidateColumnOffsets(file_name, writer->GetTotalWritten(), row_group);
 
-	// append the row group to the file meta data
+	row_group.total_compressed_size = NumericCast<int64_t>(writer->GetTotalWritten()) - row_group.file_offset;
+	row_group.__isset.total_compressed_size = true;
+
+	// append the row group to the file metadata
 	file_meta_data.row_groups.push_back(row_group);
 	file_meta_data.num_rows += row_group.num_rows;
 
 	total_written = writer->GetTotalWritten();
-	num_row_groups++;
+	++num_row_groups;
 }
 
 void ParquetWriter::Flush(ColumnDataCollection &buffer) {

--- a/test/sql/copy/parquet/parquet_stats.test
+++ b/test/sql/copy/parquet/parquet_stats.test
@@ -210,7 +210,7 @@ false	false
 query II
 select row_group_bytes, row_group_compressed_bytes from parquet_metadata('__TEST_DIR__/test.parquet');
 ----
-43	NULL
+43	1
 
 query II
 select row_group_bytes, row_group_compressed_bytes from parquet_metadata('data/parquet-testing/varchar_stats.parquet');


### PR DESCRIPTION
This is a followup for https://github.com/duckdb/duckdb/pull/18294

It supports writing RowGroup.total_compressed_size and testing