### PR TITLE
[unittest] - fix doubled error headers on `Unexpected failure`

### DIFF
--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -24,9 +24,12 @@ void SQLLogicTestLogger::LogFailure(const string &log_message) {
 	AppendFailure(log_message);
 }
 
-void SQLLogicTestLogger::Log(const string &str) {
-	std::cerr << str;
-	AppendFailure(str);
+void SQLLogicTestLogger::LogFailureAnnotation(const string header) {
+	const char *ci = std::getenv("CI");
+	// check the value is "true" otherwise you'll see the prefix in local run outputs
+	auto prefix = (ci && string(ci) == "true") ? "\n::error::" : "";
+	std::cerr << prefix << header << std::endl;
+	AppendFailure(header + "\n");
 }
 
 void SQLLogicTestLogger::PrintSummaryHeader(const std::string &file_name) {
@@ -89,7 +92,7 @@ void SQLLogicTestLogger::PrintSQL() {
 			query += ";";
 		}
 	}
-	Log(query + "\n");
+	LogFailure(query + "\n");
 }
 
 void SQLLogicTestLogger::PrintSQLFormatted() {
@@ -128,18 +131,7 @@ void SQLLogicTestLogger::PrintErrorHeader(const string &file_name, idx_t query_l
 	std::ostringstream oss;
 	PrintSummaryHeader(file_name);
 	oss << termcolor::red << termcolor::bold << description << " " << termcolor::reset;
-	if (!file_name.empty()) {
-		oss << termcolor::bold << "(" << file_name << ":" << query_line << ")!" << termcolor::reset;
-	}
-	LogFailure(oss.str() + "\n");
 	LogFailureAnnotation(oss.str());
-}
-
-void SQLLogicTestLogger::LogFailureAnnotation(const string header) {
-	const char *ci = std::getenv("CI");
-	// check the value is "true" otherwise you'll see the prefix in local run outputs
-	auto prefix = (ci && string(ci) == "true") ? "\n::error::" : "";
-	std::cout << prefix << header << std::endl;
 }
 
 void SQLLogicTestLogger::PrintErrorHeader(const string &description) {
@@ -174,7 +166,7 @@ void SQLLogicTestLogger::PrintResultError(MaterializedQueryResult &result, const
 
 void SQLLogicTestLogger::UnexpectedFailure(MaterializedQueryResult &result) {
 	std::ostringstream oss;
-	PrintErrorHeader("Query unexpectedly failed (" + file_name + ":" + to_string(query_line) + ")\n");
+	PrintErrorHeader("Query unexpectedly failed:");
 	LogFailure(oss.str());
 	PrintLineSep();
 	PrintSQL();

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -22,7 +22,6 @@ public:
 	SQLLogicTestLogger(ExecuteContext &context, const Command &command);
 	~SQLLogicTestLogger();
 
-	static void Log(const string &str);
 	void PrintExpectedResult(const vector<string> &values, idx_t columns, bool row_wise);
 	static void PrintLineSep();
 	static void PrintHeader(string header);


### PR DESCRIPTION
When running unit tests locally with `env` `CI=false`, the error header printed twice, like here:
```
1. test/ldbc/ldbc-empty.test
================================================================================
Query unexpectedly failed! (test/ldbc/ldbc-empty.test:427)!
Query unexpectedly failed! (test/ldbc/ldbc-empty.test:427)!
================================================================================
```
It was because we [passed `file_name` and `query_line`](https://github.com/hmeriann/duckdb/blob/641e95d140ca7728085445a919c3e8d436aaf0c1/test/sqlite/sqllogic_test_logger.cpp#L177) to `UnexpectedFailure()` and then [printed the same info twice](https://github.com/hmeriann/duckdb/blob/641e95d140ca7728085445a919c3e8d436aaf0c1/test/sqlite/sqllogic_test_logger.cpp#L132) (because file_name exists);

This PR fixes this behaviour and also removes unused function `Log()` - we use another function `Log()` which is from `FailureSummary` class.