### PR TITLE
Make storage-version a test parameter

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -40,6 +40,7 @@ static const TestConfigOption test_config_options[] = {
     {"skip_error_messages", "Skip compiled tests", LogicalType::LIST(LogicalType::VARCHAR), nullptr},
     {"statically_loaded_extensions", "Extensions to be loaded (from the statically available one)",
      LogicalType::LIST(LogicalType::VARCHAR), nullptr},
+    {"storage_version", "Database storage version to use by default", LogicalType::VARCHAR, nullptr},
     {nullptr, nullptr, LogicalType::INVALID, nullptr},
 };
 
@@ -308,6 +309,10 @@ bool TestConfiguration::GetSummarizeFailures() {
 
 bool TestConfiguration::GetSkipCompiledTests() {
 	return GetOptionOrDefault("skip_compiled", false);
+}
+
+string TestConfiguration::GetStorageVersion() {
+	return GetOptionOrDefault("storage_version", string());
 }
 
 DebugVectorVerification TestConfiguration::GetVectorVerification() {

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -179,6 +179,10 @@ unique_ptr<DBConfig> GetTestConfig() {
 	result->options.trim_free_blocks = true;
 #endif
 	result->options.allow_unsigned_extensions = true;
+	auto storage_version = test_config.GetStorageVersion();
+	if (!storage_version.empty()) {
+		result->options.serialization_compatibility = SerializationCompatibility::FromString(storage_version);
+	}
 
 	auto max_threads = test_config.GetMaxThreads();
 	if (max_threads.IsValid()) {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -48,6 +48,7 @@ public:
 	string OnConnectionCommand();
 	vector<string> ExtensionToBeLoadedOnLoad();
 	vector<string> ErrorMessagesToBeSkipped();
+	string GetStorageVersion();
 
 	static bool TestForceStorage();
 	static bool TestForceReload();


### PR DESCRIPTION
This allows the storage version to be set like so:

```
build/reldebug/test/unittest --storage-version latest
```

This can also be combined with e.g. `--force-storage` and other flags.