### PR TITLE
Python external dispatch param fixes

### DIFF
--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -111,5 +111,5 @@ jobs:
         if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-python/actions/workflows/on_external_dispatch.yml/dispatches
-          export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}", "force_version": "${{ inputs.override-git-describe }}", "publish_packages": ${{ inputs.should-publish }}}}'
+          export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}", "force-version": "${{ inputs.override-git-describe }}", "publish-packages": ${{ inputs.should-publish }}, "commit-duckdb-sha": true}}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"


### PR DESCRIPTION
This commit adds the `commit-duckdb-sha` param that controls whether the duckdb submodule ref will be committed.