### PR TITLE
Fix debug error in join order optimizer

### DIFF
--- a/src/optimizer/join_order/plan_enumerator.cpp
+++ b/src/optimizer/join_order/plan_enumerator.cpp
@@ -68,7 +68,7 @@ static vector<unordered_set<idx_t>> GetAllNeighborSets(vector<idx_t> neighbors) 
 				count += 1;
 			}
 		}
-		D_ASSERT(count == static_cast<size_t>(std::pow(2, neighbors.size()) - 1));
+		D_ASSERT(count == static_cast<size_t>(std::pow(2, neighbors.size() - 1)));
 	}
 #endif
 	return ret;

--- a/test/optimizer/join_reorder_optimizer.test
+++ b/test/optimizer/join_reorder_optimizer.test
@@ -3,31 +3,31 @@
 # group: [optimizer]
 
 statement ok
-CREATE TABLE t1(c1 int, c2 int, c3 int, c4 int)
+CREATE TABLE t1(c1 int, c2 int, c3 int, c4 int);
 
 statement ok
-INSERT INTO t1 VALUES (1, 1, 1, 1)
+INSERT INTO t1 VALUES (1, 1, 1, 1);
 
 statement ok
-INSERT INTO t1 VALUES (1, 1, 1, 1)
+INSERT INTO t1 VALUES (1, 1, 1, 1);
 
 statement ok
-CREATE TABLE t2 AS SELECT * FROM t1
+CREATE TABLE t2 AS SELECT * FROM t1;
 
 statement ok
-INSERT INTO t2 VALUES (1, 1, 1, 1)
+INSERT INTO t2 VALUES (1, 1, 1, 1);
 
 statement ok
-CREATE TABLE t3 AS SELECT * FROM t2
+CREATE TABLE t3 AS SELECT * FROM t2;
 
 statement ok
-INSERT INTO t2 VALUES (1, 1, 1, 1)
+INSERT INTO t2 VALUES (1, 1, 1, 1);
 
 statement ok
-CREATE TABLE t4 AS SELECT * FROM t3
+CREATE TABLE t4 AS SELECT * FROM t3;
 
 statement ok
-INSERT INTO t2 VALUES (1, 1, 1, 1)
+INSERT INTO t2 VALUES (1, 1, 1, 1);
 
 statement ok
 PRAGMA debug_force_no_cross_product=true

--- a/test/optimizer/joins/test_tpcds_pushdown.test
+++ b/test/optimizer/joins/test_tpcds_pushdown.test
@@ -1,0 +1,3 @@
+# name: test/optimizer/joins/test_tpcds_pushdown.test
+# group: [joins]
+


### PR DESCRIPTION
Caused by changes in [this PR](https://github.com/duckdb/duckdb/pull/18257), specifically [this line](https://github.com/duckdb/duckdb/commit/e8459b3348fe0a21e8b7e2191e896355e0a47073#diff-d2a42cfdb50162f51d502a59e9ef37c5cdcf466e59f225b7a7d3457682c2f001R71). The parenthesis were not put in the correct place. 

Fixes https://github.com/duckdblabs/duckdb-internal/issues/5342