### PR TITLE
download Real Nest data in quiet mode

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -189,7 +189,7 @@ jobs:
           mkdir -p duckdb_benchmark_data
           rm -R duckdb/duckdb_benchmark_data
           mkdir -p duckdb/duckdb_benchmark_data
-          wget https://duckdb-blobs.s3.amazonaws.com/data/realnest/realnest.duckdb --output-document=duckdb_benchmark_data/real_nest.duckdb
+          wget -q https://duckdb-blobs.s3.amazonaws.com/data/realnest/realnest.duckdb --output-document=duckdb_benchmark_data/real_nest.duckdb
           cp duckdb_benchmark_data/real_nest.duckdb duckdb/duckdb_benchmark_data/real_nest.duckdb
           python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/realnest.csv --verbose --threads 2
 


### PR DESCRIPTION
As described in https://github.com/duckdblabs/duckdb-internal/issues/5363, we'd like to get rid of wget logs while downloading RealNest data for `Regression.yml`
