### PR TITLE
More robustness around deprecated extension settings

### DIFF
--- a/extension/core_functions/scalar/generic/current_setting.cpp
+++ b/extension/core_functions/scalar/generic/current_setting.cpp
@@ -50,9 +50,11 @@ unique_ptr<FunctionData> CurrentSettingBind(ClientContext &context, ScalarFuncti
 	auto key = StringUtil::Lower(StringValue::Get(key_val));
 	Value val;
 	if (!context.TryGetCurrentSetting(key, val)) {
-		Catalog::AutoloadExtensionByConfigName(context, key);
+		auto extension_name = Catalog::AutoloadExtensionByConfigName(context, key);
 		// If autoloader didn't throw, the config is now available
-		context.TryGetCurrentSetting(key, val);
+		if (!context.TryGetCurrentSetting(key, val)) {
+			throw InternalException("Extension %s did not provide the '%s' config setting", extension_name, key);
+		}
 	}
 
 	bound_function.return_type = val.type();

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -534,14 +534,14 @@ bool Catalog::TryAutoLoad(ClientContext &context, const string &original_name) n
 	return false;
 }
 
-void Catalog::AutoloadExtensionByConfigName(ClientContext &context, const string &configuration_name) {
+string Catalog::AutoloadExtensionByConfigName(ClientContext &context, const string &configuration_name) {
 #ifndef DUCKDB_DISABLE_EXTENSION_LOAD
 	auto &dbconfig = DBConfig::GetConfig(context);
 	if (dbconfig.options.autoload_known_extensions) {
 		auto extension_name = ExtensionHelper::FindExtensionInEntries(configuration_name, EXTENSION_SETTINGS);
 		if (ExtensionHelper::CanAutoloadExtension(extension_name)) {
 			ExtensionHelper::AutoLoadExtension(context, extension_name);
-			return;
+			return extension_name;
 		}
 	}
 #endif

--- a/src/execution/operator/helper/physical_reset.cpp
+++ b/src/execution/operator/helper/physical_reset.cpp
@@ -32,9 +32,13 @@ SourceResultType PhysicalReset::GetData(ExecutionContext &context, DataChunk &ch
 		// check if this is an extra extension variable
 		auto entry = config.extension_parameters.find(name);
 		if (entry == config.extension_parameters.end()) {
-			Catalog::AutoloadExtensionByConfigName(context.client, name);
+			auto extension_name = Catalog::AutoloadExtensionByConfigName(context.client, name);
 			entry = config.extension_parameters.find(name);
-			D_ASSERT(entry != config.extension_parameters.end());
+			if (entry == config.extension_parameters.end()) {
+				// TODO: This is likely to harsh, but given this has a side-effect loaded the extension it should be
+				// somehow brough back to users
+				throw InternalException("Extension %s did not provide the '%s' config setting", extension_name, name);
+			}
 		}
 		ResetExtensionVariable(context, config, entry->second);
 		return SourceResultType::FINISHED;

--- a/src/execution/operator/helper/physical_set.cpp
+++ b/src/execution/operator/helper/physical_set.cpp
@@ -31,9 +31,13 @@ SourceResultType PhysicalSet::GetData(ExecutionContext &context, DataChunk &chun
 		// check if this is an extra extension variable
 		auto entry = config.extension_parameters.find(name);
 		if (entry == config.extension_parameters.end()) {
-			Catalog::AutoloadExtensionByConfigName(context.client, name);
+			auto extension_name = Catalog::AutoloadExtensionByConfigName(context.client, name);
 			entry = config.extension_parameters.find(name);
-			D_ASSERT(entry != config.extension_parameters.end());
+			if (entry == config.extension_parameters.end()) {
+				// TODO: This is likely to harsh, but given this has a side-effect loaded the extension it should be
+				// somehow brough back to users
+				throw InternalException("Extension %s did not provide the '%s' config setting", extension_name, name);
+			}
 		}
 		SetExtensionVariable(context.client, entry->second, name, scope, value);
 		return SourceResultType::FINISHED;

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -369,7 +369,7 @@ public:
 	static CatalogException UnrecognizedConfigurationError(ClientContext &context, const string &name);
 
 	//! Autoload the extension required for `configuration_name` or throw a CatalogException
-	static void AutoloadExtensionByConfigName(ClientContext &context, const string &configuration_name);
+	static string AutoloadExtensionByConfigName(ClientContext &context, const string &configuration_name);
 	//! Autoload the extension required for `function_name` or throw a CatalogException
 	static bool AutoLoadExtensionByCatalogEntry(DatabaseInstance &db, CatalogType type, const string &entry_name);
 	DUCKDB_API static bool TryAutoLoad(ClientContext &context, const string &extension_name) noexcept;


### PR DESCRIPTION
#### Current situation
Mechanism for autoloading setting currently assumes a given extension is stable over time and always provide the same set of settings (or that they grow over time, adding them is fine).
While this is currently true, as far as I am aware, it might not something we want (or can) guarantee moving forward.

Currently, if you were to remove a setting from an extension, compile it from a duckdb version that assumes the setting to be there, and allow autoloading:
```sql
SET autoload_known_extensions = true;
SET some_setting_that_trigger_autoloading_but_not_anymore_in_the_extension = true;
zsh: segmentation fault  ./build/release/duckdb
```
while with assertion enabled it would be caught by:
```c++
D_ASSERT(entry != config.extension_parameters.end());
```

#### Proposed change
This PR turns the assertion in a runtime InternalException, that is strictly better than segfault.

#### Open questions/1: InternalException or InvalidInputException
We could consider move InternalException to InvalidInputException, problem is that executing the SQL still has the side effect of autoinstall / autoloading the extension, so it would be handy to broadcast that to the user (and while InternalException are always rethrown, that's not true for other exception types).

#### Open questions/2: how to test
Code is more or less trivial, problem is that this is very hard to test without extra infrastructure.
What I did locally was compile on a hash where `httpfs` extension was available, so to be able to use default `httpfs` we ship, add a phantom setting via:
```diff
diff --git a/src/include/duckdb/main/extension_entries.hpp b/src/include/duckdb/main/extension_entries.hpp
index f15f9ea62d..b0a611268e 100644
--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1041,6 +1041,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"s3_url_compatibility_mode", "httpfs"},
     {"s3_url_style", "httpfs"},
     {"s3_use_ssl", "httpfs"},
+    {"some_setting", "httpfs"},
     {"sqlite_all_varchar", "sqlite_scanner"},
     {"sqlite_debug_show_queries", "sqlite_scanner"},
     {"timezone", "icu"},
```
and then check behaviour of:
```sql
SET autoload_known_extensions=1;
SET some_setting = true;
```
or
```sql
SET autoload_known_extensions=1;
RESET some_setting;
```