### PR TITLE
Enable stack traces on linux for bundled libraries

### DIFF
--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -188,7 +188,8 @@ jobs:
           -e ENABLE_EXTENSION_AUTOINSTALL=1                                      \
           -e BUILD_BENCHMARK=1                                                   \
           -e FORCE_WARN_UNUSED=1                                                 \
-          quay.io/pypa/manylinux_2_28_${{ matrix.config.image }}                  \
+          -e EXPORT_DYNAMIC_SYMBOLS=1                                            \
+          quay.io/pypa/manylinux_2_28_${{ matrix.config.image }}                 \
           bash -c "
             set -e
             yum install -y perl-IPC-Cmd gcc-toolset-12 gcc-toolset-12-gcc-c++


### PR DESCRIPTION
Not sure if we want to do the same for the main distribution binaries?

Currently, linux stack traces look like this:
```
./dist/myprogram() [0x25c97a6]
./dist/myprogram() [0x25c9864]
./dist/myprogram() [0x25cc6b9]
./dist/myprogram() [0x1e5ee8e]
```

See this PR, which added the flag: https://github.com/duckdb/duckdb/pull/15587

Related issue: https://github.com/duckdblabs/duckdb-internal/issues/5364