### PR TITLE
remove ancient setuptools_scm upper bound

### DIFF
--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
 	"setuptools>=60",
-	"setuptools_scm>=6.4,<8.0",
+	"setuptools_scm>=6.4",
 	"pybind11>=2.6.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The current setup tools constraint is defined as `setuptools_scm>=6.4,<8.0`. The most recent release of setuptools_scm that can meet this constraint is [v7.1.0](https://pypi.org/project/setuptools-scm/7.1.0/) released on Dec 17, 2022. The level of antiquity this constraint imposes on the build system adds to build complexity. Tests pass with `setuptools_scm==8.3.x` so I am not seeing an obvious reason for this archaic upper bound restriction to be necessary.