### PR TITLE
Pass `AttachOptions` to `attach` method, and turn `StorageExtensionInfo` into an `optional_ptr`

### DIFF
--- a/.github/patches/extensions/iceberg/iceberg_loader.patch
+++ b/.github/patches/extensions/iceberg/iceberg_loader.patch
@@ -1,5 +1,5 @@
 diff --git a/src/iceberg_extension.cpp b/src/iceberg_extension.cpp
-index 0b278db..e1f721a 100644
+index 0b278db6..83d26410 100644
 --- a/src/iceberg_extension.cpp
 +++ b/src/iceberg_extension.cpp
 @@ -1,5 +1,3 @@
@@ -17,6 +17,34 @@ index 0b278db..e1f721a 100644
  #include "duckdb/catalog/catalog_entry/macro_catalog_entry.hpp"
  #include "duckdb/catalog/default/default_functions.hpp"
  #include "duckdb/parser/parsed_data/attach_info.hpp"
+@@ -122,9 +120,9 @@ static void GlueAttach(ClientContext &context, IcebergAttachOptions &input) {
+ 
+ //! Base attach method
+ 
+-static unique_ptr<Catalog> IcebergCatalogAttach(StorageExtensionInfo *storage_info, ClientContext &context,
++static unique_ptr<Catalog> IcebergCatalogAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
+                                                 AttachedDatabase &db, const string &name, AttachInfo &info,
+-                                                AccessMode access_mode) {
++                                                AttachOptions &options) {
+ 	IRCEndpointBuilder endpoint_builder;
+ 
+ 	string endpoint_type_string;
+@@ -213,13 +211,13 @@ static unique_ptr<Catalog> IcebergCatalogAttach(StorageExtensionInfo *storage_in
+ 	}
+ 
+ 	D_ASSERT(auth_handler);
+-	auto catalog = make_uniq<IRCatalog>(db, access_mode, std::move(auth_handler), attach_options.warehouse,
++	auto catalog = make_uniq<IRCatalog>(db, options.access_mode, std::move(auth_handler), attach_options.warehouse,
+ 	                                    attach_options.endpoint);
+ 	catalog->GetConfig(context);
+ 	return std::move(catalog);
+ }
+ 
+-static unique_ptr<TransactionManager> CreateTransactionManager(StorageExtensionInfo *storage_info, AttachedDatabase &db,
++static unique_ptr<TransactionManager> CreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info, AttachedDatabase &db,
+                                                                Catalog &catalog) {
+ 	auto &ic_catalog = catalog.Cast<IRCatalog>();
+ 	return make_uniq<ICTransactionManager>(db, ic_catalog);
 @@ -233,10 +231,12 @@ public:
  	}
  };
@@ -90,7 +118,7 @@ index 0b278db..e1f721a 100644
 +}
 \ No newline at end of file
 diff --git a/src/iceberg_functions.cpp b/src/iceberg_functions.cpp
-index d3ea52f..fda8520 100644
+index d3ea52fb..fda85203 100644
 --- a/src/iceberg_functions.cpp
 +++ b/src/iceberg_functions.cpp
 @@ -7,11 +7,13 @@
@@ -110,7 +138,7 @@ index d3ea52f..fda8520 100644
  
  	return functions;
 diff --git a/src/iceberg_functions/iceberg_multi_file_reader.cpp b/src/iceberg_functions/iceberg_multi_file_reader.cpp
-index 1097807..a8b1646 100644
+index 10978072..a8b16460 100644
 --- a/src/iceberg_functions/iceberg_multi_file_reader.cpp
 +++ b/src/iceberg_functions/iceberg_multi_file_reader.cpp
 @@ -7,7 +7,6 @@
@@ -139,7 +167,7 @@ index 1097807..a8b1646 100644
  
  	// Prepare the inputs for the bind
 diff --git a/src/iceberg_functions/iceberg_scan.cpp b/src/iceberg_functions/iceberg_scan.cpp
-index 223c66f..bdb80d4 100644
+index 223c66f5..bdb80d4e 100644
 --- a/src/iceberg_functions/iceberg_scan.cpp
 +++ b/src/iceberg_functions/iceberg_scan.cpp
 @@ -19,7 +19,7 @@
@@ -166,7 +194,7 @@ index 223c66f..bdb80d4 100644
  
  	for (auto &function : parquet_scan_copy.functions) {
 diff --git a/src/iceberg_manifest.cpp b/src/iceberg_manifest.cpp
-index 74fabd7..06d4352 100644
+index 74fabd72..06d4352e 100644
 --- a/src/iceberg_manifest.cpp
 +++ b/src/iceberg_manifest.cpp
 @@ -426,9 +426,17 @@ AvroScan::AvroScan(const string &scan_name, ClientContext &context, const string
@@ -189,7 +217,7 @@ index 74fabd7..06d4352 100644
  	vector<Value> children;
  	children.reserve(1);
 diff --git a/src/include/iceberg_extension.hpp b/src/include/iceberg_extension.hpp
-index b0f51ce..021aa0e 100644
+index b0f51ceb..021aa0e6 100644
 --- a/src/include/iceberg_extension.hpp
 +++ b/src/include/iceberg_extension.hpp
 @@ -6,7 +6,7 @@ namespace duckdb {
@@ -202,7 +230,7 @@ index b0f51ce..021aa0e 100644
  };
  
 diff --git a/src/include/iceberg_functions.hpp b/src/include/iceberg_functions.hpp
-index cd85a8d..4becfa8 100644
+index cd85a8dd..4becfa81 100644
 --- a/src/include/iceberg_functions.hpp
 +++ b/src/include/iceberg_functions.hpp
 @@ -13,15 +13,16 @@
@@ -225,7 +253,7 @@ index cd85a8d..4becfa8 100644
  };
  
 diff --git a/src/include/iceberg_manifest.hpp b/src/include/iceberg_manifest.hpp
-index 2f50b6d..20e0da3 100644
+index 2f50b6d3..20e0da35 100644
 --- a/src/include/iceberg_manifest.hpp
 +++ b/src/include/iceberg_manifest.hpp
 @@ -11,7 +11,7 @@
@@ -238,7 +266,7 @@ index 2f50b6d..20e0da3 100644
  #include "duckdb/parser/tableref/table_function_ref.hpp"
  #include "duckdb/parser/expression/constant_expression.hpp"
 diff --git a/src/storage/irc_table_entry.cpp b/src/storage/irc_table_entry.cpp
-index f3a7816..e6066de 100644
+index f3a78161..e6066dea 100644
 --- a/src/storage/irc_table_entry.cpp
 +++ b/src/storage/irc_table_entry.cpp
 @@ -3,7 +3,7 @@

--- a/.github/patches/extensions/mysql_scanner/fix.patch
+++ b/.github/patches/extensions/mysql_scanner/fix.patch
@@ -146,6 +146,45 @@ index a239dfb..46df8b7 100644
  #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
  #include "mysql_scanner.hpp"
  #include "mysql_result.hpp"
+diff --git a/src/mysql_storage.cpp b/src/mysql_storage.cpp
+index 7ee6fe6..3366561 100644
+--- a/src/mysql_storage.cpp
++++ b/src/mysql_storage.cpp
+@@ -7,8 +7,8 @@
+ 
+ namespace duckdb {
+ 
+-static unique_ptr<Catalog> MySQLAttach(StorageExtensionInfo *storage_info, ClientContext &context, AttachedDatabase &db,
+-                                       const string &name, AttachInfo &info, AccessMode access_mode) {
++static unique_ptr<Catalog> MySQLAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context, AttachedDatabase &db,
++                                       const string &name, AttachInfo &info, AttachOptions &attach_options) {
+ 	auto &config = DBConfig::GetConfig(context);
+ 	if (!config.options.enable_external_access) {
+ 		throw PermissionException("Attaching MySQL databases is disabled through configuration");
+@@ -17,9 +17,7 @@ static unique_ptr<Catalog> MySQLAttach(StorageExtensionInfo *storage_info, Clien
+ 	string secret_name;
+ 	for (auto &entry : info.options) {
+ 		auto lower_name = StringUtil::Lower(entry.first);
+-		if (lower_name == "type" || lower_name == "read_only") {
+-			// already handled
+-		} else if (lower_name == "secret") {
++		if (lower_name == "secret") {
+ 			secret_name = entry.second.ToString();
+ 		} else {
+ 			throw BinderException("Unrecognized option for MySQL attach: %s", entry.first);
+@@ -28,10 +26,10 @@ static unique_ptr<Catalog> MySQLAttach(StorageExtensionInfo *storage_info, Clien
+ 
+ 	string attach_path = info.path;
+ 	auto connection_string = MySQLCatalog::GetConnectionString(context, attach_path, secret_name);
+-	return make_uniq<MySQLCatalog>(db, std::move(connection_string), std::move(attach_path), access_mode);
++	return make_uniq<MySQLCatalog>(db, std::move(connection_string), std::move(attach_path), attach_options.access_mode);
+ }
+ 
+-static unique_ptr<TransactionManager> MySQLCreateTransactionManager(StorageExtensionInfo *storage_info,
++static unique_ptr<TransactionManager> MySQLCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,
+                                                                     AttachedDatabase &db, Catalog &catalog) {
+ 	auto &mysql_catalog = catalog.Cast<MySQLCatalog>();
+ 	return make_uniq<MySQLTransactionManager>(db, mysql_catalog);
 diff --git a/src/storage/mysql_execute_query.cpp b/src/storage/mysql_execute_query.cpp
 index 8bf9426..aaeb3c7 100644
 --- a/src/storage/mysql_execute_query.cpp

--- a/.github/patches/extensions/mysql_scanner/fix.patch
+++ b/.github/patches/extensions/mysql_scanner/fix.patch
@@ -147,10 +147,10 @@ index a239dfb..46df8b7 100644
  #include "mysql_scanner.hpp"
  #include "mysql_result.hpp"
 diff --git a/src/mysql_storage.cpp b/src/mysql_storage.cpp
-index 7ee6fe6..3366561 100644
+index 7ee6fe6..fde8d08 100644
 --- a/src/mysql_storage.cpp
 +++ b/src/mysql_storage.cpp
-@@ -7,8 +7,8 @@
+@@ -7,19 +7,17 @@
  
  namespace duckdb {
  
@@ -161,9 +161,11 @@ index 7ee6fe6..3366561 100644
  	auto &config = DBConfig::GetConfig(context);
  	if (!config.options.enable_external_access) {
  		throw PermissionException("Attaching MySQL databases is disabled through configuration");
-@@ -17,9 +17,7 @@ static unique_ptr<Catalog> MySQLAttach(StorageExtensionInfo *storage_info, Clien
+ 	}
+ 	// check if we have a secret provided
  	string secret_name;
- 	for (auto &entry : info.options) {
+-	for (auto &entry : info.options) {
++	for (auto &entry : attach_options.options) {
  		auto lower_name = StringUtil::Lower(entry.first);
 -		if (lower_name == "type" || lower_name == "read_only") {
 -			// already handled

--- a/.github/patches/extensions/postgres_scanner/fix.patch
+++ b/.github/patches/extensions/postgres_scanner/fix.patch
@@ -183,6 +183,46 @@ index 9b2d062..d49d8a3 100644
  #include "duckdb/common/shared_ptr.hpp"
  #include "duckdb/common/helper.hpp"
  #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+diff --git a/src/postgres_storage.cpp b/src/postgres_storage.cpp
+index 9c46178..16c058c 100644
+--- a/src/postgres_storage.cpp
++++ b/src/postgres_storage.cpp
+@@ -7,9 +7,9 @@
+ 
+ namespace duckdb {
+ 
+-static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, ClientContext &context,
++static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
+                                           AttachedDatabase &db, const string &name, AttachInfo &info,
+-                                          AccessMode access_mode) {
++                                          AttachOptions &attach_options) {
+ 	auto &config = DBConfig::GetConfig(context);
+ 	if (!config.options.enable_external_access) {
+ 		throw PermissionException("Attaching Postgres databases is disabled through configuration");
+@@ -20,9 +20,7 @@ static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, Cl
+ 	string schema_to_load;
+ 	for (auto &entry : info.options) {
+ 		auto lower_name = StringUtil::Lower(entry.first);
+-		if (lower_name == "type" || lower_name == "read_only") {
+-			// already handled
+-		} else if (lower_name == "secret") {
++		if (lower_name == "secret") {
+ 			secret_name = entry.second.ToString();
+ 		} else if (lower_name == "schema") {
+ 			schema_to_load = entry.second.ToString();
+@@ -31,10 +29,10 @@ static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, Cl
+ 		}
+ 	}
+ 	auto connection_string = PostgresCatalog::GetConnectionString(context, attach_path, secret_name);
+-	return make_uniq<PostgresCatalog>(db, std::move(connection_string), std::move(attach_path), access_mode, std::move(schema_to_load));
++	return make_uniq<PostgresCatalog>(db, std::move(connection_string), std::move(attach_path), attach_options.access_mode, std::move(schema_to_load));
+ }
+ 
+-static unique_ptr<TransactionManager> PostgresCreateTransactionManager(StorageExtensionInfo *storage_info,
++static unique_ptr<TransactionManager> PostgresCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,
+                                                                        AttachedDatabase &db, Catalog &catalog) {
+ 	auto &postgres_catalog = catalog.Cast<PostgresCatalog>();
+ 	return make_uniq<PostgresTransactionManager>(db, postgres_catalog);
 diff --git a/src/storage/postgres_delete.cpp b/src/storage/postgres_delete.cpp
 index 88dec2c..7aa13db 100644
 --- a/src/storage/postgres_delete.cpp

--- a/.github/patches/extensions/postgres_scanner/fix.patch
+++ b/.github/patches/extensions/postgres_scanner/fix.patch
@@ -184,7 +184,7 @@ index 9b2d062..d49d8a3 100644
  #include "duckdb/common/helper.hpp"
  #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 diff --git a/src/postgres_storage.cpp b/src/postgres_storage.cpp
-index 9c46178..16c058c 100644
+index 9c46178..d665ca2 100644
 --- a/src/postgres_storage.cpp
 +++ b/src/postgres_storage.cpp
 @@ -7,9 +7,9 @@
@@ -199,9 +199,12 @@ index 9c46178..16c058c 100644
  	auto &config = DBConfig::GetConfig(context);
  	if (!config.options.enable_external_access) {
  		throw PermissionException("Attaching Postgres databases is disabled through configuration");
-@@ -20,9 +20,7 @@ static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, Cl
+@@ -18,11 +18,9 @@ static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, Cl
+ 
+ 	string secret_name;
  	string schema_to_load;
- 	for (auto &entry : info.options) {
+-	for (auto &entry : info.options) {
++	for (auto &entry : attach_options.options) {
  		auto lower_name = StringUtil::Lower(entry.first);
 -		if (lower_name == "type" || lower_name == "read_only") {
 -			// already handled

--- a/.github/patches/extensions/sqlite_scanner/fix.patch
+++ b/.github/patches/extensions/sqlite_scanner/fix.patch
@@ -132,7 +132,7 @@ index f85328f..c2f7c81 100644
 -}
  }
 diff --git a/src/sqlite_storage.cpp b/src/sqlite_storage.cpp
-index 09d212d..c5cac00 100644
+index 09d212d..38255f6 100644
 --- a/src/sqlite_storage.cpp
 +++ b/src/sqlite_storage.cpp
 @@ -12,22 +12,24 @@
@@ -146,8 +146,9 @@ index 09d212d..c5cac00 100644
 +                                        AttachOptions &attach_options) {
  	SQLiteOpenOptions options;
 -	options.access_mode = access_mode;
+-	for (auto &entry : info.options) {
 +	options.access_mode = attach_options.access_mode;
- 	for (auto &entry : info.options) {
++	for (auto &entry : attach_options.options) {
  		if (StringUtil::CIEquals(entry.first, "busy_timeout")) {
  			options.busy_timeout = entry.second.GetValue<uint64_t>();
  		} else if (StringUtil::CIEquals(entry.first, "journal_mode")) {

--- a/.github/patches/extensions/sqlite_scanner/fix.patch
+++ b/.github/patches/extensions/sqlite_scanner/fix.patch
@@ -131,6 +131,39 @@ index f85328f..c2f7c81 100644
 -	config.storage_extensions["sqlite_scanner"] = make_uniq<SQLiteStorageExtension>();
 -}
  }
+diff --git a/src/sqlite_storage.cpp b/src/sqlite_storage.cpp
+index 09d212d..c5cac00 100644
+--- a/src/sqlite_storage.cpp
++++ b/src/sqlite_storage.cpp
+@@ -12,22 +12,24 @@
+ 
+ namespace duckdb {
+ 
+-static unique_ptr<Catalog> SQLiteAttach(StorageExtensionInfo *storage_info, ClientContext &context,
++static unique_ptr<Catalog> SQLiteAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
+                                         AttachedDatabase &db, const string &name, AttachInfo &info,
+-                                        AccessMode access_mode) {
++                                        AttachOptions &attach_options) {
+ 	SQLiteOpenOptions options;
+-	options.access_mode = access_mode;
++	options.access_mode = attach_options.access_mode;
+ 	for (auto &entry : info.options) {
+ 		if (StringUtil::CIEquals(entry.first, "busy_timeout")) {
+ 			options.busy_timeout = entry.second.GetValue<uint64_t>();
+ 		} else if (StringUtil::CIEquals(entry.first, "journal_mode")) {
+ 			options.journal_mode = entry.second.ToString();
++		} else {
++			throw NotImplementedException("Unsupported parameter for SQLite Attach: %s", entry.first);
+ 		}
+ 	}
+ 	return make_uniq<SQLiteCatalog>(db, info.path, std::move(options));
+ }
+ 
+-static unique_ptr<TransactionManager> SQLiteCreateTransactionManager(StorageExtensionInfo *storage_info,
++static unique_ptr<TransactionManager> SQLiteCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,
+                                                                      AttachedDatabase &db, Catalog &catalog) {
+ 	auto &sqlite_catalog = catalog.Cast<SQLiteCatalog>();
+ 	return make_uniq<SQLiteTransactionManager>(db, sqlite_catalog);
 diff --git a/src/storage/sqlite_delete.cpp b/src/storage/sqlite_delete.cpp
 index c19f45b..bde562f 100644
 --- a/src/storage/sqlite_delete.cpp

--- a/scripts/apply_extension_patches.py
+++ b/scripts/apply_extension_patches.py
@@ -51,6 +51,7 @@ prev_output_lines.sort()
 subprocess.run(["git", "clean", "-f"], check=True)
 subprocess.run(["git", "reset", "--hard", "HEAD"], check=True)
 
+
 def apply_patch(patch_file):
     ARGUMENTS = ["patch", "-p1", "--forward", "-i"]
     arguments = []
@@ -94,6 +95,5 @@ if len(output_lines) <= len(prev_output_lines) and prev_output_lines != output_l
     print("--------------------------------------------------")
     print(f"(cd {os.getcwd()} && git diff > {os.path.join(directory, 'fix.patch')})")
     print("--------------------------------------------------")
-
 
     exit(1)

--- a/scripts/apply_extension_patches.py
+++ b/scripts/apply_extension_patches.py
@@ -3,6 +3,7 @@ import sys
 import glob
 import subprocess
 import os
+import tempfile
 
 # Get the directory and construct the patch file pattern
 directory = sys.argv[1]
@@ -38,15 +39,23 @@ if not patches:
 current_dir = os.getcwd()
 print(f"Applying patches at '{current_dir}'")
 print(f"Resetting patches in {directory}\n")
+
+# capture the current diff
+diff_proc = subprocess.run(["git", "diff"], capture_output=True, check=True)
+prev_diff = diff_proc.stdout
+
+output_proc = subprocess.run(["git", "diff", "--numstat"], capture_output=True, check=True)
+prev_output_lines = output_proc.stdout.decode('utf8').split('\n')
+prev_output_lines.sort()
+
 subprocess.run(["git", "clean", "-f"], check=True)
 subprocess.run(["git", "reset", "--hard", "HEAD"], check=True)
-# Apply each patch file using patch
-ARGUMENTS = ["patch", "-p1", "--forward", "-i"]
-for patch in patches:
-    print(f"Applying patch: {patch}\n")
+
+def apply_patch(patch_file):
+    ARGUMENTS = ["patch", "-p1", "--forward", "-i"]
     arguments = []
     arguments.extend(ARGUMENTS)
-    arguments.append(os.path.join(directory, patch))
+    arguments.append(patch_file)
     try:
         subprocess.run(arguments, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except subprocess.CalledProcessError as e:
@@ -59,3 +68,32 @@ for patch in patches:
         print(e.stdout.decode('utf-8'))
         print("Exiting")
         exit(1)
+
+
+# Apply each patch file using patch
+for patch in patches:
+    print(f"Applying patch: {patch}\n")
+    apply_patch(os.path.join(directory, patch))
+
+# all patches have applied - check the current diff
+output_proc = subprocess.run(["git", "diff", "--numstat"], capture_output=True, check=True)
+output_lines = output_proc.stdout.decode('utf8').split('\n')
+output_lines.sort()
+
+if len(output_lines) <= len(prev_output_lines) and prev_output_lines != output_lines:
+    print("Detected local changes - rolling back patch application")
+
+    subprocess.run(["git", "clean", "-f"], check=True)
+    subprocess.run(["git", "reset", "--hard", "HEAD"], check=True)
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(prev_diff)
+        apply_patch(f.name)
+
+    print("--------------------------------------------------")
+    print("Generate a patch file using the following command:")
+    print("--------------------------------------------------")
+    print(f"(cd {os.getcwd()} && git diff > {os.path.join(directory, 'fix.patch')})")
+    print("--------------------------------------------------")
+
+
+    exit(1)

--- a/src/include/duckdb/storage/storage_extension.hpp
+++ b/src/include/duckdb/storage/storage_extension.hpp
@@ -25,10 +25,10 @@ struct StorageExtensionInfo {
 	}
 };
 
-typedef unique_ptr<Catalog> (*attach_function_t)(StorageExtensionInfo *storage_info, ClientContext &context,
-                                                 AttachedDatabase &db, const string &name, AttachInfo &info,
-                                                 AccessMode access_mode);
-typedef unique_ptr<TransactionManager> (*create_transaction_manager_t)(StorageExtensionInfo *storage_info,
+typedef unique_ptr<Catalog> (*attach_function_t)(optional_ptr<StorageExtensionInfo> storage_info,
+                                                 ClientContext &context, AttachedDatabase &db, const string &name,
+                                                 AttachInfo &info, AttachOptions &options);
+typedef unique_ptr<TransactionManager> (*create_transaction_manager_t)(optional_ptr<StorageExtensionInfo> storage_info,
                                                                        AttachedDatabase &db, Catalog &catalog);
 
 class StorageExtension {

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -110,8 +110,8 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 		type = AttachedDatabaseType::READ_WRITE_DATABASE;
 	}
 
-	StorageExtensionInfo *storage_info = storage_extension->storage_info.get();
-	catalog = storage_extension->attach(storage_info, context, *this, name, info, options.access_mode);
+	optional_ptr<StorageExtensionInfo> storage_info = storage_extension->storage_info.get();
+	catalog = storage_extension->attach(storage_info, context, *this, name, info, options);
 	if (!catalog) {
 		throw InternalException("AttachedDatabase - attach function did not return a catalog");
 	}

--- a/src/storage/open_file_storage_extension.cpp
+++ b/src/storage/open_file_storage_extension.cpp
@@ -42,9 +42,9 @@ private:
 	string file;
 };
 
-unique_ptr<Catalog> OpenFileStorageAttach(StorageExtensionInfo *storage_info, ClientContext &context,
+unique_ptr<Catalog> OpenFileStorageAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
                                           AttachedDatabase &db, const string &name, AttachInfo &info,
-                                          AccessMode access_mode) {
+                                          AttachOptions &attach_options) {
 	auto file = info.path;
 	// open an in-memory database
 	info.path = ":memory:";
@@ -66,7 +66,7 @@ unique_ptr<Catalog> OpenFileStorageAttach(StorageExtensionInfo *storage_info, Cl
 	return std::move(catalog);
 }
 
-unique_ptr<TransactionManager> OpenFileStorageTransactionManager(StorageExtensionInfo *storage_info,
+unique_ptr<TransactionManager> OpenFileStorageTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,
                                                                  AttachedDatabase &db, Catalog &catalog) {
 	return make_uniq<DuckTransactionManager>(db);
 }

--- a/test/api/test_instance_cache.cpp
+++ b/test/api/test_instance_cache.cpp
@@ -39,12 +39,12 @@ TEST_CASE("Test parallel connection and destruction of connections with database
 }
 struct DelayingStorageExtension : StorageExtension {
 	DelayingStorageExtension() {
-		attach = [](StorageExtensionInfo *, ClientContext &, AttachedDatabase &db, const string &, AttachInfo &info,
-		            AccessMode) -> unique_ptr<Catalog> {
+		attach = [](optional_ptr<StorageExtensionInfo>, ClientContext &, AttachedDatabase &db, const string &,
+		            AttachInfo &info, AttachOptions &) -> unique_ptr<Catalog> {
 			std::this_thread::sleep_for(std::chrono::seconds(5));
 			return make_uniq_base<Catalog, DuckCatalog>(db);
 		};
-		create_transaction_manager = [](StorageExtensionInfo *, AttachedDatabase &db,
+		create_transaction_manager = [](optional_ptr<StorageExtensionInfo>, AttachedDatabase &db,
 		                                Catalog &) -> unique_ptr<TransactionManager> {
 			return make_uniq<DuckTransactionManager>(db);
 		};


### PR DESCRIPTION
This is a breaking change on the `attach` and `create_transaction_manager` callbacks to the following APIs:

```cpp
typedef unique_ptr<Catalog> (*attach_function_t)(optional_ptr<StorageExtensionInfo> storage_info,
                                                 ClientContext &context, AttachedDatabase &db, const string &name,
                                                 AttachInfo &info, AttachOptions &options);
typedef unique_ptr<TransactionManager> (*create_transaction_manager_t)(optional_ptr<StorageExtensionInfo> storage_info,
                                                                       AttachedDatabase &db, Catalog &catalog);
```

The main purpose is to pass `AttachOptions &options` as the final parameter instead of AccessMode. AccessMode lives in the `AttachOptions` (`options.access_mode`). In addition, `AttachOptions` has a set of *unhandled* options (`attach_options.options`) allowing extensions to easily throw errors on unrecognized options.

`AttachOptions` is intentionally passed as a mutable reference - so the attach callback can also modify e.g. the access mode of the database dynamically.
