### PR TITLE
Uncomment skipped decimal REE tests

### DIFF
--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_run_end_encoding.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_run_end_encoding.py
@@ -3,7 +3,7 @@ import pytest
 import pandas as pd
 import duckdb
 
-pa = pytest.importorskip("pyarrow", '14.0.0', reason="Needs pyarrow >= 14")
+pa = pytest.importorskip("pyarrow", '21.0.0', reason="Needs pyarrow >= 21")
 pc = pytest.importorskip("pyarrow.compute")
 
 
@@ -91,9 +91,9 @@ class TestArrowREE(object):
             ('TIMESTAMP', "'1992-03-22 01:02:03'", "'2022-11-07 08:43:04.123456'"),
             ('TIMESTAMP_MS', "'1992-03-22 01:02:03'", "'2022-11-07 08:43:04.123456'"),
             ('TIMESTAMP_NS', "'1992-03-22 01:02:03'", "'2022-11-07 08:43:04.123456'"),
-            # ('DECIMAL(4,2)', "'12.23'", "'99.99'"), REE not supported for decimal32
-            # ('DECIMAL(7,6)', "'1.234234'", "'0.000001'"), REE not supported for decimal32
-            # ('DECIMAL(14,7)', "'134523.234234'", "'999999.000001'"), REE not supported for decimal64
+            ('DECIMAL(4,2)', "'12.23'", "'99.99'"),
+            ('DECIMAL(7,6)', "'1.234234'", "'0.000001'"),
+            ('DECIMAL(14,7)', "'134523.234234'", "'999999.000001'"),
             ('DECIMAL(28,1)', "'12345678910111234123456789.1'", "'999999999999999999999999999.9'"),
             ('UUID', "'10acd298-15d7-417c-8b59-eabb5a2bacab'", "'eeccb8c5-9943-b2bb-bb5e-222f4e14b687'"),
             ('BIT', "'01010101010000'", "'01010100010101010101010101111111111'"),


### PR DESCRIPTION
These tests were commented out because, when they were added, PyArrow didn't support run-end-encoding on Decimal32/64 arrays. PyArrow>=21 supports this as of https://github.com/apache/arrow/pull/46286 so the tests can be uncommented.

With this patch, this test suite passes for me locally.