### PR TITLE
[BUGFIX] Update delim offset for RHS of DELIM JOIN when correlated column is in RHS of Cross product

### DIFF
--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -562,6 +562,8 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 
 			// recurse into left children
 			plan->children[0] = DecorrelateIndependent(binder, std::move(plan->children[0]));
+			// Similar to the LOGICAL_COMPARISON_JOIN
+			delim_offset += plan->children[0]->GetColumnBindings().size();
 			return plan;
 		}
 		// both sides have correlation

--- a/test/optimizer/joins/test_delim_join_with_cross_product_in_rhs.test
+++ b/test/optimizer/joins/test_delim_join_with_cross_product_in_rhs.test
@@ -1,0 +1,15 @@
+# name: test/optimizer/joins/test_delim_join_with_cross_product_in_rhs.test
+# description: Verify that a delim join with a correlated column in the RHS of a cross product (on the RHS of the delim GET) is properly bound
+# group: [joins]
+
+statement ok
+CREATE TABLE t1(c0 DOUBLE, c1 INT8);
+
+statement ok
+CREATE TABLE t3(c0 VARCHAR);
+
+statement ok
+INSERT INTO t1(c1) VALUES (1);
+
+statement ok
+SELECT * FROM t3, t1 INNER JOIN ( SELECT t3.c0 ) as subQuery1 ON ( t1.c0 > (t3.c0::DOUBLE) );


### PR DESCRIPTION
Fixes: https://github.com/duckdblabs/duckdb-internal/issues/5331
Fixes: https://github.com/duckdb/duckdb/issues/18267

Also fixes https://github.com/duckdb/duckdb/issues/17701 (Instead of an Internal exception it throws a Conversion Error)

This is similar to how we set the delim offset for inner joins as well.