### PR TITLE
[chore] Fixup side-effects from 8cf9ed43b60

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -217,6 +217,8 @@ runs:
         python3 scripts/get_test_list.py --file-contains 'require ' --list '"*.test"' > test.list
         python3 scripts/get_test_list.py --file-contains 'require-env LOCAL_EXTENSION_REPO' --list '"*.test"' >> test.list
         ${{ inputs.unittest_script }} '-f test.list'
+        rm -rf build/release/extension
+        mv build/extension_tmp build/release/extension
 
     - name: Run tests with auto loading with VS2019 C++ stdlib
       if: ${{ inputs.run_autoload_tests == '1' && inputs.vcpkg_target_triplet == 'x64-windows-static-md' }}
@@ -224,6 +226,8 @@ runs:
       env:
         LOCAL_EXTENSION_REPO: ${{ inputs.run_autoload_tests == '1' && github.workspace || ''}}
       run: |
+        rm -rf build/extension_tmp
+        mv build/release/extension build/extension_tmp
         choco install wget -y --no-progress
         cd  ${{ inputs.build_dir }}
         TEST_RUNNER_DIR=./build/release/test/Release


### PR DESCRIPTION
That commit was keeping same logic for Windows, but side-effectful on macos/linux, that should fix it.

I have not yet double checked, on my fork CI, this actually behaves as intended.

Problem this solves: currently OSX CI is green, but for `amd64` uploads all extensions while for `arm64` only core_functions.