### PR TITLE
Unittester: Add `--override-test-folder` parameter

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -36,6 +36,7 @@ static const TestConfigOption test_config_options[] = {
     {"on_init", "SQL statements to execute on init", LogicalType::VARCHAR, nullptr},
     {"on_load", "SQL statements to execute on explicit load", LogicalType::VARCHAR, nullptr},
     {"on_new_connection", "SQL statements to execute on connection", LogicalType::VARCHAR, nullptr},
+    {"override_test_folder", "Relative path to where test are to be searched", LogicalType::VARCHAR, nullptr},
     {"skip_tests", "Tests to be skipped", LogicalType::LIST(LogicalType::VARCHAR), nullptr},
     {"skip_compiled", "Skip compiled tests", LogicalType::BOOLEAN, nullptr},
     {"skip_error_messages", "Skip compiled tests", LogicalType::LIST(LogicalType::VARCHAR), nullptr},
@@ -326,6 +327,10 @@ bool TestConfiguration::GetSkipCompiledTests() {
 
 string TestConfiguration::GetStorageVersion() {
 	return GetOptionOrDefault("storage_version", string());
+}
+
+string TestConfiguration::GetOverrideTestFolder() {
+	return GetOptionOrDefault("override_test_folder", string());
 }
 
 DebugVectorVerification TestConfiguration::GetVectorVerification() {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -52,6 +52,7 @@ public:
 	vector<string> ExtensionToBeLoadedOnLoad();
 	vector<string> ErrorMessagesToBeSkipped();
 	string GetStorageVersion();
+	string GetOverrideTestFolder();
 
 	static bool TestForceStorage();
 	static bool TestForceReload();

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -79,8 +79,11 @@ static void testRunner() {
 		// Parse the test dir automatically
 		TestChangeDirectory(test_working_dir);
 	}
-
-	runner.ExecuteFile(name);
+	try {
+		runner.ExecuteFile(name);
+	} catch (...) {
+		// This is to allow cleanup to be executed, failure is already logged
+	}
 
 	if (AUTO_SWITCH_TEST_DIR) {
 		TestChangeDirectory(prev_directory);

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -233,7 +233,10 @@ void RegisterSqllogictests() {
 	bool is_standard_folder = true;
 	if (!override_base_folder.empty()) {
 		is_standard_folder = false;
-		base_folder = override_base_folder;
+		base_folder = override_base_folder + "/test/sql";
+		// This is the other side of the hack above, see the line:
+		// 'We assume the test working dir for extensions to be one dir above the test/sql...'
+		// This does mean only tests in the test/sql subfolder are actually executed
 	}
 
 	listFiles(*fs, base_folder, [&](const string &path) {


### PR DESCRIPTION
This PR allows, for extensions that have `duckdb` as submodule, to run duckdb tests from within the extension, like:
```bash
% ./build/release/test/unittest  --override-test-folder duckdb
```

This could be also used from duckdb to point to a different folder where test live, but currently there is a funky restriction that I kept in place that tests needs to be in a subfolder of the overridden test folder called `test/sql`.
This is fixable and handy to fix, but was a bit outside the scope here.

---

Example where this could make sense is for example for wide-reaching extensions such as `httpfs`, that have plenty of tests still in duckdb/duckdb (and more that indirectly might change behaviour with httpfs loaded, such as crypto routines).

Another example could be extensions such as `iceberg` or `ducklake` or other DB provider that when combined with default database override should allow to run duckdb/duckdb tests with a different default database.

For example with `ducklake_as_default.json` as:
```json
{
  "description": "Using a DuckDB-based DuckLake database as default database",
  "on_init": "ATTACH 'ducklake:{TEST_DIR}/{BASE_TEST_NAME}ducklake_duckdb.db' as __db (DATA_PATH '{TEST_DIR}/{BASE_TEST_NAME}sqlite_data');",
  "on_new_connection": "USE __db;",
  "autoloading": "available",
  "on_load": "skip",
  "skip_error_messages": [
    "Not implemented", "Autoloading", "Unsupported user-defined type", "DuckLake does not support generated columns", "not yet supported", "unsupported type ", "Changing Secret Manager settings after the secret manager is used is not allowed", "Collations are not supported in DuckLake storage"
  ],
  "skip_compiled": "true",
  "override_test_folder": "duckdb",
  "skip_tests": [ "test/fuzzer/pedro/concurrent_set_threads.test" , "test/sql/transactions/test_index_pending_delete.test", "test/optimizer/statistics/statistics_try_cast.test", "test/sql/update/test_update_same_value.test", "test/sql/delete/test_segment_deletes.test", "test/sql/transactions/types/test_hugeint_transactions.test", "test/sql/transactions/types/test_uhugeint_transactions.test", "test/sql/delete/cleanup_delete_on_conflict.test", "test/sql/transactions/test_from_update_conflict.test"]
}
```
one could do from the extension folder:
```bash
% GEN=ninja make
% ./build/release/test/unittest  --override-test-folder duckdb --test-config ducklake_as_default.json 
```
and this might allow to check to what degree of compatibility a given AttachDatabase implementation (with a given set of options) has when run on DuckDB tests.

---

As a demonstration this works that do not requires extensions, this PR should also allow to run tests across different DuckDB versions, example, if you have a duckdb folder checked out to this PR and a duckdb folder on `1.0.0`, you can do:
```bash
% git clone https://github.com/duckdb/duckdb duckdb_100
% cd duckdb_100 && git checkout v1.0.0 && cd ..
% ./build/release/test/unittest  --override-test-folder duckdb_100
===============================================================================
test cases:   2741 |   2483 passed | 258 failed | 166 skipped
assertions: 453348 | 453090 passed | 258 failed | 166 skipped
```
(failure could be either test infra is being more restrictive, expected failure now passing, change in behaviour, else)