### PR TITLE
Re-use table metadata when table is not altered during checkpoint

### DIFF
--- a/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
@@ -23,13 +23,13 @@ class SegmentStatistics;
 // Writes data for an entire row group.
 class RowGroupWriter {
 public:
-	RowGroupWriter(TableCatalogEntry &table, PartialBlockManager &partial_block_manager)
-	    : table(table), partial_block_manager(partial_block_manager) {
-	}
+	RowGroupWriter(TableCatalogEntry &table, PartialBlockManager &partial_block_manager);
 	virtual ~RowGroupWriter() {
 	}
 
-	CompressionType GetColumnCompressionType(idx_t i);
+	const vector<CompressionType> &GetCompressionTypes() const {
+		return compression_types;
+	}
 
 	virtual CheckpointType GetCheckpointType() const = 0;
 	virtual WriteStream &GetPayloadWriter() = 0;
@@ -43,6 +43,7 @@ public:
 protected:
 	TableCatalogEntry &table;
 	PartialBlockManager &partial_block_manager;
+	vector<CompressionType> compression_types;
 };
 
 // Writes data for an entire row group.

--- a/src/include/duckdb/storage/checkpoint/table_data_reader.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_reader.hpp
@@ -16,7 +16,7 @@ struct BoundCreateTableInfo;
 //! The table data reader is responsible for reading the data of a table from the block manager
 class TableDataReader {
 public:
-	TableDataReader(MetadataReader &reader, BoundCreateTableInfo &info);
+	TableDataReader(MetadataReader &reader, BoundCreateTableInfo &info, MetaBlockPointer table_pointer);
 
 	void ReadTableData();
 

--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -29,6 +29,7 @@ public:
 public:
 	void WriteTableData(Serializer &metadata_serializer);
 
+	virtual void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) = 0;
 	virtual void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) = 0;
 	virtual unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) = 0;
 
@@ -51,6 +52,7 @@ public:
 	                          MetadataWriter &table_data_writer);
 
 public:
+	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) override;
 	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) override;
 	unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) override;
 	CheckpointType GetCheckpointType() const override;
@@ -59,6 +61,9 @@ private:
 	SingleFileCheckpointWriter &checkpoint_manager;
 	//! Writes the actual table data
 	MetadataWriter &table_data_writer;
+	//! The root pointer, if we are re-using metadata
+	MetaBlockPointer existing_pointer;
+	optional_idx existing_rows;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -29,7 +29,8 @@ public:
 public:
 	void WriteTableData(Serializer &metadata_serializer);
 
-	virtual void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) = 0;
+	virtual void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows,
+	                                 vector<MetaBlockPointer> data_pointers) = 0;
 	virtual void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) = 0;
 	virtual unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) = 0;
 
@@ -52,7 +53,8 @@ public:
 	                          MetadataWriter &table_data_writer);
 
 public:
-	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) override;
+	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows,
+	                         vector<MetaBlockPointer> data_pointers) override;
 	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) override;
 	unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) override;
 	CheckpointType GetCheckpointType() const override;
@@ -61,9 +63,10 @@ private:
 	SingleFileCheckpointWriter &checkpoint_manager;
 	//! Writes the actual table data
 	MetadataWriter &table_data_writer;
-	//! The root pointer, if we are re-using metadata
+	//! The root pointer, if we are re-using metadata of the table
 	MetaBlockPointer existing_pointer;
 	optional_idx existing_rows;
+	vector<MetaBlockPointer> existing_pointers;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/compression/chimp/algorithm/packed_data.hpp
+++ b/src/include/duckdb/storage/compression/chimp/algorithm/packed_data.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/common.hpp"
 #include "duckdb/storage/compression/chimp/algorithm/chimp_utils.hpp"
 #include "duckdb.h"
 

--- a/src/include/duckdb/storage/metadata/metadata_reader.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_reader.hpp
@@ -32,6 +32,8 @@ public:
 	MetadataManager &GetMetadataManager() {
 		return manager;
 	}
+	//! Gets a list of all remaining blocks to be read by this metadata reader - consumes all blocks
+	vector<MetaBlockPointer> GetRemainingBlocks();
 
 private:
 	data_ptr_t BasePtr();

--- a/src/include/duckdb/storage/metadata/metadata_reader.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_reader.hpp
@@ -33,7 +33,8 @@ public:
 		return manager;
 	}
 	//! Gets a list of all remaining blocks to be read by this metadata reader - consumes all blocks
-	vector<MetaBlockPointer> GetRemainingBlocks();
+	//! If "last_block" is specified, we stop when reaching that block
+	vector<MetaBlockPointer> GetRemainingBlocks(MetaBlockPointer last_block = MetaBlockPointer());
 
 private:
 	data_ptr_t BasePtr();

--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -61,6 +61,7 @@ public:
 	unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) override;
 
 	bool IsPersistent() override;
+	bool HasAnyChanges() const override;
 	PersistentColumnData Serialize() override;
 	void InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) override;
 

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -102,6 +102,11 @@ public:
 	//! Whether or not the column has any updates
 	bool HasUpdates() const;
 	bool HasChanges(idx_t start_row, idx_t end_row) const;
+	//! Whether or not the column has changes at this level
+	bool HasChanges() const;
+
+	//! Whether or not the column has ANY changes, including in child columns
+	virtual bool HasAnyChanges() const;
 	//! Whether or not we can scan an entire vector
 	virtual ScanVectorType GetVectorScanType(ColumnScanState &state, idx_t scan_count, Vector &result);
 

--- a/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
+++ b/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
@@ -49,6 +49,7 @@ public:
 	InMemoryTableDataWriter(InMemoryCheckpointer &checkpoint_manager, TableCatalogEntry &table);
 
 public:
+	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) override;
 	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) override;
 	unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) override;
 	CheckpointType GetCheckpointType() const override;

--- a/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
+++ b/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
@@ -49,7 +49,8 @@ public:
 	InMemoryTableDataWriter(InMemoryCheckpointer &checkpoint_manager, TableCatalogEntry &table);
 
 public:
-	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) override;
+	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows,
+	                         vector<MetaBlockPointer> data_pointers) override;
 	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) override;
 	unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) override;
 	CheckpointType GetCheckpointType() const override;

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -59,6 +59,7 @@ public:
 	unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) override;
 
 	bool IsPersistent() override;
+	bool HasAnyChanges() const override;
 	PersistentColumnData Serialize() override;
 	void InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) override;
 

--- a/src/include/duckdb/storage/table/persistent_table_data.hpp
+++ b/src/include/duckdb/storage/table/persistent_table_data.hpp
@@ -22,6 +22,7 @@ public:
 	explicit PersistentTableData(idx_t column_count);
 	~PersistentTableData();
 
+	MetaBlockPointer base_table_pointer;
 	TableStatistics table_stats;
 	idx_t total_rows;
 	idx_t row_group_count;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -92,9 +92,9 @@ public:
 	RowGroupCollection &GetCollection() {
 		return collection.get();
 	}
-	const vector<MetaBlockPointer> &GetColumnPointers() const {
-		return column_pointers;
-	}
+	//! Returns the list of meta block pointers used by the columns
+	vector<MetaBlockPointer> GetColumnPointers();
+	//! Returns the list of meta block pointers used by the deletes
 	const vector<MetaBlockPointer> &GetDeletesPointers() const {
 		return deletes_pointers;
 	}

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -92,6 +92,12 @@ public:
 	RowGroupCollection &GetCollection() {
 		return collection.get();
 	}
+	const vector<MetaBlockPointer> &GetColumnPointers() const {
+		return column_pointers;
+	}
+	const vector<MetaBlockPointer> &GetDeletesPointers() const {
+		return deletes_pointers;
+	}
 	BlockManager &GetBlockManager();
 	DataTableInfo &GetTableInfo();
 

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -106,6 +106,7 @@ public:
 	void CommitDropColumn(const idx_t column_index);
 
 	void InitializeEmpty(const vector<LogicalType> &types);
+	bool HasChanges() const;
 
 	//! Initialize a scan over this row_group
 	bool InitializeScan(CollectionScanState &state);

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -167,6 +167,8 @@ private:
 	TableStatistics stats;
 	//! Allocation size, only tracked for appends
 	atomic<idx_t> allocation_size;
+	//! Root metadata pointer, if the collection is loaded from disk
+	MetaBlockPointer metadata_pointer;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/row_group_segment_tree.hpp
+++ b/src/include/duckdb/storage/table/row_group_segment_tree.hpp
@@ -23,6 +23,11 @@ public:
 
 	void Initialize(PersistentTableData &data);
 
+	bool HasChanges(SegmentLock &lock) const;
+	MetaBlockPointer GetRootPointer() const {
+		return root_pointer;
+	}
+
 protected:
 	unique_ptr<RowGroup> LoadSegment() override;
 
@@ -30,6 +35,7 @@ protected:
 	idx_t current_row_group;
 	idx_t max_row_group;
 	unique_ptr<MetadataReader> reader;
+	MetaBlockPointer root_pointer;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -38,7 +38,7 @@ public:
 
 	//! Locks the segment tree. All methods to the segment tree either lock the segment tree, or take an already
 	//! obtained lock.
-	SegmentLock Lock() {
+	SegmentLock Lock() const {
 		return SegmentLock(node_lock);
 	}
 
@@ -76,12 +76,15 @@ public:
 		auto l = Lock();
 		return ReferenceSegments(l);
 	}
+	const vector<SegmentNode<T>> &ReferenceLoadedSegments(SegmentLock &l) const {
+		return nodes;
+	}
 
 	idx_t GetSegmentCount() {
 		auto l = Lock();
 		return GetSegmentCount(l);
 	}
-	idx_t GetSegmentCount(SegmentLock &l) {
+	idx_t GetSegmentCount(SegmentLock &l) const {
 		return nodes.size();
 	}
 	//! Gets a pointer to the nth segment. Negative numbers start from the back.
@@ -274,17 +277,17 @@ protected:
 		return nullptr;
 	}
 
+	T *GetRootSegmentInternal() const {
+		return nodes.empty() ? nullptr : nodes[0].node.get();
+	}
+
 private:
 	//! The nodes in the tree, can be binary searched
 	vector<SegmentNode<T>> nodes;
 	//! Lock to access or modify the nodes
-	mutex node_lock;
+	mutable mutex node_lock;
 
 private:
-	T *GetRootSegmentInternal() {
-		return nodes.empty() ? nullptr : nodes[0].node.get();
-	}
-
 	class SegmentIterationHelper {
 	public:
 		explicit SegmentIterationHelper(SegmentTree &tree) : tree(tree) {

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -65,6 +65,7 @@ public:
 	                          vector<duckdb::ColumnSegmentInfo> &result) override;
 
 	bool IsPersistent() override;
+	bool HasAnyChanges() const override;
 	PersistentColumnData Serialize() override;
 	void InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) override;
 

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -59,6 +59,7 @@ public:
 	unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) override;
 
 	bool IsPersistent() override;
+	bool HasAnyChanges() const override;
 	PersistentColumnData Serialize() override;
 	void InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) override;
 

--- a/src/storage/checkpoint/row_group_writer.cpp
+++ b/src/storage/checkpoint/row_group_writer.cpp
@@ -5,8 +5,11 @@
 
 namespace duckdb {
 
-CompressionType RowGroupWriter::GetColumnCompressionType(idx_t i) {
-	return table.GetColumn(LogicalIndex(i)).CompressionType();
+RowGroupWriter::RowGroupWriter(TableCatalogEntry &table, PartialBlockManager &partial_block_manager)
+    : table(table), partial_block_manager(partial_block_manager) {
+	for (auto &col : table.GetColumns().Physical()) {
+		compression_types.push_back(col.CompressionType());
+	}
 }
 
 SingleFileRowGroupWriter::SingleFileRowGroupWriter(TableCatalogEntry &table, PartialBlockManager &partial_block_manager,

--- a/src/storage/checkpoint/table_data_reader.cpp
+++ b/src/storage/checkpoint/table_data_reader.cpp
@@ -10,8 +10,10 @@
 
 namespace duckdb {
 
-TableDataReader::TableDataReader(MetadataReader &reader, BoundCreateTableInfo &info) : reader(reader), info(info) {
+TableDataReader::TableDataReader(MetadataReader &reader, BoundCreateTableInfo &info, MetaBlockPointer table_pointer)
+    : reader(reader), info(info) {
 	info.data = make_uniq<PersistentTableData>(info.Base().columns.LogicalColumnCount());
+	info.data->base_table_pointer = table_pointer;
 }
 
 void TableDataReader::ReadTableData() {

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/storage/table/column_checkpoint_state.hpp"
 #include "duckdb/storage/table/table_statistics.hpp"
+#include "duckdb/storage/metadata/metadata_reader.hpp"
 
 namespace duckdb {
 
@@ -53,33 +54,52 @@ CheckpointType SingleFileTableDataWriter::GetCheckpointType() const {
 	return checkpoint_manager.GetCheckpointType();
 }
 
+void SingleFileTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) {
+	existing_pointer = pointer;
+	existing_rows = total_rows;
+}
+
 void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info,
                                               Serializer &serializer) {
+	MetaBlockPointer pointer;
+	idx_t total_rows;
+	if (!existing_pointer.IsValid()) {
+		// write the metadata
+		// store the current position in the metadata writer
+		// this is where the row groups for this table start
+		pointer = table_data_writer.GetMetaBlockPointer();
 
-	// store the current position in the metadata writer
-	// this is where the row groups for this table start
-	auto pointer = table_data_writer.GetMetaBlockPointer();
+		// Serialize statistics as a single unit
+		BinarySerializer stats_serializer(table_data_writer, serializer.GetOptions());
+		stats_serializer.Begin();
+		global_stats.Serialize(stats_serializer);
+		stats_serializer.End();
 
-	// Serialize statistics as a single unit
-	BinarySerializer stats_serializer(table_data_writer, serializer.GetOptions());
-	stats_serializer.Begin();
-	global_stats.Serialize(stats_serializer);
-	stats_serializer.End();
+		// now start writing the row group pointers to disk
+		table_data_writer.Write<uint64_t>(row_group_pointers.size());
+		total_rows = 0;
+		for (auto &row_group_pointer : row_group_pointers) {
+			auto row_group_count = row_group_pointer.row_start + row_group_pointer.tuple_count;
+			if (row_group_count > total_rows) {
+				total_rows = row_group_count;
+			}
 
-	// now start writing the row group pointers to disk
-	table_data_writer.Write<uint64_t>(row_group_pointers.size());
-	idx_t total_rows = 0;
-	for (auto &row_group_pointer : row_group_pointers) {
-		auto row_group_count = row_group_pointer.row_start + row_group_pointer.tuple_count;
-		if (row_group_count > total_rows) {
-			total_rows = row_group_count;
+			// Each RowGroup is its own unit
+			BinarySerializer row_group_serializer(table_data_writer, serializer.GetOptions());
+			row_group_serializer.Begin();
+			RowGroup::Serialize(row_group_pointer, row_group_serializer);
+			row_group_serializer.End();
 		}
+	} else {
+		// we have existing metadata and the table is unchanged - write a pointer to the existing metadata
+		pointer = existing_pointer;
+		total_rows = existing_rows.GetIndex();
 
-		// Each RowGroup is its own unit
-		BinarySerializer row_group_serializer(table_data_writer, serializer.GetOptions());
-		row_group_serializer.Begin();
-		RowGroup::Serialize(row_group_pointer, row_group_serializer);
-		row_group_serializer.End();
+		// label the blocks as used again to prevent them from being freed
+		auto &metadata_manager = checkpoint_manager.GetMetadataManager();
+		MetadataReader reader(metadata_manager, pointer);
+		auto blocks = reader.GetRemainingBlocks();
+		metadata_manager.ClearModifiedBlocks(blocks);
 	}
 
 	// Now begin the metadata as a unit

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -54,9 +54,11 @@ CheckpointType SingleFileTableDataWriter::GetCheckpointType() const {
 	return checkpoint_manager.GetCheckpointType();
 }
 
-void SingleFileTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) {
+void SingleFileTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows,
+                                                    vector<MetaBlockPointer> data_pointers) {
 	existing_pointer = pointer;
 	existing_rows = total_rows;
+	existing_pointers = std::move(data_pointers);
 }
 
 void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info,
@@ -100,6 +102,8 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 		MetadataReader reader(metadata_manager, pointer);
 		auto blocks = reader.GetRemainingBlocks();
 		metadata_manager.ClearModifiedBlocks(blocks);
+
+		metadata_manager.ClearModifiedBlocks(existing_pointers);
 	}
 
 	// Now begin the metadata as a unit

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -595,7 +595,7 @@ void CheckpointReader::ReadTableData(CatalogTransaction transaction, Deserialize
 	auto &reader = dynamic_cast<MetadataReader &>(binary_deserializer.GetStream());
 
 	MetadataReader table_data_reader(reader.GetMetadataManager(), table_pointer);
-	TableDataReader data_reader(table_data_reader, bound_info);
+	TableDataReader data_reader(table_data_reader, bound_info, table_pointer);
 	data_reader.ReadTableData();
 
 	bound_info.data->total_rows = total_rows;

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -55,6 +55,13 @@ MetadataHandle MetadataManager::AllocateHandle() {
 MetadataHandle MetadataManager::Pin(const MetadataPointer &pointer) {
 	D_ASSERT(pointer.index < METADATA_BLOCK_COUNT);
 	auto &block = blocks[UnsafeNumericCast<int64_t>(pointer.block_index)];
+#ifdef DEBUG
+	for (auto &free_block : block.free_blocks) {
+		if (free_block == pointer.index) {
+			throw InternalException("Pinning block %d.%d but it is marked as a free block", block.block_id, free_block);
+		}
+	}
+#endif
 
 	MetadataHandle handle;
 	handle.pointer.block_index = pointer.block_index;

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -306,8 +306,6 @@ void MetadataManager::ClearModifiedBlocks(const vector<MetaBlockPointer> &pointe
 			throw InternalException("ClearModifiedBlocks - Block id %llu not found in modified_blocks", block_id);
 		}
 		auto &modified_list = entry->second;
-		// verify the block has been modified
-		D_ASSERT(modified_list && (1ULL << block_index));
 		// unset the bit
 		modified_list &= ~(1ULL << block_index);
 	}

--- a/src/storage/metadata/metadata_reader.cpp
+++ b/src/storage/metadata/metadata_reader.cpp
@@ -53,10 +53,14 @@ MetaBlockPointer MetadataReader::GetMetaBlockPointer() {
 	return manager.GetDiskPointer(block.pointer, UnsafeNumericCast<uint32_t>(offset));
 }
 
-vector<MetaBlockPointer> MetadataReader::GetRemainingBlocks() {
+vector<MetaBlockPointer> MetadataReader::GetRemainingBlocks(MetaBlockPointer last_block) {
 	vector<MetaBlockPointer> result;
 	while (has_next_block) {
-		result.push_back(manager.GetDiskPointer(next_pointer, UnsafeNumericCast<uint32_t>(next_offset)));
+		auto next_block_pointer = manager.GetDiskPointer(next_pointer, UnsafeNumericCast<uint32_t>(next_offset));
+		if (last_block.IsValid() && next_block_pointer.block_pointer == last_block.block_pointer) {
+			break;
+		}
+		result.push_back(next_block_pointer);
 		ReadNextBlock();
 	}
 	return result;

--- a/src/storage/metadata/metadata_reader.cpp
+++ b/src/storage/metadata/metadata_reader.cpp
@@ -47,7 +47,19 @@ void MetadataReader::ReadData(data_ptr_t buffer, idx_t read_size) {
 }
 
 MetaBlockPointer MetadataReader::GetMetaBlockPointer() {
+	if (capacity == 0) {
+		throw InternalException("GetMetaBlockPointer called but there is no active pointer");
+	}
 	return manager.GetDiskPointer(block.pointer, UnsafeNumericCast<uint32_t>(offset));
+}
+
+vector<MetaBlockPointer> MetadataReader::GetRemainingBlocks() {
+	vector<MetaBlockPointer> result;
+	while (has_next_block) {
+		result.push_back(manager.GetDiskPointer(next_pointer, UnsafeNumericCast<uint32_t>(next_offset)));
+		ReadNextBlock();
+	}
+	return result;
 }
 
 void MetadataReader::ReadNextBlock() {

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -313,6 +313,10 @@ bool ArrayColumnData::IsPersistent() {
 	return validity.IsPersistent() && child_column->IsPersistent();
 }
 
+bool ArrayColumnData::HasAnyChanges() const {
+	return child_column->HasAnyChanges() || validity.HasAnyChanges();
+}
+
 PersistentColumnData ArrayColumnData::Serialize() {
 	PersistentColumnData persistent_data(PhysicalType::ARRAY);
 	persistent_data.child_columns.push_back(validity.Serialize());

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -361,21 +361,7 @@ void ColumnDataCheckpointer::WriteToDisk() {
 }
 
 bool ColumnDataCheckpointer::HasChanges(ColumnData &col_data) {
-	auto &nodes = col_data.data.ReferenceSegments();
-	for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
-		auto segment = nodes[segment_idx].node.get();
-		if (segment->segment_type == ColumnSegmentType::TRANSIENT) {
-			// transient segment: always need to write to disk
-			return true;
-		}
-		// persistent segment; check if there were any updates or deletions in this segment
-		idx_t start_row_idx = segment->start - row_group.start;
-		idx_t end_row_idx = start_row_idx + segment->count;
-		if (col_data.HasChanges(start_row_idx, end_row_idx)) {
-			return true;
-		}
-	}
-	return false;
+	return col_data.HasChanges();
 }
 
 void ColumnDataCheckpointer::WritePersistentSegments(ColumnCheckpointState &state) {

--- a/src/storage/table/in_memory_checkpoint.cpp
+++ b/src/storage/table/in_memory_checkpoint.cpp
@@ -86,7 +86,8 @@ InMemoryTableDataWriter::InMemoryTableDataWriter(InMemoryCheckpointer &checkpoin
     : TableDataWriter(table, checkpoint_manager.GetClientContext()), checkpoint_manager(checkpoint_manager) {
 }
 
-void InMemoryTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) {
+void InMemoryTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows,
+                                                  vector<MetaBlockPointer> data_pointers) {
 }
 
 void InMemoryTableDataWriter::FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info,

--- a/src/storage/table/in_memory_checkpoint.cpp
+++ b/src/storage/table/in_memory_checkpoint.cpp
@@ -86,6 +86,9 @@ InMemoryTableDataWriter::InMemoryTableDataWriter(InMemoryCheckpointer &checkpoin
     : TableDataWriter(table, checkpoint_manager.GetClientContext()), checkpoint_manager(checkpoint_manager) {
 }
 
+void InMemoryTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) {
+}
+
 void InMemoryTableDataWriter::FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info,
                                             Serializer &serializer) {
 	// nop: no need to write anything

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -373,6 +373,10 @@ bool ListColumnData::IsPersistent() {
 	return ColumnData::IsPersistent() && validity.IsPersistent() && child_column->IsPersistent();
 }
 
+bool ListColumnData::HasAnyChanges() const {
+	return ColumnData::HasAnyChanges() || validity.HasAnyChanges() || child_column->HasAnyChanges();
+}
+
 PersistentColumnData ListColumnData::Serialize() {
 	auto persistent_data = ColumnData::Serialize();
 	persistent_data.child_columns.push_back(validity.Serialize());

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1063,6 +1063,19 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 	return row_group_pointer;
 }
 
+bool RowGroup::HasChanges() const {
+	// avoid loading unloaded columns - they can never have changes
+	for (idx_t c = 0; c < columns.size(); c++) {
+		if (is_loaded && !is_loaded[c]) {
+			continue;
+		}
+		if (columns[c]->HasAnyChanges()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 bool RowGroup::IsPersistent() const {
 	for (auto &column : columns) {
 		if (!column->IsPersistent()) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -978,6 +978,11 @@ RowGroupWriteData RowGroup::WriteToDisk(RowGroupWriteInfo &info) {
 	// pointers all end up densely packed, and thus more cache-friendly.
 	for (idx_t column_idx = 0; column_idx < GetColumnCount(); column_idx++) {
 		auto &column = GetColumn(column_idx);
+		if (column.count != this->count) {
+			throw InternalException("Corrupted in-memory column - column with index %llu has misaligned count (row "
+			                        "group has %llu rows, column has %llu)",
+			                        column_idx, this->count.load(), column.count.load());
+		}
 		ColumnCheckpointInfo checkpoint_info(info, column_idx);
 		auto checkpoint_state = column.Checkpoint(*this, checkpoint_info);
 		D_ASSERT(checkpoint_state);
@@ -1010,18 +1015,9 @@ bool RowGroup::HasUnloadedDeletes() const {
 }
 
 RowGroupWriteData RowGroup::WriteToDisk(RowGroupWriter &writer) {
-	vector<CompressionType> compression_types;
-	compression_types.reserve(columns.size());
-
-	for (idx_t column_idx = 0; column_idx < GetColumnCount(); column_idx++) {
-		auto &column = GetColumn(column_idx);
-		if (column.count != this->count) {
-			throw InternalException("Corrupted in-memory column - column with index %llu has misaligned count (row "
-			                        "group has %llu rows, column has %llu)",
-			                        column_idx, this->count.load(), column.count.load());
-		}
-		auto compression_type = writer.GetColumnCompressionType(column_idx);
-		compression_types.push_back(compression_type);
+	auto &compression_types = writer.GetCompressionTypes();
+	if (columns.size() != compression_types.size()) {
+		throw InternalException("RowGroup::WriteToDisk - mismatch in column count vs compression types");
 	}
 
 	RowGroupWriteInfo info(writer.GetPartialBlockManager(), compression_types, writer.GetCheckpointType());

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1056,7 +1056,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 	if (metadata_pointer.IsValid() && !row_groups->HasChanges(l)) {
 		vector<MetaBlockPointer> data_pointers;
 		for (auto &row_group : row_groups->Segments(l)) {
-			auto &column_pointers = row_group.GetColumnPointers();
+			auto column_pointers = row_group.GetColumnPointers();
 			data_pointers.insert(data_pointers.end(), column_pointers.begin(), column_pointers.end());
 
 			auto &deletes_pointers = row_group.GetDeletesPointers();

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -221,7 +221,7 @@ vector<MetaBlockPointer> RowVersionManager::Checkpoint(MetadataManager &manager)
 		// we can write the current pointer as-is
 		// ensure the blocks we are pointing to are not marked as free
 		manager.ClearModifiedBlocks(storage_pointers);
-		// return the root pointer
+		// return the current set of pointers
 		return storage_pointers;
 	}
 	// first count how many ChunkInfo's we need to deserialize

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -271,6 +271,10 @@ bool StandardColumnData::IsPersistent() {
 	return ColumnData::IsPersistent() && validity.IsPersistent();
 }
 
+bool StandardColumnData::HasAnyChanges() const {
+	return ColumnData::HasAnyChanges() || validity.HasAnyChanges();
+}
+
 PersistentColumnData StandardColumnData::Serialize() {
 	auto persistent_data = ColumnData::Serialize();
 	persistent_data.child_columns.push_back(validity.Serialize());

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -328,6 +328,18 @@ bool StructColumnData::IsPersistent() {
 	return true;
 }
 
+bool StructColumnData::HasAnyChanges() const {
+	if (validity.HasAnyChanges()) {
+		return true;
+	}
+	for (auto &child_col : sub_columns) {
+		if (child_col->HasAnyChanges()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 PersistentColumnData StructColumnData::Serialize() {
 	PersistentColumnData persistent_data(PhysicalType::STRUCT);
 	persistent_data.child_columns.push_back(validity.Serialize());

--- a/test/sql/storage/metadata/full_table_metadata_reuse.test
+++ b/test/sql/storage/metadata/full_table_metadata_reuse.test
@@ -1,0 +1,40 @@
+# name: test/sql/storage/metadata/full_table_metadata_reuse.test
+# description: Test full table metadata reuse
+# group: [metadata]
+
+load __TEST_DIR__/full_table_metadata_reuse.test.db
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE bigtbl(i INT);
+
+statement ok
+INSERT INTO bigtbl FROM range(1000000)
+
+statement ok
+CREATE TABLE little_tbl(i INT);
+
+statement ok
+COMMIT
+
+
+loop i 1 10
+
+statement ok
+INSERT INTO little_tbl VALUES (1)
+
+query I
+SELECT SUM(i)=${i} FROM little_tbl
+----
+true
+
+query II
+SELECT COUNT(*), SUM(i) FROM bigtbl
+----
+1000000	499999500000
+
+restart
+
+endloop

--- a/test/sql/storage/metadata/full_table_metadata_reuse_nested.test
+++ b/test/sql/storage/metadata/full_table_metadata_reuse_nested.test
@@ -1,0 +1,49 @@
+# name: test/sql/storage/metadata/full_table_metadata_reuse_nested.test
+# description: Test full table metadata reuse of complex nested data
+# group: [metadata]
+
+load __TEST_DIR__/full_table_metadata_reuse_nested.test.db
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE complex_nested(s STRUCT(i INT, j INT[], k VARCHAR, l INT[], i1 INT, i2 INT, i3 INT, i4 INT, i5 INT, i6 INT, i7 INT, i8 INT, i9 INT, i10 INT, i11 INT, i12 INT, i13 INT, i14 INT, i15 INT, i16 INT, i17 INT, i18 INT, i19 INT, i20 INT, i21 INT, i22 INT, i23 INT, i24 INT, i25 INT, i26 INT, i27 INT, i28 INT, i29 INT, i30 INT, i31 INT, i32 INT, i33 INT, i34 INT, i35 INT, i36 INT, i37 INT, i38 INT, i39 INT, i40 INT, i41 INT, i42 INT, i43 INT, i44 INT, i45 INT, i46 INT, i47 INT, i48 INT, i49 INT, i50 INT));
+
+statement ok
+INSERT INTO complex_nested SELECT ROW(r, range(10), 'hello world', range(90, 100), r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r) s FROM range(1000000) t(r)
+
+statement ok
+CREATE TABLE complex_nested2 AS FROM complex_nested
+
+statement ok
+COMMIT
+
+
+loop i 1 10
+
+statement ok
+INSERT INTO complex_nested2 FROM complex_nested2 LIMIT 1
+
+statement ok
+CHECKPOINT
+
+restart
+
+endloop
+
+query IIIII
+SELECT COUNT(*), SUM(t.i), SUM(LEN(t.j)), SUM(LEN(t.k)), SUM(LIST_SUM([*COLUMNS('i\d+')])) FROM (SELECT UNNEST(s) FROM complex_nested) t
+----
+1000000	499999500000	10000000	11000000	24999975000000
+
+statement ok
+INSERT INTO complex_nested FROM complex_nested LIMIT 1
+
+statement ok
+CHECKPOINT
+
+query IIIII
+SELECT COUNT(*), SUM(t.i), SUM(LEN(t.j)), SUM(LEN(t.k)), SUM(LIST_SUM([*COLUMNS('i\d+')])) FROM (SELECT UNNEST(s) FROM complex_nested) t
+----
+1000001	499999500000	10000010	11000011	24999975000000

--- a/test/sql/storage/metadata/full_table_metadata_reuse_nested.test_slow
+++ b/test/sql/storage/metadata/full_table_metadata_reuse_nested.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/storage/metadata/full_table_metadata_reuse_nested.test
+# name: test/sql/storage/metadata/full_table_metadata_reuse_nested.test_slow
 # description: Test full table metadata reuse of complex nested data
 # group: [metadata]
 


### PR DESCRIPTION
Currently during a checkpoint we rewrite all metadata associated with all tables. For larger tables, the metadata can be relatively large. This causes checkpoints on larger databases to always take a base amount of time - regardless of what has actually changed.

The WAL mitigates this to some extend by buffering changes - but rewriting metadata is still wasteful:
* It causes checkpoints to take an increasing amount of time based on database size, regardless of change size
* It causes checkpoints to write a lot of data to the database, even if little changed

This PR partially mitigates this issue by re-using table metadata for tables that are fully unchanged. During checkpointing, we check if any changes have been made to a table. If no changes have been made, the entire checkpoint for that table is short-circuited and we write a pointer to the previous metadata.

Note that this is not entirely free. We still need to read parts of the previous metadata in order to figure out which blocks are used by the previous metadata. This is so that we can correctly label these blocks as still in-use, so that they do not get accidentally garbage collected.

### Performance

Consider a database storing TPC-H SF100. The biggest table (lineitem) has 600M rows.

```sql
CALL dbgen(sf=100);
```

Now insert a single row into a tiny table (`nation`) and checkpoint. We measure two times: the time of the `CHECKPOINT` command, and the full runtime of opening the database, running the insert + checkpoint, and closing the database.

```sql
INSERT INTO nation VALUES (26, 'New Country', 0, '');
CHECKPOINT;
```

| Operation  | v1.3.2 |  New  |
|------------|--------|-------|
| Checkpoint | 0.53s  | 0.07s |
| Full       | 0.64s  | 0.1s  |


Note that there is still a reasonably-sized cost here. The main remaining cost is that we are not serializing the exact blocks the row groups refer to, meaning we need to do a partial deserialization to figure this out. If we were to serialize the exact blocks of each row group we would be able to reduce the checkpoint time by another ~2.5X based on rudimentary experiments





