### PR TITLE
Correct and consistent integer arithmetic error messages

### DIFF
--- a/src/include/duckdb/common/types/hugeint.hpp
+++ b/src/include/duckdb/common/types/hugeint.hpp
@@ -116,7 +116,7 @@ public:
 	template <bool CHECK_OVERFLOW = true>
 	inline static hugeint_t Subtract(hugeint_t lhs, hugeint_t rhs) {
 		if (!TrySubtractInPlace(lhs, rhs)) {
-			throw OutOfRangeException("Underflow in HUGEINT addition: %s - %s", lhs.ToString(), rhs.ToString());
+			throw OutOfRangeException("Underflow in HUGEINT subtraction: %s - %s", lhs.ToString(), rhs.ToString());
 		}
 		return lhs;
 	}

--- a/src/include/duckdb/common/types/hugeint.hpp
+++ b/src/include/duckdb/common/types/hugeint.hpp
@@ -77,7 +77,7 @@ public:
 	inline static hugeint_t Divide(hugeint_t lhs, hugeint_t rhs) {
 		// No division by zero
 		if (rhs == 0) {
-			throw OutOfRangeException("Division of HUGEINT by zero!");
+			throw OutOfRangeException("Division of HUGEINT by zero: %s / %s", lhs.ToString(), rhs.ToString());
 		}
 
 		// division only has one reason to overflow: MINIMUM / -1

--- a/src/include/duckdb/common/types/hugeint.hpp
+++ b/src/include/duckdb/common/types/hugeint.hpp
@@ -66,7 +66,7 @@ public:
 	inline static hugeint_t Multiply(hugeint_t lhs, hugeint_t rhs) {
 		hugeint_t result;
 		if (!TryMultiply(lhs, rhs, result)) {
-			throw OutOfRangeException("Overflow in HUGEINT multiplication: %s + %s", lhs.ToString(), rhs.ToString());
+			throw OutOfRangeException("Overflow in HUGEINT multiplication: %s * %s", lhs.ToString(), rhs.ToString());
 		}
 		return result;
 	}
@@ -82,7 +82,7 @@ public:
 
 		// division only has one reason to overflow: MINIMUM / -1
 		if (lhs == NumericLimits<hugeint_t>::Minimum() && rhs == -1) {
-			throw OutOfRangeException("Overflow in HUGEINT division: %s + %s", lhs.ToString(), rhs.ToString());
+			throw OutOfRangeException("Overflow in HUGEINT division: %s / %s", lhs.ToString(), rhs.ToString());
 		}
 		return Divide<false>(lhs, rhs);
 	}
@@ -91,12 +91,12 @@ public:
 	inline static hugeint_t Modulo(hugeint_t lhs, hugeint_t rhs) {
 		// No division by zero
 		if (rhs == 0) {
-			throw OutOfRangeException("Modulo of HUGEINT by zero: %s + %s", lhs.ToString(), rhs.ToString());
+			throw OutOfRangeException("Modulo of HUGEINT by zero: %s %% %s", lhs.ToString(), rhs.ToString());
 		}
 
 		// division only has one reason to overflow: MINIMUM / -1
 		if (lhs == NumericLimits<hugeint_t>::Minimum() && rhs == -1) {
-			throw OutOfRangeException("Overflow in HUGEINT modulo: %s + %s", lhs.ToString(), rhs.ToString());
+			throw OutOfRangeException("Overflow in HUGEINT modulo: %s %% %s", lhs.ToString(), rhs.ToString());
 		}
 		return Modulo<false>(lhs, rhs);
 	}

--- a/src/include/duckdb/common/types/uhugeint.hpp
+++ b/src/include/duckdb/common/types/uhugeint.hpp
@@ -78,7 +78,7 @@ public:
 	inline static uhugeint_t Divide(uhugeint_t lhs, uhugeint_t rhs) {
 		// division between two same-size unsigned integers can only go wrong with division by zero
 		if (rhs == 0) {
-			throw OutOfRangeException("Division of UHUGEINT by zero!");
+			throw OutOfRangeException("Division of UHUGEINT by zero: %s / %s", lhs.ToString(), rhs.ToString());
 		}
 		return Divide<false>(lhs, rhs);
 	}
@@ -86,7 +86,7 @@ public:
 	template <bool CHECK_OVERFLOW = true>
 	inline static uhugeint_t Modulo(uhugeint_t lhs, uhugeint_t rhs) {
 		if (rhs == 0) {
-			throw OutOfRangeException("Modulo of UHUGEINT by zero!");
+			throw OutOfRangeException("Modulo of UHUGEINT by zero: %s %% %s", lhs.ToString(), rhs.ToString());
 		}
 		return Modulo<false>(lhs, rhs);
 	}

--- a/src/include/duckdb/common/types/uhugeint.hpp
+++ b/src/include/duckdb/common/types/uhugeint.hpp
@@ -67,7 +67,7 @@ public:
 	inline static uhugeint_t Multiply(uhugeint_t lhs, uhugeint_t rhs) {
 		uhugeint_t result;
 		if (!TryMultiply(lhs, rhs, result)) {
-			throw OutOfRangeException("Overflow in UHUGEINT multiplication!: %s + %s", lhs.ToString(), rhs.ToString());
+			throw OutOfRangeException("Overflow in UHUGEINT multiplication: %s * %s", lhs.ToString(), rhs.ToString());
 		}
 		return result;
 	}
@@ -106,7 +106,7 @@ public:
 	template <bool CHECK_OVERFLOW = true>
 	inline static uhugeint_t Subtract(uhugeint_t lhs, uhugeint_t rhs) {
 		if (!TrySubtractInPlace(lhs, rhs)) {
-			throw OutOfRangeException("Underflow in HUGEINT addition: %s - %s", lhs.ToString(), rhs.ToString());
+			throw OutOfRangeException("Underflow in HUGEINT subtraction: %s - %s", lhs.ToString(), rhs.ToString());
 		}
 		return lhs;
 	}


### PR DESCRIPTION
Clean up error messages.

- Use the same error messages in UHUGEINT and HUGEINT
- Fix operation symbols in those error messages
- Fix operation names in those error messages
