### PR TITLE
Record whether or not cross products are implicit or not, and use this for converting queries back to SQL

### DIFF
--- a/src/include/duckdb/parser/tableref/joinref.hpp
+++ b/src/include/duckdb/parser/tableref/joinref.hpp
@@ -43,6 +43,8 @@ public:
 	vector<unique_ptr<ParsedExpression>> duplicate_eliminated_columns;
 	//! If we have duplicate eliminated columns if the delim is flipped
 	bool delim_flipped = false;
+	//! Whether or not this is an implicit cross join
+	bool is_implicit = false;
 
 public:
 	string ToString() const override;

--- a/src/include/duckdb/storage/serialization/tableref.json
+++ b/src/include/duckdb/storage/serialization/tableref.json
@@ -106,6 +106,13 @@
         "id": 207,
         "name": "duplicate_eliminated_columns",
         "type": "vector<unique_ptr<ParsedExpression>>"
+      },
+      {
+        "id": 208,
+        "name": "is_implicit",
+        "type": "bool",
+        "default": "true",
+        "version": "v1.4.0"
       }
     ]
   },

--- a/src/parser/tableref/joinref.cpp
+++ b/src/parser/tableref/joinref.cpp
@@ -22,7 +22,7 @@ string JoinRef::ToString() const {
 		result += EnumUtil::ToString(type) + " JOIN ";
 		break;
 	case JoinRefType::CROSS:
-		result += "CROSS JOIN ";
+		result += is_implicit ? ", " : "CROSS JOIN ";
 		break;
 	case JoinRefType::POSITIONAL:
 		result += "POSITIONAL JOIN ";
@@ -82,6 +82,7 @@ unique_ptr<TableRef> JoinRef::Copy() {
 	for (auto &col : duplicate_eliminated_columns) {
 		copy->duplicate_eliminated_columns.emplace_back(col->Copy());
 	}
+	copy->is_implicit = is_implicit;
 	return std::move(copy);
 }
 

--- a/src/parser/tableref/joinref.cpp
+++ b/src/parser/tableref/joinref.cpp
@@ -22,7 +22,7 @@ string JoinRef::ToString() const {
 		result += EnumUtil::ToString(type) + " JOIN ";
 		break;
 	case JoinRefType::CROSS:
-		result += ", ";
+		result += "CROSS JOIN ";
 		break;
 	case JoinRefType::POSITIONAL:
 		result += "POSITIONAL JOIN ";

--- a/src/parser/transform/tableref/transform_from.cpp
+++ b/src/parser/transform/tableref/transform_from.cpp
@@ -10,8 +10,9 @@ unique_ptr<TableRef> Transformer::TransformFrom(optional_ptr<duckdb_libpgquery::
 	}
 
 	if (root->length > 1) {
-		// Cross Product
+		// Implicit Cross Product
 		auto result = make_uniq<JoinRef>(JoinRefType::CROSS);
+		result->is_implicit = true;
 		JoinRef *cur_root = result.get();
 		idx_t list_size = 0;
 		for (auto node = root->head; node != nullptr; node = node->next) {
@@ -24,6 +25,7 @@ unique_ptr<TableRef> Transformer::TransformFrom(optional_ptr<duckdb_libpgquery::
 			} else {
 				auto old_res = std::move(result);
 				result = make_uniq<JoinRef>(JoinRefType::CROSS);
+				result->is_implicit = true;
 				result->left = std::move(old_res);
 				result->right = std::move(next);
 				cur_root = result.get();

--- a/src/storage/serialization/serialize_tableref.cpp
+++ b/src/storage/serialization/serialize_tableref.cpp
@@ -138,6 +138,9 @@ void JoinRef::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<string>>(205, "using_columns", using_columns);
 	serializer.WritePropertyWithDefault<bool>(206, "delim_flipped", delim_flipped);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(207, "duplicate_eliminated_columns", duplicate_eliminated_columns);
+	if (serializer.ShouldSerialize(6)) {
+		serializer.WritePropertyWithDefault<bool>(208, "is_implicit", is_implicit, true);
+	}
 }
 
 unique_ptr<TableRef> JoinRef::Deserialize(Deserializer &deserializer) {
@@ -150,6 +153,7 @@ unique_ptr<TableRef> JoinRef::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadPropertyWithDefault<vector<string>>(205, "using_columns", result->using_columns);
 	deserializer.ReadPropertyWithDefault<bool>(206, "delim_flipped", result->delim_flipped);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(207, "duplicate_eliminated_columns", result->duplicate_eliminated_columns);
+	deserializer.ReadPropertyWithExplicitDefault<bool>(208, "is_implicit", result->is_implicit, true);
 	return std::move(result);
 }
 

--- a/test/optimizer/joins/lateral_cross_join.test
+++ b/test/optimizer/joins/lateral_cross_join.test
@@ -1,0 +1,49 @@
+# name: test/optimizer/joins/lateral_cross_join.test
+# description: test to string of complex lateral cross join
+# group: [joins]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE all_time_periods (
+    start_date DATE,
+    end_date DATE
+);
+
+statement ok
+CREATE TABLE weekly_trading_cube (
+    ship_date DATE,
+    vendor_name VARCHAR,
+    master_league VARCHAR,
+    net_demand DECIMAL
+);
+
+statement ok
+CREATE TABLE league_mapping (
+    wtc_league VARCHAR,
+    finance_league VARCHAR
+);
+
+statement ok
+INSERT INTO all_time_periods VALUES
+('2024-01-01', '2024-12-31');
+
+statement ok
+INSERT INTO weekly_trading_cube VALUES
+('2024-06-15', 'F Branded', 'MLB', 100.0),
+('2024-07-15', 'M & Ness', 'NBA', 200.0);
+
+statement ok
+INSERT INTO league_mapping VALUES
+('MLB', 'Major League Baseball'),
+('NBA', 'National Basketball Association');
+
+query III
+WITH date_range AS (SELECT min(start_date) AS min_start_date, max(end_date) AS max_end_date FROM all_time_periods)
+SELECT wtc.vendor_name, wtc.ship_date, lm.finance_league
+FROM weekly_trading_cube AS wtc CROSS JOIN date_range AS dr
+LEFT JOIN league_mapping AS lm ON (((upper(wtc.master_league) = upper(lm.wtc_league)) AND (wtc.ship_date BETWEEN dr.min_start_date AND dr.max_end_date)))
+WHERE (wtc.vendor_name = 'F Branded')
+----
+F Branded	2024-06-15	Major League Baseball


### PR DESCRIPTION
For execution, whether or not a cross join is implicit or not does not matter - but it matters for converting to SQL as implicit and explicit cross joins are handled in different orders. This fixes an issue where `ToString()` would emit a query that was not re-executable.