### PR TITLE
Re-use metadata of unaltered row groups when checkpointing a table

### DIFF
--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -29,13 +29,13 @@ public:
 public:
 	void WriteTableData(Serializer &metadata_serializer);
 
-	virtual void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows,
-	                                 vector<MetaBlockPointer> data_pointers) = 0;
+	virtual void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) = 0;
 	virtual void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) = 0;
 	virtual unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) = 0;
 
 	virtual void AddRowGroup(RowGroupPointer &&row_group_pointer, unique_ptr<RowGroupWriter> writer);
 	virtual CheckpointType GetCheckpointType() const = 0;
+	virtual MetadataManager &GetMetadataManager() = 0;
 
 	DatabaseInstance &GetDatabase();
 	unique_ptr<TaskExecutor> CreateTaskExecutor();
@@ -53,11 +53,11 @@ public:
 	                          MetadataWriter &table_data_writer);
 
 public:
-	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows,
-	                         vector<MetaBlockPointer> data_pointers) override;
+	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) override;
 	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) override;
 	unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) override;
 	CheckpointType GetCheckpointType() const override;
+	MetadataManager &GetMetadataManager() override;
 
 private:
 	SingleFileCheckpointWriter &checkpoint_manager;

--- a/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
+++ b/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
@@ -49,11 +49,11 @@ public:
 	InMemoryTableDataWriter(InMemoryCheckpointer &checkpoint_manager, TableCatalogEntry &table);
 
 public:
-	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows,
-	                         vector<MetaBlockPointer> data_pointers) override;
+	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) override;
 	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) override;
 	unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) override;
 	CheckpointType GetCheckpointType() const override;
+	MetadataManager &GetMetadataManager() override;
 
 private:
 	InMemoryCheckpointer &checkpoint_manager;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -65,6 +65,7 @@ struct RowGroupWriteInfo {
 struct RowGroupWriteData {
 	vector<unique_ptr<ColumnCheckpointState>> states;
 	vector<BaseStatistics> statistics;
+	vector<MetaBlockPointer> existing_pointers;
 };
 
 class RowGroup : public SegmentBase<RowGroup> {

--- a/src/include/duckdb/storage/table/row_group_segment_tree.hpp
+++ b/src/include/duckdb/storage/table/row_group_segment_tree.hpp
@@ -23,7 +23,6 @@ public:
 
 	void Initialize(PersistentTableData &data);
 
-	bool HasChanges(SegmentLock &lock) const;
 	MetaBlockPointer GetRootPointer() const {
 		return root_pointer;
 	}

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -54,11 +54,13 @@ CheckpointType SingleFileTableDataWriter::GetCheckpointType() const {
 	return checkpoint_manager.GetCheckpointType();
 }
 
-void SingleFileTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows,
-                                                    vector<MetaBlockPointer> data_pointers) {
+MetadataManager &SingleFileTableDataWriter::GetMetadataManager() {
+	return checkpoint_manager.GetMetadataManager();
+}
+
+void SingleFileTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) {
 	existing_pointer = pointer;
 	existing_rows = total_rows;
-	existing_pointers = std::move(data_pointers);
 }
 
 void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info,
@@ -102,8 +104,6 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 		MetadataReader reader(metadata_manager, pointer);
 		auto blocks = reader.GetRemainingBlocks();
 		metadata_manager.ClearModifiedBlocks(blocks);
-
-		metadata_manager.ClearModifiedBlocks(existing_pointers);
 	}
 
 	// Now begin the metadata as a unit

--- a/src/storage/table/in_memory_checkpoint.cpp
+++ b/src/storage/table/in_memory_checkpoint.cpp
@@ -86,8 +86,7 @@ InMemoryTableDataWriter::InMemoryTableDataWriter(InMemoryCheckpointer &checkpoin
     : TableDataWriter(table, checkpoint_manager.GetClientContext()), checkpoint_manager(checkpoint_manager) {
 }
 
-void InMemoryTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows,
-                                                  vector<MetaBlockPointer> data_pointers) {
+void InMemoryTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) {
 }
 
 void InMemoryTableDataWriter::FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info,
@@ -101,6 +100,10 @@ unique_ptr<RowGroupWriter> InMemoryTableDataWriter::GetRowGroupWriter(RowGroup &
 
 CheckpointType InMemoryTableDataWriter::GetCheckpointType() const {
 	return checkpoint_manager.GetCheckpointType();
+}
+
+MetadataManager &InMemoryTableDataWriter::GetMetadataManager() {
+	return checkpoint_manager.GetMetadataManager();
 }
 
 InMemoryPartialBlock::InMemoryPartialBlock(ColumnData &data, ColumnSegment &segment, PartialBlockState state,

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -50,18 +50,6 @@ unique_ptr<RowGroup> RowGroupSegmentTree::LoadSegment() {
 	return make_uniq<RowGroup>(collection, std::move(row_group_pointer));
 }
 
-bool RowGroupSegmentTree::HasChanges(SegmentLock &l) const {
-	// check if any changes have been made
-	// any row groups that are not loaded by definition do not have any changes - so avoid loading extra row groups
-	auto &segments = ReferenceLoadedSegments(l);
-	for (auto &segment : segments) {
-		if (segment.node->HasChanges()) {
-			return true;
-		}
-	}
-	return false;
-}
-
 //===--------------------------------------------------------------------===//
 // Row Group Collection
 //===--------------------------------------------------------------------===//

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1053,19 +1053,6 @@ unique_ptr<CheckpointTask> RowGroupCollection::GetCheckpointTask(CollectionCheck
 
 void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &global_stats) {
 	auto l = row_groups->Lock();
-	if (metadata_pointer.IsValid() && !row_groups->HasChanges(l)) {
-		vector<MetaBlockPointer> data_pointers;
-		for (auto &row_group : row_groups->Segments(l)) {
-			auto column_pointers = row_group.GetColumnPointers();
-			data_pointers.insert(data_pointers.end(), column_pointers.begin(), column_pointers.end());
-
-			auto &deletes_pointers = row_group.GetDeletesPointers();
-			data_pointers.insert(data_pointers.end(), deletes_pointers.begin(), deletes_pointers.end());
-		}
-		writer.WriteUnchangedTable(metadata_pointer, total_rows.load(), std::move(data_pointers));
-		return;
-	}
-
 	auto segments = row_groups->MoveSegments(l);
 
 	CollectionCheckpointState checkpoint_state(*this, writer, segments, global_stats);
@@ -1109,6 +1096,39 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 	checkpoint_state.executor->WorkOnTasks();
 
 	// no errors - finalize the row groups
+	// if the table already exists on disk - check if all row groups have stayed the same
+	if (metadata_pointer.IsValid()) {
+		bool table_has_changes = false;
+		for (idx_t segment_idx = 0; segment_idx < segments.size(); segment_idx++) {
+			auto &entry = segments[segment_idx];
+			if (!entry.node) {
+				table_has_changes = true;
+				break;
+			}
+			auto &write_state = checkpoint_state.write_data[segment_idx];
+			if (write_state.existing_pointers.empty()) {
+				table_has_changes = true;
+				break;
+			}
+		}
+		if (!table_has_changes) {
+			// table is unmodified and already exists on disk
+			// we can directly re-use the metadata pointer
+			// mark all blocks associated with row groups as still being in-use
+			auto &metadata_manager = writer.GetMetadataManager();
+			for (idx_t segment_idx = 0; segment_idx < segments.size(); segment_idx++) {
+				auto &entry = segments[segment_idx];
+				auto &row_group = *entry.node;
+				auto &write_state = checkpoint_state.write_data[segment_idx];
+				metadata_manager.ClearModifiedBlocks(write_state.existing_pointers);
+				metadata_manager.ClearModifiedBlocks(row_group.GetDeletesPointers());
+				row_groups->AppendSegment(l, std::move(entry.node));
+			}
+			writer.WriteUnchangedTable(metadata_pointer, total_rows.load());
+			return;
+		}
+	}
+
 	idx_t new_total_rows = 0;
 	for (idx_t segment_idx = 0; segment_idx < segments.size(); segment_idx++) {
 		auto &entry = segments[segment_idx];

--- a/test/sql/storage/metadata/partial_table_metadata_reuse.test
+++ b/test/sql/storage/metadata/partial_table_metadata_reuse.test
@@ -1,0 +1,32 @@
+# name: test/sql/storage/metadata/partial_table_metadata_reuse.test
+# description: Test partial table metadata reuse
+# group: [metadata]
+
+load __TEST_DIR__/partial_table_metadata_reuse.test.db
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE bigtbl(i INT);
+
+statement ok
+INSERT INTO bigtbl FROM range(1000000)
+
+statement ok
+COMMIT
+
+
+loop i 1 10
+
+statement ok
+INSERT INTO bigtbl VALUES (NULL)
+
+query II
+SELECT COUNT(*) - ${i}, SUM(i) FROM bigtbl
+----
+1000000	499999500000
+
+restart
+
+endloop

--- a/test/sql/storage/metadata/partial_table_metadata_reuse_nested.test_slow
+++ b/test/sql/storage/metadata/partial_table_metadata_reuse_nested.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/storage/metadata/full_table_metadata_reuse_nested.test_slow
+# name: test/sql/storage/metadata/partial_table_metadata_reuse_nested.test_slow
 # description: Test full table metadata reuse of complex nested data
 # group: [metadata]
 

--- a/test/sql/storage/metadata/partial_table_metadata_reuse_nested.test_slow
+++ b/test/sql/storage/metadata/partial_table_metadata_reuse_nested.test_slow
@@ -1,0 +1,35 @@
+# name: test/sql/storage/metadata/full_table_metadata_reuse_nested.test_slow
+# description: Test full table metadata reuse of complex nested data
+# group: [metadata]
+
+load __TEST_DIR__/partial_table_metadata_reuse_nested.test.db
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE complex_nested(s STRUCT(i INT, j INT[], k VARCHAR, l INT[], i1 INT, i2 INT, i3 INT, i4 INT, i5 INT, i6 INT, i7 INT, i8 INT, i9 INT, i10 INT, i11 INT, i12 INT, i13 INT, i14 INT, i15 INT, i16 INT, i17 INT, i18 INT, i19 INT, i20 INT, i21 INT, i22 INT, i23 INT, i24 INT, i25 INT, i26 INT, i27 INT, i28 INT, i29 INT, i30 INT, i31 INT, i32 INT, i33 INT, i34 INT, i35 INT, i36 INT, i37 INT, i38 INT, i39 INT, i40 INT, i41 INT, i42 INT, i43 INT, i44 INT, i45 INT, i46 INT, i47 INT, i48 INT, i49 INT, i50 INT));
+
+statement ok
+INSERT INTO complex_nested SELECT ROW(r, range(10), 'hello world', range(90, 100), r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r, r) s FROM range(1000000) t(r)
+
+statement ok
+COMMIT
+
+
+loop i 0 10
+
+statement ok
+INSERT INTO complex_nested DEFAULT VALUES
+
+statement ok
+CHECKPOINT
+
+restart
+
+endloop
+
+query IIIII
+SELECT COUNT(*), SUM(t.i), SUM(LEN(t.j)), SUM(LEN(t.k)), SUM(LIST_SUM([*COLUMNS('i\d+')])) FROM (SELECT UNNEST(s) FROM complex_nested) t
+----
+1000010	499999500000	10000000	11000000	24999975000000


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/18390

This PR implements metadata re-use at the row group level, so if we are e.g. appending to a large table we no longer rewrite the metadata of unchanged row-groups, and instead refer to the existing metadata on-disk. In addition, this PR also performs a few fixes where we would eagerly load columns unnecessarily. 



### Performance

Consider a database storing TPC-H SF100. The biggest table (lineitem) has 600M rows.

```sql
CALL dbgen(sf=100);
```


Now insert a single row into the largest table (`lineitem`) and checkpoint. We measure two times: the time of the `CHECKPOINT` command, and the full runtime of opening the database, running the insert + checkpoint, and closing the database.

```sql
INSERT INTO lineitem VALUES (600000001, 0, 0, 0, 0, 0, 0, 0, '', '', DATE '2000-01-01', DATE '2000-01-01', DATE '2000-01-01', '', '', '');
CHECKPOINT;
```

| Operation  | v1.3.2 |  New  |
|------------|--------|-------|
| Checkpoint | 0.5s   | 0.11s |
| Full       | 0.63s  | 0.13s |
