### PR TITLE
CI: Fix Discussion mirroring

### DIFF
--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Remove 'needs triage' label
         run: |
-          gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number || github.event.discussion.number }} --remove-label "needs triage"
+          gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number }} --remove-label "needs triage"
 
   add_needs_reproducible_example_comment:
     if: github.event.label.name == 'needs reproducible example'
@@ -37,7 +37,7 @@ jobs:
 
           For more detailed guidelines on how to create reproducible examples, please visit Stack Overflow's [“Minimal, Reproducible Example”](https://stackoverflow.com/help/minimal-reproducible-example) page.
           EOF
-          gh issue comment --repo duckdb/duckdb ${{ github.event.issue.number || github.event.discussion.number }} --body-file needs-reproducible-example-comment.md
+          gh issue comment --repo duckdb/duckdb ${{ github.event.issue.number }} --body-file needs-reproducible-example-comment.md
 
   create_or_label_mirror_issue:
     if: github.event.label.name == 'reproduced' || github.event.label.name == 'under review'
@@ -46,17 +46,17 @@ jobs:
       - name: Remove 'needs triage' / 'under review' if 'reproduced'
         if: github.event.label.name == 'reproduced'
         run: |
-          gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number || github.event.discussion.number }} --remove-label "needs triage" --remove-label "under review" --remove-label "needs reproducible example"
+          gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number }} --remove-label "needs triage" --remove-label "under review" --remove-label "needs reproducible example"
 
       - name: Remove 'needs triage' / 'reproduced' if 'under review'
         if: github.event.label.name == 'under review'
         run: |
-          gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number || github.event.discussion.number }} --remove-label "needs triage" --remove-label "reproduced"
+          gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number }} --remove-label "needs triage" --remove-label "reproduced"
 
       - name: Remove 'needs triage' if 'expected behavior'
         if: github.event.label.name == 'expected behavior'
         run: |
-          gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number || github.event.discussion.number }} --remove-label "needs triage"
+          gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number }} --remove-label "needs triage"
 
       - name: Get mirror issue number
         run: |


### PR DESCRIPTION
This PR fixes discussion mirroring.

The `gh` CLI tool has limited support to work with discussions (https://github.com/cli/cli/discussions/4212), so the recommendation is to script using GraphQL. However, we actually do not need to do much with the discussions to mirror them: we simply need to open an internal issue. There is no need to adjust the labels of discussions.