### PR TITLE
Store extra metadata blocks in RowGroupPointer, and only flush dirty Metadata blocks

### DIFF
--- a/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
@@ -35,6 +35,10 @@ public:
 	virtual WriteStream &GetPayloadWriter() = 0;
 	virtual MetaBlockPointer GetMetaBlockPointer() = 0;
 	virtual optional_ptr<MetadataManager> GetMetadataManager() = 0;
+	virtual void StartWritingColumns(vector<MetaBlockPointer> &column_metadata) {
+	}
+	virtual void FinishWritingColumns() {
+	}
 
 	PartialBlockManager &GetPartialBlockManager() {
 		return partial_block_manager;
@@ -57,6 +61,8 @@ public:
 	WriteStream &GetPayloadWriter() override;
 	MetaBlockPointer GetMetaBlockPointer() override;
 	optional_ptr<MetadataManager> GetMetadataManager() override;
+	void StartWritingColumns(vector<MetaBlockPointer> &column_metadata) override;
+	void FinishWritingColumns() override;
 
 private:
 	//! Underlying writer object

--- a/src/include/duckdb/storage/data_pointer.hpp
+++ b/src/include/duckdb/storage/data_pointer.hpp
@@ -71,6 +71,8 @@ struct RowGroupPointer {
 	vector<MetaBlockPointer> data_pointers;
 	//! Data pointers to the delete information of the row group (if any)
 	vector<MetaBlockPointer> deletes_pointers;
+	//! All metadata block pointers of column metadata - only set for newer databases
+	vector<MetaBlockPointer> column_metadata;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/data_pointer.hpp
+++ b/src/include/duckdb/storage/data_pointer.hpp
@@ -71,8 +71,11 @@ struct RowGroupPointer {
 	vector<MetaBlockPointer> data_pointers;
 	//! Data pointers to the delete information of the row group (if any)
 	vector<MetaBlockPointer> deletes_pointers;
-	//! All metadata block pointers of column metadata - only set for newer databases
-	vector<MetaBlockPointer> column_metadata;
+	//! Whether or not we have all metadata blocks defined in the pointer
+	bool has_metadata_blocks = false;
+	//! Metadata blocks of the columns that are not mentioned in "data_pointers"
+	//! This is often empty - but can be set for wide columns with a lot of metadata
+	vector<idx_t> extra_metadata_blocks;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/metadata/metadata_manager.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_manager.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/storage/block.hpp"
 #include "duckdb/storage/block_manager.hpp"
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/set.hpp"
 #include "duckdb/storage/buffer/buffer_handle.hpp"
 
@@ -19,9 +20,19 @@ class DatabaseInstance;
 struct MetadataBlockInfo;
 
 struct MetadataBlock {
+	MetadataBlock() : block_id(INVALID_BLOCK), dirty(false) {
+	}
+	// disable copy constructors
+	MetadataBlock(const MetadataBlock &other) = delete;
+	MetadataBlock &operator=(const MetadataBlock &) = delete;
+	//! enable move constructors
+	DUCKDB_API MetadataBlock(MetadataBlock &&other) noexcept;
+	DUCKDB_API MetadataBlock &operator=(MetadataBlock &&) noexcept;
+
 	shared_ptr<BlockHandle> block;
 	block_id_t block_id;
 	vector<uint8_t> free_blocks;
+	atomic<bool> dirty;
 
 	void Write(WriteStream &sink);
 	static MetadataBlock Read(ReadStream &source);

--- a/src/include/duckdb/storage/metadata/metadata_manager.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_manager.hpp
@@ -20,8 +20,7 @@ class DatabaseInstance;
 struct MetadataBlockInfo;
 
 struct MetadataBlock {
-	MetadataBlock() : block_id(INVALID_BLOCK), dirty(false) {
-	}
+	MetadataBlock();
 	// disable copy constructors
 	MetadataBlock(const MetadataBlock &other) = delete;
 	MetadataBlock &operator=(const MetadataBlock &) = delete;

--- a/src/include/duckdb/storage/metadata/metadata_writer.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_writer.hpp
@@ -30,6 +30,7 @@ public:
 	MetadataManager &GetManager() {
 		return manager;
 	}
+	void SetWrittenPointers(optional_ptr<vector<MetaBlockPointer>> written_pointers);
 
 protected:
 	virtual MetadataHandle NextHandle();

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -217,7 +217,8 @@ private:
 	vector<MetaBlockPointer> column_pointers;
 	unique_ptr<atomic<bool>[]> is_loaded;
 	vector<MetaBlockPointer> deletes_pointers;
-	vector<MetaBlockPointer> column_metadata;
+	bool has_metadata_blocks = false;
+	vector<idx_t> extra_metadata_blocks;
 	atomic<bool> deletes_is_loaded;
 	atomic<idx_t> allocation_size;
 };

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -217,6 +217,7 @@ private:
 	vector<MetaBlockPointer> column_pointers;
 	unique_ptr<atomic<bool>[]> is_loaded;
 	vector<MetaBlockPointer> deletes_pointers;
+	vector<MetaBlockPointer> column_metadata;
 	atomic<bool> deletes_is_loaded;
 	atomic<idx_t> allocation_size;
 };

--- a/src/storage/checkpoint/row_group_writer.cpp
+++ b/src/storage/checkpoint/row_group_writer.cpp
@@ -33,4 +33,12 @@ optional_ptr<MetadataManager> SingleFileRowGroupWriter::GetMetadataManager() {
 	return table_data_writer.GetManager();
 }
 
+void SingleFileRowGroupWriter::StartWritingColumns(vector<MetaBlockPointer> &column_metadata) {
+	table_data_writer.SetWrittenPointers(column_metadata);
+}
+
+void SingleFileRowGroupWriter::FinishWritingColumns() {
+	table_data_writer.SetWrittenPointers(nullptr);
+}
+
 } // namespace duckdb

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -9,6 +9,25 @@
 
 namespace duckdb {
 
+MetadataBlock::MetadataBlock(MetadataBlock &&other) noexcept {
+	std::swap(block, other.block);
+	std::swap(block_id, other.block_id);
+	std::swap(free_blocks, other.free_blocks);
+	auto dirty_val = dirty.load();
+	dirty = other.dirty.load();
+	other.dirty = dirty_val;
+}
+
+MetadataBlock &MetadataBlock::operator=(MetadataBlock &&other) noexcept {
+	std::swap(block, other.block);
+	std::swap(block_id, other.block_id);
+	std::swap(free_blocks, other.free_blocks);
+	auto dirty_val = dirty.load();
+	dirty = other.dirty.load();
+	other.dirty = dirty_val;
+	return *this;
+}
+
 MetadataManager::MetadataManager(BlockManager &block_manager, BufferManager &buffer_manager)
     : block_manager(block_manager), buffer_manager(buffer_manager) {
 }
@@ -37,6 +56,8 @@ MetadataHandle MetadataManager::AllocateHandle() {
 	MetadataPointer pointer;
 	pointer.block_index = UnsafeNumericCast<idx_t>(free_block);
 	auto &block = blocks[free_block];
+	// the block is now dirty
+	block.dirty = true;
 	if (block.block->BlockId() < MAXIMUM_BLOCK) {
 		// this block is a disk-backed block, yet we are planning to write to it
 		// we need to convert it into a transient block before we can write to it
@@ -81,6 +102,7 @@ void MetadataManager::ConvertToTransient(MetadataBlock &metadata_block) {
 	// copy the data to the transient block
 	memcpy(new_buffer.Ptr(), old_buffer.Ptr(), block_manager.GetBlockSize());
 	metadata_block.block = std::move(new_block);
+	metadata_block.dirty = true;
 
 	// unregister the old block
 	block_manager.UnregisterBlock(metadata_block.block_id);
@@ -96,6 +118,7 @@ block_id_t MetadataManager::AllocateNewBlock() {
 	for (idx_t i = 0; i < METADATA_BLOCK_COUNT; i++) {
 		new_block.free_blocks.push_back(NumericCast<uint8_t>(METADATA_BLOCK_COUNT - i - 1));
 	}
+	new_block.dirty = true;
 	// zero-initialize the handle
 	memset(handle.Ptr(), 0, block_manager.GetBlockSize());
 	AddBlock(std::move(new_block));
@@ -115,6 +138,9 @@ void MetadataManager::AddBlock(MetadataBlock new_block, bool if_exists) {
 void MetadataManager::AddAndRegisterBlock(MetadataBlock block) {
 	if (block.block) {
 		throw InternalException("Calling AddAndRegisterBlock on block that already exists");
+	}
+	if (block.block_id >= MAXIMUM_BLOCK) {
+		throw InternalException("AddAndRegisterBlock called with a transient block id");
 	}
 	block.block = block_manager.RegisterBlock(block.block_id);
 	AddBlock(std::move(block), true);
@@ -152,7 +178,7 @@ MetadataPointer MetadataManager::RegisterDiskPointer(MetaBlockPointer pointer) {
 	auto block_id = pointer.GetBlockId();
 	MetadataBlock block;
 	block.block_id = block_id;
-	AddAndRegisterBlock(block);
+	AddAndRegisterBlock(std::move(block));
 	return FromDiskPointer(pointer);
 }
 
@@ -188,6 +214,12 @@ void MetadataManager::Flush() {
 
 	for (auto &kv : blocks) {
 		auto &block = kv.second;
+		if (!block.dirty) {
+			if (block.block->BlockId() >= MAXIMUM_BLOCK) {
+				throw InternalException("Transient blocks must always be marked as dirty");
+			}
+			continue;
+		}
 		auto handle = buffer_manager.Pin(block.block);
 		// zero-initialize the few leftover bytes
 		memset(handle.Ptr() + total_metadata_size, 0, block_manager.GetBlockSize() - total_metadata_size);
@@ -196,11 +228,13 @@ void MetadataManager::Flush() {
 			// Convert the temporary block to a persistent block.
 			block.block =
 			    block_manager.ConvertToPersistent(QueryContext(), kv.first, std::move(block.block), std::move(handle));
-			continue;
+		} else {
+			// Already a persistent block, so we only need to write it.
+			D_ASSERT(block.block->BlockId() == block.block_id);
+			block_manager.Write(QueryContext(), handle.GetFileBuffer(), block.block_id);
 		}
-		// Already a persistent block, so we only need to write it.
-		D_ASSERT(block.block->BlockId() == block.block_id);
-		block_manager.Write(QueryContext(), handle.GetFileBuffer(), block.block_id);
+		// the block is no longer dirty
+		block.dirty = false;
 	}
 }
 

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -9,7 +9,10 @@
 
 namespace duckdb {
 
-MetadataBlock::MetadataBlock(MetadataBlock &&other) noexcept {
+MetadataBlock::MetadataBlock() : block_id(INVALID_BLOCK), dirty(false) {
+}
+
+MetadataBlock::MetadataBlock(MetadataBlock &&other) noexcept : dirty(false) {
 	std::swap(block, other.block);
 	std::swap(block_id, other.block_id);
 	std::swap(free_blocks, other.free_blocks);

--- a/src/storage/metadata/metadata_writer.cpp
+++ b/src/storage/metadata/metadata_writer.cpp
@@ -30,6 +30,13 @@ MetaBlockPointer MetadataWriter::GetMetaBlockPointer() {
 	return manager.GetDiskPointer(block.pointer, UnsafeNumericCast<uint32_t>(offset));
 }
 
+void MetadataWriter::SetWrittenPointers(optional_ptr<vector<MetaBlockPointer>> written_pointers_p) {
+	written_pointers = written_pointers_p;
+	if (written_pointers && capacity > 0) {
+		written_pointers->push_back(manager.GetDiskPointer(current_pointer));
+	}
+}
+
 MetadataHandle MetadataWriter::NextHandle() {
 	return manager.AllocateHandle();
 }


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/18395

This PR adds storage for `extra_metadata_blocks` in the row-group metadata when the latest storage version (v1.4.0) is used. This is a list of metadata blocks that are referenced by the row group metadata, but **not** present in the list of data pointers (`data_pointers`). These blocks can be present when either (1) columns are very wide due to e.g. being deeply nested, or (2) the final column pointer "crosses" the metadata block threshold, as `data_pointers` points only to the beginning of the column metadata.

Usually this list is empty - and therefore storing this does not take up a lot of extra storage space. The presence of this list allows us to more efficiently re-use metadata as we know exactly which metadata blocks a row group points to, without having to do any additional deserialization. 

### Only Flush Dirty Metadata blocks

Previously our metadata manager would flush all metadata blocks, incurring a lot of unnecessary I/O now that we are doing a lot of metadata re-use. This PR reworks this so that we keep track of which blocks are dirty and only flush the dirty blocks.

### Performance

Running the benchmark in https://github.com/duckdb/duckdb/pull/18395 again, we now get the following timings:

| Operation  | v1.3.2 |  Re-Use  |  New  |
|------------|--------|-------|-------|
| Checkpoint | 0.5s   | 0.11s | 0.04s |
| Full       | 0.63s  | 0.13s | 0.07s |