### PR TITLE
Wrap runner.ExecuteFile, otherwise cleanup is not properly performed

### DIFF
--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -79,8 +79,11 @@ static void testRunner() {
 		// Parse the test dir automatically
 		TestChangeDirectory(test_working_dir);
 	}
-
-	runner.ExecuteFile(name);
+	try {
+		runner.ExecuteFile(name);
+	} catch (...) {
+		// This is to allow cleanup to be executed, failure is already logged
+	}
 
 	if (AUTO_SWITCH_TEST_DIR) {
 		TestChangeDirectory(prev_directory);


### PR DESCRIPTION
Problem is that when using a non-standard folder and there is a throw that escape, cleanup is not properly performed and cause subsequent tests to be broken.