### PR TITLE
CI: Add separate job for discussion mirroring

### DIFF
--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -1,15 +1,12 @@
 name: Create or Label Mirror Issue
 on:
-  discussion:
-    types:
-      - labeled
   issues:
     types:
       - labeled
 
 env:
   GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
-  TITLE_PREFIX: "[duckdb/#${{ github.event.issue.number || github.event.discussion.number }}]"
+  TITLE_PREFIX: "[duckdb/#${{ github.event.issue.number }}]"
   PUBLIC_ISSUE_TITLE: ${{ github.event.issue.title }}
 
 jobs:
@@ -84,7 +81,7 @@ jobs:
       - name: Create or label issue
         run: |
           if [ "$MIRROR_ISSUE_NUMBER" == "" ]; then
-            gh issue create --repo duckdblabs/duckdb-internal --label "$LABEL" --title "$TITLE_PREFIX - $PUBLIC_ISSUE_TITLE" --body "See https://github.com/duckdb/duckdb/issues/${{ github.event.issue.number || github.event.discussion.number }}"
+            gh issue create --repo duckdblabs/duckdb-internal --label "$LABEL" --title "$TITLE_PREFIX - $PUBLIC_ISSUE_TITLE" --body "See https://github.com/duckdb/duckdb/issues/${{ github.event.issue.number }}"
           else
             gh issue edit --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --remove-label "$UNLABEL" --add-label "$LABEL"
           fi

--- a/.github/workflows/MirrorDiscussions.yml
+++ b/.github/workflows/MirrorDiscussions.yml
@@ -1,0 +1,19 @@
+name: Create Mirror for Discussions
+on:
+  discussion:
+    types:
+      - labeled
+
+env:
+  GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
+  TITLE_PREFIX: "[duckdb/#${{ github.event.discussion.number }}]"
+  PUBLIC_DISCUSSION_TITLE: ${{ github.event.discussion.title }}
+
+jobs:
+  create_mirror_issue:
+    if: github.event.label.name == 'under review'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create mirror issue for discussion
+        run: |
+          gh issue create --repo duckdblabs/duckdb-internal --label "discussion" --title "$TITLE_PREFIX - $PUBLIC_DISCUSSION_TITLE" --body "See https://github.com/duckdb/duckdb/discussions/${{ github.event.discussion.number }}"


### PR DESCRIPTION
Followup of #18397, splitting this to two separate jobs