### PR TITLE
Fix shell streaming output for file redirects

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -173,6 +173,7 @@ public:
 	unique_ptr<RowRenderer> GetRowRenderer();
 	unique_ptr<RowRenderer> GetRowRenderer(RenderMode mode);
 	void ExecutePreparedStatementColumnar(sqlite3_stmt *pStmt);
+	void RenderStreamingResult(sqlite3_stmt *pStmt, RenderMode render_mode);
 	char **TableColumnList(const char *zTab);
 	void ExecutePreparedStatement(sqlite3_stmt *pStmt);
 


### PR DESCRIPTION
## Summary
This PR fixes streaming output behavior in the DuckDB shell when redirecting output to files. 

The changes include:
- Extract streaming result rendering logic into a separate `RenderStreamingResult` method
- Fix CSV output mode for file redirects by properly calling the streaming renderer
- Preserve the original render mode state during streaming operations

## Changes Made
- Added `RenderStreamingResult()` method declaration to `shell_state.hpp`
- Implemented `RenderStreamingResult()` method in `shell.cpp` that handles streaming output with proper mode preservation
- Modified `ExecutePreparedStatement()` to use streaming rendering for file output and other streaming modes

## Test Plan
- Verify CSV output to files works correctly with streaming
- Test that other output modes continue to work as expected
- Ensure no regression in console output behavior

Fixes #18331