### PR TITLE
fix: remove unused start parameter from ArrowTableFunction::ArrowToDuckDB

### DIFF
--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -189,11 +189,11 @@ void ArrowTableFunction::ArrowScanFunction(ClientContext &context, TableFunction
 	if (global_state.CanRemoveFilterColumns()) {
 		state.all_columns.Reset();
 		state.all_columns.SetCardinality(output_size);
-		ArrowToDuckDB(state, data.arrow_table.GetColumns(), state.all_columns, data.lines_read - output_size);
+		ArrowToDuckDB(state, data.arrow_table.GetColumns(), state.all_columns);
 		output.ReferenceColumns(state.all_columns, global_state.projection_ids);
 	} else {
 		output.SetCardinality(output_size);
-		ArrowToDuckDB(state, data.arrow_table.GetColumns(), output, data.lines_read - output_size);
+		ArrowToDuckDB(state, data.arrow_table.GetColumns(), output);
 	}
 
 	output.Verify();

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -1422,9 +1422,16 @@ static void ColumnArrowToDuckDBDictionary(Vector &vector, ArrowArray &array, Arr
 	vector.Verify(size);
 }
 
+// Deprecated function, use the one with the rowid_column_index parameter removed
 void ArrowTableFunction::ArrowToDuckDB(ArrowScanLocalState &scan_state, const arrow_column_map_t &arrow_convert_data,
                                        DataChunk &output, idx_t start, bool arrow_scan_is_projected,
                                        idx_t rowid_column_index) {
+	ArrowTableFunction::ArrowToDuckDB(scan_state, arrow_convert_data, output, arrow_scan_is_projected,
+	                                  rowid_column_index);
+}
+
+void ArrowTableFunction::ArrowToDuckDB(ArrowScanLocalState &scan_state, const arrow_column_map_t &arrow_convert_data,
+                                       DataChunk &output, bool arrow_scan_is_projected, idx_t rowid_column_index) {
 	for (idx_t idx = 0; idx < output.ColumnCount(); idx++) {
 		auto col_idx = scan_state.column_ids.empty() ? idx : scan_state.column_ids[idx];
 

--- a/src/include/duckdb/function/table/arrow.hpp
+++ b/src/include/duckdb/function/table/arrow.hpp
@@ -193,6 +193,11 @@ public:
 	                                                  vector<LogicalType> &return_types, vector<string> &names);
 	//! Actual conversion from Arrow to DuckDB
 	static void ArrowToDuckDB(ArrowScanLocalState &scan_state, const arrow_column_map_t &arrow_convert_data,
+	                          DataChunk &output, bool arrow_scan_is_projected = true,
+	                          idx_t rowid_column_index = COLUMN_IDENTIFIER_ROW_ID);
+
+	//! Actual conversion from Arrow to DuckDB, with deprecated start parameter.
+	static void ArrowToDuckDB(ArrowScanLocalState &scan_state, const arrow_column_map_t &arrow_convert_data,
 	                          DataChunk &output, idx_t start, bool arrow_scan_is_projected = true,
 	                          idx_t rowid_column_index = COLUMN_IDENTIFIER_ROW_ID);
 


### PR DESCRIPTION
The start parameter was unused, so I've removed it.