### PR TITLE
feat: remove anything following `?` in database name

### DIFF
--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -147,11 +147,17 @@ bool AttachedDatabase::NameIsReserved(const string &name) {
 	return name == DEFAULT_SCHEMA || name == TEMP_CATALOG || name == SYSTEM_CATALOG;
 }
 
+static string RemoveQueryParams(const string &name) {
+	auto vec = StringUtil::Split(name, "?");
+	D_ASSERT(!vec.empty());
+	return vec[0];
+}
+
 string AttachedDatabase::ExtractDatabaseName(const string &dbpath, FileSystem &fs) {
 	if (dbpath.empty() || dbpath == IN_MEMORY_PATH) {
 		return "memory";
 	}
-	auto name = fs.ExtractBaseName(dbpath);
+	auto name = RemoveQueryParams(fs.ExtractBaseName(dbpath));
 	if (NameIsReserved(name)) {
 		name += "_db";
 	}


### PR DESCRIPTION
To support databases that are specified using URL paths with query parameters, I'd like to propose that when starting duckdb with

`airport:grpc://localhost:50003/test1?option=abc`

The database name is just `test1` rather than `test1?option=abc`.