### PR TITLE
Correctly fetch only base column data in ColumnData::FetchUpdateData

### DIFF
--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -567,7 +567,7 @@ void ColumnData::FetchRow(TransactionData transaction, ColumnFetchState &state, 
 
 idx_t ColumnData::FetchUpdateData(row_t *row_ids, Vector &base_vector) {
 	ColumnScanState state;
-	auto fetch_count = Fetch(state, row_ids[0], base_vector);
+	auto fetch_count = ColumnData::Fetch(state, row_ids[0], base_vector);
 	base_vector.Flatten(fetch_count);
 	return fetch_count;
 }

--- a/test/sql/update/update_join_nulls.test
+++ b/test/sql/update/update_join_nulls.test
@@ -1,0 +1,19 @@
+# name: test/sql/update/update_join_nulls.test
+# description: Test update + join with NULl values
+# group: [update]
+
+statement ok
+CREATE TABLE t(table_id BIGINT, val BOOLEAN);
+
+statement ok
+INSERT INTO t VALUES (1, NULL);
+
+statement ok
+WITH new_values(tid, new_val) AS (
+	VALUES (1, NULL)
+)
+UPDATE t
+SET val=new_val
+FROM new_values
+WHERE table_id=tid
+;


### PR DESCRIPTION
Prevents reading the validity data twice

This doesn't actually cause incorrect behavior - but it triggers an assertion, and is unnecessary work.