### PR TITLE
Fix incorrect character encoding in GetLastErrorAsString on Windows

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -796,8 +796,8 @@ std::string LocalFileSystem::GetLastErrorAsString() {
 
 	LPWSTR messageBuffer = nullptr;
 	idx_t size = FormatMessageW(
-		FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
-		errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
+	    FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
+	    errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
 
 	if (size == 0) {
 		return std::string();

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -794,12 +794,18 @@ std::string LocalFileSystem::GetLastErrorAsString() {
 	if (errorMessageID == 0)
 		return std::string(); // No error message has been recorded
 
-	LPSTR messageBuffer = nullptr;
+	LPWSTR messageBuffer = nullptr;
 	idx_t size =
-	    FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-	                   NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+	    FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+	                   NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
 
-	std::string message(messageBuffer, size);
+	if (size == 0) {
+		return std::string();
+	}
+
+	// Convert wide string to UTF-8
+	std::wstring wideMessage(messageBuffer, size);
+	std::string message = WindowsUtil::UnicodeToUTF8(wideMessage.c_str());
 
 	// Free the buffer.
 	LocalFree(messageBuffer);

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -795,9 +795,9 @@ std::string LocalFileSystem::GetLastErrorAsString() {
 		return std::string(); // No error message has been recorded
 
 	LPWSTR messageBuffer = nullptr;
-	idx_t size =
-	    FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-	                   NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
+	idx_t size = FormatMessageW(
+		FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
+		errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
 
 	if (size == 0) {
 		return std::string();


### PR DESCRIPTION
### Summary

This PR fixes a character encoding issue on Windows where error messages retrieved using `GetLastError()` and `FormatMessageA` may be garbled when non-ASCII characters are involved.

### Changes

- Replaced `FormatMessageA` with `FormatMessageW` to retrieve wide-character error messages.
- Added conversion from `std::wstring` to UTF-8 using `WindowsUtil::UnicodeToUTF8`.
- Updated return logic to handle empty messages safely.

### Why

On localized Windows systems, `FormatMessageA` can return garbled messages when using non-ASCII locale (e.g., Chinese). This patch ensures proper Unicode support.


