### PR TITLE
Parquet: add row-group ordinal during writing encryption

### DIFF
--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -547,11 +547,11 @@ void ParquetWriter::FlushRowGroup(PreparedRowGroup &prepared) {
 	row_group.__isset.total_compressed_size = true;
 
 	if (encryption_config) {
-		auto row_group_ordinal = num_row_groups.load(std::memory_order_relaxed);
+		auto row_group_ordinal = num_row_groups.load();
 		if (row_group_ordinal > std::numeric_limits<int16_t>::max()) {
 			throw InvalidInputException("RowGroup ordinal exceeds 32767 when encryption enabled");
 		}
-		row_group.ordinal = static_cast<int16_t>(num_row_groups);
+		row_group.ordinal = NumericCast<int16_t>(row_group_ordinal);
 		row_group.__isset.ordinal = true;
 	}
 

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -546,6 +546,15 @@ void ParquetWriter::FlushRowGroup(PreparedRowGroup &prepared) {
 	row_group.total_compressed_size = NumericCast<int64_t>(writer->GetTotalWritten()) - row_group.file_offset;
 	row_group.__isset.total_compressed_size = true;
 
+	if (encryption_config) {
+		auto row_group_ordinal = num_row_groups.load(std::memory_order_relaxed);
+		if (row_group_ordinal > std::numeric_limits<int16_t>::max()) {
+			throw InvalidInputException("RowGroup ordinal exceeds 32767 when encryption enabled");
+		}
+		row_group.ordinal = static_cast<int16_t>(num_row_groups);
+		row_group.__isset.ordinal = true;
+	}
+
 	// append the row group to the file metadata
 	file_meta_data.row_groups.push_back(row_group);
 	file_meta_data.num_rows += row_group.num_rows;


### PR DESCRIPTION
RowGroup.ordinal is required in encryption, see[1][2]. Arrow-cpp[3] and arrow-rs writes this

[1] https://github.com/apache/parquet-format/pull/453
[2] https://github.com/apache/parquet-format/blob/master/Encryption.md
[3] https://github.com/apache/arrow/commit/f4a63d41ebbc57566f215c1d1e87fc1647071dae
[4] https://github.com/apache/arrow-rs/blob/1d9afbc037d7c0562b7f80115928a1b5050c5692/parquet/src/file/writer.rs#L736