### PR TITLE
[Chore] Improve skipped tests in test config and add verify_fetch_row config

### DIFF
--- a/test/configs/encryption.json
+++ b/test/configs/encryption.json
@@ -6,116 +6,42 @@
   "skip_compiled": "true",
   "skip_tests": [
     {
-      "reason": "",
-      "path": "test/extension/test_tags.test"
-    },
-    {
-      "reason": "",
-      "path": "test/extension/load_extension.test"
-    },
-    {
-      "reason": "",
-      "path": "test/extension/autoloading_types.test"
+      "reason": "TODO",
+      "paths": [
+        "test/extension/test_tags.test",
+        "test/extension/load_extension.test",
+        "test/extension/autoloading_types.test",
+        "test/sql/settings/drop_set_schema.test",
+        "test/sql/show_select/test_describe_all.test",
+        "test/extension/test_custom_type_modifier_cast.test",
+        "test/extension/test_alias_point.test",
+        "test/extension/load_test_alias.test",
+        "test/fuzzer/pedro/incomplete_checkpoint.test",
+        "test/sql/catalog/test_set_search_path.test",
+        "test/sql/catalog/function/attached_macro.test",
+        "test/sql/catalog/test_temporary.test",
+        "test/sql/pragma/test_show_tables_temp_views.test",
+        "test/sql/storage/temp_directory/max_swap_space_error.test",
+        "test/sql/pg_catalog/system_functions.test",
+        "test/sql/attach/attach_table_info.test",
+        "test/sql/attach/attach_did_you_mean.test",
+        "test/sql/attach/show_databases.test",
+        "test/sql/attach/attach_show_all_tables.test",
+        "test/sql/attach/attach_default_table.test",
+        "test/sql/attach/attach_icu_collation.test",
+        "test/sql/function/list/lambdas/incorrect.test",
+        "test/sql/json/test_json_serialize_sql.test",
+        "test/sql/attach/attach_views.test",
+        "test/sql/table_function/duckdb_databases.test",
+        "test/sql/copy_database/copy_table_with_sequence.test",
+        "test/sql/logging/file_system_logging_attach.test"
+      ]
     },
     {
       "reason": "Attached databases have a main schema, which is not implicit.",
-      "path": "test/fuzzer/sqlsmith/current_schemas_null.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/settings/drop_set_schema.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/show_select/test_describe_all.test"
-    },
-    {
-      "reason": "",
-      "path": "test/extension/test_custom_type_modifier_cast.test"
-    },
-    {
-      "reason": "",
-      "path": "test/extension/test_alias_point.test"
-    },
-    {
-      "reason": "",
-      "path": "test/extension/load_test_alias.test"
-    },
-    {
-      "reason": "",
-      "path": "test/fuzzer/pedro/incomplete_checkpoint.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/catalog/test_set_search_path.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/catalog/function/attached_macro.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/catalog/test_temporary.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/pragma/test_show_tables_temp_views.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/storage/temp_directory/max_swap_space_error.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/pg_catalog/system_functions.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_table_info.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_did_you_mean.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/show_databases.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_show_all_tables.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_default_table.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_icu_collation.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/function/list/lambdas/incorrect.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/json/test_json_serialize_sql.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_views.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/table_function/duckdb_databases.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/copy_database/copy_table_with_sequence.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/logging/file_system_logging_attach.test"
+      "paths": [
+        "test/fuzzer/sqlsmith/current_schemas_null.test"
+      ]
     }
   ]
 }

--- a/test/configs/force_storage.json
+++ b/test/configs/force_storage.json
@@ -4,72 +4,25 @@
   "skip_compiled": "true",
   "skip_tests": [
     {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/show_select/test_describe_all.test"
-    },
-    {
-      "reason": "'USE memory' does not work with a persistent DB.",
-      "path": "test/sql/constraints/foreignkey/test_fk_eager_constraint_checking.test"
-    },
-    {
-      "reason": "Uses the memory catalog.",
-      "path": "test/sql/catalog/function/attached_macro.test"
-    },
-    {
-      "reason": "Uses the memory catalog.",
-      "path": "test/sql/catalog/test_temporary.test"
-    },
-    {
-      "reason": "SHOW ALL TABLES shows in-memory or persistent tables (different catalog names).",
-      "path": "test/sql/pragma/test_show_tables_temp_views.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/pg_catalog/system_functions.test"
-    },
-    {
-      "reason": "Expects the main catalog.",
-      "path": "test/sql/pg_catalog/sqlalchemy.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/attach/attach_table_info.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/attach/attach_defaults.test"
-    },
-    {
-      "reason": "Error message expects the memory catalog.",
-      "path": "test/sql/attach/attach_did_you_mean.test"
-    },
-    {
-      "reason": "Expects the memory catalog for ambiguity checks and USE.",
-      "path": "test/sql/attach/attach_default_table.test"
-    },
-    {
-      "reason": "SHOW ALL TABLES shows in-memory or persistent tables (different catalog names).",
-      "path": "test/sql/attach/attach_show_all_tables.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/attach/attach_issue7711.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/attach/attach_issue_7660.test"
-    },
-    {
-      "reason": "SHOW DATABASES expects the memory catalog.",
-      "path": "test/sql/attach/show_databases.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/attach/attach_views.test"
-    },
-    {
-      "reason": "Expects to copy an in-memory database.",
-      "path": "test/sql/copy_database/copy_table_with_sequence.test"
+      "reason": "Contains explicit use of the memory catalog.",
+      "paths": [
+        "test/sql/show_select/test_describe_all.test",
+        "test/sql/catalog/function/attached_macro.test",
+        "test/sql/catalog/test_temporary.test",
+        "test/sql/pragma/test_show_tables_temp_views.test",
+        "test/sql/pg_catalog/system_functions.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/attach/attach_table_info.test",
+        "test/sql/attach/attach_defaults.test",
+        "test/sql/attach/attach_did_you_mean.test",
+        "test/sql/attach/attach_default_table.test",
+        "test/sql/attach/attach_show_all_tables.test",
+        "test/sql/attach/attach_issue7711.test",
+        "test/sql/attach/attach_issue_7660.test",
+        "test/sql/attach/show_databases.test",
+        "test/sql/attach/attach_views.test",
+        "test/sql/copy_database/copy_table_with_sequence.test"
+      ]
     }
   ]
 }

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -5,72 +5,25 @@
   "skip_compiled": "true",
   "skip_tests": [
     {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/show_select/test_describe_all.test"
-    },
-    {
-      "reason": "'USE memory' does not work with a persistent DB.",
-      "path": "test/sql/constraints/foreignkey/test_fk_eager_constraint_checking.test"
-    },
-    {
-      "reason": "Uses the memory catalog.",
-      "path": "test/sql/catalog/function/attached_macro.test"
-    },
-    {
-      "reason": "Uses the memory catalog.",
-      "path": "test/sql/catalog/test_temporary.test"
-    },
-    {
-      "reason": "SHOW ALL TABLES shows in-memory or persistent tables (different catalog names).",
-      "path": "test/sql/pragma/test_show_tables_temp_views.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/pg_catalog/system_functions.test"
-    },
-    {
-      "reason": "Expects the main catalog.",
-      "path": "test/sql/pg_catalog/sqlalchemy.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/attach/attach_table_info.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/attach/attach_defaults.test"
-    },
-    {
-      "reason": "Error message expects the memory catalog.",
-      "path": "test/sql/attach/attach_did_you_mean.test"
-    },
-    {
-      "reason": "Expects the memory catalog for ambiguity checks and USE.",
-      "path": "test/sql/attach/attach_default_table.test"
-    },
-    {
-      "reason": "SHOW ALL TABLES shows in-memory or persistent tables (different catalog names).",
-      "path": "test/sql/attach/attach_show_all_tables.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/attach/attach_issue7711.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/attach/attach_issue_7660.test"
-    },
-    {
-      "reason": "SHOW DATABASES expects the memory catalog.",
-      "path": "test/sql/attach/show_databases.test"
-    },
-    {
-      "reason": "Expects the memory catalog.",
-      "path": "test/sql/attach/attach_views.test"
-    },
-    {
-      "reason": "Expects to copy an in-memory database.",
-      "path": "test/sql/copy_database/copy_table_with_sequence.test"
+      "reason": "Contains explicit use of the memory catalog.",
+      "paths": [
+        "test/sql/show_select/test_describe_all.test",
+        "test/sql/catalog/function/attached_macro.test",
+        "test/sql/catalog/test_temporary.test",
+        "test/sql/pragma/test_show_tables_temp_views.test",
+        "test/sql/pg_catalog/system_functions.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/attach/attach_table_info.test",
+        "test/sql/attach/attach_defaults.test",
+        "test/sql/attach/attach_did_you_mean.test",
+        "test/sql/attach/attach_default_table.test",
+        "test/sql/attach/attach_show_all_tables.test",
+        "test/sql/attach/attach_issue7711.test",
+        "test/sql/attach/attach_issue_7660.test",
+        "test/sql/attach/show_databases.test",
+        "test/sql/attach/attach_views.test",
+        "test/sql/copy_database/copy_table_with_sequence.test"
+      ]
     }
   ]
 }

--- a/test/configs/latest_storage.json
+++ b/test/configs/latest_storage.json
@@ -6,116 +6,42 @@
   "skip_compiled": "true",
   "skip_tests": [
     {
-      "reason": "",
-      "path": "test/extension/test_tags.test"
-    },
-    {
-      "reason": "",
-      "path": "test/extension/load_extension.test"
-    },
-    {
-      "reason": "",
-      "path": "test/extension/autoloading_types.test"
+      "reason": "TODO",
+      "paths": [
+        "test/extension/test_tags.test",
+        "test/extension/load_extension.test",
+        "test/extension/autoloading_types.test",
+        "test/sql/settings/drop_set_schema.test",
+        "test/sql/show_select/test_describe_all.test",
+        "test/extension/test_custom_type_modifier_cast.test",
+        "test/extension/test_alias_point.test",
+        "test/extension/load_test_alias.test",
+        "test/fuzzer/pedro/incomplete_checkpoint.test",
+        "test/sql/catalog/test_set_search_path.test",
+        "test/sql/catalog/function/attached_macro.test",
+        "test/sql/catalog/test_temporary.test",
+        "test/sql/pragma/test_show_tables_temp_views.test",
+        "test/sql/storage/temp_directory/max_swap_space_error.test",
+        "test/sql/pg_catalog/system_functions.test",
+        "test/sql/attach/attach_table_info.test",
+        "test/sql/attach/attach_did_you_mean.test",
+        "test/sql/attach/show_databases.test",
+        "test/sql/attach/attach_show_all_tables.test",
+        "test/sql/attach/attach_default_table.test",
+        "test/sql/attach/attach_icu_collation.test",
+        "test/sql/function/list/lambdas/incorrect.test",
+        "test/sql/json/test_json_serialize_sql.test",
+        "test/sql/attach/attach_views.test",
+        "test/sql/table_function/duckdb_databases.test",
+        "test/sql/copy_database/copy_table_with_sequence.test",
+        "test/sql/logging/file_system_logging_attach.test"
+      ]
     },
     {
       "reason": "Attached databases have a main schema, which is not implicit.",
-      "path": "test/fuzzer/sqlsmith/current_schemas_null.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/settings/drop_set_schema.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/show_select/test_describe_all.test"
-    },
-    {
-      "reason": "",
-      "path": "test/extension/test_custom_type_modifier_cast.test"
-    },
-    {
-      "reason": "",
-      "path": "test/extension/test_alias_point.test"
-    },
-    {
-      "reason": "",
-      "path": "test/extension/load_test_alias.test"
-    },
-    {
-      "reason": "",
-      "path": "test/fuzzer/pedro/incomplete_checkpoint.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/catalog/test_set_search_path.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/catalog/function/attached_macro.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/catalog/test_temporary.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/pragma/test_show_tables_temp_views.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/storage/temp_directory/max_swap_space_error.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/pg_catalog/system_functions.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_table_info.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_did_you_mean.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/show_databases.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_show_all_tables.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_default_table.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_icu_collation.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/function/list/lambdas/incorrect.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/json/test_json_serialize_sql.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_views.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/table_function/duckdb_databases.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/copy_database/copy_table_with_sequence.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/logging/file_system_logging_attach.test"
+      "paths": [
+        "test/fuzzer/sqlsmith/current_schemas_null.test"
+      ]
     }
   ]
 }

--- a/test/configs/latest_storage_block_size_16kB.json
+++ b/test/configs/latest_storage_block_size_16kB.json
@@ -7,80 +7,28 @@
   "block_size": "16384",
   "skip_tests": [
     {
-      "reason": "",
-      "path": "test/fuzzer/sqlsmith/current_schemas_null.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_default_table.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_did_you_mean.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_show_all_tables.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_table_info.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/attach_views.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/attach/show_databases.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/catalog/function/attached_macro.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/catalog/test_set_search_path.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/catalog/test_temporary.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/copy_database/copy_table_with_sequence.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/json/test_json_serialize_sql.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/pg_catalog/system_functions.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/pragma/test_show_tables_temp_views.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/settings/drop_set_schema.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/show_select/test_describe_all.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/storage/buffer_manager_temp_dir.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/table_function/duckdb_databases.test"
-    },
-    {
-      "reason": "",
-      "path": "test/sql/tpch/dbgen_error.test"
+      "reason": "TODO",
+      "paths": [
+        "test/fuzzer/sqlsmith/current_schemas_null.test",
+        "test/sql/attach/attach_default_table.test",
+        "test/sql/attach/attach_did_you_mean.test",
+        "test/sql/attach/attach_show_all_tables.test",
+        "test/sql/attach/attach_table_info.test",
+        "test/sql/attach/attach_views.test",
+        "test/sql/attach/show_databases.test",
+        "test/sql/catalog/function/attached_macro.test",
+        "test/sql/catalog/test_set_search_path.test",
+        "test/sql/catalog/test_temporary.test",
+        "test/sql/copy_database/copy_table_with_sequence.test",
+        "test/sql/json/test_json_serialize_sql.test",
+        "test/sql/pg_catalog/system_functions.test",
+        "test/sql/pragma/test_show_tables_temp_views.test",
+        "test/sql/settings/drop_set_schema.test",
+        "test/sql/show_select/test_describe_all.test",
+        "test/sql/storage/buffer_manager_temp_dir.test",
+        "test/sql/table_function/duckdb_databases.test",
+        "test/sql/tpch/dbgen_error.test"
+      ]
     }
   ]
 }

--- a/test/configs/no_local_filesystem.json
+++ b/test/configs/no_local_filesystem.json
@@ -7,8 +7,10 @@
   ],
   "skip_tests": [
     {
-      "reason": "",
-      "path": "test/sql/attach/attach_filepath_roundtrip.test"
+      "reason": "TODO",
+      "paths": [
+        "test/sql/attach/attach_filepath_roundtrip.test"
+      ]
     }
   ]
 }

--- a/test/configs/prefetch_all_parquet_files.json
+++ b/test/configs/prefetch_all_parquet_files.json
@@ -8,8 +8,10 @@
   "skip_compiled": "true",
   "skip_tests": [
     {
-      "reason": "",
-      "path": "test/sql/copy/csv/zstd_crash.test"
+      "reason": "TODO",
+      "paths": [
+        "test/sql/copy/csv/zstd_crash.test"
+      ]
     }
   ]
 }

--- a/test/configs/verify_fetch_row.json
+++ b/test/configs/verify_fetch_row.json
@@ -1,0 +1,156 @@
+{
+  "description": "Run on persistent databases as storage with row verification enabled.",
+  "initial_db": "{TEST_DIR}/{BASE_TEST_NAME}__test__config__verify_fetch_row.db",
+  "on_init": "PRAGMA verify_fetch_row;",
+  "skip_compiled": "true",
+  "skip_tests": [
+    {
+      "reason": "Contains random() or gen_random_uuid().",
+      "paths": [
+        "test/optimizer/pushdown/issue_16104.test",
+        "test/fuzzer/pedro/nan_as_seed.test",
+        "test/sql/function/numeric/test_random.test",
+        "test/sql/function/uuid/test_uuid.test",
+        "test/sql/window/test_volatile_independence.test"
+      ]
+    },
+    {
+      "reason": "Contains SEQUENCE.",
+      "paths": [
+        "test/fuzzer/pedro/having_query_wrong_result.test",
+        "test/fuzzer/pedro/temp_sequence_durability.test",
+        "test/issues/fuzz/sequence_overflow.test",
+        "test/sql/aggregate/aggregates/test_bit_xor.test",
+        "test/sql/aggregate/aggregates/test_bit_and.test",
+        "test/sql/aggregate/aggregates/test_bit_or.test",
+        "test/sql/aggregate/aggregates/test_avg.test",
+        "test/sql/catalog/comment_on_wal.test",
+        "test/sql/catalog/dependencies/test_alter_dependency_ownership.test",
+        "test/sql/catalog/function/test_sequence_macro.test",
+        "test/sql/catalog/sequence/sequence_offset_increment.test",
+        "test/sql/catalog/sequence/sequence_cycle.test",
+        "test/sql/catalog/sequence/test_sequence.test",
+        "test/sql/catalog/sequence/sequence_overflow.test",
+        "test/sql/function/list/aggregates/avg.test",
+        "test/sql/function/list/aggregates/bit_and.test",
+        "test/sql/function/list/aggregates/bit_xor.test",
+        "test/sql/function/list/aggregates/bit_or.test",
+        "test/sql/storage/wal/wal_store_sequences.test",
+        "test/sql/storage/wal/wal_store_default_sequence.test",
+        "test/sql/storage/wal/wal_sequence_uncommitted_transaction.test",
+        "test/sql/storage/catalog/test_sequence_uncommitted_transaction.test",
+        "test/sql/storage/catalog/test_store_default_sequence.test",
+        "test/sql/storage/catalog/test_store_sequences.test",
+        "test/sql/attach/reattach_schema.test",
+        "test/sql/attach/attach_sequence.test",
+        "test/sql/export/export_database.test",
+        "test/sql/copy_database/copy_database_different_types.test"
+      ]
+    },
+    {
+      "reason": "Contains SAMPLE (non-deterministic).",
+      "paths": [
+        "test/fuzzer/pedro/sample_limit_overflow.test",
+        "test/sql/function/numeric/set_seed_for_sample.test"
+      ]
+    },
+    {
+      "reason": "FIXME: Unexpected Parser Error",
+      "paths": [
+        "test/issues/general/test_16524.test",
+        "test/sql/collate/test_collate_between.test",
+        "test/sql/catalog/comment_on_dependencies.test",
+        "test/sql/catalog/comment_on_column.test",
+        "test/sql/catalog/comment_on.test",
+        "test/sql/catalog/comment_on_extended.test",
+        "test/sql/catalog/comment_on_pg_description.test",
+        "test/sql/pragma/test_show_tables.test",
+        "test/sql/alter/test_alter_if_exists.test",
+        "test/sql/index/create_index_options.test"
+      ]
+    },
+    {
+      "reason": "Contains FIRST (non-deterministic).",
+      "paths": [
+        "test/sql/parallelism/intraquery/test_parallel_nested_aggregates.test"
+      ]
+    },
+    {
+      "reason": "FIXME: Unexpected parsed statement verifier failure.",
+      "paths": [
+        "test/sql/types/decimal/large_decimal_constants.test",
+        "test/sql/types/uhugeint/test_uhugeint_conversion.test",
+        "test/sql/types/hugeint/test_hugeint_conversion.test"
+      ]
+    },
+    {
+      "reason": "Contains explicit use of the memory catalog.",
+      "paths": [
+        "test/sql/show_select/test_describe_all.test",
+        "test/sql/catalog/function/attached_macro.test",
+        "test/sql/catalog/test_temporary.test",
+        "test/sql/pragma/test_show_tables_temp_views.test",
+        "test/sql/pg_catalog/system_functions.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/attach/attach_table_info.test",
+        "test/sql/attach/attach_defaults.test",
+        "test/sql/attach/attach_did_you_mean.test",
+        "test/sql/attach/attach_default_table.test",
+        "test/sql/attach/attach_show_all_tables.test",
+        "test/sql/attach/attach_issue7711.test",
+        "test/sql/attach/attach_issue_7660.test",
+        "test/sql/attach/show_databases.test",
+        "test/sql/attach/attach_views.test",
+        "test/sql/copy_database/copy_table_with_sequence.test"
+      ]
+    },
+    {
+      "reason": "Non-deterministic query (subqueries return multiple rows).",
+      "paths": [
+        "test/sql/subquery/scalar/test_issue_6136.test"
+      ]
+    },
+    {
+      "reason": "FIXME: Unexpected catalog duplicate/missing entry error.",
+      "paths": [
+        "test/sql/catalog/test_set_search_path.test",
+        "test/sql/catalog/function/test_macro_issue_13104.test",
+        "test/sql/catalog/function/test_macro_relpersistence_conflict.test",
+        "test/sql/catalog/function/test_recursive_macro.test",
+        "test/sql/catalog/function/test_recursive_macro_no_dependency.test",
+        "test/sql/catalog/test_set_schema.test"
+      ]
+    },
+    {
+      "reason": "Running verification creates extra output.",
+      "paths": [
+        "test/sql/pragma/test_query_log.test",
+        "test/sql/copy/csv/rejects/csv_rejects_auto.test",
+        "test/sql/copy/csv/rejects/csv_rejects_flush_cast.test",
+        "test/sql/copy/csv/rejects/csv_unquoted_rejects.test",
+        "test/sql/copy/csv/rejects/csv_rejects_read.test",
+        "test/sql/copy/csv/rejects/csv_rejects_maximum_line.test",
+        "test/sql/copy/csv/rejects/test_invalid_utf_rejects.test",
+        "test/sql/copy/csv/rejects/csv_rejects_flush_message.test",
+        "test/sql/copy/csv/rejects/csv_rejects_two_tables.test",
+        "test/sql/copy/csv/rejects/test_mixed.test",
+        "test/sql/copy/csv/rejects/test_multiple_errors_same_line.test",
+        "test/sql/copy/csv/rejects/csv_incorrect_columns_amount_rejects.test",
+        "test/sql/copy/csv/test_non_unicode_header.test"
+      ]
+    },
+    {
+      "reason": "FIXME: Misc. unexpected failures (query succeeds, wrong result).",
+      "paths": [
+        "test/sql/storage/compression/test_using_compression.test",
+        "test/sql/create/create_table_compression.test"
+      ]
+    },
+    {
+      "reason": "Emits different vector type (FLAT).",
+      "paths": [
+        "test/sql/storage/compression/rle/rle_constant.test"
+      ]
+    }
+  ]
+}

--- a/test/issues/general/test_14286.test
+++ b/test/issues/general/test_14286.test
@@ -3,14 +3,17 @@
 # group: [general]
 
 statement ok
-select
-    category,
-    array_agg(distinct name) filter(where id != 5)            as a_list,
-    array_agg(name)          filter(where id != 5)            as b_list,
-    array_agg({'id': id, 'name': name, 'catetory': category}) as c_list
-from (
-    select 1 as id, '大熊猫' as name, '熊' as category union all
-    select 2 as id, '大熊猫' as name, '猫' as category union all
-    select 3 as id, '小熊猫' as name, '猫' as category
-) t
-group by category;
+WITH cte(category, a_list, b_list, c_list) AS (
+	SELECT
+		category,
+		array_agg(DISTINCT name) FILTER(WHERE id != 5)            AS a_list,
+		array_agg(name)          FILTER(WHERE id != 5)            AS b_list,
+		array_agg({'id': id, 'name': name, 'catetory': category}) AS c_list
+	FROM (
+		SELECT 1 AS id, '大熊猫' AS name, '熊' AS category UNION ALL
+		SELECT 2 AS id, '大熊猫' AS name, '猫' AS category UNION ALL
+		SELECT 3 AS id, '小熊猫' AS name, '猫' AS category
+	) t
+	GROUP BY category)
+SELECT category, list_sort(a_list), list_sort(b_list), list_sort(c_list)
+FROM cte ORDER BY ALL

--- a/test/optimizer/statistics/statistics_coalesce.test
+++ b/test/optimizer/statistics/statistics_coalesce.test
@@ -97,10 +97,16 @@ SELECT * FROM integers WHERE (COALESCE(i, 4, 17)=3);
 ----
 3
 
-# random needs disabled verification
+# Verification compares results, which are different for random().
+
 statement ok
 PRAGMA disable_verification
 
-# coalesce without stats
 statement ok
-SELECT COALESCE(CASE WHEN RANDOM()<100 THEN RANDOM() ELSE NULL END, NULL, 42) FROM range(10)
+PRAGMA disable_verify_fetch_row;
+
+# COALESCE without statistics.
+
+statement ok
+SELECT COALESCE (CASE WHEN RANDOM() < 100 THEN RANDOM() ELSE NULL END, NULL, 42)
+FROM range(10)

--- a/test/sql/aggregate/aggregates/test_approx_quantile.test
+++ b/test/sql/aggregate/aggregates/test_approx_quantile.test
@@ -245,6 +245,9 @@ statement ok
 PRAGMA disable_verify_external;
 
 statement ok
+PRAGMA disable_verify_fetch_row;
+
+statement ok
 SELECT reservoir_quantile(r, 0.9)  from quantile
 
 statement ok

--- a/test/sql/catalog/dependencies/test_alter_dependency_ownership.test
+++ b/test/sql/catalog/dependencies/test_alter_dependency_ownership.test
@@ -4,7 +4,6 @@
 
 require skip_reload
 
-
 ##TEST: If the table is dropped, then the sequence is also droppped
 statement ok
 CREATE SEQUENCE sequence1;

--- a/test/sql/catalog/function/test_macro_relpersistence_conflict.test
+++ b/test/sql/catalog/function/test_macro_relpersistence_conflict.test
@@ -2,7 +2,6 @@
 # description: Test Macro temporary/if exists/or replace
 # group: [function]
 
-# load the DB from disk
 load __TEST_DIR__/my_macro_database.db
 
 statement ok

--- a/test/sql/catalog/test_set_search_path.test
+++ b/test/sql/catalog/test_set_search_path.test
@@ -19,6 +19,8 @@ CREATE SCHEMA test2;
 
 statement ok
 CREATE TABLE test2.bye(i INTEGER);
+
+statement ok
 CREATE TABLE test2.test2_table(i INTEGER);
 
 statement ok
@@ -56,6 +58,7 @@ SET SEARCH_PATH = '"test","test2"';
 statement error
 SET SEARCH_PATH = 'does_not_exist';
 ----
+<REGEX>:Catalog Error.*No catalog.*schema named.*
 
 # Setting the default value through 'schema'
 
@@ -70,6 +73,7 @@ expected a single entry
 statement error
 SET SCHEMA = 'does_not_exist';
 ----
+<REGEX>:Catalog Error.*No catalog.*schema named.*
 
 # Reading out to see how aliasing works.
 
@@ -79,6 +83,7 @@ SET SEARCH_PATH = 'test,test2';
 statement error
 SET SEARCH_PATH = '"invalid quoted string list';
 ----
+<REGEX>:Parser Error.*Unterminated quote in qualified name.*
 
 query I
 SELECT MAIN.CURRENT_SETTING('search_path');
@@ -172,14 +177,15 @@ CREATE TABLE test2.table_with_same_name(in_test2 INTEGER);
 statement error
 SELECT in_main FROM table_with_same_name;
 ----
+<REGEX>:Binder Error.*not found in FROM clause.*
 
 statement error
 SELECT in_test2 FROM table_with_same_name;
 ----
+<REGEX>:Binder Error.*not found in FROM clause.*
 
 statement ok
 SELECT in_test FROM table_with_same_name;
-
 
 # Or even more schemas
 
@@ -226,10 +232,12 @@ SELECT i FROM test_table;
 statement error con2
 SELECT i FROM test_table;
 ----
+<REGEX>:Catalog Error.*does not exist.*
 
 statement error con1
 SELECT i FROM test2_table;
 ----
+<REGEX>:Catalog Error.*does not exist.*
 
 statement ok con2
 SELECT i FROM test2_table;

--- a/test/sql/constraints/foreignkey/test_fk_eager_constraint_checking.test
+++ b/test/sql/constraints/foreignkey/test_fk_eager_constraint_checking.test
@@ -31,7 +31,10 @@ statement ok
 INSERT INTO tbl_fk VALUES (1), (1), (1);
 
 statement ok
-USE memory;
+ATTACH '__TEST_DIR__/test_other_fk_eager.db' AS other_fk_db;
+
+statement ok
+USE other_fk_db;
 
 # We also want the old LEAF representation serialized.
 statement ok

--- a/test/sql/order/test_limit.test
+++ b/test/sql/order/test_limit.test
@@ -87,6 +87,9 @@ CREATE SEQUENCE seq START 3;
 statement ok
 PRAGMA disable_verification;
 
+statement ok
+PRAGMA disable_verify_fetch_row;
+
 query I
 SELECT * FROM integers LIMIT nextval('seq');
 ----

--- a/test/sql/storage/compression/bitpacking/bitpacking_simple.test
+++ b/test/sql/storage/compression/bitpacking/bitpacking_simple.test
@@ -9,9 +9,6 @@ require block_size 262144
 load __TEST_DIR__/test_bitpacking.db
 
 statement ok
-pragma verify_fetch_row
-
-statement ok
 PRAGMA force_compression='bitpacking'
 
 foreach bitpacking_mode delta_for for constant_delta constant

--- a/test/sql/storage/compression/bitpacking/bitpacking_simple_hugeint.test
+++ b/test/sql/storage/compression/bitpacking/bitpacking_simple_hugeint.test
@@ -9,9 +9,6 @@ require block_size 262144
 load __TEST_DIR__/test_bitpacking.db
 
 statement ok
-pragma verify_fetch_row
-
-statement ok
 PRAGMA force_compression='bitpacking'
 
 foreach bitpacking_mode delta_for for constant_delta constant

--- a/test/sql/storage/compression/dict_fsst/fetch_row.test
+++ b/test/sql/storage/compression/dict_fsst/fetch_row.test
@@ -42,9 +42,6 @@ cccc
 this is not an inlined string
 NULL
 
-statement ok
-PRAGMA verify_fetch_row;
-
 query I
 SELECT DISTINCT b FROM test ORDER BY a % 5;
 ----

--- a/test/sql/storage/compression/dictionary/fetch_row.test
+++ b/test/sql/storage/compression/dictionary/fetch_row.test
@@ -36,9 +36,6 @@ SELECT compression FROM pragma_storage_info('test') WHERE segment_type ILIKE 'VA
 ----
 Dictionary
 
-statement ok
-pragma verify_fetch_row;
-
 query I
 select distinct b from test order by a % 5;
 ----

--- a/test/sql/storage/compression/rle/rle_constant.test
+++ b/test/sql/storage/compression/rle/rle_constant.test
@@ -2,7 +2,6 @@
 # description: Test RLE where we can emit ConstantVectors when scanning
 # group: [rle]
 
-# load the DB from disk
 load __TEST_DIR__/test_rle.db
 
 require vector_size 2048

--- a/test/sql/storage/compression/rle/struct_rle.test
+++ b/test/sql/storage/compression/rle/struct_rle.test
@@ -2,11 +2,7 @@
 # description: Test storage with RLE inside structs
 # group: [rle]
 
-# load the DB from disk
 load __TEST_DIR__/test_rle.db
-
-statement ok
-pragma verify_fetch_row
 
 statement ok
 PRAGMA force_compression = 'rle'

--- a/test/sql/storage/compression/roaring/fetch_row.test
+++ b/test/sql/storage/compression/roaring/fetch_row.test
@@ -27,9 +27,6 @@ query I
 SELECT compression FROM pragma_storage_info('test') WHERE segment_type ILIKE 'VALIDITY' and compression != 'Roaring';
 ----
 
-statement ok
-pragma verify_fetch_row;
-
 query I
 select count(*) from test WHERE a IS NOT NULL;
 ----
@@ -39,9 +36,6 @@ query III
 select sum(a), min(a), max(a) from test;
 ----
 534800	1337	1337
-
-statement ok
-pragma disable_verify_fetch_row;
 
 statement ok
 delete from test;
@@ -59,9 +53,6 @@ query I
 SELECT compression FROM pragma_storage_info('test') WHERE segment_type ILIKE 'VALIDITY' and compression != 'Roaring';
 ----
 
-statement ok
-pragma verify_fetch_row;
-
 query I
 select count(*) from test WHERE a IS NOT NULL;
 ----
@@ -71,9 +62,6 @@ query III
 select sum(a), min(a), max(a) from test;
 ----
 2591106	1337	1337
-
-statement ok
-pragma disable_verify_fetch_row;
 
 statement ok
 delete from test;
@@ -91,9 +79,6 @@ query I
 SELECT compression FROM pragma_storage_info('test') WHERE segment_type ILIKE 'VALIDITY' and compression != 'Roaring';
 ----
 
-statement ok
-pragma verify_fetch_row;
-
 query I
 select count(*) from test WHERE a IS NOT NULL;
 ----
@@ -103,9 +88,6 @@ query III
 select sum(a), min(a), max(a) from test;
 ----
 4457558	1337	1337
-
-statement ok
-pragma disable_verify_fetch_row;
 
 statement ok
 delete from test;

--- a/test/sql/storage/compression/string/big_strings.test
+++ b/test/sql/storage/compression/string/big_strings.test
@@ -3,9 +3,6 @@
 # group: [string]
 
 statement ok
-pragma verify_fetch_row
-
-statement ok
 ATTACH '__TEST_DIR__/test_big_strings_new.db' AS db_v13 (STORAGE_VERSION 'v1.3.0');
 
 statement ok

--- a/test/sql/storage/compression/string/blob.test
+++ b/test/sql/storage/compression/string/blob.test
@@ -3,9 +3,6 @@
 # group: [string]
 
 statement ok
-pragma verify_fetch_row
-
-statement ok
 ATTACH '__TEST_DIR__/test_blob_new.db' AS db_v13 (STORAGE_VERSION 'v1.3.0');
 
 statement ok

--- a/test/sql/storage/compression/string/filter_pushdown.test
+++ b/test/sql/storage/compression/string/filter_pushdown.test
@@ -3,9 +3,6 @@
 # group: [string]
 
 statement ok
-pragma verify_fetch_row
-
-statement ok
 ATTACH '__TEST_DIR__/test_filter_pushdown_new.db' AS db_v13 (STORAGE_VERSION 'v1.3.0');
 
 statement ok

--- a/test/sql/storage/compression/string/index_fetch.test
+++ b/test/sql/storage/compression/string/index_fetch.test
@@ -3,9 +3,6 @@
 # group: [string]
 
 statement ok
-pragma verify_fetch_row
-
-statement ok
 ATTACH '__TEST_DIR__/test_index_fetch_new.db' AS db_v13 (STORAGE_VERSION 'v1.3.0');
 
 statement ok

--- a/test/sql/storage/compression/zstd/fetch_row.test
+++ b/test/sql/storage/compression/zstd/fetch_row.test
@@ -45,9 +45,6 @@ checkpoint
 
 restart
 
-statement ok
-pragma verify_fetch_row;
-
 query II
 SELECT a[1], strlen(a) from big_string;
 ----

--- a/test/sql/types/decimal/large_decimal_constants.test
+++ b/test/sql/types/decimal/large_decimal_constants.test
@@ -20,7 +20,6 @@ DECIMAL(15,5)
 DECIMAL(23,5)
 DOUBLE
 
-
 query IIIIII
 SELECT 42., 42e3, 4.23e1, 10e20, .34, - 2.3
 ----


### PR DESCRIPTION
New `verify_fetch_row.json` config:
```json
  "description": "Run on persistent databases as storage with row verification enabled.",
  "initial_db": "{TEST_DIR}/{BASE_TEST_NAME}__test__config__verify_fetch_row.db",
  "on_init": "PRAGMA verify_fetch_row;",
  "skip_compiled": "true",
  "skip_tests": [
```

Close https://github.com/duckdblabs/duckdb-internal/issues/5207.

New structure of skipped tests:
```
LogicalType::LIST(
         LogicalType::STRUCT(
{{"reason", LogicalType::VARCHAR}, 
{"paths", LogicalType::LIST(LogicalType::VARCHAR)}})),
```

Example:
```json
    {
      "reason": "Contains FIRST (non-deterministic).",
      "paths": [
        "test/sql/parallelism/intraquery/test_parallel_nested_aggregates.test"
      ]
    },
    {
      "reason": "FIXME: Unexpected parsed statement verifier failure.",
      "paths": [
        "test/sql/types/decimal/large_decimal_constants.test",
        "test/sql/types/uhugeint/test_uhugeint_conversion.test",
        "test/sql/types/hugeint/test_hugeint_conversion.test"
      ]
    },
```

There are a bunch of `FIXME` in the new `verify_fetch_row.json` - I'll open the respective internal issues once we've merged this PR.