### PR TITLE
[Fix] Reset segment memory when initialising new Prefix

### DIFF
--- a/src/include/duckdb/execution/index/art/prefix.hpp
+++ b/src/include/duckdb/execution/index/art/prefix.hpp
@@ -80,8 +80,7 @@ public:
 	static void TransformToDeprecated(ART &art, Node &node, unsafe_unique_ptr<FixedSizeAllocator> &allocator);
 
 private:
-	static Prefix NewInternal(ART &art, Node &node, const data_ptr_t data, const uint8_t count, const idx_t offset,
-	                          const NType type);
+	static Prefix NewInternal(ART &art, Node &node, const data_ptr_t data, const uint8_t count, const idx_t offset);
 
 	static Prefix GetTail(ART &art, const Node &node);
 


### PR DESCRIPTION
When making changes to indexes, we might reuse previously used index segments. In the case of this bug, we reuse a previous segment in a place where we then expect it to be uninitialised. 

I am not sure how to add the reproducer, since the table (with the correct sequence of values to cause this) is 10MB (compressed, all other columns removed). 

Fixes https://github.com/duckdb/duckdb/issues/18190