### PR TITLE
Internal #5385: WindowMergeSortTree Sort Update

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -114,6 +114,7 @@
 #include "duckdb/function/table/arrow/enum/arrow_type_info_type.hpp"
 #include "duckdb/function/table/arrow/enum/arrow_variable_size_type.hpp"
 #include "duckdb/function/table_function.hpp"
+#include "duckdb/function/window/window_merge_sort_tree.hpp"
 #include "duckdb/logging/logging.hpp"
 #include "duckdb/main/appender.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
@@ -4882,6 +4883,27 @@ const char* EnumUtil::ToChars<WindowExcludeMode>(WindowExcludeMode value) {
 template<>
 WindowExcludeMode EnumUtil::FromString<WindowExcludeMode>(const char *value) {
 	return static_cast<WindowExcludeMode>(StringUtil::StringToEnum(GetWindowExcludeModeValues(), 4, "WindowExcludeMode", value));
+}
+
+const StringUtil::EnumStringLiteral *GetWindowMergeSortStageValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(WindowMergeSortStage::INIT), "INIT" },
+		{ static_cast<uint32_t>(WindowMergeSortStage::COMBINE), "COMBINE" },
+		{ static_cast<uint32_t>(WindowMergeSortStage::FINALIZE), "FINALIZE" },
+		{ static_cast<uint32_t>(WindowMergeSortStage::SORTED), "SORTED" },
+		{ static_cast<uint32_t>(WindowMergeSortStage::FINISHED), "FINISHED" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<WindowMergeSortStage>(WindowMergeSortStage value) {
+	return StringUtil::EnumToString(GetWindowMergeSortStageValues(), 5, "WindowMergeSortStage", static_cast<uint32_t>(value));
+}
+
+template<>
+WindowMergeSortStage EnumUtil::FromString<WindowMergeSortStage>(const char *value) {
+	return static_cast<WindowMergeSortStage>(StringUtil::StringToEnum(GetWindowMergeSortStageValues(), 5, "WindowMergeSortStage", value));
 }
 
 }

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -11,7 +11,6 @@
 #include "duckdb/function/window/window_value_function.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
 #include "duckdb/main/settings.hpp"
-#include <numeric>
 
 namespace duckdb {
 
@@ -791,7 +790,7 @@ void WindowLocalSourceState::Sink(ExecutionContext &context) {
 	auto &local_states = window_hash_group->thread_states.at(task->thread_idx);
 	if (local_states.empty()) {
 		for (idx_t w = 0; w < executors.size(); ++w) {
-			local_states.emplace_back(executors[w]->GetLocalState(*gestates[w]));
+			local_states.emplace_back(executors[w]->GetLocalState(context, *gestates[w]));
 		}
 	}
 

--- a/src/function/window/window_aggregate_function.cpp
+++ b/src/function/window/window_aggregate_function.cpp
@@ -100,8 +100,9 @@ unique_ptr<WindowExecutorGlobalState> WindowAggregateExecutor::GetGlobalState(Cl
 
 class WindowAggregateExecutorLocalState : public WindowExecutorBoundsLocalState {
 public:
-	WindowAggregateExecutorLocalState(const WindowExecutorGlobalState &gstate, const WindowAggregator &aggregator)
-	    : WindowExecutorBoundsLocalState(gstate), filter_executor(gstate.client) {
+	WindowAggregateExecutorLocalState(ExecutionContext &context, const WindowExecutorGlobalState &gstate,
+	                                  const WindowAggregator &aggregator)
+	    : WindowExecutorBoundsLocalState(context, gstate), filter_executor(gstate.client) {
 
 		auto &gastate = gstate.Cast<WindowAggregateExecutorGlobalState>();
 		aggregator_state = aggregator.GetLocalState(*gastate.gsink);
@@ -124,8 +125,8 @@ public:
 };
 
 unique_ptr<WindowExecutorLocalState>
-WindowAggregateExecutor::GetLocalState(const WindowExecutorGlobalState &gstate) const {
-	return make_uniq<WindowAggregateExecutorLocalState>(gstate, *aggregator);
+WindowAggregateExecutor::GetLocalState(ExecutionContext &context, const WindowExecutorGlobalState &gstate) const {
+	return make_uniq<WindowAggregateExecutorLocalState>(context, gstate, *aggregator);
 }
 
 void WindowAggregateExecutor::Sink(ExecutionContext &context, DataChunk &sink_chunk, DataChunk &coll_chunk,

--- a/src/function/window/window_custom_aggregator.cpp
+++ b/src/function/window/window_custom_aggregator.cpp
@@ -110,7 +110,7 @@ void WindowCustomAggregator::Finalize(ExecutionContext &context, WindowAggregato
 	filter_mask.Pack(filter_packed, filter_mask.Capacity());
 
 	gcsink.partition_input =
-	    make_uniq<WindowPartitionInput>(gcsink.context, inputs, count, child_idx, all_valids, filter_packed, stats);
+	    make_uniq<WindowPartitionInput>(context, inputs, count, child_idx, all_valids, filter_packed, stats);
 
 	if (aggr.function.window_init) {
 		auto &gcstate = *gcsink.gcstate;

--- a/src/function/window/window_index_tree.cpp
+++ b/src/function/window/window_index_tree.cpp
@@ -14,37 +14,46 @@ WindowIndexTree::WindowIndexTree(ClientContext &context, const BoundOrderModifie
     : WindowIndexTree(context, order_bys.orders, sort_idx, count) {
 }
 
-unique_ptr<WindowAggregatorState> WindowIndexTree::GetLocalState() {
-	return make_uniq<WindowIndexTreeLocalState>(*this);
+unique_ptr<WindowAggregatorState> WindowIndexTree::GetLocalState(ExecutionContext &context) {
+	return make_uniq<WindowIndexTreeLocalState>(context, *this);
 }
 
-WindowIndexTreeLocalState::WindowIndexTreeLocalState(WindowIndexTree &index_tree)
-    : WindowMergeSortTreeLocalState(index_tree), index_tree(index_tree) {
+WindowIndexTreeLocalState::WindowIndexTreeLocalState(ExecutionContext &context, WindowIndexTree &index_tree)
+    : WindowMergeSortTreeLocalState(context, index_tree), index_tree(index_tree) {
 }
 
 void WindowIndexTreeLocalState::BuildLeaves() {
-	auto &global_sort = *index_tree.global_sort;
-	if (global_sort.sorted_blocks.empty()) {
+	auto &collection = *window_tree.sorted;
+	if (!collection.Count()) {
 		return;
 	}
 
-	PayloadScanner scanner(global_sort, build_task);
-	idx_t row_idx = index_tree.block_starts[build_task];
-	for (;;) {
-		payload_chunk.Reset();
-		scanner.Scan(payload_chunk);
+	// Find our chunk range
+	const auto block_begin = (build_task * collection.ChunkCount()) / window_tree.total_tasks;
+	const auto block_end = ((build_task + 1) * collection.ChunkCount()) / window_tree.total_tasks;
+
+	//	Scan the index column (the last one)
+	vector<column_t> index_ids(1, window_tree.scan_cols.size() - 1);
+	WindowCollectionChunkScanner scanner(collection, index_ids, block_begin);
+	auto &payload_chunk = scanner.chunk;
+
+	idx_t row_idx = scanner.Scanned();
+	for (auto block_curr = block_begin; block_curr < block_end; ++block_curr) {
+		if (!scanner.Scan()) {
+			break;
+		}
 		const auto count = payload_chunk.size();
 		if (count == 0) {
 			break;
 		}
 		auto &indices = payload_chunk.data[0];
-		if (index_tree.mst32) {
-			auto &sorted = index_tree.mst32->LowestLevel();
-			auto data = FlatVector::GetDataUnsafe<uint32_t>(indices);
+		if (window_tree.mst32) {
+			auto &sorted = window_tree.mst32->LowestLevel();
+			auto data = FlatVector::GetData<int32_t>(indices);
 			std::copy(data, data + count, sorted.data() + row_idx);
 		} else {
-			auto &sorted = index_tree.mst64->LowestLevel();
-			auto data = FlatVector::GetDataUnsafe<uint64_t>(indices);
+			auto &sorted = window_tree.mst64->LowestLevel();
+			auto data = FlatVector::GetData<int64_t>(indices);
 			std::copy(data, data + count, sorted.data() + row_idx);
 		}
 		row_idx += count;

--- a/src/function/window/window_merge_sort_tree.cpp
+++ b/src/function/window/window_merge_sort_tree.cpp
@@ -1,17 +1,16 @@
 #include "duckdb/function/window/window_merge_sort_tree.hpp"
-#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 
 #include <thread>
 #include <utility>
 
 namespace duckdb {
 
-WindowMergeSortTree::WindowMergeSortTree(ClientContext &context, const vector<BoundOrderByNode> &orders,
-                                         const vector<column_t> &sort_idx, const idx_t count, bool unique)
-    : context(context), memory_per_thread(PhysicalOperator::GetMaxThreadMemory(context)), sort_idx(sort_idx),
-      build_stage(PartitionSortStage::INIT), tasks_completed(0) {
+WindowMergeSortTree::WindowMergeSortTree(ClientContext &client, const vector<BoundOrderByNode> &orders_p,
+                                         const vector<column_t> &order_idx, const idx_t count, bool unique)
+    : order_idx(order_idx), build_stage(WindowMergeSortStage::INIT), tasks_completed(0) {
 	// Sort the unfiltered indices by the orders
-	const auto force_external = ClientConfig::GetConfig(context).force_external;
+	const auto force_external = ClientConfig::GetConfig(client).force_external;
 	LogicalType index_type;
 	if (count < std::numeric_limits<uint32_t>::max() && !force_external) {
 		index_type = LogicalType::INTEGER;
@@ -21,88 +20,96 @@ WindowMergeSortTree::WindowMergeSortTree(ClientContext &context, const vector<Bo
 		mst64 = make_uniq<MergeSortTree64>();
 	}
 
-	vector<LogicalType> payload_types;
-	payload_types.emplace_back(index_type);
+	vector<BoundOrderByNode> orders;
+	for (const auto &order_p : orders_p) {
+		auto order = order_p.Copy();
+		const auto &type = order.expression->return_type;
+		scan_types.emplace_back(type);
+		order.expression = make_uniq<BoundReferenceExpression>(type, orders.size());
+		orders.emplace_back(std::move(order));
+		scan_cols.emplace_back(scan_cols.size());
+		key_cols.emplace_back(key_cols.size());
+	}
 
-	RowLayout payload_layout;
-	payload_layout.Initialize(payload_types);
+	//	Also track the index type
+	scan_types.emplace_back(index_type);
+	scan_cols.emplace_back(scan_cols.size());
 
+	// 	If the caller wants disambiguation, also sort by the index column
 	if (unique) {
-		vector<BoundOrderByNode> unique_orders;
-		for (const auto &order : orders) {
-			unique_orders.emplace_back(order.Copy());
-		}
-		auto unique_expr = make_uniq<BoundConstantExpression>(Value(index_type));
+		auto unique_expr = make_uniq<BoundReferenceExpression>(scan_types.back(), orders.size());
 		const auto order_type = OrderType::ASCENDING;
 		const auto order_by_type = OrderByNullType::NULLS_LAST;
-		unique_orders.emplace_back(BoundOrderByNode(order_type, order_by_type, std::move(unique_expr)));
-		global_sort = make_uniq<GlobalSortState>(context, unique_orders, payload_layout);
-	} else {
-		global_sort = make_uniq<GlobalSortState>(context, orders, payload_layout);
+		orders.emplace_back(BoundOrderByNode(order_type, order_by_type, std::move(unique_expr)));
+		key_cols.emplace_back(key_cols.size());
 	}
-	global_sort->external = force_external;
+
+	sort = make_uniq<Sort>(client, orders, scan_types, scan_cols);
+
+	global_sink = sort->GetGlobalSinkState(client);
 }
 
-optional_ptr<LocalSortState> WindowMergeSortTree::AddLocalSort() {
+optional_ptr<LocalSinkState> WindowMergeSortTree::InitializeLocalSort(ExecutionContext &context) const {
 	lock_guard<mutex> local_sort_guard(lock);
-	auto local_sort = make_uniq<LocalSortState>();
-	local_sort->Initialize(*global_sort, global_sort->buffer_manager);
-	local_sorts.emplace_back(std::move(local_sort));
+	auto local_sink = sort->GetLocalSinkState(context);
+	local_sinks.emplace_back(std::move(local_sink));
 
-	return local_sorts.back().get();
+	return local_sinks.back().get();
 }
 
-WindowMergeSortTreeLocalState::WindowMergeSortTreeLocalState(WindowMergeSortTree &window_tree)
+WindowMergeSortTreeLocalState::WindowMergeSortTreeLocalState(ExecutionContext &context,
+                                                             WindowMergeSortTree &window_tree)
     : window_tree(window_tree) {
-	sort_chunk.Initialize(window_tree.context, window_tree.global_sort->sort_layout.logical_types);
-	payload_chunk.Initialize(window_tree.context, window_tree.global_sort->payload_layout.GetTypes());
-	local_sort = window_tree.AddLocalSort();
+	sort_chunk.Initialize(context.client, window_tree.scan_types);
+	local_sink = window_tree.InitializeLocalSort(context);
 }
 
-void WindowMergeSortTreeLocalState::SinkChunk(DataChunk &chunk, const idx_t row_idx,
-                                              optional_ptr<SelectionVector> filter_sel, idx_t filtered) {
+void WindowMergeSortTreeLocalState::Sink(ExecutionContext &context, DataChunk &chunk, const idx_t row_idx,
+                                         optional_ptr<SelectionVector> filter_sel, idx_t filtered) {
 	//	Sequence the payload column
-	auto &indices = payload_chunk.data[0];
-	payload_chunk.SetCardinality(chunk);
-	indices.Sequence(int64_t(row_idx), 1, payload_chunk.size());
+	sort_chunk.Reset();
+	auto &indices = sort_chunk.data.back();
+	indices.Sequence(int64_t(row_idx), 1, chunk.size());
 
-	//	Reference the sort columns
-	auto &sort_idx = window_tree.sort_idx;
-	for (column_t c = 0; c < sort_idx.size(); ++c) {
-		sort_chunk.data[c].Reference(chunk.data[sort_idx[c]]);
-	}
-	// Add the row numbers if we are uniquifying
-	if (sort_idx.size() < sort_chunk.ColumnCount()) {
-		sort_chunk.data[sort_idx.size()].Reference(indices);
+	//	Reference the ORDER BY columns
+	auto &order_idx = window_tree.order_idx;
+	for (column_t c = 0; c < order_idx.size(); ++c) {
+		sort_chunk.data[c].Reference(chunk.data[order_idx[c]]);
 	}
 	sort_chunk.SetCardinality(chunk);
 
 	//	Apply FILTER clause, if any
 	if (filter_sel) {
 		sort_chunk.Slice(*filter_sel, filtered);
-		payload_chunk.Slice(*filter_sel, filtered);
 	}
 
-	local_sort->SinkChunk(sort_chunk, payload_chunk);
-
-	//	Flush if we have too much data
-	if (local_sort->SizeInBytes() > window_tree.memory_per_thread) {
-		local_sort->Sort(*window_tree.global_sort, true);
-	}
+	InterruptState interrupt;
+	OperatorSinkInput sink {*window_tree.global_sink, *local_sink, interrupt};
+	window_tree.sort->Sink(context, sort_chunk, sink);
 }
 
-void WindowMergeSortTreeLocalState::ExecuteSortTask() {
+void WindowMergeSortTreeLocalState::ExecuteSortTask(ExecutionContext &context) {
 	switch (build_stage) {
-	case PartitionSortStage::SCAN:
-		window_tree.global_sort->AddLocalState(*window_tree.local_sorts[build_task]);
-		break;
-	case PartitionSortStage::MERGE: {
-		auto &global_sort = *window_tree.global_sort;
-		MergeSorter merge_sorter(global_sort, global_sort.buffer_manager);
-		merge_sorter.PerformInMergeRound();
+	case WindowMergeSortStage::COMBINE: {
+		auto &local_sink = *window_tree.local_sinks[build_task];
+		InterruptState interrupt_state;
+		OperatorSinkCombineInput combine {*window_tree.global_sink, local_sink, interrupt_state};
+		window_tree.sort->Combine(context, combine);
 		break;
 	}
-	case PartitionSortStage::SORTED:
+	case WindowMergeSortStage::FINALIZE: {
+		auto &sort = *window_tree.sort;
+		InterruptState interrupt;
+		OperatorSinkFinalizeInput finalize {*window_tree.global_sink, interrupt};
+		sort.Finalize(context.client, finalize);
+		auto sort_global = sort.GetGlobalSourceState(context.client, *window_tree.global_sink);
+		auto sort_local = sort.GetLocalSourceState(context, *sort_global);
+		OperatorSourceInput source {*sort_global, *sort_local, interrupt};
+		sort.MaterializeColumnData(context, source);
+		window_tree.sorted = sort.GetColumnData(source);
+		break;
+	}
+	case WindowMergeSortStage::SORTED:
 		BuildLeaves();
 		break;
 	default:
@@ -113,13 +120,7 @@ void WindowMergeSortTreeLocalState::ExecuteSortTask() {
 }
 
 idx_t WindowMergeSortTree::MeasurePayloadBlocks() {
-	const auto &blocks = global_sort->sorted_blocks[0]->payload_data->data_blocks;
-	idx_t count = 0;
-	for (const auto &block : blocks) {
-		block_starts.emplace_back(count);
-		count += block->count;
-	}
-	block_starts.emplace_back(count);
+	const auto count = sorted->Count();
 
 	// Allocate the leaves.
 	if (mst32) {
@@ -133,130 +134,78 @@ idx_t WindowMergeSortTree::MeasurePayloadBlocks() {
 	return count;
 }
 
-void WindowMergeSortTreeLocalState::BuildLeaves() {
-	auto &global_sort = *window_tree.global_sort;
-	if (global_sort.sorted_blocks.empty()) {
-		return;
-	}
-
-	PayloadScanner scanner(global_sort, build_task);
-	idx_t row_idx = window_tree.block_starts[build_task];
-	for (;;) {
-		payload_chunk.Reset();
-		scanner.Scan(payload_chunk);
-		const auto count = payload_chunk.size();
-		if (count == 0) {
-			break;
-		}
-		auto &indices = payload_chunk.data[0];
-		if (window_tree.mst32) {
-			auto &sorted = window_tree.mst32->LowestLevel();
-			auto data = FlatVector::GetData<uint32_t>(indices);
-			std::copy(data, data + count, sorted.data() + row_idx);
-		} else {
-			auto &sorted = window_tree.mst64->LowestLevel();
-			auto data = FlatVector::GetData<uint64_t>(indices);
-			std::copy(data, data + count, sorted.data() + row_idx);
-		}
-		row_idx += count;
-	}
-}
-
-void WindowMergeSortTree::CleanupSort() {
-	global_sort.reset();
-	local_sorts.clear();
+void WindowMergeSortTree::Finished() {
+	global_sink.reset();
+	local_sinks.clear();
+	sorted.reset();
 }
 
 bool WindowMergeSortTree::TryPrepareSortStage(WindowMergeSortTreeLocalState &lstate) {
 	lock_guard<mutex> stage_guard(lock);
 
 	switch (build_stage.load()) {
-	case PartitionSortStage::INIT:
-		total_tasks = local_sorts.size();
+	case WindowMergeSortStage::INIT:
+		total_tasks = local_sinks.size();
 		tasks_assigned = 0;
 		tasks_completed = 0;
-		lstate.build_stage = build_stage = PartitionSortStage::SCAN;
+		lstate.build_stage = build_stage = WindowMergeSortStage::COMBINE;
 		lstate.build_task = tasks_assigned++;
 		return true;
-	case PartitionSortStage::SCAN:
+	case WindowMergeSortStage::COMBINE:
 		// Process all the local sorts
 		if (tasks_assigned < total_tasks) {
-			lstate.build_stage = PartitionSortStage::SCAN;
+			lstate.build_stage = WindowMergeSortStage::COMBINE;
 			lstate.build_task = tasks_assigned++;
 			return true;
 		} else if (tasks_completed < tasks_assigned) {
 			return false;
 		}
-		global_sort->PrepareMergePhase();
-		if (!(global_sort->sorted_blocks.size() / 2)) {
-			if (global_sort->sorted_blocks.empty()) {
-				lstate.build_stage = build_stage = PartitionSortStage::FINISHED;
-				return true;
-			}
-			MeasurePayloadBlocks();
-			total_tasks = block_starts.size() - 1;
-			tasks_completed = 0;
-			tasks_assigned = 0;
-			lstate.build_stage = build_stage = PartitionSortStage::SORTED;
-			lstate.build_task = tasks_assigned++;
-			return true;
-		}
-		global_sort->InitializeMergeRound();
-		lstate.build_stage = build_stage = PartitionSortStage::MERGE;
-		total_tasks = local_sorts.size();
-		tasks_assigned = 1;
+		// All combines are done, so move on to materialising the sorted data (1 task)
+		total_tasks = 1;
 		tasks_completed = 0;
+		tasks_assigned = 0;
+		lstate.build_stage = build_stage = WindowMergeSortStage::FINALIZE;
+		lstate.build_task = tasks_assigned++;
 		return true;
-	case PartitionSortStage::MERGE:
-		if (tasks_assigned < total_tasks) {
-			lstate.build_stage = PartitionSortStage::MERGE;
-			++tasks_assigned;
-			return true;
-		} else if (tasks_completed < tasks_assigned) {
+	case WindowMergeSortStage::FINALIZE:
+		if (tasks_completed < tasks_assigned) {
+			//	Wait for the single task to finish
 			return false;
 		}
-		global_sort->CompleteMergeRound(true);
-		if (!(global_sort->sorted_blocks.size() / 2)) {
-			MeasurePayloadBlocks();
-			total_tasks = block_starts.size() - 1;
-			tasks_completed = 0;
-			tasks_assigned = 0;
-			lstate.build_stage = build_stage = PartitionSortStage::SORTED;
-			lstate.build_task = tasks_assigned++;
-			return true;
-		}
-		global_sort->InitializeMergeRound();
-		lstate.build_stage = PartitionSortStage::MERGE;
-		total_tasks = local_sorts.size();
-		tasks_assigned = 1;
+		//	Move on to building the tree in parallel
+		MeasurePayloadBlocks();
+		total_tasks = local_sinks.size();
 		tasks_completed = 0;
+		tasks_assigned = 0;
+		lstate.build_stage = build_stage = WindowMergeSortStage::SORTED;
+		lstate.build_task = tasks_assigned++;
 		return true;
-	case PartitionSortStage::SORTED:
+	case WindowMergeSortStage::SORTED:
 		if (tasks_assigned < total_tasks) {
-			lstate.build_stage = PartitionSortStage::SORTED;
+			lstate.build_stage = WindowMergeSortStage::SORTED;
 			lstate.build_task = tasks_assigned++;
 			return true;
 		} else if (tasks_completed < tasks_assigned) {
-			lstate.build_stage = PartitionSortStage::FINISHED;
+			lstate.build_stage = WindowMergeSortStage::FINISHED;
 			// Sleep while other tasks finish
 			return false;
 		}
-		CleanupSort();
+		Finished();
 		break;
-	default:
+	case WindowMergeSortStage::FINISHED:
 		break;
 	}
 
-	lstate.build_stage = build_stage = PartitionSortStage::FINISHED;
+	lstate.build_stage = build_stage = WindowMergeSortStage::FINISHED;
 
 	return true;
 }
 
-void WindowMergeSortTreeLocalState::Sort() {
+void WindowMergeSortTreeLocalState::Finalize(ExecutionContext &context) {
 	// Sort, merge and build the tree in parallel
-	while (window_tree.build_stage.load() != PartitionSortStage::FINISHED) {
+	while (window_tree.build_stage.load() != WindowMergeSortStage::FINISHED) {
 		if (window_tree.TryPrepareSortStage(*this)) {
-			ExecuteSortTask();
+			ExecuteSortTask(context);
 		} else {
 			std::this_thread::yield();
 		}

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -436,6 +436,8 @@ enum class WindowBoundary : uint8_t;
 
 enum class WindowExcludeMode : uint8_t;
 
+enum class WindowMergeSortStage : uint8_t;
+
 
 template<>
 const char* EnumUtil::ToChars<ARTConflictType>(ARTConflictType value);
@@ -1043,6 +1045,9 @@ const char* EnumUtil::ToChars<WindowBoundary>(WindowBoundary value);
 template<>
 const char* EnumUtil::ToChars<WindowExcludeMode>(WindowExcludeMode value);
 
+template<>
+const char* EnumUtil::ToChars<WindowMergeSortStage>(WindowMergeSortStage value);
+
 
 template<>
 ARTConflictType EnumUtil::FromString<ARTConflictType>(const char *value);
@@ -1649,6 +1654,9 @@ WindowBoundary EnumUtil::FromString<WindowBoundary>(const char *value);
 
 template<>
 WindowExcludeMode EnumUtil::FromString<WindowExcludeMode>(const char *value);
+
+template<>
+WindowMergeSortStage EnumUtil::FromString<WindowMergeSortStage>(const char *value);
 
 
 }

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -35,13 +35,13 @@ using FrameStats = array<FrameDelta, 2>;
 //! but the row count will still be valid
 class ColumnDataCollection;
 struct WindowPartitionInput {
-	WindowPartitionInput(ClientContext &context, const ColumnDataCollection *inputs, idx_t count,
+	WindowPartitionInput(ExecutionContext &context, const ColumnDataCollection *inputs, idx_t count,
 	                     vector<column_t> &column_ids, vector<bool> &all_valid, const ValidityMask &filter_mask,
 	                     const FrameStats &stats)
 	    : context(context), inputs(inputs), count(count), column_ids(column_ids), all_valid(all_valid),
 	      filter_mask(filter_mask), stats(stats) {
 	}
-	ClientContext &context;
+	ExecutionContext &context;
 	const ColumnDataCollection *inputs;
 	idx_t count;
 	vector<column_t> column_ids;

--- a/src/include/duckdb/function/window/window_aggregate_function.hpp
+++ b/src/include/duckdb/function/window/window_aggregate_function.hpp
@@ -27,7 +27,8 @@ public:
 	unique_ptr<WindowExecutorGlobalState> GetGlobalState(ClientContext &client, const idx_t payload_count,
 	                                                     const ValidityMask &partition_mask,
 	                                                     const ValidityMask &order_mask) const override;
-	unique_ptr<WindowExecutorLocalState> GetLocalState(const WindowExecutorGlobalState &gstate) const override;
+	unique_ptr<WindowExecutorLocalState> GetLocalState(ExecutionContext &context,
+	                                                   const WindowExecutorGlobalState &gstate) const override;
 
 	const WindowAggregationMode mode;
 

--- a/src/include/duckdb/function/window/window_executor.hpp
+++ b/src/include/duckdb/function/window/window_executor.hpp
@@ -57,11 +57,11 @@ class WindowExecutorLocalState : public WindowExecutorState {
 public:
 	using CollectionPtr = optional_ptr<WindowCollection>;
 
-	explicit WindowExecutorLocalState(const WindowExecutorGlobalState &gstate);
+	WindowExecutorLocalState(ExecutionContext &context, const WindowExecutorGlobalState &gstate);
 
 	virtual void Sink(ExecutionContext &context, WindowExecutorGlobalState &gstate, DataChunk &sink_chunk,
 	                  DataChunk &coll_chunk, idx_t input_idx);
-	virtual void Finalize(WindowExecutorGlobalState &gstate, CollectionPtr collection);
+	virtual void Finalize(ExecutionContext &context, WindowExecutorGlobalState &gstate, CollectionPtr collection);
 
 	//! The state used for reading the range collection
 	unique_ptr<WindowCursor> range_cursor;
@@ -69,7 +69,7 @@ public:
 
 class WindowExecutorBoundsLocalState : public WindowExecutorLocalState {
 public:
-	explicit WindowExecutorBoundsLocalState(const WindowExecutorGlobalState &gstate);
+	WindowExecutorBoundsLocalState(ExecutionContext &context, const WindowExecutorGlobalState &gstate);
 	~WindowExecutorBoundsLocalState() override {
 	}
 
@@ -96,7 +96,8 @@ public:
 	virtual unique_ptr<WindowExecutorGlobalState> GetGlobalState(ClientContext &client, const idx_t payload_count,
 	                                                             const ValidityMask &partition_mask,
 	                                                             const ValidityMask &order_mask) const;
-	virtual unique_ptr<WindowExecutorLocalState> GetLocalState(const WindowExecutorGlobalState &gstate) const;
+	virtual unique_ptr<WindowExecutorLocalState> GetLocalState(ExecutionContext &context,
+	                                                           const WindowExecutorGlobalState &gstate) const;
 
 	virtual void Sink(ExecutionContext &context, DataChunk &sink_chunk, DataChunk &coll_chunk, const idx_t input_idx,
 	                  WindowExecutorGlobalState &gstate, WindowExecutorLocalState &lstate) const;

--- a/src/include/duckdb/function/window/window_index_tree.hpp
+++ b/src/include/duckdb/function/window/window_index_tree.hpp
@@ -16,7 +16,7 @@ class WindowIndexTree;
 
 class WindowIndexTreeLocalState : public WindowMergeSortTreeLocalState {
 public:
-	explicit WindowIndexTreeLocalState(WindowIndexTree &index_tree);
+	WindowIndexTreeLocalState(ExecutionContext &context, WindowIndexTree &index_tree);
 
 	//! Process sorted leaf data
 	void BuildLeaves() override;
@@ -33,7 +33,7 @@ public:
 	                const idx_t count);
 	~WindowIndexTree() override = default;
 
-	unique_ptr<WindowAggregatorState> GetLocalState() override;
+	unique_ptr<WindowAggregatorState> GetLocalState(ExecutionContext &context) override;
 
 	//! Find the Nth index in the set of subframes
 	//! Returns {nth index, 0} or {nth offset, overflow}

--- a/src/include/duckdb/function/window/window_merge_sort_tree.hpp
+++ b/src/include/duckdb/function/window/window_merge_sort_tree.hpp
@@ -12,85 +12,88 @@
 #include "duckdb/planner/bound_result_modifier.hpp"
 
 #include "duckdb/function/window/window_aggregator.hpp"
-#include "duckdb/common/sort/sort.hpp"
-#include "duckdb/common/sort/partition_state.hpp"
+#include "duckdb/common/sorting/sort.hpp"
 
 namespace duckdb {
+
+enum class WindowMergeSortStage : uint8_t { INIT, COMBINE, FINALIZE, SORTED, FINISHED };
 
 class WindowMergeSortTree;
 
 class WindowMergeSortTreeLocalState : public WindowAggregatorState {
 public:
-	explicit WindowMergeSortTreeLocalState(WindowMergeSortTree &index_tree);
+	WindowMergeSortTreeLocalState(ExecutionContext &context, WindowMergeSortTree &index_tree);
 
 	//! Add a chunk to the local sort
-	void SinkChunk(DataChunk &chunk, const idx_t row_idx, optional_ptr<SelectionVector> filter_sel, idx_t filtered);
+	void Sink(ExecutionContext &context, DataChunk &chunk, const idx_t row_idx,
+	          optional_ptr<SelectionVector> filter_sel, idx_t filtered);
 	//! Sort the data
-	void Sort();
+	void Finalize(ExecutionContext &context);
 	//! Process sorted leaf data
 	virtual void BuildLeaves() = 0;
 
 	//! The index tree we are building
 	WindowMergeSortTree &window_tree;
 	//! Thread-local sorting data
-	optional_ptr<LocalSortState> local_sort;
-	//! Buffer for the sort keys
+	optional_ptr<LocalSinkState> local_sink;
+	//! Buffer for the sort data
 	DataChunk sort_chunk;
-	//! Buffer for the payload data
-	DataChunk payload_chunk;
 	//! Build stage
-	PartitionSortStage build_stage = PartitionSortStage::INIT;
+	WindowMergeSortStage build_stage = WindowMergeSortStage::INIT;
 	//! Build task number
 	idx_t build_task;
 
 private:
-	void ExecuteSortTask();
+	void ExecuteSortTask(ExecutionContext &context);
 };
 
 class WindowMergeSortTree {
 public:
-	using GlobalSortStatePtr = unique_ptr<GlobalSortState>;
-	using LocalSortStatePtr = unique_ptr<LocalSortState>;
+	using GlobalSortStatePtr = unique_ptr<GlobalSinkState>;
+	using LocalSortStatePtr = unique_ptr<LocalSinkState>;
 
 	WindowMergeSortTree(ClientContext &context, const vector<BoundOrderByNode> &orders,
-	                    const vector<column_t> &sort_idx, const idx_t count, bool unique = false);
+	                    const vector<column_t> &order_idx, const idx_t count, bool unique = false);
 	virtual ~WindowMergeSortTree() = default;
 
-	virtual unique_ptr<WindowAggregatorState> GetLocalState() = 0;
+	virtual unique_ptr<WindowAggregatorState> GetLocalState(ExecutionContext &context) = 0;
 
 	//! Make a local sort for a thread
-	optional_ptr<LocalSortState> AddLocalSort();
+	optional_ptr<LocalSinkState> InitializeLocalSort(ExecutionContext &context) const;
 
 	//! Thread-safe post-sort cleanup
-	virtual void CleanupSort();
+	virtual void Finished();
 
 	//! Sort state machine
 	bool TryPrepareSortStage(WindowMergeSortTreeLocalState &lstate);
 	//! Build the MST in parallel from the sorted data
 	void Build();
 
-	//! The query context
-	ClientContext &context;
-	//! Thread memory limit
-	const idx_t memory_per_thread;
 	//! The column indices for sorting
-	const vector<column_t> sort_idx;
+	const vector<column_t> order_idx;
+	//! The sorted data schema
+	vector<LogicalType> scan_types;
+	vector<idx_t> scan_cols;
+	//! The sort key columns
+	vector<idx_t> key_cols;
+	//! The sort specification
+	unique_ptr<Sort> sort;
 	//! The sorted data
-	GlobalSortStatePtr global_sort;
+	GlobalSortStatePtr global_sink;
+	//! The resulting sorted data
+	unique_ptr<ColumnDataCollection> sorted;
 	//! Finalize guard
-	mutex lock;
+	mutable mutex lock;
 	//! Local sort set
-	vector<LocalSortStatePtr> local_sorts;
+	mutable vector<LocalSortStatePtr> local_sinks;
 	//! Finalize stage
-	atomic<PartitionSortStage> build_stage;
+	atomic<WindowMergeSortStage> build_stage;
 	//! Tasks launched
 	idx_t total_tasks = 0;
 	//! Tasks launched
 	idx_t tasks_assigned = 0;
 	//! Tasks landed
 	atomic<idx_t> tasks_completed;
-	//! The block starts (the scanner doesn't know this) plus the total count
-	vector<idx_t> block_starts;
 
 	// Merge sort trees for various sizes
 	// Smaller is probably not worth the effort.

--- a/src/include/duckdb/function/window/window_rank_function.hpp
+++ b/src/include/duckdb/function/window/window_rank_function.hpp
@@ -19,7 +19,8 @@ public:
 	unique_ptr<WindowExecutorGlobalState> GetGlobalState(ClientContext &context, const idx_t payload_count,
 	                                                     const ValidityMask &partition_mask,
 	                                                     const ValidityMask &order_mask) const override;
-	unique_ptr<WindowExecutorLocalState> GetLocalState(const WindowExecutorGlobalState &gstate) const override;
+	unique_ptr<WindowExecutorLocalState> GetLocalState(ExecutionContext &context,
+	                                                   const WindowExecutorGlobalState &gstate) const override;
 
 	//! The column indices of any ORDER BY argument expressions
 	vector<column_t> arg_order_idx;

--- a/src/include/duckdb/function/window/window_rownumber_function.hpp
+++ b/src/include/duckdb/function/window/window_rownumber_function.hpp
@@ -19,7 +19,8 @@ public:
 	unique_ptr<WindowExecutorGlobalState> GetGlobalState(ClientContext &client, const idx_t payload_count,
 	                                                     const ValidityMask &partition_mask,
 	                                                     const ValidityMask &order_mask) const override;
-	unique_ptr<WindowExecutorLocalState> GetLocalState(const WindowExecutorGlobalState &gstate) const override;
+	unique_ptr<WindowExecutorLocalState> GetLocalState(ExecutionContext &context,
+	                                                   const WindowExecutorGlobalState &gstate) const override;
 
 	//! The evaluation index of the NTILE column
 	column_t ntile_idx = DConstants::INVALID_INDEX;

--- a/src/include/duckdb/function/window/window_token_tree.hpp
+++ b/src/include/duckdb/function/window/window_token_tree.hpp
@@ -15,19 +15,19 @@ namespace duckdb {
 // Builds a merge sort tree that uses integer tokens for the comparison values instead of the sort keys.
 class WindowTokenTree : public WindowMergeSortTree {
 public:
-	WindowTokenTree(ClientContext &context, const vector<BoundOrderByNode> &orders, const vector<column_t> &sort_idx,
+	WindowTokenTree(ClientContext &context, const vector<BoundOrderByNode> &orders, const vector<column_t> &order_idx,
 	                const idx_t count, bool unique = false)
-	    : WindowMergeSortTree(context, orders, sort_idx, count, unique) {
+	    : WindowMergeSortTree(context, orders, order_idx, count, unique) {
 	}
-	WindowTokenTree(ClientContext &context, const BoundOrderModifier &order_bys, const vector<column_t> &sort_idx,
+	WindowTokenTree(ClientContext &context, const BoundOrderModifier &order_bys, const vector<column_t> &order_idx,
 	                const idx_t count, bool unique = false)
-	    : WindowTokenTree(context, order_bys.orders, sort_idx, count, unique) {
+	    : WindowTokenTree(context, order_bys.orders, order_idx, count, unique) {
 	}
 
-	unique_ptr<WindowAggregatorState> GetLocalState() override;
+	unique_ptr<WindowAggregatorState> GetLocalState(ExecutionContext &context) override;
 
 	//! Thread-safe post-sort cleanup
-	void CleanupSort() override;
+	void Finished() override;
 
 	//! Find the rank of the row within the range
 	idx_t Rank(const idx_t lower, const idx_t upper, const idx_t row_idx) const;

--- a/src/include/duckdb/function/window/window_value_function.hpp
+++ b/src/include/duckdb/function/window/window_value_function.hpp
@@ -23,7 +23,8 @@ public:
 	unique_ptr<WindowExecutorGlobalState> GetGlobalState(ClientContext &client, const idx_t payload_count,
 	                                                     const ValidityMask &partition_mask,
 	                                                     const ValidityMask &order_mask) const override;
-	unique_ptr<WindowExecutorLocalState> GetLocalState(const WindowExecutorGlobalState &gstate) const override;
+	unique_ptr<WindowExecutorLocalState> GetLocalState(ExecutionContext &context,
+	                                                   const WindowExecutorGlobalState &gstate) const override;
 
 	//! The column index of the value column
 	column_t child_idx = DConstants::INVALID_INDEX;
@@ -44,7 +45,8 @@ public:
 	unique_ptr<WindowExecutorGlobalState> GetGlobalState(ClientContext &client, const idx_t payload_count,
 	                                                     const ValidityMask &partition_mask,
 	                                                     const ValidityMask &order_mask) const override;
-	unique_ptr<WindowExecutorLocalState> GetLocalState(const WindowExecutorGlobalState &gstate) const override;
+	unique_ptr<WindowExecutorLocalState> GetLocalState(ExecutionContext &context,
+	                                                   const WindowExecutorGlobalState &gstate) const override;
 
 protected:
 	void EvaluateInternal(ExecutionContext &context, WindowExecutorGlobalState &gstate,
@@ -94,7 +96,8 @@ public:
 	unique_ptr<WindowExecutorGlobalState> GetGlobalState(ClientContext &client, const idx_t payload_count,
 	                                                     const ValidityMask &partition_mask,
 	                                                     const ValidityMask &order_mask) const override;
-	unique_ptr<WindowExecutorLocalState> GetLocalState(const WindowExecutorGlobalState &gstate) const override;
+	unique_ptr<WindowExecutorLocalState> GetLocalState(ExecutionContext &context,
+	                                                   const WindowExecutorGlobalState &gstate) const override;
 
 	//! Secondary order collection index
 	idx_t order_idx = DConstants::INVALID_INDEX;


### PR DESCRIPTION
* Convert WindowMergeSortTree, WindowIndexTree and WindowTokenTree to the new sort code
* Cut more holes for window local states to have access to the ExecutionContext
* Update enum serialisation

fixes: duckdblabs/duckdb-internal#5385
fixes: duckdblabs/duckdb-internal#5386
