### PR TITLE
Fix: Preserve database configuration flags for tab completion in DuckDB shell

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2464,6 +2464,7 @@ static char **readline_completion(const char *zText, int iStart, int iEnd) {
 /*
 ** Linenoise completion callback
 */
+static int linenoise_open_flags = 0;
 static void linenoise_completion(const char *zLine, linenoiseCompletions *lc) {
 	idx_t nLine = ShellState::StringLength(zLine);
 	int copiedSuggestion = 0;
@@ -2507,7 +2508,7 @@ static void linenoise_completion(const char *zLine, linenoiseCompletions *lc) {
 	zSql = sqlite3_mprintf("CALL sql_auto_complete(%Q)", zLine);
 	sqlite3 *localDb = NULL;
 	if (!globalDb) {
-		sqlite3_open(":memory:", &localDb);
+		sqlite3_open_v2(":memory:", &localDb, linenoise_open_flags, 0);
 		sqlite3_prepare_v2(localDb, zSql, -1, &pStmt, 0);
 	} else {
 		sqlite3_prepare_v2(globalDb, zSql, -1, &pStmt, 0);
@@ -5158,6 +5159,7 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 #if HAVE_READLINE || HAVE_EDITLINE
 			rl_attempted_completion_function = readline_completion;
 #elif HAVE_LINENOISE
+			linenoise_open_flags = data.openFlags;
 			linenoiseSetCompletionCallback(linenoise_completion);
 #endif
 			data.in = 0;


### PR DESCRIPTION
When using tab completion in the DuckDB shell, the completion system creates a new database connection without preserving the some important configuration flags. This causes issues when extensions themselves load other extensions as part of tab-completion.

When a database is opened in the DuckDB shell and a tab-completion is requested, the database config that is used does not pass the flag for `allow_unsigned_extensions`, in actuality no config is passed. This PR persists the open flags that are set for the database so that it can be used as part of `linenoise_completions`.

This PR modifies the shell to persist the database configuration flags that were used when opening the database, ensuring they are available to the `linenoise_completions` function.

I encountered this bug by:

I have an extension that in its load function attempts to load other extensions, some of which are unsigned. 

If this extension is loaded by the `linenoise_completion` function, which pretty easy (just start the shell and press tab), the value for `allow_unsigned_extensions` is false even though the DuckDB shell was started with the `-unsigned` CLI argument.