### PR TITLE
Change ctrl-a/ctrl-e to move to start/end of line, not buffer

### DIFF
--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -1382,10 +1382,10 @@ int Linenoise::Edit() {
 			RefreshLine();
 			break;
 		case CTRL_A: /* Ctrl+a, go to the start of the line */
-			EditMoveHome();
+			EditMoveStartOfLine();
 			break;
 		case CTRL_E: /* ctrl+e, go to the end of the line */
-			EditMoveEnd();
+			EditMoveEndOfLine();
 			break;
 		case CTRL_L: /* ctrl+l, clear screen */
 			linenoiseClearScreen();


### PR DESCRIPTION
This cli behaviour has been driving me crazy, but perhaps it's only me. I think that for a multi-line query, you should go to the start/end of the current line with ctrl-a/ctrl-e, not start/end of the entire multi-line buffer. If you want to go to the start/end of the buffer, the home/end keys are bound to that.

It could be a personal preference of mine, or maybe I spend too much time in the cli, but I think this is more intuitive behaviour for multi-line queries as it mirrors how multi-line editing works in some other apps, e.g web browser, word processors etc.