### PR TITLE
Fix accidental internal exception in type transformation

### DIFF
--- a/src/parser/transform/helpers/transform_typename.cpp
+++ b/src/parser/transform/helpers/transform_typename.cpp
@@ -56,17 +56,16 @@ vector<Value> Transformer::TransformTypeModifiers(duckdb_libpgquery::PGTypeName 
 	vector<Value> type_mods;
 	if (type_name.typmods) {
 		for (auto node = type_name.typmods->head; node; node = node->next) {
-			if (type_mods.size() > 9) {
-				const auto &name =
-				    *PGPointerCast<duckdb_libpgquery::PGValue>(type_name.names->tail->data.ptr_value)->val.str;
-				throw ParserException("'%s': a maximum of 9 type modifiers is allowed", name);
-			}
 			const auto &const_val = *PGPointerCast<duckdb_libpgquery::PGAConst>(node->data.ptr_value);
 			if (const_val.type != duckdb_libpgquery::T_PGAConst) {
 				throw ParserException("Expected a constant as type modifier");
 			}
 			const auto const_expr = TransformValue(const_val.val);
 			type_mods.push_back(std::move(const_expr->value));
+		}
+		if (type_mods.size() > 9) {
+			const auto name = PGPointerCast<duckdb_libpgquery::PGValue>(type_name.names->tail->data.ptr_value)->val.str;
+			throw ParserException("'%s': a maximum of 9 type modifiers is allowed", name);
 		}
 	}
 	return type_mods;

--- a/test/sql/types/test_user_type_errors_18452.test
+++ b/test/sql/types/test_user_type_errors_18452.test
@@ -1,0 +1,25 @@
+# name: test/sql/types/test_typeof.test
+# group: [types]
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+CREATE TYPE l AS X(0,0,0,0,0,0,0,0,0,0,0); -- original issue, those are 11 parameters though
+----
+Parser Error: 'X': a maximum of 9 type modifiers is allowed
+
+statement error
+CREATE TYPE ll AS XX(1,2,3,4,5,6,7,8,9,10); -- needs to also fail on 10, did not used to
+----
+Parser Error: 'XX': a maximum of 9 type modifiers is allowed
+
+statement error
+CREATE TYPE ll AS XX(1,2,3,4,5,6,7,8,9); -- nine are fine, fails for other reasons
+----
+Catalog Error: Type with name XX does not exist!
+
+statement error
+CREATE TYPE ll AS XX(a,2,3,4,5,6,7,8,9); -- no variables
+----
+Parser Error: Expected a constant as type modifier

--- a/test/sql/types/test_user_type_errors_18452.test
+++ b/test/sql/types/test_user_type_errors_18452.test
@@ -1,4 +1,4 @@
-# name: test/sql/types/test_typeof.test
+# name: test/sql/types/test_user_type_errors_18452.test
 # group: [types]
 
 statement ok


### PR DESCRIPTION
We had a bug in the error message construction if too many type parameters were passed (#18452). This PR fixes this. 