### PR TITLE
fix: add missing space in AttachInfo::ToString()

### DIFF
--- a/src/parser/parsed_data/attach_info.cpp
+++ b/src/parser/parsed_data/attach_info.cpp
@@ -24,7 +24,7 @@ string AttachInfo::ToString() const {
 	} else if (on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
 		result += " OR REPLACE";
 	}
-	result += " DATABASE";
+	result += " DATABASE ";
 	result += KeywordHelper::WriteQuoted(path, '\'');
 	if (!name.empty()) {
 		result += " AS " + KeywordHelper::WriteOptionallyQuoted(name);


### PR DESCRIPTION
Just improving the ToString() for AttachInfo to add a missing space.