### PR TITLE
Fix: Remove overly strict assertion on empty string value

### DIFF
--- a/src/parser/transform/statement/transform_create_type.cpp
+++ b/src/parser/transform/statement/transform_create_type.cpp
@@ -28,7 +28,6 @@ Vector Transformer::PGListToVector(optional_ptr<duckdb_libpgquery::PGList> colum
 		}
 
 		auto entry_value = string(entry_value_node.val.str);
-		D_ASSERT(!entry_value.empty());
 		result_ptr[size++] = StringVector::AddStringOrBlob(result, entry_value);
 	}
 	return result;

--- a/test/fuzzer/public/enum_empty_type.test
+++ b/test/fuzzer/public/enum_empty_type.test
@@ -1,0 +1,22 @@
+# name: test/fuzzer/public/enum_empty_type.test
+# description: Test creating an enum with empty strings
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TYPE c AS ENUM('');
+
+statement error
+CREATE TYPE c AS ENUM('', '');
+----
+Invalid Input Error: Attempted to create ENUM type with duplicate value
+
+statement error
+CREATE TYPE f AS M();
+----
+Catalog Error: Type with name M does not exist!
+
+statement ok
+SELECT * FROM(VALUES(''::text))


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/5475

This removes the assertion `D_ASSERT(!entry_value.empty())`.

This assertion was based on the assumption that an empty string was an invalid state at this point. However, I think empty strings are a valid case and are handled gracefully by downstream code. The assertion was therefore too aggressive and has been removed.