### PR TITLE
ParserException for Pragma with named parameters

### DIFF
--- a/src/parser/transform/statement/transform_pragma.cpp
+++ b/src/parser/transform/statement/transform_pragma.cpp
@@ -52,7 +52,7 @@ unique_ptr<SQLStatement> Transformer::TransformPragma(duckdb_libpgquery::PGPragm
 			throw ParserException("PRAGMA statement with assignment should contain exactly one parameter");
 		}
 		if (!info.named_parameters.empty()) {
-			throw InternalException("PRAGMA statement with assignment cannot have named parameters");
+			throw ParserException("PRAGMA statement with assignment cannot have named parameters");
 		}
 		// SQLite does not distinguish between:
 		// "PRAGMA table_info='integers'"

--- a/test/fuzzer/public/pragma_named_parameters.test
+++ b/test/fuzzer/public/pragma_named_parameters.test
@@ -1,5 +1,5 @@
-# name: test/fuzzer/public/insert_returning.test
-# description: Test INSERT OR REPLACE with DEFAULT VALUES
+# name: test/fuzzer/public/pragma_named_parameters.test
+# description: Test pragma with named parameter that should throw normal exception
 # group: [public]
 
 statement ok

--- a/test/fuzzer/public/pragma_named_parameters.test
+++ b/test/fuzzer/public/pragma_named_parameters.test
@@ -1,0 +1,11 @@
+# name: test/fuzzer/public/insert_returning.test
+# description: Test INSERT OR REPLACE with DEFAULT VALUES
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement error
+PRAGMA e=r=0,0;
+----
+Parser Error: PRAGMA statement with assignment cannot have named parameters


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/5446

This changes an `InternalException` to a `ParserException` for PRAGMA statements that incorrectly use named parameters with an assignment.

This condition is a user syntax error, not an internal engine bug, so `ParserException` is the more appropriate exception type.