### PR TITLE
Restore missing `test/configs/small_block_size.json` file

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -582,8 +582,8 @@ jobs:
         run: |
           ./build/relassert/test/unittest
           ./build/relassert/test/unittest "test/sql/storage/*"
-          ./build/relassert/test/unittest --test-config test/configs/small_block_size.json
-          ./build/relassert/test/unittest "test/sql/storage/*" --test-config test/configs/small_block_size.json
+          ./build/relassert/test/unittest --test-config test/configs/block_size_16kB.json
+          ./build/relassert/test/unittest "test/sql/storage/*" --test-config test/configs/block_size_16kB.json
 
   linux-wasm-experimental:
     name: WebAssembly duckdb-wasm builds


### PR DESCRIPTION
`test/configs/small_block_size.json` went missing which caused `Block Sizes` job failure in `NightlyTests` in `main` and in `v1.3-ossivalis`.

This PR restores missing config file. 