### PR TITLE
Temporarily excluding `Build Pyodide wheel` for Python 3.11 because it fails to build `WASM` wheels 

### DIFF
--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -47,12 +47,14 @@ jobs:
             other_deps: "'pydantic<2'"
             perform_tests: true
             flags: "-fexceptions"
-          - python: "3.11"
-            pyodide-build: "0.25.1"
-            node: "18"
-            other_deps: "'pydantic<2'"
-            perform_tests: true
-            flags: "-fexceptions"
+          # FIXME: This fails on build wasm wheel step in NightlyTests and InvokeCI
+          #        It cannot find env variables from Makefile.envs
+          # - python: "3.11"
+          #   pyodide-build: "0.25.1"
+          #   node: "18"
+          #   other_deps: "'pydantic<2'"
+          #   perform_tests: true
+          #   flags: "-fexceptions"
           - python: "3.12"
             pyodide-build: "0.26.1"
             node: "20"


### PR DESCRIPTION
`InvokeCI` fails to `build wasm wheel` for Python 3.11:
```
ERROR: Failed to load environment variables from Makefile.envs
```

I'm opening this PR to temporarily skip building it for 3.11 in `main`.