### PR TITLE
When tracking evicted_data_per_tag, track actual size on disk after temp file compression

### DIFF
--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -280,11 +280,11 @@ public:
 	};
 
 	//! Create/Read/Update/Delete operations for temporary buffers
-	void WriteTemporaryBuffer(block_id_t block_id, FileBuffer &buffer);
+	idx_t WriteTemporaryBuffer(block_id_t block_id, FileBuffer &buffer);
 	bool HasTemporaryBuffer(block_id_t block_id);
 	unique_ptr<FileBuffer> ReadTemporaryBuffer(QueryContext context, block_id_t id,
 	                                           unique_ptr<FileBuffer> reusable_buffer);
-	void DeleteTemporaryBuffer(block_id_t id);
+	idx_t DeleteTemporaryBuffer(block_id_t id);
 	bool IsEncrypted() const;
 
 	//! Get the list of temporary files and their sizes

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -496,8 +496,8 @@ void StandardBufferManager::WriteTemporaryBuffer(MemoryTag tag, block_id_t block
 
 	// Append to a few grouped files.
 	if (buffer.AllocSize() == GetBlockAllocSize()) {
-		evicted_data_per_tag[uint8_t(tag)] += GetBlockAllocSize();
-		temporary_directory.handle->GetTempFile().WriteTemporaryBuffer(block_id, buffer);
+		idx_t eviction_size = temporary_directory.handle->GetTempFile().WriteTemporaryBuffer(block_id, buffer);
+		evicted_data_per_tag[uint8_t(tag)] += eviction_size;
 		return;
 	}
 
@@ -597,8 +597,8 @@ void StandardBufferManager::DeleteTemporaryFile(BlockHandle &block) {
 
 	// check if we should delete the file from the shared pool of files, or from the general file system
 	if (temporary_directory.handle->GetTempFile().HasTemporaryBuffer(id)) {
-		evicted_data_per_tag[uint8_t(block.GetMemoryTag())] -= GetBlockAllocSize();
-		temporary_directory.handle->GetTempFile().DeleteTemporaryBuffer(id);
+		idx_t eviction_size = temporary_directory.handle->GetTempFile().DeleteTemporaryBuffer(id);
+		evicted_data_per_tag[uint8_t(block.GetMemoryTag())] -= eviction_size;
 		return;
 	}
 


### PR DESCRIPTION
Previously we would report the uncompressed evicted data. We now report the actual data that is present on disk instead. 