### PR TITLE
fix: support both field orders for variant struct

### DIFF
--- a/extension/parquet/include/reader/variant_column_reader.hpp
+++ b/extension/parquet/include/reader/variant_column_reader.hpp
@@ -35,6 +35,10 @@ public:
 	idx_t GroupRowsAvailable() override;
 	uint64_t TotalCompressedSize() override;
 	void RegisterPrefetch(ThriftFileTransport &transport, bool allow_merge) override;
+
+protected:
+	idx_t metadata_reader_idx;
+	idx_t value_reader_idx;
 };
 
 } // namespace duckdb

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -518,22 +518,35 @@ static bool IsVariantType(const SchemaElement &root, const vector<ParquetColumnS
 	if (children.size() < 2) {
 		return false;
 	}
-	auto &metadata = children[0];
-	auto &value = children[1];
+	auto &child0 = children[0];
+	auto &child1 = children[1];
 
-	//! Verify names
-	if (metadata.name != "metadata") {
+	ParquetColumnSchema const *metadata;
+	ParquetColumnSchema const *value;
+
+	if (child0.name == "metadata" && child1.name == "value") {
+		metadata = &child0;
+		value = &child1;
+	} else if (child1.name == "metadata" && child0.name == "value") {
+		metadata = &child1;
+		value = &child0;
+	} else {
 		return false;
 	}
-	if (value.name != "value") {
+
+	//! Verify names
+	if (metadata->name != "metadata") {
+		return false;
+	}
+	if (value->name != "value") {
 		return false;
 	}
 
 	//! Verify types
-	if (metadata.parquet_type != duckdb_parquet::Type::BYTE_ARRAY) {
+	if (metadata->parquet_type != duckdb_parquet::Type::BYTE_ARRAY) {
 		return false;
 	}
-	if (value.parquet_type != duckdb_parquet::Type::BYTE_ARRAY) {
+	if (value->parquet_type != duckdb_parquet::Type::BYTE_ARRAY) {
 		return false;
 	}
 	if (children.size() == 3) {


### PR DESCRIPTION
Current variant code assumes a specific field order for the struct value and metadata fields.