### PR TITLE
correctly setting log transaction id in ThreadContext

### DIFF
--- a/src/parallel/thread_context.cpp
+++ b/src/parallel/thread_context.cpp
@@ -21,14 +21,6 @@ ThreadContext::ThreadContext(ClientContext &context) : profiler(context) {
 	}
 
 	log_context.thread_id = TaskScheduler::GetEstimatedCPUId();
-	if (context.transaction.HasActiveTransaction()) {
-		auto query_id = context.transaction.GetActiveQuery();
-		if (query_id == DConstants::INVALID_INDEX) {
-			log_context.transaction_id = optional_idx();
-		} else {
-			log_context.transaction_id = query_id;
-		}
-	}
 	logger = LogManager::Get(context).CreateLogger(log_context, true);
 }
 


### PR DESCRIPTION
`transaction_id` is already set above. I guess #16296 forgot to remove the old code of setting `transaction_id`.

I tried to add a test of this, but it seems `logger` in `ThreadContext` is not used in any code.