### PR TITLE
Use global index, not local id when creating filters in `MultiFileColumnMapper`

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -1091,11 +1091,12 @@ unique_ptr<TableFilterSet> MultiFileColumnMapper::CreateFilters(map<idx_t, refer
 
 			// add the expression to the expression map - we are now evaluating this inside the reader directly
 			// we need to set the index of the references inside the expression to 0
-			SetIndexToZero(reader_data.expressions[local_id]);
-			reader.expression_map[filter_idx] = std::move(reader_data.expressions[local_id]);
+			auto &expr = reader_data.expressions[global_index];
+			SetIndexToZero(expr);
+			reader.expression_map[filter_idx] = std::move(expr);
 
 			// reset the expression - since we are evaluating it in the reader we can just reference it
-			reader_data.expressions[local_id] = make_uniq<BoundReferenceExpression>(global_type, local_id);
+			expr = make_uniq<BoundReferenceExpression>(global_type, local_id);
 		}
 	}
 	return result;

--- a/test/parquet/test_18470.test
+++ b/test/parquet/test_18470.test
@@ -1,0 +1,32 @@
+# name: test/parquet/test_18470.test
+# description: Test issue #18470 - Internal Error when querying multiple Parquet files that have mixed data type for same column
+# group: [parquet]
+
+require parquet
+
+set seed 0.42
+
+statement ok
+COPY (
+    SELECT
+        (random() * 65535)::UINT16 as column1,
+        'text_value_' || row_number() OVER () as column2
+    FROM generate_series(1, 100)
+) TO '__TEST_DIR__/20250101.parquet' (FORMAT PARQUET);
+
+statement ok
+COPY (
+    SELECT
+        (random() * 65535)::UINT64 as column1,
+        'text_value_' || row_number() OVER () as column2
+    FROM generate_series(1, 100)
+) TO '__TEST_DIR__/20250102.parquet' (FORMAT PARQUET);
+
+query III
+SELECT filename = '__TEST_DIR__/20250101.parquet', *
+FROM read_parquet('__TEST_DIR__/2025010*.parquet')
+WHERE filename >= '__TEST_DIR__/20250101.parquet'
+AND column1 = 72
+LIMIT 10;
+----
+true	72	text_value_66

--- a/test/parquet/test_18470.test
+++ b/test/parquet/test_18470.test
@@ -4,6 +4,8 @@
 
 require parquet
 
+require notwindows
+
 set seed 0.42
 
 statement ok


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/18470