### PR TITLE
Add support for explicit clean-up routine in test config, and exit multi-statement execution when an error is encountered

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -986,6 +986,12 @@ unique_ptr<QueryResult> ClientContext::Query(const string &query, bool allow_str
 		} else {
 			current_result = ExecutePendingQueryInternal(*lock, *pending_query);
 		}
+		if (current_result->HasError()) {
+			// Reset the interrupted flag, this was set by the task that found the error
+			// Next statements should not be bothered by that interruption
+			interrupted = false;
+			return current_result;
+		}
 		// now append the result to the list of results
 		if (!last_result || !last_had_result) {
 			// first result of the query
@@ -1002,12 +1008,6 @@ unique_ptr<QueryResult> ClientContext::Query(const string &query, bool allow_str
 			last_result = last_result->next.get();
 		}
 		D_ASSERT(last_result);
-		if (last_result->HasError()) {
-			// Reset the interrupted flag, this was set by the task that found the error
-			// Next statements should not be bothered by that interruption
-			interrupted = false;
-			break;
-		}
 	}
 	return result;
 }

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -34,6 +34,7 @@ static const TestConfigOption test_config_options[] = {
     {"debug_initialize", "Initialize buffers with all 0 or all 1", LogicalType::VARCHAR, nullptr},
     {"autoloading", "Loading strategy for extensions not bundled in", LogicalType::VARCHAR, nullptr},
     {"init_script", "Script to execute on init", LogicalType::VARCHAR, TestConfiguration::ParseConnectScript},
+    {"on_cleanup", "SQL statements to execute on test end", LogicalType::VARCHAR, nullptr},
     {"on_init", "SQL statements to execute on init", LogicalType::VARCHAR, nullptr},
     {"on_load", "SQL statements to execute on explicit load", LogicalType::VARCHAR, nullptr},
     {"on_new_connection", "SQL statements to execute on connection", LogicalType::VARCHAR, nullptr},
@@ -203,6 +204,10 @@ string TestConfiguration::OnLoadCommand() {
 
 string TestConfiguration::OnConnectionCommand() {
 	return GetOptionOrDefault("on_new_connection", string());
+}
+
+string TestConfiguration::OnCleanupCommand() {
+	return GetOptionOrDefault("on_cleanup", string());
 }
 
 vector<string> TestConfiguration::ExtensionToBeLoadedOnLoad() {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -50,6 +50,7 @@ public:
 	string OnInitCommand();
 	string OnLoadCommand();
 	string OnConnectionCommand();
+	string OnCleanupCommand();
 	vector<string> ExtensionToBeLoadedOnLoad();
 	vector<string> ErrorMessagesToBeSkipped();
 	string GetStorageVersion();

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -89,6 +89,25 @@ static void testRunner() {
 		TestChangeDirectory(prev_directory);
 	}
 
+	auto on_cleanup = test_config.OnCleanupCommand();
+	if (!on_cleanup.empty()) {
+		// perform clean-up if any is defined
+		try {
+			if (!runner.con) {
+				runner.Reconnect();
+			}
+			auto res = runner.con->Query(on_cleanup);
+			if (res->HasError()) {
+				res->GetErrorObject().Throw();
+			}
+		} catch (std::exception &ex) {
+			string cleanup_failure = "Error while running clean-up routine:\n";
+			ErrorData error(ex);
+			cleanup_failure += error.Message();
+			FAIL(cleanup_failure);
+		}
+	}
+
 	// clear test directory after running tests
 	ClearTestDirectory();
 }


### PR DESCRIPTION
Adds support for the `"on_cleanup"` routine to the test configuration, which optionally runs a set of SQL statements after the test to perform any clean-up required