### PR TITLE
Implement special-case `VARCHAR` to `JSON[]` casts and vice versa

### DIFF
--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -75,9 +75,9 @@ public:
 	                                                optional_ptr<ReplacementScanData> data);
 	static TableFunction GetReadJSONTableFunction(shared_ptr<JSONScanInfo> function_info);
 	static CopyFunction GetJSONCopyFunction();
-	static void RegisterSimpleCastFunctions(CastFunctionSet &casts);
-	static void RegisterJSONCreateCastFunctions(CastFunctionSet &casts);
-	static void RegisterJSONTransformCastFunctions(CastFunctionSet &casts);
+	static void RegisterSimpleCastFunctions(ExtensionLoader &loader);
+	static void RegisterJSONCreateCastFunctions(ExtensionLoader &loader);
+	static void RegisterJSONTransformCastFunctions(ExtensionLoader &loader);
 
 private:
 	// Scalar functions

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -259,20 +259,147 @@ static bool CastVarcharToJSON(Vector &source, Vector &result, idx_t count, CastP
 	return success;
 }
 
-void JSONFunctions::RegisterSimpleCastFunctions(CastFunctionSet &casts) {
+static bool CastJSONListToVarchar(Vector &source, Vector &result, idx_t count, CastParameters &) {
+	UnifiedVectorFormat child_format;
+	ListVector::GetEntry(source).ToUnifiedFormat(ListVector::GetListSize(source), child_format);
+	const auto input_jsons = UnifiedVectorFormat::GetData<string_t>(child_format);
+
+	static constexpr char const *NULL_STRING = "NULL";
+	static constexpr idx_t NULL_STRING_LENGTH = 4;
+
+	UnaryExecutor::Execute<list_entry_t, string_t>(
+	    source, result, count,
+	    [&](const list_entry_t &input) {
+		    // Compute len (start with [] and ,)
+		    idx_t len = 2;
+		    len += input.length == 0 ? 0 : (input.length - 1) * 2;
+		    for (idx_t json_idx = input.offset; json_idx < input.offset + input.length; json_idx++) {
+			    const auto sel_json_idx = child_format.sel->get_index(json_idx);
+			    if (child_format.validity.RowIsValid(sel_json_idx)) {
+				    len += input_jsons[sel_json_idx].GetSize();
+			    } else {
+				    len += NULL_STRING_LENGTH;
+			    }
+		    }
+
+		    // Allocate string
+		    auto res = StringVector::EmptyString(result, len);
+		    auto ptr = res.GetDataWriteable();
+
+		    // Populate string
+		    *ptr++ = '[';
+		    for (idx_t json_idx = input.offset; json_idx < input.offset + input.length; json_idx++) {
+			    const auto sel_json_idx = child_format.sel->get_index(json_idx);
+			    if (child_format.validity.RowIsValid(sel_json_idx)) {
+				    auto &input_json = input_jsons[sel_json_idx];
+				    memcpy(ptr, input_json.GetData(), input_json.GetSize());
+				    ptr += input_json.GetSize();
+			    } else {
+				    memcpy(ptr, NULL_STRING, NULL_STRING_LENGTH);
+				    ptr += NULL_STRING_LENGTH;
+			    }
+			    if (json_idx != input.offset + input.length - 1) {
+				    *ptr++ = ',';
+				    *ptr++ = ' ';
+			    }
+		    }
+		    *ptr = ']';
+
+		    res.Finalize();
+		    return res;
+	    },
+	    FunctionErrors::CANNOT_ERROR);
+	return true;
+}
+
+static bool CastVarcharToJSONList(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+	auto &lstate = parameters.local_state->Cast<JSONFunctionLocalState>();
+	lstate.json_allocator->Reset();
+	auto alc = lstate.json_allocator->GetYYAlc();
+
+	bool success = true;
+	UnaryExecutor::ExecuteWithNulls<string_t, list_entry_t>(
+	    source, result, count, [&](const string_t &input, ValidityMask &mask, idx_t idx) -> list_entry_t {
+		    // Figure out if the cast can succeed
+		    yyjson_read_err error;
+		    const auto doc = JSONCommon::ReadDocumentUnsafe(input.GetDataWriteable(), input.GetSize(),
+		                                                    JSONCommon::READ_FLAG, alc, &error);
+		    if (!doc || !unsafe_yyjson_is_arr(doc->root)) {
+			    mask.SetInvalid(idx);
+			    if (success) {
+				    if (!doc) {
+					    HandleCastError::AssignError(
+					        JSONCommon::FormatParseError(input.GetDataWriteable(), input.GetSize(), error), parameters);
+				    } else if (!unsafe_yyjson_is_arr(doc->root)) {
+					    auto truncated_input =
+					        input.GetSize() > 50 ? string(input.GetData(), 47) + "..." : input.GetString();
+					    HandleCastError::AssignError(
+					        StringUtil::Format("Cannot cast to list of JSON. Input \"%s\"", truncated_input),
+					        parameters);
+				    }
+				    success = false;
+			    }
+			    return {};
+		    }
+
+		    auto current_size = ListVector::GetListSize(result);
+		    const auto arr_len = unsafe_yyjson_get_len(doc->root);
+		    const auto new_size = current_size + arr_len;
+
+		    // Grow list if needed
+		    if (ListVector::GetListCapacity(result) < new_size) {
+			    ListVector::Reserve(result, new_size);
+		    }
+
+		    // Populate list
+		    const auto result_jsons = FlatVector::GetData<string_t>(ListVector::GetEntry(result));
+		    size_t arr_idx, max;
+		    yyjson_val *val;
+		    yyjson_arr_foreach(doc->root, arr_idx, max, val) {
+			    result_jsons[current_size + arr_idx] = JSONCommon::WriteVal(val, alc);
+		    }
+
+		    // Update size
+		    ListVector::SetListSize(result, current_size + arr_len);
+
+		    return {current_size, arr_len};
+	    });
+
+	JSONAllocator::AddBuffer(ListVector::GetEntry(result), alc);
+	return success;
+}
+
+void JSONFunctions::RegisterSimpleCastFunctions(ExtensionLoader &loader) {
+	auto &db = loader.GetDatabaseInstance();
+
 	// JSON to VARCHAR is basically free
-	casts.RegisterCastFunction(LogicalType::JSON(), LogicalType::VARCHAR, DefaultCasts::ReinterpretCast, 1);
+	loader.RegisterCastFunction(LogicalType::JSON(), LogicalType::VARCHAR, DefaultCasts::ReinterpretCast, 1);
 
 	// VARCHAR to JSON requires a parse so it's not free. Let's make it 1 more than a cast to STRUCT
-	auto varchar_to_json_cost = casts.ImplicitCastCost(nullptr, LogicalType::SQLNULL, LogicalTypeId::STRUCT) + 1;
+	const auto varchar_to_json_cost =
+	    CastFunctionSet::ImplicitCastCost(db, LogicalType::SQLNULL, LogicalTypeId::STRUCT) + 1;
 	BoundCastInfo varchar_to_json_info(CastVarcharToJSON, nullptr, JSONFunctionLocalState::InitCastLocalState);
-	casts.RegisterCastFunction(LogicalType::VARCHAR, LogicalType::JSON(), std::move(varchar_to_json_info),
-	                           varchar_to_json_cost);
+	loader.RegisterCastFunction(LogicalType::VARCHAR, LogicalType::JSON(), std::move(varchar_to_json_info),
+	                            varchar_to_json_cost);
 
 	// Register NULL to JSON with a different cost than NULL to VARCHAR so the binder can disambiguate functions
-	auto null_to_json_cost = casts.ImplicitCastCost(nullptr, LogicalType::SQLNULL, LogicalTypeId::VARCHAR) + 1;
-	casts.RegisterCastFunction(LogicalType::SQLNULL, LogicalType::JSON(), DefaultCasts::TryVectorNullCast,
-	                           null_to_json_cost);
+	const auto null_to_json_cost =
+	    CastFunctionSet::ImplicitCastCost(db, LogicalType::SQLNULL, LogicalTypeId::VARCHAR) + 1;
+	loader.RegisterCastFunction(LogicalType::SQLNULL, LogicalType::JSON(), DefaultCasts::TryVectorNullCast,
+	                            null_to_json_cost);
+
+	// JSON[] to VARCHAR (this needs a special case otherwise the cast will escape quotes)
+	const auto json_list_to_varchar_cost =
+	    CastFunctionSet::ImplicitCastCost(db, LogicalType::LIST(LogicalType::JSON()), LogicalTypeId::VARCHAR) - 1;
+	loader.RegisterCastFunction(LogicalType::LIST(LogicalType::JSON()), LogicalTypeId::VARCHAR, CastJSONListToVarchar,
+	                            json_list_to_varchar_cost);
+
+	// VARCHAR to JSON[] (also needs a special case otherwise get a VARCHAR -> VARCHAR[] cast first)
+	const auto varchar_to_json_list_cost =
+	    CastFunctionSet::ImplicitCastCost(db, LogicalType::VARCHAR, LogicalType::LIST(LogicalType::JSON())) - 1;
+	BoundCastInfo varchar_to_json_list_info(CastVarcharToJSONList, nullptr, JSONFunctionLocalState::InitCastLocalState);
+	loader.RegisterCastFunction(LogicalType::VARCHAR, LogicalType::LIST(LogicalType::JSON()),
+	                            std::move(varchar_to_json_list_info), varchar_to_json_list_cost);
 }
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -793,7 +793,7 @@ BoundCastInfo AnyToJSONCastBind(BindCastInput &input, const LogicalType &source,
 	return BoundCastInfo(AnyToJSONCast, std::move(cast_data), JSONFunctionLocalState::InitCastLocalState);
 }
 
-void JSONFunctions::RegisterJSONCreateCastFunctions(CastFunctionSet &casts) {
+void JSONFunctions::RegisterJSONCreateCastFunctions(ExtensionLoader &loader) {
 	// Anything can be cast to JSON
 	for (const auto &type : LogicalType::AllTypes()) {
 		LogicalType source_type;
@@ -820,9 +820,9 @@ void JSONFunctions::RegisterJSONCreateCastFunctions(CastFunctionSet &casts) {
 			source_type = type;
 		}
 		// We prefer going to JSON over going to VARCHAR if a function can do either
-		const auto source_to_json_cost =
-		    MaxValue<int64_t>(casts.ImplicitCastCost(nullptr, source_type, LogicalType::VARCHAR) - 1, 0);
-		casts.RegisterCastFunction(source_type, LogicalType::JSON(), AnyToJSONCastBind, source_to_json_cost);
+		const auto source_to_json_cost = MaxValue<int64_t>(
+		    CastFunctionSet::ImplicitCastCost(loader.GetDatabaseInstance(), source_type, LogicalType::VARCHAR) - 1, 0);
+		loader.RegisterCastFunction(source_type, LogicalType::JSON(), AnyToJSONCastBind, source_to_json_cost);
 	}
 }
 

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -1028,7 +1028,7 @@ BoundCastInfo JSONToAnyCastBind(BindCastInput &input, const LogicalType &source,
 	return BoundCastInfo(JSONToAnyCast, nullptr, JSONFunctionLocalState::InitCastLocalState);
 }
 
-void JSONFunctions::RegisterJSONTransformCastFunctions(CastFunctionSet &casts) {
+void JSONFunctions::RegisterJSONTransformCastFunctions(ExtensionLoader &loader) {
 	// JSON can be cast to anything
 	for (const auto &type : LogicalType::AllTypes()) {
 		LogicalType target_type;
@@ -1055,8 +1055,9 @@ void JSONFunctions::RegisterJSONTransformCastFunctions(CastFunctionSet &casts) {
 			target_type = type;
 		}
 		// Going from JSON to another type has the same cost as going from VARCHAR to that type
-		const auto json_to_target_cost = casts.ImplicitCastCost(nullptr, LogicalType::VARCHAR, target_type);
-		casts.RegisterCastFunction(LogicalType::JSON(), target_type, JSONToAnyCastBind, json_to_target_cost);
+		const auto json_to_target_cost =
+		    CastFunctionSet::ImplicitCastCost(loader.GetDatabaseInstance(), LogicalType::VARCHAR, target_type);
+		loader.RegisterCastFunction(LogicalType::JSON(), target_type, JSONToAnyCastBind, json_to_target_cost);
 	}
 }
 

--- a/src/function/cast/cast_function_set.cpp
+++ b/src/function/cast/cast_function_set.cpp
@@ -193,6 +193,10 @@ int64_t CastFunctionSet::ImplicitCastCost(ClientContext &context, const LogicalT
 	return CastFunctionSet::Get(context).ImplicitCastCost(&context, source, target);
 }
 
+int64_t CastFunctionSet::ImplicitCastCost(DatabaseInstance &db, const LogicalType &source, const LogicalType &target) {
+	return CastFunctionSet::Get(db).ImplicitCastCost(nullptr, source, target);
+}
+
 static BoundCastInfo MapCastFunction(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
 	D_ASSERT(input.info);
 	auto &map_info = input.info->Cast<MapCastInfo>();

--- a/src/include/duckdb/function/cast/cast_function_set.hpp
+++ b/src/include/duckdb/function/cast/cast_function_set.hpp
@@ -56,6 +56,8 @@ public:
 	                                    const LogicalType &target);
 	DUCKDB_API static int64_t ImplicitCastCost(ClientContext &context, const LogicalType &source,
 	                                           const LogicalType &target);
+	DUCKDB_API static int64_t ImplicitCastCost(DatabaseInstance &db, const LogicalType &source,
+	                                           const LogicalType &target);
 	//! Register a new cast function from source to target
 	DUCKDB_API void RegisterCastFunction(const LogicalType &source, const LogicalType &target, BoundCastInfo function,
 	                                     int64_t implicit_cast_cost = -1);

--- a/test/sql/json/scalar/json_nested_casts.test
+++ b/test/sql/json/scalar/json_nested_casts.test
@@ -35,7 +35,7 @@ Conversion Error
 query I
 select cast(['[1, 2]', '[3, 4]'] as json[]);
 ----
-['[1, 2]', '[3, 4]']
+[[1, 2], [3, 4]]
 
 # struct with varchar to json
 query I
@@ -419,3 +419,35 @@ statement error
 select ('duck' || chr(0))::JSON
 ----
 Conversion Error
+
+# some varchar -> json[] and json[] -> varchar tests
+# this is needed because our varchar -> varchar[] (and vice versa) escape quotes or add them
+# this tests the special-case implementation for these casts
+
+# issue 17647
+query I
+select '[{"some_key":"some_v}alue"}]'::json[];
+----
+[{"some_key":"some_v}alue"}]
+
+# internal issue 5498
+query I
+with cte1 as (select 'a' as a),
+cte2 as (select array_agg(cte1::json) as value from cte1)
+select value::json[] from cte2;
+----
+[{"a":"a"}]
+
+# larger test
+query II
+with cte1 as (
+    select array_agg({duck:42}::json) json_list_value
+    from range(5_000)
+), cte2 as (
+    select '[' || string_agg('{"duck":42}', ', ') || ']' string_value
+    from range(5_000)
+)
+select json_list_value::varchar = string_value, json_list_value = string_value::json[]
+from cte1, cte2
+----
+true	true

--- a/test/sql/json/scalar/test_json_extract.test
+++ b/test/sql/json/scalar/test_json_extract.test
@@ -138,7 +138,7 @@ Binder Error
 query T
 SELECT json_extract('{"a":2,"c":[4,5],"f":7}', ['$.c','$.a']);
 ----
-['[4,5]', 2]
+[[4,5], 2]
 
 query T
 SELECT json_extract('{"a":2,"c":[4,5,{"f":7}]}', ['$.x', '$.a']);

--- a/test/sql/json/scalar/test_json_path.test
+++ b/test/sql/json/scalar/test_json_path.test
@@ -215,19 +215,19 @@ select sum((to_json({duck:range})->'$.*')[1]::int) = sum(range) from range(10000
 query T
 select json_extract('[{"duck":null},{"duck":42},{"duck":null},{}]', '$[*].*')
 ----
-['null', 42, 'null']
+[null, 42, null]
 
 # test recursive wildcard path
 query T
 select json_extract('{"a":{"b":1,"c":2},"d":["g","h",[{"b":5},{"x":42}]]}', '$..*')
 ----
-['{"b":1,"c":2}', '["g","h",[{"b":5},{"x":42}]]', 1, 2, '"g"', '"h"', '[{"b":5},{"x":42}]', '{"b":5}', '{"x":42}', 5, 42]
+[{"b":1,"c":2}, ["g","h",[{"b":5},{"x":42}]], 1, 2, "g", "h", [{"b":5},{"x":42}], {"b":5}, {"x":42}, 5, 42]
 
 # alternative syntax
 query T
 select json_extract('{"a":{"b":1,"c":2},"d":["g","h",[{"b":5},{"x":42}]]}', '$.**')
 ----
-['{"b":1,"c":2}', '["g","h",[{"b":5},{"x":42}]]', 1, 2, '"g"', '"h"', '[{"b":5},{"x":42}]', '{"b":5}', '{"x":42}', 5, 42]
+[{"b":1,"c":2}, ["g","h",[{"b":5},{"x":42}]], 1, 2, "g", "h", [{"b":5},{"x":42}], {"b":5}, {"x":42}, 5, 42]
 
 # recursive non-wildcard path
 query T
@@ -238,7 +238,7 @@ select json_extract('{"a":{"b":1,"c":2},"d":["g","h",[{"b":5},{"x":42}]]}', '$..
 query T
 select json_extract('{"a":{"b":1,"c":2},"d":["g","h",[{"b":5},{"x":42}]]}', '$..[0]')
 ----
-['"g"', '{"b":5}']
+["g", {"b":5}]
 
 query I
 with tbl as (
@@ -246,7 +246,7 @@ with tbl as (
 )
 select json_extract(j, '$[*]..*') from tbl
 ----
-[42, '{"a":43,"b":null}', 43, 'null']
+[42, {"a":43,"b":null}, 43, null]
 
 query T
 with tbl as (
@@ -259,7 +259,7 @@ select json_extract(j, '$.duck[*]..goose') from tbl
 query T
 select json_extract(j,'$..[*]') from test
 ----
-['"goose"', '"duck"']
+["goose", "duck"]
 
 query T
 select json_extract('[[{"a":[1,2,3]}], [{"a":[4,5,6]}]]','$[*]..a[*]')

--- a/test/sql/json/table/read_json.test
+++ b/test/sql/json/table/read_json.test
@@ -148,11 +148,11 @@ SELECT * FROM read_json_auto('data/json/with_list.json', maximum_depth=1)
 query II
 SELECT * FROM read_json_auto('data/json/with_list.json', maximum_depth=2)
 ----
-1	['"O"', '"Brother,"', '"Where"', '"Art"', '"Thou?"']
-2	['"Home"', '"for"', '"the"', '"Holidays"']
-3	['"The"', '"Firm"']
-4	['"Broadcast"', '"News"']
-5	['"Raising"', '"Arizona"']
+1	["O", "Brother,", "Where", "Art", "Thou?"]
+2	["Home", "for", "the", "Holidays"]
+3	["The", "Firm"]
+4	["Broadcast", "News"]
+5	["Raising", "Arizona"]
 
 # at level 3 it's fully detected, and we get BIGINT and VARCHAR[]
 query II


### PR DESCRIPTION
and use the `ExtensionLoader` to register functions instead of the old API.

PR https://github.com/duckdb/duckdb/pull/16304 fixed some `LIST` casting issues regarding round-tripping (e.g., adding quotes or escaping them), which introduced casting issues for JSON. These issues were found by the JSON tests, but the tests were simply changed to match the new behavior instead of fixing the issues.

The issue seemed like a rendering issue only, but when returning `JSON` to our clients, e.g., Python, we cast to `VARCHAR`, which now adds quotes or escapes them, creating invalid JSON. This PR fixes these issues by creating special-case casts from `VARCHAR` to `JSON` and vice versa.

I don't think this is needed for structs, as the default cast (which is to reinterpret) is used for structs, and we shouldn't get invalid JSON (e.g., surrounded by single quotes) when getting a struct that contains JSON into a client like Python.

Fixes:
 * #17647
 * https://github.com/duckdblabs/duckdb-internal/issues/5498