### PR TITLE
Unittester: Add the `--sort-style` parameter that allows a fallback comparison where results are sorted according to a given sort-style

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -44,6 +44,8 @@ static const TestConfigOption test_config_options[] = {
      nullptr},
     {"skip_compiled", "Skip compiled tests", LogicalType::BOOLEAN, nullptr},
     {"skip_error_messages", "Skip compiled tests", LogicalType::LIST(LogicalType::VARCHAR), nullptr},
+    {"sort_style", "Default sort style if none is configured in the test (none, rowsort, valuesort)",
+     LogicalType::VARCHAR, TestConfiguration::CheckSortStyle},
     {"statically_loaded_extensions", "Extensions to be loaded (from the statically available one)",
      LogicalType::LIST(LogicalType::VARCHAR), nullptr},
     {"storage_version", "Database storage version to use by default", LogicalType::VARCHAR, nullptr},
@@ -210,6 +212,10 @@ string TestConfiguration::OnCleanupCommand() {
 	return GetOptionOrDefault("on_cleanup", string());
 }
 
+string TestConfiguration::GetDefaultSortStyle() {
+	return GetOptionOrDefault<string>("sort_style", "none");
+}
+
 vector<string> TestConfiguration::ExtensionToBeLoadedOnLoad() {
 	vector<string> res;
 	auto entry = options.find("statically_loaded_extensions");
@@ -246,6 +252,30 @@ void TestConfiguration::ParseConnectScript(const Value &input) {
 
 	auto &test_config = TestConfiguration::Get();
 	test_config.ParseOption("on_init", Value(init_cmd));
+}
+
+void TestConfiguration::CheckSortStyle(const Value &input) {
+	SortStyle sort_style;
+	if (!TryParseSortStyle(input.ToString(), sort_style)) {
+		throw std::runtime_error(StringUtil::Format("Invalid parameter for sort style %s", input.ToString()));
+	}
+}
+
+bool TestConfiguration::TryParseSortStyle(const string &sort_style, SortStyle &result) {
+	if (sort_style == "nosort" || sort_style == "none") {
+		/* Do no sorting */
+		result = SortStyle::NO_SORT;
+	} else if (sort_style == "rowsort" || sort_style == "sort") {
+		/* Row-oriented sorting */
+		result = SortStyle::ROW_SORT;
+	} else if (sort_style == "valuesort") {
+		/* Sort all values independently */
+		result = SortStyle::VALUE_SORT;
+	} else {
+		// if this is not a known sort style
+		return false;
+	}
+	return true;
 }
 
 string TestConfiguration::ReadFileToString(const string &path) {

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -212,8 +212,12 @@ string TestConfiguration::OnCleanupCommand() {
 	return GetOptionOrDefault("on_cleanup", string());
 }
 
-string TestConfiguration::GetDefaultSortStyle() {
-	return GetOptionOrDefault<string>("sort_style", "none");
+SortStyle TestConfiguration::GetDefaultSortStyle() {
+	SortStyle default_sort_style_enum = SortStyle::NO_SORT;
+	if (!TryParseSortStyle(GetOptionOrDefault<string>("sort_style", "none"), default_sort_style_enum)) {
+		throw std::runtime_error("eek: unknown sort style in TestConfig");
+	}
+	return default_sort_style_enum;
 }
 
 vector<string> TestConfiguration::ExtensionToBeLoadedOnLoad() {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -53,7 +53,7 @@ public:
 	string OnLoadCommand();
 	string OnConnectionCommand();
 	string OnCleanupCommand();
-	string GetDefaultSortStyle();
+	SortStyle GetDefaultSortStyle();
 	vector<string> ExtensionToBeLoadedOnLoad();
 	vector<string> ErrorMessagesToBeSkipped();
 	string GetStorageVersion();

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -19,6 +19,8 @@
 
 namespace duckdb {
 
+enum class SortStyle : uint8_t { NO_SORT, ROW_SORT, VALUE_SORT };
+
 class TestConfiguration {
 public:
 	enum class ExtensionAutoLoadingMode { NONE = 0, AVAILABLE = 1, ALL = 2 };
@@ -51,6 +53,7 @@ public:
 	string OnLoadCommand();
 	string OnConnectionCommand();
 	string OnCleanupCommand();
+	string GetDefaultSortStyle();
 	vector<string> ExtensionToBeLoadedOnLoad();
 	vector<string> ErrorMessagesToBeSkipped();
 	string GetStorageVersion();
@@ -60,6 +63,8 @@ public:
 	static bool TestMemoryLeaks();
 
 	static void ParseConnectScript(const Value &input);
+	static void CheckSortStyle(const Value &input);
+	static bool TryParseSortStyle(const string &sort_style, SortStyle &result);
 
 private:
 	case_insensitive_map_t<Value> options;

--- a/test/sqlite/result_helper.hpp
+++ b/test/sqlite/result_helper.hpp
@@ -32,6 +32,7 @@ public:
 
 	static bool ResultIsHash(const string &result);
 	static bool ResultIsFile(string result);
+	void SortQueryResult(SortStyle sort_style, vector<string> &result, idx_t ncols);
 
 	bool MatchesRegex(SQLLogicTestLogger &logger, string lvalue_str, string rvalue_str);
 	bool CompareValues(SQLLogicTestLogger &logger, MaterializedQueryResult &result, string lvalue_str,

--- a/test/sqlite/result_helper.hpp
+++ b/test/sqlite/result_helper.hpp
@@ -37,7 +37,8 @@ public:
 	bool MatchesRegex(SQLLogicTestLogger &logger, string lvalue_str, string rvalue_str);
 	bool CompareValues(SQLLogicTestLogger &logger, MaterializedQueryResult &result, string lvalue_str,
 	                   string rvalue_str, idx_t current_row, idx_t current_column, vector<string> &values,
-	                   idx_t expected_column_count, bool row_wise, vector<string> &result_values);
+	                   idx_t expected_column_count, bool row_wise, vector<string> &result_values,
+	                   bool print_error = true);
 	bool SkipErrorMessage(const string &message);
 
 	vector<string> LoadResultFromFile(string fname, vector<string> names, idx_t &expected_column_count, string &error);

--- a/test/sqlite/sqllogic_command.hpp
+++ b/test/sqlite/sqllogic_command.hpp
@@ -10,11 +10,11 @@
 
 #include "duckdb.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
+#include "test_config.hpp"
 
 namespace duckdb {
 class SQLLogicTestRunner;
 
-enum class SortStyle : uint8_t { NO_SORT, ROW_SORT, VALUE_SORT };
 enum class ExpectedResult : uint8_t { RESULT_SUCCESS, RESULT_ERROR, RESULT_UNKNOWN };
 
 struct LoopDefinition {

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -131,15 +131,13 @@ void SQLLogicTestLogger::PrintErrorHeader(const string &file_name, idx_t query_l
 	if (!file_name.empty()) {
 		oss << termcolor::bold << "(" << file_name << ":" << query_line << ")!" << termcolor::reset;
 	}
-	LogFailure(oss.str() + "\n");
-	LogFailureAnnotation(oss.str());
-}
-
-void SQLLogicTestLogger::LogFailureAnnotation(const string header) {
+	string failure_header = oss.str() + "\n";
 	const char *ci = std::getenv("CI");
 	// check the value is "true" otherwise you'll see the prefix in local run outputs
-	auto prefix = (ci && string(ci) == "true") ? "\n::error::" : "";
-	std::cout << prefix << header << std::endl;
+	if (ci && string(ci) == "true") {
+		failure_header = "\n::error::" + failure_header;
+	}
+	LogFailure(failure_header);
 }
 
 void SQLLogicTestLogger::PrintErrorHeader(const string &description) {

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -57,7 +57,6 @@ public:
 
 	static void AppendFailure(const string &log_message);
 	static void LogFailure(const string &log_message);
-	static void LogFailureAnnotation(const string header);
 
 private:
 	lock_guard<mutex> log_lock;

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -858,7 +858,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 				if (!TestConfiguration::TryParseSortStyle(token.parameters[1], command->sort_style)) {
 					// if this is not a known sort style, we use this as the connection name
 					// this is a bit dirty, but well
-					command->connection_name = sort_style;
+					command->connection_name = token.parameters[1];
 				} else {
 					sort_style = token.parameters[1];
 				}

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -853,7 +853,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			command->values = parser.ExtractExpectedResult();
 
 			// figure out the sort style/connection style
-			string sort_style = test_config.GetDefaultSortStyle();
+			string sort_style = "none";
 			if (token.parameters.size() > 1) {
 				if (!TestConfiguration::TryParseSortStyle(token.parameters[1], command->sort_style)) {
 					// if this is not a known sort style, we use this as the connection name

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -853,23 +853,18 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			command->values = parser.ExtractExpectedResult();
 
 			// figure out the sort style/connection style
-			command->sort_style = SortStyle::NO_SORT;
+			string sort_style = test_config.GetDefaultSortStyle();
 			if (token.parameters.size() > 1) {
-				auto &sort_style = token.parameters[1];
-				if (sort_style == "nosort") {
-					/* Do no sorting */
-					command->sort_style = SortStyle::NO_SORT;
-				} else if (sort_style == "rowsort" || sort_style == "sort") {
-					/* Row-oriented sorting */
-					command->sort_style = SortStyle::ROW_SORT;
-				} else if (sort_style == "valuesort") {
-					/* Sort all values independently */
-					command->sort_style = SortStyle::VALUE_SORT;
-				} else {
+				if (!TestConfiguration::TryParseSortStyle(token.parameters[1], command->sort_style)) {
 					// if this is not a known sort style, we use this as the connection name
 					// this is a bit dirty, but well
 					command->connection_name = sort_style;
+				} else {
+					sort_style = token.parameters[1];
 				}
+			}
+			if (!TestConfiguration::TryParseSortStyle(sort_style, command->sort_style)) {
+				throw std::runtime_error("eek invalid sort style set, this should not happen");
 			}
 
 			// check the label of the query


### PR DESCRIPTION
This PR adds the `sort_style` parameter that allows a fallback comparison for query results in the tester, e.g. `--sort-style rowsort`. In normal operation the unittester is order-sensitive. However, several of the DuckDB tests are written with certain assumptions about order (e.g. that DuckDB is by default insertion-order preserving). This is correct for DuckDB files, but is not true for all catalog back-ends, e.g. DuckLake or Postgres are not insertion-order preserving. In order to allow for more tests to be re-run with other catalogs, we add the option to add a fallback sort style for results which considers results equivalent using order insensitive comparisons.

