### PR TITLE
fix: use thousands separator and decimal for row counts in`duckbox` output format

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -1006,7 +1006,7 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 		top_rows = rows_to_render / 2 + (rows_to_render % 2 != 0 ? 1 : 0);
 		bottom_rows = rows_to_render - top_rows;
 	}
-	auto row_count_str = to_string(row_count) + " rows";
+	auto row_count_str = FormatNumber(to_string(row_count)) + " rows";
 	bool has_limited_rows = config.limit > 0 && row_count == config.limit;
 	if (has_limited_rows) {
 		row_count_str = "? rows";
@@ -1016,9 +1016,9 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 	if (has_hidden_rows) {
 		shown_str = "(";
 		if (has_limited_rows) {
-			shown_str += ">" + to_string(config.limit - 1) + " rows, ";
+			shown_str += ">" + FormatNumber(to_string(config.limit - 1)) + " rows, ";
 		}
-		shown_str += to_string(top_rows + bottom_rows) + " shown)";
+		shown_str += FormatNumber(to_string(top_rows + bottom_rows)) + " shown)";
 	}
 	auto minimum_row_length = MaxValue<idx_t>(row_count_str.size(), shown_str.size()) + 4;
 

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4736,6 +4736,8 @@ static void verify_uninitialized(void) {
 static void main_init(ShellState *data) {
 	data->normalMode = data->cMode = data->mode = RenderMode::DUCKBOX;
 	data->max_rows = 40;
+	data->thousand_separator = ',';
+	data->decimal_separator = '.';
 	data->colSeparator = SEP_Column;
 	data->rowSeparator = SEP_Row;
 	data->showHeader = true;

--- a/tools/shell/tests/test_meta_transaction.py
+++ b/tools/shell/tests/test_meta_transaction.py
@@ -5,6 +5,7 @@ from conftest import ShellTest
 def test_temp_directory(shell):
     test = (
         ShellTest(shell)
+        .statement(".mode csv")
         .statement("CREATE SEQUENCE id_seq;")
         .statement("""
             CREATE TABLE my_table (

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -16,7 +16,11 @@ def test_basic(shell):
 
 
 def test_range(shell):
-    test = ShellTest(shell).statement("select * from range(10000)")
+    test = (
+        ShellTest(shell)
+        .statement(".mode csv")
+        .statement("select * from range(10000)")
+    )
     result = test.run()
     result.check_stdout("9999")
 


### PR DESCRIPTION
Hi DuckDB Team,

When I use the DuckDB shell, I want my row counts to come with commas — because nobody wants to squint and guess if that number is a million, a billion, or just a really big typo. So, this PR sprinkles some thousand separators into the `duckbox` output format, making those giant numbers finally behave like humans do.

Also, as an internationally minded American (yes, that’s a thing), I’m boldly letting the thousand separator and decimal point take their cues from the locale where the DuckDB CLI is launched — because well not everybody believes a decimal should be `.` rather than `,`.  We'll work on that.

Hope this helps some blurry eyed users like myself.

Rusty