### PR TITLE
fix: add formatting to explain row counts

### DIFF
--- a/src/common/tree_renderer/text_tree_renderer.cpp
+++ b/src/common/tree_renderer/text_tree_renderer.cpp
@@ -160,6 +160,41 @@ string AdjustTextForRendering(string source, idx_t max_render_width) {
 	return string(half_spaces + extra_left_space, ' ') + source + string(half_spaces, ' ');
 }
 
+string TextTreeRenderer::FormatNumber(const string &input) {
+	if (config.decimal_separator == '\0' && config.thousand_separator == '\0') {
+		// no thousand separator
+		return input;
+	}
+	// first check how many digits there are (preceding any decimal point)
+	idx_t character_count = 0;
+	for (auto c : input) {
+		if (!StringUtil::CharacterIsDigit(c)) {
+			break;
+		}
+		character_count++;
+	}
+	// find the position of the first thousand separator
+	idx_t separator_position = character_count % 3 == 0 ? 3 : character_count % 3;
+	// now add the thousand separators
+	string result;
+	for (idx_t c = 0; c < character_count; c++) {
+		if (c == separator_position && config.thousand_separator != '\0') {
+			result += config.thousand_separator;
+			separator_position += 3;
+		}
+		result += input[c];
+	}
+	// add any remaining characters
+	for (idx_t c = character_count; c < input.size(); c++) {
+		if (input[c] == '.' && config.decimal_separator != '\0') {
+			result += config.decimal_separator;
+		} else {
+			result += input[c];
+		}
+	}
+	return result;
+}
+
 void TextTreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_t y) {
 	// we first need to figure out how high our boxes are going to be
 	vector<vector<string>> extra_info;
@@ -246,7 +281,7 @@ void TextTreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_
 				if (render_y + 1 == extra_height && render_text.empty()) {
 					auto entry = node->extra_text.find(RenderTreeNode::CARDINALITY);
 					if (entry != node->extra_text.end()) {
-						render_text = entry->second + " Rows";
+						render_text = FormatNumber(entry->second) + " rows";
 					}
 				}
 				if (render_y == extra_height && render_text.empty()) {
@@ -257,14 +292,14 @@ void TextTreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_
 						// we only render estimated cardinality if there is no real cardinality
 						auto entry = node->extra_text.find(RenderTreeNode::ESTIMATED_CARDINALITY);
 						if (entry != node->extra_text.end()) {
-							render_text = "~" + entry->second + " Rows";
+							render_text = "~" + FormatNumber(entry->second) + " rows";
 						}
 					}
 					if (node->extra_text.find(RenderTreeNode::CARDINALITY) == node->extra_text.end()) {
 						// we only render estimated cardinality if there is no real cardinality
 						auto entry = node->extra_text.find(RenderTreeNode::ESTIMATED_CARDINALITY);
 						if (entry != node->extra_text.end()) {
-							render_text = "~" + entry->second + " Rows";
+							render_text = "~" + FormatNumber(entry->second) + " rows";
 						}
 					}
 				}

--- a/src/common/tree_renderer/text_tree_renderer.cpp
+++ b/src/common/tree_renderer/text_tree_renderer.cpp
@@ -281,7 +281,7 @@ void TextTreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_
 				if (render_y + 1 == extra_height && render_text.empty()) {
 					auto entry = node->extra_text.find(RenderTreeNode::CARDINALITY);
 					if (entry != node->extra_text.end()) {
-						render_text = FormatNumber(entry->second) + " rows";
+						render_text = FormatNumber(entry->second) + " row" + (entry->second == "1" ? "" : "s");
 					}
 				}
 				if (render_y == extra_height && render_text.empty()) {
@@ -292,14 +292,16 @@ void TextTreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_
 						// we only render estimated cardinality if there is no real cardinality
 						auto entry = node->extra_text.find(RenderTreeNode::ESTIMATED_CARDINALITY);
 						if (entry != node->extra_text.end()) {
-							render_text = "~" + FormatNumber(entry->second) + " rows";
+							render_text =
+							    "~" + FormatNumber(entry->second) + " row" + (entry->second == "1" ? "" : "s");
 						}
 					}
 					if (node->extra_text.find(RenderTreeNode::CARDINALITY) == node->extra_text.end()) {
 						// we only render estimated cardinality if there is no real cardinality
 						auto entry = node->extra_text.find(RenderTreeNode::ESTIMATED_CARDINALITY);
 						if (entry != node->extra_text.end()) {
-							render_text = "~" + FormatNumber(entry->second) + " rows";
+							render_text =
+							    "~" + FormatNumber(entry->second) + " row" + (entry->second == "1" ? "" : "s");
 						}
 					}
 				}

--- a/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
@@ -37,6 +37,10 @@ struct TextTreeRendererConfig {
 	idx_t max_extra_lines = 30;
 	bool detailed = false;
 
+	// Formatting options
+	char thousand_separator = ',';
+	char decimal_separator = '.';
+
 #ifndef DUCKDB_ASCII_TREE_RENDERER
 	const char *LTCORNER = "\342\224\214"; // NOLINT "┌";
 	const char *RTCORNER = "\342\224\220"; // NOLINT "┐";
@@ -115,6 +119,7 @@ private:
 	void SplitUpExtraInfo(const InsertionOrderPreservingMap<string> &extra_info, vector<string> &result,
 	                      idx_t max_lines);
 	void SplitStringBuffer(const string &source, vector<string> &result);
+	string FormatNumber(const string &input);
 };
 
 } // namespace duckdb

--- a/test/sql/function/list/generate_series.test
+++ b/test/sql/function/list/generate_series.test
@@ -223,45 +223,45 @@ SELECT * FROM (SELECT 1 UNION ALL SELECT 0 UNION ALL SELECT 2) AS _(x), generate
 query II
 EXPLAIN FROM range(0);
 ----
-physical_plan	<REGEX>:.*~0 Rows.*
+physical_plan	<REGEX>:.*~0 rows.*
 
 query II
 EXPLAIN FROM range(-1);
 ----
-physical_plan	<REGEX>:.*~0 Rows.*
+physical_plan	<REGEX>:.*~0 rows.*
 
 query II
 EXPLAIN FROM range(-5, -20, -1);
 ----
-physical_plan	<REGEX>:.*~15 Rows.*
+physical_plan	<REGEX>:.*~15 rows.*
 
 query II
 EXPLAIN FROM range(1, 4, 2);
 ----
-physical_plan	<REGEX>:.*~2 Rows.*
+physical_plan	<REGEX>:.*~2 rows.*
 
 query II
 EXPLAIN FROM range(1, 5, 2);
 ----
-physical_plan	<REGEX>:.*~2 Rows.*
+physical_plan	<REGEX>:.*~2 rows.*
 
 query II
 EXPLAIN FROM generate_series(0);
 ----
-physical_plan	<REGEX>:.*~1 Rows.*
+physical_plan	<REGEX>:.*~1 row.*
 
 query II
 EXPLAIN FROM generate_series(1);
 ----
-physical_plan	<REGEX>:.*~2 Rows.*
+physical_plan	<REGEX>:.*~2 rows.*
 
 query II
 EXPLAIN FROM generate_series(1, 4, 2);
 ----
-physical_plan	<REGEX>:.*~2 Rows.*
+physical_plan	<REGEX>:.*~2 rows.*
 
 query II
 EXPLAIN FROM generate_series(1, 5, 2);
 ----
-physical_plan	<REGEX>:.*~3 Rows.*
+physical_plan	<REGEX>:.*~3 rows.*
 


### PR DESCRIPTION
Add some numeric formatting to EXPLAIN row counts. 

1. Change "Rows" to "rows" to follow `duckbox`'s capitalization standards.
2. Add FormatNumber() to allow number of rows to include commas.
3. Properly handle the rows/row.
 
Example output:

```
┌────────────────────────────────────────────────┐
│┌──────────────────────────────────────────────┐│
││              Total Time: 0.0138s             ││
│└──────────────────────────────────────────────┘│
└────────────────────────────────────────────────┘
┌───────────────────────────┐
│           QUERY           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│      EXPLAIN_ANALYZE      │
│    ────────────────────   │
│           0 rows          │
│          (0.00s)          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│    UNGROUPED_AGGREGATE    │
│    ────────────────────   │
│        Aggregates:        │
│        count_star()       │
│                           │
│           1 row           │
│          (0.00s)          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         TABLE_SCAN        │
│    ────────────────────   │
│         Function:         │
│      GENERATE_SERIES      │
│                           │
│        10,000 rows        │
│          (0.00s)          │
└───────────────────────────┘
```
