### PR TITLE
feat: add ETA to progress bar in DuckDB CLI

### DIFF
--- a/src/common/progress_bar/CMakeLists.txt
+++ b/src/common/progress_bar/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(duckdb_progress_bar OBJECT progress_bar.cpp
-                  terminal_progress_bar_display.cpp)
+                  terminal_progress_bar_display.cpp unscented_kalman_filter.cpp)
 
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_progress_bar>

--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -133,12 +133,12 @@ void ProgressBar::Update(bool final) {
 		if (final) {
 			FinishProgressBarPrint();
 		} else {
-			PrintProgress(LossyNumericCast<int>(query_progress.percentage.load()));
+			PrintProgress(query_progress.percentage.load());
 		}
 	}
 }
 
-void ProgressBar::PrintProgress(int current_percentage_p) {
+void ProgressBar::PrintProgress(double current_percentage_p) {
 	D_ASSERT(display);
 	display->Update(current_percentage_p);
 }

--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -76,13 +76,15 @@ void TerminalProgressBarDisplay::PrintProgressInternal(int32_t percentage, doubl
 }
 
 void TerminalProgressBarDisplay::Update(double percentage) {
-	double current_time = GetElapsedDuration();
+	const double current_time = GetElapsedDuration();
+	// Filters go from 0 to 1, percentage is from 0-100
+	const double filter_percentage = percentage / 100.0;
 	if (!udf_initialized) {
-		ukf.Initialize(percentage / 100.0, current_time);
+		ukf.Initialize(filter_percentage, current_time);
 		udf_initialized = true;
 	} else {
 		ukf.Predict(current_time);
-		ukf.Update(percentage / 100.0);
+		ukf.Update(filter_percentage);
 	}
 
 	double estimated_seconds_remaining = ukf.GetEstimatedRemainingSeconds();

--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -73,14 +73,14 @@ void TerminalProgressBarDisplay::PrintProgressInternal(int32_t percentage, doubl
 void TerminalProgressBarDisplay::Update(double percentage) {
 	double current_time = GetElapsedDuration();
 	if (!udf_initialized) {
-		ukf.initialize(percentage / 100.0, current_time);
+		ukf.Initialize(percentage / 100.0, current_time);
 		udf_initialized = true;
 	} else {
-		ukf.predict(current_time);
-		ukf.update(percentage / 100.0);
+		ukf.Predict(current_time);
+		ukf.Update(percentage / 100.0);
 	}
 
-	double estimated_seconds_remaining = ukf.getEstimatedRemainingSeconds();
+	double estimated_seconds_remaining = ukf.GetEstimatedRemainingSeconds();
 
 	auto percentage_int = NormalizePercentage(percentage);
 	if (percentage_int == rendered_percentage) {

--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -15,6 +15,11 @@ int32_t TerminalProgressBarDisplay::NormalizePercentage(double percentage) {
 }
 
 static std::string format_eta(double seconds) {
+	if (seconds < 0) {
+		// We may not have a valid prediction.
+		return "unknown remaining";
+	}
+
 	// Round to nearest whole second
 	uint64_t total_seconds = static_cast<uint64_t>(std::round(seconds));
 

--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -24,8 +24,8 @@ static std::string format_eta(double seconds, bool elapsed = false) {
 	//   00:00:00.00 elapsed
 	const char *suffix = elapsed ? " elapsed)  " : " remaining)";
 
-	if (seconds < 0) {
-		// Invalid or unknown ETA
+	if (seconds < 0 || seconds > 3600 * 99) {
+		// Invalid or unknown ETA, or if its longer than 99 hours.
 		return StringUtil::Format("(%11s%s", "unknown", suffix);
 	}
 

--- a/src/common/progress_bar/unscented_kalman_filter.cpp
+++ b/src/common/progress_bar/unscented_kalman_filter.cpp
@@ -31,7 +31,7 @@ UnscentedKalmanFilter::UnscentedKalmanFilter()
 	R[0][0] = 1e-4; // measurement noise for progress
 }
 
-void UnscentedKalmanFilter::initialize(double initial_progress, double current_time) {
+void UnscentedKalmanFilter::Initialize(double initial_progress, double current_time) {
 	x[0] = initial_progress;
 	x[1] = 0.01; // initial velocity guess
 	last_time = current_time;
@@ -39,7 +39,7 @@ void UnscentedKalmanFilter::initialize(double initial_progress, double current_t
 }
 
 // Matrix operations
-std::vector<std::vector<double>> UnscentedKalmanFilter::matrixSqrt(const std::vector<std::vector<double>> &mat) {
+std::vector<std::vector<double>> UnscentedKalmanFilter::MatrixSqrt(const std::vector<std::vector<double>> &mat) {
 	size_t n = mat.size();
 	std::vector<std::vector<double>> L(n, std::vector<double>(n, 0.0));
 
@@ -65,7 +65,7 @@ std::vector<std::vector<double>> UnscentedKalmanFilter::matrixSqrt(const std::ve
 }
 
 // Generate sigma points
-std::vector<std::vector<double>> UnscentedKalmanFilter::generateSigmaPoints() {
+std::vector<std::vector<double>> UnscentedKalmanFilter::GenerateSigmaPoints() {
 	std::vector<std::vector<double>> sigma_points(SIGMA_POINTS, std::vector<double>(STATE_DIM));
 
 	// Calculate sqrt((n + lambda) * P)
@@ -77,7 +77,7 @@ std::vector<std::vector<double>> UnscentedKalmanFilter::generateSigmaPoints() {
 		}
 	}
 
-	auto sqrt_P = matrixSqrt(scaled_P);
+	auto sqrt_P = MatrixSqrt(scaled_P);
 
 	// First sigma point is the mean
 	sigma_points[0] = x;
@@ -94,7 +94,7 @@ std::vector<std::vector<double>> UnscentedKalmanFilter::generateSigmaPoints() {
 }
 
 // State transition function
-std::vector<double> UnscentedKalmanFilter::stateTransition(const std::vector<double> &state, double dt) {
+std::vector<double> UnscentedKalmanFilter::StateTransition(const std::vector<double> &state, double dt) {
 	std::vector<double> new_state(STATE_DIM);
 	new_state[0] = state[0] + state[1] * dt; // progress += velocity * dt
 	new_state[1] = state[1];                 // velocity remains constant
@@ -106,11 +106,11 @@ std::vector<double> UnscentedKalmanFilter::stateTransition(const std::vector<dou
 }
 
 // Measurement function (identity for progress)
-std::vector<double> UnscentedKalmanFilter::measurementFunction(const std::vector<double> &state) {
+std::vector<double> UnscentedKalmanFilter::MeasurementFunction(const std::vector<double> &state) {
 	return {state[0]};
 }
 
-void UnscentedKalmanFilter::predict(double current_time) {
+void UnscentedKalmanFilter::Predict(double current_time) {
 	if (!initialized) {
 		return;
 	}
@@ -123,12 +123,12 @@ void UnscentedKalmanFilter::predict(double current_time) {
 	}
 
 	// Generate sigma points
-	auto sigma_points = generateSigmaPoints();
+	auto sigma_points = GenerateSigmaPoints();
 
 	// Propagate sigma points through state transition
 	std::vector<std::vector<double>> sigma_points_pred(SIGMA_POINTS, std::vector<double>(STATE_DIM));
 	for (size_t i = 0; i < SIGMA_POINTS; i++) {
-		sigma_points_pred[i] = stateTransition(sigma_points[i], dt);
+		sigma_points_pred[i] = StateTransition(sigma_points[i], dt);
 	}
 
 	// Predict state mean
@@ -160,18 +160,18 @@ void UnscentedKalmanFilter::predict(double current_time) {
 	}
 }
 
-void UnscentedKalmanFilter::update(double measured_progress) {
+void UnscentedKalmanFilter::Update(double measured_progress) {
 	if (!initialized) {
 		return;
 	}
 
 	// Generate sigma points
-	auto sigma_points = generateSigmaPoints();
+	auto sigma_points = GenerateSigmaPoints();
 
 	// Transform sigma points through measurement function
 	std::vector<std::vector<double>> Z_sigma(SIGMA_POINTS, std::vector<double>(OBS_DIM));
 	for (size_t i = 0; i < SIGMA_POINTS; i++) {
-		Z_sigma[i] = measurementFunction(sigma_points[i]);
+		Z_sigma[i] = MeasurementFunction(sigma_points[i]);
 	}
 
 	// Predict measurement mean
@@ -233,15 +233,15 @@ void UnscentedKalmanFilter::update(double measured_progress) {
 	x[0] = std::max(0.0, std::min(1.0, x[0]));
 }
 
-double UnscentedKalmanFilter::getProgress() const {
+double UnscentedKalmanFilter::GetProgress() const {
 	return x[0];
 }
 
-double UnscentedKalmanFilter::getVelocity() const {
+double UnscentedKalmanFilter::GetVelocity() const {
 	return x[1];
 }
 
-double UnscentedKalmanFilter::getEstimatedRemainingSeconds() const {
+double UnscentedKalmanFilter::GetEstimatedRemainingSeconds() const {
 	if (!initialized || x[1] <= 0) {
 		return -1.0;
 	}
@@ -249,11 +249,11 @@ double UnscentedKalmanFilter::getEstimatedRemainingSeconds() const {
 	return remaining_progress / x[1];
 }
 
-double UnscentedKalmanFilter::getProgressVariance() const {
+double UnscentedKalmanFilter::GetProgressVariance() const {
 	return P[0][0];
 }
 
-double UnscentedKalmanFilter::getVelocityVariance() const {
+double UnscentedKalmanFilter::GetVelocityVariance() const {
 	return P[1][1];
 }
 

--- a/src/common/progress_bar/unscented_kalman_filter.cpp
+++ b/src/common/progress_bar/unscented_kalman_filter.cpp
@@ -28,7 +28,7 @@ UnscentedKalmanFilter::UnscentedKalmanFilter()
 	Q[0][0] = 1e-6; // process noise for progress
 	Q[1][1] = 1e-4; // process noise for velocity
 
-	R[0][0] = 1e-4; // measurement noise for progress
+	R[0][0] = 0.05; // measurement noise for progress
 }
 
 void UnscentedKalmanFilter::Initialize(double initial_progress, double current_time) {

--- a/src/common/progress_bar/unscented_kalman_filter.cpp
+++ b/src/common/progress_bar/unscented_kalman_filter.cpp
@@ -1,0 +1,260 @@
+#include "duckdb/common/progress_bar/unscented_kalman_filter.hpp"
+#include "duckdb.hpp"
+namespace duckdb {
+
+UnscentedKalmanFilter::UnscentedKalmanFilter()
+    : x(STATE_DIM, 0.0), P(STATE_DIM, std::vector<double>(STATE_DIM, 0.0)),
+      Q(STATE_DIM, std::vector<double>(STATE_DIM, 0.0)), R(OBS_DIM, std::vector<double>(OBS_DIM, 0.0)), last_time(0.0),
+      initialized(false) {
+
+	// Calculate UKF parameters
+	lambda = ALPHA * ALPHA * (STATE_DIM + KAPPA) - STATE_DIM;
+
+	// Initialize weights
+	wm.resize(SIGMA_POINTS);
+	wc.resize(SIGMA_POINTS);
+
+	wm[0] = lambda / (STATE_DIM + lambda);
+	wc[0] = lambda / (STATE_DIM + lambda) + (1 - ALPHA * ALPHA + BETA);
+
+	for (size_t i = 1; i < SIGMA_POINTS; i++) {
+		wm[i] = wc[i] = 0.5 / (STATE_DIM + lambda);
+	}
+
+	// Initialize covariance matrices
+	P[0][0] = 0.01;  // progress variance
+	P[1][1] = 0.001; // velocity variance
+
+	Q[0][0] = 1e-6; // process noise for progress
+	Q[1][1] = 1e-4; // process noise for velocity
+
+	R[0][0] = 1e-4; // measurement noise for progress
+}
+
+void UnscentedKalmanFilter::initialize(double initial_progress, double current_time) {
+	x[0] = initial_progress;
+	x[1] = 0.01; // initial velocity guess
+	last_time = current_time;
+	initialized = true;
+}
+
+// Matrix operations
+std::vector<std::vector<double>> UnscentedKalmanFilter::matrixSqrt(const std::vector<std::vector<double>> &mat) {
+	size_t n = mat.size();
+	std::vector<std::vector<double>> L(n, std::vector<double>(n, 0.0));
+
+	// Cholesky decomposition
+	for (size_t i = 0; i < n; i++) {
+		for (size_t j = 0; j <= i; j++) {
+			if (i == j) {
+				double sum = 0;
+				for (size_t k = 0; k < j; k++) {
+					sum += L[j][k] * L[j][k];
+				}
+				L[j][j] = std::sqrt(mat[j][j] - sum);
+			} else {
+				double sum = 0;
+				for (size_t k = 0; k < j; k++) {
+					sum += L[i][k] * L[j][k];
+				}
+				L[i][j] = (mat[i][j] - sum) / L[j][j];
+			}
+		}
+	}
+	return L;
+}
+
+// Generate sigma points
+std::vector<std::vector<double>> UnscentedKalmanFilter::generateSigmaPoints() {
+	std::vector<std::vector<double>> sigma_points(SIGMA_POINTS, std::vector<double>(STATE_DIM));
+
+	// Calculate sqrt((n + lambda) * P)
+	auto scaled_P = P;
+	double scale = STATE_DIM + lambda;
+	for (size_t i = 0; i < STATE_DIM; i++) {
+		for (size_t j = 0; j < STATE_DIM; j++) {
+			scaled_P[i][j] *= scale;
+		}
+	}
+
+	auto sqrt_P = matrixSqrt(scaled_P);
+
+	// First sigma point is the mean
+	sigma_points[0] = x;
+
+	// Remaining sigma points
+	for (size_t i = 0; i < STATE_DIM; i++) {
+		for (size_t j = 0; j < STATE_DIM; j++) {
+			sigma_points[i + 1][j] = x[j] + sqrt_P[j][i];
+			sigma_points[i + 1 + STATE_DIM][j] = x[j] - sqrt_P[j][i];
+		}
+	}
+
+	return sigma_points;
+}
+
+// State transition function
+std::vector<double> UnscentedKalmanFilter::stateTransition(const std::vector<double> &state, double dt) {
+	std::vector<double> new_state(STATE_DIM);
+	new_state[0] = state[0] + state[1] * dt; // progress += velocity * dt
+	new_state[1] = state[1];                 // velocity remains constant
+
+	// Clamp progress to [0, 1]
+	new_state[0] = std::max(0.0, std::min(1.0, new_state[0]));
+
+	return new_state;
+}
+
+// Measurement function (identity for progress)
+std::vector<double> UnscentedKalmanFilter::measurementFunction(const std::vector<double> &state) {
+	return {state[0]};
+}
+
+void UnscentedKalmanFilter::predict(double current_time) {
+	if (!initialized) {
+		return;
+	}
+
+	double dt = current_time - last_time;
+	last_time = current_time;
+
+	if (dt <= 0) {
+		return;
+	}
+
+	// Generate sigma points
+	auto sigma_points = generateSigmaPoints();
+
+	// Propagate sigma points through state transition
+	std::vector<std::vector<double>> sigma_points_pred(SIGMA_POINTS, std::vector<double>(STATE_DIM));
+	for (size_t i = 0; i < SIGMA_POINTS; i++) {
+		sigma_points_pred[i] = stateTransition(sigma_points[i], dt);
+	}
+
+	// Predict state mean
+	std::fill(x.begin(), x.end(), 0.0);
+	for (size_t i = 0; i < SIGMA_POINTS; i++) {
+		for (size_t j = 0; j < STATE_DIM; j++) {
+			x[j] += wm[i] * sigma_points_pred[i][j];
+		}
+	}
+
+	// Predict covariance
+	for (size_t i = 0; i < STATE_DIM; i++) {
+		std::fill(P[i].begin(), P[i].end(), 0.0);
+	}
+
+	for (size_t i = 0; i < SIGMA_POINTS; i++) {
+		for (size_t j = 0; j < STATE_DIM; j++) {
+			for (size_t k = 0; k < STATE_DIM; k++) {
+				P[j][k] += wc[i] * (sigma_points_pred[i][j] - x[j]) * (sigma_points_pred[i][k] - x[k]);
+			}
+		}
+	}
+
+	// Add process noise
+	for (size_t i = 0; i < STATE_DIM; i++) {
+		for (size_t j = 0; j < STATE_DIM; j++) {
+			P[i][j] += Q[i][j];
+		}
+	}
+}
+
+void UnscentedKalmanFilter::update(double measured_progress) {
+	if (!initialized) {
+		return;
+	}
+
+	// Generate sigma points
+	auto sigma_points = generateSigmaPoints();
+
+	// Transform sigma points through measurement function
+	std::vector<std::vector<double>> Z_sigma(SIGMA_POINTS, std::vector<double>(OBS_DIM));
+	for (size_t i = 0; i < SIGMA_POINTS; i++) {
+		Z_sigma[i] = measurementFunction(sigma_points[i]);
+	}
+
+	// Predict measurement mean
+	std::vector<double> z_pred(OBS_DIM, 0.0);
+	for (size_t i = 0; i < SIGMA_POINTS; i++) {
+		for (size_t j = 0; j < OBS_DIM; j++) {
+			z_pred[j] += wm[i] * Z_sigma[i][j];
+		}
+	}
+
+	// Innovation covariance
+	std::vector<std::vector<double>> S(OBS_DIM, std::vector<double>(OBS_DIM, 0.0));
+	for (size_t i = 0; i < SIGMA_POINTS; i++) {
+		for (size_t j = 0; j < OBS_DIM; j++) {
+			for (size_t k = 0; k < OBS_DIM; k++) {
+				S[j][k] += wc[i] * (Z_sigma[i][j] - z_pred[j]) * (Z_sigma[i][k] - z_pred[k]);
+			}
+		}
+	}
+
+	// Add measurement noise
+	for (size_t i = 0; i < OBS_DIM; i++) {
+		for (size_t j = 0; j < OBS_DIM; j++) {
+			S[i][j] += R[i][j];
+		}
+	}
+
+	// Cross correlation
+	std::vector<std::vector<double>> T(STATE_DIM, std::vector<double>(OBS_DIM, 0.0));
+	for (size_t i = 0; i < SIGMA_POINTS; i++) {
+		for (size_t j = 0; j < STATE_DIM; j++) {
+			for (size_t k = 0; k < OBS_DIM; k++) {
+				T[j][k] += wc[i] * (sigma_points[i][j] - x[j]) * (Z_sigma[i][k] - z_pred[k]);
+			}
+		}
+	}
+
+	// Kalman gain (simplified for 1D measurement)
+	std::vector<std::vector<double>> K(STATE_DIM, std::vector<double>(OBS_DIM));
+	double S_inv = 1.0 / S[0][0];
+	for (size_t i = 0; i < STATE_DIM; i++) {
+		K[i][0] = T[i][0] * S_inv;
+	}
+
+	// Update state
+	std::vector<double> innovation = {measured_progress - z_pred[0]};
+	for (size_t i = 0; i < STATE_DIM; i++) {
+		x[i] += K[i][0] * innovation[0];
+	}
+
+	// Update covariance
+	for (size_t i = 0; i < STATE_DIM; i++) {
+		for (size_t j = 0; j < STATE_DIM; j++) {
+			P[i][j] -= K[i][0] * S[0][0] * K[j][0];
+		}
+	}
+
+	// Ensure progress stays in bounds
+	x[0] = std::max(0.0, std::min(1.0, x[0]));
+}
+
+double UnscentedKalmanFilter::getProgress() const {
+	return x[0];
+}
+
+double UnscentedKalmanFilter::getVelocity() const {
+	return x[1];
+}
+
+double UnscentedKalmanFilter::getEstimatedRemainingSeconds() const {
+	if (!initialized || x[1] <= 0) {
+		return -1.0;
+	}
+	double remaining_progress = 1.0 - x[0];
+	return remaining_progress / x[1];
+}
+
+double UnscentedKalmanFilter::getProgressVariance() const {
+	return P[0][0];
+}
+
+double UnscentedKalmanFilter::getVelocityVariance() const {
+	return P[1][1];
+}
+
+} // namespace duckdb

--- a/src/common/progress_bar/unscented_kalman_filter.cpp
+++ b/src/common/progress_bar/unscented_kalman_filter.cpp
@@ -33,7 +33,7 @@ UnscentedKalmanFilter::UnscentedKalmanFilter()
 
 void UnscentedKalmanFilter::Initialize(double initial_progress, double current_time) {
 	x[0] = initial_progress;
-	x[1] = 0.01; // initial velocity guess
+	x[1] = current_time == 0 ? 0.01 : initial_progress / current_time; // initial velocity guess
 	last_time = current_time;
 	initialized = true;
 }

--- a/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
+++ b/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
@@ -11,12 +11,27 @@
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/progress_bar/progress_bar_display.hpp"
 #include "duckdb/common/unicode_bar.hpp"
+#include "duckdb/common/progress_bar/unscented_kalman_filter.hpp"
+#include <chrono>
 
 namespace duckdb {
 
 class TerminalProgressBarDisplay : public ProgressBarDisplay {
+private:
+	UnscentedKalmanFilter ukf;
+	std::chrono::steady_clock::time_point start_time;
+	bool udf_initialized;
+
+	double GetElapsedDuration() {
+		auto now = std::chrono::steady_clock::now();
+		return std::chrono::duration<double>(now - start_time).count();
+	}
+
 public:
-	TerminalProgressBarDisplay() = default;
+	TerminalProgressBarDisplay() : udf_initialized(false) {
+		start_time = std::chrono::steady_clock::now();
+	}
+
 	~TerminalProgressBarDisplay() override = default;
 
 public:
@@ -39,11 +54,11 @@ private:
 	const char *PROGRESS_START = "[";
 	const char *PROGRESS_END = "]";
 #endif
-	static constexpr const idx_t PROGRESS_BAR_WIDTH = 60;
+	static constexpr const idx_t PROGRESS_BAR_WIDTH = 43;
 
 private:
 	static int32_t NormalizePercentage(double percentage);
-	void PrintProgressInternal(int32_t percentage);
+	void PrintProgressInternal(int32_t percentage, double estimated_remaining_seconds);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
+++ b/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
@@ -39,7 +39,7 @@ public:
 	void Finish() override;
 
 private:
-	int32_t rendered_percentage = -1;
+	double last_update_time = 0.0;
 	static constexpr const idx_t PARTIAL_BLOCK_COUNT = UnicodeBar::PartialBlocksCount();
 #ifndef DUCKDB_ASCII_TREE_RENDERER
 	const char *PROGRESS_EMPTY = " ";                                  // NOLINT
@@ -54,11 +54,11 @@ private:
 	const char *PROGRESS_START = "[";
 	const char *PROGRESS_END = "]";
 #endif
-	static constexpr const idx_t PROGRESS_BAR_WIDTH = 43;
+	static constexpr const idx_t PROGRESS_BAR_WIDTH = 38;
 
 private:
 	static int32_t NormalizePercentage(double percentage);
-	void PrintProgressInternal(int32_t percentage, double estimated_remaining_seconds);
+	void PrintProgressInternal(int32_t percentage, double estimated_remaining_seconds, bool is_finished = false);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/progress_bar/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar/progress_bar.hpp
@@ -52,7 +52,7 @@ public:
 	//! Updates the progress bar and prints it to the screen
 	void Update(bool final);
 	QueryProgress GetDetailedQueryProgress();
-	void PrintProgress(int percentage);
+	void PrintProgress(double percentage);
 	void FinishProgressBarPrint();
 	bool ShouldPrint(bool final) const;
 	bool PrintEnabled() const;

--- a/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
+++ b/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
@@ -37,23 +37,23 @@ private:
 	bool initialized;
 
 	// Helper functions
-	std::vector<std::vector<double>> matrixSqrt(const std::vector<std::vector<double>> &mat);
-	std::vector<std::vector<double>> generateSigmaPoints();
-	std::vector<double> stateTransition(const std::vector<double> &state, double dt);
-	std::vector<double> measurementFunction(const std::vector<double> &state);
+	std::vector<std::vector<double>> MatrixSqrt(const std::vector<std::vector<double>> &mat);
+	std::vector<std::vector<double>> GenerateSigmaPoints();
+	std::vector<double> StateTransition(const std::vector<double> &state, double dt);
+	std::vector<double> MeasurementFunction(const std::vector<double> &state);
 
 public:
 	UnscentedKalmanFilter();
 
-	void initialize(double initial_progress, double current_time);
-	void predict(double current_time);
-	void update(double measured_progress);
+	void Initialize(double initial_progress, double current_time);
+	void Predict(double current_time);
+	void Update(double measured_progress);
 
-	double getProgress() const;
-	double getVelocity() const;
-	double getEstimatedRemainingSeconds() const;
-	double getProgressVariance() const;
-	double getVelocityVariance() const;
+	double GetProgress() const;
+	double GetVelocity() const;
+	double GetEstimatedRemainingSeconds() const;
+	double GetProgressVariance() const;
+	double GetVelocityVariance() const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
+++ b/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/progress_bar/unscented_kalman_filter.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb.hpp"
+#include <chrono>
+
+namespace duckdb {
+
+class UnscentedKalmanFilter {
+private:
+	static constexpr size_t STATE_DIM = 2; // [progress, velocity]
+	static constexpr size_t OBS_DIM = 1;   // [progress]
+	static constexpr size_t SIGMA_POINTS = 2 * STATE_DIM + 1;
+
+	// UKF parameters
+	static constexpr double ALPHA = 0.1;
+	static constexpr double BETA = 1.0;
+	static constexpr double KAPPA = 0.0;
+
+	double lambda;
+	std::vector<double> wm, wc; // weights for mean and covariance
+
+	// State: [progress (0-1), velocity (progress/second)]
+	std::vector<double> x;              // state estimate
+	std::vector<std::vector<double>> P; // covariance matrix
+	std::vector<std::vector<double>> Q; // process noise
+	std::vector<std::vector<double>> R; // measurement noise
+
+	double last_time;
+	bool initialized;
+
+	// Helper functions
+	std::vector<std::vector<double>> matrixSqrt(const std::vector<std::vector<double>> &mat);
+	std::vector<std::vector<double>> generateSigmaPoints();
+	std::vector<double> stateTransition(const std::vector<double> &state, double dt);
+	std::vector<double> measurementFunction(const std::vector<double> &state);
+
+public:
+	UnscentedKalmanFilter();
+
+	void initialize(double initial_progress, double current_time);
+	void predict(double current_time);
+	void update(double measured_progress);
+
+	double getProgress() const;
+	double getVelocity() const;
+	double getEstimatedRemainingSeconds() const;
+	double getProgressVariance() const;
+	double getVelocityVariance() const;
+};
+
+} // namespace duckdb


### PR DESCRIPTION
Hi DuckDB Team,

I use the DuckDB CLI frequently, almost every day. Throughout my work, the query progress bar ticks steadily from 1% to 100%. However, I often find myself wondering if I have time to do something else before my query finishes. Currently, DuckDB doesn’t provide an estimate for this, such as whether I could watch an episode of *Ted Lasso* before completion. I believe it could—and so, I’m submitting a PR to add this functionality.

A simple linear estimate of query completion time is a natural starting point but can be overly optimistic and often misleading - *I’m looking at you, macOS upgrade progress bars*. Such an estimate typically calculates the rate of progress over a recent interval and extrapolates when the query will finish. While DuckDB already offers a robust progress reporting API, I think users deserve something more accurate than a naïve linear guess.

Query execution time is inherently unpredictable for many reasons. For example, the estimate becomes less reliable when DuckDB consumes a lot of RAM and the system starts swapping, or when DuckDB is performing I/O or fetching data over the network.

Fortunately, there is a statistical technique called a [Kalman filter](https://en.wikipedia.org/wiki/Kalman_filter) that can improve estimates despite noisy progress measurements. It continuously refines its prediction of query completion as more progress data arrives, increasing accuracy over time.

I’ve attached a video demonstrating this PR in action:

https://github.com/user-attachments/assets/d88d3b05-be83-4a1f-9953-a1085d905dcc

I’d appreciate your feedback and would love to hear if you’re open to merging this improvement. Currently, it only affects the CLI progress bar. The PR is designed to be simple, with no external dependencies and only a single new class.  

Rusty