### PR TITLE
Force `LIST`/`ARRAY` child vectors on a Parquet single page

### DIFF
--- a/extension/parquet/include/column_writer.hpp
+++ b/extension/parquet/include/column_writer.hpp
@@ -119,7 +119,8 @@ public:
 		throw NotImplementedException("Writer does not need analysis");
 	}
 
-	virtual void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count) = 0;
+	virtual void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count,
+	                     bool vector_can_span_multiple_pages) = 0;
 
 	virtual void BeginWrite(ColumnWriterState &state) = 0;
 	virtual void Write(ColumnWriterState &state, Vector &vector, idx_t count) = 0;

--- a/extension/parquet/include/writer/array_column_writer.hpp
+++ b/extension/parquet/include/writer/array_column_writer.hpp
@@ -22,7 +22,8 @@ public:
 
 public:
 	void Analyze(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count) override;
-	void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count) override;
+	void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count,
+	             bool vector_can_span_multiple_pages) override;
 	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override;
 };
 

--- a/extension/parquet/include/writer/list_column_writer.hpp
+++ b/extension/parquet/include/writer/list_column_writer.hpp
@@ -40,7 +40,8 @@ public:
 	bool HasAnalyze() override;
 	void Analyze(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count) override;
 	void FinalizeAnalyze(ColumnWriterState &state) override;
-	void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count) override;
+	void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count,
+	             bool vector_can_span_multiple_pages) override;
 
 	void BeginWrite(ColumnWriterState &state) override;
 	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override;

--- a/extension/parquet/include/writer/primitive_column_writer.hpp
+++ b/extension/parquet/include/writer/primitive_column_writer.hpp
@@ -70,7 +70,8 @@ public:
 
 public:
 	unique_ptr<ColumnWriterState> InitializeWriteState(duckdb_parquet::RowGroup &row_group) override;
-	void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count) override;
+	void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count,
+	             bool vector_can_span_multiple_pages) override;
 	void BeginWrite(ColumnWriterState &state) override;
 	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override;
 	void FinalizeWrite(ColumnWriterState &state) override;

--- a/extension/parquet/include/writer/struct_column_writer.hpp
+++ b/extension/parquet/include/writer/struct_column_writer.hpp
@@ -28,7 +28,8 @@ public:
 	bool HasAnalyze() override;
 	void Analyze(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count) override;
 	void FinalizeAnalyze(ColumnWriterState &state) override;
-	void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count) override;
+	void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count,
+	             bool vector_can_span_multiple_pages) override;
 
 	void BeginWrite(ColumnWriterState &state) override;
 	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override;

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -468,7 +468,7 @@ void ParquetWriter::PrepareRowGroup(ColumnDataCollection &buffer, PreparedRowGro
 
 		for (auto &chunk : buffer.Chunks({column_ids})) {
 			for (idx_t i = 0; i < next; i++) {
-				col_writers[i].get().Prepare(*write_states[i], nullptr, chunk.data[i], chunk.size());
+				col_writers[i].get().Prepare(*write_states[i], nullptr, chunk.data[i], chunk.size(), true);
 			}
 		}
 

--- a/extension/parquet/writer/list_column_writer.cpp
+++ b/extension/parquet/writer/list_column_writer.cpp
@@ -57,7 +57,8 @@ static idx_t GetConsecutiveChildList(Vector &list, Vector &result, idx_t offset,
 	return total_length;
 }
 
-void ListColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector, idx_t count) {
+void ListColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector, idx_t count,
+                               bool vector_can_span_multiple_pages) {
 	auto &state = state_p.Cast<ListColumnWriterState>();
 
 	auto list_data = FlatVector::GetData<list_entry_t>(vector);
@@ -111,7 +112,9 @@ void ListColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *pa
 	auto &list_child = ListVector::GetEntry(vector);
 	Vector child_list(list_child);
 	auto child_length = GetConsecutiveChildList(vector, child_list, 0, count);
-	child_writer->Prepare(*state.child_state, &state_p, child_list, child_length);
+	// The elements of a single list should not span multiple Parquet pages
+	// So, we force the entire vector to fit on a single page by setting "vector_can_span_multiple_pages=false"
+	child_writer->Prepare(*state.child_state, &state_p, child_list, child_length, false);
 }
 
 void ListColumnWriter::BeginWrite(ColumnWriterState &state_p) {

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -69,7 +69,11 @@ void PrimitiveColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterStat
 			}
 			if (validity.RowIsValid(vector_index)) {
 				page_info.estimated_page_size += GetRowSize(vector, vector_index, state);
-				if (vector_can_span_multiple_pages && page_info.estimated_page_size >= MAX_UNCOMPRESSED_PAGE_SIZE) {
+				if (page_info.estimated_page_size >= MAX_UNCOMPRESSED_PAGE_SIZE) {
+					if (!vector_can_span_multiple_pages && i != 0) {
+						// Vector is not allowed to span multiple pages, and we already started writing it
+						continue;
+					}
 					PageInformation new_info;
 					new_info.offset = page_info.offset + page_info.row_count;
 					state.page_info.push_back(new_info);

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -36,8 +36,8 @@ unique_ptr<ColumnWriterPageState> PrimitiveColumnWriter::InitializePageState(Pri
 void PrimitiveColumnWriter::FlushPageState(WriteStream &temp_writer, ColumnWriterPageState *state) {
 }
 
-void PrimitiveColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector,
-                                    idx_t count) {
+void PrimitiveColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector, idx_t count,
+                                    bool vector_can_span_multiple_pages) {
 	auto &state = state_p.Cast<PrimitiveColumnWriterState>();
 	auto &col_chunk = state.row_group.columns[state.col_idx];
 
@@ -69,7 +69,7 @@ void PrimitiveColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterStat
 			}
 			if (validity.RowIsValid(vector_index)) {
 				page_info.estimated_page_size += GetRowSize(vector, vector_index, state);
-				if (page_info.estimated_page_size >= MAX_UNCOMPRESSED_PAGE_SIZE) {
+				if (vector_can_span_multiple_pages && page_info.estimated_page_size >= MAX_UNCOMPRESSED_PAGE_SIZE) {
 					PageInformation new_info;
 					new_info.offset = page_info.offset + page_info.row_count;
 					state.page_info.push_back(new_info);

--- a/extension/parquet/writer/struct_column_writer.cpp
+++ b/extension/parquet/writer/struct_column_writer.cpp
@@ -55,7 +55,8 @@ void StructColumnWriter::FinalizeAnalyze(ColumnWriterState &state_p) {
 	}
 }
 
-void StructColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector, idx_t count) {
+void StructColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector, idx_t count,
+                                 bool vector_can_span_multiple_pages) {
 	auto &state = state_p.Cast<StructColumnWriterState>();
 
 	auto &validity = FlatVector::Validity(vector);
@@ -69,7 +70,8 @@ void StructColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *
 	HandleDefineLevels(state_p, parent, validity, count, PARQUET_DEFINE_VALID, MaxDefine() - 1);
 	auto &child_vectors = StructVector::GetEntries(vector);
 	for (idx_t child_idx = 0; child_idx < child_writers.size(); child_idx++) {
-		child_writers[child_idx]->Prepare(*state.child_states[child_idx], &state_p, *child_vectors[child_idx], count);
+		child_writers[child_idx]->Prepare(*state.child_states[child_idx], &state_p, *child_vectors[child_idx], count,
+		                                  vector_can_span_multiple_pages);
 	}
 }
 


### PR DESCRIPTION
Fixes #18512

DuckDB can read/write Parquet lists that are spread out over multiple pages, but this is apparently not what the Parquet spec intended. This PR forces DuckDB Parquet writes to keep lists on a single Parquet page. It's not very fine-grained, as it forces batches of `STANDARD_VECTOR_SIZE` lists to be on a single Parquet page, but I doubt that will be an issue, and this is the easiest way to comply with the spec.