### PR TITLE
Backport renaming a config name `small_block_size.json` to `block_size_16kB` in NightlyTests

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -603,9 +603,9 @@ jobs:
         run: |
           ./build/relassert/test/unittest
           ./build/relassert/test/unittest "test/sql/storage/*"
-          ./build/relassert/test/unittest --test-config test/configs/small_block_size.json
-          ./build/relassert/test/unittest "test/sql/storage/*" --test-config test/configs/small_block_size.json
-
+          ./build/relassert/test/unittest --test-config test/configs/block_size_16kB.json
+          ./build/relassert/test/unittest "test/sql/storage/*" --test-config test/configs/block_size_16kB.json
+          
   linux-wasm-experimental:
     name: WebAssembly duckdb-wasm builds
     if: false


### PR DESCRIPTION
This PR basically cherry-picks the commit from the PR https://github.com/duckdb/duckdb/pull/18507 to make it run Block Sizes tests with correct config name 

Fixes https://github.com/duckdblabs/duckdb-internal/issues/5554