### PR TITLE
Protect against underflow while searching segment index

### DIFF
--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -222,8 +222,12 @@ public:
 			D_ASSERT(index < nodes.size());
 			auto &entry = nodes[index];
 			D_ASSERT(entry.row_start == entry.node->start);
-			if (row_number < entry.row_start && index > 0) {
-				upper = index - 1;
+			if (row_number < entry.row_start) {
+				if (index > 0) {
+					upper = index - 1;
+				} else {
+					return false;
+				}
 			} else if (row_number >= entry.row_start + entry.node->count) {
 				lower = index + 1;
 			} else {

--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -222,7 +222,7 @@ public:
 			D_ASSERT(index < nodes.size());
 			auto &entry = nodes[index];
 			D_ASSERT(entry.row_start == entry.node->start);
-			if (row_number < entry.row_start) {
+			if (row_number < entry.row_start && index > 0) {
 				upper = index - 1;
 			} else if (row_number >= entry.row_start + entry.node->count) {
 				lower = index + 1;


### PR DESCRIPTION
Since `idx_t` is an unsigned int64 integer, `-1` would mean max `uint64_t` (`9223372036854775807`).

This PR protects against this case. Let me know if you need me to figure a test out :-)