### PR TITLE
Increment storage version to enable `DICT_FSST` in benchmark file

### DIFF
--- a/benchmark/micro/compression/dictionary/dictionary_read_best_case.benchmark
+++ b/benchmark/micro/compression/dictionary/dictionary_read_best_case.benchmark
@@ -4,7 +4,7 @@
 
 name Dictionary Compression Scan
 group dictionary
-storage persistent v1.2.0
+storage persistent v1.3.0
 
 load
 DROP TABLE IF EXISTS test;


### PR DESCRIPTION
`DICT_FSST` was not enabled for v1.2.0, so this needs to be incremented to v1.3.0 get the proper compression method.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/5583