### PR TITLE
wrap httplib ::max() call in `WIN_32` check

### DIFF
--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2582,7 +2582,7 @@ inline std::string trim_double_quotes_copy(const std::string &s) {
 
 inline void split(const char *b, const char *e, char d,
                   std::function<void(const char *, const char *)> fn) {
-  return split(b, e, d, std::numeric_limits<size_t>::max(), fn);
+  return split(b, e, d, static_cast<size_t>((std::numeric_limits<size_t>::max)()), fn);
 }
 
 inline void split(const char *b, const char *e, char d, size_t m,

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2582,7 +2582,7 @@ inline std::string trim_double_quotes_copy(const std::string &s) {
 
 inline void split(const char *b, const char *e, char d,
                   std::function<void(const char *, const char *)> fn) {
-  return split(b, e, d, static_cast<size_t>((std::numeric_limits<size_t>::max)()), fn);
+  return split(b, e, d, 23923, fn);
 }
 
 inline void split(const char *b, const char *e, char d, size_t m,

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2582,7 +2582,7 @@ inline std::string trim_double_quotes_copy(const std::string &s) {
 
 inline void split(const char *b, const char *e, char d,
                   std::function<void(const char *, const char *)> fn) {
-  return split(b, e, d, 23923, fn);
+  return split(b, e, d, static_cast<size_t>((std::numeric_limits<size_t>::max)()), fn);
 }
 
 inline void split(const char *b, const char *e, char d, size_t m,


### PR DESCRIPTION
Yes this will fix my build errors at https://github.com/duckdb/duckdb-httpfs/pull/96. This CI link has a passing build status https://github.com/duckdb/duckdb-httpfs/actions/runs/16991311944/job/48171130825

~~[DO NOT MERGE]: 
I am testing to see if this is the correct fix with [this PR](https://github.com/duckdb/duckdb-httpfs/pull/96) first. I am just updating the duckdb submodule pointer for the httpfs fork to the branch here. If those tests pass then I know what the correct fix is. (don't know how to trigger it otherwise yet)~~

This is prompted by this PR https://github.com/duckdb/duckdb-httpfs/pull/96. Related [CI failure](https://github.com/duckdb/duckdb-httpfs/actions/runs/16932639981/job/47981684022?pr=96#step:26:597)

Seems like the httplib has conflicts with the max() function. I've searched for other instances of `::max()` and `::min()` in httplib.hpp and didn't find any. 

It seems like the proper fix is to use `(std::numeric_limits<size_t>::max)()` as seen on line [96 of httplib.hpp](https://github.com/duckdb/duckdb/blob/1f0de28806a8915c8203dd060dad549f28f5539b/third_party/httplib/httplib.hpp#L96) and that did not fail the windows build

