### PR TITLE
Make more configs into generic settings

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -689,7 +689,8 @@
         "name": "ordered_aggregate_threshold",
         "description": "The number of rows to accumulate before sorting, used for tuning",
         "type": "UBIGINT",
-        "scope": "local",
+        "default_scope": "local",
+        "default_value": "262144",
         "on_callbacks": [
             "set"
         ]

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -542,8 +542,8 @@
         "name": "ieee_floating_point_ops",
         "description": "Use IEE754-compliant floating point operations (returning NAN instead of errors/NULL).",
         "type": "BOOLEAN",
-        "scope": "local",
-        "struct": "IEEEFloatingPointOpsSetting"
+        "default_scope": "local",
+        "default_value": "true"
     },
     {
         "name": "immediate_transaction_mode",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -720,10 +720,10 @@
         "name": "perfect_ht_threshold",
         "description": "Threshold in bytes for when to use a perfect hash table",
         "type": "UBIGINT",
-        "scope": "local",
-        "custom_implementation": [
-            "set",
-            "get"
+        "default_scope": "local",
+        "default_value": "12",
+        "on_callbacks": [
+            "set"
         ]
     },
     {

--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -1,3 +1,5 @@
+#include "duckdb/main/settings.hpp"
+
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
@@ -215,7 +217,7 @@ static bool CanUsePerfectHashAggregate(ClientContext &context, LogicalAggregate 
 		bits_per_group.push_back(required_bits);
 		perfect_hash_bits += required_bits;
 		// check if we have exceeded the bits for the hash
-		if (perfect_hash_bits > ClientConfig::GetConfig(context).perfect_ht_threshold) {
+		if (perfect_hash_bits > DBConfig::GetSetting<PerfectHtThresholdSetting>(context)) {
 			// too many bits for perfect hash
 			return false;
 		}

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/parser/expression_map.hpp"
 #include "duckdb/parallel/thread_context.hpp"
+#include "duckdb/main/settings.hpp"
 
 namespace duckdb {
 
@@ -22,7 +23,7 @@ struct SortedAggregateBindData : public FunctionData {
 	SortedAggregateBindData(ClientContext &context, Expressions &children, AggregateFunction &aggregate,
 	                        BindInfoPtr &bind_info, OrderBys &order_bys)
 	    : context(context), function(aggregate), bind_info(std::move(bind_info)),
-	      threshold(ClientConfig::GetConfig(context).ordered_aggregate_threshold) {
+	      threshold(DBConfig::GetSetting<OrderedAggregateThresholdSetting>(context)) {
 
 		//	Describe the arguments.
 		for (const auto &child : children) {

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1,3 +1,5 @@
+#include <duckdb/main/settings.hpp>
+
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/bignum.hpp"
 #include "duckdb/common/operator/add.hpp"
@@ -1093,8 +1095,7 @@ scalar_function_t GetBinaryFunctionIgnoreZero(PhysicalType type) {
 template <class OP>
 unique_ptr<FunctionData> BindBinaryFloatingPoint(ClientContext &context, ScalarFunction &bound_function,
                                                  vector<unique_ptr<Expression>> &arguments) {
-	auto &config = ClientConfig::GetConfig(context);
-	if (config.ieee_floating_point_ops) {
+	if (DBConfig::GetSetting<IeeeFloatingPointOpsSetting>(context)) {
 		bound_function.function = GetScalarBinaryFunction<OP>(bound_function.return_type.InternalType());
 	} else {
 		bound_function.function = GetBinaryFunctionIgnoreZero<OP>(bound_function.return_type.InternalType());

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1,4 +1,4 @@
-#include <duckdb/main/settings.hpp>
+#include "duckdb/main/settings.hpp"
 
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/bignum.hpp"

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -79,9 +79,6 @@ struct ClientConfig {
 	//! If this context should also try to use the available replacement scans
 	//! True by default
 	bool use_replacement_scans = true;
-	//! Maximum bits allowed for using a perfect hash table (i.e. the perfect HT can hold up to 2^perfect_ht_threshold
-	//! elements)
-	idx_t perfect_ht_threshold = 12;
 
 	//! The maximum amount of memory to keep buffered in a streaming query result. Default: 1mb.
 	idx_t streaming_buffer_size = 1000000;

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -82,8 +82,6 @@ struct ClientConfig {
 	//! Maximum bits allowed for using a perfect hash table (i.e. the perfect HT can hold up to 2^perfect_ht_threshold
 	//! elements)
 	idx_t perfect_ht_threshold = 12;
-	//! The maximum number of rows to accumulate before sorting ordered aggregates.
-	idx_t ordered_aggregate_threshold = (idx_t(1) << 18);
 
 	//! The maximum amount of memory to keep buffered in a streaming query result. Default: 1mb.
 	idx_t streaming_buffer_size = 1000000;

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -94,8 +94,6 @@ struct ClientConfig {
 	//! The explain output type used when none is specified (default: PHYSICAL_ONLY)
 	ExplainOutputType explain_output_type = ExplainOutputType::PHYSICAL_ONLY;
 
-	//! Use IEE754-compliant floating point operations (returning NAN instead of errors/NULL)
-	bool ieee_floating_point_ops = true;
 	//! If DEFAULT or ENABLE_SINGLE_ARROW, it is possible to use the deprecated single arrow operator (->) for lambda
 	//! functions. Otherwise, DISABLE_SINGLE_ARROW.
 	LambdaSyntax lambda_syntax = LambdaSyntax::DEFAULT;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -962,10 +962,9 @@ struct OrderedAggregateThresholdSetting {
 	static constexpr const char *Name = "ordered_aggregate_threshold";
 	static constexpr const char *Description = "The number of rows to accumulate before sorting, used for tuning";
 	static constexpr const char *InputType = "UBIGINT";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static bool OnLocalSet(ClientContext &context, const Value &input);
-	static Value GetSetting(const ClientContext &context);
+	static constexpr const char *DefaultValue = "262144";
+	static constexpr SetScope DefaultScope = SetScope::SESSION;
+	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct PartitionedWriteFlushThresholdSetting {

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1002,9 +1002,9 @@ struct PerfectHtThresholdSetting {
 	static constexpr const char *Name = "perfect_ht_threshold";
 	static constexpr const char *Description = "Threshold in bytes for when to use a perfect hash table";
 	static constexpr const char *InputType = "UBIGINT";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+	static constexpr const char *DefaultValue = "12";
+	static constexpr SetScope DefaultScope = SetScope::SESSION;
+	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct PinThreadsSetting {

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -752,15 +752,14 @@ struct HTTPProxyUsernameSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
-struct IEEEFloatingPointOpsSetting {
+struct IeeeFloatingPointOpsSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "ieee_floating_point_ops";
 	static constexpr const char *Description =
 	    "Use IEE754-compliant floating point operations (returning NAN instead of errors/NULL).";
 	static constexpr const char *InputType = "BOOLEAN";
-	static void SetLocal(ClientContext &context, const Value &parameter);
-	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(const ClientContext &context);
+	static constexpr const char *DefaultValue = "true";
+	static constexpr SetScope DefaultScope = SetScope::SESSION;
 };
 
 struct ImmediateTransactionModeSetting {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -126,7 +126,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(HTTPProxySetting),
     DUCKDB_GLOBAL(HTTPProxyPasswordSetting),
     DUCKDB_GLOBAL(HTTPProxyUsernameSetting),
-    DUCKDB_LOCAL(IEEEFloatingPointOpsSetting),
+    DUCKDB_SETTING(IeeeFloatingPointOpsSetting),
     DUCKDB_SETTING(ImmediateTransactionModeSetting),
     DUCKDB_SETTING(IndexScanMaxCountSetting),
     DUCKDB_SETTING_CALLBACK(IndexScanPercentageSetting),

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -146,7 +146,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(NestedLoopJoinThresholdSetting),
     DUCKDB_SETTING(OldImplicitCastingSetting),
     DUCKDB_SETTING(OrderByNonIntegerLiteralSetting),
-    DUCKDB_LOCAL(OrderedAggregateThresholdSetting),
+    DUCKDB_SETTING_CALLBACK(OrderedAggregateThresholdSetting),
     DUCKDB_SETTING(PartitionedWriteFlushThresholdSetting),
     DUCKDB_SETTING(PartitionedWriteMaxOpenFilesSetting),
     DUCKDB_GLOBAL(PasswordSetting),

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -150,7 +150,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(PartitionedWriteFlushThresholdSetting),
     DUCKDB_SETTING(PartitionedWriteMaxOpenFilesSetting),
     DUCKDB_GLOBAL(PasswordSetting),
-    DUCKDB_LOCAL(PerfectHtThresholdSetting),
+    DUCKDB_SETTING_CALLBACK(PerfectHtThresholdSetting),
     DUCKDB_GLOBAL(PinThreadsSetting),
     DUCKDB_SETTING(PivotFilterThresholdSetting),
     DUCKDB_SETTING(PivotLimitSetting),

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -496,26 +496,6 @@ Value MaxExpressionDepthSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
-// Ordered Aggregate Threshold
-//===----------------------------------------------------------------------===//
-void OrderedAggregateThresholdSetting::SetLocal(ClientContext &context, const Value &input) {
-	if (!OnLocalSet(context, input)) {
-		return;
-	}
-	auto &config = ClientConfig::GetConfig(context);
-	config.ordered_aggregate_threshold = input.GetValue<idx_t>();
-}
-
-void OrderedAggregateThresholdSetting::ResetLocal(ClientContext &context) {
-	ClientConfig::GetConfig(context).ordered_aggregate_threshold = ClientConfig().ordered_aggregate_threshold;
-}
-
-Value OrderedAggregateThresholdSetting::GetSetting(const ClientContext &context) {
-	auto &config = ClientConfig::GetConfig(context);
-	return Value::UBIGINT(config.ordered_aggregate_threshold);
-}
-
-//===----------------------------------------------------------------------===//
 // Perfect Ht Threshold
 //===----------------------------------------------------------------------===//
 void PerfectHtThresholdSetting::ResetLocal(ClientContext &context) {

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -496,13 +496,6 @@ Value MaxExpressionDepthSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
-// Perfect Ht Threshold
-//===----------------------------------------------------------------------===//
-void PerfectHtThresholdSetting::ResetLocal(ClientContext &context) {
-	ClientConfig::GetConfig(context).perfect_ht_threshold = ClientConfig().perfect_ht_threshold;
-}
-
-//===----------------------------------------------------------------------===//
 // Pin Threads
 //===----------------------------------------------------------------------===//
 void PinThreadsSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -463,23 +463,6 @@ Value HTTPProxyUsernameSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
-// I E E E Floating Point Ops
-//===----------------------------------------------------------------------===//
-void IEEEFloatingPointOpsSetting::SetLocal(ClientContext &context, const Value &input) {
-	auto &config = ClientConfig::GetConfig(context);
-	config.ieee_floating_point_ops = input.GetValue<bool>();
-}
-
-void IEEEFloatingPointOpsSetting::ResetLocal(ClientContext &context) {
-	ClientConfig::GetConfig(context).ieee_floating_point_ops = ClientConfig().ieee_floating_point_ops;
-}
-
-Value IEEEFloatingPointOpsSetting::GetSetting(const ClientContext &context) {
-	auto &config = ClientConfig::GetConfig(context);
-	return Value::BOOLEAN(config.ieee_floating_point_ops);
-}
-
-//===----------------------------------------------------------------------===//
 // Lock Configuration
 //===----------------------------------------------------------------------===//
 void LockConfigurationSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1194,16 +1194,11 @@ Value PasswordSetting::GetSetting(const ClientContext &context) {
 //===----------------------------------------------------------------------===//
 // Perfect Ht Threshold
 //===----------------------------------------------------------------------===//
-void PerfectHtThresholdSetting::SetLocal(ClientContext &context, const Value &input) {
+void PerfectHtThresholdSetting::OnSet(SettingCallbackInfo &info, Value &input) {
 	auto bits = input.GetValue<int64_t>();
 	if (bits < 0 || bits > 32) {
 		throw ParserException("Perfect HT threshold out of range: should be within range 0 - 32");
 	}
-	ClientConfig::GetConfig(context).perfect_ht_threshold = NumericCast<idx_t>(bits);
-}
-
-Value PerfectHtThresholdSetting::GetSetting(const ClientContext &context) {
-	return Value::BIGINT(NumericCast<int64_t>(ClientConfig::GetConfig(context).perfect_ht_threshold));
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1169,12 +1169,11 @@ Value MaxTempDirectorySizeSetting::GetSetting(const ClientContext &context) {
 //===----------------------------------------------------------------------===//
 // Ordered Aggregate Threshold
 //===----------------------------------------------------------------------===//
-bool OrderedAggregateThresholdSetting::OnLocalSet(ClientContext &context, const Value &input) {
+void OrderedAggregateThresholdSetting::OnSet(SettingCallbackInfo &info, Value &input) {
 	const auto param = input.GetValue<uint64_t>();
 	if (param <= 0) {
 		throw ParserException("Invalid option for PRAGMA ordered_aggregate_threshold, value must be positive");
 	}
-	return true;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Extending upon #18447, this PR turns three session-scoped configs into generic settings:

- ieee_floating_point_ops
- ordered_aggregate_threshold
- perfect_ht_threshold
