### PR TITLE
create vcpkg_installed if not exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -538,6 +538,7 @@ bundle-setup:
 	cp src/libduckdb_static.a bundle/. && \
 	cp third_party/*/libduckdb_*.a bundle/. && \
 	cp extension/*/lib*_extension.a bundle/. && \
+	mkdir -p vcpkg_installed && \
 	find vcpkg_installed -name '*.a' -exec cp {} bundle/. \; && \
 	cd bundle && \
 	find . -name '*.a' -exec mkdir -p {}.objects \; -exec mv {} {}.objects \; && \


### PR DESCRIPTION
If no vcpkg_installed directory, the build fails. This fixes it by creating one if none exists.