### PR TITLE
Fix serialization backwards compatability for varargs functions

### DIFF
--- a/src/function/cast_rules.cpp
+++ b/src/function/cast_rules.cpp
@@ -360,6 +360,10 @@ int64_t CastRules::ImplicitCast(const LogicalType &from, const LogicalType &to) 
 		// NULL expression can be cast to anything
 		return TargetTypeCost(to);
 	}
+	if (from.id() == LogicalTypeId::ANY && to.IsTemplated()) {
+		// This can happen when changing a function from using ANY to using TEMPLATE.
+		return TargetTypeCost(to);
+	}
 	if (from.id() == LogicalTypeId::UNKNOWN) {
 		// parameter expression can be cast to anything for no cost
 		return 0;

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -57,7 +57,8 @@ public:
 	}
 
 	template <class FUNC, class CATALOG_ENTRY>
-	static pair<FUNC, bool> DeserializeBase(Deserializer &deserializer, CatalogType catalog_type) {
+	static pair<FUNC, bool> DeserializeBase(Deserializer &deserializer, CatalogType catalog_type,
+	                                        optional_ptr<vector<unique_ptr<Expression>>> children = nullptr) {
 		auto &context = deserializer.Get<ClientContext &>();
 		auto name = deserializer.ReadProperty<string>(500, "name");
 		auto arguments = deserializer.ReadProperty<vector<LogicalType>>(501, "arguments");
@@ -70,6 +71,17 @@ public:
 		if (schema_name.empty()) {
 			schema_name = DEFAULT_SCHEMA;
 		}
+
+		if (arguments.empty() && original_arguments.empty() && children && !children->empty()) {
+			// The function is specified as having no arguments, but somehow expressions were passed anyway
+			// Assume this is a "varargs" function and use the types of the expressions as the arguments
+			// This can happen when we change a function that used to take varargs, to no longer do so.
+			arguments.reserve(children->size());
+			for (auto &child : *children) {
+				arguments.push_back(child->return_type);
+			}
+		}
+
 		auto function = DeserializeFunction<FUNC, CATALOG_ENTRY>(context, catalog_type, catalog_name, schema_name, name,
 		                                                         arguments, original_arguments);
 		auto has_serialize = deserializer.ReadProperty<bool>(503, "has_serialize");
@@ -133,7 +145,7 @@ public:
 	                                                        vector<unique_ptr<Expression>> &children,
 	                                                        LogicalType return_type) { // NOLINT: clang-tidy bug
 		auto &context = deserializer.Get<ClientContext &>();
-		auto entry = DeserializeBase<FUNC, CATALOG_ENTRY>(deserializer, catalog_type);
+		auto entry = DeserializeBase<FUNC, CATALOG_ENTRY>(deserializer, catalog_type, children);
 		auto &function = entry.first;
 		auto has_serialize = entry.second;
 


### PR DESCRIPTION
In https://github.com/duckdb/duckdb/pull/18410 we added support for creating function signatures with "template types" that are inferred and resolved by the binder. This centralizes a bunch of binding logic, removes the need for a lot of special cases and makes it much easier in general to write functions that operate on nested types.

To make use of this, we changed the function signature of bunch of our built in nested functions, particularly the `map_*` family of functions that had particularly egregious and bug-prone binding code. Unfortunately, for some deranged reason most of these were marked as functions taking `varargs` when they really had no reason to. I was under the impression that our existing function serialization code would handle `varargs` properly and either 1. serialize the types that were actually instantiated as the function argument types, or 2. at least mark the function as taking `varargs`. 

We do neither. functions with `varargs` are (in most cases) simply serialized as having zero parameters, which causes an error on the catalog lookup during deserialization when my fancy new type signatures actually specify their parameters.

To remedy this, we now check during deserialization if the function we're trying to deserialize have 0 parameters, but somehow have expressions passed into it anyway. If thats the case we assume it must be a varargs function. We then derive the types from the arguments when looking up the function in the catalog.

I've also added a cast rule that allows implicit casts from `ANY` to `TEMPLATE`. This should also only happen during function deserialization between different versions of DuckDB.

Closes https://github.com/duckdblabs/duckdb-internal/issues/5581