### PR TITLE
[Fix] Hidden test failure in test_struct_update.test

### DIFF
--- a/test/sql/function/nested/test_struct_update.test
+++ b/test/sql/function/nested/test_struct_update.test
@@ -93,9 +93,9 @@ SELECT struct_update(col, i:=col.i+1) FROM tbl;
 query I
 SELECT struct_update(col, i:='i='||col.i) FROM tbl;
 ----
-{'i': i=0}
-{'i': i=1}
-{'i': i=2}
+{'i': 'i=0'}
+{'i': 'i=1'}
+{'i': 'i=2'}
 
 # Test inserting NULL as the default value.
 query I


### PR DESCRIPTION
Introduced when merging https://github.com/duckdb/duckdb/pull/15533.

If I understand correctly, we added quoted outputting of strings in the test runner, which was not in back then?