### PR TITLE
[Test] Fix test case and a benchmark

### DIFF
--- a/benchmark/micro/cast/cast_varcharmap_string.benchmark
+++ b/benchmark/micro/cast/cast_varcharmap_string.benchmark
@@ -15,4 +15,4 @@ run
 SELECT MIN(CAST(m AS VARCHAR)) FROM maps;
 
 result I
-{simple=red, needs space='  needs quotes  ', 'has,comma'='no,escape needed', 'null'=NULL, has:colon='null', quoted='contains\'quote'}
+{simple=red, needs space='  needs quotes  ', 'has,comma'='no,escape needed', 'null'=NULL, 'has:colon'='null', quoted='contains\'quote'}

--- a/test/sql/function/nested/test_struct_update.test
+++ b/test/sql/function/nested/test_struct_update.test
@@ -93,9 +93,9 @@ SELECT struct_update(col, i:=col.i+1) FROM tbl;
 query I
 SELECT struct_update(col, i:='i='||col.i) FROM tbl;
 ----
-{'i': i=0}
-{'i': i=1}
-{'i': i=2}
+{'i': 'i=0'}
+{'i': 'i=1'}
+{'i': 'i=2'}
 
 # Test inserting NULL as the default value.
 query I


### PR DESCRIPTION
This small PR adds missing quotes to the benchmark and test files:
- benchmark/micro/cast/cast_varcharmap_string.benchmark
- test/sql/function/nested/test_struct_update.test

Should fix problem `INCORRECT` result for the [benchmark](https://github.com/hmeriann/nbc/actions/runs/16804820256/job/47594449948#step:5:947) and a similar problem in the [unittest](https://github.com/duckdb/duckdb/actions/runs/16952814501/job/48049012751#step:8:4876) (affected workflows - `InvokeCI`, `Main`, `NightlyTests`)