### PR TITLE
Update estimated cardinality if Hive filters applied for better plan.

### DIFF
--- a/src/common/multi_file/multi_file_function.cpp
+++ b/src/common/multi_file/multi_file_function.cpp
@@ -29,6 +29,9 @@ shared_ptr<BaseFileReader> MultiFileReaderInterface::CreateReader(ClientContext 
 void MultiFileReaderInterface::GetBindInfo(const TableFunctionData &bind_data, BindInfo &info) {
 }
 
+void MultiFileReaderInterface::ResetCardinality(MultiFileBindData &multi_file_data) {
+}
+
 void MultiFileReaderInterface::GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data,
                                                  virtual_column_map_t &result) {
 }

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -180,6 +180,8 @@ public:
 	                           const LogicalType &type, MultiFileLocalIndex local_index,
 	                           optional_ptr<MultiFileColumnDefinition> &global_column_reference);
 
+	void UpdateCardinalityEstimate(ClientContext &context, MultiFileBindData &bind_data, MultiFileList &files);
+
 	DUCKDB_API virtual unique_ptr<MultiFileReader> Copy() const;
 
 protected:

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -75,14 +75,19 @@ struct MultiFileBindData : public TableFunctionData {
 	//! Table column names - set when using COPY tbl FROM file.parquet
 	vector<string> table_columns;
 	shared_ptr<BaseFileReader> initial_reader;
+	shared_ptr<BaseFileReader> filtered_reader;
 	// The union readers are created (when the union_by_name option is on) during binding
 	vector<shared_ptr<BaseUnionData>> union_readers;
 
 	void Initialize(shared_ptr<BaseFileReader> reader) {
 		initial_reader = std::move(reader);
+		filtered_reader = nullptr;
 	}
 	void Initialize(ClientContext &, BaseUnionData &union_data) {
 		Initialize(std::move(union_data.reader));
+	}
+	void SetFilteredReader(shared_ptr<BaseFileReader> reader) {
+		filtered_reader = std::move(reader);
 	}
 	bool SupportStatementCache() const override {
 		return false;

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -34,6 +34,8 @@ class TableFunctionSet;
 class TableFunction;
 class SimpleFunction;
 
+class BaseFileReaderOptions;
+
 struct PragmaInfo;
 
 //! The default null handling is NULL in, NULL out
@@ -88,6 +90,10 @@ struct TableFunctionData : public FunctionData {
 
 	DUCKDB_API unique_ptr<FunctionData> Copy() const override;
 	DUCKDB_API bool Equals(const FunctionData &other) const override;
+
+	DUCKDB_API virtual shared_ptr<BaseFileReaderOptions> GetFileReaderOptions() {
+		return nullptr;
+	};
 };
 
 struct FunctionParameters {


### PR DESCRIPTION
(NOTE: running into issue running clang-tidy locally, so relying on CI server to figure out issues. Have filed issue #18613 meanwhile.)

Currently cardinality estimates for MultiFileReader do not get updated after Hive filtering, which can lead to suboptimal query plans such as picking a suboptimal side for JOIN hashing. This change detects if Hive filters were applied in filter pushdown, and if so samples 1 file from the post-filtered dataset to get better estimates, similar to what's done with the initial reader today.

I think this change might better be done in other classes which I could use help in figuring out, but I wanted to show the gains first. In the JOIN example below, we see ~18% improvement in total query time. The more skewed Hive partitions are, the more exaggerated this becomes.

Below are comparisons between main/HEAD before, and this branch after.

## Basic Projection

Before:

```
$ ./build/release/duckdb

-- Loading resources from /Users/xevix/.duckdbrc
DuckDB v1.4.0-dev2883 (Development Version) 4211521582
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D EXPLAIN FROM read_parquet('/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet') WHERE year = 2024 AND element = 'TMAX';

┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│         PROJECTION        │
│    ────────────────────   │
│             ID            │
│            DATE           │
│         DATA_VALUE        │
│  CAST(M_FLAG AS INTEGER)  │
│           Q_FLAG          │
│           S_FLAG          │
│ CAST(OBS_TIME AS INTEGER) │
│          ELEMENT          │
│            YEAR           │
│                           │
│        ~18224 Rows        │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│       READ_PARQUET        │
│    ────────────────────   │
│         Function:         │
│        READ_PARQUET       │
│                           │
│        Projections:       │
│            YEAR           │
│          ELEMENT          │
│             ID            │
│            DATE           │
│         DATA_VALUE        │
│           M_FLAG          │
│           Q_FLAG          │
│           S_FLAG          │
│          OBS_TIME         │
│                           │
│       File Filters:       │
│  (YEAR = 2024)(ELEMENT =  │
│          'TMAX')          │
│                           │
│      Scanning Files:      │
│          8/13593          │
│                           │
│        ~18224 Rows        │
└───────────────────────────┘
```

After:

```
$ ./build/release/duckdb

-- Loading resources from /Users/xevix/.duckdbrc
DuckDB v1.4.0-dev2884 (Development Version) 88389d956b
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D EXPLAIN FROM read_parquet('/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet') WHERE year = 2024 AND element = 'TMAX';

┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│         PROJECTION        │
│    ────────────────────   │
│             ID            │
│            DATE           │
│         DATA_VALUE        │
│  CAST(M_FLAG AS INTEGER)  │
│           Q_FLAG          │
│           S_FLAG          │
│ CAST(OBS_TIME AS INTEGER) │
│          ELEMENT          │
│            YEAR           │
│                           │
│      ~4,000,000 rows      │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│       READ_PARQUET        │
│    ────────────────────   │
│         Function:         │
│        READ_PARQUET       │
│                           │
│        Projections:       │
│            YEAR           │
│          ELEMENT          │
│             ID            │
│            DATE           │
│         DATA_VALUE        │
│           M_FLAG          │
│           Q_FLAG          │
│           S_FLAG          │
│          OBS_TIME         │
│                           │
│       File Filters:       │
│  (YEAR = 2024)(ELEMENT =  │
│          'TMAX')          │
│                           │
│      Scanning Files:      │
│          8/13593          │
│                           │
│      ~4,000,000 rows      │
└───────────────────────────┘
```

## JOIN performance

Before:

```
D EXPLAIN ANALYZE SELECT 
          w.ID AS station_id,
          st.name AS station_name,
          c.name AS country_name,
          states.name AS state_name
      FROM read_parquet('/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet') w
      LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-stations.parquet') st
          ON w.ID = st.id
      LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-countries.parquet') c
          ON SUBSTRING(w.ID, 1, 2) = c.code
      LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-states.parquet') states
          ON st.state = states.code
      WHERE 
          year = 2024
          AND element = 'TMAX';
┌─────────────────────────────────────┐
│┌───────────────────────────────────┐│
││    Query Profiling Information    ││
│└───────────────────────────────────┘│
└─────────────────────────────────────┘
EXPLAIN ANALYZE SELECT          w.ID AS station_id,         st.name AS station_name,         c.name AS country_name,         states.name AS state_name     FROM read_parquet('/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet') w     LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-stations.parquet') st         ON w.ID = st.id     LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-countries.parquet') c         ON SUBSTRING(w.ID, 1, 2) = c.code     LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-states.parquet') states         ON st.state = states.code     WHERE          year = 2024         AND element = 'TMAX';
┌────────────────────────────────────────────────┐
│┌──────────────────────────────────────────────┐│
││              Total Time: 0.409s              ││
│└──────────────────────────────────────────────┘│
└────────────────────────────────────────────────┘
┌───────────────────────────┐
│           QUERY           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│      EXPLAIN_ANALYZE      │
│    ────────────────────   │
│           0 rows          │
│          (0.00s)          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│         station_id        │
│        station_name       │
│        country_name       │
│         state_name        │
│                           │
│       3,633,379 rows      │
│          (0.00s)          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         HASH_JOIN         │
│    ────────────────────   │
│      Join Type: LEFT      │
│                           │
│        Conditions:        ├────────────────────────────────────────────────────────────────────────┐
│        state = code       │                                                                        │
│                           │                                                                        │
│       3,633,379 rows      │                                                                        │
│          (0.01s)          │                                                                        │
└─────────────┬─────────────┘                                                                        │
┌─────────────┴─────────────┐                                                          ┌─────────────┴─────────────┐
│         HASH_JOIN         │                                                          │         TABLE_SCAN        │
│    ────────────────────   │                                                          │    ────────────────────   │
│      Join Type: LEFT      │                                                          │         Function:         │
│                           │                                                          │        READ_PARQUET       │
│        Conditions:        │                                                          │                           │
│  "substring"(ID, 1, 2) =  │                                                          │        Projections:       │
│            code           ├───────────────────────────────────────────┐              │            code           │
│                           │                                           │              │            name           │
│                           │                                           │              │                           │
│                           │                                           │              │    Total Files Read: 1    │
│                           │                                           │              │                           │
│       3,633,379 rows      │                                           │              │          74 rows          │
│          (0.04s)          │                                           │              │          (0.00s)          │
└─────────────┬─────────────┘                                           │              └───────────────────────────┘
┌─────────────┴─────────────┐                             ┌─────────────┴─────────────┐
│         HASH_JOIN         │                             │         TABLE_SCAN        │
│    ────────────────────   │                             │    ────────────────────   │
│      Join Type: RIGHT     │                             │         Function:         │
│    Conditions: id = ID    │                             │        READ_PARQUET       │
│                           │                             │                           │
│                           │                             │        Projections:       │
│                           ├──────────────┐              │            code           │
│                           │              │              │            name           │
│                           │              │              │                           │
│                           │              │              │    Total Files Read: 1    │
│                           │              │              │                           │
│       3,633,379 rows      │              │              │          219 rows         │
│          (0.20s)          │              │              │          (0.00s)          │
└─────────────┬─────────────┘              │              └───────────────────────────┘
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         TABLE_SCAN        ││         TABLE_SCAN        │
│    ────────────────────   ││    ────────────────────   │
│         Function:         ││         Function:         │
│        READ_PARQUET       ││        READ_PARQUET       │
│                           ││                           │
│        Projections:       ││      Projections: ID      │
│             id            ││                           │
│           state           ││       File Filters:       │
│            name           ││  (YEAR = 2024)(ELEMENT =  │
│                           ││          'TMAX')          │
│    Total Files Read: 1    ││                           │
│                           ││      Scanning Files:      │
│                           ││          8/13593          │
│                           ││                           │
│                           ││    Total Files Read: 8    │
│                           ││                           │
│        129,652 rows       ││       3,633,379 rows      │
│          (0.00s)          ││          (0.01s)          │
└───────────────────────────┘└───────────────────────────┘
```

After:

```
D EXPLAIN ANALYZE SELECT 
          w.ID AS station_id,
          st.name AS station_name,
          c.name AS country_name,
          states.name AS state_name
      FROM read_parquet('/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet') w
      LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-stations.parquet') st
          ON w.ID = st.id
      LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-countries.parquet') c
          ON SUBSTRING(w.ID, 1, 2) = c.code
      LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-states.parquet') states
          ON st.state = states.code
      WHERE 
          year = 2024
          AND element = 'TMAX';
┌─────────────────────────────────────┐
│┌───────────────────────────────────┐│
││    Query Profiling Information    ││
│└───────────────────────────────────┘│
└─────────────────────────────────────┘
EXPLAIN ANALYZE SELECT          w.ID AS station_id,         st.name AS station_name,         c.name AS country_name,         states.name AS state_name     FROM read_parquet('/Users/xevix/Downloads/data/noaa/by_year/**/*.parquet') w     LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-stations.parquet') st         ON w.ID = st.id     LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-countries.parquet') c         ON SUBSTRING(w.ID, 1, 2) = c.code     LEFT JOIN read_parquet('/Users/xevix/internal/noaa-d3/data/ghcnd-states.parquet') states         ON st.state = states.code     WHERE          year = 2024         AND element = 'TMAX';
┌────────────────────────────────────────────────┐
│┌──────────────────────────────────────────────┐│
││              Total Time: 0.332s              ││
│└──────────────────────────────────────────────┘│
└────────────────────────────────────────────────┘
┌───────────────────────────┐
│           QUERY           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│      EXPLAIN_ANALYZE      │
│    ────────────────────   │
│           0 rows          │
│          (0.00s)          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         HASH_JOIN         │
│    ────────────────────   │
│      Join Type: LEFT      │
│                           │
│        Conditions:        ├────────────────────────────────────────────────────────────────────────┐
│        state = code       │                                                                        │
│                           │                                                                        │
│       3,633,379 rows      │                                                                        │
│          (0.02s)          │                                                                        │
└─────────────┬─────────────┘                                                                        │
┌─────────────┴─────────────┐                                                          ┌─────────────┴─────────────┐
│         HASH_JOIN         │                                                          │         TABLE_SCAN        │
│    ────────────────────   │                                                          │    ────────────────────   │
│      Join Type: LEFT      │                                                          │         Function:         │
│                           │                                                          │        READ_PARQUET       │
│        Conditions:        │                                                          │                           │
│  "substring"(ID, 1, 2) =  │                                                          │        Projections:       │
│            code           ├───────────────────────────────────────────┐              │            code           │
│                           │                                           │              │            name           │
│                           │                                           │              │                           │
│                           │                                           │              │    Total Files Read: 1    │
│                           │                                           │              │                           │
│       3,633,379 rows      │                                           │              │          74 rows          │
│          (0.02s)          │                                           │              │          (0.00s)          │
└─────────────┬─────────────┘                                           │              └───────────────────────────┘
┌─────────────┴─────────────┐                             ┌─────────────┴─────────────┐
│         HASH_JOIN         │                             │         TABLE_SCAN        │
│    ────────────────────   │                             │    ────────────────────   │
│      Join Type: LEFT      │                             │         Function:         │
│    Conditions: ID = id    │                             │        READ_PARQUET       │
│                           │                             │                           │
│                           │                             │        Projections:       │
│                           ├──────────────┐              │            code           │
│                           │              │              │            name           │
│                           │              │              │                           │
│                           │              │              │    Total Files Read: 1    │
│                           │              │              │                           │
│       3,633,379 rows      │              │              │          219 rows         │
│          (0.04s)          │              │              │          (0.00s)          │
└─────────────┬─────────────┘              │              └───────────────────────────┘
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         TABLE_SCAN        ││         TABLE_SCAN        │
│    ────────────────────   ││    ────────────────────   │
│         Function:         ││         Function:         │
│        READ_PARQUET       ││        READ_PARQUET       │
│                           ││                           │
│      Projections: ID      ││        Projections:       │
│                           ││             id            │
│       File Filters:       ││           state           │
│  (YEAR = 2024)(ELEMENT =  ││            name           │
│          'TMAX')          ││                           │
│                           ││    Total Files Read: 1    │
│      Scanning Files:      ││                           │
│          8/13593          ││                           │
│                           ││                           │
│    Total Files Read: 8    ││                           │
│                           ││                           │
│       3,633,379 rows      ││        129,657 rows       │
│          (0.01s)          ││          (0.00s)          │
└───────────────────────────┘└───────────────────────────┘
```