### PR TITLE
Fix the issue where delta_for isn't used in bitpacking when for is unavailable

### DIFF
--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -257,7 +257,7 @@ public:
 			    BitpackingPrimitives::MinimumBitWidth<T, false>(static_cast<T>(min_max_delta_diff));
 			auto regular_required_bitwidth = BitpackingPrimitives::MinimumBitWidth(min_max_diff);
 
-			if (delta_required_bitwidth < regular_required_bitwidth && mode != BitpackingMode::FOR) {
+			if ((!can_do_for || delta_required_bitwidth < regular_required_bitwidth) && mode != BitpackingMode::FOR) {
 				SubtractFrameOfReference(delta_buffer, minimum_delta);
 
 				OP::WriteDeltaFor(reinterpret_cast<T *>(delta_buffer), compression_buffer_validity,

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -257,7 +257,10 @@ public:
 			    BitpackingPrimitives::MinimumBitWidth<T, false>(static_cast<T>(min_max_delta_diff));
 			auto regular_required_bitwidth = BitpackingPrimitives::MinimumBitWidth(min_max_diff);
 
-			if ((!can_do_for || delta_required_bitwidth < regular_required_bitwidth) && mode != BitpackingMode::FOR) {
+			//! `min_max_diff` is uninitialized if `can_do_for` isn't true
+			bool prefer_for = can_do_for && delta_required_bitwidth >= regular_required_bitwidth;
+
+			if (!prefer_for && mode != BitpackingMode::FOR) {
 				SubtractFrameOfReference(delta_buffer, minimum_delta);
 
 				OP::WriteDeltaFor(reinterpret_cast<T *>(delta_buffer), compression_buffer_validity,

--- a/test/sql/storage/compression/bitpacking/bitpacking_delta_for.test
+++ b/test/sql/storage/compression/bitpacking/bitpacking_delta_for.test
@@ -1,0 +1,26 @@
+# name: test/sql/storage/compression/bitpacking/bitpacking_delta_for.test
+# description: Test bitpacking delta for
+# group: [bitpacking]
+
+# This test defaults to another compression function for smaller block sizes,
+# because the bitpacking groups no longer fit the blocks.
+require block_size 262144
+
+load __TEST_DIR__/test_bitpacking.db
+
+statement ok
+PRAGMA force_compression='bitpacking'
+
+statement ok
+create table aux as select range::INT x from range(-2_000_000_000, 2_000_000_000, 2_000_000);
+
+statement ok
+create table tt as select (x + if (random() > 0.5, 1, -1)) x from aux;
+
+statement ok
+CHECKPOINT;
+
+query I
+select compression from pragma_storage_info('tt') where segment_type != 'VALIDITY';
+----
+BitPacking


### PR DESCRIPTION
`min_max_diff` has a default value of 0. So when `can_do_for` is false, `regular_required_bitwidth` will be 0, which makes delta_for also not used.