### PR TITLE
Add Field IDS to multi file reader for positional deletes

### DIFF
--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -37,6 +37,10 @@ public:
 	static constexpr int32_t ORDINAL_FIELD_ID = 2147483645;
 	// Reserved field id used for the "_pos" field according to the iceberg spec (used for file_row_number)
 	static constexpr int32_t FILENAME_FIELD_ID = 2147483646;
+	// Reserved field id used for the "file_path" field for iceberg positional deletes
+	static constexpr int32_t DELETE_FILE_PATH_FIELD_ID = 2147483546;
+	// Reserved field id used for the "pos" field for iceberg positional deletes
+	static constexpr int32_t DELETE_POS_FIELD_ID = 2147483545;
 	// Reserved field id used for the "_row_id" field according to the iceberg spec
 	static constexpr int32_t ROW_ID_FIELD_ID = 2147483540;
 	// Reserved field id used for the "_last_updated_sequence_number" field according to the iceberg spec


### PR DESCRIPTION
Reference https://iceberg.apache.org/spec/#reserved-field-ids

Needed for both DuckLake and DuckDB-Iceberg 
Will also help to close https://github.com/duckdb/ducklake/issues/378