### PR TITLE
Re-add `hugeint` to `__internal_compress_string`

### DIFF
--- a/src/function/scalar/compressed_materialization/compress_string.cpp
+++ b/src/function/scalar/compressed_materialization/compress_string.cpp
@@ -197,6 +197,8 @@ scalar_function_t GetStringDecompressFunctionSwitch(const LogicalType &input_typ
 		return GetStringDecompressFunction<uint64_t>(input_type);
 	case LogicalTypeId::UHUGEINT:
 		return GetStringDecompressFunction<uhugeint_t>(input_type);
+	case LogicalTypeId::HUGEINT:
+		return GetStringCompressFunction<hugeint_t>(input_type);
 	default:
 		throw InternalException("Unexpected type in GetStringDecompressFunctionSwitch");
 	}

--- a/src/function/scalar/compressed_materialization/compress_string.cpp
+++ b/src/function/scalar/compressed_materialization/compress_string.cpp
@@ -229,7 +229,10 @@ unique_ptr<FunctionData> CMStringDecompressDeserialize(Deserializer &deserialize
 
 ScalarFunctionSet GetStringDecompressFunctionSet() {
 	ScalarFunctionSet set(StringDecompressFunctionName());
-	for (const auto &input_type : CMUtils::StringTypes()) {
+	auto string_types = CMUtils::StringTypes();
+	// For backwards compatibility, see internal issue 5306
+	string_types.push_back(LogicalType::HUGEINT);
+	for (const auto &input_type : string_types) {
 		set.AddFunction(CMStringDecompressFun::GetFunction(input_type));
 	}
 	return set;

--- a/src/function/scalar/compressed_materialization_utils.cpp
+++ b/src/function/scalar/compressed_materialization_utils.cpp
@@ -8,7 +8,7 @@ const vector<LogicalType> CMUtils::IntegralTypes() {
 
 const vector<LogicalType> CMUtils::StringTypes() {
 	return {LogicalType::UTINYINT, LogicalType::USMALLINT, LogicalType::UINTEGER, LogicalType::UBIGINT,
-	         LogicalType::HUGEINT, LogicalType::UHUGEINT};
+	        LogicalType::UHUGEINT};
 }
 
 // LCOV_EXCL_START

--- a/src/function/scalar/compressed_materialization_utils.cpp
+++ b/src/function/scalar/compressed_materialization_utils.cpp
@@ -8,7 +8,7 @@ const vector<LogicalType> CMUtils::IntegralTypes() {
 
 const vector<LogicalType> CMUtils::StringTypes() {
 	return {LogicalType::UTINYINT, LogicalType::USMALLINT, LogicalType::UINTEGER, LogicalType::UBIGINT,
-	        LogicalType::UHUGEINT};
+	         LogicalType::HUGEINT, LogicalType::UHUGEINT};
 }
 
 // LCOV_EXCL_START


### PR DESCRIPTION
__internal_decompress_string stopped accepting HUGEINT in favor of UHUGEINT since v1.3.2. HUGEINT was [added back](https://github.com/duckdblabs/motherduck/issues/350) in for bwc for the compress counterpart, but not for decompress. This breaks bwc with older clients.