### PR TITLE
Python test runner: Fix hash comparison error output

### DIFF
--- a/scripts/sqllogictest/logger.py
+++ b/scripts/sqllogictest/logger.py
@@ -154,18 +154,18 @@ class SQLLogicTestLogger:
         print("Does the result contain tab values? In that case, place every value on a single row.")
         self.print_line_sep()
 
-    def wrong_result_hash(self, expected_result, result):
-        if expected_result:
-            expected_result.print()
-        else:
-            print("???")
-        self.print_error_header("Wrong result hash!")
+    def wrong_result_hash(self, expected_hash_value, hash_value):
+        self.print_error_header("Wrong result hash when comparing to previous query result!")
         self.print_line_sep()
         self.print_sql()
         self.print_line_sep()
-        self.print_header("Expected result:")
+        self.print_header("Expected hash value:")
         self.print_line_sep()
-        self.print_header("Actual result:")
+        print(expected_hash_value)
+        self.print_line_sep()
+        self.print_header("Actual hash value:")
+        self.print_line_sep()
+        print(hash_value)
         self.print_line_sep()
 
     def unexpected_statement(self, expect_ok, result):

--- a/scripts/sqllogictest/parser/parser.py
+++ b/scripts/sqllogictest/parser/parser.py
@@ -416,7 +416,7 @@ class SQLLogicParser:
         sleep_unit = get_sleep_unit(header.parameters[1])
         if sleep_unit == SleepUnit.UNKNOWN:
             options = ['second', 'millisecond', 'microsecond', 'nanosecond']
-            raise self.fail(f"Unrecognized sleep mode - expected {create_formatted_list(options)}")
+            self.fail(f"Unrecognized sleep mode - expected {create_formatted_list(options)}")
         return Sleep(header, self.current_line + 1, sleep_duration, sleep_unit)
 
     def statement_unzip(self, header: Token) -> Optional[BaseStatement]:

--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -319,21 +319,26 @@ class QueryResult:
                 context.fail("")
         else:
             hash_compare_error = False
+            expected_hash_value = None
             if query_has_label:
-                entry = runner.hash_label_map.get(query_label)
-                if entry is None:
+                expected_hash_value = runner.hash_label_map.get(query_label)
+                if expected_hash_value is None:
                     runner.hash_label_map[query_label] = hash_value
                     runner.result_label_map[query_label] = self
                 else:
-                    hash_compare_error = entry != hash_value
+                    hash_compare_error = expected_hash_value != hash_value
 
-            if is_hash:
+            if is_hash and not hash_compare_error:
+                expected_hash_value = values[0]
                 hash_compare_error = values[0] != hash_value
 
             if hash_compare_error:
                 expected_result = runner.result_label_map.get(query_label)
-                # logger.wrong_result_hash(expected_result, self)
-                context.fail(query)
+                logger.wrong_result_hash(expected_hash_value, hash_value)
+
+                if expected_result:
+                    logger.print_result_error(result_values_string, duck_db_convert_result(expected_result, runner.original_sqlite_test), expected_result.column_count, False)
+                context.fail("")
 
             assert not hash_compare_error
 

--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -337,7 +337,12 @@ class QueryResult:
                 logger.wrong_result_hash(expected_hash_value, hash_value)
 
                 if expected_result:
-                    logger.print_result_error(result_values_string, duck_db_convert_result(expected_result, runner.original_sqlite_test), expected_result.column_count, False)
+                    logger.print_result_error(
+                        result_values_string,
+                        duck_db_convert_result(expected_result, runner.original_sqlite_test),
+                        expected_result.column_count,
+                        False,
+                    )
                 context.fail("")
 
             assert not hash_compare_error


### PR DESCRIPTION
Fixes the test output for _timestamp_to_date_pushdown.test_ in the nightly Python SQLLogic tests and generally for tests that use hash result comparison. 

Right now it looks like this:
```
____ test_sqllogic[test/optimizer/pushdown/timestamp_to_date_pushdown.test] ____
<sqllogictest.statement.query.Query object at 0x7f2784fd7940>
```

With this PR, it looks like this:
```
Wrong result hash when comparing to previous query result! (/Users/florian/motherduck/duckdb/test/optimizer/pushdown/timestamp_to_date_pushdown.test:48)!
================================================================================
select * from t1 where ts::date == '2024-05-02';
================================================================================
Expected hash value:
================================================================================
4000 values hashing to df872686cb7f67a47a2ae55a435cdf2e
================================================================================
Actual hash value:
================================================================================
4000 values hashing to 65ffed7261da2ec804c5e625eb794cd5
================================================================================
Expected result:
================================================================================
2024-05-02 00:00:00	49
2024-05-02 00:00:00	50
2024-05-02 00:00:00	51
2024-05-02 00:00:00	52
2024-05-02 00:00:00	53
2024-05-02 00:00:00	54
...
================================================================================
Actual result:
================================================================================
2024-05-02 00:00:00	1
2024-05-02 00:00:00	2
2024-05-02 00:00:00	3
2024-05-02 00:00:00	4
2024-05-02 00:00:00	5
2024-05-02 00:00:00	6
2024-05-02 00:00:00	7
...
```