### PR TITLE
[CI] Temporarily skip triggering `R Package Windows (Extensions)` job

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -177,7 +177,7 @@ duckdb_extension_load(fts
 )
 
 ################# ENCODINGS
-if (NOT ${WASM_ENABLED} AND ${BUILD_COMPLETE_EXTENSION_SET})
+if (NOT MINGW AND NOT ${WASM_ENABLED} AND ${BUILD_COMPLETE_EXTENSION_SET})
 duckdb_extension_load(encodings
         LOAD_TESTS
         DONT_LINK

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -66,10 +66,10 @@ jobs:
   R:
     uses: ./.github/workflows/R.yml
     secrets: inherit
+    if: false
     with:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
 
   Wasm:
     uses: ./.github/workflows/Wasm.yml

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -66,7 +66,6 @@ jobs:
   R:
     uses: ./.github/workflows/R.yml
     secrets: inherit
-    if: false
     with:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -69,6 +69,7 @@ jobs:
     with:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
 
   Wasm:
     uses: ./.github/workflows/Wasm.yml


### PR DESCRIPTION
`[R / R Package Windows (Extensions)` job had been failing 3 times at row.
Every time GH Action states that it lost communication with the runner, failed the job, but it [keeps spinning](https://github.com/duckdb/duckdb/actions/runs/16980034919/job/48137921333).

I've opened an internal issue for this problem and think we should just skip triggering the job for now.

At the same time we don't have `[R / R Package Windows (Extensions)` job anymore in `main`. If we don't need it in `v1.3-ossivalis` maybe we should just back port those changes from `main`