### PR TITLE
Issue #18631: Streaming Windowed Quantile

### DIFF
--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -349,6 +349,10 @@ bool PhysicalStreamingWindow::IsStreamingFunction(ClientContext &context, unique
 	switch (wexpr.GetExpressionType()) {
 	// TODO: add more expression types here?
 	case ExpressionType::WINDOW_AGGREGATE:
+		// Aggregates with destructors (e.g., quantile) are too slow to repeatedly update/finalize
+		if (wexpr.aggregate->destructor) {
+			return false;
+		}
 		// We can stream aggregates if they are "running totals"
 		return wexpr.start == WindowBoundary::UNBOUNDED_PRECEDING && wexpr.end == WindowBoundary::CURRENT_ROW_ROWS;
 	case ExpressionType::WINDOW_FIRST_VALUE:


### PR DESCRIPTION
* Don't stream aggregates with destructors.

fixes: duckdb#18631
fixes: duckdblabs/duckdb-internal#5620