### PR TITLE
DuckDB converts pd.NA to the string literal '<NA>' #18530

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pandas/pandas_bind.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pandas/pandas_bind.hpp
@@ -24,6 +24,8 @@ struct PandasColumnBindData {
 	string internal_categorical_type;
 	//! Hold ownership of objects created during scanning
 	PythonObjectContainer object_str_val;
+	py::object pandas_na;
+	py::object pandas_nat;
 };
 
 struct Pandas {

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -340,7 +340,7 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 		// Get the data pointer and the validity mask of the result vector
 		auto tgt_ptr = FlatVector::GetData<string_t>(out);
 		auto &out_mask = FlatVector::Validity(out);
-		
+
 		// Get GIL before we call python
 		PythonGILWrapper gil;
 		auto &import_cache = *DuckDBPyConnection::ImportCache();
@@ -367,7 +367,7 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 					out_mask.SetInvalid(row);
 					continue;
 				}
-				
+
 				// Check if this is pandas.NaT
 				if (naT_singleton && py::handle(val).is(naT_singleton)) {
 					out_mask.SetInvalid(row);

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -343,17 +343,10 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 
 		// Get GIL before we call python
 		PythonGILWrapper gil;
-		auto &import_cache = *DuckDBPyConnection::ImportCache();
-		py::handle na_singleton, naT_singleton;
 
-		// Load pandas NA and NaT for identity checks
-		if (import_cache.pandas.NA(true)) {
-			na_singleton = import_cache.pandas.NA();
-		}
-
-		if (import_cache.pandas.NaT(true)) {
-			naT_singleton = import_cache.pandas.NaT();
-		}
+		// Reference the pandas.na and pandas.naT
+		py::handle na_singleton = bind_data.pandas_na;
+		py::handle nat_singleton = bind_data.pandas_nat;
 
 		// Loop over every row of the arrays contents
 		auto stride = numpy_col.stride;
@@ -369,7 +362,7 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 				}
 
 				// Check if this is pandas.NaT
-				if (naT_singleton && py::handle(val).is(naT_singleton)) {
+				if (nat_singleton && py::handle(val).is(nat_singleton)) {
 					out_mask.SetInvalid(row);
 					continue;
 				}

--- a/tools/pythonpkg/src/pandas/bind.cpp
+++ b/tools/pythonpkg/src/pandas/bind.cpp
@@ -1,3 +1,4 @@
+#include "duckdb_python/pyconnection/pyconnection.hpp"
 #include "duckdb_python/pandas/pandas_bind.hpp"
 #include "duckdb_python/pandas/pandas_analyzer.hpp"
 #include "duckdb_python/pandas/column/pandas_numpy_column.hpp"

--- a/tools/pythonpkg/src/pandas/bind.cpp
+++ b/tools/pythonpkg/src/pandas/bind.cpp
@@ -119,7 +119,7 @@ void Pandas::Bind(const ClientContext &context, py::handle df_p, vector<PandasCo
 
 	PythonGILWrapper gil;
 	auto &cache = *DuckDBPyConnection::ImportCache();
-	
+
 	py::object pandas_na, pandas_nat;
 	if (cache.pandas.NA(true)) {
 		pandas_na = py::reinterpret_borrow<py::object>(cache.pandas.NA());
@@ -140,7 +140,7 @@ void Pandas::Bind(const ClientContext &context, py::handle df_p, vector<PandasCo
 	for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
 		PandasColumnBindData bind_data;
 
-		bind_data.pandas_na  = pandas_na;
+		bind_data.pandas_na = pandas_na;
 		bind_data.pandas_nat = pandas_nat;
 
 		names.emplace_back(py::str(df.names[col_idx]));


### PR DESCRIPTION
### Context
When scanning Pandas DataFrames backed not backed through the arrow path, Values such as `pd.NA` or `pd.NaT` were not recognized as NULLs unless `pandas` had already been imported into the import cache. This caused incorrect results (e.g., `pd.NA` being read as a string instead of NULL).

### Changes
- Explicitly load `pandas.NA` and `pandas.NaT` singletons during object column scan when no mask is present.
- Perform identity checks against these values inside the scan loop to correctly mark rows as invalid.
- Ensures consistent NULL detection across all Pandas object dtype Series, independent of mask presence.

### Testing
- Verified test case with Pandas DataFrame containing `pd.NA` in an object column.
- Confirmed rows with `pd.NA` are marked NULL in DuckDB result instead of being returned as strings.

Fixes #18530 

---
