### PR TITLE
feat: enhance .tables command with schema disambiguation and filtering

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4042,7 +4042,7 @@ MetadataResult ShellState::DisplayEntries(const char **azArg, idx_t nArg, char t
 	string filter_pattern = nArg > 1 ? azArg[1] : "%";
 	string schema_filter = "";
 	string table_filter = filter_pattern;
-	
+
 	// Check if the filter is schema-qualified (e.g., "schema.table" or "schema.%")
 	size_t dot_pos = filter_pattern.find('.');
 	if (dot_pos != string::npos) {
@@ -4107,7 +4107,7 @@ MetadataResult ShellState::DisplayEntries(const char **azArg, idx_t nArg, char t
 	** as an array of nul-terminated strings in azResult[].  */
 	nRow = nAlloc = 0;
 	azResult = nullptr;
-	
+
 	if (type == 't') {
 		// Bind parameters for the new DuckDB query
 		if (!schema_filter.empty()) {
@@ -4124,7 +4124,7 @@ MetadataResult ShellState::DisplayEntries(const char **azArg, idx_t nArg, char t
 			sqlite3_bind_text(pStmt, 1, "%", -1, SQLITE_STATIC);
 		}
 	}
-	
+
 	while (sqlite3_step(pStmt) == SQLITE_ROW) {
 		if (nRow >= nAlloc) {
 			char **azNew;

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -1122,4 +1122,15 @@ def test_shell_csv_file(shell):
     result = test.run()
     result.check_stdout("2008-08-10")
 
+def test_tables_invalid_pattern_handling(shell):
+    test = (
+        ShellTest(shell)
+        .statement("CREATE TABLE test_table(i INTEGER);")
+        .statement(".tables \"invalid\"pattern\"")
+    )
+    result = test.run()
+    # Should show usage message for invalid pattern
+    result.check_stderr("Usage: .tables ?TABLE?")
+
+
 # fmt: on

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -422,6 +422,56 @@ def test_tables_pattern(shell):
     result = test.run()
     result.check_stdout("asda  csda")
 
+def test_tables_schema_disambiguation(shell):
+    test = (
+        ShellTest(shell)
+        .statement("CREATE SCHEMA a;")
+        .statement("CREATE SCHEMA b;")
+        .statement("CREATE TABLE a.foobar(name VARCHAR);")
+        .statement("CREATE TABLE b.foobar(name VARCHAR);")
+        .statement(".tables")
+    )
+    result = test.run()
+    result.check_stdout("a.foobar  b.foobar")
+
+def test_tables_schema_filtering(shell):
+    test = (
+        ShellTest(shell)
+        .statement("CREATE SCHEMA a;")
+        .statement("CREATE SCHEMA b;")
+        .statement("CREATE TABLE a.foobar(name VARCHAR);")
+        .statement("CREATE TABLE b.foobar(name VARCHAR);")
+        .statement("CREATE TABLE a.unique_table(x INTEGER);")
+        .statement("CREATE TABLE b.other_table(y INTEGER);")
+        .statement(".tables a.%")
+    )
+    result = test.run()
+    result.check_stdout("foobar        unique_table")
+
+def test_tables_backward_compatibility(shell):
+    test = (
+        ShellTest(shell)
+        .statement("CREATE TABLE main_table(i INTEGER);")
+        .statement("CREATE TABLE unique_table(x INTEGER);")
+        .statement(".tables")
+    )
+    result = test.run()
+    result.check_stdout("main_table    unique_table")
+
+def test_tables_with_views(shell):
+    test = (
+        ShellTest(shell)
+        .statement("CREATE SCHEMA a;")
+        .statement("CREATE SCHEMA b;")
+        .statement("CREATE TABLE a.foobar(name VARCHAR);")
+        .statement("CREATE TABLE b.foobar(name VARCHAR);")
+        .statement("CREATE VIEW a.test_view AS SELECT 1 AS x;")
+        .statement("CREATE VIEW b.test_view AS SELECT 2 AS y;")
+        .statement(".tables")
+    )
+    result = test.run()
+    result.check_stdout("a.foobar     a.test_view  b.foobar     b.test_view")
+
 def test_indexes(shell):
     test = (
         ShellTest(shell)


### PR DESCRIPTION
### Description
The `.tables` command shows confusing output when tables have the same name in different schemas - it just displays the table name twice without indicating which schema each belongs to.

### What I Did
I modified the `.tables` command in `tools/shell/shell.cpp` to:

1. **Use DuckDB's system tables** instead of SQLite's `sqlite_schema` to get schema information
2. **Detect name conflicts** - when the same table name exists in multiple schemas, show `schema.table` format
3. **Add schema filtering** - support patterns like `.tables a.%` to filter by schema
4. **Keep backward compatibility** - when no conflicts exist, show simple table names as before

### How I Tested
- **Built and tested manually** - verified the feature works with the exact scenario from the issue
- **Added comprehensive tests** in `tools/shell/tests/test_shell_basics.py` covering:
  - Schema disambiguation (core feature)
  - Schema filtering (new capability) 
  - Backward compatibility (existing behavior preserved)
  - Views support (tables + views)
- **Ran all tests** - both new and existing tests pass 
- **Tested edge cases** - mixed schemas, pattern filtering, etc.

Fixes #13603