### PR TITLE
CLI: Make ETA more of an estimate, and support large_row_rendering for footers

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -902,19 +902,11 @@ void BoxRenderer::RenderValues(const list<ColumnDataCollection> &collections, co
 	}
 }
 
-void BoxRenderer::RenderRowCount(string row_count_str, string shown_str, const string &column_count_str,
-                                 const vector<idx_t> &boundaries, bool has_hidden_rows, bool has_hidden_columns,
-                                 idx_t total_length, idx_t row_count, idx_t column_count, idx_t minimum_row_length,
-                                 BaseResultRenderer &ss) {
-	// check if we can merge the row_count_str and the shown_str
-	bool display_shown_separately = has_hidden_rows;
-	if (has_hidden_rows && total_length >= row_count_str.size() + shown_str.size() + 5) {
-		// we can!
-		row_count_str += " " + shown_str;
-		shown_str = string();
-		display_shown_separately = false;
-		minimum_row_length = row_count_str.size() + 4;
-	}
+void BoxRenderer::RenderRowCount(string &row_count_str, string &readable_rows_str, string &shown_str,
+                                 const string &column_count_str, const vector<idx_t> &boundaries, bool has_hidden_rows,
+                                 bool has_hidden_columns, idx_t total_length, idx_t row_count, idx_t column_count,
+                                 idx_t minimum_row_length, BaseResultRenderer &ss) {
+	// check if we can merge the row_count_str, readable_rows_str and the shown_str
 	auto minimum_length = row_count_str.size() + column_count_str.size() + 6;
 	bool render_rows_and_columns = total_length >= minimum_length &&
 	                               ((has_hidden_columns && row_count > 0) || (row_count >= 10 && column_count > 1));
@@ -941,23 +933,75 @@ void BoxRenderer::RenderRowCount(string row_count_str, string shown_str, const s
 	if (!render_anything) {
 		return;
 	}
-
+	idx_t padding = total_length - row_count_str.size() - 4;
 	if (render_rows_and_columns) {
-		ss << config.VERTICAL;
-		ss << " ";
-		ss.Render(ResultRenderType::FOOTER, row_count_str);
-		ss << string(total_length - row_count_str.size() - column_count_str.size() - 4, ' ');
-		ss.Render(ResultRenderType::FOOTER, column_count_str);
-		ss << " ";
-		ss << config.VERTICAL;
-		ss << '\n';
-	} else if (render_rows) {
-		RenderValue(ss, row_count_str, total_length - 4, ResultRenderType::FOOTER);
-		ss << config.VERTICAL;
-		ss << '\n';
+		padding -= column_count_str.size();
+	}
+	string extra_render_str;
+	// do we have to space to render the minimum_row_length and the shown string on the same row?
+	idx_t shown_size = readable_rows_str.size() + shown_str.size() + (readable_rows_str.empty() ? 3 : 5);
+	if (has_hidden_rows && padding >= shown_size) {
+		// we have space - render it here
+		extra_render_str = " (";
+		if (!readable_rows_str.empty()) {
+			extra_render_str += readable_rows_str + ", ";
+		}
+		extra_render_str += shown_str;
+		extra_render_str += ")";
+		D_ASSERT(extra_render_str.size() == shown_size);
+		padding -= shown_size;
+		readable_rows_str = string();
+		shown_str = string();
+	}
 
-		if (display_shown_separately) {
-			RenderValue(ss, shown_str, total_length - 4, ResultRenderType::FOOTER);
+	ss << config.VERTICAL;
+	ss << " ";
+	if (render_rows_and_columns) {
+		ss.Render(ResultRenderType::FOOTER, row_count_str);
+		if (!extra_render_str.empty()) {
+			ss.Render(ResultRenderType::NULL_VALUE, extra_render_str);
+		}
+		ss << string(padding, ' ');
+		ss.Render(ResultRenderType::FOOTER, column_count_str);
+	} else if (render_rows) {
+		idx_t lpadding = padding / 2;
+		idx_t rpadding = padding - lpadding;
+		ss << string(lpadding, ' ');
+		ss.Render(ResultRenderType::FOOTER, row_count_str);
+		if (!extra_render_str.empty()) {
+			ss.Render(ResultRenderType::NULL_VALUE, extra_render_str);
+		}
+		ss << string(rpadding, ' ');
+	}
+	ss << " ";
+	ss << config.VERTICAL;
+	ss << '\n';
+	if (!readable_rows_str.empty() || !shown_str.empty()) {
+		// we still need to render the readable rows/shown strings
+		// check if we can merge the two onto one row
+		idx_t combined_shown_length = readable_rows_str.size() + shown_str.size() + 4;
+		if (combined_shown_length <= total_length) {
+			// we can! merge them
+			ss << config.VERTICAL;
+			ss << " ";
+			ss.Render(ResultRenderType::NULL_VALUE, readable_rows_str);
+			ss << string(total_length - combined_shown_length, ' ');
+			ss.Render(ResultRenderType::NULL_VALUE, shown_str);
+			ss << " ";
+			ss << config.VERTICAL;
+			ss << '\n';
+			readable_rows_str = string();
+			shown_str = string();
+		}
+		ValueRenderAlignment alignment =
+		    render_rows_and_columns ? ValueRenderAlignment::LEFT : ValueRenderAlignment::MIDDLE;
+		if (!readable_rows_str.empty()) {
+			RenderValue(ss, "(" + readable_rows_str + ")", total_length - 4, ResultRenderType::NULL_VALUE, alignment);
+			ss << config.VERTICAL;
+			ss << '\n';
+		}
+		if (!shown_str.empty()) {
+			RenderValue(ss, "(" + shown_str + ")", total_length - 4, ResultRenderType::NULL_VALUE, alignment);
 			ss << config.VERTICAL;
 			ss << '\n';
 		}
@@ -1011,16 +1055,23 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 	if (has_limited_rows) {
 		row_count_str = "? rows";
 	}
+	string readable_rows_str;
+	if (config.large_number_rendering == LargeNumberRendering::FOOTER && !has_limited_rows) {
+		readable_rows_str = TryFormatLargeNumber(to_string(row_count));
+		if (!readable_rows_str.empty()) {
+			readable_rows_str += " rows";
+		}
+	}
 	string shown_str;
 	bool has_hidden_rows = top_rows < row_count;
 	if (has_hidden_rows) {
-		shown_str = "(";
 		if (has_limited_rows) {
 			shown_str += ">" + FormatNumber(to_string(config.limit - 1)) + " rows, ";
 		}
-		shown_str += FormatNumber(to_string(top_rows + bottom_rows)) + " shown)";
+		shown_str += FormatNumber(to_string(top_rows + bottom_rows)) + " shown";
 	}
-	auto minimum_row_length = MaxValue<idx_t>(row_count_str.size(), shown_str.size()) + 4;
+	auto minimum_row_length =
+	    MaxValue<idx_t>(MaxValue<idx_t>(row_count_str.size(), shown_str.size() + 2), readable_rows_str.size() + 2) + 4;
 
 	// fetch the top and bottom render collections from the result
 	auto collections = FetchRenderCollections(context, result, top_rows, bottom_rows);
@@ -1073,7 +1124,7 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 	if (config.render_mode == RenderMode::COLUMNS) {
 		if (has_hidden_columns) {
 			has_hidden_rows = true;
-			shown_str = " (" + to_string(column_count - 3) + " shown)";
+			shown_str = to_string(column_count - 3) + " shown";
 		} else {
 			shown_str = string();
 		}
@@ -1084,7 +1135,7 @@ void BoxRenderer::Render(ClientContext &context, const vector<string> &names, co
 		}
 	}
 
-	RenderRowCount(std::move(row_count_str), std::move(shown_str), column_count_str, boundaries, has_hidden_rows,
+	RenderRowCount(row_count_str, readable_rows_str, shown_str, column_count_str, boundaries, has_hidden_rows,
 	               has_hidden_columns, total_length, row_count, column_count, minimum_row_length, ss);
 }
 

--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -17,16 +17,25 @@ int32_t TerminalProgressBarDisplay::NormalizePercentage(double percentage) {
 	return int32_t(percentage);
 }
 
-static std::string format_eta(double seconds, bool elapsed = false) {
+static string FormatETA(double seconds, bool elapsed = false) {
+	// for terminal rendering purposes, we need to make sure the length is always the same
+	// we pad the end with spaces if that is not the case
+	// the maximum length here is "(~10.35 minutes remaining)" (26 bytes)
+	// always pad to this amount
+	static constexpr idx_t RENDER_SIZE = 26;
 	// Desired formats:
 	//   00:00:00.00 remaining
 	//   unknown     remaining
 	//   00:00:00.00 elapsed
-	const char *suffix = elapsed ? " elapsed)  " : " remaining)";
-
-	if (seconds < 0 || seconds > 3600 * 99) {
-		// Invalid or unknown ETA, or if its longer than 99 hours.
-		return StringUtil::Format("(%11s%s", "unknown", suffix);
+	if (!elapsed && seconds > 3600 * 99) {
+		// estimate larger than 99 hours remaining
+		string result = "(>99 hours remaining)";
+		result += string(RENDER_SIZE - result.size(), ' ');
+		return result;
+	}
+	if (seconds < 0) {
+		// Invalid or unknown ETA, skip rendering estimate
+		return string(RENDER_SIZE, ' ');
 	}
 
 	// Round to nearest centisecond as integer
@@ -40,8 +49,30 @@ static std::string format_eta(double seconds, bool elapsed = false) {
 	uint64_t hours = total_seconds / 3600;
 	uint32_t minutes = static_cast<uint32_t>((total_seconds % 3600) / 60);
 	uint32_t secs = static_cast<uint32_t>(total_seconds % 60);
-
-	return StringUtil::Format("(%02llu:%02u:%02u.%02llu%s", hours, minutes, secs, centiseconds, suffix);
+	string result;
+	result = "(";
+	if (!elapsed) {
+		if (hours == 0 && minutes == 0 && secs == 0) {
+			result += StringUtil::Format("<1 second");
+		} else if (hours == 0 && minutes == 0) {
+			result += StringUtil::Format("~%u second%s", secs, secs > 1 ? "s" : "");
+		} else if (hours == 0) {
+			auto minute_fraction = static_cast<uint32_t>(static_cast<double>(secs) / 60.0 * 10);
+			result += StringUtil::Format("~%u.%u minutes", minutes, minute_fraction);
+		} else {
+			auto hour_fraction = static_cast<uint32_t>(static_cast<double>(minutes) / 60.0 * 10);
+			result += StringUtil::Format("~%llu.%u hours", hours, hour_fraction);
+		}
+		result += " remaining";
+	} else {
+		result += StringUtil::Format("%02llu:%02u:%02u.%02llu", hours, minutes, secs, centiseconds);
+		result += " elapsed";
+	}
+	result += ")";
+	if (result.size() < RENDER_SIZE) {
+		result += string(RENDER_SIZE - result.size(), ' ');
+	}
+	return result;
 }
 
 void TerminalProgressBarDisplay::PrintProgressInternal(int32_t percentage, double seconds, bool finished) {
@@ -73,8 +104,6 @@ void TerminalProgressBarDisplay::PrintProgressInternal(int32_t percentage, doubl
 	}
 	result += to_string(percentage) + "%";
 	result += " ";
-	result += format_eta(seconds, finished);
-	result += " ";
 	result += PROGRESS_START;
 	idx_t i;
 	for (i = 0; i < idx_t(blocks_to_draw); i++) {
@@ -94,12 +123,13 @@ void TerminalProgressBarDisplay::PrintProgressInternal(int32_t percentage, doubl
 	}
 	result += PROGRESS_END;
 	result += " ";
+	result += FormatETA(seconds, finished);
 
 	Printer::RawPrint(OutputStream::STREAM_STDOUT, result);
 }
 
 void TerminalProgressBarDisplay::Update(double percentage) {
-	std::lock_guard<std::mutex> lock(mtx);
+	lock_guard<std::mutex> lock(mtx);
 	const double current_time = GetElapsedDuration();
 
 	if (current_time - last_update_time >= UPDATE_INTERVAL_MS / 1000.0) {
@@ -110,9 +140,7 @@ void TerminalProgressBarDisplay::Update(double percentage) {
 			udf_initialized = true;
 		} else {
 			ukf.Predict(current_time);
-			if (percentage != last_percentage) {
-				ukf.Update(filter_percentage);
-			}
+			ukf.Update(filter_percentage);
 		}
 
 		double estimated_seconds_remaining = ukf.GetEstimatedRemainingSeconds();
@@ -125,7 +153,7 @@ void TerminalProgressBarDisplay::Update(double percentage) {
 }
 
 void TerminalProgressBarDisplay::PeriodicUpdate() {
-	std::unique_lock<std::mutex> lock(mtx);
+	unique_lock<std::mutex> lock(mtx);
 	while (true) {
 		const double current_time = GetElapsedDuration();
 
@@ -150,7 +178,7 @@ void TerminalProgressBarDisplay::PeriodicUpdate() {
 void TerminalProgressBarDisplay::StopPeriodicUpdates() {
 	if (run_periodic_updates) {
 		{
-			std::lock_guard<std::mutex> lock(mtx);
+			lock_guard<std::mutex> lock(mtx);
 			run_periodic_updates = false;
 		}
 		cv.notify_one();
@@ -164,7 +192,7 @@ void TerminalProgressBarDisplay::StopPeriodicUpdates() {
 void TerminalProgressBarDisplay::Finish() {
 	StopPeriodicUpdates();
 
-	std::lock_guard<std::mutex> lock(mtx);
+	lock_guard<std::mutex> lock(mtx);
 	PrintProgressInternal(100, GetElapsedDuration(), true);
 	Printer::RawPrint(OutputStream::STREAM_STDOUT, "\n");
 	Printer::Flush(OutputStream::STREAM_STDOUT);

--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -1,11 +1,8 @@
 #include "duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/to_string.hpp"
-#include <thread>
 
 namespace duckdb {
-
-#define UPDATE_INTERVAL_MS 100
 
 int32_t TerminalProgressBarDisplay::NormalizePercentage(double percentage) {
 	if (percentage > 100) {
@@ -76,16 +73,6 @@ static string FormatETA(double seconds, bool elapsed = false) {
 }
 
 void TerminalProgressBarDisplay::PrintProgressInternal(int32_t percentage, double seconds, bool finished) {
-	if (!run_periodic_updates && !finished) {
-		run_periodic_updates = true;
-
-		// Since the progress reports may not come at a regular interval,
-		// we start a thread that will periodically update the display,
-		// with the new estimated completion time, but we're doing this
-		// here since we only want periodic updates if the progress bar is
-		// being displayed.
-		periodic_update_thread = std::thread([this]() { PeriodicUpdate(); });
-	}
 	string result;
 	// we divide the number of blocks by the percentage
 	// 0%   = 0
@@ -129,70 +116,19 @@ void TerminalProgressBarDisplay::PrintProgressInternal(int32_t percentage, doubl
 }
 
 void TerminalProgressBarDisplay::Update(double percentage) {
-	lock_guard<std::mutex> lock(mtx);
 	const double current_time = GetElapsedDuration();
 
-	if (current_time - last_update_time >= UPDATE_INTERVAL_MS / 1000.0) {
-		// Filters go from 0 to 1, percentage is from 0-100
-		const double filter_percentage = percentage / 100.0;
-		if (!udf_initialized) {
-			ukf.Initialize(filter_percentage, current_time);
-			udf_initialized = true;
-		} else {
-			ukf.Predict(current_time);
-			ukf.Update(filter_percentage);
-		}
+	// Filters go from 0 to 1, percentage is from 0-100
+	const double filter_percentage = percentage / 100.0;
+	ukf.Update(filter_percentage, current_time);
 
-		double estimated_seconds_remaining = ukf.GetEstimatedRemainingSeconds();
-		auto percentage_int = NormalizePercentage(percentage);
-		PrintProgressInternal(percentage_int, estimated_seconds_remaining);
-		Printer::Flush(OutputStream::STREAM_STDOUT);
-		last_update_time = current_time;
-		last_percentage = percentage;
-	}
-}
-
-void TerminalProgressBarDisplay::PeriodicUpdate() {
-	unique_lock<std::mutex> lock(mtx);
-	while (true) {
-		const double current_time = GetElapsedDuration();
-
-		// Only advance the time, but not the progress.
-		ukf.Predict(current_time);
-		double estimated_seconds_remaining = ukf.GetEstimatedRemainingSeconds();
-
-		if (last_percentage < 100) {
-			auto percentage_int = NormalizePercentage(last_percentage);
-			PrintProgressInternal(percentage_int, estimated_seconds_remaining);
-			Printer::Flush(OutputStream::STREAM_STDOUT);
-		}
-
-		// Wait for an interval then do an update.
-		if (cv.wait_for(lock, std::chrono::milliseconds(UPDATE_INTERVAL_MS),
-		                [this] { return !run_periodic_updates; })) {
-			break;
-		}
-	}
-}
-
-void TerminalProgressBarDisplay::StopPeriodicUpdates() {
-	if (run_periodic_updates) {
-		{
-			lock_guard<std::mutex> lock(mtx);
-			run_periodic_updates = false;
-		}
-		cv.notify_one();
-		if (periodic_update_thread.joinable()) {
-			periodic_update_thread.join();
-		}
-	}
-	run_periodic_updates = false;
+	double estimated_seconds_remaining = ukf.GetEstimatedRemainingSeconds();
+	auto percentage_int = NormalizePercentage(percentage);
+	PrintProgressInternal(percentage_int, estimated_seconds_remaining);
+	Printer::Flush(OutputStream::STREAM_STDOUT);
 }
 
 void TerminalProgressBarDisplay::Finish() {
-	StopPeriodicUpdates();
-
-	lock_guard<std::mutex> lock(mtx);
 	PrintProgressInternal(100, GetElapsedDuration(), true);
 	Printer::RawPrint(OutputStream::STREAM_STDOUT, "\n");
 	Printer::Flush(OutputStream::STREAM_STDOUT);

--- a/src/common/progress_bar/unscented_kalman_filter.cpp
+++ b/src/common/progress_bar/unscented_kalman_filter.cpp
@@ -3,9 +3,8 @@
 namespace duckdb {
 
 UnscentedKalmanFilter::UnscentedKalmanFilter()
-    : x(STATE_DIM, 0.0), P(STATE_DIM, std::vector<double>(STATE_DIM, 0.0)),
-      Q(STATE_DIM, std::vector<double>(STATE_DIM, 0.0)), R(OBS_DIM, std::vector<double>(OBS_DIM, 0.0)), last_time(0.0),
-      initialized(false) {
+    : x(STATE_DIM, 0.0), P(STATE_DIM, vector<double>(STATE_DIM, 0.0)), Q(STATE_DIM, vector<double>(STATE_DIM, 0.0)),
+      R(OBS_DIM, vector<double>(OBS_DIM, 0.0)), last_time(0.0), initialized(false) {
 
 	// Calculate UKF parameters
 	lambda = ALPHA * ALPHA * (STATE_DIM + KAPPA) - STATE_DIM;
@@ -39,9 +38,9 @@ void UnscentedKalmanFilter::Initialize(double initial_progress, double current_t
 }
 
 // Matrix operations
-std::vector<std::vector<double>> UnscentedKalmanFilter::MatrixSqrt(const std::vector<std::vector<double>> &mat) {
+vector<vector<double>> UnscentedKalmanFilter::MatrixSqrt(const vector<vector<double>> &mat) {
 	size_t n = mat.size();
-	std::vector<std::vector<double>> L(n, std::vector<double>(n, 0.0));
+	vector<vector<double>> L(n, vector<double>(n, 0.0));
 
 	// Cholesky decomposition
 	for (size_t i = 0; i < n; i++) {
@@ -65,8 +64,8 @@ std::vector<std::vector<double>> UnscentedKalmanFilter::MatrixSqrt(const std::ve
 }
 
 // Generate sigma points
-std::vector<std::vector<double>> UnscentedKalmanFilter::GenerateSigmaPoints() {
-	std::vector<std::vector<double>> sigma_points(SIGMA_POINTS, std::vector<double>(STATE_DIM));
+vector<vector<double>> UnscentedKalmanFilter::GenerateSigmaPoints() {
+	vector<vector<double>> sigma_points(SIGMA_POINTS, vector<double>(STATE_DIM));
 
 	// Calculate sqrt((n + lambda) * P)
 	auto scaled_P = P;
@@ -94,8 +93,8 @@ std::vector<std::vector<double>> UnscentedKalmanFilter::GenerateSigmaPoints() {
 }
 
 // State transition function
-std::vector<double> UnscentedKalmanFilter::StateTransition(const std::vector<double> &state, double dt) {
-	std::vector<double> new_state(STATE_DIM);
+vector<double> UnscentedKalmanFilter::StateTransition(const vector<double> &state, double dt) {
+	vector<double> new_state(STATE_DIM);
 	new_state[0] = state[0] + state[1] * dt; // progress += velocity * dt
 	new_state[1] = state[1];                 // velocity remains constant
 
@@ -106,7 +105,7 @@ std::vector<double> UnscentedKalmanFilter::StateTransition(const std::vector<dou
 }
 
 // Measurement function (identity for progress)
-std::vector<double> UnscentedKalmanFilter::MeasurementFunction(const std::vector<double> &state) {
+vector<double> UnscentedKalmanFilter::MeasurementFunction(const vector<double> &state) {
 	return {state[0]};
 }
 
@@ -126,7 +125,7 @@ void UnscentedKalmanFilter::Predict(double current_time) {
 	auto sigma_points = GenerateSigmaPoints();
 
 	// Propagate sigma points through state transition
-	std::vector<std::vector<double>> sigma_points_pred(SIGMA_POINTS, std::vector<double>(STATE_DIM));
+	vector<vector<double>> sigma_points_pred(SIGMA_POINTS, vector<double>(STATE_DIM));
 	for (size_t i = 0; i < SIGMA_POINTS; i++) {
 		sigma_points_pred[i] = StateTransition(sigma_points[i], dt);
 	}
@@ -169,13 +168,13 @@ void UnscentedKalmanFilter::Update(double measured_progress) {
 	auto sigma_points = GenerateSigmaPoints();
 
 	// Transform sigma points through measurement function
-	std::vector<std::vector<double>> Z_sigma(SIGMA_POINTS, std::vector<double>(OBS_DIM));
+	vector<vector<double>> Z_sigma(SIGMA_POINTS, vector<double>(OBS_DIM));
 	for (size_t i = 0; i < SIGMA_POINTS; i++) {
 		Z_sigma[i] = MeasurementFunction(sigma_points[i]);
 	}
 
 	// Predict measurement mean
-	std::vector<double> z_pred(OBS_DIM, 0.0);
+	vector<double> z_pred(OBS_DIM, 0.0);
 	for (size_t i = 0; i < SIGMA_POINTS; i++) {
 		for (size_t j = 0; j < OBS_DIM; j++) {
 			z_pred[j] += wm[i] * Z_sigma[i][j];
@@ -183,7 +182,7 @@ void UnscentedKalmanFilter::Update(double measured_progress) {
 	}
 
 	// Innovation covariance
-	std::vector<std::vector<double>> S(OBS_DIM, std::vector<double>(OBS_DIM, 0.0));
+	vector<vector<double>> S(OBS_DIM, vector<double>(OBS_DIM, 0.0));
 	for (size_t i = 0; i < SIGMA_POINTS; i++) {
 		for (size_t j = 0; j < OBS_DIM; j++) {
 			for (size_t k = 0; k < OBS_DIM; k++) {
@@ -200,7 +199,7 @@ void UnscentedKalmanFilter::Update(double measured_progress) {
 	}
 
 	// Cross correlation
-	std::vector<std::vector<double>> T(STATE_DIM, std::vector<double>(OBS_DIM, 0.0));
+	vector<vector<double>> T(STATE_DIM, vector<double>(OBS_DIM, 0.0));
 	for (size_t i = 0; i < SIGMA_POINTS; i++) {
 		for (size_t j = 0; j < STATE_DIM; j++) {
 			for (size_t k = 0; k < OBS_DIM; k++) {
@@ -210,14 +209,14 @@ void UnscentedKalmanFilter::Update(double measured_progress) {
 	}
 
 	// Kalman gain (simplified for 1D measurement)
-	std::vector<std::vector<double>> K(STATE_DIM, std::vector<double>(OBS_DIM));
+	vector<vector<double>> K(STATE_DIM, vector<double>(OBS_DIM));
 	double S_inv = 1.0 / S[0][0];
 	for (size_t i = 0; i < STATE_DIM; i++) {
 		K[i][0] = T[i][0] * S_inv;
 	}
 
 	// Update state
-	std::vector<double> innovation = {measured_progress - z_pred[0]};
+	vector<double> innovation = {measured_progress - z_pred[0]};
 	for (size_t i = 0; i < STATE_DIM; i++) {
 		x[i] += K[i][0] * innovation[0];
 	}
@@ -242,8 +241,12 @@ double UnscentedKalmanFilter::GetVelocity() const {
 }
 
 double UnscentedKalmanFilter::GetEstimatedRemainingSeconds() const {
-	if (!initialized || x[1] <= 0) {
+	if (!initialized) {
 		return -1.0;
+	}
+	if (x[1] <= 0) {
+		// velocity is negative or zero - we estimate this will never finish
+		return NumericLimits<double>::Maximum();
 	}
 	double remaining_progress = 1.0 - x[0];
 	return remaining_progress / x[1];

--- a/src/common/progress_bar/unscented_kalman_filter.cpp
+++ b/src/common/progress_bar/unscented_kalman_filter.cpp
@@ -30,6 +30,15 @@ UnscentedKalmanFilter::UnscentedKalmanFilter()
 	R[0][0] = 0.05; // measurement noise for progress
 }
 
+void UnscentedKalmanFilter::Update(double progress, double time) {
+	if (!initialized) {
+		Initialize(progress, time);
+		return;
+	}
+	Predict(time);
+	UpdateInternal(progress);
+}
+
 void UnscentedKalmanFilter::Initialize(double initial_progress, double current_time) {
 	x[0] = initial_progress;
 	x[1] = current_time == 0 ? 0.01 : initial_progress / current_time; // initial velocity guess
@@ -110,9 +119,7 @@ vector<double> UnscentedKalmanFilter::MeasurementFunction(const vector<double> &
 }
 
 void UnscentedKalmanFilter::Predict(double current_time) {
-	if (!initialized) {
-		return;
-	}
+	D_ASSERT(initialized);
 
 	double dt = current_time - last_time;
 	last_time = current_time;
@@ -159,11 +166,8 @@ void UnscentedKalmanFilter::Predict(double current_time) {
 	}
 }
 
-void UnscentedKalmanFilter::Update(double measured_progress) {
-	if (!initialized) {
-		return;
-	}
-
+void UnscentedKalmanFilter::UpdateInternal(double measured_progress) {
+	D_ASSERT(initialized);
 	// Generate sigma points
 	auto sigma_points = GenerateSigmaPoints();
 

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -164,10 +164,10 @@ private:
 	                  idx_t total_length, bool has_results, BaseResultRenderer &renderer);
 	void RenderValues(const list<ColumnDataCollection> &collections, const vector<idx_t> &column_map,
 	                  const vector<idx_t> &widths, const vector<LogicalType> &result_types, BaseResultRenderer &ss);
-	void RenderRowCount(string row_count_str, string shown_str, const string &column_count_str,
-	                    const vector<idx_t> &boundaries, bool has_hidden_rows, bool has_hidden_columns,
-	                    idx_t total_length, idx_t row_count, idx_t column_count, idx_t minimum_row_length,
-	                    BaseResultRenderer &ss);
+	void RenderRowCount(string &row_count_str, string &readable_rows_str, string &shown_str,
+	                    const string &column_count_str, const vector<idx_t> &boundaries, bool has_hidden_rows,
+	                    bool has_hidden_columns, idx_t total_length, idx_t row_count, idx_t column_count,
+	                    idx_t minimum_row_length, BaseResultRenderer &ss);
 
 	string FormatNumber(const string &input);
 	string ConvertRenderValue(const string &input, const LogicalType &type);

--- a/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
+++ b/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
@@ -21,10 +21,6 @@ class TerminalProgressBarDisplay : public ProgressBarDisplay {
 private:
 	UnscentedKalmanFilter ukf;
 	std::chrono::steady_clock::time_point start_time;
-	bool udf_initialized;
-	bool run_periodic_updates;
-	double last_percentage;
-	double last_update_time;
 
 	double GetElapsedDuration() {
 		auto now = std::chrono::steady_clock::now();
@@ -33,13 +29,11 @@ private:
 	void StopPeriodicUpdates();
 
 public:
-	TerminalProgressBarDisplay()
-	    : udf_initialized(false), run_periodic_updates(false), last_percentage(0.0), last_update_time(0.0) {
+	TerminalProgressBarDisplay() {
 		start_time = std::chrono::steady_clock::now();
 	}
 
 	~TerminalProgressBarDisplay() override {
-		StopPeriodicUpdates();
 	}
 
 public:

--- a/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
+++ b/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
@@ -45,13 +45,17 @@ private:
 public:
 	UnscentedKalmanFilter();
 
+	void Update(double progress, double time);
+
+	double GetEstimatedRemainingSeconds() const;
+
+private:
 	void Initialize(double initial_progress, double current_time);
 	void Predict(double current_time);
-	void Update(double measured_progress);
+	void UpdateInternal(double measured_progress);
 
 	double GetProgress() const;
 	double GetVelocity() const;
-	double GetEstimatedRemainingSeconds() const;
 	double GetProgressVariance() const;
 	double GetVelocityVariance() const;
 };

--- a/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
+++ b/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
@@ -25,22 +25,22 @@ private:
 	static constexpr double KAPPA = 0.0;
 
 	double lambda;
-	std::vector<double> wm, wc; // weights for mean and covariance
+	vector<double> wm, wc; // weights for mean and covariance
 
 	// State: [progress (0-1), velocity (progress/second)]
-	std::vector<double> x;              // state estimate
-	std::vector<std::vector<double>> P; // covariance matrix
-	std::vector<std::vector<double>> Q; // process noise
-	std::vector<std::vector<double>> R; // measurement noise
+	vector<double> x;         // state estimate
+	vector<vector<double>> P; // covariance matrix
+	vector<vector<double>> Q; // process noise
+	vector<vector<double>> R; // measurement noise
 
 	double last_time;
 	bool initialized;
 
 	// Helper functions
-	std::vector<std::vector<double>> MatrixSqrt(const std::vector<std::vector<double>> &mat);
-	std::vector<std::vector<double>> GenerateSigmaPoints();
-	std::vector<double> StateTransition(const std::vector<double> &state, double dt);
-	std::vector<double> MeasurementFunction(const std::vector<double> &state);
+	vector<vector<double>> MatrixSqrt(const vector<vector<double>> &mat);
+	vector<vector<double>> GenerateSigmaPoints();
+	vector<double> StateTransition(const vector<double> &state, double dt);
+	vector<double> MeasurementFunction(const vector<double> &state);
 
 public:
 	UnscentedKalmanFilter();

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4736,8 +4736,6 @@ static void verify_uninitialized(void) {
 static void main_init(ShellState *data) {
 	data->normalMode = data->cMode = data->mode = RenderMode::DUCKBOX;
 	data->max_rows = 40;
-	data->thousand_separator = ',';
-	data->decimal_separator = '.';
 	data->colSeparator = SEP_Column;
 	data->rowSeparator = SEP_Row;
 	data->showHeader = true;

--- a/tools/shell/tests/test_readable_numbers.py
+++ b/tools/shell/tests/test_readable_numbers.py
@@ -122,3 +122,30 @@ def test_readable_numbers_columns(shell):
     )
     result = test.run()
     result.check_not_exist('(123.46 million)')
+
+def test_readable_numbers_row_count(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".large_number_rendering footer")
+        .statement("select r from range(1230000) t(r);")
+    )
+    result = test.run()
+    result.check_stdout('1.23 million rows')
+
+def test_readable_numbers_row_count_wide(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".large_number_rendering footer")
+        .statement("select r, r, r, r, r, r, r from range(1230000) t(r);")
+    )
+    result = test.run()
+    result.check_stdout('1.23 million rows')
+
+def test_readable_numbers_row_count_wide_single_col(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".large_number_rendering footer")
+        .statement("select concat(r, r, r, r, r, r, r) c from range(1230000) t(r);")
+    )
+    result = test.run()
+    result.check_stdout('1.23 million rows')


### PR DESCRIPTION
Follow-ups to https://github.com/duckdb/duckdb/pull/18575 and https://github.com/duckdb/duckdb/pull/18564

### Render ETA as actual estimate

Currently the ETA is rendered as a very precise value, which is hard to read, and overly precise in most cases given the fact that it is an estimate. Adding it in front of the progress bar also does not look very good imo.

```bash
 29% (00:00:10.78 remaining) ▕███████████                           ▏ 
```

This PR reworks the ETA to be added to the end of the progress bar instead, and to use a less granular estimate.

```bash
 36% ▕█████████████▋                        ▏ (~7 seconds remaining)    
```

Here's some example estimates:

```bash
 36% ▕█████████████▋                        ▏ (~7 seconds remaining)    
 99% ▕█████████████████████████████████████▌▏ (<1 second remaining)     
 32% ▕████████████▏                         ▏ (~1.1 minutes remaining)  
 50% ▕███████████████████                   ▏ (~1.6 hours remaining)    
 50% ▕███████████████████                   ▏ (>99 hours remaining)     
```

The final elapsed time is still shown in the old exact notation:

```bash
100% ▕██████████████████████████████████████▏ (00:00:18.26 elapsed)     
```

We also fix an issue where large cross-products/self-joins would keep on showing a "fast" estimate instead of converging towards a more realistic (very slow) one, e.g. the following query (that will realistically never finish as it is generating 100M * 100M rows) would previously keep on showing an estimate of a few minutes - it now (correctly) converges to `>99 hours remaining`.

```sql
select count(distinct columns(*)) from 'hits.parquet' h1, 'hits.parquet' h2;
```

We also do a bunch of clean-up:

* Remove the thread spawning that was added again, this should not be necessary for updating the ETA. The progress bar update should be called granularly already.
* Some nits, e.g. avoid using `std::vector` over `duckdb::vector` and clean-up a bunch of naming/code


### Don't set thousand/decimal separator by default, and add large footer rendering 

https://github.com/duckdb/duckdb/pull/18564 set the thousand/decimal separators by default, instead of letting them be uninitialized by default. This PR reverts this back to the old behavior. If enabled, the rendering is still used in the row/column counts. Instead, we add support for the `large_number_rendering` to the duckbox mode which is enabled by default, e.g. some example renderings:

```cpp
D select watchid from '~/Data/hits.parquet';
┌───────────────────────┐
│        WatchID        │
│         int64         │
├───────────────────────┤
│   9110818468285196899 │
│   8156744413230856864 │
│   5206346422301499756 │
│            ·          │
│            ·          │
│            ·          │
│   4928833346893230859 │
│   4656762582818014930 │
├───────────────────────┤
│     99997497 rows     │
│ (100.00 million rows) │
│       (5 shown)       │
└───────────────────────┘

D select url from  '~/Data/hits.parquet';
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                                  URL                                                                                   │
│                                                                                varchar                                                                                 │
├────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│                                                                                                                                                                        │
│                                                                                                                                                                        │
│                                                                                                                                                                        │
│             ·                                                                                                                                                          │
│             ·                                                                                                                                                          │
│             ·                                                                                                                                                          │
│ http://sportosh; InfoPath                                                                                                                                              │
│ http://sp-mamrostova.ru/search.phtml?n=65&pvno=2&evlg=VC,2184-66.html?country=&op_category&op_page10/?item.html?1=1&cid=577&oki=1&op_seo_entry386633591%26url%3Dhttp…  │
├────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│                                                              99997497 rows (100.00 million rows, 5 shown)                                                              │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
D select watchid, javaenable from  '~/Data/hits.parquet';
┌─────────────────────┬────────────┐
│       WatchID       │ JavaEnable │
│        int64        │   int16    │
├─────────────────────┼────────────┤
│ 9110818468285196899 │          0 │
│ 8156744413230856864 │          0 │
│ 5206346422301499756 │          0 │
│          ·          │          · │
│          ·          │          · │
│          ·          │          · │
│ 4928833346893230859 │          1 │
│ 4656762582818014930 │          0 │
├─────────────────────┴────────────┤
│ 99997497 rows          2 columns │
│ 100.00 million rows      5 shown │
└──────────────────────────────────┘


```

These also use syntax highlighting now.
