### PR TITLE
Only return cgroup memory limit if it's a sane value

### DIFF
--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -549,7 +549,10 @@ idx_t DBConfig::GetSystemAvailableMemory(FileSystem &fs) {
 	// Check cgroup memory limit
 	auto cgroup_memory_limit = CGroups::GetMemoryLimit(fs);
 	if (cgroup_memory_limit.IsValid()) {
-		return cgroup_memory_limit.GetIndex();
+		auto cgroup_memory_limit_value = cgroup_memory_limit.GetIndex();
+		if (cgroup_memory_limit_value < NumericLimits<int64_t>::Maximum() - NumericLimits<int16_t>::Maximum()) {
+			return cgroup_memory_limit_value;
+		}
 	}
 #endif
 


### PR DESCRIPTION
We check for `cgroup_memory_limit.IsValid()` but, apparently, on some older distributions and WSL+Linux, `cgroup_memory_limit` still returns an unrealistic value (`9223372036854771712`).

This check skips such unrealistic values and falls back to using `FileSystem::GetAvailableMemory()`.

Fixes #18663