### PR TITLE
fix error message related to wrong memory unit

### DIFF
--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -617,7 +617,7 @@ idx_t DBConfig::ParseMemoryLimit(const string &arg) {
 	} else if (unit == "tib") {
 		multiplier = 1024LL * 1024LL * 1024LL * 1024LL;
 	} else {
-		throw ParserException("Unknown unit for memory_limit: '%s' (expected: KB, MB, GB, TB for 1000^i units or KiB, "
+		throw ParserException("Unknown unit for memory: '%s' (expected: KB, MB, GB, TB for 1000^i units or KiB, "
 		                      "MiB, GiB, TiB for 1024^i units)",
 		                      unit);
 	}


### PR DESCRIPTION
the parsing is used for different settings. e.g: wal_autocheckpoint so the error should be generic and not relate to "memory_limit"