### PR TITLE
fix: coalesce query progress updates to reduce terminal writes

### DIFF
--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -122,10 +122,13 @@ void TerminalProgressBarDisplay::Update(double percentage) {
 	const double filter_percentage = percentage / 100.0;
 	ukf.Update(filter_percentage, current_time);
 
-	double estimated_seconds_remaining = ukf.GetEstimatedRemainingSeconds();
-	auto percentage_int = NormalizePercentage(percentage);
-	PrintProgressInternal(percentage_int, estimated_seconds_remaining);
-	Printer::Flush(OutputStream::STREAM_STDOUT);
+	if (current_time - last_update_time > 0.1 && percentage != 100.0) {
+		double estimated_seconds_remaining = ukf.GetEstimatedRemainingSeconds();
+		auto percentage_int = NormalizePercentage(percentage);
+		PrintProgressInternal(percentage_int, estimated_seconds_remaining);
+		Printer::Flush(OutputStream::STREAM_STDOUT);
+		last_update_time = current_time;
+	}
 }
 
 void TerminalProgressBarDisplay::Finish() {

--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -122,12 +122,15 @@ void TerminalProgressBarDisplay::Update(double percentage) {
 	const double filter_percentage = percentage / 100.0;
 	ukf.Update(filter_percentage, current_time);
 
-	if (current_time - last_update_time > 0.1 && percentage != 100.0) {
-		double estimated_seconds_remaining = ukf.GetEstimatedRemainingSeconds();
-		auto percentage_int = NormalizePercentage(percentage);
+	double estimated_seconds_remaining = ukf.GetEstimatedRemainingSeconds();
+	auto percentage_int = NormalizePercentage(percentage);
+
+	TerminalProgressBarDisplayedProgressInfo updated_progress_info = {percentage_int,
+	                                                                  (int32_t)estimated_seconds_remaining};
+	if (displayed_progress_info != updated_progress_info) {
 		PrintProgressInternal(percentage_int, estimated_seconds_remaining);
 		Printer::Flush(OutputStream::STREAM_STDOUT);
-		last_update_time = current_time;
+		displayed_progress_info = updated_progress_info;
 	}
 }
 

--- a/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
+++ b/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
@@ -21,6 +21,7 @@ class TerminalProgressBarDisplay : public ProgressBarDisplay {
 private:
 	UnscentedKalmanFilter ukf;
 	std::chrono::steady_clock::time_point start_time;
+	double last_update_time;
 
 	double GetElapsedDuration() {
 		auto now = std::chrono::steady_clock::now();

--- a/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
+++ b/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
@@ -17,11 +17,27 @@
 
 namespace duckdb {
 
+struct TerminalProgressBarDisplayedProgressInfo {
+	optional_idx percentage;
+	optional_idx estimated_seconds_remaining;
+
+	bool operator==(const TerminalProgressBarDisplayedProgressInfo &other) const {
+		return percentage == other.percentage && estimated_seconds_remaining == other.estimated_seconds_remaining;
+	}
+
+	bool operator!=(const TerminalProgressBarDisplayedProgressInfo &other) const {
+		return !(*this == other);
+	}
+};
+
 class TerminalProgressBarDisplay : public ProgressBarDisplay {
 private:
 	UnscentedKalmanFilter ukf;
 	std::chrono::steady_clock::time_point start_time;
-	double last_update_time;
+
+	// track the progress info that has been previously
+	// displayed to prevent redundant updates
+	struct TerminalProgressBarDisplayedProgressInfo displayed_progress_info;
 
 	double GetElapsedDuration() {
 		auto now = std::chrono::steady_clock::now();
@@ -32,6 +48,7 @@ private:
 public:
 	TerminalProgressBarDisplay() {
 		start_time = std::chrono::steady_clock::now();
+		displayed_progress_info = {optional_idx(), optional_idx()};
 	}
 
 	~TerminalProgressBarDisplay() override {


### PR DESCRIPTION
At the end of query processing, many progress updates can report the same overall progress. Currently, each update triggers a redraw of the progress bar, resulting in unnecessary writes to the terminal.

This change limits progress updates to at most 10 times per second, reducing terminal output while keeping the progress display smooth.