### PR TITLE
[ Python SQLLogic Tester ] Add `MERGE_INTO` to `statement.type` enum in `result.py`

### DIFF
--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -864,6 +864,7 @@ class SQLLogicContext:
                     duckdb.StatementType.DELETE,
                     duckdb.StatementType.UPDATE,
                     duckdb.StatementType.INSERT,
+                    duckdb.StatementType.MERGE_INTO,
                 ]:
                     if 'returning' in sql_query.lower():
                         return False


### PR DESCRIPTION
This is a follow up for earlier merged https://github.com/duckdb/duckdb/pull/18402 that makes python test runner recognise the `MERGE_INTO` statement.

Should fix [failures](https://github.com/duckdb/duckdb/actions/runs/17085251118/job/48448032820#step:6:3692) in nightly CI runs.