### PR TITLE
Grab lock and double-check that column is not loaded in MoveToCollection

### DIFF
--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -72,7 +72,10 @@ void RowGroup::MoveToCollection(RowGroupCollection &collection_p, idx_t new_star
 		if (is_loaded && !is_loaded[c]) {
 			// we only need to set the column start position if it is already loaded
 			// if it is not loaded - we will set the correct start position upon loading
-			continue;
+			lock_guard<mutex> l(row_group_lock);
+			if (!is_loaded[c]) {
+				continue;
+			}
 		}
 		columns[c]->SetStart(new_start);
 	}


### PR DESCRIPTION
Should fix a rare race condition that would cause `start` not to be set correctly after https://github.com/duckdb/duckdb/pull/18395