### PR TITLE
Correctly allocate uncompressed string data in ZSTD for many giant strings

### DIFF
--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -900,16 +900,15 @@ public:
 		for (idx_t i = 0; i < count; i++) {
 			uncompressed_length += string_lengths[i];
 		}
-		auto empty_string = StringVector::EmptyString(result, uncompressed_length);
-		auto uncompressed_data = empty_string.GetDataWriteable();
+		auto &buffer = StringVector::GetStringBuffer(result);
+		auto uncompressed_data = buffer.AllocateShrinkableBuffer(uncompressed_length);
 		auto string_data = FlatVector::GetData<string_t>(result);
 
-		DecompressString(scan_state, reinterpret_cast<data_ptr_t>(uncompressed_data), uncompressed_length);
+		DecompressString(scan_state, uncompressed_data, uncompressed_length);
 
 		idx_t offset = 0;
-		auto uncompressed_data_const = empty_string.GetData();
 		for (idx_t i = 0; i < count; i++) {
-			string_data[result_offset + i] = string_t(uncompressed_data_const + offset, string_lengths[i]);
+			string_data[result_offset + i] = string_t(char_ptr_cast(uncompressed_data + offset), string_lengths[i]);
 			offset += string_lengths[i];
 		}
 		scan_state.scanned_count += count;

--- a/test/sql/storage/compression/zstd/zstd_giant_string.test_slow
+++ b/test/sql/storage/compression/zstd/zstd_giant_string.test_slow
@@ -1,6 +1,8 @@
 # name: test/sql/storage/compression/zstd/zstd_giant_string.test_slow
 # group: [zstd]
 
+require ram 16gb
+
 statement ok
 ATTACH '__TEST_DIR__/zstd_giant_string.db' (STORAGE_VERSION 'v1.3.2');
 

--- a/test/sql/storage/compression/zstd/zstd_giant_string.test_slow
+++ b/test/sql/storage/compression/zstd/zstd_giant_string.test_slow
@@ -1,0 +1,22 @@
+# name: test/sql/storage/compression/zstd/zstd_giant_string.test_slow
+# group: [zstd]
+
+statement ok
+ATTACH '__TEST_DIR__/zstd_giant_string.db' (STORAGE_VERSION 'v1.3.2');
+
+statement ok
+CREATE TABLE zstd_giant_string.foo (bar VARCHAR USING COMPRESSION zstd);
+
+statement ok
+INSERT INTO zstd_giant_string.foo SELECT repeat('a', 10000000) FROM range(0, 500);
+
+statement ok
+DETACH zstd_giant_string
+
+statement ok
+ATTACH '__TEST_DIR__/zstd_giant_string.db'
+
+query I
+select max(length(bar)) from zstd_giant_string.foo;
+----
+10000000


### PR DESCRIPTION
Fixes an issue where, when reading many very large strings, we would exceed the allocation limit for individual strings unnecessarily (4GB). That limit is only for individual strings - so we should directly use the allocator to decompress the ZSTD compressed strings instead.