### PR TITLE
#Fix 18558: add row_group scan fast path

### DIFF
--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -648,8 +648,12 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 						ColumnSegment::FilterSelection(sel, result_vector, vdata, filter.filter, table_filter_state,
 						                               approved_tuple_count, approved_tuple_count);
 
+					} else if (approved_tuple_count == 0) {
+						auto &col_data = GetColumn(column_idx);
+						col_data.Skip(state.column_scans[scan_idx]);
+						continue;
 					} else {
-						auto &col_data = GetColumn(filter.table_column_index);
+						auto &col_data = GetColumn(column_idx);
 						col_data.Filter(transaction, state.vector_index, state.column_scans[scan_idx], result_vector,
 						                sel, approved_tuple_count, filter.filter, table_filter_state);
 					}


### PR DESCRIPTION
This pr try to improve performance mentioned in #18558 . 
Skip scan disk when possible.
Maybe we can consider add Filter parameter in scan_vector Function in the future?