### PR TITLE
[Python SQLLogicTest] Add `test/sql/pragma/profiling/test_profiling_all.test` to the SKIPPED_TESTS set

### DIFF
--- a/tools/pythonpkg/sqllogic/skipped_tests.py
+++ b/tools/pythonpkg/sqllogic/skipped_tests.py
@@ -37,5 +37,6 @@ SKIPPED_TESTS = set(
         'test/sql/tpcds/tpcds_sf0.test',  # problems connected to auto installing tpcds from remote
         'test/sql/optimizer/plan/test_filter_pushdown_materialized_cte.test',  # problems connected to auto installing tpcds from remote
         'test/sql/explain/test_explain_analyze.test',  # unknown problem with changes in API
+        'test/sql/pragma/profiling/test_profiling_all.test', # Because of logic related to enabling 'restart' statement capabilities, this will not measure the right statement
     ]
 )

--- a/tools/pythonpkg/sqllogic/skipped_tests.py
+++ b/tools/pythonpkg/sqllogic/skipped_tests.py
@@ -37,6 +37,6 @@ SKIPPED_TESTS = set(
         'test/sql/tpcds/tpcds_sf0.test',  # problems connected to auto installing tpcds from remote
         'test/sql/optimizer/plan/test_filter_pushdown_materialized_cte.test',  # problems connected to auto installing tpcds from remote
         'test/sql/explain/test_explain_analyze.test',  # unknown problem with changes in API
-        'test/sql/pragma/profiling/test_profiling_all.test', # Because of logic related to enabling 'restart' statement capabilities, this will not measure the right statement
+        'test/sql/pragma/profiling/test_profiling_all.test',  # Because of logic related to enabling 'restart' statement capabilities, this will not measure the right statement
     ]
 )


### PR DESCRIPTION
`test/sql/pragma/profiling/test_profiling_all.test` [gets wrong result in Python SQLLogicTest](https://github.com/duckdb/duckdb/actions/runs/17113810943/job/48540731136#step:6:3671) runner, because of this:
https://github.com/duckdb/duckdb/blob/d229d97f4028e153234647b5a2b65682b321e77d/scripts/sqllogictest/result.py#L1336

