### PR TITLE
Internal #3273: Hashed Sort States

### DIFF
--- a/src/include/duckdb/common/sorting/hashed_sort.hpp
+++ b/src/include/duckdb/common/sorting/hashed_sort.hpp
@@ -8,9 +8,7 @@
 
 #pragma once
 
-#include "duckdb/common/radix_partitioning.hpp"
 #include "duckdb/common/sorting/sort.hpp"
-#include "duckdb/parallel/base_pipeline_event.hpp"
 
 namespace duckdb {
 
@@ -19,14 +17,13 @@ class HashedSortGroup {
 public:
 	using Orders = vector<BoundOrderByNode>;
 	using Types = vector<LogicalType>;
-	using OrderMasks = unordered_map<idx_t, ValidityMask>;
 
-	HashedSortGroup(ClientContext &context, const Orders &orders, const Types &input_types, idx_t group_idx);
+	HashedSortGroup(ClientContext &client, optional_ptr<Sort> sort, idx_t group_idx);
 
 	const idx_t group_idx;
 
 	//	Sink
-	unique_ptr<Sort> sort;
+	optional_ptr<Sort> sort;
 	unique_ptr<GlobalSinkState> sort_global;
 
 	//	Source
@@ -35,128 +32,65 @@ public:
 	unique_ptr<ColumnDataCollection> sorted;
 };
 
-// Formerly PartitionGlobalSinkState
-class HashedSortGlobalSinkState {
+class HashedSortCallback {
 public:
-	using HashGroupPtr = unique_ptr<HashedSortGroup>;
+	virtual ~HashedSortCallback() = default;
+	virtual void OnSortedGroup(HashedSortGroup &hash_group) const = 0;
+};
+
+class HashedSort {
+public:
 	using Orders = vector<BoundOrderByNode>;
 	using Types = vector<LogicalType>;
-
-	using GroupingPartition = unique_ptr<RadixPartitionedTupleData>;
-	using GroupingAppend = unique_ptr<PartitionedTupleDataAppendState>;
+	using HashGroupPtr = unique_ptr<HashedSortGroup>;
 
 	static void GenerateOrderings(Orders &partitions, Orders &orders,
 	                              const vector<unique_ptr<Expression>> &partition_bys, const Orders &order_bys,
 	                              const vector<unique_ptr<BaseStatistics>> &partitions_stats);
 
-	HashedSortGlobalSinkState(ClientContext &context, const vector<unique_ptr<Expression>> &partition_bys,
-	                          const vector<BoundOrderByNode> &order_bys, const Types &payload_types,
-	                          const vector<unique_ptr<BaseStatistics>> &partitions_stats, idx_t estimated_cardinality);
+	HashedSort(ClientContext &context, const vector<unique_ptr<Expression>> &partition_bys,
+	           const vector<BoundOrderByNode> &order_bys, const Types &payload_types,
+	           const vector<unique_ptr<BaseStatistics>> &partitions_stats, idx_t estimated_cardinality,
+	           optional_ptr<HashedSortCallback> callback);
 
-	bool HasMergeTasks() const;
+public:
+	//===--------------------------------------------------------------------===//
+	// Sink Interface
+	//===--------------------------------------------------------------------===//
+	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const;
+	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &client) const;
+	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const;
+	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const;
+	SinkFinalizeType Finalize(ClientContext &client, OperatorSinkFinalizeInput &finalize) const;
 
-	// OVER(PARTITION BY...) (hash grouping)
-	unique_ptr<RadixPartitionedTupleData> CreatePartition(idx_t new_bits) const;
-	void UpdateLocalPartition(GroupingPartition &local_partition, GroupingAppend &partition_append);
-	void CombineLocalPartition(GroupingPartition &local_partition, GroupingAppend &local_append);
-	void Finalize(ClientContext &context, InterruptState &interrupt_state);
+public:
+	//===--------------------------------------------------------------------===//
+	// Non-Standard Interface
+	//===--------------------------------------------------------------------===//
+	SinkFinalizeType MaterializeHashGroups(Pipeline &pipeline, Event &event, const PhysicalOperator &op,
+	                                       OperatorSinkFinalizeInput &finalize) const;
+	vector<HashGroupPtr> &GetHashGroups(GlobalSinkState &global_state) const;
 
-	//! System and query state
-	ClientContext &context;
-	BufferManager &buffer_manager;
-	Allocator &allocator;
-	mutex lock;
-
-	// OVER(PARTITION BY...) (hash grouping)
-	GroupingPartition grouping_data;
-	//! Payload plus hash column
-	shared_ptr<TupleDataLayout> grouping_types_ptr;
-	//! The number of radix bits if this partition is being synced with another
-	idx_t fixed_bits;
+public:
+	ClientContext &client;
+	//! The host's estimated row count
+	const idx_t estimated_cardinality;
 
 	// OVER(...) (sorting)
 	Orders partitions;
 	Orders orders;
+	idx_t sort_col_count;
 	Types payload_types;
-	vector<HashGroupPtr> hash_groups;
 	// Input columns in the sorted output
 	vector<column_t> scan_ids;
 	// Key columns in the sorted output
 	vector<column_t> sort_ids;
 	// Key columns that must be computed
 	vector<unique_ptr<Expression>> sort_exprs;
-
-	// OVER() (no sorting)
-	unique_ptr<ColumnDataCollection> unsorted;
-
-	// Threading
-	idx_t max_bits;
-	atomic<idx_t> count;
-
-private:
-	void Rehash(idx_t cardinality);
-	void SyncLocalPartition(GroupingPartition &local_partition, GroupingAppend &local_append);
-};
-
-// Formerly PartitionLocalSinkState
-class HashedSortLocalSinkState {
-public:
-	using LocalSortStatePtr = unique_ptr<LocalSinkState>;
-	using GroupingPartition = unique_ptr<RadixPartitionedTupleData>;
-	using GroupingAppend = unique_ptr<PartitionedTupleDataAppendState>;
-
-	HashedSortLocalSinkState(ExecutionContext &context, HashedSortGlobalSinkState &gstate);
-
-	//! Global state
-	HashedSortGlobalSinkState &gstate;
-	Allocator &allocator;
-
-	//! Shared expression evaluation
-	ExpressionExecutor hash_exec;
-	ExpressionExecutor sort_exec;
-	DataChunk group_chunk;
-	DataChunk sort_chunk;
-	DataChunk payload_chunk;
-	size_t sort_col_count;
-
-	//! Compute the hash values
-	void Hash(DataChunk &input_chunk, Vector &hash_vector);
-	//! Sink an input chunk
-	void Sink(ExecutionContext &context, DataChunk &input_chunk);
-	//! Merge the state into the global state.
-	void Combine(ExecutionContext &context);
-
-	// OVER(PARTITION BY...) (hash grouping)
-	GroupingPartition local_grouping;
-	GroupingAppend grouping_append;
-
-	// OVER(ORDER BY...) (only sorting)
-	LocalSortStatePtr sort_local;
-	InterruptState interrupt;
-
-	// OVER() (no sorting)
-	unique_ptr<ColumnDataCollection> unsorted;
-	ColumnDataAppendState unsorted_append;
-};
-
-class HashedSortCallback {
-public:
-	virtual ~HashedSortCallback() = default;
-	virtual void OnSortedGroup(HashedSortGroup &hash_group) = 0;
-};
-
-// Formerly PartitionMergeEvent
-class HashedSortMaterializeEvent : public BasePipelineEvent {
-public:
-	HashedSortMaterializeEvent(HashedSortGlobalSinkState &gstate, Pipeline &pipeline, const PhysicalOperator &op,
-	                           HashedSortCallback *callback);
-
-	HashedSortGlobalSinkState &gstate;
-	const PhysicalOperator &op;
-	optional_ptr<HashedSortCallback> callback;
-
-public:
-	void Schedule() override;
+	//! Common sort description
+	unique_ptr<Sort> sort;
+	//! Sorting callback for completed groups
+	mutable optional_ptr<HashedSortCallback> callback;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
* Convert HashedSort to use the operator APIs.
* Hide the HashedSort internals from prying eyes.

The larger goal here is to eventually split this into three Strategy patterns for modelling and implementing ordered metadata preprocessing (`HashedSort`, `FullSort` and `EmptySort`).