### PR TITLE
Move attached databases from a CatalogSet to a dedicated map of shared pointers

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -166,6 +166,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-mysql
             GIT_TAG dc470684cc670d1a4185a1a408e5d4c61f5356e8
+            APPLY_PATCHES
             )
 endif()
 

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -147,6 +147,7 @@ duckdb_extension_load(sqlsmith
         DONT_LINK LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb-sqlsmith
         GIT_TAG 3b1ad2bd7234c1143b4a819517873f4b465168d2
+        APPLY_PATCHES
         )
 
 ################# VSS

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -113,6 +113,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
             DONT_LINK
             GIT_URL https://github.com/duckdb/duckdb-postgres
             GIT_TAG c0411b950a0e80d232ba31f30bd484aebccca1b5
+            APPLY_PATCHES
             )
 endif()
 

--- a/.github/patches/extensions/mysql_scanner/fix.patch
+++ b/.github/patches/extensions/mysql_scanner/fix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/storage/mysql_clear_cache.cpp b/src/storage/mysql_clear_cache.cpp
+index bf288c0..2be4e46 100644
+--- a/src/storage/mysql_clear_cache.cpp
++++ b/src/storage/mysql_clear_cache.cpp
+@@ -24,7 +24,7 @@ static unique_ptr<FunctionData> ClearCacheBind(ClientContext &context, TableFunc
+ static void ClearMySQLCaches(ClientContext &context) {
+ 	auto databases = DatabaseManager::Get(context).GetDatabases(context);
+ 	for (auto &db_ref : databases) {
+-		auto &db = db_ref.get();
++		auto &db = *db_ref;
+ 		auto &catalog = db.GetCatalog();
+ 		if (catalog.GetCatalogType() != "mysql") {
+ 			continue;

--- a/.github/patches/extensions/postgres_scanner/fix.patch
+++ b/.github/patches/extensions/postgres_scanner/fix.patch
@@ -1,0 +1,26 @@
+diff --git a/src/postgres_extension.cpp b/src/postgres_extension.cpp
+index 5e54b69..aabaa5d 100644
+--- a/src/postgres_extension.cpp
++++ b/src/postgres_extension.cpp
+@@ -58,7 +58,7 @@ static void SetPostgresConnectionLimit(ClientContext &context, SetScope scope, V
+ 	}
+ 	auto databases = DatabaseManager::Get(context).GetDatabases(context);
+ 	for (auto &db_ref : databases) {
+-		auto &db = db_ref.get();
++		auto &db = *db_ref;
+ 		auto &catalog = db.GetCatalog();
+ 		if (catalog.GetCatalogType() != "postgres") {
+ 			continue;
+diff --git a/src/storage/postgres_clear_cache.cpp b/src/storage/postgres_clear_cache.cpp
+index 3e16e48..25c7ef6 100644
+--- a/src/storage/postgres_clear_cache.cpp
++++ b/src/storage/postgres_clear_cache.cpp
+@@ -24,7 +24,7 @@ static unique_ptr<FunctionData> ClearCacheBind(ClientContext &context, TableFunc
+ void PostgresClearCacheFunction::ClearPostgresCaches(ClientContext &context) {
+ 	auto databases = DatabaseManager::Get(context).GetDatabases(context);
+ 	for (auto &db_ref : databases) {
+-		auto &db = db_ref.get();
++		auto &db = *db_ref;
+ 		auto &catalog = db.GetCatalog();
+ 		if (catalog.GetCatalogType() != "postgres") {
+ 			continue;

--- a/.github/patches/extensions/sqlsmith/fix.patch
+++ b/.github/patches/extensions/sqlsmith/fix.patch
@@ -1,0 +1,24 @@
+diff --git a/src/statement_generator.cpp b/src/statement_generator.cpp
+index 325fb0a..fc34c7c 100644
+--- a/src/statement_generator.cpp
++++ b/src/statement_generator.cpp
+@@ -34,7 +34,7 @@ struct GeneratorContext {
+ 	vector<reference<CatalogEntry>> table_functions;
+ 	vector<reference<CatalogEntry>> pragma_functions;
+ 	vector<reference<CatalogEntry>> tables_and_views;
+-	vector<reference<AttachedDatabase>> attached_databases;
++	vector<shared_ptr<AttachedDatabase>> attached_databases;
+ };
+ 
+ StatementGenerator::StatementGenerator(ClientContext &context) : context(context), parent(nullptr), depth(0) {
+@@ -216,8 +216,8 @@ unique_ptr<DetachInfo> StatementGenerator::GenerateDetachInfo() {
+ 
+ std::string StatementGenerator::GetRandomAttachedDataBase() {
+ 	auto state = GetDatabaseState(context);
+-	auto st_name = state->attached_databases[RandomValue(state->attached_databases.size())];
+-	auto name = st_name.get().name;
++	auto &st_name = *state->attached_databases[RandomValue(state->attached_databases.size())];
++	auto name = st_name.name;
+ 	return name;
+ }
+ 

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -96,13 +96,13 @@ static vector<AutoCompleteSuggestion> ComputeSuggestions(vector<AutoCompleteCand
 	return results;
 }
 
-static vector<reference<AttachedDatabase>> GetAllCatalogs(ClientContext &context) {
-	vector<reference<AttachedDatabase>> result;
+static vector<shared_ptr<AttachedDatabase>> GetAllCatalogs(ClientContext &context) {
+	vector<shared_ptr<AttachedDatabase>> result;
 
 	auto &database_manager = DatabaseManager::Get(context);
 	auto databases = database_manager.GetDatabases(context);
 	for (auto &database : databases) {
-		result.push_back(database.get());
+		result.push_back(database);
 	}
 	return result;
 }
@@ -145,7 +145,7 @@ static vector<AutoCompleteCandidate> SuggestCatalogName(ClientContext &context) 
 	vector<AutoCompleteCandidate> suggestions;
 	auto all_entries = GetAllCatalogs(context);
 	for (auto &entry_ref : all_entries) {
-		auto &entry = entry_ref.get();
+		auto &entry = *entry_ref;
 		AutoCompleteCandidate candidate(entry.name, 0);
 		candidate.extra_char = '.';
 		suggestions.push_back(std::move(candidate));

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1119,7 +1119,7 @@ vector<reference<SchemaCatalogEntry>> Catalog::GetAllSchemas(ClientContext &cont
 
 	auto &db_manager = DatabaseManager::Get(context);
 	auto databases = db_manager.GetDatabases(context);
-	for (auto database : databases) {
+	for (auto &database : databases) {
 		auto &catalog = database->GetCatalog();
 		auto new_schemas = catalog.GetSchemas(context);
 		result.insert(result.end(), new_schemas.begin(), new_schemas.end());

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -661,7 +661,7 @@ CatalogException Catalog::CreateMissingEntryException(CatalogEntryRetriever &ret
 		if (unseen_schemas.size() >= max_schema_count) {
 			break;
 		}
-		auto &catalog = database.get().GetCatalog();
+		auto &catalog = database->GetCatalog();
 		auto current_schemas = catalog.GetSchemas(context);
 		for (auto &current_schema : current_schemas) {
 			if (unseen_schemas.size() >= max_schema_count) {
@@ -1120,7 +1120,7 @@ vector<reference<SchemaCatalogEntry>> Catalog::GetAllSchemas(ClientContext &cont
 	auto &db_manager = DatabaseManager::Get(context);
 	auto databases = db_manager.GetDatabases(context);
 	for (auto database : databases) {
-		auto &catalog = database.get().GetCatalog();
+		auto &catalog = database->GetCatalog();
 		auto new_schemas = catalog.GetSchemas(context);
 		result.insert(result.end(), new_schemas.begin(), new_schemas.end());
 	}

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4392,19 +4392,20 @@ const StringUtil::EnumStringLiteral *GetUndoFlagsValues() {
 		{ static_cast<uint32_t>(UndoFlags::INSERT_TUPLE), "INSERT_TUPLE" },
 		{ static_cast<uint32_t>(UndoFlags::DELETE_TUPLE), "DELETE_TUPLE" },
 		{ static_cast<uint32_t>(UndoFlags::UPDATE_TUPLE), "UPDATE_TUPLE" },
-		{ static_cast<uint32_t>(UndoFlags::SEQUENCE_VALUE), "SEQUENCE_VALUE" }
+		{ static_cast<uint32_t>(UndoFlags::SEQUENCE_VALUE), "SEQUENCE_VALUE" },
+		{ static_cast<uint32_t>(UndoFlags::ATTACHED_DATABASE), "ATTACHED_DATABASE" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<UndoFlags>(UndoFlags value) {
-	return StringUtil::EnumToString(GetUndoFlagsValues(), 6, "UndoFlags", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetUndoFlagsValues(), 7, "UndoFlags", static_cast<uint32_t>(value));
 }
 
 template<>
 UndoFlags EnumUtil::FromString<UndoFlags>(const char *value) {
-	return static_cast<UndoFlags>(StringUtil::StringToEnum(GetUndoFlagsValues(), 6, "UndoFlags", value));
+	return static_cast<UndoFlags>(StringUtil::StringToEnum(GetUndoFlagsValues(), 7, "UndoFlags", value));
 }
 
 const StringUtil::EnumStringLiteral *GetUnionInvalidReasonValues() {

--- a/src/execution/operator/helper/physical_transaction.cpp
+++ b/src/execution/operator/helper/physical_transaction.cpp
@@ -35,7 +35,7 @@ SourceResultType PhysicalTransaction::GetData(ExecutionContext &context, DataChu
 			if (config.options.immediate_transaction_mode) {
 				// if immediate transaction mode is enabled then start all transactions immediately
 				auto databases = DatabaseManager::Get(client).GetDatabases(client);
-				for (auto db : databases) {
+				for (auto &db : databases) {
 					context.client.transaction.ActiveTransaction().GetTransaction(*db);
 				}
 			}

--- a/src/execution/operator/helper/physical_transaction.cpp
+++ b/src/execution/operator/helper/physical_transaction.cpp
@@ -36,7 +36,7 @@ SourceResultType PhysicalTransaction::GetData(ExecutionContext &context, DataChu
 				// if immediate transaction mode is enabled then start all transactions immediately
 				auto databases = DatabaseManager::Get(client).GetDatabases(client);
 				for (auto db : databases) {
-					context.client.transaction.ActiveTransaction().GetTransaction(db.get());
+					context.client.transaction.ActiveTransaction().GetTransaction(*db);
 				}
 			}
 		} else {

--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -73,6 +73,8 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 		attached_db->GetCatalog().SetDefaultTable(options.default_table.schema, options.default_table.name);
 	}
 	attached_db->FinalizeLoad(context.client);
+
+	db_manager.FinalizeAttach(context.client, *info, std::move(attached_db));
 	return SourceResultType::FINISHED;
 }
 

--- a/src/function/table/system/duckdb_databases.cpp
+++ b/src/function/table/system/duckdb_databases.cpp
@@ -8,7 +8,7 @@ struct DuckDBDatabasesData : public GlobalTableFunctionState {
 	DuckDBDatabasesData() : offset(0) {
 	}
 
-	vector<reference<AttachedDatabase>> entries;
+	vector<shared_ptr<AttachedDatabase>> entries;
 	idx_t offset;
 };
 
@@ -62,7 +62,7 @@ void DuckDBDatabasesFunction(ClientContext &context, TableFunctionInput &data_p,
 	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = data.entries[data.offset++];
 
-		auto &attached = entry.get().Cast<AttachedDatabase>();
+		auto &attached = *entry;
 		// return values:
 
 		idx_t col = 0;

--- a/src/function/table/system/pragma_database_size.cpp
+++ b/src/function/table/system/pragma_database_size.cpp
@@ -15,7 +15,7 @@ struct PragmaDatabaseSizeData : public GlobalTableFunctionState {
 	}
 
 	idx_t index;
-	vector<reference<AttachedDatabase>> databases;
+	vector<shared_ptr<AttachedDatabase>> databases;
 	Value memory_usage;
 	Value memory_limit;
 };
@@ -68,7 +68,7 @@ void PragmaDatabaseSizeFunction(ClientContext &context, TableFunctionInput &data
 	auto &data = data_p.global_state->Cast<PragmaDatabaseSizeData>();
 	idx_t row = 0;
 	for (; data.index < data.databases.size() && row < STANDARD_VECTOR_SIZE; data.index++) {
-		auto &db = data.databases[data.index].get();
+		auto &db = *data.databases[data.index];
 		if (db.IsSystem() || db.IsTemporary()) {
 			continue;
 		}

--- a/src/include/duckdb/common/enums/undo_flags.hpp
+++ b/src/include/duckdb/common/enums/undo_flags.hpp
@@ -18,7 +18,8 @@ enum class UndoFlags : uint32_t { // far too big but aligned (TM)
 	INSERT_TUPLE = 2,
 	DELETE_TUPLE = 3,
 	UPDATE_TUPLE = 4,
-	SEQUENCE_VALUE = 5
+	SEQUENCE_VALUE = 5,
+	ATTACHED_DATABASE = 6
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -32,6 +32,14 @@ enum class AttachedDatabaseType {
 	TEMP_DATABASE,
 };
 
+struct StoredDatabasePath {
+	StoredDatabasePath(DatabaseManager &manager, string path, const string &name);
+	~StoredDatabasePath();
+
+	DatabaseManager &manager;
+	string path;
+};
+
 //! AttachOptions holds information about a database we plan to attach. These options are generalized, i.e.,
 //! they have to apply to any database file type (duckdb, sqlite, etc.).
 struct AttachOptions {
@@ -95,7 +103,11 @@ public:
 	static string ExtractDatabaseName(const string &dbpath, FileSystem &fs);
 
 private:
+	void InsertDatabasePath(const string &path);
+
+private:
 	DatabaseInstance &db;
+	unique_ptr<StoredDatabasePath> stored_database_path;
 	unique_ptr<StorageManager> storage;
 	unique_ptr<Catalog> catalog;
 	unique_ptr<TransactionManager> transaction_manager;

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -59,7 +59,7 @@ struct AttachOptions {
 };
 
 //! The AttachedDatabase represents an attached database instance.
-class AttachedDatabase : public CatalogEntry {
+class AttachedDatabase : public CatalogEntry, public enable_shared_from_this<AttachedDatabase> {
 public:
 	//! Create the built-in system database (without storage).
 	explicit AttachedDatabase(DatabaseInstance &db, AttachedDatabaseType type = AttachedDatabaseType::SYSTEM_DATABASE);

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -75,7 +75,7 @@ public:
 
 	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) const;
 
-	unique_ptr<AttachedDatabase> CreateAttachedDatabase(ClientContext &context, AttachInfo &info,
+	shared_ptr<AttachedDatabase> CreateAttachedDatabase(ClientContext &context, AttachInfo &info,
 	                                                    AttachOptions &options);
 
 	void AddExtensionInfo(const string &name, const ExtensionLoadedInfo &info);

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -63,8 +63,8 @@ public:
 	void InsertDatabasePath(const string &path, const string &name);
 	//! Erases a path from the database paths map
 	void EraseDatabasePath(const string &path);
-    //! Check if a path has a conflict
-    void CheckPathConflict(const string &path, const string &name);
+	//! Check if a path has a conflict
+	void CheckPathConflict(const string &path, const string &name);
 
 	//! Returns the database type. This might require checking the header of the file, in which case the file handle is
 	//! necessary. We can only grab the file handle, if it is not yet held, even for uncommitted changes. Thus, we have

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -58,7 +58,7 @@ public:
 	void SetDefaultDatabase(ClientContext &context, const string &new_value);
 
 	//! Inserts a path to name mapping to the database paths map
-	void InsertDatabasePath(ClientContext &context, const string &path, const string &name);
+	void InsertDatabasePath(const string &path, const string &name);
 	//! Erases a path from the database paths map
 	void EraseDatabasePath(const string &path);
 
@@ -69,7 +69,7 @@ public:
 	//! Scans the catalog set and adds each committed database entry, and each database entry of the current
 	//! transaction, to a vector holding AttachedDatabase references
 	vector<shared_ptr<AttachedDatabase>> GetDatabases(ClientContext &context,
-	                                                 const optional_idx max_db_count = optional_idx());
+	                                                  const optional_idx max_db_count = optional_idx());
 	//! Scans the catalog set and returns each committed database entry
 	vector<shared_ptr<AttachedDatabase>> GetDatabases();
 	//! Removes all databases from the catalog set. This is necessary for the database instance's destructor,
@@ -96,9 +96,6 @@ public:
 	}
 	//! Gets a list of all attached database paths
 	vector<string> GetAttachedDatabasePaths();
-
-private:
-	void CheckPathConflict(ClientContext &context, const string &path);
 
 private:
 	//! The system database is a special database that holds system entries (e.g. functions)

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -68,10 +68,10 @@ public:
 	void GetDatabaseType(ClientContext &context, AttachInfo &info, const DBConfig &config, AttachOptions &options);
 	//! Scans the catalog set and adds each committed database entry, and each database entry of the current
 	//! transaction, to a vector holding AttachedDatabase references
-	vector<reference<AttachedDatabase>> GetDatabases(ClientContext &context,
+	vector<shared_ptr<AttachedDatabase>> GetDatabases(ClientContext &context,
 	                                                 const optional_idx max_db_count = optional_idx());
 	//! Scans the catalog set and returns each committed database entry
-	vector<reference<AttachedDatabase>> GetDatabases();
+	vector<shared_ptr<AttachedDatabase>> GetDatabases();
 	//! Removes all databases from the catalog set. This is necessary for the database instance's destructor,
 	//! as the database manager has to be alive when destroying the catalog set objects.
 	void ResetDatabases(unique_ptr<TaskScheduler> &scheduler);
@@ -102,9 +102,11 @@ private:
 
 private:
 	//! The system database is a special database that holds system entries (e.g. functions)
-	unique_ptr<AttachedDatabase> system;
+	shared_ptr<AttachedDatabase> system;
+	//! Lock for databases
+	mutex databases_lock;
 	//! The set of attached databases
-	unique_ptr<CatalogSet> databases;
+	case_insensitive_map_t<shared_ptr<AttachedDatabase>> databases;
 	//! The next object id handed out by the NextOid method
 	atomic<idx_t> next_oid;
 	//! The current query number

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -63,6 +63,8 @@ public:
 	void InsertDatabasePath(const string &path, const string &name);
 	//! Erases a path from the database paths map
 	void EraseDatabasePath(const string &path);
+    //! Check if a path has a conflict
+    void CheckPathConflict(const string &path, const string &name);
 
 	//! Returns the database type. This might require checking the header of the file, in which case the file handle is
 	//! necessary. We can only grab the file handle, if it is not yet held, even for uncommitted changes. Thus, we have

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -48,7 +48,10 @@ public:
 	//! Get an attached database by its name
 	optional_ptr<AttachedDatabase> GetDatabase(ClientContext &context, const string &name);
 	//! Attach a new database
-	optional_ptr<AttachedDatabase> AttachDatabase(ClientContext &context, AttachInfo &info, AttachOptions &options);
+	shared_ptr<AttachedDatabase> AttachDatabase(ClientContext &context, AttachInfo &info, AttachOptions &options);
+
+	optional_ptr<AttachedDatabase> FinalizeAttach(ClientContext &context, AttachInfo &info,
+	                                              shared_ptr<AttachedDatabase> database);
 	//! Detach an existing database
 	void DetachDatabase(ClientContext &context, const string &name, OnEntryNotFound if_not_found);
 	//! Rollback the attach of a database

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -51,6 +51,8 @@ public:
 	optional_ptr<AttachedDatabase> AttachDatabase(ClientContext &context, AttachInfo &info, AttachOptions &options);
 	//! Detach an existing database
 	void DetachDatabase(ClientContext &context, const string &name, OnEntryNotFound if_not_found);
+	//! Rollback the attach of a database
+	shared_ptr<AttachedDatabase> DetachInternal(const string &name);
 	//! Returns a reference to the system catalog
 	Catalog &GetSystemCatalog();
 

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -51,6 +51,7 @@ public:
 	LocalStorage &GetLocalStorage();
 
 	void PushCatalogEntry(CatalogEntry &entry, data_ptr_t extra_data, idx_t extra_data_size);
+	void PushAttach(AttachedDatabase &db);
 
 	void SetReadWrite() override;
 

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -70,6 +70,7 @@ public:
 
 	void PushCatalogEntry(Transaction &transaction_p, CatalogEntry &entry, data_ptr_t extra_data = nullptr,
 	                      idx_t extra_data_size = 0);
+	void PushAttach(Transaction &transaction_p, AttachedDatabase &db);
 
 protected:
 	struct CheckpointDecision {

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -63,6 +63,7 @@ public:
 	const vector<reference<AttachedDatabase>> &OpenedTransactions() const {
 		return all_transactions;
 	}
+	AttachedDatabase &UseDatabase(shared_ptr<AttachedDatabase> &database);
 
 private:
 	//! Lock to prevent all_transactions and transactions from getting out of sync
@@ -75,6 +76,8 @@ private:
 	optional_ptr<AttachedDatabase> modified_database;
 	//! Whether or not the meta transaction is marked as read only
 	bool is_read_only;
+	//! The set of used / referenced databases
+	reference_map_t<AttachedDatabase, shared_ptr<AttachedDatabase>> referenced_databases;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -64,7 +64,6 @@ public:
 		return all_transactions;
 	}
 	AttachedDatabase &UseDatabase(shared_ptr<AttachedDatabase> &database);
-	AttachedDatabase &AttachDatabase(shared_ptr<AttachedDatabase> &database);
 
 private:
 	//! Lock to prevent all_transactions and transactions from getting out of sync
@@ -79,8 +78,6 @@ private:
 	bool is_read_only;
 	//! The set of used / referenced databases
 	reference_map_t<AttachedDatabase, shared_ptr<AttachedDatabase>> referenced_databases;
-	//! The set of databases attached by this transaction
-	vector<shared_ptr<AttachedDatabase>> attached_databases;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -64,6 +64,7 @@ public:
 		return all_transactions;
 	}
 	AttachedDatabase &UseDatabase(shared_ptr<AttachedDatabase> &database);
+	AttachedDatabase &AttachDatabase(shared_ptr<AttachedDatabase> &database);
 
 private:
 	//! Lock to prevent all_transactions and transactions from getting out of sync
@@ -78,6 +79,8 @@ private:
 	bool is_read_only;
 	//! The set of used / referenced databases
 	reference_map_t<AttachedDatabase, shared_ptr<AttachedDatabase>> referenced_databases;
+	//! The set of databases attached by this transaction
+	vector<shared_ptr<AttachedDatabase>> attached_databases;
 };
 
 } // namespace duckdb

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -93,7 +93,6 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, AttachedDatabaseType ty
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, string name_p, string file_path_p,
                                    AttachOptions &options)
     : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p) {
-
 	if (options.access_mode == AccessMode::READ_ONLY) {
 		type = AttachedDatabaseType::READ_ONLY_DATABASE;
 	} else {

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -13,6 +13,14 @@
 
 namespace duckdb {
 
+StoredDatabasePath::StoredDatabasePath(DatabaseManager &manager, string path_p, const string &name)
+    : manager(manager), path(std::move(path_p)) {
+	manager.InsertDatabasePath(path, name);
+}
+
+StoredDatabasePath::~StoredDatabasePath() {
+	manager.EraseDatabasePath(path);
+}
 //===--------------------------------------------------------------------===//
 // Attach Options
 //===--------------------------------------------------------------------===//
@@ -66,7 +74,6 @@ AttachOptions::AttachOptions(const unique_ptr<AttachInfo> &info, const AccessMod
 //===--------------------------------------------------------------------===//
 // Attached Database
 //===--------------------------------------------------------------------===//
-
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, AttachedDatabaseType type)
     : CatalogEntry(CatalogType::DATABASE_ENTRY,
                    type == AttachedDatabaseType::SYSTEM_DATABASE ? SYSTEM_CATALOG : TEMP_CATALOG, 0),
@@ -107,8 +114,10 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 		}
 		throw BinderException("Unrecognized option for attach \"%s\"", entry.first);
 	}
+
 	// We create the storage after the catalog to guarantee we allow extensions to instantiate the DuckCatalog.
 	catalog = make_uniq<DuckCatalog>(*this);
+	InsertDatabasePath(file_path_p);
 	auto read_only = options.access_mode == AccessMode::READ_ONLY;
 	storage = make_uniq<SingleFileStorageManager>(*this, std::move(file_path_p), read_only);
 	transaction_manager = make_uniq<DuckTransactionManager>(*this);
@@ -131,6 +140,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 		throw InternalException("AttachedDatabase - attach function did not return a catalog");
 	}
 	if (catalog->IsDuckCatalog()) {
+		InsertDatabasePath(info.path);
 		// The attached database uses the DuckCatalog.
 		auto read_only = options.access_mode == AccessMode::READ_ONLY;
 		storage = make_uniq<SingleFileStorageManager>(*this, info.path, read_only);
@@ -157,6 +167,13 @@ bool AttachedDatabase::IsTemporary() const {
 }
 bool AttachedDatabase::IsReadOnly() const {
 	return type == AttachedDatabaseType::READ_ONLY_DATABASE;
+}
+
+void AttachedDatabase::InsertDatabasePath(const string &path) {
+	if (path.empty() || path == IN_MEMORY_PATH) {
+		return;
+	}
+	stored_database_path = make_uniq<StoredDatabasePath>(db.GetDatabaseManager(), path, name);
 }
 
 bool AttachedDatabase::NameIsReserved(const string &name) {
@@ -232,37 +249,30 @@ void AttachedDatabase::OnDetach(ClientContext &context) {
 }
 
 void AttachedDatabase::Close() {
-	D_ASSERT(catalog);
 	if (is_closed) {
 		return;
 	}
+	D_ASSERT(catalog);
 	is_closed = true;
-
-	if (!IsSystem() && !catalog->InMemory()) {
-		db.GetDatabaseManager().EraseDatabasePath(catalog->GetDBPath());
-	}
-
-	if (Exception::UncaughtException()) {
-		return;
-	}
-	if (!storage) {
-		return;
-	}
 
 	// shutting down: attempt to checkpoint the database
 	// but only if we are not cleaning up as part of an exception unwind
-	try {
-		if (!storage->InMemory()) {
+	if (!Exception::UncaughtException() && storage && !storage->InMemory()) {
+		try {
 			auto &config = DBConfig::GetConfig(db);
-			if (!config.options.checkpoint_on_shutdown) {
-				return;
+			if (config.options.checkpoint_on_shutdown) {
+				CheckpointOptions options;
+				options.wal_action = CheckpointWALAction::DELETE_WAL;
+				storage->CreateCheckpoint(nullptr, options);
 			}
-			CheckpointOptions options;
-			options.wal_action = CheckpointWALAction::DELETE_WAL;
-			storage->CreateCheckpoint(nullptr, options);
+		} catch (...) { // NOLINT
 		}
-	} catch (...) { // NOLINT
 	}
+
+	transaction_manager.reset();
+	catalog.reset();
+	storage.reset();
+	stored_database_path.reset();
 
 	if (Allocator::SupportsFlush()) {
 		Allocator::FlushAll();

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -496,7 +496,8 @@ void ClientContext::CheckIfPreparedStatementIsExecutable(PreparedStatementData &
 		auto &modified_database = it.first;
 		auto entry = manager.GetDatabase(*this, modified_database);
 		if (!entry) {
-			throw InternalException("Database \"%s\" not found", modified_database);
+			// database has been detached
+			throw InvalidInputException("Database \"%s\" not found", modified_database);
 		}
 		if (entry->IsReadOnly()) {
 			throw InvalidInputException(StringUtil::Format(

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -206,14 +206,13 @@ void DatabaseInstance::CreateMainDatabase() {
 	info.name = AttachedDatabase::ExtractDatabaseName(config.options.database_path, GetFileSystem());
 	info.path = config.options.database_path;
 
-	optional_ptr<AttachedDatabase> initial_database;
 	Connection con(*this);
 	con.BeginTransaction();
 	AttachOptions options(config.options);
-	initial_database = db_manager->AttachDatabase(*con.context, info, options);
-
+	auto initial_database = db_manager->AttachDatabase(*con.context, info, options);
 	initial_database->SetInitialDatabase();
 	initial_database->Initialize(*con.context);
+	db_manager->FinalizeAttach(*con.context, info, std::move(initial_database));
 	con.Commit();
 }
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -172,9 +172,9 @@ ConnectionManager &ConnectionManager::Get(ClientContext &context) {
 	return ConnectionManager::Get(DatabaseInstance::GetDatabase(context));
 }
 
-unique_ptr<AttachedDatabase> DatabaseInstance::CreateAttachedDatabase(ClientContext &context, AttachInfo &info,
+shared_ptr<AttachedDatabase> DatabaseInstance::CreateAttachedDatabase(ClientContext &context, AttachInfo &info,
                                                                       AttachOptions &options) {
-	unique_ptr<AttachedDatabase> attached_database;
+	shared_ptr<AttachedDatabase> attached_database;
 	auto &catalog = Catalog::GetSystemCatalog(*this);
 
 	if (!options.db_type.empty()) {
@@ -188,16 +188,16 @@ unique_ptr<AttachedDatabase> DatabaseInstance::CreateAttachedDatabase(ClientCont
 		if (entry->second->attach != nullptr && entry->second->create_transaction_manager != nullptr) {
 			// Use the storage extension to create the initial database.
 			attached_database =
-			    make_uniq<AttachedDatabase>(*this, catalog, *entry->second, context, info.name, info, options);
+			    make_shared_ptr<AttachedDatabase>(*this, catalog, *entry->second, context, info.name, info, options);
 			return attached_database;
 		}
 
-		attached_database = make_uniq<AttachedDatabase>(*this, catalog, info.name, info.path, options);
+		attached_database = make_shared_ptr<AttachedDatabase>(*this, catalog, info.name, info.path, options);
 		return attached_database;
 	}
 
 	// An empty db_type defaults to a duckdb database file.
-	attached_database = make_uniq<AttachedDatabase>(*this, catalog, info.name, info.path, options);
+	attached_database = make_shared_ptr<AttachedDatabase>(*this, catalog, info.name, info.path, options);
 	return attached_database;
 }
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
+#include "duckdb/transaction/duck_transaction_manager.hpp"
 
 namespace duckdb {
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -88,14 +88,15 @@ optional_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &co
 	if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
 		DetachDatabase(context, name, OnEntryNotFound::RETURN_NULL);
 	}
-	lock_guard<mutex> guard(databases_lock);
-	auto entry = databases.emplace(name, attached_db);
-	if (!entry.second) {
-		throw BinderException("Failed to attach database: database with name \"%s\" already exists", name);
+	{
+		lock_guard<mutex> guard(databases_lock);
+		auto entry = databases.emplace(name, attached_db);
+		if (!entry.second) {
+			throw BinderException("Failed to attach database: database with name \"%s\" already exists", name);
+		}
 	}
 	auto &meta_transaction = MetaTransaction::Get(context);
 	auto &db_ref = meta_transaction.UseDatabase(attached_db);
-	;
 	auto &transaction = DuckTransaction::Get(context, *system);
 	auto &transaction_manager = DuckTransactionManager::Get(*system);
 	transaction_manager.PushAttach(transaction, db_ref);

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -142,7 +142,7 @@ void DatabaseManager::CheckPathConflict(const string &path, const string &name) 
 
 	lock_guard<mutex> path_lock(db_paths_lock);
 	auto entry = db_paths_to_name.find(path);
-    if (entry != db_paths_to_name.end()) {
+	if (entry != db_paths_to_name.end()) {
 		throw BinderException("Unique file handle conflict: Cannot attach \"%s\" - the database file \"%s\" is already "
 		                      "attached by database \"%s\"",
 		                      name, path, entry->second);
@@ -192,7 +192,7 @@ void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, 
 	// Try to extract the database type from the path.
 	if (options.db_type.empty()) {
 		auto &fs = FileSystem::GetFileSystem(context);
-        CheckPathConflict(info.path, info.name);
+		CheckPathConflict(info.path, info.name);
 		DBPathAndType::CheckMagicBytes(fs, info.path, options.db_type);
 	}
 

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -182,6 +182,7 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data) {
 		info->version_number = commit_id;
 		break;
 	}
+	case UndoFlags::ATTACHED_DATABASE:
 	case UndoFlags::SEQUENCE_VALUE: {
 		break;
 	}
@@ -222,6 +223,7 @@ void CommitState::RevertCommit(UndoFlags type, data_ptr_t data) {
 		info->version_number = transaction_id;
 		break;
 	}
+	case UndoFlags::ATTACHED_DATABASE:
 	case UndoFlags::SEQUENCE_VALUE: {
 		break;
 	}

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -76,6 +76,13 @@ void DuckTransaction::PushCatalogEntry(CatalogEntry &entry, data_ptr_t extra_dat
 	}
 }
 
+void DuckTransaction::PushAttach(AttachedDatabase &db) {
+	auto undo_entry = undo_buffer.CreateEntry(UndoFlags::ATTACHED_DATABASE, sizeof(AttachedDatabase *));
+	auto ptr = undo_entry.Ptr();
+	// store the pointer to the database
+	Store<CatalogEntry *>(&db, ptr);
+}
+
 void DuckTransaction::PushDelete(DataTable &table, RowVersionManager &info, idx_t vector_idx, row_t rows[], idx_t count,
                                  idx_t base_row) {
 	ModifyTable(table);

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -518,4 +518,13 @@ void DuckTransactionManager::PushCatalogEntry(Transaction &transaction_p, duckdb
 	transaction.PushCatalogEntry(entry, extra_data, extra_data_size);
 }
 
+void DuckTransactionManager::PushAttach(Transaction &transaction_p, AttachedDatabase &attached_db) {
+	auto &transaction = transaction_p.Cast<DuckTransaction>();
+	if (!db.IsSystem()) {
+		throw InternalException("Can only ATTACH in the system catalog");
+	}
+	transaction.catalog_version = ++last_uncommitted_catalog_version;
+	transaction.PushAttach(attached_db);
+}
+
 } // namespace duckdb

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -155,16 +155,6 @@ void MetaTransaction::Rollback() {
 			error.Merge(ErrorData(ex));
 		}
 	}
-	// detach any databases that were attached by this transaction
-	for (auto &entry : attached_databases) {
-		try {
-			auto &db_manager = DatabaseManager::Get(context);
-			db_manager.DetachDatabase(context, entry->name, OnEntryNotFound::RETURN_NULL);
-			entry.reset();
-		} catch (std::exception &ex) {
-			error.Merge(ErrorData(ex));
-		}
-	}
 	if (error.HasError()) {
 		error.Throw();
 	}
@@ -188,11 +178,6 @@ AttachedDatabase &MetaTransaction::UseDatabase(shared_ptr<AttachedDatabase> &dat
 		referenced_databases.emplace(reference<AttachedDatabase>(db_ref), database);
 	}
 	return db_ref;
-}
-
-AttachedDatabase &MetaTransaction::AttachDatabase(shared_ptr<AttachedDatabase> &database) {
-	attached_databases.push_back(database);
-	return UseDatabase(database);
 }
 
 void MetaTransaction::ModifyDatabase(AttachedDatabase &db) {

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -64,6 +64,7 @@ Transaction &MetaTransaction::GetTransaction(AttachedDatabase &db) {
 #endif
 		all_transactions.push_back(db);
 		transactions.insert(make_pair(reference<AttachedDatabase>(db), reference<Transaction>(new_transaction)));
+		referenced_databases.insert(make_pair(reference<AttachedDatabase>(db), db.shared_from_this()));
 
 		return new_transaction;
 	} else {

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -171,6 +171,15 @@ void MetaTransaction::SetActiveQuery(transaction_t query_number) {
 	}
 }
 
+AttachedDatabase &MetaTransaction::UseDatabase(shared_ptr<AttachedDatabase> &database) {
+	auto &db_ref = *database;
+	auto entry = referenced_databases.find(db_ref);
+	if (entry == referenced_databases.end()) {
+		referenced_databases.emplace(reference<AttachedDatabase>(db_ref), database);
+	}
+	return db_ref;
+}
+
 void MetaTransaction::ModifyDatabase(AttachedDatabase &db) {
 	if (db.IsSystem() || db.IsTemporary()) {
 		// we can always modify the system and temp databases

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -155,6 +155,16 @@ void MetaTransaction::Rollback() {
 			error.Merge(ErrorData(ex));
 		}
 	}
+	// detach any databases that were attached by this transaction
+	for (auto &entry : attached_databases) {
+		try {
+			auto &db_manager = DatabaseManager::Get(context);
+			db_manager.DetachDatabase(context, entry->name, OnEntryNotFound::RETURN_NULL);
+			entry.reset();
+		} catch (std::exception &ex) {
+			error.Merge(ErrorData(ex));
+		}
+	}
 	if (error.HasError()) {
 		error.Throw();
 	}
@@ -178,6 +188,11 @@ AttachedDatabase &MetaTransaction::UseDatabase(shared_ptr<AttachedDatabase> &dat
 		referenced_databases.emplace(reference<AttachedDatabase>(db_ref), database);
 	}
 	return db_ref;
+}
+
+AttachedDatabase &MetaTransaction::AttachDatabase(shared_ptr<AttachedDatabase> &database) {
+	attached_databases.push_back(database);
+	return UseDatabase(database);
 }
 
 void MetaTransaction::ModifyDatabase(AttachedDatabase &db) {

--- a/src/transaction/rollback_state.cpp
+++ b/src/transaction/rollback_state.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/table/update_segment.hpp"
 #include "duckdb/storage/table/row_version_manager.hpp"
+#include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
 

--- a/src/transaction/rollback_state.cpp
+++ b/src/transaction/rollback_state.cpp
@@ -42,6 +42,12 @@ void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
 		info->segment->RollbackUpdate(*info);
 		break;
 	}
+	case UndoFlags::ATTACHED_DATABASE: {
+		auto db = Load<AttachedDatabase *>(data);
+		auto &db_manager = DatabaseManager::Get(db->GetDatabase());
+		db_manager.DetachInternal(db->name);
+		break;
+	}
 	case UndoFlags::SEQUENCE_VALUE:
 		break;
 	default: // LCOV_EXCL_START

--- a/src/transaction/wal_write_state.cpp
+++ b/src/transaction/wal_write_state.cpp
@@ -281,6 +281,8 @@ void WALWriteState::CommitEntry(UndoFlags type, data_ptr_t data) {
 		}
 		break;
 	}
+	case UndoFlags::ATTACHED_DATABASE:
+		break;
 	case UndoFlags::SEQUENCE_VALUE: {
 		auto info = reinterpret_cast<SequenceValue *>(data);
 		log.WriteSequenceValue(*info);

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -22,7 +22,8 @@
         "test/sql/attach/attach_issue_7660.test",
         "test/sql/attach/show_databases.test",
         "test/sql/attach/attach_views.test",
-        "test/sql/copy_database/copy_table_with_sequence.test"
+        "test/sql/copy_database/copy_table_with_sequence.test",
+        "test/sql/attach/attach_use_rollback.test"
       ]
     }
   ]

--- a/test/configs/wal_verification.json
+++ b/test/configs/wal_verification.json
@@ -24,7 +24,8 @@
         "test/sql/pg_catalog/sqlalchemy.test",
         "test/sql/pg_catalog/system_functions.test",
         "test/sql/pragma/test_show_tables_temp_views.test",
-        "test/sql/show_select/test_describe_all.test"
+        "test/sql/show_select/test_describe_all.test",
+        "test/sql/attach/attach_use_rollback.test"
       ]
     },
     {

--- a/test/sql/attach/attach_concurrent_detach_mix.test_slow
+++ b/test/sql/attach/attach_concurrent_detach_mix.test_slow
@@ -14,7 +14,6 @@ Unique file handle conflict
 statement maybe
 CREATE TABLE attach_mix_${k}.tbl${i} AS SELECT * FROM range(${k} * ${i}) t(i)
 ----
-no database
 
 statement maybe
 DETACH attach_mix_${k}

--- a/test/sql/attach/attach_concurrent_detach_mix.test_slow
+++ b/test/sql/attach/attach_concurrent_detach_mix.test_slow
@@ -18,7 +18,7 @@ CREATE TABLE attach_mix_${k}.tbl${i} AS SELECT * FROM range(${k} * ${i}) t(i)
 
 onlyif i>=20
 statement maybe
-SELECT COUNT(*) FROM attach_mix_${k}.tbl${i}
+SELECT COUNT(*) FROM attach_mix_${k}.tbl${k}
 ----
 
 statement maybe

--- a/test/sql/attach/attach_concurrent_detach_mix.test_slow
+++ b/test/sql/attach/attach_concurrent_detach_mix.test_slow
@@ -12,7 +12,7 @@ ATTACH IF NOT EXISTS '__TEST_DIR__/attach_mix_${k}.db'
 Unique file handle conflict
 
 statement maybe
-CREATE TABLE attach_mix_${k}_${i} AS SELECT * FROM range(${k} * ${i}) t(i)
+CREATE TABLE attach_mix_${k}.tbl${i} AS SELECT * FROM range(${k} * ${i}) t(i)
 ----
 no database
 

--- a/test/sql/attach/attach_concurrent_detach_mix.test_slow
+++ b/test/sql/attach/attach_concurrent_detach_mix.test_slow
@@ -1,0 +1,26 @@
+# name: test/sql/attach/attach_concurrent_detach_mix.test_slow
+# description: Concurrently attaching/detaching/using different databases
+# group: [attach]
+
+concurrentloop i 0 40
+
+loop k 0 10
+
+statement maybe
+ATTACH IF NOT EXISTS '__TEST_DIR__/attach_mix_${k}.db'
+----
+Unique file handle conflict
+
+statement maybe
+CREATE TABLE attach_mix_${k}_${i} AS SELECT * FROM range(${k} * ${i}) t(i)
+----
+no database
+
+statement maybe
+DETACH attach_mix_${k}
+----
+database not found
+
+endloop
+
+endloop

--- a/test/sql/attach/attach_concurrent_detach_mix.test_slow
+++ b/test/sql/attach/attach_concurrent_detach_mix.test_slow
@@ -11,8 +11,14 @@ ATTACH IF NOT EXISTS '__TEST_DIR__/attach_mix_${k}.db'
 ----
 Unique file handle conflict
 
+onlyif i<20
 statement maybe
 CREATE TABLE attach_mix_${k}.tbl${i} AS SELECT * FROM range(${k} * ${i}) t(i)
+----
+
+onlyif i>=20
+statement maybe
+SELECT COUNT(*) FROM attach_mix_${k}.tbl${i}
 ----
 
 statement maybe

--- a/test/sql/attach/attach_filepath_roundtrip.test
+++ b/test/sql/attach/attach_filepath_roundtrip.test
@@ -57,19 +57,19 @@ ATTACH '__TEST_DIR__/con1_commit.db';
 statement ok con2
 DETACH con2_rollback_detach;
 
-# we can't attach, because we did not commit the detach yet
+# detach is instant - so we can attach
 
-statement error con1
+statement ok con1
 ATTACH '__TEST_DIR__/con2_rollback_detach.db';
-----
-already attached
+
+statement ok con1
+DETACH con2_rollback_detach
 
 # can't attach con1.db file in con2
-
 statement error con2
 ATTACH '__TEST_DIR__/con1.db';
 ----
-write-write
+already attached by database
 
 statement ok con1
 DETACH con1;
@@ -79,7 +79,7 @@ DETACH con1;
 statement error con2
 ATTACH '__TEST_DIR__/con1.db';
 ----
-transaction is aborted
+already attached by database
 
 # commit con1 and roll back con2
 
@@ -104,9 +104,6 @@ ATTACH '__TEST_DIR__/con1_commit.db';
 ----
 already attached
 
-# we still can't ATTACH, as we rolled back the DETACH
-
-statement error con1
+# we can attach again
+statement ok con1
 ATTACH '__TEST_DIR__/con2_rollback_detach.db';
-----
-

--- a/test/sql/attach/attach_transactionality.test
+++ b/test/sql/attach/attach_transactionality.test
@@ -48,7 +48,7 @@ INSERT INTO attach_transaction.integers VALUES (42)
 statement ok
 COMMIT
 
-# rollback detach
+# detach is not transactional
 statement ok
 BEGIN TRANSACTION
 
@@ -58,8 +58,10 @@ DETACH attach_transaction
 statement ok
 ROLLBACK
 
-statement ok
+statement error
 DETACH attach_transaction
+----
+database not found
 
 # what if we attach, push entries, then detach, and then rollback!?
 statement ok

--- a/test/sql/attach/attach_use_rollback.test
+++ b/test/sql/attach/attach_use_rollback.test
@@ -1,0 +1,20 @@
+# name: test/sql/attach/attach_use_rollback.test
+# description: Test rolling back of an attach leading to the default database not being attached
+# group: [attach]
+
+statement ok
+begin;
+
+statement ok
+attach ':memory:' as mem;
+
+statement ok
+use mem;
+
+statement ok
+rollback;
+
+statement error
+create table tbl(i int);
+----
+mem does not exist

--- a/test/sql/copy/encryption/simple_encryption.test
+++ b/test/sql/copy/encryption/simple_encryption.test
@@ -117,11 +117,13 @@ DETACH unencrypted_v_1_2_0
 statement error
 ATTACH '__TEST_DIR__/unencrypted_v_1_2_0.duckdb' AS unencrypted_v_1_2_0 (ENCRYPTION_KEY 'asdf');
 ----
+not encrypted
 
 # we cannot open this db with a lower (< v1.2.0) storage version
 statement error
 ATTACH '__TEST_DIR__/unencrypted_v_1_2_0.duckdb' AS unencrypted_v_1_2_0 (STORAGE_VERSION 'v1.0.0');
 ----
+The storage version of an existing database cannot be lowered
 
 statement ok
 ATTACH '__TEST_DIR__/unencrypted_v_1_2_0.duckdb' AS unencrypted_v_1_2_0;

--- a/test/sql/parallelism/interquery/CMakeLists.txt
+++ b/test/sql/parallelism/interquery/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library_unity(
   test_sql_interquery_parallelism
   OBJECT
+  concurrent_attach_detach.cpp
   concurrent_checkpoint.cpp
   test_concurrentappend.cpp
   test_concurrentdelete.cpp

--- a/test/sql/parallelism/interquery/concurrent_attach_detach.cpp
+++ b/test/sql/parallelism/interquery/concurrent_attach_detach.cpp
@@ -1,0 +1,149 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/common/map.hpp"
+
+#include <string>
+#include <thread>
+
+using namespace duckdb;
+using namespace std;
+
+string test_dir_path;
+const string prefix = "db_";
+const string suffix = ".db";
+
+string getDBPath(idx_t i) {
+	return test_dir_path + "/" + prefix + to_string(i) + suffix;
+}
+
+string getDBName(idx_t i) {
+	return prefix + to_string(i);
+}
+
+const idx_t dbCount = 10;
+const idx_t workerCount = 40;
+const idx_t iterationCount = 100;
+atomic<bool> success;
+
+void execQuery(Connection &conn, const string &query) {
+	auto result = conn.Query(query);
+	if (result->HasError()) {
+		Printer::Print(result->GetError());
+		success = false;
+	}
+}
+
+struct DBInfo {
+	mutex mu;
+	idx_t count = 0;
+};
+
+DBInfo dbInfos[dbCount];
+
+class DBPoolMgr {
+public:
+	mutex mu;
+	map<idx_t, idx_t> m;
+
+	void addWorker(Connection &conn, idx_t i) {
+		lock_guard<mutex> lock(mu);
+
+		if (m.find(i) != m.end()) {
+			m[i]++;
+			return;
+		}
+
+		m[i] = 1;
+		string query = "ATTACH '" + getDBPath(i) + "'";
+		execQuery(conn, query);
+	}
+
+	void removeWorker(Connection &conn, idx_t i) {
+		lock_guard<mutex> lock(mu);
+
+		m[i]--;
+		if (m[i] != 0) {
+			return;
+		}
+
+		m.erase(i);
+		string query = "DETACH " + getDBName(i);
+		execQuery(conn, query);
+	}
+};
+
+DBPoolMgr dbPool;
+
+void lookup(Connection &conn, idx_t i) {
+	unique_lock<mutex> lock(dbInfos[i].mu);
+	auto maxTblId = dbInfos[i].count;
+	lock.unlock();
+
+	if (maxTblId == 0) {
+		return;
+	}
+
+	auto tblId = std::rand() % maxTblId;
+	string query = "SELECT i, s FROM " + getDBName(i) + ".tbl_" + to_string(tblId) + " WHERE i = 2049";
+	execQuery(conn, query);
+}
+
+void createLookupTbl(Connection &conn, idx_t i) {
+	lock_guard<mutex> lock(dbInfos[i].mu);
+	auto tblId = dbInfos[i].count;
+	dbInfos[i].count++;
+
+	string query = "CREATE TABLE " + getDBName(i) + ".tbl_" + to_string(tblId) +
+	               " AS SELECT range AS i, range::VARCHAR AS s FROM range(10000)";
+	execQuery(conn, query);
+}
+
+void workUnit(std::unique_ptr<Connection> conn) {
+	for (int i = 0; i < iterationCount; i++) {
+		idx_t scenarioId = std::rand() % 2;
+		idx_t dbId = std::rand() % dbCount;
+
+		dbPool.addWorker(*conn, dbId);
+
+		switch (scenarioId) {
+		case 0:
+			lookup(*conn, dbId);
+			break;
+		case 1:
+			createLookupTbl(*conn, dbId);
+			break;
+		default:
+			throw runtime_error("invalid scenario");
+		}
+
+		dbPool.removeWorker(*conn, dbId);
+	}
+}
+
+TEST_CASE("Run a concurrent ATTACH/DETACH scenario", "[attach][.]") {
+	test_dir_path = TestDirectoryPath();
+
+	DuckDB db(nullptr);
+	Connection initConn(db);
+
+	execQuery(initConn, "SET catalog_error_max_schemas = '0'");
+	execQuery(initConn, "SET threads = '1'");
+	// execQuery(initConn, "SET default_block_size = '16384'");
+	// execQuery(initConn, "SET storage_compatibility_version = 'v1.3.2'");
+
+	success = true;
+	std::vector<thread> workers;
+	for (int i = 0; i < workerCount; i++) {
+		auto conn = make_uniq<Connection>(db);
+		workers.emplace_back(workUnit, std::move(conn));
+	}
+
+	for (auto &worker : workers) {
+		worker.join();
+	}
+	if (!success) {
+		FAIL();
+	}
+}

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -89,7 +89,7 @@ bool CanRestart(Connection &conn) {
 	auto databases = db_manager.GetDatabases();
 	idx_t database_count = 0;
 	for (auto &db_ref : databases) {
-		auto &db = db_ref.get();
+		auto &db = *db_ref;
 		if (db.IsSystem()) {
 			continue;
 		}


### PR DESCRIPTION

Previously, attached databases were tracked in a transactional manner using a CatalogSet tied to the system catalog. This would make all operations on them transactional in relation to the system catalog. When attaching, attached databases would only be visible to transactions after the attach has been committed. Similarly, detaching would not instantly detach the database, but would postpone the actual detach until all transactions on the system catalog were terminated.

This seems elegant but can cause issues / hard-to-understand behavior:
* Databases would only be detached on cleanup
* Since every transaction uses the system transaction, effectively any open transaction could defer the clean-up of a database
* We can only run the final checkpoint (checkpoint on shutdown) after the database has fully detached/shut down, which would be deferred from the actual detach

In particular, this could cause issues when detaching a database file, followed by re-attaching the same database file. If the detach had not fully completed yet - we would allow the attach, but could then have a checkpoint running in the background while other operations were happening on the attached database file. This could lead to data corruption and similar errors as we would have multiple writers writing to the same database file. 

This data corruption can be fixed differently by detecting this and throwing an error preventing the attach - but this would then create more confusion from a user perspective. The database would be detached, but not cleaned up yet in the background because other transactions are still active, **even if those transactions are not using that specific database**. As a result, it is hard to tell when a detach would *actually* happen and when we could re-attach the same database again.

### Direct Detach

In order to solve these issues - this PR moves away from using a CatalogSet for attached databases. Instead, we use a map of shared pointers. When a database is referenced by a transaction, that transaction grabs a shared pointer to that database and stores it, preventing the database from being detached as long as that transaction is active.

When a detach happens, the database is removed from the set of databases in the database manager. At this point, it will be directly cleaned up if no other transaction is actively using that database. If another transaction is still using the database, the database will be cleaned up after that transaction is finished. As a result, detaching while other transactions are using the database is still safe.

This does mean that `Detach` is no longer transactional - i.e. a rollback can no longer roll back a detach. If a transaction tries to use a database after it has been detached by another transaction, that database can disappear even if it has existed in the past. 

Attaching works slightly differently. It is also no longer transactional - so if a transaction attaches a database, other transactions can immediately start using that database. However, attaching can still be rolled back. Effectively if we attach and then roll back, we will detach the database during rollback. 
