### PR TITLE
Hold row group lock for entire call of MoveToCollection

### DIFF
--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -66,18 +66,16 @@ RowGroup::RowGroup(RowGroupCollection &collection_p, PersistentRowGroupData &dat
 }
 
 void RowGroup::MoveToCollection(RowGroupCollection &collection_p, idx_t new_start) {
-	{
-		lock_guard<mutex> l(row_group_lock);
-		this->collection = collection_p;
-		this->start = new_start;
-		for (idx_t c = 0; c < columns.size(); c++) {
-			if (is_loaded && !is_loaded[c]) {
-				// we only need to set the column start position if it is already loaded
-				// if it is not loaded - we will set the correct start position upon loading
-				continue;
-			}
-			columns[c]->SetStart(new_start);
+	lock_guard<mutex> l(row_group_lock);
+	this->collection = collection_p;
+	this->start = new_start;
+	for (idx_t c = 0; c < columns.size(); c++) {
+		if (is_loaded && !is_loaded[c]) {
+			// we only need to set the column start position if it is already loaded
+			// if it is not loaded - we will set the correct start position upon loading
+			continue;
 		}
+		columns[c]->SetStart(new_start);
 	}
 	if (!HasUnloadedDeletes()) {
 		auto vinfo = GetVersionInfo();

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -66,18 +66,18 @@ RowGroup::RowGroup(RowGroupCollection &collection_p, PersistentRowGroupData &dat
 }
 
 void RowGroup::MoveToCollection(RowGroupCollection &collection_p, idx_t new_start) {
-	this->collection = collection_p;
-	this->start = new_start;
-	for (idx_t c = 0; c < columns.size(); c++) {
-		if (is_loaded && !is_loaded[c]) {
-			// we only need to set the column start position if it is already loaded
-			// if it is not loaded - we will set the correct start position upon loading
-			lock_guard<mutex> l(row_group_lock);
-			if (!is_loaded[c]) {
+	{
+		lock_guard<mutex> l(row_group_lock);
+		this->collection = collection_p;
+		this->start = new_start;
+		for (idx_t c = 0; c < columns.size(); c++) {
+			if (is_loaded && !is_loaded[c]) {
+				// we only need to set the column start position if it is already loaded
+				// if it is not loaded - we will set the correct start position upon loading
 				continue;
 			}
+			columns[c]->SetStart(new_start);
 		}
-		columns[c]->SetStart(new_start);
 	}
 	if (!HasUnloadedDeletes()) {
 		auto vinfo = GetVersionInfo();


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/18677, hold the lock for the entire function instead

CC @ywelsch 