### PR TITLE
Expected errors 2053

### DIFF
--- a/test/sql/types/nested/map/map_from_entries/nested.test
+++ b/test/sql/types/nested/map/map_from_entries/nested.test
@@ -16,6 +16,7 @@ SELECT MAP_FROM_ENTRIES(ARRAY[([1,2], 2), ([3,4], 4)]);
 statement error
 SELECT MAP_FROM_ENTRIES(ARRAY[([1,2], 2), ([1,2], 4)]);
 ----
+<REGEX>:.*Invalid Input Error.*Map keys must be unique.*
 
 # STRUCT - correct
 query I
@@ -27,6 +28,7 @@ SELECT MAP_FROM_ENTRIES(ARRAY[({'a':5, 'b':7}, 2), ({'a':3, 'b':8}, 4)]);
 statement error
 SELECT MAP_FROM_ENTRIES(ARRAY[({'a':5, 'b':7}, 2), ({'a':5, 'b':7}, 4)]);
 ----
+<REGEX>:.*Invalid Input Error.*Map keys must be unique.*
 
 # MAP - correct
 query I
@@ -38,6 +40,7 @@ SELECT MAP_FROM_ENTRIES(ARRAY[(MAP([5,3,4], ['a', 'b', 'c']), 2), (MAP([4,3,5], 
 statement error
 SELECT MAP_FROM_ENTRIES(ARRAY[(MAP([5,3,4], ['a', 'b', 'c']), 2), (MAP([5,3,4], ['a', 'b', 'c']), 4)]);
 ----
+<REGEX>:.*Invalid Input Error.*Map keys must be unique.*
 
 # LIST(STRUCT) - correct
 query I
@@ -49,3 +52,4 @@ SELECT MAP_FROM_ENTRIES(ARRAY[([{'a':5, 'b':7}, {'a':5, 'b':7}], 2), ([{'a':5, '
 statement error
 SELECT MAP_FROM_ENTRIES(ARRAY[([{'a':5, 'b':7}, {'a':5, 'b':8}], 2), ([{'a':5, 'b':7}, {'a':5, 'b':8}], 4)]);
 ----
+<REGEX>:.*Invalid Input Error.*Map keys must be unique.*

--- a/test/sql/types/nested/map/test_map_nested_keys.test
+++ b/test/sql/types/nested/map/test_map_nested_keys.test
@@ -48,6 +48,7 @@ SELECT MAP(
 	]
 );
 ----
+<REGEX>:.*Invalid Input Error.*Map keys must be unique.*
 
 # Nested keys (list) not successful (nulls)
 statement error
@@ -60,6 +61,7 @@ SELECT MAP(
 	]
 );
 ----
+<REGEX>:.*Invalid Input Error.*Map keys can not be NULL.*
 
 # Nested keys (struct) successful
 query I
@@ -85,6 +87,7 @@ SELECT MAP(
 	]
 );
 ----
+<REGEX>:.*Invalid Input Error.*Map keys must be unique.*
 
 # Nested keys (struct) not successful (null)
 statement error
@@ -97,6 +100,7 @@ SELECT MAP(
 	]
 );
 ----
+<REGEX>:.*Invalid Input Error.*Map keys can not be NULL.*
 
 # Nested keys (map) successful
 query I
@@ -122,6 +126,7 @@ SELECT MAP(
 	]
 );
 ----
+<REGEX>:.*Invalid Input Error.*Map keys must be unique.*
 
 # Nested keys (map) not successful (null)
 statement error
@@ -134,3 +139,4 @@ SELECT MAP(
 	]
 );
 ----
+<REGEX>:.*Invalid Input Error.*Map keys can not be NULL.*

--- a/test/sql/types/nested/struct/struct_dict.test
+++ b/test/sql/types/nested/struct/struct_dict.test
@@ -37,13 +37,16 @@ SELECT {i: r, j: 2} FROM range(3) tbl(r);
 statement error
 SELECT {'i': 3, 'i': 4}
 ----
+<REGEX>:.*Binder Error.*Duplicate struct entry name.*
 
 # empty struct is not allowed
 statement error
 SELECT {};
 ----
+<REGEX>:.*Parser Error.*syntax error at or near "}".*
 
 # need string keys
 statement error
 SELECT {1:3};
 ----
+<REGEX>:.*Parser Error.*syntax error at or near "1".*

--- a/test/sql/types/struct/nested_structs.test
+++ b/test/sql/types/struct/nested_structs.test
@@ -78,11 +78,14 @@ SELECT (c).a FROM b
 statement error
 INSERT INTO a VALUES (1)
 ----
+<REGEX>:.*Conversion Error.*Unimplemented type for cast.*
 
 statement error
 INSERT INTO a VALUES (ROW(1, 2))
 ----
+<REGEX>:.*Conversion Error.*Unimplemented type for cast.*
 
 statement error
 INSERT INTO a VALUES (ROW(ROW(1, 2, 3), 1))
 ----
+<REGEX>:.*Mismatch Type Error.*Cannot cast STRUCTs of different size.*

--- a/test/sql/types/struct/remap_struct.test
+++ b/test/sql/types/struct/remap_struct.test
@@ -15,7 +15,7 @@ SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v2 INT), NULL, {'v2': NULL::INTE
 statement error
 select remap_struct(42, NULL::ROW(v1 INT, v2 INT, v3 INT), {'v1': 'j', 'v3': 'i'}, {'v2': NULL::INTEGER})
 ----
-Binder Error: Struct remap can only remap nested types
+<REGEX>:.*Binder Error.*Struct remap can only remap nested types.*
 
 # basic remap usage
 query I
@@ -139,48 +139,48 @@ SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v1 INT, v2 INT), {'v1': 'j', 'v2
 statement error
 SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v1 VARCHAR), {'v2': 'i'}, NULL);
 ----
-Target value v2 not found
+<REGEX>:.*Binder Error.*Target value v2 not found.*
 
 # invalid type
 statement error
 SELECT remap_struct({'i': 1, 'j': 2}, NULL, {'v2': 'i'}, NULL);
 ----
-Struct remap can only remap nested types
+<REGEX>:.*Binder Error.*Struct remap can only remap nested types.*
 
 statement error
 SELECT remap_struct(ROW(1, 2), NULL::ROW(v1 VARCHAR), {'v2': 'i'}, NULL);
 ----
-Struct remap can only remap named structs
+<REGEX>:.*Binder Error.*Struct remap can only remap named structs.*
 
 # invalid source value
 statement error
 SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v1 VARCHAR), {'v1': 'k'}, NULL);
 ----
-Source value k not found
+<REGEX>:.*Binder Error.*Source value k not found.*
 
 # duplicate default/target
 statement error
 SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v1 VARCHAR), {'v1': 'i'}, {'v1': NULL::VARCHAR});
 ----
-Duplicate value provided for target v1
+<REGEX>:.*Binder Error.*Duplicate value provided for target v1.*
 
 # not all target values mapped
 statement error
 SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v1 VARCHAR, v2 VARCHAR), {'v1': 'i'}, NULL);
 ----
-Missing target value v2
+<REGEX>:.*Binder Error.*Missing target value v2.*
 
 statement error
 SELECT remap_struct(struct_val, NULL::ROW(v1 VARCHAR, v2 VARCHAR, v3 VARCHAR), {'v1': 'j', 'v3': 'i'}, struct_val)
 FROM structs
 ----
-Default values must be constants
+<REGEX>:.*Binder Error.*Default values must be constants.*
 
 # default type mismatch
 statement error
 SELECT remap_struct({'i': 1, 'j': 2}, NULL::ROW(v1 INT, v2 INT, v3 INT), {'v1': 'j', 'v3': 'i'}, {'v2': 'hello'});
 ----
-Default key v2 does not match target type INTEGER
+<REGEX>:.*Binder Error.*Default key v2 does not match target type INTEGER.*
 
 # duplicate default
 statement error
@@ -190,7 +190,7 @@ SELECT remap_struct(
  {'v1': 'i', 'v2': ROW('j', {'x': 'x', 'y': 'z'})},
  {'v2': {'y': NULL::INT}, 'v3': NULL::VARCHAR});
 ----
-Duplicate value provided for target y
+<REGEX>:.*Binder Error.*Duplicate value provided for target y.*
 
 # unaligned nested type
 statement error
@@ -200,7 +200,7 @@ SELECT remap_struct(
  {'v1': 'i', 'v2': ROW('j', {'x': 'x', 'y': 'z'})},
  {'v2': NULL, 'v3': NULL::VARCHAR});
 ----
-Binder Error: Default key v2 does not match target type STRUCT(x INTEGER, y INTEGER) - add a cast
+<REGEX>:.*Binder Error.*Default key v2 does not match target type.*
 
 statement error
 SELECT remap_struct(
@@ -219,3 +219,4 @@ SELECT remap_struct(
       }
   );
 ----
+<REGEX>:.*Binder Error.*No child remaps found.*

--- a/test/sql/types/struct/struct_tables.test
+++ b/test/sql/types/struct/struct_tables.test
@@ -57,20 +57,25 @@ NULL
 statement error
 INSERT INTO a VALUES (ROW(1, 2, 3))
 ----
+<REGEX>:.*Mismatch Type Error.*Cannot cast STRUCTs of different size.*
 
 statement error
 INSERT INTO a VALUES (ROW(1))
 ----
+<REGEX>:.*Mismatch Type Error.*Cannot cast STRUCTs of different size.*
 
 # incorrect types
 statement error
 INSERT INTO a VALUES (ROW('hello', 1))
 ----
+<REGEX>:.*Conversion Error.*Could not convert string.*to INT32.*
 
 statement error
 INSERT INTO a VALUES (ROW('hello', [1, 2]))
 ----
+<REGEX>:.*Conversion Error.*Could not convert string.*to INT32.*
 
 statement error
 INSERT INTO a VALUES (ROW(1, ROW(1, 7)))
 ----
+<REGEX>:.*Conversion Error.*Unimplemented type for cast.*

--- a/test/sql/types/time/test_time.test
+++ b/test/sql/types/time/test_time.test
@@ -32,22 +32,27 @@ NULL
 statement error
 SELECT ''::TIME
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*
 
 statement error
 SELECT '  '::TIME
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*
 
 statement error
 SELECT '  	'::TIME
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*
 
 statement error
 SELECT '1'::TIME
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*
 
 statement error
 SELECT '11'::TIME
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*
 
 query I
 SELECT '11:'::TIME
@@ -72,3 +77,4 @@ SELECT '11:11:'::TIME
 statement error
 SELECT '11:11:f'::TIME
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*

--- a/test/sql/types/time/time_parsing.test
+++ b/test/sql/types/time/time_parsing.test
@@ -43,24 +43,30 @@ SELECT '14:42:04.500'::TIME::VARCHAR
 statement error
 SELECT '50:42:04.500'::TIME::VARCHAR
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*
 
 statement error
 SELECT '100:42:04.500'::TIME::VARCHAR
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*
 
 statement error
 SELECT '14:70:04.500'::TIME::VARCHAR
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*
 
 statement error
 SELECT '14:100:04.500'::TIME::VARCHAR
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*
 
 statement error
 SELECT '14:42:70.500'::TIME::VARCHAR
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*
 
 # invalid separator
 statement error
 SELECT '14-42-04'::TIME::VARCHAR
 ----
+<REGEX>:.*Conversion Error.*time field value out of range.*

--- a/test/sql/types/timestamp/test_incorrect_timestamp.test
+++ b/test/sql/types/timestamp/test_incorrect_timestamp.test
@@ -11,22 +11,27 @@ CREATE TABLE timestamp(t TIMESTAMP)
 statement error
 INSERT INTO timestamp VALUES ('blabla')
 ----
+<REGEX>:.*Conversion Error.*invalid timestamp field format.*
 
 statement error
 INSERT INTO timestamp VALUES ('1993-20-14 00:00:00')
 ----
+<REGEX>:.*Conversion Error.*timestamp field value out of range.*
 
 statement error
 INSERT INTO timestamp VALUES ('1993-08-99 00:00:00')
 ----
+<REGEX>:.*Conversion Error.*timestamp field value out of range.*
 
 statement error
 INSERT INTO timestamp VALUES ('1993-02-29 00:00:00')
 ----
+<REGEX>:.*Conversion Error.*timestamp field value out of range.*
 
 statement error
 INSERT INTO timestamp VALUES ('1900-02-29 00:00:00')
 ----
+<REGEX>:.*Conversion Error.*timestamp field value out of range.*
 
 statement ok
 INSERT INTO timestamp VALUES ('1992-02-29 00:00:00')
@@ -37,28 +42,34 @@ INSERT INTO timestamp VALUES ('2000-02-29 00:00:00')
 statement error
 INSERT INTO timestamp VALUES ('02-02-1992 00:00:00')
 ----
+<REGEX>:.*Conversion Error.*invalid timestamp field format.*
 
 statement error
 INSERT INTO timestamp VALUES ('1900-1-1 59:59:23')
 ----
+<REGEX>:.*Conversion Error.*timestamp field value out of range.*
 
 statement error
 INSERT INTO timestamp VALUES ('1900a01a01 00:00:00')
 ----
+<REGEX>:.*Conversion Error.*invalid timestamp field format.*
 
 statement error
 INSERT INTO timestamp VALUES ('1900-1-1 00;00;00')
 ----
+<REGEX>:.*Conversion Error.*invalid timestamp field format.*
 
 statement error
 INSERT INTO timestamp VALUES ('1900-1-1 00a00a00')
 ----
+<REGEX>:.*Conversion Error.*invalid timestamp field format.*
 
 statement error
 INSERT INTO timestamp VALUES ('1900-1-1 00/00/00')
 ----
+<REGEX>:.*Conversion Error.*invalid timestamp field format.*
 
 statement error
 INSERT INTO timestamp VALUES ('1900-1-1 00-00-00')
 ----
-
+<REGEX>:.*Conversion Error.*invalid timestamp field format.*

--- a/test/sql/types/union/union_limits.test
+++ b/test/sql/types/union/union_limits.test
@@ -91,9 +91,10 @@ CREATE TABLE tbl1 (u UNION(
     a249 INT, a250 INT, a251 INT, a252 INT, a253 INT, a254 INT, a255 INT, a256 INT, a257
 ))
 ----
-
+<REGEX>:.*Parser Error.*syntax error.*
 
 # Need at least one column
 statement error
 CREATE TABLE tbl1 (u UNION())
 ----
+<REGEX>:.*Parser Error.*syntax error.*

--- a/test/sql/upsert/postgres/single_key.test
+++ b/test/sql/upsert/postgres/single_key.test
@@ -56,37 +56,43 @@ ON CONFLICT (key) DO UPDATE SET fruit = excluded.fruit, key = excluded.key;
 statement error
 insert into insertconflicttest values (1, 'Apple') on conflict (key) do update set fruit = excluded.fruit RETURNING excluded.fruit;
 ----
-Not implemented Error: 'excluded' qualified columns are not supported in the RETURNING clause yet
+<REGEX>:.*Not implemented Error.*not supported in the RETURNING clause yet.*
 
 # Only suggest <table>.* column when inference element misspelled:
 
 statement error
 insert into insertconflicttest values (1, 'Apple') on conflict (keyy) do update set fruit = excluded.fruit;
 ----
+<REGEX>:.*Binder Error.*Table "insertconflicttest" does not have a column.*
 
 # Have useful HINT for EXCLUDED.* RTE within UPDATE:
 
 statement error
 insert into insertconflicttest values (1, 'Apple') on conflict (key) do update set fruit = excluded.fruitt;
 ----
+<REGEX>:.*Binder Error.*does not have a column named "fruitt".*
 
 # inference fails:
 
 statement error
 insert into insertconflicttest values (3, 'Kiwi') on conflict (key, fruit) do update set fruit = excluded.fruit;
 ----
+<REGEX>:.*Binder Error.*not referenced by a UNIQUE/PRIMARY KEY CONSTRAINT or INDEX.*
 
 statement error
 insert into insertconflicttest values (4, 'Mango') on conflict (fruit, key) do update set fruit = excluded.fruit;
 ----
+<REGEX>:.*Binder Error.*not referenced by a UNIQUE/PRIMARY KEY CONSTRAINT or INDEX.*
 
 statement error
 insert into insertconflicttest values (5, 'Lemon') on conflict (fruit) do update set fruit = excluded.fruit;
 ----
+<REGEX>:.*Binder Error.*not referenced by a UNIQUE/PRIMARY KEY CONSTRAINT or INDEX.*
 
 statement error
 insert into insertconflicttest values (6, 'Passionfruit') on conflict (fruit) do update set fruit = excluded.fruit;
 ----
+<REGEX>:.*Binder Error.*not referenced by a UNIQUE/PRIMARY KEY CONSTRAINT or INDEX.*
 
 # Check the target relation can be aliased
 
@@ -102,3 +108,4 @@ insert into insertconflicttest AS ict values (6, 'Passionfruit') on conflict (ke
 statement error
 insert into insertconflicttest AS ict values (6, 'Passionfruit') on conflict (key) do update set fruit = insertconflicttest.fruit;
 ----
+<REGEX>:.*Binder Error.*Referenced table.*not found.*

--- a/test/sql/upsert/upsert_shorthand.test
+++ b/test/sql/upsert/upsert_shorthand.test
@@ -17,7 +17,7 @@ insert into tbl values (1,2) on conflict do update set a = excluded.a;
 statement error
 insert or replace into tbl values (4,3) on conflict do nothing;
 ----
-Parser Error: You can not provide both OR REPLACE|IGNORE and an ON CONFLICT clause, please remove the first if you want to have more granual control
+<REGEX>:.*Parser Error.*You can not provide both OR.*
 
 # INSERT OR IGNORE is shorthand for DO NOTHING
 statement ok
@@ -40,3 +40,4 @@ create or replace table tbl (a integer unique, b integer unique);
 statement error
 insert or replace into tbl values (1,2);
 ----
+<REGEX>:.*Binder Error.*Conflict target has to be provided for a DO UPDATE.*

--- a/test/sql/window/test_scalar_window.test
+++ b/test/sql/window/test_scalar_window.test
@@ -20,20 +20,25 @@ SELECT avg(42) OVER ()
 statement error
 SELECT concat() OVER ()
 ----
+<REGEX>:.*Catalog Error.*concat is not an aggregate function.*
 
 statement error
 SELECT nonexistingfunction() OVER ()
 ----
+<REGEX>:.*Catalog Error.*nonexistingfunction does not exist.*
 
 # nested window functions are not allowed
 statement error
 SELECT avg(row_number() over ()) over ()
 ----
+<REGEX>:.*Binder Error.*window function calls cannot be nested.*
 
 statement error
 SELECT avg(42) over (partition by row_number() over ())
 ----
+<REGEX>:.*Parser Error.*window functions are not allowed.*
 
 statement error
 SELECT avg(42) over (order by row_number() over ())
 ----
+<REGEX>:.*Parser Error.*window functions are not allowed.*

--- a/test/sql/window/test_window_string_agg.test
+++ b/test/sql/window/test_window_string_agg.test
@@ -34,3 +34,4 @@ select j, s, string_agg(s, '|') over (partition by j order by s) from a order by
 statement error
 select j, s, string_agg(s, sep) over (partition by j order by s) from a order by j, s;
 ----
+<REGEX>:.*Binder Error.*Separator.* must be a constant.*

--- a/test/sql/window/test_window_wisconsin.test
+++ b/test/sql/window/test_window_wisconsin.test
@@ -245,6 +245,7 @@ SELECT lag(ten, four, 0) OVER (PARTITION BY four ORDER BY ten) lt FROM tenk1 ord
 statement error
 SELECT lag(ten, four, 0, 0) OVER (PARTITION BY four ORDER BY ten) lt FROM tenk1 order by four, ten, lt
 ----
+<REGEX>:.*Parser Error.*Incorrect number of parameters.*
 
 query I
 SELECT lead(ten) OVER (PARTITION BY four ORDER BY ten) lt FROM tenk1 order by four, ten, lt


### PR DESCRIPTION
This PR adds REGEX error messages to the test cases according to the https://github.com/duckdblabs/duckdb-internal/issues/2053#event-12874954527:

- test/sql/types/nested/map/map_from_entries/nested.test
- test/sql/types/nested/map/test_map_nested_keys.test
- test/sql/types/nested/struct/struct_dict.test
- test/sql/types/struct/nested_structs.test
- test/sql/types/struct/remap_struct.test
- test/sql/types/struct/struct_tables.test
- test/sql/types/time/test_time.test
- test/sql/types/time/time_parsing.test
- test/sql/types/timestamp/test_incorrect_timestamp.test
- test/sql/types/union/union_limits.test
- test/sql/upsert/postgres/single_key.test
- test/sql/upsert/upsert_shorthand.test
- test/sql/window/test_scalar_window.test
- test/sql/window/test_window_string_agg.test
- test/sql/window/test_window_wisconsin.test