### PR TITLE
Correctly handle collations for IN (subquery)

### DIFF
--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -171,6 +171,11 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 			    make_uniq<BoundColumnRefExpression>(child_type, plan_columns[child_idx]),
 			    expr.child_targets[child_idx]);
 			cond.comparison = expr.comparison_type;
+
+			// push collations
+			ExpressionBinder::PushCollation(binder.context, cond.left, cond.left->return_type);
+			ExpressionBinder::PushCollation(binder.context, cond.right, cond.right->return_type);
+
 			join->conditions.push_back(std::move(cond));
 		}
 		root = std::move(join);

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -188,6 +188,10 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::Decorrelate(unique_ptr<Logica
 				    make_uniq<BoundColumnRefExpression>(child_type, plan_columns[child_idx]),
 				    op.child_targets[child_idx]);
 				compare_cond.comparison = op.comparison_type;
+
+				// push collations
+				ExpressionBinder::PushCollation(binder.context, compare_cond.left, compare_cond.left->return_type);
+				ExpressionBinder::PushCollation(binder.context, compare_cond.right, compare_cond.right->return_type);
 				op.conditions.push_back(std::move(compare_cond));
 			}
 		}

--- a/test/sql/collate/collate_in_subquery.test
+++ b/test/sql/collate/collate_in_subquery.test
@@ -1,0 +1,15 @@
+# name: test/sql/collate/collate_in_subquery.test
+# description: Test collations with IN
+# group: [collate]
+
+# uncorrelated
+query I
+select 'ABC' collate nocase in (select 'abc');
+----
+true
+
+# correlated
+query I
+select upper in (select lower) from (values ('ABC' COLLATE nocase, 'abc' COLLATE nocase)) t(upper, lower);
+----
+true


### PR DESCRIPTION
Fixes an issue where collations where not respected for `col IN (SELECT ....)`