### PR TITLE
[Fix] Correctly handle table and index chunks in WAL replay buffering

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -415,6 +415,12 @@ jobs:
       run: |
         ./build/release/test/unittest --test-config test/configs/verify_fetch_row.json
 
+    - name: test/configs/wal_verification.json
+      if: (success() || failure()) && steps.build.conclusion == 'success'
+      shell: bash
+      run: |
+        ./build/release/test/unittest --test-config test/configs/wal_verification.json
+
     - name: test/configs/prefetch_all_parquet_files.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash

--- a/src/execution/index/bound_index.cpp
+++ b/src/execution/index/bound_index.cpp
@@ -155,7 +155,7 @@ string BoundIndex::AppendRowError(DataChunk &input, idx_t index) {
 }
 
 void BoundIndex::ApplyBufferedAppends(const vector<LogicalType> &table_types, ColumnDataCollection &buffered_appends,
-                                      const vector<StorageIndex> &columns) {
+                                      const vector<StorageIndex> &mapped_column_ids) {
 	IndexAppendInfo index_append_info(IndexAppendMode::INSERT_DUPLICATES, nullptr);
 
 	ColumnDataScanState state;
@@ -163,17 +163,17 @@ void BoundIndex::ApplyBufferedAppends(const vector<LogicalType> &table_types, Co
 
 	DataChunk scan_chunk;
 	buffered_appends.InitializeScanChunk(scan_chunk);
-	DataChunk mock_chunk;
-	mock_chunk.InitializeEmpty(table_types);
+	DataChunk table_chunk;
+	table_chunk.InitializeEmpty(table_types);
 
 	while (buffered_appends.Scan(state, scan_chunk)) {
 		for (idx_t i = 0; i < scan_chunk.ColumnCount() - 1; i++) {
-			auto col_id = columns[i].GetPrimaryIndex();
-			mock_chunk.data[col_id].Reference(scan_chunk.data[i]);
+			auto col_id = mapped_column_ids[i].GetPrimaryIndex();
+			table_chunk.data[col_id].Reference(scan_chunk.data[i]);
 		}
-		mock_chunk.SetCardinality(scan_chunk.size());
+		table_chunk.SetCardinality(scan_chunk.size());
 
-		auto error = Append(mock_chunk, scan_chunk.data.back(), index_append_info);
+		auto error = Append(table_chunk, scan_chunk.data.back(), index_append_info);
 		if (error.HasError()) {
 			throw InternalException("error while applying buffered appends: " + error.Message());
 		}

--- a/src/execution/index/unbound_index.cpp
+++ b/src/execution/index/unbound_index.cpp
@@ -35,7 +35,7 @@ void UnboundIndex::CommitDrop() {
 	}
 }
 
-void UnboundIndex::BufferChunk(DataChunk &chunk, Vector &row_ids, const vector<StorageIndex> &column_ids) {
+void UnboundIndex::BufferChunk(DataChunk &chunk, Vector &row_ids, const vector<StorageIndex> &mapped_column_ids_p) {
 	D_ASSERT(!column_ids.empty());
 	auto types = chunk.GetTypes();
 	types.push_back(LogicalType::ROW_TYPE);
@@ -43,9 +43,9 @@ void UnboundIndex::BufferChunk(DataChunk &chunk, Vector &row_ids, const vector<S
 	if (!buffered_appends) {
 		auto &allocator = Allocator::Get(db);
 		buffered_appends = make_uniq<ColumnDataCollection>(allocator, types);
-		mapped_column_ids = column_ids;
+		mapped_column_ids = mapped_column_ids_p;
 	}
-	D_ASSERT(mapped_column_ids == column_ids);
+	D_ASSERT(mapped_column_ids == mapped_column_ids_p);
 
 	DataChunk combined_chunk;
 	combined_chunk.InitializeEmpty(types);

--- a/src/execution/index/unbound_index.cpp
+++ b/src/execution/index/unbound_index.cpp
@@ -35,14 +35,17 @@ void UnboundIndex::CommitDrop() {
 	}
 }
 
-void UnboundIndex::BufferChunk(DataChunk &chunk, Vector &row_ids) {
+void UnboundIndex::BufferChunk(DataChunk &chunk, Vector &row_ids, const vector<StorageIndex> &column_ids) {
+	D_ASSERT(!column_ids.empty());
 	auto types = chunk.GetTypes();
 	types.push_back(LogicalType::ROW_TYPE);
 
 	if (!buffered_appends) {
 		auto &allocator = Allocator::Get(db);
 		buffered_appends = make_uniq<ColumnDataCollection>(allocator, types);
+		mapped_column_ids = column_ids;
 	}
+	D_ASSERT(mapped_column_ids == column_ids);
 
 	DataChunk combined_chunk;
 	combined_chunk.InitializeEmpty(types);

--- a/src/include/duckdb/execution/index/bound_index.hpp
+++ b/src/include/duckdb/execution/index/bound_index.hpp
@@ -155,7 +155,8 @@ public:
 	virtual string GetConstraintViolationMessage(VerifyExistenceType verify_type, idx_t failed_index,
 	                                             DataChunk &input) = 0;
 
-	void ApplyBufferedAppends(ColumnDataCollection &buffered_appends);
+	void ApplyBufferedAppends(const vector<LogicalType> &table_types, ColumnDataCollection &buffered_appends,
+	                          const vector<StorageIndex> &columns);
 
 protected:
 	//! Lock used for any changes to the index

--- a/src/include/duckdb/execution/index/bound_index.hpp
+++ b/src/include/duckdb/execution/index/bound_index.hpp
@@ -156,7 +156,7 @@ public:
 	                                             DataChunk &input) = 0;
 
 	void ApplyBufferedAppends(const vector<LogicalType> &table_types, ColumnDataCollection &buffered_appends,
-	                          const vector<StorageIndex> &columns);
+	                          const vector<StorageIndex> &mapped_column_ids);
 
 protected:
 	//! Lock used for any changes to the index

--- a/src/include/duckdb/execution/index/unbound_index.hpp
+++ b/src/include/duckdb/execution/index/unbound_index.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/parser/parsed_data/create_index_info.hpp"
 #include "duckdb/storage/index.hpp"
+#include "duckdb/storage/storage_index.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/execution/index/unbound_index.hpp
+++ b/src/include/duckdb/execution/index/unbound_index.hpp
@@ -23,6 +23,8 @@ private:
 	IndexStorageInfo storage_info;
 	//! Buffer for WAL replay appends.
 	unique_ptr<ColumnDataCollection> buffered_appends;
+	//! Maps the column IDs in the buffered appends to the table columns.
+	vector<StorageIndex> mapped_column_ids;
 
 public:
 	UnboundIndex(unique_ptr<CreateInfo> create_info, IndexStorageInfo storage_info, TableIOManager &table_io_manager,
@@ -56,12 +58,15 @@ public:
 
 	void CommitDrop() override;
 
-	void BufferChunk(DataChunk &chunk, Vector &row_ids);
+	void BufferChunk(DataChunk &chunk, Vector &row_ids, const vector<StorageIndex> &columns);
 	bool HasBufferedAppends() const {
 		return buffered_appends != nullptr;
 	}
 	ColumnDataCollection &GetBufferedAppends() const {
 		return *buffered_appends;
+	}
+	const vector<StorageIndex> &GetMappedColumnIds() const {
+		return mapped_column_ids;
 	}
 };
 

--- a/src/include/duckdb/execution/index/unbound_index.hpp
+++ b/src/include/duckdb/execution/index/unbound_index.hpp
@@ -58,7 +58,7 @@ public:
 
 	void CommitDrop() override;
 
-	void BufferChunk(DataChunk &chunk, Vector &row_ids, const vector<StorageIndex> &columns);
+	void BufferChunk(DataChunk &chunk, Vector &row_ids, const vector<StorageIndex> &mapped_column_ids_p);
 	bool HasBufferedAppends() const {
 		return buffered_appends != nullptr;
 	}

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -182,17 +182,14 @@ public:
 	void MergeStorage(RowGroupCollection &data, TableIndexList &indexes, optional_ptr<StorageCommitState> commit_state);
 
 	//! Appends a chunk with the row ids [row_start, ..., row_start + chunk.size()] to all indexes of the table.
-	//TODO: remove
-//	! The chunk can have two layouts:
-//	! 1. Only contains the necessary index key columns. In this case, mapped column IDs maps them to all columns of the table.
-//	! 2. Contains all columns of the table. In this case, mapped column IDs maps them to only the key columns.
-//	! Depending on whether an index is unbound or not, we pass
-//	! unbound: only the index key columns, or bound: all columns.
+	//! If an index is bound, it appends table_chunk. Else, it buffers index_chunk.
 	static ErrorData AppendToIndexes(TableIndexList &indexes, optional_ptr<TableIndexList> delete_indexes,
-									 DataChunk &table_chunk, DataChunk &index_chunk, const vector<StorageIndex> &mapped_column_ids,
-									 row_t row_start, const IndexAppendMode index_append_mode);
-	ErrorData AppendToIndexes(optional_ptr<TableIndexList> delete_indexes, DataChunk &table_chunk, DataChunk &index_chunk,
-							  const vector<StorageIndex> &mapped_column_ids, row_t row_start, const IndexAppendMode index_append_mode);
+	                                 DataChunk &table_chunk, DataChunk &index_chunk,
+	                                 const vector<StorageIndex> &mapped_column_ids, row_t row_start,
+	                                 const IndexAppendMode index_append_mode);
+	ErrorData AppendToIndexes(optional_ptr<TableIndexList> delete_indexes, DataChunk &table_chunk,
+	                          DataChunk &index_chunk, const vector<StorageIndex> &mapped_column_ids, row_t row_start,
+	                          const IndexAppendMode index_append_mode);
 	//! Remove a chunk with the row ids [row_start, ..., row_start + chunk.size()] from all indexes of the table
 	void RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, row_t row_start);
 	//! Remove the chunk with the specified set of row identifiers from all indexes of the table

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -181,12 +181,18 @@ public:
 	//! Merge a row group collection directly into this table - appending it to the end of the table without copying
 	void MergeStorage(RowGroupCollection &data, TableIndexList &indexes, optional_ptr<StorageCommitState> commit_state);
 
-	//! Append a chunk with the row ids [row_start, ..., row_start + chunk.size()] to all indexes of the table.
-	//! Returns empty ErrorData, if the append was successful.
-	ErrorData AppendToIndexes(optional_ptr<TableIndexList> delete_indexes, DataChunk &chunk, row_t row_start,
-	                          const IndexAppendMode index_append_mode);
+	//! Appends a chunk with the row ids [row_start, ..., row_start + chunk.size()] to all indexes of the table.
+	//TODO: remove
+//	! The chunk can have two layouts:
+//	! 1. Only contains the necessary index key columns. In this case, mapped column IDs maps them to all columns of the table.
+//	! 2. Contains all columns of the table. In this case, mapped column IDs maps them to only the key columns.
+//	! Depending on whether an index is unbound or not, we pass
+//	! unbound: only the index key columns, or bound: all columns.
 	static ErrorData AppendToIndexes(TableIndexList &indexes, optional_ptr<TableIndexList> delete_indexes,
-	                                 DataChunk &chunk, row_t row_start, const IndexAppendMode index_append_mode);
+									 DataChunk &table_chunk, DataChunk &index_chunk, const vector<StorageIndex> &mapped_column_ids,
+									 row_t row_start, const IndexAppendMode index_append_mode);
+	ErrorData AppendToIndexes(optional_ptr<TableIndexList> delete_indexes, DataChunk &table_chunk, DataChunk &index_chunk,
+							  const vector<StorageIndex> &mapped_column_ids, row_t row_start, const IndexAppendMode index_append_mode);
 	//! Remove a chunk with the row ids [row_start, ..., row_start + chunk.size()] from all indexes of the table
 	void RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, row_t row_start);
 	//! Remove the chunk with the specified set of row identifiers from all indexes of the table

--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -56,11 +56,26 @@ public:
 	//! Binds unbound indexes possibly present after loading an extension.
 	void Bind(ClientContext &context, DataTableInfo &table_info, const char *index_type = nullptr);
 	//! Returns true, if there are no index entries.
-	bool Empty();
+	bool Empty() {
+		lock_guard<mutex> lock(index_entries_lock);
+		return index_entries.empty();
+	}
 	//! Returns the number of index entries.
-	idx_t Count();
+	idx_t Count() {
+		lock_guard<mutex> lock(index_entries_lock);
+		return index_entries.size();
+	}
+	//! Returns true, if there are unbound indexes.
+	bool HasUnbound() {
+		lock_guard<mutex> lock(index_entries_lock);
+		return unbound_count != 0;
+	}
 	//! Overwrite this list with the other list.
-	void Move(TableIndexList &other);
+	void Move(TableIndexList &other) {
+		D_ASSERT(index_entries.empty());
+		index_entries = std::move(other.index_entries);
+	}
+	//! Returns true, if all indexes
 	//! Find the foreign key matching the keys.
 	optional_ptr<Index> FindForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, const ForeignKeyType fk_type);
 	//! Verify a foreign key constraint.
@@ -71,11 +86,21 @@ public:
 	//! Serialize all indexes of the table.
 	vector<IndexStorageInfo> SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options);
 
+public:
+	//! Initialize an index_chunk from a table.
+	static void InitializeIndexChunk(DataChunk &index_chunk, const vector<LogicalType> &table_types,
+	                                 vector<StorageIndex> &mapped_column_ids, DataTableInfo &data_table_info);
+	//! Reference the indexed columns of a table chunk.
+	static void ReferenceIndexChunk(DataChunk &table_chunk, DataChunk &index_chunk,
+	                                vector<StorageIndex> &mapped_column_ids);
+
 private:
 	//! A lock to prevent any concurrent changes to the index entries.
 	mutex index_entries_lock;
 	//! The index entries of the table.
 	vector<unique_ptr<IndexEntry>> index_entries;
+	//! Contains the number of unbound indexes.
+	idx_t unbound_count;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -100,7 +100,7 @@ private:
 	//! The index entries of the table.
 	vector<unique_ptr<IndexEntry>> index_entries;
 	//! Contains the number of unbound indexes.
-	idx_t unbound_count;
+	idx_t unbound_count = 0;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -137,7 +137,7 @@ public:
 	//! Initialize the storage and its indexes, but no row groups.
 	void InitializeStorage(LocalAppendState &state, DataTable &table);
 	//! Append a chunk to the local storage
-	static void Append(LocalAppendState &state, DataChunk &chunk);
+	static void Append(LocalAppendState &state, DataChunk &table_chunk, const unordered_set<column_t> &indexed_columns);
 	//! Finish appending to the local storage
 	static void FinalizeAppend(LocalAppendState &state);
 	//! Merge a row group collection into the transaction-local storage

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -137,7 +137,7 @@ public:
 	//! Initialize the storage and its indexes, but no row groups.
 	void InitializeStorage(LocalAppendState &state, DataTable &table);
 	//! Append a chunk to the local storage
-	static void Append(LocalAppendState &state, DataChunk &table_chunk, const unordered_set<column_t> &indexed_columns);
+	static void Append(LocalAppendState &state, DataChunk &table_chunk, DataTableInfo &data_table_info);
 	//! Finish appending to the local storage
 	static void FinalizeAppend(LocalAppendState &state);
 	//! Merge a row group collection into the transaction-local storage

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -883,7 +883,10 @@ void DataTable::LocalAppend(LocalAppendState &state, ClientContext &context, Dat
 	}
 
 	// Append to the transaction-local data.
-	LocalStorage::Append(state, chunk);
+	auto data_table_info = GetDataTableInfo();
+	auto &index_list = data_table_info->GetIndexes();
+	auto indexed_columns = index_list.GetRequiredColumns();
+	LocalStorage::Append(state, chunk, indexed_columns);
 }
 
 void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
@@ -1172,14 +1175,15 @@ void DataTable::RevertAppend(DuckTransaction &transaction, idx_t start_row, idx_
 // Indexes
 //===--------------------------------------------------------------------===//
 ErrorData DataTable::AppendToIndexes(TableIndexList &indexes, optional_ptr<TableIndexList> delete_indexes,
-                                     DataChunk &chunk, row_t row_start, const IndexAppendMode index_append_mode) {
+									 DataChunk &table_chunk, DataChunk &index_chunk, const vector<StorageIndex> &mapped_column_ids,
+									 row_t row_start, const IndexAppendMode index_append_mode) {
 	if (indexes.Empty()) {
 		return ErrorData();
 	}
 
 	// Generate the vector of row identifiers.
 	Vector row_ids(LogicalType::ROW_TYPE);
-	VectorOperations::GenerateSequence(row_ids, chunk.size(), row_start, 1);
+	VectorOperations::GenerateSequence(row_ids, table_chunk.size(), row_start, 1);
 
 	vector<reference<BoundIndex>> already_appended;
 	bool append_failed = false;
@@ -1188,8 +1192,9 @@ ErrorData DataTable::AppendToIndexes(TableIndexList &indexes, optional_ptr<Table
 	ErrorData error;
 	indexes.Scan([&](Index &index) {
 		if (!index.IsBound()) {
+			// Buffer only the key columns, and store their mapping.
 			auto &unbound_index = index.Cast<UnboundIndex>();
-			unbound_index.BufferChunk(chunk, row_ids);
+			unbound_index.BufferChunk(index_chunk, row_ids, mapped_column_ids);
 			return false;
 		}
 
@@ -1204,8 +1209,9 @@ ErrorData DataTable::AppendToIndexes(TableIndexList &indexes, optional_ptr<Table
 		}
 
 		try {
+			// Append the mock chunk containing empty columns for non-key columns.
 			IndexAppendInfo index_append_info(index_append_mode, delete_index);
-			error = bound_index.Append(chunk, row_ids, index_append_info);
+			error = bound_index.Append(table_chunk, row_ids, index_append_info);
 		} catch (std::exception &ex) {
 			error = ErrorData(ex);
 		}
@@ -1222,16 +1228,16 @@ ErrorData DataTable::AppendToIndexes(TableIndexList &indexes, optional_ptr<Table
 	if (append_failed) {
 		// Constraint violation: remove any appended entries from previous indexes (if any).
 		for (auto index : already_appended) {
-			index.get().Delete(chunk, row_ids);
+			index.get().Delete(table_chunk, row_ids);
 		}
 	}
 	return error;
 }
 
-ErrorData DataTable::AppendToIndexes(optional_ptr<TableIndexList> delete_indexes, DataChunk &chunk, row_t row_start,
-                                     const IndexAppendMode index_append_mode) {
+ErrorData DataTable::AppendToIndexes(optional_ptr<TableIndexList> delete_indexes, DataChunk &table_chunk, DataChunk &index_chunk,
+									 const vector<StorageIndex> &mapped_column_ids, row_t row_start, const IndexAppendMode index_append_mode) {
 	D_ASSERT(IsMainTable());
-	return AppendToIndexes(info->indexes, delete_indexes, chunk, row_start, index_append_mode);
+	return AppendToIndexes(info->indexes, delete_indexes, table_chunk, index_chunk, mapped_column_ids, row_start, index_append_mode);
 }
 
 void DataTable::RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, row_t row_start) {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -154,66 +154,102 @@ void LocalTableStorage::FlushBlocks() {
 ErrorData LocalTableStorage::AppendToIndexes(DuckTransaction &transaction, RowGroupCollection &source,
                                              TableIndexList &index_list, const vector<LogicalType> &table_types,
                                              row_t &start_row) {
-	// only need to scan for index append
-	// figure out which columns we need to scan for the set of indexes
-	auto index_columns = index_list.GetRequiredColumns();
-	vector<StorageIndex> required_columns;
-	for (auto &col : index_columns) {
-		required_columns.emplace_back(col);
+	// In this function, we only care about scanning the indexed columns of a table.
+	auto indexed_columns = index_list.GetRequiredColumns();
+	vector<StorageIndex> mapped_column_ids;
+	for (auto &col : indexed_columns) {
+		mapped_column_ids.emplace_back(col);
 	}
-	// create an empty mock chunk that contains all the correct types for the table
-	DataChunk mock_chunk;
-	mock_chunk.InitializeEmpty(table_types);
+
+	// However, because the bound expressions of the indexes (and their bound
+	// column references) are in relation to ALL table columns, we create an
+	// empty table chunk based on the table types. It references the indexed columns,
+	// and contains nothing for all non-indexed columns.
+	DataChunk table_chunk;
+	table_chunk.InitializeEmpty(table_types);
+
 	ErrorData error;
-	source.Scan(transaction, required_columns, [&](DataChunk &chunk) -> bool {
-		// construct the mock chunk by referencing the required columns
-		for (idx_t i = 0; i < required_columns.size(); i++) {
-			auto col_id = required_columns[i].GetPrimaryIndex();
-			mock_chunk.data[col_id].Reference(chunk.data[i]);
+	source.Scan(transaction, mapped_column_ids, [&](DataChunk &index_chunk) -> bool {
+		// The table chunk references only the indexed columns.
+		D_ASSERT(index_chunk.ColumnCount() == mapped_column_ids.size());
+		for (idx_t i = 0; i < mapped_column_ids.size(); i++) {
+			auto col_id = mapped_column_ids[i].GetPrimaryIndex();
+			table_chunk.data[col_id].Reference(index_chunk.data[i]);
 		}
-		mock_chunk.SetCardinality(chunk);
-		// append this chunk to the indexes of the table
-		error = DataTable::AppendToIndexes(index_list, delete_indexes, mock_chunk, start_row, index_append_mode);
+		table_chunk.SetCardinality(index_chunk);
+
+		// Pass both the table and the index chunk.
+		// We need the table chunk for the bound indexes,
+		// and the index chunk for the unbound indexes (to buffer it).
+		error = DataTable::AppendToIndexes(index_list, delete_indexes, table_chunk, index_chunk, mapped_column_ids, start_row, index_append_mode);
 		if (error.HasError()) {
 			return false;
 		}
-		start_row += UnsafeNumericCast<row_t>(chunk.size());
+		start_row += UnsafeNumericCast<row_t>(index_chunk.size());
 		return true;
 	});
 	return error;
 }
 
-void LocalTableStorage::AppendToIndexes(DuckTransaction &transaction, TableAppendState &append_state,
-                                        bool append_to_table) {
+void LocalTableStorage::AppendToIndexes(DuckTransaction &transaction, TableAppendState &append_state, bool append_to_table) {
+	// In this function, we might scan all table columns,
+	// as we might also append to the table itself (append_to_table).
+
 	auto &table = table_ref.get();
 	if (append_to_table) {
 		table.InitializeAppend(transaction, append_state);
 	}
+
+	auto data_table_info = table.GetDataTableInfo();
+	auto &index_list = data_table_info->GetIndexes();
 	ErrorData error;
+
 	if (append_to_table) {
-		// appending: need to scan entire
-		row_groups->Scan(transaction, [&](DataChunk &chunk) -> bool {
-			// append this chunk to the indexes of the table
-			error = table.AppendToIndexes(delete_indexes, chunk, append_state.current_row, index_append_mode);
+		// Appending to the table: we need to scan the entire chunk.
+		auto indexed_columns = index_list.GetRequiredColumns();
+		auto table_types = row_groups->GetTypes();
+		vector<LogicalType> index_types;
+		vector<StorageIndex> mapped_column_ids;
+		for (auto &col : indexed_columns) {
+			index_types.push_back(table_types[col]);
+			mapped_column_ids.emplace_back(col);
+		}
+
+		DataChunk index_chunk;
+		index_chunk.InitializeEmpty(index_types);
+
+		row_groups->Scan(transaction, [&](DataChunk &table_chunk) -> bool {
+			// The index chunk references all indexed columns.
+			for (idx_t i = 0; i < mapped_column_ids.size(); i++) {
+				auto col_id = mapped_column_ids[i].GetPrimaryIndex();
+				index_chunk.data[i].Reference(table_chunk.data[col_id]);
+			}
+			index_chunk.SetCardinality(table_chunk);
+
+			// Pass both the table and the index chunk.
+			// We need the table chunk for the bound indexes,
+			// and the index chunk for the unbound indexes (to buffer it).
+			error = table.AppendToIndexes(delete_indexes, table_chunk, index_chunk, mapped_column_ids, append_state.current_row, index_append_mode);
 			if (error.HasError()) {
 				return false;
 			}
-			// append to base table
-			table.Append(chunk, append_state);
+
+			// Append to the base table.
+			table.Append(table_chunk, append_state);
 			return true;
 		});
+
 	} else {
-		auto data_table_info = table.GetDataTableInfo();
-		auto &index_list = data_table_info->GetIndexes();
+		// We only append to the indexes.
 		error = AppendToIndexes(transaction, *row_groups, index_list, table.GetTypes(), append_state.current_row);
 	}
 
 	if (error.HasError()) {
-		// need to revert all appended row ids
+		// Revert all appended row IDs.
 		row_t current_row = append_state.row_start;
-		// remove the data from the indexes, if there are any indexes
+		// Remove the data from the indexes, if any.
 		row_groups->Scan(transaction, [&](DataChunk &chunk) -> bool {
-			// Remove this chunk from the indexes.
+			// Remove the chunk.
 			try {
 				table.RemoveFromIndexes(append_state, chunk, current_row);
 			} catch (std::exception &ex) { // LCOV_EXCL_START
@@ -223,20 +259,23 @@ void LocalTableStorage::AppendToIndexes(DuckTransaction &transaction, TableAppen
 
 			current_row += UnsafeNumericCast<row_t>(chunk.size());
 			if (current_row >= append_state.current_row) {
-				// finished deleting all rows from the index: abort now
+				// Finished deleting all rows from the index.
 				return false;
 			}
 			return true;
 		});
+
 		if (append_to_table) {
 			table.RevertAppendInternal(NumericCast<idx_t>(append_state.row_start));
 		}
+
 #ifdef DEBUG
 		// Verify that our index memory is stable.
 		table.VerifyIndexBuffers();
 #endif
 		error.Throw();
 	}
+
 	if (append_to_table) {
 		table.FinalizeAppend(transaction, append_state);
 	}
@@ -420,20 +459,40 @@ void LocalTableStorage::AppendToDeleteIndexes(Vector &row_ids, DataChunk &delete
 	});
 }
 
-void LocalStorage::Append(LocalAppendState &state, DataChunk &chunk) {
+void LocalStorage::Append(LocalAppendState &state, DataChunk &table_chunk, const unordered_set<column_t> &indexed_columns) {
 	// Append to any unique indexes.
 	auto storage = state.storage;
 	auto offset = NumericCast<idx_t>(MAX_ROW_ID) + storage->row_groups->GetTotalRows();
 	idx_t base_id = offset + state.append_state.total_append_count;
 
-	auto error = DataTable::AppendToIndexes(storage->append_indexes, storage->delete_indexes, chunk,
+	// The input chunk contains all table columns.
+	// We need to only reference the index columns in the index chunk.
+	auto table_types = table_chunk.GetTypes();
+	vector<LogicalType> index_types;
+	vector<StorageIndex> mapped_column_ids;
+	for (auto &col : indexed_columns) {
+		index_types.push_back(table_types[col]);
+		mapped_column_ids.emplace_back(col);
+	}
+
+	DataChunk index_chunk;
+	index_chunk.InitializeEmpty(index_types);
+
+	// The index chunk references all indexed columns.
+	for (idx_t i = 0; i < mapped_column_ids.size(); i++) {
+		auto col_id = mapped_column_ids[i].GetPrimaryIndex();
+		index_chunk.data[i].Reference(table_chunk.data[col_id]);
+	}
+	index_chunk.SetCardinality(table_chunk);
+
+	auto error = DataTable::AppendToIndexes(storage->append_indexes, storage->delete_indexes, table_chunk, index_chunk, mapped_column_ids,
 	                                        NumericCast<row_t>(base_id), storage->index_append_mode);
 	if (error.HasError()) {
 		error.Throw();
 	}
 
 	// Append the chunk to the local storage.
-	auto new_row_group = storage->row_groups->Append(chunk, state.append_state);
+	auto new_row_group = storage->row_groups->Append(table_chunk, state.append_state);
 
 	// Check if we should pre-emptively flush blocks to disk.
 	if (new_row_group) {

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -152,7 +152,8 @@ void TableIndexList::Bind(ClientContext &context, DataTableInfo &table_info, con
 		auto &unbound_index = index_entry->index->Cast<UnboundIndex>();
 		auto bound_idx = idx_binder.BindIndex(unbound_index);
 		if (unbound_index.HasBufferedAppends()) {
-			bound_idx->ApplyBufferedAppends(unbound_index.GetBufferedAppends());
+			bound_idx->ApplyBufferedAppends(column_types, unbound_index.GetBufferedAppends(),
+			                                unbound_index.GetMappedColumnIds());
 		}
 
 		// Commit the bound index to the index entry.

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -25,6 +25,9 @@ void TableIndexList::AddIndex(unique_ptr<Index> index) {
 	lock_guard<mutex> lock(index_entries_lock);
 	auto index_entry = make_uniq<IndexEntry>(std::move(index));
 	index_entries.push_back(std::move(index_entry));
+	if (!index_entries.back()->index->IsBound()) {
+		unbound_count++;
+	}
 }
 
 void TableIndexList::RemoveIndex(const string &name) {
@@ -32,6 +35,9 @@ void TableIndexList::RemoveIndex(const string &name) {
 	for (idx_t i = 0; i < index_entries.size(); i++) {
 		auto &index = *index_entries[i]->index;
 		if (index.GetIndexName() == name) {
+			if (!index.IsBound()) {
+				unbound_count--;
+			}
 			index_entries.erase_at(i);
 			return;
 		}
@@ -77,20 +83,12 @@ optional_ptr<BoundIndex> TableIndexList::Find(const string &name) {
 }
 
 void TableIndexList::Bind(ClientContext &context, DataTableInfo &table_info, const char *index_type) {
-	// Early-out, if we have no unbound indexes.
-	bool needs_binding = false;
 	{
+		// Early-out, if we have no unbound indexes.
 		lock_guard<mutex> lock(index_entries_lock);
-		for (auto &entry : index_entries) {
-			auto &index = *entry->index;
-			if (!index.IsBound() && (index_type == nullptr || index.GetIndexType() == index_type)) {
-				needs_binding = true;
-				break;
-			}
+		if (unbound_count == 0) {
+			return;
 		}
-	}
-	if (!needs_binding) {
-		return;
 	}
 
 	// Get the table from the catalog, so we can add it to the binder.
@@ -120,6 +118,7 @@ void TableIndexList::Bind(ClientContext &context, DataTableInfo &table_info, con
 		}
 		if (!index_entry) {
 			// We bound all indexes.
+			D_ASSERT(unbound_count == 0);
 			break;
 		}
 		if (index_entry->bind_state == IndexBindState::BINDING) {
@@ -160,22 +159,8 @@ void TableIndexList::Bind(ClientContext &context, DataTableInfo &table_info, con
 		lock.lock();
 		index_entry->bind_state = IndexBindState::BOUND;
 		index_entry->index = std::move(bound_idx);
+		unbound_count--;
 	}
-}
-
-bool TableIndexList::Empty() {
-	lock_guard<mutex> lock(index_entries_lock);
-	return index_entries.empty();
-}
-
-idx_t TableIndexList::Count() {
-	lock_guard<mutex> lock(index_entries_lock);
-	return index_entries.size();
-}
-
-void TableIndexList::Move(TableIndexList &other) {
-	D_ASSERT(index_entries.empty());
-	index_entries = std::move(other.index_entries);
 }
 
 bool IsForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, Index &index, ForeignKeyType fk_type) {
@@ -261,6 +246,31 @@ vector<IndexStorageInfo> TableIndexList::SerializeToDisk(QueryContext context,
 		infos.push_back(info);
 	}
 	return infos;
+}
+
+void TableIndexList::InitializeIndexChunk(DataChunk &index_chunk, const vector<LogicalType> &table_types,
+                                          vector<StorageIndex> &mapped_column_ids, DataTableInfo &data_table_info) {
+	// table_chunk contains all table columns.
+	// We only reference the index columns in the index chunk.
+	auto &index_list = data_table_info.GetIndexes();
+	auto indexed_columns = index_list.GetRequiredColumns();
+
+	vector<LogicalType> index_types;
+	for (auto &col : indexed_columns) {
+		index_types.push_back(table_types[col]);
+		mapped_column_ids.emplace_back(col);
+	}
+
+	index_chunk.InitializeEmpty(index_types);
+}
+
+void TableIndexList::ReferenceIndexChunk(DataChunk &table_chunk, DataChunk &index_chunk,
+                                         vector<StorageIndex> &mapped_column_ids) {
+	for (idx_t i = 0; i < mapped_column_ids.size(); i++) {
+		auto col_id = mapped_column_ids[i].GetPrimaryIndex();
+		index_chunk.data[i].Reference(table_chunk.data[col_id]);
+	}
+	index_chunk.SetCardinality(table_chunk);
 }
 
 } // namespace duckdb

--- a/test/configs/wal_verification.json
+++ b/test/configs/wal_verification.json
@@ -1,0 +1,92 @@
+{
+  "description": "Run on persistent databases as storage with automatic checkpointing disabled to stress test the WAL.",
+  "initial_db": "{TEST_DIR}/{BASE_TEST_NAME}__test__config__stress_test_wal.db",
+  "force_restart": "true",
+  "checkpoint_wal_size": "1000000000",
+  "checkpoint_on_shutdown": "false",
+  "skip_compiled": "true",
+  "skip_tests": [
+    {
+      "reason": "Contains explicit use of the memory catalog.",
+      "paths": [
+        "test/sql/attach/attach_default_table.test",
+        "test/sql/attach/attach_defaults.test",
+        "test/sql/attach/attach_did_you_mean.test",
+        "test/sql/attach/attach_issue7711.test",
+        "test/sql/attach/attach_issue_7660.test",
+        "test/sql/attach/attach_show_all_tables.test",
+        "test/sql/attach/attach_table_info.test",
+        "test/sql/attach/attach_views.test",
+        "test/sql/attach/show_databases.test",
+        "test/sql/catalog/function/attached_macro.test",
+        "test/sql/catalog/test_temporary.test",
+        "test/sql/copy_database/copy_table_with_sequence.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/pg_catalog/system_functions.test",
+        "test/sql/pragma/test_show_tables_temp_views.test",
+        "test/sql/show_select/test_describe_all.test"
+      ]
+    },
+    {
+      "reason": "FIXME: Unexpected (?) binder error.",
+      "paths": [
+        "test/fuzzer/pedro/index_generated_column.test",
+        "test/sql/alter/add_col/test_add_col_stats.test",
+        "test/sql/alter/add_col/test_add_col_user_type.test",
+        "test/sql/alter/alter_type/alter_type_struct.test",
+        "test/sql/alter/alter_type/test_alter_type.test",
+        "test/sql/alter/alter_type/test_alter_type_expression.test",
+        "test/sql/alter/alter_type/test_alter_type_multi_column.test",
+        "test/sql/alter/default/test_set_default.test",
+        "test/sql/alter/list/add_column_in_struct.test",
+        "test/sql/alter/list/drop_column_in_struct.test",
+        "test/sql/alter/list/rename_column_in_struct.test",
+        "test/sql/alter/map/add_column_in_struct.test",
+        "test/sql/alter/map/drop_column_in_struct.test",
+        "test/sql/alter/map/rename_column_in_struct.test",
+        "test/sql/alter/struct/add_col_nested_struct.test",
+        "test/sql/alter/struct/add_col_struct.test",
+        "test/sql/alter/struct/drop_col_nested_struct.test",
+        "test/sql/alter/struct/drop_col_struct.test",
+        "test/sql/alter/struct/rename_col_nested_struct.test",
+        "test/sql/alter/struct/rename_col_struct.test",
+        "test/sql/attach/attach_dependencies.test",
+        "test/sql/copy/partitioned/hive_partition_escape.test",
+        "test/sql/export/export_indexes.test",
+        "test/sql/function/list/lambdas/arrow/table_functions_deprecated.test",
+        "test/sql/function/list/lambdas/table_functions.test",
+        "test/sql/function/list/test_lambda_with_struct_aliases.test",
+        "test/sql/generated_columns/virtual/rename.test",
+        "test/sql/generated_columns/virtual/rename_dependency.test",
+        "test/sql/index/art/constraints/test_art_compound_key_changes.test",
+        "test/sql/index/art/storage/test_art_storage.test",
+        "test/sql/index/art/types/test_art_expression_key.test",
+        "test/sql/index/art/types/test_art_union.test",
+        "test/sql/types/alias/type_with_schema.test",
+        "test/sql/types/enum/test_alter_enum.test",
+        "test/sql/types/enum/test_enum_schema.test",
+        "test/sql/types/enum/test_enum_structs.test"
+      ]
+    },
+    {
+      "reason": "FIXME: Wrong result in query.",
+      "paths": [
+        "test/sql/index/art/storage/test_art_duckdb_versions.test",
+        "test/sql/storage/wal/wal_lazy_creation.test"
+      ]
+    },
+    {
+      "reason": "FIXME: Internal Exception.",
+      "paths": [
+        "test/sql/alter/add_pk/test_add_pk_with_generated_column.test"
+      ]
+    },
+    {
+      "reason": "FIXME: Query unexpectedly succeeded/failed.",
+      "paths": [
+        "test/fuzzer/sqlsmith/nullif_map_with_config.test",
+        "test/sql/storage/memory/in_memory_compress.test"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes an issue where some code paths pass the entire table chunk to `DataTable::AppendToIndexes`, while others only pass the "index chunk" containing only indexed columns.

Now, we always pass both the `table_chunk` and the `index_chunk`, and a mapping between them. In the absence of indexes, or if there are no bound indexes, we skip most of the work.

I've also already added the changes of https://github.com/duckdb/duckdb/pull/18683 here, as they reproduce multiple bugs fixed by this PR. I'll properly merge ossivalis once this PR is in. :)