### PR TITLE
Fix issue with materialized CTE optimization in flatten_dependent_join

### DIFF
--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -76,6 +76,9 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::Decorrelate(unique_ptr<Logica
 				op.children[0] = DecorrelateIndependent(binder, std::move(op.children[0]));
 			}
 
+			// we are now done with the left side, mark it as uncorrelated
+			entry->second = false;
+
 			// rewrite
 			idx_t lateral_depth = 0;
 

--- a/test/issues/general/test_18703.test
+++ b/test/issues/general/test_18703.test
@@ -1,0 +1,29 @@
+# name: test/issues/general/test_18703.test
+# description: Issue 18703 - DuckDB Crash with Correlated Aggregation inside a WITH clause
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t0(c0 INT);
+
+statement ok
+INSERT INTO t0 VALUES (1), (0), (NULL);
+
+statement ok
+CREATE TABLE t1(c0 BOOLEAN);
+
+statement ok
+INSERT INTO t1 VALUES (TRUE), (FALSE), (NULL);
+
+query I
+SELECT * FROM t0
+WHERE EXISTS (
+  SELECT 1
+  FROM t1
+  WHERE (WITH seq(i) AS (VALUES (1)) SELECT SUM(i) * t0.c0 FROM seq) IS NOT NULL
+) ORDER BY c0;
+----
+0
+1


### PR DESCRIPTION
This PR fixes an issue with an optimization that can be done during decorrelation in combination with `MATERIALIZED` CTEs.

Fix: #18703
