### PR TITLE
Correctly throw an error when too few columns are supplied in MERGE INTO INSERT

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -486,6 +486,9 @@ private:
 
 	unique_ptr<MergeIntoStatement> GenerateMergeInto(InsertStatement &stmt, TableCatalogEntry &table);
 
+	static void CheckInsertColumnCountMismatch(idx_t expected_columns, idx_t result_columns, bool columns_provided,
+	                                           const string &tname);
+
 private:
 	Binder(ClientContext &context, shared_ptr<Binder> parent, BinderType binder_type);
 };

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -33,8 +33,8 @@
 
 namespace duckdb {
 
-static void CheckInsertColumnCountMismatch(idx_t expected_columns, idx_t result_columns, bool columns_provided,
-                                           const char *tname) {
+void Binder::CheckInsertColumnCountMismatch(idx_t expected_columns, idx_t result_columns, bool columns_provided,
+                                            const string &tname) {
 	if (result_columns != expected_columns) {
 		string msg = StringUtil::Format(!columns_provided ? "table %s has %lld columns but %lld values were supplied"
 		                                                  : "Column name/value mismatch for insert on %s: "
@@ -74,8 +74,7 @@ void Binder::ExpandDefaultInValuesList(InsertStatement &stmt, TableCatalogEntry 
 		expr_list.expected_names.resize(expected_columns);
 
 		D_ASSERT(!expr_list.values.empty());
-		CheckInsertColumnCountMismatch(expected_columns, expr_list.values[0].size(), !stmt.columns.empty(),
-		                               table.name.c_str());
+		CheckInsertColumnCountMismatch(expected_columns, expr_list.values[0].size(), !stmt.columns.empty(), table.name);
 
 		// VALUES list!
 		for (idx_t col_idx = 0; col_idx < expected_columns; col_idx++) {
@@ -572,8 +571,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 			MoveCorrelatedExpressions(*select_binder);
 		}
 		// inserting from a select - check if the column count matches
-		CheckInsertColumnCountMismatch(expected_columns, root_select.types.size(), !stmt.columns.empty(),
-		                               table.name.c_str());
+		CheckInsertColumnCountMismatch(expected_columns, root_select.types.size(), !stmt.columns.empty(), table.name);
 
 		root = CastLogicalOperatorToTypes(root_select.types, insert->expected_types, std::move(root_select.plan));
 	} else {

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -112,6 +112,8 @@ unique_ptr<BoundMergeIntoAction> Binder::BindMergeAction(LogicalMergeInto &merge
 			// expand source bindings
 			action.expressions = GenerateColumnReferences(*this, source_aliases, source_names);
 		}
+		CheckInsertColumnCountMismatch(expected_types.size(), action.expressions.size(), !action.insert_columns.empty(),
+		                               table.name);
 		// explicit expressions - plan them
 		for (idx_t i = 0; i < action.expressions.size(); i++) {
 			auto &column = table.GetColumns().GetColumn(named_column_map[i]);
@@ -125,6 +127,7 @@ unique_ptr<BoundMergeIntoAction> Binder::BindMergeAction(LogicalMergeInto &merge
 			PlanSubqueries(insert_expr, root);
 			insert_expressions.push_back(std::move(insert_expr));
 		}
+
 		for (auto &insert_expr : insert_expressions) {
 			result->expressions.push_back(make_uniq<BoundColumnRefExpression>(
 			    insert_expr->return_type, ColumnBinding(proj_index, expressions.size())));

--- a/test/sql/merge/merge_into_too_few_columns.test
+++ b/test/sql/merge/merge_into_too_few_columns.test
@@ -1,0 +1,21 @@
+# name: test/sql/merge/merge_into_too_few_columns.test
+# description: Test MERGE INTO with too few columns
+# group: [merge]
+
+statement ok
+CREATE TABLE people (id INTEGER, name VARCHAR, salary FLOAT);
+
+statement ok
+INSERT INTO people VALUES (1, 'John', 92_000.0), (2, 'Anna', 100_000.0);
+
+statement error
+MERGE INTO people
+USING (
+	SELECT
+		3 AS id,
+		89_000.0 AS salary
+) AS upserts
+ON (upserts.id = people.id)
+WHEN NOT MATCHED THEN INSERT;
+----
+has 3 columns but 2 values were supplied


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/18692