### PR TITLE
Fix PIVOT in multiple statements

### DIFF
--- a/src/parser/transform/statement/transform_pivot_stmt.cpp
+++ b/src/parser/transform/statement/transform_pivot_stmt.cpp
@@ -125,6 +125,8 @@ unique_ptr<SQLStatement> Transformer::CreatePivotStatement(unique_ptr<SQLStateme
 		}
 		result->statements.push_back(GenerateCreateEnumStmt(std::move(pivot)));
 	}
+	result->stmt_location = statement->stmt_location;
+	result->stmt_length = statement->stmt_length;
 	result->statements.push_back(std::move(statement));
 	// FIXME: drop the types again!?
 	//	for(auto &pivot : pivot_entries) {

--- a/src/planner/pragma_handler.cpp
+++ b/src/planner/pragma_handler.cpp
@@ -25,7 +25,7 @@ void PragmaHandler::HandlePragmaStatementsInternal(vector<unique_ptr<SQLStatemen
 		if (statements[i]->type == StatementType::MULTI_STATEMENT) {
 			auto &multi_statement = statements[i]->Cast<MultiStatement>();
 			for (auto &stmt : multi_statement.statements) {
-				statements.push_back(std::move(stmt));
+				new_statements.push_back(std::move(stmt));
 			}
 			continue;
 		}

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(filter)
 add_subdirectory(function)
 add_subdirectory(index)
 add_subdirectory(parallelism)
+add_subdirectory(pivot)
 add_subdirectory(storage)
 
 set(ALL_OBJECT_FILES

--- a/test/sql/pivot/CMakeLists.txt
+++ b/test/sql/pivot/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library_unity(test_pivot OBJECT multi_statement_parsing.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_pivot>
+    PARENT_SCOPE)

--- a/test/sql/pivot/multi_statement_parsing.cpp
+++ b/test/sql/pivot/multi_statement_parsing.cpp
@@ -1,0 +1,30 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+// This test that the parser keeps statements in the right order, also when a multi-statement (i.e. a PIVOT is included
+// See https://github.com/duckdb/duckdb/issues/18710
+TEST_CASE("Parsing multiple statements including a PIVOT in one go results in a correctly ordered list", "[pivot][.]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto query = "PIVOT (SELECT 'a' AS col) ON col using first(col);SELECT 42;";
+
+	// Check that the SELECT 42 statement is last in the parsed statements list
+	auto statements = con.context->ParseStatements(query);
+	REQUIRE(statements.size() == 3);
+	// REQUIRE(statements.back()->query == "SELECT 42;");
+
+	// Execute the query
+	auto result = con.Query(query);
+
+	// We expect two results
+	REQUIRE(result);
+	REQUIRE(result->next);
+	REQUIRE(result->next->next == nullptr);
+	// The first result should be that of the PIVOT statement
+	REQUIRE(CHECK_COLUMN(result, 0, {"a"}));
+	// The second result should be 42
+	REQUIRE(CHECK_COLUMN(result->next, 0, {42}));
+}

--- a/tools/sqlite3_api_wrapper/test/test_sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/test/test_sqlite3_api_wrapper.cpp
@@ -336,6 +336,16 @@ TEST_CASE("Test rollback of aborted transaction", "[sqlite3wrapper]") {
 	REQUIRE(db.Execute("START TRANSACTION"));
 }
 
+TEST_CASE("Test PIVOT", "[sqlite3wrapper]") {
+	SQLiteDBWrapper db;
+
+	// open an in-memory db
+	REQUIRE(db.Open(":memory:"));
+	REQUIRE(db.Execute("PIVOT (SELECT 'a' AS col) ON col using first(col);SELECT 42;"));
+	// Results are concatenated
+	REQUIRE(db.CheckColumn(0, {"a", "42"}));
+}
+
 TEST_CASE("Test sqlite3_complete", "[sqlite3wrapper]") {
 	REQUIRE(sqlite3_complete("SELECT $$ this is a dollar quoted string without a marker $$;") == 1);
 	REQUIRE(sqlite3_complete("SELECT $this$is a dollar quoted string$this$;") == 1);


### PR DESCRIPTION
This fixes two bugs in the PIVOT / MULTI_STATEMENT code:
1. The nested statements of PIVOT were appended to the end of the statements list, resulting in behavior like #18710
2. The statement didn't get the correct position and length, resulting in funny behavior in the shell when running multiple statements at once:
```
DuckDB v1.3.2 (Ossivalis) 0b83e5d2f6
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D PIVOT (SELECT 'a' AS col) ON col using first(col);SELECT 42;
┌─────────┐
│    a    │
│ varchar │
├─────────┤
│ a       │
└─────────┘
Parser Error:
syntax error at or near "IVOT"

LINE 1: IVOT (SELECT 'a' AS col) ON col using first(col);SELECT 42;
```