### PR TITLE
Internal #5669: Loop Join Thresholds

### DIFF
--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -1,4 +1,3 @@
-#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/execution/operator/join/perfect_hash_join_executor.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
@@ -6,14 +5,11 @@
 #include "duckdb/execution/operator/join/physical_iejoin.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
 #include "duckdb/execution/operator/join/physical_piecewise_merge_join.hpp"
-#include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
-#include "duckdb/function/table/table_scan.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
-#include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/main/settings.hpp"
 
 namespace duckdb {
@@ -68,15 +64,15 @@ PhysicalOperator &PhysicalPlanGenerator::PlanComparisonJoin(LogicalComparisonJoi
 
 	D_ASSERT(op.left_projection_map.empty());
 	idx_t nested_loop_join_threshold = DBConfig::GetSetting<NestedLoopJoinThresholdSetting>(context);
-	if (left.estimated_cardinality <= nested_loop_join_threshold ||
-	    right.estimated_cardinality <= nested_loop_join_threshold) {
+	if (left.estimated_cardinality < nested_loop_join_threshold ||
+	    right.estimated_cardinality < nested_loop_join_threshold) {
 		can_iejoin = false;
 		can_merge = false;
 	}
 
 	if (can_merge && can_iejoin) {
 		idx_t merge_join_threshold = DBConfig::GetSetting<MergeJoinThresholdSetting>(context);
-		if (left.estimated_cardinality <= merge_join_threshold || right.estimated_cardinality <= merge_join_threshold) {
+		if (left.estimated_cardinality < merge_join_threshold || right.estimated_cardinality < merge_join_threshold) {
 			can_iejoin = false;
 		}
 	}

--- a/test/sql/join/iejoin/test_iejoin_null_keys.test
+++ b/test/sql/join/iejoin/test_iejoin_null_keys.test
@@ -12,6 +12,9 @@ statement ok
 SET merge_join_threshold=0
 
 statement ok
+SET nested_loop_join_threshold=0
+
+statement ok
 create table tt (x int, y int, z int);
 
 statement ok


### PR DESCRIPTION
* Change loop threshold tests to strict inequalities (so they can be used to force behaviour)
* Set nested_loop_join_threshold in the test

fixes: duckdblabs/duckdb-internal#5669