### PR TITLE
Use 1-based indexing for SQL-based JSON array extraction

### DIFF
--- a/test/sql/json/scalar/test_json_dot_syntax.test
+++ b/test/sql/json/scalar/test_json_dot_syntax.test
@@ -24,6 +24,17 @@ select json('{"foo": null}').foo.bar
 ----
 NULL
 
+# also supports this syntax
+query T
+select json('{"foo": null}')['foo']
+----
+null
+
+query T
+select json('{"foo": null}')['foo']['bar']
+----
+NULL
+
 query T
 select json('null')
 ----
@@ -42,7 +53,7 @@ NULL
 
 # but we can using array extract syntax
 query T
-select json('{"my_field": {"my_nested_field": ["goose", "duck"]}}').my_field.my_nested_field[1]
+select json('{"my_field": {"my_nested_field": ["goose", "duck"]}}').my_field.my_nested_field[2]
 ----
 "duck"
 
@@ -54,7 +65,7 @@ NULL
 
 # but this will
 query T
-select ('{"my_field": {"my_nested_field": ["goose", "duck"]}}'::JSON).my_field.my_nested_field[1]
+select ('{"my_field": {"my_nested_field": ["goose", "duck"]}}'::JSON).my_field.my_nested_field[2]
 ----
 "duck"
 
@@ -72,22 +83,22 @@ select ('{"my_field": {"my_nested_field": ["goose", "duck"]}}'::JSON).my_field.m
 [
 
 query T
-select json('{"my_field": {"my_nested_field": ["goose", "duck"]}}').my_field.my_nested_field[1]
+select json('{"my_field": {"my_nested_field": ["goose", "duck"]}}').my_field.my_nested_field[2]
 ----
 "duck"
 
 query T
-select json('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}').my_field.my_nested_field[1]
+select json('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}').my_field.my_nested_field[2]
 ----
 "duckduckduckduck"
 
 query T
-select ('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}'::JSON).my_field.my_nested_field[1]
+select ('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}'::JSON).my_field.my_nested_field[2]
 ----
 "duckduckduckduck"
 
 query T
-select json('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}').my_field.my_nested_field[1]
+select json('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}').my_field.my_nested_field[2]
 ----
 "duckduckduckduck"
 
@@ -99,18 +110,18 @@ NULL
 
 # works!
 query T
-select json('[1, 2, 42]')[2]
+select json('[1, 2, 42]')[3]
 ----
 42
 
 query T
-select json('[1, 2, 42]')[2]::text
+select json('[1, 2, 42]')[3]::text
 ----
 42
 
 # chained
 query T
-select ('{"my_field": {"my_nested_field": ["goose", "duck"]}}'::JSON).my_field.my_nested_field[1]
+select ('{"my_field": {"my_nested_field": ["goose", "duck"]}}'::JSON).my_field.my_nested_field[2]
 ----
 "duck"
 
@@ -121,12 +132,12 @@ SELECT json('{"a":2,"c":[4,5,{"f":7}]}').c
 [4,5,{"f":7}]
 
 query T
-SELECT json('{"a":2,"c":[4,5,{"f":7}]}').c[2]
+SELECT json('{"a":2,"c":[4,5,{"f":7}]}').c[3]
 ----
 {"f":7}
 
 query T
-SELECT json('{"a":2,"c":[4,5,{"f":7}]}').c[2].f
+SELECT json('{"a":2,"c":[4,5,{"f":7}]}').c[3].f
 ----
 7
 


### PR DESCRIPTION
Following the discussion here https://github.com/duckdb/duckdb/pull/18609#discussion_r2287892356, this PR implements 1-based indexing for extraction of elements from JSON arrays when using the subscript operator in SQL:
```sql
with cte as (
      select
          '["hello", "world"]'::json[] array_of_json,
          '["hello", "world"]'::json json_array,
  )
  select
      array_of_json[1] as array_access,   -- array extraction in SQL is 1-based
      json_array[1] as json_array_access, -- used to be 0-based, is now also 1-based
      json_array->'$[0]' json_path,       -- unchanged, 0-based (RFC)
      json_array->'/0' json_pointer,      -- unchanged, 0-based (RFC)
  from
      cte;
-- ┌──────────────┬───────────────────┬───────────┬──────────────┐
-- │ array_access │ json_array_access │ json_path │ json_pointer │
-- │     json     │       json        │   json    │     json     │
-- ├──────────────┼───────────────────┼───────────┼──────────────┤
-- │ "hello"      │ "hello"           │ "hello"   │ "hello"      │
-- └──────────────┴───────────────────┴───────────┴──────────────┘
```

I've also enabled this field extraction syntax:
```sql
with cte as (
      select '{"duck":42}'::json j
  )
  select j['duck']
  from cte;
-- ┌───────────┐
-- │ j['duck'] │
-- │   json    │
-- ├───────────┤
-- │ 42        │
-- └───────────┘
```
Which used to throw an error before.