### PR TITLE
Secrets: if serialization_type is not specified, assume it's a key value secret

### DIFF
--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -98,8 +98,8 @@ unique_ptr<BaseSecret> SecretManager::DeserializeSecret(Deserializer &deserializ
 	vector<string> scope;
 	deserializer.ReadList(103, "scope",
 	                      [&](Deserializer::List &list, idx_t i) { scope.push_back(list.ReadElement<string>()); });
-	auto serialization_type =
-	    deserializer.ReadPropertyWithExplicitDefault(104, "serialization_type", SecretSerializationType::CUSTOM);
+	auto serialization_type = deserializer.ReadPropertyWithExplicitDefault(104, "serialization_type",
+	                                                                       SecretSerializationType::KEY_VALUE_SECRET);
 
 	switch (serialization_type) {
 	// This allows us to skip looking up the secret type for deserialization altogether

--- a/test/sql/secrets/create_secret_persistence_error_handling.test
+++ b/test/sql/secrets/create_secret_persistence_error_handling.test
@@ -41,8 +41,6 @@ set secret_directory='__TEST_DIR__/create_secret_persistence_error_handling2'
 statement ok
 SET autoload_known_extensions=false;
 
-# Force persistent deserialization; DuckDB should throw error 
-statement error
-from duckdb_secrets(); 
-----
-Alternatively, try removing the secret at path 
+# Force persistent deserialization; we can deserialize generic key/value secrets
+statement ok
+from duckdb_secrets();


### PR DESCRIPTION
Currently the `serialization_type` is never serialized by any secrets, as this was added later, and serializing it would break forwards compatibility. All of our secrets are key/value secrets - yet we assume on deserialization that the secret type is `CUSTOM` which requires us to then load/have the extension in order to deserialize the secret. By changing the default secret type to `KEY_VALUE_SECRET` we can deserialize all of our secrets correctly. If, in the future, we need to create/serialize a non-key-value secret, we can set `serialization_type` appropriately.