### PR TITLE
Use correct type for pushing collations in subqueries

### DIFF
--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -167,14 +167,14 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 			JoinCondition cond;
 			cond.left = std::move(expr.children[child_idx]);
 			auto &child_type = expr.child_types[child_idx];
+			auto &compare_type = expr.child_targets[child_idx];
 			cond.right = BoundCastExpression::AddDefaultCastToType(
-			    make_uniq<BoundColumnRefExpression>(child_type, plan_columns[child_idx]),
-			    expr.child_targets[child_idx]);
+			    make_uniq<BoundColumnRefExpression>(child_type, plan_columns[child_idx]), compare_type);
 			cond.comparison = expr.comparison_type;
 
 			// push collations
-			ExpressionBinder::PushCollation(binder.context, cond.left, cond.left->return_type);
-			ExpressionBinder::PushCollation(binder.context, cond.right, cond.right->return_type);
+			ExpressionBinder::PushCollation(binder.context, cond.left, compare_type);
+			ExpressionBinder::PushCollation(binder.context, cond.right, compare_type);
 
 			join->conditions.push_back(std::move(cond));
 		}

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -187,14 +187,15 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::Decorrelate(unique_ptr<Logica
 				JoinCondition compare_cond;
 				compare_cond.left = std::move(op.expression_children[child_idx]);
 				auto &child_type = op.child_types[child_idx];
+				auto &compare_type = op.child_targets[child_idx];
 				compare_cond.right = BoundCastExpression::AddDefaultCastToType(
 				    make_uniq<BoundColumnRefExpression>(child_type, plan_columns[child_idx]),
 				    op.child_targets[child_idx]);
 				compare_cond.comparison = op.comparison_type;
 
 				// push collations
-				ExpressionBinder::PushCollation(binder.context, compare_cond.left, compare_cond.left->return_type);
-				ExpressionBinder::PushCollation(binder.context, compare_cond.right, compare_cond.right->return_type);
+				ExpressionBinder::PushCollation(binder.context, compare_cond.left, compare_type);
+				ExpressionBinder::PushCollation(binder.context, compare_cond.right, compare_type);
 				op.conditions.push_back(std::move(compare_cond));
 			}
 		}

--- a/test/sql/collate/collate_in_subquery.test
+++ b/test/sql/collate/collate_in_subquery.test
@@ -4,12 +4,32 @@
 
 # uncorrelated
 query I
-select 'ABC' collate nocase in (select 'abc');
+select 'ABC' collate nocase in (select 'aBc');
 ----
 true
 
 # correlated
 query I
-select upper in (select lower) from (values ('ABC' COLLATE nocase, 'abc' COLLATE nocase)) t(upper, lower);
+select upper in (select lower) from (values ('ABC' COLLATE nocase, 'aBc' COLLATE nocase)) t(upper, lower);
+----
+true
+
+query I
+select 'ABC' collate nocase in (select s) from (values ('aBc')) t(s);
+----
+true
+
+query I
+select 'ABC' in (select s collate nocase) from (values ('aBc')) t(s);
+----
+true
+
+query I
+select 'AB' collate nocase in (select 'AB');
+----
+true
+
+query I
+select 'Ab' collate nocase in (select 'Ab');
 ----
 true


### PR DESCRIPTION
Follow-up fix from https://github.com/duckdb/duckdb/pull/18698

Use the correct (combined) type for pushing collations, otherwise collations are only handled for one side of the join condition which leads to wrong results