### PR TITLE
Add OS X notarization for DuckDB CLI and libduckdb.dylib

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -149,11 +149,25 @@ jobs:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.OSX_CODESIGN_BUILD_CERTIFICATE_BASE64 }}
           P12_PASSWORD: ${{ secrets.OSX_CODESIGN_P12_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.OSX_CODESIGN_KEYCHAIN_PASSWORD }}
+          TEAM_ID: ${{ secrets.OSX_NOTARIZE_TEAM_ID }}
+          APPLE_ID: ${{ secrets.OSX_NOTARIZE_APPLE_ID }}
+          PASSWORD: ${{ secrets.OSX_NOTARIZE_PASSWORD }}
         run: |
           if [[ "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             . scripts/osx_import_codesign_certificate.sh
-            codesign --options runtime --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/duckdb
-            codesign --options runtime --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/src/libduckdb*.dylib
+            
+            echo -e '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n  <key>com.apple.security.cs.disable-library-validation</key>\n  <true/>\n</dict>\n</plist>' > entitlements.plist
+            codesign --options runtime --entitlements entitlements.plist --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/duckdb
+            codesign --options runtime --entitlements entitlements.plist --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/src/libduckdb*.dylib
+          
+            zip -j notarize.zip build/release/duckdb build/release/src/libduckdb.dylib 
+            export XCRUN_RESPONSE=$(xcrun notarytool submit --progress --apple-id "$APPLE_ID" --password "$PASSWORD" --team-id "$TEAM_ID" --wait -f json notarize.zip)
+            rm notarize.zip
+            if [[ $(echo $XCRUN_RESPONSE | jq -r .status) != "Success" ]] ; then 
+              echo "Notarization failed!"
+              echo $XCRUN_RESPONSE
+              exit 1
+            fi
           fi
 
       - name: Deploy

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -103,7 +103,7 @@ jobs:
     # Builds binaries for osx_arm64 and osx_amd64
     name: OSX Release
     runs-on: macos-14
-    needs: xcode-debug
+   # needs: xcode-debug
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
@@ -149,7 +149,7 @@ jobs:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.OSX_CODESIGN_BUILD_CERTIFICATE_BASE64 }}
           P12_PASSWORD: ${{ secrets.OSX_CODESIGN_P12_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.OSX_CODESIGN_KEYCHAIN_PASSWORD }}
-          TEAM_ID: ${{ secrets.OSX_NOTARIZE_TEAM_ID }}
+          TEAM_ID : ${{ secrets.OSX_NOTARIZE_TEAM_ID }}
           APPLE_ID: ${{ secrets.OSX_NOTARIZE_APPLE_ID }}
           PASSWORD: ${{ secrets.OSX_NOTARIZE_PASSWORD }}
         run: |
@@ -163,7 +163,7 @@ jobs:
             zip -j notarize.zip build/release/duckdb build/release/src/libduckdb.dylib 
             export XCRUN_RESPONSE=$(xcrun notarytool submit --progress --apple-id "$APPLE_ID" --password "$PASSWORD" --team-id "$TEAM_ID" --wait -f json notarize.zip)
             rm notarize.zip
-            if [[ $(echo $XCRUN_RESPONSE | jq -r .status) != "Success" ]] ; then 
+            if [[ $(echo $XCRUN_RESPONSE | ./build/release/duckdb -csv -noheader -s "FROM read_json('/dev/stdin') SELECT status") != "Success" ]] ; then 
               echo "Notarization failed!"
               echo $XCRUN_RESPONSE
               exit 1

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -163,7 +163,7 @@ jobs:
             zip -j notarize.zip build/release/duckdb build/release/src/libduckdb.dylib 
             export XCRUN_RESPONSE=$(xcrun notarytool submit --progress --apple-id "$APPLE_ID" --password "$PASSWORD" --team-id "$TEAM_ID" --wait -f json notarize.zip)
             rm notarize.zip
-            if [[ $(echo $XCRUN_RESPONSE | ./build/release/duckdb -csv -noheader -s "FROM read_json('/dev/stdin') SELECT status") != "Accepted" ]] ; then 
+            if [[ $(./build/release/duckdb -csv -noheader -c "SELECT (getenv('XCRUN_RESPONSE')::JSON).status") != "Accepted" ]] ; then 
               echo "Notarization failed!"
               echo $XCRUN_RESPONSE
               exit 1

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -152,9 +152,9 @@ jobs:
         run: |
           if [[ "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             . scripts/osx_import_codesign_certificate.sh
-
-            codesign --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/duckdb
-            codesign --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/src/libduckdb*.dylib
+            echo -e '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n  <key>com.apple.security.cs.disable-library-validation</key>\n  <true/>\n</dict>\n</plist>' > entitlements.plist
+            codesign --options runtime --entitlements entitlements.plist --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/duckdb
+            codesign --options runtime --entitlements entitlements.plist --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/src/libduckdb*.dylib
           fi
 
       - name: Deploy

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -163,7 +163,7 @@ jobs:
             zip -j notarize.zip build/release/duckdb build/release/src/libduckdb.dylib 
             export XCRUN_RESPONSE=$(xcrun notarytool submit --progress --apple-id "$APPLE_ID" --password "$PASSWORD" --team-id "$TEAM_ID" --wait -f json notarize.zip)
             rm notarize.zip
-            if [[ $(echo $XCRUN_RESPONSE | ./build/release/duckdb -csv -noheader -s "FROM read_json('/dev/stdin') SELECT status") != "Success" ]] ; then 
+            if [[ $(echo $XCRUN_RESPONSE | ./build/release/duckdb -csv -noheader -s "FROM read_json('/dev/stdin') SELECT status") != "Accepted" ]] ; then 
               echo "Notarization failed!"
               echo $XCRUN_RESPONSE
               exit 1

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -103,7 +103,7 @@ jobs:
     # Builds binaries for osx_arm64 and osx_amd64
     name: OSX Release
     runs-on: macos-14
-   # needs: xcode-debug
+    needs: xcode-debug
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -152,9 +152,8 @@ jobs:
         run: |
           if [[ "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             . scripts/osx_import_codesign_certificate.sh
-            echo -e '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n  <key>com.apple.security.cs.disable-library-validation</key>\n  <true/>\n</dict>\n</plist>' > entitlements.plist
-            codesign --options runtime --entitlements entitlements.plist --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/duckdb
-            codesign --options runtime --entitlements entitlements.plist --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/src/libduckdb*.dylib
+            codesign --options runtime --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/duckdb
+            codesign --options runtime --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/src/libduckdb*.dylib
           fi
 
       - name: Deploy

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -163,7 +163,7 @@ jobs:
             zip -j notarize.zip build/release/duckdb build/release/src/libduckdb.dylib 
             export XCRUN_RESPONSE=$(xcrun notarytool submit --progress --apple-id "$APPLE_ID" --password "$PASSWORD" --team-id "$TEAM_ID" --wait -f json notarize.zip)
             rm notarize.zip
-            if [[ $(./build/release/duckdb -csv -noheader -c "SELECT (getenv('XCRUN_RESPONSE')::JSON).status") != "Accepted" ]] ; then 
+            if [[ $(./build/release/duckdb -csv -noheader -c "SELECT (getenv('XCRUN_RESPONSE')::JSON)->>'status'") != "Accepted" ]] ; then 
               echo "Notarization failed!"
               echo $XCRUN_RESPONSE
               exit 1


### PR DESCRIPTION
This PR adds Apple "[Notarization](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)" for the DuckDB CLI tool `duckdb` and the dynamic library, `libduckdb.dylib`.

Basically, binaries are signed and then sent to Apple for approval. OSX will check with Apple on first launch of a binary if it has been notarized and allow certain things if that's true.

Notarization of command-line-binaries is not exactly a priority for Apple, so OSX will still complain if one downloads the .zip with the CLI, and then double-clicks it in Finder. *However*, with this PR, OSX will allow starting this binary *from Terminal*, which did not used to work.
