### PR TITLE
Add leak suppressions to nightly runs

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -479,6 +479,8 @@ jobs:
   vector-and-block-sizes:
     name: Tests different vector and block sizes
     runs-on: ubuntu-24.04
+    env:
+      LSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-leak-suppressions.txt
     needs: linux-memory-leaks
 
     steps:
@@ -516,6 +518,8 @@ jobs:
   linux-debug-configs:
     name: Tests different configurations with a debug build
     runs-on: ubuntu-24.04
+    env:
+      LSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-leak-suppressions.txt
     needs: linux-memory-leaks
 
     steps:


### PR DESCRIPTION
Otherwise we report leaks in TPC-H `dbgen` which we don't care about