### PR TITLE
Fixing lazy polars execution on query result

### DIFF
--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -24,6 +24,7 @@ struct ClientProperties {
 	      arrow_lossless_conversion(lossless_conversion), arrow_output_version(arrow_output_version),
 	      client_context(client_context) {
 	}
+	ClientProperties() {};
 
 	string time_zone = "UTC";
 	ArrowOffsetSize arrow_offset_size = ArrowOffsetSize::REGULAR;

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -28,7 +28,7 @@ namespace duckdb {
 struct DuckDBPyRelation {
 public:
 	explicit DuckDBPyRelation(shared_ptr<Relation> rel);
-	explicit DuckDBPyRelation(unique_ptr<DuckDBPyResult> result);
+	explicit DuckDBPyRelation(shared_ptr<DuckDBPyResult> result);
 	~DuckDBPyRelation();
 
 public:
@@ -288,7 +288,7 @@ private:
 	shared_ptr<Relation> rel;
 	vector<LogicalType> types;
 	vector<string> names;
-	unique_ptr<DuckDBPyResult> result;
+	shared_ptr<DuckDBPyResult> result;
 	std::string rendered_result;
 };
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
@@ -59,6 +59,8 @@ public:
 	const vector<string> &GetNames();
 	const vector<LogicalType> &GetTypes();
 
+	ClientProperties GetClientProperties();
+
 private:
 	void FillNumpy(py::dict &res, idx_t col_idx, NumpyResultConversion &conversion, const char *name);
 

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -984,7 +984,14 @@ PolarsDataFrame DuckDBPyRelation::ToPolars(idx_t batch_size, bool lazy) {
 	ArrowSchema arrow_schema;
 	auto result_names = names;
 	QueryResult::DeduplicateColumns(result_names);
-	auto client_properties = rel->context->GetContext()->GetClientProperties();
+	ClientProperties client_properties;
+	if (rel) {
+		client_properties = rel->context->GetContext()->GetClientProperties();
+	} else if (result) {
+		client_properties = result->GetClientProperties();
+	} else {
+		throw InternalException("DuckDBPyRelation To Polars must have a valid relation or result");
+	}
 	ArrowConverter::ToArrowSchema(&arrow_schema, types, result_names, client_properties);
 	py::list batches;
 	// Now we create an empty arrow table

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -66,7 +66,7 @@ DuckDBPyRelation::~DuckDBPyRelation() {
 	rel.reset();
 }
 
-DuckDBPyRelation::DuckDBPyRelation(unique_ptr<DuckDBPyResult> result_p) : rel(nullptr), result(std::move(result_p)) {
+DuckDBPyRelation::DuckDBPyRelation(shared_ptr<DuckDBPyResult> result_p) : rel(nullptr), result(std::move(result_p)) {
 	if (!result) {
 		throw InternalException("DuckDBPyRelation created without a result");
 	}

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -41,6 +41,10 @@ DuckDBPyResult::~DuckDBPyResult() {
 	}
 }
 
+ClientProperties DuckDBPyResult::GetClientProperties() {
+	return result->client_properties;
+}
+
 const vector<string> &DuckDBPyResult::GetNames() {
 	if (!result) {
 		throw InternalException("Calling GetNames without a result object");

--- a/tools/pythonpkg/tests/fast/arrow/test_polars.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_polars.py
@@ -21,85 +21,85 @@ def invalid_filter(filter):
 
 
 class TestPolars(object):
-    # def test_polars(self, duckdb_cursor):
-    #     df = pl.DataFrame(
-    #         {
-    #             "A": [1, 2, 3, 4, 5],
-    #             "fruits": ["banana", "banana", "apple", "apple", "banana"],
-    #             "B": [5, 4, 3, 2, 1],
-    #             "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
-    #         }
-    #     )
-    #     # scan plus return a polars dataframe
-    #     polars_result = duckdb_cursor.sql('SELECT * FROM df').pl()
-    #     pl_testing.assert_frame_equal(df, polars_result)
+    def test_polars(self, duckdb_cursor):
+        df = pl.DataFrame(
+            {
+                "A": [1, 2, 3, 4, 5],
+                "fruits": ["banana", "banana", "apple", "apple", "banana"],
+                "B": [5, 4, 3, 2, 1],
+                "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
+            }
+        )
+        # scan plus return a polars dataframe
+        polars_result = duckdb_cursor.sql('SELECT * FROM df').pl()
+        pl_testing.assert_frame_equal(df, polars_result)
 
-    #     # now do the same for a lazy dataframe
-    #     lazy_df = df.lazy()
-    #     lazy_result = duckdb_cursor.sql('SELECT * FROM lazy_df').pl()
-    #     pl_testing.assert_frame_equal(df, lazy_result)
+        # now do the same for a lazy dataframe
+        lazy_df = df.lazy()
+        lazy_result = duckdb_cursor.sql('SELECT * FROM lazy_df').pl()
+        pl_testing.assert_frame_equal(df, lazy_result)
 
-    #     con = duckdb.connect()
-    #     con_result = con.execute('SELECT * FROM df').pl()
-    #     pl_testing.assert_frame_equal(df, con_result)
+        con = duckdb.connect()
+        con_result = con.execute('SELECT * FROM df').pl()
+        pl_testing.assert_frame_equal(df, con_result)
 
-    # def test_execute_polars(self, duckdb_cursor):
-    #     res1 = duckdb_cursor.execute("SELECT 1 AS a, 2 AS a").pl()
-    #     assert res1.columns == ['a', 'a_1']
+    def test_execute_polars(self, duckdb_cursor):
+        res1 = duckdb_cursor.execute("SELECT 1 AS a, 2 AS a").pl()
+        assert res1.columns == ['a', 'a_1']
 
-    # def test_register_polars(self, duckdb_cursor):
-    #     con = duckdb.connect()
-    #     df = pl.DataFrame(
-    #         {
-    #             "A": [1, 2, 3, 4, 5],
-    #             "fruits": ["banana", "banana", "apple", "apple", "banana"],
-    #             "B": [5, 4, 3, 2, 1],
-    #             "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
-    #         }
-    #     )
-    #     # scan plus return a polars dataframe
-    #     con.register('polars_df', df)
-    #     polars_result = con.execute('select * from polars_df').pl()
-    #     pl_testing.assert_frame_equal(df, polars_result)
-    #     con.unregister('polars_df')
-    #     with pytest.raises(duckdb.CatalogException, match='Table with name polars_df does not exist'):
-    #         con.execute("SELECT * FROM polars_df;").pl()
+    def test_register_polars(self, duckdb_cursor):
+        con = duckdb.connect()
+        df = pl.DataFrame(
+            {
+                "A": [1, 2, 3, 4, 5],
+                "fruits": ["banana", "banana", "apple", "apple", "banana"],
+                "B": [5, 4, 3, 2, 1],
+                "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
+            }
+        )
+        # scan plus return a polars dataframe
+        con.register('polars_df', df)
+        polars_result = con.execute('select * from polars_df').pl()
+        pl_testing.assert_frame_equal(df, polars_result)
+        con.unregister('polars_df')
+        with pytest.raises(duckdb.CatalogException, match='Table with name polars_df does not exist'):
+            con.execute("SELECT * FROM polars_df;").pl()
 
-    #     con.register('polars_df', df.lazy())
-    #     polars_result = con.execute('select * from polars_df').pl()
-    #     pl_testing.assert_frame_equal(df, polars_result)
+        con.register('polars_df', df.lazy())
+        polars_result = con.execute('select * from polars_df').pl()
+        pl_testing.assert_frame_equal(df, polars_result)
 
-    # def test_empty_polars_dataframe(self, duckdb_cursor):
-    #     polars_empty_df = pl.DataFrame()
-    #     with pytest.raises(
-    #         duckdb.InvalidInputException, match='Provided table/dataframe must have at least one column'
-    #     ):
-    #         duckdb_cursor.sql("from polars_empty_df")
+    def test_empty_polars_dataframe(self, duckdb_cursor):
+        polars_empty_df = pl.DataFrame()
+        with pytest.raises(
+            duckdb.InvalidInputException, match='Provided table/dataframe must have at least one column'
+        ):
+            duckdb_cursor.sql("from polars_empty_df")
 
-    # def test_polars_from_json(self, duckdb_cursor):
-    #     from io import StringIO
+    def test_polars_from_json(self, duckdb_cursor):
+        from io import StringIO
 
-    #     duckdb_cursor.sql("set arrow_lossless_conversion=false")
-    #     string = StringIO("""{"entry":[{"content":{"ManagedSystem":{"test":null}}}]}""")
-    #     res = duckdb_cursor.read_json(string).pl()
-    #     assert str(res['entry'][0][0]) == "{'content': {'ManagedSystem': {'test': None}}}"
+        duckdb_cursor.sql("set arrow_lossless_conversion=false")
+        string = StringIO("""{"entry":[{"content":{"ManagedSystem":{"test":null}}}]}""")
+        res = duckdb_cursor.read_json(string).pl()
+        assert str(res['entry'][0][0]) == "{'content': {'ManagedSystem': {'test': None}}}"
 
-    # @pytest.mark.skipif(
-    #     not hasattr(pl.exceptions, "PanicException"), reason="Polars has no PanicException in this version"
-    # )
-    # def test_polars_from_json_error(self, duckdb_cursor):
-    #     from io import StringIO
+    @pytest.mark.skipif(
+        not hasattr(pl.exceptions, "PanicException"), reason="Polars has no PanicException in this version"
+    )
+    def test_polars_from_json_error(self, duckdb_cursor):
+        from io import StringIO
 
-    #     duckdb_cursor.sql("set arrow_lossless_conversion=true")
-    #     string = StringIO("""{"entry":[{"content":{"ManagedSystem":{"test":null}}}]}""")
-    #     res = duckdb_cursor.read_json(string).pl()
-    #     assert duckdb_cursor.execute("FROM res").fetchall() == [([{'content': {'ManagedSystem': {'test': None}}}],)]
+        duckdb_cursor.sql("set arrow_lossless_conversion=true")
+        string = StringIO("""{"entry":[{"content":{"ManagedSystem":{"test":null}}}]}""")
+        res = duckdb_cursor.read_json(string).pl()
+        assert duckdb_cursor.execute("FROM res").fetchall() == [([{'content': {'ManagedSystem': {'test': None}}}],)]
 
-    # def test_polars_from_json_error(self, duckdb_cursor):
-    #     conn = duckdb.connect()
-    #     my_table = conn.query("select 'x' my_str").pl()
-    #     my_res = duckdb.query("select my_str from my_table where my_str != 'y'")
-    #     assert my_res.fetchall() == [('x',)]
+    def test_polars_from_json_error(self, duckdb_cursor):
+        conn = duckdb.connect()
+        my_table = conn.query("select 'x' my_str").pl()
+        my_res = duckdb.query("select my_str from my_table where my_str != 'y'")
+        assert my_res.fetchall() == [('x',)]
 
     def test_polars_lazy_from_conn(self, duckdb_cursor):
         duckdb_conn = duckdb.connect()
@@ -108,11 +108,8 @@ class TestPolars(object):
 
         lazy_df = result.pl(lazy=True)
         assert lazy_df.collect().to_dicts() == [
-            {'a': 'Pedro', 'b': 32},
-            {'a': 'Mark', 'b': 31},
-            {'a': 'Thijs', 'b': 29},
+            {'bla': 42}
         ]
-
     def test_polars_lazy(self, duckdb_cursor):
         con = duckdb.connect()
         con.execute("Create table names (a varchar, b integer)")

--- a/tools/pythonpkg/tests/fast/arrow/test_polars.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_polars.py
@@ -21,85 +21,97 @@ def invalid_filter(filter):
 
 
 class TestPolars(object):
-    def test_polars(self, duckdb_cursor):
-        df = pl.DataFrame(
-            {
-                "A": [1, 2, 3, 4, 5],
-                "fruits": ["banana", "banana", "apple", "apple", "banana"],
-                "B": [5, 4, 3, 2, 1],
-                "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
-            }
-        )
-        # scan plus return a polars dataframe
-        polars_result = duckdb_cursor.sql('SELECT * FROM df').pl()
-        pl_testing.assert_frame_equal(df, polars_result)
+    # def test_polars(self, duckdb_cursor):
+    #     df = pl.DataFrame(
+    #         {
+    #             "A": [1, 2, 3, 4, 5],
+    #             "fruits": ["banana", "banana", "apple", "apple", "banana"],
+    #             "B": [5, 4, 3, 2, 1],
+    #             "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
+    #         }
+    #     )
+    #     # scan plus return a polars dataframe
+    #     polars_result = duckdb_cursor.sql('SELECT * FROM df').pl()
+    #     pl_testing.assert_frame_equal(df, polars_result)
 
-        # now do the same for a lazy dataframe
-        lazy_df = df.lazy()
-        lazy_result = duckdb_cursor.sql('SELECT * FROM lazy_df').pl()
-        pl_testing.assert_frame_equal(df, lazy_result)
+    #     # now do the same for a lazy dataframe
+    #     lazy_df = df.lazy()
+    #     lazy_result = duckdb_cursor.sql('SELECT * FROM lazy_df').pl()
+    #     pl_testing.assert_frame_equal(df, lazy_result)
 
-        con = duckdb.connect()
-        con_result = con.execute('SELECT * FROM df').pl()
-        pl_testing.assert_frame_equal(df, con_result)
+    #     con = duckdb.connect()
+    #     con_result = con.execute('SELECT * FROM df').pl()
+    #     pl_testing.assert_frame_equal(df, con_result)
 
-    def test_execute_polars(self, duckdb_cursor):
-        res1 = duckdb_cursor.execute("SELECT 1 AS a, 2 AS a").pl()
-        assert res1.columns == ['a', 'a_1']
+    # def test_execute_polars(self, duckdb_cursor):
+    #     res1 = duckdb_cursor.execute("SELECT 1 AS a, 2 AS a").pl()
+    #     assert res1.columns == ['a', 'a_1']
 
-    def test_register_polars(self, duckdb_cursor):
-        con = duckdb.connect()
-        df = pl.DataFrame(
-            {
-                "A": [1, 2, 3, 4, 5],
-                "fruits": ["banana", "banana", "apple", "apple", "banana"],
-                "B": [5, 4, 3, 2, 1],
-                "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
-            }
-        )
-        # scan plus return a polars dataframe
-        con.register('polars_df', df)
-        polars_result = con.execute('select * from polars_df').pl()
-        pl_testing.assert_frame_equal(df, polars_result)
-        con.unregister('polars_df')
-        with pytest.raises(duckdb.CatalogException, match='Table with name polars_df does not exist'):
-            con.execute("SELECT * FROM polars_df;").pl()
+    # def test_register_polars(self, duckdb_cursor):
+    #     con = duckdb.connect()
+    #     df = pl.DataFrame(
+    #         {
+    #             "A": [1, 2, 3, 4, 5],
+    #             "fruits": ["banana", "banana", "apple", "apple", "banana"],
+    #             "B": [5, 4, 3, 2, 1],
+    #             "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
+    #         }
+    #     )
+    #     # scan plus return a polars dataframe
+    #     con.register('polars_df', df)
+    #     polars_result = con.execute('select * from polars_df').pl()
+    #     pl_testing.assert_frame_equal(df, polars_result)
+    #     con.unregister('polars_df')
+    #     with pytest.raises(duckdb.CatalogException, match='Table with name polars_df does not exist'):
+    #         con.execute("SELECT * FROM polars_df;").pl()
 
-        con.register('polars_df', df.lazy())
-        polars_result = con.execute('select * from polars_df').pl()
-        pl_testing.assert_frame_equal(df, polars_result)
+    #     con.register('polars_df', df.lazy())
+    #     polars_result = con.execute('select * from polars_df').pl()
+    #     pl_testing.assert_frame_equal(df, polars_result)
 
-    def test_empty_polars_dataframe(self, duckdb_cursor):
-        polars_empty_df = pl.DataFrame()
-        with pytest.raises(
-            duckdb.InvalidInputException, match='Provided table/dataframe must have at least one column'
-        ):
-            duckdb_cursor.sql("from polars_empty_df")
+    # def test_empty_polars_dataframe(self, duckdb_cursor):
+    #     polars_empty_df = pl.DataFrame()
+    #     with pytest.raises(
+    #         duckdb.InvalidInputException, match='Provided table/dataframe must have at least one column'
+    #     ):
+    #         duckdb_cursor.sql("from polars_empty_df")
 
-    def test_polars_from_json(self, duckdb_cursor):
-        from io import StringIO
+    # def test_polars_from_json(self, duckdb_cursor):
+    #     from io import StringIO
 
-        duckdb_cursor.sql("set arrow_lossless_conversion=false")
-        string = StringIO("""{"entry":[{"content":{"ManagedSystem":{"test":null}}}]}""")
-        res = duckdb_cursor.read_json(string).pl()
-        assert str(res['entry'][0][0]) == "{'content': {'ManagedSystem': {'test': None}}}"
+    #     duckdb_cursor.sql("set arrow_lossless_conversion=false")
+    #     string = StringIO("""{"entry":[{"content":{"ManagedSystem":{"test":null}}}]}""")
+    #     res = duckdb_cursor.read_json(string).pl()
+    #     assert str(res['entry'][0][0]) == "{'content': {'ManagedSystem': {'test': None}}}"
 
-    @pytest.mark.skipif(
-        not hasattr(pl.exceptions, "PanicException"), reason="Polars has no PanicException in this version"
-    )
-    def test_polars_from_json_error(self, duckdb_cursor):
-        from io import StringIO
+    # @pytest.mark.skipif(
+    #     not hasattr(pl.exceptions, "PanicException"), reason="Polars has no PanicException in this version"
+    # )
+    # def test_polars_from_json_error(self, duckdb_cursor):
+    #     from io import StringIO
 
-        duckdb_cursor.sql("set arrow_lossless_conversion=true")
-        string = StringIO("""{"entry":[{"content":{"ManagedSystem":{"test":null}}}]}""")
-        res = duckdb_cursor.read_json(string).pl()
-        assert duckdb_cursor.execute("FROM res").fetchall() == [([{'content': {'ManagedSystem': {'test': None}}}],)]
+    #     duckdb_cursor.sql("set arrow_lossless_conversion=true")
+    #     string = StringIO("""{"entry":[{"content":{"ManagedSystem":{"test":null}}}]}""")
+    #     res = duckdb_cursor.read_json(string).pl()
+    #     assert duckdb_cursor.execute("FROM res").fetchall() == [([{'content': {'ManagedSystem': {'test': None}}}],)]
 
-    def test_polars_from_json_error(self, duckdb_cursor):
-        conn = duckdb.connect()
-        my_table = conn.query("select 'x' my_str").pl()
-        my_res = duckdb.query("select my_str from my_table where my_str != 'y'")
-        assert my_res.fetchall() == [('x',)]
+    # def test_polars_from_json_error(self, duckdb_cursor):
+    #     conn = duckdb.connect()
+    #     my_table = conn.query("select 'x' my_str").pl()
+    #     my_res = duckdb.query("select my_str from my_table where my_str != 'y'")
+    #     assert my_res.fetchall() == [('x',)]
+
+    def test_polars_lazy_from_conn(self, duckdb_cursor):
+        duckdb_conn = duckdb.connect()
+
+        result = duckdb_conn.execute("SELECT 42 as bla")
+
+        lazy_df = result.pl(lazy=True)
+        assert lazy_df.collect().to_dicts() == [
+            {'a': 'Pedro', 'b': 32},
+            {'a': 'Mark', 'b': 31},
+            {'a': 'Thijs', 'b': 29},
+        ]
 
     def test_polars_lazy(self, duckdb_cursor):
         con = duckdb.connect()

--- a/tools/pythonpkg/tests/fast/arrow/test_polars.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_polars.py
@@ -107,9 +107,8 @@ class TestPolars(object):
         result = duckdb_conn.execute("SELECT 42 as bla")
 
         lazy_df = result.pl(lazy=True)
-        assert lazy_df.collect().to_dicts() == [
-            {'bla': 42}
-        ]
+        assert lazy_df.collect().to_dicts() == [{'bla': 42}]
+
     def test_polars_lazy(self, duckdb_cursor):
         con = duckdb.connect()
         con.execute("Create table names (a varchar, b integer)")


### PR DESCRIPTION
PyRelation can be constructed directly from a query result and not only from a relation.

This code makes sure that the ClientProperties are acquired depending on what the relation holds and makes pyrelation copyable by changing its query result to a `shared_ptr`

Fix: https://github.com/duckdb/duckdb/issues/18701