### PR TITLE
Remove separate WAL encryption flag

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -888,12 +888,6 @@
         ]
     },
     {
-        "name": "wal_encryption",
-        "description": "Encrypt the WAL if the database is encrypted",
-        "type": "BOOLEAN",
-        "scope": "global"
-    },
-    {
         "name": "zstd_min_string_length",
         "description": "The (average) length at which to enable ZSTD compression, defaults to 4096",
         "type": "UBIGINT",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1233,16 +1233,6 @@ struct UsernameSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
-struct WalEncryptionSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "wal_encryption";
-	static constexpr const char *Description = "Encrypt the WAL if the database is encrypted";
-	static constexpr const char *InputType = "BOOLEAN";
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(const ClientContext &context);
-};
-
 struct ZstdMinStringLengthSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "zstd_min_string_length";

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -69,9 +69,6 @@ public:
 
 	void WriteVersion();
 
-	//! Determines if WAL should be encrypted
-	bool IsEncrypted() const;
-
 	virtual void WriteCreateTable(const TableCatalogEntry &entry);
 	void WriteDropTable(const TableCatalogEntry &entry);
 

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -173,7 +173,6 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(TempFileEncryptionSetting),
     DUCKDB_GLOBAL(ThreadsSetting),
     DUCKDB_GLOBAL(UsernameSetting),
-    DUCKDB_GLOBAL(WalEncryptionSetting),
     DUCKDB_GLOBAL(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -529,22 +529,6 @@ Value SchedulerProcessPartialSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
-// Wal Encryption
-//===----------------------------------------------------------------------===//
-void WalEncryptionSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
-	config.options.wal_encryption = input.GetValue<bool>();
-}
-
-void WalEncryptionSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
-	config.options.wal_encryption = DBConfig().options.wal_encryption;
-}
-
-Value WalEncryptionSetting::GetSetting(const ClientContext &context) {
-	auto &config = DBConfig::GetConfig(context);
-	return Value::BOOLEAN(config.options.wal_encryption);
-}
-
-//===----------------------------------------------------------------------===//
 // Zstd Min String Length
 //===----------------------------------------------------------------------===//
 void ZstdMinStringLengthSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -126,7 +126,7 @@ public:
 		// then encrypt WAL before flushing
 		auto &catalog = wal.GetDatabase().GetCatalog().Cast<DuckCatalog>();
 
-		if (wal.IsEncrypted() && catalog.GetIsEncrypted()) {
+		if (catalog.GetIsEncrypted()) {
 			return FlushEncrypted();
 		}
 
@@ -250,7 +250,7 @@ void WriteAheadLog::WriteVersion() {
 	serializer.WriteProperty(100, "wal_type", WALType::WAL_VERSION);
 	auto &catalog = GetDatabase().GetCatalog().Cast<DuckCatalog>();
 	auto encryption_key_id = catalog.GetEncryptionKeyId();
-	if (IsEncrypted() && catalog.GetIsEncrypted()) {
+	if (catalog.GetIsEncrypted()) {
 		serializer.WriteProperty(101, "version", idx_t(WAL_ENCRYPTED_VERSION_NUMBER));
 	} else {
 		serializer.WriteProperty(101, "version", idx_t(WAL_VERSION_NUMBER));
@@ -262,11 +262,6 @@ void WriteAheadLog::WriteCheckpoint(MetaBlockPointer meta_block) {
 	WriteAheadLogSerializer serializer(*this, WALType::CHECKPOINT);
 	serializer.WriteProperty(101, "meta_block", meta_block);
 	serializer.End();
-}
-
-bool WriteAheadLog::IsEncrypted() const {
-	const auto &config = DBConfig::GetConfig(database.GetDatabase());
-	return config.options.wal_encryption;
 }
 
 //===--------------------------------------------------------------------===//

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -54,7 +54,6 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"disabled_compression_methods", {"RLE"}},
 	    {"disabled_optimizers", {"extension"}},
 	    {"debug_force_external", {Value(true)}},
-	    {"wal_encryption", {Value(false)}},
 	    {"old_implicit_casting", {Value(true)}},
 	    {"prefer_range_joins", {Value(true)}},
 	    {"allow_persistent_secrets", {Value(false)}},

--- a/test/sql/function/autocomplete/setting.test
+++ b/test/sql/function/autocomplete/setting.test
@@ -16,10 +16,5 @@ FROM sql_auto_complete('set allowe') LIMIT 1;
 ----
 allowed_paths	4
 
-# main keywords
-query II
-FROM sql_auto_complete('set wal') LIMIT 1;
-----
-wal_encryption	4
 
 

--- a/test/sql/storage/encryption/wal/encrypted_wal_pragmas.test
+++ b/test/sql/storage/encryption/wal/encrypted_wal_pragmas.test
@@ -31,21 +31,17 @@ SELECT * FROM enc.test ORDER BY 1
 13	22
 
 statement ok
-SET wal_encryption = false;
-
-statement ok
 INSERT INTO enc.test VALUES (10, 'hello')
 
-# enable WAL encryption for the other tests
 statement ok
-SET wal_encryption = true;
+DETACH enc
 
-restart
-
-# WAL replay fails, because file is corrupted
-statement error
+# WAL replay succeeds
+statement ok
 ATTACH '__TEST_DIR__/encrypted_wal_restart.db' as enc (ENCRYPTION_KEY 'asdf');
-----
+
+statement ok
+DETACH enc
 
 # now set debug pragma at the start
 statement ok
@@ -111,12 +107,6 @@ SELECT * FROM enc.test ORDER BY 1
 11	22
 12	21
 13	22
-
-statement ok
-SET wal_encryption = false;
-
-statement ok
-SET wal_encryption = true;
 
 statement ok
 INSERT INTO enc.test VALUES (10, 'hello')


### PR DESCRIPTION
The current implementation of this setting can lead to WAL files being corrupted if the setting is changed while a WAL file already exists, and generally does not seem particularly useful. Instead, the WAL file is encrypted if the database file is encrypted.