### PR TITLE
Add missing expected errors to the test cases (next chunk)

### DIFF
--- a/test/sql/projection/select_star_replace.test
+++ b/test/sql/projection/select_star_replace.test
@@ -35,17 +35,21 @@ SELECT integers.* REPLACE (i+100 AS i) FROM integers
 statement error
 SELECT * REPLACE (i+100 AS i, i+200 AS i) FROM integers
 ----
+<REGEX>:.*Parser Error.*Duplicate entry.*
 
 # replace name that does not exist
 statement error
 SELECT * REPLACE (i+100 AS blabla) FROM integers
 ----
+<REGEX>:.*Binder Error.*not found in FROM clause.*
 
 statement error
 SELECT integers.* REPLACE (i+100 AS blabla) FROM integers
 ----
+<REGEX>:.*Binder Error.*not found in integers.*
 
 # column cannot occur in both exclude and replace list
 statement error
 SELECT * EXCLUDE (i) REPLACE (i+100 AS i) FROM integers
 ----
+<REGEX>:.*Parser Error.*cannot occur in both.*

--- a/test/sql/projection/select_struct_star.test
+++ b/test/sql/projection/select_struct_star.test
@@ -45,3 +45,4 @@ CREATE TABLE b(i row(t int));
 statement error
 SELECT i.* FROM a, b;
 ----
+<REGEX>:.*Binder Error.*Ambiguous reference to column name.*

--- a/test/sql/select/test_multi_column_reference.test
+++ b/test/sql/select/test_multi_column_reference.test
@@ -45,10 +45,12 @@ SELECT test.tbl.col FROM test.tbl;
 statement error
 SELECT test.t.col FROM test.tbl t;
 ----
+<REGEX>:.*Binder Error.*table.*not found.*
 
 statement error
 SELECT test.tbl.col FROM test.tbl t;
 ----
+<REGEX>:.*Binder Error.*table.*not found.*
 
 # check how ties are resolved
 # we create a table called "t" in a schema called "t" with a column called "t" that has a field called "t"
@@ -175,11 +177,14 @@ SELECT s2.t1.t FROM s1.t1, s2.t1
 statement error
 SELECT testX.tbl.col FROM test.tbl;
 ----
+<REGEX>:.*Binder Error.*table.*not found.*
 
 statement error
 SELECT test.tblX.col FROM test.tbl;
 ----
+<REGEX>:.*Binder Error.*table.*not found.*
 
 statement error
 SELECT test.tbl.colX FROM test.tbl;
 ----
+<REGEX>:.*Binder Error.*does not have a column.*

--- a/test/sql/select/test_positional_reference.test
+++ b/test/sql/select/test_positional_reference.test
@@ -26,23 +26,28 @@ SELECT #1 FROM (SELECT * FROM range(1)) tbl
 statement error
 select (select #1) from range(1);
 ----
+<REGEX>:.*Binder Error.*out of range.*
 
 # out of range
 statement error
 SELECT #2 FROM range(1)
 ----
+<REGEX>:.*Binder Error.*out of range.*
 
 # no from clause
 statement error
 SELECT #1
 ----
+<REGEX>:.*Binder Error.*out of range.*
 
 # zero always fails
 statement error
 SELECT #0 FROM range(1)
 ----
+<REGEX>:.*Parser Error.*Positional reference node needs.*
 
 # as do negative numbers
 statement error
 SELECT #-1 FROM range(1)
 ----
+<REGEX>:.*Parser Error.*syntax error.*

--- a/test/sql/select/test_schema_reference.test
+++ b/test/sql/select/test_schema_reference.test
@@ -19,8 +19,10 @@ SELECT s1.tbl.i FROM s1.tbl;
 statement error
 SELECT s2.tbl.i FROM s1.tbl;
 ----
+<REGEX>:.*Binder Error.*table.*not found.*
 
 # no schema present
 statement error
 SELECT a.tbl.i FROM range(10) tbl(i)
 ----
+<REGEX>:.*Binder Error.*table.*not found.*

--- a/test/sql/select/test_select_into.test
+++ b/test/sql/select/test_select_into.test
@@ -12,3 +12,4 @@ INSERT INTO t VALUES ('foo'), ('bar'), ('baz');
 statement error
 SELECT * INTO t2 FROM t WHERE t LIKE 'b%';
 ----
+<REGEX>:.*Parser Error.*SELECT INTO not supported.*

--- a/test/sql/select/test_select_locking.test
+++ b/test/sql/select/test_select_locking.test
@@ -9,18 +9,22 @@ CREATE TABLE t (t TEXT);
 statement error
 SELECT * FROM t FOR UPDATE;
 ----
+<REGEX>:.*Parser Error.*SELECT locking clause is not supported.*
 
 # unsupported
 statement error
 SELECT * FROM t FOR NO KEY UPDATE;
 ----
+<REGEX>:.*Parser Error.*SELECT locking clause is not supported.*
 
 # unsupported
 statement error
 SELECT * FROM t FOR SHARE;
 ----
+<REGEX>:.*Parser Error.*SELECT locking clause is not supported.*
 
 # unsupported
 statement error
 SELECT * FROM t KEY SHARE;
 ----
+<REGEX>:.*Parser Error.*syntax error.*

--- a/test/sql/setops/test_union_error.test
+++ b/test/sql/setops/test_union_error.test
@@ -8,3 +8,4 @@ PRAGMA enable_verification
 statement error
 SELECT x::INT FROM (SELECT x::VARCHAR x FROM range(10) tbl(x) UNION ALL SELECT 'hello' x) tbl(x);
 ----
+<REGEX>:.*Conversion Error.*Could not convert string.*

--- a/test/sql/settings/setting_profiling_mode.test
+++ b/test/sql/settings/setting_profiling_mode.test
@@ -11,3 +11,4 @@ SET profiling_mode='detailed';
 statement error
 SET profiling_mode='unknown';
 ----
+<REGEX>:.*Parser Error.*Unrecognized profiling mode.*

--- a/test/sql/storage/buffer_manager_temp_dir.test
+++ b/test/sql/storage/buffer_manager_temp_dir.test
@@ -16,7 +16,7 @@ PRAGMA memory_limit='2MB'
 statement error
 CREATE TABLE t2 AS SELECT * FROM range(1000000);
 ----
-could not allocate block of size
+<REGEX>:.*Out of Memory Error.*could not allocate block of size.*
 
 # after we set the temp directory, we can create this table
 statement ok
@@ -29,3 +29,4 @@ CREATE TABLE t2 AS SELECT * FROM range(1000000);
 statement error
 PRAGMA temp_directory=''
 ----
+<REGEX>:.*Not implemented Error.*Cannot switch temporary directory.*

--- a/test/sql/storage/catalog/test_check_constraint.test
+++ b/test/sql/storage/catalog/test_check_constraint.test
@@ -20,11 +20,13 @@ INSERT INTO test VALUES (3, 7);
 statement error
 INSERT INTO test VALUES (12, 13);
 ----
+<REGEX>:.*Constraint Error.*CHECK constraint failed on table.*
 
 # check constraint on b violated  (b < 10) => (a < b)
 statement error
 INSERT INTO test VALUES (5, 3);
 ----
+<REGEX>:.*Constraint Error.*CHECK constraint failed on table.*
 
 # check constraint on b not violated !(b < 10) => (a + b < 100)
 statement ok
@@ -34,3 +36,4 @@ INSERT INTO test VALUES (9, 90);
 statement error
 INSERT INTO test VALUES (9, 99);
 ----
+<REGEX>:.*Constraint Error.*CHECK constraint failed on table.*

--- a/test/sql/storage/catalog/test_store_rename_column.test
+++ b/test/sql/storage/catalog/test_store_rename_column.test
@@ -77,3 +77,4 @@ SELECT k FROM test ORDER BY k
 statement error
 SELECT a FROM test
 ----
+<REGEX>:.*Binder Error.*not found in FROM clause.*

--- a/test/sql/storage/wal/wal_check_constraint.test
+++ b/test/sql/storage/wal/wal_check_constraint.test
@@ -26,11 +26,13 @@ INSERT INTO test VALUES (3, 7);
 statement error
 INSERT INTO test VALUES (12, 13);
 ----
+<REGEX>:.*Constraint Error.*CHECK constraint failed on table.*
 
 # check constraint on b violated  (b < 10) => (a < b)
 statement error
 INSERT INTO test VALUES (5, 3);
 ----
+<REGEX>:.*Constraint Error.*CHECK constraint failed on table.*
 
 # check constraint on b not violated !(b < 10) => (a + b < 100)
 statement ok
@@ -40,3 +42,4 @@ INSERT INTO test VALUES (9, 90);
 statement error
 INSERT INTO test VALUES (9, 99);
 ----
+<REGEX>:.*Constraint Error.*CHECK constraint failed on table.*

--- a/test/sql/storage/wal/wal_storage_types.test
+++ b/test/sql/storage/wal/wal_storage_types.test
@@ -149,3 +149,4 @@ CREATE TABLE aliens (
     current_mood mood
 );
 ----
+<REGEX>:.*Catalog Error.*does not exist.*

--- a/test/sql/storage/wal/wal_store_rename_column.test
+++ b/test/sql/storage/wal/wal_store_rename_column.test
@@ -89,3 +89,4 @@ SELECT k FROM test ORDER BY k
 statement error
 SELECT a FROM test
 ----
+<REGEX>:.*Binder Error.*not found in FROM clause.*

--- a/test/sql/subquery/scalar/array_subquery.test
+++ b/test/sql/subquery/scalar/array_subquery.test
@@ -96,3 +96,4 @@ NULL	[]
 statement error
 select array(select 1,2)
 ----
+<REGEX>:.*inder Error.*Subquery returns 2 columns.*

--- a/test/sql/subquery/scalar/test_grouped_correlated_subquery.test
+++ b/test/sql/subquery/scalar/test_grouped_correlated_subquery.test
@@ -63,16 +63,19 @@ SELECT (col1 + 1) AS k, k IN (SELECT ColID + k FROM tbl_ProductSales) FROM anoth
 statement error
 SELECT (col1 + 1) IN (SELECT ColID + (col1 + 1) FROM tbl_ProductSales) FROM another_T GROUP BY (col1 + 1);
 ----
+<REGEX>:.*Binder Error.*must be part of an aggregate function.*
 
 # this should fail, col1 + 42 is not a grouping column
 statement error
 SELECT col1+1, col1+42 FROM another_T GROUP BY col1+1;
 ----
+<REGEX>:.*Binder Error.*must be part of an aggregate function.*
 
 # this should also fail, col1 + 42 is not a grouping column
 statement error
 SELECT (col1 + 1) IN (SELECT ColID + (col1 + 42) FROM tbl_ProductSales) FROM another_T GROUP BY (col1 + 1);
 ----
+<REGEX>:.*Binder Error.*must be part of an aggregate function.*
 
 # having without GROUP BY in subquery
 query T
@@ -125,15 +128,17 @@ SELECT (SELECT MIN(ColID) FROM tbl_ProductSales INNER JOIN another_T t2 ON t1.co
 statement error
 SELECT CASE WHEN NOT col1 NOT IN (SELECT (SELECT MAX(col7)) UNION (SELECT MIN(ColID) FROM tbl_ProductSales LEFT JOIN another_T t2 ON t2.col5 = t1.col1)) THEN 1 ELSE 2 END FROM another_T t1 GROUP BY col1 ORDER BY 1;
 ----
+<REGEX>:.*Not implemented Error.*Non-inner join on correlated columns not supported.*
 
 # REQUIRE(CHECK_COLUMN(result, 0, {1, 2, 2, 2}));
 # correlated columns in window functions not supported yet
 statement error
 SELECT EXISTS (SELECT RANK() OVER (PARTITION BY SUM(DISTINCT col5))) FROM another_T t1;
 ----
+<REGEX>:.*Binder Error.*not supported.*
 
 # REQUIRE(CHECK_COLUMN(result, 0, {true}));
 statement error
 SELECT (SELECT SUM(col2) OVER (PARTITION BY SUM(col2) ORDER BY MAX(col1 + ColID) ROWS UNBOUNDED PRECEDING) FROM tbl_ProductSales) FROM another_T t1 GROUP BY col1
 ----
-
+<REGEX>:.*Binder Error.*not supported.*

--- a/test/sql/table_function/sqlite_master_connections.test
+++ b/test/sql/table_function/sqlite_master_connections.test
@@ -26,3 +26,4 @@ SELECT * FROM sqlite_master;
 statement error
 DROP VIEW sqlite_master
 ----
+<REGEX>:.*Catalog Error.*Cannot drop internal catalog entry.*

--- a/test/sql/tpch/dbgen_error.test
+++ b/test/sql/tpch/dbgen_error.test
@@ -16,3 +16,4 @@ SET temp_directory = '.unrecognized_folder/folder2'
 statement error
 CALL dbgen(sf=1);
 ----
+<REGEX>:.*IO Error.*Failed to create directory.*

--- a/test/sql/transactions/test_basic_transactions.test
+++ b/test/sql/transactions/test_basic_transactions.test
@@ -22,6 +22,7 @@ SELECT * FROM integers
 statement error con2
 SELECT * FROM integers
 ----
+<REGEX>:.*Catalog Error.*Table.*not exist.*
 
 # if we rollback, nobody should be able to query the table
 statement ok con1
@@ -30,10 +31,12 @@ ROLLBACK
 statement error con1
 SELECT * FROM integers
 ----
+<REGEX>:.*Catalog Error.*Table.*not exist.*
 
 statement error con2
 SELECT * FROM integers
 ----
+<REGEX>:.*Catalog Error.*Table.*not exist.*
 
 # now if we commit the table
 statement ok con1
@@ -50,6 +53,7 @@ COMMIT
 statement error con2
 SELECT * FROM integers
 ----
+<REGEX>:.*Catalog Error.*Table.*not exist.*
 
 # but if we rollback and start a new transaction it should see it
 statement ok con2
@@ -75,4 +79,4 @@ CREATE TABLE integers2(i INTEGER)
 statement error con1
 CREATE TABLE integers2(i INTEGER)
 ----
-
+<REGEX>:.*Catalog Error.*Table.*already exists.*


### PR DESCRIPTION
This PR is a follow up to https://github.com/duckdb/duckdb/pull/18746

Adds missing error messages to the following test cases:

- test/sql/projection/select_star_replace.test
- test/sql/projection/select_struct_star.test
- test/sql/projection/test_value_list.test
- test/sql/select/test_multi_column_reference.test
- test/sql/select/test_positional_reference.test
- test/sql/select/test_schema_reference.test
- test/sql/select/test_select_into.test
- test/sql/select/test_select_locking.test
- test/sql/setops/test_union_error.test
- test/sql/settings/setting_profiling_mode.test
- test/sql/storage/buffer_manager_temp_dir.test
- test/sql/storage/catalog/test_check_constraint.test
- test/sql/storage/catalog/test_store_rename_column.test
- test/sql/storage/wal/wal_check_constraint.test
- test/sql/storage/wal/wal_storage_types.test
- test/sql/storage/wal/wal_store_rename_column.test
- test/sql/subquery/scalar/array_subquery.test
- test/sql/subquery/scalar/test_grouped_correlated_subquery.test
- test/sql/table_function/sqlite_master_connections.test
- test/sql/tpch/dbgen_error.test
- test/sql/transactions/test_basic_transactions.test