### PR TITLE
Extensions.yml should also check converted_to_draft

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -53,7 +53,7 @@ on:
       - '!.github/workflows/_extension_distribution.yml'
   merge_group:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, converted_to_draft]
     paths-ignore:
       - '**.md'
       - 'tools/**'


### PR DESCRIPTION
Otherwise on PRs being drafted, manually or due to auto-draft, CI will keep running