### PR TITLE
Minor logging fixes and more benchmarking

### DIFF
--- a/.github/regression/micro.csv
+++ b/.github/regression/micro.csv
@@ -22,4 +22,14 @@ benchmark/micro/logger/enabled/logging_enabled_client_context.benchmark
 benchmark/micro/logger/enabled/logging_enabled_global.benchmark
 benchmark/micro/logger/enabled/logging_enabled_file_opener.benchmark
 benchmark/micro/logger/enabled/logging_enabled_global.benchmark
+benchmark/micro/logger/filtered_out_by_log_type/client_context.benchmark
+benchmark/micro/logger/filtered_out_by_log_type/file_opener.benchmark
+benchmark/micro/logger/filtered_out_by_log_type/global.benchmark
+benchmark/micro/logger/file_handle_log/csv/file_handle_logging_csv.benchmark
+benchmark/micro/logger/file_handle_log/parquet/file_handle_logging_parquet.benchmark
+benchmark/micro/logger/logging_overhead/parquet_q1_with_filesystem_logging.benchmark
+benchmark/micro/logger/logging_overhead/parquet_q1_with_default_logging.benchmark
+benchmark/micro/logger/logging_overhead/duckdb_persistent_q1_with_default_logging.benchmark
+benchmark/micro/logger/storage/file/log_message_size/huge_string.benchmark
+benchmark/micro/logger/storage/file/log_message_size/small_string.benchmark
 benchmark/micro/filter/choose_correct_filter_function.benchmark

--- a/benchmark/micro/logger/file_handle_log/csv/file_handle_logging_csv.benchmark
+++ b/benchmark/micro/logger/file_handle_log/csv/file_handle_logging_csv.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/logger/file_handle_log/csv/file_handle_logging_csv.benchmark
+# description: 
+# group: [csv]
+
+name Client Context
+group logger
+
+load
+CALL enable_logging('FileSystem');
+CREATE TABLE test AS select i from range(0,100000000) t(i);
+
+run
+copy test to '${BENCHMARK_DIR}/file_handle_logging.csv';
+
+cleanup
+CALL truncate_duckdb_logs();

--- a/benchmark/micro/logger/file_handle_log/csv/file_handle_logging_csv_baseline.benchmark
+++ b/benchmark/micro/logger/file_handle_log/csv/file_handle_logging_csv_baseline.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/logger/file_handle_log/csv/file_handle_logging_csv_baseline.benchmark
+# description: 
+# group: [csv]
+
+name File Handle Log (parquet, baseline)
+group logger
+
+load
+CREATE TABLE test AS select i from range(0,100000000) t(i);
+
+run
+copy test to '${BENCHMARK_DIR}/file_handle_logging.csv';

--- a/benchmark/micro/logger/file_handle_log/parquet/file_handle_logging_parquet.benchmark
+++ b/benchmark/micro/logger/file_handle_log/parquet/file_handle_logging_parquet.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/logger/file_handle_log/parquet/file_handle_logging_parquet.benchmark
+# description: 
+# group: [parquet]
+
+name Client Context
+group logger
+
+load
+CALL enable_logging('FileSystem');
+CREATE TABLE test AS select i from range(0,100000000) t(i);
+
+run
+copy test to '${BENCHMARK_DIR}/file_handle_logging.parquet';
+
+cleanup
+CALL truncate_duckdb_logs();

--- a/benchmark/micro/logger/file_handle_log/parquet/file_handle_logging_parquet_baseline.benchmark
+++ b/benchmark/micro/logger/file_handle_log/parquet/file_handle_logging_parquet_baseline.benchmark
@@ -1,0 +1,12 @@
+# name: benchmark/micro/logger/file_handle_log/parquet/file_handle_logging_parquet_baseline.benchmark
+# description: 
+# group: [parquet]
+
+name File Handle Log (parquet, baseline)
+group logger
+
+load
+CREATE TABLE test AS select i from range(0,100000000) t(i);
+
+run
+copy test to '${BENCHMARK_DIR}/file_handle_logging.parquet';

--- a/benchmark/micro/logger/filtered_out_by_log_type/client_context.benchmark
+++ b/benchmark/micro/logger/filtered_out_by_log_type/client_context.benchmark
@@ -6,11 +6,7 @@ name Client Context
 group logger
 
 load
-set enable_logging=true;
-set logging_storage='memory';
-set logging_level='debug';
-set logging_mode='disable_selected';
-set disabled_log_types='duckdb.SomeName.SomeOtherName.BlaBla';
+CALL enable_logging('FileSystem');
 
 run
 SELECT write_log('hello world', level := 'warn', scope := 'connection', log_type := 'duckdb.SomeName.SomeOtherName.BlaBla' ) from range(0,10000000);

--- a/benchmark/micro/logger/filtered_out_by_log_type/file_opener.benchmark
+++ b/benchmark/micro/logger/filtered_out_by_log_type/file_opener.benchmark
@@ -6,11 +6,7 @@ name FileOpener
 group logger
 
 load
-set enable_logging=true;
-set logging_storage='memory';
-set logging_level='debug';
-set logging_mode='disable_selected';
-set disabled_log_types='duckdb.SomeName.SomeOtherName.BlaBla';
+CALL enable_logging('FileSystem');
 
 # Note: this will call the Logger, but the log type is filtered out
 run

--- a/benchmark/micro/logger/filtered_out_by_log_type/global.benchmark
+++ b/benchmark/micro/logger/filtered_out_by_log_type/global.benchmark
@@ -6,11 +6,7 @@ name Global Logger Filtering out log types
 group case
 
 load
-set enable_logging=true;
-set logging_storage='memory';
-set logging_level='debug';
-set logging_mode='disable_selected';
-set disabled_log_types='duckdb.SomeName.SomeOtherName.BlaBla';
+CALL enable_logging('FileSystem');
 
 # Note: this will call the Logger, but the log type is filtered out
 run

--- a/benchmark/micro/logger/filtered_out_by_log_type/reference.benchmark
+++ b/benchmark/micro/logger/filtered_out_by_log_type/reference.benchmark
@@ -6,11 +6,7 @@ name Disabled logger reference
 group case
 
 load
-set enable_logging=true;
-set logging_storage='memory';
-set logging_level='debug';
-set logging_mode='disable_selected';
-set disabled_log_types='duckdb.SomeName.SomeOtherName.BlaBla';
+CALL enable_logging('FileSystem');
 
 # Note: this will NOT call any logger code, it's simply for reference for the other benchmarks
 run

--- a/benchmark/micro/logger/logging_overhead/duckdb_persistent_q1_with_default_logging.benchmark
+++ b/benchmark/micro/logger/logging_overhead/duckdb_persistent_q1_with_default_logging.benchmark
@@ -1,0 +1,27 @@
+# name: benchmark/micro/logger/logging_overhead/duckdb_persistent_q1_with_default_logging.benchmark
+# description: Test overhead on query that writes lineitem sf1 to a duckdb database and runs Q1 on it
+# group: [logging_overhead]
+
+name Q1 (Parquet)
+group logger
+subgroup logging_overhead
+
+require parquet
+require tpch
+
+load
+CALL dbgen(sf=1);
+CALL enable_logging(storage_path='${BENCHMARK_DIR}/duckdb_persistent_q1_with_default_logging')
+
+run
+ATTACH '${BENCHMARK_DIR}/duckdb_persistent_q1_with_default_logging.db' as my_db;
+CREATE OR REPLACE TABLE my_db.lineitem AS FROM memory.lineitem;
+use my_db;
+PRAGMA tpch(1);
+
+cleanup
+CALL truncate_duckdb_logs();
+use memory;
+DETACH my_db;
+
+result extension/tpch/dbgen/answers/sf1/q01.csv

--- a/benchmark/micro/logger/logging_overhead/parquet_q1_with_default_logging.benchmark
+++ b/benchmark/micro/logger/logging_overhead/parquet_q1_with_default_logging.benchmark
@@ -1,0 +1,24 @@
+# name: benchmark/micro/logger/logging_overhead/parquet_q1_with_default_logging.benchmark
+# description: Test overhead on query that writes lineitem sf1 to a duckdb database and runs Q1 on it
+# group: [logging_overhead]
+
+name Q1 (Parquet)
+group logger
+subgroup logging_overhead
+
+require parquet
+require tpch
+
+load
+CALL dbgen(sf=1, suffix='_normal');
+CALL enable_logging(storage_path='${BENCHMARK_DIR}/parquet_q1_with_logging')
+
+run
+COPY lineitem_normal TO '${BENCHMARK_DIR}/parquet_q1_with_logging.parquet';
+CREATE OR REPLACE VIEW lineitem AS SELECT * FROM read_parquet('${BENCHMARK_DIR}/parquet_q1_with_logging.parquet');
+PRAGMA tpch(1)
+
+cleanup
+CALL truncate_duckdb_logs()
+
+result extension/tpch/dbgen/answers/sf1/q01.csv

--- a/benchmark/micro/logger/logging_overhead/parquet_q1_with_filesystem_logging.benchmark
+++ b/benchmark/micro/logger/logging_overhead/parquet_q1_with_filesystem_logging.benchmark
@@ -1,0 +1,24 @@
+# name: benchmark/micro/logger/logging_overhead/parquet_q1_with_filesystem_logging.benchmark
+# description: Execute Q1 over lineitem stored in a parquet file with filesystem logging enabled. This comes at a significant, but reasonable overhead.
+# group: [logging_overhead]
+
+name Q1 (Parquet)
+group logger
+subgroup logging_overhead
+
+require parquet
+require tpch
+
+load
+CALL dbgen(sf=1, suffix='_normal');
+CALL enable_logging('FileSystem', storage_path='${BENCHMARK_DIR}/parquet_q1_with_logging')
+
+run
+COPY lineitem_normal TO '${BENCHMARK_DIR}/parquet_q1_with_logging.parquet';
+CREATE OR REPLACE VIEW lineitem AS SELECT * FROM read_parquet('${BENCHMARK_DIR}/parquet_q1_with_logging.parquet');
+PRAGMA tpch(1)
+
+cleanup
+CALL truncate_duckdb_logs()
+
+result extension/tpch/dbgen/answers/sf1/q01.csv

--- a/benchmark/micro/logger/storage/file/buffer_size/custom_100.benchmark
+++ b/benchmark/micro/logger/storage/file/buffer_size/custom_100.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/logger/storage/file/buffer_size/custom_100.benchmark
+# description: benchmarking with a custom, 100 entry buffer size
+# group: [buffer_size]
+
+name Client Context Memory Logger
+group logger
+
+# Note: we write a single log entry to trigger the lazy file initialization
+load
+CALL enable_logging(level='info', storage_path='${BENCHMARK_DIR}/logging_enabled_client_context', storage_config={'buffer_size':100});
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' );
+
+run
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' ) from range(0,20000);
+
+cleanup
+CALL truncate_duckdb_logs()

--- a/benchmark/micro/logger/storage/file/buffer_size/custom_20k.benchmark
+++ b/benchmark/micro/logger/storage/file/buffer_size/custom_20k.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/logger/storage/file/buffer_size/custom_20k.benchmark
+# description: benchmarking with a custom, ~20k entry buffer size
+# group: [buffer_size]
+
+name Client Context Memory Logger
+group logger
+
+# Note: we write a single log entry to trigger the lazy file initialization
+load
+CALL enable_logging(level='info', storage_path='${BENCHMARK_DIR}/logging_enabled_client_context', storage_config={'buffer_size':10*2048});
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' );
+
+run
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' ) from range(0,20000);
+
+cleanup
+CALL truncate_duckdb_logs()

--- a/benchmark/micro/logger/storage/file/buffer_size/custom_none.benchmark
+++ b/benchmark/micro/logger/storage/file/buffer_size/custom_none.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/logger/storage/file/buffer_size/custom_none.benchmark
+# description: benchmarking with buffering disabled
+# group: [buffer_size]
+
+name Client Context Memory Logger
+group logger
+
+# Note: we write a single log entry to trigger the lazy file initialization
+load
+CALL enable_logging(level='info', storage_path='${BENCHMARK_DIR}/logging_enabled_client_context', storage_config={'buffer_size':0});
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' );
+
+run
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' ) from range(0,20000);
+
+cleanup
+CALL truncate_duckdb_logs()

--- a/benchmark/micro/logger/storage/file/buffer_size/default_2048.benchmark
+++ b/benchmark/micro/logger/storage/file/buffer_size/default_2048.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/logger/storage/file/buffer_size/default_2048.benchmark
+# description: benchmarking with the default, 2028 entry buffer size
+# group: [buffer_size]
+
+name Client Context Memory Logger
+group logger
+
+# Note: we write a single log entry to trigger the lazy file initialization
+load
+CALL enable_logging(level='info', storage_path='${BENCHMARK_DIR}/logging_enabled_client_context');
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' );
+
+run
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' ) from range(0,20000);
+
+cleanup
+CALL truncate_duckdb_logs()

--- a/benchmark/micro/logger/storage/file/log_message_size/huge_string.benchmark
+++ b/benchmark/micro/logger/storage/file/log_message_size/huge_string.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/logger/storage/file/log_message_size/huge_string.benchmark
+# description: test writing big strings as log messages
+# group: [log_message_size]
+
+name Client Context Memory Logger
+group logger
+
+# Note: we write a single log entry to trigger the lazy file initialization
+load
+CALL enable_logging(level='info', storage_path='${BENCHMARK_DIR}/logging_enabled_client_context');
+SELECT write_log('hi', level := 'info', scope := 'connection' );
+
+run
+SELECT write_log(repeat('hellohello', 1000), level := 'info', scope := 'connection' ) from range(0,20000);
+
+cleanup
+CALL truncate_duckdb_logs()

--- a/benchmark/micro/logger/storage/file/log_message_size/small_string.benchmark
+++ b/benchmark/micro/logger/storage/file/log_message_size/small_string.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/logger/storage/file/log_message_size/small_string.benchmark
+# description: test writing small strings as log messages
+# group: [log_message_size]
+
+name Client Context Memory Logger
+group logger
+
+# Note: we write a single log entry to trigger the lazy file initialization
+load
+CALL enable_logging(level='info', storage_path='${BENCHMARK_DIR}/logging_enabled_client_context');
+SELECT write_log('hi', level := 'info', scope := 'connection' );
+
+run
+SELECT write_log('hi', level := 'info', scope := 'connection' ) from range(0,2000000);
+
+cleanup
+CALL truncate_duckdb_logs()

--- a/benchmark/micro/logger/storage/file/normalization/denormalized.benchmark
+++ b/benchmark/micro/logger/storage/file/normalization/denormalized.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/logger/storage/file/normalization/denormalized.benchmark
+# description: test the denormalized (single file) log file output
+# group: [normalization]
+
+name Client Context Memory Logger
+group logger
+
+# Note: we write a single log entry to trigger the lazy file initialization
+load
+CALL enable_logging(level='info', storage_path='${BENCHMARK_DIR}/logging_enabled_client_context/file.csv');
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' );
+
+run
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' ) from range(0,1000000);
+
+cleanup
+CALL truncate_duckdb_logs()

--- a/benchmark/micro/logger/storage/file/normalization/normalized.benchmark
+++ b/benchmark/micro/logger/storage/file/normalization/normalized.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/logger/storage/file/normalization/normalized.benchmark
+# description: test the normalized (split file) log file output
+# group: [normalization]
+
+name Client Context Memory Logger
+group logger
+
+# Note: we write a single log entry to trigger the lazy file initialization
+load
+CALL enable_logging(level='info', storage_path='${BENCHMARK_DIR}/logging_enabled_client_context');
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' );
+
+run
+SELECT write_log('well hello hello hello hello hello hello world', level := 'info', scope := 'connection' ) from range(0,1000000);
+
+cleanup
+CALL truncate_duckdb_logs()

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -53,6 +53,7 @@ void DataChunk::Initialize(Allocator &allocator, const vector<LogicalType> &type
 	D_ASSERT(data.empty());
 
 	capacity = capacity_p;
+	initial_capacity = capacity_p;
 	for (idx_t i = 0; i < types.size(); i++) {
 		// We copy the type here so we don't create another reference to the same shared_ptr<ExtraTypeInfo>
 		// Otherwise, threads will constantly increment/decrement the atomic ref count to the same shared_ptr
@@ -92,7 +93,7 @@ void DataChunk::Reset() {
 	for (idx_t i = 0; i < ColumnCount(); i++) {
 		data[i].ResetFromCache(vector_caches[i]);
 	}
-	capacity = STANDARD_VECTOR_SIZE;
+	capacity = initial_capacity;
 }
 
 void DataChunk::Destroy() {

--- a/src/function/scalar/system/write_log.cpp
+++ b/src/function/scalar/system/write_log.cpp
@@ -114,14 +114,8 @@ unique_ptr<FunctionData> WriteLogBind(ClientContext &context, ScalarFunction &bo
 template <class T>
 void WriteLogValues(T &LogSource, LogLevel level, const string_t *data, const SelectionVector *sel, idx_t size,
                     const string &type) {
-	if (!type.empty()) {
-		for (idx_t i = 0; i < size; i++) {
-			DUCKDB_LOG_INTERNAL(LogSource, type.c_str(), level, data[sel->get_index(i)]);
-		}
-	} else {
-		for (idx_t i = 0; i < size; i++) {
-			DUCKDB_LOG_INTERNAL(LogSource, type.c_str(), level, data[sel->get_index(i)]);
-		}
+	for (idx_t i = 0; i < size; i++) {
+		DUCKDB_LOG_INTERNAL(LogSource, type.c_str(), level, data[sel->get_index(i)]);
 	}
 }
 

--- a/src/include/duckdb/common/types/data_chunk.hpp
+++ b/src/include/duckdb/common/types/data_chunk.hpp
@@ -139,7 +139,7 @@ public:
 	DUCKDB_API void Slice(idx_t offset, idx_t count);
 
 	//! Resets the DataChunk to its state right after the DataChunk::Initialize
-	//! function was called. This sets the count to 0, and resets each member
+	//! function was called. This sets the count to 0, the capacity to initial_capacity and resets each member
 	//! Vector to point back to the data owned by this DataChunk.
 	DUCKDB_API void Reset();
 
@@ -169,6 +169,8 @@ private:
 	idx_t count;
 	//! The amount of tuples that can be stored in the data chunk
 	idx_t capacity;
+	//! The initial capacity of this chunk set during ::Initialize, used when resetting
+	idx_t initial_capacity;
 	//! Vector caches, used to store data when ::Initialize is called
 	vector<VectorCache> vector_caches;
 };

--- a/src/include/duckdb/logging/log_manager.hpp
+++ b/src/include/duckdb/logging/log_manager.hpp
@@ -83,6 +83,8 @@ protected:
 
 	optional_ptr<const LogType> LookupLogTypeInternal(const string &type);
 
+	void SetConfigInternal(LogConfig config);
+
 	mutex lock;
 	LogConfig config;
 

--- a/src/include/duckdb/logging/log_storage.hpp
+++ b/src/include/duckdb/logging/log_storage.hpp
@@ -143,6 +143,8 @@ protected:
 	//! Whether a specific table is available in the log storage
 	bool IsEnabledInternal(LoggingTargetTable table);
 
+	idx_t GetBufferLimit() const;
+
 	//! lock to be used by this class and child classes to ensure thread safety TODO: maybe remove and delegate
 	//! thread-safety to LogManager?
 	mutable mutex lock;

--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -132,6 +132,10 @@ bool BufferingLogStorage::IsEnabledInternal(LoggingTargetTable table) {
 	return table == LoggingTargetTable::ALL_LOGS;
 }
 
+idx_t BufferingLogStorage::GetBufferLimit() const {
+	return buffer_limit;
+}
+
 void CSVLogStorage::ExecuteCast(LoggingTargetTable table, DataChunk &chunk) {
 	// Reset the cast buffer before use
 	cast_buffers[table]->Reset();
@@ -192,9 +196,10 @@ void CSVLogStorage::InitializeCastChunk(LoggingTargetTable table) {
 
 	vector<LogicalType> types;
 	types.resize(GetSchema(table).size(), LogicalType::VARCHAR);
-
-	cast_buffers[table]->Initialize(Allocator::DefaultAllocator(), types);
+	idx_t buffer_size = MaxValue<idx_t>(GetBufferLimit(), 1);
+	cast_buffers[table]->Initialize(Allocator::DefaultAllocator(), types, buffer_size);
 }
+
 void CSVLogStorage::ResetCastChunk() {
 	InitializeCastChunk(LoggingTargetTable::LOG_ENTRIES);
 	InitializeCastChunk(LoggingTargetTable::LOG_CONTEXTS);
@@ -537,18 +542,19 @@ BufferingLogStorage::BufferingLogStorage(DatabaseInstance &db_p, idx_t buffer_si
 }
 
 void BufferingLogStorage::ResetLogBuffers() {
+	idx_t buffer_size = MaxValue<idx_t>(buffer_limit, 1);
 	if (normalize_contexts) {
 		buffers[LoggingTargetTable::LOG_ENTRIES] = make_uniq<DataChunk>();
 		buffers[LoggingTargetTable::LOG_CONTEXTS] = make_uniq<DataChunk>();
 		buffers[LoggingTargetTable::LOG_ENTRIES]->Initialize(Allocator::DefaultAllocator(),
-		                                                     GetSchema(LoggingTargetTable::LOG_ENTRIES), buffer_limit);
-		buffers[LoggingTargetTable::LOG_CONTEXTS]->Initialize(
-		    Allocator::DefaultAllocator(), GetSchema(LoggingTargetTable::LOG_CONTEXTS), buffer_limit);
+		                                                     GetSchema(LoggingTargetTable::LOG_ENTRIES), buffer_size);
+		buffers[LoggingTargetTable::LOG_CONTEXTS]->Initialize(Allocator::DefaultAllocator(),
+		                                                      GetSchema(LoggingTargetTable::LOG_CONTEXTS), buffer_size);
 
 	} else {
 		buffers[LoggingTargetTable::ALL_LOGS] = make_uniq<DataChunk>();
 		buffers[LoggingTargetTable::ALL_LOGS]->Initialize(Allocator::DefaultAllocator(),
-		                                                  GetSchema(LoggingTargetTable::ALL_LOGS), buffer_limit);
+		                                                  GetSchema(LoggingTargetTable::ALL_LOGS), buffer_size);
 	}
 }
 
@@ -637,7 +643,7 @@ void BufferingLogStorage::WriteLogEntry(timestamp_t timestamp, LogLevel level, c
 	    normalize_contexts ? buffers[LoggingTargetTable::LOG_ENTRIES] : buffers[LoggingTargetTable::ALL_LOGS];
 
 	auto size = log_entries_buffer->size();
-	if (size >= buffer_limit) {
+	if (size >= buffer_limit && buffer_limit != 0) {
 		throw InternalException("Log buffer limit exceeded: code should have flushed before");
 	}
 

--- a/test/sql/logging/logging_buffer_size.test
+++ b/test/sql/logging/logging_buffer_size.test
@@ -64,3 +64,43 @@ query I
 SELECT count(*) FROM duckdb_log_contexts()
 ----
 2
+
+# Try with some big buffers now
+
+statement ok
+CALL disable_logging()
+
+statement ok
+CALL truncate_duckdb_logs()
+
+statement ok
+CALL enable_logging(level='trace', storage='memory', storage_config={'buffer_size': 20*2048});
+
+statement ok
+SELECT write_log('hello from the connection log scope', level := 'error', scope := 'connection') from range(0,40*2048);
+
+statement ok
+FROM duckdb_logs()
+
+statement ok
+CALL enable_logging(level='trace', storage='file', storage_config={'buffer_size': 20*2048, 'path': '__TEST_DIR__/logging_buffer_size'});
+
+statement ok
+SELECT write_log('hello from the connection log scope', level := 'error', scope := 'connection') from range(0,40*2048);
+
+
+# Try direct flushing 
+
+statement ok
+CALL enable_logging(level='trace', storage='file', storage_config={'buffer_size': 0, 'path': '__TEST_DIR__/logging_buffer_size'});
+
+statement ok
+SELECT write_log('hello from the connection log scope', level := 'error', scope := 'connection') from range(0, 2048);
+
+
+# Try weird buffer size
+
+statement error
+CALL enable_logging(level='trace', storage='file', storage_config={'buffer_size': -1, 'path': '__TEST_DIR__/logging_buffer_size'});
+----
+Invalid Input Error


### PR DESCRIPTION
This PR:
- adds a few more logging related benchmarks
- adds several logging-related benchmarks to CI by adding them to `.github/regression/micro.csv`
- Fixes `DataChunk::Reset` to preserve the originally set capacity (used by the log storage when buffer size > `STANDARD_VECTOR_SIZE`
- Fixed small issue where the global logger would not correctly be configured when enabling logging for a specific log type
- Fix issue where setting the log storage buffer limit to 0 would break things