### PR TITLE
Revert "Use 1-based indexing for SQL-based JSON array extraction"

### DIFF
--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -121,10 +121,17 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 			function_name = "json_extract";
 			// Make sure we only extract array elements, not fields, by adding the $[] syntax
 			auto &i_exp = BoundExpression::GetExpression(*op.children[1]);
-			if (i_exp->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			if (i_exp->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT &&
+			    !i_exp->Cast<BoundConstantExpression>().value.IsNull()) {
 				auto &const_exp = i_exp->Cast<BoundConstantExpression>();
-				if (!const_exp.value.IsNull()) {
-					const_exp.value = StringUtil::Format("$[%s]", const_exp.value.ToString());
+				if (const_exp.value.TryCastAs(context, LogicalType::UINTEGER)) {
+					// Array extraction: if the cast fails it's definitely out-of-bounds for a JSON array
+					auto index = UIntegerValue::Get(const_exp.value);
+					const_exp.value = StringUtil::Format("$[%lld]", index);
+					const_exp.return_type = LogicalType::VARCHAR;
+				} else if (const_exp.return_type.id() == LogicalType::VARCHAR) {
+					// Field extraction
+					const_exp.value = StringUtil::Format("$.\"%s\"", const_exp.value.ToString());
 					const_exp.return_type = LogicalType::VARCHAR;
 				}
 			}

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -121,18 +121,10 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 			function_name = "json_extract";
 			// Make sure we only extract array elements, not fields, by adding the $[] syntax
 			auto &i_exp = BoundExpression::GetExpression(*op.children[1]);
-			if (i_exp->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT &&
-			    !i_exp->Cast<BoundConstantExpression>().value.IsNull()) {
+			if (i_exp->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
 				auto &const_exp = i_exp->Cast<BoundConstantExpression>();
-				if (const_exp.value.TryCastAs(context, LogicalType::UINTEGER)) {
-					// Array extraction: if the cast fails it's definitely out-of-bounds for a JSON array
-					auto index = UIntegerValue::Get(const_exp.value);
-					index -= index > 0; // Subtract 1 for SQL 1-based indexing (except when accessing from back)
-					const_exp.value = StringUtil::Format("$[%lld]", index);
-					const_exp.return_type = LogicalType::VARCHAR;
-				} else if (const_exp.return_type.id() == LogicalType::VARCHAR) {
-					// Field extraction
-					const_exp.value = StringUtil::Format("$.\"%s\"", const_exp.value.ToString());
+				if (!const_exp.value.IsNull()) {
+					const_exp.value = StringUtil::Format("$[%s]", const_exp.value.ToString());
 					const_exp.return_type = LogicalType::VARCHAR;
 				}
 			}

--- a/test/sql/json/scalar/test_json_dot_syntax.test
+++ b/test/sql/json/scalar/test_json_dot_syntax.test
@@ -24,6 +24,17 @@ select json('{"foo": null}').foo.bar
 ----
 NULL
 
+# also supports this syntax
+query T
+select json('{"foo": null}')['foo']
+----
+null
+
+query T
+select json('{"foo": null}')['foo']['bar']
+----
+NULL
+
 query T
 select json('null')
 ----

--- a/test/sql/json/scalar/test_json_dot_syntax.test
+++ b/test/sql/json/scalar/test_json_dot_syntax.test
@@ -24,17 +24,6 @@ select json('{"foo": null}').foo.bar
 ----
 NULL
 
-# also supports this syntax
-query T
-select json('{"foo": null}')['foo']
-----
-null
-
-query T
-select json('{"foo": null}')['foo']['bar']
-----
-NULL
-
 query T
 select json('null')
 ----
@@ -53,7 +42,7 @@ NULL
 
 # but we can using array extract syntax
 query T
-select json('{"my_field": {"my_nested_field": ["goose", "duck"]}}').my_field.my_nested_field[2]
+select json('{"my_field": {"my_nested_field": ["goose", "duck"]}}').my_field.my_nested_field[1]
 ----
 "duck"
 
@@ -65,7 +54,7 @@ NULL
 
 # but this will
 query T
-select ('{"my_field": {"my_nested_field": ["goose", "duck"]}}'::JSON).my_field.my_nested_field[2]
+select ('{"my_field": {"my_nested_field": ["goose", "duck"]}}'::JSON).my_field.my_nested_field[1]
 ----
 "duck"
 
@@ -83,22 +72,22 @@ select ('{"my_field": {"my_nested_field": ["goose", "duck"]}}'::JSON).my_field.m
 [
 
 query T
-select json('{"my_field": {"my_nested_field": ["goose", "duck"]}}').my_field.my_nested_field[2]
+select json('{"my_field": {"my_nested_field": ["goose", "duck"]}}').my_field.my_nested_field[1]
 ----
 "duck"
 
 query T
-select json('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}').my_field.my_nested_field[2]
+select json('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}').my_field.my_nested_field[1]
 ----
 "duckduckduckduck"
 
 query T
-select ('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}'::JSON).my_field.my_nested_field[2]
+select ('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}'::JSON).my_field.my_nested_field[1]
 ----
 "duckduckduckduck"
 
 query T
-select json('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}').my_field.my_nested_field[2]
+select json('{"my_field": {"my_nested_field": ["goose", "duckduckduckduck"]}}').my_field.my_nested_field[1]
 ----
 "duckduckduckduck"
 
@@ -110,18 +99,18 @@ NULL
 
 # works!
 query T
-select json('[1, 2, 42]')[3]
+select json('[1, 2, 42]')[2]
 ----
 42
 
 query T
-select json('[1, 2, 42]')[3]::text
+select json('[1, 2, 42]')[2]::text
 ----
 42
 
 # chained
 query T
-select ('{"my_field": {"my_nested_field": ["goose", "duck"]}}'::JSON).my_field.my_nested_field[2]
+select ('{"my_field": {"my_nested_field": ["goose", "duck"]}}'::JSON).my_field.my_nested_field[1]
 ----
 "duck"
 
@@ -132,12 +121,12 @@ SELECT json('{"a":2,"c":[4,5,{"f":7}]}').c
 [4,5,{"f":7}]
 
 query T
-SELECT json('{"a":2,"c":[4,5,{"f":7}]}').c[3]
+SELECT json('{"a":2,"c":[4,5,{"f":7}]}').c[2]
 ----
 {"f":7}
 
 query T
-SELECT json('{"a":2,"c":[4,5,{"f":7}]}').c[3].f
+SELECT json('{"a":2,"c":[4,5,{"f":7}]}').c[2].f
 ----
 7
 


### PR DESCRIPTION
Reverts duckdb/duckdb#18735

After some more discussion we decided to keep the original behavior, turns out that Postgres does support accessing by `jsonb` in this manner, and they do it in a 0-based manner:

```sql
postgres=# select ('[1,2,3]'::jsonb)[0];
 jsonb 
-------
 1
(1 row)
```

The original behavior keeps us consistent with Postgres. 