### PR TITLE
Add new MySQL scanner option to extension_entries

### DIFF
--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1034,6 +1034,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"mysql_bit1_as_boolean", "mysql_scanner"},
     {"mysql_debug_show_queries", "mysql_scanner"},
     {"mysql_experimental_filter_pushdown", "mysql_scanner"},
+    {"mysql_time_as_time", "mysql_scanner"},
     {"mysql_tinyint1_as_boolean", "mysql_scanner"},
     {"parquet_metadata_cache", "parquet"},
     {"pg_array_as_varchar", "postgres_scanner"},


### PR DESCRIPTION
This PR adds new MySQL scanner option `mysql_time_as_time` (that is being added in duckdb/duckdb-mysql#142) to `extension_entries.hpp`.

It is intended to be merged after the duckdb/duckdb-mysql#142 is reviewed and merged.