### PR TITLE
Fix radix partitioning with more than 10 bits

### DIFF
--- a/src/common/radix_partitioning.cpp
+++ b/src/common/radix_partitioning.cpp
@@ -51,9 +51,9 @@ RETURN_TYPE RadixBitsSwitch(const idx_t radix_bits, ARGS &&... args) {
 	case 10:
 		return OP::template Operation<10>(std::forward<ARGS>(args)...);
 	case 11:
-		return OP::template Operation<10>(std::forward<ARGS>(args)...);
+		return OP::template Operation<11>(std::forward<ARGS>(args)...);
 	case 12:
-		return OP::template Operation<10>(std::forward<ARGS>(args)...);
+		return OP::template Operation<12>(std::forward<ARGS>(args)...);
 	default:
 		throw InternalException(
 		    "radix_bits higher than RadixPartitioning::MAX_RADIX_BITS encountered in RadixBitsSwitch");


### PR DESCRIPTION
The radix partitioning code seems to have a copy/paste error. When 11 or 12 bits were requested for partitioning, `RadixBitsSwitch`  dispatches to a partition with just 10 bits. I can't speak to the  impact, as I just found it while reading the code.

(Apologies for the drive-by action. I couldn't think of an issue description that is better than the diff. Double apologies if this is not a  bug but intentional!)