### PR TITLE
pragma memory_info

### DIFF
--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -200,6 +200,10 @@ static string PragmaDatabaseSize(ClientContext &context, const FunctionParameter
 	return "SELECT * FROM pragma_database_size();";
 }
 
+static string PragmaMemoryInfo(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_memory_info();";
+}
+
 static string PragmaStorageInfo(ClientContext &context, const FunctionParameters &parameters) {
 	return StringUtil::Format("SELECT * FROM pragma_storage_info('%s');", parameters.values[0].ToString());
 }
@@ -226,6 +230,7 @@ void PragmaQueries::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(PragmaFunction::PragmaStatement("extension_versions", PragmaExtensionVersions));
 	set.AddFunction(PragmaFunction::PragmaStatement("platform", PragmaPlatform));
 	set.AddFunction(PragmaFunction::PragmaStatement("database_size", PragmaDatabaseSize));
+	set.AddFunction(PragmaFunction::PragmaStatement("memory_info", PragmaMemoryInfo));
 	set.AddFunction(PragmaFunction::PragmaStatement("functions", PragmaFunctionsQuery));
 	set.AddFunction(PragmaFunction::PragmaCall("import_database", PragmaImportDatabase, {LogicalType::VARCHAR}));
 	set.AddFunction(

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library_unity(
   logging_utils.cpp
   pragma_collations.cpp
   pragma_database_size.cpp
+  pragma_memory_info.cpp
   pragma_metadata_info.cpp
   pragma_storage_info.cpp
   pragma_table_info.cpp

--- a/src/function/table/system/pragma_memory_info.cpp
+++ b/src/function/table/system/pragma_memory_info.cpp
@@ -1,0 +1,57 @@
+#include "duckdb/function/table/system_functions.hpp"
+
+#include "duckdb/storage/buffer_manager.hpp"
+
+namespace duckdb {
+
+struct PragmaMemoryInfoData : public GlobalTableFunctionState {
+	PragmaMemoryInfoData() : finished(false) {
+	}
+
+	Value buffer_pool_used_bytes;
+	Value buffer_pool_max_bytes;
+	bool finished;
+};
+
+static unique_ptr<FunctionData> PragmaMemoryInfoBind(ClientContext &context, TableFunctionBindInput &input,
+                                                     vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("buffer_pool_used_bytes");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("buffer_pool_max_bytes");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaMemoryInfoInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_uniq<PragmaMemoryInfoData>();
+
+	auto &buffer_manager = BufferManager::GetBufferManager(context);
+	result->buffer_pool_used_bytes = Value::BIGINT(NumericCast<int64_t>(buffer_manager.GetUsedMemory()));
+	result->buffer_pool_max_bytes = Value::BIGINT(NumericCast<int64_t>(buffer_manager.GetMaxMemory()));
+
+	return std::move(result);
+}
+
+void PragmaMemoryInfoFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<PragmaMemoryInfoData>();
+
+	if (data.finished) {
+		// signal end of output
+		return;
+	}
+
+	output.SetCardinality(1);
+	output.SetValue(0, 0, data.buffer_pool_used_bytes);
+	output.SetValue(1, 0, data.buffer_pool_max_bytes);
+
+	data.finished = true;
+}
+
+void PragmaMemoryInfo::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("pragma_memory_info", {}, PragmaMemoryInfoFunction, PragmaMemoryInfoBind, PragmaMemoryInfoInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -16,6 +16,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	PragmaStorageInfo::RegisterFunction(*this);
 	PragmaMetadataInfo::RegisterFunction(*this);
 	PragmaDatabaseSize::RegisterFunction(*this);
+	PragmaMemoryInfo::RegisterFunction(*this);
 	PragmaUserAgent::RegisterFunction(*this);
 
 	DuckDBApproxDatabaseCountFun::RegisterFunction(*this);

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -43,6 +43,10 @@ struct PragmaDatabaseSize {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct PragmaMemoryInfo {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBSchemasFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/test/sql/pragma/test_pragma_memory_info.test
+++ b/test/sql/pragma/test_pragma_memory_info.test
@@ -1,0 +1,12 @@
+# name: test/sql/pragma/test_pragma_memory_info.test
+# description: Test PRAGMA memory_info
+# group: [pragma]
+
+statement ok
+PRAGMA memory_info;
+
+statement ok
+select * from pragma_memory_info();
+
+statement ok
+select buffer_pool_used_bytes, buffer_pool_max_bytes from pragma_memory_info();


### PR DESCRIPTION
Add a new pragma: `memory_info`. This returns `buffer_pool_used_bytes` and `buffer_pool_max_bytes` as BIGINTs.

Both of the forms `pragma memory_info` and `from pragma_memory_info()` are supported.

Access to this information can be useful in some environments. In particular, it can be useful in DuckDB Wasm, where memory is highly constrained and spilling to disk is not possible. Rather than hitting errors (usually unrecoverable) when the memory limit is reached (or neared), a client can detect when memory usage is high and take some action (e.g. drop large in-memory cache tables, or simply warn the user).

Similar info is already returned by the existing pragma `database_size`. However, that pragma also returns other information (one row per database, and several other columns), and it formats the memory information as human-readable strings instead of exposing the raw information, making it harder to use programatically.