### PR TITLE
Fix Path Typo in Extension's CMake Warning Message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1342,7 +1342,7 @@ foreach(EXT_NAME IN LISTS DUCKDB_EXTENSION_NAMES)
 
   # Warning for trying to load vcpkg extensions without having VCPKG_BUILD SET
   if (EXISTS "${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_PATH}/vcpkg.json" AND NOT DEFINED VCPKG_BUILD)
-    message(WARNING "Extension '${EXT_NAME}' has a vcpkg.json, but build was not run with VCPKG. If build fails, check out VCPKG build instructions in 'duckdb/extension/README.md' or try manually installing the dependencies in ${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_PATH}vcpkg.json")
+    message(WARNING "Extension '${EXT_NAME}' has a vcpkg.json, but build was not run with VCPKG. If build fails, check out VCPKG build instructions in 'duckdb/extension/README.md' or try manually installing the dependencies in ${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_PATH}/vcpkg.json")
   endif()
 
   if (NOT "${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_EXT_VERSION}" STREQUAL "")


### PR DESCRIPTION
Fix path formatting issue in the CMake warning message that appears when building extensions with vcpkg.json but without VCPKG properly configured.

Verified locally with a test extension.
Before: Observed the warning with concatenated path
```plaintext
CMake Warning at CMakeLists.txt:1360 (message):
  Extension 'xxxx' has a vcpkg.json, but build was not run with VCPKG.
  If build fails, check out VCPKG build instructions in
  'duckdb/extension/README.md' or try manually installing the dependencies in
  /path/to/extension/xxxxvcpkg.json
```

After: Warning shows correct path with proper directory separation
```plaintext
CMake Warning at CMakeLists.txt:1360 (message):
  Extension 'xxxx' has a vcpkg.json, but build was not run with VCPKG.
  If build fails, check out VCPKG build instructions in
  'duckdb/extension/README.md' or try manually installing the dependencies in
  /path/to/extension/xxxx/vcpkg.json
```