### PR TITLE
Improve autocomplete suggestions

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -240,6 +240,11 @@ static vector<AutoCompleteCandidate> SuggestSettingName(ClientContext &context) 
 		AutoCompleteCandidate candidate(option.name, 0);
 		suggestions.push_back(std::move(candidate));
 	}
+	const auto &option_aliases = db_config.GetAliases();
+	for (const auto &option_alias : option_aliases) {
+		AutoCompleteCandidate candidate(option_alias.alias, 0);
+		suggestions.push_back(std::move(candidate));
+	}
 	return suggestions;
 }
 

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -250,6 +250,10 @@ static vector<AutoCompleteCandidate> SuggestSettingName(ClientContext &context) 
 		AutoCompleteCandidate candidate(option_alias.alias, 0);
 		suggestions.push_back(std::move(candidate));
 	}
+	for (auto &entry : db_config.extension_parameters) {
+		AutoCompleteCandidate candidate(entry.first, 0);
+		suggestions.push_back(std::move(candidate));
+	}
 	return suggestions;
 }
 

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -44,9 +44,11 @@ static vector<AutoCompleteSuggestion> ComputeSuggestions(vector<AutoCompleteCand
 	case_insensitive_map_t<idx_t> matches;
 	bool prefix_is_lower = StringUtil::IsLower(prefix);
 	bool prefix_is_upper = StringUtil::IsUpper(prefix);
+	auto lower_prefix = StringUtil::Lower(prefix);
 	for (idx_t i = 0; i < available_suggestions.size(); i++) {
 		auto &suggestion = available_suggestions[i];
 		const int32_t BASE_SCORE = 10;
+		const int32_t SUBSTRING_PENALTY = 10;
 		auto str = suggestion.candidate;
 		if (suggestion.extra_char != '\0') {
 			str += suggestion.extra_char;
@@ -65,6 +67,9 @@ static vector<AutoCompleteSuggestion> ComputeSuggestions(vector<AutoCompleteCand
 			score += StringUtil::SimilarityScore(str.substr(0, prefix.size()), prefix);
 		} else {
 			score += StringUtil::SimilarityScore(str, prefix);
+		}
+		if (!StringUtil::Contains(StringUtil::Lower(str), lower_prefix)) {
+			score += SUBSTRING_PENALTY;
 		}
 		scores.emplace_back(str, score);
 	}

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -281,6 +281,7 @@ public:
 	DUCKDB_API static const DBConfig &GetConfig(const ClientContext &context);
 	DUCKDB_API static const DBConfig &GetConfig(const DatabaseInstance &db);
 	DUCKDB_API static vector<ConfigurationOption> GetOptions();
+	DUCKDB_API static vector<ConfigurationAlias> GetAliases();
 	DUCKDB_API static idx_t GetOptionCount();
 	DUCKDB_API static idx_t GetAliasCount();
 	DUCKDB_API static vector<string> GetOptionNames();

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -193,6 +193,14 @@ vector<ConfigurationOption> DBConfig::GetOptions() {
 	return options;
 }
 
+vector<ConfigurationAlias> DBConfig::GetAliases() {
+	vector<ConfigurationAlias> aliases;
+	for (idx_t index = 0; index < GetAliasCount(); index++) {
+		aliases.push_back(setting_aliases[index]);
+	}
+	return aliases;
+}
+
 SettingCallbackInfo::SettingCallbackInfo(ClientContext &context_p, SetScope scope)
     : config(DBConfig::GetConfig(context_p)), db(context_p.db.get()), context(context_p), scope(scope) {
 }

--- a/test/sql/function/autocomplete/setting.test
+++ b/test/sql/function/autocomplete/setting.test
@@ -4,6 +4,11 @@
 
 require autocomplete
 
+query II
+FROM sql_auto_complete('SET memory') limit 1;
+----
+memory_limit	7
+
 # main keywords
 query II
 FROM sql_auto_complete('set thr') LIMIT 1;

--- a/test/sql/function/autocomplete/setting.test
+++ b/test/sql/function/autocomplete/setting.test
@@ -5,7 +5,12 @@
 require autocomplete
 
 query II
-FROM sql_auto_complete('SET memory') limit 1;
+FROM sql_auto_complete('SET directory') LIMIT 1;
+----
+home_directory	4
+
+query II
+FROM sql_auto_complete('SET memory') LIMIT 1;
 ----
 memory_limit	4
 

--- a/test/sql/function/autocomplete/setting.test
+++ b/test/sql/function/autocomplete/setting.test
@@ -9,7 +9,7 @@ require icu
 require no_extension_autoloading "FIXME: ICU is not autoloaded on 'Set timez'"
 
 query II
-FROM sql_auto_complete('SET directory') LIMIT 1;
+FROM sql_auto_complete('SET e_directory') LIMIT 1;
 ----
 home_directory	4
 

--- a/test/sql/function/autocomplete/setting.test
+++ b/test/sql/function/autocomplete/setting.test
@@ -4,10 +4,17 @@
 
 require autocomplete
 
+require icu
+
 query II
 FROM sql_auto_complete('SET directory') LIMIT 1;
 ----
 home_directory	4
+
+query II
+from sql_auto_complete('SET timez') LIMIT 1;
+----
+TimeZone	4
 
 query II
 FROM sql_auto_complete('SET memory') LIMIT 1;

--- a/test/sql/function/autocomplete/setting.test
+++ b/test/sql/function/autocomplete/setting.test
@@ -7,7 +7,7 @@ require autocomplete
 query II
 FROM sql_auto_complete('SET memory') limit 1;
 ----
-memory_limit	7
+memory_limit	4
 
 # main keywords
 query II

--- a/test/sql/function/autocomplete/setting.test
+++ b/test/sql/function/autocomplete/setting.test
@@ -6,6 +6,8 @@ require autocomplete
 
 require icu
 
+require no_extension_autoloading "FIXME: ICU is not autoloaded on 'Set timez'"
+
 query II
 FROM sql_auto_complete('SET directory') LIMIT 1;
 ----


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/5584

This PR improves the autocomplete in a couple of ways: 
1. Aliases of settings are now included in the suggestions (such as `max_memory` as an alias for `memory_limit`). 
2. Options registered by extensions are included in the suggestions. 
3. If the user input matches a substring of a given autocomplete suggestion it is given a higher score. In the code I give a penalty (increased score) to anything that isn't a substring to avoid scores going below zero. For instance `SET directory` now gives as suggestions `home_directory`, `temp_directory` and `secret_directory` as first three suggestions.