### PR TITLE
Propagate `DUCKDB_*_VERSION` in extensions and tests

### DIFF
--- a/src/main/extension/CMakeLists.txt
+++ b/src/main/extension/CMakeLists.txt
@@ -83,6 +83,9 @@ set(GENERATED_CPP_FILE
     ${PROJECT_BINARY_DIR}/codegen/src/generated_extension_loader.cpp)
 configure_file(generated_extension_loader.cpp.in "${GENERATED_CPP_FILE}")
 add_definitions(-DGENERATED_EXTENSION_HEADERS=1)
+add_definitions(-DDUCKDB_MAJOR_VERSION=${DUCKDB_MAJOR_VERSION})
+add_definitions(-DDUCKDB_MINOR_VERSION=${DUCKDB_MINOR_VERSION})
+add_definitions(-DDUCKDB_PATCH_VERSION=${DUCKDB_PATCH_VERSION})
 
 add_library(duckdb_generated_extension_loader OBJECT ${GENERATED_CPP_FILE})
 set(generated_loader_obj_files

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,9 @@ include_directories(include)
 # Allows loading tests from registered extensions
 include_directories("${PROJECT_BINARY_DIR}/codegen/include/")
 add_definitions(-DGENERATED_EXTENSION_HEADERS=1)
+add_definitions(-DDUCKDB_MAJOR_VERSION=${DUCKDB_MAJOR_VERSION})
+add_definitions(-DDUCKDB_MINOR_VERSION=${DUCKDB_MINOR_VERSION})
+add_definitions(-DDUCKDB_PATCH_VERSION=${DUCKDB_PATCH_VERSION})
 
 if(${ENABLE_UNITTEST_CPP_TESTS})
   add_subdirectory(api)


### PR DESCRIPTION
Currently, when building an extension, compilation definitions looks roughly like:
```
c++ 
  -DDUCKDB_BUILD_DIRECTORY=\"build/release\" 
  -DDUCKDB_BUILD_LIBRARY 
  -DDUCKDB_EXTENSION_CORE_FUNCTIONS_LINKED=1 
  -DDUCKDB_EXTENSION_PARQUET_LINKED=1 
  -DDUCKDB_EXTENSION_MY_EXTENSION_NAME_LINKED=1 
  -DDUCKDB_ROOT_DIRECTORY=\"duckdb\" 
  -DGENERATED_EXTENSION_HEADERS=1 
  -I...
  ... other flags ...
  -o test/sqlite/CMakeFiles/test_sqlite.dir/ub_test_sqlite.cpp.o 
  -c /build/release/test/sqlite/ub_test_sqlite.cpp
In file included from build/release/test/sqlite/ub_test_sqlite.cpp:4:
In file included from duckdb/test/sqlite/sqllogic_test_runner.cpp:7:
In file included from duckdb/src/include/duckdb/main/extension/generated_extension_loader.hpp:17:
In file included from build/release/codegen/include/generated_extension_headers.hpp:4:
In file included from src/include/my_extension_name_extension.hpp:3:
```

In particular, the `DUCKDB_MAJOR_VERSION`, `DUCKDB_MINOR_VERSION` and `DUCKDB_PATCH_VERSION` variable are not defined.

These are useful when an extension needs to be compatible with multiple DuckDB version.

This PR adds them to both the `extension` and `unittest` libs compilation.