### PR TITLE
Use microsecond resolution for printing the current timestamp

### DIFF
--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -428,9 +428,9 @@ void Timestamp::Convert(timestamp_ns_t input, date_t &out_date, dtime_t &out_tim
 }
 
 timestamp_t Timestamp::GetCurrentTimestamp() {
-	auto now = system_clock::now();
-	auto epoch_ms = duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
-	return Timestamp::FromEpochMs(epoch_ms);
+	auto now = high_resolution_clock::now();
+	auto epoch_ms = duration_cast<microseconds>(now.time_since_epoch()).count();
+	return FromEpochMicroSeconds(epoch_ms);
 }
 
 timestamp_t Timestamp::FromEpochSecondsPossiblyInfinite(int64_t sec) {

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -428,9 +428,9 @@ void Timestamp::Convert(timestamp_ns_t input, date_t &out_date, dtime_t &out_tim
 }
 
 timestamp_t Timestamp::GetCurrentTimestamp() {
-	auto now = high_resolution_clock::now();
-	auto epoch_ms = duration_cast<microseconds>(now.time_since_epoch()).count();
-	return FromEpochMicroSeconds(epoch_ms);
+	auto now = system_clock::now();
+	auto epoch_micros = duration_cast<microseconds>(now.time_since_epoch()).count();
+	return FromEpochMicroSeconds(epoch_micros);
 }
 
 timestamp_t Timestamp::FromEpochSecondsPossiblyInfinite(int64_t sec) {

--- a/src/include/duckdb/common/chrono.hpp
+++ b/src/include/duckdb/common/chrono.hpp
@@ -14,6 +14,7 @@ namespace duckdb {
 using std::chrono::duration;
 using std::chrono::duration_cast;
 using std::chrono::high_resolution_clock;
+using std::chrono::microseconds;
 using std::chrono::milliseconds;
 using std::chrono::nanoseconds;
 using std::chrono::steady_clock;


### PR DESCRIPTION
Currently we use millisecond resolution - I think there's no reason not to emit microsecond resolution here. 