### PR TITLE
Treat ENABLE_EXTENSION_AUTOINSTALL as the BOOL that it is

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ if (ENABLE_EXTENSION_AUTOLOADING)
   add_definitions(-DDUCKDB_EXTENSION_AUTOLOAD_DEFAULT=1)
 endif()
 if (ENABLE_EXTENSION_AUTOINSTALL)
-  add_definitions(-DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT=${ENABLE_EXTENSION_AUTOINSTALL})
+  add_definitions(-DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT=1)
 endif()
 
 option(OSX_BUILD_UNIVERSAL "Build both architectures on OSX and create a single binary containing both." FALSE)


### PR DESCRIPTION
Micro PR so that I can treat `ENABLE_EXTENSION_AUTOINSTALL` as the BOOL that it is supposed to be (defined as `option(ENABLE_EXTENSION_AUTOINSTALL "Enable extension auto-installing by default." FALSE)`).