### PR TITLE
Move row id logic to separate RowIdColumnData class instead of inlining it into the RowGroup

### DIFF
--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -204,6 +204,8 @@ private:
 	ColumnData &GetColumn(const StorageIndex &c);
 	idx_t GetColumnCount() const;
 	vector<shared_ptr<ColumnData>> &GetColumns();
+	ColumnData &GetRowIdColumnData();
+	void SetCount(idx_t count);
 
 	template <TableScanType TYPE>
 	void TemplatedScan(TransactionData transaction, CollectionScanState &state, DataChunk &result);
@@ -221,6 +223,8 @@ private:
 	vector<idx_t> extra_metadata_blocks;
 	atomic<bool> deletes_is_loaded;
 	atomic<idx_t> allocation_size;
+	unique_ptr<ColumnData> row_id_column_data;
+	atomic<bool> row_id_is_loaded;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/row_id_column_data.hpp
+++ b/src/include/duckdb/storage/table/row_id_column_data.hpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/table/row_id_column_data.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/storage/table/column_data.hpp"
+
+namespace duckdb {
+
+class RowIdColumnData : public ColumnData {
+public:
+	RowIdColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t start_row);
+
+public:
+	void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) override;
+	void InitializeScan(ColumnScanState &state) override;
+	void InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) override;
+
+	idx_t Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
+	           idx_t scan_count) override;
+	idx_t ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
+	                    idx_t scan_count) override;
+	void ScanCommittedRange(idx_t row_group_start, idx_t offset_in_row_group, idx_t count, Vector &result) override;
+	idx_t ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset = 0) override;
+
+	void Filter(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
+	            SelectionVector &sel, idx_t &count, const TableFilter &filter, TableFilterState &filter_state) override;
+	void Select(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
+	            SelectionVector &sel, idx_t count) override;
+	void SelectCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, SelectionVector &sel, idx_t count,
+	                     bool allow_updates) override;
+
+	idx_t Fetch(ColumnScanState &state, row_t row_id, Vector &result) override;
+	void FetchRow(TransactionData transaction, ColumnFetchState &state, row_t row_id, Vector &result,
+	              idx_t result_idx) override;
+
+	void Skip(ColumnScanState &state, idx_t count = STANDARD_VECTOR_SIZE) override;
+
+	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
+
+	void InitializeAppend(ColumnAppendState &state) override;
+	void Append(BaseStatistics &stats, ColumnAppendState &state, Vector &vector, idx_t count) override;
+	void AppendData(BaseStatistics &stats, ColumnAppendState &state, UnifiedVectorFormat &vdata, idx_t count) override;
+	void RevertAppend(row_t start_row) override;
+
+	void Update(TransactionData transaction, idx_t column_index, Vector &update_vector, row_t *row_ids,
+	            idx_t update_count) override;
+	void UpdateColumn(TransactionData transaction, const vector<column_t> &column_path, Vector &update_vector,
+	                  row_t *row_ids, idx_t update_count, idx_t depth) override;
+
+	void CommitDropColumn() override;
+
+	unique_ptr<ColumnCheckpointState> CreateCheckpointState(RowGroup &row_group,
+	                                                        PartialBlockManager &partial_block_manager) override;
+	unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) override;
+
+	void CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t row_group_start, idx_t count,
+	                    Vector &scan_vector) override;
+
+	bool IsPersistent() override;
+};
+
+} // namespace duckdb

--- a/src/storage/table/CMakeLists.txt
+++ b/src/storage/table/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library_unity(
   in_memory_checkpoint.cpp
   update_segment.cpp
   persistent_table_data.cpp
+  row_id_column_data.cpp
   row_group.cpp
   row_group_collection.cpp
   row_version_manager.cpp

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -20,17 +20,19 @@
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
+#include "duckdb/storage/table/row_id_column_data.hpp"
 
 namespace duckdb {
 
 RowGroup::RowGroup(RowGroupCollection &collection_p, idx_t start, idx_t count)
-    : SegmentBase<RowGroup>(start, count), collection(collection_p), version_info(nullptr), allocation_size(0) {
+    : SegmentBase<RowGroup>(start, count), collection(collection_p), version_info(nullptr), allocation_size(0),
+      row_id_is_loaded(false) {
 	Verify();
 }
 
 RowGroup::RowGroup(RowGroupCollection &collection_p, RowGroupPointer pointer)
     : SegmentBase<RowGroup>(pointer.row_start, pointer.tuple_count), collection(collection_p), version_info(nullptr),
-      allocation_size(0) {
+      allocation_size(0), row_id_is_loaded(false) {
 	// deserialize the columns
 	if (pointer.data_pointers.size() != collection_p.GetTypes().size()) {
 		throw IOException("Row group column count is unaligned with table column count. Corrupt file?");
@@ -51,7 +53,7 @@ RowGroup::RowGroup(RowGroupCollection &collection_p, RowGroupPointer pointer)
 
 RowGroup::RowGroup(RowGroupCollection &collection_p, PersistentRowGroupData &data)
     : SegmentBase<RowGroup>(data.start, data.count), collection(collection_p), version_info(nullptr),
-      allocation_size(0) {
+      allocation_size(0), row_id_is_loaded(false) {
 	auto &block_manager = GetBlockManager();
 	auto &info = GetTableInfo();
 	auto &types = collection.get().GetTypes();
@@ -76,6 +78,9 @@ void RowGroup::MoveToCollection(RowGroupCollection &collection_p, idx_t new_star
 			continue;
 		}
 		columns[c]->SetStart(new_start);
+	}
+	if (row_id_is_loaded) {
+		row_id_column_data->SetStart(new_start);
 	}
 	if (!HasUnloadedDeletes()) {
 		auto vinfo = GetVersionInfo();
@@ -104,11 +109,27 @@ idx_t RowGroup::GetRowGroupSize() const {
 	return collection.get().GetRowGroupSize();
 }
 
+ColumnData &RowGroup::GetRowIdColumnData() {
+	if (row_id_is_loaded) {
+		return *row_id_column_data;
+	}
+	lock_guard<mutex> l(row_group_lock);
+	if (!row_id_column_data) {
+		row_id_column_data = make_uniq<RowIdColumnData>(GetBlockManager(), GetTableInfo(), start);
+		row_id_column_data->count = count.load();
+		row_id_is_loaded = true;
+	}
+	return *row_id_column_data;
+}
+
 ColumnData &RowGroup::GetColumn(const StorageIndex &c) {
 	return GetColumn(c.GetPrimaryIndex());
 }
 
 ColumnData &RowGroup::GetColumn(storage_t c) {
+	if (c == COLUMN_IDENTIFIER_ROW_ID) {
+		return GetRowIdColumnData();
+	}
 	D_ASSERT(c < columns.size());
 	if (!is_loaded) {
 		// not being lazy loaded
@@ -243,13 +264,9 @@ bool RowGroup::InitializeScanWithOffset(CollectionScanState &state, idx_t vector
 	D_ASSERT(state.column_scans);
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		const auto &column = column_ids[i];
-		if (!column.IsRowIdColumn()) {
-			auto &column_data = GetColumn(column);
-			column_data.InitializeScanWithOffset(state.column_scans[i], row_number);
-			state.column_scans[i].scan_options = &state.GetOptions();
-		} else {
-			state.column_scans[i].current = nullptr;
-		}
+		auto &column_data = GetColumn(column);
+		column_data.InitializeScanWithOffset(state.column_scans[i], row_number);
+		state.column_scans[i].scan_options = &state.GetOptions();
 	}
 	return true;
 }
@@ -270,13 +287,9 @@ bool RowGroup::InitializeScan(CollectionScanState &state) {
 	D_ASSERT(state.column_scans);
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		auto column = column_ids[i];
-		if (!column.IsRowIdColumn()) {
-			auto &column_data = GetColumn(column);
-			column_data.InitializeScan(state.column_scans[i]);
-			state.column_scans[i].scan_options = &state.GetOptions();
-		} else {
-			state.column_scans[i].current = nullptr;
-		}
+		auto &column_data = GetColumn(column);
+		column_data.InitializeScan(state.column_scans[i]);
+		state.column_scans[i].scan_options = &state.GetOptions();
 	}
 	return true;
 }
@@ -400,9 +413,6 @@ void RowGroup::NextVector(CollectionScanState &state) {
 	const auto &column_ids = state.GetColumnIds();
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		const auto &column = column_ids[i];
-		if (column.IsRowIdColumn()) {
-			continue;
-		}
 		GetColumn(column).Skip(state.column_scans[i]);
 	}
 }
@@ -425,14 +435,7 @@ bool RowGroup::CheckZonemap(ScanFilterInfo &filters) {
 		auto &filter = entry.filter;
 		auto base_column_index = entry.table_column_index;
 
-		FilterPropagateResult prune_result;
-
-		if (base_column_index == COLUMN_IDENTIFIER_ROW_ID) {
-			prune_result = CheckRowIdFilter(filter, this->start, this->start + this->count);
-		} else {
-			prune_result = GetColumn(base_column_index).CheckZonemap(filter);
-		}
-
+		auto prune_result = GetColumn(base_column_index).CheckZonemap(filter);
 		if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
 			return false;
 		}
@@ -459,13 +462,7 @@ bool RowGroup::CheckZonemapSegments(CollectionScanState &state) {
 		auto base_column_idx = entry.table_column_index;
 		auto &filter = entry.filter;
 
-		FilterPropagateResult prune_result;
-		if (base_column_idx == COLUMN_IDENTIFIER_ROW_ID) {
-			prune_result = CheckRowIdFilter(filter, this->start, this->start + this->count);
-		} else {
-			prune_result = GetColumn(base_column_idx).CheckZonemap(state.column_scans[column_idx], filter);
-		}
-
+		auto prune_result = GetColumn(base_column_idx).CheckZonemap(state.column_scans[column_idx], filter);
 		if (prune_result != FilterPropagateResult::FILTER_ALWAYS_FALSE) {
 			continue;
 		}
@@ -561,9 +558,7 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 			PrefetchState prefetch_state;
 			for (idx_t i = 0; i < column_ids.size(); i++) {
 				const auto &column = column_ids[i];
-				if (!column.IsRowIdColumn()) {
-					GetColumn(column).InitializePrefetch(prefetch_state, state.column_scans[i], max_count);
-				}
+				GetColumn(column).InitializePrefetch(prefetch_state, state.column_scans[i], max_count);
 			}
 			auto &buffer_manager = block_manager.buffer_manager;
 			buffer_manager.Prefetch(prefetch_state.blocks);
@@ -574,18 +569,11 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 			// scan all vectors completely: full scan without deletions or table filters
 			for (idx_t i = 0; i < column_ids.size(); i++) {
 				const auto &column = column_ids[i];
-				if (column.IsRowIdColumn()) {
-					// scan row id
-					D_ASSERT(result.data[i].GetType().InternalType() == ROW_TYPE);
-					result.data[i].Sequence(UnsafeNumericCast<int64_t>(this->start + current_row), 1, count);
+				auto &col_data = GetColumn(column);
+				if (TYPE != TableScanType::TABLE_SCAN_REGULAR) {
+					col_data.ScanCommitted(state.vector_index, state.column_scans[i], result.data[i], ALLOW_UPDATES);
 				} else {
-					auto &col_data = GetColumn(column);
-					if (TYPE != TableScanType::TABLE_SCAN_REGULAR) {
-						col_data.ScanCommitted(state.vector_index, state.column_scans[i], result.data[i],
-						                       ALLOW_UPDATES);
-					} else {
-						col_data.Scan(transaction, state.vector_index, state.column_scans[i], result.data[i]);
-					}
+					col_data.Scan(transaction, state.vector_index, state.column_scans[i], result.data[i]);
 				}
 			}
 		} else {
@@ -617,47 +605,14 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 					const auto column_idx = filter.table_column_index;
 
 					auto &result_vector = result.data[scan_idx];
-					if (column_idx == COLUMN_IDENTIFIER_ROW_ID) {
-						// We do another quick statistics scan for row ids here
-						const auto rowid_start = this->start + current_row;
-						const auto rowid_end = this->start + current_row + max_count;
-						const auto prune_result = CheckRowIdFilter(filter.filter, rowid_start, rowid_end);
-						if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
-							// We can just break out of the loop here.
-							approved_tuple_count = 0;
-							continue;
-						}
-
-						// Generate row ids
-						// Create sequence for row ids
-						D_ASSERT(result_vector.GetType().InternalType() == ROW_TYPE);
-						result_vector.SetVectorType(VectorType::FLAT_VECTOR);
-						auto result_data = FlatVector::GetData<int64_t>(result_vector);
-						for (size_t sel_idx = 0; sel_idx < approved_tuple_count; sel_idx++) {
-							result_data[sel.get_index(sel_idx)] =
-							    UnsafeNumericCast<int64_t>(this->start + current_row + sel.get_index(sel_idx));
-						}
-
-						// Was this filter always true? If so, we dont need to apply it
-						if (prune_result == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
-							continue;
-						}
-
-						// Now apply the filter
-						UnifiedVectorFormat vdata;
-						result_vector.ToUnifiedFormat(approved_tuple_count, vdata);
-						ColumnSegment::FilterSelection(sel, result_vector, vdata, filter.filter, table_filter_state,
-						                               approved_tuple_count, approved_tuple_count);
-
-					} else if (approved_tuple_count == 0) {
+					if (approved_tuple_count == 0) {
 						auto &col_data = GetColumn(column_idx);
 						col_data.Skip(state.column_scans[scan_idx]);
 						continue;
-					} else {
-						auto &col_data = GetColumn(column_idx);
-						col_data.Filter(transaction, state.vector_index, state.column_scans[scan_idx], result_vector,
-						                sel, approved_tuple_count, filter.filter, table_filter_state);
 					}
+					auto &col_data = GetColumn(column_idx);
+					col_data.Filter(transaction, state.vector_index, state.column_scans[scan_idx], result_vector, sel,
+					                approved_tuple_count, filter.filter, table_filter_state);
 				}
 				for (auto &table_filter : filter_list) {
 					if (table_filter.IsAlwaysTrue()) {
@@ -673,9 +628,6 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 				// skip this vector in all the scans that were not scanned yet
 				for (idx_t i = 0; i < column_ids.size(); i++) {
 					auto &col_idx = column_ids[i];
-					if (col_idx.IsRowIdColumn()) {
-						continue;
-					}
 					if (has_filters && filter_info.ColumnHasFilters(i)) {
 						continue;
 					}
@@ -692,23 +644,13 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 					continue;
 				}
 				auto &column = column_ids[i];
-				if (column.IsRowIdColumn()) {
-					D_ASSERT(result.data[i].GetType().InternalType() == ROW_TYPE);
-					result.data[i].SetVectorType(VectorType::FLAT_VECTOR);
-					auto result_data = FlatVector::GetData<int64_t>(result.data[i]);
-					for (size_t sel_idx = 0; sel_idx < approved_tuple_count; sel_idx++) {
-						result_data[sel_idx] =
-						    UnsafeNumericCast<int64_t>(this->start + current_row + sel.get_index(sel_idx));
-					}
+				auto &col_data = GetColumn(column);
+				if (TYPE == TableScanType::TABLE_SCAN_REGULAR) {
+					col_data.Select(transaction, state.vector_index, state.column_scans[i], result.data[i], sel,
+					                approved_tuple_count);
 				} else {
-					auto &col_data = GetColumn(column);
-					if (TYPE == TableScanType::TABLE_SCAN_REGULAR) {
-						col_data.Select(transaction, state.vector_index, state.column_scans[i], result.data[i], sel,
-						                approved_tuple_count);
-					} else {
-						col_data.SelectCommitted(state.vector_index, state.column_scans[i], result.data[i], sel,
-						                         approved_tuple_count, ALLOW_UPDATES);
-					}
+					col_data.SelectCommitted(state.vector_index, state.column_scans[i], result.data[i], sel,
+					                         approved_tuple_count, ALLOW_UPDATES);
 				}
 			}
 			filter_info.EndFilter(filter_state);
@@ -840,18 +782,21 @@ void RowGroup::FetchRow(TransactionData transaction, ColumnFetchState &state, co
 		auto &result_vector = result.data[col_idx];
 		D_ASSERT(result_vector.GetVectorType() == VectorType::FLAT_VECTOR);
 		D_ASSERT(!FlatVector::IsNull(result_vector, result_idx));
-		if (column.IsRowIdColumn()) {
-			// row id column: fill in the row ids
-			D_ASSERT(result_vector.GetType().InternalType() == PhysicalType::INT64);
-			result_vector.SetVectorType(VectorType::FLAT_VECTOR);
-			auto data = FlatVector::GetData<row_t>(result_vector);
-			data[result_idx] = row_id;
-		} else {
-			// regular column: fetch data from the base column
-			auto &col_data = GetColumn(column);
-			col_data.FetchRow(transaction, state, row_id, result_vector, result_idx);
+		// regular column: fetch data from the base column
+		auto &col_data = GetColumn(column);
+		col_data.FetchRow(transaction, state, row_id, result_vector, result_idx);
+	}
+}
+
+void RowGroup::SetCount(idx_t count) {
+	this->count = count;
+	if (!row_id_is_loaded) {
+		lock_guard<mutex> guard(row_group_lock);
+		if (!row_id_is_loaded) {
+			return;
 		}
 	}
+	row_id_column_data->count = count;
 }
 
 void RowGroup::AppendVersionInfo(TransactionData transaction, idx_t count) {
@@ -864,7 +809,7 @@ void RowGroup::AppendVersionInfo(TransactionData transaction, idx_t count) {
 	// create the version_info if it doesn't exist yet
 	auto &vinfo = GetOrCreateVersionInfo();
 	vinfo.AppendVersionInfo(transaction, count, row_group_start, row_group_end);
-	this->count = row_group_end;
+	SetCount(row_group_end);
 }
 
 void RowGroup::CommitAppend(transaction_t commit_id, idx_t row_group_start, idx_t count) {
@@ -878,7 +823,7 @@ void RowGroup::RevertAppend(idx_t row_group_start) {
 	for (auto &column : columns) {
 		column->RevertAppend(UnsafeNumericCast<row_t>(row_group_start));
 	}
-	this->count = MinValue<idx_t>(row_group_start - this->start, this->count);
+	SetCount(MinValue<idx_t>(row_group_start - this->start, this->count));
 	Verify();
 }
 
@@ -919,7 +864,6 @@ void RowGroup::Update(TransactionData transaction, DataChunk &update_chunk, row_
 #endif
 	for (idx_t i = 0; i < column_ids.size(); i++) {
 		auto column = column_ids[i];
-		D_ASSERT(column.index != COLUMN_IDENTIFIER_ROW_ID);
 		auto &col_data = GetColumn(column.index);
 		D_ASSERT(col_data.type.id() == update_chunk.data[i].GetType().id());
 		if (offset > 0) {
@@ -939,7 +883,6 @@ void RowGroup::UpdateColumn(TransactionData transaction, DataChunk &updates, Vec
 	auto ids = FlatVector::GetData<row_t>(row_ids);
 
 	auto primary_column_idx = column_path[0];
-	D_ASSERT(primary_column_idx != COLUMN_IDENTIFIER_ROW_ID);
 	D_ASSERT(primary_column_idx < columns.size());
 	auto &col_data = GetColumn(primary_column_idx);
 	col_data.UpdateColumn(transaction, column_path, updates.data[0], ids, updates.size(), 1);
@@ -1287,6 +1230,10 @@ void RowGroup::Verify() {
 #ifdef DEBUG
 	for (auto &column : GetColumns()) {
 		column->Verify(*this);
+	}
+	lock_guard<mutex> guard(row_group_lock);
+	if (row_id_is_loaded) {
+		D_ASSERT(row_id_column_data->count == count);
 	}
 #endif
 }

--- a/src/storage/table/row_id_column_data.cpp
+++ b/src/storage/table/row_id_column_data.cpp
@@ -1,0 +1,173 @@
+#include "duckdb/storage/table/row_id_column_data.hpp"
+#include "duckdb/storage/table/scan_state.hpp"
+#include "duckdb/storage/table/update_segment.hpp"
+
+namespace duckdb {
+
+RowIdColumnData::RowIdColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t start_row)
+    : ColumnData(block_manager, info, COLUMN_IDENTIFIER_ROW_ID, start_row, LogicalType(LogicalTypeId::BIGINT),
+                 nullptr) {
+}
+
+FilterPropagateResult RowIdColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
+	return RowGroup::CheckRowIdFilter(filter, start, start + count);
+	;
+}
+
+void RowIdColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {
+}
+
+void RowIdColumnData::InitializeScan(ColumnScanState &state) {
+	InitializeScanWithOffset(state, start);
+}
+
+void RowIdColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) {
+	state.current = nullptr;
+	state.segment_tree = nullptr;
+	state.row_index = row_idx;
+	state.internal_index = state.row_index;
+	state.initialized = true;
+	state.scan_state.reset();
+	state.last_offset = 0;
+}
+
+idx_t RowIdColumnData::Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
+                            idx_t scan_count) {
+	return ScanCommitted(vector_index, state, result, true, scan_count);
+}
+
+idx_t RowIdColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
+                                     idx_t scan_count) {
+	return ScanCount(state, result, scan_count, 0);
+}
+
+void RowIdColumnData::ScanCommittedRange(idx_t row_group_start, idx_t offset_in_row_group, idx_t count,
+                                         Vector &result) {
+	D_ASSERT(this->start == row_group_start);
+	result.Sequence(UnsafeNumericCast<int64_t>(this->start + offset_in_row_group), 1, count);
+}
+
+idx_t RowIdColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset) {
+	if (result_offset != 0) {
+		throw InternalException("RowIdColumnData result_offset must be 0");
+	}
+	ScanCommittedRange(start, state.row_index - start, count, result);
+	state.row_index += count;
+	return count;
+}
+
+void RowIdColumnData::Filter(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
+                             SelectionVector &sel, idx_t &count, const TableFilter &filter,
+                             TableFilterState &filter_state) {
+	auto current_row = state.row_index;
+	auto max_count = GetVectorCount(vector_index);
+	state.row_index += max_count;
+	// We do another quick statistics scan for row ids here
+	const auto rowid_start = current_row;
+	const auto rowid_end = current_row + max_count;
+	const auto prune_result = RowGroup::CheckRowIdFilter(filter, rowid_start, rowid_end);
+	if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+		// We can just break out of the loop here.
+		count = 0;
+		return;
+	}
+
+	// Generate row ids
+	// Create sequence for row ids
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<row_t>(result);
+	for (size_t sel_idx = 0; sel_idx < count; sel_idx++) {
+		result_data[sel.get_index(sel_idx)] = UnsafeNumericCast<int64_t>(current_row + sel.get_index(sel_idx));
+	}
+
+	// Was this filter always true? If so, we dont need to apply it
+	if (prune_result == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+		return;
+	}
+
+	// Now apply the filter
+	UnifiedVectorFormat vdata;
+	result.ToUnifiedFormat(count, vdata);
+	ColumnSegment::FilterSelection(sel, result, vdata, filter, filter_state, count, count);
+}
+
+void RowIdColumnData::Select(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
+                             SelectionVector &sel, idx_t count) {
+	SelectCommitted(vector_index, state, result, sel, count, true);
+}
+
+void RowIdColumnData::SelectCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, SelectionVector &sel,
+                                      idx_t count, bool allow_updates) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<row_t>(result);
+	for (size_t sel_idx = 0; sel_idx < count; sel_idx++) {
+		result_data[sel_idx] = UnsafeNumericCast<row_t>(state.row_index + sel.get_index(sel_idx));
+	}
+	state.row_index += GetVectorCount(vector_index);
+}
+
+idx_t RowIdColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &result) {
+	throw InternalException("Fetch is not supported for row id columns");
+}
+
+void RowIdColumnData::FetchRow(TransactionData transaction, ColumnFetchState &state, row_t row_id, Vector &result,
+                               idx_t result_idx) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto data = FlatVector::GetData<row_t>(result);
+	data[result_idx] = row_id;
+}
+void RowIdColumnData::Skip(ColumnScanState &state, idx_t count) {
+	state.row_index += count;
+	state.internal_index = state.row_index;
+}
+
+void RowIdColumnData::InitializeAppend(ColumnAppendState &state) {
+	throw InternalException("RowIdColumnData cannot be appended to");
+}
+
+void RowIdColumnData::Append(BaseStatistics &stats, ColumnAppendState &state, Vector &vector, idx_t count) {
+	throw InternalException("RowIdColumnData cannot be appended to");
+}
+
+void RowIdColumnData::AppendData(BaseStatistics &stats, ColumnAppendState &state, UnifiedVectorFormat &vdata,
+                                 idx_t count) {
+	throw InternalException("RowIdColumnData cannot be appended to");
+}
+
+void RowIdColumnData::RevertAppend(row_t start_row) {
+	throw InternalException("RowIdColumnData cannot be appended to");
+}
+
+void RowIdColumnData::Update(TransactionData transaction, idx_t column_index, Vector &update_vector, row_t *row_ids,
+                             idx_t update_count) {
+	throw InternalException("RowIdColumnData cannot be updated");
+}
+
+void RowIdColumnData::UpdateColumn(TransactionData transaction, const vector<column_t> &column_path,
+                                   Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth) {
+	throw InternalException("RowIdColumnData cannot be updated");
+}
+
+void RowIdColumnData::CommitDropColumn() {
+	throw InternalException("RowIdColumnData cannot be dropped");
+}
+
+unique_ptr<ColumnCheckpointState> RowIdColumnData::CreateCheckpointState(RowGroup &row_group,
+                                                                         PartialBlockManager &partial_block_manager) {
+	throw InternalException("RowIdColumnData cannot be checkpointed");
+}
+
+unique_ptr<ColumnCheckpointState> RowIdColumnData::Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) {
+	throw InternalException("RowIdColumnData cannot be checkpointed");
+}
+
+void RowIdColumnData::CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t row_group_start, idx_t count,
+                                     Vector &scan_vector) {
+	throw InternalException("RowIdColumnData cannot be checkpointed");
+}
+
+bool RowIdColumnData::IsPersistent() {
+	throw InternalException("RowIdColumnData cannot be persisted");
+}
+
+} // namespace duckdb


### PR DESCRIPTION
Create a separate `RowIdColumnData` class that holds all of the logic for selecting and filtering virtual row identifiers. 