### PR TITLE
Add support for non-aggregate window functions

### DIFF
--- a/src/function/window/window_constant_aggregator.cpp
+++ b/src/function/window/window_constant_aggregator.cpp
@@ -127,6 +127,12 @@ bool WindowConstantAggregator::CanAggregate(const BoundWindowExpression &wexpr) 
 	if (!wexpr.aggregate) {
 		return false;
 	}
+
+	// The function must be able to be used as an aggregate
+	if (!wexpr.aggregate->CanAggregate()) {
+		return false;
+	}
+
 	// window exclusion cannot be handled by constant aggregates
 	if (wexpr.exclude_clause != WindowExcludeMode::NO_OTHER) {
 		return false;

--- a/src/function/window/window_custom_aggregator.cpp
+++ b/src/function/window/window_custom_aggregator.cpp
@@ -12,7 +12,7 @@ bool WindowCustomAggregator::CanAggregate(const BoundWindowExpression &wexpr, Wi
 		return false;
 	}
 
-	if (!wexpr.aggregate->window) {
+	if (!wexpr.aggregate->CanWindow()) {
 		return false;
 	}
 

--- a/src/function/window/window_distinct_aggregator.cpp
+++ b/src/function/window/window_distinct_aggregator.cpp
@@ -22,6 +22,10 @@ bool WindowDistinctAggregator::CanAggregate(const BoundWindowExpression &wexpr) 
 		return false;
 	}
 
+	if (!wexpr.aggregate->CanAggregate()) {
+		return false;
+	}
+
 	return wexpr.distinct && wexpr.exclude_clause == WindowExcludeMode::NO_OTHER && wexpr.arg_orders.empty();
 }
 

--- a/src/function/window/window_naive_aggregator.cpp
+++ b/src/function/window/window_naive_aggregator.cpp
@@ -373,7 +373,7 @@ void WindowNaiveAggregator::Evaluate(ExecutionContext &context, const DataChunk 
 }
 
 bool WindowNaiveAggregator::CanAggregate(const BoundWindowExpression &wexpr) {
-	if (wexpr.aggregate && !wexpr.aggregate->CanAggregate()) {
+	if (!wexpr.aggregate || !wexpr.aggregate->CanAggregate()) {
 		return false;
 	}
 	return true;

--- a/src/function/window/window_naive_aggregator.cpp
+++ b/src/function/window/window_naive_aggregator.cpp
@@ -372,4 +372,11 @@ void WindowNaiveAggregator::Evaluate(ExecutionContext &context, const DataChunk 
 	lnstate.Evaluate(context, gnstate, bounds, result, count, row_idx, sink.interrupt_state);
 }
 
+bool WindowNaiveAggregator::CanAggregate(const BoundWindowExpression &wexpr) {
+	if (wexpr.aggregate && !wexpr.aggregate->CanAggregate()) {
+		return false;
+	}
+	return true;
+}
+
 } // namespace duckdb

--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -15,6 +15,10 @@ bool WindowSegmentTree::CanAggregate(const BoundWindowExpression &wexpr) {
 		return false;
 	}
 
+	if (!wexpr.aggregate->CanAggregate()) {
+		return false;
+	}
+
 	return !wexpr.distinct && wexpr.arg_orders.empty();
 }
 

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -168,15 +168,31 @@ public:
 	                        FunctionNullHandling::DEFAULT_NULL_HANDLING, simple_update, bind, destructor, statistics,
 	                        window, serialize, deserialize) {
 	}
+
+	// Window constructor
+	AggregateFunction(const vector<LogicalType> &arguments, const LogicalType &return_type, aggregate_size_t state_size,
+	                  aggregate_initialize_t initialize, aggregate_wininit_t window_init, aggregate_window_t window,
+	                  bind_aggregate_function_t bind = nullptr, aggregate_destructor_t destructor = nullptr,
+	                  aggregate_statistics_t statistics = nullptr, aggregate_serialize_t serialize = nullptr,
+	                  aggregate_deserialize_t deserialize = nullptr)
+	    : BaseScalarFunction(name, arguments, return_type, FunctionStability::CONSISTENT,
+	                         LogicalType(LogicalTypeId::INVALID)),
+	      state_size(state_size), initialize(initialize), update(nullptr), combine(nullptr), finalize(nullptr),
+	      simple_update(nullptr), window(window), window_init(window_init), bind(bind), destructor(destructor),
+	      statistics(statistics), serialize(serialize), deserialize(deserialize),
+	      order_dependent(AggregateOrderDependent::ORDER_DEPENDENT),
+	      distinct_dependent(AggregateDistinctDependent::DISTINCT_DEPENDENT) {
+	}
+
 	//! The hashed aggregate state sizing function
 	aggregate_size_t state_size;
 	//! The hashed aggregate state initialization function
 	aggregate_initialize_t initialize;
-	//! The hashed aggregate update state function
+	//! The hashed aggregate update state function (may be null, if window is set)
 	aggregate_update_t update;
-	//! The hashed aggregate combine states function
+	//! The hashed aggregate combine states function (may be null, if window is set)
 	aggregate_combine_t combine;
-	//! The hashed aggregate finalization function
+	//! The hashed aggregate finalization function (may be null, if window is set)
 	aggregate_finalize_t finalize;
 	//! The simple aggregate update function (may be null)
 	aggregate_simple_update_t simple_update;
@@ -208,6 +224,13 @@ public:
 	}
 	bool operator!=(const AggregateFunction &rhs) const {
 		return !(*this == rhs);
+	}
+
+	bool CanAggregate() const {
+		return update || combine || finalize;
+	}
+	bool CanWindow() const {
+		return window;
 	}
 
 public:

--- a/src/include/duckdb/function/window/window_naive_aggregator.hpp
+++ b/src/include/duckdb/function/window/window_naive_aggregator.hpp
@@ -24,6 +24,8 @@ public:
 	void Evaluate(ExecutionContext &context, const DataChunk &bounds, Vector &result, idx_t count, idx_t row_idx,
 	              OperatorSinkInput &sink) const override;
 
+	static bool CanAggregate(const BoundWindowExpression &wexpr);
+
 	//! The parent executor
 	const WindowAggregateExecutor &executor;
 	//! The column indices of any ORDER BY argument expressions

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -264,6 +264,13 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 	// found a matching function!
 	auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 
+	if (!bound_function.CanAggregate() && bound_function.CanWindow()) {
+		auto msg = StringUtil::Format("Function '%s' can only be used as a window function", bound_function.name);
+		error = BinderException(msg);
+		error.AddQueryLocation(aggr);
+		error.Throw();
+	}
+
 	// Bind any sort columns, unless the aggregate is order-insensitive
 	unique_ptr<BoundOrderModifier> order_bys;
 	if (!aggr.order_bys->orders.empty()) {


### PR DESCRIPTION
This PR adds support for implementing non-aggregate window functions... as aggregates, which can only be used as windows. Wow, thats confusing.

DuckDB currently blurs the line between window function and aggregate functions, which makes it possible to use any aggregate function as if it were a window function (although, not the other way around). Because the aggregate function interface is relatively simple, DuckDB will use different execution strategies, so called `WindowAggregator`:s depending on what window parameters are supplied, such frame bounds, ordering, distinct etc. etc. in attempt to accelerate certain window configurations without necessarily adding a bunch of complexity to the aggregate interface. 

If none of the specialized execution strategies can be used, the window operator will first attempt to use the `CustomWindowAggregator` which uses the optional `window` and `window_init` callbacks that an aggregate function can supply, before falling back back to using the "naive" executor which also uses the standard aggregate interface, or

However, this becomes problematic if you want to define a window function **which can only be used as a window function**. Simply throwing an exception in the normal aggregate callbacks is not sufficient because the window operator can still decide to use a different strategy when windowing which still uses the aggregate callbacks, instead of always instantiating the `CustomWindowAggregate` which uses the window callbacks.

Ideally we do have a separate `WindowFunction` class/catalog entity to make this distinction, but for now I've attempted to support my use case by instead allowing the normal aggregate callbacks to be set to `nullptr`, and inspecting whether they are present during binding of aggregates/window expressions as well as choosing the window execution strategy.
