### PR TITLE
Fixup progress_bar: avoid converting doubles into int32_t unchecked

### DIFF
--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -122,7 +122,7 @@ void TerminalProgressBarDisplay::Update(double percentage) {
 	const double filter_percentage = percentage / 100.0;
 	ukf.Update(filter_percentage, current_time);
 
-	double estimated_seconds_remaining = ukf.GetEstimatedRemainingSeconds();
+	double estimated_seconds_remaining = std::min(ukf.GetEstimatedRemainingSeconds(), 2147483647.0);
 	auto percentage_int = NormalizePercentage(percentage);
 
 	TerminalProgressBarDisplayedProgressInfo updated_progress_info = {percentage_int,


### PR DESCRIPTION
Found as a runtime error building with relassert