### PR TITLE
Fix some unindented interactions between `EMPTY_RESULT_PULLUP` and `MATERIALIZED` CTEs

### DIFF
--- a/src/optimizer/cte_inlining.cpp
+++ b/src/optimizer/cte_inlining.cpp
@@ -134,7 +134,7 @@ void CTEInlining::TryInlining(unique_ptr<LogicalOperator> &op) {
 			// even if only a part of the CTE result is needed.
 			// Therefore, we check if the CTE Scans are below the LIMIT or TOP_N operator
 			// and if so, we try to inline the CTE definition.
-			if (ContainsLimit(*op->children[1])) {
+			if (ContainsLimit(*op->children[1]) || op->children[0]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
 				// this CTE is referenced multiple times and has a limit, we want to inline it
 				bool success = Inline(op->children[1], *op, true);
 				if (success) {

--- a/src/optimizer/empty_result_pullup.cpp
+++ b/src/optimizer/empty_result_pullup.cpp
@@ -85,6 +85,7 @@ unique_ptr<LogicalOperator> EmptyResultPullup::Optimize(unique_ptr<LogicalOperat
 			op = make_uniq<LogicalEmptyResult>(std::move(op));
 			break;
 		}
+		return op;
 	}
 	case LogicalOperatorType::LOGICAL_EXCEPT:
 	case LogicalOperatorType::LOGICAL_ANY_JOIN:

--- a/src/optimizer/empty_result_pullup.cpp
+++ b/src/optimizer/empty_result_pullup.cpp
@@ -66,7 +66,6 @@ unique_ptr<LogicalOperator> EmptyResultPullup::Optimize(unique_ptr<LogicalOperat
 	case LogicalOperatorType::LOGICAL_FILTER:
 	case LogicalOperatorType::LOGICAL_DISTINCT:
 	case LogicalOperatorType::LOGICAL_WINDOW:
-	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
 	case LogicalOperatorType::LOGICAL_GET:
 	case LogicalOperatorType::LOGICAL_INTERSECT:
 	case LogicalOperatorType::LOGICAL_PIVOT:
@@ -79,6 +78,13 @@ unique_ptr<LogicalOperator> EmptyResultPullup::Optimize(unique_ptr<LogicalOperat
 			}
 		}
 		return op;
+	}
+	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE: {
+		D_ASSERT(op->children.size() == 2);
+		if (op->children[1]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
+			op = make_uniq<LogicalEmptyResult>(std::move(op));
+			break;
+		}
 	}
 	case LogicalOperatorType::LOGICAL_EXCEPT:
 	case LogicalOperatorType::LOGICAL_ANY_JOIN:

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -169,6 +169,12 @@ void Optimizer::RunBuiltInOptimizers() {
 		plan = deliminator.Optimize(std::move(plan));
 	});
 
+		// try to inline CTEs instead of materialization
+	RunOptimizer(OptimizerType::CTE_INLINING, [&]() {
+		CTEInlining cte_inlining(*this);
+		plan = cte_inlining.Optimize(std::move(plan));
+	});
+
 	// Pulls up empty results
 	RunOptimizer(OptimizerType::EMPTY_RESULT_PULLUP, [&]() {
 		EmptyResultPullup empty_result_pullup;

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -169,7 +169,7 @@ void Optimizer::RunBuiltInOptimizers() {
 		plan = deliminator.Optimize(std::move(plan));
 	});
 
-		// try to inline CTEs instead of materialization
+	// try to inline CTEs instead of materialization
 	RunOptimizer(OptimizerType::CTE_INLINING, [&]() {
 		CTEInlining cte_inlining(*this);
 		plan = cte_inlining.Optimize(std::move(plan));

--- a/test/issues/general/test_18543.test
+++ b/test/issues/general/test_18543.test
@@ -1,0 +1,39 @@
+# name: test/issues/general/test_18543.test
+# description: Issue 18543 - Incorrect handling with CTE and EXIST
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t1(c0 BOOLEAN)
+
+statement ok
+CREATE TABLE t2(c0 BOOLEAN)
+
+statement ok
+CREATE TABLE t3(c0 BOOLEAN)
+
+statement ok
+INSERT INTO t2(c0) VALUES (true)
+
+statement ok
+INSERT INTO t3(c0) VALUES (true)
+
+
+query I
+WITH c AS (
+  SELECT *
+  FROM t1
+  WHERE false
+)
+SELECT t2.c0
+FROM t2 CROSS JOIN t3 CROSS JOIN c
+UNION ALL
+SELECT t2.c0 FROM t2 CROSS JOIN t3
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM c
+)
+----
+true

--- a/test/issues/general/test_18803.test
+++ b/test/issues/general/test_18803.test
@@ -1,0 +1,50 @@
+# name: test/issues/general/test_18803.test
+# description: Issue 18803 - MATERIALIZED CTE with FALSE condition causes incorrect empty result in multi-table JOIN
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t0(c INT)
+
+statement ok
+CREATE TABLE t1(c INT)
+
+statement ok
+CREATE TABLE t2(c INT)
+
+statement ok
+INSERT INTO t0 VALUES (1)
+
+statement ok
+INSERT INTO t1 VALUES (1)
+
+statement ok
+INSERT INTO t2 VALUES (1)
+
+query I
+WITH foo AS MATERIALIZED (
+  SELECT 1 AS one
+  FROM t0
+  WHERE FALSE
+)
+SELECT t0.c
+FROM t0
+JOIN t1 ON TRUE
+JOIN t2 ON TRUE
+----
+1
+
+query I
+WITH foo AS MATERIALIZED (
+  SELECT 1 AS one
+  FROM t0
+  WHERE FALSE
+)
+SELECT t0.c
+FROM t0
+JOIN t1 ON NOT EXISTS (SELECT one FROM foo)
+JOIN t2 ON NOT EXISTS (SELECT one FROM foo)
+----
+1


### PR DESCRIPTION
The `EmptyResultPullup` optimizer assumed that the entire query result would be empty, if the materializing side was empty. This is not true and this PR fixes this.

Fix: https://github.com/duckdb/duckdb/issues/18543
Fix: https://github.com/duckdb/duckdb/issues/18803