### PR TITLE
Test runner: Expand '{UUID}' into a random UUID

### DIFF
--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/file_open_flags.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
 #include "duckdb/main/extension/generated_extension_loader.hpp"
+#include "duckdb/common/types/uuid.hpp"
 #include "duckdb/main/extension_entries.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "sqllogic_parser.hpp"
@@ -222,6 +223,7 @@ string SQLLogicTestRunner::ReplaceKeywords(string input) {
 		auto &value = it.second;
 		input = StringUtil::Replace(input, StringUtil::Format("${%s}", name), value);
 	}
+	input = StringUtil::Replace(input, "{UUID}", UUID::ToString(UUID::GenerateRandomUUID()));
 	input = StringUtil::Replace(input, "__TEST_DIR__", TestDirectoryPath());
 	input = StringUtil::Replace(input, "__WORKING_DIRECTORY__", FileSystem::GetWorkingDirectory());
 	input = StringUtil::Replace(input, "__BUILD_DIRECTORY__", DUCKDB_BUILD_DIRECTORY);


### PR DESCRIPTION
This allow to say create a different schema for each test on the same database or equivalent behaviour where one might want to customize each test.

Example:
```
./build/relassert/test/unittest --skip-compiled --on-init "ATTACH 'test-persistent.db' AS my_db; CREATE SCHEMA my_db.\"{UUID}\";" --on-new-connection "USE my_db.\"{UUID}\";" --order rand --rng-seed time --on-load "skip"
```