### PR TITLE
Add callback to get a list of copy options, use this to provide suggestions and to erase options from import that are only used during exporting

### DIFF
--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -55,8 +55,7 @@ static void WriteStringStreamToFile(FileSystem &fs, stringstream &ss, const stri
 	handle.reset();
 }
 
-static void WriteCopyStatement(FileSystem &fs, stringstream &ss, CopyInfo &info, ExportedTableData &exported_table,
-                               CopyFunction const &function) {
+static void WriteCopyStatement(FileSystem &fs, stringstream &ss, CopyInfo &info, ExportedTableData &exported_table) {
 	ss << "COPY ";
 
 	//! NOTE: The catalog is explicitly not set here
@@ -69,26 +68,12 @@ static void WriteCopyStatement(FileSystem &fs, stringstream &ss, CopyInfo &info,
 	// write the copy options
 	ss << "FORMAT '" << info.format << "'";
 	if (info.format == "csv") {
-		// insert default csv options, if not specified
-		if (info.options.find("header") == info.options.end()) {
-			info.options["header"].push_back(Value::INTEGER(1));
-		}
-		if (info.options.find("delimiter") == info.options.end() && info.options.find("sep") == info.options.end() &&
-		    info.options.find("delim") == info.options.end()) {
-			info.options["delimiter"].push_back(Value(","));
-		}
-		if (info.options.find("quote") == info.options.end()) {
-			info.options["quote"].push_back(Value("\""));
-		}
 		info.options.erase("force_not_null");
 		for (auto &not_null_column : exported_table.not_null_columns) {
 			info.options["force_not_null"].push_back(not_null_column);
 		}
 	}
 	for (auto &copy_option : info.options) {
-		if (copy_option.first == "force_quote") {
-			continue;
-		}
 		if (copy_option.second.empty()) {
 			// empty options are interpreted as TRUE
 			copy_option.second.push_back(true);
@@ -249,7 +234,7 @@ SourceResultType PhysicalExport::GetData(ExecutionContext &context, DataChunk &c
 	stringstream load_ss;
 	for (idx_t i = 0; i < exported_tables->data.size(); i++) {
 		auto exported_table_info = exported_tables->data[i].table_data;
-		WriteCopyStatement(fs, load_ss, *info, exported_table_info, function);
+		WriteCopyStatement(fs, load_ss, *info, exported_table_info);
 	}
 	WriteStringStreamToFile(fs, load_ss, fs.JoinPath(info->file_path, "load.sql"));
 	state.finished = true;

--- a/src/function/copy_function.cpp
+++ b/src/function/copy_function.cpp
@@ -2,6 +2,21 @@
 
 namespace duckdb {
 
+CopyFunction::CopyFunction(const string &name)
+    : Function(name), plan(nullptr), copy_to_select(nullptr), copy_to_bind(nullptr), copy_options(nullptr),
+      copy_to_initialize_local(nullptr), copy_to_initialize_global(nullptr), copy_to_get_written_statistics(nullptr),
+      copy_to_sink(nullptr), copy_to_combine(nullptr), copy_to_finalize(nullptr), execution_mode(nullptr),
+      initialize_operator(nullptr), prepare_batch(nullptr), flush_batch(nullptr), desired_batch_size(nullptr),
+      rotate_files(nullptr), rotate_next_file(nullptr), serialize(nullptr), deserialize(nullptr),
+      copy_from_bind(nullptr) {
+}
+
+CopyOption::CopyOption() : type(LogicalType::ANY), mode(CopyOptionMode::READ_WRITE) {
+}
+
+CopyOption::CopyOption(LogicalType type_p, CopyOptionMode mode_p) : type(std::move(type_p)), mode(mode_p) {
+}
+
 vector<string> GetCopyFunctionReturnNames(CopyFunctionReturnType return_type) {
 	switch (return_type) {
 	case CopyFunctionReturnType::CHANGED_ROWS:

--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -208,6 +208,50 @@ static unique_ptr<FunctionData> WriteCSVBind(ClientContext &context, CopyFunctio
 	return std::move(bind_data);
 }
 
+static void CSVListCopyOptions(ClientContext &context, CopyOptionsInput &input) {
+	auto &copy_options = input.options;
+	copy_options["auto_detect"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_ONLY);
+	copy_options["sample_size"] = CopyOption(LogicalType::BIGINT, CopyOptionMode::READ_ONLY);
+	copy_options["skip"] = CopyOption(LogicalType::BIGINT, CopyOptionMode::READ_ONLY);
+	copy_options["max_line_size"] = CopyOption(LogicalType::BIGINT, CopyOptionMode::READ_ONLY);
+	copy_options["maximum_line_size"] = CopyOption(LogicalType::BIGINT, CopyOptionMode::READ_ONLY);
+	copy_options["ignore_errors"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_ONLY);
+	copy_options["buffer_size"] = CopyOption(LogicalType::BIGINT, CopyOptionMode::READ_ONLY);
+	copy_options["decimal_separator"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_ONLY);
+	copy_options["null_padding"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_ONLY);
+	copy_options["parallel"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_ONLY);
+	copy_options["allow_quoted_nulls"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_ONLY);
+	copy_options["store_rejects"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_ONLY);
+	copy_options["force_not_null"] = CopyOption(LogicalType::ANY, CopyOptionMode::READ_ONLY);
+	copy_options["rejects_table"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_ONLY);
+	copy_options["rejects_scan"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_ONLY);
+	copy_options["rejects_limit"] = CopyOption(LogicalType::BIGINT, CopyOptionMode::READ_ONLY);
+	copy_options["encoding"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_ONLY);
+	copy_options["thousands"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_ONLY);
+
+	copy_options["force_quote"] = CopyOption(LogicalType::ANY, CopyOptionMode::WRITE_ONLY);
+	copy_options["prefix"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::WRITE_ONLY);
+	copy_options["suffix"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::WRITE_ONLY);
+
+	copy_options["new_line"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["date_format"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["dateformat"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["timestamp_format"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["timestampformat"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["quote"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["comment"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["delim"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["delimiter"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["sep"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["separator"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["escape"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["header"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_WRITE);
+	copy_options["nullstr"] = CopyOption(LogicalType::ANY, CopyOptionMode::READ_WRITE);
+	copy_options["null"] = CopyOption(LogicalType::ANY, CopyOptionMode::READ_WRITE);
+	copy_options["compression"] = CopyOption(LogicalType::VARCHAR, CopyOptionMode::READ_WRITE);
+	copy_options["strict_mode"] = CopyOption(LogicalType::BOOLEAN, CopyOptionMode::READ_WRITE);
+}
+
 //===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//
@@ -385,6 +429,7 @@ bool WriteCSVRotateNextFile(GlobalFunctionData &gstate, FunctionData &, const op
 void CSVCopyFunction::RegisterFunction(BuiltinFunctions &set) {
 	CopyFunction info("csv");
 	info.copy_to_bind = WriteCSVBind;
+	info.copy_options = CSVListCopyOptions;
 	info.copy_to_initialize_local = WriteCSVInitializeLocal;
 	info.copy_to_initialize_global = WriteCSVInitializeGlobal;
 	info.copy_to_sink = WriteCSVSink;

--- a/src/include/duckdb/common/enums/copy_option_mode.hpp
+++ b/src/include/duckdb/common/enums/copy_option_mode.hpp
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/copy_option_mode.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+
+enum class CopyOptionMode { WRITE_ONLY, READ_ONLY, READ_WRITE };
+
+} // namespace duckdb

--- a/src/include/duckdb/function/copy_function.hpp
+++ b/src/include/duckdb/function/copy_function.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/parser/parsed_data/copy_info.hpp"
 #include "duckdb/parser/statement/copy_statement.hpp"
+#include "duckdb/common/enums/copy_option_mode.hpp"
 
 namespace duckdb {
 
@@ -90,8 +91,6 @@ struct CopyToSelectInput {
 	vector<unique_ptr<Expression>> select_list;
 	CopyToType copy_to_type;
 };
-
-enum class CopyOptionMode { WRITE_ONLY, READ_ONLY, READ_WRITE };
 
 struct CopyOption {
 	CopyOption();

--- a/src/include/duckdb/function/copy_function.hpp
+++ b/src/include/duckdb/function/copy_function.hpp
@@ -91,9 +91,27 @@ struct CopyToSelectInput {
 	CopyToType copy_to_type;
 };
 
+enum class CopyOptionMode { WRITE_ONLY, READ_ONLY, READ_WRITE };
+
+struct CopyOption {
+	CopyOption();
+	explicit CopyOption(LogicalType type_p, CopyOptionMode mode = CopyOptionMode::READ_WRITE);
+
+	LogicalType type;
+	CopyOptionMode mode;
+};
+
+struct CopyOptionsInput {
+	explicit CopyOptionsInput(case_insensitive_map_t<CopyOption> &options) : options(options) {
+	}
+
+	case_insensitive_map_t<CopyOption> &options;
+};
+
 enum class CopyFunctionExecutionMode { REGULAR_COPY_TO_FILE, PARALLEL_COPY_TO_FILE, BATCH_COPY_TO_FILE };
 
 typedef BoundStatement (*copy_to_plan_t)(Binder &binder, CopyStatement &stmt);
+typedef void (*copy_options_t)(ClientContext &context, CopyOptionsInput &input);
 typedef unique_ptr<FunctionData> (*copy_to_bind_t)(ClientContext &context, CopyFunctionBindInput &input,
                                                    const vector<string> &names, const vector<LogicalType> &sql_types);
 typedef unique_ptr<LocalFunctionData> (*copy_to_initialize_local_t)(ExecutionContext &context, FunctionData &bind_data);
@@ -152,20 +170,13 @@ struct CopyFunctionFileStatistics {
 
 class CopyFunction : public Function { // NOLINT: work-around bug in clang-tidy
 public:
-	explicit CopyFunction(const string &name)
-	    : Function(name), plan(nullptr), copy_to_select(nullptr), copy_to_bind(nullptr),
-	      copy_to_initialize_local(nullptr), copy_to_initialize_global(nullptr),
-	      copy_to_get_written_statistics(nullptr), copy_to_sink(nullptr), copy_to_combine(nullptr),
-	      copy_to_finalize(nullptr), execution_mode(nullptr), initialize_operator(nullptr), prepare_batch(nullptr),
-	      flush_batch(nullptr), desired_batch_size(nullptr), rotate_files(nullptr), rotate_next_file(nullptr),
-	      serialize(nullptr), deserialize(nullptr), copy_from_bind(nullptr) {
-	}
+	explicit CopyFunction(const string &name);
 
 	//! Plan rewrite copy function
 	copy_to_plan_t plan;
-
 	copy_to_select_t copy_to_select;
 	copy_to_bind_t copy_to_bind;
+	copy_options_t copy_options;
 	copy_to_initialize_local_t copy_to_initialize_local;
 	copy_to_initialize_global_t copy_to_initialize_global;
 	copy_to_get_written_statistics_t copy_to_get_written_statistics;

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -28,6 +28,7 @@
 #include "duckdb/planner/bound_constraint.hpp"
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/tableref/bound_delimgetref.hpp"
+#include "duckdb/common/enums/copy_option_mode.hpp"
 
 //! fwd declare
 namespace duckdb_re2 {
@@ -411,7 +412,7 @@ private:
 	BoundStatement BindCopyTo(CopyStatement &stmt, const CopyFunction &function, CopyToType copy_to_type);
 	BoundStatement BindCopyFrom(CopyStatement &stmt, const CopyFunction &function);
 	void BindCopyOptions(CopyInfo &info);
-	case_insensitive_map_t<CopyOption> GetFullCopyOptionsList(const CopyFunction &function, bool is_from);
+	case_insensitive_map_t<CopyOption> GetFullCopyOptionsList(const CopyFunction &function, CopyOptionMode mode);
 
 	void PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, BoundQueryNode &result);
 	void BindModifiers(BoundQueryNode &result, idx_t table_index, const vector<string> &names,

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -67,6 +67,7 @@ struct EntryLookupInfo;
 struct PivotColumnEntry;
 struct UnpivotEntry;
 struct CopyInfo;
+struct CopyOption;
 
 template <class T, class INDEX_TYPE>
 class IndexVector;
@@ -407,9 +408,10 @@ private:
 	unique_ptr<LogicalOperator> CreatePlan(BoundPivotRef &ref);
 	unique_ptr<LogicalOperator> CreatePlan(BoundDelimGetRef &ref);
 
-	BoundStatement BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type);
-	BoundStatement BindCopyFrom(CopyStatement &stmt);
+	BoundStatement BindCopyTo(CopyStatement &stmt, const CopyFunction &function, CopyToType copy_to_type);
+	BoundStatement BindCopyFrom(CopyStatement &stmt, const CopyFunction &function);
 	void BindCopyOptions(CopyInfo &info);
+	case_insensitive_map_t<CopyOption> GetFullCopyOptionsList(const CopyFunction &function, bool is_from);
 
 	void PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, BoundQueryNode &result);
 	void BindModifiers(BoundQueryNode &result, idx_t table_index, const vector<string> &names,

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -544,11 +544,15 @@ BoundStatement Binder::Bind(CopyStatement &stmt, CopyToType copy_to_type) {
 			}
 			auto &copy_option = option_entry->second;
 			if (copy_option.type.id() != LogicalTypeId::ANY) {
-				if (copy_option.type.id() == LogicalTypeId::BOOLEAN && provided_entry.second.empty()) {
-					// boolean can be empty (e.g. "HEADER")
-					continue;
+				if (provided_entry.second.empty()) {
+					if (copy_option.type.id() == LogicalTypeId::BOOLEAN) {
+						// boolean can be empty (e.g. "HEADER")
+						continue;
+					}
+					throw InvalidInputException("Copy option %s requires an argument of type %s", provided_option,
+					                            copy_option.type.ToString());
 				}
-				if (provided_entry.second.size() != 1) {
+				if (provided_entry.second.size() > 1) {
 					throw InvalidInputException("Copy option %s did not expect a list as argument", provided_option);
 				}
 				auto &original_value = provided_entry.second[0];

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -285,10 +285,11 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 		}
 		options.erase("force_quote");
 	}
-	// for any options that are write-only
+	// for any options that are write-only, use them for writing but don't put them in the COPY statements we generate
+	// for reading
 	auto &function = copy_function.function;
 	if (function.copy_options) {
-		auto copy_options = GetFullCopyOptionsList(function, true);
+		auto copy_options = GetFullCopyOptionsList(function, CopyOptionMode::READ_ONLY);
 		vector<string> erased_options;
 		for (auto &entry : options) {
 			if (copy_options.find(entry.first) == copy_options.end()) {

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -268,6 +268,38 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 	}
 
 	stmt.info->catalog = catalog;
+	// prepare the options for export
+	auto &format = stmt.info->format;
+	auto &options = stmt.info->options;
+	if (format == "csv") {
+		// insert default csv options, if not specified
+		if (options.find("header") == options.end()) {
+			options["header"].push_back(Value::INTEGER(1));
+		}
+		if (options.find("delimiter") == options.end() && options.find("sep") == options.end() &&
+		    options.find("delim") == options.end()) {
+			options["delimiter"].push_back(Value(","));
+		}
+		if (options.find("quote") == options.end()) {
+			options["quote"].push_back(Value("\""));
+		}
+		options.erase("force_quote");
+	}
+	// for any options that are write-only
+	auto &function = copy_function.function;
+	if (function.copy_options) {
+		auto copy_options = GetFullCopyOptionsList(function, true);
+		vector<string> erased_options;
+		for (auto &entry : options) {
+			if (copy_options.find(entry.first) == copy_options.end()) {
+				erased_options.push_back(entry.first);
+			}
+		}
+		for (auto &erased : erased_options) {
+			options.erase(erased);
+		}
+	}
+
 	// create the export node
 	auto export_node =
 	    make_uniq<LogicalExport>(copy_function.function, std::move(stmt.info), std::move(exported_tables));

--- a/test/parquet/parquet_version.test
+++ b/test/parquet/parquet_version.test
@@ -7,7 +7,7 @@ require parquet
 statement error
 copy (select range i from range(20000)) to '__TEST_DIR__/parquet_version.parquet' (parquet_version)
 ----
-Binder Error
+Invalid Input Error
 
 statement error
 copy (select range i from range(20000)) to '__TEST_DIR__/parquet_version.parquet' (parquet_version v3)

--- a/test/sql/copy/csv/test_copy.test
+++ b/test/sql/copy/csv/test_copy.test
@@ -107,19 +107,19 @@ SELECT * FROM test4 ORDER BY 1 LIMIT 3;
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (SEP ',', HEADER 0.2);
 ----
-"header" expects a boolean value (e.g. TRUE or 1)
+"HEADER" expected an argument of type BOOLEAN
 
 # empty delimiter
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (SEP);
 ----
-"sep" expects a single argument as a string value
+"SEP" requires an argument of type VARCHAR
 
 # number as delimiter
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (SEP 1);
 ----
-"sep" expects a string argument!
+"SEP" expected an argument of type VARCHAR
 
 # multiple format options
 statement error
@@ -136,25 +136,25 @@ duplicate option
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (ESCAPE 1);
 ----
-"escape" expects a string argument!
+"ESCAPE" expected an argument of type VARCHAR
 
 # no escape string
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (ESCAPE);
 ----
-"escape" expects a single argument as a string value
+"ESCAPE" requires an argument of type VARCHAR
 
 # number as quote string
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (QUOTE 1);
 ----
-"quote" expects a string argument!
+"QUOTE" expected an argument of type VARCHAR
 
 # no quote string
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (QUOTE);
 ----
-"quote" expects a single argument as a string value
+"QUOTE" requires an argument of type VARCHAR
 
 # no format string
 statement error
@@ -166,12 +166,12 @@ Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'parquet'
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (ENCODING);
 ----
-"encoding" expects a single argument as a string value
+"ENCODING" requires an argument of type VARCHAR
 
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (ENCODING 42);
 ----
-"encoding" expects a string argument!
+"ENCODING" expected an argument of type VARCHAR
 
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (ENCODING 'utf-42');
@@ -182,7 +182,7 @@ The CSV Reader does not support the encoding: "utf-42"
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (MAGIC '42');
 ----
-Unrecognized option for CSV reader "magic"
+Unrecognized option "MAGIC"
 
 # Try new_line option
 query I

--- a/test/sql/copy/csv/test_encodings.test_slow
+++ b/test/sql/copy/csv/test_encodings.test_slow
@@ -30,7 +30,7 @@ The CSV Reader does not support the encoding: "Shift-JIS"
 statement error
 COPY test TO 'data/csv/test/test.csv' (encoding 'utf-16');
 ----
-Unrecognized option CSV writer "encoding"
+Option "encoding" is not supported for writing - only for reading
 
 statement error
 FROM read_csv('data/csv/encodings/latin1.csv')

--- a/test/sql/copy/csv/test_export_not_null.test
+++ b/test/sql/copy/csv/test_export_not_null.test
@@ -31,7 +31,7 @@ IMPORT DATABASE '__TEST_DIR__/broken_empty_string';
 statement error
 EXPORT DATABASE '__TEST_DIR__/broken_empty_string_2' (FORCE_NOT_NULL ['A']);
 ----
-Unrecognized option
+"FORCE_NOT_NULL" is not supported for writing - only for reading
 
 statement ok
 abort;

--- a/test/sql/copy/csv/test_force_not_null.test
+++ b/test/sql/copy/csv/test_force_not_null.test
@@ -42,7 +42,7 @@ SELECT * FROM test ORDER BY 1;
 statement error
 COPY test TO 'data/csv/test/force_not_null.csv' (FORCE_NOT_NULL (col_b), NULL 'test', HEADER 0);
 ----
- Unrecognized option CSV writer "force_not_null"
+Option "FORCE_NOT_NULL" is not supported for writing - only for reading
 
 # FORCE_NOT_NULL must not be empty and must have the correct parameter type
 statement error

--- a/test/sql/copy/csv/test_force_quote.test
+++ b/test/sql/copy/csv/test_force_quote.test
@@ -81,7 +81,7 @@ COPY test TO '__TEST_DIR__/test_reorder.csv' (FORCE_QUOTE (col_c, col_d));
 statement error
 COPY test FROM '__TEST_DIR__/test_reorder.csv' (FORCE_QUOTE (col_c, col_d));
 ----
-Unrecognized option for CSV reader "force_quote"
+Option "FORCE_QUOTE" is not supported for reading - only for writing
 
 # FORCE_QUOTE must not be empty and must have the correct parameter type
 statement error

--- a/test/sql/copy/format_uuid.test
+++ b/test/sql/copy/format_uuid.test
@@ -132,7 +132,7 @@ Directory
 statement error
 COPY test4 TO '__TEST_DIR__/to_be_overwritten' (FORMAT PARQUET, PARTITION_BY (a), FILENAME_PATTERN);
 ----
-FILENAME_PATTERN requires an argument of type VARCHAR
+Copy option "FILENAME_PATTERN" requires an argument of type VARCHAR
 
 statement ok
 COPY test4 TO '__TEST_DIR__/to_be_overwritten' (FORMAT PARQUET, PARTITION_BY (a), FILENAME_PATTERN a_file_name);

--- a/test/sql/copy/format_uuid.test
+++ b/test/sql/copy/format_uuid.test
@@ -132,7 +132,7 @@ Directory
 statement error
 COPY test4 TO '__TEST_DIR__/to_be_overwritten' (FORMAT PARQUET, PARTITION_BY (a), FILENAME_PATTERN);
 ----
-FILENAME_PATTERN cannot be empty
+FILENAME_PATTERN requires an argument of type VARCHAR
 
 statement ok
 COPY test4 TO '__TEST_DIR__/to_be_overwritten' (FORMAT PARQUET, PARTITION_BY (a), FILENAME_PATTERN a_file_name);

--- a/test/sql/copy/parquet/copy_option_suggestion.test
+++ b/test/sql/copy/parquet/copy_option_suggestion.test
@@ -8,3 +8,8 @@ statement error
 copy (select 42) to 'file.parquet' (partition_b (a));
 ----
 partition_by
+
+statement error
+copy (select 42) to 'file.csv' (partition_b (a));
+----
+partition_by

--- a/test/sql/copy/parquet/copy_option_suggestion.test
+++ b/test/sql/copy/parquet/copy_option_suggestion.test
@@ -1,0 +1,10 @@
+# name: test/sql/copy/parquet/copy_option_suggestion.test
+# description: Test suggestion of unknown copy options
+# group: [parquet]
+
+require parquet
+
+statement error
+copy (select 42) to 'file.parquet' (partition_b (a));
+----
+partition_by

--- a/test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test
+++ b/test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test
@@ -27,7 +27,7 @@ foreach key_len 128 192 256
 statement error
 COPY (SELECT 42 i) to '__TEST_DIR__/encrypted${key_len}_openssl.parquet' (ENCRYPTION_CONFIG {footer_key: 'key${key_len}'}, DEBUG_USE_OPENSSL randomval)
 ----
-Binder Error: Expected debug_use_openssl to be a BOOLEAN
+BOOL
 
 # write files with OpenSSL enabled
 statement ok

--- a/test/sql/export/export_compression_level.test
+++ b/test/sql/export/export_compression_level.test
@@ -1,0 +1,40 @@
+# name: test/sql/export/export_compression_level.test
+# description: Test export with parameters that are only supported on export, not on import
+# group: [export]
+
+require parquet
+
+statement ok
+CREATE TABLE test_table (
+    id INTEGER,
+    name VARCHAR,
+    value DOUBLE,
+    created_at TIMESTAMP
+);
+
+statement ok
+INSERT INTO test_table VALUES
+    (1, 'Alice', 123.45, '2024-01-01 10:00:00'),
+    (2, 'Bob', 67.89, '2024-01-02 11:30:00'),
+    (3, 'Charlie', 234.56, '2024-01-03 14:15:00');
+
+statement ok
+EXPORT DATABASE 'my_duckdb' (
+    FORMAT parquet,
+    COMPRESSION zstd,
+    COMPRESSION_LEVEL 12,
+    ROW_GROUP_SIZE 100_000
+);
+
+statement ok
+DROP TABLE test_table;
+
+statement ok
+IMPORT DATABASE 'my_duckdb';
+
+query IIII
+FROM test_table;
+----
+1	Alice	123.45	2024-01-01 10:00:00
+2	Bob	67.89	2024-01-02 11:30:00
+3	Charlie	234.56	2024-01-03 14:15:00

--- a/test/sql/json/test_json_copy.test_slow
+++ b/test/sql/json/test_json_copy.test_slow
@@ -215,7 +215,7 @@ select * from read_json_auto('__TEST_DIR__/my.json', format='array')
 statement error
 copy (select range as i from range(10)) to '__TEST_DIR__/my.json' (COMPRESSION)
 ----
-Binder Error
+Invalid Input Error
 
 statement ok
 copy (select range as i from range(10)) to '__TEST_DIR__/my.json.gz' (COMPRESSION GZIP)

--- a/test/sql/types/timestamp/utc_offset.test
+++ b/test/sql/types/timestamp/utc_offset.test
@@ -7,6 +7,12 @@ require icu
 statement ok
 PRAGMA enable_verification
 
+statement ok
+set Calendar='gregorian';
+
+statement ok
+set TimeZone='UTC';
+
 # Offset parsing for plain  timestamps drops the offset instead of subtracting it
 query I
 SELECT '2025-01-01T08:00:00+08'::TIMESTAMP AS c;
@@ -17,12 +23,6 @@ query I
 SELECT '2025-01-01T08:00:00+08'::TIMESTAMPTZ AS c;
 ----
 2025-01-01 00:00:00+00
-
-statement ok
-set Calendar='gregorian';
-
-statement ok
-set TimeZone='UTC';
 
 query I
 select timestamptz '2020-12-31 21:25:58.745232';


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/17858

This PR adds a new callback to the `CopyFunction`  - `copy_options`. This is used to provide a list of options provided by the copy statement, as well as (optionally) their types and whether or not they can be used when reading, when writing, or for both.

This allows for a few things:
* When running `EXPORT DATABASE`, we know if an option is for writing only, or if we need to mirror it in the `COPY` statements we generate
* When parsing an unknown option, we can now give suggestions:

```sql
copy (select 42) to 'file.csv' (partition_b x);
```
```
Not implemented Error:
Unrecognized option "partition_b" for csv

Candidate options: "partition_by", "separator", "compression", "write_partition_columns", "prefix"
```

* When using an option that is used for writing but can only be used for reading, or vice versa, we can now inform the user of this explicitly:

```sql
copy (select 42) to 'file.csv' (encoding 'utf-16');
Invalid Input Error:
Option "encoding" is not supported for writing - only for reading
```
