### PR TITLE
Ignore null verification for statistics on structs

### DIFF
--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -83,7 +83,7 @@ public:
 	inline void SetHasNullFast() {
 		has_null = true;
 	}
-	//! Set that the CURRENT level can have valiod values
+	//! Set that the CURRENT level can have valid values
 	//! Note that this is not correct for nested types unless this information is propagated in a different manner
 	//! Use Set(StatsInfo::CAN_HAVE_VALID_VALUES) in the general case
 	inline void SetHasNoNullFast() {
@@ -104,6 +104,7 @@ public:
 	static BaseStatistics Deserialize(Deserializer &deserializer);
 
 	//! Verify that a vector does not violate the statistics
+	void Verify(Vector &vector, const SelectionVector &sel, idx_t count, bool ignore_has_null) const;
 	void Verify(Vector &vector, const SelectionVector &sel, idx_t count) const;
 	void Verify(Vector &vector, idx_t count) const;
 

--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -104,8 +104,7 @@ public:
 	static BaseStatistics Deserialize(Deserializer &deserializer);
 
 	//! Verify that a vector does not violate the statistics
-	void Verify(Vector &vector, const SelectionVector &sel, idx_t count, bool ignore_has_null) const;
-	void Verify(Vector &vector, const SelectionVector &sel, idx_t count) const;
+	void Verify(Vector &vector, const SelectionVector &sel, idx_t count, bool ignore_has_null = false) const;
 	void Verify(Vector &vector, idx_t count) const;
 
 	string ToString() const;

--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -447,10 +447,6 @@ void BaseStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t co
 	}
 }
 
-void BaseStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count) const {
-	Verify(vector, sel, count, false);
-}
-
 void BaseStatistics::Verify(Vector &vector, idx_t count) const {
 	auto sel = FlatVector::IncrementalSelectionVector();
 	Verify(vector, *sel, count, false);

--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -403,7 +403,7 @@ string BaseStatistics::ToString() const {
 	return result;
 }
 
-void BaseStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count, bool ignore_has_null) const {
+void BaseStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count, const bool ignore_has_null) const {
 	D_ASSERT(vector.GetType() == this->type);
 	switch (GetStatsType()) {
 	case StatisticsType::NUMERIC_STATS:

--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -403,7 +403,7 @@ string BaseStatistics::ToString() const {
 	return result;
 }
 
-void BaseStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count) const {
+void BaseStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count, bool ignore_has_null) const {
 	D_ASSERT(vector.GetType() == this->type);
 	switch (GetStatsType()) {
 	case StatisticsType::NUMERIC_STATS:
@@ -439,7 +439,7 @@ void BaseStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t co
 			    "Statistics mismatch: vector labeled as having only NULL values, but vector contains valid values: %s",
 			    vector.ToString(count));
 		}
-		if (!row_is_valid && !has_null) {
+		if (!row_is_valid && !has_null && !ignore_has_null) {
 			throw InternalException(
 			    "Statistics mismatch: vector labeled as not having NULL values, but vector contains null values: %s",
 			    vector.ToString(count));
@@ -447,9 +447,13 @@ void BaseStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t co
 	}
 }
 
+void BaseStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count) const {
+	Verify(vector, sel, count, false);
+}
+
 void BaseStatistics::Verify(Vector &vector, idx_t count) const {
 	auto sel = FlatVector::IncrementalSelectionVector();
-	Verify(vector, *sel, count);
+	Verify(vector, *sel, count, false);
 }
 
 BaseStatistics BaseStatistics::FromConstantType(const Value &input) {

--- a/src/storage/statistics/struct_stats.cpp
+++ b/src/storage/statistics/struct_stats.cpp
@@ -132,7 +132,7 @@ string StructStats::ToString(const BaseStatistics &stats) {
 void StructStats::Verify(const BaseStatistics &stats, Vector &vector, const SelectionVector &sel, idx_t count) {
 	auto &child_entries = StructVector::GetEntries(vector);
 	for (idx_t i = 0; i < child_entries.size(); i++) {
-		stats.child_stats[i].Verify(*child_entries[i], sel, count);
+		stats.child_stats[i].Verify(*child_entries[i], sel, count, true);
 	}
 }
 

--- a/test/configs/enable_verification.json
+++ b/test/configs/enable_verification.json
@@ -209,8 +209,7 @@
         "test/sql/logging/logging_file_bind_replace.test",
         "test/sql/optimizer/test_rowid_pushdown_plan.test",
         "test/sql/pg_catalog/system_functions.test",
-        "test/sql/storage/compression/test_using_compression.test",
-        "test/sql/storage/types/struct/nested_struct_storage.test"
+        "test/sql/storage/compression/test_using_compression.test"
       ]
     }
   ]

--- a/test/configs/enable_verification_for_debug.json
+++ b/test/configs/enable_verification_for_debug.json
@@ -723,8 +723,7 @@
         "test/sql/logging/logging_file_bind_replace.test",
         "test/sql/optimizer/test_rowid_pushdown_plan.test",
         "test/sql/pg_catalog/system_functions.test",
-        "test/sql/storage/compression/test_using_compression.test",
-        "test/sql/storage/types/struct/nested_struct_storage.test"
+        "test/sql/storage/compression/test_using_compression.test"
       ]
     }
   ]


### PR DESCRIPTION
Struct columns become null, if they are excluded by projections. However, as their base statistics are still propagated, the base statistics verification should not throw an exception if the base data does not contain nulls.