### PR TITLE
PRAGMA's MissingEntry: Suggest CALL might be an option

### DIFF
--- a/src/planner/binder/statement/bind_pragma.cpp
+++ b/src/planner/binder/statement/bind_pragma.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/parser/statement/pragma_statement.hpp"
 #include "duckdb/planner/operator/logical_pragma.hpp"
 #include "duckdb/catalog/catalog_entry/pragma_function_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/expression_binder/constant_binder.hpp"
@@ -28,16 +29,32 @@ unique_ptr<BoundPragmaInfo> Binder::BindPragma(PragmaInfo &info, QueryErrorConte
 	}
 
 	// bind the pragma function
-	auto &entry = Catalog::GetEntry<PragmaFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, info.name);
+	auto entry = Catalog::GetEntry<PragmaFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, info.name,
+	                                                           OnEntryNotFound::RETURN_NULL);
+	if (!entry) {
+		// try to find whether a table extry might exist
+		auto table_entry = Catalog::GetEntry<TableFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA,
+		                                                                info.name, OnEntryNotFound::RETURN_NULL);
+		if (table_entry) {
+			// there is a table entry with the same name, now throw more explicit error message
+			throw CatalogException("Pragma Function with name %s does not exist, but a table function with the same "
+			                       "name exists, try `CALL %s(...)`",
+			                       info.name, info.name);
+		}
+		// rebind to throw exception
+		entry = Catalog::GetEntry<PragmaFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, info.name,
+		                                                      OnEntryNotFound::THROW_EXCEPTION);
+	}
+
 	FunctionBinder function_binder(*this);
 	ErrorData error;
-	auto bound_idx = function_binder.BindFunction(entry.name, entry.functions, params, error);
+	auto bound_idx = function_binder.BindFunction(entry->name, entry->functions, params, error);
 	if (!bound_idx.IsValid()) {
 		D_ASSERT(error.HasError());
 		error.AddQueryLocation(error_context);
 		error.Throw();
 	}
-	auto bound_function = entry.functions.GetFunctionByOffset(bound_idx.GetIndex());
+	auto bound_function = entry->functions.GetFunctionByOffset(bound_idx.GetIndex());
 	// bind and check named params
 	BindNamedParameters(bound_function.named_parameters, named_parameters, error_context, bound_function.name);
 	return make_uniq<BoundPragmaInfo>(std::move(bound_function), std::move(params), std::move(named_parameters));

--- a/test/sql/logging/test_logging_function.test
+++ b/test/sql/logging/test_logging_function.test
@@ -8,6 +8,11 @@ query IIIIIIIIII
 from duckdb_logs
 ----
 
+statement error
+PRAGMA enable_logging;
+----
+Pragma Function with name enable_logging does not exist, but a table function with the same name exists, try
+
 statement ok
  CALL enable_logging();
 


### PR DESCRIPTION
Unsure if worth adding, but given over time some PRAGMA have become CALL, and more will come, maybe it make sense?

Example:
```sql
PRAGMA enable_logging(level='trace', storage='stdout');
```
goes from
```
Catalog Error:
Pragma Function with name enable_logging does not exist!
Did you mean "enable_profiling"?
```
to
```
Catalog Error:
Pragma Function with name enable_logging does not exist!
Did you mean "enable_profiling"?
Pragma Function might be available also as table function statements (eg: `CALL ...();`)
```