### PR TITLE
[Feature] Support cardinality estimation for range

### DIFF
--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -115,6 +115,9 @@ struct ClientConfig {
 	//! (empty = output to the DuckDB logger)
 	string http_logging_output;
 
+	//! Inspect range filter when calculate cardinality
+	bool inspect_range_filter = false;
+
 public:
 	static ClientConfig &GetConfig(ClientContext &context);
 	static const ClientConfig &GetConfig(const ClientContext &context);

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -691,13 +691,13 @@ struct ForceBitpackingModeSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 struct InspectRangeFilterSetting {
-    using RETURN_TYPE = bool;
-    static constexpr const char *Name = "inspect_range_filter";
-    static constexpr const char *Description = "Inspect ranges when estimating cardinality during optimization";
-    static constexpr const char *InputType = "BOOLEAN";
-    static void SetLocal(ClientContext &context, const Value &parameter);
-    static void ResetLocal(ClientContext &context);
-    static Value GetSetting(const ClientContext &context);
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "inspect_range_filter";
+	static constexpr const char *Description = "Inspect ranges when estimating cardinality during optimization";
+	static constexpr const char *InputType = "BOOLEAN";
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ForceCompressionSetting {

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -690,6 +690,15 @@ struct ForceBitpackingModeSetting {
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
 };
+struct InspectRangeFilterSetting {
+    using RETURN_TYPE = bool;
+    static constexpr const char *Name = "inspect_range_filter";
+    static constexpr const char *Description = "Inspect ranges when estimating cardinality during optimization";
+    static constexpr const char *InputType = "BOOLEAN";
+    static void SetLocal(ClientContext &context, const Value &parameter);
+    static void ResetLocal(ClientContext &context);
+    static Value GetSetting(const ClientContext &context);
+};
 
 struct ForceCompressionSetting {
 	using RETURN_TYPE = string;

--- a/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
+++ b/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
@@ -46,7 +46,7 @@ public:
 
 public:
 	static idx_t InspectTableFilter(idx_t cardinality, idx_t column_index, TableFilter &filter,
-	                                BaseStatistics &base_stats);
+	                                BaseStatistics &base_stats, ClientContext &context);
 	//	static idx_t InspectConjunctionOR(idx_t cardinality, idx_t column_index, ConjunctionOrFilter &filter,
 	//	                                  BaseStatistics &base_stats);
 	//! Extract Statistics from a LogicalGet.

--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -123,7 +123,7 @@ public:
 		T new_value = new_v.GetValueUnsafe<T>();
 		D_ASSERT(GetStatsType() == StatisticsType::NUMERIC_STATS);
 		if (new_value <= stats_union.numeric_data.min.GetReferenceUnsafe<T>() ||
-			new_value >= stats_union.numeric_data.max.GetReferenceUnsafe<T>()) {
+		    new_value >= stats_union.numeric_data.max.GetReferenceUnsafe<T>()) {
 			return;
 		}
 		if (is_left) {

--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -118,6 +118,21 @@ public:
 		NumericStats::Update(stats_union.numeric_data, new_value);
 	}
 
+	template <class T>
+	void ReduceNumericStats(Value new_v, bool is_left) {
+		T new_value = new_v.GetValueUnsafe<T>();
+		D_ASSERT(GetStatsType() == StatisticsType::NUMERIC_STATS);
+		if (new_value <= stats_union.numeric_data.min.GetReferenceUnsafe<T>() ||
+			new_value >= stats_union.numeric_data.max.GetReferenceUnsafe<T>()) {
+			return;
+		}
+		if (is_left) {
+			stats_union.numeric_data.max.GetReferenceUnsafe<T>() = new_value;
+		} else {
+			stats_union.numeric_data.min.GetReferenceUnsafe<T>() = new_value;
+		}
+	}
+
 private:
 	BaseStatistics();
 	explicit BaseStatistics(LogicalType type);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -174,7 +174,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(ThreadsSetting),
     DUCKDB_GLOBAL(UsernameSetting),
     DUCKDB_GLOBAL(ZstdMinStringLengthSetting),
-	DUCKDB_LOCAL(InspectRangeFilterSetting),
+    DUCKDB_LOCAL(InspectRangeFilterSetting),
     FINAL_SETTING};
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 82),

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -174,6 +174,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(ThreadsSetting),
     DUCKDB_GLOBAL(UsernameSetting),
     DUCKDB_GLOBAL(ZstdMinStringLengthSetting),
+	DUCKDB_LOCAL(InspectRangeFilterSetting),
     FINAL_SETTING};
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 82),

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -402,7 +402,6 @@ Value ExternalThreadsSetting::GetSetting(const ClientContext &context) {
 	return Value::UBIGINT(config.options.external_threads);
 }
 
-//===----------------------------------------------------------------------===//
 // Home Directory
 //===----------------------------------------------------------------------===//
 void HomeDirectorySetting::ResetLocal(ClientContext &context) {
@@ -542,6 +541,23 @@ void ZstdMinStringLengthSetting::ResetGlobal(DatabaseInstance *db, DBConfig &con
 Value ZstdMinStringLengthSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::UBIGINT(config.options.zstd_min_string_length);
+}
+
+//===----------------------------------------------------------------------===//
+// Inspect Range Filter
+//===----------------------------------------------------------------------===//
+void InspectRangeFilterSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto &config = ClientConfig::GetConfig(context);
+	config.inspect_range_filter = input.GetValue<bool>();
+}
+
+void InspectRangeFilterSetting::ResetLocal(ClientContext &context) {
+	ClientConfig::GetConfig(context).inspect_range_filter = ClientConfig().inspect_range_filter;
+}
+
+Value InspectRangeFilterSetting::GetSetting(const ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	return Value::BOOLEAN(config.inspect_range_filter);
 }
 
 } // namespace duckdb

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -495,8 +495,9 @@ idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, idx_t colu
 	case TableFilterType::CONJUNCTION_AND: {
 		auto &and_filter = filter.Cast<ConjunctionAndFilter>();
 		for (auto &child_filter : and_filter.child_filters) {
-			cardinality_after_filters = MinValue(
-				cardinality_after_filters, InspectTableFilter(cardinality, column_index, *child_filter, base_stats, context));
+			cardinality_after_filters =
+			    MinValue(cardinality_after_filters,
+			             InspectTableFilter(cardinality, column_index, *child_filter, base_stats, context));
 		}
 		return cardinality_after_filters;
 	}
@@ -511,9 +512,9 @@ idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, idx_t colu
 				cardinality_after_filters = (cardinality + column_count - 1) / column_count;
 			}
 		} else if (ClientConfig::GetConfig(context).GetSetting<InspectRangeFilterSetting>(context) &&
-				(comparison_filter.comparison_type >= ExpressionType::COMPARE_LESSTHAN &&
-				comparison_filter.comparison_type <= ExpressionType::COMPARE_GREATERTHANOREQUALTO) &&
-				NumericStats::HasMinMax(base_stats)) {
+		           (comparison_filter.comparison_type >= ExpressionType::COMPARE_LESSTHAN &&
+		            comparison_filter.comparison_type <= ExpressionType::COMPARE_GREATERTHANOREQUALTO) &&
+		           NumericStats::HasMinMax(base_stats)) {
 			cardinality_after_filters = InspectTableFilterForRange(cardinality, base_stats, comparison_filter);
 		}
 		return cardinality_after_filters;

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/common/operator/numeric_binary_operators.hpp"
 
 #include <math.h>
 
@@ -113,7 +114,7 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 
 			if (column_statistics) {
 				idx_t cardinality_with_filter =
-				    InspectTableFilter(base_table_cardinality, it.first, *it.second, *column_statistics);
+				    InspectTableFilter(base_table_cardinality, it.first, *it.second, *column_statistics, context);
 				cardinality_after_filters = MinValue(cardinality_after_filters, cardinality_with_filter);
 			}
 
@@ -410,28 +411,110 @@ RelationStats RelationStatisticsHelper::ExtractEmptyResultStats(LogicalEmptyResu
 	return stats;
 }
 
+// Calculates cardinality for range filter and updates statistics for following filtering of the same column
+template <typename T>
+static idx_t InspectTableFilterForRangeForType(idx_t cardinality, BaseStatistics &stats, const Value min,
+                                               const Value max, const Value filter, ExpressionType comparison_type) {
+	idx_t return_cardinality = cardinality;
+
+	T min_val = min.GetValue<T>();
+	T max_val = max.GetValue<T>();
+	T filter_val = filter.GetValue<T>();
+	double selectivity = 0.0;
+	auto distinct_count = stats.GetDistinctCount();
+
+	bool is_less_than = (comparison_type == ExpressionType::COMPARE_LESSTHAN ||
+	                     comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO);
+	// Filter right on the border, get cardinality same with equal filter.
+	if ((filter == max && comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO) ||
+	    (filter == min && comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO)) {
+		if (distinct_count > 0) {
+			return_cardinality = (cardinality + distinct_count - 1) / distinct_count;
+		}
+	} else if (filter <= min) {
+		return_cardinality = is_less_than ? 0 : cardinality;
+	} else if (filter >= max) {
+		return_cardinality = !is_less_than ? 0 : cardinality;
+	} else {
+		// Calculate as range/(max-min)*cardinality
+		if (max_val == min_val) {
+			return_cardinality = 0;
+		} else if (is_less_than) {
+			selectivity = double(filter_val - min_val) / double(max_val - min_val);
+		} else {
+			selectivity = double(max_val - filter_val) / double(max_val - min_val);
+		}
+		auto lower_bound = distinct_count > 0 ? (cardinality + distinct_count - 1) / distinct_count : 1;
+
+		return_cardinality = std::max(lower_bound, idx_t((double(cardinality) * selectivity)));
+
+		// updates statistics for following filtering of the same column
+		stats.ReduceNumericStats<T>(filter, is_less_than);
+	}
+	return return_cardinality;
+}
+
+static idx_t InspectTableFilterForRange(idx_t cardinality, BaseStatistics &base_stats,
+                                        const ConstantFilter &comparison_filter) {
+	idx_t cardinality_after_filters = cardinality;
+	auto min_value = NumericStats::Min(base_stats);
+	auto max_value = NumericStats::Max(base_stats);
+
+	if (!min_value.IsNull() && !max_value.IsNull() && comparison_filter.constant.type() == min_value.type()) {
+		auto filter_value = comparison_filter.constant;
+
+		switch (filter_value.type().InternalType()) {
+		case PhysicalType::INT32: {
+			return InspectTableFilterForRangeForType<int32_t>(cardinality, base_stats, min_value, max_value,
+			                                                  filter_value, comparison_filter.comparison_type);
+		}
+		case PhysicalType::INT64: {
+			return InspectTableFilterForRangeForType<int64_t>(cardinality, base_stats, min_value, max_value,
+			                                                  filter_value, comparison_filter.comparison_type);
+		}
+		case PhysicalType::FLOAT: {
+			return InspectTableFilterForRangeForType<float>(cardinality, base_stats, min_value, max_value, filter_value,
+			                                                comparison_filter.comparison_type);
+		}
+		case PhysicalType::DOUBLE: {
+			return InspectTableFilterForRangeForType<double>(cardinality, base_stats, min_value, max_value,
+			                                                 filter_value, comparison_filter.comparison_type);
+		}
+		default:
+			// For other types, fall back to default selectivity
+			break;
+		}
+	}
+	return cardinality_after_filters;
+}
+
 idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, idx_t column_index, TableFilter &filter,
-                                                   BaseStatistics &base_stats) {
+                                                   BaseStatistics &base_stats, ClientContext &context) {
 	auto cardinality_after_filters = cardinality;
 	switch (filter.filter_type) {
 	case TableFilterType::CONJUNCTION_AND: {
 		auto &and_filter = filter.Cast<ConjunctionAndFilter>();
 		for (auto &child_filter : and_filter.child_filters) {
 			cardinality_after_filters = MinValue(
-			    cardinality_after_filters, InspectTableFilter(cardinality, column_index, *child_filter, base_stats));
+				cardinality_after_filters, InspectTableFilter(cardinality, column_index, *child_filter, base_stats, context));
 		}
 		return cardinality_after_filters;
 	}
 	case TableFilterType::CONSTANT_COMPARISON: {
 		auto &comparison_filter = filter.Cast<ConstantFilter>();
-		if (comparison_filter.comparison_type != ExpressionType::COMPARE_EQUAL) {
-			return cardinality_after_filters;
-		}
-		auto column_count = base_stats.GetDistinctCount();
-		// column_count = 0 when there is no column count (i.e parquet scans)
-		if (column_count > 0) {
-			// we want the ceil of cardinality/column_count. We also want to avoid compiler errors
-			cardinality_after_filters = (cardinality + column_count - 1) / column_count;
+
+		if (comparison_filter.comparison_type == ExpressionType::COMPARE_EQUAL) {
+			auto column_count = base_stats.GetDistinctCount();
+			// column_count = 0 when there is no column count (i.e parquet scans)
+			if (column_count > 0) {
+				// we want the ceil of cardinality/column_count. We also want to avoid compiler errors
+				cardinality_after_filters = (cardinality + column_count - 1) / column_count;
+			}
+		} else if (ClientConfig::GetConfig(context).GetSetting<InspectRangeFilterSetting>(context) &&
+				(comparison_filter.comparison_type >= ExpressionType::COMPARE_LESSTHAN &&
+				comparison_filter.comparison_type <= ExpressionType::COMPARE_GREATERTHANOREQUALTO) &&
+				NumericStats::HasMinMax(base_stats)) {
+			cardinality_after_filters = InspectTableFilterForRange(cardinality, base_stats, comparison_filter);
 		}
 		return cardinality_after_filters;
 	}

--- a/test/optimizer/support_cardinality_estimation_for_range.test
+++ b/test/optimizer/support_cardinality_estimation_for_range.test
@@ -1,0 +1,131 @@
+# name: test/optimizer/support_cardinality_estimation_for_range.test
+# description: test for cardinality estimation for range
+# group: [optimizer]
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+#### Prepare ###
+# table data range: [1000000, 2000000)
+# distinct value count: 1000000
+# rows count: 4000000
+
+statement ok
+CREATE TABLE t1 AS SELECT range a FROM range(1000000, 2000000);
+
+statement ok
+INSERT INTO t1 SELECT * FROM t1;
+
+statement ok
+INSERT INTO t1 SELECT * FROM t1;
+
+
+#### 1. Test when inspect_range_filter = true ###
+
+statement ok
+SET inspect_range_filter = true;
+
+# equal comparison
+query II
+explain SELECT * FROM t1 WHERE a = 1100000;
+----
+logical_opt	<REGEX>:.*~1. rows.*
+
+
+# on border
+query II
+explain SELECT * FROM t1 WHERE a <= 1000000;
+----
+logical_opt	<REGEX>:.*~1. rows.*
+
+query II
+explain SELECT * FROM t1 WHERE a >= 1999999;
+----
+logical_opt	<REGEX>:.*~1. rows.*
+
+# smaller than minimum
+query II
+explain SELECT * FROM t1 WHERE a < 1000000;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# bigger than maxisum
+query II
+explain SELECT * FROM t1 WHERE a >= 2000000;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# range size 3%
+query II
+explain SELECT * FROM t1 WHERE a > 1001000 AND a < 1004000;
+----
+logical_opt	<REGEX>:.*~12,... rows.*
+
+
+#### 2. Test when inspect_range_filter = false ###
+
+statement ok
+SET inspect_range_filter = false;
+
+# equal comparison
+query II
+explain SELECT * FROM t1 WHERE a = 1100000;
+----
+logical_opt	<REGEX>:.*~1. rows.*
+
+
+# on border
+query II
+explain SELECT * FROM t1 WHERE a <= 1000000;
+----
+logical_opt	<REGEX>:.*~8..,... rows.*
+
+query II
+explain SELECT * FROM t1 WHERE a >= 1999999;
+----
+logical_opt	<REGEX>:.*~8..,... rows.*
+
+# smaller than minimum
+query II
+explain SELECT * FROM t1 WHERE a < 1000000;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# bigger than maxisum
+query II
+explain SELECT * FROM t1 WHERE a >= 2000000;
+----
+logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# range size 3%
+query II
+explain SELECT * FROM t1 WHERE a > 1001000 AND a < 1004000;
+----
+logical_opt	<REGEX>:.*~8..,... rows.*
+
+
+#### 3. Test cardinality estimation when join ###
+statement ok
+DROP TABLE IF EXISTS t1;
+
+statement ok
+CREATE TABLE t1 AS SELECT range id1, range a FROM range(1000000, 2000000);
+
+statement ok
+CREATE TABLE t2 AS SELECT range id2, range a FROM range(1000000, 1100000);
+
+statement ok
+SET inspect_range_filter = false;
+
+query II
+explain SELECT * FROM t1, t2 WHERE t1.id1 = t2.id2 and t1.a > 1001000 AND t1.a < 1004000 and t2.a > 1000000 and t2.a < 1100000 ;
+----
+logical_opt	<REGEX>:.*COMPARISON_JOIN.*id1 = id2.*
+
+statement ok
+SET inspect_range_filter = true;
+
+query II
+explain SELECT * FROM t1, t2 WHERE t1.id1 = t2.id2 and t1.a > 1001000 AND t1.a < 1004000 and t2.a > 1000000 and t2.a < 1100000 ;
+----
+logical_opt	<REGEX>:.*COMPARISON_JOIN.*id2 = id1.*


### PR DESCRIPTION
DuckDB currently lacks a histogram-based cardinality estimation capability. 
When processing range filters, it simply uses a default ratio (0.2) to estimate the filtered cardinality, which is often insufficient.

This cardinality estimation error often occurs when using timestamp column for range queries and may affect the choice of join order.

I really hope that duckdb can launch histogram estimation capabilities as soon as possible

Here, I've implemented a simple mean estimation method, using range_size / (max - min) as the coefficient.