### PR TITLE
Fix format-fix runs on Linux

### DIFF
--- a/scripts/format.py
+++ b/scripts/format.py
@@ -13,6 +13,8 @@ import tempfile
 import uuid
 import concurrent.futures
 import argparse
+import shutil
+import traceback
 from python_helpers import open_utf8
 
 try:
@@ -380,7 +382,7 @@ def format_file(f, full_path, directory, ext):
         tmpfile = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
         with open_utf8(tmpfile, 'w+') as f:
             f.write(new_text)
-        os.rename(tmpfile, full_path)
+        shutil.move(tmpfile, full_path)
 
 
 class ToFormatFile:
@@ -427,7 +429,11 @@ else:
 def process_file(f):
     if not silent:
         print(f.full_path)
-    format_file(f.filename, f.full_path, f.directory, f.ext)
+    try:
+        format_file(f.filename, f.full_path, f.directory, f.ext)
+    except:
+        print(traceback.format_exc())
+        sys.exit(1)
 
 
 # Create thread for each file


### PR DESCRIPTION
I was having troubles with the mainline `format.py` script. `make format-fix` was printing file paths, but did not do any actual formatting.

JDBC and ODBC Scanner formatting, that use the same `clang_format 11.0.1` but another version of `format.py` (simpistic, non-parallel one), were working fine at the same time.

Found the problem with `format.py` runs when `os.rename()` call was failing with the following exception, that was not printed/reported, because it was thrown from background threads:

```python
Traceback (most recent call last):
  File "/home/alex/projects/duck/duckdb-mysql/./duckdb/scripts/format.py", line 434, in <module>
    format_file(f.filename, f.full_path, f.directory, f.ext)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/projects/duck/duckdb-mysql/./duckdb/scripts/format.py", line 383, in format_file
    os.rename(tmpfile, full_path)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 18] Invalid cross-device link: '/tmp/726068ed-7cdf-4917-bf4d-374fae67b1f1' -> '/home/alex/projects/duck/duckdb-mysql/src/mysql_utils.cpp'
```

It appeared that `os.rename()` is not robust enough and changing it to `shutil.move()` (that is doing copy+delete) helped to fix this. Additonally added printing of the background errors to stdout.