### PR TITLE
Extensions.yml: Pass down save_cache to inner workflows

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -142,6 +142,7 @@ jobs:
       override_tag: ${{ inputs.override_git_describe }}
       duckdb_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests && true || false }}
+      save_cache: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
 
   # Build the extensions from .github/config/rust_based_extensions.cmake
   rust-based-extensions:
@@ -157,6 +158,7 @@ jobs:
       override_tag: ${{ inputs.override_git_describe }}
       duckdb_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests && true || false }}
+      save_cache: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
 
   # Merge all extensions into a single, versioned repository
   create-extension-repository:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -28,6 +28,10 @@ on:
         required: false
         type: boolean
         default: false
+      save_cache:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -58,7 +62,7 @@ jobs:
       duckdb_tag: ${{ inputs.override_tag }}
 
       skip_tests: ${{ inputs.skip_tests }}
-      save_cache: true
+      save_cache: ${{ inputs.save_cache }}
 
       # The extension_config.cmake configuration that gets built
       extra_extension_config: ${{ inputs.extension_config }}


### PR DESCRIPTION
This should [dis]allow polluting the cache unnecessarily

I think this should work, but let's see.