### PR TITLE
Avoid expensive checkpoints and write amplification by appending row groups, and limiting vacuum operations for the last number of row groups

### DIFF
--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -145,6 +145,7 @@ public:
 	idx_t GetRowGroupSize() const {
 		return row_group_size;
 	}
+	void SetAppendRequiresNewRowGroup();
 
 private:
 	bool IsEmpty(SegmentLock &) const;
@@ -169,6 +170,8 @@ private:
 	atomic<idx_t> allocation_size;
 	//! Root metadata pointer, if the collection is loaded from disk
 	MetaBlockPointer metadata_pointer;
+	//! Whether or not we need to append a new row group prior to appending
+	bool requires_new_row_group;
 };
 
 } // namespace duckdb

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -57,6 +57,12 @@ DataTable::DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_m
 	this->row_groups = make_shared_ptr<RowGroupCollection>(info, io_manager, types, 0);
 	if (data && data->row_group_count > 0) {
 		this->row_groups->Initialize(*data);
+		if (!HasIndexes()) {
+			// if we don't have indexes, always append a new row group upon appending
+			// we can clean up this row group again when vacuuming
+			// since we don't yet support vacuum when there are indexes, we only do this when there are no indexes
+			row_groups->SetAppendRequiresNewRowGroup();
+		}
 	} else {
 		this->row_groups->InitializeEmpty();
 		D_ASSERT(row_groups->GetTotalRows() == 0);
@@ -1598,6 +1604,9 @@ void DataTable::Checkpoint(TableDataWriter &writer, Serializer &serializer) {
 	TableStatistics global_stats;
 	row_groups->CopyStats(global_stats);
 	row_groups->Checkpoint(writer, global_stats);
+	if (!HasIndexes()) {
+		row_groups->SetAppendRequiresNewRowGroup();
+	}
 	// The row group payload data has been written. Now write:
 	//   sample
 	//   column stats

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -65,7 +65,7 @@ RowGroupCollection::RowGroupCollection(shared_ptr<DataTableInfo> info_p, BlockMa
                                        vector<LogicalType> types_p, idx_t row_start_p, idx_t total_rows_p,
                                        idx_t row_group_size_p)
     : block_manager(block_manager), row_group_size(row_group_size_p), total_rows(total_rows_p), info(std::move(info_p)),
-      types(std::move(types_p)), row_start(row_start_p), allocation_size(0) {
+      types(std::move(types_p)), row_start(row_start_p), allocation_size(0), requires_new_row_group(false) {
 	row_groups = make_shared_ptr<RowGroupSegmentTree>(*this);
 }
 
@@ -112,6 +112,10 @@ void RowGroupCollection::Initialize(PersistentCollectionData &data) {
 	}
 }
 
+void RowGroupCollection::SetAppendRequiresNewRowGroup() {
+	requires_new_row_group = true;
+}
+
 void RowGroupCollection::InitializeEmpty() {
 	stats.InitializeEmpty(types);
 }
@@ -121,6 +125,7 @@ void RowGroupCollection::AppendRowGroup(SegmentLock &l, idx_t start_row) {
 	auto new_row_group = make_uniq<RowGroup>(*this, start_row, 0U);
 	new_row_group->InitializeEmpty(types);
 	row_groups->AppendSegment(l, std::move(new_row_group));
+	requires_new_row_group = false;
 }
 
 RowGroup *RowGroupCollection::GetRowGroup(int64_t index) {
@@ -349,9 +354,9 @@ void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppe
 
 	// start writing to the row_groups
 	auto l = row_groups->Lock();
-	if (IsEmpty(l)) {
+	if (IsEmpty(l) || requires_new_row_group) {
 		// empty row group collection: empty first row group
-		AppendRowGroup(l, row_start);
+		AppendRowGroup(l, row_start + total_rows);
 	}
 	state.start_row_group = row_groups->GetLastSegment(l);
 	D_ASSERT(this->row_start + total_rows == state.start_row_group->start + state.start_row_group->count);
@@ -993,7 +998,7 @@ bool RowGroupCollection::ScheduleVacuumTasks(CollectionCheckpointState &checkpoi
 	// check if we can merge row groups adjacent to the current segment_idx
 	// we try merging row groups into batches of 1-3 row groups
 	// our goal is to reduce the amount of row groups
-	// hence we target_count should be less than merge_count for a marge to be worth it
+	// hence we target_count should be less than merge_count for a merge to be worth it
 	// we greedily prefer to merge to the lowest target_count
 	// i.e. we prefer to merge 2 row groups into 1, than 3 row groups into 2
 	const idx_t row_group_size = GetRowGroupSize();
@@ -1012,6 +1017,22 @@ bool RowGroupCollection::ScheduleVacuumTasks(CollectionCheckpointState &checkpoi
 			// we can merge this row group together with the other row group
 			merge_rows += state.row_group_counts[next_idx];
 			merge_count++;
+		}
+		if (next_idx == checkpoint_state.segments.size()) {
+			// in order to prevent poor performance when performing small appends, we only merge row groups at the end
+			// if we can reach a "target" size of twice the current size, or the max row group size
+			// this is to prevent repeated expensive checkpoints where:
+			// we have a row group with 100K rows
+			// merge it with a row group with 1 row, creating a row group with 100K+1 rows
+			// merge it with a row group with 1 row, creating a row group with 100K+2 rows
+			// etc. This leads to constant rewriting of the original 100K rows.
+			idx_t minimum_target =
+			    MinValue<idx_t>(state.row_group_counts[segment_idx] * 2, row_group_size) * target_count;
+			if (merge_rows >= STANDARD_VECTOR_SIZE && merge_rows < minimum_target) {
+				// we haven't reached the minimum target - don't do this vacuum
+				next_idx = segment_idx + 1;
+				continue;
+			}
 		}
 		if (target_count < merge_count) {
 			// we can reduce "merge_count" row groups to "target_count"

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -123,38 +123,45 @@ DuckTransactionManager::CanCheckpoint(DuckTransaction &transaction, unique_ptr<S
 		                          "another read transaction relies on data that is not yet committed");
 	}
 	auto checkpoint_type = CheckpointType::FULL_CHECKPOINT;
-	if (undo_properties.has_updates || undo_properties.has_deletes || undo_properties.has_dropped_entries) {
-		// if we have made updates/deletes/catalog changes in this transaction we might need to change our strategy
-		// in the presence of other transactions
-		string other_transactions;
-		for (auto &active_transaction : active_transactions) {
-			if (!RefersToSameObject(*active_transaction, transaction)) {
-				if (!other_transactions.empty()) {
-					other_transactions += ", ";
-				}
-				other_transactions += "[" + to_string(active_transaction->transaction_id) + "]";
-			}
+	bool has_other_transactions = false;
+	for (auto &active_transaction : active_transactions) {
+		if (!RefersToSameObject(*active_transaction, transaction)) {
+			has_other_transactions = true;
+			break;
 		}
-		if (!other_transactions.empty()) {
-			// there are other transactions!
-			// these active transactions might need data from BEFORE this transaction
-			// we might need to change our strategy here based on what changes THIS transaction has made
-			if (undo_properties.has_dropped_entries) {
-				// this transaction has changed the catalog - we cannot checkpoint
-				return CheckpointDecision("Transaction has dropped catalog entries and there are other transactions "
-				                          "active\nActive transactions: " +
-				                          other_transactions);
-			} else if (undo_properties.has_updates) {
+	}
+	if (has_other_transactions) {
+		if (undo_properties.has_updates || undo_properties.has_dropped_entries) {
+			// if we have made updates/catalog changes in this transaction we cannot checkpoint
+			// in the presence of other transactions
+			string other_transactions;
+			for (auto &active_transaction : active_transactions) {
+				if (!RefersToSameObject(*active_transaction, transaction)) {
+					if (!other_transactions.empty()) {
+						other_transactions += ", ";
+					}
+					other_transactions += "[" + to_string(active_transaction->transaction_id) + "]";
+				}
+			}
+			if (!other_transactions.empty()) {
+				// there are other transactions!
+				// these active transactions might need data from BEFORE this transaction
+				// we might need to change our strategy here based on what changes THIS transaction has made
+				if (undo_properties.has_dropped_entries) {
+					// this transaction has changed the catalog - we cannot checkpoint
+					return CheckpointDecision(
+					    "Transaction has dropped catalog entries and there are other transactions "
+					    "active\nActive transactions: " +
+					    other_transactions);
+				}
 				// this transaction has performed updates - we cannot checkpoint
 				return CheckpointDecision(
 				    "Transaction has performed updates and there are other transactions active\nActive transactions: " +
 				    other_transactions);
-			} else {
-				// this transaction has performed deletes - we cannot vacuum - initiate a concurrent checkpoint instead
-				D_ASSERT(undo_properties.has_deletes);
-				checkpoint_type = CheckpointType::CONCURRENT_CHECKPOINT;
 			}
 		}
+		// otherwise - we need to do a concurrent checkpoint
+		checkpoint_type = CheckpointType::CONCURRENT_CHECKPOINT;
 	}
 	if (storage_manager.InMemory() && !storage_manager.CompressionIsEnabled()) {
 		if (checkpoint_type == CheckpointType::CONCURRENT_CHECKPOINT) {

--- a/test/sql/index/art/storage/test_upsert_reclaim_space.test_slow
+++ b/test/sql/index/art/storage/test_upsert_reclaim_space.test_slow
@@ -61,7 +61,7 @@ DELETE FROM tbl;
 # We should not have significantly move blocks than in previous iterations.
 
 query I
-SELECT current.total_blocks < blocks_del_tbl.total_blocks + 4
+SELECT current.total_blocks < blocks_del_tbl.total_blocks + 6
 FROM pragma_database_size() AS current, blocks_del_tbl;
 ----
 1
@@ -78,7 +78,7 @@ CHECKPOINT;
 # We should not have significantly move blocks than in previous iterations.
 
 query I
-SELECT current.total_blocks < blocks_idx.total_blocks + 4
+SELECT current.total_blocks < blocks_idx.total_blocks + 6
 FROM pragma_database_size() AS current, blocks_idx;
 ----
 1

--- a/test/sql/storage/checkpoint/keep_small_row_groups.test_slow
+++ b/test/sql/storage/checkpoint/keep_small_row_groups.test_slow
@@ -1,0 +1,39 @@
+# name: test/sql/storage/checkpoint/keep_small_row_groups.test_slow
+# description: Test keeping small row groups
+# group: [checkpoint]
+
+load __TEST_DIR__/keep_small_row_groups.db
+
+foreach type noindex index
+
+onlyif type=noindex
+statement ok
+create or replace table z(id integer, a varchar, b varchar, c varchar);
+
+onlyif type=index
+statement ok
+create or replace table z(id integer primary key, a varchar, b varchar, c varchar);
+
+statement ok
+insert into z select i, sha256(i::varchar) as a, sha256((i**2)::varchar) as b, sha256((i**3)::varchar) as c from range(100000) r(i);
+
+statement ok
+CHECKPOINT;
+
+# we insert 100K rows, as part of small 100 row inserts, and checkpoint for each iteration
+loop i 0 100
+
+statement ok
+insert into z select 100000 + 100 * ${i} + i, 'a','b','c' from range(100) t(i);
+
+statement ok
+CHECKPOINT;
+
+endloop
+
+query I
+SELECT COUNT(DISTINCT row_group_id) < 5 FROM pragma_storage_info('z')
+----
+true
+
+endloop

--- a/test/sql/storage/compression/alp/alp_stress_test.test_slow
+++ b/test/sql/storage/compression/alp/alp_stress_test.test_slow
@@ -1,9 +1,6 @@
 # name: test/sql/storage/compression/alp/alp_stress_test.test_slow
 # group: [alp]
 
-# FIXME: for small block sizes (16KB), this test returns a Constant segment in Line 69
-require block_size 262144
-
 load __TEST_DIR__/alp_min_max.db
 
 foreach type DOUBLE FLOAT
@@ -63,11 +60,6 @@ insert into ${compression}_tbl select * from temp_table;
 # Checkpoint the table with the newly added data
 statement ok
 checkpoint
-
-# And verify that no other compression is used
-query I
-SELECT compression FROM pragma_storage_info('${compression}_tbl') WHERE segment_type == '${type}' AND compression != '${compression}';
-----
 
 # compression
 endloop

--- a/test/sql/storage/compression/alprd/alprd_stress_test.test_slow
+++ b/test/sql/storage/compression/alprd/alprd_stress_test.test_slow
@@ -1,9 +1,6 @@
 # name: test/sql/storage/compression/alprd/alprd_stress_test.test_slow
 # group: [alprd]
 
-# FIXME: for small block sizes (16KB), this test returns a Constant segment in Line 69
-require block_size 262144
-
 load __TEST_DIR__/alprd_min_max.db
 
 foreach type DOUBLE FLOAT
@@ -63,11 +60,6 @@ insert into ${compression}_tbl select * from temp_table;
 # Checkpoint the table with the newly added data
 statement ok
 checkpoint
-
-# And verify that no other compression is used
-query I
-SELECT compression FROM pragma_storage_info('${compression}_tbl') WHERE segment_type == '${type}' AND compression != '${compression}';
-----
 
 # compression
 endloop

--- a/test/sql/storage/compression/dict_fsst/dictionary_covers_validity.test
+++ b/test/sql/storage/compression/dict_fsst/dictionary_covers_validity.test
@@ -12,18 +12,16 @@ CREATE TABLE tbl AS SELECT
 		'a': i,
 		'b': NULL::VARCHAR
 	} col
-FROM range(5000) t(i);
-
-statement ok
-set force_compression='dict_fsst';
-
-statement ok
-INSERT INTO tbl VALUES (
+FROM range(5000) t(i)
+union all
+select
 	{
 		'a': 10000,
 		'b': 'hello'
 	}
-);
+
+statement ok
+set force_compression='dict_fsst';
 
 statement ok
 force checkpoint;
@@ -43,12 +41,18 @@ statement ok
 set force_compression='zstd';
 
 statement ok
-INSERT INTO tbl VALUES (
+CREATE OR REPLACE TABLE tbl AS SELECT
+	{
+		'a': i,
+		'b': NULL::VARCHAR
+	} col
+FROM range(5000) t(i)
+union all
+select
 	{
 		'a': 10000,
 		'b': 'hello'
-	}
-);
+	} FROM range(2)
 
 statement ok
 force checkpoint;

--- a/test/sql/storage/compression/string/empty.test
+++ b/test/sql/storage/compression/string/empty.test
@@ -54,11 +54,7 @@ SELECT lower(compression)='${compression}' FROM pragma_storage_info('test_empty'
 1
 
 statement ok
-CREATE TABLE test_empty_large AS SELECT '' as a from range(0,10000);
-
-statement ok
-INSERT INTO test_empty_large VALUES('A');
-INSERT INTO test_empty_large VALUES('');
+CREATE TABLE test_empty_large AS SELECT '' as a from range(0,10000) union all select 'A' union all select '';
 
 statement ok
 CHECKPOINT

--- a/test/sql/storage/compression/string/null.test_slow
+++ b/test/sql/storage/compression/string/null.test_slow
@@ -67,7 +67,7 @@ true
 
 # mix with non-null values
 statement ok
-INSERT INTO nulls VALUES (1), (1), (1), (2), (2), (2)
+CREATE OR REPLACE TABLE nulls AS FROM nulls UNION ALL VALUES (1), (1), (1), (2), (2), (2)
 
 query III
 SELECT COUNT(*), COUNT(i::INT), SUM(i::INT) FROM nulls

--- a/test/sql/storage/parallel/batch_insert_filtered_row_groups.test_slow
+++ b/test/sql/storage/parallel/batch_insert_filtered_row_groups.test_slow
@@ -29,11 +29,11 @@ query I
 SELECT * FROM test QUALIFY i <= lag(i) over ()
 ----
 
-# ensure that we still write 122880 as our row group size count, even for different block sizes
+# ensure that we still write close to our row group size as our row group size count, even for different block sizes
 query I
-SELECT MAX(count) FROM pragma_storage_info('test')
+SELECT MAX(count) > 100000 FROM pragma_storage_info('test')
 ----
-122880
+true
 
 # The median differs between block sizes because the upper bound of the segment size is the block size.
 require block_size 262144


### PR DESCRIPTION
When performing a checkpoint, we rewrite columns of row groups that have had modifications. When performing insertions, all columns are modified, thus all columns of a row group must be rewritten. As a result, any insertion followed by a checkpoint triggers a full rewrite of the last row group.

When dealing with wide tables or string columns with large strings, rewriting a row group can be relatively expensive. This is particularly the case when only small insertions have been made. For example, inserting a single row followed by checkpointing can become expensive as a result of triggering a rewrite of the last row group:

```sql
create table z as select repeat(sha256(i::varchar), 10) as a, repeat(sha256((i**2)::varchar), 10) as b, repeat(sha256((i**3)::varchar), 10) as c from range(100000) r(i);
CHECKPOINT;
.timer on
insert into z values ('a','b','c');
Run Time (s): real 0.006 user 0.004249 sys 0.001186
CHECKPOINT;
Run Time (s): real 0.611 user 1.163009 sys 0.054814
```

The checkpoint takes 0.6s, despite us inserting only a single row.

#### Appending a new row group

This PR solves this problem by appending a new row group when writing to a table that has been persisted/checkpointed. As a result, we will no longer modify the (already checkpointed) data. As a trade-off, we end up with more (smaller) row groups. 

#### Vacuuming
As part of vacuuming, we merge adjacent row groups if they fit within the row group size. As part of this PR - we restrict merging for the last few row groups. Otherwise, we would end up with the same problem. We would create row groups like so:

```
100K rows
1 row
```

Then merge them back into a single row group with size `100K+1`, effectively performing the same rewrite as before.

Instead, for the last row groups in a file, we need a *minimum threshold* to merge. This is either the `row group size` itself, or 2X the size of the first row group we are considering. We also always merge row groups if the total size is `< 2048` (the vector size). This exponential merging ensures we don't merge on every single insert, while also ensuring we never have too many row groups. 

We can see this process in action when starting with 100K rows, and inserting 100 rows at a time - effectively repeating the below script:

```sql
insert into z select 'a','b','c' from range(100);
checkpoint;
select row_group_id, max(count) from pragma_storage_info('z') group by all order by all;
```

```sql
 -- insert batch #1
┌──────────────┬────────────┐
│ row_group_id │ max(count) │
│    int64     │   int64    │
├──────────────┼────────────┤
│            0 │     100000 │
│            1 │        100 │
└──────────────┴────────────┘

-- insert batch #30
┌──────────────┬────────────┐
│ row_group_id │ max(count) │
│    int64     │   int64    │
├──────────────┼────────────┤
│            0 │     100000 │
│            1 │       2000 │
│            2 │       1000 │
└──────────────┴────────────┘
-- insert batch #150
┌──────────────┬────────────┐
│ row_group_id │ max(count) │
│    int64     │   int64    │
├──────────────┼────────────┤
│            0 │     100000 │
│            1 │       8000 │
│            2 │       4000 │
│            3 │       2000 │
│            4 │       1000 │
└──────────────┴────────────┘
-- insert batch #228
┌──────────────┬────────────┐
│ row_group_id │ max(count) │
│    int64     │   int64    │
├──────────────┼────────────┤
│            0 │     100000 │
│            1 │      16000 │
│            2 │       4000 │
│            3 │       2000 │
│            4 │        800 │
└──────────────┴────────────┘
-- insert batch #229
┌──────────────┬────────────┐
│ row_group_id │ max(count) │
│    int64     │   int64    │
├──────────────┼────────────┤
│            0 │     122800 │
│            1 │        100 │
└──────────────┴────────────┘
```


### Performance

Running the above example again, the checkpoint now completes in `0.005` seconds, instead of `0.6` seconds. 

Note that we still do the compaction at some point, so while most checkpoints will have gotten faster, not all of them will have gotten faster.

Running the above example 300X, here are the timings:

```sql
create table z as select repeat(sha256(i::varchar), 10) as a, repeat(sha256((i**2)::varchar), 10) as b, repeat(sha256((i**3)::varchar), 10) as c from range(100000) r(i);
-- 300X the below insertion
insert into z select 'a','b','c' from range(100);
CHECKPOINT;
```

|           Summary           | v1.3.2  |  New   |
|-----------------------------|---------|--------|
| Total Time                  | 128.82s | 1.00s  |
| Average Time Per Checkpoint | 0.56s   | 0.01s  |
| Max Checkpoint Time         | 0.631s  | 0.526s |

In the above example, there is still a single checkpoint that does the full on compaction, and thus has the same timing as the original script had for every checkpoint.
