### PR TITLE
Add support for reading/writing native parquet geometry types

### DIFF
--- a/extension/parquet/geo_parquet.cpp
+++ b/extension/parquet/geo_parquet.cpp
@@ -448,16 +448,11 @@ unique_ptr<ColumnReader> GeoParquetFileMetadata::CreateColumnReader(ParquetReade
                                                                     const ParquetColumnSchema &schema,
                                                                     ClientContext &context) {
 
-	D_ASSERT(IsGeometryColumn(schema.name));
-
-	const auto &column = geometry_columns[schema.name];
-
 	// Get the catalog
 	auto &catalog = Catalog::GetSystemCatalog(context);
 
 	// WKB encoding
-	if (schema.children[0].type.id() == LogicalTypeId::BLOB &&
-	    column.geometry_encoding == GeoParquetColumnEncoding::WKB) {
+	if (schema.children[0].type.id() == LogicalTypeId::BLOB) {
 		// Look for a conversion function in the catalog
 		auto &conversion_func_set =
 		    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "st_geomfromwkb");

--- a/extension/parquet/geo_parquet.cpp
+++ b/extension/parquet/geo_parquet.cpp
@@ -16,155 +16,168 @@ namespace duckdb {
 
 using namespace duckdb_yyjson; // NOLINT
 
-const char *WKBGeometryTypes::ToString(WKBGeometryType type) {
-	switch (type) {
-	case WKBGeometryType::POINT:
-		return "Point";
-	case WKBGeometryType::LINESTRING:
-		return "LineString";
-	case WKBGeometryType::POLYGON:
-		return "Polygon";
-	case WKBGeometryType::MULTIPOINT:
-		return "MultiPoint";
-	case WKBGeometryType::MULTILINESTRING:
-		return "MultiLineString";
-	case WKBGeometryType::MULTIPOLYGON:
-		return "MultiPolygon";
-	case WKBGeometryType::GEOMETRYCOLLECTION:
-		return "GeometryCollection";
-	case WKBGeometryType::POINT_Z:
-		return "Point Z";
-	case WKBGeometryType::LINESTRING_Z:
-		return "LineString Z";
-	case WKBGeometryType::POLYGON_Z:
-		return "Polygon Z";
-	case WKBGeometryType::MULTIPOINT_Z:
-		return "MultiPoint Z";
-	case WKBGeometryType::MULTILINESTRING_Z:
-		return "MultiLineString Z";
-	case WKBGeometryType::MULTIPOLYGON_Z:
-		return "MultiPolygon Z";
-	case WKBGeometryType::GEOMETRYCOLLECTION_Z:
-		return "GeometryCollection Z";
+//------------------------------------------------------------------------------
+// WKB stats
+//------------------------------------------------------------------------------
+namespace {
+
+class BinaryReader {
+public:
+	const char *beg;
+	const char *end;
+	const char *ptr;
+
+	BinaryReader(const char *beg, uint32_t len) : beg(beg), end(beg + len), ptr(beg) {
+	}
+
+	template <class T>
+	T Read() {
+		if (ptr + sizeof(T) > end) {
+			throw InvalidInputException("Unexpected end of WKB data");
+		}
+		T val;
+		memcpy(&val, ptr, sizeof(T));
+		ptr += sizeof(T);
+		return val;
+	}
+
+	void Skip(idx_t len) {
+		if (ptr + len > end) {
+			throw InvalidInputException("Unexpected end of WKB data");
+		}
+		ptr += len;
+	}
+
+	const char *Reserve(idx_t len) {
+		if (ptr + len > end) {
+			throw InvalidInputException("Unexpected end of WKB data");
+		}
+		auto ret = ptr;
+		ptr += len;
+		return ret;
+	}
+
+	bool IsAtEnd() const {
+		return ptr >= end;
+	}
+};
+
+} // namespace
+
+static void UpdateBoundsFromVertexArray(GeometryExtent &bbox, uint32_t flag, const char *vert_array,
+                                        uint32_t vert_count) {
+	switch (flag) {
+	case 0: { // XY
+		constexpr auto vert_width = sizeof(double) * 2;
+		for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
+			double vert[2];
+			memcpy(vert, vert_array + vert_idx * vert_width, vert_width);
+			bbox.ExtendX(vert[0]);
+			bbox.ExtendY(vert[1]);
+		}
+	} break;
+	case 1: { // XYZ
+		constexpr auto vert_width = sizeof(double) * 3;
+		for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
+			double vert[3];
+			memcpy(vert, vert_array + vert_idx * vert_width, vert_width);
+			bbox.ExtendX(vert[0]);
+			bbox.ExtendY(vert[1]);
+			bbox.ExtendZ(vert[2]);
+		}
+	} break;
+	case 2: { // XYM
+		constexpr auto vert_width = sizeof(double) * 3;
+		for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
+			double vert[3];
+			memcpy(vert, vert_array + vert_idx * vert_width, vert_width);
+			bbox.ExtendX(vert[0]);
+			bbox.ExtendY(vert[1]);
+			bbox.ExtendM(vert[2]);
+		}
+	} break;
+	case 3: { // XYZM
+		constexpr auto vert_width = sizeof(double) * 4;
+		for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
+			double vert[4];
+			memcpy(vert, vert_array + vert_idx * vert_width, vert_width);
+			bbox.ExtendX(vert[0]);
+			bbox.ExtendY(vert[1]);
+			bbox.ExtendZ(vert[2]);
+			bbox.ExtendM(vert[3]);
+		}
+	} break;
 	default:
-		throw NotImplementedException("Unsupported geometry type");
+		break;
 	}
 }
 
-//------------------------------------------------------------------------------
-// GeoParquetColumnMetadataWriter
-//------------------------------------------------------------------------------
-GeoParquetColumnMetadataWriter::GeoParquetColumnMetadataWriter(ClientContext &context) {
-	executor = make_uniq<ExpressionExecutor>(context);
+void GeometryStats::Update(const string_t &wkb) {
+	BinaryReader reader(wkb.GetData(), wkb.GetSize());
 
-	auto &catalog = Catalog::GetSystemCatalog(context);
+	bool first_geom = true;
+	while (!reader.IsAtEnd()) {
+		reader.Read<uint8_t>(); // byte order
+		auto type = reader.Read<uint32_t>();
+		auto kind = type % 1000;
+		auto flag = type / 1000;
+		const auto hasz = (flag & 0x01) != 0;
+		const auto hasm = (flag & 0x02) != 0;
 
-	// These functions are required to extract the geometry type, ZM flag and bounding box from a WKB blob
-	auto &type_func_set = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "st_geometrytype");
-	auto &flag_func_set = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "st_zmflag");
-	auto &bbox_func_set = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "st_extent");
-
-	auto wkb_type = LogicalType(LogicalTypeId::BLOB);
-	wkb_type.SetAlias("WKB_BLOB");
-
-	auto type_func = type_func_set.functions.GetFunctionByArguments(context, {wkb_type});
-	auto flag_func = flag_func_set.functions.GetFunctionByArguments(context, {wkb_type});
-	auto bbox_func = bbox_func_set.functions.GetFunctionByArguments(context, {wkb_type});
-
-	auto type_type = LogicalType::UTINYINT;
-	auto flag_type = flag_func.return_type;
-	auto bbox_type = bbox_func.return_type;
-
-	vector<unique_ptr<Expression>> type_args;
-	type_args.push_back(make_uniq<BoundReferenceExpression>(wkb_type, 0));
-
-	vector<unique_ptr<Expression>> flag_args;
-	flag_args.push_back(make_uniq<BoundReferenceExpression>(wkb_type, 0));
-
-	vector<unique_ptr<Expression>> bbox_args;
-	bbox_args.push_back(make_uniq<BoundReferenceExpression>(wkb_type, 0));
-
-	type_expr = make_uniq<BoundFunctionExpression>(type_type, type_func, std::move(type_args), nullptr);
-	flag_expr = make_uniq<BoundFunctionExpression>(flag_type, flag_func, std::move(flag_args), nullptr);
-	bbox_expr = make_uniq<BoundFunctionExpression>(bbox_type, bbox_func, std::move(bbox_args), nullptr);
-
-	// Add the expressions to the executor
-	executor->AddExpression(*type_expr);
-	executor->AddExpression(*flag_expr);
-	executor->AddExpression(*bbox_expr);
-
-	// Initialize the input and result chunks
-	// The input chunk should be empty, as we always reference the input vector
-	input_chunk.InitializeEmpty({wkb_type});
-	result_chunk.Initialize(BufferAllocator::Get(context), {type_type, flag_type, bbox_type});
-}
-
-void GeoParquetColumnMetadataWriter::Update(GeoParquetColumnMetadata &meta, Vector &vector, idx_t count) {
-	input_chunk.Reset();
-	result_chunk.Reset();
-
-	// Reference the vector
-	input_chunk.data[0].Reference(vector);
-	input_chunk.SetCardinality(count);
-
-	// Execute the expression
-	executor->Execute(input_chunk, result_chunk);
-
-	// The first column is the geometry type
-	// The second column is the zm flag
-	// The third column is the bounding box
-
-	UnifiedVectorFormat type_format;
-	UnifiedVectorFormat flag_format;
-	UnifiedVectorFormat bbox_format;
-
-	result_chunk.data[0].ToUnifiedFormat(count, type_format);
-	result_chunk.data[1].ToUnifiedFormat(count, flag_format);
-	result_chunk.data[2].ToUnifiedFormat(count, bbox_format);
-
-	const auto &bbox_components = StructVector::GetEntries(result_chunk.data[2]);
-	D_ASSERT(bbox_components.size() == 4);
-
-	UnifiedVectorFormat xmin_format;
-	UnifiedVectorFormat ymin_format;
-	UnifiedVectorFormat xmax_format;
-	UnifiedVectorFormat ymax_format;
-
-	bbox_components[0]->ToUnifiedFormat(count, xmin_format);
-	bbox_components[1]->ToUnifiedFormat(count, ymin_format);
-	bbox_components[2]->ToUnifiedFormat(count, xmax_format);
-	bbox_components[3]->ToUnifiedFormat(count, ymax_format);
-
-	for (idx_t in_idx = 0; in_idx < count; in_idx++) {
-		const auto type_idx = type_format.sel->get_index(in_idx);
-		const auto flag_idx = flag_format.sel->get_index(in_idx);
-		const auto bbox_idx = bbox_format.sel->get_index(in_idx);
-
-		const auto type_valid = type_format.validity.RowIsValid(type_idx);
-		const auto flag_valid = flag_format.validity.RowIsValid(flag_idx);
-		const auto bbox_valid = bbox_format.validity.RowIsValid(bbox_idx);
-
-		if (!type_valid || !flag_valid || !bbox_valid) {
-			continue;
+		if (first_geom) {
+			// Only add the top-level geometry type
+			types.Add(type);
+			first_geom = false;
 		}
 
-		// Update the geometry type
-		const auto flag = UnifiedVectorFormat::GetData<uint8_t>(flag_format)[flag_idx];
-		const auto type = UnifiedVectorFormat::GetData<uint8_t>(type_format)[type_idx];
-		if (flag == 1 || flag == 3) {
-			// M or ZM
-			throw InvalidInputException("Geoparquet does not support geometries with M coordinates");
-		}
-		const auto has_z = flag == 2;
-		auto wkb_type = static_cast<WKBGeometryType>((type + 1) + (has_z ? 1000 : 0));
-		meta.geometry_types.insert(wkb_type);
+		const auto vert_width = sizeof(double) * (2 + (hasz ? 1 : 0) + (hasm ? 1 : 0));
 
-		// Update the bounding box
-		const auto min_x = UnifiedVectorFormat::GetData<double>(xmin_format)[bbox_idx];
-		const auto min_y = UnifiedVectorFormat::GetData<double>(ymin_format)[bbox_idx];
-		const auto max_x = UnifiedVectorFormat::GetData<double>(xmax_format)[bbox_idx];
-		const auto max_y = UnifiedVectorFormat::GetData<double>(ymax_format)[bbox_idx];
-		meta.bbox.Combine(min_x, max_x, min_y, max_y);
+		switch (kind) {
+		case 1: { // POINT
+
+			// Point are special in that they are considered "empty" if they are all-nan
+			const auto vert_array = reader.Reserve(vert_width);
+			const auto dims_count = 2 + (hasz ? 1 : 0) + (hasm ? 1 : 0);
+			double vert_point[4] = {0, 0, 0, 0};
+
+			memcpy(vert_point, vert_array, vert_width);
+
+			for (auto dim_idx = 0; dim_idx < dims_count; dim_idx++) {
+				if (!std::isnan(vert_point[dim_idx])) {
+					bbox.ExtendX(vert_point[0]);
+					bbox.ExtendY(vert_point[1]);
+					if (hasz && hasm) {
+						bbox.ExtendZ(vert_point[2]);
+						bbox.ExtendM(vert_point[3]);
+					} else if (hasz) {
+						bbox.ExtendZ(vert_point[2]);
+					} else if (hasm) {
+						bbox.ExtendM(vert_point[2]);
+					}
+					break;
+				}
+			}
+		} break;
+		case 2: { // LINESTRING
+			const auto vert_count = reader.Read<uint32_t>();
+			const auto vert_array = reader.Reserve(vert_count * vert_width);
+			UpdateBoundsFromVertexArray(bbox, flag, vert_array, vert_count);
+		} break;
+		case 3: { // POLYGON
+			const auto ring_count = reader.Read<uint32_t>();
+			for (uint32_t ring_idx = 0; ring_idx < ring_count; ring_idx++) {
+				const auto vert_count = reader.Read<uint32_t>();
+				const auto vert_array = reader.Reserve(vert_count * vert_width);
+				UpdateBoundsFromVertexArray(bbox, flag, vert_array, vert_count);
+			}
+		} break;
+		case 4:   // MULTIPOINT
+		case 5:   // MULTILINESTRING
+		case 6:   // MULTIPOLYGON
+		case 7: { // GEOMETRYCOLLECTION
+			reader.Skip(sizeof(uint32_t));
+		} break;
+		}
 	}
 }
 
@@ -207,13 +220,6 @@ unique_ptr<GeoParquetFileMetadata> GeoParquetFileMetadata::TryRead(const duckdb_
 					// Guard against a breaking future 2.0 version
 					throw InvalidInputException("Geoparquet version %s is not supported", result->version);
 				}
-
-				// Check and parse the primary geometry column
-				const auto primary_geometry_column_val = yyjson_obj_get(root, "primary_column");
-				if (!yyjson_is_str(primary_geometry_column_val)) {
-					throw InvalidInputException("Geoparquet metadata does not have a primary column");
-				}
-				result->primary_geometry_column = yyjson_get_str(primary_geometry_column_val);
 
 				// Check and parse the geometry columns
 				const auto columns_val = yyjson_obj_get(root, "columns");
@@ -285,18 +291,53 @@ unique_ptr<GeoParquetFileMetadata> GeoParquetFileMetadata::TryRead(const duckdb_
 	return nullptr;
 }
 
-void GeoParquetFileMetadata::FlushColumnMeta(const string &column_name, const GeoParquetColumnMetadata &meta) {
+void GeoParquetFileMetadata::AddGeoParquetStats(const string &column_name, const LogicalType &type,
+                                                const GeometryStats &stats) {
+
 	// Lock the metadata
 	lock_guard<mutex> glock(write_lock);
 
-	auto &column = geometry_columns[column_name];
+	auto it = geometry_columns.find(column_name);
+	if (it == geometry_columns.end()) {
+		auto &column = geometry_columns[column_name];
 
-	// Combine the metadata
-	column.geometry_types.insert(meta.geometry_types.begin(), meta.geometry_types.end());
-	column.bbox.Combine(meta.bbox);
+		column.stats.types.Combine(stats.types);
+		column.stats.bbox.Combine(stats.bbox);
+		column.insertion_index = geometry_columns.size() - 1;
+	} else {
+		it->second.stats.types.Combine(stats.types);
+		it->second.stats.bbox.Combine(stats.bbox);
+	}
 }
 
-void GeoParquetFileMetadata::Write(duckdb_parquet::FileMetaData &file_meta_data) const {
+void GeoParquetFileMetadata::Write(duckdb_parquet::FileMetaData &file_meta_data) {
+
+	// GeoParquet does not support M or ZM coordinates. So remove any columns that have them.
+	unordered_set<string> invalid_columns;
+	for (auto &column : geometry_columns) {
+		if (column.second.stats.bbox.HasM()) {
+			invalid_columns.insert(column.first);
+		}
+	}
+	for (auto &col_name : invalid_columns) {
+		geometry_columns.erase(col_name);
+	}
+	// No columns remaining, nothing to write
+	if (geometry_columns.empty()) {
+		return;
+	}
+
+	// Find the primary geometry column
+	const auto &random_first_column = *geometry_columns.begin();
+	auto primary_geometry_column = random_first_column.first;
+	auto primary_insertion_index = random_first_column.second.insertion_index;
+
+	for (auto &column : geometry_columns) {
+		if (column.second.insertion_index < primary_insertion_index) {
+			primary_insertion_index = column.second.insertion_index;
+			primary_geometry_column = column.first;
+		}
+	}
 
 	yyjson_mut_doc *doc = yyjson_mut_doc_new(nullptr);
 	yyjson_mut_val *root = yyjson_mut_obj(doc);
@@ -313,18 +354,29 @@ void GeoParquetFileMetadata::Write(duckdb_parquet::FileMetaData &file_meta_data)
 	const auto json_columns = yyjson_mut_obj_add_obj(doc, root, "columns");
 
 	for (auto &column : geometry_columns) {
+
 		const auto column_json = yyjson_mut_obj_add_obj(doc, json_columns, column.first.c_str());
 		yyjson_mut_obj_add_str(doc, column_json, "encoding", "WKB");
 		const auto geometry_types = yyjson_mut_obj_add_arr(doc, column_json, "geometry_types");
-		for (auto &geometry_type : column.second.geometry_types) {
-			const auto type_name = WKBGeometryTypes::ToString(geometry_type);
-			yyjson_mut_arr_add_str(doc, geometry_types, type_name);
+		for (auto &type_name : column.second.stats.types.ToString(false)) {
+			yyjson_mut_arr_add_strcpy(doc, geometry_types, type_name.c_str());
 		}
-		const auto bbox = yyjson_mut_obj_add_arr(doc, column_json, "bbox");
-		yyjson_mut_arr_add_real(doc, bbox, column.second.bbox.min_x);
-		yyjson_mut_arr_add_real(doc, bbox, column.second.bbox.min_y);
-		yyjson_mut_arr_add_real(doc, bbox, column.second.bbox.max_x);
-		yyjson_mut_arr_add_real(doc, bbox, column.second.bbox.max_y);
+		const auto bbox_arr = yyjson_mut_obj_add_arr(doc, column_json, "bbox");
+		const auto &bbox = column.second.stats.bbox;
+
+		if (!column.second.stats.bbox.HasZ()) {
+			yyjson_mut_arr_add_real(doc, bbox_arr, bbox.xmin);
+			yyjson_mut_arr_add_real(doc, bbox_arr, bbox.ymin);
+			yyjson_mut_arr_add_real(doc, bbox_arr, bbox.xmax);
+			yyjson_mut_arr_add_real(doc, bbox_arr, bbox.ymax);
+		} else {
+			yyjson_mut_arr_add_real(doc, bbox_arr, bbox.xmin);
+			yyjson_mut_arr_add_real(doc, bbox_arr, bbox.ymin);
+			yyjson_mut_arr_add_real(doc, bbox_arr, bbox.zmin);
+			yyjson_mut_arr_add_real(doc, bbox_arr, bbox.xmax);
+			yyjson_mut_arr_add_real(doc, bbox_arr, bbox.ymax);
+			yyjson_mut_arr_add_real(doc, bbox_arr, bbox.zmax);
+		}
 
 		// If the CRS is present, add it
 		if (!column.second.projjson.empty()) {
@@ -366,14 +418,6 @@ bool GeoParquetFileMetadata::IsGeometryColumn(const string &column_name) const {
 	return geometry_columns.find(column_name) != geometry_columns.end();
 }
 
-void GeoParquetFileMetadata::RegisterGeometryColumn(const string &column_name) {
-	lock_guard<mutex> glock(write_lock);
-	if (primary_geometry_column.empty()) {
-		primary_geometry_column = column_name;
-	}
-	geometry_columns[column_name] = GeoParquetColumnMetadata();
-}
-
 bool GeoParquetFileMetadata::IsGeoParquetConversionEnabled(const ClientContext &context) {
 	Value geoparquet_enabled;
 	if (!context.TryGetCurrentSetting("enable_geoparquet_conversion", geoparquet_enabled)) {
@@ -394,6 +438,10 @@ LogicalType GeoParquetFileMetadata::GeometryType() {
 	auto blob_type = LogicalType(LogicalTypeId::BLOB);
 	blob_type.SetAlias("GEOMETRY");
 	return blob_type;
+}
+
+const unordered_map<string, GeoParquetColumnMetadata> &GeoParquetFileMetadata::GetColumnMeta() const {
+	return geometry_columns;
 }
 
 unique_ptr<ColumnReader> GeoParquetFileMetadata::CreateColumnReader(ParquetReader &reader,

--- a/extension/parquet/include/geo_parquet.hpp
+++ b/extension/parquet/include/geo_parquet.hpp
@@ -16,58 +16,164 @@
 #include "parquet_types.h"
 
 namespace duckdb {
+
 struct ParquetColumnSchema;
 
-enum class WKBGeometryType : uint16_t {
-	POINT = 1,
-	LINESTRING = 2,
-	POLYGON = 3,
-	MULTIPOINT = 4,
-	MULTILINESTRING = 5,
-	MULTIPOLYGON = 6,
-	GEOMETRYCOLLECTION = 7,
+struct GeometryKindSet {
 
-	POINT_Z = 1001,
-	LINESTRING_Z = 1002,
-	POLYGON_Z = 1003,
-	MULTIPOINT_Z = 1004,
-	MULTILINESTRING_Z = 1005,
-	MULTIPOLYGON_Z = 1006,
-	GEOMETRYCOLLECTION_Z = 1007,
+	uint8_t bits[4] = {0, 0, 0, 0};
+
+	void Add(uint32_t wkb_type) {
+		auto kind = wkb_type % 1000;
+		auto dims = wkb_type / 1000;
+		if (kind < 1 || kind > 7 || (dims) > 3) {
+			return;
+		}
+		bits[dims] |= (1 << (kind - 1));
+	}
+
+	void Combine(const GeometryKindSet &other) {
+		for (uint32_t d = 0; d < 4; d++) {
+			bits[d] |= other.bits[d];
+		}
+	}
+
+	bool IsEmpty() const {
+		for (uint32_t d = 0; d < 4; d++) {
+			if (bits[d] != 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	template <class T>
+	vector<T> ToList() const {
+		vector<T> result;
+		for (uint32_t d = 0; d < 4; d++) {
+			for (uint32_t i = 1; i <= 7; i++) {
+				if (bits[d] & (1 << (i - 1))) {
+					result.push_back(i + d * 1000);
+				}
+			}
+		}
+		return result;
+	}
+
+	vector<string> ToString(bool snake_case) const {
+		vector<string> result;
+		for (uint32_t d = 0; d < 4; d++) {
+			for (uint32_t i = 1; i <= 7; i++) {
+				if (bits[d] & (1 << (i - 1))) {
+					string str;
+					switch (i) {
+					case 1:
+						str = snake_case ? "point" : "Point";
+						break;
+					case 2:
+						str = snake_case ? "linestring" : "LineString";
+						break;
+					case 3:
+						str = snake_case ? "polygon" : "Polygon";
+						break;
+					case 4:
+						str = snake_case ? "multipoint" : "MultiPoint";
+						break;
+					case 5:
+						str = snake_case ? "multilinestring" : "MultiLineString";
+						break;
+					case 6:
+						str = snake_case ? "multipolygon" : "MultiPolygon";
+						break;
+					case 7:
+						str = snake_case ? "geometrycollection" : "GeometryCollection";
+						break;
+					default:
+						str = snake_case ? "unknown" : "Unknown";
+						break;
+					}
+					switch (d) {
+					case 1:
+						str += snake_case ? "_z" : " Z";
+						break;
+					case 2:
+						str += snake_case ? "_m" : " M";
+						break;
+					case 3:
+						str += snake_case ? "_zm" : " ZM";
+						break;
+					default:
+						break;
+					}
+
+					result.push_back(str);
+				}
+			}
+		}
+		return result;
+	}
 };
 
-struct WKBGeometryTypes {
-	static const char *ToString(WKBGeometryType type);
+struct GeometryExtent {
+
+	double xmin = NumericLimits<double>::Maximum();
+	double xmax = NumericLimits<double>::Minimum();
+	double ymin = NumericLimits<double>::Maximum();
+	double ymax = NumericLimits<double>::Minimum();
+	double zmin = NumericLimits<double>::Maximum();
+	double zmax = NumericLimits<double>::Minimum();
+	double mmin = NumericLimits<double>::Maximum();
+	double mmax = NumericLimits<double>::Minimum();
+
+	bool HasZ() const {
+		return zmin != NumericLimits<double>::Maximum() && zmax != NumericLimits<double>::Minimum();
+	}
+
+	bool HasM() const {
+		return mmin != NumericLimits<double>::Maximum() && mmax != NumericLimits<double>::Minimum();
+	}
+
+	void Combine(const GeometryExtent &other) {
+		xmin = std::min(xmin, other.xmin);
+		xmax = std::max(xmax, other.xmax);
+		ymin = std::min(ymin, other.ymin);
+		ymax = std::max(ymax, other.ymax);
+		zmin = std::min(zmin, other.zmin);
+		zmax = std::max(zmax, other.zmax);
+		mmin = std::min(mmin, other.mmin);
+		mmax = std::max(mmax, other.mmax);
+	}
+
+	void Combine(const double &xmin_p, const double &xmax_p, const double &ymin_p, const double &ymax_p) {
+		xmin = std::min(xmin, xmin_p);
+		xmax = std::max(xmax, xmax_p);
+		ymin = std::min(ymin, ymin_p);
+		ymax = std::max(ymax, ymax_p);
+	}
+
+	void ExtendX(const double &x) {
+		xmin = std::min(xmin, x);
+		xmax = std::max(xmax, x);
+	}
+	void ExtendY(const double &y) {
+		ymin = std::min(ymin, y);
+		ymax = std::max(ymax, y);
+	}
+	void ExtendZ(const double &z) {
+		zmin = std::min(zmin, z);
+		zmax = std::max(zmax, z);
+	}
+	void ExtendM(const double &m) {
+		mmin = std::min(mmin, m);
+		mmax = std::max(mmax, m);
+	}
 };
 
-struct GeometryBounds {
-	double min_x = NumericLimits<double>::Maximum();
-	double max_x = NumericLimits<double>::Minimum();
-	double min_y = NumericLimits<double>::Maximum();
-	double max_y = NumericLimits<double>::Minimum();
+struct GeometryStats {
+	GeometryKindSet types;
+	GeometryExtent bbox;
 
-	GeometryBounds() = default;
-
-	void Combine(const GeometryBounds &other) {
-		min_x = std::min(min_x, other.min_x);
-		max_x = std::max(max_x, other.max_x);
-		min_y = std::min(min_y, other.min_y);
-		max_y = std::max(max_y, other.max_y);
-	}
-
-	void Combine(const double &x, const double &y) {
-		min_x = std::min(min_x, x);
-		max_x = std::max(max_x, x);
-		min_y = std::min(min_y, y);
-		max_y = std::max(max_y, y);
-	}
-
-	void Combine(const double &min_x, const double &max_x, const double &min_y, const double &max_y) {
-		this->min_x = std::min(this->min_x, min_x);
-		this->max_x = std::max(this->max_x, max_x);
-		this->min_y = std::min(this->min_y, min_y);
-		this->max_y = std::max(this->max_y, max_y);
-	}
+	void Update(const string_t &wkb);
 };
 
 //------------------------------------------------------------------------------
@@ -92,47 +198,31 @@ struct GeoParquetColumnMetadata {
 	// The encoding of the geometry column
 	GeoParquetColumnEncoding geometry_encoding;
 
-	// The geometry types that are present in the column
-	set<WKBGeometryType> geometry_types;
-
-	// The bounds of the geometry column
-	GeometryBounds bbox;
+	// The statistics of the geometry column
+	GeometryStats stats;
 
 	// The crs of the geometry column (if any) in PROJJSON format
 	string projjson;
-};
 
-class GeoParquetColumnMetadataWriter {
-	unique_ptr<ExpressionExecutor> executor;
-	DataChunk input_chunk;
-	DataChunk result_chunk;
-
-	unique_ptr<Expression> type_expr;
-	unique_ptr<Expression> flag_expr;
-	unique_ptr<Expression> bbox_expr;
-
-public:
-	explicit GeoParquetColumnMetadataWriter(ClientContext &context);
-	void Update(GeoParquetColumnMetadata &meta, Vector &vector, idx_t count);
+	// Used to track the "primary" geometry column (if any)
+	idx_t insertion_index = 0;
 };
 
 class GeoParquetFileMetadata {
 public:
+	void AddGeoParquetStats(const string &column_name, const LogicalType &type, const GeometryStats &stats);
+	void Write(duckdb_parquet::FileMetaData &file_meta_data);
+
 	// Try to read GeoParquet metadata. Returns nullptr if not found, invalid or the required spatial extension is not
 	// available.
-
 	static unique_ptr<GeoParquetFileMetadata> TryRead(const duckdb_parquet::FileMetaData &file_meta_data,
 	                                                  const ClientContext &context);
-	void Write(duckdb_parquet::FileMetaData &file_meta_data) const;
-
-	void FlushColumnMeta(const string &column_name, const GeoParquetColumnMetadata &meta);
 	const unordered_map<string, GeoParquetColumnMetadata> &GetColumnMeta() const;
 
 	unique_ptr<ColumnReader> CreateColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
 	                                            ClientContext &context);
 
 	bool IsGeometryColumn(const string &column_name) const;
-	void RegisterGeometryColumn(const string &column_name);
 
 	static bool IsGeoParquetConversionEnabled(const ClientContext &context);
 	static LogicalType GeometryType();
@@ -140,7 +230,6 @@ public:
 private:
 	mutex write_lock;
 	string version = "1.1.0";
-	string primary_geometry_column;
 	unordered_map<string, GeoParquetColumnMetadata> geometry_columns;
 };
 

--- a/extension/parquet/include/geo_parquet.hpp
+++ b/extension/parquet/include/geo_parquet.hpp
@@ -219,8 +219,8 @@ public:
 	                                                  const ClientContext &context);
 	const unordered_map<string, GeoParquetColumnMetadata> &GetColumnMeta() const;
 
-	unique_ptr<ColumnReader> CreateColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
-	                                            ClientContext &context);
+	static unique_ptr<ColumnReader> CreateColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
+	                                                   ClientContext &context);
 
 	bool IsGeometryColumn(const string &column_name) const;
 

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -211,9 +211,9 @@ private:
 	void InitializeSchema(ClientContext &context);
 	bool ScanInternal(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
 	//! Parse the schema of the file
-	unique_ptr<ParquetColumnSchema> ParseSchema();
+	unique_ptr<ParquetColumnSchema> ParseSchema(ClientContext &context);
 	ParquetColumnSchema ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat, idx_t &next_schema_idx,
-	                                         idx_t &next_file_idx);
+	                                         idx_t &next_file_idx, ClientContext &context);
 
 	unique_ptr<ColumnReader> CreateReader(ClientContext &context);
 

--- a/extension/parquet/include/writer/parquet_write_stats.hpp
+++ b/extension/parquet/include/writer/parquet_write_stats.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "column_writer.hpp"
-#include "writer/parquet_write_stats.hpp"
+#include "geo_parquet.hpp"
 
 namespace duckdb {
 
@@ -26,6 +26,10 @@ public:
 	virtual bool HasNaN();
 	virtual bool MinIsExact();
 	virtual bool MaxIsExact();
+
+	virtual bool HasGeoStats();
+	virtual optional_ptr<GeometryStats> GetGeoStats();
+	virtual void WriteGeoStats(duckdb_parquet::GeospatialStatistics &stats);
 
 public:
 	template <class TARGET>
@@ -245,6 +249,53 @@ public:
 	}
 	string GetMaxValue() override {
 		return HasStats() ? string(char_ptr_cast(max), 16) : string();
+	}
+};
+
+class GeoStatisticsState final : public ColumnWriterStatistics {
+public:
+	explicit GeoStatisticsState() : has_stats(false) {
+	}
+
+	bool has_stats;
+	GeometryStats geo_stats;
+
+public:
+	void Update(const string_t &val) {
+		geo_stats.Update(val);
+		has_stats = true;
+	}
+	bool HasGeoStats() override {
+		return has_stats;
+	}
+	optional_ptr<GeometryStats> GetGeoStats() override {
+		return geo_stats;
+	}
+	void WriteGeoStats(duckdb_parquet::GeospatialStatistics &stats) override {
+		const auto &types = geo_stats.types;
+		const auto &bbox = geo_stats.bbox;
+
+		stats.__isset.bbox = true;
+		stats.bbox.xmin = bbox.xmin;
+		stats.bbox.xmax = bbox.xmax;
+		stats.bbox.ymin = bbox.ymin;
+		stats.bbox.ymax = bbox.ymax;
+
+		if (bbox.HasZ()) {
+			stats.bbox.__isset.zmin = true;
+			stats.bbox.__isset.zmax = true;
+			stats.bbox.zmin = bbox.zmin;
+			stats.bbox.zmax = bbox.zmax;
+		}
+		if (bbox.HasM()) {
+			stats.bbox.__isset.mmin = true;
+			stats.bbox.__isset.mmax = true;
+			stats.bbox.mmin = bbox.mmin;
+			stats.bbox.mmax = bbox.mmax;
+		}
+
+		stats.__isset.geospatial_types = true;
+		stats.geospatial_types = types.ToList<int>();
 	}
 };
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -225,6 +225,10 @@ LogicalType ParquetReader::DeriveLogicalType(const SchemaElement &s_ele, Parquet
 				return LogicalType::TIME_TZ;
 			}
 			return LogicalType::TIME;
+		} else if (s_ele.logicalType.__isset.GEOMETRY) {
+			return LogicalType::BLOB;
+		} else if (s_ele.logicalType.__isset.GEOGRAPHY) {
+			return LogicalType::BLOB;
 		}
 	}
 	if (s_ele.__isset.converted_type) {
@@ -403,7 +407,7 @@ unique_ptr<ColumnReader> ParquetReader::CreateReaderRecursive(ClientContext &con
                                                               const ParquetColumnSchema &schema) {
 	switch (schema.schema_type) {
 	case ParquetColumnSchemaType::GEOMETRY:
-		return metadata->geo_metadata->CreateColumnReader(*this, schema, context);
+		return GeoParquetFileMetadata::CreateColumnReader(*this, schema, context);
 	case ParquetColumnSchemaType::FILE_ROW_NUMBER:
 		return make_uniq<RowNumberColumnReader>(*this, schema);
 	case ParquetColumnSchemaType::COLUMN: {
@@ -561,7 +565,8 @@ static bool IsVariantType(const SchemaElement &root, const vector<ParquetColumnS
 }
 
 ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat,
-                                                        idx_t &next_schema_idx, idx_t &next_file_idx) {
+                                                        idx_t &next_schema_idx, idx_t &next_file_idx,
+                                                        ClientContext &context) {
 
 	auto file_meta_data = GetFileMetadata();
 	D_ASSERT(file_meta_data);
@@ -583,7 +588,7 @@ ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_d
 	// Check for geoparquet spatial types
 	if (depth == 1) {
 		// geoparquet types have to be at the root of the schema, and have to be present in the kv metadata.
-		// geoarrow types, although geometry columns, are structs and have chilren and are handled below.
+		// geoarrow types, although geometry columns, are structs and have children and are handled below.
 		if (metadata->geo_metadata && metadata->geo_metadata->IsGeometryColumn(s_ele.name) && s_ele.num_children == 0) {
 			auto root_schema = ParseColumnSchema(s_ele, max_define, max_repeat, this_idx, next_file_idx++);
 			return ParquetColumnSchema(std::move(root_schema), GeoParquetFileMetadata::GeometryType(),
@@ -598,7 +603,8 @@ ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_d
 		while (c_idx < NumericCast<idx_t>(s_ele.num_children)) {
 			next_schema_idx++;
 
-			auto child_schema = ParseSchemaRecursive(depth + 1, max_define, max_repeat, next_schema_idx, next_file_idx);
+			auto child_schema =
+			    ParseSchemaRecursive(depth + 1, max_define, max_repeat, next_schema_idx, next_file_idx, context);
 			child_schemas.push_back(std::move(child_schema));
 			c_idx++;
 		}
@@ -698,6 +704,14 @@ ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_d
 			list_schema.children.push_back(std::move(result));
 			return list_schema;
 		}
+
+		// Convert to geometry type if possible
+		if (s_ele.__isset.logicalType && (s_ele.logicalType.__isset.GEOMETRY || s_ele.logicalType.__isset.GEOGRAPHY) &&
+		    GeoParquetFileMetadata::IsGeoParquetConversionEnabled(context)) {
+			return ParquetColumnSchema(std::move(result), GeoParquetFileMetadata::GeometryType(),
+			                           ParquetColumnSchemaType::GEOMETRY);
+		}
+
 		return result;
 	}
 }
@@ -707,7 +721,7 @@ static ParquetColumnSchema FileRowNumberSchema() {
 	                           ParquetColumnSchemaType::FILE_ROW_NUMBER);
 }
 
-unique_ptr<ParquetColumnSchema> ParquetReader::ParseSchema() {
+unique_ptr<ParquetColumnSchema> ParquetReader::ParseSchema(ClientContext &context) {
 	auto file_meta_data = GetFileMetadata();
 	idx_t next_schema_idx = 0;
 	idx_t next_file_idx = 0;
@@ -718,7 +732,7 @@ unique_ptr<ParquetColumnSchema> ParquetReader::ParseSchema() {
 	if (file_meta_data->schema[0].num_children == 0) {
 		throw IOException("Parquet reader: root schema element has no children");
 	}
-	auto root = ParseSchemaRecursive(0, 0, 0, next_schema_idx, next_file_idx);
+	auto root = ParseSchemaRecursive(0, 0, 0, next_schema_idx, next_file_idx, context);
 	if (root.type.id() != LogicalTypeId::STRUCT) {
 		throw InvalidInputException("Root element of Parquet file must be a struct");
 	}
@@ -774,7 +788,7 @@ void ParquetReader::InitializeSchema(ClientContext &context) {
 		throw InvalidInputException("Failed to read Parquet file '%s': Need at least one non-root column in the file",
 		                            GetFileName());
 	}
-	root_schema = ParseSchema();
+	root_schema = ParseSchema(context);
 	for (idx_t i = 0; i < root_schema->children.size(); i++) {
 		auto &element = root_schema->children[i];
 		columns.push_back(ParseColumnDefinition(*file_meta_data, element));

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -174,6 +174,13 @@ void ParquetWriter::SetSchemaProperties(const LogicalType &duckdb_type, duckdb_p
 		schema_ele.logicalType.__set_JSON(duckdb_parquet::JsonType());
 		return;
 	}
+	if (duckdb_type.GetAlias() == "WKB_BLOB") {
+		schema_ele.__isset.logicalType = true;
+		schema_ele.logicalType.__isset.GEOMETRY = true;
+		// TODO: Set CRS in the future
+		schema_ele.logicalType.GEOMETRY.__isset.crs = false;
+		return;
+	}
 	switch (duckdb_type.id()) {
 	case LogicalTypeId::TINYINT:
 		schema_ele.converted_type = ConvertedType::INT_8;
@@ -328,6 +335,11 @@ struct ColumnStatsUnifier {
 	idx_t column_size_bytes = 0;
 	bool can_have_nan = false;
 	bool has_nan = false;
+
+	unique_ptr<GeometryStats> geo_stats;
+
+	virtual void UnifyGeoStats(const GeometryStats &other) {
+	}
 
 	virtual void UnifyMinMax(const string &new_min, const string &new_max) = 0;
 	virtual string StatsToString(const string &stats) = 0;
@@ -672,6 +684,50 @@ struct BlobStatsUnifier : public BaseStringStatsUnifier {
 	}
 };
 
+struct GeoStatsUnifier : public ColumnStatsUnifier {
+
+	void UnifyGeoStats(const GeometryStats &other) override {
+		if (geo_stats) {
+			geo_stats->bbox.Combine(other.bbox);
+			geo_stats->types.Combine(other.types);
+		} else {
+			// Make copy
+			geo_stats = make_uniq<GeometryStats>();
+			geo_stats->bbox = other.bbox;
+			geo_stats->types = other.types;
+		}
+	}
+
+	void UnifyMinMax(const string &new_min, const string &new_max) override {
+		// Do nothing
+	}
+
+	string StatsToString(const string &stats) override {
+		if (!geo_stats) {
+			return string();
+		}
+
+		const auto &bbox = geo_stats->bbox;
+		const auto &types = geo_stats->types;
+
+		const auto bbox_value = Value::STRUCT({{"xmin", bbox.xmin},
+		                                       {"xmax", bbox.xmax},
+		                                       {"ymin", bbox.ymin},
+		                                       {"ymax", bbox.ymax},
+		                                       {"zmin", bbox.zmin},
+		                                       {"zmax", bbox.zmax},
+		                                       {"mmin", bbox.mmin},
+		                                       {"mmax", bbox.mmax}});
+
+		vector<Value> type_strings;
+		for (const auto &type : types.ToString(true)) {
+			type_strings.push_back(Value(StringUtil::Lower(type)));
+		}
+
+		return Value::STRUCT({{"bbox", bbox_value}, {"types", Value::LIST(type_strings)}}).ToString();
+	}
+};
+
 struct UUIDStatsUnifier : public BaseStringStatsUnifier {
 	string StatsToString(const string &stats) override {
 		if (stats.size() != 16) {
@@ -754,7 +810,11 @@ static unique_ptr<ColumnStatsUnifier> GetBaseStatsUnifier(const LogicalType &typ
 		}
 	}
 	case LogicalTypeId::BLOB:
-		return make_uniq<BlobStatsUnifier>();
+		if (type.GetAlias() == "WKB_BLOB") {
+			return make_uniq<GeoStatsUnifier>();
+		} else {
+			return make_uniq<BlobStatsUnifier>();
+		}
 	case LogicalTypeId::VARCHAR:
 		return make_uniq<StringStatsUnifier>();
 	case LogicalTypeId::UUID:
@@ -811,6 +871,9 @@ void ParquetWriter::FlushColumnStats(idx_t col_idx, duckdb_parquet::ColumnChunk 
 		} else {
 			stats_unifier->all_nulls_set = false;
 		}
+		if (writer_stats && writer_stats->HasGeoStats()) {
+			stats_unifier->UnifyGeoStats(*writer_stats->GetGeoStats());
+		}
 		stats_unifier->column_size_bytes += column.meta_data.total_compressed_size;
 	}
 }
@@ -838,6 +901,33 @@ void ParquetWriter::GatherWrittenStatistics() {
 		}
 		if (stats_unifier->can_have_nan) {
 			column_stats["has_nan"] = Value::BOOLEAN(stats_unifier->has_nan);
+		}
+		if (stats_unifier->geo_stats) {
+			const auto &bbox = stats_unifier->geo_stats->bbox;
+			const auto &types = stats_unifier->geo_stats->types;
+
+			column_stats["bbox_xmin"] = Value::DOUBLE(bbox.xmin);
+			column_stats["bbox_xmax"] = Value::DOUBLE(bbox.xmax);
+			column_stats["bbox_ymin"] = Value::DOUBLE(bbox.ymin);
+			column_stats["bbox_ymax"] = Value::DOUBLE(bbox.ymax);
+
+			if (bbox.HasZ()) {
+				column_stats["bbox_zmin"] = Value::DOUBLE(bbox.zmin);
+				column_stats["bbox_zmax"] = Value::DOUBLE(bbox.zmax);
+			}
+
+			if (bbox.HasM()) {
+				column_stats["bbox_mmin"] = Value::DOUBLE(bbox.mmin);
+				column_stats["bbox_mmax"] = Value::DOUBLE(bbox.mmax);
+			}
+
+			if (!types.IsEmpty()) {
+				vector<Value> type_strings;
+				for (const auto &type : types.ToString(true)) {
+					type_strings.push_back(Value(StringUtil::Lower(type)));
+				}
+				column_stats["geo_types"] = Value::LIST(type_strings);
+			}
 		}
 		written_stats->column_statistics.insert(make_pair(stats_unifier->column_name, std::move(column_stats)));
 	}
@@ -885,7 +975,7 @@ void ParquetWriter::Finalize() {
 	}
 
 	// Add geoparquet metadata to the file metadata
-	if (geoparquet_data) {
+	if (geoparquet_data && GeoParquetFileMetadata::IsGeoParquetConversionEnabled(context)) {
 		geoparquet_data->Write(file_meta_data);
 	}
 

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -302,6 +302,16 @@ void PrimitiveColumnWriter::SetParquetStatistics(PrimitiveColumnWriterState &sta
 		column_chunk.meta_data.statistics.__isset.distinct_count = true;
 		column_chunk.meta_data.__isset.statistics = true;
 	}
+
+	if (state.stats_state->HasGeoStats()) {
+		column_chunk.meta_data.__isset.geospatial_statistics = true;
+		state.stats_state->WriteGeoStats(column_chunk.meta_data.geospatial_statistics);
+
+		// Add the geospatial statistics to the extra GeoParquet metadata
+		writer.GetGeoParquetData().AddGeoParquetStats(column_schema.name, column_schema.type,
+		                                              *state.stats_state->GetGeoStats());
+	}
+
 	for (const auto &write_info : state.write_info) {
 		// only care about data page encodings, data_page_header.encoding is meaningless for dict
 		if (write_info.page_header.type != PageType::DATA_PAGE &&

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -657,7 +657,7 @@ CatalogException Catalog::CreateMissingEntryException(CatalogEntryRetriever &ret
 	auto &db_manager = DatabaseManager::Get(context);
 	auto databases = db_manager.GetDatabases(context, max_schema_count);
 
-	for (auto database : databases) {
+	for (auto &database : databases) {
 		if (unseen_schemas.size() >= max_schema_count) {
 			break;
 		}

--- a/test/geoparquet/mixed.test
+++ b/test/geoparquet/mixed.test
@@ -58,4 +58,4 @@ FROM parquet_kv_metadata('__TEST_DIR__/t1.parquet');
 query IIIIII
 COPY (SELECT * FROM t1) TO '__TEST_DIR__/t1.parquet' (FORMAT 'parquet', RETURN_STATS);
 ----
-<REGEX>:.*t1.parquet	8	781	530	{'"col"'={column_size_bytes=56, max=8, min=1, null_count=0}, '"geom"'={bbox_xmax=3.0, bbox_xmin=0.0, bbox_ymax=3.0, bbox_ymin=0.0, bbox_zmax=1.0, bbox_zmin=1.0, column_size_bytes=183, geo_types='[point, linestring, polygon, multipoint, multilinestring, multipolygon, geometrycollection, point_z]', null_count=0}}	NULL
+<REGEX>:.*t1.parquet	8	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:{'"col"'={column_size_bytes=\d+, max=8, min=1, null_count=0}, '"geom"'={bbox_xmax=3.0, bbox_xmin=0.0, bbox_ymax=3.0, bbox_ymin=0.0, bbox_zmax=1.0, bbox_zmin=1.0, column_size_bytes=\d+, geo_types='\[point, linestring, polygon, multipoint, multilinestring, multipolygon, geometrycollection, point_z\]', null_count=0}}	NULL

--- a/test/geoparquet/mixed.test
+++ b/test/geoparquet/mixed.test
@@ -49,4 +49,13 @@ query I
 SELECT (decode(value)) as col
 FROM parquet_kv_metadata('__TEST_DIR__/t1.parquet');
 ----
-{"version":"1.1.0","primary_column":"geom","columns":{"geom":{"encoding":"WKB","geometry_types":["Point","LineString","Polygon","MultiPoint","MultiLineString","MultiPolygon","GeometryCollection","Point Z"],"bbox":[0.0,0.0,3.0,3.0]}}}
+{"version":"1.1.0","primary_column":"geom","columns":{"geom":{"encoding":"WKB","geometry_types":["Point","LineString","Polygon","MultiPoint","MultiLineString","MultiPolygon","GeometryCollection","Point Z"],"bbox":[0.0,0.0,1.0,3.0,3.0,1.0]}}}
+
+
+#------------------------------------------------------------------------------
+# Write with RETURN_STATS
+#------------------------------------------------------------------------------
+query IIIIII
+COPY (SELECT * FROM t1) TO '__TEST_DIR__/t1.parquet' (FORMAT 'parquet', RETURN_STATS);
+----
+<REGEX>:.*t1.parquet	8	781	530	{'"col"'={column_size_bytes=56, max=8, min=1, null_count=0}, '"geom"'={bbox_xmax=3.0, bbox_xmin=0.0, bbox_ymax=3.0, bbox_ymin=0.0, bbox_zmax=1.0, bbox_zmin=1.0, column_size_bytes=183, geo_types='[point, linestring, polygon, multipoint, multilinestring, multipolygon, geometrycollection, point_z]', null_count=0}}	NULL

--- a/test/geoparquet/unsupported.test
+++ b/test/geoparquet/unsupported.test
@@ -8,14 +8,20 @@ require parquet
 #------------------------------------------------------------------------------
 # Test unsupported geometry type
 #------------------------------------------------------------------------------
+# This is now ok, but we dont write the geoparquet metadata
 
-statement error
+statement ok
 COPY (SELECT 'POINT ZM (0 1 2 3)'::GEOMETRY) TO '__TEST_DIR__/t1.parquet' (FORMAT 'parquet');
+
+query I
+SELECT (decode(value)) as col
+FROM parquet_kv_metadata('__TEST_DIR__/t1.parquet');
 ----
-Invalid Input Error: Geoparquet does not support geometries with M coordinates
 
-
-statement error
+statement ok
 COPY (SELECT 'POINT M (0 1 2)'::GEOMETRY) TO '__TEST_DIR__/t1.parquet' (FORMAT 'parquet');
+
+query I
+SELECT (decode(value)) as col
+FROM parquet_kv_metadata('__TEST_DIR__/t1.parquet');
 ----
-Invalid Input Error: Geoparquet does not support geometries with M coordinates

--- a/test/geoparquet/unsupported.test
+++ b/test/geoparquet/unsupported.test
@@ -11,17 +11,30 @@ require parquet
 # This is now ok, but we dont write the geoparquet metadata
 
 statement ok
-COPY (SELECT 'POINT ZM (0 1 2 3)'::GEOMETRY) TO '__TEST_DIR__/t1.parquet' (FORMAT 'parquet');
+COPY (SELECT 'POINT ZM (0 1 2 3)'::GEOMETRY as geometry) TO '__TEST_DIR__/t1.parquet' (FORMAT 'parquet');
 
+# Not a geoparquet file
 query I
 SELECT (decode(value)) as col
 FROM parquet_kv_metadata('__TEST_DIR__/t1.parquet');
 ----
+
+# But still a normal parquet file
+query I
+SELECT st_astext(geometry) FROM '__TEST_DIR__/t1.parquet';
+----
+POINT ZM (0 1 2 3)
 
 statement ok
-COPY (SELECT 'POINT M (0 1 2)'::GEOMETRY) TO '__TEST_DIR__/t1.parquet' (FORMAT 'parquet');
+COPY (SELECT 'POINT M (0 1 2)'::GEOMETRY as geometry) TO '__TEST_DIR__/t1.parquet' (FORMAT 'parquet');
 
 query I
 SELECT (decode(value)) as col
 FROM parquet_kv_metadata('__TEST_DIR__/t1.parquet');
 ----
+
+# But still a normal parquet file
+query I
+SELECT st_astext(geometry) FROM '__TEST_DIR__/t1.parquet';
+----
+POINT M (0 1 2)


### PR DESCRIPTION
This PR extends DuckDBs parquet-geometry support by writing spatial geometries as the new native parquet `GEOMETRY` logical type. 

Parquet recently standardized support for `GEOMETRY` and `GEOGRAPHY` as logical types into the parquet spec itself. This is in theory mostly compatible with the existing "GeoParquet" extension format, at least to the extent that DuckDB supports it so far. While the as-of-yet unreleased "GeoParquet 2.0" is supposed to reconcile and unify the two specifications, the changes in this PR favors writing files following the native spec, while also writing the required GeoParquet metadata to the best of our ability, as the new native geometry spec is basically a superset of DuckDBs existing geoparquet support. In practice, this means that exporting a dataset containing a spatial `GEOMETRY` type will produce a parquet file that is both a valid GeoParquet file and a valid "native geometry" parquet file. As the new native types are "logical types", older parquet readers that don't support the native types yet should still be able to read these columns as their underlying physical type, and if they support GeoParquet they should still be able to interpret these as geometries as the actual geometry encoding to binary (ISO WKB) is the same.

In the few cases where the specs differ, e.g. when writing geometries with "M" coordinates (which GeoParquet does not support), we omit the geoparquet metadata for those columns. 

We also write the new geospatial stats. We can't make use of them ourselves yet when reading, but it's possible to inspect the bounding box and geometry type stats through the `parquet_stats` function . By utilizing the native parquet geometry stats we can clean up a lot of the existing "special case" geoparquet code by reusing the same statistics collection codepaths. I've also implemented the WKB stats computation code into the extension, avoiding the need to call into spatial when writing.

This PR also adds support for returning the geospatial statistics when using the `RETURN_STATS` option of the `COPY` command, opening the path for writing geometries to different data lakes.