### PR TITLE
fix: silence warnings about signed/unsigned conversions.

### DIFF
--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -125,8 +125,8 @@ void TerminalProgressBarDisplay::Update(double percentage) {
 	double estimated_seconds_remaining = std::min(ukf.GetEstimatedRemainingSeconds(), 2147483647.0);
 	auto percentage_int = NormalizePercentage(percentage);
 
-	TerminalProgressBarDisplayedProgressInfo updated_progress_info = {percentage_int,
-	                                                                  (int32_t)estimated_seconds_remaining};
+	TerminalProgressBarDisplayedProgressInfo updated_progress_info = {(idx_t)percentage_int,
+	                                                                  (idx_t)estimated_seconds_remaining};
 	if (displayed_progress_info != updated_progress_info) {
 		PrintProgressInternal(percentage_int, estimated_seconds_remaining);
 		Printer::Flush(OutputStream::STREAM_STDOUT);


### PR DESCRIPTION
Silence a warning about signed/unsigned conversions.