### PR TITLE
Avoid printing '99 hours', given in most cases that means estimate is…

### DIFF
--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -25,10 +25,8 @@ static string FormatETA(double seconds, bool elapsed = false) {
 	//   unknown     remaining
 	//   00:00:00.00 elapsed
 	if (!elapsed && seconds > 3600 * 99) {
-		// estimate larger than 99 hours remaining
-		string result = "(>99 hours remaining)";
-		result += string(RENDER_SIZE - result.size(), ' ');
-		return result;
+		// estimate larger than 99 hours remaining, treat this as invalid/unknown ETA
+		return string(RENDER_SIZE, ' ');
 	}
 	if (seconds < 0) {
 		// Invalid or unknown ETA, skip rendering estimate


### PR DESCRIPTION
… inaccurate

This is my reaction to issue a `DESCRIBE`/table listing on remote datalake.
There is no progress, apparent stall (due to wait on the network), so "99" is printed.

I would assume there are more weird query patterns where 99 happens more often than actual estimate being bigger than 99 hours.
Simplifying, just don't show estimate in that case.