### PR TITLE
Add `COPY (...) TO ... (FORMAT BLOB)`

### DIFF
--- a/src/function/CMakeLists.txt
+++ b/src/function/CMakeLists.txt
@@ -29,7 +29,8 @@ add_library_unity(
   table_macro_function.cpp
   scalar_function.cpp
   table_function.cpp
-  udf_function.cpp)
+  udf_function.cpp
+  copy_blob.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_function>
     PARENT_SCOPE)

--- a/src/function/copy_blob.cpp
+++ b/src/function/copy_blob.cpp
@@ -1,0 +1,125 @@
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/function/built_in_functions.hpp"
+#include "duckdb/function/copy_function.hpp"
+
+namespace duckdb {
+
+//----------------------------------------------------------------------------------------------------------------------
+// Bind
+//----------------------------------------------------------------------------------------------------------------------
+namespace {
+
+struct WriteBlobBindData final : public TableFunctionData {};
+
+unique_ptr<FunctionData> WriteBlobBind(ClientContext &context, CopyFunctionBindInput &input,
+                                       const vector<string> &names, const vector<LogicalType> &sql_types) {
+	if (sql_types.size() != 1 || sql_types.back().id() != LogicalTypeId::BLOB) {
+		throw BinderException("\"COPY (FORMAT BLOB)\" only supports a single BLOB column");
+	}
+
+	return make_uniq_base<FunctionData, WriteBlobBindData>();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Global State
+//----------------------------------------------------------------------------------------------------------------------
+struct WriteBlobGlobalState final : public GlobalFunctionData {
+	unique_ptr<FileHandle> handle;
+	mutex lock;
+};
+
+static unique_ptr<GlobalFunctionData> WriteBlobInitializeGlobal(ClientContext &context, FunctionData &bind_data,
+                                                                const string &file_path) {
+
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+
+	auto result = make_uniq<WriteBlobGlobalState>();
+	result->handle = std::move(handle);
+
+	return std::move(result);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Local State
+//----------------------------------------------------------------------------------------------------------------------
+struct WriteBlobLocalState final : public LocalFunctionData {};
+
+static unique_ptr<LocalFunctionData> WriteBlobInitializeLocal(ExecutionContext &context, FunctionData &bind_data) {
+	return make_uniq_base<LocalFunctionData, WriteBlobLocalState>();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Sink
+//----------------------------------------------------------------------------------------------------------------------
+static void WriteBlobSink(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                          LocalFunctionData &lstate, DataChunk &input) {
+	D_ASSERT(input.ColumnCount() == 1);
+
+	auto &state = gstate.Cast<WriteBlobGlobalState>();
+	lock_guard<mutex> glock(state.lock);
+
+	auto &handle = state.handle;
+
+	UnifiedVectorFormat vdata;
+	input.data[0].ToUnifiedFormat(input.size(), vdata);
+	const auto blobs = UnifiedVectorFormat::GetData<string_t>(vdata);
+
+	for (idx_t row_idx = 0; row_idx < input.size(); row_idx++) {
+		const auto out_idx = vdata.sel->get_index(row_idx);
+		if (vdata.validity.RowIsValid(out_idx)) {
+
+			auto &blob = blobs[out_idx];
+			auto blob_len = blob.GetSize();
+			auto blob_ptr = blob.GetDataWriteable();
+			auto blob_end = blob_ptr + blob_len;
+
+			while (blob_ptr < blob_end) {
+				auto written = handle->Write(blob_ptr, blob_len);
+				if (written <= 0) {
+					throw IOException("Failed to write to file!");
+				}
+				blob_ptr += written;
+			}
+		}
+	}
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Combine
+//----------------------------------------------------------------------------------------------------------------------
+static void WriteBlobCombine(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                             LocalFunctionData &lstate) {
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Finalize
+//----------------------------------------------------------------------------------------------------------------------
+void WriteBlobFinalize(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate) {
+	auto &state = gstate.Cast<WriteBlobGlobalState>();
+	lock_guard<mutex> glock(state.lock);
+
+	state.handle->Sync();
+	state.handle->Close();
+}
+
+} // namespace
+
+//----------------------------------------------------------------------------------------------------------------------
+// Register
+//----------------------------------------------------------------------------------------------------------------------
+void BuiltinFunctions::RegisterCopyFunctions() {
+	CopyFunction info("blob");
+	info.copy_to_bind = WriteBlobBind;
+	info.copy_to_initialize_local = WriteBlobInitializeLocal;
+	info.copy_to_initialize_global = WriteBlobInitializeGlobal;
+	info.copy_to_sink = WriteBlobSink;
+	info.copy_to_combine = WriteBlobCombine;
+	info.copy_to_finalize = WriteBlobFinalize;
+	info.extension = "blob";
+
+	AddFunction(info);
+}
+
+} // namespace duckdb

--- a/src/function/copy_blob.cpp
+++ b/src/function/copy_blob.cpp
@@ -14,7 +14,7 @@ struct WriteBlobBindData final : public TableFunctionData {
 	FileCompressionType compression_type = FileCompressionType::AUTO_DETECT;
 };
 
-static string ParseStringOption(const Value &value, const string &loption) {
+string ParseStringOption(const Value &value, const string &loption) {
 	if (value.IsNull()) {
 		return string();
 	}
@@ -59,13 +59,12 @@ struct WriteBlobGlobalState final : public GlobalFunctionData {
 	mutex lock;
 };
 
-static unique_ptr<GlobalFunctionData> WriteBlobInitializeGlobal(ClientContext &context, FunctionData &bind_data,
-                                                                const string &file_path) {
+unique_ptr<GlobalFunctionData> WriteBlobInitializeGlobal(ClientContext &context, FunctionData &bind_data,
+                                                         const string &file_path) {
 
 	auto &bdata = bind_data.Cast<WriteBlobBindData>();
 	auto &fs = FileSystem::GetFileSystem(context);
 
-	auto file_name = file_path;
 	auto flags = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW | bdata.compression_type;
 	auto handle = fs.OpenFile(file_path, flags);
 
@@ -80,15 +79,15 @@ static unique_ptr<GlobalFunctionData> WriteBlobInitializeGlobal(ClientContext &c
 //----------------------------------------------------------------------------------------------------------------------
 struct WriteBlobLocalState final : public LocalFunctionData {};
 
-static unique_ptr<LocalFunctionData> WriteBlobInitializeLocal(ExecutionContext &context, FunctionData &bind_data) {
+unique_ptr<LocalFunctionData> WriteBlobInitializeLocal(ExecutionContext &context, FunctionData &bind_data) {
 	return make_uniq_base<LocalFunctionData, WriteBlobLocalState>();
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 // Sink
 //----------------------------------------------------------------------------------------------------------------------
-static void WriteBlobSink(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
-                          LocalFunctionData &lstate, DataChunk &input) {
+void WriteBlobSink(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                   LocalFunctionData &lstate, DataChunk &input) {
 	D_ASSERT(input.ColumnCount() == 1);
 
 	auto &state = gstate.Cast<WriteBlobGlobalState>();
@@ -123,8 +122,8 @@ static void WriteBlobSink(ExecutionContext &context, FunctionData &bind_data, Gl
 //----------------------------------------------------------------------------------------------------------------------
 // Combine
 //----------------------------------------------------------------------------------------------------------------------
-static void WriteBlobCombine(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
-                             LocalFunctionData &lstate) {
+void WriteBlobCombine(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                      LocalFunctionData &lstate) {
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -101,6 +101,8 @@ void BuiltinFunctions::Initialize() {
 
 	RegisterPragmaFunctions();
 
+	RegisterCopyFunctions();
+
 	// initialize collations
 	AddCollation("nocase", LowerFun::GetFunction(), true);
 	AddCollation("noaccent", StripAccentsFun::GetFunction(), true);

--- a/src/include/duckdb/function/built_in_functions.hpp
+++ b/src/include/duckdb/function/built_in_functions.hpp
@@ -53,6 +53,7 @@ private:
 	void RegisterTableFunctions();
 	void RegisterArrowFunctions();
 	void RegisterSnifferFunction();
+	void RegisterCopyFunctions();
 
 	void RegisterExtensionOverloads();
 

--- a/test/sql/copy/copy_blob.test
+++ b/test/sql/copy/copy_blob.test
@@ -1,0 +1,22 @@
+# name: test/sql/copy/copy_blob.test
+# group: [copy]
+
+statement error
+COPY (select 'foo') TO 'test.blob' (FORMAT BLOB);
+----
+Binder Error: "COPY (FORMAT BLOB)" only supports a single BLOB column
+
+statement error
+COPY (select 'foo'::BLOB, 10) TO 'test.blob' (FORMAT BLOB);
+----
+Binder Error: "COPY (FORMAT BLOB)" only supports a single BLOB column
+
+
+statement ok
+COPY (select 'foo'::BLOB) TO 'test.blob' (FORMAT BLOB);
+
+query III
+select filename, content, size from read_blob('test.blob');
+----
+test.blob	foo	3
+

--- a/test/sql/copy/copy_blob.test
+++ b/test/sql/copy/copy_blob.test
@@ -2,44 +2,44 @@
 # group: [copy]
 
 statement error
-COPY (select 'foo') TO 'test.blob' (FORMAT BLOB);
+COPY (select 'foo') TO '__TEST_DIR__/test.blob' (FORMAT BLOB);
 ----
 Binder Error: "COPY (FORMAT BLOB)" only supports a single BLOB column
 
 statement error
-COPY (select 'foo'::BLOB, 10) TO 'test.blob' (FORMAT BLOB);
+COPY (select 'foo'::BLOB, 10) TO '__TEST_DIR__/test.blob' (FORMAT BLOB);
 ----
 Binder Error: "COPY (FORMAT BLOB)" only supports a single BLOB column
 
 
 statement ok
-COPY (select 'foo'::BLOB) TO 'test.blob' (FORMAT BLOB);
+COPY (select 'foo'::BLOB) TO '__TEST_DIR__/test.blob' (FORMAT BLOB);
 
 query III
-select filename, content, size from read_blob('test.blob');
+select filename LIKE '%test.blob', content, size from read_blob('__TEST_DIR__/test.blob');
 ----
-test.blob	foo	3
+true	foo	3
 
 
 statement error
-COPY (select 'foo'::BLOB) TO 'test.blob.gz' (FORMAT BLOB, ASDFGH);
+COPY (select 'foo'::BLOB) TO '__TEST_DIR__/test.blob.gz' (FORMAT BLOB, ASDFGH);
 ----
 Binder Error: Unrecognized option for COPY (FORMAT BLOB): "ASDFGH"
 
 # With compression
 statement ok
-COPY (select 'foo'::BLOB) TO 'test.blob.gz' (FORMAT BLOB);
+COPY (select 'foo'::BLOB) TO '__TEST_DIR__/test.blob.gz' (FORMAT BLOB);
 
 query II
-select filename, size from read_blob('test.blob.gz');
+select filename LIKE '%test.blob.gz', size from read_blob('__TEST_DIR__/test.blob.gz');
 ----
-test.blob.gz	26
+true	26
 
 # With explicit compression
 statement ok
-COPY (select 'foo'::BLOB) TO 'test2.blob' (FORMAT BLOB, COMPRESSION 'GZIP');
+COPY (select 'foo'::BLOB) TO '__TEST_DIR__/test2.blob' (FORMAT BLOB, COMPRESSION 'GZIP');
 
 query II
-select filename, size from read_blob('test2.blob');
+select filename LIKE '%test2.blob', size from read_blob('__TEST_DIR__/test2.blob');
 ----
-test2.blob	26
+true	26

--- a/test/sql/copy/copy_blob.test
+++ b/test/sql/copy/copy_blob.test
@@ -37,9 +37,9 @@ test.blob.gz	26
 
 # With explicit compression
 statement ok
-COPY (select 'foo'::BLOB) TO 'test.blob' (FORMAT BLOB, COMPRESSION 'GZIP');
+COPY (select 'foo'::BLOB) TO 'test2.blob' (FORMAT BLOB, COMPRESSION 'GZIP');
 
 query II
-select filename, size from read_blob('test.blob');
+select filename, size from read_blob('test2.blob');
 ----
-test.blob	26
+test2.blob	26

--- a/test/sql/copy/copy_blob.test
+++ b/test/sql/copy/copy_blob.test
@@ -20,3 +20,26 @@ select filename, content, size from read_blob('test.blob');
 ----
 test.blob	foo	3
 
+
+statement error
+COPY (select 'foo'::BLOB) TO 'test.blob.gz' (FORMAT BLOB, ASDFGH);
+----
+Binder Error: Unrecognized option for COPY (FORMAT BLOB): "ASDFGH"
+
+# With compression
+statement ok
+COPY (select 'foo'::BLOB) TO 'test.blob.gz' (FORMAT BLOB);
+
+query II
+select filename, size from read_blob('test.blob.gz');
+----
+test.blob.gz	26
+
+# With explicit compression
+statement ok
+COPY (select 'foo'::BLOB) TO 'test.blob' (FORMAT BLOB, COMPRESSION 'GZIP');
+
+query II
+select filename, size from read_blob('test.blob');
+----
+test.blob	26


### PR DESCRIPTION
This PR adds a new `COPY TO` format, `BLOB` which supports taking a single column of `BLOB`s and concatenating them into a file.