### PR TITLE
Document storage version flag in CLI + minor rendering fix

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -980,7 +980,7 @@ void BoxRenderer::RenderRowCount(string &row_count_str, string &readable_rows_st
 		// we still need to render the readable rows/shown strings
 		// check if we can merge the two onto one row
 		idx_t combined_shown_length = readable_rows_str.size() + shown_str.size() + 4;
-		if (combined_shown_length <= total_length) {
+		if (!readable_rows_str.empty() && !shown_str.empty() && combined_shown_length <= total_length) {
 			// we can! merge them
 			ss << config.VERTICAL;
 			ss << " ";

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4755,7 +4755,7 @@ static const char zOptions[] =
     "   -s COMMAND           run \"COMMAND\" and exit\n"
     "   -safe                enable safe-mode\n"
     "   -separator SEP       set output column separator. Default: '|'\n"
-    "   -storage-version V   database storage compatibility version to use Default: 'v0.10.0'\n"
+    "   -storage-version V   database storage compatibility version to use. Default: 'v0.10.0'\n"
     "   -table               set output mode to 'table'\n"
     "   -ui                  launches a web interface using the ui extension (configurable with .ui_command)\n"
     "   -unredacted          allow printing unredacted secrets\n"

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4755,6 +4755,7 @@ static const char zOptions[] =
     "   -s COMMAND           run \"COMMAND\" and exit\n"
     "   -safe                enable safe-mode\n"
     "   -separator SEP       set output column separator. Default: '|'\n"
+    "   -storage-version V   database storage compatibility version to use Default: 'v0.10.0'\n"
     "   -table               set output mode to 'table'\n"
     "   -ui                  launches a web interface using the ui extension (configurable with .ui_command)\n"
     "   -unredacted          allow printing unredacted secrets\n"
@@ -4964,12 +4965,12 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 			data.openFlags |= DUCKDB_UNSIGNED_EXTENSIONS;
 		} else if (strcmp(z, "-safe") == 0) {
 			safe_mode = true;
-		} else if (strcmp(z, "-storage_version") == 0) {
+		} else if (strcmp(z, "-storage_version") == 0 || strcmp(z, "-storage-version") == 0) {
 			auto storage_version = string(cmdline_option_value(argc, argv, ++i));
 			if (storage_version != "latest") {
 				utf8_printf(
 				    stderr,
-				    "%s: Error: unknown argument (%s) for '-storage_version', only 'latest' is supported currently\n",
+				    "%s: Error: unknown argument (%s) for '-storage-version', only 'latest' is supported currently\n",
 				    program_name, storage_version.c_str());
 			} else {
 				data.openFlags |= DUCKDB_LATEST_STORAGE_VERSION;


### PR DESCRIPTION
This documents the available `-storage_version` flag and adds the `-storage-version` as alias (following the naming convention used for other parameters).