### PR TITLE
Add OnBeginExtensionLoad callback

### DIFF
--- a/src/include/duckdb/planner/extension_callback.hpp
+++ b/src/include/duckdb/planner/extension_callback.hpp
@@ -24,6 +24,9 @@ public:
 	//! Called when a connection is closed
 	virtual void OnConnectionClosed(ClientContext &context) {
 	}
+	//! Called before an extension starts loading
+	virtual void OnBeginExtensionLoad(DatabaseInstance &db, const string &name) {
+	}
 	//! Called after an extension is finished loading
 	virtual void OnExtensionLoaded(DatabaseInstance &db, const string &name) {
 	}

--- a/src/include/duckdb/planner/extension_callback.hpp
+++ b/src/include/duckdb/planner/extension_callback.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/common.hpp"
 
 namespace duckdb {
+class ClientContext;
 class DatabaseInstance;
 
 class ExtensionCallback {

--- a/src/main/extension_manager.cpp
+++ b/src/main/extension_manager.cpp
@@ -96,6 +96,10 @@ unique_ptr<ExtensionActiveLoad> ExtensionManager::BeginLoad(const string &name) 
 	if (info->is_loaded) {
 		return nullptr;
 	}
+	auto &callbacks = DBConfig::GetConfig(db).extension_callbacks;
+	for (auto &callback : callbacks) {
+		callback->OnBeginExtensionLoad(db, extension_name);
+	}
 	// extension is not loaded yet and we are in charge of loading it - return
 	return result;
 }


### PR DESCRIPTION
The `OnBeginExtensionLoad` callback can be used to get notified before an extension starts loading. 