### PR TITLE
Don't notify Py pkg when override git describe is set

### DIFF
--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Call /dispatch
-        if: ${{ github.repository == 'duckdb/duckdb' }}
+        if: ${{ github.repository == 'duckdb/duckdb' && inputs.override-git-describe == '' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-python/actions/workflows/release.yml/dispatches
           export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}", "stable-version": "${{ inputs.override-git-describe }}", "pypi-index": "prod" }}'

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -111,5 +111,5 @@ jobs:
         if: ${{ github.repository == 'duckdb/duckdb' && inputs.override-git-describe == '' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-python/actions/workflows/release.yml/dispatches
-          export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}", "stable-version": "${{ inputs.override-git-describe }}", "pypi-index": "prod" }}'
+          export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}", "pypi-index": "prod" }}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"


### PR DESCRIPTION
Let's not automatically trigger Python releases for stable versions.