### PR TITLE
Make ATTACH OR REPLACE atomic, keep list of used databases in MetaTransaction

### DIFF
--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -74,7 +74,9 @@ public:
 	const vector<reference<AttachedDatabase>> &OpenedTransactions() const {
 		return all_transactions;
 	}
+	optional_ptr<AttachedDatabase> GetReferencedDatabase(const string &name);
 	AttachedDatabase &UseDatabase(shared_ptr<AttachedDatabase> &database);
+	void DetachDatabase(AttachedDatabase &database);
 
 private:
 	//! Lock to prevent all_transactions and transactions from getting out of sync
@@ -87,8 +89,12 @@ private:
 	optional_ptr<AttachedDatabase> modified_database;
 	//! Whether or not the meta transaction is marked as read only
 	bool is_read_only;
+	//! Lock for referenced_databases
+	mutex referenced_database_lock;
 	//! The set of used / referenced databases
 	reference_map_t<AttachedDatabase, shared_ptr<AttachedDatabase>> referenced_databases;
+	//! Map of name -> used database for databases that are in-use by this transaction
+	case_insensitive_map_t<reference<AttachedDatabase>> used_databases;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -16,6 +16,7 @@
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/reference_map.hpp"
 #include "duckdb/common/error_data.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 
 namespace duckdb {
 class AttachedDatabase;

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -86,15 +86,23 @@ optional_ptr<AttachedDatabase> DatabaseManager::FinalizeAttach(ClientContext &co
 	if (default_database.empty()) {
 		default_database = name;
 	}
-	if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
-		DetachDatabase(context, name, OnEntryNotFound::RETURN_NULL);
-	}
+	shared_ptr<AttachedDatabase> detached_db;
 	{
 		lock_guard<mutex> guard(databases_lock);
 		auto entry = databases.emplace(name, attached_db);
 		if (!entry.second) {
-			throw BinderException("Failed to attach database: database with name \"%s\" already exists", name);
+			if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+				detached_db = std::move(entry.first);
+				databases.erase(entry);
+
+				databases[name] = attached_db;
+			} else {
+				throw BinderException("Failed to attach database: database with name \"%s\" already exists", name);
+			}
 		}
+	}
+	if (detached_db) {
+		detached_db->OnDetach(context);
 	}
 	auto &meta_transaction = MetaTransaction::Get(context);
 	auto &db_ref = meta_transaction.UseDatabase(attached_db);

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -64,7 +64,8 @@ Transaction &MetaTransaction::GetTransaction(AttachedDatabase &db) {
 #endif
 		all_transactions.push_back(db);
 		transactions.insert(make_pair(reference<AttachedDatabase>(db), TransactionReference(new_transaction)));
-		referenced_databases.insert(make_pair(reference<AttachedDatabase>(db), db.shared_from_this()));
+		auto shared_db = db.shared_from_this();
+		UseDatabase(shared_db);
 
 		return new_transaction;
 	} else {
@@ -184,10 +185,32 @@ void MetaTransaction::SetActiveQuery(transaction_t query_number) {
 	}
 }
 
+optional_ptr<AttachedDatabase> MetaTransaction::GetReferencedDatabase(const string &name) {
+	lock_guard<mutex> guard(referenced_database_lock);
+	auto entry = used_databases.find(name);
+	if (entry != used_databases.end()) {
+		return entry->second.get();
+	}
+	return nullptr;
+}
+
+void MetaTransaction::DetachDatabase(AttachedDatabase &database) {
+	lock_guard<mutex> guard(referenced_database_lock);
+	used_databases.erase(database.GetName());
+}
+
 AttachedDatabase &MetaTransaction::UseDatabase(shared_ptr<AttachedDatabase> &database) {
 	auto &db_ref = *database;
+	lock_guard<mutex> guard(referenced_database_lock);
 	auto entry = referenced_databases.find(db_ref);
 	if (entry == referenced_databases.end()) {
+		auto used_entry = used_databases.emplace(db_ref.GetName(), db_ref);
+		if (!used_entry.second) {
+			// return used_entry.first->second.get();
+			throw InternalException(
+			    "Database name %s was already used by a different database for this meta transaction",
+			    db_ref.GetName());
+		}
 		referenced_databases.emplace(reference<AttachedDatabase>(db_ref), database);
 	}
 	return db_ref;

--- a/test/sql/storage/concurrent_attach_or_replace.test_slow
+++ b/test/sql/storage/concurrent_attach_or_replace.test_slow
@@ -16,9 +16,12 @@ detach db_name
 
 endloop
 
+statement ok
+attach '__TEST_DIR__/attached_db0.duckdb' AS db_name
+
 concurrentloop i 0 10
 
-loop db_index 0 20
+loop db_index 1 20
 
 onlyif i<1
 statement ok

--- a/test/sql/storage/concurrent_attach_or_replace.test_slow
+++ b/test/sql/storage/concurrent_attach_or_replace.test_slow
@@ -25,7 +25,19 @@ loop db_index 1 20
 
 onlyif i<1
 statement ok
+begin
+
+onlyif i<1
+statement ok
 attach or replace '__TEST_DIR__/attached_db${db_index}.duckdb' AS db_name
+
+onlyif i<1
+statement ok
+select count(*) from db_name.integers
+
+onlyif i<1
+statement ok
+commit
 
 endloop
 

--- a/test/sql/storage/concurrent_attach_or_replace.test_slow
+++ b/test/sql/storage/concurrent_attach_or_replace.test_slow
@@ -1,0 +1,37 @@
+# name: test/sql/storage/concurrent_attach_or_replace.test_slow
+# description: Test concurrent running attach or replace
+# group: [storage]
+
+# create the databases
+loop db_index 0 20
+
+statement ok
+attach '__TEST_DIR__/attached_db${db_index}.duckdb' AS db_name
+
+statement ok
+create table db_name.integers(i integer);
+
+statement ok
+detach db_name
+
+endloop
+
+concurrentloop i 0 10
+
+loop db_index 0 20
+
+onlyif i<1
+statement ok
+attach or replace '__TEST_DIR__/attached_db${db_index}.duckdb' AS db_name
+
+endloop
+
+loop insert_idx 0 100
+
+onlyif i>=1
+statement ok
+insert into db_name.integers values (42);
+
+endloop
+
+endloop


### PR DESCRIPTION
Follow-up fixes to https://github.com/duckdb/duckdb/pull/18693

* Make `ATTACH OR REPLACE` atomic
* Keep a list of used databases in the MetaTransaction, so that if we use a database with a given name in a transaction, we can keep on using that database with that name