### PR TITLE
No more `wal_encryption` flag

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -194,8 +194,6 @@ struct DBConfigOptions {
 	string duckdb_api;
 	//! Metadata from DuckDB callers
 	string custom_user_agent;
-	//!  By default, WAL is encrypted for encrypted databases
-	bool wal_encryption = true;
 	//! Encrypt the temp files
 	bool temp_file_encryption = false;
 	//! The default block allocation size for new duckdb database files (new as-in, they do not yet exist).


### PR DESCRIPTION
There is no more wal_encryption flag, so we can delete this one