### PR TITLE
Multifile `parquet_metadata` and friends parallelism 

### DIFF
--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -507,6 +507,9 @@ void ParquetMetaDataOperator::BindSchema<ParquetMetadataOperatorType::SCHEMA>(ve
 
 	names.emplace_back("duckdb_type");
 	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("column_id");
+	return_types.emplace_back(LogicalType::BIGINT);
 }
 
 static Value ParquetLogicalTypeToString(const duckdb_parquet::LogicalType &type, bool is_set) {
@@ -601,6 +604,8 @@ void ParquetSchemaProcessor::ReadRow(DataChunk &output, idx_t output_idx, idx_t 
 		duckdb_type = reader->DeriveLogicalType(column, column_schema).ToString();
 	}
 	output.SetValue(11, output_idx, duckdb_type);
+	// column_id
+	output.SetValue(12, output_idx, Value::BIGINT(UnsafeNumericCast<int64_t>(row_idx)));
 }
 
 //===--------------------------------------------------------------------===//

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -856,7 +856,7 @@ unique_ptr<LocalTableFunctionState> ParquetMetaDataOperator::InitLocal(Execution
 	default:
 		throw InternalException("Unsupported ParquetMetadataOperatorType");
 	}
-	return res;
+	return unique_ptr_cast<LocalTableFunctionState, ParquetMetadataLocalState>(std::move(res));
 }
 
 template <ParquetMetadataOperatorType OP_TYPE>

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -106,6 +106,7 @@ struct ParquetMetadataGlobalState : public GlobalTableFunctionState {
 
 	double GetProgress() const {
 		// Not the most accurate, instantly assumes all files are done and equal
+		unique_lock<mutex> lock(file_paths->file_lock);
 		return static_cast<double>(file_paths->scan_data.current_file_idx) / file_paths->file_list->GetTotalFileCount();
 	}
 

--- a/test/sql/copy/parquet/parquet_metadata.test
+++ b/test/sql/copy/parquet/parquet_metadata.test
@@ -56,3 +56,39 @@ l_receiptdate	BYTE_ARRAY	VARCHAR
 l_shipinstruct	BYTE_ARRAY	VARCHAR
 l_shipmode	BYTE_ARRAY	VARCHAR
 l_comment	BYTE_ARRAY	VARCHAR
+
+# column_id
+query II
+SELECT column_id, name FROM parquet_schema('data/parquet-testing/lineitem-top10000.gzip.parquet') ORDER BY column_id;
+----
+0	spark_schema
+1	l_orderkey
+2	l_partkey
+3	l_suppkey
+4	l_linenumber
+5	l_quantity
+6	l_extendedprice
+7	l_discount
+8	l_tax
+9	l_returnflag
+10	l_linestatus
+11	l_shipdate
+12	l_commitdate
+13	l_receiptdate
+14	l_shipinstruct
+15	l_shipmode
+16	l_comment
+
+query III
+WITH per_file AS (
+    SELECT file_name, COUNT(*) AS rows_per_file
+    FROM parquet_schema('data/parquet-testing/glob3/**/*.parquet')
+    GROUP BY file_name
+)
+SELECT
+    SUM(rows_per_file) AS total_rows,
+    MAX(rows_per_file) AS max_rows_per_filename,
+    (SELECT COUNT(DISTINCT column_id) FROM parquet_schema('data/parquet-testing/glob3/**/*.parquet')) AS distinct_column_ids
+FROM per_file;
+----
+9	3	3

--- a/test/sql/copy/parquet/parquet_metadata_glob.test_slow
+++ b/test/sql/copy/parquet/parquet_metadata_glob.test_slow
@@ -1,0 +1,15 @@
+# name: test/sql/copy/parquet/parquet_metadata_glob.test_slow
+# description: Test parquet metadata function applied to many files
+# group: [parquet]
+
+require parquet
+
+statement ok
+SELECT * FROM parquet_metadata('data/parquet-testing/**.parquet');
+
+query II
+select row_group_bytes, row_group_compressed_bytes from parquet_metadata('data/parquet-testing/**.parquet')
+where file_name = 'data/parquet-testing/varchar_stats.parquet'
+----
+200	208
+200	208

--- a/test/sql/copy/parquet/parquet_stats.test
+++ b/test/sql/copy/parquet/parquet_stats.test
@@ -210,10 +210,10 @@ false	false
 query II
 select row_group_bytes, row_group_compressed_bytes from parquet_metadata('__TEST_DIR__/test.parquet');
 ----
-27	1
+27	29
 
 query II
 select row_group_bytes, row_group_compressed_bytes from parquet_metadata('data/parquet-testing/varchar_stats.parquet');
 ----
-200	1
-200	1
+200	208
+200	208


### PR DESCRIPTION
Converts parquet_metadata and family to have file-level paralellism and output chunks at a time, didn't use existing multi_file_function because it adds some overhead each file for handling possible different types which isn't relevant here and becomes significant with these very tiny and simple outputs

Adds Glob fallback for parquet_metadata and friends

Lots of moving around of code was done to enable this, I couldn't figure out a way with my limited knowledge of duckdb to do so without lots of moving around, but git makes it look like there are more changes than there are, almost all SetValue calls are effectively the same with just some indendation and variable name changes.

Adds a rudimentary and optimistic progress tracker, thinking is that it only really matters for queries with lots of files, otherwise it will be over before you can even see the progress tracker

Fixes bug with `row_group_compressed_bytes` which previously output just the flag now actually outputs how many bytes after compression

Speed difference on my 32 core machine:
Query chosen because of it's near use by ducklake and commentary here: https://github.com/duckdb/ducklake/issues/404
```sql
SET preserve_insertion_order = False;
.timer on
COPY (SELECT file_name, column_id, num_values, coalesce(stats_min, stats_min_value), coalesce(stats_max, stats_max_value), stats_null_count, total_compressed_size
  FROM parquet_metadata('big_directory.parquet')) TO 'test1.parquet' (PER_THREAD_OUTPUT);
```
Results prior: `Run Time (s): real 34.280 user 33.362211 sys 0.893388`
Results post: `Run Time (s): real 2.938 user 77.055939 sys 4.093423`

I'm not sure how to actually get ducklake to use this newly accessible parallelism, it doesn't by default instead it still runs effectively single threaded it seems. I tried manually adding calls to `SET preserve_insertion_order = False` within ducklake and that sped up my query mentioned before from 94 seconds to 48 (27 of which are processing ReadParquetStats after getting the query result showing there is still significant room for paralleism within ducklake) but I'm not sure of the correctness of how it affects the rest of the system and what really is the best way to do that.

I didn't understand `ColumnDataCollection` and hadn't used it in any of my extensions so I just relied on `DataChunk`, I think this theoretically could lead to less memory pressure

Very open to feedback on **whatever** is needed to enable these functions for big inputs to be parallelized