### PR TITLE
Hold segment lock during GetColumnSegmentInfo

### DIFF
--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1198,7 +1198,8 @@ vector<PartitionStatistics> RowGroupCollection::GetPartitionStats() const {
 //===--------------------------------------------------------------------===//
 vector<ColumnSegmentInfo> RowGroupCollection::GetColumnSegmentInfo() {
 	vector<ColumnSegmentInfo> result;
-	for (auto &row_group : row_groups->Segments()) {
+	auto lock = row_groups->Lock();
+	for (auto &row_group : row_groups->Segments(lock)) {
 		row_group.GetColumnSegmentInfo(row_group.index, result);
 	}
 	return result;


### PR DESCRIPTION
Fixes a thread sanitizer issue when reading row group metadata while simultaneously modifying the row groups