### PR TITLE
[minor] Incompatible DB error message: add newline

### DIFF
--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -168,7 +168,7 @@ MainHeader MainHeader::Read(ReadStream &source) {
 		    "%lld.\n"
 		    "The database file was created with %s.\n\n"
 		    "Newer DuckDB version might introduce backward incompatible changes (possibly guarded by compatibility "
-		    "settings)"
+		    "settings).\n"
 		    "See the storage page for migration strategy and more information: https://duckdb.org/internals/storage",
 		    header.version_number, VERSION_NUMBER_LOWER, VERSION_NUMBER_UPPER, version_text);
 	}


### PR DESCRIPTION
Error ended in:
```
Newer DuckDB version might introduce backward incompatible changes (possibly guarded by compatibility settings)See the storage page for migration strategy and more information: https://duckdb.org/internals/storage
```
after the PR:
```
Newer DuckDB version might introduce backward incompatible changes (possibly guarded by compatibility settings).
See the storage page for migration strategy and more information: https://duckdb.org/internals/storage
```

Bumped into this randomly, not super relevant.