### PR TITLE
Fallback to simple linear estimation if unscented kalman filter fails

### DIFF
--- a/src/common/progress_bar/unscented_kalman_filter.cpp
+++ b/src/common/progress_bar/unscented_kalman_filter.cpp
@@ -222,7 +222,7 @@ void UnscentedKalmanFilter::UpdateInternal(double measured_progress) {
 	// Update state
 	vector<double> innovation = {measured_progress - z_pred[0]};
 	for (size_t i = 0; i < STATE_DIM; i++) {
-		x[i] += K[i][0] * innovation[0];
+		x[i] += MaxValue<double>(K[i][0] * innovation[0], 0);
 	}
 
 	// Update covariance

--- a/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
+++ b/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
@@ -34,6 +34,8 @@ private:
 	vector<vector<double>> R; // measurement noise
 
 	double last_time;
+	double last_progress = 0;
+	double start_time;
 	bool initialized;
 
 	// Helper functions


### PR DESCRIPTION
CC @rustyconover 

This fixes an issue where somewhat slow moving queries would quickly start reporting effectively infinite times.

This can be observed relatively easily with the following query:

```sql
SUMMARIZE FROM read_parquet(repeat(['~/Data/hits.parquet'], 10));
```

On my Macbook this query takes around ~45 seconds per file and is ~roughly linear, so with 10 files the estimated progress should be around ~7-8 minutes. This instead quickly stops displaying progress at all (and used to display `> 99 hours` prior to https://github.com/duckdb/duckdb/pull/18839).

After looking into this it turns out this was caused by the velocity (`x[1]`) turning negative. I'm not sure what exactly the root cause is here, but I suspect it might have to do with floating point inaccuracies as the numbers get smaller. 

As a work-around, this PR adds a fallback to a simple linear estimate (where we effectively estimate the rate of change to be `progress_per_second` and divide the remaining progress by that). 

I now get the following progress displays:

```
SUMMARIZE FROM read_parquet(repeat(['~/Data/hits.parquet'], 10));
--- ~8.1 minutes

SUMMARIZE FROM read_parquet(repeat(['~/Data/hits.parquet'], 30));
--- ~26 minutes

SUMMARIZE FROM read_parquet(repeat(['~/Data/hits.parquet'], 100));
--- ~1.4 hours
```

There might be a better way of addressing this through fixing the unscented kalman filter - but I don't really have the time to dive into that at this point and this seems to at least fix the issue as a stopgap. 

