### PR TITLE
[Dev] Add missing assertion to `LogicalGet::Serialize`

### DIFF
--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -211,6 +211,8 @@ void LogicalGet::Serialize(Serializer &serializer) const {
 	FunctionSerializer::Serialize(serializer, function, bind_data.get());
 	if (!function.serialize) {
 		D_ASSERT(!function.serialize);
+		//! Assert that parameters isnt empty, because that is expected by Deserialize
+		D_ASSERT(!parameters.empty());
 		// no serialize method: serialize input values and named_parameters for rebinding purposes
 		serializer.WriteProperty(206, "parameters", parameters);
 		serializer.WriteProperty(207, "named_parameters", named_parameters);


### PR DESCRIPTION
Context:
MultiFileFunction's bind does this:
```c++
frame #4: 0x0000000138836944 libduckdb.1.4.dylib`duckdb::MultiFileFunction<duckdb::ParquetMultiFileInfo>::MultiFileBind(context=0x0000616000003998, input=0x000000016fde6d10, return_types=0x000000016fde6db0, names=0x000000016fde6df0) at multi_file_function.hpp:168:63
   165                  auto multi_file_reader = MultiFileReader::Create(input.table_function);
   166 
   167                  auto glob_input = multi_file_reader->GetGlobInput(*interface);
-> 168                  auto file_list = multi_file_reader->CreateFileList(context, input.inputs[0], glob_input);
```
Which expects `input.inputs[0]` to be present, `input.inputs` references the `parameters` of the LogicalGet.

Work-around for iceberg: https://github.com/duckdb/duckdb-iceberg/pull/447

Explanation:
In `LogicalGet::Deserialize`, if `!function.serialize` it will attempt to rebind, by using `parameters[0]`.
In the `Serialize` we weren't asserting parameters to not be empty, and this happens to be the case for the IcebergScan (somehow, I couldn't find out why).

This doesn't solve that problem, but at least it should die in Serialize rather than in Deserialize, hopefully aiding debugging in the future.