### PR TITLE
fix: refine query ETA display and Kalman filter stability

### DIFF
--- a/src/common/progress_bar/terminal_progress_bar_display.cpp
+++ b/src/common/progress_bar/terminal_progress_bar_display.cpp
@@ -119,27 +119,13 @@ void TerminalProgressBarDisplay::Update(double percentage) {
 	// Filters go from 0 to 1, percentage is from 0-100
 	const double filter_percentage = percentage / 100.0;
 
-	// The Kalman filter needs an initial guess about what the value
-	// is of query velocity, if we have no prior information, we should
-	// wait until a bit of the query has been processed.
-	//
-	// This guess about query velocity will be improved by the filter over time.
-	//
-	// Normally there is a progress bar delay, so its easy to make a guess,
-	// but if the progress bar interval is set to zero, just delay until some of the
-	// query has been processed and time has gone by.
-	//
-	// For the interval where there are no estimates, no ETA will be shown, but
-	// the progress bar will appear.
-	if (current_time > 0.5 && filter_percentage > 0.01) {
-		ukf.Update(filter_percentage, current_time);
-	}
+	ukf.Update(filter_percentage, current_time);
 
 	double estimated_seconds_remaining;
-	// If the query is mostly completed, there can be oscillation of estimated
-	// time to completion since the progress updates seem sparse near the very
-	// end of the query, so clamp time remaining to not oscillate with estimates
-	// that are unlikely to be correct.
+	//  If the query is mostly completed, there can be oscillation of estimated
+	//  time to completion since the progress updates seem sparse near the very
+	//  end of the query, so clamp time remaining to not oscillate with estimates
+	//  that are unlikely to be correct.
 	if (filter_percentage > 0.99) {
 		estimated_seconds_remaining = 0.5;
 	} else {

--- a/src/common/progress_bar/unscented_kalman_filter.cpp
+++ b/src/common/progress_bar/unscented_kalman_filter.cpp
@@ -4,7 +4,8 @@ namespace duckdb {
 
 UnscentedKalmanFilter::UnscentedKalmanFilter()
     : x(STATE_DIM, 0.0), P(STATE_DIM, vector<double>(STATE_DIM, 0.0)), Q(STATE_DIM, vector<double>(STATE_DIM, 0.0)),
-      R(OBS_DIM, vector<double>(OBS_DIM, 0.0)), last_time(0.0), last_progress(-1.0), initialized(false) {
+      R(OBS_DIM, vector<double>(OBS_DIM, 0.0)), last_time(0.0), last_progress(-1.0), initialized(false),
+      scale_factor(1.0) {
 
 	// Calculate UKF parameters
 	lambda = ALPHA * ALPHA * (STATE_DIM + KAPPA) - STATE_DIM;
@@ -21,16 +22,17 @@ UnscentedKalmanFilter::UnscentedKalmanFilter()
 	}
 
 	// Initialize covariance matrices
-	P[0][0] = 0.001; // progress variance
-	P[1][1] = 0.01;  // velocity variance
+	P[0][0] = 0.165;  // progress variance
+	P[1][1] = 0.0098; // velocity variance
 
-	Q[0][0] = 0.1; // process noise for progress
-	Q[1][1] = 0.0; // process noise for velocity
+	Q[0][0] = 0.01; // process noise for progress
+	Q[1][1] = 0.0;  // process noise for velocity
 
-	R[0][0] = 0.017; // measurement noise for progress
+	R[0][0] = 0.000077; // measurement noise for progress
 }
 
 void UnscentedKalmanFilter::Update(double progress, double time) {
+	progress *= scale_factor;
 	if (!initialized) {
 		Initialize(progress, time);
 		return;
@@ -43,8 +45,21 @@ void UnscentedKalmanFilter::Update(double progress, double time) {
 }
 
 void UnscentedKalmanFilter::Initialize(double initial_progress, double current_time) {
-	D_ASSERT(initial_progress != 0.0);
-	D_ASSERT(current_time != 0.0);
+	// If the initial progress is zero we can't yet initalize, since the filter
+	// wont' have a reasonable guess about query velocity, just wait until some
+	// progress has been made.
+	if (initial_progress == 0.0 || current_time == 0.0) {
+		return;
+	}
+	// If the initial progress value is very small, it needs to be scaled up so
+	// its the same relative magnitude of updates that was used to determine
+	// the P, Q, and R parameters of the Kalman filter.
+	//
+	// The settings for the Kalman filter make assumptions around the magnitude of
+	// measurement noise.  If the progress updates are very small, the updates
+	// could be considered noise by the Kalman filter.
+	scale_factor = std::max(1.0, 0.1 / initial_progress);
+	initial_progress *= scale_factor;
 	x[0] = initial_progress;
 	x[1] = initial_progress / current_time; // initial velocity guess
 	last_time = current_time;
@@ -258,8 +273,8 @@ double UnscentedKalmanFilter::GetEstimatedRemainingSeconds() const {
 		// velocity is negative or zero - we estimate this will never finish
 		return NumericLimits<double>::Maximum();
 	}
-	double remaining_progress = 1.0 - x[0];
-	return remaining_progress / x[1];
+	double remaining_progress = (1.0 * scale_factor) - x[0];
+	return std::max(remaining_progress / x[1], 0.0);
 }
 
 double UnscentedKalmanFilter::GetProgressVariance() const {

--- a/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
+++ b/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
@@ -20,7 +20,7 @@ private:
 	static constexpr size_t SIGMA_POINTS = 2 * STATE_DIM + 1;
 
 	// UKF parameters
-	static constexpr double ALPHA = 0.06;
+	static constexpr double ALPHA = 0.044;
 	static constexpr double BETA = 1.0;
 	static constexpr double KAPPA = 0.0;
 
@@ -36,6 +36,7 @@ private:
 	double last_time;
 	bool initialized;
 	double last_progress;
+	double scale_factor;
 
 	// Helper functions
 	vector<vector<double>> MatrixSqrt(const vector<vector<double>> &mat);

--- a/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
+++ b/src/include/duckdb/common/progress_bar/unscented_kalman_filter.hpp
@@ -20,7 +20,7 @@ private:
 	static constexpr size_t SIGMA_POINTS = 2 * STATE_DIM + 1;
 
 	// UKF parameters
-	static constexpr double ALPHA = 0.1;
+	static constexpr double ALPHA = 0.06;
 	static constexpr double BETA = 1.0;
 	static constexpr double KAPPA = 0.0;
 
@@ -35,6 +35,7 @@ private:
 
 	double last_time;
 	bool initialized;
+	double last_progress;
 
 	// Helper functions
 	vector<vector<double>> MatrixSqrt(const vector<vector<double>> &mat);


### PR DESCRIPTION
## UI

- Hide ETA when the Kalman filter has no valid prediction.
- Clamp ETA to 0.5s when query progress > 99.9% to reduce oscillations.

## Kalman Filter
- When progress bar delay = 0, defer ETA predictions until enough data is collected to estimate velocity reliably.
- Track last query progress percentage and skip duplicate values (prevents filter instability).
- Tune Alpha, P, Q, and R via differential evolution using sample queries. Improves accuracy and avoids numerical instability.