### PR TITLE
Avoid automatically checkpointing if the database instance has been invalidated

### DIFF
--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/main/database_path_and_type.hpp"
+#include "duckdb/main/valid_checker.hpp"
 
 namespace duckdb {
 
@@ -249,7 +250,7 @@ void AttachedDatabase::Close() {
 
 	// shutting down: attempt to checkpoint the database
 	// but only if we are not cleaning up as part of an exception unwind
-	if (!Exception::UncaughtException() && storage && !storage->InMemory()) {
+	if (!Exception::UncaughtException() && storage && !storage->InMemory() && !ValidChecker::IsInvalidated(db)) {
 		try {
 			auto &config = DBConfig::GetConfig(db);
 			if (config.options.checkpoint_on_shutdown) {


### PR DESCRIPTION
When the database is invalidated, the system can be in an undefined state. We should not run an automatic checkpoint on shutdown in this scenario since we could then write the undefined state to the file leading to data corruption.