### PR TITLE
Added variable to control the sampling rate when call `DetectBestCompressionMethod`

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -177,6 +177,15 @@
         ]
     },
     {
+        "name": "compression_sample_rate",
+        "description": "The sampling ratio used to detect the best compression method.",
+        "type": "DOUBLE",
+        "scope": "global",
+        "custom_implementation": [
+            "set"
+        ]
+    },
+    {
         "name": "custom_extension_repository",
         "description": "Overrides the custom endpoint for remote extension installation",
         "type": "VARCHAR",

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -165,6 +165,8 @@ struct DBConfigOptions {
 	CompressionType force_compression = CompressionType::COMPRESSION_AUTO;
 	//! Force a specific bitpacking mode to be used when using the bitpacking compression method
 	BitpackingMode force_bitpacking_mode = BitpackingMode::AUTO;
+	//! Sampling ratio when performing compression analysis.
+	double compression_sample_rate = 1.0;
 	//! Database configuration variables as controlled by SET
 	case_insensitive_map_t<Value> set_variables;
 	//! Database configuration variable default values;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -270,6 +270,16 @@ struct CheckpointThresholdSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct CompressionSampleRateSetting {
+	using RETURN_TYPE = double;
+	static constexpr const char *Name = "compression_sample_rate";
+	static constexpr const char *Description = "The sampling ratio used to detect the best compression method.";
+	static constexpr const char *InputType = "DOUBLE";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct CustomExtensionRepositorySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "custom_extension_repository";

--- a/src/include/duckdb/storage/table/column_data_checkpointer.hpp
+++ b/src/include/duckdb/storage/table/column_data_checkpointer.hpp
@@ -71,6 +71,7 @@ public:
 
 private:
 	void ScanSegments(const std::function<void(Vector &, idx_t)> &callback);
+	void ScanSegmentsWithSample(const std::function<void(Vector &, idx_t)> &callback, double sample_rate);
 	vector<CheckpointAnalyzeResult> DetectBestCompressionMethod();
 	void WriteToDisk();
 	bool HasChanges(ColumnData &col_data);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -79,6 +79,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(AutoloadKnownExtensionsSetting),
     DUCKDB_SETTING(CatalogErrorMaxSchemasSetting),
     DUCKDB_GLOBAL(CheckpointThresholdSetting),
+    DUCKDB_GLOBAL(CompressionSampleRateSetting),
     DUCKDB_GLOBAL(CustomExtensionRepositorySetting),
     DUCKDB_LOCAL(CustomProfilingSettingsSetting),
     DUCKDB_GLOBAL(CustomUserAgentSetting),
@@ -182,12 +183,12 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 86),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 36),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 105),
-                                                     DUCKDB_SETTING_ALIAS("user", 120),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 87),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 37),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 106),
+                                                     DUCKDB_SETTING_ALIAS("user", 121),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 21),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 119),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 120),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -207,6 +207,18 @@ void CheckpointThresholdSetting::ResetGlobal(DatabaseInstance *db, DBConfig &con
 }
 
 //===----------------------------------------------------------------------===//
+// Compression Sample Rate
+//===----------------------------------------------------------------------===//
+void CompressionSampleRateSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.compression_sample_rate = DBConfigOptions().compression_sample_rate;
+}
+
+Value CompressionSampleRateSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::DOUBLE(config.options.compression_sample_rate);
+}
+
+//===----------------------------------------------------------------------===//
 // Custom Extension Repository
 //===----------------------------------------------------------------------===//
 void CustomExtensionRepositorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -328,6 +328,18 @@ Value CheckpointThresholdSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
+// Compression Sample Rate
+//===----------------------------------------------------------------------===//
+void CompressionSampleRateSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto compression_sample_rate = input.GetValue<double>();
+	if (compression_sample_rate < 0 || compression_sample_rate > 1.0) {
+		throw InvalidInputException("the compression sample rate must be within [0, 1]");
+	}
+
+	config.options.compression_sample_rate = input.GetValue<double>();
+}
+
+//===----------------------------------------------------------------------===//
 // Custom Profiling Settings
 //===----------------------------------------------------------------------===//
 bool IsEnabledOptimizer(MetricsType metric, const set<OptimizerType> &disabled_optimizers) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -185,7 +185,8 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "enable_progress_bar_print",
 	    "progress_bar_time",
 	    "index_scan_max_count",
-	    "profiling_mode"};
+	    "profiling_mode",
+	    "compression_sample_rate"};
 	return excluded_options.count(name) == 1;
 }
 

--- a/test/sql/storage/compression/compression_sample_rate.test
+++ b/test/sql/storage/compression/compression_sample_rate.test
@@ -1,0 +1,51 @@
+# name: test/sql/storage/compression/compression_sample_rate.test
+# group: [compression]
+
+load __TEST_DIR__/test_compression_sample_rate.db readwrite v1.0.0
+
+# compression_sample_rate = 1, default.
+statement ok
+SET GLOBAL compression_sample_rate=1;
+
+statement ok
+CREATE TABLE employees1 AS SELECT i AS id, 'Employee ' || i AS name FROM generate_series(1, 200000) AS t(i);
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT DISTINCT compression FROM pragma_storage_info('employees1') WHERE segment_type ILIKE 'VARCHAR' limit 10;
+----
+FSST
+
+
+# compression_sample_rate = 0, use the first segment to detect best compression method.
+statement ok
+SET GLOBAL compression_sample_rate=0;
+
+statement ok
+CREATE TABLE employees0 AS SELECT i AS id, 'Employee ' || i AS name FROM generate_series(1, 200000) AS t(i);
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT DISTINCT compression FROM pragma_storage_info('employees0') WHERE segment_type ILIKE 'VARCHAR' limit 10;
+----
+Uncompressed
+
+
+# compression_sample_rate = 0.1.
+statement ok
+SET GLOBAL compression_sample_rate=0.1;
+
+statement ok
+CREATE TABLE employees01 AS SELECT i AS id, 'Employee ' || i AS name FROM generate_series(1, 200000) AS t(i);
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT DISTINCT compression FROM pragma_storage_info('employees01') WHERE segment_type ILIKE 'VARCHAR' limit 10;
+----
+FSST


### PR DESCRIPTION
Currently, we iterate over all segments when calling `DetectBestCompressionMethod`. This is accurate, but can lead to performance issues in some scenarios(such as append insert).

<img width="830" height="475" alt="image" src="https://github.com/user-attachments/assets/97e27b4e-b193-4ffe-aa26-0bc88cb31e82" />


Therefore, I'm trying to introduce a variable `compression_sample_rate` to control the sampling ratio. When calling `DetectBestCompressionMethod`, we select a certain percentage of segments instead of all segments to analyze the compression method.