### PR TITLE
Json: no reinterpret<size_t*>

### DIFF
--- a/extension/json/include/json_common.hpp
+++ b/extension/json/include/json_common.hpp
@@ -353,11 +353,19 @@ private:
 
 template <>
 inline char *JSONCommon::WriteVal(yyjson_val *val, yyjson_alc *alc, idx_t &len) {
-	return yyjson_val_write_opts(val, JSONCommon::WRITE_FLAG, alc, reinterpret_cast<size_t *>(&len), nullptr);
+	size_t len_size_t;
+	// yyjson_val_write_opts must not throw
+	auto ret = yyjson_val_write_opts(val, JSONCommon::WRITE_FLAG, alc, &len_size_t, nullptr);
+	len = len_size_t;
+	return ret;
 }
 template <>
 inline char *JSONCommon::WriteVal(yyjson_mut_val *val, yyjson_alc *alc, idx_t &len) {
-	return yyjson_mut_val_write_opts(val, JSONCommon::WRITE_FLAG, alc, reinterpret_cast<size_t *>(&len), nullptr);
+	size_t len_size_t;
+	// yyjson_mut_val_write_opts must not throw
+	auto ret = yyjson_mut_val_write_opts(val, JSONCommon::WRITE_FLAG, alc, &len_size_t, nullptr);
+	len = len_size_t;
+	return ret;
 }
 
 struct yyjson_doc_deleter {

--- a/extension/json/json_functions/json_pretty.cpp
+++ b/extension/json/json_functions/json_pretty.cpp
@@ -5,9 +5,9 @@ namespace duckdb {
 //! Pretty Print a given JSON Document
 string_t PrettyPrint(yyjson_val *val, yyjson_alc *alc, Vector &, ValidityMask &, idx_t) {
 	D_ASSERT(alc);
-	idx_t len;
-	auto data =
-	    yyjson_val_write_opts(val, JSONCommon::WRITE_PRETTY_FLAG, alc, reinterpret_cast<size_t *>(&len), nullptr);
+	size_t len_size_t;
+	auto data = yyjson_val_write_opts(val, JSONCommon::WRITE_PRETTY_FLAG, alc, &len_size_t, nullptr);
+	idx_t len = len_size_t;
 	return string_t(data, len);
 }
 

--- a/extension/json/json_functions/json_serialize_plan.cpp
+++ b/extension/json/json_functions/json_serialize_plan.cpp
@@ -162,10 +162,11 @@ static void JsonSerializePlanFunction(DataChunk &args, ExpressionState &state, V
 			yyjson_mut_obj_add_false(doc, result_obj, "error");
 			yyjson_mut_obj_add_val(doc, result_obj, "plans", plans_arr);
 
-			idx_t len;
+			size_t len_size_t;
 			auto data = yyjson_mut_val_write_opts(result_obj,
 			                                      info.format ? JSONCommon::WRITE_PRETTY_FLAG : JSONCommon::WRITE_FLAG,
-			                                      alc, reinterpret_cast<size_t *>(&len), nullptr);
+			                                      alc, &len_size_t, nullptr);
+			idx_t len = len_size_t;
 			if (data == nullptr) {
 				throw SerializationException(
 				    "Failed to serialize json, perhaps the query contains invalid utf8 characters?");
@@ -185,10 +186,11 @@ static void JsonSerializePlanFunction(DataChunk &args, ExpressionState &state, V
 				yyjson_mut_obj_add_strcpy(doc, result_obj, entry.first.c_str(), entry.second.c_str());
 			}
 
-			idx_t len;
+			size_t len_size_t;
 			auto data = yyjson_mut_val_write_opts(result_obj,
 			                                      info.format ? JSONCommon::WRITE_PRETTY_FLAG : JSONCommon::WRITE_FLAG,
-			                                      alc, reinterpret_cast<size_t *>(&len), nullptr);
+			                                      alc, &len_size_t, nullptr);
+			idx_t len = len_size_t;
 			return StringVector::AddString(result, data, len);
 		}
 	});

--- a/extension/json/json_functions/json_serialize_sql.cpp
+++ b/extension/json/json_functions/json_serialize_sql.cpp
@@ -114,10 +114,11 @@ static void JsonSerializeFunction(DataChunk &args, ExpressionState &state, Vecto
 
 			yyjson_mut_obj_add_false(doc, result_obj, "error");
 			yyjson_mut_obj_add_val(doc, result_obj, "statements", statements_arr);
-			idx_t len;
+			size_t len_size_t;
 			auto data = yyjson_mut_val_write_opts(result_obj,
 			                                      info.format ? JSONCommon::WRITE_PRETTY_FLAG : JSONCommon::WRITE_FLAG,
-			                                      alc, reinterpret_cast<size_t *>(&len), nullptr);
+			                                      alc, &len_size_t, nullptr);
+			idx_t len = len_size_t;
 			if (data == nullptr) {
 				throw SerializationException(
 				    "Failed to serialize json, perhaps the query contains invalid utf8 characters?");
@@ -135,10 +136,11 @@ static void JsonSerializeFunction(DataChunk &args, ExpressionState &state, Vecto
 				yyjson_mut_obj_add_strcpy(doc, result_obj, entry.first.c_str(), entry.second.c_str());
 			}
 
-			idx_t len;
+			size_t len_size_t;
 			auto data = yyjson_mut_val_write_opts(result_obj,
 			                                      info.format ? JSONCommon::WRITE_PRETTY_FLAG : JSONCommon::WRITE_FLAG,
-			                                      alc, reinterpret_cast<size_t *>(&len), nullptr);
+			                                      alc, &len_size_t, nullptr);
+			idx_t len = len_size_t;
 			return StringVector::AddString(result, data, len);
 		}
 	});


### PR DESCRIPTION
`size_t` is a quite peculiar type, reinterpret casts to size_t* are generally not great