### PR TITLE
[CI] - Skip failing test case for Windows

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -200,7 +200,7 @@ jobs:
 
     - name: Test
       shell: bash
-      run: test/Release/unittest.exe
+      run: test/Release/unittest.exe --test-config test/configs/skip_in_windows.json
 
     - name: Tools Test
       shell: bash

--- a/test/configs/skip_in_windows.json
+++ b/test/configs/skip_in_windows.json
@@ -1,0 +1,11 @@
+{
+  "description": "Skip tests in Windows",
+  "skip_tests": [
+    {
+      "reason": "Bug in Win32",
+      "paths": [
+        "test/sql/json/scalar/test_json_transform.test"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR makes [failing test case](https://github.com/duckdb/duckdb/actions/runs/17487015862/job/49672651078#step:6:4086) skipped for `Windows`.
Problem detected after adding missing expected messages to the `test/sql/json/scalar/test_json_transform.test` test case.

There is an internal issue for this problem.