### PR TITLE
[chore] Bump config test/configs/compressed_in_memory.json to new format

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -486,3 +486,9 @@ jobs:
       shell: bash
       run: |
         ./build/release/test/unittest --test-config test/configs/variant_vector.json
+
+    - name: Test variant_vector
+      if: (success() || failure()) && steps.build.conclusion == 'success'
+      shell: bash
+      run: |
+        ./build/release/test/unittest --test-config test/configs/compressed_in_memory.json

--- a/test/configs/compressed_in_memory.json
+++ b/test/configs/compressed_in_memory.json
@@ -5,13 +5,18 @@
   "on_load": "skip",
   "skip_compiled": "true",
   "skip_tests": [
-    "test/fuzzer/sqlsmith/current_schemas_null.test",
-    "test/sql/settings/drop_set_schema.test",
-    "test/sql/catalog/test_set_search_path.test",
-    "test/sql/storage/temp_directory/max_swap_space_explicit.test",
-    "test/sql/storage/temp_directory/max_swap_space_inmemory.test",
-    "test/sql/storage/temp_directory/max_swap_space_error.test",
-    "test/sql/storage/buffer_manager_temp_dir.test",
-    "test/sql/pg_catalog/system_functions.test"
+    {
+      "reason": "Unknown, to be investigated",
+      "paths": [
+        "test/fuzzer/sqlsmith/current_schemas_null.test",
+        "test/sql/settings/drop_set_schema.test",
+        "test/sql/catalog/test_set_search_path.test",
+        "test/sql/storage/temp_directory/max_swap_space_explicit.test",
+        "test/sql/storage/temp_directory/max_swap_space_inmemory.test",
+        "test/sql/storage/temp_directory/max_swap_space_error.test",
+        "test/sql/storage/buffer_manager_temp_dir.test",
+        "test/sql/pg_catalog/system_functions.test"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Currently file sit there, but was checked-in but in the wrong format, should be better to have this fixed.

Also adds this to the tests

I'll check if the test pass, then turn green.