### PR TITLE
Expected errors 2053

### DIFF
--- a/test/sql/filter/test_illegal_filters.test
+++ b/test/sql/filter/test_illegal_filters.test
@@ -15,4 +15,4 @@ INSERT INTO integers VALUES (2, 12)
 statement error
 SELECT * FROM integers WHERE SUM(a)>10
 ----
-
+<REGEX>:.*Binder Error.*cannot contain aggregates.*

--- a/test/sql/function/blob/base64.test
+++ b/test/sql/function/blob/base64.test
@@ -87,8 +87,10 @@ select from_base64('AAAA');
 statement error
 SELECT from_base64('ab');
 ----
+<REGEX>:.*Conversion Error: Could not decode string.*
 
 # unknown bytes
 statement error
 SELECT from_base64('üab');
 ----
+<REGEX>:.*Conversion Error: Could not decode string.*

--- a/test/sql/function/date/date_trunc_stats.test
+++ b/test/sql/function/date/date_trunc_stats.test
@@ -15,3 +15,4 @@ SELECT date_trunc('DAY', A0) FROM T1
 statement error
 SELECT datetrunc('milliseconds', DATE '-2005205-7-28');
 ----
+<REGEX>:.*Conversion Error.*not in timestamp range.*

--- a/test/sql/function/date/test_strftime.test
+++ b/test/sql/function/date/test_strftime.test
@@ -132,16 +132,19 @@ endloop
 statement error
 SELECT strftime(d, d::VARCHAR) FROM dates ORDER BY d;
 ----
+<REGEX>:.*Invalid Input Error.*must be a constant.*
 
 # unterminated escape
 statement error
 SELECT strftime(DATE '1992-01-01', '%');
 ----
+<REGEX>:.*Invalid Input Error.*Failed to parse format.*
 
 # unrecognized code
 statement error
 SELECT strftime(DATE '1992-01-01', '%R');
 ----
+<REGEX>:.*Invalid Input Error.*Failed to parse format.*
 
 # millisecond specifier %g
 query IIII
@@ -155,13 +158,15 @@ select strftime(strptime('023', '%g'), '%g'), strftime(strptime('0', '%g'), '%g'
 statement error
 SELECT strptime('-1', '%g');
 ----
+<REGEX>:.*Invalid Input Error.*Could not parse string.*
 
 statement error
 SELECT strptime('1000', '%g');
 ----
+<REGEX>:.*Invalid Input Error.*Could not parse string.*
 
 # this won't work without explicit casts
 statement error
 SELECT strftime('%Y', '1992-01-01');
 ----
-
+<REGEX>:.*Binder Error.*Could not choose a best candidate.*

--- a/test/sql/function/date/test_strftime_exhaustive.test
+++ b/test/sql/function/date/test_strftime_exhaustive.test
@@ -414,4 +414,4 @@ SELECT strftime(DATE '-4869706-10-11','%-yi');
 statement error
 SELECT strftime(date '-99999-01-01', random()::varchar)
 ----
-
+<REGEX>:.*Invalid Input Error.*must be a constant.*

--- a/test/sql/function/enum/test_enum_first.test
+++ b/test/sql/function/enum/test_enum_first.test
@@ -16,3 +16,4 @@ red
 statement error
 SELECT enum_first('bla')
 ----
+<REGEX>:.*Binder Error.*This function needs an ENUM.*

--- a/test/sql/function/enum/test_enum_last.test
+++ b/test/sql/function/enum/test_enum_last.test
@@ -16,3 +16,4 @@ purple
 statement error
 SELECT enum_last('bla')
 ----
+<REGEX>:.*Binder Error.*This function needs an ENUM.*

--- a/test/sql/function/enum/test_enum_range.test
+++ b/test/sql/function/enum/test_enum_range.test
@@ -40,19 +40,24 @@ SELECT enum_range_boundary('orange'::rainbow, NULL)
 statement error
 SELECT enum_range_boundary('orange'::rainbow, 'brl'::currency)
 ----
+<REGEX>:.*Binder Error.*parameters need to link.*
 
 statement error
 SELECT enum_range_boundary(NULL, NULL)
 ----
+<REGEX>:.*Binder Error.*This function needs an ENUM.*
 
 statement error
 SELECT enum_last('bla')
 ----
+<REGEX>:.*Binder Error.*This function needs an ENUM.*
 
 statement error
 SELECT enum_range_boundary('orange'::rainbow, 1)
 ----
+<REGEX>:.*Binder Error.*This function needs an ENUM.*
 
 statement error
 SELECT enum_range_boundary(1, 'orange'::rainbow)
 ----
+<REGEX>:.*Binder Error.*This function needs an ENUM.*

--- a/test/sql/function/list/aggregates/bit_and.test
+++ b/test/sql/function/list/aggregates/bit_and.test
@@ -45,3 +45,4 @@ NULL	1	NULL
 statement error
 SELECT list_bit_and()
 ----
+<REGEX>:.*Binder Error.*does not support the supplied arguments.*

--- a/test/sql/function/list/aggregates/bit_or.test
+++ b/test/sql/function/list/aggregates/bit_or.test
@@ -45,3 +45,4 @@ NULL	1	NULL
 statement error
 SELECT list_bit_or()
 ----
+<REGEX>:.*Binder Error.*does not support the supplied arguments.*

--- a/test/sql/function/list/aggregates/bit_xor.test
+++ b/test/sql/function/list/aggregates/bit_xor.test
@@ -45,3 +45,4 @@ NULL	0	NULL
 statement error
 SELECT list_bit_xor()
 ----
+<REGEX>:.*Binder Error.*does not support the supplied arguments.*

--- a/test/sql/function/list/aggregates/count.test
+++ b/test/sql/function/list/aggregates/count.test
@@ -34,3 +34,4 @@ NULL
 statement error
 select list_count()
 ----
+<REGEX>:.*Binder Error.*does not support the supplied arguments.*

--- a/test/sql/function/list/aggregates/kurtosis.test
+++ b/test/sql/function/list/aggregates/kurtosis.test
@@ -16,6 +16,7 @@ NULL
 statement error
 select list_kurtosis([2e304, 2e305, 2e306, 2e307])
 ----
+<REGEX>:.*Out of Range Error.*out of range.*
 
 statement ok
 create table aggr(k int[]);
@@ -50,3 +51,4 @@ NULL
 statement error
 select list_kurtosis()
 ----
+<REGEX>:.*Binder Error.*does not support the supplied arguments.*

--- a/test/sql/function/list/aggregates/var_stddev.test
+++ b/test/sql/function/list/aggregates/var_stddev.test
@@ -126,19 +126,23 @@ select list_aggr([0, 0], 'stddev')
 statement error
 select list_aggr([1e301, -1e301], 'stddev')
 ----
+<REGEX>:.*Out of Range Error.*out of range.*
 
 statement error
 select list_var_samp([1e301, -1e301])
 ----
+<REGEX>:.*Out of Range Error.*out of range.*
 
 statement error
 select list_var_pop([1e301, -1e301])
 ----
+<REGEX>:.*Out of Range Error.*out of range.*
 
 # incorrect usage
 statement error
 SELECT list_stddev_samp()
 ----
+<REGEX>:.*Binder Error.*does not support the supplied arguments.*
 
 # stddev_pop unexpectedly does not fetch any rows, test for list_stddev_pop
 statement ok
@@ -150,3 +154,4 @@ INSERT INTO t0 VALUES([1E200, 0]);
 statement error
 SELECT list_stddev_pop(c0) FROM t0;
 ----
+<REGEX>:.*Out of Range Error.*out of range.*

--- a/test/sql/function/list/generate_subscripts.test
+++ b/test/sql/function/list/generate_subscripts.test
@@ -20,3 +20,4 @@ SELECT generate_subscripts(NULL, 1)
 statement error
 SELECT generate_subscripts([[1,2],[3,4],[5,6]], 2)
 ----
+<REGEX>:.*Not implemented Error.*not implemented.*


### PR DESCRIPTION
Adds missing expected error messages to the test cases:

- test/sql/filter/test_illegal_filters.test
- test/sql/function/blob/base64.test
- test/sql/function/date/date_trunc_stats.test
- test/sql/function/date/test_strftime.test
- test/sql/function/date/test_strftime_exhaustive.test
- test/sql/function/enum/test_enum_first.test
- test/sql/function/enum/test_enum_last.test
- test/sql/function/enum/test_enum_range.test
- test/sql/function/list/aggregates/bit_and.test
- test/sql/function/list/aggregates/bit_or.test
- test/sql/function/list/aggregates/bit_xor.test
- test/sql/function/list/aggregates/count.test
- test/sql/function/list/aggregates/kurtosis.test
- test/sql/function/list/aggregates/var_stddev.test
- test/sql/function/list/generate_subscripts.test