### PR TITLE
Encryption now encoded as a bit, centralizing in set/getter

### DIFF
--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -119,7 +119,10 @@ public:
 	}
 
 	bool IsEncrypted() const {
-		return flags[0] == MainHeader::ENCRYPTED_DATABASE_FLAG;
+		return flags[0] & MainHeader::ENCRYPTED_DATABASE_FLAG;
+	}
+	void SetEncrypted() {
+		flags[0] |= MainHeader::ENCRYPTED_DATABASE_FLAG;
 	}
 
 	void SetEncryptionMetadata(data_ptr_t source) {

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -123,7 +123,7 @@ void MainHeader::Write(WriteStream &ser) {
 	SerializeVersionNumber(ser, DuckDB::SourceID());
 
 	// We always serialize, and write zeros, if not set.
-	auto encryption_enabled = flags[0] & MainHeader::ENCRYPTED_DATABASE_FLAG;
+	auto encryption_enabled = IsEncrypted();
 	SerializeEncryptionMetadata(ser, encryption_metadata, encryption_enabled);
 	SerializeDBIdentifier(ser, db_identifier);
 	SerializeEncryptionMetadata(ser, encrypted_canary, encryption_enabled);
@@ -391,7 +391,7 @@ void SingleFileBlockManager::CreateNewDatabase(QueryContext context) {
 		options.encryption_options.user_key = nullptr;
 
 		// Set the encrypted DB bit to 1.
-		main_header.flags[0] |= MainHeader::ENCRYPTED_DATABASE_FLAG;
+		main_header.SetEncrypted();
 
 		// The derived key is wiped in AddKeyToCache.
 		options.encryption_options.derived_key_id = EncryptionEngine::AddKeyToCache(db.GetDatabase(), derived_key);


### PR DESCRIPTION
Follow up from https://github.com/duckdb/duckdb/pull/18823, in particular comment at https://github.com/duckdb/duckdb/pull/18823#discussion_r2317434418, where we changed way to decide if a Database file is encrypted, but only in a single place.

This PR propagate the change to the `IsEncrypted` function, so same logic applies also to other codepath, and centralize also Setter to a location close-by in the code.

This PR should be compatible / orthogonal to the other in-flight encryption PR, but maybe that's best checked first merging the other one.