### PR TITLE
Fix query() function error message for PIVOT statements without explicit IN clauses

### DIFF
--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -114,6 +114,17 @@ SELECT * FROM query('CREATE TABLE tbl (a INT)');
 ----
 Parser Error: Expected a single SELECT statement
 
+# test PIVOT statements in query() function
+query I
+SELECT * FROM query('SELECT * FROM (PIVOT (SELECT 1 AS col) ON col IN (1) using first(col))');
+----
+1
+
+# PIVOT without explicit IN clause should give helpful error message
+statement error
+SELECT * FROM query('SELECT * FROM (PIVOT (SELECT 1 AS col) ON col using first(col))');
+----
+Parser Error: PIVOT statements without explicit IN clauses are not supported in query() function. Please specify the pivot values explicitly, e.g.: PIVOT ... ON col IN (val1, val2, ...)
 
 # test query_table()
 statement ok


### PR DESCRIPTION
## Description
Fixes bug where `query()` function showed confusing "Expected a single SELECT statement" error for PIVOT statements without explicit IN clauses, while PIVOT statements with explicit IN clauses worked correctly.

**Fix:** Enhanced `ParseSubquery` function to detect `MultiStatement` objects from PIVOT statements and provide clear error message.

## Testing
- **Manual testing:** Verified fix works in DuckDB CLI with both supported and unsupported PIVOT cases
- **Test coverage:** Added unit tests covering positive and negative PIVOT scenarios  
- **Regression testing:** Confirmed existing `query()` functionality still works

**Fixes:** #18712