### PR TITLE
Avoid adding a TupleDataChunkPart with only one row.

### DIFF
--- a/src/common/types/row/tuple_data_allocator.cpp
+++ b/src/common/types/row/tuple_data_allocator.cpp
@@ -241,8 +241,14 @@ TupleDataChunkPart TupleDataAllocator::BuildChunkPart(TupleDataPinState &pin_sta
 		if (total_heap_size == 0) {
 			result.SetHeapEmpty();
 		} else {
-			const auto heap_remaining = (heap_blocks.empty() || heap_blocks.back().RemainingCapacity() < heap_sizes[append_offset]) ?
-			    MaxValue<idx_t>(block_size, heap_sizes[append_offset]) : heap_blocks.back().RemainingCapacity();
+			idx_t heap_remaining;
+			if (!heap_blocks.empty() && heap_blocks.back().RemainingCapacity() >= heap_sizes[append_offset]) {
+				// We have enough room for the current entry
+				heap_remaining = heap_blocks.back().RemainingCapacity();
+			} else {
+				// We need to allocate a new block
+				heap_remaining = MaxValue<idx_t>(block_size, heap_sizes[append_offset]);
+			}
 
 			if (total_heap_size <= heap_remaining) {
 				// Everything fits

--- a/src/common/types/row/tuple_data_allocator.cpp
+++ b/src/common/types/row/tuple_data_allocator.cpp
@@ -241,8 +241,8 @@ TupleDataChunkPart TupleDataAllocator::BuildChunkPart(TupleDataPinState &pin_sta
 		if (total_heap_size == 0) {
 			result.SetHeapEmpty();
 		} else {
-			const auto heap_remaining = MaxValue<idx_t>(
-			    heap_blocks.empty() ? block_size : heap_blocks.back().RemainingCapacity(), heap_sizes[append_offset]);
+			const auto heap_remaining = (heap_blocks.empty() || heap_blocks.back().RemainingCapacity() < heap_sizes[append_offset]) ?
+			    MaxValue<idx_t>(block_size, heap_sizes[append_offset]) : heap_blocks.back().RemainingCapacity();
 
 			if (total_heap_size <= heap_remaining) {
 				// Everything fits


### PR DESCRIPTION
If current heap_block can not hold heap_sizes[append_offset], original code will set heap_remaining to heap_sizes[append_offset], and then add a TupleDataChunkPart with only one row.

In fact, a new heap_block will be allocated, and heap_remaining should be set to max(block_size, heap_sizes[append_offset]).