### PR TITLE
Fix Catalog Error: Table Function with name regexp_split_to_table does not exist

### DIFF
--- a/src/catalog/default/default_table_functions.cpp
+++ b/src/catalog/default/default_table_functions.cpp
@@ -71,7 +71,10 @@ SELECT * EXCLUDE (message), UNNEST(parse_duckdb_log_message(log_type, message))
 FROM duckdb_logs(denormalized_table=1)
 WHERE type = log_type
 )"},
-	{nullptr, nullptr, {nullptr}, {{nullptr, nullptr}}, nullptr}
+	{DEFAULT_SCHEMA, "regexp_split_to_table", {"text", "pattern", nullptr}, {{nullptr, nullptr}}, R"(
+SELECT UNNEST(string_split_regex(text, pattern)) AS num
+)"},
+	{nullptr, nullptr, {nullptr}, {{nullptr, nullptr}}, nullptr},
 	};
 // clang-format on
 

--- a/test/sql/table_function/duckdb_regexp_split_to_table_issue18523.test
+++ b/test/sql/table_function/duckdb_regexp_split_to_table_issue18523.test
@@ -1,0 +1,26 @@
+# name: test/sql/table_function/duckdb_regexp_split_to_table_issue18523.test
+# description: Issue 18523 - Catalog Error: Table Function with name regexp_split_to_table does not exist
+# group: [table_function]
+
+# Setup test data
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE T (s text);
+
+statement ok
+INSERT INTO T VALUES ('abc(1-2)xyz');
+
+# regexp_split_to_table works when called directly
+query T
+select regexp_split_to_table(substr(t.s::text, strpos(t.s::text,'(') + 1, strpos(t.s::text,')') - strpos(t.s::text, '(') - 1), '-') from t;
+----
+1
+2
+
+# regexp_split_to_table works when used in a FROM clause in a SELECT subquery
+query T
+select (select string_agg(num, '') from regexp_split_to_table(substr(t.s::text, strpos(t.s::text,'(') + 1, strpos(t.s::text,')') - strpos(t.s::text, '(') - 1), '-') num) from t;
+----
+12


### PR DESCRIPTION
Fixes #18523 by registering `regexp_split_to_table` as a macro in `src/catalog/default/default_table_functions.cpp`

```cpp
{DEFAULT_SCHEMA, "regexp_split_to_table", {"text", "pattern", nullptr}, {{nullptr, nullptr}}, R"(
SELECT UNNEST(string_split_regex(text, pattern)) AS num
)"},
```