### PR TITLE
CLI: Correctly move to start of line

### DIFF
--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -575,7 +575,7 @@ void Linenoise::EditMoveEnd() {
 
 /* Move cursor to the start of the line. */
 void Linenoise::EditMoveStartOfLine() {
-	while (pos > 0 && buf[pos] != '\n') {
+	while (pos > 0 && buf[pos - 1] != '\n') {
 		pos--;
 	}
 	RefreshLine();


### PR DESCRIPTION
Currently `EditMoveStartOfLine()` erroneously moves to the position between `\r\n` - i.e. `\r[NEW_POS]\n`. This leads to funky behavior when editing right after.