### PR TITLE
[Dev] Fix reference of uninitialized memory in Variant conversion first pass

### DIFF
--- a/src/include/duckdb/function/cast/variant/json_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/json_to_variant.hpp
@@ -147,11 +147,11 @@ static bool ConvertJSONPrimitive(yyjson_val *val, ToVariantGlobalResultData &res
 	case YYJSON_TYPE_RAW | YYJSON_SUBTYPE_NONE: {
 		WriteVariantMetadata<WRITE_DATA>(result, result_index, values_offset_data, blob_offset_data[result_index],
 		                                 nullptr, 0, VariantLogicalType::VARCHAR);
-		auto str = unsafe_yyjson_get_str(val);
 		uint32_t length = NumericCast<uint32_t>(unsafe_yyjson_get_len(val));
-		auto str_blob_data = blob_data + blob_offset_data[result_index];
 		auto length_varint_size = GetVarintSize(length);
 		if (WRITE_DATA) {
+			auto str = unsafe_yyjson_get_str(val);
+			auto str_blob_data = blob_data + blob_offset_data[result_index];
 			VarintEncode(length, str_blob_data);
 			memcpy(str_blob_data + length_varint_size, const_data_ptr_cast(str), length);
 		}
@@ -169,30 +169,30 @@ static bool ConvertJSONPrimitive(yyjson_val *val, ToVariantGlobalResultData &res
 		break;
 	}
 	case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT: {
-		auto value = unsafe_yyjson_get_uint(val);
 		WriteVariantMetadata<WRITE_DATA>(result, result_index, values_offset_data, blob_offset_data[result_index],
 		                                 nullptr, 0, VariantLogicalType::UINT64);
 		if (WRITE_DATA) {
+			auto value = unsafe_yyjson_get_uint(val);
 			memcpy(blob_data + blob_offset_data[result_index], const_data_ptr_cast(&value), sizeof(uint64_t));
 		}
 		blob_offset_data[result_index] += sizeof(uint64_t);
 		break;
 	}
 	case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT: {
-		auto value = unsafe_yyjson_get_sint(val);
 		WriteVariantMetadata<WRITE_DATA>(result, result_index, values_offset_data, blob_offset_data[result_index],
 		                                 nullptr, 0, VariantLogicalType::INT64);
 		if (WRITE_DATA) {
+			auto value = unsafe_yyjson_get_sint(val);
 			memcpy(blob_data + blob_offset_data[result_index], const_data_ptr_cast(&value), sizeof(int64_t));
 		}
 		blob_offset_data[result_index] += sizeof(int64_t);
 		break;
 	}
 	case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL: {
-		auto value = unsafe_yyjson_get_real(val);
 		WriteVariantMetadata<WRITE_DATA>(result, result_index, values_offset_data, blob_offset_data[result_index],
 		                                 nullptr, 0, VariantLogicalType::DOUBLE);
 		if (WRITE_DATA) {
+			auto value = unsafe_yyjson_get_real(val);
 			memcpy(blob_data + blob_offset_data[result_index], const_data_ptr_cast(&value), sizeof(double));
 		}
 		blob_offset_data[result_index] += sizeof(double);

--- a/src/include/duckdb/function/cast/variant/struct_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/struct_to_variant.hpp
@@ -31,8 +31,6 @@ bool ConvertStructToVariant(ToVariantSourceData &source, ToVariantGlobalResultDa
 		auto result_index = selvec ? selvec->get_index(i) : i;
 
 		auto &blob_offset = blob_offset_data[result_index];
-		auto &children_list_entry = variant.children_data[result_index];
-		auto &keys_list_entry = variant.keys_data[result_index];
 
 		if (source_validity.RowIsValid(index)) {
 			WriteVariantMetadata<WRITE_DATA>(result, result_index, values_offset_data, blob_offset, values_index_selvec,
@@ -55,6 +53,9 @@ bool ConvertStructToVariant(ToVariantSourceData &source, ToVariantGlobalResultDa
 
 			//! children
 			if (WRITE_DATA) {
+				auto &children_list_entry = variant.children_data[result_index];
+				auto &keys_list_entry = variant.keys_data[result_index];
+
 				idx_t children_index = children_list_entry.offset + children_offset_data[result_index];
 				idx_t keys_offset = keys_list_entry.offset + keys_offset_data[result_index];
 				for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {

--- a/src/include/duckdb/function/cast/variant/to_variant_fwd.hpp
+++ b/src/include/duckdb/function/cast/variant/to_variant_fwd.hpp
@@ -92,11 +92,11 @@ public:
 template <bool WRITE_DATA>
 void WriteArrayChildren(VariantVectorData &result, uint64_t children_offset, uint32_t &children_offset_data,
                         const list_entry_t source_entry, idx_t result_index, ContainerSelectionVectors &sel) {
-	idx_t children_index = children_offset + children_offset_data;
 	for (idx_t child_idx = 0; child_idx < source_entry.length; child_idx++) {
 		//! Set up the selection vector for the child of the list vector
 		sel.new_selection.set_index(child_idx + sel.count, result_index);
 		if (WRITE_DATA) {
+			idx_t children_index = children_offset + children_offset_data;
 			sel.children_selection.set_index(child_idx + sel.count, children_index + child_idx);
 			result.keys_index_validity.SetInvalid(children_index + child_idx);
 		}

--- a/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
@@ -113,7 +113,6 @@ bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalRe
 
 		auto &keys_offset = keys_offset_data[result_index];
 		auto &children_offset = children_offset_data[result_index];
-		auto &values_offset = values_offset_data[result_index];
 		auto &blob_offset = blob_offset_data[result_index];
 
 		uint32_t keys_count = 0;
@@ -126,6 +125,7 @@ bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalRe
 			continue;
 		}
 		if (WRITE_DATA && values_index_selvec) {
+			auto &values_offset = values_offset_data[result_index];
 			//! Write the values_index for the parent of this column
 			result.values_index_data[values_index_selvec->get_index(source_index)] = values_offset;
 		}
@@ -140,6 +140,7 @@ bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalRe
 		     source_children_index++) {
 			//! values_index
 			if (WRITE_DATA) {
+				auto &values_offset = values_offset_data[result_index];
 				auto source_value_index = source.GetValuesIndex(source_index, source_children_index);
 				result.values_index_data[children_list_entry.offset + children_offset + source_children_index] =
 				    values_offset + source_value_index;


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/5826

The variant conversion is done in two passes, the second pass using `WRITE_DATA` = true
I've moved the logic that's only relevant for this second pass into the blocks of WRITE_DATA, so uninitialized memory is never referenced in the first pass.