### PR TITLE
Make row-group metadata re-use experimental for now

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -457,6 +457,13 @@
         "struct": "ErrorsAsJSONSetting"
     },
     {
+        "name": "experimental_metadata_reuse",
+        "description": "EXPERIMENTAL: Re-use row group and table metadata when checkpointing.",
+        "type": "BOOLEAN",
+        "default_scope": "global",
+        "default_value": "false"
+    },
+    {
         "name": "explain_output",
         "description": "Output of EXPLAIN statements (ALL, OPTIMIZED_ONLY, PHYSICAL_ONLY)",
         "type": "ENUM<ExplainOutputType>",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -639,6 +639,15 @@ struct ErrorsAsJSONSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct ExperimentalMetadataReuseSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "experimental_metadata_reuse";
+	static constexpr const char *Description = "EXPERIMENTAL: Re-use row group and table metadata when checkpointing.";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SetScope DefaultScope = SetScope::GLOBAL;
+};
+
 struct ExplainOutputSetting {
 	using RETURN_TYPE = ExplainOutputType;
 	static constexpr const char *Name = "explain_output";

--- a/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
@@ -40,6 +40,7 @@ public:
 	virtual void FinishWritingColumns() {
 	}
 
+	DatabaseInstance &GetDatabase();
 	PartialBlockManager &GetPartialBlockManager() {
 		return partial_block_manager;
 	}

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -115,6 +115,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(EnableViewDependenciesSetting),
     DUCKDB_GLOBAL(EnabledLogTypes),
     DUCKDB_LOCAL(ErrorsAsJSONSetting),
+    DUCKDB_SETTING(ExperimentalMetadataReuseSetting),
     DUCKDB_LOCAL(ExplainOutputSetting),
     DUCKDB_GLOBAL(ExtensionDirectorySetting),
     DUCKDB_GLOBAL(ExternalThreadsSetting),
@@ -176,12 +177,12 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 82),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 83),
                                                      DUCKDB_SETTING_ALIAS("null_order", 33),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 101),
-                                                     DUCKDB_SETTING_ALIAS("user", 115),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 102),
+                                                     DUCKDB_SETTING_ALIAS("user", 116),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 20),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 114),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 115),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/storage/checkpoint/row_group_writer.cpp
+++ b/src/storage/checkpoint/row_group_writer.cpp
@@ -12,6 +12,10 @@ RowGroupWriter::RowGroupWriter(TableCatalogEntry &table, PartialBlockManager &pa
 	}
 }
 
+DatabaseInstance &RowGroupWriter::GetDatabase() {
+	return table.ParentCatalog().GetDatabase();
+}
+
 SingleFileRowGroupWriter::SingleFileRowGroupWriter(TableCatalogEntry &table, PartialBlockManager &partial_block_manager,
                                                    TableDataWriter &writer, MetadataWriter &table_data_writer)
     : RowGroupWriter(table, partial_block_manager), writer(writer), table_data_writer(table_data_writer) {

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -372,8 +372,14 @@ void ColumnDataCheckpointer::WritePersistentSegments(ColumnCheckpointState &stat
 	auto &col_data = state.column_data;
 	auto nodes = col_data.data.MoveSegments();
 
+	idx_t current_row = row_group.start;
 	for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
 		auto segment = nodes[segment_idx].node.get();
+		if (segment->start != current_row) {
+			throw InternalException(
+			    "Failure in RowGroup::Checkpoint - column data pointer is unaligned with row group start");
+		}
+		current_row += segment->count;
 		auto pointer = segment->GetDataPointer();
 
 		// merge the persistent stats into the global column stats

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -934,7 +934,9 @@ RowGroupWriteData RowGroup::WriteToDisk(RowGroupWriteInfo &info) {
 	// pointers all end up densely packed, and thus more cache-friendly.
 	for (idx_t column_idx = 0; column_idx < GetColumnCount(); column_idx++) {
 		auto &column = GetColumn(column_idx);
-		D_ASSERT(column.start == start);
+		if (column.start != start) {
+			throw InternalException("RowGroup::WriteToDisk - child-column is unaligned with row group");
+		}
 		ColumnCheckpointInfo checkpoint_info(info, column_idx);
 		auto checkpoint_state = column.Checkpoint(*this, checkpoint_info);
 		D_ASSERT(checkpoint_state);

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/storage/table/row_id_column_data.hpp"
+#include "duckdb/main/settings.hpp"
 
 namespace duckdb {
 
@@ -1000,7 +1001,8 @@ vector<MetaBlockPointer> RowGroup::GetColumnPointers() {
 }
 
 RowGroupWriteData RowGroup::WriteToDisk(RowGroupWriter &writer) {
-	if (!column_pointers.empty() && !HasChanges()) {
+	if (DBConfig::GetSetting<ExperimentalMetadataReuseSetting>(writer.GetDatabase()) && !column_pointers.empty() &&
+	    !HasChanges()) {
 		// we have existing metadata and the row group has not been changed
 		// re-use previous metadata
 		RowGroupWriteData result;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1112,7 +1112,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 
 	// no errors - finalize the row groups
 	// if the table already exists on disk - check if all row groups have stayed the same
-	if (metadata_pointer.IsValid()) {
+	if (DBConfig::GetSetting<ExperimentalMetadataReuseSetting>(writer.GetDatabase()) && metadata_pointer.IsValid()) {
 		bool table_has_changes = false;
 		for (idx_t segment_idx = 0; segment_idx < segments.size(); segment_idx++) {
 			auto &entry = segments[segment_idx];


### PR DESCRIPTION
There are some issues found in the row-group metadata re-use. As we are nearing the release - label it experimental for now and disable it by default to avoid causing issues. 