### PR TITLE
Fix exception propagation in C API 

### DIFF
--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -153,8 +153,13 @@ duckdb_aggregate_function duckdb_create_aggregate_function() {
 	                                              duckdb::CAPIAggregateStateInit, duckdb::CAPIAggregateUpdate,
 	                                              duckdb::CAPIAggregateCombine, duckdb::CAPIAggregateFinalize, nullptr,
 	                                              duckdb::CAPIAggregateBind);
-	function->function_info = duckdb::make_shared_ptr<duckdb::CAggregateFunctionInfo>();
-	return reinterpret_cast<duckdb_aggregate_function>(function);
+	try {
+		function->function_info = duckdb::make_shared_ptr<duckdb::CAggregateFunctionInfo>();
+		return reinterpret_cast<duckdb_aggregate_function>(function);
+	} catch (...) {
+		delete function;
+		return nullptr;
+	}
 }
 
 void duckdb_destroy_aggregate_function(duckdb_aggregate_function *function) {
@@ -266,8 +271,12 @@ duckdb_aggregate_function_set duckdb_create_aggregate_function_set(const char *n
 	if (!name || !*name) {
 		return nullptr;
 	}
-	auto function_set = new duckdb::AggregateFunctionSet(name);
-	return reinterpret_cast<duckdb_aggregate_function_set>(function_set);
+	try {
+		auto function_set = new duckdb::AggregateFunctionSet(name);
+		return reinterpret_cast<duckdb_aggregate_function_set>(function_set);
+	} catch (...) {
+		return nullptr;
+	}
 }
 
 void duckdb_destroy_aggregate_function_set(duckdb_aggregate_function_set *set) {

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -159,9 +159,14 @@ void duckdb_destroy_arrow_converted_schema(duckdb_arrow_converted_schema *arrow_
 duckdb_state duckdb_query_arrow(duckdb_connection connection, const char *query, duckdb_arrow *out_result) {
 	Connection *conn = (Connection *)connection;
 	auto wrapper = new ArrowResultWrapper();
-	wrapper->result = conn->Query(query);
-	*out_result = (duckdb_arrow)wrapper;
-	return !wrapper->result->HasError() ? DuckDBSuccess : DuckDBError;
+	try {
+		wrapper->result = conn->Query(query);
+		*out_result = (duckdb_arrow)wrapper;
+		return !wrapper->result->HasError() ? DuckDBSuccess : DuckDBError;
+	} catch (...) {
+		delete wrapper;
+		return DuckDBError;
+	}
 }
 
 duckdb_state duckdb_query_arrow_schema(duckdb_arrow result, duckdb_arrow_schema *out_schema) {
@@ -313,11 +318,16 @@ duckdb_state duckdb_execute_prepared_arrow(duckdb_prepared_statement prepared_st
 		return DuckDBError;
 	}
 	auto arrow_wrapper = new ArrowResultWrapper();
-	auto result = wrapper->statement->Execute(wrapper->values, false);
-	D_ASSERT(result->type == QueryResultType::MATERIALIZED_RESULT);
-	arrow_wrapper->result = duckdb::unique_ptr_cast<QueryResult, MaterializedQueryResult>(std::move(result));
-	*out_result = reinterpret_cast<duckdb_arrow>(arrow_wrapper);
-	return !arrow_wrapper->result->HasError() ? DuckDBSuccess : DuckDBError;
+	try {
+		auto result = wrapper->statement->Execute(wrapper->values, false);
+		D_ASSERT(result->type == QueryResultType::MATERIALIZED_RESULT);
+		arrow_wrapper->result = duckdb::unique_ptr_cast<QueryResult, MaterializedQueryResult>(std::move(result));
+		*out_result = reinterpret_cast<duckdb_arrow>(arrow_wrapper);
+		return !arrow_wrapper->result->HasError() ? DuckDBSuccess : DuckDBError;
+	} catch (...) {
+		delete arrow_wrapper;
+		return DuckDBError;
+	}
 }
 
 namespace arrow_array_stream_wrapper {
@@ -463,13 +473,25 @@ duckdb_state duckdb_arrow_array_scan(duckdb_connection connection, const char *t
 	private_data->array = reinterpret_cast<ArrowArray *>(arrow_array);
 	private_data->done = false;
 
-	ArrowArrayStream *stream = new ArrowArrayStream;
-	*out_stream = reinterpret_cast<duckdb_arrow_stream>(stream);
-	stream->get_schema = arrow_array_stream_wrapper::GetSchema;
-	stream->get_next = arrow_array_stream_wrapper::GetNext;
-	stream->get_last_error = arrow_array_stream_wrapper::GetLastError;
-	stream->release = arrow_array_stream_wrapper::Release;
-	stream->private_data = private_data;
+	ArrowArrayStream *stream;
+	try {
+		stream = new ArrowArrayStream;
+	} catch (...) {
+		delete private_data;
+		return DuckDBError;
+	}
+	try {
+		*out_stream = reinterpret_cast<duckdb_arrow_stream>(stream);
+		stream->get_schema = arrow_array_stream_wrapper::GetSchema;
+		stream->get_next = arrow_array_stream_wrapper::GetNext;
+		stream->get_last_error = arrow_array_stream_wrapper::GetLastError;
+		stream->release = arrow_array_stream_wrapper::Release;
+		stream->private_data = private_data;
 
-	return duckdb_arrow_scan(connection, table_name, reinterpret_cast<duckdb_arrow_stream>(stream));
+		return duckdb_arrow_scan(connection, table_name, reinterpret_cast<duckdb_arrow_stream>(stream));
+	} catch (...) {
+		delete private_data;
+		delete stream;
+		return DuckDBError;
+	}
 }

--- a/src/main/capi/data_chunk-c.cpp
+++ b/src/main/capi/data_chunk-c.cpp
@@ -48,8 +48,12 @@ void duckdb_data_chunk_reset(duckdb_data_chunk chunk) {
 
 duckdb_vector duckdb_create_vector(duckdb_logical_type type, idx_t capacity) {
 	auto dtype = reinterpret_cast<duckdb::LogicalType *>(type);
-	auto vector = new duckdb::Vector(*dtype, capacity);
-	return reinterpret_cast<duckdb_vector>(vector);
+	try {
+		auto vector = new duckdb::Vector(*dtype, capacity);
+		return reinterpret_cast<duckdb_vector>(vector);
+	} catch (...) {
+		return nullptr;
+	}
 }
 
 void duckdb_destroy_vector(duckdb_vector *vector) {

--- a/src/main/capi/duckdb-c.cpp
+++ b/src/main/capi/duckdb-c.cpp
@@ -148,8 +148,12 @@ void duckdb_connection_get_client_context(duckdb_connection connection, duckdb_c
 		return;
 	}
 	Connection *conn = reinterpret_cast<Connection *>(connection);
-	auto wrapper = new CClientContextWrapper(*conn->context);
-	*out_context = reinterpret_cast<duckdb_client_context>(wrapper);
+	try {
+		auto wrapper = new CClientContextWrapper(*conn->context);
+		*out_context = reinterpret_cast<duckdb_client_context>(wrapper);
+	} catch (...) {
+		*out_context = nullptr;
+	}
 }
 
 void duckdb_connection_get_arrow_options(duckdb_connection connection, duckdb_arrow_options *out_arrow_options) {
@@ -157,9 +161,13 @@ void duckdb_connection_get_arrow_options(duckdb_connection connection, duckdb_ar
 		return;
 	}
 	Connection *conn = reinterpret_cast<Connection *>(connection);
-	auto client_properties = conn->context->GetClientProperties();
-	auto wrapper = new CClientArrowOptionsWrapper(client_properties);
-	*out_arrow_options = reinterpret_cast<duckdb_arrow_options>(wrapper);
+	try {
+		auto client_properties = conn->context->GetClientProperties();
+		auto wrapper = new CClientArrowOptionsWrapper(client_properties);
+		*out_arrow_options = reinterpret_cast<duckdb_arrow_options>(wrapper);
+	} catch (...) {
+		*out_arrow_options = nullptr;
+	}
 }
 
 idx_t duckdb_client_context_get_connection_id(duckdb_client_context context) {
@@ -185,8 +193,12 @@ void duckdb_destroy_arrow_options(duckdb_arrow_options *arrow_options) {
 
 duckdb_state duckdb_query(duckdb_connection connection, const char *query, duckdb_result *out) {
 	Connection *conn = reinterpret_cast<Connection *>(connection);
-	auto result = conn->Query(query);
-	return DuckDBTranslateResult(std::move(result), out);
+	try {
+		auto result = conn->Query(query);
+		return DuckDBTranslateResult(std::move(result), out);
+	} catch (...) {
+		return DuckDBError;
+	}
 }
 
 const char *duckdb_library_version() {
@@ -195,26 +207,38 @@ const char *duckdb_library_version() {
 
 duckdb_value duckdb_get_table_names(duckdb_connection connection, const char *query, bool qualified) {
 	Connection *conn = reinterpret_cast<Connection *>(connection);
-	auto table_names = conn->GetTableNames(query, qualified);
+	try {
+		auto table_names = conn->GetTableNames(query, qualified);
 
-	auto count = table_names.size();
-	auto ptr = malloc(count * sizeof(duckdb_value));
-	auto list_values = reinterpret_cast<duckdb_value *>(ptr);
+		auto count = table_names.size();
+		auto ptr = malloc(count * sizeof(duckdb_value));
+		if (!ptr) {
+			return nullptr;
+		}
+		auto list_values = reinterpret_cast<duckdb_value *>(ptr);
 
-	idx_t name_ix = 0;
-	for (const auto &name : table_names) {
-		list_values[name_ix] = duckdb_create_varchar(name.c_str());
-		name_ix++;
+		try {
+			idx_t name_ix = 0;
+			for (const auto &name : table_names) {
+				list_values[name_ix] = duckdb_create_varchar(name.c_str());
+				name_ix++;
+			}
+
+			auto varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+			auto list_value = duckdb_create_list_value(varchar_type, list_values, count);
+
+			for (idx_t i = 0; i < count; i++) {
+				duckdb_destroy_value(&list_values[i]);
+			}
+			duckdb_free(ptr);
+			duckdb_destroy_logical_type(&varchar_type);
+
+			return list_value;
+		} catch (...) {
+			duckdb_free(ptr);
+			return nullptr;
+		}
+	} catch (...) {
+		return nullptr;
 	}
-
-	auto varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
-	auto list_value = duckdb_create_list_value(varchar_type, list_values, count);
-
-	for (idx_t i = 0; i < count; i++) {
-		duckdb_destroy_value(&list_values[i]);
-	}
-	duckdb_free(ptr);
-	duckdb_destroy_logical_type(&varchar_type);
-
-	return list_value;
 }

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -49,9 +49,13 @@ duckdb_logical_type duckdb_create_list_type(duckdb_logical_type type) {
 	if (!type) {
 		return nullptr;
 	}
-	duckdb::LogicalType *logical_type = new duckdb::LogicalType;
-	*logical_type = duckdb::LogicalType::LIST(*reinterpret_cast<duckdb::LogicalType *>(type));
-	return reinterpret_cast<duckdb_logical_type>(logical_type);
+	try {
+		duckdb::LogicalType *logical_type =
+		    new duckdb::LogicalType(duckdb::LogicalType::LIST(*reinterpret_cast<duckdb::LogicalType *>(type)));
+		return reinterpret_cast<duckdb_logical_type>(logical_type);
+	} catch (...) {
+		return nullptr;
+	}
 }
 
 duckdb_logical_type duckdb_create_array_type(duckdb_logical_type type, idx_t array_size) {
@@ -61,9 +65,13 @@ duckdb_logical_type duckdb_create_array_type(duckdb_logical_type type, idx_t arr
 	if (array_size >= duckdb::ArrayType::MAX_ARRAY_SIZE) {
 		return nullptr;
 	}
-	duckdb::LogicalType *ltype = new duckdb::LogicalType;
-	*ltype = duckdb::LogicalType::ARRAY(*reinterpret_cast<duckdb::LogicalType *>(type), array_size);
-	return reinterpret_cast<duckdb_logical_type>(ltype);
+	try {
+		duckdb::LogicalType *ltype = new duckdb::LogicalType(
+		    duckdb::LogicalType::ARRAY(*reinterpret_cast<duckdb::LogicalType *>(type), array_size));
+		return reinterpret_cast<duckdb_logical_type>(ltype);
+	} catch (...) {
+		return nullptr;
+	}
 }
 
 duckdb_logical_type duckdb_create_union_type(duckdb_logical_type *member_types_p, const char **member_names,
@@ -72,14 +80,17 @@ duckdb_logical_type duckdb_create_union_type(duckdb_logical_type *member_types_p
 		return nullptr;
 	}
 	duckdb::LogicalType **member_types = reinterpret_cast<duckdb::LogicalType **>(member_types_p);
-	duckdb::LogicalType *mtype = new duckdb::LogicalType;
-	duckdb::child_list_t<duckdb::LogicalType> members;
+	try {
+		duckdb::child_list_t<duckdb::LogicalType> members;
 
-	for (idx_t i = 0; i < member_count; i++) {
-		members.push_back(make_pair(member_names[i], *member_types[i]));
+		for (idx_t i = 0; i < member_count; i++) {
+			members.push_back(make_pair(member_names[i], *member_types[i]));
+		}
+		duckdb::LogicalType *mtype = new duckdb::LogicalType(duckdb::LogicalType::UNION(members));
+		return reinterpret_cast<duckdb_logical_type>(mtype);
+	} catch (...) {
+		return nullptr;
 	}
-	*mtype = duckdb::LogicalType::UNION(members);
-	return reinterpret_cast<duckdb_logical_type>(mtype);
 }
 
 duckdb_logical_type duckdb_create_struct_type(duckdb_logical_type *member_types_p, const char **member_names,
@@ -94,14 +105,17 @@ duckdb_logical_type duckdb_create_struct_type(duckdb_logical_type *member_types_
 		}
 	}
 
-	duckdb::LogicalType *mtype = new duckdb::LogicalType;
-	duckdb::child_list_t<duckdb::LogicalType> members;
+	try {
+		duckdb::child_list_t<duckdb::LogicalType> members;
 
-	for (idx_t i = 0; i < member_count; i++) {
-		members.push_back(make_pair(member_names[i], *member_types[i]));
+		for (idx_t i = 0; i < member_count; i++) {
+			members.push_back(make_pair(member_names[i], *member_types[i]));
+		}
+		duckdb::LogicalType *mtype = new duckdb::LogicalType(duckdb::LogicalType::STRUCT(members));
+		return reinterpret_cast<duckdb_logical_type>(mtype);
+	} catch (...) {
+		return nullptr;
 	}
-	*mtype = duckdb::LogicalType::STRUCT(members);
-	return reinterpret_cast<duckdb_logical_type>(mtype);
 }
 
 duckdb_logical_type duckdb_create_enum_type(const char **member_names, idx_t member_count) {
@@ -118,19 +132,25 @@ duckdb_logical_type duckdb_create_enum_type(const char **member_names, idx_t mem
 		enum_vector_ptr[i] = duckdb::StringVector::AddStringOrBlob(enum_vector, member_names[i]);
 	}
 
-	duckdb::LogicalType *mtype = new duckdb::LogicalType;
-	*mtype = duckdb::LogicalType::ENUM(enum_vector, member_count);
-	return reinterpret_cast<duckdb_logical_type>(mtype);
+	try {
+		duckdb::LogicalType *mtype = new duckdb::LogicalType(duckdb::LogicalType::ENUM(enum_vector, member_count));
+		return reinterpret_cast<duckdb_logical_type>(mtype);
+	} catch (...) {
+		return nullptr;
+	}
 }
 
 duckdb_logical_type duckdb_create_map_type(duckdb_logical_type key_type, duckdb_logical_type value_type) {
 	if (!key_type || !value_type) {
 		return nullptr;
 	}
-	duckdb::LogicalType *mtype = new duckdb::LogicalType;
-	*mtype = duckdb::LogicalType::MAP(*reinterpret_cast<duckdb::LogicalType *>(key_type),
-	                                  *reinterpret_cast<duckdb::LogicalType *>(value_type));
-	return reinterpret_cast<duckdb_logical_type>(mtype);
+	try {
+		duckdb::LogicalType *mtype = new duckdb::LogicalType(duckdb::LogicalType::MAP(
+		    *reinterpret_cast<duckdb::LogicalType *>(key_type), *reinterpret_cast<duckdb::LogicalType *>(value_type)));
+		return reinterpret_cast<duckdb_logical_type>(mtype);
+	} catch (...) {
+		return nullptr;
+	}
 }
 
 duckdb_logical_type duckdb_create_decimal_type(uint8_t width, uint8_t scale) {

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -51,10 +51,14 @@ duckdb_state duckdb_prepare_extracted_statement(duckdb_connection connection,
 		return DuckDBError;
 	}
 	auto wrapper = new PreparedStatementWrapper();
-	wrapper->statement = conn->Prepare(std::move(source_wrapper->statements[index]));
-
-	*out_prepared_statement = (duckdb_prepared_statement)wrapper;
-	return wrapper->statement->HasError() ? DuckDBError : DuckDBSuccess;
+	try {
+		wrapper->statement = conn->Prepare(std::move(source_wrapper->statements[index]));
+		*out_prepared_statement = (duckdb_prepared_statement)wrapper;
+		return wrapper->statement->HasError() ? DuckDBError : DuckDBSuccess;
+	} catch (...) {
+		delete wrapper;
+		return DuckDBError;
+	}
 }
 
 const char *duckdb_extract_statements_error(duckdb_extracted_statements extracted_statements) {
@@ -72,9 +76,14 @@ duckdb_state duckdb_prepare(duckdb_connection connection, const char *query,
 	}
 	auto wrapper = new PreparedStatementWrapper();
 	Connection *conn = reinterpret_cast<Connection *>(connection);
-	wrapper->statement = conn->Prepare(query);
-	*out_prepared_statement = reinterpret_cast<duckdb_prepared_statement>(wrapper);
-	return !wrapper->statement->HasError() ? DuckDBSuccess : DuckDBError;
+	try {
+		wrapper->statement = conn->Prepare(query);
+		*out_prepared_statement = reinterpret_cast<duckdb_prepared_statement>(wrapper);
+		return !wrapper->statement->HasError() ? DuckDBSuccess : DuckDBError;
+	} catch (...) {
+		delete wrapper;
+		return DuckDBError;
+	}
 }
 
 const char *duckdb_prepare_error(duckdb_prepared_statement prepared_statement) {
@@ -418,8 +427,12 @@ duckdb_state duckdb_execute_prepared_streaming(duckdb_prepared_statement prepare
 		return DuckDBError;
 	}
 
-	auto result = wrapper->statement->Execute(wrapper->values, true);
-	return DuckDBTranslateResult(std::move(result), out_result);
+	try {
+		auto result = wrapper->statement->Execute(wrapper->values, true);
+		return DuckDBTranslateResult(std::move(result), out_result);
+	} catch (...) {
+		return DuckDBError;
+	}
 }
 
 duckdb_statement_type duckdb_prepared_statement_type(duckdb_prepared_statement statement) {


### PR DESCRIPTION
To prevent crashes like "Rust cannot catch foreign exceptions" in foreign language bindings.

(Similar fix from the past: 08dc46f3bfba4ba298f2127ee973c57c7f71694f)

This PR also fixes some potential memory leaks in error conditions where ownership never transfers to the caller, so we must clean up ourselves.

Best reviewed by ignoring whitespace changes: https://github.com/duckdb/duckdb/pull/18924/files?w=1
