### PR TITLE
Move Hash Zero CI run to nightly

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -162,40 +162,6 @@ jobs:
         shell: bash
         run: build/relassert/test/unittest
 
- hash-zero:
-   name: Hash Zero
-   runs-on: ubuntu-24.04
-   needs: linux-configs
-   env:
-     GEN: ninja
-     CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
-     HASH_ZERO: 1
-     LSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-leak-suppressions.txt
-     DUCKDB_TEST_DESCRIPTION: 'Compiled with HASH_ZERO=1. Use require no_hash_zero to skip.'
-
-   steps:
-     - uses: actions/checkout@v3
-       with:
-         fetch-depth: 0
-
-     - name: Install
-       shell: bash
-       run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
-
-     - name: Setup Ccache
-       uses: hendrikmuhs/ccache-action@main
-       with:
-         key: ${{ github.job }}
-         save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
-
-     - name: Build
-       shell: bash
-       run: make relassert
-
-     - name: Test
-       shell: bash
-       run: build/relassert/test/unittest --test-config test/configs/hash_zero.json
-
  vector-sizes:
     name: Vector Sizes
     runs-on: ubuntu-22.04

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -628,6 +628,40 @@ jobs:
         path: |
           duckdb-wasm32.zip
 
+  hash-zero:
+   name: Hash Zero
+   runs-on: ubuntu-24.04
+   needs: linux-memory-leaks
+   env:
+     GEN: ninja
+     CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
+     HASH_ZERO: 1
+     LSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-leak-suppressions.txt
+     DUCKDB_TEST_DESCRIPTION: 'Compiled with HASH_ZERO=1. Use require no_hash_zero to skip.'
+
+   steps:
+     - uses: actions/checkout@v3
+       with:
+         fetch-depth: 0
+
+     - name: Install
+       shell: bash
+       run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+
+     - name: Setup Ccache
+       uses: hendrikmuhs/ccache-action@main
+       with:
+         key: ${{ github.job }}
+         save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
+
+     - name: Build
+       shell: bash
+       run: make relassert
+
+     - name: Test
+       shell: bash
+       run: build/relassert/test/unittest --test-config test/configs/hash_zero.json
+
   codecov:
     name: Code Coverage
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This CI run is rather slow due to it (intentionally) creating huge hash chains in every single hash table. I think it is unlikely this will find new bugs - so let's move it to nightly instead.