### PR TITLE
[unittester] Allow overriding data/ folder to custom location

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -199,7 +199,12 @@ bool TestConfiguration::ShouldSkipTest(const string &test_name) {
 }
 
 string TestConfiguration::DataLocation() {
-	return GetOptionOrDefault("data_location", string("data/"));
+	string res = GetOptionOrDefault("data_location", string("data/"));
+	// Force DataLocation to end with a '/'
+	if (res.back() != '/') {
+		res += "/";
+	}
+	return res;
 }
 
 string TestConfiguration::OnInitCommand() {

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -53,6 +53,8 @@ static const TestConfigOption test_config_options[] = {
     {"statically_loaded_extensions", "Extensions to be loaded (from the statically available one)",
      LogicalType::LIST(LogicalType::VARCHAR), nullptr},
     {"storage_version", "Database storage version to use by default", LogicalType::VARCHAR, nullptr},
+    {"data_location", "Directory where static test files are read (defaults to `data/`)", LogicalType::VARCHAR,
+     nullptr},
     {nullptr, nullptr, LogicalType::INVALID, nullptr},
 };
 
@@ -194,6 +196,10 @@ TestConfiguration::ExtensionAutoLoadingMode TestConfiguration::GetExtensionAutoL
 
 bool TestConfiguration::ShouldSkipTest(const string &test_name) {
 	return tests_to_be_skipped.count(test_name);
+}
+
+string TestConfiguration::DataLocation() {
+	return GetOptionOrDefault("data_location", string("data/"));
 }
 
 string TestConfiguration::OnInitCommand() {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -50,6 +50,7 @@ public:
 	DebugInitialize GetDebugInitialize();
 	ExtensionAutoLoadingMode GetExtensionAutoLoadingMode();
 	bool ShouldSkipTest(const string &test_name);
+	string DataLocation();
 	string OnInitCommand();
 	string OnLoadCommand();
 	string OnConnectionCommand();

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -309,7 +309,10 @@ bool TestResultHelper::CheckStatementResult(const Statement &statement, ExecuteC
 			error = !error;
 		}
 		if (result.HasError() && !statement.expected_error.empty()) {
-			if (!StringUtil::Contains(result.GetError(), statement.expected_error)) {
+			// We run both comparions on purpose, we might move to only the second but might require some changes in
+			// tests
+			if (!StringUtil::Contains(result.GetError(), statement.expected_error) &&
+			    !StringUtil::Contains(result.GetError(), runner.ReplaceKeywords(statement.expected_error))) {
 				bool success = false;
 				if (StringUtil::StartsWith(statement.expected_error, "<REGEX>:") ||
 				    StringUtil::StartsWith(statement.expected_error, "<!REGEX>:")) {
@@ -487,7 +490,8 @@ bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQue
 	Value lvalue, rvalue;
 	bool error = false;
 	// simple first test: compare string value directly
-	if (lvalue_str == rvalue_str) {
+	// We run both comparions on purpose, we might move to only the second but might require some changes in tests
+	if (lvalue_str == rvalue_str || lvalue_str == runner.ReplaceKeywords(rvalue_str)) {
 		return true;
 	}
 	if (StringUtil::StartsWith(rvalue_str, "<REGEX>:") || StringUtil::StartsWith(rvalue_str, "<!REGEX>:")) {

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -311,6 +311,7 @@ bool TestResultHelper::CheckStatementResult(const Statement &statement, ExecuteC
 		if (result.HasError() && !statement.expected_error.empty()) {
 			// We run both comparions on purpose, we might move to only the second but might require some changes in
 			// tests
+			// This is due to some errors containing absolute paths, some relatives
 			if (!StringUtil::Contains(result.GetError(), statement.expected_error) &&
 			    !StringUtil::Contains(result.GetError(), runner.ReplaceKeywords(statement.expected_error))) {
 				bool success = false;
@@ -491,6 +492,7 @@ bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQue
 	bool error = false;
 	// simple first test: compare string value directly
 	// We run both comparions on purpose, we might move to only the second but might require some changes in tests
+	// This is due to some results containing absolute paths, some relatives
 	if (lvalue_str == rvalue_str || lvalue_str == runner.ReplaceKeywords(rvalue_str)) {
 		return true;
 	}

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -227,6 +227,16 @@ string SQLLogicTestRunner::ReplaceKeywords(string input) {
 	input = StringUtil::Replace(input, "__TEST_DIR__", TestDirectoryPath());
 	input = StringUtil::Replace(input, "__WORKING_DIRECTORY__", FileSystem::GetWorkingDirectory());
 	input = StringUtil::Replace(input, "__BUILD_DIRECTORY__", DUCKDB_BUILD_DIRECTORY);
+
+	auto &test_config = TestConfiguration::Get();
+	string data_location = test_config.DataLocation();
+
+	input = StringUtil::Replace(input, "'data/", string("'") + data_location);
+	input = StringUtil::Replace(input, "\"data/", string("\"") + data_location);
+	if (StringUtil::StartsWith(input, "data/")) {
+		input = data_location + input.substr(5);
+	}
+
 	return input;
 }
 


### PR DESCRIPTION
This allows for example to change where data files are sourced, from the default `data/` directory to:
```
./build/release/test/unittest --on-init "LOAD httpfs;" --skip-error-messages "[]"
    --data-location "path/to/data/"
```

Or the same but sourcing data files from github, so testing the remote reading of files from a HTTPS endpoint:
```
./build/release/test/unittest --on-init "LOAD httpfs;" --skip-error-messages "[]"
    --data-location "https://raw.githubusercontent.com/duckdb/duckdb/main/data/"
```

Or, after starting a local http-server, from a local HTTP endpoint:
```
./build/release/test/unittest --on-init "LOAD httpfs;" --skip-error-messages "[]"
    --data-location "http://127.0.0.1:8080/data/"
```

Or, after moving data to some S3 bucket (and a persistent secret with relevant permissions):
```
./build/release/duckdb -c "CREATE PERSISTENT SECRET s3 (...)"
./build/release/test/unittest --on-init "LOAD httpfs;" --skip-error-messages "[]"
    --data-location "s3://test-bucket/"
```

This should allow to test more paths, both on the side of the FileSystem abstraction (say `duckdb-httpfs` or other relevant file system abstractions such as duckdb-wasm's adaptation, or python's one or `duckdb-azure` or else) AND on the side of core DuckDB since different FileSystem will respond in different ways.