### PR TITLE
Bump ducklake before release

### DIFF
--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG 87de1123f10ac1486ef61844a160fa4af89a1f16
+    GIT_TAG 48bb9b335d77807c425d23c809fe4b6eb837baf0
 )


### PR DESCRIPTION
Notice that this is the correct tag for the release and not the one in https://github.com/duckdb/duckdb/pull/18936