### PR TITLE
Http_util can return success for all [200, 300) responses, as well as redirects

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,6 +14,7 @@ body:
             * [duckdb-node](https://github.com/duckdb/duckdb-node/issues/new)
             * [duckdb-node-neo](https://github.com/duckdb/duckdb-node-neo/issues/new)
             * [duckdb-odbc](https://github.com/duckdb/duckdb-odbc/issues/new)
+            * [duckdb-python](https://github.com/duckdb/duckdb-python/issues/new)
             * [duckdb-r](https://github.com/duckdb/duckdb-r/issues/new)
             * [duckdb-rs](https://github.com/duckdb/duckdb-rs/issues/new)
             * [duckdb-swift](https://github.com/duckdb/duckdb-swift/issues/new)

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -382,7 +382,7 @@ HTTPUtil::RunRequestWithRetry(const std::function<unique_ptr<HTTPResponse>(void)
 			auto response_code = static_cast<uint16_t>(response->status);
 			if (response_code >= 200 and response_code < 300) {
 				response->success = true;
-				break;
+				return response;
 			}
 			switch (response->status) {
 			case HTTPStatusCode::NotModified_304:

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -379,8 +379,12 @@ HTTPUtil::RunRequestWithRetry(const std::function<unique_ptr<HTTPResponse>(void)
 		// Note: request errors will always be retried
 		bool should_retry = !response || response->ShouldRetry();
 		if (!should_retry) {
+			auto response_code = static_cast<uint16_t>(response->status);
+			if (response_code >= 200 and response_code < 300) {
+				response->success = true;
+				break;
+			}
 			switch (response->status) {
-			case HTTPStatusCode::OK_200:
 			case HTTPStatusCode::NotModified_304:
 				response->success = true;
 				break;

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -380,7 +380,7 @@ HTTPUtil::RunRequestWithRetry(const std::function<unique_ptr<HTTPResponse>(void)
 		bool should_retry = !response || response->ShouldRetry();
 		if (!should_retry) {
 			auto response_code = static_cast<uint16_t>(response->status);
-			if (response_code >= 200 and response_code < 300) {
+			if (response_code >= 200 && response_code < 300) {
 				response->success = true;
 				return response;
 			}


### PR DESCRIPTION
Currently only OK_200, and NotModified_304 return HTTPResponse objects indicating success. With DuckDB iceberg, we have been using aws and httputil to make requests, and the response status values have not been consistent. I think all 200 responses should merit success, as well as NotModified_304. 

One example where this has come up is that Iceberg makes Head requests to verify the existence of a schema. Many IRCs respond with 204_NoContent. The Http_util library will label this as success = false, when that is indeed no the case. 

Also happy to open this to v1.4-andium.

