### PR TITLE
Fix TransformStringToLogicalType for enums arrays

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -624,6 +624,10 @@ LogicalType GetUserTypeRecursive(const LogicalType &type, ClientContext &context
 	if (type.id() == LogicalTypeId::LIST) {
 		return LogicalType::LIST(GetUserTypeRecursive(ListType::GetChildType(type), context));
 	}
+	if (type.id() == LogicalTypeId::ARRAY) {
+		return LogicalType::ARRAY(GetUserTypeRecursive(ArrayType::GetChildType(type), context),
+		                          ArrayType::GetSize(type));
+	}
 	if (type.id() == LogicalTypeId::MAP) {
 		return LogicalType::MAP(GetUserTypeRecursive(MapType::KeyType(type), context),
 		                        GetUserTypeRecursive(MapType::ValueType(type), context));

--- a/test/sql/json/scalar/test_json_transform.test
+++ b/test/sql/json/scalar/test_json_transform.test
@@ -525,3 +525,25 @@ statement error
 select json_transform_strict('42', '"TIMESTAMP"')
 ----
 <REGEX>:.*Invalid Input Error.*Unable to cast.*
+
+# enum tests
+statement ok
+CREATE OR REPLACE TYPE test_enum AS ENUM ('a', 'b', 'c');
+
+query T
+select json_transform('{"test": "a"}', '{"test": "test_enum"}')
+----
+{'test': a}
+
+query T
+select json_transform('{"test": ["a","b"]}', '{"test": "test_enum[]"}')
+----
+{'test': [a, b]}
+
+query T
+select json_transform('{"test": ["a","b"]}', '{"test": "test_enum[2]"}')
+----
+{'test': [a, b]}
+
+statement ok
+DROP TYPE test_enum;


### PR DESCRIPTION
## Description

We're using `TransformStringToLogicalType` (common/types.cpp) to convert type strings (e.g. "VARCHAR") to a DuckDB LogicalType. For ARRAY-types, the function currently only returns a shallow copy which causes an issue with enum arrays ("MY_ENUM[2]") for us. 

[`json_transform`](https://duckdb.org/docs/stable/data/json/json_functions#transforming-json-to-nested-types) appears to suffer from the same issue. 

Simple reproducer:

```
CREATE OR REPLACE TYPE test_enum AS ENUM ('a', 'b', 'c');
SELECT json_transform('{"test": ["a","b"]}', '{"test": "test_enum[]"}');
┌──────────────────────────────────────────────────────────────────┐
│ json_transform('{"test": ["a","b"]}', '{"test": "test_enum[]"}') │
│                struct(test enum('a', 'b', 'c')[])                │
├──────────────────────────────────────────────────────────────────┤
│ {'test': [a, b]}                                                 │
└──────────────────────────────────────────────────────────────────┘
SELECT json_transform('{"test": ["a","b"]}', '{"test": "test_enum[2]"}');
INTERNAL Error:
Unsupported type UNKNOWN for ColumnDataCollection::GetCopyFunction

Stack Trace:

0        duckdb::Exception::ToJSON(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 40
1        duckdb::Exception::Exception(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 36
2        duckdb::InternalException::InternalException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 20
3        duckdb::InternalException::InternalException<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>) + 92
4        duckdb::ColumnDataCollection::GetCopyFunction(duckdb::LogicalType const&) + 660
5        duckdb::ColumnDataCollection::GetCopyFunction(duckdb::LogicalType const&) + 164
6        duckdb::ColumnDataCollection::GetCopyFunction(duckdb::LogicalType const&) + 312
7        duckdb::ColumnDataCollection::Initialize(duckdb::vector<duckdb::LogicalType, true>) + 136
8        duckdb::ColumnDataCollection::ColumnDataCollection(duckdb::Allocator&, duckdb::vector<duckdb::LogicalType, true>) + 96
9        duckdb::PhysicalMaterializedCollector::GetLocalSinkState(duckdb::ExecutionContext&) const + 180
10       duckdb::PipelineExecutor::PipelineExecutor(duckdb::ClientContext&, duckdb::Pipeline&) + 236
11       duckdb::PipelineTask::ExecuteTask(duckdb::TaskExecutionMode) + 80
12       duckdb::ExecutorTask::Execute(duckdb::TaskExecutionMode) + 192
13       duckdb::Executor::ExecuteTask(bool) + 252
14       duckdb::ClientContext::ExecuteTaskInternal(duckdb::ClientContextLock&, duckdb::BaseQueryResult&, bool) + 64
15       duckdb::PendingQueryResult::ExecuteInternal(duckdb::ClientContextLock&) + 60
16       duckdb::PendingQueryResult::Execute() + 56
17       duckdb_shell_sqlite3_print_duckbox + 368
18       duckdb_shell::ShellState::ExecutePreparedStatement(sqlite3_stmt*) + 932
19       duckdb_shell::ShellState::ExecuteSQL(char const*, char**) + 376
20       duckdb_shell::ShellState::RunOneSqlLine(char*) + 104
21       duckdb_shell::ShellState::ProcessInput() + 856
22       main + 3596
23       start + 2476
```

## Test

- Manual test in our extension
- Added new tests for `json_transform` 