### PR TITLE
Unpin fixed-size sorting keys

### DIFF
--- a/src/common/sorting/sorted_run.cpp
+++ b/src/common/sorting/sorted_run.cpp
@@ -304,6 +304,9 @@ void SortedRun::Finalize(bool external) {
 		const auto sort_key_type = key_data->GetLayout().GetSortKeyType();
 		if (!SortKeyUtils::IsConstantSize(sort_key_type) || SortKeyUtils::HasPayload(sort_key_type)) {
 			Reorder(context, key_data, payload_data);
+		} else {
+			// This ensures keys are unpinned even if they are constant size and have no payload
+			key_data->Unpin();
 		}
 	}
 


### PR DESCRIPTION
I could've sworn I fixed this in https://github.com/duckdb/duckdb/pull/17717 but apparently I never checked in this change.

Makes sure we can do larger-than-memory sorting when sorting keys are fixed-size, and there are no other selected (payload) columns.