### PR TITLE
Add missing parameters to `COPY ... (FORMAT JSON)`

### DIFF
--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -18,6 +18,13 @@ static void ThrowJSONCopyParameterException(const string &loption) {
 }
 
 static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
+	static const unordered_set<string> SUPPORTED_BASE_OPTIONS {
+	    "compression", "encoding", "use_tmp_file", "overwrite_or_ignore", "overwrite", "append", "filename_pattern",
+	    "file_extension", "per_thread_output", "file_size_bytes",
+	    // "partition_by", unsupported
+	    "return_files", "preserve_order", "return_stats", "write_partition_columns", "write_empty_file",
+	    "hive_file_pattern"};
+
 	auto stmt_copy = stmt.Copy();
 	auto &copy = stmt_copy->Cast<CopyStatement>();
 	auto &copied_info = *copy.info;
@@ -48,9 +55,7 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 				csv_copy_options["suffix"] = {"\n]\n"};
 				csv_copy_options["new_line"] = {",\n\t"};
 			}
-		} else if (loption == "compression" || loption == "encoding" || loption == "per_thread_output" ||
-		           loption == "file_size_bytes" || loption == "use_tmp_file" || loption == "overwrite_or_ignore" ||
-		           loption == "filename_pattern" || loption == "file_extension") {
+		} else if (SUPPORTED_BASE_OPTIONS.find(loption) != SUPPORTED_BASE_OPTIONS.end()) {
 			// We support these base options
 			csv_copy_options.insert(kv);
 		} else {

--- a/test/sql/json/test_json_copy.test_slow
+++ b/test/sql/json/test_json_copy.test_slow
@@ -77,6 +77,17 @@ select * from roundtrip
 ----
 
 
+# test issue 18816
+statement ok
+copy (select 42 i)
+to '__TEST_DIR__/json_batch'
+(format json, per_thread_output true, overwrite true);
+
+statement ok
+copy (select 42 i)
+to '__TEST_DIR__/json_batch'
+(format json, per_thread_output true, append true);
+
 # test issue #6305
 statement ok
 copy (


### PR DESCRIPTION
Partially fixes #18816 by adding missing `COPY` parameters to the JSON writer.