### PR TITLE
Enable Release Candidates to be built IFF on a tag such as 'vX.Y.Z-rcN'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,13 @@ else()
           set(GIT_COMMIT_HASH "0123456789")
     endif()
     endif()
+      execute_process(
+            COMMAND ${GIT_EXECUTABLE} describe --tags --long --match "${VERSIONING_TAG_MATCH}-rc*" --exact-match
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            RESULT_VARIABLE GIT_RESULT
+            OUTPUT_VARIABLE GIT_DESCRIBE
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (GIT_RESULT)
     execute_process(
           COMMAND ${GIT_EXECUTABLE} describe --tags --long --match "${VERSIONING_TAG_MATCH}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -337,12 +344,29 @@ else()
       message(WARNING "git is available (at ${GIT_EXECUTABLE}) but has failed to execute 'describe --tags --long', likely due to shallow clone. Consider providing explicit OVERRIDE_GIT_DESCRIBE or clone with tags. Continuing with dummy version v0.0.1")
       set(GIT_DESCRIBE "v0.0.1-0-g${GIT_COMMIT_HASH}")
     endif()
+    endif()
   else()
     message(WARNING "Git NOT FOUND and EXTERNAL_GIT_DESCRIBE not provided, continuing with dummy version v0.0.1")
     set(GIT_DESCRIBE "v0.0.1-0-g0123456789")
   endif()
 endif()
 
+if (GIT_DESCRIBE MATCHES "^v[0-9]+\.[0-9]+\.[0-9]+\-rc[0-9]+-0+\-g[a-f0-9]+$")
+# This is only for release candidates
+
+string(REGEX REPLACE "v([0-9]+)\.[0-9]+\.[0-9]+\-.*" "\\1" DUCKDB_MAJOR_VERSION "${GIT_DESCRIBE}")
+string(REGEX REPLACE "v[0-9]+\.([0-9]+)\.[0-9]+\-.*" "\\1" DUCKDB_MINOR_VERSION "${GIT_DESCRIBE}")
+string(REGEX REPLACE "v[0-9]+\.[0-9]+\.([0-9]+)\-.*" "\\1" DUCKDB_PATCH_VERSION "${GIT_DESCRIBE}")
+string(REGEX REPLACE "v[0-9]+\.[0-9]+\.[0-9]+\-rc([0-9]+)\-.*" "\\1" DUCKDB_RC_VERSION "${GIT_DESCRIBE}")
+string(REGEX REPLACE "v[0-9]+\.[0-9]+\.[0-9]+\-rc[0-9]+\-([0-9]+)\-g.*" "\\1" DUCKDB_DEV_ITERATION "${GIT_DESCRIBE}")
+if (NOT DEFINED GIT_COMMIT_HASH)
+  string(REGEX REPLACE "v[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+\-rc[0-9]+\-g([a-f0-9]+)" "\\1" GIT_COMMIT_HASH "${GIT_DESCRIBE}")
+endif()
+
+set(DUCKDB_VERSION_NUMBER "v${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}-rc${DUCKDB_RC_VERSION}")
+  set (DUCKDB_EXPLICIT_VERSION "${DUCKDB_VERSION_NUMBER}")
+
+else ()
 if (NOT GIT_DESCRIBE MATCHES "^v[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+\-g[a-f0-9]+$")
   message(FATAL_ERROR "Computed GIT_DESCRIBE '${GIT_DESCRIBE}' is not in the expected form 'vX.Y.Z-N-gGITHASH123'. Consider providing OVERRIDE_GIT_DESCRIBE explicitly to CMake")
 endif()
@@ -356,6 +380,7 @@ if (NOT DEFINED GIT_COMMIT_HASH)
 endif()
 
 set(DUCKDB_VERSION_NUMBER "${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}")
+endif()
 
 string(LENGTH "${GIT_COMMIT_HASH}" LENGTH_GIT_COMMIT_HASH)
 if (NOT ${LENGTH_GIT_COMMIT_HASH} EQUAL 10)
@@ -370,6 +395,9 @@ if(DUCKDB_EXPLICIT_VERSION)
 elseif(DUCKDB_DEV_ITERATION EQUAL 0)
   # on a tag; directly use the version
   set(DUCKDB_VERSION "v${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}")
+  if (DEFINED ${DUCKDB_RC_VERSION})
+    set(DUCKDB_VERSION "${DUCKDB_VERSION}-rc${DUCKDB_RC_VERSION}")
+  endif()
 else()
   # not on a tag, increment the patch version by one and add a -devX suffix
   if(${MAIN_BRANCH_VERSIONING})

--- a/src/function/table/version/pragma_version.cpp
+++ b/src/function/table/version/pragma_version.cpp
@@ -63,6 +63,8 @@ const char *DuckDB::LibraryVersion() {
 }
 
 const char *DuckDB::ReleaseCodename() {
+	bool rc_postfix = StringUtil::Contains(DUCKDB_VERSION, "-rc");
+
 	// dev releases have no name
 	if (StringUtil::Contains(DUCKDB_VERSION, "-dev")) {
 		return "Development Version";
@@ -74,6 +76,9 @@ const char *DuckDB::ReleaseCodename() {
 		return "Ossivalis";
 	}
 	if (StringUtil::StartsWith(DUCKDB_VERSION, "v1.4.")) {
+		if (rc_postfix) {
+			return "Andium Release Candidate";
+		}
 		return "Andium";
 	}
 	// add new version names here


### PR DESCRIPTION
Current CI infrastructure for extensions relies on creating a local tag from 'override_git_describe'. This PR allows tags in the form 'vX.Y.Z-rcN' to be classified as release candidates, and propagates further the information to selecting extension folder name, that in this cases will be the same as the tag.

This does add some extra lines at CMake level, but those are only ever used IF the current commit has a tag in the form of a RC candidate

To locally test this:
```
git tag v1.4.0-rc123
GEN=ninja make
git tag --delete v1.4.0-rc123
./build/release/duckdb
```
and check that the output will be:
```
DuckDB v1.4.0-rc123 (Andium Release Candidate) f8902935b3
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D PRAGMA version;
┌─────────────────┬────────────┬──────────────────────────┐
│ library_version │ source_id  │         codename         │
│     varchar     │  varchar   │         varchar          │
├─────────────────┼────────────┼──────────────────────────┤
│ v1.4.0-rc123    │ f8902935b3 │ Andium Release Candidate │
└─────────────────┴────────────┴──────────────────────────┘
D LOAD spatial;
IO Error:
Extension "/Users/carlo/.duckdb/extensions/v1.4.0-rc123/osx_arm64/spatial.duckdb_extension" not found.
Extension "spatial" is an existing extension.

Install it first using "INSTALL spatial".
D INSTALL spatial;
HTTP Error:
Failed to download extension "spatial" at URL "http://extensions.duckdb.org/v1.4.0-rc123/osx_arm64/spatial.duckdb_extension.gz" (HTTP 403)
Extension "spatial" is an existing extension.

For more info, visit https://duckdb.org/docs/stable/extensions/troubleshooting?version=v1.4.0-rc123&platform=osx_arm64&extension=spatial

```

Note how the remote endpoint AND the local extension folder correspond to the local tag.