### PR TITLE
[SQLLogicTest] Detect errors thrown in `LoadExtension` of the `require` statement

### DIFF
--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -608,7 +608,14 @@ RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vec
 	bool perform_install = false;
 	bool perform_load = false;
 	if (!config->options.autoload_known_extensions) {
-		auto result = SQLLogicTestRunner::LoadExtension(*db, param);
+		auto result = ExtensionLoadResult::NOT_LOADED;
+		try {
+			result = SQLLogicTestRunner::LoadExtension(*db, param);
+		} catch (std::exception &ex) {
+			ErrorData error_data(ex);
+			parser.Fail("extension '%s' load threw an exception: %s", param, error_data.Message());
+		}
+
 		if (result == ExtensionLoadResult::LOADED_EXTENSION) {
 			// add the extension to the list of loaded extensions
 			extensions.insert(param);


### PR DESCRIPTION
This PR fixes a silent skip of tests where the `LoadExtension` in require throws an exception
This can happen in iceberg (https://github.com/duckdb/duckdb-iceberg/pull/461)

When `iceberg` is required before `avro` / `parquet` are required.

Which now properly fails:
```
-------------------------------------------------------------------------------
test/sql/local/iceberg_scans/big_query_read.test
-------------------------------------------------------------------------------
/Users/thijs/DuckDBLabs/duckdb_iceberg/duckdb/test/sqlite/test_sqllogictest.cpp:247
...............................................................................

/Users/thijs/DuckDBLabs/duckdb_iceberg/duckdb/test/sqlite/sqllogic_parser.cpp:115: FAILED:
explicitly with message:
  test/sql/local/iceberg_scans/big_query_read.test:7: extension 'iceberg' load
  threw an exception: Extension Autoloading Error: An error occurred while
  trying to automatically install the required extension 'avro':
  Extension "/Users/thijs/.duckdb/extensions/605eaf76be/osx_arm64/avro.
  duckdb_extension" not found.
  
Candidate extensions: "azure", "parquet", "jemalloc", "autocomplete", "vss"
```