### PR TITLE
Allow extensions to customize ATTACH OR REPLACE conflict behavior

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1235,4 +1235,9 @@ void Catalog::FinalizeLoad(optional_ptr<ClientContext> context) {
 void Catalog::OnDetach(ClientContext &context) {
 }
 
+bool Catalog::HasConflictingAttachOptions(const string &path, const AttachOptions &options) {
+	auto const db_type = options.db_type.empty() ? "duckdb" : options.db_type;
+	return GetDBPath() != path || GetCatalogType() != db_type;
+}
+
 } // namespace duckdb

--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -51,10 +51,8 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 				existing_db->GetCatalog().SetDefaultTable(options.default_table.schema, options.default_table.name);
 			}
 			if (info->on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
-				// same path, name and type, DB does not need replacing
-				auto const db_type = options.db_type.empty() ? "duckdb" : options.db_type;
-				if (existing_db->GetCatalog().GetDBPath() == path &&
-				    existing_db->GetCatalog().GetCatalogType() == db_type) {
+				// allow custom catalogs to override this behavior
+				if (!existing_db->GetCatalog().HasConflictingAttachOptions(path, options)) {
 					return SourceResultType::FINISHED;
 				}
 			} else {

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -26,6 +26,7 @@
 #include <functional>
 
 namespace duckdb {
+struct AttachOptions;
 struct CreateSchemaInfo;
 struct DropInfo;
 struct BoundCreateTableInfo;
@@ -345,6 +346,9 @@ public:
 
 	//! Returns the dependency manager of this catalog - if the catalog has anye
 	virtual optional_ptr<DependencyManager> GetDependencyManager();
+
+	//! Whether attaching a catalog with the given path and attach options would be considered a conflict
+	virtual bool HasConflictingAttachOptions(const string &path, const AttachOptions &options);
 
 public:
 	template <class T>


### PR DESCRIPTION
The `ATTACH OR REPLACE` command currently is a NOOP in case there is already an attached database with the same path and database type. It disregards other attach options, however.

In case where path + database type is not uniquely characterizing a database, this means that the reattach is not taking place.

This PR makes the behavior extensible, so that this behavior can be extended to check for other attach options.