### PR TITLE
Unify test runner keyword replacement, and don't run `LOAD [ext]` by default

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -338,6 +338,8 @@ void TestConfiguration::ProcessPath(string &path, const string &test_name) {
 
 	auto base_test_name = StringUtil::Replace(test_name, "/", "_");
 	path = StringUtil::Replace(path, "{BASE_TEST_NAME}", base_test_name);
+	path = StringUtil::Replace(path, "__TEST_DIR__", TestDirectoryPath());
+	path = StringUtil::Replace(path, "__WORKING_DIRECTORY__", FileSystem::GetWorkingDirectory());
 }
 
 template <class T, class VAL_T>

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -223,12 +223,10 @@ string SQLLogicTestRunner::ReplaceKeywords(string input) {
 		auto &value = it.second;
 		input = StringUtil::Replace(input, StringUtil::Format("${%s}", name), value);
 	}
-	input = StringUtil::Replace(input, "{UUID}", UUID::ToString(UUID::GenerateRandomUUID()));
-	input = StringUtil::Replace(input, "__TEST_DIR__", TestDirectoryPath());
-	input = StringUtil::Replace(input, "__WORKING_DIRECTORY__", FileSystem::GetWorkingDirectory());
+	auto &test_config = TestConfiguration::Get();
+	test_config.ProcessPath(input, file_name);
 	input = StringUtil::Replace(input, "__BUILD_DIRECTORY__", DUCKDB_BUILD_DIRECTORY);
 
-	auto &test_config = TestConfiguration::Get();
 	string data_location = test_config.DataLocation();
 
 	input = StringUtil::Replace(input, "'data/", string("'") + data_location);

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -114,10 +114,14 @@ void SQLLogicTestRunner::EndLoop() {
 }
 
 ExtensionLoadResult SQLLogicTestRunner::LoadExtension(DuckDB &db, const std::string &extension) {
-	Connection con(db);
-	auto result = con.Query("LOAD " + extension);
-	if (!result->HasError()) {
-		return ExtensionLoadResult::LOADED_EXTENSION;
+	auto &test_config = TestConfiguration::Get();
+	if (test_config.GetExtensionAutoLoadingMode() != TestConfiguration::ExtensionAutoLoadingMode::NONE) {
+		// try LOAD extension
+		Connection con(db);
+		auto result = con.Query("LOAD " + extension);
+		if (!result->HasError()) {
+			return ExtensionLoadResult::LOADED_EXTENSION;
+		}
 	}
 	return ExtensionHelper::LoadExtension(db, extension);
 }


### PR DESCRIPTION
This PR fixes two issues with the test runner:

* We unify keyword replacement between SQL queries (supporting `__TEST_DIR__` and friends) and the test config (supporting `{BASE_TEST_NAME}` and friends). This should all just go through the same path. Drawback here is that the syntax is different. I would propose we should move to using `{TEST_DIR}` over `__TEST_DIR__` going forward - but we can tackle that another day.
* Avoid running `LOAD 'ext'` for every extension with default autoloading settings - this triggers exceptions at the beginning of every test run which is kind of annoying if you are adding breakpoints on exceptions.