### PR TITLE
Correctly update row group data pointers and root table pointer after checkpoint

### DIFF
--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -30,7 +30,8 @@ public:
 	void WriteTableData(Serializer &metadata_serializer);
 
 	virtual void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) = 0;
-	virtual void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) = 0;
+	virtual void FinalizeTable(const TableStatistics &global_stats, DataTableInfo &info, RowGroupCollection &collection,
+	                           Serializer &serializer) = 0;
 	virtual unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) = 0;
 
 	virtual void AddRowGroup(RowGroupPointer &&row_group_pointer, unique_ptr<RowGroupWriter> writer);
@@ -54,7 +55,8 @@ public:
 
 public:
 	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) override;
-	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) override;
+	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo &info, RowGroupCollection &collection,
+	                   Serializer &serializer) override;
 	unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) override;
 	CheckpointType GetCheckpointType() const override;
 	MetadataManager &GetMetadataManager() override;

--- a/src/include/duckdb/storage/metadata/metadata_manager.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_manager.hpp
@@ -38,6 +38,9 @@ struct MetadataBlock {
 
 	idx_t FreeBlocksToInteger();
 	void FreeBlocksFromInteger(idx_t blocks);
+	static vector<uint8_t> BlocksFromInteger(idx_t free_list);
+
+	string ToString() const;
 };
 
 struct MetadataPointer {

--- a/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
+++ b/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
@@ -50,7 +50,8 @@ public:
 
 public:
 	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) override;
-	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info, Serializer &serializer) override;
+	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo &info, RowGroupCollection &collection,
+	                   Serializer &serializer) override;
 	unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) override;
 	CheckpointType GetCheckpointType() const override;
 	MetadataManager &GetMetadataManager() override;

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -51,6 +51,7 @@ public:
 	void Initialize(PersistentCollectionData &data);
 	void Initialize(PersistentTableData &data);
 	void InitializeEmpty();
+	void FinalizeCheckpoint(MetaBlockPointer pointer);
 
 	bool IsEmpty() const;
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1613,7 +1613,7 @@ void DataTable::Checkpoint(TableDataWriter &writer, Serializer &serializer) {
 	//   row-group pointers
 	//   table pointer
 	//   index data
-	writer.FinalizeTable(global_stats, info.get(), serializer);
+	writer.FinalizeTable(global_stats, *info, *row_groups, serializer);
 }
 
 void DataTable::CommitDropColumn(const idx_t column_index) {

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -353,7 +353,6 @@ void MetadataManager::MarkBlocksAsModified() {
 		auto &block = kv.second;
 		idx_t free_list = block.FreeBlocksToInteger();
 		idx_t occupied_list = ~free_list;
-		auto modified_block_list = MetadataBlock::BlocksFromInteger(occupied_list);
 		modified_blocks[block.block_id] = occupied_list;
 	}
 }

--- a/src/storage/table/in_memory_checkpoint.cpp
+++ b/src/storage/table/in_memory_checkpoint.cpp
@@ -89,8 +89,8 @@ InMemoryTableDataWriter::InMemoryTableDataWriter(InMemoryCheckpointer &checkpoin
 void InMemoryTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) {
 }
 
-void InMemoryTableDataWriter::FinalizeTable(const TableStatistics &global_stats, DataTableInfo *info,
-                                            Serializer &serializer) {
+void InMemoryTableDataWriter::FinalizeTable(const TableStatistics &global_stats, DataTableInfo &info,
+                                            RowGroupCollection &collection, Serializer &serializer) {
 	// nop: no need to write anything
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1087,6 +1087,11 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 		// this metadata block is not stored - add it to the extra metadata blocks
 		row_group_pointer.extra_metadata_blocks.push_back(column_pointer.block_pointer);
 	}
+	// set up the pointers correctly within this row group for future operations
+	column_pointers = row_group_pointer.data_pointers;
+	has_metadata_blocks = true;
+	extra_metadata_blocks = row_group_pointer.extra_metadata_blocks;
+
 	if (metadata_manager) {
 		row_group_pointer.deletes_pointers = CheckpointDeletes(*metadata_manager);
 	}

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -101,6 +101,10 @@ void RowGroupCollection::Initialize(PersistentTableData &data) {
 	metadata_pointer = data.base_table_pointer;
 }
 
+void RowGroupCollection::FinalizeCheckpoint(MetaBlockPointer pointer) {
+	metadata_pointer = pointer;
+}
+
 void RowGroupCollection::Initialize(PersistentCollectionData &data) {
 	stats.InitializeEmpty(types);
 	auto l = row_groups->Lock();

--- a/test/sql/storage/metadata/multi_table_metadata_reuse.test
+++ b/test/sql/storage/metadata/multi_table_metadata_reuse.test
@@ -1,0 +1,58 @@
+# name: test/sql/storage/metadata/multi_table_metadata_reuse.test
+# description: Test metadata reuse with multiple tables and restarts
+# group: [metadata]
+
+load __TEST_DIR__/multi_table_metadata_reuse.db
+
+statement ok
+SET experimental_metadata_reuse=true;
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+CREATE TABLE ducklake_table(end_snapshot BIGINT);
+
+statement ok
+CREATE TABLE ducklake_column(end_snapshot BIGINT);
+
+statement ok
+COMMIT;
+
+restart
+
+statement ok
+SET experimental_metadata_reuse=true;
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+INSERT INTO ducklake_table VALUES (1);
+
+statement ok
+INSERT INTO ducklake_column VALUES (1);
+
+statement ok
+COMMIT;
+
+restart
+
+statement ok
+SET experimental_metadata_reuse=true;
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+UPDATE ducklake_table SET end_snapshot = 3
+
+statement ok
+UPDATE ducklake_column SET end_snapshot = 3
+
+statement ok
+COMMIT;
+
+statement ok
+CREATE TABLE my_table (a INTEGER, b INTEGER);
+


### PR DESCRIPTION
This PR fixes an issue with the experimental metadata re-use.

When running a `CHECKPOINT`, we would check if a table was modified or not. If a table was unmodified, we would write the root pointer from where we loaded the table instead of rewriting the table. When the table was modified, we would re-write the table data to the metadata.

The issue here was that if we would first run a `CHECKPOINT` in which we would rewrite the table, we would re-write the table data, but not update the in-memory pointer to the new location for the table metadata. If we would then do another `CHECKPOINT` in which the table was unmodified - we would write a pointer to the (old) metadata instead of writing a pointer to the new metadata. This could then upon restart cause the table to point to old metadata, which could cause various issues as that data could have been already overwritten and now contain different data.

This PR addresses this issue by correctly overwriting the in-memory pointers of the row groups and the table metadata, which resolves the issue.