### PR TITLE
[C-API] add function registration functions with conflict resolution

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -246,10 +246,14 @@ typedef enum duckdb_error_type {
 typedef enum duckdb_cast_mode { DUCKDB_CAST_NORMAL = 0, DUCKDB_CAST_TRY = 1 } duckdb_cast_mode;
 
 typedef enum duckdb_on_conflict {
-	DUCKDB_ON_CONFLICT_ERROR = 0,   // Error on conflict
-	DUCKDB_ON_CONFLICT_IGNORE = 1,  // Ignore on conflict
-	DUCKDB_ON_CONFLICT_REPLACE = 2, // Replace on conflict
-	DUCKDB_ON_CONFLICT_ALTER = 3    // Only for functions: attempt to add an overload on conflict
+	// Error on conflict
+	DUCKDB_ON_CONFLICT_ERROR = 0,
+	// Silently do nothing on conflict
+	DUCKDB_ON_CONFLICT_IGNORE = 1,
+	// Replace on conflict
+	DUCKDB_ON_CONFLICT_REPLACE = 2,
+	// Only for functions: attempt to add an overload if the function already exists
+	DUCKDB_ON_CONFLICT_ALTER = 3
 } duckdb_on_conflict;
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -245,6 +245,13 @@ typedef enum duckdb_error_type {
 //! An enum over DuckDB's different cast modes.
 typedef enum duckdb_cast_mode { DUCKDB_CAST_NORMAL = 0, DUCKDB_CAST_TRY = 1 } duckdb_cast_mode;
 
+typedef enum duckdb_on_conflict {
+	DUCKDB_ON_CONFLICT_ERROR = 0,   // Error on conflict
+	DUCKDB_ON_CONFLICT_IGNORE = 1,  // Ignore on conflict
+	DUCKDB_ON_CONFLICT_REPLACE = 2, // Replace on conflict
+	DUCKDB_ON_CONFLICT_ALTER = 3    // Only for functions: attempt to add an overload on conflict
+} duckdb_on_conflict;
+
 //===--------------------------------------------------------------------===//
 // General type definitions
 //===--------------------------------------------------------------------===//
@@ -3580,6 +3587,22 @@ DUCKDB_C_API duckdb_state duckdb_register_scalar_function(duckdb_connection con,
                                                           duckdb_scalar_function scalar_function);
 
 /*!
+Register the scalar function object within the given connection.
+
+The function requires at least a name, a function and a return type.
+
+If the function is incomplete DuckDBError is returned.
+
+* @param con The connection to register it in.
+* @param scalar_function The function pointer
+* @param on_conflict The conflict resolution strategy to apply if a function with the same name already exists.
+* @return Whether or not the registration was successful.
+*/
+DUCKDB_C_API duckdb_state duckdb_register_scalar_function_or(duckdb_connection con,
+                                                             duckdb_scalar_function scalar_function,
+                                                             duckdb_on_conflict on_conflict);
+
+/*!
 Retrieves the extra info of the function as set in `duckdb_scalar_function_set_extra_info`.
 
 * @param info The info object.
@@ -3658,6 +3681,21 @@ If the set is incomplete or a function with this name already exists DuckDBError
 * @return Whether or not the registration was successful.
 */
 DUCKDB_C_API duckdb_state duckdb_register_scalar_function_set(duckdb_connection con, duckdb_scalar_function_set set);
+
+/*!
+Register the scalar function set within the given connection.
+
+The set requires at least a single valid overload.
+
+If the set is incomplete DuckDBError is returned.
+
+* @param con The connection to register it in.
+* @param set The function set to register
+* @param on_conflict The conflict resolution strategy to apply if a function with the same name already exists.
+* @return Whether or not the registration was successful.
+*/
+DUCKDB_C_API duckdb_state duckdb_register_scalar_function_set_or(duckdb_connection con, duckdb_scalar_function_set set,
+                                                                 duckdb_on_conflict on_conflict);
 
 /*!
 Returns the number of input arguments of the scalar function.
@@ -3789,6 +3827,21 @@ DUCKDB_C_API duckdb_state duckdb_register_aggregate_function(duckdb_connection c
                                                              duckdb_aggregate_function aggregate_function);
 
 /*!
+Register the aggregate function object within the given connection.
+
+The function requires at least a name, functions and a return type.
+
+If the function is incomplete DuckDBError is returned.
+
+* @param con The connection to register it in.
+* @param on_conflict The conflict resolution strategy to apply if a function with the same name already exists.
+* @return Whether or not the registration was successful.
+*/
+DUCKDB_C_API duckdb_state duckdb_register_aggregate_function_or(duckdb_connection con,
+                                                                duckdb_aggregate_function aggregate_function,
+                                                                duckdb_on_conflict on_conflict);
+
+/*!
 Sets the NULL handling of the aggregate function to SPECIAL_HANDLING.
 
 * @param aggregate_function The aggregate function
@@ -3860,6 +3913,22 @@ If the set is incomplete or a function with this name already exists DuckDBError
 */
 DUCKDB_C_API duckdb_state duckdb_register_aggregate_function_set(duckdb_connection con,
                                                                  duckdb_aggregate_function_set set);
+
+/*!
+Register the aggregate function set within the given connection.
+
+The set requires at least a single valid overload.
+
+If the set is incomplete DuckDBError is returned.
+
+* @param con The connection to register it in.
+* @param set The function set to register
+* @param on_conflict The conflict resolution strategy to apply if a function with the same name already exists.
+* @return Whether or not the registration was successful.
+*/
+DUCKDB_C_API duckdb_state duckdb_register_aggregate_function_set_or(duckdb_connection con,
+                                                                    duckdb_aggregate_function_set set,
+                                                                    duckdb_on_conflict on_conflict);
 
 //===--------------------------------------------------------------------===//
 // Table Functions

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -519,6 +519,17 @@ typedef struct {
 	// New query execution functions
 
 	duckdb_arrow_options (*duckdb_result_get_arrow_options)(duckdb_result *result);
+	// New functions around the registering of functions with conflict resolution
+
+	duckdb_state (*duckdb_register_aggregate_function_or)(duckdb_connection con,
+	                                                      duckdb_aggregate_function aggregate_function,
+	                                                      duckdb_on_conflict on_conflict);
+	duckdb_state (*duckdb_register_aggregate_function_set_or)(duckdb_connection con, duckdb_aggregate_function_set set,
+	                                                          duckdb_on_conflict on_conflict);
+	duckdb_state (*duckdb_register_scalar_function_or)(duckdb_connection con, duckdb_scalar_function scalar_function,
+	                                                   duckdb_on_conflict on_conflict);
+	duckdb_state (*duckdb_register_scalar_function_set_or)(duckdb_connection con, duckdb_scalar_function_set set,
+	                                                       duckdb_on_conflict on_conflict);
 	// New functions around scalar function binding
 
 	void (*duckdb_scalar_function_set_bind)(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind);
@@ -998,6 +1009,10 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_prepared_statement_column_logical_type = duckdb_prepared_statement_column_logical_type;
 	result.duckdb_prepared_statement_column_type = duckdb_prepared_statement_column_type;
 	result.duckdb_result_get_arrow_options = duckdb_result_get_arrow_options;
+	result.duckdb_register_aggregate_function_or = duckdb_register_aggregate_function_or;
+	result.duckdb_register_aggregate_function_set_or = duckdb_register_aggregate_function_set_or;
+	result.duckdb_register_scalar_function_or = duckdb_register_scalar_function_or;
+	result.duckdb_register_scalar_function_set_or = duckdb_register_scalar_function_set_or;
 	result.duckdb_scalar_function_set_bind = duckdb_scalar_function_set_bind;
 	result.duckdb_scalar_function_bind_set_error = duckdb_scalar_function_bind_set_error;
 	result.duckdb_scalar_function_get_client_context = duckdb_scalar_function_get_client_context;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_registration_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_registration_functions.json
@@ -1,0 +1,10 @@
+{
+  "version": "unstable_new_registration_conflict_handling_functions",
+  "description": "New functions around the registering of functions with conflict resolution",
+  "entries": [
+    "duckdb_register_aggregate_function_or",
+    "duckdb_register_aggregate_function_set_or",
+    "duckdb_register_scalar_function_or",
+    "duckdb_register_scalar_function_set_or"
+  ]
+}

--- a/src/include/duckdb/main/capi/header_generation/functions/aggregate_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/aggregate_functions.json
@@ -175,6 +175,33 @@
             }
         },
         {
+            "name": "duckdb_register_aggregate_function_or",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_connection",
+                    "name": "con"
+                },
+                {
+                    "type": "duckdb_aggregate_function",
+                    "name": "aggregate_function"
+                },
+                {
+                    "type": "duckdb_on_conflict",
+                    "name": "on_conflict"
+                }
+            ],
+            "comment": {
+                "description": "Register the aggregate function object within the given connection.\n\nThe function requires at least a name, functions and a return type.\n\nIf the function is incomplete DuckDBError is returned.\n\n",
+                "param_comments": {
+                    "con": "The connection to register it in.",
+                    "function": "The function pointer",
+                    "on_conflict": "The conflict resolution strategy to apply if a function with the same name already exists."
+                },
+                "return_value": "Whether or not the registration was successful."
+            }
+        },
+        {
             "name": "duckdb_aggregate_function_set_special_handling",
             "return_type": "void",
             "params": [
@@ -323,6 +350,33 @@
                 "param_comments": {
                     "con": "The connection to register it in.",
                     "set": "The function set to register"
+                },
+                "return_value": "Whether or not the registration was successful."
+            }
+        },
+        {
+            "name": "duckdb_register_aggregate_function_set_or",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_connection",
+                    "name": "con"
+                },
+                {
+                    "type": "duckdb_aggregate_function_set",
+                    "name": "set"
+                },
+                {
+                    "type": "duckdb_on_conflict",
+                    "name": "on_conflict"
+                }
+            ],
+            "comment": {
+                "description": "Register the aggregate function set within the given connection.\n\nThe set requires at least a single valid overload.\n\nIf the set is incomplete DuckDBError is returned.\n\n",
+                "param_comments": {
+                    "con": "The connection to register it in.",
+                    "set": "The function set to register",
+                    "on_conflict": "The conflict resolution strategy to apply if a function with the same name already exists."
                 },
                 "return_value": "Whether or not the registration was successful."
             }

--- a/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
@@ -303,6 +303,33 @@
             }
         },
         {
+            "name": "duckdb_register_scalar_function_or",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_connection",
+                    "name": "con"
+                },
+                {
+                    "type": "duckdb_scalar_function",
+                    "name": "scalar_function"
+                },
+                {
+                    "type": "duckdb_on_conflict",
+                    "name": "on_conflict"
+                }
+            ],
+            "comment": {
+                "description": "Register the scalar function object within the given connection.\n\nThe function requires at least a name, a function and a return type.\n\nIf the function is incomplete DuckDBError is returned.\n\n",
+                "param_comments": {
+                    "con": "The connection to register it in.",
+                    "scalar_function": "The function pointer",
+                    "on_conflict": "The conflict resolution strategy to apply if a function with the same name already exists."
+                },
+                "return_value": "Whether or not the registration was successful."
+            }
+        },
+        {
             "name": "duckdb_scalar_function_get_extra_info",
             "return_type": "void *",
             "params": [
@@ -464,6 +491,33 @@
                 "param_comments": {
                     "con": "The connection to register it in.",
                     "set": "The function set to register"
+                },
+                "return_value": "Whether or not the registration was successful."
+            }
+        },
+        {
+            "name": "duckdb_register_scalar_function_set_or",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_connection",
+                    "name": "con"
+                },
+                {
+                    "type": "duckdb_scalar_function_set",
+                    "name": "set"
+                },
+                {
+                    "type": "duckdb_on_conflict",
+                    "name": "on_conflict"
+                }
+            ],
+            "comment": {
+                "description": "Register the scalar function set within the given connection.\n\nThe set requires at least a single valid overload.\n\nIf the set is incomplete DuckDBError is returned.\n\n",
+                "param_comments": {
+                    "con": "The connection to register it in.",
+                    "set": "The function set to register",
+                    "on_conflict": "The conflict resolution strategy to apply if a function with the same name already exists."
                 },
                 "return_value": "Whether or not the registration was successful."
             }

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -245,6 +245,17 @@ typedef enum duckdb_cast_mode {
 	DUCKDB_CAST_TRY = 1
 } duckdb_cast_mode;
 
+typedef enum duckdb_on_conflict {
+    // Error on conflict
+	DUCKDB_ON_CONFLICT_ERROR = 0,
+	// Silently do nothing on conflict
+	DUCKDB_ON_CONFLICT_IGNORE = 1,
+	// Replace on conflict
+	DUCKDB_ON_CONFLICT_REPLACE = 2,
+	// Only for functions: attempt to add an overload if the function already exists
+	DUCKDB_ON_CONFLICT_ALTER = 3
+} duckdb_on_conflict;
+
 //===--------------------------------------------------------------------===//
 // General type definitions
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -602,6 +602,19 @@ typedef struct {
 	duckdb_arrow_options (*duckdb_result_get_arrow_options)(duckdb_result *result);
 #endif
 
+// New functions around the registering of functions with conflict resolution
+#ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
+	duckdb_state (*duckdb_register_aggregate_function_or)(duckdb_connection con,
+	                                                      duckdb_aggregate_function aggregate_function,
+	                                                      duckdb_on_conflict on_conflict);
+	duckdb_state (*duckdb_register_aggregate_function_set_or)(duckdb_connection con, duckdb_aggregate_function_set set,
+	                                                          duckdb_on_conflict on_conflict);
+	duckdb_state (*duckdb_register_scalar_function_or)(duckdb_connection con, duckdb_scalar_function scalar_function,
+	                                                   duckdb_on_conflict on_conflict);
+	duckdb_state (*duckdb_register_scalar_function_set_or)(duckdb_connection con, duckdb_scalar_function_set set,
+	                                                       duckdb_on_conflict on_conflict);
+#endif
+
 // New functions around scalar function binding
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
 	void (*duckdb_scalar_function_set_bind)(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind);
@@ -1109,6 +1122,12 @@ typedef struct {
 
 // Version unstable_new_query_execution_functions
 #define duckdb_result_get_arrow_options duckdb_ext_api.duckdb_result_get_arrow_options
+
+// Version unstable_new_registration_conflict_handling_functions
+#define duckdb_register_scalar_function_or        duckdb_ext_api.duckdb_register_scalar_function_or
+#define duckdb_register_scalar_function_set_or    duckdb_ext_api.duckdb_register_scalar_function_set_or
+#define duckdb_register_aggregate_function_or     duckdb_ext_api.duckdb_register_aggregate_function_or
+#define duckdb_register_aggregate_function_set_or duckdb_ext_api.duckdb_register_aggregate_function_set_or
 
 // Version unstable_new_scalar_function_functions
 #define duckdb_scalar_function_set_bind                duckdb_ext_api.duckdb_scalar_function_set_bind


### PR DESCRIPTION
Enable c-api based extensions do register overloads for existing scalar/aggregate functions. 

I've named these `..._or` to keep the prefix the same as the original function, but maybe e.g. `try_register_scalar_function_set` would be better.