### PR TITLE
Attach: Cleanup duplicate data path handling, and make IF NOT EXISTS no longer abort if we are adding a path with the same name

### DIFF
--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -61,9 +61,11 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 		}
 	}
 
-	// Get the database type and attach the database.
-	db_manager.GetDatabaseType(context.client, *info, config, options);
+	// attach the database.
 	auto attached_db = db_manager.AttachDatabase(context.client, *info, options);
+	if (!attached_db) {
+		return SourceResultType::FINISHED;
+	}
 
 	//! Initialize the database.
 	attached_db->Initialize(context.client);

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -23,6 +23,7 @@ class StorageExtension;
 class DatabaseManager;
 
 struct AttachInfo;
+struct StoredDatabasePath;
 
 enum class AttachedDatabaseType {
 	READ_WRITE_DATABASE,
@@ -31,11 +32,13 @@ enum class AttachedDatabaseType {
 	TEMP_DATABASE,
 };
 
+class DatabaseFilePathManager;
+
 struct StoredDatabasePath {
-	StoredDatabasePath(DatabaseManager &manager, string path, const string &name);
+	StoredDatabasePath(DatabaseFilePathManager &manager, string path, const string &name);
 	~StoredDatabasePath();
 
-	DatabaseManager &manager;
+	DatabaseFilePathManager &manager;
 	string path;
 };
 
@@ -55,6 +58,8 @@ struct AttachOptions {
 	unordered_map<string, Value> options;
 	//! (optionally) a catalog can be provided with a default table
 	QualifiedName default_table;
+	//! The stored database path (in the path manager)
+	unique_ptr<StoredDatabasePath> stored_database_path;
 };
 
 //! The AttachedDatabase represents an attached database instance.
@@ -101,9 +106,6 @@ public:
 
 	static bool NameIsReserved(const string &name);
 	static string ExtractDatabaseName(const string &dbpath, FileSystem &fs);
-
-private:
-	void InsertDatabasePath(const string &path);
 
 private:
 	DatabaseInstance &db;

--- a/src/include/duckdb/main/database_file_path_manager.hpp
+++ b/src/include/duckdb/main/database_file_path_manager.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/enums/on_create_conflict.hpp"
 
 namespace duckdb {
 struct AttachInfo;

--- a/src/include/duckdb/main/database_file_path_manager.hpp
+++ b/src/include/duckdb/main/database_file_path_manager.hpp
@@ -13,13 +13,17 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 
 namespace duckdb {
+struct AttachInfo;
+struct AttachOptions;
+
+enum class InsertDatabasePathResult { SUCCESS, ALREADY_EXISTS };
 
 //! The DatabaseFilePathManager is used to ensure we only ever open a single database file once
 class DatabaseFilePathManager {
 public:
-	void CheckPathConflict(const string &path, const string &name) const;
 	idx_t ApproxDatabaseCount() const;
-	void InsertDatabasePath(const string &path, const string &name);
+	InsertDatabasePathResult InsertDatabasePath(const string &path, const string &name, OnCreateConflict on_conflict,
+	                                            AttachOptions &options);
 	void EraseDatabasePath(const string &path);
 
 private:

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -64,11 +64,7 @@ public:
 	void SetDefaultDatabase(ClientContext &context, const string &new_value);
 
 	//! Inserts a path to name mapping to the database paths map
-	void InsertDatabasePath(const string &path, const string &name);
-	//! Erases a path from the database paths map
-	void EraseDatabasePath(const string &path);
-	//! Check if a path has a conflict
-	void CheckPathConflict(const string &path, const string &name);
+	InsertDatabasePathResult InsertDatabasePath(const AttachInfo &info, AttachOptions &options);
 
 	//! Returns the database type. This might require checking the header of the file, in which case the file handle is
 	//! necessary. We can only grab the file handle, if it is not yet held, even for uncommitted changes. Thus, we have

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -14,18 +14,17 @@
 
 namespace duckdb {
 
-StoredDatabasePath::StoredDatabasePath(DatabaseManager &manager, string path_p, const string &name)
+StoredDatabasePath::StoredDatabasePath(DatabaseFilePathManager &manager, string path_p, const string &name)
     : manager(manager), path(std::move(path_p)) {
-	manager.InsertDatabasePath(path, name);
 }
 
 StoredDatabasePath::~StoredDatabasePath() {
 	manager.EraseDatabasePath(path);
 }
+
 //===--------------------------------------------------------------------===//
 // Attach Options
 //===--------------------------------------------------------------------===//
-
 AttachOptions::AttachOptions(const DBConfigOptions &options)
     : access_mode(options.access_mode), db_type(options.database_type) {
 }
@@ -102,7 +101,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 	}
 	// We create the storage after the catalog to guarantee we allow extensions to instantiate the DuckCatalog.
 	catalog = make_uniq<DuckCatalog>(*this);
-	InsertDatabasePath(file_path_p);
+	stored_database_path = std::move(options.stored_database_path);
 	storage = make_uniq<SingleFileStorageManager>(*this, std::move(file_path_p), options);
 	transaction_manager = make_uniq<DuckTransactionManager>(*this);
 	internal = true;
@@ -120,11 +119,11 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 
 	optional_ptr<StorageExtensionInfo> storage_info = storage_extension->storage_info.get();
 	catalog = storage_extension->attach(storage_info, context, *this, name, info, options);
+	stored_database_path = std::move(options.stored_database_path);
 	if (!catalog) {
 		throw InternalException("AttachedDatabase - attach function did not return a catalog");
 	}
 	if (catalog->IsDuckCatalog()) {
-		InsertDatabasePath(info.path);
 		// The attached database uses the DuckCatalog.
 		storage = make_uniq<SingleFileStorageManager>(*this, info.path, options);
 	}
@@ -150,13 +149,6 @@ bool AttachedDatabase::IsTemporary() const {
 }
 bool AttachedDatabase::IsReadOnly() const {
 	return type == AttachedDatabaseType::READ_ONLY_DATABASE;
-}
-
-void AttachedDatabase::InsertDatabasePath(const string &path) {
-	if (path.empty() || path == IN_MEMORY_PATH) {
-		return;
-	}
-	stored_database_path = make_uniq<StoredDatabasePath>(db.GetDatabaseManager(), path, name);
 }
 
 bool AttachedDatabase::NameIsReserved(const string &name) {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -298,17 +298,14 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	// initialize the secret manager
 	config.secret_manager->Initialize(*this);
 
-	// resolve the type of teh database we are opening
+	// resolve the type of the database we are opening
 	auto &fs = FileSystem::GetFileSystem(*this);
 	DBPathAndType::ResolveDatabaseType(fs, config.options.database_path, config.options.database_type);
 
 	// initialize the system catalog
 	db_manager->InitializeSystemCatalog();
 
-	if (config.options.database_type == "duckdb") {
-		config.options.database_type = string();
-	}
-	if (!config.options.database_type.empty()) {
+	if (!config.options.database_type.empty() && !StringUtil::CIEquals(config.options.database_type, "duckdb")) {
 		// if we are opening an extension database - load the extension
 		if (!config.file_system) {
 			throw InternalException("No file system!?");

--- a/src/main/database_file_path_manager.cpp
+++ b/src/main/database_file_path_manager.cpp
@@ -1,39 +1,34 @@
 #include "duckdb/main/database_file_path_manager.hpp"
 #include "duckdb/common/exception/binder_exception.hpp"
+#include "duckdb/parser/parsed_data/attach_info.hpp"
+#include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
-
-void DatabaseFilePathManager::CheckPathConflict(const string &path, const string &name) const {
-	if (path.empty() || path == IN_MEMORY_PATH) {
-		return;
-	}
-
-	lock_guard<mutex> path_lock(db_paths_lock);
-	auto entry = db_paths_to_name.find(path);
-	if (entry != db_paths_to_name.end()) {
-		throw BinderException("Unique file handle conflict: Cannot attach \"%s\" - the database file \"%s\" is already "
-		                      "attached by database \"%s\"",
-		                      name, path, entry->second);
-	}
-}
 
 idx_t DatabaseFilePathManager::ApproxDatabaseCount() const {
 	lock_guard<mutex> path_lock(db_paths_lock);
 	return db_paths_to_name.size();
 }
 
-void DatabaseFilePathManager::InsertDatabasePath(const string &path, const string &name) {
+InsertDatabasePathResult DatabaseFilePathManager::InsertDatabasePath(const string &path, const string &name,
+                                                                     OnCreateConflict on_conflict,
+                                                                     AttachOptions &options) {
 	if (path.empty() || path == IN_MEMORY_PATH) {
-		return;
+		return InsertDatabasePathResult::SUCCESS;
 	}
 
 	lock_guard<mutex> path_lock(db_paths_lock);
 	auto entry = db_paths_to_name.emplace(path, name);
 	if (!entry.second) {
+		if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT && entry.first->second == name) {
+			return InsertDatabasePathResult::ALREADY_EXISTS;
+		}
 		throw BinderException("Unique file handle conflict: Cannot attach \"%s\" - the database file \"%s\" is already "
 		                      "attached by database \"%s\"",
 		                      name, path, entry.first->second);
 	}
+	options.stored_database_path = make_uniq<StoredDatabasePath>(*this, path, name);
+	return InsertDatabasePathResult::SUCCESS;
 }
 
 void DatabaseFilePathManager::EraseDatabasePath(const string &path) {

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -68,6 +68,13 @@ optional_ptr<AttachedDatabase> DatabaseManager::GetDatabase(ClientContext &conte
 
 shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &context, AttachInfo &info,
                                                              AttachOptions &options) {
+	auto &config = DBConfig::GetConfig(context);
+	if (options.db_type.empty() || StringUtil::CIEquals(options.db_type, "DUCKDB")) {
+		if (InsertDatabasePath(info, options) == InsertDatabasePathResult::ALREADY_EXISTS) {
+			return nullptr;
+		}
+	}
+	GetDatabaseType(context, info, config, options);
 	if (AttachedDatabase::NameIsReserved(info.name)) {
 		throw BinderException("Attached database name \"%s\" cannot be used because it is a reserved name", info.name);
 	}
@@ -157,20 +164,12 @@ shared_ptr<AttachedDatabase> DatabaseManager::DetachInternal(const string &name)
 	return attached_db;
 }
 
-void DatabaseManager::CheckPathConflict(const string &path, const string &name) {
-	path_manager->CheckPathConflict(path, name);
-}
-
 idx_t DatabaseManager::ApproxDatabaseCount() {
 	return path_manager->ApproxDatabaseCount();
 }
 
-void DatabaseManager::InsertDatabasePath(const string &path, const string &name) {
-	path_manager->InsertDatabasePath(path, name);
-}
-
-void DatabaseManager::EraseDatabasePath(const string &path) {
-	path_manager->EraseDatabasePath(path);
+InsertDatabasePathResult DatabaseManager::InsertDatabasePath(const AttachInfo &info, AttachOptions &options) {
+	return path_manager->InsertDatabasePath(info.path, info.name, info.on_conflict, options);
 }
 
 vector<string> DatabaseManager::GetAttachedDatabasePaths() {
@@ -203,7 +202,6 @@ void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, 
 	// Try to extract the database type from the path.
 	if (options.db_type.empty()) {
 		auto &fs = FileSystem::GetFileSystem(context);
-		CheckPathConflict(info.path, info.name);
 		DBPathAndType::CheckMagicBytes(QueryContext(context), fs, info.path, options.db_type);
 	}
 

--- a/test/sql/storage/concurrent_attach_if_not_exists.test_slow
+++ b/test/sql/storage/concurrent_attach_if_not_exists.test_slow
@@ -1,0 +1,22 @@
+# name: test/sql/storage/concurrent_attach_if_not_exists.test_slow
+# description: Test concurrent attaching
+# group: [storage]
+
+concurrentloop x 0 10
+
+foreach name db1 db2 db3 db4 db5
+
+statement ok
+attach if not exists '__TEST_DIR__/concurrent_attach_${name}.duckdb' AS ${name}
+
+statement maybe
+detach ${name}
+----
+database not found
+
+statement ok
+attach if not exists '__TEST_DIR__/concurrent_attach_${name}.duckdb' AS ${name}
+
+endloop
+
+endloop


### PR DESCRIPTION
This PR performs some clean-up in duplicate data path handling by centralizing the tracking of database paths in a single location, and ensuring they are always cleaned up correctly through the use of RAII. In addition, when we encounter a conflict we check if we are running with `ATTACH IF NOT EXISTS` and are trying to attach the same name. If so, instead of throwing an error, we succeed the attach. 