### PR TITLE
Issue #18971: Empty Unsorted Windows

### DIFF
--- a/src/common/sorting/hashed_sort.cpp
+++ b/src/common/sorting/hashed_sort.cpp
@@ -341,6 +341,9 @@ HashedSortLocalSinkState::HashedSortLocalSinkState(ExecutionContext &context, co
 		}
 		// OVER(...)
 		payload_chunk.Initialize(allocator, payload_types);
+	} else {
+		unsorted = make_uniq<ColumnDataCollection>(context.client, hashed_sort.payload_types);
+		unsorted->InitializeAppend(unsorted_append);
 	}
 }
 
@@ -369,10 +372,6 @@ SinkResultType HashedSort::Sink(ExecutionContext &context, DataChunk &input_chun
 
 	// OVER()
 	if (gstate.hashed_sort.sort_col_count == 0) {
-		if (!lstate.unsorted) {
-			lstate.unsorted = make_uniq<ColumnDataCollection>(context.client, payload_types);
-			lstate.unsorted->InitializeAppend(lstate.unsorted_append);
-		}
 		lstate.unsorted->Append(lstate.unsorted_append, input_chunk);
 		return SinkResultType::NEED_MORE_INPUT;
 	}

--- a/test/sql/window/test_evil_window.test
+++ b/test/sql/window/test_evil_window.test
@@ -77,3 +77,11 @@ personnel	100.000000
 sales	34.246575
 sales	100.000000
 
+statement ok
+CREATE TABLE empty_unsorted(c0 VARCHAR);
+
+statement ok
+SELECT * 
+FROM empty_unsorted 
+WHERE(NOT(false = ANY([]))) 
+ORDER BY(~((SUM(true) OVER() - SUM(true) OVER())::INT)) ASC;


### PR DESCRIPTION
* Initialize HashedSortLocalSinkState::unsorted in the constructor, not lazily in Sink.

fixes: duckdb#18971
fixes: duckdblabs/duckdb-internal#5875