### PR TITLE
Check context.interrupted flag in table scan

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -265,6 +265,9 @@ public:
 		l_state.scan_state.options.force_fetch_row = ClientConfig::GetConfig(context).force_fetch_row;
 
 		do {
+			if (context.interrupted) {
+				throw InterruptException();
+			}
 			if (bind_data.is_create_index) {
 				storage.CreateIndexScan(l_state.scan_state, output,
 				                        TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED);


### PR DESCRIPTION
There's a current design flaw in the TableFunction API: because an empty chunk signals that we have no more output, we need to always return data before handing back control upstream. This is usually not a problem, but when we have very selective filters, this can cause us to spend a long time in the table scan. We might be reading the entire table to find a single row, never handing back control until we have found that row.

This PR introduces a work-around to make query interruption work in this case by checking the interrupted flag. However, there's still other problems with not handing back control (scheduling fairness, etc). We need to address this separately but this requires an API change - so this will be left for a future PR.