### PR TITLE
fix: Make DirectFileReader compatible with pipe-based files

### DIFF
--- a/src/function/table/direct_file_reader.cpp
+++ b/src/function/table/direct_file_reader.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/function/table/direct_file_reader.hpp"
 #include "duckdb/function/table/read_file.hpp"
 #include "duckdb/storage/caching_file_system.hpp"
+#include "duckdb/main/database.hpp"
 
 namespace duckdb {
 
@@ -51,20 +52,34 @@ void DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionState &gl
 		return;
 	}
 
-	auto files = state.file_list;
-	auto fs = CachingFileSystem::Get(context);
 	idx_t out_idx = 0;
 
-	// We utilize projection pushdown here to only read the file content if the 'data' column is requested
-	unique_ptr<CachingFileHandle> file_handle = nullptr;
+	auto files = state.file_list;
+	auto &main_fs = context.db->GetFileSystem();
 
-	// Given the columns requested, do we even need to open the file?
-	if (state.requires_file_open) {
-		auto flags = FileFlags::FILE_FLAGS_READ;
-		if (FileSystem::IsRemoteFile(file.path)) {
-			flags |= FileFlags::FILE_FLAGS_DIRECT_IO;
+	// Since CachingFileHandle isn't a Filehandle we need to keep it seperated.
+	unique_ptr<CachingFileHandle> caching_file_handle = nullptr;
+	unique_ptr<FileHandle> pipe_file_handle = nullptr;
+
+	if (main_fs.IsPipe(file.path)) {
+		// If we are dealing with a pipe we can't cache content.
+		if (state.requires_file_open) {
+			auto flags = FileFlags::FILE_FLAGS_READ;
+			pipe_file_handle = main_fs.OpenFile(file, flags);
 		}
-		file_handle = fs.OpenFile(QueryContext(context), file, flags);
+	} else {
+		auto fs = CachingFileSystem::Get(context);
+
+		// We utilize projection pushdown here to only read the file content if the 'data' column is requested
+
+		// Given the columns requested, do we even need to open the file?
+		if (state.requires_file_open) {
+			auto flags = FileFlags::FILE_FLAGS_READ;
+			if (FileSystem::IsRemoteFile(file.path)) {
+				flags |= FileFlags::FILE_FLAGS_DIRECT_IO;
+			}
+			caching_file_handle = fs.OpenFile(QueryContext(context), file, flags);
+		}
 	}
 
 	for (idx_t col_idx = 0; col_idx < state.column_ids.size(); col_idx++) {
@@ -81,60 +96,123 @@ void DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionState &gl
 				FlatVector::GetData<string_t>(file_name_vector)[out_idx] = file_name_string;
 			} break;
 			case ReadFileBindData::FILE_CONTENT_COLUMN: {
-				auto file_size_raw = file_handle->GetFileSize();
-				AssertMaxFileSize(file.path, file_size_raw);
-				auto file_size = UnsafeNumericCast<int64_t>(file_size_raw);
 				auto &file_content_vector = output.data[col_idx];
-				auto content_string = StringVector::EmptyString(file_content_vector, file_size_raw);
 
-				auto remaining_bytes = UnsafeNumericCast<int64_t>(file_size);
+				if (caching_file_handle) {
+					auto file_size_raw = caching_file_handle->GetFileSize();
+					AssertMaxFileSize(file.path, file_size_raw);
+					auto file_size = UnsafeNumericCast<int64_t>(file_size_raw);
+					auto content_string = StringVector::EmptyString(file_content_vector, file_size_raw);
 
-				// Read in batches of 100mb
-				constexpr auto MAX_READ_SIZE = 100LL * 1024 * 1024;
-				while (remaining_bytes > 0) {
-					const auto bytes_to_read = MinValue<int64_t>(remaining_bytes, MAX_READ_SIZE);
-					const auto content_string_ptr = content_string.GetDataWriteable() + (file_size - remaining_bytes);
+					auto remaining_bytes = UnsafeNumericCast<int64_t>(file_size);
 
-					idx_t actually_read;
-					if (file_handle->IsRemoteFile()) {
-						// Remote file: caching read
-						data_ptr_t read_ptr;
-						actually_read = NumericCast<idx_t>(bytes_to_read);
-						auto buffer_handle = file_handle->Read(read_ptr, actually_read);
-						memcpy(content_string_ptr, read_ptr, actually_read);
-					} else {
-						// Local file: non-caching read
-						actually_read = NumericCast<idx_t>(file_handle->GetFileHandle().Read(
-						    content_string_ptr, UnsafeNumericCast<idx_t>(bytes_to_read)));
+					// Read in batches of 100mb
+					constexpr auto MAX_READ_SIZE = 100LL * 1024 * 1024;
+					while (remaining_bytes > 0) {
+						const auto bytes_to_read = MinValue<int64_t>(remaining_bytes, MAX_READ_SIZE);
+						const auto content_string_ptr =
+						    content_string.GetDataWriteable() + (file_size - remaining_bytes);
+
+						idx_t actually_read;
+						if (caching_file_handle->IsRemoteFile()) {
+							// Remote file: caching read
+							data_ptr_t read_ptr;
+							actually_read = NumericCast<idx_t>(bytes_to_read);
+							auto buffer_handle = caching_file_handle->Read(read_ptr, actually_read);
+							memcpy(content_string_ptr, read_ptr, actually_read);
+						} else {
+							// Local file: non-caching read
+							actually_read = NumericCast<idx_t>(caching_file_handle->GetFileHandle().Read(
+							    content_string_ptr, UnsafeNumericCast<idx_t>(bytes_to_read)));
+						}
+
+						if (actually_read == 0) {
+							// Uh oh, random EOF?
+							throw IOException("Failed to read file '%s' at offset %lu, unexpected EOF", file.path,
+							                  file_size - remaining_bytes);
+						}
+						remaining_bytes -= NumericCast<int64_t>(actually_read);
 					}
 
-					if (actually_read == 0) {
-						// Uh oh, random EOF?
-						throw IOException("Failed to read file '%s' at offset %lu, unexpected EOF", file.path,
-						                  file_size - remaining_bytes);
+					content_string.Finalize();
+
+					if (type == LogicalType::VARCHAR) {
+						VERIFY(file.path, content_string);
 					}
-					remaining_bytes -= NumericCast<int64_t>(actually_read);
+
+					FlatVector::GetData<string_t>(file_content_vector)[out_idx] = content_string;
+				} else {
+					constexpr size_t READ_CHUNK_SIZE = (size_t)(128 * 1024); // 128KB read chunks
+					constexpr size_t MAX_COLUMN_SIZE = std::numeric_limits<uint32_t>::max();
+
+					std::string content_string;
+					content_string.reserve(READ_CHUNK_SIZE);
+
+					size_t total = 0;
+
+					while (true) {
+						size_t string_capacity_remaining = content_string.capacity() - total;
+						if (string_capacity_remaining < READ_CHUNK_SIZE) {
+							// Increase capacity exponentially, but capped at max column length+1
+							auto new_cap = std::min(std::max(content_string.capacity() * 2, total + READ_CHUNK_SIZE),
+							                        MAX_COLUMN_SIZE + 1);
+							content_string.reserve(new_cap);
+							string_capacity_remaining = content_string.capacity() - total;
+						}
+
+						auto to_read = std::min(READ_CHUNK_SIZE, string_capacity_remaining);
+						content_string.resize(total + to_read);
+
+						auto bytes_read = pipe_file_handle->Read(&content_string[total], to_read);
+						if (bytes_read < 0) {
+							throw InvalidInputException("Error reading contents of pipe '%s'", file.path);
+						}
+						if (bytes_read == 0) {
+							// End of the pipe
+							content_string.resize(total);
+							break;
+						}
+
+						total += (uint64_t)bytes_read;
+						if (total > MAX_COLUMN_SIZE) {
+							throw InvalidInputException(
+							    "Contents of pipe '%s' exceeds maximum allowed size of %u bytes", file.path,
+							    NumericLimits<uint32_t>::Maximum());
+						}
+					}
+
+					if (type == LogicalType::VARCHAR) {
+						if (Utf8Proc::Analyze(content_string.data(), content_string.size()) == UnicodeType::INVALID) {
+							throw InvalidInputException(
+							    "read_text: could not read content of pipe '%s' as valid UTF-8 encoded text. You "
+							    "may want to use read_blob instead.",
+							    file.path);
+						}
+					}
+
+					FlatVector::GetData<string_t>(file_content_vector)[out_idx] =
+					    StringVector::AddStringOrBlob(file_content_vector, content_string);
 				}
-
-				content_string.Finalize();
-
-				if (type == LogicalType::VARCHAR) {
-					VERIFY(file.path, content_string);
-				}
-
-				FlatVector::GetData<string_t>(file_content_vector)[out_idx] = content_string;
 			} break;
 			case ReadFileBindData::FILE_SIZE_COLUMN: {
 				auto &file_size_vector = output.data[col_idx];
-				FlatVector::GetData<int64_t>(file_size_vector)[out_idx] =
-				    NumericCast<int64_t>(file_handle->GetFileSize());
+				if (caching_file_handle) {
+					FlatVector::GetData<int64_t>(file_size_vector)[out_idx] =
+					    NumericCast<int64_t>(caching_file_handle->GetFileSize());
+				} else {
+					FlatVector::SetNull(output.data[col_idx], out_idx, true);
+				}
 			} break;
 			case ReadFileBindData::FILE_LAST_MODIFIED_COLUMN: {
 				auto &last_modified_vector = output.data[col_idx];
+				if (pipe_file_handle) {
+					FlatVector::SetNull(output.data[col_idx], out_idx, true);
+					break;
+				}
 				// This can sometimes fail (e.g. httpfs file system cant always parse the last modified time
 				// correctly)
 				try {
-					auto timestamp_seconds = file_handle->GetLastModifiedTime();
+					auto timestamp_seconds = caching_file_handle->GetLastModifiedTime();
 					FlatVector::GetData<timestamp_tz_t>(last_modified_vector)[out_idx] =
 					    timestamp_tz_t(timestamp_seconds);
 				} catch (std::exception &ex) {


### PR DESCRIPTION
DirectFileReader previously assumed that all files could be opened via CachingFileHandle. This assumption breaks for file systems like [`shellfs`](https://query.farm/duckdb_extension_shellfs.html), where files may be pipes—single-shot readers that cannot and should not be cached.

This change detects filenames that result in opening pipes and bypasses the CachingFileSystem, reading content directly instead.