### PR TITLE
Tiny fix for ColumnDataAllocator::ColumnDataAllocator

### DIFF
--- a/src/common/types/column/column_data_allocator.cpp
+++ b/src/common/types/column/column_data_allocator.cpp
@@ -37,10 +37,10 @@ ColumnDataAllocator::ColumnDataAllocator(ColumnDataAllocator &other) {
 	switch (type) {
 	case ColumnDataAllocatorType::BUFFER_MANAGER_ALLOCATOR:
 	case ColumnDataAllocatorType::HYBRID:
-		alloc.allocator = other.alloc.allocator;
+		alloc.buffer_manager = other.alloc.buffer_manager;
 		break;
 	case ColumnDataAllocatorType::IN_MEMORY_ALLOCATOR:
-		alloc.buffer_manager = other.alloc.buffer_manager;
+		alloc.allocator = other.alloc.allocator;
 		break;
 	default:
 		throw InternalException("Unrecognized column data allocator type");


### PR DESCRIPTION
There is a minor bug in the ColumnDataAllocator constructor. It seems to have no practical impact.