### PR TITLE
Enable table in/out functions to control their own async wakeup

### DIFF
--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -18,6 +18,7 @@
 #include "duckdb/common/table_column.hpp"
 #include "duckdb/function/partition_stats.hpp"
 #include "duckdb/common/exception/binder_exception.hpp"
+#include "duckdb/parallel/interrupt.hpp"
 
 #include <functional>
 
@@ -157,14 +158,16 @@ struct TableFunctionInput {
 public:
 	TableFunctionInput(optional_ptr<const FunctionData> bind_data_p,
 	                   optional_ptr<LocalTableFunctionState> local_state_p,
-	                   optional_ptr<GlobalTableFunctionState> global_state_p)
-	    : bind_data(bind_data_p), local_state(local_state_p), global_state(global_state_p) {
+	                   optional_ptr<GlobalTableFunctionState> global_state_p,
+	                   optional_ptr<InterruptState> interrupt_state_p = nullptr)
+	    : bind_data(bind_data_p), local_state(local_state_p), global_state(global_state_p), interrupt_state(interrupt_state_p) {
 	}
 
 public:
 	optional_ptr<const FunctionData> bind_data;
 	optional_ptr<LocalTableFunctionState> local_state;
 	optional_ptr<GlobalTableFunctionState> global_state;
+	optional_ptr<InterruptState> interrupt_state;
 };
 
 struct TableFunctionPartitionInput {


### PR DESCRIPTION
This CR addresses an issue I previously raised in a discussion: https://github.com/duckdb/duckdb/discussions/18856

Currently, DuckDB's table function and table in/out function lack support for asynchronous data fetching. In scenarios involving slow I/O (e.g., network operations), synchronous waiting can waste significant thread resources.

While the table in/out function does support returning a BLOCKED state, I found that: once BLOCKED is returned, the function has no way to unblock itself. This renders the BLOCKED return value functionally meaningless in its current implementation.

To resolve this, I've implemented a solution allowing the table in/out function to access an interrupt_state. This enables it to resume itself when data becomes available.

I initially considered adding BLOCKED-related return states to the table function interface as well. However, due to potential backward compatibility concerns, so I didn't do it.