### PR TITLE
ATTACH IF NOT EXISTS - wait until database is fully attached before returning

### DIFF
--- a/test/sql/storage/concurrent_attach_if_not_exists_create.test
+++ b/test/sql/storage/concurrent_attach_if_not_exists_create.test
@@ -1,0 +1,17 @@
+# name: test/sql/storage/concurrent_attach_if_not_exists_create.test
+# description: Test concurrent ATTACH IF NOT EXISTS followed by a create
+# group: [storage]
+
+concurrentloop x 0 10
+
+foreach name db1 db2 db3 db4 db5
+
+statement ok
+attach if not exists '__TEST_DIR__/concurrent_attach_${name}.duckdb' AS ${name}
+
+statement ok
+create table ${name}.tbl${x}(i INTEGER)
+
+endloop
+
+endloop


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/18974 cleaned up handling of `ATTACH IF NOT EXISTS` - where instead of throwing if a database with the same path/name was in the process of being attached, we would return without erroring.

However, this behavior is likely still undesirable - since we would return while the database was *in process of being attached by a different connection* but not yet fully attached/queryable, we could get situations like this:

```sql
ATTACH IF NOT EXISTS 'db_file.db' AS db_name;
CREATE TABLE db_name.tbl(i INTEGER);
-- Database with name "db_name" does not exist
```

This PR resolves this by instead busy spinning until either (1) the database is actually attached, or (2) the database failed to attach in the other connection, in which case we can continue and try our attach. 