### PR TITLE
WALReplay Fix: In UpdateColumn, no longer assume all updates are part of the same vector, but instead verify this and batch updates per vector

### DIFF
--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -164,7 +164,7 @@ public:
 	            const vector<PhysicalIndex> &column_ids);
 	//! Update a single column; corresponds to DataTable::UpdateColumn
 	//! This method should only be called from the WAL
-	void UpdateColumn(TransactionData transaction, DataChunk &updates, Vector &row_ids,
+	void UpdateColumn(TransactionData transaction, DataChunk &updates, Vector &row_ids, idx_t offset, idx_t count,
 	                  const vector<column_t> &column_path);
 
 	void MergeStatistics(idx_t column_idx, const BaseStatistics &other);

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -151,6 +151,8 @@ public:
 private:
 	bool IsEmpty(SegmentLock &) const;
 
+	optional_ptr<RowGroup> NextUpdateRowGroup(row_t *ids, idx_t &pos, idx_t count) const;
+
 private:
 	//! BlockManager
 	BlockManager &block_manager;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -760,17 +760,35 @@ void RowGroupCollection::RemoveFromIndexes(TableIndexList &indexes, Vector &row_
 
 void RowGroupCollection::UpdateColumn(TransactionData transaction, Vector &row_ids, const vector<column_t> &column_path,
                                       DataChunk &updates) {
-	auto first_id = FlatVector::GetValue<row_t>(row_ids, 0);
-	if (first_id >= MAX_ROW_ID) {
-		throw NotImplementedException("Cannot update a column-path on transaction local data");
-	}
-	// find the row_group this id belongs to
-	auto primary_column_idx = column_path[0];
-	auto row_group = row_groups->GetSegment(UnsafeNumericCast<idx_t>(first_id));
-	row_group->UpdateColumn(transaction, updates, row_ids, column_path);
+	D_ASSERT(updates.size() >= 1);
+	auto ids = FlatVector::GetData<row_t>(row_ids);
+	idx_t pos = 0;
+	do {
+		idx_t start = pos;
+		auto row_group = row_groups->GetSegment(UnsafeNumericCast<idx_t>(ids[pos]));
+		row_t base_id =
+		    UnsafeNumericCast<row_t>(row_group->start + ((UnsafeNumericCast<idx_t>(ids[pos]) - row_group->start) /
+		                                                 STANDARD_VECTOR_SIZE * STANDARD_VECTOR_SIZE));
+		auto max_id = MinValue<row_t>(base_id + STANDARD_VECTOR_SIZE,
+		                              UnsafeNumericCast<row_t>(row_group->start + row_group->count));
+		for (pos++; pos < updates.size(); pos++) {
+			D_ASSERT(ids[pos] >= 0);
+			// check if this id still belongs to this vector in this row group
+			if (ids[pos] < base_id) {
+				// id is before vector start -> it does not
+				break;
+			}
+			if (ids[pos] >= max_id) {
+				// id is after the maximum id in this vector -> it does not
+				break;
+			}
+		}
+		row_group->UpdateColumn(transaction, updates, row_ids, start, pos - start, column_path);
 
-	auto lock = stats.GetLock();
-	row_group->MergeIntoStatistics(primary_column_idx, stats.GetStats(*lock, primary_column_idx).Statistics());
+		auto lock = stats.GetLock();
+		auto primary_column_idx = column_path[0];
+		row_group->MergeIntoStatistics(primary_column_idx, stats.GetStats(*lock, primary_column_idx).Statistics());
+	} while (pos < updates.size());
 }
 
 //===--------------------------------------------------------------------===//

--- a/test/sql/storage/update/wal_restart_update_insert.test
+++ b/test/sql/storage/update/wal_restart_update_insert.test
@@ -1,0 +1,39 @@
+# name: test/sql/storage/update/wal_restart_update_insert.test
+# description: Test WAL restart with updates and insertions
+# group: [update]
+
+# load the DB from disk
+load __TEST_DIR__/wal_restart_update_insert.test.db
+
+statement ok
+CREATE TABLE test(i INTEGER PRIMARY KEY, j INTEGER);
+
+statement ok
+INSERT INTO test SELECT r, r FROM range(2000) t(r);
+
+statement ok
+CHECKPOINT
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+SET checkpoint_threshold='1TB'
+
+statement ok
+INSERT INTO test SELECT r, r FROM range(2000,200000) t(r)
+
+statement ok
+UPDATE test SET j=j+1
+
+restart
+
+statement ok
+INSERT INTO test SELECT r, r FROM range(200000,400000) t(r)
+
+restart
+
+query I
+select count(*) FROM test
+----
+400000

--- a/test/sql/storage/update/wal_restart_update_insert.test
+++ b/test/sql/storage/update/wal_restart_update_insert.test
@@ -29,6 +29,12 @@ UPDATE test SET j=j+1
 restart
 
 statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+SET checkpoint_threshold='1TB'
+
+statement ok
 INSERT INTO test SELECT r, r FROM range(200000,400000) t(r)
 
 restart


### PR DESCRIPTION
Since https://github.com/duckdb/duckdb/pull/18829, it is easier for row groups to be less strictly aligned, and also for the same series of appends to not necessarily create the exact same row group layout.

The current implementation for update replay in the WAL requires row ids to be perfectly stable: it assumes that it can figure out based on the first row-id in the vector the vector that the rest of the updates belong to. This PR reworks the `UpdateColumn` method to instead figure out the correct vector that each of the row-ids in the update belongs to prior to performing the update. As a result, this code is robust to differences in row group layouts and the row-ids are no longer required to all be part of the same vector.