### PR TITLE
Add flush memory threshold for appender to prevent OOM

### DIFF
--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -66,7 +66,7 @@ void BaseAppender::EndRow() {
 	}
 	column = 0;
 	chunk.SetCardinality(chunk.size() + 1);
-	if (chunk.size() >= STANDARD_VECTOR_SIZE) {
+	if (ShouldFlushChunk()) {
 		FlushChunk();
 	}
 }
@@ -338,7 +338,7 @@ void BaseAppender::AppendDataChunk(DataChunk &chunk_p) {
 	// Early-out, if types match.
 	if (chunk_types == appender_types) {
 		collection->Append(chunk_p);
-		if (collection->Count() >= flush_count) {
+		if (ShouldFlush()) {
 			Flush();
 		}
 		return;
@@ -371,7 +371,7 @@ void BaseAppender::AppendDataChunk(DataChunk &chunk_p) {
 	}
 
 	collection->Append(cast_chunk);
-	if (collection->Count() >= flush_count) {
+	if (ShouldFlush()) {
 		Flush();
 	}
 }
@@ -382,7 +382,7 @@ void BaseAppender::FlushChunk() {
 	}
 	collection->Append(chunk);
 	chunk.Reset();
-	if (collection->Count() >= flush_count) {
+	if (ShouldFlush()) {
 		Flush();
 	}
 }
@@ -422,8 +422,13 @@ void BaseAppender::ClearColumns() {
 //===--------------------------------------------------------------------===//
 // Table Appender
 //===--------------------------------------------------------------------===//
-Appender::Appender(Connection &con, const string &database_name, const string &schema_name, const string &table_name)
+Appender::Appender(Connection &con, const string &database_name, const string &schema_name, const string &table_name,
+                   const idx_t flush_memory_threshold_p)
     : BaseAppender(Allocator::DefaultAllocator(), AppenderType::LOGICAL), context(con.context) {
+	flush_memory_threshold = (flush_memory_threshold_p == DConstants::INVALID_INDEX)
+	                             ? optional_idx::Invalid()
+	                             : optional_idx(flush_memory_threshold_p);
+
 	description = con.TableInfo(database_name, schema_name, table_name);
 	if (!description) {
 		throw CatalogException(
@@ -479,12 +484,13 @@ Appender::Appender(Connection &con, const string &database_name, const string &s
 	collection = make_uniq<ColumnDataCollection>(allocator, GetActiveTypes());
 }
 
-Appender::Appender(Connection &con, const string &schema_name, const string &table_name)
-    : Appender(con, INVALID_CATALOG, schema_name, table_name) {
+Appender::Appender(Connection &con, const string &schema_name, const string &table_name,
+                   const idx_t flush_memory_threshold_p)
+    : Appender(con, INVALID_CATALOG, schema_name, table_name, flush_memory_threshold_p) {
 }
 
-Appender::Appender(Connection &con, const string &table_name)
-    : Appender(con, INVALID_CATALOG, DEFAULT_SCHEMA, table_name) {
+Appender::Appender(Connection &con, const string &table_name, const idx_t flush_memory_threshold_p)
+    : Appender(con, INVALID_CATALOG, DEFAULT_SCHEMA, table_name, flush_memory_threshold_p) {
 }
 
 Appender::~Appender() {
@@ -576,12 +582,15 @@ void Appender::ClearColumns() {
 // Query Appender
 //===--------------------------------------------------------------------===//
 QueryAppender::QueryAppender(Connection &con, string query_p, vector<LogicalType> types_p, vector<string> names_p,
-                             string table_name_p)
+                             string table_name_p, const idx_t flush_memory_threshold_p)
     : BaseAppender(Allocator::DefaultAllocator(), AppenderType::LOGICAL), context(con.context),
       query(std::move(query_p)), names(std::move(names_p)), table_name(std::move(table_name_p)) {
 	types = std::move(types_p);
 	InitializeChunk();
 	collection = make_uniq<ColumnDataCollection>(allocator, GetActiveTypes());
+	flush_memory_threshold = (flush_memory_threshold_p == DConstants::INVALID_INDEX)
+	                             ? optional_idx::Invalid()
+	                             : optional_idx(flush_memory_threshold_p);
 }
 
 QueryAppender::~QueryAppender() {
@@ -598,9 +607,13 @@ void QueryAppender::FlushInternal(ColumnDataCollection &collection) {
 //===--------------------------------------------------------------------===//
 // Internal Appender
 //===--------------------------------------------------------------------===//
-InternalAppender::InternalAppender(ClientContext &context_p, TableCatalogEntry &table_p, const idx_t flush_count_p)
+InternalAppender::InternalAppender(ClientContext &context_p, TableCatalogEntry &table_p, const idx_t flush_count_p,
+                                   const idx_t flush_memory_threshold_p)
     : BaseAppender(Allocator::DefaultAllocator(), table_p.GetTypes(), AppenderType::PHYSICAL, flush_count_p),
       context(context_p), table(table_p) {
+	flush_memory_threshold = (flush_memory_threshold_p == DConstants::INVALID_INDEX)
+	                             ? optional_idx::Invalid()
+	                             : optional_idx(flush_memory_threshold_p);
 }
 
 InternalAppender::~InternalAppender() {
@@ -627,6 +640,30 @@ void BaseAppender::Clear() {
 	}
 
 	column = 0;
+}
+
+bool BaseAppender::ShouldFlushChunk() const {
+	if (chunk.size() >= STANDARD_VECTOR_SIZE) {
+		return true;
+	}
+
+	if (!flush_memory_threshold.IsValid()) {
+		return false;
+	}
+
+	return (collection->AllocationSize() >= flush_memory_threshold.GetIndex());
+}
+
+bool BaseAppender::ShouldFlush() const {
+	if (collection->Count() >= flush_count) {
+		return true;
+	}
+
+	if (!flush_memory_threshold.IsValid()) {
+		return false;
+	}
+
+	return (collection->AllocationSize() >= flush_memory_threshold.GetIndex());
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Currently, memory in the appender is only flushed after every 204,800 appends, and FlushChunk is triggered every 2,048 appends. This delayed flushing behavior can lead to excessive memory consumption and increase the risk of out-of-memory in high-throughput ingestion scenarios.

This patch introduces a new configuration option for appender, which sets a peak memory threshold. When the appender's memory usage exceeds this limit, it forces an early flush of temporary allocations — even within a single chunk.

Additionally, this threshold now influences the early triggering of FlushChunk, allowing more responsive memory management based on actual usage rather than fixed batch counts.

This change improves memory predictability and helps prevent unbounded growth during large appends.