### PR TITLE
Always execute cast and try_cast if they are not invertible

### DIFF
--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -16,7 +16,6 @@ unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const
 		vector<reference<Expression>> bindings;
 		if (rule.get().root->Match(*expr, bindings)) {
 			// the rule matches! try to apply it
-			// Printer::Print("Applying rule to " + expr->ToString());
 			bool rule_made_change = false;
 			auto alias = expr->alias;
 			auto result = rule.get().Apply(op, bindings, rule_made_change, is_root);

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -26,8 +26,7 @@ unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const
 				if (!alias.empty()) {
 					result->alias = std::move(alias);
 				}
-				auto ret = ExpressionRewriter::ApplyRules(op, rules, std::move(result), changes_made);
-				return ret;
+				return ExpressionRewriter::ApplyRules(op, rules, std::move(result), changes_made);
 			} else if (rule_made_change) {
 				changes_made = true;
 				// the base node didn't change, but changes were made, rerun

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -16,6 +16,7 @@ unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const
 		vector<reference<Expression>> bindings;
 		if (rule.get().root->Match(*expr, bindings)) {
 			// the rule matches! try to apply it
+			// Printer::Print("Applying rule to " + expr->ToString());
 			bool rule_made_change = false;
 			auto alias = expr->alias;
 			auto result = rule.get().Apply(op, bindings, rule_made_change, is_root);
@@ -26,7 +27,8 @@ unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const
 				if (!alias.empty()) {
 					result->alias = std::move(alias);
 				}
-				return ExpressionRewriter::ApplyRules(op, rules, std::move(result), changes_made);
+				auto ret = ExpressionRewriter::ApplyRules(op, rules, std::move(result), changes_made);
+				return ret;
 			} else if (rule_made_change) {
 				changes_made = true;
 				// the base node didn't change, but changes were made, rerun

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -56,16 +56,8 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 		// Is the constant cast invertible?
 		if (!cast_constant.IsNull() &&
 		    !BoundCastExpression::CastIsInvertible(cast_expression.return_type, target_type)) {
-			// Is it actually invertible?
-			Value uncast_constant;
-			if (!cast_constant.TryCastAs(rewriter.context, constant_value.type(), uncast_constant, &error_message,
-			                             true) ||
-			    uncast_constant != constant_value) {
-				return nullptr;
-			}
-			if (cast_expression.try_cast) {
-				return nullptr;
-			}
+			// Cast is not invertible, so we do not rewrite this expression to ensure that the cast is executed
+			return nullptr;
 		}
 
 		//! We can cast, now we change our column_ref_expression from an operator cast to a column reference

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -63,6 +63,9 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 			    uncast_constant != constant_value) {
 				return nullptr;
 			}
+			if (cast_expression.try_cast) {
+				return nullptr;
+			}
 		}
 
 		//! We can cast, now we change our column_ref_expression from an operator cast to a column reference
@@ -75,6 +78,7 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 			expr.left = std::move(new_constant_expr);
 			expr.right = std::move(child_expression);
 		}
+		changes_made = true;
 	}
 	return nullptr;
 }

--- a/test/optimizer/test_try_cast_decimal.test
+++ b/test/optimizer/test_try_cast_decimal.test
@@ -1,0 +1,34 @@
+# name: test/optimizer/test_try_cast_decimal.test
+# description: Test SUM rewrite
+# group: [optimizer]
+
+statement ok
+pragma disable_optimizer;
+
+
+statement ok
+CREATE  TABLE  t0(c0 INT , c1 BOOLEAN , PRIMARY KEY(c0));
+
+statement ok
+INSERT INTO t0(c0, c1) VALUES (890608529, false);
+
+statement ok
+pragma enable_optimizer;
+
+query I
+SELECT (true AND((TRY_CAST(t0.c0 AS DECIMAL(10,2)) > 0))) AS r FROM t0;
+----
+NULL
+
+query I
+SELECT (((TRY_CAST(t0.c0 AS DECIMAL(10,2)) > 0))) AS r FROM t0;
+----
+NULL
+
+query I
+SELECT (true OR((TRY_CAST(t0.c0 AS DECIMAL(10,2)) > 0))) AS r FROM t0;
+----
+true
+
+
+

--- a/test/optimizer/test_try_cast_decimal.test
+++ b/test/optimizer/test_try_cast_decimal.test
@@ -1,19 +1,15 @@
 # name: test/optimizer/test_try_cast_decimal.test
-# description: Test SUM rewrite
+# description: Test try cast inconsistency
 # group: [optimizer]
 
 statement ok
-pragma disable_optimizer;
-
+pragma enable_verification
 
 statement ok
 CREATE  TABLE  t0(c0 INT , c1 BOOLEAN , PRIMARY KEY(c0));
 
 statement ok
 INSERT INTO t0(c0, c1) VALUES (890608529, false);
-
-statement ok
-pragma enable_optimizer;
 
 query I
 SELECT (true AND((TRY_CAST(t0.c0 AS DECIMAL(10,2)) > 0))) AS r FROM t0;

--- a/test/optimizer/test_try_cast_decimal.test
+++ b/test/optimizer/test_try_cast_decimal.test
@@ -30,5 +30,12 @@ SELECT (true OR((TRY_CAST(t0.c0 AS DECIMAL(10,2)) > 0))) AS r FROM t0;
 ----
 true
 
+statement error
+SELECT (((CAST(t0.c0 AS DECIMAL(10,2)) > 0))) AS r FROM t0;
+----
+Conversion Error
 
+query I
+SELECT t0.c1 FROM t0 WHERE (true AND((TRY_CAST(t0.c0 AS DECIMAL(10,2)) > 0)));
+----
 


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/5876 
fixes https://github.com/duckdb/duckdb/issues/18967

Together with @Tmonster we managed to come up with a fix. We identified two separate issue. 
- an inconsistency when running the same query with and without a conjuction. The problem there was that even though we were making changes in the child expression, the variable changes_made was never updated. As a result, the expression rewriter was not aware of the changes and was not re-reruning before going to the next rule.
- Even when the cast is not invertible, the code would drop the cast and just compare the LHS and RHS if the RHS could be casted (and invertible) to the target type. 

To solve this we identified two solutions. One option is to change the functionality and when the cast is not invertible always run the cast or try_cast, but that is more work for the engine. The other option is to keep the old functionality, and just fix the inconsistency 

