### PR TITLE
Throw if we detect a quoted new line with the null padding set in parallel mode

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -797,7 +797,7 @@ void StringValueResult::NullPaddingQuotedNewlineCheck() const {
 		// If we have null_padding set, we found a quoted new line, we are scanning the file in parallel; We error.
 		LinesPerBoundary lines_per_batch(iterator.GetBoundaryIdx(), lines_read);
 		auto csv_error = CSVError::NullPaddingFail(state_machine.options, lines_per_batch, path);
-		error_handler.Error(csv_error, try_row);
+		error_handler.Error(csv_error, true);
 	}
 }
 

--- a/test/sql/copy/csv/test_null_padding_quoted_new_line.test_slow
+++ b/test/sql/copy/csv/test_null_padding_quoted_new_line.test_slow
@@ -1,0 +1,23 @@
+# name: test/sql/copy/csv/test_null_padding_quoted_new_line.test_slow
+# description: Test CSV with nullpading interoping with quoted new line
+# group: [csv]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE T as SELECT 'this line
+has a new line' from range (1000000);
+
+statement ok
+COPY T TO '__TEST_DIR__/test_null_padding_quoted_new_line.csv' (FORMAT CSV , FORCE_QUOTE *);
+
+statement error
+select count(*) FROM read_csv('__TEST_DIR__/test_null_padding_quoted_new_line.csv', null_padding = true)
+----
+The parallel scanner does not support null_padding in conjunction with quoted new lines. Please disable the parallel csv reader with parallel=false
+
+query I
+select count(*) FROM read_csv('__TEST_DIR__/test_null_padding_quoted_new_line.csv')
+----
+1000000


### PR DESCRIPTION
This is simply not supported and should error if it happens, since when detected we can't guarantee that our parallel algorithm is correctly detecting the start of rows.

The error suggests the usage of `parallel = false`. The error was being incorrectly ignored.

Fix: https://github.com/duckdb/duckdb/issues/18577