### PR TITLE
Fix union semantics in recursive CTEs

### DIFF
--- a/src/planner/binder/query_node/plan_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/plan_recursive_cte_node.cpp
@@ -36,7 +36,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundRecursiveCTENode &node) {
 	     *node.right_binder->bind_context.cte_references[node.ctename] == 0) &&
 	    !ref_recurring) {
 		auto root = make_uniq<LogicalSetOperation>(node.setop_index, node.types.size(), std::move(left_node),
-		                                           std::move(right_node), LogicalOperatorType::LOGICAL_UNION, true);
+		                                           std::move(right_node), LogicalOperatorType::LOGICAL_UNION, node.union_all);
 		return VisitQueryNode(node, std::move(root));
 	}
 

--- a/src/planner/binder/query_node/plan_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/plan_recursive_cte_node.cpp
@@ -35,8 +35,9 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundRecursiveCTENode &node) {
 	if ((!node.right_binder->bind_context.cte_references[node.ctename] ||
 	     *node.right_binder->bind_context.cte_references[node.ctename] == 0) &&
 	    !ref_recurring) {
-		auto root = make_uniq<LogicalSetOperation>(node.setop_index, node.types.size(), std::move(left_node),
-		                                           std::move(right_node), LogicalOperatorType::LOGICAL_UNION, node.union_all);
+		auto root =
+		    make_uniq<LogicalSetOperation>(node.setop_index, node.types.size(), std::move(left_node),
+		                                   std::move(right_node), LogicalOperatorType::LOGICAL_UNION, node.union_all);
 		return VisitQueryNode(node, std::move(root));
 	}
 

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -220,3 +220,7 @@ SELECT b.x
 FROM (SELECT 1) _(x), LATERAL (SELECT * FROM cte) b(x)
 ----
 
+query III
+WITH RECURSIVE rec(a, b, c) AS (select a,b,c from (values(1,2,3),(1,2,3)) s(a,b,c) union select 1,2,3) select * from rec;
+----
+1	2	3


### PR DESCRIPTION
We found a bug relating to recursive CTEs. When the recursive keyword is used without a recursive reference, the logical planner creates a logical set operator. Typically, we would expect the `UNION` or `UNION ALL` semantics of the CTE to be retained. However, the bug causes it to always use the `UNION ALL` semantic, resulting in differences in queries that we wouldn't expect.

```
WITH RECURSIVE rec(a, b, c) AS (
  SELECT a,b,c 
  FROM (VALUES(1,2,3),(1,2,3)) s(a,b,c) 
    UNION 
  SELECT 1,2,3) 
TABLE rec;
┌───────┬───────┬───────┐
│   a   │   b   │   c   │
│ int32 │ int32 │ int32 │
├───────┼───────┼───────┤
│     1 │     2 │     3 │
│     1 │     2 │     3 │
│     1 │     2 │     3 │
└───────┴───────┴───────┘
WITH rec(a, b, c) AS (
  SELECT a,b,c 
  FROM (VALUES(1,2,3),(1,2,3)) s(a,b,c) 
    UNION 
  SELECT 1,2,3) 
TABLE rec;
┌───────┬───────┬───────┐
│   a   │   b   │   c   │
│ int32 │ int32 │ int32 │
├───────┼───────┼───────┤
│   1   │   2   │   3   │
└───────┴───────┴───────┘
```
Rather than using the `UNION` semantics specified in the recursive anchor, we use `UNION ALL`.

This PR fixes the deviation by using the `UNION` semantics given in the CTE.

