### PR TITLE
[Optimize] use StorageLock for CompressionFunction

### DIFF
--- a/src/include/duckdb/function/compression_function.hpp
+++ b/src/include/duckdb/function/compression_function.hpp
@@ -17,6 +17,7 @@
 #include "duckdb/storage/data_pointer.hpp"
 #include "duckdb/storage/storage_info.hpp"
 #include "duckdb/storage/block_manager.hpp"
+#include "duckdb/storage/storage_lock.hpp"
 
 namespace duckdb {
 class DatabaseInstance;
@@ -333,7 +334,7 @@ public:
 
 //! The set of compression functions
 struct CompressionFunctionSet {
-	mutex lock;
+	StorageLock lock;
 	map<CompressionType, map<PhysicalType, CompressionFunction>> functions;
 };
 


### PR DESCRIPTION
When multiple threads write data to duckdb, we observe severe lock contention in GetCompressionFunctions. The flame graph is as follows:
<img width="1716" height="1116" alt="image" src="https://github.com/user-attachments/assets/f96e7c90-54df-4827-9a21-0721c9cd2801" />

This patch uses a read-write lock(StorageLock) instead of a mutex.
