### PR TITLE
Issue #19016: ICU Offset Parsing

### DIFF
--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -221,8 +221,9 @@ struct ICUStrptime : public ICUDateFunc {
 				if (!error.empty()) {
 					throw InvalidInputException("Failed to parse format specifier %s: %s", format_string, error);
 				}
-				// If any format has UTC offsets, then we have to produce TSTZ
+				// If any format has UTC offsets or names, then we have to produce TSTZ
 				has_tz = has_tz || format.HasFormatSpecifier(StrTimeSpecifier::TZ_NAME);
+				has_tz = has_tz || format.HasFormatSpecifier(StrTimeSpecifier::UTC_OFFSET);
 				formats.emplace_back(format);
 			}
 			if (has_tz) {

--- a/test/sql/function/timestamp/test_icu_strptime.test
+++ b/test/sql/function/timestamp/test_icu_strptime.test
@@ -513,6 +513,12 @@ ORDER BY ALL
 
 endloop
 
+# Offset patterns should also trigger casting to th current time zone
+query I
+SELECT STRPTIME('2025-09-16', ['%Y-%m-%d', '%Y-%m-%d%z']);
+----
+2025-09-16 00:00:00-07
+
 #
 # Try
 #


### PR DESCRIPTION
* Also force use of ICU parsing when %z (UTC_OFFSET) is present.

fixes: duckdb#19016
fixes: duckdblabs/duckdb-internal#5916