### PR TITLE
[C-API] default to adding overload on conflict when registering functions

### DIFF
--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -327,6 +327,7 @@ duckdb_state duckdb_register_aggregate_function_set(duckdb_connection connection
 		con->context->RunFunctionInTransaction([&]() {
 			auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
 			duckdb::CreateAggregateFunctionInfo sf_info(set);
+			sf_info.on_conflict = duckdb::OnCreateConflict::ALTER_ON_CONFLICT;
 			catalog.CreateFunction(*con->context, sf_info);
 		});
 	} catch (...) {

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -406,6 +406,7 @@ duckdb_state duckdb_register_scalar_function_set(duckdb_connection connection, d
 		con->context->RunFunctionInTransaction([&]() {
 			auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
 			duckdb::CreateScalarFunctionInfo sf_info(scalar_function_set);
+			sf_info.on_conflict = duckdb::OnCreateConflict::ALTER_ON_CONFLICT;
 			catalog.CreateFunction(*con->context, sf_info);
 		});
 	} catch (...) {

--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -347,6 +347,7 @@ duckdb_state duckdb_register_table_function(duckdb_connection connection, duckdb
 		con->context->RunFunctionInTransaction([&]() {
 			auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
 			duckdb::CreateTableFunctionInfo tf_info(tf);
+			tf_info.on_conflict = duckdb::OnCreateConflict::ALTER_ON_CONFLICT;
 			catalog.CreateTableFunction(*con->context, tf_info);
 		});
 	} catch (...) { // LCOV_EXCL_START

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -109,8 +109,8 @@ TEST_CASE("Test Scalar Functions C API", "[capi]") {
 
 	REQUIRE(tester.OpenDatabase(nullptr));
 	CAPIRegisterAddition(tester.connection, "my_addition", DuckDBSuccess);
-	// try to register it again - this should be an error
-	CAPIRegisterAddition(tester.connection, "my_addition", DuckDBError);
+	// try to register it again - this should not be an error
+	CAPIRegisterAddition(tester.connection, "my_addition", DuckDBSuccess);
 
 	// now call it
 	result = tester.Query("SELECT my_addition(40, 2)");
@@ -387,8 +387,8 @@ TEST_CASE("Test Scalar Function Overloads C API", "[capi]") {
 
 	REQUIRE(tester.OpenDatabase(nullptr));
 	CAPIRegisterAdditionOverloads(tester.connection, "my_addition", DuckDBSuccess);
-	// try to register it again - this should be an error
-	CAPIRegisterAdditionOverloads(tester.connection, "my_addition", DuckDBError);
+	// try to register it again - this should not be an error
+	CAPIRegisterAdditionOverloads(tester.connection, "my_addition", DuckDBSuccess);
 
 	// now call it
 	result = tester.Query("SELECT my_addition(40, 2)");

--- a/test/api/capi/capi_table_functions.cpp
+++ b/test/api/capi/capi_table_functions.cpp
@@ -90,8 +90,9 @@ TEST_CASE("Test Table Functions C API", "[capi]") {
 
 	REQUIRE(tester.OpenDatabase(nullptr));
 	capi_register_table_function(tester.connection, "my_function", my_bind, my_init, my_function);
-	// registering again causes an error
-	capi_register_table_function(tester.connection, "my_function", my_bind, my_init, my_function, DuckDBError);
+
+	// registering again does not cause error, because we overload
+	capi_register_table_function(tester.connection, "my_function", my_bind, my_init, my_function);
 
 	// now call it
 	result = tester.Query("SELECT * FROM my_function(1)");
@@ -158,8 +159,8 @@ TEST_CASE("Test Table Function register errors in C API", "[capi]") {
 	REQUIRE(tester.OpenDatabase(nullptr));
 
 	capi_register_table_function(tester.connection, "x", my_error_bind, my_init, my_function, DuckDBSuccess);
-	// Try to register it again with the same name, name collision
-	capi_register_table_function(tester.connection, "x", my_error_bind, my_init, my_function, DuckDBError);
+	// Try to register it again with the same name, is ok (because of overloading)
+	capi_register_table_function(tester.connection, "x", my_error_bind, my_init, my_function, DuckDBSuccess);
 }
 
 struct my_named_bind_data_struct {


### PR DESCRIPTION
This follows the same behavior as the c++ extension API.