### PR TITLE
Bump iceberg & ducklake

### DIFF
--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG 09f9b85b7ea1c5c4a14ebfb83dd8ac5c9d65a874
+    GIT_TAG 45788f0a875844ac8fed048c99b87f7f4b1c2ac1
 )

--- a/.github/config/extensions/iceberg.cmake
+++ b/.github/config/extensions/iceberg.cmake
@@ -9,6 +9,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 06ca288392a00cdf1b9232d4dd6a96b6e4754470
+            GIT_TAG 49d67e45a6f15ad855f3760658b4ab42967d9cdc
             )
 endif()


### PR DESCRIPTION
Bump them to the same versions that have been swapped from nightly to core, keeping for now parity.