### PR TITLE
add a bunch of expected error messages to old macro tests and fix iss…

### DIFF
--- a/src/parser/transform/statement/transform_create_function.cpp
+++ b/src/parser/transform/statement/transform_create_function.cpp
@@ -47,6 +47,8 @@ unique_ptr<MacroFunction> Transformer::TransformMacroFunction(duckdb_libpgquery:
 			default_expr = make_uniq<ConstantExpression>(std::move(default_value));
 			default_expr->SetAlias(param.name);
 			macro_func->default_parameters[param.name] = std::move(default_expr);
+		} else if (!macro_func->default_parameters.empty()) {
+			throw ParserException("Parameter without a default follows parameter with a default");
 		}
 	}
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -285,16 +285,7 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 		// positional parameters
 		for (idx_t param_idx = 0; param_idx < function->parameters.size(); param_idx++) {
 			dummy_types.emplace_back(function->types.empty() ? LogicalType::UNKNOWN : function->types[param_idx]);
-			auto &col_name = function->parameters[param_idx]->Cast<ColumnRefExpression>().GetColumnName();
-			dummy_names.push_back(col_name);
-			if (dummy_types.back() != LogicalType::UNKNOWN) {
-				continue;
-			}
-			// We can do better than UNKNOWN for untyped params with a default
-			auto it = function->default_parameters.find(col_name);
-			if (it != function->default_parameters.end()) {
-				dummy_types.back() = it->second->Cast<ConstantExpression>().value.type();
-			}
+			dummy_names.push_back(function->parameters[param_idx]->Cast<ColumnRefExpression>().GetColumnName());
 		}
 
 		if (!type_overloads.insert(dummy_types).second) {

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -285,7 +285,16 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 		// positional parameters
 		for (idx_t param_idx = 0; param_idx < function->parameters.size(); param_idx++) {
 			dummy_types.emplace_back(function->types.empty() ? LogicalType::UNKNOWN : function->types[param_idx]);
-			dummy_names.push_back(function->parameters[param_idx]->Cast<ColumnRefExpression>().GetColumnName());
+			auto &col_name = function->parameters[param_idx]->Cast<ColumnRefExpression>().GetColumnName();
+			dummy_names.push_back(col_name);
+			if (dummy_types.back() != LogicalType::UNKNOWN) {
+				continue;
+			}
+			// We can do better than UNKNOWN for untyped params with a default
+			auto it = function->default_parameters.find(col_name);
+			if (it != function->default_parameters.end()) {
+				dummy_types.back() = it->second->Cast<ConstantExpression>().value.type();
+			}
 		}
 
 		if (!type_overloads.insert(dummy_types).second) {

--- a/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
+++ b/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
@@ -67,10 +67,8 @@ Invalid default value
 
 # to test the dependencies we create this macro instead
 statement ok
-create macro my_macro2(i := 42) as (
-	select min(a) + i from integers
-);
-
+create macro my_macro2(i := 42) as
+    i + (select min(a) from integers);
 
 statement ok
 insert into integers values (5), (10), (13)

--- a/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
+++ b/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
@@ -67,8 +67,9 @@ Invalid default value
 
 # to test the dependencies we create this macro instead
 statement ok
-create macro my_macro2(i := 42) as
-    i + (select min(a) from integers);
+create macro my_macro2(i := 42) as (
+    select min(a) + i from integers
+);
 
 statement ok
 insert into integers values (5), (10), (13)

--- a/test/sql/catalog/function/test_simple_macro.test
+++ b/test/sql/catalog/function/test_simple_macro.test
@@ -280,11 +280,21 @@ CREATE MACRO select_plus_floats(a, f := b) AS (SELECT a + f FROM floats)
 ----
 Invalid default value
 
-# +(FLOAT, VARCHAR) does not work - constant types are checked at create time
-statement error
+# +(FLOAT, VARCHAR) does not work - but types are only checked once the macro is called
+statement ok
 CREATE MACRO wrong_type(s := 'not a float') AS (SELECT b + s FROM floats)
+
+# this should fail
+statement error
+select wrong_type()
 ----
-No function matches the given name and argument types '+(FLOAT, VARCHAR)'
+Could not convert
+
+# but succeed if we pass the correct type
+query I
+select wrong_type(42)
+----
+42.5
 
 statement error
 CREATE MACRO two_default_params(a := 4, a := 2) AS a + a

--- a/test/sql/catalog/function/test_simple_macro.test
+++ b/test/sql/catalog/function/test_simple_macro.test
@@ -22,10 +22,12 @@ SELECT one()
 statement error
 SELECT one(1)
 ----
+does not support the supplied arguments
 
 statement error
 SELECT one(NULL)
 ----
+does not support the supplied arguments
 
 statement ok
 DROP MACRO one;
@@ -98,6 +100,7 @@ DROP FUNCTION two;
 statement error
 CREATE MACRO add_macro(a) AS a + b
 ----
+column "b" not found
 
 statement ok
 CREATE MACRO add_macro(a, b) AS a + b
@@ -159,27 +162,33 @@ false
 statement error
 SELECT IFELSE();
 ----
+does not support the supplied arguments
 
 statement error
 SELECT IFELSE(1);
 ----
+does not support the supplied arguments
 
 statement error
 SELECT IFELSE(1, 2);
 ----
+does not support the supplied arguments
 
 statement error
 SELECT IFELSE(1, 2, 3, 4);
 ----
+does not support the supplied arguments
 
 # no duplicate macro function names
 statement error
 CREATE MACRO IFELSE(a,b) AS a+b
 ----
+already exists
 
 statement error
 CREATE MACRO ifelse(a,b) AS a+b
 ----
+already exists
 
 query T
 SELECT IFELSE('1', 'random', RANDOM()::VARCHAR)
@@ -253,28 +262,34 @@ SELECT add_default5(3, b := 6)
 statement error
 SELECT add_default5(b := 6, 3)
 ----
+positional argument following named argument
 
 statement error
-CREATE MACRO wrong_order(a, b := 3, c)
+CREATE MACRO wrong_order(a, b := 3, c) AS a + b + c
 ----
+Parameter without a default follows parameter with a default
 
 statement error
-CREATE MACRO wrong_order(a := 3, b)
+CREATE MACRO wrong_order(a := 3, b) AS a + b
 ----
+Parameter without a default follows parameter with a default
 
 # only constant default values are allowed
 statement error
 CREATE MACRO select_plus_floats(a, f := b) AS (SELECT a + f FROM floats)
 ----
+Invalid default value
 
 # +(FLOAT, VARCHAR) does not work - constant types are checked at create time
 statement error
-CREATE MACRO wrong_type(s='not a float') AS (SELECT b + s FROM floats)
+CREATE MACRO wrong_type(s := 'not a float') AS (SELECT b + s FROM floats)
 ----
+No function matches the given name and argument types '+(FLOAT, VARCHAR)'
 
 statement error
 CREATE MACRO two_default_params(a := 4, a := 2) AS a + a
 ----
+Duplicate parameter
 
 statement ok
 CREATE MACRO two_default_params(a := 4, b := 2) AS a + b
@@ -297,22 +312,27 @@ SELECT two_default_params(b := 3)
 statement error
 SELECT two_default_params(a := 5, a := 3)
 ----
+has named argument repeated
 
 statement error
 SELECT two_default_params(b := 5, b := 3)
 ----
+has named argument repeated
 
 statement error
 CREATE MACRO macros.add_macro(a, b) AS a + b
 ----
+already exists
 
 statement error
 CREATE MACRO my_macro(a.b) AS 42;
 ----
+syntax error
 
 statement error
 CREATE MACRO my_macro(a.b.c) AS 42;
 ----
+syntax error
 
 statement ok
 CREATE MACRO my_macro(a) AS 42;
@@ -320,10 +340,12 @@ CREATE MACRO my_macro(a) AS 42;
 statement error
 SELECT my_macro(x := 42);
 ----
+does not support the supplied arguments
 
 statement error
 SELECT my_macro(a := 42, a := 42);
 ----
+has named argument repeated
 
 # internal issue 1044
 statement ok


### PR DESCRIPTION
While working on the parser, @Dtenwolde found that some old macro tests were not producing expected error messages. Indeed, these tests were implemented before we could even add an expected error message to `statement error`. I've added a bunch of expected error messages to these old macro tests, and fixed some of the behaviour.

This should've thrown an error, but didn't anymore (which the wrong test did not catch):
```sql
CREATE MACRO wrong_order(a, b := 3, c) AS a + b + c;
-- Now throws: Parameter without a default follows parameter with a default
```

Same here, this now throws an error
```sql
CREATE TABLE floats (b FLOAT);
CREATE MACRO wrong_type(s := 'not a float') AS (SELECT b + s FROM floats);
-- Now throws: No function matches the given name and argument types '+(FLOAT, VARCHAR)'
```

Making sure we throw an error for this last example makes this no longer possible:
```sql
create macro my_macro2(i := 42) as (
	select min(a) + i from integers
);
-- Now throws: column "i" must appear in the GROUP BY clause or must be part of an aggregate function.
```
As we now no longer throw a `ParameterNotResolvedException` because we propagate the inferred type for `i`.

This is fine, however, as the macro can be rewritten to:
```sql
create macro my_macro2(i := 42) as
    i + (select min(a) from integers);
```