### PR TITLE
Redirect without location should still returns response information

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,6 +1,8 @@
 duckdb_extension_load(httpfs
-    LOAD_TESTS
-    GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 354d3f436a33f80f03a74419e76eb59459e19168
-    INCLUDE_DIR extension/httpfs/include
+        LOAD_TESTS
+        #            GIT_URL https://github.com/duckdb/duckdb-httpfs
+        #            GIT_TAG 354d3f436a33f80f03a74419e76eb59459e19168
+        #            INCLUDE_DIR extension/httpfs/include
+        SOURCE_DIR /Users/tomebergen/git/duckdb-httpfs
+        INCLUDE_DIR /Users/tomebergen/git/duckdb-httpfs/extension/httpfs/include
 )

--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,8 +1,7 @@
 duckdb_extension_load(httpfs
-        LOAD_TESTS
-        #            GIT_URL https://github.com/duckdb/duckdb-httpfs
-        #            GIT_TAG 354d3f436a33f80f03a74419e76eb59459e19168
-        #            INCLUDE_DIR extension/httpfs/include
-        SOURCE_DIR /Users/tomebergen/git/duckdb-httpfs
-        INCLUDE_DIR /Users/tomebergen/git/duckdb-httpfs/extension/httpfs/include
+    LOAD_TESTS
+    GIT_URL https://github.com/duckdb/duckdb-httpfs
+    GIT_TAG 354d3f436a33f80f03a74419e76eb59459e19168
+    INCLUDE_DIR extension/httpfs/include
 )
+

--- a/.github/patches/extensions/httpfs/fix.patch
+++ b/.github/patches/extensions/httpfs/fix.patch
@@ -1,25 +1,29 @@
 diff --git a/extension/httpfs/httpfs.cpp b/extension/httpfs/httpfs.cpp
-index bb7267a..3687009 100644
+index bb7267a..3bc8d06 100644
 --- a/extension/httpfs/httpfs.cpp
 +++ b/extension/httpfs/httpfs.cpp
-@@ -85,20 +85,26 @@ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener>
+@@ -85,20 +85,29 @@ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener>
  	return std::move(result);
  }
  
 -unique_ptr<HTTPClient> HTTPClientCache::GetClient() {
-+unique_ptr<HTTPClient> HTTPClientCache::GetClient(string host) {
++unique_ptr<HTTPClient> HTTPClientCache::GetClient(string &host) {
  	lock_guard<mutex> lck(lock);
  	if (clients.size() == 0) {
  		return nullptr;
  	}
+-
+-	auto client = std::move(clients.back());
+-	clients.pop_back();
 +	if (clients.find(host) == clients.end()) {
 +		return nullptr;
 +	}
- 
--	auto client = std::move(clients.back());
--	clients.pop_back();
-+	auto client = std::move((clients[host].back()));
-+	clients[host].pop_back();
++	auto &client_list = clients[host];
++	if (client_list.empty()) {
++		return nullptr;
++	}
++	auto client = std::move(client_list.back());
++	client_list.pop_back();
  	return client;
  }
  
@@ -34,7 +38,7 @@ index bb7267a..3687009 100644
  }
  
  unique_ptr<HTTPResponse> HTTPFileSystem::PostRequest(FileHandle &handle, string url, HTTPHeaders header_map,
-@@ -125,23 +131,26 @@ unique_ptr<HTTPResponse> HTTPFileSystem::PutRequest(FileHandle &handle, string u
+@@ -125,23 +134,26 @@ unique_ptr<HTTPResponse> HTTPFileSystem::PutRequest(FileHandle &handle, string u
  unique_ptr<HTTPResponse> HTTPFileSystem::HeadRequest(FileHandle &handle, string url, HTTPHeaders header_map) {
  	auto &hfh = handle.Cast<HTTPFileHandle>();
  	auto &http_util = hfh.http_params.http_util;
@@ -66,7 +70,7 @@ index bb7267a..3687009 100644
  	return response;
  }
  
-@@ -161,8 +170,9 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
+@@ -161,8 +173,9 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
  	auto &http_util = hfh.http_params.http_util;
  
  	D_ASSERT(hfh.cached_file_handle);
@@ -78,7 +82,7 @@ index bb7267a..3687009 100644
  	GetRequestInfo get_request(
  	    url, header_map, hfh.http_params,
  	    [&](const HTTPResponse &response) {
-@@ -200,7 +210,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
+@@ -200,7 +213,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
  
  	auto response = http_util.Request(get_request, http_client);
  
@@ -87,7 +91,7 @@ index bb7267a..3687009 100644
  	return response;
  }
  
-@@ -213,7 +223,9 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
+@@ -213,7 +226,9 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
  	string range_expr = "bytes=" + to_string(file_offset) + "-" + to_string(file_offset + buffer_out_len - 1);
  	header_map.Insert("Range", range_expr);
  
@@ -98,7 +102,7 @@ index bb7267a..3687009 100644
  
  	idx_t out_offset = 0;
  
-@@ -272,7 +284,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
+@@ -272,7 +287,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
  
  	auto response = http_util.Request(get_request, http_client);
  
@@ -107,7 +111,7 @@ index bb7267a..3687009 100644
  	return response;
  }
  
-@@ -681,7 +693,14 @@ void HTTPFileHandle::LoadFileInfo() {
+@@ -681,7 +696,14 @@ void HTTPFileHandle::LoadFileInfo() {
  			length = 0;
  			return;
  		} else {
@@ -123,12 +127,12 @@ index bb7267a..3687009 100644
  			if (flags.OpenForReading() && res->status != HTTPStatusCode::NotFound_404) {
  				auto range_res = hfs.GetRangeRequest(*this, path, {}, 0, nullptr, 2);
  				if (range_res->status != HTTPStatusCode::PartialContent_206 &&
-@@ -786,13 +805,12 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
+@@ -786,13 +808,12 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
  	}
  }
  
 -unique_ptr<HTTPClient> HTTPFileHandle::GetClient() {
-+unique_ptr<HTTPClient> HTTPFileHandle::GetClient(string host) {
++unique_ptr<HTTPClient> HTTPFileHandle::GetClient(string &host) {
  	// Try to fetch a cached client
 -	auto cached_client = client_cache.GetClient();
 +	auto cached_client = client_cache.GetClient(host);
@@ -139,21 +143,19 @@ index bb7267a..3687009 100644
  	// Create a new client
  	return CreateClient();
  }
-@@ -804,8 +822,10 @@ unique_ptr<HTTPClient> HTTPFileHandle::CreateClient() {
+@@ -804,8 +825,8 @@ unique_ptr<HTTPClient> HTTPFileHandle::CreateClient() {
  	return http_params.http_util.InitializeClient(http_params, proto_host_port);
  }
  
 -void HTTPFileHandle::StoreClient(unique_ptr<HTTPClient> client) {
 -	client_cache.StoreClient(std::move(client));
-+void HTTPFileHandle::StoreClient(string url, unique_ptr<HTTPClient> client) {
-+	string path_out, proto_host_port;
-+	HTTPUtil::DecomposeURL(url, path_out, proto_host_port);
-+	client_cache.StoreClient(proto_host_port, std::move(client));
++void HTTPFileHandle::StoreClient(string &host, unique_ptr<HTTPClient> client) {
++	client_cache.StoreClient(host, std::move(client));
  }
  
  HTTPFileHandle::~HTTPFileHandle() {
 diff --git a/extension/httpfs/httpfs_extension.cpp b/extension/httpfs/httpfs_extension.cpp
-index 695ca30..a60fbba 100644
+index 695ca30..c91f012 100644
 --- a/extension/httpfs/httpfs_extension.cpp
 +++ b/extension/httpfs/httpfs_extension.cpp
 @@ -62,7 +62,7 @@ static void LoadInternal(ExtensionLoader &loader) {
@@ -165,8 +167,17 @@ index 695ca30..a60fbba 100644
  	config.AddExtensionOption("s3_access_key_id", "S3 Access Key ID", LogicalType::VARCHAR);
  	config.AddExtensionOption("s3_secret_access_key", "S3 Access Key", LogicalType::VARCHAR);
  	config.AddExtensionOption("s3_session_token", "S3 Session Token", LogicalType::VARCHAR);
+@@ -83,6 +83,8 @@ static void LoadInternal(ExtensionLoader &loader) {
+ 	                          Value(50));
+ 	config.AddExtensionOption("unsafe_disable_etag_checks", "Disable checks on ETag consistency",
+ 	                          LogicalType::BOOLEAN, Value(false));
++	config.AddExtensionOption("follow_s3_region_redirects", "Follow S3 redirect to correct region. Only 1 redirect will be followed",
++							  LogicalType::BOOLEAN, Value(true));
+ 
+ 	// HuggingFace options
+ 	config.AddExtensionOption("hf_max_per_page", "Debug option to limit number of items returned in list requests",
 diff --git a/extension/httpfs/include/httpfs.hpp b/extension/httpfs/include/httpfs.hpp
-index 5f24455..8dad063 100644
+index 5f24455..3186614 100644
 --- a/extension/httpfs/include/httpfs.hpp
 +++ b/extension/httpfs/include/httpfs.hpp
 @@ -30,13 +30,13 @@ public:
@@ -174,7 +185,7 @@ index 5f24455..8dad063 100644
  public:
  	//! Get a client from the client cache
 -	unique_ptr<HTTPClient> GetClient();
-+	unique_ptr<HTTPClient> GetClient(string host);
++	unique_ptr<HTTPClient> GetClient(string &host);
  	//! Store a client in the cache for reuse
 -	void StoreClient(unique_ptr<HTTPClient> client);
 +	void StoreClient(string host, unique_ptr<HTTPClient> client);
@@ -192,46 +203,64 @@ index 5f24455..8dad063 100644
  
  	// Get a Client to run requests over
 -	unique_ptr<HTTPClient> GetClient();
-+	unique_ptr<HTTPClient> GetClient(string host);
++	unique_ptr<HTTPClient> GetClient(string &host);
  	// Return the client for re-use
 -	void StoreClient(unique_ptr<HTTPClient> client);
-+	void StoreClient(string url, unique_ptr<HTTPClient> client);
++	void StoreClient(string &host, unique_ptr<HTTPClient> client);
  
  public:
  	void Close() override {
 diff --git a/extension/httpfs/include/s3fs.hpp b/extension/httpfs/include/s3fs.hpp
-index b848d2c..69358c4 100644
+index b848d2c..f748dc2 100644
 --- a/extension/httpfs/include/s3fs.hpp
 +++ b/extension/httpfs/include/s3fs.hpp
 @@ -34,6 +34,7 @@ struct S3AuthParams {
  	string oauth2_bearer_token; // OAuth2 bearer token for GCS
  
  	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
-+	void OverwriteRegionAndEndpoint(string &region);
++	void OverwriteRegionAndEndpoint(string &new_region);
  };
  
  struct AWSEnvironmentCredentialsProvider {
 diff --git a/extension/httpfs/s3fs.cpp b/extension/httpfs/s3fs.cpp
-index 3ea2b98..c20bd73 100644
+index 3ea2b98..4555307 100644
 --- a/extension/httpfs/s3fs.cpp
 +++ b/extension/httpfs/s3fs.cpp
-@@ -183,6 +183,15 @@ S3AuthParams AWSEnvironmentCredentialsProvider::CreateParams() {
+@@ -183,6 +183,14 @@ S3AuthParams AWSEnvironmentCredentialsProvider::CreateParams() {
  	return params;
  }
  
-+void S3AuthParams::OverwriteRegionAndEndpoint(string &region) {
-+	D_ASSERT(!region.empty());
++void S3AuthParams::OverwriteRegionAndEndpoint(string &new_region) {
 +	D_ASSERT(!endpoint.empty());
-+	this->region = region;
-+	if (!this->endpoint.empty()) {
-+		this->endpoint = StringUtil::Format("s3.%s.amazonaws.com", this->region);
++	region = new_region;
++	if (!endpoint.empty()) {
++		endpoint = StringUtil::Format("s3.%s.amazonaws.com", region);
 +	}
 +}
 +
  S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info) {
  	auto result = S3AuthParams();
  
-@@ -836,22 +845,37 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
+@@ -831,27 +839,74 @@ unique_ptr<HTTPFileHandle> S3FileSystem::CreateHandle(const OpenFileInfo &file,
+ 	                                       S3ConfigParams::ReadFrom(opener));
+ }
+ 
++// FIXME: I think extra_info in ErrorData should be a case_insensitive map,
++// but that is too big of a fix in this current PR.
++static string GetXamzBucketHeader(const unordered_map<string, string> &headers) {
++	auto iter = headers.find("header_x-amz-bucket-region");
++	if (iter != headers.end()) {
++		return iter->second;
++	}
++	iter = headers.find("header_X-Amz-Bucket-Region");
++	if (iter != headers.end()) {
++		return iter->second;
++	}
++	return "";
++}
++
+ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
+ 	try {
  		HTTPFileHandle::Initialize(opener);
  	} catch (std::exception &ex) {
  		ErrorData error(ex);
@@ -239,7 +268,14 @@ index 3ea2b98..c20bd73 100644
  		bool refreshed_secret = false;
 +		auto &extra_info = error.ExtraInfo();
 +		auto entry = extra_info.find("status_code");
-+		string new_region = "";
++
++		Value follow_redirects;
++		bool follow_region_redirects = true;
++		if (FileOpener::TryGetCurrentSetting(opener, "follow_s3_region_redirects", follow_redirects)) {
++			follow_region_redirects = follow_redirects.GetValue<bool>();
++		}
++
++		auto new_region = string("");
  		if (error.Type() == ExceptionType::IO || error.Type() == ExceptionType::HTTP) {
 -			auto context = opener->TryGetClientContext();
 -			if (context) {
@@ -248,18 +284,29 @@ index 3ea2b98..c20bd73 100644
 -					auto res = context->db->GetSecretManager().LookupSecret(transaction, path, type);
 -					if (res.HasMatch()) {
 -						refreshed_secret |= CreateS3SecretFunctions::TryRefreshS3Secret(*context, *res.secret_entry);
-+			if (entry->second == "301") {
-+				auto region_header = extra_info.find("header_x-amz-bucket-region");
-+				if (region_header != extra_info.end()) {
-+					auth_params.region = region_header->second;
-+					new_region = region_header->second;
-+					incorrect_region_supplied = true;
-+					// FIXME: add log that we are trying a different region.
-+				} else {
++			if (entry != extra_info.end() && (entry->second == "301" || entry->second == "400")) {
++				// Check if a different region has been supplied in the header. Minio returns 400 instead of 301
++				new_region = GetXamzBucketHeader(extra_info);
++				if (!new_region.empty()) {
++					auto old_region = auth_params.region;
++					if (old_region != new_region) {
++						incorrect_region_supplied = true;
++						auth_params.region = new_region;
++						auto context = opener->TryGetClientContext();
++						if (old_region.empty()) {
++							old_region = "(No Provided Value)";
++						}
++						if (context) {
++							DUCKDB_LOG_INFO(*context, "Redirecting S3 request from region '%s' to region '%s'", old_region, new_region);
++						}
++					}
++				}
++				if (!incorrect_region_supplied && (entry->second == "400" || entry->second == "403")) {
 +					auto extra_text = S3FileSystem::GetS3BadRequestError(auth_params);
 +					throw Exception(error.Type(), error.RawMessage() + extra_text, extra_info);
 +				}
-+			} else {
++			}
++			if (!incorrect_region_supplied) {
 +				auto context = opener->TryGetClientContext();
 +				if (context) {
 +					auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*context);
@@ -279,7 +326,7 @@ index 3ea2b98..c20bd73 100644
  			if (entry != extra_info.end()) {
  				if (entry->second == "400") {
  					// 400: BAD REQUEST
-@@ -868,17 +892,24 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
+@@ -868,17 +923,27 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
  					}
  					throw Exception(error.Type(), error.RawMessage() + extra_text, extra_info);
  				}
@@ -297,6 +344,9 @@ index 3ea2b98..c20bd73 100644
  		auth_params = S3AuthParams::ReadFrom(opener, info);
 +		// pass correct region from redirect response
 +		auth_params.OverwriteRegionAndEndpoint(new_region);
++		if (!(incorrect_region_supplied && follow_region_redirects) && !refreshed_secret) {
++			throw;
++		}
  		HTTPFileHandle::Initialize(opener);
  	}
  

--- a/.github/patches/extensions/httpfs/fix.patch
+++ b/.github/patches/extensions/httpfs/fix.patch
@@ -1,0 +1,377 @@
+diff --git a/extension/httpfs/httpfs.cpp b/extension/httpfs/httpfs.cpp
+index bb7267a..3687009 100644
+--- a/extension/httpfs/httpfs.cpp
++++ b/extension/httpfs/httpfs.cpp
+@@ -85,20 +85,26 @@ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener>
+ 	return std::move(result);
+ }
+ 
+-unique_ptr<HTTPClient> HTTPClientCache::GetClient() {
++unique_ptr<HTTPClient> HTTPClientCache::GetClient(string host) {
+ 	lock_guard<mutex> lck(lock);
+ 	if (clients.size() == 0) {
+ 		return nullptr;
+ 	}
++	if (clients.find(host) == clients.end()) {
++		return nullptr;
++	}
+ 
+-	auto client = std::move(clients.back());
+-	clients.pop_back();
++	auto client = std::move((clients[host].back()));
++	clients[host].pop_back();
+ 	return client;
+ }
+ 
+-void HTTPClientCache::StoreClient(unique_ptr<HTTPClient> client) {
++void HTTPClientCache::StoreClient(string host, unique_ptr<HTTPClient> client) {
+ 	lock_guard<mutex> lck(lock);
+-	clients.push_back(std::move(client));
++	if (clients.find(host) == clients.end()) {
++		clients[host] = vector<unique_ptr<HTTPClient>>();
++	}
++	clients[host].push_back(std::move(client));
+ }
+ 
+ unique_ptr<HTTPResponse> HTTPFileSystem::PostRequest(FileHandle &handle, string url, HTTPHeaders header_map,
+@@ -125,23 +131,26 @@ unique_ptr<HTTPResponse> HTTPFileSystem::PutRequest(FileHandle &handle, string u
+ unique_ptr<HTTPResponse> HTTPFileSystem::HeadRequest(FileHandle &handle, string url, HTTPHeaders header_map) {
+ 	auto &hfh = handle.Cast<HTTPFileHandle>();
+ 	auto &http_util = hfh.http_params.http_util;
+-	auto http_client = hfh.GetClient();
++	string path_out, proto_host_port;
++	HTTPUtil::DecomposeURL(url, path_out, proto_host_port);
++	auto http_client = hfh.GetClient(proto_host_port);
+ 
+ 	HeadRequestInfo head_request(url, header_map, hfh.http_params);
+ 	auto response = http_util.Request(head_request, http_client);
+-
+-	hfh.StoreClient(std::move(http_client));
++	hfh.StoreClient(proto_host_port, std::move(http_client));
+ 	return response;
+ }
+ 
+ unique_ptr<HTTPResponse> HTTPFileSystem::DeleteRequest(FileHandle &handle, string url, HTTPHeaders header_map) {
+ 	auto &hfh = handle.Cast<HTTPFileHandle>();
+ 	auto &http_util = hfh.http_params.http_util;
+-	auto http_client = hfh.GetClient();
++	string path_out, proto_host_port;
++	HTTPUtil::DecomposeURL(url, path_out, proto_host_port);
++	auto http_client = hfh.GetClient(proto_host_port);
+ 	DeleteRequestInfo delete_request(url, header_map, hfh.http_params);
+ 	auto response = http_util.Request(delete_request, http_client);
+ 
+-	hfh.StoreClient(std::move(http_client));
++	hfh.StoreClient(proto_host_port, std::move(http_client));
+ 	return response;
+ }
+ 
+@@ -161,8 +170,9 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
+ 	auto &http_util = hfh.http_params.http_util;
+ 
+ 	D_ASSERT(hfh.cached_file_handle);
+-
+-	auto http_client = hfh.GetClient();
++	string path_out, proto_host_port;
++	HTTPUtil::DecomposeURL(url, path_out, proto_host_port);
++	auto http_client = hfh.GetClient(proto_host_port);
+ 	GetRequestInfo get_request(
+ 	    url, header_map, hfh.http_params,
+ 	    [&](const HTTPResponse &response) {
+@@ -200,7 +210,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRequest(FileHandle &handle, string u
+ 
+ 	auto response = http_util.Request(get_request, http_client);
+ 
+-	hfh.StoreClient(std::move(http_client));
++	hfh.StoreClient(proto_host_port, std::move(http_client));
+ 	return response;
+ }
+ 
+@@ -213,7 +223,9 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
+ 	string range_expr = "bytes=" + to_string(file_offset) + "-" + to_string(file_offset + buffer_out_len - 1);
+ 	header_map.Insert("Range", range_expr);
+ 
+-	auto http_client = hfh.GetClient();
++	string path_out, proto_host_port;
++	HTTPUtil::DecomposeURL(url, path_out, proto_host_port);
++	auto http_client = hfh.GetClient(proto_host_port);
+ 
+ 	idx_t out_offset = 0;
+ 
+@@ -272,7 +284,7 @@ unique_ptr<HTTPResponse> HTTPFileSystem::GetRangeRequest(FileHandle &handle, str
+ 
+ 	auto response = http_util.Request(get_request, http_client);
+ 
+-	hfh.StoreClient(std::move(http_client));
++	hfh.StoreClient(proto_host_port, std::move(http_client));
+ 	return response;
+ }
+ 
+@@ -681,7 +693,14 @@ void HTTPFileHandle::LoadFileInfo() {
+ 			length = 0;
+ 			return;
+ 		} else {
+-			// HEAD request fail, use Range request for another try (read only one byte)
++			// HEAD request fail,
++			auto status_code = static_cast<uint16_t>(res->status);
++			if (status_code >= 300 && status_code < 400) {
++				// resource has moved, do not try range request, we will get the same response
++				throw HTTPException(*res, "Unable to connect to URL \"%s\": %d (%s).", path,
++														static_cast<int>(res->status), res->GetError());
++			}
++			// Use range request for another try (read only one byte)
+ 			if (flags.OpenForReading() && res->status != HTTPStatusCode::NotFound_404) {
+ 				auto range_res = hfs.GetRangeRequest(*this, path, {}, 0, nullptr, 2);
+ 				if (range_res->status != HTTPStatusCode::PartialContent_206 &&
+@@ -786,13 +805,12 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
+ 	}
+ }
+ 
+-unique_ptr<HTTPClient> HTTPFileHandle::GetClient() {
++unique_ptr<HTTPClient> HTTPFileHandle::GetClient(string host) {
+ 	// Try to fetch a cached client
+-	auto cached_client = client_cache.GetClient();
++	auto cached_client = client_cache.GetClient(host);
+ 	if (cached_client) {
+ 		return cached_client;
+ 	}
+-
+ 	// Create a new client
+ 	return CreateClient();
+ }
+@@ -804,8 +822,10 @@ unique_ptr<HTTPClient> HTTPFileHandle::CreateClient() {
+ 	return http_params.http_util.InitializeClient(http_params, proto_host_port);
+ }
+ 
+-void HTTPFileHandle::StoreClient(unique_ptr<HTTPClient> client) {
+-	client_cache.StoreClient(std::move(client));
++void HTTPFileHandle::StoreClient(string url, unique_ptr<HTTPClient> client) {
++	string path_out, proto_host_port;
++	HTTPUtil::DecomposeURL(url, path_out, proto_host_port);
++	client_cache.StoreClient(proto_host_port, std::move(client));
+ }
+ 
+ HTTPFileHandle::~HTTPFileHandle() {
+diff --git a/extension/httpfs/httpfs_extension.cpp b/extension/httpfs/httpfs_extension.cpp
+index 695ca30..a60fbba 100644
+--- a/extension/httpfs/httpfs_extension.cpp
++++ b/extension/httpfs/httpfs_extension.cpp
+@@ -62,7 +62,7 @@ static void LoadInternal(ExtensionLoader &loader) {
+ 	config.AddExtensionOption("ca_cert_file", "Path to a custom certificate file for self-signed certificates.",
+ 	                          LogicalType::VARCHAR, Value(""));
+ 	// Global S3 config
+-	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR, Value("us-east-1"));
++	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR);
+ 	config.AddExtensionOption("s3_access_key_id", "S3 Access Key ID", LogicalType::VARCHAR);
+ 	config.AddExtensionOption("s3_secret_access_key", "S3 Access Key", LogicalType::VARCHAR);
+ 	config.AddExtensionOption("s3_session_token", "S3 Session Token", LogicalType::VARCHAR);
+diff --git a/extension/httpfs/include/httpfs.hpp b/extension/httpfs/include/httpfs.hpp
+index 5f24455..8dad063 100644
+--- a/extension/httpfs/include/httpfs.hpp
++++ b/extension/httpfs/include/httpfs.hpp
+@@ -30,13 +30,13 @@ public:
+ class HTTPClientCache {
+ public:
+ 	//! Get a client from the client cache
+-	unique_ptr<HTTPClient> GetClient();
++	unique_ptr<HTTPClient> GetClient(string host);
+ 	//! Store a client in the cache for reuse
+-	void StoreClient(unique_ptr<HTTPClient> client);
++	void StoreClient(string host, unique_ptr<HTTPClient> client);
+ 
+ protected:
+-	//! The cached clients
+-	vector<unique_ptr<HTTPClient>> clients;
++	//! The cached clients for a host
++	case_insensitive_map_t<vector<unique_ptr<HTTPClient>>> clients;
+ 	//! Lock to fetch a client
+ 	mutex lock;
+ };
+@@ -89,9 +89,9 @@ public:
+ 	void AddHeaders(HTTPHeaders &map);
+ 
+ 	// Get a Client to run requests over
+-	unique_ptr<HTTPClient> GetClient();
++	unique_ptr<HTTPClient> GetClient(string host);
+ 	// Return the client for re-use
+-	void StoreClient(unique_ptr<HTTPClient> client);
++	void StoreClient(string url, unique_ptr<HTTPClient> client);
+ 
+ public:
+ 	void Close() override {
+diff --git a/extension/httpfs/include/s3fs.hpp b/extension/httpfs/include/s3fs.hpp
+index b848d2c..69358c4 100644
+--- a/extension/httpfs/include/s3fs.hpp
++++ b/extension/httpfs/include/s3fs.hpp
+@@ -34,6 +34,7 @@ struct S3AuthParams {
+ 	string oauth2_bearer_token; // OAuth2 bearer token for GCS
+ 
+ 	static S3AuthParams ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info);
++	void OverwriteRegionAndEndpoint(string &region);
+ };
+ 
+ struct AWSEnvironmentCredentialsProvider {
+diff --git a/extension/httpfs/s3fs.cpp b/extension/httpfs/s3fs.cpp
+index 3ea2b98..c20bd73 100644
+--- a/extension/httpfs/s3fs.cpp
++++ b/extension/httpfs/s3fs.cpp
+@@ -183,6 +183,15 @@ S3AuthParams AWSEnvironmentCredentialsProvider::CreateParams() {
+ 	return params;
+ }
+ 
++void S3AuthParams::OverwriteRegionAndEndpoint(string &region) {
++	D_ASSERT(!region.empty());
++	D_ASSERT(!endpoint.empty());
++	this->region = region;
++	if (!this->endpoint.empty()) {
++		this->endpoint = StringUtil::Format("s3.%s.amazonaws.com", this->region);
++	}
++}
++
+ S3AuthParams S3AuthParams::ReadFrom(optional_ptr<FileOpener> opener, FileOpenerInfo &info) {
+ 	auto result = S3AuthParams();
+ 
+@@ -836,22 +845,37 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
+ 		HTTPFileHandle::Initialize(opener);
+ 	} catch (std::exception &ex) {
+ 		ErrorData error(ex);
++		bool incorrect_region_supplied = false;
+ 		bool refreshed_secret = false;
++		auto &extra_info = error.ExtraInfo();
++		auto entry = extra_info.find("status_code");
++		string new_region = "";
+ 		if (error.Type() == ExceptionType::IO || error.Type() == ExceptionType::HTTP) {
+-			auto context = opener->TryGetClientContext();
+-			if (context) {
+-				auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*context);
+-				for (const string type : {"s3", "r2", "gcs", "aws"}) {
+-					auto res = context->db->GetSecretManager().LookupSecret(transaction, path, type);
+-					if (res.HasMatch()) {
+-						refreshed_secret |= CreateS3SecretFunctions::TryRefreshS3Secret(*context, *res.secret_entry);
++			if (entry->second == "301") {
++				auto region_header = extra_info.find("header_x-amz-bucket-region");
++				if (region_header != extra_info.end()) {
++					auth_params.region = region_header->second;
++					new_region = region_header->second;
++					incorrect_region_supplied = true;
++					// FIXME: add log that we are trying a different region.
++				} else {
++					auto extra_text = S3FileSystem::GetS3BadRequestError(auth_params);
++					throw Exception(error.Type(), error.RawMessage() + extra_text, extra_info);
++				}
++			} else {
++				auto context = opener->TryGetClientContext();
++				if (context) {
++					auto transaction = CatalogTransaction::GetSystemCatalogTransaction(*context);
++					for (const string type : {"s3", "r2", "gcs", "aws"}) {
++						auto res = context->db->GetSecretManager().LookupSecret(transaction, path, type);
++						if (res.HasMatch()) {
++							refreshed_secret |= CreateS3SecretFunctions::TryRefreshS3Secret(*context, *res.secret_entry);
++						}
+ 					}
+ 				}
+ 			}
+ 		}
+-		if (!refreshed_secret) {
+-			auto &extra_info = error.ExtraInfo();
+-			auto entry = extra_info.find("status_code");
++		if (!refreshed_secret && !incorrect_region_supplied) {
+ 			if (entry != extra_info.end()) {
+ 				if (entry->second == "400") {
+ 					// 400: BAD REQUEST
+@@ -868,17 +892,24 @@ void S3FileHandle::Initialize(optional_ptr<FileOpener> opener) {
+ 					}
+ 					throw Exception(error.Type(), error.RawMessage() + extra_text, extra_info);
+ 				}
++			} else if (error.Message().find("Unknown error for HTTP HEAD to") != string::npos) {
++				// FIXME: Potentially a request to a bucket with an incorrect region. This returns a 301 Permanently Moved
++				//        http_util thinks this is a failed request, and ignores all response information
++				//        see: duckdblabs/duckdb-internal/issues/5905
++				auto extra_text = S3FileSystem::GetS3BadRequestError(auth_params);
++				throw Exception(error.Type(), error.RawMessage() + extra_text, extra_info);
+ 			}
+ 			throw;
+ 		}
+ 		// We have succesfully refreshed a secret: retry initializing with new credentials
+ 		FileOpenerInfo info = {path};
+ 		auth_params = S3AuthParams::ReadFrom(opener, info);
++		// pass correct region from redirect response
++		auth_params.OverwriteRegionAndEndpoint(new_region);
+ 		HTTPFileHandle::Initialize(opener);
+ 	}
+ 
+ 	auto &s3fs = file_system.Cast<S3FileSystem>();
+-
+ 	if (flags.OpenForWriting()) {
+ 		auto aws_minimum_part_size = 5242880; // 5 MiB https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+ 		auto max_part_count = config_params.max_parts_per_file;
+diff --git a/test/sql/test_headers_parsed.test b/test/sql/test_headers_parsed.test
+index d0e76bd..09ae251 100644
+--- a/test/sql/test_headers_parsed.test
++++ b/test/sql/test_headers_parsed.test
+@@ -1,4 +1,4 @@
+-# name: test/sql/copy/csv/test_headers_parsed.test
++# name: test/sql/test_headers_parsed.test
+ # description: This test triggers the http prefetch mechanism.
+ # group: [csv]
+ 
+diff --git a/test/sql/test_region_errors.test b/test/sql/test_region_errors.test
+new file mode 100644
+index 0000000..6ec5bce
+--- /dev/null
++++ b/test/sql/test_region_errors.test
+@@ -0,0 +1,54 @@
++# name: test/sql/test_region_errors.test
++# description: This test triggers the http prefetch mechanism.
++# group: [csv]
++
++require httpfs
++
++require parquet
++
++require-env AWS_ACCESS_KEY_ID
++
++require-env AWS_SECRET_ACCESS_KEY
++
++set ignore_error_messages
++
++statement ok
++CREATE or replace SECRET s1 (
++    TYPE S3,
++    KEY_ID '${AWS_ACCESS_KEY_ID}',
++    SECRET '${AWS_SECRET_ACCESS_KEY}'
++)
++
++statement ok
++set s3_region='';
++
++# no region set, no error
++statement error
++select * from 's3://clickhouse-public-datasets/hits_compatible/hits.parquet' limit 1;
++----
++HTTP Error:
++
++statement ok
++set s3_region='us-east-1';
++
++# incorrect region set, no error
++statement error
++select * from 's3://clickhouse-public-datasets/hits_compatible/hits.parquet' limit 1;
++----
++HTTP Error:
++
++mode output_result
++
++# see there has been a redirect
++query III
++select request.url, request.type, response.status from duckdb_logs_parsed('HTTP');
++----
++
++statement ok
++set s3_region='eu-central-1';
++
++# correct region also works.
++statement ok
++select * from 's3://clickhouse-public-datasets/hits_compatible/hits.parquet' limit 1;
++
++

--- a/test/optimizer/test_blah.test
+++ b/test/optimizer/test_blah.test
@@ -1,0 +1,21 @@
+# name: test/optimizer/test_try_cast_decimal.test
+# description: Test SUM rewrite
+# group: [optimizer]
+
+statement ok
+pragma disable_optimizer;
+
+
+statement ok
+CREATE  TABLE  t0(c0 INT , c1 BOOLEAN , PRIMARY KEY(c0));
+
+statement ok
+INSERT INTO t0(c0, c1) VALUES (890608529, false);
+
+statement ok
+pragma enable_optimizer;
+
+query I
+SELECT (true AND((TRY_CAST(t0.c0 AS DECIMAL(10,2)) > 0))) AS r FROM t0;
+----
+NULL

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -129,17 +129,55 @@ endloop
 statement ok
 set s3_endpoint='';
 
+statement ok
+call enable_logging();
+
 statement error
 SELECT * FROM 's3://test-bucket/whatever.parquet';
 ----
-<REGEX>:.*Unknown error for HTTP HEAD to 'http://test-bucket.s3.eu-west-1.amazonaws.com/whatever.parquet'.*
+<REGEX>:.*HTTP GET error on.*http://test-bucket.s3.us-east-1.amazonaws.com/whatever.parquet.*HTTP 403.*
 
 statement error
 SELECT * FROM 'r2://test-bucket/whatever.parquet';
 ----
-<REGEX>:.*Unknown error for HTTP HEAD to 'http://test-bucket.s3.eu-west-1.amazonaws.com/whatever.parquet'.*
+<REGEX>:.*HTTP GET error on.*http://test-bucket.s3.us-east-1.amazonaws.com/whatever.parquet.*HTTP 403.*
+
+# check redirects (minio automatically redirects to us-east-1).
+query I
+select message from duckdb_logs() where log_level like '%INFO%' and message like 'Redirecting%';
+----
+Redirecting S3 request from region 'eu-west-1' to region 'us-east-1'
+Redirecting S3 request from region 'eu-west-1' to region 'us-east-1'
 
 statement error
 SELECT * FROM 'gcs://test-bucket/whatever.parquet';
 ----
-HTTP GET error on 'http://storage.googleapis.com/test-bucket/whatever.parquet'
+<REGEX>:.*HTTP GET error on.*http://storage.googleapis.com/test-bucket/whatever.parquet.*HTTP 403.*
+.*Authentication Failure - GCS authentication failed.*
+.*HMAC credentials were provided but authentication failed.*
+.*Ensure your HMAC key_id and secret are correct.*
+
+statement ok
+call truncate_duckdb_logs();
+
+statement ok
+set s3_region='';
+
+# FIXME
+# I don't know why yet, but minio has 2 redirects. 1 from regionless to us-west-1 and then from eu-west-1 to us-east 1
+# we only follow 1 of these.
+statement error
+SELECT * FROM 's3://test-bucket/whatever.parquet';
+----
+<REGEX>:.*HTTP Error: Unable to connect to URL \"s3://test-bucket/whatever.parquet\": 301 \(Moved Permanently\).*
+
+statement error
+SELECT * FROM 'r2://test-bucket/whatever.parquet';
+----
+<REGEX>:.*HTTP Error: Unable to connect to URL \"r2://test-bucket/whatever.parquet\": 301 \(Moved Permanently\).*
+
+query I
+select message from duckdb_logs() where log_level like '%INFO%' and message like 'Redirecting%';
+----
+Redirecting S3 request from region '(No Provided Value)' to region 'eu-west-1'
+Redirecting S3 request from region '(No Provided Value)' to region 'eu-west-1'

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -18,6 +18,7 @@
 #include <exception>
 #include <stdexcept>
 
+
 /*
  * Configuration
  */
@@ -112,8 +113,10 @@
 #endif
 
 #ifndef CPPHTTPLIB_THREAD_POOL_COUNT
-#define CPPHTTPLIB_THREAD_POOL_COUNT                                                                                   \
-	((std::max)(8u, std::thread::hardware_concurrency() > 0 ? std::thread::hardware_concurrency() - 1 : 0))
+#define CPPHTTPLIB_THREAD_POOL_COUNT                                           \
+  ((std::max)(8u, std::thread::hardware_concurrency() > 0                      \
+                      ? std::thread::hardware_concurrency() - 1                \
+                      : 0))
 #endif
 
 #ifndef CPPHTTPLIB_RECV_FLAGS
@@ -286,9 +289,10 @@ using socket_t = int;
 #include <iostream>
 #include <sstream>
 
+
 // Disabled OpenSSL version check for CI
-// #if OPENSSL_VERSION_NUMBER < 0x1010100fL
-// #error Sorry, OpenSSL versions prior to 1.1.1 are not supported
+//#if OPENSSL_VERSION_NUMBER < 0x1010100fL
+//#error Sorry, OpenSSL versions prior to 1.1.1 are not supported
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
 #define SSL_get1_peer_certificate SSL_get_peer_certificate
 #endif
@@ -320,130 +324,131 @@ namespace detail {
  */
 
 template <class T, class... Args>
-typename std::enable_if<!std::is_array<T>::value, duckdb::unique_ptr<T>>::type make_unique(Args &&...args) {
-	return duckdb::unique_ptr<T>(new T(std::forward<Args>(args)...));
+typename std::enable_if<!std::is_array<T>::value, duckdb::unique_ptr<T>>::type
+make_unique(Args &&...args) {
+  return duckdb::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
 template <class T>
-typename std::enable_if<std::is_array<T>::value, duckdb::unique_ptr<T>>::type make_unique(std::size_t n) {
-	typedef typename std::remove_extent<T>::type RT;
-	return duckdb::unique_ptr<T>(new RT[n]);
+typename std::enable_if<std::is_array<T>::value, duckdb::unique_ptr<T>>::type
+make_unique(std::size_t n) {
+  typedef typename std::remove_extent<T>::type RT;
+  return duckdb::unique_ptr<T>(new RT[n]);
 }
 
 struct ci {
-	bool operator()(const std::string &s1, const std::string &s2) const {
-		return std::lexicographical_compare(
-		    s1.begin(), s1.end(), s2.begin(), s2.end(),
-		    [](unsigned char c1, unsigned char c2) { return ::tolower(c1) < ::tolower(c2); });
-	}
+  bool operator()(const std::string &s1, const std::string &s2) const {
+    return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(),
+                                        s2.end(),
+                                        [](unsigned char c1, unsigned char c2) {
+                                          return ::tolower(c1) < ::tolower(c2);
+                                        });
+  }
 };
 
 // This is based on
 // "http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4189".
 
 struct scope_exit {
-	explicit scope_exit(std::function<void(void)> &&f) : exit_function(std::move(f)), execute_on_destruction {true} {
-	}
+  explicit scope_exit(std::function<void(void)> &&f)
+      : exit_function(std::move(f)), execute_on_destruction{true} {}
 
-	scope_exit(scope_exit &&rhs) noexcept
-	    : exit_function(std::move(rhs.exit_function)), execute_on_destruction {rhs.execute_on_destruction} {
-		rhs.release();
-	}
+  scope_exit(scope_exit &&rhs) noexcept
+      : exit_function(std::move(rhs.exit_function)),
+        execute_on_destruction{rhs.execute_on_destruction} {
+    rhs.release();
+  }
 
-	~scope_exit() {
-		if (execute_on_destruction) {
-			this->exit_function();
-		}
-	}
+  ~scope_exit() {
+    if (execute_on_destruction) { this->exit_function(); }
+  }
 
-	void release() {
-		this->execute_on_destruction = false;
-	}
+  void release() { this->execute_on_destruction = false; }
 
 private:
-	scope_exit(const scope_exit &) = delete;
-	void operator=(const scope_exit &) = delete;
-	scope_exit &operator=(scope_exit &&) = delete;
+  scope_exit(const scope_exit &) = delete;
+  void operator=(const scope_exit &) = delete;
+  scope_exit &operator=(scope_exit &&) = delete;
 
-	std::function<void(void)> exit_function;
-	bool execute_on_destruction;
+  std::function<void(void)> exit_function;
+  bool execute_on_destruction;
 };
 
 } // namespace detail
 
 enum StatusCode {
-	// Information responses
-	Continue_100 = 100,
-	SwitchingProtocol_101 = 101,
-	Processing_102 = 102,
-	EarlyHints_103 = 103,
+  // Information responses
+  Continue_100 = 100,
+  SwitchingProtocol_101 = 101,
+  Processing_102 = 102,
+  EarlyHints_103 = 103,
 
-	// Successful responses
-	OK_200 = 200,
-	Created_201 = 201,
-	Accepted_202 = 202,
-	NonAuthoritativeInformation_203 = 203,
-	NoContent_204 = 204,
-	ResetContent_205 = 205,
-	PartialContent_206 = 206,
-	MultiStatus_207 = 207,
-	AlreadyReported_208 = 208,
-	IMUsed_226 = 226,
+  // Successful responses
+  OK_200 = 200,
+  Created_201 = 201,
+  Accepted_202 = 202,
+  NonAuthoritativeInformation_203 = 203,
+  NoContent_204 = 204,
+  ResetContent_205 = 205,
+  PartialContent_206 = 206,
+  MultiStatus_207 = 207,
+  AlreadyReported_208 = 208,
+  IMUsed_226 = 226,
 
-	// Redirection messages
-	MultipleChoices_300 = 300,
-	MovedPermanently_301 = 301,
-	Found_302 = 302,
-	SeeOther_303 = 303,
-	NotModified_304 = 304,
-	UseProxy_305 = 305,
-	unused_306 = 306,
-	TemporaryRedirect_307 = 307,
-	PermanentRedirect_308 = 308,
+  // Redirection messages
+  MultipleChoices_300 = 300,
+  MovedPermanently_301 = 301,
+  Found_302 = 302,
+  SeeOther_303 = 303,
+  NotModified_304 = 304,
+  UseProxy_305 = 305,
+  unused_306 = 306,
+  TemporaryRedirect_307 = 307,
+  PermanentRedirect_308 = 308,
 
-	// Client error responses
-	BadRequest_400 = 400,
-	Unauthorized_401 = 401,
-	PaymentRequired_402 = 402,
-	Forbidden_403 = 403,
-	NotFound_404 = 404,
-	MethodNotAllowed_405 = 405,
-	NotAcceptable_406 = 406,
-	ProxyAuthenticationRequired_407 = 407,
-	RequestTimeout_408 = 408,
-	Conflict_409 = 409,
-	Gone_410 = 410,
-	LengthRequired_411 = 411,
-	PreconditionFailed_412 = 412,
-	PayloadTooLarge_413 = 413,
-	UriTooLong_414 = 414,
-	UnsupportedMediaType_415 = 415,
-	RangeNotSatisfiable_416 = 416,
-	ExpectationFailed_417 = 417,
-	ImATeapot_418 = 418,
-	MisdirectedRequest_421 = 421,
-	UnprocessableContent_422 = 422,
-	Locked_423 = 423,
-	FailedDependency_424 = 424,
-	TooEarly_425 = 425,
-	UpgradeRequired_426 = 426,
-	PreconditionRequired_428 = 428,
-	TooManyRequests_429 = 429,
-	RequestHeaderFieldsTooLarge_431 = 431,
-	UnavailableForLegalReasons_451 = 451,
+  // Client error responses
+  BadRequest_400 = 400,
+  Unauthorized_401 = 401,
+  PaymentRequired_402 = 402,
+  Forbidden_403 = 403,
+  NotFound_404 = 404,
+  MethodNotAllowed_405 = 405,
+  NotAcceptable_406 = 406,
+  ProxyAuthenticationRequired_407 = 407,
+  RequestTimeout_408 = 408,
+  Conflict_409 = 409,
+  Gone_410 = 410,
+  LengthRequired_411 = 411,
+  PreconditionFailed_412 = 412,
+  PayloadTooLarge_413 = 413,
+  UriTooLong_414 = 414,
+  UnsupportedMediaType_415 = 415,
+  RangeNotSatisfiable_416 = 416,
+  ExpectationFailed_417 = 417,
+  ImATeapot_418 = 418,
+  MisdirectedRequest_421 = 421,
+  UnprocessableContent_422 = 422,
+  Locked_423 = 423,
+  FailedDependency_424 = 424,
+  TooEarly_425 = 425,
+  UpgradeRequired_426 = 426,
+  PreconditionRequired_428 = 428,
+  TooManyRequests_429 = 429,
+  RequestHeaderFieldsTooLarge_431 = 431,
+  UnavailableForLegalReasons_451 = 451,
 
-	// Server error responses
-	InternalServerError_500 = 500,
-	NotImplemented_501 = 501,
-	BadGateway_502 = 502,
-	ServiceUnavailable_503 = 503,
-	GatewayTimeout_504 = 504,
-	HttpVersionNotSupported_505 = 505,
-	VariantAlsoNegotiates_506 = 506,
-	InsufficientStorage_507 = 507,
-	LoopDetected_508 = 508,
-	NotExtended_510 = 510,
-	NetworkAuthenticationRequired_511 = 511,
+  // Server error responses
+  InternalServerError_500 = 500,
+  NotImplemented_501 = 501,
+  BadGateway_502 = 502,
+  ServiceUnavailable_503 = 503,
+  GatewayTimeout_504 = 504,
+  HttpVersionNotSupported_505 = 505,
+  VariantAlsoNegotiates_506 = 506,
+  InsufficientStorage_507 = 507,
+  LoopDetected_508 = 508,
+  NotExtended_510 = 510,
+  NetworkAuthenticationRequired_511 = 511,
 };
 
 using Headers = std::multimap<std::string, std::string, detail::ci>;
@@ -458,296 +463,301 @@ struct Response;
 using ResponseHandler = std::function<bool(const Response &response)>;
 
 struct MultipartFormData {
-	std::string name;
-	std::string content;
-	std::string filename;
-	std::string content_type;
+  std::string name;
+  std::string content;
+  std::string filename;
+  std::string content_type;
 };
 using MultipartFormDataItems = std::vector<MultipartFormData>;
 using MultipartFormDataMap = std::multimap<std::string, MultipartFormData>;
 
 class DataSink {
 public:
-	DataSink() : os(&sb_), sb_(*this) {
-	}
+  DataSink() : os(&sb_), sb_(*this) {}
 
-	DataSink(const DataSink &) = delete;
-	DataSink &operator=(const DataSink &) = delete;
-	DataSink(DataSink &&) = delete;
-	DataSink &operator=(DataSink &&) = delete;
+  DataSink(const DataSink &) = delete;
+  DataSink &operator=(const DataSink &) = delete;
+  DataSink(DataSink &&) = delete;
+  DataSink &operator=(DataSink &&) = delete;
 
-	std::function<bool(const char *data, size_t data_len)> write;
-	std::function<bool()> is_writable;
-	std::function<void()> done;
-	std::function<void(const Headers &trailer)> done_with_trailer;
-	std::ostream os;
+  std::function<bool(const char *data, size_t data_len)> write;
+  std::function<bool()> is_writable;
+  std::function<void()> done;
+  std::function<void(const Headers &trailer)> done_with_trailer;
+  std::ostream os;
 
 private:
-	class data_sink_streambuf : public std::streambuf {
-	public:
-		explicit data_sink_streambuf(DataSink &sink) : sink_(sink) {
-		}
+  class data_sink_streambuf : public std::streambuf {
+  public:
+    explicit data_sink_streambuf(DataSink &sink) : sink_(sink) {}
 
-	protected:
-		std::streamsize xsputn(const char *s, std::streamsize n) override {
-			sink_.write(s, static_cast<size_t>(n));
-			return n;
-		}
+  protected:
+    std::streamsize xsputn(const char *s, std::streamsize n) override {
+      sink_.write(s, static_cast<size_t>(n));
+      return n;
+    }
 
-	private:
-		DataSink &sink_;
-	};
+  private:
+    DataSink &sink_;
+  };
 
-	data_sink_streambuf sb_;
+  data_sink_streambuf sb_;
 };
 
-using ContentProvider = std::function<bool(size_t offset, size_t length, DataSink &sink)>;
+using ContentProvider =
+    std::function<bool(size_t offset, size_t length, DataSink &sink)>;
 
-using ContentProviderWithoutLength = std::function<bool(size_t offset, DataSink &sink)>;
+using ContentProviderWithoutLength =
+    std::function<bool(size_t offset, DataSink &sink)>;
 
 using ContentProviderResourceReleaser = std::function<void(bool success)>;
 
 struct MultipartFormDataProvider {
-	std::string name;
-	ContentProviderWithoutLength provider;
-	std::string filename;
-	std::string content_type;
+  std::string name;
+  ContentProviderWithoutLength provider;
+  std::string filename;
+  std::string content_type;
 };
 using MultipartFormDataProviderItems = std::vector<MultipartFormDataProvider>;
 
 using ContentReceiverWithProgress =
-    std::function<bool(const char *data, size_t data_length, uint64_t offset, uint64_t total_length)>;
+    std::function<bool(const char *data, size_t data_length, uint64_t offset,
+                       uint64_t total_length)>;
 
-using ContentReceiver = std::function<bool(const char *data, size_t data_length)>;
+using ContentReceiver =
+    std::function<bool(const char *data, size_t data_length)>;
 
-using MultipartContentHeader = std::function<bool(const MultipartFormData &file)>;
+using MultipartContentHeader =
+    std::function<bool(const MultipartFormData &file)>;
 
 class ContentReader {
 public:
-	using Reader = std::function<bool(ContentReceiver receiver)>;
-	using MultipartReader = std::function<bool(MultipartContentHeader header, ContentReceiver receiver)>;
+  using Reader = std::function<bool(ContentReceiver receiver)>;
+  using MultipartReader = std::function<bool(MultipartContentHeader header,
+                                             ContentReceiver receiver)>;
 
-	ContentReader(Reader reader, MultipartReader multipart_reader)
-	    : reader_(std::move(reader)), multipart_reader_(std::move(multipart_reader)) {
-	}
+  ContentReader(Reader reader, MultipartReader multipart_reader)
+      : reader_(std::move(reader)),
+        multipart_reader_(std::move(multipart_reader)) {}
 
-	bool operator()(MultipartContentHeader header, ContentReceiver receiver) const {
-		return multipart_reader_(std::move(header), std::move(receiver));
-	}
+  bool operator()(MultipartContentHeader header,
+                  ContentReceiver receiver) const {
+    return multipart_reader_(std::move(header), std::move(receiver));
+  }
 
-	bool operator()(ContentReceiver receiver) const {
-		return reader_(std::move(receiver));
-	}
+  bool operator()(ContentReceiver receiver) const {
+    return reader_(std::move(receiver));
+  }
 
-	Reader reader_;
-	MultipartReader multipart_reader_;
+  Reader reader_;
+  MultipartReader multipart_reader_;
 };
 
 using Range = std::pair<ssize_t, ssize_t>;
 using Ranges = std::vector<Range>;
 
 struct Request {
-	std::string method;
-	std::string path;
-	Headers headers;
-	std::string body;
+  std::string method;
+  std::string path;
+  Headers headers;
+  std::string body;
 
-	std::string remote_addr;
-	int remote_port = -1;
-	std::string local_addr;
-	int local_port = -1;
+  std::string remote_addr;
+  int remote_port = -1;
+  std::string local_addr;
+  int local_port = -1;
 
-	// for server
-	std::string version;
-	std::string target;
-	Params params;
-	MultipartFormDataMap files;
-	Ranges ranges;
-	Match matches;
-	std::unordered_map<std::string, std::string> path_params;
+  // for server
+  std::string version;
+  std::string target;
+  Params params;
+  MultipartFormDataMap files;
+  Ranges ranges;
+  Match matches;
+  std::unordered_map<std::string, std::string> path_params;
 
-	// for client
-	ResponseHandler response_handler;
-	ContentReceiverWithProgress content_receiver;
-	Progress progress;
+  // for client
+  ResponseHandler response_handler;
+  ContentReceiverWithProgress content_receiver;
+  Progress progress;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	const SSL *ssl = nullptr;
+  const SSL *ssl = nullptr;
 #endif
 
-	bool has_header(const std::string &key) const;
-	std::string get_header_value(const std::string &key, size_t id = 0) const;
-	uint64_t get_header_value_u64(const std::string &key, size_t id = 0) const;
-	size_t get_header_value_count(const std::string &key) const;
-	void set_header(const std::string &key, const std::string &val);
+  bool has_header(const std::string &key) const;
+  std::string get_header_value(const std::string &key, size_t id = 0) const;
+  uint64_t get_header_value_u64(const std::string &key, size_t id = 0) const;
+  size_t get_header_value_count(const std::string &key) const;
+  void set_header(const std::string &key, const std::string &val);
 
-	bool has_param(const std::string &key) const;
-	std::string get_param_value(const std::string &key, size_t id = 0) const;
-	size_t get_param_value_count(const std::string &key) const;
+  bool has_param(const std::string &key) const;
+  std::string get_param_value(const std::string &key, size_t id = 0) const;
+  size_t get_param_value_count(const std::string &key) const;
 
-	bool is_multipart_form_data() const;
+  bool is_multipart_form_data() const;
 
-	bool has_file(const std::string &key) const;
-	MultipartFormData get_file_value(const std::string &key) const;
-	std::vector<MultipartFormData> get_file_values(const std::string &key) const;
+  bool has_file(const std::string &key) const;
+  MultipartFormData get_file_value(const std::string &key) const;
+  std::vector<MultipartFormData> get_file_values(const std::string &key) const;
 
-	// private members...
-	size_t redirect_count_ = CPPHTTPLIB_REDIRECT_MAX_COUNT;
-	size_t content_length_ = 0;
-	ContentProvider content_provider_;
-	bool is_chunked_content_provider_ = false;
-	size_t authorization_count_ = 0;
+  // private members...
+  size_t redirect_count_ = CPPHTTPLIB_REDIRECT_MAX_COUNT;
+  size_t content_length_ = 0;
+  ContentProvider content_provider_;
+  bool is_chunked_content_provider_ = false;
+  size_t authorization_count_ = 0;
 };
 
 struct Response {
-	std::string version;
-	int status = -1;
-	std::string reason;
-	Headers headers;
-	std::string body;
-	std::string location; // Redirect location
+  std::string version;
+  int status = -1;
+  std::string reason;
+  Headers headers;
+  std::string body;
+  std::string location; // Redirect location
 
-	bool has_header(const std::string &key) const;
-	std::string get_header_value(const std::string &key, size_t id = 0) const;
-	uint64_t get_header_value_u64(const std::string &key, size_t id = 0) const;
-	size_t get_header_value_count(const std::string &key) const;
-	void set_header(const std::string &key, const std::string &val);
+  bool has_header(const std::string &key) const;
+  std::string get_header_value(const std::string &key, size_t id = 0) const;
+  uint64_t get_header_value_u64(const std::string &key, size_t id = 0) const;
+  size_t get_header_value_count(const std::string &key) const;
+  void set_header(const std::string &key, const std::string &val);
 
-	void set_redirect(const std::string &url, int status = StatusCode::Found_302);
-	void set_content(const char *s, size_t n, const std::string &content_type);
-	void set_content(const std::string &s, const std::string &content_type);
+  void set_redirect(const std::string &url, int status = StatusCode::Found_302);
+  void set_content(const char *s, size_t n, const std::string &content_type);
+  void set_content(const std::string &s, const std::string &content_type);
 
-	void set_content_provider(size_t length, const std::string &content_type, ContentProvider provider,
-	                          ContentProviderResourceReleaser resource_releaser = nullptr);
+  void set_content_provider(
+      size_t length, const std::string &content_type, ContentProvider provider,
+      ContentProviderResourceReleaser resource_releaser = nullptr);
 
-	void set_content_provider(const std::string &content_type, ContentProviderWithoutLength provider,
-	                          ContentProviderResourceReleaser resource_releaser = nullptr);
+  void set_content_provider(
+      const std::string &content_type, ContentProviderWithoutLength provider,
+      ContentProviderResourceReleaser resource_releaser = nullptr);
 
-	void set_chunked_content_provider(const std::string &content_type, ContentProviderWithoutLength provider,
-	                                  ContentProviderResourceReleaser resource_releaser = nullptr);
+  void set_chunked_content_provider(
+      const std::string &content_type, ContentProviderWithoutLength provider,
+      ContentProviderResourceReleaser resource_releaser = nullptr);
 
-	Response() = default;
-	Response(const Response &) = default;
-	Response &operator=(const Response &) = default;
-	Response(Response &&) = default;
-	Response &operator=(Response &&) = default;
-	~Response() {
-		if (content_provider_resource_releaser_) {
-			content_provider_resource_releaser_(content_provider_success_);
-		}
-	}
+  Response() = default;
+  Response(const Response &) = default;
+  Response &operator=(const Response &) = default;
+  Response(Response &&) = default;
+  Response &operator=(Response &&) = default;
+  ~Response() {
+    if (content_provider_resource_releaser_) {
+      content_provider_resource_releaser_(content_provider_success_);
+    }
+  }
 
-	// private members...
-	size_t content_length_ = 0;
-	ContentProvider content_provider_;
-	ContentProviderResourceReleaser content_provider_resource_releaser_;
-	bool is_chunked_content_provider_ = false;
-	bool content_provider_success_ = false;
+  // private members...
+  size_t content_length_ = 0;
+  ContentProvider content_provider_;
+  ContentProviderResourceReleaser content_provider_resource_releaser_;
+  bool is_chunked_content_provider_ = false;
+  bool content_provider_success_ = false;
 };
 
 class Stream {
 public:
-	virtual ~Stream() = default;
+  virtual ~Stream() = default;
 
-	virtual bool is_readable() const = 0;
-	virtual bool is_writable() const = 0;
+  virtual bool is_readable() const = 0;
+  virtual bool is_writable() const = 0;
 
-	virtual ssize_t read(char *ptr, size_t size) = 0;
-	virtual ssize_t write(const char *ptr, size_t size) = 0;
-	virtual void get_remote_ip_and_port(std::string &ip, int &port) const = 0;
-	virtual void get_local_ip_and_port(std::string &ip, int &port) const = 0;
-	virtual socket_t socket() const = 0;
+  virtual ssize_t read(char *ptr, size_t size) = 0;
+  virtual ssize_t write(const char *ptr, size_t size) = 0;
+  virtual void get_remote_ip_and_port(std::string &ip, int &port) const = 0;
+  virtual void get_local_ip_and_port(std::string &ip, int &port) const = 0;
+  virtual socket_t socket() const = 0;
 
-	template <typename... Args>
-	ssize_t write_format(const char *fmt, const Args &...args);
-	ssize_t write(const char *ptr);
-	ssize_t write(const std::string &s);
+  template <typename... Args>
+  ssize_t write_format(const char *fmt, const Args &...args);
+  ssize_t write(const char *ptr);
+  ssize_t write(const std::string &s);
 };
 
 class TaskQueue {
 public:
-	TaskQueue() = default;
-	virtual ~TaskQueue() = default;
+  TaskQueue() = default;
+  virtual ~TaskQueue() = default;
 
-	virtual void enqueue(std::function<void()> fn) = 0;
-	virtual void shutdown() = 0;
+  virtual void enqueue(std::function<void()> fn) = 0;
+  virtual void shutdown() = 0;
 
-	virtual void on_idle() {
-	}
+  virtual void on_idle() {}
 };
 
 class ThreadPool : public TaskQueue {
 public:
-	explicit ThreadPool(size_t n) : shutdown_(false) {
-		while (n) {
-			threads_.emplace_back(worker(*this));
-			n--;
-		}
-	}
+  explicit ThreadPool(size_t n) : shutdown_(false) {
+    while (n) {
+      threads_.emplace_back(worker(*this));
+      n--;
+    }
+  }
 
-	ThreadPool(const ThreadPool &) = delete;
-	~ThreadPool() override = default;
+  ThreadPool(const ThreadPool &) = delete;
+  ~ThreadPool() override = default;
 
-	void enqueue(std::function<void()> fn) override {
-		{
-			std::unique_lock<std::mutex> lock(mutex_);
-			jobs_.push_back(std::move(fn));
-		}
+  void enqueue(std::function<void()> fn) override {
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      jobs_.push_back(std::move(fn));
+    }
 
-		cond_.notify_one();
-	}
+    cond_.notify_one();
+  }
 
-	void shutdown() override {
-		// Stop all worker threads...
-		{
-			std::unique_lock<std::mutex> lock(mutex_);
-			shutdown_ = true;
-		}
+  void shutdown() override {
+    // Stop all worker threads...
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      shutdown_ = true;
+    }
 
-		cond_.notify_all();
+    cond_.notify_all();
 
-		// Join...
-		for (auto &t : threads_) {
-			t.join();
-		}
-	}
+    // Join...
+    for (auto &t : threads_) {
+      t.join();
+    }
+  }
 
 private:
-	struct worker {
-		explicit worker(ThreadPool &pool) : pool_(pool) {
-		}
+  struct worker {
+    explicit worker(ThreadPool &pool) : pool_(pool) {}
 
-		void operator()() {
-			for (;;) {
-				std::function<void()> fn;
-				{
-					std::unique_lock<std::mutex> lock(pool_.mutex_);
+    void operator()() {
+      for (;;) {
+        std::function<void()> fn;
+        {
+          std::unique_lock<std::mutex> lock(pool_.mutex_);
 
-					pool_.cond_.wait(lock, [&] { return !pool_.jobs_.empty() || pool_.shutdown_; });
+          pool_.cond_.wait(
+              lock, [&] { return !pool_.jobs_.empty() || pool_.shutdown_; });
 
-					if (pool_.shutdown_ && pool_.jobs_.empty()) {
-						break;
-					}
+          if (pool_.shutdown_ && pool_.jobs_.empty()) { break; }
 
-					fn = std::move(pool_.jobs_.front());
-					pool_.jobs_.pop_front();
-				}
+          fn = std::move(pool_.jobs_.front());
+          pool_.jobs_.pop_front();
+        }
 
-				assert(true == static_cast<bool>(fn));
-				fn();
-			}
-		}
+        assert(true == static_cast<bool>(fn));
+        fn();
+      }
+    }
 
-		ThreadPool &pool_;
-	};
-	friend struct worker;
+    ThreadPool &pool_;
+  };
+  friend struct worker;
 
-	std::vector<std::thread> threads_;
-	std::list<std::function<void()>> jobs_;
+  std::vector<std::thread> threads_;
+  std::list<std::function<void()>> jobs_;
 
-	bool shutdown_;
+  bool shutdown_;
 
-	std::condition_variable cond_;
-	std::mutex mutex_;
+  std::condition_variable cond_;
+  std::mutex mutex_;
 };
 
 using Logger = std::function<void(const Request &, const Response &)>;
@@ -762,10 +772,10 @@ namespace detail {
 
 class MatcherBase {
 public:
-	virtual ~MatcherBase() = default;
+  virtual ~MatcherBase() = default;
 
-	// Match request path and populate its matches and
-	virtual bool match(Request &request) const = 0;
+  // Match request path and populate its matches and
+  virtual bool match(Request &request) const = 0;
 };
 
 /**
@@ -788,24 +798,24 @@ public:
  */
 class PathParamsMatcher : public MatcherBase {
 public:
-	PathParamsMatcher(const std::string &pattern);
+  PathParamsMatcher(const std::string &pattern);
 
-	bool match(Request &request) const override;
+  bool match(Request &request) const override;
 
 private:
-	static constexpr char marker = ':';
-	// Treat segment separators as the end of path parameter capture
-	// Does not need to handle query parameters as they are parsed before path
-	// matching
-	static constexpr char separator = '/';
+  static constexpr char marker = ':';
+  // Treat segment separators as the end of path parameter capture
+  // Does not need to handle query parameters as they are parsed before path
+  // matching
+  static constexpr char separator = '/';
 
-	// Contains static path fragments to match against, excluding the '/' after
-	// path params
-	// Fragments are separated by path params
-	std::vector<std::string> static_fragments_;
-	// Stores the names of the path parameters to be used as keys in the
-	// Request::path_params map
-	std::vector<std::string> param_names_;
+  // Contains static path fragments to match against, excluding the '/' after
+  // path params
+  // Fragments are separated by path params
+  std::vector<std::string> static_fragments_;
+  // Stores the names of the path parameters to be used as keys in the
+  // Request::path_params map
+  std::vector<std::string> param_names_;
 };
 
 /**
@@ -818,13 +828,12 @@ private:
  */
 class RegexMatcher : public MatcherBase {
 public:
-	RegexMatcher(const std::string &pattern) : regex_(pattern) {
-	}
+  RegexMatcher(const std::string &pattern) : regex_(pattern) {}
 
-	bool match(Request &request) const override;
+  bool match(Request &request) const override;
 
 private:
-	Regex regex_;
+  Regex regex_;
 };
 
 ssize_t write_headers(Stream &strm, const Headers &headers);
@@ -833,198 +842,222 @@ ssize_t write_headers(Stream &strm, const Headers &headers);
 
 class Server {
 public:
-	using Handler = std::function<void(const Request &, Response &)>;
+  using Handler = std::function<void(const Request &, Response &)>;
 
-	using ExceptionHandler = std::function<void(const Request &, Response &, std::exception_ptr ep)>;
+  using ExceptionHandler =
+      std::function<void(const Request &, Response &, std::exception_ptr ep)>;
 
-	enum class HandlerResponse {
-		Handled,
-		Unhandled,
-	};
-	using HandlerWithResponse = std::function<HandlerResponse(const Request &, Response &)>;
+  enum class HandlerResponse {
+    Handled,
+    Unhandled,
+  };
+  using HandlerWithResponse =
+      std::function<HandlerResponse(const Request &, Response &)>;
 
-	using HandlerWithContentReader =
-	    std::function<void(const Request &, Response &, const ContentReader &content_reader)>;
+  using HandlerWithContentReader = std::function<void(
+      const Request &, Response &, const ContentReader &content_reader)>;
 
-	using Expect100ContinueHandler = std::function<int(const Request &, Response &)>;
+  using Expect100ContinueHandler =
+      std::function<int(const Request &, Response &)>;
 
-	Server();
+  Server();
 
-	virtual ~Server();
+  virtual ~Server();
 
-	virtual bool is_valid() const;
+  virtual bool is_valid() const;
 
-	Server &Get(const std::string &pattern, Handler handler);
-	Server &Post(const std::string &pattern, Handler handler);
-	Server &Post(const std::string &pattern, HandlerWithContentReader handler);
-	Server &Put(const std::string &pattern, Handler handler);
-	Server &Put(const std::string &pattern, HandlerWithContentReader handler);
-	Server &Patch(const std::string &pattern, Handler handler);
-	Server &Patch(const std::string &pattern, HandlerWithContentReader handler);
-	Server &Delete(const std::string &pattern, Handler handler);
-	Server &Delete(const std::string &pattern, HandlerWithContentReader handler);
-	Server &Options(const std::string &pattern, Handler handler);
+  Server &Get(const std::string &pattern, Handler handler);
+  Server &Post(const std::string &pattern, Handler handler);
+  Server &Post(const std::string &pattern, HandlerWithContentReader handler);
+  Server &Put(const std::string &pattern, Handler handler);
+  Server &Put(const std::string &pattern, HandlerWithContentReader handler);
+  Server &Patch(const std::string &pattern, Handler handler);
+  Server &Patch(const std::string &pattern, HandlerWithContentReader handler);
+  Server &Delete(const std::string &pattern, Handler handler);
+  Server &Delete(const std::string &pattern, HandlerWithContentReader handler);
+  Server &Options(const std::string &pattern, Handler handler);
 
-	bool set_base_dir(const std::string &dir, const std::string &mount_point = std::string());
-	bool set_mount_point(const std::string &mount_point, const std::string &dir, Headers headers = Headers());
-	bool remove_mount_point(const std::string &mount_point);
-	Server &set_file_extension_and_mimetype_mapping(const std::string &ext, const std::string &mime);
-	Server &set_default_file_mimetype(const std::string &mime);
-	Server &set_file_request_handler(Handler handler);
+  bool set_base_dir(const std::string &dir,
+                    const std::string &mount_point = std::string());
+  bool set_mount_point(const std::string &mount_point, const std::string &dir,
+                       Headers headers = Headers());
+  bool remove_mount_point(const std::string &mount_point);
+  Server &set_file_extension_and_mimetype_mapping(const std::string &ext,
+                                                  const std::string &mime);
+  Server &set_default_file_mimetype(const std::string &mime);
+  Server &set_file_request_handler(Handler handler);
 
-	Server &set_error_handler(HandlerWithResponse handler);
-	Server &set_error_handler(Handler handler);
-	Server &set_exception_handler(ExceptionHandler handler);
-	Server &set_pre_routing_handler(HandlerWithResponse handler);
-	Server &set_post_routing_handler(Handler handler);
+  Server &set_error_handler(HandlerWithResponse handler);
+  Server &set_error_handler(Handler handler);
+  Server &set_exception_handler(ExceptionHandler handler);
+  Server &set_pre_routing_handler(HandlerWithResponse handler);
+  Server &set_post_routing_handler(Handler handler);
 
-	Server &set_expect_100_continue_handler(Expect100ContinueHandler handler);
-	Server &set_logger(Logger logger);
+  Server &set_expect_100_continue_handler(Expect100ContinueHandler handler);
+  Server &set_logger(Logger logger);
 
-	Server &set_address_family(int family);
-	Server &set_tcp_nodelay(bool on);
-	Server &set_socket_options(SocketOptions socket_options);
+  Server &set_address_family(int family);
+  Server &set_tcp_nodelay(bool on);
+  Server &set_socket_options(SocketOptions socket_options);
 
-	Server &set_default_headers(Headers headers);
-	Server &set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
+  Server &set_default_headers(Headers headers);
+  Server &
+  set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
 
-	Server &set_keep_alive_max_count(size_t count);
-	Server &set_keep_alive_timeout(time_t sec);
+  Server &set_keep_alive_max_count(size_t count);
+  Server &set_keep_alive_timeout(time_t sec);
 
-	Server &set_read_timeout(time_t sec, time_t usec = 0);
-	template <class Rep, class Period>
-	Server &set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
+  Server &set_read_timeout(time_t sec, time_t usec = 0);
+  template <class Rep, class Period>
+  Server &set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-	Server &set_write_timeout(time_t sec, time_t usec = 0);
-	template <class Rep, class Period>
-	Server &set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
+  Server &set_write_timeout(time_t sec, time_t usec = 0);
+  template <class Rep, class Period>
+  Server &set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-	Server &set_idle_interval(time_t sec, time_t usec = 0);
-	template <class Rep, class Period>
-	Server &set_idle_interval(const std::chrono::duration<Rep, Period> &duration);
+  Server &set_idle_interval(time_t sec, time_t usec = 0);
+  template <class Rep, class Period>
+  Server &set_idle_interval(const std::chrono::duration<Rep, Period> &duration);
 
-	Server &set_payload_max_length(size_t length);
+  Server &set_payload_max_length(size_t length);
 
-	bool bind_to_port(const std::string &host, int port, int socket_flags = 0);
-	int bind_to_any_port(const std::string &host, int socket_flags = 0);
-	bool listen_after_bind();
+  bool bind_to_port(const std::string &host, int port, int socket_flags = 0);
+  int bind_to_any_port(const std::string &host, int socket_flags = 0);
+  bool listen_after_bind();
 
-	bool listen(const std::string &host, int port, int socket_flags = 0);
+  bool listen(const std::string &host, int port, int socket_flags = 0);
 
-	bool is_running() const;
-	void wait_until_ready() const;
-	void stop();
+  bool is_running() const;
+  void wait_until_ready() const;
+  void stop();
 
-	std::function<TaskQueue *(void)> new_task_queue;
+  std::function<TaskQueue *(void)> new_task_queue;
 
 protected:
-	bool process_request(Stream &strm, bool close_connection, bool &connection_closed,
-	                     const std::function<void(Request &)> &setup_request);
+  bool process_request(Stream &strm, bool close_connection,
+                       bool &connection_closed,
+                       const std::function<void(Request &)> &setup_request);
 
-	std::atomic<socket_t> svr_sock_ {INVALID_SOCKET};
-	size_t keep_alive_max_count_ = CPPHTTPLIB_KEEPALIVE_MAX_COUNT;
-	time_t keep_alive_timeout_sec_ = CPPHTTPLIB_KEEPALIVE_TIMEOUT_SECOND;
-	time_t read_timeout_sec_ = CPPHTTPLIB_READ_TIMEOUT_SECOND;
-	time_t read_timeout_usec_ = CPPHTTPLIB_READ_TIMEOUT_USECOND;
-	time_t write_timeout_sec_ = CPPHTTPLIB_WRITE_TIMEOUT_SECOND;
-	time_t write_timeout_usec_ = CPPHTTPLIB_WRITE_TIMEOUT_USECOND;
-	time_t idle_interval_sec_ = CPPHTTPLIB_IDLE_INTERVAL_SECOND;
-	time_t idle_interval_usec_ = CPPHTTPLIB_IDLE_INTERVAL_USECOND;
-	size_t payload_max_length_ = CPPHTTPLIB_PAYLOAD_MAX_LENGTH;
+  std::atomic<socket_t> svr_sock_{INVALID_SOCKET};
+  size_t keep_alive_max_count_ = CPPHTTPLIB_KEEPALIVE_MAX_COUNT;
+  time_t keep_alive_timeout_sec_ = CPPHTTPLIB_KEEPALIVE_TIMEOUT_SECOND;
+  time_t read_timeout_sec_ = CPPHTTPLIB_READ_TIMEOUT_SECOND;
+  time_t read_timeout_usec_ = CPPHTTPLIB_READ_TIMEOUT_USECOND;
+  time_t write_timeout_sec_ = CPPHTTPLIB_WRITE_TIMEOUT_SECOND;
+  time_t write_timeout_usec_ = CPPHTTPLIB_WRITE_TIMEOUT_USECOND;
+  time_t idle_interval_sec_ = CPPHTTPLIB_IDLE_INTERVAL_SECOND;
+  time_t idle_interval_usec_ = CPPHTTPLIB_IDLE_INTERVAL_USECOND;
+  size_t payload_max_length_ = CPPHTTPLIB_PAYLOAD_MAX_LENGTH;
 
 private:
-	using Handlers = std::vector<std::pair<Regex, Handler>>;
-	using HandlersForContentReader = std::vector<std::pair<Regex, HandlerWithContentReader>>;
+  using Handlers = std::vector<std::pair<Regex, Handler>>;
+  using HandlersForContentReader =
+      std::vector<std::pair<Regex, HandlerWithContentReader>>;
 
-	static duckdb::unique_ptr<detail::MatcherBase> make_matcher(const std::string &pattern);
+  static duckdb::unique_ptr<detail::MatcherBase>
+  make_matcher(const std::string &pattern);
 
-	socket_t create_server_socket(const std::string &host, int port, int socket_flags,
-	                              SocketOptions socket_options) const;
-	int bind_internal(const std::string &host, int port, int socket_flags);
-	bool listen_internal();
+  socket_t create_server_socket(const std::string &host, int port,
+                                int socket_flags,
+                                SocketOptions socket_options) const;
+  int bind_internal(const std::string &host, int port, int socket_flags);
+  bool listen_internal();
 
-	bool routing(Request &req, Response &res, Stream &strm);
-	bool handle_file_request(const Request &req, Response &res, bool head = false);
-	bool dispatch_request(Request &req, Response &res, const Handlers &handlers) const;
-	bool dispatch_request_for_content_reader(Request &req, Response &res, ContentReader content_reader,
-	                                         const HandlersForContentReader &handlers) const;
+  bool routing(Request &req, Response &res, Stream &strm);
+  bool handle_file_request(const Request &req, Response &res,
+                           bool head = false);
+  bool dispatch_request(Request &req, Response &res,
+                        const Handlers &handlers) const;
+  bool dispatch_request_for_content_reader(
+      Request &req, Response &res, ContentReader content_reader,
+      const HandlersForContentReader &handlers) const;
 
-	bool parse_request_line(const char *s, Request &req) const;
-	void apply_ranges(const Request &req, Response &res, std::string &content_type, std::string &boundary) const;
-	bool write_response(Stream &strm, bool close_connection, const Request &req, Response &res);
-	bool write_response_with_content(Stream &strm, bool close_connection, const Request &req, Response &res);
-	bool write_response_core(Stream &strm, bool close_connection, const Request &req, Response &res,
-	                         bool need_apply_ranges);
-	bool write_content_with_provider(Stream &strm, const Request &req, Response &res, const std::string &boundary,
-	                                 const std::string &content_type);
-	bool read_content(Stream &strm, Request &req, Response &res);
-	bool read_content_with_content_receiver(Stream &strm, Request &req, Response &res, ContentReceiver receiver,
-	                                        MultipartContentHeader multipart_header,
-	                                        ContentReceiver multipart_receiver);
-	bool read_content_core(Stream &strm, Request &req, Response &res, ContentReceiver receiver,
-	                       MultipartContentHeader multipart_header, ContentReceiver multipart_receiver) const;
+  bool parse_request_line(const char *s, Request &req) const;
+  void apply_ranges(const Request &req, Response &res,
+                    std::string &content_type, std::string &boundary) const;
+  bool write_response(Stream &strm, bool close_connection, const Request &req,
+                      Response &res);
+  bool write_response_with_content(Stream &strm, bool close_connection,
+                                   const Request &req, Response &res);
+  bool write_response_core(Stream &strm, bool close_connection,
+                           const Request &req, Response &res,
+                           bool need_apply_ranges);
+  bool write_content_with_provider(Stream &strm, const Request &req,
+                                   Response &res, const std::string &boundary,
+                                   const std::string &content_type);
+  bool read_content(Stream &strm, Request &req, Response &res);
+  bool
+  read_content_with_content_receiver(Stream &strm, Request &req, Response &res,
+                                     ContentReceiver receiver,
+                                     MultipartContentHeader multipart_header,
+                                     ContentReceiver multipart_receiver);
+  bool read_content_core(Stream &strm, Request &req, Response &res,
+                         ContentReceiver receiver,
+                         MultipartContentHeader multipart_header,
+                         ContentReceiver multipart_receiver) const;
 
-	virtual bool process_and_close_socket(socket_t sock);
+  virtual bool process_and_close_socket(socket_t sock);
 
-	std::atomic<bool> is_running_ {false};
-	std::atomic<bool> done_ {false};
+  std::atomic<bool> is_running_{false};
+  std::atomic<bool> done_{false};
 
-	struct MountPointEntry {
-		std::string mount_point;
-		std::string base_dir;
-		Headers headers;
-	};
-	std::vector<MountPointEntry> base_dirs_;
-	std::map<std::string, std::string> file_extension_and_mimetype_map_;
-	std::string default_file_mimetype_ = "application/octet-stream";
-	Handler file_request_handler_;
+  struct MountPointEntry {
+    std::string mount_point;
+    std::string base_dir;
+    Headers headers;
+  };
+  std::vector<MountPointEntry> base_dirs_;
+  std::map<std::string, std::string> file_extension_and_mimetype_map_;
+  std::string default_file_mimetype_ = "application/octet-stream";
+  Handler file_request_handler_;
 
-	Handlers get_handlers_;
-	Handlers post_handlers_;
-	HandlersForContentReader post_handlers_for_content_reader_;
-	Handlers put_handlers_;
-	HandlersForContentReader put_handlers_for_content_reader_;
-	Handlers patch_handlers_;
-	HandlersForContentReader patch_handlers_for_content_reader_;
-	Handlers delete_handlers_;
-	HandlersForContentReader delete_handlers_for_content_reader_;
-	Handlers options_handlers_;
+  Handlers get_handlers_;
+  Handlers post_handlers_;
+  HandlersForContentReader post_handlers_for_content_reader_;
+  Handlers put_handlers_;
+  HandlersForContentReader put_handlers_for_content_reader_;
+  Handlers patch_handlers_;
+  HandlersForContentReader patch_handlers_for_content_reader_;
+  Handlers delete_handlers_;
+  HandlersForContentReader delete_handlers_for_content_reader_;
+  Handlers options_handlers_;
 
-	HandlerWithResponse error_handler_;
-	ExceptionHandler exception_handler_;
-	HandlerWithResponse pre_routing_handler_;
-	Handler post_routing_handler_;
-	Expect100ContinueHandler expect_100_continue_handler_;
+  HandlerWithResponse error_handler_;
+  ExceptionHandler exception_handler_;
+  HandlerWithResponse pre_routing_handler_;
+  Handler post_routing_handler_;
+  Expect100ContinueHandler expect_100_continue_handler_;
 
-	Logger logger_;
+  Logger logger_;
 
-	int address_family_ = AF_UNSPEC;
-	bool tcp_nodelay_ = CPPHTTPLIB_TCP_NODELAY;
-	SocketOptions socket_options_ = default_socket_options;
+  int address_family_ = AF_UNSPEC;
+  bool tcp_nodelay_ = CPPHTTPLIB_TCP_NODELAY;
+  SocketOptions socket_options_ = default_socket_options;
 
-	Headers default_headers_;
-	std::function<ssize_t(Stream &, Headers &)> header_writer_ = detail::write_headers;
+  Headers default_headers_;
+  std::function<ssize_t(Stream &, Headers &)> header_writer_ =
+      detail::write_headers;
 };
 
 enum class Error {
-	Success = 0,
-	Unknown,
-	Connection,
-	BindIPAddress,
-	Read,
-	Write,
-	ExceedRedirectCount,
-	Canceled,
-	SSLConnection,
-	SSLLoadingCerts,
-	SSLServerVerification,
-	UnsupportedMultipartBoundaryChars,
-	Compression,
-	ConnectionTimeout,
-	ProxyConnection,
+  Success = 0,
+  Unknown,
+  Connection,
+  BindIPAddress,
+  Read,
+  Write,
+  ExceedRedirectCount,
+  Canceled,
+  SSLConnection,
+  SSLLoadingCerts,
+  SSLServerVerification,
+  UnsupportedMultipartBoundaryChars,
+  Compression,
+  ConnectionTimeout,
+  ProxyConnection,
 
-	// For internal use only
-	SSLPeerCouldBeClosed_,
+  // For internal use only
+  SSLPeerCouldBeClosed_,
 };
 
 std::string to_string(Error error);
@@ -1033,654 +1066,744 @@ std::ostream &operator<<(std::ostream &os, const Error &obj);
 
 class Result {
 public:
-	Result() = default;
-	Result(duckdb::unique_ptr<Response> &&res, Error err, Headers &&request_headers = Headers {})
-	    : res_(std::move(res)), err_(err), request_headers_(std::move(request_headers)) {
-	}
-	// Response
-	operator bool() const {
-		return res_ != nullptr;
-	}
-	bool operator==(std::nullptr_t) const {
-		return res_ == nullptr;
-	}
-	bool operator!=(std::nullptr_t) const {
-		return res_ != nullptr;
-	}
-	const Response &value() const {
-		return *res_;
-	}
-	Response &value() {
-		return *res_;
-	}
-	const Response &operator*() const {
-		return *res_;
-	}
-	Response &operator*() {
-		return *res_;
-	}
-	const Response *operator->() const {
-		return res_.get();
-	}
-	Response *operator->() {
-		return res_.get();
-	}
+  Result() = default;
+  Result(duckdb::unique_ptr<Response> &&res, Error err,
+         Headers &&request_headers = Headers{})
+      : res_(std::move(res)), err_(err),
+        request_headers_(std::move(request_headers)) {}
+  // Response
+  operator bool() const { return res_ != nullptr; }
+  bool operator==(std::nullptr_t) const { return res_ == nullptr; }
+  bool operator!=(std::nullptr_t) const { return res_ != nullptr; }
+  const Response &value() const { return *res_; }
+  Response &value() { return *res_; }
+  const Response &operator*() const { return *res_; }
+  Response &operator*() { return *res_; }
+  const Response *operator->() const { return res_.get(); }
+  Response *operator->() { return res_.get(); }
 
-	// Error
-	Error error() const {
-		return err_;
-	}
+  // Error
+  Error error() const { return err_; }
 
-	// Request Headers
-	bool has_request_header(const std::string &key) const;
-	std::string get_request_header_value(const std::string &key, size_t id = 0) const;
-	uint64_t get_request_header_value_u64(const std::string &key, size_t id = 0) const;
-	size_t get_request_header_value_count(const std::string &key) const;
+  // Request Headers
+  bool has_request_header(const std::string &key) const;
+  std::string get_request_header_value(const std::string &key,
+                                       size_t id = 0) const;
+  uint64_t get_request_header_value_u64(const std::string &key,
+                                        size_t id = 0) const;
+  size_t get_request_header_value_count(const std::string &key) const;
 
 private:
-	duckdb::unique_ptr<Response> res_;
-	Error err_ = Error::Unknown;
-	Headers request_headers_;
+  duckdb::unique_ptr<Response> res_;
+  Error err_ = Error::Unknown;
+  Headers request_headers_;
 };
 
 class ClientImpl {
 public:
-	explicit ClientImpl(const std::string &host);
+  explicit ClientImpl(const std::string &host);
 
-	explicit ClientImpl(const std::string &host, int port);
+  explicit ClientImpl(const std::string &host, int port);
 
-	explicit ClientImpl(const std::string &host, int port, const std::string &client_cert_path,
-	                    const std::string &client_key_path);
+  explicit ClientImpl(const std::string &host, int port,
+                      const std::string &client_cert_path,
+                      const std::string &client_key_path);
 
-	virtual ~ClientImpl();
+  virtual ~ClientImpl();
 
-	virtual bool is_valid() const;
+  virtual bool is_valid() const;
 
-	Result Get(const std::string &path);
-	Result Get(const std::string &path, const Headers &headers);
-	Result Get(const std::string &path, Progress progress);
-	Result Get(const std::string &path, const Headers &headers, Progress progress);
-	Result Get(const std::string &path, ContentReceiver content_receiver);
-	Result Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver);
-	Result Get(const std::string &path, ContentReceiver content_receiver, Progress progress);
-	Result Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver, Progress progress);
-	Result Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver);
-	Result Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
-	           ContentReceiver content_receiver);
-	Result Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver,
-	           Progress progress);
-	Result Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
-	           ContentReceiver content_receiver, Progress progress);
+  Result Get(const std::string &path);
+  Result Get(const std::string &path, const Headers &headers);
+  Result Get(const std::string &path, Progress progress);
+  Result Get(const std::string &path, const Headers &headers,
+             Progress progress);
+  Result Get(const std::string &path, ContentReceiver content_receiver);
+  Result Get(const std::string &path, const Headers &headers,
+             ContentReceiver content_receiver);
+  Result Get(const std::string &path, ContentReceiver content_receiver,
+             Progress progress);
+  Result Get(const std::string &path, const Headers &headers,
+             ContentReceiver content_receiver, Progress progress);
+  Result Get(const std::string &path, ResponseHandler response_handler,
+             ContentReceiver content_receiver);
+  Result Get(const std::string &path, const Headers &headers,
+             ResponseHandler response_handler,
+             ContentReceiver content_receiver);
+  Result Get(const std::string &path, ResponseHandler response_handler,
+             ContentReceiver content_receiver, Progress progress);
+  Result Get(const std::string &path, const Headers &headers,
+             ResponseHandler response_handler, ContentReceiver content_receiver,
+             Progress progress);
 
-	Result Get(const std::string &path, const Params &params, const Headers &headers, Progress progress = nullptr);
-	Result Get(const std::string &path, const Params &params, const Headers &headers, ContentReceiver content_receiver,
-	           Progress progress = nullptr);
-	Result Get(const std::string &path, const Params &params, const Headers &headers, ResponseHandler response_handler,
-	           ContentReceiver content_receiver, Progress progress = nullptr);
+  Result Get(const std::string &path, const Params &params,
+             const Headers &headers, Progress progress = nullptr);
+  Result Get(const std::string &path, const Params &params,
+             const Headers &headers, ContentReceiver content_receiver,
+             Progress progress = nullptr);
+  Result Get(const std::string &path, const Params &params,
+             const Headers &headers, ResponseHandler response_handler,
+             ContentReceiver content_receiver, Progress progress = nullptr);
 
-	Result Head(const std::string &path);
-	Result Head(const std::string &path, const Headers &headers);
+  Result Head(const std::string &path);
+  Result Head(const std::string &path, const Headers &headers);
 
-	Result Post(const std::string &path);
-	Result Post(const std::string &path, const Headers &headers);
-	Result Post(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
-	Result Post(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-	            const std::string &content_type);
-	Result Post(const std::string &path, const std::string &body, const std::string &content_type);
-	Result Post(const std::string &path, const Headers &headers, const std::string &body,
-	            const std::string &content_type);
-	Result Post(const std::string &path, size_t content_length, ContentProvider content_provider,
-	            const std::string &content_type);
-	Result Post(const std::string &path, ContentProviderWithoutLength content_provider,
-	            const std::string &content_type);
-	Result Post(const std::string &path, const Headers &headers, size_t content_length,
-	            ContentProvider content_provider, const std::string &content_type);
-	Result Post(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
-	            const std::string &content_type);
-	Result Post(const std::string &path, const Params &params);
-	Result Post(const std::string &path, const Headers &headers, const Params &params);
-	Result Post(const std::string &path, const MultipartFormDataItems &items);
-	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items);
-	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-	            const std::string &boundary);
-	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-	            const MultipartFormDataProviderItems &provider_items);
+  Result Post(const std::string &path);
+  Result Post(const std::string &path, const Headers &headers);
+  Result Post(const std::string &path, const char *body, size_t content_length,
+              const std::string &content_type);
+  Result Post(const std::string &path, const Headers &headers, const char *body,
+              size_t content_length, const std::string &content_type);
+  Result Post(const std::string &path, const std::string &body,
+              const std::string &content_type);
+  Result Post(const std::string &path, const Headers &headers,
+              const std::string &body, const std::string &content_type);
+  Result Post(const std::string &path, size_t content_length,
+              ContentProvider content_provider,
+              const std::string &content_type);
+  Result Post(const std::string &path,
+              ContentProviderWithoutLength content_provider,
+              const std::string &content_type);
+  Result Post(const std::string &path, const Headers &headers,
+              size_t content_length, ContentProvider content_provider,
+              const std::string &content_type);
+  Result Post(const std::string &path, const Headers &headers,
+              ContentProviderWithoutLength content_provider,
+              const std::string &content_type);
+  Result Post(const std::string &path, const Params &params);
+  Result Post(const std::string &path, const Headers &headers,
+              const Params &params);
+  Result Post(const std::string &path, const MultipartFormDataItems &items);
+  Result Post(const std::string &path, const Headers &headers,
+              const MultipartFormDataItems &items);
+  Result Post(const std::string &path, const Headers &headers,
+              const MultipartFormDataItems &items, const std::string &boundary);
+  Result Post(const std::string &path, const Headers &headers,
+              const MultipartFormDataItems &items,
+              const MultipartFormDataProviderItems &provider_items);
 
-	Result Put(const std::string &path);
-	Result Put(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
-	Result Put(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-	           const std::string &content_type);
-	Result Put(const std::string &path, const std::string &body, const std::string &content_type);
-	Result Put(const std::string &path, const Headers &headers, const std::string &body,
-	           const std::string &content_type);
-	Result Put(const std::string &path, size_t content_length, ContentProvider content_provider,
-	           const std::string &content_type);
-	Result Put(const std::string &path, ContentProviderWithoutLength content_provider, const std::string &content_type);
-	Result Put(const std::string &path, const Headers &headers, size_t content_length, ContentProvider content_provider,
-	           const std::string &content_type);
-	Result Put(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
-	           const std::string &content_type);
-	Result Put(const std::string &path, const Params &params);
-	Result Put(const std::string &path, const Headers &headers, const Params &params);
-	Result Put(const std::string &path, const MultipartFormDataItems &items);
-	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items);
-	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-	           const std::string &boundary);
-	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-	           const MultipartFormDataProviderItems &provider_items);
+  Result Put(const std::string &path);
+  Result Put(const std::string &path, const char *body, size_t content_length,
+             const std::string &content_type);
+  Result Put(const std::string &path, const Headers &headers, const char *body,
+             size_t content_length, const std::string &content_type);
+  Result Put(const std::string &path, const std::string &body,
+             const std::string &content_type);
+  Result Put(const std::string &path, const Headers &headers,
+             const std::string &body, const std::string &content_type);
+  Result Put(const std::string &path, size_t content_length,
+             ContentProvider content_provider, const std::string &content_type);
+  Result Put(const std::string &path,
+             ContentProviderWithoutLength content_provider,
+             const std::string &content_type);
+  Result Put(const std::string &path, const Headers &headers,
+             size_t content_length, ContentProvider content_provider,
+             const std::string &content_type);
+  Result Put(const std::string &path, const Headers &headers,
+             ContentProviderWithoutLength content_provider,
+             const std::string &content_type);
+  Result Put(const std::string &path, const Params &params);
+  Result Put(const std::string &path, const Headers &headers,
+             const Params &params);
+  Result Put(const std::string &path, const MultipartFormDataItems &items);
+  Result Put(const std::string &path, const Headers &headers,
+             const MultipartFormDataItems &items);
+  Result Put(const std::string &path, const Headers &headers,
+             const MultipartFormDataItems &items, const std::string &boundary);
+  Result Put(const std::string &path, const Headers &headers,
+             const MultipartFormDataItems &items,
+             const MultipartFormDataProviderItems &provider_items);
 
-	Result Patch(const std::string &path);
-	Result Patch(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
-	Result Patch(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-	             const std::string &content_type);
-	Result Patch(const std::string &path, const std::string &body, const std::string &content_type);
-	Result Patch(const std::string &path, const Headers &headers, const std::string &body,
-	             const std::string &content_type);
-	Result Patch(const std::string &path, size_t content_length, ContentProvider content_provider,
-	             const std::string &content_type);
-	Result Patch(const std::string &path, ContentProviderWithoutLength content_provider,
-	             const std::string &content_type);
-	Result Patch(const std::string &path, const Headers &headers, size_t content_length,
-	             ContentProvider content_provider, const std::string &content_type);
-	Result Patch(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
-	             const std::string &content_type);
+  Result Patch(const std::string &path);
+  Result Patch(const std::string &path, const char *body, size_t content_length,
+               const std::string &content_type);
+  Result Patch(const std::string &path, const Headers &headers,
+               const char *body, size_t content_length,
+               const std::string &content_type);
+  Result Patch(const std::string &path, const std::string &body,
+               const std::string &content_type);
+  Result Patch(const std::string &path, const Headers &headers,
+               const std::string &body, const std::string &content_type);
+  Result Patch(const std::string &path, size_t content_length,
+               ContentProvider content_provider,
+               const std::string &content_type);
+  Result Patch(const std::string &path,
+               ContentProviderWithoutLength content_provider,
+               const std::string &content_type);
+  Result Patch(const std::string &path, const Headers &headers,
+               size_t content_length, ContentProvider content_provider,
+               const std::string &content_type);
+  Result Patch(const std::string &path, const Headers &headers,
+               ContentProviderWithoutLength content_provider,
+               const std::string &content_type);
 
-	Result Delete(const std::string &path);
-	Result Delete(const std::string &path, const Headers &headers);
-	Result Delete(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
-	Result Delete(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-	              const std::string &content_type);
-	Result Delete(const std::string &path, const std::string &body, const std::string &content_type);
-	Result Delete(const std::string &path, const Headers &headers, const std::string &body,
-	              const std::string &content_type);
+  Result Delete(const std::string &path);
+  Result Delete(const std::string &path, const Headers &headers);
+  Result Delete(const std::string &path, const char *body,
+                size_t content_length, const std::string &content_type);
+  Result Delete(const std::string &path, const Headers &headers,
+                const char *body, size_t content_length,
+                const std::string &content_type);
+  Result Delete(const std::string &path, const std::string &body,
+                const std::string &content_type);
+  Result Delete(const std::string &path, const Headers &headers,
+                const std::string &body, const std::string &content_type);
 
-	Result Options(const std::string &path);
-	Result Options(const std::string &path, const Headers &headers);
+  Result Options(const std::string &path);
+  Result Options(const std::string &path, const Headers &headers);
 
-	bool send(Request &req, Response &res, Error &error);
-	Result send(const Request &req);
+  bool send(Request &req, Response &res, Error &error);
+  Result send(const Request &req);
 
-	void stop();
+  void stop();
 
-	std::string host() const;
-	int port() const;
+  std::string host() const;
+  int port() const;
 
-	size_t is_socket_open() const;
-	socket_t socket() const;
+  size_t is_socket_open() const;
+  socket_t socket() const;
 
-	void set_hostname_addr_map(std::map<std::string, std::string> addr_map);
+  void set_hostname_addr_map(std::map<std::string, std::string> addr_map);
 
-	void set_default_headers(Headers headers);
+  void set_default_headers(Headers headers);
 
-	void set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
+  void
+  set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
 
-	void set_address_family(int family);
-	void set_tcp_nodelay(bool on);
-	void set_socket_options(SocketOptions socket_options);
+  void set_address_family(int family);
+  void set_tcp_nodelay(bool on);
+  void set_socket_options(SocketOptions socket_options);
 
-	void set_connection_timeout(time_t sec, time_t usec = 0);
-	template <class Rep, class Period>
-	void set_connection_timeout(const std::chrono::duration<Rep, Period> &duration);
+  void set_connection_timeout(time_t sec, time_t usec = 0);
+  template <class Rep, class Period>
+  void
+  set_connection_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-	void set_read_timeout(time_t sec, time_t usec = 0);
-	template <class Rep, class Period>
-	void set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
+  void set_read_timeout(time_t sec, time_t usec = 0);
+  template <class Rep, class Period>
+  void set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-	void set_write_timeout(time_t sec, time_t usec = 0);
-	template <class Rep, class Period>
-	void set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
+  void set_write_timeout(time_t sec, time_t usec = 0);
+  template <class Rep, class Period>
+  void set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-	void set_basic_auth(const std::string &username, const std::string &password);
-	void set_bearer_token_auth(const std::string &token);
+  void set_basic_auth(const std::string &username, const std::string &password);
+  void set_bearer_token_auth(const std::string &token);
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	void set_digest_auth(const std::string &username, const std::string &password);
+  void set_digest_auth(const std::string &username,
+                       const std::string &password);
 #endif
 
-	void set_keep_alive(bool on);
-	void set_follow_location(bool on);
+  void set_keep_alive(bool on);
+  void set_follow_location(bool on);
 
-	void set_url_encode(bool on);
+  void set_url_encode(bool on);
 
-	void set_compress(bool on);
+  void set_compress(bool on);
 
-	void set_decompress(bool on);
+  void set_decompress(bool on);
 
-	void set_interface(const std::string &intf);
+  void set_interface(const std::string &intf);
 
-	void set_proxy(const std::string &host, int port);
-	void set_proxy_basic_auth(const std::string &username, const std::string &password);
-	void set_proxy_bearer_token_auth(const std::string &token);
+  void set_proxy(const std::string &host, int port);
+  void set_proxy_basic_auth(const std::string &username,
+                            const std::string &password);
+  void set_proxy_bearer_token_auth(const std::string &token);
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	void set_proxy_digest_auth(const std::string &username, const std::string &password);
+  void set_proxy_digest_auth(const std::string &username,
+                             const std::string &password);
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	void set_ca_cert_path(const std::string &ca_cert_file_path, const std::string &ca_cert_dir_path = std::string());
-	void set_ca_cert_store(X509_STORE *ca_cert_store);
-	X509_STORE *create_ca_cert_store(const char *ca_cert, std::size_t size) const;
+  void set_ca_cert_path(const std::string &ca_cert_file_path,
+                        const std::string &ca_cert_dir_path = std::string());
+  void set_ca_cert_store(X509_STORE *ca_cert_store);
+  X509_STORE *create_ca_cert_store(const char *ca_cert, std::size_t size) const;
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	void enable_server_certificate_verification(bool enabled);
+  void enable_server_certificate_verification(bool enabled);
 #endif
 
-	void set_logger(Logger logger);
+  void set_logger(Logger logger);
 
 protected:
-	struct Socket {
-		socket_t sock = INVALID_SOCKET;
+  struct Socket {
+    socket_t sock = INVALID_SOCKET;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-		SSL *ssl = nullptr;
+    SSL *ssl = nullptr;
 #endif
 
-		bool is_open() const {
-			return sock != INVALID_SOCKET;
-		}
-	};
+    bool is_open() const { return sock != INVALID_SOCKET; }
+  };
 
-	virtual bool create_and_connect_socket(Socket &socket, Error &error);
+  virtual bool create_and_connect_socket(Socket &socket, Error &error);
 
-	// All of:
-	//   shutdown_ssl
-	//   shutdown_socket
-	//   close_socket
-	// should ONLY be called when socket_mutex_ is locked.
-	// Also, shutdown_ssl and close_socket should also NOT be called concurrently
-	// with a DIFFERENT thread sending requests using that socket.
-	virtual void shutdown_ssl(Socket &socket, bool shutdown_gracefully);
-	void shutdown_socket(Socket &socket) const;
-	void close_socket(Socket &socket);
+  // All of:
+  //   shutdown_ssl
+  //   shutdown_socket
+  //   close_socket
+  // should ONLY be called when socket_mutex_ is locked.
+  // Also, shutdown_ssl and close_socket should also NOT be called concurrently
+  // with a DIFFERENT thread sending requests using that socket.
+  virtual void shutdown_ssl(Socket &socket, bool shutdown_gracefully);
+  void shutdown_socket(Socket &socket) const;
+  void close_socket(Socket &socket);
 
-	bool process_request(Stream &strm, Request &req, Response &res, bool close_connection, Error &error);
+  bool process_request(Stream &strm, Request &req, Response &res,
+                       bool close_connection, Error &error);
 
-	bool write_content_with_provider(Stream &strm, const Request &req, Error &error) const;
+  bool write_content_with_provider(Stream &strm, const Request &req,
+                                   Error &error) const;
 
-	void copy_settings(const ClientImpl &rhs);
+  void copy_settings(const ClientImpl &rhs);
 
-	// Socket endpoint information
-	const std::string host_;
-	const int port_;
-	const std::string host_and_port_;
+  // Socket endpoint information
+  const std::string host_;
+  const int port_;
+  const std::string host_and_port_;
 
-	// Current open socket
-	Socket socket_;
-	mutable std::mutex socket_mutex_;
-	std::recursive_mutex request_mutex_;
+  // Current open socket
+  Socket socket_;
+  mutable std::mutex socket_mutex_;
+  std::recursive_mutex request_mutex_;
 
-	// These are all protected under socket_mutex
-	size_t socket_requests_in_flight_ = 0;
-	std::thread::id socket_requests_are_from_thread_ = std::thread::id();
-	bool socket_should_be_closed_when_request_is_done_ = false;
+  // These are all protected under socket_mutex
+  size_t socket_requests_in_flight_ = 0;
+  std::thread::id socket_requests_are_from_thread_ = std::thread::id();
+  bool socket_should_be_closed_when_request_is_done_ = false;
 
-	// Hostname-IP map
-	std::map<std::string, std::string> addr_map_;
+  // Hostname-IP map
+  std::map<std::string, std::string> addr_map_;
 
-	// Default headers
-	Headers default_headers_;
+  // Default headers
+  Headers default_headers_;
 
-	// Header writer
-	std::function<ssize_t(Stream &, Headers &)> header_writer_ = detail::write_headers;
+  // Header writer
+  std::function<ssize_t(Stream &, Headers &)> header_writer_ =
+      detail::write_headers;
 
-	// Settings
-	std::string client_cert_path_;
-	std::string client_key_path_;
+  // Settings
+  std::string client_cert_path_;
+  std::string client_key_path_;
 
-	time_t connection_timeout_sec_ = CPPHTTPLIB_CONNECTION_TIMEOUT_SECOND;
-	time_t connection_timeout_usec_ = CPPHTTPLIB_CONNECTION_TIMEOUT_USECOND;
-	time_t read_timeout_sec_ = CPPHTTPLIB_READ_TIMEOUT_SECOND;
-	time_t read_timeout_usec_ = CPPHTTPLIB_READ_TIMEOUT_USECOND;
-	time_t write_timeout_sec_ = CPPHTTPLIB_WRITE_TIMEOUT_SECOND;
-	time_t write_timeout_usec_ = CPPHTTPLIB_WRITE_TIMEOUT_USECOND;
+  time_t connection_timeout_sec_ = CPPHTTPLIB_CONNECTION_TIMEOUT_SECOND;
+  time_t connection_timeout_usec_ = CPPHTTPLIB_CONNECTION_TIMEOUT_USECOND;
+  time_t read_timeout_sec_ = CPPHTTPLIB_READ_TIMEOUT_SECOND;
+  time_t read_timeout_usec_ = CPPHTTPLIB_READ_TIMEOUT_USECOND;
+  time_t write_timeout_sec_ = CPPHTTPLIB_WRITE_TIMEOUT_SECOND;
+  time_t write_timeout_usec_ = CPPHTTPLIB_WRITE_TIMEOUT_USECOND;
 
-	std::string basic_auth_username_;
-	std::string basic_auth_password_;
-	std::string bearer_token_auth_token_;
+  std::string basic_auth_username_;
+  std::string basic_auth_password_;
+  std::string bearer_token_auth_token_;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	std::string digest_auth_username_;
-	std::string digest_auth_password_;
+  std::string digest_auth_username_;
+  std::string digest_auth_password_;
 #endif
 
-	bool keep_alive_ = false;
-	bool follow_location_ = false;
+  bool keep_alive_ = false;
+  bool follow_location_ = false;
 
-	bool url_encode_ = true;
+  bool url_encode_ = true;
 
-	int address_family_ = AF_UNSPEC;
-	bool tcp_nodelay_ = CPPHTTPLIB_TCP_NODELAY;
-	SocketOptions socket_options_ = nullptr;
+  int address_family_ = AF_UNSPEC;
+  bool tcp_nodelay_ = CPPHTTPLIB_TCP_NODELAY;
+  SocketOptions socket_options_ = nullptr;
 
-	bool compress_ = false;
-	bool decompress_ = true;
+  bool compress_ = false;
+  bool decompress_ = true;
 
-	std::string interface_;
+  std::string interface_;
 
-	std::string proxy_host_;
-	int proxy_port_ = -1;
+  std::string proxy_host_;
+  int proxy_port_ = -1;
 
-	std::string proxy_basic_auth_username_;
-	std::string proxy_basic_auth_password_;
-	std::string proxy_bearer_token_auth_token_;
+  std::string proxy_basic_auth_username_;
+  std::string proxy_basic_auth_password_;
+  std::string proxy_bearer_token_auth_token_;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	std::string proxy_digest_auth_username_;
-	std::string proxy_digest_auth_password_;
-#endif
-
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	std::string ca_cert_file_path_;
-	std::string ca_cert_dir_path_;
-
-	X509_STORE *ca_cert_store_ = nullptr;
+  std::string proxy_digest_auth_username_;
+  std::string proxy_digest_auth_password_;
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	bool server_certificate_verification_ = true;
+  std::string ca_cert_file_path_;
+  std::string ca_cert_dir_path_;
+
+  X509_STORE *ca_cert_store_ = nullptr;
 #endif
 
-	Logger logger_;
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  bool server_certificate_verification_ = true;
+#endif
+
+  Logger logger_;
 
 private:
-	bool send_(Request &req, Response &res, Error &error);
-	Result send_(Request &&req);
+  bool send_(Request &req, Response &res, Error &error);
+  Result send_(Request &&req);
 
-	socket_t create_client_socket(Error &error) const;
-	bool read_response_line(Stream &strm, const Request &req, Response &res) const;
-	bool write_request(Stream &strm, Request &req, bool close_connection, Error &error);
-	bool redirect(Request &req, Response &res, Error &error);
-	bool handle_request(Stream &strm, Request &req, Response &res, bool close_connection, Error &error);
-	duckdb::unique_ptr<Response>
-	send_with_content_provider(Request &req, const char *body, size_t content_length, ContentProvider content_provider,
-	                           ContentProviderWithoutLength content_provider_without_length,
-	                           const std::string &content_type, Error &error);
-	Result send_with_content_provider(const std::string &method, const std::string &path, const Headers &headers,
-	                                  const char *body, size_t content_length, ContentProvider content_provider,
-	                                  ContentProviderWithoutLength content_provider_without_length,
-	                                  const std::string &content_type);
-	ContentProviderWithoutLength
-	get_multipart_content_provider(const std::string &boundary, const MultipartFormDataItems &items,
-	                               const MultipartFormDataProviderItems &provider_items) const;
+  socket_t create_client_socket(Error &error) const;
+  bool read_response_line(Stream &strm, const Request &req,
+                          Response &res) const;
+  bool write_request(Stream &strm, Request &req, bool close_connection,
+                     Error &error);
+  bool redirect(Request &req, Response &res, Error &error);
+  bool handle_request(Stream &strm, Request &req, Response &res,
+                      bool close_connection, Error &error);
+  duckdb::unique_ptr<Response> send_with_content_provider(
+      Request &req, const char *body, size_t content_length,
+      ContentProvider content_provider,
+      ContentProviderWithoutLength content_provider_without_length,
+      const std::string &content_type, Error &error);
+  Result send_with_content_provider(
+      const std::string &method, const std::string &path,
+      const Headers &headers, const char *body, size_t content_length,
+      ContentProvider content_provider,
+      ContentProviderWithoutLength content_provider_without_length,
+      const std::string &content_type);
+  ContentProviderWithoutLength get_multipart_content_provider(
+      const std::string &boundary, const MultipartFormDataItems &items,
+      const MultipartFormDataProviderItems &provider_items) const;
 
-	std::string adjust_host_string(const std::string &host) const;
+  std::string adjust_host_string(const std::string &host) const;
 
-	virtual bool process_socket(const Socket &socket, std::function<bool(Stream &strm)> callback);
-	virtual bool is_ssl() const;
+  virtual bool process_socket(const Socket &socket,
+                              std::function<bool(Stream &strm)> callback);
+  virtual bool is_ssl() const;
 };
 
 class Client {
 public:
-	// Universal interface
-	explicit Client(const std::string &scheme_host_port);
+  // Universal interface
+  explicit Client(const std::string &scheme_host_port);
 
-	explicit Client(const std::string &scheme_host_port, const std::string &client_cert_path,
-	                const std::string &client_key_path);
+  explicit Client(const std::string &scheme_host_port,
+                  const std::string &client_cert_path,
+                  const std::string &client_key_path);
 
-	// HTTP only interface
-	explicit Client(const std::string &host, int port);
+  // HTTP only interface
+  explicit Client(const std::string &host, int port);
 
-	explicit Client(const std::string &host, int port, const std::string &client_cert_path,
-	                const std::string &client_key_path);
+  explicit Client(const std::string &host, int port,
+                  const std::string &client_cert_path,
+                  const std::string &client_key_path);
 
-	Client(Client &&) = default;
+  Client(Client &&) = default;
 
-	~Client();
+  ~Client();
 
-	bool is_valid() const;
+  bool is_valid() const;
 
-	Result Get(const std::string &path);
-	Result Get(const std::string &path, const Headers &headers);
-	Result Get(const std::string &path, Progress progress);
-	Result Get(const std::string &path, const Headers &headers, Progress progress);
-	Result Get(const std::string &path, ContentReceiver content_receiver);
-	Result Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver);
-	Result Get(const std::string &path, ContentReceiver content_receiver, Progress progress);
-	Result Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver, Progress progress);
-	Result Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver);
-	Result Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
-	           ContentReceiver content_receiver);
-	Result Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
-	           ContentReceiver content_receiver, Progress progress);
-	Result Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver,
-	           Progress progress);
+  Result Get(const std::string &path);
+  Result Get(const std::string &path, const Headers &headers);
+  Result Get(const std::string &path, Progress progress);
+  Result Get(const std::string &path, const Headers &headers,
+             Progress progress);
+  Result Get(const std::string &path, ContentReceiver content_receiver);
+  Result Get(const std::string &path, const Headers &headers,
+             ContentReceiver content_receiver);
+  Result Get(const std::string &path, ContentReceiver content_receiver,
+             Progress progress);
+  Result Get(const std::string &path, const Headers &headers,
+             ContentReceiver content_receiver, Progress progress);
+  Result Get(const std::string &path, ResponseHandler response_handler,
+             ContentReceiver content_receiver);
+  Result Get(const std::string &path, const Headers &headers,
+             ResponseHandler response_handler,
+             ContentReceiver content_receiver);
+  Result Get(const std::string &path, const Headers &headers,
+             ResponseHandler response_handler, ContentReceiver content_receiver,
+             Progress progress);
+  Result Get(const std::string &path, ResponseHandler response_handler,
+             ContentReceiver content_receiver, Progress progress);
 
-	Result Get(const std::string &path, const Params &params, const Headers &headers, Progress progress = nullptr);
-	Result Get(const std::string &path, const Params &params, const Headers &headers, ContentReceiver content_receiver,
-	           Progress progress = nullptr);
-	Result Get(const std::string &path, const Params &params, const Headers &headers, ResponseHandler response_handler,
-	           ContentReceiver content_receiver, Progress progress = nullptr);
+  Result Get(const std::string &path, const Params &params,
+             const Headers &headers, Progress progress = nullptr);
+  Result Get(const std::string &path, const Params &params,
+             const Headers &headers, ContentReceiver content_receiver,
+             Progress progress = nullptr);
+  Result Get(const std::string &path, const Params &params,
+             const Headers &headers, ResponseHandler response_handler,
+             ContentReceiver content_receiver, Progress progress = nullptr);
 
-	Result Head(const std::string &path);
-	Result Head(const std::string &path, const Headers &headers);
+  Result Head(const std::string &path);
+  Result Head(const std::string &path, const Headers &headers);
 
-	Result Post(const std::string &path);
-	Result Post(const std::string &path, const Headers &headers);
-	Result Post(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
-	Result Post(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-	            const std::string &content_type);
-	Result Post(const std::string &path, const std::string &body, const std::string &content_type);
-	Result Post(const std::string &path, const Headers &headers, const std::string &body,
-	            const std::string &content_type);
-	Result Post(const std::string &path, size_t content_length, ContentProvider content_provider,
-	            const std::string &content_type);
-	Result Post(const std::string &path, ContentProviderWithoutLength content_provider,
-	            const std::string &content_type);
-	Result Post(const std::string &path, const Headers &headers, size_t content_length,
-	            ContentProvider content_provider, const std::string &content_type);
-	Result Post(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
-	            const std::string &content_type);
-	Result Post(const std::string &path, const Params &params);
-	Result Post(const std::string &path, const Headers &headers, const Params &params);
-	Result Post(const std::string &path, const MultipartFormDataItems &items);
-	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items);
-	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-	            const std::string &boundary);
-	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-	            const MultipartFormDataProviderItems &provider_items);
+  Result Post(const std::string &path);
+  Result Post(const std::string &path, const Headers &headers);
+  Result Post(const std::string &path, const char *body, size_t content_length,
+              const std::string &content_type);
+  Result Post(const std::string &path, const Headers &headers, const char *body,
+              size_t content_length, const std::string &content_type);
+  Result Post(const std::string &path, const std::string &body,
+              const std::string &content_type);
+  Result Post(const std::string &path, const Headers &headers,
+              const std::string &body, const std::string &content_type);
+  Result Post(const std::string &path, size_t content_length,
+              ContentProvider content_provider,
+              const std::string &content_type);
+  Result Post(const std::string &path,
+              ContentProviderWithoutLength content_provider,
+              const std::string &content_type);
+  Result Post(const std::string &path, const Headers &headers,
+              size_t content_length, ContentProvider content_provider,
+              const std::string &content_type);
+  Result Post(const std::string &path, const Headers &headers,
+              ContentProviderWithoutLength content_provider,
+              const std::string &content_type);
+  Result Post(const std::string &path, const Params &params);
+  Result Post(const std::string &path, const Headers &headers,
+              const Params &params);
+  Result Post(const std::string &path, const MultipartFormDataItems &items);
+  Result Post(const std::string &path, const Headers &headers,
+              const MultipartFormDataItems &items);
+  Result Post(const std::string &path, const Headers &headers,
+              const MultipartFormDataItems &items, const std::string &boundary);
+  Result Post(const std::string &path, const Headers &headers,
+              const MultipartFormDataItems &items,
+              const MultipartFormDataProviderItems &provider_items);
 
-	Result Put(const std::string &path);
-	Result Put(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
-	Result Put(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-	           const std::string &content_type);
-	Result Put(const std::string &path, const std::string &body, const std::string &content_type);
-	Result Put(const std::string &path, const Headers &headers, const std::string &body,
-	           const std::string &content_type);
-	Result Put(const std::string &path, size_t content_length, ContentProvider content_provider,
-	           const std::string &content_type);
-	Result Put(const std::string &path, ContentProviderWithoutLength content_provider, const std::string &content_type);
-	Result Put(const std::string &path, const Headers &headers, size_t content_length, ContentProvider content_provider,
-	           const std::string &content_type);
-	Result Put(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
-	           const std::string &content_type);
-	Result Put(const std::string &path, const Params &params);
-	Result Put(const std::string &path, const Headers &headers, const Params &params);
-	Result Put(const std::string &path, const MultipartFormDataItems &items);
-	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items);
-	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-	           const std::string &boundary);
-	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-	           const MultipartFormDataProviderItems &provider_items);
+  Result Put(const std::string &path);
+  Result Put(const std::string &path, const char *body, size_t content_length,
+             const std::string &content_type);
+  Result Put(const std::string &path, const Headers &headers, const char *body,
+             size_t content_length, const std::string &content_type);
+  Result Put(const std::string &path, const std::string &body,
+             const std::string &content_type);
+  Result Put(const std::string &path, const Headers &headers,
+             const std::string &body, const std::string &content_type);
+  Result Put(const std::string &path, size_t content_length,
+             ContentProvider content_provider, const std::string &content_type);
+  Result Put(const std::string &path,
+             ContentProviderWithoutLength content_provider,
+             const std::string &content_type);
+  Result Put(const std::string &path, const Headers &headers,
+             size_t content_length, ContentProvider content_provider,
+             const std::string &content_type);
+  Result Put(const std::string &path, const Headers &headers,
+             ContentProviderWithoutLength content_provider,
+             const std::string &content_type);
+  Result Put(const std::string &path, const Params &params);
+  Result Put(const std::string &path, const Headers &headers,
+             const Params &params);
+  Result Put(const std::string &path, const MultipartFormDataItems &items);
+  Result Put(const std::string &path, const Headers &headers,
+             const MultipartFormDataItems &items);
+  Result Put(const std::string &path, const Headers &headers,
+             const MultipartFormDataItems &items, const std::string &boundary);
+  Result Put(const std::string &path, const Headers &headers,
+             const MultipartFormDataItems &items,
+             const MultipartFormDataProviderItems &provider_items);
 
-	Result Patch(const std::string &path);
-	Result Patch(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
-	Result Patch(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-	             const std::string &content_type);
-	Result Patch(const std::string &path, const std::string &body, const std::string &content_type);
-	Result Patch(const std::string &path, const Headers &headers, const std::string &body,
-	             const std::string &content_type);
-	Result Patch(const std::string &path, size_t content_length, ContentProvider content_provider,
-	             const std::string &content_type);
-	Result Patch(const std::string &path, ContentProviderWithoutLength content_provider,
-	             const std::string &content_type);
-	Result Patch(const std::string &path, const Headers &headers, size_t content_length,
-	             ContentProvider content_provider, const std::string &content_type);
-	Result Patch(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
-	             const std::string &content_type);
+  Result Patch(const std::string &path);
+  Result Patch(const std::string &path, const char *body, size_t content_length,
+               const std::string &content_type);
+  Result Patch(const std::string &path, const Headers &headers,
+               const char *body, size_t content_length,
+               const std::string &content_type);
+  Result Patch(const std::string &path, const std::string &body,
+               const std::string &content_type);
+  Result Patch(const std::string &path, const Headers &headers,
+               const std::string &body, const std::string &content_type);
+  Result Patch(const std::string &path, size_t content_length,
+               ContentProvider content_provider,
+               const std::string &content_type);
+  Result Patch(const std::string &path,
+               ContentProviderWithoutLength content_provider,
+               const std::string &content_type);
+  Result Patch(const std::string &path, const Headers &headers,
+               size_t content_length, ContentProvider content_provider,
+               const std::string &content_type);
+  Result Patch(const std::string &path, const Headers &headers,
+               ContentProviderWithoutLength content_provider,
+               const std::string &content_type);
 
-	Result Delete(const std::string &path);
-	Result Delete(const std::string &path, const Headers &headers);
-	Result Delete(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
-	Result Delete(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-	              const std::string &content_type);
-	Result Delete(const std::string &path, const std::string &body, const std::string &content_type);
-	Result Delete(const std::string &path, const Headers &headers, const std::string &body,
-	              const std::string &content_type);
+  Result Delete(const std::string &path);
+  Result Delete(const std::string &path, const Headers &headers);
+  Result Delete(const std::string &path, const char *body,
+                size_t content_length, const std::string &content_type);
+  Result Delete(const std::string &path, const Headers &headers,
+                const char *body, size_t content_length,
+                const std::string &content_type);
+  Result Delete(const std::string &path, const std::string &body,
+                const std::string &content_type);
+  Result Delete(const std::string &path, const Headers &headers,
+                const std::string &body, const std::string &content_type);
 
-	Result Options(const std::string &path);
-	Result Options(const std::string &path, const Headers &headers);
+  Result Options(const std::string &path);
+  Result Options(const std::string &path, const Headers &headers);
 
-	bool send(Request &req, Response &res, Error &error);
-	Result send(const Request &req);
+  bool send(Request &req, Response &res, Error &error);
+  Result send(const Request &req);
 
-	void stop();
+  void stop();
 
-	std::string host() const;
-	int port() const;
+  std::string host() const;
+  int port() const;
 
-	size_t is_socket_open() const;
-	socket_t socket() const;
+  size_t is_socket_open() const;
+  socket_t socket() const;
 
-	void set_hostname_addr_map(std::map<std::string, std::string> addr_map);
+  void set_hostname_addr_map(std::map<std::string, std::string> addr_map);
 
-	void set_default_headers(Headers headers);
+  void set_default_headers(Headers headers);
 
-	void set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
+  void
+  set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
 
-	void set_address_family(int family);
-	void set_tcp_nodelay(bool on);
-	void set_socket_options(SocketOptions socket_options);
+  void set_address_family(int family);
+  void set_tcp_nodelay(bool on);
+  void set_socket_options(SocketOptions socket_options);
 
-	void set_connection_timeout(time_t sec, time_t usec = 0);
-	template <class Rep, class Period>
-	void set_connection_timeout(const std::chrono::duration<Rep, Period> &duration);
+  void set_connection_timeout(time_t sec, time_t usec = 0);
+  template <class Rep, class Period>
+  void
+  set_connection_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-	void set_read_timeout(time_t sec, time_t usec = 0);
-	template <class Rep, class Period>
-	void set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
+  void set_read_timeout(time_t sec, time_t usec = 0);
+  template <class Rep, class Period>
+  void set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-	void set_write_timeout(time_t sec, time_t usec = 0);
-	template <class Rep, class Period>
-	void set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
+  void set_write_timeout(time_t sec, time_t usec = 0);
+  template <class Rep, class Period>
+  void set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-	void set_basic_auth(const std::string &username, const std::string &password);
-	void set_bearer_token_auth(const std::string &token);
+  void set_basic_auth(const std::string &username, const std::string &password);
+  void set_bearer_token_auth(const std::string &token);
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	void set_digest_auth(const std::string &username, const std::string &password);
+  void set_digest_auth(const std::string &username,
+                       const std::string &password);
 #endif
 
-	void set_keep_alive(bool on);
-	void set_follow_location(bool on);
+  void set_keep_alive(bool on);
+  void set_follow_location(bool on);
 
-	void set_url_encode(bool on);
+  void set_url_encode(bool on);
 
-	void set_compress(bool on);
+  void set_compress(bool on);
 
-	void set_decompress(bool on);
+  void set_decompress(bool on);
 
-	void set_interface(const std::string &intf);
+  void set_interface(const std::string &intf);
 
-	void set_proxy(const std::string &host, int port);
-	void set_proxy_basic_auth(const std::string &username, const std::string &password);
-	void set_proxy_bearer_token_auth(const std::string &token);
+  void set_proxy(const std::string &host, int port);
+  void set_proxy_basic_auth(const std::string &username,
+                            const std::string &password);
+  void set_proxy_bearer_token_auth(const std::string &token);
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	void set_proxy_digest_auth(const std::string &username, const std::string &password);
+  void set_proxy_digest_auth(const std::string &username,
+                             const std::string &password);
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	void enable_server_certificate_verification(bool enabled);
+  void enable_server_certificate_verification(bool enabled);
 #endif
 
-	void set_logger(Logger logger);
+  void set_logger(Logger logger);
 
-	// SSL
+  // SSL
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	void set_ca_cert_path(const std::string &ca_cert_file_path, const std::string &ca_cert_dir_path = std::string());
+  void set_ca_cert_path(const std::string &ca_cert_file_path,
+                        const std::string &ca_cert_dir_path = std::string());
 
-	void set_ca_cert_store(X509_STORE *ca_cert_store);
-	void load_ca_cert_store(const char *ca_cert, std::size_t size);
+  void set_ca_cert_store(X509_STORE *ca_cert_store);
+  void load_ca_cert_store(const char *ca_cert, std::size_t size);
 
-	long get_openssl_verify_result() const;
+  long get_openssl_verify_result() const;
 
-	SSL_CTX *ssl_context() const;
+  SSL_CTX *ssl_context() const;
 #endif
 
 private:
-	duckdb::unique_ptr<ClientImpl> cli_;
+  duckdb::unique_ptr<ClientImpl> cli_;
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	bool is_ssl_ = false;
+  bool is_ssl_ = false;
 #endif
 };
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 class SSLServer : public Server {
 public:
-	SSLServer(const char *cert_path, const char *private_key_path, const char *client_ca_cert_file_path = nullptr,
-	          const char *client_ca_cert_dir_path = nullptr, const char *private_key_password = nullptr);
+  SSLServer(const char *cert_path, const char *private_key_path,
+            const char *client_ca_cert_file_path = nullptr,
+            const char *client_ca_cert_dir_path = nullptr,
+            const char *private_key_password = nullptr);
 
-	SSLServer(X509 *cert, EVP_PKEY *private_key, X509_STORE *client_ca_cert_store = nullptr);
+  SSLServer(X509 *cert, EVP_PKEY *private_key,
+            X509_STORE *client_ca_cert_store = nullptr);
 
-	SSLServer(const std::function<bool(SSL_CTX &ssl_ctx)> &setup_ssl_ctx_callback);
+  SSLServer(
+      const std::function<bool(SSL_CTX &ssl_ctx)> &setup_ssl_ctx_callback);
 
-	~SSLServer() override;
+  ~SSLServer() override;
 
-	bool is_valid() const override;
+  bool is_valid() const override;
 
-	SSL_CTX *ssl_context() const;
+  SSL_CTX *ssl_context() const;
 
 private:
-	bool process_and_close_socket(socket_t sock) override;
+  bool process_and_close_socket(socket_t sock) override;
 
-	SSL_CTX *ctx_;
-	std::mutex ctx_mutex_;
+  SSL_CTX *ctx_;
+  std::mutex ctx_mutex_;
 };
 
 class SSLClient : public ClientImpl {
 public:
-	explicit SSLClient(const std::string &host);
+  explicit SSLClient(const std::string &host);
 
-	explicit SSLClient(const std::string &host, int port);
+  explicit SSLClient(const std::string &host, int port);
 
-	explicit SSLClient(const std::string &host, int port, const std::string &client_cert_path,
-	                   const std::string &client_key_path);
+  explicit SSLClient(const std::string &host, int port,
+                     const std::string &client_cert_path,
+                     const std::string &client_key_path);
 
-	explicit SSLClient(const std::string &host, int port, X509 *client_cert, EVP_PKEY *client_key);
+  explicit SSLClient(const std::string &host, int port, X509 *client_cert,
+                     EVP_PKEY *client_key);
 
-	~SSLClient() override;
+  ~SSLClient() override;
 
-	bool is_valid() const override;
+  bool is_valid() const override;
 
-	void set_ca_cert_store(X509_STORE *ca_cert_store);
-	void load_ca_cert_store(const char *ca_cert, std::size_t size);
+  void set_ca_cert_store(X509_STORE *ca_cert_store);
+  void load_ca_cert_store(const char *ca_cert, std::size_t size);
 
-	long get_openssl_verify_result() const;
+  long get_openssl_verify_result() const;
 
-	SSL_CTX *ssl_context() const;
+  SSL_CTX *ssl_context() const;
 
 private:
-	bool create_and_connect_socket(Socket &socket, Error &error) override;
-	void shutdown_ssl(Socket &socket, bool shutdown_gracefully) override;
-	void shutdown_ssl_impl(Socket &socket, bool shutdown_gracefully);
+  bool create_and_connect_socket(Socket &socket, Error &error) override;
+  void shutdown_ssl(Socket &socket, bool shutdown_gracefully) override;
+  void shutdown_ssl_impl(Socket &socket, bool shutdown_gracefully);
 
-	bool process_socket(const Socket &socket, std::function<bool(Stream &strm)> callback) override;
-	bool is_ssl() const override;
+  bool process_socket(const Socket &socket,
+                      std::function<bool(Stream &strm)> callback) override;
+  bool is_ssl() const override;
 
-	bool connect_with_proxy(Socket &sock, Response &res, bool &success, Error &error);
-	bool initialize_ssl(Socket &socket, Error &error);
+  bool connect_with_proxy(Socket &sock, Response &res, bool &success,
+                          Error &error);
+  bool initialize_ssl(Socket &socket, Error &error);
 
-	bool load_certs();
+  bool load_certs();
 
-	bool verify_host(X509 *server_cert) const;
-	bool verify_host_with_subject_alt_name(X509 *server_cert) const;
-	bool verify_host_with_common_name(X509 *server_cert) const;
-	bool check_host_name(const char *pattern, size_t pattern_len) const;
+  bool verify_host(X509 *server_cert) const;
+  bool verify_host_with_subject_alt_name(X509 *server_cert) const;
+  bool verify_host_with_common_name(X509 *server_cert) const;
+  bool check_host_name(const char *pattern, size_t pattern_len) const;
 
-	SSL_CTX *ctx_;
-	std::mutex ctx_mutex_;
-	std::once_flag initialize_cert_;
+  SSL_CTX *ctx_;
+  std::mutex ctx_mutex_;
+  std::once_flag initialize_cert_;
 
-	std::vector<std::string> host_components_;
+  std::vector<std::string> host_components_;
 
-	long verify_result_ = 0;
+  long verify_result_ = 0;
 
-	friend class ClientImpl;
+  friend class ClientImpl;
 };
 #endif
 
@@ -1692,298 +1815,252 @@ namespace detail {
 
 template <typename T, typename U>
 inline void duration_to_sec_and_usec(const T &duration, U callback) {
-	auto sec = std::chrono::duration_cast<std::chrono::seconds>(duration).count();
-	auto usec = std::chrono::duration_cast<std::chrono::microseconds>(duration - std::chrono::seconds(sec)).count();
-	callback(static_cast<time_t>(sec), static_cast<time_t>(usec));
+  auto sec = std::chrono::duration_cast<std::chrono::seconds>(duration).count();
+  auto usec = std::chrono::duration_cast<std::chrono::microseconds>(
+                  duration - std::chrono::seconds(sec))
+                  .count();
+  callback(static_cast<time_t>(sec), static_cast<time_t>(usec));
 }
 
-inline uint64_t get_header_value_u64(const Headers &headers, const std::string &key, size_t id, uint64_t def) {
-	auto rng = headers.equal_range(key);
-	auto it = rng.first;
-	std::advance(it, static_cast<ssize_t>(id));
-	if (it != rng.second) {
-		return std::strtoull(it->second.data(), nullptr, 10);
-	}
-	return def;
+inline uint64_t get_header_value_u64(const Headers &headers,
+                                     const std::string &key, size_t id,
+                                     uint64_t def) {
+  auto rng = headers.equal_range(key);
+  auto it = rng.first;
+  std::advance(it, static_cast<ssize_t>(id));
+  if (it != rng.second) {
+    return std::strtoull(it->second.data(), nullptr, 10);
+  }
+  return def;
 }
 
 } // namespace detail
 
-inline uint64_t Request::get_header_value_u64(const std::string &key, size_t id) const {
-	return detail::get_header_value_u64(headers, key, id, 0);
+inline uint64_t Request::get_header_value_u64(const std::string &key,
+                                              size_t id) const {
+  return detail::get_header_value_u64(headers, key, id, 0);
 }
 
-inline uint64_t Response::get_header_value_u64(const std::string &key, size_t id) const {
-	return detail::get_header_value_u64(headers, key, id, 0);
+inline uint64_t Response::get_header_value_u64(const std::string &key,
+                                               size_t id) const {
+  return detail::get_header_value_u64(headers, key, id, 0);
 }
 
 template <typename... Args>
 inline ssize_t Stream::write_format(const char *fmt, const Args &...args) {
-	const auto bufsiz = 2048;
-	std::array<char, bufsiz> buf {};
+  const auto bufsiz = 2048;
+  std::array<char, bufsiz> buf{};
 
-	auto sn = snprintf(buf.data(), buf.size() - 1, fmt, args...);
-	if (sn <= 0) {
-		return sn;
-	}
+  auto sn = snprintf(buf.data(), buf.size() - 1, fmt, args...);
+  if (sn <= 0) { return sn; }
 
-	auto n = static_cast<size_t>(sn);
+  auto n = static_cast<size_t>(sn);
 
-	if (n >= buf.size() - 1) {
-		std::vector<char> glowable_buf(buf.size());
+  if (n >= buf.size() - 1) {
+    std::vector<char> glowable_buf(buf.size());
 
-		while (n >= glowable_buf.size() - 1) {
-			glowable_buf.resize(glowable_buf.size() * 2);
-			n = static_cast<size_t>(snprintf(&glowable_buf[0], glowable_buf.size() - 1, fmt, args...));
-		}
-		return write(&glowable_buf[0], n);
-	} else {
-		return write(buf.data(), n);
-	}
+    while (n >= glowable_buf.size() - 1) {
+      glowable_buf.resize(glowable_buf.size() * 2);
+      n = static_cast<size_t>(
+          snprintf(&glowable_buf[0], glowable_buf.size() - 1, fmt, args...));
+    }
+    return write(&glowable_buf[0], n);
+  } else {
+    return write(buf.data(), n);
+  }
 }
 
 inline void default_socket_options(socket_t sock) {
-	int yes = 1;
+  int yes = 1;
 #ifdef _WIN32
-	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char *>(&yes), sizeof(yes));
-	setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, reinterpret_cast<const char *>(&yes), sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
+             reinterpret_cast<const char *>(&yes), sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
+             reinterpret_cast<const char *>(&yes), sizeof(yes));
 #else
 #ifdef SO_REUSEPORT
-	setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, reinterpret_cast<const void *>(&yes), sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_REUSEPORT,
+             reinterpret_cast<const void *>(&yes), sizeof(yes));
 #else
-	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const void *>(&yes), sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
+             reinterpret_cast<const void *>(&yes), sizeof(yes));
 #endif
 #endif
 }
 
 inline const char *status_message(int status) {
-	switch (status) {
-	case StatusCode::Continue_100:
-		return "Continue";
-	case StatusCode::SwitchingProtocol_101:
-		return "Switching Protocol";
-	case StatusCode::Processing_102:
-		return "Processing";
-	case StatusCode::EarlyHints_103:
-		return "Early Hints";
-	case StatusCode::OK_200:
-		return "OK";
-	case StatusCode::Created_201:
-		return "Created";
-	case StatusCode::Accepted_202:
-		return "Accepted";
-	case StatusCode::NonAuthoritativeInformation_203:
-		return "Non-Authoritative Information";
-	case StatusCode::NoContent_204:
-		return "No Content";
-	case StatusCode::ResetContent_205:
-		return "Reset Content";
-	case StatusCode::PartialContent_206:
-		return "Partial Content";
-	case StatusCode::MultiStatus_207:
-		return "Multi-Status";
-	case StatusCode::AlreadyReported_208:
-		return "Already Reported";
-	case StatusCode::IMUsed_226:
-		return "IM Used";
-	case StatusCode::MultipleChoices_300:
-		return "Multiple Choices";
-	case StatusCode::MovedPermanently_301:
-		return "Moved Permanently";
-	case StatusCode::Found_302:
-		return "Found";
-	case StatusCode::SeeOther_303:
-		return "See Other";
-	case StatusCode::NotModified_304:
-		return "Not Modified";
-	case StatusCode::UseProxy_305:
-		return "Use Proxy";
-	case StatusCode::unused_306:
-		return "unused";
-	case StatusCode::TemporaryRedirect_307:
-		return "Temporary Redirect";
-	case StatusCode::PermanentRedirect_308:
-		return "Permanent Redirect";
-	case StatusCode::BadRequest_400:
-		return "Bad Request";
-	case StatusCode::Unauthorized_401:
-		return "Unauthorized";
-	case StatusCode::PaymentRequired_402:
-		return "Payment Required";
-	case StatusCode::Forbidden_403:
-		return "Forbidden";
-	case StatusCode::NotFound_404:
-		return "Not Found";
-	case StatusCode::MethodNotAllowed_405:
-		return "Method Not Allowed";
-	case StatusCode::NotAcceptable_406:
-		return "Not Acceptable";
-	case StatusCode::ProxyAuthenticationRequired_407:
-		return "Proxy Authentication Required";
-	case StatusCode::RequestTimeout_408:
-		return "Request Timeout";
-	case StatusCode::Conflict_409:
-		return "Conflict";
-	case StatusCode::Gone_410:
-		return "Gone";
-	case StatusCode::LengthRequired_411:
-		return "Length Required";
-	case StatusCode::PreconditionFailed_412:
-		return "Precondition Failed";
-	case StatusCode::PayloadTooLarge_413:
-		return "Payload Too Large";
-	case StatusCode::UriTooLong_414:
-		return "URI Too Long";
-	case StatusCode::UnsupportedMediaType_415:
-		return "Unsupported Media Type";
-	case StatusCode::RangeNotSatisfiable_416:
-		return "Range Not Satisfiable";
-	case StatusCode::ExpectationFailed_417:
-		return "Expectation Failed";
-	case StatusCode::ImATeapot_418:
-		return "I'm a teapot";
-	case StatusCode::MisdirectedRequest_421:
-		return "Misdirected Request";
-	case StatusCode::UnprocessableContent_422:
-		return "Unprocessable Content";
-	case StatusCode::Locked_423:
-		return "Locked";
-	case StatusCode::FailedDependency_424:
-		return "Failed Dependency";
-	case StatusCode::TooEarly_425:
-		return "Too Early";
-	case StatusCode::UpgradeRequired_426:
-		return "Upgrade Required";
-	case StatusCode::PreconditionRequired_428:
-		return "Precondition Required";
-	case StatusCode::TooManyRequests_429:
-		return "Too Many Requests";
-	case StatusCode::RequestHeaderFieldsTooLarge_431:
-		return "Request Header Fields Too Large";
-	case StatusCode::UnavailableForLegalReasons_451:
-		return "Unavailable For Legal Reasons";
-	case StatusCode::NotImplemented_501:
-		return "Not Implemented";
-	case StatusCode::BadGateway_502:
-		return "Bad Gateway";
-	case StatusCode::ServiceUnavailable_503:
-		return "Service Unavailable";
-	case StatusCode::GatewayTimeout_504:
-		return "Gateway Timeout";
-	case StatusCode::HttpVersionNotSupported_505:
-		return "HTTP Version Not Supported";
-	case StatusCode::VariantAlsoNegotiates_506:
-		return "Variant Also Negotiates";
-	case StatusCode::InsufficientStorage_507:
-		return "Insufficient Storage";
-	case StatusCode::LoopDetected_508:
-		return "Loop Detected";
-	case StatusCode::NotExtended_510:
-		return "Not Extended";
-	case StatusCode::NetworkAuthenticationRequired_511:
-		return "Network Authentication Required";
+  switch (status) {
+  case StatusCode::Continue_100: return "Continue";
+  case StatusCode::SwitchingProtocol_101: return "Switching Protocol";
+  case StatusCode::Processing_102: return "Processing";
+  case StatusCode::EarlyHints_103: return "Early Hints";
+  case StatusCode::OK_200: return "OK";
+  case StatusCode::Created_201: return "Created";
+  case StatusCode::Accepted_202: return "Accepted";
+  case StatusCode::NonAuthoritativeInformation_203:
+    return "Non-Authoritative Information";
+  case StatusCode::NoContent_204: return "No Content";
+  case StatusCode::ResetContent_205: return "Reset Content";
+  case StatusCode::PartialContent_206: return "Partial Content";
+  case StatusCode::MultiStatus_207: return "Multi-Status";
+  case StatusCode::AlreadyReported_208: return "Already Reported";
+  case StatusCode::IMUsed_226: return "IM Used";
+  case StatusCode::MultipleChoices_300: return "Multiple Choices";
+  case StatusCode::MovedPermanently_301: return "Moved Permanently";
+  case StatusCode::Found_302: return "Found";
+  case StatusCode::SeeOther_303: return "See Other";
+  case StatusCode::NotModified_304: return "Not Modified";
+  case StatusCode::UseProxy_305: return "Use Proxy";
+  case StatusCode::unused_306: return "unused";
+  case StatusCode::TemporaryRedirect_307: return "Temporary Redirect";
+  case StatusCode::PermanentRedirect_308: return "Permanent Redirect";
+  case StatusCode::BadRequest_400: return "Bad Request";
+  case StatusCode::Unauthorized_401: return "Unauthorized";
+  case StatusCode::PaymentRequired_402: return "Payment Required";
+  case StatusCode::Forbidden_403: return "Forbidden";
+  case StatusCode::NotFound_404: return "Not Found";
+  case StatusCode::MethodNotAllowed_405: return "Method Not Allowed";
+  case StatusCode::NotAcceptable_406: return "Not Acceptable";
+  case StatusCode::ProxyAuthenticationRequired_407:
+    return "Proxy Authentication Required";
+  case StatusCode::RequestTimeout_408: return "Request Timeout";
+  case StatusCode::Conflict_409: return "Conflict";
+  case StatusCode::Gone_410: return "Gone";
+  case StatusCode::LengthRequired_411: return "Length Required";
+  case StatusCode::PreconditionFailed_412: return "Precondition Failed";
+  case StatusCode::PayloadTooLarge_413: return "Payload Too Large";
+  case StatusCode::UriTooLong_414: return "URI Too Long";
+  case StatusCode::UnsupportedMediaType_415: return "Unsupported Media Type";
+  case StatusCode::RangeNotSatisfiable_416: return "Range Not Satisfiable";
+  case StatusCode::ExpectationFailed_417: return "Expectation Failed";
+  case StatusCode::ImATeapot_418: return "I'm a teapot";
+  case StatusCode::MisdirectedRequest_421: return "Misdirected Request";
+  case StatusCode::UnprocessableContent_422: return "Unprocessable Content";
+  case StatusCode::Locked_423: return "Locked";
+  case StatusCode::FailedDependency_424: return "Failed Dependency";
+  case StatusCode::TooEarly_425: return "Too Early";
+  case StatusCode::UpgradeRequired_426: return "Upgrade Required";
+  case StatusCode::PreconditionRequired_428: return "Precondition Required";
+  case StatusCode::TooManyRequests_429: return "Too Many Requests";
+  case StatusCode::RequestHeaderFieldsTooLarge_431:
+    return "Request Header Fields Too Large";
+  case StatusCode::UnavailableForLegalReasons_451:
+    return "Unavailable For Legal Reasons";
+  case StatusCode::NotImplemented_501: return "Not Implemented";
+  case StatusCode::BadGateway_502: return "Bad Gateway";
+  case StatusCode::ServiceUnavailable_503: return "Service Unavailable";
+  case StatusCode::GatewayTimeout_504: return "Gateway Timeout";
+  case StatusCode::HttpVersionNotSupported_505:
+    return "HTTP Version Not Supported";
+  case StatusCode::VariantAlsoNegotiates_506: return "Variant Also Negotiates";
+  case StatusCode::InsufficientStorage_507: return "Insufficient Storage";
+  case StatusCode::LoopDetected_508: return "Loop Detected";
+  case StatusCode::NotExtended_510: return "Not Extended";
+  case StatusCode::NetworkAuthenticationRequired_511:
+    return "Network Authentication Required";
 
-	default:
-	case StatusCode::InternalServerError_500:
-		return "Internal Server Error";
-	}
+  default:
+  case StatusCode::InternalServerError_500: return "Internal Server Error";
+  }
 }
 
 template <class Rep, class Period>
-inline Server &Server::set_read_timeout(const std::chrono::duration<Rep, Period> &duration) {
-	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_read_timeout(sec, usec); });
-	return *this;
+inline Server &
+Server::set_read_timeout(const std::chrono::duration<Rep, Period> &duration) {
+  detail::duration_to_sec_and_usec(
+      duration, [&](time_t sec, time_t usec) { set_read_timeout(sec, usec); });
+  return *this;
 }
 
 template <class Rep, class Period>
-inline Server &Server::set_write_timeout(const std::chrono::duration<Rep, Period> &duration) {
-	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_write_timeout(sec, usec); });
-	return *this;
+inline Server &
+Server::set_write_timeout(const std::chrono::duration<Rep, Period> &duration) {
+  detail::duration_to_sec_and_usec(
+      duration, [&](time_t sec, time_t usec) { set_write_timeout(sec, usec); });
+  return *this;
 }
 
 template <class Rep, class Period>
-inline Server &Server::set_idle_interval(const std::chrono::duration<Rep, Period> &duration) {
-	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_idle_interval(sec, usec); });
-	return *this;
+inline Server &
+Server::set_idle_interval(const std::chrono::duration<Rep, Period> &duration) {
+  detail::duration_to_sec_and_usec(
+      duration, [&](time_t sec, time_t usec) { set_idle_interval(sec, usec); });
+  return *this;
 }
 
 inline std::string to_string(const Error error) {
-	switch (error) {
-	case Error::Success:
-		return "Success (no error)";
-	case Error::Connection:
-		return "Could not establish connection";
-	case Error::BindIPAddress:
-		return "Failed to bind IP address";
-	case Error::Read:
-		return "Failed to read connection";
-	case Error::Write:
-		return "Failed to write connection";
-	case Error::ExceedRedirectCount:
-		return "Maximum redirect count exceeded";
-	case Error::Canceled:
-		return "Connection handling canceled";
-	case Error::SSLConnection:
-		return "SSL connection failed";
-	case Error::SSLLoadingCerts:
-		return "SSL certificate loading failed";
-	case Error::SSLServerVerification:
-		return "SSL server verification failed";
-	case Error::UnsupportedMultipartBoundaryChars:
-		return "Unsupported HTTP multipart boundary characters";
-	case Error::Compression:
-		return "Compression failed";
-	case Error::ConnectionTimeout:
-		return "Connection timed out";
-	case Error::ProxyConnection:
-		return "Proxy connection failed";
-	case Error::Unknown:
-		return "Unknown";
-	default:
-		break;
-	}
+  switch (error) {
+  case Error::Success: return "Success (no error)";
+  case Error::Connection: return "Could not establish connection";
+  case Error::BindIPAddress: return "Failed to bind IP address";
+  case Error::Read: return "Failed to read connection";
+  case Error::Write: return "Failed to write connection";
+  case Error::ExceedRedirectCount: return "Maximum redirect count exceeded";
+  case Error::Canceled: return "Connection handling canceled";
+  case Error::SSLConnection: return "SSL connection failed";
+  case Error::SSLLoadingCerts: return "SSL certificate loading failed";
+  case Error::SSLServerVerification: return "SSL server verification failed";
+  case Error::UnsupportedMultipartBoundaryChars:
+    return "Unsupported HTTP multipart boundary characters";
+  case Error::Compression: return "Compression failed";
+  case Error::ConnectionTimeout: return "Connection timed out";
+  case Error::ProxyConnection: return "Proxy connection failed";
+  case Error::Unknown: return "Unknown";
+  default: break;
+  }
 
-	return "Invalid";
+  return "Invalid";
 }
 
 inline std::ostream &operator<<(std::ostream &os, const Error &obj) {
-	os << to_string(obj);
-	os << " (" << static_cast<std::underlying_type<Error>::type>(obj) << ')';
-	return os;
+  os << to_string(obj);
+  os << " (" << static_cast<std::underlying_type<Error>::type>(obj) << ')';
+  return os;
 }
 
-inline uint64_t Result::get_request_header_value_u64(const std::string &key, size_t id) const {
-	return detail::get_header_value_u64(request_headers_, key, id, 0);
-}
-
-template <class Rep, class Period>
-inline void ClientImpl::set_connection_timeout(const std::chrono::duration<Rep, Period> &duration) {
-	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_connection_timeout(sec, usec); });
+inline uint64_t Result::get_request_header_value_u64(const std::string &key,
+                                                     size_t id) const {
+  return detail::get_header_value_u64(request_headers_, key, id, 0);
 }
 
 template <class Rep, class Period>
-inline void ClientImpl::set_read_timeout(const std::chrono::duration<Rep, Period> &duration) {
-	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_read_timeout(sec, usec); });
+inline void ClientImpl::set_connection_timeout(
+    const std::chrono::duration<Rep, Period> &duration) {
+  detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) {
+    set_connection_timeout(sec, usec);
+  });
 }
 
 template <class Rep, class Period>
-inline void ClientImpl::set_write_timeout(const std::chrono::duration<Rep, Period> &duration) {
-	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_write_timeout(sec, usec); });
+inline void ClientImpl::set_read_timeout(
+    const std::chrono::duration<Rep, Period> &duration) {
+  detail::duration_to_sec_and_usec(
+      duration, [&](time_t sec, time_t usec) { set_read_timeout(sec, usec); });
 }
 
 template <class Rep, class Period>
-inline void Client::set_connection_timeout(const std::chrono::duration<Rep, Period> &duration) {
-	cli_->set_connection_timeout(duration);
+inline void ClientImpl::set_write_timeout(
+    const std::chrono::duration<Rep, Period> &duration) {
+  detail::duration_to_sec_and_usec(
+      duration, [&](time_t sec, time_t usec) { set_write_timeout(sec, usec); });
 }
 
 template <class Rep, class Period>
-inline void Client::set_read_timeout(const std::chrono::duration<Rep, Period> &duration) {
-	cli_->set_read_timeout(duration);
+inline void Client::set_connection_timeout(
+    const std::chrono::duration<Rep, Period> &duration) {
+  cli_->set_connection_timeout(duration);
 }
 
 template <class Rep, class Period>
-inline void Client::set_write_timeout(const std::chrono::duration<Rep, Period> &duration) {
-	cli_->set_write_timeout(duration);
+inline void
+Client::set_read_timeout(const std::chrono::duration<Rep, Period> &duration) {
+  cli_->set_read_timeout(duration);
+}
+
+template <class Rep, class Period>
+inline void
+Client::set_write_timeout(const std::chrono::duration<Rep, Period> &duration) {
+  cli_->set_write_timeout(duration);
 }
 
 /*
@@ -2000,7 +2077,9 @@ std::string append_query_params(const std::string &path, const Params &params);
 std::pair<std::string, std::string> make_range_header(Ranges ranges);
 
 std::pair<std::string, std::string>
-make_basic_authentication_header(const std::string &username, const std::string &password, bool is_proxy = false);
+make_basic_authentication_header(const std::string &username,
+                                 const std::string &password,
+                                 bool is_proxy = false);
 
 namespace detail {
 
@@ -2011,26 +2090,33 @@ void read_file(const std::string &path, std::string &out);
 
 std::string trim_copy(const std::string &s);
 
-void split(const char *b, const char *e, char d, std::function<void(const char *, const char *)> fn);
+void split(const char *b, const char *e, char d,
+           std::function<void(const char *, const char *)> fn);
 
-void split(const char *b, const char *e, char d, size_t m, std::function<void(const char *, const char *)> fn);
+void split(const char *b, const char *e, char d, size_t m,
+           std::function<void(const char *, const char *)> fn);
 
-bool process_client_socket(socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
-                           time_t write_timeout_usec, std::function<bool(Stream &)> callback);
+bool process_client_socket(socket_t sock, time_t read_timeout_sec,
+                           time_t read_timeout_usec, time_t write_timeout_sec,
+                           time_t write_timeout_usec,
+                           std::function<bool(Stream &)> callback);
 
-socket_t create_client_socket(const std::string &host, const std::string &ip, int port, int address_family,
-                              bool tcp_nodelay, SocketOptions socket_options, time_t connection_timeout_sec,
-                              time_t connection_timeout_usec, time_t read_timeout_sec, time_t read_timeout_usec,
-                              time_t write_timeout_sec, time_t write_timeout_usec, const std::string &intf,
-                              Error &error);
+socket_t create_client_socket(
+    const std::string &host, const std::string &ip, int port,
+    int address_family, bool tcp_nodelay, SocketOptions socket_options,
+    time_t connection_timeout_sec, time_t connection_timeout_usec,
+    time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
+    time_t write_timeout_usec, const std::string &intf, Error &error);
 
-const char *get_header_value(const Headers &headers, const std::string &key, size_t id = 0, const char *def = nullptr);
+const char *get_header_value(const Headers &headers, const std::string &key,
+                             size_t id = 0, const char *def = nullptr);
 
 std::string params_to_query_str(const Params &params);
 
 void parse_query_text(const std::string &s, Params &params);
 
-bool parse_multipart_boundary(const std::string &content_type, std::string &boundary);
+bool parse_multipart_boundary(const std::string &content_type,
+                              std::string &boundary);
 
 bool parse_range_header(const std::string &s, Ranges &ranges);
 
@@ -2046,101 +2132,108 @@ EncodingType encoding_type(const Request &req, const Response &res);
 
 class BufferStream : public Stream {
 public:
-	BufferStream() = default;
-	~BufferStream() override = default;
+  BufferStream() = default;
+  ~BufferStream() override = default;
 
-	bool is_readable() const override;
-	bool is_writable() const override;
-	ssize_t read(char *ptr, size_t size) override;
-	ssize_t write(const char *ptr, size_t size) override;
-	void get_remote_ip_and_port(std::string &ip, int &port) const override;
-	void get_local_ip_and_port(std::string &ip, int &port) const override;
-	socket_t socket() const override;
+  bool is_readable() const override;
+  bool is_writable() const override;
+  ssize_t read(char *ptr, size_t size) override;
+  ssize_t write(const char *ptr, size_t size) override;
+  void get_remote_ip_and_port(std::string &ip, int &port) const override;
+  void get_local_ip_and_port(std::string &ip, int &port) const override;
+  socket_t socket() const override;
 
-	const std::string &get_buffer() const;
+  const std::string &get_buffer() const;
 
 private:
-	std::string buffer;
-	size_t position = 0;
+  std::string buffer;
+  size_t position = 0;
 };
 
 class compressor {
 public:
-	virtual ~compressor() = default;
+  virtual ~compressor() = default;
 
-	typedef std::function<bool(const char *data, size_t data_len)> Callback;
-	virtual bool compress(const char *data, size_t data_length, bool last, Callback callback) = 0;
+  typedef std::function<bool(const char *data, size_t data_len)> Callback;
+  virtual bool compress(const char *data, size_t data_length, bool last,
+                        Callback callback) = 0;
 };
 
 class decompressor {
 public:
-	virtual ~decompressor() = default;
+  virtual ~decompressor() = default;
 
-	virtual bool is_valid() const = 0;
+  virtual bool is_valid() const = 0;
 
-	typedef std::function<bool(const char *data, size_t data_len)> Callback;
-	virtual bool decompress(const char *data, size_t data_length, Callback callback) = 0;
+  typedef std::function<bool(const char *data, size_t data_len)> Callback;
+  virtual bool decompress(const char *data, size_t data_length,
+                          Callback callback) = 0;
 };
 
 class nocompressor : public compressor {
 public:
-	~nocompressor() override = default;
+  ~nocompressor() override = default;
 
-	bool compress(const char *data, size_t data_length, bool /*last*/, Callback callback) override;
+  bool compress(const char *data, size_t data_length, bool /*last*/,
+                Callback callback) override;
 };
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
 class gzip_compressor : public compressor {
 public:
-	gzip_compressor();
-	~gzip_compressor() override;
+  gzip_compressor();
+  ~gzip_compressor() override;
 
-	bool compress(const char *data, size_t data_length, bool last, Callback callback) override;
+  bool compress(const char *data, size_t data_length, bool last,
+                Callback callback) override;
 
 private:
-	bool is_valid_ = false;
-	z_stream strm_;
+  bool is_valid_ = false;
+  z_stream strm_;
 };
 
 class gzip_decompressor : public decompressor {
 public:
-	gzip_decompressor();
-	~gzip_decompressor() override;
+  gzip_decompressor();
+  ~gzip_decompressor() override;
 
-	bool is_valid() const override;
+  bool is_valid() const override;
 
-	bool decompress(const char *data, size_t data_length, Callback callback) override;
+  bool decompress(const char *data, size_t data_length,
+                  Callback callback) override;
 
 private:
-	bool is_valid_ = false;
-	z_stream strm_;
+  bool is_valid_ = false;
+  z_stream strm_;
 };
 #endif
 
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
 class brotli_compressor : public compressor {
 public:
-	brotli_compressor();
-	~brotli_compressor();
+  brotli_compressor();
+  ~brotli_compressor();
 
-	bool compress(const char *data, size_t data_length, bool last, Callback callback) override;
+  bool compress(const char *data, size_t data_length, bool last,
+                Callback callback) override;
 
 private:
-	BrotliEncoderState *state_ = nullptr;
+  BrotliEncoderState *state_ = nullptr;
 };
 
 class brotli_decompressor : public decompressor {
 public:
-	brotli_decompressor();
-	~brotli_decompressor();
+  brotli_decompressor();
+  ~brotli_decompressor();
 
-	bool is_valid() const override;
+  bool is_valid() const override;
 
-	bool decompress(const char *data, size_t data_length, Callback callback) override;
+  bool decompress(const char *data, size_t data_length,
+                  Callback callback) override;
 
 private:
-	BrotliDecoderResult decoder_r;
-	BrotliDecoderState *decoder_s = nullptr;
+  BrotliDecoderResult decoder_r;
+  BrotliDecoderState *decoder_s = nullptr;
 };
 #endif
 
@@ -2148,43 +2241,44 @@ private:
 // to store data. The call can set memory on stack for performance.
 class stream_line_reader {
 public:
-	stream_line_reader(Stream &strm, char *fixed_buffer, size_t fixed_buffer_size);
-	const char *ptr() const;
-	size_t size() const;
-	bool end_with_crlf() const;
-	bool getline();
+  stream_line_reader(Stream &strm, char *fixed_buffer,
+                     size_t fixed_buffer_size);
+  const char *ptr() const;
+  size_t size() const;
+  bool end_with_crlf() const;
+  bool getline();
 
 private:
-	void append(char c);
+  void append(char c);
 
-	Stream &strm_;
-	char *fixed_buffer_;
-	const size_t fixed_buffer_size_;
-	size_t fixed_buffer_used_size_ = 0;
-	std::string glowable_buffer_;
+  Stream &strm_;
+  char *fixed_buffer_;
+  const size_t fixed_buffer_size_;
+  size_t fixed_buffer_used_size_ = 0;
+  std::string glowable_buffer_;
 };
 
 class mmap {
 public:
-	mmap(const char *path);
-	~mmap();
+  mmap(const char *path);
+  ~mmap();
 
-	bool open(const char *path);
-	void close();
+  bool open(const char *path);
+  void close();
 
-	bool is_open() const;
-	size_t size() const;
-	const char *data() const;
+  bool is_open() const;
+  size_t size() const;
+  const char *data() const;
 
 private:
 #if defined(_WIN32)
-	HANDLE hFile_;
-	HANDLE hMapping_;
+  HANDLE hFile_;
+  HANDLE hMapping_;
 #else
-	int fd_;
+  int fd_;
 #endif
-	size_t size_;
-	void *addr_;
+  size_t size_;
+  void *addr_;
 };
 
 } // namespace detail
@@ -2198,406 +2292,384 @@ private:
 namespace detail {
 
 inline bool is_hex(char c, int &v) {
-	if (0x20 <= c && isdigit(c)) {
-		v = c - '0';
-		return true;
-	} else if ('A' <= c && c <= 'F') {
-		v = c - 'A' + 10;
-		return true;
-	} else if ('a' <= c && c <= 'f') {
-		v = c - 'a' + 10;
-		return true;
-	}
-	return false;
+  if (0x20 <= c && isdigit(c)) {
+    v = c - '0';
+    return true;
+  } else if ('A' <= c && c <= 'F') {
+    v = c - 'A' + 10;
+    return true;
+  } else if ('a' <= c && c <= 'f') {
+    v = c - 'a' + 10;
+    return true;
+  }
+  return false;
 }
 
-inline bool from_hex_to_i(const std::string &s, size_t i, size_t cnt, int &val) {
-	if (i >= s.size()) {
-		return false;
-	}
+inline bool from_hex_to_i(const std::string &s, size_t i, size_t cnt,
+                          int &val) {
+  if (i >= s.size()) { return false; }
 
-	val = 0;
-	for (; cnt; i++, cnt--) {
-		if (!s[i]) {
-			return false;
-		}
-		auto v = 0;
-		if (is_hex(s[i], v)) {
-			val = val * 16 + v;
-		} else {
-			return false;
-		}
-	}
-	return true;
+  val = 0;
+  for (; cnt; i++, cnt--) {
+    if (!s[i]) { return false; }
+    auto v = 0;
+    if (is_hex(s[i], v)) {
+      val = val * 16 + v;
+    } else {
+      return false;
+    }
+  }
+  return true;
 }
 
 inline std::string from_i_to_hex(size_t n) {
-	static const auto charset = "0123456789abcdef";
-	std::string ret;
-	do {
-		ret = charset[n & 15] + ret;
-		n >>= 4;
-	} while (n > 0);
-	return ret;
+  static const auto charset = "0123456789abcdef";
+  std::string ret;
+  do {
+    ret = charset[n & 15] + ret;
+    n >>= 4;
+  } while (n > 0);
+  return ret;
 }
 
 inline size_t to_utf8(int code, char *buff) {
-	if (code < 0x0080) {
-		buff[0] = static_cast<char>(code & 0x7F);
-		return 1;
-	} else if (code < 0x0800) {
-		buff[0] = static_cast<char>(0xC0 | ((code >> 6) & 0x1F));
-		buff[1] = static_cast<char>(0x80 | (code & 0x3F));
-		return 2;
-	} else if (code < 0xD800) {
-		buff[0] = static_cast<char>(0xE0 | ((code >> 12) & 0xF));
-		buff[1] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
-		buff[2] = static_cast<char>(0x80 | (code & 0x3F));
-		return 3;
-	} else if (code < 0xE000) { // D800 - DFFF is invalid...
-		return 0;
-	} else if (code < 0x10000) {
-		buff[0] = static_cast<char>(0xE0 | ((code >> 12) & 0xF));
-		buff[1] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
-		buff[2] = static_cast<char>(0x80 | (code & 0x3F));
-		return 3;
-	} else if (code < 0x110000) {
-		buff[0] = static_cast<char>(0xF0 | ((code >> 18) & 0x7));
-		buff[1] = static_cast<char>(0x80 | ((code >> 12) & 0x3F));
-		buff[2] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
-		buff[3] = static_cast<char>(0x80 | (code & 0x3F));
-		return 4;
-	}
+  if (code < 0x0080) {
+    buff[0] = static_cast<char>(code & 0x7F);
+    return 1;
+  } else if (code < 0x0800) {
+    buff[0] = static_cast<char>(0xC0 | ((code >> 6) & 0x1F));
+    buff[1] = static_cast<char>(0x80 | (code & 0x3F));
+    return 2;
+  } else if (code < 0xD800) {
+    buff[0] = static_cast<char>(0xE0 | ((code >> 12) & 0xF));
+    buff[1] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
+    buff[2] = static_cast<char>(0x80 | (code & 0x3F));
+    return 3;
+  } else if (code < 0xE000) { // D800 - DFFF is invalid...
+    return 0;
+  } else if (code < 0x10000) {
+    buff[0] = static_cast<char>(0xE0 | ((code >> 12) & 0xF));
+    buff[1] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
+    buff[2] = static_cast<char>(0x80 | (code & 0x3F));
+    return 3;
+  } else if (code < 0x110000) {
+    buff[0] = static_cast<char>(0xF0 | ((code >> 18) & 0x7));
+    buff[1] = static_cast<char>(0x80 | ((code >> 12) & 0x3F));
+    buff[2] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
+    buff[3] = static_cast<char>(0x80 | (code & 0x3F));
+    return 4;
+  }
 
-	// NOTREACHED
-	return 0;
+  // NOTREACHED
+  return 0;
 }
 
 // NOTE: This code came up with the following stackoverflow post:
 // https://stackoverflow.com/questions/180947/base64-decode-snippet-in-c
 inline std::string base64_encode(const std::string &in) {
-	static const auto lookup = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  static const auto lookup =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-	std::string out;
-	out.reserve(in.size());
+  std::string out;
+  out.reserve(in.size());
 
-	unsigned int val = 0;
-	int valb = -6;
+  unsigned int val = 0;
+  int valb = -6;
 
-	for (auto c : in) {
-		val = (val << 8) + static_cast<uint8_t>(c);
-		valb += 8;
-		while (valb >= 0) {
-			out.push_back(lookup[(val >> valb) & 0x3F]);
-			valb -= 6;
-		}
-	}
+  for (auto c : in) {
+    val = (val << 8) + static_cast<uint8_t>(c);
+    valb += 8;
+    while (valb >= 0) {
+      out.push_back(lookup[(val >> valb) & 0x3F]);
+      valb -= 6;
+    }
+  }
 
-	if (valb > -6) {
-		out.push_back(lookup[((val << 8) >> (valb + 8)) & 0x3F]);
-	}
+  if (valb > -6) { out.push_back(lookup[((val << 8) >> (valb + 8)) & 0x3F]); }
 
-	while (out.size() % 4) {
-		out.push_back('=');
-	}
+  while (out.size() % 4) {
+    out.push_back('=');
+  }
 
-	return out;
+  return out;
 }
 
 inline bool is_file(const std::string &path) {
 #ifdef _WIN32
-	return _access_s(path.c_str(), 0) == 0;
+  return _access_s(path.c_str(), 0) == 0;
 #else
-	struct stat st;
-	return stat(path.c_str(), &st) >= 0 && S_ISREG(st.st_mode);
+  struct stat st;
+  return stat(path.c_str(), &st) >= 0 && S_ISREG(st.st_mode);
 #endif
 }
 
 inline bool is_dir(const std::string &path) {
-	struct stat st;
-	return stat(path.c_str(), &st) >= 0 && S_ISDIR(st.st_mode);
+  struct stat st;
+  return stat(path.c_str(), &st) >= 0 && S_ISDIR(st.st_mode);
 }
 
 inline bool is_valid_path(const std::string &path) {
-	size_t level = 0;
-	size_t i = 0;
+  size_t level = 0;
+  size_t i = 0;
 
-	// Skip slash
-	while (i < path.size() && path[i] == '/') {
-		i++;
-	}
+  // Skip slash
+  while (i < path.size() && path[i] == '/') {
+    i++;
+  }
 
-	while (i < path.size()) {
-		// Read component
-		auto beg = i;
-		while (i < path.size() && path[i] != '/') {
-			i++;
-		}
+  while (i < path.size()) {
+    // Read component
+    auto beg = i;
+    while (i < path.size() && path[i] != '/') {
+      i++;
+    }
 
-		auto len = i - beg;
-		assert(len > 0);
+    auto len = i - beg;
+    assert(len > 0);
 
-		if (!path.compare(beg, len, ".")) {
-			;
-		} else if (!path.compare(beg, len, "..")) {
-			if (level == 0) {
-				return false;
-			}
-			level--;
-		} else {
-			level++;
-		}
+    if (!path.compare(beg, len, ".")) {
+      ;
+    } else if (!path.compare(beg, len, "..")) {
+      if (level == 0) { return false; }
+      level--;
+    } else {
+      level++;
+    }
 
-		// Skip slash
-		while (i < path.size() && path[i] == '/') {
-			i++;
-		}
-	}
+    // Skip slash
+    while (i < path.size() && path[i] == '/') {
+      i++;
+    }
+  }
 
-	return true;
+  return true;
 }
 
 inline std::string encode_query_param(const std::string &value) {
-	std::ostringstream escaped;
-	escaped.fill('0');
-	escaped << std::hex;
+  std::ostringstream escaped;
+  escaped.fill('0');
+  escaped << std::hex;
 
-	for (auto c : value) {
-		if (std::isalnum(static_cast<uint8_t>(c)) || c == '-' || c == '_' || c == '.' || c == '!' || c == '~' ||
-		    c == '*' || c == '\'' || c == '(' || c == ')') {
-			escaped << c;
-		} else {
-			escaped << std::uppercase;
-			escaped << '%' << std::setw(2) << static_cast<int>(static_cast<unsigned char>(c));
-			escaped << std::nouppercase;
-		}
-	}
+  for (auto c : value) {
+    if (std::isalnum(static_cast<uint8_t>(c)) || c == '-' || c == '_' ||
+        c == '.' || c == '!' || c == '~' || c == '*' || c == '\'' || c == '(' ||
+        c == ')') {
+      escaped << c;
+    } else {
+      escaped << std::uppercase;
+      escaped << '%' << std::setw(2)
+              << static_cast<int>(static_cast<unsigned char>(c));
+      escaped << std::nouppercase;
+    }
+  }
 
-	return escaped.str();
+  return escaped.str();
 }
 
 inline std::string encode_url(const std::string &s) {
-	std::string result;
-	result.reserve(s.size());
+  std::string result;
+  result.reserve(s.size());
 
-	for (size_t i = 0; s[i]; i++) {
-		switch (s[i]) {
-		case ' ':
-			result += "%20";
-			break;
-		case '\r':
-			result += "%0D";
-			break;
-		case '\n':
-			result += "%0A";
-			break;
-		case '\'':
-			result += "%27";
-			break;
-		case ',':
-			result += "%2C";
-			break;
-		// case ':': result += "%3A"; break; // ok? probably...
-		case ';':
-			result += "%3B";
-			break;
-		default:
-			auto c = static_cast<uint8_t>(s[i]);
-			if (c >= 0x80) {
-				result += '%';
-				char hex[4];
-				auto len = snprintf(hex, sizeof(hex) - 1, "%02X", c);
-				assert(len == 2);
-				result.append(hex, static_cast<size_t>(len));
-			} else {
-				result += s[i];
-			}
-			break;
-		}
-	}
+  for (size_t i = 0; s[i]; i++) {
+    switch (s[i]) {
+    case ' ': result += "%20"; break;
+    case '\r': result += "%0D"; break;
+    case '\n': result += "%0A"; break;
+    case '\'': result += "%27"; break;
+    case ',': result += "%2C"; break;
+    // case ':': result += "%3A"; break; // ok? probably...
+    case ';': result += "%3B"; break;
+    default:
+      auto c = static_cast<uint8_t>(s[i]);
+      if (c >= 0x80) {
+        result += '%';
+        char hex[4];
+        auto len = snprintf(hex, sizeof(hex) - 1, "%02X", c);
+        assert(len == 2);
+        result.append(hex, static_cast<size_t>(len));
+      } else {
+        result += s[i];
+      }
+      break;
+    }
+  }
 
-	return result;
+  return result;
 }
 
-inline std::string decode_url(const std::string &s, bool convert_plus_to_space, const std::set<char> &exclude) {
-	std::string result;
+inline std::string decode_url(const std::string &s,
+                              bool convert_plus_to_space,
+                              const std::set<char> &exclude) {
+  std::string result;
 
-	for (size_t i = 0; i < s.size(); i++) {
-		if (s[i] == '%' && i + 1 < s.size()) {
-			if (s[i + 1] == 'u') {
-				auto val = 0;
-				if (from_hex_to_i(s, i + 2, 4, val)) {
-					// 4 digits Unicode codes
-					char buff[4];
-					size_t len = to_utf8(val, buff);
-					if (len > 0) {
-						result.append(buff, len);
-					}
-					i += 5; // 'u0000'
-				} else {
-					result += s[i];
-				}
-			} else {
-				auto val = 0;
-				if (from_hex_to_i(s, i + 1, 2, val)) {
-					const auto converted = static_cast<char>(val);
-					if (exclude.count(converted) == 0) {
-						result += converted;
-					} else {
-						result.append(s, i, 3);
-					}
-					i += 2; // '00'
-				} else {
-					result += s[i];
-				}
-			}
-		} else if (convert_plus_to_space && s[i] == '+') {
-			result += ' ';
-		} else {
-			result += s[i];
-		}
-	}
+  for (size_t i = 0; i < s.size(); i++) {
+    if (s[i] == '%' && i + 1 < s.size()) {
+      if (s[i + 1] == 'u') {
+        auto val = 0;
+        if (from_hex_to_i(s, i + 2, 4, val)) {
+          // 4 digits Unicode codes
+          char buff[4];
+          size_t len = to_utf8(val, buff);
+          if (len > 0) { result.append(buff, len); }
+          i += 5; // 'u0000'
+        } else {
+          result += s[i];
+        }
+      } else {
+        auto val = 0;
+        if (from_hex_to_i(s, i + 1, 2, val)) {
+          const auto converted = static_cast<char>(val);
+          if (exclude.count(converted) == 0) {
+            result += converted;
+          } else {
+            result.append(s, i, 3);
+          }
+          i += 2; // '00'
+        } else {
+          result += s[i];
+        }
+      }
+    } else if (convert_plus_to_space && s[i] == '+') {
+      result += ' ';
+    } else {
+      result += s[i];
+    }
+  }
 
-	return result;
+  return result;
 }
 
 inline void read_file(const std::string &path, std::string &out) {
-	std::ifstream fs(path, std::ios_base::binary);
-	fs.seekg(0, std::ios_base::end);
-	auto size = fs.tellg();
-	fs.seekg(0);
-	out.resize(static_cast<size_t>(size));
-	fs.read(&out[0], static_cast<std::streamsize>(size));
+  std::ifstream fs(path, std::ios_base::binary);
+  fs.seekg(0, std::ios_base::end);
+  auto size = fs.tellg();
+  fs.seekg(0);
+  out.resize(static_cast<size_t>(size));
+  fs.read(&out[0], static_cast<std::streamsize>(size));
 }
 
 inline std::string file_extension(const std::string &path) {
-	Match m;
-	auto re = Regex("\\.([a-zA-Z0-9]+)$");
-	if (duckdb_re2::RegexSearch(path, m, re)) {
-		return m[1].str();
-	}
-	return std::string();
+  Match m;
+  auto re = Regex("\\.([a-zA-Z0-9]+)$");
+  if (duckdb_re2::RegexSearch(path, m, re)) { return m[1].str(); }
+  return std::string();
 }
 
-inline bool is_space_or_tab(char c) {
-	return c == ' ' || c == '\t';
-}
+inline bool is_space_or_tab(char c) { return c == ' ' || c == '\t'; }
 
-inline std::pair<size_t, size_t> trim(const char *b, const char *e, size_t left, size_t right) {
-	while (b + left < e && is_space_or_tab(b[left])) {
-		left++;
-	}
-	while (right > 0 && is_space_or_tab(b[right - 1])) {
-		right--;
-	}
-	return std::make_pair(left, right);
+inline std::pair<size_t, size_t> trim(const char *b, const char *e, size_t left,
+                                      size_t right) {
+  while (b + left < e && is_space_or_tab(b[left])) {
+    left++;
+  }
+  while (right > 0 && is_space_or_tab(b[right - 1])) {
+    right--;
+  }
+  return std::make_pair(left, right);
 }
 
 inline std::string trim_copy(const std::string &s) {
-	auto r = trim(s.data(), s.data() + s.size(), 0, s.size());
-	return s.substr(r.first, r.second - r.first);
+  auto r = trim(s.data(), s.data() + s.size(), 0, s.size());
+  return s.substr(r.first, r.second - r.first);
 }
 
 inline std::string trim_double_quotes_copy(const std::string &s) {
-	if (s.length() >= 2 && s.front() == '"' && s.back() == '"') {
-		return s.substr(1, s.size() - 2);
-	}
-	return s;
+  if (s.length() >= 2 && s.front() == '"' && s.back() == '"') {
+    return s.substr(1, s.size() - 2);
+  }
+  return s;
 }
 
-inline void split(const char *b, const char *e, char d, std::function<void(const char *, const char *)> fn) {
-	return split(b, e, d, static_cast<size_t>((std::numeric_limits<size_t>::max)()), fn);
+inline void split(const char *b, const char *e, char d,
+                  std::function<void(const char *, const char *)> fn) {
+  return split(b, e, d, static_cast<size_t>((std::numeric_limits<size_t>::max)()), fn);
 }
 
-inline void split(const char *b, const char *e, char d, size_t m, std::function<void(const char *, const char *)> fn) {
-	size_t i = 0;
-	size_t beg = 0;
-	size_t count = 1;
+inline void split(const char *b, const char *e, char d, size_t m,
+                  std::function<void(const char *, const char *)> fn) {
+  size_t i = 0;
+  size_t beg = 0;
+  size_t count = 1;
 
-	while (e ? (b + i < e) : (b[i] != '\0')) {
-		if (b[i] == d && count < m) {
-			auto r = trim(b, e, beg, i);
-			if (r.first < r.second) {
-				fn(&b[r.first], &b[r.second]);
-			}
-			beg = i + 1;
-			count++;
-		}
-		i++;
-	}
+  while (e ? (b + i < e) : (b[i] != '\0')) {
+    if (b[i] == d && count < m) {
+      auto r = trim(b, e, beg, i);
+      if (r.first < r.second) { fn(&b[r.first], &b[r.second]); }
+      beg = i + 1;
+      count++;
+    }
+    i++;
+  }
 
-	if (i) {
-		auto r = trim(b, e, beg, i);
-		if (r.first < r.second) {
-			fn(&b[r.first], &b[r.second]);
-		}
-	}
+  if (i) {
+    auto r = trim(b, e, beg, i);
+    if (r.first < r.second) { fn(&b[r.first], &b[r.second]); }
+  }
 }
 
-inline stream_line_reader::stream_line_reader(Stream &strm, char *fixed_buffer, size_t fixed_buffer_size)
-    : strm_(strm), fixed_buffer_(fixed_buffer), fixed_buffer_size_(fixed_buffer_size) {
-}
+inline stream_line_reader::stream_line_reader(Stream &strm, char *fixed_buffer,
+                                              size_t fixed_buffer_size)
+    : strm_(strm), fixed_buffer_(fixed_buffer),
+      fixed_buffer_size_(fixed_buffer_size) {}
 
 inline const char *stream_line_reader::ptr() const {
-	if (glowable_buffer_.empty()) {
-		return fixed_buffer_;
-	} else {
-		return glowable_buffer_.data();
-	}
+  if (glowable_buffer_.empty()) {
+    return fixed_buffer_;
+  } else {
+    return glowable_buffer_.data();
+  }
 }
 
 inline size_t stream_line_reader::size() const {
-	if (glowable_buffer_.empty()) {
-		return fixed_buffer_used_size_;
-	} else {
-		return glowable_buffer_.size();
-	}
+  if (glowable_buffer_.empty()) {
+    return fixed_buffer_used_size_;
+  } else {
+    return glowable_buffer_.size();
+  }
 }
 
 inline bool stream_line_reader::end_with_crlf() const {
-	auto end = ptr() + size();
-	return size() >= 2 && end[-2] == '\r' && end[-1] == '\n';
+  auto end = ptr() + size();
+  return size() >= 2 && end[-2] == '\r' && end[-1] == '\n';
 }
 
 inline bool stream_line_reader::getline() {
-	fixed_buffer_used_size_ = 0;
-	glowable_buffer_.clear();
+  fixed_buffer_used_size_ = 0;
+  glowable_buffer_.clear();
 
-	for (size_t i = 0;; i++) {
-		char byte;
-		auto n = strm_.read(&byte, 1);
+  for (size_t i = 0;; i++) {
+    char byte;
+    auto n = strm_.read(&byte, 1);
 
-		if (n < 0) {
-			return false;
-		} else if (n == 0) {
-			if (i == 0) {
-				return false;
-			} else {
-				break;
-			}
-		}
+    if (n < 0) {
+      return false;
+    } else if (n == 0) {
+      if (i == 0) {
+        return false;
+      } else {
+        break;
+      }
+    }
 
-		append(byte);
+    append(byte);
 
-		if (byte == '\n') {
-			break;
-		}
-	}
+    if (byte == '\n') { break; }
+  }
 
-	return true;
+  return true;
 }
 
 inline void stream_line_reader::append(char c) {
-	if (fixed_buffer_used_size_ < fixed_buffer_size_ - 1) {
-		fixed_buffer_[fixed_buffer_used_size_++] = c;
-		fixed_buffer_[fixed_buffer_used_size_] = '\0';
-	} else {
-		if (glowable_buffer_.empty()) {
-			assert(fixed_buffer_[fixed_buffer_used_size_] == '\0');
-			glowable_buffer_.assign(fixed_buffer_, fixed_buffer_used_size_);
-		}
-		glowable_buffer_ += c;
-	}
+  if (fixed_buffer_used_size_ < fixed_buffer_size_ - 1) {
+    fixed_buffer_[fixed_buffer_used_size_++] = c;
+    fixed_buffer_[fixed_buffer_used_size_] = '\0';
+  } else {
+    if (glowable_buffer_.empty()) {
+      assert(fixed_buffer_[fixed_buffer_used_size_] == '\0');
+      glowable_buffer_.assign(fixed_buffer_, fixed_buffer_used_size_);
+    }
+    glowable_buffer_ += c;
+  }
 }
 
 inline mmap::mmap(const char *path)
@@ -2608,564 +2680,554 @@ inline mmap::mmap(const char *path)
 #endif
       ,
       size_(0), addr_(nullptr) {
-	open(path);
+  open(path);
 }
 
-inline mmap::~mmap() {
-	close();
-}
+inline mmap::~mmap() { close(); }
 
 inline bool mmap::open(const char *path) {
-	close();
+  close();
 
 #if defined(_WIN32)
-	hFile_ = ::CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  hFile_ = ::CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, NULL,
+                         OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
-	if (hFile_ == INVALID_HANDLE_VALUE) {
-		return false;
-	}
+  if (hFile_ == INVALID_HANDLE_VALUE) { return false; }
 
-	size_ = ::GetFileSize(hFile_, NULL);
+  size_ = ::GetFileSize(hFile_, NULL);
 
-	hMapping_ = ::CreateFileMapping(hFile_, NULL, PAGE_READONLY, 0, 0, NULL);
+  hMapping_ = ::CreateFileMapping(hFile_, NULL, PAGE_READONLY, 0, 0, NULL);
 
-	if (hMapping_ == NULL) {
-		close();
-		return false;
-	}
+  if (hMapping_ == NULL) {
+    close();
+    return false;
+  }
 
-	addr_ = ::MapViewOfFile(hMapping_, FILE_MAP_READ, 0, 0, 0);
+  addr_ = ::MapViewOfFile(hMapping_, FILE_MAP_READ, 0, 0, 0);
 #else
-	fd_ = ::open(path, O_RDONLY);
-	if (fd_ == -1) {
-		return false;
-	}
+  fd_ = ::open(path, O_RDONLY);
+  if (fd_ == -1) { return false; }
 
-	struct stat sb;
-	if (fstat(fd_, &sb) == -1) {
-		close();
-		return false;
-	}
-	size_ = static_cast<size_t>(sb.st_size);
+  struct stat sb;
+  if (fstat(fd_, &sb) == -1) {
+    close();
+    return false;
+  }
+  size_ = static_cast<size_t>(sb.st_size);
 
-	addr_ = ::mmap(NULL, size_, PROT_READ, MAP_PRIVATE, fd_, 0);
+  addr_ = ::mmap(NULL, size_, PROT_READ, MAP_PRIVATE, fd_, 0);
 #endif
 
-	if (addr_ == nullptr) {
-		close();
-		return false;
-	}
+  if (addr_ == nullptr) {
+    close();
+    return false;
+  }
 
-	return true;
+  return true;
 }
 
-inline bool mmap::is_open() const {
-	return addr_ != nullptr;
-}
+inline bool mmap::is_open() const { return addr_ != nullptr; }
 
-inline size_t mmap::size() const {
-	return size_;
-}
+inline size_t mmap::size() const { return size_; }
 
-inline const char *mmap::data() const {
-	return (const char *)addr_;
-}
+inline const char *mmap::data() const { return (const char *)addr_; }
 
 inline void mmap::close() {
 #if defined(_WIN32)
-	if (addr_) {
-		::UnmapViewOfFile(addr_);
-		addr_ = nullptr;
-	}
+  if (addr_) {
+    ::UnmapViewOfFile(addr_);
+    addr_ = nullptr;
+  }
 
-	if (hMapping_) {
-		::CloseHandle(hMapping_);
-		hMapping_ = NULL;
-	}
+  if (hMapping_) {
+    ::CloseHandle(hMapping_);
+    hMapping_ = NULL;
+  }
 
-	if (hFile_ != INVALID_HANDLE_VALUE) {
-		::CloseHandle(hFile_);
-		hFile_ = INVALID_HANDLE_VALUE;
-	}
+  if (hFile_ != INVALID_HANDLE_VALUE) {
+    ::CloseHandle(hFile_);
+    hFile_ = INVALID_HANDLE_VALUE;
+  }
 #else
-	if (addr_ != nullptr) {
-		munmap(addr_, size_);
-		addr_ = nullptr;
-	}
+  if (addr_ != nullptr) {
+    munmap(addr_, size_);
+    addr_ = nullptr;
+  }
 
-	if (fd_ != -1) {
-		::close(fd_);
-		fd_ = -1;
-	}
+  if (fd_ != -1) {
+    ::close(fd_);
+    fd_ = -1;
+  }
 #endif
-	size_ = 0;
+  size_ = 0;
 }
 inline int close_socket(socket_t sock) {
 #ifdef _WIN32
-	return closesocket(sock);
+  return closesocket(sock);
 #else
-	return close(sock);
+  return close(sock);
 #endif
 }
 
-template <typename T>
-inline ssize_t handle_EINTR(T fn) {
-	ssize_t res = 0;
-	while (true) {
-		res = fn();
-		if (res < 0 && errno == EINTR) {
-			continue;
-		}
-		break;
-	}
-	return res;
+template <typename T> inline ssize_t handle_EINTR(T fn) {
+  ssize_t res = 0;
+  while (true) {
+    res = fn();
+    if (res < 0 && errno == EINTR) { continue; }
+    break;
+  }
+  return res;
 }
 
 inline ssize_t read_socket(socket_t sock, void *ptr, size_t size, int flags) {
-	return handle_EINTR([&]() {
-		return recv(sock,
+  return handle_EINTR([&]() {
+    return recv(sock,
 #ifdef _WIN32
-		            static_cast<char *>(ptr), static_cast<int>(size),
+                static_cast<char *>(ptr), static_cast<int>(size),
 #else
-		            ptr, size,
+                ptr, size,
 #endif
-		            flags);
-	});
+                flags);
+  });
 }
 
-inline ssize_t send_socket(socket_t sock, const void *ptr, size_t size, int flags) {
-	return handle_EINTR([&]() {
-		return send(sock,
+inline ssize_t send_socket(socket_t sock, const void *ptr, size_t size,
+                           int flags) {
+  return handle_EINTR([&]() {
+    return send(sock,
 #ifdef _WIN32
-		            static_cast<const char *>(ptr), static_cast<int>(size),
+                static_cast<const char *>(ptr), static_cast<int>(size),
 #else
-		            ptr, size,
+                ptr, size,
 #endif
-		            flags);
-	});
+                flags);
+  });
 }
 
 inline ssize_t select_read(socket_t sock, time_t sec, time_t usec) {
 #ifdef CPPHTTPLIB_USE_POLL
-	struct pollfd pfd_read;
-	pfd_read.fd = sock;
-	pfd_read.events = POLLIN;
+  struct pollfd pfd_read;
+  pfd_read.fd = sock;
+  pfd_read.events = POLLIN;
 
-	auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
+  auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
 
-	return handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
+  return handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
 #else
 #ifndef _WIN32
-	if (sock >= FD_SETSIZE) {
-		return 1;
-	}
+  if (sock >= FD_SETSIZE) { return 1; }
 #endif
 
-	fd_set fds;
-	FD_ZERO(&fds);
-	FD_SET(sock, &fds);
+  fd_set fds;
+  FD_ZERO(&fds);
+  FD_SET(sock, &fds);
 
-	timeval tv;
-	tv.tv_sec = static_cast<long>(sec);
-	tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
+  timeval tv;
+  tv.tv_sec = static_cast<long>(sec);
+  tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
 
-	return handle_EINTR([&]() { return select(static_cast<int>(sock + 1), &fds, nullptr, nullptr, &tv); });
+  return handle_EINTR([&]() {
+    return select(static_cast<int>(sock + 1), &fds, nullptr, nullptr, &tv);
+  });
 #endif
 }
 
 inline ssize_t select_write(socket_t sock, time_t sec, time_t usec) {
 #ifdef CPPHTTPLIB_USE_POLL
-	struct pollfd pfd_read;
-	pfd_read.fd = sock;
-	pfd_read.events = POLLOUT;
+  struct pollfd pfd_read;
+  pfd_read.fd = sock;
+  pfd_read.events = POLLOUT;
 
-	auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
+  auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
 
-	return handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
+  return handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
 #else
 #ifndef _WIN32
-	if (sock >= FD_SETSIZE) {
-		return 1;
-	}
+  if (sock >= FD_SETSIZE) { return 1; }
 #endif
 
-	fd_set fds;
-	FD_ZERO(&fds);
-	FD_SET(sock, &fds);
+  fd_set fds;
+  FD_ZERO(&fds);
+  FD_SET(sock, &fds);
 
-	timeval tv;
-	tv.tv_sec = static_cast<long>(sec);
-	tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
+  timeval tv;
+  tv.tv_sec = static_cast<long>(sec);
+  tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
 
-	return handle_EINTR([&]() { return select(static_cast<int>(sock + 1), nullptr, &fds, nullptr, &tv); });
+  return handle_EINTR([&]() {
+    return select(static_cast<int>(sock + 1), nullptr, &fds, nullptr, &tv);
+  });
 #endif
 }
 
-inline Error wait_until_socket_is_ready(socket_t sock, time_t sec, time_t usec) {
+inline Error wait_until_socket_is_ready(socket_t sock, time_t sec,
+                                        time_t usec) {
 #ifdef CPPHTTPLIB_USE_POLL
-	struct pollfd pfd_read;
-	pfd_read.fd = sock;
-	pfd_read.events = POLLIN | POLLOUT;
+  struct pollfd pfd_read;
+  pfd_read.fd = sock;
+  pfd_read.events = POLLIN | POLLOUT;
 
-	auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
+  auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
 
-	auto poll_res = handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
+  auto poll_res = handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
 
-	if (poll_res == 0) {
-		return Error::ConnectionTimeout;
-	}
+  if (poll_res == 0) { return Error::ConnectionTimeout; }
 
-	if (poll_res > 0 && pfd_read.revents & (POLLIN | POLLOUT)) {
-		auto error = 0;
-		socklen_t len = sizeof(error);
-		auto res = getsockopt(sock, SOL_SOCKET, SO_ERROR, reinterpret_cast<char *>(&error), &len);
-		auto successful = res >= 0 && !error;
-		return successful ? Error::Success : Error::Connection;
-	}
+  if (poll_res > 0 && pfd_read.revents & (POLLIN | POLLOUT)) {
+    auto error = 0;
+    socklen_t len = sizeof(error);
+    auto res = getsockopt(sock, SOL_SOCKET, SO_ERROR,
+                          reinterpret_cast<char *>(&error), &len);
+    auto successful = res >= 0 && !error;
+    return successful ? Error::Success : Error::Connection;
+  }
 
-	return Error::Connection;
+  return Error::Connection;
 #else
 #ifndef _WIN32
-	if (sock >= FD_SETSIZE) {
-		return Error::Connection;
-	}
+  if (sock >= FD_SETSIZE) { return Error::Connection; }
 #endif
 
-	fd_set fdsr;
-	FD_ZERO(&fdsr);
-	FD_SET(sock, &fdsr);
+  fd_set fdsr;
+  FD_ZERO(&fdsr);
+  FD_SET(sock, &fdsr);
 
-	auto fdsw = fdsr;
-	auto fdse = fdsr;
+  auto fdsw = fdsr;
+  auto fdse = fdsr;
 
-	timeval tv;
-	tv.tv_sec = static_cast<long>(sec);
-	tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
+  timeval tv;
+  tv.tv_sec = static_cast<long>(sec);
+  tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
 
-	auto ret = handle_EINTR([&]() { return select(static_cast<int>(sock + 1), &fdsr, &fdsw, &fdse, &tv); });
+  auto ret = handle_EINTR([&]() {
+    return select(static_cast<int>(sock + 1), &fdsr, &fdsw, &fdse, &tv);
+  });
 
-	if (ret == 0) {
-		return Error::ConnectionTimeout;
-	}
+  if (ret == 0) { return Error::ConnectionTimeout; }
 
-	if (ret > 0 && (FD_ISSET(sock, &fdsr) || FD_ISSET(sock, &fdsw))) {
-		auto error = 0;
-		socklen_t len = sizeof(error);
-		auto res = getsockopt(sock, SOL_SOCKET, SO_ERROR, reinterpret_cast<char *>(&error), &len);
-		auto successful = res >= 0 && !error;
-		return successful ? Error::Success : Error::Connection;
-	}
-	return Error::Connection;
+  if (ret > 0 && (FD_ISSET(sock, &fdsr) || FD_ISSET(sock, &fdsw))) {
+    auto error = 0;
+    socklen_t len = sizeof(error);
+    auto res = getsockopt(sock, SOL_SOCKET, SO_ERROR,
+                          reinterpret_cast<char *>(&error), &len);
+    auto successful = res >= 0 && !error;
+    return successful ? Error::Success : Error::Connection;
+  }
+  return Error::Connection;
 #endif
 }
 
 inline bool is_socket_alive(socket_t sock) {
-	const auto val = detail::select_read(sock, 0, 0);
-	if (val == 0) {
-		return true;
-	} else if (val < 0 && errno == EBADF) {
-		return false;
-	}
-	char buf[1];
-	return detail::read_socket(sock, &buf[0], sizeof(buf), MSG_PEEK) > 0;
+  const auto val = detail::select_read(sock, 0, 0);
+  if (val == 0) {
+    return true;
+  } else if (val < 0 && errno == EBADF) {
+    return false;
+  }
+  char buf[1];
+  return detail::read_socket(sock, &buf[0], sizeof(buf), MSG_PEEK) > 0;
 }
 
 class SocketStream : public Stream {
 public:
-	SocketStream(socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
-	             time_t write_timeout_usec);
-	~SocketStream() override;
+  SocketStream(socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec,
+               time_t write_timeout_sec, time_t write_timeout_usec);
+  ~SocketStream() override;
 
-	bool is_readable() const override;
-	bool is_writable() const override;
-	ssize_t read(char *ptr, size_t size) override;
-	ssize_t write(const char *ptr, size_t size) override;
-	void get_remote_ip_and_port(std::string &ip, int &port) const override;
-	void get_local_ip_and_port(std::string &ip, int &port) const override;
-	socket_t socket() const override;
+  bool is_readable() const override;
+  bool is_writable() const override;
+  ssize_t read(char *ptr, size_t size) override;
+  ssize_t write(const char *ptr, size_t size) override;
+  void get_remote_ip_and_port(std::string &ip, int &port) const override;
+  void get_local_ip_and_port(std::string &ip, int &port) const override;
+  socket_t socket() const override;
 
 private:
-	socket_t sock_;
-	time_t read_timeout_sec_;
-	time_t read_timeout_usec_;
-	time_t write_timeout_sec_;
-	time_t write_timeout_usec_;
+  socket_t sock_;
+  time_t read_timeout_sec_;
+  time_t read_timeout_usec_;
+  time_t write_timeout_sec_;
+  time_t write_timeout_usec_;
 
-	std::vector<char> read_buff_;
-	size_t read_buff_off_ = 0;
-	size_t read_buff_content_size_ = 0;
+  std::vector<char> read_buff_;
+  size_t read_buff_off_ = 0;
+  size_t read_buff_content_size_ = 0;
 
-	static const size_t read_buff_size_ = 1024l * 4;
+  static const size_t read_buff_size_ = 1024l * 4;
 };
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 class SSLSocketStream : public Stream {
 public:
-	SSLSocketStream(socket_t sock, SSL *ssl, time_t read_timeout_sec, time_t read_timeout_usec,
-	                time_t write_timeout_sec, time_t write_timeout_usec);
-	~SSLSocketStream() override;
+  SSLSocketStream(socket_t sock, SSL *ssl, time_t read_timeout_sec,
+                  time_t read_timeout_usec, time_t write_timeout_sec,
+                  time_t write_timeout_usec);
+  ~SSLSocketStream() override;
 
-	bool is_readable() const override;
-	bool is_writable() const override;
-	ssize_t read(char *ptr, size_t size) override;
-	ssize_t write(const char *ptr, size_t size) override;
-	void get_remote_ip_and_port(std::string &ip, int &port) const override;
-	void get_local_ip_and_port(std::string &ip, int &port) const override;
-	socket_t socket() const override;
+  bool is_readable() const override;
+  bool is_writable() const override;
+  ssize_t read(char *ptr, size_t size) override;
+  ssize_t write(const char *ptr, size_t size) override;
+  void get_remote_ip_and_port(std::string &ip, int &port) const override;
+  void get_local_ip_and_port(std::string &ip, int &port) const override;
+  socket_t socket() const override;
 
 private:
-	socket_t sock_;
-	SSL *ssl_;
-	time_t read_timeout_sec_;
-	time_t read_timeout_usec_;
-	time_t write_timeout_sec_;
-	time_t write_timeout_usec_;
+  socket_t sock_;
+  SSL *ssl_;
+  time_t read_timeout_sec_;
+  time_t read_timeout_usec_;
+  time_t write_timeout_sec_;
+  time_t write_timeout_usec_;
 };
 #endif
 
 inline bool keep_alive(socket_t sock, time_t keep_alive_timeout_sec) {
-	using namespace std::chrono;
-	auto start = steady_clock::now();
-	while (true) {
-		auto val = select_read(sock, 0, 10000);
-		if (val < 0) {
-			return false;
-		} else if (val == 0) {
-			auto current = steady_clock::now();
-			auto duration = duration_cast<milliseconds>(current - start);
-			auto timeout = keep_alive_timeout_sec * 1000;
-			if (duration.count() > timeout) {
-				return false;
-			}
-			std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		} else {
-			return true;
-		}
-	}
+  using namespace std::chrono;
+  auto start = steady_clock::now();
+  while (true) {
+    auto val = select_read(sock, 0, 10000);
+    if (val < 0) {
+      return false;
+    } else if (val == 0) {
+      auto current = steady_clock::now();
+      auto duration = duration_cast<milliseconds>(current - start);
+      auto timeout = keep_alive_timeout_sec * 1000;
+      if (duration.count() > timeout) { return false; }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    } else {
+      return true;
+    }
+  }
 }
 
 template <typename T>
-inline bool process_server_socket_core(const std::atomic<socket_t> &svr_sock, socket_t sock,
-                                       size_t keep_alive_max_count, time_t keep_alive_timeout_sec, T callback) {
-	assert(keep_alive_max_count > 0);
-	auto ret = false;
-	auto count = keep_alive_max_count;
-	while (svr_sock != INVALID_SOCKET && count > 0 && keep_alive(sock, keep_alive_timeout_sec)) {
-		auto close_connection = count == 1;
-		auto connection_closed = false;
-		ret = callback(close_connection, connection_closed);
-		if (!ret || connection_closed) {
-			break;
-		}
-		count--;
-	}
-	return ret;
+inline bool
+process_server_socket_core(const std::atomic<socket_t> &svr_sock, socket_t sock,
+                           size_t keep_alive_max_count,
+                           time_t keep_alive_timeout_sec, T callback) {
+  assert(keep_alive_max_count > 0);
+  auto ret = false;
+  auto count = keep_alive_max_count;
+  while (svr_sock != INVALID_SOCKET && count > 0 &&
+         keep_alive(sock, keep_alive_timeout_sec)) {
+    auto close_connection = count == 1;
+    auto connection_closed = false;
+    ret = callback(close_connection, connection_closed);
+    if (!ret || connection_closed) { break; }
+    count--;
+  }
+  return ret;
 }
 
 template <typename T>
-inline bool process_server_socket(const std::atomic<socket_t> &svr_sock, socket_t sock, size_t keep_alive_max_count,
-                                  time_t keep_alive_timeout_sec, time_t read_timeout_sec, time_t read_timeout_usec,
-                                  time_t write_timeout_sec, time_t write_timeout_usec, T callback) {
-	return process_server_socket_core(svr_sock, sock, keep_alive_max_count, keep_alive_timeout_sec,
-	                                  [&](bool close_connection, bool &connection_closed) {
-		                                  SocketStream strm(sock, read_timeout_sec, read_timeout_usec,
-		                                                    write_timeout_sec, write_timeout_usec);
-		                                  return callback(strm, close_connection, connection_closed);
-	                                  });
+inline bool
+process_server_socket(const std::atomic<socket_t> &svr_sock, socket_t sock,
+                      size_t keep_alive_max_count,
+                      time_t keep_alive_timeout_sec, time_t read_timeout_sec,
+                      time_t read_timeout_usec, time_t write_timeout_sec,
+                      time_t write_timeout_usec, T callback) {
+  return process_server_socket_core(
+      svr_sock, sock, keep_alive_max_count, keep_alive_timeout_sec,
+      [&](bool close_connection, bool &connection_closed) {
+        SocketStream strm(sock, read_timeout_sec, read_timeout_usec,
+                          write_timeout_sec, write_timeout_usec);
+        return callback(strm, close_connection, connection_closed);
+      });
 }
 
-inline bool process_client_socket(socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec,
-                                  time_t write_timeout_sec, time_t write_timeout_usec,
+inline bool process_client_socket(socket_t sock, time_t read_timeout_sec,
+                                  time_t read_timeout_usec,
+                                  time_t write_timeout_sec,
+                                  time_t write_timeout_usec,
                                   std::function<bool(Stream &)> callback) {
-	SocketStream strm(sock, read_timeout_sec, read_timeout_usec, write_timeout_sec, write_timeout_usec);
-	return callback(strm);
+  SocketStream strm(sock, read_timeout_sec, read_timeout_usec,
+                    write_timeout_sec, write_timeout_usec);
+  return callback(strm);
 }
 
 inline int shutdown_socket(socket_t sock) {
 #ifdef _WIN32
-	return shutdown(sock, SD_BOTH);
+  return shutdown(sock, SD_BOTH);
 #else
-	return shutdown(sock, SHUT_RDWR);
+  return shutdown(sock, SHUT_RDWR);
 #endif
 }
 
 template <typename BindOrConnect>
-socket_t create_socket(const std::string &host, const std::string &ip, int port, int address_family, int socket_flags,
-                       bool tcp_nodelay, SocketOptions socket_options, BindOrConnect bind_or_connect) {
-	// Get address info
-	const char *node = nullptr;
-	struct addrinfo hints;
-	struct addrinfo *result;
+socket_t create_socket(const std::string &host, const std::string &ip, int port,
+                       int address_family, int socket_flags, bool tcp_nodelay,
+                       SocketOptions socket_options,
+                       BindOrConnect bind_or_connect) {
+  // Get address info
+  const char *node = nullptr;
+  struct addrinfo hints;
+  struct addrinfo *result;
 
-	memset(&hints, 0, sizeof(struct addrinfo));
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_protocol = 0;
+  memset(&hints, 0, sizeof(struct addrinfo));
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_protocol = 0;
 
-	if (!ip.empty()) {
-		node = ip.c_str();
-		// Ask getaddrinfo to convert IP in c-string to address
-		hints.ai_family = AF_UNSPEC;
-		hints.ai_flags = AI_NUMERICHOST;
-	} else {
-		if (!host.empty()) {
-			node = host.c_str();
-		}
-		hints.ai_family = address_family;
-		hints.ai_flags = socket_flags;
-	}
+  if (!ip.empty()) {
+    node = ip.c_str();
+    // Ask getaddrinfo to convert IP in c-string to address
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_flags = AI_NUMERICHOST;
+  } else {
+    if (!host.empty()) { node = host.c_str(); }
+    hints.ai_family = address_family;
+    hints.ai_flags = socket_flags;
+  }
 
 #ifndef _WIN32
-	if (hints.ai_family == AF_UNIX) {
-		const auto addrlen = host.length();
-		if (addrlen > sizeof(sockaddr_un::sun_path)) {
-			return INVALID_SOCKET;
-		}
+  if (hints.ai_family == AF_UNIX) {
+    const auto addrlen = host.length();
+    if (addrlen > sizeof(sockaddr_un::sun_path)) { return INVALID_SOCKET; }
 
-		auto sock = socket(hints.ai_family, hints.ai_socktype, hints.ai_protocol);
-		if (sock != INVALID_SOCKET) {
-			sockaddr_un addr {};
-			addr.sun_family = AF_UNIX;
-			std::copy(host.begin(), host.end(), addr.sun_path);
+    auto sock = socket(hints.ai_family, hints.ai_socktype, hints.ai_protocol);
+    if (sock != INVALID_SOCKET) {
+      sockaddr_un addr{};
+      addr.sun_family = AF_UNIX;
+      std::copy(host.begin(), host.end(), addr.sun_path);
 
-			hints.ai_addr = reinterpret_cast<sockaddr *>(&addr);
-			hints.ai_addrlen = static_cast<socklen_t>(sizeof(addr) - sizeof(addr.sun_path) + addrlen);
+      hints.ai_addr = reinterpret_cast<sockaddr *>(&addr);
+      hints.ai_addrlen = static_cast<socklen_t>(
+          sizeof(addr) - sizeof(addr.sun_path) + addrlen);
 
-			fcntl(sock, F_SETFD, FD_CLOEXEC);
-			if (socket_options) {
-				socket_options(sock);
-			}
+      fcntl(sock, F_SETFD, FD_CLOEXEC);
+      if (socket_options) { socket_options(sock); }
 
-			if (!bind_or_connect(sock, hints)) {
-				close_socket(sock);
-				sock = INVALID_SOCKET;
-			}
-		}
-		return sock;
-	}
+      if (!bind_or_connect(sock, hints)) {
+        close_socket(sock);
+        sock = INVALID_SOCKET;
+      }
+    }
+    return sock;
+  }
 #endif
 
-	auto service = std::to_string(port);
+  auto service = std::to_string(port);
 
-	if (getaddrinfo(node, service.c_str(), &hints, &result)) {
+  if (getaddrinfo(node, service.c_str(), &hints, &result)) {
 #if defined __linux__ && !defined __ANDROID__
-		res_init();
+    res_init();
 #endif
-		return INVALID_SOCKET;
-	}
+    return INVALID_SOCKET;
+  }
 
-	for (auto rp = result; rp; rp = rp->ai_next) {
-		// Create a socket
+  for (auto rp = result; rp; rp = rp->ai_next) {
+    // Create a socket
 #ifdef _WIN32
-		auto sock = WSASocketW(rp->ai_family, rp->ai_socktype, rp->ai_protocol, nullptr, 0,
-		                       WSA_FLAG_NO_HANDLE_INHERIT | WSA_FLAG_OVERLAPPED);
-		/**
-		 * Since the WSA_FLAG_NO_HANDLE_INHERIT is only supported on Windows 7 SP1
-		 * and above the socket creation fails on older Windows Systems.
-		 *
-		 * Let's try to create a socket the old way in this case.
-		 *
-		 * Reference:
-		 * https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketa
-		 *
-		 * WSA_FLAG_NO_HANDLE_INHERIT:
-		 * This flag is supported on Windows 7 with SP1, Windows Server 2008 R2 with
-		 * SP1, and later
-		 *
-		 */
-		if (sock == INVALID_SOCKET) {
-			sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-		}
+    auto sock =
+        WSASocketW(rp->ai_family, rp->ai_socktype, rp->ai_protocol, nullptr, 0,
+                   WSA_FLAG_NO_HANDLE_INHERIT | WSA_FLAG_OVERLAPPED);
+    /**
+     * Since the WSA_FLAG_NO_HANDLE_INHERIT is only supported on Windows 7 SP1
+     * and above the socket creation fails on older Windows Systems.
+     *
+     * Let's try to create a socket the old way in this case.
+     *
+     * Reference:
+     * https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketa
+     *
+     * WSA_FLAG_NO_HANDLE_INHERIT:
+     * This flag is supported on Windows 7 with SP1, Windows Server 2008 R2 with
+     * SP1, and later
+     *
+     */
+    if (sock == INVALID_SOCKET) {
+      sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+    }
 #else
-		auto sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+    auto sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
 #endif
-		if (sock == INVALID_SOCKET) {
-			continue;
-		}
+    if (sock == INVALID_SOCKET) { continue; }
 
 #ifndef _WIN32
-		if (fcntl(sock, F_SETFD, FD_CLOEXEC) == -1) {
-			close_socket(sock);
-			continue;
-		}
+    if (fcntl(sock, F_SETFD, FD_CLOEXEC) == -1) {
+      close_socket(sock);
+      continue;
+    }
 #endif
 
-		if (tcp_nodelay) {
-			auto yes = 1;
+    if (tcp_nodelay) {
+      auto yes = 1;
 #ifdef _WIN32
-			setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char *>(&yes), sizeof(yes));
+      setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
+                 reinterpret_cast<const char *>(&yes), sizeof(yes));
 #else
-			setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const void *>(&yes), sizeof(yes));
+      setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
+                 reinterpret_cast<const void *>(&yes), sizeof(yes));
 #endif
-		}
+    }
 
-		if (socket_options) {
-			socket_options(sock);
-		}
+    if (socket_options) { socket_options(sock); }
 
-		if (rp->ai_family == AF_INET6) {
-			auto no = 0;
+    if (rp->ai_family == AF_INET6) {
+      auto no = 0;
 #ifdef _WIN32
-			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char *>(&no), sizeof(no));
+      setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
+                 reinterpret_cast<const char *>(&no), sizeof(no));
 #else
-			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const void *>(&no), sizeof(no));
+      setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
+                 reinterpret_cast<const void *>(&no), sizeof(no));
 #endif
-		}
+    }
 
-		// bind or connect
-		if (bind_or_connect(sock, *rp)) {
-			freeaddrinfo(result);
-			return sock;
-		}
+    // bind or connect
+    if (bind_or_connect(sock, *rp)) {
+      freeaddrinfo(result);
+      return sock;
+    }
 
-		close_socket(sock);
-	}
+    close_socket(sock);
+  }
 
-	freeaddrinfo(result);
-	return INVALID_SOCKET;
+  freeaddrinfo(result);
+  return INVALID_SOCKET;
 }
 
 inline void set_nonblocking(socket_t sock, bool nonblocking) {
 #ifdef _WIN32
-	auto flags = nonblocking ? 1UL : 0UL;
-	ioctlsocket(sock, FIONBIO, &flags);
+  auto flags = nonblocking ? 1UL : 0UL;
+  ioctlsocket(sock, FIONBIO, &flags);
 #else
-	auto flags = fcntl(sock, F_GETFL, 0);
-	fcntl(sock, F_SETFL, nonblocking ? (flags | O_NONBLOCK) : (flags & (~O_NONBLOCK)));
+  auto flags = fcntl(sock, F_GETFL, 0);
+  fcntl(sock, F_SETFL,
+        nonblocking ? (flags | O_NONBLOCK) : (flags & (~O_NONBLOCK)));
 #endif
 }
 
 inline bool is_connection_error() {
 #ifdef _WIN32
-	return WSAGetLastError() != WSAEWOULDBLOCK;
+  return WSAGetLastError() != WSAEWOULDBLOCK;
 #else
-	return errno != EINPROGRESS;
+  return errno != EINPROGRESS;
 #endif
 }
 
 inline bool bind_ip_address(socket_t sock, const std::string &host) {
-	struct addrinfo hints;
-	struct addrinfo *result;
+  struct addrinfo hints;
+  struct addrinfo *result;
 
-	memset(&hints, 0, sizeof(struct addrinfo));
-	hints.ai_family = AF_UNSPEC;
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_protocol = 0;
+  memset(&hints, 0, sizeof(struct addrinfo));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_protocol = 0;
 
-	if (getaddrinfo(host.c_str(), "0", &hints, &result)) {
-		return false;
-	}
+  if (getaddrinfo(host.c_str(), "0", &hints, &result)) { return false; }
 
-	auto ret = false;
-	for (auto rp = result; rp; rp = rp->ai_next) {
-		const auto &ai = *rp;
-		if (!::bind(sock, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen))) {
-			ret = true;
-			break;
-		}
-	}
+  auto ret = false;
+  for (auto rp = result; rp; rp = rp->ai_next) {
+    const auto &ai = *rp;
+    if (!::bind(sock, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen))) {
+      ret = true;
+      break;
+    }
+  }
 
-	freeaddrinfo(result);
-	return ret;
+  freeaddrinfo(result);
+  return ret;
 }
 
 #if !defined _WIN32 && !defined ANDROID && !defined _AIX && !defined __MVS__
@@ -3174,1209 +3236,1119 @@ inline bool bind_ip_address(socket_t sock, const std::string &host) {
 
 #ifdef USE_IF2IP
 inline std::string if2ip(int address_family, const std::string &ifn) {
-	struct ifaddrs *ifap;
-	getifaddrs(&ifap);
-	std::string addr_candidate;
-	for (auto ifa = ifap; ifa; ifa = ifa->ifa_next) {
-		if (ifa->ifa_addr && ifn == ifa->ifa_name &&
-		    (AF_UNSPEC == address_family || ifa->ifa_addr->sa_family == address_family)) {
-			if (ifa->ifa_addr->sa_family == AF_INET) {
-				auto sa = reinterpret_cast<struct sockaddr_in *>(ifa->ifa_addr);
-				char buf[INET_ADDRSTRLEN];
-				if (inet_ntop(AF_INET, &sa->sin_addr, buf, INET_ADDRSTRLEN)) {
-					freeifaddrs(ifap);
-					return std::string(buf, INET_ADDRSTRLEN);
-				}
-			} else if (ifa->ifa_addr->sa_family == AF_INET6) {
-				auto sa = reinterpret_cast<struct sockaddr_in6 *>(ifa->ifa_addr);
-				if (!IN6_IS_ADDR_LINKLOCAL(&sa->sin6_addr)) {
-					char buf[INET6_ADDRSTRLEN] = {};
-					if (inet_ntop(AF_INET6, &sa->sin6_addr, buf, INET6_ADDRSTRLEN)) {
-						// equivalent to mac's IN6_IS_ADDR_UNIQUE_LOCAL
-						auto s6_addr_head = sa->sin6_addr.s6_addr[0];
-						if (s6_addr_head == 0xfc || s6_addr_head == 0xfd) {
-							addr_candidate = std::string(buf, INET6_ADDRSTRLEN);
-						} else {
-							freeifaddrs(ifap);
-							return std::string(buf, INET6_ADDRSTRLEN);
-						}
-					}
-				}
-			}
-		}
-	}
-	freeifaddrs(ifap);
-	return addr_candidate;
+  struct ifaddrs *ifap;
+  getifaddrs(&ifap);
+  std::string addr_candidate;
+  for (auto ifa = ifap; ifa; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr && ifn == ifa->ifa_name &&
+        (AF_UNSPEC == address_family ||
+         ifa->ifa_addr->sa_family == address_family)) {
+      if (ifa->ifa_addr->sa_family == AF_INET) {
+        auto sa = reinterpret_cast<struct sockaddr_in *>(ifa->ifa_addr);
+        char buf[INET_ADDRSTRLEN];
+        if (inet_ntop(AF_INET, &sa->sin_addr, buf, INET_ADDRSTRLEN)) {
+          freeifaddrs(ifap);
+          return std::string(buf, INET_ADDRSTRLEN);
+        }
+      } else if (ifa->ifa_addr->sa_family == AF_INET6) {
+        auto sa = reinterpret_cast<struct sockaddr_in6 *>(ifa->ifa_addr);
+        if (!IN6_IS_ADDR_LINKLOCAL(&sa->sin6_addr)) {
+          char buf[INET6_ADDRSTRLEN] = {};
+          if (inet_ntop(AF_INET6, &sa->sin6_addr, buf, INET6_ADDRSTRLEN)) {
+            // equivalent to mac's IN6_IS_ADDR_UNIQUE_LOCAL
+            auto s6_addr_head = sa->sin6_addr.s6_addr[0];
+            if (s6_addr_head == 0xfc || s6_addr_head == 0xfd) {
+              addr_candidate = std::string(buf, INET6_ADDRSTRLEN);
+            } else {
+              freeifaddrs(ifap);
+              return std::string(buf, INET6_ADDRSTRLEN);
+            }
+          }
+        }
+      }
+    }
+  }
+  freeifaddrs(ifap);
+  return addr_candidate;
 }
 #endif
 
-inline socket_t create_client_socket(const std::string &host, const std::string &ip, int port, int address_family,
-                                     bool tcp_nodelay, SocketOptions socket_options, time_t connection_timeout_sec,
-                                     time_t connection_timeout_usec, time_t read_timeout_sec, time_t read_timeout_usec,
-                                     time_t write_timeout_sec, time_t write_timeout_usec, const std::string &intf,
-                                     Error &error) {
-	auto sock = create_socket(
-	    host, ip, port, address_family, 0, tcp_nodelay, std::move(socket_options),
-	    [&](socket_t sock2, struct addrinfo &ai) -> bool {
-		    if (!intf.empty()) {
+inline socket_t create_client_socket(
+    const std::string &host, const std::string &ip, int port,
+    int address_family, bool tcp_nodelay, SocketOptions socket_options,
+    time_t connection_timeout_sec, time_t connection_timeout_usec,
+    time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
+    time_t write_timeout_usec, const std::string &intf, Error &error) {
+  auto sock = create_socket(
+      host, ip, port, address_family, 0, tcp_nodelay, std::move(socket_options),
+      [&](socket_t sock2, struct addrinfo &ai) -> bool {
+        if (!intf.empty()) {
 #ifdef USE_IF2IP
-			    auto ip_from_if = if2ip(address_family, intf);
-			    if (ip_from_if.empty()) {
-				    ip_from_if = intf;
-			    }
-			    if (!bind_ip_address(sock2, ip_from_if)) {
-				    error = Error::BindIPAddress;
-				    return false;
-			    }
+          auto ip_from_if = if2ip(address_family, intf);
+          if (ip_from_if.empty()) { ip_from_if = intf; }
+          if (!bind_ip_address(sock2, ip_from_if)) {
+            error = Error::BindIPAddress;
+            return false;
+          }
 #endif
-		    }
+        }
 
-		    set_nonblocking(sock2, true);
+        set_nonblocking(sock2, true);
 
-		    auto ret = ::connect(sock2, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen));
+        auto ret =
+            ::connect(sock2, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen));
 
-		    if (ret < 0) {
-			    if (is_connection_error()) {
-				    error = Error::Connection;
-				    return false;
-			    }
-			    error = wait_until_socket_is_ready(sock2, connection_timeout_sec, connection_timeout_usec);
-			    if (error != Error::Success) {
-				    return false;
-			    }
-		    }
+        if (ret < 0) {
+          if (is_connection_error()) {
+            error = Error::Connection;
+            return false;
+          }
+          error = wait_until_socket_is_ready(sock2, connection_timeout_sec,
+                                             connection_timeout_usec);
+          if (error != Error::Success) { return false; }
+        }
 
-		    set_nonblocking(sock2, false);
+        set_nonblocking(sock2, false);
 
-		    {
+        {
 #ifdef _WIN32
-			    auto timeout = static_cast<uint32_t>(read_timeout_sec * 1000 + read_timeout_usec / 1000);
-			    setsockopt(sock2, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char *>(&timeout), sizeof(timeout));
+          auto timeout = static_cast<uint32_t>(read_timeout_sec * 1000 +
+                                               read_timeout_usec / 1000);
+          setsockopt(sock2, SOL_SOCKET, SO_RCVTIMEO,
+                     reinterpret_cast<const char *>(&timeout), sizeof(timeout));
 #else
-			    timeval tv;
-			    tv.tv_sec = static_cast<long>(read_timeout_sec);
-			    tv.tv_usec = static_cast<decltype(tv.tv_usec)>(read_timeout_usec);
-			    setsockopt(sock2, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const void *>(&tv), sizeof(tv));
+          timeval tv;
+          tv.tv_sec = static_cast<long>(read_timeout_sec);
+          tv.tv_usec = static_cast<decltype(tv.tv_usec)>(read_timeout_usec);
+          setsockopt(sock2, SOL_SOCKET, SO_RCVTIMEO,
+                     reinterpret_cast<const void *>(&tv), sizeof(tv));
 #endif
-		    }
-		    {
+        }
+        {
 
 #ifdef _WIN32
-			    auto timeout = static_cast<uint32_t>(write_timeout_sec * 1000 + write_timeout_usec / 1000);
-			    setsockopt(sock2, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char *>(&timeout), sizeof(timeout));
+          auto timeout = static_cast<uint32_t>(write_timeout_sec * 1000 +
+                                               write_timeout_usec / 1000);
+          setsockopt(sock2, SOL_SOCKET, SO_SNDTIMEO,
+                     reinterpret_cast<const char *>(&timeout), sizeof(timeout));
 #else
-			    timeval tv;
-			    tv.tv_sec = static_cast<long>(write_timeout_sec);
-			    tv.tv_usec = static_cast<decltype(tv.tv_usec)>(write_timeout_usec);
-			    setsockopt(sock2, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const void *>(&tv), sizeof(tv));
+          timeval tv;
+          tv.tv_sec = static_cast<long>(write_timeout_sec);
+          tv.tv_usec = static_cast<decltype(tv.tv_usec)>(write_timeout_usec);
+          setsockopt(sock2, SOL_SOCKET, SO_SNDTIMEO,
+                     reinterpret_cast<const void *>(&tv), sizeof(tv));
 #endif
-		    }
+        }
 
-		    error = Error::Success;
-		    return true;
-	    });
+        error = Error::Success;
+        return true;
+      });
 
-	if (sock != INVALID_SOCKET) {
-		error = Error::Success;
-	} else {
-		if (error == Error::Success) {
-			error = Error::Connection;
-		}
-	}
+  if (sock != INVALID_SOCKET) {
+    error = Error::Success;
+  } else {
+    if (error == Error::Success) { error = Error::Connection; }
+  }
 
-	return sock;
+  return sock;
 }
 
-inline bool get_ip_and_port(const struct sockaddr_storage &addr, socklen_t addr_len, std::string &ip, int &port) {
-	if (addr.ss_family == AF_INET) {
-		port = ntohs(reinterpret_cast<const struct sockaddr_in *>(&addr)->sin_port);
-	} else if (addr.ss_family == AF_INET6) {
-		port = ntohs(reinterpret_cast<const struct sockaddr_in6 *>(&addr)->sin6_port);
-	} else {
-		return false;
-	}
+inline bool get_ip_and_port(const struct sockaddr_storage &addr,
+                            socklen_t addr_len, std::string &ip, int &port) {
+  if (addr.ss_family == AF_INET) {
+    port = ntohs(reinterpret_cast<const struct sockaddr_in *>(&addr)->sin_port);
+  } else if (addr.ss_family == AF_INET6) {
+    port =
+        ntohs(reinterpret_cast<const struct sockaddr_in6 *>(&addr)->sin6_port);
+  } else {
+    return false;
+  }
 
-	std::array<char, NI_MAXHOST> ipstr {};
-	if (getnameinfo(reinterpret_cast<const struct sockaddr *>(&addr), addr_len, ipstr.data(),
-	                static_cast<socklen_t>(ipstr.size()), nullptr, 0, NI_NUMERICHOST)) {
-		return false;
-	}
+  std::array<char, NI_MAXHOST> ipstr{};
+  if (getnameinfo(reinterpret_cast<const struct sockaddr *>(&addr), addr_len,
+                  ipstr.data(), static_cast<socklen_t>(ipstr.size()), nullptr,
+                  0, NI_NUMERICHOST)) {
+    return false;
+  }
 
-	ip = ipstr.data();
-	return true;
+  ip = ipstr.data();
+  return true;
 }
 
 inline void get_local_ip_and_port(socket_t sock, std::string &ip, int &port) {
-	struct sockaddr_storage addr;
-	socklen_t addr_len = sizeof(addr);
-	if (!getsockname(sock, reinterpret_cast<struct sockaddr *>(&addr), &addr_len)) {
-		get_ip_and_port(addr, addr_len, ip, port);
-	}
+  struct sockaddr_storage addr;
+  socklen_t addr_len = sizeof(addr);
+  if (!getsockname(sock, reinterpret_cast<struct sockaddr *>(&addr),
+                   &addr_len)) {
+    get_ip_and_port(addr, addr_len, ip, port);
+  }
 }
 
 inline void get_remote_ip_and_port(socket_t sock, std::string &ip, int &port) {
-	struct sockaddr_storage addr;
-	socklen_t addr_len = sizeof(addr);
+  struct sockaddr_storage addr;
+  socklen_t addr_len = sizeof(addr);
 
-	if (!getpeername(sock, reinterpret_cast<struct sockaddr *>(&addr), &addr_len)) {
+  if (!getpeername(sock, reinterpret_cast<struct sockaddr *>(&addr),
+                   &addr_len)) {
 #ifndef _WIN32
-		if (addr.ss_family == AF_UNIX) {
+    if (addr.ss_family == AF_UNIX) {
 #if defined(__linux__)
-			struct ucred ucred;
-			socklen_t len = sizeof(ucred);
-			if (getsockopt(sock, SOL_SOCKET, SO_PEERCRED, &ucred, &len) == 0) {
-				port = ucred.pid;
-			}
+      struct ucred ucred;
+      socklen_t len = sizeof(ucred);
+      if (getsockopt(sock, SOL_SOCKET, SO_PEERCRED, &ucred, &len) == 0) {
+        port = ucred.pid;
+      }
 #elif defined(SOL_LOCAL) && defined(SO_PEERPID) // __APPLE__
-			pid_t pid;
-			socklen_t len = sizeof(pid);
-			if (getsockopt(sock, SOL_LOCAL, SO_PEERPID, &pid, &len) == 0) {
-				port = pid;
-			}
+      pid_t pid;
+      socklen_t len = sizeof(pid);
+      if (getsockopt(sock, SOL_LOCAL, SO_PEERPID, &pid, &len) == 0) {
+        port = pid;
+      }
 #endif
-			return;
-		}
+      return;
+    }
 #endif
-		get_ip_and_port(addr, addr_len, ip, port);
-	}
+    get_ip_and_port(addr, addr_len, ip, port);
+  }
 }
 
-inline constexpr unsigned int str2tag_core(const char *s, size_t l, unsigned int h) {
-	return (l == 0) ? h
-	                : str2tag_core(s + 1, l - 1,
-	                               // Unsets the 6 high bits of h, therefore no overflow happens
-	                               (((std::numeric_limits<unsigned int>::max)() >> 6) & h * 33) ^
-	                                   static_cast<unsigned char>(*s));
+inline constexpr unsigned int str2tag_core(const char *s, size_t l,
+                                           unsigned int h) {
+  return (l == 0)
+             ? h
+             : str2tag_core(
+                   s + 1, l - 1,
+                   // Unsets the 6 high bits of h, therefore no overflow happens
+                   (((std::numeric_limits<unsigned int>::max)() >> 6) &
+                    h * 33) ^
+                       static_cast<unsigned char>(*s));
 }
 
 inline unsigned int str2tag(const std::string &s) {
-	return str2tag_core(s.data(), s.size(), 0);
+  return str2tag_core(s.data(), s.size(), 0);
 }
 
 namespace udl {
 
-inline constexpr unsigned int operator""_t(const char *s, size_t l) {
-	return str2tag_core(s, l, 0);
+inline constexpr unsigned int operator ""_t(const char *s, size_t l) {
+  return str2tag_core(s, l, 0);
 }
 
 } // namespace udl
 
-inline std::string find_content_type(const std::string &path, const std::map<std::string, std::string> &user_data,
-                                     const std::string &default_content_type) {
-	auto ext = file_extension(path);
+inline std::string
+find_content_type(const std::string &path,
+                  const std::map<std::string, std::string> &user_data,
+                  const std::string &default_content_type) {
+  auto ext = file_extension(path);
 
-	auto it = user_data.find(ext);
-	if (it != user_data.end()) {
-		return it->second;
-	}
+  auto it = user_data.find(ext);
+  if (it != user_data.end()) { return it->second; }
 
-	using udl::operator""_t;
+  using udl::operator ""_t;
 
-	switch (str2tag(ext)) {
-	default:
-		return default_content_type;
+  switch (str2tag(ext)) {
+  default: return default_content_type;
 
-	case "css"_t:
-		return "text/css";
-	case "csv"_t:
-		return "text/csv";
-	case "htm"_t:
-	case "html"_t:
-		return "text/html";
-	case "js"_t:
-	case "mjs"_t:
-		return "text/javascript";
-	case "txt"_t:
-		return "text/plain";
-	case "vtt"_t:
-		return "text/vtt";
+  case "css"_t: return "text/css";
+  case "csv"_t: return "text/csv";
+  case "htm"_t:
+  case "html"_t: return "text/html";
+  case "js"_t:
+  case "mjs"_t: return "text/javascript";
+  case "txt"_t: return "text/plain";
+  case "vtt"_t: return "text/vtt";
 
-	case "apng"_t:
-		return "image/apng";
-	case "avif"_t:
-		return "image/avif";
-	case "bmp"_t:
-		return "image/bmp";
-	case "gif"_t:
-		return "image/gif";
-	case "png"_t:
-		return "image/png";
-	case "svg"_t:
-		return "image/svg+xml";
-	case "webp"_t:
-		return "image/webp";
-	case "ico"_t:
-		return "image/x-icon";
-	case "tif"_t:
-		return "image/tiff";
-	case "tiff"_t:
-		return "image/tiff";
-	case "jpg"_t:
-	case "jpeg"_t:
-		return "image/jpeg";
+  case "apng"_t: return "image/apng";
+  case "avif"_t: return "image/avif";
+  case "bmp"_t: return "image/bmp";
+  case "gif"_t: return "image/gif";
+  case "png"_t: return "image/png";
+  case "svg"_t: return "image/svg+xml";
+  case "webp"_t: return "image/webp";
+  case "ico"_t: return "image/x-icon";
+  case "tif"_t: return "image/tiff";
+  case "tiff"_t: return "image/tiff";
+  case "jpg"_t:
+  case "jpeg"_t: return "image/jpeg";
 
-	case "mp4"_t:
-		return "video/mp4";
-	case "mpeg"_t:
-		return "video/mpeg";
-	case "webm"_t:
-		return "video/webm";
+  case "mp4"_t: return "video/mp4";
+  case "mpeg"_t: return "video/mpeg";
+  case "webm"_t: return "video/webm";
 
-	case "mp3"_t:
-		return "audio/mp3";
-	case "mpga"_t:
-		return "audio/mpeg";
-	case "weba"_t:
-		return "audio/webm";
-	case "wav"_t:
-		return "audio/wave";
+  case "mp3"_t: return "audio/mp3";
+  case "mpga"_t: return "audio/mpeg";
+  case "weba"_t: return "audio/webm";
+  case "wav"_t: return "audio/wave";
 
-	case "otf"_t:
-		return "font/otf";
-	case "ttf"_t:
-		return "font/ttf";
-	case "woff"_t:
-		return "font/woff";
-	case "woff2"_t:
-		return "font/woff2";
+  case "otf"_t: return "font/otf";
+  case "ttf"_t: return "font/ttf";
+  case "woff"_t: return "font/woff";
+  case "woff2"_t: return "font/woff2";
 
-	case "7z"_t:
-		return "application/x-7z-compressed";
-	case "atom"_t:
-		return "application/atom+xml";
-	case "pdf"_t:
-		return "application/pdf";
-	case "json"_t:
-		return "application/json";
-	case "rss"_t:
-		return "application/rss+xml";
-	case "tar"_t:
-		return "application/x-tar";
-	case "xht"_t:
-	case "xhtml"_t:
-		return "application/xhtml+xml";
-	case "xslt"_t:
-		return "application/xslt+xml";
-	case "xml"_t:
-		return "application/xml";
-	case "gz"_t:
-		return "application/gzip";
-	case "zip"_t:
-		return "application/zip";
-	case "wasm"_t:
-		return "application/wasm";
-	}
+  case "7z"_t: return "application/x-7z-compressed";
+  case "atom"_t: return "application/atom+xml";
+  case "pdf"_t: return "application/pdf";
+  case "json"_t: return "application/json";
+  case "rss"_t: return "application/rss+xml";
+  case "tar"_t: return "application/x-tar";
+  case "xht"_t:
+  case "xhtml"_t: return "application/xhtml+xml";
+  case "xslt"_t: return "application/xslt+xml";
+  case "xml"_t: return "application/xml";
+  case "gz"_t: return "application/gzip";
+  case "zip"_t: return "application/zip";
+  case "wasm"_t: return "application/wasm";
+  }
 }
 
 inline bool can_compress_content_type(const std::string &content_type) {
-	using udl::operator""_t;
+  using udl::operator ""_t;
 
-	auto tag = str2tag(content_type);
+  auto tag = str2tag(content_type);
 
-	switch (tag) {
-	case "image/svg+xml"_t:
-	case "application/javascript"_t:
-	case "application/json"_t:
-	case "application/xml"_t:
-	case "application/protobuf"_t:
-	case "application/xhtml+xml"_t:
-		return true;
+  switch (tag) {
+  case "image/svg+xml"_t:
+  case "application/javascript"_t:
+  case "application/json"_t:
+  case "application/xml"_t:
+  case "application/protobuf"_t:
+  case "application/xhtml+xml"_t: return true;
 
-	default:
-		return !content_type.rfind("text/", 0) && tag != "text/event-stream"_t;
-	}
+  default:
+    return !content_type.rfind("text/", 0) && tag != "text/event-stream"_t;
+  }
 }
 
 inline EncodingType encoding_type(const Request &req, const Response &res) {
-	auto ret = detail::can_compress_content_type(res.get_header_value("Content-Type"));
-	if (!ret) {
-		return EncodingType::None;
-	}
+  auto ret =
+      detail::can_compress_content_type(res.get_header_value("Content-Type"));
+  if (!ret) { return EncodingType::None; }
 
-	const auto &s = req.get_header_value("Accept-Encoding");
-	(void)(s);
+  const auto &s = req.get_header_value("Accept-Encoding");
+  (void)(s);
 
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
-	// TODO: 'Accept-Encoding' has br, not br;q=0
-	ret = s.find("br") != std::string::npos;
-	if (ret) {
-		return EncodingType::Brotli;
-	}
+  // TODO: 'Accept-Encoding' has br, not br;q=0
+  ret = s.find("br") != std::string::npos;
+  if (ret) { return EncodingType::Brotli; }
 #endif
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-	// TODO: 'Accept-Encoding' has gzip, not gzip;q=0
-	ret = s.find("gzip") != std::string::npos;
-	if (ret) {
-		return EncodingType::Gzip;
-	}
+  // TODO: 'Accept-Encoding' has gzip, not gzip;q=0
+  ret = s.find("gzip") != std::string::npos;
+  if (ret) { return EncodingType::Gzip; }
 #endif
 
-	return EncodingType::None;
+  return EncodingType::None;
 }
 
-inline bool nocompressor::compress(const char *data, size_t data_length, bool /*last*/, Callback callback) {
-	if (!data_length) {
-		return true;
-	}
-	return callback(data, data_length);
+inline bool nocompressor::compress(const char *data, size_t data_length,
+                                   bool /*last*/, Callback callback) {
+  if (!data_length) { return true; }
+  return callback(data, data_length);
 }
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
 inline gzip_compressor::gzip_compressor() {
-	std::memset(&strm_, 0, sizeof(strm_));
-	strm_.zalloc = Z_NULL;
-	strm_.zfree = Z_NULL;
-	strm_.opaque = Z_NULL;
+  std::memset(&strm_, 0, sizeof(strm_));
+  strm_.zalloc = Z_NULL;
+  strm_.zfree = Z_NULL;
+  strm_.opaque = Z_NULL;
 
-	is_valid_ = deflateInit2(&strm_, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY) == Z_OK;
+  is_valid_ = deflateInit2(&strm_, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8,
+                           Z_DEFAULT_STRATEGY) == Z_OK;
 }
 
-inline gzip_compressor::~gzip_compressor() {
-	deflateEnd(&strm_);
-}
+inline gzip_compressor::~gzip_compressor() { deflateEnd(&strm_); }
 
-inline bool gzip_compressor::compress(const char *data, size_t data_length, bool last, Callback callback) {
-	assert(is_valid_);
+inline bool gzip_compressor::compress(const char *data, size_t data_length,
+                                      bool last, Callback callback) {
+  assert(is_valid_);
 
-	do {
-		constexpr size_t max_avail_in = (std::numeric_limits<decltype(strm_.avail_in)>::max)();
+  do {
+    constexpr size_t max_avail_in =
+        (std::numeric_limits<decltype(strm_.avail_in)>::max)();
 
-		strm_.avail_in = static_cast<decltype(strm_.avail_in)>((std::min)(data_length, max_avail_in));
-		strm_.next_in = const_cast<Bytef *>(reinterpret_cast<const Bytef *>(data));
+    strm_.avail_in = static_cast<decltype(strm_.avail_in)>(
+        (std::min)(data_length, max_avail_in));
+    strm_.next_in = const_cast<Bytef *>(reinterpret_cast<const Bytef *>(data));
 
-		data_length -= strm_.avail_in;
-		data += strm_.avail_in;
+    data_length -= strm_.avail_in;
+    data += strm_.avail_in;
 
-		auto flush = (last && data_length == 0) ? Z_FINISH : Z_NO_FLUSH;
-		auto ret = Z_OK;
+    auto flush = (last && data_length == 0) ? Z_FINISH : Z_NO_FLUSH;
+    auto ret = Z_OK;
 
-		std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff {};
-		do {
-			strm_.avail_out = static_cast<uInt>(buff.size());
-			strm_.next_out = reinterpret_cast<Bytef *>(buff.data());
+    std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff{};
+    do {
+      strm_.avail_out = static_cast<uInt>(buff.size());
+      strm_.next_out = reinterpret_cast<Bytef *>(buff.data());
 
-			ret = deflate(&strm_, flush);
-			if (ret == Z_STREAM_ERROR) {
-				return false;
-			}
+      ret = deflate(&strm_, flush);
+      if (ret == Z_STREAM_ERROR) { return false; }
 
-			if (!callback(buff.data(), buff.size() - strm_.avail_out)) {
-				return false;
-			}
-		} while (strm_.avail_out == 0);
+      if (!callback(buff.data(), buff.size() - strm_.avail_out)) {
+        return false;
+      }
+    } while (strm_.avail_out == 0);
 
-		assert((flush == Z_FINISH && ret == Z_STREAM_END) || (flush == Z_NO_FLUSH && ret == Z_OK));
-		assert(strm_.avail_in == 0);
-	} while (data_length > 0);
+    assert((flush == Z_FINISH && ret == Z_STREAM_END) ||
+           (flush == Z_NO_FLUSH && ret == Z_OK));
+    assert(strm_.avail_in == 0);
+  } while (data_length > 0);
 
-	return true;
+  return true;
 }
 
 inline gzip_decompressor::gzip_decompressor() {
-	std::memset(&strm_, 0, sizeof(strm_));
-	strm_.zalloc = Z_NULL;
-	strm_.zfree = Z_NULL;
-	strm_.opaque = Z_NULL;
+  std::memset(&strm_, 0, sizeof(strm_));
+  strm_.zalloc = Z_NULL;
+  strm_.zfree = Z_NULL;
+  strm_.opaque = Z_NULL;
 
-	// 15 is the value of wbits, which should be at the maximum possible value
-	// to ensure that any gzip stream can be decoded. The offset of 32 specifies
-	// that the stream type should be automatically detected either gzip or
-	// deflate.
-	is_valid_ = inflateInit2(&strm_, 32 + 15) == Z_OK;
+  // 15 is the value of wbits, which should be at the maximum possible value
+  // to ensure that any gzip stream can be decoded. The offset of 32 specifies
+  // that the stream type should be automatically detected either gzip or
+  // deflate.
+  is_valid_ = inflateInit2(&strm_, 32 + 15) == Z_OK;
 }
 
-inline gzip_decompressor::~gzip_decompressor() {
-	inflateEnd(&strm_);
-}
+inline gzip_decompressor::~gzip_decompressor() { inflateEnd(&strm_); }
 
-inline bool gzip_decompressor::is_valid() const {
-	return is_valid_;
-}
+inline bool gzip_decompressor::is_valid() const { return is_valid_; }
 
-inline bool gzip_decompressor::decompress(const char *data, size_t data_length, Callback callback) {
-	assert(is_valid_);
+inline bool gzip_decompressor::decompress(const char *data, size_t data_length,
+                                          Callback callback) {
+  assert(is_valid_);
 
-	auto ret = Z_OK;
+  auto ret = Z_OK;
 
-	do {
-		constexpr size_t max_avail_in = (std::numeric_limits<decltype(strm_.avail_in)>::max)();
+  do {
+    constexpr size_t max_avail_in =
+        (std::numeric_limits<decltype(strm_.avail_in)>::max)();
 
-		strm_.avail_in = static_cast<decltype(strm_.avail_in)>((std::min)(data_length, max_avail_in));
-		strm_.next_in = const_cast<Bytef *>(reinterpret_cast<const Bytef *>(data));
+    strm_.avail_in = static_cast<decltype(strm_.avail_in)>(
+        (std::min)(data_length, max_avail_in));
+    strm_.next_in = const_cast<Bytef *>(reinterpret_cast<const Bytef *>(data));
 
-		data_length -= strm_.avail_in;
-		data += strm_.avail_in;
+    data_length -= strm_.avail_in;
+    data += strm_.avail_in;
 
-		std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff {};
-		while (strm_.avail_in > 0 && ret == Z_OK) {
-			strm_.avail_out = static_cast<uInt>(buff.size());
-			strm_.next_out = reinterpret_cast<Bytef *>(buff.data());
+    std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff{};
+    while (strm_.avail_in > 0 && ret == Z_OK) {
+      strm_.avail_out = static_cast<uInt>(buff.size());
+      strm_.next_out = reinterpret_cast<Bytef *>(buff.data());
 
-			ret = inflate(&strm_, Z_NO_FLUSH);
+      ret = inflate(&strm_, Z_NO_FLUSH);
 
-			assert(ret != Z_STREAM_ERROR);
-			switch (ret) {
-			case Z_NEED_DICT:
-			case Z_DATA_ERROR:
-			case Z_MEM_ERROR:
-				inflateEnd(&strm_);
-				return false;
-			}
+      assert(ret != Z_STREAM_ERROR);
+      switch (ret) {
+      case Z_NEED_DICT:
+      case Z_DATA_ERROR:
+      case Z_MEM_ERROR: inflateEnd(&strm_); return false;
+      }
 
-			if (!callback(buff.data(), buff.size() - strm_.avail_out)) {
-				return false;
-			}
-		}
+      if (!callback(buff.data(), buff.size() - strm_.avail_out)) {
+        return false;
+      }
+    }
 
-		if (ret != Z_OK && ret != Z_STREAM_END) {
-			return false;
-		}
+    if (ret != Z_OK && ret != Z_STREAM_END) { return false; }
 
-	} while (data_length > 0);
+  } while (data_length > 0);
 
-	return true;
+  return true;
 }
 #endif
 
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
 inline brotli_compressor::brotli_compressor() {
-	state_ = BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
+  state_ = BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
 }
 
 inline brotli_compressor::~brotli_compressor() {
-	BrotliEncoderDestroyInstance(state_);
+  BrotliEncoderDestroyInstance(state_);
 }
 
-inline bool brotli_compressor::compress(const char *data, size_t data_length, bool last, Callback callback) {
-	std::array<uint8_t, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff {};
+inline bool brotli_compressor::compress(const char *data, size_t data_length,
+                                        bool last, Callback callback) {
+  std::array<uint8_t, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff{};
 
-	auto operation = last ? BROTLI_OPERATION_FINISH : BROTLI_OPERATION_PROCESS;
-	auto available_in = data_length;
-	auto next_in = reinterpret_cast<const uint8_t *>(data);
+  auto operation = last ? BROTLI_OPERATION_FINISH : BROTLI_OPERATION_PROCESS;
+  auto available_in = data_length;
+  auto next_in = reinterpret_cast<const uint8_t *>(data);
 
-	for (;;) {
-		if (last) {
-			if (BrotliEncoderIsFinished(state_)) {
-				break;
-			}
-		} else {
-			if (!available_in) {
-				break;
-			}
-		}
+  for (;;) {
+    if (last) {
+      if (BrotliEncoderIsFinished(state_)) { break; }
+    } else {
+      if (!available_in) { break; }
+    }
 
-		auto available_out = buff.size();
-		auto next_out = buff.data();
+    auto available_out = buff.size();
+    auto next_out = buff.data();
 
-		if (!BrotliEncoderCompressStream(state_, operation, &available_in, &next_in, &available_out, &next_out,
-		                                 nullptr)) {
-			return false;
-		}
+    if (!BrotliEncoderCompressStream(state_, operation, &available_in, &next_in,
+                                     &available_out, &next_out, nullptr)) {
+      return false;
+    }
 
-		auto output_bytes = buff.size() - available_out;
-		if (output_bytes) {
-			callback(reinterpret_cast<const char *>(buff.data()), output_bytes);
-		}
-	}
+    auto output_bytes = buff.size() - available_out;
+    if (output_bytes) {
+      callback(reinterpret_cast<const char *>(buff.data()), output_bytes);
+    }
+  }
 
-	return true;
+  return true;
 }
 
 inline brotli_decompressor::brotli_decompressor() {
-	decoder_s = BrotliDecoderCreateInstance(0, 0, 0);
-	decoder_r = decoder_s ? BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT : BROTLI_DECODER_RESULT_ERROR;
+  decoder_s = BrotliDecoderCreateInstance(0, 0, 0);
+  decoder_r = decoder_s ? BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT
+                        : BROTLI_DECODER_RESULT_ERROR;
 }
 
 inline brotli_decompressor::~brotli_decompressor() {
-	if (decoder_s) {
-		BrotliDecoderDestroyInstance(decoder_s);
-	}
+  if (decoder_s) { BrotliDecoderDestroyInstance(decoder_s); }
 }
 
-inline bool brotli_decompressor::is_valid() const {
-	return decoder_s;
-}
+inline bool brotli_decompressor::is_valid() const { return decoder_s; }
 
-inline bool brotli_decompressor::decompress(const char *data, size_t data_length, Callback callback) {
-	if (decoder_r == BROTLI_DECODER_RESULT_SUCCESS || decoder_r == BROTLI_DECODER_RESULT_ERROR) {
-		return 0;
-	}
+inline bool brotli_decompressor::decompress(const char *data,
+                                            size_t data_length,
+                                            Callback callback) {
+  if (decoder_r == BROTLI_DECODER_RESULT_SUCCESS ||
+      decoder_r == BROTLI_DECODER_RESULT_ERROR) {
+    return 0;
+  }
 
-	auto next_in = reinterpret_cast<const uint8_t *>(data);
-	size_t avail_in = data_length;
-	size_t total_out;
+  auto next_in = reinterpret_cast<const uint8_t *>(data);
+  size_t avail_in = data_length;
+  size_t total_out;
 
-	decoder_r = BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT;
+  decoder_r = BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT;
 
-	std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff {};
-	while (decoder_r == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
-		char *next_out = buff.data();
-		size_t avail_out = buff.size();
+  std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff{};
+  while (decoder_r == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
+    char *next_out = buff.data();
+    size_t avail_out = buff.size();
 
-		decoder_r = BrotliDecoderDecompressStream(decoder_s, &avail_in, &next_in, &avail_out,
-		                                          reinterpret_cast<uint8_t **>(&next_out), &total_out);
+    decoder_r = BrotliDecoderDecompressStream(
+        decoder_s, &avail_in, &next_in, &avail_out,
+        reinterpret_cast<uint8_t **>(&next_out), &total_out);
 
-		if (decoder_r == BROTLI_DECODER_RESULT_ERROR) {
-			return false;
-		}
+    if (decoder_r == BROTLI_DECODER_RESULT_ERROR) { return false; }
 
-		if (!callback(buff.data(), buff.size() - avail_out)) {
-			return false;
-		}
-	}
+    if (!callback(buff.data(), buff.size() - avail_out)) { return false; }
+  }
 
-	return decoder_r == BROTLI_DECODER_RESULT_SUCCESS || decoder_r == BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT;
+  return decoder_r == BROTLI_DECODER_RESULT_SUCCESS ||
+         decoder_r == BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT;
 }
 #endif
 
 inline bool has_header(const Headers &headers, const std::string &key) {
-	return headers.find(key) != headers.end();
+  return headers.find(key) != headers.end();
 }
 
-inline const char *get_header_value(const Headers &headers, const std::string &key, size_t id, const char *def) {
-	auto rng = headers.equal_range(key);
-	auto it = rng.first;
-	std::advance(it, static_cast<ssize_t>(id));
-	if (it != rng.second) {
-		return it->second.c_str();
-	}
-	return def;
+inline const char *get_header_value(const Headers &headers,
+                                    const std::string &key, size_t id,
+                                    const char *def) {
+  auto rng = headers.equal_range(key);
+  auto it = rng.first;
+  std::advance(it, static_cast<ssize_t>(id));
+  if (it != rng.second) { return it->second.c_str(); }
+  return def;
 }
 
 inline bool compare_case_ignore(const std::string &a, const std::string &b) {
-	if (a.size() != b.size()) {
-		return false;
-	}
-	for (size_t i = 0; i < b.size(); i++) {
-		if (::tolower(a[i]) != ::tolower(b[i])) {
-			return false;
-		}
-	}
-	return true;
+  if (a.size() != b.size()) { return false; }
+  for (size_t i = 0; i < b.size(); i++) {
+    if (::tolower(a[i]) != ::tolower(b[i])) { return false; }
+  }
+  return true;
 }
 
 template <typename T>
 inline bool parse_header(const char *beg, const char *end, T fn) {
-	// Skip trailing spaces and tabs.
-	while (beg < end && is_space_or_tab(end[-1])) {
-		end--;
-	}
+  // Skip trailing spaces and tabs.
+  while (beg < end && is_space_or_tab(end[-1])) {
+    end--;
+  }
 
-	auto p = beg;
-	while (p < end && *p != ':') {
-		p++;
-	}
+  auto p = beg;
+  while (p < end && *p != ':') {
+    p++;
+  }
 
-	if (p == end) {
-		return false;
-	}
+  if (p == end) { return false; }
 
-	auto key_end = p;
+  auto key_end = p;
 
-	if (*p++ != ':') {
-		return false;
-	}
+  if (*p++ != ':') { return false; }
 
-	while (p < end && is_space_or_tab(*p)) {
-		p++;
-	}
+  while (p < end && is_space_or_tab(*p)) {
+    p++;
+  }
 
-	if (p < end) {
-		auto key_len = key_end - beg;
-		if (!key_len) {
-			return false;
-		}
+  if (p < end) {
+    auto key_len = key_end - beg;
+    if (!key_len) { return false; }
 
-		auto key = std::string(beg, key_end);
-		auto val = compare_case_ignore(key, "Location") || compare_case_ignore(key, "Link")
-		               ? std::string(p, end)
-		               : decode_url(std::string(p, end), false);
-		fn(std::move(key), std::move(val));
-		return true;
-	}
+    auto key = std::string(beg, key_end);
+    auto val = compare_case_ignore(key, "Location") || compare_case_ignore(key, "Link")
+                   ? std::string(p, end)
+                   : decode_url(std::string(p, end), false);
+    fn(std::move(key), std::move(val));
+    return true;
+  }
 
-	return false;
+  return false;
 }
 
 inline bool read_headers(Stream &strm, Headers &headers) {
-	const auto bufsiz = 2048;
-	char buf[bufsiz];
-	stream_line_reader line_reader(strm, buf, bufsiz);
+  const auto bufsiz = 2048;
+  char buf[bufsiz];
+  stream_line_reader line_reader(strm, buf, bufsiz);
 
-	for (;;) {
-		if (!line_reader.getline()) {
-			return false;
-		}
+  for (;;) {
+    if (!line_reader.getline()) { return false; }
 
-		// Check if the line ends with CRLF.
-		auto line_terminator_len = 2;
-		if (line_reader.end_with_crlf()) {
-			// Blank line indicates end of headers.
-			if (line_reader.size() == 2) {
-				break;
-			}
+    // Check if the line ends with CRLF.
+    auto line_terminator_len = 2;
+    if (line_reader.end_with_crlf()) {
+      // Blank line indicates end of headers.
+      if (line_reader.size() == 2) { break; }
 #ifdef CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR
-		} else {
-			// Blank line indicates end of headers.
-			if (line_reader.size() == 1) {
-				break;
-			}
-			line_terminator_len = 1;
-		}
+    } else {
+      // Blank line indicates end of headers.
+      if (line_reader.size() == 1) { break; }
+      line_terminator_len = 1;
+    }
 #else
-		} else {
-			continue; // Skip invalid line.
-		}
+    } else {
+      continue; // Skip invalid line.
+    }
 #endif
 
-		if (line_reader.size() > CPPHTTPLIB_HEADER_MAX_LENGTH) {
-			return false;
-		}
+    if (line_reader.size() > CPPHTTPLIB_HEADER_MAX_LENGTH) { return false; }
 
-		// Exclude line terminator
-		auto end = line_reader.ptr() + line_reader.size() - line_terminator_len;
+    // Exclude line terminator
+    auto end = line_reader.ptr() + line_reader.size() - line_terminator_len;
 
-		parse_header(line_reader.ptr(), end,
-		             [&](std::string &&key, std::string &&val) { headers.emplace(std::move(key), std::move(val)); });
-	}
+    parse_header(line_reader.ptr(), end,
+                 [&](std::string &&key, std::string &&val) {
+                   headers.emplace(std::move(key), std::move(val));
+                 });
+  }
 
-	return true;
+  return true;
 }
 
-inline bool read_content_with_length(Stream &strm, uint64_t len, Progress progress, ContentReceiverWithProgress out) {
-	char buf[CPPHTTPLIB_RECV_BUFSIZ];
+inline bool read_content_with_length(Stream &strm, uint64_t len,
+                                     Progress progress,
+                                     ContentReceiverWithProgress out) {
+  char buf[CPPHTTPLIB_RECV_BUFSIZ];
 
-	uint64_t r = 0;
-	while (r < len) {
-		auto read_len = static_cast<size_t>(len - r);
-		auto n = strm.read(buf, (std::min)(read_len, CPPHTTPLIB_RECV_BUFSIZ));
-		if (n <= 0) {
-			return false;
-		}
+  uint64_t r = 0;
+  while (r < len) {
+    auto read_len = static_cast<size_t>(len - r);
+    auto n = strm.read(buf, (std::min)(read_len, CPPHTTPLIB_RECV_BUFSIZ));
+    if (n <= 0) { return false; }
 
-		if (!out(buf, static_cast<size_t>(n), r, len)) {
-			return false;
-		}
-		r += static_cast<uint64_t>(n);
+    if (!out(buf, static_cast<size_t>(n), r, len)) { return false; }
+    r += static_cast<uint64_t>(n);
 
-		if (progress) {
-			if (!progress(r, len)) {
-				return false;
-			}
-		}
-	}
+    if (progress) {
+      if (!progress(r, len)) { return false; }
+    }
+  }
 
-	return true;
+  return true;
 }
 
 inline void skip_content_with_length(Stream &strm, uint64_t len) {
-	char buf[CPPHTTPLIB_RECV_BUFSIZ];
-	uint64_t r = 0;
-	while (r < len) {
-		auto read_len = static_cast<size_t>(len - r);
-		auto n = strm.read(buf, (std::min)(read_len, CPPHTTPLIB_RECV_BUFSIZ));
-		if (n <= 0) {
-			return;
-		}
-		r += static_cast<uint64_t>(n);
-	}
+  char buf[CPPHTTPLIB_RECV_BUFSIZ];
+  uint64_t r = 0;
+  while (r < len) {
+    auto read_len = static_cast<size_t>(len - r);
+    auto n = strm.read(buf, (std::min)(read_len, CPPHTTPLIB_RECV_BUFSIZ));
+    if (n <= 0) { return; }
+    r += static_cast<uint64_t>(n);
+  }
 }
 
-inline bool read_content_without_length(Stream &strm, ContentReceiverWithProgress out) {
-	char buf[CPPHTTPLIB_RECV_BUFSIZ];
-	uint64_t r = 0;
-	for (;;) {
-		auto n = strm.read(buf, CPPHTTPLIB_RECV_BUFSIZ);
-		if (n <= 0) {
-			return true;
-		}
+inline bool read_content_without_length(Stream &strm,
+                                        ContentReceiverWithProgress out) {
+  char buf[CPPHTTPLIB_RECV_BUFSIZ];
+  uint64_t r = 0;
+  for (;;) {
+    auto n = strm.read(buf, CPPHTTPLIB_RECV_BUFSIZ);
+    if (n <= 0) { return true; }
 
-		if (!out(buf, static_cast<size_t>(n), r, 0)) {
-			return false;
-		}
-		r += static_cast<uint64_t>(n);
-	}
+    if (!out(buf, static_cast<size_t>(n), r, 0)) { return false; }
+    r += static_cast<uint64_t>(n);
+  }
 
-	return true;
+  return true;
 }
 
 template <typename T>
-inline bool read_content_chunked(Stream &strm, T &x, ContentReceiverWithProgress out) {
-	const auto bufsiz = 16;
-	char buf[bufsiz];
+inline bool read_content_chunked(Stream &strm, T &x,
+                                 ContentReceiverWithProgress out) {
+  const auto bufsiz = 16;
+  char buf[bufsiz];
 
-	stream_line_reader line_reader(strm, buf, bufsiz);
+  stream_line_reader line_reader(strm, buf, bufsiz);
 
-	if (!line_reader.getline()) {
-		return false;
-	}
+  if (!line_reader.getline()) { return false; }
 
-	unsigned long chunk_len;
-	while (true) {
-		char *end_ptr;
+  unsigned long chunk_len;
+  while (true) {
+    char *end_ptr;
 
-		chunk_len = std::strtoul(line_reader.ptr(), &end_ptr, 16);
+    chunk_len = std::strtoul(line_reader.ptr(), &end_ptr, 16);
 
-		if (end_ptr == line_reader.ptr()) {
-			return false;
-		}
-		if (chunk_len == ULONG_MAX) {
-			return false;
-		}
+    if (end_ptr == line_reader.ptr()) { return false; }
+    if (chunk_len == ULONG_MAX) { return false; }
 
-		if (chunk_len == 0) {
-			break;
-		}
+    if (chunk_len == 0) { break; }
 
-		if (!read_content_with_length(strm, chunk_len, nullptr, out)) {
-			return false;
-		}
+    if (!read_content_with_length(strm, chunk_len, nullptr, out)) {
+      return false;
+    }
 
-		if (!line_reader.getline()) {
-			return false;
-		}
+    if (!line_reader.getline()) { return false; }
 
-		if (strcmp(line_reader.ptr(), "\r\n") != 0) {
-			return false;
-		}
+    if (strcmp(line_reader.ptr(), "\r\n") != 0) { return false; }
 
-		if (!line_reader.getline()) {
-			return false;
-		}
-	}
+    if (!line_reader.getline()) { return false; }
+  }
 
-	assert(chunk_len == 0);
+  assert(chunk_len == 0);
 
-	// Trailer
-	if (!line_reader.getline()) {
-		return false;
-	}
+  // Trailer
+  if (!line_reader.getline()) { return false; }
 
-	while (strcmp(line_reader.ptr(), "\r\n") != 0) {
-		if (line_reader.size() > CPPHTTPLIB_HEADER_MAX_LENGTH) {
-			return false;
-		}
+  while (strcmp(line_reader.ptr(), "\r\n") != 0) {
+    if (line_reader.size() > CPPHTTPLIB_HEADER_MAX_LENGTH) { return false; }
 
-		// Exclude line terminator
-		constexpr auto line_terminator_len = 2;
-		auto end = line_reader.ptr() + line_reader.size() - line_terminator_len;
+    // Exclude line terminator
+    constexpr auto line_terminator_len = 2;
+    auto end = line_reader.ptr() + line_reader.size() - line_terminator_len;
 
-		parse_header(line_reader.ptr(), end,
-		             [&](std::string &&key, std::string &&val) { x.headers.emplace(std::move(key), std::move(val)); });
+    parse_header(line_reader.ptr(), end,
+                 [&](std::string &&key, std::string &&val) {
+                   x.headers.emplace(std::move(key), std::move(val));
+                 });
 
-		if (!line_reader.getline()) {
-			return false;
-		}
-	}
+    if (!line_reader.getline()) { return false; }
+  }
 
-	return true;
+  return true;
 }
 
 inline bool is_chunked_transfer_encoding(const Headers &headers) {
-	return !strcasecmp(get_header_value(headers, "Transfer-Encoding", 0, ""), "chunked");
+  return !strcasecmp(get_header_value(headers, "Transfer-Encoding", 0, ""),
+                     "chunked");
 }
 
 template <typename T, typename U>
-bool prepare_content_receiver(T &x, int &status, ContentReceiverWithProgress receiver, bool decompress, U callback) {
-	if (decompress) {
-		std::string encoding = x.get_header_value("Content-Encoding");
-		duckdb::unique_ptr<decompressor> decompressor;
+bool prepare_content_receiver(T &x, int &status,
+                              ContentReceiverWithProgress receiver,
+                              bool decompress, U callback) {
+  if (decompress) {
+    std::string encoding = x.get_header_value("Content-Encoding");
+    duckdb::unique_ptr<decompressor> decompressor;
 
-		if (encoding == "gzip" || encoding == "deflate") {
+    if (encoding == "gzip" || encoding == "deflate") {
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-			decompressor = detail::make_unique<gzip_decompressor>();
+      decompressor = detail::make_unique<gzip_decompressor>();
 #else
-			status = StatusCode::UnsupportedMediaType_415;
-			return false;
+      status = StatusCode::UnsupportedMediaType_415;
+      return false;
 #endif
-		} else if (encoding.find("br") != std::string::npos) {
+    } else if (encoding.find("br") != std::string::npos) {
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
-			decompressor = detail::make_unique<brotli_decompressor>();
+      decompressor = detail::make_unique<brotli_decompressor>();
 #else
-			status = StatusCode::UnsupportedMediaType_415;
-			return false;
+      status = StatusCode::UnsupportedMediaType_415;
+      return false;
 #endif
-		}
+    }
 
-		if (decompressor) {
-			if (decompressor->is_valid()) {
-				ContentReceiverWithProgress out = [&](const char *buf, size_t n, uint64_t off, uint64_t len) {
-					return decompressor->decompress(
-					    buf, n, [&](const char *buf2, size_t n2) { return receiver(buf2, n2, off, len); });
-				};
-				return callback(std::move(out));
-			} else {
-				status = StatusCode::InternalServerError_500;
-				return false;
-			}
-		}
-	}
+    if (decompressor) {
+      if (decompressor->is_valid()) {
+        ContentReceiverWithProgress out = [&](const char *buf, size_t n,
+                                              uint64_t off, uint64_t len) {
+          return decompressor->decompress(buf, n,
+                                          [&](const char *buf2, size_t n2) {
+                                            return receiver(buf2, n2, off, len);
+                                          });
+        };
+        return callback(std::move(out));
+      } else {
+        status = StatusCode::InternalServerError_500;
+        return false;
+      }
+    }
+  }
 
-	ContentReceiverWithProgress out = [&](const char *buf, size_t n, uint64_t off, uint64_t len) {
-		return receiver(buf, n, off, len);
-	};
-	return callback(std::move(out));
+  ContentReceiverWithProgress out = [&](const char *buf, size_t n, uint64_t off,
+                                        uint64_t len) {
+    return receiver(buf, n, off, len);
+  };
+  return callback(std::move(out));
 }
 
 template <typename T>
-bool read_content(Stream &strm, T &x, size_t payload_max_length, int &status, Progress progress,
-                  ContentReceiverWithProgress receiver, bool decompress) {
-	return prepare_content_receiver(
-	    x, status, std::move(receiver), decompress, [&](const ContentReceiverWithProgress &out) {
-		    auto ret = true;
-		    auto exceed_payload_max_length = false;
+bool read_content(Stream &strm, T &x, size_t payload_max_length, int &status,
+                  Progress progress, ContentReceiverWithProgress receiver,
+                  bool decompress) {
+  return prepare_content_receiver(
+      x, status, std::move(receiver), decompress,
+      [&](const ContentReceiverWithProgress &out) {
+        auto ret = true;
+        auto exceed_payload_max_length = false;
 
-		    if (is_chunked_transfer_encoding(x.headers)) {
-			    ret = read_content_chunked(strm, x, out);
-		    } else if (!has_header(x.headers, "Content-Length")) {
-			    ret = read_content_without_length(strm, out);
-		    } else {
-			    auto len = get_header_value_u64(x.headers, "Content-Length", 0, 0);
-			    if (len > payload_max_length) {
-				    exceed_payload_max_length = true;
-				    skip_content_with_length(strm, len);
-				    ret = false;
-			    } else if (len > 0) {
-				    ret = read_content_with_length(strm, len, std::move(progress), out);
-			    }
-		    }
+        if (is_chunked_transfer_encoding(x.headers)) {
+          ret = read_content_chunked(strm, x, out);
+        } else if (!has_header(x.headers, "Content-Length")) {
+          ret = read_content_without_length(strm, out);
+        } else {
+          auto len = get_header_value_u64(x.headers, "Content-Length", 0, 0);
+          if (len > payload_max_length) {
+            exceed_payload_max_length = true;
+            skip_content_with_length(strm, len);
+            ret = false;
+          } else if (len > 0) {
+            ret = read_content_with_length(strm, len, std::move(progress), out);
+          }
+        }
 
-		    if (!ret) {
-			    status = exceed_payload_max_length ? StatusCode::PayloadTooLarge_413 : StatusCode::BadRequest_400;
-		    }
-		    return ret;
-	    });
+        if (!ret) {
+          status = exceed_payload_max_length ? StatusCode::PayloadTooLarge_413
+                                             : StatusCode::BadRequest_400;
+        }
+        return ret;
+      });
 } // namespace detail
 
 inline ssize_t write_headers(Stream &strm, const Headers &headers) {
-	ssize_t write_len = 0;
-	for (const auto &x : headers) {
-		auto len = strm.write_format("%s: %s\r\n", x.first.c_str(), x.second.c_str());
-		if (len < 0) {
-			return len;
-		}
-		write_len += len;
-	}
-	auto len = strm.write("\r\n");
-	if (len < 0) {
-		return len;
-	}
-	write_len += len;
-	return write_len;
+  ssize_t write_len = 0;
+  for (const auto &x : headers) {
+    auto len =
+        strm.write_format("%s: %s\r\n", x.first.c_str(), x.second.c_str());
+    if (len < 0) { return len; }
+    write_len += len;
+  }
+  auto len = strm.write("\r\n");
+  if (len < 0) { return len; }
+  write_len += len;
+  return write_len;
 }
 
 inline bool write_data(Stream &strm, const char *d, size_t l) {
-	size_t offset = 0;
-	while (offset < l) {
-		auto length = strm.write(d + offset, l - offset);
-		if (length < 0) {
-			return false;
-		}
-		offset += static_cast<size_t>(length);
-	}
-	return true;
+  size_t offset = 0;
+  while (offset < l) {
+    auto length = strm.write(d + offset, l - offset);
+    if (length < 0) { return false; }
+    offset += static_cast<size_t>(length);
+  }
+  return true;
 }
 
 template <typename T>
-inline bool write_content(Stream &strm, const ContentProvider &content_provider, size_t offset, size_t length,
-                          T is_shutting_down, Error &error) {
-	size_t end_offset = offset + length;
-	auto ok = true;
-	DataSink data_sink;
+inline bool write_content(Stream &strm, const ContentProvider &content_provider,
+                          size_t offset, size_t length, T is_shutting_down,
+                          Error &error) {
+  size_t end_offset = offset + length;
+  auto ok = true;
+  DataSink data_sink;
 
-	data_sink.write = [&](const char *d, size_t l) -> bool {
-		if (ok) {
-			if (strm.is_writable() && write_data(strm, d, l)) {
-				offset += l;
-			} else {
-				ok = false;
-			}
-		}
-		return ok;
-	};
+  data_sink.write = [&](const char *d, size_t l) -> bool {
+    if (ok) {
+      if (strm.is_writable() && write_data(strm, d, l)) {
+        offset += l;
+      } else {
+        ok = false;
+      }
+    }
+    return ok;
+  };
 
-	data_sink.is_writable = [&]() -> bool {
-		return strm.is_writable();
-	};
+  data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
 
-	while (offset < end_offset && !is_shutting_down()) {
-		if (!strm.is_writable()) {
-			error = Error::Write;
-			return false;
-		} else if (!content_provider(offset, end_offset - offset, data_sink)) {
-			error = Error::Canceled;
-			return false;
-		} else if (!ok) {
-			error = Error::Write;
-			return false;
-		}
-	}
+  while (offset < end_offset && !is_shutting_down()) {
+    if (!strm.is_writable()) {
+      error = Error::Write;
+      return false;
+    } else if (!content_provider(offset, end_offset - offset, data_sink)) {
+      error = Error::Canceled;
+      return false;
+    } else if (!ok) {
+      error = Error::Write;
+      return false;
+    }
+  }
 
-	error = Error::Success;
-	return true;
+  error = Error::Success;
+  return true;
 }
 
 template <typename T>
-inline bool write_content(Stream &strm, const ContentProvider &content_provider, size_t offset, size_t length,
+inline bool write_content(Stream &strm, const ContentProvider &content_provider,
+                          size_t offset, size_t length,
                           const T &is_shutting_down) {
-	auto error = Error::Success;
-	return write_content(strm, content_provider, offset, length, is_shutting_down, error);
+  auto error = Error::Success;
+  return write_content(strm, content_provider, offset, length, is_shutting_down,
+                       error);
 }
 
 template <typename T>
-inline bool write_content_without_length(Stream &strm, const ContentProvider &content_provider,
-                                         const T &is_shutting_down) {
-	size_t offset = 0;
-	auto data_available = true;
-	auto ok = true;
-	DataSink data_sink;
+inline bool
+write_content_without_length(Stream &strm,
+                             const ContentProvider &content_provider,
+                             const T &is_shutting_down) {
+  size_t offset = 0;
+  auto data_available = true;
+  auto ok = true;
+  DataSink data_sink;
 
-	data_sink.write = [&](const char *d, size_t l) -> bool {
-		if (ok) {
-			offset += l;
-			if (!strm.is_writable() || !write_data(strm, d, l)) {
-				ok = false;
-			}
-		}
-		return ok;
-	};
+  data_sink.write = [&](const char *d, size_t l) -> bool {
+    if (ok) {
+      offset += l;
+      if (!strm.is_writable() || !write_data(strm, d, l)) { ok = false; }
+    }
+    return ok;
+  };
 
-	data_sink.is_writable = [&]() -> bool {
-		return strm.is_writable();
-	};
+  data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
 
-	data_sink.done = [&](void) {
-		data_available = false;
-	};
+  data_sink.done = [&](void) { data_available = false; };
 
-	while (data_available && !is_shutting_down()) {
-		if (!strm.is_writable()) {
-			return false;
-		} else if (!content_provider(offset, 0, data_sink)) {
-			return false;
-		} else if (!ok) {
-			return false;
-		}
-	}
-	return true;
+  while (data_available && !is_shutting_down()) {
+    if (!strm.is_writable()) {
+      return false;
+    } else if (!content_provider(offset, 0, data_sink)) {
+      return false;
+    } else if (!ok) {
+      return false;
+    }
+  }
+  return true;
 }
 
 template <typename T, typename U>
-inline bool write_content_chunked(Stream &strm, const ContentProvider &content_provider, const T &is_shutting_down,
-                                  U &compressor, Error &error) {
-	size_t offset = 0;
-	auto data_available = true;
-	auto ok = true;
-	DataSink data_sink;
+inline bool
+write_content_chunked(Stream &strm, const ContentProvider &content_provider,
+                      const T &is_shutting_down, U &compressor, Error &error) {
+  size_t offset = 0;
+  auto data_available = true;
+  auto ok = true;
+  DataSink data_sink;
 
-	data_sink.write = [&](const char *d, size_t l) -> bool {
-		if (ok) {
-			data_available = l > 0;
-			offset += l;
+  data_sink.write = [&](const char *d, size_t l) -> bool {
+    if (ok) {
+      data_available = l > 0;
+      offset += l;
 
-			std::string payload;
-			if (compressor.compress(d, l, false, [&](const char *data, size_t data_len) {
-				    payload.append(data, data_len);
-				    return true;
-			    })) {
-				if (!payload.empty()) {
-					// Emit chunked response header and footer for each chunk
-					auto chunk = from_i_to_hex(payload.size()) + "\r\n" + payload + "\r\n";
-					if (!strm.is_writable() || !write_data(strm, chunk.data(), chunk.size())) {
-						ok = false;
-					}
-				}
-			} else {
-				ok = false;
-			}
-		}
-		return ok;
-	};
+      std::string payload;
+      if (compressor.compress(d, l, false,
+                              [&](const char *data, size_t data_len) {
+                                payload.append(data, data_len);
+                                return true;
+                              })) {
+        if (!payload.empty()) {
+          // Emit chunked response header and footer for each chunk
+          auto chunk =
+              from_i_to_hex(payload.size()) + "\r\n" + payload + "\r\n";
+          if (!strm.is_writable() ||
+              !write_data(strm, chunk.data(), chunk.size())) {
+            ok = false;
+          }
+        }
+      } else {
+        ok = false;
+      }
+    }
+    return ok;
+  };
 
-	data_sink.is_writable = [&]() -> bool {
-		return strm.is_writable();
-	};
+  data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
 
-	auto done_with_trailer = [&](const Headers *trailer) {
-		if (!ok) {
-			return;
-		}
+  auto done_with_trailer = [&](const Headers *trailer) {
+    if (!ok) { return; }
 
-		data_available = false;
+    data_available = false;
 
-		std::string payload;
-		if (!compressor.compress(nullptr, 0, true, [&](const char *data, size_t data_len) {
-			    payload.append(data, data_len);
-			    return true;
-		    })) {
-			ok = false;
-			return;
-		}
+    std::string payload;
+    if (!compressor.compress(nullptr, 0, true,
+                             [&](const char *data, size_t data_len) {
+                               payload.append(data, data_len);
+                               return true;
+                             })) {
+      ok = false;
+      return;
+    }
 
-		if (!payload.empty()) {
-			// Emit chunked response header and footer for each chunk
-			auto chunk = from_i_to_hex(payload.size()) + "\r\n" + payload + "\r\n";
-			if (!strm.is_writable() || !write_data(strm, chunk.data(), chunk.size())) {
-				ok = false;
-				return;
-			}
-		}
+    if (!payload.empty()) {
+      // Emit chunked response header and footer for each chunk
+      auto chunk = from_i_to_hex(payload.size()) + "\r\n" + payload + "\r\n";
+      if (!strm.is_writable() ||
+          !write_data(strm, chunk.data(), chunk.size())) {
+        ok = false;
+        return;
+      }
+    }
 
-		const std::string done_marker("0\r\n");
-		if (!write_data(strm, done_marker.data(), done_marker.size())) {
-			ok = false;
-		}
+    const std::string done_marker("0\r\n");
+    if (!write_data(strm, done_marker.data(), done_marker.size())) {
+      ok = false;
+    }
 
-		// Trailer
-		if (trailer) {
-			for (const auto &kv : *trailer) {
-				std::string field_line = kv.first + ": " + kv.second + "\r\n";
-				if (!write_data(strm, field_line.data(), field_line.size())) {
-					ok = false;
-				}
-			}
-		}
+    // Trailer
+    if (trailer) {
+      for (const auto &kv : *trailer) {
+        std::string field_line = kv.first + ": " + kv.second + "\r\n";
+        if (!write_data(strm, field_line.data(), field_line.size())) {
+          ok = false;
+        }
+      }
+    }
 
-		const std::string crlf("\r\n");
-		if (!write_data(strm, crlf.data(), crlf.size())) {
-			ok = false;
-		}
-	};
+    const std::string crlf("\r\n");
+    if (!write_data(strm, crlf.data(), crlf.size())) { ok = false; }
+  };
 
-	data_sink.done = [&](void) {
-		done_with_trailer(nullptr);
-	};
+  data_sink.done = [&](void) { done_with_trailer(nullptr); };
 
-	data_sink.done_with_trailer = [&](const Headers &trailer) {
-		done_with_trailer(&trailer);
-	};
+  data_sink.done_with_trailer = [&](const Headers &trailer) {
+    done_with_trailer(&trailer);
+  };
 
-	while (data_available && !is_shutting_down()) {
-		if (!strm.is_writable()) {
-			error = Error::Write;
-			return false;
-		} else if (!content_provider(offset, 0, data_sink)) {
-			error = Error::Canceled;
-			return false;
-		} else if (!ok) {
-			error = Error::Write;
-			return false;
-		}
-	}
+  while (data_available && !is_shutting_down()) {
+    if (!strm.is_writable()) {
+      error = Error::Write;
+      return false;
+    } else if (!content_provider(offset, 0, data_sink)) {
+      error = Error::Canceled;
+      return false;
+    } else if (!ok) {
+      error = Error::Write;
+      return false;
+    }
+  }
 
-	error = Error::Success;
-	return true;
+  error = Error::Success;
+  return true;
 }
 
 template <typename T, typename U>
-inline bool write_content_chunked(Stream &strm, const ContentProvider &content_provider, const T &is_shutting_down,
-                                  U &compressor) {
-	auto error = Error::Success;
-	return write_content_chunked(strm, content_provider, is_shutting_down, compressor, error);
+inline bool write_content_chunked(Stream &strm,
+                                  const ContentProvider &content_provider,
+                                  const T &is_shutting_down, U &compressor) {
+  auto error = Error::Success;
+  return write_content_chunked(strm, content_provider, is_shutting_down,
+                               compressor, error);
 }
 
 template <typename T>
-inline bool redirect(T &cli, Request &req, Response &res, const std::string &path, const std::string &location,
+inline bool redirect(T &cli, Request &req, Response &res,
+                     const std::string &path, const std::string &location,
                      Error &error) {
-	Request new_req = req;
-	new_req.path = path;
-	new_req.redirect_count_ -= 1;
+  Request new_req = req;
+  new_req.path = path;
+  new_req.redirect_count_ -= 1;
 
-	if (res.status == StatusCode::SeeOther_303 && (req.method != "GET" && req.method != "HEAD")) {
-		new_req.method = "GET";
-		new_req.body.clear();
-		new_req.headers.clear();
-	}
+  if (res.status == StatusCode::SeeOther_303 &&
+      (req.method != "GET" && req.method != "HEAD")) {
+    new_req.method = "GET";
+    new_req.body.clear();
+    new_req.headers.clear();
+  }
 
-	Response new_res;
+  Response new_res;
 
-	auto ret = cli.send(new_req, new_res, error);
-	if (ret) {
-		req = new_req;
-		res = new_res;
+  auto ret = cli.send(new_req, new_res, error);
+  if (ret) {
+    req = new_req;
+    res = new_res;
 
-		if (res.location.empty()) {
-			res.location = location;
-		}
-	}
-	return ret;
+    if (res.location.empty()) { res.location = location; }
+  }
+  return ret;
 }
 
 inline std::string params_to_query_str(const Params &params) {
-	std::string query;
+  std::string query;
 
-	for (auto it = params.begin(); it != params.end(); ++it) {
-		if (it != params.begin()) {
-			query += "&";
-		}
-		query += it->first;
-		query += "=";
-		query += encode_query_param(it->second);
-	}
-	return query;
+  for (auto it = params.begin(); it != params.end(); ++it) {
+    if (it != params.begin()) { query += "&"; }
+    query += it->first;
+    query += "=";
+    query += encode_query_param(it->second);
+  }
+  return query;
 }
 
 inline void parse_query_text(const std::string &s, Params &params) {
-	std::set<std::string> cache;
-	split(s.data(), s.data() + s.size(), '&', [&](const char *b, const char *e) {
-		std::string kv(b, e);
-		if (cache.find(kv) != cache.end()) {
-			return;
-		}
-		cache.insert(kv);
+  std::set<std::string> cache;
+  split(s.data(), s.data() + s.size(), '&', [&](const char *b, const char *e) {
+    std::string kv(b, e);
+    if (cache.find(kv) != cache.end()) { return; }
+    cache.insert(kv);
 
-		std::string key;
-		std::string val;
-		split(b, e, '=', [&](const char *b2, const char *e2) {
-			if (key.empty()) {
-				key.assign(b2, e2);
-			} else {
-				val.assign(b2, e2);
-			}
-		});
+    std::string key;
+    std::string val;
+    split(b, e, '=', [&](const char *b2, const char *e2) {
+      if (key.empty()) {
+        key.assign(b2, e2);
+      } else {
+        val.assign(b2, e2);
+      }
+    });
 
-		if (!key.empty()) {
-			params.emplace(decode_url(key, true), decode_url(val, true));
-		}
-	});
+    if (!key.empty()) {
+      params.emplace(decode_url(key, true), decode_url(val, true));
+    }
+  });
 }
 
-inline bool parse_multipart_boundary(const std::string &content_type, std::string &boundary) {
-	auto boundary_keyword = "boundary=";
-	auto pos = content_type.find(boundary_keyword);
-	if (pos == std::string::npos) {
-		return false;
-	}
-	auto end = content_type.find(';', pos);
-	auto beg = pos + strlen(boundary_keyword);
-	boundary = trim_double_quotes_copy(content_type.substr(beg, end - beg));
-	return !boundary.empty();
+inline bool parse_multipart_boundary(const std::string &content_type,
+                                     std::string &boundary) {
+  auto boundary_keyword = "boundary=";
+  auto pos = content_type.find(boundary_keyword);
+  if (pos == std::string::npos) { return false; }
+  auto end = content_type.find(';', pos);
+  auto beg = pos + strlen(boundary_keyword);
+  boundary = trim_double_quotes_copy(content_type.substr(beg, end - beg));
+  return !boundary.empty();
 }
 
 inline void parse_disposition_params(const std::string &s, Params &params) {
-	std::set<std::string> cache;
-	split(s.data(), s.data() + s.size(), ';', [&](const char *b, const char *e) {
-		std::string kv(b, e);
-		if (cache.find(kv) != cache.end()) {
-			return;
-		}
-		cache.insert(kv);
+  std::set<std::string> cache;
+  split(s.data(), s.data() + s.size(), ';', [&](const char *b, const char *e) {
+    std::string kv(b, e);
+    if (cache.find(kv) != cache.end()) { return; }
+    cache.insert(kv);
 
-		std::string key;
-		std::string val;
-		split(b, e, '=', [&](const char *b2, const char *e2) {
-			if (key.empty()) {
-				key.assign(b2, e2);
-			} else {
-				val.assign(b2, e2);
-			}
-		});
+    std::string key;
+    std::string val;
+    split(b, e, '=', [&](const char *b2, const char *e2) {
+      if (key.empty()) {
+        key.assign(b2, e2);
+      } else {
+        val.assign(b2, e2);
+      }
+    });
 
-		if (!key.empty()) {
-			params.emplace(trim_double_quotes_copy((key)), trim_double_quotes_copy((val)));
-		}
-	});
+    if (!key.empty()) {
+      params.emplace(trim_double_quotes_copy((key)),
+                     trim_double_quotes_copy((val)));
+    }
+  });
 }
 
 #ifdef CPPHTTPLIB_NO_EXCEPTIONS
@@ -4384,576 +4356,546 @@ inline bool parse_range_header(const std::string &s, Ranges &ranges) {
 #else
 inline bool parse_range_header(const std::string &s, Ranges &ranges) try {
 #endif
-	auto re_first_range = Regex(R"(bytes=(\d*-\d*(?:,\s*\d*-\d*)*))");
-	Match m;
-	if (RegexMatch(s, m, re_first_range)) {
-		auto pos = static_cast<size_t>(m.position(1));
-		auto len = static_cast<size_t>(m.length(1));
-		auto all_valid_ranges = true;
-		split(&s[pos], &s[pos + len], ',', [&](const char *b, const char *e) {
-			if (!all_valid_ranges) {
-				return;
-			}
-			auto re_another_range = Regex(R"(\s*(\d*)-(\d*))");
-			Match cm;
-			if (RegexMatch(b, e, cm, re_another_range)) {
-				ssize_t first = -1;
-				if (!cm.str(1).empty()) {
-					first = static_cast<ssize_t>(std::stoll(cm.str(1)));
-				}
+  auto re_first_range = Regex(R"(bytes=(\d*-\d*(?:,\s*\d*-\d*)*))");
+  Match m;
+  if (RegexMatch(s, m, re_first_range)) {
+    auto pos = static_cast<size_t>(m.position(1));
+    auto len = static_cast<size_t>(m.length(1));
+    auto all_valid_ranges = true;
+    split(&s[pos], &s[pos + len], ',', [&](const char *b, const char *e) {
+      if (!all_valid_ranges) { return; }
+      auto re_another_range = Regex(R"(\s*(\d*)-(\d*))");
+      Match cm;
+      if (RegexMatch(b, e, cm, re_another_range)) {
+        ssize_t first = -1;
+        if (!cm.str(1).empty()) {
+          first = static_cast<ssize_t>(std::stoll(cm.str(1)));
+        }
 
-				ssize_t last = -1;
-				if (!cm.str(2).empty()) {
-					last = static_cast<ssize_t>(std::stoll(cm.str(2)));
-				}
+        ssize_t last = -1;
+        if (!cm.str(2).empty()) {
+          last = static_cast<ssize_t>(std::stoll(cm.str(2)));
+        }
 
-				if (first != -1 && last != -1 && first > last) {
-					all_valid_ranges = false;
-					return;
-				}
-				ranges.emplace_back(std::make_pair(first, last));
-			}
-		});
-		return all_valid_ranges;
-	}
-	return false;
+        if (first != -1 && last != -1 && first > last) {
+          all_valid_ranges = false;
+          return;
+        }
+        ranges.emplace_back(std::make_pair(first, last));
+      }
+    });
+    return all_valid_ranges;
+  }
+  return false;
 #ifdef CPPHTTPLIB_NO_EXCEPTIONS
 }
 #else
-} catch (...) {
-	return false;
-}
+} catch (...) { return false; }
 #endif
 
 class MultipartFormDataParser {
 public:
-	MultipartFormDataParser() = default;
+  MultipartFormDataParser() = default;
 
-	void set_boundary(std::string &&boundary) {
-		boundary_ = boundary;
-		dash_boundary_crlf_ = dash_ + boundary_ + crlf_;
-		crlf_dash_boundary_ = crlf_ + dash_ + boundary_;
-	}
+  void set_boundary(std::string &&boundary) {
+    boundary_ = boundary;
+    dash_boundary_crlf_ = dash_ + boundary_ + crlf_;
+    crlf_dash_boundary_ = crlf_ + dash_ + boundary_;
+  }
 
-	bool is_valid() const {
-		return is_valid_;
-	}
+  bool is_valid() const { return is_valid_; }
 
-	bool parse(const char *buf, size_t n, const ContentReceiver &content_callback,
-	           const MultipartContentHeader &header_callback) {
+  bool parse(const char *buf, size_t n, const ContentReceiver &content_callback,
+             const MultipartContentHeader &header_callback) {
 
-		buf_append(buf, n);
+    buf_append(buf, n);
 
-		while (buf_size() > 0) {
-			switch (state_) {
-			case 0: { // Initial boundary
-				buf_erase(buf_find(dash_boundary_crlf_));
-				if (dash_boundary_crlf_.size() > buf_size()) {
-					return true;
-				}
-				if (!buf_start_with(dash_boundary_crlf_)) {
-					return false;
-				}
-				buf_erase(dash_boundary_crlf_.size());
-				state_ = 1;
-				break;
-			}
-			case 1: { // New entry
-				clear_file_info();
-				state_ = 2;
-				break;
-			}
-			case 2: { // Headers
-				auto pos = buf_find(crlf_);
-				if (pos > CPPHTTPLIB_HEADER_MAX_LENGTH) {
-					return false;
-				}
-				while (pos < buf_size()) {
-					// Empty line
-					if (pos == 0) {
-						if (!header_callback(file_)) {
-							is_valid_ = false;
-							return false;
-						}
-						buf_erase(crlf_.size());
-						state_ = 3;
-						break;
-					}
+    while (buf_size() > 0) {
+      switch (state_) {
+      case 0: { // Initial boundary
+        buf_erase(buf_find(dash_boundary_crlf_));
+        if (dash_boundary_crlf_.size() > buf_size()) { return true; }
+        if (!buf_start_with(dash_boundary_crlf_)) { return false; }
+        buf_erase(dash_boundary_crlf_.size());
+        state_ = 1;
+        break;
+      }
+      case 1: { // New entry
+        clear_file_info();
+        state_ = 2;
+        break;
+      }
+      case 2: { // Headers
+        auto pos = buf_find(crlf_);
+        if (pos > CPPHTTPLIB_HEADER_MAX_LENGTH) { return false; }
+        while (pos < buf_size()) {
+          // Empty line
+          if (pos == 0) {
+            if (!header_callback(file_)) {
+              is_valid_ = false;
+              return false;
+            }
+            buf_erase(crlf_.size());
+            state_ = 3;
+            break;
+          }
 
-					const auto header = buf_head(pos);
+          const auto header = buf_head(pos);
 
-					if (!parse_header(header.data(), header.data() + header.size(),
-					                  [&](std::string &&, std::string &&) {})) {
-						is_valid_ = false;
-						return false;
-					}
+          if (!parse_header(header.data(), header.data() + header.size(),
+                            [&](std::string &&, std::string &&) {})) {
+            is_valid_ = false;
+            return false;
+          }
 
-					const std::string header_content_type = "Content-Type:";
+          const std::string header_content_type = "Content-Type:";
 
-					if (start_with_case_ignore(header, header_content_type)) {
-						file_.content_type = trim_copy(header.substr(header_content_type.size()));
-					} else {
-						const Regex re_content_disposition(R"~(^Content-Disposition:\s*form-data;\s*(.*)$)~",
-						                                   duckdb_re2::RegexOptions::CASE_INSENSITIVE);
+          if (start_with_case_ignore(header, header_content_type)) {
+            file_.content_type =
+                trim_copy(header.substr(header_content_type.size()));
+          } else {
+            const Regex re_content_disposition(
+                R"~(^Content-Disposition:\s*form-data;\s*(.*)$)~",
+                duckdb_re2::RegexOptions::CASE_INSENSITIVE);
 
-						Match m;
-						if (RegexMatch(header, m, re_content_disposition)) {
-							Params params;
-							parse_disposition_params(m[1], params);
+            Match m;
+            if (RegexMatch(header, m, re_content_disposition)) {
+              Params params;
+              parse_disposition_params(m[1], params);
 
-							auto it = params.find("name");
-							if (it != params.end()) {
-								file_.name = it->second;
-							} else {
-								is_valid_ = false;
-								return false;
-							}
+              auto it = params.find("name");
+              if (it != params.end()) {
+                file_.name = it->second;
+              } else {
+                is_valid_ = false;
+                return false;
+              }
 
-							it = params.find("filename");
-							if (it != params.end()) {
-								file_.filename = it->second;
-							}
+              it = params.find("filename");
+              if (it != params.end()) { file_.filename = it->second; }
 
-							it = params.find("filename*");
-							if (it != params.end()) {
-								// Only allow UTF-8 enconnding...
-								const Regex re_rfc5987_encoding(R"~(^UTF-8''(.+?)$)~",
-								                                duckdb_re2::RegexOptions::CASE_INSENSITIVE);
+              it = params.find("filename*");
+              if (it != params.end()) {
+                // Only allow UTF-8 enconnding...
+                const Regex re_rfc5987_encoding(
+                    R"~(^UTF-8''(.+?)$)~", duckdb_re2::RegexOptions::CASE_INSENSITIVE);
 
-								Match m2;
-								if (RegexMatch(it->second, m2, re_rfc5987_encoding)) {
-									file_.filename = decode_url(m2[1], false); // override...
-								} else {
-									is_valid_ = false;
-									return false;
-								}
-							}
-						}
-					}
-					buf_erase(pos + crlf_.size());
-					pos = buf_find(crlf_);
-				}
-				if (state_ != 3) {
-					return true;
-				}
-				break;
-			}
-			case 3: { // Body
-				if (crlf_dash_boundary_.size() > buf_size()) {
-					return true;
-				}
-				auto pos = buf_find(crlf_dash_boundary_);
-				if (pos < buf_size()) {
-					if (!content_callback(buf_data(), pos)) {
-						is_valid_ = false;
-						return false;
-					}
-					buf_erase(pos + crlf_dash_boundary_.size());
-					state_ = 4;
-				} else {
-					auto len = buf_size() - crlf_dash_boundary_.size();
-					if (len > 0) {
-						if (!content_callback(buf_data(), len)) {
-							is_valid_ = false;
-							return false;
-						}
-						buf_erase(len);
-					}
-					return true;
-				}
-				break;
-			}
-			case 4: { // Boundary
-				if (crlf_.size() > buf_size()) {
-					return true;
-				}
-				if (buf_start_with(crlf_)) {
-					buf_erase(crlf_.size());
-					state_ = 1;
-				} else {
-					if (dash_.size() > buf_size()) {
-						return true;
-					}
-					if (buf_start_with(dash_)) {
-						buf_erase(dash_.size());
-						is_valid_ = true;
-						buf_erase(buf_size()); // Remove epilogue
-					} else {
-						return true;
-					}
-				}
-				break;
-			}
-			}
-		}
+                Match m2;
+                if (RegexMatch(it->second, m2, re_rfc5987_encoding)) {
+                  file_.filename = decode_url(m2[1], false); // override...
+                } else {
+                  is_valid_ = false;
+                  return false;
+                }
+              }
+            }
+          }
+          buf_erase(pos + crlf_.size());
+          pos = buf_find(crlf_);
+        }
+        if (state_ != 3) { return true; }
+        break;
+      }
+      case 3: { // Body
+        if (crlf_dash_boundary_.size() > buf_size()) { return true; }
+        auto pos = buf_find(crlf_dash_boundary_);
+        if (pos < buf_size()) {
+          if (!content_callback(buf_data(), pos)) {
+            is_valid_ = false;
+            return false;
+          }
+          buf_erase(pos + crlf_dash_boundary_.size());
+          state_ = 4;
+        } else {
+          auto len = buf_size() - crlf_dash_boundary_.size();
+          if (len > 0) {
+            if (!content_callback(buf_data(), len)) {
+              is_valid_ = false;
+              return false;
+            }
+            buf_erase(len);
+          }
+          return true;
+        }
+        break;
+      }
+      case 4: { // Boundary
+        if (crlf_.size() > buf_size()) { return true; }
+        if (buf_start_with(crlf_)) {
+          buf_erase(crlf_.size());
+          state_ = 1;
+        } else {
+          if (dash_.size() > buf_size()) { return true; }
+          if (buf_start_with(dash_)) {
+            buf_erase(dash_.size());
+            is_valid_ = true;
+            buf_erase(buf_size()); // Remove epilogue
+          } else {
+            return true;
+          }
+        }
+        break;
+      }
+      }
+    }
 
-		return true;
-	}
+    return true;
+  }
 
 private:
-	void clear_file_info() {
-		file_.name.clear();
-		file_.filename.clear();
-		file_.content_type.clear();
-	}
+  void clear_file_info() {
+    file_.name.clear();
+    file_.filename.clear();
+    file_.content_type.clear();
+  }
 
-	bool start_with_case_ignore(const std::string &a, const std::string &b) const {
-		if (a.size() < b.size()) {
-			return false;
-		}
-		for (size_t i = 0; i < b.size(); i++) {
-			if (::tolower(a[i]) != ::tolower(b[i])) {
-				return false;
-			}
-		}
-		return true;
-	}
+  bool start_with_case_ignore(const std::string &a,
+                              const std::string &b) const {
+    if (a.size() < b.size()) { return false; }
+    for (size_t i = 0; i < b.size(); i++) {
+      if (::tolower(a[i]) != ::tolower(b[i])) { return false; }
+    }
+    return true;
+  }
 
-	const std::string dash_ = "--";
-	const std::string crlf_ = "\r\n";
-	std::string boundary_;
-	std::string dash_boundary_crlf_;
-	std::string crlf_dash_boundary_;
+  const std::string dash_ = "--";
+  const std::string crlf_ = "\r\n";
+  std::string boundary_;
+  std::string dash_boundary_crlf_;
+  std::string crlf_dash_boundary_;
 
-	size_t state_ = 0;
-	bool is_valid_ = false;
-	MultipartFormData file_;
+  size_t state_ = 0;
+  bool is_valid_ = false;
+  MultipartFormData file_;
 
-	// Buffer
-	bool start_with(const std::string &a, size_t spos, size_t epos, const std::string &b) const {
-		if (epos - spos < b.size()) {
-			return false;
-		}
-		for (size_t i = 0; i < b.size(); i++) {
-			if (a[i + spos] != b[i]) {
-				return false;
-			}
-		}
-		return true;
-	}
+  // Buffer
+  bool start_with(const std::string &a, size_t spos, size_t epos,
+                  const std::string &b) const {
+    if (epos - spos < b.size()) { return false; }
+    for (size_t i = 0; i < b.size(); i++) {
+      if (a[i + spos] != b[i]) { return false; }
+    }
+    return true;
+  }
 
-	size_t buf_size() const {
-		return buf_epos_ - buf_spos_;
-	}
+  size_t buf_size() const { return buf_epos_ - buf_spos_; }
 
-	const char *buf_data() const {
-		return &buf_[buf_spos_];
-	}
+  const char *buf_data() const { return &buf_[buf_spos_]; }
 
-	std::string buf_head(size_t l) const {
-		return buf_.substr(buf_spos_, l);
-	}
+  std::string buf_head(size_t l) const { return buf_.substr(buf_spos_, l); }
 
-	bool buf_start_with(const std::string &s) const {
-		return start_with(buf_, buf_spos_, buf_epos_, s);
-	}
+  bool buf_start_with(const std::string &s) const {
+    return start_with(buf_, buf_spos_, buf_epos_, s);
+  }
 
-	size_t buf_find(const std::string &s) const {
-		auto c = s.front();
+  size_t buf_find(const std::string &s) const {
+    auto c = s.front();
 
-		size_t off = buf_spos_;
-		while (off < buf_epos_) {
-			auto pos = off;
-			while (true) {
-				if (pos == buf_epos_) {
-					return buf_size();
-				}
-				if (buf_[pos] == c) {
-					break;
-				}
-				pos++;
-			}
+    size_t off = buf_spos_;
+    while (off < buf_epos_) {
+      auto pos = off;
+      while (true) {
+        if (pos == buf_epos_) { return buf_size(); }
+        if (buf_[pos] == c) { break; }
+        pos++;
+      }
 
-			auto remaining_size = buf_epos_ - pos;
-			if (s.size() > remaining_size) {
-				return buf_size();
-			}
+      auto remaining_size = buf_epos_ - pos;
+      if (s.size() > remaining_size) { return buf_size(); }
 
-			if (start_with(buf_, pos, buf_epos_, s)) {
-				return pos - buf_spos_;
-			}
+      if (start_with(buf_, pos, buf_epos_, s)) { return pos - buf_spos_; }
 
-			off = pos + 1;
-		}
+      off = pos + 1;
+    }
 
-		return buf_size();
-	}
+    return buf_size();
+  }
 
-	void buf_append(const char *data, size_t n) {
-		auto remaining_size = buf_size();
-		if (remaining_size > 0 && buf_spos_ > 0) {
-			for (size_t i = 0; i < remaining_size; i++) {
-				buf_[i] = buf_[buf_spos_ + i];
-			}
-		}
-		buf_spos_ = 0;
-		buf_epos_ = remaining_size;
+  void buf_append(const char *data, size_t n) {
+    auto remaining_size = buf_size();
+    if (remaining_size > 0 && buf_spos_ > 0) {
+      for (size_t i = 0; i < remaining_size; i++) {
+        buf_[i] = buf_[buf_spos_ + i];
+      }
+    }
+    buf_spos_ = 0;
+    buf_epos_ = remaining_size;
 
-		if (remaining_size + n > buf_.size()) {
-			buf_.resize(remaining_size + n);
-		}
+    if (remaining_size + n > buf_.size()) { buf_.resize(remaining_size + n); }
 
-		for (size_t i = 0; i < n; i++) {
-			buf_[buf_epos_ + i] = data[i];
-		}
-		buf_epos_ += n;
-	}
+    for (size_t i = 0; i < n; i++) {
+      buf_[buf_epos_ + i] = data[i];
+    }
+    buf_epos_ += n;
+  }
 
-	void buf_erase(size_t size) {
-		buf_spos_ += size;
-	}
+  void buf_erase(size_t size) { buf_spos_ += size; }
 
-	std::string buf_;
-	size_t buf_spos_ = 0;
-	size_t buf_epos_ = 0;
+  std::string buf_;
+  size_t buf_spos_ = 0;
+  size_t buf_epos_ = 0;
 };
 
 inline std::string to_lower(const char *beg, const char *end) {
-	std::string out;
-	auto it = beg;
-	while (it != end) {
-		out += static_cast<char>(::tolower(*it));
-		it++;
-	}
-	return out;
+  std::string out;
+  auto it = beg;
+  while (it != end) {
+    out += static_cast<char>(::tolower(*it));
+    it++;
+  }
+  return out;
 }
 
 inline std::string make_multipart_data_boundary() {
-	static const char data[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  static const char data[] =
+      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-	std::string result = "--cpp-httplib-multipart-data-";
-	duckdb::RandomEngine engine;
-	for (auto i = 0; i < 16; i++) {
-		result += data[engine.NextRandomInteger32(0, sizeof(data) - 1)];
-	}
+  std::string result = "--cpp-httplib-multipart-data-";
+  duckdb::RandomEngine engine;
+  for (auto i = 0; i < 16; i++) {
+    result += data[engine.NextRandomInteger32(0,sizeof(data) - 1)];
+  }
 
-	return result;
+  return result;
 }
 
 inline bool is_multipart_boundary_chars_valid(const std::string &boundary) {
-	auto valid = true;
-	for (size_t i = 0; i < boundary.size(); i++) {
-		auto c = boundary[i];
-		if (!std::isalnum(c) && c != '-' && c != '_') {
-			valid = false;
-			break;
-		}
-	}
-	return valid;
+  auto valid = true;
+  for (size_t i = 0; i < boundary.size(); i++) {
+    auto c = boundary[i];
+    if (!std::isalnum(c) && c != '-' && c != '_') {
+      valid = false;
+      break;
+    }
+  }
+  return valid;
 }
 
 template <typename T>
-inline std::string serialize_multipart_formdata_item_begin(const T &item, const std::string &boundary) {
-	std::string body = "--" + boundary + "\r\n";
-	body += "Content-Disposition: form-data; name=\"" + item.name + "\"";
-	if (!item.filename.empty()) {
-		body += "; filename=\"" + item.filename + "\"";
-	}
-	body += "\r\n";
-	if (!item.content_type.empty()) {
-		body += "Content-Type: " + item.content_type + "\r\n";
-	}
-	body += "\r\n";
+inline std::string
+serialize_multipart_formdata_item_begin(const T &item,
+                                        const std::string &boundary) {
+  std::string body = "--" + boundary + "\r\n";
+  body += "Content-Disposition: form-data; name=\"" + item.name + "\"";
+  if (!item.filename.empty()) {
+    body += "; filename=\"" + item.filename + "\"";
+  }
+  body += "\r\n";
+  if (!item.content_type.empty()) {
+    body += "Content-Type: " + item.content_type + "\r\n";
+  }
+  body += "\r\n";
 
-	return body;
+  return body;
 }
 
-inline std::string serialize_multipart_formdata_item_end() {
-	return "\r\n";
+inline std::string serialize_multipart_formdata_item_end() { return "\r\n"; }
+
+inline std::string
+serialize_multipart_formdata_finish(const std::string &boundary) {
+  return "--" + boundary + "--\r\n";
 }
 
-inline std::string serialize_multipart_formdata_finish(const std::string &boundary) {
-	return "--" + boundary + "--\r\n";
+inline std::string
+serialize_multipart_formdata_get_content_type(const std::string &boundary) {
+  return "multipart/form-data; boundary=" + boundary;
 }
 
-inline std::string serialize_multipart_formdata_get_content_type(const std::string &boundary) {
-	return "multipart/form-data; boundary=" + boundary;
+inline std::string
+serialize_multipart_formdata(const MultipartFormDataItems &items,
+                             const std::string &boundary, bool finish = true) {
+  std::string body;
+
+  for (const auto &item : items) {
+    body += serialize_multipart_formdata_item_begin(item, boundary);
+    body += item.content + serialize_multipart_formdata_item_end();
+  }
+
+  if (finish) { body += serialize_multipart_formdata_finish(boundary); }
+
+  return body;
 }
 
-inline std::string serialize_multipart_formdata(const MultipartFormDataItems &items, const std::string &boundary,
-                                                bool finish = true) {
-	std::string body;
+inline std::pair<size_t, size_t>
+get_range_offset_and_length(const Request &req, size_t content_length,
+                            size_t index) {
+  auto r = req.ranges[index];
 
-	for (const auto &item : items) {
-		body += serialize_multipart_formdata_item_begin(item, boundary);
-		body += item.content + serialize_multipart_formdata_item_end();
-	}
+  if (r.first == -1 && r.second == -1) {
+    return std::make_pair(0, content_length);
+  }
 
-	if (finish) {
-		body += serialize_multipart_formdata_finish(boundary);
-	}
+  auto slen = static_cast<ssize_t>(content_length);
 
-	return body;
+  if (r.first == -1) {
+    r.first = (std::max)(static_cast<ssize_t>(0), slen - r.second);
+    r.second = slen - 1;
+  }
+
+  if (r.second == -1) { r.second = slen - 1; }
+  return std::make_pair(r.first, static_cast<size_t>(r.second - r.first) + 1);
 }
 
-inline std::pair<size_t, size_t> get_range_offset_and_length(const Request &req, size_t content_length, size_t index) {
-	auto r = req.ranges[index];
-
-	if (r.first == -1 && r.second == -1) {
-		return std::make_pair(0, content_length);
-	}
-
-	auto slen = static_cast<ssize_t>(content_length);
-
-	if (r.first == -1) {
-		r.first = (std::max)(static_cast<ssize_t>(0), slen - r.second);
-		r.second = slen - 1;
-	}
-
-	if (r.second == -1) {
-		r.second = slen - 1;
-	}
-	return std::make_pair(r.first, static_cast<size_t>(r.second - r.first) + 1);
-}
-
-inline std::string make_content_range_header_field(const std::pair<ssize_t, ssize_t> &range, size_t content_length) {
-	std::string field = "bytes ";
-	if (range.first != -1) {
-		field += std::to_string(range.first);
-	}
-	field += "-";
-	if (range.second != -1) {
-		field += std::to_string(range.second);
-	}
-	field += "/";
-	field += std::to_string(content_length);
-	return field;
+inline std::string
+make_content_range_header_field(const std::pair<ssize_t, ssize_t> &range,
+                                size_t content_length) {
+  std::string field = "bytes ";
+  if (range.first != -1) { field += std::to_string(range.first); }
+  field += "-";
+  if (range.second != -1) { field += std::to_string(range.second); }
+  field += "/";
+  field += std::to_string(content_length);
+  return field;
 }
 
 template <typename SToken, typename CToken, typename Content>
-bool process_multipart_ranges_data(const Request &req, Response &res, const std::string &boundary,
-                                   const std::string &content_type, SToken stoken, CToken ctoken, Content content) {
-	for (size_t i = 0; i < req.ranges.size(); i++) {
-		ctoken("--");
-		stoken(boundary);
-		ctoken("\r\n");
-		if (!content_type.empty()) {
-			ctoken("Content-Type: ");
-			stoken(content_type);
-			ctoken("\r\n");
-		}
+bool process_multipart_ranges_data(const Request &req, Response &res,
+                                   const std::string &boundary,
+                                   const std::string &content_type,
+                                   SToken stoken, CToken ctoken,
+                                   Content content) {
+  for (size_t i = 0; i < req.ranges.size(); i++) {
+    ctoken("--");
+    stoken(boundary);
+    ctoken("\r\n");
+    if (!content_type.empty()) {
+      ctoken("Content-Type: ");
+      stoken(content_type);
+      ctoken("\r\n");
+    }
 
-		ctoken("Content-Range: ");
-		const auto &range = req.ranges[i];
-		stoken(make_content_range_header_field(range, res.content_length_));
-		ctoken("\r\n");
-		ctoken("\r\n");
+    ctoken("Content-Range: ");
+    const auto &range = req.ranges[i];
+    stoken(make_content_range_header_field(range, res.content_length_));
+    ctoken("\r\n");
+    ctoken("\r\n");
 
-		auto offsets = get_range_offset_and_length(req, res.content_length_, i);
-		auto offset = offsets.first;
-		auto length = offsets.second;
-		if (!content(offset, length)) {
-			return false;
-		}
-		ctoken("\r\n");
-	}
+    auto offsets = get_range_offset_and_length(req, res.content_length_, i);
+    auto offset = offsets.first;
+    auto length = offsets.second;
+    if (!content(offset, length)) { return false; }
+    ctoken("\r\n");
+  }
 
-	ctoken("--");
-	stoken(boundary);
-	ctoken("--");
+  ctoken("--");
+  stoken(boundary);
+  ctoken("--");
 
-	return true;
+  return true;
 }
 
-inline bool make_multipart_ranges_data(const Request &req, Response &res, const std::string &boundary,
-                                       const std::string &content_type, std::string &data) {
-	return process_multipart_ranges_data(
-	    req, res, boundary, content_type, [&](const std::string &token) { data += token; },
-	    [&](const std::string &token) { data += token; },
-	    [&](size_t offset, size_t length) {
-		    if (offset < res.body.size()) {
-			    data += res.body.substr(offset, length);
-			    return true;
-		    }
-		    return false;
-	    });
+inline bool make_multipart_ranges_data(const Request &req, Response &res,
+                                       const std::string &boundary,
+                                       const std::string &content_type,
+                                       std::string &data) {
+  return process_multipart_ranges_data(
+      req, res, boundary, content_type,
+      [&](const std::string &token) { data += token; },
+      [&](const std::string &token) { data += token; },
+      [&](size_t offset, size_t length) {
+        if (offset < res.body.size()) {
+          data += res.body.substr(offset, length);
+          return true;
+        }
+        return false;
+      });
 }
 
-inline size_t get_multipart_ranges_data_length(const Request &req, Response &res, const std::string &boundary,
-                                               const std::string &content_type) {
-	size_t data_length = 0;
+inline size_t
+get_multipart_ranges_data_length(const Request &req, Response &res,
+                                 const std::string &boundary,
+                                 const std::string &content_type) {
+  size_t data_length = 0;
 
-	process_multipart_ranges_data(
-	    req, res, boundary, content_type, [&](const std::string &token) { data_length += token.size(); },
-	    [&](const std::string &token) { data_length += token.size(); },
-	    [&](size_t /*offset*/, size_t length) {
-		    data_length += length;
-		    return true;
-	    });
+  process_multipart_ranges_data(
+      req, res, boundary, content_type,
+      [&](const std::string &token) { data_length += token.size(); },
+      [&](const std::string &token) { data_length += token.size(); },
+      [&](size_t /*offset*/, size_t length) {
+        data_length += length;
+        return true;
+      });
 
-	return data_length;
+  return data_length;
 }
 
 template <typename T>
-inline bool write_multipart_ranges_data(Stream &strm, const Request &req, Response &res, const std::string &boundary,
-                                        const std::string &content_type, const T &is_shutting_down) {
-	return process_multipart_ranges_data(
-	    req, res, boundary, content_type, [&](const std::string &token) { strm.write(token); },
-	    [&](const std::string &token) { strm.write(token); },
-	    [&](size_t offset, size_t length) {
-		    return write_content(strm, res.content_provider_, offset, length, is_shutting_down);
-	    });
+inline bool write_multipart_ranges_data(Stream &strm, const Request &req,
+                                        Response &res,
+                                        const std::string &boundary,
+                                        const std::string &content_type,
+                                        const T &is_shutting_down) {
+  return process_multipart_ranges_data(
+      req, res, boundary, content_type,
+      [&](const std::string &token) { strm.write(token); },
+      [&](const std::string &token) { strm.write(token); },
+      [&](size_t offset, size_t length) {
+        return write_content(strm, res.content_provider_, offset, length,
+                             is_shutting_down);
+      });
 }
 
-inline std::pair<size_t, size_t> get_range_offset_and_length(const Request &req, const Response &res, size_t index) {
-	auto r = req.ranges[index];
+inline std::pair<size_t, size_t>
+get_range_offset_and_length(const Request &req, const Response &res,
+                            size_t index) {
+  auto r = req.ranges[index];
 
-	if (r.second == -1) {
-		r.second = static_cast<ssize_t>(res.content_length_) - 1;
-	}
+  if (r.second == -1) {
+    r.second = static_cast<ssize_t>(res.content_length_) - 1;
+  }
 
-	return std::make_pair(r.first, r.second - r.first + 1);
+  return std::make_pair(r.first, r.second - r.first + 1);
 }
 
 inline bool expect_content(const Request &req) {
-	if (req.method == "POST" || req.method == "PUT" || req.method == "PATCH" || req.method == "PRI" ||
-	    req.method == "DELETE") {
-		return true;
-	}
-	// TODO: check if Content-Length is set
-	return false;
+  if (req.method == "POST" || req.method == "PUT" || req.method == "PATCH" ||
+      req.method == "PRI" || req.method == "DELETE") {
+    return true;
+  }
+  // TODO: check if Content-Length is set
+  return false;
 }
 
 inline bool has_crlf(const std::string &s) {
-	auto p = s.c_str();
-	while (*p) {
-		if (*p == '\r' || *p == '\n') {
-			return true;
-		}
-		p++;
-	}
-	return false;
+  auto p = s.c_str();
+  while (*p) {
+    if (*p == '\r' || *p == '\n') { return true; }
+    p++;
+  }
+  return false;
 }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 inline std::string message_digest(const std::string &s, const EVP_MD *algo) {
-	auto context = duckdb::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+  auto context = duckdb::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>(
+      EVP_MD_CTX_new(), EVP_MD_CTX_free);
 
-	unsigned int hash_length = 0;
-	unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int hash_length = 0;
+  unsigned char hash[EVP_MAX_MD_SIZE];
 
-	EVP_DigestInit_ex(context.get(), algo, nullptr);
-	EVP_DigestUpdate(context.get(), s.c_str(), s.size());
-	EVP_DigestFinal_ex(context.get(), hash, &hash_length);
+  EVP_DigestInit_ex(context.get(), algo, nullptr);
+  EVP_DigestUpdate(context.get(), s.c_str(), s.size());
+  EVP_DigestFinal_ex(context.get(), hash, &hash_length);
 
-	duckdb::stringstream ss;
-	for (auto i = 0u; i < hash_length; ++i) {
-		ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned int>(hash[i]);
-	}
+  duckdb::stringstream ss;
+  for (auto i = 0u; i < hash_length; ++i) {
+    ss << std::hex << std::setw(2) << std::setfill('0')
+       << static_cast<unsigned int>(hash[i]);
+  }
 
-	return ss.str();
+  return ss.str();
 }
 
 inline std::string MD5(const std::string &s) {
-	return message_digest(s, EVP_md5());
+  return message_digest(s, EVP_md5());
 }
 
 inline std::string SHA_256(const std::string &s) {
-	return message_digest(s, EVP_sha256());
+  return message_digest(s, EVP_sha256());
 }
 
 inline std::string SHA_512(const std::string &s) {
-	return message_digest(s, EVP_sha512());
+  return message_digest(s, EVP_sha512());
 }
 #endif
 
@@ -4962,115 +4904,117 @@ inline std::string SHA_512(const std::string &s) {
 // NOTE: This code came up with the following stackoverflow post:
 // https://stackoverflow.com/questions/9507184/can-openssl-on-windows-use-the-system-certificate-store
 inline bool load_system_certs_on_windows(X509_STORE *store) {
-	auto hStore = CertOpenSystemStoreW((HCRYPTPROV_LEGACY)NULL, L"ROOT");
-	if (!hStore) {
-		return false;
-	}
+  auto hStore = CertOpenSystemStoreW((HCRYPTPROV_LEGACY)NULL, L"ROOT");
+  if (!hStore) { return false; }
 
-	auto result = false;
-	PCCERT_CONTEXT pContext = NULL;
-	while ((pContext = CertEnumCertificatesInStore(hStore, pContext)) != nullptr) {
-		auto encoded_cert = static_cast<const unsigned char *>(pContext->pbCertEncoded);
+  auto result = false;
+  PCCERT_CONTEXT pContext = NULL;
+  while ((pContext = CertEnumCertificatesInStore(hStore, pContext)) !=
+         nullptr) {
+    auto encoded_cert =
+        static_cast<const unsigned char *>(pContext->pbCertEncoded);
 
-		auto x509 = d2i_X509(NULL, &encoded_cert, pContext->cbCertEncoded);
-		if (x509) {
-			X509_STORE_add_cert(store, x509);
-			X509_free(x509);
-			result = true;
-		}
-	}
+    auto x509 = d2i_X509(NULL, &encoded_cert, pContext->cbCertEncoded);
+    if (x509) {
+      X509_STORE_add_cert(store, x509);
+      X509_free(x509);
+      result = true;
+    }
+  }
 
-	CertFreeCertificateContext(pContext);
-	CertCloseStore(hStore, 0);
+  CertFreeCertificateContext(pContext);
+  CertCloseStore(hStore, 0);
 
-	return result;
+  return result;
 }
 #elif defined(CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN) && defined(__APPLE__)
 #if TARGET_OS_OSX
 template <typename T>
-using CFObjectPtr = duckdb::unique_ptr<typename std::remove_pointer<T>::type, void (*)(CFTypeRef)>;
+using CFObjectPtr =
+    duckdb::unique_ptr<typename std::remove_pointer<T>::type, void (*)(CFTypeRef)>;
 
 inline void cf_object_ptr_deleter(CFTypeRef obj) {
-	if (obj) {
-		CFRelease(obj);
-	}
+  if (obj) { CFRelease(obj); }
 }
 
 inline bool retrieve_certs_from_keychain(CFObjectPtr<CFArrayRef> &certs) {
-	CFStringRef keys[] = {kSecClass, kSecMatchLimit, kSecReturnRef};
-	CFTypeRef values[] = {kSecClassCertificate, kSecMatchLimitAll, kCFBooleanTrue};
+  CFStringRef keys[] = {kSecClass, kSecMatchLimit, kSecReturnRef};
+  CFTypeRef values[] = {kSecClassCertificate, kSecMatchLimitAll,
+                        kCFBooleanTrue};
 
-	CFObjectPtr<CFDictionaryRef> query(
-	    CFDictionaryCreate(nullptr, reinterpret_cast<const void **>(keys), values, sizeof(keys) / sizeof(keys[0]),
-	                       &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks),
-	    cf_object_ptr_deleter);
+  CFObjectPtr<CFDictionaryRef> query(
+      CFDictionaryCreate(nullptr, reinterpret_cast<const void **>(keys), values,
+                         sizeof(keys) / sizeof(keys[0]),
+                         &kCFTypeDictionaryKeyCallBacks,
+                         &kCFTypeDictionaryValueCallBacks),
+      cf_object_ptr_deleter);
 
-	if (!query) {
-		return false;
-	}
+  if (!query) { return false; }
 
-	CFTypeRef security_items = nullptr;
-	if (SecItemCopyMatching(query.get(), &security_items) != errSecSuccess ||
-	    CFArrayGetTypeID() != CFGetTypeID(security_items)) {
-		return false;
-	}
+  CFTypeRef security_items = nullptr;
+  if (SecItemCopyMatching(query.get(), &security_items) != errSecSuccess ||
+      CFArrayGetTypeID() != CFGetTypeID(security_items)) {
+    return false;
+  }
 
-	certs.reset(reinterpret_cast<CFArrayRef>(security_items));
-	return true;
+  certs.reset(reinterpret_cast<CFArrayRef>(security_items));
+  return true;
 }
 
 inline bool retrieve_root_certs_from_keychain(CFObjectPtr<CFArrayRef> &certs) {
-	CFArrayRef root_security_items = nullptr;
-	if (SecTrustCopyAnchorCertificates(&root_security_items) != errSecSuccess) {
-		return false;
-	}
+  CFArrayRef root_security_items = nullptr;
+  if (SecTrustCopyAnchorCertificates(&root_security_items) != errSecSuccess) {
+    return false;
+  }
 
-	certs.reset(root_security_items);
-	return true;
+  certs.reset(root_security_items);
+  return true;
 }
 
 inline bool add_certs_to_x509_store(CFArrayRef certs, X509_STORE *store) {
-	auto result = false;
-	for (auto i = 0; i < CFArrayGetCount(certs); ++i) {
-		const auto cert = reinterpret_cast<const __SecCertificate *>(CFArrayGetValueAtIndex(certs, i));
+  auto result = false;
+  for (auto i = 0; i < CFArrayGetCount(certs); ++i) {
+    const auto cert = reinterpret_cast<const __SecCertificate *>(
+        CFArrayGetValueAtIndex(certs, i));
 
-		if (SecCertificateGetTypeID() != CFGetTypeID(cert)) {
-			continue;
-		}
+    if (SecCertificateGetTypeID() != CFGetTypeID(cert)) { continue; }
 
-		CFDataRef cert_data = nullptr;
-		if (SecItemExport(cert, kSecFormatX509Cert, 0, nullptr, &cert_data) != errSecSuccess) {
-			continue;
-		}
+    CFDataRef cert_data = nullptr;
+    if (SecItemExport(cert, kSecFormatX509Cert, 0, nullptr, &cert_data) !=
+        errSecSuccess) {
+      continue;
+    }
 
-		CFObjectPtr<CFDataRef> cert_data_ptr(cert_data, cf_object_ptr_deleter);
+    CFObjectPtr<CFDataRef> cert_data_ptr(cert_data, cf_object_ptr_deleter);
 
-		auto encoded_cert = static_cast<const unsigned char *>(CFDataGetBytePtr(cert_data_ptr.get()));
+    auto encoded_cert = static_cast<const unsigned char *>(
+        CFDataGetBytePtr(cert_data_ptr.get()));
 
-		auto x509 = d2i_X509(NULL, &encoded_cert, CFDataGetLength(cert_data_ptr.get()));
+    auto x509 =
+        d2i_X509(NULL, &encoded_cert, CFDataGetLength(cert_data_ptr.get()));
 
-		if (x509) {
-			X509_STORE_add_cert(store, x509);
-			X509_free(x509);
-			result = true;
-		}
-	}
+    if (x509) {
+      X509_STORE_add_cert(store, x509);
+      X509_free(x509);
+      result = true;
+    }
+  }
 
-	return result;
+  return result;
 }
 
 inline bool load_system_certs_on_macos(X509_STORE *store) {
-	auto result = false;
-	CFObjectPtr<CFArrayRef> certs(nullptr, cf_object_ptr_deleter);
-	if (retrieve_certs_from_keychain(certs) && certs) {
-		result = add_certs_to_x509_store(certs.get(), store);
-	}
+  auto result = false;
+  CFObjectPtr<CFArrayRef> certs(nullptr, cf_object_ptr_deleter);
+  if (retrieve_certs_from_keychain(certs) && certs) {
+    result = add_certs_to_x509_store(certs.get(), store);
+  }
 
-	if (retrieve_root_certs_from_keychain(certs) && certs) {
-		result = add_certs_to_x509_store(certs.get(), store) || result;
-	}
+  if (retrieve_root_certs_from_keychain(certs) && certs) {
+    result = add_certs_to_x509_store(certs.get(), store) || result;
+  }
 
-	return result;
+  return result;
 }
 #endif // TARGET_OS_OSX
 #endif // _WIN32
@@ -5079,3054 +5023,3135 @@ inline bool load_system_certs_on_macos(X509_STORE *store) {
 #ifdef _WIN32
 class WSInit {
 public:
-	WSInit() {
-		WSADATA wsaData;
-		if (WSAStartup(0x0002, &wsaData) == 0)
-			is_valid_ = true;
-	}
+  WSInit() {
+    WSADATA wsaData;
+    if (WSAStartup(0x0002, &wsaData) == 0) is_valid_ = true;
+  }
 
-	~WSInit() {
-		if (is_valid_)
-			WSACleanup();
-	}
+  ~WSInit() {
+    if (is_valid_) WSACleanup();
+  }
 
-	bool is_valid_ = false;
+  bool is_valid_ = false;
 };
 
 static WSInit wsinit_;
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline std::pair<std::string, std::string>
-make_digest_authentication_header(const Request &req, const std::map<std::string, std::string> &auth,
-                                  size_t cnonce_count, const std::string &cnonce, const std::string &username,
-                                  const std::string &password, bool is_proxy = false) {
-	std::string nc;
-	{
-		duckdb::stringstream ss;
-		ss << std::setfill('0') << std::setw(8) << std::hex << cnonce_count;
-		nc = ss.str();
-	}
+inline std::pair<std::string, std::string> make_digest_authentication_header(
+    const Request &req, const std::map<std::string, std::string> &auth,
+    size_t cnonce_count, const std::string &cnonce, const std::string &username,
+    const std::string &password, bool is_proxy = false) {
+  std::string nc;
+  {
+    duckdb::stringstream ss;
+    ss << std::setfill('0') << std::setw(8) << std::hex << cnonce_count;
+    nc = ss.str();
+  }
 
-	std::string qop;
-	if (auth.find("qop") != auth.end()) {
-		qop = auth.at("qop");
-		if (qop.find("auth-int") != std::string::npos) {
-			qop = "auth-int";
-		} else if (qop.find("auth") != std::string::npos) {
-			qop = "auth";
-		} else {
-			qop.clear();
-		}
-	}
+  std::string qop;
+  if (auth.find("qop") != auth.end()) {
+    qop = auth.at("qop");
+    if (qop.find("auth-int") != std::string::npos) {
+      qop = "auth-int";
+    } else if (qop.find("auth") != std::string::npos) {
+      qop = "auth";
+    } else {
+      qop.clear();
+    }
+  }
 
-	std::string algo = "MD5";
-	if (auth.find("algorithm") != auth.end()) {
-		algo = auth.at("algorithm");
-	}
+  std::string algo = "MD5";
+  if (auth.find("algorithm") != auth.end()) { algo = auth.at("algorithm"); }
 
-	std::string response;
-	{
-		auto H = algo == "SHA-256" ? detail::SHA_256 : algo == "SHA-512" ? detail::SHA_512 : detail::MD5;
+  std::string response;
+  {
+    auto H = algo == "SHA-256"   ? detail::SHA_256
+             : algo == "SHA-512" ? detail::SHA_512
+                                 : detail::MD5;
 
-		auto A1 = username + ":" + auth.at("realm") + ":" + password;
+    auto A1 = username + ":" + auth.at("realm") + ":" + password;
 
-		auto A2 = req.method + ":" + req.path;
-		if (qop == "auth-int") {
-			A2 += ":" + H(req.body);
-		}
+    auto A2 = req.method + ":" + req.path;
+    if (qop == "auth-int") { A2 += ":" + H(req.body); }
 
-		if (qop.empty()) {
-			response = H(H(A1) + ":" + auth.at("nonce") + ":" + H(A2));
-		} else {
-			response = H(H(A1) + ":" + auth.at("nonce") + ":" + nc + ":" + cnonce + ":" + qop + ":" + H(A2));
-		}
-	}
+    if (qop.empty()) {
+      response = H(H(A1) + ":" + auth.at("nonce") + ":" + H(A2));
+    } else {
+      response = H(H(A1) + ":" + auth.at("nonce") + ":" + nc + ":" + cnonce +
+                   ":" + qop + ":" + H(A2));
+    }
+  }
 
-	auto opaque = (auth.find("opaque") != auth.end()) ? auth.at("opaque") : "";
+  auto opaque = (auth.find("opaque") != auth.end()) ? auth.at("opaque") : "";
 
-	auto field =
-	    "Digest username=\"" + username + "\", realm=\"" + auth.at("realm") + "\", nonce=\"" + auth.at("nonce") +
-	    "\", uri=\"" + req.path + "\", algorithm=" + algo +
-	    (qop.empty() ? ", response=\"" : ", qop=" + qop + ", nc=" + nc + ", cnonce=\"" + cnonce + "\", response=\"") +
-	    response + "\"" + (opaque.empty() ? "" : ", opaque=\"" + opaque + "\"");
+  auto field = "Digest username=\"" + username + "\", realm=\"" +
+               auth.at("realm") + "\", nonce=\"" + auth.at("nonce") +
+               "\", uri=\"" + req.path + "\", algorithm=" + algo +
+               (qop.empty() ? ", response=\""
+                            : ", qop=" + qop + ", nc=" + nc + ", cnonce=\"" +
+                                  cnonce + "\", response=\"") +
+               response + "\"" +
+               (opaque.empty() ? "" : ", opaque=\"" + opaque + "\"");
 
-	auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
-	return std::make_pair(key, field);
+  auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
+  return std::make_pair(key, field);
 }
 #endif
 
-inline bool parse_www_authenticate(const Response &res, std::map<std::string, std::string> &auth, bool is_proxy) {
-	auto auth_key = is_proxy ? "Proxy-Authenticate" : "WWW-Authenticate";
-	if (res.has_header(auth_key)) {
-		auto re = Regex(R"~((?:(?:,\s*)?(.+?)=(?:"(.*?)"|([^,]*))))~");
-		auto s = res.get_header_value(auth_key);
-		auto pos = s.find(' ');
-		if (pos != std::string::npos) {
-			auto type = s.substr(0, pos);
-			if (type == "Basic") {
-				return false;
-			} else if (type == "Digest") {
-				s = s.substr(pos + 1);
-				auto matches = duckdb_re2::RegexFindAll(s, re);
-				for (auto &m : matches) {
-					auto key = s.substr(static_cast<size_t>(m.position(1)), static_cast<size_t>(m.length(1)));
-					auto val = m.length(2) > 0
-					               ? s.substr(static_cast<size_t>(m.position(2)), static_cast<size_t>(m.length(2)))
-					               : s.substr(static_cast<size_t>(m.position(3)), static_cast<size_t>(m.length(3)));
-					auth[key] = val;
-				}
-				return true;
-			}
-		}
-	}
-	return false;
+inline bool parse_www_authenticate(const Response &res,
+                                   std::map<std::string, std::string> &auth,
+                                   bool is_proxy) {
+  auto auth_key = is_proxy ? "Proxy-Authenticate" : "WWW-Authenticate";
+  if (res.has_header(auth_key)) {
+    auto re = Regex(R"~((?:(?:,\s*)?(.+?)=(?:"(.*?)"|([^,]*))))~");
+    auto s = res.get_header_value(auth_key);
+    auto pos = s.find(' ');
+    if (pos != std::string::npos) {
+      auto type = s.substr(0, pos);
+      if (type == "Basic") {
+        return false;
+      } else if (type == "Digest") {
+        s = s.substr(pos + 1);
+        auto matches = duckdb_re2::RegexFindAll(s, re);
+        for (auto &m : matches) {
+          auto key = s.substr(static_cast<size_t>(m.position(1)),
+                              static_cast<size_t>(m.length(1)));
+          auto val = m.length(2) > 0
+                         ? s.substr(static_cast<size_t>(m.position(2)),
+                                    static_cast<size_t>(m.length(2)))
+                         : s.substr(static_cast<size_t>(m.position(3)),
+                                    static_cast<size_t>(m.length(3)));
+          auth[key] = val;
+        }
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 // https://stackoverflow.com/questions/440133/how-do-i-create-a-random-alpha-numeric-string-in-c/440240#answer-440240
 inline std::string random_string(size_t length) {
-	auto randchar = []() -> char {
-		const char charset[] = "0123456789"
-		                       "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-		                       "abcdefghijklmnopqrstuvwxyz";
-		const size_t max_index = (sizeof(charset) - 1);
-		return charset[static_cast<size_t>(std::rand()) % max_index];
-	};
-	std::string str(length, 0);
-	std::generate_n(str.begin(), length, randchar);
-	return str;
+  auto randchar = []() -> char {
+    const char charset[] = "0123456789"
+                           "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                           "abcdefghijklmnopqrstuvwxyz";
+    const size_t max_index = (sizeof(charset) - 1);
+    return charset[static_cast<size_t>(std::rand()) % max_index];
+  };
+  std::string str(length, 0);
+  std::generate_n(str.begin(), length, randchar);
+  return str;
 }
 
 class ContentProviderAdapter {
 public:
-	explicit ContentProviderAdapter(ContentProviderWithoutLength &&content_provider)
-	    : content_provider_(content_provider) {
-	}
+  explicit ContentProviderAdapter(
+      ContentProviderWithoutLength &&content_provider)
+      : content_provider_(content_provider) {}
 
-	bool operator()(size_t offset, size_t, DataSink &sink) {
-		return content_provider_(offset, sink);
-	}
+  bool operator()(size_t offset, size_t, DataSink &sink) {
+    return content_provider_(offset, sink);
+  }
 
 private:
-	ContentProviderWithoutLength content_provider_;
+  ContentProviderWithoutLength content_provider_;
 };
 
 } // namespace detail
 
 inline std::string hosted_at(const std::string &hostname) {
-	std::vector<std::string> addrs;
-	hosted_at(hostname, addrs);
-	if (addrs.empty()) {
-		return std::string();
-	}
-	return addrs[0];
+  std::vector<std::string> addrs;
+  hosted_at(hostname, addrs);
+  if (addrs.empty()) { return std::string(); }
+  return addrs[0];
 }
 
-inline void hosted_at(const std::string &hostname, std::vector<std::string> &addrs) {
-	struct addrinfo hints;
-	struct addrinfo *result;
+inline void hosted_at(const std::string &hostname,
+                      std::vector<std::string> &addrs) {
+  struct addrinfo hints;
+  struct addrinfo *result;
 
-	memset(&hints, 0, sizeof(struct addrinfo));
-	hints.ai_family = AF_UNSPEC;
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_protocol = 0;
+  memset(&hints, 0, sizeof(struct addrinfo));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_protocol = 0;
 
-	if (getaddrinfo(hostname.c_str(), nullptr, &hints, &result)) {
+  if (getaddrinfo(hostname.c_str(), nullptr, &hints, &result)) {
 #if defined __linux__ && !defined __ANDROID__
-		res_init();
+    res_init();
 #endif
-		return;
-	}
+    return;
+  }
 
-	for (auto rp = result; rp; rp = rp->ai_next) {
-		const auto &addr = *reinterpret_cast<struct sockaddr_storage *>(rp->ai_addr);
-		std::string ip;
-		auto dummy = -1;
-		if (detail::get_ip_and_port(addr, sizeof(struct sockaddr_storage), ip, dummy)) {
-			addrs.push_back(ip);
-		}
-	}
+  for (auto rp = result; rp; rp = rp->ai_next) {
+    const auto &addr =
+        *reinterpret_cast<struct sockaddr_storage *>(rp->ai_addr);
+    std::string ip;
+    auto dummy = -1;
+    if (detail::get_ip_and_port(addr, sizeof(struct sockaddr_storage), ip,
+                                dummy)) {
+      addrs.push_back(ip);
+    }
+  }
 
-	freeaddrinfo(result);
+  freeaddrinfo(result);
 }
 
-inline std::string append_query_params(const std::string &path, const Params &params) {
-	std::string path_with_query = path;
-	const Regex re("[^?]+\\?.*");
-	auto delm = RegexMatch(path, re) ? '&' : '?';
-	path_with_query += delm + detail::params_to_query_str(params);
-	return path_with_query;
+inline std::string append_query_params(const std::string &path,
+                                       const Params &params) {
+  std::string path_with_query = path;
+  const Regex re("[^?]+\\?.*");
+  auto delm = RegexMatch(path, re) ? '&' : '?';
+  path_with_query += delm + detail::params_to_query_str(params);
+  return path_with_query;
 }
 
 // Header utilities
 inline std::pair<std::string, std::string> make_range_header(Ranges ranges) {
-	std::string field = "bytes=";
-	auto i = 0;
-	for (auto r : ranges) {
-		if (i != 0) {
-			field += ", ";
-		}
-		if (r.first != -1) {
-			field += std::to_string(r.first);
-		}
-		field += '-';
-		if (r.second != -1) {
-			field += std::to_string(r.second);
-		}
-		i++;
-	}
-	return std::make_pair("Range", std::move(field));
+  std::string field = "bytes=";
+  auto i = 0;
+  for (auto r : ranges) {
+    if (i != 0) { field += ", "; }
+    if (r.first != -1) { field += std::to_string(r.first); }
+    field += '-';
+    if (r.second != -1) { field += std::to_string(r.second); }
+    i++;
+  }
+  return std::make_pair("Range", std::move(field));
 }
 
 inline std::pair<std::string, std::string>
-make_basic_authentication_header(const std::string &username, const std::string &password, bool is_proxy) {
-	auto field = "Basic " + detail::base64_encode(username + ":" + password);
-	auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
-	return std::make_pair(key, std::move(field));
+make_basic_authentication_header(const std::string &username,
+                                 const std::string &password, bool is_proxy) {
+  auto field = "Basic " + detail::base64_encode(username + ":" + password);
+  auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
+  return std::make_pair(key, std::move(field));
 }
 
-inline std::pair<std::string, std::string> make_bearer_token_authentication_header(const std::string &token,
-                                                                                   bool is_proxy = false) {
-	auto field = "Bearer " + token;
-	auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
-	return std::make_pair(key, std::move(field));
+inline std::pair<std::string, std::string>
+make_bearer_token_authentication_header(const std::string &token,
+                                        bool is_proxy = false) {
+  auto field = "Bearer " + token;
+  auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
+  return std::make_pair(key, std::move(field));
 }
 
 // Request implementation
 inline bool Request::has_header(const std::string &key) const {
-	return detail::has_header(headers, key);
+  return detail::has_header(headers, key);
 }
 
-inline std::string Request::get_header_value(const std::string &key, size_t id) const {
-	return detail::get_header_value(headers, key, id, "");
+inline std::string Request::get_header_value(const std::string &key,
+                                             size_t id) const {
+  return detail::get_header_value(headers, key, id, "");
 }
 
 inline size_t Request::get_header_value_count(const std::string &key) const {
-	auto r = headers.equal_range(key);
-	return static_cast<size_t>(std::distance(r.first, r.second));
+  auto r = headers.equal_range(key);
+  return static_cast<size_t>(std::distance(r.first, r.second));
 }
 
-inline void Request::set_header(const std::string &key, const std::string &val) {
-	if (!detail::has_crlf(key) && !detail::has_crlf(val)) {
-		headers.emplace(key, val);
-	}
+inline void Request::set_header(const std::string &key,
+                                const std::string &val) {
+  if (!detail::has_crlf(key) && !detail::has_crlf(val)) {
+    headers.emplace(key, val);
+  }
 }
 
 inline bool Request::has_param(const std::string &key) const {
-	return params.find(key) != params.end();
+  return params.find(key) != params.end();
 }
 
-inline std::string Request::get_param_value(const std::string &key, size_t id) const {
-	auto rng = params.equal_range(key);
-	auto it = rng.first;
-	std::advance(it, static_cast<ssize_t>(id));
-	if (it != rng.second) {
-		return it->second;
-	}
-	return std::string();
+inline std::string Request::get_param_value(const std::string &key,
+                                            size_t id) const {
+  auto rng = params.equal_range(key);
+  auto it = rng.first;
+  std::advance(it, static_cast<ssize_t>(id));
+  if (it != rng.second) { return it->second; }
+  return std::string();
 }
 
 inline size_t Request::get_param_value_count(const std::string &key) const {
-	auto r = params.equal_range(key);
-	return static_cast<size_t>(std::distance(r.first, r.second));
+  auto r = params.equal_range(key);
+  return static_cast<size_t>(std::distance(r.first, r.second));
 }
 
 inline bool Request::is_multipart_form_data() const {
-	const auto &content_type = get_header_value("Content-Type");
-	return !content_type.rfind("multipart/form-data", 0);
+  const auto &content_type = get_header_value("Content-Type");
+  return !content_type.rfind("multipart/form-data", 0);
 }
 
 inline bool Request::has_file(const std::string &key) const {
-	return files.find(key) != files.end();
+  return files.find(key) != files.end();
 }
 
 inline MultipartFormData Request::get_file_value(const std::string &key) const {
-	auto it = files.find(key);
-	if (it != files.end()) {
-		return it->second;
-	}
-	return MultipartFormData();
+  auto it = files.find(key);
+  if (it != files.end()) { return it->second; }
+  return MultipartFormData();
 }
 
-inline std::vector<MultipartFormData> Request::get_file_values(const std::string &key) const {
-	std::vector<MultipartFormData> values;
-	auto rng = files.equal_range(key);
-	for (auto it = rng.first; it != rng.second; it++) {
-		values.push_back(it->second);
-	}
-	return values;
+inline std::vector<MultipartFormData>
+Request::get_file_values(const std::string &key) const {
+  std::vector<MultipartFormData> values;
+  auto rng = files.equal_range(key);
+  for (auto it = rng.first; it != rng.second; it++) {
+    values.push_back(it->second);
+  }
+  return values;
 }
 
 // Response implementation
 inline bool Response::has_header(const std::string &key) const {
-	return headers.find(key) != headers.end();
+  return headers.find(key) != headers.end();
 }
 
-inline std::string Response::get_header_value(const std::string &key, size_t id) const {
-	return detail::get_header_value(headers, key, id, "");
+inline std::string Response::get_header_value(const std::string &key,
+                                              size_t id) const {
+  return detail::get_header_value(headers, key, id, "");
 }
 
 inline size_t Response::get_header_value_count(const std::string &key) const {
-	auto r = headers.equal_range(key);
-	return static_cast<size_t>(std::distance(r.first, r.second));
+  auto r = headers.equal_range(key);
+  return static_cast<size_t>(std::distance(r.first, r.second));
 }
 
-inline void Response::set_header(const std::string &key, const std::string &val) {
-	if (!detail::has_crlf(key) && !detail::has_crlf(val)) {
-		headers.emplace(key, val);
-	}
+inline void Response::set_header(const std::string &key,
+                                 const std::string &val) {
+  if (!detail::has_crlf(key) && !detail::has_crlf(val)) {
+    headers.emplace(key, val);
+  }
 }
 
 inline void Response::set_redirect(const std::string &url, int stat) {
-	if (!detail::has_crlf(url)) {
-		set_header("Location", url);
-		if (300 <= stat && stat < 400) {
-			this->status = stat;
-		} else {
-			this->status = StatusCode::Found_302;
-		}
-	}
+  if (!detail::has_crlf(url)) {
+    set_header("Location", url);
+    if (300 <= stat && stat < 400) {
+      this->status = stat;
+    } else {
+      this->status = StatusCode::Found_302;
+    }
+  }
 }
 
-inline void Response::set_content(const char *s, size_t n, const std::string &content_type) {
-	body.assign(s, n);
+inline void Response::set_content(const char *s, size_t n,
+                                  const std::string &content_type) {
+  body.assign(s, n);
 
-	auto rng = headers.equal_range("Content-Type");
-	headers.erase(rng.first, rng.second);
-	set_header("Content-Type", content_type);
+  auto rng = headers.equal_range("Content-Type");
+  headers.erase(rng.first, rng.second);
+  set_header("Content-Type", content_type);
 }
 
-inline void Response::set_content(const std::string &s, const std::string &content_type) {
-	set_content(s.data(), s.size(), content_type);
+inline void Response::set_content(const std::string &s,
+                                  const std::string &content_type) {
+  set_content(s.data(), s.size(), content_type);
 }
 
-inline void Response::set_content_provider(size_t in_length, const std::string &content_type, ContentProvider provider,
-                                           ContentProviderResourceReleaser resource_releaser) {
-	set_header("Content-Type", content_type);
-	content_length_ = in_length;
-	if (in_length > 0) {
-		content_provider_ = std::move(provider);
-	}
-	content_provider_resource_releaser_ = resource_releaser;
-	is_chunked_content_provider_ = false;
+inline void Response::set_content_provider(
+    size_t in_length, const std::string &content_type, ContentProvider provider,
+    ContentProviderResourceReleaser resource_releaser) {
+  set_header("Content-Type", content_type);
+  content_length_ = in_length;
+  if (in_length > 0) { content_provider_ = std::move(provider); }
+  content_provider_resource_releaser_ = resource_releaser;
+  is_chunked_content_provider_ = false;
 }
 
-inline void Response::set_content_provider(const std::string &content_type, ContentProviderWithoutLength provider,
-                                           ContentProviderResourceReleaser resource_releaser) {
-	set_header("Content-Type", content_type);
-	content_length_ = 0;
-	content_provider_ = detail::ContentProviderAdapter(std::move(provider));
-	content_provider_resource_releaser_ = resource_releaser;
-	is_chunked_content_provider_ = false;
+inline void Response::set_content_provider(
+    const std::string &content_type, ContentProviderWithoutLength provider,
+    ContentProviderResourceReleaser resource_releaser) {
+  set_header("Content-Type", content_type);
+  content_length_ = 0;
+  content_provider_ = detail::ContentProviderAdapter(std::move(provider));
+  content_provider_resource_releaser_ = resource_releaser;
+  is_chunked_content_provider_ = false;
 }
 
-inline void Response::set_chunked_content_provider(const std::string &content_type,
-                                                   ContentProviderWithoutLength provider,
-                                                   ContentProviderResourceReleaser resource_releaser) {
-	set_header("Content-Type", content_type);
-	content_length_ = 0;
-	content_provider_ = detail::ContentProviderAdapter(std::move(provider));
-	content_provider_resource_releaser_ = resource_releaser;
-	is_chunked_content_provider_ = true;
+inline void Response::set_chunked_content_provider(
+    const std::string &content_type, ContentProviderWithoutLength provider,
+    ContentProviderResourceReleaser resource_releaser) {
+  set_header("Content-Type", content_type);
+  content_length_ = 0;
+  content_provider_ = detail::ContentProviderAdapter(std::move(provider));
+  content_provider_resource_releaser_ = resource_releaser;
+  is_chunked_content_provider_ = true;
 }
 
 // Result implementation
 inline bool Result::has_request_header(const std::string &key) const {
-	return request_headers_.find(key) != request_headers_.end();
+  return request_headers_.find(key) != request_headers_.end();
 }
 
-inline std::string Result::get_request_header_value(const std::string &key, size_t id) const {
-	return detail::get_header_value(request_headers_, key, id, "");
+inline std::string Result::get_request_header_value(const std::string &key,
+                                                    size_t id) const {
+  return detail::get_header_value(request_headers_, key, id, "");
 }
 
-inline size_t Result::get_request_header_value_count(const std::string &key) const {
-	auto r = request_headers_.equal_range(key);
-	return static_cast<size_t>(std::distance(r.first, r.second));
+inline size_t
+Result::get_request_header_value_count(const std::string &key) const {
+  auto r = request_headers_.equal_range(key);
+  return static_cast<size_t>(std::distance(r.first, r.second));
 }
 
 // Stream implementation
 inline ssize_t Stream::write(const char *ptr) {
-	return write(ptr, strlen(ptr));
+  return write(ptr, strlen(ptr));
 }
 
 inline ssize_t Stream::write(const std::string &s) {
-	return write(s.data(), s.size());
+  return write(s.data(), s.size());
 }
 
 namespace detail {
 
 // Socket stream implementation
-inline SocketStream::SocketStream(socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec,
-                                  time_t write_timeout_sec, time_t write_timeout_usec)
-    : sock_(sock), read_timeout_sec_(read_timeout_sec), read_timeout_usec_(read_timeout_usec),
-      write_timeout_sec_(write_timeout_sec), write_timeout_usec_(write_timeout_usec), read_buff_(read_buff_size_, 0) {
-}
+inline SocketStream::SocketStream(socket_t sock, time_t read_timeout_sec,
+                                  time_t read_timeout_usec,
+                                  time_t write_timeout_sec,
+                                  time_t write_timeout_usec)
+    : sock_(sock), read_timeout_sec_(read_timeout_sec),
+      read_timeout_usec_(read_timeout_usec),
+      write_timeout_sec_(write_timeout_sec),
+      write_timeout_usec_(write_timeout_usec), read_buff_(read_buff_size_, 0) {}
 
 inline SocketStream::~SocketStream() = default;
 
 inline bool SocketStream::is_readable() const {
-	return select_read(sock_, read_timeout_sec_, read_timeout_usec_) > 0;
+  return select_read(sock_, read_timeout_sec_, read_timeout_usec_) > 0;
 }
 
 inline bool SocketStream::is_writable() const {
-	return select_write(sock_, write_timeout_sec_, write_timeout_usec_) > 0 && is_socket_alive(sock_);
+  return select_write(sock_, write_timeout_sec_, write_timeout_usec_) > 0 &&
+         is_socket_alive(sock_);
 }
 
 inline ssize_t SocketStream::read(char *ptr, size_t size) {
 #ifdef _WIN32
-	size = (std::min)(size, static_cast<size_t>((std::numeric_limits<int>::max)()));
+  size =
+      (std::min)(size, static_cast<size_t>((std::numeric_limits<int>::max)()));
 #else
-	size = (std::min)(size, static_cast<size_t>((std::numeric_limits<ssize_t>::max)()));
+  size = (std::min)(size,
+                    static_cast<size_t>((std::numeric_limits<ssize_t>::max)()));
 #endif
 
-	if (read_buff_off_ < read_buff_content_size_) {
-		auto remaining_size = read_buff_content_size_ - read_buff_off_;
-		if (size <= remaining_size) {
-			memcpy(ptr, read_buff_.data() + read_buff_off_, size);
-			read_buff_off_ += size;
-			return static_cast<ssize_t>(size);
-		} else {
-			memcpy(ptr, read_buff_.data() + read_buff_off_, remaining_size);
-			read_buff_off_ += remaining_size;
-			return static_cast<ssize_t>(remaining_size);
-		}
-	}
+  if (read_buff_off_ < read_buff_content_size_) {
+    auto remaining_size = read_buff_content_size_ - read_buff_off_;
+    if (size <= remaining_size) {
+      memcpy(ptr, read_buff_.data() + read_buff_off_, size);
+      read_buff_off_ += size;
+      return static_cast<ssize_t>(size);
+    } else {
+      memcpy(ptr, read_buff_.data() + read_buff_off_, remaining_size);
+      read_buff_off_ += remaining_size;
+      return static_cast<ssize_t>(remaining_size);
+    }
+  }
 
-	if (!is_readable()) {
-		return -1;
-	}
+  if (!is_readable()) { return -1; }
 
-	read_buff_off_ = 0;
-	read_buff_content_size_ = 0;
+  read_buff_off_ = 0;
+  read_buff_content_size_ = 0;
 
-	if (size < read_buff_size_) {
-		auto n = read_socket(sock_, read_buff_.data(), read_buff_size_, CPPHTTPLIB_RECV_FLAGS);
-		if (n <= 0) {
-			return n;
-		} else if (n <= static_cast<ssize_t>(size)) {
-			memcpy(ptr, read_buff_.data(), static_cast<size_t>(n));
-			return n;
-		} else {
-			memcpy(ptr, read_buff_.data(), size);
-			read_buff_off_ = size;
-			read_buff_content_size_ = static_cast<size_t>(n);
-			return static_cast<ssize_t>(size);
-		}
-	} else {
-		return read_socket(sock_, ptr, size, CPPHTTPLIB_RECV_FLAGS);
-	}
+  if (size < read_buff_size_) {
+    auto n = read_socket(sock_, read_buff_.data(), read_buff_size_,
+                         CPPHTTPLIB_RECV_FLAGS);
+    if (n <= 0) {
+      return n;
+    } else if (n <= static_cast<ssize_t>(size)) {
+      memcpy(ptr, read_buff_.data(), static_cast<size_t>(n));
+      return n;
+    } else {
+      memcpy(ptr, read_buff_.data(), size);
+      read_buff_off_ = size;
+      read_buff_content_size_ = static_cast<size_t>(n);
+      return static_cast<ssize_t>(size);
+    }
+  } else {
+    return read_socket(sock_, ptr, size, CPPHTTPLIB_RECV_FLAGS);
+  }
 }
 
 inline ssize_t SocketStream::write(const char *ptr, size_t size) {
-	if (!is_writable()) {
-		return -1;
-	}
+  if (!is_writable()) { return -1; }
 
 #if defined(_WIN32) && !defined(_WIN64)
-	size = (std::min)(size, static_cast<size_t>((std::numeric_limits<int>::max)()));
+  size =
+      (std::min)(size, static_cast<size_t>((std::numeric_limits<int>::max)()));
 #endif
 
-	return send_socket(sock_, ptr, size, CPPHTTPLIB_SEND_FLAGS);
+  return send_socket(sock_, ptr, size, CPPHTTPLIB_SEND_FLAGS);
 }
 
-inline void SocketStream::get_remote_ip_and_port(std::string &ip, int &port) const {
-	return detail::get_remote_ip_and_port(sock_, ip, port);
+inline void SocketStream::get_remote_ip_and_port(std::string &ip,
+                                                 int &port) const {
+  return detail::get_remote_ip_and_port(sock_, ip, port);
 }
 
-inline void SocketStream::get_local_ip_and_port(std::string &ip, int &port) const {
-	return detail::get_local_ip_and_port(sock_, ip, port);
+inline void SocketStream::get_local_ip_and_port(std::string &ip,
+                                                int &port) const {
+  return detail::get_local_ip_and_port(sock_, ip, port);
 }
 
-inline socket_t SocketStream::socket() const {
-	return sock_;
-}
+inline socket_t SocketStream::socket() const { return sock_; }
 
 // Buffer stream implementation
-inline bool BufferStream::is_readable() const {
-	return true;
-}
+inline bool BufferStream::is_readable() const { return true; }
 
-inline bool BufferStream::is_writable() const {
-	return true;
-}
+inline bool BufferStream::is_writable() const { return true; }
 
 inline ssize_t BufferStream::read(char *ptr, size_t size) {
 #if defined(_MSC_VER) && _MSC_VER < 1910
-	auto len_read = buffer._Copy_s(ptr, size, size, position);
+  auto len_read = buffer._Copy_s(ptr, size, size, position);
 #else
-	auto len_read = buffer.copy(ptr, size, position);
+  auto len_read = buffer.copy(ptr, size, position);
 #endif
-	position += static_cast<size_t>(len_read);
-	return static_cast<ssize_t>(len_read);
+  position += static_cast<size_t>(len_read);
+  return static_cast<ssize_t>(len_read);
 }
 
 inline ssize_t BufferStream::write(const char *ptr, size_t size) {
-	buffer.append(ptr, size);
-	return static_cast<ssize_t>(size);
+  buffer.append(ptr, size);
+  return static_cast<ssize_t>(size);
 }
 
-inline void BufferStream::get_remote_ip_and_port(std::string & /*ip*/, int & /*port*/) const {
-}
+inline void BufferStream::get_remote_ip_and_port(std::string & /*ip*/,
+                                                 int & /*port*/) const {}
 
-inline void BufferStream::get_local_ip_and_port(std::string & /*ip*/, int & /*port*/) const {
-}
+inline void BufferStream::get_local_ip_and_port(std::string & /*ip*/,
+                                                int & /*port*/) const {}
 
-inline socket_t BufferStream::socket() const {
-	return 0;
-}
+inline socket_t BufferStream::socket() const { return 0; }
 
-inline const std::string &BufferStream::get_buffer() const {
-	return buffer;
-}
+inline const std::string &BufferStream::get_buffer() const { return buffer; }
 
 inline PathParamsMatcher::PathParamsMatcher(const std::string &pattern) {
-	// One past the last ending position of a path param substring
-	std::size_t last_param_end = 0;
+  // One past the last ending position of a path param substring
+  std::size_t last_param_end = 0;
 
 #ifndef CPPHTTPLIB_NO_EXCEPTIONS
-	// Needed to ensure that parameter names are unique during matcher
-	// construction
-	// If exceptions are disabled, only last duplicate path
-	// parameter will be set
-	std::unordered_set<std::string> param_name_set;
+  // Needed to ensure that parameter names are unique during matcher
+  // construction
+  // If exceptions are disabled, only last duplicate path
+  // parameter will be set
+  std::unordered_set<std::string> param_name_set;
 #endif
 
-	while (true) {
-		const auto marker_pos = pattern.find(marker, last_param_end);
-		if (marker_pos == std::string::npos) {
-			break;
-		}
+  while (true) {
+    const auto marker_pos = pattern.find(marker, last_param_end);
+    if (marker_pos == std::string::npos) { break; }
 
-		static_fragments_.push_back(pattern.substr(last_param_end, marker_pos - last_param_end));
+    static_fragments_.push_back(
+        pattern.substr(last_param_end, marker_pos - last_param_end));
 
-		const auto param_name_start = marker_pos + 1;
+    const auto param_name_start = marker_pos + 1;
 
-		auto sep_pos = pattern.find(separator, param_name_start);
-		if (sep_pos == std::string::npos) {
-			sep_pos = pattern.length();
-		}
+    auto sep_pos = pattern.find(separator, param_name_start);
+    if (sep_pos == std::string::npos) { sep_pos = pattern.length(); }
 
-		auto param_name = pattern.substr(param_name_start, sep_pos - param_name_start);
+    auto param_name =
+        pattern.substr(param_name_start, sep_pos - param_name_start);
 
 #ifndef CPPHTTPLIB_NO_EXCEPTIONS
-		if (param_name_set.find(param_name) != param_name_set.cend()) {
-			std::string msg =
-			    "Encountered path parameter '" + param_name + "' multiple times in route pattern '" + pattern + "'.";
-			throw std::invalid_argument(msg);
-		}
+    if (param_name_set.find(param_name) != param_name_set.cend()) {
+      std::string msg = "Encountered path parameter '" + param_name +
+                        "' multiple times in route pattern '" + pattern + "'.";
+      throw std::invalid_argument(msg);
+    }
 #endif
 
-		param_names_.push_back(std::move(param_name));
+    param_names_.push_back(std::move(param_name));
 
-		last_param_end = sep_pos + 1;
-	}
+    last_param_end = sep_pos + 1;
+  }
 
-	if (last_param_end < pattern.length()) {
-		static_fragments_.push_back(pattern.substr(last_param_end));
-	}
+  if (last_param_end < pattern.length()) {
+    static_fragments_.push_back(pattern.substr(last_param_end));
+  }
 }
 
 inline bool PathParamsMatcher::match(Request &request) const {
-	request.matches = Match();
-	request.path_params.clear();
-	request.path_params.reserve(param_names_.size());
+  request.matches = Match();
+  request.path_params.clear();
+  request.path_params.reserve(param_names_.size());
 
-	// One past the position at which the path matched the pattern last time
-	std::size_t starting_pos = 0;
-	for (size_t i = 0; i < static_fragments_.size(); ++i) {
-		const auto &fragment = static_fragments_[i];
+  // One past the position at which the path matched the pattern last time
+  std::size_t starting_pos = 0;
+  for (size_t i = 0; i < static_fragments_.size(); ++i) {
+    const auto &fragment = static_fragments_[i];
 
-		if (starting_pos + fragment.length() > request.path.length()) {
-			return false;
-		}
+    if (starting_pos + fragment.length() > request.path.length()) {
+      return false;
+    }
 
-		// Avoid unnecessary allocation by using strncmp instead of substr +
-		// comparison
-		if (std::strncmp(request.path.c_str() + starting_pos, fragment.c_str(), fragment.length()) != 0) {
-			return false;
-		}
+    // Avoid unnecessary allocation by using strncmp instead of substr +
+    // comparison
+    if (std::strncmp(request.path.c_str() + starting_pos, fragment.c_str(),
+                     fragment.length()) != 0) {
+      return false;
+    }
 
-		starting_pos += fragment.length();
+    starting_pos += fragment.length();
 
-		// Should only happen when we have a static fragment after a param
-		// Example: '/users/:id/subscriptions'
-		// The 'subscriptions' fragment here does not have a corresponding param
-		if (i >= param_names_.size()) {
-			continue;
-		}
+    // Should only happen when we have a static fragment after a param
+    // Example: '/users/:id/subscriptions'
+    // The 'subscriptions' fragment here does not have a corresponding param
+    if (i >= param_names_.size()) { continue; }
 
-		auto sep_pos = request.path.find(separator, starting_pos);
-		if (sep_pos == std::string::npos) {
-			sep_pos = request.path.length();
-		}
+    auto sep_pos = request.path.find(separator, starting_pos);
+    if (sep_pos == std::string::npos) { sep_pos = request.path.length(); }
 
-		const auto &param_name = param_names_[i];
+    const auto &param_name = param_names_[i];
 
-		request.path_params.emplace(param_name, request.path.substr(starting_pos, sep_pos - starting_pos));
+    request.path_params.emplace(
+        param_name, request.path.substr(starting_pos, sep_pos - starting_pos));
 
-		// Mark everythin up to '/' as matched
-		starting_pos = sep_pos + 1;
-	}
-	// Returns false if the path is longer than the pattern
-	return starting_pos >= request.path.length();
+    // Mark everythin up to '/' as matched
+    starting_pos = sep_pos + 1;
+  }
+  // Returns false if the path is longer than the pattern
+  return starting_pos >= request.path.length();
 }
 
 inline bool RegexMatcher::match(Request &request) const {
-	request.path_params.clear();
-	return RegexMatch(request.path, request.matches, regex_);
+  request.path_params.clear();
+  return RegexMatch(request.path, request.matches, regex_);
 }
 
 } // namespace detail
 
 // HTTP server implementation
-inline Server::Server() : new_task_queue([] { return new ThreadPool(CPPHTTPLIB_THREAD_POOL_COUNT); }) {
+inline Server::Server()
+    : new_task_queue(
+          [] { return new ThreadPool(CPPHTTPLIB_THREAD_POOL_COUNT); }) {
 #ifndef _WIN32
-	signal(SIGPIPE, SIG_IGN);
+  signal(SIGPIPE, SIG_IGN);
 #endif
 }
 
 inline Server::~Server() = default;
 
-inline duckdb::unique_ptr<detail::MatcherBase> Server::make_matcher(const std::string &pattern) {
-	if (pattern.find("/:") != std::string::npos) {
-		return detail::make_unique<detail::PathParamsMatcher>(pattern);
-	} else {
-		return detail::make_unique<detail::RegexMatcher>(pattern);
-	}
+inline duckdb::unique_ptr<detail::MatcherBase>
+Server::make_matcher(const std::string &pattern) {
+  if (pattern.find("/:") != std::string::npos) {
+    return detail::make_unique<detail::PathParamsMatcher>(pattern);
+  } else {
+    return detail::make_unique<detail::RegexMatcher>(pattern);
+  }
 }
 
 inline Server &Server::Get(const std::string &pattern, Handler handler) {
-	get_handlers_.emplace_back(Regex(pattern), std::move(handler));
-	return *this;
+  get_handlers_.emplace_back(Regex(pattern), std::move(handler));
+  return *this;
 }
 
 inline Server &Server::Post(const std::string &pattern, Handler handler) {
-	post_handlers_.emplace_back(Regex(pattern), std::move(handler));
-	return *this;
+  post_handlers_.emplace_back(Regex(pattern), std::move(handler));
+  return *this;
 }
 
-inline Server &Server::Post(const std::string &pattern, HandlerWithContentReader handler) {
-	post_handlers_for_content_reader_.emplace_back(Regex(pattern), std::move(handler));
-	return *this;
+inline Server &Server::Post(const std::string &pattern,
+                            HandlerWithContentReader handler) {
+  post_handlers_for_content_reader_.emplace_back(Regex(pattern),
+                                                 std::move(handler));
+  return *this;
 }
 
 inline Server &Server::Put(const std::string &pattern, Handler handler) {
-	put_handlers_.emplace_back(Regex(pattern), std::move(handler));
-	return *this;
+  put_handlers_.emplace_back(Regex(pattern), std::move(handler));
+  return *this;
 }
 
-inline Server &Server::Put(const std::string &pattern, HandlerWithContentReader handler) {
-	put_handlers_for_content_reader_.emplace_back(Regex(pattern), std::move(handler));
-	return *this;
+inline Server &Server::Put(const std::string &pattern,
+                           HandlerWithContentReader handler) {
+  put_handlers_for_content_reader_.emplace_back(Regex(pattern),
+                                                std::move(handler));
+  return *this;
 }
 
 inline Server &Server::Patch(const std::string &pattern, Handler handler) {
-	patch_handlers_.emplace_back(Regex(pattern), std::move(handler));
-	return *this;
+  patch_handlers_.emplace_back(Regex(pattern), std::move(handler));
+  return *this;
 }
 
-inline Server &Server::Patch(const std::string &pattern, HandlerWithContentReader handler) {
-	patch_handlers_for_content_reader_.emplace_back(Regex(pattern), std::move(handler));
-	return *this;
+inline Server &Server::Patch(const std::string &pattern,
+                             HandlerWithContentReader handler) {
+  patch_handlers_for_content_reader_.emplace_back(Regex(pattern),
+                                                  std::move(handler));
+  return *this;
 }
 
 inline Server &Server::Delete(const std::string &pattern, Handler handler) {
-	delete_handlers_.emplace_back(Regex(pattern), std::move(handler));
-	return *this;
+  delete_handlers_.emplace_back(Regex(pattern), std::move(handler));
+  return *this;
 }
 
-inline Server &Server::Delete(const std::string &pattern, HandlerWithContentReader handler) {
-	delete_handlers_for_content_reader_.emplace_back(Regex(pattern), std::move(handler));
-	return *this;
+inline Server &Server::Delete(const std::string &pattern,
+                              HandlerWithContentReader handler) {
+  delete_handlers_for_content_reader_.emplace_back(Regex(pattern),
+                                                   std::move(handler));
+  return *this;
 }
 
 inline Server &Server::Options(const std::string &pattern, Handler handler) {
-	options_handlers_.emplace_back(Regex(pattern), std::move(handler));
-	return *this;
+  options_handlers_.emplace_back(Regex(pattern), std::move(handler));
+  return *this;
 }
 
-inline bool Server::set_base_dir(const std::string &dir, const std::string &mount_point) {
-	return set_mount_point(mount_point, dir);
+inline bool Server::set_base_dir(const std::string &dir,
+                                 const std::string &mount_point) {
+  return set_mount_point(mount_point, dir);
 }
 
-inline bool Server::set_mount_point(const std::string &mount_point, const std::string &dir, Headers headers) {
-	if (detail::is_dir(dir)) {
-		std::string mnt = !mount_point.empty() ? mount_point : "/";
-		if (!mnt.empty() && mnt[0] == '/') {
-			base_dirs_.push_back({mnt, dir, std::move(headers)});
-			return true;
-		}
-	}
-	return false;
+inline bool Server::set_mount_point(const std::string &mount_point,
+                                    const std::string &dir, Headers headers) {
+  if (detail::is_dir(dir)) {
+    std::string mnt = !mount_point.empty() ? mount_point : "/";
+    if (!mnt.empty() && mnt[0] == '/') {
+      base_dirs_.push_back({mnt, dir, std::move(headers)});
+      return true;
+    }
+  }
+  return false;
 }
 
 inline bool Server::remove_mount_point(const std::string &mount_point) {
-	for (auto it = base_dirs_.begin(); it != base_dirs_.end(); ++it) {
-		if (it->mount_point == mount_point) {
-			base_dirs_.erase(it);
-			return true;
-		}
-	}
-	return false;
+  for (auto it = base_dirs_.begin(); it != base_dirs_.end(); ++it) {
+    if (it->mount_point == mount_point) {
+      base_dirs_.erase(it);
+      return true;
+    }
+  }
+  return false;
 }
 
-inline Server &Server::set_file_extension_and_mimetype_mapping(const std::string &ext, const std::string &mime) {
-	file_extension_and_mimetype_map_[ext] = mime;
-	return *this;
+inline Server &
+Server::set_file_extension_and_mimetype_mapping(const std::string &ext,
+                                                const std::string &mime) {
+  file_extension_and_mimetype_map_[ext] = mime;
+  return *this;
 }
 
 inline Server &Server::set_default_file_mimetype(const std::string &mime) {
-	default_file_mimetype_ = mime;
-	return *this;
+  default_file_mimetype_ = mime;
+  return *this;
 }
 
 inline Server &Server::set_file_request_handler(Handler handler) {
-	file_request_handler_ = std::move(handler);
-	return *this;
+  file_request_handler_ = std::move(handler);
+  return *this;
 }
 
 inline Server &Server::set_error_handler(HandlerWithResponse handler) {
-	error_handler_ = std::move(handler);
-	return *this;
+  error_handler_ = std::move(handler);
+  return *this;
 }
 
 inline Server &Server::set_error_handler(Handler handler) {
-	error_handler_ = [handler](const Request &req, Response &res) {
-		handler(req, res);
-		return HandlerResponse::Handled;
-	};
-	return *this;
+  error_handler_ = [handler](const Request &req, Response &res) {
+    handler(req, res);
+    return HandlerResponse::Handled;
+  };
+  return *this;
 }
 
 inline Server &Server::set_exception_handler(ExceptionHandler handler) {
-	exception_handler_ = std::move(handler);
-	return *this;
+  exception_handler_ = std::move(handler);
+  return *this;
 }
 
 inline Server &Server::set_pre_routing_handler(HandlerWithResponse handler) {
-	pre_routing_handler_ = std::move(handler);
-	return *this;
+  pre_routing_handler_ = std::move(handler);
+  return *this;
 }
 
 inline Server &Server::set_post_routing_handler(Handler handler) {
-	post_routing_handler_ = std::move(handler);
-	return *this;
+  post_routing_handler_ = std::move(handler);
+  return *this;
 }
 
 inline Server &Server::set_logger(Logger logger) {
-	logger_ = std::move(logger);
-	return *this;
+  logger_ = std::move(logger);
+  return *this;
 }
 
-inline Server &Server::set_expect_100_continue_handler(Expect100ContinueHandler handler) {
-	expect_100_continue_handler_ = std::move(handler);
-	return *this;
+inline Server &
+Server::set_expect_100_continue_handler(Expect100ContinueHandler handler) {
+  expect_100_continue_handler_ = std::move(handler);
+  return *this;
 }
 
 inline Server &Server::set_address_family(int family) {
-	address_family_ = family;
-	return *this;
+  address_family_ = family;
+  return *this;
 }
 
 inline Server &Server::set_tcp_nodelay(bool on) {
-	tcp_nodelay_ = on;
-	return *this;
+  tcp_nodelay_ = on;
+  return *this;
 }
 
 inline Server &Server::set_socket_options(SocketOptions socket_options) {
-	socket_options_ = std::move(socket_options);
-	return *this;
+  socket_options_ = std::move(socket_options);
+  return *this;
 }
 
 inline Server &Server::set_default_headers(Headers headers) {
-	default_headers_ = std::move(headers);
-	return *this;
+  default_headers_ = std::move(headers);
+  return *this;
 }
 
-inline Server &Server::set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer) {
-	header_writer_ = writer;
-	return *this;
+inline Server &Server::set_header_writer(
+    std::function<ssize_t(Stream &, Headers &)> const &writer) {
+  header_writer_ = writer;
+  return *this;
 }
 
 inline Server &Server::set_keep_alive_max_count(size_t count) {
-	keep_alive_max_count_ = count;
-	return *this;
+  keep_alive_max_count_ = count;
+  return *this;
 }
 
 inline Server &Server::set_keep_alive_timeout(time_t sec) {
-	keep_alive_timeout_sec_ = sec;
-	return *this;
+  keep_alive_timeout_sec_ = sec;
+  return *this;
 }
 
 inline Server &Server::set_read_timeout(time_t sec, time_t usec) {
-	read_timeout_sec_ = sec;
-	read_timeout_usec_ = usec;
-	return *this;
+  read_timeout_sec_ = sec;
+  read_timeout_usec_ = usec;
+  return *this;
 }
 
 inline Server &Server::set_write_timeout(time_t sec, time_t usec) {
-	write_timeout_sec_ = sec;
-	write_timeout_usec_ = usec;
-	return *this;
+  write_timeout_sec_ = sec;
+  write_timeout_usec_ = usec;
+  return *this;
 }
 
 inline Server &Server::set_idle_interval(time_t sec, time_t usec) {
-	idle_interval_sec_ = sec;
-	idle_interval_usec_ = usec;
-	return *this;
+  idle_interval_sec_ = sec;
+  idle_interval_usec_ = usec;
+  return *this;
 }
 
 inline Server &Server::set_payload_max_length(size_t length) {
-	payload_max_length_ = length;
-	return *this;
+  payload_max_length_ = length;
+  return *this;
 }
 
-inline bool Server::bind_to_port(const std::string &host, int port, int socket_flags) {
-	return bind_internal(host, port, socket_flags) >= 0;
+inline bool Server::bind_to_port(const std::string &host, int port,
+                                 int socket_flags) {
+  return bind_internal(host, port, socket_flags) >= 0;
 }
 inline int Server::bind_to_any_port(const std::string &host, int socket_flags) {
-	return bind_internal(host, 0, socket_flags);
+  return bind_internal(host, 0, socket_flags);
 }
 
 inline bool Server::listen_after_bind() {
-	auto se = detail::scope_exit([&]() { done_ = true; });
-	return listen_internal();
+  auto se = detail::scope_exit([&]() { done_ = true; });
+  return listen_internal();
 }
 
-inline bool Server::listen(const std::string &host, int port, int socket_flags) {
-	auto se = detail::scope_exit([&]() { done_ = true; });
-	return bind_to_port(host, port, socket_flags) && listen_internal();
+inline bool Server::listen(const std::string &host, int port,
+                           int socket_flags) {
+  auto se = detail::scope_exit([&]() { done_ = true; });
+  return bind_to_port(host, port, socket_flags) && listen_internal();
 }
 
-inline bool Server::is_running() const {
-	return is_running_;
-}
+inline bool Server::is_running() const { return is_running_; }
 
 inline void Server::wait_until_ready() const {
-	while (!is_running() && !done_) {
-		std::this_thread::sleep_for(std::chrono::milliseconds {1});
-	}
+  while (!is_running() && !done_) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{1});
+  }
 }
 
 inline void Server::stop() {
-	if (is_running_) {
-		assert(svr_sock_ != INVALID_SOCKET);
-		std::atomic<socket_t> sock(svr_sock_.exchange(INVALID_SOCKET));
-		detail::shutdown_socket(sock);
-		detail::close_socket(sock);
-	}
+  if (is_running_) {
+    assert(svr_sock_ != INVALID_SOCKET);
+    std::atomic<socket_t> sock(svr_sock_.exchange(INVALID_SOCKET));
+    detail::shutdown_socket(sock);
+    detail::close_socket(sock);
+  }
 }
 
-static const std::set<std::string> SERVER_METHODS {"GET",     "HEAD",    "POST",  "PUT",   "DELETE",
-                                                   "CONNECT", "OPTIONS", "TRACE", "PATCH", "PRI"};
+static const std::set<std::string> SERVER_METHODS{
+	"GET",     "HEAD",    "POST",  "PUT",   "DELETE",
+	"CONNECT", "OPTIONS", "TRACE", "PATCH", "PRI"};
 
 inline bool Server::parse_request_line(const char *s, Request &req) const {
-	auto len = strlen(s);
-	if (len < 2 || s[len - 2] != '\r' || s[len - 1] != '\n') {
-		return false;
-	}
-	len -= 2;
+  auto len = strlen(s);
+  if (len < 2 || s[len - 2] != '\r' || s[len - 1] != '\n') { return false; }
+  len -= 2;
 
-	{
-		size_t count = 0;
+  {
+    size_t count = 0;
 
-		detail::split(s, s + len, ' ', [&](const char *b, const char *e) {
-			switch (count) {
-			case 0:
-				req.method = std::string(b, e);
-				break;
-			case 1:
-				req.target = std::string(b, e);
-				break;
-			case 2:
-				req.version = std::string(b, e);
-				break;
-			default:
-				break;
-			}
-			count++;
-		});
+    detail::split(s, s + len, ' ', [&](const char *b, const char *e) {
+      switch (count) {
+      case 0: req.method = std::string(b, e); break;
+      case 1: req.target = std::string(b, e); break;
+      case 2: req.version = std::string(b, e); break;
+      default: break;
+      }
+      count++;
+    });
 
-		if (count != 3) {
-			return false;
-		}
-	}
+    if (count != 3) { return false; }
+  }
 
-	if (SERVER_METHODS.find(req.method) == SERVER_METHODS.end()) {
-		return false;
-	}
+  if (SERVER_METHODS.find(req.method) == SERVER_METHODS.end()) { return false; }
 
-	if (req.version != "HTTP/1.1" && req.version != "HTTP/1.0") {
-		return false;
-	}
+  if (req.version != "HTTP/1.1" && req.version != "HTTP/1.0") { return false; }
 
-	{
-		// Skip URL fragment
-		for (size_t i = 0; i < req.target.size(); i++) {
-			if (req.target[i] == '#') {
-				req.target.erase(i);
-				break;
-			}
-		}
+  {
+    // Skip URL fragment
+    for (size_t i = 0; i < req.target.size(); i++) {
+      if (req.target[i] == '#') {
+        req.target.erase(i);
+        break;
+      }
+    }
 
-		size_t count = 0;
+    size_t count = 0;
 
-		detail::split(req.target.data(), req.target.data() + req.target.size(), '?', 2,
-		              [&](const char *b, const char *e) {
-			              switch (count) {
-			              case 0:
-				              req.path = detail::decode_url(std::string(b, e), false);
-				              break;
-			              case 1: {
-				              if (e - b > 0) {
-					              detail::parse_query_text(std::string(b, e), req.params);
-				              }
-				              break;
-			              }
-			              default:
-				              break;
-			              }
-			              count++;
-		              });
+    detail::split(req.target.data(), req.target.data() + req.target.size(), '?',
+                  2, [&](const char *b, const char *e) {
+                    switch (count) {
+                    case 0:
+                      req.path = detail::decode_url(std::string(b, e), false);
+                      break;
+                    case 1: {
+                      if (e - b > 0) {
+                        detail::parse_query_text(std::string(b, e), req.params);
+                      }
+                      break;
+                    }
+                    default: break;
+                    }
+                    count++;
+                  });
 
-		if (count > 2) {
-			return false;
-		}
-	}
+    if (count > 2) { return false; }
+  }
 
-	return true;
+  return true;
 }
 
-inline bool Server::write_response(Stream &strm, bool close_connection, const Request &req, Response &res) {
-	return write_response_core(strm, close_connection, req, res, false);
+inline bool Server::write_response(Stream &strm, bool close_connection,
+                                   const Request &req, Response &res) {
+  return write_response_core(strm, close_connection, req, res, false);
 }
 
-inline bool Server::write_response_with_content(Stream &strm, bool close_connection, const Request &req,
+inline bool Server::write_response_with_content(Stream &strm,
+                                                bool close_connection,
+                                                const Request &req,
                                                 Response &res) {
-	return write_response_core(strm, close_connection, req, res, true);
+  return write_response_core(strm, close_connection, req, res, true);
 }
 
-inline bool Server::write_response_core(Stream &strm, bool close_connection, const Request &req, Response &res,
+inline bool Server::write_response_core(Stream &strm, bool close_connection,
+                                        const Request &req, Response &res,
                                         bool need_apply_ranges) {
-	assert(res.status != -1);
+  assert(res.status != -1);
 
-	if (400 <= res.status && error_handler_ && error_handler_(req, res) == HandlerResponse::Handled) {
-		need_apply_ranges = true;
-	}
+  if (400 <= res.status && error_handler_ &&
+      error_handler_(req, res) == HandlerResponse::Handled) {
+    need_apply_ranges = true;
+  }
 
-	std::string content_type;
-	std::string boundary;
-	if (need_apply_ranges) {
-		apply_ranges(req, res, content_type, boundary);
-	}
+  std::string content_type;
+  std::string boundary;
+  if (need_apply_ranges) { apply_ranges(req, res, content_type, boundary); }
 
-	// Prepare additional headers
-	if (close_connection || req.get_header_value("Connection") == "close") {
-		res.set_header("Connection", "close");
-	} else {
-		duckdb::stringstream ss;
-		ss << "timeout=" << keep_alive_timeout_sec_ << ", max=" << keep_alive_max_count_;
-		res.set_header("Keep-Alive", ss.str());
-	}
+  // Prepare additional headers
+  if (close_connection || req.get_header_value("Connection") == "close") {
+    res.set_header("Connection", "close");
+  } else {
+    duckdb::stringstream ss;
+    ss << "timeout=" << keep_alive_timeout_sec_
+       << ", max=" << keep_alive_max_count_;
+    res.set_header("Keep-Alive", ss.str());
+  }
 
-	if (!res.has_header("Content-Type") && (!res.body.empty() || res.content_length_ > 0 || res.content_provider_)) {
-		res.set_header("Content-Type", "text/plain");
-	}
+  if (!res.has_header("Content-Type") &&
+      (!res.body.empty() || res.content_length_ > 0 || res.content_provider_)) {
+    res.set_header("Content-Type", "text/plain");
+  }
 
-	if (!res.has_header("Content-Length") && res.body.empty() && !res.content_length_ && !res.content_provider_) {
-		res.set_header("Content-Length", "0");
-	}
+  if (!res.has_header("Content-Length") && res.body.empty() &&
+      !res.content_length_ && !res.content_provider_) {
+    res.set_header("Content-Length", "0");
+  }
 
-	if (!res.has_header("Accept-Ranges") && req.method == "HEAD") {
-		res.set_header("Accept-Ranges", "bytes");
-	}
+  if (!res.has_header("Accept-Ranges") && req.method == "HEAD") {
+    res.set_header("Accept-Ranges", "bytes");
+  }
 
-	if (post_routing_handler_) {
-		post_routing_handler_(req, res);
-	}
+  if (post_routing_handler_) { post_routing_handler_(req, res); }
 
-	// Response line and headers
-	{
-		detail::BufferStream bstrm;
+  // Response line and headers
+  {
+    detail::BufferStream bstrm;
 
-		if (!bstrm.write_format("HTTP/1.1 %d %s\r\n", res.status, status_message(res.status))) {
-			return false;
-		}
+    if (!bstrm.write_format("HTTP/1.1 %d %s\r\n", res.status,
+                            status_message(res.status))) {
+      return false;
+    }
 
-		if (!header_writer_(bstrm, res.headers)) {
-			return false;
-		}
+    if (!header_writer_(bstrm, res.headers)) { return false; }
 
-		// Flush buffer
-		auto &data = bstrm.get_buffer();
-		detail::write_data(strm, data.data(), data.size());
-	}
+    // Flush buffer
+    auto &data = bstrm.get_buffer();
+    detail::write_data(strm, data.data(), data.size());
+  }
 
-	// Body
-	auto ret = true;
-	if (req.method != "HEAD") {
-		if (!res.body.empty()) {
-			if (!detail::write_data(strm, res.body.data(), res.body.size())) {
-				ret = false;
-			}
-		} else if (res.content_provider_) {
-			if (write_content_with_provider(strm, req, res, boundary, content_type)) {
-				res.content_provider_success_ = true;
-			} else {
-				res.content_provider_success_ = false;
-				ret = false;
-			}
-		}
-	}
+  // Body
+  auto ret = true;
+  if (req.method != "HEAD") {
+    if (!res.body.empty()) {
+      if (!detail::write_data(strm, res.body.data(), res.body.size())) {
+        ret = false;
+      }
+    } else if (res.content_provider_) {
+      if (write_content_with_provider(strm, req, res, boundary, content_type)) {
+        res.content_provider_success_ = true;
+      } else {
+        res.content_provider_success_ = false;
+        ret = false;
+      }
+    }
+  }
 
-	// Log
-	if (logger_) {
-		logger_(req, res);
-	}
+  // Log
+  if (logger_) { logger_(req, res); }
 
-	return ret;
+  return ret;
 }
 
-inline bool Server::write_content_with_provider(Stream &strm, const Request &req, Response &res,
-                                                const std::string &boundary, const std::string &content_type) {
-	auto is_shutting_down = [this]() {
-		return this->svr_sock_ == INVALID_SOCKET;
-	};
+inline bool
+Server::write_content_with_provider(Stream &strm, const Request &req,
+                                    Response &res, const std::string &boundary,
+                                    const std::string &content_type) {
+  auto is_shutting_down = [this]() {
+    return this->svr_sock_ == INVALID_SOCKET;
+  };
 
-	if (res.content_length_ > 0) {
-		if (req.ranges.empty()) {
-			return detail::write_content(strm, res.content_provider_, 0, res.content_length_, is_shutting_down);
-		} else if (req.ranges.size() == 1) {
-			auto offsets = detail::get_range_offset_and_length(req, res.content_length_, 0);
-			auto offset = offsets.first;
-			auto length = offsets.second;
-			return detail::write_content(strm, res.content_provider_, offset, length, is_shutting_down);
-		} else {
-			return detail::write_multipart_ranges_data(strm, req, res, boundary, content_type, is_shutting_down);
-		}
-	} else {
-		if (res.is_chunked_content_provider_) {
-			auto type = detail::encoding_type(req, res);
+  if (res.content_length_ > 0) {
+    if (req.ranges.empty()) {
+      return detail::write_content(strm, res.content_provider_, 0,
+                                   res.content_length_, is_shutting_down);
+    } else if (req.ranges.size() == 1) {
+      auto offsets =
+          detail::get_range_offset_and_length(req, res.content_length_, 0);
+      auto offset = offsets.first;
+      auto length = offsets.second;
+      return detail::write_content(strm, res.content_provider_, offset, length,
+                                   is_shutting_down);
+    } else {
+      return detail::write_multipart_ranges_data(
+          strm, req, res, boundary, content_type, is_shutting_down);
+    }
+  } else {
+    if (res.is_chunked_content_provider_) {
+      auto type = detail::encoding_type(req, res);
 
-			duckdb::unique_ptr<detail::compressor> compressor;
-			if (type == detail::EncodingType::Gzip) {
+      duckdb::unique_ptr<detail::compressor> compressor;
+      if (type == detail::EncodingType::Gzip) {
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-				compressor = detail::make_unique<detail::gzip_compressor>();
+        compressor = detail::make_unique<detail::gzip_compressor>();
 #endif
-			} else if (type == detail::EncodingType::Brotli) {
+      } else if (type == detail::EncodingType::Brotli) {
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
-				compressor = detail::make_unique<detail::brotli_compressor>();
+        compressor = detail::make_unique<detail::brotli_compressor>();
 #endif
-			} else {
-				compressor = detail::make_unique<detail::nocompressor>();
-			}
-			assert(compressor != nullptr);
+      } else {
+        compressor = detail::make_unique<detail::nocompressor>();
+      }
+      assert(compressor != nullptr);
 
-			return detail::write_content_chunked(strm, res.content_provider_, is_shutting_down, *compressor);
-		} else {
-			return detail::write_content_without_length(strm, res.content_provider_, is_shutting_down);
-		}
-	}
+      return detail::write_content_chunked(strm, res.content_provider_,
+                                           is_shutting_down, *compressor);
+    } else {
+      return detail::write_content_without_length(strm, res.content_provider_,
+                                                  is_shutting_down);
+    }
+  }
 }
 
 inline bool Server::read_content(Stream &strm, Request &req, Response &res) {
-	MultipartFormDataMap::iterator cur;
-	auto file_count = 0;
-	if (read_content_core(
-	        strm, req, res,
-	        // Regular
-	        [&](const char *buf, size_t n) {
-		        if (req.body.size() + n > req.body.max_size()) {
-			        return false;
-		        }
-		        req.body.append(buf, n);
-		        return true;
-	        },
-	        // Multipart
-	        [&](const MultipartFormData &file) {
-		        if (file_count++ == CPPHTTPLIB_MULTIPART_FORM_DATA_FILE_MAX_COUNT) {
-			        return false;
-		        }
-		        cur = req.files.emplace(file.name, file);
-		        return true;
-	        },
-	        [&](const char *buf, size_t n) {
-		        auto &content = cur->second.content;
-		        if (content.size() + n > content.max_size()) {
-			        return false;
-		        }
-		        content.append(buf, n);
-		        return true;
-	        })) {
-		const auto &content_type = req.get_header_value("Content-Type");
-		if (!content_type.find("application/x-www-form-urlencoded")) {
-			if (req.body.size() > CPPHTTPLIB_FORM_URL_ENCODED_PAYLOAD_MAX_LENGTH) {
-				res.status = StatusCode::PayloadTooLarge_413; // NOTE: should be 414?
-				return false;
-			}
-			detail::parse_query_text(req.body, req.params);
-		}
-		return true;
-	}
-	return false;
+  MultipartFormDataMap::iterator cur;
+  auto file_count = 0;
+  if (read_content_core(
+          strm, req, res,
+          // Regular
+          [&](const char *buf, size_t n) {
+            if (req.body.size() + n > req.body.max_size()) { return false; }
+            req.body.append(buf, n);
+            return true;
+          },
+          // Multipart
+          [&](const MultipartFormData &file) {
+            if (file_count++ == CPPHTTPLIB_MULTIPART_FORM_DATA_FILE_MAX_COUNT) {
+              return false;
+            }
+            cur = req.files.emplace(file.name, file);
+            return true;
+          },
+          [&](const char *buf, size_t n) {
+            auto &content = cur->second.content;
+            if (content.size() + n > content.max_size()) { return false; }
+            content.append(buf, n);
+            return true;
+          })) {
+    const auto &content_type = req.get_header_value("Content-Type");
+    if (!content_type.find("application/x-www-form-urlencoded")) {
+      if (req.body.size() > CPPHTTPLIB_FORM_URL_ENCODED_PAYLOAD_MAX_LENGTH) {
+        res.status = StatusCode::PayloadTooLarge_413; // NOTE: should be 414?
+        return false;
+      }
+      detail::parse_query_text(req.body, req.params);
+    }
+    return true;
+  }
+  return false;
 }
 
-inline bool Server::read_content_with_content_receiver(Stream &strm, Request &req, Response &res,
-                                                       ContentReceiver receiver,
-                                                       MultipartContentHeader multipart_header,
-                                                       ContentReceiver multipart_receiver) {
-	return read_content_core(strm, req, res, std::move(receiver), std::move(multipart_header),
-	                         std::move(multipart_receiver));
+inline bool Server::read_content_with_content_receiver(
+    Stream &strm, Request &req, Response &res, ContentReceiver receiver,
+    MultipartContentHeader multipart_header,
+    ContentReceiver multipart_receiver) {
+  return read_content_core(strm, req, res, std::move(receiver),
+                           std::move(multipart_header),
+                           std::move(multipart_receiver));
 }
 
-inline bool Server::read_content_core(Stream &strm, Request &req, Response &res, ContentReceiver receiver,
-                                      MultipartContentHeader multipart_header,
-                                      ContentReceiver multipart_receiver) const {
-	detail::MultipartFormDataParser multipart_form_data_parser;
-	ContentReceiverWithProgress out;
+inline bool
+Server::read_content_core(Stream &strm, Request &req, Response &res,
+                          ContentReceiver receiver,
+                          MultipartContentHeader multipart_header,
+                          ContentReceiver multipart_receiver) const {
+  detail::MultipartFormDataParser multipart_form_data_parser;
+  ContentReceiverWithProgress out;
 
-	if (req.is_multipart_form_data()) {
-		const auto &content_type = req.get_header_value("Content-Type");
-		std::string boundary;
-		if (!detail::parse_multipart_boundary(content_type, boundary)) {
-			res.status = StatusCode::BadRequest_400;
-			return false;
-		}
+  if (req.is_multipart_form_data()) {
+    const auto &content_type = req.get_header_value("Content-Type");
+    std::string boundary;
+    if (!detail::parse_multipart_boundary(content_type, boundary)) {
+      res.status = StatusCode::BadRequest_400;
+      return false;
+    }
 
-		multipart_form_data_parser.set_boundary(std::move(boundary));
-		out = [&](const char *buf, size_t n, uint64_t /*off*/, uint64_t /*len*/) {
-			/* For debug
-			size_t pos = 0;
-			while (pos < n) {
-			  auto read_size = (std::min)<size_t>(1, n - pos);
-			  auto ret = multipart_form_data_parser.parse(
-			      buf + pos, read_size, multipart_receiver, multipart_header);
-			  if (!ret) { return false; }
-			  pos += read_size;
-			}
-			return true;
-			*/
-			return multipart_form_data_parser.parse(buf, n, multipart_receiver, multipart_header);
-		};
-	} else {
-		out = [receiver](const char *buf, size_t n, uint64_t /*off*/, uint64_t /*len*/) {
-			return receiver(buf, n);
-		};
-	}
+    multipart_form_data_parser.set_boundary(std::move(boundary));
+    out = [&](const char *buf, size_t n, uint64_t /*off*/, uint64_t /*len*/) {
+      /* For debug
+      size_t pos = 0;
+      while (pos < n) {
+        auto read_size = (std::min)<size_t>(1, n - pos);
+        auto ret = multipart_form_data_parser.parse(
+            buf + pos, read_size, multipart_receiver, multipart_header);
+        if (!ret) { return false; }
+        pos += read_size;
+      }
+      return true;
+      */
+      return multipart_form_data_parser.parse(buf, n, multipart_receiver,
+                                              multipart_header);
+    };
+  } else {
+    out = [receiver](const char *buf, size_t n, uint64_t /*off*/,
+                     uint64_t /*len*/) { return receiver(buf, n); };
+  }
 
-	if (req.method == "DELETE" && !req.has_header("Content-Length")) {
-		return true;
-	}
+  if (req.method == "DELETE" && !req.has_header("Content-Length")) {
+    return true;
+  }
 
-	if (!detail::read_content(strm, req, payload_max_length_, res.status, nullptr, out, true)) {
-		return false;
-	}
+  if (!detail::read_content(strm, req, payload_max_length_, res.status, nullptr,
+                            out, true)) {
+    return false;
+  }
 
-	if (req.is_multipart_form_data()) {
-		if (!multipart_form_data_parser.is_valid()) {
-			res.status = StatusCode::BadRequest_400;
-			return false;
-		}
-	}
+  if (req.is_multipart_form_data()) {
+    if (!multipart_form_data_parser.is_valid()) {
+      res.status = StatusCode::BadRequest_400;
+      return false;
+    }
+  }
 
-	return true;
+  return true;
 }
 
-inline bool Server::handle_file_request(const Request &req, Response &res, bool head) {
-	for (const auto &entry : base_dirs_) {
-		// Prefix match
-		if (!req.path.compare(0, entry.mount_point.size(), entry.mount_point)) {
-			std::string sub_path = "/" + req.path.substr(entry.mount_point.size());
-			if (detail::is_valid_path(sub_path)) {
-				auto path = entry.base_dir + sub_path;
-				if (path.back() == '/') {
-					path += "index.html";
-				}
+inline bool Server::handle_file_request(const Request &req, Response &res,
+                                        bool head) {
+  for (const auto &entry : base_dirs_) {
+    // Prefix match
+    if (!req.path.compare(0, entry.mount_point.size(), entry.mount_point)) {
+      std::string sub_path = "/" + req.path.substr(entry.mount_point.size());
+      if (detail::is_valid_path(sub_path)) {
+        auto path = entry.base_dir + sub_path;
+        if (path.back() == '/') { path += "index.html"; }
 
-				if (detail::is_file(path)) {
-					for (const auto &kv : entry.headers) {
-						res.set_header(kv.first, kv.second);
-					}
+        if (detail::is_file(path)) {
+          for (const auto &kv : entry.headers) {
+            res.set_header(kv.first, kv.second);
+          }
 
-					auto mm = duckdb::make_shared_ptr<detail::mmap>(path.c_str());
-					if (!mm->is_open()) {
-						return false;
-					}
+          auto mm = duckdb::make_shared_ptr<detail::mmap>(path.c_str());
+          if (!mm->is_open()) { return false; }
 
-					res.set_content_provider(
-					    mm->size(),
-					    detail::find_content_type(path, file_extension_and_mimetype_map_, default_file_mimetype_),
-					    [mm](size_t offset, size_t length, DataSink &sink) -> bool {
-						    sink.write(mm->data() + offset, length);
-						    return true;
-					    });
+          res.set_content_provider(
+              mm->size(),
+              detail::find_content_type(path, file_extension_and_mimetype_map_,
+                                        default_file_mimetype_),
+              [mm](size_t offset, size_t length, DataSink &sink) -> bool {
+                sink.write(mm->data() + offset, length);
+                return true;
+              });
 
-					if (!head && file_request_handler_) {
-						file_request_handler_(req, res);
-					}
+          if (!head && file_request_handler_) {
+            file_request_handler_(req, res);
+          }
 
-					return true;
-				}
-			}
-		}
-	}
-	return false;
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }
 
-inline socket_t Server::create_server_socket(const std::string &host, int port, int socket_flags,
-                                             SocketOptions socket_options) const {
-	return detail::create_socket(host, std::string(), port, address_family_, socket_flags, tcp_nodelay_,
-	                             std::move(socket_options), [](socket_t sock, struct addrinfo &ai) -> bool {
-		                             if (::bind(sock, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen))) {
-			                             return false;
-		                             }
-		                             if (::listen(sock, CPPHTTPLIB_LISTEN_BACKLOG)) {
-			                             return false;
-		                             }
-		                             return true;
-	                             });
+inline socket_t
+Server::create_server_socket(const std::string &host, int port,
+                             int socket_flags,
+                             SocketOptions socket_options) const {
+  return detail::create_socket(
+      host, std::string(), port, address_family_, socket_flags, tcp_nodelay_,
+      std::move(socket_options),
+      [](socket_t sock, struct addrinfo &ai) -> bool {
+        if (::bind(sock, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen))) {
+          return false;
+        }
+        if (::listen(sock, CPPHTTPLIB_LISTEN_BACKLOG)) { return false; }
+        return true;
+      });
 }
 
-inline int Server::bind_internal(const std::string &host, int port, int socket_flags) {
-	if (!is_valid()) {
-		return -1;
-	}
+inline int Server::bind_internal(const std::string &host, int port,
+                                 int socket_flags) {
+  if (!is_valid()) { return -1; }
 
-	svr_sock_ = create_server_socket(host, port, socket_flags, socket_options_);
-	if (svr_sock_ == INVALID_SOCKET) {
-		return -1;
-	}
+  svr_sock_ = create_server_socket(host, port, socket_flags, socket_options_);
+  if (svr_sock_ == INVALID_SOCKET) { return -1; }
 
-	if (port == 0) {
-		struct sockaddr_storage addr;
-		socklen_t addr_len = sizeof(addr);
-		if (getsockname(svr_sock_, reinterpret_cast<struct sockaddr *>(&addr), &addr_len) == -1) {
-			return -1;
-		}
-		if (addr.ss_family == AF_INET) {
-			return ntohs(reinterpret_cast<struct sockaddr_in *>(&addr)->sin_port);
-		} else if (addr.ss_family == AF_INET6) {
-			return ntohs(reinterpret_cast<struct sockaddr_in6 *>(&addr)->sin6_port);
-		} else {
-			return -1;
-		}
-	} else {
-		return port;
-	}
+  if (port == 0) {
+    struct sockaddr_storage addr;
+    socklen_t addr_len = sizeof(addr);
+    if (getsockname(svr_sock_, reinterpret_cast<struct sockaddr *>(&addr),
+                    &addr_len) == -1) {
+      return -1;
+    }
+    if (addr.ss_family == AF_INET) {
+      return ntohs(reinterpret_cast<struct sockaddr_in *>(&addr)->sin_port);
+    } else if (addr.ss_family == AF_INET6) {
+      return ntohs(reinterpret_cast<struct sockaddr_in6 *>(&addr)->sin6_port);
+    } else {
+      return -1;
+    }
+  } else {
+    return port;
+  }
 }
 
 inline bool Server::listen_internal() {
-	auto ret = true;
-	is_running_ = true;
-	auto se = detail::scope_exit([&]() { is_running_ = false; });
+  auto ret = true;
+  is_running_ = true;
+  auto se = detail::scope_exit([&]() { is_running_ = false; });
 
-	{
-		duckdb::unique_ptr<TaskQueue> task_queue(new_task_queue());
+  {
+    duckdb::unique_ptr<TaskQueue> task_queue(new_task_queue());
 
-		while (svr_sock_ != INVALID_SOCKET) {
+    while (svr_sock_ != INVALID_SOCKET) {
 #ifndef _WIN32
-			if (idle_interval_sec_ > 0 || idle_interval_usec_ > 0) {
+      if (idle_interval_sec_ > 0 || idle_interval_usec_ > 0) {
 #endif
-				auto val = detail::select_read(svr_sock_, idle_interval_sec_, idle_interval_usec_);
-				if (val == 0) { // Timeout
-					task_queue->on_idle();
-					continue;
-				}
+        auto val = detail::select_read(svr_sock_, idle_interval_sec_,
+                                       idle_interval_usec_);
+        if (val == 0) { // Timeout
+          task_queue->on_idle();
+          continue;
+        }
 #ifndef _WIN32
-			}
+      }
 #endif
-			socket_t sock = accept(svr_sock_, nullptr, nullptr);
+      socket_t sock = accept(svr_sock_, nullptr, nullptr);
 
-			if (sock == INVALID_SOCKET) {
-				if (errno == EMFILE) {
-					// The per-process limit of open file descriptors has been reached.
-					// Try to accept new connections after a short sleep.
-					std::this_thread::sleep_for(std::chrono::milliseconds(1));
-					continue;
-				} else if (errno == EINTR || errno == EAGAIN) {
-					continue;
-				}
-				if (svr_sock_ != INVALID_SOCKET) {
-					detail::close_socket(svr_sock_);
-					ret = false;
-				} else {
-					; // The server socket was closed by user.
-				}
-				break;
-			}
+      if (sock == INVALID_SOCKET) {
+        if (errno == EMFILE) {
+          // The per-process limit of open file descriptors has been reached.
+          // Try to accept new connections after a short sleep.
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          continue;
+        } else if (errno == EINTR || errno == EAGAIN) {
+          continue;
+        }
+        if (svr_sock_ != INVALID_SOCKET) {
+          detail::close_socket(svr_sock_);
+          ret = false;
+        } else {
+          ; // The server socket was closed by user.
+        }
+        break;
+      }
 
-			{
+      {
 #ifdef _WIN32
-				auto timeout = static_cast<uint32_t>(read_timeout_sec_ * 1000 + read_timeout_usec_ / 1000);
-				setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char *>(&timeout), sizeof(timeout));
+        auto timeout = static_cast<uint32_t>(read_timeout_sec_ * 1000 +
+                                             read_timeout_usec_ / 1000);
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO,
+                   reinterpret_cast<const char *>(&timeout), sizeof(timeout));
 #else
-				timeval tv;
-				tv.tv_sec = static_cast<long>(read_timeout_sec_);
-				tv.tv_usec = static_cast<decltype(tv.tv_usec)>(read_timeout_usec_);
-				setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const void *>(&tv), sizeof(tv));
+        timeval tv;
+        tv.tv_sec = static_cast<long>(read_timeout_sec_);
+        tv.tv_usec = static_cast<decltype(tv.tv_usec)>(read_timeout_usec_);
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO,
+                   reinterpret_cast<const void *>(&tv), sizeof(tv));
 #endif
-			}
-			{
+      }
+      {
 
 #ifdef _WIN32
-				auto timeout = static_cast<uint32_t>(write_timeout_sec_ * 1000 + write_timeout_usec_ / 1000);
-				setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char *>(&timeout), sizeof(timeout));
+        auto timeout = static_cast<uint32_t>(write_timeout_sec_ * 1000 +
+                                             write_timeout_usec_ / 1000);
+        setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO,
+                   reinterpret_cast<const char *>(&timeout), sizeof(timeout));
 #else
-				timeval tv;
-				tv.tv_sec = static_cast<long>(write_timeout_sec_);
-				tv.tv_usec = static_cast<decltype(tv.tv_usec)>(write_timeout_usec_);
-				setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const void *>(&tv), sizeof(tv));
+        timeval tv;
+        tv.tv_sec = static_cast<long>(write_timeout_sec_);
+        tv.tv_usec = static_cast<decltype(tv.tv_usec)>(write_timeout_usec_);
+        setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO,
+                   reinterpret_cast<const void *>(&tv), sizeof(tv));
 #endif
-			}
+      }
 
-			task_queue->enqueue([this, sock]() { process_and_close_socket(sock); });
-		}
+      task_queue->enqueue([this, sock]() { process_and_close_socket(sock); });
+    }
 
-		task_queue->shutdown();
-	}
+    task_queue->shutdown();
+  }
 
-	return ret;
+  return ret;
 }
 
 inline bool Server::routing(Request &req, Response &res, Stream &strm) {
-	if (pre_routing_handler_ && pre_routing_handler_(req, res) == HandlerResponse::Handled) {
-		return true;
-	}
+  if (pre_routing_handler_ &&
+      pre_routing_handler_(req, res) == HandlerResponse::Handled) {
+    return true;
+  }
 
-	// File handler
-	auto is_head_request = req.method == "HEAD";
-	if ((req.method == "GET" || is_head_request) && handle_file_request(req, res, is_head_request)) {
-		return true;
-	}
+  // File handler
+  auto is_head_request = req.method == "HEAD";
+  if ((req.method == "GET" || is_head_request) &&
+      handle_file_request(req, res, is_head_request)) {
+    return true;
+  }
 
-	if (detail::expect_content(req)) {
-		// Content reader handler
-		{
-			ContentReader reader(
-			    [&](ContentReceiver receiver) {
-				    return read_content_with_content_receiver(strm, req, res, std::move(receiver), nullptr, nullptr);
-			    },
-			    [&](MultipartContentHeader header, ContentReceiver receiver) {
-				    return read_content_with_content_receiver(strm, req, res, nullptr, std::move(header),
-				                                              std::move(receiver));
-			    });
+  if (detail::expect_content(req)) {
+    // Content reader handler
+    {
+      ContentReader reader(
+          [&](ContentReceiver receiver) {
+            return read_content_with_content_receiver(
+                strm, req, res, std::move(receiver), nullptr, nullptr);
+          },
+          [&](MultipartContentHeader header, ContentReceiver receiver) {
+            return read_content_with_content_receiver(strm, req, res, nullptr,
+                                                      std::move(header),
+                                                      std::move(receiver));
+          });
 
-			if (req.method == "POST") {
-				if (dispatch_request_for_content_reader(req, res, std::move(reader),
-				                                        post_handlers_for_content_reader_)) {
-					return true;
-				}
-			} else if (req.method == "PUT") {
-				if (dispatch_request_for_content_reader(req, res, std::move(reader),
-				                                        put_handlers_for_content_reader_)) {
-					return true;
-				}
-			} else if (req.method == "PATCH") {
-				if (dispatch_request_for_content_reader(req, res, std::move(reader),
-				                                        patch_handlers_for_content_reader_)) {
-					return true;
-				}
-			} else if (req.method == "DELETE") {
-				if (dispatch_request_for_content_reader(req, res, std::move(reader),
-				                                        delete_handlers_for_content_reader_)) {
-					return true;
-				}
-			}
-		}
+      if (req.method == "POST") {
+        if (dispatch_request_for_content_reader(
+                req, res, std::move(reader),
+                post_handlers_for_content_reader_)) {
+          return true;
+        }
+      } else if (req.method == "PUT") {
+        if (dispatch_request_for_content_reader(
+                req, res, std::move(reader),
+                put_handlers_for_content_reader_)) {
+          return true;
+        }
+      } else if (req.method == "PATCH") {
+        if (dispatch_request_for_content_reader(
+                req, res, std::move(reader),
+                patch_handlers_for_content_reader_)) {
+          return true;
+        }
+      } else if (req.method == "DELETE") {
+        if (dispatch_request_for_content_reader(
+                req, res, std::move(reader),
+                delete_handlers_for_content_reader_)) {
+          return true;
+        }
+      }
+    }
 
-		// Read content into `req.body`
-		if (!read_content(strm, req, res)) {
-			return false;
-		}
-	}
+    // Read content into `req.body`
+    if (!read_content(strm, req, res)) { return false; }
+  }
 
-	// Regular handler
-	if (req.method == "GET" || req.method == "HEAD") {
-		return dispatch_request(req, res, get_handlers_);
-	} else if (req.method == "POST") {
-		return dispatch_request(req, res, post_handlers_);
-	} else if (req.method == "PUT") {
-		return dispatch_request(req, res, put_handlers_);
-	} else if (req.method == "DELETE") {
-		return dispatch_request(req, res, delete_handlers_);
-	} else if (req.method == "OPTIONS") {
-		return dispatch_request(req, res, options_handlers_);
-	} else if (req.method == "PATCH") {
-		return dispatch_request(req, res, patch_handlers_);
-	}
+  // Regular handler
+  if (req.method == "GET" || req.method == "HEAD") {
+    return dispatch_request(req, res, get_handlers_);
+  } else if (req.method == "POST") {
+    return dispatch_request(req, res, post_handlers_);
+  } else if (req.method == "PUT") {
+    return dispatch_request(req, res, put_handlers_);
+  } else if (req.method == "DELETE") {
+    return dispatch_request(req, res, delete_handlers_);
+  } else if (req.method == "OPTIONS") {
+    return dispatch_request(req, res, options_handlers_);
+  } else if (req.method == "PATCH") {
+    return dispatch_request(req, res, patch_handlers_);
+  }
 
-	res.status = StatusCode::BadRequest_400;
-	return false;
+  res.status = StatusCode::BadRequest_400;
+  return false;
 }
 
-inline bool Server::dispatch_request(Request &req, Response &res, const Handlers &handlers) const {
-	for (const auto &x : handlers) {
-		const auto &pattern = x.first;
-		const auto &handler = x.second;
+inline bool Server::dispatch_request(Request &req, Response &res,
+                                     const Handlers &handlers) const {
+  for (const auto &x : handlers) {
+    const auto &pattern = x.first;
+    const auto &handler = x.second;
 
-		if (duckdb_re2::RegexMatch(req.path, req.matches, pattern)) {
-			handler(req, res);
-			return true;
-		}
-	}
-	return false;
+    if (duckdb_re2::RegexMatch(req.path, req.matches, pattern)) {
+      handler(req, res);
+      return true;
+    }
+  }
+  return false;
 }
 
-inline void Server::apply_ranges(const Request &req, Response &res, std::string &content_type,
+inline void Server::apply_ranges(const Request &req, Response &res,
+                                 std::string &content_type,
                                  std::string &boundary) const {
-	if (req.ranges.size() > 1) {
-		boundary = detail::make_multipart_data_boundary();
+  if (req.ranges.size() > 1) {
+    boundary = detail::make_multipart_data_boundary();
 
-		auto it = res.headers.find("Content-Type");
-		if (it != res.headers.end()) {
-			content_type = it->second;
-			res.headers.erase(it);
-		}
+    auto it = res.headers.find("Content-Type");
+    if (it != res.headers.end()) {
+      content_type = it->second;
+      res.headers.erase(it);
+    }
 
-		res.set_header("Content-Type", "multipart/byteranges; boundary=" + boundary);
-	}
+    res.set_header("Content-Type",
+                   "multipart/byteranges; boundary=" + boundary);
+  }
 
-	auto type = detail::encoding_type(req, res);
+  auto type = detail::encoding_type(req, res);
 
-	if (res.body.empty()) {
-		if (res.content_length_ > 0) {
-			size_t length = 0;
-			if (req.ranges.empty()) {
-				length = res.content_length_;
-			} else if (req.ranges.size() == 1) {
-				auto offsets = detail::get_range_offset_and_length(req, res.content_length_, 0);
-				length = offsets.second;
+  if (res.body.empty()) {
+    if (res.content_length_ > 0) {
+      size_t length = 0;
+      if (req.ranges.empty()) {
+        length = res.content_length_;
+      } else if (req.ranges.size() == 1) {
+        auto offsets =
+            detail::get_range_offset_and_length(req, res.content_length_, 0);
+        length = offsets.second;
 
-				auto content_range = detail::make_content_range_header_field(req.ranges[0], res.content_length_);
-				res.set_header("Content-Range", content_range);
-			} else {
-				length = detail::get_multipart_ranges_data_length(req, res, boundary, content_type);
-			}
-			res.set_header("Content-Length", std::to_string(length));
-		} else {
-			if (res.content_provider_) {
-				if (res.is_chunked_content_provider_) {
-					res.set_header("Transfer-Encoding", "chunked");
-					if (type == detail::EncodingType::Gzip) {
-						res.set_header("Content-Encoding", "gzip");
-					} else if (type == detail::EncodingType::Brotli) {
-						res.set_header("Content-Encoding", "br");
-					}
-				}
-			}
-		}
-	} else {
-		if (req.ranges.empty()) {
-			;
-		} else if (req.ranges.size() == 1) {
-			auto content_range = detail::make_content_range_header_field(req.ranges[0], res.body.size());
-			res.set_header("Content-Range", content_range);
+        auto content_range = detail::make_content_range_header_field(
+            req.ranges[0], res.content_length_);
+        res.set_header("Content-Range", content_range);
+      } else {
+        length = detail::get_multipart_ranges_data_length(req, res, boundary,
+                                                          content_type);
+      }
+      res.set_header("Content-Length", std::to_string(length));
+    } else {
+      if (res.content_provider_) {
+        if (res.is_chunked_content_provider_) {
+          res.set_header("Transfer-Encoding", "chunked");
+          if (type == detail::EncodingType::Gzip) {
+            res.set_header("Content-Encoding", "gzip");
+          } else if (type == detail::EncodingType::Brotli) {
+            res.set_header("Content-Encoding", "br");
+          }
+        }
+      }
+    }
+  } else {
+    if (req.ranges.empty()) {
+      ;
+    } else if (req.ranges.size() == 1) {
+      auto content_range = detail::make_content_range_header_field(
+          req.ranges[0], res.body.size());
+      res.set_header("Content-Range", content_range);
 
-			auto offsets = detail::get_range_offset_and_length(req, res.body.size(), 0);
-			auto offset = offsets.first;
-			auto length = offsets.second;
+      auto offsets =
+          detail::get_range_offset_and_length(req, res.body.size(), 0);
+      auto offset = offsets.first;
+      auto length = offsets.second;
 
-			if (offset < res.body.size()) {
-				res.body = res.body.substr(offset, length);
-			} else {
-				res.body.clear();
-				res.status = StatusCode::RangeNotSatisfiable_416;
-			}
-		} else {
-			std::string data;
-			if (detail::make_multipart_ranges_data(req, res, boundary, content_type, data)) {
-				res.body.swap(data);
-			} else {
-				res.body.clear();
-				res.status = StatusCode::RangeNotSatisfiable_416;
-			}
-		}
+      if (offset < res.body.size()) {
+        res.body = res.body.substr(offset, length);
+      } else {
+        res.body.clear();
+        res.status = StatusCode::RangeNotSatisfiable_416;
+      }
+    } else {
+      std::string data;
+      if (detail::make_multipart_ranges_data(req, res, boundary, content_type,
+                                             data)) {
+        res.body.swap(data);
+      } else {
+        res.body.clear();
+        res.status = StatusCode::RangeNotSatisfiable_416;
+      }
+    }
 
-		if (type != detail::EncodingType::None) {
-			duckdb::unique_ptr<detail::compressor> compressor;
-			std::string content_encoding;
+    if (type != detail::EncodingType::None) {
+      duckdb::unique_ptr<detail::compressor> compressor;
+      std::string content_encoding;
 
-			if (type == detail::EncodingType::Gzip) {
+      if (type == detail::EncodingType::Gzip) {
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-				compressor = detail::make_unique<detail::gzip_compressor>();
-				content_encoding = "gzip";
+        compressor = detail::make_unique<detail::gzip_compressor>();
+        content_encoding = "gzip";
 #endif
-			} else if (type == detail::EncodingType::Brotli) {
+      } else if (type == detail::EncodingType::Brotli) {
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
-				compressor = detail::make_unique<detail::brotli_compressor>();
-				content_encoding = "br";
+        compressor = detail::make_unique<detail::brotli_compressor>();
+        content_encoding = "br";
 #endif
-			}
+      }
 
-			if (compressor) {
-				std::string compressed;
-				if (compressor->compress(res.body.data(), res.body.size(), true,
-				                         [&](const char *data, size_t data_len) {
-					                         compressed.append(data, data_len);
-					                         return true;
-				                         })) {
-					res.body.swap(compressed);
-					res.set_header("Content-Encoding", content_encoding);
-				}
-			}
-		}
+      if (compressor) {
+        std::string compressed;
+        if (compressor->compress(res.body.data(), res.body.size(), true,
+                                 [&](const char *data, size_t data_len) {
+                                   compressed.append(data, data_len);
+                                   return true;
+                                 })) {
+          res.body.swap(compressed);
+          res.set_header("Content-Encoding", content_encoding);
+        }
+      }
+    }
 
-		auto length = std::to_string(res.body.size());
-		res.set_header("Content-Length", length);
-	}
+    auto length = std::to_string(res.body.size());
+    res.set_header("Content-Length", length);
+  }
 }
 
-inline bool Server::dispatch_request_for_content_reader(Request &req, Response &res, ContentReader content_reader,
-                                                        const HandlersForContentReader &handlers) const {
-	for (const auto &x : handlers) {
-		const auto &pattern = x.first;
-		const auto &handler = x.second;
+inline bool Server::dispatch_request_for_content_reader(
+    Request &req, Response &res, ContentReader content_reader,
+    const HandlersForContentReader &handlers) const {
+  for (const auto &x : handlers) {
+    const auto &pattern = x.first;
+    const auto &handler = x.second;
 
-		if (duckdb_re2::RegexMatch(req.path, req.matches, pattern)) {
-			handler(req, res, content_reader);
-			return true;
-		}
-	}
-	return false;
+    if (duckdb_re2::RegexMatch(req.path, req.matches, pattern)) {
+      handler(req, res, content_reader);
+      return true;
+    }
+  }
+  return false;
 }
 
-inline bool Server::process_request(Stream &strm, bool close_connection, bool &connection_closed,
-                                    const std::function<void(Request &)> &setup_request) {
-	std::array<char, 2048> buf {};
+inline bool
+Server::process_request(Stream &strm, bool close_connection,
+                        bool &connection_closed,
+                        const std::function<void(Request &)> &setup_request) {
+  std::array<char, 2048> buf{};
 
-	detail::stream_line_reader line_reader(strm, buf.data(), buf.size());
+  detail::stream_line_reader line_reader(strm, buf.data(), buf.size());
 
-	// Connection has been closed on client
-	if (!line_reader.getline()) {
-		return false;
-	}
+  // Connection has been closed on client
+  if (!line_reader.getline()) { return false; }
 
-	Request req;
+  Request req;
 
-	Response res;
-	res.version = "HTTP/1.1";
-	res.headers = default_headers_;
+  Response res;
+  res.version = "HTTP/1.1";
+  res.headers = default_headers_;
 
 #ifdef _WIN32
-	// TODO: Increase FD_SETSIZE statically (libzmq), dynamically (MySQL).
+  // TODO: Increase FD_SETSIZE statically (libzmq), dynamically (MySQL).
 #else
 #ifndef CPPHTTPLIB_USE_POLL
-	// Socket file descriptor exceeded FD_SETSIZE...
-	if (strm.socket() >= FD_SETSIZE) {
-		Headers dummy;
-		detail::read_headers(strm, dummy);
-		res.status = StatusCode::InternalServerError_500;
-		return write_response(strm, close_connection, req, res);
-	}
+  // Socket file descriptor exceeded FD_SETSIZE...
+  if (strm.socket() >= FD_SETSIZE) {
+    Headers dummy;
+    detail::read_headers(strm, dummy);
+    res.status = StatusCode::InternalServerError_500;
+    return write_response(strm, close_connection, req, res);
+  }
 #endif
 #endif
 
-	// Check if the request URI doesn't exceed the limit
-	if (line_reader.size() > CPPHTTPLIB_REQUEST_URI_MAX_LENGTH) {
-		Headers dummy;
-		detail::read_headers(strm, dummy);
-		res.status = StatusCode::UriTooLong_414;
-		return write_response(strm, close_connection, req, res);
-	}
+  // Check if the request URI doesn't exceed the limit
+  if (line_reader.size() > CPPHTTPLIB_REQUEST_URI_MAX_LENGTH) {
+    Headers dummy;
+    detail::read_headers(strm, dummy);
+    res.status = StatusCode::UriTooLong_414;
+    return write_response(strm, close_connection, req, res);
+  }
 
-	// Request line and headers
-	if (!parse_request_line(line_reader.ptr(), req) || !detail::read_headers(strm, req.headers)) {
-		res.status = StatusCode::BadRequest_400;
-		return write_response(strm, close_connection, req, res);
-	}
+  // Request line and headers
+  if (!parse_request_line(line_reader.ptr(), req) ||
+      !detail::read_headers(strm, req.headers)) {
+    res.status = StatusCode::BadRequest_400;
+    return write_response(strm, close_connection, req, res);
+  }
 
-	if (req.get_header_value("Connection") == "close") {
-		connection_closed = true;
-	}
+  if (req.get_header_value("Connection") == "close") {
+    connection_closed = true;
+  }
 
-	if (req.version == "HTTP/1.0" && req.get_header_value("Connection") != "Keep-Alive") {
-		connection_closed = true;
-	}
+  if (req.version == "HTTP/1.0" &&
+      req.get_header_value("Connection") != "Keep-Alive") {
+    connection_closed = true;
+  }
 
-	strm.get_remote_ip_and_port(req.remote_addr, req.remote_port);
-	req.set_header("REMOTE_ADDR", req.remote_addr);
-	req.set_header("REMOTE_PORT", std::to_string(req.remote_port));
+  strm.get_remote_ip_and_port(req.remote_addr, req.remote_port);
+  req.set_header("REMOTE_ADDR", req.remote_addr);
+  req.set_header("REMOTE_PORT", std::to_string(req.remote_port));
 
-	strm.get_local_ip_and_port(req.local_addr, req.local_port);
-	req.set_header("LOCAL_ADDR", req.local_addr);
-	req.set_header("LOCAL_PORT", std::to_string(req.local_port));
+  strm.get_local_ip_and_port(req.local_addr, req.local_port);
+  req.set_header("LOCAL_ADDR", req.local_addr);
+  req.set_header("LOCAL_PORT", std::to_string(req.local_port));
 
-	if (req.has_header("Range")) {
-		const auto &range_header_value = req.get_header_value("Range");
-		if (!detail::parse_range_header(range_header_value, req.ranges)) {
-			res.status = StatusCode::RangeNotSatisfiable_416;
-			return write_response(strm, close_connection, req, res);
-		}
-	}
+  if (req.has_header("Range")) {
+    const auto &range_header_value = req.get_header_value("Range");
+    if (!detail::parse_range_header(range_header_value, req.ranges)) {
+      res.status = StatusCode::RangeNotSatisfiable_416;
+      return write_response(strm, close_connection, req, res);
+    }
+  }
 
-	if (setup_request) {
-		setup_request(req);
-	}
+  if (setup_request) { setup_request(req); }
 
-	if (req.get_header_value("Expect") == "100-continue") {
-		int status = StatusCode::Continue_100;
-		if (expect_100_continue_handler_) {
-			status = expect_100_continue_handler_(req, res);
-		}
-		switch (status) {
-		case StatusCode::Continue_100:
-		case StatusCode::ExpectationFailed_417:
-			strm.write_format("HTTP/1.1 %d %s\r\n\r\n", status, status_message(status));
-			break;
-		default:
-			return write_response(strm, close_connection, req, res);
-		}
-	}
+  if (req.get_header_value("Expect") == "100-continue") {
+    int status = StatusCode::Continue_100;
+    if (expect_100_continue_handler_) {
+      status = expect_100_continue_handler_(req, res);
+    }
+    switch (status) {
+    case StatusCode::Continue_100:
+    case StatusCode::ExpectationFailed_417:
+      strm.write_format("HTTP/1.1 %d %s\r\n\r\n", status,
+                        status_message(status));
+      break;
+    default: return write_response(strm, close_connection, req, res);
+    }
+  }
 
-	// Rounting
-	auto routed = false;
+  // Rounting
+  auto routed = false;
 #ifdef CPPHTTPLIB_NO_EXCEPTIONS
-	routed = routing(req, res, strm);
+  routed = routing(req, res, strm);
 #else
-	try {
-		routed = routing(req, res, strm);
-	} catch (std::exception &e) {
-		if (exception_handler_) {
-			auto ep = std::current_exception();
-			exception_handler_(req, res, ep);
-			routed = true;
-		} else {
-			res.status = StatusCode::InternalServerError_500;
-			std::string val;
-			auto s = e.what();
-			for (size_t i = 0; s[i]; i++) {
-				switch (s[i]) {
-				case '\r':
-					val += "\\r";
-					break;
-				case '\n':
-					val += "\\n";
-					break;
-				default:
-					val += s[i];
-					break;
-				}
-			}
-			res.set_header("EXCEPTION_WHAT", val);
-		}
-	} catch (...) {
-		if (exception_handler_) {
-			auto ep = std::current_exception();
-			exception_handler_(req, res, ep);
-			routed = true;
-		} else {
-			res.status = StatusCode::InternalServerError_500;
-			res.set_header("EXCEPTION_WHAT", "UNKNOWN");
-		}
-	}
+  try {
+    routed = routing(req, res, strm);
+  } catch (std::exception &e) {
+    if (exception_handler_) {
+      auto ep = std::current_exception();
+      exception_handler_(req, res, ep);
+      routed = true;
+    } else {
+      res.status = StatusCode::InternalServerError_500;
+      std::string val;
+      auto s = e.what();
+      for (size_t i = 0; s[i]; i++) {
+        switch (s[i]) {
+        case '\r': val += "\\r"; break;
+        case '\n': val += "\\n"; break;
+        default: val += s[i]; break;
+        }
+      }
+      res.set_header("EXCEPTION_WHAT", val);
+    }
+  } catch (...) {
+    if (exception_handler_) {
+      auto ep = std::current_exception();
+      exception_handler_(req, res, ep);
+      routed = true;
+    } else {
+      res.status = StatusCode::InternalServerError_500;
+      res.set_header("EXCEPTION_WHAT", "UNKNOWN");
+    }
+  }
 #endif
 
-	if (routed) {
-		if (res.status == -1) {
-			res.status = req.ranges.empty() ? StatusCode::OK_200 : StatusCode::PartialContent_206;
-		}
-		return write_response_with_content(strm, close_connection, req, res);
-	} else {
-		if (res.status == -1) {
-			res.status = StatusCode::NotFound_404;
-		}
-		return write_response(strm, close_connection, req, res);
-	}
+  if (routed) {
+    if (res.status == -1) {
+      res.status = req.ranges.empty() ? StatusCode::OK_200
+                                      : StatusCode::PartialContent_206;
+    }
+    return write_response_with_content(strm, close_connection, req, res);
+  } else {
+    if (res.status == -1) { res.status = StatusCode::NotFound_404; }
+    return write_response(strm, close_connection, req, res);
+  }
 }
 
-inline bool Server::is_valid() const {
-	return true;
-}
+inline bool Server::is_valid() const { return true; }
 
 inline bool Server::process_and_close_socket(socket_t sock) {
-	auto ret = detail::process_server_socket(
-	    svr_sock_, sock, keep_alive_max_count_, keep_alive_timeout_sec_, read_timeout_sec_, read_timeout_usec_,
-	    write_timeout_sec_, write_timeout_usec_, [this](Stream &strm, bool close_connection, bool &connection_closed) {
-		    return process_request(strm, close_connection, connection_closed, nullptr);
-	    });
+  auto ret = detail::process_server_socket(
+      svr_sock_, sock, keep_alive_max_count_, keep_alive_timeout_sec_,
+      read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
+      write_timeout_usec_,
+      [this](Stream &strm, bool close_connection, bool &connection_closed) {
+        return process_request(strm, close_connection, connection_closed,
+                               nullptr);
+      });
 
-	detail::shutdown_socket(sock);
-	detail::close_socket(sock);
-	return ret;
+  detail::shutdown_socket(sock);
+  detail::close_socket(sock);
+  return ret;
 }
 
 // HTTP client implementation
-inline ClientImpl::ClientImpl(const std::string &host) : ClientImpl(host, 80, std::string(), std::string()) {
-}
+inline ClientImpl::ClientImpl(const std::string &host)
+    : ClientImpl(host, 80, std::string(), std::string()) {}
 
 inline ClientImpl::ClientImpl(const std::string &host, int port)
-    : ClientImpl(host, port, std::string(), std::string()) {
-}
+    : ClientImpl(host, port, std::string(), std::string()) {}
 
-inline ClientImpl::ClientImpl(const std::string &host, int port, const std::string &client_cert_path,
+inline ClientImpl::ClientImpl(const std::string &host, int port,
+                              const std::string &client_cert_path,
                               const std::string &client_key_path)
-    : host_(host), port_(port), host_and_port_(adjust_host_string(host) + ":" + std::to_string(port)),
-      client_cert_path_(client_cert_path), client_key_path_(client_key_path) {
-}
+    : host_(host), port_(port),
+      host_and_port_(adjust_host_string(host) + ":" + std::to_string(port)),
+      client_cert_path_(client_cert_path), client_key_path_(client_key_path) {}
 
 inline ClientImpl::~ClientImpl() {
-	std::lock_guard<std::mutex> guard(socket_mutex_);
-	shutdown_socket(socket_);
-	close_socket(socket_);
+  std::lock_guard<std::mutex> guard(socket_mutex_);
+  shutdown_socket(socket_);
+  close_socket(socket_);
 }
 
-inline bool ClientImpl::is_valid() const {
-	return true;
-}
+inline bool ClientImpl::is_valid() const { return true; }
 
 inline void ClientImpl::copy_settings(const ClientImpl &rhs) {
-	client_cert_path_ = rhs.client_cert_path_;
-	client_key_path_ = rhs.client_key_path_;
-	connection_timeout_sec_ = rhs.connection_timeout_sec_;
-	read_timeout_sec_ = rhs.read_timeout_sec_;
-	read_timeout_usec_ = rhs.read_timeout_usec_;
-	write_timeout_sec_ = rhs.write_timeout_sec_;
-	write_timeout_usec_ = rhs.write_timeout_usec_;
-	basic_auth_username_ = rhs.basic_auth_username_;
-	basic_auth_password_ = rhs.basic_auth_password_;
-	bearer_token_auth_token_ = rhs.bearer_token_auth_token_;
+  client_cert_path_ = rhs.client_cert_path_;
+  client_key_path_ = rhs.client_key_path_;
+  connection_timeout_sec_ = rhs.connection_timeout_sec_;
+  read_timeout_sec_ = rhs.read_timeout_sec_;
+  read_timeout_usec_ = rhs.read_timeout_usec_;
+  write_timeout_sec_ = rhs.write_timeout_sec_;
+  write_timeout_usec_ = rhs.write_timeout_usec_;
+  basic_auth_username_ = rhs.basic_auth_username_;
+  basic_auth_password_ = rhs.basic_auth_password_;
+  bearer_token_auth_token_ = rhs.bearer_token_auth_token_;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	digest_auth_username_ = rhs.digest_auth_username_;
-	digest_auth_password_ = rhs.digest_auth_password_;
+  digest_auth_username_ = rhs.digest_auth_username_;
+  digest_auth_password_ = rhs.digest_auth_password_;
 #endif
-	keep_alive_ = rhs.keep_alive_;
-	follow_location_ = rhs.follow_location_;
-	url_encode_ = rhs.url_encode_;
-	address_family_ = rhs.address_family_;
-	tcp_nodelay_ = rhs.tcp_nodelay_;
-	socket_options_ = rhs.socket_options_;
-	compress_ = rhs.compress_;
-	decompress_ = rhs.decompress_;
-	interface_ = rhs.interface_;
-	proxy_host_ = rhs.proxy_host_;
-	proxy_port_ = rhs.proxy_port_;
-	proxy_basic_auth_username_ = rhs.proxy_basic_auth_username_;
-	proxy_basic_auth_password_ = rhs.proxy_basic_auth_password_;
-	proxy_bearer_token_auth_token_ = rhs.proxy_bearer_token_auth_token_;
+  keep_alive_ = rhs.keep_alive_;
+  follow_location_ = rhs.follow_location_;
+  url_encode_ = rhs.url_encode_;
+  address_family_ = rhs.address_family_;
+  tcp_nodelay_ = rhs.tcp_nodelay_;
+  socket_options_ = rhs.socket_options_;
+  compress_ = rhs.compress_;
+  decompress_ = rhs.decompress_;
+  interface_ = rhs.interface_;
+  proxy_host_ = rhs.proxy_host_;
+  proxy_port_ = rhs.proxy_port_;
+  proxy_basic_auth_username_ = rhs.proxy_basic_auth_username_;
+  proxy_basic_auth_password_ = rhs.proxy_basic_auth_password_;
+  proxy_bearer_token_auth_token_ = rhs.proxy_bearer_token_auth_token_;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	proxy_digest_auth_username_ = rhs.proxy_digest_auth_username_;
-	proxy_digest_auth_password_ = rhs.proxy_digest_auth_password_;
-#endif
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	ca_cert_file_path_ = rhs.ca_cert_file_path_;
-	ca_cert_dir_path_ = rhs.ca_cert_dir_path_;
-	ca_cert_store_ = rhs.ca_cert_store_;
+  proxy_digest_auth_username_ = rhs.proxy_digest_auth_username_;
+  proxy_digest_auth_password_ = rhs.proxy_digest_auth_password_;
 #endif
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	server_certificate_verification_ = rhs.server_certificate_verification_;
+  ca_cert_file_path_ = rhs.ca_cert_file_path_;
+  ca_cert_dir_path_ = rhs.ca_cert_dir_path_;
+  ca_cert_store_ = rhs.ca_cert_store_;
 #endif
-	logger_ = rhs.logger_;
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  server_certificate_verification_ = rhs.server_certificate_verification_;
+#endif
+  logger_ = rhs.logger_;
 }
 
 inline socket_t ClientImpl::create_client_socket(Error &error) const {
-	if (!proxy_host_.empty() && proxy_port_ != -1) {
-		return detail::create_client_socket(proxy_host_, std::string(), proxy_port_, address_family_, tcp_nodelay_,
-		                                    socket_options_, connection_timeout_sec_, connection_timeout_usec_,
-		                                    read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
-		                                    write_timeout_usec_, interface_, error);
-	}
+  if (!proxy_host_.empty() && proxy_port_ != -1) {
+    return detail::create_client_socket(
+        proxy_host_, std::string(), proxy_port_, address_family_, tcp_nodelay_,
+        socket_options_, connection_timeout_sec_, connection_timeout_usec_,
+        read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
+        write_timeout_usec_, interface_, error);
+  }
 
-	// Check is custom IP specified for host_
-	std::string ip;
-	auto it = addr_map_.find(host_);
-	if (it != addr_map_.end()) {
-		ip = it->second;
-	}
+  // Check is custom IP specified for host_
+  std::string ip;
+  auto it = addr_map_.find(host_);
+  if (it != addr_map_.end()) { ip = it->second; }
 
-	return detail::create_client_socket(host_, ip, port_, address_family_, tcp_nodelay_, socket_options_,
-	                                    connection_timeout_sec_, connection_timeout_usec_, read_timeout_sec_,
-	                                    read_timeout_usec_, write_timeout_sec_, write_timeout_usec_, interface_, error);
+  return detail::create_client_socket(
+      host_, ip, port_, address_family_, tcp_nodelay_, socket_options_,
+      connection_timeout_sec_, connection_timeout_usec_, read_timeout_sec_,
+      read_timeout_usec_, write_timeout_sec_, write_timeout_usec_, interface_,
+      error);
 }
 
-inline bool ClientImpl::create_and_connect_socket(Socket &socket, Error &error) {
-	auto sock = create_client_socket(error);
-	if (sock == INVALID_SOCKET) {
-		return false;
-	}
-	socket.sock = sock;
-	return true;
+inline bool ClientImpl::create_and_connect_socket(Socket &socket,
+                                                  Error &error) {
+  auto sock = create_client_socket(error);
+  if (sock == INVALID_SOCKET) { return false; }
+  socket.sock = sock;
+  return true;
 }
 
-inline void ClientImpl::shutdown_ssl(Socket & /*socket*/, bool /*shutdown_gracefully*/) {
-	// If there are any requests in flight from threads other than us, then it's
-	// a thread-unsafe race because individual ssl* objects are not thread-safe.
-	assert(socket_requests_in_flight_ == 0 || socket_requests_are_from_thread_ == std::this_thread::get_id());
+inline void ClientImpl::shutdown_ssl(Socket & /*socket*/,
+                                     bool /*shutdown_gracefully*/) {
+  // If there are any requests in flight from threads other than us, then it's
+  // a thread-unsafe race because individual ssl* objects are not thread-safe.
+  assert(socket_requests_in_flight_ == 0 ||
+         socket_requests_are_from_thread_ == std::this_thread::get_id());
 }
 
 inline void ClientImpl::shutdown_socket(Socket &socket) const {
-	if (socket.sock == INVALID_SOCKET) {
-		return;
-	}
-	detail::shutdown_socket(socket.sock);
+  if (socket.sock == INVALID_SOCKET) { return; }
+  detail::shutdown_socket(socket.sock);
 }
 
 inline void ClientImpl::close_socket(Socket &socket) {
-	// If there are requests in flight in another thread, usually closing
-	// the socket will be fine and they will simply receive an error when
-	// using the closed socket, but it is still a bug since rarely the OS
-	// may reassign the socket id to be used for a new socket, and then
-	// suddenly they will be operating on a live socket that is different
-	// than the one they intended!
-	assert(socket_requests_in_flight_ == 0 || socket_requests_are_from_thread_ == std::this_thread::get_id());
+  // If there are requests in flight in another thread, usually closing
+  // the socket will be fine and they will simply receive an error when
+  // using the closed socket, but it is still a bug since rarely the OS
+  // may reassign the socket id to be used for a new socket, and then
+  // suddenly they will be operating on a live socket that is different
+  // than the one they intended!
+  assert(socket_requests_in_flight_ == 0 ||
+         socket_requests_are_from_thread_ == std::this_thread::get_id());
 
-	// It is also a bug if this happens while SSL is still active
+  // It is also a bug if this happens while SSL is still active
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	assert(socket.ssl == nullptr);
+  assert(socket.ssl == nullptr);
 #endif
-	if (socket.sock == INVALID_SOCKET) {
-		return;
-	}
-	detail::close_socket(socket.sock);
-	socket.sock = INVALID_SOCKET;
+  if (socket.sock == INVALID_SOCKET) { return; }
+  detail::close_socket(socket.sock);
+  socket.sock = INVALID_SOCKET;
 }
 
-inline bool ClientImpl::read_response_line(Stream &strm, const Request &req, Response &res) const {
-	std::array<char, 2048> buf {};
+inline bool ClientImpl::read_response_line(Stream &strm, const Request &req,
+                                           Response &res) const {
+  std::array<char, 2048> buf{};
 
-	detail::stream_line_reader line_reader(strm, buf.data(), buf.size());
+  detail::stream_line_reader line_reader(strm, buf.data(), buf.size());
 
-	if (!line_reader.getline()) {
-		return false;
-	}
+  if (!line_reader.getline()) { return false; }
 
 #ifdef CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR
-	const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r?\n");
+  const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r?\n");
 #else
-	const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r\n");
+  const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r\n");
 #endif
 
-	Match m;
-	if (!RegexMatch(line_reader.ptr(), m, re)) {
-		return req.method == "CONNECT";
-	}
-	res.version = std::string(m[1]);
-	res.status = std::stoi(std::string(m[2]));
-	res.reason = std::string(m[3]);
+  Match m;
+  if (!RegexMatch(line_reader.ptr(), m, re)) {
+    return req.method == "CONNECT";
+  }
+  res.version = std::string(m[1]);
+  res.status = std::stoi(std::string(m[2]));
+  res.reason = std::string(m[3]);
 
-	// Ignore '100 Continue'
-	while (res.status == StatusCode::Continue_100) {
-		if (!line_reader.getline()) {
-			return false;
-		} // CRLF
-		if (!line_reader.getline()) {
-			return false;
-		} // next response line
+  // Ignore '100 Continue'
+  while (res.status == StatusCode::Continue_100) {
+    if (!line_reader.getline()) { return false; } // CRLF
+    if (!line_reader.getline()) { return false; } // next response line
 
-		if (!RegexMatch(line_reader.ptr(), m, re)) {
-			return false;
-		}
-		res.version = std::string(m[1]);
-		res.status = std::stoi(std::string(m[2]));
-		res.reason = std::string(m[3]);
-	}
+    if (!RegexMatch(line_reader.ptr(), m, re)) { return false; }
+    res.version = std::string(m[1]);
+    res.status = std::stoi(std::string(m[2]));
+    res.reason = std::string(m[3]);
+  }
 
-	return true;
+  return true;
 }
 
 inline bool ClientImpl::send(Request &req, Response &res, Error &error) {
-	std::lock_guard<std::recursive_mutex> request_mutex_guard(request_mutex_);
-	auto ret = send_(req, res, error);
-	if (error == Error::SSLPeerCouldBeClosed_) {
-		assert(!ret);
-		ret = send_(req, res, error);
-	}
-	return ret;
+  std::lock_guard<std::recursive_mutex> request_mutex_guard(request_mutex_);
+  auto ret = send_(req, res, error);
+  if (error == Error::SSLPeerCouldBeClosed_) {
+    assert(!ret);
+    ret = send_(req, res, error);
+  }
+  return ret;
 }
 
 inline bool ClientImpl::send_(Request &req, Response &res, Error &error) {
-	{
-		std::lock_guard<std::mutex> guard(socket_mutex_);
+  {
+    std::lock_guard<std::mutex> guard(socket_mutex_);
 
-		// Set this to false immediately - if it ever gets set to true by the end of
-		// the request, we know another thread instructed us to close the socket.
-		socket_should_be_closed_when_request_is_done_ = false;
+    // Set this to false immediately - if it ever gets set to true by the end of
+    // the request, we know another thread instructed us to close the socket.
+    socket_should_be_closed_when_request_is_done_ = false;
 
-		auto is_alive = false;
-		if (socket_.is_open()) {
-			is_alive = detail::is_socket_alive(socket_.sock);
-			if (!is_alive) {
-				// Attempt to avoid sigpipe by shutting down nongracefully if it seems
-				// like the other side has already closed the connection Also, there
-				// cannot be any requests in flight from other threads since we locked
-				// request_mutex_, so safe to close everything immediately
-				const bool shutdown_gracefully = false;
-				shutdown_ssl(socket_, shutdown_gracefully);
-				shutdown_socket(socket_);
-				close_socket(socket_);
-			}
-		}
+    auto is_alive = false;
+    if (socket_.is_open()) {
+      is_alive = detail::is_socket_alive(socket_.sock);
+      if (!is_alive) {
+        // Attempt to avoid sigpipe by shutting down nongracefully if it seems
+        // like the other side has already closed the connection Also, there
+        // cannot be any requests in flight from other threads since we locked
+        // request_mutex_, so safe to close everything immediately
+        const bool shutdown_gracefully = false;
+        shutdown_ssl(socket_, shutdown_gracefully);
+        shutdown_socket(socket_);
+        close_socket(socket_);
+      }
+    }
 
-		if (!is_alive) {
-			if (!create_and_connect_socket(socket_, error)) {
-				return false;
-			}
+    if (!is_alive) {
+      if (!create_and_connect_socket(socket_, error)) { return false; }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-			// TODO: refactoring
-			if (is_ssl()) {
-				auto &scli = static_cast<SSLClient &>(*this);
-				if (!proxy_host_.empty() && proxy_port_ != -1) {
-					auto success = false;
-					if (!scli.connect_with_proxy(socket_, res, success, error)) {
-						return success;
-					}
-				}
+      // TODO: refactoring
+      if (is_ssl()) {
+        auto &scli = static_cast<SSLClient &>(*this);
+        if (!proxy_host_.empty() && proxy_port_ != -1) {
+          auto success = false;
+          if (!scli.connect_with_proxy(socket_, res, success, error)) {
+            return success;
+          }
+        }
 
-				if (!scli.initialize_ssl(socket_, error)) {
-					return false;
-				}
-			}
+        if (!scli.initialize_ssl(socket_, error)) { return false; }
+      }
 #endif
-		}
+    }
 
-		// Mark the current socket as being in use so that it cannot be closed by
-		// anyone else while this request is ongoing, even though we will be
-		// releasing the mutex.
-		if (socket_requests_in_flight_ > 1) {
-			assert(socket_requests_are_from_thread_ == std::this_thread::get_id());
-		}
-		socket_requests_in_flight_ += 1;
-		socket_requests_are_from_thread_ = std::this_thread::get_id();
-	}
+    // Mark the current socket as being in use so that it cannot be closed by
+    // anyone else while this request is ongoing, even though we will be
+    // releasing the mutex.
+    if (socket_requests_in_flight_ > 1) {
+      assert(socket_requests_are_from_thread_ == std::this_thread::get_id());
+    }
+    socket_requests_in_flight_ += 1;
+    socket_requests_are_from_thread_ = std::this_thread::get_id();
+  }
 
-	for (const auto &header : default_headers_) {
-		if (req.headers.find(header.first) == req.headers.end()) {
-			req.headers.insert(header);
-		}
-	}
+  for (const auto &header : default_headers_) {
+    if (req.headers.find(header.first) == req.headers.end()) {
+      req.headers.insert(header);
+    }
+  }
 
-	auto ret = false;
-	auto close_connection = !keep_alive_;
+  auto ret = false;
+  auto close_connection = !keep_alive_;
 
-	auto se = detail::scope_exit([&]() {
-		// Briefly lock mutex in order to mark that a request is no longer ongoing
-		std::lock_guard<std::mutex> guard(socket_mutex_);
-		socket_requests_in_flight_ -= 1;
-		if (socket_requests_in_flight_ <= 0) {
-			assert(socket_requests_in_flight_ == 0);
-			socket_requests_are_from_thread_ = std::thread::id();
-		}
+  auto se = detail::scope_exit([&]() {
+    // Briefly lock mutex in order to mark that a request is no longer ongoing
+    std::lock_guard<std::mutex> guard(socket_mutex_);
+    socket_requests_in_flight_ -= 1;
+    if (socket_requests_in_flight_ <= 0) {
+      assert(socket_requests_in_flight_ == 0);
+      socket_requests_are_from_thread_ = std::thread::id();
+    }
 
-		if (socket_should_be_closed_when_request_is_done_ || close_connection || !ret) {
-			shutdown_ssl(socket_, true);
-			shutdown_socket(socket_);
-			close_socket(socket_);
-		}
-	});
+    if (socket_should_be_closed_when_request_is_done_ || close_connection ||
+        !ret) {
+      shutdown_ssl(socket_, true);
+      shutdown_socket(socket_);
+      close_socket(socket_);
+    }
+  });
 
-	ret =
-	    process_socket(socket_, [&](Stream &strm) { return handle_request(strm, req, res, close_connection, error); });
+  ret = process_socket(socket_, [&](Stream &strm) {
+    return handle_request(strm, req, res, close_connection, error);
+  });
 
-	if (!ret) {
-		if (error == Error::Success) {
-			error = Error::Unknown;
-		}
-	}
+  if (!ret) {
+    if (error == Error::Success) { error = Error::Unknown; }
+  }
 
-	return ret;
+  return ret;
 }
 
 inline Result ClientImpl::send(const Request &req) {
-	auto req2 = req;
-	return send_(std::move(req2));
+  auto req2 = req;
+  return send_(std::move(req2));
 }
 
 inline Result ClientImpl::send_(Request &&req) {
-	auto res = detail::make_unique<Response>();
-	auto error = Error::Success;
-	auto ret = send(req, *res, error);
-	return Result {ret ? std::move(res) : nullptr, error, std::move(req.headers)};
+  auto res = detail::make_unique<Response>();
+  auto error = Error::Success;
+  auto ret = send(req, *res, error);
+  return Result{ret ? std::move(res) : nullptr, error, std::move(req.headers)};
 }
 
-inline bool ClientImpl::handle_request(Stream &strm, Request &req, Response &res, bool close_connection, Error &error) {
-	if (req.path.empty()) {
-		error = Error::Connection;
-		return false;
-	}
+inline bool ClientImpl::handle_request(Stream &strm, Request &req,
+                                       Response &res, bool close_connection,
+                                       Error &error) {
+  if (req.path.empty()) {
+    error = Error::Connection;
+    return false;
+  }
 
-	auto req_save = req;
+  auto req_save = req;
 
-	bool ret;
+  bool ret;
 
-	if (!is_ssl() && !proxy_host_.empty() && proxy_port_ != -1) {
-		auto req2 = req;
-		req2.path = "http://" + host_and_port_ + req.path;
-		ret = process_request(strm, req2, res, close_connection, error);
-		req = req2;
-		req.path = req_save.path;
-	} else {
-		ret = process_request(strm, req, res, close_connection, error);
-	}
+  if (!is_ssl() && !proxy_host_.empty() && proxy_port_ != -1) {
+    auto req2 = req;
+    req2.path = "http://" + host_and_port_ + req.path;
+    ret = process_request(strm, req2, res, close_connection, error);
+    req = req2;
+    req.path = req_save.path;
+  } else {
+    ret = process_request(strm, req, res, close_connection, error);
+  }
 
-	if (!ret) {
-		return false;
-	}
+  if (!ret) { return false; }
 
-	if (res.get_header_value("Connection") == "close" ||
-	    (res.version == "HTTP/1.0" && res.reason != "Connection established")) {
-		// TODO this requires a not-entirely-obvious chain of calls to be correct
-		// for this to be safe.
+  if (res.get_header_value("Connection") == "close" ||
+      (res.version == "HTTP/1.0" && res.reason != "Connection established")) {
+    // TODO this requires a not-entirely-obvious chain of calls to be correct
+    // for this to be safe.
 
-		// This is safe to call because handle_request is only called by send_
-		// which locks the request mutex during the process. It would be a bug
-		// to call it from a different thread since it's a thread-safety issue
-		// to do these things to the socket if another thread is using the socket.
-		std::lock_guard<std::mutex> guard(socket_mutex_);
-		shutdown_ssl(socket_, true);
-		shutdown_socket(socket_);
-		close_socket(socket_);
-	}
+    // This is safe to call because handle_request is only called by send_
+    // which locks the request mutex during the process. It would be a bug
+    // to call it from a different thread since it's a thread-safety issue
+    // to do these things to the socket if another thread is using the socket.
+    std::lock_guard<std::mutex> guard(socket_mutex_);
+    shutdown_ssl(socket_, true);
+    shutdown_socket(socket_);
+    close_socket(socket_);
+  }
 
-	if (300 < res.status && res.status < 400 && follow_location_) {
-		req = req_save;
-		ret = redirect(req, res, error);
-	}
+  if (300 < res.status && res.status < 400 && follow_location_) {
+    req = req_save;
+    ret = redirect(req, res, error);
+  }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	if ((res.status == StatusCode::Unauthorized_401 || res.status == StatusCode::ProxyAuthenticationRequired_407) &&
-	    req.authorization_count_ < 5) {
-		auto is_proxy = res.status == StatusCode::ProxyAuthenticationRequired_407;
-		const auto &username = is_proxy ? proxy_digest_auth_username_ : digest_auth_username_;
-		const auto &password = is_proxy ? proxy_digest_auth_password_ : digest_auth_password_;
+  if ((res.status == StatusCode::Unauthorized_401 ||
+       res.status == StatusCode::ProxyAuthenticationRequired_407) &&
+      req.authorization_count_ < 5) {
+    auto is_proxy = res.status == StatusCode::ProxyAuthenticationRequired_407;
+    const auto &username =
+        is_proxy ? proxy_digest_auth_username_ : digest_auth_username_;
+    const auto &password =
+        is_proxy ? proxy_digest_auth_password_ : digest_auth_password_;
 
-		if (!username.empty() && !password.empty()) {
-			std::map<std::string, std::string> auth;
-			if (detail::parse_www_authenticate(res, auth, is_proxy)) {
-				Request new_req = req;
-				new_req.authorization_count_ += 1;
-				new_req.headers.erase(is_proxy ? "Proxy-Authorization" : "Authorization");
-				new_req.headers.insert(detail::make_digest_authentication_header(
-				    req, auth, new_req.authorization_count_, detail::random_string(10), username, password, is_proxy));
+    if (!username.empty() && !password.empty()) {
+      std::map<std::string, std::string> auth;
+      if (detail::parse_www_authenticate(res, auth, is_proxy)) {
+        Request new_req = req;
+        new_req.authorization_count_ += 1;
+        new_req.headers.erase(is_proxy ? "Proxy-Authorization"
+                                       : "Authorization");
+        new_req.headers.insert(detail::make_digest_authentication_header(
+            req, auth, new_req.authorization_count_, detail::random_string(10),
+            username, password, is_proxy));
 
-				Response new_res;
+        Response new_res;
 
-				ret = send(new_req, new_res, error);
-				if (ret) {
-					res = new_res;
-				}
-			}
-		}
-	}
+        ret = send(new_req, new_res, error);
+        if (ret) { res = new_res; }
+      }
+    }
+  }
 #endif
 
-	return ret;
+  return ret;
 }
 
 inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
-	if (req.redirect_count_ == 0) {
-		error = Error::ExceedRedirectCount;
-		return false;
-	}
+  if (req.redirect_count_ == 0) {
+    error = Error::ExceedRedirectCount;
+    return false;
+  }
 
-	auto location = res.get_header_value("location");
-	if (location.empty()) {
-		return false;
-	}
+  auto location = res.get_header_value("location");
+  if (location.empty()) { return false; }
 
-	const Regex re(R"((?:(https?):)?(?://(?:\[([\d:]+)\]|([^:/?#]+))(?::(\d+))?)?([^?#]*)(\?[^#]*)?(?:#.*)?)");
+  const Regex re(
+      R"((?:(https?):)?(?://(?:\[([\d:]+)\]|([^:/?#]+))(?::(\d+))?)?([^?#]*)(\?[^#]*)?(?:#.*)?)");
 
-	Match m;
-	if (!RegexMatch(location, m, re)) {
-		return false;
-	}
+  Match m;
+  if (!RegexMatch(location, m, re)) { return false; }
 
-	auto scheme = is_ssl() ? "https" : "http";
+  auto scheme = is_ssl() ? "https" : "http";
 
-	auto next_scheme = m[1].str();
-	auto next_host = m[2].str();
-	if (next_host.empty()) {
-		next_host = m[3].str();
-	}
-	auto port_str = m[4].str();
-	auto next_path = m[5].str();
-	auto next_query = m[6].str();
+  auto next_scheme = m[1].str();
+  auto next_host = m[2].str();
+  if (next_host.empty()) { next_host = m[3].str(); }
+  auto port_str = m[4].str();
+  auto next_path = m[5].str();
+  auto next_query = m[6].str();
 
-	auto next_port = port_;
-	if (!port_str.empty()) {
-		next_port = std::stoi(port_str);
-	} else if (!next_scheme.empty()) {
-		next_port = next_scheme == "https" ? 443 : 80;
-	}
+  auto next_port = port_;
+  if (!port_str.empty()) {
+    next_port = std::stoi(port_str);
+  } else if (!next_scheme.empty()) {
+    next_port = next_scheme == "https" ? 443 : 80;
+  }
 
-	if (next_scheme.empty()) {
-		next_scheme = scheme;
-	}
-	if (next_host.empty()) {
-		next_host = host_;
-	}
-	if (next_path.empty()) {
-		next_path = "/";
-	}
-
-	auto path = detail::decode_url(next_path, true, std::set<char> {'/'}) + next_query;
-
-	if (next_scheme == scheme && next_host == host_ && next_port == port_) {
-		return detail::redirect(*this, req, res, path, location, error);
-	} else {
-		if (next_scheme == "https") {
+  if (next_scheme.empty()) { next_scheme = scheme; }
+  if (next_host.empty()) { next_host = host_; }
+  if (next_path.empty()) { next_path = "/"; }
+  
+  auto path = detail::decode_url(next_path, true, std::set<char> {'/'}) + next_query;
+	
+  if (next_scheme == scheme && next_host == host_ && next_port == port_) {
+    return detail::redirect(*this, req, res, path, location, error);
+  } else {
+    if (next_scheme == "https") {
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-			SSLClient cli(next_host, next_port);
-			cli.copy_settings(*this);
-			if (ca_cert_store_) {
-				cli.set_ca_cert_store(ca_cert_store_);
-			}
-			return detail::redirect(cli, req, res, path, location, error);
+      SSLClient cli(next_host, next_port);
+      cli.copy_settings(*this);
+      if (ca_cert_store_) { cli.set_ca_cert_store(ca_cert_store_); }
+      return detail::redirect(cli, req, res, path, location, error);
 #else
-			return false;
+      return false;
 #endif
-		} else {
-			ClientImpl cli(next_host, next_port);
-			cli.copy_settings(*this);
-			return detail::redirect(cli, req, res, path, location, error);
-		}
-	}
+    } else {
+      ClientImpl cli(next_host, next_port);
+      cli.copy_settings(*this);
+      return detail::redirect(cli, req, res, path, location, error);
+    }
+  }
 }
 
-inline bool ClientImpl::write_content_with_provider(Stream &strm, const Request &req, Error &error) const {
-	auto is_shutting_down = []() {
-		return false;
-	};
+inline bool ClientImpl::write_content_with_provider(Stream &strm,
+                                                    const Request &req,
+                                                    Error &error) const {
+  auto is_shutting_down = []() { return false; };
 
-	if (req.is_chunked_content_provider_) {
-		// TODO: Brotli support
-		duckdb::unique_ptr<detail::compressor> compressor;
+  if (req.is_chunked_content_provider_) {
+    // TODO: Brotli support
+    duckdb::unique_ptr<detail::compressor> compressor;
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-		if (compress_) {
-			compressor = detail::make_unique<detail::gzip_compressor>();
-		} else
+    if (compress_) {
+      compressor = detail::make_unique<detail::gzip_compressor>();
+    } else
 #endif
-		{
-			compressor = detail::make_unique<detail::nocompressor>();
-		}
+    {
+      compressor = detail::make_unique<detail::nocompressor>();
+    }
 
-		return detail::write_content_chunked(strm, req.content_provider_, is_shutting_down, *compressor, error);
-	} else {
-		return detail::write_content(strm, req.content_provider_, 0, req.content_length_, is_shutting_down, error);
-	}
+    return detail::write_content_chunked(strm, req.content_provider_,
+                                         is_shutting_down, *compressor, error);
+  } else {
+    return detail::write_content(strm, req.content_provider_, 0,
+                                 req.content_length_, is_shutting_down, error);
+  }
 }
 
-inline bool ClientImpl::write_request(Stream &strm, Request &req, bool close_connection, Error &error) {
-	// Prepare additional headers
-	if (close_connection) {
-		if (!req.has_header("Connection")) {
-			req.set_header("Connection", "close");
-		}
-	}
+inline bool ClientImpl::write_request(Stream &strm, Request &req,
+                                      bool close_connection, Error &error) {
+  // Prepare additional headers
+  if (close_connection) {
+    if (!req.has_header("Connection")) {
+      req.set_header("Connection", "close");
+    }
+  }
 
-	if (!req.has_header("Host")) {
-		if (is_ssl()) {
-			if (port_ == 443) {
-				req.set_header("Host", host_);
-			} else {
-				req.set_header("Host", host_and_port_);
-			}
-		} else {
-			if (port_ == 80) {
-				req.set_header("Host", host_);
-			} else {
-				req.set_header("Host", host_and_port_);
-			}
-		}
-	}
+  if (!req.has_header("Host")) {
+    if (is_ssl()) {
+      if (port_ == 443) {
+        req.set_header("Host", host_);
+      } else {
+        req.set_header("Host", host_and_port_);
+      }
+    } else {
+      if (port_ == 80) {
+        req.set_header("Host", host_);
+      } else {
+        req.set_header("Host", host_and_port_);
+      }
+    }
+  }
 
-	if (!req.has_header("Accept")) {
-		req.set_header("Accept", "*/*");
-	}
+  if (!req.has_header("Accept")) { req.set_header("Accept", "*/*"); }
 
 #ifndef CPPHTTPLIB_NO_DEFAULT_USER_AGENT
-	if (!req.has_header("User-Agent")) {
-		auto agent = std::string("cpp-httplib/") + CPPHTTPLIB_VERSION;
-		req.set_header("User-Agent", agent);
-	}
+  if (!req.has_header("User-Agent")) {
+    auto agent = std::string("cpp-httplib/") + CPPHTTPLIB_VERSION;
+    req.set_header("User-Agent", agent);
+  }
 #endif
 
-	if (req.body.empty()) {
-		if (req.content_provider_) {
-			if (!req.is_chunked_content_provider_) {
-				if (!req.has_header("Content-Length")) {
-					auto length = std::to_string(req.content_length_);
-					req.set_header("Content-Length", length);
-				}
-			}
-		} else {
-			if (req.method == "POST" || req.method == "PUT" || req.method == "PATCH") {
-				req.set_header("Content-Length", "0");
-			}
-		}
-	} else {
-		if (!req.has_header("Content-Type")) {
-			req.set_header("Content-Type", "text/plain");
-		}
+  if (req.body.empty()) {
+    if (req.content_provider_) {
+      if (!req.is_chunked_content_provider_) {
+        if (!req.has_header("Content-Length")) {
+          auto length = std::to_string(req.content_length_);
+          req.set_header("Content-Length", length);
+        }
+      }
+    } else {
+      if (req.method == "POST" || req.method == "PUT" ||
+          req.method == "PATCH") {
+        req.set_header("Content-Length", "0");
+      }
+    }
+  } else {
+    if (!req.has_header("Content-Type")) {
+      req.set_header("Content-Type", "text/plain");
+    }
 
-		if (!req.has_header("Content-Length")) {
-			auto length = std::to_string(req.body.size());
-			req.set_header("Content-Length", length);
-		}
-	}
+    if (!req.has_header("Content-Length")) {
+      auto length = std::to_string(req.body.size());
+      req.set_header("Content-Length", length);
+    }
+  }
 
-	if (!basic_auth_password_.empty() || !basic_auth_username_.empty()) {
-		if (!req.has_header("Authorization")) {
-			req.headers.insert(make_basic_authentication_header(basic_auth_username_, basic_auth_password_, false));
-		}
-	}
+  if (!basic_auth_password_.empty() || !basic_auth_username_.empty()) {
+    if (!req.has_header("Authorization")) {
+      req.headers.insert(make_basic_authentication_header(
+          basic_auth_username_, basic_auth_password_, false));
+    }
+  }
 
-	if (!proxy_basic_auth_username_.empty() && !proxy_basic_auth_password_.empty()) {
-		if (!req.has_header("Proxy-Authorization")) {
-			req.headers.insert(
-			    make_basic_authentication_header(proxy_basic_auth_username_, proxy_basic_auth_password_, true));
-		}
-	}
+  if (!proxy_basic_auth_username_.empty() &&
+      !proxy_basic_auth_password_.empty()) {
+    if (!req.has_header("Proxy-Authorization")) {
+      req.headers.insert(make_basic_authentication_header(
+          proxy_basic_auth_username_, proxy_basic_auth_password_, true));
+    }
+  }
 
-	if (!bearer_token_auth_token_.empty()) {
-		if (!req.has_header("Authorization")) {
-			req.headers.insert(make_bearer_token_authentication_header(bearer_token_auth_token_, false));
-		}
-	}
+  if (!bearer_token_auth_token_.empty()) {
+    if (!req.has_header("Authorization")) {
+      req.headers.insert(make_bearer_token_authentication_header(
+          bearer_token_auth_token_, false));
+    }
+  }
 
-	if (!proxy_bearer_token_auth_token_.empty()) {
-		if (!req.has_header("Proxy-Authorization")) {
-			req.headers.insert(make_bearer_token_authentication_header(proxy_bearer_token_auth_token_, true));
-		}
-	}
+  if (!proxy_bearer_token_auth_token_.empty()) {
+    if (!req.has_header("Proxy-Authorization")) {
+      req.headers.insert(make_bearer_token_authentication_header(
+          proxy_bearer_token_auth_token_, true));
+    }
+  }
 
-	// Request line and headers
-	{
-		detail::BufferStream bstrm;
+  // Request line and headers
+  {
+    detail::BufferStream bstrm;
 
-		const auto &path = url_encode_ ? detail::encode_url(req.path) : req.path;
-		bstrm.write_format("%s %s HTTP/1.1\r\n", req.method.c_str(), path.c_str());
+    const auto &path = url_encode_ ? detail::encode_url(req.path) : req.path;
+    bstrm.write_format("%s %s HTTP/1.1\r\n", req.method.c_str(), path.c_str());
 
-		header_writer_(bstrm, req.headers);
+    header_writer_(bstrm, req.headers);
 
-		// Flush buffer
-		auto &data = bstrm.get_buffer();
-		if (!detail::write_data(strm, data.data(), data.size())) {
-			error = Error::Write;
-			return false;
-		}
-	}
+    // Flush buffer
+    auto &data = bstrm.get_buffer();
+    if (!detail::write_data(strm, data.data(), data.size())) {
+      error = Error::Write;
+      return false;
+    }
+  }
 
-	// Body
-	if (req.body.empty()) {
-		return write_content_with_provider(strm, req, error);
-	}
+  // Body
+  if (req.body.empty()) {
+    return write_content_with_provider(strm, req, error);
+  }
 
-	if (!detail::write_data(strm, req.body.data(), req.body.size())) {
-		error = Error::Write;
-		return false;
-	}
+  if (!detail::write_data(strm, req.body.data(), req.body.size())) {
+    error = Error::Write;
+    return false;
+  }
 
-	return true;
+  return true;
 }
 
 inline duckdb::unique_ptr<Response> ClientImpl::send_with_content_provider(
-    Request &req, const char *body, size_t content_length, ContentProvider content_provider,
-    ContentProviderWithoutLength content_provider_without_length, const std::string &content_type, Error &error) {
-	if (!content_type.empty()) {
-		req.set_header("Content-Type", content_type);
-	}
+    Request &req, const char *body, size_t content_length,
+    ContentProvider content_provider,
+    ContentProviderWithoutLength content_provider_without_length,
+    const std::string &content_type, Error &error) {
+  if (!content_type.empty()) { req.set_header("Content-Type", content_type); }
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-	if (compress_) {
-		req.set_header("Content-Encoding", "gzip");
-	}
+  if (compress_) { req.set_header("Content-Encoding", "gzip"); }
 #endif
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-	if (compress_ && !content_provider_without_length) {
-		// TODO: Brotli support
-		detail::gzip_compressor compressor;
+  if (compress_ && !content_provider_without_length) {
+    // TODO: Brotli support
+    detail::gzip_compressor compressor;
 
-		if (content_provider) {
-			auto ok = true;
-			size_t offset = 0;
-			DataSink data_sink;
+    if (content_provider) {
+      auto ok = true;
+      size_t offset = 0;
+      DataSink data_sink;
 
-			data_sink.write = [&](const char *data, size_t data_len) -> bool {
-				if (ok) {
-					auto last = offset + data_len == content_length;
+      data_sink.write = [&](const char *data, size_t data_len) -> bool {
+        if (ok) {
+          auto last = offset + data_len == content_length;
 
-					auto ret = compressor.compress(data, data_len, last,
-					                               [&](const char *compressed_data, size_t compressed_data_len) {
-						                               req.body.append(compressed_data, compressed_data_len);
-						                               return true;
-					                               });
+          auto ret = compressor.compress(
+              data, data_len, last,
+              [&](const char *compressed_data, size_t compressed_data_len) {
+                req.body.append(compressed_data, compressed_data_len);
+                return true;
+              });
 
-					if (ret) {
-						offset += data_len;
-					} else {
-						ok = false;
-					}
-				}
-				return ok;
-			};
+          if (ret) {
+            offset += data_len;
+          } else {
+            ok = false;
+          }
+        }
+        return ok;
+      };
 
-			while (ok && offset < content_length) {
-				if (!content_provider(offset, content_length - offset, data_sink)) {
-					error = Error::Canceled;
-					return nullptr;
-				}
-			}
-		} else {
-			if (!compressor.compress(body, content_length, true, [&](const char *data, size_t data_len) {
-				    req.body.append(data, data_len);
-				    return true;
-			    })) {
-				error = Error::Compression;
-				return nullptr;
-			}
-		}
-	} else
+      while (ok && offset < content_length) {
+        if (!content_provider(offset, content_length - offset, data_sink)) {
+          error = Error::Canceled;
+          return nullptr;
+        }
+      }
+    } else {
+      if (!compressor.compress(body, content_length, true,
+                               [&](const char *data, size_t data_len) {
+                                 req.body.append(data, data_len);
+                                 return true;
+                               })) {
+        error = Error::Compression;
+        return nullptr;
+      }
+    }
+  } else
 #endif
-	{
-		if (content_provider) {
-			req.content_length_ = content_length;
-			req.content_provider_ = std::move(content_provider);
-			req.is_chunked_content_provider_ = false;
-		} else if (content_provider_without_length) {
-			req.content_length_ = 0;
-			req.content_provider_ = detail::ContentProviderAdapter(std::move(content_provider_without_length));
-			req.is_chunked_content_provider_ = true;
-			req.set_header("Transfer-Encoding", "chunked");
-		} else {
-			req.body.assign(body, content_length);
-		}
-	}
+  {
+    if (content_provider) {
+      req.content_length_ = content_length;
+      req.content_provider_ = std::move(content_provider);
+      req.is_chunked_content_provider_ = false;
+    } else if (content_provider_without_length) {
+      req.content_length_ = 0;
+      req.content_provider_ = detail::ContentProviderAdapter(
+          std::move(content_provider_without_length));
+      req.is_chunked_content_provider_ = true;
+      req.set_header("Transfer-Encoding", "chunked");
+    } else {
+      req.body.assign(body, content_length);
+    }
+  }
 
-	auto res = detail::make_unique<Response>();
-	return send(req, *res, error) ? std::move(res) : nullptr;
+  auto res = detail::make_unique<Response>();
+  return send(req, *res, error) ? std::move(res) : nullptr;
 }
 
-inline Result ClientImpl::send_with_content_provider(const std::string &method, const std::string &path,
-                                                     const Headers &headers, const char *body, size_t content_length,
-                                                     ContentProvider content_provider,
-                                                     ContentProviderWithoutLength content_provider_without_length,
-                                                     const std::string &content_type) {
-	Request req;
-	req.method = method;
-	req.headers = headers;
-	req.path = path;
+inline Result ClientImpl::send_with_content_provider(
+    const std::string &method, const std::string &path, const Headers &headers,
+    const char *body, size_t content_length, ContentProvider content_provider,
+    ContentProviderWithoutLength content_provider_without_length,
+    const std::string &content_type) {
+  Request req;
+  req.method = method;
+  req.headers = headers;
+  req.path = path;
 
-	auto error = Error::Success;
+  auto error = Error::Success;
 
-	auto res = send_with_content_provider(req, body, content_length, std::move(content_provider),
-	                                      std::move(content_provider_without_length), content_type, error);
+  auto res = send_with_content_provider(
+      req, body, content_length, std::move(content_provider),
+      std::move(content_provider_without_length), content_type, error);
 
-	return Result {std::move(res), error, std::move(req.headers)};
+  return Result{std::move(res), error, std::move(req.headers)};
 }
 
-inline std::string ClientImpl::adjust_host_string(const std::string &host) const {
-	if (host.find(':') != std::string::npos) {
-		return "[" + host + "]";
-	}
-	return host;
+inline std::string
+ClientImpl::adjust_host_string(const std::string &host) const {
+  if (host.find(':') != std::string::npos) { return "[" + host + "]"; }
+  return host;
 }
 
-inline bool ClientImpl::process_request(Stream &strm, Request &req, Response &res, bool close_connection,
+inline bool ClientImpl::process_request(Stream &strm, Request &req,
+                                        Response &res, bool close_connection,
                                         Error &error) {
-	// Send request
-	if (!write_request(strm, req, close_connection, error)) {
-		return false;
-	}
+  // Send request
+  if (!write_request(strm, req, close_connection, error)) { return false; }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-	if (is_ssl()) {
-		auto is_proxy_enabled = !proxy_host_.empty() && proxy_port_ != -1;
-		if (!is_proxy_enabled) {
-			char buf[1];
-			if (SSL_peek(socket_.ssl, buf, 1) == 0 && SSL_get_error(socket_.ssl, 0) == SSL_ERROR_ZERO_RETURN) {
-				error = Error::SSLPeerCouldBeClosed_;
-				return false;
-			}
-		}
-	}
+  if (is_ssl()) {
+    auto is_proxy_enabled = !proxy_host_.empty() && proxy_port_ != -1;
+    if (!is_proxy_enabled) {
+      char buf[1];
+      if (SSL_peek(socket_.ssl, buf, 1) == 0 &&
+          SSL_get_error(socket_.ssl, 0) == SSL_ERROR_ZERO_RETURN) {
+        error = Error::SSLPeerCouldBeClosed_;
+        return false;
+      }
+    }
+  }
 #endif
 
-	// Receive response and headers
-	if (!read_response_line(strm, req, res) || !detail::read_headers(strm, res.headers)) {
-		error = Error::Read;
-		return false;
-	}
+  // Receive response and headers
+  if (!read_response_line(strm, req, res) ||
+      !detail::read_headers(strm, res.headers)) {
+    error = Error::Read;
+    return false;
+  }
 
-	// Body
-	if ((res.status != StatusCode::NoContent_204) && req.method != "CONNECT") {
-		auto redirect = 300 < res.status && res.status < 400 && follow_location_;
+  // Body
+  if ((res.status != StatusCode::NoContent_204) && req.method != "HEAD" &&
+      req.method != "CONNECT") {
+    auto redirect = 300 < res.status && res.status < 400 && follow_location_;
 
-		if (req.response_handler && !redirect) {
-			if (!req.response_handler(res)) {
-				error = Error::Canceled;
-				return false;
-			}
-		}
+    if (req.response_handler && !redirect) {
+      if (!req.response_handler(res)) {
+        error = Error::Canceled;
+        return false;
+      }
+    }
 
-		auto out =
-		    req.content_receiver
-		        ? static_cast<ContentReceiverWithProgress>([&](const char *buf, size_t n, uint64_t off, uint64_t len) {
-			          if (redirect) {
-				          return true;
-			          }
-			          auto ret = req.content_receiver(buf, n, off, len);
-			          if (!ret) {
-				          error = Error::Canceled;
-			          }
-			          return ret;
-		          })
-		        : static_cast<ContentReceiverWithProgress>(
-		              [&](const char *buf, size_t n, uint64_t /*off*/, uint64_t /*len*/) {
-			              if (res.body.size() + n > res.body.max_size()) {
-				              return false;
-			              }
-			              res.body.append(buf, n);
-			              return true;
-		              });
+    auto out =
+        req.content_receiver
+            ? static_cast<ContentReceiverWithProgress>(
+                  [&](const char *buf, size_t n, uint64_t off, uint64_t len) {
+                    if (redirect) { return true; }
+                    auto ret = req.content_receiver(buf, n, off, len);
+                    if (!ret) { error = Error::Canceled; }
+                    return ret;
+                  })
+            : static_cast<ContentReceiverWithProgress>(
+                  [&](const char *buf, size_t n, uint64_t /*off*/,
+                      uint64_t /*len*/) {
+                    if (res.body.size() + n > res.body.max_size()) {
+                      return false;
+                    }
+                    res.body.append(buf, n);
+                    return true;
+                  });
 
-		auto progress = [&](uint64_t current, uint64_t total) {
-			if (!req.progress || redirect) {
-				return true;
-			}
-			auto ret = req.progress(current, total);
-			if (!ret) {
-				error = Error::Canceled;
-			}
-			return ret;
-		};
+    auto progress = [&](uint64_t current, uint64_t total) {
+      if (!req.progress || redirect) { return true; }
+      auto ret = req.progress(current, total);
+      if (!ret) { error = Error::Canceled; }
+      return ret;
+    };
 
-		int dummy_status;
-		if (!detail::read_content(strm, res, (std::numeric_limits<size_t>::max)(), dummy_status, std::move(progress),
-		                          std::move(out), decompress_)) {
-			if (error != Error::Canceled) {
-				error = Error::Read;
-			}
-			return false;
-		}
-	}
+    int dummy_status;
+    if (!detail::read_content(strm, res, (std::numeric_limits<size_t>::max)(),
+                              dummy_status, std::move(progress), std::move(out),
+                              decompress_)) {
+      if (error != Error::Canceled) { error = Error::Read; }
+      return false;
+    }
+  }
 
-	// Log
-	if (logger_) {
-		logger_(req, res);
-	}
+  // Log
+  if (logger_) { logger_(req, res); }
 
-	return true;
+  return true;
 }
 
-inline ContentProviderWithoutLength
-ClientImpl::get_multipart_content_provider(const std::string &boundary, const MultipartFormDataItems &items,
-                                           const MultipartFormDataProviderItems &provider_items) const {
-	size_t cur_item = 0;
-	size_t cur_start = 0;
-	// cur_item and cur_start are copied to within the std::function and maintain
-	// state between successive calls
-	return [&, cur_item, cur_start](size_t offset, DataSink &sink) mutable -> bool {
-		if (!offset && !items.empty()) {
-			sink.os << detail::serialize_multipart_formdata(items, boundary, false);
-			return true;
-		} else if (cur_item < provider_items.size()) {
-			if (!cur_start) {
-				const auto &begin = detail::serialize_multipart_formdata_item_begin(provider_items[cur_item], boundary);
-				offset += begin.size();
-				cur_start = offset;
-				sink.os << begin;
-			}
+inline ContentProviderWithoutLength ClientImpl::get_multipart_content_provider(
+    const std::string &boundary, const MultipartFormDataItems &items,
+    const MultipartFormDataProviderItems &provider_items) const {
+  size_t cur_item = 0;
+  size_t cur_start = 0;
+  // cur_item and cur_start are copied to within the std::function and maintain
+  // state between successive calls
+  return [&, cur_item, cur_start](size_t offset,
+                                  DataSink &sink) mutable -> bool {
+    if (!offset && !items.empty()) {
+      sink.os << detail::serialize_multipart_formdata(items, boundary, false);
+      return true;
+    } else if (cur_item < provider_items.size()) {
+      if (!cur_start) {
+        const auto &begin = detail::serialize_multipart_formdata_item_begin(
+            provider_items[cur_item], boundary);
+        offset += begin.size();
+        cur_start = offset;
+        sink.os << begin;
+      }
 
-			DataSink cur_sink;
-			auto has_data = true;
-			cur_sink.write = sink.write;
-			cur_sink.done = [&]() {
-				has_data = false;
-			};
+      DataSink cur_sink;
+      auto has_data = true;
+      cur_sink.write = sink.write;
+      cur_sink.done = [&]() { has_data = false; };
 
-			if (!provider_items[cur_item].provider(offset - cur_start, cur_sink)) {
-				return false;
-			}
+      if (!provider_items[cur_item].provider(offset - cur_start, cur_sink)) {
+        return false;
+      }
 
-			if (!has_data) {
-				sink.os << detail::serialize_multipart_formdata_item_end();
-				cur_item++;
-				cur_start = 0;
-			}
-			return true;
-		} else {
-			sink.os << detail::serialize_multipart_formdata_finish(boundary);
-			sink.done();
-			return true;
-		}
-	};
+      if (!has_data) {
+        sink.os << detail::serialize_multipart_formdata_item_end();
+        cur_item++;
+        cur_start = 0;
+      }
+      return true;
+    } else {
+      sink.os << detail::serialize_multipart_formdata_finish(boundary);
+      sink.done();
+      return true;
+    }
+  };
 }
 
-inline bool ClientImpl::process_socket(const Socket &socket, std::function<bool(Stream &strm)> callback) {
-	return detail::process_client_socket(socket.sock, read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
-	                                     write_timeout_usec_, std::move(callback));
+inline bool
+ClientImpl::process_socket(const Socket &socket,
+                           std::function<bool(Stream &strm)> callback) {
+  return detail::process_client_socket(
+      socket.sock, read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
+      write_timeout_usec_, std::move(callback));
 }
 
-inline bool ClientImpl::is_ssl() const {
-	return false;
-}
+inline bool ClientImpl::is_ssl() const { return false; }
 
 inline Result ClientImpl::Get(const std::string &path) {
-	return Get(path, Headers(), Progress());
+  return Get(path, Headers(), Progress());
 }
 
 inline Result ClientImpl::Get(const std::string &path, Progress progress) {
-	return Get(path, Headers(), std::move(progress));
+  return Get(path, Headers(), std::move(progress));
 }
 
 inline Result ClientImpl::Get(const std::string &path, const Headers &headers) {
-	return Get(path, headers, Progress());
+  return Get(path, headers, Progress());
 }
 
-inline Result ClientImpl::Get(const std::string &path, const Headers &headers, Progress progress) {
-	Request req;
-	req.method = "GET";
-	req.path = path;
-	req.headers = headers;
-	req.progress = std::move(progress);
-
-	return send_(std::move(req));
-}
-
-inline Result ClientImpl::Get(const std::string &path, ContentReceiver content_receiver) {
-	return Get(path, Headers(), nullptr, std::move(content_receiver), nullptr);
-}
-
-inline Result ClientImpl::Get(const std::string &path, ContentReceiver content_receiver, Progress progress) {
-	return Get(path, Headers(), nullptr, std::move(content_receiver), std::move(progress));
-}
-
-inline Result ClientImpl::Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver) {
-	return Get(path, headers, nullptr, std::move(content_receiver), nullptr);
-}
-
-inline Result ClientImpl::Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver,
+inline Result ClientImpl::Get(const std::string &path, const Headers &headers,
                               Progress progress) {
-	return Get(path, headers, nullptr, std::move(content_receiver), std::move(progress));
+  Request req;
+  req.method = "GET";
+  req.path = path;
+  req.headers = headers;
+  req.progress = std::move(progress);
+
+  return send_(std::move(req));
 }
 
-inline Result ClientImpl::Get(const std::string &path, ResponseHandler response_handler,
+inline Result ClientImpl::Get(const std::string &path,
                               ContentReceiver content_receiver) {
-	return Get(path, Headers(), std::move(response_handler), std::move(content_receiver), nullptr);
+  return Get(path, Headers(), nullptr, std::move(content_receiver), nullptr);
 }
 
-inline Result ClientImpl::Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
-                              ContentReceiver content_receiver) {
-	return Get(path, headers, std::move(response_handler), std::move(content_receiver), nullptr);
-}
-
-inline Result ClientImpl::Get(const std::string &path, ResponseHandler response_handler,
-                              ContentReceiver content_receiver, Progress progress) {
-	return Get(path, Headers(), std::move(response_handler), std::move(content_receiver), std::move(progress));
-}
-
-inline Result ClientImpl::Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
-                              ContentReceiver content_receiver, Progress progress) {
-	Request req;
-	req.method = "GET";
-	req.path = path;
-	req.headers = headers;
-	req.response_handler = std::move(response_handler);
-	req.content_receiver = [content_receiver](const char *data, size_t data_length, uint64_t /*offset*/,
-	                                          uint64_t /*total_length*/) {
-		return content_receiver(data, data_length);
-	};
-	req.progress = std::move(progress);
-
-	return send_(std::move(req));
-}
-
-inline Result ClientImpl::Get(const std::string &path, const Params &params, const Headers &headers,
+inline Result ClientImpl::Get(const std::string &path,
+                              ContentReceiver content_receiver,
                               Progress progress) {
-	if (params.empty()) {
-		return Get(path, headers);
-	}
-
-	std::string path_with_query = append_query_params(path, params);
-	return Get(path_with_query, headers, progress);
+  return Get(path, Headers(), nullptr, std::move(content_receiver),
+             std::move(progress));
 }
 
-inline Result ClientImpl::Get(const std::string &path, const Params &params, const Headers &headers,
-                              ContentReceiver content_receiver, Progress progress) {
-	return Get(path, params, headers, nullptr, content_receiver, progress);
+inline Result ClientImpl::Get(const std::string &path, const Headers &headers,
+                              ContentReceiver content_receiver) {
+  return Get(path, headers, nullptr, std::move(content_receiver), nullptr);
 }
 
-inline Result ClientImpl::Get(const std::string &path, const Params &params, const Headers &headers,
-                              ResponseHandler response_handler, ContentReceiver content_receiver, Progress progress) {
-	if (params.empty()) {
-		return Get(path, headers, response_handler, content_receiver, progress);
-	}
+inline Result ClientImpl::Get(const std::string &path, const Headers &headers,
+                              ContentReceiver content_receiver,
+                              Progress progress) {
+  return Get(path, headers, nullptr, std::move(content_receiver),
+             std::move(progress));
+}
 
-	std::string path_with_query = append_query_params(path, params);
-	return Get(path_with_query, headers, response_handler, content_receiver, progress);
+inline Result ClientImpl::Get(const std::string &path,
+                              ResponseHandler response_handler,
+                              ContentReceiver content_receiver) {
+  return Get(path, Headers(), std::move(response_handler),
+             std::move(content_receiver), nullptr);
+}
+
+inline Result ClientImpl::Get(const std::string &path, const Headers &headers,
+                              ResponseHandler response_handler,
+                              ContentReceiver content_receiver) {
+  return Get(path, headers, std::move(response_handler),
+             std::move(content_receiver), nullptr);
+}
+
+inline Result ClientImpl::Get(const std::string &path,
+                              ResponseHandler response_handler,
+                              ContentReceiver content_receiver,
+                              Progress progress) {
+  return Get(path, Headers(), std::move(response_handler),
+             std::move(content_receiver), std::move(progress));
+}
+
+inline Result ClientImpl::Get(const std::string &path, const Headers &headers,
+                              ResponseHandler response_handler,
+                              ContentReceiver content_receiver,
+                              Progress progress) {
+  Request req;
+  req.method = "GET";
+  req.path = path;
+  req.headers = headers;
+  req.response_handler = std::move(response_handler);
+  req.content_receiver =
+      [content_receiver](const char *data, size_t data_length,
+                         uint64_t /*offset*/, uint64_t /*total_length*/) {
+        return content_receiver(data, data_length);
+      };
+  req.progress = std::move(progress);
+
+  return send_(std::move(req));
+}
+
+inline Result ClientImpl::Get(const std::string &path, const Params &params,
+                              const Headers &headers, Progress progress) {
+  if (params.empty()) { return Get(path, headers); }
+
+  std::string path_with_query = append_query_params(path, params);
+  return Get(path_with_query, headers, progress);
+}
+
+inline Result ClientImpl::Get(const std::string &path, const Params &params,
+                              const Headers &headers,
+                              ContentReceiver content_receiver,
+                              Progress progress) {
+  return Get(path, params, headers, nullptr, content_receiver, progress);
+}
+
+inline Result ClientImpl::Get(const std::string &path, const Params &params,
+                              const Headers &headers,
+                              ResponseHandler response_handler,
+                              ContentReceiver content_receiver,
+                              Progress progress) {
+  if (params.empty()) {
+    return Get(path, headers, response_handler, content_receiver, progress);
+  }
+
+  std::string path_with_query = append_query_params(path, params);
+  return Get(path_with_query, headers, response_handler, content_receiver,
+             progress);
 }
 
 inline Result ClientImpl::Head(const std::string &path) {
-	return Head(path, Headers());
+  return Head(path, Headers());
 }
 
-inline Result ClientImpl::Head(const std::string &path, const Headers &headers) {
-	Request req;
-	req.method = "HEAD";
-	req.headers = headers;
-	req.path = path;
+inline Result ClientImpl::Head(const std::string &path,
+                               const Headers &headers) {
+  Request req;
+  req.method = "HEAD";
+  req.headers = headers;
+  req.path = path;
 
-	return send_(std::move(req));
+  return send_(std::move(req));
 }
 
 inline Result ClientImpl::Post(const std::string &path) {
-	return Post(path, std::string(), std::string());
+  return Post(path, std::string(), std::string());
 }
 
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers) {
-	return Post(path, headers, nullptr, 0, std::string());
+inline Result ClientImpl::Post(const std::string &path,
+                               const Headers &headers) {
+  return Post(path, headers, nullptr, 0, std::string());
 }
 
-inline Result ClientImpl::Post(const std::string &path, const char *body, size_t content_length,
+inline Result ClientImpl::Post(const std::string &path, const char *body,
+                               size_t content_length,
                                const std::string &content_type) {
-	return Post(path, Headers(), body, content_length, content_type);
-}
-
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-                               const std::string &content_type) {
-	return send_with_content_provider("POST", path, headers, body, content_length, nullptr, nullptr, content_type);
-}
-
-inline Result ClientImpl::Post(const std::string &path, const std::string &body, const std::string &content_type) {
-	return Post(path, Headers(), body, content_type);
-}
-
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const std::string &body,
-                               const std::string &content_type) {
-	return send_with_content_provider("POST", path, headers, body.data(), body.size(), nullptr, nullptr, content_type);
-}
-
-inline Result ClientImpl::Post(const std::string &path, const Params &params) {
-	return Post(path, Headers(), params);
-}
-
-inline Result ClientImpl::Post(const std::string &path, size_t content_length, ContentProvider content_provider,
-                               const std::string &content_type) {
-	return Post(path, Headers(), content_length, std::move(content_provider), content_type);
-}
-
-inline Result ClientImpl::Post(const std::string &path, ContentProviderWithoutLength content_provider,
-                               const std::string &content_type) {
-	return Post(path, Headers(), std::move(content_provider), content_type);
-}
-
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers, size_t content_length,
-                               ContentProvider content_provider, const std::string &content_type) {
-	return send_with_content_provider("POST", path, headers, nullptr, content_length, std::move(content_provider),
-	                                  nullptr, content_type);
+  return Post(path, Headers(), body, content_length, content_type);
 }
 
 inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
-                               ContentProviderWithoutLength content_provider, const std::string &content_type) {
-	return send_with_content_provider("POST", path, headers, nullptr, 0, nullptr, std::move(content_provider),
-	                                  content_type);
+                               const char *body, size_t content_length,
+                               const std::string &content_type) {
+  return send_with_content_provider("POST", path, headers, body, content_length,
+                                    nullptr, nullptr, content_type);
 }
 
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const Params &params) {
-	auto query = detail::params_to_query_str(params);
-	return Post(path, headers, query, "application/x-www-form-urlencoded");
+inline Result ClientImpl::Post(const std::string &path, const std::string &body,
+                               const std::string &content_type) {
+  return Post(path, Headers(), body, content_type);
 }
 
-inline Result ClientImpl::Post(const std::string &path, const MultipartFormDataItems &items) {
-	return Post(path, Headers(), items);
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
+                               const std::string &body,
+                               const std::string &content_type) {
+  return send_with_content_provider("POST", path, headers, body.data(),
+                                    body.size(), nullptr, nullptr,
+                                    content_type);
 }
 
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items) {
-	const auto &boundary = detail::make_multipart_data_boundary();
-	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
-	const auto &body = detail::serialize_multipart_formdata(items, boundary);
-	return Post(path, headers, body, content_type);
+inline Result ClientImpl::Post(const std::string &path, const Params &params) {
+  return Post(path, Headers(), params);
 }
 
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+inline Result ClientImpl::Post(const std::string &path, size_t content_length,
+                               ContentProvider content_provider,
+                               const std::string &content_type) {
+  return Post(path, Headers(), content_length, std::move(content_provider),
+              content_type);
+}
+
+inline Result ClientImpl::Post(const std::string &path,
+                               ContentProviderWithoutLength content_provider,
+                               const std::string &content_type) {
+  return Post(path, Headers(), std::move(content_provider), content_type);
+}
+
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
+                               size_t content_length,
+                               ContentProvider content_provider,
+                               const std::string &content_type) {
+  return send_with_content_provider("POST", path, headers, nullptr,
+                                    content_length, std::move(content_provider),
+                                    nullptr, content_type);
+}
+
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
+                               ContentProviderWithoutLength content_provider,
+                               const std::string &content_type) {
+  return send_with_content_provider("POST", path, headers, nullptr, 0, nullptr,
+                                    std::move(content_provider), content_type);
+}
+
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
+                               const Params &params) {
+  auto query = detail::params_to_query_str(params);
+  return Post(path, headers, query, "application/x-www-form-urlencoded");
+}
+
+inline Result ClientImpl::Post(const std::string &path,
+                               const MultipartFormDataItems &items) {
+  return Post(path, Headers(), items);
+}
+
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
+                               const MultipartFormDataItems &items) {
+  const auto &boundary = detail::make_multipart_data_boundary();
+  const auto &content_type =
+      detail::serialize_multipart_formdata_get_content_type(boundary);
+  const auto &body = detail::serialize_multipart_formdata(items, boundary);
+  return Post(path, headers, body, content_type);
+}
+
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
+                               const MultipartFormDataItems &items,
                                const std::string &boundary) {
-	if (!detail::is_multipart_boundary_chars_valid(boundary)) {
-		return Result {nullptr, Error::UnsupportedMultipartBoundaryChars};
-	}
+  if (!detail::is_multipart_boundary_chars_valid(boundary)) {
+    return Result{nullptr, Error::UnsupportedMultipartBoundaryChars};
+  }
 
-	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
-	const auto &body = detail::serialize_multipart_formdata(items, boundary);
-	return Post(path, headers, body, content_type);
+  const auto &content_type =
+      detail::serialize_multipart_formdata_get_content_type(boundary);
+  const auto &body = detail::serialize_multipart_formdata(items, boundary);
+  return Post(path, headers, body, content_type);
 }
 
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-                               const MultipartFormDataProviderItems &provider_items) {
-	const auto &boundary = detail::make_multipart_data_boundary();
-	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
-	return send_with_content_provider("POST", path, headers, nullptr, 0, nullptr,
-	                                  get_multipart_content_provider(boundary, items, provider_items), content_type);
+inline Result
+ClientImpl::Post(const std::string &path, const Headers &headers,
+                 const MultipartFormDataItems &items,
+                 const MultipartFormDataProviderItems &provider_items) {
+  const auto &boundary = detail::make_multipart_data_boundary();
+  const auto &content_type =
+      detail::serialize_multipart_formdata_get_content_type(boundary);
+  return send_with_content_provider(
+      "POST", path, headers, nullptr, 0, nullptr,
+      get_multipart_content_provider(boundary, items, provider_items),
+      content_type);
 }
 
 inline Result ClientImpl::Put(const std::string &path) {
-	return Put(path, std::string(), std::string());
+  return Put(path, std::string(), std::string());
 }
 
-inline Result ClientImpl::Put(const std::string &path, const char *body, size_t content_length,
+inline Result ClientImpl::Put(const std::string &path, const char *body,
+                              size_t content_length,
                               const std::string &content_type) {
-	return Put(path, Headers(), body, content_length, content_type);
-}
-
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-                              const std::string &content_type) {
-	return send_with_content_provider("PUT", path, headers, body, content_length, nullptr, nullptr, content_type);
-}
-
-inline Result ClientImpl::Put(const std::string &path, const std::string &body, const std::string &content_type) {
-	return Put(path, Headers(), body, content_type);
-}
-
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const std::string &body,
-                              const std::string &content_type) {
-	return send_with_content_provider("PUT", path, headers, body.data(), body.size(), nullptr, nullptr, content_type);
-}
-
-inline Result ClientImpl::Put(const std::string &path, size_t content_length, ContentProvider content_provider,
-                              const std::string &content_type) {
-	return Put(path, Headers(), content_length, std::move(content_provider), content_type);
-}
-
-inline Result ClientImpl::Put(const std::string &path, ContentProviderWithoutLength content_provider,
-                              const std::string &content_type) {
-	return Put(path, Headers(), std::move(content_provider), content_type);
-}
-
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers, size_t content_length,
-                              ContentProvider content_provider, const std::string &content_type) {
-	return send_with_content_provider("PUT", path, headers, nullptr, content_length, std::move(content_provider),
-	                                  nullptr, content_type);
+  return Put(path, Headers(), body, content_length, content_type);
 }
 
 inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
-                              ContentProviderWithoutLength content_provider, const std::string &content_type) {
-	return send_with_content_provider("PUT", path, headers, nullptr, 0, nullptr, std::move(content_provider),
-	                                  content_type);
+                              const char *body, size_t content_length,
+                              const std::string &content_type) {
+  return send_with_content_provider("PUT", path, headers, body, content_length,
+                                    nullptr, nullptr, content_type);
+}
+
+inline Result ClientImpl::Put(const std::string &path, const std::string &body,
+                              const std::string &content_type) {
+  return Put(path, Headers(), body, content_type);
+}
+
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
+                              const std::string &body,
+                              const std::string &content_type) {
+  return send_with_content_provider("PUT", path, headers, body.data(),
+                                    body.size(), nullptr, nullptr,
+                                    content_type);
+}
+
+inline Result ClientImpl::Put(const std::string &path, size_t content_length,
+                              ContentProvider content_provider,
+                              const std::string &content_type) {
+  return Put(path, Headers(), content_length, std::move(content_provider),
+             content_type);
+}
+
+inline Result ClientImpl::Put(const std::string &path,
+                              ContentProviderWithoutLength content_provider,
+                              const std::string &content_type) {
+  return Put(path, Headers(), std::move(content_provider), content_type);
+}
+
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
+                              size_t content_length,
+                              ContentProvider content_provider,
+                              const std::string &content_type) {
+  return send_with_content_provider("PUT", path, headers, nullptr,
+                                    content_length, std::move(content_provider),
+                                    nullptr, content_type);
+}
+
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
+                              ContentProviderWithoutLength content_provider,
+                              const std::string &content_type) {
+  return send_with_content_provider("PUT", path, headers, nullptr, 0, nullptr,
+                                    std::move(content_provider), content_type);
 }
 
 inline Result ClientImpl::Put(const std::string &path, const Params &params) {
-	return Put(path, Headers(), params);
+  return Put(path, Headers(), params);
 }
 
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const Params &params) {
-	auto query = detail::params_to_query_str(params);
-	return Put(path, headers, query, "application/x-www-form-urlencoded");
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
+                              const Params &params) {
+  auto query = detail::params_to_query_str(params);
+  return Put(path, headers, query, "application/x-www-form-urlencoded");
 }
 
-inline Result ClientImpl::Put(const std::string &path, const MultipartFormDataItems &items) {
-	return Put(path, Headers(), items);
+inline Result ClientImpl::Put(const std::string &path,
+                              const MultipartFormDataItems &items) {
+  return Put(path, Headers(), items);
 }
 
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items) {
-	const auto &boundary = detail::make_multipart_data_boundary();
-	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
-	const auto &body = detail::serialize_multipart_formdata(items, boundary);
-	return Put(path, headers, body, content_type);
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
+                              const MultipartFormDataItems &items) {
+  const auto &boundary = detail::make_multipart_data_boundary();
+  const auto &content_type =
+      detail::serialize_multipart_formdata_get_content_type(boundary);
+  const auto &body = detail::serialize_multipart_formdata(items, boundary);
+  return Put(path, headers, body, content_type);
 }
 
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
+                              const MultipartFormDataItems &items,
                               const std::string &boundary) {
-	if (!detail::is_multipart_boundary_chars_valid(boundary)) {
-		return Result {nullptr, Error::UnsupportedMultipartBoundaryChars};
-	}
+  if (!detail::is_multipart_boundary_chars_valid(boundary)) {
+    return Result{nullptr, Error::UnsupportedMultipartBoundaryChars};
+  }
 
-	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
-	const auto &body = detail::serialize_multipart_formdata(items, boundary);
-	return Put(path, headers, body, content_type);
+  const auto &content_type =
+      detail::serialize_multipart_formdata_get_content_type(boundary);
+  const auto &body = detail::serialize_multipart_formdata(items, boundary);
+  return Put(path, headers, body, content_type);
 }
 
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-                              const MultipartFormDataProviderItems &provider_items) {
-	const auto &boundary = detail::make_multipart_data_boundary();
-	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
-	return send_with_content_provider("PUT", path, headers, nullptr, 0, nullptr,
-	                                  get_multipart_content_provider(boundary, items, provider_items), content_type);
+inline Result
+ClientImpl::Put(const std::string &path, const Headers &headers,
+                const MultipartFormDataItems &items,
+                const MultipartFormDataProviderItems &provider_items) {
+  const auto &boundary = detail::make_multipart_data_boundary();
+  const auto &content_type =
+      detail::serialize_multipart_formdata_get_content_type(boundary);
+  return send_with_content_provider(
+      "PUT", path, headers, nullptr, 0, nullptr,
+      get_multipart_content_provider(boundary, items, provider_items),
+      content_type);
 }
 inline Result ClientImpl::Patch(const std::string &path) {
-	return Patch(path, std::string(), std::string());
+  return Patch(path, std::string(), std::string());
 }
 
-inline Result ClientImpl::Patch(const std::string &path, const char *body, size_t content_length,
+inline Result ClientImpl::Patch(const std::string &path, const char *body,
+                                size_t content_length,
                                 const std::string &content_type) {
-	return Patch(path, Headers(), body, content_length, content_type);
-}
-
-inline Result ClientImpl::Patch(const std::string &path, const Headers &headers, const char *body,
-                                size_t content_length, const std::string &content_type) {
-	return send_with_content_provider("PATCH", path, headers, body, content_length, nullptr, nullptr, content_type);
-}
-
-inline Result ClientImpl::Patch(const std::string &path, const std::string &body, const std::string &content_type) {
-	return Patch(path, Headers(), body, content_type);
-}
-
-inline Result ClientImpl::Patch(const std::string &path, const Headers &headers, const std::string &body,
-                                const std::string &content_type) {
-	return send_with_content_provider("PATCH", path, headers, body.data(), body.size(), nullptr, nullptr, content_type);
-}
-
-inline Result ClientImpl::Patch(const std::string &path, size_t content_length, ContentProvider content_provider,
-                                const std::string &content_type) {
-	return Patch(path, Headers(), content_length, std::move(content_provider), content_type);
-}
-
-inline Result ClientImpl::Patch(const std::string &path, ContentProviderWithoutLength content_provider,
-                                const std::string &content_type) {
-	return Patch(path, Headers(), std::move(content_provider), content_type);
-}
-
-inline Result ClientImpl::Patch(const std::string &path, const Headers &headers, size_t content_length,
-                                ContentProvider content_provider, const std::string &content_type) {
-	return send_with_content_provider("PATCH", path, headers, nullptr, content_length, std::move(content_provider),
-	                                  nullptr, content_type);
+  return Patch(path, Headers(), body, content_length, content_type);
 }
 
 inline Result ClientImpl::Patch(const std::string &path, const Headers &headers,
-                                ContentProviderWithoutLength content_provider, const std::string &content_type) {
-	return send_with_content_provider("PATCH", path, headers, nullptr, 0, nullptr, std::move(content_provider),
-	                                  content_type);
+                                const char *body, size_t content_length,
+                                const std::string &content_type) {
+  return send_with_content_provider("PATCH", path, headers, body,
+                                    content_length, nullptr, nullptr,
+                                    content_type);
+}
+
+inline Result ClientImpl::Patch(const std::string &path,
+                                const std::string &body,
+                                const std::string &content_type) {
+  return Patch(path, Headers(), body, content_type);
+}
+
+inline Result ClientImpl::Patch(const std::string &path, const Headers &headers,
+                                const std::string &body,
+                                const std::string &content_type) {
+  return send_with_content_provider("PATCH", path, headers, body.data(),
+                                    body.size(), nullptr, nullptr,
+                                    content_type);
+}
+
+inline Result ClientImpl::Patch(const std::string &path, size_t content_length,
+                                ContentProvider content_provider,
+                                const std::string &content_type) {
+  return Patch(path, Headers(), content_length, std::move(content_provider),
+               content_type);
+}
+
+inline Result ClientImpl::Patch(const std::string &path,
+                                ContentProviderWithoutLength content_provider,
+                                const std::string &content_type) {
+  return Patch(path, Headers(), std::move(content_provider), content_type);
+}
+
+inline Result ClientImpl::Patch(const std::string &path, const Headers &headers,
+                                size_t content_length,
+                                ContentProvider content_provider,
+                                const std::string &content_type) {
+  return send_with_content_provider("PATCH", path, headers, nullptr,
+                                    content_length, std::move(content_provider),
+                                    nullptr, content_type);
+}
+
+inline Result ClientImpl::Patch(const std::string &path, const Headers &headers,
+                                ContentProviderWithoutLength content_provider,
+                                const std::string &content_type) {
+  return send_with_content_provider("PATCH", path, headers, nullptr, 0, nullptr,
+                                    std::move(content_provider), content_type);
 }
 
 inline Result ClientImpl::Delete(const std::string &path) {
-	return Delete(path, Headers(), std::string(), std::string());
+  return Delete(path, Headers(), std::string(), std::string());
 }
 
-inline Result ClientImpl::Delete(const std::string &path, const Headers &headers) {
-	return Delete(path, headers, std::string(), std::string());
+inline Result ClientImpl::Delete(const std::string &path,
+                                 const Headers &headers) {
+  return Delete(path, headers, std::string(), std::string());
 }
 
-inline Result ClientImpl::Delete(const std::string &path, const char *body, size_t content_length,
+inline Result ClientImpl::Delete(const std::string &path, const char *body,
+                                 size_t content_length,
                                  const std::string &content_type) {
-	return Delete(path, Headers(), body, content_length, content_type);
+  return Delete(path, Headers(), body, content_length, content_type);
 }
 
-inline Result ClientImpl::Delete(const std::string &path, const Headers &headers, const char *body,
-                                 size_t content_length, const std::string &content_type) {
-	Request req;
-	req.method = "DELETE";
-	req.headers = headers;
-	req.path = path;
-
-	if (!content_type.empty()) {
-		req.set_header("Content-Type", content_type);
-	}
-	req.body.assign(body, content_length);
-
-	return send_(std::move(req));
-}
-
-inline Result ClientImpl::Delete(const std::string &path, const std::string &body, const std::string &content_type) {
-	return Delete(path, Headers(), body.data(), body.size(), content_type);
-}
-
-inline Result ClientImpl::Delete(const std::string &path, const Headers &headers, const std::string &body,
+inline Result ClientImpl::Delete(const std::string &path,
+                                 const Headers &headers, const char *body,
+                                 size_t content_length,
                                  const std::string &content_type) {
-	return Delete(path, headers, body.data(), body.size(), content_type);
+  Request req;
+  req.method = "DELETE";
+  req.headers = headers;
+  req.path = path;
+
+  if (!content_type.empty()) { req.set_header("Content-Type", content_type); }
+  req.body.assign(body, content_length);
+
+  return send_(std::move(req));
+}
+
+inline Result ClientImpl::Delete(const std::string &path,
+                                 const std::string &body,
+                                 const std::string &content_type) {
+  return Delete(path, Headers(), body.data(), body.size(), content_type);
+}
+
+inline Result ClientImpl::Delete(const std::string &path,
+                                 const Headers &headers,
+                                 const std::string &body,
+                                 const std::string &content_type) {
+  return Delete(path, headers, body.data(), body.size(), content_type);
 }
 
 inline Result ClientImpl::Options(const std::string &path) {
-	return Options(path, Headers());
+  return Options(path, Headers());
 }
 
-inline Result ClientImpl::Options(const std::string &path, const Headers &headers) {
-	Request req;
-	req.method = "OPTIONS";
-	req.headers = headers;
-	req.path = path;
+inline Result ClientImpl::Options(const std::string &path,
+                                  const Headers &headers) {
+  Request req;
+  req.method = "OPTIONS";
+  req.headers = headers;
+  req.path = path;
 
-	return send_(std::move(req));
+  return send_(std::move(req));
 }
 
 inline void ClientImpl::stop() {
-	std::lock_guard<std::mutex> guard(socket_mutex_);
+  std::lock_guard<std::mutex> guard(socket_mutex_);
 
-	// If there is anything ongoing right now, the ONLY thread-safe thing we can
-	// do is to shutdown_socket, so that threads using this socket suddenly
-	// discover they can't read/write any more and error out. Everything else
-	// (closing the socket, shutting ssl down) is unsafe because these actions are
-	// not thread-safe.
-	if (socket_requests_in_flight_ > 0) {
-		shutdown_socket(socket_);
+  // If there is anything ongoing right now, the ONLY thread-safe thing we can
+  // do is to shutdown_socket, so that threads using this socket suddenly
+  // discover they can't read/write any more and error out. Everything else
+  // (closing the socket, shutting ssl down) is unsafe because these actions are
+  // not thread-safe.
+  if (socket_requests_in_flight_ > 0) {
+    shutdown_socket(socket_);
 
-		// Aside from that, we set a flag for the socket to be closed when we're
-		// done.
-		socket_should_be_closed_when_request_is_done_ = true;
-		return;
-	}
+    // Aside from that, we set a flag for the socket to be closed when we're
+    // done.
+    socket_should_be_closed_when_request_is_done_ = true;
+    return;
+  }
 
-	// Otherwise, still holding the mutex, we can shut everything down ourselves
-	shutdown_ssl(socket_, true);
-	shutdown_socket(socket_);
-	close_socket(socket_);
+  // Otherwise, still holding the mutex, we can shut everything down ourselves
+  shutdown_ssl(socket_, true);
+  shutdown_socket(socket_);
+  close_socket(socket_);
 }
 
-inline std::string ClientImpl::host() const {
-	return host_;
-}
+inline std::string ClientImpl::host() const { return host_; }
 
-inline int ClientImpl::port() const {
-	return port_;
-}
+inline int ClientImpl::port() const { return port_; }
 
 inline size_t ClientImpl::is_socket_open() const {
-	std::lock_guard<std::mutex> guard(socket_mutex_);
-	return socket_.is_open();
+  std::lock_guard<std::mutex> guard(socket_mutex_);
+  return socket_.is_open();
 }
 
-inline socket_t ClientImpl::socket() const {
-	return socket_.sock;
-}
+inline socket_t ClientImpl::socket() const { return socket_.sock; }
 
 inline void ClientImpl::set_connection_timeout(time_t sec, time_t usec) {
-	connection_timeout_sec_ = sec;
-	connection_timeout_usec_ = usec;
+  connection_timeout_sec_ = sec;
+  connection_timeout_usec_ = usec;
 }
 
 inline void ClientImpl::set_read_timeout(time_t sec, time_t usec) {
-	read_timeout_sec_ = sec;
-	read_timeout_usec_ = usec;
+  read_timeout_sec_ = sec;
+  read_timeout_usec_ = usec;
 }
 
 inline void ClientImpl::set_write_timeout(time_t sec, time_t usec) {
-	write_timeout_sec_ = sec;
-	write_timeout_usec_ = usec;
+  write_timeout_sec_ = sec;
+  write_timeout_usec_ = usec;
 }
 
-inline void ClientImpl::set_basic_auth(const std::string &username, const std::string &password) {
-	basic_auth_username_ = username;
-	basic_auth_password_ = password;
+inline void ClientImpl::set_basic_auth(const std::string &username,
+                                       const std::string &password) {
+  basic_auth_username_ = username;
+  basic_auth_password_ = password;
 }
 
 inline void ClientImpl::set_bearer_token_auth(const std::string &token) {
-	bearer_token_auth_token_ = token;
+  bearer_token_auth_token_ = token;
 }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline void ClientImpl::set_digest_auth(const std::string &username, const std::string &password) {
-	digest_auth_username_ = username;
-	digest_auth_password_ = password;
+inline void ClientImpl::set_digest_auth(const std::string &username,
+                                        const std::string &password) {
+  digest_auth_username_ = username;
+  digest_auth_password_ = password;
 }
 #endif
 
-inline void ClientImpl::set_keep_alive(bool on) {
-	keep_alive_ = on;
-}
+inline void ClientImpl::set_keep_alive(bool on) { keep_alive_ = on; }
 
-inline void ClientImpl::set_follow_location(bool on) {
-	follow_location_ = on;
-}
+inline void ClientImpl::set_follow_location(bool on) { follow_location_ = on; }
 
-inline void ClientImpl::set_url_encode(bool on) {
-	url_encode_ = on;
-}
+inline void ClientImpl::set_url_encode(bool on) { url_encode_ = on; }
 
-inline void ClientImpl::set_hostname_addr_map(std::map<std::string, std::string> addr_map) {
-	addr_map_ = std::move(addr_map);
+inline void
+ClientImpl::set_hostname_addr_map(std::map<std::string, std::string> addr_map) {
+  addr_map_ = std::move(addr_map);
 }
 
 inline void ClientImpl::set_default_headers(Headers headers) {
-	default_headers_ = std::move(headers);
+  default_headers_ = std::move(headers);
 }
 
-inline void ClientImpl::set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer) {
-	header_writer_ = writer;
+inline void ClientImpl::set_header_writer(
+    std::function<ssize_t(Stream &, Headers &)> const &writer) {
+  header_writer_ = writer;
 }
 
 inline void ClientImpl::set_address_family(int family) {
-	address_family_ = family;
+  address_family_ = family;
 }
 
-inline void ClientImpl::set_tcp_nodelay(bool on) {
-	tcp_nodelay_ = on;
-}
+inline void ClientImpl::set_tcp_nodelay(bool on) { tcp_nodelay_ = on; }
 
 inline void ClientImpl::set_socket_options(SocketOptions socket_options) {
-	socket_options_ = std::move(socket_options);
+  socket_options_ = std::move(socket_options);
 }
 
-inline void ClientImpl::set_compress(bool on) {
-	compress_ = on;
-}
+inline void ClientImpl::set_compress(bool on) { compress_ = on; }
 
-inline void ClientImpl::set_decompress(bool on) {
-	decompress_ = on;
-}
+inline void ClientImpl::set_decompress(bool on) { decompress_ = on; }
 
 inline void ClientImpl::set_interface(const std::string &intf) {
-	interface_ = intf;
+  interface_ = intf;
 }
 
 inline void ClientImpl::set_proxy(const std::string &host, int port) {
-	proxy_host_ = host;
-	proxy_port_ = port;
+  proxy_host_ = host;
+  proxy_port_ = port;
 }
 
-inline void ClientImpl::set_proxy_basic_auth(const std::string &username, const std::string &password) {
-	proxy_basic_auth_username_ = username;
-	proxy_basic_auth_password_ = password;
+inline void ClientImpl::set_proxy_basic_auth(const std::string &username,
+                                             const std::string &password) {
+  proxy_basic_auth_username_ = username;
+  proxy_basic_auth_password_ = password;
 }
 
 inline void ClientImpl::set_proxy_bearer_token_auth(const std::string &token) {
-	proxy_bearer_token_auth_token_ = token;
+  proxy_bearer_token_auth_token_ = token;
 }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline void ClientImpl::set_proxy_digest_auth(const std::string &username, const std::string &password) {
-	proxy_digest_auth_username_ = username;
-	proxy_digest_auth_password_ = password;
+inline void ClientImpl::set_proxy_digest_auth(const std::string &username,
+                                              const std::string &password) {
+  proxy_digest_auth_username_ = username;
+  proxy_digest_auth_password_ = password;
 }
 
-inline void ClientImpl::set_ca_cert_path(const std::string &ca_cert_file_path, const std::string &ca_cert_dir_path) {
-	ca_cert_file_path_ = ca_cert_file_path;
-	ca_cert_dir_path_ = ca_cert_dir_path;
+inline void ClientImpl::set_ca_cert_path(const std::string &ca_cert_file_path,
+                                         const std::string &ca_cert_dir_path) {
+  ca_cert_file_path_ = ca_cert_file_path;
+  ca_cert_dir_path_ = ca_cert_dir_path;
 }
 
 inline void ClientImpl::set_ca_cert_store(X509_STORE *ca_cert_store) {
-	if (ca_cert_store && ca_cert_store != ca_cert_store_) {
-		ca_cert_store_ = ca_cert_store;
-	}
+  if (ca_cert_store && ca_cert_store != ca_cert_store_) {
+    ca_cert_store_ = ca_cert_store;
+  }
 }
 
-inline X509_STORE *ClientImpl::create_ca_cert_store(const char *ca_cert, std::size_t size) const {
-	auto mem = BIO_new_mem_buf(ca_cert, static_cast<int>(size));
-	if (!mem) {
-		return nullptr;
-	}
+inline X509_STORE *ClientImpl::create_ca_cert_store(const char *ca_cert,
+                                                    std::size_t size) const {
+  auto mem = BIO_new_mem_buf(ca_cert, static_cast<int>(size));
+  if (!mem) { return nullptr; }
 
-	auto inf = PEM_X509_INFO_read_bio(mem, nullptr, nullptr, nullptr);
-	if (!inf) {
-		BIO_free_all(mem);
-		return nullptr;
-	}
+  auto inf = PEM_X509_INFO_read_bio(mem, nullptr, nullptr, nullptr);
+  if (!inf) {
+    BIO_free_all(mem);
+    return nullptr;
+  }
 
-	auto cts = X509_STORE_new();
-	if (cts) {
-		for (auto i = 0; i < static_cast<int>(sk_X509_INFO_num(inf)); i++) {
-			auto itmp = sk_X509_INFO_value(inf, i);
-			if (!itmp) {
-				continue;
-			}
+  auto cts = X509_STORE_new();
+  if (cts) {
+    for (auto i = 0; i < static_cast<int>(sk_X509_INFO_num(inf)); i++) {
+      auto itmp = sk_X509_INFO_value(inf, i);
+      if (!itmp) { continue; }
 
-			if (itmp->x509) {
-				X509_STORE_add_cert(cts, itmp->x509);
-			}
-			if (itmp->crl) {
-				X509_STORE_add_crl(cts, itmp->crl);
-			}
-		}
-	}
+      if (itmp->x509) { X509_STORE_add_cert(cts, itmp->x509); }
+      if (itmp->crl) { X509_STORE_add_crl(cts, itmp->crl); }
+    }
+  }
 
-	sk_X509_INFO_pop_free(inf, X509_INFO_free);
-	BIO_free_all(mem);
-	return cts;
+  sk_X509_INFO_pop_free(inf, X509_INFO_free);
+  BIO_free_all(mem);
+  return cts;
 }
 
 inline void ClientImpl::enable_server_certificate_verification(bool enabled) {
-	server_certificate_verification_ = enabled;
+  server_certificate_verification_ = enabled;
 }
 #endif
 
 inline void ClientImpl::set_logger(Logger logger) {
-	logger_ = std::move(logger);
+  logger_ = std::move(logger);
 }
 
 /*
@@ -8136,1143 +8161,1220 @@ inline void ClientImpl::set_logger(Logger logger) {
 namespace detail {
 
 template <typename U, typename V>
-inline SSL *ssl_new(socket_t sock, SSL_CTX *ctx, std::mutex &ctx_mutex, U SSL_connect_or_accept, V setup) {
-	SSL *ssl = nullptr;
-	{
-		std::lock_guard<std::mutex> guard(ctx_mutex);
-		ssl = SSL_new(ctx);
-	}
+inline SSL *ssl_new(socket_t sock, SSL_CTX *ctx, std::mutex &ctx_mutex,
+                    U SSL_connect_or_accept, V setup) {
+  SSL *ssl = nullptr;
+  {
+    std::lock_guard<std::mutex> guard(ctx_mutex);
+    ssl = SSL_new(ctx);
+  }
 
-	if (ssl) {
-		set_nonblocking(sock, true);
-		auto bio = BIO_new_socket(static_cast<int>(sock), BIO_NOCLOSE);
-		BIO_set_nbio(bio, 1);
-		SSL_set_bio(ssl, bio, bio);
+  if (ssl) {
+    set_nonblocking(sock, true);
+    auto bio = BIO_new_socket(static_cast<int>(sock), BIO_NOCLOSE);
+    BIO_set_nbio(bio, 1);
+    SSL_set_bio(ssl, bio, bio);
 
-		if (!setup(ssl) || SSL_connect_or_accept(ssl) != 1) {
-			SSL_shutdown(ssl);
-			{
-				std::lock_guard<std::mutex> guard(ctx_mutex);
-				SSL_free(ssl);
-			}
-			set_nonblocking(sock, false);
-			return nullptr;
-		}
-		BIO_set_nbio(bio, 0);
-		set_nonblocking(sock, false);
-	}
+    if (!setup(ssl) || SSL_connect_or_accept(ssl) != 1) {
+      SSL_shutdown(ssl);
+      {
+        std::lock_guard<std::mutex> guard(ctx_mutex);
+        SSL_free(ssl);
+      }
+      set_nonblocking(sock, false);
+      return nullptr;
+    }
+    BIO_set_nbio(bio, 0);
+    set_nonblocking(sock, false);
+  }
 
-	return ssl;
+  return ssl;
 }
 
-inline void ssl_delete(std::mutex &ctx_mutex, SSL *ssl, bool shutdown_gracefully) {
-	// sometimes we may want to skip this to try to avoid SIGPIPE if we know
-	// the remote has closed the network connection
-	// Note that it is not always possible to avoid SIGPIPE, this is merely a
-	// best-efforts.
-	if (shutdown_gracefully) {
-		SSL_shutdown(ssl);
-	}
+inline void ssl_delete(std::mutex &ctx_mutex, SSL *ssl,
+                       bool shutdown_gracefully) {
+  // sometimes we may want to skip this to try to avoid SIGPIPE if we know
+  // the remote has closed the network connection
+  // Note that it is not always possible to avoid SIGPIPE, this is merely a
+  // best-efforts.
+  if (shutdown_gracefully) { SSL_shutdown(ssl); }
 
-	std::lock_guard<std::mutex> guard(ctx_mutex);
-	SSL_free(ssl);
+  std::lock_guard<std::mutex> guard(ctx_mutex);
+  SSL_free(ssl);
 }
 
 template <typename U>
-bool ssl_connect_or_accept_nonblocking(socket_t sock, SSL *ssl, U ssl_connect_or_accept, time_t timeout_sec,
+bool ssl_connect_or_accept_nonblocking(socket_t sock, SSL *ssl,
+                                       U ssl_connect_or_accept,
+                                       time_t timeout_sec,
                                        time_t timeout_usec) {
-	auto res = 0;
-	while ((res = ssl_connect_or_accept(ssl)) != 1) {
-		auto err = SSL_get_error(ssl, res);
-		switch (err) {
-		case SSL_ERROR_WANT_READ:
-			if (select_read(sock, timeout_sec, timeout_usec) > 0) {
-				continue;
-			}
-			break;
-		case SSL_ERROR_WANT_WRITE:
-			if (select_write(sock, timeout_sec, timeout_usec) > 0) {
-				continue;
-			}
-			break;
-		default:
-			break;
-		}
-		return false;
-	}
-	return true;
+  auto res = 0;
+  while ((res = ssl_connect_or_accept(ssl)) != 1) {
+    auto err = SSL_get_error(ssl, res);
+    switch (err) {
+    case SSL_ERROR_WANT_READ:
+      if (select_read(sock, timeout_sec, timeout_usec) > 0) { continue; }
+      break;
+    case SSL_ERROR_WANT_WRITE:
+      if (select_write(sock, timeout_sec, timeout_usec) > 0) { continue; }
+      break;
+    default: break;
+    }
+    return false;
+  }
+  return true;
 }
 
 template <typename T>
-inline bool process_server_socket_ssl(const std::atomic<socket_t> &svr_sock, SSL *ssl, socket_t sock,
-                                      size_t keep_alive_max_count, time_t keep_alive_timeout_sec,
-                                      time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
-                                      time_t write_timeout_usec, T callback) {
-	return process_server_socket_core(svr_sock, sock, keep_alive_max_count, keep_alive_timeout_sec,
-	                                  [&](bool close_connection, bool &connection_closed) {
-		                                  SSLSocketStream strm(sock, ssl, read_timeout_sec, read_timeout_usec,
-		                                                       write_timeout_sec, write_timeout_usec);
-		                                  return callback(strm, close_connection, connection_closed);
-	                                  });
+inline bool process_server_socket_ssl(
+    const std::atomic<socket_t> &svr_sock, SSL *ssl, socket_t sock,
+    size_t keep_alive_max_count, time_t keep_alive_timeout_sec,
+    time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
+    time_t write_timeout_usec, T callback) {
+  return process_server_socket_core(
+      svr_sock, sock, keep_alive_max_count, keep_alive_timeout_sec,
+      [&](bool close_connection, bool &connection_closed) {
+        SSLSocketStream strm(sock, ssl, read_timeout_sec, read_timeout_usec,
+                             write_timeout_sec, write_timeout_usec);
+        return callback(strm, close_connection, connection_closed);
+      });
 }
 
 template <typename T>
-inline bool process_client_socket_ssl(SSL *ssl, socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec,
-                                      time_t write_timeout_sec, time_t write_timeout_usec, T callback) {
-	SSLSocketStream strm(sock, ssl, read_timeout_sec, read_timeout_usec, write_timeout_sec, write_timeout_usec);
-	return callback(strm);
+inline bool
+process_client_socket_ssl(SSL *ssl, socket_t sock, time_t read_timeout_sec,
+                          time_t read_timeout_usec, time_t write_timeout_sec,
+                          time_t write_timeout_usec, T callback) {
+  SSLSocketStream strm(sock, ssl, read_timeout_sec, read_timeout_usec,
+                       write_timeout_sec, write_timeout_usec);
+  return callback(strm);
 }
 
 class SSLInit {
 public:
-	SSLInit() {
-		OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-	}
+  SSLInit() {
+    OPENSSL_init_ssl(
+        OPENSSL_INIT_LOAD_SSL_STRINGS | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+  }
 };
 
 // SSL socket stream implementation
-inline SSLSocketStream::SSLSocketStream(socket_t sock, SSL *ssl, time_t read_timeout_sec, time_t read_timeout_usec,
-                                        time_t write_timeout_sec, time_t write_timeout_usec)
-    : sock_(sock), ssl_(ssl), read_timeout_sec_(read_timeout_sec), read_timeout_usec_(read_timeout_usec),
-      write_timeout_sec_(write_timeout_sec), write_timeout_usec_(write_timeout_usec) {
-	SSL_clear_mode(ssl, SSL_MODE_AUTO_RETRY);
+inline SSLSocketStream::SSLSocketStream(socket_t sock, SSL *ssl,
+                                        time_t read_timeout_sec,
+                                        time_t read_timeout_usec,
+                                        time_t write_timeout_sec,
+                                        time_t write_timeout_usec)
+    : sock_(sock), ssl_(ssl), read_timeout_sec_(read_timeout_sec),
+      read_timeout_usec_(read_timeout_usec),
+      write_timeout_sec_(write_timeout_sec),
+      write_timeout_usec_(write_timeout_usec) {
+  SSL_clear_mode(ssl, SSL_MODE_AUTO_RETRY);
 }
 
 inline SSLSocketStream::~SSLSocketStream() = default;
 
 inline bool SSLSocketStream::is_readable() const {
-	return detail::select_read(sock_, read_timeout_sec_, read_timeout_usec_) > 0;
+  return detail::select_read(sock_, read_timeout_sec_, read_timeout_usec_) > 0;
 }
 
 inline bool SSLSocketStream::is_writable() const {
-	return select_write(sock_, write_timeout_sec_, write_timeout_usec_) > 0 && is_socket_alive(sock_);
+  return select_write(sock_, write_timeout_sec_, write_timeout_usec_) > 0 &&
+         is_socket_alive(sock_);
 }
 
 inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {
-	if (SSL_pending(ssl_) > 0) {
-		return SSL_read(ssl_, ptr, static_cast<int>(size));
-	} else if (is_readable()) {
-		auto ret = SSL_read(ssl_, ptr, static_cast<int>(size));
-		if (ret < 0) {
-			auto err = SSL_get_error(ssl_, ret);
-			auto n = 1000;
+  if (SSL_pending(ssl_) > 0) {
+    return SSL_read(ssl_, ptr, static_cast<int>(size));
+  } else if (is_readable()) {
+    auto ret = SSL_read(ssl_, ptr, static_cast<int>(size));
+    if (ret < 0) {
+      auto err = SSL_get_error(ssl_, ret);
+      auto n = 1000;
 #ifdef _WIN32
-			while (--n >= 0 &&
-			       (err == SSL_ERROR_WANT_READ || (err == SSL_ERROR_SYSCALL && WSAGetLastError() == WSAETIMEDOUT))) {
+      while (--n >= 0 && (err == SSL_ERROR_WANT_READ ||
+                          (err == SSL_ERROR_SYSCALL &&
+                           WSAGetLastError() == WSAETIMEDOUT))) {
 #else
-			while (--n >= 0 && err == SSL_ERROR_WANT_READ) {
+      while (--n >= 0 && err == SSL_ERROR_WANT_READ) {
 #endif
-				if (SSL_pending(ssl_) > 0) {
-					return SSL_read(ssl_, ptr, static_cast<int>(size));
-				} else if (is_readable()) {
-					std::this_thread::sleep_for(std::chrono::milliseconds(1));
-					ret = SSL_read(ssl_, ptr, static_cast<int>(size));
-					if (ret >= 0) {
-						return ret;
-					}
-					err = SSL_get_error(ssl_, ret);
-				} else {
-					return -1;
-				}
-			}
-		}
-		return ret;
-	}
-	return -1;
+        if (SSL_pending(ssl_) > 0) {
+          return SSL_read(ssl_, ptr, static_cast<int>(size));
+        } else if (is_readable()) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          ret = SSL_read(ssl_, ptr, static_cast<int>(size));
+          if (ret >= 0) { return ret; }
+          err = SSL_get_error(ssl_, ret);
+        } else {
+          return -1;
+        }
+      }
+    }
+    return ret;
+  }
+  return -1;
 }
 
 inline ssize_t SSLSocketStream::write(const char *ptr, size_t size) {
-	if (is_writable()) {
-		auto handle_size = static_cast<int>(std::min<size_t>(size, (std::numeric_limits<int>::max)()));
+  if (is_writable()) {
+    auto handle_size = static_cast<int>(
+        std::min<size_t>(size, (std::numeric_limits<int>::max)()));
 
-		auto ret = SSL_write(ssl_, ptr, static_cast<int>(handle_size));
-		if (ret < 0) {
-			auto err = SSL_get_error(ssl_, ret);
-			auto n = 1000;
+    auto ret = SSL_write(ssl_, ptr, static_cast<int>(handle_size));
+    if (ret < 0) {
+      auto err = SSL_get_error(ssl_, ret);
+      auto n = 1000;
 #ifdef _WIN32
-			while (--n >= 0 &&
-			       (err == SSL_ERROR_WANT_WRITE || (err == SSL_ERROR_SYSCALL && WSAGetLastError() == WSAETIMEDOUT))) {
+      while (--n >= 0 && (err == SSL_ERROR_WANT_WRITE ||
+                          (err == SSL_ERROR_SYSCALL &&
+                           WSAGetLastError() == WSAETIMEDOUT))) {
 #else
-			while (--n >= 0 && err == SSL_ERROR_WANT_WRITE) {
+      while (--n >= 0 && err == SSL_ERROR_WANT_WRITE) {
 #endif
-				if (is_writable()) {
-					std::this_thread::sleep_for(std::chrono::milliseconds(1));
-					ret = SSL_write(ssl_, ptr, static_cast<int>(handle_size));
-					if (ret >= 0) {
-						return ret;
-					}
-					err = SSL_get_error(ssl_, ret);
-				} else {
-					return -1;
-				}
-			}
-		}
-		return ret;
-	}
-	return -1;
+        if (is_writable()) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          ret = SSL_write(ssl_, ptr, static_cast<int>(handle_size));
+          if (ret >= 0) { return ret; }
+          err = SSL_get_error(ssl_, ret);
+        } else {
+          return -1;
+        }
+      }
+    }
+    return ret;
+  }
+  return -1;
 }
 
-inline void SSLSocketStream::get_remote_ip_and_port(std::string &ip, int &port) const {
-	detail::get_remote_ip_and_port(sock_, ip, port);
+inline void SSLSocketStream::get_remote_ip_and_port(std::string &ip,
+                                                    int &port) const {
+  detail::get_remote_ip_and_port(sock_, ip, port);
 }
 
-inline void SSLSocketStream::get_local_ip_and_port(std::string &ip, int &port) const {
-	detail::get_local_ip_and_port(sock_, ip, port);
+inline void SSLSocketStream::get_local_ip_and_port(std::string &ip,
+                                                   int &port) const {
+  detail::get_local_ip_and_port(sock_, ip, port);
 }
 
-inline socket_t SSLSocketStream::socket() const {
-	return sock_;
-}
+inline socket_t SSLSocketStream::socket() const { return sock_; }
 
 static SSLInit sslinit_;
 
 } // namespace detail
 
 // SSL HTTP server implementation
-inline SSLServer::SSLServer(const char *cert_path, const char *private_key_path, const char *client_ca_cert_file_path,
-                            const char *client_ca_cert_dir_path, const char *private_key_password) {
-	ctx_ = SSL_CTX_new(TLS_server_method());
+inline SSLServer::SSLServer(const char *cert_path, const char *private_key_path,
+                            const char *client_ca_cert_file_path,
+                            const char *client_ca_cert_dir_path,
+                            const char *private_key_password) {
+  ctx_ = SSL_CTX_new(TLS_server_method());
 
-	if (ctx_) {
-		SSL_CTX_set_options(ctx_, SSL_OP_NO_COMPRESSION | SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
+  if (ctx_) {
+    SSL_CTX_set_options(ctx_,
+                        SSL_OP_NO_COMPRESSION |
+                            SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
 
-		SSL_CTX_set_min_proto_version(ctx_, TLS1_1_VERSION);
+    SSL_CTX_set_min_proto_version(ctx_, TLS1_1_VERSION);
 
-		// add default password callback before opening encrypted private key
-		if (private_key_password != nullptr && (private_key_password[0] != '\0')) {
-			SSL_CTX_set_default_passwd_cb_userdata(ctx_,
-			                                       reinterpret_cast<void *>(const_cast<char *>(private_key_password)));
-		}
+    // add default password callback before opening encrypted private key
+    if (private_key_password != nullptr && (private_key_password[0] != '\0')) {
+      SSL_CTX_set_default_passwd_cb_userdata(
+          ctx_,
+          reinterpret_cast<void *>(const_cast<char *>(private_key_password)));
+    }
 
-		if (SSL_CTX_use_certificate_chain_file(ctx_, cert_path) != 1 ||
-		    SSL_CTX_use_PrivateKey_file(ctx_, private_key_path, SSL_FILETYPE_PEM) != 1) {
-			SSL_CTX_free(ctx_);
-			ctx_ = nullptr;
-		} else if (client_ca_cert_file_path || client_ca_cert_dir_path) {
-			SSL_CTX_load_verify_locations(ctx_, client_ca_cert_file_path, client_ca_cert_dir_path);
+    if (SSL_CTX_use_certificate_chain_file(ctx_, cert_path) != 1 ||
+        SSL_CTX_use_PrivateKey_file(ctx_, private_key_path, SSL_FILETYPE_PEM) !=
+            1) {
+      SSL_CTX_free(ctx_);
+      ctx_ = nullptr;
+    } else if (client_ca_cert_file_path || client_ca_cert_dir_path) {
+      SSL_CTX_load_verify_locations(ctx_, client_ca_cert_file_path,
+                                    client_ca_cert_dir_path);
 
-			SSL_CTX_set_verify(ctx_, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
-		}
-	}
+      SSL_CTX_set_verify(
+          ctx_, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
+    }
+  }
 }
 
-inline SSLServer::SSLServer(X509 *cert, EVP_PKEY *private_key, X509_STORE *client_ca_cert_store) {
-	ctx_ = SSL_CTX_new(TLS_server_method());
+inline SSLServer::SSLServer(X509 *cert, EVP_PKEY *private_key,
+                            X509_STORE *client_ca_cert_store) {
+  ctx_ = SSL_CTX_new(TLS_server_method());
 
-	if (ctx_) {
-		SSL_CTX_set_options(ctx_, SSL_OP_NO_COMPRESSION | SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
+  if (ctx_) {
+    SSL_CTX_set_options(ctx_,
+                        SSL_OP_NO_COMPRESSION |
+                            SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
 
-		SSL_CTX_set_min_proto_version(ctx_, TLS1_1_VERSION);
+    SSL_CTX_set_min_proto_version(ctx_, TLS1_1_VERSION);
 
-		if (SSL_CTX_use_certificate(ctx_, cert) != 1 || SSL_CTX_use_PrivateKey(ctx_, private_key) != 1) {
-			SSL_CTX_free(ctx_);
-			ctx_ = nullptr;
-		} else if (client_ca_cert_store) {
-			SSL_CTX_set_cert_store(ctx_, client_ca_cert_store);
+    if (SSL_CTX_use_certificate(ctx_, cert) != 1 ||
+        SSL_CTX_use_PrivateKey(ctx_, private_key) != 1) {
+      SSL_CTX_free(ctx_);
+      ctx_ = nullptr;
+    } else if (client_ca_cert_store) {
+      SSL_CTX_set_cert_store(ctx_, client_ca_cert_store);
 
-			SSL_CTX_set_verify(ctx_, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
-		}
-	}
+      SSL_CTX_set_verify(
+          ctx_, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
+    }
+  }
 }
 
-inline SSLServer::SSLServer(const std::function<bool(SSL_CTX &ssl_ctx)> &setup_ssl_ctx_callback) {
-	ctx_ = SSL_CTX_new(TLS_method());
-	if (ctx_) {
-		if (!setup_ssl_ctx_callback(*ctx_)) {
-			SSL_CTX_free(ctx_);
-			ctx_ = nullptr;
-		}
-	}
+inline SSLServer::SSLServer(
+    const std::function<bool(SSL_CTX &ssl_ctx)> &setup_ssl_ctx_callback) {
+  ctx_ = SSL_CTX_new(TLS_method());
+  if (ctx_) {
+    if (!setup_ssl_ctx_callback(*ctx_)) {
+      SSL_CTX_free(ctx_);
+      ctx_ = nullptr;
+    }
+  }
 }
 
 inline SSLServer::~SSLServer() {
-	if (ctx_) {
-		SSL_CTX_free(ctx_);
-	}
+  if (ctx_) { SSL_CTX_free(ctx_); }
 }
 
-inline bool SSLServer::is_valid() const {
-	return ctx_;
-}
+inline bool SSLServer::is_valid() const { return ctx_; }
 
-inline SSL_CTX *SSLServer::ssl_context() const {
-	return ctx_;
-}
+inline SSL_CTX *SSLServer::ssl_context() const { return ctx_; }
 
 inline bool SSLServer::process_and_close_socket(socket_t sock) {
-	auto ssl = detail::ssl_new(
-	    sock, ctx_, ctx_mutex_,
-	    [&](SSL *ssl2) {
-		    return detail::ssl_connect_or_accept_nonblocking(sock, ssl2, SSL_accept, read_timeout_sec_,
-		                                                     read_timeout_usec_);
-	    },
-	    [](SSL * /*ssl2*/) { return true; });
+  auto ssl = detail::ssl_new(
+      sock, ctx_, ctx_mutex_,
+      [&](SSL *ssl2) {
+        return detail::ssl_connect_or_accept_nonblocking(
+            sock, ssl2, SSL_accept, read_timeout_sec_, read_timeout_usec_);
+      },
+      [](SSL * /*ssl2*/) { return true; });
 
-	auto ret = false;
-	if (ssl) {
-		ret = detail::process_server_socket_ssl(
-		    svr_sock_, ssl, sock, keep_alive_max_count_, keep_alive_timeout_sec_, read_timeout_sec_, read_timeout_usec_,
-		    write_timeout_sec_, write_timeout_usec_,
-		    [this, ssl](Stream &strm, bool close_connection, bool &connection_closed) {
-			    return process_request(strm, close_connection, connection_closed, [&](Request &req) { req.ssl = ssl; });
-		    });
+  auto ret = false;
+  if (ssl) {
+    ret = detail::process_server_socket_ssl(
+        svr_sock_, ssl, sock, keep_alive_max_count_, keep_alive_timeout_sec_,
+        read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
+        write_timeout_usec_,
+        [this, ssl](Stream &strm, bool close_connection,
+                    bool &connection_closed) {
+          return process_request(strm, close_connection, connection_closed,
+                                 [&](Request &req) { req.ssl = ssl; });
+        });
 
-		// Shutdown gracefully if the result seemed successful, non-gracefully if
-		// the connection appeared to be closed.
-		const bool shutdown_gracefully = ret;
-		detail::ssl_delete(ctx_mutex_, ssl, shutdown_gracefully);
-	}
+    // Shutdown gracefully if the result seemed successful, non-gracefully if
+    // the connection appeared to be closed.
+    const bool shutdown_gracefully = ret;
+    detail::ssl_delete(ctx_mutex_, ssl, shutdown_gracefully);
+  }
 
-	detail::shutdown_socket(sock);
-	detail::close_socket(sock);
-	return ret;
+  detail::shutdown_socket(sock);
+  detail::close_socket(sock);
+  return ret;
 }
 
 // SSL HTTP client implementation
-inline SSLClient::SSLClient(const std::string &host) : SSLClient(host, 443, std::string(), std::string()) {
-}
+inline SSLClient::SSLClient(const std::string &host)
+    : SSLClient(host, 443, std::string(), std::string()) {}
 
-inline SSLClient::SSLClient(const std::string &host, int port) : SSLClient(host, port, std::string(), std::string()) {
-}
+inline SSLClient::SSLClient(const std::string &host, int port)
+    : SSLClient(host, port, std::string(), std::string()) {}
 
-inline SSLClient::SSLClient(const std::string &host, int port, const std::string &client_cert_path,
+inline SSLClient::SSLClient(const std::string &host, int port,
+                            const std::string &client_cert_path,
                             const std::string &client_key_path)
     : ClientImpl(host, port, client_cert_path, client_key_path) {
-	ctx_ = SSL_CTX_new(TLS_client_method());
+  ctx_ = SSL_CTX_new(TLS_client_method());
 
-	detail::split(&host_[0], &host_[host_.size()], '.',
-	              [&](const char *b, const char *e) { host_components_.emplace_back(b, e); });
+  detail::split(&host_[0], &host_[host_.size()], '.',
+                [&](const char *b, const char *e) {
+                  host_components_.emplace_back(b, e);
+                });
 
-	if (!client_cert_path.empty() && !client_key_path.empty()) {
-		if (SSL_CTX_use_certificate_file(ctx_, client_cert_path.c_str(), SSL_FILETYPE_PEM) != 1 ||
-		    SSL_CTX_use_PrivateKey_file(ctx_, client_key_path.c_str(), SSL_FILETYPE_PEM) != 1) {
-			SSL_CTX_free(ctx_);
-			ctx_ = nullptr;
-		}
-	}
+  if (!client_cert_path.empty() && !client_key_path.empty()) {
+    if (SSL_CTX_use_certificate_file(ctx_, client_cert_path.c_str(),
+                                     SSL_FILETYPE_PEM) != 1 ||
+        SSL_CTX_use_PrivateKey_file(ctx_, client_key_path.c_str(),
+                                    SSL_FILETYPE_PEM) != 1) {
+      SSL_CTX_free(ctx_);
+      ctx_ = nullptr;
+    }
+  }
 }
 
-inline SSLClient::SSLClient(const std::string &host, int port, X509 *client_cert, EVP_PKEY *client_key)
+inline SSLClient::SSLClient(const std::string &host, int port,
+                            X509 *client_cert, EVP_PKEY *client_key)
     : ClientImpl(host, port) {
-	ctx_ = SSL_CTX_new(TLS_client_method());
+  ctx_ = SSL_CTX_new(TLS_client_method());
 
-	detail::split(&host_[0], &host_[host_.size()], '.',
-	              [&](const char *b, const char *e) { host_components_.emplace_back(b, e); });
+  detail::split(&host_[0], &host_[host_.size()], '.',
+                [&](const char *b, const char *e) {
+                  host_components_.emplace_back(b, e);
+                });
 
-	if (client_cert != nullptr && client_key != nullptr) {
-		if (SSL_CTX_use_certificate(ctx_, client_cert) != 1 || SSL_CTX_use_PrivateKey(ctx_, client_key) != 1) {
-			SSL_CTX_free(ctx_);
-			ctx_ = nullptr;
-		}
-	}
+  if (client_cert != nullptr && client_key != nullptr) {
+    if (SSL_CTX_use_certificate(ctx_, client_cert) != 1 ||
+        SSL_CTX_use_PrivateKey(ctx_, client_key) != 1) {
+      SSL_CTX_free(ctx_);
+      ctx_ = nullptr;
+    }
+  }
 }
 
 inline SSLClient::~SSLClient() {
-	if (ctx_) {
-		SSL_CTX_free(ctx_);
-	}
-	// Make sure to shut down SSL since shutdown_ssl will resolve to the
-	// base function rather than the derived function once we get to the
-	// base class destructor, and won't free the SSL (causing a leak).
-	shutdown_ssl_impl(socket_, true);
+  if (ctx_) { SSL_CTX_free(ctx_); }
+  // Make sure to shut down SSL since shutdown_ssl will resolve to the
+  // base function rather than the derived function once we get to the
+  // base class destructor, and won't free the SSL (causing a leak).
+  shutdown_ssl_impl(socket_, true);
 }
 
-inline bool SSLClient::is_valid() const {
-	return ctx_;
-}
+inline bool SSLClient::is_valid() const { return ctx_; }
 
 inline void SSLClient::set_ca_cert_store(X509_STORE *ca_cert_store) {
-	if (ca_cert_store) {
-		if (ctx_) {
-			if (SSL_CTX_get_cert_store(ctx_) != ca_cert_store) {
-				// Free memory allocated for old cert and use new store `ca_cert_store`
-				SSL_CTX_set_cert_store(ctx_, ca_cert_store);
-			}
-		} else {
-			X509_STORE_free(ca_cert_store);
-		}
-	}
+  if (ca_cert_store) {
+    if (ctx_) {
+      if (SSL_CTX_get_cert_store(ctx_) != ca_cert_store) {
+        // Free memory allocated for old cert and use new store `ca_cert_store`
+        SSL_CTX_set_cert_store(ctx_, ca_cert_store);
+      }
+    } else {
+      X509_STORE_free(ca_cert_store);
+    }
+  }
 }
 
-inline void SSLClient::load_ca_cert_store(const char *ca_cert, std::size_t size) {
-	set_ca_cert_store(ClientImpl::create_ca_cert_store(ca_cert, size));
+inline void SSLClient::load_ca_cert_store(const char *ca_cert,
+                                          std::size_t size) {
+  set_ca_cert_store(ClientImpl::create_ca_cert_store(ca_cert, size));
 }
 
 inline long SSLClient::get_openssl_verify_result() const {
-	return verify_result_;
+  return verify_result_;
 }
 
-inline SSL_CTX *SSLClient::ssl_context() const {
-	return ctx_;
-}
+inline SSL_CTX *SSLClient::ssl_context() const { return ctx_; }
 
 inline bool SSLClient::create_and_connect_socket(Socket &socket, Error &error) {
-	if (!is_valid()) {
-		error = Error::SSLConnection;
-		return false;
-	}
-	return ClientImpl::create_and_connect_socket(socket, error);
+  if (!is_valid()) {
+    error = Error::SSLConnection;
+    return false;
+  }
+  return ClientImpl::create_and_connect_socket(socket, error);
 }
 
 // Assumes that socket_mutex_ is locked and that there are no requests in flight
-inline bool SSLClient::connect_with_proxy(Socket &socket, Response &res, bool &success, Error &error) {
-	success = true;
-	Response proxy_res;
-	if (!detail::process_client_socket(socket.sock, read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
-	                                   write_timeout_usec_, [&](Stream &strm) {
-		                                   Request req2;
-		                                   req2.method = "CONNECT";
-		                                   req2.path = host_and_port_;
-		                                   return process_request(strm, req2, proxy_res, false, error);
-	                                   })) {
-		// Thread-safe to close everything because we are assuming there are no
-		// requests in flight
-		shutdown_ssl(socket, true);
-		shutdown_socket(socket);
-		close_socket(socket);
-		success = false;
-		return false;
-	}
+inline bool SSLClient::connect_with_proxy(Socket &socket, Response &res,
+                                          bool &success, Error &error) {
+  success = true;
+  Response proxy_res;
+  if (!detail::process_client_socket(
+          socket.sock, read_timeout_sec_, read_timeout_usec_,
+          write_timeout_sec_, write_timeout_usec_, [&](Stream &strm) {
+            Request req2;
+            req2.method = "CONNECT";
+            req2.path = host_and_port_;
+            return process_request(strm, req2, proxy_res, false, error);
+          })) {
+    // Thread-safe to close everything because we are assuming there are no
+    // requests in flight
+    shutdown_ssl(socket, true);
+    shutdown_socket(socket);
+    close_socket(socket);
+    success = false;
+    return false;
+  }
 
-	if (proxy_res.status == StatusCode::ProxyAuthenticationRequired_407) {
-		if (!proxy_digest_auth_username_.empty() && !proxy_digest_auth_password_.empty()) {
-			std::map<std::string, std::string> auth;
-			if (detail::parse_www_authenticate(proxy_res, auth, true)) {
-				proxy_res = Response();
-				if (!detail::process_client_socket(socket.sock, read_timeout_sec_, read_timeout_usec_,
-				                                   write_timeout_sec_, write_timeout_usec_, [&](Stream &strm) {
-					                                   Request req3;
-					                                   req3.method = "CONNECT";
-					                                   req3.path = host_and_port_;
-					                                   req3.headers.insert(detail::make_digest_authentication_header(
-					                                       req3, auth, 1, detail::random_string(10),
-					                                       proxy_digest_auth_username_, proxy_digest_auth_password_,
-					                                       true));
-					                                   return process_request(strm, req3, proxy_res, false, error);
-				                                   })) {
-					// Thread-safe to close everything because we are assuming there are
-					// no requests in flight
-					shutdown_ssl(socket, true);
-					shutdown_socket(socket);
-					close_socket(socket);
-					success = false;
-					return false;
-				}
-			}
-		}
-	}
+  if (proxy_res.status == StatusCode::ProxyAuthenticationRequired_407) {
+    if (!proxy_digest_auth_username_.empty() &&
+        !proxy_digest_auth_password_.empty()) {
+      std::map<std::string, std::string> auth;
+      if (detail::parse_www_authenticate(proxy_res, auth, true)) {
+        proxy_res = Response();
+        if (!detail::process_client_socket(
+                socket.sock, read_timeout_sec_, read_timeout_usec_,
+                write_timeout_sec_, write_timeout_usec_, [&](Stream &strm) {
+                  Request req3;
+                  req3.method = "CONNECT";
+                  req3.path = host_and_port_;
+                  req3.headers.insert(detail::make_digest_authentication_header(
+                      req3, auth, 1, detail::random_string(10),
+                      proxy_digest_auth_username_, proxy_digest_auth_password_,
+                      true));
+                  return process_request(strm, req3, proxy_res, false, error);
+                })) {
+          // Thread-safe to close everything because we are assuming there are
+          // no requests in flight
+          shutdown_ssl(socket, true);
+          shutdown_socket(socket);
+          close_socket(socket);
+          success = false;
+          return false;
+        }
+      }
+    }
+  }
 
-	// If status code is not 200, proxy request is failed.
-	// Set error to ProxyConnection and return proxy response
-	// as the response of the request
-	if (proxy_res.status != StatusCode::OK_200) {
-		error = Error::ProxyConnection;
-		res = std::move(proxy_res);
-		// Thread-safe to close everything because we are assuming there are
-		// no requests in flight
-		shutdown_ssl(socket, true);
-		shutdown_socket(socket);
-		close_socket(socket);
-		return false;
-	}
+  // If status code is not 200, proxy request is failed.
+  // Set error to ProxyConnection and return proxy response
+  // as the response of the request
+  if (proxy_res.status != StatusCode::OK_200) {
+    error = Error::ProxyConnection;
+    res = std::move(proxy_res);
+    // Thread-safe to close everything because we are assuming there are
+    // no requests in flight
+    shutdown_ssl(socket, true);
+    shutdown_socket(socket);
+    close_socket(socket);
+    return false;
+  }
 
-	return true;
+  return true;
 }
 
 inline bool SSLClient::load_certs() {
-	auto ret = true;
+  auto ret = true;
 
-	std::call_once(initialize_cert_, [&]() {
-		std::lock_guard<std::mutex> guard(ctx_mutex_);
-		if (!ca_cert_file_path_.empty()) {
-			if (!SSL_CTX_load_verify_locations(ctx_, ca_cert_file_path_.c_str(), nullptr)) {
-				ret = false;
-			}
-		} else if (!ca_cert_dir_path_.empty()) {
-			if (!SSL_CTX_load_verify_locations(ctx_, nullptr, ca_cert_dir_path_.c_str())) {
-				ret = false;
-			}
-		} else {
-			auto loaded = false;
+  std::call_once(initialize_cert_, [&]() {
+    std::lock_guard<std::mutex> guard(ctx_mutex_);
+    if (!ca_cert_file_path_.empty()) {
+      if (!SSL_CTX_load_verify_locations(ctx_, ca_cert_file_path_.c_str(),
+                                         nullptr)) {
+        ret = false;
+      }
+    } else if (!ca_cert_dir_path_.empty()) {
+      if (!SSL_CTX_load_verify_locations(ctx_, nullptr,
+                                         ca_cert_dir_path_.c_str())) {
+        ret = false;
+      }
+    } else {
+      auto loaded = false;
 #ifdef _WIN32
-			loaded = detail::load_system_certs_on_windows(SSL_CTX_get_cert_store(ctx_));
+      loaded =
+          detail::load_system_certs_on_windows(SSL_CTX_get_cert_store(ctx_));
 #elif defined(CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN) && defined(__APPLE__)
 #if TARGET_OS_OSX
       loaded = detail::load_system_certs_on_macos(SSL_CTX_get_cert_store(ctx_));
 #endif // TARGET_OS_OSX
 #endif // _WIN32
-			if (!loaded) {
-				SSL_CTX_set_default_verify_paths(ctx_);
-			}
-		}
-	});
+      if (!loaded) { SSL_CTX_set_default_verify_paths(ctx_); }
+    }
+  });
 
-	return ret;
+  return ret;
 }
 
 inline bool SSLClient::initialize_ssl(Socket &socket, Error &error) {
-	auto ssl = detail::ssl_new(
-	    socket.sock, ctx_, ctx_mutex_,
-	    [&](SSL *ssl2) {
-		    if (server_certificate_verification_) {
-			    if (!load_certs()) {
-				    error = Error::SSLLoadingCerts;
-				    return false;
-			    }
-			    SSL_set_verify(ssl2, SSL_VERIFY_NONE, nullptr);
-		    }
+  auto ssl = detail::ssl_new(
+      socket.sock, ctx_, ctx_mutex_,
+      [&](SSL *ssl2) {
+        if (server_certificate_verification_) {
+          if (!load_certs()) {
+            error = Error::SSLLoadingCerts;
+            return false;
+          }
+          SSL_set_verify(ssl2, SSL_VERIFY_NONE, nullptr);
+        }
 
-		    if (!detail::ssl_connect_or_accept_nonblocking(socket.sock, ssl2, SSL_connect, connection_timeout_sec_,
-		                                                   connection_timeout_usec_)) {
-			    error = Error::SSLConnection;
-			    return false;
-		    }
+        if (!detail::ssl_connect_or_accept_nonblocking(
+                socket.sock, ssl2, SSL_connect, connection_timeout_sec_,
+                connection_timeout_usec_)) {
+          error = Error::SSLConnection;
+          return false;
+        }
 
-		    if (server_certificate_verification_) {
-			    verify_result_ = SSL_get_verify_result(ssl2);
+        if (server_certificate_verification_) {
+          verify_result_ = SSL_get_verify_result(ssl2);
 
-			    if (verify_result_ != X509_V_OK) {
-				    error = Error::SSLServerVerification;
-				    return false;
-			    }
+          if (verify_result_ != X509_V_OK) {
+            error = Error::SSLServerVerification;
+            return false;
+          }
 
-			    auto server_cert = SSL_get1_peer_certificate(ssl2);
+          auto server_cert = SSL_get1_peer_certificate(ssl2);
 
-			    if (server_cert == nullptr) {
-				    error = Error::SSLServerVerification;
-				    return false;
-			    }
+          if (server_cert == nullptr) {
+            error = Error::SSLServerVerification;
+            return false;
+          }
 
-			    if (!verify_host(server_cert)) {
-				    X509_free(server_cert);
-				    error = Error::SSLServerVerification;
-				    return false;
-			    }
-			    X509_free(server_cert);
-		    }
+          if (!verify_host(server_cert)) {
+            X509_free(server_cert);
+            error = Error::SSLServerVerification;
+            return false;
+          }
+          X509_free(server_cert);
+        }
 
-		    return true;
-	    },
-	    [&](SSL *ssl2) {
-		    // NOTE: With -Wold-style-cast, this can produce a warning, since
-		    //  SSL_set_tlsext_host_name is a macro (in OpenSSL), which contains
-		    //  an old style cast. Short of doing compiler specific pragma's
-		    //  here, we can't get rid of this warning. :'(
-		    SSL_set_tlsext_host_name(ssl2, host_.c_str());
-		    return true;
-	    });
+        return true;
+      },
+      [&](SSL *ssl2) {
+        // NOTE: With -Wold-style-cast, this can produce a warning, since
+        //  SSL_set_tlsext_host_name is a macro (in OpenSSL), which contains
+        //  an old style cast. Short of doing compiler specific pragma's
+        //  here, we can't get rid of this warning. :'(
+        SSL_set_tlsext_host_name(ssl2, host_.c_str());
+        return true;
+      });
 
-	if (ssl) {
-		socket.ssl = ssl;
-		return true;
-	}
+  if (ssl) {
+    socket.ssl = ssl;
+    return true;
+  }
 
-	shutdown_socket(socket);
-	close_socket(socket);
-	return false;
+  shutdown_socket(socket);
+  close_socket(socket);
+  return false;
 }
 
 inline void SSLClient::shutdown_ssl(Socket &socket, bool shutdown_gracefully) {
-	shutdown_ssl_impl(socket, shutdown_gracefully);
+  shutdown_ssl_impl(socket, shutdown_gracefully);
 }
 
-inline void SSLClient::shutdown_ssl_impl(Socket &socket, bool shutdown_gracefully) {
-	if (socket.sock == INVALID_SOCKET) {
-		assert(socket.ssl == nullptr);
-		return;
-	}
-	if (socket.ssl) {
-		detail::ssl_delete(ctx_mutex_, socket.ssl, shutdown_gracefully);
-		socket.ssl = nullptr;
-	}
-	assert(socket.ssl == nullptr);
+inline void SSLClient::shutdown_ssl_impl(Socket &socket,
+                                         bool shutdown_gracefully) {
+  if (socket.sock == INVALID_SOCKET) {
+    assert(socket.ssl == nullptr);
+    return;
+  }
+  if (socket.ssl) {
+    detail::ssl_delete(ctx_mutex_, socket.ssl, shutdown_gracefully);
+    socket.ssl = nullptr;
+  }
+  assert(socket.ssl == nullptr);
 }
 
-inline bool SSLClient::process_socket(const Socket &socket, std::function<bool(Stream &strm)> callback) {
-	assert(socket.ssl);
-	return detail::process_client_socket_ssl(socket.ssl, socket.sock, read_timeout_sec_, read_timeout_usec_,
-	                                         write_timeout_sec_, write_timeout_usec_, std::move(callback));
+inline bool
+SSLClient::process_socket(const Socket &socket,
+                          std::function<bool(Stream &strm)> callback) {
+  assert(socket.ssl);
+  return detail::process_client_socket_ssl(
+      socket.ssl, socket.sock, read_timeout_sec_, read_timeout_usec_,
+      write_timeout_sec_, write_timeout_usec_, std::move(callback));
 }
 
-inline bool SSLClient::is_ssl() const {
-	return true;
-}
+inline bool SSLClient::is_ssl() const { return true; }
 
 inline bool SSLClient::verify_host(X509 *server_cert) const {
-	/* Quote from RFC2818 section 3.1 "Server Identity"
+  /* Quote from RFC2818 section 3.1 "Server Identity"
 
-	   If a subjectAltName extension of type dNSName is present, that MUST
-	   be used as the identity. Otherwise, the (most specific) Common Name
-	   field in the Subject field of the certificate MUST be used. Although
-	   the use of the Common Name is existing practice, it is deprecated and
-	   Certification Authorities are encouraged to use the dNSName instead.
+     If a subjectAltName extension of type dNSName is present, that MUST
+     be used as the identity. Otherwise, the (most specific) Common Name
+     field in the Subject field of the certificate MUST be used. Although
+     the use of the Common Name is existing practice, it is deprecated and
+     Certification Authorities are encouraged to use the dNSName instead.
 
-	   Matching is performed using the matching rules specified by
-	   [RFC2459].  If more than one identity of a given type is present in
-	   the certificate (e.g., more than one dNSName name, a match in any one
-	   of the set is considered acceptable.) Names may contain the wildcard
-	   character * which is considered to match any single domain name
-	   component or component fragment. E.g., *.a.com matches foo.a.com but
-	   not bar.foo.a.com. f*.com matches foo.com but not bar.com.
+     Matching is performed using the matching rules specified by
+     [RFC2459].  If more than one identity of a given type is present in
+     the certificate (e.g., more than one dNSName name, a match in any one
+     of the set is considered acceptable.) Names may contain the wildcard
+     character * which is considered to match any single domain name
+     component or component fragment. E.g., *.a.com matches foo.a.com but
+     not bar.foo.a.com. f*.com matches foo.com but not bar.com.
 
-	   In some cases, the URI is specified as an IP address rather than a
-	   hostname. In this case, the iPAddress subjectAltName must be present
-	   in the certificate and must exactly match the IP in the URI.
+     In some cases, the URI is specified as an IP address rather than a
+     hostname. In this case, the iPAddress subjectAltName must be present
+     in the certificate and must exactly match the IP in the URI.
 
-	*/
-	return verify_host_with_subject_alt_name(server_cert) || verify_host_with_common_name(server_cert);
+  */
+  return verify_host_with_subject_alt_name(server_cert) ||
+         verify_host_with_common_name(server_cert);
 }
 
-inline bool SSLClient::verify_host_with_subject_alt_name(X509 *server_cert) const {
-	auto ret = false;
+inline bool
+SSLClient::verify_host_with_subject_alt_name(X509 *server_cert) const {
+  auto ret = false;
 
-	auto type = GEN_DNS;
+  auto type = GEN_DNS;
 
-	struct in6_addr addr6 {};
-	struct in_addr addr {};
-	size_t addr_len = 0;
+  struct in6_addr addr6 {};
+  struct in_addr addr {};
+  size_t addr_len = 0;
 
 #ifndef __MINGW32__
-	if (inet_pton(AF_INET6, host_.c_str(), &addr6)) {
-		type = GEN_IPADD;
-		addr_len = sizeof(struct in6_addr);
-	} else if (inet_pton(AF_INET, host_.c_str(), &addr)) {
-		type = GEN_IPADD;
-		addr_len = sizeof(struct in_addr);
-	}
+  if (inet_pton(AF_INET6, host_.c_str(), &addr6)) {
+    type = GEN_IPADD;
+    addr_len = sizeof(struct in6_addr);
+  } else if (inet_pton(AF_INET, host_.c_str(), &addr)) {
+    type = GEN_IPADD;
+    addr_len = sizeof(struct in_addr);
+  }
 #endif
 
-	auto alt_names = static_cast<const struct stack_st_GENERAL_NAME *>(
-	    X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
+  auto alt_names = static_cast<const struct stack_st_GENERAL_NAME *>(
+      X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
 
-	if (alt_names) {
-		auto dsn_matched = false;
-		auto ip_matched = false;
+  if (alt_names) {
+    auto dsn_matched = false;
+    auto ip_matched = false;
 
-		auto count = sk_GENERAL_NAME_num(alt_names);
+    auto count = sk_GENERAL_NAME_num(alt_names);
 
-		for (decltype(count) i = 0; i < count && !dsn_matched; i++) {
-			auto val = sk_GENERAL_NAME_value(alt_names, i);
-			if (val->type == type) {
-				auto name = reinterpret_cast<const char *>(ASN1_STRING_get0_data(val->d.ia5));
-				auto name_len = static_cast<size_t>(ASN1_STRING_length(val->d.ia5));
+    for (decltype(count) i = 0; i < count && !dsn_matched; i++) {
+      auto val = sk_GENERAL_NAME_value(alt_names, i);
+      if (val->type == type) {
+        auto name =
+            reinterpret_cast<const char *>(ASN1_STRING_get0_data(val->d.ia5));
+        auto name_len = static_cast<size_t>(ASN1_STRING_length(val->d.ia5));
 
-				switch (type) {
-				case GEN_DNS:
-					dsn_matched = check_host_name(name, name_len);
-					break;
+        switch (type) {
+        case GEN_DNS: dsn_matched = check_host_name(name, name_len); break;
 
-				case GEN_IPADD:
-					if (!memcmp(&addr6, name, addr_len) || !memcmp(&addr, name, addr_len)) {
-						ip_matched = true;
-					}
-					break;
-				}
-			}
-		}
+        case GEN_IPADD:
+          if (!memcmp(&addr6, name, addr_len) ||
+              !memcmp(&addr, name, addr_len)) {
+            ip_matched = true;
+          }
+          break;
+        }
+      }
+    }
 
-		if (dsn_matched || ip_matched) {
-			ret = true;
-		}
-	}
+    if (dsn_matched || ip_matched) { ret = true; }
+  }
 
-	GENERAL_NAMES_free(
-	    const_cast<STACK_OF(GENERAL_NAME) *>(reinterpret_cast<const STACK_OF(GENERAL_NAME) *>(alt_names)));
-	return ret;
+  GENERAL_NAMES_free(const_cast<STACK_OF(GENERAL_NAME) *>(
+      reinterpret_cast<const STACK_OF(GENERAL_NAME) *>(alt_names)));
+  return ret;
 }
 
 inline bool SSLClient::verify_host_with_common_name(X509 *server_cert) const {
-	const auto subject_name = X509_get_subject_name(server_cert);
+  const auto subject_name = X509_get_subject_name(server_cert);
 
-	if (subject_name != nullptr) {
-		char name[BUFSIZ];
-		auto name_len = X509_NAME_get_text_by_NID(subject_name, NID_commonName, name, sizeof(name));
+  if (subject_name != nullptr) {
+    char name[BUFSIZ];
+    auto name_len = X509_NAME_get_text_by_NID(subject_name, NID_commonName,
+                                              name, sizeof(name));
 
-		if (name_len != -1) {
-			return check_host_name(name, static_cast<size_t>(name_len));
-		}
-	}
+    if (name_len != -1) {
+      return check_host_name(name, static_cast<size_t>(name_len));
+    }
+  }
 
-	return false;
+  return false;
 }
 
-inline bool SSLClient::check_host_name(const char *pattern, size_t pattern_len) const {
-	if (host_.size() == pattern_len && host_ == pattern) {
-		return true;
-	}
+inline bool SSLClient::check_host_name(const char *pattern,
+                                       size_t pattern_len) const {
+  if (host_.size() == pattern_len && host_ == pattern) { return true; }
 
-	// Wildcard match
-	// https://bugs.launchpad.net/ubuntu/+source/firefox-3.0/+bug/376484
-	std::vector<std::string> pattern_components;
-	detail::split(&pattern[0], &pattern[pattern_len], '.',
-	              [&](const char *b, const char *e) { pattern_components.emplace_back(b, e); });
+  // Wildcard match
+  // https://bugs.launchpad.net/ubuntu/+source/firefox-3.0/+bug/376484
+  std::vector<std::string> pattern_components;
+  detail::split(&pattern[0], &pattern[pattern_len], '.',
+                [&](const char *b, const char *e) {
+                  pattern_components.emplace_back(b, e);
+                });
 
-	if (host_components_.size() != pattern_components.size()) {
-		return false;
-	}
+  if (host_components_.size() != pattern_components.size()) { return false; }
 
-	auto itr = pattern_components.begin();
-	for (const auto &h : host_components_) {
-		auto &p = *itr;
-		if (p != h && p != "*") {
-			auto partial_match = (p.size() > 0 && p[p.size() - 1] == '*' && !p.compare(0, p.size() - 1, h));
-			if (!partial_match) {
-				return false;
-			}
-		}
-		++itr;
-	}
+  auto itr = pattern_components.begin();
+  for (const auto &h : host_components_) {
+    auto &p = *itr;
+    if (p != h && p != "*") {
+      auto partial_match = (p.size() > 0 && p[p.size() - 1] == '*' &&
+                            !p.compare(0, p.size() - 1, h));
+      if (!partial_match) { return false; }
+    }
+    ++itr;
+  }
 
-	return true;
+  return true;
 }
 #endif
 
 // Universal client implementation
-inline Client::Client(const std::string &scheme_host_port) : Client(scheme_host_port, std::string(), std::string()) {
-}
+inline Client::Client(const std::string &scheme_host_port)
+    : Client(scheme_host_port, std::string(), std::string()) {}
 
-inline Client::Client(const std::string &scheme_host_port, const std::string &client_cert_path,
+inline Client::Client(const std::string &scheme_host_port,
+                      const std::string &client_cert_path,
                       const std::string &client_key_path) {
-	const Regex re(R"((?:([a-z]+):\/\/)?(?:\[([\d:]+)\]|([^:/?#]+))(?::(\d+))?)");
+  const Regex re(
+      R"((?:([a-z]+):\/\/)?(?:\[([\d:]+)\]|([^:/?#]+))(?::(\d+))?)");
 
-	Match m;
-	if (RegexMatch(scheme_host_port, m, re)) {
-		auto scheme = m[1].str();
+  Match m;
+  if (RegexMatch(scheme_host_port, m, re)) {
+    auto scheme = m[1].str();
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-		if (!scheme.empty() && (scheme != "http" && scheme != "https")) {
+    if (!scheme.empty() && (scheme != "http" && scheme != "https")) {
 #else
-		if (!scheme.empty() && scheme != "http") {
+    if (!scheme.empty() && scheme != "http") {
 #endif
 #ifndef CPPHTTPLIB_NO_EXCEPTIONS
-			std::string msg = "'" + scheme + "' scheme is not supported.";
-			throw std::invalid_argument(msg);
+      std::string msg = "'" + scheme + "' scheme is not supported.";
+      throw std::invalid_argument(msg);
 #endif
-			return;
-		}
+      return;
+    }
 
-		auto is_ssl = scheme == "https";
+    auto is_ssl = scheme == "https";
 
-		auto host = m[2].str();
-		if (host.empty()) {
-			host = m[3].str();
-		}
+    auto host = m[2].str();
+    if (host.empty()) { host = m[3].str(); }
 
-		auto port_str = m[4].str();
-		auto port = !port_str.empty() ? std::stoi(port_str) : (is_ssl ? 443 : 80);
+    auto port_str = m[4].str();
+    auto port = !port_str.empty() ? std::stoi(port_str) : (is_ssl ? 443 : 80);
 
-		if (is_ssl) {
+    if (is_ssl) {
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-			cli_ = detail::make_unique<SSLClient>(host, port, client_cert_path, client_key_path);
-			is_ssl_ = is_ssl;
+      cli_ = detail::make_unique<SSLClient>(host, port, client_cert_path,
+                                            client_key_path);
+      is_ssl_ = is_ssl;
 #endif
-		} else {
-			cli_ = detail::make_unique<ClientImpl>(host, port, client_cert_path, client_key_path);
-		}
-	} else {
-		cli_ = detail::make_unique<ClientImpl>(scheme_host_port, 80, client_cert_path, client_key_path);
-	}
+    } else {
+      cli_ = detail::make_unique<ClientImpl>(host, port, client_cert_path,
+                                             client_key_path);
+    }
+  } else {
+    cli_ = detail::make_unique<ClientImpl>(scheme_host_port, 80,
+                                           client_cert_path, client_key_path);
+  }
 }
 
-inline Client::Client(const std::string &host, int port) : cli_(detail::make_unique<ClientImpl>(host, port)) {
-}
+inline Client::Client(const std::string &host, int port)
+    : cli_(detail::make_unique<ClientImpl>(host, port)) {}
 
-inline Client::Client(const std::string &host, int port, const std::string &client_cert_path,
+inline Client::Client(const std::string &host, int port,
+                      const std::string &client_cert_path,
                       const std::string &client_key_path)
-    : cli_(detail::make_unique<ClientImpl>(host, port, client_cert_path, client_key_path)) {
-}
+    : cli_(detail::make_unique<ClientImpl>(host, port, client_cert_path,
+                                           client_key_path)) {}
 
 inline Client::~Client() = default;
 
 inline bool Client::is_valid() const {
-	return cli_ != nullptr && cli_->is_valid();
+  return cli_ != nullptr && cli_->is_valid();
 }
 
-inline Result Client::Get(const std::string &path) {
-	return cli_->Get(path);
-}
+inline Result Client::Get(const std::string &path) { return cli_->Get(path); }
 inline Result Client::Get(const std::string &path, const Headers &headers) {
-	return cli_->Get(path, headers);
+  return cli_->Get(path, headers);
 }
 inline Result Client::Get(const std::string &path, Progress progress) {
-	return cli_->Get(path, std::move(progress));
+  return cli_->Get(path, std::move(progress));
 }
-inline Result Client::Get(const std::string &path, const Headers &headers, Progress progress) {
-	return cli_->Get(path, headers, std::move(progress));
-}
-inline Result Client::Get(const std::string &path, ContentReceiver content_receiver) {
-	return cli_->Get(path, std::move(content_receiver));
-}
-inline Result Client::Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver) {
-	return cli_->Get(path, headers, std::move(content_receiver));
-}
-inline Result Client::Get(const std::string &path, ContentReceiver content_receiver, Progress progress) {
-	return cli_->Get(path, std::move(content_receiver), std::move(progress));
-}
-inline Result Client::Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver,
+inline Result Client::Get(const std::string &path, const Headers &headers,
                           Progress progress) {
-	return cli_->Get(path, headers, std::move(content_receiver), std::move(progress));
+  return cli_->Get(path, headers, std::move(progress));
 }
-inline Result Client::Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver) {
-	return cli_->Get(path, std::move(response_handler), std::move(content_receiver));
-}
-inline Result Client::Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
+inline Result Client::Get(const std::string &path,
                           ContentReceiver content_receiver) {
-	return cli_->Get(path, headers, std::move(response_handler), std::move(content_receiver));
+  return cli_->Get(path, std::move(content_receiver));
 }
-inline Result Client::Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver,
-                          Progress progress) {
-	return cli_->Get(path, std::move(response_handler), std::move(content_receiver), std::move(progress));
+inline Result Client::Get(const std::string &path, const Headers &headers,
+                          ContentReceiver content_receiver) {
+  return cli_->Get(path, headers, std::move(content_receiver));
 }
-inline Result Client::Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
+inline Result Client::Get(const std::string &path,
                           ContentReceiver content_receiver, Progress progress) {
-	return cli_->Get(path, headers, std::move(response_handler), std::move(content_receiver), std::move(progress));
+  return cli_->Get(path, std::move(content_receiver), std::move(progress));
 }
-inline Result Client::Get(const std::string &path, const Params &params, const Headers &headers, Progress progress) {
-	return cli_->Get(path, params, headers, progress);
-}
-inline Result Client::Get(const std::string &path, const Params &params, const Headers &headers,
+inline Result Client::Get(const std::string &path, const Headers &headers,
                           ContentReceiver content_receiver, Progress progress) {
-	return cli_->Get(path, params, headers, content_receiver, progress);
+  return cli_->Get(path, headers, std::move(content_receiver),
+                   std::move(progress));
 }
-inline Result Client::Get(const std::string &path, const Params &params, const Headers &headers,
-                          ResponseHandler response_handler, ContentReceiver content_receiver, Progress progress) {
-	return cli_->Get(path, params, headers, response_handler, content_receiver, progress);
+inline Result Client::Get(const std::string &path,
+                          ResponseHandler response_handler,
+                          ContentReceiver content_receiver) {
+  return cli_->Get(path, std::move(response_handler),
+                   std::move(content_receiver));
+}
+inline Result Client::Get(const std::string &path, const Headers &headers,
+                          ResponseHandler response_handler,
+                          ContentReceiver content_receiver) {
+  return cli_->Get(path, headers, std::move(response_handler),
+                   std::move(content_receiver));
+}
+inline Result Client::Get(const std::string &path,
+                          ResponseHandler response_handler,
+                          ContentReceiver content_receiver, Progress progress) {
+  return cli_->Get(path, std::move(response_handler),
+                   std::move(content_receiver), std::move(progress));
+}
+inline Result Client::Get(const std::string &path, const Headers &headers,
+                          ResponseHandler response_handler,
+                          ContentReceiver content_receiver, Progress progress) {
+  return cli_->Get(path, headers, std::move(response_handler),
+                   std::move(content_receiver), std::move(progress));
+}
+inline Result Client::Get(const std::string &path, const Params &params,
+                          const Headers &headers, Progress progress) {
+  return cli_->Get(path, params, headers, progress);
+}
+inline Result Client::Get(const std::string &path, const Params &params,
+                          const Headers &headers,
+                          ContentReceiver content_receiver, Progress progress) {
+  return cli_->Get(path, params, headers, content_receiver, progress);
+}
+inline Result Client::Get(const std::string &path, const Params &params,
+                          const Headers &headers,
+                          ResponseHandler response_handler,
+                          ContentReceiver content_receiver, Progress progress) {
+  return cli_->Get(path, params, headers, response_handler, content_receiver,
+                   progress);
 }
 
-inline Result Client::Head(const std::string &path) {
-	return cli_->Head(path);
-}
+inline Result Client::Head(const std::string &path) { return cli_->Head(path); }
 inline Result Client::Head(const std::string &path, const Headers &headers) {
-	return cli_->Head(path, headers);
+  return cli_->Head(path, headers);
 }
 
-inline Result Client::Post(const std::string &path) {
-	return cli_->Post(path);
-}
+inline Result Client::Post(const std::string &path) { return cli_->Post(path); }
 inline Result Client::Post(const std::string &path, const Headers &headers) {
-	return cli_->Post(path, headers);
+  return cli_->Post(path, headers);
 }
-inline Result Client::Post(const std::string &path, const char *body, size_t content_length,
+inline Result Client::Post(const std::string &path, const char *body,
+                           size_t content_length,
                            const std::string &content_type) {
-	return cli_->Post(path, body, content_length, content_type);
-}
-inline Result Client::Post(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-                           const std::string &content_type) {
-	return cli_->Post(path, headers, body, content_length, content_type);
-}
-inline Result Client::Post(const std::string &path, const std::string &body, const std::string &content_type) {
-	return cli_->Post(path, body, content_type);
-}
-inline Result Client::Post(const std::string &path, const Headers &headers, const std::string &body,
-                           const std::string &content_type) {
-	return cli_->Post(path, headers, body, content_type);
-}
-inline Result Client::Post(const std::string &path, size_t content_length, ContentProvider content_provider,
-                           const std::string &content_type) {
-	return cli_->Post(path, content_length, std::move(content_provider), content_type);
-}
-inline Result Client::Post(const std::string &path, ContentProviderWithoutLength content_provider,
-                           const std::string &content_type) {
-	return cli_->Post(path, std::move(content_provider), content_type);
-}
-inline Result Client::Post(const std::string &path, const Headers &headers, size_t content_length,
-                           ContentProvider content_provider, const std::string &content_type) {
-	return cli_->Post(path, headers, content_length, std::move(content_provider), content_type);
+  return cli_->Post(path, body, content_length, content_type);
 }
 inline Result Client::Post(const std::string &path, const Headers &headers,
-                           ContentProviderWithoutLength content_provider, const std::string &content_type) {
-	return cli_->Post(path, headers, std::move(content_provider), content_type);
+                           const char *body, size_t content_length,
+                           const std::string &content_type) {
+  return cli_->Post(path, headers, body, content_length, content_type);
+}
+inline Result Client::Post(const std::string &path, const std::string &body,
+                           const std::string &content_type) {
+  return cli_->Post(path, body, content_type);
+}
+inline Result Client::Post(const std::string &path, const Headers &headers,
+                           const std::string &body,
+                           const std::string &content_type) {
+  return cli_->Post(path, headers, body, content_type);
+}
+inline Result Client::Post(const std::string &path, size_t content_length,
+                           ContentProvider content_provider,
+                           const std::string &content_type) {
+  return cli_->Post(path, content_length, std::move(content_provider),
+                    content_type);
+}
+inline Result Client::Post(const std::string &path,
+                           ContentProviderWithoutLength content_provider,
+                           const std::string &content_type) {
+  return cli_->Post(path, std::move(content_provider), content_type);
+}
+inline Result Client::Post(const std::string &path, const Headers &headers,
+                           size_t content_length,
+                           ContentProvider content_provider,
+                           const std::string &content_type) {
+  return cli_->Post(path, headers, content_length, std::move(content_provider),
+                    content_type);
+}
+inline Result Client::Post(const std::string &path, const Headers &headers,
+                           ContentProviderWithoutLength content_provider,
+                           const std::string &content_type) {
+  return cli_->Post(path, headers, std::move(content_provider), content_type);
 }
 inline Result Client::Post(const std::string &path, const Params &params) {
-	return cli_->Post(path, params);
+  return cli_->Post(path, params);
 }
-inline Result Client::Post(const std::string &path, const Headers &headers, const Params &params) {
-	return cli_->Post(path, headers, params);
+inline Result Client::Post(const std::string &path, const Headers &headers,
+                           const Params &params) {
+  return cli_->Post(path, headers, params);
 }
-inline Result Client::Post(const std::string &path, const MultipartFormDataItems &items) {
-	return cli_->Post(path, items);
+inline Result Client::Post(const std::string &path,
+                           const MultipartFormDataItems &items) {
+  return cli_->Post(path, items);
 }
-inline Result Client::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items) {
-	return cli_->Post(path, headers, items);
+inline Result Client::Post(const std::string &path, const Headers &headers,
+                           const MultipartFormDataItems &items) {
+  return cli_->Post(path, headers, items);
 }
-inline Result Client::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+inline Result Client::Post(const std::string &path, const Headers &headers,
+                           const MultipartFormDataItems &items,
                            const std::string &boundary) {
-	return cli_->Post(path, headers, items, boundary);
+  return cli_->Post(path, headers, items, boundary);
 }
-inline Result Client::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-                           const MultipartFormDataProviderItems &provider_items) {
-	return cli_->Post(path, headers, items, provider_items);
+inline Result
+Client::Post(const std::string &path, const Headers &headers,
+             const MultipartFormDataItems &items,
+             const MultipartFormDataProviderItems &provider_items) {
+  return cli_->Post(path, headers, items, provider_items);
 }
-inline Result Client::Put(const std::string &path) {
-	return cli_->Put(path);
-}
-inline Result Client::Put(const std::string &path, const char *body, size_t content_length,
+inline Result Client::Put(const std::string &path) { return cli_->Put(path); }
+inline Result Client::Put(const std::string &path, const char *body,
+                          size_t content_length,
                           const std::string &content_type) {
-	return cli_->Put(path, body, content_length, content_type);
-}
-inline Result Client::Put(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-                          const std::string &content_type) {
-	return cli_->Put(path, headers, body, content_length, content_type);
-}
-inline Result Client::Put(const std::string &path, const std::string &body, const std::string &content_type) {
-	return cli_->Put(path, body, content_type);
-}
-inline Result Client::Put(const std::string &path, const Headers &headers, const std::string &body,
-                          const std::string &content_type) {
-	return cli_->Put(path, headers, body, content_type);
-}
-inline Result Client::Put(const std::string &path, size_t content_length, ContentProvider content_provider,
-                          const std::string &content_type) {
-	return cli_->Put(path, content_length, std::move(content_provider), content_type);
-}
-inline Result Client::Put(const std::string &path, ContentProviderWithoutLength content_provider,
-                          const std::string &content_type) {
-	return cli_->Put(path, std::move(content_provider), content_type);
-}
-inline Result Client::Put(const std::string &path, const Headers &headers, size_t content_length,
-                          ContentProvider content_provider, const std::string &content_type) {
-	return cli_->Put(path, headers, content_length, std::move(content_provider), content_type);
+  return cli_->Put(path, body, content_length, content_type);
 }
 inline Result Client::Put(const std::string &path, const Headers &headers,
-                          ContentProviderWithoutLength content_provider, const std::string &content_type) {
-	return cli_->Put(path, headers, std::move(content_provider), content_type);
+                          const char *body, size_t content_length,
+                          const std::string &content_type) {
+  return cli_->Put(path, headers, body, content_length, content_type);
+}
+inline Result Client::Put(const std::string &path, const std::string &body,
+                          const std::string &content_type) {
+  return cli_->Put(path, body, content_type);
+}
+inline Result Client::Put(const std::string &path, const Headers &headers,
+                          const std::string &body,
+                          const std::string &content_type) {
+  return cli_->Put(path, headers, body, content_type);
+}
+inline Result Client::Put(const std::string &path, size_t content_length,
+                          ContentProvider content_provider,
+                          const std::string &content_type) {
+  return cli_->Put(path, content_length, std::move(content_provider),
+                   content_type);
+}
+inline Result Client::Put(const std::string &path,
+                          ContentProviderWithoutLength content_provider,
+                          const std::string &content_type) {
+  return cli_->Put(path, std::move(content_provider), content_type);
+}
+inline Result Client::Put(const std::string &path, const Headers &headers,
+                          size_t content_length,
+                          ContentProvider content_provider,
+                          const std::string &content_type) {
+  return cli_->Put(path, headers, content_length, std::move(content_provider),
+                   content_type);
+}
+inline Result Client::Put(const std::string &path, const Headers &headers,
+                          ContentProviderWithoutLength content_provider,
+                          const std::string &content_type) {
+  return cli_->Put(path, headers, std::move(content_provider), content_type);
 }
 inline Result Client::Put(const std::string &path, const Params &params) {
-	return cli_->Put(path, params);
+  return cli_->Put(path, params);
 }
-inline Result Client::Put(const std::string &path, const Headers &headers, const Params &params) {
-	return cli_->Put(path, headers, params);
+inline Result Client::Put(const std::string &path, const Headers &headers,
+                          const Params &params) {
+  return cli_->Put(path, headers, params);
 }
-inline Result Client::Put(const std::string &path, const MultipartFormDataItems &items) {
-	return cli_->Put(path, items);
+inline Result Client::Put(const std::string &path,
+                          const MultipartFormDataItems &items) {
+  return cli_->Put(path, items);
 }
-inline Result Client::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items) {
-	return cli_->Put(path, headers, items);
+inline Result Client::Put(const std::string &path, const Headers &headers,
+                          const MultipartFormDataItems &items) {
+  return cli_->Put(path, headers, items);
 }
-inline Result Client::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+inline Result Client::Put(const std::string &path, const Headers &headers,
+                          const MultipartFormDataItems &items,
                           const std::string &boundary) {
-	return cli_->Put(path, headers, items, boundary);
+  return cli_->Put(path, headers, items, boundary);
 }
-inline Result Client::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
-                          const MultipartFormDataProviderItems &provider_items) {
-	return cli_->Put(path, headers, items, provider_items);
+inline Result
+Client::Put(const std::string &path, const Headers &headers,
+            const MultipartFormDataItems &items,
+            const MultipartFormDataProviderItems &provider_items) {
+  return cli_->Put(path, headers, items, provider_items);
 }
 inline Result Client::Patch(const std::string &path) {
-	return cli_->Patch(path);
+  return cli_->Patch(path);
 }
-inline Result Client::Patch(const std::string &path, const char *body, size_t content_length,
+inline Result Client::Patch(const std::string &path, const char *body,
+                            size_t content_length,
                             const std::string &content_type) {
-	return cli_->Patch(path, body, content_length, content_type);
-}
-inline Result Client::Patch(const std::string &path, const Headers &headers, const char *body, size_t content_length,
-                            const std::string &content_type) {
-	return cli_->Patch(path, headers, body, content_length, content_type);
-}
-inline Result Client::Patch(const std::string &path, const std::string &body, const std::string &content_type) {
-	return cli_->Patch(path, body, content_type);
-}
-inline Result Client::Patch(const std::string &path, const Headers &headers, const std::string &body,
-                            const std::string &content_type) {
-	return cli_->Patch(path, headers, body, content_type);
-}
-inline Result Client::Patch(const std::string &path, size_t content_length, ContentProvider content_provider,
-                            const std::string &content_type) {
-	return cli_->Patch(path, content_length, std::move(content_provider), content_type);
-}
-inline Result Client::Patch(const std::string &path, ContentProviderWithoutLength content_provider,
-                            const std::string &content_type) {
-	return cli_->Patch(path, std::move(content_provider), content_type);
-}
-inline Result Client::Patch(const std::string &path, const Headers &headers, size_t content_length,
-                            ContentProvider content_provider, const std::string &content_type) {
-	return cli_->Patch(path, headers, content_length, std::move(content_provider), content_type);
+  return cli_->Patch(path, body, content_length, content_type);
 }
 inline Result Client::Patch(const std::string &path, const Headers &headers,
-                            ContentProviderWithoutLength content_provider, const std::string &content_type) {
-	return cli_->Patch(path, headers, std::move(content_provider), content_type);
+                            const char *body, size_t content_length,
+                            const std::string &content_type) {
+  return cli_->Patch(path, headers, body, content_length, content_type);
+}
+inline Result Client::Patch(const std::string &path, const std::string &body,
+                            const std::string &content_type) {
+  return cli_->Patch(path, body, content_type);
+}
+inline Result Client::Patch(const std::string &path, const Headers &headers,
+                            const std::string &body,
+                            const std::string &content_type) {
+  return cli_->Patch(path, headers, body, content_type);
+}
+inline Result Client::Patch(const std::string &path, size_t content_length,
+                            ContentProvider content_provider,
+                            const std::string &content_type) {
+  return cli_->Patch(path, content_length, std::move(content_provider),
+                     content_type);
+}
+inline Result Client::Patch(const std::string &path,
+                            ContentProviderWithoutLength content_provider,
+                            const std::string &content_type) {
+  return cli_->Patch(path, std::move(content_provider), content_type);
+}
+inline Result Client::Patch(const std::string &path, const Headers &headers,
+                            size_t content_length,
+                            ContentProvider content_provider,
+                            const std::string &content_type) {
+  return cli_->Patch(path, headers, content_length, std::move(content_provider),
+                     content_type);
+}
+inline Result Client::Patch(const std::string &path, const Headers &headers,
+                            ContentProviderWithoutLength content_provider,
+                            const std::string &content_type) {
+  return cli_->Patch(path, headers, std::move(content_provider), content_type);
 }
 inline Result Client::Delete(const std::string &path) {
-	return cli_->Delete(path);
+  return cli_->Delete(path);
 }
 inline Result Client::Delete(const std::string &path, const Headers &headers) {
-	return cli_->Delete(path, headers);
+  return cli_->Delete(path, headers);
 }
-inline Result Client::Delete(const std::string &path, const char *body, size_t content_length,
+inline Result Client::Delete(const std::string &path, const char *body,
+                             size_t content_length,
                              const std::string &content_type) {
-	return cli_->Delete(path, body, content_length, content_type);
+  return cli_->Delete(path, body, content_length, content_type);
 }
-inline Result Client::Delete(const std::string &path, const Headers &headers, const char *body, size_t content_length,
+inline Result Client::Delete(const std::string &path, const Headers &headers,
+                             const char *body, size_t content_length,
                              const std::string &content_type) {
-	return cli_->Delete(path, headers, body, content_length, content_type);
+  return cli_->Delete(path, headers, body, content_length, content_type);
 }
-inline Result Client::Delete(const std::string &path, const std::string &body, const std::string &content_type) {
-	return cli_->Delete(path, body, content_type);
-}
-inline Result Client::Delete(const std::string &path, const Headers &headers, const std::string &body,
+inline Result Client::Delete(const std::string &path, const std::string &body,
                              const std::string &content_type) {
-	return cli_->Delete(path, headers, body, content_type);
+  return cli_->Delete(path, body, content_type);
+}
+inline Result Client::Delete(const std::string &path, const Headers &headers,
+                             const std::string &body,
+                             const std::string &content_type) {
+  return cli_->Delete(path, headers, body, content_type);
 }
 inline Result Client::Options(const std::string &path) {
-	return cli_->Options(path);
+  return cli_->Options(path);
 }
 inline Result Client::Options(const std::string &path, const Headers &headers) {
-	return cli_->Options(path, headers);
+  return cli_->Options(path, headers);
 }
 
 inline bool Client::send(Request &req, Response &res, Error &error) {
-	return cli_->send(req, res, error);
+  return cli_->send(req, res, error);
 }
 
-inline Result Client::send(const Request &req) {
-	return cli_->send(req);
-}
+inline Result Client::send(const Request &req) { return cli_->send(req); }
 
-inline void Client::stop() {
-	cli_->stop();
-}
+inline void Client::stop() { cli_->stop(); }
 
-inline std::string Client::host() const {
-	return cli_->host();
-}
+inline std::string Client::host() const { return cli_->host(); }
 
-inline int Client::port() const {
-	return cli_->port();
-}
+inline int Client::port() const { return cli_->port(); }
 
-inline size_t Client::is_socket_open() const {
-	return cli_->is_socket_open();
-}
+inline size_t Client::is_socket_open() const { return cli_->is_socket_open(); }
 
-inline socket_t Client::socket() const {
-	return cli_->socket();
-}
+inline socket_t Client::socket() const { return cli_->socket(); }
 
-inline void Client::set_hostname_addr_map(std::map<std::string, std::string> addr_map) {
-	cli_->set_hostname_addr_map(std::move(addr_map));
+inline void
+Client::set_hostname_addr_map(std::map<std::string, std::string> addr_map) {
+  cli_->set_hostname_addr_map(std::move(addr_map));
 }
 
 inline void Client::set_default_headers(Headers headers) {
-	cli_->set_default_headers(std::move(headers));
+  cli_->set_default_headers(std::move(headers));
 }
 
-inline void Client::set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer) {
-	cli_->set_header_writer(writer);
+inline void Client::set_header_writer(
+    std::function<ssize_t(Stream &, Headers &)> const &writer) {
+  cli_->set_header_writer(writer);
 }
 
 inline void Client::set_address_family(int family) {
-	cli_->set_address_family(family);
+  cli_->set_address_family(family);
 }
 
-inline void Client::set_tcp_nodelay(bool on) {
-	cli_->set_tcp_nodelay(on);
-}
+inline void Client::set_tcp_nodelay(bool on) { cli_->set_tcp_nodelay(on); }
 
 inline void Client::set_socket_options(SocketOptions socket_options) {
-	cli_->set_socket_options(std::move(socket_options));
+  cli_->set_socket_options(std::move(socket_options));
 }
 
 inline void Client::set_connection_timeout(time_t sec, time_t usec) {
-	cli_->set_connection_timeout(sec, usec);
+  cli_->set_connection_timeout(sec, usec);
 }
 
 inline void Client::set_read_timeout(time_t sec, time_t usec) {
-	cli_->set_read_timeout(sec, usec);
+  cli_->set_read_timeout(sec, usec);
 }
 
 inline void Client::set_write_timeout(time_t sec, time_t usec) {
-	cli_->set_write_timeout(sec, usec);
+  cli_->set_write_timeout(sec, usec);
 }
 
-inline void Client::set_basic_auth(const std::string &username, const std::string &password) {
-	cli_->set_basic_auth(username, password);
+inline void Client::set_basic_auth(const std::string &username,
+                                   const std::string &password) {
+  cli_->set_basic_auth(username, password);
 }
 inline void Client::set_bearer_token_auth(const std::string &token) {
-	cli_->set_bearer_token_auth(token);
+  cli_->set_bearer_token_auth(token);
 }
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline void Client::set_digest_auth(const std::string &username, const std::string &password) {
-	cli_->set_digest_auth(username, password);
+inline void Client::set_digest_auth(const std::string &username,
+                                    const std::string &password) {
+  cli_->set_digest_auth(username, password);
 }
 #endif
 
-inline void Client::set_keep_alive(bool on) {
-	cli_->set_keep_alive(on);
-}
+inline void Client::set_keep_alive(bool on) { cli_->set_keep_alive(on); }
 inline void Client::set_follow_location(bool on) {
-	cli_->set_follow_location(on);
+  cli_->set_follow_location(on);
 }
 
-inline void Client::set_url_encode(bool on) {
-	cli_->set_url_encode(on);
-}
+inline void Client::set_url_encode(bool on) { cli_->set_url_encode(on); }
 
-inline void Client::set_compress(bool on) {
-	cli_->set_compress(on);
-}
+inline void Client::set_compress(bool on) { cli_->set_compress(on); }
 
-inline void Client::set_decompress(bool on) {
-	cli_->set_decompress(on);
-}
+inline void Client::set_decompress(bool on) { cli_->set_decompress(on); }
 
 inline void Client::set_interface(const std::string &intf) {
-	cli_->set_interface(intf);
+  cli_->set_interface(intf);
 }
 
 inline void Client::set_proxy(const std::string &host, int port) {
-	cli_->set_proxy(host, port);
+  cli_->set_proxy(host, port);
 }
-inline void Client::set_proxy_basic_auth(const std::string &username, const std::string &password) {
-	cli_->set_proxy_basic_auth(username, password);
+inline void Client::set_proxy_basic_auth(const std::string &username,
+                                         const std::string &password) {
+  cli_->set_proxy_basic_auth(username, password);
 }
 inline void Client::set_proxy_bearer_token_auth(const std::string &token) {
-	cli_->set_proxy_bearer_token_auth(token);
+  cli_->set_proxy_bearer_token_auth(token);
 }
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline void Client::set_proxy_digest_auth(const std::string &username, const std::string &password) {
-	cli_->set_proxy_digest_auth(username, password);
+inline void Client::set_proxy_digest_auth(const std::string &username,
+                                          const std::string &password) {
+  cli_->set_proxy_digest_auth(username, password);
 }
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 inline void Client::enable_server_certificate_verification(bool enabled) {
-	cli_->enable_server_certificate_verification(enabled);
+  cli_->enable_server_certificate_verification(enabled);
 }
 #endif
 
 inline void Client::set_logger(Logger logger) {
-	cli_->set_logger(std::move(logger));
+  cli_->set_logger(std::move(logger));
 }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline void Client::set_ca_cert_path(const std::string &ca_cert_file_path, const std::string &ca_cert_dir_path) {
-	cli_->set_ca_cert_path(ca_cert_file_path, ca_cert_dir_path);
+inline void Client::set_ca_cert_path(const std::string &ca_cert_file_path,
+                                     const std::string &ca_cert_dir_path) {
+  cli_->set_ca_cert_path(ca_cert_file_path, ca_cert_dir_path);
 }
 
 inline void Client::set_ca_cert_store(X509_STORE *ca_cert_store) {
-	if (is_ssl_) {
-		static_cast<SSLClient &>(*cli_).set_ca_cert_store(ca_cert_store);
-	} else {
-		cli_->set_ca_cert_store(ca_cert_store);
-	}
+  if (is_ssl_) {
+    static_cast<SSLClient &>(*cli_).set_ca_cert_store(ca_cert_store);
+  } else {
+    cli_->set_ca_cert_store(ca_cert_store);
+  }
 }
 
 inline void Client::load_ca_cert_store(const char *ca_cert, std::size_t size) {
-	set_ca_cert_store(cli_->create_ca_cert_store(ca_cert, size));
+  set_ca_cert_store(cli_->create_ca_cert_store(ca_cert, size));
 }
 
 inline long Client::get_openssl_verify_result() const {
-	if (is_ssl_) {
-		return static_cast<SSLClient &>(*cli_).get_openssl_verify_result();
-	}
-	return -1; // NOTE: -1 doesn't match any of X509_V_ERR_???
+  if (is_ssl_) {
+    return static_cast<SSLClient &>(*cli_).get_openssl_verify_result();
+  }
+  return -1; // NOTE: -1 doesn't match any of X509_V_ERR_???
 }
 
 inline SSL_CTX *Client::ssl_context() const {
-	if (is_ssl_) {
-		return static_cast<SSLClient &>(*cli_).ssl_context();
-	}
-	return nullptr;
+  if (is_ssl_) { return static_cast<SSLClient &>(*cli_).ssl_context(); }
+  return nullptr;
 }
 #endif
 

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -7077,7 +7077,11 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
   }
 
   auto location = res.get_header_value("location");
-  if (location.empty()) { return false; }
+  if (location.empty()) { 
+	// potentially a s3 redirect. new location is in x-amz-region-bucket response header
+        // FileHandle is reponsible for parsing the header and requesting the new location
+	return true; 
+  }
 
   const Regex re(
       R"((?:(https?):)?(?://(?:\[([\d:]+)\]|([^:/?#]+))(?::(\d+))?)?([^?#]*)(\?[^#]*)?(?:#.*)?)");

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -18,7 +18,6 @@
 #include <exception>
 #include <stdexcept>
 
-
 /*
  * Configuration
  */
@@ -113,10 +112,8 @@
 #endif
 
 #ifndef CPPHTTPLIB_THREAD_POOL_COUNT
-#define CPPHTTPLIB_THREAD_POOL_COUNT                                           \
-  ((std::max)(8u, std::thread::hardware_concurrency() > 0                      \
-                      ? std::thread::hardware_concurrency() - 1                \
-                      : 0))
+#define CPPHTTPLIB_THREAD_POOL_COUNT                                                                                   \
+	((std::max)(8u, std::thread::hardware_concurrency() > 0 ? std::thread::hardware_concurrency() - 1 : 0))
 #endif
 
 #ifndef CPPHTTPLIB_RECV_FLAGS
@@ -289,10 +286,9 @@ using socket_t = int;
 #include <iostream>
 #include <sstream>
 
-
 // Disabled OpenSSL version check for CI
-//#if OPENSSL_VERSION_NUMBER < 0x1010100fL
-//#error Sorry, OpenSSL versions prior to 1.1.1 are not supported
+// #if OPENSSL_VERSION_NUMBER < 0x1010100fL
+// #error Sorry, OpenSSL versions prior to 1.1.1 are not supported
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
 #define SSL_get1_peer_certificate SSL_get_peer_certificate
 #endif
@@ -324,131 +320,130 @@ namespace detail {
  */
 
 template <class T, class... Args>
-typename std::enable_if<!std::is_array<T>::value, duckdb::unique_ptr<T>>::type
-make_unique(Args &&...args) {
-  return duckdb::unique_ptr<T>(new T(std::forward<Args>(args)...));
+typename std::enable_if<!std::is_array<T>::value, duckdb::unique_ptr<T>>::type make_unique(Args &&...args) {
+	return duckdb::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
 template <class T>
-typename std::enable_if<std::is_array<T>::value, duckdb::unique_ptr<T>>::type
-make_unique(std::size_t n) {
-  typedef typename std::remove_extent<T>::type RT;
-  return duckdb::unique_ptr<T>(new RT[n]);
+typename std::enable_if<std::is_array<T>::value, duckdb::unique_ptr<T>>::type make_unique(std::size_t n) {
+	typedef typename std::remove_extent<T>::type RT;
+	return duckdb::unique_ptr<T>(new RT[n]);
 }
 
 struct ci {
-  bool operator()(const std::string &s1, const std::string &s2) const {
-    return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(),
-                                        s2.end(),
-                                        [](unsigned char c1, unsigned char c2) {
-                                          return ::tolower(c1) < ::tolower(c2);
-                                        });
-  }
+	bool operator()(const std::string &s1, const std::string &s2) const {
+		return std::lexicographical_compare(
+		    s1.begin(), s1.end(), s2.begin(), s2.end(),
+		    [](unsigned char c1, unsigned char c2) { return ::tolower(c1) < ::tolower(c2); });
+	}
 };
 
 // This is based on
 // "http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4189".
 
 struct scope_exit {
-  explicit scope_exit(std::function<void(void)> &&f)
-      : exit_function(std::move(f)), execute_on_destruction{true} {}
+	explicit scope_exit(std::function<void(void)> &&f) : exit_function(std::move(f)), execute_on_destruction {true} {
+	}
 
-  scope_exit(scope_exit &&rhs) noexcept
-      : exit_function(std::move(rhs.exit_function)),
-        execute_on_destruction{rhs.execute_on_destruction} {
-    rhs.release();
-  }
+	scope_exit(scope_exit &&rhs) noexcept
+	    : exit_function(std::move(rhs.exit_function)), execute_on_destruction {rhs.execute_on_destruction} {
+		rhs.release();
+	}
 
-  ~scope_exit() {
-    if (execute_on_destruction) { this->exit_function(); }
-  }
+	~scope_exit() {
+		if (execute_on_destruction) {
+			this->exit_function();
+		}
+	}
 
-  void release() { this->execute_on_destruction = false; }
+	void release() {
+		this->execute_on_destruction = false;
+	}
 
 private:
-  scope_exit(const scope_exit &) = delete;
-  void operator=(const scope_exit &) = delete;
-  scope_exit &operator=(scope_exit &&) = delete;
+	scope_exit(const scope_exit &) = delete;
+	void operator=(const scope_exit &) = delete;
+	scope_exit &operator=(scope_exit &&) = delete;
 
-  std::function<void(void)> exit_function;
-  bool execute_on_destruction;
+	std::function<void(void)> exit_function;
+	bool execute_on_destruction;
 };
 
 } // namespace detail
 
 enum StatusCode {
-  // Information responses
-  Continue_100 = 100,
-  SwitchingProtocol_101 = 101,
-  Processing_102 = 102,
-  EarlyHints_103 = 103,
+	// Information responses
+	Continue_100 = 100,
+	SwitchingProtocol_101 = 101,
+	Processing_102 = 102,
+	EarlyHints_103 = 103,
 
-  // Successful responses
-  OK_200 = 200,
-  Created_201 = 201,
-  Accepted_202 = 202,
-  NonAuthoritativeInformation_203 = 203,
-  NoContent_204 = 204,
-  ResetContent_205 = 205,
-  PartialContent_206 = 206,
-  MultiStatus_207 = 207,
-  AlreadyReported_208 = 208,
-  IMUsed_226 = 226,
+	// Successful responses
+	OK_200 = 200,
+	Created_201 = 201,
+	Accepted_202 = 202,
+	NonAuthoritativeInformation_203 = 203,
+	NoContent_204 = 204,
+	ResetContent_205 = 205,
+	PartialContent_206 = 206,
+	MultiStatus_207 = 207,
+	AlreadyReported_208 = 208,
+	IMUsed_226 = 226,
 
-  // Redirection messages
-  MultipleChoices_300 = 300,
-  MovedPermanently_301 = 301,
-  Found_302 = 302,
-  SeeOther_303 = 303,
-  NotModified_304 = 304,
-  UseProxy_305 = 305,
-  unused_306 = 306,
-  TemporaryRedirect_307 = 307,
-  PermanentRedirect_308 = 308,
+	// Redirection messages
+	MultipleChoices_300 = 300,
+	MovedPermanently_301 = 301,
+	Found_302 = 302,
+	SeeOther_303 = 303,
+	NotModified_304 = 304,
+	UseProxy_305 = 305,
+	unused_306 = 306,
+	TemporaryRedirect_307 = 307,
+	PermanentRedirect_308 = 308,
 
-  // Client error responses
-  BadRequest_400 = 400,
-  Unauthorized_401 = 401,
-  PaymentRequired_402 = 402,
-  Forbidden_403 = 403,
-  NotFound_404 = 404,
-  MethodNotAllowed_405 = 405,
-  NotAcceptable_406 = 406,
-  ProxyAuthenticationRequired_407 = 407,
-  RequestTimeout_408 = 408,
-  Conflict_409 = 409,
-  Gone_410 = 410,
-  LengthRequired_411 = 411,
-  PreconditionFailed_412 = 412,
-  PayloadTooLarge_413 = 413,
-  UriTooLong_414 = 414,
-  UnsupportedMediaType_415 = 415,
-  RangeNotSatisfiable_416 = 416,
-  ExpectationFailed_417 = 417,
-  ImATeapot_418 = 418,
-  MisdirectedRequest_421 = 421,
-  UnprocessableContent_422 = 422,
-  Locked_423 = 423,
-  FailedDependency_424 = 424,
-  TooEarly_425 = 425,
-  UpgradeRequired_426 = 426,
-  PreconditionRequired_428 = 428,
-  TooManyRequests_429 = 429,
-  RequestHeaderFieldsTooLarge_431 = 431,
-  UnavailableForLegalReasons_451 = 451,
+	// Client error responses
+	BadRequest_400 = 400,
+	Unauthorized_401 = 401,
+	PaymentRequired_402 = 402,
+	Forbidden_403 = 403,
+	NotFound_404 = 404,
+	MethodNotAllowed_405 = 405,
+	NotAcceptable_406 = 406,
+	ProxyAuthenticationRequired_407 = 407,
+	RequestTimeout_408 = 408,
+	Conflict_409 = 409,
+	Gone_410 = 410,
+	LengthRequired_411 = 411,
+	PreconditionFailed_412 = 412,
+	PayloadTooLarge_413 = 413,
+	UriTooLong_414 = 414,
+	UnsupportedMediaType_415 = 415,
+	RangeNotSatisfiable_416 = 416,
+	ExpectationFailed_417 = 417,
+	ImATeapot_418 = 418,
+	MisdirectedRequest_421 = 421,
+	UnprocessableContent_422 = 422,
+	Locked_423 = 423,
+	FailedDependency_424 = 424,
+	TooEarly_425 = 425,
+	UpgradeRequired_426 = 426,
+	PreconditionRequired_428 = 428,
+	TooManyRequests_429 = 429,
+	RequestHeaderFieldsTooLarge_431 = 431,
+	UnavailableForLegalReasons_451 = 451,
 
-  // Server error responses
-  InternalServerError_500 = 500,
-  NotImplemented_501 = 501,
-  BadGateway_502 = 502,
-  ServiceUnavailable_503 = 503,
-  GatewayTimeout_504 = 504,
-  HttpVersionNotSupported_505 = 505,
-  VariantAlsoNegotiates_506 = 506,
-  InsufficientStorage_507 = 507,
-  LoopDetected_508 = 508,
-  NotExtended_510 = 510,
-  NetworkAuthenticationRequired_511 = 511,
+	// Server error responses
+	InternalServerError_500 = 500,
+	NotImplemented_501 = 501,
+	BadGateway_502 = 502,
+	ServiceUnavailable_503 = 503,
+	GatewayTimeout_504 = 504,
+	HttpVersionNotSupported_505 = 505,
+	VariantAlsoNegotiates_506 = 506,
+	InsufficientStorage_507 = 507,
+	LoopDetected_508 = 508,
+	NotExtended_510 = 510,
+	NetworkAuthenticationRequired_511 = 511,
 };
 
 using Headers = std::multimap<std::string, std::string, detail::ci>;
@@ -463,301 +458,296 @@ struct Response;
 using ResponseHandler = std::function<bool(const Response &response)>;
 
 struct MultipartFormData {
-  std::string name;
-  std::string content;
-  std::string filename;
-  std::string content_type;
+	std::string name;
+	std::string content;
+	std::string filename;
+	std::string content_type;
 };
 using MultipartFormDataItems = std::vector<MultipartFormData>;
 using MultipartFormDataMap = std::multimap<std::string, MultipartFormData>;
 
 class DataSink {
 public:
-  DataSink() : os(&sb_), sb_(*this) {}
+	DataSink() : os(&sb_), sb_(*this) {
+	}
 
-  DataSink(const DataSink &) = delete;
-  DataSink &operator=(const DataSink &) = delete;
-  DataSink(DataSink &&) = delete;
-  DataSink &operator=(DataSink &&) = delete;
+	DataSink(const DataSink &) = delete;
+	DataSink &operator=(const DataSink &) = delete;
+	DataSink(DataSink &&) = delete;
+	DataSink &operator=(DataSink &&) = delete;
 
-  std::function<bool(const char *data, size_t data_len)> write;
-  std::function<bool()> is_writable;
-  std::function<void()> done;
-  std::function<void(const Headers &trailer)> done_with_trailer;
-  std::ostream os;
+	std::function<bool(const char *data, size_t data_len)> write;
+	std::function<bool()> is_writable;
+	std::function<void()> done;
+	std::function<void(const Headers &trailer)> done_with_trailer;
+	std::ostream os;
 
 private:
-  class data_sink_streambuf : public std::streambuf {
-  public:
-    explicit data_sink_streambuf(DataSink &sink) : sink_(sink) {}
+	class data_sink_streambuf : public std::streambuf {
+	public:
+		explicit data_sink_streambuf(DataSink &sink) : sink_(sink) {
+		}
 
-  protected:
-    std::streamsize xsputn(const char *s, std::streamsize n) override {
-      sink_.write(s, static_cast<size_t>(n));
-      return n;
-    }
+	protected:
+		std::streamsize xsputn(const char *s, std::streamsize n) override {
+			sink_.write(s, static_cast<size_t>(n));
+			return n;
+		}
 
-  private:
-    DataSink &sink_;
-  };
+	private:
+		DataSink &sink_;
+	};
 
-  data_sink_streambuf sb_;
+	data_sink_streambuf sb_;
 };
 
-using ContentProvider =
-    std::function<bool(size_t offset, size_t length, DataSink &sink)>;
+using ContentProvider = std::function<bool(size_t offset, size_t length, DataSink &sink)>;
 
-using ContentProviderWithoutLength =
-    std::function<bool(size_t offset, DataSink &sink)>;
+using ContentProviderWithoutLength = std::function<bool(size_t offset, DataSink &sink)>;
 
 using ContentProviderResourceReleaser = std::function<void(bool success)>;
 
 struct MultipartFormDataProvider {
-  std::string name;
-  ContentProviderWithoutLength provider;
-  std::string filename;
-  std::string content_type;
+	std::string name;
+	ContentProviderWithoutLength provider;
+	std::string filename;
+	std::string content_type;
 };
 using MultipartFormDataProviderItems = std::vector<MultipartFormDataProvider>;
 
 using ContentReceiverWithProgress =
-    std::function<bool(const char *data, size_t data_length, uint64_t offset,
-                       uint64_t total_length)>;
+    std::function<bool(const char *data, size_t data_length, uint64_t offset, uint64_t total_length)>;
 
-using ContentReceiver =
-    std::function<bool(const char *data, size_t data_length)>;
+using ContentReceiver = std::function<bool(const char *data, size_t data_length)>;
 
-using MultipartContentHeader =
-    std::function<bool(const MultipartFormData &file)>;
+using MultipartContentHeader = std::function<bool(const MultipartFormData &file)>;
 
 class ContentReader {
 public:
-  using Reader = std::function<bool(ContentReceiver receiver)>;
-  using MultipartReader = std::function<bool(MultipartContentHeader header,
-                                             ContentReceiver receiver)>;
+	using Reader = std::function<bool(ContentReceiver receiver)>;
+	using MultipartReader = std::function<bool(MultipartContentHeader header, ContentReceiver receiver)>;
 
-  ContentReader(Reader reader, MultipartReader multipart_reader)
-      : reader_(std::move(reader)),
-        multipart_reader_(std::move(multipart_reader)) {}
+	ContentReader(Reader reader, MultipartReader multipart_reader)
+	    : reader_(std::move(reader)), multipart_reader_(std::move(multipart_reader)) {
+	}
 
-  bool operator()(MultipartContentHeader header,
-                  ContentReceiver receiver) const {
-    return multipart_reader_(std::move(header), std::move(receiver));
-  }
+	bool operator()(MultipartContentHeader header, ContentReceiver receiver) const {
+		return multipart_reader_(std::move(header), std::move(receiver));
+	}
 
-  bool operator()(ContentReceiver receiver) const {
-    return reader_(std::move(receiver));
-  }
+	bool operator()(ContentReceiver receiver) const {
+		return reader_(std::move(receiver));
+	}
 
-  Reader reader_;
-  MultipartReader multipart_reader_;
+	Reader reader_;
+	MultipartReader multipart_reader_;
 };
 
 using Range = std::pair<ssize_t, ssize_t>;
 using Ranges = std::vector<Range>;
 
 struct Request {
-  std::string method;
-  std::string path;
-  Headers headers;
-  std::string body;
+	std::string method;
+	std::string path;
+	Headers headers;
+	std::string body;
 
-  std::string remote_addr;
-  int remote_port = -1;
-  std::string local_addr;
-  int local_port = -1;
+	std::string remote_addr;
+	int remote_port = -1;
+	std::string local_addr;
+	int local_port = -1;
 
-  // for server
-  std::string version;
-  std::string target;
-  Params params;
-  MultipartFormDataMap files;
-  Ranges ranges;
-  Match matches;
-  std::unordered_map<std::string, std::string> path_params;
+	// for server
+	std::string version;
+	std::string target;
+	Params params;
+	MultipartFormDataMap files;
+	Ranges ranges;
+	Match matches;
+	std::unordered_map<std::string, std::string> path_params;
 
-  // for client
-  ResponseHandler response_handler;
-  ContentReceiverWithProgress content_receiver;
-  Progress progress;
+	// for client
+	ResponseHandler response_handler;
+	ContentReceiverWithProgress content_receiver;
+	Progress progress;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  const SSL *ssl = nullptr;
+	const SSL *ssl = nullptr;
 #endif
 
-  bool has_header(const std::string &key) const;
-  std::string get_header_value(const std::string &key, size_t id = 0) const;
-  uint64_t get_header_value_u64(const std::string &key, size_t id = 0) const;
-  size_t get_header_value_count(const std::string &key) const;
-  void set_header(const std::string &key, const std::string &val);
+	bool has_header(const std::string &key) const;
+	std::string get_header_value(const std::string &key, size_t id = 0) const;
+	uint64_t get_header_value_u64(const std::string &key, size_t id = 0) const;
+	size_t get_header_value_count(const std::string &key) const;
+	void set_header(const std::string &key, const std::string &val);
 
-  bool has_param(const std::string &key) const;
-  std::string get_param_value(const std::string &key, size_t id = 0) const;
-  size_t get_param_value_count(const std::string &key) const;
+	bool has_param(const std::string &key) const;
+	std::string get_param_value(const std::string &key, size_t id = 0) const;
+	size_t get_param_value_count(const std::string &key) const;
 
-  bool is_multipart_form_data() const;
+	bool is_multipart_form_data() const;
 
-  bool has_file(const std::string &key) const;
-  MultipartFormData get_file_value(const std::string &key) const;
-  std::vector<MultipartFormData> get_file_values(const std::string &key) const;
+	bool has_file(const std::string &key) const;
+	MultipartFormData get_file_value(const std::string &key) const;
+	std::vector<MultipartFormData> get_file_values(const std::string &key) const;
 
-  // private members...
-  size_t redirect_count_ = CPPHTTPLIB_REDIRECT_MAX_COUNT;
-  size_t content_length_ = 0;
-  ContentProvider content_provider_;
-  bool is_chunked_content_provider_ = false;
-  size_t authorization_count_ = 0;
+	// private members...
+	size_t redirect_count_ = CPPHTTPLIB_REDIRECT_MAX_COUNT;
+	size_t content_length_ = 0;
+	ContentProvider content_provider_;
+	bool is_chunked_content_provider_ = false;
+	size_t authorization_count_ = 0;
 };
 
 struct Response {
-  std::string version;
-  int status = -1;
-  std::string reason;
-  Headers headers;
-  std::string body;
-  std::string location; // Redirect location
+	std::string version;
+	int status = -1;
+	std::string reason;
+	Headers headers;
+	std::string body;
+	std::string location; // Redirect location
 
-  bool has_header(const std::string &key) const;
-  std::string get_header_value(const std::string &key, size_t id = 0) const;
-  uint64_t get_header_value_u64(const std::string &key, size_t id = 0) const;
-  size_t get_header_value_count(const std::string &key) const;
-  void set_header(const std::string &key, const std::string &val);
+	bool has_header(const std::string &key) const;
+	std::string get_header_value(const std::string &key, size_t id = 0) const;
+	uint64_t get_header_value_u64(const std::string &key, size_t id = 0) const;
+	size_t get_header_value_count(const std::string &key) const;
+	void set_header(const std::string &key, const std::string &val);
 
-  void set_redirect(const std::string &url, int status = StatusCode::Found_302);
-  void set_content(const char *s, size_t n, const std::string &content_type);
-  void set_content(const std::string &s, const std::string &content_type);
+	void set_redirect(const std::string &url, int status = StatusCode::Found_302);
+	void set_content(const char *s, size_t n, const std::string &content_type);
+	void set_content(const std::string &s, const std::string &content_type);
 
-  void set_content_provider(
-      size_t length, const std::string &content_type, ContentProvider provider,
-      ContentProviderResourceReleaser resource_releaser = nullptr);
+	void set_content_provider(size_t length, const std::string &content_type, ContentProvider provider,
+	                          ContentProviderResourceReleaser resource_releaser = nullptr);
 
-  void set_content_provider(
-      const std::string &content_type, ContentProviderWithoutLength provider,
-      ContentProviderResourceReleaser resource_releaser = nullptr);
+	void set_content_provider(const std::string &content_type, ContentProviderWithoutLength provider,
+	                          ContentProviderResourceReleaser resource_releaser = nullptr);
 
-  void set_chunked_content_provider(
-      const std::string &content_type, ContentProviderWithoutLength provider,
-      ContentProviderResourceReleaser resource_releaser = nullptr);
+	void set_chunked_content_provider(const std::string &content_type, ContentProviderWithoutLength provider,
+	                                  ContentProviderResourceReleaser resource_releaser = nullptr);
 
-  Response() = default;
-  Response(const Response &) = default;
-  Response &operator=(const Response &) = default;
-  Response(Response &&) = default;
-  Response &operator=(Response &&) = default;
-  ~Response() {
-    if (content_provider_resource_releaser_) {
-      content_provider_resource_releaser_(content_provider_success_);
-    }
-  }
+	Response() = default;
+	Response(const Response &) = default;
+	Response &operator=(const Response &) = default;
+	Response(Response &&) = default;
+	Response &operator=(Response &&) = default;
+	~Response() {
+		if (content_provider_resource_releaser_) {
+			content_provider_resource_releaser_(content_provider_success_);
+		}
+	}
 
-  // private members...
-  size_t content_length_ = 0;
-  ContentProvider content_provider_;
-  ContentProviderResourceReleaser content_provider_resource_releaser_;
-  bool is_chunked_content_provider_ = false;
-  bool content_provider_success_ = false;
+	// private members...
+	size_t content_length_ = 0;
+	ContentProvider content_provider_;
+	ContentProviderResourceReleaser content_provider_resource_releaser_;
+	bool is_chunked_content_provider_ = false;
+	bool content_provider_success_ = false;
 };
 
 class Stream {
 public:
-  virtual ~Stream() = default;
+	virtual ~Stream() = default;
 
-  virtual bool is_readable() const = 0;
-  virtual bool is_writable() const = 0;
+	virtual bool is_readable() const = 0;
+	virtual bool is_writable() const = 0;
 
-  virtual ssize_t read(char *ptr, size_t size) = 0;
-  virtual ssize_t write(const char *ptr, size_t size) = 0;
-  virtual void get_remote_ip_and_port(std::string &ip, int &port) const = 0;
-  virtual void get_local_ip_and_port(std::string &ip, int &port) const = 0;
-  virtual socket_t socket() const = 0;
+	virtual ssize_t read(char *ptr, size_t size) = 0;
+	virtual ssize_t write(const char *ptr, size_t size) = 0;
+	virtual void get_remote_ip_and_port(std::string &ip, int &port) const = 0;
+	virtual void get_local_ip_and_port(std::string &ip, int &port) const = 0;
+	virtual socket_t socket() const = 0;
 
-  template <typename... Args>
-  ssize_t write_format(const char *fmt, const Args &...args);
-  ssize_t write(const char *ptr);
-  ssize_t write(const std::string &s);
+	template <typename... Args>
+	ssize_t write_format(const char *fmt, const Args &...args);
+	ssize_t write(const char *ptr);
+	ssize_t write(const std::string &s);
 };
 
 class TaskQueue {
 public:
-  TaskQueue() = default;
-  virtual ~TaskQueue() = default;
+	TaskQueue() = default;
+	virtual ~TaskQueue() = default;
 
-  virtual void enqueue(std::function<void()> fn) = 0;
-  virtual void shutdown() = 0;
+	virtual void enqueue(std::function<void()> fn) = 0;
+	virtual void shutdown() = 0;
 
-  virtual void on_idle() {}
+	virtual void on_idle() {
+	}
 };
 
 class ThreadPool : public TaskQueue {
 public:
-  explicit ThreadPool(size_t n) : shutdown_(false) {
-    while (n) {
-      threads_.emplace_back(worker(*this));
-      n--;
-    }
-  }
+	explicit ThreadPool(size_t n) : shutdown_(false) {
+		while (n) {
+			threads_.emplace_back(worker(*this));
+			n--;
+		}
+	}
 
-  ThreadPool(const ThreadPool &) = delete;
-  ~ThreadPool() override = default;
+	ThreadPool(const ThreadPool &) = delete;
+	~ThreadPool() override = default;
 
-  void enqueue(std::function<void()> fn) override {
-    {
-      std::unique_lock<std::mutex> lock(mutex_);
-      jobs_.push_back(std::move(fn));
-    }
+	void enqueue(std::function<void()> fn) override {
+		{
+			std::unique_lock<std::mutex> lock(mutex_);
+			jobs_.push_back(std::move(fn));
+		}
 
-    cond_.notify_one();
-  }
+		cond_.notify_one();
+	}
 
-  void shutdown() override {
-    // Stop all worker threads...
-    {
-      std::unique_lock<std::mutex> lock(mutex_);
-      shutdown_ = true;
-    }
+	void shutdown() override {
+		// Stop all worker threads...
+		{
+			std::unique_lock<std::mutex> lock(mutex_);
+			shutdown_ = true;
+		}
 
-    cond_.notify_all();
+		cond_.notify_all();
 
-    // Join...
-    for (auto &t : threads_) {
-      t.join();
-    }
-  }
+		// Join...
+		for (auto &t : threads_) {
+			t.join();
+		}
+	}
 
 private:
-  struct worker {
-    explicit worker(ThreadPool &pool) : pool_(pool) {}
+	struct worker {
+		explicit worker(ThreadPool &pool) : pool_(pool) {
+		}
 
-    void operator()() {
-      for (;;) {
-        std::function<void()> fn;
-        {
-          std::unique_lock<std::mutex> lock(pool_.mutex_);
+		void operator()() {
+			for (;;) {
+				std::function<void()> fn;
+				{
+					std::unique_lock<std::mutex> lock(pool_.mutex_);
 
-          pool_.cond_.wait(
-              lock, [&] { return !pool_.jobs_.empty() || pool_.shutdown_; });
+					pool_.cond_.wait(lock, [&] { return !pool_.jobs_.empty() || pool_.shutdown_; });
 
-          if (pool_.shutdown_ && pool_.jobs_.empty()) { break; }
+					if (pool_.shutdown_ && pool_.jobs_.empty()) {
+						break;
+					}
 
-          fn = std::move(pool_.jobs_.front());
-          pool_.jobs_.pop_front();
-        }
+					fn = std::move(pool_.jobs_.front());
+					pool_.jobs_.pop_front();
+				}
 
-        assert(true == static_cast<bool>(fn));
-        fn();
-      }
-    }
+				assert(true == static_cast<bool>(fn));
+				fn();
+			}
+		}
 
-    ThreadPool &pool_;
-  };
-  friend struct worker;
+		ThreadPool &pool_;
+	};
+	friend struct worker;
 
-  std::vector<std::thread> threads_;
-  std::list<std::function<void()>> jobs_;
+	std::vector<std::thread> threads_;
+	std::list<std::function<void()>> jobs_;
 
-  bool shutdown_;
+	bool shutdown_;
 
-  std::condition_variable cond_;
-  std::mutex mutex_;
+	std::condition_variable cond_;
+	std::mutex mutex_;
 };
 
 using Logger = std::function<void(const Request &, const Response &)>;
@@ -772,10 +762,10 @@ namespace detail {
 
 class MatcherBase {
 public:
-  virtual ~MatcherBase() = default;
+	virtual ~MatcherBase() = default;
 
-  // Match request path and populate its matches and
-  virtual bool match(Request &request) const = 0;
+	// Match request path and populate its matches and
+	virtual bool match(Request &request) const = 0;
 };
 
 /**
@@ -798,24 +788,24 @@ public:
  */
 class PathParamsMatcher : public MatcherBase {
 public:
-  PathParamsMatcher(const std::string &pattern);
+	PathParamsMatcher(const std::string &pattern);
 
-  bool match(Request &request) const override;
+	bool match(Request &request) const override;
 
 private:
-  static constexpr char marker = ':';
-  // Treat segment separators as the end of path parameter capture
-  // Does not need to handle query parameters as they are parsed before path
-  // matching
-  static constexpr char separator = '/';
+	static constexpr char marker = ':';
+	// Treat segment separators as the end of path parameter capture
+	// Does not need to handle query parameters as they are parsed before path
+	// matching
+	static constexpr char separator = '/';
 
-  // Contains static path fragments to match against, excluding the '/' after
-  // path params
-  // Fragments are separated by path params
-  std::vector<std::string> static_fragments_;
-  // Stores the names of the path parameters to be used as keys in the
-  // Request::path_params map
-  std::vector<std::string> param_names_;
+	// Contains static path fragments to match against, excluding the '/' after
+	// path params
+	// Fragments are separated by path params
+	std::vector<std::string> static_fragments_;
+	// Stores the names of the path parameters to be used as keys in the
+	// Request::path_params map
+	std::vector<std::string> param_names_;
 };
 
 /**
@@ -828,12 +818,13 @@ private:
  */
 class RegexMatcher : public MatcherBase {
 public:
-  RegexMatcher(const std::string &pattern) : regex_(pattern) {}
+	RegexMatcher(const std::string &pattern) : regex_(pattern) {
+	}
 
-  bool match(Request &request) const override;
+	bool match(Request &request) const override;
 
 private:
-  Regex regex_;
+	Regex regex_;
 };
 
 ssize_t write_headers(Stream &strm, const Headers &headers);
@@ -842,222 +833,198 @@ ssize_t write_headers(Stream &strm, const Headers &headers);
 
 class Server {
 public:
-  using Handler = std::function<void(const Request &, Response &)>;
+	using Handler = std::function<void(const Request &, Response &)>;
 
-  using ExceptionHandler =
-      std::function<void(const Request &, Response &, std::exception_ptr ep)>;
+	using ExceptionHandler = std::function<void(const Request &, Response &, std::exception_ptr ep)>;
 
-  enum class HandlerResponse {
-    Handled,
-    Unhandled,
-  };
-  using HandlerWithResponse =
-      std::function<HandlerResponse(const Request &, Response &)>;
+	enum class HandlerResponse {
+		Handled,
+		Unhandled,
+	};
+	using HandlerWithResponse = std::function<HandlerResponse(const Request &, Response &)>;
 
-  using HandlerWithContentReader = std::function<void(
-      const Request &, Response &, const ContentReader &content_reader)>;
+	using HandlerWithContentReader =
+	    std::function<void(const Request &, Response &, const ContentReader &content_reader)>;
 
-  using Expect100ContinueHandler =
-      std::function<int(const Request &, Response &)>;
+	using Expect100ContinueHandler = std::function<int(const Request &, Response &)>;
 
-  Server();
+	Server();
 
-  virtual ~Server();
+	virtual ~Server();
 
-  virtual bool is_valid() const;
+	virtual bool is_valid() const;
 
-  Server &Get(const std::string &pattern, Handler handler);
-  Server &Post(const std::string &pattern, Handler handler);
-  Server &Post(const std::string &pattern, HandlerWithContentReader handler);
-  Server &Put(const std::string &pattern, Handler handler);
-  Server &Put(const std::string &pattern, HandlerWithContentReader handler);
-  Server &Patch(const std::string &pattern, Handler handler);
-  Server &Patch(const std::string &pattern, HandlerWithContentReader handler);
-  Server &Delete(const std::string &pattern, Handler handler);
-  Server &Delete(const std::string &pattern, HandlerWithContentReader handler);
-  Server &Options(const std::string &pattern, Handler handler);
+	Server &Get(const std::string &pattern, Handler handler);
+	Server &Post(const std::string &pattern, Handler handler);
+	Server &Post(const std::string &pattern, HandlerWithContentReader handler);
+	Server &Put(const std::string &pattern, Handler handler);
+	Server &Put(const std::string &pattern, HandlerWithContentReader handler);
+	Server &Patch(const std::string &pattern, Handler handler);
+	Server &Patch(const std::string &pattern, HandlerWithContentReader handler);
+	Server &Delete(const std::string &pattern, Handler handler);
+	Server &Delete(const std::string &pattern, HandlerWithContentReader handler);
+	Server &Options(const std::string &pattern, Handler handler);
 
-  bool set_base_dir(const std::string &dir,
-                    const std::string &mount_point = std::string());
-  bool set_mount_point(const std::string &mount_point, const std::string &dir,
-                       Headers headers = Headers());
-  bool remove_mount_point(const std::string &mount_point);
-  Server &set_file_extension_and_mimetype_mapping(const std::string &ext,
-                                                  const std::string &mime);
-  Server &set_default_file_mimetype(const std::string &mime);
-  Server &set_file_request_handler(Handler handler);
+	bool set_base_dir(const std::string &dir, const std::string &mount_point = std::string());
+	bool set_mount_point(const std::string &mount_point, const std::string &dir, Headers headers = Headers());
+	bool remove_mount_point(const std::string &mount_point);
+	Server &set_file_extension_and_mimetype_mapping(const std::string &ext, const std::string &mime);
+	Server &set_default_file_mimetype(const std::string &mime);
+	Server &set_file_request_handler(Handler handler);
 
-  Server &set_error_handler(HandlerWithResponse handler);
-  Server &set_error_handler(Handler handler);
-  Server &set_exception_handler(ExceptionHandler handler);
-  Server &set_pre_routing_handler(HandlerWithResponse handler);
-  Server &set_post_routing_handler(Handler handler);
+	Server &set_error_handler(HandlerWithResponse handler);
+	Server &set_error_handler(Handler handler);
+	Server &set_exception_handler(ExceptionHandler handler);
+	Server &set_pre_routing_handler(HandlerWithResponse handler);
+	Server &set_post_routing_handler(Handler handler);
 
-  Server &set_expect_100_continue_handler(Expect100ContinueHandler handler);
-  Server &set_logger(Logger logger);
+	Server &set_expect_100_continue_handler(Expect100ContinueHandler handler);
+	Server &set_logger(Logger logger);
 
-  Server &set_address_family(int family);
-  Server &set_tcp_nodelay(bool on);
-  Server &set_socket_options(SocketOptions socket_options);
+	Server &set_address_family(int family);
+	Server &set_tcp_nodelay(bool on);
+	Server &set_socket_options(SocketOptions socket_options);
 
-  Server &set_default_headers(Headers headers);
-  Server &
-  set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
+	Server &set_default_headers(Headers headers);
+	Server &set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
 
-  Server &set_keep_alive_max_count(size_t count);
-  Server &set_keep_alive_timeout(time_t sec);
+	Server &set_keep_alive_max_count(size_t count);
+	Server &set_keep_alive_timeout(time_t sec);
 
-  Server &set_read_timeout(time_t sec, time_t usec = 0);
-  template <class Rep, class Period>
-  Server &set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
+	Server &set_read_timeout(time_t sec, time_t usec = 0);
+	template <class Rep, class Period>
+	Server &set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-  Server &set_write_timeout(time_t sec, time_t usec = 0);
-  template <class Rep, class Period>
-  Server &set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
+	Server &set_write_timeout(time_t sec, time_t usec = 0);
+	template <class Rep, class Period>
+	Server &set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-  Server &set_idle_interval(time_t sec, time_t usec = 0);
-  template <class Rep, class Period>
-  Server &set_idle_interval(const std::chrono::duration<Rep, Period> &duration);
+	Server &set_idle_interval(time_t sec, time_t usec = 0);
+	template <class Rep, class Period>
+	Server &set_idle_interval(const std::chrono::duration<Rep, Period> &duration);
 
-  Server &set_payload_max_length(size_t length);
+	Server &set_payload_max_length(size_t length);
 
-  bool bind_to_port(const std::string &host, int port, int socket_flags = 0);
-  int bind_to_any_port(const std::string &host, int socket_flags = 0);
-  bool listen_after_bind();
+	bool bind_to_port(const std::string &host, int port, int socket_flags = 0);
+	int bind_to_any_port(const std::string &host, int socket_flags = 0);
+	bool listen_after_bind();
 
-  bool listen(const std::string &host, int port, int socket_flags = 0);
+	bool listen(const std::string &host, int port, int socket_flags = 0);
 
-  bool is_running() const;
-  void wait_until_ready() const;
-  void stop();
+	bool is_running() const;
+	void wait_until_ready() const;
+	void stop();
 
-  std::function<TaskQueue *(void)> new_task_queue;
+	std::function<TaskQueue *(void)> new_task_queue;
 
 protected:
-  bool process_request(Stream &strm, bool close_connection,
-                       bool &connection_closed,
-                       const std::function<void(Request &)> &setup_request);
+	bool process_request(Stream &strm, bool close_connection, bool &connection_closed,
+	                     const std::function<void(Request &)> &setup_request);
 
-  std::atomic<socket_t> svr_sock_{INVALID_SOCKET};
-  size_t keep_alive_max_count_ = CPPHTTPLIB_KEEPALIVE_MAX_COUNT;
-  time_t keep_alive_timeout_sec_ = CPPHTTPLIB_KEEPALIVE_TIMEOUT_SECOND;
-  time_t read_timeout_sec_ = CPPHTTPLIB_READ_TIMEOUT_SECOND;
-  time_t read_timeout_usec_ = CPPHTTPLIB_READ_TIMEOUT_USECOND;
-  time_t write_timeout_sec_ = CPPHTTPLIB_WRITE_TIMEOUT_SECOND;
-  time_t write_timeout_usec_ = CPPHTTPLIB_WRITE_TIMEOUT_USECOND;
-  time_t idle_interval_sec_ = CPPHTTPLIB_IDLE_INTERVAL_SECOND;
-  time_t idle_interval_usec_ = CPPHTTPLIB_IDLE_INTERVAL_USECOND;
-  size_t payload_max_length_ = CPPHTTPLIB_PAYLOAD_MAX_LENGTH;
+	std::atomic<socket_t> svr_sock_ {INVALID_SOCKET};
+	size_t keep_alive_max_count_ = CPPHTTPLIB_KEEPALIVE_MAX_COUNT;
+	time_t keep_alive_timeout_sec_ = CPPHTTPLIB_KEEPALIVE_TIMEOUT_SECOND;
+	time_t read_timeout_sec_ = CPPHTTPLIB_READ_TIMEOUT_SECOND;
+	time_t read_timeout_usec_ = CPPHTTPLIB_READ_TIMEOUT_USECOND;
+	time_t write_timeout_sec_ = CPPHTTPLIB_WRITE_TIMEOUT_SECOND;
+	time_t write_timeout_usec_ = CPPHTTPLIB_WRITE_TIMEOUT_USECOND;
+	time_t idle_interval_sec_ = CPPHTTPLIB_IDLE_INTERVAL_SECOND;
+	time_t idle_interval_usec_ = CPPHTTPLIB_IDLE_INTERVAL_USECOND;
+	size_t payload_max_length_ = CPPHTTPLIB_PAYLOAD_MAX_LENGTH;
 
 private:
-  using Handlers = std::vector<std::pair<Regex, Handler>>;
-  using HandlersForContentReader =
-      std::vector<std::pair<Regex, HandlerWithContentReader>>;
+	using Handlers = std::vector<std::pair<Regex, Handler>>;
+	using HandlersForContentReader = std::vector<std::pair<Regex, HandlerWithContentReader>>;
 
-  static duckdb::unique_ptr<detail::MatcherBase>
-  make_matcher(const std::string &pattern);
+	static duckdb::unique_ptr<detail::MatcherBase> make_matcher(const std::string &pattern);
 
-  socket_t create_server_socket(const std::string &host, int port,
-                                int socket_flags,
-                                SocketOptions socket_options) const;
-  int bind_internal(const std::string &host, int port, int socket_flags);
-  bool listen_internal();
+	socket_t create_server_socket(const std::string &host, int port, int socket_flags,
+	                              SocketOptions socket_options) const;
+	int bind_internal(const std::string &host, int port, int socket_flags);
+	bool listen_internal();
 
-  bool routing(Request &req, Response &res, Stream &strm);
-  bool handle_file_request(const Request &req, Response &res,
-                           bool head = false);
-  bool dispatch_request(Request &req, Response &res,
-                        const Handlers &handlers) const;
-  bool dispatch_request_for_content_reader(
-      Request &req, Response &res, ContentReader content_reader,
-      const HandlersForContentReader &handlers) const;
+	bool routing(Request &req, Response &res, Stream &strm);
+	bool handle_file_request(const Request &req, Response &res, bool head = false);
+	bool dispatch_request(Request &req, Response &res, const Handlers &handlers) const;
+	bool dispatch_request_for_content_reader(Request &req, Response &res, ContentReader content_reader,
+	                                         const HandlersForContentReader &handlers) const;
 
-  bool parse_request_line(const char *s, Request &req) const;
-  void apply_ranges(const Request &req, Response &res,
-                    std::string &content_type, std::string &boundary) const;
-  bool write_response(Stream &strm, bool close_connection, const Request &req,
-                      Response &res);
-  bool write_response_with_content(Stream &strm, bool close_connection,
-                                   const Request &req, Response &res);
-  bool write_response_core(Stream &strm, bool close_connection,
-                           const Request &req, Response &res,
-                           bool need_apply_ranges);
-  bool write_content_with_provider(Stream &strm, const Request &req,
-                                   Response &res, const std::string &boundary,
-                                   const std::string &content_type);
-  bool read_content(Stream &strm, Request &req, Response &res);
-  bool
-  read_content_with_content_receiver(Stream &strm, Request &req, Response &res,
-                                     ContentReceiver receiver,
-                                     MultipartContentHeader multipart_header,
-                                     ContentReceiver multipart_receiver);
-  bool read_content_core(Stream &strm, Request &req, Response &res,
-                         ContentReceiver receiver,
-                         MultipartContentHeader multipart_header,
-                         ContentReceiver multipart_receiver) const;
+	bool parse_request_line(const char *s, Request &req) const;
+	void apply_ranges(const Request &req, Response &res, std::string &content_type, std::string &boundary) const;
+	bool write_response(Stream &strm, bool close_connection, const Request &req, Response &res);
+	bool write_response_with_content(Stream &strm, bool close_connection, const Request &req, Response &res);
+	bool write_response_core(Stream &strm, bool close_connection, const Request &req, Response &res,
+	                         bool need_apply_ranges);
+	bool write_content_with_provider(Stream &strm, const Request &req, Response &res, const std::string &boundary,
+	                                 const std::string &content_type);
+	bool read_content(Stream &strm, Request &req, Response &res);
+	bool read_content_with_content_receiver(Stream &strm, Request &req, Response &res, ContentReceiver receiver,
+	                                        MultipartContentHeader multipart_header,
+	                                        ContentReceiver multipart_receiver);
+	bool read_content_core(Stream &strm, Request &req, Response &res, ContentReceiver receiver,
+	                       MultipartContentHeader multipart_header, ContentReceiver multipart_receiver) const;
 
-  virtual bool process_and_close_socket(socket_t sock);
+	virtual bool process_and_close_socket(socket_t sock);
 
-  std::atomic<bool> is_running_{false};
-  std::atomic<bool> done_{false};
+	std::atomic<bool> is_running_ {false};
+	std::atomic<bool> done_ {false};
 
-  struct MountPointEntry {
-    std::string mount_point;
-    std::string base_dir;
-    Headers headers;
-  };
-  std::vector<MountPointEntry> base_dirs_;
-  std::map<std::string, std::string> file_extension_and_mimetype_map_;
-  std::string default_file_mimetype_ = "application/octet-stream";
-  Handler file_request_handler_;
+	struct MountPointEntry {
+		std::string mount_point;
+		std::string base_dir;
+		Headers headers;
+	};
+	std::vector<MountPointEntry> base_dirs_;
+	std::map<std::string, std::string> file_extension_and_mimetype_map_;
+	std::string default_file_mimetype_ = "application/octet-stream";
+	Handler file_request_handler_;
 
-  Handlers get_handlers_;
-  Handlers post_handlers_;
-  HandlersForContentReader post_handlers_for_content_reader_;
-  Handlers put_handlers_;
-  HandlersForContentReader put_handlers_for_content_reader_;
-  Handlers patch_handlers_;
-  HandlersForContentReader patch_handlers_for_content_reader_;
-  Handlers delete_handlers_;
-  HandlersForContentReader delete_handlers_for_content_reader_;
-  Handlers options_handlers_;
+	Handlers get_handlers_;
+	Handlers post_handlers_;
+	HandlersForContentReader post_handlers_for_content_reader_;
+	Handlers put_handlers_;
+	HandlersForContentReader put_handlers_for_content_reader_;
+	Handlers patch_handlers_;
+	HandlersForContentReader patch_handlers_for_content_reader_;
+	Handlers delete_handlers_;
+	HandlersForContentReader delete_handlers_for_content_reader_;
+	Handlers options_handlers_;
 
-  HandlerWithResponse error_handler_;
-  ExceptionHandler exception_handler_;
-  HandlerWithResponse pre_routing_handler_;
-  Handler post_routing_handler_;
-  Expect100ContinueHandler expect_100_continue_handler_;
+	HandlerWithResponse error_handler_;
+	ExceptionHandler exception_handler_;
+	HandlerWithResponse pre_routing_handler_;
+	Handler post_routing_handler_;
+	Expect100ContinueHandler expect_100_continue_handler_;
 
-  Logger logger_;
+	Logger logger_;
 
-  int address_family_ = AF_UNSPEC;
-  bool tcp_nodelay_ = CPPHTTPLIB_TCP_NODELAY;
-  SocketOptions socket_options_ = default_socket_options;
+	int address_family_ = AF_UNSPEC;
+	bool tcp_nodelay_ = CPPHTTPLIB_TCP_NODELAY;
+	SocketOptions socket_options_ = default_socket_options;
 
-  Headers default_headers_;
-  std::function<ssize_t(Stream &, Headers &)> header_writer_ =
-      detail::write_headers;
+	Headers default_headers_;
+	std::function<ssize_t(Stream &, Headers &)> header_writer_ = detail::write_headers;
 };
 
 enum class Error {
-  Success = 0,
-  Unknown,
-  Connection,
-  BindIPAddress,
-  Read,
-  Write,
-  ExceedRedirectCount,
-  Canceled,
-  SSLConnection,
-  SSLLoadingCerts,
-  SSLServerVerification,
-  UnsupportedMultipartBoundaryChars,
-  Compression,
-  ConnectionTimeout,
-  ProxyConnection,
+	Success = 0,
+	Unknown,
+	Connection,
+	BindIPAddress,
+	Read,
+	Write,
+	ExceedRedirectCount,
+	Canceled,
+	SSLConnection,
+	SSLLoadingCerts,
+	SSLServerVerification,
+	UnsupportedMultipartBoundaryChars,
+	Compression,
+	ConnectionTimeout,
+	ProxyConnection,
 
-  // For internal use only
-  SSLPeerCouldBeClosed_,
+	// For internal use only
+	SSLPeerCouldBeClosed_,
 };
 
 std::string to_string(Error error);
@@ -1066,744 +1033,654 @@ std::ostream &operator<<(std::ostream &os, const Error &obj);
 
 class Result {
 public:
-  Result() = default;
-  Result(duckdb::unique_ptr<Response> &&res, Error err,
-         Headers &&request_headers = Headers{})
-      : res_(std::move(res)), err_(err),
-        request_headers_(std::move(request_headers)) {}
-  // Response
-  operator bool() const { return res_ != nullptr; }
-  bool operator==(std::nullptr_t) const { return res_ == nullptr; }
-  bool operator!=(std::nullptr_t) const { return res_ != nullptr; }
-  const Response &value() const { return *res_; }
-  Response &value() { return *res_; }
-  const Response &operator*() const { return *res_; }
-  Response &operator*() { return *res_; }
-  const Response *operator->() const { return res_.get(); }
-  Response *operator->() { return res_.get(); }
+	Result() = default;
+	Result(duckdb::unique_ptr<Response> &&res, Error err, Headers &&request_headers = Headers {})
+	    : res_(std::move(res)), err_(err), request_headers_(std::move(request_headers)) {
+	}
+	// Response
+	operator bool() const {
+		return res_ != nullptr;
+	}
+	bool operator==(std::nullptr_t) const {
+		return res_ == nullptr;
+	}
+	bool operator!=(std::nullptr_t) const {
+		return res_ != nullptr;
+	}
+	const Response &value() const {
+		return *res_;
+	}
+	Response &value() {
+		return *res_;
+	}
+	const Response &operator*() const {
+		return *res_;
+	}
+	Response &operator*() {
+		return *res_;
+	}
+	const Response *operator->() const {
+		return res_.get();
+	}
+	Response *operator->() {
+		return res_.get();
+	}
 
-  // Error
-  Error error() const { return err_; }
+	// Error
+	Error error() const {
+		return err_;
+	}
 
-  // Request Headers
-  bool has_request_header(const std::string &key) const;
-  std::string get_request_header_value(const std::string &key,
-                                       size_t id = 0) const;
-  uint64_t get_request_header_value_u64(const std::string &key,
-                                        size_t id = 0) const;
-  size_t get_request_header_value_count(const std::string &key) const;
+	// Request Headers
+	bool has_request_header(const std::string &key) const;
+	std::string get_request_header_value(const std::string &key, size_t id = 0) const;
+	uint64_t get_request_header_value_u64(const std::string &key, size_t id = 0) const;
+	size_t get_request_header_value_count(const std::string &key) const;
 
 private:
-  duckdb::unique_ptr<Response> res_;
-  Error err_ = Error::Unknown;
-  Headers request_headers_;
+	duckdb::unique_ptr<Response> res_;
+	Error err_ = Error::Unknown;
+	Headers request_headers_;
 };
 
 class ClientImpl {
 public:
-  explicit ClientImpl(const std::string &host);
+	explicit ClientImpl(const std::string &host);
 
-  explicit ClientImpl(const std::string &host, int port);
+	explicit ClientImpl(const std::string &host, int port);
 
-  explicit ClientImpl(const std::string &host, int port,
-                      const std::string &client_cert_path,
-                      const std::string &client_key_path);
+	explicit ClientImpl(const std::string &host, int port, const std::string &client_cert_path,
+	                    const std::string &client_key_path);
 
-  virtual ~ClientImpl();
+	virtual ~ClientImpl();
 
-  virtual bool is_valid() const;
+	virtual bool is_valid() const;
 
-  Result Get(const std::string &path);
-  Result Get(const std::string &path, const Headers &headers);
-  Result Get(const std::string &path, Progress progress);
-  Result Get(const std::string &path, const Headers &headers,
-             Progress progress);
-  Result Get(const std::string &path, ContentReceiver content_receiver);
-  Result Get(const std::string &path, const Headers &headers,
-             ContentReceiver content_receiver);
-  Result Get(const std::string &path, ContentReceiver content_receiver,
-             Progress progress);
-  Result Get(const std::string &path, const Headers &headers,
-             ContentReceiver content_receiver, Progress progress);
-  Result Get(const std::string &path, ResponseHandler response_handler,
-             ContentReceiver content_receiver);
-  Result Get(const std::string &path, const Headers &headers,
-             ResponseHandler response_handler,
-             ContentReceiver content_receiver);
-  Result Get(const std::string &path, ResponseHandler response_handler,
-             ContentReceiver content_receiver, Progress progress);
-  Result Get(const std::string &path, const Headers &headers,
-             ResponseHandler response_handler, ContentReceiver content_receiver,
-             Progress progress);
+	Result Get(const std::string &path);
+	Result Get(const std::string &path, const Headers &headers);
+	Result Get(const std::string &path, Progress progress);
+	Result Get(const std::string &path, const Headers &headers, Progress progress);
+	Result Get(const std::string &path, ContentReceiver content_receiver);
+	Result Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver);
+	Result Get(const std::string &path, ContentReceiver content_receiver, Progress progress);
+	Result Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver, Progress progress);
+	Result Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver);
+	Result Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
+	           ContentReceiver content_receiver);
+	Result Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver,
+	           Progress progress);
+	Result Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
+	           ContentReceiver content_receiver, Progress progress);
 
-  Result Get(const std::string &path, const Params &params,
-             const Headers &headers, Progress progress = nullptr);
-  Result Get(const std::string &path, const Params &params,
-             const Headers &headers, ContentReceiver content_receiver,
-             Progress progress = nullptr);
-  Result Get(const std::string &path, const Params &params,
-             const Headers &headers, ResponseHandler response_handler,
-             ContentReceiver content_receiver, Progress progress = nullptr);
+	Result Get(const std::string &path, const Params &params, const Headers &headers, Progress progress = nullptr);
+	Result Get(const std::string &path, const Params &params, const Headers &headers, ContentReceiver content_receiver,
+	           Progress progress = nullptr);
+	Result Get(const std::string &path, const Params &params, const Headers &headers, ResponseHandler response_handler,
+	           ContentReceiver content_receiver, Progress progress = nullptr);
 
-  Result Head(const std::string &path);
-  Result Head(const std::string &path, const Headers &headers);
+	Result Head(const std::string &path);
+	Result Head(const std::string &path, const Headers &headers);
 
-  Result Post(const std::string &path);
-  Result Post(const std::string &path, const Headers &headers);
-  Result Post(const std::string &path, const char *body, size_t content_length,
-              const std::string &content_type);
-  Result Post(const std::string &path, const Headers &headers, const char *body,
-              size_t content_length, const std::string &content_type);
-  Result Post(const std::string &path, const std::string &body,
-              const std::string &content_type);
-  Result Post(const std::string &path, const Headers &headers,
-              const std::string &body, const std::string &content_type);
-  Result Post(const std::string &path, size_t content_length,
-              ContentProvider content_provider,
-              const std::string &content_type);
-  Result Post(const std::string &path,
-              ContentProviderWithoutLength content_provider,
-              const std::string &content_type);
-  Result Post(const std::string &path, const Headers &headers,
-              size_t content_length, ContentProvider content_provider,
-              const std::string &content_type);
-  Result Post(const std::string &path, const Headers &headers,
-              ContentProviderWithoutLength content_provider,
-              const std::string &content_type);
-  Result Post(const std::string &path, const Params &params);
-  Result Post(const std::string &path, const Headers &headers,
-              const Params &params);
-  Result Post(const std::string &path, const MultipartFormDataItems &items);
-  Result Post(const std::string &path, const Headers &headers,
-              const MultipartFormDataItems &items);
-  Result Post(const std::string &path, const Headers &headers,
-              const MultipartFormDataItems &items, const std::string &boundary);
-  Result Post(const std::string &path, const Headers &headers,
-              const MultipartFormDataItems &items,
-              const MultipartFormDataProviderItems &provider_items);
+	Result Post(const std::string &path);
+	Result Post(const std::string &path, const Headers &headers);
+	Result Post(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
+	Result Post(const std::string &path, const Headers &headers, const char *body, size_t content_length,
+	            const std::string &content_type);
+	Result Post(const std::string &path, const std::string &body, const std::string &content_type);
+	Result Post(const std::string &path, const Headers &headers, const std::string &body,
+	            const std::string &content_type);
+	Result Post(const std::string &path, size_t content_length, ContentProvider content_provider,
+	            const std::string &content_type);
+	Result Post(const std::string &path, ContentProviderWithoutLength content_provider,
+	            const std::string &content_type);
+	Result Post(const std::string &path, const Headers &headers, size_t content_length,
+	            ContentProvider content_provider, const std::string &content_type);
+	Result Post(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
+	            const std::string &content_type);
+	Result Post(const std::string &path, const Params &params);
+	Result Post(const std::string &path, const Headers &headers, const Params &params);
+	Result Post(const std::string &path, const MultipartFormDataItems &items);
+	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items);
+	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+	            const std::string &boundary);
+	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+	            const MultipartFormDataProviderItems &provider_items);
 
-  Result Put(const std::string &path);
-  Result Put(const std::string &path, const char *body, size_t content_length,
-             const std::string &content_type);
-  Result Put(const std::string &path, const Headers &headers, const char *body,
-             size_t content_length, const std::string &content_type);
-  Result Put(const std::string &path, const std::string &body,
-             const std::string &content_type);
-  Result Put(const std::string &path, const Headers &headers,
-             const std::string &body, const std::string &content_type);
-  Result Put(const std::string &path, size_t content_length,
-             ContentProvider content_provider, const std::string &content_type);
-  Result Put(const std::string &path,
-             ContentProviderWithoutLength content_provider,
-             const std::string &content_type);
-  Result Put(const std::string &path, const Headers &headers,
-             size_t content_length, ContentProvider content_provider,
-             const std::string &content_type);
-  Result Put(const std::string &path, const Headers &headers,
-             ContentProviderWithoutLength content_provider,
-             const std::string &content_type);
-  Result Put(const std::string &path, const Params &params);
-  Result Put(const std::string &path, const Headers &headers,
-             const Params &params);
-  Result Put(const std::string &path, const MultipartFormDataItems &items);
-  Result Put(const std::string &path, const Headers &headers,
-             const MultipartFormDataItems &items);
-  Result Put(const std::string &path, const Headers &headers,
-             const MultipartFormDataItems &items, const std::string &boundary);
-  Result Put(const std::string &path, const Headers &headers,
-             const MultipartFormDataItems &items,
-             const MultipartFormDataProviderItems &provider_items);
+	Result Put(const std::string &path);
+	Result Put(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
+	Result Put(const std::string &path, const Headers &headers, const char *body, size_t content_length,
+	           const std::string &content_type);
+	Result Put(const std::string &path, const std::string &body, const std::string &content_type);
+	Result Put(const std::string &path, const Headers &headers, const std::string &body,
+	           const std::string &content_type);
+	Result Put(const std::string &path, size_t content_length, ContentProvider content_provider,
+	           const std::string &content_type);
+	Result Put(const std::string &path, ContentProviderWithoutLength content_provider, const std::string &content_type);
+	Result Put(const std::string &path, const Headers &headers, size_t content_length, ContentProvider content_provider,
+	           const std::string &content_type);
+	Result Put(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
+	           const std::string &content_type);
+	Result Put(const std::string &path, const Params &params);
+	Result Put(const std::string &path, const Headers &headers, const Params &params);
+	Result Put(const std::string &path, const MultipartFormDataItems &items);
+	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items);
+	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+	           const std::string &boundary);
+	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+	           const MultipartFormDataProviderItems &provider_items);
 
-  Result Patch(const std::string &path);
-  Result Patch(const std::string &path, const char *body, size_t content_length,
-               const std::string &content_type);
-  Result Patch(const std::string &path, const Headers &headers,
-               const char *body, size_t content_length,
-               const std::string &content_type);
-  Result Patch(const std::string &path, const std::string &body,
-               const std::string &content_type);
-  Result Patch(const std::string &path, const Headers &headers,
-               const std::string &body, const std::string &content_type);
-  Result Patch(const std::string &path, size_t content_length,
-               ContentProvider content_provider,
-               const std::string &content_type);
-  Result Patch(const std::string &path,
-               ContentProviderWithoutLength content_provider,
-               const std::string &content_type);
-  Result Patch(const std::string &path, const Headers &headers,
-               size_t content_length, ContentProvider content_provider,
-               const std::string &content_type);
-  Result Patch(const std::string &path, const Headers &headers,
-               ContentProviderWithoutLength content_provider,
-               const std::string &content_type);
+	Result Patch(const std::string &path);
+	Result Patch(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
+	Result Patch(const std::string &path, const Headers &headers, const char *body, size_t content_length,
+	             const std::string &content_type);
+	Result Patch(const std::string &path, const std::string &body, const std::string &content_type);
+	Result Patch(const std::string &path, const Headers &headers, const std::string &body,
+	             const std::string &content_type);
+	Result Patch(const std::string &path, size_t content_length, ContentProvider content_provider,
+	             const std::string &content_type);
+	Result Patch(const std::string &path, ContentProviderWithoutLength content_provider,
+	             const std::string &content_type);
+	Result Patch(const std::string &path, const Headers &headers, size_t content_length,
+	             ContentProvider content_provider, const std::string &content_type);
+	Result Patch(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
+	             const std::string &content_type);
 
-  Result Delete(const std::string &path);
-  Result Delete(const std::string &path, const Headers &headers);
-  Result Delete(const std::string &path, const char *body,
-                size_t content_length, const std::string &content_type);
-  Result Delete(const std::string &path, const Headers &headers,
-                const char *body, size_t content_length,
-                const std::string &content_type);
-  Result Delete(const std::string &path, const std::string &body,
-                const std::string &content_type);
-  Result Delete(const std::string &path, const Headers &headers,
-                const std::string &body, const std::string &content_type);
+	Result Delete(const std::string &path);
+	Result Delete(const std::string &path, const Headers &headers);
+	Result Delete(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
+	Result Delete(const std::string &path, const Headers &headers, const char *body, size_t content_length,
+	              const std::string &content_type);
+	Result Delete(const std::string &path, const std::string &body, const std::string &content_type);
+	Result Delete(const std::string &path, const Headers &headers, const std::string &body,
+	              const std::string &content_type);
 
-  Result Options(const std::string &path);
-  Result Options(const std::string &path, const Headers &headers);
+	Result Options(const std::string &path);
+	Result Options(const std::string &path, const Headers &headers);
 
-  bool send(Request &req, Response &res, Error &error);
-  Result send(const Request &req);
+	bool send(Request &req, Response &res, Error &error);
+	Result send(const Request &req);
 
-  void stop();
+	void stop();
 
-  std::string host() const;
-  int port() const;
+	std::string host() const;
+	int port() const;
 
-  size_t is_socket_open() const;
-  socket_t socket() const;
+	size_t is_socket_open() const;
+	socket_t socket() const;
 
-  void set_hostname_addr_map(std::map<std::string, std::string> addr_map);
+	void set_hostname_addr_map(std::map<std::string, std::string> addr_map);
 
-  void set_default_headers(Headers headers);
+	void set_default_headers(Headers headers);
 
-  void
-  set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
+	void set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
 
-  void set_address_family(int family);
-  void set_tcp_nodelay(bool on);
-  void set_socket_options(SocketOptions socket_options);
+	void set_address_family(int family);
+	void set_tcp_nodelay(bool on);
+	void set_socket_options(SocketOptions socket_options);
 
-  void set_connection_timeout(time_t sec, time_t usec = 0);
-  template <class Rep, class Period>
-  void
-  set_connection_timeout(const std::chrono::duration<Rep, Period> &duration);
+	void set_connection_timeout(time_t sec, time_t usec = 0);
+	template <class Rep, class Period>
+	void set_connection_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-  void set_read_timeout(time_t sec, time_t usec = 0);
-  template <class Rep, class Period>
-  void set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
+	void set_read_timeout(time_t sec, time_t usec = 0);
+	template <class Rep, class Period>
+	void set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-  void set_write_timeout(time_t sec, time_t usec = 0);
-  template <class Rep, class Period>
-  void set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
+	void set_write_timeout(time_t sec, time_t usec = 0);
+	template <class Rep, class Period>
+	void set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-  void set_basic_auth(const std::string &username, const std::string &password);
-  void set_bearer_token_auth(const std::string &token);
+	void set_basic_auth(const std::string &username, const std::string &password);
+	void set_bearer_token_auth(const std::string &token);
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  void set_digest_auth(const std::string &username,
-                       const std::string &password);
+	void set_digest_auth(const std::string &username, const std::string &password);
 #endif
 
-  void set_keep_alive(bool on);
-  void set_follow_location(bool on);
+	void set_keep_alive(bool on);
+	void set_follow_location(bool on);
 
-  void set_url_encode(bool on);
+	void set_url_encode(bool on);
 
-  void set_compress(bool on);
+	void set_compress(bool on);
 
-  void set_decompress(bool on);
+	void set_decompress(bool on);
 
-  void set_interface(const std::string &intf);
+	void set_interface(const std::string &intf);
 
-  void set_proxy(const std::string &host, int port);
-  void set_proxy_basic_auth(const std::string &username,
-                            const std::string &password);
-  void set_proxy_bearer_token_auth(const std::string &token);
+	void set_proxy(const std::string &host, int port);
+	void set_proxy_basic_auth(const std::string &username, const std::string &password);
+	void set_proxy_bearer_token_auth(const std::string &token);
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  void set_proxy_digest_auth(const std::string &username,
-                             const std::string &password);
+	void set_proxy_digest_auth(const std::string &username, const std::string &password);
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  void set_ca_cert_path(const std::string &ca_cert_file_path,
-                        const std::string &ca_cert_dir_path = std::string());
-  void set_ca_cert_store(X509_STORE *ca_cert_store);
-  X509_STORE *create_ca_cert_store(const char *ca_cert, std::size_t size) const;
+	void set_ca_cert_path(const std::string &ca_cert_file_path, const std::string &ca_cert_dir_path = std::string());
+	void set_ca_cert_store(X509_STORE *ca_cert_store);
+	X509_STORE *create_ca_cert_store(const char *ca_cert, std::size_t size) const;
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  void enable_server_certificate_verification(bool enabled);
+	void enable_server_certificate_verification(bool enabled);
 #endif
 
-  void set_logger(Logger logger);
+	void set_logger(Logger logger);
 
 protected:
-  struct Socket {
-    socket_t sock = INVALID_SOCKET;
+	struct Socket {
+		socket_t sock = INVALID_SOCKET;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    SSL *ssl = nullptr;
+		SSL *ssl = nullptr;
 #endif
 
-    bool is_open() const { return sock != INVALID_SOCKET; }
-  };
+		bool is_open() const {
+			return sock != INVALID_SOCKET;
+		}
+	};
 
-  virtual bool create_and_connect_socket(Socket &socket, Error &error);
+	virtual bool create_and_connect_socket(Socket &socket, Error &error);
 
-  // All of:
-  //   shutdown_ssl
-  //   shutdown_socket
-  //   close_socket
-  // should ONLY be called when socket_mutex_ is locked.
-  // Also, shutdown_ssl and close_socket should also NOT be called concurrently
-  // with a DIFFERENT thread sending requests using that socket.
-  virtual void shutdown_ssl(Socket &socket, bool shutdown_gracefully);
-  void shutdown_socket(Socket &socket) const;
-  void close_socket(Socket &socket);
+	// All of:
+	//   shutdown_ssl
+	//   shutdown_socket
+	//   close_socket
+	// should ONLY be called when socket_mutex_ is locked.
+	// Also, shutdown_ssl and close_socket should also NOT be called concurrently
+	// with a DIFFERENT thread sending requests using that socket.
+	virtual void shutdown_ssl(Socket &socket, bool shutdown_gracefully);
+	void shutdown_socket(Socket &socket) const;
+	void close_socket(Socket &socket);
 
-  bool process_request(Stream &strm, Request &req, Response &res,
-                       bool close_connection, Error &error);
+	bool process_request(Stream &strm, Request &req, Response &res, bool close_connection, Error &error);
 
-  bool write_content_with_provider(Stream &strm, const Request &req,
-                                   Error &error) const;
+	bool write_content_with_provider(Stream &strm, const Request &req, Error &error) const;
 
-  void copy_settings(const ClientImpl &rhs);
+	void copy_settings(const ClientImpl &rhs);
 
-  // Socket endpoint information
-  const std::string host_;
-  const int port_;
-  const std::string host_and_port_;
+	// Socket endpoint information
+	const std::string host_;
+	const int port_;
+	const std::string host_and_port_;
 
-  // Current open socket
-  Socket socket_;
-  mutable std::mutex socket_mutex_;
-  std::recursive_mutex request_mutex_;
+	// Current open socket
+	Socket socket_;
+	mutable std::mutex socket_mutex_;
+	std::recursive_mutex request_mutex_;
 
-  // These are all protected under socket_mutex
-  size_t socket_requests_in_flight_ = 0;
-  std::thread::id socket_requests_are_from_thread_ = std::thread::id();
-  bool socket_should_be_closed_when_request_is_done_ = false;
+	// These are all protected under socket_mutex
+	size_t socket_requests_in_flight_ = 0;
+	std::thread::id socket_requests_are_from_thread_ = std::thread::id();
+	bool socket_should_be_closed_when_request_is_done_ = false;
 
-  // Hostname-IP map
-  std::map<std::string, std::string> addr_map_;
+	// Hostname-IP map
+	std::map<std::string, std::string> addr_map_;
 
-  // Default headers
-  Headers default_headers_;
+	// Default headers
+	Headers default_headers_;
 
-  // Header writer
-  std::function<ssize_t(Stream &, Headers &)> header_writer_ =
-      detail::write_headers;
+	// Header writer
+	std::function<ssize_t(Stream &, Headers &)> header_writer_ = detail::write_headers;
 
-  // Settings
-  std::string client_cert_path_;
-  std::string client_key_path_;
+	// Settings
+	std::string client_cert_path_;
+	std::string client_key_path_;
 
-  time_t connection_timeout_sec_ = CPPHTTPLIB_CONNECTION_TIMEOUT_SECOND;
-  time_t connection_timeout_usec_ = CPPHTTPLIB_CONNECTION_TIMEOUT_USECOND;
-  time_t read_timeout_sec_ = CPPHTTPLIB_READ_TIMEOUT_SECOND;
-  time_t read_timeout_usec_ = CPPHTTPLIB_READ_TIMEOUT_USECOND;
-  time_t write_timeout_sec_ = CPPHTTPLIB_WRITE_TIMEOUT_SECOND;
-  time_t write_timeout_usec_ = CPPHTTPLIB_WRITE_TIMEOUT_USECOND;
+	time_t connection_timeout_sec_ = CPPHTTPLIB_CONNECTION_TIMEOUT_SECOND;
+	time_t connection_timeout_usec_ = CPPHTTPLIB_CONNECTION_TIMEOUT_USECOND;
+	time_t read_timeout_sec_ = CPPHTTPLIB_READ_TIMEOUT_SECOND;
+	time_t read_timeout_usec_ = CPPHTTPLIB_READ_TIMEOUT_USECOND;
+	time_t write_timeout_sec_ = CPPHTTPLIB_WRITE_TIMEOUT_SECOND;
+	time_t write_timeout_usec_ = CPPHTTPLIB_WRITE_TIMEOUT_USECOND;
 
-  std::string basic_auth_username_;
-  std::string basic_auth_password_;
-  std::string bearer_token_auth_token_;
+	std::string basic_auth_username_;
+	std::string basic_auth_password_;
+	std::string bearer_token_auth_token_;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  std::string digest_auth_username_;
-  std::string digest_auth_password_;
+	std::string digest_auth_username_;
+	std::string digest_auth_password_;
 #endif
 
-  bool keep_alive_ = false;
-  bool follow_location_ = false;
+	bool keep_alive_ = false;
+	bool follow_location_ = false;
 
-  bool url_encode_ = true;
+	bool url_encode_ = true;
 
-  int address_family_ = AF_UNSPEC;
-  bool tcp_nodelay_ = CPPHTTPLIB_TCP_NODELAY;
-  SocketOptions socket_options_ = nullptr;
+	int address_family_ = AF_UNSPEC;
+	bool tcp_nodelay_ = CPPHTTPLIB_TCP_NODELAY;
+	SocketOptions socket_options_ = nullptr;
 
-  bool compress_ = false;
-  bool decompress_ = true;
+	bool compress_ = false;
+	bool decompress_ = true;
 
-  std::string interface_;
+	std::string interface_;
 
-  std::string proxy_host_;
-  int proxy_port_ = -1;
+	std::string proxy_host_;
+	int proxy_port_ = -1;
 
-  std::string proxy_basic_auth_username_;
-  std::string proxy_basic_auth_password_;
-  std::string proxy_bearer_token_auth_token_;
+	std::string proxy_basic_auth_username_;
+	std::string proxy_basic_auth_password_;
+	std::string proxy_bearer_token_auth_token_;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  std::string proxy_digest_auth_username_;
-  std::string proxy_digest_auth_password_;
-#endif
-
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  std::string ca_cert_file_path_;
-  std::string ca_cert_dir_path_;
-
-  X509_STORE *ca_cert_store_ = nullptr;
+	std::string proxy_digest_auth_username_;
+	std::string proxy_digest_auth_password_;
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  bool server_certificate_verification_ = true;
+	std::string ca_cert_file_path_;
+	std::string ca_cert_dir_path_;
+
+	X509_STORE *ca_cert_store_ = nullptr;
 #endif
 
-  Logger logger_;
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+	bool server_certificate_verification_ = true;
+#endif
+
+	Logger logger_;
 
 private:
-  bool send_(Request &req, Response &res, Error &error);
-  Result send_(Request &&req);
+	bool send_(Request &req, Response &res, Error &error);
+	Result send_(Request &&req);
 
-  socket_t create_client_socket(Error &error) const;
-  bool read_response_line(Stream &strm, const Request &req,
-                          Response &res) const;
-  bool write_request(Stream &strm, Request &req, bool close_connection,
-                     Error &error);
-  bool redirect(Request &req, Response &res, Error &error);
-  bool handle_request(Stream &strm, Request &req, Response &res,
-                      bool close_connection, Error &error);
-  duckdb::unique_ptr<Response> send_with_content_provider(
-      Request &req, const char *body, size_t content_length,
-      ContentProvider content_provider,
-      ContentProviderWithoutLength content_provider_without_length,
-      const std::string &content_type, Error &error);
-  Result send_with_content_provider(
-      const std::string &method, const std::string &path,
-      const Headers &headers, const char *body, size_t content_length,
-      ContentProvider content_provider,
-      ContentProviderWithoutLength content_provider_without_length,
-      const std::string &content_type);
-  ContentProviderWithoutLength get_multipart_content_provider(
-      const std::string &boundary, const MultipartFormDataItems &items,
-      const MultipartFormDataProviderItems &provider_items) const;
+	socket_t create_client_socket(Error &error) const;
+	bool read_response_line(Stream &strm, const Request &req, Response &res) const;
+	bool write_request(Stream &strm, Request &req, bool close_connection, Error &error);
+	bool redirect(Request &req, Response &res, Error &error);
+	bool handle_request(Stream &strm, Request &req, Response &res, bool close_connection, Error &error);
+	duckdb::unique_ptr<Response>
+	send_with_content_provider(Request &req, const char *body, size_t content_length, ContentProvider content_provider,
+	                           ContentProviderWithoutLength content_provider_without_length,
+	                           const std::string &content_type, Error &error);
+	Result send_with_content_provider(const std::string &method, const std::string &path, const Headers &headers,
+	                                  const char *body, size_t content_length, ContentProvider content_provider,
+	                                  ContentProviderWithoutLength content_provider_without_length,
+	                                  const std::string &content_type);
+	ContentProviderWithoutLength
+	get_multipart_content_provider(const std::string &boundary, const MultipartFormDataItems &items,
+	                               const MultipartFormDataProviderItems &provider_items) const;
 
-  std::string adjust_host_string(const std::string &host) const;
+	std::string adjust_host_string(const std::string &host) const;
 
-  virtual bool process_socket(const Socket &socket,
-                              std::function<bool(Stream &strm)> callback);
-  virtual bool is_ssl() const;
+	virtual bool process_socket(const Socket &socket, std::function<bool(Stream &strm)> callback);
+	virtual bool is_ssl() const;
 };
 
 class Client {
 public:
-  // Universal interface
-  explicit Client(const std::string &scheme_host_port);
+	// Universal interface
+	explicit Client(const std::string &scheme_host_port);
 
-  explicit Client(const std::string &scheme_host_port,
-                  const std::string &client_cert_path,
-                  const std::string &client_key_path);
+	explicit Client(const std::string &scheme_host_port, const std::string &client_cert_path,
+	                const std::string &client_key_path);
 
-  // HTTP only interface
-  explicit Client(const std::string &host, int port);
+	// HTTP only interface
+	explicit Client(const std::string &host, int port);
 
-  explicit Client(const std::string &host, int port,
-                  const std::string &client_cert_path,
-                  const std::string &client_key_path);
+	explicit Client(const std::string &host, int port, const std::string &client_cert_path,
+	                const std::string &client_key_path);
 
-  Client(Client &&) = default;
+	Client(Client &&) = default;
 
-  ~Client();
+	~Client();
 
-  bool is_valid() const;
+	bool is_valid() const;
 
-  Result Get(const std::string &path);
-  Result Get(const std::string &path, const Headers &headers);
-  Result Get(const std::string &path, Progress progress);
-  Result Get(const std::string &path, const Headers &headers,
-             Progress progress);
-  Result Get(const std::string &path, ContentReceiver content_receiver);
-  Result Get(const std::string &path, const Headers &headers,
-             ContentReceiver content_receiver);
-  Result Get(const std::string &path, ContentReceiver content_receiver,
-             Progress progress);
-  Result Get(const std::string &path, const Headers &headers,
-             ContentReceiver content_receiver, Progress progress);
-  Result Get(const std::string &path, ResponseHandler response_handler,
-             ContentReceiver content_receiver);
-  Result Get(const std::string &path, const Headers &headers,
-             ResponseHandler response_handler,
-             ContentReceiver content_receiver);
-  Result Get(const std::string &path, const Headers &headers,
-             ResponseHandler response_handler, ContentReceiver content_receiver,
-             Progress progress);
-  Result Get(const std::string &path, ResponseHandler response_handler,
-             ContentReceiver content_receiver, Progress progress);
+	Result Get(const std::string &path);
+	Result Get(const std::string &path, const Headers &headers);
+	Result Get(const std::string &path, Progress progress);
+	Result Get(const std::string &path, const Headers &headers, Progress progress);
+	Result Get(const std::string &path, ContentReceiver content_receiver);
+	Result Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver);
+	Result Get(const std::string &path, ContentReceiver content_receiver, Progress progress);
+	Result Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver, Progress progress);
+	Result Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver);
+	Result Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
+	           ContentReceiver content_receiver);
+	Result Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
+	           ContentReceiver content_receiver, Progress progress);
+	Result Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver,
+	           Progress progress);
 
-  Result Get(const std::string &path, const Params &params,
-             const Headers &headers, Progress progress = nullptr);
-  Result Get(const std::string &path, const Params &params,
-             const Headers &headers, ContentReceiver content_receiver,
-             Progress progress = nullptr);
-  Result Get(const std::string &path, const Params &params,
-             const Headers &headers, ResponseHandler response_handler,
-             ContentReceiver content_receiver, Progress progress = nullptr);
+	Result Get(const std::string &path, const Params &params, const Headers &headers, Progress progress = nullptr);
+	Result Get(const std::string &path, const Params &params, const Headers &headers, ContentReceiver content_receiver,
+	           Progress progress = nullptr);
+	Result Get(const std::string &path, const Params &params, const Headers &headers, ResponseHandler response_handler,
+	           ContentReceiver content_receiver, Progress progress = nullptr);
 
-  Result Head(const std::string &path);
-  Result Head(const std::string &path, const Headers &headers);
+	Result Head(const std::string &path);
+	Result Head(const std::string &path, const Headers &headers);
 
-  Result Post(const std::string &path);
-  Result Post(const std::string &path, const Headers &headers);
-  Result Post(const std::string &path, const char *body, size_t content_length,
-              const std::string &content_type);
-  Result Post(const std::string &path, const Headers &headers, const char *body,
-              size_t content_length, const std::string &content_type);
-  Result Post(const std::string &path, const std::string &body,
-              const std::string &content_type);
-  Result Post(const std::string &path, const Headers &headers,
-              const std::string &body, const std::string &content_type);
-  Result Post(const std::string &path, size_t content_length,
-              ContentProvider content_provider,
-              const std::string &content_type);
-  Result Post(const std::string &path,
-              ContentProviderWithoutLength content_provider,
-              const std::string &content_type);
-  Result Post(const std::string &path, const Headers &headers,
-              size_t content_length, ContentProvider content_provider,
-              const std::string &content_type);
-  Result Post(const std::string &path, const Headers &headers,
-              ContentProviderWithoutLength content_provider,
-              const std::string &content_type);
-  Result Post(const std::string &path, const Params &params);
-  Result Post(const std::string &path, const Headers &headers,
-              const Params &params);
-  Result Post(const std::string &path, const MultipartFormDataItems &items);
-  Result Post(const std::string &path, const Headers &headers,
-              const MultipartFormDataItems &items);
-  Result Post(const std::string &path, const Headers &headers,
-              const MultipartFormDataItems &items, const std::string &boundary);
-  Result Post(const std::string &path, const Headers &headers,
-              const MultipartFormDataItems &items,
-              const MultipartFormDataProviderItems &provider_items);
+	Result Post(const std::string &path);
+	Result Post(const std::string &path, const Headers &headers);
+	Result Post(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
+	Result Post(const std::string &path, const Headers &headers, const char *body, size_t content_length,
+	            const std::string &content_type);
+	Result Post(const std::string &path, const std::string &body, const std::string &content_type);
+	Result Post(const std::string &path, const Headers &headers, const std::string &body,
+	            const std::string &content_type);
+	Result Post(const std::string &path, size_t content_length, ContentProvider content_provider,
+	            const std::string &content_type);
+	Result Post(const std::string &path, ContentProviderWithoutLength content_provider,
+	            const std::string &content_type);
+	Result Post(const std::string &path, const Headers &headers, size_t content_length,
+	            ContentProvider content_provider, const std::string &content_type);
+	Result Post(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
+	            const std::string &content_type);
+	Result Post(const std::string &path, const Params &params);
+	Result Post(const std::string &path, const Headers &headers, const Params &params);
+	Result Post(const std::string &path, const MultipartFormDataItems &items);
+	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items);
+	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+	            const std::string &boundary);
+	Result Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+	            const MultipartFormDataProviderItems &provider_items);
 
-  Result Put(const std::string &path);
-  Result Put(const std::string &path, const char *body, size_t content_length,
-             const std::string &content_type);
-  Result Put(const std::string &path, const Headers &headers, const char *body,
-             size_t content_length, const std::string &content_type);
-  Result Put(const std::string &path, const std::string &body,
-             const std::string &content_type);
-  Result Put(const std::string &path, const Headers &headers,
-             const std::string &body, const std::string &content_type);
-  Result Put(const std::string &path, size_t content_length,
-             ContentProvider content_provider, const std::string &content_type);
-  Result Put(const std::string &path,
-             ContentProviderWithoutLength content_provider,
-             const std::string &content_type);
-  Result Put(const std::string &path, const Headers &headers,
-             size_t content_length, ContentProvider content_provider,
-             const std::string &content_type);
-  Result Put(const std::string &path, const Headers &headers,
-             ContentProviderWithoutLength content_provider,
-             const std::string &content_type);
-  Result Put(const std::string &path, const Params &params);
-  Result Put(const std::string &path, const Headers &headers,
-             const Params &params);
-  Result Put(const std::string &path, const MultipartFormDataItems &items);
-  Result Put(const std::string &path, const Headers &headers,
-             const MultipartFormDataItems &items);
-  Result Put(const std::string &path, const Headers &headers,
-             const MultipartFormDataItems &items, const std::string &boundary);
-  Result Put(const std::string &path, const Headers &headers,
-             const MultipartFormDataItems &items,
-             const MultipartFormDataProviderItems &provider_items);
+	Result Put(const std::string &path);
+	Result Put(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
+	Result Put(const std::string &path, const Headers &headers, const char *body, size_t content_length,
+	           const std::string &content_type);
+	Result Put(const std::string &path, const std::string &body, const std::string &content_type);
+	Result Put(const std::string &path, const Headers &headers, const std::string &body,
+	           const std::string &content_type);
+	Result Put(const std::string &path, size_t content_length, ContentProvider content_provider,
+	           const std::string &content_type);
+	Result Put(const std::string &path, ContentProviderWithoutLength content_provider, const std::string &content_type);
+	Result Put(const std::string &path, const Headers &headers, size_t content_length, ContentProvider content_provider,
+	           const std::string &content_type);
+	Result Put(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
+	           const std::string &content_type);
+	Result Put(const std::string &path, const Params &params);
+	Result Put(const std::string &path, const Headers &headers, const Params &params);
+	Result Put(const std::string &path, const MultipartFormDataItems &items);
+	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items);
+	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+	           const std::string &boundary);
+	Result Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+	           const MultipartFormDataProviderItems &provider_items);
 
-  Result Patch(const std::string &path);
-  Result Patch(const std::string &path, const char *body, size_t content_length,
-               const std::string &content_type);
-  Result Patch(const std::string &path, const Headers &headers,
-               const char *body, size_t content_length,
-               const std::string &content_type);
-  Result Patch(const std::string &path, const std::string &body,
-               const std::string &content_type);
-  Result Patch(const std::string &path, const Headers &headers,
-               const std::string &body, const std::string &content_type);
-  Result Patch(const std::string &path, size_t content_length,
-               ContentProvider content_provider,
-               const std::string &content_type);
-  Result Patch(const std::string &path,
-               ContentProviderWithoutLength content_provider,
-               const std::string &content_type);
-  Result Patch(const std::string &path, const Headers &headers,
-               size_t content_length, ContentProvider content_provider,
-               const std::string &content_type);
-  Result Patch(const std::string &path, const Headers &headers,
-               ContentProviderWithoutLength content_provider,
-               const std::string &content_type);
+	Result Patch(const std::string &path);
+	Result Patch(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
+	Result Patch(const std::string &path, const Headers &headers, const char *body, size_t content_length,
+	             const std::string &content_type);
+	Result Patch(const std::string &path, const std::string &body, const std::string &content_type);
+	Result Patch(const std::string &path, const Headers &headers, const std::string &body,
+	             const std::string &content_type);
+	Result Patch(const std::string &path, size_t content_length, ContentProvider content_provider,
+	             const std::string &content_type);
+	Result Patch(const std::string &path, ContentProviderWithoutLength content_provider,
+	             const std::string &content_type);
+	Result Patch(const std::string &path, const Headers &headers, size_t content_length,
+	             ContentProvider content_provider, const std::string &content_type);
+	Result Patch(const std::string &path, const Headers &headers, ContentProviderWithoutLength content_provider,
+	             const std::string &content_type);
 
-  Result Delete(const std::string &path);
-  Result Delete(const std::string &path, const Headers &headers);
-  Result Delete(const std::string &path, const char *body,
-                size_t content_length, const std::string &content_type);
-  Result Delete(const std::string &path, const Headers &headers,
-                const char *body, size_t content_length,
-                const std::string &content_type);
-  Result Delete(const std::string &path, const std::string &body,
-                const std::string &content_type);
-  Result Delete(const std::string &path, const Headers &headers,
-                const std::string &body, const std::string &content_type);
+	Result Delete(const std::string &path);
+	Result Delete(const std::string &path, const Headers &headers);
+	Result Delete(const std::string &path, const char *body, size_t content_length, const std::string &content_type);
+	Result Delete(const std::string &path, const Headers &headers, const char *body, size_t content_length,
+	              const std::string &content_type);
+	Result Delete(const std::string &path, const std::string &body, const std::string &content_type);
+	Result Delete(const std::string &path, const Headers &headers, const std::string &body,
+	              const std::string &content_type);
 
-  Result Options(const std::string &path);
-  Result Options(const std::string &path, const Headers &headers);
+	Result Options(const std::string &path);
+	Result Options(const std::string &path, const Headers &headers);
 
-  bool send(Request &req, Response &res, Error &error);
-  Result send(const Request &req);
+	bool send(Request &req, Response &res, Error &error);
+	Result send(const Request &req);
 
-  void stop();
+	void stop();
 
-  std::string host() const;
-  int port() const;
+	std::string host() const;
+	int port() const;
 
-  size_t is_socket_open() const;
-  socket_t socket() const;
+	size_t is_socket_open() const;
+	socket_t socket() const;
 
-  void set_hostname_addr_map(std::map<std::string, std::string> addr_map);
+	void set_hostname_addr_map(std::map<std::string, std::string> addr_map);
 
-  void set_default_headers(Headers headers);
+	void set_default_headers(Headers headers);
 
-  void
-  set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
+	void set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer);
 
-  void set_address_family(int family);
-  void set_tcp_nodelay(bool on);
-  void set_socket_options(SocketOptions socket_options);
+	void set_address_family(int family);
+	void set_tcp_nodelay(bool on);
+	void set_socket_options(SocketOptions socket_options);
 
-  void set_connection_timeout(time_t sec, time_t usec = 0);
-  template <class Rep, class Period>
-  void
-  set_connection_timeout(const std::chrono::duration<Rep, Period> &duration);
+	void set_connection_timeout(time_t sec, time_t usec = 0);
+	template <class Rep, class Period>
+	void set_connection_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-  void set_read_timeout(time_t sec, time_t usec = 0);
-  template <class Rep, class Period>
-  void set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
+	void set_read_timeout(time_t sec, time_t usec = 0);
+	template <class Rep, class Period>
+	void set_read_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-  void set_write_timeout(time_t sec, time_t usec = 0);
-  template <class Rep, class Period>
-  void set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
+	void set_write_timeout(time_t sec, time_t usec = 0);
+	template <class Rep, class Period>
+	void set_write_timeout(const std::chrono::duration<Rep, Period> &duration);
 
-  void set_basic_auth(const std::string &username, const std::string &password);
-  void set_bearer_token_auth(const std::string &token);
+	void set_basic_auth(const std::string &username, const std::string &password);
+	void set_bearer_token_auth(const std::string &token);
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  void set_digest_auth(const std::string &username,
-                       const std::string &password);
+	void set_digest_auth(const std::string &username, const std::string &password);
 #endif
 
-  void set_keep_alive(bool on);
-  void set_follow_location(bool on);
+	void set_keep_alive(bool on);
+	void set_follow_location(bool on);
 
-  void set_url_encode(bool on);
+	void set_url_encode(bool on);
 
-  void set_compress(bool on);
+	void set_compress(bool on);
 
-  void set_decompress(bool on);
+	void set_decompress(bool on);
 
-  void set_interface(const std::string &intf);
+	void set_interface(const std::string &intf);
 
-  void set_proxy(const std::string &host, int port);
-  void set_proxy_basic_auth(const std::string &username,
-                            const std::string &password);
-  void set_proxy_bearer_token_auth(const std::string &token);
+	void set_proxy(const std::string &host, int port);
+	void set_proxy_basic_auth(const std::string &username, const std::string &password);
+	void set_proxy_bearer_token_auth(const std::string &token);
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  void set_proxy_digest_auth(const std::string &username,
-                             const std::string &password);
+	void set_proxy_digest_auth(const std::string &username, const std::string &password);
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  void enable_server_certificate_verification(bool enabled);
+	void enable_server_certificate_verification(bool enabled);
 #endif
 
-  void set_logger(Logger logger);
+	void set_logger(Logger logger);
 
-  // SSL
+	// SSL
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  void set_ca_cert_path(const std::string &ca_cert_file_path,
-                        const std::string &ca_cert_dir_path = std::string());
+	void set_ca_cert_path(const std::string &ca_cert_file_path, const std::string &ca_cert_dir_path = std::string());
 
-  void set_ca_cert_store(X509_STORE *ca_cert_store);
-  void load_ca_cert_store(const char *ca_cert, std::size_t size);
+	void set_ca_cert_store(X509_STORE *ca_cert_store);
+	void load_ca_cert_store(const char *ca_cert, std::size_t size);
 
-  long get_openssl_verify_result() const;
+	long get_openssl_verify_result() const;
 
-  SSL_CTX *ssl_context() const;
+	SSL_CTX *ssl_context() const;
 #endif
 
 private:
-  duckdb::unique_ptr<ClientImpl> cli_;
+	duckdb::unique_ptr<ClientImpl> cli_;
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  bool is_ssl_ = false;
+	bool is_ssl_ = false;
 #endif
 };
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 class SSLServer : public Server {
 public:
-  SSLServer(const char *cert_path, const char *private_key_path,
-            const char *client_ca_cert_file_path = nullptr,
-            const char *client_ca_cert_dir_path = nullptr,
-            const char *private_key_password = nullptr);
+	SSLServer(const char *cert_path, const char *private_key_path, const char *client_ca_cert_file_path = nullptr,
+	          const char *client_ca_cert_dir_path = nullptr, const char *private_key_password = nullptr);
 
-  SSLServer(X509 *cert, EVP_PKEY *private_key,
-            X509_STORE *client_ca_cert_store = nullptr);
+	SSLServer(X509 *cert, EVP_PKEY *private_key, X509_STORE *client_ca_cert_store = nullptr);
 
-  SSLServer(
-      const std::function<bool(SSL_CTX &ssl_ctx)> &setup_ssl_ctx_callback);
+	SSLServer(const std::function<bool(SSL_CTX &ssl_ctx)> &setup_ssl_ctx_callback);
 
-  ~SSLServer() override;
+	~SSLServer() override;
 
-  bool is_valid() const override;
+	bool is_valid() const override;
 
-  SSL_CTX *ssl_context() const;
+	SSL_CTX *ssl_context() const;
 
 private:
-  bool process_and_close_socket(socket_t sock) override;
+	bool process_and_close_socket(socket_t sock) override;
 
-  SSL_CTX *ctx_;
-  std::mutex ctx_mutex_;
+	SSL_CTX *ctx_;
+	std::mutex ctx_mutex_;
 };
 
 class SSLClient : public ClientImpl {
 public:
-  explicit SSLClient(const std::string &host);
+	explicit SSLClient(const std::string &host);
 
-  explicit SSLClient(const std::string &host, int port);
+	explicit SSLClient(const std::string &host, int port);
 
-  explicit SSLClient(const std::string &host, int port,
-                     const std::string &client_cert_path,
-                     const std::string &client_key_path);
+	explicit SSLClient(const std::string &host, int port, const std::string &client_cert_path,
+	                   const std::string &client_key_path);
 
-  explicit SSLClient(const std::string &host, int port, X509 *client_cert,
-                     EVP_PKEY *client_key);
+	explicit SSLClient(const std::string &host, int port, X509 *client_cert, EVP_PKEY *client_key);
 
-  ~SSLClient() override;
+	~SSLClient() override;
 
-  bool is_valid() const override;
+	bool is_valid() const override;
 
-  void set_ca_cert_store(X509_STORE *ca_cert_store);
-  void load_ca_cert_store(const char *ca_cert, std::size_t size);
+	void set_ca_cert_store(X509_STORE *ca_cert_store);
+	void load_ca_cert_store(const char *ca_cert, std::size_t size);
 
-  long get_openssl_verify_result() const;
+	long get_openssl_verify_result() const;
 
-  SSL_CTX *ssl_context() const;
+	SSL_CTX *ssl_context() const;
 
 private:
-  bool create_and_connect_socket(Socket &socket, Error &error) override;
-  void shutdown_ssl(Socket &socket, bool shutdown_gracefully) override;
-  void shutdown_ssl_impl(Socket &socket, bool shutdown_gracefully);
+	bool create_and_connect_socket(Socket &socket, Error &error) override;
+	void shutdown_ssl(Socket &socket, bool shutdown_gracefully) override;
+	void shutdown_ssl_impl(Socket &socket, bool shutdown_gracefully);
 
-  bool process_socket(const Socket &socket,
-                      std::function<bool(Stream &strm)> callback) override;
-  bool is_ssl() const override;
+	bool process_socket(const Socket &socket, std::function<bool(Stream &strm)> callback) override;
+	bool is_ssl() const override;
 
-  bool connect_with_proxy(Socket &sock, Response &res, bool &success,
-                          Error &error);
-  bool initialize_ssl(Socket &socket, Error &error);
+	bool connect_with_proxy(Socket &sock, Response &res, bool &success, Error &error);
+	bool initialize_ssl(Socket &socket, Error &error);
 
-  bool load_certs();
+	bool load_certs();
 
-  bool verify_host(X509 *server_cert) const;
-  bool verify_host_with_subject_alt_name(X509 *server_cert) const;
-  bool verify_host_with_common_name(X509 *server_cert) const;
-  bool check_host_name(const char *pattern, size_t pattern_len) const;
+	bool verify_host(X509 *server_cert) const;
+	bool verify_host_with_subject_alt_name(X509 *server_cert) const;
+	bool verify_host_with_common_name(X509 *server_cert) const;
+	bool check_host_name(const char *pattern, size_t pattern_len) const;
 
-  SSL_CTX *ctx_;
-  std::mutex ctx_mutex_;
-  std::once_flag initialize_cert_;
+	SSL_CTX *ctx_;
+	std::mutex ctx_mutex_;
+	std::once_flag initialize_cert_;
 
-  std::vector<std::string> host_components_;
+	std::vector<std::string> host_components_;
 
-  long verify_result_ = 0;
+	long verify_result_ = 0;
 
-  friend class ClientImpl;
+	friend class ClientImpl;
 };
 #endif
 
@@ -1815,252 +1692,298 @@ namespace detail {
 
 template <typename T, typename U>
 inline void duration_to_sec_and_usec(const T &duration, U callback) {
-  auto sec = std::chrono::duration_cast<std::chrono::seconds>(duration).count();
-  auto usec = std::chrono::duration_cast<std::chrono::microseconds>(
-                  duration - std::chrono::seconds(sec))
-                  .count();
-  callback(static_cast<time_t>(sec), static_cast<time_t>(usec));
+	auto sec = std::chrono::duration_cast<std::chrono::seconds>(duration).count();
+	auto usec = std::chrono::duration_cast<std::chrono::microseconds>(duration - std::chrono::seconds(sec)).count();
+	callback(static_cast<time_t>(sec), static_cast<time_t>(usec));
 }
 
-inline uint64_t get_header_value_u64(const Headers &headers,
-                                     const std::string &key, size_t id,
-                                     uint64_t def) {
-  auto rng = headers.equal_range(key);
-  auto it = rng.first;
-  std::advance(it, static_cast<ssize_t>(id));
-  if (it != rng.second) {
-    return std::strtoull(it->second.data(), nullptr, 10);
-  }
-  return def;
+inline uint64_t get_header_value_u64(const Headers &headers, const std::string &key, size_t id, uint64_t def) {
+	auto rng = headers.equal_range(key);
+	auto it = rng.first;
+	std::advance(it, static_cast<ssize_t>(id));
+	if (it != rng.second) {
+		return std::strtoull(it->second.data(), nullptr, 10);
+	}
+	return def;
 }
 
 } // namespace detail
 
-inline uint64_t Request::get_header_value_u64(const std::string &key,
-                                              size_t id) const {
-  return detail::get_header_value_u64(headers, key, id, 0);
+inline uint64_t Request::get_header_value_u64(const std::string &key, size_t id) const {
+	return detail::get_header_value_u64(headers, key, id, 0);
 }
 
-inline uint64_t Response::get_header_value_u64(const std::string &key,
-                                               size_t id) const {
-  return detail::get_header_value_u64(headers, key, id, 0);
+inline uint64_t Response::get_header_value_u64(const std::string &key, size_t id) const {
+	return detail::get_header_value_u64(headers, key, id, 0);
 }
 
 template <typename... Args>
 inline ssize_t Stream::write_format(const char *fmt, const Args &...args) {
-  const auto bufsiz = 2048;
-  std::array<char, bufsiz> buf{};
+	const auto bufsiz = 2048;
+	std::array<char, bufsiz> buf {};
 
-  auto sn = snprintf(buf.data(), buf.size() - 1, fmt, args...);
-  if (sn <= 0) { return sn; }
+	auto sn = snprintf(buf.data(), buf.size() - 1, fmt, args...);
+	if (sn <= 0) {
+		return sn;
+	}
 
-  auto n = static_cast<size_t>(sn);
+	auto n = static_cast<size_t>(sn);
 
-  if (n >= buf.size() - 1) {
-    std::vector<char> glowable_buf(buf.size());
+	if (n >= buf.size() - 1) {
+		std::vector<char> glowable_buf(buf.size());
 
-    while (n >= glowable_buf.size() - 1) {
-      glowable_buf.resize(glowable_buf.size() * 2);
-      n = static_cast<size_t>(
-          snprintf(&glowable_buf[0], glowable_buf.size() - 1, fmt, args...));
-    }
-    return write(&glowable_buf[0], n);
-  } else {
-    return write(buf.data(), n);
-  }
+		while (n >= glowable_buf.size() - 1) {
+			glowable_buf.resize(glowable_buf.size() * 2);
+			n = static_cast<size_t>(snprintf(&glowable_buf[0], glowable_buf.size() - 1, fmt, args...));
+		}
+		return write(&glowable_buf[0], n);
+	} else {
+		return write(buf.data(), n);
+	}
 }
 
 inline void default_socket_options(socket_t sock) {
-  int yes = 1;
+	int yes = 1;
 #ifdef _WIN32
-  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
-             reinterpret_cast<const char *>(&yes), sizeof(yes));
-  setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
-             reinterpret_cast<const char *>(&yes), sizeof(yes));
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char *>(&yes), sizeof(yes));
+	setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, reinterpret_cast<const char *>(&yes), sizeof(yes));
 #else
 #ifdef SO_REUSEPORT
-  setsockopt(sock, SOL_SOCKET, SO_REUSEPORT,
-             reinterpret_cast<const void *>(&yes), sizeof(yes));
+	setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, reinterpret_cast<const void *>(&yes), sizeof(yes));
 #else
-  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
-             reinterpret_cast<const void *>(&yes), sizeof(yes));
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const void *>(&yes), sizeof(yes));
 #endif
 #endif
 }
 
 inline const char *status_message(int status) {
-  switch (status) {
-  case StatusCode::Continue_100: return "Continue";
-  case StatusCode::SwitchingProtocol_101: return "Switching Protocol";
-  case StatusCode::Processing_102: return "Processing";
-  case StatusCode::EarlyHints_103: return "Early Hints";
-  case StatusCode::OK_200: return "OK";
-  case StatusCode::Created_201: return "Created";
-  case StatusCode::Accepted_202: return "Accepted";
-  case StatusCode::NonAuthoritativeInformation_203:
-    return "Non-Authoritative Information";
-  case StatusCode::NoContent_204: return "No Content";
-  case StatusCode::ResetContent_205: return "Reset Content";
-  case StatusCode::PartialContent_206: return "Partial Content";
-  case StatusCode::MultiStatus_207: return "Multi-Status";
-  case StatusCode::AlreadyReported_208: return "Already Reported";
-  case StatusCode::IMUsed_226: return "IM Used";
-  case StatusCode::MultipleChoices_300: return "Multiple Choices";
-  case StatusCode::MovedPermanently_301: return "Moved Permanently";
-  case StatusCode::Found_302: return "Found";
-  case StatusCode::SeeOther_303: return "See Other";
-  case StatusCode::NotModified_304: return "Not Modified";
-  case StatusCode::UseProxy_305: return "Use Proxy";
-  case StatusCode::unused_306: return "unused";
-  case StatusCode::TemporaryRedirect_307: return "Temporary Redirect";
-  case StatusCode::PermanentRedirect_308: return "Permanent Redirect";
-  case StatusCode::BadRequest_400: return "Bad Request";
-  case StatusCode::Unauthorized_401: return "Unauthorized";
-  case StatusCode::PaymentRequired_402: return "Payment Required";
-  case StatusCode::Forbidden_403: return "Forbidden";
-  case StatusCode::NotFound_404: return "Not Found";
-  case StatusCode::MethodNotAllowed_405: return "Method Not Allowed";
-  case StatusCode::NotAcceptable_406: return "Not Acceptable";
-  case StatusCode::ProxyAuthenticationRequired_407:
-    return "Proxy Authentication Required";
-  case StatusCode::RequestTimeout_408: return "Request Timeout";
-  case StatusCode::Conflict_409: return "Conflict";
-  case StatusCode::Gone_410: return "Gone";
-  case StatusCode::LengthRequired_411: return "Length Required";
-  case StatusCode::PreconditionFailed_412: return "Precondition Failed";
-  case StatusCode::PayloadTooLarge_413: return "Payload Too Large";
-  case StatusCode::UriTooLong_414: return "URI Too Long";
-  case StatusCode::UnsupportedMediaType_415: return "Unsupported Media Type";
-  case StatusCode::RangeNotSatisfiable_416: return "Range Not Satisfiable";
-  case StatusCode::ExpectationFailed_417: return "Expectation Failed";
-  case StatusCode::ImATeapot_418: return "I'm a teapot";
-  case StatusCode::MisdirectedRequest_421: return "Misdirected Request";
-  case StatusCode::UnprocessableContent_422: return "Unprocessable Content";
-  case StatusCode::Locked_423: return "Locked";
-  case StatusCode::FailedDependency_424: return "Failed Dependency";
-  case StatusCode::TooEarly_425: return "Too Early";
-  case StatusCode::UpgradeRequired_426: return "Upgrade Required";
-  case StatusCode::PreconditionRequired_428: return "Precondition Required";
-  case StatusCode::TooManyRequests_429: return "Too Many Requests";
-  case StatusCode::RequestHeaderFieldsTooLarge_431:
-    return "Request Header Fields Too Large";
-  case StatusCode::UnavailableForLegalReasons_451:
-    return "Unavailable For Legal Reasons";
-  case StatusCode::NotImplemented_501: return "Not Implemented";
-  case StatusCode::BadGateway_502: return "Bad Gateway";
-  case StatusCode::ServiceUnavailable_503: return "Service Unavailable";
-  case StatusCode::GatewayTimeout_504: return "Gateway Timeout";
-  case StatusCode::HttpVersionNotSupported_505:
-    return "HTTP Version Not Supported";
-  case StatusCode::VariantAlsoNegotiates_506: return "Variant Also Negotiates";
-  case StatusCode::InsufficientStorage_507: return "Insufficient Storage";
-  case StatusCode::LoopDetected_508: return "Loop Detected";
-  case StatusCode::NotExtended_510: return "Not Extended";
-  case StatusCode::NetworkAuthenticationRequired_511:
-    return "Network Authentication Required";
+	switch (status) {
+	case StatusCode::Continue_100:
+		return "Continue";
+	case StatusCode::SwitchingProtocol_101:
+		return "Switching Protocol";
+	case StatusCode::Processing_102:
+		return "Processing";
+	case StatusCode::EarlyHints_103:
+		return "Early Hints";
+	case StatusCode::OK_200:
+		return "OK";
+	case StatusCode::Created_201:
+		return "Created";
+	case StatusCode::Accepted_202:
+		return "Accepted";
+	case StatusCode::NonAuthoritativeInformation_203:
+		return "Non-Authoritative Information";
+	case StatusCode::NoContent_204:
+		return "No Content";
+	case StatusCode::ResetContent_205:
+		return "Reset Content";
+	case StatusCode::PartialContent_206:
+		return "Partial Content";
+	case StatusCode::MultiStatus_207:
+		return "Multi-Status";
+	case StatusCode::AlreadyReported_208:
+		return "Already Reported";
+	case StatusCode::IMUsed_226:
+		return "IM Used";
+	case StatusCode::MultipleChoices_300:
+		return "Multiple Choices";
+	case StatusCode::MovedPermanently_301:
+		return "Moved Permanently";
+	case StatusCode::Found_302:
+		return "Found";
+	case StatusCode::SeeOther_303:
+		return "See Other";
+	case StatusCode::NotModified_304:
+		return "Not Modified";
+	case StatusCode::UseProxy_305:
+		return "Use Proxy";
+	case StatusCode::unused_306:
+		return "unused";
+	case StatusCode::TemporaryRedirect_307:
+		return "Temporary Redirect";
+	case StatusCode::PermanentRedirect_308:
+		return "Permanent Redirect";
+	case StatusCode::BadRequest_400:
+		return "Bad Request";
+	case StatusCode::Unauthorized_401:
+		return "Unauthorized";
+	case StatusCode::PaymentRequired_402:
+		return "Payment Required";
+	case StatusCode::Forbidden_403:
+		return "Forbidden";
+	case StatusCode::NotFound_404:
+		return "Not Found";
+	case StatusCode::MethodNotAllowed_405:
+		return "Method Not Allowed";
+	case StatusCode::NotAcceptable_406:
+		return "Not Acceptable";
+	case StatusCode::ProxyAuthenticationRequired_407:
+		return "Proxy Authentication Required";
+	case StatusCode::RequestTimeout_408:
+		return "Request Timeout";
+	case StatusCode::Conflict_409:
+		return "Conflict";
+	case StatusCode::Gone_410:
+		return "Gone";
+	case StatusCode::LengthRequired_411:
+		return "Length Required";
+	case StatusCode::PreconditionFailed_412:
+		return "Precondition Failed";
+	case StatusCode::PayloadTooLarge_413:
+		return "Payload Too Large";
+	case StatusCode::UriTooLong_414:
+		return "URI Too Long";
+	case StatusCode::UnsupportedMediaType_415:
+		return "Unsupported Media Type";
+	case StatusCode::RangeNotSatisfiable_416:
+		return "Range Not Satisfiable";
+	case StatusCode::ExpectationFailed_417:
+		return "Expectation Failed";
+	case StatusCode::ImATeapot_418:
+		return "I'm a teapot";
+	case StatusCode::MisdirectedRequest_421:
+		return "Misdirected Request";
+	case StatusCode::UnprocessableContent_422:
+		return "Unprocessable Content";
+	case StatusCode::Locked_423:
+		return "Locked";
+	case StatusCode::FailedDependency_424:
+		return "Failed Dependency";
+	case StatusCode::TooEarly_425:
+		return "Too Early";
+	case StatusCode::UpgradeRequired_426:
+		return "Upgrade Required";
+	case StatusCode::PreconditionRequired_428:
+		return "Precondition Required";
+	case StatusCode::TooManyRequests_429:
+		return "Too Many Requests";
+	case StatusCode::RequestHeaderFieldsTooLarge_431:
+		return "Request Header Fields Too Large";
+	case StatusCode::UnavailableForLegalReasons_451:
+		return "Unavailable For Legal Reasons";
+	case StatusCode::NotImplemented_501:
+		return "Not Implemented";
+	case StatusCode::BadGateway_502:
+		return "Bad Gateway";
+	case StatusCode::ServiceUnavailable_503:
+		return "Service Unavailable";
+	case StatusCode::GatewayTimeout_504:
+		return "Gateway Timeout";
+	case StatusCode::HttpVersionNotSupported_505:
+		return "HTTP Version Not Supported";
+	case StatusCode::VariantAlsoNegotiates_506:
+		return "Variant Also Negotiates";
+	case StatusCode::InsufficientStorage_507:
+		return "Insufficient Storage";
+	case StatusCode::LoopDetected_508:
+		return "Loop Detected";
+	case StatusCode::NotExtended_510:
+		return "Not Extended";
+	case StatusCode::NetworkAuthenticationRequired_511:
+		return "Network Authentication Required";
 
-  default:
-  case StatusCode::InternalServerError_500: return "Internal Server Error";
-  }
+	default:
+	case StatusCode::InternalServerError_500:
+		return "Internal Server Error";
+	}
 }
 
 template <class Rep, class Period>
-inline Server &
-Server::set_read_timeout(const std::chrono::duration<Rep, Period> &duration) {
-  detail::duration_to_sec_and_usec(
-      duration, [&](time_t sec, time_t usec) { set_read_timeout(sec, usec); });
-  return *this;
+inline Server &Server::set_read_timeout(const std::chrono::duration<Rep, Period> &duration) {
+	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_read_timeout(sec, usec); });
+	return *this;
 }
 
 template <class Rep, class Period>
-inline Server &
-Server::set_write_timeout(const std::chrono::duration<Rep, Period> &duration) {
-  detail::duration_to_sec_and_usec(
-      duration, [&](time_t sec, time_t usec) { set_write_timeout(sec, usec); });
-  return *this;
+inline Server &Server::set_write_timeout(const std::chrono::duration<Rep, Period> &duration) {
+	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_write_timeout(sec, usec); });
+	return *this;
 }
 
 template <class Rep, class Period>
-inline Server &
-Server::set_idle_interval(const std::chrono::duration<Rep, Period> &duration) {
-  detail::duration_to_sec_and_usec(
-      duration, [&](time_t sec, time_t usec) { set_idle_interval(sec, usec); });
-  return *this;
+inline Server &Server::set_idle_interval(const std::chrono::duration<Rep, Period> &duration) {
+	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_idle_interval(sec, usec); });
+	return *this;
 }
 
 inline std::string to_string(const Error error) {
-  switch (error) {
-  case Error::Success: return "Success (no error)";
-  case Error::Connection: return "Could not establish connection";
-  case Error::BindIPAddress: return "Failed to bind IP address";
-  case Error::Read: return "Failed to read connection";
-  case Error::Write: return "Failed to write connection";
-  case Error::ExceedRedirectCount: return "Maximum redirect count exceeded";
-  case Error::Canceled: return "Connection handling canceled";
-  case Error::SSLConnection: return "SSL connection failed";
-  case Error::SSLLoadingCerts: return "SSL certificate loading failed";
-  case Error::SSLServerVerification: return "SSL server verification failed";
-  case Error::UnsupportedMultipartBoundaryChars:
-    return "Unsupported HTTP multipart boundary characters";
-  case Error::Compression: return "Compression failed";
-  case Error::ConnectionTimeout: return "Connection timed out";
-  case Error::ProxyConnection: return "Proxy connection failed";
-  case Error::Unknown: return "Unknown";
-  default: break;
-  }
+	switch (error) {
+	case Error::Success:
+		return "Success (no error)";
+	case Error::Connection:
+		return "Could not establish connection";
+	case Error::BindIPAddress:
+		return "Failed to bind IP address";
+	case Error::Read:
+		return "Failed to read connection";
+	case Error::Write:
+		return "Failed to write connection";
+	case Error::ExceedRedirectCount:
+		return "Maximum redirect count exceeded";
+	case Error::Canceled:
+		return "Connection handling canceled";
+	case Error::SSLConnection:
+		return "SSL connection failed";
+	case Error::SSLLoadingCerts:
+		return "SSL certificate loading failed";
+	case Error::SSLServerVerification:
+		return "SSL server verification failed";
+	case Error::UnsupportedMultipartBoundaryChars:
+		return "Unsupported HTTP multipart boundary characters";
+	case Error::Compression:
+		return "Compression failed";
+	case Error::ConnectionTimeout:
+		return "Connection timed out";
+	case Error::ProxyConnection:
+		return "Proxy connection failed";
+	case Error::Unknown:
+		return "Unknown";
+	default:
+		break;
+	}
 
-  return "Invalid";
+	return "Invalid";
 }
 
 inline std::ostream &operator<<(std::ostream &os, const Error &obj) {
-  os << to_string(obj);
-  os << " (" << static_cast<std::underlying_type<Error>::type>(obj) << ')';
-  return os;
+	os << to_string(obj);
+	os << " (" << static_cast<std::underlying_type<Error>::type>(obj) << ')';
+	return os;
 }
 
-inline uint64_t Result::get_request_header_value_u64(const std::string &key,
-                                                     size_t id) const {
-  return detail::get_header_value_u64(request_headers_, key, id, 0);
-}
-
-template <class Rep, class Period>
-inline void ClientImpl::set_connection_timeout(
-    const std::chrono::duration<Rep, Period> &duration) {
-  detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) {
-    set_connection_timeout(sec, usec);
-  });
+inline uint64_t Result::get_request_header_value_u64(const std::string &key, size_t id) const {
+	return detail::get_header_value_u64(request_headers_, key, id, 0);
 }
 
 template <class Rep, class Period>
-inline void ClientImpl::set_read_timeout(
-    const std::chrono::duration<Rep, Period> &duration) {
-  detail::duration_to_sec_and_usec(
-      duration, [&](time_t sec, time_t usec) { set_read_timeout(sec, usec); });
+inline void ClientImpl::set_connection_timeout(const std::chrono::duration<Rep, Period> &duration) {
+	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_connection_timeout(sec, usec); });
 }
 
 template <class Rep, class Period>
-inline void ClientImpl::set_write_timeout(
-    const std::chrono::duration<Rep, Period> &duration) {
-  detail::duration_to_sec_and_usec(
-      duration, [&](time_t sec, time_t usec) { set_write_timeout(sec, usec); });
+inline void ClientImpl::set_read_timeout(const std::chrono::duration<Rep, Period> &duration) {
+	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_read_timeout(sec, usec); });
 }
 
 template <class Rep, class Period>
-inline void Client::set_connection_timeout(
-    const std::chrono::duration<Rep, Period> &duration) {
-  cli_->set_connection_timeout(duration);
+inline void ClientImpl::set_write_timeout(const std::chrono::duration<Rep, Period> &duration) {
+	detail::duration_to_sec_and_usec(duration, [&](time_t sec, time_t usec) { set_write_timeout(sec, usec); });
 }
 
 template <class Rep, class Period>
-inline void
-Client::set_read_timeout(const std::chrono::duration<Rep, Period> &duration) {
-  cli_->set_read_timeout(duration);
+inline void Client::set_connection_timeout(const std::chrono::duration<Rep, Period> &duration) {
+	cli_->set_connection_timeout(duration);
 }
 
 template <class Rep, class Period>
-inline void
-Client::set_write_timeout(const std::chrono::duration<Rep, Period> &duration) {
-  cli_->set_write_timeout(duration);
+inline void Client::set_read_timeout(const std::chrono::duration<Rep, Period> &duration) {
+	cli_->set_read_timeout(duration);
+}
+
+template <class Rep, class Period>
+inline void Client::set_write_timeout(const std::chrono::duration<Rep, Period> &duration) {
+	cli_->set_write_timeout(duration);
 }
 
 /*
@@ -2077,9 +2000,7 @@ std::string append_query_params(const std::string &path, const Params &params);
 std::pair<std::string, std::string> make_range_header(Ranges ranges);
 
 std::pair<std::string, std::string>
-make_basic_authentication_header(const std::string &username,
-                                 const std::string &password,
-                                 bool is_proxy = false);
+make_basic_authentication_header(const std::string &username, const std::string &password, bool is_proxy = false);
 
 namespace detail {
 
@@ -2090,33 +2011,26 @@ void read_file(const std::string &path, std::string &out);
 
 std::string trim_copy(const std::string &s);
 
-void split(const char *b, const char *e, char d,
-           std::function<void(const char *, const char *)> fn);
+void split(const char *b, const char *e, char d, std::function<void(const char *, const char *)> fn);
 
-void split(const char *b, const char *e, char d, size_t m,
-           std::function<void(const char *, const char *)> fn);
+void split(const char *b, const char *e, char d, size_t m, std::function<void(const char *, const char *)> fn);
 
-bool process_client_socket(socket_t sock, time_t read_timeout_sec,
-                           time_t read_timeout_usec, time_t write_timeout_sec,
-                           time_t write_timeout_usec,
-                           std::function<bool(Stream &)> callback);
+bool process_client_socket(socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
+                           time_t write_timeout_usec, std::function<bool(Stream &)> callback);
 
-socket_t create_client_socket(
-    const std::string &host, const std::string &ip, int port,
-    int address_family, bool tcp_nodelay, SocketOptions socket_options,
-    time_t connection_timeout_sec, time_t connection_timeout_usec,
-    time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
-    time_t write_timeout_usec, const std::string &intf, Error &error);
+socket_t create_client_socket(const std::string &host, const std::string &ip, int port, int address_family,
+                              bool tcp_nodelay, SocketOptions socket_options, time_t connection_timeout_sec,
+                              time_t connection_timeout_usec, time_t read_timeout_sec, time_t read_timeout_usec,
+                              time_t write_timeout_sec, time_t write_timeout_usec, const std::string &intf,
+                              Error &error);
 
-const char *get_header_value(const Headers &headers, const std::string &key,
-                             size_t id = 0, const char *def = nullptr);
+const char *get_header_value(const Headers &headers, const std::string &key, size_t id = 0, const char *def = nullptr);
 
 std::string params_to_query_str(const Params &params);
 
 void parse_query_text(const std::string &s, Params &params);
 
-bool parse_multipart_boundary(const std::string &content_type,
-                              std::string &boundary);
+bool parse_multipart_boundary(const std::string &content_type, std::string &boundary);
 
 bool parse_range_header(const std::string &s, Ranges &ranges);
 
@@ -2132,108 +2046,101 @@ EncodingType encoding_type(const Request &req, const Response &res);
 
 class BufferStream : public Stream {
 public:
-  BufferStream() = default;
-  ~BufferStream() override = default;
+	BufferStream() = default;
+	~BufferStream() override = default;
 
-  bool is_readable() const override;
-  bool is_writable() const override;
-  ssize_t read(char *ptr, size_t size) override;
-  ssize_t write(const char *ptr, size_t size) override;
-  void get_remote_ip_and_port(std::string &ip, int &port) const override;
-  void get_local_ip_and_port(std::string &ip, int &port) const override;
-  socket_t socket() const override;
+	bool is_readable() const override;
+	bool is_writable() const override;
+	ssize_t read(char *ptr, size_t size) override;
+	ssize_t write(const char *ptr, size_t size) override;
+	void get_remote_ip_and_port(std::string &ip, int &port) const override;
+	void get_local_ip_and_port(std::string &ip, int &port) const override;
+	socket_t socket() const override;
 
-  const std::string &get_buffer() const;
+	const std::string &get_buffer() const;
 
 private:
-  std::string buffer;
-  size_t position = 0;
+	std::string buffer;
+	size_t position = 0;
 };
 
 class compressor {
 public:
-  virtual ~compressor() = default;
+	virtual ~compressor() = default;
 
-  typedef std::function<bool(const char *data, size_t data_len)> Callback;
-  virtual bool compress(const char *data, size_t data_length, bool last,
-                        Callback callback) = 0;
+	typedef std::function<bool(const char *data, size_t data_len)> Callback;
+	virtual bool compress(const char *data, size_t data_length, bool last, Callback callback) = 0;
 };
 
 class decompressor {
 public:
-  virtual ~decompressor() = default;
+	virtual ~decompressor() = default;
 
-  virtual bool is_valid() const = 0;
+	virtual bool is_valid() const = 0;
 
-  typedef std::function<bool(const char *data, size_t data_len)> Callback;
-  virtual bool decompress(const char *data, size_t data_length,
-                          Callback callback) = 0;
+	typedef std::function<bool(const char *data, size_t data_len)> Callback;
+	virtual bool decompress(const char *data, size_t data_length, Callback callback) = 0;
 };
 
 class nocompressor : public compressor {
 public:
-  ~nocompressor() override = default;
+	~nocompressor() override = default;
 
-  bool compress(const char *data, size_t data_length, bool /*last*/,
-                Callback callback) override;
+	bool compress(const char *data, size_t data_length, bool /*last*/, Callback callback) override;
 };
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
 class gzip_compressor : public compressor {
 public:
-  gzip_compressor();
-  ~gzip_compressor() override;
+	gzip_compressor();
+	~gzip_compressor() override;
 
-  bool compress(const char *data, size_t data_length, bool last,
-                Callback callback) override;
+	bool compress(const char *data, size_t data_length, bool last, Callback callback) override;
 
 private:
-  bool is_valid_ = false;
-  z_stream strm_;
+	bool is_valid_ = false;
+	z_stream strm_;
 };
 
 class gzip_decompressor : public decompressor {
 public:
-  gzip_decompressor();
-  ~gzip_decompressor() override;
+	gzip_decompressor();
+	~gzip_decompressor() override;
 
-  bool is_valid() const override;
+	bool is_valid() const override;
 
-  bool decompress(const char *data, size_t data_length,
-                  Callback callback) override;
+	bool decompress(const char *data, size_t data_length, Callback callback) override;
 
 private:
-  bool is_valid_ = false;
-  z_stream strm_;
+	bool is_valid_ = false;
+	z_stream strm_;
 };
 #endif
 
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
 class brotli_compressor : public compressor {
 public:
-  brotli_compressor();
-  ~brotli_compressor();
+	brotli_compressor();
+	~brotli_compressor();
 
-  bool compress(const char *data, size_t data_length, bool last,
-                Callback callback) override;
+	bool compress(const char *data, size_t data_length, bool last, Callback callback) override;
 
 private:
-  BrotliEncoderState *state_ = nullptr;
+	BrotliEncoderState *state_ = nullptr;
 };
 
 class brotli_decompressor : public decompressor {
 public:
-  brotli_decompressor();
-  ~brotli_decompressor();
+	brotli_decompressor();
+	~brotli_decompressor();
 
-  bool is_valid() const override;
+	bool is_valid() const override;
 
-  bool decompress(const char *data, size_t data_length,
-                  Callback callback) override;
+	bool decompress(const char *data, size_t data_length, Callback callback) override;
 
 private:
-  BrotliDecoderResult decoder_r;
-  BrotliDecoderState *decoder_s = nullptr;
+	BrotliDecoderResult decoder_r;
+	BrotliDecoderState *decoder_s = nullptr;
 };
 #endif
 
@@ -2241,44 +2148,43 @@ private:
 // to store data. The call can set memory on stack for performance.
 class stream_line_reader {
 public:
-  stream_line_reader(Stream &strm, char *fixed_buffer,
-                     size_t fixed_buffer_size);
-  const char *ptr() const;
-  size_t size() const;
-  bool end_with_crlf() const;
-  bool getline();
+	stream_line_reader(Stream &strm, char *fixed_buffer, size_t fixed_buffer_size);
+	const char *ptr() const;
+	size_t size() const;
+	bool end_with_crlf() const;
+	bool getline();
 
 private:
-  void append(char c);
+	void append(char c);
 
-  Stream &strm_;
-  char *fixed_buffer_;
-  const size_t fixed_buffer_size_;
-  size_t fixed_buffer_used_size_ = 0;
-  std::string glowable_buffer_;
+	Stream &strm_;
+	char *fixed_buffer_;
+	const size_t fixed_buffer_size_;
+	size_t fixed_buffer_used_size_ = 0;
+	std::string glowable_buffer_;
 };
 
 class mmap {
 public:
-  mmap(const char *path);
-  ~mmap();
+	mmap(const char *path);
+	~mmap();
 
-  bool open(const char *path);
-  void close();
+	bool open(const char *path);
+	void close();
 
-  bool is_open() const;
-  size_t size() const;
-  const char *data() const;
+	bool is_open() const;
+	size_t size() const;
+	const char *data() const;
 
 private:
 #if defined(_WIN32)
-  HANDLE hFile_;
-  HANDLE hMapping_;
+	HANDLE hFile_;
+	HANDLE hMapping_;
 #else
-  int fd_;
+	int fd_;
 #endif
-  size_t size_;
-  void *addr_;
+	size_t size_;
+	void *addr_;
 };
 
 } // namespace detail
@@ -2292,384 +2198,406 @@ private:
 namespace detail {
 
 inline bool is_hex(char c, int &v) {
-  if (0x20 <= c && isdigit(c)) {
-    v = c - '0';
-    return true;
-  } else if ('A' <= c && c <= 'F') {
-    v = c - 'A' + 10;
-    return true;
-  } else if ('a' <= c && c <= 'f') {
-    v = c - 'a' + 10;
-    return true;
-  }
-  return false;
+	if (0x20 <= c && isdigit(c)) {
+		v = c - '0';
+		return true;
+	} else if ('A' <= c && c <= 'F') {
+		v = c - 'A' + 10;
+		return true;
+	} else if ('a' <= c && c <= 'f') {
+		v = c - 'a' + 10;
+		return true;
+	}
+	return false;
 }
 
-inline bool from_hex_to_i(const std::string &s, size_t i, size_t cnt,
-                          int &val) {
-  if (i >= s.size()) { return false; }
+inline bool from_hex_to_i(const std::string &s, size_t i, size_t cnt, int &val) {
+	if (i >= s.size()) {
+		return false;
+	}
 
-  val = 0;
-  for (; cnt; i++, cnt--) {
-    if (!s[i]) { return false; }
-    auto v = 0;
-    if (is_hex(s[i], v)) {
-      val = val * 16 + v;
-    } else {
-      return false;
-    }
-  }
-  return true;
+	val = 0;
+	for (; cnt; i++, cnt--) {
+		if (!s[i]) {
+			return false;
+		}
+		auto v = 0;
+		if (is_hex(s[i], v)) {
+			val = val * 16 + v;
+		} else {
+			return false;
+		}
+	}
+	return true;
 }
 
 inline std::string from_i_to_hex(size_t n) {
-  static const auto charset = "0123456789abcdef";
-  std::string ret;
-  do {
-    ret = charset[n & 15] + ret;
-    n >>= 4;
-  } while (n > 0);
-  return ret;
+	static const auto charset = "0123456789abcdef";
+	std::string ret;
+	do {
+		ret = charset[n & 15] + ret;
+		n >>= 4;
+	} while (n > 0);
+	return ret;
 }
 
 inline size_t to_utf8(int code, char *buff) {
-  if (code < 0x0080) {
-    buff[0] = static_cast<char>(code & 0x7F);
-    return 1;
-  } else if (code < 0x0800) {
-    buff[0] = static_cast<char>(0xC0 | ((code >> 6) & 0x1F));
-    buff[1] = static_cast<char>(0x80 | (code & 0x3F));
-    return 2;
-  } else if (code < 0xD800) {
-    buff[0] = static_cast<char>(0xE0 | ((code >> 12) & 0xF));
-    buff[1] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
-    buff[2] = static_cast<char>(0x80 | (code & 0x3F));
-    return 3;
-  } else if (code < 0xE000) { // D800 - DFFF is invalid...
-    return 0;
-  } else if (code < 0x10000) {
-    buff[0] = static_cast<char>(0xE0 | ((code >> 12) & 0xF));
-    buff[1] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
-    buff[2] = static_cast<char>(0x80 | (code & 0x3F));
-    return 3;
-  } else if (code < 0x110000) {
-    buff[0] = static_cast<char>(0xF0 | ((code >> 18) & 0x7));
-    buff[1] = static_cast<char>(0x80 | ((code >> 12) & 0x3F));
-    buff[2] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
-    buff[3] = static_cast<char>(0x80 | (code & 0x3F));
-    return 4;
-  }
+	if (code < 0x0080) {
+		buff[0] = static_cast<char>(code & 0x7F);
+		return 1;
+	} else if (code < 0x0800) {
+		buff[0] = static_cast<char>(0xC0 | ((code >> 6) & 0x1F));
+		buff[1] = static_cast<char>(0x80 | (code & 0x3F));
+		return 2;
+	} else if (code < 0xD800) {
+		buff[0] = static_cast<char>(0xE0 | ((code >> 12) & 0xF));
+		buff[1] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
+		buff[2] = static_cast<char>(0x80 | (code & 0x3F));
+		return 3;
+	} else if (code < 0xE000) { // D800 - DFFF is invalid...
+		return 0;
+	} else if (code < 0x10000) {
+		buff[0] = static_cast<char>(0xE0 | ((code >> 12) & 0xF));
+		buff[1] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
+		buff[2] = static_cast<char>(0x80 | (code & 0x3F));
+		return 3;
+	} else if (code < 0x110000) {
+		buff[0] = static_cast<char>(0xF0 | ((code >> 18) & 0x7));
+		buff[1] = static_cast<char>(0x80 | ((code >> 12) & 0x3F));
+		buff[2] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
+		buff[3] = static_cast<char>(0x80 | (code & 0x3F));
+		return 4;
+	}
 
-  // NOTREACHED
-  return 0;
+	// NOTREACHED
+	return 0;
 }
 
 // NOTE: This code came up with the following stackoverflow post:
 // https://stackoverflow.com/questions/180947/base64-decode-snippet-in-c
 inline std::string base64_encode(const std::string &in) {
-  static const auto lookup =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	static const auto lookup = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-  std::string out;
-  out.reserve(in.size());
+	std::string out;
+	out.reserve(in.size());
 
-  unsigned int val = 0;
-  int valb = -6;
+	unsigned int val = 0;
+	int valb = -6;
 
-  for (auto c : in) {
-    val = (val << 8) + static_cast<uint8_t>(c);
-    valb += 8;
-    while (valb >= 0) {
-      out.push_back(lookup[(val >> valb) & 0x3F]);
-      valb -= 6;
-    }
-  }
+	for (auto c : in) {
+		val = (val << 8) + static_cast<uint8_t>(c);
+		valb += 8;
+		while (valb >= 0) {
+			out.push_back(lookup[(val >> valb) & 0x3F]);
+			valb -= 6;
+		}
+	}
 
-  if (valb > -6) { out.push_back(lookup[((val << 8) >> (valb + 8)) & 0x3F]); }
+	if (valb > -6) {
+		out.push_back(lookup[((val << 8) >> (valb + 8)) & 0x3F]);
+	}
 
-  while (out.size() % 4) {
-    out.push_back('=');
-  }
+	while (out.size() % 4) {
+		out.push_back('=');
+	}
 
-  return out;
+	return out;
 }
 
 inline bool is_file(const std::string &path) {
 #ifdef _WIN32
-  return _access_s(path.c_str(), 0) == 0;
+	return _access_s(path.c_str(), 0) == 0;
 #else
-  struct stat st;
-  return stat(path.c_str(), &st) >= 0 && S_ISREG(st.st_mode);
+	struct stat st;
+	return stat(path.c_str(), &st) >= 0 && S_ISREG(st.st_mode);
 #endif
 }
 
 inline bool is_dir(const std::string &path) {
-  struct stat st;
-  return stat(path.c_str(), &st) >= 0 && S_ISDIR(st.st_mode);
+	struct stat st;
+	return stat(path.c_str(), &st) >= 0 && S_ISDIR(st.st_mode);
 }
 
 inline bool is_valid_path(const std::string &path) {
-  size_t level = 0;
-  size_t i = 0;
+	size_t level = 0;
+	size_t i = 0;
 
-  // Skip slash
-  while (i < path.size() && path[i] == '/') {
-    i++;
-  }
+	// Skip slash
+	while (i < path.size() && path[i] == '/') {
+		i++;
+	}
 
-  while (i < path.size()) {
-    // Read component
-    auto beg = i;
-    while (i < path.size() && path[i] != '/') {
-      i++;
-    }
+	while (i < path.size()) {
+		// Read component
+		auto beg = i;
+		while (i < path.size() && path[i] != '/') {
+			i++;
+		}
 
-    auto len = i - beg;
-    assert(len > 0);
+		auto len = i - beg;
+		assert(len > 0);
 
-    if (!path.compare(beg, len, ".")) {
-      ;
-    } else if (!path.compare(beg, len, "..")) {
-      if (level == 0) { return false; }
-      level--;
-    } else {
-      level++;
-    }
+		if (!path.compare(beg, len, ".")) {
+			;
+		} else if (!path.compare(beg, len, "..")) {
+			if (level == 0) {
+				return false;
+			}
+			level--;
+		} else {
+			level++;
+		}
 
-    // Skip slash
-    while (i < path.size() && path[i] == '/') {
-      i++;
-    }
-  }
+		// Skip slash
+		while (i < path.size() && path[i] == '/') {
+			i++;
+		}
+	}
 
-  return true;
+	return true;
 }
 
 inline std::string encode_query_param(const std::string &value) {
-  std::ostringstream escaped;
-  escaped.fill('0');
-  escaped << std::hex;
+	std::ostringstream escaped;
+	escaped.fill('0');
+	escaped << std::hex;
 
-  for (auto c : value) {
-    if (std::isalnum(static_cast<uint8_t>(c)) || c == '-' || c == '_' ||
-        c == '.' || c == '!' || c == '~' || c == '*' || c == '\'' || c == '(' ||
-        c == ')') {
-      escaped << c;
-    } else {
-      escaped << std::uppercase;
-      escaped << '%' << std::setw(2)
-              << static_cast<int>(static_cast<unsigned char>(c));
-      escaped << std::nouppercase;
-    }
-  }
+	for (auto c : value) {
+		if (std::isalnum(static_cast<uint8_t>(c)) || c == '-' || c == '_' || c == '.' || c == '!' || c == '~' ||
+		    c == '*' || c == '\'' || c == '(' || c == ')') {
+			escaped << c;
+		} else {
+			escaped << std::uppercase;
+			escaped << '%' << std::setw(2) << static_cast<int>(static_cast<unsigned char>(c));
+			escaped << std::nouppercase;
+		}
+	}
 
-  return escaped.str();
+	return escaped.str();
 }
 
 inline std::string encode_url(const std::string &s) {
-  std::string result;
-  result.reserve(s.size());
+	std::string result;
+	result.reserve(s.size());
 
-  for (size_t i = 0; s[i]; i++) {
-    switch (s[i]) {
-    case ' ': result += "%20"; break;
-    case '\r': result += "%0D"; break;
-    case '\n': result += "%0A"; break;
-    case '\'': result += "%27"; break;
-    case ',': result += "%2C"; break;
-    // case ':': result += "%3A"; break; // ok? probably...
-    case ';': result += "%3B"; break;
-    default:
-      auto c = static_cast<uint8_t>(s[i]);
-      if (c >= 0x80) {
-        result += '%';
-        char hex[4];
-        auto len = snprintf(hex, sizeof(hex) - 1, "%02X", c);
-        assert(len == 2);
-        result.append(hex, static_cast<size_t>(len));
-      } else {
-        result += s[i];
-      }
-      break;
-    }
-  }
+	for (size_t i = 0; s[i]; i++) {
+		switch (s[i]) {
+		case ' ':
+			result += "%20";
+			break;
+		case '\r':
+			result += "%0D";
+			break;
+		case '\n':
+			result += "%0A";
+			break;
+		case '\'':
+			result += "%27";
+			break;
+		case ',':
+			result += "%2C";
+			break;
+		// case ':': result += "%3A"; break; // ok? probably...
+		case ';':
+			result += "%3B";
+			break;
+		default:
+			auto c = static_cast<uint8_t>(s[i]);
+			if (c >= 0x80) {
+				result += '%';
+				char hex[4];
+				auto len = snprintf(hex, sizeof(hex) - 1, "%02X", c);
+				assert(len == 2);
+				result.append(hex, static_cast<size_t>(len));
+			} else {
+				result += s[i];
+			}
+			break;
+		}
+	}
 
-  return result;
+	return result;
 }
 
-inline std::string decode_url(const std::string &s,
-                              bool convert_plus_to_space,
-                              const std::set<char> &exclude) {
-  std::string result;
+inline std::string decode_url(const std::string &s, bool convert_plus_to_space, const std::set<char> &exclude) {
+	std::string result;
 
-  for (size_t i = 0; i < s.size(); i++) {
-    if (s[i] == '%' && i + 1 < s.size()) {
-      if (s[i + 1] == 'u') {
-        auto val = 0;
-        if (from_hex_to_i(s, i + 2, 4, val)) {
-          // 4 digits Unicode codes
-          char buff[4];
-          size_t len = to_utf8(val, buff);
-          if (len > 0) { result.append(buff, len); }
-          i += 5; // 'u0000'
-        } else {
-          result += s[i];
-        }
-      } else {
-        auto val = 0;
-        if (from_hex_to_i(s, i + 1, 2, val)) {
-          const auto converted = static_cast<char>(val);
-          if (exclude.count(converted) == 0) {
-            result += converted;
-          } else {
-            result.append(s, i, 3);
-          }
-          i += 2; // '00'
-        } else {
-          result += s[i];
-        }
-      }
-    } else if (convert_plus_to_space && s[i] == '+') {
-      result += ' ';
-    } else {
-      result += s[i];
-    }
-  }
+	for (size_t i = 0; i < s.size(); i++) {
+		if (s[i] == '%' && i + 1 < s.size()) {
+			if (s[i + 1] == 'u') {
+				auto val = 0;
+				if (from_hex_to_i(s, i + 2, 4, val)) {
+					// 4 digits Unicode codes
+					char buff[4];
+					size_t len = to_utf8(val, buff);
+					if (len > 0) {
+						result.append(buff, len);
+					}
+					i += 5; // 'u0000'
+				} else {
+					result += s[i];
+				}
+			} else {
+				auto val = 0;
+				if (from_hex_to_i(s, i + 1, 2, val)) {
+					const auto converted = static_cast<char>(val);
+					if (exclude.count(converted) == 0) {
+						result += converted;
+					} else {
+						result.append(s, i, 3);
+					}
+					i += 2; // '00'
+				} else {
+					result += s[i];
+				}
+			}
+		} else if (convert_plus_to_space && s[i] == '+') {
+			result += ' ';
+		} else {
+			result += s[i];
+		}
+	}
 
-  return result;
+	return result;
 }
 
 inline void read_file(const std::string &path, std::string &out) {
-  std::ifstream fs(path, std::ios_base::binary);
-  fs.seekg(0, std::ios_base::end);
-  auto size = fs.tellg();
-  fs.seekg(0);
-  out.resize(static_cast<size_t>(size));
-  fs.read(&out[0], static_cast<std::streamsize>(size));
+	std::ifstream fs(path, std::ios_base::binary);
+	fs.seekg(0, std::ios_base::end);
+	auto size = fs.tellg();
+	fs.seekg(0);
+	out.resize(static_cast<size_t>(size));
+	fs.read(&out[0], static_cast<std::streamsize>(size));
 }
 
 inline std::string file_extension(const std::string &path) {
-  Match m;
-  auto re = Regex("\\.([a-zA-Z0-9]+)$");
-  if (duckdb_re2::RegexSearch(path, m, re)) { return m[1].str(); }
-  return std::string();
+	Match m;
+	auto re = Regex("\\.([a-zA-Z0-9]+)$");
+	if (duckdb_re2::RegexSearch(path, m, re)) {
+		return m[1].str();
+	}
+	return std::string();
 }
 
-inline bool is_space_or_tab(char c) { return c == ' ' || c == '\t'; }
+inline bool is_space_or_tab(char c) {
+	return c == ' ' || c == '\t';
+}
 
-inline std::pair<size_t, size_t> trim(const char *b, const char *e, size_t left,
-                                      size_t right) {
-  while (b + left < e && is_space_or_tab(b[left])) {
-    left++;
-  }
-  while (right > 0 && is_space_or_tab(b[right - 1])) {
-    right--;
-  }
-  return std::make_pair(left, right);
+inline std::pair<size_t, size_t> trim(const char *b, const char *e, size_t left, size_t right) {
+	while (b + left < e && is_space_or_tab(b[left])) {
+		left++;
+	}
+	while (right > 0 && is_space_or_tab(b[right - 1])) {
+		right--;
+	}
+	return std::make_pair(left, right);
 }
 
 inline std::string trim_copy(const std::string &s) {
-  auto r = trim(s.data(), s.data() + s.size(), 0, s.size());
-  return s.substr(r.first, r.second - r.first);
+	auto r = trim(s.data(), s.data() + s.size(), 0, s.size());
+	return s.substr(r.first, r.second - r.first);
 }
 
 inline std::string trim_double_quotes_copy(const std::string &s) {
-  if (s.length() >= 2 && s.front() == '"' && s.back() == '"') {
-    return s.substr(1, s.size() - 2);
-  }
-  return s;
+	if (s.length() >= 2 && s.front() == '"' && s.back() == '"') {
+		return s.substr(1, s.size() - 2);
+	}
+	return s;
 }
 
-inline void split(const char *b, const char *e, char d,
-                  std::function<void(const char *, const char *)> fn) {
-  return split(b, e, d, static_cast<size_t>((std::numeric_limits<size_t>::max)()), fn);
+inline void split(const char *b, const char *e, char d, std::function<void(const char *, const char *)> fn) {
+	return split(b, e, d, static_cast<size_t>((std::numeric_limits<size_t>::max)()), fn);
 }
 
-inline void split(const char *b, const char *e, char d, size_t m,
-                  std::function<void(const char *, const char *)> fn) {
-  size_t i = 0;
-  size_t beg = 0;
-  size_t count = 1;
+inline void split(const char *b, const char *e, char d, size_t m, std::function<void(const char *, const char *)> fn) {
+	size_t i = 0;
+	size_t beg = 0;
+	size_t count = 1;
 
-  while (e ? (b + i < e) : (b[i] != '\0')) {
-    if (b[i] == d && count < m) {
-      auto r = trim(b, e, beg, i);
-      if (r.first < r.second) { fn(&b[r.first], &b[r.second]); }
-      beg = i + 1;
-      count++;
-    }
-    i++;
-  }
+	while (e ? (b + i < e) : (b[i] != '\0')) {
+		if (b[i] == d && count < m) {
+			auto r = trim(b, e, beg, i);
+			if (r.first < r.second) {
+				fn(&b[r.first], &b[r.second]);
+			}
+			beg = i + 1;
+			count++;
+		}
+		i++;
+	}
 
-  if (i) {
-    auto r = trim(b, e, beg, i);
-    if (r.first < r.second) { fn(&b[r.first], &b[r.second]); }
-  }
+	if (i) {
+		auto r = trim(b, e, beg, i);
+		if (r.first < r.second) {
+			fn(&b[r.first], &b[r.second]);
+		}
+	}
 }
 
-inline stream_line_reader::stream_line_reader(Stream &strm, char *fixed_buffer,
-                                              size_t fixed_buffer_size)
-    : strm_(strm), fixed_buffer_(fixed_buffer),
-      fixed_buffer_size_(fixed_buffer_size) {}
+inline stream_line_reader::stream_line_reader(Stream &strm, char *fixed_buffer, size_t fixed_buffer_size)
+    : strm_(strm), fixed_buffer_(fixed_buffer), fixed_buffer_size_(fixed_buffer_size) {
+}
 
 inline const char *stream_line_reader::ptr() const {
-  if (glowable_buffer_.empty()) {
-    return fixed_buffer_;
-  } else {
-    return glowable_buffer_.data();
-  }
+	if (glowable_buffer_.empty()) {
+		return fixed_buffer_;
+	} else {
+		return glowable_buffer_.data();
+	}
 }
 
 inline size_t stream_line_reader::size() const {
-  if (glowable_buffer_.empty()) {
-    return fixed_buffer_used_size_;
-  } else {
-    return glowable_buffer_.size();
-  }
+	if (glowable_buffer_.empty()) {
+		return fixed_buffer_used_size_;
+	} else {
+		return glowable_buffer_.size();
+	}
 }
 
 inline bool stream_line_reader::end_with_crlf() const {
-  auto end = ptr() + size();
-  return size() >= 2 && end[-2] == '\r' && end[-1] == '\n';
+	auto end = ptr() + size();
+	return size() >= 2 && end[-2] == '\r' && end[-1] == '\n';
 }
 
 inline bool stream_line_reader::getline() {
-  fixed_buffer_used_size_ = 0;
-  glowable_buffer_.clear();
+	fixed_buffer_used_size_ = 0;
+	glowable_buffer_.clear();
 
-  for (size_t i = 0;; i++) {
-    char byte;
-    auto n = strm_.read(&byte, 1);
+	for (size_t i = 0;; i++) {
+		char byte;
+		auto n = strm_.read(&byte, 1);
 
-    if (n < 0) {
-      return false;
-    } else if (n == 0) {
-      if (i == 0) {
-        return false;
-      } else {
-        break;
-      }
-    }
+		if (n < 0) {
+			return false;
+		} else if (n == 0) {
+			if (i == 0) {
+				return false;
+			} else {
+				break;
+			}
+		}
 
-    append(byte);
+		append(byte);
 
-    if (byte == '\n') { break; }
-  }
+		if (byte == '\n') {
+			break;
+		}
+	}
 
-  return true;
+	return true;
 }
 
 inline void stream_line_reader::append(char c) {
-  if (fixed_buffer_used_size_ < fixed_buffer_size_ - 1) {
-    fixed_buffer_[fixed_buffer_used_size_++] = c;
-    fixed_buffer_[fixed_buffer_used_size_] = '\0';
-  } else {
-    if (glowable_buffer_.empty()) {
-      assert(fixed_buffer_[fixed_buffer_used_size_] == '\0');
-      glowable_buffer_.assign(fixed_buffer_, fixed_buffer_used_size_);
-    }
-    glowable_buffer_ += c;
-  }
+	if (fixed_buffer_used_size_ < fixed_buffer_size_ - 1) {
+		fixed_buffer_[fixed_buffer_used_size_++] = c;
+		fixed_buffer_[fixed_buffer_used_size_] = '\0';
+	} else {
+		if (glowable_buffer_.empty()) {
+			assert(fixed_buffer_[fixed_buffer_used_size_] == '\0');
+			glowable_buffer_.assign(fixed_buffer_, fixed_buffer_used_size_);
+		}
+		glowable_buffer_ += c;
+	}
 }
 
 inline mmap::mmap(const char *path)
@@ -2680,554 +2608,564 @@ inline mmap::mmap(const char *path)
 #endif
       ,
       size_(0), addr_(nullptr) {
-  open(path);
+	open(path);
 }
 
-inline mmap::~mmap() { close(); }
+inline mmap::~mmap() {
+	close();
+}
 
 inline bool mmap::open(const char *path) {
-  close();
+	close();
 
 #if defined(_WIN32)
-  hFile_ = ::CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, NULL,
-                         OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	hFile_ = ::CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
-  if (hFile_ == INVALID_HANDLE_VALUE) { return false; }
+	if (hFile_ == INVALID_HANDLE_VALUE) {
+		return false;
+	}
 
-  size_ = ::GetFileSize(hFile_, NULL);
+	size_ = ::GetFileSize(hFile_, NULL);
 
-  hMapping_ = ::CreateFileMapping(hFile_, NULL, PAGE_READONLY, 0, 0, NULL);
+	hMapping_ = ::CreateFileMapping(hFile_, NULL, PAGE_READONLY, 0, 0, NULL);
 
-  if (hMapping_ == NULL) {
-    close();
-    return false;
-  }
+	if (hMapping_ == NULL) {
+		close();
+		return false;
+	}
 
-  addr_ = ::MapViewOfFile(hMapping_, FILE_MAP_READ, 0, 0, 0);
+	addr_ = ::MapViewOfFile(hMapping_, FILE_MAP_READ, 0, 0, 0);
 #else
-  fd_ = ::open(path, O_RDONLY);
-  if (fd_ == -1) { return false; }
+	fd_ = ::open(path, O_RDONLY);
+	if (fd_ == -1) {
+		return false;
+	}
 
-  struct stat sb;
-  if (fstat(fd_, &sb) == -1) {
-    close();
-    return false;
-  }
-  size_ = static_cast<size_t>(sb.st_size);
+	struct stat sb;
+	if (fstat(fd_, &sb) == -1) {
+		close();
+		return false;
+	}
+	size_ = static_cast<size_t>(sb.st_size);
 
-  addr_ = ::mmap(NULL, size_, PROT_READ, MAP_PRIVATE, fd_, 0);
+	addr_ = ::mmap(NULL, size_, PROT_READ, MAP_PRIVATE, fd_, 0);
 #endif
 
-  if (addr_ == nullptr) {
-    close();
-    return false;
-  }
+	if (addr_ == nullptr) {
+		close();
+		return false;
+	}
 
-  return true;
+	return true;
 }
 
-inline bool mmap::is_open() const { return addr_ != nullptr; }
+inline bool mmap::is_open() const {
+	return addr_ != nullptr;
+}
 
-inline size_t mmap::size() const { return size_; }
+inline size_t mmap::size() const {
+	return size_;
+}
 
-inline const char *mmap::data() const { return (const char *)addr_; }
+inline const char *mmap::data() const {
+	return (const char *)addr_;
+}
 
 inline void mmap::close() {
 #if defined(_WIN32)
-  if (addr_) {
-    ::UnmapViewOfFile(addr_);
-    addr_ = nullptr;
-  }
+	if (addr_) {
+		::UnmapViewOfFile(addr_);
+		addr_ = nullptr;
+	}
 
-  if (hMapping_) {
-    ::CloseHandle(hMapping_);
-    hMapping_ = NULL;
-  }
+	if (hMapping_) {
+		::CloseHandle(hMapping_);
+		hMapping_ = NULL;
+	}
 
-  if (hFile_ != INVALID_HANDLE_VALUE) {
-    ::CloseHandle(hFile_);
-    hFile_ = INVALID_HANDLE_VALUE;
-  }
+	if (hFile_ != INVALID_HANDLE_VALUE) {
+		::CloseHandle(hFile_);
+		hFile_ = INVALID_HANDLE_VALUE;
+	}
 #else
-  if (addr_ != nullptr) {
-    munmap(addr_, size_);
-    addr_ = nullptr;
-  }
+	if (addr_ != nullptr) {
+		munmap(addr_, size_);
+		addr_ = nullptr;
+	}
 
-  if (fd_ != -1) {
-    ::close(fd_);
-    fd_ = -1;
-  }
+	if (fd_ != -1) {
+		::close(fd_);
+		fd_ = -1;
+	}
 #endif
-  size_ = 0;
+	size_ = 0;
 }
 inline int close_socket(socket_t sock) {
 #ifdef _WIN32
-  return closesocket(sock);
+	return closesocket(sock);
 #else
-  return close(sock);
+	return close(sock);
 #endif
 }
 
-template <typename T> inline ssize_t handle_EINTR(T fn) {
-  ssize_t res = 0;
-  while (true) {
-    res = fn();
-    if (res < 0 && errno == EINTR) { continue; }
-    break;
-  }
-  return res;
+template <typename T>
+inline ssize_t handle_EINTR(T fn) {
+	ssize_t res = 0;
+	while (true) {
+		res = fn();
+		if (res < 0 && errno == EINTR) {
+			continue;
+		}
+		break;
+	}
+	return res;
 }
 
 inline ssize_t read_socket(socket_t sock, void *ptr, size_t size, int flags) {
-  return handle_EINTR([&]() {
-    return recv(sock,
+	return handle_EINTR([&]() {
+		return recv(sock,
 #ifdef _WIN32
-                static_cast<char *>(ptr), static_cast<int>(size),
+		            static_cast<char *>(ptr), static_cast<int>(size),
 #else
-                ptr, size,
+		            ptr, size,
 #endif
-                flags);
-  });
+		            flags);
+	});
 }
 
-inline ssize_t send_socket(socket_t sock, const void *ptr, size_t size,
-                           int flags) {
-  return handle_EINTR([&]() {
-    return send(sock,
+inline ssize_t send_socket(socket_t sock, const void *ptr, size_t size, int flags) {
+	return handle_EINTR([&]() {
+		return send(sock,
 #ifdef _WIN32
-                static_cast<const char *>(ptr), static_cast<int>(size),
+		            static_cast<const char *>(ptr), static_cast<int>(size),
 #else
-                ptr, size,
+		            ptr, size,
 #endif
-                flags);
-  });
+		            flags);
+	});
 }
 
 inline ssize_t select_read(socket_t sock, time_t sec, time_t usec) {
 #ifdef CPPHTTPLIB_USE_POLL
-  struct pollfd pfd_read;
-  pfd_read.fd = sock;
-  pfd_read.events = POLLIN;
+	struct pollfd pfd_read;
+	pfd_read.fd = sock;
+	pfd_read.events = POLLIN;
 
-  auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
+	auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
 
-  return handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
+	return handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
 #else
 #ifndef _WIN32
-  if (sock >= FD_SETSIZE) { return 1; }
+	if (sock >= FD_SETSIZE) {
+		return 1;
+	}
 #endif
 
-  fd_set fds;
-  FD_ZERO(&fds);
-  FD_SET(sock, &fds);
+	fd_set fds;
+	FD_ZERO(&fds);
+	FD_SET(sock, &fds);
 
-  timeval tv;
-  tv.tv_sec = static_cast<long>(sec);
-  tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
+	timeval tv;
+	tv.tv_sec = static_cast<long>(sec);
+	tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
 
-  return handle_EINTR([&]() {
-    return select(static_cast<int>(sock + 1), &fds, nullptr, nullptr, &tv);
-  });
+	return handle_EINTR([&]() { return select(static_cast<int>(sock + 1), &fds, nullptr, nullptr, &tv); });
 #endif
 }
 
 inline ssize_t select_write(socket_t sock, time_t sec, time_t usec) {
 #ifdef CPPHTTPLIB_USE_POLL
-  struct pollfd pfd_read;
-  pfd_read.fd = sock;
-  pfd_read.events = POLLOUT;
+	struct pollfd pfd_read;
+	pfd_read.fd = sock;
+	pfd_read.events = POLLOUT;
 
-  auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
+	auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
 
-  return handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
+	return handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
 #else
 #ifndef _WIN32
-  if (sock >= FD_SETSIZE) { return 1; }
+	if (sock >= FD_SETSIZE) {
+		return 1;
+	}
 #endif
 
-  fd_set fds;
-  FD_ZERO(&fds);
-  FD_SET(sock, &fds);
+	fd_set fds;
+	FD_ZERO(&fds);
+	FD_SET(sock, &fds);
 
-  timeval tv;
-  tv.tv_sec = static_cast<long>(sec);
-  tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
+	timeval tv;
+	tv.tv_sec = static_cast<long>(sec);
+	tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
 
-  return handle_EINTR([&]() {
-    return select(static_cast<int>(sock + 1), nullptr, &fds, nullptr, &tv);
-  });
+	return handle_EINTR([&]() { return select(static_cast<int>(sock + 1), nullptr, &fds, nullptr, &tv); });
 #endif
 }
 
-inline Error wait_until_socket_is_ready(socket_t sock, time_t sec,
-                                        time_t usec) {
+inline Error wait_until_socket_is_ready(socket_t sock, time_t sec, time_t usec) {
 #ifdef CPPHTTPLIB_USE_POLL
-  struct pollfd pfd_read;
-  pfd_read.fd = sock;
-  pfd_read.events = POLLIN | POLLOUT;
+	struct pollfd pfd_read;
+	pfd_read.fd = sock;
+	pfd_read.events = POLLIN | POLLOUT;
 
-  auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
+	auto timeout = static_cast<int>(sec * 1000 + usec / 1000);
 
-  auto poll_res = handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
+	auto poll_res = handle_EINTR([&]() { return poll(&pfd_read, 1, timeout); });
 
-  if (poll_res == 0) { return Error::ConnectionTimeout; }
+	if (poll_res == 0) {
+		return Error::ConnectionTimeout;
+	}
 
-  if (poll_res > 0 && pfd_read.revents & (POLLIN | POLLOUT)) {
-    auto error = 0;
-    socklen_t len = sizeof(error);
-    auto res = getsockopt(sock, SOL_SOCKET, SO_ERROR,
-                          reinterpret_cast<char *>(&error), &len);
-    auto successful = res >= 0 && !error;
-    return successful ? Error::Success : Error::Connection;
-  }
+	if (poll_res > 0 && pfd_read.revents & (POLLIN | POLLOUT)) {
+		auto error = 0;
+		socklen_t len = sizeof(error);
+		auto res = getsockopt(sock, SOL_SOCKET, SO_ERROR, reinterpret_cast<char *>(&error), &len);
+		auto successful = res >= 0 && !error;
+		return successful ? Error::Success : Error::Connection;
+	}
 
-  return Error::Connection;
+	return Error::Connection;
 #else
 #ifndef _WIN32
-  if (sock >= FD_SETSIZE) { return Error::Connection; }
+	if (sock >= FD_SETSIZE) {
+		return Error::Connection;
+	}
 #endif
 
-  fd_set fdsr;
-  FD_ZERO(&fdsr);
-  FD_SET(sock, &fdsr);
+	fd_set fdsr;
+	FD_ZERO(&fdsr);
+	FD_SET(sock, &fdsr);
 
-  auto fdsw = fdsr;
-  auto fdse = fdsr;
+	auto fdsw = fdsr;
+	auto fdse = fdsr;
 
-  timeval tv;
-  tv.tv_sec = static_cast<long>(sec);
-  tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
+	timeval tv;
+	tv.tv_sec = static_cast<long>(sec);
+	tv.tv_usec = static_cast<decltype(tv.tv_usec)>(usec);
 
-  auto ret = handle_EINTR([&]() {
-    return select(static_cast<int>(sock + 1), &fdsr, &fdsw, &fdse, &tv);
-  });
+	auto ret = handle_EINTR([&]() { return select(static_cast<int>(sock + 1), &fdsr, &fdsw, &fdse, &tv); });
 
-  if (ret == 0) { return Error::ConnectionTimeout; }
+	if (ret == 0) {
+		return Error::ConnectionTimeout;
+	}
 
-  if (ret > 0 && (FD_ISSET(sock, &fdsr) || FD_ISSET(sock, &fdsw))) {
-    auto error = 0;
-    socklen_t len = sizeof(error);
-    auto res = getsockopt(sock, SOL_SOCKET, SO_ERROR,
-                          reinterpret_cast<char *>(&error), &len);
-    auto successful = res >= 0 && !error;
-    return successful ? Error::Success : Error::Connection;
-  }
-  return Error::Connection;
+	if (ret > 0 && (FD_ISSET(sock, &fdsr) || FD_ISSET(sock, &fdsw))) {
+		auto error = 0;
+		socklen_t len = sizeof(error);
+		auto res = getsockopt(sock, SOL_SOCKET, SO_ERROR, reinterpret_cast<char *>(&error), &len);
+		auto successful = res >= 0 && !error;
+		return successful ? Error::Success : Error::Connection;
+	}
+	return Error::Connection;
 #endif
 }
 
 inline bool is_socket_alive(socket_t sock) {
-  const auto val = detail::select_read(sock, 0, 0);
-  if (val == 0) {
-    return true;
-  } else if (val < 0 && errno == EBADF) {
-    return false;
-  }
-  char buf[1];
-  return detail::read_socket(sock, &buf[0], sizeof(buf), MSG_PEEK) > 0;
+	const auto val = detail::select_read(sock, 0, 0);
+	if (val == 0) {
+		return true;
+	} else if (val < 0 && errno == EBADF) {
+		return false;
+	}
+	char buf[1];
+	return detail::read_socket(sock, &buf[0], sizeof(buf), MSG_PEEK) > 0;
 }
 
 class SocketStream : public Stream {
 public:
-  SocketStream(socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec,
-               time_t write_timeout_sec, time_t write_timeout_usec);
-  ~SocketStream() override;
+	SocketStream(socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
+	             time_t write_timeout_usec);
+	~SocketStream() override;
 
-  bool is_readable() const override;
-  bool is_writable() const override;
-  ssize_t read(char *ptr, size_t size) override;
-  ssize_t write(const char *ptr, size_t size) override;
-  void get_remote_ip_and_port(std::string &ip, int &port) const override;
-  void get_local_ip_and_port(std::string &ip, int &port) const override;
-  socket_t socket() const override;
+	bool is_readable() const override;
+	bool is_writable() const override;
+	ssize_t read(char *ptr, size_t size) override;
+	ssize_t write(const char *ptr, size_t size) override;
+	void get_remote_ip_and_port(std::string &ip, int &port) const override;
+	void get_local_ip_and_port(std::string &ip, int &port) const override;
+	socket_t socket() const override;
 
 private:
-  socket_t sock_;
-  time_t read_timeout_sec_;
-  time_t read_timeout_usec_;
-  time_t write_timeout_sec_;
-  time_t write_timeout_usec_;
+	socket_t sock_;
+	time_t read_timeout_sec_;
+	time_t read_timeout_usec_;
+	time_t write_timeout_sec_;
+	time_t write_timeout_usec_;
 
-  std::vector<char> read_buff_;
-  size_t read_buff_off_ = 0;
-  size_t read_buff_content_size_ = 0;
+	std::vector<char> read_buff_;
+	size_t read_buff_off_ = 0;
+	size_t read_buff_content_size_ = 0;
 
-  static const size_t read_buff_size_ = 1024l * 4;
+	static const size_t read_buff_size_ = 1024l * 4;
 };
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 class SSLSocketStream : public Stream {
 public:
-  SSLSocketStream(socket_t sock, SSL *ssl, time_t read_timeout_sec,
-                  time_t read_timeout_usec, time_t write_timeout_sec,
-                  time_t write_timeout_usec);
-  ~SSLSocketStream() override;
+	SSLSocketStream(socket_t sock, SSL *ssl, time_t read_timeout_sec, time_t read_timeout_usec,
+	                time_t write_timeout_sec, time_t write_timeout_usec);
+	~SSLSocketStream() override;
 
-  bool is_readable() const override;
-  bool is_writable() const override;
-  ssize_t read(char *ptr, size_t size) override;
-  ssize_t write(const char *ptr, size_t size) override;
-  void get_remote_ip_and_port(std::string &ip, int &port) const override;
-  void get_local_ip_and_port(std::string &ip, int &port) const override;
-  socket_t socket() const override;
+	bool is_readable() const override;
+	bool is_writable() const override;
+	ssize_t read(char *ptr, size_t size) override;
+	ssize_t write(const char *ptr, size_t size) override;
+	void get_remote_ip_and_port(std::string &ip, int &port) const override;
+	void get_local_ip_and_port(std::string &ip, int &port) const override;
+	socket_t socket() const override;
 
 private:
-  socket_t sock_;
-  SSL *ssl_;
-  time_t read_timeout_sec_;
-  time_t read_timeout_usec_;
-  time_t write_timeout_sec_;
-  time_t write_timeout_usec_;
+	socket_t sock_;
+	SSL *ssl_;
+	time_t read_timeout_sec_;
+	time_t read_timeout_usec_;
+	time_t write_timeout_sec_;
+	time_t write_timeout_usec_;
 };
 #endif
 
 inline bool keep_alive(socket_t sock, time_t keep_alive_timeout_sec) {
-  using namespace std::chrono;
-  auto start = steady_clock::now();
-  while (true) {
-    auto val = select_read(sock, 0, 10000);
-    if (val < 0) {
-      return false;
-    } else if (val == 0) {
-      auto current = steady_clock::now();
-      auto duration = duration_cast<milliseconds>(current - start);
-      auto timeout = keep_alive_timeout_sec * 1000;
-      if (duration.count() > timeout) { return false; }
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    } else {
-      return true;
-    }
-  }
+	using namespace std::chrono;
+	auto start = steady_clock::now();
+	while (true) {
+		auto val = select_read(sock, 0, 10000);
+		if (val < 0) {
+			return false;
+		} else if (val == 0) {
+			auto current = steady_clock::now();
+			auto duration = duration_cast<milliseconds>(current - start);
+			auto timeout = keep_alive_timeout_sec * 1000;
+			if (duration.count() > timeout) {
+				return false;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		} else {
+			return true;
+		}
+	}
 }
 
 template <typename T>
-inline bool
-process_server_socket_core(const std::atomic<socket_t> &svr_sock, socket_t sock,
-                           size_t keep_alive_max_count,
-                           time_t keep_alive_timeout_sec, T callback) {
-  assert(keep_alive_max_count > 0);
-  auto ret = false;
-  auto count = keep_alive_max_count;
-  while (svr_sock != INVALID_SOCKET && count > 0 &&
-         keep_alive(sock, keep_alive_timeout_sec)) {
-    auto close_connection = count == 1;
-    auto connection_closed = false;
-    ret = callback(close_connection, connection_closed);
-    if (!ret || connection_closed) { break; }
-    count--;
-  }
-  return ret;
+inline bool process_server_socket_core(const std::atomic<socket_t> &svr_sock, socket_t sock,
+                                       size_t keep_alive_max_count, time_t keep_alive_timeout_sec, T callback) {
+	assert(keep_alive_max_count > 0);
+	auto ret = false;
+	auto count = keep_alive_max_count;
+	while (svr_sock != INVALID_SOCKET && count > 0 && keep_alive(sock, keep_alive_timeout_sec)) {
+		auto close_connection = count == 1;
+		auto connection_closed = false;
+		ret = callback(close_connection, connection_closed);
+		if (!ret || connection_closed) {
+			break;
+		}
+		count--;
+	}
+	return ret;
 }
 
 template <typename T>
-inline bool
-process_server_socket(const std::atomic<socket_t> &svr_sock, socket_t sock,
-                      size_t keep_alive_max_count,
-                      time_t keep_alive_timeout_sec, time_t read_timeout_sec,
-                      time_t read_timeout_usec, time_t write_timeout_sec,
-                      time_t write_timeout_usec, T callback) {
-  return process_server_socket_core(
-      svr_sock, sock, keep_alive_max_count, keep_alive_timeout_sec,
-      [&](bool close_connection, bool &connection_closed) {
-        SocketStream strm(sock, read_timeout_sec, read_timeout_usec,
-                          write_timeout_sec, write_timeout_usec);
-        return callback(strm, close_connection, connection_closed);
-      });
+inline bool process_server_socket(const std::atomic<socket_t> &svr_sock, socket_t sock, size_t keep_alive_max_count,
+                                  time_t keep_alive_timeout_sec, time_t read_timeout_sec, time_t read_timeout_usec,
+                                  time_t write_timeout_sec, time_t write_timeout_usec, T callback) {
+	return process_server_socket_core(svr_sock, sock, keep_alive_max_count, keep_alive_timeout_sec,
+	                                  [&](bool close_connection, bool &connection_closed) {
+		                                  SocketStream strm(sock, read_timeout_sec, read_timeout_usec,
+		                                                    write_timeout_sec, write_timeout_usec);
+		                                  return callback(strm, close_connection, connection_closed);
+	                                  });
 }
 
-inline bool process_client_socket(socket_t sock, time_t read_timeout_sec,
-                                  time_t read_timeout_usec,
-                                  time_t write_timeout_sec,
-                                  time_t write_timeout_usec,
+inline bool process_client_socket(socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec,
+                                  time_t write_timeout_sec, time_t write_timeout_usec,
                                   std::function<bool(Stream &)> callback) {
-  SocketStream strm(sock, read_timeout_sec, read_timeout_usec,
-                    write_timeout_sec, write_timeout_usec);
-  return callback(strm);
+	SocketStream strm(sock, read_timeout_sec, read_timeout_usec, write_timeout_sec, write_timeout_usec);
+	return callback(strm);
 }
 
 inline int shutdown_socket(socket_t sock) {
 #ifdef _WIN32
-  return shutdown(sock, SD_BOTH);
+	return shutdown(sock, SD_BOTH);
 #else
-  return shutdown(sock, SHUT_RDWR);
+	return shutdown(sock, SHUT_RDWR);
 #endif
 }
 
 template <typename BindOrConnect>
-socket_t create_socket(const std::string &host, const std::string &ip, int port,
-                       int address_family, int socket_flags, bool tcp_nodelay,
-                       SocketOptions socket_options,
-                       BindOrConnect bind_or_connect) {
-  // Get address info
-  const char *node = nullptr;
-  struct addrinfo hints;
-  struct addrinfo *result;
+socket_t create_socket(const std::string &host, const std::string &ip, int port, int address_family, int socket_flags,
+                       bool tcp_nodelay, SocketOptions socket_options, BindOrConnect bind_or_connect) {
+	// Get address info
+	const char *node = nullptr;
+	struct addrinfo hints;
+	struct addrinfo *result;
 
-  memset(&hints, 0, sizeof(struct addrinfo));
-  hints.ai_socktype = SOCK_STREAM;
-  hints.ai_protocol = 0;
+	memset(&hints, 0, sizeof(struct addrinfo));
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = 0;
 
-  if (!ip.empty()) {
-    node = ip.c_str();
-    // Ask getaddrinfo to convert IP in c-string to address
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_flags = AI_NUMERICHOST;
-  } else {
-    if (!host.empty()) { node = host.c_str(); }
-    hints.ai_family = address_family;
-    hints.ai_flags = socket_flags;
-  }
+	if (!ip.empty()) {
+		node = ip.c_str();
+		// Ask getaddrinfo to convert IP in c-string to address
+		hints.ai_family = AF_UNSPEC;
+		hints.ai_flags = AI_NUMERICHOST;
+	} else {
+		if (!host.empty()) {
+			node = host.c_str();
+		}
+		hints.ai_family = address_family;
+		hints.ai_flags = socket_flags;
+	}
 
 #ifndef _WIN32
-  if (hints.ai_family == AF_UNIX) {
-    const auto addrlen = host.length();
-    if (addrlen > sizeof(sockaddr_un::sun_path)) { return INVALID_SOCKET; }
+	if (hints.ai_family == AF_UNIX) {
+		const auto addrlen = host.length();
+		if (addrlen > sizeof(sockaddr_un::sun_path)) {
+			return INVALID_SOCKET;
+		}
 
-    auto sock = socket(hints.ai_family, hints.ai_socktype, hints.ai_protocol);
-    if (sock != INVALID_SOCKET) {
-      sockaddr_un addr{};
-      addr.sun_family = AF_UNIX;
-      std::copy(host.begin(), host.end(), addr.sun_path);
+		auto sock = socket(hints.ai_family, hints.ai_socktype, hints.ai_protocol);
+		if (sock != INVALID_SOCKET) {
+			sockaddr_un addr {};
+			addr.sun_family = AF_UNIX;
+			std::copy(host.begin(), host.end(), addr.sun_path);
 
-      hints.ai_addr = reinterpret_cast<sockaddr *>(&addr);
-      hints.ai_addrlen = static_cast<socklen_t>(
-          sizeof(addr) - sizeof(addr.sun_path) + addrlen);
+			hints.ai_addr = reinterpret_cast<sockaddr *>(&addr);
+			hints.ai_addrlen = static_cast<socklen_t>(sizeof(addr) - sizeof(addr.sun_path) + addrlen);
 
-      fcntl(sock, F_SETFD, FD_CLOEXEC);
-      if (socket_options) { socket_options(sock); }
+			fcntl(sock, F_SETFD, FD_CLOEXEC);
+			if (socket_options) {
+				socket_options(sock);
+			}
 
-      if (!bind_or_connect(sock, hints)) {
-        close_socket(sock);
-        sock = INVALID_SOCKET;
-      }
-    }
-    return sock;
-  }
+			if (!bind_or_connect(sock, hints)) {
+				close_socket(sock);
+				sock = INVALID_SOCKET;
+			}
+		}
+		return sock;
+	}
 #endif
 
-  auto service = std::to_string(port);
+	auto service = std::to_string(port);
 
-  if (getaddrinfo(node, service.c_str(), &hints, &result)) {
+	if (getaddrinfo(node, service.c_str(), &hints, &result)) {
 #if defined __linux__ && !defined __ANDROID__
-    res_init();
+		res_init();
 #endif
-    return INVALID_SOCKET;
-  }
+		return INVALID_SOCKET;
+	}
 
-  for (auto rp = result; rp; rp = rp->ai_next) {
-    // Create a socket
+	for (auto rp = result; rp; rp = rp->ai_next) {
+		// Create a socket
 #ifdef _WIN32
-    auto sock =
-        WSASocketW(rp->ai_family, rp->ai_socktype, rp->ai_protocol, nullptr, 0,
-                   WSA_FLAG_NO_HANDLE_INHERIT | WSA_FLAG_OVERLAPPED);
-    /**
-     * Since the WSA_FLAG_NO_HANDLE_INHERIT is only supported on Windows 7 SP1
-     * and above the socket creation fails on older Windows Systems.
-     *
-     * Let's try to create a socket the old way in this case.
-     *
-     * Reference:
-     * https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketa
-     *
-     * WSA_FLAG_NO_HANDLE_INHERIT:
-     * This flag is supported on Windows 7 with SP1, Windows Server 2008 R2 with
-     * SP1, and later
-     *
-     */
-    if (sock == INVALID_SOCKET) {
-      sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-    }
+		auto sock = WSASocketW(rp->ai_family, rp->ai_socktype, rp->ai_protocol, nullptr, 0,
+		                       WSA_FLAG_NO_HANDLE_INHERIT | WSA_FLAG_OVERLAPPED);
+		/**
+		 * Since the WSA_FLAG_NO_HANDLE_INHERIT is only supported on Windows 7 SP1
+		 * and above the socket creation fails on older Windows Systems.
+		 *
+		 * Let's try to create a socket the old way in this case.
+		 *
+		 * Reference:
+		 * https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketa
+		 *
+		 * WSA_FLAG_NO_HANDLE_INHERIT:
+		 * This flag is supported on Windows 7 with SP1, Windows Server 2008 R2 with
+		 * SP1, and later
+		 *
+		 */
+		if (sock == INVALID_SOCKET) {
+			sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+		}
 #else
-    auto sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+		auto sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
 #endif
-    if (sock == INVALID_SOCKET) { continue; }
+		if (sock == INVALID_SOCKET) {
+			continue;
+		}
 
 #ifndef _WIN32
-    if (fcntl(sock, F_SETFD, FD_CLOEXEC) == -1) {
-      close_socket(sock);
-      continue;
-    }
+		if (fcntl(sock, F_SETFD, FD_CLOEXEC) == -1) {
+			close_socket(sock);
+			continue;
+		}
 #endif
 
-    if (tcp_nodelay) {
-      auto yes = 1;
+		if (tcp_nodelay) {
+			auto yes = 1;
 #ifdef _WIN32
-      setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
-                 reinterpret_cast<const char *>(&yes), sizeof(yes));
+			setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char *>(&yes), sizeof(yes));
 #else
-      setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
-                 reinterpret_cast<const void *>(&yes), sizeof(yes));
+			setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const void *>(&yes), sizeof(yes));
 #endif
-    }
+		}
 
-    if (socket_options) { socket_options(sock); }
+		if (socket_options) {
+			socket_options(sock);
+		}
 
-    if (rp->ai_family == AF_INET6) {
-      auto no = 0;
+		if (rp->ai_family == AF_INET6) {
+			auto no = 0;
 #ifdef _WIN32
-      setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
-                 reinterpret_cast<const char *>(&no), sizeof(no));
+			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char *>(&no), sizeof(no));
 #else
-      setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
-                 reinterpret_cast<const void *>(&no), sizeof(no));
+			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const void *>(&no), sizeof(no));
 #endif
-    }
+		}
 
-    // bind or connect
-    if (bind_or_connect(sock, *rp)) {
-      freeaddrinfo(result);
-      return sock;
-    }
+		// bind or connect
+		if (bind_or_connect(sock, *rp)) {
+			freeaddrinfo(result);
+			return sock;
+		}
 
-    close_socket(sock);
-  }
+		close_socket(sock);
+	}
 
-  freeaddrinfo(result);
-  return INVALID_SOCKET;
+	freeaddrinfo(result);
+	return INVALID_SOCKET;
 }
 
 inline void set_nonblocking(socket_t sock, bool nonblocking) {
 #ifdef _WIN32
-  auto flags = nonblocking ? 1UL : 0UL;
-  ioctlsocket(sock, FIONBIO, &flags);
+	auto flags = nonblocking ? 1UL : 0UL;
+	ioctlsocket(sock, FIONBIO, &flags);
 #else
-  auto flags = fcntl(sock, F_GETFL, 0);
-  fcntl(sock, F_SETFL,
-        nonblocking ? (flags | O_NONBLOCK) : (flags & (~O_NONBLOCK)));
+	auto flags = fcntl(sock, F_GETFL, 0);
+	fcntl(sock, F_SETFL, nonblocking ? (flags | O_NONBLOCK) : (flags & (~O_NONBLOCK)));
 #endif
 }
 
 inline bool is_connection_error() {
 #ifdef _WIN32
-  return WSAGetLastError() != WSAEWOULDBLOCK;
+	return WSAGetLastError() != WSAEWOULDBLOCK;
 #else
-  return errno != EINPROGRESS;
+	return errno != EINPROGRESS;
 #endif
 }
 
 inline bool bind_ip_address(socket_t sock, const std::string &host) {
-  struct addrinfo hints;
-  struct addrinfo *result;
+	struct addrinfo hints;
+	struct addrinfo *result;
 
-  memset(&hints, 0, sizeof(struct addrinfo));
-  hints.ai_family = AF_UNSPEC;
-  hints.ai_socktype = SOCK_STREAM;
-  hints.ai_protocol = 0;
+	memset(&hints, 0, sizeof(struct addrinfo));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = 0;
 
-  if (getaddrinfo(host.c_str(), "0", &hints, &result)) { return false; }
+	if (getaddrinfo(host.c_str(), "0", &hints, &result)) {
+		return false;
+	}
 
-  auto ret = false;
-  for (auto rp = result; rp; rp = rp->ai_next) {
-    const auto &ai = *rp;
-    if (!::bind(sock, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen))) {
-      ret = true;
-      break;
-    }
-  }
+	auto ret = false;
+	for (auto rp = result; rp; rp = rp->ai_next) {
+		const auto &ai = *rp;
+		if (!::bind(sock, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen))) {
+			ret = true;
+			break;
+		}
+	}
 
-  freeaddrinfo(result);
-  return ret;
+	freeaddrinfo(result);
+	return ret;
 }
 
 #if !defined _WIN32 && !defined ANDROID && !defined _AIX && !defined __MVS__
@@ -3236,1119 +3174,1209 @@ inline bool bind_ip_address(socket_t sock, const std::string &host) {
 
 #ifdef USE_IF2IP
 inline std::string if2ip(int address_family, const std::string &ifn) {
-  struct ifaddrs *ifap;
-  getifaddrs(&ifap);
-  std::string addr_candidate;
-  for (auto ifa = ifap; ifa; ifa = ifa->ifa_next) {
-    if (ifa->ifa_addr && ifn == ifa->ifa_name &&
-        (AF_UNSPEC == address_family ||
-         ifa->ifa_addr->sa_family == address_family)) {
-      if (ifa->ifa_addr->sa_family == AF_INET) {
-        auto sa = reinterpret_cast<struct sockaddr_in *>(ifa->ifa_addr);
-        char buf[INET_ADDRSTRLEN];
-        if (inet_ntop(AF_INET, &sa->sin_addr, buf, INET_ADDRSTRLEN)) {
-          freeifaddrs(ifap);
-          return std::string(buf, INET_ADDRSTRLEN);
-        }
-      } else if (ifa->ifa_addr->sa_family == AF_INET6) {
-        auto sa = reinterpret_cast<struct sockaddr_in6 *>(ifa->ifa_addr);
-        if (!IN6_IS_ADDR_LINKLOCAL(&sa->sin6_addr)) {
-          char buf[INET6_ADDRSTRLEN] = {};
-          if (inet_ntop(AF_INET6, &sa->sin6_addr, buf, INET6_ADDRSTRLEN)) {
-            // equivalent to mac's IN6_IS_ADDR_UNIQUE_LOCAL
-            auto s6_addr_head = sa->sin6_addr.s6_addr[0];
-            if (s6_addr_head == 0xfc || s6_addr_head == 0xfd) {
-              addr_candidate = std::string(buf, INET6_ADDRSTRLEN);
-            } else {
-              freeifaddrs(ifap);
-              return std::string(buf, INET6_ADDRSTRLEN);
-            }
-          }
-        }
-      }
-    }
-  }
-  freeifaddrs(ifap);
-  return addr_candidate;
+	struct ifaddrs *ifap;
+	getifaddrs(&ifap);
+	std::string addr_candidate;
+	for (auto ifa = ifap; ifa; ifa = ifa->ifa_next) {
+		if (ifa->ifa_addr && ifn == ifa->ifa_name &&
+		    (AF_UNSPEC == address_family || ifa->ifa_addr->sa_family == address_family)) {
+			if (ifa->ifa_addr->sa_family == AF_INET) {
+				auto sa = reinterpret_cast<struct sockaddr_in *>(ifa->ifa_addr);
+				char buf[INET_ADDRSTRLEN];
+				if (inet_ntop(AF_INET, &sa->sin_addr, buf, INET_ADDRSTRLEN)) {
+					freeifaddrs(ifap);
+					return std::string(buf, INET_ADDRSTRLEN);
+				}
+			} else if (ifa->ifa_addr->sa_family == AF_INET6) {
+				auto sa = reinterpret_cast<struct sockaddr_in6 *>(ifa->ifa_addr);
+				if (!IN6_IS_ADDR_LINKLOCAL(&sa->sin6_addr)) {
+					char buf[INET6_ADDRSTRLEN] = {};
+					if (inet_ntop(AF_INET6, &sa->sin6_addr, buf, INET6_ADDRSTRLEN)) {
+						// equivalent to mac's IN6_IS_ADDR_UNIQUE_LOCAL
+						auto s6_addr_head = sa->sin6_addr.s6_addr[0];
+						if (s6_addr_head == 0xfc || s6_addr_head == 0xfd) {
+							addr_candidate = std::string(buf, INET6_ADDRSTRLEN);
+						} else {
+							freeifaddrs(ifap);
+							return std::string(buf, INET6_ADDRSTRLEN);
+						}
+					}
+				}
+			}
+		}
+	}
+	freeifaddrs(ifap);
+	return addr_candidate;
 }
 #endif
 
-inline socket_t create_client_socket(
-    const std::string &host, const std::string &ip, int port,
-    int address_family, bool tcp_nodelay, SocketOptions socket_options,
-    time_t connection_timeout_sec, time_t connection_timeout_usec,
-    time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
-    time_t write_timeout_usec, const std::string &intf, Error &error) {
-  auto sock = create_socket(
-      host, ip, port, address_family, 0, tcp_nodelay, std::move(socket_options),
-      [&](socket_t sock2, struct addrinfo &ai) -> bool {
-        if (!intf.empty()) {
+inline socket_t create_client_socket(const std::string &host, const std::string &ip, int port, int address_family,
+                                     bool tcp_nodelay, SocketOptions socket_options, time_t connection_timeout_sec,
+                                     time_t connection_timeout_usec, time_t read_timeout_sec, time_t read_timeout_usec,
+                                     time_t write_timeout_sec, time_t write_timeout_usec, const std::string &intf,
+                                     Error &error) {
+	auto sock = create_socket(
+	    host, ip, port, address_family, 0, tcp_nodelay, std::move(socket_options),
+	    [&](socket_t sock2, struct addrinfo &ai) -> bool {
+		    if (!intf.empty()) {
 #ifdef USE_IF2IP
-          auto ip_from_if = if2ip(address_family, intf);
-          if (ip_from_if.empty()) { ip_from_if = intf; }
-          if (!bind_ip_address(sock2, ip_from_if)) {
-            error = Error::BindIPAddress;
-            return false;
-          }
+			    auto ip_from_if = if2ip(address_family, intf);
+			    if (ip_from_if.empty()) {
+				    ip_from_if = intf;
+			    }
+			    if (!bind_ip_address(sock2, ip_from_if)) {
+				    error = Error::BindIPAddress;
+				    return false;
+			    }
 #endif
-        }
+		    }
 
-        set_nonblocking(sock2, true);
+		    set_nonblocking(sock2, true);
 
-        auto ret =
-            ::connect(sock2, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen));
+		    auto ret = ::connect(sock2, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen));
 
-        if (ret < 0) {
-          if (is_connection_error()) {
-            error = Error::Connection;
-            return false;
-          }
-          error = wait_until_socket_is_ready(sock2, connection_timeout_sec,
-                                             connection_timeout_usec);
-          if (error != Error::Success) { return false; }
-        }
+		    if (ret < 0) {
+			    if (is_connection_error()) {
+				    error = Error::Connection;
+				    return false;
+			    }
+			    error = wait_until_socket_is_ready(sock2, connection_timeout_sec, connection_timeout_usec);
+			    if (error != Error::Success) {
+				    return false;
+			    }
+		    }
 
-        set_nonblocking(sock2, false);
+		    set_nonblocking(sock2, false);
 
-        {
+		    {
 #ifdef _WIN32
-          auto timeout = static_cast<uint32_t>(read_timeout_sec * 1000 +
-                                               read_timeout_usec / 1000);
-          setsockopt(sock2, SOL_SOCKET, SO_RCVTIMEO,
-                     reinterpret_cast<const char *>(&timeout), sizeof(timeout));
+			    auto timeout = static_cast<uint32_t>(read_timeout_sec * 1000 + read_timeout_usec / 1000);
+			    setsockopt(sock2, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char *>(&timeout), sizeof(timeout));
 #else
-          timeval tv;
-          tv.tv_sec = static_cast<long>(read_timeout_sec);
-          tv.tv_usec = static_cast<decltype(tv.tv_usec)>(read_timeout_usec);
-          setsockopt(sock2, SOL_SOCKET, SO_RCVTIMEO,
-                     reinterpret_cast<const void *>(&tv), sizeof(tv));
+			    timeval tv;
+			    tv.tv_sec = static_cast<long>(read_timeout_sec);
+			    tv.tv_usec = static_cast<decltype(tv.tv_usec)>(read_timeout_usec);
+			    setsockopt(sock2, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const void *>(&tv), sizeof(tv));
 #endif
-        }
-        {
+		    }
+		    {
 
 #ifdef _WIN32
-          auto timeout = static_cast<uint32_t>(write_timeout_sec * 1000 +
-                                               write_timeout_usec / 1000);
-          setsockopt(sock2, SOL_SOCKET, SO_SNDTIMEO,
-                     reinterpret_cast<const char *>(&timeout), sizeof(timeout));
+			    auto timeout = static_cast<uint32_t>(write_timeout_sec * 1000 + write_timeout_usec / 1000);
+			    setsockopt(sock2, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char *>(&timeout), sizeof(timeout));
 #else
-          timeval tv;
-          tv.tv_sec = static_cast<long>(write_timeout_sec);
-          tv.tv_usec = static_cast<decltype(tv.tv_usec)>(write_timeout_usec);
-          setsockopt(sock2, SOL_SOCKET, SO_SNDTIMEO,
-                     reinterpret_cast<const void *>(&tv), sizeof(tv));
+			    timeval tv;
+			    tv.tv_sec = static_cast<long>(write_timeout_sec);
+			    tv.tv_usec = static_cast<decltype(tv.tv_usec)>(write_timeout_usec);
+			    setsockopt(sock2, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const void *>(&tv), sizeof(tv));
 #endif
-        }
+		    }
 
-        error = Error::Success;
-        return true;
-      });
+		    error = Error::Success;
+		    return true;
+	    });
 
-  if (sock != INVALID_SOCKET) {
-    error = Error::Success;
-  } else {
-    if (error == Error::Success) { error = Error::Connection; }
-  }
+	if (sock != INVALID_SOCKET) {
+		error = Error::Success;
+	} else {
+		if (error == Error::Success) {
+			error = Error::Connection;
+		}
+	}
 
-  return sock;
+	return sock;
 }
 
-inline bool get_ip_and_port(const struct sockaddr_storage &addr,
-                            socklen_t addr_len, std::string &ip, int &port) {
-  if (addr.ss_family == AF_INET) {
-    port = ntohs(reinterpret_cast<const struct sockaddr_in *>(&addr)->sin_port);
-  } else if (addr.ss_family == AF_INET6) {
-    port =
-        ntohs(reinterpret_cast<const struct sockaddr_in6 *>(&addr)->sin6_port);
-  } else {
-    return false;
-  }
+inline bool get_ip_and_port(const struct sockaddr_storage &addr, socklen_t addr_len, std::string &ip, int &port) {
+	if (addr.ss_family == AF_INET) {
+		port = ntohs(reinterpret_cast<const struct sockaddr_in *>(&addr)->sin_port);
+	} else if (addr.ss_family == AF_INET6) {
+		port = ntohs(reinterpret_cast<const struct sockaddr_in6 *>(&addr)->sin6_port);
+	} else {
+		return false;
+	}
 
-  std::array<char, NI_MAXHOST> ipstr{};
-  if (getnameinfo(reinterpret_cast<const struct sockaddr *>(&addr), addr_len,
-                  ipstr.data(), static_cast<socklen_t>(ipstr.size()), nullptr,
-                  0, NI_NUMERICHOST)) {
-    return false;
-  }
+	std::array<char, NI_MAXHOST> ipstr {};
+	if (getnameinfo(reinterpret_cast<const struct sockaddr *>(&addr), addr_len, ipstr.data(),
+	                static_cast<socklen_t>(ipstr.size()), nullptr, 0, NI_NUMERICHOST)) {
+		return false;
+	}
 
-  ip = ipstr.data();
-  return true;
+	ip = ipstr.data();
+	return true;
 }
 
 inline void get_local_ip_and_port(socket_t sock, std::string &ip, int &port) {
-  struct sockaddr_storage addr;
-  socklen_t addr_len = sizeof(addr);
-  if (!getsockname(sock, reinterpret_cast<struct sockaddr *>(&addr),
-                   &addr_len)) {
-    get_ip_and_port(addr, addr_len, ip, port);
-  }
+	struct sockaddr_storage addr;
+	socklen_t addr_len = sizeof(addr);
+	if (!getsockname(sock, reinterpret_cast<struct sockaddr *>(&addr), &addr_len)) {
+		get_ip_and_port(addr, addr_len, ip, port);
+	}
 }
 
 inline void get_remote_ip_and_port(socket_t sock, std::string &ip, int &port) {
-  struct sockaddr_storage addr;
-  socklen_t addr_len = sizeof(addr);
+	struct sockaddr_storage addr;
+	socklen_t addr_len = sizeof(addr);
 
-  if (!getpeername(sock, reinterpret_cast<struct sockaddr *>(&addr),
-                   &addr_len)) {
+	if (!getpeername(sock, reinterpret_cast<struct sockaddr *>(&addr), &addr_len)) {
 #ifndef _WIN32
-    if (addr.ss_family == AF_UNIX) {
+		if (addr.ss_family == AF_UNIX) {
 #if defined(__linux__)
-      struct ucred ucred;
-      socklen_t len = sizeof(ucred);
-      if (getsockopt(sock, SOL_SOCKET, SO_PEERCRED, &ucred, &len) == 0) {
-        port = ucred.pid;
-      }
+			struct ucred ucred;
+			socklen_t len = sizeof(ucred);
+			if (getsockopt(sock, SOL_SOCKET, SO_PEERCRED, &ucred, &len) == 0) {
+				port = ucred.pid;
+			}
 #elif defined(SOL_LOCAL) && defined(SO_PEERPID) // __APPLE__
-      pid_t pid;
-      socklen_t len = sizeof(pid);
-      if (getsockopt(sock, SOL_LOCAL, SO_PEERPID, &pid, &len) == 0) {
-        port = pid;
-      }
+			pid_t pid;
+			socklen_t len = sizeof(pid);
+			if (getsockopt(sock, SOL_LOCAL, SO_PEERPID, &pid, &len) == 0) {
+				port = pid;
+			}
 #endif
-      return;
-    }
+			return;
+		}
 #endif
-    get_ip_and_port(addr, addr_len, ip, port);
-  }
+		get_ip_and_port(addr, addr_len, ip, port);
+	}
 }
 
-inline constexpr unsigned int str2tag_core(const char *s, size_t l,
-                                           unsigned int h) {
-  return (l == 0)
-             ? h
-             : str2tag_core(
-                   s + 1, l - 1,
-                   // Unsets the 6 high bits of h, therefore no overflow happens
-                   (((std::numeric_limits<unsigned int>::max)() >> 6) &
-                    h * 33) ^
-                       static_cast<unsigned char>(*s));
+inline constexpr unsigned int str2tag_core(const char *s, size_t l, unsigned int h) {
+	return (l == 0) ? h
+	                : str2tag_core(s + 1, l - 1,
+	                               // Unsets the 6 high bits of h, therefore no overflow happens
+	                               (((std::numeric_limits<unsigned int>::max)() >> 6) & h * 33) ^
+	                                   static_cast<unsigned char>(*s));
 }
 
 inline unsigned int str2tag(const std::string &s) {
-  return str2tag_core(s.data(), s.size(), 0);
+	return str2tag_core(s.data(), s.size(), 0);
 }
 
 namespace udl {
 
-inline constexpr unsigned int operator ""_t(const char *s, size_t l) {
-  return str2tag_core(s, l, 0);
+inline constexpr unsigned int operator""_t(const char *s, size_t l) {
+	return str2tag_core(s, l, 0);
 }
 
 } // namespace udl
 
-inline std::string
-find_content_type(const std::string &path,
-                  const std::map<std::string, std::string> &user_data,
-                  const std::string &default_content_type) {
-  auto ext = file_extension(path);
+inline std::string find_content_type(const std::string &path, const std::map<std::string, std::string> &user_data,
+                                     const std::string &default_content_type) {
+	auto ext = file_extension(path);
 
-  auto it = user_data.find(ext);
-  if (it != user_data.end()) { return it->second; }
+	auto it = user_data.find(ext);
+	if (it != user_data.end()) {
+		return it->second;
+	}
 
-  using udl::operator ""_t;
+	using udl::operator""_t;
 
-  switch (str2tag(ext)) {
-  default: return default_content_type;
+	switch (str2tag(ext)) {
+	default:
+		return default_content_type;
 
-  case "css"_t: return "text/css";
-  case "csv"_t: return "text/csv";
-  case "htm"_t:
-  case "html"_t: return "text/html";
-  case "js"_t:
-  case "mjs"_t: return "text/javascript";
-  case "txt"_t: return "text/plain";
-  case "vtt"_t: return "text/vtt";
+	case "css"_t:
+		return "text/css";
+	case "csv"_t:
+		return "text/csv";
+	case "htm"_t:
+	case "html"_t:
+		return "text/html";
+	case "js"_t:
+	case "mjs"_t:
+		return "text/javascript";
+	case "txt"_t:
+		return "text/plain";
+	case "vtt"_t:
+		return "text/vtt";
 
-  case "apng"_t: return "image/apng";
-  case "avif"_t: return "image/avif";
-  case "bmp"_t: return "image/bmp";
-  case "gif"_t: return "image/gif";
-  case "png"_t: return "image/png";
-  case "svg"_t: return "image/svg+xml";
-  case "webp"_t: return "image/webp";
-  case "ico"_t: return "image/x-icon";
-  case "tif"_t: return "image/tiff";
-  case "tiff"_t: return "image/tiff";
-  case "jpg"_t:
-  case "jpeg"_t: return "image/jpeg";
+	case "apng"_t:
+		return "image/apng";
+	case "avif"_t:
+		return "image/avif";
+	case "bmp"_t:
+		return "image/bmp";
+	case "gif"_t:
+		return "image/gif";
+	case "png"_t:
+		return "image/png";
+	case "svg"_t:
+		return "image/svg+xml";
+	case "webp"_t:
+		return "image/webp";
+	case "ico"_t:
+		return "image/x-icon";
+	case "tif"_t:
+		return "image/tiff";
+	case "tiff"_t:
+		return "image/tiff";
+	case "jpg"_t:
+	case "jpeg"_t:
+		return "image/jpeg";
 
-  case "mp4"_t: return "video/mp4";
-  case "mpeg"_t: return "video/mpeg";
-  case "webm"_t: return "video/webm";
+	case "mp4"_t:
+		return "video/mp4";
+	case "mpeg"_t:
+		return "video/mpeg";
+	case "webm"_t:
+		return "video/webm";
 
-  case "mp3"_t: return "audio/mp3";
-  case "mpga"_t: return "audio/mpeg";
-  case "weba"_t: return "audio/webm";
-  case "wav"_t: return "audio/wave";
+	case "mp3"_t:
+		return "audio/mp3";
+	case "mpga"_t:
+		return "audio/mpeg";
+	case "weba"_t:
+		return "audio/webm";
+	case "wav"_t:
+		return "audio/wave";
 
-  case "otf"_t: return "font/otf";
-  case "ttf"_t: return "font/ttf";
-  case "woff"_t: return "font/woff";
-  case "woff2"_t: return "font/woff2";
+	case "otf"_t:
+		return "font/otf";
+	case "ttf"_t:
+		return "font/ttf";
+	case "woff"_t:
+		return "font/woff";
+	case "woff2"_t:
+		return "font/woff2";
 
-  case "7z"_t: return "application/x-7z-compressed";
-  case "atom"_t: return "application/atom+xml";
-  case "pdf"_t: return "application/pdf";
-  case "json"_t: return "application/json";
-  case "rss"_t: return "application/rss+xml";
-  case "tar"_t: return "application/x-tar";
-  case "xht"_t:
-  case "xhtml"_t: return "application/xhtml+xml";
-  case "xslt"_t: return "application/xslt+xml";
-  case "xml"_t: return "application/xml";
-  case "gz"_t: return "application/gzip";
-  case "zip"_t: return "application/zip";
-  case "wasm"_t: return "application/wasm";
-  }
+	case "7z"_t:
+		return "application/x-7z-compressed";
+	case "atom"_t:
+		return "application/atom+xml";
+	case "pdf"_t:
+		return "application/pdf";
+	case "json"_t:
+		return "application/json";
+	case "rss"_t:
+		return "application/rss+xml";
+	case "tar"_t:
+		return "application/x-tar";
+	case "xht"_t:
+	case "xhtml"_t:
+		return "application/xhtml+xml";
+	case "xslt"_t:
+		return "application/xslt+xml";
+	case "xml"_t:
+		return "application/xml";
+	case "gz"_t:
+		return "application/gzip";
+	case "zip"_t:
+		return "application/zip";
+	case "wasm"_t:
+		return "application/wasm";
+	}
 }
 
 inline bool can_compress_content_type(const std::string &content_type) {
-  using udl::operator ""_t;
+	using udl::operator""_t;
 
-  auto tag = str2tag(content_type);
+	auto tag = str2tag(content_type);
 
-  switch (tag) {
-  case "image/svg+xml"_t:
-  case "application/javascript"_t:
-  case "application/json"_t:
-  case "application/xml"_t:
-  case "application/protobuf"_t:
-  case "application/xhtml+xml"_t: return true;
+	switch (tag) {
+	case "image/svg+xml"_t:
+	case "application/javascript"_t:
+	case "application/json"_t:
+	case "application/xml"_t:
+	case "application/protobuf"_t:
+	case "application/xhtml+xml"_t:
+		return true;
 
-  default:
-    return !content_type.rfind("text/", 0) && tag != "text/event-stream"_t;
-  }
+	default:
+		return !content_type.rfind("text/", 0) && tag != "text/event-stream"_t;
+	}
 }
 
 inline EncodingType encoding_type(const Request &req, const Response &res) {
-  auto ret =
-      detail::can_compress_content_type(res.get_header_value("Content-Type"));
-  if (!ret) { return EncodingType::None; }
+	auto ret = detail::can_compress_content_type(res.get_header_value("Content-Type"));
+	if (!ret) {
+		return EncodingType::None;
+	}
 
-  const auto &s = req.get_header_value("Accept-Encoding");
-  (void)(s);
+	const auto &s = req.get_header_value("Accept-Encoding");
+	(void)(s);
 
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
-  // TODO: 'Accept-Encoding' has br, not br;q=0
-  ret = s.find("br") != std::string::npos;
-  if (ret) { return EncodingType::Brotli; }
+	// TODO: 'Accept-Encoding' has br, not br;q=0
+	ret = s.find("br") != std::string::npos;
+	if (ret) {
+		return EncodingType::Brotli;
+	}
 #endif
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-  // TODO: 'Accept-Encoding' has gzip, not gzip;q=0
-  ret = s.find("gzip") != std::string::npos;
-  if (ret) { return EncodingType::Gzip; }
+	// TODO: 'Accept-Encoding' has gzip, not gzip;q=0
+	ret = s.find("gzip") != std::string::npos;
+	if (ret) {
+		return EncodingType::Gzip;
+	}
 #endif
 
-  return EncodingType::None;
+	return EncodingType::None;
 }
 
-inline bool nocompressor::compress(const char *data, size_t data_length,
-                                   bool /*last*/, Callback callback) {
-  if (!data_length) { return true; }
-  return callback(data, data_length);
+inline bool nocompressor::compress(const char *data, size_t data_length, bool /*last*/, Callback callback) {
+	if (!data_length) {
+		return true;
+	}
+	return callback(data, data_length);
 }
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
 inline gzip_compressor::gzip_compressor() {
-  std::memset(&strm_, 0, sizeof(strm_));
-  strm_.zalloc = Z_NULL;
-  strm_.zfree = Z_NULL;
-  strm_.opaque = Z_NULL;
+	std::memset(&strm_, 0, sizeof(strm_));
+	strm_.zalloc = Z_NULL;
+	strm_.zfree = Z_NULL;
+	strm_.opaque = Z_NULL;
 
-  is_valid_ = deflateInit2(&strm_, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8,
-                           Z_DEFAULT_STRATEGY) == Z_OK;
+	is_valid_ = deflateInit2(&strm_, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY) == Z_OK;
 }
 
-inline gzip_compressor::~gzip_compressor() { deflateEnd(&strm_); }
+inline gzip_compressor::~gzip_compressor() {
+	deflateEnd(&strm_);
+}
 
-inline bool gzip_compressor::compress(const char *data, size_t data_length,
-                                      bool last, Callback callback) {
-  assert(is_valid_);
+inline bool gzip_compressor::compress(const char *data, size_t data_length, bool last, Callback callback) {
+	assert(is_valid_);
 
-  do {
-    constexpr size_t max_avail_in =
-        (std::numeric_limits<decltype(strm_.avail_in)>::max)();
+	do {
+		constexpr size_t max_avail_in = (std::numeric_limits<decltype(strm_.avail_in)>::max)();
 
-    strm_.avail_in = static_cast<decltype(strm_.avail_in)>(
-        (std::min)(data_length, max_avail_in));
-    strm_.next_in = const_cast<Bytef *>(reinterpret_cast<const Bytef *>(data));
+		strm_.avail_in = static_cast<decltype(strm_.avail_in)>((std::min)(data_length, max_avail_in));
+		strm_.next_in = const_cast<Bytef *>(reinterpret_cast<const Bytef *>(data));
 
-    data_length -= strm_.avail_in;
-    data += strm_.avail_in;
+		data_length -= strm_.avail_in;
+		data += strm_.avail_in;
 
-    auto flush = (last && data_length == 0) ? Z_FINISH : Z_NO_FLUSH;
-    auto ret = Z_OK;
+		auto flush = (last && data_length == 0) ? Z_FINISH : Z_NO_FLUSH;
+		auto ret = Z_OK;
 
-    std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff{};
-    do {
-      strm_.avail_out = static_cast<uInt>(buff.size());
-      strm_.next_out = reinterpret_cast<Bytef *>(buff.data());
+		std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff {};
+		do {
+			strm_.avail_out = static_cast<uInt>(buff.size());
+			strm_.next_out = reinterpret_cast<Bytef *>(buff.data());
 
-      ret = deflate(&strm_, flush);
-      if (ret == Z_STREAM_ERROR) { return false; }
+			ret = deflate(&strm_, flush);
+			if (ret == Z_STREAM_ERROR) {
+				return false;
+			}
 
-      if (!callback(buff.data(), buff.size() - strm_.avail_out)) {
-        return false;
-      }
-    } while (strm_.avail_out == 0);
+			if (!callback(buff.data(), buff.size() - strm_.avail_out)) {
+				return false;
+			}
+		} while (strm_.avail_out == 0);
 
-    assert((flush == Z_FINISH && ret == Z_STREAM_END) ||
-           (flush == Z_NO_FLUSH && ret == Z_OK));
-    assert(strm_.avail_in == 0);
-  } while (data_length > 0);
+		assert((flush == Z_FINISH && ret == Z_STREAM_END) || (flush == Z_NO_FLUSH && ret == Z_OK));
+		assert(strm_.avail_in == 0);
+	} while (data_length > 0);
 
-  return true;
+	return true;
 }
 
 inline gzip_decompressor::gzip_decompressor() {
-  std::memset(&strm_, 0, sizeof(strm_));
-  strm_.zalloc = Z_NULL;
-  strm_.zfree = Z_NULL;
-  strm_.opaque = Z_NULL;
+	std::memset(&strm_, 0, sizeof(strm_));
+	strm_.zalloc = Z_NULL;
+	strm_.zfree = Z_NULL;
+	strm_.opaque = Z_NULL;
 
-  // 15 is the value of wbits, which should be at the maximum possible value
-  // to ensure that any gzip stream can be decoded. The offset of 32 specifies
-  // that the stream type should be automatically detected either gzip or
-  // deflate.
-  is_valid_ = inflateInit2(&strm_, 32 + 15) == Z_OK;
+	// 15 is the value of wbits, which should be at the maximum possible value
+	// to ensure that any gzip stream can be decoded. The offset of 32 specifies
+	// that the stream type should be automatically detected either gzip or
+	// deflate.
+	is_valid_ = inflateInit2(&strm_, 32 + 15) == Z_OK;
 }
 
-inline gzip_decompressor::~gzip_decompressor() { inflateEnd(&strm_); }
+inline gzip_decompressor::~gzip_decompressor() {
+	inflateEnd(&strm_);
+}
 
-inline bool gzip_decompressor::is_valid() const { return is_valid_; }
+inline bool gzip_decompressor::is_valid() const {
+	return is_valid_;
+}
 
-inline bool gzip_decompressor::decompress(const char *data, size_t data_length,
-                                          Callback callback) {
-  assert(is_valid_);
+inline bool gzip_decompressor::decompress(const char *data, size_t data_length, Callback callback) {
+	assert(is_valid_);
 
-  auto ret = Z_OK;
+	auto ret = Z_OK;
 
-  do {
-    constexpr size_t max_avail_in =
-        (std::numeric_limits<decltype(strm_.avail_in)>::max)();
+	do {
+		constexpr size_t max_avail_in = (std::numeric_limits<decltype(strm_.avail_in)>::max)();
 
-    strm_.avail_in = static_cast<decltype(strm_.avail_in)>(
-        (std::min)(data_length, max_avail_in));
-    strm_.next_in = const_cast<Bytef *>(reinterpret_cast<const Bytef *>(data));
+		strm_.avail_in = static_cast<decltype(strm_.avail_in)>((std::min)(data_length, max_avail_in));
+		strm_.next_in = const_cast<Bytef *>(reinterpret_cast<const Bytef *>(data));
 
-    data_length -= strm_.avail_in;
-    data += strm_.avail_in;
+		data_length -= strm_.avail_in;
+		data += strm_.avail_in;
 
-    std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff{};
-    while (strm_.avail_in > 0 && ret == Z_OK) {
-      strm_.avail_out = static_cast<uInt>(buff.size());
-      strm_.next_out = reinterpret_cast<Bytef *>(buff.data());
+		std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff {};
+		while (strm_.avail_in > 0 && ret == Z_OK) {
+			strm_.avail_out = static_cast<uInt>(buff.size());
+			strm_.next_out = reinterpret_cast<Bytef *>(buff.data());
 
-      ret = inflate(&strm_, Z_NO_FLUSH);
+			ret = inflate(&strm_, Z_NO_FLUSH);
 
-      assert(ret != Z_STREAM_ERROR);
-      switch (ret) {
-      case Z_NEED_DICT:
-      case Z_DATA_ERROR:
-      case Z_MEM_ERROR: inflateEnd(&strm_); return false;
-      }
+			assert(ret != Z_STREAM_ERROR);
+			switch (ret) {
+			case Z_NEED_DICT:
+			case Z_DATA_ERROR:
+			case Z_MEM_ERROR:
+				inflateEnd(&strm_);
+				return false;
+			}
 
-      if (!callback(buff.data(), buff.size() - strm_.avail_out)) {
-        return false;
-      }
-    }
+			if (!callback(buff.data(), buff.size() - strm_.avail_out)) {
+				return false;
+			}
+		}
 
-    if (ret != Z_OK && ret != Z_STREAM_END) { return false; }
+		if (ret != Z_OK && ret != Z_STREAM_END) {
+			return false;
+		}
 
-  } while (data_length > 0);
+	} while (data_length > 0);
 
-  return true;
+	return true;
 }
 #endif
 
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
 inline brotli_compressor::brotli_compressor() {
-  state_ = BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
+	state_ = BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
 }
 
 inline brotli_compressor::~brotli_compressor() {
-  BrotliEncoderDestroyInstance(state_);
+	BrotliEncoderDestroyInstance(state_);
 }
 
-inline bool brotli_compressor::compress(const char *data, size_t data_length,
-                                        bool last, Callback callback) {
-  std::array<uint8_t, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff{};
+inline bool brotli_compressor::compress(const char *data, size_t data_length, bool last, Callback callback) {
+	std::array<uint8_t, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff {};
 
-  auto operation = last ? BROTLI_OPERATION_FINISH : BROTLI_OPERATION_PROCESS;
-  auto available_in = data_length;
-  auto next_in = reinterpret_cast<const uint8_t *>(data);
+	auto operation = last ? BROTLI_OPERATION_FINISH : BROTLI_OPERATION_PROCESS;
+	auto available_in = data_length;
+	auto next_in = reinterpret_cast<const uint8_t *>(data);
 
-  for (;;) {
-    if (last) {
-      if (BrotliEncoderIsFinished(state_)) { break; }
-    } else {
-      if (!available_in) { break; }
-    }
+	for (;;) {
+		if (last) {
+			if (BrotliEncoderIsFinished(state_)) {
+				break;
+			}
+		} else {
+			if (!available_in) {
+				break;
+			}
+		}
 
-    auto available_out = buff.size();
-    auto next_out = buff.data();
+		auto available_out = buff.size();
+		auto next_out = buff.data();
 
-    if (!BrotliEncoderCompressStream(state_, operation, &available_in, &next_in,
-                                     &available_out, &next_out, nullptr)) {
-      return false;
-    }
+		if (!BrotliEncoderCompressStream(state_, operation, &available_in, &next_in, &available_out, &next_out,
+		                                 nullptr)) {
+			return false;
+		}
 
-    auto output_bytes = buff.size() - available_out;
-    if (output_bytes) {
-      callback(reinterpret_cast<const char *>(buff.data()), output_bytes);
-    }
-  }
+		auto output_bytes = buff.size() - available_out;
+		if (output_bytes) {
+			callback(reinterpret_cast<const char *>(buff.data()), output_bytes);
+		}
+	}
 
-  return true;
+	return true;
 }
 
 inline brotli_decompressor::brotli_decompressor() {
-  decoder_s = BrotliDecoderCreateInstance(0, 0, 0);
-  decoder_r = decoder_s ? BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT
-                        : BROTLI_DECODER_RESULT_ERROR;
+	decoder_s = BrotliDecoderCreateInstance(0, 0, 0);
+	decoder_r = decoder_s ? BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT : BROTLI_DECODER_RESULT_ERROR;
 }
 
 inline brotli_decompressor::~brotli_decompressor() {
-  if (decoder_s) { BrotliDecoderDestroyInstance(decoder_s); }
+	if (decoder_s) {
+		BrotliDecoderDestroyInstance(decoder_s);
+	}
 }
 
-inline bool brotli_decompressor::is_valid() const { return decoder_s; }
+inline bool brotli_decompressor::is_valid() const {
+	return decoder_s;
+}
 
-inline bool brotli_decompressor::decompress(const char *data,
-                                            size_t data_length,
-                                            Callback callback) {
-  if (decoder_r == BROTLI_DECODER_RESULT_SUCCESS ||
-      decoder_r == BROTLI_DECODER_RESULT_ERROR) {
-    return 0;
-  }
+inline bool brotli_decompressor::decompress(const char *data, size_t data_length, Callback callback) {
+	if (decoder_r == BROTLI_DECODER_RESULT_SUCCESS || decoder_r == BROTLI_DECODER_RESULT_ERROR) {
+		return 0;
+	}
 
-  auto next_in = reinterpret_cast<const uint8_t *>(data);
-  size_t avail_in = data_length;
-  size_t total_out;
+	auto next_in = reinterpret_cast<const uint8_t *>(data);
+	size_t avail_in = data_length;
+	size_t total_out;
 
-  decoder_r = BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT;
+	decoder_r = BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT;
 
-  std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff{};
-  while (decoder_r == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
-    char *next_out = buff.data();
-    size_t avail_out = buff.size();
+	std::array<char, CPPHTTPLIB_COMPRESSION_BUFSIZ> buff {};
+	while (decoder_r == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
+		char *next_out = buff.data();
+		size_t avail_out = buff.size();
 
-    decoder_r = BrotliDecoderDecompressStream(
-        decoder_s, &avail_in, &next_in, &avail_out,
-        reinterpret_cast<uint8_t **>(&next_out), &total_out);
+		decoder_r = BrotliDecoderDecompressStream(decoder_s, &avail_in, &next_in, &avail_out,
+		                                          reinterpret_cast<uint8_t **>(&next_out), &total_out);
 
-    if (decoder_r == BROTLI_DECODER_RESULT_ERROR) { return false; }
+		if (decoder_r == BROTLI_DECODER_RESULT_ERROR) {
+			return false;
+		}
 
-    if (!callback(buff.data(), buff.size() - avail_out)) { return false; }
-  }
+		if (!callback(buff.data(), buff.size() - avail_out)) {
+			return false;
+		}
+	}
 
-  return decoder_r == BROTLI_DECODER_RESULT_SUCCESS ||
-         decoder_r == BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT;
+	return decoder_r == BROTLI_DECODER_RESULT_SUCCESS || decoder_r == BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT;
 }
 #endif
 
 inline bool has_header(const Headers &headers, const std::string &key) {
-  return headers.find(key) != headers.end();
+	return headers.find(key) != headers.end();
 }
 
-inline const char *get_header_value(const Headers &headers,
-                                    const std::string &key, size_t id,
-                                    const char *def) {
-  auto rng = headers.equal_range(key);
-  auto it = rng.first;
-  std::advance(it, static_cast<ssize_t>(id));
-  if (it != rng.second) { return it->second.c_str(); }
-  return def;
+inline const char *get_header_value(const Headers &headers, const std::string &key, size_t id, const char *def) {
+	auto rng = headers.equal_range(key);
+	auto it = rng.first;
+	std::advance(it, static_cast<ssize_t>(id));
+	if (it != rng.second) {
+		return it->second.c_str();
+	}
+	return def;
 }
 
 inline bool compare_case_ignore(const std::string &a, const std::string &b) {
-  if (a.size() != b.size()) { return false; }
-  for (size_t i = 0; i < b.size(); i++) {
-    if (::tolower(a[i]) != ::tolower(b[i])) { return false; }
-  }
-  return true;
+	if (a.size() != b.size()) {
+		return false;
+	}
+	for (size_t i = 0; i < b.size(); i++) {
+		if (::tolower(a[i]) != ::tolower(b[i])) {
+			return false;
+		}
+	}
+	return true;
 }
 
 template <typename T>
 inline bool parse_header(const char *beg, const char *end, T fn) {
-  // Skip trailing spaces and tabs.
-  while (beg < end && is_space_or_tab(end[-1])) {
-    end--;
-  }
+	// Skip trailing spaces and tabs.
+	while (beg < end && is_space_or_tab(end[-1])) {
+		end--;
+	}
 
-  auto p = beg;
-  while (p < end && *p != ':') {
-    p++;
-  }
+	auto p = beg;
+	while (p < end && *p != ':') {
+		p++;
+	}
 
-  if (p == end) { return false; }
+	if (p == end) {
+		return false;
+	}
 
-  auto key_end = p;
+	auto key_end = p;
 
-  if (*p++ != ':') { return false; }
+	if (*p++ != ':') {
+		return false;
+	}
 
-  while (p < end && is_space_or_tab(*p)) {
-    p++;
-  }
+	while (p < end && is_space_or_tab(*p)) {
+		p++;
+	}
 
-  if (p < end) {
-    auto key_len = key_end - beg;
-    if (!key_len) { return false; }
+	if (p < end) {
+		auto key_len = key_end - beg;
+		if (!key_len) {
+			return false;
+		}
 
-    auto key = std::string(beg, key_end);
-    auto val = compare_case_ignore(key, "Location") || compare_case_ignore(key, "Link")
-                   ? std::string(p, end)
-                   : decode_url(std::string(p, end), false);
-    fn(std::move(key), std::move(val));
-    return true;
-  }
+		auto key = std::string(beg, key_end);
+		auto val = compare_case_ignore(key, "Location") || compare_case_ignore(key, "Link")
+		               ? std::string(p, end)
+		               : decode_url(std::string(p, end), false);
+		fn(std::move(key), std::move(val));
+		return true;
+	}
 
-  return false;
+	return false;
 }
 
 inline bool read_headers(Stream &strm, Headers &headers) {
-  const auto bufsiz = 2048;
-  char buf[bufsiz];
-  stream_line_reader line_reader(strm, buf, bufsiz);
+	const auto bufsiz = 2048;
+	char buf[bufsiz];
+	stream_line_reader line_reader(strm, buf, bufsiz);
 
-  for (;;) {
-    if (!line_reader.getline()) { return false; }
+	for (;;) {
+		if (!line_reader.getline()) {
+			return false;
+		}
 
-    // Check if the line ends with CRLF.
-    auto line_terminator_len = 2;
-    if (line_reader.end_with_crlf()) {
-      // Blank line indicates end of headers.
-      if (line_reader.size() == 2) { break; }
+		// Check if the line ends with CRLF.
+		auto line_terminator_len = 2;
+		if (line_reader.end_with_crlf()) {
+			// Blank line indicates end of headers.
+			if (line_reader.size() == 2) {
+				break;
+			}
 #ifdef CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR
-    } else {
-      // Blank line indicates end of headers.
-      if (line_reader.size() == 1) { break; }
-      line_terminator_len = 1;
-    }
+		} else {
+			// Blank line indicates end of headers.
+			if (line_reader.size() == 1) {
+				break;
+			}
+			line_terminator_len = 1;
+		}
 #else
-    } else {
-      continue; // Skip invalid line.
-    }
+		} else {
+			continue; // Skip invalid line.
+		}
 #endif
 
-    if (line_reader.size() > CPPHTTPLIB_HEADER_MAX_LENGTH) { return false; }
+		if (line_reader.size() > CPPHTTPLIB_HEADER_MAX_LENGTH) {
+			return false;
+		}
 
-    // Exclude line terminator
-    auto end = line_reader.ptr() + line_reader.size() - line_terminator_len;
+		// Exclude line terminator
+		auto end = line_reader.ptr() + line_reader.size() - line_terminator_len;
 
-    parse_header(line_reader.ptr(), end,
-                 [&](std::string &&key, std::string &&val) {
-                   headers.emplace(std::move(key), std::move(val));
-                 });
-  }
+		parse_header(line_reader.ptr(), end,
+		             [&](std::string &&key, std::string &&val) { headers.emplace(std::move(key), std::move(val)); });
+	}
 
-  return true;
+	return true;
 }
 
-inline bool read_content_with_length(Stream &strm, uint64_t len,
-                                     Progress progress,
-                                     ContentReceiverWithProgress out) {
-  char buf[CPPHTTPLIB_RECV_BUFSIZ];
+inline bool read_content_with_length(Stream &strm, uint64_t len, Progress progress, ContentReceiverWithProgress out) {
+	char buf[CPPHTTPLIB_RECV_BUFSIZ];
 
-  uint64_t r = 0;
-  while (r < len) {
-    auto read_len = static_cast<size_t>(len - r);
-    auto n = strm.read(buf, (std::min)(read_len, CPPHTTPLIB_RECV_BUFSIZ));
-    if (n <= 0) { return false; }
+	uint64_t r = 0;
+	while (r < len) {
+		auto read_len = static_cast<size_t>(len - r);
+		auto n = strm.read(buf, (std::min)(read_len, CPPHTTPLIB_RECV_BUFSIZ));
+		if (n <= 0) {
+			return false;
+		}
 
-    if (!out(buf, static_cast<size_t>(n), r, len)) { return false; }
-    r += static_cast<uint64_t>(n);
+		if (!out(buf, static_cast<size_t>(n), r, len)) {
+			return false;
+		}
+		r += static_cast<uint64_t>(n);
 
-    if (progress) {
-      if (!progress(r, len)) { return false; }
-    }
-  }
+		if (progress) {
+			if (!progress(r, len)) {
+				return false;
+			}
+		}
+	}
 
-  return true;
+	return true;
 }
 
 inline void skip_content_with_length(Stream &strm, uint64_t len) {
-  char buf[CPPHTTPLIB_RECV_BUFSIZ];
-  uint64_t r = 0;
-  while (r < len) {
-    auto read_len = static_cast<size_t>(len - r);
-    auto n = strm.read(buf, (std::min)(read_len, CPPHTTPLIB_RECV_BUFSIZ));
-    if (n <= 0) { return; }
-    r += static_cast<uint64_t>(n);
-  }
+	char buf[CPPHTTPLIB_RECV_BUFSIZ];
+	uint64_t r = 0;
+	while (r < len) {
+		auto read_len = static_cast<size_t>(len - r);
+		auto n = strm.read(buf, (std::min)(read_len, CPPHTTPLIB_RECV_BUFSIZ));
+		if (n <= 0) {
+			return;
+		}
+		r += static_cast<uint64_t>(n);
+	}
 }
 
-inline bool read_content_without_length(Stream &strm,
-                                        ContentReceiverWithProgress out) {
-  char buf[CPPHTTPLIB_RECV_BUFSIZ];
-  uint64_t r = 0;
-  for (;;) {
-    auto n = strm.read(buf, CPPHTTPLIB_RECV_BUFSIZ);
-    if (n <= 0) { return true; }
+inline bool read_content_without_length(Stream &strm, ContentReceiverWithProgress out) {
+	char buf[CPPHTTPLIB_RECV_BUFSIZ];
+	uint64_t r = 0;
+	for (;;) {
+		auto n = strm.read(buf, CPPHTTPLIB_RECV_BUFSIZ);
+		if (n <= 0) {
+			return true;
+		}
 
-    if (!out(buf, static_cast<size_t>(n), r, 0)) { return false; }
-    r += static_cast<uint64_t>(n);
-  }
+		if (!out(buf, static_cast<size_t>(n), r, 0)) {
+			return false;
+		}
+		r += static_cast<uint64_t>(n);
+	}
 
-  return true;
+	return true;
 }
 
 template <typename T>
-inline bool read_content_chunked(Stream &strm, T &x,
-                                 ContentReceiverWithProgress out) {
-  const auto bufsiz = 16;
-  char buf[bufsiz];
+inline bool read_content_chunked(Stream &strm, T &x, ContentReceiverWithProgress out) {
+	const auto bufsiz = 16;
+	char buf[bufsiz];
 
-  stream_line_reader line_reader(strm, buf, bufsiz);
+	stream_line_reader line_reader(strm, buf, bufsiz);
 
-  if (!line_reader.getline()) { return false; }
+	if (!line_reader.getline()) {
+		return false;
+	}
 
-  unsigned long chunk_len;
-  while (true) {
-    char *end_ptr;
+	unsigned long chunk_len;
+	while (true) {
+		char *end_ptr;
 
-    chunk_len = std::strtoul(line_reader.ptr(), &end_ptr, 16);
+		chunk_len = std::strtoul(line_reader.ptr(), &end_ptr, 16);
 
-    if (end_ptr == line_reader.ptr()) { return false; }
-    if (chunk_len == ULONG_MAX) { return false; }
+		if (end_ptr == line_reader.ptr()) {
+			return false;
+		}
+		if (chunk_len == ULONG_MAX) {
+			return false;
+		}
 
-    if (chunk_len == 0) { break; }
+		if (chunk_len == 0) {
+			break;
+		}
 
-    if (!read_content_with_length(strm, chunk_len, nullptr, out)) {
-      return false;
-    }
+		if (!read_content_with_length(strm, chunk_len, nullptr, out)) {
+			return false;
+		}
 
-    if (!line_reader.getline()) { return false; }
+		if (!line_reader.getline()) {
+			return false;
+		}
 
-    if (strcmp(line_reader.ptr(), "\r\n") != 0) { return false; }
+		if (strcmp(line_reader.ptr(), "\r\n") != 0) {
+			return false;
+		}
 
-    if (!line_reader.getline()) { return false; }
-  }
+		if (!line_reader.getline()) {
+			return false;
+		}
+	}
 
-  assert(chunk_len == 0);
+	assert(chunk_len == 0);
 
-  // Trailer
-  if (!line_reader.getline()) { return false; }
+	// Trailer
+	if (!line_reader.getline()) {
+		return false;
+	}
 
-  while (strcmp(line_reader.ptr(), "\r\n") != 0) {
-    if (line_reader.size() > CPPHTTPLIB_HEADER_MAX_LENGTH) { return false; }
+	while (strcmp(line_reader.ptr(), "\r\n") != 0) {
+		if (line_reader.size() > CPPHTTPLIB_HEADER_MAX_LENGTH) {
+			return false;
+		}
 
-    // Exclude line terminator
-    constexpr auto line_terminator_len = 2;
-    auto end = line_reader.ptr() + line_reader.size() - line_terminator_len;
+		// Exclude line terminator
+		constexpr auto line_terminator_len = 2;
+		auto end = line_reader.ptr() + line_reader.size() - line_terminator_len;
 
-    parse_header(line_reader.ptr(), end,
-                 [&](std::string &&key, std::string &&val) {
-                   x.headers.emplace(std::move(key), std::move(val));
-                 });
+		parse_header(line_reader.ptr(), end,
+		             [&](std::string &&key, std::string &&val) { x.headers.emplace(std::move(key), std::move(val)); });
 
-    if (!line_reader.getline()) { return false; }
-  }
+		if (!line_reader.getline()) {
+			return false;
+		}
+	}
 
-  return true;
+	return true;
 }
 
 inline bool is_chunked_transfer_encoding(const Headers &headers) {
-  return !strcasecmp(get_header_value(headers, "Transfer-Encoding", 0, ""),
-                     "chunked");
+	return !strcasecmp(get_header_value(headers, "Transfer-Encoding", 0, ""), "chunked");
 }
 
 template <typename T, typename U>
-bool prepare_content_receiver(T &x, int &status,
-                              ContentReceiverWithProgress receiver,
-                              bool decompress, U callback) {
-  if (decompress) {
-    std::string encoding = x.get_header_value("Content-Encoding");
-    duckdb::unique_ptr<decompressor> decompressor;
+bool prepare_content_receiver(T &x, int &status, ContentReceiverWithProgress receiver, bool decompress, U callback) {
+	if (decompress) {
+		std::string encoding = x.get_header_value("Content-Encoding");
+		duckdb::unique_ptr<decompressor> decompressor;
 
-    if (encoding == "gzip" || encoding == "deflate") {
+		if (encoding == "gzip" || encoding == "deflate") {
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-      decompressor = detail::make_unique<gzip_decompressor>();
+			decompressor = detail::make_unique<gzip_decompressor>();
 #else
-      status = StatusCode::UnsupportedMediaType_415;
-      return false;
+			status = StatusCode::UnsupportedMediaType_415;
+			return false;
 #endif
-    } else if (encoding.find("br") != std::string::npos) {
+		} else if (encoding.find("br") != std::string::npos) {
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
-      decompressor = detail::make_unique<brotli_decompressor>();
+			decompressor = detail::make_unique<brotli_decompressor>();
 #else
-      status = StatusCode::UnsupportedMediaType_415;
-      return false;
+			status = StatusCode::UnsupportedMediaType_415;
+			return false;
 #endif
-    }
+		}
 
-    if (decompressor) {
-      if (decompressor->is_valid()) {
-        ContentReceiverWithProgress out = [&](const char *buf, size_t n,
-                                              uint64_t off, uint64_t len) {
-          return decompressor->decompress(buf, n,
-                                          [&](const char *buf2, size_t n2) {
-                                            return receiver(buf2, n2, off, len);
-                                          });
-        };
-        return callback(std::move(out));
-      } else {
-        status = StatusCode::InternalServerError_500;
-        return false;
-      }
-    }
-  }
+		if (decompressor) {
+			if (decompressor->is_valid()) {
+				ContentReceiverWithProgress out = [&](const char *buf, size_t n, uint64_t off, uint64_t len) {
+					return decompressor->decompress(
+					    buf, n, [&](const char *buf2, size_t n2) { return receiver(buf2, n2, off, len); });
+				};
+				return callback(std::move(out));
+			} else {
+				status = StatusCode::InternalServerError_500;
+				return false;
+			}
+		}
+	}
 
-  ContentReceiverWithProgress out = [&](const char *buf, size_t n, uint64_t off,
-                                        uint64_t len) {
-    return receiver(buf, n, off, len);
-  };
-  return callback(std::move(out));
+	ContentReceiverWithProgress out = [&](const char *buf, size_t n, uint64_t off, uint64_t len) {
+		return receiver(buf, n, off, len);
+	};
+	return callback(std::move(out));
 }
 
 template <typename T>
-bool read_content(Stream &strm, T &x, size_t payload_max_length, int &status,
-                  Progress progress, ContentReceiverWithProgress receiver,
-                  bool decompress) {
-  return prepare_content_receiver(
-      x, status, std::move(receiver), decompress,
-      [&](const ContentReceiverWithProgress &out) {
-        auto ret = true;
-        auto exceed_payload_max_length = false;
+bool read_content(Stream &strm, T &x, size_t payload_max_length, int &status, Progress progress,
+                  ContentReceiverWithProgress receiver, bool decompress) {
+	return prepare_content_receiver(
+	    x, status, std::move(receiver), decompress, [&](const ContentReceiverWithProgress &out) {
+		    auto ret = true;
+		    auto exceed_payload_max_length = false;
 
-        if (is_chunked_transfer_encoding(x.headers)) {
-          ret = read_content_chunked(strm, x, out);
-        } else if (!has_header(x.headers, "Content-Length")) {
-          ret = read_content_without_length(strm, out);
-        } else {
-          auto len = get_header_value_u64(x.headers, "Content-Length", 0, 0);
-          if (len > payload_max_length) {
-            exceed_payload_max_length = true;
-            skip_content_with_length(strm, len);
-            ret = false;
-          } else if (len > 0) {
-            ret = read_content_with_length(strm, len, std::move(progress), out);
-          }
-        }
+		    if (is_chunked_transfer_encoding(x.headers)) {
+			    ret = read_content_chunked(strm, x, out);
+		    } else if (!has_header(x.headers, "Content-Length")) {
+			    ret = read_content_without_length(strm, out);
+		    } else {
+			    auto len = get_header_value_u64(x.headers, "Content-Length", 0, 0);
+			    if (len > payload_max_length) {
+				    exceed_payload_max_length = true;
+				    skip_content_with_length(strm, len);
+				    ret = false;
+			    } else if (len > 0) {
+				    ret = read_content_with_length(strm, len, std::move(progress), out);
+			    }
+		    }
 
-        if (!ret) {
-          status = exceed_payload_max_length ? StatusCode::PayloadTooLarge_413
-                                             : StatusCode::BadRequest_400;
-        }
-        return ret;
-      });
+		    if (!ret) {
+			    status = exceed_payload_max_length ? StatusCode::PayloadTooLarge_413 : StatusCode::BadRequest_400;
+		    }
+		    return ret;
+	    });
 } // namespace detail
 
 inline ssize_t write_headers(Stream &strm, const Headers &headers) {
-  ssize_t write_len = 0;
-  for (const auto &x : headers) {
-    auto len =
-        strm.write_format("%s: %s\r\n", x.first.c_str(), x.second.c_str());
-    if (len < 0) { return len; }
-    write_len += len;
-  }
-  auto len = strm.write("\r\n");
-  if (len < 0) { return len; }
-  write_len += len;
-  return write_len;
+	ssize_t write_len = 0;
+	for (const auto &x : headers) {
+		auto len = strm.write_format("%s: %s\r\n", x.first.c_str(), x.second.c_str());
+		if (len < 0) {
+			return len;
+		}
+		write_len += len;
+	}
+	auto len = strm.write("\r\n");
+	if (len < 0) {
+		return len;
+	}
+	write_len += len;
+	return write_len;
 }
 
 inline bool write_data(Stream &strm, const char *d, size_t l) {
-  size_t offset = 0;
-  while (offset < l) {
-    auto length = strm.write(d + offset, l - offset);
-    if (length < 0) { return false; }
-    offset += static_cast<size_t>(length);
-  }
-  return true;
+	size_t offset = 0;
+	while (offset < l) {
+		auto length = strm.write(d + offset, l - offset);
+		if (length < 0) {
+			return false;
+		}
+		offset += static_cast<size_t>(length);
+	}
+	return true;
 }
 
 template <typename T>
-inline bool write_content(Stream &strm, const ContentProvider &content_provider,
-                          size_t offset, size_t length, T is_shutting_down,
-                          Error &error) {
-  size_t end_offset = offset + length;
-  auto ok = true;
-  DataSink data_sink;
+inline bool write_content(Stream &strm, const ContentProvider &content_provider, size_t offset, size_t length,
+                          T is_shutting_down, Error &error) {
+	size_t end_offset = offset + length;
+	auto ok = true;
+	DataSink data_sink;
 
-  data_sink.write = [&](const char *d, size_t l) -> bool {
-    if (ok) {
-      if (strm.is_writable() && write_data(strm, d, l)) {
-        offset += l;
-      } else {
-        ok = false;
-      }
-    }
-    return ok;
-  };
+	data_sink.write = [&](const char *d, size_t l) -> bool {
+		if (ok) {
+			if (strm.is_writable() && write_data(strm, d, l)) {
+				offset += l;
+			} else {
+				ok = false;
+			}
+		}
+		return ok;
+	};
 
-  data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
+	data_sink.is_writable = [&]() -> bool {
+		return strm.is_writable();
+	};
 
-  while (offset < end_offset && !is_shutting_down()) {
-    if (!strm.is_writable()) {
-      error = Error::Write;
-      return false;
-    } else if (!content_provider(offset, end_offset - offset, data_sink)) {
-      error = Error::Canceled;
-      return false;
-    } else if (!ok) {
-      error = Error::Write;
-      return false;
-    }
-  }
+	while (offset < end_offset && !is_shutting_down()) {
+		if (!strm.is_writable()) {
+			error = Error::Write;
+			return false;
+		} else if (!content_provider(offset, end_offset - offset, data_sink)) {
+			error = Error::Canceled;
+			return false;
+		} else if (!ok) {
+			error = Error::Write;
+			return false;
+		}
+	}
 
-  error = Error::Success;
-  return true;
+	error = Error::Success;
+	return true;
 }
 
 template <typename T>
-inline bool write_content(Stream &strm, const ContentProvider &content_provider,
-                          size_t offset, size_t length,
+inline bool write_content(Stream &strm, const ContentProvider &content_provider, size_t offset, size_t length,
                           const T &is_shutting_down) {
-  auto error = Error::Success;
-  return write_content(strm, content_provider, offset, length, is_shutting_down,
-                       error);
+	auto error = Error::Success;
+	return write_content(strm, content_provider, offset, length, is_shutting_down, error);
 }
 
 template <typename T>
-inline bool
-write_content_without_length(Stream &strm,
-                             const ContentProvider &content_provider,
-                             const T &is_shutting_down) {
-  size_t offset = 0;
-  auto data_available = true;
-  auto ok = true;
-  DataSink data_sink;
+inline bool write_content_without_length(Stream &strm, const ContentProvider &content_provider,
+                                         const T &is_shutting_down) {
+	size_t offset = 0;
+	auto data_available = true;
+	auto ok = true;
+	DataSink data_sink;
 
-  data_sink.write = [&](const char *d, size_t l) -> bool {
-    if (ok) {
-      offset += l;
-      if (!strm.is_writable() || !write_data(strm, d, l)) { ok = false; }
-    }
-    return ok;
-  };
+	data_sink.write = [&](const char *d, size_t l) -> bool {
+		if (ok) {
+			offset += l;
+			if (!strm.is_writable() || !write_data(strm, d, l)) {
+				ok = false;
+			}
+		}
+		return ok;
+	};
 
-  data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
+	data_sink.is_writable = [&]() -> bool {
+		return strm.is_writable();
+	};
 
-  data_sink.done = [&](void) { data_available = false; };
+	data_sink.done = [&](void) {
+		data_available = false;
+	};
 
-  while (data_available && !is_shutting_down()) {
-    if (!strm.is_writable()) {
-      return false;
-    } else if (!content_provider(offset, 0, data_sink)) {
-      return false;
-    } else if (!ok) {
-      return false;
-    }
-  }
-  return true;
+	while (data_available && !is_shutting_down()) {
+		if (!strm.is_writable()) {
+			return false;
+		} else if (!content_provider(offset, 0, data_sink)) {
+			return false;
+		} else if (!ok) {
+			return false;
+		}
+	}
+	return true;
 }
 
 template <typename T, typename U>
-inline bool
-write_content_chunked(Stream &strm, const ContentProvider &content_provider,
-                      const T &is_shutting_down, U &compressor, Error &error) {
-  size_t offset = 0;
-  auto data_available = true;
-  auto ok = true;
-  DataSink data_sink;
+inline bool write_content_chunked(Stream &strm, const ContentProvider &content_provider, const T &is_shutting_down,
+                                  U &compressor, Error &error) {
+	size_t offset = 0;
+	auto data_available = true;
+	auto ok = true;
+	DataSink data_sink;
 
-  data_sink.write = [&](const char *d, size_t l) -> bool {
-    if (ok) {
-      data_available = l > 0;
-      offset += l;
+	data_sink.write = [&](const char *d, size_t l) -> bool {
+		if (ok) {
+			data_available = l > 0;
+			offset += l;
 
-      std::string payload;
-      if (compressor.compress(d, l, false,
-                              [&](const char *data, size_t data_len) {
-                                payload.append(data, data_len);
-                                return true;
-                              })) {
-        if (!payload.empty()) {
-          // Emit chunked response header and footer for each chunk
-          auto chunk =
-              from_i_to_hex(payload.size()) + "\r\n" + payload + "\r\n";
-          if (!strm.is_writable() ||
-              !write_data(strm, chunk.data(), chunk.size())) {
-            ok = false;
-          }
-        }
-      } else {
-        ok = false;
-      }
-    }
-    return ok;
-  };
+			std::string payload;
+			if (compressor.compress(d, l, false, [&](const char *data, size_t data_len) {
+				    payload.append(data, data_len);
+				    return true;
+			    })) {
+				if (!payload.empty()) {
+					// Emit chunked response header and footer for each chunk
+					auto chunk = from_i_to_hex(payload.size()) + "\r\n" + payload + "\r\n";
+					if (!strm.is_writable() || !write_data(strm, chunk.data(), chunk.size())) {
+						ok = false;
+					}
+				}
+			} else {
+				ok = false;
+			}
+		}
+		return ok;
+	};
 
-  data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
+	data_sink.is_writable = [&]() -> bool {
+		return strm.is_writable();
+	};
 
-  auto done_with_trailer = [&](const Headers *trailer) {
-    if (!ok) { return; }
+	auto done_with_trailer = [&](const Headers *trailer) {
+		if (!ok) {
+			return;
+		}
 
-    data_available = false;
+		data_available = false;
 
-    std::string payload;
-    if (!compressor.compress(nullptr, 0, true,
-                             [&](const char *data, size_t data_len) {
-                               payload.append(data, data_len);
-                               return true;
-                             })) {
-      ok = false;
-      return;
-    }
+		std::string payload;
+		if (!compressor.compress(nullptr, 0, true, [&](const char *data, size_t data_len) {
+			    payload.append(data, data_len);
+			    return true;
+		    })) {
+			ok = false;
+			return;
+		}
 
-    if (!payload.empty()) {
-      // Emit chunked response header and footer for each chunk
-      auto chunk = from_i_to_hex(payload.size()) + "\r\n" + payload + "\r\n";
-      if (!strm.is_writable() ||
-          !write_data(strm, chunk.data(), chunk.size())) {
-        ok = false;
-        return;
-      }
-    }
+		if (!payload.empty()) {
+			// Emit chunked response header and footer for each chunk
+			auto chunk = from_i_to_hex(payload.size()) + "\r\n" + payload + "\r\n";
+			if (!strm.is_writable() || !write_data(strm, chunk.data(), chunk.size())) {
+				ok = false;
+				return;
+			}
+		}
 
-    const std::string done_marker("0\r\n");
-    if (!write_data(strm, done_marker.data(), done_marker.size())) {
-      ok = false;
-    }
+		const std::string done_marker("0\r\n");
+		if (!write_data(strm, done_marker.data(), done_marker.size())) {
+			ok = false;
+		}
 
-    // Trailer
-    if (trailer) {
-      for (const auto &kv : *trailer) {
-        std::string field_line = kv.first + ": " + kv.second + "\r\n";
-        if (!write_data(strm, field_line.data(), field_line.size())) {
-          ok = false;
-        }
-      }
-    }
+		// Trailer
+		if (trailer) {
+			for (const auto &kv : *trailer) {
+				std::string field_line = kv.first + ": " + kv.second + "\r\n";
+				if (!write_data(strm, field_line.data(), field_line.size())) {
+					ok = false;
+				}
+			}
+		}
 
-    const std::string crlf("\r\n");
-    if (!write_data(strm, crlf.data(), crlf.size())) { ok = false; }
-  };
+		const std::string crlf("\r\n");
+		if (!write_data(strm, crlf.data(), crlf.size())) {
+			ok = false;
+		}
+	};
 
-  data_sink.done = [&](void) { done_with_trailer(nullptr); };
+	data_sink.done = [&](void) {
+		done_with_trailer(nullptr);
+	};
 
-  data_sink.done_with_trailer = [&](const Headers &trailer) {
-    done_with_trailer(&trailer);
-  };
+	data_sink.done_with_trailer = [&](const Headers &trailer) {
+		done_with_trailer(&trailer);
+	};
 
-  while (data_available && !is_shutting_down()) {
-    if (!strm.is_writable()) {
-      error = Error::Write;
-      return false;
-    } else if (!content_provider(offset, 0, data_sink)) {
-      error = Error::Canceled;
-      return false;
-    } else if (!ok) {
-      error = Error::Write;
-      return false;
-    }
-  }
+	while (data_available && !is_shutting_down()) {
+		if (!strm.is_writable()) {
+			error = Error::Write;
+			return false;
+		} else if (!content_provider(offset, 0, data_sink)) {
+			error = Error::Canceled;
+			return false;
+		} else if (!ok) {
+			error = Error::Write;
+			return false;
+		}
+	}
 
-  error = Error::Success;
-  return true;
+	error = Error::Success;
+	return true;
 }
 
 template <typename T, typename U>
-inline bool write_content_chunked(Stream &strm,
-                                  const ContentProvider &content_provider,
-                                  const T &is_shutting_down, U &compressor) {
-  auto error = Error::Success;
-  return write_content_chunked(strm, content_provider, is_shutting_down,
-                               compressor, error);
+inline bool write_content_chunked(Stream &strm, const ContentProvider &content_provider, const T &is_shutting_down,
+                                  U &compressor) {
+	auto error = Error::Success;
+	return write_content_chunked(strm, content_provider, is_shutting_down, compressor, error);
 }
 
 template <typename T>
-inline bool redirect(T &cli, Request &req, Response &res,
-                     const std::string &path, const std::string &location,
+inline bool redirect(T &cli, Request &req, Response &res, const std::string &path, const std::string &location,
                      Error &error) {
-  Request new_req = req;
-  new_req.path = path;
-  new_req.redirect_count_ -= 1;
+	Request new_req = req;
+	new_req.path = path;
+	new_req.redirect_count_ -= 1;
 
-  if (res.status == StatusCode::SeeOther_303 &&
-      (req.method != "GET" && req.method != "HEAD")) {
-    new_req.method = "GET";
-    new_req.body.clear();
-    new_req.headers.clear();
-  }
+	if (res.status == StatusCode::SeeOther_303 && (req.method != "GET" && req.method != "HEAD")) {
+		new_req.method = "GET";
+		new_req.body.clear();
+		new_req.headers.clear();
+	}
 
-  Response new_res;
+	Response new_res;
 
-  auto ret = cli.send(new_req, new_res, error);
-  if (ret) {
-    req = new_req;
-    res = new_res;
+	auto ret = cli.send(new_req, new_res, error);
+	if (ret) {
+		req = new_req;
+		res = new_res;
 
-    if (res.location.empty()) { res.location = location; }
-  }
-  return ret;
+		if (res.location.empty()) {
+			res.location = location;
+		}
+	}
+	return ret;
 }
 
 inline std::string params_to_query_str(const Params &params) {
-  std::string query;
+	std::string query;
 
-  for (auto it = params.begin(); it != params.end(); ++it) {
-    if (it != params.begin()) { query += "&"; }
-    query += it->first;
-    query += "=";
-    query += encode_query_param(it->second);
-  }
-  return query;
+	for (auto it = params.begin(); it != params.end(); ++it) {
+		if (it != params.begin()) {
+			query += "&";
+		}
+		query += it->first;
+		query += "=";
+		query += encode_query_param(it->second);
+	}
+	return query;
 }
 
 inline void parse_query_text(const std::string &s, Params &params) {
-  std::set<std::string> cache;
-  split(s.data(), s.data() + s.size(), '&', [&](const char *b, const char *e) {
-    std::string kv(b, e);
-    if (cache.find(kv) != cache.end()) { return; }
-    cache.insert(kv);
+	std::set<std::string> cache;
+	split(s.data(), s.data() + s.size(), '&', [&](const char *b, const char *e) {
+		std::string kv(b, e);
+		if (cache.find(kv) != cache.end()) {
+			return;
+		}
+		cache.insert(kv);
 
-    std::string key;
-    std::string val;
-    split(b, e, '=', [&](const char *b2, const char *e2) {
-      if (key.empty()) {
-        key.assign(b2, e2);
-      } else {
-        val.assign(b2, e2);
-      }
-    });
+		std::string key;
+		std::string val;
+		split(b, e, '=', [&](const char *b2, const char *e2) {
+			if (key.empty()) {
+				key.assign(b2, e2);
+			} else {
+				val.assign(b2, e2);
+			}
+		});
 
-    if (!key.empty()) {
-      params.emplace(decode_url(key, true), decode_url(val, true));
-    }
-  });
+		if (!key.empty()) {
+			params.emplace(decode_url(key, true), decode_url(val, true));
+		}
+	});
 }
 
-inline bool parse_multipart_boundary(const std::string &content_type,
-                                     std::string &boundary) {
-  auto boundary_keyword = "boundary=";
-  auto pos = content_type.find(boundary_keyword);
-  if (pos == std::string::npos) { return false; }
-  auto end = content_type.find(';', pos);
-  auto beg = pos + strlen(boundary_keyword);
-  boundary = trim_double_quotes_copy(content_type.substr(beg, end - beg));
-  return !boundary.empty();
+inline bool parse_multipart_boundary(const std::string &content_type, std::string &boundary) {
+	auto boundary_keyword = "boundary=";
+	auto pos = content_type.find(boundary_keyword);
+	if (pos == std::string::npos) {
+		return false;
+	}
+	auto end = content_type.find(';', pos);
+	auto beg = pos + strlen(boundary_keyword);
+	boundary = trim_double_quotes_copy(content_type.substr(beg, end - beg));
+	return !boundary.empty();
 }
 
 inline void parse_disposition_params(const std::string &s, Params &params) {
-  std::set<std::string> cache;
-  split(s.data(), s.data() + s.size(), ';', [&](const char *b, const char *e) {
-    std::string kv(b, e);
-    if (cache.find(kv) != cache.end()) { return; }
-    cache.insert(kv);
+	std::set<std::string> cache;
+	split(s.data(), s.data() + s.size(), ';', [&](const char *b, const char *e) {
+		std::string kv(b, e);
+		if (cache.find(kv) != cache.end()) {
+			return;
+		}
+		cache.insert(kv);
 
-    std::string key;
-    std::string val;
-    split(b, e, '=', [&](const char *b2, const char *e2) {
-      if (key.empty()) {
-        key.assign(b2, e2);
-      } else {
-        val.assign(b2, e2);
-      }
-    });
+		std::string key;
+		std::string val;
+		split(b, e, '=', [&](const char *b2, const char *e2) {
+			if (key.empty()) {
+				key.assign(b2, e2);
+			} else {
+				val.assign(b2, e2);
+			}
+		});
 
-    if (!key.empty()) {
-      params.emplace(trim_double_quotes_copy((key)),
-                     trim_double_quotes_copy((val)));
-    }
-  });
+		if (!key.empty()) {
+			params.emplace(trim_double_quotes_copy((key)), trim_double_quotes_copy((val)));
+		}
+	});
 }
 
 #ifdef CPPHTTPLIB_NO_EXCEPTIONS
@@ -4356,546 +4384,576 @@ inline bool parse_range_header(const std::string &s, Ranges &ranges) {
 #else
 inline bool parse_range_header(const std::string &s, Ranges &ranges) try {
 #endif
-  auto re_first_range = Regex(R"(bytes=(\d*-\d*(?:,\s*\d*-\d*)*))");
-  Match m;
-  if (RegexMatch(s, m, re_first_range)) {
-    auto pos = static_cast<size_t>(m.position(1));
-    auto len = static_cast<size_t>(m.length(1));
-    auto all_valid_ranges = true;
-    split(&s[pos], &s[pos + len], ',', [&](const char *b, const char *e) {
-      if (!all_valid_ranges) { return; }
-      auto re_another_range = Regex(R"(\s*(\d*)-(\d*))");
-      Match cm;
-      if (RegexMatch(b, e, cm, re_another_range)) {
-        ssize_t first = -1;
-        if (!cm.str(1).empty()) {
-          first = static_cast<ssize_t>(std::stoll(cm.str(1)));
-        }
+	auto re_first_range = Regex(R"(bytes=(\d*-\d*(?:,\s*\d*-\d*)*))");
+	Match m;
+	if (RegexMatch(s, m, re_first_range)) {
+		auto pos = static_cast<size_t>(m.position(1));
+		auto len = static_cast<size_t>(m.length(1));
+		auto all_valid_ranges = true;
+		split(&s[pos], &s[pos + len], ',', [&](const char *b, const char *e) {
+			if (!all_valid_ranges) {
+				return;
+			}
+			auto re_another_range = Regex(R"(\s*(\d*)-(\d*))");
+			Match cm;
+			if (RegexMatch(b, e, cm, re_another_range)) {
+				ssize_t first = -1;
+				if (!cm.str(1).empty()) {
+					first = static_cast<ssize_t>(std::stoll(cm.str(1)));
+				}
 
-        ssize_t last = -1;
-        if (!cm.str(2).empty()) {
-          last = static_cast<ssize_t>(std::stoll(cm.str(2)));
-        }
+				ssize_t last = -1;
+				if (!cm.str(2).empty()) {
+					last = static_cast<ssize_t>(std::stoll(cm.str(2)));
+				}
 
-        if (first != -1 && last != -1 && first > last) {
-          all_valid_ranges = false;
-          return;
-        }
-        ranges.emplace_back(std::make_pair(first, last));
-      }
-    });
-    return all_valid_ranges;
-  }
-  return false;
+				if (first != -1 && last != -1 && first > last) {
+					all_valid_ranges = false;
+					return;
+				}
+				ranges.emplace_back(std::make_pair(first, last));
+			}
+		});
+		return all_valid_ranges;
+	}
+	return false;
 #ifdef CPPHTTPLIB_NO_EXCEPTIONS
 }
 #else
-} catch (...) { return false; }
+} catch (...) {
+	return false;
+}
 #endif
 
 class MultipartFormDataParser {
 public:
-  MultipartFormDataParser() = default;
+	MultipartFormDataParser() = default;
 
-  void set_boundary(std::string &&boundary) {
-    boundary_ = boundary;
-    dash_boundary_crlf_ = dash_ + boundary_ + crlf_;
-    crlf_dash_boundary_ = crlf_ + dash_ + boundary_;
-  }
+	void set_boundary(std::string &&boundary) {
+		boundary_ = boundary;
+		dash_boundary_crlf_ = dash_ + boundary_ + crlf_;
+		crlf_dash_boundary_ = crlf_ + dash_ + boundary_;
+	}
 
-  bool is_valid() const { return is_valid_; }
+	bool is_valid() const {
+		return is_valid_;
+	}
 
-  bool parse(const char *buf, size_t n, const ContentReceiver &content_callback,
-             const MultipartContentHeader &header_callback) {
+	bool parse(const char *buf, size_t n, const ContentReceiver &content_callback,
+	           const MultipartContentHeader &header_callback) {
 
-    buf_append(buf, n);
+		buf_append(buf, n);
 
-    while (buf_size() > 0) {
-      switch (state_) {
-      case 0: { // Initial boundary
-        buf_erase(buf_find(dash_boundary_crlf_));
-        if (dash_boundary_crlf_.size() > buf_size()) { return true; }
-        if (!buf_start_with(dash_boundary_crlf_)) { return false; }
-        buf_erase(dash_boundary_crlf_.size());
-        state_ = 1;
-        break;
-      }
-      case 1: { // New entry
-        clear_file_info();
-        state_ = 2;
-        break;
-      }
-      case 2: { // Headers
-        auto pos = buf_find(crlf_);
-        if (pos > CPPHTTPLIB_HEADER_MAX_LENGTH) { return false; }
-        while (pos < buf_size()) {
-          // Empty line
-          if (pos == 0) {
-            if (!header_callback(file_)) {
-              is_valid_ = false;
-              return false;
-            }
-            buf_erase(crlf_.size());
-            state_ = 3;
-            break;
-          }
+		while (buf_size() > 0) {
+			switch (state_) {
+			case 0: { // Initial boundary
+				buf_erase(buf_find(dash_boundary_crlf_));
+				if (dash_boundary_crlf_.size() > buf_size()) {
+					return true;
+				}
+				if (!buf_start_with(dash_boundary_crlf_)) {
+					return false;
+				}
+				buf_erase(dash_boundary_crlf_.size());
+				state_ = 1;
+				break;
+			}
+			case 1: { // New entry
+				clear_file_info();
+				state_ = 2;
+				break;
+			}
+			case 2: { // Headers
+				auto pos = buf_find(crlf_);
+				if (pos > CPPHTTPLIB_HEADER_MAX_LENGTH) {
+					return false;
+				}
+				while (pos < buf_size()) {
+					// Empty line
+					if (pos == 0) {
+						if (!header_callback(file_)) {
+							is_valid_ = false;
+							return false;
+						}
+						buf_erase(crlf_.size());
+						state_ = 3;
+						break;
+					}
 
-          const auto header = buf_head(pos);
+					const auto header = buf_head(pos);
 
-          if (!parse_header(header.data(), header.data() + header.size(),
-                            [&](std::string &&, std::string &&) {})) {
-            is_valid_ = false;
-            return false;
-          }
+					if (!parse_header(header.data(), header.data() + header.size(),
+					                  [&](std::string &&, std::string &&) {})) {
+						is_valid_ = false;
+						return false;
+					}
 
-          const std::string header_content_type = "Content-Type:";
+					const std::string header_content_type = "Content-Type:";
 
-          if (start_with_case_ignore(header, header_content_type)) {
-            file_.content_type =
-                trim_copy(header.substr(header_content_type.size()));
-          } else {
-            const Regex re_content_disposition(
-                R"~(^Content-Disposition:\s*form-data;\s*(.*)$)~",
-                duckdb_re2::RegexOptions::CASE_INSENSITIVE);
+					if (start_with_case_ignore(header, header_content_type)) {
+						file_.content_type = trim_copy(header.substr(header_content_type.size()));
+					} else {
+						const Regex re_content_disposition(R"~(^Content-Disposition:\s*form-data;\s*(.*)$)~",
+						                                   duckdb_re2::RegexOptions::CASE_INSENSITIVE);
 
-            Match m;
-            if (RegexMatch(header, m, re_content_disposition)) {
-              Params params;
-              parse_disposition_params(m[1], params);
+						Match m;
+						if (RegexMatch(header, m, re_content_disposition)) {
+							Params params;
+							parse_disposition_params(m[1], params);
 
-              auto it = params.find("name");
-              if (it != params.end()) {
-                file_.name = it->second;
-              } else {
-                is_valid_ = false;
-                return false;
-              }
+							auto it = params.find("name");
+							if (it != params.end()) {
+								file_.name = it->second;
+							} else {
+								is_valid_ = false;
+								return false;
+							}
 
-              it = params.find("filename");
-              if (it != params.end()) { file_.filename = it->second; }
+							it = params.find("filename");
+							if (it != params.end()) {
+								file_.filename = it->second;
+							}
 
-              it = params.find("filename*");
-              if (it != params.end()) {
-                // Only allow UTF-8 enconnding...
-                const Regex re_rfc5987_encoding(
-                    R"~(^UTF-8''(.+?)$)~", duckdb_re2::RegexOptions::CASE_INSENSITIVE);
+							it = params.find("filename*");
+							if (it != params.end()) {
+								// Only allow UTF-8 enconnding...
+								const Regex re_rfc5987_encoding(R"~(^UTF-8''(.+?)$)~",
+								                                duckdb_re2::RegexOptions::CASE_INSENSITIVE);
 
-                Match m2;
-                if (RegexMatch(it->second, m2, re_rfc5987_encoding)) {
-                  file_.filename = decode_url(m2[1], false); // override...
-                } else {
-                  is_valid_ = false;
-                  return false;
-                }
-              }
-            }
-          }
-          buf_erase(pos + crlf_.size());
-          pos = buf_find(crlf_);
-        }
-        if (state_ != 3) { return true; }
-        break;
-      }
-      case 3: { // Body
-        if (crlf_dash_boundary_.size() > buf_size()) { return true; }
-        auto pos = buf_find(crlf_dash_boundary_);
-        if (pos < buf_size()) {
-          if (!content_callback(buf_data(), pos)) {
-            is_valid_ = false;
-            return false;
-          }
-          buf_erase(pos + crlf_dash_boundary_.size());
-          state_ = 4;
-        } else {
-          auto len = buf_size() - crlf_dash_boundary_.size();
-          if (len > 0) {
-            if (!content_callback(buf_data(), len)) {
-              is_valid_ = false;
-              return false;
-            }
-            buf_erase(len);
-          }
-          return true;
-        }
-        break;
-      }
-      case 4: { // Boundary
-        if (crlf_.size() > buf_size()) { return true; }
-        if (buf_start_with(crlf_)) {
-          buf_erase(crlf_.size());
-          state_ = 1;
-        } else {
-          if (dash_.size() > buf_size()) { return true; }
-          if (buf_start_with(dash_)) {
-            buf_erase(dash_.size());
-            is_valid_ = true;
-            buf_erase(buf_size()); // Remove epilogue
-          } else {
-            return true;
-          }
-        }
-        break;
-      }
-      }
-    }
+								Match m2;
+								if (RegexMatch(it->second, m2, re_rfc5987_encoding)) {
+									file_.filename = decode_url(m2[1], false); // override...
+								} else {
+									is_valid_ = false;
+									return false;
+								}
+							}
+						}
+					}
+					buf_erase(pos + crlf_.size());
+					pos = buf_find(crlf_);
+				}
+				if (state_ != 3) {
+					return true;
+				}
+				break;
+			}
+			case 3: { // Body
+				if (crlf_dash_boundary_.size() > buf_size()) {
+					return true;
+				}
+				auto pos = buf_find(crlf_dash_boundary_);
+				if (pos < buf_size()) {
+					if (!content_callback(buf_data(), pos)) {
+						is_valid_ = false;
+						return false;
+					}
+					buf_erase(pos + crlf_dash_boundary_.size());
+					state_ = 4;
+				} else {
+					auto len = buf_size() - crlf_dash_boundary_.size();
+					if (len > 0) {
+						if (!content_callback(buf_data(), len)) {
+							is_valid_ = false;
+							return false;
+						}
+						buf_erase(len);
+					}
+					return true;
+				}
+				break;
+			}
+			case 4: { // Boundary
+				if (crlf_.size() > buf_size()) {
+					return true;
+				}
+				if (buf_start_with(crlf_)) {
+					buf_erase(crlf_.size());
+					state_ = 1;
+				} else {
+					if (dash_.size() > buf_size()) {
+						return true;
+					}
+					if (buf_start_with(dash_)) {
+						buf_erase(dash_.size());
+						is_valid_ = true;
+						buf_erase(buf_size()); // Remove epilogue
+					} else {
+						return true;
+					}
+				}
+				break;
+			}
+			}
+		}
 
-    return true;
-  }
+		return true;
+	}
 
 private:
-  void clear_file_info() {
-    file_.name.clear();
-    file_.filename.clear();
-    file_.content_type.clear();
-  }
+	void clear_file_info() {
+		file_.name.clear();
+		file_.filename.clear();
+		file_.content_type.clear();
+	}
 
-  bool start_with_case_ignore(const std::string &a,
-                              const std::string &b) const {
-    if (a.size() < b.size()) { return false; }
-    for (size_t i = 0; i < b.size(); i++) {
-      if (::tolower(a[i]) != ::tolower(b[i])) { return false; }
-    }
-    return true;
-  }
+	bool start_with_case_ignore(const std::string &a, const std::string &b) const {
+		if (a.size() < b.size()) {
+			return false;
+		}
+		for (size_t i = 0; i < b.size(); i++) {
+			if (::tolower(a[i]) != ::tolower(b[i])) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-  const std::string dash_ = "--";
-  const std::string crlf_ = "\r\n";
-  std::string boundary_;
-  std::string dash_boundary_crlf_;
-  std::string crlf_dash_boundary_;
+	const std::string dash_ = "--";
+	const std::string crlf_ = "\r\n";
+	std::string boundary_;
+	std::string dash_boundary_crlf_;
+	std::string crlf_dash_boundary_;
 
-  size_t state_ = 0;
-  bool is_valid_ = false;
-  MultipartFormData file_;
+	size_t state_ = 0;
+	bool is_valid_ = false;
+	MultipartFormData file_;
 
-  // Buffer
-  bool start_with(const std::string &a, size_t spos, size_t epos,
-                  const std::string &b) const {
-    if (epos - spos < b.size()) { return false; }
-    for (size_t i = 0; i < b.size(); i++) {
-      if (a[i + spos] != b[i]) { return false; }
-    }
-    return true;
-  }
+	// Buffer
+	bool start_with(const std::string &a, size_t spos, size_t epos, const std::string &b) const {
+		if (epos - spos < b.size()) {
+			return false;
+		}
+		for (size_t i = 0; i < b.size(); i++) {
+			if (a[i + spos] != b[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-  size_t buf_size() const { return buf_epos_ - buf_spos_; }
+	size_t buf_size() const {
+		return buf_epos_ - buf_spos_;
+	}
 
-  const char *buf_data() const { return &buf_[buf_spos_]; }
+	const char *buf_data() const {
+		return &buf_[buf_spos_];
+	}
 
-  std::string buf_head(size_t l) const { return buf_.substr(buf_spos_, l); }
+	std::string buf_head(size_t l) const {
+		return buf_.substr(buf_spos_, l);
+	}
 
-  bool buf_start_with(const std::string &s) const {
-    return start_with(buf_, buf_spos_, buf_epos_, s);
-  }
+	bool buf_start_with(const std::string &s) const {
+		return start_with(buf_, buf_spos_, buf_epos_, s);
+	}
 
-  size_t buf_find(const std::string &s) const {
-    auto c = s.front();
+	size_t buf_find(const std::string &s) const {
+		auto c = s.front();
 
-    size_t off = buf_spos_;
-    while (off < buf_epos_) {
-      auto pos = off;
-      while (true) {
-        if (pos == buf_epos_) { return buf_size(); }
-        if (buf_[pos] == c) { break; }
-        pos++;
-      }
+		size_t off = buf_spos_;
+		while (off < buf_epos_) {
+			auto pos = off;
+			while (true) {
+				if (pos == buf_epos_) {
+					return buf_size();
+				}
+				if (buf_[pos] == c) {
+					break;
+				}
+				pos++;
+			}
 
-      auto remaining_size = buf_epos_ - pos;
-      if (s.size() > remaining_size) { return buf_size(); }
+			auto remaining_size = buf_epos_ - pos;
+			if (s.size() > remaining_size) {
+				return buf_size();
+			}
 
-      if (start_with(buf_, pos, buf_epos_, s)) { return pos - buf_spos_; }
+			if (start_with(buf_, pos, buf_epos_, s)) {
+				return pos - buf_spos_;
+			}
 
-      off = pos + 1;
-    }
+			off = pos + 1;
+		}
 
-    return buf_size();
-  }
+		return buf_size();
+	}
 
-  void buf_append(const char *data, size_t n) {
-    auto remaining_size = buf_size();
-    if (remaining_size > 0 && buf_spos_ > 0) {
-      for (size_t i = 0; i < remaining_size; i++) {
-        buf_[i] = buf_[buf_spos_ + i];
-      }
-    }
-    buf_spos_ = 0;
-    buf_epos_ = remaining_size;
+	void buf_append(const char *data, size_t n) {
+		auto remaining_size = buf_size();
+		if (remaining_size > 0 && buf_spos_ > 0) {
+			for (size_t i = 0; i < remaining_size; i++) {
+				buf_[i] = buf_[buf_spos_ + i];
+			}
+		}
+		buf_spos_ = 0;
+		buf_epos_ = remaining_size;
 
-    if (remaining_size + n > buf_.size()) { buf_.resize(remaining_size + n); }
+		if (remaining_size + n > buf_.size()) {
+			buf_.resize(remaining_size + n);
+		}
 
-    for (size_t i = 0; i < n; i++) {
-      buf_[buf_epos_ + i] = data[i];
-    }
-    buf_epos_ += n;
-  }
+		for (size_t i = 0; i < n; i++) {
+			buf_[buf_epos_ + i] = data[i];
+		}
+		buf_epos_ += n;
+	}
 
-  void buf_erase(size_t size) { buf_spos_ += size; }
+	void buf_erase(size_t size) {
+		buf_spos_ += size;
+	}
 
-  std::string buf_;
-  size_t buf_spos_ = 0;
-  size_t buf_epos_ = 0;
+	std::string buf_;
+	size_t buf_spos_ = 0;
+	size_t buf_epos_ = 0;
 };
 
 inline std::string to_lower(const char *beg, const char *end) {
-  std::string out;
-  auto it = beg;
-  while (it != end) {
-    out += static_cast<char>(::tolower(*it));
-    it++;
-  }
-  return out;
+	std::string out;
+	auto it = beg;
+	while (it != end) {
+		out += static_cast<char>(::tolower(*it));
+		it++;
+	}
+	return out;
 }
 
 inline std::string make_multipart_data_boundary() {
-  static const char data[] =
-      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+	static const char data[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-  std::string result = "--cpp-httplib-multipart-data-";
-  duckdb::RandomEngine engine;
-  for (auto i = 0; i < 16; i++) {
-    result += data[engine.NextRandomInteger32(0,sizeof(data) - 1)];
-  }
+	std::string result = "--cpp-httplib-multipart-data-";
+	duckdb::RandomEngine engine;
+	for (auto i = 0; i < 16; i++) {
+		result += data[engine.NextRandomInteger32(0, sizeof(data) - 1)];
+	}
 
-  return result;
+	return result;
 }
 
 inline bool is_multipart_boundary_chars_valid(const std::string &boundary) {
-  auto valid = true;
-  for (size_t i = 0; i < boundary.size(); i++) {
-    auto c = boundary[i];
-    if (!std::isalnum(c) && c != '-' && c != '_') {
-      valid = false;
-      break;
-    }
-  }
-  return valid;
+	auto valid = true;
+	for (size_t i = 0; i < boundary.size(); i++) {
+		auto c = boundary[i];
+		if (!std::isalnum(c) && c != '-' && c != '_') {
+			valid = false;
+			break;
+		}
+	}
+	return valid;
 }
 
 template <typename T>
-inline std::string
-serialize_multipart_formdata_item_begin(const T &item,
-                                        const std::string &boundary) {
-  std::string body = "--" + boundary + "\r\n";
-  body += "Content-Disposition: form-data; name=\"" + item.name + "\"";
-  if (!item.filename.empty()) {
-    body += "; filename=\"" + item.filename + "\"";
-  }
-  body += "\r\n";
-  if (!item.content_type.empty()) {
-    body += "Content-Type: " + item.content_type + "\r\n";
-  }
-  body += "\r\n";
+inline std::string serialize_multipart_formdata_item_begin(const T &item, const std::string &boundary) {
+	std::string body = "--" + boundary + "\r\n";
+	body += "Content-Disposition: form-data; name=\"" + item.name + "\"";
+	if (!item.filename.empty()) {
+		body += "; filename=\"" + item.filename + "\"";
+	}
+	body += "\r\n";
+	if (!item.content_type.empty()) {
+		body += "Content-Type: " + item.content_type + "\r\n";
+	}
+	body += "\r\n";
 
-  return body;
+	return body;
 }
 
-inline std::string serialize_multipart_formdata_item_end() { return "\r\n"; }
-
-inline std::string
-serialize_multipart_formdata_finish(const std::string &boundary) {
-  return "--" + boundary + "--\r\n";
+inline std::string serialize_multipart_formdata_item_end() {
+	return "\r\n";
 }
 
-inline std::string
-serialize_multipart_formdata_get_content_type(const std::string &boundary) {
-  return "multipart/form-data; boundary=" + boundary;
+inline std::string serialize_multipart_formdata_finish(const std::string &boundary) {
+	return "--" + boundary + "--\r\n";
 }
 
-inline std::string
-serialize_multipart_formdata(const MultipartFormDataItems &items,
-                             const std::string &boundary, bool finish = true) {
-  std::string body;
-
-  for (const auto &item : items) {
-    body += serialize_multipart_formdata_item_begin(item, boundary);
-    body += item.content + serialize_multipart_formdata_item_end();
-  }
-
-  if (finish) { body += serialize_multipart_formdata_finish(boundary); }
-
-  return body;
+inline std::string serialize_multipart_formdata_get_content_type(const std::string &boundary) {
+	return "multipart/form-data; boundary=" + boundary;
 }
 
-inline std::pair<size_t, size_t>
-get_range_offset_and_length(const Request &req, size_t content_length,
-                            size_t index) {
-  auto r = req.ranges[index];
+inline std::string serialize_multipart_formdata(const MultipartFormDataItems &items, const std::string &boundary,
+                                                bool finish = true) {
+	std::string body;
 
-  if (r.first == -1 && r.second == -1) {
-    return std::make_pair(0, content_length);
-  }
+	for (const auto &item : items) {
+		body += serialize_multipart_formdata_item_begin(item, boundary);
+		body += item.content + serialize_multipart_formdata_item_end();
+	}
 
-  auto slen = static_cast<ssize_t>(content_length);
+	if (finish) {
+		body += serialize_multipart_formdata_finish(boundary);
+	}
 
-  if (r.first == -1) {
-    r.first = (std::max)(static_cast<ssize_t>(0), slen - r.second);
-    r.second = slen - 1;
-  }
-
-  if (r.second == -1) { r.second = slen - 1; }
-  return std::make_pair(r.first, static_cast<size_t>(r.second - r.first) + 1);
+	return body;
 }
 
-inline std::string
-make_content_range_header_field(const std::pair<ssize_t, ssize_t> &range,
-                                size_t content_length) {
-  std::string field = "bytes ";
-  if (range.first != -1) { field += std::to_string(range.first); }
-  field += "-";
-  if (range.second != -1) { field += std::to_string(range.second); }
-  field += "/";
-  field += std::to_string(content_length);
-  return field;
+inline std::pair<size_t, size_t> get_range_offset_and_length(const Request &req, size_t content_length, size_t index) {
+	auto r = req.ranges[index];
+
+	if (r.first == -1 && r.second == -1) {
+		return std::make_pair(0, content_length);
+	}
+
+	auto slen = static_cast<ssize_t>(content_length);
+
+	if (r.first == -1) {
+		r.first = (std::max)(static_cast<ssize_t>(0), slen - r.second);
+		r.second = slen - 1;
+	}
+
+	if (r.second == -1) {
+		r.second = slen - 1;
+	}
+	return std::make_pair(r.first, static_cast<size_t>(r.second - r.first) + 1);
+}
+
+inline std::string make_content_range_header_field(const std::pair<ssize_t, ssize_t> &range, size_t content_length) {
+	std::string field = "bytes ";
+	if (range.first != -1) {
+		field += std::to_string(range.first);
+	}
+	field += "-";
+	if (range.second != -1) {
+		field += std::to_string(range.second);
+	}
+	field += "/";
+	field += std::to_string(content_length);
+	return field;
 }
 
 template <typename SToken, typename CToken, typename Content>
-bool process_multipart_ranges_data(const Request &req, Response &res,
-                                   const std::string &boundary,
-                                   const std::string &content_type,
-                                   SToken stoken, CToken ctoken,
-                                   Content content) {
-  for (size_t i = 0; i < req.ranges.size(); i++) {
-    ctoken("--");
-    stoken(boundary);
-    ctoken("\r\n");
-    if (!content_type.empty()) {
-      ctoken("Content-Type: ");
-      stoken(content_type);
-      ctoken("\r\n");
-    }
+bool process_multipart_ranges_data(const Request &req, Response &res, const std::string &boundary,
+                                   const std::string &content_type, SToken stoken, CToken ctoken, Content content) {
+	for (size_t i = 0; i < req.ranges.size(); i++) {
+		ctoken("--");
+		stoken(boundary);
+		ctoken("\r\n");
+		if (!content_type.empty()) {
+			ctoken("Content-Type: ");
+			stoken(content_type);
+			ctoken("\r\n");
+		}
 
-    ctoken("Content-Range: ");
-    const auto &range = req.ranges[i];
-    stoken(make_content_range_header_field(range, res.content_length_));
-    ctoken("\r\n");
-    ctoken("\r\n");
+		ctoken("Content-Range: ");
+		const auto &range = req.ranges[i];
+		stoken(make_content_range_header_field(range, res.content_length_));
+		ctoken("\r\n");
+		ctoken("\r\n");
 
-    auto offsets = get_range_offset_and_length(req, res.content_length_, i);
-    auto offset = offsets.first;
-    auto length = offsets.second;
-    if (!content(offset, length)) { return false; }
-    ctoken("\r\n");
-  }
+		auto offsets = get_range_offset_and_length(req, res.content_length_, i);
+		auto offset = offsets.first;
+		auto length = offsets.second;
+		if (!content(offset, length)) {
+			return false;
+		}
+		ctoken("\r\n");
+	}
 
-  ctoken("--");
-  stoken(boundary);
-  ctoken("--");
+	ctoken("--");
+	stoken(boundary);
+	ctoken("--");
 
-  return true;
+	return true;
 }
 
-inline bool make_multipart_ranges_data(const Request &req, Response &res,
-                                       const std::string &boundary,
-                                       const std::string &content_type,
-                                       std::string &data) {
-  return process_multipart_ranges_data(
-      req, res, boundary, content_type,
-      [&](const std::string &token) { data += token; },
-      [&](const std::string &token) { data += token; },
-      [&](size_t offset, size_t length) {
-        if (offset < res.body.size()) {
-          data += res.body.substr(offset, length);
-          return true;
-        }
-        return false;
-      });
+inline bool make_multipart_ranges_data(const Request &req, Response &res, const std::string &boundary,
+                                       const std::string &content_type, std::string &data) {
+	return process_multipart_ranges_data(
+	    req, res, boundary, content_type, [&](const std::string &token) { data += token; },
+	    [&](const std::string &token) { data += token; },
+	    [&](size_t offset, size_t length) {
+		    if (offset < res.body.size()) {
+			    data += res.body.substr(offset, length);
+			    return true;
+		    }
+		    return false;
+	    });
 }
 
-inline size_t
-get_multipart_ranges_data_length(const Request &req, Response &res,
-                                 const std::string &boundary,
-                                 const std::string &content_type) {
-  size_t data_length = 0;
+inline size_t get_multipart_ranges_data_length(const Request &req, Response &res, const std::string &boundary,
+                                               const std::string &content_type) {
+	size_t data_length = 0;
 
-  process_multipart_ranges_data(
-      req, res, boundary, content_type,
-      [&](const std::string &token) { data_length += token.size(); },
-      [&](const std::string &token) { data_length += token.size(); },
-      [&](size_t /*offset*/, size_t length) {
-        data_length += length;
-        return true;
-      });
+	process_multipart_ranges_data(
+	    req, res, boundary, content_type, [&](const std::string &token) { data_length += token.size(); },
+	    [&](const std::string &token) { data_length += token.size(); },
+	    [&](size_t /*offset*/, size_t length) {
+		    data_length += length;
+		    return true;
+	    });
 
-  return data_length;
+	return data_length;
 }
 
 template <typename T>
-inline bool write_multipart_ranges_data(Stream &strm, const Request &req,
-                                        Response &res,
-                                        const std::string &boundary,
-                                        const std::string &content_type,
-                                        const T &is_shutting_down) {
-  return process_multipart_ranges_data(
-      req, res, boundary, content_type,
-      [&](const std::string &token) { strm.write(token); },
-      [&](const std::string &token) { strm.write(token); },
-      [&](size_t offset, size_t length) {
-        return write_content(strm, res.content_provider_, offset, length,
-                             is_shutting_down);
-      });
+inline bool write_multipart_ranges_data(Stream &strm, const Request &req, Response &res, const std::string &boundary,
+                                        const std::string &content_type, const T &is_shutting_down) {
+	return process_multipart_ranges_data(
+	    req, res, boundary, content_type, [&](const std::string &token) { strm.write(token); },
+	    [&](const std::string &token) { strm.write(token); },
+	    [&](size_t offset, size_t length) {
+		    return write_content(strm, res.content_provider_, offset, length, is_shutting_down);
+	    });
 }
 
-inline std::pair<size_t, size_t>
-get_range_offset_and_length(const Request &req, const Response &res,
-                            size_t index) {
-  auto r = req.ranges[index];
+inline std::pair<size_t, size_t> get_range_offset_and_length(const Request &req, const Response &res, size_t index) {
+	auto r = req.ranges[index];
 
-  if (r.second == -1) {
-    r.second = static_cast<ssize_t>(res.content_length_) - 1;
-  }
+	if (r.second == -1) {
+		r.second = static_cast<ssize_t>(res.content_length_) - 1;
+	}
 
-  return std::make_pair(r.first, r.second - r.first + 1);
+	return std::make_pair(r.first, r.second - r.first + 1);
 }
 
 inline bool expect_content(const Request &req) {
-  if (req.method == "POST" || req.method == "PUT" || req.method == "PATCH" ||
-      req.method == "PRI" || req.method == "DELETE") {
-    return true;
-  }
-  // TODO: check if Content-Length is set
-  return false;
+	if (req.method == "POST" || req.method == "PUT" || req.method == "PATCH" || req.method == "PRI" ||
+	    req.method == "DELETE") {
+		return true;
+	}
+	// TODO: check if Content-Length is set
+	return false;
 }
 
 inline bool has_crlf(const std::string &s) {
-  auto p = s.c_str();
-  while (*p) {
-    if (*p == '\r' || *p == '\n') { return true; }
-    p++;
-  }
-  return false;
+	auto p = s.c_str();
+	while (*p) {
+		if (*p == '\r' || *p == '\n') {
+			return true;
+		}
+		p++;
+	}
+	return false;
 }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 inline std::string message_digest(const std::string &s, const EVP_MD *algo) {
-  auto context = duckdb::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>(
-      EVP_MD_CTX_new(), EVP_MD_CTX_free);
+	auto context = duckdb::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>(EVP_MD_CTX_new(), EVP_MD_CTX_free);
 
-  unsigned int hash_length = 0;
-  unsigned char hash[EVP_MAX_MD_SIZE];
+	unsigned int hash_length = 0;
+	unsigned char hash[EVP_MAX_MD_SIZE];
 
-  EVP_DigestInit_ex(context.get(), algo, nullptr);
-  EVP_DigestUpdate(context.get(), s.c_str(), s.size());
-  EVP_DigestFinal_ex(context.get(), hash, &hash_length);
+	EVP_DigestInit_ex(context.get(), algo, nullptr);
+	EVP_DigestUpdate(context.get(), s.c_str(), s.size());
+	EVP_DigestFinal_ex(context.get(), hash, &hash_length);
 
-  duckdb::stringstream ss;
-  for (auto i = 0u; i < hash_length; ++i) {
-    ss << std::hex << std::setw(2) << std::setfill('0')
-       << static_cast<unsigned int>(hash[i]);
-  }
+	duckdb::stringstream ss;
+	for (auto i = 0u; i < hash_length; ++i) {
+		ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<unsigned int>(hash[i]);
+	}
 
-  return ss.str();
+	return ss.str();
 }
 
 inline std::string MD5(const std::string &s) {
-  return message_digest(s, EVP_md5());
+	return message_digest(s, EVP_md5());
 }
 
 inline std::string SHA_256(const std::string &s) {
-  return message_digest(s, EVP_sha256());
+	return message_digest(s, EVP_sha256());
 }
 
 inline std::string SHA_512(const std::string &s) {
-  return message_digest(s, EVP_sha512());
+	return message_digest(s, EVP_sha512());
 }
 #endif
 
@@ -4904,117 +4962,115 @@ inline std::string SHA_512(const std::string &s) {
 // NOTE: This code came up with the following stackoverflow post:
 // https://stackoverflow.com/questions/9507184/can-openssl-on-windows-use-the-system-certificate-store
 inline bool load_system_certs_on_windows(X509_STORE *store) {
-  auto hStore = CertOpenSystemStoreW((HCRYPTPROV_LEGACY)NULL, L"ROOT");
-  if (!hStore) { return false; }
+	auto hStore = CertOpenSystemStoreW((HCRYPTPROV_LEGACY)NULL, L"ROOT");
+	if (!hStore) {
+		return false;
+	}
 
-  auto result = false;
-  PCCERT_CONTEXT pContext = NULL;
-  while ((pContext = CertEnumCertificatesInStore(hStore, pContext)) !=
-         nullptr) {
-    auto encoded_cert =
-        static_cast<const unsigned char *>(pContext->pbCertEncoded);
+	auto result = false;
+	PCCERT_CONTEXT pContext = NULL;
+	while ((pContext = CertEnumCertificatesInStore(hStore, pContext)) != nullptr) {
+		auto encoded_cert = static_cast<const unsigned char *>(pContext->pbCertEncoded);
 
-    auto x509 = d2i_X509(NULL, &encoded_cert, pContext->cbCertEncoded);
-    if (x509) {
-      X509_STORE_add_cert(store, x509);
-      X509_free(x509);
-      result = true;
-    }
-  }
+		auto x509 = d2i_X509(NULL, &encoded_cert, pContext->cbCertEncoded);
+		if (x509) {
+			X509_STORE_add_cert(store, x509);
+			X509_free(x509);
+			result = true;
+		}
+	}
 
-  CertFreeCertificateContext(pContext);
-  CertCloseStore(hStore, 0);
+	CertFreeCertificateContext(pContext);
+	CertCloseStore(hStore, 0);
 
-  return result;
+	return result;
 }
 #elif defined(CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN) && defined(__APPLE__)
 #if TARGET_OS_OSX
 template <typename T>
-using CFObjectPtr =
-    duckdb::unique_ptr<typename std::remove_pointer<T>::type, void (*)(CFTypeRef)>;
+using CFObjectPtr = duckdb::unique_ptr<typename std::remove_pointer<T>::type, void (*)(CFTypeRef)>;
 
 inline void cf_object_ptr_deleter(CFTypeRef obj) {
-  if (obj) { CFRelease(obj); }
+	if (obj) {
+		CFRelease(obj);
+	}
 }
 
 inline bool retrieve_certs_from_keychain(CFObjectPtr<CFArrayRef> &certs) {
-  CFStringRef keys[] = {kSecClass, kSecMatchLimit, kSecReturnRef};
-  CFTypeRef values[] = {kSecClassCertificate, kSecMatchLimitAll,
-                        kCFBooleanTrue};
+	CFStringRef keys[] = {kSecClass, kSecMatchLimit, kSecReturnRef};
+	CFTypeRef values[] = {kSecClassCertificate, kSecMatchLimitAll, kCFBooleanTrue};
 
-  CFObjectPtr<CFDictionaryRef> query(
-      CFDictionaryCreate(nullptr, reinterpret_cast<const void **>(keys), values,
-                         sizeof(keys) / sizeof(keys[0]),
-                         &kCFTypeDictionaryKeyCallBacks,
-                         &kCFTypeDictionaryValueCallBacks),
-      cf_object_ptr_deleter);
+	CFObjectPtr<CFDictionaryRef> query(
+	    CFDictionaryCreate(nullptr, reinterpret_cast<const void **>(keys), values, sizeof(keys) / sizeof(keys[0]),
+	                       &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks),
+	    cf_object_ptr_deleter);
 
-  if (!query) { return false; }
+	if (!query) {
+		return false;
+	}
 
-  CFTypeRef security_items = nullptr;
-  if (SecItemCopyMatching(query.get(), &security_items) != errSecSuccess ||
-      CFArrayGetTypeID() != CFGetTypeID(security_items)) {
-    return false;
-  }
+	CFTypeRef security_items = nullptr;
+	if (SecItemCopyMatching(query.get(), &security_items) != errSecSuccess ||
+	    CFArrayGetTypeID() != CFGetTypeID(security_items)) {
+		return false;
+	}
 
-  certs.reset(reinterpret_cast<CFArrayRef>(security_items));
-  return true;
+	certs.reset(reinterpret_cast<CFArrayRef>(security_items));
+	return true;
 }
 
 inline bool retrieve_root_certs_from_keychain(CFObjectPtr<CFArrayRef> &certs) {
-  CFArrayRef root_security_items = nullptr;
-  if (SecTrustCopyAnchorCertificates(&root_security_items) != errSecSuccess) {
-    return false;
-  }
+	CFArrayRef root_security_items = nullptr;
+	if (SecTrustCopyAnchorCertificates(&root_security_items) != errSecSuccess) {
+		return false;
+	}
 
-  certs.reset(root_security_items);
-  return true;
+	certs.reset(root_security_items);
+	return true;
 }
 
 inline bool add_certs_to_x509_store(CFArrayRef certs, X509_STORE *store) {
-  auto result = false;
-  for (auto i = 0; i < CFArrayGetCount(certs); ++i) {
-    const auto cert = reinterpret_cast<const __SecCertificate *>(
-        CFArrayGetValueAtIndex(certs, i));
+	auto result = false;
+	for (auto i = 0; i < CFArrayGetCount(certs); ++i) {
+		const auto cert = reinterpret_cast<const __SecCertificate *>(CFArrayGetValueAtIndex(certs, i));
 
-    if (SecCertificateGetTypeID() != CFGetTypeID(cert)) { continue; }
+		if (SecCertificateGetTypeID() != CFGetTypeID(cert)) {
+			continue;
+		}
 
-    CFDataRef cert_data = nullptr;
-    if (SecItemExport(cert, kSecFormatX509Cert, 0, nullptr, &cert_data) !=
-        errSecSuccess) {
-      continue;
-    }
+		CFDataRef cert_data = nullptr;
+		if (SecItemExport(cert, kSecFormatX509Cert, 0, nullptr, &cert_data) != errSecSuccess) {
+			continue;
+		}
 
-    CFObjectPtr<CFDataRef> cert_data_ptr(cert_data, cf_object_ptr_deleter);
+		CFObjectPtr<CFDataRef> cert_data_ptr(cert_data, cf_object_ptr_deleter);
 
-    auto encoded_cert = static_cast<const unsigned char *>(
-        CFDataGetBytePtr(cert_data_ptr.get()));
+		auto encoded_cert = static_cast<const unsigned char *>(CFDataGetBytePtr(cert_data_ptr.get()));
 
-    auto x509 =
-        d2i_X509(NULL, &encoded_cert, CFDataGetLength(cert_data_ptr.get()));
+		auto x509 = d2i_X509(NULL, &encoded_cert, CFDataGetLength(cert_data_ptr.get()));
 
-    if (x509) {
-      X509_STORE_add_cert(store, x509);
-      X509_free(x509);
-      result = true;
-    }
-  }
+		if (x509) {
+			X509_STORE_add_cert(store, x509);
+			X509_free(x509);
+			result = true;
+		}
+	}
 
-  return result;
+	return result;
 }
 
 inline bool load_system_certs_on_macos(X509_STORE *store) {
-  auto result = false;
-  CFObjectPtr<CFArrayRef> certs(nullptr, cf_object_ptr_deleter);
-  if (retrieve_certs_from_keychain(certs) && certs) {
-    result = add_certs_to_x509_store(certs.get(), store);
-  }
+	auto result = false;
+	CFObjectPtr<CFArrayRef> certs(nullptr, cf_object_ptr_deleter);
+	if (retrieve_certs_from_keychain(certs) && certs) {
+		result = add_certs_to_x509_store(certs.get(), store);
+	}
 
-  if (retrieve_root_certs_from_keychain(certs) && certs) {
-    result = add_certs_to_x509_store(certs.get(), store) || result;
-  }
+	if (retrieve_root_certs_from_keychain(certs) && certs) {
+		result = add_certs_to_x509_store(certs.get(), store) || result;
+	}
 
-  return result;
+	return result;
 }
 #endif // TARGET_OS_OSX
 #endif // _WIN32
@@ -5023,3135 +5079,3054 @@ inline bool load_system_certs_on_macos(X509_STORE *store) {
 #ifdef _WIN32
 class WSInit {
 public:
-  WSInit() {
-    WSADATA wsaData;
-    if (WSAStartup(0x0002, &wsaData) == 0) is_valid_ = true;
-  }
+	WSInit() {
+		WSADATA wsaData;
+		if (WSAStartup(0x0002, &wsaData) == 0)
+			is_valid_ = true;
+	}
 
-  ~WSInit() {
-    if (is_valid_) WSACleanup();
-  }
+	~WSInit() {
+		if (is_valid_)
+			WSACleanup();
+	}
 
-  bool is_valid_ = false;
+	bool is_valid_ = false;
 };
 
 static WSInit wsinit_;
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline std::pair<std::string, std::string> make_digest_authentication_header(
-    const Request &req, const std::map<std::string, std::string> &auth,
-    size_t cnonce_count, const std::string &cnonce, const std::string &username,
-    const std::string &password, bool is_proxy = false) {
-  std::string nc;
-  {
-    duckdb::stringstream ss;
-    ss << std::setfill('0') << std::setw(8) << std::hex << cnonce_count;
-    nc = ss.str();
-  }
+inline std::pair<std::string, std::string>
+make_digest_authentication_header(const Request &req, const std::map<std::string, std::string> &auth,
+                                  size_t cnonce_count, const std::string &cnonce, const std::string &username,
+                                  const std::string &password, bool is_proxy = false) {
+	std::string nc;
+	{
+		duckdb::stringstream ss;
+		ss << std::setfill('0') << std::setw(8) << std::hex << cnonce_count;
+		nc = ss.str();
+	}
 
-  std::string qop;
-  if (auth.find("qop") != auth.end()) {
-    qop = auth.at("qop");
-    if (qop.find("auth-int") != std::string::npos) {
-      qop = "auth-int";
-    } else if (qop.find("auth") != std::string::npos) {
-      qop = "auth";
-    } else {
-      qop.clear();
-    }
-  }
+	std::string qop;
+	if (auth.find("qop") != auth.end()) {
+		qop = auth.at("qop");
+		if (qop.find("auth-int") != std::string::npos) {
+			qop = "auth-int";
+		} else if (qop.find("auth") != std::string::npos) {
+			qop = "auth";
+		} else {
+			qop.clear();
+		}
+	}
 
-  std::string algo = "MD5";
-  if (auth.find("algorithm") != auth.end()) { algo = auth.at("algorithm"); }
+	std::string algo = "MD5";
+	if (auth.find("algorithm") != auth.end()) {
+		algo = auth.at("algorithm");
+	}
 
-  std::string response;
-  {
-    auto H = algo == "SHA-256"   ? detail::SHA_256
-             : algo == "SHA-512" ? detail::SHA_512
-                                 : detail::MD5;
+	std::string response;
+	{
+		auto H = algo == "SHA-256" ? detail::SHA_256 : algo == "SHA-512" ? detail::SHA_512 : detail::MD5;
 
-    auto A1 = username + ":" + auth.at("realm") + ":" + password;
+		auto A1 = username + ":" + auth.at("realm") + ":" + password;
 
-    auto A2 = req.method + ":" + req.path;
-    if (qop == "auth-int") { A2 += ":" + H(req.body); }
+		auto A2 = req.method + ":" + req.path;
+		if (qop == "auth-int") {
+			A2 += ":" + H(req.body);
+		}
 
-    if (qop.empty()) {
-      response = H(H(A1) + ":" + auth.at("nonce") + ":" + H(A2));
-    } else {
-      response = H(H(A1) + ":" + auth.at("nonce") + ":" + nc + ":" + cnonce +
-                   ":" + qop + ":" + H(A2));
-    }
-  }
+		if (qop.empty()) {
+			response = H(H(A1) + ":" + auth.at("nonce") + ":" + H(A2));
+		} else {
+			response = H(H(A1) + ":" + auth.at("nonce") + ":" + nc + ":" + cnonce + ":" + qop + ":" + H(A2));
+		}
+	}
 
-  auto opaque = (auth.find("opaque") != auth.end()) ? auth.at("opaque") : "";
+	auto opaque = (auth.find("opaque") != auth.end()) ? auth.at("opaque") : "";
 
-  auto field = "Digest username=\"" + username + "\", realm=\"" +
-               auth.at("realm") + "\", nonce=\"" + auth.at("nonce") +
-               "\", uri=\"" + req.path + "\", algorithm=" + algo +
-               (qop.empty() ? ", response=\""
-                            : ", qop=" + qop + ", nc=" + nc + ", cnonce=\"" +
-                                  cnonce + "\", response=\"") +
-               response + "\"" +
-               (opaque.empty() ? "" : ", opaque=\"" + opaque + "\"");
+	auto field =
+	    "Digest username=\"" + username + "\", realm=\"" + auth.at("realm") + "\", nonce=\"" + auth.at("nonce") +
+	    "\", uri=\"" + req.path + "\", algorithm=" + algo +
+	    (qop.empty() ? ", response=\"" : ", qop=" + qop + ", nc=" + nc + ", cnonce=\"" + cnonce + "\", response=\"") +
+	    response + "\"" + (opaque.empty() ? "" : ", opaque=\"" + opaque + "\"");
 
-  auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
-  return std::make_pair(key, field);
+	auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
+	return std::make_pair(key, field);
 }
 #endif
 
-inline bool parse_www_authenticate(const Response &res,
-                                   std::map<std::string, std::string> &auth,
-                                   bool is_proxy) {
-  auto auth_key = is_proxy ? "Proxy-Authenticate" : "WWW-Authenticate";
-  if (res.has_header(auth_key)) {
-    auto re = Regex(R"~((?:(?:,\s*)?(.+?)=(?:"(.*?)"|([^,]*))))~");
-    auto s = res.get_header_value(auth_key);
-    auto pos = s.find(' ');
-    if (pos != std::string::npos) {
-      auto type = s.substr(0, pos);
-      if (type == "Basic") {
-        return false;
-      } else if (type == "Digest") {
-        s = s.substr(pos + 1);
-        auto matches = duckdb_re2::RegexFindAll(s, re);
-        for (auto &m : matches) {
-          auto key = s.substr(static_cast<size_t>(m.position(1)),
-                              static_cast<size_t>(m.length(1)));
-          auto val = m.length(2) > 0
-                         ? s.substr(static_cast<size_t>(m.position(2)),
-                                    static_cast<size_t>(m.length(2)))
-                         : s.substr(static_cast<size_t>(m.position(3)),
-                                    static_cast<size_t>(m.length(3)));
-          auth[key] = val;
-        }
-        return true;
-      }
-    }
-  }
-  return false;
+inline bool parse_www_authenticate(const Response &res, std::map<std::string, std::string> &auth, bool is_proxy) {
+	auto auth_key = is_proxy ? "Proxy-Authenticate" : "WWW-Authenticate";
+	if (res.has_header(auth_key)) {
+		auto re = Regex(R"~((?:(?:,\s*)?(.+?)=(?:"(.*?)"|([^,]*))))~");
+		auto s = res.get_header_value(auth_key);
+		auto pos = s.find(' ');
+		if (pos != std::string::npos) {
+			auto type = s.substr(0, pos);
+			if (type == "Basic") {
+				return false;
+			} else if (type == "Digest") {
+				s = s.substr(pos + 1);
+				auto matches = duckdb_re2::RegexFindAll(s, re);
+				for (auto &m : matches) {
+					auto key = s.substr(static_cast<size_t>(m.position(1)), static_cast<size_t>(m.length(1)));
+					auto val = m.length(2) > 0
+					               ? s.substr(static_cast<size_t>(m.position(2)), static_cast<size_t>(m.length(2)))
+					               : s.substr(static_cast<size_t>(m.position(3)), static_cast<size_t>(m.length(3)));
+					auth[key] = val;
+				}
+				return true;
+			}
+		}
+	}
+	return false;
 }
 
 // https://stackoverflow.com/questions/440133/how-do-i-create-a-random-alpha-numeric-string-in-c/440240#answer-440240
 inline std::string random_string(size_t length) {
-  auto randchar = []() -> char {
-    const char charset[] = "0123456789"
-                           "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                           "abcdefghijklmnopqrstuvwxyz";
-    const size_t max_index = (sizeof(charset) - 1);
-    return charset[static_cast<size_t>(std::rand()) % max_index];
-  };
-  std::string str(length, 0);
-  std::generate_n(str.begin(), length, randchar);
-  return str;
+	auto randchar = []() -> char {
+		const char charset[] = "0123456789"
+		                       "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		                       "abcdefghijklmnopqrstuvwxyz";
+		const size_t max_index = (sizeof(charset) - 1);
+		return charset[static_cast<size_t>(std::rand()) % max_index];
+	};
+	std::string str(length, 0);
+	std::generate_n(str.begin(), length, randchar);
+	return str;
 }
 
 class ContentProviderAdapter {
 public:
-  explicit ContentProviderAdapter(
-      ContentProviderWithoutLength &&content_provider)
-      : content_provider_(content_provider) {}
+	explicit ContentProviderAdapter(ContentProviderWithoutLength &&content_provider)
+	    : content_provider_(content_provider) {
+	}
 
-  bool operator()(size_t offset, size_t, DataSink &sink) {
-    return content_provider_(offset, sink);
-  }
+	bool operator()(size_t offset, size_t, DataSink &sink) {
+		return content_provider_(offset, sink);
+	}
 
 private:
-  ContentProviderWithoutLength content_provider_;
+	ContentProviderWithoutLength content_provider_;
 };
 
 } // namespace detail
 
 inline std::string hosted_at(const std::string &hostname) {
-  std::vector<std::string> addrs;
-  hosted_at(hostname, addrs);
-  if (addrs.empty()) { return std::string(); }
-  return addrs[0];
+	std::vector<std::string> addrs;
+	hosted_at(hostname, addrs);
+	if (addrs.empty()) {
+		return std::string();
+	}
+	return addrs[0];
 }
 
-inline void hosted_at(const std::string &hostname,
-                      std::vector<std::string> &addrs) {
-  struct addrinfo hints;
-  struct addrinfo *result;
+inline void hosted_at(const std::string &hostname, std::vector<std::string> &addrs) {
+	struct addrinfo hints;
+	struct addrinfo *result;
 
-  memset(&hints, 0, sizeof(struct addrinfo));
-  hints.ai_family = AF_UNSPEC;
-  hints.ai_socktype = SOCK_STREAM;
-  hints.ai_protocol = 0;
+	memset(&hints, 0, sizeof(struct addrinfo));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = 0;
 
-  if (getaddrinfo(hostname.c_str(), nullptr, &hints, &result)) {
+	if (getaddrinfo(hostname.c_str(), nullptr, &hints, &result)) {
 #if defined __linux__ && !defined __ANDROID__
-    res_init();
+		res_init();
 #endif
-    return;
-  }
+		return;
+	}
 
-  for (auto rp = result; rp; rp = rp->ai_next) {
-    const auto &addr =
-        *reinterpret_cast<struct sockaddr_storage *>(rp->ai_addr);
-    std::string ip;
-    auto dummy = -1;
-    if (detail::get_ip_and_port(addr, sizeof(struct sockaddr_storage), ip,
-                                dummy)) {
-      addrs.push_back(ip);
-    }
-  }
+	for (auto rp = result; rp; rp = rp->ai_next) {
+		const auto &addr = *reinterpret_cast<struct sockaddr_storage *>(rp->ai_addr);
+		std::string ip;
+		auto dummy = -1;
+		if (detail::get_ip_and_port(addr, sizeof(struct sockaddr_storage), ip, dummy)) {
+			addrs.push_back(ip);
+		}
+	}
 
-  freeaddrinfo(result);
+	freeaddrinfo(result);
 }
 
-inline std::string append_query_params(const std::string &path,
-                                       const Params &params) {
-  std::string path_with_query = path;
-  const Regex re("[^?]+\\?.*");
-  auto delm = RegexMatch(path, re) ? '&' : '?';
-  path_with_query += delm + detail::params_to_query_str(params);
-  return path_with_query;
+inline std::string append_query_params(const std::string &path, const Params &params) {
+	std::string path_with_query = path;
+	const Regex re("[^?]+\\?.*");
+	auto delm = RegexMatch(path, re) ? '&' : '?';
+	path_with_query += delm + detail::params_to_query_str(params);
+	return path_with_query;
 }
 
 // Header utilities
 inline std::pair<std::string, std::string> make_range_header(Ranges ranges) {
-  std::string field = "bytes=";
-  auto i = 0;
-  for (auto r : ranges) {
-    if (i != 0) { field += ", "; }
-    if (r.first != -1) { field += std::to_string(r.first); }
-    field += '-';
-    if (r.second != -1) { field += std::to_string(r.second); }
-    i++;
-  }
-  return std::make_pair("Range", std::move(field));
+	std::string field = "bytes=";
+	auto i = 0;
+	for (auto r : ranges) {
+		if (i != 0) {
+			field += ", ";
+		}
+		if (r.first != -1) {
+			field += std::to_string(r.first);
+		}
+		field += '-';
+		if (r.second != -1) {
+			field += std::to_string(r.second);
+		}
+		i++;
+	}
+	return std::make_pair("Range", std::move(field));
 }
 
 inline std::pair<std::string, std::string>
-make_basic_authentication_header(const std::string &username,
-                                 const std::string &password, bool is_proxy) {
-  auto field = "Basic " + detail::base64_encode(username + ":" + password);
-  auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
-  return std::make_pair(key, std::move(field));
+make_basic_authentication_header(const std::string &username, const std::string &password, bool is_proxy) {
+	auto field = "Basic " + detail::base64_encode(username + ":" + password);
+	auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
+	return std::make_pair(key, std::move(field));
 }
 
-inline std::pair<std::string, std::string>
-make_bearer_token_authentication_header(const std::string &token,
-                                        bool is_proxy = false) {
-  auto field = "Bearer " + token;
-  auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
-  return std::make_pair(key, std::move(field));
+inline std::pair<std::string, std::string> make_bearer_token_authentication_header(const std::string &token,
+                                                                                   bool is_proxy = false) {
+	auto field = "Bearer " + token;
+	auto key = is_proxy ? "Proxy-Authorization" : "Authorization";
+	return std::make_pair(key, std::move(field));
 }
 
 // Request implementation
 inline bool Request::has_header(const std::string &key) const {
-  return detail::has_header(headers, key);
+	return detail::has_header(headers, key);
 }
 
-inline std::string Request::get_header_value(const std::string &key,
-                                             size_t id) const {
-  return detail::get_header_value(headers, key, id, "");
+inline std::string Request::get_header_value(const std::string &key, size_t id) const {
+	return detail::get_header_value(headers, key, id, "");
 }
 
 inline size_t Request::get_header_value_count(const std::string &key) const {
-  auto r = headers.equal_range(key);
-  return static_cast<size_t>(std::distance(r.first, r.second));
+	auto r = headers.equal_range(key);
+	return static_cast<size_t>(std::distance(r.first, r.second));
 }
 
-inline void Request::set_header(const std::string &key,
-                                const std::string &val) {
-  if (!detail::has_crlf(key) && !detail::has_crlf(val)) {
-    headers.emplace(key, val);
-  }
+inline void Request::set_header(const std::string &key, const std::string &val) {
+	if (!detail::has_crlf(key) && !detail::has_crlf(val)) {
+		headers.emplace(key, val);
+	}
 }
 
 inline bool Request::has_param(const std::string &key) const {
-  return params.find(key) != params.end();
+	return params.find(key) != params.end();
 }
 
-inline std::string Request::get_param_value(const std::string &key,
-                                            size_t id) const {
-  auto rng = params.equal_range(key);
-  auto it = rng.first;
-  std::advance(it, static_cast<ssize_t>(id));
-  if (it != rng.second) { return it->second; }
-  return std::string();
+inline std::string Request::get_param_value(const std::string &key, size_t id) const {
+	auto rng = params.equal_range(key);
+	auto it = rng.first;
+	std::advance(it, static_cast<ssize_t>(id));
+	if (it != rng.second) {
+		return it->second;
+	}
+	return std::string();
 }
 
 inline size_t Request::get_param_value_count(const std::string &key) const {
-  auto r = params.equal_range(key);
-  return static_cast<size_t>(std::distance(r.first, r.second));
+	auto r = params.equal_range(key);
+	return static_cast<size_t>(std::distance(r.first, r.second));
 }
 
 inline bool Request::is_multipart_form_data() const {
-  const auto &content_type = get_header_value("Content-Type");
-  return !content_type.rfind("multipart/form-data", 0);
+	const auto &content_type = get_header_value("Content-Type");
+	return !content_type.rfind("multipart/form-data", 0);
 }
 
 inline bool Request::has_file(const std::string &key) const {
-  return files.find(key) != files.end();
+	return files.find(key) != files.end();
 }
 
 inline MultipartFormData Request::get_file_value(const std::string &key) const {
-  auto it = files.find(key);
-  if (it != files.end()) { return it->second; }
-  return MultipartFormData();
+	auto it = files.find(key);
+	if (it != files.end()) {
+		return it->second;
+	}
+	return MultipartFormData();
 }
 
-inline std::vector<MultipartFormData>
-Request::get_file_values(const std::string &key) const {
-  std::vector<MultipartFormData> values;
-  auto rng = files.equal_range(key);
-  for (auto it = rng.first; it != rng.second; it++) {
-    values.push_back(it->second);
-  }
-  return values;
+inline std::vector<MultipartFormData> Request::get_file_values(const std::string &key) const {
+	std::vector<MultipartFormData> values;
+	auto rng = files.equal_range(key);
+	for (auto it = rng.first; it != rng.second; it++) {
+		values.push_back(it->second);
+	}
+	return values;
 }
 
 // Response implementation
 inline bool Response::has_header(const std::string &key) const {
-  return headers.find(key) != headers.end();
+	return headers.find(key) != headers.end();
 }
 
-inline std::string Response::get_header_value(const std::string &key,
-                                              size_t id) const {
-  return detail::get_header_value(headers, key, id, "");
+inline std::string Response::get_header_value(const std::string &key, size_t id) const {
+	return detail::get_header_value(headers, key, id, "");
 }
 
 inline size_t Response::get_header_value_count(const std::string &key) const {
-  auto r = headers.equal_range(key);
-  return static_cast<size_t>(std::distance(r.first, r.second));
+	auto r = headers.equal_range(key);
+	return static_cast<size_t>(std::distance(r.first, r.second));
 }
 
-inline void Response::set_header(const std::string &key,
-                                 const std::string &val) {
-  if (!detail::has_crlf(key) && !detail::has_crlf(val)) {
-    headers.emplace(key, val);
-  }
+inline void Response::set_header(const std::string &key, const std::string &val) {
+	if (!detail::has_crlf(key) && !detail::has_crlf(val)) {
+		headers.emplace(key, val);
+	}
 }
 
 inline void Response::set_redirect(const std::string &url, int stat) {
-  if (!detail::has_crlf(url)) {
-    set_header("Location", url);
-    if (300 <= stat && stat < 400) {
-      this->status = stat;
-    } else {
-      this->status = StatusCode::Found_302;
-    }
-  }
+	if (!detail::has_crlf(url)) {
+		set_header("Location", url);
+		if (300 <= stat && stat < 400) {
+			this->status = stat;
+		} else {
+			this->status = StatusCode::Found_302;
+		}
+	}
 }
 
-inline void Response::set_content(const char *s, size_t n,
-                                  const std::string &content_type) {
-  body.assign(s, n);
+inline void Response::set_content(const char *s, size_t n, const std::string &content_type) {
+	body.assign(s, n);
 
-  auto rng = headers.equal_range("Content-Type");
-  headers.erase(rng.first, rng.second);
-  set_header("Content-Type", content_type);
+	auto rng = headers.equal_range("Content-Type");
+	headers.erase(rng.first, rng.second);
+	set_header("Content-Type", content_type);
 }
 
-inline void Response::set_content(const std::string &s,
-                                  const std::string &content_type) {
-  set_content(s.data(), s.size(), content_type);
+inline void Response::set_content(const std::string &s, const std::string &content_type) {
+	set_content(s.data(), s.size(), content_type);
 }
 
-inline void Response::set_content_provider(
-    size_t in_length, const std::string &content_type, ContentProvider provider,
-    ContentProviderResourceReleaser resource_releaser) {
-  set_header("Content-Type", content_type);
-  content_length_ = in_length;
-  if (in_length > 0) { content_provider_ = std::move(provider); }
-  content_provider_resource_releaser_ = resource_releaser;
-  is_chunked_content_provider_ = false;
+inline void Response::set_content_provider(size_t in_length, const std::string &content_type, ContentProvider provider,
+                                           ContentProviderResourceReleaser resource_releaser) {
+	set_header("Content-Type", content_type);
+	content_length_ = in_length;
+	if (in_length > 0) {
+		content_provider_ = std::move(provider);
+	}
+	content_provider_resource_releaser_ = resource_releaser;
+	is_chunked_content_provider_ = false;
 }
 
-inline void Response::set_content_provider(
-    const std::string &content_type, ContentProviderWithoutLength provider,
-    ContentProviderResourceReleaser resource_releaser) {
-  set_header("Content-Type", content_type);
-  content_length_ = 0;
-  content_provider_ = detail::ContentProviderAdapter(std::move(provider));
-  content_provider_resource_releaser_ = resource_releaser;
-  is_chunked_content_provider_ = false;
+inline void Response::set_content_provider(const std::string &content_type, ContentProviderWithoutLength provider,
+                                           ContentProviderResourceReleaser resource_releaser) {
+	set_header("Content-Type", content_type);
+	content_length_ = 0;
+	content_provider_ = detail::ContentProviderAdapter(std::move(provider));
+	content_provider_resource_releaser_ = resource_releaser;
+	is_chunked_content_provider_ = false;
 }
 
-inline void Response::set_chunked_content_provider(
-    const std::string &content_type, ContentProviderWithoutLength provider,
-    ContentProviderResourceReleaser resource_releaser) {
-  set_header("Content-Type", content_type);
-  content_length_ = 0;
-  content_provider_ = detail::ContentProviderAdapter(std::move(provider));
-  content_provider_resource_releaser_ = resource_releaser;
-  is_chunked_content_provider_ = true;
+inline void Response::set_chunked_content_provider(const std::string &content_type,
+                                                   ContentProviderWithoutLength provider,
+                                                   ContentProviderResourceReleaser resource_releaser) {
+	set_header("Content-Type", content_type);
+	content_length_ = 0;
+	content_provider_ = detail::ContentProviderAdapter(std::move(provider));
+	content_provider_resource_releaser_ = resource_releaser;
+	is_chunked_content_provider_ = true;
 }
 
 // Result implementation
 inline bool Result::has_request_header(const std::string &key) const {
-  return request_headers_.find(key) != request_headers_.end();
+	return request_headers_.find(key) != request_headers_.end();
 }
 
-inline std::string Result::get_request_header_value(const std::string &key,
-                                                    size_t id) const {
-  return detail::get_header_value(request_headers_, key, id, "");
+inline std::string Result::get_request_header_value(const std::string &key, size_t id) const {
+	return detail::get_header_value(request_headers_, key, id, "");
 }
 
-inline size_t
-Result::get_request_header_value_count(const std::string &key) const {
-  auto r = request_headers_.equal_range(key);
-  return static_cast<size_t>(std::distance(r.first, r.second));
+inline size_t Result::get_request_header_value_count(const std::string &key) const {
+	auto r = request_headers_.equal_range(key);
+	return static_cast<size_t>(std::distance(r.first, r.second));
 }
 
 // Stream implementation
 inline ssize_t Stream::write(const char *ptr) {
-  return write(ptr, strlen(ptr));
+	return write(ptr, strlen(ptr));
 }
 
 inline ssize_t Stream::write(const std::string &s) {
-  return write(s.data(), s.size());
+	return write(s.data(), s.size());
 }
 
 namespace detail {
 
 // Socket stream implementation
-inline SocketStream::SocketStream(socket_t sock, time_t read_timeout_sec,
-                                  time_t read_timeout_usec,
-                                  time_t write_timeout_sec,
-                                  time_t write_timeout_usec)
-    : sock_(sock), read_timeout_sec_(read_timeout_sec),
-      read_timeout_usec_(read_timeout_usec),
-      write_timeout_sec_(write_timeout_sec),
-      write_timeout_usec_(write_timeout_usec), read_buff_(read_buff_size_, 0) {}
+inline SocketStream::SocketStream(socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec,
+                                  time_t write_timeout_sec, time_t write_timeout_usec)
+    : sock_(sock), read_timeout_sec_(read_timeout_sec), read_timeout_usec_(read_timeout_usec),
+      write_timeout_sec_(write_timeout_sec), write_timeout_usec_(write_timeout_usec), read_buff_(read_buff_size_, 0) {
+}
 
 inline SocketStream::~SocketStream() = default;
 
 inline bool SocketStream::is_readable() const {
-  return select_read(sock_, read_timeout_sec_, read_timeout_usec_) > 0;
+	return select_read(sock_, read_timeout_sec_, read_timeout_usec_) > 0;
 }
 
 inline bool SocketStream::is_writable() const {
-  return select_write(sock_, write_timeout_sec_, write_timeout_usec_) > 0 &&
-         is_socket_alive(sock_);
+	return select_write(sock_, write_timeout_sec_, write_timeout_usec_) > 0 && is_socket_alive(sock_);
 }
 
 inline ssize_t SocketStream::read(char *ptr, size_t size) {
 #ifdef _WIN32
-  size =
-      (std::min)(size, static_cast<size_t>((std::numeric_limits<int>::max)()));
+	size = (std::min)(size, static_cast<size_t>((std::numeric_limits<int>::max)()));
 #else
-  size = (std::min)(size,
-                    static_cast<size_t>((std::numeric_limits<ssize_t>::max)()));
+	size = (std::min)(size, static_cast<size_t>((std::numeric_limits<ssize_t>::max)()));
 #endif
 
-  if (read_buff_off_ < read_buff_content_size_) {
-    auto remaining_size = read_buff_content_size_ - read_buff_off_;
-    if (size <= remaining_size) {
-      memcpy(ptr, read_buff_.data() + read_buff_off_, size);
-      read_buff_off_ += size;
-      return static_cast<ssize_t>(size);
-    } else {
-      memcpy(ptr, read_buff_.data() + read_buff_off_, remaining_size);
-      read_buff_off_ += remaining_size;
-      return static_cast<ssize_t>(remaining_size);
-    }
-  }
+	if (read_buff_off_ < read_buff_content_size_) {
+		auto remaining_size = read_buff_content_size_ - read_buff_off_;
+		if (size <= remaining_size) {
+			memcpy(ptr, read_buff_.data() + read_buff_off_, size);
+			read_buff_off_ += size;
+			return static_cast<ssize_t>(size);
+		} else {
+			memcpy(ptr, read_buff_.data() + read_buff_off_, remaining_size);
+			read_buff_off_ += remaining_size;
+			return static_cast<ssize_t>(remaining_size);
+		}
+	}
 
-  if (!is_readable()) { return -1; }
+	if (!is_readable()) {
+		return -1;
+	}
 
-  read_buff_off_ = 0;
-  read_buff_content_size_ = 0;
+	read_buff_off_ = 0;
+	read_buff_content_size_ = 0;
 
-  if (size < read_buff_size_) {
-    auto n = read_socket(sock_, read_buff_.data(), read_buff_size_,
-                         CPPHTTPLIB_RECV_FLAGS);
-    if (n <= 0) {
-      return n;
-    } else if (n <= static_cast<ssize_t>(size)) {
-      memcpy(ptr, read_buff_.data(), static_cast<size_t>(n));
-      return n;
-    } else {
-      memcpy(ptr, read_buff_.data(), size);
-      read_buff_off_ = size;
-      read_buff_content_size_ = static_cast<size_t>(n);
-      return static_cast<ssize_t>(size);
-    }
-  } else {
-    return read_socket(sock_, ptr, size, CPPHTTPLIB_RECV_FLAGS);
-  }
+	if (size < read_buff_size_) {
+		auto n = read_socket(sock_, read_buff_.data(), read_buff_size_, CPPHTTPLIB_RECV_FLAGS);
+		if (n <= 0) {
+			return n;
+		} else if (n <= static_cast<ssize_t>(size)) {
+			memcpy(ptr, read_buff_.data(), static_cast<size_t>(n));
+			return n;
+		} else {
+			memcpy(ptr, read_buff_.data(), size);
+			read_buff_off_ = size;
+			read_buff_content_size_ = static_cast<size_t>(n);
+			return static_cast<ssize_t>(size);
+		}
+	} else {
+		return read_socket(sock_, ptr, size, CPPHTTPLIB_RECV_FLAGS);
+	}
 }
 
 inline ssize_t SocketStream::write(const char *ptr, size_t size) {
-  if (!is_writable()) { return -1; }
+	if (!is_writable()) {
+		return -1;
+	}
 
 #if defined(_WIN32) && !defined(_WIN64)
-  size =
-      (std::min)(size, static_cast<size_t>((std::numeric_limits<int>::max)()));
+	size = (std::min)(size, static_cast<size_t>((std::numeric_limits<int>::max)()));
 #endif
 
-  return send_socket(sock_, ptr, size, CPPHTTPLIB_SEND_FLAGS);
+	return send_socket(sock_, ptr, size, CPPHTTPLIB_SEND_FLAGS);
 }
 
-inline void SocketStream::get_remote_ip_and_port(std::string &ip,
-                                                 int &port) const {
-  return detail::get_remote_ip_and_port(sock_, ip, port);
+inline void SocketStream::get_remote_ip_and_port(std::string &ip, int &port) const {
+	return detail::get_remote_ip_and_port(sock_, ip, port);
 }
 
-inline void SocketStream::get_local_ip_and_port(std::string &ip,
-                                                int &port) const {
-  return detail::get_local_ip_and_port(sock_, ip, port);
+inline void SocketStream::get_local_ip_and_port(std::string &ip, int &port) const {
+	return detail::get_local_ip_and_port(sock_, ip, port);
 }
 
-inline socket_t SocketStream::socket() const { return sock_; }
+inline socket_t SocketStream::socket() const {
+	return sock_;
+}
 
 // Buffer stream implementation
-inline bool BufferStream::is_readable() const { return true; }
+inline bool BufferStream::is_readable() const {
+	return true;
+}
 
-inline bool BufferStream::is_writable() const { return true; }
+inline bool BufferStream::is_writable() const {
+	return true;
+}
 
 inline ssize_t BufferStream::read(char *ptr, size_t size) {
 #if defined(_MSC_VER) && _MSC_VER < 1910
-  auto len_read = buffer._Copy_s(ptr, size, size, position);
+	auto len_read = buffer._Copy_s(ptr, size, size, position);
 #else
-  auto len_read = buffer.copy(ptr, size, position);
+	auto len_read = buffer.copy(ptr, size, position);
 #endif
-  position += static_cast<size_t>(len_read);
-  return static_cast<ssize_t>(len_read);
+	position += static_cast<size_t>(len_read);
+	return static_cast<ssize_t>(len_read);
 }
 
 inline ssize_t BufferStream::write(const char *ptr, size_t size) {
-  buffer.append(ptr, size);
-  return static_cast<ssize_t>(size);
+	buffer.append(ptr, size);
+	return static_cast<ssize_t>(size);
 }
 
-inline void BufferStream::get_remote_ip_and_port(std::string & /*ip*/,
-                                                 int & /*port*/) const {}
+inline void BufferStream::get_remote_ip_and_port(std::string & /*ip*/, int & /*port*/) const {
+}
 
-inline void BufferStream::get_local_ip_and_port(std::string & /*ip*/,
-                                                int & /*port*/) const {}
+inline void BufferStream::get_local_ip_and_port(std::string & /*ip*/, int & /*port*/) const {
+}
 
-inline socket_t BufferStream::socket() const { return 0; }
+inline socket_t BufferStream::socket() const {
+	return 0;
+}
 
-inline const std::string &BufferStream::get_buffer() const { return buffer; }
+inline const std::string &BufferStream::get_buffer() const {
+	return buffer;
+}
 
 inline PathParamsMatcher::PathParamsMatcher(const std::string &pattern) {
-  // One past the last ending position of a path param substring
-  std::size_t last_param_end = 0;
+	// One past the last ending position of a path param substring
+	std::size_t last_param_end = 0;
 
 #ifndef CPPHTTPLIB_NO_EXCEPTIONS
-  // Needed to ensure that parameter names are unique during matcher
-  // construction
-  // If exceptions are disabled, only last duplicate path
-  // parameter will be set
-  std::unordered_set<std::string> param_name_set;
+	// Needed to ensure that parameter names are unique during matcher
+	// construction
+	// If exceptions are disabled, only last duplicate path
+	// parameter will be set
+	std::unordered_set<std::string> param_name_set;
 #endif
 
-  while (true) {
-    const auto marker_pos = pattern.find(marker, last_param_end);
-    if (marker_pos == std::string::npos) { break; }
+	while (true) {
+		const auto marker_pos = pattern.find(marker, last_param_end);
+		if (marker_pos == std::string::npos) {
+			break;
+		}
 
-    static_fragments_.push_back(
-        pattern.substr(last_param_end, marker_pos - last_param_end));
+		static_fragments_.push_back(pattern.substr(last_param_end, marker_pos - last_param_end));
 
-    const auto param_name_start = marker_pos + 1;
+		const auto param_name_start = marker_pos + 1;
 
-    auto sep_pos = pattern.find(separator, param_name_start);
-    if (sep_pos == std::string::npos) { sep_pos = pattern.length(); }
+		auto sep_pos = pattern.find(separator, param_name_start);
+		if (sep_pos == std::string::npos) {
+			sep_pos = pattern.length();
+		}
 
-    auto param_name =
-        pattern.substr(param_name_start, sep_pos - param_name_start);
+		auto param_name = pattern.substr(param_name_start, sep_pos - param_name_start);
 
 #ifndef CPPHTTPLIB_NO_EXCEPTIONS
-    if (param_name_set.find(param_name) != param_name_set.cend()) {
-      std::string msg = "Encountered path parameter '" + param_name +
-                        "' multiple times in route pattern '" + pattern + "'.";
-      throw std::invalid_argument(msg);
-    }
+		if (param_name_set.find(param_name) != param_name_set.cend()) {
+			std::string msg =
+			    "Encountered path parameter '" + param_name + "' multiple times in route pattern '" + pattern + "'.";
+			throw std::invalid_argument(msg);
+		}
 #endif
 
-    param_names_.push_back(std::move(param_name));
+		param_names_.push_back(std::move(param_name));
 
-    last_param_end = sep_pos + 1;
-  }
+		last_param_end = sep_pos + 1;
+	}
 
-  if (last_param_end < pattern.length()) {
-    static_fragments_.push_back(pattern.substr(last_param_end));
-  }
+	if (last_param_end < pattern.length()) {
+		static_fragments_.push_back(pattern.substr(last_param_end));
+	}
 }
 
 inline bool PathParamsMatcher::match(Request &request) const {
-  request.matches = Match();
-  request.path_params.clear();
-  request.path_params.reserve(param_names_.size());
+	request.matches = Match();
+	request.path_params.clear();
+	request.path_params.reserve(param_names_.size());
 
-  // One past the position at which the path matched the pattern last time
-  std::size_t starting_pos = 0;
-  for (size_t i = 0; i < static_fragments_.size(); ++i) {
-    const auto &fragment = static_fragments_[i];
+	// One past the position at which the path matched the pattern last time
+	std::size_t starting_pos = 0;
+	for (size_t i = 0; i < static_fragments_.size(); ++i) {
+		const auto &fragment = static_fragments_[i];
 
-    if (starting_pos + fragment.length() > request.path.length()) {
-      return false;
-    }
+		if (starting_pos + fragment.length() > request.path.length()) {
+			return false;
+		}
 
-    // Avoid unnecessary allocation by using strncmp instead of substr +
-    // comparison
-    if (std::strncmp(request.path.c_str() + starting_pos, fragment.c_str(),
-                     fragment.length()) != 0) {
-      return false;
-    }
+		// Avoid unnecessary allocation by using strncmp instead of substr +
+		// comparison
+		if (std::strncmp(request.path.c_str() + starting_pos, fragment.c_str(), fragment.length()) != 0) {
+			return false;
+		}
 
-    starting_pos += fragment.length();
+		starting_pos += fragment.length();
 
-    // Should only happen when we have a static fragment after a param
-    // Example: '/users/:id/subscriptions'
-    // The 'subscriptions' fragment here does not have a corresponding param
-    if (i >= param_names_.size()) { continue; }
+		// Should only happen when we have a static fragment after a param
+		// Example: '/users/:id/subscriptions'
+		// The 'subscriptions' fragment here does not have a corresponding param
+		if (i >= param_names_.size()) {
+			continue;
+		}
 
-    auto sep_pos = request.path.find(separator, starting_pos);
-    if (sep_pos == std::string::npos) { sep_pos = request.path.length(); }
+		auto sep_pos = request.path.find(separator, starting_pos);
+		if (sep_pos == std::string::npos) {
+			sep_pos = request.path.length();
+		}
 
-    const auto &param_name = param_names_[i];
+		const auto &param_name = param_names_[i];
 
-    request.path_params.emplace(
-        param_name, request.path.substr(starting_pos, sep_pos - starting_pos));
+		request.path_params.emplace(param_name, request.path.substr(starting_pos, sep_pos - starting_pos));
 
-    // Mark everythin up to '/' as matched
-    starting_pos = sep_pos + 1;
-  }
-  // Returns false if the path is longer than the pattern
-  return starting_pos >= request.path.length();
+		// Mark everythin up to '/' as matched
+		starting_pos = sep_pos + 1;
+	}
+	// Returns false if the path is longer than the pattern
+	return starting_pos >= request.path.length();
 }
 
 inline bool RegexMatcher::match(Request &request) const {
-  request.path_params.clear();
-  return RegexMatch(request.path, request.matches, regex_);
+	request.path_params.clear();
+	return RegexMatch(request.path, request.matches, regex_);
 }
 
 } // namespace detail
 
 // HTTP server implementation
-inline Server::Server()
-    : new_task_queue(
-          [] { return new ThreadPool(CPPHTTPLIB_THREAD_POOL_COUNT); }) {
+inline Server::Server() : new_task_queue([] { return new ThreadPool(CPPHTTPLIB_THREAD_POOL_COUNT); }) {
 #ifndef _WIN32
-  signal(SIGPIPE, SIG_IGN);
+	signal(SIGPIPE, SIG_IGN);
 #endif
 }
 
 inline Server::~Server() = default;
 
-inline duckdb::unique_ptr<detail::MatcherBase>
-Server::make_matcher(const std::string &pattern) {
-  if (pattern.find("/:") != std::string::npos) {
-    return detail::make_unique<detail::PathParamsMatcher>(pattern);
-  } else {
-    return detail::make_unique<detail::RegexMatcher>(pattern);
-  }
+inline duckdb::unique_ptr<detail::MatcherBase> Server::make_matcher(const std::string &pattern) {
+	if (pattern.find("/:") != std::string::npos) {
+		return detail::make_unique<detail::PathParamsMatcher>(pattern);
+	} else {
+		return detail::make_unique<detail::RegexMatcher>(pattern);
+	}
 }
 
 inline Server &Server::Get(const std::string &pattern, Handler handler) {
-  get_handlers_.emplace_back(Regex(pattern), std::move(handler));
-  return *this;
+	get_handlers_.emplace_back(Regex(pattern), std::move(handler));
+	return *this;
 }
 
 inline Server &Server::Post(const std::string &pattern, Handler handler) {
-  post_handlers_.emplace_back(Regex(pattern), std::move(handler));
-  return *this;
+	post_handlers_.emplace_back(Regex(pattern), std::move(handler));
+	return *this;
 }
 
-inline Server &Server::Post(const std::string &pattern,
-                            HandlerWithContentReader handler) {
-  post_handlers_for_content_reader_.emplace_back(Regex(pattern),
-                                                 std::move(handler));
-  return *this;
+inline Server &Server::Post(const std::string &pattern, HandlerWithContentReader handler) {
+	post_handlers_for_content_reader_.emplace_back(Regex(pattern), std::move(handler));
+	return *this;
 }
 
 inline Server &Server::Put(const std::string &pattern, Handler handler) {
-  put_handlers_.emplace_back(Regex(pattern), std::move(handler));
-  return *this;
+	put_handlers_.emplace_back(Regex(pattern), std::move(handler));
+	return *this;
 }
 
-inline Server &Server::Put(const std::string &pattern,
-                           HandlerWithContentReader handler) {
-  put_handlers_for_content_reader_.emplace_back(Regex(pattern),
-                                                std::move(handler));
-  return *this;
+inline Server &Server::Put(const std::string &pattern, HandlerWithContentReader handler) {
+	put_handlers_for_content_reader_.emplace_back(Regex(pattern), std::move(handler));
+	return *this;
 }
 
 inline Server &Server::Patch(const std::string &pattern, Handler handler) {
-  patch_handlers_.emplace_back(Regex(pattern), std::move(handler));
-  return *this;
+	patch_handlers_.emplace_back(Regex(pattern), std::move(handler));
+	return *this;
 }
 
-inline Server &Server::Patch(const std::string &pattern,
-                             HandlerWithContentReader handler) {
-  patch_handlers_for_content_reader_.emplace_back(Regex(pattern),
-                                                  std::move(handler));
-  return *this;
+inline Server &Server::Patch(const std::string &pattern, HandlerWithContentReader handler) {
+	patch_handlers_for_content_reader_.emplace_back(Regex(pattern), std::move(handler));
+	return *this;
 }
 
 inline Server &Server::Delete(const std::string &pattern, Handler handler) {
-  delete_handlers_.emplace_back(Regex(pattern), std::move(handler));
-  return *this;
+	delete_handlers_.emplace_back(Regex(pattern), std::move(handler));
+	return *this;
 }
 
-inline Server &Server::Delete(const std::string &pattern,
-                              HandlerWithContentReader handler) {
-  delete_handlers_for_content_reader_.emplace_back(Regex(pattern),
-                                                   std::move(handler));
-  return *this;
+inline Server &Server::Delete(const std::string &pattern, HandlerWithContentReader handler) {
+	delete_handlers_for_content_reader_.emplace_back(Regex(pattern), std::move(handler));
+	return *this;
 }
 
 inline Server &Server::Options(const std::string &pattern, Handler handler) {
-  options_handlers_.emplace_back(Regex(pattern), std::move(handler));
-  return *this;
+	options_handlers_.emplace_back(Regex(pattern), std::move(handler));
+	return *this;
 }
 
-inline bool Server::set_base_dir(const std::string &dir,
-                                 const std::string &mount_point) {
-  return set_mount_point(mount_point, dir);
+inline bool Server::set_base_dir(const std::string &dir, const std::string &mount_point) {
+	return set_mount_point(mount_point, dir);
 }
 
-inline bool Server::set_mount_point(const std::string &mount_point,
-                                    const std::string &dir, Headers headers) {
-  if (detail::is_dir(dir)) {
-    std::string mnt = !mount_point.empty() ? mount_point : "/";
-    if (!mnt.empty() && mnt[0] == '/') {
-      base_dirs_.push_back({mnt, dir, std::move(headers)});
-      return true;
-    }
-  }
-  return false;
+inline bool Server::set_mount_point(const std::string &mount_point, const std::string &dir, Headers headers) {
+	if (detail::is_dir(dir)) {
+		std::string mnt = !mount_point.empty() ? mount_point : "/";
+		if (!mnt.empty() && mnt[0] == '/') {
+			base_dirs_.push_back({mnt, dir, std::move(headers)});
+			return true;
+		}
+	}
+	return false;
 }
 
 inline bool Server::remove_mount_point(const std::string &mount_point) {
-  for (auto it = base_dirs_.begin(); it != base_dirs_.end(); ++it) {
-    if (it->mount_point == mount_point) {
-      base_dirs_.erase(it);
-      return true;
-    }
-  }
-  return false;
+	for (auto it = base_dirs_.begin(); it != base_dirs_.end(); ++it) {
+		if (it->mount_point == mount_point) {
+			base_dirs_.erase(it);
+			return true;
+		}
+	}
+	return false;
 }
 
-inline Server &
-Server::set_file_extension_and_mimetype_mapping(const std::string &ext,
-                                                const std::string &mime) {
-  file_extension_and_mimetype_map_[ext] = mime;
-  return *this;
+inline Server &Server::set_file_extension_and_mimetype_mapping(const std::string &ext, const std::string &mime) {
+	file_extension_and_mimetype_map_[ext] = mime;
+	return *this;
 }
 
 inline Server &Server::set_default_file_mimetype(const std::string &mime) {
-  default_file_mimetype_ = mime;
-  return *this;
+	default_file_mimetype_ = mime;
+	return *this;
 }
 
 inline Server &Server::set_file_request_handler(Handler handler) {
-  file_request_handler_ = std::move(handler);
-  return *this;
+	file_request_handler_ = std::move(handler);
+	return *this;
 }
 
 inline Server &Server::set_error_handler(HandlerWithResponse handler) {
-  error_handler_ = std::move(handler);
-  return *this;
+	error_handler_ = std::move(handler);
+	return *this;
 }
 
 inline Server &Server::set_error_handler(Handler handler) {
-  error_handler_ = [handler](const Request &req, Response &res) {
-    handler(req, res);
-    return HandlerResponse::Handled;
-  };
-  return *this;
+	error_handler_ = [handler](const Request &req, Response &res) {
+		handler(req, res);
+		return HandlerResponse::Handled;
+	};
+	return *this;
 }
 
 inline Server &Server::set_exception_handler(ExceptionHandler handler) {
-  exception_handler_ = std::move(handler);
-  return *this;
+	exception_handler_ = std::move(handler);
+	return *this;
 }
 
 inline Server &Server::set_pre_routing_handler(HandlerWithResponse handler) {
-  pre_routing_handler_ = std::move(handler);
-  return *this;
+	pre_routing_handler_ = std::move(handler);
+	return *this;
 }
 
 inline Server &Server::set_post_routing_handler(Handler handler) {
-  post_routing_handler_ = std::move(handler);
-  return *this;
+	post_routing_handler_ = std::move(handler);
+	return *this;
 }
 
 inline Server &Server::set_logger(Logger logger) {
-  logger_ = std::move(logger);
-  return *this;
+	logger_ = std::move(logger);
+	return *this;
 }
 
-inline Server &
-Server::set_expect_100_continue_handler(Expect100ContinueHandler handler) {
-  expect_100_continue_handler_ = std::move(handler);
-  return *this;
+inline Server &Server::set_expect_100_continue_handler(Expect100ContinueHandler handler) {
+	expect_100_continue_handler_ = std::move(handler);
+	return *this;
 }
 
 inline Server &Server::set_address_family(int family) {
-  address_family_ = family;
-  return *this;
+	address_family_ = family;
+	return *this;
 }
 
 inline Server &Server::set_tcp_nodelay(bool on) {
-  tcp_nodelay_ = on;
-  return *this;
+	tcp_nodelay_ = on;
+	return *this;
 }
 
 inline Server &Server::set_socket_options(SocketOptions socket_options) {
-  socket_options_ = std::move(socket_options);
-  return *this;
+	socket_options_ = std::move(socket_options);
+	return *this;
 }
 
 inline Server &Server::set_default_headers(Headers headers) {
-  default_headers_ = std::move(headers);
-  return *this;
+	default_headers_ = std::move(headers);
+	return *this;
 }
 
-inline Server &Server::set_header_writer(
-    std::function<ssize_t(Stream &, Headers &)> const &writer) {
-  header_writer_ = writer;
-  return *this;
+inline Server &Server::set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer) {
+	header_writer_ = writer;
+	return *this;
 }
 
 inline Server &Server::set_keep_alive_max_count(size_t count) {
-  keep_alive_max_count_ = count;
-  return *this;
+	keep_alive_max_count_ = count;
+	return *this;
 }
 
 inline Server &Server::set_keep_alive_timeout(time_t sec) {
-  keep_alive_timeout_sec_ = sec;
-  return *this;
+	keep_alive_timeout_sec_ = sec;
+	return *this;
 }
 
 inline Server &Server::set_read_timeout(time_t sec, time_t usec) {
-  read_timeout_sec_ = sec;
-  read_timeout_usec_ = usec;
-  return *this;
+	read_timeout_sec_ = sec;
+	read_timeout_usec_ = usec;
+	return *this;
 }
 
 inline Server &Server::set_write_timeout(time_t sec, time_t usec) {
-  write_timeout_sec_ = sec;
-  write_timeout_usec_ = usec;
-  return *this;
+	write_timeout_sec_ = sec;
+	write_timeout_usec_ = usec;
+	return *this;
 }
 
 inline Server &Server::set_idle_interval(time_t sec, time_t usec) {
-  idle_interval_sec_ = sec;
-  idle_interval_usec_ = usec;
-  return *this;
+	idle_interval_sec_ = sec;
+	idle_interval_usec_ = usec;
+	return *this;
 }
 
 inline Server &Server::set_payload_max_length(size_t length) {
-  payload_max_length_ = length;
-  return *this;
+	payload_max_length_ = length;
+	return *this;
 }
 
-inline bool Server::bind_to_port(const std::string &host, int port,
-                                 int socket_flags) {
-  return bind_internal(host, port, socket_flags) >= 0;
+inline bool Server::bind_to_port(const std::string &host, int port, int socket_flags) {
+	return bind_internal(host, port, socket_flags) >= 0;
 }
 inline int Server::bind_to_any_port(const std::string &host, int socket_flags) {
-  return bind_internal(host, 0, socket_flags);
+	return bind_internal(host, 0, socket_flags);
 }
 
 inline bool Server::listen_after_bind() {
-  auto se = detail::scope_exit([&]() { done_ = true; });
-  return listen_internal();
+	auto se = detail::scope_exit([&]() { done_ = true; });
+	return listen_internal();
 }
 
-inline bool Server::listen(const std::string &host, int port,
-                           int socket_flags) {
-  auto se = detail::scope_exit([&]() { done_ = true; });
-  return bind_to_port(host, port, socket_flags) && listen_internal();
+inline bool Server::listen(const std::string &host, int port, int socket_flags) {
+	auto se = detail::scope_exit([&]() { done_ = true; });
+	return bind_to_port(host, port, socket_flags) && listen_internal();
 }
 
-inline bool Server::is_running() const { return is_running_; }
+inline bool Server::is_running() const {
+	return is_running_;
+}
 
 inline void Server::wait_until_ready() const {
-  while (!is_running() && !done_) {
-    std::this_thread::sleep_for(std::chrono::milliseconds{1});
-  }
+	while (!is_running() && !done_) {
+		std::this_thread::sleep_for(std::chrono::milliseconds {1});
+	}
 }
 
 inline void Server::stop() {
-  if (is_running_) {
-    assert(svr_sock_ != INVALID_SOCKET);
-    std::atomic<socket_t> sock(svr_sock_.exchange(INVALID_SOCKET));
-    detail::shutdown_socket(sock);
-    detail::close_socket(sock);
-  }
+	if (is_running_) {
+		assert(svr_sock_ != INVALID_SOCKET);
+		std::atomic<socket_t> sock(svr_sock_.exchange(INVALID_SOCKET));
+		detail::shutdown_socket(sock);
+		detail::close_socket(sock);
+	}
 }
 
-static const std::set<std::string> SERVER_METHODS{
-	"GET",     "HEAD",    "POST",  "PUT",   "DELETE",
-	"CONNECT", "OPTIONS", "TRACE", "PATCH", "PRI"};
+static const std::set<std::string> SERVER_METHODS {"GET",     "HEAD",    "POST",  "PUT",   "DELETE",
+                                                   "CONNECT", "OPTIONS", "TRACE", "PATCH", "PRI"};
 
 inline bool Server::parse_request_line(const char *s, Request &req) const {
-  auto len = strlen(s);
-  if (len < 2 || s[len - 2] != '\r' || s[len - 1] != '\n') { return false; }
-  len -= 2;
+	auto len = strlen(s);
+	if (len < 2 || s[len - 2] != '\r' || s[len - 1] != '\n') {
+		return false;
+	}
+	len -= 2;
 
-  {
-    size_t count = 0;
+	{
+		size_t count = 0;
 
-    detail::split(s, s + len, ' ', [&](const char *b, const char *e) {
-      switch (count) {
-      case 0: req.method = std::string(b, e); break;
-      case 1: req.target = std::string(b, e); break;
-      case 2: req.version = std::string(b, e); break;
-      default: break;
-      }
-      count++;
-    });
+		detail::split(s, s + len, ' ', [&](const char *b, const char *e) {
+			switch (count) {
+			case 0:
+				req.method = std::string(b, e);
+				break;
+			case 1:
+				req.target = std::string(b, e);
+				break;
+			case 2:
+				req.version = std::string(b, e);
+				break;
+			default:
+				break;
+			}
+			count++;
+		});
 
-    if (count != 3) { return false; }
-  }
+		if (count != 3) {
+			return false;
+		}
+	}
 
-  if (SERVER_METHODS.find(req.method) == SERVER_METHODS.end()) { return false; }
+	if (SERVER_METHODS.find(req.method) == SERVER_METHODS.end()) {
+		return false;
+	}
 
-  if (req.version != "HTTP/1.1" && req.version != "HTTP/1.0") { return false; }
+	if (req.version != "HTTP/1.1" && req.version != "HTTP/1.0") {
+		return false;
+	}
 
-  {
-    // Skip URL fragment
-    for (size_t i = 0; i < req.target.size(); i++) {
-      if (req.target[i] == '#') {
-        req.target.erase(i);
-        break;
-      }
-    }
+	{
+		// Skip URL fragment
+		for (size_t i = 0; i < req.target.size(); i++) {
+			if (req.target[i] == '#') {
+				req.target.erase(i);
+				break;
+			}
+		}
 
-    size_t count = 0;
+		size_t count = 0;
 
-    detail::split(req.target.data(), req.target.data() + req.target.size(), '?',
-                  2, [&](const char *b, const char *e) {
-                    switch (count) {
-                    case 0:
-                      req.path = detail::decode_url(std::string(b, e), false);
-                      break;
-                    case 1: {
-                      if (e - b > 0) {
-                        detail::parse_query_text(std::string(b, e), req.params);
-                      }
-                      break;
-                    }
-                    default: break;
-                    }
-                    count++;
-                  });
+		detail::split(req.target.data(), req.target.data() + req.target.size(), '?', 2,
+		              [&](const char *b, const char *e) {
+			              switch (count) {
+			              case 0:
+				              req.path = detail::decode_url(std::string(b, e), false);
+				              break;
+			              case 1: {
+				              if (e - b > 0) {
+					              detail::parse_query_text(std::string(b, e), req.params);
+				              }
+				              break;
+			              }
+			              default:
+				              break;
+			              }
+			              count++;
+		              });
 
-    if (count > 2) { return false; }
-  }
+		if (count > 2) {
+			return false;
+		}
+	}
 
-  return true;
+	return true;
 }
 
-inline bool Server::write_response(Stream &strm, bool close_connection,
-                                   const Request &req, Response &res) {
-  return write_response_core(strm, close_connection, req, res, false);
+inline bool Server::write_response(Stream &strm, bool close_connection, const Request &req, Response &res) {
+	return write_response_core(strm, close_connection, req, res, false);
 }
 
-inline bool Server::write_response_with_content(Stream &strm,
-                                                bool close_connection,
-                                                const Request &req,
+inline bool Server::write_response_with_content(Stream &strm, bool close_connection, const Request &req,
                                                 Response &res) {
-  return write_response_core(strm, close_connection, req, res, true);
+	return write_response_core(strm, close_connection, req, res, true);
 }
 
-inline bool Server::write_response_core(Stream &strm, bool close_connection,
-                                        const Request &req, Response &res,
+inline bool Server::write_response_core(Stream &strm, bool close_connection, const Request &req, Response &res,
                                         bool need_apply_ranges) {
-  assert(res.status != -1);
+	assert(res.status != -1);
 
-  if (400 <= res.status && error_handler_ &&
-      error_handler_(req, res) == HandlerResponse::Handled) {
-    need_apply_ranges = true;
-  }
+	if (400 <= res.status && error_handler_ && error_handler_(req, res) == HandlerResponse::Handled) {
+		need_apply_ranges = true;
+	}
 
-  std::string content_type;
-  std::string boundary;
-  if (need_apply_ranges) { apply_ranges(req, res, content_type, boundary); }
+	std::string content_type;
+	std::string boundary;
+	if (need_apply_ranges) {
+		apply_ranges(req, res, content_type, boundary);
+	}
 
-  // Prepare additional headers
-  if (close_connection || req.get_header_value("Connection") == "close") {
-    res.set_header("Connection", "close");
-  } else {
-    duckdb::stringstream ss;
-    ss << "timeout=" << keep_alive_timeout_sec_
-       << ", max=" << keep_alive_max_count_;
-    res.set_header("Keep-Alive", ss.str());
-  }
+	// Prepare additional headers
+	if (close_connection || req.get_header_value("Connection") == "close") {
+		res.set_header("Connection", "close");
+	} else {
+		duckdb::stringstream ss;
+		ss << "timeout=" << keep_alive_timeout_sec_ << ", max=" << keep_alive_max_count_;
+		res.set_header("Keep-Alive", ss.str());
+	}
 
-  if (!res.has_header("Content-Type") &&
-      (!res.body.empty() || res.content_length_ > 0 || res.content_provider_)) {
-    res.set_header("Content-Type", "text/plain");
-  }
+	if (!res.has_header("Content-Type") && (!res.body.empty() || res.content_length_ > 0 || res.content_provider_)) {
+		res.set_header("Content-Type", "text/plain");
+	}
 
-  if (!res.has_header("Content-Length") && res.body.empty() &&
-      !res.content_length_ && !res.content_provider_) {
-    res.set_header("Content-Length", "0");
-  }
+	if (!res.has_header("Content-Length") && res.body.empty() && !res.content_length_ && !res.content_provider_) {
+		res.set_header("Content-Length", "0");
+	}
 
-  if (!res.has_header("Accept-Ranges") && req.method == "HEAD") {
-    res.set_header("Accept-Ranges", "bytes");
-  }
+	if (!res.has_header("Accept-Ranges") && req.method == "HEAD") {
+		res.set_header("Accept-Ranges", "bytes");
+	}
 
-  if (post_routing_handler_) { post_routing_handler_(req, res); }
+	if (post_routing_handler_) {
+		post_routing_handler_(req, res);
+	}
 
-  // Response line and headers
-  {
-    detail::BufferStream bstrm;
+	// Response line and headers
+	{
+		detail::BufferStream bstrm;
 
-    if (!bstrm.write_format("HTTP/1.1 %d %s\r\n", res.status,
-                            status_message(res.status))) {
-      return false;
-    }
+		if (!bstrm.write_format("HTTP/1.1 %d %s\r\n", res.status, status_message(res.status))) {
+			return false;
+		}
 
-    if (!header_writer_(bstrm, res.headers)) { return false; }
+		if (!header_writer_(bstrm, res.headers)) {
+			return false;
+		}
 
-    // Flush buffer
-    auto &data = bstrm.get_buffer();
-    detail::write_data(strm, data.data(), data.size());
-  }
+		// Flush buffer
+		auto &data = bstrm.get_buffer();
+		detail::write_data(strm, data.data(), data.size());
+	}
 
-  // Body
-  auto ret = true;
-  if (req.method != "HEAD") {
-    if (!res.body.empty()) {
-      if (!detail::write_data(strm, res.body.data(), res.body.size())) {
-        ret = false;
-      }
-    } else if (res.content_provider_) {
-      if (write_content_with_provider(strm, req, res, boundary, content_type)) {
-        res.content_provider_success_ = true;
-      } else {
-        res.content_provider_success_ = false;
-        ret = false;
-      }
-    }
-  }
+	// Body
+	auto ret = true;
+	if (req.method != "HEAD") {
+		if (!res.body.empty()) {
+			if (!detail::write_data(strm, res.body.data(), res.body.size())) {
+				ret = false;
+			}
+		} else if (res.content_provider_) {
+			if (write_content_with_provider(strm, req, res, boundary, content_type)) {
+				res.content_provider_success_ = true;
+			} else {
+				res.content_provider_success_ = false;
+				ret = false;
+			}
+		}
+	}
 
-  // Log
-  if (logger_) { logger_(req, res); }
+	// Log
+	if (logger_) {
+		logger_(req, res);
+	}
 
-  return ret;
+	return ret;
 }
 
-inline bool
-Server::write_content_with_provider(Stream &strm, const Request &req,
-                                    Response &res, const std::string &boundary,
-                                    const std::string &content_type) {
-  auto is_shutting_down = [this]() {
-    return this->svr_sock_ == INVALID_SOCKET;
-  };
+inline bool Server::write_content_with_provider(Stream &strm, const Request &req, Response &res,
+                                                const std::string &boundary, const std::string &content_type) {
+	auto is_shutting_down = [this]() {
+		return this->svr_sock_ == INVALID_SOCKET;
+	};
 
-  if (res.content_length_ > 0) {
-    if (req.ranges.empty()) {
-      return detail::write_content(strm, res.content_provider_, 0,
-                                   res.content_length_, is_shutting_down);
-    } else if (req.ranges.size() == 1) {
-      auto offsets =
-          detail::get_range_offset_and_length(req, res.content_length_, 0);
-      auto offset = offsets.first;
-      auto length = offsets.second;
-      return detail::write_content(strm, res.content_provider_, offset, length,
-                                   is_shutting_down);
-    } else {
-      return detail::write_multipart_ranges_data(
-          strm, req, res, boundary, content_type, is_shutting_down);
-    }
-  } else {
-    if (res.is_chunked_content_provider_) {
-      auto type = detail::encoding_type(req, res);
+	if (res.content_length_ > 0) {
+		if (req.ranges.empty()) {
+			return detail::write_content(strm, res.content_provider_, 0, res.content_length_, is_shutting_down);
+		} else if (req.ranges.size() == 1) {
+			auto offsets = detail::get_range_offset_and_length(req, res.content_length_, 0);
+			auto offset = offsets.first;
+			auto length = offsets.second;
+			return detail::write_content(strm, res.content_provider_, offset, length, is_shutting_down);
+		} else {
+			return detail::write_multipart_ranges_data(strm, req, res, boundary, content_type, is_shutting_down);
+		}
+	} else {
+		if (res.is_chunked_content_provider_) {
+			auto type = detail::encoding_type(req, res);
 
-      duckdb::unique_ptr<detail::compressor> compressor;
-      if (type == detail::EncodingType::Gzip) {
+			duckdb::unique_ptr<detail::compressor> compressor;
+			if (type == detail::EncodingType::Gzip) {
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-        compressor = detail::make_unique<detail::gzip_compressor>();
+				compressor = detail::make_unique<detail::gzip_compressor>();
 #endif
-      } else if (type == detail::EncodingType::Brotli) {
+			} else if (type == detail::EncodingType::Brotli) {
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
-        compressor = detail::make_unique<detail::brotli_compressor>();
+				compressor = detail::make_unique<detail::brotli_compressor>();
 #endif
-      } else {
-        compressor = detail::make_unique<detail::nocompressor>();
-      }
-      assert(compressor != nullptr);
+			} else {
+				compressor = detail::make_unique<detail::nocompressor>();
+			}
+			assert(compressor != nullptr);
 
-      return detail::write_content_chunked(strm, res.content_provider_,
-                                           is_shutting_down, *compressor);
-    } else {
-      return detail::write_content_without_length(strm, res.content_provider_,
-                                                  is_shutting_down);
-    }
-  }
+			return detail::write_content_chunked(strm, res.content_provider_, is_shutting_down, *compressor);
+		} else {
+			return detail::write_content_without_length(strm, res.content_provider_, is_shutting_down);
+		}
+	}
 }
 
 inline bool Server::read_content(Stream &strm, Request &req, Response &res) {
-  MultipartFormDataMap::iterator cur;
-  auto file_count = 0;
-  if (read_content_core(
-          strm, req, res,
-          // Regular
-          [&](const char *buf, size_t n) {
-            if (req.body.size() + n > req.body.max_size()) { return false; }
-            req.body.append(buf, n);
-            return true;
-          },
-          // Multipart
-          [&](const MultipartFormData &file) {
-            if (file_count++ == CPPHTTPLIB_MULTIPART_FORM_DATA_FILE_MAX_COUNT) {
-              return false;
-            }
-            cur = req.files.emplace(file.name, file);
-            return true;
-          },
-          [&](const char *buf, size_t n) {
-            auto &content = cur->second.content;
-            if (content.size() + n > content.max_size()) { return false; }
-            content.append(buf, n);
-            return true;
-          })) {
-    const auto &content_type = req.get_header_value("Content-Type");
-    if (!content_type.find("application/x-www-form-urlencoded")) {
-      if (req.body.size() > CPPHTTPLIB_FORM_URL_ENCODED_PAYLOAD_MAX_LENGTH) {
-        res.status = StatusCode::PayloadTooLarge_413; // NOTE: should be 414?
-        return false;
-      }
-      detail::parse_query_text(req.body, req.params);
-    }
-    return true;
-  }
-  return false;
+	MultipartFormDataMap::iterator cur;
+	auto file_count = 0;
+	if (read_content_core(
+	        strm, req, res,
+	        // Regular
+	        [&](const char *buf, size_t n) {
+		        if (req.body.size() + n > req.body.max_size()) {
+			        return false;
+		        }
+		        req.body.append(buf, n);
+		        return true;
+	        },
+	        // Multipart
+	        [&](const MultipartFormData &file) {
+		        if (file_count++ == CPPHTTPLIB_MULTIPART_FORM_DATA_FILE_MAX_COUNT) {
+			        return false;
+		        }
+		        cur = req.files.emplace(file.name, file);
+		        return true;
+	        },
+	        [&](const char *buf, size_t n) {
+		        auto &content = cur->second.content;
+		        if (content.size() + n > content.max_size()) {
+			        return false;
+		        }
+		        content.append(buf, n);
+		        return true;
+	        })) {
+		const auto &content_type = req.get_header_value("Content-Type");
+		if (!content_type.find("application/x-www-form-urlencoded")) {
+			if (req.body.size() > CPPHTTPLIB_FORM_URL_ENCODED_PAYLOAD_MAX_LENGTH) {
+				res.status = StatusCode::PayloadTooLarge_413; // NOTE: should be 414?
+				return false;
+			}
+			detail::parse_query_text(req.body, req.params);
+		}
+		return true;
+	}
+	return false;
 }
 
-inline bool Server::read_content_with_content_receiver(
-    Stream &strm, Request &req, Response &res, ContentReceiver receiver,
-    MultipartContentHeader multipart_header,
-    ContentReceiver multipart_receiver) {
-  return read_content_core(strm, req, res, std::move(receiver),
-                           std::move(multipart_header),
-                           std::move(multipart_receiver));
+inline bool Server::read_content_with_content_receiver(Stream &strm, Request &req, Response &res,
+                                                       ContentReceiver receiver,
+                                                       MultipartContentHeader multipart_header,
+                                                       ContentReceiver multipart_receiver) {
+	return read_content_core(strm, req, res, std::move(receiver), std::move(multipart_header),
+	                         std::move(multipart_receiver));
 }
 
-inline bool
-Server::read_content_core(Stream &strm, Request &req, Response &res,
-                          ContentReceiver receiver,
-                          MultipartContentHeader multipart_header,
-                          ContentReceiver multipart_receiver) const {
-  detail::MultipartFormDataParser multipart_form_data_parser;
-  ContentReceiverWithProgress out;
+inline bool Server::read_content_core(Stream &strm, Request &req, Response &res, ContentReceiver receiver,
+                                      MultipartContentHeader multipart_header,
+                                      ContentReceiver multipart_receiver) const {
+	detail::MultipartFormDataParser multipart_form_data_parser;
+	ContentReceiverWithProgress out;
 
-  if (req.is_multipart_form_data()) {
-    const auto &content_type = req.get_header_value("Content-Type");
-    std::string boundary;
-    if (!detail::parse_multipart_boundary(content_type, boundary)) {
-      res.status = StatusCode::BadRequest_400;
-      return false;
-    }
+	if (req.is_multipart_form_data()) {
+		const auto &content_type = req.get_header_value("Content-Type");
+		std::string boundary;
+		if (!detail::parse_multipart_boundary(content_type, boundary)) {
+			res.status = StatusCode::BadRequest_400;
+			return false;
+		}
 
-    multipart_form_data_parser.set_boundary(std::move(boundary));
-    out = [&](const char *buf, size_t n, uint64_t /*off*/, uint64_t /*len*/) {
-      /* For debug
-      size_t pos = 0;
-      while (pos < n) {
-        auto read_size = (std::min)<size_t>(1, n - pos);
-        auto ret = multipart_form_data_parser.parse(
-            buf + pos, read_size, multipart_receiver, multipart_header);
-        if (!ret) { return false; }
-        pos += read_size;
-      }
-      return true;
-      */
-      return multipart_form_data_parser.parse(buf, n, multipart_receiver,
-                                              multipart_header);
-    };
-  } else {
-    out = [receiver](const char *buf, size_t n, uint64_t /*off*/,
-                     uint64_t /*len*/) { return receiver(buf, n); };
-  }
+		multipart_form_data_parser.set_boundary(std::move(boundary));
+		out = [&](const char *buf, size_t n, uint64_t /*off*/, uint64_t /*len*/) {
+			/* For debug
+			size_t pos = 0;
+			while (pos < n) {
+			  auto read_size = (std::min)<size_t>(1, n - pos);
+			  auto ret = multipart_form_data_parser.parse(
+			      buf + pos, read_size, multipart_receiver, multipart_header);
+			  if (!ret) { return false; }
+			  pos += read_size;
+			}
+			return true;
+			*/
+			return multipart_form_data_parser.parse(buf, n, multipart_receiver, multipart_header);
+		};
+	} else {
+		out = [receiver](const char *buf, size_t n, uint64_t /*off*/, uint64_t /*len*/) {
+			return receiver(buf, n);
+		};
+	}
 
-  if (req.method == "DELETE" && !req.has_header("Content-Length")) {
-    return true;
-  }
+	if (req.method == "DELETE" && !req.has_header("Content-Length")) {
+		return true;
+	}
 
-  if (!detail::read_content(strm, req, payload_max_length_, res.status, nullptr,
-                            out, true)) {
-    return false;
-  }
+	if (!detail::read_content(strm, req, payload_max_length_, res.status, nullptr, out, true)) {
+		return false;
+	}
 
-  if (req.is_multipart_form_data()) {
-    if (!multipart_form_data_parser.is_valid()) {
-      res.status = StatusCode::BadRequest_400;
-      return false;
-    }
-  }
+	if (req.is_multipart_form_data()) {
+		if (!multipart_form_data_parser.is_valid()) {
+			res.status = StatusCode::BadRequest_400;
+			return false;
+		}
+	}
 
-  return true;
+	return true;
 }
 
-inline bool Server::handle_file_request(const Request &req, Response &res,
-                                        bool head) {
-  for (const auto &entry : base_dirs_) {
-    // Prefix match
-    if (!req.path.compare(0, entry.mount_point.size(), entry.mount_point)) {
-      std::string sub_path = "/" + req.path.substr(entry.mount_point.size());
-      if (detail::is_valid_path(sub_path)) {
-        auto path = entry.base_dir + sub_path;
-        if (path.back() == '/') { path += "index.html"; }
+inline bool Server::handle_file_request(const Request &req, Response &res, bool head) {
+	for (const auto &entry : base_dirs_) {
+		// Prefix match
+		if (!req.path.compare(0, entry.mount_point.size(), entry.mount_point)) {
+			std::string sub_path = "/" + req.path.substr(entry.mount_point.size());
+			if (detail::is_valid_path(sub_path)) {
+				auto path = entry.base_dir + sub_path;
+				if (path.back() == '/') {
+					path += "index.html";
+				}
 
-        if (detail::is_file(path)) {
-          for (const auto &kv : entry.headers) {
-            res.set_header(kv.first, kv.second);
-          }
+				if (detail::is_file(path)) {
+					for (const auto &kv : entry.headers) {
+						res.set_header(kv.first, kv.second);
+					}
 
-          auto mm = duckdb::make_shared_ptr<detail::mmap>(path.c_str());
-          if (!mm->is_open()) { return false; }
+					auto mm = duckdb::make_shared_ptr<detail::mmap>(path.c_str());
+					if (!mm->is_open()) {
+						return false;
+					}
 
-          res.set_content_provider(
-              mm->size(),
-              detail::find_content_type(path, file_extension_and_mimetype_map_,
-                                        default_file_mimetype_),
-              [mm](size_t offset, size_t length, DataSink &sink) -> bool {
-                sink.write(mm->data() + offset, length);
-                return true;
-              });
+					res.set_content_provider(
+					    mm->size(),
+					    detail::find_content_type(path, file_extension_and_mimetype_map_, default_file_mimetype_),
+					    [mm](size_t offset, size_t length, DataSink &sink) -> bool {
+						    sink.write(mm->data() + offset, length);
+						    return true;
+					    });
 
-          if (!head && file_request_handler_) {
-            file_request_handler_(req, res);
-          }
+					if (!head && file_request_handler_) {
+						file_request_handler_(req, res);
+					}
 
-          return true;
-        }
-      }
-    }
-  }
-  return false;
+					return true;
+				}
+			}
+		}
+	}
+	return false;
 }
 
-inline socket_t
-Server::create_server_socket(const std::string &host, int port,
-                             int socket_flags,
-                             SocketOptions socket_options) const {
-  return detail::create_socket(
-      host, std::string(), port, address_family_, socket_flags, tcp_nodelay_,
-      std::move(socket_options),
-      [](socket_t sock, struct addrinfo &ai) -> bool {
-        if (::bind(sock, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen))) {
-          return false;
-        }
-        if (::listen(sock, CPPHTTPLIB_LISTEN_BACKLOG)) { return false; }
-        return true;
-      });
+inline socket_t Server::create_server_socket(const std::string &host, int port, int socket_flags,
+                                             SocketOptions socket_options) const {
+	return detail::create_socket(host, std::string(), port, address_family_, socket_flags, tcp_nodelay_,
+	                             std::move(socket_options), [](socket_t sock, struct addrinfo &ai) -> bool {
+		                             if (::bind(sock, ai.ai_addr, static_cast<socklen_t>(ai.ai_addrlen))) {
+			                             return false;
+		                             }
+		                             if (::listen(sock, CPPHTTPLIB_LISTEN_BACKLOG)) {
+			                             return false;
+		                             }
+		                             return true;
+	                             });
 }
 
-inline int Server::bind_internal(const std::string &host, int port,
-                                 int socket_flags) {
-  if (!is_valid()) { return -1; }
+inline int Server::bind_internal(const std::string &host, int port, int socket_flags) {
+	if (!is_valid()) {
+		return -1;
+	}
 
-  svr_sock_ = create_server_socket(host, port, socket_flags, socket_options_);
-  if (svr_sock_ == INVALID_SOCKET) { return -1; }
+	svr_sock_ = create_server_socket(host, port, socket_flags, socket_options_);
+	if (svr_sock_ == INVALID_SOCKET) {
+		return -1;
+	}
 
-  if (port == 0) {
-    struct sockaddr_storage addr;
-    socklen_t addr_len = sizeof(addr);
-    if (getsockname(svr_sock_, reinterpret_cast<struct sockaddr *>(&addr),
-                    &addr_len) == -1) {
-      return -1;
-    }
-    if (addr.ss_family == AF_INET) {
-      return ntohs(reinterpret_cast<struct sockaddr_in *>(&addr)->sin_port);
-    } else if (addr.ss_family == AF_INET6) {
-      return ntohs(reinterpret_cast<struct sockaddr_in6 *>(&addr)->sin6_port);
-    } else {
-      return -1;
-    }
-  } else {
-    return port;
-  }
+	if (port == 0) {
+		struct sockaddr_storage addr;
+		socklen_t addr_len = sizeof(addr);
+		if (getsockname(svr_sock_, reinterpret_cast<struct sockaddr *>(&addr), &addr_len) == -1) {
+			return -1;
+		}
+		if (addr.ss_family == AF_INET) {
+			return ntohs(reinterpret_cast<struct sockaddr_in *>(&addr)->sin_port);
+		} else if (addr.ss_family == AF_INET6) {
+			return ntohs(reinterpret_cast<struct sockaddr_in6 *>(&addr)->sin6_port);
+		} else {
+			return -1;
+		}
+	} else {
+		return port;
+	}
 }
 
 inline bool Server::listen_internal() {
-  auto ret = true;
-  is_running_ = true;
-  auto se = detail::scope_exit([&]() { is_running_ = false; });
+	auto ret = true;
+	is_running_ = true;
+	auto se = detail::scope_exit([&]() { is_running_ = false; });
 
-  {
-    duckdb::unique_ptr<TaskQueue> task_queue(new_task_queue());
+	{
+		duckdb::unique_ptr<TaskQueue> task_queue(new_task_queue());
 
-    while (svr_sock_ != INVALID_SOCKET) {
+		while (svr_sock_ != INVALID_SOCKET) {
 #ifndef _WIN32
-      if (idle_interval_sec_ > 0 || idle_interval_usec_ > 0) {
+			if (idle_interval_sec_ > 0 || idle_interval_usec_ > 0) {
 #endif
-        auto val = detail::select_read(svr_sock_, idle_interval_sec_,
-                                       idle_interval_usec_);
-        if (val == 0) { // Timeout
-          task_queue->on_idle();
-          continue;
-        }
+				auto val = detail::select_read(svr_sock_, idle_interval_sec_, idle_interval_usec_);
+				if (val == 0) { // Timeout
+					task_queue->on_idle();
+					continue;
+				}
 #ifndef _WIN32
-      }
+			}
 #endif
-      socket_t sock = accept(svr_sock_, nullptr, nullptr);
+			socket_t sock = accept(svr_sock_, nullptr, nullptr);
 
-      if (sock == INVALID_SOCKET) {
-        if (errno == EMFILE) {
-          // The per-process limit of open file descriptors has been reached.
-          // Try to accept new connections after a short sleep.
-          std::this_thread::sleep_for(std::chrono::milliseconds(1));
-          continue;
-        } else if (errno == EINTR || errno == EAGAIN) {
-          continue;
-        }
-        if (svr_sock_ != INVALID_SOCKET) {
-          detail::close_socket(svr_sock_);
-          ret = false;
-        } else {
-          ; // The server socket was closed by user.
-        }
-        break;
-      }
+			if (sock == INVALID_SOCKET) {
+				if (errno == EMFILE) {
+					// The per-process limit of open file descriptors has been reached.
+					// Try to accept new connections after a short sleep.
+					std::this_thread::sleep_for(std::chrono::milliseconds(1));
+					continue;
+				} else if (errno == EINTR || errno == EAGAIN) {
+					continue;
+				}
+				if (svr_sock_ != INVALID_SOCKET) {
+					detail::close_socket(svr_sock_);
+					ret = false;
+				} else {
+					; // The server socket was closed by user.
+				}
+				break;
+			}
 
-      {
+			{
 #ifdef _WIN32
-        auto timeout = static_cast<uint32_t>(read_timeout_sec_ * 1000 +
-                                             read_timeout_usec_ / 1000);
-        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO,
-                   reinterpret_cast<const char *>(&timeout), sizeof(timeout));
+				auto timeout = static_cast<uint32_t>(read_timeout_sec_ * 1000 + read_timeout_usec_ / 1000);
+				setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char *>(&timeout), sizeof(timeout));
 #else
-        timeval tv;
-        tv.tv_sec = static_cast<long>(read_timeout_sec_);
-        tv.tv_usec = static_cast<decltype(tv.tv_usec)>(read_timeout_usec_);
-        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO,
-                   reinterpret_cast<const void *>(&tv), sizeof(tv));
+				timeval tv;
+				tv.tv_sec = static_cast<long>(read_timeout_sec_);
+				tv.tv_usec = static_cast<decltype(tv.tv_usec)>(read_timeout_usec_);
+				setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const void *>(&tv), sizeof(tv));
 #endif
-      }
-      {
+			}
+			{
 
 #ifdef _WIN32
-        auto timeout = static_cast<uint32_t>(write_timeout_sec_ * 1000 +
-                                             write_timeout_usec_ / 1000);
-        setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO,
-                   reinterpret_cast<const char *>(&timeout), sizeof(timeout));
+				auto timeout = static_cast<uint32_t>(write_timeout_sec_ * 1000 + write_timeout_usec_ / 1000);
+				setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char *>(&timeout), sizeof(timeout));
 #else
-        timeval tv;
-        tv.tv_sec = static_cast<long>(write_timeout_sec_);
-        tv.tv_usec = static_cast<decltype(tv.tv_usec)>(write_timeout_usec_);
-        setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO,
-                   reinterpret_cast<const void *>(&tv), sizeof(tv));
+				timeval tv;
+				tv.tv_sec = static_cast<long>(write_timeout_sec_);
+				tv.tv_usec = static_cast<decltype(tv.tv_usec)>(write_timeout_usec_);
+				setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const void *>(&tv), sizeof(tv));
 #endif
-      }
+			}
 
-      task_queue->enqueue([this, sock]() { process_and_close_socket(sock); });
-    }
+			task_queue->enqueue([this, sock]() { process_and_close_socket(sock); });
+		}
 
-    task_queue->shutdown();
-  }
+		task_queue->shutdown();
+	}
 
-  return ret;
+	return ret;
 }
 
 inline bool Server::routing(Request &req, Response &res, Stream &strm) {
-  if (pre_routing_handler_ &&
-      pre_routing_handler_(req, res) == HandlerResponse::Handled) {
-    return true;
-  }
+	if (pre_routing_handler_ && pre_routing_handler_(req, res) == HandlerResponse::Handled) {
+		return true;
+	}
 
-  // File handler
-  auto is_head_request = req.method == "HEAD";
-  if ((req.method == "GET" || is_head_request) &&
-      handle_file_request(req, res, is_head_request)) {
-    return true;
-  }
+	// File handler
+	auto is_head_request = req.method == "HEAD";
+	if ((req.method == "GET" || is_head_request) && handle_file_request(req, res, is_head_request)) {
+		return true;
+	}
 
-  if (detail::expect_content(req)) {
-    // Content reader handler
-    {
-      ContentReader reader(
-          [&](ContentReceiver receiver) {
-            return read_content_with_content_receiver(
-                strm, req, res, std::move(receiver), nullptr, nullptr);
-          },
-          [&](MultipartContentHeader header, ContentReceiver receiver) {
-            return read_content_with_content_receiver(strm, req, res, nullptr,
-                                                      std::move(header),
-                                                      std::move(receiver));
-          });
+	if (detail::expect_content(req)) {
+		// Content reader handler
+		{
+			ContentReader reader(
+			    [&](ContentReceiver receiver) {
+				    return read_content_with_content_receiver(strm, req, res, std::move(receiver), nullptr, nullptr);
+			    },
+			    [&](MultipartContentHeader header, ContentReceiver receiver) {
+				    return read_content_with_content_receiver(strm, req, res, nullptr, std::move(header),
+				                                              std::move(receiver));
+			    });
 
-      if (req.method == "POST") {
-        if (dispatch_request_for_content_reader(
-                req, res, std::move(reader),
-                post_handlers_for_content_reader_)) {
-          return true;
-        }
-      } else if (req.method == "PUT") {
-        if (dispatch_request_for_content_reader(
-                req, res, std::move(reader),
-                put_handlers_for_content_reader_)) {
-          return true;
-        }
-      } else if (req.method == "PATCH") {
-        if (dispatch_request_for_content_reader(
-                req, res, std::move(reader),
-                patch_handlers_for_content_reader_)) {
-          return true;
-        }
-      } else if (req.method == "DELETE") {
-        if (dispatch_request_for_content_reader(
-                req, res, std::move(reader),
-                delete_handlers_for_content_reader_)) {
-          return true;
-        }
-      }
-    }
+			if (req.method == "POST") {
+				if (dispatch_request_for_content_reader(req, res, std::move(reader),
+				                                        post_handlers_for_content_reader_)) {
+					return true;
+				}
+			} else if (req.method == "PUT") {
+				if (dispatch_request_for_content_reader(req, res, std::move(reader),
+				                                        put_handlers_for_content_reader_)) {
+					return true;
+				}
+			} else if (req.method == "PATCH") {
+				if (dispatch_request_for_content_reader(req, res, std::move(reader),
+				                                        patch_handlers_for_content_reader_)) {
+					return true;
+				}
+			} else if (req.method == "DELETE") {
+				if (dispatch_request_for_content_reader(req, res, std::move(reader),
+				                                        delete_handlers_for_content_reader_)) {
+					return true;
+				}
+			}
+		}
 
-    // Read content into `req.body`
-    if (!read_content(strm, req, res)) { return false; }
-  }
+		// Read content into `req.body`
+		if (!read_content(strm, req, res)) {
+			return false;
+		}
+	}
 
-  // Regular handler
-  if (req.method == "GET" || req.method == "HEAD") {
-    return dispatch_request(req, res, get_handlers_);
-  } else if (req.method == "POST") {
-    return dispatch_request(req, res, post_handlers_);
-  } else if (req.method == "PUT") {
-    return dispatch_request(req, res, put_handlers_);
-  } else if (req.method == "DELETE") {
-    return dispatch_request(req, res, delete_handlers_);
-  } else if (req.method == "OPTIONS") {
-    return dispatch_request(req, res, options_handlers_);
-  } else if (req.method == "PATCH") {
-    return dispatch_request(req, res, patch_handlers_);
-  }
+	// Regular handler
+	if (req.method == "GET" || req.method == "HEAD") {
+		return dispatch_request(req, res, get_handlers_);
+	} else if (req.method == "POST") {
+		return dispatch_request(req, res, post_handlers_);
+	} else if (req.method == "PUT") {
+		return dispatch_request(req, res, put_handlers_);
+	} else if (req.method == "DELETE") {
+		return dispatch_request(req, res, delete_handlers_);
+	} else if (req.method == "OPTIONS") {
+		return dispatch_request(req, res, options_handlers_);
+	} else if (req.method == "PATCH") {
+		return dispatch_request(req, res, patch_handlers_);
+	}
 
-  res.status = StatusCode::BadRequest_400;
-  return false;
+	res.status = StatusCode::BadRequest_400;
+	return false;
 }
 
-inline bool Server::dispatch_request(Request &req, Response &res,
-                                     const Handlers &handlers) const {
-  for (const auto &x : handlers) {
-    const auto &pattern = x.first;
-    const auto &handler = x.second;
+inline bool Server::dispatch_request(Request &req, Response &res, const Handlers &handlers) const {
+	for (const auto &x : handlers) {
+		const auto &pattern = x.first;
+		const auto &handler = x.second;
 
-    if (duckdb_re2::RegexMatch(req.path, req.matches, pattern)) {
-      handler(req, res);
-      return true;
-    }
-  }
-  return false;
+		if (duckdb_re2::RegexMatch(req.path, req.matches, pattern)) {
+			handler(req, res);
+			return true;
+		}
+	}
+	return false;
 }
 
-inline void Server::apply_ranges(const Request &req, Response &res,
-                                 std::string &content_type,
+inline void Server::apply_ranges(const Request &req, Response &res, std::string &content_type,
                                  std::string &boundary) const {
-  if (req.ranges.size() > 1) {
-    boundary = detail::make_multipart_data_boundary();
+	if (req.ranges.size() > 1) {
+		boundary = detail::make_multipart_data_boundary();
 
-    auto it = res.headers.find("Content-Type");
-    if (it != res.headers.end()) {
-      content_type = it->second;
-      res.headers.erase(it);
-    }
+		auto it = res.headers.find("Content-Type");
+		if (it != res.headers.end()) {
+			content_type = it->second;
+			res.headers.erase(it);
+		}
 
-    res.set_header("Content-Type",
-                   "multipart/byteranges; boundary=" + boundary);
-  }
+		res.set_header("Content-Type", "multipart/byteranges; boundary=" + boundary);
+	}
 
-  auto type = detail::encoding_type(req, res);
+	auto type = detail::encoding_type(req, res);
 
-  if (res.body.empty()) {
-    if (res.content_length_ > 0) {
-      size_t length = 0;
-      if (req.ranges.empty()) {
-        length = res.content_length_;
-      } else if (req.ranges.size() == 1) {
-        auto offsets =
-            detail::get_range_offset_and_length(req, res.content_length_, 0);
-        length = offsets.second;
+	if (res.body.empty()) {
+		if (res.content_length_ > 0) {
+			size_t length = 0;
+			if (req.ranges.empty()) {
+				length = res.content_length_;
+			} else if (req.ranges.size() == 1) {
+				auto offsets = detail::get_range_offset_and_length(req, res.content_length_, 0);
+				length = offsets.second;
 
-        auto content_range = detail::make_content_range_header_field(
-            req.ranges[0], res.content_length_);
-        res.set_header("Content-Range", content_range);
-      } else {
-        length = detail::get_multipart_ranges_data_length(req, res, boundary,
-                                                          content_type);
-      }
-      res.set_header("Content-Length", std::to_string(length));
-    } else {
-      if (res.content_provider_) {
-        if (res.is_chunked_content_provider_) {
-          res.set_header("Transfer-Encoding", "chunked");
-          if (type == detail::EncodingType::Gzip) {
-            res.set_header("Content-Encoding", "gzip");
-          } else if (type == detail::EncodingType::Brotli) {
-            res.set_header("Content-Encoding", "br");
-          }
-        }
-      }
-    }
-  } else {
-    if (req.ranges.empty()) {
-      ;
-    } else if (req.ranges.size() == 1) {
-      auto content_range = detail::make_content_range_header_field(
-          req.ranges[0], res.body.size());
-      res.set_header("Content-Range", content_range);
+				auto content_range = detail::make_content_range_header_field(req.ranges[0], res.content_length_);
+				res.set_header("Content-Range", content_range);
+			} else {
+				length = detail::get_multipart_ranges_data_length(req, res, boundary, content_type);
+			}
+			res.set_header("Content-Length", std::to_string(length));
+		} else {
+			if (res.content_provider_) {
+				if (res.is_chunked_content_provider_) {
+					res.set_header("Transfer-Encoding", "chunked");
+					if (type == detail::EncodingType::Gzip) {
+						res.set_header("Content-Encoding", "gzip");
+					} else if (type == detail::EncodingType::Brotli) {
+						res.set_header("Content-Encoding", "br");
+					}
+				}
+			}
+		}
+	} else {
+		if (req.ranges.empty()) {
+			;
+		} else if (req.ranges.size() == 1) {
+			auto content_range = detail::make_content_range_header_field(req.ranges[0], res.body.size());
+			res.set_header("Content-Range", content_range);
 
-      auto offsets =
-          detail::get_range_offset_and_length(req, res.body.size(), 0);
-      auto offset = offsets.first;
-      auto length = offsets.second;
+			auto offsets = detail::get_range_offset_and_length(req, res.body.size(), 0);
+			auto offset = offsets.first;
+			auto length = offsets.second;
 
-      if (offset < res.body.size()) {
-        res.body = res.body.substr(offset, length);
-      } else {
-        res.body.clear();
-        res.status = StatusCode::RangeNotSatisfiable_416;
-      }
-    } else {
-      std::string data;
-      if (detail::make_multipart_ranges_data(req, res, boundary, content_type,
-                                             data)) {
-        res.body.swap(data);
-      } else {
-        res.body.clear();
-        res.status = StatusCode::RangeNotSatisfiable_416;
-      }
-    }
+			if (offset < res.body.size()) {
+				res.body = res.body.substr(offset, length);
+			} else {
+				res.body.clear();
+				res.status = StatusCode::RangeNotSatisfiable_416;
+			}
+		} else {
+			std::string data;
+			if (detail::make_multipart_ranges_data(req, res, boundary, content_type, data)) {
+				res.body.swap(data);
+			} else {
+				res.body.clear();
+				res.status = StatusCode::RangeNotSatisfiable_416;
+			}
+		}
 
-    if (type != detail::EncodingType::None) {
-      duckdb::unique_ptr<detail::compressor> compressor;
-      std::string content_encoding;
+		if (type != detail::EncodingType::None) {
+			duckdb::unique_ptr<detail::compressor> compressor;
+			std::string content_encoding;
 
-      if (type == detail::EncodingType::Gzip) {
+			if (type == detail::EncodingType::Gzip) {
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-        compressor = detail::make_unique<detail::gzip_compressor>();
-        content_encoding = "gzip";
+				compressor = detail::make_unique<detail::gzip_compressor>();
+				content_encoding = "gzip";
 #endif
-      } else if (type == detail::EncodingType::Brotli) {
+			} else if (type == detail::EncodingType::Brotli) {
 #ifdef CPPHTTPLIB_BROTLI_SUPPORT
-        compressor = detail::make_unique<detail::brotli_compressor>();
-        content_encoding = "br";
+				compressor = detail::make_unique<detail::brotli_compressor>();
+				content_encoding = "br";
 #endif
-      }
+			}
 
-      if (compressor) {
-        std::string compressed;
-        if (compressor->compress(res.body.data(), res.body.size(), true,
-                                 [&](const char *data, size_t data_len) {
-                                   compressed.append(data, data_len);
-                                   return true;
-                                 })) {
-          res.body.swap(compressed);
-          res.set_header("Content-Encoding", content_encoding);
-        }
-      }
-    }
+			if (compressor) {
+				std::string compressed;
+				if (compressor->compress(res.body.data(), res.body.size(), true,
+				                         [&](const char *data, size_t data_len) {
+					                         compressed.append(data, data_len);
+					                         return true;
+				                         })) {
+					res.body.swap(compressed);
+					res.set_header("Content-Encoding", content_encoding);
+				}
+			}
+		}
 
-    auto length = std::to_string(res.body.size());
-    res.set_header("Content-Length", length);
-  }
+		auto length = std::to_string(res.body.size());
+		res.set_header("Content-Length", length);
+	}
 }
 
-inline bool Server::dispatch_request_for_content_reader(
-    Request &req, Response &res, ContentReader content_reader,
-    const HandlersForContentReader &handlers) const {
-  for (const auto &x : handlers) {
-    const auto &pattern = x.first;
-    const auto &handler = x.second;
+inline bool Server::dispatch_request_for_content_reader(Request &req, Response &res, ContentReader content_reader,
+                                                        const HandlersForContentReader &handlers) const {
+	for (const auto &x : handlers) {
+		const auto &pattern = x.first;
+		const auto &handler = x.second;
 
-    if (duckdb_re2::RegexMatch(req.path, req.matches, pattern)) {
-      handler(req, res, content_reader);
-      return true;
-    }
-  }
-  return false;
+		if (duckdb_re2::RegexMatch(req.path, req.matches, pattern)) {
+			handler(req, res, content_reader);
+			return true;
+		}
+	}
+	return false;
 }
 
-inline bool
-Server::process_request(Stream &strm, bool close_connection,
-                        bool &connection_closed,
-                        const std::function<void(Request &)> &setup_request) {
-  std::array<char, 2048> buf{};
+inline bool Server::process_request(Stream &strm, bool close_connection, bool &connection_closed,
+                                    const std::function<void(Request &)> &setup_request) {
+	std::array<char, 2048> buf {};
 
-  detail::stream_line_reader line_reader(strm, buf.data(), buf.size());
+	detail::stream_line_reader line_reader(strm, buf.data(), buf.size());
 
-  // Connection has been closed on client
-  if (!line_reader.getline()) { return false; }
+	// Connection has been closed on client
+	if (!line_reader.getline()) {
+		return false;
+	}
 
-  Request req;
+	Request req;
 
-  Response res;
-  res.version = "HTTP/1.1";
-  res.headers = default_headers_;
+	Response res;
+	res.version = "HTTP/1.1";
+	res.headers = default_headers_;
 
 #ifdef _WIN32
-  // TODO: Increase FD_SETSIZE statically (libzmq), dynamically (MySQL).
+	// TODO: Increase FD_SETSIZE statically (libzmq), dynamically (MySQL).
 #else
 #ifndef CPPHTTPLIB_USE_POLL
-  // Socket file descriptor exceeded FD_SETSIZE...
-  if (strm.socket() >= FD_SETSIZE) {
-    Headers dummy;
-    detail::read_headers(strm, dummy);
-    res.status = StatusCode::InternalServerError_500;
-    return write_response(strm, close_connection, req, res);
-  }
+	// Socket file descriptor exceeded FD_SETSIZE...
+	if (strm.socket() >= FD_SETSIZE) {
+		Headers dummy;
+		detail::read_headers(strm, dummy);
+		res.status = StatusCode::InternalServerError_500;
+		return write_response(strm, close_connection, req, res);
+	}
 #endif
 #endif
 
-  // Check if the request URI doesn't exceed the limit
-  if (line_reader.size() > CPPHTTPLIB_REQUEST_URI_MAX_LENGTH) {
-    Headers dummy;
-    detail::read_headers(strm, dummy);
-    res.status = StatusCode::UriTooLong_414;
-    return write_response(strm, close_connection, req, res);
-  }
+	// Check if the request URI doesn't exceed the limit
+	if (line_reader.size() > CPPHTTPLIB_REQUEST_URI_MAX_LENGTH) {
+		Headers dummy;
+		detail::read_headers(strm, dummy);
+		res.status = StatusCode::UriTooLong_414;
+		return write_response(strm, close_connection, req, res);
+	}
 
-  // Request line and headers
-  if (!parse_request_line(line_reader.ptr(), req) ||
-      !detail::read_headers(strm, req.headers)) {
-    res.status = StatusCode::BadRequest_400;
-    return write_response(strm, close_connection, req, res);
-  }
+	// Request line and headers
+	if (!parse_request_line(line_reader.ptr(), req) || !detail::read_headers(strm, req.headers)) {
+		res.status = StatusCode::BadRequest_400;
+		return write_response(strm, close_connection, req, res);
+	}
 
-  if (req.get_header_value("Connection") == "close") {
-    connection_closed = true;
-  }
+	if (req.get_header_value("Connection") == "close") {
+		connection_closed = true;
+	}
 
-  if (req.version == "HTTP/1.0" &&
-      req.get_header_value("Connection") != "Keep-Alive") {
-    connection_closed = true;
-  }
+	if (req.version == "HTTP/1.0" && req.get_header_value("Connection") != "Keep-Alive") {
+		connection_closed = true;
+	}
 
-  strm.get_remote_ip_and_port(req.remote_addr, req.remote_port);
-  req.set_header("REMOTE_ADDR", req.remote_addr);
-  req.set_header("REMOTE_PORT", std::to_string(req.remote_port));
+	strm.get_remote_ip_and_port(req.remote_addr, req.remote_port);
+	req.set_header("REMOTE_ADDR", req.remote_addr);
+	req.set_header("REMOTE_PORT", std::to_string(req.remote_port));
 
-  strm.get_local_ip_and_port(req.local_addr, req.local_port);
-  req.set_header("LOCAL_ADDR", req.local_addr);
-  req.set_header("LOCAL_PORT", std::to_string(req.local_port));
+	strm.get_local_ip_and_port(req.local_addr, req.local_port);
+	req.set_header("LOCAL_ADDR", req.local_addr);
+	req.set_header("LOCAL_PORT", std::to_string(req.local_port));
 
-  if (req.has_header("Range")) {
-    const auto &range_header_value = req.get_header_value("Range");
-    if (!detail::parse_range_header(range_header_value, req.ranges)) {
-      res.status = StatusCode::RangeNotSatisfiable_416;
-      return write_response(strm, close_connection, req, res);
-    }
-  }
+	if (req.has_header("Range")) {
+		const auto &range_header_value = req.get_header_value("Range");
+		if (!detail::parse_range_header(range_header_value, req.ranges)) {
+			res.status = StatusCode::RangeNotSatisfiable_416;
+			return write_response(strm, close_connection, req, res);
+		}
+	}
 
-  if (setup_request) { setup_request(req); }
+	if (setup_request) {
+		setup_request(req);
+	}
 
-  if (req.get_header_value("Expect") == "100-continue") {
-    int status = StatusCode::Continue_100;
-    if (expect_100_continue_handler_) {
-      status = expect_100_continue_handler_(req, res);
-    }
-    switch (status) {
-    case StatusCode::Continue_100:
-    case StatusCode::ExpectationFailed_417:
-      strm.write_format("HTTP/1.1 %d %s\r\n\r\n", status,
-                        status_message(status));
-      break;
-    default: return write_response(strm, close_connection, req, res);
-    }
-  }
+	if (req.get_header_value("Expect") == "100-continue") {
+		int status = StatusCode::Continue_100;
+		if (expect_100_continue_handler_) {
+			status = expect_100_continue_handler_(req, res);
+		}
+		switch (status) {
+		case StatusCode::Continue_100:
+		case StatusCode::ExpectationFailed_417:
+			strm.write_format("HTTP/1.1 %d %s\r\n\r\n", status, status_message(status));
+			break;
+		default:
+			return write_response(strm, close_connection, req, res);
+		}
+	}
 
-  // Rounting
-  auto routed = false;
+	// Rounting
+	auto routed = false;
 #ifdef CPPHTTPLIB_NO_EXCEPTIONS
-  routed = routing(req, res, strm);
+	routed = routing(req, res, strm);
 #else
-  try {
-    routed = routing(req, res, strm);
-  } catch (std::exception &e) {
-    if (exception_handler_) {
-      auto ep = std::current_exception();
-      exception_handler_(req, res, ep);
-      routed = true;
-    } else {
-      res.status = StatusCode::InternalServerError_500;
-      std::string val;
-      auto s = e.what();
-      for (size_t i = 0; s[i]; i++) {
-        switch (s[i]) {
-        case '\r': val += "\\r"; break;
-        case '\n': val += "\\n"; break;
-        default: val += s[i]; break;
-        }
-      }
-      res.set_header("EXCEPTION_WHAT", val);
-    }
-  } catch (...) {
-    if (exception_handler_) {
-      auto ep = std::current_exception();
-      exception_handler_(req, res, ep);
-      routed = true;
-    } else {
-      res.status = StatusCode::InternalServerError_500;
-      res.set_header("EXCEPTION_WHAT", "UNKNOWN");
-    }
-  }
+	try {
+		routed = routing(req, res, strm);
+	} catch (std::exception &e) {
+		if (exception_handler_) {
+			auto ep = std::current_exception();
+			exception_handler_(req, res, ep);
+			routed = true;
+		} else {
+			res.status = StatusCode::InternalServerError_500;
+			std::string val;
+			auto s = e.what();
+			for (size_t i = 0; s[i]; i++) {
+				switch (s[i]) {
+				case '\r':
+					val += "\\r";
+					break;
+				case '\n':
+					val += "\\n";
+					break;
+				default:
+					val += s[i];
+					break;
+				}
+			}
+			res.set_header("EXCEPTION_WHAT", val);
+		}
+	} catch (...) {
+		if (exception_handler_) {
+			auto ep = std::current_exception();
+			exception_handler_(req, res, ep);
+			routed = true;
+		} else {
+			res.status = StatusCode::InternalServerError_500;
+			res.set_header("EXCEPTION_WHAT", "UNKNOWN");
+		}
+	}
 #endif
 
-  if (routed) {
-    if (res.status == -1) {
-      res.status = req.ranges.empty() ? StatusCode::OK_200
-                                      : StatusCode::PartialContent_206;
-    }
-    return write_response_with_content(strm, close_connection, req, res);
-  } else {
-    if (res.status == -1) { res.status = StatusCode::NotFound_404; }
-    return write_response(strm, close_connection, req, res);
-  }
+	if (routed) {
+		if (res.status == -1) {
+			res.status = req.ranges.empty() ? StatusCode::OK_200 : StatusCode::PartialContent_206;
+		}
+		return write_response_with_content(strm, close_connection, req, res);
+	} else {
+		if (res.status == -1) {
+			res.status = StatusCode::NotFound_404;
+		}
+		return write_response(strm, close_connection, req, res);
+	}
 }
 
-inline bool Server::is_valid() const { return true; }
+inline bool Server::is_valid() const {
+	return true;
+}
 
 inline bool Server::process_and_close_socket(socket_t sock) {
-  auto ret = detail::process_server_socket(
-      svr_sock_, sock, keep_alive_max_count_, keep_alive_timeout_sec_,
-      read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
-      write_timeout_usec_,
-      [this](Stream &strm, bool close_connection, bool &connection_closed) {
-        return process_request(strm, close_connection, connection_closed,
-                               nullptr);
-      });
+	auto ret = detail::process_server_socket(
+	    svr_sock_, sock, keep_alive_max_count_, keep_alive_timeout_sec_, read_timeout_sec_, read_timeout_usec_,
+	    write_timeout_sec_, write_timeout_usec_, [this](Stream &strm, bool close_connection, bool &connection_closed) {
+		    return process_request(strm, close_connection, connection_closed, nullptr);
+	    });
 
-  detail::shutdown_socket(sock);
-  detail::close_socket(sock);
-  return ret;
+	detail::shutdown_socket(sock);
+	detail::close_socket(sock);
+	return ret;
 }
 
 // HTTP client implementation
-inline ClientImpl::ClientImpl(const std::string &host)
-    : ClientImpl(host, 80, std::string(), std::string()) {}
-
-inline ClientImpl::ClientImpl(const std::string &host, int port)
-    : ClientImpl(host, port, std::string(), std::string()) {}
-
-inline ClientImpl::ClientImpl(const std::string &host, int port,
-                              const std::string &client_cert_path,
-                              const std::string &client_key_path)
-    : host_(host), port_(port),
-      host_and_port_(adjust_host_string(host) + ":" + std::to_string(port)),
-      client_cert_path_(client_cert_path), client_key_path_(client_key_path) {}
-
-inline ClientImpl::~ClientImpl() {
-  std::lock_guard<std::mutex> guard(socket_mutex_);
-  shutdown_socket(socket_);
-  close_socket(socket_);
+inline ClientImpl::ClientImpl(const std::string &host) : ClientImpl(host, 80, std::string(), std::string()) {
 }
 
-inline bool ClientImpl::is_valid() const { return true; }
+inline ClientImpl::ClientImpl(const std::string &host, int port)
+    : ClientImpl(host, port, std::string(), std::string()) {
+}
+
+inline ClientImpl::ClientImpl(const std::string &host, int port, const std::string &client_cert_path,
+                              const std::string &client_key_path)
+    : host_(host), port_(port), host_and_port_(adjust_host_string(host) + ":" + std::to_string(port)),
+      client_cert_path_(client_cert_path), client_key_path_(client_key_path) {
+}
+
+inline ClientImpl::~ClientImpl() {
+	std::lock_guard<std::mutex> guard(socket_mutex_);
+	shutdown_socket(socket_);
+	close_socket(socket_);
+}
+
+inline bool ClientImpl::is_valid() const {
+	return true;
+}
 
 inline void ClientImpl::copy_settings(const ClientImpl &rhs) {
-  client_cert_path_ = rhs.client_cert_path_;
-  client_key_path_ = rhs.client_key_path_;
-  connection_timeout_sec_ = rhs.connection_timeout_sec_;
-  read_timeout_sec_ = rhs.read_timeout_sec_;
-  read_timeout_usec_ = rhs.read_timeout_usec_;
-  write_timeout_sec_ = rhs.write_timeout_sec_;
-  write_timeout_usec_ = rhs.write_timeout_usec_;
-  basic_auth_username_ = rhs.basic_auth_username_;
-  basic_auth_password_ = rhs.basic_auth_password_;
-  bearer_token_auth_token_ = rhs.bearer_token_auth_token_;
+	client_cert_path_ = rhs.client_cert_path_;
+	client_key_path_ = rhs.client_key_path_;
+	connection_timeout_sec_ = rhs.connection_timeout_sec_;
+	read_timeout_sec_ = rhs.read_timeout_sec_;
+	read_timeout_usec_ = rhs.read_timeout_usec_;
+	write_timeout_sec_ = rhs.write_timeout_sec_;
+	write_timeout_usec_ = rhs.write_timeout_usec_;
+	basic_auth_username_ = rhs.basic_auth_username_;
+	basic_auth_password_ = rhs.basic_auth_password_;
+	bearer_token_auth_token_ = rhs.bearer_token_auth_token_;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  digest_auth_username_ = rhs.digest_auth_username_;
-  digest_auth_password_ = rhs.digest_auth_password_;
+	digest_auth_username_ = rhs.digest_auth_username_;
+	digest_auth_password_ = rhs.digest_auth_password_;
 #endif
-  keep_alive_ = rhs.keep_alive_;
-  follow_location_ = rhs.follow_location_;
-  url_encode_ = rhs.url_encode_;
-  address_family_ = rhs.address_family_;
-  tcp_nodelay_ = rhs.tcp_nodelay_;
-  socket_options_ = rhs.socket_options_;
-  compress_ = rhs.compress_;
-  decompress_ = rhs.decompress_;
-  interface_ = rhs.interface_;
-  proxy_host_ = rhs.proxy_host_;
-  proxy_port_ = rhs.proxy_port_;
-  proxy_basic_auth_username_ = rhs.proxy_basic_auth_username_;
-  proxy_basic_auth_password_ = rhs.proxy_basic_auth_password_;
-  proxy_bearer_token_auth_token_ = rhs.proxy_bearer_token_auth_token_;
+	keep_alive_ = rhs.keep_alive_;
+	follow_location_ = rhs.follow_location_;
+	url_encode_ = rhs.url_encode_;
+	address_family_ = rhs.address_family_;
+	tcp_nodelay_ = rhs.tcp_nodelay_;
+	socket_options_ = rhs.socket_options_;
+	compress_ = rhs.compress_;
+	decompress_ = rhs.decompress_;
+	interface_ = rhs.interface_;
+	proxy_host_ = rhs.proxy_host_;
+	proxy_port_ = rhs.proxy_port_;
+	proxy_basic_auth_username_ = rhs.proxy_basic_auth_username_;
+	proxy_basic_auth_password_ = rhs.proxy_basic_auth_password_;
+	proxy_bearer_token_auth_token_ = rhs.proxy_bearer_token_auth_token_;
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  proxy_digest_auth_username_ = rhs.proxy_digest_auth_username_;
-  proxy_digest_auth_password_ = rhs.proxy_digest_auth_password_;
-#endif
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  ca_cert_file_path_ = rhs.ca_cert_file_path_;
-  ca_cert_dir_path_ = rhs.ca_cert_dir_path_;
-  ca_cert_store_ = rhs.ca_cert_store_;
+	proxy_digest_auth_username_ = rhs.proxy_digest_auth_username_;
+	proxy_digest_auth_password_ = rhs.proxy_digest_auth_password_;
 #endif
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  server_certificate_verification_ = rhs.server_certificate_verification_;
+	ca_cert_file_path_ = rhs.ca_cert_file_path_;
+	ca_cert_dir_path_ = rhs.ca_cert_dir_path_;
+	ca_cert_store_ = rhs.ca_cert_store_;
 #endif
-  logger_ = rhs.logger_;
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+	server_certificate_verification_ = rhs.server_certificate_verification_;
+#endif
+	logger_ = rhs.logger_;
 }
 
 inline socket_t ClientImpl::create_client_socket(Error &error) const {
-  if (!proxy_host_.empty() && proxy_port_ != -1) {
-    return detail::create_client_socket(
-        proxy_host_, std::string(), proxy_port_, address_family_, tcp_nodelay_,
-        socket_options_, connection_timeout_sec_, connection_timeout_usec_,
-        read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
-        write_timeout_usec_, interface_, error);
-  }
+	if (!proxy_host_.empty() && proxy_port_ != -1) {
+		return detail::create_client_socket(proxy_host_, std::string(), proxy_port_, address_family_, tcp_nodelay_,
+		                                    socket_options_, connection_timeout_sec_, connection_timeout_usec_,
+		                                    read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
+		                                    write_timeout_usec_, interface_, error);
+	}
 
-  // Check is custom IP specified for host_
-  std::string ip;
-  auto it = addr_map_.find(host_);
-  if (it != addr_map_.end()) { ip = it->second; }
+	// Check is custom IP specified for host_
+	std::string ip;
+	auto it = addr_map_.find(host_);
+	if (it != addr_map_.end()) {
+		ip = it->second;
+	}
 
-  return detail::create_client_socket(
-      host_, ip, port_, address_family_, tcp_nodelay_, socket_options_,
-      connection_timeout_sec_, connection_timeout_usec_, read_timeout_sec_,
-      read_timeout_usec_, write_timeout_sec_, write_timeout_usec_, interface_,
-      error);
+	return detail::create_client_socket(host_, ip, port_, address_family_, tcp_nodelay_, socket_options_,
+	                                    connection_timeout_sec_, connection_timeout_usec_, read_timeout_sec_,
+	                                    read_timeout_usec_, write_timeout_sec_, write_timeout_usec_, interface_, error);
 }
 
-inline bool ClientImpl::create_and_connect_socket(Socket &socket,
-                                                  Error &error) {
-  auto sock = create_client_socket(error);
-  if (sock == INVALID_SOCKET) { return false; }
-  socket.sock = sock;
-  return true;
+inline bool ClientImpl::create_and_connect_socket(Socket &socket, Error &error) {
+	auto sock = create_client_socket(error);
+	if (sock == INVALID_SOCKET) {
+		return false;
+	}
+	socket.sock = sock;
+	return true;
 }
 
-inline void ClientImpl::shutdown_ssl(Socket & /*socket*/,
-                                     bool /*shutdown_gracefully*/) {
-  // If there are any requests in flight from threads other than us, then it's
-  // a thread-unsafe race because individual ssl* objects are not thread-safe.
-  assert(socket_requests_in_flight_ == 0 ||
-         socket_requests_are_from_thread_ == std::this_thread::get_id());
+inline void ClientImpl::shutdown_ssl(Socket & /*socket*/, bool /*shutdown_gracefully*/) {
+	// If there are any requests in flight from threads other than us, then it's
+	// a thread-unsafe race because individual ssl* objects are not thread-safe.
+	assert(socket_requests_in_flight_ == 0 || socket_requests_are_from_thread_ == std::this_thread::get_id());
 }
 
 inline void ClientImpl::shutdown_socket(Socket &socket) const {
-  if (socket.sock == INVALID_SOCKET) { return; }
-  detail::shutdown_socket(socket.sock);
+	if (socket.sock == INVALID_SOCKET) {
+		return;
+	}
+	detail::shutdown_socket(socket.sock);
 }
 
 inline void ClientImpl::close_socket(Socket &socket) {
-  // If there are requests in flight in another thread, usually closing
-  // the socket will be fine and they will simply receive an error when
-  // using the closed socket, but it is still a bug since rarely the OS
-  // may reassign the socket id to be used for a new socket, and then
-  // suddenly they will be operating on a live socket that is different
-  // than the one they intended!
-  assert(socket_requests_in_flight_ == 0 ||
-         socket_requests_are_from_thread_ == std::this_thread::get_id());
+	// If there are requests in flight in another thread, usually closing
+	// the socket will be fine and they will simply receive an error when
+	// using the closed socket, but it is still a bug since rarely the OS
+	// may reassign the socket id to be used for a new socket, and then
+	// suddenly they will be operating on a live socket that is different
+	// than the one they intended!
+	assert(socket_requests_in_flight_ == 0 || socket_requests_are_from_thread_ == std::this_thread::get_id());
 
-  // It is also a bug if this happens while SSL is still active
+	// It is also a bug if this happens while SSL is still active
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  assert(socket.ssl == nullptr);
+	assert(socket.ssl == nullptr);
 #endif
-  if (socket.sock == INVALID_SOCKET) { return; }
-  detail::close_socket(socket.sock);
-  socket.sock = INVALID_SOCKET;
+	if (socket.sock == INVALID_SOCKET) {
+		return;
+	}
+	detail::close_socket(socket.sock);
+	socket.sock = INVALID_SOCKET;
 }
 
-inline bool ClientImpl::read_response_line(Stream &strm, const Request &req,
-                                           Response &res) const {
-  std::array<char, 2048> buf{};
+inline bool ClientImpl::read_response_line(Stream &strm, const Request &req, Response &res) const {
+	std::array<char, 2048> buf {};
 
-  detail::stream_line_reader line_reader(strm, buf.data(), buf.size());
+	detail::stream_line_reader line_reader(strm, buf.data(), buf.size());
 
-  if (!line_reader.getline()) { return false; }
+	if (!line_reader.getline()) {
+		return false;
+	}
 
 #ifdef CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR
-  const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r?\n");
+	const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r?\n");
 #else
-  const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r\n");
+	const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r\n");
 #endif
 
-  Match m;
-  if (!RegexMatch(line_reader.ptr(), m, re)) {
-    return req.method == "CONNECT";
-  }
-  res.version = std::string(m[1]);
-  res.status = std::stoi(std::string(m[2]));
-  res.reason = std::string(m[3]);
+	Match m;
+	if (!RegexMatch(line_reader.ptr(), m, re)) {
+		return req.method == "CONNECT";
+	}
+	res.version = std::string(m[1]);
+	res.status = std::stoi(std::string(m[2]));
+	res.reason = std::string(m[3]);
 
-  // Ignore '100 Continue'
-  while (res.status == StatusCode::Continue_100) {
-    if (!line_reader.getline()) { return false; } // CRLF
-    if (!line_reader.getline()) { return false; } // next response line
+	// Ignore '100 Continue'
+	while (res.status == StatusCode::Continue_100) {
+		if (!line_reader.getline()) {
+			return false;
+		} // CRLF
+		if (!line_reader.getline()) {
+			return false;
+		} // next response line
 
-    if (!RegexMatch(line_reader.ptr(), m, re)) { return false; }
-    res.version = std::string(m[1]);
-    res.status = std::stoi(std::string(m[2]));
-    res.reason = std::string(m[3]);
-  }
+		if (!RegexMatch(line_reader.ptr(), m, re)) {
+			return false;
+		}
+		res.version = std::string(m[1]);
+		res.status = std::stoi(std::string(m[2]));
+		res.reason = std::string(m[3]);
+	}
 
-  return true;
+	return true;
 }
 
 inline bool ClientImpl::send(Request &req, Response &res, Error &error) {
-  std::lock_guard<std::recursive_mutex> request_mutex_guard(request_mutex_);
-  auto ret = send_(req, res, error);
-  if (error == Error::SSLPeerCouldBeClosed_) {
-    assert(!ret);
-    ret = send_(req, res, error);
-  }
-  return ret;
+	std::lock_guard<std::recursive_mutex> request_mutex_guard(request_mutex_);
+	auto ret = send_(req, res, error);
+	if (error == Error::SSLPeerCouldBeClosed_) {
+		assert(!ret);
+		ret = send_(req, res, error);
+	}
+	return ret;
 }
 
 inline bool ClientImpl::send_(Request &req, Response &res, Error &error) {
-  {
-    std::lock_guard<std::mutex> guard(socket_mutex_);
+	{
+		std::lock_guard<std::mutex> guard(socket_mutex_);
 
-    // Set this to false immediately - if it ever gets set to true by the end of
-    // the request, we know another thread instructed us to close the socket.
-    socket_should_be_closed_when_request_is_done_ = false;
+		// Set this to false immediately - if it ever gets set to true by the end of
+		// the request, we know another thread instructed us to close the socket.
+		socket_should_be_closed_when_request_is_done_ = false;
 
-    auto is_alive = false;
-    if (socket_.is_open()) {
-      is_alive = detail::is_socket_alive(socket_.sock);
-      if (!is_alive) {
-        // Attempt to avoid sigpipe by shutting down nongracefully if it seems
-        // like the other side has already closed the connection Also, there
-        // cannot be any requests in flight from other threads since we locked
-        // request_mutex_, so safe to close everything immediately
-        const bool shutdown_gracefully = false;
-        shutdown_ssl(socket_, shutdown_gracefully);
-        shutdown_socket(socket_);
-        close_socket(socket_);
-      }
-    }
+		auto is_alive = false;
+		if (socket_.is_open()) {
+			is_alive = detail::is_socket_alive(socket_.sock);
+			if (!is_alive) {
+				// Attempt to avoid sigpipe by shutting down nongracefully if it seems
+				// like the other side has already closed the connection Also, there
+				// cannot be any requests in flight from other threads since we locked
+				// request_mutex_, so safe to close everything immediately
+				const bool shutdown_gracefully = false;
+				shutdown_ssl(socket_, shutdown_gracefully);
+				shutdown_socket(socket_);
+				close_socket(socket_);
+			}
+		}
 
-    if (!is_alive) {
-      if (!create_and_connect_socket(socket_, error)) { return false; }
+		if (!is_alive) {
+			if (!create_and_connect_socket(socket_, error)) {
+				return false;
+			}
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-      // TODO: refactoring
-      if (is_ssl()) {
-        auto &scli = static_cast<SSLClient &>(*this);
-        if (!proxy_host_.empty() && proxy_port_ != -1) {
-          auto success = false;
-          if (!scli.connect_with_proxy(socket_, res, success, error)) {
-            return success;
-          }
-        }
+			// TODO: refactoring
+			if (is_ssl()) {
+				auto &scli = static_cast<SSLClient &>(*this);
+				if (!proxy_host_.empty() && proxy_port_ != -1) {
+					auto success = false;
+					if (!scli.connect_with_proxy(socket_, res, success, error)) {
+						return success;
+					}
+				}
 
-        if (!scli.initialize_ssl(socket_, error)) { return false; }
-      }
+				if (!scli.initialize_ssl(socket_, error)) {
+					return false;
+				}
+			}
 #endif
-    }
+		}
 
-    // Mark the current socket as being in use so that it cannot be closed by
-    // anyone else while this request is ongoing, even though we will be
-    // releasing the mutex.
-    if (socket_requests_in_flight_ > 1) {
-      assert(socket_requests_are_from_thread_ == std::this_thread::get_id());
-    }
-    socket_requests_in_flight_ += 1;
-    socket_requests_are_from_thread_ = std::this_thread::get_id();
-  }
+		// Mark the current socket as being in use so that it cannot be closed by
+		// anyone else while this request is ongoing, even though we will be
+		// releasing the mutex.
+		if (socket_requests_in_flight_ > 1) {
+			assert(socket_requests_are_from_thread_ == std::this_thread::get_id());
+		}
+		socket_requests_in_flight_ += 1;
+		socket_requests_are_from_thread_ = std::this_thread::get_id();
+	}
 
-  for (const auto &header : default_headers_) {
-    if (req.headers.find(header.first) == req.headers.end()) {
-      req.headers.insert(header);
-    }
-  }
+	for (const auto &header : default_headers_) {
+		if (req.headers.find(header.first) == req.headers.end()) {
+			req.headers.insert(header);
+		}
+	}
 
-  auto ret = false;
-  auto close_connection = !keep_alive_;
+	auto ret = false;
+	auto close_connection = !keep_alive_;
 
-  auto se = detail::scope_exit([&]() {
-    // Briefly lock mutex in order to mark that a request is no longer ongoing
-    std::lock_guard<std::mutex> guard(socket_mutex_);
-    socket_requests_in_flight_ -= 1;
-    if (socket_requests_in_flight_ <= 0) {
-      assert(socket_requests_in_flight_ == 0);
-      socket_requests_are_from_thread_ = std::thread::id();
-    }
+	auto se = detail::scope_exit([&]() {
+		// Briefly lock mutex in order to mark that a request is no longer ongoing
+		std::lock_guard<std::mutex> guard(socket_mutex_);
+		socket_requests_in_flight_ -= 1;
+		if (socket_requests_in_flight_ <= 0) {
+			assert(socket_requests_in_flight_ == 0);
+			socket_requests_are_from_thread_ = std::thread::id();
+		}
 
-    if (socket_should_be_closed_when_request_is_done_ || close_connection ||
-        !ret) {
-      shutdown_ssl(socket_, true);
-      shutdown_socket(socket_);
-      close_socket(socket_);
-    }
-  });
+		if (socket_should_be_closed_when_request_is_done_ || close_connection || !ret) {
+			shutdown_ssl(socket_, true);
+			shutdown_socket(socket_);
+			close_socket(socket_);
+		}
+	});
 
-  ret = process_socket(socket_, [&](Stream &strm) {
-    return handle_request(strm, req, res, close_connection, error);
-  });
+	ret =
+	    process_socket(socket_, [&](Stream &strm) { return handle_request(strm, req, res, close_connection, error); });
 
-  if (!ret) {
-    if (error == Error::Success) { error = Error::Unknown; }
-  }
+	if (!ret) {
+		if (error == Error::Success) {
+			error = Error::Unknown;
+		}
+	}
 
-  return ret;
+	return ret;
 }
 
 inline Result ClientImpl::send(const Request &req) {
-  auto req2 = req;
-  return send_(std::move(req2));
+	auto req2 = req;
+	return send_(std::move(req2));
 }
 
 inline Result ClientImpl::send_(Request &&req) {
-  auto res = detail::make_unique<Response>();
-  auto error = Error::Success;
-  auto ret = send(req, *res, error);
-  return Result{ret ? std::move(res) : nullptr, error, std::move(req.headers)};
+	auto res = detail::make_unique<Response>();
+	auto error = Error::Success;
+	auto ret = send(req, *res, error);
+	return Result {ret ? std::move(res) : nullptr, error, std::move(req.headers)};
 }
 
-inline bool ClientImpl::handle_request(Stream &strm, Request &req,
-                                       Response &res, bool close_connection,
-                                       Error &error) {
-  if (req.path.empty()) {
-    error = Error::Connection;
-    return false;
-  }
+inline bool ClientImpl::handle_request(Stream &strm, Request &req, Response &res, bool close_connection, Error &error) {
+	if (req.path.empty()) {
+		error = Error::Connection;
+		return false;
+	}
 
-  auto req_save = req;
+	auto req_save = req;
 
-  bool ret;
+	bool ret;
 
-  if (!is_ssl() && !proxy_host_.empty() && proxy_port_ != -1) {
-    auto req2 = req;
-    req2.path = "http://" + host_and_port_ + req.path;
-    ret = process_request(strm, req2, res, close_connection, error);
-    req = req2;
-    req.path = req_save.path;
-  } else {
-    ret = process_request(strm, req, res, close_connection, error);
-  }
+	if (!is_ssl() && !proxy_host_.empty() && proxy_port_ != -1) {
+		auto req2 = req;
+		req2.path = "http://" + host_and_port_ + req.path;
+		ret = process_request(strm, req2, res, close_connection, error);
+		req = req2;
+		req.path = req_save.path;
+	} else {
+		ret = process_request(strm, req, res, close_connection, error);
+	}
 
-  if (!ret) { return false; }
+	if (!ret) {
+		return false;
+	}
 
-  if (res.get_header_value("Connection") == "close" ||
-      (res.version == "HTTP/1.0" && res.reason != "Connection established")) {
-    // TODO this requires a not-entirely-obvious chain of calls to be correct
-    // for this to be safe.
+	if (res.get_header_value("Connection") == "close" ||
+	    (res.version == "HTTP/1.0" && res.reason != "Connection established")) {
+		// TODO this requires a not-entirely-obvious chain of calls to be correct
+		// for this to be safe.
 
-    // This is safe to call because handle_request is only called by send_
-    // which locks the request mutex during the process. It would be a bug
-    // to call it from a different thread since it's a thread-safety issue
-    // to do these things to the socket if another thread is using the socket.
-    std::lock_guard<std::mutex> guard(socket_mutex_);
-    shutdown_ssl(socket_, true);
-    shutdown_socket(socket_);
-    close_socket(socket_);
-  }
+		// This is safe to call because handle_request is only called by send_
+		// which locks the request mutex during the process. It would be a bug
+		// to call it from a different thread since it's a thread-safety issue
+		// to do these things to the socket if another thread is using the socket.
+		std::lock_guard<std::mutex> guard(socket_mutex_);
+		shutdown_ssl(socket_, true);
+		shutdown_socket(socket_);
+		close_socket(socket_);
+	}
 
-  if (300 < res.status && res.status < 400 && follow_location_) {
-    req = req_save;
-    ret = redirect(req, res, error);
-  }
+	if (300 < res.status && res.status < 400 && follow_location_) {
+		req = req_save;
+		ret = redirect(req, res, error);
+	}
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  if ((res.status == StatusCode::Unauthorized_401 ||
-       res.status == StatusCode::ProxyAuthenticationRequired_407) &&
-      req.authorization_count_ < 5) {
-    auto is_proxy = res.status == StatusCode::ProxyAuthenticationRequired_407;
-    const auto &username =
-        is_proxy ? proxy_digest_auth_username_ : digest_auth_username_;
-    const auto &password =
-        is_proxy ? proxy_digest_auth_password_ : digest_auth_password_;
+	if ((res.status == StatusCode::Unauthorized_401 || res.status == StatusCode::ProxyAuthenticationRequired_407) &&
+	    req.authorization_count_ < 5) {
+		auto is_proxy = res.status == StatusCode::ProxyAuthenticationRequired_407;
+		const auto &username = is_proxy ? proxy_digest_auth_username_ : digest_auth_username_;
+		const auto &password = is_proxy ? proxy_digest_auth_password_ : digest_auth_password_;
 
-    if (!username.empty() && !password.empty()) {
-      std::map<std::string, std::string> auth;
-      if (detail::parse_www_authenticate(res, auth, is_proxy)) {
-        Request new_req = req;
-        new_req.authorization_count_ += 1;
-        new_req.headers.erase(is_proxy ? "Proxy-Authorization"
-                                       : "Authorization");
-        new_req.headers.insert(detail::make_digest_authentication_header(
-            req, auth, new_req.authorization_count_, detail::random_string(10),
-            username, password, is_proxy));
+		if (!username.empty() && !password.empty()) {
+			std::map<std::string, std::string> auth;
+			if (detail::parse_www_authenticate(res, auth, is_proxy)) {
+				Request new_req = req;
+				new_req.authorization_count_ += 1;
+				new_req.headers.erase(is_proxy ? "Proxy-Authorization" : "Authorization");
+				new_req.headers.insert(detail::make_digest_authentication_header(
+				    req, auth, new_req.authorization_count_, detail::random_string(10), username, password, is_proxy));
 
-        Response new_res;
+				Response new_res;
 
-        ret = send(new_req, new_res, error);
-        if (ret) { res = new_res; }
-      }
-    }
-  }
+				ret = send(new_req, new_res, error);
+				if (ret) {
+					res = new_res;
+				}
+			}
+		}
+	}
 #endif
 
-  return ret;
+	return ret;
 }
 
 inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
-  if (req.redirect_count_ == 0) {
-    error = Error::ExceedRedirectCount;
-    return false;
-  }
+	if (req.redirect_count_ == 0) {
+		error = Error::ExceedRedirectCount;
+		return false;
+	}
 
-  auto location = res.get_header_value("location");
-  if (location.empty()) { return false; }
+	auto location = res.get_header_value("location");
+	if (location.empty()) {
+		return false;
+	}
 
-  const Regex re(
-      R"((?:(https?):)?(?://(?:\[([\d:]+)\]|([^:/?#]+))(?::(\d+))?)?([^?#]*)(\?[^#]*)?(?:#.*)?)");
+	const Regex re(R"((?:(https?):)?(?://(?:\[([\d:]+)\]|([^:/?#]+))(?::(\d+))?)?([^?#]*)(\?[^#]*)?(?:#.*)?)");
 
-  Match m;
-  if (!RegexMatch(location, m, re)) { return false; }
+	Match m;
+	if (!RegexMatch(location, m, re)) {
+		return false;
+	}
 
-  auto scheme = is_ssl() ? "https" : "http";
+	auto scheme = is_ssl() ? "https" : "http";
 
-  auto next_scheme = m[1].str();
-  auto next_host = m[2].str();
-  if (next_host.empty()) { next_host = m[3].str(); }
-  auto port_str = m[4].str();
-  auto next_path = m[5].str();
-  auto next_query = m[6].str();
+	auto next_scheme = m[1].str();
+	auto next_host = m[2].str();
+	if (next_host.empty()) {
+		next_host = m[3].str();
+	}
+	auto port_str = m[4].str();
+	auto next_path = m[5].str();
+	auto next_query = m[6].str();
 
-  auto next_port = port_;
-  if (!port_str.empty()) {
-    next_port = std::stoi(port_str);
-  } else if (!next_scheme.empty()) {
-    next_port = next_scheme == "https" ? 443 : 80;
-  }
+	auto next_port = port_;
+	if (!port_str.empty()) {
+		next_port = std::stoi(port_str);
+	} else if (!next_scheme.empty()) {
+		next_port = next_scheme == "https" ? 443 : 80;
+	}
 
-  if (next_scheme.empty()) { next_scheme = scheme; }
-  if (next_host.empty()) { next_host = host_; }
-  if (next_path.empty()) { next_path = "/"; }
-  
-  auto path = detail::decode_url(next_path, true, std::set<char> {'/'}) + next_query;
-	
-  if (next_scheme == scheme && next_host == host_ && next_port == port_) {
-    return detail::redirect(*this, req, res, path, location, error);
-  } else {
-    if (next_scheme == "https") {
+	if (next_scheme.empty()) {
+		next_scheme = scheme;
+	}
+	if (next_host.empty()) {
+		next_host = host_;
+	}
+	if (next_path.empty()) {
+		next_path = "/";
+	}
+
+	auto path = detail::decode_url(next_path, true, std::set<char> {'/'}) + next_query;
+
+	if (next_scheme == scheme && next_host == host_ && next_port == port_) {
+		return detail::redirect(*this, req, res, path, location, error);
+	} else {
+		if (next_scheme == "https") {
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-      SSLClient cli(next_host, next_port);
-      cli.copy_settings(*this);
-      if (ca_cert_store_) { cli.set_ca_cert_store(ca_cert_store_); }
-      return detail::redirect(cli, req, res, path, location, error);
+			SSLClient cli(next_host, next_port);
+			cli.copy_settings(*this);
+			if (ca_cert_store_) {
+				cli.set_ca_cert_store(ca_cert_store_);
+			}
+			return detail::redirect(cli, req, res, path, location, error);
 #else
-      return false;
+			return false;
 #endif
-    } else {
-      ClientImpl cli(next_host, next_port);
-      cli.copy_settings(*this);
-      return detail::redirect(cli, req, res, path, location, error);
-    }
-  }
+		} else {
+			ClientImpl cli(next_host, next_port);
+			cli.copy_settings(*this);
+			return detail::redirect(cli, req, res, path, location, error);
+		}
+	}
 }
 
-inline bool ClientImpl::write_content_with_provider(Stream &strm,
-                                                    const Request &req,
-                                                    Error &error) const {
-  auto is_shutting_down = []() { return false; };
+inline bool ClientImpl::write_content_with_provider(Stream &strm, const Request &req, Error &error) const {
+	auto is_shutting_down = []() {
+		return false;
+	};
 
-  if (req.is_chunked_content_provider_) {
-    // TODO: Brotli support
-    duckdb::unique_ptr<detail::compressor> compressor;
+	if (req.is_chunked_content_provider_) {
+		// TODO: Brotli support
+		duckdb::unique_ptr<detail::compressor> compressor;
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-    if (compress_) {
-      compressor = detail::make_unique<detail::gzip_compressor>();
-    } else
+		if (compress_) {
+			compressor = detail::make_unique<detail::gzip_compressor>();
+		} else
 #endif
-    {
-      compressor = detail::make_unique<detail::nocompressor>();
-    }
+		{
+			compressor = detail::make_unique<detail::nocompressor>();
+		}
 
-    return detail::write_content_chunked(strm, req.content_provider_,
-                                         is_shutting_down, *compressor, error);
-  } else {
-    return detail::write_content(strm, req.content_provider_, 0,
-                                 req.content_length_, is_shutting_down, error);
-  }
+		return detail::write_content_chunked(strm, req.content_provider_, is_shutting_down, *compressor, error);
+	} else {
+		return detail::write_content(strm, req.content_provider_, 0, req.content_length_, is_shutting_down, error);
+	}
 }
 
-inline bool ClientImpl::write_request(Stream &strm, Request &req,
-                                      bool close_connection, Error &error) {
-  // Prepare additional headers
-  if (close_connection) {
-    if (!req.has_header("Connection")) {
-      req.set_header("Connection", "close");
-    }
-  }
+inline bool ClientImpl::write_request(Stream &strm, Request &req, bool close_connection, Error &error) {
+	// Prepare additional headers
+	if (close_connection) {
+		if (!req.has_header("Connection")) {
+			req.set_header("Connection", "close");
+		}
+	}
 
-  if (!req.has_header("Host")) {
-    if (is_ssl()) {
-      if (port_ == 443) {
-        req.set_header("Host", host_);
-      } else {
-        req.set_header("Host", host_and_port_);
-      }
-    } else {
-      if (port_ == 80) {
-        req.set_header("Host", host_);
-      } else {
-        req.set_header("Host", host_and_port_);
-      }
-    }
-  }
+	if (!req.has_header("Host")) {
+		if (is_ssl()) {
+			if (port_ == 443) {
+				req.set_header("Host", host_);
+			} else {
+				req.set_header("Host", host_and_port_);
+			}
+		} else {
+			if (port_ == 80) {
+				req.set_header("Host", host_);
+			} else {
+				req.set_header("Host", host_and_port_);
+			}
+		}
+	}
 
-  if (!req.has_header("Accept")) { req.set_header("Accept", "*/*"); }
+	if (!req.has_header("Accept")) {
+		req.set_header("Accept", "*/*");
+	}
 
 #ifndef CPPHTTPLIB_NO_DEFAULT_USER_AGENT
-  if (!req.has_header("User-Agent")) {
-    auto agent = std::string("cpp-httplib/") + CPPHTTPLIB_VERSION;
-    req.set_header("User-Agent", agent);
-  }
+	if (!req.has_header("User-Agent")) {
+		auto agent = std::string("cpp-httplib/") + CPPHTTPLIB_VERSION;
+		req.set_header("User-Agent", agent);
+	}
 #endif
 
-  if (req.body.empty()) {
-    if (req.content_provider_) {
-      if (!req.is_chunked_content_provider_) {
-        if (!req.has_header("Content-Length")) {
-          auto length = std::to_string(req.content_length_);
-          req.set_header("Content-Length", length);
-        }
-      }
-    } else {
-      if (req.method == "POST" || req.method == "PUT" ||
-          req.method == "PATCH") {
-        req.set_header("Content-Length", "0");
-      }
-    }
-  } else {
-    if (!req.has_header("Content-Type")) {
-      req.set_header("Content-Type", "text/plain");
-    }
+	if (req.body.empty()) {
+		if (req.content_provider_) {
+			if (!req.is_chunked_content_provider_) {
+				if (!req.has_header("Content-Length")) {
+					auto length = std::to_string(req.content_length_);
+					req.set_header("Content-Length", length);
+				}
+			}
+		} else {
+			if (req.method == "POST" || req.method == "PUT" || req.method == "PATCH") {
+				req.set_header("Content-Length", "0");
+			}
+		}
+	} else {
+		if (!req.has_header("Content-Type")) {
+			req.set_header("Content-Type", "text/plain");
+		}
 
-    if (!req.has_header("Content-Length")) {
-      auto length = std::to_string(req.body.size());
-      req.set_header("Content-Length", length);
-    }
-  }
+		if (!req.has_header("Content-Length")) {
+			auto length = std::to_string(req.body.size());
+			req.set_header("Content-Length", length);
+		}
+	}
 
-  if (!basic_auth_password_.empty() || !basic_auth_username_.empty()) {
-    if (!req.has_header("Authorization")) {
-      req.headers.insert(make_basic_authentication_header(
-          basic_auth_username_, basic_auth_password_, false));
-    }
-  }
+	if (!basic_auth_password_.empty() || !basic_auth_username_.empty()) {
+		if (!req.has_header("Authorization")) {
+			req.headers.insert(make_basic_authentication_header(basic_auth_username_, basic_auth_password_, false));
+		}
+	}
 
-  if (!proxy_basic_auth_username_.empty() &&
-      !proxy_basic_auth_password_.empty()) {
-    if (!req.has_header("Proxy-Authorization")) {
-      req.headers.insert(make_basic_authentication_header(
-          proxy_basic_auth_username_, proxy_basic_auth_password_, true));
-    }
-  }
+	if (!proxy_basic_auth_username_.empty() && !proxy_basic_auth_password_.empty()) {
+		if (!req.has_header("Proxy-Authorization")) {
+			req.headers.insert(
+			    make_basic_authentication_header(proxy_basic_auth_username_, proxy_basic_auth_password_, true));
+		}
+	}
 
-  if (!bearer_token_auth_token_.empty()) {
-    if (!req.has_header("Authorization")) {
-      req.headers.insert(make_bearer_token_authentication_header(
-          bearer_token_auth_token_, false));
-    }
-  }
+	if (!bearer_token_auth_token_.empty()) {
+		if (!req.has_header("Authorization")) {
+			req.headers.insert(make_bearer_token_authentication_header(bearer_token_auth_token_, false));
+		}
+	}
 
-  if (!proxy_bearer_token_auth_token_.empty()) {
-    if (!req.has_header("Proxy-Authorization")) {
-      req.headers.insert(make_bearer_token_authentication_header(
-          proxy_bearer_token_auth_token_, true));
-    }
-  }
+	if (!proxy_bearer_token_auth_token_.empty()) {
+		if (!req.has_header("Proxy-Authorization")) {
+			req.headers.insert(make_bearer_token_authentication_header(proxy_bearer_token_auth_token_, true));
+		}
+	}
 
-  // Request line and headers
-  {
-    detail::BufferStream bstrm;
+	// Request line and headers
+	{
+		detail::BufferStream bstrm;
 
-    const auto &path = url_encode_ ? detail::encode_url(req.path) : req.path;
-    bstrm.write_format("%s %s HTTP/1.1\r\n", req.method.c_str(), path.c_str());
+		const auto &path = url_encode_ ? detail::encode_url(req.path) : req.path;
+		bstrm.write_format("%s %s HTTP/1.1\r\n", req.method.c_str(), path.c_str());
 
-    header_writer_(bstrm, req.headers);
+		header_writer_(bstrm, req.headers);
 
-    // Flush buffer
-    auto &data = bstrm.get_buffer();
-    if (!detail::write_data(strm, data.data(), data.size())) {
-      error = Error::Write;
-      return false;
-    }
-  }
+		// Flush buffer
+		auto &data = bstrm.get_buffer();
+		if (!detail::write_data(strm, data.data(), data.size())) {
+			error = Error::Write;
+			return false;
+		}
+	}
 
-  // Body
-  if (req.body.empty()) {
-    return write_content_with_provider(strm, req, error);
-  }
+	// Body
+	if (req.body.empty()) {
+		return write_content_with_provider(strm, req, error);
+	}
 
-  if (!detail::write_data(strm, req.body.data(), req.body.size())) {
-    error = Error::Write;
-    return false;
-  }
+	if (!detail::write_data(strm, req.body.data(), req.body.size())) {
+		error = Error::Write;
+		return false;
+	}
 
-  return true;
+	return true;
 }
 
 inline duckdb::unique_ptr<Response> ClientImpl::send_with_content_provider(
-    Request &req, const char *body, size_t content_length,
-    ContentProvider content_provider,
-    ContentProviderWithoutLength content_provider_without_length,
-    const std::string &content_type, Error &error) {
-  if (!content_type.empty()) { req.set_header("Content-Type", content_type); }
+    Request &req, const char *body, size_t content_length, ContentProvider content_provider,
+    ContentProviderWithoutLength content_provider_without_length, const std::string &content_type, Error &error) {
+	if (!content_type.empty()) {
+		req.set_header("Content-Type", content_type);
+	}
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-  if (compress_) { req.set_header("Content-Encoding", "gzip"); }
+	if (compress_) {
+		req.set_header("Content-Encoding", "gzip");
+	}
 #endif
 
 #ifdef CPPHTTPLIB_ZLIB_SUPPORT
-  if (compress_ && !content_provider_without_length) {
-    // TODO: Brotli support
-    detail::gzip_compressor compressor;
+	if (compress_ && !content_provider_without_length) {
+		// TODO: Brotli support
+		detail::gzip_compressor compressor;
 
-    if (content_provider) {
-      auto ok = true;
-      size_t offset = 0;
-      DataSink data_sink;
+		if (content_provider) {
+			auto ok = true;
+			size_t offset = 0;
+			DataSink data_sink;
 
-      data_sink.write = [&](const char *data, size_t data_len) -> bool {
-        if (ok) {
-          auto last = offset + data_len == content_length;
+			data_sink.write = [&](const char *data, size_t data_len) -> bool {
+				if (ok) {
+					auto last = offset + data_len == content_length;
 
-          auto ret = compressor.compress(
-              data, data_len, last,
-              [&](const char *compressed_data, size_t compressed_data_len) {
-                req.body.append(compressed_data, compressed_data_len);
-                return true;
-              });
+					auto ret = compressor.compress(data, data_len, last,
+					                               [&](const char *compressed_data, size_t compressed_data_len) {
+						                               req.body.append(compressed_data, compressed_data_len);
+						                               return true;
+					                               });
 
-          if (ret) {
-            offset += data_len;
-          } else {
-            ok = false;
-          }
-        }
-        return ok;
-      };
+					if (ret) {
+						offset += data_len;
+					} else {
+						ok = false;
+					}
+				}
+				return ok;
+			};
 
-      while (ok && offset < content_length) {
-        if (!content_provider(offset, content_length - offset, data_sink)) {
-          error = Error::Canceled;
-          return nullptr;
-        }
-      }
-    } else {
-      if (!compressor.compress(body, content_length, true,
-                               [&](const char *data, size_t data_len) {
-                                 req.body.append(data, data_len);
-                                 return true;
-                               })) {
-        error = Error::Compression;
-        return nullptr;
-      }
-    }
-  } else
+			while (ok && offset < content_length) {
+				if (!content_provider(offset, content_length - offset, data_sink)) {
+					error = Error::Canceled;
+					return nullptr;
+				}
+			}
+		} else {
+			if (!compressor.compress(body, content_length, true, [&](const char *data, size_t data_len) {
+				    req.body.append(data, data_len);
+				    return true;
+			    })) {
+				error = Error::Compression;
+				return nullptr;
+			}
+		}
+	} else
 #endif
-  {
-    if (content_provider) {
-      req.content_length_ = content_length;
-      req.content_provider_ = std::move(content_provider);
-      req.is_chunked_content_provider_ = false;
-    } else if (content_provider_without_length) {
-      req.content_length_ = 0;
-      req.content_provider_ = detail::ContentProviderAdapter(
-          std::move(content_provider_without_length));
-      req.is_chunked_content_provider_ = true;
-      req.set_header("Transfer-Encoding", "chunked");
-    } else {
-      req.body.assign(body, content_length);
-    }
-  }
+	{
+		if (content_provider) {
+			req.content_length_ = content_length;
+			req.content_provider_ = std::move(content_provider);
+			req.is_chunked_content_provider_ = false;
+		} else if (content_provider_without_length) {
+			req.content_length_ = 0;
+			req.content_provider_ = detail::ContentProviderAdapter(std::move(content_provider_without_length));
+			req.is_chunked_content_provider_ = true;
+			req.set_header("Transfer-Encoding", "chunked");
+		} else {
+			req.body.assign(body, content_length);
+		}
+	}
 
-  auto res = detail::make_unique<Response>();
-  return send(req, *res, error) ? std::move(res) : nullptr;
+	auto res = detail::make_unique<Response>();
+	return send(req, *res, error) ? std::move(res) : nullptr;
 }
 
-inline Result ClientImpl::send_with_content_provider(
-    const std::string &method, const std::string &path, const Headers &headers,
-    const char *body, size_t content_length, ContentProvider content_provider,
-    ContentProviderWithoutLength content_provider_without_length,
-    const std::string &content_type) {
-  Request req;
-  req.method = method;
-  req.headers = headers;
-  req.path = path;
+inline Result ClientImpl::send_with_content_provider(const std::string &method, const std::string &path,
+                                                     const Headers &headers, const char *body, size_t content_length,
+                                                     ContentProvider content_provider,
+                                                     ContentProviderWithoutLength content_provider_without_length,
+                                                     const std::string &content_type) {
+	Request req;
+	req.method = method;
+	req.headers = headers;
+	req.path = path;
 
-  auto error = Error::Success;
+	auto error = Error::Success;
 
-  auto res = send_with_content_provider(
-      req, body, content_length, std::move(content_provider),
-      std::move(content_provider_without_length), content_type, error);
+	auto res = send_with_content_provider(req, body, content_length, std::move(content_provider),
+	                                      std::move(content_provider_without_length), content_type, error);
 
-  return Result{std::move(res), error, std::move(req.headers)};
+	return Result {std::move(res), error, std::move(req.headers)};
 }
 
-inline std::string
-ClientImpl::adjust_host_string(const std::string &host) const {
-  if (host.find(':') != std::string::npos) { return "[" + host + "]"; }
-  return host;
+inline std::string ClientImpl::adjust_host_string(const std::string &host) const {
+	if (host.find(':') != std::string::npos) {
+		return "[" + host + "]";
+	}
+	return host;
 }
 
-inline bool ClientImpl::process_request(Stream &strm, Request &req,
-                                        Response &res, bool close_connection,
+inline bool ClientImpl::process_request(Stream &strm, Request &req, Response &res, bool close_connection,
                                         Error &error) {
-  // Send request
-  if (!write_request(strm, req, close_connection, error)) { return false; }
+	// Send request
+	if (!write_request(strm, req, close_connection, error)) {
+		return false;
+	}
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-  if (is_ssl()) {
-    auto is_proxy_enabled = !proxy_host_.empty() && proxy_port_ != -1;
-    if (!is_proxy_enabled) {
-      char buf[1];
-      if (SSL_peek(socket_.ssl, buf, 1) == 0 &&
-          SSL_get_error(socket_.ssl, 0) == SSL_ERROR_ZERO_RETURN) {
-        error = Error::SSLPeerCouldBeClosed_;
-        return false;
-      }
-    }
-  }
+	if (is_ssl()) {
+		auto is_proxy_enabled = !proxy_host_.empty() && proxy_port_ != -1;
+		if (!is_proxy_enabled) {
+			char buf[1];
+			if (SSL_peek(socket_.ssl, buf, 1) == 0 && SSL_get_error(socket_.ssl, 0) == SSL_ERROR_ZERO_RETURN) {
+				error = Error::SSLPeerCouldBeClosed_;
+				return false;
+			}
+		}
+	}
 #endif
 
-  // Receive response and headers
-  if (!read_response_line(strm, req, res) ||
-      !detail::read_headers(strm, res.headers)) {
-    error = Error::Read;
-    return false;
-  }
+	// Receive response and headers
+	if (!read_response_line(strm, req, res) || !detail::read_headers(strm, res.headers)) {
+		error = Error::Read;
+		return false;
+	}
 
-  // Body
-  if ((res.status != StatusCode::NoContent_204) && req.method != "HEAD" &&
-      req.method != "CONNECT") {
-    auto redirect = 300 < res.status && res.status < 400 && follow_location_;
+	// Body
+	if ((res.status != StatusCode::NoContent_204) && req.method != "CONNECT") {
+		auto redirect = 300 < res.status && res.status < 400 && follow_location_;
 
-    if (req.response_handler && !redirect) {
-      if (!req.response_handler(res)) {
-        error = Error::Canceled;
-        return false;
-      }
-    }
+		if (req.response_handler && !redirect) {
+			if (!req.response_handler(res)) {
+				error = Error::Canceled;
+				return false;
+			}
+		}
 
-    auto out =
-        req.content_receiver
-            ? static_cast<ContentReceiverWithProgress>(
-                  [&](const char *buf, size_t n, uint64_t off, uint64_t len) {
-                    if (redirect) { return true; }
-                    auto ret = req.content_receiver(buf, n, off, len);
-                    if (!ret) { error = Error::Canceled; }
-                    return ret;
-                  })
-            : static_cast<ContentReceiverWithProgress>(
-                  [&](const char *buf, size_t n, uint64_t /*off*/,
-                      uint64_t /*len*/) {
-                    if (res.body.size() + n > res.body.max_size()) {
-                      return false;
-                    }
-                    res.body.append(buf, n);
-                    return true;
-                  });
+		auto out =
+		    req.content_receiver
+		        ? static_cast<ContentReceiverWithProgress>([&](const char *buf, size_t n, uint64_t off, uint64_t len) {
+			          if (redirect) {
+				          return true;
+			          }
+			          auto ret = req.content_receiver(buf, n, off, len);
+			          if (!ret) {
+				          error = Error::Canceled;
+			          }
+			          return ret;
+		          })
+		        : static_cast<ContentReceiverWithProgress>(
+		              [&](const char *buf, size_t n, uint64_t /*off*/, uint64_t /*len*/) {
+			              if (res.body.size() + n > res.body.max_size()) {
+				              return false;
+			              }
+			              res.body.append(buf, n);
+			              return true;
+		              });
 
-    auto progress = [&](uint64_t current, uint64_t total) {
-      if (!req.progress || redirect) { return true; }
-      auto ret = req.progress(current, total);
-      if (!ret) { error = Error::Canceled; }
-      return ret;
-    };
+		auto progress = [&](uint64_t current, uint64_t total) {
+			if (!req.progress || redirect) {
+				return true;
+			}
+			auto ret = req.progress(current, total);
+			if (!ret) {
+				error = Error::Canceled;
+			}
+			return ret;
+		};
 
-    int dummy_status;
-    if (!detail::read_content(strm, res, (std::numeric_limits<size_t>::max)(),
-                              dummy_status, std::move(progress), std::move(out),
-                              decompress_)) {
-      if (error != Error::Canceled) { error = Error::Read; }
-      return false;
-    }
-  }
+		int dummy_status;
+		if (!detail::read_content(strm, res, (std::numeric_limits<size_t>::max)(), dummy_status, std::move(progress),
+		                          std::move(out), decompress_)) {
+			if (error != Error::Canceled) {
+				error = Error::Read;
+			}
+			return false;
+		}
+	}
 
-  // Log
-  if (logger_) { logger_(req, res); }
+	// Log
+	if (logger_) {
+		logger_(req, res);
+	}
 
-  return true;
+	return true;
 }
 
-inline ContentProviderWithoutLength ClientImpl::get_multipart_content_provider(
-    const std::string &boundary, const MultipartFormDataItems &items,
-    const MultipartFormDataProviderItems &provider_items) const {
-  size_t cur_item = 0;
-  size_t cur_start = 0;
-  // cur_item and cur_start are copied to within the std::function and maintain
-  // state between successive calls
-  return [&, cur_item, cur_start](size_t offset,
-                                  DataSink &sink) mutable -> bool {
-    if (!offset && !items.empty()) {
-      sink.os << detail::serialize_multipart_formdata(items, boundary, false);
-      return true;
-    } else if (cur_item < provider_items.size()) {
-      if (!cur_start) {
-        const auto &begin = detail::serialize_multipart_formdata_item_begin(
-            provider_items[cur_item], boundary);
-        offset += begin.size();
-        cur_start = offset;
-        sink.os << begin;
-      }
+inline ContentProviderWithoutLength
+ClientImpl::get_multipart_content_provider(const std::string &boundary, const MultipartFormDataItems &items,
+                                           const MultipartFormDataProviderItems &provider_items) const {
+	size_t cur_item = 0;
+	size_t cur_start = 0;
+	// cur_item and cur_start are copied to within the std::function and maintain
+	// state between successive calls
+	return [&, cur_item, cur_start](size_t offset, DataSink &sink) mutable -> bool {
+		if (!offset && !items.empty()) {
+			sink.os << detail::serialize_multipart_formdata(items, boundary, false);
+			return true;
+		} else if (cur_item < provider_items.size()) {
+			if (!cur_start) {
+				const auto &begin = detail::serialize_multipart_formdata_item_begin(provider_items[cur_item], boundary);
+				offset += begin.size();
+				cur_start = offset;
+				sink.os << begin;
+			}
 
-      DataSink cur_sink;
-      auto has_data = true;
-      cur_sink.write = sink.write;
-      cur_sink.done = [&]() { has_data = false; };
+			DataSink cur_sink;
+			auto has_data = true;
+			cur_sink.write = sink.write;
+			cur_sink.done = [&]() {
+				has_data = false;
+			};
 
-      if (!provider_items[cur_item].provider(offset - cur_start, cur_sink)) {
-        return false;
-      }
+			if (!provider_items[cur_item].provider(offset - cur_start, cur_sink)) {
+				return false;
+			}
 
-      if (!has_data) {
-        sink.os << detail::serialize_multipart_formdata_item_end();
-        cur_item++;
-        cur_start = 0;
-      }
-      return true;
-    } else {
-      sink.os << detail::serialize_multipart_formdata_finish(boundary);
-      sink.done();
-      return true;
-    }
-  };
+			if (!has_data) {
+				sink.os << detail::serialize_multipart_formdata_item_end();
+				cur_item++;
+				cur_start = 0;
+			}
+			return true;
+		} else {
+			sink.os << detail::serialize_multipart_formdata_finish(boundary);
+			sink.done();
+			return true;
+		}
+	};
 }
 
-inline bool
-ClientImpl::process_socket(const Socket &socket,
-                           std::function<bool(Stream &strm)> callback) {
-  return detail::process_client_socket(
-      socket.sock, read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
-      write_timeout_usec_, std::move(callback));
+inline bool ClientImpl::process_socket(const Socket &socket, std::function<bool(Stream &strm)> callback) {
+	return detail::process_client_socket(socket.sock, read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
+	                                     write_timeout_usec_, std::move(callback));
 }
 
-inline bool ClientImpl::is_ssl() const { return false; }
+inline bool ClientImpl::is_ssl() const {
+	return false;
+}
 
 inline Result ClientImpl::Get(const std::string &path) {
-  return Get(path, Headers(), Progress());
+	return Get(path, Headers(), Progress());
 }
 
 inline Result ClientImpl::Get(const std::string &path, Progress progress) {
-  return Get(path, Headers(), std::move(progress));
+	return Get(path, Headers(), std::move(progress));
 }
 
 inline Result ClientImpl::Get(const std::string &path, const Headers &headers) {
-  return Get(path, headers, Progress());
+	return Get(path, headers, Progress());
 }
 
-inline Result ClientImpl::Get(const std::string &path, const Headers &headers,
+inline Result ClientImpl::Get(const std::string &path, const Headers &headers, Progress progress) {
+	Request req;
+	req.method = "GET";
+	req.path = path;
+	req.headers = headers;
+	req.progress = std::move(progress);
+
+	return send_(std::move(req));
+}
+
+inline Result ClientImpl::Get(const std::string &path, ContentReceiver content_receiver) {
+	return Get(path, Headers(), nullptr, std::move(content_receiver), nullptr);
+}
+
+inline Result ClientImpl::Get(const std::string &path, ContentReceiver content_receiver, Progress progress) {
+	return Get(path, Headers(), nullptr, std::move(content_receiver), std::move(progress));
+}
+
+inline Result ClientImpl::Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver) {
+	return Get(path, headers, nullptr, std::move(content_receiver), nullptr);
+}
+
+inline Result ClientImpl::Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver,
                               Progress progress) {
-  Request req;
-  req.method = "GET";
-  req.path = path;
-  req.headers = headers;
-  req.progress = std::move(progress);
-
-  return send_(std::move(req));
+	return Get(path, headers, nullptr, std::move(content_receiver), std::move(progress));
 }
 
-inline Result ClientImpl::Get(const std::string &path,
+inline Result ClientImpl::Get(const std::string &path, ResponseHandler response_handler,
                               ContentReceiver content_receiver) {
-  return Get(path, Headers(), nullptr, std::move(content_receiver), nullptr);
+	return Get(path, Headers(), std::move(response_handler), std::move(content_receiver), nullptr);
 }
 
-inline Result ClientImpl::Get(const std::string &path,
-                              ContentReceiver content_receiver,
-                              Progress progress) {
-  return Get(path, Headers(), nullptr, std::move(content_receiver),
-             std::move(progress));
-}
-
-inline Result ClientImpl::Get(const std::string &path, const Headers &headers,
+inline Result ClientImpl::Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
                               ContentReceiver content_receiver) {
-  return Get(path, headers, nullptr, std::move(content_receiver), nullptr);
+	return Get(path, headers, std::move(response_handler), std::move(content_receiver), nullptr);
 }
 
-inline Result ClientImpl::Get(const std::string &path, const Headers &headers,
-                              ContentReceiver content_receiver,
+inline Result ClientImpl::Get(const std::string &path, ResponseHandler response_handler,
+                              ContentReceiver content_receiver, Progress progress) {
+	return Get(path, Headers(), std::move(response_handler), std::move(content_receiver), std::move(progress));
+}
+
+inline Result ClientImpl::Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
+                              ContentReceiver content_receiver, Progress progress) {
+	Request req;
+	req.method = "GET";
+	req.path = path;
+	req.headers = headers;
+	req.response_handler = std::move(response_handler);
+	req.content_receiver = [content_receiver](const char *data, size_t data_length, uint64_t /*offset*/,
+	                                          uint64_t /*total_length*/) {
+		return content_receiver(data, data_length);
+	};
+	req.progress = std::move(progress);
+
+	return send_(std::move(req));
+}
+
+inline Result ClientImpl::Get(const std::string &path, const Params &params, const Headers &headers,
                               Progress progress) {
-  return Get(path, headers, nullptr, std::move(content_receiver),
-             std::move(progress));
+	if (params.empty()) {
+		return Get(path, headers);
+	}
+
+	std::string path_with_query = append_query_params(path, params);
+	return Get(path_with_query, headers, progress);
 }
 
-inline Result ClientImpl::Get(const std::string &path,
-                              ResponseHandler response_handler,
-                              ContentReceiver content_receiver) {
-  return Get(path, Headers(), std::move(response_handler),
-             std::move(content_receiver), nullptr);
+inline Result ClientImpl::Get(const std::string &path, const Params &params, const Headers &headers,
+                              ContentReceiver content_receiver, Progress progress) {
+	return Get(path, params, headers, nullptr, content_receiver, progress);
 }
 
-inline Result ClientImpl::Get(const std::string &path, const Headers &headers,
-                              ResponseHandler response_handler,
-                              ContentReceiver content_receiver) {
-  return Get(path, headers, std::move(response_handler),
-             std::move(content_receiver), nullptr);
-}
+inline Result ClientImpl::Get(const std::string &path, const Params &params, const Headers &headers,
+                              ResponseHandler response_handler, ContentReceiver content_receiver, Progress progress) {
+	if (params.empty()) {
+		return Get(path, headers, response_handler, content_receiver, progress);
+	}
 
-inline Result ClientImpl::Get(const std::string &path,
-                              ResponseHandler response_handler,
-                              ContentReceiver content_receiver,
-                              Progress progress) {
-  return Get(path, Headers(), std::move(response_handler),
-             std::move(content_receiver), std::move(progress));
-}
-
-inline Result ClientImpl::Get(const std::string &path, const Headers &headers,
-                              ResponseHandler response_handler,
-                              ContentReceiver content_receiver,
-                              Progress progress) {
-  Request req;
-  req.method = "GET";
-  req.path = path;
-  req.headers = headers;
-  req.response_handler = std::move(response_handler);
-  req.content_receiver =
-      [content_receiver](const char *data, size_t data_length,
-                         uint64_t /*offset*/, uint64_t /*total_length*/) {
-        return content_receiver(data, data_length);
-      };
-  req.progress = std::move(progress);
-
-  return send_(std::move(req));
-}
-
-inline Result ClientImpl::Get(const std::string &path, const Params &params,
-                              const Headers &headers, Progress progress) {
-  if (params.empty()) { return Get(path, headers); }
-
-  std::string path_with_query = append_query_params(path, params);
-  return Get(path_with_query, headers, progress);
-}
-
-inline Result ClientImpl::Get(const std::string &path, const Params &params,
-                              const Headers &headers,
-                              ContentReceiver content_receiver,
-                              Progress progress) {
-  return Get(path, params, headers, nullptr, content_receiver, progress);
-}
-
-inline Result ClientImpl::Get(const std::string &path, const Params &params,
-                              const Headers &headers,
-                              ResponseHandler response_handler,
-                              ContentReceiver content_receiver,
-                              Progress progress) {
-  if (params.empty()) {
-    return Get(path, headers, response_handler, content_receiver, progress);
-  }
-
-  std::string path_with_query = append_query_params(path, params);
-  return Get(path_with_query, headers, response_handler, content_receiver,
-             progress);
+	std::string path_with_query = append_query_params(path, params);
+	return Get(path_with_query, headers, response_handler, content_receiver, progress);
 }
 
 inline Result ClientImpl::Head(const std::string &path) {
-  return Head(path, Headers());
+	return Head(path, Headers());
 }
 
-inline Result ClientImpl::Head(const std::string &path,
-                               const Headers &headers) {
-  Request req;
-  req.method = "HEAD";
-  req.headers = headers;
-  req.path = path;
+inline Result ClientImpl::Head(const std::string &path, const Headers &headers) {
+	Request req;
+	req.method = "HEAD";
+	req.headers = headers;
+	req.path = path;
 
-  return send_(std::move(req));
+	return send_(std::move(req));
 }
 
 inline Result ClientImpl::Post(const std::string &path) {
-  return Post(path, std::string(), std::string());
+	return Post(path, std::string(), std::string());
 }
 
-inline Result ClientImpl::Post(const std::string &path,
-                               const Headers &headers) {
-  return Post(path, headers, nullptr, 0, std::string());
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers) {
+	return Post(path, headers, nullptr, 0, std::string());
 }
 
-inline Result ClientImpl::Post(const std::string &path, const char *body,
-                               size_t content_length,
+inline Result ClientImpl::Post(const std::string &path, const char *body, size_t content_length,
                                const std::string &content_type) {
-  return Post(path, Headers(), body, content_length, content_type);
+	return Post(path, Headers(), body, content_length, content_type);
 }
 
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
-                               const char *body, size_t content_length,
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const char *body, size_t content_length,
                                const std::string &content_type) {
-  return send_with_content_provider("POST", path, headers, body, content_length,
-                                    nullptr, nullptr, content_type);
+	return send_with_content_provider("POST", path, headers, body, content_length, nullptr, nullptr, content_type);
 }
 
-inline Result ClientImpl::Post(const std::string &path, const std::string &body,
-                               const std::string &content_type) {
-  return Post(path, Headers(), body, content_type);
+inline Result ClientImpl::Post(const std::string &path, const std::string &body, const std::string &content_type) {
+	return Post(path, Headers(), body, content_type);
 }
 
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
-                               const std::string &body,
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const std::string &body,
                                const std::string &content_type) {
-  return send_with_content_provider("POST", path, headers, body.data(),
-                                    body.size(), nullptr, nullptr,
-                                    content_type);
+	return send_with_content_provider("POST", path, headers, body.data(), body.size(), nullptr, nullptr, content_type);
 }
 
 inline Result ClientImpl::Post(const std::string &path, const Params &params) {
-  return Post(path, Headers(), params);
+	return Post(path, Headers(), params);
 }
 
-inline Result ClientImpl::Post(const std::string &path, size_t content_length,
-                               ContentProvider content_provider,
+inline Result ClientImpl::Post(const std::string &path, size_t content_length, ContentProvider content_provider,
                                const std::string &content_type) {
-  return Post(path, Headers(), content_length, std::move(content_provider),
-              content_type);
+	return Post(path, Headers(), content_length, std::move(content_provider), content_type);
 }
 
-inline Result ClientImpl::Post(const std::string &path,
-                               ContentProviderWithoutLength content_provider,
+inline Result ClientImpl::Post(const std::string &path, ContentProviderWithoutLength content_provider,
                                const std::string &content_type) {
-  return Post(path, Headers(), std::move(content_provider), content_type);
+	return Post(path, Headers(), std::move(content_provider), content_type);
+}
+
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers, size_t content_length,
+                               ContentProvider content_provider, const std::string &content_type) {
+	return send_with_content_provider("POST", path, headers, nullptr, content_length, std::move(content_provider),
+	                                  nullptr, content_type);
 }
 
 inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
-                               size_t content_length,
-                               ContentProvider content_provider,
-                               const std::string &content_type) {
-  return send_with_content_provider("POST", path, headers, nullptr,
-                                    content_length, std::move(content_provider),
-                                    nullptr, content_type);
+                               ContentProviderWithoutLength content_provider, const std::string &content_type) {
+	return send_with_content_provider("POST", path, headers, nullptr, 0, nullptr, std::move(content_provider),
+	                                  content_type);
 }
 
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
-                               ContentProviderWithoutLength content_provider,
-                               const std::string &content_type) {
-  return send_with_content_provider("POST", path, headers, nullptr, 0, nullptr,
-                                    std::move(content_provider), content_type);
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const Params &params) {
+	auto query = detail::params_to_query_str(params);
+	return Post(path, headers, query, "application/x-www-form-urlencoded");
 }
 
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
-                               const Params &params) {
-  auto query = detail::params_to_query_str(params);
-  return Post(path, headers, query, "application/x-www-form-urlencoded");
+inline Result ClientImpl::Post(const std::string &path, const MultipartFormDataItems &items) {
+	return Post(path, Headers(), items);
 }
 
-inline Result ClientImpl::Post(const std::string &path,
-                               const MultipartFormDataItems &items) {
-  return Post(path, Headers(), items);
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items) {
+	const auto &boundary = detail::make_multipart_data_boundary();
+	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
+	const auto &body = detail::serialize_multipart_formdata(items, boundary);
+	return Post(path, headers, body, content_type);
 }
 
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
-                               const MultipartFormDataItems &items) {
-  const auto &boundary = detail::make_multipart_data_boundary();
-  const auto &content_type =
-      detail::serialize_multipart_formdata_get_content_type(boundary);
-  const auto &body = detail::serialize_multipart_formdata(items, boundary);
-  return Post(path, headers, body, content_type);
-}
-
-inline Result ClientImpl::Post(const std::string &path, const Headers &headers,
-                               const MultipartFormDataItems &items,
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
                                const std::string &boundary) {
-  if (!detail::is_multipart_boundary_chars_valid(boundary)) {
-    return Result{nullptr, Error::UnsupportedMultipartBoundaryChars};
-  }
+	if (!detail::is_multipart_boundary_chars_valid(boundary)) {
+		return Result {nullptr, Error::UnsupportedMultipartBoundaryChars};
+	}
 
-  const auto &content_type =
-      detail::serialize_multipart_formdata_get_content_type(boundary);
-  const auto &body = detail::serialize_multipart_formdata(items, boundary);
-  return Post(path, headers, body, content_type);
+	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
+	const auto &body = detail::serialize_multipart_formdata(items, boundary);
+	return Post(path, headers, body, content_type);
 }
 
-inline Result
-ClientImpl::Post(const std::string &path, const Headers &headers,
-                 const MultipartFormDataItems &items,
-                 const MultipartFormDataProviderItems &provider_items) {
-  const auto &boundary = detail::make_multipart_data_boundary();
-  const auto &content_type =
-      detail::serialize_multipart_formdata_get_content_type(boundary);
-  return send_with_content_provider(
-      "POST", path, headers, nullptr, 0, nullptr,
-      get_multipart_content_provider(boundary, items, provider_items),
-      content_type);
+inline Result ClientImpl::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+                               const MultipartFormDataProviderItems &provider_items) {
+	const auto &boundary = detail::make_multipart_data_boundary();
+	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
+	return send_with_content_provider("POST", path, headers, nullptr, 0, nullptr,
+	                                  get_multipart_content_provider(boundary, items, provider_items), content_type);
 }
 
 inline Result ClientImpl::Put(const std::string &path) {
-  return Put(path, std::string(), std::string());
+	return Put(path, std::string(), std::string());
 }
 
-inline Result ClientImpl::Put(const std::string &path, const char *body,
-                              size_t content_length,
+inline Result ClientImpl::Put(const std::string &path, const char *body, size_t content_length,
                               const std::string &content_type) {
-  return Put(path, Headers(), body, content_length, content_type);
+	return Put(path, Headers(), body, content_length, content_type);
 }
 
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
-                              const char *body, size_t content_length,
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const char *body, size_t content_length,
                               const std::string &content_type) {
-  return send_with_content_provider("PUT", path, headers, body, content_length,
-                                    nullptr, nullptr, content_type);
+	return send_with_content_provider("PUT", path, headers, body, content_length, nullptr, nullptr, content_type);
 }
 
-inline Result ClientImpl::Put(const std::string &path, const std::string &body,
-                              const std::string &content_type) {
-  return Put(path, Headers(), body, content_type);
+inline Result ClientImpl::Put(const std::string &path, const std::string &body, const std::string &content_type) {
+	return Put(path, Headers(), body, content_type);
 }
 
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
-                              const std::string &body,
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const std::string &body,
                               const std::string &content_type) {
-  return send_with_content_provider("PUT", path, headers, body.data(),
-                                    body.size(), nullptr, nullptr,
-                                    content_type);
+	return send_with_content_provider("PUT", path, headers, body.data(), body.size(), nullptr, nullptr, content_type);
 }
 
-inline Result ClientImpl::Put(const std::string &path, size_t content_length,
-                              ContentProvider content_provider,
+inline Result ClientImpl::Put(const std::string &path, size_t content_length, ContentProvider content_provider,
                               const std::string &content_type) {
-  return Put(path, Headers(), content_length, std::move(content_provider),
-             content_type);
+	return Put(path, Headers(), content_length, std::move(content_provider), content_type);
 }
 
-inline Result ClientImpl::Put(const std::string &path,
-                              ContentProviderWithoutLength content_provider,
+inline Result ClientImpl::Put(const std::string &path, ContentProviderWithoutLength content_provider,
                               const std::string &content_type) {
-  return Put(path, Headers(), std::move(content_provider), content_type);
+	return Put(path, Headers(), std::move(content_provider), content_type);
+}
+
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers, size_t content_length,
+                              ContentProvider content_provider, const std::string &content_type) {
+	return send_with_content_provider("PUT", path, headers, nullptr, content_length, std::move(content_provider),
+	                                  nullptr, content_type);
 }
 
 inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
-                              size_t content_length,
-                              ContentProvider content_provider,
-                              const std::string &content_type) {
-  return send_with_content_provider("PUT", path, headers, nullptr,
-                                    content_length, std::move(content_provider),
-                                    nullptr, content_type);
-}
-
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
-                              ContentProviderWithoutLength content_provider,
-                              const std::string &content_type) {
-  return send_with_content_provider("PUT", path, headers, nullptr, 0, nullptr,
-                                    std::move(content_provider), content_type);
+                              ContentProviderWithoutLength content_provider, const std::string &content_type) {
+	return send_with_content_provider("PUT", path, headers, nullptr, 0, nullptr, std::move(content_provider),
+	                                  content_type);
 }
 
 inline Result ClientImpl::Put(const std::string &path, const Params &params) {
-  return Put(path, Headers(), params);
+	return Put(path, Headers(), params);
 }
 
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
-                              const Params &params) {
-  auto query = detail::params_to_query_str(params);
-  return Put(path, headers, query, "application/x-www-form-urlencoded");
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const Params &params) {
+	auto query = detail::params_to_query_str(params);
+	return Put(path, headers, query, "application/x-www-form-urlencoded");
 }
 
-inline Result ClientImpl::Put(const std::string &path,
-                              const MultipartFormDataItems &items) {
-  return Put(path, Headers(), items);
+inline Result ClientImpl::Put(const std::string &path, const MultipartFormDataItems &items) {
+	return Put(path, Headers(), items);
 }
 
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
-                              const MultipartFormDataItems &items) {
-  const auto &boundary = detail::make_multipart_data_boundary();
-  const auto &content_type =
-      detail::serialize_multipart_formdata_get_content_type(boundary);
-  const auto &body = detail::serialize_multipart_formdata(items, boundary);
-  return Put(path, headers, body, content_type);
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items) {
+	const auto &boundary = detail::make_multipart_data_boundary();
+	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
+	const auto &body = detail::serialize_multipart_formdata(items, boundary);
+	return Put(path, headers, body, content_type);
 }
 
-inline Result ClientImpl::Put(const std::string &path, const Headers &headers,
-                              const MultipartFormDataItems &items,
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
                               const std::string &boundary) {
-  if (!detail::is_multipart_boundary_chars_valid(boundary)) {
-    return Result{nullptr, Error::UnsupportedMultipartBoundaryChars};
-  }
+	if (!detail::is_multipart_boundary_chars_valid(boundary)) {
+		return Result {nullptr, Error::UnsupportedMultipartBoundaryChars};
+	}
 
-  const auto &content_type =
-      detail::serialize_multipart_formdata_get_content_type(boundary);
-  const auto &body = detail::serialize_multipart_formdata(items, boundary);
-  return Put(path, headers, body, content_type);
+	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
+	const auto &body = detail::serialize_multipart_formdata(items, boundary);
+	return Put(path, headers, body, content_type);
 }
 
-inline Result
-ClientImpl::Put(const std::string &path, const Headers &headers,
-                const MultipartFormDataItems &items,
-                const MultipartFormDataProviderItems &provider_items) {
-  const auto &boundary = detail::make_multipart_data_boundary();
-  const auto &content_type =
-      detail::serialize_multipart_formdata_get_content_type(boundary);
-  return send_with_content_provider(
-      "PUT", path, headers, nullptr, 0, nullptr,
-      get_multipart_content_provider(boundary, items, provider_items),
-      content_type);
+inline Result ClientImpl::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+                              const MultipartFormDataProviderItems &provider_items) {
+	const auto &boundary = detail::make_multipart_data_boundary();
+	const auto &content_type = detail::serialize_multipart_formdata_get_content_type(boundary);
+	return send_with_content_provider("PUT", path, headers, nullptr, 0, nullptr,
+	                                  get_multipart_content_provider(boundary, items, provider_items), content_type);
 }
 inline Result ClientImpl::Patch(const std::string &path) {
-  return Patch(path, std::string(), std::string());
+	return Patch(path, std::string(), std::string());
 }
 
-inline Result ClientImpl::Patch(const std::string &path, const char *body,
-                                size_t content_length,
+inline Result ClientImpl::Patch(const std::string &path, const char *body, size_t content_length,
                                 const std::string &content_type) {
-  return Patch(path, Headers(), body, content_length, content_type);
+	return Patch(path, Headers(), body, content_length, content_type);
 }
 
-inline Result ClientImpl::Patch(const std::string &path, const Headers &headers,
-                                const char *body, size_t content_length,
-                                const std::string &content_type) {
-  return send_with_content_provider("PATCH", path, headers, body,
-                                    content_length, nullptr, nullptr,
-                                    content_type);
+inline Result ClientImpl::Patch(const std::string &path, const Headers &headers, const char *body,
+                                size_t content_length, const std::string &content_type) {
+	return send_with_content_provider("PATCH", path, headers, body, content_length, nullptr, nullptr, content_type);
 }
 
-inline Result ClientImpl::Patch(const std::string &path,
-                                const std::string &body,
-                                const std::string &content_type) {
-  return Patch(path, Headers(), body, content_type);
+inline Result ClientImpl::Patch(const std::string &path, const std::string &body, const std::string &content_type) {
+	return Patch(path, Headers(), body, content_type);
 }
 
-inline Result ClientImpl::Patch(const std::string &path, const Headers &headers,
-                                const std::string &body,
+inline Result ClientImpl::Patch(const std::string &path, const Headers &headers, const std::string &body,
                                 const std::string &content_type) {
-  return send_with_content_provider("PATCH", path, headers, body.data(),
-                                    body.size(), nullptr, nullptr,
-                                    content_type);
+	return send_with_content_provider("PATCH", path, headers, body.data(), body.size(), nullptr, nullptr, content_type);
 }
 
-inline Result ClientImpl::Patch(const std::string &path, size_t content_length,
-                                ContentProvider content_provider,
+inline Result ClientImpl::Patch(const std::string &path, size_t content_length, ContentProvider content_provider,
                                 const std::string &content_type) {
-  return Patch(path, Headers(), content_length, std::move(content_provider),
-               content_type);
+	return Patch(path, Headers(), content_length, std::move(content_provider), content_type);
 }
 
-inline Result ClientImpl::Patch(const std::string &path,
-                                ContentProviderWithoutLength content_provider,
+inline Result ClientImpl::Patch(const std::string &path, ContentProviderWithoutLength content_provider,
                                 const std::string &content_type) {
-  return Patch(path, Headers(), std::move(content_provider), content_type);
+	return Patch(path, Headers(), std::move(content_provider), content_type);
+}
+
+inline Result ClientImpl::Patch(const std::string &path, const Headers &headers, size_t content_length,
+                                ContentProvider content_provider, const std::string &content_type) {
+	return send_with_content_provider("PATCH", path, headers, nullptr, content_length, std::move(content_provider),
+	                                  nullptr, content_type);
 }
 
 inline Result ClientImpl::Patch(const std::string &path, const Headers &headers,
-                                size_t content_length,
-                                ContentProvider content_provider,
-                                const std::string &content_type) {
-  return send_with_content_provider("PATCH", path, headers, nullptr,
-                                    content_length, std::move(content_provider),
-                                    nullptr, content_type);
-}
-
-inline Result ClientImpl::Patch(const std::string &path, const Headers &headers,
-                                ContentProviderWithoutLength content_provider,
-                                const std::string &content_type) {
-  return send_with_content_provider("PATCH", path, headers, nullptr, 0, nullptr,
-                                    std::move(content_provider), content_type);
+                                ContentProviderWithoutLength content_provider, const std::string &content_type) {
+	return send_with_content_provider("PATCH", path, headers, nullptr, 0, nullptr, std::move(content_provider),
+	                                  content_type);
 }
 
 inline Result ClientImpl::Delete(const std::string &path) {
-  return Delete(path, Headers(), std::string(), std::string());
+	return Delete(path, Headers(), std::string(), std::string());
 }
 
-inline Result ClientImpl::Delete(const std::string &path,
-                                 const Headers &headers) {
-  return Delete(path, headers, std::string(), std::string());
+inline Result ClientImpl::Delete(const std::string &path, const Headers &headers) {
+	return Delete(path, headers, std::string(), std::string());
 }
 
-inline Result ClientImpl::Delete(const std::string &path, const char *body,
-                                 size_t content_length,
+inline Result ClientImpl::Delete(const std::string &path, const char *body, size_t content_length,
                                  const std::string &content_type) {
-  return Delete(path, Headers(), body, content_length, content_type);
+	return Delete(path, Headers(), body, content_length, content_type);
 }
 
-inline Result ClientImpl::Delete(const std::string &path,
-                                 const Headers &headers, const char *body,
-                                 size_t content_length,
-                                 const std::string &content_type) {
-  Request req;
-  req.method = "DELETE";
-  req.headers = headers;
-  req.path = path;
+inline Result ClientImpl::Delete(const std::string &path, const Headers &headers, const char *body,
+                                 size_t content_length, const std::string &content_type) {
+	Request req;
+	req.method = "DELETE";
+	req.headers = headers;
+	req.path = path;
 
-  if (!content_type.empty()) { req.set_header("Content-Type", content_type); }
-  req.body.assign(body, content_length);
+	if (!content_type.empty()) {
+		req.set_header("Content-Type", content_type);
+	}
+	req.body.assign(body, content_length);
 
-  return send_(std::move(req));
+	return send_(std::move(req));
 }
 
-inline Result ClientImpl::Delete(const std::string &path,
-                                 const std::string &body,
-                                 const std::string &content_type) {
-  return Delete(path, Headers(), body.data(), body.size(), content_type);
+inline Result ClientImpl::Delete(const std::string &path, const std::string &body, const std::string &content_type) {
+	return Delete(path, Headers(), body.data(), body.size(), content_type);
 }
 
-inline Result ClientImpl::Delete(const std::string &path,
-                                 const Headers &headers,
-                                 const std::string &body,
+inline Result ClientImpl::Delete(const std::string &path, const Headers &headers, const std::string &body,
                                  const std::string &content_type) {
-  return Delete(path, headers, body.data(), body.size(), content_type);
+	return Delete(path, headers, body.data(), body.size(), content_type);
 }
 
 inline Result ClientImpl::Options(const std::string &path) {
-  return Options(path, Headers());
+	return Options(path, Headers());
 }
 
-inline Result ClientImpl::Options(const std::string &path,
-                                  const Headers &headers) {
-  Request req;
-  req.method = "OPTIONS";
-  req.headers = headers;
-  req.path = path;
+inline Result ClientImpl::Options(const std::string &path, const Headers &headers) {
+	Request req;
+	req.method = "OPTIONS";
+	req.headers = headers;
+	req.path = path;
 
-  return send_(std::move(req));
+	return send_(std::move(req));
 }
 
 inline void ClientImpl::stop() {
-  std::lock_guard<std::mutex> guard(socket_mutex_);
+	std::lock_guard<std::mutex> guard(socket_mutex_);
 
-  // If there is anything ongoing right now, the ONLY thread-safe thing we can
-  // do is to shutdown_socket, so that threads using this socket suddenly
-  // discover they can't read/write any more and error out. Everything else
-  // (closing the socket, shutting ssl down) is unsafe because these actions are
-  // not thread-safe.
-  if (socket_requests_in_flight_ > 0) {
-    shutdown_socket(socket_);
+	// If there is anything ongoing right now, the ONLY thread-safe thing we can
+	// do is to shutdown_socket, so that threads using this socket suddenly
+	// discover they can't read/write any more and error out. Everything else
+	// (closing the socket, shutting ssl down) is unsafe because these actions are
+	// not thread-safe.
+	if (socket_requests_in_flight_ > 0) {
+		shutdown_socket(socket_);
 
-    // Aside from that, we set a flag for the socket to be closed when we're
-    // done.
-    socket_should_be_closed_when_request_is_done_ = true;
-    return;
-  }
+		// Aside from that, we set a flag for the socket to be closed when we're
+		// done.
+		socket_should_be_closed_when_request_is_done_ = true;
+		return;
+	}
 
-  // Otherwise, still holding the mutex, we can shut everything down ourselves
-  shutdown_ssl(socket_, true);
-  shutdown_socket(socket_);
-  close_socket(socket_);
+	// Otherwise, still holding the mutex, we can shut everything down ourselves
+	shutdown_ssl(socket_, true);
+	shutdown_socket(socket_);
+	close_socket(socket_);
 }
 
-inline std::string ClientImpl::host() const { return host_; }
+inline std::string ClientImpl::host() const {
+	return host_;
+}
 
-inline int ClientImpl::port() const { return port_; }
+inline int ClientImpl::port() const {
+	return port_;
+}
 
 inline size_t ClientImpl::is_socket_open() const {
-  std::lock_guard<std::mutex> guard(socket_mutex_);
-  return socket_.is_open();
+	std::lock_guard<std::mutex> guard(socket_mutex_);
+	return socket_.is_open();
 }
 
-inline socket_t ClientImpl::socket() const { return socket_.sock; }
+inline socket_t ClientImpl::socket() const {
+	return socket_.sock;
+}
 
 inline void ClientImpl::set_connection_timeout(time_t sec, time_t usec) {
-  connection_timeout_sec_ = sec;
-  connection_timeout_usec_ = usec;
+	connection_timeout_sec_ = sec;
+	connection_timeout_usec_ = usec;
 }
 
 inline void ClientImpl::set_read_timeout(time_t sec, time_t usec) {
-  read_timeout_sec_ = sec;
-  read_timeout_usec_ = usec;
+	read_timeout_sec_ = sec;
+	read_timeout_usec_ = usec;
 }
 
 inline void ClientImpl::set_write_timeout(time_t sec, time_t usec) {
-  write_timeout_sec_ = sec;
-  write_timeout_usec_ = usec;
+	write_timeout_sec_ = sec;
+	write_timeout_usec_ = usec;
 }
 
-inline void ClientImpl::set_basic_auth(const std::string &username,
-                                       const std::string &password) {
-  basic_auth_username_ = username;
-  basic_auth_password_ = password;
+inline void ClientImpl::set_basic_auth(const std::string &username, const std::string &password) {
+	basic_auth_username_ = username;
+	basic_auth_password_ = password;
 }
 
 inline void ClientImpl::set_bearer_token_auth(const std::string &token) {
-  bearer_token_auth_token_ = token;
+	bearer_token_auth_token_ = token;
 }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline void ClientImpl::set_digest_auth(const std::string &username,
-                                        const std::string &password) {
-  digest_auth_username_ = username;
-  digest_auth_password_ = password;
+inline void ClientImpl::set_digest_auth(const std::string &username, const std::string &password) {
+	digest_auth_username_ = username;
+	digest_auth_password_ = password;
 }
 #endif
 
-inline void ClientImpl::set_keep_alive(bool on) { keep_alive_ = on; }
+inline void ClientImpl::set_keep_alive(bool on) {
+	keep_alive_ = on;
+}
 
-inline void ClientImpl::set_follow_location(bool on) { follow_location_ = on; }
+inline void ClientImpl::set_follow_location(bool on) {
+	follow_location_ = on;
+}
 
-inline void ClientImpl::set_url_encode(bool on) { url_encode_ = on; }
+inline void ClientImpl::set_url_encode(bool on) {
+	url_encode_ = on;
+}
 
-inline void
-ClientImpl::set_hostname_addr_map(std::map<std::string, std::string> addr_map) {
-  addr_map_ = std::move(addr_map);
+inline void ClientImpl::set_hostname_addr_map(std::map<std::string, std::string> addr_map) {
+	addr_map_ = std::move(addr_map);
 }
 
 inline void ClientImpl::set_default_headers(Headers headers) {
-  default_headers_ = std::move(headers);
+	default_headers_ = std::move(headers);
 }
 
-inline void ClientImpl::set_header_writer(
-    std::function<ssize_t(Stream &, Headers &)> const &writer) {
-  header_writer_ = writer;
+inline void ClientImpl::set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer) {
+	header_writer_ = writer;
 }
 
 inline void ClientImpl::set_address_family(int family) {
-  address_family_ = family;
+	address_family_ = family;
 }
 
-inline void ClientImpl::set_tcp_nodelay(bool on) { tcp_nodelay_ = on; }
+inline void ClientImpl::set_tcp_nodelay(bool on) {
+	tcp_nodelay_ = on;
+}
 
 inline void ClientImpl::set_socket_options(SocketOptions socket_options) {
-  socket_options_ = std::move(socket_options);
+	socket_options_ = std::move(socket_options);
 }
 
-inline void ClientImpl::set_compress(bool on) { compress_ = on; }
+inline void ClientImpl::set_compress(bool on) {
+	compress_ = on;
+}
 
-inline void ClientImpl::set_decompress(bool on) { decompress_ = on; }
+inline void ClientImpl::set_decompress(bool on) {
+	decompress_ = on;
+}
 
 inline void ClientImpl::set_interface(const std::string &intf) {
-  interface_ = intf;
+	interface_ = intf;
 }
 
 inline void ClientImpl::set_proxy(const std::string &host, int port) {
-  proxy_host_ = host;
-  proxy_port_ = port;
+	proxy_host_ = host;
+	proxy_port_ = port;
 }
 
-inline void ClientImpl::set_proxy_basic_auth(const std::string &username,
-                                             const std::string &password) {
-  proxy_basic_auth_username_ = username;
-  proxy_basic_auth_password_ = password;
+inline void ClientImpl::set_proxy_basic_auth(const std::string &username, const std::string &password) {
+	proxy_basic_auth_username_ = username;
+	proxy_basic_auth_password_ = password;
 }
 
 inline void ClientImpl::set_proxy_bearer_token_auth(const std::string &token) {
-  proxy_bearer_token_auth_token_ = token;
+	proxy_bearer_token_auth_token_ = token;
 }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline void ClientImpl::set_proxy_digest_auth(const std::string &username,
-                                              const std::string &password) {
-  proxy_digest_auth_username_ = username;
-  proxy_digest_auth_password_ = password;
+inline void ClientImpl::set_proxy_digest_auth(const std::string &username, const std::string &password) {
+	proxy_digest_auth_username_ = username;
+	proxy_digest_auth_password_ = password;
 }
 
-inline void ClientImpl::set_ca_cert_path(const std::string &ca_cert_file_path,
-                                         const std::string &ca_cert_dir_path) {
-  ca_cert_file_path_ = ca_cert_file_path;
-  ca_cert_dir_path_ = ca_cert_dir_path;
+inline void ClientImpl::set_ca_cert_path(const std::string &ca_cert_file_path, const std::string &ca_cert_dir_path) {
+	ca_cert_file_path_ = ca_cert_file_path;
+	ca_cert_dir_path_ = ca_cert_dir_path;
 }
 
 inline void ClientImpl::set_ca_cert_store(X509_STORE *ca_cert_store) {
-  if (ca_cert_store && ca_cert_store != ca_cert_store_) {
-    ca_cert_store_ = ca_cert_store;
-  }
+	if (ca_cert_store && ca_cert_store != ca_cert_store_) {
+		ca_cert_store_ = ca_cert_store;
+	}
 }
 
-inline X509_STORE *ClientImpl::create_ca_cert_store(const char *ca_cert,
-                                                    std::size_t size) const {
-  auto mem = BIO_new_mem_buf(ca_cert, static_cast<int>(size));
-  if (!mem) { return nullptr; }
+inline X509_STORE *ClientImpl::create_ca_cert_store(const char *ca_cert, std::size_t size) const {
+	auto mem = BIO_new_mem_buf(ca_cert, static_cast<int>(size));
+	if (!mem) {
+		return nullptr;
+	}
 
-  auto inf = PEM_X509_INFO_read_bio(mem, nullptr, nullptr, nullptr);
-  if (!inf) {
-    BIO_free_all(mem);
-    return nullptr;
-  }
+	auto inf = PEM_X509_INFO_read_bio(mem, nullptr, nullptr, nullptr);
+	if (!inf) {
+		BIO_free_all(mem);
+		return nullptr;
+	}
 
-  auto cts = X509_STORE_new();
-  if (cts) {
-    for (auto i = 0; i < static_cast<int>(sk_X509_INFO_num(inf)); i++) {
-      auto itmp = sk_X509_INFO_value(inf, i);
-      if (!itmp) { continue; }
+	auto cts = X509_STORE_new();
+	if (cts) {
+		for (auto i = 0; i < static_cast<int>(sk_X509_INFO_num(inf)); i++) {
+			auto itmp = sk_X509_INFO_value(inf, i);
+			if (!itmp) {
+				continue;
+			}
 
-      if (itmp->x509) { X509_STORE_add_cert(cts, itmp->x509); }
-      if (itmp->crl) { X509_STORE_add_crl(cts, itmp->crl); }
-    }
-  }
+			if (itmp->x509) {
+				X509_STORE_add_cert(cts, itmp->x509);
+			}
+			if (itmp->crl) {
+				X509_STORE_add_crl(cts, itmp->crl);
+			}
+		}
+	}
 
-  sk_X509_INFO_pop_free(inf, X509_INFO_free);
-  BIO_free_all(mem);
-  return cts;
+	sk_X509_INFO_pop_free(inf, X509_INFO_free);
+	BIO_free_all(mem);
+	return cts;
 }
 
 inline void ClientImpl::enable_server_certificate_verification(bool enabled) {
-  server_certificate_verification_ = enabled;
+	server_certificate_verification_ = enabled;
 }
 #endif
 
 inline void ClientImpl::set_logger(Logger logger) {
-  logger_ = std::move(logger);
+	logger_ = std::move(logger);
 }
 
 /*
@@ -8161,1220 +8136,1143 @@ inline void ClientImpl::set_logger(Logger logger) {
 namespace detail {
 
 template <typename U, typename V>
-inline SSL *ssl_new(socket_t sock, SSL_CTX *ctx, std::mutex &ctx_mutex,
-                    U SSL_connect_or_accept, V setup) {
-  SSL *ssl = nullptr;
-  {
-    std::lock_guard<std::mutex> guard(ctx_mutex);
-    ssl = SSL_new(ctx);
-  }
+inline SSL *ssl_new(socket_t sock, SSL_CTX *ctx, std::mutex &ctx_mutex, U SSL_connect_or_accept, V setup) {
+	SSL *ssl = nullptr;
+	{
+		std::lock_guard<std::mutex> guard(ctx_mutex);
+		ssl = SSL_new(ctx);
+	}
 
-  if (ssl) {
-    set_nonblocking(sock, true);
-    auto bio = BIO_new_socket(static_cast<int>(sock), BIO_NOCLOSE);
-    BIO_set_nbio(bio, 1);
-    SSL_set_bio(ssl, bio, bio);
+	if (ssl) {
+		set_nonblocking(sock, true);
+		auto bio = BIO_new_socket(static_cast<int>(sock), BIO_NOCLOSE);
+		BIO_set_nbio(bio, 1);
+		SSL_set_bio(ssl, bio, bio);
 
-    if (!setup(ssl) || SSL_connect_or_accept(ssl) != 1) {
-      SSL_shutdown(ssl);
-      {
-        std::lock_guard<std::mutex> guard(ctx_mutex);
-        SSL_free(ssl);
-      }
-      set_nonblocking(sock, false);
-      return nullptr;
-    }
-    BIO_set_nbio(bio, 0);
-    set_nonblocking(sock, false);
-  }
+		if (!setup(ssl) || SSL_connect_or_accept(ssl) != 1) {
+			SSL_shutdown(ssl);
+			{
+				std::lock_guard<std::mutex> guard(ctx_mutex);
+				SSL_free(ssl);
+			}
+			set_nonblocking(sock, false);
+			return nullptr;
+		}
+		BIO_set_nbio(bio, 0);
+		set_nonblocking(sock, false);
+	}
 
-  return ssl;
+	return ssl;
 }
 
-inline void ssl_delete(std::mutex &ctx_mutex, SSL *ssl,
-                       bool shutdown_gracefully) {
-  // sometimes we may want to skip this to try to avoid SIGPIPE if we know
-  // the remote has closed the network connection
-  // Note that it is not always possible to avoid SIGPIPE, this is merely a
-  // best-efforts.
-  if (shutdown_gracefully) { SSL_shutdown(ssl); }
+inline void ssl_delete(std::mutex &ctx_mutex, SSL *ssl, bool shutdown_gracefully) {
+	// sometimes we may want to skip this to try to avoid SIGPIPE if we know
+	// the remote has closed the network connection
+	// Note that it is not always possible to avoid SIGPIPE, this is merely a
+	// best-efforts.
+	if (shutdown_gracefully) {
+		SSL_shutdown(ssl);
+	}
 
-  std::lock_guard<std::mutex> guard(ctx_mutex);
-  SSL_free(ssl);
+	std::lock_guard<std::mutex> guard(ctx_mutex);
+	SSL_free(ssl);
 }
 
 template <typename U>
-bool ssl_connect_or_accept_nonblocking(socket_t sock, SSL *ssl,
-                                       U ssl_connect_or_accept,
-                                       time_t timeout_sec,
+bool ssl_connect_or_accept_nonblocking(socket_t sock, SSL *ssl, U ssl_connect_or_accept, time_t timeout_sec,
                                        time_t timeout_usec) {
-  auto res = 0;
-  while ((res = ssl_connect_or_accept(ssl)) != 1) {
-    auto err = SSL_get_error(ssl, res);
-    switch (err) {
-    case SSL_ERROR_WANT_READ:
-      if (select_read(sock, timeout_sec, timeout_usec) > 0) { continue; }
-      break;
-    case SSL_ERROR_WANT_WRITE:
-      if (select_write(sock, timeout_sec, timeout_usec) > 0) { continue; }
-      break;
-    default: break;
-    }
-    return false;
-  }
-  return true;
+	auto res = 0;
+	while ((res = ssl_connect_or_accept(ssl)) != 1) {
+		auto err = SSL_get_error(ssl, res);
+		switch (err) {
+		case SSL_ERROR_WANT_READ:
+			if (select_read(sock, timeout_sec, timeout_usec) > 0) {
+				continue;
+			}
+			break;
+		case SSL_ERROR_WANT_WRITE:
+			if (select_write(sock, timeout_sec, timeout_usec) > 0) {
+				continue;
+			}
+			break;
+		default:
+			break;
+		}
+		return false;
+	}
+	return true;
 }
 
 template <typename T>
-inline bool process_server_socket_ssl(
-    const std::atomic<socket_t> &svr_sock, SSL *ssl, socket_t sock,
-    size_t keep_alive_max_count, time_t keep_alive_timeout_sec,
-    time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
-    time_t write_timeout_usec, T callback) {
-  return process_server_socket_core(
-      svr_sock, sock, keep_alive_max_count, keep_alive_timeout_sec,
-      [&](bool close_connection, bool &connection_closed) {
-        SSLSocketStream strm(sock, ssl, read_timeout_sec, read_timeout_usec,
-                             write_timeout_sec, write_timeout_usec);
-        return callback(strm, close_connection, connection_closed);
-      });
+inline bool process_server_socket_ssl(const std::atomic<socket_t> &svr_sock, SSL *ssl, socket_t sock,
+                                      size_t keep_alive_max_count, time_t keep_alive_timeout_sec,
+                                      time_t read_timeout_sec, time_t read_timeout_usec, time_t write_timeout_sec,
+                                      time_t write_timeout_usec, T callback) {
+	return process_server_socket_core(svr_sock, sock, keep_alive_max_count, keep_alive_timeout_sec,
+	                                  [&](bool close_connection, bool &connection_closed) {
+		                                  SSLSocketStream strm(sock, ssl, read_timeout_sec, read_timeout_usec,
+		                                                       write_timeout_sec, write_timeout_usec);
+		                                  return callback(strm, close_connection, connection_closed);
+	                                  });
 }
 
 template <typename T>
-inline bool
-process_client_socket_ssl(SSL *ssl, socket_t sock, time_t read_timeout_sec,
-                          time_t read_timeout_usec, time_t write_timeout_sec,
-                          time_t write_timeout_usec, T callback) {
-  SSLSocketStream strm(sock, ssl, read_timeout_sec, read_timeout_usec,
-                       write_timeout_sec, write_timeout_usec);
-  return callback(strm);
+inline bool process_client_socket_ssl(SSL *ssl, socket_t sock, time_t read_timeout_sec, time_t read_timeout_usec,
+                                      time_t write_timeout_sec, time_t write_timeout_usec, T callback) {
+	SSLSocketStream strm(sock, ssl, read_timeout_sec, read_timeout_usec, write_timeout_sec, write_timeout_usec);
+	return callback(strm);
 }
 
 class SSLInit {
 public:
-  SSLInit() {
-    OPENSSL_init_ssl(
-        OPENSSL_INIT_LOAD_SSL_STRINGS | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-  }
+	SSLInit() {
+		OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+	}
 };
 
 // SSL socket stream implementation
-inline SSLSocketStream::SSLSocketStream(socket_t sock, SSL *ssl,
-                                        time_t read_timeout_sec,
-                                        time_t read_timeout_usec,
-                                        time_t write_timeout_sec,
-                                        time_t write_timeout_usec)
-    : sock_(sock), ssl_(ssl), read_timeout_sec_(read_timeout_sec),
-      read_timeout_usec_(read_timeout_usec),
-      write_timeout_sec_(write_timeout_sec),
-      write_timeout_usec_(write_timeout_usec) {
-  SSL_clear_mode(ssl, SSL_MODE_AUTO_RETRY);
+inline SSLSocketStream::SSLSocketStream(socket_t sock, SSL *ssl, time_t read_timeout_sec, time_t read_timeout_usec,
+                                        time_t write_timeout_sec, time_t write_timeout_usec)
+    : sock_(sock), ssl_(ssl), read_timeout_sec_(read_timeout_sec), read_timeout_usec_(read_timeout_usec),
+      write_timeout_sec_(write_timeout_sec), write_timeout_usec_(write_timeout_usec) {
+	SSL_clear_mode(ssl, SSL_MODE_AUTO_RETRY);
 }
 
 inline SSLSocketStream::~SSLSocketStream() = default;
 
 inline bool SSLSocketStream::is_readable() const {
-  return detail::select_read(sock_, read_timeout_sec_, read_timeout_usec_) > 0;
+	return detail::select_read(sock_, read_timeout_sec_, read_timeout_usec_) > 0;
 }
 
 inline bool SSLSocketStream::is_writable() const {
-  return select_write(sock_, write_timeout_sec_, write_timeout_usec_) > 0 &&
-         is_socket_alive(sock_);
+	return select_write(sock_, write_timeout_sec_, write_timeout_usec_) > 0 && is_socket_alive(sock_);
 }
 
 inline ssize_t SSLSocketStream::read(char *ptr, size_t size) {
-  if (SSL_pending(ssl_) > 0) {
-    return SSL_read(ssl_, ptr, static_cast<int>(size));
-  } else if (is_readable()) {
-    auto ret = SSL_read(ssl_, ptr, static_cast<int>(size));
-    if (ret < 0) {
-      auto err = SSL_get_error(ssl_, ret);
-      auto n = 1000;
+	if (SSL_pending(ssl_) > 0) {
+		return SSL_read(ssl_, ptr, static_cast<int>(size));
+	} else if (is_readable()) {
+		auto ret = SSL_read(ssl_, ptr, static_cast<int>(size));
+		if (ret < 0) {
+			auto err = SSL_get_error(ssl_, ret);
+			auto n = 1000;
 #ifdef _WIN32
-      while (--n >= 0 && (err == SSL_ERROR_WANT_READ ||
-                          (err == SSL_ERROR_SYSCALL &&
-                           WSAGetLastError() == WSAETIMEDOUT))) {
+			while (--n >= 0 &&
+			       (err == SSL_ERROR_WANT_READ || (err == SSL_ERROR_SYSCALL && WSAGetLastError() == WSAETIMEDOUT))) {
 #else
-      while (--n >= 0 && err == SSL_ERROR_WANT_READ) {
+			while (--n >= 0 && err == SSL_ERROR_WANT_READ) {
 #endif
-        if (SSL_pending(ssl_) > 0) {
-          return SSL_read(ssl_, ptr, static_cast<int>(size));
-        } else if (is_readable()) {
-          std::this_thread::sleep_for(std::chrono::milliseconds(1));
-          ret = SSL_read(ssl_, ptr, static_cast<int>(size));
-          if (ret >= 0) { return ret; }
-          err = SSL_get_error(ssl_, ret);
-        } else {
-          return -1;
-        }
-      }
-    }
-    return ret;
-  }
-  return -1;
+				if (SSL_pending(ssl_) > 0) {
+					return SSL_read(ssl_, ptr, static_cast<int>(size));
+				} else if (is_readable()) {
+					std::this_thread::sleep_for(std::chrono::milliseconds(1));
+					ret = SSL_read(ssl_, ptr, static_cast<int>(size));
+					if (ret >= 0) {
+						return ret;
+					}
+					err = SSL_get_error(ssl_, ret);
+				} else {
+					return -1;
+				}
+			}
+		}
+		return ret;
+	}
+	return -1;
 }
 
 inline ssize_t SSLSocketStream::write(const char *ptr, size_t size) {
-  if (is_writable()) {
-    auto handle_size = static_cast<int>(
-        std::min<size_t>(size, (std::numeric_limits<int>::max)()));
+	if (is_writable()) {
+		auto handle_size = static_cast<int>(std::min<size_t>(size, (std::numeric_limits<int>::max)()));
 
-    auto ret = SSL_write(ssl_, ptr, static_cast<int>(handle_size));
-    if (ret < 0) {
-      auto err = SSL_get_error(ssl_, ret);
-      auto n = 1000;
+		auto ret = SSL_write(ssl_, ptr, static_cast<int>(handle_size));
+		if (ret < 0) {
+			auto err = SSL_get_error(ssl_, ret);
+			auto n = 1000;
 #ifdef _WIN32
-      while (--n >= 0 && (err == SSL_ERROR_WANT_WRITE ||
-                          (err == SSL_ERROR_SYSCALL &&
-                           WSAGetLastError() == WSAETIMEDOUT))) {
+			while (--n >= 0 &&
+			       (err == SSL_ERROR_WANT_WRITE || (err == SSL_ERROR_SYSCALL && WSAGetLastError() == WSAETIMEDOUT))) {
 #else
-      while (--n >= 0 && err == SSL_ERROR_WANT_WRITE) {
+			while (--n >= 0 && err == SSL_ERROR_WANT_WRITE) {
 #endif
-        if (is_writable()) {
-          std::this_thread::sleep_for(std::chrono::milliseconds(1));
-          ret = SSL_write(ssl_, ptr, static_cast<int>(handle_size));
-          if (ret >= 0) { return ret; }
-          err = SSL_get_error(ssl_, ret);
-        } else {
-          return -1;
-        }
-      }
-    }
-    return ret;
-  }
-  return -1;
+				if (is_writable()) {
+					std::this_thread::sleep_for(std::chrono::milliseconds(1));
+					ret = SSL_write(ssl_, ptr, static_cast<int>(handle_size));
+					if (ret >= 0) {
+						return ret;
+					}
+					err = SSL_get_error(ssl_, ret);
+				} else {
+					return -1;
+				}
+			}
+		}
+		return ret;
+	}
+	return -1;
 }
 
-inline void SSLSocketStream::get_remote_ip_and_port(std::string &ip,
-                                                    int &port) const {
-  detail::get_remote_ip_and_port(sock_, ip, port);
+inline void SSLSocketStream::get_remote_ip_and_port(std::string &ip, int &port) const {
+	detail::get_remote_ip_and_port(sock_, ip, port);
 }
 
-inline void SSLSocketStream::get_local_ip_and_port(std::string &ip,
-                                                   int &port) const {
-  detail::get_local_ip_and_port(sock_, ip, port);
+inline void SSLSocketStream::get_local_ip_and_port(std::string &ip, int &port) const {
+	detail::get_local_ip_and_port(sock_, ip, port);
 }
 
-inline socket_t SSLSocketStream::socket() const { return sock_; }
+inline socket_t SSLSocketStream::socket() const {
+	return sock_;
+}
 
 static SSLInit sslinit_;
 
 } // namespace detail
 
 // SSL HTTP server implementation
-inline SSLServer::SSLServer(const char *cert_path, const char *private_key_path,
-                            const char *client_ca_cert_file_path,
-                            const char *client_ca_cert_dir_path,
-                            const char *private_key_password) {
-  ctx_ = SSL_CTX_new(TLS_server_method());
+inline SSLServer::SSLServer(const char *cert_path, const char *private_key_path, const char *client_ca_cert_file_path,
+                            const char *client_ca_cert_dir_path, const char *private_key_password) {
+	ctx_ = SSL_CTX_new(TLS_server_method());
 
-  if (ctx_) {
-    SSL_CTX_set_options(ctx_,
-                        SSL_OP_NO_COMPRESSION |
-                            SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
+	if (ctx_) {
+		SSL_CTX_set_options(ctx_, SSL_OP_NO_COMPRESSION | SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
 
-    SSL_CTX_set_min_proto_version(ctx_, TLS1_1_VERSION);
+		SSL_CTX_set_min_proto_version(ctx_, TLS1_1_VERSION);
 
-    // add default password callback before opening encrypted private key
-    if (private_key_password != nullptr && (private_key_password[0] != '\0')) {
-      SSL_CTX_set_default_passwd_cb_userdata(
-          ctx_,
-          reinterpret_cast<void *>(const_cast<char *>(private_key_password)));
-    }
+		// add default password callback before opening encrypted private key
+		if (private_key_password != nullptr && (private_key_password[0] != '\0')) {
+			SSL_CTX_set_default_passwd_cb_userdata(ctx_,
+			                                       reinterpret_cast<void *>(const_cast<char *>(private_key_password)));
+		}
 
-    if (SSL_CTX_use_certificate_chain_file(ctx_, cert_path) != 1 ||
-        SSL_CTX_use_PrivateKey_file(ctx_, private_key_path, SSL_FILETYPE_PEM) !=
-            1) {
-      SSL_CTX_free(ctx_);
-      ctx_ = nullptr;
-    } else if (client_ca_cert_file_path || client_ca_cert_dir_path) {
-      SSL_CTX_load_verify_locations(ctx_, client_ca_cert_file_path,
-                                    client_ca_cert_dir_path);
+		if (SSL_CTX_use_certificate_chain_file(ctx_, cert_path) != 1 ||
+		    SSL_CTX_use_PrivateKey_file(ctx_, private_key_path, SSL_FILETYPE_PEM) != 1) {
+			SSL_CTX_free(ctx_);
+			ctx_ = nullptr;
+		} else if (client_ca_cert_file_path || client_ca_cert_dir_path) {
+			SSL_CTX_load_verify_locations(ctx_, client_ca_cert_file_path, client_ca_cert_dir_path);
 
-      SSL_CTX_set_verify(
-          ctx_, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
-    }
-  }
+			SSL_CTX_set_verify(ctx_, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
+		}
+	}
 }
 
-inline SSLServer::SSLServer(X509 *cert, EVP_PKEY *private_key,
-                            X509_STORE *client_ca_cert_store) {
-  ctx_ = SSL_CTX_new(TLS_server_method());
+inline SSLServer::SSLServer(X509 *cert, EVP_PKEY *private_key, X509_STORE *client_ca_cert_store) {
+	ctx_ = SSL_CTX_new(TLS_server_method());
 
-  if (ctx_) {
-    SSL_CTX_set_options(ctx_,
-                        SSL_OP_NO_COMPRESSION |
-                            SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
+	if (ctx_) {
+		SSL_CTX_set_options(ctx_, SSL_OP_NO_COMPRESSION | SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
 
-    SSL_CTX_set_min_proto_version(ctx_, TLS1_1_VERSION);
+		SSL_CTX_set_min_proto_version(ctx_, TLS1_1_VERSION);
 
-    if (SSL_CTX_use_certificate(ctx_, cert) != 1 ||
-        SSL_CTX_use_PrivateKey(ctx_, private_key) != 1) {
-      SSL_CTX_free(ctx_);
-      ctx_ = nullptr;
-    } else if (client_ca_cert_store) {
-      SSL_CTX_set_cert_store(ctx_, client_ca_cert_store);
+		if (SSL_CTX_use_certificate(ctx_, cert) != 1 || SSL_CTX_use_PrivateKey(ctx_, private_key) != 1) {
+			SSL_CTX_free(ctx_);
+			ctx_ = nullptr;
+		} else if (client_ca_cert_store) {
+			SSL_CTX_set_cert_store(ctx_, client_ca_cert_store);
 
-      SSL_CTX_set_verify(
-          ctx_, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
-    }
-  }
+			SSL_CTX_set_verify(ctx_, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
+		}
+	}
 }
 
-inline SSLServer::SSLServer(
-    const std::function<bool(SSL_CTX &ssl_ctx)> &setup_ssl_ctx_callback) {
-  ctx_ = SSL_CTX_new(TLS_method());
-  if (ctx_) {
-    if (!setup_ssl_ctx_callback(*ctx_)) {
-      SSL_CTX_free(ctx_);
-      ctx_ = nullptr;
-    }
-  }
+inline SSLServer::SSLServer(const std::function<bool(SSL_CTX &ssl_ctx)> &setup_ssl_ctx_callback) {
+	ctx_ = SSL_CTX_new(TLS_method());
+	if (ctx_) {
+		if (!setup_ssl_ctx_callback(*ctx_)) {
+			SSL_CTX_free(ctx_);
+			ctx_ = nullptr;
+		}
+	}
 }
 
 inline SSLServer::~SSLServer() {
-  if (ctx_) { SSL_CTX_free(ctx_); }
+	if (ctx_) {
+		SSL_CTX_free(ctx_);
+	}
 }
 
-inline bool SSLServer::is_valid() const { return ctx_; }
+inline bool SSLServer::is_valid() const {
+	return ctx_;
+}
 
-inline SSL_CTX *SSLServer::ssl_context() const { return ctx_; }
+inline SSL_CTX *SSLServer::ssl_context() const {
+	return ctx_;
+}
 
 inline bool SSLServer::process_and_close_socket(socket_t sock) {
-  auto ssl = detail::ssl_new(
-      sock, ctx_, ctx_mutex_,
-      [&](SSL *ssl2) {
-        return detail::ssl_connect_or_accept_nonblocking(
-            sock, ssl2, SSL_accept, read_timeout_sec_, read_timeout_usec_);
-      },
-      [](SSL * /*ssl2*/) { return true; });
+	auto ssl = detail::ssl_new(
+	    sock, ctx_, ctx_mutex_,
+	    [&](SSL *ssl2) {
+		    return detail::ssl_connect_or_accept_nonblocking(sock, ssl2, SSL_accept, read_timeout_sec_,
+		                                                     read_timeout_usec_);
+	    },
+	    [](SSL * /*ssl2*/) { return true; });
 
-  auto ret = false;
-  if (ssl) {
-    ret = detail::process_server_socket_ssl(
-        svr_sock_, ssl, sock, keep_alive_max_count_, keep_alive_timeout_sec_,
-        read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
-        write_timeout_usec_,
-        [this, ssl](Stream &strm, bool close_connection,
-                    bool &connection_closed) {
-          return process_request(strm, close_connection, connection_closed,
-                                 [&](Request &req) { req.ssl = ssl; });
-        });
+	auto ret = false;
+	if (ssl) {
+		ret = detail::process_server_socket_ssl(
+		    svr_sock_, ssl, sock, keep_alive_max_count_, keep_alive_timeout_sec_, read_timeout_sec_, read_timeout_usec_,
+		    write_timeout_sec_, write_timeout_usec_,
+		    [this, ssl](Stream &strm, bool close_connection, bool &connection_closed) {
+			    return process_request(strm, close_connection, connection_closed, [&](Request &req) { req.ssl = ssl; });
+		    });
 
-    // Shutdown gracefully if the result seemed successful, non-gracefully if
-    // the connection appeared to be closed.
-    const bool shutdown_gracefully = ret;
-    detail::ssl_delete(ctx_mutex_, ssl, shutdown_gracefully);
-  }
+		// Shutdown gracefully if the result seemed successful, non-gracefully if
+		// the connection appeared to be closed.
+		const bool shutdown_gracefully = ret;
+		detail::ssl_delete(ctx_mutex_, ssl, shutdown_gracefully);
+	}
 
-  detail::shutdown_socket(sock);
-  detail::close_socket(sock);
-  return ret;
+	detail::shutdown_socket(sock);
+	detail::close_socket(sock);
+	return ret;
 }
 
 // SSL HTTP client implementation
-inline SSLClient::SSLClient(const std::string &host)
-    : SSLClient(host, 443, std::string(), std::string()) {}
-
-inline SSLClient::SSLClient(const std::string &host, int port)
-    : SSLClient(host, port, std::string(), std::string()) {}
-
-inline SSLClient::SSLClient(const std::string &host, int port,
-                            const std::string &client_cert_path,
-                            const std::string &client_key_path)
-    : ClientImpl(host, port, client_cert_path, client_key_path) {
-  ctx_ = SSL_CTX_new(TLS_client_method());
-
-  detail::split(&host_[0], &host_[host_.size()], '.',
-                [&](const char *b, const char *e) {
-                  host_components_.emplace_back(b, e);
-                });
-
-  if (!client_cert_path.empty() && !client_key_path.empty()) {
-    if (SSL_CTX_use_certificate_file(ctx_, client_cert_path.c_str(),
-                                     SSL_FILETYPE_PEM) != 1 ||
-        SSL_CTX_use_PrivateKey_file(ctx_, client_key_path.c_str(),
-                                    SSL_FILETYPE_PEM) != 1) {
-      SSL_CTX_free(ctx_);
-      ctx_ = nullptr;
-    }
-  }
+inline SSLClient::SSLClient(const std::string &host) : SSLClient(host, 443, std::string(), std::string()) {
 }
 
-inline SSLClient::SSLClient(const std::string &host, int port,
-                            X509 *client_cert, EVP_PKEY *client_key)
+inline SSLClient::SSLClient(const std::string &host, int port) : SSLClient(host, port, std::string(), std::string()) {
+}
+
+inline SSLClient::SSLClient(const std::string &host, int port, const std::string &client_cert_path,
+                            const std::string &client_key_path)
+    : ClientImpl(host, port, client_cert_path, client_key_path) {
+	ctx_ = SSL_CTX_new(TLS_client_method());
+
+	detail::split(&host_[0], &host_[host_.size()], '.',
+	              [&](const char *b, const char *e) { host_components_.emplace_back(b, e); });
+
+	if (!client_cert_path.empty() && !client_key_path.empty()) {
+		if (SSL_CTX_use_certificate_file(ctx_, client_cert_path.c_str(), SSL_FILETYPE_PEM) != 1 ||
+		    SSL_CTX_use_PrivateKey_file(ctx_, client_key_path.c_str(), SSL_FILETYPE_PEM) != 1) {
+			SSL_CTX_free(ctx_);
+			ctx_ = nullptr;
+		}
+	}
+}
+
+inline SSLClient::SSLClient(const std::string &host, int port, X509 *client_cert, EVP_PKEY *client_key)
     : ClientImpl(host, port) {
-  ctx_ = SSL_CTX_new(TLS_client_method());
+	ctx_ = SSL_CTX_new(TLS_client_method());
 
-  detail::split(&host_[0], &host_[host_.size()], '.',
-                [&](const char *b, const char *e) {
-                  host_components_.emplace_back(b, e);
-                });
+	detail::split(&host_[0], &host_[host_.size()], '.',
+	              [&](const char *b, const char *e) { host_components_.emplace_back(b, e); });
 
-  if (client_cert != nullptr && client_key != nullptr) {
-    if (SSL_CTX_use_certificate(ctx_, client_cert) != 1 ||
-        SSL_CTX_use_PrivateKey(ctx_, client_key) != 1) {
-      SSL_CTX_free(ctx_);
-      ctx_ = nullptr;
-    }
-  }
+	if (client_cert != nullptr && client_key != nullptr) {
+		if (SSL_CTX_use_certificate(ctx_, client_cert) != 1 || SSL_CTX_use_PrivateKey(ctx_, client_key) != 1) {
+			SSL_CTX_free(ctx_);
+			ctx_ = nullptr;
+		}
+	}
 }
 
 inline SSLClient::~SSLClient() {
-  if (ctx_) { SSL_CTX_free(ctx_); }
-  // Make sure to shut down SSL since shutdown_ssl will resolve to the
-  // base function rather than the derived function once we get to the
-  // base class destructor, and won't free the SSL (causing a leak).
-  shutdown_ssl_impl(socket_, true);
+	if (ctx_) {
+		SSL_CTX_free(ctx_);
+	}
+	// Make sure to shut down SSL since shutdown_ssl will resolve to the
+	// base function rather than the derived function once we get to the
+	// base class destructor, and won't free the SSL (causing a leak).
+	shutdown_ssl_impl(socket_, true);
 }
 
-inline bool SSLClient::is_valid() const { return ctx_; }
+inline bool SSLClient::is_valid() const {
+	return ctx_;
+}
 
 inline void SSLClient::set_ca_cert_store(X509_STORE *ca_cert_store) {
-  if (ca_cert_store) {
-    if (ctx_) {
-      if (SSL_CTX_get_cert_store(ctx_) != ca_cert_store) {
-        // Free memory allocated for old cert and use new store `ca_cert_store`
-        SSL_CTX_set_cert_store(ctx_, ca_cert_store);
-      }
-    } else {
-      X509_STORE_free(ca_cert_store);
-    }
-  }
+	if (ca_cert_store) {
+		if (ctx_) {
+			if (SSL_CTX_get_cert_store(ctx_) != ca_cert_store) {
+				// Free memory allocated for old cert and use new store `ca_cert_store`
+				SSL_CTX_set_cert_store(ctx_, ca_cert_store);
+			}
+		} else {
+			X509_STORE_free(ca_cert_store);
+		}
+	}
 }
 
-inline void SSLClient::load_ca_cert_store(const char *ca_cert,
-                                          std::size_t size) {
-  set_ca_cert_store(ClientImpl::create_ca_cert_store(ca_cert, size));
+inline void SSLClient::load_ca_cert_store(const char *ca_cert, std::size_t size) {
+	set_ca_cert_store(ClientImpl::create_ca_cert_store(ca_cert, size));
 }
 
 inline long SSLClient::get_openssl_verify_result() const {
-  return verify_result_;
+	return verify_result_;
 }
 
-inline SSL_CTX *SSLClient::ssl_context() const { return ctx_; }
+inline SSL_CTX *SSLClient::ssl_context() const {
+	return ctx_;
+}
 
 inline bool SSLClient::create_and_connect_socket(Socket &socket, Error &error) {
-  if (!is_valid()) {
-    error = Error::SSLConnection;
-    return false;
-  }
-  return ClientImpl::create_and_connect_socket(socket, error);
+	if (!is_valid()) {
+		error = Error::SSLConnection;
+		return false;
+	}
+	return ClientImpl::create_and_connect_socket(socket, error);
 }
 
 // Assumes that socket_mutex_ is locked and that there are no requests in flight
-inline bool SSLClient::connect_with_proxy(Socket &socket, Response &res,
-                                          bool &success, Error &error) {
-  success = true;
-  Response proxy_res;
-  if (!detail::process_client_socket(
-          socket.sock, read_timeout_sec_, read_timeout_usec_,
-          write_timeout_sec_, write_timeout_usec_, [&](Stream &strm) {
-            Request req2;
-            req2.method = "CONNECT";
-            req2.path = host_and_port_;
-            return process_request(strm, req2, proxy_res, false, error);
-          })) {
-    // Thread-safe to close everything because we are assuming there are no
-    // requests in flight
-    shutdown_ssl(socket, true);
-    shutdown_socket(socket);
-    close_socket(socket);
-    success = false;
-    return false;
-  }
+inline bool SSLClient::connect_with_proxy(Socket &socket, Response &res, bool &success, Error &error) {
+	success = true;
+	Response proxy_res;
+	if (!detail::process_client_socket(socket.sock, read_timeout_sec_, read_timeout_usec_, write_timeout_sec_,
+	                                   write_timeout_usec_, [&](Stream &strm) {
+		                                   Request req2;
+		                                   req2.method = "CONNECT";
+		                                   req2.path = host_and_port_;
+		                                   return process_request(strm, req2, proxy_res, false, error);
+	                                   })) {
+		// Thread-safe to close everything because we are assuming there are no
+		// requests in flight
+		shutdown_ssl(socket, true);
+		shutdown_socket(socket);
+		close_socket(socket);
+		success = false;
+		return false;
+	}
 
-  if (proxy_res.status == StatusCode::ProxyAuthenticationRequired_407) {
-    if (!proxy_digest_auth_username_.empty() &&
-        !proxy_digest_auth_password_.empty()) {
-      std::map<std::string, std::string> auth;
-      if (detail::parse_www_authenticate(proxy_res, auth, true)) {
-        proxy_res = Response();
-        if (!detail::process_client_socket(
-                socket.sock, read_timeout_sec_, read_timeout_usec_,
-                write_timeout_sec_, write_timeout_usec_, [&](Stream &strm) {
-                  Request req3;
-                  req3.method = "CONNECT";
-                  req3.path = host_and_port_;
-                  req3.headers.insert(detail::make_digest_authentication_header(
-                      req3, auth, 1, detail::random_string(10),
-                      proxy_digest_auth_username_, proxy_digest_auth_password_,
-                      true));
-                  return process_request(strm, req3, proxy_res, false, error);
-                })) {
-          // Thread-safe to close everything because we are assuming there are
-          // no requests in flight
-          shutdown_ssl(socket, true);
-          shutdown_socket(socket);
-          close_socket(socket);
-          success = false;
-          return false;
-        }
-      }
-    }
-  }
+	if (proxy_res.status == StatusCode::ProxyAuthenticationRequired_407) {
+		if (!proxy_digest_auth_username_.empty() && !proxy_digest_auth_password_.empty()) {
+			std::map<std::string, std::string> auth;
+			if (detail::parse_www_authenticate(proxy_res, auth, true)) {
+				proxy_res = Response();
+				if (!detail::process_client_socket(socket.sock, read_timeout_sec_, read_timeout_usec_,
+				                                   write_timeout_sec_, write_timeout_usec_, [&](Stream &strm) {
+					                                   Request req3;
+					                                   req3.method = "CONNECT";
+					                                   req3.path = host_and_port_;
+					                                   req3.headers.insert(detail::make_digest_authentication_header(
+					                                       req3, auth, 1, detail::random_string(10),
+					                                       proxy_digest_auth_username_, proxy_digest_auth_password_,
+					                                       true));
+					                                   return process_request(strm, req3, proxy_res, false, error);
+				                                   })) {
+					// Thread-safe to close everything because we are assuming there are
+					// no requests in flight
+					shutdown_ssl(socket, true);
+					shutdown_socket(socket);
+					close_socket(socket);
+					success = false;
+					return false;
+				}
+			}
+		}
+	}
 
-  // If status code is not 200, proxy request is failed.
-  // Set error to ProxyConnection and return proxy response
-  // as the response of the request
-  if (proxy_res.status != StatusCode::OK_200) {
-    error = Error::ProxyConnection;
-    res = std::move(proxy_res);
-    // Thread-safe to close everything because we are assuming there are
-    // no requests in flight
-    shutdown_ssl(socket, true);
-    shutdown_socket(socket);
-    close_socket(socket);
-    return false;
-  }
+	// If status code is not 200, proxy request is failed.
+	// Set error to ProxyConnection and return proxy response
+	// as the response of the request
+	if (proxy_res.status != StatusCode::OK_200) {
+		error = Error::ProxyConnection;
+		res = std::move(proxy_res);
+		// Thread-safe to close everything because we are assuming there are
+		// no requests in flight
+		shutdown_ssl(socket, true);
+		shutdown_socket(socket);
+		close_socket(socket);
+		return false;
+	}
 
-  return true;
+	return true;
 }
 
 inline bool SSLClient::load_certs() {
-  auto ret = true;
+	auto ret = true;
 
-  std::call_once(initialize_cert_, [&]() {
-    std::lock_guard<std::mutex> guard(ctx_mutex_);
-    if (!ca_cert_file_path_.empty()) {
-      if (!SSL_CTX_load_verify_locations(ctx_, ca_cert_file_path_.c_str(),
-                                         nullptr)) {
-        ret = false;
-      }
-    } else if (!ca_cert_dir_path_.empty()) {
-      if (!SSL_CTX_load_verify_locations(ctx_, nullptr,
-                                         ca_cert_dir_path_.c_str())) {
-        ret = false;
-      }
-    } else {
-      auto loaded = false;
+	std::call_once(initialize_cert_, [&]() {
+		std::lock_guard<std::mutex> guard(ctx_mutex_);
+		if (!ca_cert_file_path_.empty()) {
+			if (!SSL_CTX_load_verify_locations(ctx_, ca_cert_file_path_.c_str(), nullptr)) {
+				ret = false;
+			}
+		} else if (!ca_cert_dir_path_.empty()) {
+			if (!SSL_CTX_load_verify_locations(ctx_, nullptr, ca_cert_dir_path_.c_str())) {
+				ret = false;
+			}
+		} else {
+			auto loaded = false;
 #ifdef _WIN32
-      loaded =
-          detail::load_system_certs_on_windows(SSL_CTX_get_cert_store(ctx_));
+			loaded = detail::load_system_certs_on_windows(SSL_CTX_get_cert_store(ctx_));
 #elif defined(CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN) && defined(__APPLE__)
 #if TARGET_OS_OSX
       loaded = detail::load_system_certs_on_macos(SSL_CTX_get_cert_store(ctx_));
 #endif // TARGET_OS_OSX
 #endif // _WIN32
-      if (!loaded) { SSL_CTX_set_default_verify_paths(ctx_); }
-    }
-  });
+			if (!loaded) {
+				SSL_CTX_set_default_verify_paths(ctx_);
+			}
+		}
+	});
 
-  return ret;
+	return ret;
 }
 
 inline bool SSLClient::initialize_ssl(Socket &socket, Error &error) {
-  auto ssl = detail::ssl_new(
-      socket.sock, ctx_, ctx_mutex_,
-      [&](SSL *ssl2) {
-        if (server_certificate_verification_) {
-          if (!load_certs()) {
-            error = Error::SSLLoadingCerts;
-            return false;
-          }
-          SSL_set_verify(ssl2, SSL_VERIFY_NONE, nullptr);
-        }
+	auto ssl = detail::ssl_new(
+	    socket.sock, ctx_, ctx_mutex_,
+	    [&](SSL *ssl2) {
+		    if (server_certificate_verification_) {
+			    if (!load_certs()) {
+				    error = Error::SSLLoadingCerts;
+				    return false;
+			    }
+			    SSL_set_verify(ssl2, SSL_VERIFY_NONE, nullptr);
+		    }
 
-        if (!detail::ssl_connect_or_accept_nonblocking(
-                socket.sock, ssl2, SSL_connect, connection_timeout_sec_,
-                connection_timeout_usec_)) {
-          error = Error::SSLConnection;
-          return false;
-        }
+		    if (!detail::ssl_connect_or_accept_nonblocking(socket.sock, ssl2, SSL_connect, connection_timeout_sec_,
+		                                                   connection_timeout_usec_)) {
+			    error = Error::SSLConnection;
+			    return false;
+		    }
 
-        if (server_certificate_verification_) {
-          verify_result_ = SSL_get_verify_result(ssl2);
+		    if (server_certificate_verification_) {
+			    verify_result_ = SSL_get_verify_result(ssl2);
 
-          if (verify_result_ != X509_V_OK) {
-            error = Error::SSLServerVerification;
-            return false;
-          }
+			    if (verify_result_ != X509_V_OK) {
+				    error = Error::SSLServerVerification;
+				    return false;
+			    }
 
-          auto server_cert = SSL_get1_peer_certificate(ssl2);
+			    auto server_cert = SSL_get1_peer_certificate(ssl2);
 
-          if (server_cert == nullptr) {
-            error = Error::SSLServerVerification;
-            return false;
-          }
+			    if (server_cert == nullptr) {
+				    error = Error::SSLServerVerification;
+				    return false;
+			    }
 
-          if (!verify_host(server_cert)) {
-            X509_free(server_cert);
-            error = Error::SSLServerVerification;
-            return false;
-          }
-          X509_free(server_cert);
-        }
+			    if (!verify_host(server_cert)) {
+				    X509_free(server_cert);
+				    error = Error::SSLServerVerification;
+				    return false;
+			    }
+			    X509_free(server_cert);
+		    }
 
-        return true;
-      },
-      [&](SSL *ssl2) {
-        // NOTE: With -Wold-style-cast, this can produce a warning, since
-        //  SSL_set_tlsext_host_name is a macro (in OpenSSL), which contains
-        //  an old style cast. Short of doing compiler specific pragma's
-        //  here, we can't get rid of this warning. :'(
-        SSL_set_tlsext_host_name(ssl2, host_.c_str());
-        return true;
-      });
+		    return true;
+	    },
+	    [&](SSL *ssl2) {
+		    // NOTE: With -Wold-style-cast, this can produce a warning, since
+		    //  SSL_set_tlsext_host_name is a macro (in OpenSSL), which contains
+		    //  an old style cast. Short of doing compiler specific pragma's
+		    //  here, we can't get rid of this warning. :'(
+		    SSL_set_tlsext_host_name(ssl2, host_.c_str());
+		    return true;
+	    });
 
-  if (ssl) {
-    socket.ssl = ssl;
-    return true;
-  }
+	if (ssl) {
+		socket.ssl = ssl;
+		return true;
+	}
 
-  shutdown_socket(socket);
-  close_socket(socket);
-  return false;
+	shutdown_socket(socket);
+	close_socket(socket);
+	return false;
 }
 
 inline void SSLClient::shutdown_ssl(Socket &socket, bool shutdown_gracefully) {
-  shutdown_ssl_impl(socket, shutdown_gracefully);
+	shutdown_ssl_impl(socket, shutdown_gracefully);
 }
 
-inline void SSLClient::shutdown_ssl_impl(Socket &socket,
-                                         bool shutdown_gracefully) {
-  if (socket.sock == INVALID_SOCKET) {
-    assert(socket.ssl == nullptr);
-    return;
-  }
-  if (socket.ssl) {
-    detail::ssl_delete(ctx_mutex_, socket.ssl, shutdown_gracefully);
-    socket.ssl = nullptr;
-  }
-  assert(socket.ssl == nullptr);
+inline void SSLClient::shutdown_ssl_impl(Socket &socket, bool shutdown_gracefully) {
+	if (socket.sock == INVALID_SOCKET) {
+		assert(socket.ssl == nullptr);
+		return;
+	}
+	if (socket.ssl) {
+		detail::ssl_delete(ctx_mutex_, socket.ssl, shutdown_gracefully);
+		socket.ssl = nullptr;
+	}
+	assert(socket.ssl == nullptr);
 }
 
-inline bool
-SSLClient::process_socket(const Socket &socket,
-                          std::function<bool(Stream &strm)> callback) {
-  assert(socket.ssl);
-  return detail::process_client_socket_ssl(
-      socket.ssl, socket.sock, read_timeout_sec_, read_timeout_usec_,
-      write_timeout_sec_, write_timeout_usec_, std::move(callback));
+inline bool SSLClient::process_socket(const Socket &socket, std::function<bool(Stream &strm)> callback) {
+	assert(socket.ssl);
+	return detail::process_client_socket_ssl(socket.ssl, socket.sock, read_timeout_sec_, read_timeout_usec_,
+	                                         write_timeout_sec_, write_timeout_usec_, std::move(callback));
 }
 
-inline bool SSLClient::is_ssl() const { return true; }
+inline bool SSLClient::is_ssl() const {
+	return true;
+}
 
 inline bool SSLClient::verify_host(X509 *server_cert) const {
-  /* Quote from RFC2818 section 3.1 "Server Identity"
+	/* Quote from RFC2818 section 3.1 "Server Identity"
 
-     If a subjectAltName extension of type dNSName is present, that MUST
-     be used as the identity. Otherwise, the (most specific) Common Name
-     field in the Subject field of the certificate MUST be used. Although
-     the use of the Common Name is existing practice, it is deprecated and
-     Certification Authorities are encouraged to use the dNSName instead.
+	   If a subjectAltName extension of type dNSName is present, that MUST
+	   be used as the identity. Otherwise, the (most specific) Common Name
+	   field in the Subject field of the certificate MUST be used. Although
+	   the use of the Common Name is existing practice, it is deprecated and
+	   Certification Authorities are encouraged to use the dNSName instead.
 
-     Matching is performed using the matching rules specified by
-     [RFC2459].  If more than one identity of a given type is present in
-     the certificate (e.g., more than one dNSName name, a match in any one
-     of the set is considered acceptable.) Names may contain the wildcard
-     character * which is considered to match any single domain name
-     component or component fragment. E.g., *.a.com matches foo.a.com but
-     not bar.foo.a.com. f*.com matches foo.com but not bar.com.
+	   Matching is performed using the matching rules specified by
+	   [RFC2459].  If more than one identity of a given type is present in
+	   the certificate (e.g., more than one dNSName name, a match in any one
+	   of the set is considered acceptable.) Names may contain the wildcard
+	   character * which is considered to match any single domain name
+	   component or component fragment. E.g., *.a.com matches foo.a.com but
+	   not bar.foo.a.com. f*.com matches foo.com but not bar.com.
 
-     In some cases, the URI is specified as an IP address rather than a
-     hostname. In this case, the iPAddress subjectAltName must be present
-     in the certificate and must exactly match the IP in the URI.
+	   In some cases, the URI is specified as an IP address rather than a
+	   hostname. In this case, the iPAddress subjectAltName must be present
+	   in the certificate and must exactly match the IP in the URI.
 
-  */
-  return verify_host_with_subject_alt_name(server_cert) ||
-         verify_host_with_common_name(server_cert);
+	*/
+	return verify_host_with_subject_alt_name(server_cert) || verify_host_with_common_name(server_cert);
 }
 
-inline bool
-SSLClient::verify_host_with_subject_alt_name(X509 *server_cert) const {
-  auto ret = false;
+inline bool SSLClient::verify_host_with_subject_alt_name(X509 *server_cert) const {
+	auto ret = false;
 
-  auto type = GEN_DNS;
+	auto type = GEN_DNS;
 
-  struct in6_addr addr6 {};
-  struct in_addr addr {};
-  size_t addr_len = 0;
+	struct in6_addr addr6 {};
+	struct in_addr addr {};
+	size_t addr_len = 0;
 
 #ifndef __MINGW32__
-  if (inet_pton(AF_INET6, host_.c_str(), &addr6)) {
-    type = GEN_IPADD;
-    addr_len = sizeof(struct in6_addr);
-  } else if (inet_pton(AF_INET, host_.c_str(), &addr)) {
-    type = GEN_IPADD;
-    addr_len = sizeof(struct in_addr);
-  }
+	if (inet_pton(AF_INET6, host_.c_str(), &addr6)) {
+		type = GEN_IPADD;
+		addr_len = sizeof(struct in6_addr);
+	} else if (inet_pton(AF_INET, host_.c_str(), &addr)) {
+		type = GEN_IPADD;
+		addr_len = sizeof(struct in_addr);
+	}
 #endif
 
-  auto alt_names = static_cast<const struct stack_st_GENERAL_NAME *>(
-      X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
+	auto alt_names = static_cast<const struct stack_st_GENERAL_NAME *>(
+	    X509_get_ext_d2i(server_cert, NID_subject_alt_name, nullptr, nullptr));
 
-  if (alt_names) {
-    auto dsn_matched = false;
-    auto ip_matched = false;
+	if (alt_names) {
+		auto dsn_matched = false;
+		auto ip_matched = false;
 
-    auto count = sk_GENERAL_NAME_num(alt_names);
+		auto count = sk_GENERAL_NAME_num(alt_names);
 
-    for (decltype(count) i = 0; i < count && !dsn_matched; i++) {
-      auto val = sk_GENERAL_NAME_value(alt_names, i);
-      if (val->type == type) {
-        auto name =
-            reinterpret_cast<const char *>(ASN1_STRING_get0_data(val->d.ia5));
-        auto name_len = static_cast<size_t>(ASN1_STRING_length(val->d.ia5));
+		for (decltype(count) i = 0; i < count && !dsn_matched; i++) {
+			auto val = sk_GENERAL_NAME_value(alt_names, i);
+			if (val->type == type) {
+				auto name = reinterpret_cast<const char *>(ASN1_STRING_get0_data(val->d.ia5));
+				auto name_len = static_cast<size_t>(ASN1_STRING_length(val->d.ia5));
 
-        switch (type) {
-        case GEN_DNS: dsn_matched = check_host_name(name, name_len); break;
+				switch (type) {
+				case GEN_DNS:
+					dsn_matched = check_host_name(name, name_len);
+					break;
 
-        case GEN_IPADD:
-          if (!memcmp(&addr6, name, addr_len) ||
-              !memcmp(&addr, name, addr_len)) {
-            ip_matched = true;
-          }
-          break;
-        }
-      }
-    }
+				case GEN_IPADD:
+					if (!memcmp(&addr6, name, addr_len) || !memcmp(&addr, name, addr_len)) {
+						ip_matched = true;
+					}
+					break;
+				}
+			}
+		}
 
-    if (dsn_matched || ip_matched) { ret = true; }
-  }
+		if (dsn_matched || ip_matched) {
+			ret = true;
+		}
+	}
 
-  GENERAL_NAMES_free(const_cast<STACK_OF(GENERAL_NAME) *>(
-      reinterpret_cast<const STACK_OF(GENERAL_NAME) *>(alt_names)));
-  return ret;
+	GENERAL_NAMES_free(
+	    const_cast<STACK_OF(GENERAL_NAME) *>(reinterpret_cast<const STACK_OF(GENERAL_NAME) *>(alt_names)));
+	return ret;
 }
 
 inline bool SSLClient::verify_host_with_common_name(X509 *server_cert) const {
-  const auto subject_name = X509_get_subject_name(server_cert);
+	const auto subject_name = X509_get_subject_name(server_cert);
 
-  if (subject_name != nullptr) {
-    char name[BUFSIZ];
-    auto name_len = X509_NAME_get_text_by_NID(subject_name, NID_commonName,
-                                              name, sizeof(name));
+	if (subject_name != nullptr) {
+		char name[BUFSIZ];
+		auto name_len = X509_NAME_get_text_by_NID(subject_name, NID_commonName, name, sizeof(name));
 
-    if (name_len != -1) {
-      return check_host_name(name, static_cast<size_t>(name_len));
-    }
-  }
+		if (name_len != -1) {
+			return check_host_name(name, static_cast<size_t>(name_len));
+		}
+	}
 
-  return false;
+	return false;
 }
 
-inline bool SSLClient::check_host_name(const char *pattern,
-                                       size_t pattern_len) const {
-  if (host_.size() == pattern_len && host_ == pattern) { return true; }
+inline bool SSLClient::check_host_name(const char *pattern, size_t pattern_len) const {
+	if (host_.size() == pattern_len && host_ == pattern) {
+		return true;
+	}
 
-  // Wildcard match
-  // https://bugs.launchpad.net/ubuntu/+source/firefox-3.0/+bug/376484
-  std::vector<std::string> pattern_components;
-  detail::split(&pattern[0], &pattern[pattern_len], '.',
-                [&](const char *b, const char *e) {
-                  pattern_components.emplace_back(b, e);
-                });
+	// Wildcard match
+	// https://bugs.launchpad.net/ubuntu/+source/firefox-3.0/+bug/376484
+	std::vector<std::string> pattern_components;
+	detail::split(&pattern[0], &pattern[pattern_len], '.',
+	              [&](const char *b, const char *e) { pattern_components.emplace_back(b, e); });
 
-  if (host_components_.size() != pattern_components.size()) { return false; }
+	if (host_components_.size() != pattern_components.size()) {
+		return false;
+	}
 
-  auto itr = pattern_components.begin();
-  for (const auto &h : host_components_) {
-    auto &p = *itr;
-    if (p != h && p != "*") {
-      auto partial_match = (p.size() > 0 && p[p.size() - 1] == '*' &&
-                            !p.compare(0, p.size() - 1, h));
-      if (!partial_match) { return false; }
-    }
-    ++itr;
-  }
+	auto itr = pattern_components.begin();
+	for (const auto &h : host_components_) {
+		auto &p = *itr;
+		if (p != h && p != "*") {
+			auto partial_match = (p.size() > 0 && p[p.size() - 1] == '*' && !p.compare(0, p.size() - 1, h));
+			if (!partial_match) {
+				return false;
+			}
+		}
+		++itr;
+	}
 
-  return true;
+	return true;
 }
 #endif
 
 // Universal client implementation
-inline Client::Client(const std::string &scheme_host_port)
-    : Client(scheme_host_port, std::string(), std::string()) {}
-
-inline Client::Client(const std::string &scheme_host_port,
-                      const std::string &client_cert_path,
-                      const std::string &client_key_path) {
-  const Regex re(
-      R"((?:([a-z]+):\/\/)?(?:\[([\d:]+)\]|([^:/?#]+))(?::(\d+))?)");
-
-  Match m;
-  if (RegexMatch(scheme_host_port, m, re)) {
-    auto scheme = m[1].str();
-
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    if (!scheme.empty() && (scheme != "http" && scheme != "https")) {
-#else
-    if (!scheme.empty() && scheme != "http") {
-#endif
-#ifndef CPPHTTPLIB_NO_EXCEPTIONS
-      std::string msg = "'" + scheme + "' scheme is not supported.";
-      throw std::invalid_argument(msg);
-#endif
-      return;
-    }
-
-    auto is_ssl = scheme == "https";
-
-    auto host = m[2].str();
-    if (host.empty()) { host = m[3].str(); }
-
-    auto port_str = m[4].str();
-    auto port = !port_str.empty() ? std::stoi(port_str) : (is_ssl ? 443 : 80);
-
-    if (is_ssl) {
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-      cli_ = detail::make_unique<SSLClient>(host, port, client_cert_path,
-                                            client_key_path);
-      is_ssl_ = is_ssl;
-#endif
-    } else {
-      cli_ = detail::make_unique<ClientImpl>(host, port, client_cert_path,
-                                             client_key_path);
-    }
-  } else {
-    cli_ = detail::make_unique<ClientImpl>(scheme_host_port, 80,
-                                           client_cert_path, client_key_path);
-  }
+inline Client::Client(const std::string &scheme_host_port) : Client(scheme_host_port, std::string(), std::string()) {
 }
 
-inline Client::Client(const std::string &host, int port)
-    : cli_(detail::make_unique<ClientImpl>(host, port)) {}
+inline Client::Client(const std::string &scheme_host_port, const std::string &client_cert_path,
+                      const std::string &client_key_path) {
+	const Regex re(R"((?:([a-z]+):\/\/)?(?:\[([\d:]+)\]|([^:/?#]+))(?::(\d+))?)");
 
-inline Client::Client(const std::string &host, int port,
-                      const std::string &client_cert_path,
+	Match m;
+	if (RegexMatch(scheme_host_port, m, re)) {
+		auto scheme = m[1].str();
+
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+		if (!scheme.empty() && (scheme != "http" && scheme != "https")) {
+#else
+		if (!scheme.empty() && scheme != "http") {
+#endif
+#ifndef CPPHTTPLIB_NO_EXCEPTIONS
+			std::string msg = "'" + scheme + "' scheme is not supported.";
+			throw std::invalid_argument(msg);
+#endif
+			return;
+		}
+
+		auto is_ssl = scheme == "https";
+
+		auto host = m[2].str();
+		if (host.empty()) {
+			host = m[3].str();
+		}
+
+		auto port_str = m[4].str();
+		auto port = !port_str.empty() ? std::stoi(port_str) : (is_ssl ? 443 : 80);
+
+		if (is_ssl) {
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+			cli_ = detail::make_unique<SSLClient>(host, port, client_cert_path, client_key_path);
+			is_ssl_ = is_ssl;
+#endif
+		} else {
+			cli_ = detail::make_unique<ClientImpl>(host, port, client_cert_path, client_key_path);
+		}
+	} else {
+		cli_ = detail::make_unique<ClientImpl>(scheme_host_port, 80, client_cert_path, client_key_path);
+	}
+}
+
+inline Client::Client(const std::string &host, int port) : cli_(detail::make_unique<ClientImpl>(host, port)) {
+}
+
+inline Client::Client(const std::string &host, int port, const std::string &client_cert_path,
                       const std::string &client_key_path)
-    : cli_(detail::make_unique<ClientImpl>(host, port, client_cert_path,
-                                           client_key_path)) {}
+    : cli_(detail::make_unique<ClientImpl>(host, port, client_cert_path, client_key_path)) {
+}
 
 inline Client::~Client() = default;
 
 inline bool Client::is_valid() const {
-  return cli_ != nullptr && cli_->is_valid();
+	return cli_ != nullptr && cli_->is_valid();
 }
 
-inline Result Client::Get(const std::string &path) { return cli_->Get(path); }
+inline Result Client::Get(const std::string &path) {
+	return cli_->Get(path);
+}
 inline Result Client::Get(const std::string &path, const Headers &headers) {
-  return cli_->Get(path, headers);
+	return cli_->Get(path, headers);
 }
 inline Result Client::Get(const std::string &path, Progress progress) {
-  return cli_->Get(path, std::move(progress));
+	return cli_->Get(path, std::move(progress));
 }
-inline Result Client::Get(const std::string &path, const Headers &headers,
+inline Result Client::Get(const std::string &path, const Headers &headers, Progress progress) {
+	return cli_->Get(path, headers, std::move(progress));
+}
+inline Result Client::Get(const std::string &path, ContentReceiver content_receiver) {
+	return cli_->Get(path, std::move(content_receiver));
+}
+inline Result Client::Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver) {
+	return cli_->Get(path, headers, std::move(content_receiver));
+}
+inline Result Client::Get(const std::string &path, ContentReceiver content_receiver, Progress progress) {
+	return cli_->Get(path, std::move(content_receiver), std::move(progress));
+}
+inline Result Client::Get(const std::string &path, const Headers &headers, ContentReceiver content_receiver,
                           Progress progress) {
-  return cli_->Get(path, headers, std::move(progress));
+	return cli_->Get(path, headers, std::move(content_receiver), std::move(progress));
 }
-inline Result Client::Get(const std::string &path,
+inline Result Client::Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver) {
+	return cli_->Get(path, std::move(response_handler), std::move(content_receiver));
+}
+inline Result Client::Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
                           ContentReceiver content_receiver) {
-  return cli_->Get(path, std::move(content_receiver));
+	return cli_->Get(path, headers, std::move(response_handler), std::move(content_receiver));
 }
-inline Result Client::Get(const std::string &path, const Headers &headers,
-                          ContentReceiver content_receiver) {
-  return cli_->Get(path, headers, std::move(content_receiver));
+inline Result Client::Get(const std::string &path, ResponseHandler response_handler, ContentReceiver content_receiver,
+                          Progress progress) {
+	return cli_->Get(path, std::move(response_handler), std::move(content_receiver), std::move(progress));
 }
-inline Result Client::Get(const std::string &path,
+inline Result Client::Get(const std::string &path, const Headers &headers, ResponseHandler response_handler,
                           ContentReceiver content_receiver, Progress progress) {
-  return cli_->Get(path, std::move(content_receiver), std::move(progress));
+	return cli_->Get(path, headers, std::move(response_handler), std::move(content_receiver), std::move(progress));
 }
-inline Result Client::Get(const std::string &path, const Headers &headers,
+inline Result Client::Get(const std::string &path, const Params &params, const Headers &headers, Progress progress) {
+	return cli_->Get(path, params, headers, progress);
+}
+inline Result Client::Get(const std::string &path, const Params &params, const Headers &headers,
                           ContentReceiver content_receiver, Progress progress) {
-  return cli_->Get(path, headers, std::move(content_receiver),
-                   std::move(progress));
+	return cli_->Get(path, params, headers, content_receiver, progress);
 }
-inline Result Client::Get(const std::string &path,
-                          ResponseHandler response_handler,
-                          ContentReceiver content_receiver) {
-  return cli_->Get(path, std::move(response_handler),
-                   std::move(content_receiver));
-}
-inline Result Client::Get(const std::string &path, const Headers &headers,
-                          ResponseHandler response_handler,
-                          ContentReceiver content_receiver) {
-  return cli_->Get(path, headers, std::move(response_handler),
-                   std::move(content_receiver));
-}
-inline Result Client::Get(const std::string &path,
-                          ResponseHandler response_handler,
-                          ContentReceiver content_receiver, Progress progress) {
-  return cli_->Get(path, std::move(response_handler),
-                   std::move(content_receiver), std::move(progress));
-}
-inline Result Client::Get(const std::string &path, const Headers &headers,
-                          ResponseHandler response_handler,
-                          ContentReceiver content_receiver, Progress progress) {
-  return cli_->Get(path, headers, std::move(response_handler),
-                   std::move(content_receiver), std::move(progress));
-}
-inline Result Client::Get(const std::string &path, const Params &params,
-                          const Headers &headers, Progress progress) {
-  return cli_->Get(path, params, headers, progress);
-}
-inline Result Client::Get(const std::string &path, const Params &params,
-                          const Headers &headers,
-                          ContentReceiver content_receiver, Progress progress) {
-  return cli_->Get(path, params, headers, content_receiver, progress);
-}
-inline Result Client::Get(const std::string &path, const Params &params,
-                          const Headers &headers,
-                          ResponseHandler response_handler,
-                          ContentReceiver content_receiver, Progress progress) {
-  return cli_->Get(path, params, headers, response_handler, content_receiver,
-                   progress);
+inline Result Client::Get(const std::string &path, const Params &params, const Headers &headers,
+                          ResponseHandler response_handler, ContentReceiver content_receiver, Progress progress) {
+	return cli_->Get(path, params, headers, response_handler, content_receiver, progress);
 }
 
-inline Result Client::Head(const std::string &path) { return cli_->Head(path); }
+inline Result Client::Head(const std::string &path) {
+	return cli_->Head(path);
+}
 inline Result Client::Head(const std::string &path, const Headers &headers) {
-  return cli_->Head(path, headers);
+	return cli_->Head(path, headers);
 }
 
-inline Result Client::Post(const std::string &path) { return cli_->Post(path); }
+inline Result Client::Post(const std::string &path) {
+	return cli_->Post(path);
+}
 inline Result Client::Post(const std::string &path, const Headers &headers) {
-  return cli_->Post(path, headers);
+	return cli_->Post(path, headers);
 }
-inline Result Client::Post(const std::string &path, const char *body,
-                           size_t content_length,
+inline Result Client::Post(const std::string &path, const char *body, size_t content_length,
                            const std::string &content_type) {
-  return cli_->Post(path, body, content_length, content_type);
+	return cli_->Post(path, body, content_length, content_type);
 }
-inline Result Client::Post(const std::string &path, const Headers &headers,
-                           const char *body, size_t content_length,
+inline Result Client::Post(const std::string &path, const Headers &headers, const char *body, size_t content_length,
                            const std::string &content_type) {
-  return cli_->Post(path, headers, body, content_length, content_type);
+	return cli_->Post(path, headers, body, content_length, content_type);
 }
-inline Result Client::Post(const std::string &path, const std::string &body,
-                           const std::string &content_type) {
-  return cli_->Post(path, body, content_type);
+inline Result Client::Post(const std::string &path, const std::string &body, const std::string &content_type) {
+	return cli_->Post(path, body, content_type);
 }
-inline Result Client::Post(const std::string &path, const Headers &headers,
-                           const std::string &body,
+inline Result Client::Post(const std::string &path, const Headers &headers, const std::string &body,
                            const std::string &content_type) {
-  return cli_->Post(path, headers, body, content_type);
+	return cli_->Post(path, headers, body, content_type);
 }
-inline Result Client::Post(const std::string &path, size_t content_length,
-                           ContentProvider content_provider,
+inline Result Client::Post(const std::string &path, size_t content_length, ContentProvider content_provider,
                            const std::string &content_type) {
-  return cli_->Post(path, content_length, std::move(content_provider),
-                    content_type);
+	return cli_->Post(path, content_length, std::move(content_provider), content_type);
 }
-inline Result Client::Post(const std::string &path,
-                           ContentProviderWithoutLength content_provider,
+inline Result Client::Post(const std::string &path, ContentProviderWithoutLength content_provider,
                            const std::string &content_type) {
-  return cli_->Post(path, std::move(content_provider), content_type);
+	return cli_->Post(path, std::move(content_provider), content_type);
+}
+inline Result Client::Post(const std::string &path, const Headers &headers, size_t content_length,
+                           ContentProvider content_provider, const std::string &content_type) {
+	return cli_->Post(path, headers, content_length, std::move(content_provider), content_type);
 }
 inline Result Client::Post(const std::string &path, const Headers &headers,
-                           size_t content_length,
-                           ContentProvider content_provider,
-                           const std::string &content_type) {
-  return cli_->Post(path, headers, content_length, std::move(content_provider),
-                    content_type);
-}
-inline Result Client::Post(const std::string &path, const Headers &headers,
-                           ContentProviderWithoutLength content_provider,
-                           const std::string &content_type) {
-  return cli_->Post(path, headers, std::move(content_provider), content_type);
+                           ContentProviderWithoutLength content_provider, const std::string &content_type) {
+	return cli_->Post(path, headers, std::move(content_provider), content_type);
 }
 inline Result Client::Post(const std::string &path, const Params &params) {
-  return cli_->Post(path, params);
+	return cli_->Post(path, params);
 }
-inline Result Client::Post(const std::string &path, const Headers &headers,
-                           const Params &params) {
-  return cli_->Post(path, headers, params);
+inline Result Client::Post(const std::string &path, const Headers &headers, const Params &params) {
+	return cli_->Post(path, headers, params);
 }
-inline Result Client::Post(const std::string &path,
-                           const MultipartFormDataItems &items) {
-  return cli_->Post(path, items);
+inline Result Client::Post(const std::string &path, const MultipartFormDataItems &items) {
+	return cli_->Post(path, items);
 }
-inline Result Client::Post(const std::string &path, const Headers &headers,
-                           const MultipartFormDataItems &items) {
-  return cli_->Post(path, headers, items);
+inline Result Client::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items) {
+	return cli_->Post(path, headers, items);
 }
-inline Result Client::Post(const std::string &path, const Headers &headers,
-                           const MultipartFormDataItems &items,
+inline Result Client::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
                            const std::string &boundary) {
-  return cli_->Post(path, headers, items, boundary);
+	return cli_->Post(path, headers, items, boundary);
 }
-inline Result
-Client::Post(const std::string &path, const Headers &headers,
-             const MultipartFormDataItems &items,
-             const MultipartFormDataProviderItems &provider_items) {
-  return cli_->Post(path, headers, items, provider_items);
+inline Result Client::Post(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+                           const MultipartFormDataProviderItems &provider_items) {
+	return cli_->Post(path, headers, items, provider_items);
 }
-inline Result Client::Put(const std::string &path) { return cli_->Put(path); }
-inline Result Client::Put(const std::string &path, const char *body,
-                          size_t content_length,
+inline Result Client::Put(const std::string &path) {
+	return cli_->Put(path);
+}
+inline Result Client::Put(const std::string &path, const char *body, size_t content_length,
                           const std::string &content_type) {
-  return cli_->Put(path, body, content_length, content_type);
+	return cli_->Put(path, body, content_length, content_type);
+}
+inline Result Client::Put(const std::string &path, const Headers &headers, const char *body, size_t content_length,
+                          const std::string &content_type) {
+	return cli_->Put(path, headers, body, content_length, content_type);
+}
+inline Result Client::Put(const std::string &path, const std::string &body, const std::string &content_type) {
+	return cli_->Put(path, body, content_type);
+}
+inline Result Client::Put(const std::string &path, const Headers &headers, const std::string &body,
+                          const std::string &content_type) {
+	return cli_->Put(path, headers, body, content_type);
+}
+inline Result Client::Put(const std::string &path, size_t content_length, ContentProvider content_provider,
+                          const std::string &content_type) {
+	return cli_->Put(path, content_length, std::move(content_provider), content_type);
+}
+inline Result Client::Put(const std::string &path, ContentProviderWithoutLength content_provider,
+                          const std::string &content_type) {
+	return cli_->Put(path, std::move(content_provider), content_type);
+}
+inline Result Client::Put(const std::string &path, const Headers &headers, size_t content_length,
+                          ContentProvider content_provider, const std::string &content_type) {
+	return cli_->Put(path, headers, content_length, std::move(content_provider), content_type);
 }
 inline Result Client::Put(const std::string &path, const Headers &headers,
-                          const char *body, size_t content_length,
-                          const std::string &content_type) {
-  return cli_->Put(path, headers, body, content_length, content_type);
-}
-inline Result Client::Put(const std::string &path, const std::string &body,
-                          const std::string &content_type) {
-  return cli_->Put(path, body, content_type);
-}
-inline Result Client::Put(const std::string &path, const Headers &headers,
-                          const std::string &body,
-                          const std::string &content_type) {
-  return cli_->Put(path, headers, body, content_type);
-}
-inline Result Client::Put(const std::string &path, size_t content_length,
-                          ContentProvider content_provider,
-                          const std::string &content_type) {
-  return cli_->Put(path, content_length, std::move(content_provider),
-                   content_type);
-}
-inline Result Client::Put(const std::string &path,
-                          ContentProviderWithoutLength content_provider,
-                          const std::string &content_type) {
-  return cli_->Put(path, std::move(content_provider), content_type);
-}
-inline Result Client::Put(const std::string &path, const Headers &headers,
-                          size_t content_length,
-                          ContentProvider content_provider,
-                          const std::string &content_type) {
-  return cli_->Put(path, headers, content_length, std::move(content_provider),
-                   content_type);
-}
-inline Result Client::Put(const std::string &path, const Headers &headers,
-                          ContentProviderWithoutLength content_provider,
-                          const std::string &content_type) {
-  return cli_->Put(path, headers, std::move(content_provider), content_type);
+                          ContentProviderWithoutLength content_provider, const std::string &content_type) {
+	return cli_->Put(path, headers, std::move(content_provider), content_type);
 }
 inline Result Client::Put(const std::string &path, const Params &params) {
-  return cli_->Put(path, params);
+	return cli_->Put(path, params);
 }
-inline Result Client::Put(const std::string &path, const Headers &headers,
-                          const Params &params) {
-  return cli_->Put(path, headers, params);
+inline Result Client::Put(const std::string &path, const Headers &headers, const Params &params) {
+	return cli_->Put(path, headers, params);
 }
-inline Result Client::Put(const std::string &path,
-                          const MultipartFormDataItems &items) {
-  return cli_->Put(path, items);
+inline Result Client::Put(const std::string &path, const MultipartFormDataItems &items) {
+	return cli_->Put(path, items);
 }
-inline Result Client::Put(const std::string &path, const Headers &headers,
-                          const MultipartFormDataItems &items) {
-  return cli_->Put(path, headers, items);
+inline Result Client::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items) {
+	return cli_->Put(path, headers, items);
 }
-inline Result Client::Put(const std::string &path, const Headers &headers,
-                          const MultipartFormDataItems &items,
+inline Result Client::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
                           const std::string &boundary) {
-  return cli_->Put(path, headers, items, boundary);
+	return cli_->Put(path, headers, items, boundary);
 }
-inline Result
-Client::Put(const std::string &path, const Headers &headers,
-            const MultipartFormDataItems &items,
-            const MultipartFormDataProviderItems &provider_items) {
-  return cli_->Put(path, headers, items, provider_items);
+inline Result Client::Put(const std::string &path, const Headers &headers, const MultipartFormDataItems &items,
+                          const MultipartFormDataProviderItems &provider_items) {
+	return cli_->Put(path, headers, items, provider_items);
 }
 inline Result Client::Patch(const std::string &path) {
-  return cli_->Patch(path);
+	return cli_->Patch(path);
 }
-inline Result Client::Patch(const std::string &path, const char *body,
-                            size_t content_length,
+inline Result Client::Patch(const std::string &path, const char *body, size_t content_length,
                             const std::string &content_type) {
-  return cli_->Patch(path, body, content_length, content_type);
+	return cli_->Patch(path, body, content_length, content_type);
 }
-inline Result Client::Patch(const std::string &path, const Headers &headers,
-                            const char *body, size_t content_length,
+inline Result Client::Patch(const std::string &path, const Headers &headers, const char *body, size_t content_length,
                             const std::string &content_type) {
-  return cli_->Patch(path, headers, body, content_length, content_type);
+	return cli_->Patch(path, headers, body, content_length, content_type);
 }
-inline Result Client::Patch(const std::string &path, const std::string &body,
-                            const std::string &content_type) {
-  return cli_->Patch(path, body, content_type);
+inline Result Client::Patch(const std::string &path, const std::string &body, const std::string &content_type) {
+	return cli_->Patch(path, body, content_type);
 }
-inline Result Client::Patch(const std::string &path, const Headers &headers,
-                            const std::string &body,
+inline Result Client::Patch(const std::string &path, const Headers &headers, const std::string &body,
                             const std::string &content_type) {
-  return cli_->Patch(path, headers, body, content_type);
+	return cli_->Patch(path, headers, body, content_type);
 }
-inline Result Client::Patch(const std::string &path, size_t content_length,
-                            ContentProvider content_provider,
+inline Result Client::Patch(const std::string &path, size_t content_length, ContentProvider content_provider,
                             const std::string &content_type) {
-  return cli_->Patch(path, content_length, std::move(content_provider),
-                     content_type);
+	return cli_->Patch(path, content_length, std::move(content_provider), content_type);
 }
-inline Result Client::Patch(const std::string &path,
-                            ContentProviderWithoutLength content_provider,
+inline Result Client::Patch(const std::string &path, ContentProviderWithoutLength content_provider,
                             const std::string &content_type) {
-  return cli_->Patch(path, std::move(content_provider), content_type);
+	return cli_->Patch(path, std::move(content_provider), content_type);
+}
+inline Result Client::Patch(const std::string &path, const Headers &headers, size_t content_length,
+                            ContentProvider content_provider, const std::string &content_type) {
+	return cli_->Patch(path, headers, content_length, std::move(content_provider), content_type);
 }
 inline Result Client::Patch(const std::string &path, const Headers &headers,
-                            size_t content_length,
-                            ContentProvider content_provider,
-                            const std::string &content_type) {
-  return cli_->Patch(path, headers, content_length, std::move(content_provider),
-                     content_type);
-}
-inline Result Client::Patch(const std::string &path, const Headers &headers,
-                            ContentProviderWithoutLength content_provider,
-                            const std::string &content_type) {
-  return cli_->Patch(path, headers, std::move(content_provider), content_type);
+                            ContentProviderWithoutLength content_provider, const std::string &content_type) {
+	return cli_->Patch(path, headers, std::move(content_provider), content_type);
 }
 inline Result Client::Delete(const std::string &path) {
-  return cli_->Delete(path);
+	return cli_->Delete(path);
 }
 inline Result Client::Delete(const std::string &path, const Headers &headers) {
-  return cli_->Delete(path, headers);
+	return cli_->Delete(path, headers);
 }
-inline Result Client::Delete(const std::string &path, const char *body,
-                             size_t content_length,
+inline Result Client::Delete(const std::string &path, const char *body, size_t content_length,
                              const std::string &content_type) {
-  return cli_->Delete(path, body, content_length, content_type);
+	return cli_->Delete(path, body, content_length, content_type);
 }
-inline Result Client::Delete(const std::string &path, const Headers &headers,
-                             const char *body, size_t content_length,
+inline Result Client::Delete(const std::string &path, const Headers &headers, const char *body, size_t content_length,
                              const std::string &content_type) {
-  return cli_->Delete(path, headers, body, content_length, content_type);
+	return cli_->Delete(path, headers, body, content_length, content_type);
 }
-inline Result Client::Delete(const std::string &path, const std::string &body,
-                             const std::string &content_type) {
-  return cli_->Delete(path, body, content_type);
+inline Result Client::Delete(const std::string &path, const std::string &body, const std::string &content_type) {
+	return cli_->Delete(path, body, content_type);
 }
-inline Result Client::Delete(const std::string &path, const Headers &headers,
-                             const std::string &body,
+inline Result Client::Delete(const std::string &path, const Headers &headers, const std::string &body,
                              const std::string &content_type) {
-  return cli_->Delete(path, headers, body, content_type);
+	return cli_->Delete(path, headers, body, content_type);
 }
 inline Result Client::Options(const std::string &path) {
-  return cli_->Options(path);
+	return cli_->Options(path);
 }
 inline Result Client::Options(const std::string &path, const Headers &headers) {
-  return cli_->Options(path, headers);
+	return cli_->Options(path, headers);
 }
 
 inline bool Client::send(Request &req, Response &res, Error &error) {
-  return cli_->send(req, res, error);
+	return cli_->send(req, res, error);
 }
 
-inline Result Client::send(const Request &req) { return cli_->send(req); }
+inline Result Client::send(const Request &req) {
+	return cli_->send(req);
+}
 
-inline void Client::stop() { cli_->stop(); }
+inline void Client::stop() {
+	cli_->stop();
+}
 
-inline std::string Client::host() const { return cli_->host(); }
+inline std::string Client::host() const {
+	return cli_->host();
+}
 
-inline int Client::port() const { return cli_->port(); }
+inline int Client::port() const {
+	return cli_->port();
+}
 
-inline size_t Client::is_socket_open() const { return cli_->is_socket_open(); }
+inline size_t Client::is_socket_open() const {
+	return cli_->is_socket_open();
+}
 
-inline socket_t Client::socket() const { return cli_->socket(); }
+inline socket_t Client::socket() const {
+	return cli_->socket();
+}
 
-inline void
-Client::set_hostname_addr_map(std::map<std::string, std::string> addr_map) {
-  cli_->set_hostname_addr_map(std::move(addr_map));
+inline void Client::set_hostname_addr_map(std::map<std::string, std::string> addr_map) {
+	cli_->set_hostname_addr_map(std::move(addr_map));
 }
 
 inline void Client::set_default_headers(Headers headers) {
-  cli_->set_default_headers(std::move(headers));
+	cli_->set_default_headers(std::move(headers));
 }
 
-inline void Client::set_header_writer(
-    std::function<ssize_t(Stream &, Headers &)> const &writer) {
-  cli_->set_header_writer(writer);
+inline void Client::set_header_writer(std::function<ssize_t(Stream &, Headers &)> const &writer) {
+	cli_->set_header_writer(writer);
 }
 
 inline void Client::set_address_family(int family) {
-  cli_->set_address_family(family);
+	cli_->set_address_family(family);
 }
 
-inline void Client::set_tcp_nodelay(bool on) { cli_->set_tcp_nodelay(on); }
+inline void Client::set_tcp_nodelay(bool on) {
+	cli_->set_tcp_nodelay(on);
+}
 
 inline void Client::set_socket_options(SocketOptions socket_options) {
-  cli_->set_socket_options(std::move(socket_options));
+	cli_->set_socket_options(std::move(socket_options));
 }
 
 inline void Client::set_connection_timeout(time_t sec, time_t usec) {
-  cli_->set_connection_timeout(sec, usec);
+	cli_->set_connection_timeout(sec, usec);
 }
 
 inline void Client::set_read_timeout(time_t sec, time_t usec) {
-  cli_->set_read_timeout(sec, usec);
+	cli_->set_read_timeout(sec, usec);
 }
 
 inline void Client::set_write_timeout(time_t sec, time_t usec) {
-  cli_->set_write_timeout(sec, usec);
+	cli_->set_write_timeout(sec, usec);
 }
 
-inline void Client::set_basic_auth(const std::string &username,
-                                   const std::string &password) {
-  cli_->set_basic_auth(username, password);
+inline void Client::set_basic_auth(const std::string &username, const std::string &password) {
+	cli_->set_basic_auth(username, password);
 }
 inline void Client::set_bearer_token_auth(const std::string &token) {
-  cli_->set_bearer_token_auth(token);
+	cli_->set_bearer_token_auth(token);
 }
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline void Client::set_digest_auth(const std::string &username,
-                                    const std::string &password) {
-  cli_->set_digest_auth(username, password);
+inline void Client::set_digest_auth(const std::string &username, const std::string &password) {
+	cli_->set_digest_auth(username, password);
 }
 #endif
 
-inline void Client::set_keep_alive(bool on) { cli_->set_keep_alive(on); }
+inline void Client::set_keep_alive(bool on) {
+	cli_->set_keep_alive(on);
+}
 inline void Client::set_follow_location(bool on) {
-  cli_->set_follow_location(on);
+	cli_->set_follow_location(on);
 }
 
-inline void Client::set_url_encode(bool on) { cli_->set_url_encode(on); }
+inline void Client::set_url_encode(bool on) {
+	cli_->set_url_encode(on);
+}
 
-inline void Client::set_compress(bool on) { cli_->set_compress(on); }
+inline void Client::set_compress(bool on) {
+	cli_->set_compress(on);
+}
 
-inline void Client::set_decompress(bool on) { cli_->set_decompress(on); }
+inline void Client::set_decompress(bool on) {
+	cli_->set_decompress(on);
+}
 
 inline void Client::set_interface(const std::string &intf) {
-  cli_->set_interface(intf);
+	cli_->set_interface(intf);
 }
 
 inline void Client::set_proxy(const std::string &host, int port) {
-  cli_->set_proxy(host, port);
+	cli_->set_proxy(host, port);
 }
-inline void Client::set_proxy_basic_auth(const std::string &username,
-                                         const std::string &password) {
-  cli_->set_proxy_basic_auth(username, password);
+inline void Client::set_proxy_basic_auth(const std::string &username, const std::string &password) {
+	cli_->set_proxy_basic_auth(username, password);
 }
 inline void Client::set_proxy_bearer_token_auth(const std::string &token) {
-  cli_->set_proxy_bearer_token_auth(token);
+	cli_->set_proxy_bearer_token_auth(token);
 }
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline void Client::set_proxy_digest_auth(const std::string &username,
-                                          const std::string &password) {
-  cli_->set_proxy_digest_auth(username, password);
+inline void Client::set_proxy_digest_auth(const std::string &username, const std::string &password) {
+	cli_->set_proxy_digest_auth(username, password);
 }
 #endif
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 inline void Client::enable_server_certificate_verification(bool enabled) {
-  cli_->enable_server_certificate_verification(enabled);
+	cli_->enable_server_certificate_verification(enabled);
 }
 #endif
 
 inline void Client::set_logger(Logger logger) {
-  cli_->set_logger(std::move(logger));
+	cli_->set_logger(std::move(logger));
 }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-inline void Client::set_ca_cert_path(const std::string &ca_cert_file_path,
-                                     const std::string &ca_cert_dir_path) {
-  cli_->set_ca_cert_path(ca_cert_file_path, ca_cert_dir_path);
+inline void Client::set_ca_cert_path(const std::string &ca_cert_file_path, const std::string &ca_cert_dir_path) {
+	cli_->set_ca_cert_path(ca_cert_file_path, ca_cert_dir_path);
 }
 
 inline void Client::set_ca_cert_store(X509_STORE *ca_cert_store) {
-  if (is_ssl_) {
-    static_cast<SSLClient &>(*cli_).set_ca_cert_store(ca_cert_store);
-  } else {
-    cli_->set_ca_cert_store(ca_cert_store);
-  }
+	if (is_ssl_) {
+		static_cast<SSLClient &>(*cli_).set_ca_cert_store(ca_cert_store);
+	} else {
+		cli_->set_ca_cert_store(ca_cert_store);
+	}
 }
 
 inline void Client::load_ca_cert_store(const char *ca_cert, std::size_t size) {
-  set_ca_cert_store(cli_->create_ca_cert_store(ca_cert, size));
+	set_ca_cert_store(cli_->create_ca_cert_store(ca_cert, size));
 }
 
 inline long Client::get_openssl_verify_result() const {
-  if (is_ssl_) {
-    return static_cast<SSLClient &>(*cli_).get_openssl_verify_result();
-  }
-  return -1; // NOTE: -1 doesn't match any of X509_V_ERR_???
+	if (is_ssl_) {
+		return static_cast<SSLClient &>(*cli_).get_openssl_verify_result();
+	}
+	return -1; // NOTE: -1 doesn't match any of X509_V_ERR_???
 }
 
 inline SSL_CTX *Client::ssl_context() const {
-  if (is_ssl_) { return static_cast<SSLClient &>(*cli_).ssl_context(); }
-  return nullptr;
+	if (is_ssl_) {
+		return static_cast<SSLClient &>(*cli_).ssl_context();
+	}
+	return nullptr;
 }
 #endif
 


### PR DESCRIPTION
If no new location was provided, then httplib would return that the request failed. This is not ideal, since requests to s3 will redirect you to the correct region, and pass the correct region in the response headers. Now all response headers are passed to the FileHandle and the FIleHandle (i.e an S3 file handle) can create the correct url. If there is a location response header, httplib handles it as normal.

fixes https://github.com/duckdblabs/duckdb-internal/issues/5905

closing in favor of https://github.com/duckdb/duckdb/pull/19087
