### PR TITLE
Rework Compression Function registration to avoid grabbing locks

### DIFF
--- a/src/include/duckdb/function/compression_function.hpp
+++ b/src/include/duckdb/function/compression_function.hpp
@@ -333,8 +333,31 @@ public:
 
 //! The set of compression functions
 struct CompressionFunctionSet {
+	static constexpr idx_t COMPRESSION_TYPE_COUNT = 15;
+	static constexpr idx_t PHYSICAL_TYPE_COUNT = 19;
+
+public:
+	CompressionFunctionSet();
+
+	vector<reference<CompressionFunction>> GetCompressionFunctions(PhysicalType physical_type);
+	optional_ptr<CompressionFunction> GetCompressionFunction(CompressionType type, PhysicalType physical_type);
+	void SetDisabledCompressionMethods(const vector<CompressionType> &methods);
+	vector<CompressionType> GetDisabledCompressionMethods() const;
+
+private:
 	mutex lock;
-	map<CompressionType, map<PhysicalType, CompressionFunction>> functions;
+	atomic<bool> is_disabled[COMPRESSION_TYPE_COUNT];
+	atomic<bool> is_loaded[PHYSICAL_TYPE_COUNT];
+	vector<vector<CompressionFunction>> functions;
+
+private:
+	void LoadCompressionFunctions(PhysicalType physical_type);
+
+	static void TryLoadCompression(CompressionType type, PhysicalType physical_type,
+	                               vector<CompressionFunction> &result);
+	static idx_t GetCompressionIndex(PhysicalType physical_type);
+	static idx_t GetCompressionIndex(CompressionType type);
+	void ResetDisabledMethods();
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -161,8 +161,6 @@ struct DBConfigOptions {
 	uint64_t zstd_min_string_length = 4096;
 	//! Force a specific compression method to be used when checkpointing (if available)
 	CompressionType force_compression = CompressionType::COMPRESSION_AUTO;
-	//! The set of disabled compression methods (default empty)
-	set<CompressionType> disabled_compression_methods;
 	//! Force a specific bitpacking mode to be used when using the bitpacking compression method
 	BitpackingMode force_bitpacking_mode = BitpackingMode::AUTO;
 	//! Database configuration variables as controlled by SET
@@ -316,6 +314,10 @@ public:
 	//! Returns the compression function matching the compression and physical type.
 	DUCKDB_API optional_ptr<CompressionFunction> GetCompressionFunction(CompressionType type,
 	                                                                    const PhysicalType physical_type);
+	//! Sets the disabled compression methods
+	DUCKDB_API void SetDisabledCompressionMethods(const vector<CompressionType> &disabled_compression_methods);
+	//! Returns a list of disabled compression methods
+	DUCKDB_API vector<CompressionType> GetDisabledCompressionMethods() const;
 
 	//! Returns the encode function matching the encoding name.
 	DUCKDB_API optional_ptr<EncodingFunction> GetEncodeFunction(const string &name) const;

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -494,7 +494,7 @@ Value DefaultSecretStorageSetting::GetSetting(const ClientContext &context) {
 //===----------------------------------------------------------------------===//
 void DisabledCompressionMethodsSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
 	auto list = StringUtil::Split(input.ToString(), ",");
-	set<CompressionType> disabled_compression_methods;
+	vector<CompressionType> disabled_compression_methods;
 	for (auto &entry : list) {
 		auto param = StringUtil::Lower(entry);
 		StringUtil::Trim(param);
@@ -512,19 +512,20 @@ void DisabledCompressionMethodsSetting::SetGlobal(DatabaseInstance *db, DBConfig
 		if (compression_type == CompressionType::COMPRESSION_AUTO) {
 			throw InvalidInputException("Unrecognized compression method \"%s\"", entry);
 		}
-		disabled_compression_methods.insert(compression_type);
+		disabled_compression_methods.push_back(compression_type);
 	}
-	config.options.disabled_compression_methods = std::move(disabled_compression_methods);
+	config.SetDisabledCompressionMethods(disabled_compression_methods);
 }
 
 void DisabledCompressionMethodsSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
-	config.options.disabled_compression_methods = DBConfigOptions().disabled_compression_methods;
+	vector<CompressionType> disabled_compression_methods;
+	config.SetDisabledCompressionMethods(disabled_compression_methods);
 }
 
 Value DisabledCompressionMethodsSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	string result;
-	for (auto &optimizer : config.options.disabled_compression_methods) {
+	for (auto &optimizer : config.GetDisabledCompressionMethods()) {
 		if (!result.empty()) {
 			result += ",";
 		}

--- a/src/storage/compression/empty_validity.cpp
+++ b/src/storage/compression/empty_validity.cpp
@@ -8,8 +8,7 @@ CompressionFunction EmptyValidityCompressionFun::GetFunction(PhysicalType type) 
 }
 
 bool EmptyValidityCompressionFun::TypeIsSupported(const PhysicalType physical_type) {
-	D_ASSERT(physical_type == PhysicalType::BIT);
-	return true;
+	return physical_type == PhysicalType::BIT;
 }
 
 } // namespace duckdb

--- a/src/storage/compression/numeric_constant.cpp
+++ b/src/storage/compression/numeric_constant.cpp
@@ -263,7 +263,7 @@ bool ConstantFun::TypeIsSupported(const PhysicalType physical_type) {
 	case PhysicalType::DOUBLE:
 		return true;
 	default:
-		throw InternalException("Unsupported type for constant function");
+		return false;
 	}
 }
 

--- a/test/sql/storage/compression/fsst/fsst_disable_compression.test
+++ b/test/sql/storage/compression/fsst/fsst_disable_compression.test
@@ -4,6 +4,8 @@
 
 require no_latest_storage
 
+require skip_reload
+
 # load the DB from disk
 load __TEST_DIR__/test_disabled_compression_methods.db readwrite v1.0.0
 


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/19028

Getting eligible compression functions for a given type should not be expensive or run into significant contention. This PR reworks the `CompressionFunctionSet` to no longer grab a bunch of locks in the common case and instead do a single quick atomic check, which should hopefully further remove this unnecessary bottleneck.