### PR TITLE
Disable emitting versioned libraries by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,6 +451,7 @@ option(BUILD_RDTSC "Enable the rdtsc instruction." FALSE)
 option(SMALLER_BINARY "Produce a smaller binary by trimming specialized code paths. This can negatively affect performance." FALSE)
 option(NATIVE_ARCH "Compile targeting the native architecture" FALSE)
 option(OVERRIDE_NEW_DELETE "Override C++ new/delete (only when jemalloc is enabled)" FALSE)
+option(SET_DUCKDB_LIBRARY_VERSION "Whether or not to set the DuckDB Library version and emit versioned shared libraries" FALSE)
 
 if(${BUILD_RDTSC})
   add_compile_definitions(RDTSC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,9 +60,12 @@ endfunction()
 if(AMALGAMATION_BUILD)
 
   add_library(duckdb SHARED "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.cpp")
-  set_target_properties(
-    duckdb PROPERTIES VERSION ${DUCKDB_VERSION_NUMBER}
-                      SOVERSION ${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION})
+  if(SET_DUCKDB_LIBRARY_VERSION)
+    set_target_properties(
+      duckdb
+      PROPERTIES VERSION ${DUCKDB_VERSION_NUMBER}
+                 SOVERSION ${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION})
+  endif()
   target_link_libraries(duckdb ${DUCKDB_SYSTEM_LIBS})
   link_threads(duckdb PUBLIC)
   link_extension_libraries(duckdb PRIVATE)
@@ -113,9 +116,12 @@ else()
       duckdb_zstd)
 
   add_library(duckdb SHARED ${ALL_OBJECT_FILES})
-  set_target_properties(
-    duckdb PROPERTIES VERSION ${DUCKDB_VERSION_NUMBER}
-                      SOVERSION ${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION})
+  if(SET_DUCKDB_LIBRARY_VERSION)
+    set_target_properties(
+      duckdb
+      PROPERTIES VERSION ${DUCKDB_VERSION_NUMBER}
+                 SOVERSION ${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION})
+  endif()
 
   if(WIN32 AND NOT MINGW)
     ensure_variable_is_number(DUCKDB_MAJOR_VERSION RC_MAJOR_VERSION)


### PR DESCRIPTION
Moves the setting from https://github.com/duckdb/duckdb/pull/18305 behind the `SET_DUCKDB_LIBRARY_VERSION` CMake option. Otherwise this causes a bunch of problems for our current distribution (causing us to distribute three library versions, 2 of which are broken). 