### PR TITLE
Re-add aliased settings to duckdb_settings() view, and some fixes for aliased settings

### DIFF
--- a/src/execution/operator/helper/physical_reset.cpp
+++ b/src/execution/operator/helper/physical_reset.cpp
@@ -65,9 +65,9 @@ SourceResultType PhysicalReset::GetData(ExecutionContext &context, DataChunk &ch
 		}
 		if (variable_scope == SetScope::SESSION) {
 			auto &client_config = ClientConfig::GetConfig(context.client);
-			client_config.set_variables.erase(name.ToStdString());
+			client_config.set_variables.erase(option->name);
 		} else {
-			config.ResetGenericOption(name);
+			config.ResetGenericOption(option->name);
 		}
 		return SourceResultType::FINISHED;
 	}

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -304,6 +304,8 @@ private:
 	CreatePreparedStatementInternal(ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
 	                                optional_ptr<case_insensitive_map_t<BoundParameterData>> values);
 
+	SettingLookupResult TryGetCurrentSettingInternal(const string &key, Value &result) const;
+
 private:
 	//! Lock on using the ClientContext in parallel
 	mutex context_lock;

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -88,7 +88,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"memory_limit", {"4.0 GiB"}},
 	    {"storage_compatibility_version", {"v0.10.0"}},
 	    {"ordered_aggregate_threshold", {Value::UBIGINT(idx_t(1) << 12)}},
-	    {"null_order", {"nulls_first"}},
+	    {"null_order", {"NULLS_FIRST"}},
 	    {"debug_verify_vector", {"dictionary_expression"}},
 	    {"perfect_ht_threshold", {0}},
 	    {"pivot_filter_threshold", {999}},

--- a/test/sql/settings/setting_alias.test
+++ b/test/sql/settings/setting_alias.test
@@ -1,0 +1,26 @@
+# name: test/sql/settings/setting_alias.test
+# description: Test behavior of aliased settings
+# group: [settings]
+
+require skip_reload
+
+query II
+SELECT current_setting('null_order'), (SELECT value FROM duckdb_settings() WHERE name='null_order')
+----
+NULLS_LAST	NULLS_LAST
+
+statement ok
+SET null_order='NULLS_FIRST'
+
+query II
+SELECT current_setting('null_order'), (SELECT value FROM duckdb_settings() WHERE name='null_order')
+----
+NULLS_FIRST	NULLS_FIRST
+
+statement ok
+RESET null_order
+
+query II
+SELECT current_setting('null_order'), (SELECT value FROM duckdb_settings() WHERE name='null_order')
+----
+NULLS_LAST	NULLS_LAST


### PR DESCRIPTION
This PR re-adds aliases to the `duckdb_settings` table as duplicate entries for backwards compatibility reasons (which was a change made in https://github.com/duckdb/duckdb/pull/18447).

In addition, we fix an issue with `current_setting('{alias}')` and `reset {alias}` not correctly forwarding to the underlying setting in all cases.