### PR TITLE
Destroy row groups in parallel

### DIFF
--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -258,6 +258,7 @@ public:
 	void VacuumIndexes();
 	void VerifyIndexBuffers();
 	void CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count);
+	void Destroy();
 
 	string GetTableName() const;
 	void SetTableName(string new_name);

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -104,6 +104,7 @@ public:
 	virtual vector<MetadataBlockInfo> GetMetadataInfo() = 0;
 	virtual shared_ptr<TableIOManager> GetTableIOManager(BoundCreateTableInfo *info) = 0;
 	virtual BlockManager &GetBlockManager() = 0;
+	virtual void Destroy();
 
 	void SetStorageVersion(idx_t version) {
 		storage_version = version;
@@ -193,6 +194,7 @@ public:
 	vector<MetadataBlockInfo> GetMetadataInfo() override;
 	shared_ptr<TableIOManager> GetTableIOManager(BoundCreateTableInfo *info) override;
 	BlockManager &GetBlockManager() override;
+	void Destroy() override;
 
 protected:
 	void LoadDatabase(QueryContext context) override;

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -59,6 +59,7 @@ public:
 	//! Get the nth row-group, negative numbers start from the back (so -1 is the last row group, etc)
 	RowGroup *GetRowGroup(int64_t index);
 	void Verify();
+	void Destroy();
 
 	void InitializeScan(CollectionScanState &state, const vector<StorageIndex> &column_ids,
 	                    optional_ptr<TableFilterSet> table_filters);

--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -76,6 +76,9 @@ public:
 		auto l = Lock();
 		return ReferenceSegments(l);
 	}
+	vector<SegmentNode<T>> &ReferenceLoadedSegmentsMutable(SegmentLock &l) {
+		return nodes;
+	}
 	const vector<SegmentNode<T>> &ReferenceLoadedSegments(SegmentLock &l) const {
 		return nodes;
 	}

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1620,6 +1620,10 @@ void DataTable::CommitDropColumn(const idx_t column_index) {
 	row_groups->CommitDropColumn(column_index);
 }
 
+void DataTable::Destroy() {
+	row_groups->Destroy();
+}
+
 idx_t DataTable::ColumnCount() const {
 	return column_definitions.size();
 }

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -13,6 +13,9 @@
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/storage/table/column_data.hpp"
 #include "duckdb/storage/table/in_memory_checkpoint.hpp"
+#include "duckdb/catalog/duck_catalog.hpp"
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "mbedtls_wrapper.hpp"
 
 namespace duckdb {


### PR DESCRIPTION
When shutting down or closing a database, we need to destroy all loaded row groups. For very large databases, we can have many row groups with many column data / column segments loaded. Relying on regular C++ destructors to destroy these results in a single-threaded pass over all this data. On many core machines, this can be significantly sped up by doing this in parallel. 