### PR TITLE
Fix threading issues in metadata manager, and expand concurrent attach / detach fuzz test

### DIFF
--- a/src/include/duckdb/storage/metadata/metadata_manager.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_manager.hpp
@@ -92,17 +92,19 @@ public:
 protected:
 	BlockManager &block_manager;
 	BufferManager &buffer_manager;
+	mutable mutex block_lock;
 	unordered_map<block_id_t, MetadataBlock> blocks;
 	unordered_map<block_id_t, idx_t> modified_blocks;
 
 protected:
-	block_id_t AllocateNewBlock();
-	block_id_t PeekNextBlockId();
-	block_id_t GetNextBlockId();
+	block_id_t AllocateNewBlock(unique_lock<mutex> &block_lock);
+	block_id_t PeekNextBlockId() const;
+	block_id_t GetNextBlockId() const;
 
-	void AddBlock(MetadataBlock new_block, bool if_exists = false);
-	void AddAndRegisterBlock(MetadataBlock block);
-	void ConvertToTransient(MetadataBlock &block);
+	void AddBlock(unique_lock<mutex> &block_lock, MetadataBlock new_block, bool if_exists = false);
+	void AddAndRegisterBlock(unique_lock<mutex> &block_lock, MetadataBlock block);
+	void ConvertToTransient(unique_lock<mutex> &block_lock, MetadataBlock &block);
+	MetadataPointer FromDiskPointerInternal(unique_lock<mutex> &block_lock, MetaBlockPointer pointer);
 };
 
 } // namespace duckdb

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -54,6 +54,8 @@ MetadataManager::~MetadataManager() {
 MetadataHandle MetadataManager::AllocateHandle() {
 	// check if there is any free space left in an existing block
 	// if not allocate a new block
+	MetadataPointer pointer;
+	unique_lock<mutex> guard(block_lock);
 	block_id_t free_block = INVALID_BLOCK;
 	for (auto &kv : blocks) {
 		auto &block = kv.second;
@@ -63,13 +65,16 @@ MetadataHandle MetadataManager::AllocateHandle() {
 			break;
 		}
 	}
+	guard.unlock();
 	if (free_block == INVALID_BLOCK || free_block > PeekNextBlockId()) {
-		free_block = AllocateNewBlock();
+		free_block = AllocateNewBlock(guard);
+	} else {
+		guard.lock();
 	}
+	D_ASSERT(guard.owns_lock());
 	D_ASSERT(free_block != INVALID_BLOCK);
 
 	// select the first free metadata block we can find
-	MetadataPointer pointer;
 	pointer.block_index = UnsafeNumericCast<idx_t>(free_block);
 	auto &block = blocks[free_block];
 	// the block is now dirty
@@ -77,7 +82,7 @@ MetadataHandle MetadataManager::AllocateHandle() {
 	if (block.block->BlockId() < MAXIMUM_BLOCK) {
 		// this block is a disk-backed block, yet we are planning to write to it
 		// we need to convert it into a transient block before we can write to it
-		ConvertToTransient(block);
+		ConvertToTransient(guard, block);
 		D_ASSERT(block.block->BlockId() >= MAXIMUM_BLOCK);
 	}
 	D_ASSERT(!block.free_blocks.empty());
@@ -85,6 +90,7 @@ MetadataHandle MetadataManager::AllocateHandle() {
 	// mark the block as used
 	block.free_blocks.pop_back();
 	D_ASSERT(pointer.index < METADATA_BLOCK_COUNT);
+	guard.unlock();
 	// pin the block
 	return Pin(pointer);
 }
@@ -95,25 +101,34 @@ MetadataHandle MetadataManager::Pin(const MetadataPointer &pointer) {
 
 MetadataHandle MetadataManager::Pin(QueryContext context, const MetadataPointer &pointer) {
 	D_ASSERT(pointer.index < METADATA_BLOCK_COUNT);
-	auto &block = blocks[UnsafeNumericCast<int64_t>(pointer.block_index)];
+	shared_ptr<BlockHandle> block_handle;
+	{
+		lock_guard<mutex> guard(block_lock);
+		auto &block = blocks[UnsafeNumericCast<int64_t>(pointer.block_index)];
 #ifdef DEBUG
-	for (auto &free_block : block.free_blocks) {
-		if (free_block == pointer.index) {
-			throw InternalException("Pinning block %d.%d but it is marked as a free block", block.block_id, free_block);
+		for (auto &free_block : block.free_blocks) {
+			if (free_block == pointer.index) {
+				throw InternalException("Pinning block %d.%d but it is marked as a free block", block.block_id,
+				                        free_block);
+			}
 		}
-	}
 #endif
+		block_handle = block.block;
+	}
 
 	MetadataHandle handle;
 	handle.pointer.block_index = pointer.block_index;
 	handle.pointer.index = pointer.index;
-	handle.handle = buffer_manager.Pin(block.block);
+	handle.handle = buffer_manager.Pin(block_handle);
 	return handle;
 }
 
-void MetadataManager::ConvertToTransient(MetadataBlock &metadata_block) {
+void MetadataManager::ConvertToTransient(unique_lock<mutex> &block_lock, MetadataBlock &metadata_block) {
+	D_ASSERT(block_lock.owns_lock());
+	auto old_block = metadata_block.block;
+	block_lock.unlock();
 	// pin the old block
-	auto old_buffer = buffer_manager.Pin(metadata_block.block);
+	auto old_buffer = buffer_manager.Pin(old_block);
 
 	// allocate a new transient block to replace it
 	auto new_buffer = buffer_manager.Allocate(MemoryTag::METADATA, &block_manager, false);
@@ -121,14 +136,17 @@ void MetadataManager::ConvertToTransient(MetadataBlock &metadata_block) {
 
 	// copy the data to the transient block
 	memcpy(new_buffer.Ptr(), old_buffer.Ptr(), block_manager.GetBlockSize());
-	metadata_block.block = std::move(new_block);
-	metadata_block.dirty = true;
 
 	// unregister the old block
 	block_manager.UnregisterBlock(metadata_block.block_id);
+
+	block_lock.lock();
+	metadata_block.block = std::move(new_block);
+	metadata_block.dirty = true;
 }
 
-block_id_t MetadataManager::AllocateNewBlock() {
+block_id_t MetadataManager::AllocateNewBlock(unique_lock<mutex> &block_lock) {
+	D_ASSERT(!block_lock.owns_lock());
 	auto new_block_id = GetNextBlockId();
 
 	MetadataBlock new_block;
@@ -141,11 +159,14 @@ block_id_t MetadataManager::AllocateNewBlock() {
 	new_block.dirty = true;
 	// zero-initialize the handle
 	memset(handle.Ptr(), 0, block_manager.GetBlockSize());
-	AddBlock(std::move(new_block));
+
+	block_lock.lock();
+	AddBlock(block_lock, std::move(new_block));
 	return new_block_id;
 }
 
-void MetadataManager::AddBlock(MetadataBlock new_block, bool if_exists) {
+void MetadataManager::AddBlock(unique_lock<mutex> &block_lock, MetadataBlock new_block, bool if_exists) {
+	D_ASSERT(block_lock.owns_lock());
 	if (blocks.find(new_block.block_id) != blocks.end()) {
 		if (if_exists) {
 			return;
@@ -155,15 +176,17 @@ void MetadataManager::AddBlock(MetadataBlock new_block, bool if_exists) {
 	blocks[new_block.block_id] = std::move(new_block);
 }
 
-void MetadataManager::AddAndRegisterBlock(MetadataBlock block) {
+void MetadataManager::AddAndRegisterBlock(unique_lock<mutex> &block_lock, MetadataBlock block) {
 	if (block.block) {
 		throw InternalException("Calling AddAndRegisterBlock on block that already exists");
 	}
 	if (block.block_id >= MAXIMUM_BLOCK) {
 		throw InternalException("AddAndRegisterBlock called with a transient block id");
 	}
+	block_lock.unlock();
 	block.block = block_manager.RegisterBlock(block.block_id);
-	AddBlock(std::move(block), true);
+	block_lock.lock();
+	AddBlock(block_lock, std::move(block), true);
 }
 
 MetaBlockPointer MetadataManager::GetDiskPointer(const MetadataPointer &pointer, uint32_t offset) {
@@ -181,8 +204,14 @@ uint32_t MetaBlockPointer::GetBlockIndex() const {
 }
 
 MetadataPointer MetadataManager::FromDiskPointer(MetaBlockPointer pointer) {
+	unique_lock<mutex> guard(block_lock);
+	return FromDiskPointerInternal(guard, pointer);
+}
+
+MetadataPointer MetadataManager::FromDiskPointerInternal(unique_lock<mutex> &block_lock, MetaBlockPointer pointer) {
 	auto block_id = pointer.GetBlockId();
 	auto index = pointer.GetBlockIndex();
+
 	auto entry = blocks.find(block_id);
 	if (entry == blocks.end()) { // LCOV_EXCL_START
 		throw InternalException("Failed to load metadata pointer (id %llu, idx %llu, ptr %llu)\n", block_id, index,
@@ -195,11 +224,13 @@ MetadataPointer MetadataManager::FromDiskPointer(MetaBlockPointer pointer) {
 }
 
 MetadataPointer MetadataManager::RegisterDiskPointer(MetaBlockPointer pointer) {
+	unique_lock<mutex> guard(block_lock);
+
 	auto block_id = pointer.GetBlockId();
 	MetadataBlock block;
 	block.block_id = block_id;
-	AddAndRegisterBlock(std::move(block));
-	return FromDiskPointer(pointer);
+	AddAndRegisterBlock(guard, std::move(block));
+	return FromDiskPointerInternal(guard, pointer);
 }
 
 BlockPointer MetadataManager::ToBlockPointer(MetaBlockPointer meta_pointer, const idx_t metadata_block_size) {
@@ -232,6 +263,7 @@ void MetadataManager::Flush() {
 	// Write the blocks of the metadata manager to disk.
 	const idx_t total_metadata_size = GetMetadataBlockSize() * METADATA_BLOCK_COUNT;
 
+	unique_lock<mutex> guard(block_lock, std::defer_lock);
 	for (auto &kv : blocks) {
 		auto &block = kv.second;
 		if (!block.dirty) {
@@ -245,9 +277,13 @@ void MetadataManager::Flush() {
 		memset(handle.Ptr() + total_metadata_size, 0, block_manager.GetBlockSize() - total_metadata_size);
 		D_ASSERT(kv.first == block.block_id);
 		if (block.block->BlockId() >= MAXIMUM_BLOCK) {
+			auto new_block =
+			    block_manager.ConvertToPersistent(QueryContext(), kv.first, block.block, std::move(handle));
+
 			// Convert the temporary block to a persistent block.
-			block.block =
-			    block_manager.ConvertToPersistent(QueryContext(), kv.first, std::move(block.block), std::move(handle));
+			guard.lock();
+			block.block = std::move(new_block);
+			guard.unlock();
 		} else {
 			// Already a persistent block, so we only need to write it.
 			D_ASSERT(block.block->BlockId() == block.block_id);
@@ -267,12 +303,13 @@ void MetadataManager::Write(WriteStream &sink) {
 
 void MetadataManager::Read(ReadStream &source) {
 	auto block_count = source.Read<uint64_t>();
+	unique_lock<mutex> guard(block_lock);
 	for (idx_t i = 0; i < block_count; i++) {
 		auto block = MetadataBlock::Read(source);
 		auto entry = blocks.find(block.block_id);
 		if (entry == blocks.end()) {
 			// block does not exist yet
-			AddAndRegisterBlock(std::move(block));
+			AddAndRegisterBlock(guard, std::move(block));
 		} else {
 			// block was already created - only copy over the free list
 			entry->second.free_blocks = std::move(block.free_blocks);
@@ -349,6 +386,7 @@ void MetadataManager::MarkBlocksAsModified() {
 	}
 
 	modified_blocks.clear();
+
 	for (auto &kv : blocks) {
 		auto &block = kv.second;
 		idx_t free_list = block.FreeBlocksToInteger();
@@ -361,6 +399,7 @@ void MetadataManager::ClearModifiedBlocks(const vector<MetaBlockPointer> &pointe
 	if (pointers.empty()) {
 		return;
 	}
+	unique_lock<mutex> guard(block_lock);
 	for (auto &pointer : pointers) {
 		auto block_id = pointer.GetBlockId();
 		auto block_index = pointer.GetBlockIndex();
@@ -376,6 +415,7 @@ void MetadataManager::ClearModifiedBlocks(const vector<MetaBlockPointer> &pointe
 
 vector<MetadataBlockInfo> MetadataManager::GetMetadataInfo() const {
 	vector<MetadataBlockInfo> result;
+	unique_lock<mutex> guard(block_lock);
 	for (auto &block : blocks) {
 		MetadataBlockInfo block_info;
 		block_info.block_id = block.second.block_id;
@@ -393,17 +433,18 @@ vector<MetadataBlockInfo> MetadataManager::GetMetadataInfo() const {
 
 vector<shared_ptr<BlockHandle>> MetadataManager::GetBlocks() const {
 	vector<shared_ptr<BlockHandle>> result;
+	unique_lock<mutex> guard(block_lock);
 	for (auto &entry : blocks) {
 		result.push_back(entry.second.block);
 	}
 	return result;
 }
 
-block_id_t MetadataManager::PeekNextBlockId() {
+block_id_t MetadataManager::PeekNextBlockId() const {
 	return block_manager.PeekFreeBlockId();
 }
 
-block_id_t MetadataManager::GetNextBlockId() {
+block_id_t MetadataManager::GetNextBlockId() const {
 	return block_manager.GetFreeBlockId();
 }
 

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -303,9 +303,10 @@ void MetadataManager::Write(WriteStream &sink) {
 
 void MetadataManager::Read(ReadStream &source) {
 	auto block_count = source.Read<uint64_t>();
-	unique_lock<mutex> guard(block_lock);
 	for (idx_t i = 0; i < block_count; i++) {
 		auto block = MetadataBlock::Read(source);
+
+		unique_lock<mutex> guard(block_lock);
 		auto entry = blocks.find(block.block_id);
 		if (entry == blocks.end()) {
 			// block does not exist yet

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -97,7 +97,7 @@ idx_t ArrayColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t c
 
 void ArrayColumnData::Select(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
                              SelectionVector &sel, idx_t sel_count) {
-	bool is_supported = !child_column->type.IsNested();
+	bool is_supported = !child_column->type.IsNested() && child_column->type.InternalType() != PhysicalType::VARCHAR;
 	if (!is_supported) {
 		ColumnData::Select(transaction, vector_index, state, result, sel, sel_count);
 		return;

--- a/test/sql/parallelism/interquery/concurrent_attach_detach.cpp
+++ b/test/sql/parallelism/interquery/concurrent_attach_detach.cpp
@@ -25,8 +25,8 @@ string getDBName(idx_t i) {
 }
 
 const idx_t db_count = 10;
-const idx_t worker_count = 100;
-const idx_t iteration_count = 500;
+const idx_t worker_count = 40;
+const idx_t iteration_count = 100;
 const idx_t nr_initial_rows = 2050;
 
 vector<vector<string>> logging;

--- a/test/sql/parallelism/interquery/concurrent_attach_detach.cpp
+++ b/test/sql/parallelism/interquery/concurrent_attach_detach.cpp
@@ -24,8 +24,8 @@ string getDBName(idx_t i) {
 	return prefix + to_string(i);
 }
 
-const idx_t db_count = 100;
-const idx_t worker_count = 50;
+const idx_t db_count = 10;
+const idx_t worker_count = 100;
 const idx_t iteration_count = 500;
 const idx_t nr_initial_rows = 2050;
 
@@ -309,7 +309,8 @@ void checkpoint_db(Connection &conn, const idx_t db_id, const idx_t worker_id) {
 	unique_lock<mutex> lock(db_infos[db_id].mu);
 	string checkpoint_sql = "CHECKPOINT " + getDBName(db_id);
 	addLog(worker_id, "q: " + checkpoint_sql);
-	execQuery(conn, checkpoint_sql);
+	// checkpoint can fail, we don't care
+	conn.Query(checkpoint_sql);
 }
 
 void workUnit(std::unique_ptr<Connection> conn, const idx_t worker_id) {

--- a/test/sql/parallelism/interquery/concurrent_attach_detach.cpp
+++ b/test/sql/parallelism/interquery/concurrent_attach_detach.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/vector.hpp"
 #include "test_helpers.hpp"
 
+#include <unordered_set>
 #include <thread>
 
 using namespace duckdb;
@@ -23,26 +24,22 @@ string getDBName(idx_t i) {
 	return prefix + to_string(i);
 }
 
-const idx_t db_count = 10;
-const idx_t worker_count = 40;
-const idx_t iteration_count = 100;
+const idx_t db_count = 100;
+const idx_t worker_count = 50;
+const idx_t iteration_count = 500;
 const idx_t nr_initial_rows = 2050;
 
-vector<string> logging;
-mutex log_mutex;
+vector<vector<string>> logging;
 atomic<bool> success {true};
 
-void addLog(const string &msg) {
-	if (success) {
-		lock_guard<mutex> lock(log_mutex);
-		logging.push_back(msg);
-	}
+void addLog(const idx_t worker_id, const string &msg) {
+	logging[worker_id].push_back(msg);
 }
 
 duckdb::unique_ptr<MaterializedQueryResult> execQuery(Connection &conn, const string &query) {
 	auto result = conn.Query(query);
 	if (result->HasError()) {
-		Printer::Print(result->GetError());
+		Printer::PrintF("Failed to execute query %s:\n------\n%s\n-------", query, result->GetError());
 		success = false;
 	}
 	return result;
@@ -72,8 +69,8 @@ public:
 			m[i]++;
 			return;
 		}
-
 		m[i] = 1;
+
 		string query = "ATTACH '" + getDBPath(i) + "'";
 		execQuery(conn, query);
 	}
@@ -100,17 +97,23 @@ void createTbl(Connection &conn, const idx_t db_id, const idx_t worker_id) {
 	db_infos[db_id].tables.emplace_back(TableInfo {nr_initial_rows});
 	db_infos[db_id].table_count++;
 
-	string query = "CREATE TABLE " + getDBName(db_id) + ".tbl_" + to_string(tbl_id) +
-	               " AS SELECT "
-	               "range::UBIGINT AS i, "
-	               "range::VARCHAR AS s, "
-	               // Note: We increment timestamps by 1 millisecond (i.e., 1000 microseconds).
-	               "epoch_ms(range) AS ts, "
-	               "{'key1': range::UBIGINT, 'key2': range::VARCHAR} AS obj "
-	               "FROM range(" +
-	               to_string(nr_initial_rows) + ")";
-	addLog("thread: " + to_string(worker_id) + "; q: " + query);
-	execQuery(conn, query);
+	string tbl_path = StringUtil::Format("%s.tbl_%d", getDBName(db_id), tbl_id);
+	string create_sql = StringUtil::Format(
+	    "CREATE TABLE %s(i BIGINT PRIMARY KEY, s VARCHAR, ts TIMESTAMP, obj STRUCT(key1 UBIGINT, key2 VARCHAR))",
+	    tbl_path);
+	addLog(worker_id, "; q: " + create_sql);
+	execQuery(conn, create_sql);
+	string insert_sql = "INSERT INTO " + tbl_path +
+	                    " SELECT "
+	                    "range::UBIGINT AS i, "
+	                    "range::VARCHAR AS s, "
+	                    // Note: We increment timestamps by 1 millisecond (i.e., 1000 microseconds).
+	                    "epoch_ms(range) AS ts, "
+	                    "{'key1': range::UBIGINT, 'key2': range::VARCHAR} AS obj "
+	                    "FROM range(" +
+	                    to_string(nr_initial_rows) + ")";
+	addLog(worker_id, "; q: " + insert_sql);
+	execQuery(conn, insert_sql);
 }
 
 void lookup(Connection &conn, const idx_t db_id, const idx_t worker_id) {
@@ -129,9 +132,12 @@ void lookup(Connection &conn, const idx_t db_id, const idx_t worker_id) {
 	// Run the query.
 	auto table_name = getDBName(db_id) + ".tbl_" + to_string(tbl_id);
 	string query = "SELECT i, s, ts, obj FROM " + table_name + " WHERE i = " + to_string(expected_max_val);
-	addLog("thread: " + to_string(worker_id) + "; q: " + query);
+	addLog(worker_id, "q: " + query);
 	auto result = execQuery(conn, query);
-
+	if (result->RowCount() == 0) {
+		Printer::PrintF("FAILURE - No rows returned from query");
+		success = false;
+	}
 	if (!CHECK_COLUMN(result, 0, {Value::UBIGINT(expected_max_val)})) {
 		success = false;
 		return;
@@ -152,20 +158,11 @@ void lookup(Connection &conn, const idx_t db_id, const idx_t worker_id) {
 	}
 }
 
-void append(Connection &conn, const idx_t db_id, const idx_t worker_id) {
-	lock_guard<mutex> lock(db_infos[db_id].mu);
-	auto max_tbl_id = db_infos[db_id].table_count;
-	if (max_tbl_id == 0) {
-		return;
-	}
-
-	auto tbl_id = std::rand() % max_tbl_id;
-	auto current_num_rows = db_infos[db_id].tables[tbl_id].size;
-	db_infos[db_id].tables[tbl_id].size += STANDARD_VECTOR_SIZE;
-
-	// set appender
+void append_internal(Connection &conn, const idx_t db_id, const idx_t tbl_id, const idx_t worker_id,
+                     const vector<idx_t> &ids) {
 	auto tbl_str = "tbl_" + to_string(tbl_id);
-	addLog("thread: " + to_string(worker_id) + "; db: " + getDBName(db_id) + "; table: " + tbl_str + "; append rows");
+	// set appender
+	addLog(worker_id, "db: " + getDBName(db_id) + "; table: " + tbl_str + "; append rows");
 
 	try {
 		Appender appender(conn, getDBName(db_id), DEFAULT_SCHEMA, tbl_str);
@@ -197,28 +194,122 @@ void append(Connection &conn, const idx_t db_id, const idx_t worker_id) {
 		auto &entry_varchar = data_struct_entries[1];
 		auto data_struct_varchar = FlatVector::GetData<string_t>(*entry_varchar);
 
-		for (idx_t row_idx = 0; row_idx < STANDARD_VECTOR_SIZE; row_idx++) {
-			data_ubigint[row_idx] = current_num_rows + row_idx;
-			data_varchar[row_idx] = StringVector::AddString(col_varchar, to_string(current_num_rows + row_idx));
-			data_ts[row_idx] = timestamp_t {static_cast<int64_t>(1000 * (current_num_rows + row_idx))};
-			data_struct_ubigint[row_idx] = current_num_rows + row_idx;
-			data_struct_varchar[row_idx] =
-			    StringVector::AddString(*entry_varchar, to_string(current_num_rows + row_idx));
+		for (idx_t i = 0; i < ids.size(); i++) {
+			auto row_idx = ids[i];
+			data_ubigint[i] = row_idx;
+			data_varchar[i] = StringVector::AddString(col_varchar, to_string(row_idx));
+			data_ts[i] = timestamp_t {static_cast<int64_t>(1000 * (row_idx))};
+			data_struct_ubigint[i] = row_idx;
+			data_struct_varchar[i] = StringVector::AddString(*entry_varchar, to_string(row_idx));
 		}
 
-		chunk.SetCardinality(STANDARD_VECTOR_SIZE);
+		chunk.SetCardinality(ids.size());
 		appender.AppendDataChunk(chunk);
 		appender.Close();
 
 	} catch (const std::exception &e) {
-		addLog("Caught exception when using Appender: " + string(e.what()));
+		addLog(worker_id, "Caught exception when using Appender: " + string(e.what()));
 		success = false;
 		return;
 	} catch (...) {
-		addLog("Caught error when using Appender!");
+		addLog(worker_id, "Caught error when using Appender!");
 		success = false;
 		return;
 	}
+}
+
+void append(Connection &conn, const idx_t db_id, const idx_t worker_id) {
+	lock_guard<mutex> lock(db_infos[db_id].mu);
+	auto max_tbl_id = db_infos[db_id].table_count;
+	if (max_tbl_id == 0) {
+		return;
+	}
+
+	auto tbl_id = std::rand() % max_tbl_id;
+	auto current_num_rows = db_infos[db_id].tables[tbl_id].size;
+	idx_t append_count = STANDARD_VECTOR_SIZE;
+
+	vector<idx_t> ids;
+	for (idx_t i = 0; i < append_count; i++) {
+		ids.push_back(current_num_rows + i);
+	}
+
+	append_internal(conn, db_id, tbl_id, worker_id, ids);
+	db_infos[db_id].tables[tbl_id].size += append_count;
+}
+
+void delete_internal(Connection &conn, const idx_t db_id, const idx_t tbl_id, const idx_t worker_id,
+                     const vector<idx_t> &ids) {
+	auto tbl_str = "tbl_" + to_string(tbl_id);
+
+	string delete_list;
+	for (auto delete_idx : ids) {
+		if (!delete_list.empty()) {
+			delete_list += ", ";
+		}
+		delete_list += "(" + to_string(delete_idx) + ")";
+	}
+	string delete_sql =
+	    StringUtil::Format("WITH ids (id) AS (VALUES %s) DELETE FROM %s.%s.%s AS t USING ids WHERE t.i = ids.id",
+	                       delete_list, getDBName(db_id), DEFAULT_SCHEMA, tbl_str);
+	addLog(worker_id, "q: " + delete_sql);
+	execQuery(conn, delete_sql);
+}
+
+void apply_changes(Connection &conn, const idx_t db_id, const idx_t worker_id) {
+	lock_guard<mutex> lock(db_infos[db_id].mu);
+	auto max_tbl_id = db_infos[db_id].table_count;
+	if (max_tbl_id == 0) {
+		return;
+	}
+	// select a random table to delete from
+	auto tbl_id = std::rand() % max_tbl_id;
+	// select some random tuples to apply changes to
+	auto current_num_rows = db_infos[db_id].tables[tbl_id].size;
+	idx_t delete_count = std::rand() % (STANDARD_VECTOR_SIZE / 3);
+	if (delete_count == 0) {
+		delete_count = 1;
+	}
+	unordered_set<idx_t> unique_ids;
+	for (idx_t i = 0; i < delete_count; i++) {
+		unique_ids.insert(std::rand() % current_num_rows);
+	}
+	vector<idx_t> ids;
+	for (auto &id : unique_ids) {
+		ids.push_back(id);
+	}
+	execQuery(conn, "BEGIN");
+	delete_internal(conn, db_id, tbl_id, worker_id, ids);
+	append_internal(conn, db_id, tbl_id, worker_id, ids);
+	execQuery(conn, "COMMIT");
+}
+
+void describe_tbl(Connection &conn, const idx_t db_id, const idx_t worker_id) {
+	unique_lock<mutex> lock(db_infos[db_id].mu);
+	auto max_tbl_id = db_infos[db_id].table_count;
+	if (max_tbl_id == 0) {
+		return;
+	}
+	auto tbl_id = std::rand() % max_tbl_id;
+	auto tbl_str = "tbl_" + to_string(tbl_id);
+	lock.unlock();
+	auto actual_describe = std::rand() % 2 == 0;
+	string describe_sql;
+	if (actual_describe) {
+		describe_sql = StringUtil::Format("DESCRIBE %s.%s.%s", getDBName(db_id), DEFAULT_SCHEMA, tbl_str);
+	} else {
+		describe_sql = StringUtil::Format("SELECT 1 FROM %s.%s.%s LIMIT 1", getDBName(db_id), DEFAULT_SCHEMA, tbl_str);
+	}
+
+	addLog(worker_id, "q: " + describe_sql);
+	execQuery(conn, describe_sql);
+}
+
+void checkpoint_db(Connection &conn, const idx_t db_id, const idx_t worker_id) {
+	unique_lock<mutex> lock(db_infos[db_id].mu);
+	string checkpoint_sql = "CHECKPOINT " + getDBName(db_id);
+	addLog(worker_id, "q: " + checkpoint_sql);
+	execQuery(conn, checkpoint_sql);
 }
 
 void workUnit(std::unique_ptr<Connection> conn, const idx_t worker_id) {
@@ -228,7 +319,7 @@ void workUnit(std::unique_ptr<Connection> conn, const idx_t worker_id) {
 		}
 
 		try {
-			idx_t scenario_id = std::rand() % 3;
+			idx_t scenario_id = std::rand() % 10;
 			idx_t db_id = std::rand() % db_count;
 
 			db_pool.addWorker(*conn, db_id);
@@ -243,19 +334,32 @@ void workUnit(std::unique_ptr<Connection> conn, const idx_t worker_id) {
 			case 2:
 				append(*conn, db_id, worker_id);
 				break;
+			case 3:
+				apply_changes(*conn, db_id, worker_id);
+				break;
+			case 4:
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				describe_tbl(*conn, db_id, worker_id);
+				break;
+			case 9:
+				checkpoint_db(*conn, db_id, worker_id);
+				break;
 			default:
-				addLog("invalid scenario: " + to_string(scenario_id));
+				addLog(worker_id, "invalid scenario: " + to_string(scenario_id));
 				success = false;
 				return;
 			}
 			db_pool.removeWorker(*conn, db_id);
 
 		} catch (const std::exception &e) {
-			addLog("Caught exception when running iterations: " + string(e.what()));
+			addLog(worker_id, "Caught exception when running iterations: " + string(e.what()));
 			success = false;
 			return;
 		} catch (...) {
-			addLog("Caught unknown when using running iterations");
+			addLog(worker_id, "Caught unknown when using running iterations");
 			success = false;
 			return;
 		}
@@ -270,8 +374,11 @@ TEST_CASE("Run a concurrent ATTACH/DETACH scenario", "[interquery][.]") {
 
 	execQuery(init_conn, "SET catalog_error_max_schemas = '0'");
 	execQuery(init_conn, "SET threads = '1'");
-	execQuery(init_conn, "SET storage_compatibility_version = 'v1.3.2'");
+	execQuery(init_conn, "SET storage_compatibility_version = 'latest'");
+	execQuery(init_conn, "CALL enable_logging()");
+	execQuery(init_conn, "PRAGMA enable_profiling='no_output'");
 
+	logging.resize(worker_count);
 	vector<std::thread> workers;
 	for (idx_t i = 0; i < worker_count; i++) {
 		auto conn = make_uniq<Connection>(db);
@@ -282,8 +389,10 @@ TEST_CASE("Run a concurrent ATTACH/DETACH scenario", "[interquery][.]") {
 		worker.join();
 	}
 	if (!success) {
-		for (const auto &msg : logging) {
-			Printer::Print(msg);
+		for (idx_t worker_id = 0; worker_id < logging.size(); worker_id++) {
+			for (auto &log : logging[worker_id]) {
+				Printer::PrintF("thread %d; %s", worker_id, log);
+			}
 		}
 		FAIL();
 	}


### PR DESCRIPTION
This PR fixes a threading issue in the Metadata Manager caused by performing reads while checkpointing. In particular, reads can trigger metadata loads due to lazy metadata reading - which can cause a race with the checkpointing code that writes new metadata to disk. 

In addition, we expand the attach / detach test to do more operations (such as checkpointing and delete + inserts in a single transaction) to help detect more issues.