### PR TITLE
Correctly re-align all child column segments of the ColumnData on Deserialize, and add logging to checkpoints

### DIFF
--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -57,9 +57,7 @@ public:
 
 	QueryLogType() : LogType(NAME, LEVEL) {};
 
-	static string ConstructLogMessage(const string &str) {
-		return str;
-	}
+	static string ConstructLogMessage(const string &str);
 };
 
 class FileSystemLogType : public LogType {

--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -17,6 +17,9 @@ struct FileHandle;
 struct BaseRequest;
 struct HTTPResponse;
 class PhysicalOperator;
+class AttachedDatabase;
+class RowGroup;
+struct DataTableInfo;
 
 //! Log types provide some structure to the formats that the different log messages can have
 //! For now, this holds a type that the VARCHAR value will be auto-cast into.
@@ -103,6 +106,28 @@ public:
 
 	static string ConstructLogMessage(const PhysicalOperator &op, const string &class_p, const string &event,
 	                                  const vector<pair<string, string>> &info);
+};
+
+class CheckpointLogType : public LogType {
+public:
+	static constexpr const char *NAME = "Checkpoint";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_DEBUG;
+
+	//! Construct the log type
+	CheckpointLogType();
+
+	static LogicalType GetLogType();
+
+	//! Vacuum
+	static string ConstructLogMessage(const AttachedDatabase &db, DataTableInfo &table, idx_t segment_idx,
+	                                  idx_t merge_count, idx_t target_count, idx_t merge_rows, idx_t row_start);
+	//! Checkpoint
+	static string ConstructLogMessage(const AttachedDatabase &db, DataTableInfo &table, idx_t segment_idx,
+	                                  RowGroup &row_group);
+
+private:
+	static string CreateLog(const AttachedDatabase &db, DataTableInfo &table, const char *op, vector<Value> map_keys,
+	                        vector<Value> map_values);
 };
 
 } // namespace duckdb

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -16,6 +16,16 @@ constexpr LogLevel HTTPLogType::LEVEL;
 constexpr LogLevel PhysicalOperatorLogType::LEVEL;
 constexpr LogLevel CheckpointLogType::LEVEL;
 
+//===--------------------------------------------------------------------===//
+// QueryLogType
+//===--------------------------------------------------------------------===//
+string QueryLogType::ConstructLogMessage(const string &str) {
+	return str;
+}
+
+//===--------------------------------------------------------------------===//
+// FileSystemLogType
+//===--------------------------------------------------------------------===//
 FileSystemLogType::FileSystemLogType() : LogType(NAME, LEVEL, GetLogType()) {
 }
 

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -376,8 +376,22 @@ void ColumnDataCheckpointer::WritePersistentSegments(ColumnCheckpointState &stat
 	for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
 		auto segment = nodes[segment_idx].node.get();
 		if (segment->start != current_row) {
+			string extra_info;
+			for (auto &s : nodes) {
+				extra_info += "\n";
+				extra_info += StringUtil::Format("Start %d, count %d", s.node->start, s.node->count.load());
+			}
+			const_reference<ColumnData> root = col_data;
+			while (root.get().HasParent()) {
+				root = root.get().Parent();
+			}
 			throw InternalException(
-			    "Failure in RowGroup::Checkpoint - column data pointer is unaligned with row group start");
+			    "Failure in RowGroup::Checkpoint - column data pointer is unaligned with row group "
+			    "start\nRow group start: %d\nRow group count %d\nCurrent row: %d\nSegment start: %d\nColumn index: "
+			    "%d\nColumn type: %s\nRoot type: %s\nTable: %s.%s\nAll segments:%s",
+			    row_group.start, row_group.count.load(), current_row, segment->start, root.get().column_index,
+			    col_data.type, root.get().type, root.get().info.GetSchemaName(), root.get().info.GetTableName(),
+			    extra_info);
 		}
 		current_row += segment->count;
 		auto pointer = segment->GetDataPointer();

--- a/test/sql/storage/checkpoint/concurrent_load_delete.test_slow
+++ b/test/sql/storage/checkpoint/concurrent_load_delete.test_slow
@@ -1,0 +1,51 @@
+# name: test/sql/storage/checkpoint/concurrent_load_delete.test_slow
+# description: Test concurrent delete load workflow
+# group: [checkpoint]
+
+load __TEST_DIR__/concurrent_delete_load.db
+
+statement ok
+create or replace table z(id integer);
+
+statement ok
+insert into z from range(10_000_000);
+
+loop i 0 100
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+SET checkpoint_threshold='1TB'
+
+concurrentloop c 0 7
+
+onlyif c=0
+statement ok
+FORCE CHECKPOINT
+
+onlyif c>0&&c<=5
+statement ok
+SELECT SUM(id) FROM z
+
+onlyif c=5
+statement ok
+DELETE FROM z WHERE id%((random() * 3)::UBIGINT)=0
+
+onlyif c=6
+statement ok
+INSERT INTO z FROM range(1000, 100000 + ${c} * 100000)
+
+endloop
+
+restart
+
+endloop
+
+statement ok
+CHECKPOINT
+
+restart
+
+statement ok
+SELECT SUM(id) FROM z


### PR DESCRIPTION
This PR fixes an issue where column segments would not be re-aligned correctly upon `Deserialize` when the row group itself was re-aligned due to a vacuum operation. This could occur following an optimization done in https://github.com/duckdb/duckdb/pull/18395 that would postpone de-serializing column data in `RowGroup::MoveToCollection`. This could lead to an internal exception happening on checkpoint, which would occur when we would vacuum row groups, followed by loading previously unloaded segments. 

In addition, this PR also adds logging to vacuum/checkpoints. 