### PR TITLE
Revert "set default value of MAIN_BRANCH_VERSIONING to false"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ set(VERSIONING_TAG_MATCH "v*.*.*")
 # - scripts/amalgamation.py
 # - scripts/package_build.py
 ######
-option(MAIN_BRANCH_VERSIONING "Versioning scheme for main branch" FALSE)
+option(MAIN_BRANCH_VERSIONING "Versioning scheme for main branch" TRUE)
 if(${MAIN_BRANCH_VERSIONING})
   set(VERSIONING_TAG_MATCH "v*.*.0")
 endif()

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -278,7 +278,7 @@ def git_commit_hash():
 # - scripts/amalgamation.py
 # - scripts/package_build.py
 ######
-MAIN_BRANCH_VERSIONING = False
+MAIN_BRANCH_VERSIONING = True
 if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
     MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "1":

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -147,7 +147,7 @@ def get_relative_path(source_dir, target_file):
 # - scripts/amalgamation.py
 # - scripts/package_build.py
 ######
-MAIN_BRANCH_VERSIONING = False
+MAIN_BRANCH_VERSIONING = True
 if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
     MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "1":


### PR DESCRIPTION
This reverts commit 862ed3420cafb720fe5193ebcb9a1be7cdadcbed.

This is needed because `MAIN_BRANCH_VERSIONING` should default to True on the main branch.
see: 
https://github.com/duckdb/duckdb/pull/19014
https://github.com/duckdb/duckdb/pull/19048#issuecomment-3307539009