### PR TITLE
[Dev] Bit of code cleanup in (parquet) ColumnWriter

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -187,9 +187,12 @@ void ColumnWriter::HandleRepeatLevels(ColumnWriterState &state, ColumnWriterStat
 		// no repeat levels without a parent node
 		return;
 	}
-	while (state.repetition_levels.size() < parent->repetition_levels.size()) {
-		state.repetition_levels.push_back(parent->repetition_levels[state.repetition_levels.size()]);
+	if (state.repetition_levels.size() >= parent->repetition_levels.size()) {
+		return;
 	}
+	state.repetition_levels.insert(state.repetition_levels.end(),
+	                               parent->repetition_levels.begin() + state.repetition_levels.size(),
+	                               parent->repetition_levels.end());
 }
 
 void ColumnWriter::HandleDefineLevels(ColumnWriterState &state, ColumnWriterState *parent, const ValidityMask &validity,
@@ -200,35 +203,40 @@ void ColumnWriter::HandleDefineLevels(ColumnWriterState &state, ColumnWriterStat
 		while (state.definition_levels.size() < parent->definition_levels.size()) {
 			idx_t current_index = state.definition_levels.size();
 			if (parent->definition_levels[current_index] != PARQUET_DEFINE_VALID) {
+				//! Inherit nulls from parent
 				state.definition_levels.push_back(parent->definition_levels[current_index]);
 				state.parent_null_count++;
 			} else if (validity.RowIsValid(vector_index)) {
+				//! Produce a non-null define
 				state.definition_levels.push_back(define_value);
 			} else {
+				//! Produce a null define
 				if (!can_have_nulls) {
 					throw IOException("Parquet writer: map key column is not allowed to contain NULL values");
 				}
 				state.null_count++;
 				state.definition_levels.push_back(null_value);
 			}
+			D_ASSERT(parent->is_empty.empty() || current_index < parent->is_empty.size());
 			if (parent->is_empty.empty() || !parent->is_empty[current_index]) {
 				vector_index++;
 			}
 		}
+		return;
+	}
+
+	// no parent: set definition levels only from this validity mask
+	if (validity.AllValid()) {
+		state.definition_levels.insert(state.definition_levels.end(), count, define_value);
 	} else {
-		// no parent: set definition levels only from this validity mask
-		if (validity.AllValid()) {
-			state.definition_levels.insert(state.definition_levels.end(), count, define_value);
-		} else {
-			for (idx_t i = 0; i < count; i++) {
-				const auto is_null = !validity.RowIsValid(i);
-				state.definition_levels.emplace_back(is_null ? null_value : define_value);
-				state.null_count += is_null;
-			}
+		for (idx_t i = 0; i < count; i++) {
+			const auto is_null = !validity.RowIsValid(i);
+			state.definition_levels.emplace_back(is_null ? null_value : define_value);
+			state.null_count += is_null;
 		}
-		if (!can_have_nulls && state.null_count != 0) {
-			throw IOException("Parquet writer: map key column is not allowed to contain NULL values");
-		}
+	}
+	if (!can_have_nulls && state.null_count != 0) {
+		throw IOException("Parquet writer: map key column is not allowed to contain NULL values");
 	}
 }
 
@@ -368,6 +376,7 @@ ParquetColumnSchema ColumnWriter::FillParquetSchema(vector<duckdb_parquet::Schem
 		}
 		return map_column;
 	}
+
 	duckdb_parquet::SchemaElement schema_element;
 	schema_element.type = ParquetWriter::DuckDBTypeToParquetType(type);
 	schema_element.repetition_type = null_type;

--- a/extension/parquet/include/column_writer.hpp
+++ b/extension/parquet/include/column_writer.hpp
@@ -27,7 +27,7 @@ public:
 
 	unsafe_vector<uint16_t> definition_levels;
 	unsafe_vector<uint16_t> repetition_levels;
-	vector<bool> is_empty;
+	unsafe_vector<uint8_t> is_empty;
 	idx_t parent_null_count = 0;
 	idx_t null_count = 0;
 

--- a/extension/parquet/include/writer/array_column_writer.hpp
+++ b/extension/parquet/include/writer/array_column_writer.hpp
@@ -25,6 +25,10 @@ public:
 	void Prepare(ColumnWriterState &state, ColumnWriterState *parent, Vector &vector, idx_t count,
 	             bool vector_can_span_multiple_pages) override;
 	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override;
+
+protected:
+	void WriteArrayState(ListColumnWriterState &state, idx_t array_size, uint16_t first_repeat_level,
+	                     idx_t define_value, const bool is_empty = false);
 };
 
 } // namespace duckdb

--- a/extension/parquet/writer/array_column_writer.cpp
+++ b/extension/parquet/writer/array_column_writer.cpp
@@ -9,6 +9,22 @@ void ArrayColumnWriter::Analyze(ColumnWriterState &state_p, ColumnWriterState *p
 	child_writer->Analyze(*state.child_state, &state_p, array_child, array_size * count);
 }
 
+void ArrayColumnWriter::WriteArrayState(ListColumnWriterState &state, idx_t array_size, uint16_t first_repeat_level,
+                                        idx_t define_value, const bool is_empty) {
+	state.definition_levels.push_back(define_value);
+	state.repetition_levels.push_back(first_repeat_level);
+	state.is_empty.push_back(is_empty);
+
+	if (is_empty) {
+		return;
+	}
+	for (idx_t k = 1; k < array_size; k++) {
+		state.repetition_levels.push_back(MaxRepeat() + 1);
+		state.definition_levels.push_back(define_value);
+		state.is_empty.push_back(false);
+	}
+}
+
 void ArrayColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *parent, Vector &vector, idx_t count,
                                 bool vector_can_span_multiple_pages) {
 	auto &state = state_p.Cast<ListColumnWriterState>();
@@ -25,42 +41,20 @@ void ArrayColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *p
 	for (idx_t i = start; i < vcount; i++) {
 		idx_t parent_index = state.parent_index + i;
 		if (parent && !parent->is_empty.empty() && parent->is_empty[parent_index]) {
-			state.definition_levels.push_back(parent->definition_levels[parent_index]);
-			state.repetition_levels.push_back(parent->repetition_levels[parent_index]);
-			state.is_empty.push_back(true);
+			WriteArrayState(state, array_size, parent->repetition_levels[parent_index],
+			                parent->definition_levels[parent_index], true);
 			continue;
 		}
 		auto first_repeat_level =
 		    parent && !parent->repetition_levels.empty() ? parent->repetition_levels[parent_index] : MaxRepeat();
 		if (parent && parent->definition_levels[parent_index] != PARQUET_DEFINE_VALID) {
-			state.definition_levels.push_back(parent->definition_levels[parent_index]);
-			state.repetition_levels.push_back(first_repeat_level);
-			state.is_empty.push_back(false);
-			for (idx_t k = 1; k < array_size; k++) {
-				state.repetition_levels.push_back(MaxRepeat() + 1);
-				state.definition_levels.push_back(parent->definition_levels[parent_index]);
-				state.is_empty.push_back(false);
-			}
+			WriteArrayState(state, array_size, first_repeat_level, parent->definition_levels[parent_index]);
 		} else if (validity.RowIsValid(vector_index)) {
 			// push the repetition levels
-			state.definition_levels.push_back(PARQUET_DEFINE_VALID);
-			state.is_empty.push_back(false);
-
-			state.repetition_levels.push_back(first_repeat_level);
-			for (idx_t k = 1; k < array_size; k++) {
-				state.repetition_levels.push_back(MaxRepeat() + 1);
-				state.definition_levels.push_back(PARQUET_DEFINE_VALID);
-				state.is_empty.push_back(false);
-			}
+			WriteArrayState(state, array_size, first_repeat_level, PARQUET_DEFINE_VALID);
 		} else {
-			state.definition_levels.push_back(MaxDefine() - 1);
-			state.repetition_levels.push_back(first_repeat_level);
-			state.is_empty.push_back(false);
-			for (idx_t k = 1; k < array_size; k++) {
-				state.repetition_levels.push_back(MaxRepeat() + 1);
-				state.definition_levels.push_back(MaxDefine() - 1);
-				state.is_empty.push_back(false);
-			}
+			//! Produce a null
+			WriteArrayState(state, array_size, first_repeat_level, MaxDefine() - 1);
 		}
 		vector_index++;
 	}

--- a/extension/parquet/writer/struct_column_writer.cpp
+++ b/extension/parquet/writer/struct_column_writer.cpp
@@ -62,8 +62,9 @@ void StructColumnWriter::Prepare(ColumnWriterState &state_p, ColumnWriterState *
 	auto &validity = FlatVector::Validity(vector);
 	if (parent) {
 		// propagate empty entries from the parent
-		while (state.is_empty.size() < parent->is_empty.size()) {
-			state.is_empty.push_back(parent->is_empty[state.is_empty.size()]);
+		if (state.is_empty.size() < parent->is_empty.size()) {
+			state.is_empty.insert(state.is_empty.end(), parent->is_empty.begin() + state.is_empty.size(),
+			                      parent->is_empty.end());
 		}
 	}
 	HandleRepeatLevels(state_p, parent, count, MaxRepeat());


### PR DESCRIPTION
While going through the code I noticed the use of `std::vector<bool>`, this is a space-efficient specialization of `std::vector`, but it's not exactly cpu efficient.

Other than that, minor clean up.