### PR TITLE
restore 1.3.2 behavior for json_type(JSON[])

### DIFF
--- a/test/sql/function/json/json_type_list_compat.test
+++ b/test/sql/function/json/json_type_list_compat.test
@@ -1,0 +1,44 @@
+# name: test/sql/function/json/json_type_list_compat.test
+# description: Test json_type function with LIST(JSON) input
+# group: [json]
+
+require json
+
+query T
+SELECT json_type(json_extract('{"duck":[1,2,3]}', '$..duck'));
+----
+ARRAY
+
+query T
+SELECT json_type(json_extract('{"duck":[1,2,3]}', '$.duck[*]'));
+----
+ARRAY
+
+query T
+SELECT json_type(json_extract('{"a":{"duck":[1]},"b":{"duck":[2,3]}}', '$..duck'));
+----
+ARRAY
+
+query T
+SELECT json_type(json_extract(doc, '$..duck')) FROM (VALUES
+('{"duck":[1,2,3]}'),
+('{"nested":{"duck":[4]}}')
+) t(doc);
+----
+ARRAY
+ARRAY
+
+query T
+SELECT json_type(CAST(json_extract('{"duck":[1,2,3]}', '$..duck') AS VARCHAR));
+----
+ARRAY
+
+query T
+SELECT json_type(json_extract('{"duck":42}', '$.duck'));
+----
+UBIGINT
+
+query T
+SELECT json_type(json_extract('{"duck":true}', '$.duck'));
+----
+BOOLEAN

--- a/test/sql/json/scalar/test_json_type.test
+++ b/test/sql/json/scalar/test_json_type.test
@@ -218,3 +218,19 @@ query T
 SELECT json_type('{"a":[2,3.5,true,false,null,"x"]}','$.a[6]');
 ----
 NULL
+
+# test LIST(JSON) compatibility
+query T
+select json_type(json_extract('{"duck":[1,2,3]}', '$..duck'))
+----
+ARRAY
+
+query T
+select json_type(json_extract('{"a":{"duck":[1]},"b":{"duck":[2,3]}}', '$..duck'))
+----
+ARRAY
+
+query T
+select json_type(json_extract('{"duck":[1,2,3]}', '$.duck[*]'))
+----
+ARRAY


### PR DESCRIPTION
Added `json_type(LIST(JSON)) -> VARCHAR` overload returning scalar `"ARRAY"` to restore 1.3.2 compatibility.

### Testing
* Local CLI (in-memory):
  * `SELECT json_type(json_extract('{"duck":[1,2,3]}', '$..duck'));` → `ARRAY`
  * `SELECT json_type(json_extract('{"duck":[1,2,3]}', '$.duck[*]'));` → `ARRAY`
  * `SELECT json_type(json_extract('{"goose":1}', '$..duck'));` → `NULL`
* Unit tests: new sqllogictests pass alongside existing JSON tests.

fix #19068