### PR TITLE
Add 'maximum_json_object_size' global setting

### DIFF
--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -1,6 +1,7 @@
 #include "json_multi_file_info.hpp"
 #include "json_scan.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/main/config.hpp"
 
 namespace duckdb {
 
@@ -12,6 +13,11 @@ unique_ptr<BaseFileReaderOptions> JSONMultiFileInfo::InitializeOptions(ClientCon
                                                                        optional_ptr<TableFunctionInfo> info) {
 	auto reader_options = make_uniq<JSONFileReaderOptions>();
 	auto &options = reader_options->options;
+
+	// Set maximum_object_size from global config
+	auto &config = DBConfig::GetConfig(context);
+	options.maximum_object_size = config.options.maximum_json_object_size;
+
 	if (info) {
 		auto &scan_info = info->Cast<JSONScanInfo>();
 		options.type = scan_info.type;

--- a/extension/json/json_reader.cpp
+++ b/extension/json/json_reader.cpp
@@ -717,7 +717,8 @@ void JSONReader::AutoDetect(Allocator &allocator, idx_t buffer_capacity) {
 void JSONReader::ThrowObjectSizeError(const idx_t object_size) {
 	throw InvalidInputException(
 	    "\"maximum_object_size\" of %llu bytes exceeded while reading file \"%s\" (>%llu bytes)."
-	    "\n Try increasing \"maximum_object_size\".",
+	    "\n Try increasing \"maximum_object_size\" for read_json()."
+		"\n Or increase it globally with \"SET maximum_json_object_size = '64mb';\"",
 	    options.maximum_object_size, GetFileName(), object_size);
 }
 

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -118,6 +118,8 @@ struct DBConfigOptions {
 	idx_t maximum_memory = DConstants::INVALID_INDEX;
 	//! The maximum size of the 'temp_directory' folder when set (in bytes). Default: 90% of available disk space.
 	idx_t maximum_swap_space = DConstants::INVALID_INDEX;
+	//! The maximum JSON object size (in bytes). Default: 16MB.
+	idx_t maximum_json_object_size = 16777216;
 	//! The maximum amount of CPU threads used by the database system. Default: all available.
 	idx_t maximum_threads = DConstants::INVALID_INDEX;
 	//! The number of external threads that work on DuckDB tasks. Default: 1.

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -908,6 +908,16 @@ struct MaxMemorySetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct MaxJSONObjectSizeSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "maximum_json_object_size";
+	static constexpr const char *Description = "The maximum JSON object size (e.g. 16MB)";
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct MaxTempDirectorySizeSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "max_temp_directory_size";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -141,6 +141,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(LoggingStorage),
     DUCKDB_LOCAL(MaxExpressionDepthSetting),
     DUCKDB_GLOBAL(MaxMemorySetting),
+    DUCKDB_GLOBAL(MaxJSONObjectSizeSetting),
     DUCKDB_GLOBAL(MaxTempDirectorySizeSetting),
     DUCKDB_SETTING(MaxVacuumTasksSetting),
     DUCKDB_SETTING(MergeJoinThresholdSetting),

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1117,6 +1117,20 @@ Value MaxMemorySetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
+// MaxJSONObjectSizeSetting
+//===----------------------------------------------------------------------===//
+void MaxJSONObjectSizeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.options.maximum_json_object_size = DBConfig::ParseMemoryLimit(input.ToString());
+}
+void MaxJSONObjectSizeSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.maximum_json_object_size = 16777216; // 16MB default
+}
+Value MaxJSONObjectSizeSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value(StringUtil::BytesToHumanReadableString(config.options.maximum_json_object_size));
+}
+
+//===----------------------------------------------------------------------===//
 // Max Temp Directory Size
 //===----------------------------------------------------------------------===//
 void MaxTempDirectorySizeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {


### PR DESCRIPTION
Hey!

I would want to read large JSON objects from dynamic location using `CREATE MACRO` and the `query_table` function like this:
```sql
INSTALL zipfs FROM community;
LOAD zipfs;
CREATE OR REPLACE MACRO read_data(zip_file) AS TABLE
    FROM query_table('zip://' || zip_file || '/data*.json');
SELECT * FROM read_data('data.zip');
```

My problem is just that the query_table doesn't allow overriding the `maximum_object_size` for `read_json()` function.

I added a new global flag to be able to override it and after this I can run the above commands for even large json files by first using:
```sql
SET maximum_json_object_size = '64mb';
```

This is my first time contributing and I'm sorry if I were not able to follow all conventions. I did try building the changed duckdb with the json extension:
```
$ BUILD_JSON=1 make
$ ./build/release/duckdb
```

Then with this newly built duckdb I tried to use the new flag:
 ```sql
SELECT COUNT(*) FROM '/Volumes/JetDrive/my-data/data*.json';
Invalid Input Error:
"maximum_object_size" of 16777216 bytes exceeded while reading file "/Volumes/JetDrive/my-data/data20.json" (>21813847 bytes).
 Try increasing "maximum_object_size".
-- Tried again by increasing the object size and it worked just fine:
SET maximum_json_object_size = '64mb';
SELECT COUNT(*) FROM '/Volumes/JetDrive/my-data/data*.json'
```