### PR TITLE
Pushdown filter when doing cross or lateral join with unnest

### DIFF
--- a/benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark
+++ b/benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark
@@ -1,0 +1,14 @@
+# name: benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark
+# description: Benchmark filter pushdown with unnest
+# group: [optimizer]
+
+name Unnest Filter Pushdown
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE test_table as
+SELECT s.i as id,  [1, 2, 3]::bigint[] AS VALUES FROM generate_series(1, 10000000) AS s(i);
+
+run
+SELECT id, value FROM test_table CROSS JOIN UNNEST(values) AS values(value) WHERE id = 87100;

--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/optimizer/filter_pushdown.hpp"
 #include "duckdb/optimizer/filter_combiner.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
-#include "duckdb/optimizer/unnest_rewriter.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
@@ -9,7 +8,6 @@
 #include "duckdb/planner/operator/logical_join.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_window.hpp"
-#include "fmt/printf.h"
 
 namespace duckdb {
 

--- a/test/optimizer/pushdown/issue_18653.test
+++ b/test/optimizer/pushdown/issue_18653.test
@@ -1,0 +1,59 @@
+# name: test/optimizer/pushdown/issue_18653.test
+# description: Performance issue with CROSS JOIN and LATERAL JOIN combined with unnest and json_each. Filter should be pushed down to reduce the joined rows
+# group: [pushdown]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table test_table as
+select s.i as id,  [1, 2, 3]::bigint[] as values from generate_series(1, 1000000) as s(i);
+
+statement ok
+create index test_table_id_idx on test_table(id);
+
+query II
+explain analyze
+select id, value
+from test_table
+cross join unnest(values) as values(value) where id = 87100;
+----
+analyzed_plan	<REGEX>:.*LEFT_DELIM_JOIN.*FILTER.*
+
+query II
+select id, value
+from test_table
+cross join unnest(values) as values(value) where id = 87100;
+----
+87100	3
+87100	2
+87100	1
+
+query II
+explain analyze
+select id, value
+from test_table t
+left join lateral unnest(t.values) as value on true
+where id = 87100;
+----
+analyzed_plan	<REGEX>:.*LEFT_DELIM_JOIN.*FILTER.*
+
+require json
+
+statement ok
+create table test_table2 as
+select s.i as id, '{"key1": 1, "key2": 2, "key3": 3}'::JSON as values
+from generate_series(1, 1000000) as s(i);
+
+statement ok
+create index test_table2_id_idx on test_table2(id);
+
+query II
+explain analyze
+select t.id, key, value
+from test_table2 t
+cross join json_each(t.values) as kv(key, value)
+where t.id = 87100;
+----
+analyzed_plan	<REGEX>:.*LEFT_DELIM_JOIN.*Filters:.*id=87100.*
+


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb/issues/18653
fixes https://github.com/duckdblabs/duckdb-internal/issues/5634

This PR fixes the issue where filters were not pushed down when doing cross or lateral join with unnest.  When the optimizer is ```LogicalOperatorType::LOGICAL_DELIM_JOIN``` we push down the filter if ALL bindings are present in the child.

Some benchmark numbers for reference.

Before:

```
./build/release/benchmark/benchmark_runner benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark
name	run	timing
benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark	1	3.851295
benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark	2	3.835077
benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark	3	3.906475
benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark	4	3.923379
benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark	5	3.854740
```


After:

```
./build/release/benchmark/benchmark_runner benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark 
name	run	timing
benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark	1	0.037180
benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark	2	0.036140
benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark	3	0.034952
benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark	4	0.036367
benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark	5	0.034717
```