### PR TITLE
[C-API] Initial support for accessing file system

### DIFF
--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -81,6 +81,7 @@ ORIGINAL_FUNCTION_GROUP_ORDER = [
     'streaming_result_interface',
     'cast_functions',
     'expression_interface',
+    'file_system_interface',
 ]
 
 # The file that forms the base for the header generation

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -5278,7 +5278,7 @@ Reads data from the file into the buffer.
 * @param file The file instance to read from.
 * @param buffer The buffer to read data into.
 * @param size The number of bytes to read.
-* @return The number of bytes actually read, or -1 on error.
+* @return The number of bytes actually read, or negative on error.
 */
 DUCKDB_C_API int64_t duckdb_file_handle_read(duckdb_file_handle file, void *buffer, int64_t size);
 
@@ -5288,7 +5288,7 @@ Writes data from the buffer to the file.
 * @param file The file instance to write to.
 * @param buffer The buffer containing data to write.
 * @param size The number of bytes to write.
-* @return The number of bytes actually written, or -1 on error.
+* @return The number of bytes actually written, or negative on error.
 */
 DUCKDB_C_API int64_t duckdb_file_handle_write(duckdb_file_handle file, const void *buffer, int64_t size);
 
@@ -5296,7 +5296,7 @@ DUCKDB_C_API int64_t duckdb_file_handle_write(duckdb_file_handle file, const voi
 Tells the current position in the file.
 
 * @param file The file instance to tell the position of.
-* @return The current position in the file, or -1 on error.
+* @return The current position in the file, or negative on error.
 */
 DUCKDB_C_API int64_t duckdb_file_handle_tell(duckdb_file_handle file);
 
@@ -5304,7 +5304,7 @@ DUCKDB_C_API int64_t duckdb_file_handle_tell(duckdb_file_handle file);
 Gets the size of the file.
 
 * @param file The file instance to get the size of.
-* @return The size of the file in bytes, or -1 on error.
+* @return The size of the file in bytes, or negative on error.
 */
 DUCKDB_C_API int64_t duckdb_file_handle_size(duckdb_file_handle file);
 

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -5204,6 +5204,15 @@ Creates a new file system instance associated with the given connection.
 DUCKDB_C_API void duckdb_connection_get_file_system(duckdb_connection connection, duckdb_file_system *out_file_system);
 
 /*!
+Creates a new file system instance associated with the given client context.
+
+* @param context The client context.
+* @param out_file_system The resulting file system instance. or NULL if not available.
+*/
+DUCKDB_C_API void duckdb_client_context_get_file_system(duckdb_client_context context,
+                                                        duckdb_file_system *out_file_system);
+
+/*!
 Destroys the given file system instance.
 * @param file_system The file system instance to destroy.
 */

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -5196,25 +5196,13 @@ DUCKDB_C_API duckdb_error_data duckdb_expression_fold(duckdb_client_context cont
 //===--------------------------------------------------------------------===//
 
 /*!
-Get a file system instance associated with the given connection.
-Must be destroyed with `duckdb_destroy_file_system`
-
-* @param connection The database connection.
-* @param out_file_system The resulting file system instance, or `nullptr` if not available. Must be destroyed with
-`duckdb_destroy_file_system`.
-*/
-DUCKDB_C_API void duckdb_connection_get_file_system(duckdb_connection connection, duckdb_file_system *out_file_system);
-
-/*!
 Get a file system instance associated with the given client context.
 Must be destroyed with `duckdb_destroy_file_system`
 
 * @param context The client context.
-* @param out_file_system The resulting file system instance, or `nullptr` if not available. Must be destroyed with
-`duckdb_destroy_file_system`.
+* @return The resulting file system instance. Must be destroyed with `duckdb_destroy_file_system`.
 */
-DUCKDB_C_API void duckdb_client_context_get_file_system(duckdb_client_context context,
-                                                        duckdb_file_system *out_file_system);
+DUCKDB_C_API duckdb_file_system duckdb_client_context_get_file_system(duckdb_client_context context);
 
 /*!
 Destroys the given file system instance.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -243,15 +243,15 @@ typedef enum duckdb_cast_mode { DUCKDB_CAST_NORMAL = 0, DUCKDB_CAST_TRY = 1 } du
 
 typedef enum duckdb_file_flag {
 	DUCKDB_FILE_FLAG_INVALID = 0,
-	// Open a file for reading only.
+	// Open the file with "read" capabilities.
 	DUCKDB_FILE_FLAG_READ = 1,
-	// Open a file for writing only.
+	// Open the file with "write" capabilities.
 	DUCKDB_FILE_FLAG_WRITE = 2,
-	// Create or open the file if it already exists.
+	// Create a new file, or open if it already exists.
 	DUCKDB_FILE_FLAG_CREATE = 3,
-	// Create a new file, fail if it already exists.
+	// Create a new file, or fail if it already exists.
 	DUCKDB_FILE_FLAG_CREATE_NEW = 4,
-	// Open the file in append mode.
+	// Open the file in "append" mode.
 	DUCKDB_FILE_FLAG_APPEND = 5,
 } duckdb_file_flag;
 
@@ -5197,7 +5197,6 @@ DUCKDB_C_API duckdb_error_data duckdb_expression_fold(duckdb_client_context cont
 
 /*!
 Get a file system instance associated with the given client context.
-Must be destroyed with `duckdb_destroy_file_system`
 
 * @param context The client context.
 * @return The resulting file system instance. Must be destroyed with `duckdb_destroy_file_system`.
@@ -5212,7 +5211,6 @@ DUCKDB_C_API void duckdb_destroy_file_system(duckdb_file_system *file_system);
 
 /*!
 Retrieves the last error that occurred on the given file system instance.
-Must be destroyed with duckdb_destroy_error_data.
 
 * @param file_system The file system instance.
 * @return The error data.
@@ -5220,7 +5218,7 @@ Must be destroyed with duckdb_destroy_error_data.
 DUCKDB_C_API duckdb_error_data duckdb_file_system_error_data(duckdb_file_system file_system);
 
 /*!
-Opens a file at the given path with the specified flags.
+Opens a file at the given path with the specified options.
 
 * @param file_system The file system instance.
 * @param path The path to the file.
@@ -5235,9 +5233,8 @@ DUCKDB_C_API duckdb_state duckdb_file_system_open(duckdb_file_system file_system
 
 /*!
 Creates a new file open options instance with blank settings.
-Must be destroyed with `duckdb_destroy_file_open_options`.
 
-* @return The new file open options instance.
+* @return The new file open options instance. Must be destroyed with `duckdb_destroy_file_open_options`.
 */
 DUCKDB_C_API duckdb_file_open_options duckdb_create_file_open_options();
 
@@ -5269,10 +5266,9 @@ DUCKDB_C_API void duckdb_destroy_file_handle(duckdb_file_handle *file_handle);
 
 /*!
 Retrieves the last error that occurred on the given file handle.
-Must be destroyed with duckdb_destroy_error_data.
 
 * @param file_handle The file handle.
-* @return The error data.
+* @return The error data. Must be destroyed with `duckdb_destroy_error_data`
 */
 DUCKDB_C_API duckdb_error_data duckdb_file_handle_error_data(duckdb_file_handle file_handle);
 
@@ -5316,7 +5312,7 @@ DUCKDB_C_API int64_t duckdb_file_handle_size(duckdb_file_handle file_handle);
 Seeks to a specific position in the file.
 
 * @param file_handle The file handle to seek in.
-* @return Whether the seek was successful. If not, the error data can be retrieved using
+* @return `DuckDBSuccess` on success or `DuckDBError` on failure. If unsuccessful, the error data can be retrieved using
 `duckdb_file_handle_error_data`.
 */
 DUCKDB_C_API duckdb_state duckdb_file_handle_seek(duckdb_file_handle file_handle, int64_t position);
@@ -5325,7 +5321,8 @@ DUCKDB_C_API duckdb_state duckdb_file_handle_seek(duckdb_file_handle file_handle
 Synchronizes the file's state with the underlying storage.
 
 * @param file_handle The file handle to synchronize.
-* @return `DuckDBSuccess` on success or `DuckDBError` on failure.
+* @return `DuckDBSuccess` on success or `DuckDBError` on failure. If unsuccessful, the error data can be retrieved using
+`duckdb_file_handle_error_data`.
 */
 DUCKDB_C_API duckdb_state duckdb_file_handle_sync(duckdb_file_handle file_handle);
 
@@ -5333,7 +5330,8 @@ DUCKDB_C_API duckdb_state duckdb_file_handle_sync(duckdb_file_handle file_handle
 Closes the given file handle.
 
 * @param file_handle The file handle to close.
-* @return `DuckDBSuccess` on success or `DuckDBError` on failure.
+* @return `DuckDBSuccess` on success or `DuckDBError` on failure. If unsuccessful, the error data can be retrieved using
+`duckdb_file_handle_error_data`.
 */
 DUCKDB_C_API duckdb_state duckdb_file_handle_close(duckdb_file_handle file_handle);
 

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -503,8 +503,7 @@ typedef struct {
 	                                            duckdb_value *out_value);
 	// API to manage file system operations
 
-	void (*duckdb_connection_get_file_system)(duckdb_connection connection, duckdb_file_system *out_file_system);
-	void (*duckdb_client_context_get_file_system)(duckdb_client_context context, duckdb_file_system *out_file_system);
+	duckdb_file_system (*duckdb_client_context_get_file_system)(duckdb_client_context context);
 	void (*duckdb_destroy_file_system)(duckdb_file_system *file_system);
 	duckdb_state (*duckdb_file_system_open)(duckdb_file_system file_system, const char *path,
 	                                        duckdb_file_open_options options, duckdb_file_handle *out_file);
@@ -1008,7 +1007,6 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_expression_return_type = duckdb_expression_return_type;
 	result.duckdb_expression_is_foldable = duckdb_expression_is_foldable;
 	result.duckdb_expression_fold = duckdb_expression_fold;
-	result.duckdb_connection_get_file_system = duckdb_connection_get_file_system;
 	result.duckdb_client_context_get_file_system = duckdb_client_context_get_file_system;
 	result.duckdb_destroy_file_system = duckdb_destroy_file_system;
 	result.duckdb_file_system_open = duckdb_file_system_open;

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -513,15 +513,15 @@ typedef struct {
 	duckdb_state (*duckdb_file_open_options_set_flag)(duckdb_file_open_options options, duckdb_file_flag flag,
 	                                                  bool value);
 	void (*duckdb_destroy_file_open_options)(duckdb_file_open_options *options);
-	void (*duckdb_destroy_file_handle)(duckdb_file_handle *file);
-	duckdb_error_data (*duckdb_file_handle_error_data)(duckdb_file_handle file);
-	duckdb_state (*duckdb_file_handle_close)(duckdb_file_handle file);
-	int64_t (*duckdb_file_handle_read)(duckdb_file_handle file, void *buffer, int64_t size);
-	int64_t (*duckdb_file_handle_write)(duckdb_file_handle file, const void *buffer, int64_t size);
-	duckdb_state (*duckdb_file_handle_seek)(duckdb_file_handle file, int64_t position);
-	int64_t (*duckdb_file_handle_tell)(duckdb_file_handle file);
-	duckdb_state (*duckdb_file_handle_sync)(duckdb_file_handle file);
-	int64_t (*duckdb_file_handle_size)(duckdb_file_handle file);
+	void (*duckdb_destroy_file_handle)(duckdb_file_handle *file_handle);
+	duckdb_error_data (*duckdb_file_handle_error_data)(duckdb_file_handle file_handle);
+	duckdb_state (*duckdb_file_handle_close)(duckdb_file_handle file_handle);
+	int64_t (*duckdb_file_handle_read)(duckdb_file_handle file_handle, void *buffer, int64_t size);
+	int64_t (*duckdb_file_handle_write)(duckdb_file_handle file_handle, const void *buffer, int64_t size);
+	duckdb_state (*duckdb_file_handle_seek)(duckdb_file_handle file_handle, int64_t position);
+	int64_t (*duckdb_file_handle_tell)(duckdb_file_handle file_handle);
+	duckdb_state (*duckdb_file_handle_sync)(duckdb_file_handle file_handle);
+	int64_t (*duckdb_file_handle_size)(duckdb_file_handle file_handle);
 	// New functions around the client context
 
 	idx_t (*duckdb_client_context_get_connection_id)(duckdb_client_context context);

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -504,6 +504,7 @@ typedef struct {
 	// API to manage file system operations
 
 	void (*duckdb_connection_get_file_system)(duckdb_connection connection, duckdb_file_system *out_file_system);
+	void (*duckdb_client_context_get_file_system)(duckdb_client_context context, duckdb_file_system *out_file_system);
 	void (*duckdb_destroy_file_system)(duckdb_file_system *file_system);
 	duckdb_state (*duckdb_file_system_open)(duckdb_file_system file_system, const char *path,
 	                                        duckdb_file_open_options options, duckdb_file_handle *out_file);
@@ -1008,6 +1009,7 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_expression_is_foldable = duckdb_expression_is_foldable;
 	result.duckdb_expression_fold = duckdb_expression_fold;
 	result.duckdb_connection_get_file_system = duckdb_connection_get_file_system;
+	result.duckdb_client_context_get_file_system = duckdb_client_context_get_file_system;
 	result.duckdb_destroy_file_system = duckdb_destroy_file_system;
 	result.duckdb_file_system_open = duckdb_file_system_open;
 	result.duckdb_file_system_error_data = duckdb_file_system_error_data;

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -501,6 +501,26 @@ typedef struct {
 	bool (*duckdb_expression_is_foldable)(duckdb_expression expr);
 	duckdb_error_data (*duckdb_expression_fold)(duckdb_client_context context, duckdb_expression expr,
 	                                            duckdb_value *out_value);
+	// API to manage file system operations
+
+	void (*duckdb_connection_get_file_system)(duckdb_connection connection, duckdb_file_system *out_file_system);
+	void (*duckdb_destroy_file_system)(duckdb_file_system *file_system);
+	duckdb_state (*duckdb_file_system_open)(duckdb_file_system file_system, const char *path,
+	                                        duckdb_file_open_options options, duckdb_file_handle *out_file);
+	duckdb_error_data (*duckdb_file_system_error_data)(duckdb_file_system file_system);
+	duckdb_file_open_options (*duckdb_create_file_open_options)();
+	duckdb_state (*duckdb_file_open_options_set_flag)(duckdb_file_open_options options, duckdb_file_flag flag,
+	                                                  bool value);
+	void (*duckdb_destroy_file_open_options)(duckdb_file_open_options *options);
+	void (*duckdb_destroy_file_handle)(duckdb_file_handle *file);
+	duckdb_error_data (*duckdb_file_handle_error_data)(duckdb_file_handle file);
+	duckdb_state (*duckdb_file_handle_close)(duckdb_file_handle file);
+	int64_t (*duckdb_file_handle_read)(duckdb_file_handle file, void *buffer, int64_t size);
+	int64_t (*duckdb_file_handle_write)(duckdb_file_handle file, const void *buffer, int64_t size);
+	duckdb_state (*duckdb_file_handle_seek)(duckdb_file_handle file, int64_t position);
+	int64_t (*duckdb_file_handle_tell)(duckdb_file_handle file);
+	duckdb_state (*duckdb_file_handle_sync)(duckdb_file_handle file);
+	int64_t (*duckdb_file_handle_size)(duckdb_file_handle file);
 	// New functions around the client context
 
 	idx_t (*duckdb_client_context_get_connection_id)(duckdb_client_context context);
@@ -987,6 +1007,22 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_expression_return_type = duckdb_expression_return_type;
 	result.duckdb_expression_is_foldable = duckdb_expression_is_foldable;
 	result.duckdb_expression_fold = duckdb_expression_fold;
+	result.duckdb_connection_get_file_system = duckdb_connection_get_file_system;
+	result.duckdb_destroy_file_system = duckdb_destroy_file_system;
+	result.duckdb_file_system_open = duckdb_file_system_open;
+	result.duckdb_file_system_error_data = duckdb_file_system_error_data;
+	result.duckdb_create_file_open_options = duckdb_create_file_open_options;
+	result.duckdb_file_open_options_set_flag = duckdb_file_open_options_set_flag;
+	result.duckdb_destroy_file_open_options = duckdb_destroy_file_open_options;
+	result.duckdb_destroy_file_handle = duckdb_destroy_file_handle;
+	result.duckdb_file_handle_error_data = duckdb_file_handle_error_data;
+	result.duckdb_file_handle_close = duckdb_file_handle_close;
+	result.duckdb_file_handle_read = duckdb_file_handle_read;
+	result.duckdb_file_handle_write = duckdb_file_handle_write;
+	result.duckdb_file_handle_seek = duckdb_file_handle_seek;
+	result.duckdb_file_handle_tell = duckdb_file_handle_tell;
+	result.duckdb_file_handle_sync = duckdb_file_handle_sync;
+	result.duckdb_file_handle_size = duckdb_file_handle_size;
 	result.duckdb_client_context_get_connection_id = duckdb_client_context_get_connection_id;
 	result.duckdb_destroy_client_context = duckdb_destroy_client_context;
 	result.duckdb_connection_get_client_context = duckdb_connection_get_client_context;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/file_system.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/file_system.json
@@ -1,0 +1,24 @@
+{
+  "version": "unstable_new_file_system_api",
+  "description": "API to manage file system operations",
+  "entries": [
+    "duckdb_connection_get_file_system",
+    "duckdb_destroy_file_system",
+    "duckdb_file_system_open",
+    "duckdb_file_system_error_data",
+
+    "duckdb_create_file_open_options",
+    "duckdb_file_open_options_set_flag",
+    "duckdb_destroy_file_open_options",
+
+    "duckdb_destroy_file_handle",
+    "duckdb_file_handle_error_data",
+    "duckdb_file_handle_close",
+    "duckdb_file_handle_read",
+    "duckdb_file_handle_write",
+    "duckdb_file_handle_seek",
+    "duckdb_file_handle_tell",
+    "duckdb_file_handle_sync",
+    "duckdb_file_handle_size"
+  ]
+}

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/file_system.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/file_system.json
@@ -2,7 +2,6 @@
   "version": "unstable_new_file_system_api",
   "description": "API to manage file system operations",
   "entries": [
-    "duckdb_connection_get_file_system",
     "duckdb_client_context_get_file_system",
     "duckdb_destroy_file_system",
     "duckdb_file_system_open",

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/file_system.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/file_system.json
@@ -3,6 +3,7 @@
   "description": "API to manage file system operations",
   "entries": [
     "duckdb_connection_get_file_system",
+    "duckdb_client_context_get_file_system",
     "duckdb_destroy_file_system",
     "duckdb_file_system_open",
     "duckdb_file_system_error_data",

--- a/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
@@ -24,6 +24,27 @@
       }
     },
     {
+      "name": "duckdb_client_context_get_file_system",
+      "return_type": "void",
+      "params": [
+        {
+          "type": "duckdb_client_context",
+          "name": "context"
+        },
+        {
+          "type": "duckdb_file_system*",
+          "name": "out_file_system"
+        }
+      ],
+      "comment": {
+        "description": "Creates a new file system instance associated with the given client context.\n\n",
+        "param_comments": {
+          "context": "The client context.",
+          "out_file_system": "The resulting file system instance. or NULL if not available."
+        }
+      }
+    },
+    {
       "name": "duckdb_destroy_file_system",
       "return_type": "void",
       "params": [

--- a/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
@@ -16,10 +16,10 @@
         }
       ],
       "comment": {
-        "description": "Creates a new file system instance associated with the given connection.\n\n",
+        "description": "Get a file system instance associated with the given connection.\nMust be destroyed with `duckdb_destroy_file_system`\n\n",
         "param_comments": {
           "connection": "The database connection.",
-          "out_file_system": "The resulting file system instance. or NULL if not available."
+          "out_file_system": "The resulting file system instance, or `nullptr` if not available. Must be destroyed with `duckdb_destroy_file_system`."
         }
       }
     },
@@ -37,10 +37,10 @@
         }
       ],
       "comment": {
-        "description": "Creates a new file system instance associated with the given client context.\n\n",
+        "description": "Get a file system instance associated with the given client context.\nMust be destroyed with `duckdb_destroy_file_system`\n\n",
         "param_comments": {
           "context": "The client context.",
-          "out_file_system": "The resulting file system instance. or NULL if not available."
+          "out_file_system": "The resulting file system instance, or `nullptr` if not available. Must be destroyed with `duckdb_destroy_file_system`."
         }
       }
     },
@@ -104,7 +104,7 @@
           "file_system": "The file system instance.",
           "path": "The path to the file.",
           "options": "The file open options specifying how to open the file.",
-          "out_file": "The resulting file instance, or NULL if the open failed."
+          "out_file": "The resulting file handle instance, or `nullptr` if the open failed. Must be destroyed with `duckdb_destroy_file_handle`."
         },
         "return_value": "Whether the operation was successful. If not, the error data can be retrieved using `duckdb_file_system_error_data`."
       }
@@ -114,7 +114,7 @@
       "return_type": "duckdb_file_open_options",
       "params": [],
       "comment": {
-        "description": "Creates a new file open options instance with blank settings.\n\n",
+        "description": "Creates a new file open options instance with blank settings.\nMust be destroyed with `duckdb_destroy_file_open_options`.\n\n",
         "param_comments": {},
         "return_value": "The new file open options instance."
       }
@@ -141,9 +141,9 @@
         "param_comments": {
           "options": "The file open options instance.",
           "flag": "The flag to set (e.g., read, write).",
-          "value": "The value to set for the flag (true or false)."
+          "value": "If the flag is enabled or disabled."
         },
-        "return_value": "`DuckDBSuccess` on success or `DuckDBError` if the flag is unrecognized."
+        "return_value": "`DuckDBSuccess` on success or `DuckDBError` if the flag is unrecognized or unsupported by this version of DuckDB."
       }
     },
     {
@@ -168,13 +168,13 @@
       "params": [
         {
           "type": "duckdb_file_handle*",
-          "name": "file"
+          "name": "file_handle"
         }
       ],
       "comment": {
-        "description": "Destroys the given file instance and deallocates all associated resources.\nThis will also close the file if it is still open.\n\n",
+        "description": "Destroys the given file handle and deallocates all associated resources.\nThis will also close the file if it is still open.\n\n",
         "param_comments": {
-          "file": "The file instance to destroy."
+          "file_handle": "The file handle to destroy."
         }
       }
     },
@@ -184,13 +184,13 @@
       "params": [
         {
           "type": "duckdb_file_handle",
-          "name": "file"
+          "name": "file_handle"
         }
       ],
       "comment": {
-        "description": "Retrieves the last error that occurred on the given file instance.\nMust be destroyed with duckdb_destroy_error_data.\n\n",
+        "description": "Retrieves the last error that occurred on the given file handle.\nMust be destroyed with duckdb_destroy_error_data.\n\n",
         "param_comments": {
-          "file": "The file instance."
+          "file_handle": "The file handle."
         },
         "return_value": "The error data."
       }
@@ -201,7 +201,7 @@
       "params": [
         {
           "type": "duckdb_file_handle",
-          "name": "file"
+          "name": "file_handle"
         },
         {
           "type": "void*",
@@ -215,7 +215,7 @@
       "comment": {
         "description": "Reads data from the file into the buffer.\n\n",
         "param_comments": {
-          "file": "The file instance to read from.",
+          "file_handle": "The file handle to read from.",
           "buffer": "The buffer to read data into.",
           "size": "The number of bytes to read."
         },
@@ -228,7 +228,7 @@
       "params": [
         {
           "type": "duckdb_file_handle",
-          "name": "file"
+          "name": "file_handle"
         },
         {
           "type": "const void*",
@@ -242,7 +242,7 @@
       "comment": {
         "description": "Writes data from the buffer to the file.\n\n",
         "param_comments": {
-          "file": "The file instance to write to.",
+          "file_handle": "The file handle to write to.",
           "buffer": "The buffer containing data to write.",
           "size": "The number of bytes to write."
         },
@@ -255,13 +255,13 @@
       "params": [
         {
           "type": "duckdb_file_handle",
-          "name": "file"
+          "name": "file_handle"
         }
       ],
       "comment": {
         "description": "Tells the current position in the file.\n\n",
         "param_comments": {
-          "file": "The file instance to tell the position of."
+          "file_handle": "The file handle to tell the position of."
         },
         "return_value": "The current position in the file, or negative on error."
       }
@@ -272,13 +272,13 @@
       "params": [
         {
           "type": "duckdb_file_handle",
-          "name": "file"
+          "name": "file_handle"
         }
       ],
       "comment": {
         "description": "Gets the size of the file.\n\n",
         "param_comments": {
-          "file": "The file instance to get the size of."
+          "file_handle": "The file handle to get the size of."
         },
         "return_value": "The size of the file in bytes, or negative on error."
       }
@@ -289,7 +289,7 @@
       "params": [
         {
           "type": "duckdb_file_handle",
-          "name": "file"
+          "name": "file_handle"
         },
         {
           "type": "int64_t",
@@ -299,7 +299,7 @@
       "comment": {
         "description": "Seeks to a specific position in the file.\n\n",
         "param_comments": {
-          "file": "The file instance to seek in.",
+          "file_handle": "The file handle to seek in.",
           "offset": "The position to seek to."
         },
         "return_value": "Whether the seek was successful. If not, the error data can be retrieved using `duckdb_file_handle_error_data`."
@@ -311,13 +311,13 @@
       "params": [
         {
           "type": "duckdb_file_handle",
-          "name": "file"
+          "name": "file_handle"
         }
       ],
       "comment": {
         "description": "Synchronizes the file's state with the underlying storage.\n\n",
         "param_comments": {
-          "file": "The file instance to synchronize."
+          "file_handle": "The file handle to synchronize."
         },
         "return_value": "`DuckDBSuccess` on success or `DuckDBError` on failure."
       }
@@ -328,13 +328,13 @@
       "params": [
         {
           "type": "duckdb_file_handle",
-          "name": "file"
+          "name": "file_handle"
         }
       ],
       "comment": {
-        "description": "Closes the given file instance.\n\n",
+        "description": "Closes the given file handle.\n\n",
         "param_comments": {
-          "file": "The file instance to close."
+          "file_handle": "The file handle to close."
         },
         "return_value": "`DuckDBSuccess` on success or `DuckDBError` on failure."
       }

--- a/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
@@ -12,7 +12,7 @@
         }
       ],
       "comment": {
-        "description": "Get a file system instance associated with the given client context.\nMust be destroyed with `duckdb_destroy_file_system`\n\n",
+        "description": "Get a file system instance associated with the given client context.\n\n",
         "param_comments": {
           "context": "The client context."
         },
@@ -45,7 +45,7 @@
         }
       ],
       "comment": {
-        "description": "Retrieves the last error that occurred on the given file system instance.\nMust be destroyed with duckdb_destroy_error_data.\n\n",
+        "description": "Retrieves the last error that occurred on the given file system instance.\n\n",
         "param_comments": {
           "file_system": "The file system instance."
         },
@@ -74,7 +74,7 @@
         }
       ],
       "comment": {
-        "description": "Opens a file at the given path with the specified flags.\n\n",
+        "description": "Opens a file at the given path with the specified options.\n\n",
         "param_comments": {
           "file_system": "The file system instance.",
           "path": "The path to the file.",
@@ -89,9 +89,9 @@
       "return_type": "duckdb_file_open_options",
       "params": [],
       "comment": {
-        "description": "Creates a new file open options instance with blank settings.\nMust be destroyed with `duckdb_destroy_file_open_options`.\n\n",
+        "description": "Creates a new file open options instance with blank settings.\n\n",
         "param_comments": {},
-        "return_value": "The new file open options instance."
+        "return_value": "The new file open options instance. Must be destroyed with `duckdb_destroy_file_open_options`."
       }
     },
     {
@@ -163,11 +163,11 @@
         }
       ],
       "comment": {
-        "description": "Retrieves the last error that occurred on the given file handle.\nMust be destroyed with duckdb_destroy_error_data.\n\n",
+        "description": "Retrieves the last error that occurred on the given file handle.\n\n",
         "param_comments": {
           "file_handle": "The file handle."
         },
-        "return_value": "The error data."
+        "return_value": "The error data. Must be destroyed with `duckdb_destroy_error_data`"
       }
     },
     {
@@ -277,7 +277,7 @@
           "file_handle": "The file handle to seek in.",
           "offset": "The position to seek to."
         },
-        "return_value": "Whether the seek was successful. If not, the error data can be retrieved using `duckdb_file_handle_error_data`."
+        "return_value": "`DuckDBSuccess` on success or `DuckDBError` on failure. If unsuccessful, the error data can be retrieved using `duckdb_file_handle_error_data`."
       }
     },
     {
@@ -294,7 +294,7 @@
         "param_comments": {
           "file_handle": "The file handle to synchronize."
         },
-        "return_value": "`DuckDBSuccess` on success or `DuckDBError` on failure."
+        "return_value": "`DuckDBSuccess` on success or `DuckDBError` on failure. If unsuccessful, the error data can be retrieved using `duckdb_file_handle_error_data`."
       }
     },
     {
@@ -311,7 +311,7 @@
         "param_comments": {
           "file_handle": "The file handle to close."
         },
-        "return_value": "`DuckDBSuccess` on success or `DuckDBError` on failure."
+        "return_value": "`DuckDBSuccess` on success or `DuckDBError` on failure. If unsuccessful, the error data can be retrieved using `duckdb_file_handle_error_data`."
       }
     }
   ]

--- a/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
@@ -3,45 +3,20 @@
   "deprecated": false,
   "entries": [
     {
-      "name": "duckdb_connection_get_file_system",
-      "return_type": "void",
-      "params": [
-        {
-          "type": "duckdb_connection",
-          "name": "connection"
-        },
-        {
-          "type": "duckdb_file_system*",
-          "name": "out_file_system"
-        }
-      ],
-      "comment": {
-        "description": "Get a file system instance associated with the given connection.\nMust be destroyed with `duckdb_destroy_file_system`\n\n",
-        "param_comments": {
-          "connection": "The database connection.",
-          "out_file_system": "The resulting file system instance, or `nullptr` if not available. Must be destroyed with `duckdb_destroy_file_system`."
-        }
-      }
-    },
-    {
       "name": "duckdb_client_context_get_file_system",
-      "return_type": "void",
+      "return_type": "duckdb_file_system",
       "params": [
         {
           "type": "duckdb_client_context",
           "name": "context"
-        },
-        {
-          "type": "duckdb_file_system*",
-          "name": "out_file_system"
         }
       ],
       "comment": {
         "description": "Get a file system instance associated with the given client context.\nMust be destroyed with `duckdb_destroy_file_system`\n\n",
         "param_comments": {
-          "context": "The client context.",
-          "out_file_system": "The resulting file system instance, or `nullptr` if not available. Must be destroyed with `duckdb_destroy_file_system`."
-        }
+          "context": "The client context."
+        },
+        "return_value": "The resulting file system instance. Must be destroyed with `duckdb_destroy_file_system`."
       }
     },
     {

--- a/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
@@ -1,0 +1,322 @@
+{
+  "group": "file_system_interface",
+  "deprecated": false,
+  "entries": [
+    {
+      "name": "duckdb_connection_get_file_system",
+      "return_type": "void",
+      "params": [
+        {
+          "type": "duckdb_connection",
+          "name": "connection"
+        },
+        {
+          "type": "duckdb_file_system*",
+          "name": "out_file_system"
+        }
+      ],
+      "comment": {
+        "description": "Creates a new file system instance associated with the given connection.\n\n",
+        "param_comments": {
+          "connection": "The database connection.",
+          "out_file_system": "The resulting file system instance. or NULL if not available."
+        }
+      }
+    },
+    {
+      "name": "duckdb_destroy_file_system",
+      "return_type": "void",
+      "params": [
+        {
+          "type": "duckdb_file_system*",
+          "name": "file_system"
+        }
+      ],
+      "comment": {
+        "description": "Destroys the given file system instance.\n",
+        "param_comments": {
+          "file_system": "The file system instance to destroy."
+        }
+      }
+    },
+    {
+      "name": "duckdb_file_system_error_data",
+      "return_type": "duckdb_error_data",
+      "params": [
+        {
+          "type": "duckdb_file_system",
+          "name": "file_system"
+        }
+      ],
+      "comment": {
+        "description": "Retrieves the last error that occurred on the given file system instance.\nMust be destroyed with duckdb_destroy_error_data.\n\n",
+        "param_comments": {
+          "file_system": "The file system instance."
+        },
+        "return_value": "The error data."
+      }
+    },
+    {
+      "name": "duckdb_file_system_open",
+      "return_type": "duckdb_state",
+      "params": [
+        {
+          "type": "duckdb_file_system",
+          "name": "file_system"
+        },
+        {
+          "type": "const char*",
+          "name": "path"
+        },
+        {
+          "type": "duckdb_file_open_options",
+          "name": "options"
+        },
+        {
+          "type": "duckdb_file_handle*",
+          "name": "out_file"
+        }
+      ],
+      "comment": {
+        "description": "Opens a file at the given path with the specified flags.\n\n",
+        "param_comments": {
+          "file_system": "The file system instance.",
+          "path": "The path to the file.",
+          "options": "The file open options specifying how to open the file.",
+          "out_file": "The resulting file instance, or NULL if the open failed."
+        },
+        "return_value": "Whether the operation was successful. If not, the error data can be retrieved using `duckdb_file_system_error_data`."
+      }
+    },
+    {
+      "name": "duckdb_create_file_open_options",
+      "return_type": "duckdb_file_open_options",
+      "params": [],
+      "comment": {
+        "description": "Creates a new file open options instance with blank settings.\n\n",
+        "param_comments": {},
+        "return_value": "The new file open options instance."
+      }
+    },
+    {
+      "name": "duckdb_file_open_options_set_flag",
+      "return_type": "duckdb_state",
+      "params": [
+        {
+          "type": "duckdb_file_open_options",
+          "name": "options"
+        },
+        {
+          "type": "duckdb_file_flag",
+          "name": "flag"
+        },
+        {
+          "type": "bool",
+          "name": "value"
+        }
+      ],
+      "comment": {
+        "description": "Sets a specific flag in the file open options.\n\n",
+        "param_comments": {
+          "options": "The file open options instance.",
+          "flag": "The flag to set (e.g., read, write).",
+          "value": "The value to set for the flag (true or false)."
+        },
+        "return_value": "`DuckDBSuccess` on success or `DuckDBError` if the flag is unrecognized."
+      }
+    },
+    {
+      "name": "duckdb_destroy_file_open_options",
+      "return_type": "void",
+      "params": [
+        {
+          "type": "duckdb_file_open_options*",
+          "name": "options"
+        }
+      ],
+      "comment": {
+        "description": "Destroys the given file open options instance.\n",
+        "param_comments": {
+          "options": "The file open options instance to destroy."
+        }
+      }
+    },
+    {
+      "name": "duckdb_destroy_file_handle",
+      "return_type": "void",
+      "params": [
+        {
+          "type": "duckdb_file_handle*",
+          "name": "file"
+        }
+      ],
+      "comment": {
+        "description": "Destroys the given file instance and deallocates all associated resources.\nThis will also close the file if it is still open.\n\n",
+        "param_comments": {
+          "file": "The file instance to destroy."
+        }
+      }
+    },
+    {
+      "name": "duckdb_file_handle_error_data",
+      "return_type": "duckdb_error_data",
+      "params": [
+        {
+          "type": "duckdb_file_handle",
+          "name": "file"
+        }
+      ],
+      "comment": {
+        "description": "Retrieves the last error that occurred on the given file instance.\nMust be destroyed with duckdb_destroy_error_data.\n\n",
+        "param_comments": {
+          "file": "The file instance."
+        },
+        "return_value": "The error data."
+      }
+    },
+    {
+      "name": "duckdb_file_handle_read",
+      "return_type": "int64_t",
+      "params": [
+        {
+          "type": "duckdb_file_handle",
+          "name": "file"
+        },
+        {
+          "type": "void*",
+          "name": "buffer"
+        },
+        {
+          "type": "int64_t",
+          "name": "size"
+        }
+      ],
+      "comment": {
+        "description": "Reads data from the file into the buffer.\n\n",
+        "param_comments": {
+          "file": "The file instance to read from.",
+          "buffer": "The buffer to read data into.",
+          "size": "The number of bytes to read."
+        },
+        "return_value": "The number of bytes actually read, or -1 on error."
+      }
+    },
+    {
+      "name": "duckdb_file_handle_write",
+      "return_type": "int64_t",
+      "params": [
+        {
+          "type": "duckdb_file_handle",
+          "name": "file"
+        },
+        {
+          "type": "const void*",
+          "name": "buffer"
+        },
+        {
+          "type": "int64_t",
+          "name": "size"
+        }
+      ],
+      "comment": {
+        "description": "Writes data from the buffer to the file.\n\n",
+        "param_comments": {
+          "file": "The file instance to write to.",
+          "buffer": "The buffer containing data to write.",
+          "size": "The number of bytes to write."
+        },
+        "return_value": "The number of bytes actually written, or -1 on error."
+      }
+    },
+    {
+      "name": "duckdb_file_handle_tell",
+      "return_type": "int64_t",
+      "params": [
+        {
+          "type": "duckdb_file_handle",
+          "name": "file"
+        }
+      ],
+      "comment": {
+        "description": "Tells the current position in the file.\n\n",
+        "param_comments": {
+          "file": "The file instance to tell the position of."
+        },
+        "return_value": "The current position in the file, or -1 on error."
+      }
+    },
+    {
+      "name": "duckdb_file_handle_size",
+      "return_type": "int64_t",
+      "params": [
+        {
+          "type": "duckdb_file_handle",
+          "name": "file"
+        }
+      ],
+      "comment": {
+        "description": "Gets the size of the file.\n\n",
+        "param_comments": {
+          "file": "The file instance to get the size of."
+        },
+        "return_value": "The size of the file in bytes, or -1 on error."
+      }
+    },
+    {
+      "name": "duckdb_file_handle_seek",
+      "return_type": "duckdb_state",
+      "params": [
+        {
+          "type": "duckdb_file_handle",
+          "name": "file"
+        },
+        {
+          "type": "int64_t",
+          "name": "position"
+        }
+      ],
+      "comment": {
+        "description": "Seeks to a specific position in the file.\n\n",
+        "param_comments": {
+          "file": "The file instance to seek in.",
+          "offset": "The position to seek to."
+        },
+        "return_value": "Whether the seek was successful. If not, the error data can be retrieved using `duckdb_file_handle_error_data`."
+      }
+    },
+    {
+      "name": "duckdb_file_handle_sync",
+      "return_type": "duckdb_state",
+      "params": [
+        {
+          "type": "duckdb_file_handle",
+          "name": "file"
+        }
+      ],
+      "comment": {
+        "description": "Synchronizes the file's state with the underlying storage.\n\n",
+        "param_comments": {
+          "file": "The file instance to synchronize."
+        },
+        "return_value": "`DuckDBSuccess` on success or `DuckDBError` on failure."
+      }
+    },
+    {
+      "name": "duckdb_file_handle_close",
+      "return_type": "duckdb_state",
+      "params": [
+        {
+          "type": "duckdb_file_handle",
+          "name": "file"
+        }
+      ],
+      "comment": {
+        "description": "Closes the given file instance.\n\n",
+        "param_comments": {
+          "file": "The file instance to close."
+        },
+        "return_value": "`DuckDBSuccess` on success or `DuckDBError` on failure."
+      }
+    }
+  ]
+}

--- a/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/file_system_interface.json
@@ -198,7 +198,7 @@
           "buffer": "The buffer to read data into.",
           "size": "The number of bytes to read."
         },
-        "return_value": "The number of bytes actually read, or -1 on error."
+        "return_value": "The number of bytes actually read, or negative on error."
       }
     },
     {
@@ -225,7 +225,7 @@
           "buffer": "The buffer containing data to write.",
           "size": "The number of bytes to write."
         },
-        "return_value": "The number of bytes actually written, or -1 on error."
+        "return_value": "The number of bytes actually written, or negative on error."
       }
     },
     {
@@ -242,7 +242,7 @@
         "param_comments": {
           "file": "The file instance to tell the position of."
         },
-        "return_value": "The current position in the file, or -1 on error."
+        "return_value": "The current position in the file, or negative on error."
       }
     },
     {
@@ -259,7 +259,7 @@
         "param_comments": {
           "file": "The file instance to get the size of."
         },
-        "return_value": "The size of the file in bytes, or -1 on error."
+        "return_value": "The size of the file in bytes, or negative on error."
       }
     },
     {

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -755,6 +755,35 @@ typedef struct _duckdb_arrow_options {
 	void *internal_ptr;
 } * duckdb_arrow_options;
 
+//===--------------------------------------------------------------------===//
+// Virtual File System Access
+//===--------------------------------------------------------------------===//
+
+typedef enum duckdb_file_flag {
+	DUCKDB_FILE_FLAGS_NONE = 0,
+	// Open a file for reading only.
+	DUCKDB_FILE_FLAGS_READ = 1,
+	// Open a file for writing only.
+	DUCKDB_FILE_FLAGS_WRITE = 2,
+	// Create or open the file if it already exists.
+	DUCKDB_FILE_FLAGS_CREATE = 3,
+	// Create a new file, fail if it already exists.
+	DUCKDB_FILE_FLAGS_CREATE_NEW = 4,
+	// Open the file in append mode.
+	DUCKDB_FILE_FLAGS_APPEND = 5,
+} duckdb_file_flag;
+
+typedef struct _duckdb_file_open_options {
+	void *internal_ptr;
+} * duckdb_file_open_options;
+
+typedef struct _duckdb_file_system {
+	void *internal_ptr;
+} * duckdb_file_system;
+
+typedef struct _duckdb_file_handle {
+	void *internal_ptr;
+} * duckdb_file_handle;
 
 //===--------------------------------------------------------------------===//
 // DuckDB extension access

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -243,15 +243,15 @@ typedef enum duckdb_cast_mode {
 
 typedef enum duckdb_file_flag {
 	DUCKDB_FILE_FLAG_INVALID = 0,
-	// Open a file for reading only.
+	// Open the file with "read" capabilities.
 	DUCKDB_FILE_FLAG_READ = 1,
-	// Open a file for writing only.
+	// Open the file with "write" capabilities.
 	DUCKDB_FILE_FLAG_WRITE = 2,
-	// Create or open the file if it already exists.
+	// Create a new file, or open if it already exists.
 	DUCKDB_FILE_FLAG_CREATE = 3,
-	// Create a new file, fail if it already exists.
+	// Create a new file, or fail if it already exists.
 	DUCKDB_FILE_FLAG_CREATE_NEW = 4,
-	// Open the file in append mode.
+	// Open the file in "append" mode.
 	DUCKDB_FILE_FLAG_APPEND = 5,
 } duckdb_file_flag;
 

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -241,6 +241,20 @@ typedef enum duckdb_cast_mode {
 	DUCKDB_CAST_TRY = 1
 } duckdb_cast_mode;
 
+typedef enum duckdb_file_flag {
+	DUCKDB_FILE_FLAG_INVALID = 0,
+	// Open a file for reading only.
+	DUCKDB_FILE_FLAG_READ = 1,
+	// Open a file for writing only.
+	DUCKDB_FILE_FLAG_WRITE = 2,
+	// Create or open the file if it already exists.
+	DUCKDB_FILE_FLAG_CREATE = 3,
+	// Create a new file, fail if it already exists.
+	DUCKDB_FILE_FLAG_CREATE_NEW = 4,
+	// Open the file in append mode.
+	DUCKDB_FILE_FLAG_APPEND = 5,
+} duckdb_file_flag;
+
 //===--------------------------------------------------------------------===//
 // General type definitions
 //===--------------------------------------------------------------------===//
@@ -758,20 +772,6 @@ typedef struct _duckdb_arrow_options {
 //===--------------------------------------------------------------------===//
 // Virtual File System Access
 //===--------------------------------------------------------------------===//
-
-typedef enum duckdb_file_flag {
-	DUCKDB_FILE_FLAGS_NONE = 0,
-	// Open a file for reading only.
-	DUCKDB_FILE_FLAGS_READ = 1,
-	// Open a file for writing only.
-	DUCKDB_FILE_FLAGS_WRITE = 2,
-	// Create or open the file if it already exists.
-	DUCKDB_FILE_FLAGS_CREATE = 3,
-	// Create a new file, fail if it already exists.
-	DUCKDB_FILE_FLAGS_CREATE_NEW = 4,
-	// Open the file in append mode.
-	DUCKDB_FILE_FLAGS_APPEND = 5,
-} duckdb_file_flag;
 
 typedef struct _duckdb_file_open_options {
 	void *internal_ptr;

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -580,8 +580,7 @@ typedef struct {
 
 // API to manage file system operations
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
-	void (*duckdb_connection_get_file_system)(duckdb_connection connection, duckdb_file_system *out_file_system);
-	void (*duckdb_client_context_get_file_system)(duckdb_client_context context, duckdb_file_system *out_file_system);
+	duckdb_file_system (*duckdb_client_context_get_file_system)(duckdb_client_context context);
 	void (*duckdb_destroy_file_system)(duckdb_file_system *file_system);
 	duckdb_state (*duckdb_file_system_open)(duckdb_file_system file_system, const char *path,
 	                                        duckdb_file_open_options options, duckdb_file_handle *out_file);
@@ -1117,7 +1116,6 @@ typedef struct {
 #define duckdb_expression_fold        duckdb_ext_api.duckdb_expression_fold
 
 // Version unstable_new_file_system_api
-#define duckdb_connection_get_file_system     duckdb_ext_api.duckdb_connection_get_file_system
 #define duckdb_client_context_get_file_system duckdb_ext_api.duckdb_client_context_get_file_system
 #define duckdb_destroy_file_system            duckdb_ext_api.duckdb_destroy_file_system
 #define duckdb_file_system_error_data         duckdb_ext_api.duckdb_file_system_error_data

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -578,6 +578,28 @@ typedef struct {
 	                                            duckdb_value *out_value);
 #endif
 
+// API to manage file system operations
+#ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
+	void (*duckdb_connection_get_file_system)(duckdb_connection connection, duckdb_file_system *out_file_system);
+	void (*duckdb_destroy_file_system)(duckdb_file_system *file_system);
+	duckdb_state (*duckdb_file_system_open)(duckdb_file_system file_system, const char *path,
+	                                        duckdb_file_open_options options, duckdb_file_handle *out_file);
+	duckdb_error_data (*duckdb_file_system_error_data)(duckdb_file_system file_system);
+	duckdb_file_open_options (*duckdb_create_file_open_options)();
+	duckdb_state (*duckdb_file_open_options_set_flag)(duckdb_file_open_options options, duckdb_file_flag flag,
+	                                                  bool value);
+	void (*duckdb_destroy_file_open_options)(duckdb_file_open_options *options);
+	void (*duckdb_destroy_file_handle)(duckdb_file_handle *file);
+	duckdb_error_data (*duckdb_file_handle_error_data)(duckdb_file_handle file);
+	duckdb_state (*duckdb_file_handle_close)(duckdb_file_handle file);
+	int64_t (*duckdb_file_handle_read)(duckdb_file_handle file, void *buffer, int64_t size);
+	int64_t (*duckdb_file_handle_write)(duckdb_file_handle file, const void *buffer, int64_t size);
+	duckdb_state (*duckdb_file_handle_seek)(duckdb_file_handle file, int64_t position);
+	int64_t (*duckdb_file_handle_tell)(duckdb_file_handle file);
+	duckdb_state (*duckdb_file_handle_sync)(duckdb_file_handle file);
+	int64_t (*duckdb_file_handle_size)(duckdb_file_handle file);
+#endif
+
 // New functions around the client context
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
 	idx_t (*duckdb_client_context_get_connection_id)(duckdb_client_context context);
@@ -1092,6 +1114,24 @@ typedef struct {
 #define duckdb_expression_return_type duckdb_ext_api.duckdb_expression_return_type
 #define duckdb_expression_is_foldable duckdb_ext_api.duckdb_expression_is_foldable
 #define duckdb_expression_fold        duckdb_ext_api.duckdb_expression_fold
+
+// Version unstable_new_file_system_api
+#define duckdb_connection_get_file_system duckdb_ext_api.duckdb_connection_get_file_system
+#define duckdb_destroy_file_system        duckdb_ext_api.duckdb_destroy_file_system
+#define duckdb_file_system_error_data     duckdb_ext_api.duckdb_file_system_error_data
+#define duckdb_file_system_open           duckdb_ext_api.duckdb_file_system_open
+#define duckdb_create_file_open_options   duckdb_ext_api.duckdb_create_file_open_options
+#define duckdb_file_open_options_set_flag duckdb_ext_api.duckdb_file_open_options_set_flag
+#define duckdb_destroy_file_open_options  duckdb_ext_api.duckdb_destroy_file_open_options
+#define duckdb_destroy_file_handle        duckdb_ext_api.duckdb_destroy_file_handle
+#define duckdb_file_handle_error_data     duckdb_ext_api.duckdb_file_handle_error_data
+#define duckdb_file_handle_read           duckdb_ext_api.duckdb_file_handle_read
+#define duckdb_file_handle_write          duckdb_ext_api.duckdb_file_handle_write
+#define duckdb_file_handle_tell           duckdb_ext_api.duckdb_file_handle_tell
+#define duckdb_file_handle_size           duckdb_ext_api.duckdb_file_handle_size
+#define duckdb_file_handle_seek           duckdb_ext_api.duckdb_file_handle_seek
+#define duckdb_file_handle_sync           duckdb_ext_api.duckdb_file_handle_sync
+#define duckdb_file_handle_close          duckdb_ext_api.duckdb_file_handle_close
 
 // Version unstable_new_open_connect_functions
 #define duckdb_connection_get_client_context    duckdb_ext_api.duckdb_connection_get_client_context

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -590,15 +590,15 @@ typedef struct {
 	duckdb_state (*duckdb_file_open_options_set_flag)(duckdb_file_open_options options, duckdb_file_flag flag,
 	                                                  bool value);
 	void (*duckdb_destroy_file_open_options)(duckdb_file_open_options *options);
-	void (*duckdb_destroy_file_handle)(duckdb_file_handle *file);
-	duckdb_error_data (*duckdb_file_handle_error_data)(duckdb_file_handle file);
-	duckdb_state (*duckdb_file_handle_close)(duckdb_file_handle file);
-	int64_t (*duckdb_file_handle_read)(duckdb_file_handle file, void *buffer, int64_t size);
-	int64_t (*duckdb_file_handle_write)(duckdb_file_handle file, const void *buffer, int64_t size);
-	duckdb_state (*duckdb_file_handle_seek)(duckdb_file_handle file, int64_t position);
-	int64_t (*duckdb_file_handle_tell)(duckdb_file_handle file);
-	duckdb_state (*duckdb_file_handle_sync)(duckdb_file_handle file);
-	int64_t (*duckdb_file_handle_size)(duckdb_file_handle file);
+	void (*duckdb_destroy_file_handle)(duckdb_file_handle *file_handle);
+	duckdb_error_data (*duckdb_file_handle_error_data)(duckdb_file_handle file_handle);
+	duckdb_state (*duckdb_file_handle_close)(duckdb_file_handle file_handle);
+	int64_t (*duckdb_file_handle_read)(duckdb_file_handle file_handle, void *buffer, int64_t size);
+	int64_t (*duckdb_file_handle_write)(duckdb_file_handle file_handle, const void *buffer, int64_t size);
+	duckdb_state (*duckdb_file_handle_seek)(duckdb_file_handle file_handle, int64_t position);
+	int64_t (*duckdb_file_handle_tell)(duckdb_file_handle file_handle);
+	duckdb_state (*duckdb_file_handle_sync)(duckdb_file_handle file_handle);
+	int64_t (*duckdb_file_handle_size)(duckdb_file_handle file_handle);
 #endif
 
 // New functions around the client context

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -581,6 +581,7 @@ typedef struct {
 // API to manage file system operations
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
 	void (*duckdb_connection_get_file_system)(duckdb_connection connection, duckdb_file_system *out_file_system);
+	void (*duckdb_client_context_get_file_system)(duckdb_client_context context, duckdb_file_system *out_file_system);
 	void (*duckdb_destroy_file_system)(duckdb_file_system *file_system);
 	duckdb_state (*duckdb_file_system_open)(duckdb_file_system file_system, const char *path,
 	                                        duckdb_file_open_options options, duckdb_file_handle *out_file);
@@ -1116,22 +1117,23 @@ typedef struct {
 #define duckdb_expression_fold        duckdb_ext_api.duckdb_expression_fold
 
 // Version unstable_new_file_system_api
-#define duckdb_connection_get_file_system duckdb_ext_api.duckdb_connection_get_file_system
-#define duckdb_destroy_file_system        duckdb_ext_api.duckdb_destroy_file_system
-#define duckdb_file_system_error_data     duckdb_ext_api.duckdb_file_system_error_data
-#define duckdb_file_system_open           duckdb_ext_api.duckdb_file_system_open
-#define duckdb_create_file_open_options   duckdb_ext_api.duckdb_create_file_open_options
-#define duckdb_file_open_options_set_flag duckdb_ext_api.duckdb_file_open_options_set_flag
-#define duckdb_destroy_file_open_options  duckdb_ext_api.duckdb_destroy_file_open_options
-#define duckdb_destroy_file_handle        duckdb_ext_api.duckdb_destroy_file_handle
-#define duckdb_file_handle_error_data     duckdb_ext_api.duckdb_file_handle_error_data
-#define duckdb_file_handle_read           duckdb_ext_api.duckdb_file_handle_read
-#define duckdb_file_handle_write          duckdb_ext_api.duckdb_file_handle_write
-#define duckdb_file_handle_tell           duckdb_ext_api.duckdb_file_handle_tell
-#define duckdb_file_handle_size           duckdb_ext_api.duckdb_file_handle_size
-#define duckdb_file_handle_seek           duckdb_ext_api.duckdb_file_handle_seek
-#define duckdb_file_handle_sync           duckdb_ext_api.duckdb_file_handle_sync
-#define duckdb_file_handle_close          duckdb_ext_api.duckdb_file_handle_close
+#define duckdb_connection_get_file_system     duckdb_ext_api.duckdb_connection_get_file_system
+#define duckdb_client_context_get_file_system duckdb_ext_api.duckdb_client_context_get_file_system
+#define duckdb_destroy_file_system            duckdb_ext_api.duckdb_destroy_file_system
+#define duckdb_file_system_error_data         duckdb_ext_api.duckdb_file_system_error_data
+#define duckdb_file_system_open               duckdb_ext_api.duckdb_file_system_open
+#define duckdb_create_file_open_options       duckdb_ext_api.duckdb_create_file_open_options
+#define duckdb_file_open_options_set_flag     duckdb_ext_api.duckdb_file_open_options_set_flag
+#define duckdb_destroy_file_open_options      duckdb_ext_api.duckdb_destroy_file_open_options
+#define duckdb_destroy_file_handle            duckdb_ext_api.duckdb_destroy_file_handle
+#define duckdb_file_handle_error_data         duckdb_ext_api.duckdb_file_handle_error_data
+#define duckdb_file_handle_read               duckdb_ext_api.duckdb_file_handle_read
+#define duckdb_file_handle_write              duckdb_ext_api.duckdb_file_handle_write
+#define duckdb_file_handle_tell               duckdb_ext_api.duckdb_file_handle_tell
+#define duckdb_file_handle_size               duckdb_ext_api.duckdb_file_handle_size
+#define duckdb_file_handle_seek               duckdb_ext_api.duckdb_file_handle_seek
+#define duckdb_file_handle_sync               duckdb_ext_api.duckdb_file_handle_sync
+#define duckdb_file_handle_close              duckdb_ext_api.duckdb_file_handle_close
 
 // Version unstable_new_open_connect_functions
 #define duckdb_connection_get_client_context    duckdb_ext_api.duckdb_connection_get_client_context

--- a/src/main/capi/CMakeLists.txt
+++ b/src/main/capi/CMakeLists.txt
@@ -27,7 +27,8 @@ add_library_unity(
   table_description-c.cpp
   table_function-c.cpp
   threading-c.cpp
-  value-c.cpp)
+  value-c.cpp
+  file_system-c.cpp)
 
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_main_capi>

--- a/src/main/capi/file_system-c.cpp
+++ b/src/main/capi/file_system-c.cpp
@@ -237,7 +237,7 @@ int64_t duckdb_file_handle_tell(duckdb_file_handle file) {
 		cfile->SetError(ex);
 		return -1;
 	} catch (...) {
-		cfile->SetError("Unknown error occurred during when getting file position");
+		cfile->SetError("Unknown error occurred when getting file position");
 		return -1;
 	}
 }

--- a/src/main/capi/file_system-c.cpp
+++ b/src/main/capi/file_system-c.cpp
@@ -129,7 +129,7 @@ duckdb_state duckdb_file_system_open(duckdb_file_system fs, const char *path, du
 }
 
 duckdb_error_data duckdb_file_system_error_data(duckdb_file_system fs) {
-	auto wrapper = new ErrorDataWrapper();
+	auto wrapper = new duckdb::ErrorDataWrapper();
 	if (!fs) {
 		return reinterpret_cast<duckdb_error_data>(wrapper);
 	}
@@ -149,7 +149,7 @@ void duckdb_destroy_file_handle(duckdb_file_handle *file) {
 }
 
 duckdb_error_data duckdb_file_handle_error_data(duckdb_file_handle file) {
-	auto wrapper = new ErrorDataWrapper();
+	auto wrapper = new duckdb::ErrorDataWrapper();
 	if (!file) {
 		return reinterpret_cast<duckdb_error_data>(wrapper);
 	}

--- a/src/main/capi/file_system-c.cpp
+++ b/src/main/capi/file_system-c.cpp
@@ -54,6 +54,19 @@ void duckdb_connection_get_file_system(duckdb_connection connection, duckdb_file
 	}
 }
 
+void duckdb_client_context_get_file_system(duckdb_client_context context, duckdb_file_system *out_file_system) {
+	if (!context || !out_file_system) {
+		return;
+	}
+	auto ctx = reinterpret_cast<duckdb::ClientContext *>(context);
+	try {
+		auto wrapper = new duckdb::CFileSystem(duckdb::FileSystem::GetFileSystem(*ctx));
+		*out_file_system = reinterpret_cast<duckdb_file_system>(wrapper);
+	} catch (...) {
+		*out_file_system = nullptr;
+	}
+}
+
 void duckdb_destroy_file_system(duckdb_file_system *file_system) {
 	if (!file_system || !*file_system) {
 		return;

--- a/src/main/capi/file_system-c.cpp
+++ b/src/main/capi/file_system-c.cpp
@@ -37,32 +37,13 @@ struct CFileHandle {
 } // namespace
 } // namespace duckdb
 
-void duckdb_connection_get_file_system(duckdb_connection connection, duckdb_file_system *out_file_system) {
-	if (!connection || !out_file_system) {
-		*out_file_system = nullptr;
-		return;
-	}
-	auto conn = reinterpret_cast<duckdb::Connection *>(connection);
-	try {
-		auto wrapper = new duckdb::CFileSystem(duckdb::FileSystem::GetFileSystem(*conn->context));
-		*out_file_system = reinterpret_cast<duckdb_file_system>(wrapper);
-	} catch (...) {
-		*out_file_system = nullptr;
-	}
-}
-
-void duckdb_client_context_get_file_system(duckdb_client_context context, duckdb_file_system *out_file_system) {
-	if (!context || !out_file_system) {
-		*out_file_system = nullptr;
-		return;
+duckdb_file_system duckdb_client_context_get_file_system(duckdb_client_context context) {
+	if (!context) {
+		return nullptr;
 	}
 	auto ctx = reinterpret_cast<duckdb::CClientContextWrapper *>(context);
-	try {
-		auto wrapper = new duckdb::CFileSystem(duckdb::FileSystem::GetFileSystem(ctx->context));
-		*out_file_system = reinterpret_cast<duckdb_file_system>(wrapper);
-	} catch (...) {
-		*out_file_system = nullptr;
-	}
+	auto wrapper = new duckdb::CFileSystem(duckdb::FileSystem::GetFileSystem(ctx->context));
+	return reinterpret_cast<duckdb_file_system>(wrapper);
 }
 
 void duckdb_destroy_file_system(duckdb_file_system *file_system) {

--- a/test/api/capi/CMakeLists.txt
+++ b/test/api/capi/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library_unity(
   OBJECT
   capi_aggregate_functions.cpp
   capi_custom_type.cpp
+  capi_file_system.cpp
   capi_scalar_functions.cpp
   capi_table_functions.cpp
   test_capi.cpp

--- a/test/api/capi/capi_file_system.cpp
+++ b/test/api/capi/capi_file_system.cpp
@@ -135,26 +135,18 @@ static void test_file_system(duckdb_file_system fs, string file_name) {
 
 TEST_CASE("Test File System in C API", "[capi]") {
 	CAPITester tester;
+	duckdb_client_context context;
 	duckdb_file_system fs;
 	duckdb::unique_ptr<CAPIResult> result;
 
 	REQUIRE(tester.OpenDatabase(nullptr));
-	duckdb_connection_get_file_system(tester.connection, &fs);
+
+	// get a file system from the client context
+	duckdb_connection_get_client_context(tester.connection, &context);
+	fs = duckdb_client_context_get_file_system(context);
 	REQUIRE(fs != nullptr);
 
 	test_file_system(fs, "test_file_capi_1.txt");
-
-	duckdb_destroy_file_system(&fs);
-	REQUIRE(fs == nullptr);
-
-	// get a file system from the client context as well
-	duckdb_client_context context;
-	duckdb_connection_get_client_context(tester.connection, &context);
-
-	duckdb_client_context_get_file_system(context, &fs);
-	REQUIRE(fs != nullptr);
-
-	test_file_system(fs, "test_file_capi_2.txt");
 
 	duckdb_destroy_file_system(&fs);
 	REQUIRE(fs == nullptr);

--- a/test/api/capi/capi_file_system.cpp
+++ b/test/api/capi/capi_file_system.cpp
@@ -26,7 +26,7 @@ static void test_file_system(duckdb_file_system fs, string file_name) {
 	duckdb_destroy_error_data(&error_data);
 
 	// Try to write to a null file handle
-	int64_t failed_bytes_written = duckdb_file_handle_write(file, "data", 4);
+	auto failed_bytes_written = duckdb_file_handle_write(file, "data", 4);
 	REQUIRE(failed_bytes_written == -1);
 	auto file_error_data = duckdb_file_handle_error_data(file);
 	auto has_error = duckdb_error_data_has_error(file_error_data);
@@ -44,11 +44,11 @@ static void test_file_system(duckdb_file_system fs, string file_name) {
 
 	// Write to the file
 	const char *data = "Hello, DuckDB File System!";
-	int64_t bytes_written = duckdb_file_handle_write(file, data, strlen(data));
+	auto bytes_written = duckdb_file_handle_write(file, data, strlen(data));
 	REQUIRE(bytes_written == (int64_t)strlen(data));
-	int64_t position = duckdb_file_handle_tell(file);
+	auto position = duckdb_file_handle_tell(file);
 	REQUIRE(position == bytes_written);
-	int64_t size = duckdb_file_handle_size(file);
+	auto size = duckdb_file_handle_size(file);
 	REQUIRE(size == bytes_written);
 
 	// Sync
@@ -63,7 +63,7 @@ static void test_file_system(duckdb_file_system fs, string file_name) {
 	// Read from the file
 	char buffer[30];
 	memset(buffer, 0, sizeof(buffer));
-	int64_t bytes_read = duckdb_file_handle_read(file, buffer, sizeof(buffer) - 1);
+	auto bytes_read = duckdb_file_handle_read(file, buffer, sizeof(buffer) - 1);
 	REQUIRE(bytes_read == bytes_written);
 	REQUIRE(strcmp(buffer, data) == 0);
 	position = duckdb_file_handle_tell(file);

--- a/test/api/capi/capi_file_system.cpp
+++ b/test/api/capi/capi_file_system.cpp
@@ -1,0 +1,120 @@
+#include "capi_tester.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+static void test_file_system(duckdb_file_system fs, string file_name) {
+	REQUIRE(fs != nullptr);
+
+	duckdb_state state = DuckDBSuccess;
+	duckdb_file_handle file;
+
+	auto file_path = TestDirectoryPath() + "/" + file_name;
+
+	auto options = duckdb_create_file_open_options();
+	state = duckdb_file_open_options_set_flag(options, DUCKDB_FILE_FLAGS_WRITE, true);
+	REQUIRE(state == DuckDBSuccess);
+	state = duckdb_file_open_options_set_flag(options, DUCKDB_FILE_FLAGS_READ, true);
+	REQUIRE(state == DuckDBSuccess);
+
+	// Try to open non-existing file without create flag
+	state = duckdb_file_system_open(fs, file_path.c_str(), options, &file);
+	REQUIRE(state != DuckDBSuccess);
+	auto error_data = duckdb_file_system_error_data(fs);
+	auto error_type = duckdb_error_data_error_type(error_data);
+	REQUIRE(error_type == DUCKDB_ERROR_IO);
+	duckdb_destroy_error_data(&error_data);
+
+	// Set create flag
+	state = duckdb_file_open_options_set_flag(options, DUCKDB_FILE_FLAGS_CREATE, true);
+	REQUIRE(state == DuckDBSuccess);
+
+	// Create and open a file
+	state = duckdb_file_system_open(fs, file_path.c_str(), options, &file);
+	REQUIRE(state == DuckDBSuccess);
+	REQUIRE(file != nullptr);
+
+	// Write to the file
+	const char *data = "Hello, DuckDB File System!";
+	int64_t bytes_written = duckdb_file_handle_write(file, data, strlen(data));
+	REQUIRE(bytes_written == (int64_t)strlen(data));
+	int64_t position = duckdb_file_handle_tell(file);
+	REQUIRE(position == bytes_written);
+	int64_t size = duckdb_file_handle_size(file);
+	REQUIRE(size == bytes_written);
+
+	// Seek to the beginning
+	state = duckdb_file_handle_seek(file, 0);
+	REQUIRE(state == DuckDBSuccess);
+	position = duckdb_file_handle_tell(file);
+	REQUIRE(position == 0);
+
+	// Read from the file
+	char buffer[30];
+	memset(buffer, 0, sizeof(buffer));
+	int64_t bytes_read = duckdb_file_handle_read(file, buffer, sizeof(buffer) - 1);
+	REQUIRE(bytes_read == bytes_written);
+	REQUIRE(strcmp(buffer, data) == 0);
+	position = duckdb_file_handle_tell(file);
+	REQUIRE(position == bytes_read);
+	size = duckdb_file_handle_size(file);
+	REQUIRE(size == bytes_written);
+
+	// Seek to the end
+	state = duckdb_file_handle_seek(file, bytes_written);
+	REQUIRE(state == DuckDBSuccess);
+	position = duckdb_file_handle_tell(file);
+	REQUIRE(position == bytes_written);
+	size = duckdb_file_handle_size(file);
+	REQUIRE(size == bytes_written);
+
+	// Try to read from the end of the file
+	memset(buffer, 0, sizeof(buffer));
+	bytes_read = duckdb_file_handle_read(file, buffer, sizeof(buffer) - 1);
+	REQUIRE(bytes_read == 0); // EOF
+	position = duckdb_file_handle_tell(file);
+	REQUIRE(position == bytes_written);
+	size = duckdb_file_handle_size(file);
+	REQUIRE(size == bytes_written);
+
+	// Close the file
+	state = duckdb_file_handle_seek(file, 0);
+	REQUIRE(state == DuckDBSuccess);
+	position = duckdb_file_handle_tell(file);
+	REQUIRE(position == 0);
+	size = duckdb_file_handle_size(file);
+	REQUIRE(size == bytes_written);
+
+	// Free resources
+	duckdb_destroy_file_handle(&file);
+	duckdb_destroy_file_open_options(&options);
+}
+
+TEST_CASE("Test File System in C API", "[capi]") {
+	CAPITester tester;
+	duckdb_file_system fs;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	duckdb_connection_get_file_system(tester.connection, &fs);
+	REQUIRE(fs != nullptr);
+
+	test_file_system(fs, "test_file_capi_1.txt");
+
+	duckdb_destroy_file_system(&fs);
+	REQUIRE(fs == nullptr);
+
+	// get a file system from the client context as well
+	duckdb_client_context context;
+	duckdb_connection_get_client_context(tester.connection, &context);
+
+	duckdb_client_context_get_file_system(context, &fs);
+	REQUIRE(fs != nullptr);
+
+	test_file_system(fs, "test_file_capi_2.txt");
+
+	duckdb_destroy_file_system(&fs);
+	REQUIRE(fs == nullptr);
+
+	duckdb_destroy_client_context(&context);
+}


### PR DESCRIPTION
This PR adds initial support for accessing DuckDB's filesystem layer from the C-API. 

With the current state of the C-API this is primarily useful when writing table functions that scan some external file format, as it allows you to make use of DuckDBs existing cross platform filesystem, as well as any loaded extension file systems (like httpfs), without having to reimplement the equivalent functionality yourself.

I've tried to keep this initial version of the interface as small and simple as possible, while also leaving room to expand it in the future. The most complex part is the error handling, but I think I've solved it relatively neatly by having both the `duckdb_file_system` and `duckdb_file_handle` store their last occurred error internally, which can then be converted to `duckdb_error_data` through a pair of separate functions. Other than that the read/write functions follow posix semantics, returning the number of bytes read/written, 0 on EOF and a negative value on error. In practice the error value is always `-1`, but I've left it unspecified so that we can potentially return specific error codes in the future (like something like EAGAIN, when we get asyncio), without forcing the user to allocate, inspect and destroy a `duckdb_error_data` object to handle "common" IO errors.