### PR TITLE
[C-API] Filter Pushdown

### DIFF
--- a/src/include/duckdb/main/capi/header_generation/functions/table_function_init.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_function_init.json
@@ -102,6 +102,178 @@
             }
         },
         {
+            "name": "duckdb_init_get_filter_count",
+            "return_type": "idx_t",
+            "params": [
+                {
+                    "type": "duckdb_init_info",
+                    "name": "info"
+                }
+            ],
+            "comment": {
+                "description": "Returns the number of filter predicate trees that were pushed into the table function.\n\nThe returned filters can be inspected through `duckdb_init_get_filter`. Only predicates composed of the comparison operators `=`, `!=`, `>`, `<`, `>=`, and `<=`, optionally combined through AND/OR, are reported through this interface.\n\n",
+                "param_comments": {
+                    "info": "The info object"
+                },
+                "return_value": "The number of pushed filters supported by the C API."
+            }
+        },
+        {
+            "name": "duckdb_init_get_filter",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_init_info",
+                    "name": "info"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "filter_index"
+                },
+                {
+                    "type": "duckdb_table_function_filter *",
+                    "name": "out_filter"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the pushed filter tree at the specified index.\n\nThe index must be smaller than the value returned by `duckdb_init_get_filter_count`. The returned filter handle must be destroyed with `duckdb_destroy_table_function_filter` when it is no longer needed. Use `duckdb_table_function_filter_get_type`, `duckdb_table_function_filter_get_child_count`, `duckdb_table_function_filter_get_child`, `duckdb_table_function_filter_get_column_index`, `duckdb_table_function_filter_get_operator`, and `duckdb_table_function_filter_get_constant` to inspect the tree. The value returned by `duckdb_table_function_filter_get_constant` must be destroyed with `duckdb_destroy_value` when it is no longer needed.\n\n",
+                "param_comments": {
+                    "info": "The info object",
+                    "filter_index": "The index of the filter to fetch, from 0..duckdb_init_get_filter_count(info)",
+                    "out_filter": "The output filter handle."
+                },
+                "return_value": "`DuckDBSuccess` on success or `DuckDBError` if the filter index is invalid."
+            }
+        },
+        {
+            "name": "duckdb_table_function_filter_get_column_index",
+            "return_type": "idx_t",
+            "params": [
+                {
+                    "type": "duckdb_table_function_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the column index the pushed filter applies to.\n\n",
+                "param_comments": {
+                    "filter": "The filter handle."
+                },
+                "return_value": "The column index of the filter or 0 if the handle is invalid."
+            }
+        },
+        {
+            "name": "duckdb_table_function_filter_get_type",
+            "return_type": "duckdb_table_filter_type",
+            "params": [
+                {
+                    "type": "duckdb_table_function_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the node type of the pushed filter.\n\n",
+                "param_comments": {
+                    "filter": "The filter handle."
+                },
+                "return_value": "The node type of the filter. Returns `DUCKDB_TABLE_FILTER_TYPE_INVALID` if the handle is invalid."
+            }
+        },
+        {
+            "name": "duckdb_table_function_filter_get_operator",
+            "return_type": "duckdb_table_filter_operator",
+            "params": [
+                {
+                    "type": "duckdb_table_function_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the comparison operator of the pushed filter.\n\n",
+                "param_comments": {
+                    "filter": "The filter handle."
+                },
+                "return_value": "The comparison operator of the filter. Returns `DUCKDB_TABLE_FILTER_OPERATOR_INVALID` if the handle is invalid."
+            }
+        },
+        {
+            "name": "duckdb_table_function_filter_get_constant",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_table_function_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the constant value the pushed filter compares against.\n\nThe returned value must be destroyed with `duckdb_destroy_value` when it is no longer needed.\n\n",
+                "param_comments": {
+                    "filter": "The filter handle."
+                },
+                "return_value": "The constant value of the filter."
+            }
+        },
+        {
+            "name": "duckdb_table_function_filter_get_child_count",
+            "return_type": "idx_t",
+            "params": [
+                {
+                    "type": "duckdb_table_function_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the number of child predicates of the pushed filter node.\n\n",
+                "param_comments": {
+                    "filter": "The filter handle."
+                },
+                "return_value": "The number of child predicates. Returns 0 if the handle is invalid or the node has no children."
+            }
+        },
+        {
+            "name": "duckdb_table_function_filter_get_child",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_table_function_filter",
+                    "name": "filter"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "index"
+                },
+                {
+                    "type": "duckdb_table_function_filter *",
+                    "name": "out_child"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves a child predicate of the pushed filter node.\n\nThe index must be smaller than the value returned by `duckdb_table_function_filter_get_child_count`. The returned filter handle must be destroyed with `duckdb_destroy_table_function_filter` when it is no longer needed.\n\n",
+                "param_comments": {
+                    "filter": "The filter handle.",
+                    "index": "The index of the child to fetch, from 0..duckdb_table_function_filter_get_child_count(filter)",
+                    "out_child": "The output child filter handle."
+                },
+                "return_value": "`DuckDBSuccess` on success or `DuckDBError` if the filter or index is invalid."
+            }
+        },
+        {
+            "name": "duckdb_destroy_table_function_filter",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_table_function_filter *",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Destroys the given table function filter handle.\n\n",
+                "param_comments": {
+                    "filter": "The filter handle to destroy."
+                }
+            }
+        },
+        {
             "name": "duckdb_init_set_max_threads",
             "return_type": "void",
             "params": [

--- a/src/include/duckdb/main/capi/header_generation/functions/table_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_functions.json
@@ -227,6 +227,27 @@
             }
         },
         {
+            "name": "duckdb_table_function_supports_filter_pushdown",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_table_function",
+                    "name": "table_function"
+                },
+                {
+                    "type": "bool",
+                    "name": "pushdown"
+                }
+            ],
+            "comment": {
+                "description": "Sets whether or not the given table function supports filter pushdown.\n\nIf this is set to true, the system will provide filters that can be inspected in the `init` stage through the `duckdb_init_get_filter_count` and `duckdb_init_get_filter` functions.\nIf this is set to false (the default), the system will apply filters after the table function has produced its data.\n\n",
+                "param_comments": {
+                    "table_function": "The table function",
+                    "pushdown": "True if the table function supports filter pushdown, false otherwise."
+                }
+            }
+        },
+        {
             "name": "duckdb_register_table_function",
             "return_type": "duckdb_state",
             "params": [

--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -6,6 +6,8 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb/storage/statistics/node_statistics.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/conjunction_filter.hpp"
 
 namespace duckdb {
 
@@ -115,6 +117,31 @@ struct CTableInternalFunctionInfo {
 	string error;
 };
 
+struct CTableFilterNode {
+	CTableFilterNode(idx_t column_index, TableFilterType filter_type)
+	    : column_index(column_index), filter_type(filter_type), comparison_type(ExpressionType::INVALID),
+	      has_comparison(false) {
+	}
+
+	idx_t column_index;
+	TableFilterType filter_type;
+	ExpressionType comparison_type;
+	bool has_comparison;
+	Value constant;
+	vector<unique_ptr<CTableFilterNode>> children;
+
+	unique_ptr<CTableFilterNode> Copy() const {
+		auto result = make_uniq<CTableFilterNode>(column_index, filter_type);
+		result->comparison_type = comparison_type;
+		result->has_comparison = has_comparison;
+		result->constant = constant;
+		for (auto &child : children) {
+			result->children.push_back(child->Copy());
+		}
+		return result;
+	}
+};
+
 //===--------------------------------------------------------------------===//
 // Helper Functions
 //===--------------------------------------------------------------------===//
@@ -148,6 +175,100 @@ duckdb::CTableInternalFunctionInfo &GetCTableFunctionInfo(duckdb_function_info i
 
 duckdb_function_info ToCTableFunctionInfo(duckdb::CTableInternalFunctionInfo &info) {
 	return reinterpret_cast<duckdb_function_info>(&info);
+}
+
+static duckdb::CTableFilterNode *GetCTableFunctionFilter(duckdb_table_function_filter filter) {
+	return reinterpret_cast<duckdb::CTableFilterNode *>(filter);
+}
+
+static duckdb_table_function_filter ToCTableFunctionFilter(duckdb::CTableFilterNode *filter) {
+	return reinterpret_cast<duckdb_table_function_filter>(filter);
+}
+
+static bool ExpressionTypeToFilterOperator(ExpressionType type, duckdb_table_filter_operator &result) {
+	switch (type) {
+	case ExpressionType::COMPARE_EQUAL:
+		result = DUCKDB_TABLE_FILTER_OPERATOR_EQUAL;
+		return true;
+	case ExpressionType::COMPARE_NOTEQUAL:
+		result = DUCKDB_TABLE_FILTER_OPERATOR_NOT_EQUAL;
+		return true;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		result = DUCKDB_TABLE_FILTER_OPERATOR_GREATER_THAN;
+		return true;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		result = DUCKDB_TABLE_FILTER_OPERATOR_GREATER_THAN_OR_EQUAL;
+		return true;
+	case ExpressionType::COMPARE_LESSTHAN:
+		result = DUCKDB_TABLE_FILTER_OPERATOR_LESS_THAN;
+		return true;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		result = DUCKDB_TABLE_FILTER_OPERATOR_LESS_THAN_OR_EQUAL;
+		return true;
+	default:
+		result = DUCKDB_TABLE_FILTER_OPERATOR_INVALID;
+		return false;
+	}
+}
+
+static duckdb_table_filter_type TableFilterTypeToFilterType(TableFilterType type) {
+	switch (type) {
+	case TableFilterType::CONSTANT_COMPARISON:
+		return DUCKDB_TABLE_FILTER_TYPE_CONSTANT_COMPARISON;
+	case TableFilterType::CONJUNCTION_AND:
+		return DUCKDB_TABLE_FILTER_TYPE_CONJUNCTION_AND;
+	default:
+		return DUCKDB_TABLE_FILTER_TYPE_INVALID;
+	}
+}
+
+static unique_ptr<CTableFilterNode> ExtractFilterNode(idx_t column_index, const TableFilter &filter) {
+	switch (filter.filter_type) {
+	case TableFilterType::CONSTANT_COMPARISON: {
+		auto &constant_filter = filter.Cast<ConstantFilter>();
+		duckdb_table_filter_operator op;
+		if (!ExpressionTypeToFilterOperator(constant_filter.comparison_type, op)) {
+			return nullptr;
+		}
+		auto result = make_uniq<CTableFilterNode>(column_index, TableFilterType::CONSTANT_COMPARISON);
+		result->comparison_type = constant_filter.comparison_type;
+		result->has_comparison = true;
+		result->constant = constant_filter.constant;
+		return result;
+	}
+	case TableFilterType::CONJUNCTION_AND: {
+		auto &and_filter = filter.Cast<ConjunctionAndFilter>();
+		auto result = make_uniq<CTableFilterNode>(column_index, TableFilterType::CONJUNCTION_AND);
+		for (auto &child : and_filter.child_filters) {
+			auto child_node = ExtractFilterNode(column_index, *child);
+			if (!child_node) {
+				return nullptr;
+			}
+			result->children.push_back(std::move(child_node));
+		}
+		return result;
+	}
+	default:
+		return nullptr;
+	}
+}
+
+static vector<unique_ptr<CTableFilterNode>> ExtractFilters(optional_ptr<TableFilterSet> filters) {
+	vector<unique_ptr<CTableFilterNode>> result;
+	if (!filters) {
+		return result;
+	}
+	for (auto &entry : filters->filters) {
+		if (!entry.second) {
+			continue;
+		}
+		auto filter_node = ExtractFilterNode(entry.first, *entry.second);
+		if (!filter_node) {
+			continue;
+		}
+		result.push_back(std::move(filter_node));
+	}
+	return result;
 }
 
 //===--------------------------------------------------------------------===//
@@ -319,6 +440,14 @@ void duckdb_table_function_supports_projection_pushdown(duckdb_table_function ta
 	}
 	auto &tf = GetCTableFunction(table_function);
 	tf.projection_pushdown = pushdown;
+}
+
+void duckdb_table_function_supports_filter_pushdown(duckdb_table_function table_function, bool pushdown) {
+	if (!table_function) {
+		return;
+	}
+	auto &tf = GetCTableFunction(table_function);
+	tf.filter_pushdown = pushdown;
 }
 
 duckdb_state duckdb_register_table_function(duckdb_connection connection, duckdb_table_function function) {
@@ -508,6 +637,127 @@ idx_t duckdb_init_get_column_index(duckdb_init_info info, idx_t column_index) {
 		return 0;
 	}
 	return init_info.column_ids[column_index];
+}
+
+idx_t duckdb_init_get_filter_count(duckdb_init_info info) {
+	if (!info) {
+		return 0;
+	}
+	auto &init_info = GetCInitInfo(info);
+	auto filters = ExtractFilters(init_info.filters);
+	return filters.size();
+}
+
+duckdb_state duckdb_init_get_filter(duckdb_init_info info, idx_t filter_index,
+                                    duckdb_table_function_filter *out_filter) {
+	if (!info || !out_filter) {
+		return DuckDBError;
+	}
+	*out_filter = nullptr;
+
+	auto &init_info = GetCInitInfo(info);
+	auto filters = ExtractFilters(init_info.filters);
+	if (filter_index >= filters.size()) {
+		return DuckDBError;
+	}
+	auto filter_handle = filters[filter_index].release();
+	*out_filter = ToCTableFunctionFilter(filter_handle);
+	return DuckDBSuccess;
+}
+
+idx_t duckdb_table_function_filter_get_column_index(duckdb_table_function_filter filter) {
+	if (!filter) {
+		return 0;
+	}
+	auto *internal = duckdb::GetCTableFunctionFilter(filter);
+	if (!internal) {
+		return 0;
+	}
+	return internal->column_index;
+}
+
+duckdb_table_filter_type duckdb_table_function_filter_get_type(duckdb_table_function_filter filter) {
+	if (!filter) {
+		return DUCKDB_TABLE_FILTER_TYPE_INVALID;
+	}
+	auto *internal = duckdb::GetCTableFunctionFilter(filter);
+	if (!internal) {
+		return DUCKDB_TABLE_FILTER_TYPE_INVALID;
+	}
+	return TableFilterTypeToFilterType(internal->filter_type);
+}
+
+duckdb_table_filter_operator duckdb_table_function_filter_get_operator(duckdb_table_function_filter filter) {
+	if (!filter) {
+		return DUCKDB_TABLE_FILTER_OPERATOR_INVALID;
+	}
+	auto *internal = duckdb::GetCTableFunctionFilter(filter);
+	if (!internal) {
+		return DUCKDB_TABLE_FILTER_OPERATOR_INVALID;
+	}
+	if (!internal->has_comparison) {
+		return DUCKDB_TABLE_FILTER_OPERATOR_INVALID;
+	}
+	duckdb_table_filter_operator result;
+	if (!ExpressionTypeToFilterOperator(internal->comparison_type, result)) {
+		return DUCKDB_TABLE_FILTER_OPERATOR_INVALID;
+	}
+	return result;
+}
+
+duckdb_value duckdb_table_function_filter_get_constant(duckdb_table_function_filter filter) {
+	if (!filter) {
+		return nullptr;
+	}
+	auto *internal = duckdb::GetCTableFunctionFilter(filter);
+	if (!internal) {
+		return nullptr;
+	}
+	if (!internal->has_comparison) {
+		return nullptr;
+	}
+	return reinterpret_cast<duckdb_value>(new Value(internal->constant));
+}
+
+idx_t duckdb_table_function_filter_get_child_count(duckdb_table_function_filter filter) {
+	if (!filter) {
+		return 0;
+	}
+	auto *internal = duckdb::GetCTableFunctionFilter(filter);
+	if (!internal) {
+		return 0;
+	}
+	return internal->children.size();
+}
+
+duckdb_state duckdb_table_function_filter_get_child(duckdb_table_function_filter filter, idx_t index,
+                                                    duckdb_table_function_filter *out_child) {
+	if (!filter || !out_child) {
+		return DuckDBError;
+	}
+	*out_child = nullptr;
+	auto *internal = duckdb::GetCTableFunctionFilter(filter);
+	if (!internal) {
+		return DuckDBError;
+	}
+	if (index >= internal->children.size()) {
+		return DuckDBError;
+	}
+	auto child_copy = internal->children[index]->Copy();
+	if (!child_copy) {
+		return DuckDBError;
+	}
+	*out_child = ToCTableFunctionFilter(child_copy.release());
+	return DuckDBSuccess;
+}
+
+void duckdb_destroy_table_function_filter(duckdb_table_function_filter *filter) {
+	if (!filter || !*filter) {
+		return;
+	}
+	auto *internal = duckdb::GetCTableFunctionFilter(*filter);
+	delete internal;
+	*filter = nullptr;
 }
 
 void duckdb_init_set_max_threads(duckdb_init_info info, idx_t max_threads) {


### PR DESCRIPTION
This PR does the following:

* Exposes C-APIs for marking table functions as supporting filter pushdown
* Exposes constant predicates and `AND` clauses
* Supports `=`, `!=`, `<`, `>`, `<=`, `>=` operators (easily extendable in the future)
* Implements tests for these operators
* Attempted to make the whole API match the existing C API, in that the filters are opaque pointers navigated by getter functions

--

My C++ is a bit rusty, please let me know if there's some coding conventions or best practices I'm missing. I attempted to make sure the coding style and constructs match the rest of the codebase. 