### PR TITLE
fix: check tree depth and flatten dep join for custom operator extension

### DIFF
--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -48,10 +48,6 @@ void Planner::CreatePlan(SQLStatement &statement) {
 		this->names = bound_statement.names;
 		this->types = bound_statement.types;
 		this->plan = std::move(bound_statement.plan);
-		auto max_tree_depth = ClientConfig::GetConfig(context).max_expression_depth;
-		CheckTreeDepth(*plan, max_tree_depth);
-
-		this->plan = FlattenDependentJoins::DecorrelateIndependent(*binder, std::move(this->plan));
 	} catch (const std::exception &ex) {
 		ErrorData error(ex);
 		this->plan = nullptr;
@@ -70,11 +66,6 @@ void Planner::CreatePlan(SQLStatement &statement) {
 					this->names = bound_statement.names;
 					this->types = bound_statement.types;
 					this->plan = std::move(bound_statement.plan);
-
-					auto max_tree_depth = ClientConfig::GetConfig(context).max_expression_depth;
-					CheckTreeDepth(*plan, max_tree_depth);
-
-					this->plan = FlattenDependentJoins::DecorrelateIndependent(*this->binder, std::move(this->plan));
 					break;
 				}
 			}
@@ -84,6 +75,12 @@ void Planner::CreatePlan(SQLStatement &statement) {
 		} else {
 			throw;
 		}
+	}
+	if (this->plan) {
+		auto max_tree_depth = ClientConfig::GetConfig(context).max_expression_depth;
+		CheckTreeDepth(*plan, max_tree_depth);
+
+		this->plan = FlattenDependentJoins::DecorrelateIndependent(*this->binder, std::move(this->plan));
 	}
 	this->properties = binder->GetStatementProperties();
 	this->properties.parameter_count = parameter_count;

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -70,6 +70,11 @@ void Planner::CreatePlan(SQLStatement &statement) {
 					this->names = bound_statement.names;
 					this->types = bound_statement.types;
 					this->plan = std::move(bound_statement.plan);
+
+					auto max_tree_depth = ClientConfig::GetConfig(context).max_expression_depth;
+					CheckTreeDepth(*plan, max_tree_depth);
+
+					this->plan = FlattenDependentJoins::DecorrelateIndependent(*this->binder, std::move(this->plan));
 					break;
 				}
 			}


### PR DESCRIPTION
### Summary

In 1.3.x, https://github.com/duckdb/duckdb/pull/17294 flattens dependent joins after calling Bind on the statement. However, this wasn’t applied to custom operator extensions.

As a result, when we queried MotherDuck using our custom operator extension, we encountered unexpected operator errors. @Alex-Monahan can provide more context and detail on the error.

After tracking down the root cause, we applied the flatten call in our extension, which resolved the error.

```cpp
auto bound_statement = dxql_binder->Bind(*(dxql_parse_data->statement));
if (bound_statement.plan) {
    bound_statement.plan = FlattenDependentJoins::DecorrelateIndependent(*dxql_binder, std::move(bound_statement.plan));
}
return bound_statement;
```

We’re looking to make a fix in DuckDB because this issue would affect other custom operator extensions as well.

The current pull request copies the tree depth check and DecorrelateIndependent after calling the operator extensions.

I’m not sure if this is the correct fix and still have some open questions.

I’d appreciate any feedback and comments.

### Questions

**1. If we always want to apply the depth check and flatten call, should we move it after the try-catch block?**

For example:

```cpp
bool parameters_resolved = true;
try {
   // bind the statement
} catch (const std::exception &ex) {
   // handle exception
}

if (this->plan) {
  auto max_tree_depth = ClientConfig::GetConfig(context).max_expression_depth;
  CheckTreeDepth(*plan, max_tree_depth);
  this->plan = FlattenDependentJoins::DecorrelateIndependent(*binder, std::move(this->plan));
}
```


But is the current try-catch block handling errors for this logic as well?

**2. `DecorrelateIndependent` takes a binder, and the current PR passes in this->binder. Will this work if the statement is bound with a different binder from the extension?**

For our specific case, this is how we created the binder:

```cpp
auto dxql_binder = Binder::CreateBinder(context, &binder);
```

**3. Where should the custom operator extension fit in the long term?**

For future improvements to the execution plan logic, should custom operator extensions automatically benefit from these improvements, or should it be up to the extension maintainer to update and maintain parity?

I haven’t yet created a reproducible case with local DuckDB, so this error may not occur locally.