### PR TITLE
Perform deduplication based on join_keys when building ht

### DIFF
--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -277,6 +277,8 @@ public:
 	uint64_t bitmask = DConstants::INVALID_INDEX;
 	//! Whether or not we error on multiple rows found per match in a SINGLE join
 	bool single_join_error_on_multiple_rows = true;
+	//! Whether or not to perform deduplication based on join_keys when building ht
+	bool insert_duplicate_keys = true;
 
 	struct {
 		mutex mj_lock;


### PR DESCRIPTION
When building a hash table in the `PhysicalHashJoin` operator, in some cases, if the `join_keys` is duplicated, it is actually not necessary to insert it. For example, the `join_type` is SEMI and the join condition is a equality condition.