### PR TITLE
Bump httpfs

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 354d3f436a33f80f03a74419e76eb59459e19168
+    GIT_TAG 1f137f7962327054392d83b8a46b48850fb184b2
     INCLUDE_DIR extension/httpfs/include
 )

--- a/test/sql/copy/s3/metadata_cache.test
+++ b/test/sql/copy/s3/metadata_cache.test
@@ -38,12 +38,12 @@ CREATE TABLE test1 as SELECT * FROM range(10,20) tbl(i);
 query II
 EXPLAIN ANALYZE COPY test TO 's3://test-bucket-public/root-dir/metadata_cache/test.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 0.*PUT\: 1.*\#POST\: 2.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 0.*PUT\: 1.*\#POST\: 0.*
 
 query II
 EXPLAIN ANALYZE COPY test TO 's3://test-bucket-public/root-dir/metadata_cache/test1.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 0.*PUT\: 1.*\#POST\: 2.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 0.*PUT\: 1.*\#POST\: 0.*
 
 # Now we query the file metadata without the global metadata cache: There should be 1 HEAD request for the file size,
 # then a GET for the pointer to the parquet metadata, then a GET for the metadata.


### PR DESCRIPTION
Diff: https://github.com/duckdb/duckdb-httpfs/compare/354d3f436a33f80f03a74419e76eb59459e19168..1f137f7962327054392d83b8a46b48850fb184b2

Relevant changes:
* when doing multipart uplaod, and uploading a single buffer, we do a single PUT (instead of POST + PUT + POST), changing also connected test
* update User-Agent header to use DuckDB's UserAgent in more (most? all?) cases