### PR TITLE
Skip serialization of row_start in DataPointer when targeting latest storage

### DIFF
--- a/src/include/duckdb/storage/serialization/storage.json
+++ b/src/include/duckdb/storage/serialization/storage.json
@@ -110,7 +110,9 @@
       {
         "id": 100,
         "name": "row_start",
-        "type": "uint64_t"
+        "type": "uint64_t",
+        "status": "deleted",
+        "version": "7"
       },
       {
         "id": 101,

--- a/src/storage/serialization/serialize_storage.cpp
+++ b/src/storage/serialization/serialize_storage.cpp
@@ -25,7 +25,9 @@ BlockPointer BlockPointer::Deserialize(Deserializer &deserializer) {
 }
 
 void DataPointer::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<uint64_t>(100, "row_start", row_start);
+	if (!serializer.ShouldSerialize(6)) {
+		serializer.WritePropertyWithDefault<uint64_t>(100, "row_start", row_start);
+	}
 	serializer.WritePropertyWithDefault<uint64_t>(101, "tuple_count", tuple_count);
 	serializer.WriteProperty<BlockPointer>(102, "block_pointer", block_pointer);
 	serializer.WriteProperty<CompressionType>(103, "compression_type", compression_type);
@@ -34,13 +36,12 @@ void DataPointer::Serialize(Serializer &serializer) const {
 }
 
 DataPointer DataPointer::Deserialize(Deserializer &deserializer) {
-	auto row_start = deserializer.ReadPropertyWithDefault<uint64_t>(100, "row_start");
+	deserializer.ReadDeletedProperty<uint64_t>(100, "row_start");
 	auto tuple_count = deserializer.ReadPropertyWithDefault<uint64_t>(101, "tuple_count");
 	auto block_pointer = deserializer.ReadProperty<BlockPointer>(102, "block_pointer");
 	auto compression_type = deserializer.ReadProperty<CompressionType>(103, "compression_type");
 	auto statistics = deserializer.ReadProperty<BaseStatistics>(104, "statistics");
 	DataPointer result(std::move(statistics));
-	result.row_start = row_start;
 	result.tuple_count = tuple_count;
 	result.block_pointer = block_pointer;
 	result.compression_type = compression_type;


### PR DESCRIPTION

Writing the start row for column segments is not useful - since we already have the start position of the row group, we can just set the start row for each column segment to the correct location. This is now done already as well in https://github.com/duckdb/duckdb/pull/19055 as this actually resolved a bug with these start positions being written incorrectly.

This PR removes the start row positions when targeting the latest storage version. As a result, we write less metadata at no loss of information. For example, for `hits`, the total metadata size decreases from 14MB to 12MB as a result of this change. 