### PR TITLE
fix: Make DirectFileReader compatible with pipe filehandles (using CachingFileHandle to read)

### DIFF
--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -81,7 +81,7 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 
 BufferHandle CachingFileHandle::Read(data_ptr_t &buffer, const idx_t nr_bytes, const idx_t location) {
 	BufferHandle result;
-	if (!external_file_cache.IsEnabled()) {
+	if (!external_file_cache.IsEnabled() || GetFileHandle().IsPipe()) {
 		result = external_file_cache.GetBufferManager().Allocate(MemoryTag::EXTERNAL_FILE_CACHE, nr_bytes);
 		buffer = result.Ptr();
 		GetFileHandle().Read(context, buffer, nr_bytes, location);


### PR DESCRIPTION
This is PR that enhances CachingFileHandle to handle the reads from file handles that are pipes.  It's should be compared to the code in https://github.com/duckdb/duckdb/pull/18985.

@lnkuiper, @Maxxen do you guys think this the better way even with the extra data copy?
