### PR TITLE
restore 1.3.2 behavior for json_type(JSON[])

### DIFF
--- a/extension/json/json_functions/json_type.cpp
+++ b/extension/json/json_functions/json_type.cpp
@@ -27,7 +27,6 @@ static void ListJSONContainerTypeFunction(DataChunk &args, ExpressionState &stat
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		auto data = ConstantVector::GetData<string_t>(result);
 		auto &validity = ConstantVector::Validity(result);
-		
 		if (!input.validity.RowIsValid(0)) {
 			validity.SetInvalid(0);
 		} else {

--- a/extension/json/json_functions/json_type.cpp
+++ b/extension/json/json_functions/json_type.cpp
@@ -18,6 +18,37 @@ static void ManyTypeFunction(DataChunk &args, ExpressionState &state, Vector &re
 	JSONExecutors::ExecuteMany<string_t>(args, state, result, GetType);
 }
 
+static void ListJSONContainerTypeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	const idx_t count = args.size();
+	UnifiedVectorFormat input;
+	args.data[0].ToUnifiedFormat(count, input);
+
+	if (args.AllConstant()) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto data = ConstantVector::GetData<string_t>(result);
+		auto &validity = ConstantVector::Validity(result);
+		
+		if (!input.validity.RowIsValid(0)) {
+			validity.SetInvalid(0);
+		} else {
+			*data = StringVector::AddString(result, "ARRAY");
+		}
+	} else {
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		auto data = FlatVector::GetData<string_t>(result);
+		auto &validity = FlatVector::Validity(result);
+
+		for (idx_t i = 0; i < count; i++) {
+			const auto idx = input.sel->get_index(i);
+			if (!input.validity.RowIsValid(idx)) {
+				validity.SetInvalid(i);
+				continue;
+			}
+			data[i] = StringVector::AddString(result, "ARRAY");
+		}
+	}
+}
+
 static void GetTypeFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
 	set.AddFunction(ScalarFunction({input_type}, LogicalType::VARCHAR, UnaryTypeFunction, nullptr, nullptr, nullptr,
 	                               JSONFunctionLocalState::Init));
@@ -28,10 +59,17 @@ static void GetTypeFunctionsInternal(ScalarFunctionSet &set, const LogicalType &
 	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
 }
 
+static void GetTypeFunctionsForListJSON(ScalarFunctionSet &set) {
+	set.AddFunction(ScalarFunction({LogicalType::LIST(LogicalType::JSON())}, LogicalType::VARCHAR,
+	                               ListJSONContainerTypeFunction, nullptr, nullptr, nullptr,
+	                               JSONFunctionLocalState::Init));
+}
+
 ScalarFunctionSet JSONFunctions::GetTypeFunction() {
 	ScalarFunctionSet set("json_type");
 	GetTypeFunctionsInternal(set, LogicalType::VARCHAR);
 	GetTypeFunctionsInternal(set, LogicalType::JSON());
+	GetTypeFunctionsForListJSON(set);
 	return set;
 }
 

--- a/test/sql/json/scalar/json_type_list_compat.test
+++ b/test/sql/json/scalar/json_type_list_compat.test
@@ -1,6 +1,6 @@
 # name: test/sql/json/scalar/json_type_list_compat.test
 # description: Test json_type function with LIST(JSON) input
-# group: [json]
+# group: [scalar]
 
 require json
 

--- a/test/sql/json/scalar/json_type_list_compat.test
+++ b/test/sql/json/scalar/json_type_list_compat.test
@@ -1,0 +1,44 @@
+# name: test/sql/json/scalar/json_type_list_compat.test
+# description: Test json_type function with LIST(JSON) input
+# group: [json]
+
+require json
+
+query T
+SELECT json_type(json_extract('{"duck":[1,2,3]}', '$..duck'));
+----
+ARRAY
+
+query T
+SELECT json_type(json_extract('{"duck":[1,2,3]}', '$.duck[*]'));
+----
+ARRAY
+
+query T
+SELECT json_type(json_extract('{"a":{"duck":[1]},"b":{"duck":[2,3]}}', '$..duck'));
+----
+ARRAY
+
+query T
+SELECT json_type(json_extract(doc, '$..duck')) FROM (VALUES
+('{"duck":[1,2,3]}'),
+('{"nested":{"duck":[4]}}')
+) t(doc);
+----
+ARRAY
+ARRAY
+
+query T
+SELECT json_type(CAST(json_extract('{"duck":[1,2,3]}', '$..duck') AS VARCHAR));
+----
+ARRAY
+
+query T
+SELECT json_type(json_extract('{"duck":42}', '$.duck'));
+----
+UBIGINT
+
+query T
+SELECT json_type(json_extract('{"duck":true}', '$.duck'));
+----
+BOOLEAN

--- a/test/sql/json/scalar/test_json_type.test
+++ b/test/sql/json/scalar/test_json_type.test
@@ -218,3 +218,19 @@ query T
 SELECT json_type('{"a":[2,3.5,true,false,null,"x"]}','$.a[6]');
 ----
 NULL
+
+# test LIST(JSON) compatibility
+query T
+select json_type(json_extract('{"duck":[1,2,3]}', '$..duck'))
+----
+ARRAY
+
+query T
+select json_type(json_extract('{"a":{"duck":[1]},"b":{"duck":[2,3]}}', '$..duck'))
+----
+ARRAY
+
+query T
+select json_type(json_extract('{"duck":[1,2,3]}', '$.duck[*]'))
+----
+ARRAY


### PR DESCRIPTION
Added json_type(LIST(JSON)) -> VARCHAR overload returning scalar "ARRAY" to restore 1.3.2 compatibility.

### Testing
* Local CLI (in-memory):
  * `SELECT json_extract('{"duck": [1, 2, 3]}', '$..duck') AS working;` → `[1,2,3]`
  * `SELECT typeof(json_extract('{"duck": [1, 2, 3]}', '$..duck')) AS working;` → `JSON[]`
  * `SELECT json_type(json_extract('{"duck": [1, 2, 3]}', '$..duck')) AS erroring;` → `ARRAY`
* Added Unit tests

fix #19068