### PR TITLE
Fix unholy interaction between `CREATE VIEW` and `CTE` definitions

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -118,8 +118,6 @@ public:
 	ClientContext &context;
 	//! A mapping of names to common table expressions
 	case_insensitive_set_t CTE_bindings; // NOLINT
-	//! The CTEs that have already been bound
-	reference_set_t<CommonTableExpressionInfo> bound_ctes;
 	//! The bind context
 	BindContext bind_context;
 	//! The set of correlated columns bound by this binder (FIXME: this should probably be an unordered_set and not a
@@ -367,7 +365,7 @@ private:
 	unique_ptr<BoundTableRef> Bind(BaseTableRef &ref);
 	unique_ptr<BoundTableRef> Bind(BoundRefWrapper &ref);
 	unique_ptr<BoundTableRef> Bind(JoinRef &ref);
-	unique_ptr<BoundTableRef> Bind(SubqueryRef &ref, optional_ptr<CommonTableExpressionInfo> cte = nullptr);
+	unique_ptr<BoundTableRef> Bind(SubqueryRef &ref);
 	unique_ptr<BoundTableRef> Bind(TableFunctionRef &ref);
 	unique_ptr<BoundTableRef> Bind(EmptyTableRef &ref);
 	unique_ptr<BoundTableRef> Bind(DelimGetRef &ref);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -188,7 +188,6 @@ public:
 	vector<reference<Binding>> FindCTE(const string &name, bool skip = false);
 
 	bool CTEExists(const string &name);
-	bool CTEIsAlreadyBound(CommonTableExpressionInfo &cte);
 
 	//! Add the view to the set of currently bound views - used for detecting recursive view definitions
 	void AddBoundView(ViewCatalogEntry &view);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -117,7 +117,7 @@ public:
 	//! The client context
 	ClientContext &context;
 	//! A mapping of names to common table expressions
-	case_insensitive_map_t<reference<CommonTableExpressionInfo>> CTE_bindings; // NOLINT
+	case_insensitive_set_t CTE_bindings; // NOLINT
 	//! The CTEs that have already been bound
 	reference_set_t<CommonTableExpressionInfo> bound_ctes;
 	//! The bind context
@@ -183,10 +183,11 @@ public:
 	                                           const EntryLookupInfo &lookup_info, OnEntryNotFound on_entry_not_found);
 
 	//! Add a common table expression to the binder
-	void AddCTE(const string &name, CommonTableExpressionInfo &cte);
+	void AddCTE(const string &name);
 	//! Find all candidate common table expression by name; returns empty vector if none exists
-	vector<reference<CommonTableExpressionInfo>> FindCTE(const string &name, bool skip = false);
+	vector<reference<Binding>> FindCTE(const string &name, bool skip = false);
 
+	bool CTEExists(const string &name);
 	bool CTEIsAlreadyBound(CommonTableExpressionInfo &cte);
 
 	//! Add the view to the set of currently bound views - used for detecting recursive view definitions

--- a/src/include/duckdb/planner/operator/logical_cteref.hpp
+++ b/src/include/duckdb/planner/operator/logical_cteref.hpp
@@ -20,9 +20,9 @@ public:
 
 public:
 	LogicalCTERef(idx_t table_index, idx_t cte_index, vector<LogicalType> types, vector<string> colnames,
-	              CTEMaterialize materialized_cte, bool is_recurring = false)
+	              bool is_recurring = false)
 	    : LogicalOperator(LogicalOperatorType::LOGICAL_CTE_REF), table_index(table_index), cte_index(cte_index),
-	      correlated_columns(0), materialized_cte(materialized_cte), is_recurring(is_recurring) {
+	      correlated_columns(0), is_recurring(is_recurring) {
 		D_ASSERT(!types.empty());
 		chunk_types = std::move(types);
 		bound_columns = std::move(colnames);
@@ -37,8 +37,6 @@ public:
 	vector<LogicalType> chunk_types;
 	//! Number of correlated columns
 	idx_t correlated_columns;
-	//! Does this operator read a materialized CTE?
-	CTEMaterialize materialized_cte;
 	//! Does this operator read the recurring CTE table
 	bool is_recurring = false;
 

--- a/src/include/duckdb/planner/tableref/bound_cteref.hpp
+++ b/src/include/duckdb/planner/tableref/bound_cteref.hpp
@@ -18,14 +18,14 @@ public:
 	static constexpr const TableReferenceType TYPE = TableReferenceType::CTE;
 
 public:
-	BoundCTERef(idx_t bind_index, idx_t cte_index, CTEMaterialize materialized_cte)
-	    : BoundTableRef(TableReferenceType::CTE), bind_index(bind_index), cte_index(cte_index),
-	      materialized_cte(materialized_cte) {
+	BoundCTERef(idx_t bind_index, idx_t cte_index)
+	    : BoundTableRef(TableReferenceType::CTE), bind_index(bind_index), cte_index(cte_index)
+	      {
 	}
 
-	BoundCTERef(idx_t bind_index, idx_t cte_index, CTEMaterialize materialized_cte, bool is_recurring)
+	BoundCTERef(idx_t bind_index, idx_t cte_index, bool is_recurring)
 	    : BoundTableRef(TableReferenceType::CTE), bind_index(bind_index), cte_index(cte_index),
-	      materialized_cte(materialized_cte), is_recurring(is_recurring) {
+	       is_recurring(is_recurring) {
 	}
 	//! The set of columns bound to this base table reference
 	vector<string> bound_columns;
@@ -35,8 +35,6 @@ public:
 	idx_t bind_index;
 	//! The index of the cte
 	idx_t cte_index;
-	//! Is this a reference to a materialized CTE?
-	CTEMaterialize materialized_cte;
 	//! Is this a reference to the recurring table of a CTE
 	bool is_recurring = false;
 };

--- a/src/include/duckdb/planner/tableref/bound_cteref.hpp
+++ b/src/include/duckdb/planner/tableref/bound_cteref.hpp
@@ -19,13 +19,12 @@ public:
 
 public:
 	BoundCTERef(idx_t bind_index, idx_t cte_index)
-	    : BoundTableRef(TableReferenceType::CTE), bind_index(bind_index), cte_index(cte_index)
-	      {
+	    : BoundTableRef(TableReferenceType::CTE), bind_index(bind_index), cte_index(cte_index) {
 	}
 
 	BoundCTERef(idx_t bind_index, idx_t cte_index, bool is_recurring)
 	    : BoundTableRef(TableReferenceType::CTE), bind_index(bind_index), cte_index(cte_index),
-	       is_recurring(is_recurring) {
+	      is_recurring(is_recurring) {
 	}
 	//! The set of columns bound to this base table reference
 	vector<string> bound_columns;

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -392,11 +392,6 @@
         "type": "vector<string>"
       },
       {
-        "id": 204,
-        "name": "materialized_cte",
-        "type": "CTEMaterialize"
-      },
-      {
         "id": 205,
         "name": "is_recurring",
         "type": "bool"
@@ -406,8 +401,7 @@
       "table_index",
       "cte_index",
       "chunk_types",
-      "bound_columns",
-      "materialized_cte"
+      "bound_columns"
     ]
   },
   {

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -249,7 +249,6 @@ unique_ptr<QueryNode> Transformer::TransformMaterializedCTE(unique_ptr<QueryNode
 	while (!materialized_ctes.empty()) {
 		unique_ptr<CTENode> node_result;
 		node_result = std::move(materialized_ctes.back());
-		node_result->cte_map = root->cte_map.Copy();
 		node_result->child = std::move(root);
 		root = std::move(node_result);
 		materialized_ctes.pop_back();

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -200,7 +200,7 @@ BoundStatement Binder::Bind(SQLStatement &statement) {
 
 void Binder::AddCTEMap(CommonTableExpressionMap &cte_map) {
 	for (auto &cte_it : cte_map.map) {
-		AddCTE(cte_it.first, *cte_it.second);
+		AddCTE(cte_it.first);
 	}
 }
 
@@ -343,28 +343,32 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundTableRef &ref) {
 	return root;
 }
 
-void Binder::AddCTE(const string &name, CommonTableExpressionInfo &info) {
+void Binder::AddCTE(const string &name) {
 	D_ASSERT(!name.empty());
-	auto entry = CTE_bindings.find(name);
-	if (entry != CTE_bindings.end()) {
-		throw InternalException("Duplicate CTE \"%s\" in query!", name);
-	}
-	CTE_bindings.insert(make_pair(name, reference<CommonTableExpressionInfo>(info)));
+	CTE_bindings.insert(name);
 }
 
-vector<reference<CommonTableExpressionInfo>> Binder::FindCTE(const string &name, bool skip) {
-	auto entry = CTE_bindings.find(name);
-	vector<reference<CommonTableExpressionInfo>> ctes;
-	if (entry != CTE_bindings.end()) {
-		if (!skip || entry->second.get().query->node->type == QueryNodeType::RECURSIVE_CTE_NODE) {
-			ctes.push_back(entry->second);
-		}
+vector<reference<Binding>> Binder::FindCTE(const string &name, bool skip) {
+	auto entry = bind_context.GetCTEBinding(name);
+	vector<reference<Binding>> ctes;
+	if (entry) {
+		ctes.push_back(*entry.get());
 	}
 	if (parent && binder_type == BinderType::REGULAR_BINDER) {
 		auto parent_ctes = parent->FindCTE(name, name == alias);
 		ctes.insert(ctes.end(), parent_ctes.begin(), parent_ctes.end());
 	}
 	return ctes;
+}
+
+bool Binder::CTEExists(const string &name) {
+	if (CTE_bindings.find(name) != CTE_bindings.end()) {
+		return true;
+	}
+	if (parent && binder_type == BinderType::REGULAR_BINDER) {
+		return parent->CTEExists(name);
+	}
+	return false;
 }
 
 bool Binder::CTEIsAlreadyBound(CommonTableExpressionInfo &cte) {

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -371,16 +371,6 @@ bool Binder::CTEExists(const string &name) {
 	return false;
 }
 
-bool Binder::CTEIsAlreadyBound(CommonTableExpressionInfo &cte) {
-	if (bound_ctes.find(cte) != bound_ctes.end()) {
-		return true;
-	}
-	if (parent && binder_type == BinderType::REGULAR_BINDER) {
-		return parent->CTEIsAlreadyBound(cte);
-	}
-	return false;
-}
-
 void Binder::AddBoundView(ViewCatalogEntry &view) {
 	// check if the view is already bound
 	auto current = this;

--- a/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_cte_node.cpp
@@ -27,6 +27,8 @@ unique_ptr<BoundCTENode> Binder::BindCTE(CTENode &statement) {
 	result->materialized = statement.materialized;
 	result->setop_index = GenerateTableIndex();
 
+	AddCTE(result->ctename);
+
 	result->query_binder = Binder::CreateBinder(context, this);
 	result->query = result->query_binder->BindNode(*statement.query);
 

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -123,30 +123,34 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 
 	// CTE name should never be qualified (i.e. schema_name should be empty)
 	// unless we want to refer to the recurring table of "using key".
-	vector<reference<CommonTableExpressionInfo>> found_ctes;
+	vector<reference<Binding>> found_ctes;
 	if (ref.schema_name.empty() || ref.schema_name == "recurring") {
-		found_ctes = FindCTE(ref.table_name, ref.table_name == alias);
+		found_ctes = FindCTE(ref.table_name, false);
 	}
 
 	if (!found_ctes.empty()) {
 		// Check if there is a CTE binding in the BindContext
 		bool circular_cte = false;
 		for (auto found_cte : found_ctes) {
-			auto &cte = found_cte.get();
 			auto ctebinding = bind_context.GetCTEBinding(ref.table_name);
 			if (ctebinding) {
 				// There is a CTE binding in the BindContext.
 				// This can only be the case if there is a recursive CTE,
 				// or a materialized CTE present.
 				auto index = GenerateTableIndex();
-				auto materialized = cte.materialized;
 
-				if (ref.schema_name == "recurring" && cte.key_targets.empty()) {
-					throw InvalidInputException("RECURRING can only be used with USING KEY in recursive CTE.");
+				if(ref.schema_name == "recurring") {
+					auto recurring_bindings = FindCTE("recurring." + ref.table_name, false);
+					if (recurring_bindings.empty()) {
+						throw BinderException(error_context, "There is a WITH item named \"%s\", but the recurring table cannot be "
+											                      "referenced from this part of the query."
+																  " Hint: RECURRING can only be used with USING KEY in recursive CTE.",
+											                      ref.table_name);
+					}
 				}
 
 				auto result =
-				    make_uniq<BoundCTERef>(index, ctebinding->index, materialized, ref.schema_name == "recurring");
+				    make_uniq<BoundCTERef>(index, ctebinding->index, ref.schema_name == "recurring");
 				auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
 				auto names = BindContext::AliasColumnNames(alias, ctebinding->names, ref.column_name_alias);
 
@@ -158,7 +162,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 				auto cteref = bind_context.cte_references[cte_reference];
 
 				if (cteref == nullptr && ref.schema_name == "recurring") {
-					throw BinderException("There is a WITH item named \"%s\", but the recurring table cannot be "
+					throw BinderException(error_context, "There is a WITH item named \"%s\", but the recurring table cannot be "
 					                      "referenced from this part of the query.",
 					                      ref.table_name);
 				}
@@ -169,26 +173,9 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 				result->bound_columns = std::move(names);
 				return std::move(result);
 			} else {
-				if (CTEIsAlreadyBound(cte)) {
-					// remember error state
-					circular_cte = true;
-					// retry with next candidate CTE
-					continue;
-				}
-
-				// If we have found a materialized CTE, but no corresponding CTE binding,
-				// something is wrong.
-				if (cte.materialized == CTEMaterialize::CTE_MATERIALIZE_ALWAYS) {
-					throw BinderException(
-					    "There is a WITH item named \"%s\", but it cannot be referenced from this part of the query.",
-					    ref.table_name);
-				}
-
-				if (ref.schema_name == "recurring") {
-					throw BinderException("There is a WITH item named \"%s\", but the recurring table cannot be "
-					                      "referenced from this part of the query.",
-					                      ref.table_name);
-				}
+				circular_cte = true;
+				// retry with next candidate CTE
+				continue;
 			}
 		}
 		if (circular_cte) {
@@ -197,7 +184,21 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 				return replacement_scan_bind_result;
 			}
 
-			throw BinderException(
+			throw BinderException(error_context,
+			    "Circular reference to CTE \"%s\", There are two possible solutions. \n1. use WITH RECURSIVE to "
+			    "use recursive CTEs. \n2. If "
+			    "you want to use the TABLE name \"%s\" the same as the CTE name, please explicitly add "
+			    "\"SCHEMA\" before table name. You can try \"main.%s\" (main is the duckdb default schema)",
+			    ref.table_name, ref.table_name, ref.table_name);
+		}
+	} else {
+		auto replacement_scan_bind_result = BindWithReplacementScan(context, ref);
+		if (replacement_scan_bind_result) {
+			return replacement_scan_bind_result;
+		}
+		// remember that we did not find a CTE
+		if (ref.schema_name.empty() && CTEExists(ref.table_name)) {
+			throw BinderException(error_context,
 			    "Circular reference to CTE \"%s\", There are two possible solutions. \n1. use WITH RECURSIVE to "
 			    "use recursive CTEs. \n2. If "
 			    "you want to use the TABLE name \"%s\" the same as the CTE name, please explicitly add "
@@ -343,7 +344,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		while (!materialized_ctes.empty()) {
 			unique_ptr<CTENode> node_result;
 			node_result = std::move(materialized_ctes.back());
-			node_result->cte_map = root->cte_map.Copy();
+//			node_result->cte_map = root->cte_map.Copy();
 			node_result->child = std::move(root);
 			root = std::move(node_result);
 			materialized_ctes.pop_back();

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -139,18 +139,18 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 				// or a materialized CTE present.
 				auto index = GenerateTableIndex();
 
-				if(ref.schema_name == "recurring") {
+				if (ref.schema_name == "recurring") {
 					auto recurring_bindings = FindCTE("recurring." + ref.table_name, false);
 					if (recurring_bindings.empty()) {
-						throw BinderException(error_context, "There is a WITH item named \"%s\", but the recurring table cannot be "
-											                      "referenced from this part of the query."
-																  " Hint: RECURRING can only be used with USING KEY in recursive CTE.",
-											                      ref.table_name);
+						throw BinderException(error_context,
+						                      "There is a WITH item named \"%s\", but the recurring table cannot be "
+						                      "referenced from this part of the query."
+						                      " Hint: RECURRING can only be used with USING KEY in recursive CTE.",
+						                      ref.table_name);
 					}
 				}
 
-				auto result =
-				    make_uniq<BoundCTERef>(index, ctebinding->index, ref.schema_name == "recurring");
+				auto result = make_uniq<BoundCTERef>(index, ctebinding->index, ref.schema_name == "recurring");
 				auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
 				auto names = BindContext::AliasColumnNames(alias, ctebinding->names, ref.column_name_alias);
 
@@ -162,7 +162,8 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 				auto cteref = bind_context.cte_references[cte_reference];
 
 				if (cteref == nullptr && ref.schema_name == "recurring") {
-					throw BinderException(error_context, "There is a WITH item named \"%s\", but the recurring table cannot be "
+					throw BinderException(error_context,
+					                      "There is a WITH item named \"%s\", but the recurring table cannot be "
 					                      "referenced from this part of the query.",
 					                      ref.table_name);
 				}
@@ -184,7 +185,8 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 				return replacement_scan_bind_result;
 			}
 
-			throw BinderException(error_context,
+			throw BinderException(
+			    error_context,
 			    "Circular reference to CTE \"%s\", There are two possible solutions. \n1. use WITH RECURSIVE to "
 			    "use recursive CTEs. \n2. If "
 			    "you want to use the TABLE name \"%s\" the same as the CTE name, please explicitly add "
@@ -198,7 +200,8 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		}
 		// remember that we did not find a CTE
 		if (ref.schema_name.empty() && CTEExists(ref.table_name)) {
-			throw BinderException(error_context,
+			throw BinderException(
+			    error_context,
 			    "Circular reference to CTE \"%s\", There are two possible solutions. \n1. use WITH RECURSIVE to "
 			    "use recursive CTEs. \n2. If "
 			    "you want to use the TABLE name \"%s\" the same as the CTE name, please explicitly add "
@@ -344,7 +347,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		while (!materialized_ctes.empty()) {
 			unique_ptr<CTENode> node_result;
 			node_result = std::move(materialized_ctes.back());
-//			node_result->cte_map = root->cte_map.Copy();
+			//			node_result->cte_map = root->cte_map.Copy();
 			node_result->child = std::move(root);
 			root = std::move(node_result);
 			materialized_ctes.pop_back();

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -347,7 +347,6 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		while (!materialized_ctes.empty()) {
 			unique_ptr<CTENode> node_result;
 			node_result = std::move(materialized_ctes.back());
-			//			node_result->cte_map = root->cte_map.Copy();
 			node_result->child = std::move(root);
 			root = std::move(node_result);
 			materialized_ctes.pop_back();

--- a/src/planner/binder/tableref/bind_subqueryref.cpp
+++ b/src/planner/binder/tableref/bind_subqueryref.cpp
@@ -4,12 +4,9 @@
 
 namespace duckdb {
 
-unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref, optional_ptr<CommonTableExpressionInfo> cte) {
+unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref) {
 	auto binder = Binder::CreateBinder(context, this);
 	binder->can_contain_nulls = true;
-	if (cte) {
-		binder->bound_ctes.insert(*cte);
-	}
 	auto subquery = binder->BindNode(*ref.subquery->node);
 	binder->alias = ref.alias.empty() ? "unnamed_subquery" : ref.alias;
 	idx_t bind_index = subquery->GetRootIndex();

--- a/src/planner/binder/tableref/plan_cteref.cpp
+++ b/src/planner/binder/tableref/plan_cteref.cpp
@@ -5,7 +5,7 @@
 namespace duckdb {
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundCTERef &ref) {
-	return make_uniq<LogicalCTERef>(ref.bind_index, ref.cte_index, ref.types, ref.bound_columns, ref.materialized_cte,
+	return make_uniq<LogicalCTERef>(ref.bind_index, ref.cte_index, ref.types, ref.bound_columns,
 	                                ref.is_recurring);
 }
 

--- a/src/planner/binder/tableref/plan_cteref.cpp
+++ b/src/planner/binder/tableref/plan_cteref.cpp
@@ -5,8 +5,7 @@
 namespace duckdb {
 
 unique_ptr<LogicalOperator> Binder::CreatePlan(BoundCTERef &ref) {
-	return make_uniq<LogicalCTERef>(ref.bind_index, ref.cte_index, ref.types, ref.bound_columns,
-	                                ref.is_recurring);
+	return make_uniq<LogicalCTERef>(ref.bind_index, ref.cte_index, ref.types, ref.bound_columns, ref.is_recurring);
 }
 
 } // namespace duckdb

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -290,7 +290,6 @@ void LogicalCTERef::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<idx_t>(201, "cte_index", cte_index);
 	serializer.WritePropertyWithDefault<vector<LogicalType>>(202, "chunk_types", chunk_types);
 	serializer.WritePropertyWithDefault<vector<string>>(203, "bound_columns", bound_columns);
-	serializer.WriteProperty<CTEMaterialize>(204, "materialized_cte", materialized_cte);
 	serializer.WritePropertyWithDefault<bool>(205, "is_recurring", is_recurring);
 }
 
@@ -299,8 +298,7 @@ unique_ptr<LogicalOperator> LogicalCTERef::Deserialize(Deserializer &deserialize
 	auto cte_index = deserializer.ReadPropertyWithDefault<idx_t>(201, "cte_index");
 	auto chunk_types = deserializer.ReadPropertyWithDefault<vector<LogicalType>>(202, "chunk_types");
 	auto bound_columns = deserializer.ReadPropertyWithDefault<vector<string>>(203, "bound_columns");
-	auto materialized_cte = deserializer.ReadProperty<CTEMaterialize>(204, "materialized_cte");
-	auto result = duckdb::unique_ptr<LogicalCTERef>(new LogicalCTERef(table_index, cte_index, std::move(chunk_types), std::move(bound_columns), materialized_cte));
+	auto result = duckdb::unique_ptr<LogicalCTERef>(new LogicalCTERef(table_index, cte_index, std::move(chunk_types), std::move(bound_columns)));
 	deserializer.ReadPropertyWithDefault<bool>(205, "is_recurring", result->is_recurring);
 	return std::move(result);
 }

--- a/test/issues/general/test_19067.test
+++ b/test/issues/general/test_19067.test
@@ -1,0 +1,171 @@
+# name: test/issues/general/test_19067.test
+# description: Issue 19067 - Cascading Views using CTEs High Memory & CPU
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE OR REPLACE VIEW view_1 AS
+SELECT
+    i AS id,
+    i * 10 AS value,
+    'item_' || i AS name,
+    (i % 3) + 1 AS category
+FROM generate_series(1, 100) AS t(i);
+
+statement ok
+CREATE OR REPLACE VIEW view_2 AS
+WITH prev1 AS (SELECT * FROM view_1)
+SELECT
+    *,
+    value * 2 AS double_value
+FROM prev1;
+
+statement ok
+CREATE OR REPLACE VIEW view_3 AS
+WITH prev2 AS (SELECT * FROM view_2)
+SELECT
+    *,
+    LENGTH(name) AS name_length
+FROM prev2;
+
+statement ok
+CREATE OR REPLACE VIEW view_4 AS
+WITH prev3 AS (SELECT * FROM view_3)
+SELECT
+    *,
+    CASE
+        WHEN category = 1 THEN 'Type A'
+        WHEN category = 2 THEN 'Type B'
+        ELSE 'Type C'
+    END AS category_desc
+FROM prev3;
+
+statement ok
+CREATE OR REPLACE VIEW view_5 AS
+WITH prev AS (SELECT * FROM view_4)
+SELECT
+    *,
+    value + id AS sum_value_id
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_6 AS
+WITH prev AS (SELECT * FROM view_5)
+SELECT
+    *,
+    UPPER(name) AS name_upper
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_7 AS
+WITH prev AS (SELECT * FROM view_6)
+SELECT
+    *,
+    ROW_NUMBER() OVER (ORDER BY id) AS row_num
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_8 AS
+WITH prev AS (SELECT * FROM view_7)
+SELECT
+    *,
+    CASE WHEN value > 500 THEN 'HIGH' ELSE 'LOW' END AS value_flag
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_9 AS
+WITH prev AS (SELECT * FROM view_8)
+SELECT
+    *,
+    id % 10 AS id_mod_10
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_10 AS
+WITH prev AS (SELECT * FROM view_9)
+SELECT
+    *,
+    value / 10 AS value_divided
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_11 AS
+WITH prev AS (SELECT * FROM view_10)
+SELECT
+    *,
+    SUBSTRING(name, 1, 4) AS name_prefix
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_12 AS
+WITH prev AS (SELECT * FROM view_11)
+SELECT
+    *,
+    AVG(value) OVER () AS avg_value
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_13 AS
+WITH prev AS (SELECT * FROM view_12)
+SELECT
+    *,
+    value - avg_value AS diff_from_avg
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_14 AS
+WITH prev AS (SELECT * FROM view_13)
+SELECT
+    *,
+    RANK() OVER (ORDER BY value) AS value_rank
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_15 AS
+WITH prev AS (SELECT * FROM view_14)
+SELECT
+    *,
+    id % 2 = 0 AS is_even
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_16 AS
+WITH prev AS (SELECT * FROM view_15)
+SELECT
+    *,
+    name || '_' || category_desc AS full_name
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_17 AS
+WITH prev AS (SELECT * FROM view_16)
+SELECT
+    *,
+    id * id AS id_squared
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_18 AS
+WITH prev AS (SELECT * FROM view_17)
+SELECT
+    *,
+    COUNT(*) OVER (PARTITION BY category) AS category_count
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_19 AS
+WITH prev AS (SELECT * FROM view_18)
+SELECT
+    *,
+    ROUND((value * 100.0 / sum_value_id), 2) AS value_percentage
+FROM prev;
+
+statement ok
+CREATE OR REPLACE VIEW view_20 AS
+WITH prev AS (SELECT * FROM view_19)
+SELECT
+    *,
+    CASE WHEN value_rank <= 10 THEN 'TOP_10' ELSE 'OTHER' END AS final_category
+FROM prev;

--- a/test/sql/cte/materialized/test_cte_in_cte_materialized.test
+++ b/test/sql/cte/materialized/test_cte_in_cte_materialized.test
@@ -67,4 +67,4 @@ with cte as MATERIALIZED (Select i as j from a) select * from cte where j = (wit
 statement error
 with cte as MATERIALIZED (select * from cte) select * from cte
 ----
-<REGEX>:.*Binder Error.*cannot be referenced.*
+<REGEX>:.*Binder Error.*Circular reference to CTE.*

--- a/test/sql/cte/recursive_cte_key_variant.test
+++ b/test/sql/cte/recursive_cte_key_variant.test
@@ -115,41 +115,41 @@ Catalog Error: Table with name tbl does not exist!
 statement error
 WITH RECURSIVE tbl2(a) AS (SELECT 1 UNION SELECT a.a + 1 FROM tbl2 AS a, recurring.tbl2 AS b WHERE a.a < 2) SELECT * FROM tbl2;
 ----
-Invalid Input Error: RECURRING can only be used with USING KEY in recursive CTE.
+<REGEX>:.*Binder Error.*cannot be referenced.*
 
 statement error
 WITH RECURSIVE tbl2(a,b) AS (SELECT 1, NULL UNION SELECT a.a+1, a.b FROM tbl2 AS a, (SELECT * FROM recurring.tbl2) AS b WHERE a.a < 2) SELECT * FROM tbl2;
 ----
-Invalid Input Error: RECURRING can only be used with USING KEY in recursive CTE.
+<REGEX>:.*Binder Error.*cannot be referenced.*
 
 # second cte references recurring table of first cte while first cte does not
 statement error
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS (SELECT 5, 1 UNION SELECT a, b + 1 FROM tbl WHERE b < a),
 tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;
 ----
-cannot be referenced
+<REGEX>:.*Binder Error.*cannot be referenced.*
 
 # second cte references recurring table of first like the first cte
 statement error
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS (SELECT  * FROM ((VALUES (5, 1), (6,1)) UNION SELECT a, b + 1 FROM recurring.tbl WHERE b < a) WHERE a = 5),
 tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;
 ----
-cannot be referenced
+<REGEX>:.*Catalog Error.*does not exist.*
 
 statement error
 WITH RECURSIVE tbl2(a) AS (SELECT 1 UNION SELECT a.a+1 FROM tbl2 AS a, (SELECT * FROM recurring.tbl2) AS b WHERE a.a < 2) SELECT * FROM tbl2;
 ----
-Invalid Input Error: RECURRING can only be used with USING KEY in recursive CTE.
+<REGEX>:.*Binder Error.*cannot be referenced.*
 
 statement error
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS (SELECT 5, 1 UNION SELECT a, b + 1 FROM tbl WHERE b < a),tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;
 ----
-cannot be referenced
+<REGEX>:.*Binder Error.*cannot be referenced.*
 
 statement error
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS MATERIALIZED (SELECT 5, 1 UNION SELECT a, b + 1 FROM tbl WHERE b < a),tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;
 ----
-cannot be referenced
+<REGEX>:.*Binder Error.*cannot be referenced.*
 
 
 #######################

--- a/test/sql/cte/test_cte_in_cte.test
+++ b/test/sql/cte/test_cte_in_cte.test
@@ -61,4 +61,4 @@ with cte as (Select i as j from a) select * from cte where j = (with cte as (sel
 statement error
 with cte as (select * from cte) select * from cte
 ----
-<REGEX>:.*Catalog Error.*does not exist.*
+<REGEX>:.*Binder Error.*Circular reference to CTE.*


### PR DESCRIPTION
This PR fixes an exponential growth that could occur under certain circumstances when `VIEW` definitions used `CTE`s.

To fix this, the `cte_map` must no longer be copied in the transformer, when a `CTE` node is created.
This required a few further changes to `bind_basetableref`, as we can no longer access the `CommonTableExpressionInfo` entry. But, as it turns out, this is no longer required anyways.

---

Fix: https://github.com/duckdb/duckdb/issues/19067