### PR TITLE
Perform optimistic reads while filling gaps in CachingFileSystem

### DIFF
--- a/src/include/duckdb/storage/caching_file_system.hpp
+++ b/src/include/duckdb/storage/caching_file_system.hpp
@@ -61,7 +61,8 @@ private:
 	//! Tries to read from the cache, filling "overlapping_ranges" with ranges that overlap with the request.
 	//! Returns an invalid BufferHandle if it fails
 	BufferHandle TryReadFromCache(data_ptr_t &buffer, idx_t nr_bytes, idx_t location,
-	                              vector<shared_ptr<CachedFileRange>> &overlapping_ranges);
+	                              vector<shared_ptr<CachedFileRange>> &overlapping_ranges,
+	                              idx_t &start_location_of_next_range);
 	//! Try to read from the specified range, return an invalid BufferHandle if it fails
 	BufferHandle TryReadFromFileRange(const unique_ptr<StorageLockKey> &guard, CachedFileRange &file_range,
 	                                  data_ptr_t &buffer, idx_t nr_bytes, idx_t location);

--- a/src/include/duckdb/storage/caching_file_system.hpp
+++ b/src/include/duckdb/storage/caching_file_system.hpp
@@ -62,7 +62,7 @@ private:
 	//! Returns an invalid BufferHandle if it fails
 	BufferHandle TryReadFromCache(data_ptr_t &buffer, idx_t nr_bytes, idx_t location,
 	                              vector<shared_ptr<CachedFileRange>> &overlapping_ranges,
-	                              idx_t &start_location_of_next_range);
+	                              optional_idx &start_location_of_next_range);
 	//! Try to read from the specified range, return an invalid BufferHandle if it fails
 	BufferHandle TryReadFromFileRange(const unique_ptr<StorageLockKey> &guard, CachedFileRange &file_range,
 	                                  data_ptr_t &buffer, idx_t nr_bytes, idx_t location);


### PR DESCRIPTION
Example situation, you have read the following byte ranges: `(1000000, 1300000) and (2000000, 2300000)`

And you are about to read the (uncached) range `(800000, 9500000)`, that would generate the following covered ranges: `(800000, 9500000), (1000000, 1300000) and (2000000, 2300000)`

Now the idea of the PR is: why not read `(800000, 1000000)` instead of `(800000, 9500000)` ?
It's slightly bigger but will generate the following ranges: `(800000, 1300000) and (2000000, 2300000)`, that might avoid an extra range request down the line if we ever discover we need (some of) the bytes in `(9500000, 1000000)` to be read.

Basically this is swapping doing bigger ranges, that means more memory pressure AND somewhat more inefficient requests in exchange from the uncertain prospect of skipping a whole request at some future point in time, with the assumption that extra requests are more costly that bigger requests, and that chances are that even in the same query you might end up reading the rest of the ranges.

Idea is similar (but more limited and so safer) to buffering file system in DuckDB-Wasm, where we trade some extra work on current requests hoping for that to be offset by skipping a full request at some later point.

From my basic tests this is very much dependent on data, for example running `PRAGMA tpch(1)` at SF=10 on a datalake (so storage are parquet files) cuts from 50 range requests to 38, for basically the same total transfered bytes. But then running `PRAGMA tpch(1)` to `PRAGMA tpch(22)` (with the same cache) shows no advantages in other queries, and 1% extra total transfered bytes.

Change is small, and seems to me to make sense on paper (or does it?), but some more solid numbers would be handy.

Open questions:
1. what should be the exact formula to decide whether to fetch extra bytes or not. Currently it's whether [location, end] range needs to be expanded by less than (location-end) bytes (so guaranteeing worse case of 2x) AND by less than 1MB.
2. whether there should be a knob/setting to regulate behaviour
3. validating this idea on other data sets