### PR TITLE
Infrastructure for allowing invalidated file handles to propagate infromation back to the database

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 354d3f436a33f80f03a74419e76eb59459e19168
+    GIT_TAG 1f137f7962327054392d83b8a46b48850fb184b2
     INCLUDE_DIR extension/httpfs/include
 )

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -709,6 +709,11 @@ unique_ptr<FileHandle> FileSystem::OpenCompressedFile(QueryContext context, uniq
 bool FileSystem::OnDiskFile(FileHandle &handle) {
 	throw NotImplementedException("%s: OnDiskFile is not implemented!", GetName());
 }
+
+bool FileSystem::IsInvalidated(FileHandle &handle) {
+	// Base case is files are never invalidated
+	return false;
+}
 // LCOV_EXCL_STOP
 
 FileHandle::FileHandle(FileSystem &file_system, string path_p, FileOpenFlags flags)
@@ -812,6 +817,10 @@ string FileHandle::ReadLine(QueryContext context) {
 
 bool FileHandle::OnDiskFile() {
 	return file_system.OnDiskFile(*this);
+}
+
+bool FileHandle::IsInvalidated() {
+	return file_system.IsInvalidated(*this);
 }
 
 idx_t FileHandle::GetFileSize() {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1297,6 +1297,10 @@ idx_t LocalFileSystem::SeekPosition(FileHandle &handle) {
 	return GetFilePointer(handle);
 }
 
+bool LocalFileSystem::IsInvalidated(FileHandle &handle) {
+	return false;
+}
+
 static bool IsCrawl(const string &glob) {
 	// glob must match exactly
 	return glob == "**";

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -96,6 +96,10 @@ void VirtualFileSystem::FileSync(FileHandle &handle) {
 	handle.file_system.FileSync(handle);
 }
 
+bool VirtualFileSystem::IsInvalidated(FileHandle &handle) {
+	return handle.file_system.IsInvalidated(handle);
+}
+
 // need to look up correct fs for this
 bool VirtualFileSystem::DirectoryExists(const string &directory, optional_ptr<FileOpener> opener) {
 	return FindFileSystem(directory).DirectoryExists(directory, opener);

--- a/src/function/scalar/variant/functions.json
+++ b/src/function/scalar/variant/functions.json
@@ -43,7 +43,7 @@
 		"name": "variant_typeof",
 		"parameters": "input_variant",
 		"description": "Returns the internal type of the `input_variant`.",
-		"example": "variant_typeof({'a': 42, 'b': [1,2,3])::VARIANT)",
+		"example": "variant_typeof({'a': 42, 'b': [1,2,3]})::VARIANT)",
 		"categories": [
 			"variant"
 		],

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -85,6 +85,7 @@ public:
 	DUCKDB_API bool CanSeek();
 	DUCKDB_API bool IsPipe();
 	DUCKDB_API bool OnDiskFile();
+	DUCKDB_API bool IsInvalidated();
 	DUCKDB_API idx_t GetFileSize();
 	DUCKDB_API FileType GetType();
 
@@ -266,6 +267,7 @@ public:
 	//! Whether or not the FS handles plain files on disk. This is relevant for certain optimizations, as random reads
 	//! in a file on-disk are much cheaper than e.g. random reads in a file over the network
 	DUCKDB_API virtual bool OnDiskFile(FileHandle &handle);
+	DUCKDB_API virtual bool IsInvalidated(FileHandle &handle);
 
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
 	                                                             bool write);

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -62,6 +62,7 @@ public:
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
 	//! Sync a file handle to disk
 	void FileSync(FileHandle &handle) override;
+	bool IsInvalidated(FileHandle &handle) override;
 
 	//! Runs a glob on the file system, returning a list of matching files
 	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -29,6 +29,7 @@ public:
 	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
 	string GetVersionTag(FileHandle &handle) override;
 	FileType GetFileType(FileHandle &handle) override;
+	bool IsInvalidated(FileHandle &handle) override;
 
 	void Truncate(FileHandle &handle, int64_t new_size) override;
 

--- a/src/include/duckdb/function/scalar/variant_functions.hpp
+++ b/src/include/duckdb/function/scalar/variant_functions.hpp
@@ -29,7 +29,7 @@ struct VariantTypeofFun {
 	static constexpr const char *Name = "variant_typeof";
 	static constexpr const char *Parameters = "input_variant";
 	static constexpr const char *Description = "Returns the internal type of the `input_variant`.";
-	static constexpr const char *Example = "variant_typeof({'a': 42, 'b': [1,2,3])::VARIANT)";
+	static constexpr const char *Example = "variant_typeof({'a': 42, 'b': [1,2,3]})::VARIANT)";
 	static constexpr const char *Categories = "variant";
 
 	static ScalarFunction GetFunction();

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -138,6 +138,8 @@ private:
 	void CheckChecksum(FileBuffer &block, uint64_t location, uint64_t delta, bool skip_block_header = false) const;
 	void CheckChecksum(data_ptr_t start_ptr, uint64_t delta, bool skip_block_header = false) const;
 
+	template <class BLOCK>
+	void ReadSingleBlock(BLOCK &block, QueryContext &context, FileHandle &handle, const idx_t location) const;
 	void ReadAndChecksum(QueryContext context, FileBuffer &handle, uint64_t location,
 	                     bool skip_block_header = false) const;
 	void ChecksumAndWrite(QueryContext context, FileBuffer &handle, uint64_t location,

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -583,7 +583,7 @@ void SingleFileBlockManager::CheckChecksum(FileBuffer &block, uint64_t location,
 void SingleFileBlockManager::ReadAndChecksum(QueryContext context, FileBuffer &block, uint64_t location,
                                              bool skip_block_header) const {
 	// read the buffer from disk
-	block.Read(context, *handle, location);
+	ReadSingleBlock(block, context, *handle, location);
 
 	//! calculate delta header bytes (if any)
 	uint64_t delta = GetBlockHeaderSize() - Storage::DEFAULT_BLOCK_HEADER_SIZE;
@@ -900,10 +900,29 @@ void SingleFileBlockManager::ReadBlock(data_ptr_t internal_buffer, uint64_t bloc
 	CheckChecksum(internal_buffer, delta, skip_block_header);
 }
 
+template void SingleFileBlockManager::ReadSingleBlock(Block &block, QueryContext &context, FileHandle &handle,
+                                                      const idx_t location) const;
+template void SingleFileBlockManager::ReadSingleBlock(FileBuffer &block, QueryContext &context, FileHandle &handle,
+                                                      const idx_t location) const;
+
+template <class BLOCK>
+void SingleFileBlockManager::ReadSingleBlock(BLOCK &block, QueryContext &context, FileHandle &handle,
+                                             const idx_t location) const {
+	try {
+		block.Read(context, handle, location);
+	} catch (...) {
+		if (handle.IsInvalidated()) {
+			// TODO: db.Close();
+		}
+		throw;
+	}
+}
+
 void SingleFileBlockManager::ReadBlock(Block &block, bool skip_block_header) const {
 	// read the buffer from disk
 	auto location = GetBlockLocation(block.id);
-	block.Read(QueryContext(), *handle, location);
+	QueryContext context;
+	ReadSingleBlock(block, context, *handle, location);
 
 	//! calculate delta header bytes (if any)
 	uint64_t delta = GetBlockHeaderSize() - Storage::DEFAULT_BLOCK_HEADER_SIZE;

--- a/test/sql/copy/s3/metadata_cache.test
+++ b/test/sql/copy/s3/metadata_cache.test
@@ -38,12 +38,12 @@ CREATE TABLE test1 as SELECT * FROM range(10,20) tbl(i);
 query II
 EXPLAIN ANALYZE COPY test TO 's3://test-bucket-public/root-dir/metadata_cache/test.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 0.*PUT\: 1.*\#POST\: 2.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 0.*PUT\: 1.*\#POST\: 0.*
 
 query II
 EXPLAIN ANALYZE COPY test TO 's3://test-bucket-public/root-dir/metadata_cache/test1.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 0.*PUT\: 1.*\#POST\: 2.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*\#HEAD\: 0.*GET\: 0.*PUT\: 1.*\#POST\: 0.*
 
 # Now we query the file metadata without the global metadata cache: There should be 1 HEAD request for the file size,
 # then a GET for the pointer to the parquet metadata, then a GET for the metadata.

--- a/test/sql/export/export_compression_level.test
+++ b/test/sql/export/export_compression_level.test
@@ -19,7 +19,7 @@ INSERT INTO test_table VALUES
     (3, 'Charlie', 234.56, '2024-01-03 14:15:00');
 
 statement ok
-EXPORT DATABASE 'my_duckdb' (
+EXPORT DATABASE '__TEST_DIR__/my_duckdb' (
     FORMAT parquet,
     COMPRESSION zstd,
     COMPRESSION_LEVEL 12,
@@ -30,7 +30,7 @@ statement ok
 DROP TABLE test_table;
 
 statement ok
-IMPORT DATABASE 'my_duckdb';
+IMPORT DATABASE '__TEST_DIR__/my_duckdb';
 
 query IIII
 FROM test_table;


### PR DESCRIPTION
Already an implementation question:
- is templating SingleFileBlockManager::ReadSingleBlock the right way to go?

Something similar could be used also in say SingleFileBlockManager::ReadBlock + SingleFileBlockManager::ReadAndChecksum that have to share the same implementation.

This is a first step, towards allowing a more proper behaviour around changing remote database files.
Current behaviour (duckdb 1.4.0) is that we recognize changes in ETag and bubble back to users, but we keep the AttachedDatabase open even if we now have proof to contain outdated data.

Bigger picture is if allowing automatic re-attach or just closing the DB, I will find out what is feasible.