### PR TITLE
`GEOMETRY` Rework: Part 1 - Logical Type

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -27,7 +27,7 @@ include("${EXTENSION_CONFIG_BASE_DIR}/iceberg.cmake")
 include("${EXTENSION_CONFIG_BASE_DIR}/inet.cmake")
 include("${EXTENSION_CONFIG_BASE_DIR}/mysql_scanner.cmake")
 include("${EXTENSION_CONFIG_BASE_DIR}/postgres_scanner.cmake")
-include("${EXTENSION_CONFIG_BASE_DIR}/spatial.cmake")
+# include("${EXTENSION_CONFIG_BASE_DIR}/spatial.cmake") Remove spatial until the geometry refactor is done
 include("${EXTENSION_CONFIG_BASE_DIR}/sqlite_scanner.cmake")
 include("${EXTENSION_CONFIG_BASE_DIR}/sqlsmith.cmake")
 include("${EXTENSION_CONFIG_BASE_DIR}/vss.cmake")

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -89,6 +89,7 @@
 #include "duckdb/common/types/column/partitioned_column_data.hpp"
 #include "duckdb/common/types/conflict_manager.hpp"
 #include "duckdb/common/types/date.hpp"
+#include "duckdb/common/types/geometry.hpp"
 #include "duckdb/common/types/hyperloglog.hpp"
 #include "duckdb/common/types/row/block_iterator.hpp"
 #include "duckdb/common/types/row/partitioned_tuple_data.hpp"
@@ -2058,6 +2059,30 @@ const char* EnumUtil::ToChars<GateStatus>(GateStatus value) {
 template<>
 GateStatus EnumUtil::FromString<GateStatus>(const char *value) {
 	return static_cast<GateStatus>(StringUtil::StringToEnum(GetGateStatusValues(), 2, "GateStatus", value));
+}
+
+const StringUtil::EnumStringLiteral *GetGeometryTypeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(GeometryType::INVALID), "INVALID" },
+		{ static_cast<uint32_t>(GeometryType::POINT), "POINT" },
+		{ static_cast<uint32_t>(GeometryType::LINESTRING), "LINESTRING" },
+		{ static_cast<uint32_t>(GeometryType::POLYGON), "POLYGON" },
+		{ static_cast<uint32_t>(GeometryType::MULTIPOINT), "MULTIPOINT" },
+		{ static_cast<uint32_t>(GeometryType::MULTILINESTRING), "MULTILINESTRING" },
+		{ static_cast<uint32_t>(GeometryType::MULTIPOLYGON), "MULTIPOLYGON" },
+		{ static_cast<uint32_t>(GeometryType::GEOMETRYCOLLECTION), "GEOMETRYCOLLECTION" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<GeometryType>(GeometryType value) {
+	return StringUtil::EnumToString(GetGeometryTypeValues(), 8, "GeometryType", static_cast<uint32_t>(value));
+}
+
+template<>
+GeometryType EnumUtil::FromString<GeometryType>(const char *value) {
+	return static_cast<GeometryType>(StringUtil::StringToEnum(GetGeometryTypeValues(), 8, "GeometryType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetHLLStorageTypeValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4833,6 +4833,7 @@ const StringUtil::EnumStringLiteral *GetVariantLogicalTypeValues() {
 		{ static_cast<uint32_t>(VariantLogicalType::ARRAY), "ARRAY" },
 		{ static_cast<uint32_t>(VariantLogicalType::BIGNUM), "BIGNUM" },
 		{ static_cast<uint32_t>(VariantLogicalType::BITSTRING), "BITSTRING" },
+		{ static_cast<uint32_t>(VariantLogicalType::GEOMETRY), "GEOMETRY" },
 		{ static_cast<uint32_t>(VariantLogicalType::ENUM_SIZE), "ENUM_SIZE" }
 	};
 	return values;
@@ -4840,12 +4841,12 @@ const StringUtil::EnumStringLiteral *GetVariantLogicalTypeValues() {
 
 template<>
 const char* EnumUtil::ToChars<VariantLogicalType>(VariantLogicalType value) {
-	return StringUtil::EnumToString(GetVariantLogicalTypeValues(), 34, "VariantLogicalType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetVariantLogicalTypeValues(), 35, "VariantLogicalType", static_cast<uint32_t>(value));
 }
 
 template<>
 VariantLogicalType EnumUtil::FromString<VariantLogicalType>(const char *value) {
-	return static_cast<VariantLogicalType>(StringUtil::StringToEnum(GetVariantLogicalTypeValues(), 34, "VariantLogicalType", value));
+	return static_cast<VariantLogicalType>(StringUtil::StringToEnum(GetVariantLogicalTypeValues(), 35, "VariantLogicalType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetVectorAuxiliaryDataTypeValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1795,19 +1795,20 @@ const StringUtil::EnumStringLiteral *GetExtraTypeInfoTypeValues() {
 		{ static_cast<uint32_t>(ExtraTypeInfoType::ARRAY_TYPE_INFO), "ARRAY_TYPE_INFO" },
 		{ static_cast<uint32_t>(ExtraTypeInfoType::ANY_TYPE_INFO), "ANY_TYPE_INFO" },
 		{ static_cast<uint32_t>(ExtraTypeInfoType::INTEGER_LITERAL_TYPE_INFO), "INTEGER_LITERAL_TYPE_INFO" },
-		{ static_cast<uint32_t>(ExtraTypeInfoType::TEMPLATE_TYPE_INFO), "TEMPLATE_TYPE_INFO" }
+		{ static_cast<uint32_t>(ExtraTypeInfoType::TEMPLATE_TYPE_INFO), "TEMPLATE_TYPE_INFO" },
+		{ static_cast<uint32_t>(ExtraTypeInfoType::GEO_TYPE_INFO), "GEO_TYPE_INFO" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<ExtraTypeInfoType>(ExtraTypeInfoType value) {
-	return StringUtil::EnumToString(GetExtraTypeInfoTypeValues(), 13, "ExtraTypeInfoType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetExtraTypeInfoTypeValues(), 14, "ExtraTypeInfoType", static_cast<uint32_t>(value));
 }
 
 template<>
 ExtraTypeInfoType EnumUtil::FromString<ExtraTypeInfoType>(const char *value) {
-	return static_cast<ExtraTypeInfoType>(StringUtil::StringToEnum(GetExtraTypeInfoTypeValues(), 13, "ExtraTypeInfoType", value));
+	return static_cast<ExtraTypeInfoType>(StringUtil::StringToEnum(GetExtraTypeInfoTypeValues(), 14, "ExtraTypeInfoType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetFileBufferTypeValues() {
@@ -2599,6 +2600,7 @@ const StringUtil::EnumStringLiteral *GetLogicalTypeIdValues() {
 		{ static_cast<uint32_t>(LogicalTypeId::POINTER), "POINTER" },
 		{ static_cast<uint32_t>(LogicalTypeId::VALIDITY), "VALIDITY" },
 		{ static_cast<uint32_t>(LogicalTypeId::UUID), "UUID" },
+		{ static_cast<uint32_t>(LogicalTypeId::GEOMETRY), "GEOMETRY" },
 		{ static_cast<uint32_t>(LogicalTypeId::STRUCT), "STRUCT" },
 		{ static_cast<uint32_t>(LogicalTypeId::LIST), "LIST" },
 		{ static_cast<uint32_t>(LogicalTypeId::MAP), "MAP" },
@@ -2615,12 +2617,12 @@ const StringUtil::EnumStringLiteral *GetLogicalTypeIdValues() {
 
 template<>
 const char* EnumUtil::ToChars<LogicalTypeId>(LogicalTypeId value) {
-	return StringUtil::EnumToString(GetLogicalTypeIdValues(), 50, "LogicalTypeId", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetLogicalTypeIdValues(), 51, "LogicalTypeId", static_cast<uint32_t>(value));
 }
 
 template<>
 LogicalTypeId EnumUtil::FromString<LogicalTypeId>(const char *value) {
-	return static_cast<LogicalTypeId>(StringUtil::StringToEnum(GetLogicalTypeIdValues(), 50, "LogicalTypeId", value));
+	return static_cast<LogicalTypeId>(StringUtil::StringToEnum(GetLogicalTypeIdValues(), 51, "LogicalTypeId", value));
 }
 
 const StringUtil::EnumStringLiteral *GetLookupResultTypeValues() {

--- a/src/common/extra_type_info.cpp
+++ b/src/common/extra_type_info.cpp
@@ -507,4 +507,19 @@ shared_ptr<ExtraTypeInfo> TemplateTypeInfo::Copy() const {
 	return make_shared_ptr<TemplateTypeInfo>(*this);
 }
 
+//===--------------------------------------------------------------------===//
+// Geo Type Info
+//===--------------------------------------------------------------------===//
+GeoTypeInfo::GeoTypeInfo() : ExtraTypeInfo(ExtraTypeInfoType::GEO_TYPE_INFO) {
+}
+
+bool GeoTypeInfo::EqualsInternal(ExtraTypeInfo *other_p) const {
+	// No additional info to compare
+	return true;
+}
+
+shared_ptr<ExtraTypeInfo> GeoTypeInfo::Copy() const {
+	return make_shared_ptr<GeoTypeInfo>(*this);
+}
+
 } // namespace duckdb

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/types/geometry.hpp"
 #include "duckdb/common/types.hpp"
 #include "fast_float/fast_float.h"
 #include "duckdb/common/types/bit.hpp"
@@ -1558,6 +1559,14 @@ bool TryCastBlobToUUID::Operation(string_t input, hugeint_t &result, bool strict
 	result = BaseUUID::FromBlob(data);
 
 	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To Geometry
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToGeometry::Operation(string_t input, string_t &result, Vector &result_vector, CastParameters &parameters) {
+	return Geometry::FromString(input, result, result_vector, parameters.strict);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -159,6 +159,8 @@ PhysicalType LogicalType::GetInternalType() {
 		return PhysicalType::UNKNOWN;
 	case LogicalTypeId::AGGREGATE_STATE:
 		return PhysicalType::VARCHAR;
+	case LogicalTypeId::GEOMETRY:
+		return PhysicalType::VARCHAR;
 	default:
 		throw InternalException("Invalid LogicalType %s", ToString());
 	}
@@ -1344,6 +1346,8 @@ static idx_t GetLogicalTypeScore(const LogicalType &type) {
 		return 102;
 	case LogicalTypeId::BIGNUM:
 		return 103;
+	case LogicalTypeId::GEOMETRY:
+		return 104;
 	// nested types
 	case LogicalTypeId::STRUCT:
 		return 125;
@@ -2012,6 +2016,15 @@ LogicalType LogicalType::VARIANT() {
 
 	auto info = make_shared_ptr<StructTypeInfo>(std::move(children));
 	return LogicalType(LogicalTypeId::VARIANT, std::move(info));
+}
+
+//===--------------------------------------------------------------------===//
+// Spatial Types
+//===--------------------------------------------------------------------===//
+
+LogicalType LogicalType::GEOMETRY() {
+	auto info = make_shared_ptr<GeoTypeInfo>();
+	return LogicalType(LogicalTypeId::GEOMETRY, std::move(info));
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/common/types/CMakeLists.txt
+++ b/src/common/types/CMakeLists.txt
@@ -36,7 +36,8 @@ add_library_unity(
   vector_buffer.cpp
   vector.cpp
   vector_cache.cpp
-  vector_constants.cpp)
+  vector_constants.cpp
+  geometry.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_common_types>
     PARENT_SCOPE)

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1,0 +1,773 @@
+#include "duckdb/common/types/geometry.hpp"
+#include "duckdb/common/types/string_type.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "fast_float/fast_float.h"
+#include "fmt/format.h"
+
+//----------------------------------------------------------------------------------------------------------------------
+// Internals
+//----------------------------------------------------------------------------------------------------------------------
+namespace duckdb {
+
+namespace {
+
+class BlobWriter {
+public:
+	template <class T>
+	void Write(const T &value) {
+		auto ptr = reinterpret_cast<const char *>(&value);
+		buffer.insert(buffer.end(), ptr, ptr + sizeof(T));
+	}
+
+	template <class T>
+	struct Reserved {
+		size_t offset;
+		T value;
+	};
+
+	template <class T>
+	Reserved<T> Reserve() {
+		auto offset = buffer.size();
+		buffer.resize(buffer.size() + sizeof(T));
+		return {offset, T()};
+	}
+
+	template <class T>
+	void Write(const Reserved<T> &reserved) {
+		if (reserved.offset + sizeof(T) > buffer.size()) {
+			throw InternalException("Write out of bounds in BinaryWriter");
+		}
+		auto ptr = reinterpret_cast<const char *>(&reserved.value);
+		// We've reserved 0 bytes, so we can safely memcpy
+		memcpy(buffer.data() + reserved.offset, ptr, sizeof(T));
+	}
+
+	void Write(const char *data, size_t size) {
+		D_ASSERT(data != nullptr);
+		buffer.insert(buffer.end(), data, data + size);
+	}
+
+	const vector<char> &GetBuffer() const {
+		return buffer;
+	}
+
+private:
+	vector<char> buffer;
+};
+
+class BlobReader {
+public:
+	BlobReader(const char *data, uint32_t size) : beg(data), pos(data), end(data + size) {
+	}
+
+	template <class T, bool LE = true>
+	T Read() {
+		if (pos + sizeof(T) > end) {
+			throw InvalidInputException("Unexpected end of binary data at position %zu", pos - beg);
+		}
+		T value;
+		if (LE) {
+			memcpy(&value, pos, sizeof(T));
+			pos += sizeof(T);
+		} else {
+			char temp[sizeof(T)];
+			for (size_t i = 0; i < sizeof(T); ++i) {
+				temp[i] = pos[sizeof(T) - 1 - i];
+			}
+			memcpy(&value, temp, sizeof(T));
+			pos += sizeof(T);
+		}
+		return value;
+	}
+
+	void Skip(size_t size) {
+		if (pos + size > end) {
+			throw InvalidInputException("Skipping beyond end of binary data at position %zu", pos - beg);
+		}
+		pos += size;
+	}
+
+	const char *Reserve(size_t size) {
+		if (pos + size > end) {
+			throw InvalidInputException("Reserving beyond end of binary data at position %zu", pos - beg);
+		}
+		auto current_pos = pos;
+		pos += size;
+		return current_pos;
+	}
+
+	size_t GetPosition() const {
+		return static_cast<idx_t>(pos - beg);
+	}
+
+	bool IsAtEnd() const {
+		return pos >= end;
+	}
+
+private:
+	const char *beg;
+	const char *pos;
+	const char *end;
+};
+
+class TextWriter {
+public:
+	void Write(const char *str) {
+		buffer.insert(buffer.end(), str, str + strlen(str));
+	}
+	void Write(char c) {
+		buffer.push_back(c);
+	}
+	void Write(double value) {
+		duckdb_fmt::format_to(std::back_inserter(buffer), "{}", value);
+		// Remove trailing zero
+		if (buffer.back() == '0') {
+			buffer.pop_back();
+			if (buffer.back() == '.') {
+				buffer.pop_back();
+			}
+		}
+	}
+	const vector<char> &GetBuffer() const {
+		return buffer;
+	}
+
+private:
+	vector<char> buffer;
+};
+
+class TextReader {
+public:
+	TextReader(const char *text, const uint32_t size) : beg(text), pos(text), end(text + size) {
+	}
+
+	bool TryMatch(const char *str) {
+		auto ptr = pos;
+		while (*str && pos < end && tolower(*pos) == tolower(*str)) {
+			pos++;
+			str++;
+		}
+		if (*str == '\0') {
+			SkipWhitespace(); // remove trailing whitespace
+			return true;      // matched
+		} else {
+			pos = ptr;    // reset position
+			return false; // not matched
+		}
+	}
+
+	bool TryMatch(char c) {
+		if (pos < end && tolower(*pos) == tolower(c)) {
+			pos++;
+			SkipWhitespace(); // remove trailing whitespace
+			return true;      // matched
+		}
+		return false; // not matched
+	}
+
+	void Match(const char *str) {
+		if (!TryMatch(str)) {
+			throw InvalidInputException("Expected '%s' but got '%c' at position %zu", str, *pos, pos - beg);
+		}
+	}
+
+	void Match(char c) {
+		if (!TryMatch(c)) {
+			throw InvalidInputException("Expected '%c' but got '%c' at position %zu", c, *pos, pos - beg);
+		}
+	}
+
+	double MatchNumber() {
+		// Now use fast_float to parse the number
+		double num;
+		const auto res = duckdb_fast_float::from_chars(pos, end, num);
+		if (res.ec != std::errc()) {
+			throw InvalidInputException("Expected number at position %zu", pos - beg);
+		}
+
+		pos = res.ptr; // update position to the end of the parsed number
+
+		SkipWhitespace(); // remove trailing whitespace
+		return num;       // return the parsed number
+	}
+
+	idx_t GetPosition() const {
+		return static_cast<idx_t>(pos - beg);
+	}
+
+	void Reset() {
+		pos = beg;
+	}
+
+private:
+	void SkipWhitespace() {
+		while (pos < end && isspace(*pos)) {
+			pos++;
+		}
+	}
+
+	const char *beg;
+	const char *pos;
+	const char *end;
+};
+
+void FromStringRecursive(TextReader &reader, BlobWriter &writer, uint32_t depth, bool parent_has_z, bool parent_has_m) {
+
+	if (depth == Geometry::MAX_RECURSION_DEPTH) {
+		throw InvalidInputException("Geometry string exceeds maximum recursion depth of %d",
+		                            Geometry::MAX_RECURSION_DEPTH);
+	}
+
+	GeometryType type;
+
+	if (reader.TryMatch("point")) {
+		type = GeometryType::POINT;
+	} else if (reader.TryMatch("linestring")) {
+		type = GeometryType::LINESTRING;
+	} else if (reader.TryMatch("polygon")) {
+		type = GeometryType::POLYGON;
+	} else if (reader.TryMatch("multipoint")) {
+		type = GeometryType::MULTIPOINT;
+	} else if (reader.TryMatch("multilinestring")) {
+		type = GeometryType::MULTILINESTRING;
+	} else if (reader.TryMatch("multipolygon")) {
+		type = GeometryType::MULTIPOLYGON;
+	} else if (reader.TryMatch("geometrycollection")) {
+		type = GeometryType::GEOMETRYCOLLECTION;
+	} else {
+		throw InvalidInputException("Unknown geometry type at position %zu", reader.GetPosition());
+	}
+
+	const auto has_z = reader.TryMatch("z");
+	const auto has_m = reader.TryMatch("m");
+
+	const auto is_empty = reader.TryMatch("empty");
+
+	if ((depth != 0) && ((parent_has_z != has_z) || (parent_has_m != has_m))) {
+		throw InvalidInputException("Geometry has inconsistent Z/M dimensions, starting at position %zu",
+		                            reader.GetPosition());
+	}
+
+	// How many dimensions does this geometry have?
+	const uint32_t dims = 2 + (has_z ? 1 : 0) + (has_m ? 1 : 0);
+
+	// WKB type
+	const auto meta = static_cast<uint32_t>(type) + (has_z ? 1000 : 0) + (has_m ? 2000 : 0);
+	// Write the geometry type and vertex type
+	writer.Write<uint8_t>(1); // LE Byte Order
+	writer.Write<uint32_t>(meta);
+
+	switch (type) {
+	case GeometryType::POINT: {
+		if (is_empty) {
+			for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+				// Write NaN for each dimension, if point is empty
+				writer.Write<double>(std::numeric_limits<double>::quiet_NaN());
+			}
+		} else {
+			reader.Match('(');
+			for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+				auto value = reader.MatchNumber();
+				writer.Write<double>(value);
+			}
+			reader.Match(')');
+		}
+	} break;
+	case GeometryType::LINESTRING: {
+		if (is_empty) {
+			writer.Write<uint32_t>(0); // No vertices in empty linestring
+			break;
+		}
+		auto vert_count = writer.Reserve<uint32_t>();
+		reader.Match('(');
+		do {
+			for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+				auto value = reader.MatchNumber();
+				writer.Write<double>(value);
+			}
+			vert_count.value++;
+		} while (reader.TryMatch(','));
+		reader.Match(')');
+		writer.Write(vert_count);
+	} break;
+	case GeometryType::POLYGON: {
+		if (is_empty) {
+			writer.Write<uint32_t>(0);
+			break; // No rings in empty polygon
+		}
+		auto ring_count = writer.Reserve<uint32_t>();
+		reader.Match('(');
+		do {
+			auto vert_count = writer.Reserve<uint32_t>();
+			reader.Match('(');
+			do {
+				for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+					auto value = reader.MatchNumber();
+					writer.Write<double>(value);
+				}
+				vert_count.value++;
+			} while (reader.TryMatch(','));
+			reader.Match(')');
+			writer.Write(vert_count);
+			ring_count.value++;
+		} while (reader.TryMatch(','));
+		reader.Match(')');
+		writer.Write(ring_count);
+	} break;
+	case GeometryType::MULTIPOINT: {
+		if (is_empty) {
+			writer.Write<uint32_t>(0); // No points in empty multipoint
+			break;
+		}
+		auto part_count = writer.Reserve<uint32_t>();
+		reader.Match('(');
+		do {
+			bool has_paren = reader.TryMatch('(');
+
+			const auto part_meta = static_cast<uint32_t>(GeometryType::POINT) + (has_z ? 1000 : 0) + (has_m ? 2000 : 0);
+			writer.Write<uint8_t>(1);
+			writer.Write<uint32_t>(part_meta);
+
+			if (reader.TryMatch("EMPTY")) {
+				for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+					// Write NaN for each dimension, if point is empty
+					writer.Write<double>(std::numeric_limits<double>::quiet_NaN());
+				}
+			} else {
+				for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+					auto value = reader.MatchNumber();
+					writer.Write<double>(value);
+				}
+			}
+			if (has_paren) {
+				reader.Match(')'); // Match the closing parenthesis if it was opened
+			}
+			part_count.value++;
+		} while (reader.TryMatch(','));
+		writer.Write(part_count);
+	} break;
+	case GeometryType::MULTILINESTRING: {
+		if (is_empty) {
+			return; // No linestrings in empty multilinestring
+		}
+		auto part_count = writer.Reserve<uint32_t>();
+		reader.Match('(');
+		do {
+
+			const auto part_meta =
+			    static_cast<uint32_t>(GeometryType::LINESTRING) + (has_z ? 1000 : 0) + (has_m ? 2000 : 0);
+			writer.Write<uint8_t>(1);
+			writer.Write<uint32_t>(part_meta);
+
+			auto vert_count = writer.Reserve<uint32_t>();
+			reader.Match('(');
+			do {
+				for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+					auto value = reader.MatchNumber();
+					writer.Write<double>(value);
+				}
+				vert_count.value++;
+			} while (reader.TryMatch(','));
+			reader.Match(')');
+			writer.Write(vert_count);
+			part_count.value++;
+		} while (reader.TryMatch(','));
+		reader.Match(')');
+		writer.Write(part_count);
+	} break;
+	case GeometryType::MULTIPOLYGON: {
+		if (is_empty) {
+			writer.Write<uint32_t>(0); // No polygons in empty multipolygon
+			break;
+		}
+		auto part_count = writer.Reserve<uint32_t>();
+		reader.Match('(');
+		do {
+
+			const auto part_meta =
+			    static_cast<uint32_t>(GeometryType::POLYGON) + (has_z ? 1000 : 0) + (has_m ? 2000 : 0);
+			writer.Write<uint8_t>(1);
+			writer.Write<uint32_t>(part_meta);
+
+			auto ring_count = writer.Reserve<uint32_t>();
+			reader.Match('(');
+			do {
+				auto vert_count = writer.Reserve<uint32_t>();
+				reader.Match('(');
+				do {
+					for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+						auto value = reader.MatchNumber();
+						writer.Write<double>(value);
+					}
+					vert_count.value++;
+				} while (reader.TryMatch(','));
+				reader.Match(')');
+				writer.Write(vert_count);
+				ring_count.value++;
+			} while (reader.TryMatch(','));
+			reader.Match(')');
+			writer.Write(ring_count);
+			part_count.value++;
+		} while (reader.TryMatch(','));
+		reader.Match(')');
+		writer.Write(part_count);
+	} break;
+	case GeometryType::GEOMETRYCOLLECTION: {
+		if (is_empty) {
+			writer.Write<uint32_t>(0); // No geometries in empty geometry collection
+			break;
+		}
+		auto part_count = writer.Reserve<uint32_t>();
+		reader.Match('(');
+		do {
+			// Recursively parse the geometry inside the collection
+			FromStringRecursive(reader, writer, depth + 1, has_z, has_m);
+			part_count.value++;
+		} while (reader.TryMatch(','));
+		reader.Match(')');
+		writer.Write(part_count);
+	} break;
+	default:
+		throw InvalidInputException("Unknown geometry type %d at position %zu", static_cast<int>(type),
+		                            reader.GetPosition());
+	}
+}
+
+void ToStringRecursive(BlobReader &reader, TextWriter &writer, idx_t depth, bool parent_has_z, bool parent_has_m) {
+	if (depth == Geometry::MAX_RECURSION_DEPTH) {
+		throw InvalidInputException("Geometry exceeds maximum recursion depth of %d", Geometry::MAX_RECURSION_DEPTH);
+	}
+
+	// Read the byte order (should always be 1 for little-endian)
+	auto byte_order = reader.Read<uint8_t>();
+	if (byte_order != 1) {
+		throw InvalidInputException("Unsupported byte order %d in WKB", byte_order);
+	}
+
+	const auto meta = reader.Read<uint32_t>();
+	const auto type = static_cast<GeometryType>(meta % 1000);
+	const auto flag = meta / 1000;
+	const auto has_z = (flag & 0x01) != 0;
+	const auto has_m = (flag & 0x02) != 0;
+
+	if ((depth != 0) && ((parent_has_z != has_z) || (parent_has_m != has_m))) {
+		throw InvalidInputException("Geometry has inconsistent Z/M dimensions, starting at position %zu",
+		                            reader.GetPosition());
+	}
+
+	const uint32_t dims = 2 + (has_z ? 1 : 0) + (has_m ? 1 : 0);
+	const auto flag_str = has_z ? (has_m ? " ZM " : " Z ") : (has_m ? " M " : " ");
+
+	switch (type) {
+	case GeometryType::POINT: {
+		writer.Write("POINT");
+		writer.Write(flag_str);
+
+		double vert[4] = {0, 0, 0, 0};
+		auto all_nan = true;
+		for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+			vert[d_idx] = reader.Read<double>();
+			all_nan &= std::isnan(vert[d_idx]);
+		}
+		if (all_nan) {
+			writer.Write("EMPTY");
+			return;
+		}
+		writer.Write('(');
+		for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+			if (d_idx > 0) {
+				writer.Write(' ');
+			}
+			writer.Write(vert[d_idx]);
+		}
+		writer.Write(')');
+	} break;
+	case GeometryType::LINESTRING: {
+		writer.Write("LINESTRING");
+		;
+		writer.Write(flag_str);
+		const auto vert_count = reader.Read<uint32_t>();
+		if (vert_count == 0) {
+			writer.Write("EMPTY");
+			return;
+		}
+		writer.Write('(');
+		for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
+			if (vert_idx > 0) {
+				writer.Write(", ");
+			}
+			for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+				if (d_idx > 0) {
+					writer.Write(' ');
+				}
+				auto value = reader.Read<double>();
+				writer.Write(value);
+			}
+		}
+		writer.Write(')');
+	} break;
+	case GeometryType::POLYGON: {
+		writer.Write("POLYGON");
+		writer.Write(flag_str);
+		const auto ring_count = reader.Read<uint32_t>();
+		if (ring_count == 0) {
+			writer.Write("EMPTY");
+			return;
+		}
+		writer.Write('(');
+		for (uint32_t ring_idx = 0; ring_idx < ring_count; ring_idx++) {
+			if (ring_idx > 0) {
+				writer.Write(", ");
+			}
+			const auto vert_count = reader.Read<uint32_t>();
+			if (vert_count == 0) {
+				writer.Write("EMPTY");
+				continue;
+			}
+			writer.Write('(');
+			for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
+				if (vert_idx > 0) {
+					writer.Write(", ");
+				}
+				for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+					if (d_idx > 0) {
+						writer.Write(' ');
+					}
+					auto value = reader.Read<double>();
+					writer.Write(value);
+				}
+			}
+			writer.Write(')');
+		}
+		writer.Write(')');
+	} break;
+	case GeometryType::MULTIPOINT: {
+		writer.Write("MULTIPOINT");
+		writer.Write(flag_str);
+		const auto part_count = reader.Read<uint32_t>();
+		if (part_count == 0) {
+			writer.Write("EMPTY");
+			return;
+		}
+		writer.Write('(');
+		for (uint32_t part_idx = 0; part_idx < part_count; part_idx++) {
+			const auto part_byte_order = reader.Read<uint8_t>();
+			if (part_byte_order != 1) {
+				throw InvalidInputException("Unsupported byte order %d in WKB", part_byte_order);
+			}
+			const auto part_meta = reader.Read<uint32_t>();
+			const auto part_type = static_cast<GeometryType>(part_meta % 1000);
+			const auto part_flag = part_meta / 1000;
+			const auto part_has_z = (part_flag & 0x01) != 0;
+			const auto part_has_m = (part_flag & 0x02) != 0;
+
+			if (part_type != GeometryType::POINT) {
+				throw InvalidInputException("Expected POINT in MULTIPOINT but got %d", static_cast<int>(part_type));
+			}
+
+			if ((has_z != part_has_z) || (has_m != part_has_m)) {
+				throw InvalidInputException(
+				    "Geometry has inconsistent Z/M dimensions in MULTIPOINT, starting at position %zu",
+				    reader.GetPosition());
+			}
+			if (part_idx > 0) {
+				writer.Write(", ");
+			}
+			// writer.Write('(');
+			double vert[4] = {0, 0, 0, 0};
+			auto all_nan = true;
+			for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+				vert[d_idx] = reader.Read<double>();
+				all_nan &= std::isnan(vert[d_idx]);
+			}
+			if (all_nan) {
+				writer.Write("EMPTY");
+				// writer.Write(')');
+				continue;
+			}
+			for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+				if (d_idx > 0) {
+					writer.Write(' ');
+				}
+				writer.Write(vert[d_idx]);
+			}
+			// writer.Write(')');
+		}
+		writer.Write(')');
+
+	} break;
+	case GeometryType::MULTILINESTRING: {
+		writer.Write("MULTILINESTRING");
+		writer.Write(flag_str);
+		const auto part_count = reader.Read<uint32_t>();
+		if (part_count == 0) {
+			writer.Write("EMPTY");
+			return;
+		}
+		writer.Write('(');
+		for (uint32_t part_idx = 0; part_idx < part_count; part_idx++) {
+			const auto part_byte_order = reader.Read<uint8_t>();
+			if (part_byte_order != 1) {
+				throw InvalidInputException("Unsupported byte order %d in WKB", part_byte_order);
+			}
+			const auto part_meta = reader.Read<uint32_t>();
+			const auto part_type = static_cast<GeometryType>(part_meta % 1000);
+			const auto part_flag = part_meta / 1000;
+			const auto part_has_z = (part_flag & 0x01) != 0;
+			const auto part_has_m = (part_flag & 0x02) != 0;
+
+			if (part_type != GeometryType::LINESTRING) {
+				throw InvalidInputException("Expected LINESTRING in MULTILINESTRING but got %d",
+				                            static_cast<int>(part_type));
+			}
+			if ((has_z != part_has_z) || (has_m != part_has_m)) {
+				throw InvalidInputException(
+				    "Geometry has inconsistent Z/M dimensions in MULTILINESTRING, starting at position %zu",
+				    reader.GetPosition());
+			}
+			if (part_idx > 0) {
+				writer.Write(", ");
+			}
+			const auto vert_count = reader.Read<uint32_t>();
+			if (vert_count == 0) {
+				writer.Write("EMPTY");
+				continue;
+			}
+			writer.Write('(');
+			for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
+				if (vert_idx > 0) {
+					writer.Write(", ");
+				}
+				for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+					if (d_idx > 0) {
+						writer.Write(' ');
+					}
+					auto value = reader.Read<double>();
+					writer.Write(value);
+				}
+			}
+			writer.Write(')');
+		}
+		writer.Write(')');
+	} break;
+	case GeometryType::MULTIPOLYGON: {
+		writer.Write("MULTIPOLYGON");
+		writer.Write(flag_str);
+		const auto part_count = reader.Read<uint32_t>();
+		if (part_count == 0) {
+			writer.Write("EMPTY");
+			return;
+		}
+		writer.Write('(');
+		for (uint32_t part_idx = 0; part_idx < part_count; part_idx++) {
+			if (part_idx > 0) {
+				writer.Write(", ");
+			}
+
+			const auto part_byte_order = reader.Read<uint8_t>();
+			if (part_byte_order != 1) {
+				throw InvalidInputException("Unsupported byte order %d in WKB", part_byte_order);
+			}
+			const auto part_meta = reader.Read<uint32_t>();
+			const auto part_type = static_cast<GeometryType>(part_meta % 1000);
+			const auto part_flag = part_meta / 1000;
+			const auto part_has_z = (part_flag & 0x01) != 0;
+			const auto part_has_m = (part_flag & 0x02) != 0;
+			if (part_type != GeometryType::POLYGON) {
+				throw InvalidInputException("Expected POLYGON in MULTIPOLYGON but got %d", static_cast<int>(part_type));
+			}
+			if ((has_z != part_has_z) || (has_m != part_has_m)) {
+				throw InvalidInputException(
+				    "Geometry has inconsistent Z/M dimensions in MULTIPOLYGON, starting at position %zu",
+				    reader.GetPosition());
+			}
+
+			const auto ring_count = reader.Read<uint32_t>();
+			if (ring_count == 0) {
+				writer.Write("EMPTY");
+				continue;
+			}
+			writer.Write('(');
+			for (uint32_t ring_idx = 0; ring_idx < ring_count; ring_idx++) {
+				if (ring_idx > 0) {
+					writer.Write(", ");
+				}
+				const auto vert_count = reader.Read<uint32_t>();
+				if (vert_count == 0) {
+					writer.Write("EMPTY");
+					continue;
+				}
+				writer.Write('(');
+				for (uint32_t vert_idx = 0; vert_idx < vert_count; vert_idx++) {
+					if (vert_idx > 0) {
+						writer.Write(", ");
+					}
+					for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
+						if (d_idx > 0) {
+							writer.Write(' ');
+						}
+						auto value = reader.Read<double>();
+						writer.Write(value);
+					}
+				}
+				writer.Write(')');
+			}
+			writer.Write(')');
+		}
+		writer.Write(')');
+	} break;
+	case GeometryType::GEOMETRYCOLLECTION: {
+		writer.Write("GEOMETRYCOLLECTION");
+		writer.Write(flag_str);
+		const auto part_count = reader.Read<uint32_t>();
+		if (part_count == 0) {
+			writer.Write("EMPTY");
+			return;
+		}
+		writer.Write('(');
+		for (uint32_t part_idx = 0; part_idx < part_count; part_idx++) {
+			if (part_idx > 0) {
+				writer.Write(", ");
+			}
+			// Recursively parse the geometry inside the collection
+			ToStringRecursive(reader, writer, depth + 1, has_z, has_m);
+		}
+		writer.Write(')');
+	} break;
+	default:
+		throw InvalidInputException("Unsupported geometry type %d in WKB", static_cast<int>(type));
+	}
+}
+
+} // namespace
+
+} // namespace duckdb
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public interface
+//----------------------------------------------------------------------------------------------------------------------
+namespace duckdb {
+
+bool Geometry::FromString(const string_t &wkt_text, string_t &result, Vector &result_vector, bool strict) {
+	TextReader reader(wkt_text.GetData(), static_cast<uint32_t>(wkt_text.GetSize()));
+	BlobWriter writer;
+
+	FromStringRecursive(reader, writer, 0, false, false);
+
+	const auto &buffer = writer.GetBuffer();
+	result = StringVector::AddStringOrBlob(result_vector, buffer.data(), buffer.size());
+	return true;
+}
+
+string_t Geometry::ToString(Vector &result, const string_t &geom) {
+	BlobReader reader(geom.GetData(), static_cast<uint32_t>(geom.GetSize()));
+	TextWriter writer;
+
+	ToStringRecursive(reader, writer, 0, false, false);
+
+	// Convert the buffer to string_t
+	const auto &buffer = writer.GetBuffer();
+	return StringVector::AddString(result, buffer.data(), buffer.size());
+}
+
+} // namespace duckdb

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -348,6 +348,7 @@ void FromStringRecursive(TextReader &reader, BlobWriter &writer, uint32_t depth,
 	} break;
 	case GeometryType::MULTILINESTRING: {
 		if (is_empty) {
+			writer.Write<uint32_t>(0);
 			return; // No linestrings in empty multilinestring
 		}
 		auto part_count = writer.Reserve<uint32_t>();
@@ -573,7 +574,6 @@ void ToStringRecursive(BlobReader &reader, TextWriter &writer, idx_t depth, bool
 			if (part_idx > 0) {
 				writer.Write(", ");
 			}
-			// writer.Write('(');
 			double vert[4] = {0, 0, 0, 0};
 			auto all_nan = true;
 			for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
@@ -582,9 +582,9 @@ void ToStringRecursive(BlobReader &reader, TextWriter &writer, idx_t depth, bool
 			}
 			if (all_nan) {
 				writer.Write("EMPTY");
-				// writer.Write(')');
 				continue;
 			}
+			// writer.Write('(');
 			for (uint32_t d_idx = 0; d_idx < dims; d_idx++) {
 				if (d_idx > 0) {
 					writer.Write(' ');

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -919,6 +919,13 @@ Value Value::BIGNUM(const string &data) {
 	return result;
 }
 
+Value Value::GEOMETRY(const_data_ptr_t data, idx_t len) {
+	Value result(LogicalTypeId::GEOMETRY);
+	result.is_null = false;
+	result.value_info_ = make_shared_ptr<StringValueInfo>(string(const_char_ptr_cast(data), len));
+	return result;
+}
+
 Value Value::BLOB(const string &data) {
 	Value result(LogicalType::BLOB);
 	result.is_null = false;

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -724,6 +724,10 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 		auto str = reinterpret_cast<bignum_t *>(data)[index];
 		return Value::BIGNUM(const_data_ptr_cast(str.data.GetData()), str.data.GetSize());
 	}
+	case LogicalTypeId::GEOMETRY: {
+		auto str = reinterpret_cast<string_t *>(data)[index];
+		return Value::GEOMETRY(const_data_ptr_cast(str.GetData()), str.GetSize());
+	}
 	case LogicalTypeId::AGGREGATE_STATE: {
 		auto str = reinterpret_cast<string_t *>(data)[index];
 		return Value::AGGREGATE_STATE(vector->GetType(), const_data_ptr_cast(str.GetData()), str.GetSize());

--- a/src/function/cast/CMakeLists.txt
+++ b/src/function/cast/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library_unity(
   decimal_cast.cpp
   default_casts.cpp
   enum_casts.cpp
+  geo_casts.cpp
   list_casts.cpp
   map_cast.cpp
   numeric_casts.cpp

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -162,6 +162,8 @@ BoundCastInfo DefaultCasts::GetDefaultCastFunction(BindCastInput &input, const L
 		return EnumCastSwitch(input, source, target);
 	case LogicalTypeId::ARRAY:
 		return ArrayCastSwitch(input, source, target);
+	case LogicalTypeId::GEOMETRY:
+		return GeoCastSwitch(input, source, target);
 	case LogicalTypeId::BIGNUM:
 		return BignumCastSwitch(input, source, target);
 	case LogicalTypeId::AGGREGATE_STATE:

--- a/src/function/cast/geo_casts.cpp
+++ b/src/function/cast/geo_casts.cpp
@@ -1,0 +1,24 @@
+#include "duckdb/common/types/geometry.hpp"
+#include "duckdb/function/cast/default_casts.hpp"
+#include "duckdb/function/cast/vector_cast_helpers.hpp"
+
+namespace duckdb {
+
+static bool GeometryToVarcharCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+	UnaryExecutor::Execute<string_t, string_t>(
+	    source, result, count, [&](const string_t &input) -> string_t { return Geometry::ToString(result, input); });
+	return true;
+}
+
+BoundCastInfo DefaultCasts::GeoCastSwitch(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
+
+	// now switch on the result type
+	switch (target.id()) {
+	case LogicalTypeId::VARCHAR:
+		return GeometryToVarcharCast;
+	default:
+		return TryVectorNullCast;
+	}
+}
+
+} // namespace duckdb

--- a/src/function/cast/string_cast.cpp
+++ b/src/function/cast/string_cast.cpp
@@ -490,6 +490,8 @@ BoundCastInfo DefaultCasts::StringCastSwitch(BindCastInput &input, const Logical
 		return BoundCastInfo(&VectorCastHelpers::TryCastStringLoop<string_t, string_t, duckdb::TryCastToBit>);
 	case LogicalTypeId::UUID:
 		return BoundCastInfo(&VectorCastHelpers::TryCastStringLoop<string_t, hugeint_t, duckdb::TryCastToUUID>);
+	case LogicalTypeId::GEOMETRY:
+		return BoundCastInfo(&VectorCastHelpers::TryCastStringLoop<string_t, string_t, duckdb::TryCastToGeometry>);
 	case LogicalTypeId::SQLNULL:
 		return &DefaultCasts::TryVectorNullCast;
 	case LogicalTypeId::VARCHAR:

--- a/src/function/cast/variant/from_variant.cpp
+++ b/src/function/cast/variant/from_variant.cpp
@@ -550,6 +550,11 @@ static bool CastVariant(FromVariantConversionData &conversion_data, Vector &resu
 			return CastVariantToPrimitive<VariantDirectConversion<string_t, VariantLogicalType::BLOB>>(
 			    conversion_data, result, sel, offset, count, row, string_payload);
 		}
+		case LogicalTypeId::GEOMETRY: {
+			StringConversionPayload string_payload(result);
+			return CastVariantToPrimitive<VariantDirectConversion<string_t, VariantLogicalType::GEOMETRY>>(
+			    conversion_data, result, sel, offset, count, row, string_payload);
+		}
 		case LogicalTypeId::VARCHAR: {
 			if (target_type.IsJSONType()) {
 				return CastVariantToJSON(conversion_data, result, sel, offset, count, row);
@@ -685,6 +690,8 @@ BoundCastInfo DefaultCasts::VariantCastSwitch(BindCastInput &input, const Logica
 	case LogicalTypeId::UNION:
 	case LogicalTypeId::UUID:
 	case LogicalTypeId::ARRAY:
+		return BoundCastInfo(CastFromVARIANT);
+	case LogicalTypeId::GEOMETRY:
 		return BoundCastInfo(CastFromVARIANT);
 	case LogicalTypeId::VARCHAR: {
 		return BoundCastInfo(CastFromVARIANT);

--- a/src/function/cast/variant/to_json.cpp
+++ b/src/function/cast/variant/to_json.cpp
@@ -149,6 +149,12 @@ yyjson_mut_val *VariantCasts::ConvertVariantToJSON(yyjson_mut_doc *doc, const Re
 		auto val_str = Value::BLOB(const_data_ptr_cast(string_data), string_length).ToString();
 		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
 	}
+	case VariantLogicalType::GEOMETRY: {
+		auto string_length = VarintDecode<uint32_t>(ptr);
+		auto string_data = reinterpret_cast<const char *>(ptr);
+		auto val_str = Value::GEOMETRY(const_data_ptr_cast(string_data), string_length).ToString();
+		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
+	}
 	case VariantLogicalType::VARCHAR: {
 		auto string_length = VarintDecode<uint32_t>(ptr);
 		auto string_data = reinterpret_cast<const char *>(ptr);

--- a/src/include/duckdb/catalog/default/builtin_types/types.hpp
+++ b/src/include/duckdb/catalog/default/builtin_types/types.hpp
@@ -19,7 +19,7 @@ struct DefaultType {
 	LogicalTypeId type;
 };
 
-using builtin_type_array = std::array<DefaultType, 76>;
+using builtin_type_array = std::array<DefaultType, 77>;
 
 static constexpr const builtin_type_array BUILTIN_TYPES{{
 	{"decimal", LogicalTypeId::DECIMAL},
@@ -97,7 +97,8 @@ static constexpr const builtin_type_array BUILTIN_TYPES{{
 	{"real", LogicalTypeId::FLOAT},
 	{"float4", LogicalTypeId::FLOAT},
 	{"double", LogicalTypeId::DOUBLE},
-	{"float8", LogicalTypeId::DOUBLE}
+	{"float8", LogicalTypeId::DOUBLE},
+	{"geometry", LogicalTypeId::GEOMETRY}
 }};
 
 } // namespace duckdb

--- a/src/include/duckdb/catalog/default/builtin_types/types.json
+++ b/src/include/duckdb/catalog/default/builtin_types/types.json
@@ -290,5 +290,12 @@
             "float8"
         ],
         "description": "double precision floating-point number (8 bytes)"
+    },
+    {
+        "id": "GEOMETRY",
+        "names": [
+            "geometry"
+        ],
+        "description": "A data type that represents geometric objects such as points, lines, and polygons."
     }
 ]

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -202,6 +202,8 @@ enum class FunctionStability : uint8_t;
 
 enum class GateStatus : uint8_t;
 
+enum class GeometryType : uint32_t;
+
 enum class HLLStorageType : uint8_t;
 
 enum class HTTPStatusCode : uint16_t;
@@ -705,6 +707,9 @@ const char* EnumUtil::ToChars<FunctionStability>(FunctionStability value);
 
 template<>
 const char* EnumUtil::ToChars<GateStatus>(GateStatus value);
+
+template<>
+const char* EnumUtil::ToChars<GeometryType>(GeometryType value);
 
 template<>
 const char* EnumUtil::ToChars<HLLStorageType>(HLLStorageType value);
@@ -1333,6 +1338,9 @@ FunctionStability EnumUtil::FromString<FunctionStability>(const char *value);
 
 template<>
 GateStatus EnumUtil::FromString<GateStatus>(const char *value);
+
+template<>
+GeometryType EnumUtil::FromString<GeometryType>(const char *value);
 
 template<>
 HLLStorageType EnumUtil::FromString<HLLStorageType>(const char *value);

--- a/src/include/duckdb/common/extra_type_info.hpp
+++ b/src/include/duckdb/common/extra_type_info.hpp
@@ -28,7 +28,8 @@ enum class ExtraTypeInfoType : uint8_t {
 	ARRAY_TYPE_INFO = 9,
 	ANY_TYPE_INFO = 10,
 	INTEGER_LITERAL_TYPE_INFO = 11,
-	TEMPLATE_TYPE_INFO = 12
+	TEMPLATE_TYPE_INFO = 12,
+	GEO_TYPE_INFO = 13
 };
 
 struct ExtraTypeInfo {
@@ -276,6 +277,18 @@ public:
 protected:
 	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
 	TemplateTypeInfo();
+};
+
+struct GeoTypeInfo : public ExtraTypeInfo {
+public:
+	GeoTypeInfo();
+
+	void Serialize(Serializer &serializer) const override;
+	static shared_ptr<ExtraTypeInfo> Deserialize(Deserializer &source);
+	shared_ptr<ExtraTypeInfo> Copy() const override;
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -1071,6 +1071,19 @@ template <>
 bool TryCastBlobToUUID::Operation(string_t input, hugeint_t &result, bool strict);
 
 //===--------------------------------------------------------------------===//
+// GEOMETRY
+//===--------------------------------------------------------------------===//
+struct TryCastToGeometry {
+	template <class SRC, class DST>
+	static inline bool Operation(SRC input, DST &result, Vector &result_vector, CastParameters &parameters) {
+		throw InternalException("Unsupported type for try cast to geometry");
+	}
+};
+
+template <>
+bool TryCastToGeometry::Operation(string_t input, string_t &result, Vector &result_vector, CastParameters &parameters);
+
+//===--------------------------------------------------------------------===//
 // Pointers
 //===--------------------------------------------------------------------===//
 struct CastFromPointer {

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -230,6 +230,8 @@ enum class LogicalTypeId : uint8_t {
 	VALIDITY = 53,
 	UUID = 54,
 
+	GEOMETRY = 60,
+
 	STRUCT = 100,
 	LIST = 101,
 	MAP = 102,
@@ -430,6 +432,7 @@ public:
 	DUCKDB_API static LogicalType UNION(child_list_t<LogicalType> members);      // NOLINT
 	DUCKDB_API static LogicalType ARRAY(const LogicalType &child, optional_idx index);   // NOLINT
 	DUCKDB_API static LogicalType ENUM(Vector &ordered_data, idx_t size); // NOLINT
+	DUCKDB_API static LogicalType GEOMETRY(); // NOLINT
 	// ANY but with special rules (default is LogicalType::ANY, 5)
 	DUCKDB_API static LogicalType ANY_PARAMS(LogicalType target, idx_t cast_score = 5); // NOLINT
 	DUCKDB_API static LogicalType TEMPLATE(const string &name);							// NOLINT

--- a/src/include/duckdb/common/types/geometry.hpp
+++ b/src/include/duckdb/common/types/geometry.hpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/time.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/types.hpp"
+
+namespace duckdb {
+
+enum class GeometryType : uint32_t {
+	INVALID = 0,
+	POINT = 1,
+	LINESTRING = 2,
+	POLYGON = 3,
+	MULTIPOINT = 4,
+	MULTILINESTRING = 5,
+	MULTIPOLYGON = 6,
+	GEOMETRYCOLLECTION = 7,
+};
+
+class Geometry {
+public:
+	static constexpr auto MAX_RECURSION_DEPTH = 16;
+
+	DUCKDB_API static bool FromString(const string_t &wkt_text, string_t &result, Vector &result_vector, bool strict);
+	DUCKDB_API static string_t ToString(Vector &result, const string_t &geom);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -201,6 +201,8 @@ public:
 	DUCKDB_API static Value BIGNUM(const_data_ptr_t data, idx_t len);
 	DUCKDB_API static Value BIGNUM(const string &data);
 
+	DUCKDB_API static Value GEOMETRY(const_data_ptr_t data, idx_t len);
+
 	//! Creates an aggregate state
 	DUCKDB_API static Value AGGREGATE_STATE(const LogicalType &type, const_data_ptr_t data, idx_t len); // NOLINT
 

--- a/src/include/duckdb/common/types/variant.hpp
+++ b/src/include/duckdb/common/types/variant.hpp
@@ -105,6 +105,7 @@ enum class VariantLogicalType : uint8_t {
 	ARRAY = 30,
 	BIGNUM = 31,
 	BITSTRING = 32,
+	GEOMETRY = 33,
 	ENUM_SIZE /* always kept as last item of the enum */
 };
 

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -170,6 +170,7 @@ private:
 	static BoundCastInfo UnionCastSwitch(BindCastInput &input, const LogicalType &source, const LogicalType &target);
 	static BoundCastInfo VariantCastSwitch(BindCastInput &input, const LogicalType &source, const LogicalType &target);
 	static BoundCastInfo UUIDCastSwitch(BindCastInput &input, const LogicalType &source, const LogicalType &target);
+	static BoundCastInfo GeoCastSwitch(BindCastInput &input, const LogicalType &source, const LogicalType &target);
 	static BoundCastInfo BignumCastSwitch(BindCastInput &input, const LogicalType &source, const LogicalType &target);
 	static BoundCastInfo ImplicitToUnionCast(BindCastInput &input, const LogicalType &source,
 	                                         const LogicalType &target);

--- a/src/include/duckdb/function/cast/variant/primitive_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/primitive_to_variant.hpp
@@ -357,6 +357,9 @@ bool ConvertPrimitiveToVariant(ToVariantSourceData &source, ToVariantGlobalResul
 	case LogicalTypeId::CHAR:
 		return ConvertPrimitiveTemplated<WRITE_DATA, IGNORE_NULLS, VariantLogicalType::VARCHAR, string_t>(
 		    source, result, count, selvec, values_index_selvec, empty_payload, is_root);
+	case LogicalTypeId::GEOMETRY:
+		return ConvertPrimitiveTemplated<WRITE_DATA, IGNORE_NULLS, VariantLogicalType::GEOMETRY, string_t>(
+		    source, result, count, selvec, values_index_selvec, empty_payload, is_root);
 	case LogicalTypeId::BLOB:
 		return ConvertPrimitiveTemplated<WRITE_DATA, IGNORE_NULLS, VariantLogicalType::BLOB, string_t>(
 		    source, result, count, selvec, values_index_selvec, empty_payload, is_root);

--- a/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
@@ -240,7 +240,7 @@ bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalRe
 				}
 			} else if (source_type_id == VariantLogicalType::BITSTRING ||
 			           source_type_id == VariantLogicalType::BIGNUM || source_type_id == VariantLogicalType::VARCHAR ||
-			           source_type_id == VariantLogicalType::BLOB) {
+			           source_type_id == VariantLogicalType::BLOB || source_type_id == VariantLogicalType::GEOMETRY) {
 				auto str_blob_data = source_blob_data + source_byte_offset;
 				auto str_length = VarintDecode<uint32_t>(str_blob_data);
 				auto str_length_varint_size = GetVarintSize(str_length);

--- a/src/include/duckdb/storage/serialization/types.json
+++ b/src/include/duckdb/storage/serialization/types.json
@@ -248,5 +248,12 @@
         "type": "string"
       }
     ]
+  },
+  {
+    "class": "GeoTypeInfo",
+    "base": "ExtraTypeInfo",
+    "enum": "GEO_TYPE_INFO",
+    "members": [
+    ]
   }
 ]

--- a/src/storage/serialization/serialize_types.cpp
+++ b/src/storage/serialization/serialize_types.cpp
@@ -42,6 +42,9 @@ shared_ptr<ExtraTypeInfo> ExtraTypeInfo::Deserialize(Deserializer &deserializer)
 	case ExtraTypeInfoType::GENERIC_TYPE_INFO:
 		result = make_shared_ptr<ExtraTypeInfo>(type);
 		break;
+	case ExtraTypeInfoType::GEO_TYPE_INFO:
+		result = GeoTypeInfo::Deserialize(deserializer);
+		break;
 	case ExtraTypeInfoType::INTEGER_LITERAL_TYPE_INFO:
 		result = IntegerLiteralTypeInfo::Deserialize(deserializer);
 		break;
@@ -134,6 +137,15 @@ unique_ptr<ExtensionTypeInfo> ExtensionTypeInfo::Deserialize(Deserializer &deser
 	deserializer.ReadPropertyWithDefault<vector<LogicalTypeModifier>>(100, "modifiers", result->modifiers);
 	deserializer.ReadPropertyWithExplicitDefault<unordered_map<string, Value>>(101, "properties", result->properties, unordered_map<string, Value>());
 	return result;
+}
+
+void GeoTypeInfo::Serialize(Serializer &serializer) const {
+	ExtraTypeInfo::Serialize(serializer);
+}
+
+shared_ptr<ExtraTypeInfo> GeoTypeInfo::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::shared_ptr<GeoTypeInfo>(new GeoTypeInfo());
+	return std::move(result);
 }
 
 void IntegerLiteralTypeInfo::Serialize(Serializer &serializer) const {

--- a/test/sql/types/geo/geometry.test
+++ b/test/sql/types/geo/geometry.test
@@ -1,0 +1,64 @@
+# name: test/sql/types/geo/geometry.test
+# group: [geo]
+
+statement ok
+create table t1(id INT, g GEOMETRY);
+
+# Note: We print multipoints as POINTs, without extra parentheses, like PostGIS does
+# But both syntaxes are accepted input
+
+statement ok
+insert into t1 values
+	(1, 'POINT(0 1)'),
+	(2, 'LINESTRING(0 0, 1 1, 2 2)'),
+	(3, 'POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))'),
+	(4, 'MULTIPOINT((1 1), (2 2), (3 3))'),
+	(5, 'MULTIPOINT(1 1, 2 2, 3 3)'), --alternative syntax
+	(6, 'MULTILINESTRING((0 0, 1 1), (2 2, 3 3))'),
+	(7, 'MULTIPOLYGON(((0 0, 4 0, 4 4, 0 4, 0 0)), ((5 5, 7 5, 7 7, 5 7, 5 5)))'),
+	(8, 'GEOMETRYCOLLECTION(POINT(1 1), LINESTRING(0 0, 1 1))'),
+	(9, NULL);
+
+query II
+select id, g::VARCHAR from t1 order by id;
+----
+1	POINT (0 1)
+2	LINESTRING (0 0, 1 1, 2 2)
+3	POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))
+4	MULTIPOINT (1 1, 2 2, 3 3)
+5	MULTIPOINT (1 1, 2 2, 3 3)
+6	MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))
+7	MULTIPOLYGON (((0 0, 4 0, 4 4, 0 4, 0 0)), ((5 5, 7 5, 7 7, 5 7, 5 5)))
+8	GEOMETRYCOLLECTION (POINT (1 1), LINESTRING (0 0, 1 1))
+9	NULL
+
+# Handle empty geometries
+statement ok
+create table t2(id INT, g GEOMETRY);
+
+statement ok
+insert into t2 values
+	(1, 'POINT EMPTY'),
+	(2, 'LINESTRING EMPTY'),
+	(3, 'POLYGON EMPTY'),
+	(4, 'MULTIPOINT EMPTY'),
+	(5, 'MULTILINESTRING EMPTY'),
+	(6, 'MULTIPOLYGON EMPTY'),
+	(7, 'GEOMETRYCOLLECTION EMPTY'),
+
+query II
+select id, g::VARCHAR from t2 order by id;
+----
+1	POINT EMPTY
+2	LINESTRING EMPTY
+3	POLYGON EMPTY
+4	MULTIPOINT EMPTY
+5	MULTILINESTRING EMPTY
+6	MULTIPOLYGON EMPTY
+7	GEOMETRYCOLLECTION EMPTY
+
+# Special case
+query I
+SELECT 'MULTIPOINT(EMPTY, 2 2, EMPTY)'::GEOMETRY::VARCHAR;
+----
+MULTIPOINT (EMPTY, 2 2, EMPTY)

--- a/test/sql/types/geo/geometry.test
+++ b/test/sql/types/geo/geometry.test
@@ -62,3 +62,62 @@ query I
 SELECT 'MULTIPOINT(EMPTY, 2 2, EMPTY)'::GEOMETRY::VARCHAR;
 ----
 MULTIPOINT (EMPTY, 2 2, EMPTY)
+
+
+# Z/M/ZM coordinates
+statement ok
+create table t3(id INT, g GEOMETRY);
+
+statement ok
+insert into t3 values
+	(1, 'POINT Z (1 2 3)'),
+	(2, 'POINT M (1 2 3)'),
+	(3, 'POINT ZM (1 2 3 4)'),
+	(4, 'LINESTRING Z (0 0 0, 1 1 1, 2 2 2)'),
+	(5, 'LINESTRING M (0 0 0, 1 1 1, 2 2 2)'),
+	(6, 'LINESTRING ZM (0 0 0 0, 1 1 1 1, 2 2 2 2)'),
+	(7, 'POLYGON Z ((0 0 0, 4 0 0, 4 4 0, 0 4 0, 0 0 0))'),
+	(8, 'POLYGON M ((0 0 0, 4 0 0, 4 4 0, 0 4 0, 0 0 0))'),
+	(9, 'POLYGON ZM ((0 0 0 0, 4 0 0 0, 4 4 0 0, 0 4 0 0, 0 0 0 0))'),
+	(10, 'MULTIPOINT Z ((1 1 1), (2 2 2), (3 3 3))'),
+	(11, 'MULTIPOINT M ((1 1 1), (2 2 2), (3 3 3))'),
+	(12, 'MULTIPOINT ZM ((1 1 1 1), (2 2 2 2), (3 3 3 3))'),
+	(13, 'MULTILINESTRING Z ((0 0 0, 1 1 1), (2 2 2, 3 3 3))'),
+	(14, 'MULTILINESTRING M ((0 0 0, 1 1 1), (2 2 2, 3 3 3))'),
+	(15, 'MULTILINESTRING ZM ((0 0 0 0, 1 1 1 1), (2 2 2 2, 3 3 3 3))'),
+	(16, 'MULTIPOLYGON Z (((0 0 0,4 0 0,4 4 0,0 4 0,0 0 0)),((5 5 5,7 5 5,7 7 5,5 7 5,5 5 5)))'),
+	(17, 'MULTIPOLYGON M (((0 0 0,4 0 0,4 4 0,0 4 0,0 0 0)),((5 5 5,7 5 5,7 7 5,5 7 5,5 5 5)))'),
+	(18, 'MULTIPOLYGON ZM (((0 0 0 0,4 0 0 0,4 4 0 0,0 4 0 0,0 0 0 0)),((5 5 5 5,7 5 5 5,7 7 5 5,5 7 5 5,5 5 5 5)))'),
+	(19, 'GEOMETRYCOLLECTION Z (POINT Z (1 1 1), LINESTRING Z (0 0 0, 1 1 1))'),
+	(20, 'GEOMETRYCOLLECTION M (POINT M (1 1 1), LINESTRING M (0 0 0, 1 1 1))'),
+	(21, 'GEOMETRYCOLLECTION ZM (POINT ZM (1 1 1 1), LINESTRING ZM (0 0 0 0, 1 1 1 1))');
+
+query II
+select id, g::VARCHAR from t3 order by id;
+----
+1	POINT Z (1 2 3)
+2	POINT M (1 2 3)
+3	POINT ZM (1 2 3 4)
+4	LINESTRING Z (0 0 0, 1 1 1, 2 2 2)
+5	LINESTRING M (0 0 0, 1 1 1, 2 2 2)
+6	LINESTRING ZM (0 0 0 0, 1 1 1 1, 2 2 2 2)
+7	POLYGON Z ((0 0 0, 4 0 0, 4 4 0, 0 4 0, 0 0 0))
+8	POLYGON M ((0 0 0, 4 0 0, 4 4 0, 0 4 0, 0 0 0))
+9	POLYGON ZM ((0 0 0 0, 4 0 0 0, 4 4 0 0, 0 4 0 0, 0 0 0 0))
+10	MULTIPOINT Z (1 1 1, 2 2 2, 3 3 3)
+11	MULTIPOINT M (1 1 1, 2 2 2, 3 3 3)
+12	MULTIPOINT ZM (1 1 1 1, 2 2 2 2, 3 3 3 3)
+13	MULTILINESTRING Z ((0 0 0, 1 1 1), (2 2 2, 3 3 3))
+14	MULTILINESTRING M ((0 0 0, 1 1 1), (2 2 2, 3 3 3))
+15	MULTILINESTRING ZM ((0 0 0 0, 1 1 1 1), (2 2 2 2, 3 3 3 3))
+16	MULTIPOLYGON Z (((0 0 0, 4 0 0, 4 4 0, 0 4 0, 0 0 0)), ((5 5 5, 7 5 5, 7 7 5, 5 7 5, 5 5 5)))
+17	MULTIPOLYGON M (((0 0 0, 4 0 0, 4 4 0, 0 4 0, 0 0 0)), ((5 5 5, 7 5 5, 7 7 5, 5 7 5, 5 5 5)))
+18	MULTIPOLYGON ZM (((0 0 0 0, 4 0 0 0, 4 4 0 0, 0 4 0 0, 0 0 0 0)), ((5 5 5 5, 7 5 5 5, 7 7 5 5, 5 7 5 5, 5 5 5 5)))
+19	GEOMETRYCOLLECTION Z (POINT Z (1 1 1), LINESTRING Z (0 0 0, 1 1 1))
+20	GEOMETRYCOLLECTION M (POINT M (1 1 1), LINESTRING M (0 0 0, 1 1 1))
+21	GEOMETRYCOLLECTION ZM (POINT ZM (1 1 1 1), LINESTRING ZM (0 0 0 0, 1 1 1 1))
+
+statement error
+select 'GEOMETRYCOLLECTION Z (POINT Z (1 1 2), LINESTRING (0 0, 1 1))'::GEOMETRY;
+----
+Invalid Input Error: Geometry has inconsistent Z/M dimensions


### PR DESCRIPTION
This PR adds a dedicated `GEOMETRY` logical type into core DuckDB. The internal representation is currently [WKB-encoded](https://libgeos.org/specifications/wkb/) `BLOB`, but that will likely change in a future PR. No functions are implemented for this type, except to/from `VARCHAR` casts.

This is the first PR in a long series of changes thats going to be pushed the coming weeks, with the ultimate goal of significantly elevating DuckDBs geospatial capabilities for the DuckDB v1.5 release in early 2026.

### Background

So far DuckDB has (mostly) contained all geospatial features in the `spatial` extension. This has worked great as it has allowed us to independently and rapidly experiment with how to adapt geospatial processing to DuckDBs engine, while also keeping a lot of the domain-specific details and dependencies separate from core DuckDBs core codebase. Besides integrating a lot of third-party geospatial libraries, `spatial` has also been integrating deeply into DuckDBs core execution engine and made itself dependent on a lot of fragile interfaces within DuckDBs internals (custom operators, optimizer rules, indexes, etc). Fast forward to today, and `spatial` is one of DuckDBs largest and most complex extensions. 

While this complexity has been somewhat manageable so far, we're now reaching a point where it's no longer feasible to relegate all geospatial related stuff into a single separate extension. There's already some awkwardness when dealing with e.g. Pandas/Postgres/SQLite through DuckDB, which have their own geospatial extensions (GeoPandas, PostGIS, GeoPackage/SpatiaLite) as core DuckDB doesn't really want to acknowledge anything spatial specific and we don't want to introduce inter-extension dependencies either. But geospatial support is now also part of the parquet standard itself, which is of much higher importance to DuckDB, as well as supported by all up and coming data lake formats. 

In short: [Geospatial data Isn't special (anymore)](https://forrest.nyc/why-cloud-native-geospatial-data-is-making-spatial-just-data-again/)

### What's changing

Therefore we're taking some steps to making vanilla DuckDB spatial aware, by moving the `GEOMETRY` type from `spatial` into core DuckDB. 

While almost all of the geospatial functionality will still remain in `spatial` (e.g. 99% of `ST_` functions), this will give our (and community!) extensions and client libraries some common ground as they can all interface with the same `GEOMETRY` type. We will also make sure that existing databases that use the `GEOMETRY` type as currently defined in `spatial` will remain compatible.

Additionally, because `GEOMETRY` will now become part of both DuckDBs execution and storage engine, this opens up a lot of optimization opportunities that are currently impractical/impossible to implement solely in `spatial`. The two big ones being __statistics propagation__ and __compression__, which will significantly improve performance of processing both external formats like (Geo)Parquet and DuckDBs own storage format.

Again, this is a pretty massive change. I have prototyped most of it on my own fork(s), but will break it up into multiple PR's keep it manageable. The rough short-term roadmap looks something like this:

- [x] Add the `GEOMETRY` to core
- [x] Add geometry statistics support (Implemented in #19203)
- [x] Add geometry filter pushdown using statistics (implemented in #19439)
- [x] Fixup `parquet` extension (implemented in https://github.com/duckdb/duckdb/pull/19476)
- [x] Fixup `spatial` extension
- [x] Dedicated geometry storage/compression (Shredding implemented in https://github.com/duckdb/duckdb/pull/20281)
- [x] Type-level CRS tracking/management (Initially implemented in https://github.com/duckdb/duckdb/pull/20143)
- [ ] Maybe `GEOGRAPHY`/"vectorized types" too

Client/other extension integrations etc, etc, is planned to get in before 1.5 as well, but we will first focus on core/parquet/spatial.

This PR also removes spatial from the CI workflow until I've had time adapt it to these changes, but that will hopefully not take too long (I have an old branch with most of the work already)

