### PR TITLE
Validate JSON in Parquet reader

### DIFF
--- a/extension/json/include/json_common.hpp
+++ b/extension/json/include/json_common.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/operator/string_cast.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "yyjson.hpp"
+#include "duckdb/common/types/blob.hpp"
 
 using namespace duckdb_yyjson; // NOLINT
 
@@ -228,11 +229,8 @@ public:
 
 	static string FormatParseError(const char *data, idx_t length, yyjson_read_err &error, const string &extra = "") {
 		D_ASSERT(error.code != YYJSON_READ_SUCCESS);
-		// Go to blob so we can have a better error message for weird strings
-		auto blob = Value::BLOB(string(data, length));
 		// Truncate, so we don't print megabytes worth of JSON
-		string input = blob.ToString();
-		input = input.length() > 50 ? string(input.c_str(), 47) + "..." : input;
+		auto input = length > 50 ? string(data, 47) + "..." : string(data, length);
 		// Have to replace \r, otherwise output is unreadable
 		input = StringUtil::Replace(input, "\r", "\\r");
 		return StringUtil::Format("Malformed JSON at byte %lld of input: %s. %s Input: \"%s\"", error.pos, error.msg,

--- a/extension/parquet/include/reader/string_column_reader.hpp
+++ b/extension/parquet/include/reader/string_column_reader.hpp
@@ -14,12 +14,25 @@
 namespace duckdb {
 
 class StringColumnReader : public ColumnReader {
+	enum class StringColumnType : uint8_t { VARCHAR, JSON, OTHER };
+
+	static StringColumnType GetStringColumnType(const LogicalType &type) {
+		if (type.IsJSONType()) {
+			return StringColumnType::JSON;
+		}
+		if (type.id() == LogicalTypeId::VARCHAR) {
+			return StringColumnType::VARCHAR;
+		}
+		return StringColumnType::OTHER;
+	}
+
 public:
 	static constexpr const PhysicalType TYPE = PhysicalType::VARCHAR;
 
 public:
 	StringColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema);
 	idx_t fixed_width_string_length;
+	const StringColumnType string_column_type;
 
 public:
 	static void VerifyString(const char *str_data, uint32_t str_len, const bool isVarchar);

--- a/extension/parquet/reader/string_column_reader.cpp
+++ b/extension/parquet/reader/string_column_reader.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 // String Column Reader
 //===--------------------------------------------------------------------===//
 StringColumnReader::StringColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
-    : ColumnReader(reader, schema) {
+    : ColumnReader(reader, schema), string_column_type(GetStringColumnType(Type())) {
 	fixed_width_string_length = 0;
 	if (schema.parquet_type == Type::FIXED_LEN_BYTE_ARRAY) {
 		fixed_width_string_length = schema.type_length;
@@ -26,13 +26,26 @@ void StringColumnReader::VerifyString(const char *str_data, uint32_t str_len, co
 	size_t pos;
 	auto utf_type = Utf8Proc::Analyze(str_data, str_len, &reason, &pos);
 	if (utf_type == UnicodeType::INVALID) {
-		throw InvalidInputException("Invalid string encoding found in Parquet file: value \"" +
-		                            Blob::ToString(string_t(str_data, str_len)) + "\" is not valid UTF8!");
+		throw InvalidInputException("Invalid string encoding found in Parquet file: value \"%s\" is not valid UTF8!",
+		                            Blob::ToString(string_t(str_data, str_len)));
 	}
 }
 
 void StringColumnReader::VerifyString(const char *str_data, uint32_t str_len) {
-	VerifyString(str_data, str_len, Type().id() == LogicalTypeId::VARCHAR);
+	switch (string_column_type) {
+	case StringColumnType::VARCHAR:
+		VerifyString(str_data, str_len, true);
+		break;
+	case StringColumnType::JSON: {
+		const auto error = StringUtil::ValidateJSON(str_data, str_len);
+		if (!error.empty()) {
+			throw InvalidInputException("Invalid JSON found in Parquet file: %s", error);
+		}
+		break;
+	}
+	default:
+		break;
+	}
 }
 
 class ParquetStringVectorBuffer : public VectorBuffer {

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -708,10 +708,6 @@ string StringUtil::ValidateJSON(const char *data, const idx_t &len) {
 	    YYJSON_READ_ALLOW_INF_AND_NAN | YYJSON_READ_ALLOW_TRAILING_COMMAS | YYJSON_READ_BIGNUM_AS_RAW;
 	yyjson_read_err error;
 	yyjson_doc *doc = yyjson_read_opts((char *)data, len, READ_FLAG, nullptr, &error); // NOLINT: for yyjson
-	if (!doc) {
-		return StringUtil::Format("Failed to parse JSON string: %s", string(data, len));
-	}
-
 	if (error.code != YYJSON_READ_SUCCESS) {
 		return StringUtil::Format("Malformed JSON at byte %lld of input: %s. Input: \"%s\"", error.pos, error.msg,
 		                          string(data, len));

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -318,6 +318,8 @@ public:
 	//! Transforms an complex JSON to a JSON string
 	DUCKDB_API static string ToComplexJSONMap(const ComplexJSON &complex_json);
 
+	DUCKDB_API static string ValidateJSON(const char *data, const idx_t &len);
+
 	DUCKDB_API static string GetFileName(const string &file_path);
 	DUCKDB_API static string GetFileExtension(const string &file_name);
 	DUCKDB_API static string GetFileStem(const string &file_name);


### PR DESCRIPTION
Just like we validate UTF-8 in the Parquet reader, this PR adds validation for JSON. This avoids ingesting invalid JSON as the `JSON` type in DuckDB. Since we assume that any JSON stored in the `JSON` type is valid, this avoids hard-to-understand issues with non-descriptive errors down the line.

Fixes https://github.com/duckdb/duckdb/issues/19113