### PR TITLE
Delay throwing `NotImplementedException` in `ExpressionBinder`

### DIFF
--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -103,7 +103,9 @@ BindResult ExpressionBinder::BindExpression(unique_ptr<ParsedExpression> &expr, 
 	case ExpressionClass::STAR:
 		return BindResult(BinderException::Unsupported(expr_ref, "STAR expression is not supported here"));
 	default:
-		throw NotImplementedException("Unimplemented expression class");
+		return BindResult(
+		    NotImplementedException("Unimplemented expression class in ExpressionBinder::BindExpression: %s",
+		                            EnumUtil::ToString(expr_ref.GetExpressionClass())));
 	}
 }
 

--- a/test/sql/catalog/function/test_macro_issue_19119.test
+++ b/test/sql/catalog/function/test_macro_issue_19119.test
@@ -1,0 +1,12 @@
+# name: test/sql/catalog/function/test_macro_issue_19119.test
+# description: Test Issue 19119 - Regression: combination of window functions and RAISE_EVEN raises "Not implemented Error: Unimplemented expression class"
+# group: [function]
+
+statement ok
+CREATE TABLE t (x INT);
+
+statement ok
+INSERT INTO t (x) VALUES (1), (2);
+
+statement ok
+SELECT ROUND_EVEN(SUM(x) OVER (), 0) AS y FROM t;


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/19119

Since v1.4.0 we bind macro arguments to determine their type. We do this using a temporary `ExpressionBinder` that we create, which is not able to bind `ExpressionClass::WINDOW`, which only `SelectBinder` can do.

We already have a path to success for expressions that we cannot bind: default to the previous (pre v1.4.0) behaviour by using `LogicalType::UNKNOWN`. However, the `ExpressionBinder` immediately would immediately throw, instead of wrapping the error in a `BindResult`. This PR wraps the error instead of throwing immediately, allowing us to detect this and continue as before.