### PR TITLE
MRE for replacement scan on file with same name as cte bug

### DIFF
--- a/test/sql/cte/cte_with_replacement_scan.test
+++ b/test/sql/cte/cte_with_replacement_scan.test
@@ -1,0 +1,17 @@
+# name: test/sql/cte/cte_with_replacement_scan.test
+# description: Test CTE with same name as file
+# group: [cte]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+copy (select 42 as answer) to 'df.parquet';
+
+query I
+WITH 'df.parquet' AS (
+	SELECT answer FROM 'df.parquet'
+)
+SELECT * FROM 'df.parquet';
+----
+42


### PR DESCRIPTION
This MRE errors on latest main, and not on 1.4.0:
```bash
❯ duckdb
DuckDB v1.4.0 (Andium) b8a06e4a22
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D copy (select 42 as answer) to 'df.parquet';
D WITH 'df.parquet' AS (
      SELECT answer FROM 'df.parquet'
  )
  SELECT * FROM 'df.parquet';
┌────────┐
│ answer │
│ int32  │
├────────┤
│   42   │
└────────┘

❯ ./build/release/duckdb
DuckDB v1.5.0-dev370 (Development Version) 4bfb6e2f8c
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D WITH 'df.parquet' AS (
      SELECT answer FROM 'df.parquet'
  )
  SELECT * FROM 'df.parquet';
Binder Error:
Circular reference to CTE "df.parquet", There are two possible solutions.
1. use WITH RECURSIVE to use recursive CTEs.
2. If you want to use the TABLE name "df.parquet" the same as the CTE name, please explicitly add "SCHEMA" before table name. You can try "main.df.parquet" (main is the duckdb default schema)

LINE 2:     SELECT answer FROM 'df.parquet'
                               ^
```