### PR TITLE
fix: add flag to indicate if CopyStatement has been previously processed by the `.plan` function.

### DIFF
--- a/src/include/duckdb/parser/statement/copy_statement.hpp
+++ b/src/include/duckdb/parser/statement/copy_statement.hpp
@@ -27,6 +27,8 @@ public:
 
 	string ToString() const override;
 
+	bool has_been_planned = false;
+
 protected:
 	CopyStatement(const CopyStatement &other);
 

--- a/src/parser/statement/copy_statement.cpp
+++ b/src/parser/statement/copy_statement.cpp
@@ -2,10 +2,12 @@
 
 namespace duckdb {
 
-CopyStatement::CopyStatement() : SQLStatement(StatementType::COPY_STATEMENT), info(make_uniq<CopyInfo>()) {
+CopyStatement::CopyStatement()
+    : SQLStatement(StatementType::COPY_STATEMENT), info(make_uniq<CopyInfo>()), has_been_planned(false) {
 }
 
-CopyStatement::CopyStatement(const CopyStatement &other) : SQLStatement(other), info(other.info->Copy()) {
+CopyStatement::CopyStatement(const CopyStatement &other)
+    : SQLStatement(other), info(other.info->Copy()), has_been_planned(other.has_been_planned) {
 }
 
 string CopyStatement::ToString() const {

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -86,8 +86,9 @@ case_insensitive_map_t<CopyOption> Binder::GetFullCopyOptionsList(const CopyFunc
 }
 
 BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &function, CopyToType copy_to_type) {
-	if (function.plan) {
+	if (function.plan && !stmt.has_been_planned) {
 		// plan rewrite COPY TO
+		stmt.has_been_planned = true;
 		return function.plan(*this, stmt);
 	}
 


### PR DESCRIPTION
This change adds a new flag to the `CopyStatement` to indicate if it has previously been processed with the `plan` function.  This prevents an infinite loop as describe in issue #19165.

