### PR TITLE
Validate filesystem registration

### DIFF
--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -144,10 +144,11 @@ vector<OpenFileInfo> VirtualFileSystem::Glob(const string &path, FileOpener *ope
 
 void VirtualFileSystem::RegisterSubSystem(unique_ptr<FileSystem> fs) {
 	// Sub-filesystem number is not expected to be huge, also filesystem registration should be called infrequently.
-	const auto& name = fs->GetName();
+	const auto &name = fs->GetName();
 	for (auto sub_system = sub_systems.begin(); sub_system != sub_systems.end(); sub_system++) {
 		if (sub_system->get()->GetName() == name) {
-			throw InvalidInputException("Filesystem with name %s has already been registered, cannot re-register!", name);
+			throw InvalidInputException("Filesystem with name %s has already been registered, cannot re-register!",
+			                            name);
 		}
 	}
 	sub_systems.push_back(std::move(fs));

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -143,6 +143,13 @@ vector<OpenFileInfo> VirtualFileSystem::Glob(const string &path, FileOpener *ope
 }
 
 void VirtualFileSystem::RegisterSubSystem(unique_ptr<FileSystem> fs) {
+	// Sub-filesystem number is not expected to be huge, also filesystem registration should be called infrequently.
+	const auto& name = fs->GetName();
+	for (auto sub_system = sub_systems.begin(); sub_system != sub_systems.end(); sub_system++) {
+		if (sub_system->get()->GetName() == name) {
+			throw InvalidInputException("Filesystem with name %s has already been registered, cannot re-register!", name);
+		}
+	}
 	sub_systems.push_back(std::move(fs));
 }
 

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -224,3 +224,15 @@ TEST_CASE("extract subsystem", "[file_system]") {
 	vfs.SetDisabledFileSystems(disabled_subfilesystems);
 	REQUIRE(vfs.ExtractSubSystem(target_fs) == nullptr);
 }
+
+TEST_CASE("re-register subsystem", "[file_system]") {
+	duckdb::VirtualFileSystem vfs;
+
+	// First time registration should succeed.
+	auto local_filesystem = FileSystem::CreateLocal();
+	vfs.RegisterSubSystem(std::move(local_filesystem));
+
+	// Re-register an already registered subfilesystem should throw.
+	auto second_local_filesystem = FileSystem::CreateLocal();
+	REQUIRE_THROWS(vfs.RegisterSubSystem(std::move(second_local_filesystem)));
+}


### PR DESCRIPTION
I'm trying to write a new filesystem extension, and I found registering the same filesystem for multiple times doesn't seem to throw error or logging message, which leads to confusing behavior later on.

This PR adds assertion that one filesystem (which is uniquely determined by its name) can only registered for at most once.