### PR TITLE
Print help to stdout

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4763,17 +4763,17 @@ static const char zOptions[] =
     "   -unsigned            allow loading of unsigned extensions\n"
     "   -version             show DuckDB version\n";
 static void usage(int showDetail) {
-	utf8_printf(stderr,
+	utf8_printf(stdout,
 	            "Usage: %s [OPTIONS] FILENAME [SQL]\n"
 	            "FILENAME is the name of a DuckDB database. A new database is created\n"
 	            "if the file does not previously exist.\n",
 	            program_name);
 	if (showDetail) {
-		utf8_printf(stderr, "OPTIONS include:\n%s", zOptions);
+		utf8_printf(stdout, "OPTIONS include:\n%s", zOptions);
 	} else {
-		raw_printf(stderr, "Use the -help option for additional information\n");
+		raw_printf(stdout, "Use the -help option for additional information\n");
 	}
-	exit(1);
+	exit(0);
 }
 
 /*

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -1132,5 +1132,10 @@ def test_tables_invalid_pattern_handling(shell):
     # Should show usage message for invalid pattern
     result.check_stderr("Usage: .tables ?TABLE?")
 
+def test_help_prints_to_stdout(shell):
+    test = ShellTest(shell, ["--help"])
+    result = test.run()
+    result.check_stdout("OPTIONS include:")
+
 
 # fmt: on


### PR DESCRIPTION
This PR changes the `-help` output from `stderr` (inherited from SQLite) to `stdout` and changes its exit status to `0` to follow [GNU Coding Standards](https://www.gnu.org/prep/standards/standards.html):

> 4.8.2 --help
> The standard --help option should output brief documentation for how
> to invoke the program, on standard output, then exit successfully.

Testing: new shell test added.

Fixes: #19003