### PR TITLE
Issue #18303: AsOf NLJ Nulls

### DIFF
--- a/src/execution/physical_plan/plan_asof_join.cpp
+++ b/src/execution/physical_plan/plan_asof_join.cpp
@@ -27,7 +27,7 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 	//
 	//		 ∏ * \ pk
 	//		 |
-	//		 Γ pk;first(P),arg_xxx(B,inequality)
+	//		 Γ pk;first(P),arg_xxx_null(B,inequality)
 	//		 |
 	//		 ∏ *,inequality
 	//		 |
@@ -88,13 +88,13 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 		case ExpressionType::COMPARE_GREATERTHAN:
 			D_ASSERT(asof_idx == op.conditions.size());
 			asof_idx = i;
-			arg_min_max = "arg_max";
+			arg_min_max = "arg_max_null";
 			break;
 		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
 		case ExpressionType::COMPARE_LESSTHAN:
 			D_ASSERT(asof_idx == op.conditions.size());
 			asof_idx = i;
-			arg_min_max = "arg_min";
+			arg_min_max = "arg_min_null";
 			break;
 		case ExpressionType::COMPARE_EQUAL:
 		case ExpressionType::COMPARE_NOTEQUAL:

--- a/test/sql/join/asof/test_asof_join_timestamps.test
+++ b/test/sql/join/asof/test_asof_join_timestamps.test
@@ -29,6 +29,18 @@ INSERT INTO probe0 VALUES
 	('infinity')
 ;
 
+statement ok
+CREATE TABLE asof_nulls (
+	time TIMESTAMP,
+	value FLOAT
+);
+
+statement ok
+INSERT INTO asof_nulls (time, value) VALUES ('2025-07-15 00:00:00', 42);
+
+statement ok
+INSERT INTO asof_nulls (time, value) VALUES ('2025-07-15 01:00:00', null);
+
 # Compare NLJ optimisation to operator
 foreach threshold 0 32
 
@@ -207,5 +219,13 @@ ON p.begin >= e.begin
 ORDER BY p.begin ASC
 ----
 2023-03-21 12:00:00
+
+# Return NULLs
+query II
+SELECT time_series.time, asof_nulls.value
+FROM (VALUES ('2025-07-15 02:00:00'::TIMESTAMP)) as time_series(time)
+ASOF LEFT JOIN asof_nulls ON asof_nulls.time <= time_series.time;
+----
+2025-07-15 02:00:00	NULL
 
 endloop


### PR DESCRIPTION
* Use arg_min/max_nulls so that null results are returned by the NLJ plan.

fixes: duckdb#18303
fixes: duckdblabs/duckdb-internal#5358