### PR TITLE
HTTPUtil: response might be null, perform check

### DIFF
--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -367,7 +367,9 @@ HTTPUtil::RunRequestWithRetry(const std::function<unique_ptr<HTTPResponse>(void)
 
 		try {
 			response = on_request();
-			response->url = request.url;
+			if (response) {
+				response->url = request.url;
+			}
 		} catch (IOException &e) {
 			exception_error = e.what();
 			caught_e = std::current_exception();


### PR DESCRIPTION
Minor, not actually happening (I think), but given nullptr is a valid return value, it's handy to just handle it properly.