### PR TITLE
Add option for opt-in to parser override

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -55,7 +55,8 @@
         "type": "VARCHAR",
         "scope": "global",
         "on_callbacks": [
-            "set"
+            "set",
+            "reset"
         ]
     },
     {

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -50,6 +50,13 @@
         "default_value": "false"
     },
     {
+        "name": "allow_parser_override_extension",
+        "description": "Allow extensions to override the current parser",
+        "type": "BOOLEAN",
+        "default_scope": "global",
+        "default_value": "false"
+    },
+    {
         "name": "allow_persistent_secrets",
         "description": "Allow the creation of persistent secrets, that are stored and loaded on restarts",
         "type": "BOOLEAN",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -52,9 +52,11 @@
     {
         "name": "allow_parser_override_extension",
         "description": "Allow extensions to override the current parser",
-        "type": "BOOLEAN",
-        "default_scope": "global",
-        "default_value": "false"
+        "type": "VARCHAR",
+        "scope": "global",
+        "on_callbacks": [
+            "set"
+        ]
     },
     {
         "name": "allow_persistent_secrets",

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -110,6 +110,8 @@ struct DBConfigOptions {
 #else
 	bool autoinstall_known_extensions = false;
 #endif
+	//! Setting for the parser override registered by extensions. Allowed options: "default, "fallback", "strict"
+	string allow_parser_override_extension = "default";
 	//! Override for the default extension repository
 	string custom_extension_repo = "";
 	//! Override for the default autoload extension repository

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -96,12 +96,14 @@ struct AllowExtensionsMetadataMismatchSetting {
 };
 
 struct AllowParserOverrideExtensionSetting {
-	using RETURN_TYPE = bool;
+	using RETURN_TYPE = string;
 	static constexpr const char *Name = "allow_parser_override_extension";
 	static constexpr const char *Description = "Allow extensions to override the current parser";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SetScope DefaultScope = SetScope::GLOBAL;
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct AllowPersistentSecretsSetting {

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -95,6 +95,15 @@ struct AllowExtensionsMetadataMismatchSetting {
 	static constexpr SetScope DefaultScope = SetScope::GLOBAL;
 };
 
+struct AllowParserOverrideExtensionSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "allow_parser_override_extension";
+	static constexpr const char *Description = "Allow extensions to override the current parser";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SetScope DefaultScope = SetScope::GLOBAL;
+};
+
 struct AllowPersistentSecretsSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "allow_persistent_secrets";

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -103,6 +103,7 @@ struct AllowParserOverrideExtensionSetting {
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
+	static bool OnGlobalReset(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
 };
 

--- a/src/include/duckdb/parser/parser_options.hpp
+++ b/src/include/duckdb/parser/parser_options.hpp
@@ -18,6 +18,7 @@ struct ParserOptions {
 	bool integer_division = false;
 	idx_t max_expression_depth = 1000;
 	const vector<ParserExtension> *extensions = nullptr;
+	bool allow_parser_overrides = false;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parser_options.hpp
+++ b/src/include/duckdb/parser/parser_options.hpp
@@ -18,7 +18,7 @@ struct ParserOptions {
 	bool integer_division = false;
 	idx_t max_expression_depth = 1000;
 	const vector<ParserExtension> *extensions = nullptr;
-	bool allow_parser_overrides = false;
+	string parser_override_setting = "default";
 };
 
 } // namespace duckdb

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1443,7 +1443,7 @@ ParserOptions ClientContext::GetParserOptions() const {
 	options.integer_division = DBConfig::GetSetting<IntegerDivisionSetting>(*this);
 	options.max_expression_depth = client_config.max_expression_depth;
 	options.extensions = &DBConfig::GetConfig(*this).parser_extensions;
-	options.allow_parser_overrides = DBConfig::GetSetting<AllowParserOverrideExtensionSetting>(*this);
+	options.parser_override_setting = DBConfig::GetConfig(*this).options.allow_parser_override_extension;
 	return options;
 }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1443,6 +1443,7 @@ ParserOptions ClientContext::GetParserOptions() const {
 	options.integer_division = DBConfig::GetSetting<IntegerDivisionSetting>(*this);
 	options.max_expression_depth = client_config.max_expression_depth;
 	options.extensions = &DBConfig::GetConfig(*this).parser_extensions;
+	options.allow_parser_overrides = DBConfig::GetSetting<AllowParserOverrideExtensionSetting>(*this);
 	return options;
 }
 

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -63,7 +63,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(AllocatorFlushThresholdSetting),
     DUCKDB_GLOBAL(AllowCommunityExtensionsSetting),
     DUCKDB_SETTING(AllowExtensionsMetadataMismatchSetting),
-    DUCKDB_SETTING(AllowParserOverrideExtensionSetting),
+    DUCKDB_GLOBAL(AllowParserOverrideExtensionSetting),
     DUCKDB_GLOBAL(AllowPersistentSecretsSetting),
     DUCKDB_GLOBAL(AllowUnredactedSecretsSetting),
     DUCKDB_GLOBAL(AllowUnsignedExtensionsSetting),

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -63,6 +63,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(AllocatorFlushThresholdSetting),
     DUCKDB_GLOBAL(AllowCommunityExtensionsSetting),
     DUCKDB_SETTING(AllowExtensionsMetadataMismatchSetting),
+    DUCKDB_SETTING(AllowParserOverrideExtensionSetting),
     DUCKDB_GLOBAL(AllowPersistentSecretsSetting),
     DUCKDB_GLOBAL(AllowUnredactedSecretsSetting),
     DUCKDB_GLOBAL(AllowUnsignedExtensionsSetting),
@@ -179,12 +180,12 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 83),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 33),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 102),
-                                                     DUCKDB_SETTING_ALIAS("user", 117),
-                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 20),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 116),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 84),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 34),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 103),
+                                                     DUCKDB_SETTING_ALIAS("user", 118),
+                                                     DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 21),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 117),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -79,6 +79,25 @@ Value AllowCommunityExtensionsSetting::GetSetting(const ClientContext &context) 
 }
 
 //===----------------------------------------------------------------------===//
+// Allow Parser Override Extension
+//===----------------------------------------------------------------------===//
+void AllowParserOverrideExtensionSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	if (!OnGlobalSet(db, config, input)) {
+		return;
+	}
+	config.options.allow_parser_override_extension = input.GetValue<string>();
+}
+
+void AllowParserOverrideExtensionSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.allow_parser_override_extension = DBConfigOptions().allow_parser_override_extension;
+}
+
+Value AllowParserOverrideExtensionSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value(config.options.allow_parser_override_extension);
+}
+
+//===----------------------------------------------------------------------===//
 // Allow Unredacted Secrets
 //===----------------------------------------------------------------------===//
 void AllowUnredactedSecretsSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -89,6 +89,9 @@ void AllowParserOverrideExtensionSetting::SetGlobal(DatabaseInstance *db, DBConf
 }
 
 void AllowParserOverrideExtensionSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	if (!OnGlobalReset(db, config)) {
+		return;
+	}
 	config.options.allow_parser_override_extension = DBConfigOptions().allow_parser_override_extension;
 }
 

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -163,6 +163,11 @@ bool AllowParserOverrideExtensionSetting::OnGlobalSet(DatabaseInstance *db, DBCo
 	return true;
 }
 
+bool AllowParserOverrideExtensionSetting::OnGlobalReset(DatabaseInstance *db, DBConfig &config) {
+	config.options.allow_parser_override_extension = "default";
+	return true;
+}
+
 //===----------------------------------------------------------------------===//
 // Allow Persistent Secrets
 //===----------------------------------------------------------------------===//

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -151,6 +151,19 @@ bool AllowCommunityExtensionsSetting::OnGlobalReset(DatabaseInstance *db, DBConf
 }
 
 //===----------------------------------------------------------------------===//
+// Allow Parser Override
+//===----------------------------------------------------------------------===//
+bool AllowParserOverrideExtensionSetting::OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto new_value = input.GetValue<string>();
+	if (!StringUtil::CIEquals(new_value, "default") && !StringUtil::CIEquals(new_value, "fallback") &&
+	    !StringUtil::CIEquals(new_value, "strict")) {
+		throw InvalidInputException("Unrecognized value for parser override setting. Valid options are: \"default\", "
+		                            "\"fallback\", \"strict\".");
+	}
+	return true;
+}
+
+//===----------------------------------------------------------------------===//
 // Allow Persistent Secrets
 //===----------------------------------------------------------------------===//
 void AllowPersistentSecretsSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -207,6 +207,9 @@ void Parser::ParseQuery(const string &query) {
 				if (!ext.parser_override) {
 					continue;
 				}
+				if (!options.allow_parser_overrides) {
+					continue;
+				}
 				auto result = ext.parser_override(ext.parser_info.get(), query);
 				if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
 					statements = std::move(result.statements);

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -192,6 +192,8 @@ void Parser::ParseQuery(const string &query) {
 	Transformer transformer(options);
 	string parser_error;
 	optional_idx parser_error_location;
+	string parser_override_option = StringUtil::Lower(options.parser_override_setting);
+	Printer::PrintF("%s, %s", parser_override_option, query);
 	{
 		// check if there are any unicode spaces in the string
 		string new_query;
@@ -207,15 +209,24 @@ void Parser::ParseQuery(const string &query) {
 				if (!ext.parser_override) {
 					continue;
 				}
-				if (!options.allow_parser_overrides) {
+				if (StringUtil::CIEquals(parser_override_option, "default")) {
 					continue;
 				}
 				auto result = ext.parser_override(ext.parser_info.get(), query);
 				if (result.type == ParserExtensionResultType::PARSE_SUCCESSFUL) {
 					statements = std::move(result.statements);
 					return;
-				} else if (result.type == ParserExtensionResultType::DISPLAY_EXTENSION_ERROR) {
-					throw ParserException(result.error);
+				}
+				if (StringUtil::CIEquals(parser_override_option, "strict")) {
+					if (result.type == ParserExtensionResultType::DISPLAY_ORIGINAL_ERROR) {
+						throw ParserException(
+						    "Parser override failed to return a valid statement. Consider restarting the database and "
+						    "using the setting \"set allow_parser_override_extension=fallback\" to fallback to the "
+						    "default parser.");
+					}
+					if (result.type == ParserExtensionResultType::DISPLAY_EXTENSION_ERROR) {
+						throw ParserException(result.error);
+					}
 				}
 			}
 		}

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -193,7 +193,6 @@ void Parser::ParseQuery(const string &query) {
 	string parser_error;
 	optional_idx parser_error_location;
 	string parser_override_option = StringUtil::Lower(options.parser_override_setting);
-	Printer::PrintF("%s, %s", parser_override_option, query);
 	{
 		// check if there are any unicode spaces in the string
 		string new_query;

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -62,7 +62,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"custom_extension_repository", {"duckdb.org/no-extensions-here", "duckdb.org/no-extensions-here"}},
 	    {"autoinstall_extension_repository", {"duckdb.org/no-extensions-here", "duckdb.org/no-extensions-here"}},
 	    {"lambda_syntax", {EnumUtil::ToString(LambdaSyntax::DISABLE_SINGLE_ARROW)}},
-		{"allow_parser_override_extension", {"fallback"}},
+	    {"allow_parser_override_extension", {"fallback"}},
 	    {"profiling_coverage", {EnumUtil::ToString(ProfilingCoverage::ALL)}},
 #ifdef DUCKDB_EXTENSION_AUTOLOAD_DEFAULT
 	    {"autoload_known_extensions", {!DUCKDB_EXTENSION_AUTOLOAD_DEFAULT}},

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -62,6 +62,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"custom_extension_repository", {"duckdb.org/no-extensions-here", "duckdb.org/no-extensions-here"}},
 	    {"autoinstall_extension_repository", {"duckdb.org/no-extensions-here", "duckdb.org/no-extensions-here"}},
 	    {"lambda_syntax", {EnumUtil::ToString(LambdaSyntax::DISABLE_SINGLE_ARROW)}},
+		{"allow_parser_override_extension", {"fallback"}},
 	    {"profiling_coverage", {EnumUtil::ToString(ProfilingCoverage::ALL)}},
 #ifdef DUCKDB_EXTENSION_AUTOLOAD_DEFAULT
 	    {"autoload_known_extensions", {!DUCKDB_EXTENSION_AUTOLOAD_DEFAULT}},

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -235,21 +235,26 @@ public:
 	}
 
 	static ParserOverrideResult QuackParser(ParserExtensionInfo *info, const string &query) {
-		if (StringUtil::CIEquals(query, "override")) {
-			auto select_node = make_uniq<SelectNode>();
-			select_node->select_list.push_back(
-			    make_uniq<ConstantExpression>(Value("The DuckDB parser has been overridden")));
-			select_node->from_table = make_uniq<EmptyTableRef>();
-			auto select_statement = make_uniq<SelectStatement>();
-			select_statement->node = std::move(select_node);
-			vector<unique_ptr<SQLStatement>> statements;
-			statements.push_back(std::move(select_statement));
-			return ParserOverrideResult(std::move(statements));
+		vector<string> queries = StringUtil::Split(query, ";");
+		vector<unique_ptr<SQLStatement>> statements;
+		for (const auto &query_input : queries) {
+			if (StringUtil::CIEquals(query_input, "override")) {
+				auto select_node = make_uniq<SelectNode>();
+				select_node->select_list.push_back(
+				    make_uniq<ConstantExpression>(Value("The DuckDB parser has been overridden")));
+				select_node->from_table = make_uniq<EmptyTableRef>();
+				auto select_statement = make_uniq<SelectStatement>();
+				select_statement->node = std::move(select_node);
+				statements.push_back(std::move(select_statement));
+			}
+			if (StringUtil::CIEquals(query_input, "over")) {
+				return ParserOverrideResult("Parser overridden, query equaled \"over\" but not \"override\"");
+			}
 		}
-		if (StringUtil::Contains(query, "over")) {
-			return ParserOverrideResult("Parser overridden, query contained \"over\" but not \"override\"");
+		if (statements.empty()) {
+			return ParserOverrideResult();
 		}
-		return ParserOverrideResult();
+		return ParserOverrideResult(std::move(statements));
 	}
 };
 

--- a/test/extension/loadable_parser_override.test
+++ b/test/extension/loadable_parser_override.test
@@ -2,12 +2,6 @@
 # description: Try loading a parser override with an extension
 # group: [extension]
 
-require notmingw
-
-require skip_reload
-
-require allow_unsigned_extensions
-
 statement error
 override
 ----
@@ -17,12 +11,40 @@ statement ok
 LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
 
 statement error
+set allow_parser_override_extension=doesnotexist;
+----
+Invalid Input Error: Unrecognized value for parser override setting. Valid options are: "default", "fallback", "strict".
+
+# Default behavior is not using the parser override
+statement error
 override
 ----
 Parser Error: syntax error at or near "override"
 
+# Fallback behavior is trying the parser override and if they error falling back to the default parser
 statement ok
-set allow_parser_override_extension=true;
+set allow_parser_override_extension=fallback;
+
+# The QuackParser can return a valid SQLStatement for this query
+query I
+override
+----
+The DuckDB parser has been overridden
+
+# The parser cannot return a valid SQLStatement for this query, the default parser also gets an error
+statement error
+over
+----
+Parser Error: syntax error at or near "over"
+
+
+query I
+SELECT 1;
+----
+1
+
+statement ok
+set allow_parser_override_extension=strict;
 
 query I
 override
@@ -30,11 +52,11 @@ override
 The DuckDB parser has been overridden
 
 statement error
-overr;
+over
 ----
-Parser Error: Parser overridden, query contained "over" but not "override"
+Parser Error: Parser overridden, query equaled "over" but not "override"
 
-query I
+statement error
 SELECT 1;
 ----
-1
+Parser Error: Parser override failed to return a valid statement. Consider restarting the database and using the setting "set allow_parser_override_extension=fallback" to fallback to the default parser.

--- a/test/extension/loadable_parser_override.test
+++ b/test/extension/loadable_parser_override.test
@@ -16,6 +16,14 @@ Parser Error: syntax error at or near "override"
 statement ok
 LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
 
+statement error
+override
+----
+Parser Error: syntax error at or near "override"
+
+statement ok
+set allow_parser_override_extension=true;
+
 query I
 override
 ----

--- a/test/extension/loadable_parser_override.test
+++ b/test/extension/loadable_parser_override.test
@@ -2,6 +2,8 @@
 # description: Try loading a parser override with an extension
 # group: [extension]
 
+require skip_reload
+
 statement error
 override
 ----


### PR DESCRIPTION
This PR adds an option to enable the parser extension override. By default this option is set to false to allow users to opt-in to parser overrides. 
The option is called `allow_parser_override_extension`.

Without this option, there was no way to opt-out of parser overrides