### PR TITLE
Correctly set row start in WAL replay

### DIFF
--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -699,6 +699,7 @@ void ColumnData::InitializeColumn(PersistentColumnData &column_data, BaseStatist
 	this->count = 0;
 	for (auto &data_pointer : column_data.pointers) {
 		// Update the count and statistics
+		data_pointer.row_start = start + count;
 		this->count += data_pointer.tuple_count;
 
 		// Merge the statistics. If this is a child column, the target_stats reference will point into the parents stats


### PR DESCRIPTION
Follow-up fix from not writing the row start to the data pointer anymore