### PR TITLE
ATTACH IF NOT EXISTS: avoid looping waiting for DETACH to finish, wait only for an ATTACH operation to finish

### DIFF
--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -40,6 +40,9 @@ struct StoredDatabasePath {
 
 	DatabaseFilePathManager &manager;
 	string path;
+
+public:
+	void OnDetach();
 };
 
 //! AttachOptions holds information about a database we plan to attach. These options are generalized, i.e.,
@@ -103,6 +106,7 @@ public:
 	void SetInitialDatabase();
 	void SetReadOnlyDatabase();
 	void OnDetach(ClientContext &context);
+	string StoredPath() const;
 
 	static bool NameIsReserved(const string &name);
 	static string ExtractDatabaseName(const string &dbpath, FileSystem &fs);

--- a/src/include/duckdb/main/database_file_path_manager.hpp
+++ b/src/include/duckdb/main/database_file_path_manager.hpp
@@ -19,6 +19,14 @@ struct AttachOptions;
 
 enum class InsertDatabasePathResult { SUCCESS, ALREADY_EXISTS };
 
+struct DatabasePathInfo {
+	explicit DatabasePathInfo(string name_p) : name(std::move(name_p)), is_attached(true) {
+	}
+
+	string name;
+	bool is_attached;
+};
+
 //! The DatabaseFilePathManager is used to ensure we only ever open a single database file once
 class DatabaseFilePathManager {
 public:
@@ -26,6 +34,8 @@ public:
 	InsertDatabasePathResult InsertDatabasePath(const string &path, const string &name, OnCreateConflict on_conflict,
 	                                            AttachOptions &options);
 	void EraseDatabasePath(const string &path);
+	//! Called when a database is detached, but before it is fully finished being used
+	void DetachDatabase(const string &path);
 
 private:
 	//! The lock to add entries to the database path map
@@ -33,7 +43,7 @@ private:
 	//! A set containing all attached database path
 	//! This allows to attach many databases efficiently, and to avoid attaching the
 	//! same file path twice
-	case_insensitive_map_t<string> db_paths_to_name;
+	case_insensitive_map_t<DatabasePathInfo> db_paths_to_name;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/database_file_path_manager.hpp
+++ b/src/include/duckdb/main/database_file_path_manager.hpp
@@ -33,6 +33,7 @@ public:
 	idx_t ApproxDatabaseCount() const;
 	InsertDatabasePathResult InsertDatabasePath(const string &path, const string &name, OnCreateConflict on_conflict,
 	                                            AttachOptions &options);
+	//! Erase a database path - indicating we are done with using it
 	void EraseDatabasePath(const string &path);
 	//! Called when a database is detached, but before it is fully finished being used
 	void DetachDatabase(const string &path);
@@ -43,7 +44,7 @@ private:
 	//! A set containing all attached database path
 	//! This allows to attach many databases efficiently, and to avoid attaching the
 	//! same file path twice
-	case_insensitive_map_t<DatabasePathInfo> db_paths_to_name;
+	case_insensitive_map_t<DatabasePathInfo> db_paths;
 };
 
 } // namespace duckdb

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -22,6 +22,10 @@ StoredDatabasePath::~StoredDatabasePath() {
 	manager.EraseDatabasePath(path);
 }
 
+void StoredDatabasePath::OnDetach() {
+	manager.DetachDatabase(path);
+}
+
 //===--------------------------------------------------------------------===//
 // Attach Options
 //===--------------------------------------------------------------------===//
@@ -155,6 +159,13 @@ bool AttachedDatabase::NameIsReserved(const string &name) {
 	return name == DEFAULT_SCHEMA || name == TEMP_CATALOG || name == SYSTEM_CATALOG;
 }
 
+string AttachedDatabase::StoredPath() const {
+	if (stored_database_path) {
+		return stored_database_path->path;
+	}
+	return string();
+}
+
 static string RemoveQueryParams(const string &name) {
 	auto vec = StringUtil::Split(name, "?");
 	D_ASSERT(!vec.empty());
@@ -227,10 +238,12 @@ void AttachedDatabase::SetReadOnlyDatabase() {
 }
 
 void AttachedDatabase::OnDetach(ClientContext &context) {
-	if (!catalog) {
-		return;
+	if (catalog) {
+		catalog->OnDetach(context);
 	}
-	catalog->OnDetach(context);
+	if (stored_database_path) {
+		stored_database_path->OnDetach();
+	}
 }
 
 void AttachedDatabase::Close() {

--- a/src/main/database_file_path_manager.cpp
+++ b/src/main/database_file_path_manager.cpp
@@ -42,7 +42,7 @@ void DatabaseFilePathManager::EraseDatabasePath(const string &path) {
 		return;
 	}
 	lock_guard<mutex> path_lock(db_paths_lock);
-	db_paths_to_name.erase(path);
+	db_paths.erase(path);
 }
 
 void DatabaseFilePathManager::DetachDatabase(const string &path) {
@@ -50,8 +50,8 @@ void DatabaseFilePathManager::DetachDatabase(const string &path) {
 		return;
 	}
 	lock_guard<mutex> path_lock(db_paths_lock);
-	auto entry = db_paths_to_name.find(path);
-	if (entry != db_paths_to_name.end()) {
+	auto entry = db_paths.find(path);
+	if (entry != db_paths.end()) {
 		entry->second.is_attached = false;
 	}
 }

--- a/src/main/database_file_path_manager.cpp
+++ b/src/main/database_file_path_manager.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 
 idx_t DatabaseFilePathManager::ApproxDatabaseCount() const {
 	lock_guard<mutex> path_lock(db_paths_lock);
-	return db_paths_to_name.size();
+	return db_paths.size();
 }
 
 InsertDatabasePathResult DatabaseFilePathManager::InsertDatabasePath(const string &path, const string &name,
@@ -18,7 +18,7 @@ InsertDatabasePathResult DatabaseFilePathManager::InsertDatabasePath(const strin
 	}
 
 	lock_guard<mutex> path_lock(db_paths_lock);
-	auto entry = db_paths_to_name.emplace(path, DatabasePathInfo(name));
+	auto entry = db_paths.emplace(path, DatabasePathInfo(name));
 	if (!entry.second) {
 		auto &existing = entry.first->second;
 		if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT && existing.name == name) {

--- a/src/main/database_file_path_manager.cpp
+++ b/src/main/database_file_path_manager.cpp
@@ -18,14 +18,20 @@ InsertDatabasePathResult DatabaseFilePathManager::InsertDatabasePath(const strin
 	}
 
 	lock_guard<mutex> path_lock(db_paths_lock);
-	auto entry = db_paths_to_name.emplace(path, name);
+	auto entry = db_paths_to_name.emplace(path, DatabasePathInfo(name));
 	if (!entry.second) {
-		if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT && entry.first->second == name) {
-			return InsertDatabasePathResult::ALREADY_EXISTS;
+		auto &existing = entry.first->second;
+		if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT && existing.name == name) {
+			if (existing.is_attached) {
+				return InsertDatabasePathResult::ALREADY_EXISTS;
+			}
+			throw BinderException("Unique file handle conflict: Cannot attach \"%s\" - the database file \"%s\" is in "
+			                      "the process of being detached",
+			                      name, path);
 		}
 		throw BinderException("Unique file handle conflict: Cannot attach \"%s\" - the database file \"%s\" is already "
 		                      "attached by database \"%s\"",
-		                      name, path, entry.first->second);
+		                      name, path, existing.name);
 	}
 	options.stored_database_path = make_uniq<StoredDatabasePath>(*this, path, name);
 	return InsertDatabasePathResult::SUCCESS;
@@ -37,6 +43,17 @@ void DatabaseFilePathManager::EraseDatabasePath(const string &path) {
 	}
 	lock_guard<mutex> path_lock(db_paths_lock);
 	db_paths_to_name.erase(path);
+}
+
+void DatabaseFilePathManager::DetachDatabase(const string &path) {
+	if (path.empty() || path == IN_MEMORY_PATH) {
+		return;
+	}
+	lock_guard<mutex> path_lock(db_paths_lock);
+	auto entry = db_paths_to_name.find(path);
+	if (entry != db_paths_to_name.end()) {
+		entry->second.is_attached = false;
+	}
 }
 
 } // namespace duckdb

--- a/test/sql/attach/attach_if_not_exists_detach.test
+++ b/test/sql/attach/attach_if_not_exists_detach.test
@@ -1,0 +1,23 @@
+# name: test/sql/attach/attach_if_not_exists_detach.test
+# description: Test ATTACH IF NOT EXISTS
+# group: [attach]
+
+statement ok
+ATTACH '__TEST_DIR__/attach_if_not_exists_detach.db' AS db1
+
+# con1 opens a transaction for db1 that prevents it from being fully detached
+statement ok con1
+BEGIN
+
+statement ok con1
+CREATE TABLE db1.tbl(i INTEGER);
+
+# con2 can detach db1, but it will not actually be detached
+statement ok con2
+DETACH db1
+
+# upon attaching we should fail
+statement error con2
+ATTACH IF NOT EXISTS '__TEST_DIR__/attach_if_not_exists_detach.db' AS db1
+----
+the process of being detached

--- a/test/sql/storage/concurrent_attach_if_not_exists.test_slow
+++ b/test/sql/storage/concurrent_attach_if_not_exists.test_slow
@@ -14,8 +14,10 @@ detach ${name}
 ----
 database not found
 
-statement ok
+statement maybe
 attach if not exists '__TEST_DIR__/concurrent_attach_${name}.duckdb' AS ${name}
+----
+in the process of being detached
 
 endloop
 

--- a/test/sql/storage/concurrent_attach_if_not_exists.test_slow
+++ b/test/sql/storage/concurrent_attach_if_not_exists.test_slow
@@ -6,8 +6,10 @@ concurrentloop x 0 10
 
 foreach name db1 db2 db3 db4 db5
 
-statement ok
+statement maybe
 attach if not exists '__TEST_DIR__/concurrent_attach_${name}.duckdb' AS ${name}
+----
+detach
 
 statement maybe
 detach ${name}
@@ -17,7 +19,7 @@ database not found
 statement maybe
 attach if not exists '__TEST_DIR__/concurrent_attach_${name}.duckdb' AS ${name}
 ----
-in the process of being detached
+detach
 
 endloop
 


### PR DESCRIPTION
Waiting for an `ATTACH` to finish is not very problematic as this generally involves only starting up the database. Detaches are more problematic since a detach is only finished when all transactions that refer to a given database are closed - hence this could end up taking a very long time / forever.