### PR TITLE
Use a `PartialBlockManager` per column, instead of sharing one over the entire row group

### DIFF
--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -194,7 +194,10 @@ public:
 
 	void CreateNewCollection(ClientContext &context, DuckTableEntry &table_entry,
 	                         const vector<LogicalType> &insert_types) {
-		auto collection = OptimisticDataWriter::CreateCollection(table_entry.GetStorage(), insert_types);
+		if (!optimistic_writer) {
+			optimistic_writer = make_uniq<OptimisticDataWriter>(context, table_entry.GetStorage());
+		}
+		auto collection = optimistic_writer->CreateCollection(table_entry.GetStorage(), insert_types);
 		auto &row_collection = *collection->collection;
 		row_collection.InitializeEmpty();
 		row_collection.InitializeAppend(current_append_state);
@@ -526,9 +529,6 @@ SinkResultType PhysicalBatchInsert::Sink(ExecutionContext &context, DataChunk &i
 		lock_guard<mutex> l(gstate.lock);
 		// no collection yet: create a new one
 		lstate.CreateNewCollection(context.client, table, insert_types);
-		if (!lstate.optimistic_writer) {
-			lstate.optimistic_writer = make_uniq<OptimisticDataWriter>(context.client, table.GetStorage());
-		}
 	}
 
 	if (lstate.current_index != batch_index) {

--- a/src/include/duckdb/storage/optimistic_data_writer.hpp
+++ b/src/include/duckdb/storage/optimistic_data_writer.hpp
@@ -22,6 +22,8 @@ struct OptimisticWriteCollection {
 	vector<unique_ptr<PartialBlockManager>> partial_block_managers;
 };
 
+enum class OptimisticWritePartialManagers { PER_COLUMN, GLOBAL };
+
 class OptimisticDataWriter {
 public:
 	OptimisticDataWriter(ClientContext &context, DataTable &table);
@@ -29,7 +31,9 @@ public:
 	~OptimisticDataWriter();
 
 	//! Creates a collection to write to
-	unique_ptr<OptimisticWriteCollection> CreateCollection(DataTable &storage, const vector<LogicalType> &insert_types);
+	unique_ptr<OptimisticWriteCollection>
+	CreateCollection(DataTable &storage, const vector<LogicalType> &insert_types,
+	                 OptimisticWritePartialManagers type = OptimisticWritePartialManagers::PER_COLUMN);
 	//! Write a new row group to disk (if possible)
 	void WriteNewRowGroup(OptimisticWriteCollection &row_groups);
 	//! Write the last row group of a collection to disk

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -39,14 +39,16 @@ struct PersistentColumnData;
 using column_segment_vector_t = vector<SegmentNode<ColumnSegment>>;
 
 struct ColumnCheckpointInfo {
-	ColumnCheckpointInfo(RowGroupWriteInfo &info, idx_t column_idx) : info(info), column_idx(column_idx) {
-	}
+	ColumnCheckpointInfo(RowGroupWriteInfo &info, idx_t column_idx);
 
-	RowGroupWriteInfo &info;
 	idx_t column_idx;
 
 public:
+	PartialBlockManager &GetPartialBlockManager();
 	CompressionType GetCompressionType();
+
+private:
+	RowGroupWriteInfo &info;
 };
 
 class ColumnData {

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -53,15 +53,13 @@ class StorageCommitState;
 
 struct RowGroupWriteInfo {
 	RowGroupWriteInfo(PartialBlockManager &manager, const vector<CompressionType> &compression_types,
-	                  CheckpointType checkpoint_type = CheckpointType::FULL_CHECKPOINT)
-	    : manager(manager), compression_types(compression_types), checkpoint_type(checkpoint_type) {
-	}
+	                  CheckpointType checkpoint_type = CheckpointType::FULL_CHECKPOINT);
 	RowGroupWriteInfo(PartialBlockManager &manager, const vector<CompressionType> &compression_types,
-	                  vector<unique_ptr<PartialBlockManager>> &column_partial_block_managers_p)
-	    : manager(manager), compression_types(compression_types), checkpoint_type(CheckpointType::FULL_CHECKPOINT),
-	      column_partial_block_managers(column_partial_block_managers_p) {
-	}
+	                  vector<unique_ptr<PartialBlockManager>> &column_partial_block_managers_p);
 
+private:
+	PartialBlockManager &manager;
+public:
 	const vector<CompressionType> &compression_types;
 	CheckpointType checkpoint_type;
 
@@ -69,7 +67,6 @@ public:
 	PartialBlockManager &GetPartialBlockManager(idx_t column_idx);
 
 private:
-	PartialBlockManager &manager;
 	optional_ptr<vector<unique_ptr<PartialBlockManager>>> column_partial_block_managers;
 };
 

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -59,6 +59,7 @@ struct RowGroupWriteInfo {
 
 private:
 	PartialBlockManager &manager;
+
 public:
 	const vector<CompressionType> &compression_types;
 	CheckpointType checkpoint_type;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -56,6 +56,11 @@ struct RowGroupWriteInfo {
 	                  CheckpointType checkpoint_type = CheckpointType::FULL_CHECKPOINT)
 	    : manager(manager), compression_types(compression_types), checkpoint_type(checkpoint_type) {
 	}
+	RowGroupWriteInfo(PartialBlockManager &manager, const vector<CompressionType> &compression_types,
+	                  vector<unique_ptr<PartialBlockManager>> &column_partial_block_managers_p)
+	    : manager(manager), compression_types(compression_types), checkpoint_type(CheckpointType::FULL_CHECKPOINT),
+	      column_partial_block_managers(column_partial_block_managers_p) {
+	}
 
 	const vector<CompressionType> &compression_types;
 	CheckpointType checkpoint_type;
@@ -65,6 +70,7 @@ public:
 
 private:
 	PartialBlockManager &manager;
+	optional_ptr<vector<unique_ptr<PartialBlockManager>>> column_partial_block_managers;
 };
 
 struct RowGroupWriteData {

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -57,9 +57,14 @@ struct RowGroupWriteInfo {
 	    : manager(manager), compression_types(compression_types), checkpoint_type(checkpoint_type) {
 	}
 
-	PartialBlockManager &manager;
 	const vector<CompressionType> &compression_types;
 	CheckpointType checkpoint_type;
+
+public:
+	PartialBlockManager &GetPartialBlockManager(idx_t column_idx);
+
+private:
+	PartialBlockManager &manager;
 };
 
 struct RowGroupWriteData {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -21,7 +21,7 @@ LocalTableStorage::LocalTableStorage(ClientContext &context, DataTable &table)
 
 	auto types = table.GetTypes();
 	auto data_table_info = table.GetDataTableInfo();
-	row_groups = optimistic_writer.CreateCollection(table, types);
+	row_groups = optimistic_writer.CreateCollection(table, types, OptimisticWritePartialManagers::GLOBAL);
 	auto &collection = *row_groups->collection;
 	collection.InitializeEmpty();
 

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -21,7 +21,7 @@ LocalTableStorage::LocalTableStorage(ClientContext &context, DataTable &table)
 
 	auto types = table.GetTypes();
 	auto data_table_info = table.GetDataTableInfo();
-	row_groups = OptimisticDataWriter::CreateCollection(table, types);
+	row_groups = optimistic_writer.CreateCollection(table, types);
 	auto &collection = *row_groups->collection;
 	collection.InitializeEmpty();
 

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -302,8 +302,8 @@ unique_ptr<ColumnCheckpointState> ArrayColumnData::CreateCheckpointState(RowGrou
 
 unique_ptr<ColumnCheckpointState> ArrayColumnData::Checkpoint(RowGroup &row_group,
                                                               ColumnCheckpointInfo &checkpoint_info) {
-
-	auto checkpoint_state = make_uniq<ArrayColumnCheckpointState>(row_group, *this, checkpoint_info.info.manager);
+	auto &partial_block_manager = checkpoint_info.GetPartialBlockManager();
+	auto checkpoint_state = make_uniq<ArrayColumnCheckpointState>(row_group, *this, partial_block_manager);
 	checkpoint_state->validity_state = validity.Checkpoint(row_group, checkpoint_info);
 	checkpoint_state->child_state = child_column->Checkpoint(row_group, checkpoint_info);
 	return std::move(checkpoint_state);

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -673,7 +673,8 @@ void ColumnData::CheckpointScan(ColumnSegment &segment, ColumnScanState &state, 
 unique_ptr<ColumnCheckpointState> ColumnData::Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &checkpoint_info) {
 	// scan the segments of the column data
 	// set up the checkpoint state
-	auto checkpoint_state = CreateCheckpointState(row_group, checkpoint_info.info.manager);
+	auto &partial_block_manager = checkpoint_info.GetPartialBlockManager();
+	auto checkpoint_state = CreateCheckpointState(row_group, partial_block_manager);
 	checkpoint_state->global_stats = BaseStatistics::CreateEmpty(type).ToUnique();
 
 	auto &nodes = data.ReferenceSegments();

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -914,6 +914,14 @@ void RowGroup::MergeIntoStatistics(TableStatistics &other) {
 	}
 }
 
+ColumnCheckpointInfo::ColumnCheckpointInfo(RowGroupWriteInfo &info, idx_t column_idx)
+    : column_idx(column_idx), info(info) {
+}
+
+PartialBlockManager &ColumnCheckpointInfo::GetPartialBlockManager() {
+	return info.manager;
+}
+
 CompressionType ColumnCheckpointInfo::GetCompressionType() {
 	return info.compression_types[column_idx];
 }

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -918,6 +918,17 @@ ColumnCheckpointInfo::ColumnCheckpointInfo(RowGroupWriteInfo &info, idx_t column
     : column_idx(column_idx), info(info) {
 }
 
+RowGroupWriteInfo::RowGroupWriteInfo(PartialBlockManager &manager, const vector<CompressionType> &compression_types,
+				  CheckpointType checkpoint_type)
+	: manager(manager), compression_types(compression_types), checkpoint_type(checkpoint_type) {
+}
+
+RowGroupWriteInfo::RowGroupWriteInfo(PartialBlockManager &manager, const vector<CompressionType> &compression_types,
+				  vector<unique_ptr<PartialBlockManager>> &column_partial_block_managers_p)
+	: manager(manager), compression_types(compression_types), checkpoint_type(CheckpointType::FULL_CHECKPOINT),
+	  column_partial_block_managers(column_partial_block_managers_p) {
+}
+
 PartialBlockManager &RowGroupWriteInfo::GetPartialBlockManager(idx_t column_idx) {
 	if (column_partial_block_managers) {
 		return *column_partial_block_managers->at(column_idx);

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -919,6 +919,9 @@ ColumnCheckpointInfo::ColumnCheckpointInfo(RowGroupWriteInfo &info, idx_t column
 }
 
 PartialBlockManager &RowGroupWriteInfo::GetPartialBlockManager(idx_t column_idx) {
+	if (column_partial_block_managers) {
+		return *column_partial_block_managers->at(column_idx);
+	}
 	return manager;
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -919,18 +919,18 @@ ColumnCheckpointInfo::ColumnCheckpointInfo(RowGroupWriteInfo &info, idx_t column
 }
 
 RowGroupWriteInfo::RowGroupWriteInfo(PartialBlockManager &manager, const vector<CompressionType> &compression_types,
-				  CheckpointType checkpoint_type)
-	: manager(manager), compression_types(compression_types), checkpoint_type(checkpoint_type) {
+                                     CheckpointType checkpoint_type)
+    : manager(manager), compression_types(compression_types), checkpoint_type(checkpoint_type) {
 }
 
 RowGroupWriteInfo::RowGroupWriteInfo(PartialBlockManager &manager, const vector<CompressionType> &compression_types,
-				  vector<unique_ptr<PartialBlockManager>> &column_partial_block_managers_p)
-	: manager(manager), compression_types(compression_types), checkpoint_type(CheckpointType::FULL_CHECKPOINT),
-	  column_partial_block_managers(column_partial_block_managers_p) {
+                                     vector<unique_ptr<PartialBlockManager>> &column_partial_block_managers_p)
+    : manager(manager), compression_types(compression_types), checkpoint_type(CheckpointType::FULL_CHECKPOINT),
+      column_partial_block_managers(column_partial_block_managers_p) {
 }
 
 PartialBlockManager &RowGroupWriteInfo::GetPartialBlockManager(idx_t column_idx) {
-	if (column_partial_block_managers) {
+	if (column_partial_block_managers && !column_partial_block_managers->empty()) {
 		return *column_partial_block_managers->at(column_idx);
 	}
 	return manager;

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -918,8 +918,12 @@ ColumnCheckpointInfo::ColumnCheckpointInfo(RowGroupWriteInfo &info, idx_t column
     : column_idx(column_idx), info(info) {
 }
 
+PartialBlockManager &RowGroupWriteInfo::GetPartialBlockManager(idx_t column_idx) {
+	return manager;
+}
+
 PartialBlockManager &ColumnCheckpointInfo::GetPartialBlockManager() {
-	return info.manager;
+	return info.GetPartialBlockManager(column_idx);
 }
 
 CompressionType ColumnCheckpointInfo::GetCompressionType() {

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -241,9 +241,10 @@ unique_ptr<ColumnCheckpointState> StandardColumnData::Checkpoint(RowGroup &row_g
 	// to prevent reading the validity data immediately after it is checkpointed we first checkpoint the main column
 	// this is necessary for concurrent checkpointing as due to the partial block manager checkpointed data might be
 	// flushed to disk by a different thread than the one that wrote it, causing a data race
-	auto base_state = CreateCheckpointState(row_group, checkpoint_info.info.manager);
+	auto &partial_block_manager = checkpoint_info.GetPartialBlockManager();
+	auto base_state = CreateCheckpointState(row_group, partial_block_manager);
 	base_state->global_stats = BaseStatistics::CreateEmpty(type).ToUnique();
-	auto validity_state_p = validity.CreateCheckpointState(row_group, checkpoint_info.info.manager);
+	auto validity_state_p = validity.CreateCheckpointState(row_group, partial_block_manager);
 	validity_state_p->global_stats = BaseStatistics::CreateEmpty(validity.type).ToUnique();
 
 	auto &validity_state = *validity_state_p;

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -311,7 +311,8 @@ unique_ptr<ColumnCheckpointState> StructColumnData::CreateCheckpointState(RowGro
 
 unique_ptr<ColumnCheckpointState> StructColumnData::Checkpoint(RowGroup &row_group,
                                                                ColumnCheckpointInfo &checkpoint_info) {
-	auto checkpoint_state = make_uniq<StructColumnCheckpointState>(row_group, *this, checkpoint_info.info.manager);
+	auto &partial_block_manager = checkpoint_info.GetPartialBlockManager();
+	auto checkpoint_state = make_uniq<StructColumnCheckpointState>(row_group, *this, partial_block_manager);
 	checkpoint_state->validity_state = validity.Checkpoint(row_group, checkpoint_info);
 	for (auto &sub_column : sub_columns) {
 		checkpoint_state->child_states.push_back(sub_column->Checkpoint(row_group, checkpoint_info));


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/19118

This further increases the co-location of the same column on the same blocks by preferring to put the same column on the same block. This co-location reduces I/O required for queries that refer to only a small subset of columns. Below are the new per-column block counts. 


|        Column         | v1.4.0 | main  |  new  |
|-----------------------|-------:|------:|------:|
| AdvEngineID           | 699    | 314   | 255   |
| Age                   | 895    | 597   | 367   |
| BrowserCountry        | 893    | 555   | 383   |
| BrowserLanguage       | 893    | 595   | 410   |
| CLID                  | 258    | 165   | 126   |
| ClientEventTime       | 1691   | 1592  | 1538  |
| ClientIP              | 1070   | 949   | 708   |
| ClientTimeZone        | 893    | 672   | 392   |
| CodeVersion           | 729    | 313   | 256   |
| ConnectTiming         | 638    | 473   | 385   |
| CookieEnable          | 841    | 314   | 273   |
| CounterClass          | 258    | 146   | 141   |
| CounterID             | 363    | 183   | 176   |
| DNSTiming             | 638    | 374   | 264   |
| DontCountHits         | 529    | 295   | 194   |
| EventDate             | 470    | 219   | 202   |
| EventTime             | 1594   | 1304  | 1024  |
| FUniqID               | 1312   | 1109  | 1020  |
| FetchTiming           | 638    | 568   | 500   |
| FlashMajor            | 893    | 518   | 298   |
| FlashMinor            | 893    | 498   | 311   |
| FlashMinor2           | 894    | 578   | 434   |
| FromTag               | 893    | 447   | 290   |
| GoodEvent             | 1      | 1     | 1     |
| HID                   | 1674   | 1665  | 1652  |
| HTTPError             | 1      | 1     | 1     |
| HasGCLID              | 379    | 174   | 157   |
| HistoryLength         | 537    | 380   | 256   |
| HitColor              | 895    | 531   | 274   |
| IPNetworkID           | 1053   | 773   | 671   |
| Income                | 894    | 415   | 273   |
| Interests             | 894    | 559   | 459   |
| IsArtifical           | 533    | 279   | 197   |
| IsDownload            | 388    | 180   | 161   |
| IsEvent               | 1      | 1     | 1     |
| IsLink                | 421    | 197   | 165   |
| IsMobile              | 892    | 453   | 277   |
| IsNotBounce           | 496    | 242   | 189   |
| IsOldCounter          | 31     | 28    | 27    |
| IsParameter           | 57     | 43    | 33    |
| IsRefresh             | 894    | 580   | 275   |
| JavaEnable            | 892    | 845   | 276   |
| JavascriptEnable      | 627    | 261   | 217   |
| LocalEventTime        | 1599   | 1139  | 1027  |
| MobilePhone           | 892    | 386   | 275   |
| MobilePhoneModel      | 892    | 524   | 382   |
| NetMajor              | 892    | 405   | 277   |
| NetMinor              | 893    | 360   | 277   |
| OS                    | 892    | 691   | 375   |
| OpenerName            | 10     | 10    | 10    |
| OpenstatAdID          | 893    | 517   | 393   |
| OpenstatCampaignID    | 892    | 451   | 323   |
| OpenstatServiceName   | 890    | 400   | 277   |
| OpenstatSourceID      | 892    | 471   | 326   |
| OriginalURL           | 8241   | 8147  | 8043  |
| PageCharset           | 893    | 524   | 287   |
| ParamCurrency         | 892    | 413   | 276   |
| ParamCurrencyID       | 26     | 22    | 21    |
| ParamOrderID          | 893    | 472   | 278   |
| ParamPrice            | 26     | 21    | 21    |
| Params                | 891    | 395   | 281   |
| Referer               | 9048   | 8984  | 8862  |
| RefererCategoryID     | 895    | 814   | 722   |
| RefererHash           | 3200   | 3105  | 3065  |
| RefererRegionID       | 895    | 819   | 760   |
| RegionID              | 893    | 759   | 597   |
| RemoteIP              | 1071   | 828   | 712   |
| ResolutionDepth       | 893    | 594   | 319   |
| ResolutionHeight      | 894    | 655   | 471   |
| ResolutionWidth       | 894    | 702   | 477   |
| ResponseEndTiming     | 638    | 586   | 547   |
| ResponseStartTiming   | 638    | 581   | 548   |
| Robotness             | 893    | 516   | 353   |
| SearchEngineID        | 892    | 501   | 391   |
| SearchPhrase          | 1907   | 1840  | 1786  |
| SendTiming            | 496    | 385   | 337   |
| Sex                   | 895    | 450   | 275   |
| SilverlightVersion1   | 894    | 697   | 292   |
| SilverlightVersion2   | 892    | 438   | 275   |
| SilverlightVersion3   | 893    | 625   | 472   |
| SilverlightVersion4   | 695    | 281   | 251   |
| SocialAction          | 894    | 384   | 275   |
| SocialNetwork         | 892    | 436   | 275   |
| SocialSourceNetworkID | 890    | 370   | 273   |
| SocialSourcePage      | 896    | 687   | 441   |
| Title                 | 6975   | 6936  | 6877  |
| TraficSourceID        | 895    | 551   | 345   |
| URL                   | 11586  | 11529 | 11476 |
| URLCategoryID         | 887    | 571   | 310   |
| URLHash               | 3086   | 3052  | 2993  |
| URLRegionID           | 879    | 506   | 326   |
| UTMCampaign           | 893    | 454   | 335   |
| UTMContent            | 893    | 420   | 294   |
| UTMMedium             | 892    | 434   | 293   |
| UTMSource             | 892    | 466   | 301   |
| UTMTerm               | 891    | 419   | 308   |
| UserAgent             | 893    | 575   | 399   |
| UserAgentMajor        | 894    | 505   | 364   |
| UserAgentMinor        | 894    | 566   | 451   |
| UserID                | 1329   | 1205  | 1035  |
| WatchID               | 3336   | 3329  | 3308  |
| WindowClientHeight    | 893    | 732   | 617   |
| WindowClientWidth     | 893    | 754   | 623   |
| WindowName            | 537    | 446   | 383   |
| WithHash              | 218    | 126   | 113   |

Note that while the per-column block counts go down significantly, the total database size remains unchanged. The difference is just that before we would more often co-locate different columns on the same blocks.

| database_name | database_size | total_blocks |
|---------------|---------------|-------------:|
| hits_grouped  | 18.3 GiB      | 75222        |
| hits_columnar | 18.2 GiB      | 74864        |
| hits_14       | 18.3 GiB      | 75227        |
