### PR TITLE
Check for unresolved parameters when binding `CREATE MACRO ... AS TABLE`

### DIFF
--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -345,11 +345,7 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 			try {
 				dummy_binder->Bind(*query_node);
 			} catch (const std::exception &ex) {
-				// TODO: we would like to do something like "error = ErrorData(ex);" here,
-				//  but that breaks macro's like "create macro m(x) as table (from query_table(x));",
-				//  because dummy-binding these always throws an error instead of a ParameterNotResolvedException.
-				//  So, for now, we allow macro's with bind errors to be created.
-				//  Binding is still useful because we can create the dependencies.
+				error = ErrorData(ex);
 			}
 		}
 

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -469,8 +469,15 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 		}
 	}
 
-	auto get = BindTableFunctionInternal(table_function, ref, std::move(parameters), std::move(named_parameters),
-	                                     std::move(input_table_types), std::move(input_table_names));
+	unique_ptr<LogicalOperator> get;
+	try {
+		get = BindTableFunctionInternal(table_function, ref, std::move(parameters), std::move(named_parameters),
+		                                std::move(input_table_types), std::move(input_table_names));
+	} catch (std::exception &ex) {
+		error = ErrorData(ex);
+		error.AddQueryLocation(ref);
+		error.Throw();
+	}
 	auto table_function_ref = make_uniq<BoundTableFunction>(std::move(get));
 	table_function_ref->subquery = std::move(subquery);
 	return std::move(table_function_ref);

--- a/src/planner/expression_binder/table_function_binder.cpp
+++ b/src/planner/expression_binder/table_function_binder.cpp
@@ -27,9 +27,13 @@ BindResult TableFunctionBinder::BindColumnReference(unique_ptr<ParsedExpression>
 		if (lambda_ref) {
 			return BindLambdaReference(lambda_ref->Cast<LambdaRefExpression>(), depth);
 		}
+
 		if (binder.macro_binding && binder.macro_binding->HasMatchingBinding(col_ref.GetName())) {
 			throw ParameterNotResolvedException();
 		}
+	} else if (col_ref.column_names[0].find(DummyBinding::DUMMY_NAME) != string::npos && binder.macro_binding &&
+	           binder.macro_binding->HasMatchingBinding(col_ref.GetName())) {
+		throw ParameterNotResolvedException();
 	}
 
 	auto query_location = col_ref.GetQueryLocation();

--- a/test/configs/enable_verification.json
+++ b/test/configs/enable_verification.json
@@ -209,7 +209,8 @@
         "test/sql/logging/logging_file_bind_replace.test",
         "test/sql/optimizer/test_rowid_pushdown_plan.test",
         "test/sql/pg_catalog/system_functions.test",
-        "test/sql/storage/compression/test_using_compression.test"
+        "test/sql/storage/compression/test_using_compression.test",
+        "test/sql/error/error_position.test"
       ]
     }
   ]

--- a/test/sql/catalog/function/test_table_macro_args.test
+++ b/test/sql/catalog/function/test_table_macro_args.test
@@ -138,13 +138,10 @@ spades
 
 
 # create macro with non existing table
-statement ok
-CREATE MACRO card_no_tbl() as TABLE SELECT * FROM suit_tbl;
-
 statement error
-SELECT * FROM card_no_tbl();
+CREATE MACRO card_no_tbl() as TABLE SELECT * FROM suit_tbl;
 ----
-
+Catalog Error
 
 # wrong arg order
 statement error

--- a/test/sql/error/error_position.test
+++ b/test/sql/error/error_position.test
@@ -2,14 +2,12 @@
 # description: Test error position
 # group: [error]
 
-# error within table macro
-statement ok
-create macro checksum(x) as table SELECT bit_xor(md5_number(CAST(COLUMNS(*) AS VARCHAR))) FROM query_table(table_name);
-
 statement ok
 set errors_as_json=true;
 
+# error within table macro
 statement error
-select * from checksum('tbl');
+create macro checksum(x) as table SELECT bit_xor(md5_number(CAST(COLUMNS(*) AS VARCHAR))) FROM query_table(table_name);
 ----
-<REGEX>:.*"position".*:.*"14".*
+<REGEX>:.*"position".*:.*"95".*
+


### PR DESCRIPTION
Since v1.4.0, we bind table macros upon creation, just like we do for scalar macros. However, there were some issues where we did not properly throw upon finding unresolved parameters. This PR addresses that.

Fixes https://github.com/duckdb/duckdb/issues/19142
Fixes https://github.com/duckdblabs/duckdb-internal/issues/6081