### PR TITLE
Disable ALP for non-default block sizes

### DIFF
--- a/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
@@ -82,7 +82,12 @@ unique_ptr<AnalyzeState> AlpInitAnalyze(ColumnData &col_data, PhysicalType type)
  */
 template <class T>
 bool AlpAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
-	auto &analyze_state = (AlpAnalyzeState<T> &)state;
+	if (state.info.GetBlockSize() + state.info.GetBlockHeaderSize() < DEFAULT_BLOCK_ALLOC_SIZE) {
+		return false;
+	}
+
+	auto &analyze_state = state.Cast<AlpAnalyzeState<T>>();
+
 	bool must_skip_current_vector = alp::AlpUtils::MustSkipSamplingFromCurrentVector(
 	    analyze_state.vectors_count, analyze_state.vectors_sampled_count, count);
 	analyze_state.vectors_count += 1;

--- a/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
@@ -47,8 +47,12 @@ unique_ptr<AnalyzeState> AlpRDInitAnalyze(ColumnData &col_data, PhysicalType typ
  */
 template <class T>
 bool AlpRDAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
+	if (state.info.GetBlockSize() + state.info.GetBlockHeaderSize() < DEFAULT_BLOCK_ALLOC_SIZE) {
+		return false;
+	}
+
 	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
-	auto &analyze_state = (AlpRDAnalyzeState<T> &)state;
+	auto &analyze_state = state.Cast<AlpRDAnalyzeState<T>>();
 
 	bool must_skip_current_vector = alp::AlpUtils::MustSkipSamplingFromCurrentVector(
 	    analyze_state.vectors_count, analyze_state.vectors_sampled_count, count);

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -341,8 +341,6 @@ unique_ptr<AnalyzeState> BitpackingInitAnalyze(ColumnData &col_data, PhysicalTyp
 
 template <class T>
 bool BitpackingAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
-	auto &analyze_state = state.Cast<BitpackingAnalyzeState<T>>();
-
 	// We use BITPACKING_METADATA_GROUP_SIZE tuples, which can exceed the block size.
 	// In that case, we disable bitpacking.
 	// we are conservative here by multiplying by 2
@@ -351,6 +349,7 @@ bool BitpackingAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
 		return false;
 	}
 
+	auto &analyze_state = state.Cast<BitpackingAnalyzeState<T>>();
 	UnifiedVectorFormat vdata;
 	input.ToUnifiedFormat(count, vdata);
 

--- a/test/configs/block_size_16kB.json
+++ b/test/configs/block_size_16kB.json
@@ -8,6 +8,12 @@
       "paths": [
         "test/sql/storage/constraints/foreignkey/foreign_key_persistent_memory_limit.test"
       ]
+    },
+    {
+      "reason": "ALP is disabled for non-default block sizes.",
+      "paths": [
+        "test/sql/storage/compression/alp/alp_min_max.test"
+      ]
     }
   ]
 }

--- a/test/configs/block_size_16kB.json
+++ b/test/configs/block_size_16kB.json
@@ -10,9 +10,10 @@
       ]
     },
     {
-      "reason": "ALP is disabled for non-default block sizes.",
+      "reason": "ALP and ALPRD are disabled for non-default block sizes.",
       "paths": [
-        "test/sql/storage/compression/alp/alp_min_max.test"
+        "test/sql/storage/compression/alp/alp_min_max.test",
+        "test/sql/storage/compression/alprd/alprd_min_max.test"
       ]
     }
   ]

--- a/test/configs/latest_storage_block_size_16kB.json
+++ b/test/configs/latest_storage_block_size_16kB.json
@@ -29,6 +29,12 @@
         "test/sql/table_function/duckdb_databases.test",
         "test/sql/tpch/dbgen_error.test"
       ]
+    },
+    {
+      "reason": "ALP is disabled for non-default block sizes.",
+      "paths": [
+        "test/sql/storage/compression/alp/alp_min_max.test"
+      ]
     }
   ]
 }

--- a/test/sql/storage/compression/alp/alp_min_max.test
+++ b/test/sql/storage/compression/alp/alp_min_max.test
@@ -1,14 +1,13 @@
 # name: test/sql/storage/compression/alp/alp_min_max.test
 # group: [alp]
 
-# load the DB from disk
 load __TEST_DIR__/alp_min_max.db
 
 statement ok
 PRAGMA enable_verification
 
 statement ok
-pragma force_compression='alp';
+PRAGMA force_compression='alp';
 
 foreach type DOUBLE FLOAT
 
@@ -16,7 +15,6 @@ statement ok
 CREATE TABLE all_types AS SELECT ${type} FROM test_all_types();
 
 loop i 0 15
-
 
 statement ok
 INSERT INTO all_types SELECT ${type} FROM all_types;

--- a/test/sql/storage/compression/alprd/alprd_min_max.test
+++ b/test/sql/storage/compression/alprd/alprd_min_max.test
@@ -1,14 +1,13 @@
 # name: test/sql/storage/compression/alprd/alprd_min_max.test
 # group: [alprd]
 
-# load the DB from disk
 load __TEST_DIR__/alprd_min_max.db
 
 statement ok
 PRAGMA enable_verification
 
 statement ok
-pragma force_compression='alprd';
+PRAGMA force_compression='alprd';
 
 foreach type DOUBLE FLOAT
 


### PR DESCRIPTION
Currently, the ALP code assumes that it can always write 1024 values to a block. That might not be the case in the presence of many exceptions, if block sizes are small. Eventually, we should refactor the ALP compression code to address that, see https://github.com/duckdblabs/duckdb-internal/issues/6076. For now, we just disable it for non-default block sizes.

Fix https://github.com/duckdblabs/duckdb-internal/issues/6075.