### PR TITLE
Autoloading helper file system: allow either autoloading or proper errors in more file operations

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -628,15 +628,6 @@ bool FileSystem::CanHandleFile(const string &fpath) {
 	throw NotImplementedException("%s: CanHandleFile is not implemented!", GetName());
 }
 
-static string LookupExtensionForPattern(const string &pattern) {
-	for (const auto &entry : EXTENSION_FILE_PREFIXES) {
-		if (StringUtil::StartsWith(pattern, entry.name)) {
-			return entry.extension;
-		}
-	}
-	return "";
-}
-
 vector<OpenFileInfo> FileSystem::GlobFiles(const string &pattern, ClientContext &context, const FileGlobInput &input) {
 	auto result = Glob(pattern);
 	if (result.empty()) {

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -113,7 +113,7 @@ void VirtualFileSystem::RemoveDirectory(const string &directory, optional_ptr<Fi
 bool VirtualFileSystem::ListFilesExtended(const string &directory,
                                           const std::function<void(OpenFileInfo &info)> &callback,
                                           optional_ptr<FileOpener> opener) {
-	return FindFileSystem(directory).ListFiles(directory, callback, opener);
+	return FindFileSystem(directory, opener).ListFiles(directory, callback, opener);
 }
 
 void VirtualFileSystem::MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener) {

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -122,7 +122,7 @@ void VirtualFileSystem::MoveFile(const string &source, const string &target, opt
 }
 
 bool VirtualFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
-	return FindFileSystem(filename).FileExists(filename, opener);
+	return FindFileSystem(filename, opener).FileExists(filename, opener);
 }
 
 bool VirtualFileSystem::IsPipe(const string &filename, optional_ptr<FileOpener> opener) {

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -242,9 +242,11 @@ FileSystem &VirtualFileSystem::FindFileSystem(const string &path, optional_ptr<C
 		}
 
 		FileSystem &fs_no_autoloading = FindFileSystem(path);
-		if (!disabled_file_systems.empty() && disabled_file_systems.find(fs_no_autoloading.GetName()) != disabled_file_systems.end()) {
+		if (!disabled_file_systems.empty() &&
+		    disabled_file_systems.find(fs_no_autoloading.GetName()) != disabled_file_systems.end()) {
 			throw PermissionException("File system %s has been disabled by configuration", fs_no_autoloading.GetName());
 		}
+
 		return fs_no_autoloading;
 	}
 

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -142,7 +142,7 @@ string VirtualFileSystem::PathSeparator(const string &path) {
 }
 
 vector<OpenFileInfo> VirtualFileSystem::Glob(const string &path, FileOpener *opener) {
-	return FindFileSystem(path).Glob(path, opener);
+	return FindFileSystem(path, opener).Glob(path, opener);
 }
 
 void VirtualFileSystem::RegisterSubSystem(unique_ptr<FileSystem> fs) {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -284,6 +284,9 @@ public:
 	DUCKDB_API virtual bool SubSystemIsDisabled(const string &name);
 
 	DUCKDB_API static bool IsDirectory(const OpenFileInfo &info);
+	DUCKDB_API virtual bool IsAutoloadingFileSystem() {
+		return false;
+	}
 
 protected:
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &path, FileOpenFlags flags,

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -284,9 +284,6 @@ public:
 	DUCKDB_API virtual bool SubSystemIsDisabled(const string &name);
 
 	DUCKDB_API static bool IsDirectory(const OpenFileInfo &info);
-	DUCKDB_API virtual bool IsAutoloadingFileSystem() {
-		return false;
-	}
 
 protected:
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &path, FileOpenFlags flags,

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/map.hpp"
 #include "duckdb/common/unordered_set.hpp"
+#include "duckdb/main/extension_helper.hpp"
 
 namespace duckdb {
 
@@ -82,14 +83,58 @@ protected:
 	}
 
 private:
+	FileSystem &FindFileSystem(const string &path, optional_ptr<FileOpener> file_opener);
+	FileSystem &FindFileSystem(const string &path, optional_ptr<ClientContext> client_context);
 	FileSystem &FindFileSystem(const string &path);
-	FileSystem &FindFileSystemInternal(const string &path);
+	FileSystem &FindFileSystemInternal(const string &path, bool allow_autoloading_file_system = false);
 
 private:
 	vector<unique_ptr<FileSystem>> sub_systems;
 	map<FileCompressionType, unique_ptr<FileSystem>> compressed_fs;
 	const unique_ptr<FileSystem> default_fs;
 	unordered_set<string> disabled_file_systems;
+};
+
+class AutoloadingFileSystem : public FileSystem {
+public:
+	bool CanHandleFile(const string &path) override {
+		string required_extension = "";
+		for (const auto &entry : EXTENSION_FILE_PREFIXES) {
+			if (StringUtil::StartsWith(path, entry.name)) {
+				required_extension = entry.extension;
+				return true;
+			}
+		}
+		// success! glob again
+		return false;
+	}
+	std::string GetName() const override {
+		return "AutoloadingBaseFileSystem";
+	}
+
+	bool Autoload(const string &path, optional_ptr<ClientContext> context, string &required_extension) {
+		for (const auto &entry : EXTENSION_FILE_PREFIXES) {
+			if (StringUtil::StartsWith(path, entry.name)) {
+				required_extension = entry.extension;
+			}
+		}
+		if (!required_extension.empty() && context && !context->db->ExtensionIsLoaded(required_extension)) {
+			auto &dbconfig = DBConfig::GetConfig(*context);
+			if (!ExtensionHelper::CanAutoloadExtension(required_extension) ||
+			    !dbconfig.options.autoload_known_extensions) {
+				auto error_message = "File " + path + " requires the extension " + required_extension + " to be loaded";
+				error_message =
+				    ExtensionHelper::AddExtensionInstallHintToErrorMsg(*context, error_message, required_extension);
+				throw MissingExtensionException(error_message);
+			}
+			// an extension is required to read this file, but it is not loaded - try to load it
+			ExtensionHelper::AutoLoadExtension(*context, required_extension);
+		}
+		return true;
+	};
+	bool IsAutoloadingFileSystem() override {
+		return true;
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -84,9 +84,9 @@ protected:
 
 private:
 	FileSystem &FindFileSystem(const string &path, optional_ptr<FileOpener> file_opener);
-	FileSystem &FindFileSystem(const string &path, optional_ptr<ClientContext> client_context);
+	FileSystem &FindFileSystem(const string &path, optional_ptr<DatabaseInstance> database_instance);
 	FileSystem &FindFileSystem(const string &path);
-	FileSystem &FindFileSystemInternal(const string &path, bool &allow_autoloading_file_system);
+	optional_ptr<FileSystem> FindFileSystemInternal(const string &path);
 
 private:
 	vector<unique_ptr<FileSystem>> sub_systems;

--- a/test/extension/autoloading_copy_function_target.test
+++ b/test/extension/autoloading_copy_function_target.test
@@ -12,3 +12,8 @@ statement error
 copy (select 1337 as edgy_hacker_number) TO 's3://non-existent-bucket/test1337.csv'
 ----
 <REGEX>:.*Missing Extension Error: File .*test1337.csv requires the extension httpfs to be loaded.*
+
+statement error
+copy (select 1337 as edgy_hacker_number) TO 'azure://non-existent-bucket/test1337.csv'
+----
+<REGEX>:.*Missing Extension Error: File .*test1337.csv requires the extension azure to be loaded.*

--- a/test/extension/autoloading_copy_function_target.test
+++ b/test/extension/autoloading_copy_function_target.test
@@ -2,8 +2,6 @@
 # description: Tests for autoloading copy functions targets
 # group: [extension]
 
-require parquet
-
 statement ok
 set autoload_known_extensions=false
 
@@ -11,6 +9,6 @@ statement ok
 set autoinstall_known_extensions=false
 
 statement error
-copy (select 1337 as edgy_hacker_number) TO 's3://non-existent-bucket/test1337.parquet'
+copy (select 1337 as edgy_hacker_number) TO 's3://non-existent-bucket/test1337.csv'
 ----
-<REGEX>:.*Missing Extension Error: File .*test1337.parquet requires the extension httpfs to be loaded.*
+<REGEX>:.*Missing Extension Error: File .*test1337.csv requires the extension httpfs to be loaded.*

--- a/test/extension/autoloading_copy_function_target.test
+++ b/test/extension/autoloading_copy_function_target.test
@@ -1,0 +1,16 @@
+# name: test/extension/autoloading_copy_function_target.test
+# description: Tests for autoloading copy functions targets
+# group: [extension]
+
+require parquet
+
+statement ok
+set autoload_known_extensions=false
+
+statement ok
+set autoinstall_known_extensions=false
+
+statement error
+copy (select 1337 as edgy_hacker_number) TO 's3://non-existent-bucket/test1337.parquet'
+----
+<REGEX>:.*Missing Extension Error: File .*test1337.parquet requires the extension httpfs to be loaded.*


### PR DESCRIPTION
Currently, if `httpfs` extension has not been loaded yet:
```sql
COPY (SELECT 42 AS answer) TO 's3://my_bucket/my_file.parquet';
```
either fails like:
```
IO Error:
Cannot open file "s3://my_bucket/my_file.parquet": No such file or directory
```
where `s3://my_bucket/my_file.parquet` is treated as a local file system and can't find the base directory `s3://my_bucket` that is necessary to actually save the file.

```sql
LOAD httpfs;
COPY (SELECT 42 AS answer) TO 's3://my_bucket/my_file.parquet';
```
will rightly fail like:
```
HTTP Error:
Unable to connect to URL https://my_bucket.s3.us-east-1.amazonaws.com/my_file.parquet?uploads=: Forbidden (HTTP code 403)
```
that, given I choose a random bucket name that I have no permissions for is appropriate.


Goal of this PR is making autoloading (or detection that loading an extension is needed) work in more broader contest, in particular:
* for targets of COPY TO
* for globs (this worked already, but now with the same infrastructure)
* for fetching single files in a non-globbing situation (example: `SELECT name, id FROM ICEBERG_SCAN('https://raw.githubusercontent.com/duckdb/duckdb-iceberg/main/data/persistent/equality_deletes/warehouse/mydb/mytable', VERSION='1', allow_moved_paths = true);` will now correctly trigger autoloading of httpfs)

This infrastructure is also easy to generalize, it's a matter of calling `VirtualFileSystem::FindFileSystem(path)` overload that takes either a ClientContext or a FileOpener: `VirtualFileSystem::FindFileSystem(path, context_or_file_opener)`.


After this PR, same example as above would either autoload and throw HTTP Error:
```
HTTP Error:
Unable to connect to URL https://my_bucket.s3.us-east-1.amazonaws.com/my_file.parquet?uploads=: Forbidden (HTTP code 403)
```
or throw a Missing Extension Error:
```
Missing Extension Error:
File s3://my_bucket/my_file.parquet requires the extension httpfs to be loaded

Please try installing and loading the httpfs extension by running:
INSTALL httpfs;
LOAD httpfs;

Alternatively, consider enabling auto-install and auto-load by running:
SET autoinstall_known_extensions=1;
SET autoload_known_extensions=1;
```

Fixes https://github.com/duckdb/duckdb/issues/19180
Fixes autoloading of FileExist, example:
```sql
SELECT name, id FROM ICEBERG_SCAN('https://raw.githubusercontent.com/duckdb/duckdb-iceberg/main/data/persistent/equality_deletes/warehouse/mydb/mytable', VERSION='2', allow_moved_paths = true);
```