### PR TITLE
[Fix] Correctly reset the gate status during ART merging

### DIFF
--- a/src/execution/index/art/art_merger.cpp
+++ b/src/execution/index/art/art_merger.cpp
@@ -217,9 +217,6 @@ void ARTMerger::MergeNodeAndPrefix(Node &node, Node &prefix, const GateStatus pa
 	auto child = node.GetChildMutable(art, byte);
 
 	// Reduce the prefix to the bytes after pos.
-	// We always reduce by at least one byte,
-	// thus, if the prefix was a gate, it no longer is.
-	prefix.SetGateStatus(GateStatus::GATE_NOT_SET);
 	Prefix::Reduce(art, prefix, pos);
 
 	if (child) {

--- a/src/execution/index/art/prefix.cpp
+++ b/src/execution/index/art/prefix.cpp
@@ -100,6 +100,10 @@ void Prefix::Reduce(ART &art, Node &node, const idx_t pos) {
 	D_ASSERT(node.HasMetadata());
 	D_ASSERT(pos < Count(art));
 
+	// We always reduce by at least one byte,
+	// thus, if the prefix was a gate, it no longer is.
+	node.SetGateStatus(GateStatus::GATE_NOT_SET);
+
 	Prefix prefix(art, node);
 	if (pos == idx_t(prefix.data[Count(art)] - 1)) {
 		auto next = *prefix.ptr;


### PR DESCRIPTION
Fix https://github.com/duckdb/duckdb/issues/19190.

I *really* tried to generate the data to reproduce this... The bug happens for four row IDs, if they have the same value. Two each have to be inside a gate in different row groups, so that we create two ARTs in different sinks. The gate also has to start with a prefix that has the `GATE_SET` status. However, I could not figure out what else is missing for the `ARTMerger` to hit this code path...

Here's my attempt:
```sql
# Create a table that spans two row groups to trigger parallelism.

statement ok
CREATE TABLE tbl (id UBIGINT);

statement ok
INSERT INTO tbl SELECT range FROM range(38_330);

# Insert the same value for row IDs 38_330 and 38_331.

statement ok
INSERT INTO tbl VALUES (38_330), (38_330);

# Fill up until row ID 418_986.
# 418_986 - 2 - 38_330 = 380_654.

statement ok
INSERT INTO tbl SELECT range + 2 + 38_330 FROM range (380_654);

# Insert the same value for row IDs 418_986 and 418_987.
statement ok
INSERT INTO tbl VALUES (38_330), (38_330);

query I
SELECT rowid FROM tbl WHERE id = 38_330 ORDER BY rowid;
----
38330
38331
418986
418987

statement ok
CREATE INDEX idx ON tbl(id);

query I
SELECT COUNT(id) FROM tbl WHERE id = 38_330;
----
4
```

See also my comment here on how we could maybe allow testing on the original files: https://github.com/duckdblabs/duckdb-internal/issues/6083