### PR TITLE
Bump 4 extensions: aws, ducklake, httpfs, ...

### DIFF
--- a/.github/config/extensions/aws.cmake
+++ b/.github/config/extensions/aws.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(aws
             ### TODO: re-enable LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG 812ce80fde0bfa6e4641b6fd798087349a610795
+            GIT_TAG 2afb8de8716682de76ee8d5b57cdcec714c273f7
             )
 endif()

--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG 45788f0a875844ac8fed048c99b87f7f4b1c2ac1
+    GIT_TAG 799ff08424a167d9bbb79e16fedcf7bb6bcf3cd7
 )

--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 1f137f7962327054392d83b8a46b48850fb184b2
+    GIT_TAG 0518838dae609ab8e8ae66960ce982b839754075
     INCLUDE_DIR extension/httpfs/include
 )

--- a/.github/config/extensions/iceberg.cmake
+++ b/.github/config/extensions/iceberg.cmake
@@ -9,6 +9,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 49d67e45a6f15ad855f3760658b4ab42967d9cdc
+            GIT_TAG cef50c71d9cd2ae853ef718829d69356d580d22c
             )
 endif()


### PR DESCRIPTION
This PR bumps the following extensions:
- `aws` from `812ce80fde` to `2afb8de871`
- `ducklake` from `45788f0a87` to `799ff08424`
- `httpfs` from `1f137f7962` to `0518838dae`
- `iceberg` from `49d67e45a6` to `cef50c71d9`
