### PR TITLE
[CI] - Fix failing `Extension updating test` NightlyTests job by cleaning up some space on the runner

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -334,6 +334,10 @@ jobs:
           sudo rm -rf /var/lib/apt/lists/*
           docker system prune -af || true
           rm -rf ~/.cache
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           echo "Disk usage after clean up:"
           df -h
 

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -326,6 +326,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Cleanup disk before build
+        run: |
+          echo "Disk usage before clean up:"
+          df -h
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          docker system prune -af || true
+          rm -rf ~/.cache
+          echo "Disk usage after clean up:"
+          df -h
 
       - name: Install
         shell: bash


### PR DESCRIPTION
[`Extension updating test` fails](https://github.com/duckdb/duckdb/actions/runs/18147501715/job/51652792095) because no space left on device. GH Actions runners have a lot of preinstalled apps that we don't use in this job, so we can easily clean up some space to run this job.

[Tested here](https://github.com/hmeriann/duckdb/actions/runs/18131737845/job/51600463174)