### PR TITLE
Fixup templated version of TryGetSecretKeyOrSetting

### DIFF
--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -296,7 +296,9 @@ public:
 		Value result;
 		auto lookup_result = TryGetSecretKeyOrSetting(secret_key, setting_name, result);
 		if (lookup_result) {
-			value_out = result.GetValue<TYPE>();
+			if (!result.IsNull()) {
+				value_out = result.GetValue<TYPE>();
+			}
 		}
 		return lookup_result;
 	}


### PR DESCRIPTION
If the value is NULL, do not attempt to get it back. This cause the funny bug where:
```
SET s3_region = NULL;
SELECT current_setting('s3_region');
----- NULL
FROM read_parquet('s3://my_bucket/test.parquet');
```
will query: https://my_bucket.s3.NULL.amazonaws.com/test.parquet instead of the more reasonable https://my_bucket.s3.amazonaws.com/test.parquet