### PR TITLE
Bump: delta

### DIFF
--- a/.github/config/extensions/delta.cmake
+++ b/.github/config/extensions/delta.cmake
@@ -1,7 +1,7 @@
 if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(delta
             GIT_URL https://github.com/duckdb/duckdb-delta
-            GIT_TAG fa847248e163335bd1fc6bacf9c0d82e368e3426
+            GIT_TAG 03aaf0f073bc622ade27c158d32473588b32aa8b
             SUBMODULES extension-ci-tools
     )
 endif()


### PR DESCRIPTION
This PR bumps the following extensions:
- `delta` from `fa847248e1` to `03aaf0f073`
