### PR TITLE
Eargerly destroy sort buffers in Window

### DIFF
--- a/src/common/sorting/sort.cpp
+++ b/src/common/sorting/sort.cpp
@@ -379,6 +379,9 @@ public:
 	}
 
 	void Destroy() {
+		if (!merger_global_state) {
+			return;
+		}
 		auto guard = merger_global_state->Lock();
 		merger.sorted_runs.clear();
 		sink.temporary_memory_state.reset();

--- a/src/common/sorting/sort.cpp
+++ b/src/common/sorting/sort.cpp
@@ -379,6 +379,7 @@ public:
 	}
 
 	void Destroy() {
+		auto guard = merger_global_state->Lock();
 		merger.sorted_runs.clear();
 		sink.temporary_memory_state.reset();
 	}

--- a/src/common/sorting/sort.cpp
+++ b/src/common/sorting/sort.cpp
@@ -379,7 +379,6 @@ public:
 	}
 
 	void Destroy() {
-		merger_global_state.reset();
 		merger.sorted_runs.clear();
 		sink.temporary_memory_state.reset();
 	}

--- a/src/common/sorting/sort.cpp
+++ b/src/common/sorting/sort.cpp
@@ -378,6 +378,12 @@ public:
 		return merger_global_state ? merger_global_state->MaxThreads() : 1;
 	}
 
+	void Destroy() {
+		merger_global_state.reset();
+		merger.sorted_runs.clear();
+		sink.temporary_memory_state.reset();
+	}
+
 public:
 	//! The global sink state
 	SortGlobalSinkState &sink;
@@ -477,16 +483,26 @@ SourceResultType Sort::MaterializeColumnData(ExecutionContext &context, Operator
 	}
 
 	// Merge into global output collection
-	auto guard = gstate.Lock();
-	if (!gstate.column_data) {
-		gstate.column_data = std::move(local_column_data);
-	} else {
-		gstate.column_data->Merge(*local_column_data);
+	{
+		auto guard = gstate.Lock();
+		if (!gstate.column_data) {
+			gstate.column_data = std::move(local_column_data);
+		} else {
+			gstate.column_data->Merge(*local_column_data);
+		}
 	}
+
+	// Destroy local state before returning
+	input.local_state.Cast<SortLocalSourceState>().merger_local_state.reset();
 
 	// Return type indicates whether materialization is done
 	const auto progress_data = GetProgress(context.client, input.global_state);
-	return progress_data.done == progress_data.total ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;
+	if (progress_data.done == progress_data.total) {
+		// Destroy global state before returning
+		gstate.Destroy();
+		return SourceResultType::FINISHED;
+	}
+	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
 unique_ptr<ColumnDataCollection> Sort::GetColumnData(OperatorSourceInput &input) const {

--- a/src/common/sorting/sorted_run_merger.cpp
+++ b/src/common/sorting/sorted_run_merger.cpp
@@ -888,6 +888,7 @@ SortedRunMerger::SortedRunMerger(const Expression &decode_sort_key_p, shared_ptr
 unique_ptr<LocalSourceState> SortedRunMerger::GetLocalSourceState(ExecutionContext &,
                                                                   GlobalSourceState &gstate_p) const {
 	auto &gstate = gstate_p.Cast<SortedRunMergerGlobalState>();
+	auto guard = gstate.Lock();
 	return make_uniq<SortedRunMergerLocalState>(gstate);
 }
 


### PR DESCRIPTION
We were holding onto them for longer than necessary.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/6067