### PR TITLE
Issue 18603

### DIFF
--- a/src/include/duckdb/optimizer/filter_pushdown.hpp
+++ b/src/include/duckdb/optimizer/filter_pushdown.hpp
@@ -102,8 +102,9 @@ private:
 	void ExtractFilterBindings(const Expression &expr, vector<ColumnBinding> &bindings);
 	//! Generate filters from the current set of filters stored in the FilterCombiner
 	void GenerateFilters();
-	//! if there are filters in this FilterPushdown node, push them into the combiner
-	void PushFilters();
+	//! if there are filters in this FilterPushdown node, push them into the combiner. Returns
+	//! FilterResult::UNSATISFIABLE if the subtree should be stripped, or FilterResult::SUCCESS otherwise
+	FilterResult PushFilters();
 };
 
 } // namespace duckdb

--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -207,17 +207,23 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownJoin(unique_ptr<LogicalOpera
 	}
 	return result;
 }
-void FilterPushdown::PushFilters() {
+FilterResult FilterPushdown::PushFilters() {
 	for (auto &f : filters) {
 		auto result = combiner.AddFilter(std::move(f->filter));
 		D_ASSERT(result != FilterResult::UNSUPPORTED);
-		(void)result;
+		if (result == FilterResult::UNSATISFIABLE) {
+			// one of the filters is unsatisfiable - abort filter pushdown
+			return FilterResult::UNSATISFIABLE;
+		}
 	}
 	filters.clear();
+	return FilterResult::SUCCESS;
 }
 
 FilterResult FilterPushdown::AddFilter(unique_ptr<Expression> expr) {
-	PushFilters();
+	if (PushFilters() == FilterResult::UNSATISFIABLE) {
+		return FilterResult::UNSATISFIABLE;
+	}
 	// split up the filters by AND predicate
 	vector<unique_ptr<Expression>> expressions;
 	expressions.push_back(std::move(expr));

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_empty_result.hpp"
 
 namespace duckdb {
 unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperator> op) {
@@ -48,7 +49,9 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 		// the table function does not support filter pushdown: push a LogicalFilter on top
 		return FinishPushdown(std::move(op));
 	}
-	PushFilters();
+	if (PushFilters() == FilterResult::UNSATISFIABLE) {
+		return make_uniq<LogicalEmptyResult>(std::move(op));
+	}
 
 	//! We generate the table filters that will be executed during the table scan
 	vector<FilterPushdownResult> pushdown_results;

--- a/test/optimizer/pushdown/issue_18603.test
+++ b/test/optimizer/pushdown/issue_18603.test
@@ -1,0 +1,31 @@
+# name: test/optimizer/pushdown/issue_18603.test
+# description: Test filter pushdown with conflict comparison filters
+# group: [pushdown]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE t0(c0 INT, c1 BOOLEAN);
+
+statement ok
+CREATE TABLE t1(c0 INT);
+
+statement ok
+INSERT INTO t0(c0, c1) VALUES (0, 0);
+
+statement ok
+INSERT INTO t1(c0) VALUES (1);
+
+# test different order of filters
+query III
+SELECT * FROM t0 INNER JOIN t1 ON (t0.c1 > t0.c0) AND (t1.c0 > t0.c0) AND (t0.c0 < 7) AND (t0.c1 = t0.c0);
+----
+
+query III
+SELECT * FROM t0 INNER JOIN t1 ON (t0.c1 = t0.c0) AND (t0.c1 > t0.c0) AND (t1.c0 > t0.c0) AND (t0.c0 < 7);
+----
+
+query III
+SELECT * FROM t0 INNER JOIN t1 ON (t0.c1 = t0.c0) AND  (t0.c0 < 7) AND (t0.c1 > t0.c0) AND (t1.c0 > t0.c0);
+----

--- a/test/optimizer/pushdown/issue_18603.test
+++ b/test/optimizer/pushdown/issue_18603.test
@@ -22,6 +22,21 @@ query III
 SELECT * FROM t0 INNER JOIN t1 ON (t0.c1 > t0.c0) AND (t1.c0 > t0.c0) AND (t0.c0 < 7) AND (t0.c1 = t0.c0);
 ----
 
+query II
+EXPLAIN SELECT * FROM t0 INNER JOIN t1 ON (t0.c1 > t0.c0) AND (t1.c0 > t0.c0) AND (t0.c0 < 7) AND (t0.c1 = t0.c0);
+----
+physical_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN SELECT * FROM t0 INNER JOIN t1 ON (t0.c1 > t0.c0) AND (t1.c0 > t0.c0) AND (t0.c0 < 7) AND (t0.c1 = t0.c0);
+----
+physical_plan	<!REGEX>:.*c0 > c0.*
+
+query II
+EXPLAIN SELECT * FROM t0 INNER JOIN t1 ON (t0.c1 > t0.c0) AND (t1.c0 > t0.c0) AND (t0.c0 < 7) AND (t0.c1 = t0.c0);
+----
+physical_plan	<!REGEX>:.*c0 < 7.*
+
 query III
 SELECT * FROM t0 INNER JOIN t1 ON (t0.c1 = t0.c0) AND (t0.c1 > t0.c0) AND (t1.c0 > t0.c0) AND (t0.c0 < 7);
 ----


### PR DESCRIPTION
Picking up the original PR from https://github.com/duckdb/duckdb/pull/18635. Hoping to include it in v1.4.1
Thanks again @Damon07 

Original PR description

This PR fixes https://github.com/duckdb/duckdb/issues/18603, the conflict of filters should be checked with existing filters when adding, otherwise filters can be dropped silently in `FilterPushdown::PushFilters()`. Maybe we should add a assertion with `D_ASSERT(result != FilterResult::UNSATISFIABLE);`.