### PR TITLE
Bump: aws, ducklake, iceberg

### DIFF
--- a/.github/config/extensions/aws.cmake
+++ b/.github/config/extensions/aws.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(aws
             ### TODO: re-enable LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG 812ce80fde0bfa6e4641b6fd798087349a610795
+            GIT_TAG 18803d5e55b9f9f6dda5047d0fdb4f4238b6801d
             )
 endif()

--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG 45788f0a875844ac8fed048c99b87f7f4b1c2ac1
+    GIT_TAG 2ed23c985bb03709160e60bd239b3c0be2cf3b93
 )

--- a/.github/config/extensions/iceberg.cmake
+++ b/.github/config/extensions/iceberg.cmake
@@ -9,6 +9,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 49d67e45a6f15ad855f3760658b4ab42967d9cdc
+            GIT_TAG 9b8c6de6b78d08b0e408b67372f3b6fadf8f53f0
             )
 endif()


### PR DESCRIPTION
This PR bumps the following extensions:
- `aws` from `812ce80fde` to `18803d5e55`
- `ducklake` from `45788f0a87` to `2ed23c985b`
- `iceberg` from `49d67e45a6` to `9b8c6de6b7`
