### PR TITLE
[shell] Fix tilde parsing for .once statement

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -81,6 +81,7 @@
 #include <assert.h>
 #include "duckdb_shell_wrapper.h"
 #include "duckdb/common/box_renderer.hpp"
+#include "duckdb/common/file_system.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 #include "sqlite3.h"
 typedef sqlite3_int64 i64;
@@ -2647,7 +2648,7 @@ static void output_file_close(FILE *f) {
 ** filename is "off".
 */
 static FILE *output_file_open(const char *zFile, int bTextMode) {
-	FILE *f;
+	FILE *f = nullptr;
 	if (strcmp(zFile, "stdout") == 0) {
 		f = stdout;
 	} else if (strcmp(zFile, "stderr") == 0) {
@@ -2655,7 +2656,8 @@ static FILE *output_file_open(const char *zFile, int bTextMode) {
 	} else if (strcmp(zFile, "off") == 0) {
 		f = 0;
 	} else {
-		f = fopen(zFile, bTextMode ? "w" : "wb");
+		const string expanded_path = duckdb::FileSystem::ExpandPath(zFile, /*opener=*/nullptr);
+		f = fopen(expanded_path.c_str(), bTextMode ? "w" : "wb");
 		if (f == 0) {
 			utf8_printf(stderr, "Error: cannot open \"%s\"\n", zFile);
 		}


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/discussions/19253

In the current implementation, shell uses `fopen` to directly open the file, which doesn't recognize and expand `~`.
I leverage existing filesystem utils to perform the expansion, and here's my SQL tests.

```sql
D .mode csv

-- Check original CSV file.
D select * from read_csv_auto('~/test.csv');
id
42
NULL

-- Set output with no issue.
D .once '~/table/test.csv'

-- Check output CSV file.
D select * from read_csv_auto('~/test.csv')
D select * from read_csv_auto('~/table/test.csv');
id
42
NULL
D .quit
```