### PR TITLE
feat: Fix length of sort keys

### DIFF
--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -696,13 +696,15 @@ void PrepareSortData(Vector &result, idx_t size, SortKeyLengthInfo &key_lengths,
 	}
 }
 
-void FinalizeSortData(Vector &result, idx_t size) {
+void FinalizeSortData(Vector &result, idx_t size, const SortKeyLengthInfo &key_lengths,
+                      const unsafe_vector<idx_t> &offsets) {
 	switch (result.GetType().id()) {
 	case LogicalTypeId::BLOB: {
 		auto result_data = FlatVector::GetData<string_t>(result);
 		// call Finalize on the result
 		for (idx_t r = 0; r < size; r++) {
-			result_data[r].Finalize();
+			result_data[r].SetSizeAndFinalize(offsets[r],
+			                                  key_lengths.variable_lengths[r] + key_lengths.constant_length);
 		}
 		break;
 	}
@@ -739,7 +741,7 @@ void CreateSortKeyInternal(vector<unique_ptr<SortKeyVectorData>> &sort_key_data,
 		SortKeyConstructInfo info(modifiers[c], offsets, data_pointers.get());
 		ConstructSortKey(*sort_key_data[c], info);
 	}
-	FinalizeSortData(result, row_count);
+	FinalizeSortData(result, row_count, key_lengths, offsets);
 }
 
 } // namespace


### PR DESCRIPTION
This is in response to Valgrind errors observed in the R package.

In the presence of `NULL` values (and perhaps with other conditions), sort keys can become shorter than the originally anticipated length. This leads to uninitialized memory access.

To prevent UMA, we can either ensure that the uninitialized memory is not read (as this PR does), or fill it with some value.

Submitting the PR to get a second opinion and also to perhaps run the tests on CI/CD. Merging will make my patch in the R package obsolete.

<details>

Failing valgrind run: https://github.com/duckdb/duckdb-r/actions/runs/18214180255/job/51860150272#step:6:1717

Reproducible example in R:

```r
library(duckdb)

# Autogenerated
drv <- duckdb()
con <- dbConnect(drv)

dbExecute(con, "SET threads TO 1")

df1 <- tibble::remove_rownames(data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))[1:2, ])

"union_all"
rel1 <- duckdb:::rel_from_df(con, df1)
print("rel1:")
print(duckdb:::rel_to_altrep(rel1))

df2 <- data.frame(a = 1L, b = 3, g = 2L)

"union_all"
rel2 <- duckdb:::rel_from_df(con, df2)
print("rel2:")
print(duckdb:::rel_to_altrep(rel2))

"union_all"
rel3 <- duckdb:::rel_project(
  rel1,
  list(
    {
      tmp_expr <- duckdb:::expr_reference("a")
      duckdb:::expr_set_alias(tmp_expr, "a")
      tmp_expr
    },
    {
      tmp_expr <- duckdb:::expr_reference("b")
      duckdb:::expr_set_alias(tmp_expr, "b")
      tmp_expr
    },
    {
      tmp_expr <- duckdb:::expr_reference("g")
      duckdb:::expr_set_alias(tmp_expr, "g")
      tmp_expr
    },
    {
      tmp_expr <- duckdb:::expr_window(duckdb:::expr_function("row_number", list()), list(), list(), offset_expr = NULL, default_expr = NULL)
      duckdb:::expr_set_alias(tmp_expr, "___row_number_x")
      tmp_expr
    },
    {
      tmp_expr <- duckdb:::expr_constant(NA_integer_)
      duckdb:::expr_set_alias(tmp_expr, "___row_number_y")
      tmp_expr
    }
  )
)
print("rel3:")
print(duckdb:::rel_to_altrep(rel3))

"union_all"
rel4 <- duckdb:::rel_project(
  rel2,
  list(
    {
      tmp_expr <- duckdb:::expr_reference("a")
      duckdb:::expr_set_alias(tmp_expr, "a")
      tmp_expr
    },
    {
      tmp_expr <- duckdb:::expr_reference("b")
      duckdb:::expr_set_alias(tmp_expr, "b")
      tmp_expr
    },
    {
      tmp_expr <- duckdb:::expr_reference("g")
      duckdb:::expr_set_alias(tmp_expr, "g")
      tmp_expr
    },
    {
      tmp_expr <- duckdb:::expr_constant(NA_integer_)
      duckdb:::expr_set_alias(tmp_expr, "___row_number_x")
      tmp_expr
    },
    {
      tmp_expr <- duckdb:::expr_window(duckdb:::expr_function("row_number", list()), list(), list(), offset_expr = NULL, default_expr = NULL)
      duckdb:::expr_set_alias(tmp_expr, "___row_number_y")
      tmp_expr
    }
  )
)
print("rel4:")
print(duckdb:::rel_to_altrep(rel4))

"union_all"
rel5 <- duckdb:::rel_union_all(rel3, rel4)
print("rel5:")
print(duckdb:::rel_to_altrep(rel5))

# df5 <- duckdb:::rel_to_altrep(rel5)
# rel5 <- duckdb:::rel_from_df(con, df5)

"union_all"
rel6 <- duckdb:::rel_order(
  rel5,
  list(duckdb:::expr_reference("___row_number_x"), duckdb:::expr_reference("___row_number_y"))
)
print("rel6:")
print(duckdb:::rel_to_altrep(rel6))

dbDisconnect(con, shutdown = TRUE)
```

</details>