### PR TITLE
Make filesystem extended API public

### DIFF
--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -285,7 +285,6 @@ public:
 
 	DUCKDB_API static bool IsDirectory(const OpenFileInfo &info);
 
-protected:
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &path, FileOpenFlags flags,
 	                                                           optional_ptr<FileOpener> opener);
 	DUCKDB_API virtual bool SupportsOpenFileExtended() const;
@@ -295,7 +294,6 @@ protected:
 	                                          optional_ptr<FileOpener> opener);
 	DUCKDB_API virtual bool SupportsListFilesExtended() const;
 
-public:
 	template <class TARGET>
 	TARGET &Cast() {
 		DynamicCastCheck<TARGET>(this);


### PR DESCRIPTION
I'm the author of a few duckdb filesystem community extensions, including [cache_httpfs](https://duckdb.org/community_extensions/extensions/cache_httpfs.html) and [observefs](https://duckdb.org/community_extensions/extensions/observefs.html).

All these extensions are built on top of duckdb virtual filesystem, example implementation:
```cpp
unique_ptr<FileHandle> OpenFile(path) {
  auto internal_file_handle = internal_filesystem->OpenFile(path);
  auto cache_file_handle = CacheFileHandle::new(std::move(internal_file_handle));
  return cache_file_handle;
}
```

I found recently a few extended interfaces are added to the filesystem API, the `protected` visibility makes it hard for extensions to adapt and extend.
https://github.com/duckdb/duckdb/blob/5657cbdc0b3029e1bc5675c81a202fd7f02a2a30/src/include/duckdb/common/file_system.hpp#L288-L296

To me, I think the extended file API set is already more or less public API which duckdb filesystem callers could access --- all the arguments and return value are public types and pretty commonly used in filesystem; and I don't see downside to change it to public.

Happy to discuss more about it, and welcome to better alternative solutions!