### PR TITLE
Fix `COLUMNS(* REPLACE)` generating duplicate columns with joins

### DIFF
--- a/test/sql/projection/select_star_replace.test
+++ b/test/sql/projection/select_star_replace.test
@@ -52,4 +52,42 @@ SELECT integers.* REPLACE (i+100 AS blabla) FROM integers
 statement error
 SELECT * EXCLUDE (i) REPLACE (i+100 AS i) FROM integers
 ----
-<REGEX>:.*Parser Error.*cannot occur in both.*
+<REGEX>:.*Parser Error: Column "i" cannot occur in both EXCLUDE and REPLACE list
+
+-- Test: REPLACE with quoted string constant (ColLabel parser support)
+statement ok
+CREATE TABLE test_star(id INTEGER, col1 VARCHAR, col2 VARCHAR, col3 INTEGER);
+
+statement ok
+INSERT INTO test_star VALUES (1, 'val1', 'val2', 42);
+
+query IIII
+SELECT test_star.* REPLACE ('quoted_val' AS quoted_val) FROM test_star;
+----
+id	quoted_val	col2	col3
+1	quoted_val	val2	42
+-- 1
+
+-- Test: REPLACE with quoted string and arithmetic expression (binding verification)
+query IIII
+SELECT test_star.* REPLACE (col1 AS 'computed: ' || (id * 2)::VARCHAR) FROM test_star;
+----
+id	?column?	col2	col3
+1	computed: 2	val2	42
+-- 1
+
+-- Test: Full combo EXCLUDE + REPLACE (arithmetic) + RENAME (unified HandleRename, qualified)
+query III
+SELECT test_star.* EXCLUDE (col2) REPLACE (col1 AS id * 2) RENAME (col3 AS final3) FROM test_star;
+----
+id	?column?	final3
+1	2	42
+-- 1
+
+-- Test: Combo with quoted REPLACE, EXCLUDE, and qualified RENAME (parser + binder integration)
+query III
+SELECT test_star.* EXCLUDE (col2) REPLACE (col1 AS 'replaced: ' || col3::VARCHAR) RENAME (id AS renamed_id, col3 AS final3) FROM test_star;
+----
+renamed_id	?column?	final3
+1	replaced: 42	42
+-- 1*

--- a/test/sql/projection/test_columns_replace_using.test
+++ b/test/sql/projection/test_columns_replace_using.test
@@ -1,0 +1,111 @@
+# name: test/sql/projection/test_columns_replace_using.test
+# description: Test COLUMNS REPLACE with NATURAL JOIN and JOIN USING
+# group: [projection]
+
+statement ok
+PRAGMA enable_verification
+
+# Test COLUMNS(* REPLACE) with NATURAL JOIN
+# Issue: COLUMNS(* REPLACE a AS a) was generating duplicate columns for USING columns
+# Expected: Should produce the same result as SELECT *
+
+query I
+SELECT COLUMNS(* REPLACE a AS a) FROM range(1) t1(a) NATURAL JOIN range(1) t2(a)
+----
+0
+
+query I
+SELECT * FROM range(1) t1(a) NATURAL JOIN range(1) t2(a)
+----
+0
+
+# Test with JOIN USING
+query I
+SELECT COLUMNS(* REPLACE a AS a) FROM range(1) t1(a) JOIN range(1) t2(a) USING (a)
+----
+0
+
+# Test with an actual replacement expression
+query I
+SELECT COLUMNS(* REPLACE (a + 1 AS a)) FROM range(1) t1(a) NATURAL JOIN range(1) t2(a)
+----
+1
+
+# Test with multiple rows
+query I
+SELECT COLUMNS(* REPLACE (a * 2 AS a)) FROM range(3) t1(a) NATURAL JOIN range(3) t2(a)
+----
+0
+2
+4
+
+# Test with multiple columns where one is a USING column
+query III
+SELECT COLUMNS(* REPLACE (a + 100 AS a)) FROM (SELECT 1 as a, 2 as b) t1 NATURAL JOIN (SELECT 1 as a, 3 as c) t2
+----
+101	2	3
+
+# Test replacing a non-USING column
+query III
+SELECT COLUMNS(* REPLACE (b + 10 AS b)) FROM (SELECT 1 as a, 2 as b) t1 NATURAL JOIN (SELECT 1 as a, 3 as c) t2
+----
+1	12	3
+
+# Test with three-way NATURAL JOIN
+query I
+SELECT COLUMNS(* REPLACE (a AS a)) FROM range(1) t1(a) NATURAL JOIN range(1) t2(a) NATURAL JOIN range(1) t3(a)
+----
+0
+
+# Test with three-way NATURAL JOIN with complex expression
+query I
+SELECT COLUMNS(* REPLACE (a + 1 AS a)) FROM range(2) t1(a) NATURAL JOIN range(2) t2(a) NATURAL JOIN range(2) t3(a)
+----
+1
+2
+
+# Test COLUMNS(* RENAME) still works correctly with NATURAL JOIN
+query I
+SELECT COLUMNS(* RENAME a AS b) FROM range(1) t1(a) NATURAL JOIN range(1) t2(a)
+----
+0
+
+# Test multiple replacements with NATURAL JOIN
+statement ok
+CREATE TABLE test_t1 AS SELECT 1 as a, 2 as b, 3 as c
+
+statement ok
+CREATE TABLE test_t2 AS SELECT 1 as a, 4 as d, 5 as e
+
+query IIIII
+SELECT COLUMNS(* REPLACE (a + 10 AS a, b + 20 AS b)) FROM test_t1 NATURAL JOIN test_t2
+----
+11	22	3	4	5
+
+# Test REPLACE with complex expression on USING column
+query IIIII
+SELECT COLUMNS(* REPLACE (concat(a::VARCHAR, '_joined') AS a)) FROM test_t1 NATURAL JOIN test_t2
+----
+1_joined	2	3	4	5
+
+# Test that EXCLUDE with qualified names still works correctly
+statement ok
+CREATE TABLE integers(i INTEGER, j INTEGER, k INTEGER)
+
+statement ok
+INSERT INTO integers VALUES (1, 2, 3)
+
+query IIII
+SELECT * EXCLUDE (i1.i, i2.i) FROM integers i1 JOIN integers i2 USING (i)
+----
+2	3	2	3
+
+# Clean up
+statement ok
+DROP TABLE test_t1
+
+statement ok
+DROP TABLE test_t2
+
+statement ok
+DROP TABLE integers


### PR DESCRIPTION
When using `COLUMNS(* REPLACE column AS column)` with joins, the column that appears in both tables (the `USING` column) was being replaced multiple times - once for each table. This resulted in duplicate columns in the output instead of a single merged column.

### Example
``` sql
SELECT COLUMNS(* REPLACE a AS a)
FROM range(1) t1(a) NATURAL JOIN range(1) t2(a)
```

### Summary
The fix tracks which columns have already been replaced in the ExclusionListInfo structure to prevent duplicate replacement expressions from being added for USING columns.

### Reference issue
fixes #18604