### PR TITLE
Add safe queue and deque

### DIFF
--- a/src/include/duckdb/common/deque.hpp
+++ b/src/include/duckdb/common/deque.hpp
@@ -21,19 +21,19 @@ template <class DATA_TYPE, bool SAFE = true>
 class deque : public std::deque<DATA_TYPE, std::allocator<DATA_TYPE>> { // NOLINT: matching name of std
 public:
 	using original = std::deque<DATA_TYPE, std::allocator<DATA_TYPE>>;
-    using original::original;
-    using value_type = typename original::value_type;
-    using allocator_type = typename original::allocator_type;
-    using size_type = typename original::size_type;
-    using difference_type = typename original::difference_type;
-    using reference = typename original::reference;
-    using const_reference = typename original::const_reference;
-    using pointer = typename original::pointer;
-    using const_pointer = typename original::const_pointer;
-    using iterator = typename original::iterator;
-    using const_iterator = typename original::const_iterator;
-    using reverse_iterator = typename original::reverse_iterator;
-    using const_reverse_iterator = typename original::const_reverse_iterator;
+	using original::original;
+	using value_type = typename original::value_type;
+	using allocator_type = typename original::allocator_type;
+	using size_type = typename original::size_type;
+	using difference_type = typename original::difference_type;
+	using reference = typename original::reference;
+	using const_reference = typename original::const_reference;
+	using pointer = typename original::pointer;
+	using const_pointer = typename original::const_pointer;
+	using iterator = typename original::iterator;
+	using const_iterator = typename original::const_iterator;
+	using reverse_iterator = typename original::reverse_iterator;
+	using const_reverse_iterator = typename original::const_reverse_iterator;
 
 private:
 	static inline void AssertIndexInBounds(idx_t index, idx_t size) {
@@ -51,7 +51,7 @@ public:
 	[[clang::reinitializes]]
 #endif
 	inline void
-    clear() noexcept { // NOLINT: hiding on purpose
+	clear() noexcept { // NOLINT: hiding on purpose
 		original::clear();
 	}
 

--- a/src/include/duckdb/common/deque.hpp
+++ b/src/include/duckdb/common/deque.hpp
@@ -22,17 +22,17 @@ class deque : public std::deque<DATA_TYPE, std::allocator<DATA_TYPE>> { // NOLIN
 public:
 	using original = std::deque<DATA_TYPE, std::allocator<DATA_TYPE>>;
     using original::original;
-    using value_type             = typename original::value_type;
-    using allocator_type         = typename original::allocator_type;
-    using size_type              = typename original::size_type;
-    using difference_type        = typename original::difference_type;
-    using reference              = typename original::reference;
-    using const_reference        = typename original::const_reference;
-    using pointer                = typename original::pointer;
-    using const_pointer          = typename original::const_pointer;
-    using iterator               = typename original::iterator;
-    using const_iterator         = typename original::const_iterator;
-    using reverse_iterator       = typename original::reverse_iterator;
+    using value_type = typename original::value_type;
+    using allocator_type = typename original::allocator_type;
+    using size_type = typename original::size_type;
+    using difference_type = typename original::difference_type;
+    using reference = typename original::reference;
+    using const_reference = typename original::const_reference;
+    using pointer = typename original::pointer;
+    using const_pointer = typename original::const_pointer;
+    using iterator = typename original::iterator;
+    using const_iterator = typename original::const_iterator;
+    using reverse_iterator = typename original::reverse_iterator;
     using const_reverse_iterator = typename original::const_reverse_iterator;
 
 private:
@@ -50,11 +50,12 @@ public:
 #ifdef DUCKDB_CLANG_TIDY
 	[[clang::reinitializes]]
 #endif
-	inline void clear() noexcept { // NOLINT: hiding on purpose
+	inline void
+    clear() noexcept { // NOLINT: hiding on purpose
 		original::clear();
 	}
 
-    // Because we create the other constructor, the implicitly created constructor
+	// Because we create the other constructor, the implicitly created constructor
 	// gets deleted, so we have to be explicit
 	deque() = default;
 	deque(original &&other) : original(std::move(other)) { // NOLINT: allow implicit conversion

--- a/src/include/duckdb/common/deque.hpp
+++ b/src/include/duckdb/common/deque.hpp
@@ -8,8 +8,125 @@
 
 #pragma once
 
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/likely.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/memory_safety.hpp"
 #include <deque>
 
 namespace duckdb {
-using std::deque;
-}
+
+template <class DATA_TYPE, bool SAFE = true>
+class deque : public std::deque<DATA_TYPE, std::allocator<DATA_TYPE>> { // NOLINT: matching name of std
+public:
+	using original = std::deque<DATA_TYPE, std::allocator<DATA_TYPE>>;
+    using original::original;
+    using value_type             = typename original::value_type;
+    using allocator_type         = typename original::allocator_type;
+    using size_type              = typename original::size_type;
+    using difference_type        = typename original::difference_type;
+    using reference              = typename original::reference;
+    using const_reference        = typename original::const_reference;
+    using pointer                = typename original::pointer;
+    using const_pointer          = typename original::const_pointer;
+    using iterator               = typename original::iterator;
+    using const_iterator         = typename original::const_iterator;
+    using reverse_iterator       = typename original::reverse_iterator;
+    using const_reverse_iterator = typename original::const_reverse_iterator;
+
+private:
+	static inline void AssertIndexInBounds(idx_t index, idx_t size) {
+#if defined(DUCKDB_DEBUG_NO_SAFETY) || defined(DUCKDB_CLANG_TIDY)
+		return;
+#else
+		if (DUCKDB_UNLIKELY(index >= size)) {
+			throw InternalException("Attempted to access index %ld within deque of size %ld", index, size);
+		}
+#endif
+	}
+
+public:
+#ifdef DUCKDB_CLANG_TIDY
+	[[clang::reinitializes]]
+#endif
+	inline void clear() noexcept { // NOLINT: hiding on purpose
+		original::clear();
+	}
+
+    // Because we create the other constructor, the implicitly created constructor
+	// gets deleted, so we have to be explicit
+	deque() = default;
+	deque(original &&other) : original(std::move(other)) { // NOLINT: allow implicit conversion
+	}
+	template <bool INTERNAL_SAFE>
+	deque(deque<DATA_TYPE, INTERNAL_SAFE> &&other) : original(std::move(other)) { // NOLINT: allow implicit conversion
+	}
+
+	template <bool INTERNAL_SAFE = false>
+	inline typename original::reference get(typename original::size_type __n) { // NOLINT: hiding on purpose
+		if (MemorySafety<INTERNAL_SAFE>::ENABLED) {
+			AssertIndexInBounds(__n, original::size());
+		}
+		return original::operator[](__n);
+	}
+
+	template <bool INTERNAL_SAFE = false>
+	inline typename original::const_reference get(typename original::size_type __n) const { // NOLINT: hiding on purpose
+		if (MemorySafety<INTERNAL_SAFE>::ENABLED) {
+			AssertIndexInBounds(__n, original::size());
+		}
+		return original::operator[](__n);
+	}
+
+	typename original::reference operator[](typename original::size_type __n) { // NOLINT: hiding on purpose
+		return get<SAFE>(__n);
+	}
+	typename original::const_reference operator[](typename original::size_type __n) const { // NOLINT: hiding on purpose
+		return get<SAFE>(__n);
+	}
+
+	typename original::reference front() { // NOLINT: hiding on purpose
+		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
+			throw InternalException("'front' called on an empty deque!");
+		}
+		return get<SAFE>(0);
+	}
+
+	typename original::const_reference front() const { // NOLINT: hiding on purpose
+		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
+			throw InternalException("'front' called on an empty deque!");
+		}
+		return get<SAFE>(0);
+	}
+
+	typename original::reference back() { // NOLINT: hiding on purpose
+		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
+			throw InternalException("'back' called on an empty deque!");
+		}
+		return get<SAFE>(original::size() - 1);
+	}
+
+	typename original::const_reference back() const { // NOLINT: hiding on purpose
+		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
+			throw InternalException("'back' called on an empty deque!");
+		}
+		return get<SAFE>(original::size() - 1);
+	}
+
+	void unsafe_erase_at(idx_t idx) { // NOLINT: not using camelcase on purpose here
+		original::erase(original::begin() + static_cast<typename original::iterator::difference_type>(idx));
+	}
+
+	void erase_at(idx_t idx) { // NOLINT: not using camelcase on purpose here
+		if (MemorySafety<SAFE>::ENABLED && idx >= original::size()) {
+			throw InternalException("Can't remove offset %d from deque of size %d", idx, original::size());
+		}
+		unsafe_erase_at(idx);
+	}
+};
+
+template <typename T>
+using unsafe_deque = deque<T, false>;
+
+} // namespace duckdb

--- a/src/include/duckdb/common/deque.hpp
+++ b/src/include/duckdb/common/deque.hpp
@@ -114,17 +114,6 @@ public:
 		}
 		return get<SAFE>(original::size() - 1);
 	}
-
-	void unsafe_erase_at(idx_t idx) { // NOLINT: not using camelcase on purpose here
-		original::erase(original::begin() + static_cast<typename original::iterator::difference_type>(idx));
-	}
-
-	void erase_at(idx_t idx) { // NOLINT: not using camelcase on purpose here
-		if (MemorySafety<SAFE>::ENABLED && idx >= original::size()) {
-			throw InternalException("Can't remove offset %d from deque of size %d", idx, original::size());
-		}
-		unsafe_erase_at(idx);
-	}
 };
 
 template <typename T>

--- a/src/include/duckdb/common/queue.hpp
+++ b/src/include/duckdb/common/queue.hpp
@@ -25,16 +25,8 @@ public:
     using container_type         = typename original::container_type;
     using value_type             = typename original::value_type;
     using size_type              = typename container_type::size_type;
-    using difference_type        = typename container_type::difference_type;
     using reference              = typename container_type::reference;
     using const_reference        = typename container_type::const_reference;
-    using pointer                = typename container_type::pointer;
-    using const_pointer          = typename container_type::const_pointer;
-    using allocator_type         = typename container_type::allocator_type;
-    using iterator               = typename container_type::iterator;
-    using const_iterator         = typename container_type::const_iterator;
-    using reverse_iterator       = typename container_type::reverse_iterator;
-    using const_reverse_iterator = typename container_type::const_reverse_iterator;
 
 public:
     // Because we create the other constructor, the implicitly created constructor

--- a/src/include/duckdb/common/queue.hpp
+++ b/src/include/duckdb/common/queue.hpp
@@ -21,12 +21,12 @@ template <class DATA_TYPE, class CONTAINER = std::deque<DATA_TYPE>, bool SAFE = 
 class queue : public std::queue<DATA_TYPE, CONTAINER> { // NOLINT: matching name of std
 public:
 	using original = std::queue<DATA_TYPE, CONTAINER>;
-    using original::original;
-    using container_type = typename original::container_type;
-    using value_type = typename original::value_type;
-    using size_type = typename container_type::size_type;
-    using reference = typename container_type::reference;
-    using const_reference = typename container_type::const_reference;
+	using original::original;
+	using container_type = typename original::container_type;
+	using value_type = typename original::value_type;
+	using size_type = typename container_type::size_type;
+	using reference = typename container_type::reference;
+	using const_reference = typename container_type::const_reference;
 
 public:
 	// Because we create the other constructor, the implicitly created constructor

--- a/src/include/duckdb/common/queue.hpp
+++ b/src/include/duckdb/common/queue.hpp
@@ -8,8 +8,85 @@
 
 #pragma once
 
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/likely.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/memory_safety.hpp"
 #include <queue>
 
 namespace duckdb {
-using std::queue;
+
+template <class DATA_TYPE, class CONTAINER = std::deque<DATA_TYPE>, bool SAFE = true>
+class queue : public std::queue<DATA_TYPE, CONTAINER> { // NOLINT: matching name of std
+public:
+	using original = std::queue<DATA_TYPE, CONTAINER>;
+    using original::original;
+    using container_type         = typename original::container_type;
+    using value_type             = typename original::value_type;
+    using size_type              = typename container_type::size_type;
+    using difference_type        = typename container_type::difference_type;
+    using reference              = typename container_type::reference;
+    using const_reference        = typename container_type::const_reference;
+    using pointer                = typename container_type::pointer;
+    using const_pointer          = typename container_type::const_pointer;
+    using allocator_type         = typename container_type::allocator_type;
+    using iterator               = typename container_type::iterator;
+    using const_iterator         = typename container_type::const_iterator;
+    using reverse_iterator       = typename container_type::reverse_iterator;
+    using const_reverse_iterator = typename container_type::const_reverse_iterator;
+
+public:
+    // Because we create the other constructor, the implicitly created constructor
+	// gets deleted, so we have to be explicit
+	queue() = default;
+	queue(original &&other) : original(std::move(other)) { // NOLINT: allow implicit conversion
+	}
+	template <bool INTERNAL_SAFE>
+	queue(queue<DATA_TYPE, CONTAINER, INTERNAL_SAFE> &&other) : original(std::move(other)) { // NOLINT
+	}
+
+	inline void clear() noexcept {
+		original::c.clear();
+	}
+
+	reference front() {
+		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
+			throw InternalException("'front' called on an empty queue!");
+		}
+		return original::front();
+	}
+
+	const_reference front() const {
+		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
+			throw InternalException("'front' called on an empty queue!");
+		}
+		return original::front();
+	}
+
+	reference back() {
+		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
+			throw InternalException("'back' called on an empty queue!");
+		}
+		return original::back();
+	}
+
+	const_reference back() const {
+		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
+			throw InternalException("'back' called on an empty queue!");
+		}
+		return original::back();
+	}
+
+	void pop() {
+		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
+			throw InternalException("'pop' called on an empty queue!");
+		}
+		original::pop();
+	}
+};
+
+template <typename T, typename Container = std::deque<T>>
+using unsafe_queue = queue<T, Container, false>;
+
 } // namespace duckdb

--- a/src/include/duckdb/common/queue.hpp
+++ b/src/include/duckdb/common/queue.hpp
@@ -22,14 +22,14 @@ class queue : public std::queue<DATA_TYPE, CONTAINER> { // NOLINT: matching name
 public:
 	using original = std::queue<DATA_TYPE, CONTAINER>;
     using original::original;
-    using container_type         = typename original::container_type;
-    using value_type             = typename original::value_type;
-    using size_type              = typename container_type::size_type;
-    using reference              = typename container_type::reference;
-    using const_reference        = typename container_type::const_reference;
+    using container_type = typename original::container_type;
+    using value_type = typename original::value_type;
+    using size_type = typename container_type::size_type;
+    using reference = typename container_type::reference;
+    using const_reference = typename container_type::const_reference;
 
 public:
-    // Because we create the other constructor, the implicitly created constructor
+	// Because we create the other constructor, the implicitly created constructor
 	// gets deleted, so we have to be explicit
 	queue() = default;
 	queue(original &&other) : original(std::move(other)) { // NOLINT: allow implicit conversion

--- a/src/include/duckdb/common/vector.hpp
+++ b/src/include/duckdb/common/vector.hpp
@@ -22,17 +22,17 @@ class vector : public std::vector<DATA_TYPE, std::allocator<DATA_TYPE>> { // NOL
 public:
 	using original = std::vector<DATA_TYPE, std::allocator<DATA_TYPE>>;
 	using original::original;
-	using value_type             = typename original::value_type;
-	using allocator_type         = typename original::allocator_type;
-	using size_type              = typename original::size_type;
-	using difference_type        = typename original::difference_type;
-	using reference              = typename original::reference;
-	using const_reference        = typename original::const_reference;
-	using pointer                = typename original::pointer;
-	using const_pointer          = typename original::const_pointer;
-	using iterator               = typename original::iterator;
-	using const_iterator         = typename original::const_iterator;
-	using reverse_iterator       = typename original::reverse_iterator;
+	using value_type = typename original::value_type;
+	using allocator_type = typename original::allocator_type;
+	using size_type = typename original::size_type;
+	using difference_type = typename original::difference_type;
+	using reference = typename original::reference;
+	using const_reference = typename original::const_reference;
+	using pointer = typename original::pointer;
+	using const_pointer = typename original::const_pointer;
+	using iterator = typename original::iterator;
+	using const_iterator = typename original::const_iterator;
+	using reverse_iterator = typename original::reverse_iterator;
 	using const_reverse_iterator = typename original::const_reverse_iterator;
 
 private:

--- a/src/include/duckdb/common/vector.hpp
+++ b/src/include/duckdb/common/vector.hpp
@@ -22,9 +22,18 @@ class vector : public std::vector<DATA_TYPE, std::allocator<DATA_TYPE>> { // NOL
 public:
 	using original = std::vector<DATA_TYPE, std::allocator<DATA_TYPE>>;
 	using original::original;
-	using size_type = typename original::size_type;
-	using const_reference = typename original::const_reference;
-	using reference = typename original::reference;
+	using value_type             = typename original::value_type;
+	using allocator_type         = typename original::allocator_type;
+	using size_type              = typename original::size_type;
+	using difference_type        = typename original::difference_type;
+	using reference              = typename original::reference;
+	using const_reference        = typename original::const_reference;
+	using pointer                = typename original::pointer;
+	using const_pointer          = typename original::const_pointer;
+	using iterator               = typename original::iterator;
+	using const_iterator         = typename original::const_iterator;
+	using reverse_iterator       = typename original::reverse_iterator;
+	using const_reverse_iterator = typename original::const_reverse_iterator;
 
 private:
 	static inline void AssertIndexInBounds(idx_t index, idx_t size) {


### PR DESCRIPTION
Last week I wrote a bug in my extension to pop elements out of an empty queue, which leads to a segfault; what caught my eye is (1) getting the front item works with no error; (2) accessing the element leads to segfault.

After checking the [doc](https://en.cppreference.com/w/cpp/container/queue/front.html), I found it's an undefined behavior.
So in this PR, I would like to extend duckdb's safe container implementation to surface error ASAP.

This PR contains two parts:
- Add safe implementation for deque and queue, which mimic `duckdb::vector`'s code
- Add "missing" member types as specified in the docs