### PR TITLE
fix: make `GetCachedHashes` thread safe

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1929,7 +1929,10 @@ void Vector::DebugShuffleNestedVector(Vector &vector, idx_t count) {
 const Vector &DictionaryVector::GetCachedHashes(Vector &input) {
 	D_ASSERT(CanCacheHashes(input));
 	auto &dictionary = Child(input);
+
+	lock_guard<mutex> lock(dictionary.cached_hashes_mutex);
 	auto &dictionary_hashes = dictionary.cached_hashes->Cast<VectorChildBuffer>().data;
+
 	if (!dictionary_hashes.data) {
 		// Uninitialized: hash the dictionary
 		const auto dictionary_count = DictionarySize(input).GetIndex();

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/bitset.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/vector_type.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/selection_vector.hpp"
 #include "duckdb/common/types/validity_mask.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -309,6 +310,9 @@ protected:
 	//! The buffer holding precomputed hashes of the data in the vector
 	//! used for caching hashes of string dictionaries
 	buffer_ptr<VectorBuffer> cached_hashes;
+	//! Use a mutex to make the cached hashes getter thread-safe. This is necessary as the hashes are computed lazily.
+	//! In general, read-only operations on Vector should be thread-safe after the Vector is initialized.
+	mutable mutex cached_hashes_mutex;
 };
 
 //! The DictionaryBuffer holds a selection vector


### PR DESCRIPTION
Addresses: https://github.com/duckdb/duckdb/issues/19157#issuecomment-3351504591

Verified by running TPC-H with thread sanitizer (compiling DuckDB with `THREADSAN=1`).