### PR TITLE
bump duckdb-azure ref for 1.4.1

### DIFF
--- a/.github/config/extensions/azure.cmake
+++ b/.github/config/extensions/azure.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(azure
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-azure
-            GIT_TAG 5e458fcc466d2bc421922b11f4316564e3017800
+            GIT_TAG 0709c0fa1cf67a668b58b1f06ff3e5fc1696e10a
             )
 endif()


### PR DESCRIPTION
addresses the mismatch between Azure's 1.4.0 tag and the docs, see also duckdb/duckdb-azure#123