### PR TITLE
feat: add dynamic prompts and ASCII escape code capability

### DIFF
--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT WIN32)
   include_directories(linenoise/include)
 endif()
 set(SHELL_SOURCES ${SHELL_SOURCES} shell.cpp shell_renderer.cpp
-                  shell_highlight.cpp)
+                  shell_highlight.cpp shell_prompt_parser.cpp)
 
 option(STATIC_LIBCPP "Statically link CLI to libc++" FALSE)
 

--- a/tools/shell/include/shell_prompt_parser.hpp
+++ b/tools/shell/include/shell_prompt_parser.hpp
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// shell_prompt_parser.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include "shell_state.hpp"
+namespace duckdb_shell {
+string get_prompt(const string &prompt, ShellState &state);
+}

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -210,6 +210,7 @@ public:
 	bool ProcessDuckDBRC(const char *file);
 	bool ProcessFile(const string &file, bool is_duckdb_rc = false);
 	int ProcessInput(InputMode mode);
+	string ExecutePromptSQL(const string &sql);
 };
 
 } // namespace duckdb_shell

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -190,12 +190,46 @@ int Linenoise::CompleteLine(EscapeSequence &current_sequence) {
 }
 
 size_t Linenoise::ComputeRenderWidth(const char *buf, size_t len) {
-	// utf8 in prompt, get render width
-	size_t cpos = 0;
-	size_t render_width = 0;
-	int sz;
+	size_t cpos = 0;         // byte position in buffer
+	size_t render_width = 0; // width of the current line
+	int sz;                  // for UTF-8 codepoint length
+
 	while (cpos < len) {
-		if (duckdb::Utf8Proc::UTF8ToCodepoint(buf + cpos, sz) < 0) {
+		// --- 1. Handle newline ---
+		if (buf[cpos] == '\n') {
+			render_width = 0; // reset width for new line
+			cpos++;
+			continue;
+		}
+
+		// --- 2. Handle tab (optional, usually 8-space tab stops) ---
+		if (buf[cpos] == '\t') {
+			render_width += 8 - (render_width % 8);
+			cpos++;
+			continue;
+		}
+
+		// --- 3. Handle ANSI escape sequences ---
+		if (buf[cpos] == '\033') {
+			cpos++;
+			if (cpos < len && buf[cpos] == '[') { // CSI sequence
+				cpos++;
+				while (cpos < len && !(buf[cpos] >= '@' && buf[cpos] <= '~')) {
+					cpos++;
+				}
+				if (cpos < len)
+					cpos++; // skip final letter
+			} else {
+				// standalone ESC
+				cpos++;
+			}
+			continue; // width does not increase
+		}
+
+		// --- 4. Handle UTF-8 grapheme clusters ---
+		int codepoint = duckdb::Utf8Proc::UTF8ToCodepoint(buf + cpos, sz);
+		if (codepoint < 0) {
+			// invalid byte, treat as width 1
 			cpos++;
 			render_width++;
 			continue;

--- a/tools/shell/shell_prompt_parser.cpp
+++ b/tools/shell/shell_prompt_parser.cpp
@@ -1,0 +1,132 @@
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <functional>
+#include <sstream>
+#include <iomanip>
+#include <cctype>
+#include <cstdlib>
+
+#include "shell_state.hpp"
+#include "shell_prompt_parser.hpp"
+using namespace duckdb_shell;
+
+// ----------------------------
+// Helper: convert escape sequences to actual characters
+// Supports: \033, \x1b, \n, \t, \uXXXX
+// ----------------------------
+static std::string parse_escapes(const std::string &s) {
+	std::string out;
+	size_t i = 0;
+	while (i < s.size()) {
+		if (s[i] == '\\' && i + 1 < s.size()) {
+			char c = s[i + 1];
+			if (c == '0' && s.substr(i + 1, 3) == "033") {
+				out += '\033';
+				i += 4;
+			} else if (c == 'x' && i + 3 < s.size()) {
+				std::string hex = s.substr(i + 2, 2);
+				out += static_cast<char>(std::stoi(hex, nullptr, 16));
+				i += 4;
+			} else if (c == 'e') {
+				out += '\033';
+				i += 2;
+			} else if (c == 'n') {
+				out += '\n';
+				i += 2;
+			} else if (c == 't') {
+				out += '\t';
+				i += 2;
+			} else if (c == 'u' && i + 5 < s.size()) {
+				std::string hex = s.substr(i + 2, 4);
+				int codepoint = std::stoi(hex, nullptr, 16);
+				// UTF-8 encoding
+				if (codepoint <= 0x7F) {
+					out += static_cast<char>(codepoint);
+				} else if (codepoint <= 0x7FF) {
+					out += static_cast<char>(0xC0 | ((codepoint >> 6) & 0x1F));
+					out += static_cast<char>(0x80 | (codepoint & 0x3F));
+				} else {
+					out += static_cast<char>(0xE0 | ((codepoint >> 12) & 0x0F));
+					out += static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F));
+					out += static_cast<char>(0x80 | (codepoint & 0x3F));
+				}
+				i += 6;
+			} else if (c == '\\') {
+				out += '\\';
+				i += 2;
+			} else {
+				// Unknown escape, copy literally
+				out += c;
+				i += 2;
+			}
+		} else {
+			out += s[i++];
+		}
+	}
+	return out;
+}
+
+// ----------------------------
+// Wrap ANSI sequences for Readline
+// ----------------------------
+static std::string rl_wrap_ansi(const std::string &s) {
+	return "\001" + s + "\002";
+}
+
+static std::string expand_tokens(const std::string &fmt, ShellState &state) {
+	std::string result;
+	size_t i = 0;
+	while (i < fmt.size()) {
+		if (fmt[i] == '{') {
+			size_t end = fmt.find('}', i);
+			if (end != std::string::npos) {
+				std::string statement = fmt.substr(i + 1, end - i - 1);
+				result += state.ExecutePromptSQL(statement);
+				i = end + 1;
+			} else {
+				result += fmt[i++];
+			}
+		} else {
+			result += fmt[i++];
+		}
+	}
+	return result;
+}
+
+// ----------------------------
+// Wrap ANSI sequences automatically in the string for readline
+// Finds sequences starting with ESC (\033) and ending with 'm'
+// ----------------------------
+static std::string wrap_all_ansi_for_readline(const std::string &s) {
+	std::string out;
+	size_t i = 0;
+	while (i < s.size()) {
+		if (s[i] == '\033') {
+			size_t start = i;
+			while (i < s.size() && s[i] != 'm')
+				++i;
+			if (i < s.size())
+				++i; // include 'm'
+			out += rl_wrap_ansi(s.substr(start, i - start));
+		} else {
+			out += s[i++];
+		}
+	}
+	return out;
+}
+
+namespace duckdb_shell {
+
+string get_prompt(const string &prompt, ShellState &state) {
+	std::string parsed = parse_escapes(prompt);
+
+	std::string expanded = expand_tokens(parsed, state);
+
+#if HAVE_EDITLINE || !HAVE_LINENOISE
+	return wrap_all_ansi_for_readline(expanded);
+#else
+	return expanded;
+#endif
+}
+} // namespace duckdb_shell


### PR DESCRIPTION
Hi DuckDB Friends,

I was traveling across the Atlantic and had enough time and mental energy to create PR that adds support for the shell/CLI to have what I call "dynamic" prompts.

Here is a demo video that shows how the prompt can display the current search path which is changed when users issue `USE` statements.

https://github.com/user-attachments/assets/28d5d6c8-98e4-41cc-9177-5fec9e0a0725

This is very helpful when you have multiple attached databases.

As a simpler example if you wanted to have the current time shown on your prompt you could to that by issuing this command

```sql
.prompt "D {SELECT current_time} >"
```

You'll get a prompt with the current time displayed.   Prompts now can execute any SQL statement that returns a single row with a `VARCHAR` column that is contained between `{` and `}`.  This could probably be made more robust.

While I was working on the dynamic prompt support, I've increased the allowed length of a prompt from 20 to 1024 bytes (to accommodate longer SQL statements). 

I've also added support for ASCII escape codes to be present in the prompt so that users can make their prompts colorful.  This required a small change to `linenoise` to skip over non-displayed ASCII escape sequences.

Please let me know your ideas about this.

Best wishes,

Rusty