### PR TITLE
Fix regex optimization to remove flags when converting to contains

### DIFF
--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -184,6 +184,13 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 		if (!escaped_like_string.exists) {
 			return nullptr;
 		}
+
+		// if regexp had options, remove them so the new Contains Expression can be matched for other optimizers.
+		if (root.children.size() == 3) {
+			root.children.pop_back();
+			D_ASSERT(root.children.size() == 2);
+		}
+
 		auto parameter = make_uniq<BoundConstantExpression>(Value(std::move(escaped_like_string.like_string)));
 		auto contains = make_uniq<BoundFunctionExpression>(root.return_type, GetStringContains(),
 		                                                   std::move(root.children), nullptr);

--- a/test/optimizer/regex_optimizer.test
+++ b/test/optimizer/regex_optimizer.test
@@ -228,3 +228,28 @@ statement error
 select count(s) from test where regexp_matches('aaa');
 ----
 Binder Error
+
+# Test regexp_matches with flags (like 'm') is properly optimized to contains
+statement ok
+DELETE FROM test;
+
+statement ok
+INSERT INTO test VALUES ('hello world'), ('test'), ('hello again');
+
+query II
+explain analyze SELECT s FROM test WHERE regexp_matches(s, 'hello', 'm');
+----
+analyzed_plan	<REGEX>:.*contains\(s, 'hello'\).*
+
+query I nosort
+SELECT s FROM test WHERE regexp_matches(s, 'hello', 'm');
+----
+hello world
+hello again
+
+# This used to trigger a debug assertion
+query I
+WITH fetch_schema AS (
+  SELECT s FROM test WHERE regexp_matches(s, 'hello', 'm')
+) SELECT * FROM fetch_schema LIMIT 0;
+----


### PR DESCRIPTION
When `regexp_matches` with flags such as 'm' is optimized to `contains`, the flags argument must be removed since `contains` only accepts 2 arguments.

Without this fix, the optimizer would create an invalid `contains` expression with 3 arguments, causing assertion failures in later optimization passes (debug only).

Fixes https://github.com/duckdb/duckdb-rs/issues/599