### PR TITLE
Binder clean-up

### DIFF
--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -184,8 +184,6 @@ private:
 	vector<unique_ptr<Binding>> bindings_list;
 	//! The set of columns used in USING join conditions
 	case_insensitive_map_t<reference_set_t<UsingColumnSet>> using_columns;
-	//! Using column sets
-	vector<unique_ptr<UsingColumnSet>> using_column_sets;
 
 	//! The set of CTE bindings
 	case_insensitive_map_t<shared_ptr<Binding>> cte_bindings;

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -172,8 +172,7 @@ private:
 	vector<unique_ptr<Binding>> bindings_list;
 	//! The set of columns used in USING join conditions
 	case_insensitive_map_t<reference_set_t<UsingColumnSet>> using_columns;
-
 	//! The set of CTE bindings
-	case_insensitive_map_t<shared_ptr<Binding>> cte_bindings;
+	case_insensitive_map_t<unique_ptr<Binding>> cte_bindings;
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -122,8 +122,6 @@ public:
 	void AddCTEBinding(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types,
 	                   bool using_key = false);
 
-	void RemoveCTEBinding(const string &alias);
-
 	//! Add an implicit join condition (e.g. USING (x))
 	void AddUsingBinding(const string &column_name, UsingColumnSet &set);
 

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -146,13 +146,6 @@ public:
 	string GetActualColumnName(const BindingAlias &binding_alias, const string &column_name);
 	string GetActualColumnName(Binding &binding, const string &column_name);
 
-	case_insensitive_map_t<shared_ptr<Binding>> GetCTEBindings() {
-		return cte_bindings;
-	}
-	void SetCTEBindings(case_insensitive_map_t<shared_ptr<Binding>> bindings) {
-		cte_bindings = std::move(bindings);
-	}
-
 	//! Alias a set of column names for the specified table, using the original names if there are not enough aliases
 	//! specified.
 	static vector<string> AliasColumnNames(const string &table_name, const vector<string> &names,

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -43,9 +43,6 @@ class BindContext {
 public:
 	explicit BindContext(Binder &binder);
 
-	//! Keep track of recursive CTE references
-	case_insensitive_map_t<shared_ptr<idx_t>> cte_references;
-
 public:
 	//! Given a column name, find the matching table it belongs to. Throws an
 	//! exception if no table has a column of the given name.

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -501,8 +501,6 @@ private:
 	BindingAlias RetrieveUsingBinding(Binder &current_binder, optional_ptr<UsingColumnSet> current_set,
 	                                  const string &column_name, const string &join_side);
 
-	void AddCTEMap(CommonTableExpressionMap &cte_map);
-
 	void ExpandStarExpressions(vector<unique_ptr<ParsedExpression>> &select_list,
 	                           vector<unique_ptr<ParsedExpression>> &new_select_list);
 	void ExpandStarExpression(unique_ptr<ParsedExpression> expr, vector<unique_ptr<ParsedExpression>> &new_select_list);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -265,7 +265,7 @@ public:
 	//! Add a common table expression to the binder
 	void AddCTE(const string &name);
 	//! Find all candidate common table expression by name; returns empty vector if none exists
-	vector<reference<Binding>> FindCTE(const string &name, bool skip = false);
+	optional_ptr<Binding> GetCTEBinding(const string &name);
 
 	bool CTEExists(const string &name);
 

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -331,6 +331,8 @@ public:
 private:
 	//! The parent binder (if any)
 	shared_ptr<Binder> parent;
+	//! What kind of node we are binding using this binder
+	BinderType binder_type = BinderType::REGULAR_BINDER;
 	//! Global binder state
 	shared_ptr<GlobalBinderState> global_binder_state;
 	//! Query binder state
@@ -339,8 +341,6 @@ private:
 	bool has_unplanned_dependent_joins = false;
 	//! Whether or not outside dependent joins have been planned and flattened
 	bool is_outside_flattened = true;
-	//! What kind of node we are binding using this binder
-	BinderType binder_type = BinderType::REGULAR_BINDER;
 	//! Whether or not the binder can contain NULLs as the root of expressions
 	bool can_contain_nulls = false;
 	//! The set of bound views

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -303,9 +303,6 @@ public:
 	void AddReplacementScan(const string &table_name, unique_ptr<TableRef> replacement);
 	const unordered_set<string> &GetTableNames();
 	case_insensitive_map_t<unique_ptr<TableRef>> &GetReplacementScans();
-	optional_ptr<SQLStatement> GetRootStatement() {
-		return root_statement;
-	}
 	CatalogEntryRetriever &EntryRetriever() {
 		return entry_retriever;
 	}
@@ -337,8 +334,6 @@ private:
 	BinderType binder_type = BinderType::REGULAR_BINDER;
 	//! Whether or not the binder can contain NULLs as the root of expressions
 	bool can_contain_nulls = false;
-	//! The root statement of the query that is currently being parsed
-	optional_ptr<SQLStatement> root_statement;
 	//! The set of bound views
 	reference_set_t<ViewCatalogEntry> bound_views;
 	//! Used to retrieve CatalogEntry's

--- a/src/include/duckdb/planner/table_binding.hpp
+++ b/src/include/duckdb/planner/table_binding.hpp
@@ -30,7 +30,7 @@ class BoundTableFunction;
 class StandardEntry;
 struct ColumnBinding;
 
-enum class BindingType { BASE, TABLE, DUMMY, CATALOG_ENTRY };
+enum class BindingType { BASE, TABLE, DUMMY, CATALOG_ENTRY, CTE };
 
 //! A Binding represents a binding to a table, table-producing function or subquery with a specified table index.
 struct Binding {
@@ -147,6 +147,16 @@ public:
 
 	//! Returns a copy of the col_ref parameter as a parsed expression
 	unique_ptr<ParsedExpression> ParamToArg(ColumnRefExpression &col_ref);
+};
+
+struct CTEBinding : public Binding {
+public:
+	static constexpr const BindingType TYPE = BindingType::CTE;
+
+public:
+	CTEBinding(BindingAlias alias, vector<LogicalType> types, vector<string> names, idx_t index);
+
+	idx_t reference_count;
 };
 
 } // namespace duckdb

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -710,7 +710,7 @@ void BindContext::AddGenericBinding(idx_t index, const string &alias, const vect
 
 void BindContext::AddCTEBinding(idx_t index, const string &alias, const vector<string> &names,
                                 const vector<LogicalType> &types, bool using_key) {
-	auto binding = make_shared_ptr<CTEBinding>(BindingAlias(alias), types, names, index);
+	auto binding = make_uniq<CTEBinding>(BindingAlias(alias), types, names, index);
 
 	if (cte_bindings.find(alias) != cte_bindings.end()) {
 		throw BinderException("Duplicate CTE binding \"%s\" in query!", alias);
@@ -719,7 +719,7 @@ void BindContext::AddCTEBinding(idx_t index, const string &alias, const vector<s
 
 	if (using_key) {
 		auto recurring_alias = "recurring." + alias;
-		cte_bindings[recurring_alias] = make_shared_ptr<CTEBinding>(BindingAlias(recurring_alias), types, names, index);
+		cte_bindings[recurring_alias] = make_uniq<CTEBinding>(BindingAlias(recurring_alias), types, names, index);
 	}
 }
 

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -726,17 +726,6 @@ void BindContext::AddCTEBinding(idx_t index, const string &alias, const vector<s
 	}
 }
 
-void BindContext::RemoveCTEBinding(const std::string &alias) {
-	auto it = cte_bindings.find(alias);
-	if (it != cte_bindings.end()) {
-		cte_bindings.erase(it);
-	}
-	auto it2 = cte_references.find(alias);
-	if (it2 != cte_references.end()) {
-		cte_references.erase(it2);
-	}
-}
-
 void BindContext::AddContext(BindContext other) {
 	for (auto &binding : other.bindings_list) {
 		AddBinding(std::move(binding));

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -77,10 +77,6 @@ void BindContext::AddUsingBinding(const string &column_name, UsingColumnSet &set
 	using_columns[column_name].insert(set);
 }
 
-void BindContext::AddUsingBindingSet(unique_ptr<UsingColumnSet> set) {
-	using_column_sets.push_back(std::move(set));
-}
-
 optional_ptr<UsingColumnSet> BindContext::GetUsingBinding(const string &column_name) {
 	auto entry = using_columns.find(column_name);
 	if (entry == using_columns.end()) {

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -710,19 +710,16 @@ void BindContext::AddGenericBinding(idx_t index, const string &alias, const vect
 
 void BindContext::AddCTEBinding(idx_t index, const string &alias, const vector<string> &names,
                                 const vector<LogicalType> &types, bool using_key) {
-	auto binding = make_shared_ptr<Binding>(BindingType::BASE, BindingAlias(alias), types, names, index);
+	auto binding = make_shared_ptr<CTEBinding>(BindingAlias(alias), types, names, index);
 
 	if (cte_bindings.find(alias) != cte_bindings.end()) {
 		throw BinderException("Duplicate CTE binding \"%s\" in query!", alias);
 	}
 	cte_bindings[alias] = std::move(binding);
-	cte_references[alias] = make_shared_ptr<idx_t>(0);
 
 	if (using_key) {
 		auto recurring_alias = "recurring." + alias;
-		cte_bindings[recurring_alias] =
-		    make_shared_ptr<Binding>(BindingType::BASE, BindingAlias(recurring_alias), types, names, index);
-		cte_references[recurring_alias] = make_shared_ptr<idx_t>(0);
+		cte_bindings[recurring_alias] = make_shared_ptr<CTEBinding>(BindingAlias(recurring_alias), types, names, index);
 	}
 }
 

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -74,7 +74,7 @@ BoundStatement Binder::BindWithCTE(T &statement) {
 		auto &cte_entry = cte.second;
 		auto mat_cte = make_uniq<CTENode>();
 		mat_cte->ctename = cte.first;
-		mat_cte->query = cte_entry->query->node->Copy();
+		mat_cte->query = std::move(cte_entry->query->node);
 		mat_cte->aliases = cte_entry->aliases;
 		mat_cte->materialized = cte_entry->materialized;
 		materialized_ctes.push_back(std::move(mat_cte));
@@ -84,7 +84,6 @@ BoundStatement Binder::BindWithCTE(T &statement) {
 	while (!materialized_ctes.empty()) {
 		unique_ptr<CTENode> node_result;
 		node_result = std::move(materialized_ctes.back());
-		node_result->cte_map = cte_map.Copy();
 		node_result->child = std::move(cte_root);
 		cte_root = std::move(node_result);
 		materialized_ctes.pop_back();

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -96,7 +96,6 @@ BoundStatement Binder::BindWithCTE(T &statement) {
 		materialized_ctes.pop_back();
 	}
 
-	AddCTEMap(cte_map);
 	return Bind(*cte_root);
 }
 
@@ -160,15 +159,7 @@ BoundStatement Binder::Bind(SQLStatement &statement) {
 	} // LCOV_EXCL_STOP
 }
 
-void Binder::AddCTEMap(CommonTableExpressionMap &cte_map) {
-	for (auto &cte_it : cte_map.map) {
-		AddCTE(cte_it.first);
-	}
-}
-
 BoundStatement Binder::BindNode(QueryNode &node) {
-	// first we visit the set of CTEs and add them to the bind context
-	AddCTEMap(node.cte_map);
 	// now we bind the node
 	switch (node.type) {
 	case QueryNodeType::SELECT_NODE:

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -59,10 +59,8 @@ Binder::Binder(ClientContext &context, shared_ptr<Binder> parent_p, BinderType b
 		// We have to inherit macro and lambda parameter bindings and from the parent binder, if there is a parent.
 		macro_binding = parent->macro_binding;
 		lambda_bindings = parent->lambda_bindings;
-
 		if (binder_type == BinderType::REGULAR_BINDER) {
 			// We have to inherit CTE bindings from the parent bind_context, if there is a parent.
-			bind_context.SetCTEBindings(parent->bind_context.GetCTEBindings());
 			bind_context.cte_references = parent->bind_context.cte_references;
 		}
 	}
@@ -276,17 +274,15 @@ void Binder::AddCTE(const string &name) {
 	CTE_bindings.insert(name);
 }
 
-vector<reference<Binding>> Binder::FindCTE(const string &name, bool skip) {
+optional_ptr<Binding> Binder::GetCTEBinding(const string &name) {
 	auto entry = bind_context.GetCTEBinding(name);
-	vector<reference<Binding>> ctes;
 	if (entry) {
-		ctes.push_back(*entry.get());
+		return entry;
 	}
 	if (parent && binder_type == BinderType::REGULAR_BINDER) {
-		auto parent_ctes = parent->FindCTE(name, name == alias);
-		ctes.insert(ctes.end(), parent_ctes.begin(), parent_ctes.end());
+		return parent->GetCTEBinding(name);
 	}
-	return ctes;
+	return nullptr;
 }
 
 bool Binder::CTEExists(const string &name) {

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -101,7 +101,6 @@ BoundStatement Binder::BindWithCTE(T &statement) {
 }
 
 BoundStatement Binder::Bind(SQLStatement &statement) {
-	root_statement = &statement;
 	switch (statement.type) {
 	case StatementType::SELECT_STATEMENT:
 		return Bind(statement.Cast<SelectStatement>());

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -275,14 +275,18 @@ void Binder::AddCTE(const string &name) {
 }
 
 optional_ptr<Binding> Binder::GetCTEBinding(const string &name) {
-	auto entry = bind_context.GetCTEBinding(name);
-	if (entry) {
-		return entry;
+	reference<Binder> current_binder(*this);
+	while(true) {
+		auto &current = current_binder.get();
+		auto entry = current.bind_context.GetCTEBinding(name);
+		if (entry) {
+			return entry;
+		}
+		if (!current.parent || current.binder_type != BinderType::REGULAR_BINDER) {
+			return nullptr;
+		}
+		current_binder = *current.parent;
 	}
-	if (parent && binder_type == BinderType::REGULAR_BINDER) {
-		return parent->GetCTEBinding(name);
-	}
-	return nullptr;
 }
 
 bool Binder::CTEExists(const string &name) {

--- a/src/planner/binder/expression/bind_parameter_expression.cpp
+++ b/src/planner/binder/expression/bind_parameter_expression.cpp
@@ -8,19 +8,19 @@
 namespace duckdb {
 
 BindResult ExpressionBinder::BindExpression(ParameterExpression &expr, idx_t depth) {
-	if (!binder.parameters) {
+	auto parameters = binder.GetParameters();
+	if (!parameters) {
 		throw BinderException("Unexpected prepared parameter. This type of statement can't be prepared!");
 	}
 	auto parameter_id = expr.identifier;
 
-	D_ASSERT(binder.parameters);
 	// Check if a parameter value has already been supplied
-	auto &parameter_data = binder.parameters->GetParameterData();
+	auto &parameter_data = parameters->GetParameterData();
 	auto param_data_it = parameter_data.find(parameter_id);
 	if (param_data_it != parameter_data.end()) {
 		// it has! emit a constant directly
 		auto &data = param_data_it->second;
-		auto return_type = binder.parameters->GetReturnType(parameter_id);
+		auto return_type = parameters->GetReturnType(parameter_id);
 		bool is_literal =
 		    return_type.id() == LogicalTypeId::INTEGER_LITERAL || return_type.id() == LogicalTypeId::STRING_LITERAL;
 		auto constant = make_uniq<BoundConstantExpression>(data.GetValue());
@@ -32,7 +32,7 @@ BindResult ExpressionBinder::BindExpression(ParameterExpression &expr, idx_t dep
 		return BindResult(std::move(cast));
 	}
 
-	auto bound_parameter = binder.parameters->BindParameterExpression(expr);
+	auto bound_parameter = parameters->BindParameterExpression(expr);
 	return BindResult(std::move(bound_parameter));
 }
 

--- a/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_cte_node.cpp
@@ -63,7 +63,6 @@ BoundStatement Binder::BindCTE(CTENode &statement) {
 	// If there is already a binding for the CTE, we need to remove it first
 	// as we are binding a CTE currently, we take precendence over the existing binding.
 	// This implements the CTE shadowing behavior.
-	result.child_binder->bind_context.RemoveCTEBinding(statement.ctename);
 	result.child_binder->bind_context.AddCTEBinding(result.setop_index, statement.ctename, names, result.types);
 
 	if (statement.child) {

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -40,10 +40,6 @@ BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
 	result.right_binder = Binder::CreateBinder(context, this);
 
 	// Add bindings of left side to temporary CTE bindings context
-	// If there is already a binding for the CTE, we need to remove it first
-	// as we are binding a CTE currently, we take precendence over the existing binding.
-	// This implements the CTE shadowing behavior.
-	result.right_binder->bind_context.RemoveCTEBinding(statement.ctename);
 	result.right_binder->bind_context.AddCTEBinding(result.setop_index, statement.ctename, result.names, result.types,
 	                                                !statement.key_targets.empty());
 

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -31,9 +31,6 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 		properties.RegisterDBModify(table.catalog, context);
 	}
 
-	// Add CTEs as bindable
-	AddCTEMap(stmt.cte_map);
-
 	// plan any tables from the various using clauses
 	if (!stmt.using_clauses.empty()) {
 		unique_ptr<LogicalOperator> child_operator;

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -79,7 +79,7 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 		prepared = prepared_planner.PrepareSQLStatement(entry->second->unbound_statement->Copy());
 		rebound_plan = std::move(prepared_planner.plan);
 		D_ASSERT(prepared->properties.bound_all_parameters);
-		this->bound_tables = prepared_planner.binder->bound_tables;
+		global_binder_state->bound_tables = prepared_planner.binder->global_binder_state->bound_tables;
 	}
 	// copy the properties of the prepared statement into the planner
 	auto &properties = GetStatementProperties();

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -519,8 +519,6 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	}
 
 	auto insert = make_uniq<LogicalInsert>(table, GenerateTableIndex());
-	// Add CTEs as bindable
-	AddCTEMap(stmt.cte_map);
 
 	auto values_list = stmt.GetValuesList();
 

--- a/src/planner/binder/statement/bind_logical_plan.cpp
+++ b/src/planner/binder/statement/bind_logical_plan.cpp
@@ -32,7 +32,7 @@ BoundStatement Binder::Bind(LogicalPlanStatement &stmt) {
 	if (parent) {
 		throw InternalException("LogicalPlanStatement should be bound in root binder");
 	}
-	bound_tables = GetMaxTableIndex(*result.plan) + 1;
+	global_binder_state->bound_tables = GetMaxTableIndex(*result.plan) + 1;
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_prepare.cpp
+++ b/src/planner/binder/statement/bind_prepare.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 BoundStatement Binder::Bind(PrepareStatement &stmt) {
 	Planner prepared_planner(context);
 	auto prepared_data = prepared_planner.PrepareSQLStatement(std::move(stmt.statement));
-	this->bound_tables = prepared_planner.binder->bound_tables;
+	global_binder_state->bound_tables = prepared_planner.binder->global_binder_state->bound_tables;
 
 	if (prepared_planner.properties.always_require_rebind) {
 		// we always need to rebind - don't keep the plan around

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -116,9 +116,6 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 	auto &table_binding = bound_table->Cast<BoundBaseTableRef>();
 	auto &table = table_binding.table;
 
-	// Add CTEs as bindable
-	AddCTEMap(stmt.cte_map);
-
 	optional_ptr<LogicalGet> get;
 	if (stmt.from_table) {
 		auto from_binder = Binder::CreateBinder(context, this);

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -41,7 +41,7 @@ void Planner::CreatePlan(SQLStatement &statement) {
 	bool parameters_resolved = true;
 	try {
 		profiler.StartPhase(MetricsType::PLANNER_BINDING);
-		binder->parameters = &bound_parameters;
+		binder->SetParameters(bound_parameters);
 		auto bound_statement = binder->Bind(statement);
 		profiler.EndPhase();
 

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -304,4 +304,8 @@ unique_ptr<ParsedExpression> DummyBinding::ParamToArg(ColumnRefExpression &colre
 	return arg;
 }
 
+CTEBinding::CTEBinding(BindingAlias alias, vector<LogicalType> types, vector<string> names, idx_t index)
+    : Binding(BindingType::CTE, std::move(alias), std::move(types), std::move(names), index), reference_count(0) {
+}
+
 } // namespace duckdb

--- a/test/ldbc/ldbc-empty.test
+++ b/test/ldbc/ldbc-empty.test
@@ -160,6 +160,7 @@ create table tag (
    t_tagclassid bigint not null
 );
 
+
 # run the queries
 
 #  Q1. Posting summary


### PR DESCRIPTION
* Move global binder state out of binder and into shared `GlobalBinderState`
* Move binder state that is not inherited by views into shared `QueryBinderState`
* Avoid unnecessarily copying around CTE bindings, and move CTE reference count into CTE binding
* 