### PR TITLE
test: add test for CREATE TABLE with `my_schema.my_enum[]`

### DIFF
--- a/test/sql/types/enum/test_enum_schema.test
+++ b/test/sql/types/enum/test_enum_schema.test
@@ -121,3 +121,30 @@ statement ok
 CREATE TABLE foo.baz (
 	bar_col "foo".bar NOT NULL
 );
+
+statement ok
+drop schema "foo" cascade;
+
+# Test schema-qualified enum types with arrays
+# https://github.com/duckdb/duckdb/issues/17041
+statement ok
+CREATE SCHEMA foo;
+
+statement ok
+CREATE TYPE foo.bar AS ENUM ('a', 'b', 'c');
+
+statement ok
+CREATE TABLE foo.test (
+	qualified_array foo.bar[]
+);
+
+statement ok
+INSERT INTO foo.test VALUES (['a', 'b']);
+
+query I
+SELECT * FROM foo.test;
+----
+[a, b]
+
+statement ok
+DROP SCHEMA foo CASCADE;


### PR DESCRIPTION
Adds a test for https://github.com/duckdb/duckdb/issues/17041.

This test looks like it fails on 1.4 when run on shell.duckdb.org, but currently on main it appears to pass.

I still need to try cherry-picking this test back to 1.4 in my local machine to confirm that it does fail (which would confirm that the fix happened sometime between 1.4 and main)