### PR TITLE
Use cross-compilation for static libs on OSX

### DIFF
--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -54,7 +54,7 @@ jobs:
       ENABLE_EXTENSION_AUTOLOADING: 1
       ENABLE_EXTENSION_AUTOINSTALL: 1
       GEN: ninja
-      OSX_BUILD_ARCH: ${{ matrix.architecture }}
+      OSX_BUILD_ARCH: ${{ matrix.xcode_target_flag }}
       DUCKDB_PLATFORM: osx_${{ matrix.architecture }}
 
     steps:

--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -44,16 +44,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: "macos-13"
+          - xcode_target_flag: "x86_64"
             architecture: "amd64"
-          - version: "macos-14"
+          - xcode_target_flag: "arm64"
             architecture: "arm64"
-    runs-on: ${{ matrix.version }}
+    runs-on: macos-latest
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1
       ENABLE_EXTENSION_AUTOINSTALL: 1
       GEN: ninja
+      OSX_BUILD_ARCH: ${{ matrix.architecture }}
+      DUCKDB_PLATFORM: osx_${{ matrix.architecture }}
 
     steps:
       - uses: actions/checkout@v4
@@ -83,10 +85,6 @@ jobs:
         run: |
           make gather-libs
 
-      - name: Print platform
-        shell: bash
-        run: ./build/release/duckdb -c "PRAGMA platform;"
-
       - name: Deploy
         shell: bash
         env:
@@ -102,6 +100,7 @@ jobs:
           name: duckdb-static-libs-osx-${{ matrix.architecture }}
           path: |
             static-libs-osx-${{ matrix.architecture }}.zip
+
 
   bundle-mingw-static-lib:
     name: Windows MingW static libs


### PR DESCRIPTION
this avoids relying on intel osx runners

<img width="1073" height="721" alt="Screenshot 2025-10-08 at 10 26 34" src="https://github.com/user-attachments/assets/5594a817-86b2-4233-9d3e-51eb308b4408" />
