### PR TITLE
Add async_function to TableFunction

### DIFF
--- a/.github/config/extensions/avro.cmake
+++ b/.github/config/extensions/avro.cmake
@@ -3,5 +3,6 @@ if (NOT MINGW)
             LOAD_TESTS DONT_LINK
             GIT_URL https://github.com/duckdb/duckdb-avro
             GIT_TAG 7b75062f6345d11c5342c09216a75c57342c2e82
+            APPLY_PATCHES
     )
 endif()

--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,5 +1,6 @@
 duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG f134ad86f2f6e7cdf4133086c38ecd9c48f1a772
+    GIT_TAG 45788f0a875844ac8fed048c99b87f7f4b1c2ac1
+    APPLY_PATCHES
 )

--- a/.github/patches/extensions/avro/wrapped_scan.patch
+++ b/.github/patches/extensions/avro/wrapped_scan.patch
@@ -1,0 +1,32 @@
+diff --git a/src/avro_multi_file_info.cpp b/src/avro_multi_file_info.cpp
+index d67d744..e8717dd 100644
+--- a/src/avro_multi_file_info.cpp
++++ b/src/avro_multi_file_info.cpp
+@@ -122,9 +122,10 @@ bool AvroReader::TryInitializeScan(ClientContext &context, GlobalTableFunctionSt
+ 	return true;
+ }
+ 
+-void AvroReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+-                      LocalTableFunctionState &local_state_p, DataChunk &chunk) {
++SourceResultType AvroReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
++                      LocalTableFunctionState &local_state_p, DataChunk &chunk, InterruptState &state) {
+ 	Read(chunk);
++	return chunk.size() ? SourceResultType::HAVE_MORE_OUTPUT : SourceResultType::FINISHED;
+ }
+ 
+ unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) {
+diff --git a/src/include/avro_reader.hpp b/src/include/avro_reader.hpp
+index 8d7820d..ef54ffd 100644
+--- a/src/include/avro_reader.hpp
++++ b/src/include/avro_reader.hpp
+@@ -24,8 +24,8 @@ public:
+ 
+ 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
+ 	                       LocalTableFunctionState &lstate) override;
+-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
+-	          DataChunk &chunk) override;
++	SourceResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
++	          DataChunk &chunk, InterruptState &interrupt_state) override;
+ 
+ public:
+ 	avro_file_reader_t reader;

--- a/.github/patches/extensions/ducklake/wrapped_scan.patch
+++ b/.github/patches/extensions/ducklake/wrapped_scan.patch
@@ -1,0 +1,39 @@
+diff --git a/src/include/storage/ducklake_inlined_data_reader.hpp b/src/include/storage/ducklake_inlined_data_reader.hpp
+index f0af8ec..43a3263 100644
+--- a/src/include/storage/ducklake_inlined_data_reader.hpp
++++ b/src/include/storage/ducklake_inlined_data_reader.hpp
+@@ -30,8 +30,8 @@ public:
+ public:
+ 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
+ 	                       LocalTableFunctionState &lstate) override;
+-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
+-	          DataChunk &chunk) override;
++	SourceResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
++	          DataChunk &chunk, InterruptState &interrupt_state) override;
+ 
+ 	string GetReaderType() const override;
+ 
+diff --git a/src/storage/ducklake_inlined_data_reader.cpp b/src/storage/ducklake_inlined_data_reader.cpp
+index 432ef24..3e9a0b5 100644
+--- a/src/storage/ducklake_inlined_data_reader.cpp
++++ b/src/storage/ducklake_inlined_data_reader.cpp
+@@ -154,8 +154,8 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
+ 	return true;
+ }
+ 
+-void DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+-                                     LocalTableFunctionState &local_state, DataChunk &chunk) {
++SourceResultType DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
++                                     LocalTableFunctionState &local_state, DataChunk &chunk, InterruptState &interrupt_state) {
+ 	if (!virtual_columns.empty()) {
+ 		scan_chunk.Reset();
+ 		data->data->Scan(state, scan_chunk);
+@@ -210,6 +210,8 @@ void DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunction
+ 		}
+ 	}
+ 	file_row_number += NumericCast<int64_t>(scan_count);
++
++	return chunk.size() ? SourceResultType::HAVE_MORE_OUTPUT : SourceResultType::FINISHED;
+ }
+ 
+ void DuckLakeInlinedDataReader::AddVirtualColumn(column_t virtual_column_id) {

--- a/extension/json/include/json_reader.hpp
+++ b/extension/json/include/json_reader.hpp
@@ -210,8 +210,9 @@ public:
 	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-	          DataChunk &chunk) override;
+	SourceResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                      LocalTableFunctionState &local_state, DataChunk &chunk,
+	                      InterruptState &interrupt_state) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -530,8 +530,9 @@ void ReadJSONObjectsFunction(ClientContext &context, JSONReader &json_reader, JS
 	output.SetCardinality(count);
 }
 
-void JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-                      LocalTableFunctionState &local_state, DataChunk &output) {
+SourceResultType JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                                  LocalTableFunctionState &local_state, DataChunk &output,
+                                  InterruptState &interrupt_state) {
 	auto &gstate = global_state.Cast<JSONGlobalTableFunctionState>().state;
 	auto &lstate = local_state.Cast<JSONLocalTableFunctionState>().state;
 	auto &json_data = gstate.bind_data.bind_data->Cast<JSONScanData>();
@@ -545,6 +546,7 @@ void JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &global_s
 	default:
 		throw InternalException("Unsupported scan type for JSONMultiFileInfo::Scan");
 	}
+	return output.size() ? SourceResultType::HAVE_MORE_OUTPUT : SourceResultType::FINISHED;
 }
 
 void JSONReader::FinishFile(ClientContext &context, GlobalTableFunctionState &global_state) {

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -212,7 +212,7 @@ private:
 
 	void InitializeSchema(ClientContext &context);
 	SourceResultType ScanInternal(ClientContext &context, ParquetReaderScanState &state, DataChunk &output,
-	                              InterruptState &interrupt_state, bool &keep_going);
+	                              InterruptState &interrupt_state);
 	//! Parse the schema of the file
 	unique_ptr<ParquetColumnSchema> ParseSchema(ClientContext &context);
 	ParquetColumnSchema ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat, idx_t &next_schema_idx,

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -166,14 +166,16 @@ public:
 
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-	          DataChunk &chunk) override;
+	SourceResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                      LocalTableFunctionState &local_state, DataChunk &chunk,
+	                      InterruptState &interrupt_state) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 
 public:
 	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, vector<idx_t> groups_to_read);
-	void Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
+	SourceResultType Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &output,
+	                      InterruptState &interrupt_state);
 
 	idx_t NumRows() const;
 	idx_t NumRowGroups() const;
@@ -209,7 +211,8 @@ private:
 	              shared_ptr<ParquetFileMetadataCache> metadata);
 
 	void InitializeSchema(ClientContext &context);
-	bool ScanInternal(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
+	SourceResultType ScanInternal(ClientContext &context, ParquetReaderScanState &state, DataChunk &output,
+	                              InterruptState &interrupt_state, bool &keep_going);
 	//! Parse the schema of the file
 	unique_ptr<ParquetColumnSchema> ParseSchema(ClientContext &context);
 	ParquetColumnSchema ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat, idx_t &next_schema_idx,

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -575,12 +575,13 @@ void ParquetReader::FinishFile(ClientContext &context, GlobalTableFunctionState 
 	gstate.row_group_index = 0;
 }
 
-void ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
-                         LocalTableFunctionState &local_state_p, DataChunk &chunk) {
+SourceResultType ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+                                     LocalTableFunctionState &local_state_p, DataChunk &chunk,
+                                     InterruptState &interrupt_state) {
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	local_state.scan_state.op = gstate.op;
-	Scan(context, local_state.scan_state, chunk);
+	return Scan(context, local_state.scan_state, chunk, interrupt_state);
 }
 
 unique_ptr<MultiFileReaderInterface> ParquetMultiFileInfo::Copy() {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1262,16 +1262,19 @@ SourceResultType ParquetReader::Scan(ClientContext &context, ParquetReaderScanSt
 		bool keep_going;
 		SourceResultType res = ScanInternal(context, state, result, interrupt_state, keep_going);
 
-		if (res == SourceResultType::BLOCKED)
+		if (res == SourceResultType::BLOCKED) {
 			return res;
+		}
 
-		if (result.size())
+		if (result.size()) {
 			return SourceResultType::HAVE_MORE_OUTPUT;
+		}
 
 		result.Reset();
 
-		if (keep_going == false)
+		if (keep_going == false) {
 			return SourceResultType::FINISHED;
+		}
 	}
 	return SourceResultType::FINISHED;
 }

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1256,13 +1256,24 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 	state.repeat_buf.resize(allocator, STANDARD_VECTOR_SIZE);
 }
 
-void ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
-	while (ScanInternal(context, state, result)) {
-		if (result.size() > 0) {
-			break;
-		}
+SourceResultType ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &result,
+                                     InterruptState &interrupt_state) {
+	while (true) {
+		bool keep_going;
+		SourceResultType res = ScanInternal(context, state, result, interrupt_state, keep_going);
+
+		if (res == SourceResultType::BLOCKED)
+			return res;
+
+		if (result.size())
+			return SourceResultType::HAVE_MORE_OUTPUT;
+
 		result.Reset();
+
+		if (keep_going == false)
+			return SourceResultType::FINISHED;
 	}
+	return SourceResultType::FINISHED;
 }
 
 void ParquetReader::GetPartitionStats(vector<PartitionStatistics> &result) {
@@ -1282,9 +1293,11 @@ void ParquetReader::GetPartitionStats(const duckdb_parquet::FileMetaData &metada
 	}
 }
 
-bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
+SourceResultType ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState &state, DataChunk &result,
+                                             InterruptState &interrupt_state, bool &keep_going) {
 	if (state.finished) {
-		return false;
+		keep_going = false;
+		return SourceResultType::FINISHED;
 	}
 
 	// see if we have to switch to the next row group in the parquet file
@@ -1298,7 +1311,8 @@ bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState 
 
 		if ((idx_t)state.current_group == state.group_idx_list.size()) {
 			state.finished = true;
-			return false;
+			keep_going = true;
+			return SourceResultType::HAVE_MORE_OUTPUT;
 		}
 
 		// TODO: only need this if we have a deletion vector?
@@ -1370,7 +1384,8 @@ bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState 
 				}
 			}
 		}
-		return true;
+		keep_going = true;
+		return SourceResultType::HAVE_MORE_OUTPUT;
 	}
 
 	auto scan_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, GetGroup(state).num_rows - state.offset_in_group);
@@ -1378,7 +1393,9 @@ bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState 
 
 	if (scan_count == 0) {
 		state.finished = true;
-		return false; // end of last group, we are done
+		// end of last group, we are done
+		keep_going = false;
+		return SourceResultType::HAVE_MORE_OUTPUT;
 	}
 
 	auto &deletion_filter = state.root_reader->Reader().deletion_filter;
@@ -1464,7 +1481,8 @@ bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState 
 
 	rows_read += scan_count;
 	state.offset_in_group += scan_count;
-	return true;
+	keep_going = true;
+	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
 } // namespace duckdb

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -365,13 +365,15 @@ bool CSVFileScan::TryInitializeScan(ClientContext &context, GlobalTableFunctionS
 	return true;
 }
 
-void CSVFileScan::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-                       LocalTableFunctionState &local_state, DataChunk &chunk) {
+SourceResultType CSVFileScan::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                                   LocalTableFunctionState &local_state, DataChunk &chunk,
+                                   InterruptState &interrupt_state) {
 	auto &lstate = local_state.Cast<CSVLocalState>();
 	if (lstate.csv_reader->FinishedIterator()) {
-		return;
+		return SourceResultType::FINISHED;
 	}
 	lstate.csv_reader->Flush(chunk);
+	return chunk.size() == 0 ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;
 }
 
 void CSVFileScan::FinishFile(ClientContext &context, GlobalTableFunctionState &global_state) {

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -101,9 +101,22 @@ SourceResultType PhysicalTableScan::GetData(ExecutionContext &context, DataChunk
 
 	TableFunctionInput data(bind_data.get(), l_state.local_state.get(), g_state.global_state.get());
 
-	if (function.function) {
-		function.function(context.client, data, chunk);
-		return chunk.size() == 0 ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;
+	if (function.HasSimpleScan()) {
+		auto res = function.SimpleScan(context.client, data, chunk, input.interrupt_state);
+
+		if (res == SourceResultType::BLOCKED) {
+			// TODO: this needs to be implemented
+			throw InternalException("Returning BLOCKED from wrapped_function is not supported at the moment");
+		}
+
+		auto expected_res = chunk.size() == 0 ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;
+
+		if (res != expected_res) {
+			throw NotImplementedException(
+			    "Currently this differs from the reference implementation for `async_function`");
+		}
+
+		return res;
 	}
 
 	if (g_state.in_out_final) {
@@ -262,6 +275,9 @@ bool PhysicalTableScan::Equals(const PhysicalOperator &other_p) const {
 	if (function.function != other.function.function) {
 		return false;
 	}
+	if (function.async_function != other.function.async_function) {
+		return false;
+	}
 	if (column_ids != other.column_ids) {
 		return false;
 	}
@@ -272,7 +288,7 @@ bool PhysicalTableScan::Equals(const PhysicalOperator &other_p) const {
 }
 
 bool PhysicalTableScan::ParallelSource() const {
-	if (!function.function) {
+	if (!function.HasSimpleScan()) {
 		// table in-out functions cannot be executed in parallel as part of a PhysicalTableScan
 		// since they have only a single input row
 		return false;

--- a/src/function/table/direct_file_reader.cpp
+++ b/src/function/table/direct_file_reader.cpp
@@ -44,11 +44,13 @@ static inline void VERIFY(const string &filename, const string_t &content) {
 	}
 }
 
-void DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-                            LocalTableFunctionState &local_state, DataChunk &output) {
+SourceResultType DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                                        LocalTableFunctionState &local_state, DataChunk &output,
+                                        InterruptState &interrupt_state) {
 	auto &state = global_state.Cast<ReadFileGlobalState>();
 	if (done || file_list_idx.GetIndex() >= state.file_list->GetTotalFileCount()) {
-		return;
+
+		return SourceResultType::FINISHED;
 	}
 
 	auto files = state.file_list;
@@ -163,6 +165,7 @@ void DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionState &gl
 	}
 	output.SetCardinality(1);
 	done = true;
+	return SourceResultType::HAVE_MORE_OUTPUT;
 };
 
 void DirectFileReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) {

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -14,24 +14,63 @@ PartitionStatistics::PartitionStatistics() : row_start(0), count(0), count_type(
 TableFunctionInfo::~TableFunctionInfo() {
 }
 
-TableFunction::TableFunction(string name, vector<LogicalType> arguments, table_function_t function,
+TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, table_function_t function_,
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
-    : SimpleNamedParameterFunction(std::move(name), std::move(arguments)), bind(bind), bind_replace(nullptr),
-      bind_operator(nullptr), init_global(init_global), init_local(init_local), function(function),
-      in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr), dependency(nullptr),
-      cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr), to_string(nullptr),
-      dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr), get_bind_info(nullptr),
-      type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
+    : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), async_function(nullptr),
+      function(function_), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
+      dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
+      to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
+      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
       get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
       get_row_id_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
       filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
 }
 
-TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function,
+TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, async_table_function_t function_,
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
-    : TableFunction(string(), arguments, function, bind, init_global, init_local) {
+    : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), async_function(function_),
+      function(nullptr), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
+      dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
+      to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
+      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
+      get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
+      get_row_id_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
+      filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
+}
+
+TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, std::nullptr_t function_,
+                             table_function_bind_t bind, table_function_init_global_t init_global,
+                             table_function_init_local_t init_local)
+    : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), async_function(nullptr),
+      function(nullptr), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
+      dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
+      to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
+      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
+      get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
+      get_row_id_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
+      filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
+}
+
+TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function_,
+                             table_function_bind_t bind, table_function_init_global_t init_global,
+                             table_function_init_local_t init_local)
+    : TableFunction("", arguments, function_, bind, init_global, init_local) {
+}
+
+TableFunction::TableFunction(const vector<LogicalType> &arguments, async_table_function_t function_,
+                             table_function_bind_t bind, table_function_init_global_t init_global,
+                             table_function_init_local_t init_local)
+    : TableFunction("", arguments, function_, bind, init_global, init_local) {
+}
+
+TableFunction::TableFunction(const vector<LogicalType> &arguments, std::nullptr_t function_, table_function_bind_t bind,
+                             table_function_init_global_t init_global, table_function_init_local_t init_local)
+    : TableFunction("", arguments, function_, bind, init_global, init_local) {
 }
 
 TableFunction::TableFunction() : TableFunction("", {}, nullptr, nullptr, nullptr, nullptr) {

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -79,8 +79,9 @@ public:
 	virtual bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                               LocalTableFunctionState &lstate) = 0;
 	//! Scan a chunk from the read state
-	virtual void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-	                  LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
+	virtual SourceResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                              LocalTableFunctionState &local_state, DataChunk &chunk,
+	                              InterruptState &interrupt_state) = 0;
 	//! Finish scanning a given file
 	DUCKDB_API virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate);
 	//! Get progress within a given file

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -59,8 +59,9 @@ public:
 	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-	          DataChunk &chunk) override;
+	SourceResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                      LocalTableFunctionState &local_state, DataChunk &chunk,
+	                      InterruptState &interrupt_state) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 

--- a/src/include/duckdb/function/table/direct_file_reader.hpp
+++ b/src/include/duckdb/function/table/direct_file_reader.hpp
@@ -23,8 +23,8 @@ public:
 
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-	          DataChunk &chunk) override;
+	SourceResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                      LocalTableFunctionState &local_state, DataChunk &chunk, InterruptState &state) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) override;
 
 	string GetReaderType() const override {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -364,12 +364,17 @@ public:
 	                                       ClientContext &context, TableFunctionInput &data, DataChunk &output,
 	                                       InterruptState &interrupt_state) {
 		if (function) {
+			if (async_function) {
+				throw NotImplementedException(
+				    "Only one between function and async_function are expected, but both are provided");
+			}
 			function(context, data, output);
 			return output.size() ? SourceResultType::HAVE_MORE_OUTPUT : SourceResultType::FINISHED;
 		} else if (async_function) {
 			return async_function(context, data, output, interrupt_state);
 		} else {
-			throw NotImplementedException("Only one between function and async_function are expected");
+			throw NotImplementedException(
+			    "Only one between function and async_function are expected, but none is provided");
 		}
 	}
 	bool HasSimpleScan() const {

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -54,7 +54,7 @@ static TableFunctionBindType GetTableFunctionBindType(TableFunctionCatalogEntry 
 		}
 		if (function.in_out_function) {
 			has_in_out_function = true;
-		} else if (function.function || function.bind_replace || function.bind_operator) {
+		} else if (function.HasSimpleScan() || function.bind_replace || function.bind_operator) {
 			has_standard_table_function = true;
 		} else {
 			throw InternalException("Function \"%s\" has neither in_out_function nor function defined",


### PR DESCRIPTION
This is scaffolding towards allowing BLOCKING during scans, but I think given the surface to separate this in different PRs.

Core of this PR is allowing an additional TableFunction callback, `asycn_function`, that takes precedence over regular `function` and already bakes in (allowing in the future more customisations) the `SourceResultType` that should be returned.

MultiFileScans are already moved to new signature, but currently all functions are expected to have an implementation equivalent to:
```
return chunk.size() ? SourceResultType::HAVE_MORE_OUTPUT : SourceResultType::FINISHED;
```
and returning BLOCKING is at the moment invalid (and checked).

This PR should not change any code actual behaviour.