### PR TITLE
Add settings field to test config

### DIFF
--- a/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
+++ b/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
@@ -26,6 +26,7 @@ applications, and to alter it and redistribute it freely, subject to the followi
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/operator/numeric_cast.hpp"
 
 #include <algorithm>
 #include <cstddef>

--- a/test/configs/latest_storage.json
+++ b/test/configs/latest_storage.json
@@ -3,6 +3,9 @@
   "on_init": "ATTACH '__TEST_DIR__/{BASE_TEST_NAME}__test__config__latest__storage.db' AS __test__config__latest__storage (STORAGE_VERSION 'latest'); SET storage_compatibility_version='latest';",
   "on_new_connection": "USE __test__config__latest__storage;",
   "on_load": "skip",
+  "settings": [
+    {"name": "storage_compatibility_version", "value": "latest"}
+  ],
   "skip_compiled": "true",
   "skip_tests": [
     {

--- a/test/configs/latest_storage_block_size_16kB.json
+++ b/test/configs/latest_storage_block_size_16kB.json
@@ -3,6 +3,9 @@
   "on_init": "ATTACH '__TEST_DIR__/{BASE_TEST_NAME}__test__config__latest_storage_block_size_16kB.db' AS __test__config__latest_storage_block_size_16kB (STORAGE_VERSION 'latest'); SET storage_compatibility_version='latest';",
   "on_new_connection": "USE __test__config__latest_storage_block_size_16kB;",
   "on_load": "skip",
+  "settings": [
+    {"name": "storage_compatibility_version", "value": "latest"}
+  ],
   "skip_compiled": "true",
   "block_size": "16384",
   "skip_tests": [

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -55,6 +55,9 @@ static const TestConfigOption test_config_options[] = {
     {"storage_version", "Database storage version to use by default", LogicalType::VARCHAR, nullptr},
     {"data_location", "Directory where static test files are read (defaults to `data/`)", LogicalType::VARCHAR,
      nullptr},
+    {"settings", "Configuration settings to apply",
+     LogicalType::LIST(LogicalType::STRUCT({{"name", LogicalType::VARCHAR}, {"value", LogicalType::VARCHAR}})),
+     nullptr},
     {nullptr, nullptr, LogicalType::INVALID, nullptr},
 };
 
@@ -397,6 +400,22 @@ bool TestConfiguration::GetSkipCompiledTests() {
 
 string TestConfiguration::GetStorageVersion() {
 	return GetOptionOrDefault("storage_version", string());
+}
+
+vector<ConfigSetting> TestConfiguration::GetConfigSettings() {
+	vector<ConfigSetting> result;
+	if (options.find("settings") != options.end()) {
+		auto entry = options["settings"];
+		auto list_children = ListValue::GetChildren(entry);
+		for (const auto &value : list_children) {
+			auto &struct_children = StructValue::GetChildren(value);
+			ConfigSetting config_setting;
+			config_setting.name = StringValue::Get(struct_children[0]);
+			config_setting.value = StringValue::Get(struct_children[1]);
+			result.push_back(std::move(config_setting));
+		}
+	}
+	return result;
 }
 
 string TestConfiguration::GetTestEnv(const string &key, const string &default_value) {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -21,6 +21,11 @@ namespace duckdb {
 
 enum class SortStyle : uint8_t { NO_SORT, ROW_SORT, VALUE_SORT };
 
+struct ConfigSetting {
+	string name;
+	Value value;
+};
+
 class TestConfiguration {
 public:
 	enum class ExtensionAutoLoadingMode { NONE = 0, AVAILABLE = 1, ALL = 2 };
@@ -60,6 +65,7 @@ public:
 	vector<string> ErrorMessagesToBeSkipped();
 	string GetStorageVersion();
 	string GetTestEnv(const string &key, const string &default_value);
+	vector<ConfigSetting> GetConfigSettings();
 
 	static bool TestForceStorage();
 	static bool TestForceReload();

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -58,6 +58,9 @@ SQLLogicTestRunner::SQLLogicTestRunner(string dbpath) : dbpath(std::move(dbpath)
 	} else if (config->options.autoload_known_extensions) {
 		local_extension_repo = string(DUCKDB_BUILD_DIRECTORY) + "/repository";
 	}
+	for (auto &entry : test_config.GetConfigSettings()) {
+		config->SetOptionByName(entry.name, entry.value);
+	}
 }
 
 SQLLogicTestRunner::~SQLLogicTestRunner() {


### PR DESCRIPTION
This allows settings to be set, also prior to connecting to the initial database. Syntax is:

```
  "settings": [
    {"name": "storage_compatibility_version", "value": "latest"}
  ]
```