### PR TITLE
[C API] Expose column count and type for table description

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -4676,6 +4676,14 @@ Check if the column at 'index' index of the table has a DEFAULT expression.
 DUCKDB_C_API duckdb_state duckdb_column_has_default(duckdb_table_description table_description, idx_t index, bool *out);
 
 /*!
+Return the number of columns of the described table.
+
+* @param table_description The table_description to query.
+* @return The column count.
+*/
+DUCKDB_C_API idx_t duckdb_table_description_get_column_count(duckdb_table_description table_description);
+
+/*!
 Obtain the column name at 'index'.
 The out result must be destroyed with `duckdb_free`.
 
@@ -4684,6 +4692,17 @@ The out result must be destroyed with `duckdb_free`.
 * @return The column name.
 */
 DUCKDB_C_API char *duckdb_table_description_get_column_name(duckdb_table_description table_description, idx_t index);
+
+/*!
+Obtain the column type at 'index'.
+The return value must be destroyed with `duckdb_destroy_logical_type`.
+
+* @param table_description The table_description to query.
+* @param index The index of the column to query.
+* @return The column type.
+*/
+DUCKDB_C_API duckdb_logical_type duckdb_table_description_get_column_type(duckdb_table_description table_description,
+                                                                          idx_t index);
 
 //===--------------------------------------------------------------------===//
 // Arrow Interface

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -554,6 +554,11 @@ typedef struct {
 	// New string functions that are added
 
 	char *(*duckdb_value_to_string)(duckdb_value value);
+	// New functions around the table description
+
+	idx_t (*duckdb_table_description_get_column_count)(duckdb_table_description table_description);
+	duckdb_logical_type (*duckdb_table_description_get_column_type)(duckdb_table_description table_description,
+	                                                                idx_t index);
 	// New functions around table function binding
 
 	void (*duckdb_table_function_get_client_context)(duckdb_bind_info info, duckdb_client_context *out_context);
@@ -1044,6 +1049,8 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_scalar_function_bind_get_argument = duckdb_scalar_function_bind_get_argument;
 	result.duckdb_scalar_function_set_bind_data_copy = duckdb_scalar_function_set_bind_data_copy;
 	result.duckdb_value_to_string = duckdb_value_to_string;
+	result.duckdb_table_description_get_column_count = duckdb_table_description_get_column_count;
+	result.duckdb_table_description_get_column_type = duckdb_table_description_get_column_type;
 	result.duckdb_table_function_get_client_context = duckdb_table_function_get_client_context;
 	result.duckdb_create_map_value = duckdb_create_map_value;
 	result.duckdb_create_union_value = duckdb_create_union_value;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_table_description_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_table_description_functions.json
@@ -1,0 +1,8 @@
+{
+  "version": "unstable_new_table_description_functions",
+  "description": "New functions around the table description",
+  "entries": [
+    "duckdb_table_description_get_column_count",
+    "duckdb_table_description_get_column_type"
+  ]
+}

--- a/src/include/duckdb/main/capi/header_generation/functions/table_description.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_description.json
@@ -132,6 +132,23 @@
             }
         },
         {
+            "name": "duckdb_table_description_get_column_count",
+            "return_type": "idx_t",
+            "params": [
+                {
+                    "type": "duckdb_table_description",
+                    "name": "table_description"
+                }
+            ],
+            "comment": {
+                "description": "Return the number of columns of the described table.\n\n",
+                "param_comments": {
+                    "table_description": "The table_description to query."
+                },
+                "return_value": "The column count."
+            }
+        },
+        {
             "name": "duckdb_table_description_get_column_name",
             "return_type": "char *",
             "params": [
@@ -151,6 +168,28 @@
                     "index": "The index of the column to query."
                 },
                 "return_value": "The column name."
+            }
+        },
+        {
+            "name": "duckdb_table_description_get_column_type",
+            "return_type": "duckdb_logical_type",
+            "params": [
+                {
+                    "type": "duckdb_table_description",
+                    "name": "table_description"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "index"
+                }
+            ],
+            "comment": {
+                "description": "Obtain the column type at 'index'.\nThe return value must be destroyed with `duckdb_destroy_logical_type`.\n\n",
+                "param_comments": {
+                    "table_description": "The table_description to query.",
+                    "index": "The index of the column to query."
+                },
+                "return_value": "The column type."
             }
         }
     ]

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -643,6 +643,13 @@ typedef struct {
 	char *(*duckdb_value_to_string)(duckdb_value value);
 #endif
 
+// New functions around the table description
+#ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
+	idx_t (*duckdb_table_description_get_column_count)(duckdb_table_description table_description);
+	duckdb_logical_type (*duckdb_table_description_get_column_type)(duckdb_table_description table_description,
+	                                                                idx_t index);
+#endif
+
 // New functions around table function binding
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
 	void (*duckdb_table_function_get_client_context)(duckdb_bind_info info, duckdb_client_context *out_context);
@@ -1163,6 +1170,10 @@ typedef struct {
 
 // Version unstable_new_string_functions
 #define duckdb_value_to_string duckdb_ext_api.duckdb_value_to_string
+
+// Version unstable_new_table_description_functions
+#define duckdb_table_description_get_column_count duckdb_ext_api.duckdb_table_description_get_column_count
+#define duckdb_table_description_get_column_type  duckdb_ext_api.duckdb_table_description_get_column_type
 
 // Version unstable_new_table_function_functions
 #define duckdb_table_function_get_client_context duckdb_ext_api.duckdb_table_function_get_client_context

--- a/test/api/capi/test_capi_table_description.cpp
+++ b/test/api/capi/test_capi_table_description.cpp
@@ -64,17 +64,36 @@ TEST_CASE("Test the table description in the C API", "[capi]") {
 	REQUIRE(status == DuckDBSuccess);
 	REQUIRE(duckdb_table_description_error(table_description) == nullptr);
 
+	SECTION("Passing nullptr to get_column_count") {
+		REQUIRE(duckdb_table_description_get_column_count(nullptr) == 0);
+	}
 	SECTION("Passing nullptr to get_name") {
 		REQUIRE(duckdb_table_description_get_column_name(nullptr, 0) == nullptr);
 	}
+	SECTION("Passing nullptr to get_type") {
+		REQUIRE(duckdb_table_description_get_column_type(nullptr, 0) == nullptr);
+	}
 	SECTION("Out of range column for get_name") {
 		REQUIRE(duckdb_table_description_get_column_name(table_description, 1) == nullptr);
+	}
+	SECTION("Out of range column for get_type") {
+		REQUIRE(duckdb_table_description_get_column_type(table_description, 1) == nullptr);
+	}
+	SECTION("get the column count") {
+		auto column_count = duckdb_table_description_get_column_count(table_description);
+		REQUIRE(column_count == 1);
 	}
 	SECTION("In range column - get the name") {
 		auto column_name = duckdb_table_description_get_column_name(table_description, 0);
 		string expected = "my_column";
 		REQUIRE(!expected.compare(column_name));
 		duckdb_free(column_name);
+	}
+	SECTION("In range column - get the type") {
+		auto column_type = duckdb_table_description_get_column_type(table_description, 0);
+		auto type_id = duckdb_get_type_id(column_type);
+		REQUIRE(type_id == DUCKDB_TYPE_INTEGER);
+		duckdb_destroy_logical_type(&column_type);
 	}
 	duckdb_table_description_destroy(&table_description);
 }


### PR DESCRIPTION
Necessary to auto-infer target types of a query with the query appender.