### PR TITLE
Keep track of which database managers have which databases attached in the DatabaseFilePathManager

### DIFF
--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -35,9 +35,10 @@ enum class AttachedDatabaseType {
 class DatabaseFilePathManager;
 
 struct StoredDatabasePath {
-	StoredDatabasePath(DatabaseFilePathManager &manager, string path, const string &name);
+	StoredDatabasePath(DatabaseManager &db_manager, DatabaseFilePathManager &manager, string path, const string &name);
 	~StoredDatabasePath();
 
+	DatabaseManager &db_manager;
 	DatabaseFilePathManager &manager;
 	string path;
 

--- a/src/include/duckdb/main/database_file_path_manager.hpp
+++ b/src/include/duckdb/main/database_file_path_manager.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/enums/on_create_conflict.hpp"
 #include "duckdb/common/enums/access_mode.hpp"
+#include "duckdb/common/reference_map.hpp"
 
 namespace duckdb {
 struct AttachInfo;

--- a/src/include/duckdb/main/database_file_path_manager.hpp
+++ b/src/include/duckdb/main/database_file_path_manager.hpp
@@ -17,17 +17,16 @@
 namespace duckdb {
 struct AttachInfo;
 struct AttachOptions;
+class DatabaseManager;
 
 enum class InsertDatabasePathResult { SUCCESS, ALREADY_EXISTS };
 
 struct DatabasePathInfo {
-	explicit DatabasePathInfo(string name_p, AccessMode access_mode)
-	    : name(std::move(name_p)), access_mode(access_mode), is_attached(true) {
-	}
+	DatabasePathInfo(DatabaseManager &manager, string name_p, AccessMode access_mode);
 
 	string name;
 	AccessMode access_mode;
-	bool is_attached;
+	reference_set_t<DatabaseManager> attached_databases;
 	idx_t reference_count = 1;
 };
 
@@ -35,12 +34,12 @@ struct DatabasePathInfo {
 class DatabaseFilePathManager {
 public:
 	idx_t ApproxDatabaseCount() const;
-	InsertDatabasePathResult InsertDatabasePath(const string &path, const string &name, OnCreateConflict on_conflict,
-	                                            AttachOptions &options);
+	InsertDatabasePathResult InsertDatabasePath(DatabaseManager &manager, const string &path, const string &name,
+	                                            OnCreateConflict on_conflict, AttachOptions &options);
 	//! Erase a database path - indicating we are done with using it
 	void EraseDatabasePath(const string &path);
 	//! Called when a database is detached, but before it is fully finished being used
-	void DetachDatabase(const string &path);
+	void DetachDatabase(DatabaseManager &manager, const string &path);
 
 private:
 	//! The lock to add entries to the database path map

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -14,8 +14,9 @@
 
 namespace duckdb {
 
-StoredDatabasePath::StoredDatabasePath(DatabaseFilePathManager &manager, string path_p, const string &name)
-    : manager(manager), path(std::move(path_p)) {
+StoredDatabasePath::StoredDatabasePath(DatabaseManager &db_manager, DatabaseFilePathManager &manager, string path_p,
+                                       const string &name)
+    : db_manager(db_manager), manager(manager), path(std::move(path_p)) {
 }
 
 StoredDatabasePath::~StoredDatabasePath() {
@@ -23,7 +24,7 @@ StoredDatabasePath::~StoredDatabasePath() {
 }
 
 void StoredDatabasePath::OnDetach() {
-	manager.DetachDatabase(path);
+	manager.DetachDatabase(db_manager, path);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/main/database_file_path_manager.cpp
+++ b/src/main/database_file_path_manager.cpp
@@ -5,28 +5,43 @@
 
 namespace duckdb {
 
+DatabasePathInfo::DatabasePathInfo(DatabaseManager &manager, string name_p, AccessMode access_mode)
+    : name(std::move(name_p)), access_mode(access_mode) {
+	attached_databases.insert(manager);
+}
+
 idx_t DatabaseFilePathManager::ApproxDatabaseCount() const {
 	lock_guard<mutex> path_lock(db_paths_lock);
 	return db_paths.size();
 }
 
-InsertDatabasePathResult DatabaseFilePathManager::InsertDatabasePath(const string &path, const string &name,
-                                                                     OnCreateConflict on_conflict,
+InsertDatabasePathResult DatabaseFilePathManager::InsertDatabasePath(DatabaseManager &manager, const string &path,
+                                                                     const string &name, OnCreateConflict on_conflict,
                                                                      AttachOptions &options) {
 	if (path.empty() || path == IN_MEMORY_PATH) {
 		return InsertDatabasePathResult::SUCCESS;
 	}
 
 	lock_guard<mutex> path_lock(db_paths_lock);
-	auto entry = db_paths.emplace(path, DatabasePathInfo(name, options.access_mode));
+	auto entry = db_paths.emplace(path, DatabasePathInfo(manager, name, options.access_mode));
 	if (!entry.second) {
 		auto &existing = entry.first->second;
+		bool already_exists = false;
+		bool attached_in_this_system = false;
+		if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT && existing.name == name) {
+			already_exists = true;
+			attached_in_this_system = existing.attached_databases.find(manager) != existing.attached_databases.end();
+		}
 		if (options.access_mode == AccessMode::READ_ONLY && existing.access_mode == AccessMode::READ_ONLY) {
+			if (attached_in_this_system) {
+				return InsertDatabasePathResult::ALREADY_EXISTS;
+			}
 			// all attaches are in read-only mode - there is no conflict, just increase the reference count
+			existing.attached_databases.insert(manager);
 			existing.reference_count++;
 		} else {
-			if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT && existing.name == name) {
-				if (existing.is_attached) {
+			if (already_exists) {
+				if (attached_in_this_system) {
 					return InsertDatabasePathResult::ALREADY_EXISTS;
 				}
 				throw BinderException(
@@ -40,7 +55,7 @@ InsertDatabasePathResult DatabaseFilePathManager::InsertDatabasePath(const strin
 			    name, path, existing.name);
 		}
 	}
-	options.stored_database_path = make_uniq<StoredDatabasePath>(*this, path, name);
+	options.stored_database_path = make_uniq<StoredDatabasePath>(manager, *this, path, name);
 	return InsertDatabasePathResult::SUCCESS;
 }
 
@@ -59,14 +74,14 @@ void DatabaseFilePathManager::EraseDatabasePath(const string &path) {
 	}
 }
 
-void DatabaseFilePathManager::DetachDatabase(const string &path) {
+void DatabaseFilePathManager::DetachDatabase(DatabaseManager &manager, const string &path) {
 	if (path.empty() || path == IN_MEMORY_PATH) {
 		return;
 	}
 	lock_guard<mutex> path_lock(db_paths_lock);
 	auto entry = db_paths.find(path);
 	if (entry != db_paths.end()) {
-		entry->second.is_attached = false;
+		entry->second.attached_databases.erase(manager);
 	}
 }
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -199,7 +199,7 @@ idx_t DatabaseManager::ApproxDatabaseCount() {
 }
 
 InsertDatabasePathResult DatabaseManager::InsertDatabasePath(const AttachInfo &info, AttachOptions &options) {
-	return path_manager->InsertDatabasePath(info.path, info.name, info.on_conflict, options);
+	return path_manager->InsertDatabasePath(*this, info.path, info.name, info.on_conflict, options);
 }
 
 vector<string> DatabaseManager::GetAttachedDatabasePaths() {

--- a/test/api/test_instance_cache.cpp
+++ b/test/api/test_instance_cache.cpp
@@ -110,22 +110,32 @@ TEST_CASE("Test attaching the same database path from different databases", "[ap
 	auto db1 = instance_cache.GetOrCreateInstance(":memory:", config, false);
 	auto db2 = instance_cache.GetOrCreateInstance(":memory:", config, false);
 
-	string attach_query = "ATTACH '" + test_path + "' AS db_ref";
-
 	Connection con1(*db1);
-	REQUIRE_NO_FAIL(con1.Query(attach_query));
-
-	// fails - already attached in db1
 	Connection con2(*db2);
-	REQUIRE_FAIL(con2.Query(attach_query));
+	SECTION("Regular ATTACH conflict") {
+		string attach_query = "ATTACH '" + test_path + "' AS db_ref";
 
-	// if we detach from con1, we can now attach in con2
-	REQUIRE_NO_FAIL(con1.Query("DETACH db_ref"));
+		REQUIRE_NO_FAIL(con1.Query(attach_query));
 
-	REQUIRE_NO_FAIL(con2.Query(attach_query));
+		// fails - already attached in db1
+		REQUIRE_FAIL(con2.Query(attach_query));
 
-	// .. but not in con1 anymore!
-	REQUIRE_FAIL(con1.Query(attach_query));
+		// if we detach from con1, we can now attach in con2
+		REQUIRE_NO_FAIL(con1.Query("DETACH db_ref"));
+
+		REQUIRE_NO_FAIL(con2.Query(attach_query));
+
+		// .. but not in con1 anymore!
+		REQUIRE_FAIL(con1.Query(attach_query));
+	}
+	SECTION("ATTACH IF NOT EXISTS") {
+		string attach_query = "ATTACH IF NOT EXISTS '" + test_path + "' AS db_ref";
+
+		REQUIRE_NO_FAIL(con1.Query(attach_query));
+
+		// fails - already attached in db1
+		REQUIRE_FAIL(con2.Query(attach_query));
+	}
 }
 
 TEST_CASE("Test attaching the same database path from different databases in read-only mode", "[api][.]") {
@@ -136,7 +146,7 @@ TEST_CASE("Test attaching the same database path from different databases in rea
 	{
 		DuckDB db(test_path);
 		Connection con(db);
-		REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers AS FROM (VALUES (1), (2), (3)) t(i)"));
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE IF NOT EXISTS integers AS FROM (VALUES (1), (2), (3)) t(i)"));
 	}
 
 	DBConfig config;
@@ -144,28 +154,54 @@ TEST_CASE("Test attaching the same database path from different databases in rea
 	auto db2 = instance_cache.GetOrCreateInstance(":memory:", config, false);
 	auto db3 = instance_cache.GetOrCreateInstance(":memory:", config, false);
 
-	string attach_query = "ATTACH '" + test_path + "' AS db_ref";
-	string read_only_attach = attach_query + " (READ_ONLY)";
-
 	Connection con1(*db1);
-	REQUIRE_NO_FAIL(con1.Query(read_only_attach));
-
-	// succeeds - we can attach the same database multiple times in read-only mode
 	Connection con2(*db2);
-	REQUIRE_NO_FAIL(con2.Query(read_only_attach));
-
-	// fails - we cannot attach in read-write
 	Connection con3(*db3);
-	REQUIRE_FAIL(con3.Query(attach_query));
 
-	// if we detach from con1, we still cannot attach in read-write in con3
-	REQUIRE_NO_FAIL(con1.Query("DETACH db_ref"));
-	REQUIRE_FAIL(con3.Query(attach_query));
+	SECTION("Regular ATTACH conflict") {
+		string attach_query = "ATTACH '" + test_path + "' AS db_ref";
+		string read_only_attach = attach_query + " (READ_ONLY)";
 
-	// but if we detach in con2, we can attach in read-write mode now
-	REQUIRE_NO_FAIL(con2.Query("DETACH db_ref"));
-	REQUIRE_NO_FAIL(con3.Query(attach_query));
+		REQUIRE_NO_FAIL(con1.Query(read_only_attach));
 
-	// and now we can no longer attach in read-only mode
-	REQUIRE_FAIL(con1.Query(read_only_attach));
+		// succeeds - we can attach the same database multiple times in read-only mode
+		REQUIRE_NO_FAIL(con2.Query(read_only_attach));
+
+		// fails - we cannot attach in read-write
+		REQUIRE_FAIL(con3.Query(attach_query));
+
+		// if we detach from con1, we still cannot attach in read-write in con3
+		REQUIRE_NO_FAIL(con1.Query("DETACH db_ref"));
+		REQUIRE_FAIL(con3.Query(attach_query));
+
+		// but if we detach in con2, we can attach in read-write mode now
+		REQUIRE_NO_FAIL(con2.Query("DETACH db_ref"));
+		REQUIRE_NO_FAIL(con3.Query(attach_query));
+
+		// and now we can no longer attach in read-only mode
+		REQUIRE_FAIL(con1.Query(read_only_attach));
+	}
+	SECTION("ATTACH IF EXISTS") {
+		string attach_query = "ATTACH IF NOT EXISTS '" + test_path + "' AS db_ref";
+		string read_only_attach = attach_query + " (READ_ONLY)";
+
+		REQUIRE_NO_FAIL(con1.Query(read_only_attach));
+
+		// succeeds - we can attach the same database multiple times in read-only mode
+		REQUIRE_NO_FAIL(con2.Query(read_only_attach));
+
+		// fails - we cannot attach in read-write
+		REQUIRE_FAIL(con3.Query(attach_query));
+
+		// if we detach from con1, we still cannot attach in read-write in con3
+		REQUIRE_NO_FAIL(con1.Query("DETACH db_ref"));
+		REQUIRE_FAIL(con3.Query(attach_query));
+
+		// but if we detach in con2, we can attach in read-write mode now
+		REQUIRE_NO_FAIL(con2.Query("DETACH db_ref"));
+		REQUIRE_NO_FAIL(con3.Query(attach_query));
+
+		// and now we can no longer attach in read-only mode
+		REQUIRE_FAIL(con1.Query(read_only_attach));
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/19333

Otherwise we are waiting for an attach to complete that will never complete (because it has happened in a different database instance).