### PR TITLE
Binder: Rework the way set operations work so that we can use the standard binding flow

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -424,6 +424,7 @@ private:
 	unique_ptr<LogicalOperator> CreatePlan(BoundQueryNode &node);
 
 	BoundSetOpChild BindSetOpChild(QueryNode &child);
+	void BuildUnionByNameInfo(BoundSetOperationNode &result);
 
 	BoundStatement BindJoin(Binder &parent, TableRef &ref);
 	BoundStatement Bind(BaseTableRef &ref);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -423,7 +423,6 @@ private:
 	unique_ptr<LogicalOperator> CreatePlan(BoundSetOperationNode &node);
 	unique_ptr<LogicalOperator> CreatePlan(BoundQueryNode &node);
 
-	BoundSetOpChild BindSetOpChild(QueryNode &child);
 	void BuildUnionByNameInfo(BoundSetOperationNode &result);
 
 	BoundStatement BindJoin(Binder &parent, TableRef &ref);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -424,7 +424,6 @@ private:
 	unique_ptr<LogicalOperator> CreatePlan(BoundQueryNode &node);
 
 	BoundSetOpChild BindSetOpChild(QueryNode &child);
-	unique_ptr<BoundSetOperationNode> BindSetOpNode(SetOperationNode &statement);
 
 	BoundStatement BindJoin(Binder &parent, TableRef &ref);
 	BoundStatement Bind(BaseTableRef &ref);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -515,8 +515,6 @@ private:
 	LogicalType BindLogicalTypeInternal(const LogicalType &type, optional_ptr<Catalog> catalog, const string &schema);
 
 	BoundStatement BindSelectNode(SelectNode &statement, BoundStatement from_table);
-	unique_ptr<BoundSelectNode> BindSelectNodeInternal(SelectNode &statement);
-	unique_ptr<BoundSelectNode> BindSelectNodeInternal(SelectNode &statement, BoundStatement from_table);
 
 	unique_ptr<LogicalOperator> BindCopyDatabaseSchema(Catalog &source_catalog, const string &target_database_name);
 	unique_ptr<LogicalOperator> BindCopyDatabaseData(Catalog &source_catalog, const string &target_database_name);

--- a/src/include/duckdb/planner/bound_statement.hpp
+++ b/src/include/duckdb/planner/bound_statement.hpp
@@ -10,16 +10,23 @@
 
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/common/enums/set_operation_type.hpp"
 
 namespace duckdb {
 
 class LogicalOperator;
 struct LogicalType;
+struct BoundStatement;
+
+struct ExtraBoundInfo {
+	vector<unique_ptr<ParsedExpression>> original_expressions;
+};
 
 struct BoundStatement {
 	unique_ptr<LogicalOperator> plan;
 	vector<LogicalType> types;
 	vector<string> names;
+	ExtraBoundInfo extra_info;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/bound_statement.hpp
+++ b/src/include/duckdb/planner/bound_statement.hpp
@@ -17,8 +17,12 @@ namespace duckdb {
 class LogicalOperator;
 struct LogicalType;
 struct BoundStatement;
+class Binder;
 
 struct ExtraBoundInfo {
+	SetOperationType setop_type = SetOperationType::NONE;
+	vector<shared_ptr<Binder>> child_binders;
+	vector<BoundStatement> bound_children;
 	vector<unique_ptr<ParsedExpression>> original_expressions;
 };
 

--- a/src/include/duckdb/planner/bound_statement.hpp
+++ b/src/include/duckdb/planner/bound_statement.hpp
@@ -11,12 +11,14 @@
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/enums/set_operation_type.hpp"
+#include "duckdb/common/shared_ptr.hpp"
 
 namespace duckdb {
 
 class LogicalOperator;
 struct LogicalType;
 struct BoundStatement;
+class ParsedExpression;
 class Binder;
 
 struct ExtraBoundInfo {

--- a/src/include/duckdb/planner/query_node/bound_set_operation_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_set_operation_node.hpp
@@ -13,7 +13,6 @@
 #include "duckdb/planner/bound_query_node.hpp"
 
 namespace duckdb {
-struct BoundSetOpChild;
 
 //! Bound equivalent of SetOperationNode
 class BoundSetOperationNode : public BoundQueryNode {
@@ -23,7 +22,9 @@ public:
 	//! whether the ALL modifier was used or not
 	bool setop_all = false;
 	//! The bound children
-	vector<BoundSetOpChild> bound_children;
+	vector<BoundStatement> bound_children;
+	//! Child binders
+	vector<shared_ptr<Binder>> child_binders;
 
 	//! Index used by the set operation
 	idx_t setop_index;
@@ -32,11 +33,6 @@ public:
 	idx_t GetRootIndex() override {
 		return setop_index;
 	}
-};
-
-struct BoundSetOpChild {
-	BoundStatement node;
-	shared_ptr<Binder> binder;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/query_node/bound_set_operation_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_set_operation_node.hpp
@@ -35,15 +35,10 @@ public:
 };
 
 struct BoundSetOpChild {
-	unique_ptr<BoundSetOperationNode> bound_node;
 	BoundStatement node;
 	shared_ptr<Binder> binder;
 	//! Exprs used by the UNION BY NAME operations to add a new projection
 	vector<unique_ptr<Expression>> reorder_expressions;
-
-	const vector<string> &GetNames();
-	const vector<LogicalType> &GetTypes();
-	idx_t GetRootIndex();
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/query_node/bound_set_operation_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_set_operation_node.hpp
@@ -38,8 +38,6 @@ struct BoundSetOpChild {
 	unique_ptr<BoundSetOperationNode> bound_node;
 	BoundStatement node;
 	shared_ptr<Binder> binder;
-	//! Original select list (if this was a SELECT statement)
-	vector<unique_ptr<ParsedExpression>> select_list;
 	//! Exprs used by the UNION BY NAME operations to add a new projection
 	vector<unique_ptr<Expression>> reorder_expressions;
 

--- a/src/include/duckdb/planner/query_node/bound_set_operation_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_set_operation_node.hpp
@@ -37,8 +37,6 @@ public:
 struct BoundSetOpChild {
 	BoundStatement node;
 	shared_ptr<Binder> binder;
-	//! Exprs used by the UNION BY NAME operations to add a new projection
-	vector<unique_ptr<Expression>> reorder_expressions;
 };
 
 } // namespace duckdb

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -698,6 +698,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 	result_statement.types = result->types;
 	result_statement.names = result->names;
 	result_statement.plan = CreatePlan(*result);
+	result_statement.extra_info.original_expressions = std::move(result->bind_state.original_expressions);
 	return result_statement;
 }
 

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -58,8 +58,9 @@ void SetOpAliasGatherer::GatherAliases(BoundSetOpChild &node, const vector<idx_t
 		}
 	}
 	// check if the expression matches one of the expressions in the original expression list
-	for (idx_t i = 0; i < node.select_list.size(); i++) {
-		auto &expr = node.select_list[i];
+	auto &select_list = node.node.extra_info.original_expressions;
+	for (idx_t i = 0; i < select_list.size(); i++) {
+		auto &expr = select_list[i];
 		idx_t index = reorder_idx[i];
 		// now check if the node is already in the set of expressions
 		auto expr_entry = bind_state.projection_map.find(*expr);
@@ -218,18 +219,7 @@ BoundSetOpChild Binder::BindSetOpChild(QueryNode &child) {
 	} else {
 		bound_child.binder = Binder::CreateBinder(context, this);
 		bound_child.binder->can_contain_nulls = true;
-		if (child.type == QueryNodeType::SELECT_NODE) {
-			auto &select_node = child.Cast<SelectNode>();
-			auto bound_select_node = bound_child.binder->BindSelectNodeInternal(select_node);
-			for (auto &expr : bound_select_node->bind_state.original_expressions) {
-				bound_child.select_list.push_back(expr->Copy());
-			}
-			bound_child.node.names = bound_select_node->names;
-			bound_child.node.types = bound_select_node->types;
-			bound_child.node.plan = bound_child.binder->CreatePlan(*bound_select_node);
-		} else {
-			bound_child.node = bound_child.binder->BindNode(child);
-		}
+		bound_child.node = bound_child.binder->BindNode(child);
 	}
 	return bound_child;
 }

--- a/src/planner/binder/query_node/plan_setop.cpp
+++ b/src/planner/binder/query_node/plan_setop.cpp
@@ -114,15 +114,10 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSetOperationNode &node) {
 	D_ASSERT(node.bound_children.size() >= 2);
 	vector<unique_ptr<LogicalOperator>> children;
 	for (auto &child : node.bound_children) {
-		unique_ptr<LogicalOperator> child_node;
-		if (child.bound_node) {
-			child_node = CreatePlan(*child.bound_node);
-		} else {
-			child.binder->is_outside_flattened = is_outside_flattened;
+		child.binder->is_outside_flattened = is_outside_flattened;
 
-			// construct the logical plan for the child node
-			child_node = std::move(child.node.plan);
-		}
+		// construct the logical plan for the child node
+		auto child_node = std::move(child.node.plan);
 		if (!child.reorder_expressions.empty()) {
 			// if we have re-order expressions push a projection
 			vector<LogicalType> child_types;
@@ -137,7 +132,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSetOperationNode &node) {
 			child_node = CastLogicalOperatorToTypes(child_types, node.types, std::move(child_node));
 		} else {
 			// otherwise push only casts
-			child_node = CastLogicalOperatorToTypes(child.GetTypes(), node.types, std::move(child_node));
+			child_node = CastLogicalOperatorToTypes(child.node.types, node.types, std::move(child_node));
 		}
 		// check if there are any unplanned subqueries left in any child
 		if (child.binder && child.binder->has_unplanned_dependent_joins) {

--- a/src/planner/binder/query_node/plan_setop.cpp
+++ b/src/planner/binder/query_node/plan_setop.cpp
@@ -113,15 +113,16 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSetOperationNode &node) {
 
 	D_ASSERT(node.bound_children.size() >= 2);
 	vector<unique_ptr<LogicalOperator>> children;
-	for (auto &child : node.bound_children) {
-		child.binder->is_outside_flattened = is_outside_flattened;
+	for (idx_t child_idx = 0; child_idx < node.bound_children.size(); child_idx++) {
+		auto &child = node.bound_children[child_idx];
+		auto &child_binder = *node.child_binders[child_idx];
 
 		// construct the logical plan for the child node
-		auto child_node = std::move(child.node.plan);
+		auto child_node = std::move(child.plan);
 		// push casts for the target types
-		child_node = CastLogicalOperatorToTypes(child.node.types, node.types, std::move(child_node));
+		child_node = CastLogicalOperatorToTypes(child.types, node.types, std::move(child_node));
 		// check if there are any unplanned subqueries left in any child
-		if (child.binder && child.binder->has_unplanned_dependent_joins) {
+		if (child_binder.has_unplanned_dependent_joins) {
 			has_unplanned_dependent_joins = true;
 		}
 		children.push_back(std::move(child_node));


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/19322

This PR reworks the way that set operations bind so that they can use the standard binding flow which takes a `BoundStatement` from the children and returns a `BoundStatement` when finished. This does require extending `BoundStatement` with several members, however:

```cpp
struct ExtraBoundInfo {
	SetOperationType setop_type = SetOperationType::NONE;
	vector<shared_ptr<Binder>> child_binders;
	vector<BoundStatement> bound_children;
	vector<unique_ptr<ParsedExpression>> original_expressions;
};
```

The reason this is required is because we have some quite involved logic in how set operations are bound. In particular, when binding expressions within the result modifiers (i.e. `ORDER BY` and such), we peer into the select statements to figure out if there are any matches. This allows queries like this to work:

```sql
SELECT i + 1 FROM (VALUES (42)) t(i) UNION ALL SELECT 84 ORDER BY i + 1;
```

As we can match the `i + 1` in the `ORDER BY` to the `i + 1` in the select statement.

We also can't "just" look at the original parsed expressions in the `SelectNode` - as they need to be qualified so e.g. statements like this work:

```sql
SELECT i FROM (VALUES (42)) t(i) UNION ALL SELECT 84 ORDER BY t.i;
```

Instead of peering into the `BoundQueryNode` of the children - we now opt to return the required information to bind set operations as part of the `BoundStatement`, allowing the regular binding flow to be used.
