### PR TITLE
add failing tests for string coercion during comparisons to enums

### DIFF
--- a/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -52,6 +52,7 @@ static bool SwitchVarcharComparison(const LogicalType &type) {
 	case LogicalTypeId::TIMESTAMP_TZ:
 	case LogicalTypeId::TIME_TZ:
 	case LogicalTypeId::INTEGER_LITERAL:
+	case LogicalTypeId::ENUM:
 		return true;
 	default:
 		return false;

--- a/test/sql/types/enum/test_enum_comparisons.test
+++ b/test/sql/types/enum/test_enum_comparisons.test
@@ -49,7 +49,7 @@ SELECT 'sad' = 'sad'::mood AS comp;
 True
 
 # Comparing to a non-existent enum value should error
-Error: Enum value 'ecstatic' not found in enum type 'mood'
+# Error: Enum value 'ecstatic' not found in enum type 'mood'
 statement error
 select 'sad'::mood = 'ecstatic'
 ----

--- a/test/sql/types/enum/test_enum_comparisons.test
+++ b/test/sql/types/enum/test_enum_comparisons.test
@@ -26,6 +26,39 @@ CREATE TABLE robots (
 statement ok
 insert into robots values ('Timmynator','sad'), ('Tars', 'ok'), ('Diggernaut', NULL)
 
+# enums are ordered
+query I
+SELECT 'sad'::mood < 'ok'::mood AS comp;
+----
+True
+
+# strings are coerced to enums
+query I
+SELECT 'sad'::mood < 'ok' AS comp;
+----
+True
+
+query I
+SELECT 'sad'::mood = 'ok' AS comp;
+----
+False
+
+query I
+SELECT 'sad' = 'sad'::mood AS comp;
+----
+True
+
+# Comparing to a non-existent enum value should error
+statement error
+select 'sad'::mood = 'ecstatic'
+----
+Error: Enum value 'ecstatic' not found in enum type 'mood'
+
+statement error
+select 'sad'::mood < 'ecstatic'
+----
+Error: Enum value 'ecstatic' not found in enum type 'mood'
+
 # This just compares the actual uint value of the column since both are from the same mood type
 query II
 select person.name, robots.name from person inner join robots on (person.current_mood = robots.current_mood)
@@ -50,6 +83,28 @@ query II
 select person.name, pet.name from person inner join pet on (person.current_mood > pet.current_mood) where person.name = 'Pedro'
 ----
 Pedro	Vacilo
+
+query II
+select * from person where current_mood = 'happy'
+----
+Pedro	happy
+
+query II rowsort
+select * from person where current_mood >= 'happy'
+----
+Pedro	happy
+Tim	ok
+
+# Comparing to a non-existent enum value should error
+statement error
+select * from person where current_mood = 'ecstatic'
+----
+Error: Enum value 'ecstatic' not found in enum type 'mood'
+
+statement error
+select * from person where current_mood >= 'ecstatic'
+----
+Error: Enum value 'ecstatic' not found in enum type 'mood'
 
 
 # This actually performs the optimized comparison since they are both ENUMs but of different types.

--- a/test/sql/types/enum/test_enum_comparisons.test
+++ b/test/sql/types/enum/test_enum_comparisons.test
@@ -49,15 +49,24 @@ SELECT 'sad' = 'sad'::mood AS comp;
 True
 
 # Comparing to a non-existent enum value should error
+Error: Enum value 'ecstatic' not found in enum type 'mood'
 statement error
 select 'sad'::mood = 'ecstatic'
 ----
-Error: Enum value 'ecstatic' not found in enum type 'mood'
 
+# Error: Enum value 'ecstatic' not found in enum type 'mood'
 statement error
 select 'sad'::mood < 'ecstatic'
 ----
-Error: Enum value 'ecstatic' not found in enum type 'mood'
+
+# Should also error when compared to only-known-at-runtime strings
+statement error
+select name = 'sad'::mood from person
+----
+
+statement error
+select name > 'sad'::mood from person
+----
 
 # This just compares the actual uint value of the column since both are from the same mood type
 query II
@@ -99,13 +108,10 @@ Tim	ok
 statement error
 select * from person where current_mood = 'ecstatic'
 ----
-Error: Enum value 'ecstatic' not found in enum type 'mood'
 
 statement error
 select * from person where current_mood >= 'ecstatic'
 ----
-Error: Enum value 'ecstatic' not found in enum type 'mood'
-
 
 # This actually performs the optimized comparison since they are both ENUMs but of different types.
 


### PR DESCRIPTION
At this point this is just a failing test case that demonstrates https://github.com/duckdb/duckdb/issues/16623.

I intend to actually try to fix this, but I am going to be mostly blindly poking around with claude to figure out how everything works, so if you can point me in the right direction, that would be greatly appreciated.

I think there are actually two bugs on main:

1. Based on `SELECT 'sad'::mood < 'sac', 'sad'::mood < 'sae';`, which returns (false, true), it appears to me that actually we are casting the enums to strings, (and therefore comparing 'sad' < 'sac' and 'sad' < 'sae'), when really what we want to be doing is casting the strings to enums.

So, I fixed this in [`9af25c3` (#19345)](https://github.com/duckdb/duckdb/pull/19345/commits/9af25c3c9b325aafb339f5d19c7e82dabee02983) by preferring to cast varchar to enum when comparing varchar to enum, instead of casting the enum to varchar.

But even with this fix, there is still a remaining bug:

2. If you compare an enum to a bogus string, eg `select 'sad'::mood = 'bogus'`, then the 'bogus' is now correctly cast to the enum. BUT, it is try_casted(), resulting in `'sad'::mood = NULL`, which results in `NULL`, when really this should be a strict cast that errors. I have gotten stuck solving this second step.

Notes for myself:
build: `GEN=ninja make debug`
test: `build/debug/test/unittest test/sql/types/enum/test_enum_comparisons.test`