### PR TITLE
Avoid keeping shared ptr to ClientContext in QueryContext

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -339,9 +339,6 @@ public:
 	}
 	QueryContext(ClientContext &context) : context(&context) { // NOLINT: allow implicit construction
 	}
-	QueryContext(weak_ptr<ClientContext> context) // NOLINT: allow implicit construction
-	    : owning_context(context.lock()), context(owning_context.get()) {
-	}
 
 public:
 	bool Valid() const {
@@ -352,7 +349,6 @@ public:
 	}
 
 private:
-	shared_ptr<ClientContext> owning_context;
 	optional_ptr<ClientContext> context;
 };
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -253,7 +253,7 @@ void DataTable::InitializeScanWithOffset(DuckTransaction &transaction, TableScan
                                          const vector<StorageIndex> &column_ids, idx_t start_row, idx_t end_row) {
 	state.checkpoint_lock = transaction.SharedLockTable(*info);
 	state.Initialize(column_ids);
-	row_groups->InitializeScanWithOffset(transaction.context, state.table_state, column_ids, start_row, end_row);
+	row_groups->InitializeScanWithOffset(QueryContext(), state.table_state, column_ids, start_row, end_row);
 }
 
 idx_t DataTable::GetRowGroupSize() const {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -271,7 +271,7 @@ bool RowGroupCollection::Scan(DuckTransaction &transaction, const vector<Storage
 	// initialize the scan
 	TableScanState state;
 	state.Initialize(column_ids, nullptr);
-	InitializeScan(transaction.context, state.local_state, column_ids, nullptr);
+	InitializeScan(QueryContext(), state.local_state, column_ids, nullptr);
 
 	while (true) {
 		chunk.Reset();

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -177,7 +177,7 @@ void UndoBuffer::Cleanup(transaction_t lowest_active_transaction) {
 	//      the chunks)
 	//  (2) there is no active transaction with start_id < commit_id of this
 	//  transaction
-	CleanupState state(transaction.context, lowest_active_transaction);
+	CleanupState state(QueryContext(), lowest_active_transaction);
 	UndoBuffer::IteratorState iterator_state;
 	IterateEntries(iterator_state, [&](UndoFlags type, data_ptr_t data) { state.CleanupEntry(type, data); });
 


### PR DESCRIPTION
This fixes a thread sanitizer issue that has been popping up due to this, see e.g. [here](https://github.com/Mytherin/duckdb/actions/runs/18417785208/job/52491151141).

The issue is in particular in `UndoBuffer::Cleanup`. Currently, we log it using the original transaction that created the undo buffer. This is however not the transaction that is initiating the current operation - and that connection might have already been destroyed / be in the process of being destroyed. This leads to a lock inversion (and potential deadlock) if the client contexts' destroy is triggered in this location.

In general it seems like this is not the right solution at this location given that we are passing in a ClientContext that is not actually operating there at that moment. We should be passing in the actual client context that is operating.

The main confusion here is that, in general, a Transaction has a ClientContext associated with it - and the Transaction only exists while the ClientContext exists. However, because we store transactions after the client is done with them (in `recently_committed_transactions` and `old_transactions`) this is no longer the case during that window. I think this is not very intuitive from a code perspective.

I would propose reworking this so that we are not storing a `DuckTransaction` in these places, but instead storing only the relevant components of that transaction (i.e. the `UndoBuffer`). We can then rework `Transaction` to no longer have a `weak_ptr<ClientContext>` but to just have a `ClientContext &` - as the transaction will only be alive while the ClientContext itself is alive and is not kept around past the lifetime of its parent connection. 
