### PR TITLE
Internal #6210: IEJoin Threading

### DIFF
--- a/src/include/duckdb/execution/operator/join/physical_iejoin.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_iejoin.hpp
@@ -70,10 +70,6 @@ public:
 
 public:
 	void BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline) override;
-
-private:
-	// resolve joins that can potentially output N*M elements (INNER, LEFT, FULL)
-	void ResolveComplexJoin(ExecutionContext &context, DataChunk &result, LocalSourceState &state) const;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
* Move the result generation to task methods in IEJoinLocalSourceState
* Add the usual blocking state management.

fixes: duckdblabs/duckdb-internal#6210
