### PR TITLE
Throw if non-`VARCHAR` key is passed to `json_object`

### DIFF
--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -111,11 +111,10 @@ static unique_ptr<FunctionData> JSONCreateBindParams(ScalarFunction &bound_funct
 		auto &type = arguments[i]->return_type;
 		if (arguments[i]->HasParameter()) {
 			throw ParameterNotResolvedException();
-		} else if (type == LogicalTypeId::SQLNULL) {
-			// This is needed for macro's
-			bound_function.arguments.push_back(type);
 		} else if (object && i % 2 == 0) {
-			// Key, must be varchar
+			if (type != LogicalType::VARCHAR) {
+				throw BinderException("json_object() keys must be VARCHAR");
+			}
 			bound_function.arguments.push_back(LogicalType::VARCHAR);
 		} else {
 			// Value, cast to types that we can put in JSON
@@ -128,7 +127,7 @@ static unique_ptr<FunctionData> JSONCreateBindParams(ScalarFunction &bound_funct
 static unique_ptr<FunctionData> JSONObjectBind(ClientContext &context, ScalarFunction &bound_function,
                                                vector<unique_ptr<Expression>> &arguments) {
 	if (arguments.size() % 2 != 0) {
-		throw InvalidInputException("json_object() requires an even number of arguments");
+		throw BinderException("json_object() requires an even number of arguments");
 	}
 	return JSONCreateBindParams(bound_function, arguments, true);
 }
@@ -141,7 +140,7 @@ static unique_ptr<FunctionData> JSONArrayBind(ClientContext &context, ScalarFunc
 static unique_ptr<FunctionData> ToJSONBind(ClientContext &context, ScalarFunction &bound_function,
                                            vector<unique_ptr<Expression>> &arguments) {
 	if (arguments.size() != 1) {
-		throw InvalidInputException("to_json() takes exactly one argument");
+		throw BinderException("to_json() takes exactly one argument");
 	}
 	return JSONCreateBindParams(bound_function, arguments, false);
 }
@@ -149,14 +148,14 @@ static unique_ptr<FunctionData> ToJSONBind(ClientContext &context, ScalarFunctio
 static unique_ptr<FunctionData> ArrayToJSONBind(ClientContext &context, ScalarFunction &bound_function,
                                                 vector<unique_ptr<Expression>> &arguments) {
 	if (arguments.size() != 1) {
-		throw InvalidInputException("array_to_json() takes exactly one argument");
+		throw BinderException("array_to_json() takes exactly one argument");
 	}
 	auto arg_id = arguments[0]->return_type.id();
 	if (arguments[0]->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
 	if (arg_id != LogicalTypeId::LIST && arg_id != LogicalTypeId::SQLNULL) {
-		throw InvalidInputException("array_to_json() argument type must be LIST");
+		throw BinderException("array_to_json() argument type must be LIST");
 	}
 	return JSONCreateBindParams(bound_function, arguments, false);
 }
@@ -164,14 +163,14 @@ static unique_ptr<FunctionData> ArrayToJSONBind(ClientContext &context, ScalarFu
 static unique_ptr<FunctionData> RowToJSONBind(ClientContext &context, ScalarFunction &bound_function,
                                               vector<unique_ptr<Expression>> &arguments) {
 	if (arguments.size() != 1) {
-		throw InvalidInputException("row_to_json() takes exactly one argument");
+		throw BinderException("row_to_json() takes exactly one argument");
 	}
 	auto arg_id = arguments[0]->return_type.id();
 	if (arguments[0]->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
 	if (arguments[0]->return_type.id() != LogicalTypeId::STRUCT && arg_id != LogicalTypeId::SQLNULL) {
-		throw InvalidInputException("row_to_json() argument type must be STRUCT");
+		throw BinderException("row_to_json() argument type must be STRUCT");
 	}
 	return JSONCreateBindParams(bound_function, arguments, false);
 }

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -113,7 +113,8 @@ static unique_ptr<FunctionData> JSONCreateBindParams(ScalarFunction &bound_funct
 			throw ParameterNotResolvedException();
 		} else if (object && i % 2 == 0) {
 			if (type != LogicalType::VARCHAR) {
-				throw BinderException("json_object() keys must be VARCHAR");
+				throw BinderException("json_object() keys must be VARCHAR, add an explicit cast to argument \"%s\"",
+				                      arguments[i]->GetName());
 			}
 			bound_function.arguments.push_back(LogicalType::VARCHAR);
 		} else {

--- a/test/sql/json/issues/issue19357.test
+++ b/test/sql/json/issues/issue19357.test
@@ -1,0 +1,20 @@
+# name: test/sql/json/issues/issue19357.test
+# description: Test issue 19357 - Expected unified vector format of type VARCHAR, but found type INT32
+# group: [issues]
+
+require json
+
+query I
+SELECT TO_JSON({'key_1': 'one'}) AS WITHOUT_KEEP_NULL
+----
+{"key_1":"one"}
+
+query I
+SELECT JSON_OBJECT('key_1', 'one', 'key_2', NULL) AS KEEP_NULL_1
+----
+{"key_1":"one","key_2":null}
+
+statement error
+SELECT JSON_OBJECT('key_1', 'one', NULL, 'two') AS KEEP_NULL_2
+----
+json_object() keys must be VARCHAR

--- a/test/sql/json/scalar/test_json_create.test
+++ b/test/sql/json/scalar/test_json_create.test
@@ -27,7 +27,7 @@ select to_json({n: 42})
 statement error
 select to_json({n: 42}, {extra: 'argument'})
 ----
-Invalid Input Error: to_json() takes exactly one argument
+to_json() takes exactly one argument
 
 query T
 select to_json(union_value(n := 42))
@@ -141,7 +141,7 @@ select json_array(a, b, c, d, e) from test
 [-777,4.2,"goose",[4,2],null]
 
 query T
-select json_object(a, a, b, b, c, c, d, d, e, e) from test
+select json_object(a::varchar, a, b::varchar, b, c, c, d::varchar, d, e::varchar, e) from test
 ----
 {"0":0,"0.5":0.5,"short":"short","[0, 1, 2, 3, 4, 5, 6, 7, 9]":[0,1,2,3,4,5,6,7,9],"33":33}
 {"42":42,"1.0":1.0,"looooooooooooooong":"looooooooooooooong","[]":[],"42":42}


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/19357

Now throws (just like SQLite3, which we copied the function from). Also changes some `InvalidInputException`s to `BinderException`s, as they happen in the binder.