### PR TITLE
Destroy TaskNotifier prior to calling FinishTask

### DIFF
--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -69,8 +69,10 @@ TaskExecutionResult BaseExecutorTask::Execute(TaskExecutionMode mode) {
 		return TaskExecutionResult::TASK_FINISHED;
 	}
 	try {
-		TaskNotifier task_notifier {executor.context};
-		ExecuteTask();
+		{
+			TaskNotifier task_notifier {executor.context};
+			ExecuteTask();
+		}
 		executor.FinishTask();
 		return TaskExecutionResult::TASK_FINISHED;
 	} catch (std::exception &ex) {


### PR DESCRIPTION
This fixes a rare race condition when destroying a Connection while there are active tasks for that connection. When a connection is destroyed, all tasks for that connection are cleaned up. This is done through notifications from `Executor::FinishTask`. In the current implementation, we first notify the executor the task is finished, and then destroy the TaskNotifier triggering it to notify any registered ClientContextStates. However, these live in the Connection. By destroying the TaskNotifier first we ensure the client is still around at that point.