### PR TITLE
Add system libraries to clang-tidy on macOS which allows it to run.

### DIFF
--- a/scripts/clang-tidy-diff.py
+++ b/scripts/clang-tidy-diff.py
@@ -317,7 +317,7 @@ def main():
     if args.allow_no_checks:
         common_clang_tidy_args.append("--allow-no-checks")
     for arg in args.extra_arg:
-        common_clang_tidy_args.append("-extra-arg=%s" % arg)
+        common_clang_tidy_args.append("--extra-arg=%s" % arg)
     for arg in args.extra_arg_before:
         common_clang_tidy_args.append("-extra-arg-before=%s" % arg)
     for plugin in args.plugins:

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -95,7 +95,7 @@ def get_tidy_invocation(
         os.close(handle)
         start.append(name)
     for arg in extra_arg:
-        start.append('-extra-arg=%s' % arg)
+        start.append('--extra-arg=%s' % arg)
     for arg in extra_arg_before:
         start.append('-extra-arg-before=%s' % arg)
     start.append('-p=' + build_path)


### PR DESCRIPTION
Addresses #18613.

Running clang-tidy fails on mac because system libraries are not found, leading to errors as shown in the linked issue. This dynamically injects those system paths to the clang-tidy Python scripts, and also fixes the Python scripts to use the correct switches to forward them (`--` instead of `-`). This enables mac developers to not need a Linux box to run clang-tidy before pushing up a PR.

As a follow-up, I can document installation of llvm/clang-tidy for mac devs as well.