### PR TITLE
Avoid calling shared_from_this() and instead use the passed in ClientContext in buffered data

### DIFF
--- a/src/execution/operator/helper/physical_buffered_batch_collector.cpp
+++ b/src/execution/operator/helper/physical_buffered_batch_collector.cpp
@@ -94,7 +94,7 @@ unique_ptr<LocalSinkState> PhysicalBufferedBatchCollector::GetLocalSinkState(Exe
 unique_ptr<GlobalSinkState> PhysicalBufferedBatchCollector::GetGlobalSinkState(ClientContext &context) const {
 	auto state = make_uniq<BufferedBatchCollectorGlobalState>();
 	state->context = context.shared_from_this();
-	state->buffered_data = make_shared_ptr<BatchedBufferedData>(state->context);
+	state->buffered_data = make_shared_ptr<BatchedBufferedData>(context);
 	return std::move(state);
 }
 

--- a/src/execution/operator/helper/physical_buffered_collector.cpp
+++ b/src/execution/operator/helper/physical_buffered_collector.cpp
@@ -48,7 +48,7 @@ SinkCombineResultType PhysicalBufferedCollector::Combine(ExecutionContext &conte
 unique_ptr<GlobalSinkState> PhysicalBufferedCollector::GetGlobalSinkState(ClientContext &context) const {
 	auto state = make_uniq<BufferedCollectorGlobalState>();
 	state->context = context.shared_from_this();
-	state->buffered_data = make_shared_ptr<SimpleBufferedData>(state->context);
+	state->buffered_data = make_shared_ptr<SimpleBufferedData>(context);
 	return std::move(state);
 }
 

--- a/src/include/duckdb/main/buffered_data/batched_buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/batched_buffered_data.hpp
@@ -32,7 +32,7 @@ public:
 	static constexpr const BufferedData::Type TYPE = BufferedData::Type::BATCHED;
 
 public:
-	explicit BatchedBufferedData(weak_ptr<ClientContext> context);
+	explicit BatchedBufferedData(ClientContext &context);
 
 public:
 	void Append(const DataChunk &chunk, idx_t batch);

--- a/src/include/duckdb/main/buffered_data/buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/buffered_data.hpp
@@ -28,7 +28,7 @@ protected:
 	enum class Type { SIMPLE, BATCHED };
 
 public:
-	BufferedData(Type type, weak_ptr<ClientContext> context_p);
+	BufferedData(Type type, ClientContext &context);
 	virtual ~BufferedData();
 
 public:

--- a/src/include/duckdb/main/buffered_data/simple_buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/simple_buffered_data.hpp
@@ -24,7 +24,7 @@ public:
 	static constexpr const BufferedData::Type TYPE = BufferedData::Type::SIMPLE;
 
 public:
-	explicit SimpleBufferedData(weak_ptr<ClientContext> context);
+	explicit SimpleBufferedData(ClientContext &context);
 	~SimpleBufferedData() override;
 
 public:

--- a/src/main/buffered_data/batched_buffered_data.cpp
+++ b/src/main/buffered_data/batched_buffered_data.cpp
@@ -14,9 +14,8 @@ void BatchedBufferedData::BlockSink(const InterruptState &blocked_sink, idx_t ba
 	blocked_sinks.emplace(batch, blocked_sink);
 }
 
-BatchedBufferedData::BatchedBufferedData(weak_ptr<ClientContext> context)
-    : BufferedData(BufferedData::Type::BATCHED, std::move(context)), buffer_byte_count(0), read_queue_byte_count(0),
-      min_batch(0) {
+BatchedBufferedData::BatchedBufferedData(ClientContext &context)
+    : BufferedData(BufferedData::Type::BATCHED, context), buffer_byte_count(0), read_queue_byte_count(0), min_batch(0) {
 	read_queue_capacity = (idx_t)(static_cast<double>(total_buffer_size) * 0.6);
 	buffer_capacity = (idx_t)(static_cast<double>(total_buffer_size) * 0.4);
 }

--- a/src/main/buffered_data/buffered_data.cpp
+++ b/src/main/buffered_data/buffered_data.cpp
@@ -4,9 +4,8 @@
 
 namespace duckdb {
 
-BufferedData::BufferedData(Type type, weak_ptr<ClientContext> context_p) : type(type), context(std::move(context_p)) {
-	auto client_context = context.lock();
-	auto &config = ClientConfig::GetConfig(*client_context);
+BufferedData::BufferedData(Type type, ClientContext &context_p) : type(type), context(context_p.shared_from_this()) {
+	auto &config = ClientConfig::GetConfig(context_p);
 	total_buffer_size = config.streaming_buffer_size;
 }
 

--- a/src/main/buffered_data/simple_buffered_data.cpp
+++ b/src/main/buffered_data/simple_buffered_data.cpp
@@ -6,8 +6,7 @@
 
 namespace duckdb {
 
-SimpleBufferedData::SimpleBufferedData(weak_ptr<ClientContext> context)
-    : BufferedData(BufferedData::Type::SIMPLE, std::move(context)) {
+SimpleBufferedData::SimpleBufferedData(ClientContext &context) : BufferedData(BufferedData::Type::SIMPLE, context) {
 	buffered_count = 0;
 	buffer_size = total_buffer_size;
 }


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/6234

When running the `ClientContext` destructor, we cancel all pending tasks that are scheduled for execution for that client. This is required because tasks generally access the ClientContext all over.

This works just fine - except that we are in a fun situation in a destructor. While the `ClientContext` is still valid and can be used as normal - `weak_ptr.lock()` returns `nullptr`. That is because [in order to construct a valid shared_ptr, we need the object to be alive, and that is not the case while it is being destroyed](https://stackoverflow.com/questions/28338978/stdenable-shared-from-this-is-it-allowed-to-call-shared-from-this-in-destru). As a result, we could rarely run into a `Attempted to dereference shared_ptr that is NULL` error in the result collection code as that would call `weak_ptr.lock()` followed by accessing the ClientContext. 

This PR fixes that issue by instead using the ClientContext that is passed in directly. 