### PR TITLE
`old_transactions` is no longer necessary

### DIFF
--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -35,14 +35,12 @@ public:
 	transaction_t transaction_id;
 	//! The commit id of this transaction, if it has successfully been committed
 	transaction_t commit_id;
-	//! Highest active query when the transaction finished, used for cleaning up
-	transaction_t highest_active_query;
 
 	atomic<idx_t> catalog_version;
 
 	//! Transactions undergo Cleanup, after (1) removing them directly in RemoveTransaction,
-	//! or (2) after they exist old_transactions.
-	//! Some (after rollback) enter old_transactions, but do not require Cleanup.
+	//! or (2) after they enter cleanup_queue.
+	//! Some (after rollback) enter cleanup_queue, but do not require Cleanup.
 	bool awaiting_cleanup;
 
 public:

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -110,8 +110,6 @@ private:
 	vector<unique_ptr<DuckTransaction>> active_transactions;
 	//! Set of recently committed transactions
 	vector<unique_ptr<DuckTransaction>> recently_committed_transactions;
-	//! Transactions awaiting GC
-	vector<unique_ptr<DuckTransaction>> old_transactions;
 	//! The lock used for transaction operations
 	mutex transaction_lock;
 	//! The checkpoint lock

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -32,8 +32,8 @@ TransactionData::TransactionData(transaction_t transaction_id_p, transaction_t s
 DuckTransaction::DuckTransaction(DuckTransactionManager &manager, ClientContext &context_p, transaction_t start_time,
                                  transaction_t transaction_id, idx_t catalog_version_p)
     : Transaction(manager, context_p), start_time(start_time), transaction_id(transaction_id), commit_id(0),
-      highest_active_query(0), catalog_version(catalog_version_p), awaiting_cleanup(false),
-      transaction_manager(manager), undo_buffer(*this, context_p), storage(make_uniq<LocalStorage>(context_p, *this)) {
+      catalog_version(catalog_version_p), awaiting_cleanup(false), transaction_manager(manager),
+      undo_buffer(*this, context_p), storage(make_uniq<LocalStorage>(context_p, *this)) {
 }
 
 DuckTransaction::~DuckTransaction() {

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -324,7 +324,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	}
 
 	// We do not need to hold the transaction lock during cleanup of transactions,
-	// as they (1) have been removed, or (2) exited old_transactions.
+	// as they (1) have been removed, or (2) enter cleanup_info.
 	t_lock.unlock();
 
 	{
@@ -412,7 +412,6 @@ unique_ptr<DuckCleanupInfo> DuckTransactionManager::RemoveTransaction(DuckTransa
 	idx_t t_index = active_transactions.size();
 	auto lowest_start_time = TRANSACTION_ID_START;
 	auto lowest_transaction_id = MAX_TRANSACTION_ID;
-	auto lowest_active_query = MAXIMUM_QUERY_ID;
 	for (idx_t i = 0; i < active_transactions.size(); i++) {
 		if (active_transactions[i].get() == &transaction) {
 			t_index = i;
@@ -420,8 +419,6 @@ unique_ptr<DuckCleanupInfo> DuckTransactionManager::RemoveTransaction(DuckTransa
 		}
 		lowest_start_time = MinValue(lowest_start_time, active_transactions[i]->start_time);
 		lowest_transaction_id = MinValue(lowest_transaction_id, active_transactions[i]->transaction_id);
-		transaction_t active_query = active_transactions[i]->active_query;
-		lowest_active_query = MinValue(lowest_active_query, active_query);
 	}
 	lowest_active_start = lowest_start_time;
 	lowest_active_id = lowest_transaction_id;
@@ -430,7 +427,6 @@ unique_ptr<DuckCleanupInfo> DuckTransactionManager::RemoveTransaction(DuckTransa
 
 	// Decide if we need to store the transaction, or if we can schedule it for cleanup.
 	auto current_transaction = std::move(active_transactions[t_index]);
-	auto current_query = DatabaseManager::Get(db).ActiveQueryNumber();
 	if (store_transaction) {
 		// If the transaction made any changes, we need to keep it around.
 		if (transaction.commit_id != 0) {
@@ -439,9 +435,7 @@ unique_ptr<DuckCleanupInfo> DuckTransactionManager::RemoveTransaction(DuckTransa
 			recently_committed_transactions.push_back(std::move(current_transaction));
 		} else {
 			// The transaction was aborted.
-			// We might still need its information; add it to the set of transactions awaiting GC.
-			current_transaction->highest_active_query = current_query;
-			old_transactions.push_back(std::move(current_transaction));
+			cleanup_info->transactions.push_back(std::move(current_transaction));
 		}
 	} else if (transaction.ChangesMade()) {
 		// We do not need to store the transaction, directly schedule it for cleanup.
@@ -466,18 +460,8 @@ unique_ptr<DuckCleanupInfo> DuckTransactionManager::RemoveTransaction(DuckTransa
 			break;
 		}
 
-		// Changes made BEFORE this transaction are no longer relevant.
-		// We can schedule the transaction and its undo buffer for cleanup.
 		recently_committed_transactions[i]->awaiting_cleanup = true;
-
-		// HOWEVER: Any currently running QUERY can still be using
-		// the version information of the transaction.
-		// If we remove the UndoBuffer immediately, we have a race condition.
-
-		// Store the current highest active query.
-		recently_committed_transactions[i]->highest_active_query = current_query;
-		// Move it to the list of transactions awaiting GC.
-		old_transactions.push_back(std::move(recently_committed_transactions[i]));
+		cleanup_info->transactions.push_back(std::move(recently_committed_transactions[i]));
 	}
 
 	if (i > 0) {
@@ -485,34 +469,6 @@ unique_ptr<DuckCleanupInfo> DuckTransactionManager::RemoveTransaction(DuckTransa
 		auto start = recently_committed_transactions.begin();
 		auto end = recently_committed_transactions.begin() + static_cast<int64_t>(i);
 		recently_committed_transactions.erase(start, end);
-	}
-
-	// Check if we can clean up and free the memory of any old transactions.
-	i = active_transactions.empty() ? old_transactions.size() : 0;
-	for (; i < old_transactions.size(); i++) {
-		D_ASSERT(old_transactions[i]);
-		D_ASSERT(old_transactions[i]->highest_active_query > 0);
-		if (old_transactions[i]->highest_active_query >= lowest_active_query) {
-			// There is still a query running that could be using
-			// this transactions' data.
-			break;
-		}
-	}
-
-	if (i > 0) {
-		// We garbage-collected old transactions:
-		// - Remove them from the list and schedule them for cleanup.
-
-		// We can only safely do the actual memory cleanup when all the
-		// currently active queries have finished running! (actually,
-		// when all the currently active scans have finished running...).
-
-		// Because we clean up asynchronously, we only clean up once we
-		// no longer need the transaction for anything (i.e., we can move it).
-		for (idx_t t_idx = 0; t_idx < i; t_idx++) {
-			cleanup_info->transactions.push_back(std::move(old_transactions[t_idx]));
-		}
-		old_transactions.erase(old_transactions.begin(), old_transactions.begin() + static_cast<int64_t>(i));
 	}
 
 	return cleanup_info;


### PR DESCRIPTION
See https://github.com/duckdb/duckdb/discussions/19335 for detail.

Currently, all functions that access or modify the `UpdateInfo` chain acquire a read or write lock on `UpdateSegment::lock`. Therefore, an Active Query traversing the `UpdateInfo` chain is now mutually exclusive with `UpdateSegment::CleanupUpdate`. Therefore, `old_transactions` is no longer necessary.