### PR TITLE
[Dev] Add a `VARIANT` visitor class

### DIFF
--- a/src/function/cast/variant/to_json.cpp
+++ b/src/function/cast/variant/to_json.cpp
@@ -36,58 +36,6 @@ struct JSONConverter {
 		throw InternalException("JSONConverter::VisitInteger not implemented!");
 	}
 
-	template <>
-	yyjson_mut_val *VisitInteger<int8_t>(int8_t val, yyjson_mut_doc *doc) {
-		return yyjson_mut_sint(doc, val);
-	}
-
-	template <>
-	yyjson_mut_val *VisitInteger<int16_t>(int16_t val, yyjson_mut_doc *doc) {
-		return yyjson_mut_sint(doc, val);
-	}
-
-	template <>
-	yyjson_mut_val *VisitInteger<int32_t>(int32_t val, yyjson_mut_doc *doc) {
-		return yyjson_mut_sint(doc, val);
-	}
-
-	template <>
-	yyjson_mut_val *VisitInteger<int64_t>(int64_t val, yyjson_mut_doc *doc) {
-		return yyjson_mut_sint(doc, val);
-	}
-
-	template <>
-	yyjson_mut_val *VisitInteger<hugeint_t>(hugeint_t val, yyjson_mut_doc *doc) {
-		auto val_str = val.ToString();
-		return yyjson_mut_rawncpy(doc, val_str.c_str(), val_str.size());
-	}
-
-	template <>
-	yyjson_mut_val *VisitInteger<uint8_t>(uint8_t val, yyjson_mut_doc *doc) {
-		return yyjson_mut_sint(doc, val);
-	}
-
-	template <>
-	yyjson_mut_val *VisitInteger<uint16_t>(uint16_t val, yyjson_mut_doc *doc) {
-		return yyjson_mut_sint(doc, val);
-	}
-
-	template <>
-	yyjson_mut_val *VisitInteger<uint32_t>(uint32_t val, yyjson_mut_doc *doc) {
-		return yyjson_mut_sint(doc, val);
-	}
-
-	template <>
-	yyjson_mut_val *VisitInteger<uint64_t>(uint64_t val, yyjson_mut_doc *doc) {
-		return yyjson_mut_uint(doc, val);
-	}
-
-	template <>
-	yyjson_mut_val *VisitInteger<uhugeint_t>(uhugeint_t val, yyjson_mut_doc *doc) {
-		auto val_str = val.ToString();
-		return yyjson_mut_rawncpy(doc, val_str.c_str(), val_str.size());
-	}
-
 	static yyjson_mut_val *VisitTime(dtime_t val, yyjson_mut_doc *doc) {
 		auto val_str = Time::ToString(val);
 		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
@@ -216,6 +164,58 @@ struct JSONConverter {
 		throw InternalException("VariantLogicalType(%s) not handled", EnumUtil::ToString(type_id));
 	}
 };
+
+template <>
+yyjson_mut_val *JSONConverter::VisitInteger<int8_t>(int8_t val, yyjson_mut_doc *doc) {
+	return yyjson_mut_sint(doc, val);
+}
+
+template <>
+yyjson_mut_val *JSONConverter::VisitInteger<int16_t>(int16_t val, yyjson_mut_doc *doc) {
+	return yyjson_mut_sint(doc, val);
+}
+
+template <>
+yyjson_mut_val *JSONConverter::VisitInteger<int32_t>(int32_t val, yyjson_mut_doc *doc) {
+	return yyjson_mut_sint(doc, val);
+}
+
+template <>
+yyjson_mut_val *JSONConverter::VisitInteger<int64_t>(int64_t val, yyjson_mut_doc *doc) {
+	return yyjson_mut_sint(doc, val);
+}
+
+template <>
+yyjson_mut_val *JSONConverter::VisitInteger<hugeint_t>(hugeint_t val, yyjson_mut_doc *doc) {
+	auto val_str = val.ToString();
+	return yyjson_mut_rawncpy(doc, val_str.c_str(), val_str.size());
+}
+
+template <>
+yyjson_mut_val *JSONConverter::VisitInteger<uint8_t>(uint8_t val, yyjson_mut_doc *doc) {
+	return yyjson_mut_sint(doc, val);
+}
+
+template <>
+yyjson_mut_val *JSONConverter::VisitInteger<uint16_t>(uint16_t val, yyjson_mut_doc *doc) {
+	return yyjson_mut_sint(doc, val);
+}
+
+template <>
+yyjson_mut_val *JSONConverter::VisitInteger<uint32_t>(uint32_t val, yyjson_mut_doc *doc) {
+	return yyjson_mut_sint(doc, val);
+}
+
+template <>
+yyjson_mut_val *JSONConverter::VisitInteger<uint64_t>(uint64_t val, yyjson_mut_doc *doc) {
+	return yyjson_mut_uint(doc, val);
+}
+
+template <>
+yyjson_mut_val *JSONConverter::VisitInteger<uhugeint_t>(uhugeint_t val, yyjson_mut_doc *doc) {
+	auto val_str = val.ToString();
+	return yyjson_mut_rawncpy(doc, val_str.c_str(), val_str.size());
+}
 
 } // namespace
 

--- a/src/function/cast/variant/to_json.cpp
+++ b/src/function/cast/variant/to_json.cpp
@@ -32,7 +32,9 @@ struct JSONConverter {
 	}
 
 	template <typename T>
-	static yyjson_mut_val *VisitInteger(T val, yyjson_mut_doc *doc);
+	static yyjson_mut_val *VisitInteger(T val, yyjson_mut_doc *doc) {
+		throw InternalException("JSONConverter::VisitInteger not implemented!");
+	}
 
 	template <>
 	yyjson_mut_val *VisitInteger<int8_t>(int8_t val, yyjson_mut_doc *doc) {

--- a/src/function/cast/variant/to_json.cpp
+++ b/src/function/cast/variant/to_json.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/common/types/decimal.hpp"
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/variant_visitor.hpp"
 
 using namespace duckdb_yyjson; // NOLINT
 
@@ -17,262 +18,209 @@ namespace duckdb {
 
 //! ------------ Variant -> JSON ------------
 
-yyjson_mut_val *VariantCasts::ConvertVariantToJSON(yyjson_mut_doc *doc, const RecursiveUnifiedVectorFormat &source,
-                                                   idx_t row, uint32_t values_idx) {
-	auto index = source.unified.sel->get_index(row);
-	if (!source.unified.validity.RowIsValid(index)) {
+namespace {
+
+struct JSONConverter {
+	using result_type = yyjson_mut_val *;
+
+	static yyjson_mut_val *VisitNull(yyjson_mut_doc *doc) {
 		return yyjson_mut_null(doc);
 	}
 
-	//! values
-	auto &values = UnifiedVariantVector::GetValues(source);
-	auto values_data = values.GetData<list_entry_t>(values);
+	static yyjson_mut_val *VisitBoolean(bool val, yyjson_mut_doc *doc) {
+		return val ? yyjson_mut_true(doc) : yyjson_mut_false(doc);
+	}
 
-	//! type_ids
-	auto &type_ids = UnifiedVariantVector::GetValuesTypeId(source);
-	auto type_ids_data = type_ids.GetData<uint8_t>(type_ids);
+	template <typename T>
+	static yyjson_mut_val *VisitInteger(T val, yyjson_mut_doc *doc);
 
-	//! byte_offsets
-	auto &byte_offsets = UnifiedVariantVector::GetValuesByteOffset(source);
-	auto byte_offsets_data = byte_offsets.GetData<uint32_t>(byte_offsets);
-
-	//! children
-	auto &children = UnifiedVariantVector::GetChildren(source);
-	auto children_data = children.GetData<list_entry_t>(children);
-
-	//! values_index
-	auto &values_index = UnifiedVariantVector::GetChildrenValuesIndex(source);
-	auto values_index_data = values_index.GetData<uint32_t>(values_index);
-
-	//! keys_index
-	auto &keys_index = UnifiedVariantVector::GetChildrenKeysIndex(source);
-	auto keys_index_data = keys_index.GetData<uint32_t>(keys_index);
-
-	//! keys
-	auto &keys = UnifiedVariantVector::GetKeys(source);
-	auto keys_data = keys.GetData<list_entry_t>(keys);
-	auto &keys_entry = UnifiedVariantVector::GetKeysEntry(source);
-	auto keys_entry_data = keys_entry.GetData<string_t>(keys_entry);
-
-	//! list entries
-	auto keys_list_entry = keys_data[keys.sel->get_index(row)];
-	auto children_list_entry = children_data[children.sel->get_index(row)];
-	auto values_list_entry = values_data[values.sel->get_index(row)];
-
-	//! The 'values' data of the value we're currently converting
-	values_idx += values_list_entry.offset;
-	auto type_id = static_cast<VariantLogicalType>(type_ids_data[type_ids.sel->get_index(values_idx)]);
-	auto byte_offset = byte_offsets_data[byte_offsets.sel->get_index(values_idx)];
-
-	//! The blob data of the Variant, accessed by byte offset retrieved above ^
-	auto &value = UnifiedVariantVector::GetData(source);
-	auto value_data = value.GetData<string_t>(value);
-	auto &blob = value_data[value.sel->get_index(row)];
-	auto blob_data = const_data_ptr_cast(blob.GetData());
-
-	auto ptr = const_data_ptr_cast(blob_data + byte_offset);
-	switch (type_id) {
-	case VariantLogicalType::VARIANT_NULL:
-		return yyjson_mut_null(doc);
-	case VariantLogicalType::BOOL_TRUE:
-		return yyjson_mut_true(doc);
-	case VariantLogicalType::BOOL_FALSE:
-		return yyjson_mut_false(doc);
-	case VariantLogicalType::INT8: {
-		auto val = Load<int8_t>(ptr);
+	template <>
+	yyjson_mut_val *VisitInteger<int8_t>(int8_t val, yyjson_mut_doc *doc) {
 		return yyjson_mut_sint(doc, val);
 	}
-	case VariantLogicalType::INT16: {
-		auto val = Load<int16_t>(ptr);
+
+	template <>
+	yyjson_mut_val *VisitInteger<int16_t>(int16_t val, yyjson_mut_doc *doc) {
 		return yyjson_mut_sint(doc, val);
 	}
-	case VariantLogicalType::INT32: {
-		auto val = Load<int32_t>(ptr);
+
+	template <>
+	yyjson_mut_val *VisitInteger<int32_t>(int32_t val, yyjson_mut_doc *doc) {
 		return yyjson_mut_sint(doc, val);
 	}
-	case VariantLogicalType::INT64: {
-		auto val = Load<int64_t>(ptr);
+
+	template <>
+	yyjson_mut_val *VisitInteger<int64_t>(int64_t val, yyjson_mut_doc *doc) {
 		return yyjson_mut_sint(doc, val);
 	}
-	case VariantLogicalType::INT128: {
-		auto val = Load<hugeint_t>(ptr);
+
+	template <>
+	yyjson_mut_val *VisitInteger<hugeint_t>(hugeint_t val, yyjson_mut_doc *doc) {
 		auto val_str = val.ToString();
 		return yyjson_mut_rawncpy(doc, val_str.c_str(), val_str.size());
 	}
-	case VariantLogicalType::UINT8: {
-		auto val = Load<uint8_t>(ptr);
+
+	template <>
+	yyjson_mut_val *VisitInteger<uint8_t>(uint8_t val, yyjson_mut_doc *doc) {
 		return yyjson_mut_sint(doc, val);
 	}
-	case VariantLogicalType::UINT16: {
-		auto val = Load<uint16_t>(ptr);
+
+	template <>
+	yyjson_mut_val *VisitInteger<uint16_t>(uint16_t val, yyjson_mut_doc *doc) {
 		return yyjson_mut_sint(doc, val);
 	}
-	case VariantLogicalType::UINT32: {
-		auto val = Load<uint32_t>(ptr);
+
+	template <>
+	yyjson_mut_val *VisitInteger<uint32_t>(uint32_t val, yyjson_mut_doc *doc) {
 		return yyjson_mut_sint(doc, val);
 	}
-	case VariantLogicalType::UINT64: {
-		auto val = Load<uint64_t>(ptr);
+
+	template <>
+	yyjson_mut_val *VisitInteger<uint64_t>(uint64_t val, yyjson_mut_doc *doc) {
 		return yyjson_mut_uint(doc, val);
 	}
-	case VariantLogicalType::UINT128: {
-		auto val = Load<uhugeint_t>(ptr);
-		auto val_str = val.ToString();
-		return yyjson_mut_rawncpy(doc, val_str.c_str(), val_str.size());
-	}
-	case VariantLogicalType::UUID: {
-		auto val = Value::UUID(Load<hugeint_t>(ptr));
-		auto val_str = val.ToString();
-		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
-	}
-	case VariantLogicalType::INTERVAL: {
-		auto val = Value::INTERVAL(Load<interval_t>(ptr));
-		auto val_str = val.ToString();
-		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
-	}
-	case VariantLogicalType::FLOAT: {
-		auto val = Load<float>(ptr);
-		return yyjson_mut_real(doc, val);
-	}
-	case VariantLogicalType::DOUBLE: {
-		auto val = Load<double>(ptr);
-		return yyjson_mut_real(doc, val);
-	}
-	case VariantLogicalType::DATE: {
-		auto val = Load<int32_t>(ptr);
-		auto val_str = Date::ToString(date_t(val));
-		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
-	}
-	case VariantLogicalType::BLOB: {
-		auto string_length = VarintDecode<uint32_t>(ptr);
-		auto string_data = reinterpret_cast<const char *>(ptr);
-		auto val_str = Value::BLOB(const_data_ptr_cast(string_data), string_length).ToString();
-		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
-	}
-	case VariantLogicalType::GEOMETRY: {
-		auto string_length = VarintDecode<uint32_t>(ptr);
-		auto string_data = reinterpret_cast<const char *>(ptr);
-		auto val_str = Value::GEOMETRY(const_data_ptr_cast(string_data), string_length).ToString();
-		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
-	}
-	case VariantLogicalType::VARCHAR: {
-		auto string_length = VarintDecode<uint32_t>(ptr);
-		auto string_data = reinterpret_cast<const char *>(ptr);
-		return yyjson_mut_strncpy(doc, string_data, static_cast<size_t>(string_length));
-	}
-	case VariantLogicalType::DECIMAL: {
-		auto width = NumericCast<uint8_t>(VarintDecode<idx_t>(ptr));
-		auto scale = NumericCast<uint8_t>(VarintDecode<idx_t>(ptr));
 
-		string val_str;
-		if (width > DecimalWidth<int64_t>::max) {
-			val_str = Decimal::ToString(Load<hugeint_t>(ptr), width, scale);
-		} else if (width > DecimalWidth<int32_t>::max) {
-			val_str = Decimal::ToString(Load<int64_t>(ptr), width, scale);
-		} else if (width > DecimalWidth<int16_t>::max) {
-			val_str = Decimal::ToString(Load<int32_t>(ptr), width, scale);
-		} else {
-			val_str = Decimal::ToString(Load<int16_t>(ptr), width, scale);
-		}
+	template <>
+	yyjson_mut_val *VisitInteger<uhugeint_t>(uhugeint_t val, yyjson_mut_doc *doc) {
+		auto val_str = val.ToString();
 		return yyjson_mut_rawncpy(doc, val_str.c_str(), val_str.size());
 	}
-	case VariantLogicalType::TIME_MICROS: {
-		auto val = Load<dtime_t>(ptr);
+
+	static yyjson_mut_val *VisitTime(dtime_t val, yyjson_mut_doc *doc) {
 		auto val_str = Time::ToString(val);
 		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
 	}
-	case VariantLogicalType::TIME_MICROS_TZ: {
-		auto val = Value::TIMETZ(Load<dtime_tz_t>(ptr));
-		auto val_str = val.ToString();
+
+	static yyjson_mut_val *VisitTimeNanos(dtime_ns_t val, yyjson_mut_doc *doc) {
+		auto val_str = Value::TIME_NS(val).ToString();
 		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
 	}
-	case VariantLogicalType::TIMESTAMP_MICROS: {
-		auto val = Load<timestamp_t>(ptr);
+
+	static yyjson_mut_val *VisitTimeTZ(dtime_tz_t val, yyjson_mut_doc *doc) {
+		auto val_str = Value::TIMETZ(val).ToString();
+		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
+	}
+
+	static yyjson_mut_val *VisitTimestampSec(timestamp_sec_t val, yyjson_mut_doc *doc) {
+		auto val_str = Value::TIMESTAMPSEC(val).ToString();
+		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
+	}
+
+	static yyjson_mut_val *VisitTimestampMs(timestamp_ms_t val, yyjson_mut_doc *doc) {
+		auto val_str = Value::TIMESTAMPMS(val).ToString();
+		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
+	}
+
+	static yyjson_mut_val *VisitTimestamp(timestamp_t val, yyjson_mut_doc *doc) {
 		auto val_str = Timestamp::ToString(val);
 		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
 	}
-	case VariantLogicalType::TIMESTAMP_SEC: {
-		auto val = Value::TIMESTAMPSEC(Load<timestamp_sec_t>(ptr));
-		auto val_str = val.ToString();
+
+	static yyjson_mut_val *VisitTimestampNanos(timestamp_ns_t val, yyjson_mut_doc *doc) {
+		auto val_str = Value::TIMESTAMPNS(val).ToString();
 		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
 	}
-	case VariantLogicalType::TIMESTAMP_NANOS: {
-		auto val = Value::TIMESTAMPNS(Load<timestamp_ns_t>(ptr));
-		auto val_str = val.ToString();
+
+	static yyjson_mut_val *VisitTimestampTZ(timestamp_tz_t val, yyjson_mut_doc *doc) {
+		auto val_str = Value::TIMESTAMPTZ(val).ToString();
 		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
 	}
-	case VariantLogicalType::TIMESTAMP_MILIS: {
-		auto val = Value::TIMESTAMPMS(Load<timestamp_ms_t>(ptr));
-		auto val_str = val.ToString();
+
+	static yyjson_mut_val *VisitFloat(float val, yyjson_mut_doc *doc) {
+		return yyjson_mut_real(doc, val);
+	}
+
+	static yyjson_mut_val *VisitDouble(double val, yyjson_mut_doc *doc) {
+		return yyjson_mut_real(doc, val);
+	}
+
+	static yyjson_mut_val *VisitUUID(hugeint_t val, yyjson_mut_doc *doc) {
+		auto val_str = Value::UUID(val).ToString();
 		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
 	}
-	case VariantLogicalType::TIMESTAMP_MICROS_TZ: {
-		auto val = Value::TIMESTAMPTZ(Load<timestamp_tz_t>(ptr));
-		auto val_str = val.ToString();
+
+	static yyjson_mut_val *VisitDate(date_t val, yyjson_mut_doc *doc) {
+		auto val_str = Date::ToString(val);
 		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
 	}
-	case VariantLogicalType::ARRAY: {
-		auto count = VarintDecode<uint32_t>(ptr);
-		auto arr = yyjson_mut_arr(doc);
-		if (!count) {
-			return arr;
+
+	static yyjson_mut_val *VisitInterval(interval_t val, yyjson_mut_doc *doc) {
+		auto val_str = Value::INTERVAL(val).ToString();
+		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
+	}
+
+	static yyjson_mut_val *VisitString(const string_t &str, yyjson_mut_doc *doc) {
+		return yyjson_mut_strncpy(doc, str.GetData(), str.GetSize());
+	}
+
+	static yyjson_mut_val *VisitBlob(const string_t &str, yyjson_mut_doc *doc) {
+		auto val_str = Value::BLOB(const_data_ptr_cast(str.GetData()), str.GetSize()).ToString();
+		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
+	}
+
+	static yyjson_mut_val *VisitBignum(const string_t &str, yyjson_mut_doc *doc) {
+		auto val_str = Value::BIGNUM(const_data_ptr_cast(str.GetData()), str.GetSize()).ToString();
+		return yyjson_mut_rawncpy(doc, val_str.c_str(), val_str.size());
+	}
+
+	static yyjson_mut_val *VisitGeometry(const string_t &str, yyjson_mut_doc *doc) {
+		auto val_str = Value::GEOMETRY(const_data_ptr_cast(str.GetData()), str.GetSize()).ToString();
+		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
+	}
+
+	static yyjson_mut_val *VisitBitstring(const string_t &str, yyjson_mut_doc *doc) {
+		auto val_str = Value::BIT(const_data_ptr_cast(str.GetData()), str.GetSize()).ToString();
+		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
+	}
+
+	template <typename T>
+	static yyjson_mut_val *VisitDecimal(T val, uint32_t width, uint32_t scale, yyjson_mut_doc *doc) {
+		string val_str;
+		if (std::is_same<T, int16_t>::value) {
+			val_str = Decimal::ToString(val, static_cast<uint8_t>(width), static_cast<uint8_t>(scale));
+		} else if (std::is_same<T, int32_t>::value) {
+			val_str = Decimal::ToString(val, static_cast<uint8_t>(width), static_cast<uint8_t>(scale));
+		} else if (std::is_same<T, int64_t>::value) {
+			val_str = Decimal::ToString(val, static_cast<uint8_t>(width), static_cast<uint8_t>(scale));
+		} else if (std::is_same<T, hugeint_t>::value) {
+			val_str = Decimal::ToString(val, static_cast<uint8_t>(width), static_cast<uint8_t>(scale));
+		} else {
+			throw InternalException("Unhandled decimal type");
 		}
-		auto child_index_start = VarintDecode<uint32_t>(ptr);
-		for (idx_t i = 0; i < count; i++) {
-			auto index = values_index.sel->get_index(children_list_entry.offset + child_index_start + i);
-			auto child_index = values_index_data[index];
-#ifdef DEBUG
-			auto key_id_index = keys_index.sel->get_index(children_list_entry.offset + child_index_start + i);
-			D_ASSERT(!keys_index.validity.RowIsValid(key_id_index));
-#endif
-			auto val = ConvertVariantToJSON(doc, source, row, child_index);
-			if (!val) {
-				return nullptr;
-			}
-			yyjson_mut_arr_add_val(arr, val);
+		return yyjson_mut_rawncpy(doc, val_str.c_str(), val_str.size());
+	}
+
+	static yyjson_mut_val *VisitArray(const UnifiedVariantVectorData &variant, idx_t row,
+	                                  const VariantNestedData &nested_data, yyjson_mut_doc *doc) {
+		auto arr = yyjson_mut_arr(doc);
+		auto array_items = VariantVisitor<JSONConverter>::VisitArrayItems(variant, row, nested_data, doc);
+		for (auto &entry : array_items) {
+			yyjson_mut_arr_add_val(arr, entry);
 		}
 		return arr;
 	}
-	case VariantLogicalType::OBJECT: {
-		auto count = VarintDecode<uint32_t>(ptr);
-		auto obj = yyjson_mut_obj(doc);
-		if (!count) {
-			return obj;
-		}
-		auto child_index_start = VarintDecode<uint32_t>(ptr);
 
-		for (idx_t i = 0; i < count; i++) {
-			auto children_index = values_index.sel->get_index(children_list_entry.offset + child_index_start + i);
-			auto child_value_idx = values_index_data[children_index];
-			auto val = ConvertVariantToJSON(doc, source, row, child_value_idx);
-			if (!val) {
-				return nullptr;
-			}
-			auto keys_index_index = keys_index.sel->get_index(children_list_entry.offset + child_index_start + i);
-			D_ASSERT(keys_index.validity.RowIsValid(keys_index_index));
-			auto child_key_id = keys_index_data[keys_index_index];
-			auto &key = keys_entry_data[keys_entry.sel->get_index(keys_list_entry.offset + child_key_id)];
-			yyjson_mut_obj_put(obj, yyjson_mut_strncpy(doc, key.GetData(), key.GetSize()), val);
+	static yyjson_mut_val *VisitObject(const UnifiedVariantVectorData &variant, idx_t row,
+	                                   const VariantNestedData &nested_data, yyjson_mut_doc *doc) {
+		auto obj = yyjson_mut_obj(doc);
+		auto object_items = VariantVisitor<JSONConverter>::VisitObjectItems(variant, row, nested_data, doc);
+		for (auto &entry : object_items) {
+			yyjson_mut_obj_put(obj, yyjson_mut_strncpy(doc, entry.first.c_str(), entry.first.size()), entry.second);
 		}
 		return obj;
 	}
-	case VariantLogicalType::BITSTRING: {
-		auto string_length = VarintDecode<uint32_t>(ptr);
-		auto string_data = reinterpret_cast<const char *>(ptr);
-		auto val_str = Value::BIT(const_data_ptr_cast(string_data), string_length).ToString();
-		return yyjson_mut_strncpy(doc, val_str.c_str(), val_str.size());
-	}
-	case VariantLogicalType::BIGNUM: {
-		auto string_length = VarintDecode<uint32_t>(ptr);
-		auto string_data = reinterpret_cast<const char *>(ptr);
-		auto val_str = Value::BIGNUM(const_data_ptr_cast(string_data), string_length).ToString();
-		return yyjson_mut_rawncpy(doc, val_str.c_str(), val_str.size());
-	}
-	default:
-		throw InternalException("VariantLogicalType(%d) not handled", static_cast<uint8_t>(type_id));
-	}
 
-	return nullptr;
+	static yyjson_mut_val *VisitDefault(VariantLogicalType type_id, const_data_ptr_t, yyjson_mut_doc *) {
+		throw InternalException("VariantLogicalType(%s) not handled", EnumUtil::ToString(type_id));
+	}
+};
+
+} // namespace
+
+yyjson_mut_val *VariantCasts::ConvertVariantToJSON(yyjson_mut_doc *doc, const RecursiveUnifiedVectorFormat &source,
+                                                   idx_t row, uint32_t values_idx) {
+	UnifiedVariantVectorData variant(source);
+	return VariantVisitor<JSONConverter>::Visit(variant, row, values_idx, doc);
 }
 
 } // namespace duckdb

--- a/src/function/scalar/variant/variant_utils.cpp
+++ b/src/function/scalar/variant/variant_utils.cpp
@@ -182,57 +182,6 @@ struct ValueConverter {
 		throw InternalException("ValueConverter::VisitInteger not implemented!");
 	}
 
-	// Explicit specializations for each integer type
-	template <>
-	Value VisitInteger<int8_t>(int8_t val) {
-		return Value::TINYINT(val);
-	}
-
-	template <>
-	Value VisitInteger<int16_t>(int16_t val) {
-		return Value::SMALLINT(val);
-	}
-
-	template <>
-	Value VisitInteger<int32_t>(int32_t val) {
-		return Value::INTEGER(val);
-	}
-
-	template <>
-	Value VisitInteger<int64_t>(int64_t val) {
-		return Value::BIGINT(val);
-	}
-
-	template <>
-	Value VisitInteger<hugeint_t>(hugeint_t val) {
-		return Value::HUGEINT(val);
-	}
-
-	template <>
-	Value VisitInteger<uint8_t>(uint8_t val) {
-		return Value::UTINYINT(val);
-	}
-
-	template <>
-	Value VisitInteger<uint16_t>(uint16_t val) {
-		return Value::USMALLINT(val);
-	}
-
-	template <>
-	Value VisitInteger<uint32_t>(uint32_t val) {
-		return Value::UINTEGER(val);
-	}
-
-	template <>
-	Value VisitInteger<uint64_t>(uint64_t val) {
-		return Value::UBIGINT(val);
-	}
-
-	template <>
-	Value VisitInteger<uhugeint_t>(uhugeint_t val) {
-		return Value::UHUGEINT(val);
-	}
-
 	static Value VisitTime(dtime_t val) {
 		return Value::TIME(val);
 	}
@@ -326,6 +275,56 @@ struct ValueConverter {
 		throw InternalException("VariantLogicalType(%s) not handled", EnumUtil::ToString(type_id));
 	}
 };
+
+template <>
+Value ValueConverter::VisitInteger<int8_t>(int8_t val) {
+	return Value::TINYINT(val);
+}
+
+template <>
+Value ValueConverter::VisitInteger<int16_t>(int16_t val) {
+	return Value::SMALLINT(val);
+}
+
+template <>
+Value ValueConverter::VisitInteger<int32_t>(int32_t val) {
+	return Value::INTEGER(val);
+}
+
+template <>
+Value ValueConverter::VisitInteger<int64_t>(int64_t val) {
+	return Value::BIGINT(val);
+}
+
+template <>
+Value ValueConverter::VisitInteger<hugeint_t>(hugeint_t val) {
+	return Value::HUGEINT(val);
+}
+
+template <>
+Value ValueConverter::VisitInteger<uint8_t>(uint8_t val) {
+	return Value::UTINYINT(val);
+}
+
+template <>
+Value ValueConverter::VisitInteger<uint16_t>(uint16_t val) {
+	return Value::USMALLINT(val);
+}
+
+template <>
+Value ValueConverter::VisitInteger<uint32_t>(uint32_t val) {
+	return Value::UINTEGER(val);
+}
+
+template <>
+Value ValueConverter::VisitInteger<uint64_t>(uint64_t val) {
+	return Value::UBIGINT(val);
+}
+
+template <>
+Value ValueConverter::VisitInteger<uhugeint_t>(uhugeint_t val) {
+	return Value::UHUGEINT(val);
+}
 
 } // namespace
 

--- a/src/function/scalar/variant/variant_utils.cpp
+++ b/src/function/scalar/variant/variant_utils.cpp
@@ -178,7 +178,9 @@ struct ValueConverter {
 	}
 
 	template <typename T>
-	static Value VisitInteger(T val);
+	static Value VisitInteger(T val) {
+		throw InternalException("ValueConverter::VisitInteger not implemented!");
+	}
 
 	// Explicit specializations for each integer type
 	template <>

--- a/src/include/duckdb/common/serializer/varint.hpp
+++ b/src/include/duckdb/common/serializer/varint.hpp
@@ -35,7 +35,8 @@ uint8_t GetVarintSize(T val) {
 }
 
 template <class T>
-void VarintEncode(T val, data_ptr_t ptr) {
+idx_t VarintEncode(T val, data_ptr_t ptr) {
+	idx_t size = 0;
 	do {
 		uint8_t byte = val & 127;
 		val >>= 7;
@@ -44,11 +45,14 @@ void VarintEncode(T val, data_ptr_t ptr) {
 		}
 		*ptr = byte;
 		ptr++;
+		size++;
 	} while (val != 0);
+	return size;
 }
 
 template <class T>
-void VarintEncode(T val, MemoryStream &ser) {
+idx_t VarintEncode(T val, MemoryStream &ser) {
+	idx_t size = 0;
 	do {
 		uint8_t byte = val & 127;
 		val >>= 7;
@@ -56,7 +60,9 @@ void VarintEncode(T val, MemoryStream &ser) {
 			byte |= 128;
 		}
 		ser.WriteData(&byte, sizeof(uint8_t));
+		size++;
 	} while (val != 0);
+	return size;
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types/variant_visitor.hpp
+++ b/src/include/duckdb/common/types/variant_visitor.hpp
@@ -1,0 +1,183 @@
+#pragma once
+
+#include "duckdb/common/types/variant.hpp"
+#include "duckdb/function/scalar/variant_utils.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+template <typename Visitor, typename ReturnType = typename Visitor::result_type>
+class VariantVisitor {
+public:
+	template <typename... Args>
+	static ReturnType Visit(const UnifiedVariantVectorData &variant, idx_t row, uint32_t values_idx, Args &&...args) {
+		if (!variant.RowIsValid(row)) {
+			return Visitor::VisitNull(std::forward<Args>(args)...);
+		}
+
+		auto type_id = variant.GetTypeId(row, values_idx);
+		auto byte_offset = variant.GetByteOffset(row, values_idx);
+		auto blob_data = const_data_ptr_cast(variant.GetData(row).GetData());
+		auto ptr = const_data_ptr_cast(blob_data + byte_offset);
+
+		switch (type_id) {
+		case VariantLogicalType::VARIANT_NULL:
+			return Visitor::VisitNull(std::forward<Args>(args)...);
+		case VariantLogicalType::BOOL_TRUE:
+			return Visitor::VisitBoolean(true, std::forward<Args>(args)...);
+		case VariantLogicalType::BOOL_FALSE:
+			return Visitor::VisitBoolean(false, std::forward<Args>(args)...);
+		case VariantLogicalType::INT8:
+			return Visitor::template VisitInteger<int8_t>(Load<int8_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::INT16:
+			return Visitor::template VisitInteger<int16_t>(Load<int16_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::INT32:
+			return Visitor::template VisitInteger<int32_t>(Load<int32_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::INT64:
+			return Visitor::template VisitInteger<int64_t>(Load<int64_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::INT128:
+			return Visitor::template VisitInteger<hugeint_t>(Load<hugeint_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::UINT8:
+			return Visitor::template VisitInteger<uint8_t>(Load<uint8_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::UINT16:
+			return Visitor::template VisitInteger<uint16_t>(Load<uint16_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::UINT32:
+			return Visitor::template VisitInteger<uint32_t>(Load<uint32_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::UINT64:
+			return Visitor::template VisitInteger<uint64_t>(Load<uint64_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::UINT128:
+			return Visitor::template VisitInteger<uhugeint_t>(Load<uhugeint_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::FLOAT:
+			return Visitor::VisitFloat(Load<float>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::DOUBLE:
+			return Visitor::VisitDouble(Load<double>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::UUID:
+			return Visitor::VisitUUID(Load<hugeint_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::DATE:
+			return Visitor::VisitDate(date_t(Load<int32_t>(ptr)), std::forward<Args>(args)...);
+		case VariantLogicalType::INTERVAL:
+			return Visitor::VisitInterval(Load<interval_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::VARCHAR:
+		case VariantLogicalType::BLOB:
+		case VariantLogicalType::BITSTRING:
+		case VariantLogicalType::BIGNUM:
+		case VariantLogicalType::GEOMETRY:
+			return VisitString(type_id, variant, row, values_idx, std::forward<Args>(args)...);
+		case VariantLogicalType::DECIMAL:
+			return VisitDecimal(variant, row, values_idx, std::forward<Args>(args)...);
+		case VariantLogicalType::ARRAY:
+			return VisitArray(variant, row, values_idx, std::forward<Args>(args)...);
+		case VariantLogicalType::OBJECT:
+			return VisitObject(variant, row, values_idx, std::forward<Args>(args)...);
+		case VariantLogicalType::TIME_MICROS:
+			return Visitor::VisitTime(Load<dtime_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::TIME_NANOS:
+			return Visitor::VisitTimeNanos(Load<dtime_ns_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::TIME_MICROS_TZ:
+			return Visitor::VisitTimeTZ(Load<dtime_tz_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::TIMESTAMP_SEC:
+			return Visitor::VisitTimestampSec(Load<timestamp_sec_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::TIMESTAMP_MILIS:
+			return Visitor::VisitTimestampMs(Load<timestamp_ms_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::TIMESTAMP_MICROS:
+			return Visitor::VisitTimestamp(Load<timestamp_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::TIMESTAMP_NANOS:
+			return Visitor::VisitTimestampNanos(Load<timestamp_ns_t>(ptr), std::forward<Args>(args)...);
+		case VariantLogicalType::TIMESTAMP_MICROS_TZ:
+			return Visitor::VisitTimestampTZ(Load<timestamp_tz_t>(ptr), std::forward<Args>(args)...);
+		default:
+			return Visitor::VisitDefault(type_id, ptr, std::forward<Args>(args)...);
+		}
+	}
+
+	template <typename... Args>
+	static vector<ReturnType> VisitArrayItems(const UnifiedVariantVectorData &variant, idx_t row,
+	                                          const VariantNestedData &array_data, Args &&...args) {
+		vector<ReturnType> array_items;
+		for (idx_t i = 0; i < array_data.child_count; i++) {
+			auto values_index = variant.GetValuesIndex(row, array_data.children_idx + i);
+			array_items.emplace_back(Visit(variant, row, values_index, std::forward<Args>(args)...));
+		}
+		return array_items;
+	}
+
+	template <typename... Args>
+	static child_list_t<ReturnType> VisitObjectItems(const UnifiedVariantVectorData &variant, idx_t row,
+	                                                 const VariantNestedData &object_data, Args &&...args) {
+		child_list_t<ReturnType> object_items;
+		for (idx_t i = 0; i < object_data.child_count; i++) {
+			auto values_index = variant.GetValuesIndex(row, object_data.children_idx + i);
+			auto val = Visit(variant, row, values_index, std::forward<Args>(args)...);
+
+			auto keys_index = variant.GetKeysIndex(row, object_data.children_idx + i);
+			auto &key = variant.GetKey(row, keys_index);
+
+			object_items.emplace_back(key.GetString(), std::move(val));
+		}
+		return object_items;
+	}
+
+private:
+	template <typename... Args>
+	static ReturnType VisitArray(const UnifiedVariantVectorData &variant, idx_t row, uint32_t values_idx,
+	                             Args &&...args) {
+		auto decoded_nested_data = VariantUtils::DecodeNestedData(variant, row, values_idx);
+		return Visitor::VisitArray(variant, row, decoded_nested_data, std::forward<Args>(args)...);
+	}
+
+	template <typename... Args>
+	static ReturnType VisitObject(const UnifiedVariantVectorData &variant, idx_t row, uint32_t values_idx,
+	                              Args &&...args) {
+		auto decoded_nested_data = VariantUtils::DecodeNestedData(variant, row, values_idx);
+		return Visitor::VisitObject(variant, row, decoded_nested_data, std::forward<Args>(args)...);
+	}
+
+	template <typename... Args>
+	static ReturnType VisitString(VariantLogicalType type_id, const UnifiedVariantVectorData &variant, idx_t row,
+	                              uint32_t values_idx, Args &&...args) {
+		auto decoded_string = VariantUtils::DecodeStringData(variant, row, values_idx);
+		if (type_id == VariantLogicalType::VARCHAR) {
+			return Visitor::VisitString(decoded_string, std::forward<Args>(args)...);
+		}
+		if (type_id == VariantLogicalType::BLOB) {
+			return Visitor::VisitBlob(decoded_string, std::forward<Args>(args)...);
+		}
+		if (type_id == VariantLogicalType::BIGNUM) {
+			return Visitor::VisitBignum(decoded_string, std::forward<Args>(args)...);
+		}
+		if (type_id == VariantLogicalType::GEOMETRY) {
+			return Visitor::VisitGeometry(decoded_string, std::forward<Args>(args)...);
+		}
+		if (type_id == VariantLogicalType::BITSTRING) {
+			return Visitor::VisitBitstring(decoded_string, std::forward<Args>(args)...);
+		}
+		throw InternalException("String-backed variant type (%s) not handled", EnumUtil::ToString(type_id));
+	}
+
+	template <typename... Args>
+	static ReturnType VisitDecimal(const UnifiedVariantVectorData &variant, idx_t row, uint32_t values_idx,
+	                               Args &&...args) {
+		auto decoded_decimal = VariantUtils::DecodeDecimalData(variant, row, values_idx);
+		auto &width = decoded_decimal.width;
+		auto &scale = decoded_decimal.scale;
+		auto &ptr = decoded_decimal.value_ptr;
+		if (width > DecimalWidth<hugeint_t>::max) {
+			throw InternalException("Can't handle decimal of width: %d", width);
+		} else if (width > DecimalWidth<int64_t>::max) {
+			return Visitor::template VisitDecimal<hugeint_t>(Load<hugeint_t>(ptr), width, scale,
+			                                                 std::forward<Args>(args)...);
+		} else if (width > DecimalWidth<int32_t>::max) {
+			return Visitor::template VisitDecimal<int64_t>(Load<int64_t>(ptr), width, scale,
+			                                               std::forward<Args>(args)...);
+		} else if (width > DecimalWidth<int16_t>::max) {
+			return Visitor::template VisitDecimal<int32_t>(Load<int32_t>(ptr), width, scale,
+			                                               std::forward<Args>(args)...);
+		} else {
+			return Visitor::template VisitDecimal<int16_t>(Load<int16_t>(ptr), width, scale,
+			                                               std::forward<Args>(args)...);
+		}
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/types/variant_visitor.hpp
+++ b/src/include/duckdb/common/types/variant_visitor.hpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/types/decimal.hpp"
+#include "duckdb/common/enum_util.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/common/types/variant_visitor.hpp
+++ b/src/include/duckdb/common/types/variant_visitor.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/function/scalar/variant_utils.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/common/types/decimal.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
@@ -1,93 +1,246 @@
 #pragma once
 
 #include "duckdb/function/cast/variant/to_variant_fwd.hpp"
+#include "duckdb/common/types/variant_visitor.hpp"
 
 namespace duckdb {
 namespace variant {
 
-static bool VariantIsTrivialPrimitive(VariantLogicalType type) {
-	switch (type) {
-	case VariantLogicalType::INT8:
-	case VariantLogicalType::INT16:
-	case VariantLogicalType::INT32:
-	case VariantLogicalType::INT64:
-	case VariantLogicalType::INT128:
-	case VariantLogicalType::UINT8:
-	case VariantLogicalType::UINT16:
-	case VariantLogicalType::UINT32:
-	case VariantLogicalType::UINT64:
-	case VariantLogicalType::UINT128:
-	case VariantLogicalType::FLOAT:
-	case VariantLogicalType::DOUBLE:
-	case VariantLogicalType::UUID:
-	case VariantLogicalType::DATE:
-	case VariantLogicalType::TIME_MICROS:
-	case VariantLogicalType::TIME_NANOS:
-	case VariantLogicalType::TIMESTAMP_SEC:
-	case VariantLogicalType::TIMESTAMP_MILIS:
-	case VariantLogicalType::TIMESTAMP_MICROS:
-	case VariantLogicalType::TIMESTAMP_NANOS:
-	case VariantLogicalType::TIME_MICROS_TZ:
-	case VariantLogicalType::TIMESTAMP_MICROS_TZ:
-	case VariantLogicalType::INTERVAL:
-		return true;
-	default:
-		return false;
-	}
-}
+namespace {
 
-static uint32_t VariantTrivialPrimitiveSize(VariantLogicalType type) {
-	switch (type) {
-	case VariantLogicalType::INT8:
-		return sizeof(int8_t);
-	case VariantLogicalType::INT16:
-		return sizeof(int16_t);
-	case VariantLogicalType::INT32:
-		return sizeof(int32_t);
-	case VariantLogicalType::INT64:
-		return sizeof(int64_t);
-	case VariantLogicalType::INT128:
-		return sizeof(hugeint_t);
-	case VariantLogicalType::UINT8:
-		return sizeof(uint8_t);
-	case VariantLogicalType::UINT16:
-		return sizeof(uint16_t);
-	case VariantLogicalType::UINT32:
-		return sizeof(uint32_t);
-	case VariantLogicalType::UINT64:
-		return sizeof(uint64_t);
-	case VariantLogicalType::UINT128:
-		return sizeof(uhugeint_t);
-	case VariantLogicalType::FLOAT:
-		return sizeof(float);
-	case VariantLogicalType::DOUBLE:
-		return sizeof(double);
-	case VariantLogicalType::UUID:
-		return sizeof(hugeint_t);
-	case VariantLogicalType::DATE:
-		return sizeof(int32_t);
-	case VariantLogicalType::TIME_MICROS:
-		return sizeof(dtime_t);
-	case VariantLogicalType::TIME_NANOS:
-		return sizeof(dtime_ns_t);
-	case VariantLogicalType::TIMESTAMP_SEC:
-		return sizeof(timestamp_sec_t);
-	case VariantLogicalType::TIMESTAMP_MILIS:
-		return sizeof(timestamp_ms_t);
-	case VariantLogicalType::TIMESTAMP_MICROS:
-		return sizeof(timestamp_t);
-	case VariantLogicalType::TIMESTAMP_NANOS:
-		return sizeof(timestamp_ns_t);
-	case VariantLogicalType::TIME_MICROS_TZ:
-		return sizeof(dtime_tz_t);
-	case VariantLogicalType::TIMESTAMP_MICROS_TZ:
-		return sizeof(timestamp_tz_t);
-	case VariantLogicalType::INTERVAL:
-		return sizeof(interval_t);
-	default:
-		throw InternalException("VariantLogicalType '%s' is not a trivial primitive", EnumUtil::ToString(type));
+struct AnalyzeState {
+public:
+	explicit AnalyzeState(uint32_t &children_offset) : children_offset(children_offset) {
 	}
-}
+
+public:
+	uint32_t &children_offset;
+};
+
+struct WriteState {
+public:
+	WriteState(uint32_t &keys_offset, uint32_t &children_offset, uint32_t &blob_offset, data_ptr_t blob_data,
+	           uint32_t &blob_size)
+	    : keys_offset(keys_offset), children_offset(children_offset), blob_offset(blob_offset), blob_data(blob_data),
+	      blob_size(blob_size) {
+	}
+
+public:
+	inline data_ptr_t GetDestination() {
+		return blob_data + blob_offset + blob_size;
+	}
+
+public:
+	uint32_t &keys_offset;
+	uint32_t &children_offset;
+	uint32_t &blob_offset;
+	data_ptr_t blob_data;
+	uint32_t &blob_size;
+};
+
+struct VariantToVariantSizeAnalyzer {
+	using result_type = uint32_t;
+
+	static uint32_t VisitNull(AnalyzeState &state) {
+		return 0;
+	}
+	static uint32_t VisitBoolean(bool, AnalyzeState &state) {
+		return 0;
+	}
+
+	template <typename T>
+	static uint32_t VisitInteger(T, AnalyzeState &state) {
+		return sizeof(T);
+	}
+
+	static uint32_t VisitFloat(float, AnalyzeState &state) {
+		return sizeof(float);
+	}
+	static uint32_t VisitDouble(double, AnalyzeState &state) {
+		return sizeof(double);
+	}
+	static uint32_t VisitUUID(hugeint_t, AnalyzeState &state) {
+		return sizeof(hugeint_t);
+	}
+	static uint32_t VisitDate(date_t, AnalyzeState &state) {
+		return sizeof(int32_t);
+	}
+	static uint32_t VisitInterval(interval_t, AnalyzeState &state) {
+		return sizeof(interval_t);
+	}
+
+	static uint32_t VisitTime(dtime_t, AnalyzeState &state) {
+		return sizeof(dtime_t);
+	}
+	static uint32_t VisitTimeNanos(dtime_ns_t, AnalyzeState &state) {
+		return sizeof(dtime_ns_t);
+	}
+	static uint32_t VisitTimeTZ(dtime_tz_t, AnalyzeState &state) {
+		return sizeof(dtime_tz_t);
+	}
+	static uint32_t VisitTimestampSec(timestamp_sec_t, AnalyzeState &state) {
+		return sizeof(timestamp_sec_t);
+	}
+	static uint32_t VisitTimestampMs(timestamp_ms_t, AnalyzeState &state) {
+		return sizeof(timestamp_ms_t);
+	}
+	static uint32_t VisitTimestamp(timestamp_t, AnalyzeState &state) {
+		return sizeof(timestamp_t);
+	}
+	static uint32_t VisitTimestampNanos(timestamp_ns_t, AnalyzeState &state) {
+		return sizeof(timestamp_ns_t);
+	}
+	static uint32_t VisitTimestampTZ(timestamp_tz_t, AnalyzeState &state) {
+		return sizeof(timestamp_tz_t);
+	}
+
+	static uint32_t VisitString(const string_t &str, AnalyzeState &state) {
+		auto length = static_cast<uint32_t>(str.GetSize());
+		return GetVarintSize(length) + length;
+	}
+
+	static uint32_t VisitBlob(const string_t &blob, AnalyzeState &state) {
+		return VisitString(blob, state);
+	}
+	static uint32_t VisitBignum(const string_t &bignum, AnalyzeState &state) {
+		return VisitString(bignum, state);
+	}
+	static uint32_t VisitGeometry(const string_t &geom, AnalyzeState &state) {
+		return VisitString(geom, state);
+	}
+	static uint32_t VisitBitstring(const string_t &bits, AnalyzeState &state) {
+		return VisitString(bits, state);
+	}
+
+	template <typename T>
+	static uint32_t VisitDecimal(T, uint32_t width, uint32_t scale, AnalyzeState &state) {
+		uint32_t size = GetVarintSize(width) + GetVarintSize(scale);
+		size += sizeof(T);
+		return size;
+	}
+
+	static uint32_t VisitArray(const UnifiedVariantVectorData &variant, idx_t row, const VariantNestedData &nested_data,
+	                           AnalyzeState &state) {
+		uint32_t size = GetVarintSize(nested_data.child_count);
+		if (nested_data.child_count) {
+			size += GetVarintSize(nested_data.children_idx + state.children_offset);
+		}
+		return size;
+	}
+
+	static uint32_t VisitObject(const UnifiedVariantVectorData &variant, idx_t row,
+	                            const VariantNestedData &nested_data, AnalyzeState &state) {
+		return VisitArray(variant, row, nested_data, state);
+	}
+
+	static uint32_t VisitDefault(VariantLogicalType type_id, const_data_ptr_t, AnalyzeState &) {
+		throw InternalException("Unrecognized VariantLogicalType: %s", EnumUtil::ToString(type_id));
+	}
+};
+
+struct VariantToVariantDataWriter {
+	using result_type = void;
+
+	static void VisitNull(WriteState &state) {
+		return;
+	}
+	static void VisitBoolean(bool, WriteState &state) {
+		return;
+	}
+
+	template <typename T>
+	static void VisitInteger(T val, WriteState &state) {
+		Store<T>(val, state.GetDestination());
+		state.blob_size += sizeof(T);
+	}
+	static void VisitFloat(float val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitDouble(double val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitUUID(hugeint_t val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitDate(date_t val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitInterval(interval_t val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitTime(dtime_t val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitTimeNanos(dtime_ns_t val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitTimeTZ(dtime_tz_t val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitTimestampSec(timestamp_sec_t val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitTimestampMs(timestamp_ms_t val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitTimestamp(timestamp_t val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitTimestampNanos(timestamp_ns_t val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+	static void VisitTimestampTZ(timestamp_tz_t val, WriteState &state) {
+		VisitInteger(val, state);
+	}
+
+	static void VisitString(const string_t &str, WriteState &state) {
+		auto length = str.GetSize();
+		state.blob_size += VarintEncode(length, state.GetDestination());
+		memcpy(state.GetDestination(), str.GetData(), length);
+		state.blob_size += length;
+	}
+	static void VisitBlob(const string_t &blob, WriteState &state) {
+		return VisitString(blob, state);
+	}
+	static void VisitBignum(const string_t &bignum, WriteState &state) {
+		return VisitString(bignum, state);
+	}
+	static void VisitGeometry(const string_t &geom, WriteState &state) {
+		return VisitString(geom, state);
+	}
+	static void VisitBitstring(const string_t &bits, WriteState &state) {
+		return VisitString(bits, state);
+	}
+
+	template <typename T>
+	static void VisitDecimal(T val, uint32_t width, uint32_t scale, WriteState &state) {
+		state.blob_size += VarintEncode(width, state.GetDestination());
+		state.blob_size += VarintEncode(scale, state.GetDestination());
+		Store<T>(val, state.GetDestination());
+		state.blob_size += sizeof(T);
+	}
+
+	static void VisitArray(const UnifiedVariantVectorData &variant, idx_t row, const VariantNestedData &nested_data,
+	                       WriteState &state) {
+		state.blob_size += VarintEncode(nested_data.child_count, state.GetDestination());
+		if (nested_data.child_count) {
+			//! NOTE: The 'child_index' stored in the OBJECT/ARRAY data could require more bits
+			//! That's the reason we have to rewrite the data in VARIANT->VARIANT cast
+			state.blob_size += VarintEncode(nested_data.children_idx + state.children_offset, state.GetDestination());
+		}
+	}
+
+	static void VisitObject(const UnifiedVariantVectorData &variant, idx_t row, const VariantNestedData &nested_data,
+	                        WriteState &state) {
+		return VisitArray(variant, row, nested_data, state);
+	}
+
+	static void VisitDefault(VariantLogicalType type_id, const_data_ptr_t, WriteState &) {
+		throw InternalException("Unrecognized VariantLogicalType: %s", EnumUtil::ToString(type_id));
+	}
+};
+
+} // namespace
 
 template <bool WRITE_DATA, bool IGNORE_NULLS>
 bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalResultData &result_data, idx_t count,
@@ -168,99 +321,26 @@ bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalRe
 			}
 		}
 
-		auto source_blob_data = const_data_ptr_cast(source.GetData(source_index).GetData());
-
-		//! Then write all values
 		auto source_values_list_entry = source.GetValuesListEntry(source_index);
-		for (uint32_t source_value_index = 0; source_value_index < source_values_list_entry.length;
-		     source_value_index++) {
-			auto source_type_id = source.GetTypeId(source_index, source_value_index);
-			auto source_byte_offset = source.GetByteOffset(source_index, source_value_index);
 
-			//! NOTE: we have to deserialize these in both passes
-			//! because to figure out the size of the 'data' that is added by the VARIANT, we have to traverse the
-			//! VARIANT solely because the 'child_index' stored in the OBJECT/ARRAY data could require more bits
-			WriteVariantMetadata<WRITE_DATA>(result_data, result_index, values_offset_data, blob_offset + blob_size,
-			                                 nullptr, 0, source_type_id);
+		if (WRITE_DATA) {
+			WriteState write_state(keys_offset, children_offset, blob_offset, blob_data, blob_size);
+			for (uint32_t source_value_index = 0; source_value_index < source_values_list_entry.length;
+			     source_value_index++) {
+				auto source_type_id = source.GetTypeId(source_index, source_value_index);
+				WriteVariantMetadata<WRITE_DATA>(result_data, result_index, values_offset_data, blob_offset + blob_size,
+				                                 nullptr, 0, source_type_id);
 
-			if (source_type_id == VariantLogicalType::ARRAY || source_type_id == VariantLogicalType::OBJECT) {
-				auto source_nested_data = VariantUtils::DecodeNestedData(source, source_index, source_value_index);
-				if (WRITE_DATA) {
-					VarintEncode(source_nested_data.child_count, blob_data + blob_offset + blob_size);
-				}
-				blob_size += GetVarintSize(source_nested_data.child_count);
-				if (source_nested_data.child_count) {
-					auto new_child_index = source_nested_data.children_idx + children_offset;
-					if (WRITE_DATA) {
-						VarintEncode(new_child_index, blob_data + blob_offset + blob_size);
-					}
-					blob_size += GetVarintSize(new_child_index);
-				}
-			} else if (source_type_id == VariantLogicalType::VARIANT_NULL ||
-			           source_type_id == VariantLogicalType::BOOL_FALSE ||
-			           source_type_id == VariantLogicalType::BOOL_TRUE) {
-				// no-op
-			} else if (source_type_id == VariantLogicalType::DECIMAL) {
-				auto decimal_blob_data = source_blob_data + source_byte_offset;
-				auto width = static_cast<uint8_t>(VarintDecode<uint32_t>(decimal_blob_data));
-				auto width_varint_size = GetVarintSize(width);
-				if (WRITE_DATA) {
-					memcpy(blob_data + blob_offset + blob_size, decimal_blob_data - width_varint_size,
-					       width_varint_size);
-				}
-				blob_size += width_varint_size;
-				auto scale = static_cast<uint8_t>(VarintDecode<uint32_t>(decimal_blob_data));
-				auto scale_varint_size = GetVarintSize(scale);
-				if (WRITE_DATA) {
-					memcpy(blob_data + blob_offset + blob_size, decimal_blob_data - scale_varint_size,
-					       scale_varint_size);
-				}
-				blob_size += scale_varint_size;
-
-				if (width > DecimalWidth<int64_t>::max) {
-					if (WRITE_DATA) {
-						memcpy(blob_data + blob_offset + blob_size, decimal_blob_data, sizeof(hugeint_t));
-					}
-					blob_size += sizeof(hugeint_t);
-				} else if (width > DecimalWidth<int32_t>::max) {
-					if (WRITE_DATA) {
-						memcpy(blob_data + blob_offset + blob_size, decimal_blob_data, sizeof(int64_t));
-					}
-					blob_size += sizeof(int64_t);
-				} else if (width > DecimalWidth<int16_t>::max) {
-					if (WRITE_DATA) {
-						memcpy(blob_data + blob_offset + blob_size, decimal_blob_data, sizeof(int32_t));
-					}
-					blob_size += sizeof(int32_t);
-				} else {
-					if (WRITE_DATA) {
-						memcpy(blob_data + blob_offset + blob_size, decimal_blob_data, sizeof(int16_t));
-					}
-					blob_size += sizeof(int16_t);
-				}
-			} else if (source_type_id == VariantLogicalType::BITSTRING ||
-			           source_type_id == VariantLogicalType::BIGNUM || source_type_id == VariantLogicalType::VARCHAR ||
-			           source_type_id == VariantLogicalType::BLOB || source_type_id == VariantLogicalType::GEOMETRY) {
-				auto str_blob_data = source_blob_data + source_byte_offset;
-				auto str_length = VarintDecode<uint32_t>(str_blob_data);
-				auto str_length_varint_size = GetVarintSize(str_length);
-				if (WRITE_DATA) {
-					memcpy(blob_data + blob_offset + blob_size, str_blob_data - str_length_varint_size,
-					       str_length_varint_size);
-				}
-				blob_size += str_length_varint_size;
-				if (WRITE_DATA) {
-					memcpy(blob_data + blob_offset + blob_size, str_blob_data, str_length);
-				}
-				blob_size += str_length;
-			} else if (VariantIsTrivialPrimitive(source_type_id)) {
-				auto size = VariantTrivialPrimitiveSize(source_type_id);
-				if (WRITE_DATA) {
-					memcpy(blob_data + blob_offset + blob_size, source_blob_data + source_byte_offset, size);
-				}
-				blob_size += size;
-			} else {
-				throw InternalException("Unrecognized VariantLogicalType: %s", EnumUtil::ToString(source_type_id));
+				VariantVisitor<VariantToVariantDataWriter>::Visit(source, source_index, source_value_index,
+				                                                  write_state);
+			}
+		} else {
+			AnalyzeState analyze_state(children_offset);
+			for (uint32_t source_value_index = 0; source_value_index < source_values_list_entry.length;
+			     source_value_index++) {
+				values_offset_data[result_index]++;
+				blob_size += VariantVisitor<VariantToVariantSizeAnalyzer>::Visit(source, source_index,
+				                                                                 source_value_index, analyze_state);
 			}
 		}
 

--- a/src/include/duckdb/function/scalar/variant_utils.hpp
+++ b/src/include/duckdb/function/scalar/variant_utils.hpp
@@ -80,7 +80,8 @@ struct VariantUtils {
 	                  VariantNestedData *child_data, ValidityMask &validity);
 	DUCKDB_API static vector<uint32_t> ValueIsNull(const UnifiedVariantVectorData &variant, const SelectionVector &sel,
 	                                               idx_t count, optional_idx row);
-	DUCKDB_API static Value ConvertVariantToValue(const UnifiedVariantVectorData &variant, idx_t row, idx_t values_idx);
+	DUCKDB_API static Value ConvertVariantToValue(const UnifiedVariantVectorData &variant, idx_t row,
+	                                              uint32_t values_idx);
 	DUCKDB_API static bool Verify(Vector &variant, const SelectionVector &sel_p, idx_t count);
 };
 


### PR DESCRIPTION
This PR adds a visitor class that encapsulates the logic to traverse a variant, removing some duplication and protecting against implementations missing logic for handling certain types (such as GEOMETRY)

This pattern is now used in `ConvertVariantToValue` and `ConvertVariantToJSON`, and `variant_to_variant.hpp`
Not a *great* sign that the additions are higher than the deletions, but in the long run it should help