### PR TITLE
CSV Reader: make line reconstruction deal with buffer_pos == buffer_size

### DIFF
--- a/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
@@ -41,19 +41,24 @@ public:
 			return {};
 		}
 		string result;
-		if (end.buffer_idx == begin.buffer_idx) {
-			if (buffer_handles.find(end.buffer_idx) == buffer_handles.end()) {
+		if (end.buffer_idx == begin.buffer_idx || begin.buffer_pos == begin.buffer_size) {
+			idx_t buffer_idx = end.buffer_idx;
+			if (buffer_handles.find(buffer_idx) == buffer_handles.end()) {
 				return {};
 			}
-			auto buffer = buffer_handles[begin.buffer_idx]->Ptr();
-			first_char_nl = buffer[begin.buffer_pos] == '\n' || buffer[begin.buffer_pos] == '\r';
-			for (idx_t i = begin.buffer_pos + first_char_nl; i < end.buffer_pos; i++) {
+			idx_t start_pos = begin.buffer_pos == begin.buffer_size ? 0 : begin.buffer_pos;
+			auto buffer = buffer_handles[buffer_idx]->Ptr();
+			first_char_nl = buffer[start_pos] == '\n' || buffer[start_pos] == '\r';
+			for (idx_t i = start_pos + first_char_nl; i < end.buffer_pos; i++) {
 				result += buffer[i];
 			}
 		} else {
 			if (buffer_handles.find(begin.buffer_idx) == buffer_handles.end() ||
 			    buffer_handles.find(end.buffer_idx) == buffer_handles.end()) {
 				return {};
+			}
+			if (begin.buffer_pos >= begin.buffer_size) {
+				throw InternalException("CSV reader: buffer pos out of range for buffer");
 			}
 			auto first_buffer = buffer_handles[begin.buffer_idx]->Ptr();
 			auto first_buffer_size = buffer_handles[begin.buffer_idx]->actual_size;


### PR DESCRIPTION
Fixes an issue with the line reconstruction code, which would otherwise cause the `first_nl` to be read from an uninitialized piece of memory leading to potential off-by-one errors in line / byte positions.