### PR TITLE
Switch RowVersionManager to using the FixedSizeAllocator

### DIFF
--- a/src/execution/index/fixed_size_allocator.cpp
+++ b/src/execution/index/fixed_size_allocator.cpp
@@ -4,9 +4,9 @@
 
 namespace duckdb {
 
-FixedSizeAllocator::FixedSizeAllocator(const idx_t segment_size, BlockManager &block_manager)
-    : block_manager(block_manager), buffer_manager(block_manager.buffer_manager), segment_size(segment_size),
-      total_segment_count(0) {
+FixedSizeAllocator::FixedSizeAllocator(const idx_t segment_size, BlockManager &block_manager, MemoryTag memory_tag)
+    : block_manager(block_manager), buffer_manager(block_manager.buffer_manager), memory_tag(memory_tag),
+      segment_size(segment_size), total_segment_count(0) {
 
 	if (segment_size > block_manager.GetBlockSize() - sizeof(validity_t)) {
 		throw InternalException("The maximum segment size of fixed-size allocators is " +
@@ -48,7 +48,7 @@ IndexPointer FixedSizeAllocator::New() {
 	if (!buffer_with_free_space.IsValid()) {
 		// Add a new buffer.
 		auto buffer_id = GetAvailableBufferId();
-		buffers[buffer_id] = make_uniq<FixedSizeBuffer>(block_manager);
+		buffers[buffer_id] = make_uniq<FixedSizeBuffer>(block_manager, memory_tag);
 		buffers_with_free_space.insert(buffer_id);
 		buffer_with_free_space = buffer_id;
 

--- a/src/execution/index/fixed_size_buffer.cpp
+++ b/src/execution/index/fixed_size_buffer.cpp
@@ -35,12 +35,12 @@ void PartialBlockForIndex::Clear() {
 constexpr idx_t FixedSizeBuffer::BASE[];
 constexpr uint8_t FixedSizeBuffer::SHIFT[];
 
-FixedSizeBuffer::FixedSizeBuffer(BlockManager &block_manager)
+FixedSizeBuffer::FixedSizeBuffer(BlockManager &block_manager, MemoryTag memory_tag)
     : block_manager(block_manager), readers(0), segment_count(0), allocation_size(0), dirty(false), vacuum(false),
       loaded(false), block_pointer(), block_handle(nullptr) {
 
 	auto &buffer_manager = block_manager.buffer_manager;
-	buffer_handle = buffer_manager.Allocate(MemoryTag::ART_INDEX, &block_manager, false);
+	buffer_handle = buffer_manager.Allocate(memory_tag, &block_manager, false);
 	block_handle = buffer_handle.GetBlockHandle();
 
 	// Zero-initialize the buffer as it might get serialized to storage.

--- a/src/include/duckdb/execution/index/fixed_size_allocator.hpp
+++ b/src/include/duckdb/execution/index/fixed_size_allocator.hpp
@@ -30,7 +30,8 @@ public:
 
 public:
 	//! Construct a new fixed-size allocator
-	FixedSizeAllocator(const idx_t segment_size, BlockManager &block_manager);
+	FixedSizeAllocator(const idx_t segment_size, BlockManager &block_manager,
+	                   MemoryTag memory_tag = MemoryTag::ART_INDEX);
 
 	//! Block manager of the database instance
 	BlockManager &block_manager;
@@ -152,6 +153,8 @@ public:
 	void VerifyBuffers();
 
 private:
+	//! Memory tag of memory that is allocated through the allocator
+	MemoryTag memory_tag;
 	//! Allocation size of one segment in a buffer
 	//! We only need this value to calculate bitmask_count, bitmask_offset, and
 	//! available_segments_per_buffer

--- a/src/include/duckdb/execution/index/fixed_size_buffer.hpp
+++ b/src/include/duckdb/execution/index/fixed_size_buffer.hpp
@@ -43,7 +43,7 @@ public:
 
 public:
 	//! Constructor for a new in-memory buffer
-	explicit FixedSizeBuffer(BlockManager &block_manager);
+	explicit FixedSizeBuffer(BlockManager &block_manager, MemoryTag memory_tag);
 	//! Constructor for deserializing buffer metadata from disk
 	FixedSizeBuffer(BlockManager &block_manager, const idx_t segment_count, const idx_t allocation_size,
 	                const BlockPointer &block_pointer);

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -37,6 +37,9 @@ public:
 	BufferManager &buffer_manager;
 
 public:
+	BufferManager &GetBufferManager() const {
+		return buffer_manager;
+	}
 	//! Creates a new block inside the block manager
 	virtual unique_ptr<Block> ConvertBlock(block_id_t block_id, FileBuffer &source_buffer) = 0;
 	virtual unique_ptr<Block> CreateBlock(block_id_t block_id, FileBuffer *source_buffer) = 0;

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -101,6 +101,8 @@ public:
 	//! Set a new swap limit.
 	virtual void SetSwapLimit(optional_idx limit = optional_idx());
 
+	//! Get the block manager used for in-memory data
+	virtual BlockManager &GetTemporaryBlockManager() = 0;
 	//! Get the temporary file information of each temporary file.
 	virtual vector<TemporaryFileInformation> GetTemporaryFiles();
 	//! Get the path to the temporary file directory.

--- a/src/include/duckdb/storage/metadata/metadata_manager.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_manager.hpp
@@ -62,6 +62,10 @@ public:
 	MetadataManager(BlockManager &block_manager, BufferManager &buffer_manager);
 	~MetadataManager();
 
+	BufferManager &GetBufferManager() const {
+		return buffer_manager;
+	}
+
 	MetadataHandle AllocateHandle();
 	MetadataHandle Pin(const MetadataPointer &pointer);
 

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -84,6 +84,8 @@ public:
 	//! Returns information about memory usage
 	vector<MemoryInformation> GetMemoryUsageInfo() const override;
 
+	BlockManager &GetTemporaryBlockManager() final;
+
 	//! Returns a list of all temporary files
 	vector<TemporaryFileInformation> GetTemporaryFiles() final;
 

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -108,7 +108,7 @@ public:
 
 public:
 	explicit ChunkVectorInfo(FixedSizeAllocator &allocator, idx_t start, transaction_t insert_id = 0);
-	~ChunkVectorInfo() final;
+	~ChunkVectorInfo() override;
 
 public:
 	idx_t GetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/common/atomic.hpp"
+#include "duckdb/execution/index/index_pointer.hpp"
 
 namespace duckdb {
 class RowGroup;
@@ -20,6 +21,7 @@ struct TransactionData;
 struct DeleteInfo;
 class Serializer;
 class Deserializer;
+class FixedSizeAllocator;
 
 enum class ChunkInfoType : uint8_t { CONSTANT_INFO, VECTOR_INFO, EMPTY_INFO };
 
@@ -38,19 +40,19 @@ public:
 public:
 	//! Gets up to max_count entries from the chunk info. If the ret is 0>ret>max_count, the selection vector is filled
 	//! with the tuples
-	virtual idx_t GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) = 0;
+	virtual idx_t GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) const = 0;
 	virtual idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
 	                                    SelectionVector &sel_vector, idx_t max_count) = 0;
 	//! Returns whether or not a single row in the ChunkInfo should be used or not for the given transaction
 	virtual bool Fetch(TransactionData transaction, row_t row) = 0;
 	virtual void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) = 0;
-	virtual idx_t GetCommittedDeletedCount(idx_t max_count) = 0;
+	virtual idx_t GetCommittedDeletedCount(idx_t max_count) const = 0;
 	virtual bool Cleanup(transaction_t lowest_transaction, unique_ptr<ChunkInfo> &result) const;
 
 	virtual bool HasDeletes() const = 0;
 
 	virtual void Write(WriteStream &writer) const;
-	static unique_ptr<ChunkInfo> Read(ReadStream &reader);
+	static unique_ptr<ChunkInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);
 
 public:
 	template <class TARGET>
@@ -81,12 +83,12 @@ public:
 	transaction_t delete_id;
 
 public:
-	idx_t GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) override;
+	idx_t GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) const override;
 	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
 	                            SelectionVector &sel_vector, idx_t max_count) override;
 	bool Fetch(TransactionData transaction, row_t row) override;
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
-	idx_t GetCommittedDeletedCount(idx_t max_count) override;
+	idx_t GetCommittedDeletedCount(idx_t max_count) const override;
 	bool Cleanup(transaction_t lowest_transaction, unique_ptr<ChunkInfo> &result) const override;
 
 	bool HasDeletes() const override;
@@ -105,27 +107,19 @@ public:
 	static constexpr const ChunkInfoType TYPE = ChunkInfoType::VECTOR_INFO;
 
 public:
-	explicit ChunkVectorInfo(idx_t start);
-
-	//! The transaction ids of the transactions that inserted the tuples (if any)
-	transaction_t inserted[STANDARD_VECTOR_SIZE];
-	transaction_t insert_id;
-	bool same_inserted_id;
-
-	//! The transaction ids of the transactions that deleted the tuples (if any)
-	transaction_t deleted[STANDARD_VECTOR_SIZE];
-	bool any_deleted;
+	explicit ChunkVectorInfo(FixedSizeAllocator &allocator, idx_t start, transaction_t insert_id = 0);
+	~ChunkVectorInfo() final;
 
 public:
 	idx_t GetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,
 	                   idx_t max_count) const;
-	idx_t GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) override;
+	idx_t GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) const override;
 	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
 	                            SelectionVector &sel_vector, idx_t max_count) override;
 	bool Fetch(TransactionData transaction, row_t row) override;
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
 	bool Cleanup(transaction_t lowest_transaction, unique_ptr<ChunkInfo> &result) const override;
-	idx_t GetCommittedDeletedCount(idx_t max_count) override;
+	idx_t GetCommittedDeletedCount(idx_t max_count) const override;
 
 	void Append(idx_t start, idx_t end, transaction_t commit_id);
 
@@ -140,12 +134,28 @@ public:
 	bool HasDeletes() const override;
 
 	void Write(WriteStream &writer) const override;
-	static unique_ptr<ChunkInfo> Read(ReadStream &reader);
+	static unique_ptr<ChunkInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);
 
 private:
 	template <class OP>
 	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,
 	                            idx_t max_count) const;
+
+	IndexPointer GetInsertedPointer() const;
+	IndexPointer GetDeletedPointer() const;
+	IndexPointer GetInitializedInsertedPointer();
+	IndexPointer GetInitializedDeletedPointer();
+
+private:
+	FixedSizeAllocator &allocator;
+	//! The transaction ids of the transactions that inserted the tuples (if any)
+	IndexPointer inserted_data;
+	transaction_t insert_id;
+	bool same_inserted_id;
+
+	//! The transaction ids of the transactions that deleted the tuples (if any)
+	IndexPointer deleted_data;
+	bool any_deleted;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -132,6 +132,8 @@ public:
 	void CommitDelete(transaction_t commit_id, const DeleteInfo &info);
 
 	bool HasDeletes() const override;
+	bool AnyDeleted() const;
+	bool HasSingleInsertionId() const;
 
 	void Write(WriteStream &writer) const override;
 	static unique_ptr<ChunkInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -153,11 +153,9 @@ private:
 	//! The transaction ids of the transactions that inserted the tuples (if any)
 	IndexPointer inserted_data;
 	transaction_t insert_id;
-	bool same_inserted_id;
 
 	//! The transaction ids of the transactions that deleted the tuples (if any)
 	IndexPointer deleted_data;
-	bool any_deleted;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -133,7 +133,8 @@ public:
 
 	bool HasDeletes() const override;
 	bool AnyDeleted() const;
-	bool HasSingleInsertionId() const;
+	bool HasConstantInsertionId() const;
+	transaction_t ConstantInsertId() const;
 
 	void Write(WriteStream &writer) const override;
 	static unique_ptr<ChunkInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);
@@ -152,7 +153,8 @@ private:
 	FixedSizeAllocator &allocator;
 	//! The transaction ids of the transactions that inserted the tuples (if any)
 	IndexPointer inserted_data;
-	transaction_t insert_id;
+	//! The constant insert id (if there is only one)
+	transaction_t constant_insert_id;
 
 	//! The transaction ids of the transactions that deleted the tuples (if any)
 	IndexPointer deleted_data;

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -12,19 +12,24 @@
 #include "duckdb/storage/table/chunk_info.hpp"
 #include "duckdb/storage/storage_info.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/execution/index/fixed_size_allocator.hpp"
 
 namespace duckdb {
 
 struct DeleteInfo;
 class MetadataManager;
+class BufferManager;
 struct MetaBlockPointer;
 
 class RowVersionManager {
 public:
-	explicit RowVersionManager(idx_t start) noexcept;
+	explicit RowVersionManager(BufferManager &buffer_manager, idx_t start) noexcept;
 
-	idx_t GetStart() {
+	idx_t GetStart() const {
 		return start;
+	}
+	FixedSizeAllocator &GetAllocator() {
+		return allocator;
 	}
 	void SetStart(idx_t start);
 	idx_t GetCommittedDeletedCount(idx_t count);
@@ -48,6 +53,7 @@ public:
 
 private:
 	mutex version_lock;
+	FixedSizeAllocator allocator;
 	idx_t start;
 	vector<unique_ptr<ChunkInfo>> vector_info;
 	bool has_changes;

--- a/src/main/client_data.cpp
+++ b/src/main/client_data.cpp
@@ -119,6 +119,9 @@ public:
 		return buffer_manager.SetSwapLimit(limit);
 	}
 
+	BlockManager &GetTemporaryBlockManager() override {
+		return buffer_manager.GetTemporaryBlockManager();
+	}
 	vector<TemporaryFileInformation> GetTemporaryFiles() override {
 		return buffer_manager.GetTemporaryFiles();
 	}

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -642,6 +642,10 @@ bool StandardBufferManager::HasFilesInTemporaryDirectory() const {
 	return found;
 }
 
+BlockManager &StandardBufferManager::GetTemporaryBlockManager() {
+	return *temp_block_manager;
+}
+
 vector<TemporaryFileInformation> StandardBufferManager::GetTemporaryFiles() {
 	vector<TemporaryFileInformation> result;
 	if (temporary_directory.path.empty()) {

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -1,10 +1,12 @@
 #include "duckdb/storage/table/chunk_info.hpp"
+
 #include "duckdb/transaction/transaction.hpp"
 #include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/transaction/delete_info.hpp"
+#include "duckdb/execution/index/fixed_size_allocator.hpp"
 
 namespace duckdb {
 
@@ -40,7 +42,7 @@ void ChunkInfo::Write(WriteStream &writer) const {
 	writer.Write<ChunkInfoType>(type);
 }
 
-unique_ptr<ChunkInfo> ChunkInfo::Read(ReadStream &reader) {
+unique_ptr<ChunkInfo> ChunkInfo::Read(FixedSizeAllocator &allocator, ReadStream &reader) {
 	auto type = reader.Read<ChunkInfoType>();
 	switch (type) {
 	case ChunkInfoType::EMPTY_INFO:
@@ -48,7 +50,7 @@ unique_ptr<ChunkInfo> ChunkInfo::Read(ReadStream &reader) {
 	case ChunkInfoType::CONSTANT_INFO:
 		return ChunkConstantInfo::Read(reader);
 	case ChunkInfoType::VECTOR_INFO:
-		return ChunkVectorInfo::Read(reader);
+		return ChunkVectorInfo::Read(allocator, reader);
 	default:
 		throw SerializationException("Could not deserialize Chunk Info Type: unrecognized type");
 	}
@@ -71,7 +73,7 @@ idx_t ChunkConstantInfo::TemplatedGetSelVector(transaction_t start_time, transac
 	return 0;
 }
 
-idx_t ChunkConstantInfo::GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) {
+idx_t ChunkConstantInfo::GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) const {
 	return TemplatedGetSelVector<TransactionVersionOperator>(transaction.start_time, transaction.transaction_id,
 	                                                         sel_vector, max_count);
 }
@@ -95,7 +97,7 @@ bool ChunkConstantInfo::HasDeletes() const {
 	return is_deleted;
 }
 
-idx_t ChunkConstantInfo::GetCommittedDeletedCount(idx_t max_count) {
+idx_t ChunkConstantInfo::GetCommittedDeletedCount(idx_t max_count) const {
 	return delete_id < TRANSACTION_ID_START ? max_count : 0;
 }
 
@@ -128,49 +130,73 @@ unique_ptr<ChunkInfo> ChunkConstantInfo::Read(ReadStream &reader) {
 //===--------------------------------------------------------------------===//
 // Vector info
 //===--------------------------------------------------------------------===//
-ChunkVectorInfo::ChunkVectorInfo(idx_t start)
-    : ChunkInfo(start, ChunkInfoType::VECTOR_INFO), insert_id(0), same_inserted_id(true), any_deleted(false) {
-	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-		inserted[i] = 0;
-		deleted[i] = NOT_DELETED_ID;
+ChunkVectorInfo::ChunkVectorInfo(FixedSizeAllocator &allocator_p, idx_t start, transaction_t insert_id_p)
+    : ChunkInfo(start, ChunkInfoType::VECTOR_INFO), allocator(allocator_p), insert_id(insert_id_p),
+      same_inserted_id(true), any_deleted(false) {
+}
+
+ChunkVectorInfo::~ChunkVectorInfo() {
+	D_ASSERT(any_deleted || deleted_data.Get() == 0);
+	D_ASSERT(!same_inserted_id || inserted_data.Get() == 0);
+	if (any_deleted) {
+		allocator.Free(deleted_data);
+	}
+	if (!same_inserted_id) {
+		allocator.Free(inserted_data);
 	}
 }
 
 template <class OP>
 idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id,
                                              SelectionVector &sel_vector, idx_t max_count) const {
-	idx_t count = 0;
-	if (same_inserted_id && !any_deleted) {
-		// all tuples have the same inserted id: and no tuples were deleted
-		if (OP::UseInsertedVersion(start_time, transaction_id, insert_id)) {
-			return max_count;
-		} else {
-			return 0;
+	if (same_inserted_id) {
+		if (!any_deleted) {
+			// all tuples have the same inserted id: and no tuples were deleted
+			if (OP::UseInsertedVersion(start_time, transaction_id, insert_id)) {
+				return max_count;
+			} else {
+				return 0;
+			}
 		}
-	} else if (same_inserted_id) {
 		if (!OP::UseInsertedVersion(start_time, transaction_id, insert_id)) {
 			return 0;
 		}
 		// have to check deleted flag
+		idx_t count = 0;
+		auto segment = allocator.GetHandle(GetDeletedPointer());
+		auto deleted = segment.GetPtr<transaction_t>();
 		for (idx_t i = 0; i < max_count; i++) {
 			if (OP::UseDeletedVersion(start_time, transaction_id, deleted[i])) {
 				sel_vector.set_index(count++, i);
 			}
 		}
-	} else if (!any_deleted) {
+		return count;
+	}
+	if (!any_deleted) {
 		// have to check inserted flag
+		auto insert_segment = allocator.GetHandle(GetInsertedPointer());
+		auto inserted = insert_segment.GetPtr<transaction_t>();
+
+		idx_t count = 0;
 		for (idx_t i = 0; i < max_count; i++) {
 			if (OP::UseInsertedVersion(start_time, transaction_id, inserted[i])) {
 				sel_vector.set_index(count++, i);
 			}
 		}
-	} else {
-		// have to check both flags
-		for (idx_t i = 0; i < max_count; i++) {
-			if (OP::UseInsertedVersion(start_time, transaction_id, inserted[i]) &&
-			    OP::UseDeletedVersion(start_time, transaction_id, deleted[i])) {
-				sel_vector.set_index(count++, i);
-			}
+		return count;
+	}
+
+	idx_t count = 0;
+	// have to check both flags
+	auto insert_segment = allocator.GetHandle(GetInsertedPointer());
+	auto inserted = insert_segment.GetPtr<transaction_t>();
+
+	auto delete_segment = allocator.GetHandle(GetDeletedPointer());
+	auto deleted = delete_segment.GetPtr<transaction_t>();
+	for (idx_t i = 0; i < max_count; i++) {
+		if (OP::UseInsertedVersion(start_time, transaction_id, inserted[i]) &&
+		    OP::UseDeletedVersion(start_time, transaction_id, deleted[i])) {
+			sel_vector.set_index(count++, i);
 		}
 	}
 	return count;
@@ -186,16 +212,76 @@ idx_t ChunkVectorInfo::GetCommittedSelVector(transaction_t min_start_id, transac
 	return TemplatedGetSelVector<CommittedVersionOperator>(min_start_id, min_transaction_id, sel_vector, max_count);
 }
 
-idx_t ChunkVectorInfo::GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) {
+idx_t ChunkVectorInfo::GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) const {
 	return GetSelVector(transaction.start_time, transaction.transaction_id, sel_vector, max_count);
 }
 
 bool ChunkVectorInfo::Fetch(TransactionData transaction, row_t row) {
-	return UseVersion(transaction, inserted[row]) && !UseVersion(transaction, deleted[row]);
+	transaction_t fetch_insert_id;
+	transaction_t fetch_deleted_id;
+	if (same_inserted_id) {
+		fetch_insert_id = insert_id;
+	} else {
+		auto insert_segment = allocator.GetHandle(GetInsertedPointer());
+		auto inserted = insert_segment.GetPtr<transaction_t>();
+		fetch_insert_id = inserted[row];
+	}
+	if (!any_deleted) {
+		fetch_deleted_id = NOT_DELETED_ID;
+	} else {
+		auto delete_segment = allocator.GetHandle(GetDeletedPointer());
+		auto deleted = delete_segment.GetPtr<transaction_t>();
+		fetch_deleted_id = deleted[row];
+	}
+
+	return UseVersion(transaction, fetch_insert_id) && !UseVersion(transaction, fetch_deleted_id);
+}
+
+IndexPointer ChunkVectorInfo::GetInsertedPointer() const {
+	if (same_inserted_id) {
+		throw InternalException("ChunkVectorInfo: insert id requested but insertions were not initialized");
+	}
+	return inserted_data;
+}
+
+IndexPointer ChunkVectorInfo::GetDeletedPointer() const {
+	if (!any_deleted) {
+		throw InternalException("ChunkVectorInfo: deleted id requested but deletions were not initialized");
+	}
+	return deleted_data;
+}
+
+IndexPointer ChunkVectorInfo::GetInitializedInsertedPointer() {
+	if (same_inserted_id) {
+		same_inserted_id = false;
+
+		inserted_data = allocator.New();
+		auto segment = allocator.GetHandle(inserted_data);
+		auto inserted = segment.GetPtr<transaction_t>();
+		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+			inserted[i] = insert_id;
+		}
+	}
+	return inserted_data;
+}
+
+IndexPointer ChunkVectorInfo::GetInitializedDeletedPointer() {
+	if (!any_deleted) {
+		any_deleted = true;
+
+		deleted_data = allocator.New();
+		auto segment = allocator.GetHandle(deleted_data);
+		auto deleted = segment.GetPtr<transaction_t>();
+		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+			deleted[i] = NOT_DELETED_ID;
+		}
+	}
+	return deleted_data;
 }
 
 idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t count) {
-	any_deleted = true;
+	auto segment = allocator.GetHandle(GetInitializedDeletedPointer());
+	auto deleted = segment.GetPtr<transaction_t>();
 
 	idx_t deleted_tuples = 0;
 	for (idx_t i = 0; i < count; i++) {
@@ -220,6 +306,9 @@ idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t 
 }
 
 void ChunkVectorInfo::CommitDelete(transaction_t commit_id, const DeleteInfo &info) {
+	auto segment = allocator.GetHandle(GetDeletedPointer());
+	auto deleted = segment.GetPtr<transaction_t>();
+
 	if (info.is_consecutive) {
 		for (idx_t i = 0; i < info.count; i++) {
 			deleted[i] = commit_id;
@@ -234,11 +323,17 @@ void ChunkVectorInfo::CommitDelete(transaction_t commit_id, const DeleteInfo &in
 
 void ChunkVectorInfo::Append(idx_t start, idx_t end, transaction_t commit_id) {
 	if (start == 0) {
+		// first insert to this vector - just assign the commit id
 		insert_id = commit_id;
-	} else if (insert_id != commit_id) {
-		same_inserted_id = false;
-		insert_id = NOT_DELETED_ID;
+		return;
 	}
+	if (same_inserted_id && insert_id == commit_id) {
+		// we are inserting again, but we have the same id as before - still the same insert id
+		return;
+	}
+
+	auto segment = allocator.GetHandle(GetInitializedInsertedPointer());
+	auto inserted = segment.GetPtr<transaction_t>();
 	for (idx_t i = start; i < end; i++) {
 		inserted[i] = commit_id;
 	}
@@ -247,7 +342,11 @@ void ChunkVectorInfo::Append(idx_t start, idx_t end, transaction_t commit_id) {
 void ChunkVectorInfo::CommitAppend(transaction_t commit_id, idx_t start, idx_t end) {
 	if (same_inserted_id) {
 		insert_id = commit_id;
+		return;
 	}
+	auto segment = allocator.GetHandle(GetInsertedPointer());
+	auto inserted = segment.GetPtr<transaction_t>();
+
 	for (idx_t i = start; i < end; i++) {
 		inserted[i] = commit_id;
 	}
@@ -260,6 +359,9 @@ bool ChunkVectorInfo::Cleanup(transaction_t lowest_transaction, unique_ptr<Chunk
 	}
 	// check if the insertion markers have to be used by all transactions going forward
 	if (!same_inserted_id) {
+		auto segment = allocator.GetHandle(GetInsertedPointer());
+		auto inserted = segment.GetPtr<transaction_t>();
+
 		for (idx_t idx = 1; idx < STANDARD_VECTOR_SIZE; idx++) {
 			if (inserted[idx] > lowest_transaction) {
 				// transaction was inserted after the lowest transaction start
@@ -279,10 +381,13 @@ bool ChunkVectorInfo::HasDeletes() const {
 	return any_deleted;
 }
 
-idx_t ChunkVectorInfo::GetCommittedDeletedCount(idx_t max_count) {
+idx_t ChunkVectorInfo::GetCommittedDeletedCount(idx_t max_count) const {
 	if (!any_deleted) {
 		return 0;
 	}
+	auto segment = allocator.GetHandle(GetDeletedPointer());
+	auto deleted = segment.GetPtr<transaction_t>();
+
 	idx_t delete_count = 0;
 	for (idx_t i = 0; i < max_count; i++) {
 		if (deleted[i] < TRANSACTION_ID_START) {
@@ -319,15 +424,17 @@ void ChunkVectorInfo::Write(WriteStream &writer) const {
 	mask.Write(writer, STANDARD_VECTOR_SIZE);
 }
 
-unique_ptr<ChunkInfo> ChunkVectorInfo::Read(ReadStream &reader) {
+unique_ptr<ChunkInfo> ChunkVectorInfo::Read(FixedSizeAllocator &allocator, ReadStream &reader) {
 	auto start = reader.Read<idx_t>();
-	auto result = make_uniq<ChunkVectorInfo>(start);
-	result->any_deleted = true;
+	auto result = make_uniq<ChunkVectorInfo>(allocator, start);
 	ValidityMask mask;
 	mask.Read(reader, STANDARD_VECTOR_SIZE);
+
+	auto segment = allocator.GetHandle(result->GetInitializedDeletedPointer());
+	auto deleted = segment.GetPtr<transaction_t>();
 	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
 		if (mask.RowIsValid(i)) {
-			result->deleted[i] = 0;
+			deleted[i] = 0;
 		}
 	}
 	return std::move(result);

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -723,7 +723,8 @@ shared_ptr<RowVersionManager> RowGroup::GetOrCreateVersionInfoInternal() {
 	// version info does not exist - need to create it
 	lock_guard<mutex> lock(row_group_lock);
 	if (!owned_version_info) {
-		auto new_info = make_shared_ptr<RowVersionManager>(start);
+		auto &buffer_manager = GetBlockManager().GetBufferManager();
+		auto new_info = make_shared_ptr<RowVersionManager>(buffer_manager, start);
 		SetVersionInfo(std::move(new_info));
 	}
 	return owned_version_info;

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -8,7 +8,8 @@
 namespace duckdb {
 
 RowVersionManager::RowVersionManager(BufferManager &buffer_manager_p, idx_t start) noexcept
-    : allocator(STANDARD_VECTOR_SIZE * sizeof(transaction_t), buffer_manager_p.GetTemporaryBlockManager()),
+    : allocator(STANDARD_VECTOR_SIZE * sizeof(transaction_t), buffer_manager_p.GetTemporaryBlockManager(),
+                MemoryTag::BASE_TABLE),
       start(start), has_changes(false) {
 }
 

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -7,7 +7,9 @@
 
 namespace duckdb {
 
-RowVersionManager::RowVersionManager(idx_t start) noexcept : start(start), has_changes(false) {
+RowVersionManager::RowVersionManager(BufferManager &buffer_manager_p, idx_t start) noexcept
+    : allocator(STANDARD_VECTOR_SIZE * sizeof(transaction_t), buffer_manager_p.GetTemporaryBlockManager()),
+      start(start), has_changes(false) {
 }
 
 void RowVersionManager::SetStart(idx_t new_start) {
@@ -112,7 +114,7 @@ void RowVersionManager::AppendVersionInfo(TransactionData transaction, idx_t cou
 			optional_ptr<ChunkVectorInfo> new_info;
 			if (!vector_info[vector_idx]) {
 				// first time appending to this vector: create new info
-				auto insert_info = make_uniq<ChunkVectorInfo>(start + vector_idx * STANDARD_VECTOR_SIZE);
+				auto insert_info = make_uniq<ChunkVectorInfo>(allocator, start + vector_idx * STANDARD_VECTOR_SIZE);
 				new_info = insert_info.get();
 				vector_info[vector_idx] = std::move(insert_info);
 			} else if (vector_info[vector_idx]->type == ChunkInfoType::VECTOR_INFO) {
@@ -188,15 +190,12 @@ ChunkVectorInfo &RowVersionManager::GetVectorInfo(idx_t vector_idx) {
 
 	if (!vector_info[vector_idx]) {
 		// no info yet: create it
-		vector_info[vector_idx] = make_uniq<ChunkVectorInfo>(start + vector_idx * STANDARD_VECTOR_SIZE);
+		vector_info[vector_idx] = make_uniq<ChunkVectorInfo>(allocator, start + vector_idx * STANDARD_VECTOR_SIZE);
 	} else if (vector_info[vector_idx]->type == ChunkInfoType::CONSTANT_INFO) {
 		auto &constant = vector_info[vector_idx]->Cast<ChunkConstantInfo>();
 		// info exists but it's a constant info: convert to a vector info
-		auto new_info = make_uniq<ChunkVectorInfo>(start + vector_idx * STANDARD_VECTOR_SIZE);
-		new_info->insert_id = constant.insert_id;
-		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-			new_info->inserted[i] = constant.insert_id;
-		}
+		auto new_info =
+		    make_uniq<ChunkVectorInfo>(allocator, start + vector_idx * STANDARD_VECTOR_SIZE, constant.insert_id);
 		vector_info[vector_idx] = std::move(new_info);
 	}
 	D_ASSERT(vector_info[vector_idx]->type == ChunkInfoType::VECTOR_INFO);
@@ -262,7 +261,7 @@ shared_ptr<RowVersionManager> RowVersionManager::Deserialize(MetaBlockPointer de
 	if (!delete_pointer.IsValid()) {
 		return nullptr;
 	}
-	auto version_info = make_shared_ptr<RowVersionManager>(start);
+	auto version_info = make_shared_ptr<RowVersionManager>(manager.GetBufferManager(), start);
 	MetadataReader source(manager, delete_pointer, &version_info->storage_pointers);
 	auto chunk_count = source.Read<idx_t>();
 	D_ASSERT(chunk_count > 0);
@@ -275,7 +274,7 @@ shared_ptr<RowVersionManager> RowVersionManager::Deserialize(MetaBlockPointer de
 		}
 
 		version_info->FillVectorInfo(vector_index);
-		version_info->vector_info[vector_index] = ChunkInfo::Read(source);
+		version_info->vector_info[vector_index] = ChunkInfo::Read(version_info->GetAllocator(), source);
 	}
 	version_info->has_changes = false;
 	return version_info;

--- a/test/sql/index/art/issues/test_art_fuzzer_persisted.test
+++ b/test/sql/index/art/issues/test_art_fuzzer_persisted.test
@@ -14,7 +14,7 @@ statement ok
 CREATE INDEX i1 ON t1 (c1);
 
 statement ok
-PRAGMA MEMORY_LIMIT='2MB';
+PRAGMA MEMORY_LIMIT='4MB';
 
 statement ok
 CHECKPOINT;


### PR DESCRIPTION
This PR switches the `RowVersionManager` that tracks whether or not rows are relevant for a given transaction to using the `FixedSizeAllocator`. This makes the majority of its memory usage trackable with the buffer manager. The `FixedSizeAllocator` does not support evicting yet - but it could in theory also start supporting that in the future using this setup.

