### PR TITLE
Fixes for CTE (de)serialization compatibility with older versions

### DIFF
--- a/src/include/duckdb/parser/query_node.hpp
+++ b/src/include/duckdb/parser/query_node.hpp
@@ -78,6 +78,9 @@ public:
 	virtual void Serialize(Serializer &serializer) const;
 	static unique_ptr<QueryNode> Deserialize(Deserializer &deserializer);
 
+	//! TEMPORARY BUG FIX WORKAROUND: extract elements from the CommonTableExpressionMap and construct CTENodes
+	static void ExtractCTENodes(unique_ptr<QueryNode> &query_node);
+
 protected:
 	//! Copy base QueryNode properties from another expression to this one,
 	//! used in Copy method

--- a/src/include/duckdb/storage/serialization/query_node.json
+++ b/src/include/duckdb/storage/serialization/query_node.json
@@ -21,6 +21,9 @@
         "name": "cte_map",
         "type": "CommonTableExpressionMap"
       }
+    ],
+    "finalize_deserialization": [
+        "ExtractCTENodes(result);"
     ]
   },
   {
@@ -176,13 +179,8 @@
         "id": 203,
         "name": "aliases",
         "type": "vector<string>"
-      },
-      {
-        "id": 204,
-        "name": "materialized",
-        "type": "CTEMaterialize",
-        "default": "CTEMaterialize::CTE_MATERIALIZE_DEFAULT"
       }
-    ]
+    ],
+    "custom_implementation": true
   }
 ]

--- a/src/include/duckdb/verification/deserialized_statement_verifier.hpp
+++ b/src/include/duckdb/verification/deserialized_statement_verifier.hpp
@@ -18,6 +18,12 @@ public:
 	                                       optional_ptr<case_insensitive_map_t<BoundParameterData>> parameters);
 	static unique_ptr<StatementVerifier> Create(const SQLStatement &statement,
 	                                            optional_ptr<case_insensitive_map_t<BoundParameterData>> parameters);
+
+public:
+	// TEMPORARY FIX: work-around for CTE serialization for v1.4.X
+	bool RequireEquality() const override {
+		return false;
+	}
 };
 
 } // namespace duckdb

--- a/src/parser/query_node/cte_node.cpp
+++ b/src/parser/query_node/cte_node.cpp
@@ -45,7 +45,7 @@ unique_ptr<QueryNode> CTENode::Copy() const {
 // the below code fixes backwards and forwards compatibility of CTEs with the somewhat broken version of CTEs in v1.4
 // all of this code has been made obsolete with the CTE binding rework
 void QueryNode::ExtractCTENodes(unique_ptr<QueryNode> &query_node) {
-	if (!query_node->cte_map.map.empty()) {
+	if (query_node->cte_map.map.empty()) {
 		return;
 	}
 	vector<unique_ptr<CTENode>> materialized_ctes;

--- a/src/parser/query_node/cte_node.cpp
+++ b/src/parser/query_node/cte_node.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/parser/query_node/cte_node.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
 
 namespace duckdb {
 
@@ -38,5 +39,84 @@ unique_ptr<QueryNode> CTENode::Copy() const {
 	this->CopyProperties(*result);
 	return std::move(result);
 }
+
+// TEMPORARY BUGFIX WARNING - none of this code should make it into main - this is a temporary work-around for v1.4
+// TEMPORARY BUGFIX START
+// the below code fixes backwards and forwards compatibility of CTEs with the somewhat broken version of CTEs in v1.4
+// all of this code has been made obsolete with the CTE binding rework
+void QueryNode::ExtractCTENodes(unique_ptr<QueryNode> &query_node) {
+	if (!query_node->cte_map.map.empty()) {
+		return;
+	}
+	vector<unique_ptr<CTENode>> materialized_ctes;
+	for (auto &cte : query_node->cte_map.map) {
+		auto &cte_entry = cte.second;
+		auto mat_cte = make_uniq<CTENode>();
+		mat_cte->ctename = cte.first;
+		mat_cte->query = cte_entry->query->node->Copy();
+		mat_cte->aliases = cte_entry->aliases;
+		mat_cte->materialized = cte_entry->materialized;
+		materialized_ctes.push_back(std::move(mat_cte));
+	}
+
+	auto root = std::move(query_node);
+	while (!materialized_ctes.empty()) {
+		unique_ptr<CTENode> node_result;
+		node_result = std::move(materialized_ctes.back());
+		node_result->cte_map = root->cte_map.Copy();
+		node_result->child = std::move(root);
+		root = std::move(node_result);
+		materialized_ctes.pop_back();
+	}
+	query_node = std::move(root);
+}
+
+void CTENode::Serialize(Serializer &serializer) const {
+	if (materialized == CTEMaterialize::CTE_MATERIALIZE_NEVER) {
+		// for non-materialized CTEs - don't serialize CTENode
+		// older DuckDB versions only expect a CTENode to be there for materialized CTEs
+		child->Serialize(serializer);
+		return;
+	}
+	QueryNode::Serialize(serializer);
+	serializer.WritePropertyWithDefault<string>(200, "cte_name", ctename);
+	serializer.WritePropertyWithDefault<unique_ptr<QueryNode>>(201, "query", query);
+	serializer.WritePropertyWithDefault<unique_ptr<QueryNode>>(202, "child", child);
+	serializer.WritePropertyWithDefault<vector<string>>(203, "aliases", aliases);
+}
+
+// In QueryNode::ExtractCTENodes we create a bunch of CTENodes from the CommonTableExpressionMap in the QueryNode
+// however, we might ALSO have a CTENode present depending on how the serialization is set up
+// if we ended up creating duplicate CTE nodes in QueryNode::ExtractCTENodes - this ends up de-duplicating them again
+void EraseDuplicateCTE(unique_ptr<QueryNode> &node, const string &ctename) {
+	if (node->type != QueryNodeType::CTE_NODE) {
+		// not a CTE
+		return;
+	}
+	auto &cte_node = node->Cast<CTENode>();
+	if (cte_node.ctename == ctename) {
+		// duplicate CTE - erase this CTE node
+		node = std::move(cte_node.child);
+		EraseDuplicateCTE(node, ctename);
+	} else {
+		// not a duplicate - recurse into child
+		EraseDuplicateCTE(cte_node.child, ctename);
+	}
+}
+
+unique_ptr<QueryNode> CTENode::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<CTENode>(new CTENode());
+	deserializer.ReadPropertyWithDefault<string>(200, "cte_name", result->ctename);
+	deserializer.ReadPropertyWithDefault<unique_ptr<QueryNode>>(201, "query", result->query);
+	deserializer.ReadPropertyWithDefault<unique_ptr<QueryNode>>(202, "child", result->child);
+	deserializer.ReadPropertyWithDefault<vector<string>>(203, "aliases", result->aliases);
+	// v1.4.0 and v1.4.1 wrote this property - deserialize it for BC with these versions
+	deserializer.ReadPropertyWithExplicitDefault<CTEMaterialize>(204, "materialized", result->materialized,
+	                                                             CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
+	EraseDuplicateCTE(result->child, result->ctename);
+	return std::move(result);
+}
+// TEMPORARY BUGFIX WARNING - none of this code should make it into main - this is a temporary work-around for v1.4
+// TEMPORARY BUGFIX END
 
 } // namespace duckdb

--- a/src/storage/serialization/serialize_query_node.cpp
+++ b/src/storage/serialization/serialize_query_node.cpp
@@ -38,26 +38,8 @@ unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &deserializer) {
 	}
 	result->modifiers = std::move(modifiers);
 	result->cte_map = std::move(cte_map);
+	ExtractCTENodes(result);
 	return result;
-}
-
-void CTENode::Serialize(Serializer &serializer) const {
-	QueryNode::Serialize(serializer);
-	serializer.WritePropertyWithDefault<string>(200, "cte_name", ctename);
-	serializer.WritePropertyWithDefault<unique_ptr<QueryNode>>(201, "query", query);
-	serializer.WritePropertyWithDefault<unique_ptr<QueryNode>>(202, "child", child);
-	serializer.WritePropertyWithDefault<vector<string>>(203, "aliases", aliases);
-	serializer.WritePropertyWithDefault<CTEMaterialize>(204, "materialized", materialized, CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
-}
-
-unique_ptr<QueryNode> CTENode::Deserialize(Deserializer &deserializer) {
-	auto result = duckdb::unique_ptr<CTENode>(new CTENode());
-	deserializer.ReadPropertyWithDefault<string>(200, "cte_name", result->ctename);
-	deserializer.ReadPropertyWithDefault<unique_ptr<QueryNode>>(201, "query", result->query);
-	deserializer.ReadPropertyWithDefault<unique_ptr<QueryNode>>(202, "child", result->child);
-	deserializer.ReadPropertyWithDefault<vector<string>>(203, "aliases", result->aliases);
-	deserializer.ReadPropertyWithExplicitDefault<CTEMaterialize>(204, "materialized", result->materialized, CTEMaterialize::CTE_MATERIALIZE_DEFAULT);
-	return std::move(result);
 }
 
 void RecursiveCTENode::Serialize(Serializer &serializer) const {


### PR DESCRIPTION

The CTE (de)serialization code in v1.4 has a number of issues:

* It is writing `CTEMaterialize` for CTENodes which is not supported in older DuckDB versions, causing forwards compatibility to break and older versions not to be able to read DuckDB files written by v1.4 when they contain CTEs that are explicitly labeled as `MATERIALIZED` or `NOT MATERIALIZED`
* It is not correctly de-duplicating CTENodes from the CommonTableExpressionMap, causing some old CTEs to not be readable anymore (as explained here - https://github.com/duckdb/duckdb/pull/19351)

This has all already been fundamentally fixed in main in https://github.com/duckdb/duckdb/pull/19351. However, in order to also fix this for following v1.4 versions (v1.4.2) - this PR patches the serialization code in a lower risk manner. Effectively:

* We no longer write `CTEMaterialize` for CTENodes. Instead, we only write the CTENode if it should be materialized. Otherwise, we don't write it to the file.
* When reading a `QueryNode`, we immediately perform "re-duplication" by extracting CTENodes from the `CommonTableExpressionMap. This fixes an issue where we were not correctly re-duplicating at all levels.
* When deserializing a CTENode, we perform de-duplication of CTEs within its child. This fixes an issue where the above re-duplication could cause the same CTE to appear multiple times depending on from which version we are de-serializing.

All of this is only necessary for v1.4 - and when we merge v1.4 into main this code should be deleted.

