### PR TITLE
[Dev] `variant_extract` BindData copy fix

### DIFF
--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -12,6 +12,7 @@ struct BindData : public FunctionData {
 public:
 	explicit BindData(const string &str);
 	explicit BindData(uint32_t index);
+	BindData(const BindData &other) = default;
 
 public:
 	unique_ptr<FunctionData> Copy() const override;
@@ -36,10 +37,7 @@ BindData::BindData(uint32_t index) : FunctionData() {
 }
 
 unique_ptr<FunctionData> BindData::Copy() const {
-	if (component.lookup_mode == VariantChildLookupMode::BY_INDEX) {
-		return make_uniq<BindData>(component.index);
-	}
-	return make_uniq<BindData>(component.key);
+	return make_uniq<BindData>(*this);
 }
 
 bool BindData::Equals(const FunctionData &other) const {

--- a/test/sql/function/variant/variant_typeof.test
+++ b/test/sql/function/variant/variant_typeof.test
@@ -1,6 +1,9 @@
 # name: test/sql/function/variant/variant_typeof.test
 # group: [variant]
 
+statement ok
+pragma enable_verification;
+
 query I
 select variant_typeof({'a': 42}::VARIANT);
 ----


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/6250 and https://github.com/duckdblabs/duckdb-internal/issues/6224