### PR TITLE
Fixup Kalman fiter: bound it's (0, scale_factor), not (0, 1)

### DIFF
--- a/src/common/progress_bar/unscented_kalman_filter.cpp
+++ b/src/common/progress_bar/unscented_kalman_filter.cpp
@@ -254,11 +254,11 @@ void UnscentedKalmanFilter::UpdateInternal(double measured_progress) {
 	}
 
 	// Ensure progress stays in bounds
-	x[0] = std::max(0.0, std::min(1.0, x[0]));
+	x[0] = std::max(0.0, std::min(scale_factor, x[0]));
 }
 
 double UnscentedKalmanFilter::GetProgress() const {
-	return x[0];
+	return x[0] / scale_factor;
 }
 
 double UnscentedKalmanFilter::GetVelocity() const {


### PR DESCRIPTION
When `scale_factor` is not 1.0, current computations would eventually stop working towards the last part of a query (after `1.0 / scale_factor` time).

Funny thing is that `scale_factor` is mostly 1.0 if you have a decent network, so in a production setup this is hard to see.

Basic is that say `scale_factor` is 2.0, after a jittery start progress estimate (`x[0]`) would go towards 2.0. Problem, currently it's cut at 1.0.
Example with round numbers:

elapsed time | x[0] | current estimate | fixed-up estimate
--- | ---- | ---- | ---
0 s | 0 | ??? | ???
30 s | 0.5 (scale_factor = 2.0) | around 90 s | around 90 s
60 s | 1.0 (scale_factor = 2.0) | around 60 s | around 60 s
90 s | 1.5, capped at 1.0 (sf = 2.0) | around 60 s (!!) | around 30 s
119 s | 1.98, capped at 1.0 (sf = 2.0) | around 60 s (!!!!) | around 1 s

FYI: @rustyconover, I think those are the only places I have seen, and with those changes estimates act reasonably again.