### PR TITLE
Fix #18139: correctly initialize flush size in MemoryStream, and re-use writer states

### DIFF
--- a/src/common/csv_writer.cpp
+++ b/src/common/csv_writer.cpp
@@ -16,7 +16,7 @@ CSVWriterState::CSVWriterState()
 }
 
 CSVWriterState::CSVWriterState(ClientContext &context, idx_t flush_size_p)
-    : flush_size(flush_size_p), stream(make_uniq<MemoryStream>(Allocator::Get(context))) {
+    : flush_size(flush_size_p), stream(make_uniq<MemoryStream>(Allocator::Get(context), flush_size)) {
 }
 
 CSVWriterState::CSVWriterState(DatabaseInstance &db, idx_t flush_size_p)

--- a/src/common/csv_writer.cpp
+++ b/src/common/csv_writer.cpp
@@ -198,18 +198,6 @@ void CSVWriter::ResetInternal(optional_ptr<CSVWriterState> local_state) {
 	bytes_written = 0;
 }
 
-unique_ptr<CSVWriterState> CSVWriter::InitializeLocalWriteState(ClientContext &context, idx_t flush_size) {
-	auto res = make_uniq<CSVWriterState>(context, flush_size);
-	res->stream = make_uniq<MemoryStream>();
-	return res;
-}
-
-unique_ptr<CSVWriterState> CSVWriter::InitializeLocalWriteState(DatabaseInstance &db, idx_t flush_size) {
-	auto res = make_uniq<CSVWriterState>(db, flush_size);
-	res->stream = make_uniq<MemoryStream>();
-	return res;
-}
-
 idx_t CSVWriter::BytesWritten() {
 	if (shared) {
 		lock_guard<mutex> flock(lock);

--- a/src/include/duckdb/common/csv_writer.hpp
+++ b/src/include/duckdb/common/csv_writer.hpp
@@ -90,9 +90,6 @@ public:
 	//! Closes the writer, optionally writes a postfix
 	void Close();
 
-	unique_ptr<CSVWriterState> InitializeLocalWriteState(ClientContext &context, idx_t flush_size);
-	unique_ptr<CSVWriterState> InitializeLocalWriteState(DatabaseInstance &db, idx_t flush_size);
-
 	vector<unique_ptr<Expression>> string_casts;
 
 	idx_t BytesWritten();


### PR DESCRIPTION
Fixes #18139 

The performance variation comes from us triggering a poor case in MacOS' allocator - the issue doesn't occur outside of MacOS and requires a specific number of threads. We can avoid the issue (and it is generally good practice anyway) by doing fewer (re)-allocations. 

This was already partially fixed once before in https://github.com/duckdb/duckdb/pull/18174 but that seems to have gotten lost in the refactor of https://github.com/duckdb/duckdb/pull/17692. This PR brings back that fix and adds an additional fix by reducing the number of `CSVWriterState` that are instantiated during batch writes.