### PR TITLE
fix: treat HAVING without GROUP BY/aggregates as global aggregation

### DIFF
--- a/src/planner/binder/query_node/plan_select_node.cpp
+++ b/src/planner/binder/query_node/plan_select_node.cpp
@@ -54,6 +54,20 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 		// this can only happen if we have e.g. select 1 from tbl group by ();
 		// just output a dummy scan
 		root = make_uniq_base<LogicalOperator, LogicalDummyScan>(statement.group_index);
+	} else if (statement.having) {
+		// HAVING without GROUP BY or aggregates should still operate on a single group
+		// Introduce a global aggregate (with zero aggregate expressions) so that HAVING is evaluated once
+		// over a single row result, matching PostgreSQL semantics.
+		auto aggregate = make_uniq<LogicalAggregate>(statement.group_index, statement.aggregate_index,
+		                                         std::move(statement.aggregates));
+		// no groups
+		aggregate->groupings_index = statement.groupings_index;
+		// grouping sets/functions are irrelevant here but keep structure intact
+		aggregate->grouping_sets = std::move(statement.groups.grouping_sets);
+		aggregate->grouping_functions = std::move(statement.grouping_functions);
+
+		aggregate->AddChild(std::move(root));
+		root = std::move(aggregate);
 	}
 
 	if (statement.having) {

--- a/src/planner/binder/query_node/plan_select_node.cpp
+++ b/src/planner/binder/query_node/plan_select_node.cpp
@@ -59,7 +59,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 		// Introduce a global aggregate (with zero aggregate expressions) so that HAVING is evaluated once
 		// over a single row result, matching PostgreSQL semantics.
 		auto aggregate = make_uniq<LogicalAggregate>(statement.group_index, statement.aggregate_index,
-		                                         std::move(statement.aggregates));
+		                                             std::move(statement.aggregates));
 		// no groups
 		aggregate->groupings_index = statement.groupings_index;
 		// grouping sets/functions are irrelevant here but keep structure intact

--- a/test/sql/aggregate/having/test_scalar_having.test
+++ b/test/sql/aggregate/having/test_scalar_having.test
@@ -81,3 +81,9 @@ query R
 SELECT SUM(a) FROM test HAVING COUNT(*)>10;
 ----
 
+# HAVING without GROUP BY and without aggregates should evaluate once, not per input row
+query I
+SELECT 1 AS one FROM (values(1,2),(2,3)) HAVING 1 < 2;
+----
+1
+


### PR DESCRIPTION
Add test for single-row HAVING evaluation to ensure HAVING clauses without GROUP BY operate on a single global group, matching PostgreSQL semantics.

Fixes #19313