### PR TITLE
Fix StringDecompress for hugeint_t values

### DIFF
--- a/src/function/scalar/compressed_materialization/compress_string.cpp
+++ b/src/function/scalar/compressed_materialization/compress_string.cpp
@@ -198,7 +198,7 @@ scalar_function_t GetStringDecompressFunctionSwitch(const LogicalType &input_typ
 	case LogicalTypeId::UHUGEINT:
 		return GetStringDecompressFunction<uhugeint_t>(input_type);
 	case LogicalTypeId::HUGEINT:
-		return GetStringCompressFunction<hugeint_t>(input_type);
+		return GetStringDecompressFunction<hugeint_t>(input_type);
 	default:
 		throw InternalException("Unexpected type in GetStringDecompressFunctionSwitch");
 	}


### PR DESCRIPTION
The patch in https://github.com/duckdb/duckdb/pull/18622 had a copy-paste bug. This causes clients with older plans that still use the legacy hugeint_t compression to not be compatible with DuckDB 1.4 and later.