### PR TITLE
Fix #19211: make INSERT OR IGNORE correctly handle multiple constraints

### DIFF
--- a/test/sql/upsert/upsert_multiple_constraints.test
+++ b/test/sql/upsert/upsert_multiple_constraints.test
@@ -1,0 +1,16 @@
+# name: test/sql/upsert/upsert_multiple_constraints.test
+# description: Test upsert with a mix of primary / unique constraints
+# group: [upsert]
+
+statement ok
+CREATE TABLE IF NOT EXISTS tbl (id INTEGER PRIMARY KEY, uniq INTEGER, UNIQUE(uniq));
+
+query I
+INSERT OR IGNORE INTO tbl VALUES (1, 1), (2, 1);
+----
+1
+
+query I
+SELECT uniq FROM tbl
+----
+1


### PR DESCRIPTION
Fixes #19211

We push a `DISTINCT ON (unique_col)` to filter for unique values within each column. When dealing with multiple constraints, we need to push multiple `DISTINCT ON` clauses. This can only happen with `INSERT OR IGNORE` - because that is the only statement type that supports handling multiple constraints at the same time. 