### PR TITLE
TaskExecutor constructor with alternative producer token

### DIFF
--- a/src/include/duckdb/parallel/task_executor.hpp
+++ b/src/include/duckdb/parallel/task_executor.hpp
@@ -20,6 +20,8 @@ class TaskScheduler;
 //! The TaskExecutor is a helper class that enables parallel scheduling and execution of tasks
 class TaskExecutor {
 public:
+	explicit TaskExecutor(ClientContext &context, ProducerToken &token);
+	explicit TaskExecutor(TaskScheduler &scheduler, ProducerToken &token);
 	explicit TaskExecutor(ClientContext &context);
 	explicit TaskExecutor(TaskScheduler &scheduler);
 	~TaskExecutor();
@@ -45,7 +47,8 @@ public:
 private:
 	TaskScheduler &scheduler;
 	TaskErrorManager error_manager;
-	unique_ptr<ProducerToken> token;
+	unique_ptr<ProducerToken> owned_token;
+	ProducerToken &token;
 	atomic<idx_t> completed_tasks;
 	atomic<idx_t> total_tasks;
 	friend class BaseExecutorTask;

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -49,7 +49,8 @@ void TaskExecutor::FinishTask() {
 void TaskExecutor::WorkOnTasks() {
 	// repeatedly execute tasks until we are finished
 	shared_ptr<Task> task_from_producer;
-	while (scheduler.GetTaskFromProducer(token, task_from_producer)) {
+	// NOTE: in case we don't own the token, we might end up executing other Query tasks
+	while (completed_tasks != total_tasks && scheduler.GetTaskFromProducer(token, task_from_producer)) {
 		auto res = task_from_producer->Execute(TaskExecutionMode::PROCESS_ALL);
 		(void)res;
 		D_ASSERT(res != TaskExecutionResult::TASK_BLOCKED);


### PR DESCRIPTION
This is not exercised in current code (yet), but bumped against a quirk that is that Task scheduled via TaskExecutor with their own token can't be executed on the main thread, due to it waiting for ProducerToken-releated tasks to ensure progress.

In constructed cases, this might mean a `N / (N-1)` slowdown given a thread might end up being idle.
Solution is passing around ProducerToken wherever available, but I have not reviewed when this is possible.