### PR TITLE
Implement `std::allocator` that uses `ArenaAllocator`

### DIFF
--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/order/physical_top_n.hpp"
 
 #include "duckdb/common/assert.hpp"
+#include "duckdb/common/arena_containers.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/create_sort_key.hpp"
 #include "duckdb/storage/data_table.hpp"
@@ -85,7 +86,8 @@ public:
 
 	Allocator &allocator;
 	BufferManager &buffer_manager;
-	unsafe_vector<TopNEntry> heap;
+	ArenaAllocator arena_allocator;
+	unsafe_arena_vector<TopNEntry> heap;
 	const vector<LogicalType> &payload_types;
 	const vector<BoundOrderByNode> &orders;
 	vector<OrderModifiers> modifiers;
@@ -162,10 +164,11 @@ private:
 //===--------------------------------------------------------------------===//
 TopNHeap::TopNHeap(ClientContext &context, Allocator &allocator, const vector<LogicalType> &payload_types_p,
                    const vector<BoundOrderByNode> &orders_p, idx_t limit, idx_t offset)
-    : allocator(allocator), buffer_manager(BufferManager::GetBufferManager(context)), payload_types(payload_types_p),
-      orders(orders_p), limit(limit), offset(offset), heap_size(limit + offset), executor(context),
-      sort_key_heap(allocator), matching_sel(STANDARD_VECTOR_SIZE), final_sel(STANDARD_VECTOR_SIZE),
-      true_sel(STANDARD_VECTOR_SIZE), false_sel(STANDARD_VECTOR_SIZE), new_remaining_sel(STANDARD_VECTOR_SIZE) {
+    : allocator(allocator), buffer_manager(BufferManager::GetBufferManager(context)), arena_allocator(allocator),
+      heap(arena_allocator), payload_types(payload_types_p), orders(orders_p), limit(limit), offset(offset),
+      heap_size(limit + offset), executor(context), sort_key_heap(allocator), matching_sel(STANDARD_VECTOR_SIZE),
+      final_sel(STANDARD_VECTOR_SIZE), true_sel(STANDARD_VECTOR_SIZE), false_sel(STANDARD_VECTOR_SIZE),
+      new_remaining_sel(STANDARD_VECTOR_SIZE) {
 	// initialize the executor and the sort_chunk
 	vector<LogicalType> sort_types;
 	for (auto &order : orders) {

--- a/src/include/duckdb/common/arena_containers.hpp
+++ b/src/include/duckdb/common/arena_containers.hpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/arena_containers.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/arena_stl_allocator.hpp"
+
+namespace duckdb {
+
+template <class T>
+using arena_vector = vector<T, true, arena_stl_allocator<T>>;
+
+template <class T>
+using unsafe_arena_vector = vector<T, false, arena_stl_allocator<T>>;
+
+} // namespace duckdb

--- a/src/include/duckdb/common/arena_stl_allocator.hpp
+++ b/src/include/duckdb/common/arena_stl_allocator.hpp
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/arena_stl_allocator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/storage/arena_allocator.hpp"
+
+namespace duckdb {
+
+template <class T>
+class arena_stl_allocator { // NOLINT: match stl case
+public:
+	//! Typedefs
+	typedef T value_type;
+	typedef std::size_t size_type;
+	typedef std::ptrdiff_t difference_type;
+	typedef value_type &reference;
+	typedef value_type const &const_reference;
+	typedef value_type *pointer;
+	typedef value_type const *const_pointer;
+
+	//! Propagation traits
+	using propagate_on_container_copy_assignment = std::true_type;
+	using propagate_on_container_move_assignment = std::true_type;
+	using propagate_on_container_swap = std::true_type;
+	using is_always_equal = std::false_type;
+
+	//! Rebind
+	template <class U>
+	struct rebind {
+		using other = arena_stl_allocator<U>;
+	};
+
+public:
+	arena_stl_allocator(ArenaAllocator &arena_allocator_p) noexcept // NOLINT: allow implicit conversion
+	    : arena_allocator(arena_allocator_p) {
+	}
+	template <class U>
+	arena_stl_allocator(const arena_stl_allocator<U> &other) noexcept // NOLINT: allow implicit conversion
+	    : arena_allocator(other.arena_allocator) {
+	}
+
+public:
+	pointer allocate(size_type n) { // NOLINT: match stl case
+		arena_allocator.get().AlignNext();
+		return reinterpret_cast<pointer>(arena_allocator.get().Allocate(n * sizeof(T)));
+	}
+
+	void deallocate(pointer p, size_type n) noexcept { // NOLINT: match stl case
+	}
+
+	template <class U, class... Args>
+	void construct(U *p, Args &&...args) { // NOLINT: match stl case
+		::new (p) U(std::forward<Args>(args)...);
+	}
+
+	template <class U>
+	void destroy(U *p) noexcept { // NOLINT: match stl case
+		p->~U();
+	}
+
+	pointer address(reference x) const { // NOLINT: match stl case
+		return &x;
+	}
+
+	const_pointer address(const_reference x) const { // NOLINT: match stl case
+		return &x;
+	}
+
+public:
+	bool operator==(const arena_stl_allocator &other) const noexcept {
+		return RefersToSameObject(arena_allocator, other.arena_allocator);
+	}
+	bool operator!=(const arena_stl_allocator &other) const noexcept {
+		return !(*this == other);
+	}
+
+private:
+	//! Need to use std::reference_wrapper because "reference" is already a typedef
+	std::reference_wrapper<ArenaAllocator> arena_allocator;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/vector.hpp
+++ b/src/include/duckdb/common/vector.hpp
@@ -17,10 +17,10 @@
 
 namespace duckdb {
 
-template <class DATA_TYPE, bool SAFE = true>
-class vector : public std::vector<DATA_TYPE, std::allocator<DATA_TYPE>> { // NOLINT: matching name of std
+template <class DATA_TYPE, bool SAFE = true, class ALLOCATOR = std::allocator<DATA_TYPE>>
+class vector : public std::vector<DATA_TYPE, ALLOCATOR> { // NOLINT: matching name of std
 public:
-	using original = std::vector<DATA_TYPE, std::allocator<DATA_TYPE>>;
+	using original = std::vector<DATA_TYPE, ALLOCATOR>;
 	using original::original;
 	using size_type = typename original::size_type;
 	using const_reference = typename original::const_reference;


### PR DESCRIPTION
This PR implements `arena_stl_allocator`, which implements the `std::allocator` interface. It allocates using the `ArenaAllocator`. This can allow us to have many small STL container allocations that live in the same `ArenaAllocator`, instead of all being tiny individual allocations.

I've added it in the `PhysicalTopN` operator as a test (as the allocator to a `vector`), but we should try adding this in various parts of the code.

CC @taniabogatsch 