### PR TITLE
Issue #19386: ICU TZDEFAULT

### DIFF
--- a/extension/icu/third_party/icu/common/putil.cpp
+++ b/extension/icu/third_party/icu/common/putil.cpp
@@ -1090,9 +1090,15 @@ uprv_tzname(int n)
         if (tzid[0] == ':') {
             tzid++;
         }
-        /* This might be a good Olson ID. */
-        skipZoneIDPrefix(&tzid);
-        return tzid;
+#if defined(TZDEFAULT)
+        if (uprv_strcmp(tzid, TZDEFAULT) != 0) {
+#endif
+        	/* This might be a good Olson ID. */
+			skipZoneIDPrefix(&tzid);
+			return tzid;
+#if defined(TZDEFAULT)
+		}
+#endif
     }
     /* else U_TZNAME will give a better result. */
 #endif


### PR DESCRIPTION
* Make uprv_tzname ignore /etc/localtime as a TZ environment setting.

fixes: duckdb#19386
fixes: duckdblabs/duckdb-internal#6254