### PR TITLE
enable direct select for numeric readers; add regression test (#19277)

### DIFF
--- a/extension/parquet/include/reader/templated_column_reader.hpp
+++ b/extension/parquet/include/reader/templated_column_reader.hpp
@@ -74,6 +74,15 @@ public:
 	bool SupportsDirectFilter() const override {
 		return true;
 	}
+	bool SupportsDirectSelect() const override {
+		return true;
+	}
+
+	void PlainSelect(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values, Vector &result,
+	                const SelectionVector &sel, idx_t approved_tuple_count) override {
+		PlainSelectTemplated<VALUE_TYPE, VALUE_CONVERSION>(*plain_data, defines, num_values, result, sel,
+		                                                 approved_tuple_count);
+	}
 };
 
 template <class PARQUET_PHYSICAL_TYPE, class DUCKDB_PHYSICAL_TYPE,

--- a/test/sql/copy/parquet/parquet_direct_select_numeric.test
+++ b/test/sql/copy/parquet/parquet_direct_select_numeric.test
@@ -1,0 +1,28 @@
+# name: parquet_direct_select_numeric
+
+statement ok
+INSTALL parquet;
+
+statement ok
+LOAD parquet;
+
+# Create a table with many numeric values to ensure PLAIN encoding for doubles
+statement ok
+CREATE TABLE pdn_source AS SELECT i AS id, random() AS column_0, random() AS column_1 FROM range(200000) i;
+
+statement ok
+COPY (SELECT * FROM pdn_source) TO '__parquet_dir__/pdn_numeric.parquet' (FORMAT PARQUET);
+
+# Compare counts are equal between in-memory and Parquet scan
+query I
+WITH a AS (
+  SELECT COUNT(*) AS cnt FROM read_parquet('__parquet_dir__/pdn_numeric.parquet') WHERE sqrt(column_0) < 0.01
+), b AS (
+  SELECT COUNT(*) AS cnt FROM pdn_source WHERE sqrt(column_0) < 0.01
+)
+SELECT (SELECT cnt FROM a) = (SELECT cnt FROM b);
+----
+1
+
+statement ok
+DROP TABLE pdn_source;


### PR DESCRIPTION
Added DirectSelect support for numeric Parquet readers and a sqllogictest validating equality between Parquet and base table filtering.

This fixes #19277 