### PR TITLE
v1.4: Only serialize CTE nodes when MATERIALIZED is specified

### DIFF
--- a/src/parser/query_node/cte_node.cpp
+++ b/src/parser/query_node/cte_node.cpp
@@ -72,17 +72,8 @@ void QueryNode::ExtractCTENodes(unique_ptr<QueryNode> &query_node) {
 }
 
 void CTENode::Serialize(Serializer &serializer) const {
-	if (materialized == CTEMaterialize::CTE_MATERIALIZE_NEVER) {
-		// for non-materialized CTEs - don't serialize CTENode
-		// older DuckDB versions only expect a CTENode to be there for materialized CTEs
-		child->Serialize(serializer);
-		return;
-	}
-	QueryNode::Serialize(serializer);
-	serializer.WritePropertyWithDefault<string>(200, "cte_name", ctename);
-	serializer.WritePropertyWithDefault<unique_ptr<QueryNode>>(201, "query", query);
-	serializer.WritePropertyWithDefault<unique_ptr<QueryNode>>(202, "child", child);
-	serializer.WritePropertyWithDefault<vector<string>>(203, "aliases", aliases);
+	// never serialize CTE nodes for backwards compatibility
+	child->Serialize(serializer);
 }
 
 // In QueryNode::ExtractCTENodes we create a bunch of CTENodes from the CommonTableExpressionMap in the QueryNode

--- a/src/parser/query_node/cte_node.cpp
+++ b/src/parser/query_node/cte_node.cpp
@@ -72,8 +72,17 @@ void QueryNode::ExtractCTENodes(unique_ptr<QueryNode> &query_node) {
 }
 
 void CTENode::Serialize(Serializer &serializer) const {
-	// never serialize CTE nodes for backwards compatibility
-	child->Serialize(serializer);
+	if (materialized == CTEMaterialize::CTE_MATERIALIZE_NEVER) {
+		// for non-materialized CTEs - don't serialize CTENode
+		// older DuckDB versions only expect a CTENode to be there for materialized CTEs
+		child->Serialize(serializer);
+		return;
+	}
+	QueryNode::Serialize(serializer);
+	serializer.WritePropertyWithDefault<string>(200, "cte_name", ctename);
+	serializer.WritePropertyWithDefault<unique_ptr<QueryNode>>(201, "query", query);
+	serializer.WritePropertyWithDefault<unique_ptr<QueryNode>>(202, "child", child);
+	serializer.WritePropertyWithDefault<vector<string>>(203, "aliases", aliases);
 }
 
 // In QueryNode::ExtractCTENodes we create a bunch of CTENodes from the CommonTableExpressionMap in the QueryNode


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/19393

There are a number of issues still caused by serializing CTE nodes - this PR makes it so that we only serialize CTE nodes when MATERIALIZED is explicitly defined, and serialize only the CommonTableExpressionMap otherwise. In addition, we never deserialize CTENodes anymore - and always reconstruct them from the CommonTableExpressionMap.