### PR TITLE
Augment Table API `function` via context stored in `AsyncResult` object

### DIFF
--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -2,4 +2,5 @@ duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
     GIT_TAG f134ad86f2f6e7cdf4133086c38ecd9c48f1a772
+    APPLY_PATCHES
 )

--- a/.github/patches/extensions/avro/async_scan.patch
+++ b/.github/patches/extensions/avro/async_scan.patch
@@ -7,10 +7,10 @@ index 176f6e0..14a648f 100644
  }
  
 -void AvroReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-+AsyncResultType AvroReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
++AsyncResult AvroReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
                        LocalTableFunctionState &local_state_p, DataChunk &chunk) {
  	Read(chunk);
-+	return chunk.size() ? AsyncResultType(SourceResultType::HAVE_MORE_OUTPUT) : AsyncResultType(SourceResultType::FINISHED);
++	return chunk.size() ? AsyncResult(SourceResultType::HAVE_MORE_OUTPUT) : AsyncResult(SourceResultType::FINISHED);
  }
  
  unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) {
@@ -23,7 +23,7 @@ index 8d7820d..5e646c8 100644
  	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
  	                       LocalTableFunctionState &lstate) override;
 -	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-+	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
++	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
  	          DataChunk &chunk) override;
  
  public:

--- a/.github/patches/extensions/avro/async_scan.patch
+++ b/.github/patches/extensions/avro/async_scan.patch
@@ -1,0 +1,29 @@
+diff --git a/src/avro_multi_file_info.cpp b/src/avro_multi_file_info.cpp
+index 176f6e0..b20993c 100644
+--- a/src/avro_multi_file_info.cpp
++++ b/src/avro_multi_file_info.cpp
+@@ -121,9 +121,10 @@ bool AvroReader::TryInitializeScan(ClientContext &context, GlobalTableFunctionSt
+ 	return true;
+ }
+ 
+-void AvroReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
++AsyncResultType AvroReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                       LocalTableFunctionState &local_state_p, DataChunk &chunk) {
+ 	Read(chunk);
++	return chunk.size() ? SourceResultType::HAVE_MORE_OUTPUT : SourceResultType::FINISHED;
+ }
+ 
+ unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) {
+diff --git a/src/include/avro_reader.hpp b/src/include/avro_reader.hpp
+index 8d7820d..5e646c8 100644
+--- a/src/include/avro_reader.hpp
++++ b/src/include/avro_reader.hpp
+@@ -24,7 +24,7 @@ public:
+ 
+ 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
+ 	                       LocalTableFunctionState &lstate) override;
+-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
++	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
+ 	          DataChunk &chunk) override;
+ 
+ public:

--- a/.github/patches/extensions/avro/async_scan.patch
+++ b/.github/patches/extensions/avro/async_scan.patch
@@ -1,5 +1,5 @@
 diff --git a/src/avro_multi_file_info.cpp b/src/avro_multi_file_info.cpp
-index 176f6e0..b20993c 100644
+index 176f6e0..14a648f 100644
 --- a/src/avro_multi_file_info.cpp
 +++ b/src/avro_multi_file_info.cpp
 @@ -121,9 +121,10 @@ bool AvroReader::TryInitializeScan(ClientContext &context, GlobalTableFunctionSt
@@ -10,7 +10,7 @@ index 176f6e0..b20993c 100644
 +AsyncResultType AvroReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
                        LocalTableFunctionState &local_state_p, DataChunk &chunk) {
  	Read(chunk);
-+	return chunk.size() ? SourceResultType::HAVE_MORE_OUTPUT : SourceResultType::FINISHED;
++	return chunk.size() ? AsyncResultType(SourceResultType::HAVE_MORE_OUTPUT) : AsyncResultType(SourceResultType::FINISHED);
  }
  
  unique_ptr<NodeStatistics> AvroMultiFileInfo::GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) {

--- a/.github/patches/extensions/ducklake/async_scan.patch
+++ b/.github/patches/extensions/ducklake/async_scan.patch
@@ -7,7 +7,7 @@ index f0af8ec..5648aef 100644
  	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
  	                       LocalTableFunctionState &lstate) override;
 -	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-+	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
++	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
  	          DataChunk &chunk) override;
  
  	string GetReaderType() const override;
@@ -20,7 +20,7 @@ index 432ef24..b5f6827 100644
  }
  
 -void DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-+AsyncResultType DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
++AsyncResult DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
                                       LocalTableFunctionState &local_state, DataChunk &chunk) {
  	if (!virtual_columns.empty()) {
  		scan_chunk.Reset();
@@ -28,7 +28,7 @@ index 432ef24..b5f6827 100644
  		}
  	}
  	file_row_number += NumericCast<int64_t>(scan_count);
-+	return chunk.size() ? AsyncResultType(SourceResultType::HAVE_MORE_OUTPUT) : AsyncResultType(SourceResultType::FINISHED);
++	return chunk.size() ? AsyncResult(SourceResultType::HAVE_MORE_OUTPUT) : AsyncResult(SourceResultType::FINISHED);
  }
  
  void DuckLakeInlinedDataReader::AddVirtualColumn(column_t virtual_column_id) {

--- a/.github/patches/extensions/ducklake/async_scan.patch
+++ b/.github/patches/extensions/ducklake/async_scan.patch
@@ -12,7 +12,7 @@ index f0af8ec..5648aef 100644
  
  	string GetReaderType() const override;
 diff --git a/src/storage/ducklake_inlined_data_reader.cpp b/src/storage/ducklake_inlined_data_reader.cpp
-index 432ef24..9e7d3c6 100644
+index 432ef24..b5f6827 100644
 --- a/src/storage/ducklake_inlined_data_reader.cpp
 +++ b/src/storage/ducklake_inlined_data_reader.cpp
 @@ -154,7 +154,7 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
@@ -28,7 +28,7 @@ index 432ef24..9e7d3c6 100644
  		}
  	}
  	file_row_number += NumericCast<int64_t>(scan_count);
-+	return chunk.size() ? SourceResultType::HAVE_MORE_OUTPUT : SourceResultType::FINISHED;
++	return chunk.size() ? AsyncResultType(SourceResultType::HAVE_MORE_OUTPUT) : AsyncResultType(SourceResultType::FINISHED);
  }
  
  void DuckLakeInlinedDataReader::AddVirtualColumn(column_t virtual_column_id) {

--- a/.github/patches/extensions/ducklake/async_scan.patch
+++ b/.github/patches/extensions/ducklake/async_scan.patch
@@ -1,0 +1,34 @@
+diff --git a/src/include/storage/ducklake_inlined_data_reader.hpp b/src/include/storage/ducklake_inlined_data_reader.hpp
+index f0af8ec..5648aef 100644
+--- a/src/include/storage/ducklake_inlined_data_reader.hpp
++++ b/src/include/storage/ducklake_inlined_data_reader.hpp
+@@ -30,7 +30,7 @@ public:
+ public:
+ 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
+ 	                       LocalTableFunctionState &lstate) override;
+-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
++	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
+ 	          DataChunk &chunk) override;
+ 
+ 	string GetReaderType() const override;
+diff --git a/src/storage/ducklake_inlined_data_reader.cpp b/src/storage/ducklake_inlined_data_reader.cpp
+index 432ef24..9e7d3c6 100644
+--- a/src/storage/ducklake_inlined_data_reader.cpp
++++ b/src/storage/ducklake_inlined_data_reader.cpp
+@@ -154,7 +154,7 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
+ 	return true;
+ }
+ 
+-void DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
++AsyncResultType DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                                      LocalTableFunctionState &local_state, DataChunk &chunk) {
+ 	if (!virtual_columns.empty()) {
+ 		scan_chunk.Reset();
+@@ -210,6 +210,7 @@ void DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunction
+ 		}
+ 	}
+ 	file_row_number += NumericCast<int64_t>(scan_count);
++	return chunk.size() ? SourceResultType::HAVE_MORE_OUTPUT : SourceResultType::FINISHED;
+ }
+ 
+ void DuckLakeInlinedDataReader::AddVirtualColumn(column_t virtual_column_id) {

--- a/extension/json/include/json_reader.hpp
+++ b/extension/json/include/json_reader.hpp
@@ -210,8 +210,8 @@ public:
 	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-	          DataChunk &chunk) override;
+	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                     LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 

--- a/extension/json/include/json_reader.hpp
+++ b/extension/json/include/json_reader.hpp
@@ -210,8 +210,8 @@ public:
 	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-	                     LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -537,7 +537,6 @@ void ReadJSONObjectsFunction(ClientContext &context, JSONReader &json_reader, JS
 
 AsyncResult JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
                              LocalTableFunctionState &local_state, DataChunk &output) {
-
 #ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
 	{
 		vector<unique_ptr<AsyncTask>> tasks;

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -545,6 +545,13 @@ AsyncResult JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &g
 		switch (random_number) {
 		case 0:
 			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
 #ifndef AVOID_DUCKDB_DEBUG_ASYNC_THROW
 		case 1:
 			tasks.push_back(make_uniq<ThrowAsyncTask>(rand() % 32));
@@ -553,7 +560,6 @@ AsyncResult JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &g
 			break;
 		}
 		if (!tasks.empty()) {
-			D_ASSERT(tasks.size() == 1);
 			return AsyncResult(std::move(tasks));
 		}
 	}

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -535,8 +535,8 @@ void ReadJSONObjectsFunction(ClientContext &context, JSONReader &json_reader, JS
 	output.SetCardinality(count);
 }
 
-AsyncResultType JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-                                 LocalTableFunctionState &local_state, DataChunk &output) {
+AsyncResult JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                             LocalTableFunctionState &local_state, DataChunk &output) {
 
 #ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
 	{
@@ -554,7 +554,7 @@ AsyncResultType JSONReader::Scan(ClientContext &context, GlobalTableFunctionStat
 		}
 		if (!tasks.empty()) {
 			D_ASSERT(tasks.size() == 1);
-			return AsyncResultType(std::move(tasks));
+			return AsyncResult(std::move(tasks));
 		}
 	}
 #endif
@@ -572,8 +572,7 @@ AsyncResultType JSONReader::Scan(ClientContext &context, GlobalTableFunctionStat
 	default:
 		throw InternalException("Unsupported scan type for JSONMultiFileInfo::Scan");
 	}
-	return output.size() ? AsyncResultType(SourceResultType::HAVE_MORE_OUTPUT)
-	                     : AsyncResultType(SourceResultType::FINISHED);
+	return AsyncResult(output.size() ? SourceResultType::HAVE_MORE_OUTPUT : SourceResultType::FINISHED);
 }
 
 void JSONReader::FinishFile(ClientContext &context, GlobalTableFunctionState &global_state) {

--- a/extension/json/json_multi_file_info.cpp
+++ b/extension/json/json_multi_file_info.cpp
@@ -3,10 +3,6 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/parallel/async_result.hpp"
 
-#ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
-#include "duckdb/parallel/sleep_async_task.hpp"
-#endif
-
 namespace duckdb {
 
 unique_ptr<MultiFileReaderInterface> JSONMultiFileInfo::CreateInterface(ClientContext &context) {
@@ -539,25 +535,7 @@ AsyncResult JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &g
                              LocalTableFunctionState &local_state, DataChunk &output) {
 #ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
 	{
-		vector<unique_ptr<AsyncTask>> tasks;
-		auto random_number = rand() % 16;
-		switch (random_number) {
-		case 0:
-			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
-			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
-			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
-			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
-			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
-			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
-			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
-			tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
-#ifndef AVOID_DUCKDB_DEBUG_ASYNC_THROW
-		case 1:
-			tasks.push_back(make_uniq<ThrowAsyncTask>(rand() % 32));
-#endif
-		default:
-			break;
-		}
+		vector<unique_ptr<AsyncTask>> tasks = AsyncResult::GenerateTestTasks();
 		if (!tasks.empty()) {
 			return AsyncResult(std::move(tasks));
 		}

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -166,14 +166,14 @@ public:
 
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-	                     LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 
 public:
 	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, vector<idx_t> groups_to_read);
-	AsyncResultType Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
+	AsyncResult Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
 
 	idx_t NumRows() const;
 	idx_t NumRowGroups() const;

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -166,14 +166,14 @@ public:
 
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-	          DataChunk &chunk) override;
+	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                     LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 
 public:
 	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, vector<idx_t> groups_to_read);
-	void Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
+	AsyncResultType Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
 
 	idx_t NumRows() const;
 	idx_t NumRowGroups() const;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -575,12 +575,12 @@ void ParquetReader::FinishFile(ClientContext &context, GlobalTableFunctionState 
 	gstate.row_group_index = 0;
 }
 
-void ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
-                         LocalTableFunctionState &local_state_p, DataChunk &chunk) {
+AsyncResultType ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+                                    LocalTableFunctionState &local_state_p, DataChunk &chunk) {
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	local_state.scan_state.op = gstate.op;
-	Scan(context, local_state.scan_state, chunk);
+	return Scan(context, local_state.scan_state, chunk);
 }
 
 unique_ptr<MultiFileReaderInterface> ParquetMultiFileInfo::Copy() {

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -577,6 +577,15 @@ void ParquetReader::FinishFile(ClientContext &context, GlobalTableFunctionState 
 
 AsyncResult ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
                                 LocalTableFunctionState &local_state_p, DataChunk &chunk) {
+#ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
+	{
+		vector<unique_ptr<AsyncTask>> tasks = AsyncResult::GenerateTestTasks();
+		if (!tasks.empty()) {
+			return AsyncResult(std::move(tasks));
+		}
+	}
+#endif
+
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	local_state.scan_state.op = gstate.op;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -575,8 +575,8 @@ void ParquetReader::FinishFile(ClientContext &context, GlobalTableFunctionState 
 	gstate.row_group_index = 0;
 }
 
-AsyncResultType ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
-                                    LocalTableFunctionState &local_state_p, DataChunk &chunk) {
+AsyncResult ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+                                LocalTableFunctionState &local_state_p, DataChunk &chunk) {
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	local_state.scan_state.op = gstate.op;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1255,11 +1255,11 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 AsyncResultType ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
 	while (ScanInternal(context, state, result)) {
 		if (result.size() > 0) {
-			return SourceResultType::HAVE_MORE_OUTPUT;
+			return AsyncResultType(SourceResultType::HAVE_MORE_OUTPUT);
 		}
 		result.Reset();
 	}
-	return SourceResultType::FINISHED;
+	return AsyncResultType(SourceResultType::FINISHED);
 }
 
 void ParquetReader::GetPartitionStats(vector<PartitionStatistics> &result) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1252,13 +1252,14 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 	state.repeat_buf.resize(allocator, STANDARD_VECTOR_SIZE);
 }
 
-void ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
+AsyncResultType ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
 	while (ScanInternal(context, state, result)) {
 		if (result.size() > 0) {
-			break;
+			return SourceResultType::HAVE_MORE_OUTPUT;
 		}
 		result.Reset();
 	}
+	return SourceResultType::FINISHED;
 }
 
 void ParquetReader::GetPartitionStats(vector<PartitionStatistics> &result) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1252,14 +1252,14 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 	state.repeat_buf.resize(allocator, STANDARD_VECTOR_SIZE);
 }
 
-AsyncResultType ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
+AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
 	while (ScanInternal(context, state, result)) {
 		if (result.size() > 0) {
-			return AsyncResultType(SourceResultType::HAVE_MORE_OUTPUT);
+			return AsyncResult(SourceResultType::HAVE_MORE_OUTPUT);
 		}
 		result.Reset();
 	}
-	return AsyncResultType(SourceResultType::FINISHED);
+	return AsyncResult(SourceResultType::FINISHED);
 }
 
 void ParquetReader::GetPartitionStats(vector<PartitionStatistics> &result) {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -655,7 +655,7 @@ AsyncResultType EnumUtil::FromString<AsyncResultType>(const char *value) {
 
 const StringUtil::EnumStringLiteral *GetAsyncResultsExecutionModeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
-		{ static_cast<uint32_t>(AsyncResultsExecutionMode::SYNCRONOUS), "SYNCRONOUS" },
+		{ static_cast<uint32_t>(AsyncResultsExecutionMode::SYNCHRONOUS), "SYNCHRONOUS" },
 		{ static_cast<uint32_t>(AsyncResultsExecutionMode::TASK_EXECUTOR), "TASK_EXECUTOR" }
 	};
 	return values;

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4432,6 +4432,27 @@ TableFilterType EnumUtil::FromString<TableFilterType>(const char *value) {
 	return static_cast<TableFilterType>(StringUtil::StringToEnum(GetTableFilterTypeValues(), 10, "TableFilterType", value));
 }
 
+const StringUtil::EnumStringLiteral *GetTableFunctionResultTypeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(TableFunctionResultType::HAVE_MORE_OUTPUT), "HAVE_MORE_OUTPUT" },
+		{ static_cast<uint32_t>(TableFunctionResultType::FINISHED), "FINISHED" },
+		{ static_cast<uint32_t>(TableFunctionResultType::BLOCKED), "BLOCKED" },
+		{ static_cast<uint32_t>(TableFunctionResultType::DEFAULT), "DEFAULT" },
+		{ static_cast<uint32_t>(TableFunctionResultType::INVALID), "INVALID" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<TableFunctionResultType>(TableFunctionResultType value) {
+	return StringUtil::EnumToString(GetTableFunctionResultTypeValues(), 5, "TableFunctionResultType", static_cast<uint32_t>(value));
+}
+
+template<>
+TableFunctionResultType EnumUtil::FromString<TableFunctionResultType>(const char *value) {
+	return static_cast<TableFunctionResultType>(StringUtil::StringToEnum(GetTableFunctionResultTypeValues(), 5, "TableFunctionResultType", value));
+}
+
 const StringUtil::EnumStringLiteral *GetTablePartitionInfoValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(TablePartitionInfo::NOT_PARTITIONED), "NOT_PARTITIONED" },

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -631,6 +631,27 @@ ArrowVariableSizeType EnumUtil::FromString<ArrowVariableSizeType>(const char *va
 	return static_cast<ArrowVariableSizeType>(StringUtil::StringToEnum(GetArrowVariableSizeTypeValues(), 4, "ArrowVariableSizeType", value));
 }
 
+const StringUtil::EnumStringLiteral *GetAsyncResultTypeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(AsyncResultType::INVALID), "INVALID" },
+		{ static_cast<uint32_t>(AsyncResultType::IMPLICIT), "IMPLICIT" },
+		{ static_cast<uint32_t>(AsyncResultType::HAVE_MORE_OUTPUT), "HAVE_MORE_OUTPUT" },
+		{ static_cast<uint32_t>(AsyncResultType::FINISHED), "FINISHED" },
+		{ static_cast<uint32_t>(AsyncResultType::BLOCKED), "BLOCKED" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<AsyncResultType>(AsyncResultType value) {
+	return StringUtil::EnumToString(GetAsyncResultTypeValues(), 5, "AsyncResultType", static_cast<uint32_t>(value));
+}
+
+template<>
+AsyncResultType EnumUtil::FromString<AsyncResultType>(const char *value) {
+	return static_cast<AsyncResultType>(StringUtil::StringToEnum(GetAsyncResultTypeValues(), 5, "AsyncResultType", value));
+}
+
 const StringUtil::EnumStringLiteral *GetBinderTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(BinderType::REGULAR_BINDER), "REGULAR_BINDER" },
@@ -4430,27 +4451,6 @@ const char* EnumUtil::ToChars<TableFilterType>(TableFilterType value) {
 template<>
 TableFilterType EnumUtil::FromString<TableFilterType>(const char *value) {
 	return static_cast<TableFilterType>(StringUtil::StringToEnum(GetTableFilterTypeValues(), 10, "TableFilterType", value));
-}
-
-const StringUtil::EnumStringLiteral *GetTableFunctionResultTypeValues() {
-	static constexpr StringUtil::EnumStringLiteral values[] {
-		{ static_cast<uint32_t>(TableFunctionResultType::HAVE_MORE_OUTPUT), "HAVE_MORE_OUTPUT" },
-		{ static_cast<uint32_t>(TableFunctionResultType::FINISHED), "FINISHED" },
-		{ static_cast<uint32_t>(TableFunctionResultType::BLOCKED), "BLOCKED" },
-		{ static_cast<uint32_t>(TableFunctionResultType::DEFAULT), "DEFAULT" },
-		{ static_cast<uint32_t>(TableFunctionResultType::INVALID), "INVALID" }
-	};
-	return values;
-}
-
-template<>
-const char* EnumUtil::ToChars<TableFunctionResultType>(TableFunctionResultType value) {
-	return StringUtil::EnumToString(GetTableFunctionResultTypeValues(), 5, "TableFunctionResultType", static_cast<uint32_t>(value));
-}
-
-template<>
-TableFunctionResultType EnumUtil::FromString<TableFunctionResultType>(const char *value) {
-	return static_cast<TableFunctionResultType>(StringUtil::StringToEnum(GetTableFunctionResultTypeValues(), 5, "TableFunctionResultType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetTablePartitionInfoValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -635,7 +635,7 @@ const StringUtil::EnumStringLiteral *GetAsyncResultTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(AsyncResultType::INVALID), "INVALID" },
 		{ static_cast<uint32_t>(AsyncResultType::IMPLICIT), "IMPLICIT" },
-		{ static_cast<uint32_t>(AsyncResultType::HAVE_MORE_OUTPUT), "HAVE_MORE_OUTPUT" },
+		{ static_cast<uint32_t>(AsyncResultType::ONGOING), "ONGOING" },
 		{ static_cast<uint32_t>(AsyncResultType::FINISHED), "FINISHED" },
 		{ static_cast<uint32_t>(AsyncResultType::BLOCKED), "BLOCKED" }
 	};

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -633,9 +633,8 @@ ArrowVariableSizeType EnumUtil::FromString<ArrowVariableSizeType>(const char *va
 
 const StringUtil::EnumStringLiteral *GetAsyncResultTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
-		{ static_cast<uint32_t>(AsyncResultType::INVALID), "INVALID" },
 		{ static_cast<uint32_t>(AsyncResultType::IMPLICIT), "IMPLICIT" },
-		{ static_cast<uint32_t>(AsyncResultType::ONGOING), "ONGOING" },
+		{ static_cast<uint32_t>(AsyncResultType::HAVE_MORE_OUTPUT), "HAVE_MORE_OUTPUT" },
 		{ static_cast<uint32_t>(AsyncResultType::FINISHED), "FINISHED" },
 		{ static_cast<uint32_t>(AsyncResultType::BLOCKED), "BLOCKED" }
 	};
@@ -644,12 +643,12 @@ const StringUtil::EnumStringLiteral *GetAsyncResultTypeValues() {
 
 template<>
 const char* EnumUtil::ToChars<AsyncResultType>(AsyncResultType value) {
-	return StringUtil::EnumToString(GetAsyncResultTypeValues(), 5, "AsyncResultType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetAsyncResultTypeValues(), 4, "AsyncResultType", static_cast<uint32_t>(value));
 }
 
 template<>
 AsyncResultType EnumUtil::FromString<AsyncResultType>(const char *value) {
-	return static_cast<AsyncResultType>(StringUtil::StringToEnum(GetAsyncResultTypeValues(), 5, "AsyncResultType", value));
+	return static_cast<AsyncResultType>(StringUtil::StringToEnum(GetAsyncResultTypeValues(), 4, "AsyncResultType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetBinderTypeValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -633,6 +633,7 @@ ArrowVariableSizeType EnumUtil::FromString<ArrowVariableSizeType>(const char *va
 
 const StringUtil::EnumStringLiteral *GetAsyncResultTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(AsyncResultType::INVALID), "INVALID" },
 		{ static_cast<uint32_t>(AsyncResultType::IMPLICIT), "IMPLICIT" },
 		{ static_cast<uint32_t>(AsyncResultType::HAVE_MORE_OUTPUT), "HAVE_MORE_OUTPUT" },
 		{ static_cast<uint32_t>(AsyncResultType::FINISHED), "FINISHED" },
@@ -643,12 +644,12 @@ const StringUtil::EnumStringLiteral *GetAsyncResultTypeValues() {
 
 template<>
 const char* EnumUtil::ToChars<AsyncResultType>(AsyncResultType value) {
-	return StringUtil::EnumToString(GetAsyncResultTypeValues(), 4, "AsyncResultType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetAsyncResultTypeValues(), 5, "AsyncResultType", static_cast<uint32_t>(value));
 }
 
 template<>
 AsyncResultType EnumUtil::FromString<AsyncResultType>(const char *value) {
-	return static_cast<AsyncResultType>(StringUtil::StringToEnum(GetAsyncResultTypeValues(), 4, "AsyncResultType", value));
+	return static_cast<AsyncResultType>(StringUtil::StringToEnum(GetAsyncResultTypeValues(), 5, "AsyncResultType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetBinderTypeValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -130,6 +130,7 @@
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/setting_info.hpp"
+#include "duckdb/parallel/async_result.hpp"
 #include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/parallel/meta_pipeline.hpp"
 #include "duckdb/parallel/task.hpp"
@@ -650,6 +651,24 @@ const char* EnumUtil::ToChars<AsyncResultType>(AsyncResultType value) {
 template<>
 AsyncResultType EnumUtil::FromString<AsyncResultType>(const char *value) {
 	return static_cast<AsyncResultType>(StringUtil::StringToEnum(GetAsyncResultTypeValues(), 5, "AsyncResultType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetAsyncResultsExecutionModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(AsyncResultsExecutionMode::SYNCRONOUS), "SYNCRONOUS" },
+		{ static_cast<uint32_t>(AsyncResultsExecutionMode::TASK_EXECUTOR), "TASK_EXECUTOR" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<AsyncResultsExecutionMode>(AsyncResultsExecutionMode value) {
+	return StringUtil::EnumToString(GetAsyncResultsExecutionModeValues(), 2, "AsyncResultsExecutionMode", static_cast<uint32_t>(value));
+}
+
+template<>
+AsyncResultsExecutionMode EnumUtil::FromString<AsyncResultsExecutionMode>(const char *value) {
+	return static_cast<AsyncResultsExecutionMode>(StringUtil::StringToEnum(GetAsyncResultsExecutionModeValues(), 2, "AsyncResultsExecutionMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetBinderTypeValues() {

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -365,15 +365,15 @@ bool CSVFileScan::TryInitializeScan(ClientContext &context, GlobalTableFunctionS
 	return true;
 }
 
-AsyncResultType CSVFileScan::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-                                  LocalTableFunctionState &local_state, DataChunk &chunk) {
+AsyncResult CSVFileScan::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                              LocalTableFunctionState &local_state, DataChunk &chunk) {
 	auto &lstate = local_state.Cast<CSVLocalState>();
 	if (lstate.csv_reader->FinishedIterator()) {
-		return AsyncResultType(SourceResultType::FINISHED);
+		return AsyncResult(SourceResultType::FINISHED);
 	}
 	lstate.csv_reader->Flush(chunk);
-	return chunk.size() == 0 ? AsyncResultType(SourceResultType::FINISHED)
-	                         : AsyncResultType(SourceResultType::HAVE_MORE_OUTPUT);
+	return chunk.size() == 0 ? AsyncResult(SourceResultType::FINISHED)
+	                         : AsyncResult(SourceResultType::HAVE_MORE_OUTPUT);
 }
 
 void CSVFileScan::FinishFile(ClientContext &context, GlobalTableFunctionState &global_state) {

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -365,13 +365,14 @@ bool CSVFileScan::TryInitializeScan(ClientContext &context, GlobalTableFunctionS
 	return true;
 }
 
-void CSVFileScan::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-                       LocalTableFunctionState &local_state, DataChunk &chunk) {
+AsyncResultType CSVFileScan::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                                  LocalTableFunctionState &local_state, DataChunk &chunk) {
 	auto &lstate = local_state.Cast<CSVLocalState>();
 	if (lstate.csv_reader->FinishedIterator()) {
-		return;
+		return SourceResultType::FINISHED;
 	}
 	lstate.csv_reader->Flush(chunk);
+	return chunk.size() == 0 ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;
 }
 
 void CSVFileScan::FinishFile(ClientContext &context, GlobalTableFunctionState &global_state) {

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -369,10 +369,11 @@ AsyncResultType CSVFileScan::Scan(ClientContext &context, GlobalTableFunctionSta
                                   LocalTableFunctionState &local_state, DataChunk &chunk) {
 	auto &lstate = local_state.Cast<CSVLocalState>();
 	if (lstate.csv_reader->FinishedIterator()) {
-		return SourceResultType::FINISHED;
+		return AsyncResultType(SourceResultType::FINISHED);
 	}
 	lstate.csv_reader->Flush(chunk);
-	return chunk.size() == 0 ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;
+	return chunk.size() == 0 ? AsyncResultType(SourceResultType::FINISHED)
+	                         : AsyncResultType(SourceResultType::HAVE_MORE_OUTPUT);
 }
 
 void CSVFileScan::FinishFile(ClientContext &context, GlobalTableFunctionState &global_state) {

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -107,10 +107,8 @@ SourceResultType PhysicalTableScan::GetData(ExecutionContext &context, DataChunk
 		if (res == SourceResultType::BLOCKED) {
 			D_ASSERT(data.async_result.HasTasks());
 			auto guard = g_state.Lock();
-			auto can_block = g_state.CanBlock(guard);
 			if (g_state.CanBlock(guard)) {
-				AsyncResult async_handler(std::move(data.async_result));
-				async_handler.ScheduleTasks(input.interrupt_state, context.pipeline->executor);
+				data.async_result.ScheduleTasks(input.interrupt_state, context.pipeline->executor);
 				return SourceResultType::BLOCKED;
 			} else {
 				return SourceResultType::FINISHED;

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -111,7 +111,7 @@ SourceResultType PhysicalTableScan::GetData(ExecutionContext &context, DataChunk
 			if (inner_result == SourceResultType::FINISHED) {
 				return SourceResultType::FINISHED;
 			} else if (inner_result == SourceResultType::BLOCKED) {
-				AsyncResultType async_handler(std::move(data.async_result));
+				AsyncResult async_handler(std::move(data.async_result));
 				async_handler.ScheduleTasks(input.interrupt_state, context.pipeline->executor);
 				return SourceResultType::BLOCKED;
 			} else {

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -104,7 +104,7 @@ SourceResultType PhysicalTableScan::GetData(ExecutionContext &context, DataChunk
 	if (function.HasSimpleScan()) {
 		auto res = function.SimpleScan(context.client, data, chunk);
 
-		if (res.mode == SourceResultType::BLOCKED) {
+		if (res.GetResultType() == SourceResultType::BLOCKED) {
 			auto guard = g_state.Lock();
 			auto inner_result = g_state.BlockSource(guard, input.interrupt_state);
 			if (inner_result == SourceResultType::FINISHED) {
@@ -119,12 +119,12 @@ SourceResultType PhysicalTableScan::GetData(ExecutionContext &context, DataChunk
 
 		auto expected_res = chunk.size() == 0 ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;
 
-		if (res.mode != expected_res) {
+		if (res.GetResultType() != expected_res) {
 			throw NotImplementedException(
 			    "Currently this differs from the reference implementation for `async_function`");
 		}
 
-		return res.mode;
+		return res.GetResultType();
 	}
 
 	if (g_state.in_out_final) {

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -103,6 +103,7 @@ SourceResultType PhysicalTableScan::GetData(ExecutionContext &context, DataChunk
 
 	if (function.function) {
 		data.async_result = AsyncResultType::IMPLICIT;
+		data.results_execution_mode = AsyncResultsExecutionMode::TASK_EXECUTOR;
 		function.function(context.client, data, chunk);
 
 		switch (data.async_result.GetResultType()) {

--- a/src/function/table/direct_file_reader.cpp
+++ b/src/function/table/direct_file_reader.cpp
@@ -44,11 +44,12 @@ static inline void VERIFY(const string &filename, const string_t &content) {
 	}
 }
 
-void DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-                            LocalTableFunctionState &local_state, DataChunk &output) {
+AsyncResultType DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                                       LocalTableFunctionState &local_state, DataChunk &output) {
 	auto &state = global_state.Cast<ReadFileGlobalState>();
 	if (done || file_list_idx.GetIndex() >= state.file_list->GetTotalFileCount()) {
-		return;
+
+		return SourceResultType::FINISHED;
 	}
 
 	auto files = state.file_list;
@@ -163,6 +164,7 @@ void DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionState &gl
 	}
 	output.SetCardinality(1);
 	done = true;
+	return SourceResultType::HAVE_MORE_OUTPUT;
 };
 
 void DirectFileReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) {

--- a/src/function/table/direct_file_reader.cpp
+++ b/src/function/table/direct_file_reader.cpp
@@ -48,7 +48,6 @@ AsyncResult DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionSt
                                    LocalTableFunctionState &local_state, DataChunk &output) {
 	auto &state = global_state.Cast<ReadFileGlobalState>();
 	if (done || file_list_idx.GetIndex() >= state.file_list->GetTotalFileCount()) {
-
 		return AsyncResult(SourceResultType::FINISHED);
 	}
 

--- a/src/function/table/direct_file_reader.cpp
+++ b/src/function/table/direct_file_reader.cpp
@@ -49,7 +49,7 @@ AsyncResultType DirectFileReader::Scan(ClientContext &context, GlobalTableFuncti
 	auto &state = global_state.Cast<ReadFileGlobalState>();
 	if (done || file_list_idx.GetIndex() >= state.file_list->GetTotalFileCount()) {
 
-		return SourceResultType::FINISHED;
+		return AsyncResultType(SourceResultType::FINISHED);
 	}
 
 	auto files = state.file_list;
@@ -164,7 +164,7 @@ AsyncResultType DirectFileReader::Scan(ClientContext &context, GlobalTableFuncti
 	}
 	output.SetCardinality(1);
 	done = true;
-	return SourceResultType::HAVE_MORE_OUTPUT;
+	return AsyncResultType(SourceResultType::HAVE_MORE_OUTPUT);
 };
 
 void DirectFileReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) {

--- a/src/function/table/direct_file_reader.cpp
+++ b/src/function/table/direct_file_reader.cpp
@@ -44,12 +44,12 @@ static inline void VERIFY(const string &filename, const string_t &content) {
 	}
 }
 
-AsyncResultType DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-                                       LocalTableFunctionState &local_state, DataChunk &output) {
+AsyncResult DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                                   LocalTableFunctionState &local_state, DataChunk &output) {
 	auto &state = global_state.Cast<ReadFileGlobalState>();
 	if (done || file_list_idx.GetIndex() >= state.file_list->GetTotalFileCount()) {
 
-		return AsyncResultType(SourceResultType::FINISHED);
+		return AsyncResult(SourceResultType::FINISHED);
 	}
 
 	auto files = state.file_list;
@@ -164,7 +164,7 @@ AsyncResultType DirectFileReader::Scan(ClientContext &context, GlobalTableFuncti
 	}
 	output.SetCardinality(1);
 	done = true;
-	return AsyncResultType(SourceResultType::HAVE_MORE_OUTPUT);
+	return AsyncResult(SourceResultType::HAVE_MORE_OUTPUT);
 };
 
 void DirectFileReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) {

--- a/src/function/table/read_duckdb.cpp
+++ b/src/function/table/read_duckdb.cpp
@@ -316,15 +316,17 @@ AsyncResult DuckDBReader::Scan(ClientContext &context, GlobalTableFunctionState 
 		switch (input.async_result.GetResultType()) {
 		case AsyncResultType::BLOCKED:
 			return std::move(input.async_result);
+		case AsyncResultType::HAVE_MORE_OUTPUT:
+			return SourceResultType::HAVE_MORE_OUTPUT;
 		case AsyncResultType::IMPLICIT:
 			if (chunk.size() > 0) {
 				return SourceResultType::HAVE_MORE_OUTPUT;
 			}
+			finished = true;
 			return SourceResultType::FINISHED;
 		case AsyncResultType::FINISHED:
+			finished = true;
 			return SourceResultType::FINISHED;
-		case AsyncResultType::HAVE_MORE_OUTPUT:
-			return SourceResultType::HAVE_MORE_OUTPUT;
 		default:
 			throw InternalException("DuckDBReader call of scan_function.function returned unexpected return '%'",
 			                        EnumUtil::ToChars(input.async_result.GetResultType()));

--- a/src/function/table/read_duckdb.cpp
+++ b/src/function/table/read_duckdb.cpp
@@ -313,7 +313,7 @@ AsyncResultType DuckDBReader::Scan(ClientContext &context, GlobalTableFunctionSt
 	auto res = scan_function.SimpleScan(context, input, chunk);
 
 	if (res == SourceResultType::BLOCKED) {
-		return AsyncResultType(std::move(input.async_tasks));
+		return std::move(input.async_result);
 	}
 	if (res == SourceResultType::FINISHED) {
 		finished = true;

--- a/src/function/table/read_duckdb.cpp
+++ b/src/function/table/read_duckdb.cpp
@@ -312,7 +312,7 @@ AsyncResultType DuckDBReader::Scan(ClientContext &context, GlobalTableFunctionSt
 
 	auto res = scan_function.SimpleScan(context, input, chunk);
 
-	if (res.mode == SourceResultType::FINISHED) {
+	if (res.GetResultType() == SourceResultType::FINISHED) {
 		finished = true;
 	}
 

--- a/src/function/table/read_duckdb.cpp
+++ b/src/function/table/read_duckdb.cpp
@@ -87,8 +87,8 @@ public:
 public:
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-	                     LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	shared_ptr<BaseUnionData> GetUnionData(idx_t file_idx) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) override;
 	double GetProgressInFile(ClientContext &context) override;
@@ -300,8 +300,8 @@ bool DuckDBReader::TryInitializeScan(ClientContext &context, GlobalTableFunction
 	return true;
 }
 
-AsyncResultType DuckDBReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
-                                   LocalTableFunctionState &lstate_p, DataChunk &chunk) {
+AsyncResult DuckDBReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+                               LocalTableFunctionState &lstate_p, DataChunk &chunk) {
 	chunk.Reset();
 	auto &lstate = lstate_p.Cast<DuckDBReadLocalState>();
 	TableFunctionInput input(bind_data.get(), lstate.local_state, global_state);
@@ -319,7 +319,7 @@ AsyncResultType DuckDBReader::Scan(ClientContext &context, GlobalTableFunctionSt
 		finished = true;
 	}
 
-	return AsyncResultType(res);
+	return AsyncResult(res);
 }
 
 void DuckDBReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) {

--- a/src/function/table/read_duckdb.cpp
+++ b/src/function/table/read_duckdb.cpp
@@ -87,8 +87,8 @@ public:
 public:
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-	          DataChunk &chunk) override;
+	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                     LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	shared_ptr<BaseUnionData> GetUnionData(idx_t file_idx) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) override;
 	double GetProgressInFile(ClientContext &context) override;
@@ -300,15 +300,23 @@ bool DuckDBReader::TryInitializeScan(ClientContext &context, GlobalTableFunction
 	return true;
 }
 
-void DuckDBReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p, LocalTableFunctionState &lstate_p,
-                        DataChunk &chunk) {
+AsyncResultType DuckDBReader::Scan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+                                   LocalTableFunctionState &lstate_p, DataChunk &chunk) {
 	chunk.Reset();
 	auto &lstate = lstate_p.Cast<DuckDBReadLocalState>();
 	TableFunctionInput input(bind_data.get(), lstate.local_state, global_state);
-	scan_function.function(context, input, chunk);
-	if (chunk.size() == 0) {
+
+	if (!scan_function.HasSimpleScan()) {
+		throw InternalException("DuckDBReader works only with SimpleScans");
+	}
+
+	auto res = scan_function.SimpleScan(context, input, chunk);
+
+	if (res.mode == SourceResultType::FINISHED) {
 		finished = true;
 	}
+
+	return res;
 }
 
 void DuckDBReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) {

--- a/src/function/table/read_duckdb.cpp
+++ b/src/function/table/read_duckdb.cpp
@@ -310,6 +310,7 @@ AsyncResult DuckDBReader::Scan(ClientContext &context, GlobalTableFunctionState 
 		throw InternalException("DuckDBReader works only with simple table functions");
 	} else {
 		input.async_result = AsyncResultType::IMPLICIT;
+		input.results_execution_mode = AsyncResultsExecutionMode::TASK_EXECUTOR;
 		scan_function.function(context, input, chunk);
 
 		switch (input.async_result.GetResultType()) {

--- a/src/function/table/read_duckdb.cpp
+++ b/src/function/table/read_duckdb.cpp
@@ -312,11 +312,14 @@ AsyncResultType DuckDBReader::Scan(ClientContext &context, GlobalTableFunctionSt
 
 	auto res = scan_function.SimpleScan(context, input, chunk);
 
-	if (res.GetResultType() == SourceResultType::FINISHED) {
+	if (res == SourceResultType::BLOCKED) {
+		return AsyncResultType(std::move(input.async_tasks));
+	}
+	if (res == SourceResultType::FINISHED) {
 		finished = true;
 	}
 
-	return res;
+	return AsyncResultType(res);
 }
 
 void DuckDBReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) {

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -80,7 +80,7 @@ bool ExtractSourceResultType(AsyncResultType in, SourceResultType &out) {
 	case AsyncResultType::IMPLICIT:
 	case AsyncResultType::INVALID:
 		return false;
-	case AsyncResultType::HAVE_MORE_OUTPUT:
+	case AsyncResultType::ONGOING:
 		out = SourceResultType::HAVE_MORE_OUTPUT;
 		break;
 	case AsyncResultType::FINISHED:
@@ -96,7 +96,7 @@ bool ExtractSourceResultType(AsyncResultType in, SourceResultType &out) {
 AsyncResultType GetAsyncResultType(SourceResultType s) {
 	switch (s) {
 	case SourceResultType::HAVE_MORE_OUTPUT:
-		return AsyncResultType::HAVE_MORE_OUTPUT;
+		return AsyncResultType::ONGOING;
 	case SourceResultType::FINISHED:
 		return AsyncResultType::FINISHED;
 	case SourceResultType::BLOCKED:

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -102,6 +102,9 @@ AsyncResultType GetAsyncResultType(SourceResultType s) {
 	case SourceResultType::BLOCKED:
 		return AsyncResultType::BLOCKED;
 	}
+	D_ASSERT(false);
+	// This is an impossible path
+	return AsyncResultType::INVALID;
 }
 
 } // namespace duckdb

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -14,24 +14,63 @@ PartitionStatistics::PartitionStatistics() : row_start(0), count(0), count_type(
 TableFunctionInfo::~TableFunctionInfo() {
 }
 
-TableFunction::TableFunction(string name, vector<LogicalType> arguments, table_function_t function,
+TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, table_function_t function_,
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
-    : SimpleNamedParameterFunction(std::move(name), std::move(arguments)), bind(bind), bind_replace(nullptr),
-      bind_operator(nullptr), init_global(init_global), init_local(init_local), function(function),
-      in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr), dependency(nullptr),
-      cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr), to_string(nullptr),
-      dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr), get_bind_info(nullptr),
-      type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
+    : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), async_function(nullptr),
+      function(function_), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
+      dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
+      to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
+      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
       get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
       get_row_id_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
       filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
 }
 
-TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function,
+TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, async_table_function_t function_,
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
-    : TableFunction(string(), arguments, function, bind, init_global, init_local) {
+    : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), async_function(function_),
+      function(nullptr), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
+      dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
+      to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
+      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
+      get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
+      get_row_id_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
+      filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
+}
+
+TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, std::nullptr_t function_,
+                             table_function_bind_t bind, table_function_init_global_t init_global,
+                             table_function_init_local_t init_local)
+    : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), async_function(nullptr),
+      function(nullptr), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
+      dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
+      to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
+      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
+      get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
+      get_row_id_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
+      filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
+}
+
+TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function_,
+                             table_function_bind_t bind, table_function_init_global_t init_global,
+                             table_function_init_local_t init_local)
+    : TableFunction("", arguments, function_, bind, init_global, init_local) {
+}
+
+TableFunction::TableFunction(const vector<LogicalType> &arguments, async_table_function_t function_,
+                             table_function_bind_t bind, table_function_init_global_t init_global,
+                             table_function_init_local_t init_local)
+    : TableFunction("", arguments, function_, bind, init_global, init_local) {
+}
+
+TableFunction::TableFunction(const vector<LogicalType> &arguments, std::nullptr_t function_, table_function_bind_t bind,
+                             table_function_init_global_t init_global, table_function_init_local_t init_local)
+    : TableFunction("", arguments, function_, bind, init_global, init_local) {
 }
 
 TableFunction::TableFunction() : TableFunction("", {}, nullptr, nullptr, nullptr, nullptr) {

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -18,25 +18,11 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
     : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
-      bind_operator(nullptr), init_global(init_global), init_local(init_local), function_ext(nullptr),
-      function(function_), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
-      dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
-      to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
-      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
-      get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
-      get_row_id_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
-      filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
-}
-
-TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, table_function_ext_t function_,
-                             table_function_bind_t bind, table_function_init_global_t init_global,
-                             table_function_init_local_t init_local)
-    : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
-      bind_operator(nullptr), init_global(init_global), init_local(init_local), function_ext(function_),
-      function(nullptr), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
-      dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
-      to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
-      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), function(function_),
+      in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr), dependency(nullptr),
+      cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr), to_string(nullptr),
+      dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr), get_bind_info(nullptr),
+      type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
       get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
       get_row_id_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
       filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
@@ -46,23 +32,17 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
     : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
-      bind_operator(nullptr), init_global(init_global), init_local(init_local), function_ext(nullptr),
-      function(nullptr), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
-      dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
-      to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
-      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), function(nullptr),
+      in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr), dependency(nullptr),
+      cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr), to_string(nullptr),
+      dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr), get_bind_info(nullptr),
+      type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
       get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
       get_row_id_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
       filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
 }
 
 TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function_,
-                             table_function_bind_t bind, table_function_init_global_t init_global,
-                             table_function_init_local_t init_local)
-    : TableFunction("", arguments, function_, bind, init_global, init_local) {
-}
-
-TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_ext_t function_,
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
     : TableFunction("", arguments, function_, bind, init_global, init_local) {
@@ -93,6 +73,35 @@ bool TableFunction::Equal(const TableFunction &rhs) const {
 	}
 
 	return true; // they are equal
+}
+
+bool ExtractSourceResultType(TableFunctionResultType in, SourceResultType &out) {
+	switch (in) {
+	case TableFunctionResultType::DEFAULT:
+	case TableFunctionResultType::INVALID:
+		return false;
+	case TableFunctionResultType::HAVE_MORE_OUTPUT:
+		out = SourceResultType::HAVE_MORE_OUTPUT;
+		break;
+	case TableFunctionResultType::FINISHED:
+		out = SourceResultType::FINISHED;
+		break;
+	case TableFunctionResultType::BLOCKED:
+		out = SourceResultType::BLOCKED;
+		break;
+	}
+	return true;
+}
+
+TableFunctionResultType GetTableFunctionResultType(SourceResultType s) {
+	switch (s) {
+	case SourceResultType::HAVE_MORE_OUTPUT:
+		return TableFunctionResultType::HAVE_MORE_OUTPUT;
+	case SourceResultType::FINISHED:
+		return TableFunctionResultType::FINISHED;
+	case SourceResultType::BLOCKED:
+		return TableFunctionResultType::BLOCKED;
+	}
 }
 
 } // namespace duckdb

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -93,18 +93,4 @@ bool ExtractSourceResultType(AsyncResultType in, SourceResultType &out) {
 	return true;
 }
 
-AsyncResultType GetAsyncResultType(SourceResultType s) {
-	switch (s) {
-	case SourceResultType::HAVE_MORE_OUTPUT:
-		return AsyncResultType::HAVE_MORE_OUTPUT;
-	case SourceResultType::FINISHED:
-		return AsyncResultType::FINISHED;
-	case SourceResultType::BLOCKED:
-		return AsyncResultType::BLOCKED;
-	}
-	D_ASSERT(false);
-	// This is an impossible path
-	return AsyncResultType::INVALID;
-}
-
 } // namespace duckdb

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -18,7 +18,7 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
     : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
-      bind_operator(nullptr), init_global(init_global), init_local(init_local), async_function(nullptr),
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), function_ext(nullptr),
       function(function_), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
       dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
       to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
@@ -28,11 +28,11 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
       filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
 }
 
-TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, async_table_function_t function_,
+TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, table_function_ext_t function_,
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
     : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
-      bind_operator(nullptr), init_global(init_global), init_local(init_local), async_function(function_),
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), function_ext(function_),
       function(nullptr), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
       dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
       to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
@@ -46,7 +46,7 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
     : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
-      bind_operator(nullptr), init_global(init_global), init_local(init_local), async_function(nullptr),
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), function_ext(nullptr),
       function(nullptr), in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr),
       dependency(nullptr), cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
       to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
@@ -62,7 +62,7 @@ TableFunction::TableFunction(const vector<LogicalType> &arguments, table_functio
     : TableFunction("", arguments, function_, bind, init_global, init_local) {
 }
 
-TableFunction::TableFunction(const vector<LogicalType> &arguments, async_table_function_t function_,
+TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_ext_t function_,
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
     : TableFunction("", arguments, function_, bind, init_global, init_local) {

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -80,7 +80,7 @@ bool ExtractSourceResultType(AsyncResultType in, SourceResultType &out) {
 	case AsyncResultType::IMPLICIT:
 	case AsyncResultType::INVALID:
 		return false;
-	case AsyncResultType::ONGOING:
+	case AsyncResultType::HAVE_MORE_OUTPUT:
 		out = SourceResultType::HAVE_MORE_OUTPUT;
 		break;
 	case AsyncResultType::FINISHED:
@@ -96,7 +96,7 @@ bool ExtractSourceResultType(AsyncResultType in, SourceResultType &out) {
 AsyncResultType GetAsyncResultType(SourceResultType s) {
 	switch (s) {
 	case SourceResultType::HAVE_MORE_OUTPUT:
-		return AsyncResultType::ONGOING;
+		return AsyncResultType::HAVE_MORE_OUTPUT;
 	case SourceResultType::FINISHED:
 		return AsyncResultType::FINISHED;
 	case SourceResultType::BLOCKED:

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -75,32 +75,32 @@ bool TableFunction::Equal(const TableFunction &rhs) const {
 	return true; // they are equal
 }
 
-bool ExtractSourceResultType(TableFunctionResultType in, SourceResultType &out) {
+bool ExtractSourceResultType(AsyncResultType in, SourceResultType &out) {
 	switch (in) {
-	case TableFunctionResultType::DEFAULT:
-	case TableFunctionResultType::INVALID:
+	case AsyncResultType::IMPLICIT:
+	case AsyncResultType::INVALID:
 		return false;
-	case TableFunctionResultType::HAVE_MORE_OUTPUT:
+	case AsyncResultType::HAVE_MORE_OUTPUT:
 		out = SourceResultType::HAVE_MORE_OUTPUT;
 		break;
-	case TableFunctionResultType::FINISHED:
+	case AsyncResultType::FINISHED:
 		out = SourceResultType::FINISHED;
 		break;
-	case TableFunctionResultType::BLOCKED:
+	case AsyncResultType::BLOCKED:
 		out = SourceResultType::BLOCKED;
 		break;
 	}
 	return true;
 }
 
-TableFunctionResultType GetTableFunctionResultType(SourceResultType s) {
+AsyncResultType GetAsyncResultType(SourceResultType s) {
 	switch (s) {
 	case SourceResultType::HAVE_MORE_OUTPUT:
-		return TableFunctionResultType::HAVE_MORE_OUTPUT;
+		return AsyncResultType::HAVE_MORE_OUTPUT;
 	case SourceResultType::FINISHED:
-		return TableFunctionResultType::FINISHED;
+		return AsyncResultType::FINISHED;
 	case SourceResultType::BLOCKED:
-		return TableFunctionResultType::BLOCKED;
+		return AsyncResultType::BLOCKED;
 	}
 }
 

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -78,6 +78,8 @@ enum class ArrowTypeInfoType : uint8_t;
 
 enum class ArrowVariableSizeType : uint8_t;
 
+enum class AsyncResultType : uint8_t;
+
 enum class BinderType : uint8_t;
 
 enum class BindingMode : uint8_t;
@@ -394,8 +396,6 @@ enum class TableColumnType : uint8_t;
 
 enum class TableFilterType : uint8_t;
 
-enum class TableFunctionResultType : uint8_t;
-
 enum class TablePartitionInfo : uint8_t;
 
 enum class TableReferenceType : uint8_t;
@@ -523,6 +523,9 @@ const char* EnumUtil::ToChars<ArrowTypeInfoType>(ArrowTypeInfoType value);
 
 template<>
 const char* EnumUtil::ToChars<ArrowVariableSizeType>(ArrowVariableSizeType value);
+
+template<>
+const char* EnumUtil::ToChars<AsyncResultType>(AsyncResultType value);
 
 template<>
 const char* EnumUtil::ToChars<BinderType>(BinderType value);
@@ -999,9 +1002,6 @@ template<>
 const char* EnumUtil::ToChars<TableFilterType>(TableFilterType value);
 
 template<>
-const char* EnumUtil::ToChars<TableFunctionResultType>(TableFunctionResultType value);
-
-template<>
 const char* EnumUtil::ToChars<TablePartitionInfo>(TablePartitionInfo value);
 
 template<>
@@ -1157,6 +1157,9 @@ ArrowTypeInfoType EnumUtil::FromString<ArrowTypeInfoType>(const char *value);
 
 template<>
 ArrowVariableSizeType EnumUtil::FromString<ArrowVariableSizeType>(const char *value);
+
+template<>
+AsyncResultType EnumUtil::FromString<AsyncResultType>(const char *value);
 
 template<>
 BinderType EnumUtil::FromString<BinderType>(const char *value);
@@ -1631,9 +1634,6 @@ TableColumnType EnumUtil::FromString<TableColumnType>(const char *value);
 
 template<>
 TableFilterType EnumUtil::FromString<TableFilterType>(const char *value);
-
-template<>
-TableFunctionResultType EnumUtil::FromString<TableFunctionResultType>(const char *value);
 
 template<>
 TablePartitionInfo EnumUtil::FromString<TablePartitionInfo>(const char *value);

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -80,6 +80,8 @@ enum class ArrowVariableSizeType : uint8_t;
 
 enum class AsyncResultType : uint8_t;
 
+enum class AsyncResultsExecutionMode : uint8_t;
+
 enum class BinderType : uint8_t;
 
 enum class BindingMode : uint8_t;
@@ -526,6 +528,9 @@ const char* EnumUtil::ToChars<ArrowVariableSizeType>(ArrowVariableSizeType value
 
 template<>
 const char* EnumUtil::ToChars<AsyncResultType>(AsyncResultType value);
+
+template<>
+const char* EnumUtil::ToChars<AsyncResultsExecutionMode>(AsyncResultsExecutionMode value);
 
 template<>
 const char* EnumUtil::ToChars<BinderType>(BinderType value);
@@ -1160,6 +1165,9 @@ ArrowVariableSizeType EnumUtil::FromString<ArrowVariableSizeType>(const char *va
 
 template<>
 AsyncResultType EnumUtil::FromString<AsyncResultType>(const char *value);
+
+template<>
+AsyncResultsExecutionMode EnumUtil::FromString<AsyncResultsExecutionMode>(const char *value);
 
 template<>
 BinderType EnumUtil::FromString<BinderType>(const char *value);

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -394,6 +394,8 @@ enum class TableColumnType : uint8_t;
 
 enum class TableFilterType : uint8_t;
 
+enum class TableFunctionResultType : uint8_t;
+
 enum class TablePartitionInfo : uint8_t;
 
 enum class TableReferenceType : uint8_t;
@@ -995,6 +997,9 @@ const char* EnumUtil::ToChars<TableColumnType>(TableColumnType value);
 
 template<>
 const char* EnumUtil::ToChars<TableFilterType>(TableFilterType value);
+
+template<>
+const char* EnumUtil::ToChars<TableFunctionResultType>(TableFunctionResultType value);
 
 template<>
 const char* EnumUtil::ToChars<TablePartitionInfo>(TablePartitionInfo value);
@@ -1626,6 +1631,9 @@ TableColumnType EnumUtil::FromString<TableColumnType>(const char *value);
 
 template<>
 TableFilterType EnumUtil::FromString<TableFilterType>(const char *value);
+
+template<>
+TableFunctionResultType EnumUtil::FromString<TableFunctionResultType>(const char *value);
 
 template<>
 TablePartitionInfo EnumUtil::FromString<TablePartitionInfo>(const char *value);

--- a/src/include/duckdb/common/enums/operator_result_type.hpp
+++ b/src/include/duckdb/common/enums/operator_result_type.hpp
@@ -44,10 +44,9 @@ enum class SourceResultType : uint8_t { HAVE_MORE_OUTPUT, FINISHED, BLOCKED };
 
 //! AsyncResultType is used to indicate the result of a AsyncResult, in the context of a wider operation being executed
 enum class AsyncResultType : uint8_t {
-	INVALID,  // current result is in an invalid state (eg: it's in the process of being initialized)
 	IMPLICIT, // current result depends on external context (eg: in the context of TableFunctions, either FINISHED or
-	          // ONGOING depending on output_chunk.size())
-	ONGOING,  // current result is not completed, finished (eg: in the context of TableFunctions, function accept more
+	          // HAVE_MORE_OUTPUT depending on output_chunk.size())
+	HAVE_MORE_OUTPUT,  // current result is not completed, finished (eg: in the context of TableFunctions, function accept more
 	          // iterations and might produce further results)
 	FINISHED, // current result is completed, no subsequent calls on the same state should be attempted
 	BLOCKED // current result is blocked, no subsequent calls on the same state should be attempted (eg: in the context

--- a/src/include/duckdb/common/enums/operator_result_type.hpp
+++ b/src/include/duckdb/common/enums/operator_result_type.hpp
@@ -43,12 +43,16 @@ enum class OperatorFinalResultType : uint8_t { FINISHED, BLOCKED };
 enum class SourceResultType : uint8_t { HAVE_MORE_OUTPUT, FINISHED, BLOCKED };
 
 //! AsyncResultType is used to indicate the result of a AsyncResult, in the context of a wider operation being executed
-//! on a Source There are five possible results: INVALID means the current AsyncResult is in an invalid state (eg. it's
-//! in the process of being initialized) IMPLICIT means impliying the result from the context (that is, in the case of
-//! TableFunctions: FINISHED if output is empty and HAVE_MORE_OUTPUT otherwise) HAVE_MORE_OUTPUT means the source has
-//! more output, and should be queried again FINISHED means the source is exhausted BLOCKED means the source is
-//! currently blocked, and the AsyncResult should hold the vector of AsyncTasks to be scheduled to trigger progress
-enum class AsyncResultType : uint8_t { INVALID, IMPLICIT, HAVE_MORE_OUTPUT, FINISHED, BLOCKED };
+enum class AsyncResultType : uint8_t {
+	INVALID,  // current result is in an invalid state (eg: it's in the process of being initialized)
+	IMPLICIT, // current result depends on external context (eg: in the context of TableFunctions, either FINISHED or
+	          // ONGOING depending on output_chunk.size())
+	ONGOING,  // current result is not completed, finished (eg: in the context of TableFunctions, function accept more
+	          // iterations and might producer further results)
+	FINISHED, // current result is completed, no subsequent calls on the same state should be attempted
+	BLOCKED   // current result is blocked, no subsequent calls on the same state should be attempted, BLOCKED migth be
+	          // associated with a vector of AsycnTasks to be scheduled
+};
 
 bool ExtractSourceResultType(AsyncResultType in, SourceResultType &out);
 

--- a/src/include/duckdb/common/enums/operator_result_type.hpp
+++ b/src/include/duckdb/common/enums/operator_result_type.hpp
@@ -49,7 +49,7 @@ enum class AsyncResultType : uint8_t {
 	          // HAVE_MORE_OUTPUT depending on output_chunk.size())
 	HAVE_MORE_OUTPUT, // current result is not completed, finished (eg: in the context of TableFunctions, function
 	                  // accept more iterations and might produce further results)
-	FINISHED, // current result is completed, no subsequent calls on the same state should be attempted
+	FINISHED,         // current result is completed, no subsequent calls on the same state should be attempted
 	BLOCKED // current result is blocked, no subsequent calls on the same state should be attempted (eg: in the context
 	        // of AsyncResult, BLOCKED will be associated with a vector of AsyncTasks to be scheduled)
 };

--- a/src/include/duckdb/common/enums/operator_result_type.hpp
+++ b/src/include/duckdb/common/enums/operator_result_type.hpp
@@ -55,8 +55,6 @@ enum class AsyncResultType : uint8_t {
 
 bool ExtractSourceResultType(AsyncResultType in, SourceResultType &out);
 
-AsyncResultType GetAsyncResultType(SourceResultType s);
-
 //! The SinkResultType is used to indicate the result of data flowing into a sink
 //! There are three possible results:
 //! NEED_MORE_INPUT means the sink needs more input

--- a/src/include/duckdb/common/enums/operator_result_type.hpp
+++ b/src/include/duckdb/common/enums/operator_result_type.hpp
@@ -48,10 +48,10 @@ enum class AsyncResultType : uint8_t {
 	IMPLICIT, // current result depends on external context (eg: in the context of TableFunctions, either FINISHED or
 	          // ONGOING depending on output_chunk.size())
 	ONGOING,  // current result is not completed, finished (eg: in the context of TableFunctions, function accept more
-	          // iterations and might producer further results)
+	          // iterations and might produce further results)
 	FINISHED, // current result is completed, no subsequent calls on the same state should be attempted
-	BLOCKED   // current result is blocked, no subsequent calls on the same state should be attempted, BLOCKED migth be
-	          // associated with a vector of AsycnTasks to be scheduled
+	BLOCKED // current result is blocked, no subsequent calls on the same state should be attempted (eg: in the context
+	        // of AsyncResult, BLOCKED will be associated with a vector of AsyncTasks to be scheduled)
 };
 
 bool ExtractSourceResultType(AsyncResultType in, SourceResultType &out);

--- a/src/include/duckdb/common/enums/operator_result_type.hpp
+++ b/src/include/duckdb/common/enums/operator_result_type.hpp
@@ -42,18 +42,17 @@ enum class OperatorFinalResultType : uint8_t { FINISHED, BLOCKED };
 //! BLOCKED means the source is currently blocked, e.g. by some async I/O
 enum class SourceResultType : uint8_t { HAVE_MORE_OUTPUT, FINISHED, BLOCKED };
 
-//! TableFunctionResultType is used to indicate the result of data being pulled out of a TableFunction.
-//! There are four possible results:
-//! HAVE_MORE_OUTPUT means the source has more output
-//! FINISHED means the source is exhausted
-//! BLOCKED means the source is currently blocked, e.g. by some async I/O
-//! DEFAULT means impliying the result from the context (that is FINISHED if output is empty and HAVE_MORE_OUTPUT
-//! otherwise)
-enum class TableFunctionResultType : uint8_t { HAVE_MORE_OUTPUT, FINISHED, BLOCKED, DEFAULT, INVALID };
+//! AsyncResultType is used to indicate the result of a AsyncResult, in the context of a wider operation being executed
+//! on a Source There are five possible results: INVALID means the current AsyncResult is in an invalid state (eg. it's
+//! in the process of being initialized) IMPLICIT means impliying the result from the context (that is, in the case of
+//! TableFunctions: FINISHED if output is empty and HAVE_MORE_OUTPUT otherwise) HAVE_MORE_OUTPUT means the source has
+//! more output, and should be queried again FINISHED means the source is exhausted BLOCKED means the source is
+//! currently blocked, and the AsyncResult should hold the vector of AsyncTasks to be scheduled to trigger progress
+enum class AsyncResultType : uint8_t { INVALID, IMPLICIT, HAVE_MORE_OUTPUT, FINISHED, BLOCKED };
 
-bool ExtractSourceResultType(TableFunctionResultType in, SourceResultType &out);
+bool ExtractSourceResultType(AsyncResultType in, SourceResultType &out);
 
-TableFunctionResultType GetTableFunctionResultType(SourceResultType s);
+AsyncResultType GetAsyncResultType(SourceResultType s);
 
 //! The SinkResultType is used to indicate the result of data flowing into a sink
 //! There are three possible results:

--- a/src/include/duckdb/common/enums/operator_result_type.hpp
+++ b/src/include/duckdb/common/enums/operator_result_type.hpp
@@ -47,8 +47,8 @@ enum class AsyncResultType : uint8_t {
 	INVALID,  // current result is in an invalid state (eg: it's in the process of being initialized)
 	IMPLICIT, // current result depends on external context (eg: in the context of TableFunctions, either FINISHED or
 	          // HAVE_MORE_OUTPUT depending on output_chunk.size())
-	HAVE_MORE_OUTPUT,  // current result is not completed, finished (eg: in the context of TableFunctions, function accept more
-	          // iterations and might produce further results)
+	HAVE_MORE_OUTPUT, // current result is not completed, finished (eg: in the context of TableFunctions, function
+	                  // accept more iterations and might produce further results)
 	FINISHED, // current result is completed, no subsequent calls on the same state should be attempted
 	BLOCKED // current result is blocked, no subsequent calls on the same state should be attempted (eg: in the context
 	        // of AsyncResult, BLOCKED will be associated with a vector of AsyncTasks to be scheduled)

--- a/src/include/duckdb/common/enums/operator_result_type.hpp
+++ b/src/include/duckdb/common/enums/operator_result_type.hpp
@@ -44,6 +44,7 @@ enum class SourceResultType : uint8_t { HAVE_MORE_OUTPUT, FINISHED, BLOCKED };
 
 //! AsyncResultType is used to indicate the result of a AsyncResult, in the context of a wider operation being executed
 enum class AsyncResultType : uint8_t {
+	INVALID,  // current result is in an invalid state (eg: it's in the process of being initialized)
 	IMPLICIT, // current result depends on external context (eg: in the context of TableFunctions, either FINISHED or
 	          // HAVE_MORE_OUTPUT depending on output_chunk.size())
 	HAVE_MORE_OUTPUT,  // current result is not completed, finished (eg: in the context of TableFunctions, function accept more

--- a/src/include/duckdb/common/enums/operator_result_type.hpp
+++ b/src/include/duckdb/common/enums/operator_result_type.hpp
@@ -42,6 +42,19 @@ enum class OperatorFinalResultType : uint8_t { FINISHED, BLOCKED };
 //! BLOCKED means the source is currently blocked, e.g. by some async I/O
 enum class SourceResultType : uint8_t { HAVE_MORE_OUTPUT, FINISHED, BLOCKED };
 
+//! TableFunctionResultType is used to indicate the result of data being pulled out of a TableFunction.
+//! There are four possible results:
+//! HAVE_MORE_OUTPUT means the source has more output
+//! FINISHED means the source is exhausted
+//! BLOCKED means the source is currently blocked, e.g. by some async I/O
+//! DEFAULT means impliying the result from the context (that is FINISHED if output is empty and HAVE_MORE_OUTPUT
+//! otherwise)
+enum class TableFunctionResultType : uint8_t { HAVE_MORE_OUTPUT, FINISHED, BLOCKED, DEFAULT, INVALID };
+
+bool ExtractSourceResultType(TableFunctionResultType in, SourceResultType &out);
+
+TableFunctionResultType GetTableFunctionResultType(SourceResultType s);
+
 //! The SinkResultType is used to indicate the result of data flowing into a sink
 //! There are three possible results:
 //! NEED_MORE_INPUT means the sink needs more input

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -79,8 +79,8 @@ public:
 	virtual bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                               LocalTableFunctionState &lstate) = 0;
 	//! Scan a chunk from the read state
-	virtual void Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-	                  LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
+	virtual AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                             LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
 	//! Finish scanning a given file
 	DUCKDB_API virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate);
 	//! Get progress within a given file

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -79,8 +79,8 @@ public:
 	virtual bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                               LocalTableFunctionState &lstate) = 0;
 	//! Scan a chunk from the read state
-	virtual AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-	                             LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
+	virtual AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                         LocalTableFunctionState &local_state, DataChunk &chunk) = 0;
 	//! Finish scanning a given file
 	DUCKDB_API virtual void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate);
 	//! Get progress within a given file

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -611,10 +611,10 @@ public:
 				case AsyncResultsExecutionMode::TASK_EXECUTOR:
 					data_p.async_result = std::move(res);
 					return;
-				case AsyncResultsExecutionMode::SYNCRONOUS:
-					res.ExecuteTasksSyncronously();
+				case AsyncResultsExecutionMode::SYNCHRONOUS:
+					res.ExecuteTasksSynchronously();
 					if (res.GetResultType() != AsyncResultType::HAVE_MORE_OUTPUT) {
-						throw InternalException("Unexpected behaviour from ExecuteTasksSyncronously");
+						throw InternalException("Unexpected behaviour from ExecuteTasksSynchronously");
 					}
 					// scan_chunk.size() is 0, see check above, and result is HAVE_MORE_OUTPUT, we need to loop again
 					continue;

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -626,7 +626,7 @@ public:
 			}
 		} while (true);
 		// This is not expected to be ever taken
-		D_ASSERT(false);
+		throw InternalException("MultiFileScan is malformed");
 	}
 
 	static unique_ptr<BaseStatistics> MultiFileScanStats(ClientContext &context, const FunctionData *bind_data_p,

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -588,7 +588,7 @@ public:
 		return partition_data;
 	}
 
-	static AsyncResultType MultiFileScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	static SourceResultType MultiFileScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 
 		if (!data_p.local_state) {
 			return SourceResultType::FINISHED;
@@ -604,7 +604,8 @@ public:
 			auto res = data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
 
 			if (res.GetResultType() == SourceResultType::BLOCKED) {
-				return res;
+				data_p.async_tasks = std::move(res.GetAsyncTasks());
+				return SourceResultType::BLOCKED;
 			}
 
 			output.SetCardinality(scan_chunk.size());

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -604,7 +604,7 @@ public:
 
 			auto res = data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
 
-			if (res.GetResultType() == TableFunctionResultType::BLOCKED) {
+			if (res.GetResultType() == AsyncResultType::BLOCKED) {
 				data_p.async_result = std::move(res);
 				return;
 			}

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -589,7 +589,6 @@ public:
 	}
 
 	static void MultiFileScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-
 		if (!data_p.local_state) {
 			data_p.async_result = SourceResultType::FINISHED;
 			return;

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -603,7 +603,7 @@ public:
 
 			auto res = data.reader->Scan(context, *gstate.global_state, *data.local_state, scan_chunk);
 
-			if (res.mode == SourceResultType::BLOCKED) {
+			if (res.GetResultType() == SourceResultType::BLOCKED) {
 				return res;
 			}
 

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -59,8 +59,8 @@ public:
 	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-	                     LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -59,8 +59,8 @@ public:
 	void PrepareReader(ClientContext &context, GlobalTableFunctionState &) override;
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-	          DataChunk &chunk) override;
+	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                     LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 

--- a/src/include/duckdb/function/table/direct_file_reader.hpp
+++ b/src/include/duckdb/function/table/direct_file_reader.hpp
@@ -23,8 +23,8 @@ public:
 
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-	                     LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) override;
 
 	string GetReaderType() const override {

--- a/src/include/duckdb/function/table/direct_file_reader.hpp
+++ b/src/include/duckdb/function/table/direct_file_reader.hpp
@@ -23,8 +23,8 @@ public:
 
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	void Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-	          DataChunk &chunk) override;
+	AsyncResultType Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                     LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) override;
 
 	string GetReaderType() const override {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -166,7 +166,7 @@ public:
 	optional_ptr<const FunctionData> bind_data;
 	optional_ptr<LocalTableFunctionState> local_state;
 	optional_ptr<GlobalTableFunctionState> global_state;
-	AsyncResultType async_result {};
+	AsyncResult async_result {};
 };
 
 struct TableFunctionPartitionInput {
@@ -353,7 +353,7 @@ public:
 		return function;
 	}
 	SourceResultType SimpleScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) const {
-		data.async_result = AsyncResultType();
+		data.async_result = AsyncResult();
 		function(context, data, output);
 		TableFunctionResultType table_res = data.async_result.GetResultType();
 		SourceResultType source_res;

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -353,9 +353,9 @@ public:
 		return function;
 	}
 	SourceResultType SimpleScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) const {
-		data.async_result = AsyncResult();
+		data.async_result = AsyncResult(AsyncResultType::IMPLICIT);
 		function(context, data, output);
-		TableFunctionResultType table_res = data.async_result.GetResultType();
+		AsyncResultType table_res = data.async_result.GetResultType();
 		SourceResultType source_res;
 		if (ExtractSourceResultType(table_res, source_res)) {
 			return source_res;

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -167,7 +167,7 @@ public:
 	optional_ptr<LocalTableFunctionState> local_state;
 	optional_ptr<GlobalTableFunctionState> global_state;
 	AsyncResult async_result {};
-	AsyncResultsExecutionMode results_execution_mode {AsyncResultsExecutionMode::SYNCRONOUS};
+	AsyncResultsExecutionMode results_execution_mode {AsyncResultsExecutionMode::SYNCHRONOUS};
 };
 
 struct TableFunctionPartitionInput {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -360,6 +360,7 @@ public:
 		if (ExtractSourceResultType(table_res, source_res)) {
 			return source_res;
 		}
+		// data.async_result is IMPLICIT, so implicit handling:
 		if (output.size() > 0) {
 			return SourceResultType::HAVE_MORE_OUTPUT;
 		}

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -167,6 +167,7 @@ public:
 	optional_ptr<LocalTableFunctionState> local_state;
 	optional_ptr<GlobalTableFunctionState> global_state;
 	AsyncResult async_result {};
+	AsyncResultsExecutionMode results_execution_mode {AsyncResultsExecutionMode::SYNCRONOUS};
 };
 
 struct TableFunctionPartitionInput {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -353,7 +353,7 @@ public:
 		return function;
 	}
 	SourceResultType SimpleScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) const {
-		data.async_result = AsyncResult(AsyncResultType::IMPLICIT);
+		data.async_result = AsyncResult();
 		function(context, data, output);
 		AsyncResultType table_res = data.async_result.GetResultType();
 		SourceResultType source_res;

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -353,7 +353,7 @@ public:
 		return function;
 	}
 	SourceResultType SimpleScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) const {
-		data.async_result = AsyncResult();
+		data.async_result = AsyncResultType::IMPLICIT;
 		function(context, data, output);
 		AsyncResultType table_res = data.async_result.GetResultType();
 		SourceResultType source_res;

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -349,24 +349,6 @@ public:
 	TableFunction(const vector<LogicalType> &arguments, std::nullptr_t function, table_function_bind_t bind = nullptr,
 	              table_function_init_global_t init_global = nullptr, table_function_init_local_t init_local = nullptr);
 
-	bool HasSimpleScan() const {
-		return function;
-	}
-	SourceResultType SimpleScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) const {
-		data.async_result = AsyncResultType::IMPLICIT;
-		function(context, data, output);
-		AsyncResultType table_res = data.async_result.GetResultType();
-		SourceResultType source_res;
-		if (ExtractSourceResultType(table_res, source_res)) {
-			return source_res;
-		}
-		// data.async_result is IMPLICIT, so implicit handling:
-		if (output.size() > 0) {
-			return SourceResultType::HAVE_MORE_OUTPUT;
-		}
-		return SourceResultType::FINISHED;
-	}
-
 	//! Bind function
 	//! This function is used for determining the return type of a table producing function and returning bind data
 	//! The returned FunctionData object should be constant and should not be changed during execution.

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -22,25 +22,27 @@ public:
 	AsyncResult() = default;
 	AsyncResult(AsyncResult &&) = default;
 	explicit AsyncResult(SourceResultType t);
+	explicit AsyncResult(AsyncResultType t);
 	explicit AsyncResult(vector<unique_ptr<AsyncTask>> &&task);
 	AsyncResult &operator=(SourceResultType t);
+	AsyncResult &operator=(AsyncResultType t);
 	AsyncResult &operator=(AsyncResult &&) noexcept;
 	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
 	bool HasTasks() const {
-		D_ASSERT((result_type == TableFunctionResultType::BLOCKED) != async_tasks.empty());
+		D_ASSERT((result_type == AsyncResultType::BLOCKED) != async_tasks.empty());
 		return !async_tasks.empty();
 	}
-	TableFunctionResultType GetResultType() const {
-		D_ASSERT((result_type == TableFunctionResultType::BLOCKED) != async_tasks.empty());
+	AsyncResultType GetResultType() const {
+		D_ASSERT((result_type == AsyncResultType::BLOCKED) != async_tasks.empty());
 		return result_type;
 	}
 	vector<unique_ptr<AsyncTask>> &&GetAsyncTasks() {
-		result_type = TableFunctionResultType::INVALID;
+		result_type = AsyncResultType::INVALID;
 		return std::move(async_tasks);
 	}
 
 private:
-	TableFunctionResultType result_type {TableFunctionResultType::DEFAULT};
+	AsyncResultType result_type {AsyncResultType::INVALID};
 	vector<unique_ptr<AsyncTask>> async_tasks {};
 };
 } // namespace duckdb

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -1,9 +1,17 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parallel/async_result.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/enums/operator_result_type.hpp"
-
-#pragma once
 
 namespace duckdb {
 

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -19,9 +19,12 @@ public:
 	AsyncResultType(SourceResultType t);
 	AsyncResultType(unique_ptr<AsyncTask> &&task);
 	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
+	SourceResultType GetResultType() const {
+		return result_type;
+	}
 
-public:
-	SourceResultType mode;
+private:
+	SourceResultType result_type;
 	unique_ptr<AsyncTask> async_task;
 };
 } // namespace duckdb

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -1,4 +1,6 @@
 #include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/vector.hpp"
 
 #pragma once
 
@@ -16,15 +18,18 @@ public:
 
 class AsyncResultType {
 public:
-	AsyncResultType(SourceResultType t);
-	AsyncResultType(unique_ptr<AsyncTask> &&task);
+	explicit AsyncResultType(SourceResultType t);
+	explicit AsyncResultType(vector<unique_ptr<AsyncTask>> &&task);
 	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
 	SourceResultType GetResultType() const {
 		return result_type;
 	}
+	vector<unique_ptr<AsyncTask>> &&GetAsyncTasks() {
+		return std::move(async_tasks);
+	}
 
 private:
 	SourceResultType result_type;
-	unique_ptr<AsyncTask> async_task;
+	vector<unique_ptr<AsyncTask>> async_tasks;
 };
 } // namespace duckdb

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -58,6 +58,10 @@ public:
 	// Extract associated tasks, moving them away, will empty async_tasks and trasnform to INVALID
 	vector<unique_ptr<AsyncTask>> &&ExtractAsyncTasks();
 
+#ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
+	static vector<unique_ptr<AsyncTask>> GenerateTestTasks();
+#endif
+
 private:
 	AsyncResultType result_type {AsyncResultType::INVALID};
 	vector<unique_ptr<AsyncTask>> async_tasks {};

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -1,0 +1,27 @@
+#include "duckdb/common/enum_util.hpp"
+
+#pragma once
+
+namespace duckdb {
+
+class InterruptState;
+class TaskExecutor;
+class Executor;
+
+class AsyncTask {
+public:
+	virtual ~AsyncTask() {};
+	virtual void Execute() = 0;
+};
+
+class AsyncResultType {
+public:
+	AsyncResultType(SourceResultType t);
+	AsyncResultType(unique_ptr<AsyncTask> &&task);
+	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
+
+public:
+	SourceResultType mode;
+	unique_ptr<AsyncTask> async_task;
+};
+} // namespace duckdb

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/common/enums/operator_result_type.hpp"
 
 #pragma once
 
@@ -18,18 +19,28 @@ public:
 
 class AsyncResultType {
 public:
+	AsyncResultType() = default;
+	AsyncResultType(AsyncResultType &&) = default;
 	explicit AsyncResultType(SourceResultType t);
 	explicit AsyncResultType(vector<unique_ptr<AsyncTask>> &&task);
+	AsyncResultType &operator=(SourceResultType t);
+	AsyncResultType &operator=(AsyncResultType &&) noexcept;
 	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
-	SourceResultType GetResultType() const {
+	bool HasTasks() const {
+		D_ASSERT((result_type == TableFunctionResultType::BLOCKED) != async_tasks.empty());
+		return !async_tasks.empty();
+	}
+	TableFunctionResultType GetResultType() const {
+		D_ASSERT((result_type == TableFunctionResultType::BLOCKED) != async_tasks.empty());
 		return result_type;
 	}
 	vector<unique_ptr<AsyncTask>> &&GetAsyncTasks() {
+		result_type = TableFunctionResultType::INVALID;
 		return std::move(async_tasks);
 	}
 
 private:
-	SourceResultType result_type;
-	vector<unique_ptr<AsyncTask>> async_tasks;
+	TableFunctionResultType result_type {TableFunctionResultType::DEFAULT};
+	vector<unique_ptr<AsyncTask>> async_tasks {};
 };
 } // namespace duckdb

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -29,8 +29,7 @@ class AsyncResult {
 public:
 	AsyncResult() = default;
 	AsyncResult(AsyncResult &&) = default;
-	explicit AsyncResult(SourceResultType t);
-	explicit AsyncResult(AsyncResultType t);
+	AsyncResult(SourceResultType t); // NOLINT
 	explicit AsyncResult(vector<unique_ptr<AsyncTask>> &&task);
 	AsyncResult &operator=(SourceResultType t);
 	AsyncResult &operator=(AsyncResultType t);
@@ -39,14 +38,26 @@ public:
 	static AsyncResultType GetAsyncResultType(SourceResultType s);
 
 	bool HasTasks() const {
-		D_ASSERT((result_type == AsyncResultType::BLOCKED) != async_tasks.empty());
-		return !async_tasks.empty();
+		D_ASSERT(result_type != AsyncResultType::INVALID);
+		if (async_result.empty()) {
+			D_ASSERT(result_type != AsyncResultType::BLOCKED);
+			return false;
+		} else {
+			D_ASSERT(result_type == AsyncResultType::BLOCKED);
+			return true;
+		}
 	}
 	AsyncResultType GetResultType() const {
-		D_ASSERT((result_type == AsyncResultType::BLOCKED) != async_tasks.empty());
+		D_ASSERT(result_type != AsyncResultType::INVALID);
+		if (async_result.empty()) {
+			D_ASSERT(result_type != AsyncResultType::BLOCKED);
+		} else {
+			D_ASSERT(result_type == AsyncResultType::BLOCKED);
+		}
 		return result_type;
 	}
-	vector<unique_ptr<AsyncTask>> &&GetAsyncTasks() {
+	vector<unique_ptr<AsyncTask>> &&ExtractAsyncTasks() {
+		D_ASSERT(result_type != AsyncResultType::INVALID);
 		result_type = AsyncResultType::INVALID;
 		return std::move(async_tasks);
 	}

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -19,6 +19,11 @@ class InterruptState;
 class TaskExecutor;
 class Executor;
 
+enum class AsyncResultsExecutionMode : uint8_t {
+	SYNCRONOUS,   // BLOCKED should not bubble up, and they should be executed syncronously
+	TASK_EXECUTOR // BLOCKED is allowed
+};
+
 class AsyncTask {
 public:
 	virtual ~AsyncTask() {};
@@ -37,6 +42,7 @@ public:
 	AsyncResult &operator=(AsyncResultType t);
 	AsyncResult &operator=(AsyncResult &&) noexcept;
 	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
+	void ExecuteTasksSyncronously();
 	static AsyncResultType GetAsyncResultType(SourceResultType s);
 
 	bool HasTasks() const {

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -26,6 +26,8 @@ public:
 };
 
 class AsyncResult {
+	explicit AsyncResult(AsyncResultType t);
+
 public:
 	AsyncResult() = default;
 	AsyncResult(AsyncResult &&) = default;

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -20,7 +20,7 @@ class TaskExecutor;
 class Executor;
 
 enum class AsyncResultsExecutionMode : uint8_t {
-	SYNCRONOUS,   // BLOCKED should not bubble up, and they should be executed syncronously
+	SYNCHRONOUS,  // BLOCKED should not bubble up, and they should be executed synchronously
 	TASK_EXECUTOR // BLOCKED is allowed
 };
 
@@ -42,7 +42,7 @@ public:
 	AsyncResult &operator=(AsyncResultType t);
 	AsyncResult &operator=(AsyncResult &&) noexcept;
 	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
-	void ExecuteTasksSyncronously();
+	void ExecuteTasksSynchronously();
 	static AsyncResultType GetAsyncResultType(SourceResultType s);
 
 	bool HasTasks() const {

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -17,14 +17,14 @@ public:
 	virtual void Execute() = 0;
 };
 
-class AsyncResultType {
+class AsyncResult {
 public:
-	AsyncResultType() = default;
-	AsyncResultType(AsyncResultType &&) = default;
-	explicit AsyncResultType(SourceResultType t);
-	explicit AsyncResultType(vector<unique_ptr<AsyncTask>> &&task);
-	AsyncResultType &operator=(SourceResultType t);
-	AsyncResultType &operator=(AsyncResultType &&) noexcept;
+	AsyncResult() = default;
+	AsyncResult(AsyncResult &&) = default;
+	explicit AsyncResult(SourceResultType t);
+	explicit AsyncResult(vector<unique_ptr<AsyncTask>> &&task);
+	AsyncResult &operator=(SourceResultType t);
+	AsyncResult &operator=(AsyncResult &&) noexcept;
 	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
 	bool HasTasks() const {
 		D_ASSERT((result_type == TableFunctionResultType::BLOCKED) != async_tasks.empty());

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -36,6 +36,8 @@ public:
 	AsyncResult &operator=(AsyncResultType t);
 	AsyncResult &operator=(AsyncResult &&) noexcept;
 	void ScheduleTasks(InterruptState &interrupt_state, Executor &executor);
+	static AsyncResultType GetAsyncResultType(SourceResultType s);
+
 	bool HasTasks() const {
 		D_ASSERT((result_type == AsyncResultType::BLOCKED) != async_tasks.empty());
 		return !async_tasks.empty();

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -39,7 +39,7 @@ public:
 
 	bool HasTasks() const {
 		D_ASSERT(result_type != AsyncResultType::INVALID);
-		if (async_result.empty()) {
+		if (async_tasks.empty()) {
 			D_ASSERT(result_type != AsyncResultType::BLOCKED);
 			return false;
 		} else {
@@ -49,7 +49,7 @@ public:
 	}
 	AsyncResultType GetResultType() const {
 		D_ASSERT(result_type != AsyncResultType::INVALID);
-		if (async_result.empty()) {
+		if (async_tasks.empty()) {
 			D_ASSERT(result_type != AsyncResultType::BLOCKED);
 		} else {
 			D_ASSERT(result_type == AsyncResultType::BLOCKED);

--- a/src/include/duckdb/parallel/interrupt.hpp
+++ b/src/include/duckdb/parallel/interrupt.hpp
@@ -83,6 +83,11 @@ public:
 		return false;
 	}
 
+	bool CanBlock(const unique_lock<mutex> &guard) const {
+		VerifyLock(guard);
+		return can_block;
+	}
+
 	//! Unblock all tasks (must hold the lock)
 	bool UnblockTasks(const unique_lock<mutex> &guard) {
 		VerifyLock(guard);

--- a/src/include/duckdb/parallel/sleep_async_task.hpp
+++ b/src/include/duckdb/parallel/sleep_async_task.hpp
@@ -9,7 +9,7 @@ namespace duckdb {
 
 class SleepAsyncTask : public AsyncTask {
 public:
-	SleepAsyncTask(idx_t sleep_for) : sleep_for(sleep_for) {
+	explicit SleepAsyncTask(idx_t sleep_for) : sleep_for(sleep_for) {
 	}
 	void Execute() override {
 		std::this_thread::sleep_for(std::chrono::milliseconds(sleep_for));
@@ -19,7 +19,7 @@ public:
 
 class ThrowAsyncTask : public AsyncTask {
 public:
-	ThrowAsyncTask(idx_t sleep_for) : sleep_for(sleep_for) {
+	explicit ThrowAsyncTask(idx_t sleep_for) : sleep_for(sleep_for) {
 	}
 	void Execute() override {
 		std::this_thread::sleep_for(std::chrono::milliseconds(sleep_for));

--- a/src/include/duckdb/parallel/sleep_async_task.hpp
+++ b/src/include/duckdb/parallel/sleep_async_task.hpp
@@ -1,9 +1,17 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parallel/sleep_async_task.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
 #include "duckdb/parallel/async_result.hpp"
 
 #include <chrono>
 #include <thread>
-#include <iostream>
-#pragma once
 
 namespace duckdb {
 

--- a/src/include/duckdb/parallel/sleep_async_task.hpp
+++ b/src/include/duckdb/parallel/sleep_async_task.hpp
@@ -1,0 +1,31 @@
+#include "duckdb/parallel/async_result.hpp"
+
+#include <chrono>
+#include <thread>
+#include <iostream>
+#pragma once
+
+namespace duckdb {
+
+class SleepAsyncTask : public AsyncTask {
+public:
+	SleepAsyncTask(idx_t sleep_for) : sleep_for(sleep_for) {
+	}
+	void Execute() override {
+		std::this_thread::sleep_for(std::chrono::milliseconds(sleep_for));
+	}
+	const idx_t sleep_for;
+};
+
+class ThrowAsyncTask : public AsyncTask {
+public:
+	ThrowAsyncTask(idx_t sleep_for) : sleep_for(sleep_for) {
+	}
+	void Execute() override {
+		std::this_thread::sleep_for(std::chrono::milliseconds(sleep_for));
+		throw NotImplementedException("ThrowAsyncTask: Test error handling when throwing mid-task");
+	}
+	const idx_t sleep_for;
+};
+
+} // namespace duckdb

--- a/src/parallel/CMakeLists.txt
+++ b/src/parallel/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library_unity(
   duckdb_parallel
   OBJECT
+  async_result.cpp
   base_pipeline_event.cpp
   meta_pipeline.cpp
   executor_task.cpp

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -44,7 +44,10 @@ private:
 	shared_ptr<Counter> counter;
 };
 
-AsyncResult::AsyncResult(SourceResultType t) : result_type(GetAsyncResultType(t)) {
+AsyncResult::AsyncResult(SourceResultType t) : AsyncResult(GetAsyncResultType(t)) {
+}
+
+AsyncResult::AsyncResult(AsyncResultType t) : result_type(t) {
 	if (result_type == AsyncResultType::BLOCKED) {
 		throw InternalException("AsyncResult constructed with a BLOCKED state, do provide AsyncTasks");
 	}
@@ -58,6 +61,10 @@ AsyncResult::AsyncResult(vector<unique_ptr<AsyncTask>> &&tasks)
 }
 
 AsyncResult &AsyncResult::operator=(duckdb::SourceResultType t) {
+	return operator=(AsyncResult(t));
+}
+
+AsyncResult &AsyncResult::operator=(duckdb::AsyncResultType t) {
 	return operator=(AsyncResult(t));
 }
 

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -26,34 +26,34 @@ private:
 	InterruptState interrupt_state;
 };
 
-AsyncResultType::AsyncResultType(SourceResultType t) : result_type(GetTableFunctionResultType(t)) {
+AsyncResult::AsyncResult(SourceResultType t) : result_type(GetTableFunctionResultType(t)) {
 	D_ASSERT(t != SourceResultType::BLOCKED);
 }
 
-AsyncResultType::AsyncResultType(vector<unique_ptr<AsyncTask>> &&tasks)
+AsyncResult::AsyncResult(vector<unique_ptr<AsyncTask>> &&tasks)
     : result_type(TableFunctionResultType::BLOCKED), async_tasks(std::move(tasks)) {
 	if (async_tasks.empty()) {
-		throw InternalException("AsyncResultType constructed from empty vector of tasks");
+		throw InternalException("AsyncResult constructed from empty vector of tasks");
 	}
 }
 
-AsyncResultType &AsyncResultType::operator=(duckdb::SourceResultType t) {
-	return operator=(AsyncResultType(t));
+AsyncResult &AsyncResult::operator=(duckdb::SourceResultType t) {
+	return operator=(AsyncResult(t));
 }
 
-AsyncResultType &AsyncResultType::operator=(AsyncResultType &&other) noexcept {
+AsyncResult &AsyncResult::operator=(AsyncResult &&other) noexcept {
 	result_type = other.result_type;
 	async_tasks = std::move(other.async_tasks);
 	return *this;
 }
 
-void AsyncResultType::ScheduleTasks(InterruptState &interrupt_state, Executor &executor) {
+void AsyncResult::ScheduleTasks(InterruptState &interrupt_state, Executor &executor) {
 	D_ASSERT(result_type == TableFunctionResultType::BLOCKED);
 
 	if (async_tasks.size() > 1) {
-		throw InternalException("AsyncResultType with more that 1 task found");
+		throw InternalException("AsyncResult with more that 1 task found");
 	} else if (async_tasks.empty()) {
-		throw InternalException("AsyncResultType with no task found");
+		throw InternalException("AsyncResult with no task found");
 	}
 
 	auto task = make_uniq<AsyncExecutionTask>(executor, std::move(async_tasks[0]), interrupt_state);

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -26,13 +26,17 @@ private:
 	InterruptState interrupt_state;
 };
 
-AsyncResultType::AsyncResultType(SourceResultType t) : mode(t) {
+AsyncResultType::AsyncResultType(SourceResultType t) : result_type(t) {
+	D_ASSERT(result_type != SourceResultType::BLOCKED);
 }
+
 AsyncResultType::AsyncResultType(unique_ptr<AsyncTask> &&task)
-    : mode(SourceResultType::BLOCKED), async_task(std::move(task)) {
+    : result_type(SourceResultType::BLOCKED), async_task(std::move(task)) {
 }
 
 void AsyncResultType::ScheduleTasks(InterruptState &interrupt_state, Executor &executor) {
+	D_ASSERT(result_type == SourceResultType::BLOCKED);
+
 	auto task = make_uniq<AsyncExecutionTask>(executor, std::move(async_task), interrupt_state);
 	//	executor.ScheduleTask(std::move(task));
 	TaskScheduler::GetScheduler(executor.context).ScheduleTask(executor.GetToken(), std::move(task));

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -4,6 +4,10 @@
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/execution/executor.hpp"
 
+#ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
+#include "duckdb/parallel/sleep_async_task.hpp"
+#endif
+
 namespace duckdb {
 
 struct Counter {
@@ -145,5 +149,30 @@ vector<unique_ptr<AsyncTask>> &&AsyncResult::ExtractAsyncTasks() {
 	result_type = AsyncResultType::INVALID;
 	return std::move(async_tasks);
 }
+
+#ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
+vector<unique_ptr<AsyncTask>> AsyncResult::GenerateTestTasks() {
+	vector<unique_ptr<AsyncTask>> tasks;
+	auto random_number = rand() % 16;
+	switch (random_number) {
+	case 0:
+		tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+		tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+		tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+		tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+		tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+		tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+		tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+		tasks.push_back(make_uniq<SleepAsyncTask>(rand() % 32));
+#ifndef AVOID_DUCKDB_DEBUG_ASYNC_THROW
+	case 1:
+		tasks.push_back(make_uniq<ThrowAsyncTask>(rand() % 32));
+#endif
+	default:
+		break;
+	}
+	return tasks;
+}
+#endif
 
 } // namespace duckdb

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -21,6 +21,7 @@ public:
 	}
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
 		async_task->Execute();
+		D_ASSERT(counter->counter.load() > 0);
 		if (--counter->counter == 0) {
 			interrupt_state.Callback();
 		}
@@ -33,7 +34,7 @@ public:
 
 private:
 	unique_ptr<AsyncTask> async_task;
-	InterruptState &interrupt_state;
+	InterruptState interrupt_state;
 	shared_ptr<Counter> counter;
 };
 

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -1,0 +1,41 @@
+#include "duckdb/parallel/executor_task.hpp"
+#include "duckdb/parallel/async_result.hpp"
+#include "duckdb/parallel/interrupt.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
+#include "duckdb/execution/executor.hpp"
+
+namespace duckdb {
+
+class AsyncExecutionTask : public ExecutorTask {
+public:
+	AsyncExecutionTask(Executor &executor, unique_ptr<AsyncTask> &&async_task, InterruptState &interrupt_state)
+	    : ExecutorTask(executor, nullptr), async_task(std::move(async_task)), interrupt_state(interrupt_state) {
+	}
+	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
+		async_task->Execute();
+		interrupt_state.Callback();
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+	string TaskType() const override {
+		return "AsyncTask";
+	}
+
+private:
+	unique_ptr<AsyncTask> async_task;
+	InterruptState interrupt_state;
+};
+
+AsyncResultType::AsyncResultType(SourceResultType t) : mode(t) {
+}
+AsyncResultType::AsyncResultType(unique_ptr<AsyncTask> &&task)
+    : mode(SourceResultType::BLOCKED), async_task(std::move(task)) {
+}
+
+void AsyncResultType::ScheduleTasks(InterruptState &interrupt_state, Executor &executor) {
+	auto task = make_uniq<AsyncExecutionTask>(executor, std::move(async_task), interrupt_state);
+	//	executor.ScheduleTask(std::move(task));
+	TaskScheduler::GetScheduler(executor.context).ScheduleTask(executor.GetToken(), std::move(task));
+}
+
+} // namespace duckdb

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -77,4 +77,16 @@ void AsyncResult::ScheduleTasks(InterruptState &interrupt_state, Executor &execu
 	}
 }
 
+AsyncResultType AsyncResult::GetAsyncResultType(SourceResultType s) {
+	switch (s) {
+	case SourceResultType::HAVE_MORE_OUTPUT:
+		return AsyncResultType::HAVE_MORE_OUTPUT;
+	case SourceResultType::FINISHED:
+		return AsyncResultType::FINISHED;
+	case SourceResultType::BLOCKED:
+		return AsyncResultType::BLOCKED;
+	}
+	throw InternalException("GetAsyncResultType has an unexpected input");
+}
+
 } // namespace duckdb

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -121,4 +121,29 @@ AsyncResultType AsyncResult::GetAsyncResultType(SourceResultType s) {
 	throw InternalException("GetAsyncResultType has an unexpected input");
 }
 
+bool AsyncResult::HasTasks() const {
+	D_ASSERT(result_type != AsyncResultType::INVALID);
+	if (async_tasks.empty()) {
+		D_ASSERT(result_type != AsyncResultType::BLOCKED);
+		return false;
+	} else {
+		D_ASSERT(result_type == AsyncResultType::BLOCKED);
+		return true;
+	}
+}
+AsyncResultType AsyncResult::GetResultType() const {
+	D_ASSERT(result_type != AsyncResultType::INVALID);
+	if (async_tasks.empty()) {
+		D_ASSERT(result_type != AsyncResultType::BLOCKED);
+	} else {
+		D_ASSERT(result_type == AsyncResultType::BLOCKED);
+	}
+	return result_type;
+}
+vector<unique_ptr<AsyncTask>> &&AsyncResult::ExtractAsyncTasks() {
+	D_ASSERT(result_type != AsyncResultType::INVALID);
+	result_type = AsyncResultType::INVALID;
+	return std::move(async_tasks);
+}
+
 } // namespace duckdb

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -21,7 +21,7 @@ public:
 	}
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
 		async_task->Execute();
-		if (counter->counter-- == 0) {
+		if (--counter->counter == 0) {
 			interrupt_state.Callback();
 		}
 		return TaskExecutionResult::TASK_FINISHED;

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -26,12 +26,15 @@ private:
 	InterruptState interrupt_state;
 };
 
-AsyncResult::AsyncResult(SourceResultType t) : result_type(GetTableFunctionResultType(t)) {
-	D_ASSERT(t != SourceResultType::BLOCKED);
+AsyncResult::AsyncResult(AsyncResultType t) : result_type(t) {
+	D_ASSERT(t != AsyncResultType::BLOCKED);
+}
+
+AsyncResult::AsyncResult(SourceResultType t) : AsyncResult(GetAsyncResultType(t)) {
 }
 
 AsyncResult::AsyncResult(vector<unique_ptr<AsyncTask>> &&tasks)
-    : result_type(TableFunctionResultType::BLOCKED), async_tasks(std::move(tasks)) {
+    : result_type(AsyncResultType::BLOCKED), async_tasks(std::move(tasks)) {
 	if (async_tasks.empty()) {
 		throw InternalException("AsyncResult constructed from empty vector of tasks");
 	}
@@ -48,7 +51,7 @@ AsyncResult &AsyncResult::operator=(AsyncResult &&other) noexcept {
 }
 
 void AsyncResult::ScheduleTasks(InterruptState &interrupt_state, Executor &executor) {
-	D_ASSERT(result_type == TableFunctionResultType::BLOCKED);
+	D_ASSERT(result_type == AsyncResultType::BLOCKED);
 
 	if (async_tasks.size() > 1) {
 		throw InternalException("AsyncResult with more that 1 task found");

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -75,10 +75,12 @@ AsyncResult &AsyncResult::operator=(AsyncResult &&other) noexcept {
 }
 
 void AsyncResult::ScheduleTasks(InterruptState &interrupt_state, Executor &executor) {
-	D_ASSERT(result_type == AsyncResultType::BLOCKED);
+	if (result_type != AsyncResultType::BLOCKED) {
+		throw InternalException("AsyncResult::ScheduleTasks called on non BLOCKED AsyncResult");
+	}
 
 	if (async_tasks.empty()) {
-		throw InternalException("AsyncResultType with no task found");
+		throw InternalException("AsyncResult::ScheduleTasks called with no available tasks");
 	}
 
 	shared_ptr<Counter> counter = make_shared_ptr<Counter>(async_tasks.size());
@@ -90,10 +92,12 @@ void AsyncResult::ScheduleTasks(InterruptState &interrupt_state, Executor &execu
 }
 
 void AsyncResult::ExecuteTasksSyncronously() {
-	D_ASSERT(result_type == AsyncResultType::BLOCKED);
+	if (result_type != AsyncResultType::BLOCKED) {
+		throw InternalException("AsyncResult::ExecuteTasksSyncronously called on non BLOCKED AsyncResult");
+	}
 
 	if (async_tasks.empty()) {
-		throw InternalException("AsyncResultType with no task found");
+		throw InternalException("AsyncResult::ExecuteTasksSyncronously called with no available tasks");
 	}
 
 	for (auto &async_task : async_tasks) {

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -38,11 +38,11 @@ private:
 	shared_ptr<Counter> counter;
 };
 
-AsyncResult::AsyncResult(AsyncResultType t) : result_type(t) {
-	D_ASSERT(t != AsyncResultType::BLOCKED);
-}
 
-AsyncResult::AsyncResult(SourceResultType t) : AsyncResult(GetAsyncResultType(t)) {
+AsyncResult::AsyncResult(SourceResultType t) : result_type(GetAsyncResultType(t)) {
+	if (result_type == AsyncResultType::BLOCKED) {
+		throw InternalException("AsyncResult constructed with a BLOCKED state, do provide AsyncTasks");
+	}
 }
 
 AsyncResult::AsyncResult(vector<unique_ptr<AsyncTask>> &&tasks)

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -91,13 +91,13 @@ void AsyncResult::ScheduleTasks(InterruptState &interrupt_state, Executor &execu
 	}
 }
 
-void AsyncResult::ExecuteTasksSyncronously() {
+void AsyncResult::ExecuteTasksSynchronously() {
 	if (result_type != AsyncResultType::BLOCKED) {
-		throw InternalException("AsyncResult::ExecuteTasksSyncronously called on non BLOCKED AsyncResult");
+		throw InternalException("AsyncResult::ExecuteTasksSynchronously called on non BLOCKED AsyncResult");
 	}
 
 	if (async_tasks.empty()) {
-		throw InternalException("AsyncResult::ExecuteTasksSyncronously called with no available tasks");
+		throw InternalException("AsyncResult::ExecuteTasksSynchronously called with no available tasks");
 	}
 
 	for (auto &async_task : async_tasks) {

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -89,6 +89,22 @@ void AsyncResult::ScheduleTasks(InterruptState &interrupt_state, Executor &execu
 	}
 }
 
+void AsyncResult::ExecuteTasksSyncronously() {
+	D_ASSERT(result_type == AsyncResultType::BLOCKED);
+
+	if (async_tasks.empty()) {
+		throw InternalException("AsyncResultType with no task found");
+	}
+
+	for (auto &async_task : async_tasks) {
+		async_task->Execute();
+	}
+
+	async_tasks.clear();
+
+	result_type = AsyncResultType::HAVE_MORE_OUTPUT;
+}
+
 AsyncResultType AsyncResult::GetAsyncResultType(SourceResultType s) {
 	switch (s) {
 	case SourceResultType::HAVE_MORE_OUTPUT:

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -422,7 +422,6 @@ void Executor::InitializeInternal(PhysicalOperator &plan) {
 
 void Executor::CancelTasks() {
 	task.reset();
-
 	{
 		lock_guard<mutex> elock(executor_lock);
 		// mark the query as cancelled so tasks will early-out
@@ -577,6 +576,12 @@ PendingExecutionResult Executor::ExecuteTask(bool dry_run) {
 			} else if (result == TaskExecutionResult::TASK_FINISHED) {
 				// if the task is finished, clean it up
 				task.reset();
+			} else if (result == TaskExecutionResult::TASK_ERROR) {
+				if (!HasError()) {
+					// This is very much unexpected, TASK_ERROR means this executor should have an Error
+					throw InternalException("A task executed within Executor::ExecuteTask, from own producer, returned "
+					                        "TASK_ERROR without setting error on the Executor");
+				}
 			}
 		}
 		if (!HasError()) {

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -54,7 +54,7 @@ static TableFunctionBindType GetTableFunctionBindType(TableFunctionCatalogEntry 
 		}
 		if (function.in_out_function) {
 			has_in_out_function = true;
-		} else if (function.HasSimpleScan() || function.bind_replace || function.bind_operator) {
+		} else if (function.function || function.bind_replace || function.bind_operator) {
 			has_standard_table_function = true;
 		} else {
 			throw InternalException("Function \"%s\" has neither in_out_function nor function defined",

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -54,7 +54,7 @@ static TableFunctionBindType GetTableFunctionBindType(TableFunctionCatalogEntry 
 		}
 		if (function.in_out_function) {
 			has_in_out_function = true;
-		} else if (function.function || function.bind_replace || function.bind_operator) {
+		} else if (function.HasSimpleScan() || function.bind_replace || function.bind_operator) {
 			has_standard_table_function = true;
 		} else {
 			throw InternalException("Function \"%s\" has neither in_out_function nor function defined",

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -301,6 +301,7 @@ vector<string> TestConfiguration::ErrorMessagesToBeSkipped() {
 	} else {
 		res.push_back("HTTP");
 		res.push_back("Unable to connect");
+		res.push_back("ThrowAsyncTask: Test error handling when throwing mid-task");
 	}
 	return res;
 }


### PR DESCRIPTION
Two main changes introduced with this PR:
1. adding a `AsyncResult` class, that can hold the explicit state of a given computation (`HAVE_MORE_OUTPUT`, `FINISHED`, or `BLOCKED` + a list of tasks that once completed should trigger rescheduling)
2. using this class in `MultiFileScan`, and add a demo of returning blocked within read_json (behind ifdef) 

### AsyncResult
This class wraps an enum that can take currently either of this values:
* `IMPLICIT`: actual behavior depends on context, in the context of TableFunction this would be `output_chunk.empty() : FINISHED ? HAVE_MORE_OUTPUT`
* `HAVE_MORE_OUTPUT`: explicit `HAVE_MORE_OUTPUT`
* `FINISHED`: explicit `FINISHED` (possibly paired with non-empty output_chunk)
* `BLOCKED`: operation is blocked
* `INVALID`: signal already consumed `AsyncResult` or not yet properly constructed `AsyncResult`

Iff enum is `BLOCKED` there should be present a non-empty vector of `AsyncTask` that can then be materialized into `ExecutorTask` once the original `Task` has been actually blocked.

### AsyncTask
An abstract class declared as:
```c++
class AsyncTask {
public:
        virtual ~AsyncTask() {};
        virtual void Execute() = 0;
};
```
to be either executed syncronously via `ExecuteTasksSyncronously` or materialized as `ExecutorTask` via `AsyncExecutionTask`.
Note this tasks will be scheduled sharing the same Executor and the same ProducerToken as the current pipeline being executed. This means throws within those task will result in the cancellation of the query. Custom handling for errors (such as allowing retried) needs to be handled in a follow up.

### Opt-in to new `function` behaviour
By default, caller of `function` will get the same result / API.
Caller (such as read_duckdb and the MultiFileScan) CAN opt-in the newer behavior by setting:
```c++
      table_input_data.results_execution_mode = AsyncResultsExecutionMode::TASK_EXECUTOR;
```
default is `AsyncResultsExecutionMode::SYNCRONOUS`, and will require `BLOCKED` is never returned.

### Opt-in in to new explicit behavior, `FINISHED` or `HAVE_MORE_OUTPUT`
Non-blocking explicit behavior can be implemented by setting the relevant field of the 2nd parameter of the `function` callback, the `TableFunctionInput& data`, a simple example would be:
```c++
void SingleChunkResult(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
                // initialize output, say:
                output.SetCardinality(42);
                data.async_result = AsyncResult(AsyncResultType::FINISHED);
}
```
while this currently require first returning 42 rows, then keeping a `finished` state, then actually return 0 rows.

Same can also be done on the other side, where `HAVE_MORE_OUTPUT` can be returned whether 0 or more rows are available.

### Opt-in in to new explicit behavior, `BLOCKED`
This is viable ONLY if `result_execution_mode`, passed in as part of the TableFunctionInput, is set to `AsyncResultsExecutionMode::TASK_EXECUTOR`.
This is demonstrated in the JSON extenions, via two example AsyncTask, one that sleeps for some milliseconds, and one that first sleeps for some time, the  throw an exception, to check both can be handled and demonstrate this working, see for example the code (behind ifdef) at [extension/json/json_multi_file_info.cpp](https://github.com/duckdb/duckdb/compare/main...carlopi:duckdb:async_function_t?expand=1#diff-907dfad5696eacc1daad29d8d92d9afb341d185aa4d69c3e0c5a92cd7a7767ee), that slimmed down looks like:
```c++
AsyncResultType JSONReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
                                 LocalTableFunctionState &local_state, DataChunk &output) {

             if (SomeCondition()) {
                          auto how_long = SomeAmountOfTime();
                          return AsyncResultType(std::move(make_uniq<SleepAsyncTask>(how_long)));
             }
             // actual code
}
```

### Follow-ups
This PR adds infrastructure, and allow following changes, but should NOT change any actual behavior, given there are no connected code changes (basically, `BLOCKED` is only ever returned behind ifdef for testing purposes, and the explicit returns correspond to the older implicit behavior, and this is currently checked in in a check that will be relaxed).

Actually using this and actually adding useful BLOCKING behaviour would be the most direct and useful follow-up.

---

This PR followed a few iterations, ending up in a way cleaner design thanks to feedback from reviewers, thanks!