### PR TITLE
[CI] Correct file path in test case

### DIFF
--- a/test/sql/copy/parquet/parquet_encrypted_tpch_httpfs.test_slow
+++ b/test/sql/copy/parquet/parquet_encrypted_tpch_httpfs.test_slow
@@ -8,8 +8,6 @@ require httpfs
 
 require tpch
 
-require-env DUCKDB_DATA_DIR
-
 statement ok
 CALL dbgen(sf=1)
 
@@ -33,7 +31,7 @@ loop i 1 9
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:${DUCKDB_DATA_DIR}/extension/tpch/dbgen/answers/sf1/q0${i}.csv
+<FILE>:extension/tpch/dbgen/answers/sf1/q0${i}.csv
 
 endloop
 
@@ -42,7 +40,7 @@ loop i 10 23
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:${DUCKDB_DATA_DIR}/extension/tpch/dbgen/answers/sf1/q${i}.csv
+<FILE>:extension/tpch/dbgen/answers/sf1/q${i}.csv
 
 endloop
 
@@ -82,7 +80,7 @@ loop i 1 9
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:${DUCKDB_DATA_DIR}/extension/tpch/dbgen/answers/sf1/q0${i}.csv
+<FILE>:extension/tpch/dbgen/answers/sf1/q0${i}.csv
 
 endloop
 
@@ -91,6 +89,6 @@ loop i 10 23
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:${DUCKDB_DATA_DIR}/extension/tpch/dbgen/answers/sf1/q${i}.csv
+<FILE>:extension/tpch/dbgen/answers/sf1/q${i}.csv
 
 endloop


### PR DESCRIPTION
This is a follow up to https://github.com/duckdb/duckdb/pull/19368

In current configuration of the file path it will fail in CI - PR fixes it.

We also might need bump httpfs again since we'll keep getting previous state of this test case from currently bumped version as [it happens now](https://github.com/duckdb/duckdb/actions/runs/18546600528/job/52866519080#step:6:5028). 