### PR TITLE
Add forwards compatibility tests to CI

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -50,35 +50,6 @@ jobs:
       - name: Preliminary checks on CI 
         run: echo "Event name is ${{ github.event_name }}"
 
- forwards-compatibility:
-    name: Forwards Compatibility Test
-    needs: check-draft
-    runs-on: ubuntu-24.04
-    env:
-      GEN: ninja
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install
-        shell: bash
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
-
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@main
-        with:
-          key: ${{ github.job }}
-          save: ${{ vars.BRANCHES_TO_BE_CACHED == '' || contains(vars.BRANCHES_TO_BE_CACHED, github.ref) }}
-
-      - name: Build
-        shell: bash
-        run: make release
-
-      - name: Run forwards compatibility tests
-        shell: bash
-        run: |
-          python3 scripts/test_storage_compatibility.py --versions "1.2.1|1.3.2" --new-unittest build/release/test/unittest
-
  linux-debug:
     name: Linux Debug
     # This tests release build while enabling slow verifiers (masked by #ifdef DEBUG) and sanitizers
@@ -493,3 +464,9 @@ jobs:
       shell: bash
       run: |
         ./build/release/test/unittest --test-config test/configs/compressed_in_memory.json
+
+    - name: Forwards compatibility tests
+      if: (success() || failure()) && steps.build.conclusion == 'success'
+      shell: bash
+      run: |
+        python3 scripts/test_storage_compatibility.py --versions "1.2.1|1.3.2" --new-unittest build/release/test/unittest

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -49,7 +49,36 @@ jobs:
     steps:
       - name: Preliminary checks on CI 
         run: echo "Event name is ${{ github.event_name }}"
-      
+
+ forwards-compatibility:
+    name: Forwards Compatibility Test
+    needs: check-draft
+    runs-on: ubuntu-24.04
+    env:
+      GEN: ninja
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install
+        shell: bash
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          key: ${{ github.job }}
+          save: ${{ vars.BRANCHES_TO_BE_CACHED == '' || contains(vars.BRANCHES_TO_BE_CACHED, github.ref) }}
+
+      - name: Build
+        shell: bash
+        run: make release
+
+      - name: Run forwards compatibility tests
+        shell: bash
+        run: |
+          python3 scripts/test_storage_compatibility.py --versions "1.1.3|1.2.1|1.3.2" --new-unittest build/release/test/unittest
+
  linux-debug:
     name: Linux Debug
     # This tests release build while enabling slow verifiers (masked by #ifdef DEBUG) and sanitizers

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Run forwards compatibility tests
         shell: bash
         run: |
-          python3 scripts/test_storage_compatibility.py --versions "1.1.3|1.2.1|1.3.2" --new-unittest build/release/test/unittest
+          python3 scripts/test_storage_compatibility.py --versions "1.2.1|1.3.2" --new-unittest build/release/test/unittest
 
  linux-debug:
     name: Linux Debug

--- a/extension/json/include/json_serializer.hpp
+++ b/extension/json/include/json_serializer.hpp
@@ -39,6 +39,18 @@ public:
 		return serializer.GetRootObject();
 	}
 
+	template <class T>
+	static string SerializeToString(T &value) {
+		auto doc = yyjson_mut_doc_new(nullptr);
+		JsonSerializer serializer(doc, false, false, false);
+		value.Serialize(serializer);
+		auto result_obj = serializer.GetRootObject();
+		idx_t len = 0;
+		auto data = yyjson_mut_val_write_opts(result_obj, JSONCommon::WRITE_PRETTY_FLAG, nullptr,
+		                                      reinterpret_cast<size_t *>(&len), nullptr);
+		return string(data, len);
+	}
+
 	yyjson_mut_val *GetRootObject() {
 		D_ASSERT(stack.size() == 1); // or we forgot to pop somewhere
 		return stack.front();

--- a/scripts/test_storage_compatibility.py
+++ b/scripts/test_storage_compatibility.py
@@ -1,0 +1,229 @@
+import argparse
+import os
+import subprocess
+import re
+import csv
+from pathlib import Path
+
+parser = argparse.ArgumentParser(description='Run a full benchmark using the CLI and report the results.')
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--old-cli', action='store', help='Path to the CLI of the old DuckDB version to test')
+group.add_argument('--versions', type=str, action='store', help='DuckDB versions to test')
+parser.add_argument('--new-unittest', action='store', help='Path to the new unittester to run', required=True)
+parser.add_argument('--new-cli', action='store', help='Path to the new unittester to run', default=None)
+parser.add_argument('--compatibility', action='store', help='Storage compatibility version', default='v1.0.0')
+parser.add_argument(
+    '--test-config', action='store', help='Test config script to run', default='test/configs/storage_compatibility.json'
+)
+parser.add_argument('--db-name', action='store', help='Database name to write to', default='bwc_storage_test.db')
+parser.add_argument('--abort-on-failure', action='store_true', help='Abort on first failure', default=False)
+parser.add_argument('--start-offset', type=int, action='store', help='Test start offset', default=None)
+parser.add_argument('--end-offset', type=int, action='store', help='Test end offset', default=None)
+parser.add_argument('--no-summarize-failures', action='store_true', help='Skip failure summary', default=False)
+parser.add_argument('--list-versions', action='store_true', help='Only list versions to test', default=False)
+parser.add_argument(
+    '--run-empty-tests',
+    action='store_true',
+    help='Run tests that don' 't have a CREATE TABLE or CREATE VIEW statement',
+    default=False,
+)
+
+args, extra_args = parser.parse_known_args()
+
+programs_to_test = []
+if args.versions is not None:
+    version_splits = args.versions.split('|')
+    for version in version_splits:
+        cli_path = os.path.join(Path.home(), '.duckdb', 'cli', version, 'duckdb')
+        if not os.path.isfile(cli_path):
+            os.system(f'curl https://install.duckdb.org | DUCKDB_VERSION={version} sh')
+        programs_to_test.append(cli_path)
+else:
+    programs_to_test.append(args.old_cli)
+
+unittest_program = args.new_unittest
+db_name = args.db_name
+new_cli = args.new_unittest.replace('test/unittest', 'duckdb') if args.new_cli is None else args.new_cli
+summarize_failures = not args.no_summarize_failures
+
+# Use the '-l' parameter to output the list of tests to run
+proc = subprocess.run(
+    [unittest_program, '--test-config', args.test_config, '-l'] + extra_args,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+stdout = proc.stdout.decode('utf8').strip()
+stderr = proc.stderr.decode('utf8').strip()
+if len(stderr) > 0:
+    print("Failed to run program " + unittest_program)
+    print("Returncode:", proc.returncode)
+    print(stdout)
+    print(stderr)
+    exit(1)
+
+
+# The output is in the format of 'PATH\tGROUP', we're only interested in the PATH portion
+test_cases = []
+first_line = True
+for line in stdout.splitlines():
+    if first_line:
+        first_line = False
+        continue
+    if len(line.strip()) == 0:
+        continue
+    splits = line.rsplit('\t', 1)
+    test_cases.append(splits[0])
+
+test_cases.sort()
+if args.compatibility != 'v1.0.0':
+    raise Exception("Only v1.0.0 is supported for now (FIXME)")
+
+
+def escape_cmd_arg(arg):
+    if '"' in arg or '\'' in arg or ' ' in arg or '\\' in arg:
+        arg = arg.replace('\\', '\\\\')
+        arg = arg.replace('"', '\\"')
+        arg = arg.replace("'", "\\'")
+        return f'"{arg}"'
+    return arg
+
+
+error_container = []
+
+
+def handle_failure(test, cmd, msg, stdout, stderr, returncode):
+    print(f"==============FAILURE============")
+    print(test)
+    print(f"==============MESSAGE============")
+    print(msg)
+    print(f"==============COMMAND============")
+    cmd_str = ''
+    for entry in cmd:
+        cmd_str += escape_cmd_arg(entry) + ' '
+    print(cmd_str.strip())
+    print(f"==============RETURNCODE=========")
+    print(str(returncode))
+    print(f"==============STDOUT=============")
+    print(stdout)
+    print(f"==============STDERR=============")
+    print(stderr)
+    print(f"=================================")
+    if args.abort_on_failure:
+        exit(1)
+    else:
+        error_container.append({'test': test, 'stderr': stderr})
+
+
+def run_program(cmd, description):
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout = proc.stdout.decode('utf8').strip()
+    stderr = proc.stderr.decode('utf8').strip()
+    if proc.returncode != 0:
+        return {
+            'test': test,
+            'cmd': cmd,
+            'msg': f'Failed to {description}',
+            'stdout': stdout,
+            'stderr': stderr,
+            'returncode': proc.returncode,
+        }
+    return None
+
+
+def try_run_program(cmd, description):
+    result = run_program(cmd, description)
+    if result is None:
+        return True
+    handle_failure(**result)
+    return False
+
+
+index = 0
+start = 0 if args.start_offset is None else args.start_offset
+end = len(test_cases) if args.end_offset is None else args.end_offset
+for i in range(start, end):
+    test = test_cases[i]
+    skipped = ''
+    if not args.run_empty_tests:
+        with open(test, 'r') as f:
+            test_contents = f.read().lower()
+        if 'create table' not in test_contents and 'create view' not in test_contents:
+            skipped = ' (SKIPPED)'
+
+    print(f'[{i}/{len(test_cases)}]: {test}{skipped}')
+    if skipped != '':
+        continue
+    # remove the old db
+    try:
+        os.remove(db_name)
+    except:
+        pass
+    cmd = [unittest_program, '--test-config', args.test_config, test]
+    if not try_run_program(cmd, 'Run Test'):
+        continue
+
+    if not os.path.isfile(db_name):
+        # db not created
+        continue
+
+    cmd = [
+        programs_to_test[-1],
+        db_name,
+        '-c',
+        '.headers off',
+        '-csv',
+        '-c',
+        '.output table_list.csv',
+        '-c',
+        'SHOW ALL TABLES',
+    ]
+    if not try_run_program(cmd, 'List Tables'):
+        continue
+
+    tables = []
+    with open('table_list.csv', newline='') as f:
+        reader = csv.reader(f)
+        for row in reader:
+            tables.append((row[1], row[2]))
+    # no tables / views
+    if len(tables) == 0:
+        continue
+
+    # read all tables / views
+    failures = []
+    for cli in programs_to_test:
+        cmd = [cli, db_name]
+        for table in tables:
+            schema_name = table[0].replace('"', '""')
+            table_name = table[1].replace('"', '""')
+            cmd += ['-c', f'FROM "{schema_name}"."{table_name}"']
+        failure = run_program(cmd, 'Query Tables')
+        if failure is not None:
+            failures.append(failure)
+    if len(failures) > 0:
+        # we failed to query the tables
+        # this MIGHT be expected - e.g. we might have views that reference stale state (e.g. files that are deleted)
+        # try to run it with the new CLI - if this succeeds we have a problem
+        new_cmd = [new_cli] + cmd[1:]
+        new_failure = run_program(new_cmd, 'Query Tables (New)')
+        if new_failure is None:
+            # we succeeded with the new CLI - report the failure
+            for failure in failures:
+                handle_failure(**failure)
+        continue
+
+if len(error_container) == 0:
+    exit(0)
+
+if summarize_failures:
+    print(
+        '''\n\n====================================================
+================  FAILURES SUMMARY  ================
+====================================================\n
+'''
+    )
+    for i, error in enumerate(error_container, start=1):
+        print(f"\n{i}:", error["test"], "\n")
+        print(error["stderr"])
+
+exit(1)

--- a/test/configs/storage_compatibility.json
+++ b/test/configs/storage_compatibility.json
@@ -1,0 +1,54 @@
+{
+  "description": "Storage compatibility test.",
+  "initial_db": "bwc_storage_test.db",
+  "settings": [
+    {"name": "storage_compatibility_version", "value": "v1.0.0"}
+  ],
+  "skip_compiled": "true",
+  "skip_tests": [
+    {
+      "reason": "Contains explicit use of the memory catalog.",
+      "paths": [
+        "test/sql/show_select/test_describe_all.test",
+        "test/sql/catalog/function/attached_macro.test",
+        "test/sql/catalog/test_temporary.test",
+        "test/sql/pragma/test_show_tables_temp_views.test",
+        "test/sql/pg_catalog/system_functions.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/attach/attach_table_info.test",
+        "test/sql/attach/attach_defaults.test",
+        "test/sql/attach/attach_did_you_mean.test",
+        "test/sql/attach/attach_default_table.test",
+        "test/sql/attach/attach_show_all_tables.test",
+        "test/sql/attach/attach_issue7711.test",
+        "test/sql/attach/attach_issue_7660.test",
+        "test/sql/attach/show_databases.test",
+        "test/sql/attach/attach_views.test",
+        "test/sql/copy_database/copy_table_with_sequence.test"
+      ]
+    },
+    {
+      "reason": "Stringification too slow",
+      "paths": [
+        "test/sql/types/bignum/test_bignum_sum.test"
+      ]
+    },
+    {
+      "reason": "Time (NS) not supported (new type).",
+      "paths": [
+        "test/parquet/timens_parquet.test",
+        "test/sql/types/time/test_time_ns.test"
+      ]
+    },
+    {
+      "reason": "Expected forwards compatibility failure.",
+      "paths": [
+        "test/fuzzer/pedro/view_not_rebound_error_no_view_dependencies.test",
+        "test/issues/rigger/assertion_scale.test",
+        "test/issues/general/test_16662.test",
+        "test/sql/copy/csv/test_null_padding_projection.test"
+
+      ]
+    }
+  ]
+}

--- a/test/sql/index/art/issues/test_art_fuzzer_persisted.test
+++ b/test/sql/index/art/issues/test_art_fuzzer_persisted.test
@@ -14,7 +14,7 @@ statement ok
 CREATE INDEX i1 ON t1 (c1);
 
 statement ok
-PRAGMA MEMORY_LIMIT='2MB';
+PRAGMA MEMORY_LIMIT='4MB';
 
 statement ok
 CHECKPOINT;


### PR DESCRIPTION
Includes https://github.com/duckdb/duckdb/pull/19420

This PR adds forwards compatibility testing to the CI. Example usage of the script:

```
python3 scripts/test_storage_compatibility.py --versions "1.2.1|1.3.2" --new-unittest build/release/test/unittest
```

The script works by running the unittester (compiled with the latest version) with the config `test/configs/storage_compatibility.json` for each test with a `CREATE TABLE` or `CREATE VIEW` statement. The provided config then runs the test in `--force-storage` mode, but with a fixed database path (`bwc_storage_test.db`). This then gives us a database file that has a number of tables / views in it as created in the test.

For each version specified, we then try to read all tables and views stored within that file. If any of the queries fail, we report an error **if** the original CLI can successfully query the table / view. The reason we also do this is that there might be invalid views in the file, e.g. views that refer to files that have since been deleted.

In order to get the older versions, our install script is used (i.e. we run `f'curl https://install.duckdb.org | DUCKDB_VERSION=1.3.2 sh` for each included version).