### PR TITLE
Internal #6270: Fix small binary fallback values for arg_min/max_nulls_last

### DIFF
--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -889,14 +889,14 @@ void AddArgMinMaxNFunction(AggregateFunctionSet &set) {
 AggregateFunctionSet ArgMinFun::GetFunctions() {
 	AggregateFunctionSet fun;
 	AddArgMinMaxFunctions<LessThan, OrderType::ASCENDING>(fun, ArgMinMaxNullHandling::IGNORE_ANY_NULL);
-	AddArgMinMaxNFunction<ArgMinMaxNullHandling::IGNORE_ANY_NULL, false, LessThan>(fun);
+	AddArgMinMaxNFunction<ArgMinMaxNullHandling::IGNORE_ANY_NULL, true, LessThan>(fun);
 	return fun;
 }
 
 AggregateFunctionSet ArgMaxFun::GetFunctions() {
 	AggregateFunctionSet fun;
 	AddArgMinMaxFunctions<GreaterThan, OrderType::DESCENDING>(fun, ArgMinMaxNullHandling::IGNORE_ANY_NULL);
-	AddArgMinMaxNFunction<ArgMinMaxNullHandling::IGNORE_ANY_NULL, true, GreaterThan>(fun);
+	AddArgMinMaxNFunction<ArgMinMaxNullHandling::IGNORE_ANY_NULL, false, GreaterThan>(fun);
 	return fun;
 }
 
@@ -915,14 +915,14 @@ AggregateFunctionSet ArgMaxNullFun::GetFunctions() {
 AggregateFunctionSet ArgMinNullsLastFun::GetFunctions() {
 	AggregateFunctionSet fun;
 	AddArgMinMaxFunctions<LessThan, OrderType::ASCENDING>(fun, ArgMinMaxNullHandling::HANDLE_ANY_NULL);
-	AddArgMinMaxNFunction<ArgMinMaxNullHandling::HANDLE_ANY_NULL, false, LessThan>(fun);
+	AddArgMinMaxNFunction<ArgMinMaxNullHandling::HANDLE_ANY_NULL, true, LessThan>(fun);
 	return fun;
 }
 
 AggregateFunctionSet ArgMaxNullsLastFun::GetFunctions() {
 	AggregateFunctionSet fun;
 	AddArgMinMaxFunctions<GreaterThan, OrderType::DESCENDING>(fun, ArgMinMaxNullHandling::HANDLE_ANY_NULL);
-	AddArgMinMaxNFunction<ArgMinMaxNullHandling::HANDLE_ANY_NULL, true, GreaterThan>(fun);
+	AddArgMinMaxNFunction<ArgMinMaxNullHandling::HANDLE_ANY_NULL, false, GreaterThan>(fun);
 	return fun;
 }
 

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -362,7 +362,7 @@ struct ValueOrNull {
 			return false;
 		}
 
-		return is_valid ^ !NULLS_LAST;
+		return is_valid ^ NULLS_LAST;
 	}
 };
 

--- a/test/sql/aggregate/aggregates/arg_min_max_nulls_last_all_types.test_slow
+++ b/test/sql/aggregate/aggregates/arg_min_max_nulls_last_all_types.test_slow
@@ -22,11 +22,11 @@ CREATE OR REPLACE TABLE arg_min_result AS SELECT unnest(arg_min_nulls_last("${co
 statement ok
 CREATE OR REPLACE TABLE arg_max_result AS SELECT unnest(arg_max_nulls_last("${col}", "${col}", 3)) FROM all_types
 
-query I
-SELECT * FROM (SELECT * FROM asc_ordered ORDER BY rowid) EXCEPT SELECT * FROM (SELECT * FROM arg_min_result ORDER BY rowid);
+query II
+SELECT * FROM (SELECT rowid, * FROM asc_ordered ORDER BY rowid) EXCEPT SELECT * FROM (SELECT rowid, * FROM arg_min_result ORDER BY rowid);
 
-query I
-SELECT * FROM (SELECT * FROM desc_ordered ORDER BY rowid) EXCEPT SELECT * FROM (SELECT * FROM arg_max_result ORDER BY rowid);
+query II
+SELECT * FROM (SELECT rowid, * FROM desc_ordered ORDER BY rowid) EXCEPT SELECT * FROM (SELECT rowid, * FROM arg_max_result ORDER BY rowid);
 
 statement ok
 CREATE OR REPLACE TABLE arg_min_result AS SELECT arg_min_nulls_last("${col}", "${col}") FROM all_types
@@ -34,10 +34,10 @@ CREATE OR REPLACE TABLE arg_min_result AS SELECT arg_min_nulls_last("${col}", "$
 statement ok
 CREATE OR REPLACE TABLE arg_max_result AS SELECT arg_max_nulls_last("${col}", "${col}") FROM all_types
 
-query I
-SELECT * FROM (SELECT * FROM asc_ordered ORDER BY rowid LIMIT 1) EXCEPT SELECT * FROM (SELECT * FROM arg_min_result ORDER BY rowid);
+query II
+SELECT * FROM (SELECT rowid, * FROM asc_ordered ORDER BY rowid LIMIT 1) EXCEPT SELECT * FROM (SELECT rowid, * FROM arg_min_result ORDER BY rowid);
 
-query I
-SELECT * FROM (SELECT * FROM desc_ordered ORDER BY rowid LIMIT 1) EXCEPT SELECT * FROM (SELECT * FROM arg_max_result ORDER BY rowid);
+query II
+SELECT * FROM (SELECT rowid, * FROM desc_ordered ORDER BY rowid LIMIT 1) EXCEPT SELECT * FROM (SELECT rowid, * FROM arg_max_result ORDER BY rowid);
 
 endloop


### PR DESCRIPTION
I also realized that the slow_test was not able to catch this, even though it should have.

fixes: duckdblabs/duckdb-internal/issues/6270