### PR TITLE
[Profiling] Enable ATTACH / CHECKPOINT / WAL replay metrics by default

### DIFF
--- a/scripts/generate_metric_enums.py
+++ b/scripts/generate_metric_enums.py
@@ -59,13 +59,6 @@ query_global_metrics = [
     "WAITING_TO_ATTACH_LATENCY",
 ]
 
-excluded_query_global_metrics = [
-    "ATTACH_LOAD_STORAGE_LATENCY",
-    "ATTACH_REPLAY_WAL_LATENCY",
-    "CHECKPOINT_LATENCY",
-    "WAITING_TO_ATTACH_LATENCY",
-]
-
 optimizer_types = []
 
 # Regular expression to match the enum values
@@ -397,13 +390,7 @@ for test_file, name, description in zip(test_files, test_names, test_description
         metrics.sort()
 
         for metric in metrics:
-            skip = False
-            for excluded_metric in excluded_query_global_metrics:
-                if metric == excluded_metric:
-                    skip = True
-                    break
-            if not skip:
-                f.write(f'"{metric}": "true"\n')
+            f.write(f'"{metric}": "true"\n')
         f.write("\n")
 
         write_statement(

--- a/src/main/profiling_info.cpp
+++ b/src/main/profiling_info.cpp
@@ -37,7 +37,10 @@ ProfilingInfo::ProfilingInfo(const profiler_settings_t &n_settings, const idx_t 
 }
 
 profiler_settings_t ProfilingInfo::DefaultSettings() {
-	return {MetricsType::BLOCKED_THREAD_TIME,
+	return {MetricsType::ATTACH_LOAD_STORAGE_LATENCY,
+	        MetricsType::ATTACH_REPLAY_WAL_LATENCY,
+	        MetricsType::BLOCKED_THREAD_TIME,
+	        MetricsType::CHECKPOINT_LATENCY,
 	        MetricsType::CPU_TIME,
 	        MetricsType::CUMULATIVE_CARDINALITY,
 	        MetricsType::CUMULATIVE_ROWS_SCANNED,
@@ -54,6 +57,7 @@ profiler_settings_t ProfilingInfo::DefaultSettings() {
 	        MetricsType::SYSTEM_PEAK_TEMP_DIR_SIZE,
 	        MetricsType::TOTAL_BYTES_READ,
 	        MetricsType::TOTAL_BYTES_WRITTEN,
+	        MetricsType::WAITING_TO_ATTACH_LATENCY,
 	        MetricsType::QUERY_NAME};
 }
 

--- a/test/sql/pragma/profiling/test_custom_profiling_optimizer.test
+++ b/test/sql/pragma/profiling/test_custom_profiling_optimizer.test
@@ -169,7 +169,10 @@ SELECT unnest(res) FROM (
     string_split(setting, ', ') AS res
 ) ORDER BY ALL;
 ----
+"ATTACH_LOAD_STORAGE_LATENCY": "true"
+"ATTACH_REPLAY_WAL_LATENCY": "true"
 "BLOCKED_THREAD_TIME": "true"
+"CHECKPOINT_LATENCY": "true"
 "CPU_TIME": "true"
 "CUMULATIVE_CARDINALITY": "true"
 "CUMULATIVE_ROWS_SCANNED": "true"
@@ -187,6 +190,7 @@ SELECT unnest(res) FROM (
 "SYSTEM_PEAK_TEMP_DIR_SIZE": "true"
 "TOTAL_BYTES_READ": "true"
 "TOTAL_BYTES_WRITTEN": "true"
+"WAITING_TO_ATTACH_LATENCY": "true"
 
 statement ok
 CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '__TEST_DIR__/profiling_output.json';

--- a/test/sql/pragma/profiling/test_default_profiling_settings.test
+++ b/test/sql/pragma/profiling/test_default_profiling_settings.test
@@ -29,7 +29,10 @@ SELECT unnest(res) FROM (
     string_split(setting, ', ') AS res
 ) ORDER BY ALL;
 ----
+"ATTACH_LOAD_STORAGE_LATENCY": "true"
+"ATTACH_REPLAY_WAL_LATENCY": "true"
 "BLOCKED_THREAD_TIME": "true"
+"CHECKPOINT_LATENCY": "true"
 "CPU_TIME": "true"
 "CUMULATIVE_CARDINALITY": "true"
 "CUMULATIVE_ROWS_SCANNED": "true"
@@ -47,6 +50,7 @@ SELECT unnest(res) FROM (
 "SYSTEM_PEAK_TEMP_DIR_SIZE": "true"
 "TOTAL_BYTES_READ": "true"
 "TOTAL_BYTES_WRITTEN": "true"
+"WAITING_TO_ATTACH_LATENCY": "true"
 
 statement ok
 CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '__TEST_DIR__/profiling_output.json';


### PR DESCRIPTION
The following are now enabled by default
- `MetricsType::WAITING_TO_ATTACH_LATENCY`
- `MetricsType::ATTACH_LOAD_STORAGE_LATENCY`
- `MetricsType::ATTACH_REPLAY_WAL_LATENCY`
- `MetricsType::CHECKPOINT_LATENCY`

Follow up to:
- #19367