### PR TITLE
[TPCH] fix `load.sql` to produce valid test data

### DIFF
--- a/benchmark/large/tpch-sf100/load.sql
+++ b/benchmark/large/tpch-sf100/load.sql
@@ -1,3 +1,4 @@
+CALL dbgen(sf=100, children=10, step=0);
 CALL dbgen(sf=100, children=10, step=1);
 CALL dbgen(sf=100, children=10, step=2);
 CALL dbgen(sf=100, children=10, step=3);
@@ -7,4 +8,3 @@ CALL dbgen(sf=100, children=10, step=6);
 CALL dbgen(sf=100, children=10, step=7);
 CALL dbgen(sf=100, children=10, step=8);
 CALL dbgen(sf=100, children=10, step=9);
-CALL dbgen(sf=100, children=10, step=10);


### PR DESCRIPTION
Test data for `TPCH sf100`, when it is not downloaded from elsewhere, uses `load.sql` to generate data in steps.
There was a minor issue that lead to generating wrong test data. This PR fixes `load.sql` according to the [documentation](https://duckdb.org/docs/stable/core_extensions/tpch#resource-usage-of-the-data-generator)