### PR TITLE
Fix bug initializing std::vector for column names in ADBC API

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -537,7 +537,8 @@ static int get_schema(struct ArrowArrayStream *stream, struct ArrowSchema *out) 
 	auto count = duckdb_column_count(&result_wrapper->result);
 	std::vector<duckdb_logical_type> types(count);
 
-	std::vector<std::string> owned_names(count);
+	std::vector<std::string> owned_names;
+	owned_names.reserve(count);
 	duckdb::vector<const char *> names(count);
 	for (idx_t i = 0; i < count; i++) {
 		types[i] = duckdb_column_logical_type(&result_wrapper->result, i);
@@ -793,7 +794,8 @@ AdbcStatusCode StatementGetParameterSchema(struct AdbcStatement *statement, stru
 		count = 1;
 	}
 	std::vector<duckdb_logical_type> types(count);
-	std::vector<std::string> owned_names(count);
+	std::vector<std::string> owned_names;
+	owned_names.reserve(count);
 	duckdb::vector<const char *> names(count);
 
 	for (idx_t i = 0; i < count; i++) {


### PR DESCRIPTION
Passing a size to the constructor of `std::vector` initializes not the capacity but the size. When elements are subsequently pushed or placed onto the back of the vector, the vector will grow. If the growth goes past the capacity, a vector of strings will be reallocated in a way that may invalidate pointers previously gotten from those strings.

Resolves #19443.

There may be a cleaner way to express the intent here. I went with a minimal change. I didn't add a test case because there was an existing test case that was already failing on Windows.