### PR TITLE
feat: add --sql option to `.open` in the cli client

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -281,6 +281,7 @@ public:
 
 	int RenderRow(RowRenderer &renderer, RowResult &result);
 
+	string EvaluateSQL(const string &sql);
 	SuccessState ExecuteSQL(const string &zSql);
 	void RunSchemaDumpQuery(const string &zQuery);
 	void RunTableDumpQuery(const string &zSelect);

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -646,7 +646,7 @@ static const MetadataCommand metadata_commands[] = {
 
     {"open", 0, OpenDatabase, "?OPTIONS? ?FILE?", "Close existing database and reopen FILE", 2,
      "Options:\n\t--new\tInitialize FILE to an empty database\n\t--nofollow\tDo not follow symbolic "
-     "links\n\t--readonly\tOpen FILE in read-only mode"},
+     "links\n\t--readonly\tOpen FILE in read-only mode\n\t--sql\tSet FILE using SQL"},
     {"once", 0, SetOutputOnce, "?FILE?", "Output for the next SQL command only to FILE", 0,
      "If FILE begins with '|' then open as a pipe\n\t--bom\tPut a UTF8 byte-order mark at the beginning\n\t-e\tSend "
      "output to the system text editor\n\t-x\tSend output as CSV to a spreadsheet (same as \".excel\")"},

--- a/tools/shell/shell_prompt.cpp
+++ b/tools/shell/shell_prompt.cpp
@@ -182,26 +182,6 @@ void Prompt::ParsePrompt(const string &prompt) {
 	}
 }
 
-string Prompt::EvaluateSQL(ShellState &state, const string &sql) {
-	state.OpenDB();
-	auto &con = *state.conn;
-	auto result = con.Query(sql);
-	if (result->HasError()) {
-		return "#ERROR#:" + result->GetError();
-	}
-	auto &collection = result->Collection();
-	if (collection.Count() > 1) {
-		return "#TOO MANY ROWS#";
-	}
-	if (collection.ColumnCount() != 1) {
-		return "#TOO MANY COLUMNS#";
-	}
-	for (auto &row : collection.Rows()) {
-		return row.GetValue(0).ToString();
-	}
-	return "#EMPTY#";
-}
-
 string Prompt::HandleSetting(ShellState &state, const PromptComponent &component) {
 	if (!state.conn) {
 		return component.literal == "current_schema" ? "main" : "memory";
@@ -278,7 +258,7 @@ string Prompt::GeneratePrompt(ShellState &state) {
 			prompt += HandleText(state, component.literal, length);
 			break;
 		case PromptComponentType::SQL: {
-			auto query_result = EvaluateSQL(state, component.literal);
+			auto query_result = state.EvaluateSQL(component.literal);
 			prompt += HandleText(state, query_result, length);
 			break;
 		}
@@ -311,7 +291,7 @@ void Prompt::PrintPrompt(ShellState &state, PrintOutput output) {
 			highlight.PrintText(HandleText(state, component.literal, length), output, color, intensity);
 			break;
 		case PromptComponentType::SQL: {
-			auto result = EvaluateSQL(state, component.literal);
+			auto result = state.EvaluateSQL(component.literal);
 			highlight.PrintText(HandleText(state, result, length), output, color, intensity);
 			break;
 		}

--- a/tools/shell/tests/conftest.py
+++ b/tools/shell/tests/conftest.py
@@ -1,13 +1,16 @@
-import pytest
 import os
 import subprocess
-import sys
-from typing import List, NamedTuple, Union
+from typing import List, Union
+
+import pytest
 
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--shell-binary", action="store", default=None, help="Provide the shell binary to use for the tests"
+        "--shell-binary",
+        action="store",
+        default=None,
+        help="Provide the shell binary to use for the tests",
     )
     parser.addoption("--start-offset", action="store", type=int, help="Skip the first 'n' tests")
 
@@ -30,20 +33,26 @@ class TestResult:
         self.stderr: Union[str, bytes] = stderr
         self.status_code: int = status_code
 
-    def check_stdout(self, expected: Union[str, List[str], bytes]):
+    def check_stdout(self, expected: Union[str, List[str], bytes, None]):
+        if expected is None:
+            assert self.stdout == ""
+            return
         if isinstance(expected, list):
-            expected = '\n'.join(expected)
+            expected = "\n".join(expected)
         assert self.status_code == 0
-        assert expected in self.stdout
+        assert is_needle_in_haystack(expected, self.stdout)
 
     def check_not_exist(self, not_exist: Union[str, List[str], bytes]):
         if isinstance(not_exist, list):
-            not_exist = '\n'.join(not_exist)
+            not_exist = "\n".join(not_exist)
         assert self.status_code == 0
-        assert not_exist not in self.stdout
+        assert not is_needle_in_haystack(not_exist, self.stdout)
 
-    def check_stderr(self, expected: str):
-        assert expected in self.stderr
+    def check_stderr(self, expected: str | None):
+        if expected is None:
+            assert self.stderr == ""
+        else:
+            assert is_needle_in_haystack(expected, self.stderr)
 
 
 class ShellTest:
@@ -51,7 +60,7 @@ class ShellTest:
         if not shell:
             raise ValueError("Please provide a shell binary")
         self.shell = shell
-        self.arguments = [shell, '--batch', '--init', '/dev/null'] + arguments
+        self.arguments = [shell, "--batch", "--init", "/dev/null"] + arguments
         self.statements: List[str] = []
         self.input = None
         self.output = None
@@ -63,6 +72,10 @@ class ShellTest:
 
     def statement(self, stmt):
         self.statements.append(stmt)
+        return self
+
+    def env_var(self, key: str, value: str):
+        self.environment[key] = value
         return self
 
     def query(self, *stmts):
@@ -87,46 +100,56 @@ class ShellTest:
 
     def get_input_data(self, cmd: str):
         if self.input:
-            input_data = open(self.input, 'rb').read()
+            with open(self.input, "rb") as f:
+                input_data = f.read()
         else:
-            input_data = bytearray(cmd, 'utf8')
+            input_data = bytearray(cmd, "utf8")
         return input_data
 
-    def get_output_pipe(self):
-        output_pipe = subprocess.PIPE
-        if self.output:
-            output_pipe = open(self.output, 'w+')
-        return output_pipe
-
     def get_statements(self):
-        result = ""
         statements = []
         for statement in self.statements:
-            if statement.startswith('.'):
+            if statement.startswith("."):
                 statements.append(statement)
             else:
-                statements.append(statement + ';')
-        return '\n'.join(statements)
+                statements.append(statement + ";")
+        return "\n".join(statements)
 
     def get_output_data(self, res):
         if self.output:
-            stdout = open(self.output, 'r').read()
+            with open(self.output, "r") as f:
+                stdout = f.read()
         else:
-            stdout = res.stdout.decode('utf8').strip()
-        stderr = res.stderr.decode('utf8').strip()
+            stdout = res.stdout.decode("utf8").strip()
+        stderr = res.stderr.decode("utf8").strip()
         return stdout, stderr
 
     def run(self):
         statements = self.get_statements()
         command = self.get_command(statements)
         input_data = self.get_input_data(statements)
-        output_pipe = self.get_output_pipe()
 
         my_env = os.environ.copy()
         for key, val in self.environment.items():
             my_env[key] = val
 
-        res = subprocess.run(command, input=input_data, stdout=output_pipe, stderr=subprocess.PIPE, env=my_env)
+        if self.output:
+            with open(self.output, "w") as output_pipe:
+                res = subprocess.run(
+                    command,
+                    input=input_data,
+                    stdout=output_pipe,
+                    stderr=subprocess.PIPE,
+                    env=my_env,
+                )
+        else:
+            res = subprocess.run(
+                command,
+                input=input_data,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=my_env,
+            )
 
         stdout, stderr = self.get_output_data(res)
         return TestResult(stdout, stderr, res.returncode)
@@ -141,7 +164,7 @@ def shell(request):
 
 
 @pytest.fixture()
-def random_filepath(request, tmp_path):
+def random_filepath(tmp_path):
     tmp_file = tmp_path / "random_import_file"
     return tmp_file
 
@@ -150,7 +173,7 @@ def random_filepath(request, tmp_path):
 def generated_file(request, random_filepath):
     param = request.param
     tmp_file = random_filepath
-    with open(tmp_file, 'w+') as f:
+    with open(tmp_file, "w+") as f:
         f.write(param)
     return tmp_file
 
@@ -162,19 +185,30 @@ def check_load_status(shell, extension: str):
     return result.stdout
 
 
+def is_needle_in_haystack(needle: str | bytes, haystack: str | bytes) -> bool:
+    if needle == "" or haystack == "":
+        return False
+    if isinstance(haystack, str) and isinstance(needle, str):
+        return needle in haystack
+    elif isinstance(haystack, bytes) and isinstance(needle, bytes):
+        return needle in haystack
+    else:
+        return False
+
+
 def assert_loaded(shell, extension: str):
     # TODO: add a command line argument to fail instead of skip if the extension is not loaded
     out = check_load_status(shell, extension)
-    if 'true' not in out:
+    if not is_needle_in_haystack("true", out):
         pytest.skip(reason=f"'{extension}' extension is not loaded!")
     return
 
 
 @pytest.fixture()
 def autocomplete_extension(shell):
-    assert_loaded(shell, 'autocomplete')
+    assert_loaded(shell, "autocomplete")
 
 
 @pytest.fixture()
 def json_extension(shell):
-    assert_loaded(shell, 'json')
+    assert_loaded(shell, "json")

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -1,12 +1,10 @@
 # fmt: off
 
-import pytest
-import subprocess
-import sys
-from typing import List
-from conftest import ShellTest
 import os
-from pathlib import Path
+import re
+
+import pytest
+from conftest import ShellTest
 
 
 def test_basic(shell):
@@ -117,31 +115,57 @@ world" """)
     result = test.run()
     result.check_stdout("hello\\nworld")
 
-# FIXME: this test was underspecified, no expected result was provided
-def test_bailing_mechanism(shell):
+def test_bail_on_stops_after_error(shell):
     test = (
         ShellTest(shell)
         .statement(".bail on")
-        .statement(".bail off")
-        .statement(".binary on")
-        .statement("SELECT 42")
-        .statement(".binary off")
-        .statement("SELECT 42")
+        .statement("invalid sql;")
+        .statement("select 'should not reach here'")
     )
 
     result = test.run()
-    result.check_stdout("42")
+    assert result.status_code == 1
+    assert result.stdout == ""
 
-# FIXME: no verification at all?
-def test_cd(shell, tmp_path):
-    current_dir = Path(os.getcwd())
 
+def test_bail_off_continues_after_error(shell):
     test = (
         ShellTest(shell)
-        .statement(f".cd {tmp_path.as_posix()}")
-        .statement(f".cd {current_dir.as_posix()}")
+        .statement(".bail off")
+        .statement("invalid sql;")
+        .statement("select 'reached here'")
+    )
+
+    result = test.run()
+    result.check_stderr("Parser Error: syntax error at or near \"invalid\"")
+    assert "reached here" in str(result.stdout)
+
+@pytest.mark.skipif(os.name == 'nt', reason="Skipped on windows")
+def test_shell_command(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".shell echo quack")
     )
     result = test.run()
+    result.check_stdout("quack")
+
+def test_cd(shell, tmp_path):
+    pwd_dir = os.getcwd()
+
+    pwd_test = (
+        ShellTest(shell)
+        .statement(".shell pwd")
+    )
+    pwd_result = pwd_test.run()
+    pwd_result.check_stdout('duckdb')
+
+    random_dir_test = (
+        ShellTest(shell)
+        .statement(f".cd {tmp_path.as_posix()}")
+    )
+    random_dir_result = random_dir_test.run()
+    random_dir_result.check_not_exist(pwd_dir)
+    random_dir_result.check_stderr(None)
 
 def test_changes_on(shell):
     test = (
@@ -165,7 +189,8 @@ def test_changes_off(shell):
         .statement("DROP TABLE a;")
     )
     result = test.run()
-    result.check_stdout("")
+    result.check_not_exist("changes:")
+    result.check_stdout(None)
 
 def test_echo(shell):
     test = (
@@ -176,13 +201,22 @@ def test_echo(shell):
     result = test.run()
     result.check_stdout("SELECT 42")
 
+def test_invalid_sql(shell):
+    test = ShellTest(shell).statement("invalid command;")
+    result = test.run()
+    assert result.status_code == 1
+    result.check_stderr("Parser Error: syntax error at or near \"invalid\"")
+
 @pytest.mark.parametrize("alias", ["exit", "quit"])
 def test_exit(shell, alias):
-    test = ShellTest(shell).statement(f".{alias}")
+    test = ShellTest(shell).statement(f".{alias}").statement("invalid command;")
     result = test.run()
+    # Shows that the exit & quit dot commands exit the shell prior to the error
+    # Still indirect but ensures a failure if they do not work as expected
+    assert result.status_code == 0
 
 def test_exit_rc(shell):
-    test = ShellTest(shell).statement(f".exit 17")
+    test = ShellTest(shell).statement(".exit 17")
     result = test.run()
     assert result.status_code == 17
 
@@ -213,8 +247,8 @@ def test_regexp_matches(shell):
 
 def test_help(shell):
     test = (
-        ShellTest(shell).
-        statement(".help")
+        ShellTest(shell)
+        .statement(".help")
     )
     result = test.run()
     result.check_stdout("Show help text for PATTERN")
@@ -333,18 +367,18 @@ def test_show_basic(shell):
     result.check_stdout("rowseparator")
 
 @pytest.mark.parametrize("cmd", [
-    ".vfsinfo",
-    ".vfsname",
-    ".vfslist"
+    "vfsinfo",
+    "vfsname",
+    "vfslist",
 ])
 def test_volatile_commands(shell, cmd):
-    # The original comment read: don't crash plz
     test = (
         ShellTest(shell)
         .statement(f".{cmd}")
     )
     result = test.run()
-    result.check_stderr("")
+    assert result.status_code == 1
+    result.check_stderr("Unknown Command Error")
 
 @pytest.mark.parametrize("pattern", [
     "test",
@@ -366,7 +400,7 @@ def test_schema_indent(shell):
     test = (
         ShellTest(shell)
         .statement("create table test (a int, b varchar, c int, d int, k int, primary key(a, b));")
-        .statement(f".schema -indent")
+        .statement(".schema -indent")
     )
     result = test.run()
     result.check_stdout("CREATE TABLE test(")
@@ -456,10 +490,12 @@ def test_indexes(shell):
 def test_schema_pattern_no_result(shell):
     test = (
         ShellTest(shell)
-        .statement(".schema %p%")
+        .statement("create table testp (a integer)")
+        .statement("create table test_p (b integer)")
+        .statement(".schema %z%")
     )
     result = test.run()
-    result.check_stdout("")
+    result.check_not_exist("CREATE TABLE")
 
 def test_schema_pattern(shell):
     test = (
@@ -500,7 +536,7 @@ def test_sha3sum(shell):
         .statement(".sha3sum")
     )
     result = test.run()
-    result.check_stderr('')
+    result.check_stderr('Unknown Command Error')
 
 def test_jsonlines(shell):
     test = (
@@ -550,14 +586,20 @@ def test_output_csv_mode(shell, random_filepath):
     result.stdout = open(random_filepath, 'rb').read()
     result.check_stdout(b'42')
 
-def test_issue_6204(shell):
+def test_issue_6204(shell, random_filepath):
     test = (
         ShellTest(shell)
-        .statement(".output foo.txt")
+        .statement(f".output {random_filepath.as_posix()}")
         .statement("select * from range(2049);")
     )
     result = test.run()
-    result.check_stdout("")
+    result.check_stdout(None)
+
+    with open(random_filepath, 'r', encoding='utf-8') as f:
+        output = f.read()
+        nums = set(int(x) for x in re.findall(r'\d+', output))
+
+        assert all(i in nums for i in range(2049))
 
 def test_once(shell, random_filepath):
     test = (
@@ -568,16 +610,6 @@ def test_once(shell, random_filepath):
     result = test.run()
     result.stdout = open(random_filepath, 'rb').read()
     result.check_stdout(b'43')
-
-def test_log(shell, random_filepath):
-    test = (
-        ShellTest(shell)
-        .statement(f".log {random_filepath.as_posix()}")
-        .statement("SELECT 42;")
-        .statement(".log off")
-    )
-    result = test.run()
-    result.check_stdout('')
 
 @pytest.mark.parametrize("dot_command", [
     ".mode ascii",
@@ -786,7 +818,7 @@ def test_enable_profiling(shell):
         .statement("PRAGMA enable_profiling")
     )
     result = test.run()
-    result.check_stderr('')
+    result.check_stderr(None)
 
 def test_profiling_select(shell):
     test = (
@@ -907,7 +939,7 @@ def test_mode_trash(shell):
         .statement("select 1")
     )
     result = test.run()
-    result.check_stdout('')
+    result.check_stdout(None)
 
 def test_sqlite_comments(shell):
     # Using /* <comment> */
@@ -1098,5 +1130,101 @@ def test_help_prints_to_stdout(shell):
     result = test.run()
     result.check_stdout("OPTIONS")
 
+def test_open_with_sql(shell, random_filepath):
+    test = (
+        ShellTest(shell)
+        .env_var("MY_DB", str(random_filepath))
+        .statement(".open -sql \"select getenv('MY_DB');\"")
+        .statement("show databases;")
+    )
+    result = test.run()
+    result.check_stdout("random_import_file")
+    result.check_stderr(None)
+
+def test_open_with_multiple_sql_flags(shell, random_filepath):
+    test = (
+        ShellTest(shell)
+        .env_var("MY_DB", str(random_filepath))
+        .statement(".open -sql \"select getenv('MY_DB');\" -sql \"select 42;\"")
+    )
+    result = test.run()
+    result.check_stderr("Error: --sql provided multiple times")
+
+def test_open_with_sql_and_no_query(shell, random_filepath):
+    test = (
+        ShellTest(shell)
+        .env_var("MY_DB", str(random_filepath))
+        .statement(".open -sql")
+    )
+    result = test.run()
+    result.check_stderr("Error: missing SQL query after --sql")
+
+def test_open_with_sql_and_file(shell, random_filepath):
+    test = (
+        ShellTest(shell)
+        .env_var("MY_DB", str(random_filepath))
+        .statement(".open -sql \"select getenv('MY_DB');\" \"test.db\"")
+    )
+    result = test.run()
+    result.check_stderr("Error: cannot use both --sql and a FILE argument")
+
+def test_open_with_sql_and_multiple_columns(shell, random_filepath):
+    test = (
+        ShellTest(shell)
+        .env_var("MY_DB", str(random_filepath))
+        .statement(".open -sql \"select getenv('MY_DB'), 42;\"")
+    )
+    result = test.run()
+    result.check_stderr("Error: --sql query returned multiple columns, expected single value")
+
+def test_open_with_sql_and_multiple_rows(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".open -sql \"select unnest(generate_series(1,2));\"")
+    )
+    result = test.run()
+    result.check_stderr("Error: --sql query returned multiple rows, expected single value")
+
+def test_open_with_sql_w_db_error(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".open -sql \"select 'test'::int;\"")
+    )
+    result = test.run()
+    result.check_stderr("Error: failed to evaluate --sql query")
+
+def test_open_with_sql_and_no_return(shell):
+    test = (
+        ShellTest(shell)
+        .statement("create table a (i integer);")
+        .statement(".open -sql \"from a where 1=0;\"")
+    )
+    result = test.run()
+    result.check_stderr("Error: --sql query returned no value")
+
+def test_open_with_sql_and_dml(shell):
+    test = (
+        ShellTest(shell)
+        .statement("create table test(i integer);")
+        .statement(".open -sql \"insert into test values (1);\"")
+    )
+    result = test.run()
+    result.check_stderr("Error: the --sql argument")
+
+def test_open_with_sql_and_null_return(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".open -sql \"select NULL;\"")
+    )
+    result = test.run()
+    result.check_stderr("Error: --sql query returned a null value")
+
+def test_open_with_sql_and_empty_string_return(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".open -sql \"select '';\"")
+    )
+    result = test.run()
+    result.check_stderr("Error: --sql query returned an empty string")
 
 # fmt: on


### PR DESCRIPTION
This PR will allow users to generate their connection string or file path dynamically for the `.open` command using SQL and the unique-to-the-CLI `getenv` function; i.e.,

`> .open -sql "select getenv('DB_FILE_PATH')"`

`> .open -sql "select getenv('ENV_PATH') || '.my_db.duckdb'`

`> .open -sql "select 'md:my_db?motherduck_token=' || getenv('MD_TOKEN')"`

This is especially useful when paired with a `.duckdbrc` file and Motherduck. It'll allow a user to connect to motherduck anytime they use `duckdb` in the terminal without having to specify their token each time, along with additional databases thereafter. To do the same thing today, you have to hard code your token in your `.duckdbrc` which is not ideal, especially if you like to keep that file in your dev environment repo or share it.