### PR TITLE
Internal #6196: AsOf Prefix Comparisons 

### DIFF
--- a/test/sql/join/asof/test_asof_join_timestamps.test
+++ b/test/sql/join/asof/test_asof_join_timestamps.test
@@ -219,6 +219,7 @@ ON p.begin >= e.begin
 ORDER BY p.begin ASC
 ----
 2023-03-21 12:00:00
+NULL
 
 # Return NULLs
 query II


### PR DESCRIPTION
* Replace (incorrect) single row equality comparisons with key prefix comparisons
* Move LHS Scans to after the key comparisons to avoid data corruption.
* Fix incorrect ANTI JOIN result this all uncovered.

fixes: duckdblabs/duckdb-internal#6196
