### PR TITLE
Internal #6196: AsOf Prefix Comparisons

### DIFF
--- a/src/common/sort/sorted_run.cpp
+++ b/src/common/sort/sorted_run.cpp
@@ -78,7 +78,7 @@ void GetKeyAndPayload(SORT_KEY *const *const sort_keys, const idx_t &count, Data
 template <class SORT_KEY>
 void TemplatedReconstructSortKey(SORT_KEY *const *const sort_keys, const idx_t &count) {
 	for (idx_t i = 0; i < count; i++) {
-		sort_keys[i]->ByteSwap();
+		sort_keys[i]->Reconstruct();
 	}
 }
 

--- a/src/common/sort/sorted_run_merger.cpp
+++ b/src/common/sort/sorted_run_merger.cpp
@@ -687,34 +687,6 @@ void SortedRunMergerLocalState::ScanPartition(SortedRunMergerGlobalState &gstate
 	}
 }
 
-template <class SORT_KEY, class PHYSICAL_TYPE>
-void TemplatedGetKeyAndPayload(SORT_KEY *const merged_partition_keys, const idx_t count, DataChunk &key,
-                               data_ptr_t *const payload_ptrs) {
-	const auto key_data = FlatVector::GetData<PHYSICAL_TYPE>(key.data[0]);
-	for (idx_t i = 0; i < count; i++) {
-		auto &merged_partition_key = merged_partition_keys[i];
-		merged_partition_key.Deconstruct(key_data[i]);
-		if (SORT_KEY::HAS_PAYLOAD) {
-			payload_ptrs[i] = merged_partition_key.GetPayload();
-		}
-	}
-	key.SetCardinality(count);
-}
-
-template <class SORT_KEY>
-void GetKeyAndPayload(SORT_KEY *const merged_partition_keys, const idx_t count, DataChunk &key,
-                      data_ptr_t *const payload_ptrs) {
-	const auto type_id = key.data[0].GetType().id();
-	switch (type_id) {
-	case LogicalTypeId::BLOB:
-		return TemplatedGetKeyAndPayload<SORT_KEY, string_t>(merged_partition_keys, count, key, payload_ptrs);
-	case LogicalTypeId::BIGINT:
-		return TemplatedGetKeyAndPayload<SORT_KEY, int64_t>(merged_partition_keys, count, key, payload_ptrs);
-	default:
-		throw NotImplementedException("GetKeyAndPayload for %s", EnumUtil::ToString(type_id));
-	}
-}
-
 template <SortKeyType SORT_KEY_TYPE>
 void SortedRunMergerLocalState::TemplatedScanPartition(SortedRunMergerGlobalState &gstate, DataChunk &chunk) {
 	using SORT_KEY = SortKey<SORT_KEY_TYPE>;

--- a/src/execution/operator/join/physical_asof_join.cpp
+++ b/src/execution/operator/join/physical_asof_join.cpp
@@ -363,7 +363,7 @@ AsOfGlobalSourceState::AsOfGlobalSourceState(ClientContext &client, const Physic
 	auto &rhs_groups = hashed_groups[1];
 	right_outers.reserve(rhs_groups.size());
 	for (const auto &hash_group : rhs_groups) {
-		right_outers.emplace_back(OuterJoinMarker(is_right_outer));
+		right_outers.emplace_back(is_right_outer);
 		right_outers.back().Initialize(hash_group ? hash_group->Count() : 0);
 	}
 }

--- a/src/include/duckdb/common/sorting/sort_key.hpp
+++ b/src/include/duckdb/common/sorting/sort_key.hpp
@@ -45,7 +45,7 @@ struct SortKey;
 template <class SORT_KEY>
 struct SortKeyNoPayload {
 protected:
-	SortKeyNoPayload() = default;
+	SortKeyNoPayload() = default; // NOLINT
 	friend SORT_KEY;
 
 public:
@@ -63,7 +63,7 @@ public:
 template <class SORT_KEY>
 struct SortKeyPayload {
 protected:
-	SortKeyPayload() = default;
+	SortKeyPayload() = default; // NOLINT
 	friend SORT_KEY;
 
 public:
@@ -93,7 +93,7 @@ inline bool SortKeyLessThan<1>(const uint64_t *const &lhs, const uint64_t *const
 template <class SORT_KEY, bool HAS_PAYLOAD>
 struct FixedSortKey : std::conditional<HAS_PAYLOAD, SortKeyPayload<SORT_KEY>, SortKeyNoPayload<SORT_KEY>>::type {
 protected:
-	FixedSortKey() = default;
+	FixedSortKey() = default; // NOLINT
 	friend SORT_KEY;
 
 public:
@@ -143,6 +143,10 @@ public:
 		val = static_cast<int64_t>(sort_key.part0); // NOLINT: unsafe cast on purpose
 	}
 
+	void Reconstruct() {
+		ByteSwap();
+	}
+
 	data_ptr_t GetData() const {
 		throw InternalException("GetData() called on a FixedSortKey");
 	}
@@ -163,7 +167,7 @@ public:
 template <class SORT_KEY, bool HAS_PAYLOAD>
 struct VariableSortKey : std::conditional<HAS_PAYLOAD, SortKeyPayload<SORT_KEY>, SortKeyNoPayload<SORT_KEY>>::type {
 protected:
-	VariableSortKey() = default;
+	VariableSortKey() = default; // NOLINT
 	friend SORT_KEY;
 
 public:
@@ -213,6 +217,13 @@ public:
 
 	void Deconstruct(int64_t &) {
 		throw InternalException("VariableSortKey::Deconstruct() called with an int64_t");
+	}
+
+	void Reconstruct() {
+		auto &sort_key = static_cast<SORT_KEY &>(*this);
+		if (sort_key.size <= SORT_KEY::INLINE_LENGTH) {
+			ByteSwap();
+		}
 	}
 
 	data_ptr_t GetData() const {


### PR DESCRIPTION
* Fix TemplatedReconstructSortKey to call new key Reconstruct methods instead of assuming byte swapping is always valid
* Remove dead code.
* Fix new tidy failure.
