### PR TITLE
Get table bindings for all operators under a logical get if the logical get function is an unnest

### DIFF
--- a/src/include/duckdb/optimizer/join_order/relation_manager.hpp
+++ b/src/include/duckdb/optimizer/join_order/relation_manager.hpp
@@ -56,7 +56,11 @@ public:
 	//! Extract the set of relations referred to inside an expression
 	bool ExtractBindings(Expression &expression, unordered_set<idx_t> &bindings);
 	void AddRelation(LogicalOperator &op, optional_ptr<LogicalOperator> parent, const RelationStats &stats);
-
+	//! Add an unnest relation which can come from a logical unnest or a logical get which has an unnest function
+	void AddUnnestRelation(JoinOrderOptimizer &optimizer, LogicalOperator &op, LogicalOperator &input_op,
+	                       optional_ptr<LogicalOperator> parent, RelationStats &child_stats,
+	                       optional_ptr<LogicalOperator> limit_op,
+	                       vector<reference<LogicalOperator>> &datasource_filters);
 	void AddAggregateOrWindowRelation(LogicalOperator &op, optional_ptr<LogicalOperator> parent,
 	                                  const RelationStats &stats, LogicalOperatorType op_type);
 	vector<unique_ptr<SingleJoinRelation>> GetRelations();

--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -54,6 +54,13 @@ void RelationManager::AddRelation(LogicalOperator &op, optional_ptr<LogicalOpera
 	auto relation_id = relations.size();
 
 	auto table_indexes = op.GetTableIndex();
+	bool is_unnest_or_get_with_unnest = op.type == LogicalOperatorType::LOGICAL_UNNEST;
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		auto &get = op.Cast<LogicalGet>();
+		if (get.function.name == "unnest") {
+			is_unnest_or_get_with_unnest = true;
+		}
+	}
 	if (table_indexes.empty()) {
 		// relation represents a non-reorderable relation, most likely a join relation
 		// Get the tables referenced in the non-reorderable relation and add them to the relation mapping
@@ -65,7 +72,7 @@ void RelationManager::AddRelation(LogicalOperator &op, optional_ptr<LogicalOpera
 			D_ASSERT(relation_mapping.find(reference) == relation_mapping.end());
 			relation_mapping[reference] = relation_id;
 		}
-	} else if (op.type == LogicalOperatorType::LOGICAL_UNNEST) {
+	} else if (is_unnest_or_get_with_unnest) {
 		// logical unnest has a logical_unnest index, but other bindings can refer to
 		// columns that are not unnested.
 		auto bindings = op.GetColumnBindings();
@@ -182,6 +189,21 @@ static void ModifyStatsIfLimit(optional_ptr<LogicalOperator> limit_op, RelationS
 	}
 }
 
+void RelationManager::AddUnnestRelation(JoinOrderOptimizer &optimizer, LogicalOperator &op, LogicalOperator &input_op,
+                                        optional_ptr<LogicalOperator> parent, RelationStats &child_stats,
+                                        optional_ptr<LogicalOperator> limit_op,
+                                        vector<reference<LogicalOperator>> &datasource_filters) {
+	D_ASSERT(!op.children.empty());
+	auto child_optimizer = optimizer.CreateChildOptimizer();
+	op.children[0] = child_optimizer.Optimize(std::move(op.children[0]), &child_stats);
+	if (!datasource_filters.empty()) {
+		child_stats.cardinality = LossyNumericCast<idx_t>(static_cast<double>(child_stats.cardinality) *
+		                                                  RelationStatisticsHelper::DEFAULT_SELECTIVITY);
+	}
+	ModifyStatsIfLimit(limit_op.get(), child_stats);
+	AddRelation(input_op, parent, child_stats);
+}
+
 bool RelationManager::ExtractJoinRelations(JoinOrderOptimizer &optimizer, LogicalOperator &input_op,
                                            vector<reference<LogicalOperator>> &filter_operators,
                                            optional_ptr<LogicalOperator> parent) {
@@ -279,15 +301,7 @@ bool RelationManager::ExtractJoinRelations(JoinOrderOptimizer &optimizer, Logica
 	case LogicalOperatorType::LOGICAL_UNNEST: {
 		// optimize children of unnest
 		RelationStats child_stats;
-		auto child_optimizer = optimizer.CreateChildOptimizer();
-		op->children[0] = child_optimizer.Optimize(std::move(op->children[0]), &child_stats);
-		// the extracted cardinality should be set for window
-		if (!datasource_filters.empty()) {
-			child_stats.cardinality = LossyNumericCast<idx_t>(static_cast<double>(child_stats.cardinality) *
-			                                                  RelationStatisticsHelper::DEFAULT_SELECTIVITY);
-		}
-		ModifyStatsIfLimit(limit_op.get(), child_stats);
-		AddRelation(input_op, parent, child_stats);
+		AddUnnestRelation(optimizer, *op, input_op, parent, child_stats, limit_op, datasource_filters);
 		return true;
 	}
 	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
@@ -345,6 +359,11 @@ bool RelationManager::ExtractJoinRelations(JoinOrderOptimizer &optimizer, Logica
 	case LogicalOperatorType::LOGICAL_GET: {
 		// TODO: Get stats from a logical GET
 		auto &get = op->Cast<LogicalGet>();
+		if (get.function.name == "unnest" && !op->children.empty()) {
+			RelationStats child_stats;
+			AddUnnestRelation(optimizer, *op, input_op, parent, child_stats, limit_op, datasource_filters);
+			return true;
+		}
 		auto stats = RelationStatisticsHelper::ExtractGetStats(get, context);
 		// if there is another logical filter that could not be pushed down into the
 		// table scan, apply another selectivity.

--- a/test/optimizer/joins/test_logical_get_with_unnest.test
+++ b/test/optimizer/joins/test_logical_get_with_unnest.test
@@ -1,0 +1,30 @@
+# name: test/optimizer/joins/test_logical_get_with_unnest.test
+# description: Test unnest as logical Get. Make sure relation manager has all column bindings
+# group: [joins]
+
+require json
+
+statement ok
+CREATE TABLE foo AS
+SELECT
+  ['1', '2'] AS "number",
+  '{}' AS "my_json",
+  42 AS "forty_two",
+  'foo' AS "bar",
+  'bar' AS "baz"
+  FROM
+range(50);
+
+statement ok
+SELECT
+  *
+FROM
+foo AS cc,
+UNNEST(cc.number) AS t2
+CROSS JOIN LATERAL
+(
+SELECT
+  x.value AS whizz
+FROM
+  json_each(cc.my_json) AS x
+) AS col3;


### PR DESCRIPTION
The issue is caused by a very specific plan where a logical get (that has an unnest function) is the direct child of a logical comparison join. Normally for logical gets, we only add the one table index to the set of table indexes that can be joined on. However, if the logical get has an unnest function and there are children, the table indexes of those children can also be joined on. The Join Order Optimizer did not consider this case, which also turns out to be extremely rare. Here is the plan before the join order optimizer gets to it.

I tried to write another test case but struggled for about 30 min. 

```
┌───────────────────────────┐
│       PROJECTION #23      │
│    ────────────────────   │
│        Expressions:       │
│     #[0.0] (VARCHAR[])    │
│      #[0.1] (VARCHAR)     │
│      #[0.2] (INTEGER)     │
│      #[0.3] (VARCHAR)     │
│      #[0.4] (VARCHAR)     │
│      #[8.0] (VARCHAR)     │
│       #[17.0] (JSON)      │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         DELIM_JOIN        │
│    ────────────────────   │
│      Join Type: INNER     │
│                           ├──────────────┐
│        Conditions:        │              │
│  (#[29.0] IS NOT DISTINCT │              │
│        FROM #[2.1])       │              │
└─────────────┬─────────────┘              │
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         WINDOW #29        ││      COMPARISON_JOIN      │
│    ────────────────────   ││    ────────────────────   │
│        Expressions:       ││      Join Type: INNER     │
│  ROW_NUMBER() OVER (ROWS  ││                           │
│      BETWEEN UNBOUNDED    ││        Conditions:        │
│ PRECEDING AND CURRENT ROW)││  (#[2.1] IS NOT DISTINCT  ├──────────────┐
│                           ││        FROM #[17.1])      │              │
│                           ││  (#[2.2] IS NOT DISTINCT  │              │
│                           ││        FROM #[17.2])      │              │
│                           ││  (#[2.3] IS NOT DISTINCT  │              │
│                           ││        FROM #[17.3])      │              │
└─────────────┬─────────────┘└─────────────┬─────────────┘              │
┌─────────────┴─────────────┐┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│        SEQ_SCAN #0        ││         UNNEST #8         ││       PROJECTION #17      │
│    ────────────────────   ││    ────────────────────   ││    ────────────────────   │
│   Table: xxxxxxxxxxxxxx   ││                           ││        Expressions:       │
│   Type: Sequential Scan   ││                           ││       #[16.1] (JSON)      │
│                           ││                           ││      #[10.1] (BIGINT)     │
│                           ││                           ││     #[10.2] (VARCHAR)     │
│                           ││                           ││    #[10.3] (VARCHAR[])    │
└───────────────────────────┘└─────────────┬─────────────┘└─────────────┬─────────────┘
                             ┌─────────────┴─────────────┐┌─────────────┴─────────────┐
                             │       PROJECTION #2       ││       JSON_EACH #16       │
                             │    ────────────────────   ││    ────────────────────   │
                             │        Expressions:       ││                           │
                             │    #[30.2] (VARCHAR[])    ││                           │
                             │      #[30.0] (BIGINT)     ││                           │
                             │     #[30.1] (VARCHAR)     ││                           │
                             │    #[30.2] (VARCHAR[])    ││                           │
                             └─────────────┬─────────────┘└─────────────┬─────────────┘
                             ┌─────────────┴─────────────┐┌─────────────┴─────────────┐
                             │       DELIM_GET #30       ││       PROJECTION #10      │
                             │    ────────────────────   ││    ────────────────────   │
                             │                           ││        Expressions:       │
                             │                           ││     #[31.1] (VARCHAR)     │
                             │                           ││      #[31.0] (BIGINT)     │
                             │                           ││     #[31.1] (VARCHAR)     │
                             │                           ││    #[31.2] (VARCHAR[])    │
                             └───────────────────────────┘└─────────────┬─────────────┘
                                                          ┌─────────────┴─────────────┐
                                                          │       DELIM_GET #31       │
                                                          │    ────────────────────   │
                                                          └───────────────────────────┘
```