### PR TITLE
Make `DatabaseInstance::log_manager` a `unique_ptr`

### DIFF
--- a/src/include/duckdb/logging/log_manager.hpp
+++ b/src/include/duckdb/logging/log_manager.hpp
@@ -21,7 +21,7 @@ class LogType;
 // - Creates Loggers with cached configuration
 // - Main sink for logs (either by logging directly into this, or by syncing a pre-cached set of log entries)
 // - Holds the log storage
-class LogManager : public enable_shared_from_this<LogManager> {
+class LogManager {
 	friend class ThreadSafeLogger;
 	friend class ThreadLocalLogger;
 	friend class MutableLogger;

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -90,7 +90,7 @@ private:
 	unique_ptr<ExtensionManager> extension_manager;
 	ValidChecker db_validity;
 	unique_ptr<DatabaseFileSystem> db_file_system;
-	shared_ptr<LogManager> log_manager;
+	unique_ptr<LogManager> log_manager;
 	unique_ptr<ExternalFileCache> external_file_cache;
 
 	duckdb_ext_api_v1 (*create_api_v1)();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -285,7 +285,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 		buffer_manager = make_uniq<StandardBufferManager>(*this, config.options.temporary_directory);
 	}
 
-	log_manager = make_shared_ptr<LogManager>(*this, LogConfig());
+	log_manager = make_uniq<LogManager>(*this, LogConfig());
 	log_manager->Initialize();
 
 	external_file_cache = make_uniq<ExternalFileCache>(*this, config.options.enable_external_file_cache);


### PR DESCRIPTION
`DatabaseInstance` never shares ownership of its `LogManager` with anyone. One can only get a reference to it with `GetLogManager`.
To make the ownership model more explicit, and have me worry less about whether a `LogStorage` can outlive a `DatabaseInstance`, this changes the pointer type to a `unique_ptr`.