### PR TITLE
[C-API] Add support for defining config options (settings)

### DIFF
--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -82,6 +82,7 @@ ORIGINAL_FUNCTION_GROUP_ORDER = [
     'cast_functions',
     'expression_interface',
     'file_system_interface',
+    'config_options_interface',
 ]
 
 # The file that forms the base for the header generation

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -487,6 +487,19 @@ typedef struct {
 	                                                  duckdb_arrow_converted_schema converted_schema,
 	                                                  duckdb_data_chunk *out_chunk);
 	void (*duckdb_destroy_arrow_converted_schema)(duckdb_arrow_converted_schema *arrow_converted_schema);
+	// New configuration options functions
+
+	duckdb_config_option (*duckdb_create_config_option)();
+	void (*duckdb_destroy_config_option)(duckdb_config_option *option);
+	void (*duckdb_config_option_set_name)(duckdb_config_option option, const char *name);
+	void (*duckdb_config_option_set_type)(duckdb_config_option option, duckdb_logical_type type);
+	void (*duckdb_config_option_set_default_value)(duckdb_config_option option, duckdb_value default_value);
+	void (*duckdb_config_option_set_default_scope)(duckdb_config_option option,
+	                                               duckdb_config_option_scope default_scope);
+	void (*duckdb_config_option_set_description)(duckdb_config_option option, const char *description);
+	duckdb_state (*duckdb_register_config_option)(duckdb_connection connection, duckdb_config_option option);
+	duckdb_value (*duckdb_client_context_get_config_option)(duckdb_client_context context, const char *name,
+	                                                        duckdb_config_option_scope *out_scope);
 	// New functions for duckdb error data
 
 	duckdb_error_data (*duckdb_create_error_data)(duckdb_error_type type, const char *message);
@@ -1003,6 +1016,15 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_schema_from_arrow = duckdb_schema_from_arrow;
 	result.duckdb_data_chunk_from_arrow = duckdb_data_chunk_from_arrow;
 	result.duckdb_destroy_arrow_converted_schema = duckdb_destroy_arrow_converted_schema;
+	result.duckdb_create_config_option = duckdb_create_config_option;
+	result.duckdb_destroy_config_option = duckdb_destroy_config_option;
+	result.duckdb_config_option_set_name = duckdb_config_option_set_name;
+	result.duckdb_config_option_set_type = duckdb_config_option_set_type;
+	result.duckdb_config_option_set_default_value = duckdb_config_option_set_default_value;
+	result.duckdb_config_option_set_default_scope = duckdb_config_option_set_default_scope;
+	result.duckdb_config_option_set_description = duckdb_config_option_set_description;
+	result.duckdb_register_config_option = duckdb_register_config_option;
+	result.duckdb_client_context_get_config_option = duckdb_client_context_get_config_option;
 	result.duckdb_create_error_data = duckdb_create_error_data;
 	result.duckdb_destroy_error_data = duckdb_destroy_error_data;
 	result.duckdb_error_data_error_type = duckdb_error_data_error_type;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_config_options_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_config_options_functions.json
@@ -1,0 +1,16 @@
+{
+  "version": "unstable_new_config_options_functions",
+  "description": "New configuration options functions",
+  "entries": [
+    "duckdb_create_config_option",
+    "duckdb_destroy_config_option",
+    "duckdb_config_option_set_name",
+    "duckdb_config_option_set_type",
+    "duckdb_config_option_set_default_value",
+    "duckdb_config_option_set_default_scope",
+    "duckdb_config_option_set_description",
+    "duckdb_register_config_option",
+
+    "duckdb_client_context_get_config_option"
+  ]
+}

--- a/src/include/duckdb/main/capi/header_generation/functions/config_options_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/config_options_interface.json
@@ -1,0 +1,185 @@
+{
+  "group": "config_options_interface",
+  "deprecated": false,
+  "entries": [
+    {
+      "name": "duckdb_create_config_option",
+      "return_type": "duckdb_config_option",
+      "params": [],
+      "comment": {
+        "description": "Creates a configuration option instance.\n\n",
+        "return_value": "The resulting configuration option instance. Must be destroyed with `duckdb_destroy_config_option`."
+      }
+    },
+    {
+      "name": "duckdb_destroy_config_option",
+      "return_type": "void",
+      "params": [
+        {
+          "type": "duckdb_config_option*",
+          "name": "option"
+        }
+      ],
+      "comment": {
+        "description": "Destroys the given configuration option instance.\n",
+        "param_comments": {
+          "option": "The configuration option instance to destroy."
+        }
+      }
+    },
+    {
+      "name": "duckdb_config_option_set_name",
+      "return_type": "void",
+      "params": [
+        {
+          "type": "duckdb_config_option",
+          "name": "option"
+        },
+        {
+          "type": "const char*",
+          "name": "name"
+        }
+      ],
+      "comment": {
+        "description": "Sets the name of the configuration option.\n\n",
+        "param_comments": {
+          "option": "The configuration option instance.",
+          "name": "The name to set."
+        }
+      }
+    },
+    {
+      "name": "duckdb_config_option_set_type",
+      "return_type": "void",
+      "params": [
+        {
+          "type": "duckdb_config_option",
+          "name": "option"
+        },
+        {
+          "type": "duckdb_logical_type",
+          "name": "type"
+        }
+      ],
+      "comment": {
+        "description": "Sets the type of the configuration option.\n\n",
+        "param_comments": {
+          "option": "The configuration option instance.",
+          "type": "The type to set."
+        }
+      }
+    },
+    {
+      "name": "duckdb_config_option_set_default_value",
+      "return_type": "void",
+      "params": [
+        {
+          "type": "duckdb_config_option",
+          "name": "option"
+        },
+        {
+          "type": "duckdb_value",
+          "name": "default_value"
+        }
+      ],
+      "comment": {
+        "description": "Sets the default value of the configuration option.\nIf the type of this option has already been set with `duckdb_config_option_set_type`, the value is cast to the type.\nOtherwise, the type is inferred from the value.\n\n",
+        "param_comments": {
+          "option": "The configuration option instance.",
+          "default_value": "The default value to set."
+        }
+      }
+    },
+    {
+      "name": "duckdb_config_option_set_default_scope",
+      "return_type": "void",
+        "params": [
+            {
+            "type": "duckdb_config_option",
+            "name": "option"
+            },
+            {
+            "type": "duckdb_config_option_scope",
+            "name": "default_scope"
+            }
+        ],
+      "comment": {
+        "description": "Sets the default scope of the configuration option.\nIf not set, this defaults to `DUCKDB_CONFIG_OPTION_SCOPE_SESSION`.\n\n",
+        "param_comments": {
+          "option": "The configuration option instance.",
+          "default_scope": "The default scope to set."
+        }
+      }
+    },
+    {
+      "name": "duckdb_config_option_set_description",
+      "return_type": "void",
+      "params": [
+        {
+          "type": "duckdb_config_option",
+          "name": "option"
+        },
+        {
+          "type": "const char*",
+          "name": "description"
+        }
+      ],
+      "comment": {
+        "description": "Sets the description of the configuration option.\n\n",
+        "param_comments": {
+          "option": "The configuration option instance.",
+          "description": "The description to set."
+        }
+      }
+    },
+    {
+      "name": "duckdb_register_config_option",
+      "return_type": "duckdb_state",
+      "params": [
+        {
+          "type": "duckdb_connection",
+          "name": "connection"
+        },
+        {
+          "type": "duckdb_config_option",
+          "name": "option"
+        }
+      ],
+      "comment": {
+        "description": "Registers the given configuration option on the specified connection.\n\n",
+        "param_comments": {
+          "connection": "The connection to register the option on.",
+          "option": "The configuration option instance to register."
+        },
+        "return_value": "A duckdb_state indicating success or failure."
+      }
+    },
+    {
+      "name": "duckdb_client_context_get_config_option",
+      "return_type": "duckdb_value",
+      "params": [
+        {
+          "type": "duckdb_client_context",
+          "name": "context"
+        },
+        {
+          "type": "const char*",
+          "name": "name"
+        },
+        {
+          "type": "duckdb_config_option_scope*",
+          "name": "out_scope"
+        }
+      ],
+      "comment": {
+          "description": "Retrieves the value of a configuration option by name from the given client context.\n\n",
+          "param_comments": {
+            "context": "The client context.",
+            "name": "The name of the configuration option to retrieve.",
+            "out_scope": "Output parameter to optionally store the scope that the configuration option was retrieved from.\nIf this is `nullptr`, the scope is not returned.\nIf the requested option does not exist the scope is set to `DUCKDB_CONFIG_OPTION_SCOPE_INVALID`."
+          },
+          "return_value": "The value of the configuration option. Returns `nullptr` if the option does not exist."
+      }
+    }
+  ]
+}

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -255,6 +255,21 @@ typedef enum duckdb_file_flag {
 	DUCKDB_FILE_FLAG_APPEND = 5,
 } duckdb_file_flag;
 
+//! An enum over DuckDB's configuration option scopes.
+//! This enum can be used to specify the default scope when creating a custom configuration option,
+//! but it is also be used to determine the scope in which a configuration option is set when it is
+//! changed or retrieved.
+typedef enum duckdb_config_option_scope {
+	DUCKDB_CONFIG_OPTION_SCOPE_INVALID = 0,
+	// The option is set for the duration of the current transaction only.
+	// !! CURRENTLY NOT IMPLEMENTED !!
+	DUCKDB_CONFIG_OPTION_SCOPE_LOCAL = 1,
+	// The option is set for the current session/connection only.
+	DUCKDB_CONFIG_OPTION_SCOPE_SESSION = 2,
+	// Set the option globally for all sessions/connections.
+	DUCKDB_CONFIG_OPTION_SCOPE_GLOBAL = 3,
+} duckdb_config_option_scope;
+
 //===--------------------------------------------------------------------===//
 // General type definitions
 //===--------------------------------------------------------------------===//
@@ -547,6 +562,12 @@ typedef struct _duckdb_table_description {
 typedef struct _duckdb_config {
 	void *internal_ptr;
 } * duckdb_config;
+
+//! A custom configuration option instance. Used to register custom options that can be set on a duckdb_config.
+//! or by the user in SQL using `SET <option_name> = <value>`.
+typedef struct _duckdb_config_option {
+	void *internal_ptr;
+} * duckdb_config_option;
 
 //! A logical type.
 //! Must be destroyed with `duckdb_destroy_logical_type`.

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -291,6 +291,7 @@ public:
 	DUCKDB_API void AddExtensionOption(const string &name, string description, LogicalType parameter,
 	                                   const Value &default_value = Value(), set_option_callback_t function = nullptr,
 	                                   SetScope default_scope = SetScope::SESSION);
+	DUCKDB_API bool HasExtensionOption(const string &name);
 	//! Fetch an option by index. Returns a pointer to the option, or nullptr if out of range
 	DUCKDB_API static optional_ptr<const ConfigurationOption> GetOptionByIndex(idx_t index);
 	//! Fetcha n alias by index, or nullptr if out of range

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -560,6 +560,21 @@ typedef struct {
 	void (*duckdb_destroy_arrow_converted_schema)(duckdb_arrow_converted_schema *arrow_converted_schema);
 #endif
 
+// New configuration options functions
+#ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
+	duckdb_config_option (*duckdb_create_config_option)();
+	void (*duckdb_destroy_config_option)(duckdb_config_option *option);
+	void (*duckdb_config_option_set_name)(duckdb_config_option option, const char *name);
+	void (*duckdb_config_option_set_type)(duckdb_config_option option, duckdb_logical_type type);
+	void (*duckdb_config_option_set_default_value)(duckdb_config_option option, duckdb_value default_value);
+	void (*duckdb_config_option_set_default_scope)(duckdb_config_option option,
+	                                               duckdb_config_option_scope default_scope);
+	void (*duckdb_config_option_set_description)(duckdb_config_option option, const char *description);
+	duckdb_state (*duckdb_register_config_option)(duckdb_connection connection, duckdb_config_option option);
+	duckdb_value (*duckdb_client_context_get_config_option)(duckdb_client_context context, const char *name,
+	                                                        duckdb_config_option_scope *out_scope);
+#endif
+
 // New functions for duckdb error data
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
 	duckdb_error_data (*duckdb_create_error_data)(duckdb_error_type type, const char *message);
@@ -1108,6 +1123,17 @@ typedef struct {
 #define duckdb_schema_from_arrow              duckdb_ext_api.duckdb_schema_from_arrow
 #define duckdb_data_chunk_from_arrow          duckdb_ext_api.duckdb_data_chunk_from_arrow
 #define duckdb_destroy_arrow_converted_schema duckdb_ext_api.duckdb_destroy_arrow_converted_schema
+
+// Version unstable_new_config_options_functions
+#define duckdb_create_config_option             duckdb_ext_api.duckdb_create_config_option
+#define duckdb_destroy_config_option            duckdb_ext_api.duckdb_destroy_config_option
+#define duckdb_config_option_set_name           duckdb_ext_api.duckdb_config_option_set_name
+#define duckdb_config_option_set_type           duckdb_ext_api.duckdb_config_option_set_type
+#define duckdb_config_option_set_default_value  duckdb_ext_api.duckdb_config_option_set_default_value
+#define duckdb_config_option_set_default_scope  duckdb_ext_api.duckdb_config_option_set_default_scope
+#define duckdb_config_option_set_description    duckdb_ext_api.duckdb_config_option_set_description
+#define duckdb_register_config_option           duckdb_ext_api.duckdb_register_config_option
+#define duckdb_client_context_get_config_option duckdb_ext_api.duckdb_client_context_get_config_option
 
 // Version unstable_new_error_data_functions
 #define duckdb_create_error_data     duckdb_ext_api.duckdb_create_error_data

--- a/src/main/capi/CMakeLists.txt
+++ b/src/main/capi/CMakeLists.txt
@@ -28,7 +28,8 @@ add_library_unity(
   table_function-c.cpp
   threading-c.cpp
   value-c.cpp
-  file_system-c.cpp)
+  file_system-c.cpp
+  config_options-c.cpp)
 
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_main_capi>

--- a/src/main/capi/config_options-c.cpp
+++ b/src/main/capi/config_options-c.cpp
@@ -1,0 +1,159 @@
+#include "duckdb/main/capi/capi_internal.hpp"
+
+namespace duckdb {
+namespace {
+
+struct CConfigOption {
+	string name;
+	LogicalType type;
+	Value default_value;
+	SetScope default_scope = SetScope::SESSION;
+	string description;
+};
+
+} // namespace
+} // namespace duckdb
+
+duckdb_config_option duckdb_create_config_option() {
+	auto coption = new duckdb::CConfigOption();
+	return reinterpret_cast<duckdb_config_option>(coption);
+}
+
+void duckdb_destroy_config_option(duckdb_config_option *option) {
+	if (!option || !*option) {
+		return;
+	}
+	auto coption = *reinterpret_cast<duckdb::CConfigOption **>(option);
+	delete coption;
+
+	*option = nullptr;
+}
+
+void duckdb_config_option_set_name(duckdb_config_option option, const char *name) {
+	if (!option || !name) {
+		return;
+	}
+	auto coption = reinterpret_cast<duckdb::CConfigOption *>(option);
+	coption->name = name;
+}
+
+void duckdb_config_option_set_type(duckdb_config_option option, duckdb_logical_type type) {
+	if (!option || !type) {
+		return;
+	}
+	auto coption = reinterpret_cast<duckdb::CConfigOption *>(option);
+	coption->type = *reinterpret_cast<duckdb::LogicalType *>(type);
+}
+
+void duckdb_config_option_set_default_value(duckdb_config_option option, duckdb_value default_value) {
+	if (!option || !default_value) {
+		return;
+	}
+	auto coption = reinterpret_cast<duckdb::CConfigOption *>(option);
+	auto cvalue = reinterpret_cast<duckdb::Value *>(default_value);
+
+	if (coption->type.id() == LogicalTypeId::INVALID) {
+		coption->type = cvalue->type();
+		coption->default_value = *cvalue;
+		return;
+	}
+
+	if (coption->type != cvalue->type()) {
+		coption->default_value = cvalue->DefaultCastAs(coption->type, false);
+		return;
+	}
+
+	coption->default_value = *cvalue;
+}
+
+void duckdb_config_option_set_default_scope(duckdb_config_option option, duckdb_config_option_scope scope) {
+	if (!option) {
+		return;
+	}
+	auto coption = reinterpret_cast<duckdb::CConfigOption *>(option);
+	switch (scope) {
+	case DUCKDB_CONFIG_OPTION_SCOPE_LOCAL:
+		coption->default_scope = duckdb::SetScope::LOCAL;
+		break;
+	// Set the option for the current session/connection only.
+	case DUCKDB_CONFIG_OPTION_SCOPE_SESSION:
+		coption->default_scope = duckdb::SetScope::SESSION;
+		break;
+	// Set the option globally for all sessions/connections.
+	case DUCKDB_CONFIG_OPTION_SCOPE_GLOBAL:
+		coption->default_scope = duckdb::SetScope::GLOBAL;
+		break;
+	default:
+		return;
+	}
+}
+
+void duckdb_config_option_set_description(duckdb_config_option option, const char *description) {
+	if (!option || !description) {
+		return;
+	}
+	auto coption = reinterpret_cast<duckdb::CConfigOption *>(option);
+	coption->description = description;
+}
+
+duckdb_state duckdb_register_config_option(duckdb_connection connection, duckdb_config_option option) {
+	if (!connection || !option) {
+		return DuckDBError;
+	}
+
+	auto conn = reinterpret_cast<duckdb::Connection *>(connection);
+	auto coption = reinterpret_cast<duckdb::CConfigOption *>(option);
+
+	if (coption->name.empty() || coption->type.id() == LogicalTypeId::INVALID) {
+		return DuckDBError;
+	}
+
+	// TODO: This is not transactional... but theres no easy way to make it so currently.
+	try {
+		if (conn->context->db->config.HasExtensionOption(coption->name)) {
+			// Option already exists
+			return DuckDBError;
+		}
+		conn->context->db->config.AddExtensionOption(coption->name, coption->description, coption->type,
+		                                             coption->default_value, nullptr, coption->default_scope);
+	} catch (...) {
+		return DuckDBError;
+	}
+
+	return DuckDBSuccess;
+}
+
+duckdb_value duckdb_client_context_get_config_option(duckdb_client_context context, const char *option_name,
+                                                     duckdb_config_option_scope *out_scope) {
+	if (!context || !option_name) {
+		return nullptr;
+	}
+
+	auto wrapper = reinterpret_cast<CClientContextWrapper *>(context);
+	auto &ctx = wrapper->context;
+
+	duckdb_config_option_scope res_scope = DUCKDB_CONFIG_OPTION_SCOPE_INVALID;
+	duckdb::Value *res_value = nullptr;
+
+	duckdb::Value result;
+	switch (ctx.TryGetCurrentSetting(option_name, result).GetScope()) {
+	case duckdb::SettingScope::LOCAL:
+		// This is a bit messy, but "session" is presented as LOCAL on the "settings" side of the API.
+		res_value = new duckdb::Value(std::move(result));
+		res_scope = DUCKDB_CONFIG_OPTION_SCOPE_SESSION;
+		break;
+	case duckdb::SettingScope::GLOBAL:
+		res_value = new duckdb::Value(std::move(result));
+		res_scope = DUCKDB_CONFIG_OPTION_SCOPE_GLOBAL;
+		break;
+	default:
+		res_value = nullptr;
+		res_scope = DUCKDB_CONFIG_OPTION_SCOPE_INVALID;
+		break;
+	}
+
+	if (out_scope) {
+		*out_scope = res_scope;
+	}
+	return reinterpret_cast<duckdb_value>(res_value);
+}

--- a/src/main/capi/config_options-c.cpp
+++ b/src/main/capi/config_options-c.cpp
@@ -52,7 +52,7 @@ void duckdb_config_option_set_default_value(duckdb_config_option option, duckdb_
 	auto coption = reinterpret_cast<duckdb::CConfigOption *>(option);
 	auto cvalue = reinterpret_cast<duckdb::Value *>(default_value);
 
-	if (coption->type.id() == LogicalTypeId::INVALID) {
+	if (coption->type.id() == duckdb::LogicalTypeId::INVALID) {
 		coption->type = cvalue->type();
 		coption->default_value = *cvalue;
 		return;
@@ -104,7 +104,7 @@ duckdb_state duckdb_register_config_option(duckdb_connection connection, duckdb_
 	auto conn = reinterpret_cast<duckdb::Connection *>(connection);
 	auto coption = reinterpret_cast<duckdb::CConfigOption *>(option);
 
-	if (coption->name.empty() || coption->type.id() == LogicalTypeId::INVALID) {
+	if (coption->name.empty() || coption->type.id() == duckdb::LogicalTypeId::INVALID) {
 		return DuckDBError;
 	}
 
@@ -129,7 +129,7 @@ duckdb_value duckdb_client_context_get_config_option(duckdb_client_context conte
 		return nullptr;
 	}
 
-	auto wrapper = reinterpret_cast<CClientContextWrapper *>(context);
+	auto wrapper = reinterpret_cast<duckdb::CClientContextWrapper *>(context);
 	auto &ctx = wrapper->context;
 
 	duckdb_config_option_scope res_scope = DUCKDB_CONFIG_OPTION_SCOPE_INVALID;

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -441,8 +441,15 @@ LogicalType DBConfig::ParseLogicalType(const string &type) {
 	return type_id;
 }
 
+bool DBConfig::HasExtensionOption(const string &name) {
+	lock_guard<mutex> l(config_lock);
+	return extension_parameters.find(name) != extension_parameters.end();
+}
+
 void DBConfig::AddExtensionOption(const string &name, string description, LogicalType parameter,
                                   const Value &default_value, set_option_callback_t function, SetScope default_scope) {
+
+	lock_guard<mutex> l(config_lock);
 	extension_parameters.insert(make_pair(
 	    name, ExtensionOption(std::move(description), std::move(parameter), function, default_value, default_scope)));
 	// copy over unrecognized options, if they match the new extension option

--- a/test/api/capi/CMakeLists.txt
+++ b/test/api/capi/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library_unity(
   test_sql_capi
   OBJECT
   capi_aggregate_functions.cpp
+  capi_config_options.cpp
   capi_custom_type.cpp
   capi_file_system.cpp
   capi_scalar_functions.cpp

--- a/test/api/capi/capi_config_options.cpp
+++ b/test/api/capi/capi_config_options.cpp
@@ -1,0 +1,110 @@
+#include "capi_tester.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+TEST_CASE("Test Custom Configuration Options in C API", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	// Create a connection and get client context
+	REQUIRE(tester.OpenDatabase(nullptr));
+	duckdb_client_context context;
+	duckdb_connection_get_client_context(tester.connection, &context);
+	REQUIRE(context != nullptr);
+
+	// Setup some types for config options
+	auto str_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+	auto int_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+
+	auto default_str_value = duckdb_create_varchar("default_string");
+	auto default_int_value = duckdb_create_int32(42);
+
+	// Test 1: Create a string config option
+	auto str_opt = duckdb_create_config_option();
+	REQUIRE(str_opt != nullptr);
+	duckdb_config_option_set_name(str_opt, "test_string_option");
+	duckdb_config_option_set_type(str_opt, str_type);
+	duckdb_config_option_set_description(str_opt, "A test string configuration option");
+	duckdb_config_option_set_default_value(str_opt, default_str_value);
+	REQUIRE(duckdb_register_config_option(tester.connection, str_opt) == DuckDBSuccess);
+
+	// Get and verify the string option
+	result = tester.Query("SELECT current_setting('test_string_option')");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<string>(0, 0) == "default_string");
+
+	// Set and verify the string option
+	REQUIRE_NO_FAIL(tester.Query("SET test_string_option = 'new_value'"));
+	result = tester.Query("SELECT current_setting('test_string_option')");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<string>(0, 0) == "new_value");
+
+	// Also get it from the client context
+	duckdb_config_option_scope scope;
+	auto retrieved_str = duckdb_client_context_get_config_option(context, "test_string_option", &scope);
+	REQUIRE(retrieved_str != nullptr);
+	duckdb_destroy_value(&retrieved_str);
+
+	// By default, the scope should be SESSION
+	REQUIRE(scope == DUCKDB_CONFIG_OPTION_SCOPE_SESSION);
+
+	duckdb_destroy_config_option(&str_opt);
+	duckdb_destroy_config_option(&str_opt);
+
+	// Fetch it from the duckdb_settings() function
+	result =
+	    tester.Query("SELECT name, value, input_type, scope FROM duckdb_settings() WHERE name = 'test_string_option'");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->ChunkCount() == 1);
+	REQUIRE(result->Fetch<string>(0, 0) == "test_string_option");
+	REQUIRE(result->Fetch<string>(1, 0) == "new_value");
+	REQUIRE(result->Fetch<string>(2, 0) == "VARCHAR");
+	REQUIRE(result->Fetch<string>(3, 0) == "LOCAL");
+
+	// Test 2: Create an integer config option, with the type inferred from the default value
+	auto int_opt = duckdb_create_config_option();
+	REQUIRE(int_opt != nullptr);
+	duckdb_config_option_set_name(int_opt, "test_integer_option");
+	duckdb_config_option_set_description(int_opt, "A test integer configuration option");
+	duckdb_config_option_set_default_value(int_opt, default_int_value);
+	duckdb_config_option_set_default_scope(int_opt, DUCKDB_CONFIG_OPTION_SCOPE_GLOBAL);
+	REQUIRE(duckdb_register_config_option(tester.connection, int_opt) == DuckDBSuccess);
+
+	// Get and verify the integer option
+	result = tester.Query("SELECT current_setting('test_integer_option')");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int32_t>(0, 0) == 42);
+
+	// Also get it from the client context. Try without specifying scope first
+	auto retrieved_int = duckdb_client_context_get_config_option(context, "test_integer_option", nullptr);
+	REQUIRE(retrieved_int != nullptr);
+	REQUIRE(duckdb_get_int32(retrieved_int) == 42);
+	duckdb_destroy_value(&retrieved_int);
+
+	// By default, the scope should be GLOBAL, as that was what we defined this option with
+	retrieved_int = duckdb_client_context_get_config_option(context, "test_integer_option", &scope);
+	REQUIRE(retrieved_int != nullptr);
+	duckdb_destroy_value(&retrieved_int);
+
+	// Also check in duckdb_settings()
+	result =
+	    tester.Query("SELECT name, value, input_type, scope FROM duckdb_settings() WHERE name = 'test_integer_option'");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->ChunkCount() == 1);
+	REQUIRE(result->Fetch<string>(0, 0) == "test_integer_option");
+	REQUIRE(result->Fetch<string>(1, 0) == "42");
+	REQUIRE(result->Fetch<string>(2, 0) == "INTEGER");
+	REQUIRE(result->Fetch<string>(3, 0) == "GLOBAL");
+
+	duckdb_destroy_config_option(&int_opt);
+	duckdb_destroy_config_option(&int_opt);
+
+	// Cleanup
+	duckdb_destroy_client_context(&context);
+	duckdb_destroy_logical_type(&str_type);
+	duckdb_destroy_logical_type(&int_type);
+
+	duckdb_destroy_value(&default_str_value);
+	duckdb_destroy_value(&default_int_value);
+}


### PR DESCRIPTION
This PR adds support for defining custom configuration options (settings) from the C-API.

The state of extension/configuration-options/settings and setting "scopes" in DuckDB are currently in a bit of a mess. I've tried to hide their differences in the C-API by only introducing a single `duckdb_config_option_scope` enum that can be used both when defining the default scope of a config option as well as determine from which scope a setting was derived when querying a config option. 

The only discrepancy is that we currently allow config options to be declared and set with `SESSION`, `GLOBAL` and an unused yet-to-be-implemeted transaction-`LOCAL` scope, but in the docs (and when querying from `duckdb_settings()` we present all `SESSION` local settings as `LOCAL`. Basically, we in c++ we have both a `SetScope` and `SettingScope` enum that represent the same things but differently. This should probably be fixed/changed/alleviated C++-side, but I think it makes sense to define the enum as the C-API to as `LOCAL/SESSION/GLOBAL` as that seems to be the way we want all our settings to be defined eventually (judging from recent work on settings such as https://github.com/duckdb/duckdb/pull/2609)

Since `ExtensionOption`'s currently don't store any extra state somewhere, and we are still figuring out extension lifetimes, this PR does not implement a way to set a callback to be notified when a config option changes. That will be done in a follow-up PR.