### PR TITLE
Apply `RemoveUnusedColumns` below table in out functions

### DIFF
--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -68,5 +68,6 @@ private:
 private:
 	template <class T>
 	void ClearUnusedExpressions(vector<T> &list, idx_t table_idx, bool replace = true);
+	void RemoveColumnsFromLogicalGet(LogicalGet &get);
 };
 } // namespace duckdb

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -228,89 +228,13 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 	}
 	case LogicalOperatorType::LOGICAL_GET: {
 		LogicalOperatorVisitor::VisitOperatorExpressions(op);
-		if (everything_referenced) {
-			return;
-		}
 		auto &get = op.Cast<LogicalGet>();
-		if (!get.function.projection_pushdown) {
-			return;
-		}
-
-		auto final_column_ids = get.GetColumnIds();
-
-		// Create "selection vector" of all column ids
-		vector<idx_t> proj_sel;
-		for (idx_t col_idx = 0; col_idx < final_column_ids.size(); col_idx++) {
-			proj_sel.push_back(col_idx);
-		}
-		// Create a copy that we can use to match ids later
-		auto col_sel = proj_sel;
-		// Clear unused ids, exclude filter columns that are projected out immediately
-		ClearUnusedExpressions(proj_sel, get.table_index, false);
-
-		vector<unique_ptr<Expression>> filter_expressions;
-		// for every table filter, push a column binding into the column references map to prevent the column from
-		// being projected out
-		for (auto &filter : get.table_filters.filters) {
-			optional_idx index;
-			for (idx_t i = 0; i < final_column_ids.size(); i++) {
-				if (final_column_ids[i].GetPrimaryIndex() == filter.first) {
-					index = i;
-					break;
-				}
-			}
-			if (!index.IsValid()) {
-				throw InternalException("Could not find column index for table filter");
-			}
-
-			auto column_type = get.GetColumnType(ColumnIndex(filter.first));
-
-			ColumnBinding filter_binding(get.table_index, index.GetIndex());
-			auto column_ref = make_uniq<BoundColumnRefExpression>(std::move(column_type), filter_binding);
-			auto filter_expr = filter.second->ToExpression(*column_ref);
-			if (filter_expr->IsScalar()) {
-				filter_expr = std::move(column_ref);
-			}
-			VisitExpression(&filter_expr);
-			filter_expressions.push_back(std::move(filter_expr));
-		}
-
-		// Clear unused ids, include filter columns that are projected out immediately
-		ClearUnusedExpressions(col_sel, get.table_index);
-
-		// Now set the column ids in the LogicalGet using the "selection vector"
-		vector<ColumnIndex> column_ids;
-		column_ids.reserve(col_sel.size());
-		for (auto col_sel_idx : col_sel) {
-			auto entry = column_references.find(ColumnBinding(get.table_index, col_sel_idx));
-			if (entry == column_references.end()) {
-				throw InternalException("RemoveUnusedColumns - could not find referenced column");
-			}
-			ColumnIndex new_index(final_column_ids[col_sel_idx].GetPrimaryIndex(), entry->second.child_columns);
-			column_ids.emplace_back(new_index);
-		}
-		if (column_ids.empty()) {
-			// this generally means we are only interested in whether or not anything exists in the table (e.g.
-			// EXISTS(SELECT * FROM tbl)) in this case, we just scan the row identifier column as it means we do not
-			// need to read any of the columns
-			column_ids.emplace_back(get.GetAnyColumn());
-		}
-		get.SetColumnIds(std::move(column_ids));
-
-		if (!get.function.filter_prune) {
-			return;
-		}
-		// Now set the projection cols by matching the "selection vector" that excludes filter columns
-		// with the "selection vector" that includes filter columns
-		idx_t col_idx = 0;
-		get.projection_ids.clear();
-		for (auto proj_sel_idx : proj_sel) {
-			for (; col_idx < col_sel.size(); col_idx++) {
-				if (proj_sel_idx == col_sel[col_idx]) {
-					get.projection_ids.push_back(col_idx);
-					break;
-				}
-			}
+		RemoveColumnsFromLogicalGet(get);
+		if (!op.children.empty()) {
+			// Some LOGICAL_GET operators (e.g., table in out functions) may have a
+			// child operator. So we recurse into it if it exists.
+			RemoveUnusedColumns remove(binder, context, true);
+			remove.VisitOperator(*op.children[0]);
 		}
 		return;
 	}
@@ -360,6 +284,92 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			}
 		}
 		comp_join.conditions = std::move(unique_conditions);
+	}
+}
+
+void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get) {
+	if (everything_referenced) {
+		return;
+	}
+	if (!get.function.projection_pushdown) {
+		return;
+	}
+
+	auto final_column_ids = get.GetColumnIds();
+
+	// Create "selection vector" of all column ids
+	vector<idx_t> proj_sel;
+	for (idx_t col_idx = 0; col_idx < final_column_ids.size(); col_idx++) {
+		proj_sel.push_back(col_idx);
+	}
+	// Create a copy that we can use to match ids later
+	auto col_sel = proj_sel;
+	// Clear unused ids, exclude filter columns that are projected out immediately
+	ClearUnusedExpressions(proj_sel, get.table_index, false);
+
+	vector<unique_ptr<Expression>> filter_expressions;
+	// for every table filter, push a column binding into the column references map to prevent the column from
+	// being projected out
+	for (auto &filter : get.table_filters.filters) {
+		optional_idx index;
+		for (idx_t i = 0; i < final_column_ids.size(); i++) {
+			if (final_column_ids[i].GetPrimaryIndex() == filter.first) {
+				index = i;
+				break;
+			}
+		}
+		if (!index.IsValid()) {
+			throw InternalException("Could not find column index for table filter");
+		}
+
+		auto column_type = get.GetColumnType(ColumnIndex(filter.first));
+
+		ColumnBinding filter_binding(get.table_index, index.GetIndex());
+		auto column_ref = make_uniq<BoundColumnRefExpression>(std::move(column_type), filter_binding);
+		auto filter_expr = filter.second->ToExpression(*column_ref);
+		if (filter_expr->IsScalar()) {
+			filter_expr = std::move(column_ref);
+		}
+		VisitExpression(&filter_expr);
+		filter_expressions.push_back(std::move(filter_expr));
+	}
+
+	// Clear unused ids, include filter columns that are projected out immediately
+	ClearUnusedExpressions(col_sel, get.table_index);
+
+	// Now set the column ids in the LogicalGet using the "selection vector"
+	vector<ColumnIndex> column_ids;
+	column_ids.reserve(col_sel.size());
+	for (auto col_sel_idx : col_sel) {
+		auto entry = column_references.find(ColumnBinding(get.table_index, col_sel_idx));
+		if (entry == column_references.end()) {
+			throw InternalException("RemoveUnusedColumns - could not find referenced column");
+		}
+		ColumnIndex new_index(final_column_ids[col_sel_idx].GetPrimaryIndex(), entry->second.child_columns);
+		column_ids.emplace_back(new_index);
+	}
+	if (column_ids.empty()) {
+		// this generally means we are only interested in whether or not anything exists in the table (e.g.
+		// EXISTS(SELECT * FROM tbl)) in this case, we just scan the row identifier column as it means we do not
+		// need to read any of the columns
+		column_ids.emplace_back(get.GetAnyColumn());
+	}
+	get.SetColumnIds(std::move(column_ids));
+
+	if (!get.function.filter_prune) {
+		return;
+	}
+	// Now set the projection cols by matching the "selection vector" that excludes filter columns
+	// with the "selection vector" that includes filter columns
+	idx_t col_idx = 0;
+	get.projection_ids.clear();
+	for (auto proj_sel_idx : proj_sel) {
+		for (; col_idx < col_sel.size(); col_idx++) {
+			if (proj_sel_idx == col_sel[col_idx]) {
+				get.projection_ids.push_back(col_idx);
+				break;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

When using a table in out function in a query, DuckDB's optimizer does not push down projections into the base scan. I've observed this causing slow queries in some cases because there is extra computation done for columns that are not needed in the query.

## Steps to reproduce

I created a "no-op" table in out function called `passthrough_fn()` that simply sets its output equal to its input. I loaded TPC-H data and then ran the following (this was done on SF = 100, but the exact scale factor should be irrelevant).

### Problematic query
```sql
EXPLAIN
  WITH
    t0 AS (SELECT * FROM lineitem),
    t1 AS (SELECT l_orderkey, l_quantity FROM t0)
  SELECT * FROM passthrough_fn((SELECT * FROM t1));
```

The output is

```
┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│       INOUT_FUNCTION      │
│    ────────────────────   │
│    Name: passthrough_fn   │
│                           │
│     ~600,037,902 rows     │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│         l_orderkey        │
│         l_quantity        │
│                           │
│     ~600,037,902 rows     │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         SEQ_SCAN          │
│    ────────────────────   │
│      Table: lineitem      │
│   Type: Sequential Scan   │
│                           │
│          ~0 rows          │
└───────────────────────────┘
```

### Query without the in out function
```sql
EXPLAIN
  WITH
    t0 AS (SELECT * FROM lineitem),
    t1 AS (SELECT l_orderkey, l_quantity FROM t0)
  SELECT * FROM t1;
```

The output is

```
┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│         SEQ_SCAN          │
│    ────────────────────   │
│      Table: lineitem      │
│   Type: Sequential Scan   │
│                           │
│        Projections:       │
│         l_orderkey        │
│         l_quantity        │
│                           │
│     ~600,037,902 rows     │
└───────────────────────────┘
```

## Root cause and the proposed fix

I believe the problem is that the `RemoveUnusedColumns` optimizer pass does not recurse below `LOGICAL_GET` operations. My understanding is that most `LOGICAL_GET` operations represent "base" operators like table scans or table producing functions. But since they also include table in out functions, it seems like we should be recursing to the child operation for these functions.

I modified the logic for `LOGICAL_GET` to recurse to its child operation if it is a table in out function and its children are non-empty. I wrapped the logic with a `do { .. } while (false);` to keep the early returns (replacing them with breaks).

I had looked into adding a test, but I didn't see an obvious existing in-out function that I could use (it seemed like I would need to add a table in out function to trigger the old behavior). I'd be happy to add a test if you feel that it's needed, but would appreciate a pointer to how to include a table in out function that I can use only in the tests.

## After this fix is applied

```sql
EXPLAIN
  WITH
    t0 AS (SELECT * FROM lineitem),
    t1 AS (SELECT l_orderkey, l_quantity FROM t0)
  SELECT * FROM passthrough_fn((SELECT * FROM t1));
```

returns

```
┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│       INOUT_FUNCTION      │
│    ────────────────────   │
│    Name: passthrough_fn   │
│                           │
│     ~600,037,902 rows     │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         SEQ_SCAN          │
│    ────────────────────   │
│      Table: lineitem      │
│   Type: Sequential Scan   │
│                           │
│        Projections:       │
│         l_orderkey        │
│         l_quantity        │
│                           │
│     ~600,037,902 rows     │
└───────────────────────────┘
```