### PR TITLE
[Compression] Fix issue in ZSTD decompression related to mis-interpreted segment offsets

### DIFF
--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -869,7 +869,7 @@ public:
 		scan_state.in_buffer.src = ptr;
 		scan_state.in_buffer.pos = 0;
 
-		idx_t page_size = block_manager.GetBlockSize() - sizeof(block_id_t);
+		idx_t page_size = segment.SegmentSize() - sizeof(block_id_t);
 		idx_t remaining_compressed_data = scan_state.metadata.compressed_size - scan_state.compressed_scan_count;
 		scan_state.in_buffer.size = MinValue<idx_t>(page_size, remaining_compressed_data);
 	}

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -365,7 +365,7 @@ public:
 			NewSegment();
 		}
 
-		if (current_offset + (vector_size * sizeof(string_length_t)) >= GetWritableSpace(info)) {
+		if (current_offset + (vector_size * sizeof(string_length_t)) > GetWritableSpace(info)) {
 			// Check if there is room on the current page for the vector data
 			NewPage();
 		}

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -249,6 +249,7 @@ public:
 
 public:
 	void ResetOutBuffer() {
+		D_ASSERT(GetCurrentOffset() <= GetWritableSpace(info));
 		out_buffer.dst = current_buffer_ptr;
 		out_buffer.pos = 0;
 
@@ -356,6 +357,7 @@ public:
 		current_offset = UnsafeNumericCast<page_offset_t>(
 		    AlignValue<idx_t, sizeof(string_length_t)>(UnsafeNumericCast<idx_t>(current_offset)));
 		current_buffer_ptr = current_buffer->Ptr() + current_offset;
+		D_ASSERT(GetCurrentOffset() <= GetWritableSpace(info));
 		compressed_size = 0;
 		uncompressed_size = 0;
 

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -367,7 +367,7 @@ public:
 			NewSegment();
 		}
 
-		if (current_offset + (vector_size * sizeof(string_length_t)) > GetWritableSpace(info)) {
+		if (current_offset + (vector_size * sizeof(string_length_t)) >= GetWritableSpace(info)) {
 			// Check if there is room on the current page for the vector data
 			NewPage();
 		}

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -413,10 +413,12 @@ public:
 				throw InvalidInputException("ZSTD Compression failed: %s",
 				                            duckdb_zstd::ZSTD_getErrorName(compress_result));
 			}
+			D_ASSERT(GetCurrentOffset() <= GetWritableSpace(info));
 			if (compress_result == 0) {
 				// Finished
 				break;
 			}
+
 			//! compress_result has indicated that it couldn't flush all of its data, and its not an error
 			//! So that means it needs more output_buffer to flush the data, give it a new page for that.
 			NewPage();

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -867,6 +867,10 @@ public:
 			if (duckdb_zstd::ZSTD_isError(res)) {
 				throw InvalidInputException("ZSTD Decompression failed: %s", duckdb_zstd::ZSTD_getErrorName(res));
 			}
+			if (out_buffer.pos == out_buffer.size) {
+				//! Done decompressing the relevant portion
+				break;
+			}
 			if (!res) {
 				D_ASSERT(out_buffer.pos == out_buffer.size);
 				D_ASSERT(in_buffer.pos == in_buffer.size);

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -827,7 +827,7 @@ public:
 		scan_state.in_buffer.src = scan_state.current_buffer_ptr;
 		scan_state.in_buffer.pos = 0;
 		scan_state.in_buffer.size =
-		    MinValue(metadata.compressed_size, segment.SegmentSize() - sizeof(block_id_t) - current_offset);
+		    MinValue(metadata.compressed_size, block_manager.GetBlockSize() - sizeof(block_id_t) - current_offset);
 
 		// Initialize the context for streaming decompression
 		duckdb_zstd::ZSTD_DCtx_reset(decompression_context, duckdb_zstd::ZSTD_reset_session_only);

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -492,6 +492,7 @@ public:
 			if (duckdb_zstd::ZSTD_isError(flush_result)) {
 				throw InvalidInputException("ZSTD Flush failed: %s", duckdb_zstd::ZSTD_getErrorName(flush_result));
 			}
+			D_ASSERT(GetCurrentOffset() <= GetWritableSpace(info));
 			if (flush_result == 0) {
 				// Finished
 				break;


### PR DESCRIPTION
Fix a problem where the ZSTD decompression treated regular bytes as "reserved space". Which could lead to cutting the read short to attempt to grab the next page when there wasn't one.