### PR TITLE
[swift] fix microseconds conversion to seconds

### DIFF
--- a/tools/swift/duckdb-swift/Sources/DuckDB/Extensions/Timestamp+Foundation.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Extensions/Timestamp+Foundation.swift
@@ -28,7 +28,7 @@ public extension Foundation.Date {
   
   /// Creates a date value initialized from a DuckDB Timestamp value
   init(_ timestamp: Timestamp) {
-    self.init(timeIntervalSince1970: TimeInterval(timestamp.microseconds) * 1e-3)
+    self.init(timeIntervalSince1970: TimeInterval(timestamp.microseconds) * 1e-6)
   }
 }
 
@@ -36,6 +36,6 @@ public extension Timestamp {
   
   /// Creates a timestamp value initialized from a Foundation Date
   init(_ date: Foundation.Date) {
-    self.init(microseconds: Int64(date.timeIntervalSince1970 * 1e3))
+    self.init(microseconds: Int64(date.timeIntervalSince1970 * 1e6))
   }
 }

--- a/tools/swift/duckdb-swift/Tests/DuckDBTests/FoundationTests.swift
+++ b/tools/swift/duckdb-swift/Tests/DuckDBTests/FoundationTests.swift
@@ -23,19 +23,28 @@
 //  IN THE SOFTWARE.
 
 import Foundation
+import XCTest
+@testable import DuckDB
 
-public extension Foundation.Date {
-  
-  /// Creates a date value initialized from a DuckDB Time value
-  init(_ date: Time) {
-    self.init(timeIntervalSince1970: TimeInterval(date.microseconds) * 1e-6)
-  }
-}
-
-public extension Time {
-  
-  /// Creates a time value initialized from a Foundation Date
-  init(_ date: Foundation.Date) {
-    self.init(microseconds: Int64(date.timeIntervalSince1970 * 1e6))
-  }
+final class FoundationTests: XCTestCase {
+    func test_time_to_date() {
+        let time = Time(microseconds: Int64(USEC_PER_SEC))
+        let date = Foundation.Date(time)
+        XCTAssertEqual(date.timeIntervalSince1970, 1)
+    }
+    func test_date_to_time() throws {
+        let date = Foundation.Date(timeIntervalSince1970: 1)
+        let time = Time(date)
+        XCTAssertEqual(time.microseconds, Int64(USEC_PER_SEC))
+    }
+    func test_timestamp_to_date() throws {
+        let time = Timestamp(microseconds: Int64(USEC_PER_SEC))
+        let date = Foundation.Date(time)
+        XCTAssertEqual(date.timeIntervalSince1970, 1)
+    }
+    func test_date_to_timestamp() throws {
+        let date = Foundation.Date(timeIntervalSince1970: 1)
+        let time = Timestamp(date)
+        XCTAssertEqual(time.microseconds, Int64(USEC_PER_SEC))
+    }
 }


### PR DESCRIPTION
This pr fix the bridge between duckdb-swift and foundation where time intervals are expressed in seconds but currently converting microseconds to milliseconds instead of seconds. 

fixes https://github.com/duckdb/duckdb-swift/issues/22