### PR TITLE
Remove empty lines at the start of code blocks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,6 +27,7 @@ AlwaysBreakTemplateDeclarations: Yes
 IncludeBlocks: Regroup
 Language: Cpp
 AccessModifierOffset: -4
+KeepEmptyLinesAtTheStartOfBlocks: false
 ---
 Language: Java
 SpaceAfterCStyleCast: true

--- a/extension/core_functions/aggregate/distributive/bitagg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitagg.cpp
@@ -166,7 +166,6 @@ struct BitStringBitwiseOperation : public BitwiseOperation {
 };
 
 struct BitStringAndOperation : public BitStringBitwiseOperation {
-
 	template <class INPUT_TYPE, class STATE>
 	static void Execute(STATE &state, INPUT_TYPE input) {
 		Bit::BitwiseAnd(input, state.value, state.value);
@@ -174,7 +173,6 @@ struct BitStringAndOperation : public BitStringBitwiseOperation {
 };
 
 struct BitStringOrOperation : public BitStringBitwiseOperation {
-
 	template <class INPUT_TYPE, class STATE>
 	static void Execute(STATE &state, INPUT_TYPE input) {
 		Bit::BitwiseOr(input, state.value, state.value);

--- a/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
@@ -235,7 +235,6 @@ idx_t BitStringAggOperation::GetRange(uhugeint_t min, uhugeint_t max) {
 
 unique_ptr<BaseStatistics> BitstringPropagateStats(ClientContext &context, BoundAggregateExpression &expr,
                                                    AggregateStatisticsInput &input) {
-
 	if (NumericStats::HasMinMax(input.child_stats[0])) {
 		auto &bind_agg_data = input.bind_data->Cast<BitstringAggBindData>();
 		bind_agg_data.min = NumericStats::Min(input.child_stats[0]);

--- a/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
+++ b/extension/core_functions/aggregate/holistic/approximate_quantile.cpp
@@ -294,7 +294,6 @@ AggregateFunction GetApproximateQuantileAggregate(const LogicalType &type) {
 
 template <class CHILD_TYPE>
 struct ApproxQuantileListOperation : public ApproxQuantileOperation {
-
 	template <class RESULT_TYPE, class STATE>
 	static void Finalize(STATE &state, RESULT_TYPE &target, AggregateFinalizeData &finalize_data) {
 		if (state.pos == 0) {

--- a/extension/core_functions/aggregate/holistic/mad.cpp
+++ b/extension/core_functions/aggregate/holistic/mad.cpp
@@ -57,7 +57,6 @@ struct QuantileReuseUpdater {
 };
 
 void ReuseIndexes(idx_t *index, const SubFrames &currs, const SubFrames &prevs) {
-
 	//  Copy overlapping indices by scanning the previous set and copying down into holes.
 	//	We copy instead of leaving gaps in case there are fewer values in the current frame.
 	FrameSet prev_set(prevs);

--- a/extension/core_functions/aggregate/nested/histogram.cpp
+++ b/extension/core_functions/aggregate/nested/histogram.cpp
@@ -61,7 +61,6 @@ struct StringMapType {
 template <class OP, class T, class MAP_TYPE>
 void HistogramUpdateFunction(Vector inputs[], AggregateInputData &aggr_input, idx_t input_count, Vector &state_vector,
                              idx_t count) {
-
 	D_ASSERT(input_count == 1);
 
 	auto &input = inputs[0];
@@ -209,7 +208,6 @@ AggregateFunction GetHistogramFunction(const LogicalType &type) {
 template <bool IS_ORDERED = true>
 unique_ptr<FunctionData> HistogramBindFunction(ClientContext &context, AggregateFunction &function,
                                                vector<unique_ptr<Expression>> &arguments) {
-
 	D_ASSERT(arguments.size() == 1);
 
 	if (arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {

--- a/extension/core_functions/aggregate/nested/list.cpp
+++ b/extension/core_functions/aggregate/nested/list.cpp
@@ -47,7 +47,6 @@ struct ListFunction {
 
 void ListUpdateFunction(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count, Vector &state_vector,
                         idx_t count) {
-
 	D_ASSERT(input_count == 1);
 	auto &input = inputs[0];
 	RecursiveUnifiedVectorFormat input_data;
@@ -75,7 +74,6 @@ void ListAbsorbFunction(Vector &states_vector, Vector &combined, AggregateInputD
 
 	auto combined_ptr = FlatVector::GetData<ListAggState *>(combined);
 	for (idx_t i = 0; i < count; i++) {
-
 		auto &state = *states_ptr[states_data.sel->get_index(i)];
 		if (state.linked_list.total_capacity == 0) {
 			// NULL, no need to append
@@ -98,7 +96,6 @@ void ListAbsorbFunction(Vector &states_vector, Vector &combined, AggregateInputD
 
 void ListFinalize(Vector &states_vector, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
                   idx_t offset) {
-
 	UnifiedVectorFormat states_data;
 	states_vector.ToUnifiedFormat(count, states_data);
 	auto states = UnifiedVectorFormat::GetData<ListAggState *>(states_data);
@@ -132,7 +129,6 @@ void ListFinalize(Vector &states_vector, AggregateInputData &aggr_input_data, Ve
 	ListVector::Reserve(result, total_len);
 	auto &result_child = ListVector::GetEntry(result);
 	for (idx_t i = 0; i < count; i++) {
-
 		auto &state = *states[states_data.sel->get_index(i)];
 		const auto rid = i + offset;
 		if (state.linked_list.total_capacity == 0) {
@@ -147,7 +143,6 @@ void ListFinalize(Vector &states_vector, AggregateInputData &aggr_input_data, Ve
 }
 
 void ListCombineFunction(Vector &states_vector, Vector &combined, AggregateInputData &aggr_input_data, idx_t count) {
-
 	//	Can we use destructive combining?
 	if (aggr_input_data.combine_type == AggregateCombineType::ALLOW_DESTRUCTIVE) {
 		ListAbsorbFunction(states_vector, combined, aggr_input_data, count);
@@ -182,7 +177,6 @@ void ListCombineFunction(Vector &states_vector, Vector &combined, AggregateInput
 
 unique_ptr<FunctionData> ListBindFunction(ClientContext &context, AggregateFunction &function,
                                           vector<unique_ptr<Expression>> &arguments) {
-
 	function.return_type = LogicalType::LIST(arguments[0]->return_type);
 	return make_uniq<ListBindData>(function.return_type);
 }

--- a/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
@@ -300,7 +300,6 @@ struct QuantileIncluded {
 };
 
 struct QuantileSortTree {
-
 	unique_ptr<WindowIndexTree> index_tree;
 
 	QuantileSortTree(AggregateInputData &aggr_input_data, const WindowPartitionInput &partition) {

--- a/extension/core_functions/include/core_functions/array_kernels.hpp
+++ b/extension/core_functions/include/core_functions/array_kernels.hpp
@@ -13,7 +13,6 @@ struct InnerProductOp {
 
 	template <class TYPE>
 	static TYPE Operation(const TYPE *lhs_data, const TYPE *rhs_data, const idx_t count) {
-
 		TYPE result = 0;
 
 		auto lhs_ptr = lhs_data;
@@ -43,7 +42,6 @@ struct CosineSimilarityOp {
 
 	template <class TYPE>
 	static TYPE Operation(const TYPE *lhs_data, const TYPE *rhs_data, const idx_t count) {
-
 		TYPE distance = 0;
 		TYPE norm_l = 0;
 		TYPE norm_r = 0;
@@ -78,7 +76,6 @@ struct DistanceSquaredOp {
 
 	template <class TYPE>
 	static TYPE Operation(const TYPE *lhs_data, const TYPE *rhs_data, const idx_t count) {
-
 		TYPE distance = 0;
 
 		auto l_ptr = lhs_data;

--- a/extension/core_functions/lambda_functions.cpp
+++ b/extension/core_functions/lambda_functions.cpp
@@ -18,7 +18,6 @@ struct LambdaExecuteInfo {
 	LambdaExecuteInfo(ClientContext &context, const Expression &lambda_expr, const DataChunk &args,
 	                  const bool has_index, const Vector &child_vector)
 	    : has_index(has_index) {
-
 		expr_executor = make_uniq<ExpressionExecutor>(context, lambda_expr);
 
 		// get the input types for the input chunk
@@ -103,7 +102,6 @@ struct ListFilterFunctor {
 	//! Uses the lambda vector to filter the incoming list and to append the filtered list to the result vector
 	static void AppendResult(Vector &result, Vector &lambda_vector, const idx_t elem_cnt, list_entry_t *result_entries,
 	                         ListFilterInfo &info, LambdaExecuteInfo &execute_info) {
-
 		idx_t count = 0;
 		SelectionVector sel(elem_cnt);
 		UnifiedVectorFormat lambda_data;
@@ -184,7 +182,6 @@ LambdaFunctions::GetMutableColumnInfo(vector<LambdaFunctions::ColumnInfo> &data)
 static void ExecuteExpression(const idx_t elem_cnt, const LambdaFunctions::ColumnInfo &column_info,
                               const vector<LambdaFunctions::ColumnInfo> &column_infos, const Vector &index_vector,
                               LambdaExecuteInfo &info) {
-
 	info.input_chunk.SetCardinality(elem_cnt);
 	info.lambda_chunk.SetCardinality(elem_cnt);
 
@@ -203,7 +200,6 @@ static void ExecuteExpression(const idx_t elem_cnt, const LambdaFunctions::Colum
 	// (slice and) reference the other columns
 	vector<Vector> slices;
 	for (idx_t i = 0; i < column_infos.size(); i++) {
-
 		if (column_infos[i].vector.get().GetVectorType() == VectorType::CONSTANT_VECTOR) {
 			// only reference constant vectorsl
 			info.input_chunk.data[i + slice_offset].Reference(column_infos[i].vector);
@@ -273,7 +269,6 @@ LogicalType LambdaFunctions::BindBinaryChildren(const vector<LogicalType> &funct
 
 template <class FUNCTION_FUNCTOR>
 static void ExecuteLambda(DataChunk &args, ExpressionState &state, Vector &result) {
-
 	bool result_is_null = false;
 	LambdaFunctions::LambdaInfo info(args, state, result, result_is_null);
 	if (result_is_null) {
@@ -302,7 +297,6 @@ static void ExecuteLambda(DataChunk &args, ExpressionState &state, Vector &resul
 	idx_t elem_cnt = 0;
 	idx_t offset = 0;
 	for (idx_t row_idx = 0; row_idx < info.row_count; row_idx++) {
-
 		auto list_idx = info.list_column_format.sel->get_index(row_idx);
 		const auto &list_entry = info.list_entries[list_idx];
 
@@ -322,10 +316,8 @@ static void ExecuteLambda(DataChunk &args, ExpressionState &state, Vector &resul
 
 		// iterate the elements of the current list and create the corresponding selection vectors
 		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
-
 			// reached STANDARD_VECTOR_SIZE elements
 			if (elem_cnt == STANDARD_VECTOR_SIZE) {
-
 				execute_info.lambda_chunk.Reset();
 				ExecuteExpression(elem_cnt, child_info, info.column_infos, index_vector, execute_info);
 				auto &lambda_vector = execute_info.lambda_chunk.data[0];

--- a/extension/core_functions/scalar/array/array_functions.cpp
+++ b/extension/core_functions/scalar/array/array_functions.cpp
@@ -6,7 +6,6 @@ namespace duckdb {
 
 static unique_ptr<FunctionData> ArrayGenericBinaryBind(ClientContext &context, ScalarFunction &bound_function,
                                                        vector<unique_ptr<Expression>> &arguments) {
-
 	const auto &lhs_type = arguments[0]->return_type;
 	const auto &rhs_type = arguments[1]->return_type;
 

--- a/extension/core_functions/scalar/date/date_sub.cpp
+++ b/extension/core_functions/scalar/date/date_sub.cpp
@@ -37,7 +37,6 @@ struct DateSub {
 	struct MonthOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA start_ts, TB end_ts) {
-
 			if (start_ts > end_ts) {
 				return -MonthOperator::Operation<TA, TB, TR>(end_ts, start_ts);
 			}

--- a/extension/core_functions/scalar/date/make_date.cpp
+++ b/extension/core_functions/scalar/date/make_date.cpp
@@ -65,7 +65,6 @@ void ExecuteStructMakeDate(DataChunk &input, ExpressionState &state, Vector &res
 struct MakeTimeOperator {
 	template <typename HH, typename MM, typename SS, typename RESULT_TYPE>
 	static RESULT_TYPE Operation(HH hh, MM mm, SS ss) {
-
 		auto hh_32 = Cast::Operation<HH, int32_t>(hh);
 		auto mm_32 = Cast::Operation<MM, int32_t>(mm);
 		// Have to check this separately because safe casting of DOUBLE => INT32 can round.

--- a/extension/core_functions/scalar/date/time_bucket.cpp
+++ b/extension/core_functions/scalar/date/time_bucket.cpp
@@ -16,7 +16,6 @@ namespace duckdb {
 namespace {
 
 struct TimeBucket {
-
 	// Use 2000-01-03 00:00:00 (Monday) as origin when bucket_width is days, hours, ... for TimescaleDB compatibility
 	// There are 10959 days between 1970-01-01 and 2000-01-03
 	constexpr static const int64_t DEFAULT_ORIGIN_MICROS = 10959 * Interval::MICROS_PER_DAY;

--- a/extension/core_functions/scalar/generic/current_setting.cpp
+++ b/extension/core_functions/scalar/generic/current_setting.cpp
@@ -33,7 +33,6 @@ void CurrentSettingFunction(DataChunk &args, ExpressionState &state, Vector &res
 
 unique_ptr<FunctionData> CurrentSettingBind(ClientContext &context, ScalarFunction &bound_function,
                                             vector<unique_ptr<Expression>> &arguments) {
-
 	auto &key_child = arguments[0];
 	if (key_child->return_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();

--- a/extension/core_functions/scalar/list/array_slice.cpp
+++ b/extension/core_functions/scalar/list/array_slice.cpp
@@ -161,7 +161,6 @@ template <typename INPUT_TYPE, typename INDEX_TYPE, typename OP>
 void ExecuteConstantSlice(Vector &result, Vector &str_vector, Vector &begin_vector, Vector &end_vector,
                           optional_ptr<Vector> step_vector, const idx_t count, SelectionVector &sel, idx_t &sel_idx,
                           optional_ptr<Vector> result_child_vector, bool begin_is_empty, bool end_is_empty) {
-
 	// check all this nullness early
 	auto str_valid = !ConstantVector::IsNull(str_vector);
 	auto begin_valid = !ConstantVector::IsNull(begin_vector);

--- a/extension/core_functions/scalar/list/flatten.cpp
+++ b/extension/core_functions/scalar/list/flatten.cpp
@@ -10,7 +10,6 @@ namespace duckdb {
 namespace {
 
 void ListFlattenFunction(DataChunk &args, ExpressionState &, Vector &result) {
-
 	const auto flat_list_data = FlatVector::GetData<list_entry_t>(result);
 	auto &flat_list_mask = FlatVector::Validity(result);
 

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -187,7 +187,6 @@ struct UniqueFunctor {
 
 		auto result_data = FlatVector::GetData<uint64_t>(result);
 		for (idx_t i = 0; i < count; i++) {
-
 			auto state = states[sdata.sel->get_index(i)];
 
 			if (!state->hist) {
@@ -253,7 +252,6 @@ void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vector &res
 	idx_t states_idx = 0;
 
 	for (idx_t i = 0; i < count; i++) {
-
 		// initialize the state for this list
 		auto state_ptr = state_buffer.get() + size * i;
 		states[i] = state_ptr;
@@ -390,7 +388,6 @@ template <bool IS_AGGR = false>
 unique_ptr<FunctionData>
 ListAggregatesBindFunction(ClientContext &context, ScalarFunction &bound_function, const LogicalType &list_child_type,
                            AggregateFunction &aggr_function, vector<unique_ptr<Expression>> &arguments) {
-
 	// create the child expression and its type
 	vector<unique_ptr<Expression>> children;
 	auto expr = make_uniq<BoundConstantExpression>(Value(list_child_type));
@@ -423,7 +420,6 @@ ListAggregatesBindFunction(ClientContext &context, ScalarFunction &bound_functio
 template <bool IS_AGGR = false>
 unique_ptr<FunctionData> ListAggregatesBind(ClientContext &context, ScalarFunction &bound_function,
                                             vector<unique_ptr<Expression>> &arguments) {
-
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 
 	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
@@ -493,7 +489,6 @@ unique_ptr<FunctionData> ListAggregatesBind(ClientContext &context, ScalarFuncti
 
 unique_ptr<FunctionData> ListAggregateBind(ClientContext &context, ScalarFunction &bound_function,
                                            vector<unique_ptr<Expression>> &arguments) {
-
 	// the list column and the name of the aggregate function
 	D_ASSERT(bound_function.arguments.size() >= 2);
 	D_ASSERT(arguments.size() >= 2);

--- a/extension/core_functions/scalar/list/list_filter.cpp
+++ b/extension/core_functions/scalar/list/list_filter.cpp
@@ -7,7 +7,6 @@ namespace duckdb {
 
 static unique_ptr<FunctionData> ListFilterBind(ClientContext &context, ScalarFunction &bound_function,
                                                vector<unique_ptr<Expression>> &arguments) {
-
 	// the list column and the bound lambda expression
 	D_ASSERT(arguments.size() == 2);
 	if (arguments[1]->GetExpressionClass() != ExpressionClass::BOUND_LAMBDA) {

--- a/extension/core_functions/scalar/list/list_has_any_or_all.cpp
+++ b/extension/core_functions/scalar/list/list_has_any_or_all.cpp
@@ -7,7 +7,6 @@
 namespace duckdb {
 
 static void ListHasAnyFunction(DataChunk &args, ExpressionState &, Vector &result) {
-
 	auto &l_vec = args.data[0];
 	auto &r_vec = args.data[1];
 
@@ -63,7 +62,6 @@ static void ListHasAnyFunction(DataChunk &args, ExpressionState &, Vector &resul
 
 		    // Use the smaller list to build the set
 		    if (r_list.length < l_list.length) {
-
 			    build_list = r_list;
 			    probe_list = l_list;
 
@@ -96,7 +94,6 @@ static void ListHasAnyFunction(DataChunk &args, ExpressionState &, Vector &resul
 }
 
 static void ListHasAllFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-
 	const auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	const auto swap = func_expr.function.name == "<@";
 

--- a/extension/core_functions/scalar/list/list_reduce.cpp
+++ b/extension/core_functions/scalar/list/list_reduce.cpp
@@ -175,7 +175,6 @@ bool ExecuteReduce(const idx_t loops, ReduceExecuteInfo &execute_info, LambdaFun
 
 unique_ptr<FunctionData> ListReduceBind(ClientContext &context, ScalarFunction &bound_function,
                                         vector<unique_ptr<Expression>> &arguments) {
-
 	// the list column and the bound lambda expression
 	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
 	if (arguments[1]->GetExpressionClass() != ExpressionClass::BOUND_LAMBDA) {

--- a/extension/core_functions/scalar/list/list_sort.cpp
+++ b/extension/core_functions/scalar/list/list_sort.cpp
@@ -37,7 +37,6 @@ ListSortBindData::ListSortBindData(OrderType order_type_p, OrderByNullType null_
                                    ClientContext &context_p)
     : order_type(order_type_p), null_order(null_order_p), return_type(return_type_p), child_type(child_type_p),
       is_grade_up(is_grade_up_p), context(context_p) {
-
 	// get the vector types
 	types.emplace_back(LogicalType::USMALLINT);
 	types.emplace_back(child_type);
@@ -71,7 +70,6 @@ static void SinkDataChunk(const Sort &sort, ExecutionContext &context, OperatorS
                           Vector *child_vector, SelectionVector &sel, idx_t offset_lists_indices,
                           vector<LogicalType> &types, Vector &payload_vector, bool &data_to_sort,
                           Vector &lists_indices) {
-
 	// slice the child vector
 	Vector slice(*child_vector, sel, offset_lists_indices);
 
@@ -256,7 +254,6 @@ static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &re
 static unique_ptr<FunctionData> ListSortBind(ClientContext &context, ScalarFunction &bound_function,
                                              vector<unique_ptr<Expression>> &arguments, OrderType &order,
                                              OrderByNullType &null_order) {
-
 	LogicalType child_type;
 	if (arguments[0]->return_type == LogicalTypeId::UNKNOWN) {
 		bound_function.arguments[0] = LogicalTypeId::UNKNOWN;
@@ -286,7 +283,6 @@ static T GetOrder(ClientContext &context, Expression &expr) {
 
 static unique_ptr<FunctionData> ListGradeUpBind(ClientContext &context, ScalarFunction &bound_function,
                                                 vector<unique_ptr<Expression>> &arguments) {
-
 	D_ASSERT(!arguments.empty() && arguments.size() <= 3);
 	auto order = OrderType::ORDER_DEFAULT;
 	auto null_order = OrderByNullType::ORDER_DEFAULT;

--- a/extension/core_functions/scalar/list/list_transform.cpp
+++ b/extension/core_functions/scalar/list/list_transform.cpp
@@ -7,7 +7,6 @@ namespace duckdb {
 
 static unique_ptr<FunctionData> ListTransformBind(ClientContext &context, ScalarFunction &bound_function,
                                                   vector<unique_ptr<Expression>> &arguments) {
-
 	// the list column and the bound lambda expression
 	D_ASSERT(arguments.size() == 2);
 	if (arguments[1]->GetExpressionClass() != ExpressionClass::BOUND_LAMBDA) {

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -309,7 +309,6 @@ unique_ptr<BaseStatistics> ListValueStats(ClientContext &context, FunctionStatis
 } // namespace
 
 ScalarFunctionSet ListValueFun::GetFunctions() {
-
 	ScalarFunctionSet set("list_value");
 
 	// Overload for 0 arguments, which returns an empty list.

--- a/extension/core_functions/scalar/map/map.cpp
+++ b/extension/core_functions/scalar/map/map.cpp
@@ -38,7 +38,6 @@ static bool MapIsNull(DataChunk &chunk) {
 }
 
 static void MapFunction(DataChunk &args, ExpressionState &, Vector &result) {
-
 	// internal MAP representation
 	// - LIST-vector that contains STRUCTs as child entries
 	// - STRUCTs have exactly two fields, a key-field, and a value-field
@@ -107,7 +106,6 @@ static void MapFunction(DataChunk &args, ExpressionState &, Vector &result) {
 	idx_t offset = 0;
 
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-
 		auto keys_idx = keys_data.sel->get_index(row_idx);
 		auto values_idx = values_data.sel->get_index(row_idx);
 		auto result_idx = result_data.sel->get_index(row_idx);
@@ -128,7 +126,6 @@ static void MapFunction(DataChunk &args, ExpressionState &, Vector &result) {
 		// set the selection vectors and perform a duplicate key check
 		value_set_t unique_keys;
 		for (idx_t child_idx = 0; child_idx < keys_entry.length; child_idx++) {
-
 			auto key_idx = keys_child_data.sel->get_index(keys_entry.offset + child_idx);
 			auto value_idx = values_child_data.sel->get_index(values_entry.offset + child_idx);
 
@@ -173,7 +170,6 @@ static void MapFunction(DataChunk &args, ExpressionState &, Vector &result) {
 }
 
 ScalarFunctionSet MapFun::GetFunctions() {
-
 	ScalarFunction empty_func({}, LogicalType::MAP(LogicalType::SQLNULL, LogicalType::SQLNULL), MapFunction);
 	BaseScalarFunction::SetReturnsError(empty_func);
 

--- a/extension/core_functions/scalar/map/map_concat.cpp
+++ b/extension/core_functions/scalar/map/map_concat.cpp
@@ -132,7 +132,6 @@ bool IsEmptyMap(const LogicalType &map) {
 
 unique_ptr<FunctionData> MapConcatBind(ClientContext &context, ScalarFunction &bound_function,
                                        vector<unique_ptr<Expression>> &arguments) {
-
 	auto arg_count = arguments.size();
 	if (arg_count < 2) {
 		throw InvalidInputException("The provided amount of arguments is incorrect, please provide 2 or more maps");

--- a/extension/core_functions/scalar/map/map_entries.cpp
+++ b/extension/core_functions/scalar/map/map_entries.cpp
@@ -29,7 +29,6 @@ static void MapEntriesFunction(DataChunk &args, ExpressionState &state, Vector &
 }
 
 ScalarFunction MapEntriesFun::GetFunction() {
-
 	auto key_type = LogicalType::TEMPLATE("K");
 	auto val_type = LogicalType::TEMPLATE("V");
 	auto map_type = LogicalType::MAP(key_type, val_type);

--- a/extension/core_functions/scalar/string/hex.cpp
+++ b/extension/core_functions/scalar/string/hex.cpp
@@ -89,7 +89,6 @@ struct HexStrOperator {
 struct HexIntegralOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-
 		auto num_leading_zero = CountZeros<uint64_t>::Leading(static_cast<uint64_t>(input));
 		idx_t num_bits_to_check = 64 - num_leading_zero;
 		D_ASSERT(num_bits_to_check <= sizeof(INPUT_TYPE) * 8);
@@ -119,7 +118,6 @@ struct HexIntegralOperator {
 struct HexHugeIntOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-
 		idx_t num_leading_zero = CountZeros<hugeint_t>::Leading(UnsafeNumericCast<hugeint_t>(input));
 		idx_t buffer_size = sizeof(INPUT_TYPE) * 2 - (num_leading_zero / 4);
 
@@ -146,7 +144,6 @@ struct HexHugeIntOperator {
 struct HexUhugeIntOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-
 		idx_t num_leading_zero = CountZeros<uhugeint_t>::Leading(UnsafeNumericCast<uhugeint_t>(input));
 		idx_t buffer_size = sizeof(INPUT_TYPE) * 2 - (num_leading_zero / 4);
 
@@ -204,7 +201,6 @@ struct BinaryStrOperator {
 struct BinaryIntegralOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-
 		auto num_leading_zero = CountZeros<uint64_t>::Leading(static_cast<uint64_t>(input));
 		idx_t num_bits_to_check = 64 - num_leading_zero;
 		D_ASSERT(num_bits_to_check <= sizeof(INPUT_TYPE) * 8);

--- a/extension/core_functions/scalar/string/starts_with.cpp
+++ b/extension/core_functions/scalar/string/starts_with.cpp
@@ -17,7 +17,6 @@ static bool StartsWith(const unsigned char *haystack, idx_t haystack_size, const
 }
 
 static bool StartsWith(const string_t &haystack_s, const string_t &needle_s) {
-
 	auto haystack = const_uchar_ptr_cast(haystack_s.GetData());
 	auto haystack_size = haystack_s.GetSize();
 	auto needle = const_uchar_ptr_cast(needle_s.GetData());

--- a/extension/core_functions/scalar/union/union_tag.cpp
+++ b/extension/core_functions/scalar/union/union_tag.cpp
@@ -10,7 +10,6 @@ namespace {
 
 unique_ptr<FunctionData> UnionTagBind(ClientContext &context, ScalarFunction &bound_function,
                                       vector<unique_ptr<Expression>> &arguments) {
-
 	if (arguments.empty()) {
 		throw BinderException("Missing required arguments for union_tag function.");
 	}

--- a/extension/core_functions/scalar/union/union_value.cpp
+++ b/extension/core_functions/scalar/union/union_value.cpp
@@ -40,7 +40,6 @@ void UnionValueFunction(DataChunk &args, ExpressionState &state, Vector &result)
 
 unique_ptr<FunctionData> UnionValueBind(ClientContext &context, ScalarFunction &bound_function,
                                         vector<unique_ptr<Expression>> &arguments) {
-
 	if (arguments.size() != 1) {
 		throw BinderException("union_value takes exactly one argument");
 	}

--- a/extension/delta/src/functions/delta_scan.cpp
+++ b/extension/delta/src/functions/delta_scan.cpp
@@ -309,7 +309,6 @@ bool DeltaMultiFileReader::Bind(MultiFileOptions &options, MultiFileList &files,
 void DeltaMultiFileReader::BindOptions(MultiFileOptions &options, MultiFileList &files,
                                        vector<LogicalType> &return_types, vector<string> &names,
                                        MultiFileReaderBindData &bind_data) {
-
 	// Disable all other multifilereader options
 	options.auto_detect_hive_partitioning = false;
 	options.hive_partitioning = false;

--- a/extension/demo_capi/capi_demo.cpp
+++ b/extension/demo_capi/capi_demo.cpp
@@ -2,7 +2,6 @@
 #include "duckdb_extension.h"
 
 DUCKDB_EXTENSION_ENTRYPOINT(duckdb_connection connection, duckdb_extension_info info, duckdb_extension_access *access) {
-
 	// Register a demo function
 	RegisterAddNumbersFunction(connection);
 

--- a/extension/icu/icu-dateadd.cpp
+++ b/extension/icu/icu-dateadd.cpp
@@ -219,7 +219,6 @@ interval_t ICUCalendarAge::Operation(timestamp_t end_date, timestamp_t start_dat
 }
 
 struct ICUDateAdd : public ICUDateFunc {
-
 	template <typename TA, typename TR, typename OP>
 	static void ExecuteUnary(DataChunk &args, ExpressionState &state, Vector &result) {
 		D_ASSERT(args.ColumnCount() == 1);

--- a/extension/icu/icu-datefunc.cpp
+++ b/extension/icu/icu-datefunc.cpp
@@ -16,7 +16,6 @@ ICUDateFunc::BindData::BindData(const BindData &other)
 
 ICUDateFunc::BindData::BindData(const string &tz_setting_p, const string &cal_setting_p)
     : tz_setting(tz_setting_p), cal_setting(cal_setting_p) {
-
 	InitCalendar();
 }
 

--- a/extension/icu/icu-datesub.cpp
+++ b/extension/icu/icu-datesub.cpp
@@ -9,7 +9,6 @@
 namespace duckdb {
 
 struct ICUCalendarSub : public ICUDateFunc {
-
 	//	ICU only has 32 bit precision for date parts, so it can overflow a high resolution.
 	//	Since there is no difference between ICU and the obvious calculations,
 	//	we make these using the DuckDB internal type.
@@ -192,7 +191,6 @@ ICUDateFunc::part_sub_t ICUDateFunc::SubtractFactory(DatePartSpecifier type) {
 // MS-SQL differences can be computed using ICU by truncating both arguments
 // to the desired part precision and then applying ICU subtraction/difference
 struct ICUCalendarDiff : public ICUDateFunc {
-
 	template <typename T>
 	static int64_t DifferenceFunc(icu::Calendar *calendar, timestamp_t start_date, timestamp_t end_date,
 	                              part_trunc_t trunc_func, part_sub_t sub_func) {

--- a/extension/icu/icu-list-range.cpp
+++ b/extension/icu/icu-list-range.cpp
@@ -181,7 +181,6 @@ struct ICUListRange : public ICUDateFunc {
 	}
 
 	static void AddICUListRangeFunction(ExtensionLoader &loader) {
-
 		ScalarFunctionSet range("range");
 		range.AddFunction(ScalarFunction({LogicalType::TIMESTAMP_TZ, LogicalType::TIMESTAMP_TZ, LogicalType::INTERVAL},
 		                                 LogicalType::LIST(LogicalType::TIMESTAMP_TZ), ICUListRangeFunction<false>,

--- a/extension/icu/icu-timebucket.cpp
+++ b/extension/icu/icu-timebucket.cpp
@@ -16,7 +16,6 @@
 namespace duckdb {
 
 struct ICUTimeBucket : public ICUDateFunc {
-
 	// Use 2000-01-03 00:00:00 (Monday) as origin when bucket_width is days, hours, ... for TimescaleDB compatibility
 	// There are 10959 days between 1970-01-01 and 2000-01-03
 	constexpr static const int64_t DEFAULT_ORIGIN_MICROS_1 = 10959 * Interval::MICROS_PER_DAY;

--- a/extension/icu/icu-timezone.cpp
+++ b/extension/icu/icu-timezone.cpp
@@ -267,7 +267,6 @@ struct ICUToNaiveTimestamp : public ICUDateFunc {
 };
 
 struct ICULocalTimestampFunc : public ICUDateFunc {
-
 	struct BindDataNow : public BindData {
 		explicit BindDataNow(ClientContext &context) : BindData(context) {
 			now = MetaTransaction::Get(context).start_timestamp;

--- a/extension/icu/icu_extension.cpp
+++ b/extension/icu/icu_extension.cpp
@@ -362,7 +362,6 @@ static void SetICUCalendar(ClientContext &context, SetScope scope, Value &parame
 }
 
 static void LoadInternal(ExtensionLoader &loader) {
-
 	// iterate over all the collations
 	int32_t count;
 	auto locales = icu::Collator::getAvailableLocales(count);

--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -473,7 +473,6 @@ static void CreateValuesList(const StructNames &names, yyjson_mut_doc *doc, yyjs
 
 static void CreateValuesArray(const StructNames &names, yyjson_mut_doc *doc, yyjson_mut_val *vals[], Vector &value_v,
                               idx_t count) {
-
 	value_v.Flatten(count);
 
 	// Initialize array for the nested values

--- a/extension/json/json_functions/json_table_in_out.cpp
+++ b/extension/json/json_functions/json_table_in_out.cpp
@@ -284,7 +284,6 @@ static void InitializeLocalState(JSONTableInOutLocalState &lstate, DataChunk &in
 template <JSONTableInOutType TYPE>
 static bool JSONTableInOutHandleValue(JSONTableInOutLocalState &lstate, JSONTableInOutResult &result,
                                       idx_t &child_index, size_t &idx, yyjson_val *child_key, yyjson_val *child_val) {
-
 	if (idx < child_index) {
 		return false; // Continue: Get back to where we left off
 	}

--- a/extension/parquet/include/parquet_statistics.hpp
+++ b/extension/parquet/include/parquet_statistics.hpp
@@ -23,7 +23,6 @@ struct ParquetColumnSchema;
 class ResizeableBuffer;
 
 struct ParquetStatisticsUtils {
-
 	static unique_ptr<BaseStatistics> TransformColumnStatistics(const ParquetColumnSchema &reader,
 	                                                            const vector<ColumnChunk> &columns, bool can_have_nan);
 

--- a/extension/parquet/include/parquet_support.hpp
+++ b/extension/parquet/include/parquet_support.hpp
@@ -118,7 +118,6 @@ public:
 };
 
 class ColumnReader {
-
 public:
 	ColumnReader(const EncodingKey &ek, StripeStreams &stripe);
 

--- a/extension/parquet/include/reader/interval_column_reader.hpp
+++ b/extension/parquet/include/reader/interval_column_reader.hpp
@@ -57,7 +57,6 @@ struct IntervalValueConversion {
 };
 
 class IntervalColumnReader : public TemplatedColumnReader<interval_t, IntervalValueConversion> {
-
 public:
 	IntervalColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
 	    : TemplatedColumnReader<interval_t, IntervalValueConversion>(reader, schema) {

--- a/extension/parquet/include/reader/templated_column_reader.hpp
+++ b/extension/parquet/include/reader/templated_column_reader.hpp
@@ -79,7 +79,6 @@ public:
 template <class PARQUET_PHYSICAL_TYPE, class DUCKDB_PHYSICAL_TYPE,
           DUCKDB_PHYSICAL_TYPE (*FUNC)(const PARQUET_PHYSICAL_TYPE &input)>
 struct CallbackParquetValueConversion {
-
 	template <bool CHECKED>
 	static DUCKDB_PHYSICAL_TYPE PlainRead(ByteBuffer &plain_data, ColumnReader &reader) {
 		if (CHECKED) {

--- a/extension/parquet/include/reader/uuid_column_reader.hpp
+++ b/extension/parquet/include/reader/uuid_column_reader.hpp
@@ -50,7 +50,6 @@ struct UUIDValueConversion {
 };
 
 class UUIDColumnReader : public TemplatedColumnReader<hugeint_t, UUIDValueConversion> {
-
 public:
 	UUIDColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
 	    : TemplatedColumnReader<hugeint_t, UUIDValueConversion>(reader, schema) {

--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -198,7 +198,6 @@ public:
 	}
 
 	uint32_t Finalize() {
-
 		if (read_buffer_offset != read_buffer_size) {
 			throw InternalException("DecryptionTransport::Finalize was called with bytes remaining in read buffer: \n"
 			                        "read buffer offset: %d, read buffer size: %d",

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -838,7 +838,6 @@ static string GetShredding(case_insensitive_map_t<vector<Value>> &options, const
 }
 
 static vector<unique_ptr<Expression>> ParquetWriteSelect(CopyToSelectInput &input) {
-
 	auto &context = input.context;
 
 	vector<unique_ptr<Expression>> result;
@@ -846,14 +845,12 @@ static vector<unique_ptr<Expression>> ParquetWriteSelect(CopyToSelectInput &inpu
 	bool any_change = false;
 
 	for (auto &expr : input.select_list) {
-
 		const auto &type = expr->return_type;
 		const auto &name = expr->GetAlias();
 
 		// Spatial types need to be encoded into WKB when writing GeoParquet.
 		// But dont perform this conversion if this is a EXPORT DATABASE statement
 		if (input.copy_to_type == CopyToType::COPY_TO_FILE && IsExtensionGeometryType(type, context)) {
-
 			// Cast the column to GEOMETRY
 			auto cast_expr =
 			    BoundCastExpression::AddCastToType(context, std::move(expr), LogicalType::GEOMETRY(), false);

--- a/extension/parquet/parquet_geometry.cpp
+++ b/extension/parquet/parquet_geometry.cpp
@@ -22,7 +22,6 @@ using namespace duckdb_yyjson; // NOLINT
 
 unique_ptr<GeoParquetFileMetadata> GeoParquetFileMetadata::TryRead(const duckdb_parquet::FileMetaData &file_meta_data,
                                                                    const ClientContext &context) {
-
 	// Conversion not enabled, or spatial is not loaded!
 	if (!IsGeoParquetConversionEnabled(context)) {
 		return nullptr;
@@ -130,7 +129,6 @@ unique_ptr<GeoParquetFileMetadata> GeoParquetFileMetadata::TryRead(const duckdb_
 
 void GeoParquetFileMetadata::AddGeoParquetStats(const string &column_name, const LogicalType &type,
                                                 const GeometryStatsData &stats) {
-
 	// Lock the metadata
 	lock_guard<mutex> glock(write_lock);
 
@@ -146,7 +144,6 @@ void GeoParquetFileMetadata::AddGeoParquetStats(const string &column_name, const
 }
 
 void GeoParquetFileMetadata::Write(duckdb_parquet::FileMetaData &file_meta_data) {
-
 	// GeoParquet does not support M or ZM coordinates. So remove any columns that have them.
 	unordered_set<string> invalid_columns;
 	for (auto &column : geometry_columns) {
@@ -202,7 +199,6 @@ void GeoParquetFileMetadata::Write(duckdb_parquet::FileMetaData &file_meta_data)
 	const auto json_columns = yyjson_mut_obj_add_obj(doc, root, "columns");
 
 	for (auto &column : geometry_columns) {
-
 		const auto column_json = yyjson_mut_obj_add_obj(doc, json_columns, column.first.c_str());
 		yyjson_mut_obj_add_str(doc, column_json, "encoding", "WKB");
 		const auto geometry_types = yyjson_mut_obj_add_arr(doc, column_json, "geometry_types");
@@ -214,7 +210,6 @@ void GeoParquetFileMetadata::Write(duckdb_parquet::FileMetaData &file_meta_data)
 		const auto &bbox = column.second.stats.extent;
 
 		if (bbox.HasXY()) {
-
 			const auto bbox_arr = yyjson_mut_obj_add_arr(doc, column_json, "bbox");
 
 			if (!column.second.stats.extent.HasZ()) {
@@ -291,7 +286,6 @@ const unordered_map<string, GeoParquetColumnMetadata> &GeoParquetFileMetadata::G
 unique_ptr<ColumnReader> GeoParquetFileMetadata::CreateColumnReader(ParquetReader &reader,
                                                                     const ParquetColumnSchema &schema,
                                                                     ClientContext &context) {
-
 	// Get the catalog
 	auto &catalog = Catalog::GetSystemCatalog(context);
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -566,7 +566,6 @@ static bool IsVariantType(const SchemaElement &root, const vector<ParquetColumnS
 ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat,
                                                         idx_t &next_schema_idx, idx_t &next_file_idx,
                                                         ClientContext &context) {
-
 	auto file_meta_data = GetFileMetadata();
 	D_ASSERT(file_meta_data);
 	if (next_schema_idx >= file_meta_data->schema.size()) {
@@ -1047,7 +1046,6 @@ uint64_t ParquetReader::GetGroupSpan(ParquetReaderScanState &state) {
 	idx_t max_offset = NumericLimits<idx_t>::Minimum();
 
 	for (auto &column_chunk : group.columns) {
-
 		// Set the min offset
 		idx_t current_min_offset = NumericLimits<idx_t>::Maximum();
 		if (column_chunk.meta_data.__isset.dictionary_page_offset) {

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -322,7 +322,6 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type, cons
 unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(const ParquetColumnSchema &schema,
                                                                              const vector<ColumnChunk> &columns,
                                                                              bool can_have_nan) {
-
 	// Not supported types
 	auto &type = schema.type;
 	if (type.id() == LogicalTypeId::ARRAY || type.id() == LogicalTypeId::MAP || type.id() == LogicalTypeId::LIST) {
@@ -625,7 +624,6 @@ bool ParquetStatisticsUtils::BloomFilterExcludes(const TableFilter &duckdb_filte
 }
 
 ParquetBloomFilter::ParquetBloomFilter(idx_t num_entries, double bloom_filter_false_positive_ratio) {
-
 	// aim for hit ratio of 0.01%
 	// see http://tfk.mit.edu/pdf/bloom.pdf
 	double f = bloom_filter_false_positive_ratio;

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -347,7 +347,6 @@ ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, string file
       bloom_filter_false_positive_ratio(bloom_filter_false_positive_ratio_p), compression_level(compression_level_p),
       debug_use_openssl(debug_use_openssl_p), parquet_version(parquet_version), geoparquet_version(geoparquet_version),
       total_written(0), num_row_groups(0) {
-
 	// initialize the file writer
 	writer = make_uniq<BufferedFileWriter>(fs, file_name.c_str(),
 	                                       FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
@@ -671,7 +670,6 @@ struct BlobStatsUnifier : public BaseStringStatsUnifier {
 };
 
 struct GeoStatsUnifier : public ColumnStatsUnifier {
-
 	void UnifyGeoStats(const GeometryStatsData &other) override {
 		if (geo_stats) {
 			geo_stats->Merge(other);
@@ -890,7 +888,6 @@ void ParquetWriter::GatherWrittenStatistics() {
 			const auto &types = stats_unifier->geo_stats->types;
 
 			if (bbox.HasXY()) {
-
 				column_stats["bbox_xmin"] = Value::DOUBLE(bbox.x_min);
 				column_stats["bbox_xmax"] = Value::DOUBLE(bbox.x_max);
 				column_stats["bbox_ymin"] = Value::DOUBLE(bbox.y_min);
@@ -920,7 +917,6 @@ void ParquetWriter::GatherWrittenStatistics() {
 }
 
 void ParquetWriter::Finalize() {
-
 	// dump the bloom filters right before footer, not if stuff is encrypted
 
 	for (auto &bloom_filter_entry : bloom_filters) {

--- a/extension/parquet/reader/list_column_reader.cpp
+++ b/extension/parquet/reader/list_column_reader.cpp
@@ -175,7 +175,6 @@ ListColumnReader::ListColumnReader(ParquetReader &reader, const ParquetColumnSch
                                    unique_ptr<ColumnReader> child_column_reader_p)
     : ColumnReader(reader, schema), child_column_reader(std::move(child_column_reader_p)),
       read_cache(reader.allocator, ListType::GetChildType(Type())), read_vector(read_cache), overflow_child_count(0) {
-
 	child_defines.resize(reader.allocator, STANDARD_VECTOR_SIZE);
 	child_repeats.resize(reader.allocator, STANDARD_VECTOR_SIZE);
 	child_defines_ptr = (uint8_t *)child_defines.ptr;

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -307,7 +307,6 @@ void PrimitiveColumnWriter::SetParquetStatistics(PrimitiveColumnWriterState &sta
 	}
 
 	if (state.stats_state->HasGeoStats()) {
-
 		auto gpq_version = writer.GetGeoParquetVersion();
 
 		const auto has_real_stats = gpq_version == GeoParquetVersion::NONE || gpq_version == GeoParquetVersion::BOTH ||

--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -408,7 +408,6 @@ void CopySimplePrimitiveData(const UnifiedVariantVectorData &variant, data_ptr_t
 }
 
 void CopyUUIDData(const UnifiedVariantVectorData &variant, data_ptr_t &value_data, idx_t row, uint32_t values_index) {
-
 	auto byte_offset = variant.GetByteOffset(row, values_index);
 	auto data = const_data_ptr_cast(variant.GetData(row).GetData());
 	auto ptr = data + byte_offset;
@@ -561,7 +560,6 @@ static void WritePrimitiveValueData(const UnifiedVariantVectorData &variant, idx
 static void WriteValueData(const UnifiedVariantVectorData &variant, idx_t row, uint32_t values_index,
                            data_ptr_t &value_data, const vector<uint32_t> &offsets, idx_t &offset_index,
                            optional_ptr<ShreddingState> shredding_state) {
-
 	VariantLogicalType type_id = VariantLogicalType::VARIANT_NULL;
 	if (variant.RowIsValid(row)) {
 		type_id = variant.GetTypeId(row, values_index);

--- a/src/catalog/catalog_entry/duck_index_entry.cpp
+++ b/src/catalog/catalog_entry/duck_index_entry.cpp
@@ -22,7 +22,6 @@ void DuckIndexEntry::Rollback(CatalogEntry &) {
 DuckIndexEntry::DuckIndexEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateIndexInfo &create_info,
                                TableCatalogEntry &table_p)
     : IndexCatalogEntry(catalog, schema, create_info), initial_index_size(0) {
-
 	auto &table = table_p.Cast<DuckTableEntry>();
 	auto &storage = table.GetStorage();
 	info = make_shared_ptr<IndexDataTableInfo>(storage.GetDataTableInfo(), name);

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -29,7 +29,6 @@ namespace duckdb {
 
 IndexStorageInfo GetIndexInfo(const IndexConstraintType type, const bool v1_0_0_storage, unique_ptr<CreateInfo> &info,
                               const idx_t id) {
-
 	auto &table_info = info->Cast<CreateTableInfo>();
 	auto constraint_name = EnumUtil::ToString(type) + "_";
 	auto name = constraint_name + table_info.table + "_" + to_string(id);
@@ -44,7 +43,6 @@ DuckTableEntry::DuckTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, Bou
                                shared_ptr<DataTable> inherited_storage)
     : TableCatalogEntry(catalog, schema, info.Base()), storage(std::move(inherited_storage)),
       column_dependency_manager(std::move(info.column_dependency_manager)) {
-
 	if (storage) {
 		if (!info.indexes.empty()) {
 			storage->SetIndexStorageInfo(std::move(info.indexes));
@@ -68,7 +66,6 @@ DuckTableEntry::DuckTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, Bou
 	for (idx_t i = 0; i < constraints.size(); i++) {
 		auto &constraint = constraints[i];
 		if (constraint->type == ConstraintType::UNIQUE) {
-
 			// UNIQUE constraint: Create a unique index.
 			auto &unique = constraint->Cast<UniqueConstraint>();
 			IndexConstraintType constraint_type = IndexConstraintType::UNIQUE;
@@ -99,7 +96,6 @@ DuckTableEntry::DuckTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, Bou
 			auto &bfk = constraint->Cast<ForeignKeyConstraint>();
 			if (bfk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE ||
 			    bfk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
-
 				vector<LogicalIndex> column_indexes;
 				for (const auto &physical_index : bfk.info.fk_keys) {
 					auto &col = columns.GetColumn(physical_index);

--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -5,7 +5,6 @@ namespace duckdb {
 IndexCatalogEntry::IndexCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateIndexInfo &info)
     : StandardEntry(CatalogType::INDEX_ENTRY, schema, catalog, info.index_name), sql(info.sql), options(info.options),
       index_type(info.index_type), index_constraint_type(info.constraint_type), column_ids(info.column_ids) {
-
 	this->temporary = info.temporary;
 	this->dependencies = info.dependencies;
 	this->comment = info.comment;

--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -196,7 +196,6 @@ AdbcStatusCode DatabaseInit(struct AdbcDatabase *database, struct AdbcError *err
 }
 
 AdbcStatusCode DatabaseRelease(struct AdbcDatabase *database, struct AdbcError *error) {
-
 	if (database && database->private_data) {
 		auto wrapper = static_cast<DuckDBAdbcDatabaseWrapper *>(database->private_data);
 
@@ -605,7 +604,6 @@ const char *get_last_error(struct ArrowArrayStream *stream) {
 
 duckdb::unique_ptr<duckdb::ArrowArrayStreamWrapper> stream_produce(uintptr_t factory_ptr,
                                                                    duckdb::ArrowStreamParameters &parameters) {
-
 	// TODO this will ignore any projections or filters but since we don't expose the scan it should be sort of fine
 	auto res = duckdb::make_uniq<duckdb::ArrowArrayStreamWrapper>();
 	res->arrow_array_stream = *reinterpret_cast<ArrowArrayStream *>(factory_ptr);
@@ -619,7 +617,6 @@ void stream_schema(ArrowArrayStream *stream, ArrowSchema &schema) {
 AdbcStatusCode Ingest(duckdb_connection connection, const char *table_name, const char *schema,
                       struct ArrowArrayStream *input, struct AdbcError *error, IngestionMode ingestion_mode,
                       bool temporary) {
-
 	if (!connection) {
 		SetError(error, "Missing connection object");
 		return ADBC_STATUS_INVALID_ARGUMENT;

--- a/src/common/adbc/driver_manager.cpp
+++ b/src/common/adbc/driver_manager.cpp
@@ -1080,7 +1080,6 @@ AdbcStatusCode AdbcConnectionGetTableTypes(struct AdbcConnection *connection, st
 
 AdbcStatusCode AdbcConnectionInit(struct AdbcConnection *connection, struct AdbcDatabase *database,
                                   struct AdbcError *error) {
-
 	if (!connection->private_data) {
 		SetError(error, "Must call AdbcConnectionNew first");
 		return ADBC_STATUS_INVALID_STATE;

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -358,7 +358,6 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		}
 		child.children = &root_holder.nested_children_ptr.back()[0];
 		for (size_t type_idx = 0; type_idx < child_types.size(); type_idx++) {
-
 			InitializeChild(*child.children[type_idx], root_holder);
 
 			root_holder.owned_type_names.push_back(AddName(child_types[type_idx].first));

--- a/src/common/bignum.cpp
+++ b/src/common/bignum.cpp
@@ -232,7 +232,6 @@ void BignumAddition(data_ptr_t result, int64_t result_end, bool is_target_absolu
 }
 
 string_t BignumIntermediate::Negate(Vector &result_vector) const {
-
 	auto target = StringVector::EmptyString(result_vector, size + Bignum::BIGNUM_HEADER_SIZE);
 	auto ptr = target.GetDataWriteable();
 

--- a/src/common/csv_writer.cpp
+++ b/src/common/csv_writer.cpp
@@ -71,7 +71,6 @@ CSVWriter::CSVWriter(CSVReaderOptions &options_p, FileSystem &fs, const string &
                                                 FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW |
                                                     FileLockType::WRITE_LOCK | compression)),
       write_stream(*file_writer), should_initialize(true), shared(shared) {
-
 	if (!shared) {
 		global_write_state = make_uniq<CSVWriterState>();
 	}

--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -24,7 +24,6 @@ ErrorData::ErrorData(ExceptionType type, const string &message)
 
 ErrorData::ErrorData(const string &message)
     : initialized(true), type(ExceptionType::INVALID), raw_message(string()), final_message(string()) {
-
 	// parse the constructed JSON
 	if (message.empty() || message[0] != '{') {
 		// not JSON! Use the message as a raw Exception message and leave type as uninitialized

--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -153,7 +153,6 @@ void HivePartitioning::ApplyFiltersToFileList(ClientContext &context, vector<Ope
                                               vector<unique_ptr<Expression>> &filters,
                                               const HivePartitioningFilterInfo &filter_info,
                                               MultiFilePushdownInfo &info) {
-
 	vector<OpenFileInfo> pruned_files;
 	vector<bool> have_preserved_filter(filters.size(), false);
 	vector<unique_ptr<Expression>> pruned_filters;

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1319,7 +1319,6 @@ static bool IsSymbolicLink(const string &path) {
 
 static void RecursiveGlobDirectories(FileSystem &fs, const string &path, vector<OpenFileInfo> &result,
                                      bool match_directory, bool join_path) {
-
 	fs.ListFiles(path, [&](OpenFileInfo &info) {
 		if (join_path) {
 			info.path = fs.JoinPath(path, info.path);

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -299,7 +299,6 @@ void MultiFileReader::FinalizeBind(MultiFileReaderData &reader_data, const Multi
                                    const vector<MultiFileColumnDefinition> &global_columns,
                                    const vector<ColumnIndex> &global_column_ids, ClientContext &context,
                                    optional_ptr<MultiFileReaderGlobalState> global_state) {
-
 	// create a map of name -> column index
 	auto &local_columns = reader_data.reader->GetColumns();
 	auto &filename = reader_data.reader->GetFileName();

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1407,7 +1407,6 @@ string_t CastFromBlobToBit::Operation(string_t input, Vector &vector) {
 //===--------------------------------------------------------------------===//
 template <>
 string_t CastFromBitToString::Operation(string_t input, Vector &vector) {
-
 	idx_t result_size = Bit::BitLength(input);
 	string_t result = StringVector::EmptyString(vector, result_size);
 	Bit::ToString(input, result.GetDataWriteable());

--- a/src/common/progress_bar/unscented_kalman_filter.cpp
+++ b/src/common/progress_bar/unscented_kalman_filter.cpp
@@ -6,7 +6,6 @@ UnscentedKalmanFilter::UnscentedKalmanFilter()
     : x(STATE_DIM, 0.0), P(STATE_DIM, vector<double>(STATE_DIM, 0.0)), Q(STATE_DIM, vector<double>(STATE_DIM, 0.0)),
       R(OBS_DIM, vector<double>(OBS_DIM, 0.0)), last_time(0.0), initialized(false), last_progress(-1.0),
       scale_factor(1.0) {
-
 	// Calculate UKF parameters
 	lambda = ALPHA * ALPHA * (STATE_DIM + KAPPA) - STATE_DIM;
 

--- a/src/common/sort/hashed_sort.cpp
+++ b/src/common/sort/hashed_sort.cpp
@@ -89,7 +89,6 @@ private:
 HashedSortGlobalSinkState::HashedSortGlobalSinkState(ClientContext &client, const HashedSort &hashed_sort)
     : hashed_sort(hashed_sort), buffer_manager(BufferManager::GetBufferManager(client)),
       allocator(Allocator::Get(client)), fixed_bits(0), max_bits(1), count(0) {
-
 	const auto memory_per_thread = PhysicalOperator::GetMaxThreadMemory(client);
 	const auto thread_pages = PreviousPowerOfTwo(memory_per_thread / (4 * buffer_manager.GetBlockAllocSize()));
 	while (max_bits < 8 && (thread_pages >> max_bits) > 1) {
@@ -318,7 +317,6 @@ public:
 HashedSortLocalSinkState::HashedSortLocalSinkState(ExecutionContext &context, const HashedSort &hashed_sort)
     : hashed_sort(hashed_sort), allocator(Allocator::Get(context.client)), hash_exec(context.client),
       sort_exec(context.client) {
-
 	vector<LogicalType> group_types;
 	for (idx_t prt_idx = 0; prt_idx < hashed_sort.partitions.size(); prt_idx++) {
 		auto &pexpr = *hashed_sort.partitions[prt_idx].expression.get();
@@ -666,7 +664,6 @@ public:
 void HashedSort::GenerateOrderings(Orders &partitions, Orders &orders,
                                    const vector<unique_ptr<Expression>> &partition_bys, const Orders &order_bys,
                                    const vector<unique_ptr<BaseStatistics>> &partition_stats) {
-
 	// we sort by both 1) partition by expression list and 2) order by expressions
 	const auto partition_cols = partition_bys.size();
 	for (idx_t prt_idx = 0; prt_idx < partition_cols; prt_idx++) {

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -738,7 +738,6 @@ string StringUtil::ExceptionToJSONMap(ExceptionType type, const string &message,
 }
 
 string StringUtil::GetFileName(const string &file_path) {
-
 	idx_t pos = file_path.find_last_of("/\\");
 	if (pos == string::npos) {
 		return file_path;

--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -593,7 +593,6 @@ bool ColumnDataCopyCompressedStrings(ColumnDataMetaData &meta_data, const Vector
 template <>
 void ColumnDataCopy<string_t>(ColumnDataMetaData &meta_data, const UnifiedVectorFormat &source_data, Vector &source,
                               idx_t offset, idx_t copy_count) {
-
 	const auto &allocator_type = meta_data.segment.allocator->GetType();
 	if (allocator_type == ColumnDataAllocatorType::IN_MEMORY_ALLOCATOR ||
 	    allocator_type == ColumnDataAllocatorType::HYBRID) {
@@ -733,7 +732,6 @@ void ColumnDataCopy<string_t>(ColumnDataMetaData &meta_data, const UnifiedVector
 template <>
 void ColumnDataCopy<list_entry_t>(ColumnDataMetaData &meta_data, const UnifiedVectorFormat &source_data, Vector &source,
                                   idx_t offset, idx_t copy_count) {
-
 	auto &segment = meta_data.segment;
 
 	auto &child_vector = ListVector::GetEntry(source);
@@ -813,7 +811,6 @@ void ColumnDataCopyStruct(ColumnDataMetaData &meta_data, const UnifiedVectorForm
 
 void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorFormat &source_data, Vector &source,
                          idx_t offset, idx_t copy_count) {
-
 	auto &segment = meta_data.segment;
 
 	// copy the NULL values for the main array vector (the same as for a struct vector)

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -254,7 +254,6 @@ string DataChunk::ToString() const {
 }
 
 void DataChunk::Serialize(Serializer &serializer, bool compressed_serialization) const {
-
 	// write the count
 	auto row_count = size();
 	serializer.WriteProperty<sel_t>(100, "rows", NumericCast<sel_t>(row_count));
@@ -279,7 +278,6 @@ void DataChunk::Serialize(Serializer &serializer, bool compressed_serialization)
 }
 
 void DataChunk::Deserialize(Deserializer &deserializer) {
-
 	// read and set the row count
 	auto row_count = deserializer.ReadProperty<sel_t>(100, "rows");
 

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -211,7 +211,6 @@ private:
 };
 
 void FromStringRecursive(TextReader &reader, BlobWriter &writer, uint32_t depth, bool parent_has_z, bool parent_has_m) {
-
 	if (depth == Geometry::MAX_RECURSION_DEPTH) {
 		throw InvalidInputException("Geometry string exceeds maximum recursion depth of %d",
 		                            Geometry::MAX_RECURSION_DEPTH);
@@ -353,7 +352,6 @@ void FromStringRecursive(TextReader &reader, BlobWriter &writer, uint32_t depth,
 		auto part_count = writer.Reserve<uint32_t>();
 		reader.Match('(');
 		do {
-
 			const auto part_meta =
 			    static_cast<uint32_t>(GeometryType::LINESTRING) + (has_z ? 1000 : 0) + (has_m ? 2000 : 0);
 			writer.Write<uint8_t>(1);
@@ -383,7 +381,6 @@ void FromStringRecursive(TextReader &reader, BlobWriter &writer, uint32_t depth,
 		auto part_count = writer.Reserve<uint32_t>();
 		reader.Match('(');
 		do {
-
 			const auto part_meta =
 			    static_cast<uint32_t>(GeometryType::POLYGON) + (has_z ? 1000 : 0) + (has_m ? 2000 : 0);
 			writer.Write<uint8_t>(1);

--- a/src/common/types/list_segment.cpp
+++ b/src/common/types/list_segment.cpp
@@ -239,7 +239,6 @@ static ListSegment *GetSegment(const ListSegmentFunctions &functions, ArenaAlloc
 template <class T>
 static void WriteDataToPrimitiveSegment(const ListSegmentFunctions &, ArenaAllocator &, ListSegment *segment,
                                         RecursiveUnifiedVectorFormat &input_data, idx_t &entry_idx) {
-
 	auto sel_entry_idx = input_data.unified.sel->get_index(entry_idx);
 
 	// write null validity
@@ -258,7 +257,6 @@ static void WriteDataToPrimitiveSegment(const ListSegmentFunctions &, ArenaAlloc
 static void WriteDataToVarcharSegment(const ListSegmentFunctions &functions, ArenaAllocator &allocator,
                                       ListSegment *segment, RecursiveUnifiedVectorFormat &input_data,
                                       idx_t &entry_idx) {
-
 	auto sel_entry_idx = input_data.unified.sel->get_index(entry_idx);
 
 	// write null validity
@@ -297,7 +295,6 @@ static void WriteDataToVarcharSegment(const ListSegmentFunctions &functions, Are
 
 static void WriteDataToListSegment(const ListSegmentFunctions &functions, ArenaAllocator &allocator,
                                    ListSegment *segment, RecursiveUnifiedVectorFormat &input_data, idx_t &entry_idx) {
-
 	auto sel_entry_idx = input_data.unified.sel->get_index(entry_idx);
 
 	// write null validity
@@ -331,7 +328,6 @@ static void WriteDataToListSegment(const ListSegmentFunctions &functions, ArenaA
 
 static void WriteDataToStructSegment(const ListSegmentFunctions &functions, ArenaAllocator &allocator,
                                      ListSegment *segment, RecursiveUnifiedVectorFormat &input_data, idx_t &entry_idx) {
-
 	auto sel_entry_idx = input_data.unified.sel->get_index(entry_idx);
 
 	// write null validity
@@ -376,7 +372,6 @@ static void WriteDataToArraySegment(const ListSegmentFunctions &functions, Arena
 
 void ListSegmentFunctions::AppendRow(ArenaAllocator &allocator, LinkedList &linked_list,
                                      RecursiveUnifiedVectorFormat &input_data, idx_t &entry_idx) const {
-
 	auto &write_data_to_segment = *this;
 	auto segment = GetSegment(write_data_to_segment, allocator, linked_list);
 	write_data_to_segment.write_data(write_data_to_segment, allocator, segment, input_data, entry_idx);
@@ -391,7 +386,6 @@ void ListSegmentFunctions::AppendRow(ArenaAllocator &allocator, LinkedList &link
 template <class T>
 static void ReadDataFromPrimitiveSegment(const ListSegmentFunctions &, const ListSegment *segment, Vector &result,
                                          idx_t &total_count) {
-
 	auto &aggr_vector_validity = FlatVector::Validity(result);
 
 	// set NULLs
@@ -462,7 +456,6 @@ static void ReadDataFromVarcharSegment(const ListSegmentFunctions &, const ListS
 
 static void ReadDataFromListSegment(const ListSegmentFunctions &functions, const ListSegment *segment, Vector &result,
                                     idx_t &total_count) {
-
 	auto &aggr_vector_validity = FlatVector::Validity(result);
 
 	// set NULLs
@@ -503,7 +496,6 @@ static void ReadDataFromListSegment(const ListSegmentFunctions &functions, const
 
 static void ReadDataFromStructSegment(const ListSegmentFunctions &functions, const ListSegment *segment, Vector &result,
                                       idx_t &total_count) {
-
 	auto &aggr_vector_validity = FlatVector::Validity(result);
 
 	// set NULLs
@@ -528,7 +520,6 @@ static void ReadDataFromStructSegment(const ListSegmentFunctions &functions, con
 
 static void ReadDataFromArraySegment(const ListSegmentFunctions &functions, const ListSegment *segment, Vector &result,
                                      idx_t &total_count) {
-
 	auto &aggr_vector_validity = FlatVector::Validity(result);
 
 	// set NULLs
@@ -570,7 +561,6 @@ void SegmentPrimitiveFunction(ListSegmentFunctions &functions) {
 }
 
 void GetSegmentDataFunctions(ListSegmentFunctions &functions, const LogicalType &type) {
-
 	if (type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}

--- a/src/common/types/row/tuple_data_scatter_gather.cpp
+++ b/src/common/types/row/tuple_data_scatter_gather.cpp
@@ -1794,7 +1794,6 @@ static void TupleDataCastToArrayStructGather(const TupleDataLayout &layout, Vect
                                              const SelectionVector &scan_sel, const idx_t scan_count, Vector &target,
                                              const SelectionVector &target_sel, optional_ptr<Vector> cached_cast_vector,
                                              const vector<TupleDataGatherFunction> &child_functions) {
-
 	if (cached_cast_vector) {
 		// Reuse the cached cast vector
 		TupleDataStructGather(layout, row_locations, col_idx, scan_sel, scan_count, *cached_cast_vector, target_sel,

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -363,7 +363,6 @@ void Vector::Initialize(bool initialize_to_zero, idx_t capacity) {
 }
 
 void Vector::FindResizeInfos(vector<ResizeInfo> &resize_infos, const idx_t multiplier) {
-
 	ResizeInfo resize_info(*this, data, buffer.get(), multiplier);
 	resize_infos.emplace_back(resize_info);
 
@@ -816,7 +815,6 @@ Value Vector::GetValue(const Vector &v_p, idx_t index_p) {
 		value.GetTypeMutable().CopyAuxInfo(v_p.GetType());
 	}
 	if (v_p.GetType().id() != LogicalTypeId::AGGREGATE_STATE && value.type().id() != LogicalTypeId::AGGREGATE_STATE) {
-
 		D_ASSERT(v_p.GetType() == value.type());
 	}
 	return value;
@@ -1233,7 +1231,6 @@ void Vector::ToUnifiedFormat(idx_t count, UnifiedVectorFormat &format) {
 }
 
 void Vector::RecursiveToUnifiedFormat(Vector &input, idx_t count, RecursiveUnifiedVectorFormat &data) {
-
 	input.ToUnifiedFormat(count, data.unified);
 	data.logical_type = input.GetType();
 
@@ -2348,7 +2345,6 @@ const Vector &MapVector::GetValues(const Vector &vector) {
 }
 
 MapInvalidReason MapVector::CheckMapValidity(Vector &map, idx_t count, const SelectionVector &sel) {
-
 	D_ASSERT(map.GetType().id() == LogicalTypeId::MAP);
 
 	// unify the MAP vector, which is a physical LIST vector
@@ -2363,7 +2359,6 @@ MapInvalidReason MapVector::CheckMapValidity(Vector &map, idx_t count, const Sel
 	keys.ToUnifiedFormat(maps_length, key_data);
 
 	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
-
 		auto mapped_row = sel.get_index(row_idx);
 		auto map_idx = map_data.sel->get_index(mapped_row);
 
@@ -2534,7 +2529,6 @@ void ListVector::PushBack(Vector &target, const Value &insert) {
 }
 
 idx_t ListVector::GetConsecutiveChildList(Vector &list, Vector &result, idx_t offset, idx_t count) {
-
 	auto info = ListVector::GetConsecutiveChildListInfo(list, offset, count);
 	if (info.needs_slicing) {
 		SelectionVector sel(info.child_list_info.length);
@@ -2547,7 +2541,6 @@ idx_t ListVector::GetConsecutiveChildList(Vector &list, Vector &result, idx_t of
 }
 
 ConsecutiveChildListInfo ListVector::GetConsecutiveChildListInfo(Vector &list, idx_t offset, idx_t count) {
-
 	ConsecutiveChildListInfo info;
 	UnifiedVectorFormat unified_list_data;
 	list.ToUnifiedFormat(offset + count, unified_list_data);

--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -471,7 +471,6 @@ using StructEntries = vector<unique_ptr<Vector>>;
 
 void ExtractNestedSelection(const SelectionVector &slice_sel, const idx_t count, const SelectionVector &sel,
                             OptionalSelection &opt) {
-
 	for (idx_t i = 0; i < count;) {
 		const auto slice_idx = slice_sel.get_index(i);
 		const auto result_idx = sel.get_index(slice_idx);
@@ -482,7 +481,6 @@ void ExtractNestedSelection(const SelectionVector &slice_sel, const idx_t count,
 
 void ExtractNestedMask(const SelectionVector &slice_sel, const idx_t count, const SelectionVector &sel,
                        ValidityMask *child_mask_p, optional_ptr<ValidityMask> null_mask) {
-
 	if (!child_mask_p) {
 		return;
 	}
@@ -1015,7 +1013,6 @@ template <class OP>
 idx_t TemplatedDistinctSelectOperation(Vector &left, Vector &right, optional_ptr<const SelectionVector> sel,
                                        idx_t count, optional_ptr<SelectionVector> true_sel,
                                        optional_ptr<SelectionVector> false_sel, optional_ptr<ValidityMask> null_mask) {
-
 	switch (left.GetType().InternalType()) {
 	case PhysicalType::BOOL:
 	case PhysicalType::INT8:

--- a/src/common/vector_operations/vector_copy.cpp
+++ b/src/common/vector_operations/vector_copy.cpp
@@ -39,7 +39,6 @@ static const ValidityMask &ExtractValidityMask(const Vector &v) {
 
 void VectorOperations::Copy(const Vector &source_p, Vector &target, const SelectionVector &sel_p, idx_t source_count,
                             idx_t source_offset, idx_t target_offset, idx_t copy_count) {
-
 	SelectionVector owned_sel;
 	const SelectionVector *sel = &sel_p;
 

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -17,7 +17,6 @@ VirtualFileSystem::VirtualFileSystem(unique_ptr<FileSystem> &&inner) : default_f
 
 unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
                                                            optional_ptr<FileOpener> opener) {
-
 	auto compression = flags.Compression();
 	if (compression == FileCompressionType::AUTO_DETECT) {
 		// auto-detect compression settings based on file name

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -48,7 +48,6 @@ GroupedAggregateHashTable::GroupedAggregateHashTable(ClientContext &context_p, A
     : BaseAggregateHashTable(context_p, allocator, aggregate_objects_p, std::move(payload_types_p)), context(context_p),
       radix_bits(radix_bits), count(0), capacity(0), sink_count(0), skip_lookups(false), enable_hll(false),
       aggregate_allocator(make_shared_ptr<ArenaAllocator>(allocator)), state(*aggregate_allocator) {
-
 	// Append hash column to the end and initialise the row layout
 	group_types_p.emplace_back(LogicalType::HASH);
 

--- a/src/execution/expression_executor.cpp
+++ b/src/execution/expression_executor.cpp
@@ -230,7 +230,6 @@ void ExpressionExecutor::Execute(const Expression &expr, ExpressionState *state,
 	// The result vector must be used for the first time, or must be reset.
 	// Otherwise, the validity mask can contain previous (now incorrect) data.
 	if (result.GetVectorType() == VectorType::FLAT_VECTOR) {
-
 		// We do not initialize vector caches for these expressions.
 		if (expr.GetExpressionClass() != ExpressionClass::BOUND_REF &&
 		    expr.GetExpressionClass() != ExpressionClass::BOUND_CONSTANT &&

--- a/src/execution/expression_executor/execute_comparison.cpp
+++ b/src/execution/expression_executor/execute_comparison.cpp
@@ -209,7 +209,6 @@ idx_t NestedSelector::Select<duckdb::GreaterThanEquals>(Vector &left, Vector &ri
 static inline idx_t SelectNotNull(Vector &left, Vector &right, const idx_t count, const SelectionVector &sel,
                                   SelectionVector &maybe_vec, OptionalSelection &false_opt,
                                   optional_ptr<ValidityMask> null_mask) {
-
 	UnifiedVectorFormat lvdata, rvdata;
 	left.ToUnifiedFormat(count, lvdata);
 	right.ToUnifiedFormat(count, rvdata);

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -50,7 +50,6 @@ ART::ART(const string &name, const IndexConstraintType index_constraint_type, co
          const IndexStorageInfo &info)
     : BoundIndex(name, ART::TYPE_NAME, index_constraint_type, column_ids, table_io_manager, unbound_expressions, db),
       allocators(allocators_ptr), owns_data(false), verify_max_key_len(false) {
-
 	// FIXME: Use the new byte representation function to support nested types.
 	for (idx_t i = 0; i < types.size(); i++) {
 		switch (types[i]) {

--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -162,7 +162,6 @@ bool Leaf::DeprecatedGetRowIds(ART &art, const Node &node, set<row_t> &row_ids, 
 
 	reference<const Node> ref(node);
 	while (ref.get().HasMetadata()) {
-
 		auto &leaf = Node::Ref<const Leaf>(art, ref, LEAF);
 		if (row_ids.size() + leaf.count > max_count) {
 			return false;

--- a/src/execution/index/bound_index.cpp
+++ b/src/execution/index/bound_index.cpp
@@ -18,7 +18,6 @@ BoundIndex::BoundIndex(const string &name, const string &index_type, IndexConstr
                        const vector<unique_ptr<Expression>> &unbound_expressions_p, AttachedDatabase &db)
     : Index(column_ids, table_io_manager, db), name(name), index_type(index_type),
       index_constraint_type(index_constraint_type) {
-
 	for (auto &expr : unbound_expressions_p) {
 		types.push_back(expr->return_type.InternalType());
 		logical_types.push_back(expr->return_type);

--- a/src/execution/index/fixed_size_allocator.cpp
+++ b/src/execution/index/fixed_size_allocator.cpp
@@ -7,7 +7,6 @@ namespace duckdb {
 FixedSizeAllocator::FixedSizeAllocator(const idx_t segment_size, BlockManager &block_manager, MemoryTag memory_tag)
     : block_manager(block_manager), buffer_manager(block_manager.buffer_manager), memory_tag(memory_tag),
       segment_size(segment_size), total_segment_count(0) {
-
 	if (segment_size > block_manager.GetBlockSize() - sizeof(validity_t)) {
 		throw InternalException("The maximum segment size of fixed-size allocators is " +
 		                        to_string(block_manager.GetBlockSize() - sizeof(validity_t)));
@@ -321,7 +320,6 @@ void FixedSizeAllocator::Init(const FixedSizeAllocatorInfo &info) {
 	total_segment_count = 0;
 
 	for (idx_t i = 0; i < info.buffer_ids.size(); i++) {
-
 		// read all FixedSizeBuffer data
 		auto buffer_id = info.buffer_ids[i];
 

--- a/src/execution/index/fixed_size_buffer.cpp
+++ b/src/execution/index/fixed_size_buffer.cpp
@@ -38,7 +38,6 @@ constexpr uint8_t FixedSizeBuffer::SHIFT[];
 FixedSizeBuffer::FixedSizeBuffer(BlockManager &block_manager, MemoryTag memory_tag)
     : block_manager(block_manager), readers(0), segment_count(0), allocation_size(0), dirty(false), vacuum(false),
       loaded(false), block_pointer(), block_handle(nullptr) {
-
 	auto &buffer_manager = block_manager.buffer_manager;
 	buffer_handle = buffer_manager.Allocate(memory_tag, &block_manager, false);
 	block_handle = buffer_handle.GetBlockHandle();
@@ -52,7 +51,6 @@ FixedSizeBuffer::FixedSizeBuffer(BlockManager &block_manager, const idx_t segmen
                                  const BlockPointer &block_pointer)
     : block_manager(block_manager), readers(0), segment_count(segment_count), allocation_size(allocation_size),
       dirty(false), vacuum(false), loaded(false), block_pointer(block_pointer) {
-
 	D_ASSERT(block_pointer.IsValid());
 	block_handle = block_manager.RegisterBlock(block_pointer.block_id);
 	D_ASSERT(block_handle->BlockId() < MAXIMUM_BLOCK);
@@ -159,7 +157,6 @@ void FixedSizeBuffer::LoadFromDisk() {
 }
 
 uint32_t FixedSizeBuffer::GetOffset(const idx_t bitmask_count, const idx_t available_segments) {
-
 	// Get a handle to the buffer's validity mask (offset 0).
 	SegmentHandle handle(*this, 0);
 	const auto bitmask_ptr = handle.GetPtr<validity_t>();

--- a/src/execution/index/index_type_set.cpp
+++ b/src/execution/index/index_type_set.cpp
@@ -5,7 +5,6 @@
 namespace duckdb {
 
 IndexTypeSet::IndexTypeSet() {
-
 	// Register the ART index type by default
 	IndexType art_index_type;
 	art_index_type.name = ART::TYPE_NAME;

--- a/src/execution/index/unbound_index.cpp
+++ b/src/execution/index/unbound_index.cpp
@@ -12,7 +12,6 @@ UnboundIndex::UnboundIndex(unique_ptr<CreateInfo> create_info, IndexStorageInfo 
                            TableIOManager &table_io_manager, AttachedDatabase &db)
     : Index(create_info->Cast<CreateIndexInfo>().column_ids, table_io_manager, db), create_info(std::move(create_info)),
       storage_info(std::move(storage_info_p)) {
-
 	// Memory safety check.
 	for (idx_t info_idx = 0; info_idx < storage_info.allocator_infos.size(); info_idx++) {
 		auto &info = storage_info.allocator_infos[info_idx];

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -45,7 +45,6 @@ JoinHashTable::JoinHashTable(ClientContext &context_p, const PhysicalOperator &o
 		auto type = condition.left->return_type;
 		if (condition.comparison == ExpressionType::COMPARE_EQUAL ||
 		    condition.comparison == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
-
 			// ensure that all equality conditions are at the front,
 			// and that all other conditions are at the back
 			D_ASSERT(equality_types.size() == condition_types.size());
@@ -82,7 +81,6 @@ JoinHashTable::JoinHashTable(ClientContext &context_p, const PhysicalOperator &o
 
 	// Initialize the row matcher that are used for filtering during the probing only if there are non-equality
 	if (!non_equality_predicates.empty()) {
-
 		row_matcher_probe = unique_ptr<RowMatcher>(new RowMatcher());
 		row_matcher_probe_no_match_sel = unique_ptr<RowMatcher>(new RowMatcher());
 
@@ -172,7 +170,6 @@ idx_t GetOptionalIndex(const SelectionVector *sel, const idx_t idx) {
 
 static void AddPointerToCompare(JoinHashTable::ProbeState &state, const ht_entry_t &entry, Vector &pointers_result_v,
                                 idx_t row_ht_offset, idx_t &keys_to_compare_count, const idx_t &row_index) {
-
 	const auto row_ptr_insert_to = FlatVector::GetData<data_ptr_t>(pointers_result_v);
 	const auto ht_offsets_and_salts = FlatVector::GetData<idx_t>(state.ht_offsets_and_salts_v);
 
@@ -189,13 +186,11 @@ static void AddPointerToCompare(JoinHashTable::ProbeState &state, const ht_entry
 template <bool USE_SALTS, bool HAS_SEL>
 static idx_t ProbeForPointersInternal(JoinHashTable::ProbeState &state, JoinHashTable &ht, ht_entry_t *entries,
                                       Vector &pointers_result_v, const SelectionVector *row_sel, idx_t &count) {
-
 	auto hashes_dense = FlatVector::GetData<hash_t>(state.hashes_dense_v);
 
 	idx_t keys_to_compare_count = 0;
 
 	for (idx_t i = 0; i < count; i++) {
-
 		auto row_hash = hashes_dense[i]; // hashes have been flattened before -> always access dense
 		auto row_ht_offset = row_hash & ht.bitmask;
 
@@ -260,7 +255,6 @@ static void GetRowPointersInternal(DataChunk &keys, TupleDataChunkState &key_sta
                                    Vector &hashes_v, const SelectionVector *row_sel, idx_t &count, JoinHashTable &ht,
                                    ht_entry_t *entries, Vector &pointers_result_v, SelectionVector &match_sel,
                                    bool has_row_sel) {
-
 	// densify hashes: If there is no sel, flatten the hashes, else densify via UnifiedVectorFormat
 	if (has_row_sel) {
 		UnifiedVectorFormat hashes_unified_v;
@@ -339,7 +333,6 @@ inline bool JoinHashTable::UseSalt() const {
 void JoinHashTable::GetRowPointers(DataChunk &keys, TupleDataChunkState &key_state, ProbeState &state, Vector &hashes_v,
                                    const SelectionVector *sel, idx_t &count, Vector &pointers_result_v,
                                    SelectionVector &match_sel, const bool has_sel) {
-
 	if (UseSalt()) {
 		GetRowPointersInternal<true>(keys, key_state, state, hashes_v, sel, count, *this, entries, pointers_result_v,
 		                             match_sel, has_sel);
@@ -888,7 +881,6 @@ bool ScanStructure::PointersExhausted() const {
 }
 
 idx_t ScanStructure::ResolvePredicates(DataChunk &keys, SelectionVector &match_sel, SelectionVector *no_match_sel) {
-
 	// Initialize the found_match array to the current sel_vector
 	for (idx_t i = 0; i < this->count; ++i) {
 		match_sel.set_index(i, this->sel_vector.get_index(i));
@@ -934,7 +926,6 @@ idx_t ScanStructure::ScanInnerJoin(DataChunk &keys, SelectionVector &result_vect
 }
 
 void ScanStructure::AdvancePointers(const SelectionVector &sel, const idx_t sel_count) {
-
 	if (!ht.chains_longer_than_one) {
 		this->count = 0;
 		return;

--- a/src/execution/operator/aggregate/distinct_aggregate_data.cpp
+++ b/src/execution/operator/aggregate/distinct_aggregate_data.cpp
@@ -29,7 +29,6 @@ DistinctAggregateCollectionInfo::DistinctAggregateCollectionInfo(const vector<un
 
 DistinctAggregateState::DistinctAggregateState(const DistinctAggregateData &data, ClientContext &client)
     : child_executor(client) {
-
 	radix_states.resize(data.info.table_count);
 	distinct_output_chunks.resize(data.info.table_count);
 

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -221,7 +221,6 @@ public:
 class HashAggregateLocalSinkState : public LocalSinkState {
 public:
 	HashAggregateLocalSinkState(const PhysicalHashAggregate &op, ExecutionContext &context) {
-
 		auto &payload_types = op.grouped_aggregate_data.payload_types;
 		if (!payload_types.empty()) {
 			aggregate_input_chunk.InitializeEmpty(payload_types);
@@ -415,7 +414,6 @@ SinkResultType PhysicalHashAggregate::Sink(ExecutionContext &context, DataChunk 
 // Combine
 //===--------------------------------------------------------------------===//
 void PhysicalHashAggregate::CombineDistinct(ExecutionContext &context, OperatorSinkCombineInput &input) const {
-
 	auto &global_sink = input.global_state.Cast<HashAggregateGlobalSinkState>();
 	auto &sink = input.local_state.Cast<HashAggregateLocalSinkState>();
 

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -28,7 +28,6 @@ PhysicalUngroupedAggregate::PhysicalUngroupedAggregate(PhysicalPlan &physical_pl
     : PhysicalOperator(physical_plan, PhysicalOperatorType::UNGROUPED_AGGREGATE, std::move(types),
                        estimated_cardinality),
       aggregates(std::move(expressions)) {
-
 	distinct_collection_info = DistinctAggregateCollectionInfo::Create(aggregates);
 	if (!distinct_collection_info) {
 		return;
@@ -239,7 +238,6 @@ public:
 public:
 	void InitializeDistinctAggregates(const PhysicalUngroupedAggregate &op,
 	                                  const UngroupedAggregateGlobalSinkState &gstate, ExecutionContext &context) {
-
 		if (!op.distinct_data) {
 			return;
 		}

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -218,7 +218,6 @@ PhysicalWindow::PhysicalWindow(PhysicalPlan &physical_plan, vector<LogicalType> 
                                PhysicalOperatorType type)
     : PhysicalOperator(physical_plan, type, std::move(types), estimated_cardinality),
       select_list(std::move(select_list_p)), order_idx(0), is_order_dependent(false) {
-
 	idx_t max_orders = 0;
 	for (idx_t i = 0; i < select_list.size(); ++i) {
 		auto &expr = select_list[i];
@@ -271,7 +270,6 @@ static unique_ptr<WindowExecutor> WindowExecutorFactory(BoundWindowExpression &w
 
 WindowGlobalSinkState::WindowGlobalSinkState(const PhysicalWindow &op, ClientContext &client)
     : op(op), client(client), count(0) {
-
 	D_ASSERT(op.select_list[op.order_idx]->GetExpressionClass() == ExpressionClass::BOUND_WINDOW);
 	auto &wexpr = op.select_list[op.order_idx]->Cast<BoundWindowExpression>();
 
@@ -404,7 +402,6 @@ protected:
 
 WindowGlobalSourceState::WindowGlobalSourceState(ClientContext &client, WindowGlobalSinkState &gsink_p)
     : client(client), gsink(gsink_p), next_group(0), locals(0), started(0), finished(0), stopped(false), completed(0) {
-
 	auto &global_partition = *gsink.global_partition;
 	auto hashed_source = global_partition.GetGlobalSourceState(client, *gsink.hashed_sink);
 	auto &hash_groups = global_partition.GetHashGroups(*hashed_source);

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -639,7 +639,6 @@ void StringValueResult::AddValue(StringValueResult &result, const idx_t buffer_p
 }
 
 void StringValueResult::HandleUnicodeError(idx_t col_idx, LinePosition &error_position) {
-
 	bool first_nl = false;
 	auto borked_line = current_line_position.ReconstructCurrentLine(first_nl, buffer_handles, PrintErrorLine());
 	LinesPerBoundary lines_per_batch(iterator.GetBoundaryIdx(), lines_read);

--- a/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
@@ -146,7 +146,6 @@ void CSVSniffer::GenerateStateMachineSearchSpace(vector<unique_ptr<ColumnCountSc
 	for (const auto &comment : dialect_candidates.comment_candidates) {
 		for (const auto quote_escape_candidate : dialect_candidates.quote_escape_candidates) {
 			for (const auto &delimiter : dialect_candidates.delim_candidates) {
-
 				D_ASSERT(buffer_manager);
 				CSVStateMachineOptions state_machine_options(
 				    delimiter, quote_escape_candidate.quote, quote_escape_candidate.escape, comment, new_line_id,

--- a/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
+++ b/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
@@ -495,7 +495,6 @@ const StateMachine &CSVStateMachineCache::Get(const CSVStateMachineOptions &stat
 }
 
 CSVStateMachineCache &CSVStateMachineCache::Get(ClientContext &context) {
-
 	auto &cache = ObjectCache::GetObjectCache(context);
 	return *cache.GetOrCreate<CSVStateMachineCache>(CSVStateMachineCache::ObjectType());
 }

--- a/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
@@ -13,7 +13,6 @@ CSVFileScan::CSVFileScan(ClientContext &context, const OpenFileInfo &file_p, CSV
     : BaseFileReader(file_p), buffer_manager(std::move(buffer_manager_p)),
       error_handler(make_shared_ptr<CSVErrorHandler>(options_p.ignore_errors.GetValue())),
       options(std::move(options_p)) {
-
 	// Initialize Buffer Manager
 	if (!buffer_manager) {
 		buffer_manager = make_shared_ptr<CSVBufferManager>(context, options, file, per_file_single_threaded);

--- a/src/execution/operator/filter/physical_filter.cpp
+++ b/src/execution/operator/filter/physical_filter.cpp
@@ -7,7 +7,6 @@ namespace duckdb {
 PhysicalFilter::PhysicalFilter(PhysicalPlan &physical_plan, vector<LogicalType> types,
                                vector<unique_ptr<Expression>> select_list, idx_t estimated_cardinality)
     : CachingPhysicalOperator(physical_plan, PhysicalOperatorType::FILTER, std::move(types), estimated_cardinality) {
-
 	D_ASSERT(!select_list.empty());
 	if (select_list.size() == 1) {
 		expression = std::move(select_list[0]);

--- a/src/execution/operator/helper/physical_buffered_batch_collector.cpp
+++ b/src/execution/operator/helper/physical_buffered_batch_collector.cpp
@@ -53,7 +53,6 @@ SinkResultType PhysicalBufferedBatchCollector::Sink(ExecutionContext &context, D
 
 SinkNextBatchType PhysicalBufferedBatchCollector::NextBatch(ExecutionContext &context,
                                                             OperatorSinkNextBatchInput &input) const {
-
 	auto &gstate = input.global_state.Cast<BufferedBatchCollectorGlobalState>();
 	auto &lstate = input.local_state.Cast<BufferedBatchCollectorLocalState>();
 

--- a/src/execution/operator/helper/physical_limit.cpp
+++ b/src/execution/operator/helper/physical_limit.cpp
@@ -110,7 +110,6 @@ bool PhysicalLimit::ComputeOffset(ExecutionContext &context, DataChunk &input, o
 }
 
 SinkResultType PhysicalLimit::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
-
 	D_ASSERT(chunk.size() > 0);
 	auto &state = input.local_state.Cast<LimitLocalState>();
 	auto &limit = state.limit;

--- a/src/execution/operator/join/physical_asof_join.cpp
+++ b/src/execution/operator/join/physical_asof_join.cpp
@@ -18,7 +18,6 @@ PhysicalAsOfJoin::PhysicalAsOfJoin(PhysicalPlan &physical_plan, LogicalCompariso
     : PhysicalComparisonJoin(physical_plan, op, PhysicalOperatorType::ASOF_JOIN, std::move(op.conditions), op.join_type,
                              op.estimated_cardinality),
       comparison_type(ExpressionType::INVALID) {
-
 	// Convert the conditions partitions and sorts
 	D_ASSERT(!op.predicate.get());
 	for (auto &cond : conditions) {
@@ -262,7 +261,6 @@ private:
 AsOfPayloadScanner::AsOfPayloadScanner(const SortedRun &sorted_run, const HashedSort &hashed_sort)
     : sorted_run(sorted_run), block_state(*sorted_run.key_data, sorted_run.payload_data.get()),
       scan_state(sorted_run.context, sorted_run.sort), scan_ids(hashed_sort.scan_ids), count(sorted_run.Count()) {
-
 	scan_chunk.Initialize(sorted_run.context, hashed_sort.payload_types);
 	const auto sort_key_type = sorted_run.key_data->GetLayout().GetSortKeyType();
 	switch (sort_key_type) {
@@ -340,7 +338,6 @@ public:
 AsOfGlobalSourceState::AsOfGlobalSourceState(ClientContext &client, const PhysicalAsOfJoin &op)
     : op(op), stage(AsOfJoinSourceStage::INNER), is_right_outer(IsRightOuterJoin(op.join_type)), next_left(0),
       flushed_left(0), next_right(0), flushed_right(0) {
-
 	//	 Take ownership of the hash groups
 	auto &gsink = op.sink_state->Cast<AsOfGlobalSinkState>();
 	hashed_groups.resize(2);
@@ -554,7 +551,6 @@ public:
 AsOfProbeBuffer::AsOfProbeBuffer(ClientContext &client, const PhysicalAsOfJoin &op, AsOfGlobalSourceState &gsource)
     : client(client), op(op), gsource(gsource), strict(IsStrictComparison(op.comparison_type)),
       left_outer(IsLeftOuterJoin(op.join_type)), lhs_executor(client), fetch_next_left(true) {
-
 	lhs_keys.Initialize(client, op.join_key_types);
 	for (const auto &cond : op.conditions) {
 		lhs_executor.AddExpression(*cond.left);
@@ -980,7 +976,6 @@ public:
 AsOfLocalSourceState::AsOfLocalSourceState(ExecutionContext &context, AsOfGlobalSourceState &gsource,
                                            const PhysicalAsOfJoin &op)
     : gsource(gsource), context(context), probe_buffer(context.client, op, gsource), rsel(STANDARD_VECTOR_SIZE) {
-
 	rhs_chunk.Initialize(context.client, op.children[1].get().GetTypes());
 }
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -36,7 +36,6 @@ PhysicalHashJoin::PhysicalHashJoin(PhysicalPlan &physical_plan, LogicalOperator 
     : PhysicalComparisonJoin(physical_plan, op, PhysicalOperatorType::HASH_JOIN, std::move(cond), join_type,
                              estimated_cardinality),
       delim_types(std::move(delim_types)) {
-
 	filter_pushdown = std::move(pushdown_info_p);
 
 	children.push_back(left);
@@ -391,7 +390,6 @@ static bool KeysAreSkewed(const HashJoinGlobalSinkState &sink) {
 //! If we have only one thread, always finalize single-threaded. Otherwise, we finalize in parallel if we
 //! have more than 1M rows or if we want to verify parallelism.
 static bool FinalizeSingleThreaded(const HashJoinGlobalSinkState &sink, const bool consider_skew) {
-
 	// if only one thread, finalize single-threaded
 	const auto num_threads = NumericCast<idx_t>(sink.num_threads);
 	if (num_threads == 1) {

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -19,7 +19,6 @@ PhysicalIEJoin::PhysicalIEJoin(PhysicalPlan &physical_plan, LogicalComparisonJoi
                                idx_t estimated_cardinality, unique_ptr<JoinFilterPushdownInfo> pushdown_info)
     : PhysicalRangeJoin(physical_plan, op, PhysicalOperatorType::IE_JOIN, left, right, std::move(cond), join_type,
                         estimated_cardinality, std::move(pushdown_info)) {
-
 	// 1. let L1 (resp. L2) be the array of column X (resp. Y)
 	D_ASSERT(conditions.size() >= 2);
 	for (idx_t i = 0; i < 2; ++i) {
@@ -125,7 +124,6 @@ public:
 
 	IEJoinLocalState(ExecutionContext &context, const PhysicalRangeJoin &op, IEJoinGlobalState &gstate)
 	    : table(context, *gstate.tables[gstate.child], gstate.child) {
-
 		if (op.filter_pushdown) {
 			local_filter_state = op.filter_pushdown->GetLocalState(*gstate.global_filter_state);
 		}
@@ -463,7 +461,6 @@ bool IEJoinUnion::TemplatedCompareKeys(ExternalBlockIteratorState &state1, const
 
 bool IEJoinUnion::CompareKeys(ExternalBlockIteratorState &state1, const idx_t pos1, ExternalBlockIteratorState &state2,
                               const idx_t pos2, bool strict, const SortKeyType &sort_key_type) {
-
 	switch (sort_key_type) {
 	case SortKeyType::NO_PAYLOAD_FIXED_8:
 		return TemplatedCompareKeys<SortKeyType::NO_PAYLOAD_FIXED_8>(state1, pos1, state2, pos2, strict);

--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -15,7 +15,6 @@ PhysicalNestedLoopJoin::PhysicalNestedLoopJoin(PhysicalPlan &physical_plan, Logi
     : PhysicalComparisonJoin(physical_plan, op, PhysicalOperatorType::NESTED_LOOP_JOIN, std::move(cond), join_type,
                              estimated_cardinality),
       predicate(std::move(op.predicate)) {
-
 	filter_pushdown = std::move(pushdown_info_p);
 	children.push_back(left);
 	children.push_back(right);

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -18,7 +18,6 @@ PhysicalPiecewiseMergeJoin::PhysicalPiecewiseMergeJoin(PhysicalPlan &physical_pl
                                                        unique_ptr<JoinFilterPushdownInfo> pushdown_info_p)
     : PhysicalRangeJoin(physical_plan, op, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, left, right, std::move(cond),
                         join_type, estimated_cardinality, std::move(pushdown_info_p)) {
-
 	for (auto &join_cond : conditions) {
 		D_ASSERT(join_cond.left->return_type == join_cond.right->return_type);
 		join_key_types.push_back(join_cond.left->return_type);
@@ -477,7 +476,6 @@ static idx_t TemplatedMergeJoinComplexBlocks(ChunkMergeInfo &l, ChunkMergeInfo &
 	BLOCK_ITERATOR l_ptr(l.state);
 	BLOCK_ITERATOR r_ptr(r.state);
 	while (true) {
-
 		if (l.entry_idx < prev_left_index) {
 			// left side smaller: found match
 			l.result.set_index(result_count, sel_t(l.entry_idx));

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -40,7 +40,6 @@ PhysicalRangeJoin::LocalSortedTable::LocalSortedTable(ExecutionContext &context,
 }
 
 void PhysicalRangeJoin::LocalSortedTable::Sink(ExecutionContext &context, DataChunk &input) {
-
 	// Obtain sorting columns
 	keys.Reset();
 	executor.Execute(input, keys);
@@ -69,7 +68,6 @@ PhysicalRangeJoin::GlobalSortedTable::GlobalSortedTable(ClientContext &client,
                                                         const vector<LogicalType> &payload_types,
                                                         const PhysicalRangeJoin &op)
     : op(op), has_null(0), count(0), tasks_completed(0) {
-
 	// Set up the sort. We will materialize keys ourselves, so just set up references.
 	vector<BoundOrderByNode> orders;
 	vector<LogicalType> input_types;
@@ -420,7 +418,6 @@ void PhysicalRangeJoin::SliceSortedPayload(DataChunk &chunk, GlobalSortedTable &
                                            ExternalBlockIteratorState &state, TupleDataChunkState &chunk_state,
                                            const idx_t chunk_idx, SelectionVector &result, const idx_t result_count,
                                            SortedRunScanState &scan_state) {
-
 	auto &sorted = *table.sorted;
 	auto &sort_keys = chunk_state.row_locations;
 	const auto sort_key_type = table.GetSortKeyType();

--- a/src/execution/operator/persistent/physical_delete.cpp
+++ b/src/execution/operator/persistent/physical_delete.cpp
@@ -27,7 +27,6 @@ public:
 	explicit DeleteGlobalState(ClientContext &context, const vector<LogicalType> &return_types,
 	                           TableCatalogEntry &table, const vector<unique_ptr<BoundConstraint>> &bound_constraints)
 	    : deleted_count(0), return_collection(context, return_types), has_unique_indexes(false) {
-
 		// We need to append deletes to the local delete-ART.
 		auto &storage = table.GetStorage();
 		if (storage.HasUniqueIndexes()) {

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -36,7 +36,6 @@ PhysicalInsert::PhysicalInsert(PhysicalPlan &physical_plan, vector<LogicalType> 
       set_expressions(std::move(set_expressions)), set_columns(std::move(set_columns)), set_types(std::move(set_types)),
       on_conflict_condition(std::move(on_conflict_condition_p)), do_update_condition(std::move(do_update_condition_p)),
       conflict_target(std::move(conflict_target_p)), update_is_del_and_insert(update_is_del_and_insert) {
-
 	if (action_type == OnConflictAction::THROW) {
 		return;
 	}
@@ -82,7 +81,6 @@ InsertGlobalState::InsertGlobalState(ClientContext &context, const vector<Logica
 InsertLocalState::InsertLocalState(ClientContext &context, const vector<LogicalType> &types,
                                    const vector<unique_ptr<BoundConstraint>> &bound_constraints)
     : collection_index(DConstants::INVALID_INDEX), bound_constraints(bound_constraints) {
-
 	auto &allocator = Allocator::Get(context);
 	update_chunk.Initialize(allocator, types);
 	append_chunk.Initialize(allocator, types);
@@ -189,7 +187,6 @@ static void CombineExistingAndInsertTuples(DataChunk &result, DataChunk &scan_ch
 
 static void CreateUpdateChunk(ExecutionContext &context, DataChunk &chunk, TableCatalogEntry &table, Vector &row_ids,
                               DataChunk &update_chunk, const PhysicalInsert &op) {
-
 	auto &do_update_condition = op.do_update_condition;
 	auto &set_types = op.set_types;
 	auto &set_expressions = op.set_expressions;

--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -10,7 +10,6 @@ PhysicalMergeInto::PhysicalMergeInto(PhysicalPlan &physical_plan, vector<Logical
                                      bool return_chunk_p)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::MERGE_INTO, std::move(types), 1),
       row_id_index(row_id_index), source_marker(source_marker), parallel(parallel_p), return_chunk(return_chunk_p) {
-
 	map<MergeActionCondition, MergeActionRange> ranges;
 	for (auto &entry : actions_p) {
 		MergeActionRange range;

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -25,7 +25,6 @@ PhysicalUpdate::PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> 
       tableref(tableref), table(table), columns(std::move(columns)), expressions(std::move(expressions)),
       bound_defaults(std::move(bound_defaults)), bound_constraints(std::move(bound_constraints)),
       return_chunk(return_chunk), index_update(false) {
-
 	auto &indexes = table.GetDataTableInfo().get()->GetIndexes();
 	auto index_columns = indexes.GetRequiredColumns();
 
@@ -67,7 +66,6 @@ public:
 	                 const vector<LogicalType> &table_types, const vector<unique_ptr<Expression>> &bound_defaults,
 	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints)
 	    : default_executor(context, bound_defaults), bound_constraints(bound_constraints) {
-
 		// Initialize the update chunk.
 		auto &allocator = Allocator::Get(context);
 		vector<LogicalType> update_types;

--- a/src/execution/operator/projection/physical_pivot.cpp
+++ b/src/execution/operator/projection/physical_pivot.cpp
@@ -9,7 +9,6 @@ PhysicalPivot::PhysicalPivot(PhysicalPlan &physical_plan, vector<LogicalType> ty
                              BoundPivotInfo bound_pivot_p)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::PIVOT, std::move(types_p), child.estimated_cardinality),
       bound_pivot(std::move(bound_pivot_p)) {
-
 	children.push_back(child);
 	for (idx_t p = 0; p < bound_pivot.pivot_values.size(); p++) {
 		auto entry = pivot_map.find(bound_pivot.pivot_values[p]);

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -13,7 +13,6 @@ class UnnestOperatorState : public OperatorState {
 public:
 	UnnestOperatorState(ClientContext &context, const vector<unique_ptr<Expression>> &select_list)
 	    : current_row(0), list_position(0), first_fetch(true), input_sel(STANDARD_VECTOR_SIZE), executor(context) {
-
 		// for each UNNEST in the select_list, we add the child expression to the expression executor
 		// and set the return type in the list_data chunk, which will contain the evaluated expression results
 		vector<LogicalType> list_data_types;
@@ -139,7 +138,6 @@ OperatorResultType PhysicalUnnest::ExecuteInternal(ExecutionContext &context, Da
                                                    OperatorState &state_p,
                                                    const vector<unique_ptr<Expression>> &select_list,
                                                    bool include_input) {
-
 	auto &state = state_p.Cast<UnnestOperatorState>();
 
 	do {

--- a/src/execution/operator/scan/physical_positional_scan.cpp
+++ b/src/execution/operator/scan/physical_positional_scan.cpp
@@ -14,7 +14,6 @@ PhysicalPositionalScan::PhysicalPositionalScan(PhysicalPlan &physical_plan, vect
                                                PhysicalOperator &left, PhysicalOperator &right)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::POSITIONAL_SCAN, std::move(types),
                        MaxValue(left.estimated_cardinality, right.estimated_cardinality)) {
-
 	// Manage the children ourselves
 	if (left.type == PhysicalOperatorType::TABLE_SCAN) {
 		child_tables.emplace_back(left);

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -110,7 +110,6 @@ SourceResultType PhysicalTableScan::GetData(ExecutionContext &context, DataChunk
 		function.in_out_function_final(context, data, chunk);
 	}
 	switch (function.in_out_function(context, data, g_state.input_chunk, chunk)) {
-
 	case OperatorResultType::BLOCKED: {
 		auto guard = g_state.Lock();
 		return g_state.BlockSource(guard, input.interrupt_state);

--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -40,7 +40,6 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 		if (existing_db) {
 			if ((existing_db->IsReadOnly() && options.access_mode == AccessMode::READ_WRITE) ||
 			    (!existing_db->IsReadOnly() && options.access_mode == AccessMode::READ_ONLY)) {
-
 				auto existing_mode = existing_db->IsReadOnly() ? AccessMode::READ_ONLY : AccessMode::READ_WRITE;
 				auto existing_mode_str = EnumUtil::ToString(existing_mode);
 				auto attached_mode = EnumUtil::ToString(options.access_mode);

--- a/src/execution/operator/schema/physical_create_art_index.cpp
+++ b/src/execution/operator/schema/physical_create_art_index.cpp
@@ -23,7 +23,6 @@ PhysicalCreateARTIndex::PhysicalCreateARTIndex(PhysicalPlan &physical_plan, Logi
     : PhysicalOperator(physical_plan, PhysicalOperatorType::CREATE_INDEX, op.types, estimated_cardinality),
       table(table_p.Cast<DuckTableEntry>()), info(std::move(info)), unbound_expressions(std::move(unbound_expressions)),
       sorted(sorted), alter_table_info(std::move(alter_table_info)) {
-
 	// Convert the logical column ids to physical column ids.
 	for (auto &column_id : column_ids) {
 		storage_ids.push_back(table.GetColumns().LogicalToPhysical(LogicalIndex(column_id)).index);
@@ -85,7 +84,6 @@ unique_ptr<LocalSinkState> PhysicalCreateARTIndex::GetLocalSinkState(ExecutionCo
 }
 
 SinkResultType PhysicalCreateARTIndex::SinkUnsorted(OperatorSinkInput &input) const {
-
 	auto &l_state = input.local_state.Cast<CreateARTIndexLocalSinkState>();
 	auto row_count = l_state.key_chunk.size();
 	auto &art = l_state.local_index->Cast<ART>();
@@ -105,7 +103,6 @@ SinkResultType PhysicalCreateARTIndex::SinkUnsorted(OperatorSinkInput &input) co
 }
 
 SinkResultType PhysicalCreateARTIndex::SinkSorted(OperatorSinkInput &input) const {
-
 	auto &l_state = input.local_state.Cast<CreateARTIndexLocalSinkState>();
 	auto &storage = table.GetStorage();
 	auto &l_index = l_state.local_index;

--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -34,7 +34,6 @@ class RecursiveCTEState : public GlobalSinkState {
 public:
 	explicit RecursiveCTEState(ClientContext &context, const PhysicalRecursiveCTE &op)
 	    : intermediate_table(context, op.GetTypes()), new_groups(STANDARD_VECTOR_SIZE) {
-
 		vector<BoundAggregateExpression *> payload_aggregates_ptr;
 		for (idx_t i = 0; i < op.payload_aggregates.size(); i++) {
 			auto &dat = op.payload_aggregates[i];

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -301,7 +301,6 @@ bool CachingPhysicalOperator::CanCacheType(const LogicalType &type) {
 CachingPhysicalOperator::CachingPhysicalOperator(PhysicalPlan &physical_plan, PhysicalOperatorType type,
                                                  vector<LogicalType> types_p, idx_t estimated_cardinality)
     : PhysicalOperator(physical_plan, type, std::move(types_p), estimated_cardinality) {
-
 	caching_supported = true;
 	for (auto &col_type : types) {
 		if (!CanCacheType(col_type)) {

--- a/src/execution/physical_plan/plan_asof_join.cpp
+++ b/src/execution/physical_plan/plan_asof_join.cpp
@@ -20,7 +20,6 @@ namespace duckdb {
 
 optional_ptr<PhysicalOperator>
 PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOperator &probe, PhysicalOperator &build) {
-
 	// Plan a inverse nested loop join, then aggregate the values to choose the optimal match for each probe row.
 	// Use a row number primary key to handle duplicate probe values.
 	// aggregate the fields to produce at most one match per probe row,

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -208,7 +208,6 @@ RadixHTGlobalSinkState::RadixHTGlobalSinkState(ClientContext &context_p, const R
       any_combined(false), radix_ht(radix_ht_p), config(*this), stored_allocators_size(0), finalize_done(0),
       scan_pin_properties(TupleDataPinProperties::DESTROY_AFTER_DONE), count_before_combining(0),
       max_partition_size(0) {
-
 	// Compute minimum reservation
 	auto block_alloc_size = BufferManager::GetBufferManager(context).GetBlockAllocSize();
 	auto tuples_per_block = block_alloc_size / radix_ht.GetLayout().GetRowWidth();

--- a/src/execution/sample/base_reservoir_sample.cpp
+++ b/src/execution/sample/base_reservoir_sample.cpp
@@ -60,7 +60,6 @@ void BaseReservoirSampling::SetNextEntry() {
 }
 
 void BaseReservoirSampling::ReplaceElementWithIndex(idx_t entry_index, double with_weight, bool pop) {
-
 	if (pop) {
 		reservoir_weights.pop();
 	}

--- a/src/execution/sample/reservoir_sample.cpp
+++ b/src/execution/sample/reservoir_sample.cpp
@@ -190,7 +190,6 @@ void ReservoirSample::Vacuum() {
 }
 
 unique_ptr<BlockingSample> ReservoirSample::Copy() const {
-
 	auto ret = make_uniq<ReservoirSample>(sample_count);
 	ret->stats_sample = stats_sample;
 
@@ -564,7 +563,6 @@ T ReservoirSample::GetReservoirChunkCapacity() const {
 }
 
 idx_t ReservoirSample::FillReservoir(DataChunk &chunk) {
-
 	idx_t ingested_count = 0;
 	if (!reservoir_chunk) {
 		if (chunk.size() > FIXED_SAMPLE_SIZE) {
@@ -609,7 +607,6 @@ SelectionVectorHelper ReservoirSample::GetReplacementIndexes(idx_t sample_chunk_
 }
 
 SelectionVectorHelper ReservoirSample::GetReplacementIndexesFast(idx_t sample_chunk_offset, idx_t chunk_length) {
-
 	// how much weight to the other tuples have compared to the ones in this chunk?
 	auto weight_tuples_other = static_cast<double>(chunk_length) / static_cast<double>(GetTuplesSeen() + chunk_length);
 	auto num_to_pop = static_cast<uint32_t>(round(weight_tuples_other * static_cast<double>(sample_count)));

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -519,7 +519,6 @@ void SpecializeMinMaxNFunction(PhysicalType arg_type, AggregateFunction &functio
 template <class COMPARATOR>
 unique_ptr<FunctionData> MinMaxNBind(ClientContext &context, AggregateFunction &function,
                                      vector<unique_ptr<Expression>> &arguments) {
-
 	for (auto &arg : arguments) {
 		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -25,7 +25,6 @@ struct SortedAggregateBindData : public FunctionData {
 	                        BindInfoPtr &bind_info, OrderBys &order_bys)
 	    : context(context), function(aggregate), bind_info(std::move(bind_info)),
 	      threshold(DBConfig::GetSetting<OrderedAggregateThresholdSetting>(context)) {
-
 		//	Describe the arguments.
 		for (const auto &child : children) {
 			buffered_cols.emplace_back(buffered_cols.size());
@@ -434,7 +433,6 @@ struct SortedAggregateFunction {
 
 	static void ProjectInputs(Vector inputs[], const SortedAggregateBindData &order_bind, idx_t input_count,
 	                          idx_t count, DataChunk &buffered) {
-
 		//	Only reference the buffered columns
 		buffered.InitializeEmpty(order_bind.buffered_types);
 		const auto &buffered_cols = order_bind.buffered_cols;

--- a/src/function/cast/array_casts.cpp
+++ b/src/function/cast/array_casts.cpp
@@ -39,7 +39,6 @@ unique_ptr<FunctionLocalState> ArrayBoundCastData::InitArrayLocalState(CastLocal
 // ARRAY -> ARRAY
 //------------------------------------------------------------------------------
 static bool ArrayToArrayCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-
 	auto source_array_size = ArrayType::GetSize(source.GetType());
 	auto target_array_size = ArrayType::GetSize(result.GetType());
 	if (source_array_size != target_array_size) {

--- a/src/function/cast/geo_casts.cpp
+++ b/src/function/cast/geo_casts.cpp
@@ -11,7 +11,6 @@ static bool GeometryToVarcharCast(Vector &source, Vector &result, idx_t count, C
 }
 
 BoundCastInfo DefaultCasts::GeoCastSwitch(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
-
 	// now switch on the result type
 	switch (target.id()) {
 	case LogicalTypeId::VARCHAR:

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -268,7 +268,6 @@ StructToMapBoundCastData::InitStructToMapCastLocalState(CastLocalStateParameters
 }
 
 static bool StructToMapCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-
 	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		// Optimization: if the source vector is constant, we only have a single physical element, so we can set the
 		// result vectortype to ConstantVector as well and set the (logical) count to 1

--- a/src/function/cast/union_casts.cpp
+++ b/src/function/cast/union_casts.cpp
@@ -56,7 +56,6 @@ static unique_ptr<BoundCastData> BindToUnionCast(BindCastInput &input, const Log
 
 	// check if the cast is ambiguous (2 or more casts have the same cost)
 	if (candidates.size() > 1 && candidates[1].cost == selected_cost) {
-
 		// collect all the ambiguous types
 		auto message = StringUtil::Format(
 		    "Type %s can't be cast as %s. The cast is ambiguous, multiple possible members in target: ", source,
@@ -107,7 +106,6 @@ static bool ToUnionCast(Vector &source, Vector &result, idx_t count, CastParamet
 
 BoundCastInfo DefaultCasts::ImplicitToUnionCast(BindCastInput &input, const LogicalType &source,
                                                 const LogicalType &target) {
-
 	D_ASSERT(target.id() == LogicalTypeId::UNION);
 	if (StructToUnionCast::AllowImplicitCastFromStruct(source, target)) {
 		return StructToUnionCast::Bind(input, source, target);
@@ -130,7 +128,6 @@ BoundCastInfo DefaultCasts::ImplicitToUnionCast(BindCastInput &input, const Logi
 // INVALID:	UNION(A, B, D) 	->	UNION(A, B, C)
 
 struct UnionUnionBoundCastData : public BoundCastData {
-
 	// mapping from source member index to target member index
 	// these are always the same size as the source member count
 	// (since all source members must be present in the target)
@@ -284,7 +281,6 @@ static bool UnionToUnionCast(Vector &source, Vector &result, idx_t count, CastPa
 				FlatVector::GetData<union_tag_t>(result_tag_vector)[row_idx] =
 				    UnsafeNumericCast<union_tag_t>(target_tag);
 			} else {
-
 				// Issue: The members of the result is not always flatvectors
 				// In the case of TryNullCast, the result member is constant.
 				FlatVector::SetNull(result, row_idx, true);

--- a/src/function/cast_rules.cpp
+++ b/src/function/cast_rules.cpp
@@ -146,7 +146,6 @@ static int64_t ImplicitCastUSmallint(const LogicalType &to) {
 
 static int64_t ImplicitCastUInteger(const LogicalType &to) {
 	switch (to.id()) {
-
 	case LogicalTypeId::UBIGINT:
 	case LogicalTypeId::BIGINT:
 	case LogicalTypeId::UHUGEINT:
@@ -187,7 +186,6 @@ static int64_t ImplicitCastFloat(const LogicalType &to) {
 
 static int64_t ImplicitCastDouble(const LogicalType &to) {
 	switch (to.id()) {
-
 	case LogicalTypeId::BIGNUM:
 		return TargetTypeCost(to);
 	default:
@@ -500,7 +498,6 @@ int64_t CastRules::ImplicitCast(const LogicalType &from, const LogicalType &to) 
 
 		int64_t cost = -1;
 		if (named_struct_cast) {
-
 			// Collect the target members in a map for easy lookup
 			case_insensitive_map_t<idx_t> target_members;
 			for (idx_t target_idx = 0; target_idx < target_children.size(); target_idx++) {

--- a/src/function/copy_blob.cpp
+++ b/src/function/copy_blob.cpp
@@ -61,7 +61,6 @@ struct WriteBlobGlobalState final : public GlobalFunctionData {
 
 unique_ptr<GlobalFunctionData> WriteBlobInitializeGlobal(ClientContext &context, FunctionData &bind_data,
                                                          const string &file_path) {
-
 	auto &bdata = bind_data.Cast<WriteBlobBindData>();
 	auto &fs = FileSystem::GetFileSystem(context);
 
@@ -102,7 +101,6 @@ void WriteBlobSink(ExecutionContext &context, FunctionData &bind_data, GlobalFun
 	for (idx_t row_idx = 0; row_idx < input.size(); row_idx++) {
 		const auto out_idx = vdata.sel->get_index(row_idx);
 		if (vdata.validity.RowIsValid(out_idx)) {
-
 			auto &blob = blobs[out_idx];
 			auto blob_len = blob.GetSize();
 			auto blob_ptr = blob.GetDataWriteable();

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -436,7 +436,6 @@ static void HandleCollations(ClientContext &context, ScalarFunction &bound_funct
 static void InferTemplateType(ClientContext &context, const LogicalType &source, const LogicalType &target,
                               case_insensitive_map_t<vector<LogicalType>> &bindings, const Expression &current_expr,
                               const BaseScalarFunction &function) {
-
 	if (target.id() == LogicalTypeId::UNKNOWN || target.id() == LogicalTypeId::SQLNULL) {
 		// If the actual type is unknown, we cannot infer anything more.
 		// Therefore, we map all remaining templates in the source to UNKNOWN or SQLNULL, if not already inferred to
@@ -517,7 +516,6 @@ static void InferTemplateType(ClientContext &context, const LogicalType &source,
 	case LogicalTypeId::ARRAY: {
 		if ((source.id() == LogicalTypeId::ARRAY || source.id() == LogicalTypeId::LIST) &&
 		    (target.id() == LogicalTypeId::LIST || target.id() == LogicalTypeId::ARRAY)) {
-
 			const auto &source_child =
 			    source.id() == LogicalTypeId::LIST ? ListType::GetChildType(source) : ArrayType::GetChildType(source);
 			const auto &target_child =
@@ -565,7 +563,6 @@ static void InferTemplateType(ClientContext &context, const LogicalType &source,
 
 static void SubstituteTemplateType(LogicalType &type, case_insensitive_map_t<vector<LogicalType>> &bindings,
                                    const string &function_name) {
-
 	// Replace all template types in with their bound concrete types.
 	type = TypeVisitor::VisitReplace(type, [&](const LogicalType &t) -> LogicalType {
 		if (t.id() == LogicalTypeId::TEMPLATE) {
@@ -647,7 +644,6 @@ void FunctionBinder::CheckTemplateTypesResolved(const BaseScalarFunction &bound_
 unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunction bound_function,
                                                           vector<unique_ptr<Expression>> children, bool is_operator,
                                                           optional_ptr<Binder> binder) {
-
 	// Attempt to resolve template types, before we call the "Bind" callback.
 	ResolveTemplateTypes(bound_function, children);
 
@@ -698,7 +694,6 @@ unique_ptr<BoundAggregateExpression> FunctionBinder::BindAggregateFunction(Aggre
                                                                            vector<unique_ptr<Expression>> children,
                                                                            unique_ptr<Expression> filter,
                                                                            AggregateType aggr_type) {
-
 	ResolveTemplateTypes(bound_function, children);
 
 	unique_ptr<FunctionData> bind_info;

--- a/src/function/macro_function.cpp
+++ b/src/function/macro_function.cpp
@@ -45,7 +45,6 @@ MacroBindResult MacroFunction::BindMacroFunction(
     Binder &binder, const vector<unique_ptr<MacroFunction>> &functions, const string &name,
     FunctionExpression &function_expr, vector<unique_ptr<ParsedExpression>> &positional_arguments,
     InsertionOrderPreservingMap<unique_ptr<ParsedExpression>> &named_arguments, idx_t depth) {
-
 	ExpressionBinder expr_binder(binder, binder.context);
 	expr_binder.lambda_bindings = binder.lambda_bindings;
 	// Find argument types and separate positional and default arguments

--- a/src/function/scalar/date/strftime.cpp
+++ b/src/function/scalar/date/strftime.cpp
@@ -148,7 +148,6 @@ inline bool StrpTimeTryResult(StrpTimeFormat &format, string_t &input, timestamp
 }
 
 struct StrpTimeFunction {
-
 	template <typename T>
 	static void Parse(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();

--- a/src/function/scalar/list/list_resize.cpp
+++ b/src/function/scalar/list/list_resize.cpp
@@ -8,7 +8,6 @@
 namespace duckdb {
 
 static void ListResizeFunction(DataChunk &args, ExpressionState &, Vector &result) {
-
 	// Early-out, if the return value is a constant NULL.
 	if (result.GetType().id() == LogicalTypeId::SQLNULL) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
@@ -63,7 +62,6 @@ static void ListResizeFunction(DataChunk &args, ExpressionState &, Vector &resul
 
 	idx_t offset = 0;
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-
 		auto list_idx = lists_data.sel->get_index(row_idx);
 		auto new_size_idx = new_sizes_data.sel->get_index(row_idx);
 

--- a/src/function/scalar/list/list_zip.cpp
+++ b/src/function/scalar/list/list_zip.cpp
@@ -160,7 +160,6 @@ static unique_ptr<FunctionData> ListZipBind(ClientContext &context, ScalarFuncti
 }
 
 ScalarFunction ListZipFun::GetFunction() {
-
 	auto fun = ScalarFunction({}, LogicalType::LIST(LogicalTypeId::STRUCT), ListZipFunction, ListZipBind);
 	fun.varargs = LogicalType::ANY;
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -277,7 +277,6 @@ void SerializeDecimalArithmetic(Serializer &serializer, const optional_ptr<Funct
 // TODO this is partially duplicated from the bind
 template <class OP, class OPOVERFLOWCHECK, bool IS_SUBTRACT = false>
 unique_ptr<FunctionData> DeserializeDecimalArithmetic(Deserializer &deserializer, ScalarFunction &bound_function) {
-
 	//	// re-change the function pointers
 	auto check_overflow = deserializer.ReadProperty<bool>(100, "check_overflow");
 	auto return_type = deserializer.ReadProperty<LogicalType>(101, "return_type");
@@ -589,7 +588,6 @@ struct DecimalNegateBindData : public FunctionData {
 
 unique_ptr<FunctionData> DecimalNegateBind(ClientContext &context, ScalarFunction &bound_function,
                                            vector<unique_ptr<Expression>> &arguments) {
-
 	auto bind_data = make_uniq<DecimalNegateBindData>();
 
 	auto &decimal_type = arguments[0]->return_type;
@@ -861,7 +859,6 @@ struct MultiplyPropagateStatistics {
 
 unique_ptr<FunctionData> BindDecimalMultiply(ClientContext &context, ScalarFunction &bound_function,
                                              vector<unique_ptr<Expression>> &arguments) {
-
 	auto bind_data = make_uniq<DecimalArithmeticBindData>();
 
 	uint8_t result_width = 0, result_scale = 0;

--- a/src/function/scalar/string/regexp/regexp_extract_all.cpp
+++ b/src/function/scalar/string/regexp/regexp_extract_all.cpp
@@ -24,7 +24,6 @@ RegexpExtractAll::InitLocalState(ExpressionState &state, const BoundFunctionExpr
 // Forwards startpos automatically
 bool ExtractAll(duckdb_re2::StringPiece &input, duckdb_re2::RE2 &pattern, idx_t *startpos,
                 duckdb_re2::StringPiece *groups, int ngroups) {
-
 	D_ASSERT(pattern.ok());
 	D_ASSERT(pattern.NumberOfCapturingGroups() == ngroups);
 

--- a/src/function/scalar/string/substring.cpp
+++ b/src/function/scalar/string/substring.cpp
@@ -16,7 +16,6 @@ static const int64_t SUPPORTED_UPPER_BOUND = NumericLimits<uint32_t>::Maximum();
 static const int64_t SUPPORTED_LOWER_BOUND = -SUPPORTED_UPPER_BOUND - 1;
 
 static inline void AssertInSupportedRange(idx_t input_size, int64_t offset, int64_t length) {
-
 	if (input_size > (uint64_t)SUPPORTED_UPPER_BOUND) {
 		throw OutOfRangeException("Substring input size is too large (> %d)", SUPPORTED_UPPER_BOUND);
 	}

--- a/src/function/scalar/struct/struct_concat.cpp
+++ b/src/function/scalar/struct/struct_concat.cpp
@@ -33,7 +33,6 @@ static void StructConcatFunction(DataChunk &args, ExpressionState &state, Vector
 
 static unique_ptr<FunctionData> StructConcatBind(ClientContext &context, ScalarFunction &bound_function,
                                                  vector<unique_ptr<Expression>> &arguments) {
-
 	// collect names and deconflict, construct return type
 	if (arguments.empty()) {
 		throw InvalidInputException("struct_concat: At least one argument is required");

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -185,7 +185,6 @@ void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &r
 
 unique_ptr<FunctionData> BindAggregateState(ClientContext &context, ScalarFunction &bound_function,
                                             vector<unique_ptr<Expression>> &arguments) {
-
 	// grab the aggregate type and bind the aggregate again
 
 	// the aggregate name and types are in the logical type of the aggregate state, make sure its sane

--- a/src/function/scalar/system/parse_log_message.cpp
+++ b/src/function/scalar/system/parse_log_message.cpp
@@ -29,7 +29,6 @@ struct ParseLogMessageData : FunctionData {
 
 unique_ptr<FunctionData> ParseLogMessageBind(ClientContext &context, ScalarFunction &bound_function,
                                              vector<unique_ptr<Expression>> &arguments) {
-
 	if (arguments.size() != 2) {
 		throw BinderException("structured_log_schema: expects 1 argument", arguments[0]->alias);
 	}

--- a/src/function/scalar/variant/variant_utils.cpp
+++ b/src/function/scalar/variant/variant_utils.cpp
@@ -79,7 +79,6 @@ vector<string> VariantUtils::GetObjectKeys(const UnifiedVariantVectorData &varia
 void VariantUtils::FindChildValues(const UnifiedVariantVectorData &variant, const VariantPathComponent &component,
                                    optional_ptr<const SelectionVector> sel, SelectionVector &res,
                                    ValidityMask &res_validity, VariantNestedData *nested_data, idx_t count) {
-
 	for (idx_t i = 0; i < count; i++) {
 		auto row_index = sel ? sel->get_index(i) : i;
 

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -257,7 +257,6 @@ static void ArrowToDuckDBList(Vector &vector, ArrowArray &array, idx_t chunk_off
 static void ArrowToDuckDBArray(Vector &vector, ArrowArray &array, idx_t chunk_offset, ArrowArrayScanState &array_state,
                                idx_t size, const ArrowType &arrow_type, int64_t nested_offset,
                                const ValidityMask *parent_mask, int64_t parent_offset) {
-
 	auto &array_info = arrow_type.GetTypeInfo<ArrowArrayInfo>();
 	auto array_size = array_info.FixedSize();
 	auto child_count = array_size * size;
@@ -695,7 +694,6 @@ template <class SRC>
 void ConvertDecimal(SRC src_ptr, Vector &vector, ArrowArray &array, idx_t size, int64_t nested_offset,
                     uint64_t parent_offset, idx_t chunk_offset, ValidityMask &val_mask,
                     DecimalBitWidth arrow_bit_width) {
-
 	switch (vector.GetType().InternalType()) {
 	case PhysicalType::INT16: {
 		auto tgt_ptr = FlatVector::GetData<int16_t>(vector);
@@ -1184,7 +1182,6 @@ static void SetSelectionVectorLoop(SelectionVector &sel, data_ptr_t indices_p, i
 
 template <class T>
 static void SetSelectionVectorLoopWithChecks(SelectionVector &sel, data_ptr_t indices_p, idx_t size) {
-
 	auto indices = reinterpret_cast<T *>(indices_p);
 	for (idx_t row = 0; row < size; row++) {
 		if (indices[row] > NumericLimits<uint32_t>::Maximum()) {

--- a/src/function/table/summary.cpp
+++ b/src/function/table/summary.cpp
@@ -9,7 +9,6 @@ namespace duckdb {
 
 static unique_ptr<FunctionData> SummaryFunctionBind(ClientContext &context, TableFunctionBindInput &input,
                                                     vector<LogicalType> &return_types, vector<string> &names) {
-
 	return_types.emplace_back(LogicalType::VARCHAR);
 	names.emplace_back("summary");
 

--- a/src/function/table/system/pragma_table_sample.cpp
+++ b/src/function/table/system/pragma_table_sample.cpp
@@ -32,7 +32,6 @@ struct DuckDBTableSampleOperatorData : public GlobalTableFunctionState {
 
 static unique_ptr<FunctionData> DuckDBTableSampleBind(ClientContext &context, TableFunctionBindInput &input,
                                                       vector<LogicalType> &return_types, vector<string> &names) {
-
 	// look up the table name in the catalog
 	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
 	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);

--- a/src/function/table/system/pragma_user_agent.cpp
+++ b/src/function/table/system/pragma_user_agent.cpp
@@ -13,7 +13,6 @@ struct PragmaUserAgentData : public GlobalTableFunctionState {
 
 static unique_ptr<FunctionData> PragmaUserAgentBind(ClientContext &context, TableFunctionBindInput &input,
                                                     vector<LogicalType> &return_types, vector<string> &names) {
-
 	names.emplace_back("user_agent");
 	return_types.emplace_back(LogicalType::VARCHAR);
 

--- a/src/function/udf_function.cpp
+++ b/src/function/udf_function.cpp
@@ -9,7 +9,6 @@ namespace duckdb {
 
 void UDFWrapper::RegisterFunction(string name, vector<LogicalType> args, LogicalType ret_type,
                                   scalar_function_t udf_function, ClientContext &context, LogicalType varargs) {
-
 	ScalarFunction scalar_function(std::move(name), std::move(args), std::move(ret_type), std::move(udf_function));
 	scalar_function.varargs = std::move(varargs);
 	scalar_function.null_handling = FunctionNullHandling::SPECIAL_HANDLING;

--- a/src/function/window/window_aggregate_function.cpp
+++ b/src/function/window/window_aggregate_function.cpp
@@ -52,7 +52,6 @@ static BoundWindowExpression &SimplifyWindowedAggregate(BoundWindowExpression &w
 WindowAggregateExecutor::WindowAggregateExecutor(BoundWindowExpression &wexpr, ClientContext &client,
                                                  WindowSharedExpressions &shared, WindowAggregationMode mode)
     : WindowExecutor(SimplifyWindowedAggregate(wexpr, client), shared), mode(mode) {
-
 	// Force naive for SEPARATE mode or for (currently!) unsupported functionality
 	if (!ClientConfig::GetConfig(client).enable_optimizer || mode == WindowAggregationMode::SEPARATE) {
 		if (!WindowNaiveAggregator::CanAggregate(wexpr)) {
@@ -111,7 +110,6 @@ public:
 	                                  const WindowAggregator &aggregator)
 	    : WindowExecutorBoundsLocalState(context, gstate.Cast<WindowAggregateExecutorGlobalState>()),
 	      filter_executor(context.client) {
-
 		auto &gastate = gstate.Cast<WindowAggregateExecutorGlobalState>();
 		aggregator_state = aggregator.GetLocalState(context, *gastate.gsink);
 

--- a/src/function/window/window_aggregator.cpp
+++ b/src/function/window/window_aggregator.cpp
@@ -12,7 +12,6 @@ namespace duckdb {
 WindowAggregator::WindowAggregator(const BoundWindowExpression &wexpr)
     : wexpr(wexpr), aggr(wexpr), result_type(wexpr.return_type), state_size(aggr.function.state_size(aggr.function)),
       exclude_mode(wexpr.exclude_clause) {
-
 	for (auto &child : wexpr.children) {
 		arg_types.emplace_back(child->return_type);
 	}
@@ -32,7 +31,6 @@ WindowAggregatorGlobalState::WindowAggregatorGlobalState(ClientContext &client, 
                                                          idx_t group_count)
     : client(client), allocator(Allocator::DefaultAllocator()), aggregator(aggregator_p), aggr(aggregator.wexpr),
       locals(0), finalized(0) {
-
 	if (aggr.filter) {
 		// 	Start with all invalid and set the ones that pass
 		filter_mask.Initialize(group_count, false);

--- a/src/function/window/window_boundaries_state.cpp
+++ b/src/function/window/window_boundaries_state.cpp
@@ -620,7 +620,6 @@ void WindowBoundariesState::PartitionEnd(DataChunk &bounds, idx_t row_idx, const
 
 void WindowBoundariesState::PeerBegin(DataChunk &bounds, idx_t row_idx, const idx_t count, bool is_jump,
                                       const ValidityMask &partition_mask, const ValidityMask &order_mask) {
-
 	auto peer_begin_data = FlatVector::GetData<idx_t>(bounds.data[PEER_BEGIN]);
 
 	//	OVER()

--- a/src/function/window/window_constant_aggregator.cpp
+++ b/src/function/window/window_constant_aggregator.cpp
@@ -35,7 +35,6 @@ WindowConstantAggregatorGlobalState::WindowConstantAggregatorGlobalState(ClientC
                                                                          idx_t group_count,
                                                                          const ValidityMask &partition_mask)
     : WindowAggregatorGlobalState(context, aggregator, STANDARD_VECTOR_SIZE), statef(aggr) {
-
 	// Locate the partition boundaries
 	if (partition_mask.AllValid()) {
 		partition_offsets.emplace_back(0);
@@ -201,7 +200,6 @@ BoundWindowExpression &WindowConstantAggregator::RebindAggregate(ClientContext &
 WindowConstantAggregator::WindowConstantAggregator(BoundWindowExpression &wexpr, WindowSharedExpressions &shared,
                                                    ClientContext &context)
     : WindowAggregator(RebindAggregate(context, wexpr)) {
-
 	// We only need these values for Sink
 	for (auto &child : wexpr.children) {
 		child_idx.emplace_back(shared.RegisterSink(child));

--- a/src/function/window/window_distinct_aggregator.cpp
+++ b/src/function/window/window_distinct_aggregator.cpp
@@ -124,7 +124,6 @@ WindowDistinctAggregatorGlobalState::WindowDistinctAggregatorGlobalState(ClientC
                                                                          idx_t group_count)
     : WindowAggregatorGlobalState(client, aggregator, group_count), stage(WindowDistinctSortStage::INIT),
       tasks_assigned(0), tasks_completed(0), merge_sort_tree(*this, group_count), levels_flat_native(aggr) {
-
 	//	1:	functionComputePrevIdcs(𝑖𝑛)
 	//	2:		sorted ← []
 	//	We sort the aggregate arguments and use the partition index as a tie-breaker.
@@ -704,7 +703,6 @@ unique_ptr<LocalSinkState> WindowDistinctAggregator::GetLocalState(ExecutionCont
 
 void WindowDistinctAggregator::Evaluate(ExecutionContext &context, const DataChunk &bounds, Vector &result, idx_t count,
                                         idx_t row_idx, OperatorSinkInput &sink) const {
-
 	const auto &gdstate = sink.global_state.Cast<WindowDistinctAggregatorGlobalState>();
 	auto &ldstate = sink.local_state.Cast<WindowDistinctAggregatorLocalState>();
 	ldstate.Evaluate(context, gdstate, bounds, result, count, row_idx);

--- a/src/function/window/window_naive_aggregator.cpp
+++ b/src/function/window/window_naive_aggregator.cpp
@@ -13,7 +13,6 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 WindowNaiveAggregator::WindowNaiveAggregator(const WindowAggregateExecutor &executor, WindowSharedExpressions &shared)
     : WindowAggregator(executor.wexpr, shared), executor(executor) {
-
 	for (const auto &order : wexpr.arg_orders) {
 		arg_order_idx.emplace_back(shared.RegisterCollection(order.expression, false));
 	}

--- a/src/function/window/window_rank_function.cpp
+++ b/src/function/window/window_rank_function.cpp
@@ -104,7 +104,6 @@ void WindowPeerLocalState::NextRank(idx_t partition_begin, idx_t peer_begin, idx
 //===--------------------------------------------------------------------===//
 WindowPeerExecutor::WindowPeerExecutor(BoundWindowExpression &wexpr, WindowSharedExpressions &shared)
     : WindowExecutor(wexpr, shared) {
-
 	for (const auto &order : wexpr.arg_orders) {
 		arg_order_idx.emplace_back(shared.RegisterSink(order.expression));
 	}

--- a/src/function/window/window_rownumber_function.cpp
+++ b/src/function/window/window_rownumber_function.cpp
@@ -92,7 +92,6 @@ void WindowRowNumberLocalState::Finalize(ExecutionContext &context, CollectionPt
 //===--------------------------------------------------------------------===//
 WindowRowNumberExecutor::WindowRowNumberExecutor(BoundWindowExpression &wexpr, WindowSharedExpressions &shared)
     : WindowExecutor(wexpr, shared) {
-
 	for (const auto &order : wexpr.arg_orders) {
 		arg_order_idx.emplace_back(shared.RegisterSink(order.expression));
 	}
@@ -142,7 +141,6 @@ void WindowRowNumberExecutor::EvaluateInternal(ExecutionContext &context, DataCh
 //===--------------------------------------------------------------------===//
 WindowNtileExecutor::WindowNtileExecutor(BoundWindowExpression &wexpr, WindowSharedExpressions &shared)
     : WindowRowNumberExecutor(wexpr, shared) {
-
 	// NTILE has one argument
 	ntile_idx = shared.RegisterEvaluate(wexpr.children[0]);
 }

--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -164,7 +164,6 @@ WindowSegmentTreePart::WindowSegmentTreePart(ArenaAllocator &allocator, const Ag
       filter_mask(filter_mask), state_size(aggr.function.state_size(aggr.function)),
       state(state_size * STANDARD_VECTOR_SIZE), cursor(std::move(cursor_p)), statep(LogicalType::POINTER),
       statel(LogicalType::POINTER), statef(LogicalType::POINTER), flush_count(0) {
-
 	auto &inputs = cursor->chunk;
 	if (inputs.ColumnCount() > 0) {
 		leaves.Initialize(Allocator::DefaultAllocator(), inputs.GetTypes());
@@ -298,7 +297,6 @@ void WindowSegmentTreePart::Finalize(Vector &result, idx_t count) {
 WindowSegmentTreeGlobalState::WindowSegmentTreeGlobalState(ClientContext &context, const WindowSegmentTree &aggregator,
                                                            idx_t group_count)
     : WindowAggregatorGlobalState(context, aggregator, group_count), tree(aggregator), levels_flat_native(aggr) {
-
 	D_ASSERT(!aggregator.wexpr.children.empty());
 
 	// compute space required to store internal nodes of segment tree
@@ -570,7 +568,6 @@ void WindowSegmentTreePart::EvaluateUpperLevels(const WindowSegmentTreeGlobalSta
 void WindowSegmentTreePart::EvaluateLeaves(const WindowSegmentTreeGlobalState &tree, const idx_t *begins,
                                            const idx_t *ends, const idx_t *bounds, idx_t count, idx_t row_idx,
                                            FramePart frame_part, FramePart leaf_part) {
-
 	auto fdata = FlatVector::GetData<data_ptr_t>(statef);
 
 	// For order-sensitive aggregates, we have to process the ragged leaves in two pieces.

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -23,7 +23,6 @@ public:
 	                       const ValidityMask &partition_mask, const ValidityMask &order_mask)
 	    : WindowExecutorGlobalState(client, executor, payload_count, partition_mask, order_mask),
 	      ignore_nulls(&all_valid), child_idx(executor.child_idx) {
-
 		if (!executor.arg_order_idx.empty()) {
 			value_tree =
 			    make_uniq<WindowIndexTree>(client, executor.wexpr.arg_orders, executor.arg_order_idx, payload_count);
@@ -139,7 +138,6 @@ void WindowValueLocalState::Finalize(ExecutionContext &context, CollectionPtr co
 //===--------------------------------------------------------------------===//
 WindowValueExecutor::WindowValueExecutor(BoundWindowExpression &wexpr, WindowSharedExpressions &shared)
     : WindowExecutor(wexpr, shared) {
-
 	for (const auto &order : wexpr.arg_orders) {
 		arg_order_idx.emplace_back(shared.RegisterSink(order.expression));
 	}
@@ -200,7 +198,6 @@ public:
 	                                  const idx_t payload_count, const ValidityMask &partition_mask,
 	                                  const ValidityMask &order_mask)
 	    : WindowValueGlobalState(client, executor, payload_count, partition_mask, order_mask) {
-
 		if (value_tree) {
 			use_framing = true;
 
@@ -842,7 +839,6 @@ static fill_value_t GetFillValueFunction(const LogicalType &type) {
 
 WindowFillExecutor::WindowFillExecutor(BoundWindowExpression &wexpr, WindowSharedExpressions &shared)
     : WindowValueExecutor(wexpr, shared) {
-
 	//	We need the sort values for interpolation, so either use the range or the secondary ordering expression
 	if (arg_order_idx.empty()) {
 		//	We use the range ordering, even if it has not been defined
@@ -918,7 +914,6 @@ unique_ptr<LocalSinkState> WindowFillExecutor::GetLocalState(ExecutionContext &c
 
 void WindowFillExecutor::EvaluateInternal(ExecutionContext &context, DataChunk &eval_chunk, Vector &result, idx_t count,
                                           idx_t row_idx, OperatorSinkInput &sink) const {
-
 	auto &lfstate = sink.local_state.Cast<WindowFillLocalState>();
 	auto &cursor = *lfstate.cursor;
 

--- a/src/include/duckdb/common/bitpacking.hpp
+++ b/src/include/duckdb/common/bitpacking.hpp
@@ -25,7 +25,6 @@ struct HugeIntPacker {
 };
 
 class BitpackingPrimitives {
-
 public:
 	static constexpr const idx_t BITPACKING_ALGORITHM_GROUP_SIZE = 32;
 	static constexpr const idx_t BITPACKING_HEADER_SIZE = sizeof(uint64_t);
@@ -61,7 +60,6 @@ public:
 	template <class T>
 	inline static void UnPackBuffer(data_ptr_t dst, data_ptr_t src, idx_t count, bitpacking_width_t width,
 	                                bool skip_sign_extension = false) {
-
 		for (idx_t i = 0; i < count; i += BITPACKING_ALGORITHM_GROUP_SIZE) {
 			UnPackGroup<T>(dst + i * sizeof(T), src + (i * width) / 8, width, skip_sign_extension);
 		}

--- a/src/include/duckdb/common/encryption_functions.hpp
+++ b/src/include/duckdb/common/encryption_functions.hpp
@@ -27,7 +27,6 @@ private:
 };
 
 class EncryptionEngine {
-
 public:
 	EncryptionEngine();
 	~EncryptionEngine();

--- a/src/include/duckdb/common/encryption_key_manager.hpp
+++ b/src/include/duckdb/common/encryption_key_manager.hpp
@@ -17,7 +17,6 @@
 namespace duckdb {
 
 class EncryptionKey {
-
 public:
 	explicit EncryptionKey(data_ptr_t encryption_key);
 	~EncryptionKey();
@@ -42,7 +41,6 @@ private:
 };
 
 class EncryptionKeyManager : public ObjectCacheEntry {
-
 public:
 	static EncryptionKeyManager &GetInternal(ObjectCache &cache);
 	static EncryptionKeyManager &Get(ClientContext &context);

--- a/src/include/duckdb/common/encryption_state.hpp
+++ b/src/include/duckdb/common/encryption_state.hpp
@@ -14,7 +14,6 @@
 namespace duckdb {
 
 class EncryptionTypes {
-
 public:
 	enum CipherType : uint8_t { INVALID = 0, GCM = 1, CTR = 2, CBC = 3 };
 	enum KeyDerivationFunction : uint8_t { DEFAULT = 0, SHA256 = 1, PBKDF2 = 2 };
@@ -27,7 +26,6 @@ public:
 };
 
 class EncryptionState {
-
 public:
 	DUCKDB_API explicit EncryptionState(EncryptionTypes::CipherType cipher_p, idx_t key_len);
 	DUCKDB_API virtual ~EncryptionState();
@@ -47,7 +45,6 @@ protected:
 };
 
 class EncryptionUtil {
-
 public:
 	DUCKDB_API explicit EncryptionUtil() {};
 

--- a/src/include/duckdb/common/extra_type_info.hpp
+++ b/src/include/duckdb/common/extra_type_info.hpp
@@ -262,7 +262,6 @@ private:
 };
 
 struct TemplateTypeInfo : public ExtraTypeInfo {
-
 	explicit TemplateTypeInfo(string name_p);
 
 	// The name of the template, e.g. `T`, or `KEY_TYPE`. Used to distinguish between different template types within

--- a/src/include/duckdb/common/serializer/encoding_util.hpp
+++ b/src/include/duckdb/common/serializer/encoding_util.hpp
@@ -14,7 +14,6 @@
 namespace duckdb {
 
 struct EncodingUtil {
-
 	// Encode unsigned integer, returns the number of bytes written
 	template <class T>
 	static idx_t EncodeUnsignedLEB128(data_ptr_t target, T value) {

--- a/src/include/duckdb/common/serializer/serialization_traits.hpp
+++ b/src/include/duckdb/common/serializer/serialization_traits.hpp
@@ -186,7 +186,6 @@ struct is_atomic<std::atomic<T>> : std::true_type {
 // NOLINTEND
 
 struct SerializationDefaultValue {
-
 	template <typename T = void>
 	static inline typename std::enable_if<is_atomic<T>::value, T>::type GetDefault() {
 		using INNER = typename is_atomic<T>::TYPE;

--- a/src/include/duckdb/execution/index/art/art_operator.hpp
+++ b/src/include/duckdb/execution/index/art/art_operator.hpp
@@ -336,7 +336,6 @@ private:
 
 	static void InsertIntoPrefix(ART &art, reference<Node> &node_ref, const ARTKey &key, const ARTKey &row_id,
 	                             const idx_t pos, const idx_t depth, const GateStatus status) {
-
 		const auto cast_pos = UnsafeNumericCast<uint8_t>(pos);
 		const auto byte = Prefix::GetByte(art, node_ref, cast_pos);
 

--- a/src/include/duckdb/execution/merge_sort_tree.hpp
+++ b/src/include/duckdb/execution/merge_sort_tree.hpp
@@ -574,7 +574,6 @@ template <typename E, typename O, typename CMP, uint64_t F, uint64_t C>
 template <typename L>
 void MergeSortTree<E, O, CMP, F, C>::AggregateLowerBound(const idx_t lower, const idx_t upper, const E needle,
                                                          L aggregate) const {
-
 	if (lower >= upper) {
 		return;
 	}

--- a/src/include/duckdb/function/cast/variant/to_variant_fwd.hpp
+++ b/src/include/duckdb/function/cast/variant/to_variant_fwd.hpp
@@ -110,7 +110,6 @@ template <bool WRITE_DATA>
 void WriteVariantMetadata(ToVariantGlobalResultData &result, idx_t result_index, uint32_t *values_offsets,
                           uint32_t blob_offset, optional_ptr<const SelectionVector> value_index_selvec, idx_t i,
                           VariantLogicalType type_id) {
-
 	auto &values_offset_data = values_offsets[result_index];
 	if (WRITE_DATA) {
 		auto &variant = result.variant;

--- a/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
+++ b/src/include/duckdb/function/cast/variant/variant_to_variant.hpp
@@ -246,7 +246,6 @@ template <bool WRITE_DATA, bool IGNORE_NULLS>
 bool ConvertVariantToVariant(ToVariantSourceData &source_data, ToVariantGlobalResultData &result_data, idx_t count,
                              optional_ptr<const SelectionVector> selvec,
                              optional_ptr<const SelectionVector> values_index_selvec, const bool is_root) {
-
 	auto keys_offset_data = OffsetData::GetKeys(result_data.offsets);
 	auto children_offset_data = OffsetData::GetChildren(result_data.offsets);
 	auto values_offset_data = OffsetData::GetValues(result_data.offsets);

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -156,7 +156,6 @@ public:
 			bind_data = FunctionDeserialize<FUNC>(deserializer, function);
 			deserializer.Unset<LogicalType>();
 		} else {
-
 			FunctionBinder binder(context);
 
 			// Resolve templates

--- a/src/include/duckdb/function/udf_function.hpp
+++ b/src/include/duckdb/function/udf_function.hpp
@@ -123,7 +123,6 @@ public:
 	                        aggregate_combine_t combine, aggregate_finalize_t finalize,
 	                        aggregate_simple_update_t simple_update = nullptr, bind_aggregate_function_t bind = nullptr,
 	                        aggregate_destructor_t destructor = nullptr) {
-
 		AggregateFunction aggr_function(name, arguments, return_type, state_size, initialize, update, combine, finalize,
 		                                simple_update, bind, destructor);
 		aggr_function.null_handling = FunctionNullHandling::SPECIAL_HANDLING;

--- a/src/include/duckdb/function/window/window_boundaries_state.hpp
+++ b/src/include/duckdb/function/window/window_boundaries_state.hpp
@@ -89,7 +89,6 @@ private:
 };
 
 struct WindowBoundariesState {
-
 	static bool HasPrecedingRange(const BoundWindowExpression &wexpr);
 	static bool HasFollowingRange(const BoundWindowExpression &wexpr);
 	static WindowBoundsSet GetWindowBounds(const BoundWindowExpression &wexpr);

--- a/src/include/duckdb/function/window/window_collection.hpp
+++ b/src/include/duckdb/function/window/window_collection.hpp
@@ -190,7 +190,6 @@ public:
 template <typename OP>
 static void WindowDeltaScanner(ColumnDataCollection &collection, idx_t block_begin, idx_t block_end,
                                const vector<column_t> &scan_cols, const idx_t key_count, OP operation) {
-
 	//	Stop if there is no work to do
 	if (!collection.Count()) {
 		return;

--- a/src/include/duckdb/parser/parsed_data/sample_options.hpp
+++ b/src/include/duckdb/parser/parsed_data/sample_options.hpp
@@ -23,7 +23,6 @@ enum class SampleMethod : uint8_t { SYSTEM_SAMPLE = 0, BERNOULLI_SAMPLE = 1, RES
 string SampleMethodToString(SampleMethod method);
 
 class SampleOptions {
-
 public:
 	explicit SampleOptions(int64_t seed_ = -1);
 

--- a/src/include/duckdb/parser/tableref/delimgetref.hpp
+++ b/src/include/duckdb/parser/tableref/delimgetref.hpp
@@ -13,7 +13,6 @@
 namespace duckdb {
 
 class DelimGetRef : public TableRef {
-
 public:
 	explicit DelimGetRef(const vector<LogicalType> &types_p) : TableRef(TableReferenceType::DELIM_GET), types(types_p) {
 		for (idx_t i = 0; i < types.size(); i++) {

--- a/src/include/duckdb/planner/constraints/bound_unique_constraint.hpp
+++ b/src/include/duckdb/planner/constraints/bound_unique_constraint.hpp
@@ -22,7 +22,6 @@ public:
 	BoundUniqueConstraint(vector<PhysicalIndex> keys_p, physical_index_set_t key_set_p, const bool is_primary_key)
 	    : BoundConstraint(ConstraintType::UNIQUE), keys(std::move(keys_p)), key_set(std::move(key_set_p)),
 	      is_primary_key(is_primary_key) {
-
 #ifdef DEBUG
 		D_ASSERT(keys.size() == key_set.size());
 		for (auto &key : keys) {

--- a/src/include/duckdb/storage/compression/alp/alp_compress.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_compress.hpp
@@ -28,7 +28,6 @@ namespace duckdb {
 
 template <class T>
 struct AlpCompressionState : public CompressionState {
-
 public:
 	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 

--- a/src/include/duckdb/storage/compression/alp/alp_constants.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_constants.hpp
@@ -66,7 +66,6 @@ struct AlpTypedConstants {};
 
 template <>
 struct AlpTypedConstants<float> {
-
 	static constexpr float MAGIC_NUMBER = 12582912.0; //! 2^22 + 2^23
 	static constexpr uint8_t MAX_EXPONENT = 10;
 
@@ -80,7 +79,6 @@ struct AlpTypedConstants<float> {
 
 template <>
 struct AlpTypedConstants<double> {
-
 	static constexpr double MAGIC_NUMBER = 6755399441055744.0; //! 2^51 + 2^52
 	static constexpr uint8_t MAX_EXPONENT = 18;                //! 10^18 is the maximum int64
 

--- a/src/include/duckdb/storage/compression/alp/alp_utils.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_utils.hpp
@@ -36,7 +36,6 @@ public:
 
 public:
 	static AlpSamplingParameters GetSamplingParameters(idx_t current_vector_n_values) {
-
 		auto n_lookup_values =
 		    NumericCast<uint32_t>(MinValue(current_vector_n_values, (idx_t)AlpConstants::ALP_VECTOR_SIZE));
 		//! We sample equidistant values within a vector; to do this we jump a fixed number of values

--- a/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
+++ b/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
@@ -152,7 +152,6 @@ struct AlpRDCompression {
 	}
 
 	static void Compress(const EXACT_TYPE *input_vector, idx_t n_values, State &state) {
-
 		uint64_t right_parts[AlpRDConstants::ALP_VECTOR_SIZE];
 		uint16_t left_parts[AlpRDConstants::ALP_VECTOR_SIZE];
 
@@ -207,7 +206,6 @@ struct AlpRDDecompression {
 	                       EXACT_TYPE *output, idx_t values_count, uint16_t exceptions_count,
 	                       const uint16_t *exceptions, const uint16_t *exceptions_positions, uint8_t left_bit_width,
 	                       uint8_t right_bit_width) {
-
 		uint8_t left_decoded[AlpRDConstants::ALP_VECTOR_SIZE * 8] = {0};
 		uint8_t right_decoded[AlpRDConstants::ALP_VECTOR_SIZE * 8] = {0};
 

--- a/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
@@ -30,7 +30,6 @@ namespace duckdb {
 
 template <class T>
 struct AlpRDCompressionState : public CompressionState {
-
 public:
 	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 

--- a/src/include/duckdb/storage/compression/chimp/algorithm/chimp128.hpp
+++ b/src/include/duckdb/storage/compression/chimp/algorithm/chimp128.hpp
@@ -31,7 +31,6 @@ namespace duckdb {
 
 template <class CHIMP_TYPE, bool EMPTY>
 struct Chimp128CompressionState {
-
 	Chimp128CompressionState() : ring_buffer(), previous_leading_zeros(NumericLimits<uint8_t>::Maximum()) {
 		previous_value = 0;
 	}
@@ -104,7 +103,6 @@ public:
 	}
 
 	static void CompressValue(CHIMP_TYPE in, State &state) {
-
 		auto key = state.ring_buffer.Key(in);
 		CHIMP_TYPE xor_result;
 		uint8_t previous_index;

--- a/src/include/duckdb/storage/compression/chimp/algorithm/flag_buffer.hpp
+++ b/src/include/duckdb/storage/compression/chimp/algorithm/flag_buffer.hpp
@@ -34,7 +34,6 @@ struct FlagBufferConstants {
 // So we can just read/write from left to right
 template <bool EMPTY>
 class FlagBuffer {
-
 public:
 	FlagBuffer() : counter(0), buffer(nullptr) {
 	}

--- a/src/include/duckdb/storage/compression/chimp/algorithm/leading_zero_buffer.hpp
+++ b/src/include/duckdb/storage/compression/chimp/algorithm/leading_zero_buffer.hpp
@@ -40,7 +40,6 @@ struct LeadingZeroBufferConstants {
 
 template <bool EMPTY>
 class LeadingZeroBuffer {
-
 public:
 	static constexpr uint32_t CHIMP_GROUP_SIZE = 1024;
 	static constexpr uint32_t LEADING_ZERO_BITS_SIZE = 3;

--- a/src/include/duckdb/storage/compression/chimp/chimp_scan.hpp
+++ b/src/include/duckdb/storage/compression/chimp/chimp_scan.hpp
@@ -185,7 +185,6 @@ public:
 	}
 
 	void LoadGroup(CHIMP_TYPE *value_buffer) {
-
 		//! FIXME: If we change the order of this to flag -> leading_zero_blocks -> packed_data
 		//! We can leave out the leading zero block count as well, because it can be derived from
 		//! Extracting all the flags and counting the 3's

--- a/src/include/duckdb/storage/statistics/geometry_stats.hpp
+++ b/src/include/duckdb/storage/statistics/geometry_stats.hpp
@@ -105,7 +105,6 @@ public:
 };
 
 struct GeometryStatsData {
-
 	GeometryTypeSet types;
 	GeometryExtent extent;
 
@@ -125,7 +124,6 @@ struct GeometryStatsData {
 	}
 
 	void Update(const string_t &geom_blob) {
-
 		// Parse type
 		const auto type_info = Geometry::GetType(geom_blob);
 		types.Add(type_info.first, type_info.second);

--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -599,7 +599,6 @@ BufferingLogStorage::~BufferingLogStorage() {
 }
 
 static void WriteLoggingContextsToChunk(DataChunk &chunk, const RegisteredLoggingContext &context, idx_t &col) {
-
 	auto size = chunk.size();
 
 	auto context_id_data = FlatVector::GetData<idx_t>(chunk.data[col++]);

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -424,7 +424,6 @@ void BaseAppender::ClearColumns() {
 //===--------------------------------------------------------------------===//
 Appender::Appender(Connection &con, const string &database_name, const string &schema_name, const string &table_name)
     : BaseAppender(Allocator::DefaultAllocator(), AppenderType::LOGICAL), context(con.context) {
-
 	description = con.TableInfo(database_name, schema_name, table_name);
 	if (!description) {
 		throw CatalogException(

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -36,7 +36,6 @@ AttachOptions::AttachOptions(const DBConfigOptions &options)
 
 AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options, const AccessMode default_access_mode)
     : access_mode(default_access_mode) {
-
 	for (auto &entry : attach_options) {
 		if (entry.first == "readonly" || entry.first == "read_only") {
 			// Extract the read access mode.
@@ -82,7 +81,6 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, AttachedDatabaseType ty
     : CatalogEntry(CatalogType::DATABASE_ENTRY,
                    type == AttachedDatabaseType::SYSTEM_DATABASE ? SYSTEM_CATALOG : TEMP_CATALOG, 0),
       db(db), type(type) {
-
 	// This database does not have storage, or uses temporary_objects for in-memory storage.
 	D_ASSERT(type == AttachedDatabaseType::TEMP_DATABASE || type == AttachedDatabaseType::SYSTEM_DATABASE);
 	if (type == AttachedDatabaseType::TEMP_DATABASE) {

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -18,7 +18,6 @@ using duckdb::QueryResultType;
 
 duckdb_error_data duckdb_to_arrow_schema(duckdb_arrow_options arrow_options, duckdb_logical_type *types,
                                          const char **names, idx_t column_count, struct ArrowSchema *out_schema) {
-
 	if (!types || !names || !arrow_options || !out_schema) {
 		return duckdb_create_error_data(DUCKDB_ERROR_INVALID_INPUT, "Invalid argument(s) to duckdb_to_arrow_schema");
 	}
@@ -298,7 +297,6 @@ void duckdb_destroy_arrow(duckdb_arrow *result) {
 }
 
 void duckdb_destroy_arrow_stream(duckdb_arrow_stream *stream_p) {
-
 	auto stream = reinterpret_cast<ArrowArrayStream *>(*stream_p);
 	if (!stream) {
 		return;

--- a/src/main/capi/cast_function-c.cpp
+++ b/src/main/capi/cast_function-c.cpp
@@ -25,7 +25,6 @@ struct CCastFunction {
 };
 
 struct CCastFunctionUserData {
-
 	duckdb_function_info data_ptr = nullptr;
 	duckdb_delete_callback_t delete_callback = nullptr;
 
@@ -56,7 +55,6 @@ struct CCastFunctionData final : public BoundCastData {
 };
 
 static bool CAPICastFunction(Vector &input, Vector &output, idx_t count, CastParameters &parameters) {
-
 	const auto is_const = input.GetVectorType() == VectorType::CONSTANT_VECTOR;
 	input.Flatten(count);
 

--- a/src/main/capi/file_system-c.cpp
+++ b/src/main/capi/file_system-c.cpp
@@ -3,7 +3,6 @@
 namespace duckdb {
 namespace {
 struct CFileSystem {
-
 	FileSystem &fs;
 	ErrorData error_data;
 

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -448,7 +448,6 @@ bool DBConfig::HasExtensionOption(const string &name) {
 
 void DBConfig::AddExtensionOption(const string &name, string description, LogicalType parameter,
                                   const Value &default_value, set_option_callback_t function, SetScope default_scope) {
-
 	lock_guard<mutex> l(config_lock);
 	extension_parameters.insert(make_pair(
 	    name, ExtensionOption(std::move(description), std::move(parameter), function, default_value, default_scope)));

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -303,7 +303,6 @@ vector<string> DatabaseManager::GetAttachedDatabasePaths() {
 
 void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, const DBConfig &config,
                                       AttachOptions &options) {
-
 	// Test if the database is a DuckDB database file.
 	if (StringUtil::CIEquals(options.db_type, "duckdb")) {
 		options.db_type = "";

--- a/src/main/db_instance_cache.cpp
+++ b/src/main/db_instance_cache.cpp
@@ -139,7 +139,6 @@ shared_ptr<DuckDB> DBInstanceCache::GetOrCreateInstance(const string &database, 
                                                         const std::function<void(DuckDB &)> &on_create) {
 	unique_lock<mutex> lock(cache_lock, std::defer_lock);
 	if (cache_instance) {
-
 		// While we do not own the lock, we cannot definitively say that the database instance does not exist.
 		while (!lock.owns_lock()) {
 			// The problem is, that we have to unlock the mutex in GetInstanceInternal, so we can non-blockingly wait

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -175,7 +175,6 @@ bool ExtensionHelper::CanAutoloadExtension(const string &ext_name) {
 
 string ExtensionHelper::AddExtensionInstallHintToErrorMsg(ClientContext &context, const string &base_error,
                                                           const string &extension_name) {
-
 	return AddExtensionInstallHintToErrorMsg(DatabaseInstance::GetDatabase(context), base_error, extension_name);
 }
 string ExtensionHelper::AddExtensionInstallHintToErrorMsg(DatabaseInstance &db, const string &base_error,

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -179,7 +179,6 @@ void QueryProfiler::Finalize(ProfilingNode &node) {
 		auto type = PhysicalOperatorType(info.GetMetricValue<uint8_t>(MetricsType::OPERATOR_TYPE));
 		if (type == PhysicalOperatorType::UNION &&
 		    info.Enabled(info.expanded_settings, MetricsType::OPERATOR_CARDINALITY)) {
-
 			auto &child_info = child->GetProfilingInfo();
 			auto value = child_info.metrics[MetricsType::OPERATOR_CARDINALITY].GetValue<idx_t>();
 			info.MetricSum(MetricsType::OPERATOR_CARDINALITY, value);

--- a/src/main/relation/read_json_relation.cpp
+++ b/src/main/relation/read_json_relation.cpp
@@ -15,7 +15,6 @@ ReadJSONRelation::ReadJSONRelation(const shared_ptr<ClientContext> &context, vec
     : TableFunctionRelation(context, auto_detect ? "read_json_auto" : "read_json",
                             {MultiFileReader::CreateValueFromFileList(input)}, std::move(options)),
       alias(std::move(alias_p)) {
-
 	InitializeAlias(input);
 }
 
@@ -24,7 +23,6 @@ ReadJSONRelation::ReadJSONRelation(const shared_ptr<ClientContext> &context, str
     : TableFunctionRelation(context, auto_detect ? "read_json_auto" : "read_json", {Value(json_file_p)},
                             std::move(options)),
       json_file(std::move(json_file_p)), alias(std::move(alias_p)) {
-
 	if (alias.empty()) {
 		alias = StringUtil::Split(json_file, ".")[0];
 	}

--- a/src/optimizer/join_order/join_order_optimizer.cpp
+++ b/src/optimizer/join_order/join_order_optimizer.cpp
@@ -25,7 +25,6 @@ JoinOrderOptimizer JoinOrderOptimizer::CreateChildOptimizer() {
 
 unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOperator> plan,
                                                          optional_ptr<RelationStats> stats) {
-
 	if (depth > query_graph_manager.context.config.max_expression_depth) {
 		// Very deep plans will eventually consume quite some stack space
 		// Returning the current plan is always a valid choice

--- a/src/optimizer/join_order/plan_enumerator.cpp
+++ b/src/optimizer/join_order/plan_enumerator.cpp
@@ -102,7 +102,6 @@ const reference_map_t<JoinRelationSet, unique_ptr<DPJoinNode>> &PlanEnumerator::
 unique_ptr<DPJoinNode> PlanEnumerator::CreateJoinTree(JoinRelationSet &set,
                                                       const vector<reference<NeighborInfo>> &possible_connections,
                                                       DPJoinNode &left, DPJoinNode &right) {
-
 	// FIXME: should consider different join algorithms, should we pick a join algorithm here as well? (probably)
 	optional_ptr<NeighborInfo> best_connection = possible_connections.back().get();
 	// cross products are technically still connections, but the filter expression is a null_ptr

--- a/src/optimizer/join_order/query_graph.cpp
+++ b/src/optimizer/join_order/query_graph.cpp
@@ -79,7 +79,6 @@ void QueryGraphEdges::CreateEdge(JoinRelationSet &left, JoinRelationSet &right, 
 
 void QueryGraphEdges::EnumerateNeighborsDFS(JoinRelationSet &node, reference<QueryEdge> info, idx_t index,
                                             const std::function<bool(NeighborInfo &)> &callback) const {
-
 	for (auto &neighbor : info.get().neighbors) {
 		if (callback(*neighbor)) {
 			return;

--- a/src/optimizer/join_order/query_graph_manager.cpp
+++ b/src/optimizer/join_order/query_graph_manager.cpp
@@ -243,7 +243,6 @@ GenerateJoinRelation QueryGraphManager::GenerateJoins(vector<unique_ptr<LogicalO
 	}
 	auto &node = dp_entry->second;
 	if (!dp_entry->second->is_leaf) {
-
 		// generate the left and right children
 		auto left = GenerateJoins(extracted_relations, node->left_set);
 		auto right = GenerateJoins(extracted_relations, node->right_set);

--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -46,7 +46,6 @@ void RelationManager::AddAggregateOrWindowRelation(LogicalOperator &op, optional
 
 void RelationManager::AddRelation(LogicalOperator &op, optional_ptr<LogicalOperator> parent,
                                   const RelationStats &stats) {
-
 	// if parent is null, then this is a root relation
 	// if parent is not null, it should have multiple children
 	D_ASSERT(!parent || parent->children.size() >= 2);
@@ -542,7 +541,6 @@ vector<unique_ptr<FilterInfo>> RelationManager::ExtractEdges(LogicalOperator &op
 			auto &join = f_op.Cast<LogicalComparisonJoin>();
 			D_ASSERT(join.expressions.empty());
 			if (join.join_type == JoinType::SEMI || join.join_type == JoinType::ANTI) {
-
 				auto conjunction_expression = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
 				// create a conjunction expression for the semi join.
 				// It's possible multiple LHS relations have a condition in

--- a/src/optimizer/pushdown/pushdown_outer_join.cpp
+++ b/src/optimizer/pushdown/pushdown_outer_join.cpp
@@ -174,7 +174,6 @@ PushDownFiltersOnCoalescedEqualJoinKeys(vector<unique_ptr<Filter>> &filters,
 unique_ptr<LogicalOperator> FilterPushdown::PushdownOuterJoin(unique_ptr<LogicalOperator> op,
                                                               unordered_set<idx_t> &left_bindings,
                                                               unordered_set<idx_t> &right_bindings) {
-
 	if (op->type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
 		return FinishPushdown(std::move(op));
 	}

--- a/src/optimizer/regex_range_filter.cpp
+++ b/src/optimizer/regex_range_filter.cpp
@@ -16,7 +16,6 @@
 namespace duckdb {
 
 unique_ptr<LogicalOperator> RegexRangeFilter::Rewrite(unique_ptr<LogicalOperator> op) {
-
 	for (idx_t child_idx = 0; child_idx < op->children.size(); child_idx++) {
 		op->children[child_idx] = Rewrite(std::move(op->children[child_idx]));
 	}

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -17,7 +17,6 @@ ComparisonSimplificationRule::ComparisonSimplificationRule(ExpressionRewriter &r
 
 unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
                                                            bool &changes_made, bool is_root) {
-
 	auto &expr = bindings[0].get().Cast<BoundComparisonExpression>();
 	auto &constant_expr = bindings[1].get();
 	bool column_ref_left = expr.left.get() != &constant_expr;

--- a/src/optimizer/rule/enum_comparison.cpp
+++ b/src/optimizer/rule/enum_comparison.cpp
@@ -47,7 +47,6 @@ bool AreMatchesPossible(LogicalType &left, LogicalType &right) {
 }
 unique_ptr<Expression> EnumComparisonRule::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
                                                  bool &changes_made, bool is_root) {
-
 	auto &root = bindings[0].get().Cast<BoundComparisonExpression>();
 	auto &left_child = bindings[1].get().Cast<BoundCastExpression>();
 	auto &right_child = bindings[3].get().Cast<BoundCastExpression>();

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -127,7 +127,6 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 
 unique_ptr<LogicalOperator> TopN::Optimize(unique_ptr<LogicalOperator> op) {
 	if (CanOptimize(*op, &context)) {
-
 		vector<unique_ptr<LogicalOperator>> projections;
 
 		// traverse operator tree and collect all projection nodes until we reach

--- a/src/optimizer/unnest_rewriter.cpp
+++ b/src/optimizer/unnest_rewriter.cpp
@@ -33,14 +33,12 @@ void UnnestRewriterPlanUpdater::VisitExpression(unique_ptr<Expression> *expressi
 }
 
 unique_ptr<LogicalOperator> UnnestRewriter::Optimize(unique_ptr<LogicalOperator> op) {
-
 	UnnestRewriterPlanUpdater updater;
 	vector<reference<unique_ptr<LogicalOperator>>> candidates;
 	FindCandidates(op, candidates);
 
 	// rewrite the plan and update the bindings
 	for (auto &candidate : candidates) {
-
 		// rearrange the logical operators
 		if (RewriteCandidate(candidate)) {
 			updater.overwritten_tbl_idx = overwritten_tbl_idx;
@@ -106,7 +104,6 @@ void UnnestRewriter::FindCandidates(unique_ptr<LogicalOperator> &op,
 }
 
 bool UnnestRewriter::RewriteCandidate(unique_ptr<LogicalOperator> &candidate) {
-
 	auto &topmost_op = *candidate;
 	if (topmost_op.type != LogicalOperatorType::LOGICAL_PROJECTION &&
 	    topmost_op.type != LogicalOperatorType::LOGICAL_WINDOW &&
@@ -160,14 +157,12 @@ bool UnnestRewriter::RewriteCandidate(unique_ptr<LogicalOperator> &candidate) {
 
 void UnnestRewriter::UpdateRHSBindings(unique_ptr<LogicalOperator> &plan, unique_ptr<LogicalOperator> &candidate,
                                        UnnestRewriterPlanUpdater &updater) {
-
 	auto &topmost_op = *candidate;
 	idx_t shift = lhs_bindings.size();
 
 	vector<unique_ptr<LogicalOperator> *> path_to_unnest;
 	auto curr_op = &topmost_op.children[0];
 	while (curr_op->get()->type == LogicalOperatorType::LOGICAL_PROJECTION) {
-
 		path_to_unnest.push_back(curr_op);
 		D_ASSERT(curr_op->get()->type == LogicalOperatorType::LOGICAL_PROJECTION);
 		auto &proj = curr_op->get()->Cast<LogicalProjection>();
@@ -222,7 +217,6 @@ void UnnestRewriter::UpdateRHSBindings(unique_ptr<LogicalOperator> &plan, unique
 
 	// add the LHS expressions to each LOGICAL_PROJECTION
 	for (idx_t i = path_to_unnest.size(); i > 0; i--) {
-
 		D_ASSERT(path_to_unnest[i - 1]->get()->type == LogicalOperatorType::LOGICAL_PROJECTION);
 		auto &proj = path_to_unnest[i - 1]->get()->Cast<LogicalProjection>();
 
@@ -254,7 +248,6 @@ void UnnestRewriter::UpdateRHSBindings(unique_ptr<LogicalOperator> &plan, unique
 
 void UnnestRewriter::UpdateBoundUnnestBindings(UnnestRewriterPlanUpdater &updater,
                                                unique_ptr<LogicalOperator> &candidate) {
-
 	auto &topmost_op = *candidate;
 
 	// traverse LOGICAL_PROJECTION(s)
@@ -296,7 +289,6 @@ void UnnestRewriter::UpdateBoundUnnestBindings(UnnestRewriterPlanUpdater &update
 }
 
 void UnnestRewriter::GetDelimColumns(LogicalOperator &op) {
-
 	D_ASSERT(op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN);
 	auto &delim_join = op.Cast<LogicalComparisonJoin>();
 	for (idx_t i = 0; i < delim_join.duplicate_eliminated_columns.size(); i++) {
@@ -308,7 +300,6 @@ void UnnestRewriter::GetDelimColumns(LogicalOperator &op) {
 }
 
 void UnnestRewriter::GetLHSExpressions(LogicalOperator &op) {
-
 	op.ResolveOperatorTypes();
 	auto col_bindings = op.GetColumnBindings();
 	D_ASSERT(op.types.size() == col_bindings.size());

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -379,7 +379,6 @@ void Executor::Initialize(PhysicalOperator &plan) {
 }
 
 void Executor::InitializeInternal(PhysicalOperator &plan) {
-
 	auto &scheduler = TaskScheduler::GetScheduler(context);
 	{
 		lock_guard<mutex> elock(executor_lock);

--- a/src/parser/expression/lambda_expression.cpp
+++ b/src/parser/expression/lambda_expression.cpp
@@ -34,7 +34,6 @@ LambdaExpression::LambdaExpression(unique_ptr<ParsedExpression> lhs, unique_ptr<
 }
 
 vector<reference<const ParsedExpression>> LambdaExpression::ExtractColumnRefExpressions(string &error_message) const {
-
 	// we return an error message because we can't throw a binder exception here,
 	// since we can't distinguish between a lambda function and the JSON operator yet
 	vector<reference<const ParsedExpression>> column_refs;

--- a/src/parser/expression/lambdaref_expression.cpp
+++ b/src/parser/expression/lambdaref_expression.cpp
@@ -37,7 +37,6 @@ unique_ptr<ParsedExpression> LambdaRefExpression::Copy() const {
 unique_ptr<ParsedExpression>
 LambdaRefExpression::FindMatchingBinding(optional_ptr<vector<DummyBinding>> &lambda_bindings,
                                          const string &column_name) {
-
 	// if this is a lambda parameter, then we temporarily add a BoundLambdaRef,
 	// which we capture and remove later
 

--- a/src/parser/parsed_expression_iterator.cpp
+++ b/src/parser/parsed_expression_iterator.cpp
@@ -162,7 +162,6 @@ void ParsedExpressionIterator::EnumerateChildren(
 
 void ParsedExpressionIterator::EnumerateQueryNodeModifiers(
     QueryNode &node, const std::function<void(unique_ptr<ParsedExpression> &child)> &callback) {
-
 	for (auto &modifier : node.modifiers) {
 		switch (modifier->type) {
 		case ResultModifierType::LIMIT_MODIFIER: {

--- a/src/parser/statement/update_statement.cpp
+++ b/src/parser/statement/update_statement.cpp
@@ -49,7 +49,6 @@ UpdateStatement::UpdateStatement(const UpdateStatement &other)
 }
 
 string UpdateStatement::ToString() const {
-
 	string result;
 	result = cte_map.ToString();
 	result += "UPDATE ";

--- a/src/parser/transform/expression/transform_array_access.cpp
+++ b/src/parser/transform/expression/transform_array_access.cpp
@@ -7,7 +7,6 @@
 namespace duckdb {
 
 unique_ptr<ParsedExpression> Transformer::TransformArrayAccess(duckdb_libpgquery::PGAIndirection &indirection_node) {
-
 	// Transform the source expression.
 	unique_ptr<ParsedExpression> result;
 	result = TransformExpression(indirection_node.arg);

--- a/src/parser/transform/expression/transform_expression.cpp
+++ b/src/parser/transform/expression/transform_expression.cpp
@@ -16,7 +16,6 @@ unique_ptr<ParsedExpression> Transformer::TransformResTarget(duckdb_libpgquery::
 }
 
 unique_ptr<ParsedExpression> Transformer::TransformNamedArg(duckdb_libpgquery::PGNamedArgExpr &root) {
-
 	auto expr = TransformExpression(PGPointerCast<duckdb_libpgquery::PGNode>(root.arg));
 	if (root.name) {
 		expr->SetAlias(root.name);
@@ -25,7 +24,6 @@ unique_ptr<ParsedExpression> Transformer::TransformNamedArg(duckdb_libpgquery::P
 }
 
 unique_ptr<ParsedExpression> Transformer::TransformExpression(duckdb_libpgquery::PGNode &node) {
-
 	auto stack_checker = StackCheck();
 
 	switch (node.type) {

--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -38,7 +38,6 @@ void Transformer::TransformWindowDef(duckdb_libpgquery::PGWindowDef &window_spec
 
 static inline WindowBoundary TransformFrameOption(const int frameOptions, const WindowBoundary rows,
                                                   const WindowBoundary range, const WindowBoundary groups) {
-
 	if (frameOptions & FRAMEOPTION_RANGE) {
 		return range;
 	} else if (frameOptions & FRAMEOPTION_GROUPS) {

--- a/src/parser/transform/expression/transform_multi_assign_reference.cpp
+++ b/src/parser/transform/expression/transform_multi_assign_reference.cpp
@@ -4,7 +4,6 @@
 namespace duckdb {
 
 unique_ptr<ParsedExpression> Transformer::TransformMultiAssignRef(duckdb_libpgquery::PGMultiAssignRef &root) {
-
 	// Early-out, if the root is not a function call.
 	if (root.source->type != duckdb_libpgquery::T_PGFuncCall) {
 		return TransformExpression(root.source);

--- a/src/parser/transform/helpers/transform_typename.cpp
+++ b/src/parser/transform/helpers/transform_typename.cpp
@@ -17,7 +17,6 @@ struct SizeModifiers {
 };
 
 static SizeModifiers GetSizeModifiers(duckdb_libpgquery::PGTypeName &type_name, LogicalTypeId base_type) {
-
 	SizeModifiers result;
 
 	if (base_type == LogicalTypeId::DECIMAL) {

--- a/src/parser/transform/statement/transform_alter_table.cpp
+++ b/src/parser/transform/statement/transform_alter_table.cpp
@@ -19,7 +19,6 @@ vector<string> Transformer::TransformNameList(duckdb_libpgquery::PGList &list) {
 }
 
 unique_ptr<AlterStatement> Transformer::TransformAlter(duckdb_libpgquery::PGAlterTableStmt &stmt) {
-
 	D_ASSERT(stmt.relation);
 	if (stmt.cmds->length != 1) {
 		throw ParserException("Only one ALTER command per statement is supported");
@@ -30,7 +29,6 @@ unique_ptr<AlterStatement> Transformer::TransformAlter(duckdb_libpgquery::PGAlte
 
 	// Check the ALTER type.
 	for (auto c = stmt.cmds->head; c != nullptr; c = c->next) {
-
 		auto command = PGPointerCast<duckdb_libpgquery::PGAlterTableCmd>(c->data.ptr_value);
 		AlterEntryData data(qualified_name.catalog, qualified_name.schema, qualified_name.name,
 		                    TransformOnEntryNotFound(stmt.missing_ok));

--- a/src/parser/transform/statement/transform_upsert.cpp
+++ b/src/parser/transform/statement/transform_upsert.cpp
@@ -67,7 +67,6 @@ unique_ptr<OnConflictInfo> Transformer::DummyOnConflictClause(duckdb_libpgquery:
 
 unique_ptr<OnConflictInfo> Transformer::TransformOnConflictClause(duckdb_libpgquery::PGOnConflictClause *node,
                                                                   const string &) {
-
 	auto stmt = PGPointerCast<duckdb_libpgquery::PGOnConflictClause>(node);
 	D_ASSERT(stmt);
 

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -366,7 +366,6 @@ void VerifyNotExcluded(const ParsedExpression &root_expr) {
 BoundStatement Binder::BindReturning(vector<unique_ptr<ParsedExpression>> returning_list, TableCatalogEntry &table,
                                      const string &alias, idx_t update_table_index,
                                      unique_ptr<LogicalOperator> child_operator, virtual_column_map_t virtual_columns) {
-
 	vector<LogicalType> types;
 	vector<string> names;
 

--- a/src/planner/binder/expression/bind_between_expression.cpp
+++ b/src/planner/binder/expression/bind_between_expression.cpp
@@ -32,7 +32,6 @@ BindResult ExpressionBinder::BindExpression(BetweenExpression &expr, idx_t depth
 	LogicalType input_type;
 	if (!BoundComparisonExpression::TryBindComparison(context, input_sql_type, lower_sql_type, input_type,
 	                                                  expr.GetExpressionType())) {
-
 		throw BinderException(expr,
 		                      "Cannot mix values of type %s and %s in BETWEEN clause - an explicit cast is required",
 		                      input_sql_type.ToString(), lower_sql_type.ToString());

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -111,7 +111,6 @@ unique_ptr<ParsedExpression> ExpressionBinder::QualifyColumnName(const string &c
 void ExpressionBinder::QualifyColumnNames(unique_ptr<ParsedExpression> &expr,
                                           vector<unordered_set<string>> &lambda_params,
                                           const bool within_function_expression) {
-
 	bool next_within_function_expression = false;
 	switch (expr->GetExpressionType()) {
 	case ExpressionType::COLUMN_REF: {
@@ -177,7 +176,6 @@ void ExpressionBinder::QualifyColumnNames(unique_ptr<ParsedExpression> &expr,
 
 void ExpressionBinder::QualifyColumnNamesInLambda(FunctionExpression &function,
                                                   vector<unordered_set<string>> &lambda_params) {
-
 	for (auto &child : function.children) {
 		if (child->GetExpressionClass() != ExpressionClass::LAMBDA) {
 			// not a lambda expression
@@ -228,7 +226,6 @@ void ExpressionBinder::QualifyColumnNames(ExpressionBinder &expression_binder, u
 
 unique_ptr<ParsedExpression> ExpressionBinder::CreateStructExtract(unique_ptr<ParsedExpression> base,
                                                                    const string &field_name) {
-
 	vector<unique_ptr<ParsedExpression>> children;
 	children.push_back(std::move(base));
 	children.push_back(make_uniq_base<ParsedExpression, ConstantExpression>(Value(field_name)));

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -204,7 +204,6 @@ BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFu
 
 BindResult ExpressionBinder::BindLambdaFunction(FunctionExpression &function, ScalarFunctionCatalogEntry &func,
                                                 idx_t depth) {
-
 	// get the callback function for the lambda parameter types
 	auto &scalar_function = func.functions.functions.front();
 	auto &bind_lambda_function = scalar_function.bind_lambda;
@@ -302,7 +301,6 @@ BindResult ExpressionBinder::BindLambdaFunction(FunctionExpression &function, Sc
 	idx_t offset = 0;
 	if (lambda_bindings) {
 		for (idx_t i = lambda_bindings->size(); i > 0; i--) {
-
 			auto &binding = (*lambda_bindings)[i - 1];
 			auto &column_names = binding.GetColumnNames();
 			auto &column_types = binding.GetColumnTypes();

--- a/src/planner/binder/expression/bind_lambda.cpp
+++ b/src/planner/binder/expression/bind_lambda.cpp
@@ -36,7 +36,6 @@ idx_t GetLambdaParamIndex(vector<DummyBinding> &lambda_bindings, const BoundLamb
 }
 
 void ExtractParameter(const ParsedExpression &expr, vector<string> &column_names, vector<string> &column_aliases) {
-
 	auto &column_ref = expr.Cast<ColumnRefExpression>();
 	if (column_ref.IsQualified()) {
 		throw BinderException(LambdaExpression::InvalidParametersErrorMessage());
@@ -47,7 +46,6 @@ void ExtractParameter(const ParsedExpression &expr, vector<string> &column_names
 }
 
 void ExtractParameters(LambdaExpression &expr, vector<string> &column_names, vector<string> &column_aliases) {
-
 	// extract the lambda parameters, which are a single column
 	// reference, or a list of column references (ROW function)
 	string error_message;
@@ -136,17 +134,14 @@ void ExpressionBinder::TransformCapturedLambdaColumn(unique_ptr<Expression> &ori
                                                      BoundLambdaExpression &bound_lambda_expr,
                                                      const optional_ptr<bind_lambda_function_t> bind_lambda_function,
                                                      const vector<LogicalType> &function_child_types) {
-
 	// check if the original expression is a lambda parameter
 	if (original->GetExpressionClass() == ExpressionClass::BOUND_LAMBDA_REF) {
-
 		auto &bound_lambda_ref = original->Cast<BoundLambdaRefExpression>();
 		auto alias = bound_lambda_ref.GetAlias();
 
 		// refers to a lambda parameter outside the current lambda function
 		// so the lambda parameter will be inside the lambda_bindings
 		if (lambda_bindings && bound_lambda_ref.lambda_idx != lambda_bindings->size()) {
-
 			auto &binding = (*lambda_bindings)[bound_lambda_ref.lambda_idx];
 			auto &column_names = binding.GetColumnNames();
 			auto &column_types = binding.GetColumnTypes();
@@ -155,7 +150,6 @@ void ExpressionBinder::TransformCapturedLambdaColumn(unique_ptr<Expression> &ori
 			// find the matching dummy column in the lambda binding
 			for (idx_t column_idx = 0; column_idx < binding.GetColumnCount(); column_idx++) {
 				if (column_idx == bound_lambda_ref.binding.column_index) {
-
 					// now create the replacement
 					auto index = GetLambdaParamIndex(*lambda_bindings, bound_lambda_expr, bound_lambda_ref);
 					replacement =
@@ -190,7 +184,6 @@ void ExpressionBinder::TransformCapturedLambdaColumn(unique_ptr<Expression> &ori
 void ExpressionBinder::CaptureLambdaColumns(BoundLambdaExpression &bound_lambda_expr, unique_ptr<Expression> &expr,
                                             const optional_ptr<bind_lambda_function_t> bind_lambda_function,
                                             const vector<LogicalType> &function_child_types) {
-
 	if (expr->GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY) {
 		throw BinderException("subqueries in lambda expressions are not supported");
 	}
@@ -208,7 +201,6 @@ void ExpressionBinder::CaptureLambdaColumns(BoundLambdaExpression &bound_lambda_
 	if (expr->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF ||
 	    expr->GetExpressionClass() == ExpressionClass::BOUND_PARAMETER ||
 	    expr->GetExpressionClass() == ExpressionClass::BOUND_LAMBDA_REF) {
-
 		if (expr->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
 			// Search for UNNEST.
 			auto &column_binding = expr->Cast<BoundColumnRefExpression>().binding;

--- a/src/planner/binder/expression/bind_macro_expression.cpp
+++ b/src/planner/binder/expression/bind_macro_expression.cpp
@@ -11,7 +11,6 @@ namespace duckdb {
 
 void ExpressionBinder::ReplaceMacroParametersInLambda(FunctionExpression &function,
                                                       vector<unordered_set<string>> &lambda_params) {
-
 	for (auto &child : function.children) {
 		if (child->GetExpressionClass() != ExpressionClass::LAMBDA) {
 			ReplaceMacroParameters(child, lambda_params);
@@ -47,7 +46,6 @@ void ExpressionBinder::ReplaceMacroParametersInLambda(FunctionExpression &functi
 
 void ExpressionBinder::ReplaceMacroParameters(unique_ptr<ParsedExpression> &expr,
                                               vector<unordered_set<string>> &lambda_params) {
-
 	switch (expr->GetExpressionClass()) {
 	case ExpressionClass::COLUMN_REF: {
 		// If the expression is a column reference, we replace it with its argument.

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -17,7 +17,6 @@
 namespace duckdb {
 
 static LogicalType ResolveWindowExpressionType(ExpressionType window_type, const vector<LogicalType> &child_types) {
-
 	idx_t param_count;
 	switch (window_type) {
 	case ExpressionType::WINDOW_RANK:
@@ -115,7 +114,6 @@ static bool IsFillType(const LogicalType &type) {
 
 static LogicalType BindRangeExpression(ClientContext &context, const string &name, unique_ptr<ParsedExpression> &expr,
                                        unique_ptr<ParsedExpression> &order_expr) {
-
 	vector<unique_ptr<Expression>> children;
 
 	D_ASSERT(order_expr.get());

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -9,7 +9,6 @@
 namespace duckdb {
 
 BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
-
 	// first recursively visit the recursive CTE operations
 	// the left side is visited first and is added to the BindContext of the right side
 	D_ASSERT(statement.left);

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -154,7 +154,6 @@ void Binder::PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, B
 			break;
 		}
 		case ResultModifierType::ORDER_MODIFIER: {
-
 			auto &order = mod->Cast<OrderModifier>();
 			auto bound_order = make_uniq<BoundOrderModifier>();
 			auto &config = DBConfig::GetConfig(context);
@@ -468,7 +467,6 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 		unbound_groups.resize(group_expressions.size());
 		GroupBinder group_binder(*this, context, statement, result.group_index, bind_state, info.alias_map);
 		for (idx_t i = 0; i < group_expressions.size(); i++) {
-
 			// we keep a copy of the unbound expression;
 			// we keep the unbound copy around to check for group references in the SELECT and HAVING clause
 			// the reason we want the unbound copy is because we want to figure out whether an expression

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -251,7 +251,6 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 
 		auto new_select_list = function.copy_to_select(input);
 		if (!new_select_list.empty()) {
-
 			// We have a new select list, create a projection on top of the current plan
 			auto projection = make_uniq<LogicalProjection>(GenerateTableIndex(), std::move(new_select_list));
 			projection->children.push_back(std::move(select_node.plan));

--- a/src/planner/binder/statement/bind_copy_database.cpp
+++ b/src/planner/binder/statement/bind_copy_database.cpp
@@ -21,7 +21,6 @@
 namespace duckdb {
 
 unique_ptr<LogicalOperator> Binder::BindCopyDatabaseSchema(Catalog &from_database, const string &target_database_name) {
-
 	catalog_entry_vector_t catalog_entries;
 	catalog_entries = PhysicalExport::GetNaiveExportOrder(context, from_database);
 

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -96,7 +96,6 @@ void DoUpdateSetQualify(unique_ptr<ParsedExpression> &expr, const string &table_
 
 void DoUpdateSetQualifyInLambda(FunctionExpression &function, const string &table_name,
                                 vector<unordered_set<string>> &lambda_params) {
-
 	for (auto &child : function.children) {
 		if (child->GetExpressionClass() != ExpressionClass::LAMBDA) {
 			DoUpdateSetQualify(child, table_name, lambda_params);
@@ -138,7 +137,6 @@ void DoUpdateSetQualifyInLambda(FunctionExpression &function, const string &tabl
 
 void DoUpdateSetQualify(unique_ptr<ParsedExpression> &expr, const string &table_name,
                         vector<unordered_set<string>> &lambda_params) {
-
 	// We avoid ambiguity with EXCLUDED columns by qualifying all column references.
 	switch (expr->GetExpressionClass()) {
 	case ExpressionClass::COLUMN_REF: {

--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -681,7 +681,6 @@ unique_ptr<SelectNode> Binder::BindUnpivot(Binder &child_binder, PivotRef &ref,
 			vector<string> result;
 			ExtractUnpivotColumnName(*unpivot_expr, result);
 			if (result.empty()) {
-
 				throw BinderException(
 				    *unpivot_expr,
 				    "UNPIVOT clause must contain exactly one column - expression \"%s\" does not contain any",

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -70,7 +70,6 @@ void LogicalComparisonJoin::ExtractJoinConditions(
     unique_ptr<LogicalOperator> &right_child, const unordered_set<idx_t> &left_bindings,
     const unordered_set<idx_t> &right_bindings, vector<unique_ptr<Expression>> &expressions,
     vector<JoinCondition> &conditions, vector<unique_ptr<Expression>> &arbitrary_expressions) {
-
 	for (auto &expr : expressions) {
 		auto total_side = JoinSide::GetJoinSide(*expr, left_bindings, right_bindings);
 		if (total_side != JoinSide::BOTH) {

--- a/src/planner/bound_parameter_map.cpp
+++ b/src/planner/bound_parameter_map.cpp
@@ -43,7 +43,6 @@ shared_ptr<BoundParameterData> BoundParameterMap::CreateOrGetData(const string &
 }
 
 unique_ptr<BoundParameterExpression> BoundParameterMap::BindParameterExpression(ParameterExpression &expr) {
-
 	auto &identifier = expr.identifier;
 	D_ASSERT(!parameter_data.count(identifier));
 

--- a/src/planner/expression_binder/check_binder.cpp
+++ b/src/planner/expression_binder/check_binder.cpp
@@ -43,7 +43,6 @@ BindResult ExpressionBinder::BindQualifiedColumnName(ColumnRefExpression &colref
 }
 
 BindResult CheckBinder::BindCheckColumn(ColumnRefExpression &colref) {
-
 	if (!colref.IsQualified()) {
 		if (lambda_bindings) {
 			for (idx_t i = lambda_bindings->size(); i > 0; i--) {

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -13,7 +13,6 @@ ColumnAliasBinder::ColumnAliasBinder(SelectBindState &bind_state) : bind_state(b
 
 bool ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, unique_ptr<ParsedExpression> &expr_ptr,
                                   idx_t depth, bool root_expression, BindResult &result) {
-
 	D_ASSERT(expr_ptr->GetExpressionClass() == ExpressionClass::COLUMN_REF);
 	auto &expr = expr_ptr->Cast<ColumnRefExpression>();
 

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -39,7 +39,6 @@ unique_ptr<ParsedExpression> HavingBinder::QualifyColumnName(ColumnRefExpression
 }
 
 BindResult HavingBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
-
 	// Keep the original column name to return a meaningful error message.
 	auto col_ref = expr_ptr->Cast<ColumnRefExpression>();
 	const auto &column_name = col_ref.GetColumnName();

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -10,7 +10,6 @@ WhereBinder::WhereBinder(Binder &binder, ClientContext &context, optional_ptr<Co
 }
 
 BindResult WhereBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
-
 	auto result = ExpressionBinder::BindExpression(expr_ptr, depth);
 	if (!result.HasError() || !column_alias_binder) {
 		return result;

--- a/src/planner/logical_operator_visitor.cpp
+++ b/src/planner/logical_operator_visitor.cpp
@@ -85,7 +85,6 @@ void LogicalOperatorVisitor::VisitChildOfOperatorWithProjectionMap(LogicalOperat
 
 void LogicalOperatorVisitor::EnumerateExpressions(LogicalOperator &op,
                                                   const std::function<void(unique_ptr<Expression> *child)> &callback) {
-
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_EXPRESSION_GET: {
 		auto &get = op.Cast<LogicalExpressionGet>();

--- a/src/planner/operator/logical_create_index.cpp
+++ b/src/planner/operator/logical_create_index.cpp
@@ -10,7 +10,6 @@ LogicalCreateIndex::LogicalCreateIndex(unique_ptr<CreateIndexInfo> info_p, vecto
                                        TableCatalogEntry &table_p, unique_ptr<AlterTableInfo> alter_table_info)
     : LogicalOperator(LogicalOperatorType::LOGICAL_CREATE_INDEX), info(std::move(info_p)), table(table_p),
       alter_table_info(std::move(alter_table_info)) {
-
 	for (auto &expr : expressions_p) {
 		unbound_expressions.push_back(expr->Copy());
 	}
@@ -27,7 +26,6 @@ LogicalCreateIndex::LogicalCreateIndex(ClientContext &context, unique_ptr<Create
     : LogicalOperator(LogicalOperatorType::LOGICAL_CREATE_INDEX),
       info(unique_ptr_cast<CreateInfo, CreateIndexInfo>(std::move(info_p))), table(BindTable(context, *info)),
       alter_table_info(unique_ptr_cast<ParseInfo, AlterTableInfo>(std::move(alter_table_info))) {
-
 	for (auto &expr : expressions_p) {
 		unbound_expressions.push_back(expr->Copy());
 	}

--- a/src/planner/operator/logical_empty_result.cpp
+++ b/src/planner/operator/logical_empty_result.cpp
@@ -4,7 +4,6 @@ namespace duckdb {
 
 LogicalEmptyResult::LogicalEmptyResult(unique_ptr<LogicalOperator> op)
     : LogicalOperator(LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
-
 	this->bindings = op->GetColumnBindings();
 
 	op->ResolveOperatorTypes();

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -212,7 +212,6 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::Decorrelate(unique_ptr<Logica
 
 bool FlattenDependentJoins::DetectCorrelatedExpressions(LogicalOperator &op, bool lateral, idx_t lateral_depth,
                                                         bool parent_is_dependent_join) {
-
 	bool is_lateral_join = false;
 
 	// check if this entry has correlated expressions
@@ -996,7 +995,6 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 	}
 	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
 	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE: {
-
 #ifdef DEBUG
 		plan->children[0]->ResolveOperatorTypes();
 		plan->children[1]->ResolveOperatorTypes();

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -60,7 +60,6 @@ BlockHandle::~BlockHandle() { // NOLINT: allow internal exceptions
 
 unique_ptr<Block> AllocateBlock(BlockManager &block_manager, unique_ptr<FileBuffer> reusable_buffer,
                                 block_id_t block_id) {
-
 	if (reusable_buffer && reusable_buffer->GetHeaderSize() == block_manager.GetBlockHeaderSize()) {
 		// re-usable buffer: re-use it
 		if (reusable_buffer->GetBufferType() == FileBufferType::BLOCK) {

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -565,7 +565,6 @@ void CheckpointReader::ReadTable(CatalogTransaction transaction, Deserializer &d
 
 void CheckpointReader::ReadTableData(CatalogTransaction transaction, Deserializer &deserializer,
                                      BoundCreateTableInfo &bound_info) {
-
 	// written in "SingleFileTableDataWriter::FinalizeTable"
 	auto table_pointer = deserializer.ReadProperty<MetaBlockPointer>(101, "table_pointer");
 	auto total_rows = deserializer.ReadProperty<idx_t>(102, "total_rows");

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -720,7 +720,6 @@ public:
 		// This skips straight to the correct metadata group
 		idx_t meta_groups_to_skip = (skip_count + current_group_offset) / BITPACKING_METADATA_GROUP_SIZE;
 		if (meta_groups_to_skip) {
-
 			// bitpacking_metadata_ptr points to the next metadata: this means we need to advance the pointer by n-1
 			bitpacking_metadata_ptr -= (meta_groups_to_skip - 1) * sizeof(bitpacking_metadata_encoded_t);
 			LoadNextGroup();

--- a/src/storage/compression/bitpacking_hugeint.cpp
+++ b/src/storage/compression/bitpacking_hugeint.cpp
@@ -119,7 +119,6 @@ static void UnpackDelta128(const uint32_t *__restrict in, uhugeint_t *__restrict
 
 static void PackSingle(const uhugeint_t in, uint32_t *__restrict &out, uint16_t delta, uint16_t shl, uhugeint_t mask) {
 	if (delta + shl < 32) {
-
 		if (shl == 0) {
 			out[0] = static_cast<uint32_t>(in & mask);
 		} else {
@@ -127,7 +126,6 @@ static void PackSingle(const uhugeint_t in, uint32_t *__restrict &out, uint16_t 
 		}
 
 	} else if (delta + shl >= 32 && delta + shl < 64) {
-
 		if (shl == 0) {
 			out[0] = static_cast<uint32_t>(in & mask);
 		} else {
@@ -141,7 +139,6 @@ static void PackSingle(const uhugeint_t in, uint32_t *__restrict &out, uint16_t 
 	}
 
 	else if (delta + shl >= 64 && delta + shl < 96) {
-
 		if (shl == 0) {
 			out[0] = static_cast<uint32_t>(in & mask);
 		} else {

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -641,7 +641,6 @@ void FSSTStorage::EndScan(FSSTScanState &scan_state, bp_delta_offsets_t &offsets
 template <bool ALLOW_FSST_VECTORS>
 void FSSTStorage::StringScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
                                     idx_t result_offset) {
-
 	auto &scan_state = state.scan_state->Cast<FSSTScanState>();
 	auto start = segment.GetRelativeIndex(state.row_index);
 
@@ -735,7 +734,6 @@ void FSSTStorage::Select(ColumnSegment &segment, ColumnScanState &state, idx_t v
 //===--------------------------------------------------------------------===//
 void FSSTStorage::StringFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result,
                                  idx_t result_idx) {
-
 	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
 	auto handle = buffer_manager.Pin(segment.block);
 	auto base_ptr = handle.Ptr() + segment.GetBlockOffset();

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -231,7 +231,6 @@ public:
 	      checkpoint_data(checkpoint_data),
 	      partial_block_manager(checkpoint_data.GetCheckpointState().GetPartialBlockManager()),
 	      function(checkpoint_data.GetCompressionFunction(CompressionType::COMPRESSION_ZSTD)) {
-
 		total_vector_count = GetVectorCount(analyze_state->count);
 		total_segment_count = analyze_state->segment_count;
 		vectors_per_segment = analyze_state->vectors_per_segment;

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -146,7 +146,6 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t removed_co
 
 DataTable::DataTable(ClientContext &context, DataTable &parent, BoundConstraint &constraint)
     : db(parent.db), info(parent.info), row_groups(parent.row_groups), version(DataTableVersion::MAIN_TABLE) {
-
 	// ALTER COLUMN to add a new constraint.
 
 	// Clone the storage info vector or the table.
@@ -173,7 +172,6 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, BoundConstraint 
 DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t changed_idx, const LogicalType &target_type,
                      const vector<StorageIndex> &bound_columns, Expression &cast_expr)
     : db(parent.db), info(parent.info), version(DataTableVersion::MAIN_TABLE) {
-
 	auto &local_storage = LocalStorage::Get(context, db);
 	// prevent any tuples from being added to the parent
 	lock_guard<mutex> lock(append_lock);
@@ -768,7 +766,6 @@ void DataTable::VerifyUniqueIndexes(TableIndexList &indexes, optional_ptr<LocalT
 void DataTable::VerifyAppendConstraints(ConstraintState &constraint_state, ClientContext &context, DataChunk &chunk,
                                         optional_ptr<LocalTableStorage> storage,
                                         optional_ptr<ConflictManager> manager) {
-
 	auto &table = constraint_state.table;
 	if (table.HasGeneratedColumns()) {
 		// Verify the generated columns against the inserted values.
@@ -958,7 +955,6 @@ void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, Da
 void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, ColumnDataCollection &collection,
                             const vector<unique_ptr<BoundConstraint>> &bound_constraints,
                             optional_ptr<const vector<LogicalIndex>> column_ids) {
-
 	LocalAppendState append_state;
 	auto &storage = table.GetStorage();
 	storage.InitializeLocalAppend(append_state, table, context, bound_constraints);

--- a/src/storage/index.cpp
+++ b/src/storage/index.cpp
@@ -7,7 +7,6 @@ namespace duckdb {
 Index::Index(const vector<column_t> &column_ids, TableIOManager &table_io_manager, AttachedDatabase &db)
 
     : column_ids(column_ids), table_io_manager(table_io_manager), db(db) {
-
 	if (!Radix::IsLittleEndian()) {
 		throw NotImplementedException("indexes are not supported on big endian architectures");
 	}

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -18,7 +18,6 @@ namespace duckdb {
 LocalTableStorage::LocalTableStorage(ClientContext &context, DataTable &table)
     : context(context), table_ref(table), allocator(Allocator::Get(table.db)), deleted_rows(0),
       optimistic_writer(context, table), merged_storage(false) {
-
 	auto types = table.GetTypes();
 	auto data_table_info = table.GetDataTableInfo();
 	row_groups = optimistic_writer.CreateCollection(table, types, OptimisticWritePartialManagers::GLOBAL);
@@ -66,7 +65,6 @@ LocalTableStorage::LocalTableStorage(ClientContext &context, DataTable &new_data
     : context(context), table_ref(new_data_table), allocator(Allocator::Get(new_data_table.db)),
       deleted_rows(parent.deleted_rows), optimistic_collections(std::move(parent.optimistic_collections)),
       optimistic_writer(new_data_table, parent.optimistic_writer), merged_storage(parent.merged_storage) {
-
 	// Alter the column type.
 	auto &parent_collection = *parent.row_groups->collection;
 	auto new_collection =
@@ -83,7 +81,6 @@ LocalTableStorage::LocalTableStorage(DataTable &new_data_table, LocalTableStorag
     : table_ref(new_data_table), allocator(Allocator::Get(new_data_table.db)), deleted_rows(parent.deleted_rows),
       optimistic_collections(std::move(parent.optimistic_collections)),
       optimistic_writer(new_data_table, parent.optimistic_writer), merged_storage(parent.merged_storage) {
-
 	// Remove the column from the previous table storage.
 	auto &parent_collection = *parent.row_groups->collection;
 	auto new_collection = parent_collection.RemoveColumn(drop_column_index);
@@ -99,7 +96,6 @@ LocalTableStorage::LocalTableStorage(ClientContext &context, DataTable &new_dt, 
     : table_ref(new_dt), allocator(Allocator::Get(new_dt.db)), deleted_rows(parent.deleted_rows),
       optimistic_collections(std::move(parent.optimistic_collections)),
       optimistic_writer(new_dt, parent.optimistic_writer), merged_storage(parent.merged_storage) {
-
 	auto &parent_collection = *parent.row_groups->collection;
 	auto new_collection = parent_collection.AddColumn(context, new_column, default_executor);
 	row_groups = std::move(parent.row_groups);

--- a/src/storage/partial_block_manager.cpp
+++ b/src/storage/partial_block_manager.cpp
@@ -22,7 +22,6 @@ void PartialBlock::AddSegmentToTail(ColumnData &data, ColumnSegment &segment, ui
 }
 
 void PartialBlock::FlushInternal(const idx_t free_space_left) {
-
 	// ensure that we do not leak any data
 	if (free_space_left > 0 || !uninitialized_regions.empty()) {
 		auto buffer_handle = block_manager.buffer_manager.Pin(block_handle);
@@ -45,7 +44,6 @@ PartialBlockManager::PartialBlockManager(QueryContext context, BlockManager &blo
                                          uint32_t max_use_count)
     : context(context.GetClientContext()), block_manager(block_manager), partial_block_type(partial_block_type),
       max_use_count(max_use_count) {
-
 	if (max_partial_block_size_p.IsValid()) {
 		max_partial_block_size = NumericCast<uint32_t>(max_partial_block_size_p.GetIndex());
 		return;

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -72,7 +72,6 @@ void GenerateDBIdentifier(uint8_t *db_identifier) {
 
 void EncryptCanary(MainHeader &main_header, const shared_ptr<EncryptionState> &encryption_state,
                    const_data_ptr_t derived_key) {
-
 	uint8_t canary_buffer[MainHeader::CANARY_BYTE_SIZE];
 
 	// we zero-out the iv and the (not yet) encrypted canary

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -495,7 +495,6 @@ void StandardBufferManager::RequireTemporaryDirectory() {
 }
 
 void StandardBufferManager::WriteTemporaryBuffer(MemoryTag tag, block_id_t block_id, FileBuffer &buffer) {
-
 	// WriteTemporaryBuffer assumes that we never write a buffer below DEFAULT_BLOCK_ALLOC_SIZE.
 	RequireTemporaryDirectory();
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -81,7 +81,6 @@ void StorageOptions::Initialize(const unordered_map<string, Value> &options) {
 StorageManager::StorageManager(AttachedDatabase &db, string path_p, const AttachOptions &options)
     : db(db), path(std::move(path_p)), read_only(options.access_mode == AccessMode::READ_ONLY),
       in_memory_change_size(0) {
-
 	if (path.empty()) {
 		path = IN_MEMORY_PATH;
 		return;
@@ -509,7 +508,6 @@ void SingleFileStorageManager::CreateCheckpoint(QueryContext context, Checkpoint
 	// We only need to checkpoint if there is anything in the WAL.
 	if (GetWALSize() > 0 || config.options.force_checkpoint || options.action == CheckpointAction::ALWAYS_CHECKPOINT) {
 		try {
-
 			// Start timing the checkpoint.
 			auto client_context = context.GetClientContext();
 			if (client_context) {

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -241,7 +241,6 @@ unique_ptr<BaseStatistics> ArrayColumnData::GetUpdateStatistics() {
 
 void ArrayColumnData::FetchRow(TransactionData transaction, ColumnFetchState &state, row_t row_id, Vector &result,
                                idx_t result_idx) {
-
 	// Create state for validity & child column
 	if (state.child_states.empty()) {
 		state.child_states.push_back(make_uniq<ColumnFetchState>());

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -595,7 +595,6 @@ void ColumnData::UpdateColumn(TransactionData transaction, DataTable &data_table
 }
 
 void ColumnData::AppendTransientSegment(SegmentLock &l, idx_t start_row) {
-
 	const auto block_size = block_manager.GetBlockSize();
 	const auto type_size = GetTypeIdSize(type.InternalType());
 	auto vector_segment_size = block_size;

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -65,7 +65,6 @@ ColumnDataCheckpointer::ColumnDataCheckpointer(vector<reference<ColumnCheckpoint
                                                ColumnCheckpointInfo &checkpoint_info)
     : checkpoint_states(checkpoint_states), storage_manager(storage_manager), row_group(row_group),
       intermediate(CreateIntermediateVector(checkpoint_states)), checkpoint_info(checkpoint_info) {
-
 	auto &db = storage_manager.GetDatabase();
 	auto &config = DBConfig::GetConfig(db);
 	compression_functions.resize(checkpoint_states.size());

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -30,7 +30,6 @@ unique_ptr<ColumnSegment> ColumnSegment::CreatePersistentSegment(DatabaseInstanc
                                                                  CompressionType compression_type,
                                                                  BaseStatistics statistics,
                                                                  unique_ptr<ColumnSegmentState> segment_state) {
-
 	auto &config = DBConfig::GetConfig(db);
 	optional_ptr<CompressionFunction> function;
 	shared_ptr<BlockHandle> block;
@@ -48,7 +47,6 @@ unique_ptr<ColumnSegment> ColumnSegment::CreatePersistentSegment(DatabaseInstanc
 unique_ptr<ColumnSegment> ColumnSegment::CreateTransientSegment(DatabaseInstance &db, CompressionFunction &function,
                                                                 const LogicalType &type, const idx_t start,
                                                                 const idx_t segment_size, BlockManager &block_manager) {
-
 	// Allocate a buffer for the uncompressed segment.
 	auto &buffer_manager = BufferManager::GetBufferManager(db);
 	D_ASSERT(&buffer_manager == &block_manager.buffer_manager);
@@ -70,7 +68,6 @@ ColumnSegment::ColumnSegment(DatabaseInstance &db, shared_ptr<BlockHandle> block
     : SegmentBase<ColumnSegment>(start, count), db(db), type(type), type_size(GetTypeIdSize(type.InternalType())),
       segment_type(segment_type), stats(std::move(statistics)), block(std::move(block_p)), function(function_p),
       block_id(block_id_p), offset(offset), segment_size(segment_size_p) {
-
 	if (function.get().init_segment) {
 		segment_state = function.get().init_segment(*this, block_id, segment_state_p.get());
 	}
@@ -84,7 +81,6 @@ ColumnSegment::ColumnSegment(ColumnSegment &other, const idx_t start)
       type_size(other.type_size), segment_type(other.segment_type), stats(std::move(other.stats)),
       block(std::move(other.block)), function(other.function), block_id(other.block_id), offset(other.offset),
       segment_size(other.segment_size), segment_state(std::move(other.segment_state)) {
-
 	// For constant segments (CompressionType::COMPRESSION_CONSTANT) the block is a nullptr.
 	D_ASSERT(!block || segment_size <= GetBlockManager().GetBlockSize());
 }

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -1356,7 +1356,6 @@ void UpdateSegment::Update(TransactionData transaction, DataTable &data_table, i
 		base_info.Verify();
 		node->Verify();
 	} else {
-
 		// there is no version info yet: create the top level update info and fill it with the updates
 		// allocate space for the UpdateInfo in the allocator
 		idx_t alloc_size = UpdateInfo::GetAllocSize(type_size);

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -73,7 +73,6 @@ TemporaryFileIdentifier::TemporaryFileIdentifier(TemporaryBufferSize size_p, idx
 TemporaryFileIdentifier::TemporaryFileIdentifier(DatabaseInstance &db, TemporaryBufferSize size_p, idx_t file_index_p,
                                                  bool encrypted_p)
     : size(size_p), file_index(file_index_p), encrypted(encrypted_p) {
-
 	if (encrypted) {
 		// generate a random encryption key ID and corresponding key
 		EncryptionEngine::AddTempKeyToCache(db);

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -562,7 +562,6 @@ void WriteAheadLogDeserializer::ReplayIndexData(IndexStorageInfo &info) {
 
 		// Read the data into buffer handles and convert them to blocks on disk.
 		for (idx_t j = 0; j < data_info.allocation_sizes.size(); j++) {
-
 			// Read the data into a buffer handle.
 			auto buffer_handle = buffer_manager.Allocate(MemoryTag::ART_INDEX, block_manager.get(), false);
 			auto block_handle = buffer_handle.GetBlockHandle();

--- a/src/verification/deserialized_statement_verifier.cpp
+++ b/src/verification/deserialized_statement_verifier.cpp
@@ -13,7 +13,6 @@ DeserializedStatementVerifier::DeserializedStatementVerifier(
 unique_ptr<StatementVerifier>
 DeserializedStatementVerifier::Create(const SQLStatement &statement,
                                       optional_ptr<case_insensitive_map_t<BoundParameterData>> parameters) {
-
 	auto &select_stmt = statement.Cast<SelectStatement>();
 	Allocator allocator;
 	MemoryStream stream(allocator);

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -36,7 +36,6 @@ void AddVariadicNumbersTogether(duckdb_function_info, duckdb_data_chunk input, d
 
 	// execution
 	for (idx_t row_idx = 0; row_idx < input_size; row_idx++) {
-
 		// validity check
 		auto invalid = false;
 		for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
@@ -264,7 +263,6 @@ TEST_CASE("Test Scalar Functions - variadic number of input parameters", "[capi]
 }
 
 void CountNULLValues(duckdb_function_info, duckdb_data_chunk input, duckdb_vector output) {
-
 	// Get the total number of rows and columns in this chunk.
 	auto input_size = duckdb_data_chunk_get_size(input);
 	auto column_count = duckdb_data_chunk_get_column_count(input);

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -626,7 +626,6 @@ TEST_CASE("Issue #2058: Cleanup after execution of invalid SQL statement causes 
 }
 
 TEST_CASE("Decimal -> Double casting issue", "[capi]") {
-
 	CAPITester tester;
 	duckdb::unique_ptr<CAPIResult> result;
 
@@ -645,7 +644,6 @@ TEST_CASE("Decimal -> Double casting issue", "[capi]") {
 }
 
 TEST_CASE("Test custom_user_agent config", "[capi]") {
-
 	{
 		duckdb_database db;
 		duckdb_connection con;

--- a/test/api/capi/test_capi_arrow.cpp
+++ b/test/api/capi/test_capi_arrow.cpp
@@ -6,7 +6,6 @@ using namespace duckdb;
 using namespace std;
 
 TEST_CASE("Test arrow in C API", "[capi][arrow]") {
-
 	CAPITester tester;
 	duckdb::unique_ptr<CAPIResult> result;
 
@@ -17,7 +16,6 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 	REQUIRE(tester.OpenDatabase(nullptr));
 
 	SECTION("test rows changed") {
-
 		REQUIRE_NO_FAIL(tester.Query("CREATE TABLE test(a INTEGER);"));
 		auto state = duckdb_query_arrow(tester.connection, "INSERT INTO test VALUES (1), (2);", &arrow_result);
 		REQUIRE(state == DuckDBSuccess);
@@ -27,7 +25,6 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 	}
 
 	SECTION("test query arrow") {
-
 		auto state = duckdb_query_arrow(tester.connection, "SELECT 42 AS VALUE, [1,2,3,4,5] AS LST;", &arrow_result);
 		REQUIRE(state == DuckDBSuccess);
 		REQUIRE(duckdb_arrow_row_count(arrow_result) == 1);
@@ -67,7 +64,6 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 	}
 
 	SECTION("test multiple chunks") {
-
 		// create a table that consists of multiple chunks
 		REQUIRE_NO_FAIL(tester.Query("CREATE TABLE test(a INTEGER);"));
 		REQUIRE_NO_FAIL(
@@ -88,7 +84,6 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 
 		int total_count = 0;
 		while (true) {
-
 			// query array data
 			ArrowArray arrow_array;
 			arrow_array.Init();
@@ -115,7 +110,6 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 	}
 
 	SECTION("test prepare query arrow") {
-
 		auto state = duckdb_prepare(tester.connection, "SELECT CAST($1 AS BIGINT)", &stmt);
 		REQUIRE(state == DuckDBSuccess);
 		REQUIRE(stmt != nullptr);
@@ -160,7 +154,6 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 	}
 
 	SECTION("test scan") {
-
 		const auto logical_types = duckdb::vector<LogicalType> {LogicalType(LogicalTypeId::INTEGER)};
 		const auto column_names = duckdb::vector<string> {"value"};
 
@@ -177,7 +170,6 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 		auto arrow_array_ptr = &arrow_array;
 
 		SECTION("empty array") {
-
 			// Create an empty view with a `value` column.
 			string view_name = "foo_empty_table";
 
@@ -212,7 +204,6 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 		}
 
 		SECTION("big array") {
-
 			// Create a view with a `value` column containing 4096 values.
 			int num_buffers = 2, size = STANDARD_VECTOR_SIZE * num_buffers;
 			unordered_map<idx_t, const duckdb::shared_ptr<ArrowTypeExtensionData>> extension_type_cast;

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -403,7 +403,6 @@ TEST_CASE("Test DataChunk populate ListVector in C API", "[capi]") {
 }
 
 TEST_CASE("Test DataChunk populate ArrayVector in C API", "[capi]") {
-
 	auto elem_type = duckdb_create_logical_type(duckdb_type::DUCKDB_TYPE_INTEGER);
 	auto array_type = duckdb_create_array_type(elem_type, 3);
 	duckdb_logical_type schema[] = {array_type};

--- a/test/api/capi/test_capi_extract.cpp
+++ b/test/api/capi/test_capi_extract.cpp
@@ -64,7 +64,6 @@ TEST_CASE("Test extract statements in C API", "[capi]") {
 }
 
 TEST_CASE("Test invalid PRAGMA in C API", "[capi]") {
-
 	duckdb_database db;
 	duckdb_connection con;
 	const char *err_msg;

--- a/test/api/capi/test_capi_profiling.cpp
+++ b/test/api/capi/test_capi_profiling.cpp
@@ -86,7 +86,6 @@ void RetrieveMetrics(duckdb_profiling_info info, duckdb::map<string, double> &cu
 
 void TraverseTree(duckdb_profiling_info profiling_info, duckdb::map<string, double> &cumulative_counter,
                   duckdb::map<string, double> &cumulative_result, const idx_t depth) {
-
 	RetrieveMetrics(profiling_info, cumulative_counter, cumulative_result, depth);
 
 	// Recurse into the child node.

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -643,7 +643,6 @@ TEST_CASE("Issue #14130: InsertStatement::ToString causes InternalException late
 }
 
 TEST_CASE("Issue #6284: CachingPhysicalOperator in pull causes issues", "[api][.]") {
-
 	DBConfig config;
 	config.options.maximum_threads = 8;
 	DuckDB db(nullptr, &config);

--- a/test/optimizer/union_alls.cpp
+++ b/test/optimizer/union_alls.cpp
@@ -10,7 +10,6 @@ using namespace duckdb;
 using namespace std;
 
 TEST_CASE("A lot of unions", "[optimizer][.]") {
-
 	DuckDB db(nullptr);
 	Connection con(db);
 

--- a/test/serialize/serialization_test.cpp
+++ b/test/serialize/serialization_test.cpp
@@ -40,7 +40,6 @@ struct Foo {
 };
 
 TEST_CASE("Test default values", "[serialization]") {
-
 	Foo foo_in;
 	foo_in.a = 42;
 	foo_in.bar = make_uniq<Bar>();

--- a/test/sql/index/test_art_keys.cpp
+++ b/test/sql/index/test_art_keys.cpp
@@ -46,7 +46,6 @@ static void TestKeys(duckdb::vector<ARTKey> &keys) {
 }
 
 static ARTKey CreateCompoundKey(ArenaAllocator &arena_allocator, const string &str_val, int32_t int_val) {
-
 	auto key_left = ARTKey::CreateARTKey<string_t>(arena_allocator, string_t(str_val.c_str(), str_val.size()));
 	auto key_right = ARTKey::CreateARTKey<int32_t>(arena_allocator, int_val);
 
@@ -57,7 +56,6 @@ static ARTKey CreateCompoundKey(ArenaAllocator &arena_allocator, const string &s
 }
 
 TEST_CASE("Test correct functioning of art keys", "[art]") {
-
 	ArenaAllocator arena_allocator(Allocator::DefaultAllocator());
 
 	// Test tiny int

--- a/test/sql/parallelism/interquery/test_concurrent_index.cpp
+++ b/test/sql/parallelism/interquery/test_concurrent_index.cpp
@@ -29,10 +29,8 @@ static void CheckConstraintViolation(const string &result_str) {
 }
 
 static void ReadFromIntegers(DuckDB *db, idx_t thread_idx, atomic<bool> *success) {
-
 	Connection con(*db);
 	while (!concurrent_index_finished) {
-
 		auto expected_value = to_string(thread_idx * 10000);
 		auto result = con.Query("SELECT i FROM integers WHERE i = " + expected_value);
 		if (result->HasError()) {
@@ -86,7 +84,6 @@ static void AppendToIntegers(DuckDB *db, atomic<bool> *success) {
 }
 
 TEST_CASE("Concurrent writes during index creation", "[index][.]") {
-
 	DuckDB db(nullptr);
 	Connection con(db);
 	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
@@ -124,7 +121,6 @@ TEST_CASE("Concurrent writes during index creation", "[index][.]") {
 }
 
 static void AppendToPK(DuckDB *db) {
-
 	Connection con(*db);
 	for (idx_t i = 0; i < 1000; i++) {
 		auto result = con.Query("INSERT INTO integers VALUES ($1)", i);
@@ -135,7 +131,6 @@ static void AppendToPK(DuckDB *db) {
 }
 
 TEST_CASE("Concurrent inserts to PRIMARY KEY", "[index][.]") {
-
 	DuckDB db(nullptr);
 	Connection con(db);
 	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
@@ -161,7 +156,6 @@ TEST_CASE("Concurrent inserts to PRIMARY KEY", "[index][.]") {
 }
 
 static void UpdatePK(DuckDB *db) {
-
 	Connection con(*db);
 	for (idx_t i = 0; i < 1000; i++) {
 		auto result = con.Query("UPDATE integers SET i = 1000 + (i % 100) WHERE i = $1", i);
@@ -172,7 +166,6 @@ static void UpdatePK(DuckDB *db) {
 }
 
 TEST_CASE("Concurrent updates to PRIMARY KEY", "[index][.]") {
-
 	DuckDB db(nullptr);
 	Connection con(db);
 	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
@@ -199,10 +192,8 @@ TEST_CASE("Concurrent updates to PRIMARY KEY", "[index][.]") {
 }
 
 static void MixAppendToPK(DuckDB *db, atomic<idx_t> *count) {
-
 	Connection con(*db);
 	for (idx_t i = 0; i < 100; i++) {
-
 		auto result = con.Query("INSERT INTO integers VALUES ($1)", i);
 		if (!result->HasError()) {
 			(*count)++;
@@ -214,14 +205,12 @@ static void MixAppendToPK(DuckDB *db, atomic<idx_t> *count) {
 }
 
 static void MixUpdatePK(DuckDB *db, idx_t thread_idx) {
-
 	std::uniform_int_distribution<> distribution(1, 100);
 	std::mt19937 gen;
 	gen.seed(thread_idx);
 
 	Connection con(*db);
 	for (idx_t i = 0; i < 100; i++) {
-
 		idx_t old_value = distribution(gen);
 		idx_t new_value = 100 + distribution(gen);
 
@@ -234,7 +223,6 @@ static void MixUpdatePK(DuckDB *db, idx_t thread_idx) {
 }
 
 TEST_CASE("Mix updates and inserts on PRIMARY KEY", "[index][.]") {
-
 	DuckDB db(nullptr);
 	Connection con(db);
 	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
@@ -285,7 +273,6 @@ static void TransactionalAppendToPK(DuckDB *db, idx_t thread_idx) {
 	auto initial_count = chunk->GetValue(0, 0).GetValue<int32_t>();
 
 	for (idx_t i = 0; i < 50; i++) {
-
 		result = con.Query("INSERT INTO integers VALUES ($1)", (int32_t)(thread_idx * 1000 + i));
 		if (result->HasError()) {
 			FAIL(result->GetError());
@@ -347,7 +334,6 @@ static void JoinIntegers(Connection *con) {
 }
 
 TEST_CASE("Concurrent appends during joins", "[index][.]") {
-
 	duckdb::unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
 	Connection con(db);

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -256,7 +256,6 @@ void SQLLogicTestLogger::WrongRowCount(idx_t expected_rows, MaterializedQueryRes
 
 void SQLLogicTestLogger::ColumnCountMismatchCorrectResult(idx_t original_expected_columns, idx_t expected_column_count,
                                                           MaterializedQueryResult &result) {
-
 	std::ostringstream oss;
 	PrintErrorHeader("Wrong column count in query!");
 	oss << "Expected " << termcolor::bold << original_expected_columns << termcolor::reset << " columns, but got "
@@ -280,7 +279,6 @@ void SQLLogicTestLogger::ColumnCountMismatchCorrectResult(idx_t original_expecte
 }
 
 void SQLLogicTestLogger::SplitMismatch(idx_t row_number, idx_t expected_column_count, idx_t split_count) {
-
 	std::ostringstream oss;
 	PrintLineSep();
 	PrintErrorHeader("Error in test! Column count mismatch after splitting on tab on row " + to_string(row_number) +

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2453,7 +2453,6 @@ int deduceDatabaseType(const char *zName, int dfltZip) {
 ** the database fails to open, print an error message and exit.
 */
 void ShellState::OpenDB(int flags) {
-
 	if (db == 0) {
 		if (openMode == SHELL_OPEN_UNSPEC) {
 			if (zDbFilename.empty()) {

--- a/tools/sqlite3_api_wrapper/shell_extension.cpp
+++ b/tools/sqlite3_api_wrapper/shell_extension.cpp
@@ -28,7 +28,6 @@ static unique_ptr<FunctionData> GetEnvBind(ClientContext &context, ScalarFunctio
 }
 
 void ShellExtension::Load(ExtensionLoader &loader) {
-
 	loader.SetDescription("Adds CLI-specific support and functionalities");
 	loader.RegisterFunction(
 	    ScalarFunction("getenv", {LogicalType::VARCHAR}, LogicalType::VARCHAR, GetEnvFunction, GetEnvBind));

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -1142,7 +1142,6 @@ int sqlite3_complete(const char *zSql) {
 
 // length of varchar or blob value
 int sqlite3_column_bytes(sqlite3_stmt *pStmt, int iCol) {
-
 	if (!pStmt || iCol < 0 || pStmt->result->types.size() <= static_cast<size_t>(iCol))
 		return 0;
 

--- a/tools/sqlite3_api_wrapper/sqlite3_udf_api/include/cast_sqlite.hpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_udf_api/include/cast_sqlite.hpp
@@ -57,7 +57,6 @@ struct CastToSQLiteValue {
 };
 
 struct CastToVectorSQLiteValue {
-
 	template <class INPUT_TYPE, class OPCAST>
 	static inline unique_ptr<vector<sqlite3_value>> Operation(UnifiedVectorFormat &vec_data, idx_t count) {
 		unique_ptr<vector<sqlite3_value>> result = make_uniq<vector<sqlite3_value>>(count);


### PR DESCRIPTION
Added `KeepEmptyLinesAtTheStartOfBlocks: false` to `.clang-format` to fix this kind of stuff:
```c++
int MyFun() {

    return 42;
}
```
This rule removes the leading newline in the function.