### PR TITLE
Bump multiple extensions

### DIFF
--- a/.github/config/extensions/avro.cmake
+++ b/.github/config/extensions/avro.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW)
     duckdb_extension_load(avro
             LOAD_TESTS DONT_LINK
             GIT_URL https://github.com/duckdb/duckdb-avro
-            GIT_TAG 7b75062f6345d11c5342c09216a75c57342c2e82
+            GIT_TAG 93da8a19b41eb577add83d0552c6946a16e97c83
     )
 endif()

--- a/.github/config/extensions/delta.cmake
+++ b/.github/config/extensions/delta.cmake
@@ -1,7 +1,7 @@
 if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(delta
             GIT_URL https://github.com/duckdb/duckdb-delta
-            GIT_TAG 03aaf0f073bc622ade27c158d32473588b32aa8b
+            GIT_TAG 0747c23791c6ad53dfc22f58dc73008d49d2a8ae
             SUBMODULES extension-ci-tools
     )
 endif()

--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG f134ad86f2f6e7cdf4133086c38ecd9c48f1a772
+    GIT_TAG 2554312f71916ba11530c838b5c8c65b4786825c
 )

--- a/.github/config/extensions/iceberg.cmake
+++ b/.github/config/extensions/iceberg.cmake
@@ -8,6 +8,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 4f3c5499e5feec9fe17a69a8ca74d81aaf472fd2
+            GIT_TAG 30a2c66f1040ffd36e117ace6e22acbdb402e79c
             )
 endif()

--- a/.github/config/extensions/spatial.cmake
+++ b/.github/config/extensions/spatial.cmake
@@ -3,7 +3,7 @@ if (${BUILD_COMPLETE_EXTENSION_SET})
 duckdb_extension_load(spatial
     DONT_LINK LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-spatial
-    GIT_TAG a6a607fe3a98ef9ad4bed218490b770f725fbc12
+    GIT_TAG 61ede09becdc06c4a3d0df1c1e8361be478142be
     INCLUDE_DIR src/spatial
     TEST_DIR test/sql
     )


### PR DESCRIPTION
This PR bumps the following extensions:
- `avro` from `7b75062f63` to `93da8a19b4`
- `delta` from `03aaf0f073` to `0747c23791`
- `ducklake` from `f134ad86f2` to `2554312f71`
- `iceberg` from `4f3c5499e5` to `30a2c66f10`
- `spatial` from `a6a607fe3a` to `61ede09bec`
