### PR TITLE
Support non-standard NULL in Parquet again

### DIFF
--- a/test/parquet/test_legacy_empty_pandas_parquet.test
+++ b/test/parquet/test_legacy_empty_pandas_parquet.test
@@ -6,7 +6,5 @@ require parquet
 # This file includes the unsupported NULL (24) ConvertedType
 # Which is not supported by the spec, but written by some ancient versions of Pandas (pre-2020)
 
-statement error
+statement ok
 select * from '{DATA_DIR}/parquet-testing/empty.parquet'
-----
-Invalid data

--- a/third_party/parquet/parquet.thrift
+++ b/third_party/parquet/parquet.thrift
@@ -175,6 +175,14 @@ enum ConvertedType {
    * particular timezone or date.
    */
   INTERVAL = 21;
+
+  /**
+   * Non-standard NULL value
+   *
+   * This was written by old writers - it is kept here for compatibility purposes.
+   * See https://github.com/duckdb/duckdb/pull/11774
+   */
+  PARQUET_NULL = 24;
 }
 
 /**

--- a/third_party/parquet/parquet_types.cpp
+++ b/third_party/parquet/parquet_types.cpp
@@ -184,7 +184,14 @@ int _kConvertedTypeValues[] = {
    * the provided duration.  This duration of time is independent of any
    * particular timezone or date.
    */
-  ConvertedType::INTERVAL
+  ConvertedType::INTERVAL,
+  /**
+   * Non-standard NULL value
+   * 
+   * This was written by old writers - it is kept here for compatibility purposes.
+   * See https://github.com/duckdb/duckdb/pull/11774
+   */
+  ConvertedType::PARQUET_NULL
 };
 const char* _kConvertedTypeNames[] = {
   /**
@@ -308,9 +315,16 @@ const char* _kConvertedTypeNames[] = {
    * the provided duration.  This duration of time is independent of any
    * particular timezone or date.
    */
-  "INTERVAL"
+  "INTERVAL",
+  /**
+   * Non-standard NULL value
+   * 
+   * This was written by old writers - it is kept here for compatibility purposes.
+   * See https://github.com/duckdb/duckdb/pull/11774
+   */
+  "PARQUET_NULL"
 };
-const std::map<int, const char*> _ConvertedType_VALUES_TO_NAMES(::apache::thrift::TEnumIterator(22, _kConvertedTypeValues, _kConvertedTypeNames), ::apache::thrift::TEnumIterator(-1, nullptr, nullptr));
+const std::map<int, const char*> _ConvertedType_VALUES_TO_NAMES(::apache::thrift::TEnumIterator(23, _kConvertedTypeValues, _kConvertedTypeNames), ::apache::thrift::TEnumIterator(-1, nullptr, nullptr));
 
 std::ostream& operator<<(std::ostream& out, const ConvertedType::type& val) {
   std::map<int, const char*>::const_iterator it = _ConvertedType_VALUES_TO_NAMES.find(val);

--- a/third_party/parquet/parquet_types.h
+++ b/third_party/parquet/parquet_types.h
@@ -178,7 +178,14 @@ struct ConvertedType {
      * the provided duration.  This duration of time is independent of any
      * particular timezone or date.
      */
-    INTERVAL = 21
+    INTERVAL = 21,
+    /**
+     * Non-standard NULL value
+     * 
+     * This was written by old writers - it is kept here for compatibility purposes.
+     * See https://github.com/duckdb/duckdb/pull/11774
+     */
+    PARQUET_NULL = 24
   };
 };
 


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/19406 removed support for the non-standard NULL by adding the safe enum casts. 

Support for this was explicitly added in https://github.com/duckdb/duckdb/pull/11774

We could consider removing support for this - but it shouldn't be done as part of a bug-fix release imo. This also currently breaks merging v1.4 -> main.