### PR TITLE
Add test that either 'latest' or 'vX.Y.Z' are supported STORAGE_VERSIONs

### DIFF
--- a/test/sql/pragma/test_pragma_version.test
+++ b/test/sql/pragma/test_pragma_version.test
@@ -27,3 +27,12 @@ SELECT count(*) FROM pragma_version() WHERE library_version LIKE 'v%';
 
 statement ok
 pragma extension_versions;
+
+statement ok
+SET VARIABLE v = (select library_version  from pragma_version());
+
+statement ok
+SET VARIABLE v_or_latest = (select CASE WHEN getvariable('v') ILIKE 'v%-dev%' THEN 'latest' WHEN getvariable('v') ILIKE 'v0.0.1' THEN 'latest' ELSE getvariable('v') END);
+
+statement ok
+ATTACH 'somefile.db' (STORAGE_VERSION getvariable('v_or_latest'));


### PR DESCRIPTION
Connected to https://github.com/duckdb/duckdb/pull/19525, adds a test that would have triggered.

That test is not build when actually building releases, so that's not fool-proof, but I think adding this in is helpful.

Tested locally to behave as intended both on dev commit (success) and tag (fails, fixed via linked PR).