### PR TITLE
Moving staging to cf and uploading to install bucket

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -89,6 +89,7 @@ jobs:
     - name: Deploy
       shell: bash
       env:
+        AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |

--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Deploy
         shell: bash
         env:
+          AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
@@ -148,6 +149,7 @@ jobs:
       - name: Deploy
         shell: bash
         env:
+          AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
@@ -208,6 +210,7 @@ jobs:
       - name: Deploy
         shell: bash
         env:
+          AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -117,6 +117,7 @@ jobs:
     - name: Deploy
       shell: bash
       env:
+        AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |
@@ -167,6 +168,7 @@ jobs:
     - name: Deploy
       shell: bash
       env:
+        AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -173,6 +173,7 @@ jobs:
       - name: Deploy
         shell: bash
         env:
+          AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |

--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -38,7 +38,7 @@ jobs:
           aws s3 cp --recursive "s3://duckdb-staging/$TARGET/${{ inputs.target_git_describe }}/$GITHUB_REPOSITORY/github_release" to_be_uploaded
 
      - name: Deploy
-        if: ${{ inputs.target_git_describe != '' }}
+       if: ${{ inputs.target_git_describe != '' }}
        shell: bash
        env:
          AWS_ENDPOINT_URL: ${{ secrets.DUCKDB_INSTALL_S3_ENDPOINT }}

--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -9,9 +9,6 @@ on:
       target_git_describe:
         type: string
 
-env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
 jobs:
  staged-upload:
    runs-on: ubuntu-latest
@@ -32,14 +29,21 @@ jobs:
      - name: Download from staging bucket
        shell: bash
        env:
+         AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
        run: |
           TARGET=$(git log -1 --format=%h)
           mkdir to_be_uploaded
-          aws s3 cp --recursive "s3://duckdb-staging/$TARGET/${{ inputs.target_git_describe }}/$GITHUB_REPOSITORY/github_release" to_be_uploaded --region us-east-2
+          aws s3 cp --recursive "s3://duckdb-staging/$TARGET/${{ inputs.target_git_describe }}/$GITHUB_REPOSITORY/github_release" to_be_uploaded
 
      - name: Deploy
        shell: bash
+       env:
+         AWS_ENDPOINT_URL: ${{ secrets.DUCKDB_INSTALL_S3_ENDPOINT }}
+         AWS_ACCESS_KEY_ID: ${{ secrets.DUCKDB_INSTALL_S3_ID }}
+         AWS_SECRET_ACCESS_KEY: ${{ secrets.DUCKDB_INSTALL_S3_SECRET }}
+         GH_TOKEN: ${{ secrets.GH_TOKEN }}
        run: |
          python3 scripts/asset-upload-gha.py to_be_uploaded/*
+         aws s3 cp to_be_uploaded/* "s3://duckdb-install/${{ inputs.target_git_describe }}

--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -38,6 +38,7 @@ jobs:
           aws s3 cp --recursive "s3://duckdb-staging/$TARGET/${{ inputs.target_git_describe }}/$GITHUB_REPOSITORY/github_release" to_be_uploaded
 
      - name: Deploy
+        if: ${{ inputs.target_git_describe != '' }}
        shell: bash
        env:
          AWS_ENDPOINT_URL: ${{ secrets.DUCKDB_INSTALL_S3_ENDPOINT }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -150,6 +150,7 @@ jobs:
     - name: Deploy
       shell: bash
       env:
+        AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |
@@ -263,6 +264,7 @@ jobs:
      - name: Deploy
        shell: bash
        env:
+         AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
        run: |


### PR DESCRIPTION
This adds a custom endpoint for staging uploads so we can move to R2 for this. We also add functionality to upload to the R2 bucket behind `install.duckdb.org`. Once merged, I will update/add the following secrets:

- `S3_DUCKDB_STAGING_ENDPOINT`
- `S3_DUCKDB_STAGING_ID`
- `S3_DUCKDB_STAGING_KEY`
- `DUCKDB_INSTALL_S3_ENDPOINT`
- `DUCKDB_INSTALL_S3_ID`
- `DUCKDB_INSTALL_S3_SECRET`

