### PR TITLE
CLI: Generate ".help" menu from the list of commands, and add syntax highlighting to .help

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -200,6 +200,7 @@ public:
 	void ClearTempFile();
 	void NewTempFile(const char *zSuffix);
 	int DoMetaCommand(const string &zLine);
+	idx_t PrintHelp(const char *zPattern);
 
 	int RunOneSqlLine(InputMode mode, char *zSql);
 	string GetDefaultDuckDBRC();

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4295,7 +4295,7 @@ static void linenoise_completion(const char *zLine, linenoiseCompletions *lc) {
 			bool found_match = true;
 			idx_t line_pos;
 			zBuf[0] = '.';
-			for (line_pos = 0; !ShellState::IsSpace(line[line_pos]) && line[line_pos] && line_pos + 1 < sizeof(zBuf);
+			for (line_pos = 0; !ShellState::IsSpace(line[line_pos]) && line[line_pos] && line_pos + 2 < sizeof(zBuf);
 			     line_pos++) {
 				zBuf[line_pos + 1] = line[line_pos];
 				if (line_pos + 1 < nLine && line[line_pos] != zLine[line_pos + 1]) {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1742,138 +1742,6 @@ void ShellState::RunSchemaDumpQuery(const string &zQuery) {
 	}
 }
 
-static const char *azHelp[] = {
-    ".bail on|off             Stop after hitting an error.  Default OFF",
-    ".binary on|off           Turn binary output on or off.  Default OFF",
-    ".cd DIRECTORY            Change the working directory to DIRECTORY",
-    ".changes on|off          Show number of rows changed by SQL",
-    ".check GLOB              Fail if output since .testcase does not match",
-    ".columns                 Column-wise rendering of query results",
-#ifdef HAVE_LINENOISE
-    ".constant ?COLOR?        Sets the syntax highlighting color used for constant values",
-    "   COLOR is one of:",
-    "     red|green|yellow|blue|magenta|cyan|white|brightblack|brightred|brightgreen",
-    "     brightyellow|brightblue|brightmagenta|brightcyan|brightwhite",
-    ".constantcode ?CODE?     Sets the syntax highlighting terminal code used for constant values",
-#endif
-    ".databases               List names and files of attached databases",
-    ".decimal_sep SEP         Sets the decimal separator used when rendering numbers. Only for duckbox mode.",
-    ".dump ?TABLE?            Render database content as SQL",
-    "   Options:",
-    "     --newlines             Allow unescaped newline characters in output",
-    "   TABLE is a LIKE pattern for the tables to dump",
-    "   Additional LIKE patterns can be given in subsequent arguments",
-    ".echo on|off             Turn command echo on or off",
-    ".excel                   Display the output of next command in spreadsheet",
-    "   --bom                   Put a UTF8 byte-order mark on intermediate file",
-#ifdef HAVE_LINENOISE
-    ".edit                    Opens an external text editor to edit a query.",
-    "   Notes:",
-    "     *  The editor is read from the environment variables",
-    "        DUCKDB_EDITOR, EDITOR, VISUAL in-order",
-    "     * If none of these are set, the default editor is vi",
-    "   * \\e can be used as an alias for .edit",
-#endif
-    ".exit ?CODE?             Exit this program with return-code CODE",
-    ".explain ?on|off|auto?   Change the EXPLAIN formatting mode.  Default: auto",
-    ".fullschema ?--indent?   Show schema and the content of sqlite_stat tables",
-    ".headers on|off          Turn display of headers on or off",
-    ".help ?-all? ?PATTERN?   Show help text for PATTERN",
-#ifdef HAVE_LINENOISE
-    ".highlight [on|off]      Toggle syntax highlighting in the shell on/off",
-#endif
-    ".highlight_colors [element] [color]  ([bold])? Configure highlighting colors",
-    ".highlight_errors [on|off] Toggle highlighting of errors in the shell on/off",
-    ".highlight_results [on|off] Toggle highlighting of results in the shell on/off",
-    ".import FILE TABLE       Import data from FILE into TABLE",
-    "   Options:",
-    "     --ascii               Use \\037 and \\036 as column and row separators",
-    "     --csv                 Use , and \\n as column and row separators",
-    "     --skip N              Skip the first N rows of input",
-    "     -v                    \"Verbose\" - increase auxiliary output",
-    "   Notes:",
-    "     *  If TABLE does not exist, it is created.  The first row of input",
-    "        determines the column names.",
-    "     *  If neither --csv or --ascii are used, the input mode is derived",
-    "        from the \".mode\" output mode",
-    "     *  If FILE begins with \"|\" then it is a command that generates the",
-    "        input text.",
-    ".indexes ?TABLE?         Show names of indexes",
-    "                           If TABLE is specified, only show indexes for",
-    "                           tables matching TABLE using the LIKE operator.",
-#ifdef HAVE_LINENOISE
-    ".keyword ?COLOR?         Sets the syntax highlighting color used for keywords",
-    "   COLOR is one of:",
-    "     red|green|yellow|blue|magenta|cyan|white|brightblack|brightred|brightgreen",
-    "     brightyellow|brightblue|brightmagenta|brightcyan|brightwhite",
-    ".keywordcode ?CODE?      Sets the syntax highlighting terminal code used for keywords",
-#endif
-    ".large_number_rendering all|footer|off Toggle readable rendering of large numbers (duckbox only)",
-    ".log FILE|off            Turn logging on or off.  FILE can be stderr/stdout",
-    ".maxrows COUNT           Sets the maximum number of rows for display (default: 40). Only for duckbox mode.",
-    ".maxwidth COUNT          Sets the maximum width in characters. 0 defaults to terminal width. Only for duckbox "
-    "mode.",
-    ".mode MODE ?TABLE?       Set output mode",
-    "   MODE is one of:",
-    "     ascii     Columns/rows delimited by 0x1F and 0x1E",
-    "     box       Tables using unicode box-drawing characters",
-    "     csv       Comma-separated values",
-    "     column    Output in columns.  (See .width)",
-    "     duckbox   Tables with extensive features",
-    "     html      HTML <table> code",
-    "     insert    SQL insert statements for TABLE",
-    "     json      Results in a JSON array",
-    "     jsonlines Results in a NDJSON",
-    "     latex     LaTeX tabular environment code",
-    "     line      One value per line",
-    "     list      Values delimited by \"|\"",
-    "     markdown  Markdown table format",
-    "     quote     Escape answers as for SQL",
-    "     table     ASCII-art table",
-    "     tabs      Tab-separated values",
-    "     tcl       TCL list elements",
-    "     trash     No output",
-    ".nullvalue STRING        Use STRING in place of NULL values",
-    ".once ?OPTIONS? ?FILE?   Output for the next SQL command only to FILE",
-    "     If FILE begins with '|' then open as a pipe",
-    "       --bom  Put a UTF8 byte-order mark at the beginning",
-    "       -e     Send output to the system text editor",
-    "       -x     Send output as CSV to a spreadsheet (same as \".excel\")",
-    ".open ?OPTIONS? ?FILE?   Close existing database and reopen FILE",
-    "     Options:",
-    "        --new           Initialize FILE to an empty database",
-    "        --nofollow      Do not follow symbolic links",
-    "        --readonly      Open FILE readonly",
-    ".output ?FILE?           Send output to FILE or stdout if FILE is omitted",
-    "   If FILE begins with '|' then open it as a pipe.",
-    "   Options:",
-    "     --bom                 Prefix output with a UTF8 byte-order mark",
-    "     -e                    Send output to the system text editor",
-    "     -x                    Send output as CSV to a spreadsheet",
-    ".print STRING...         Print literal STRING",
-    ".prompt MAIN CONTINUE    Replace the standard prompts",
-    ".quit                    Exit this program",
-    ".read FILE               Read input from FILE",
-    ".rows                    Row-wise rendering of query results (default)",
-    ".safe_mode               Enable safe-mode",
-    ".schema ?PATTERN?        Show the CREATE statements matching PATTERN",
-    "     Options:",
-    "         --indent            Try to pretty-print the schema",
-    ".separator COL ?ROW?     Change the column and row separators",
-    ".shell CMD ARGS...       Run CMD ARGS... in a system shell",
-    ".show                    Show the current values for various settings",
-    ".system CMD ARGS...      Run CMD ARGS... in a system shell",
-    ".tables ?TABLE?          List names of tables matching LIKE pattern TABLE",
-    ".testcase NAME           Begin redirecting output to 'testcase-out.txt'",
-    ".thousand_sep SEP        Sets the thousand separator used when rendering numbers. Only for duckbox mode.",
-    ".timer on|off            Turn SQL timer on or off",
-    ".width NUM1 NUM2 ...     Set minimum column widths for columnar output",
-    "     Negative values right-justify",
-#if defined(_WIN32) || defined(WIN32)
-    ".utf8                    Enable experimental UTF-8 console output mode"
-#endif
-};
-
 SuccessState ShellState::ExecuteQuery(const string &query) {
 	auto &con = *conn;
 	auto res = con.Query(query);
@@ -1912,77 +1780,6 @@ void ShellState::OpenDB(ShellOpenFlags flags) {
 		}
 	}
 }
-
-#ifdef HAVE_LINENOISE
-/*
-** Linenoise completion callback
-*/
-static void linenoise_completion(const char *zLine, linenoiseCompletions *lc) {
-	idx_t nLine = ShellState::StringLength(zLine);
-	char zBuf[1000];
-
-	if (nLine > sizeof(zBuf) - 30) {
-		return;
-	}
-	if (!globalState) {
-		return;
-	}
-	if (zLine[0] == '.') {
-		// auto-complete dot command
-		// look for all completions in the help file
-		size_t line_idx;
-		for (line_idx = 0; line_idx < ArraySize(azHelp); line_idx++) {
-			const char *line = azHelp[line_idx];
-			if (line[0] != '.') {
-				continue;
-			}
-			int found_match = 1;
-			size_t line_pos;
-			for (line_pos = 0; !ShellState::IsSpace(line[line_pos]) && line[line_pos] && line_pos + 1 < sizeof(zBuf);
-			     line_pos++) {
-				zBuf[line_pos] = line[line_pos];
-				if (line_pos < nLine && line[line_pos] != zLine[line_pos]) {
-					// only match prefixes for auto-completion, i.e. ".sh" matches ".shell"
-					found_match = 0;
-					break;
-				}
-			}
-			zBuf[line_pos] = '\0';
-			if (found_match && line_pos >= nLine) {
-				linenoiseAddCompletion(lc, zBuf);
-			}
-		}
-		return;
-	}
-	if (zLine[0] == '#') {
-		return;
-	}
-	//  if( i==nLine-1 ) return;
-	auto zSql = StringUtil::Format("CALL sql_auto_complete(%s)", SQLString(zLine));
-	unique_ptr<duckdb::DuckDB> localDB;
-	unique_ptr<duckdb::Connection> localCon;
-
-	if (!globalState->conn) {
-		globalState->OpenDB();
-	}
-	auto &con = *globalState->conn;
-	bool copiedSuggestion = false;
-	auto result = con.Query(zSql);
-	for (auto &row : *result) {
-		auto zCompletion = row.GetValue<string>(0);
-		auto nCompletion = zCompletion.size();
-		idx_t iStart = row.GetValue<idx_t>(1);
-		if (iStart + nCompletion < (sizeof(zBuf) - 1)) {
-			if (!copiedSuggestion) {
-				memcpy(zBuf, zLine, iStart);
-				copiedSuggestion = true;
-			}
-			memcpy(zBuf + iStart, zCompletion.c_str(), nCompletion + 1);
-			linenoiseAddCompletion(lc, zBuf);
-		}
-	}
-}
-#endif
 
 /*
 ** Do C-language style dequoting.
@@ -4475,6 +4272,74 @@ bool ShellState::ProcessDuckDBRC(const char *file) {
 	}
 	return ProcessFile(file, true);
 }
+
+#ifdef HAVE_LINENOISE
+/*
+** Linenoise completion callback
+*/
+static void linenoise_completion(const char *zLine, linenoiseCompletions *lc) {
+	idx_t nLine = ShellState::StringLength(zLine);
+	char zBuf[1000];
+
+	if (nLine > sizeof(zBuf) - 30) {
+		return;
+	}
+	if (!globalState) {
+		return;
+	}
+	if (zLine[0] == '.') {
+		// auto-complete dot command
+		for (idx_t c = 0; metadata_commands[c].command; c++) {
+			auto &command = metadata_commands[c];
+			auto &line = command.command;
+			bool found_match = true;
+			idx_t line_pos;
+			zBuf[0] = '.';
+			for (line_pos = 0; !ShellState::IsSpace(line[line_pos]) && line[line_pos] && line_pos + 1 < sizeof(zBuf);
+			     line_pos++) {
+				zBuf[line_pos + 1] = line[line_pos];
+				if (line_pos + 1 < nLine && line[line_pos] != zLine[line_pos + 1]) {
+					// only match prefixes for auto-completion, i.e. ".sh" matches ".shell"
+					found_match = false;
+					break;
+				}
+			}
+			zBuf[line_pos + 1] = '\0';
+			if (found_match && line_pos + 1 >= nLine) {
+				linenoiseAddCompletion(lc, zBuf);
+			}
+		}
+		return;
+	}
+	if (zLine[0] == '#') {
+		return;
+	}
+	//  if( i==nLine-1 ) return;
+	auto zSql = StringUtil::Format("CALL sql_auto_complete(%s)", SQLString(zLine));
+	unique_ptr<duckdb::DuckDB> localDB;
+	unique_ptr<duckdb::Connection> localCon;
+
+	if (!globalState->conn) {
+		globalState->OpenDB();
+	}
+	auto &con = *globalState->conn;
+	bool copiedSuggestion = false;
+	auto result = con.Query(zSql);
+	for (auto &row : *result) {
+		auto zCompletion = row.GetValue<string>(0);
+		auto nCompletion = zCompletion.size();
+		idx_t iStart = row.GetValue<idx_t>(1);
+		if (iStart + nCompletion < (sizeof(zBuf) - 1)) {
+			if (!copiedSuggestion) {
+				memcpy(zBuf, zLine, iStart);
+				copiedSuggestion = true;
+			}
+			memcpy(zBuf + iStart, zCompletion.c_str(), nCompletion + 1);
+			linenoiseAddCompletion(lc, zBuf);
+		}
+	}
+}
+#endif
 
 /*
 ** Show available command line options

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1741,16 +1741,6 @@ void ShellState::RunSchemaDumpQuery(const string &zQuery) {
 		}
 	}
 }
-
-/*
-** Text of help messages.
-**
-** The help text for each individual command begins with a line that starts
-** with ".".  Subsequent lines are supplimental information.
-**
-** There must be two or more spaces between the end of the command and the
-** start of the description of what that command does.
-*/
 static const char *azHelp[] = {
     ".bail on|off             Stop after hitting an error.  Default OFF",
     ".binary on|off           Turn binary output on or off.  Default OFF",
@@ -2484,6 +2474,7 @@ struct MetadataCommand {
 	const char *usage;
 	const char *description;
 	idx_t match_size;
+	const char *extra_description;
 };
 
 MetadataResult ToggleBail(ShellState &state, const vector<string> &args) {
@@ -3778,119 +3769,147 @@ MetadataResult SetHighlightingColor(ShellState &state, const vector<string> &arg
 #endif
 
 static const MetadataCommand metadata_commands[] = {
-    {"backup", 0, nullptr, "?DB? FILE", "Backup DB (default \"main\") to FILE", 3},
-    {"bail", 2, ToggleBail, "on|off", "Stop after hitting an error.  Default OFF", 3},
-    {"binary", 2, ToggleBinary, "on|off", "Turn binary output on or off.  Default OFF", 3},
-    {"cd", 2, ChangeDirectory, "DIRECTORY", "Change the working directory to DIRECTORY", 0},
-    {"changes", 2, ToggleChanges, "on|off", "Show number of rows changed by SQL", 3},
-    {"columns", 1, SetColumnRendering, "", "Column-wise rendering of query results", 0},
+    {"backup", 0, nullptr, "?DB? FILE", "Backup DB (default \"main\") to FILE", 3, ""},
+    {"bail", 2, ToggleBail, "on|off", "Stop after hitting an error.  Default OFF", 3, ""},
+    {"binary", 2, ToggleBinary, "on|off", "Turn binary output on or off.  Default OFF", 3, ""},
+    {"cd", 2, ChangeDirectory, "DIRECTORY", "Change the working directory to DIRECTORY", 0, ""},
+    {"changes", 2, ToggleChanges, "on|off", "Show number of rows changed by SQL", 3, ""},
+    {"columns", 1, SetColumnRendering, "", "Column-wise rendering of query results", 0, ""},
 #ifdef HAVE_LINENOISE
     {"comment", 2, SetHighlightingColor<DeprecatedHighlightColors::COMMENT>, "?COLOR?",
-     "DEPRECATED: Sets the syntax highlighting color used for comment values", 0},
+     "DEPRECATED: Sets the syntax highlighting color used for comment values", 0, nullptr},
     {"commentcode", 2, SetHighlightingColor<DeprecatedHighlightColors::COMMENT_CODE>, "?CODE?",
-     "DEPRECATED: Sets the syntax highlighting terminal code used for comment values", 0},
+     "DEPRECATED: Sets the syntax highlighting terminal code used for comment values", 0, nullptr},
     {"constant", 2, SetHighlightingColor<DeprecatedHighlightColors::CONSTANT>, "?COLOR?",
-     "DEPRECATED: Sets the syntax highlighting color used for constant values", 0},
+     "DEPRECATED: Sets the syntax highlighting color used for constant values", 0, nullptr},
     {"constantcode", 2, SetHighlightingColor<DeprecatedHighlightColors::CONSTANT_CODE>, "?CODE?",
-     "DEPRECATED: Sets the syntax highlighting terminal code used for constant values", 0},
+     "DEPRECATED: Sets the syntax highlighting terminal code used for constant values", 0, nullptr},
     {"cont", 2, SetHighlightingColor<DeprecatedHighlightColors::CONT>, "?COLOR?",
-     "DEPRECATED: Sets the syntax highlighting color used for continuation markers", 0},
+     "DEPRECATED: Sets the syntax highlighting color used for continuation markers", 0, nullptr},
     {"contcode", 2, SetHighlightingColor<DeprecatedHighlightColors::CONT_CODE>, "?CODE?",
-     "DEPRECATED: Sets the syntax highlighting terminal code used for continuation markers", 0},
+     "DEPRECATED: Sets the syntax highlighting terminal code used for continuation markers", 0, nullptr},
     {"cont_sel", 2, SetHighlightingColor<DeprecatedHighlightColors::CONT_SEL>, "?COLOR?",
-     "DEPRECATED: Sets the syntax highlighting color used for continuation markers", 0},
+     "DEPRECATED: Sets the syntax highlighting color used for continuation markers", 0, nullptr},
     {"cont_selcode", 2, SetHighlightingColor<DeprecatedHighlightColors::CONT_SEL_CODE>, "?CODE?",
-     "DEPRECATED: Sets the syntax highlighting terminal code used for continuation markers", 0},
+     "DEPRECATED: Sets the syntax highlighting terminal code used for continuation markers", 0, nullptr},
 #endif
     {"decimal_sep", 0, SetDecimalSep, "SEP",
-     "Sets the decimal separator used when rendering numbers. Only for duckbox mode.", 3},
-    {"databases", 1, ShowDatabases, "", "List names and files of attached databases", 2},
-    {"dump", 0, DumpTable, "?TABLE?",
-     "Render database content as SQL\n   Options:\n     --newlines             Allow unescaped newline characters in "
-     "output\n   TABLE is a LIKE pattern for the tables to dump\n   Additional LIKE patterns can be given in "
-     "subsequent arguments",
-     0},
-    {"echo", 2, ToggleEcho, "on|off", "Turn command echo on or off", 3},
+     "Sets the decimal separator used when rendering numbers. Only for duckbox mode.", 3, ""},
+    {"databases", 1, ShowDatabases, "", "List names and files of attached databases", 2, ""},
+    {
+        "dump",
+        0,
+        DumpTable,
+        "?TABLE?",
+        "Render database content as SQL",
+        0,
+        "Options:\n\t--newlines\tAllow unescaped newline characters in output\nTABLE is a LIKE pattern for the tables "
+        "to dump\nAdditional LIKE patterns can be given in subsequent arguments",
+    },
+    {"echo", 2, ToggleEcho, "on|off", "Turn command echo on or off", 3, ""},
+    {"edit", 0, nullptr, "", "Opens an external text editor to edit a query.", 0,
+     "Notes:\n\t*  The editor is read from the environment variables\n\tDUCKDB_EDITOR, EDITOR, VISUAL in-order\n\t* If "
+     "none of these are set, the default editor is vi\n* \\e can be used as an alias for .edit"},
 #ifdef HAVE_LINENOISE
     {"error", 2, SetHighlightingColor<DeprecatedHighlightColors::ERROR>, "?COLOR?",
-     "DEPRECATED: Sets the syntax highlighting color used for errors", 0},
+     "DEPRECATED: Sets the syntax highlighting color used for errors", 0, nullptr},
     {"errorcode", 2, SetHighlightingColor<DeprecatedHighlightColors::ERROR_CODE>, "?CODE?",
-     "DEPRECATED: Sets the syntax highlighting terminal code used for errors", 0},
+     "DEPRECATED: Sets the syntax highlighting terminal code used for errors", 0, nullptr},
 #endif
-    {"excel", 0, SetOutputExcel, "", "Display the output of next command in spreadsheet", 0},
-    {"exit", 0, ExitProcess, "?CODE?", "Exit this program with return-code CODE", 0},
-    {"fullschema", 0, nullptr, "", "", 0},
-    {"headers", 2, ToggleHeaders, "on|off", "Turn display of headers on or off", 0},
-    {"help", 0, ShowHelp, "?-all? ?PATTERN?", "Show help text for PATTERN", 0},
+    {"excel", 0, SetOutputExcel, "", "Display the output of next command in spreadsheet", 0,
+     "--bom\tPut a UTF8 byte-order mark on intermediate file"},
+    {"exit", 0, ExitProcess, "?CODE?", "Exit this program with return-code CODE", 0, ""},
+    {"fullschema", 0, nullptr, "", "", 0, ""},
+    {"headers", 2, ToggleHeaders, "on|off", "Turn display of headers on or off", 0, ""},
+    {"help", 0, ShowHelp, "?-all? ?PATTERN?", "Show help text for PATTERN", 0, ""},
 #ifdef HAVE_LINENOISE
-    {"highlight", 2, ToggleHighlighting, "on|off", "Toggle syntax highlighting in the shell on/off", 0},
+    {"highlight", 2, ToggleHighlighting, "on|off", "Toggle syntax highlighting in the shell on/off", 0, ""},
 #endif
-    {"highlight_colors", 0, SetHighlightColors, "[element] [color] ([bold])?", "Configure highlighting colors", 0},
-    {"highlight_errors", 2, ToggleHighlighErrors, "on|off", "Turn highlighting of errors on or off", 0},
-    {"highlight_results", 2, ToggleHighlightResult, "on|off", "Turn highlighting of results on or off", 0},
-    {"import", 0, ImportData, "FILE TABLE", "Import data from FILE into TABLE", 0},
-
-    {"indexes", 0, ShowIndexes, "?TABLE?", "Show names of indexes", 0},
+    {"highlight_colors", 0, SetHighlightColors, "[element] [color] ([bold])?", "Configure highlighting colors", 0, ""},
+    {"highlight_errors", 2, ToggleHighlighErrors, "on|off", "Turn highlighting of errors on or off", 0, ""},
+    {"highlight_results", 2, ToggleHighlightResult, "on|off", "Turn highlighting of results on or off", 0, ""},
+    {"import", 0, ImportData, "FILE TABLE", "Import data from FILE into TABLE", 0,
+     "Options:\n\t--ascii\tUse \\037 and \\036 as column and row separators\n\t--csv\tUse , and \\n as column and row "
+     "separators\n\t--skip N\tSkip the first N rows of input\n\t-v\t\"Verbose\" - increase auxiliary "
+     "output\nNotes:\n\t*  If TABLE does not exist, it is created.  The first row of input\n\tdetermines the column "
+     "names.\n\t*  If neither --csv or --ascii are used, the input mode is derived\n\tfrom the \".mode\" output "
+     "mode\n\t*  If FILE begins with \"|\" then it is a command that generates the\n\tinput text."},
+    {"indexes", 0, ShowIndexes, "?TABLE?", "Show names of indexes", 0,
+     "Notes:\n\t* If TABLE is specified, only show indexes for\n\ttables matching TABLE using the LIKE operator."},
     {"indices", 0, ShowIndexes, "?TABLE?", "Show names of indexes", 0},
 #ifdef HAVE_LINENOISE
     {"keyword", 2, SetHighlightingColor<DeprecatedHighlightColors::KEYWORD>, "?COLOR?",
-     "DEPRECATED: Sets the syntax highlighting color used for keywords", 0},
+     "DEPRECATED: Sets the syntax highlighting color used for keywords", 0, nullptr},
     {"keywordcode", 2, SetHighlightingColor<DeprecatedHighlightColors::KEYWORD_CODE>, "?CODE?",
-     "DEPRECATED: Sets the syntax highlighting terminal code used for keywords", 0},
+     "DEPRECATED: Sets the syntax highlighting terminal code used for keywords", 0, nullptr},
 #endif
     {"large_number_rendering", 2, SetLargeNumberRendering, "all|footer|off",
-     "Toggle readable rendering of large numbers (duckbox only)", 0},
-    {"log", 2, ToggleLog, "FILE|off", "Turn logging on or off.  FILE can be stderr/stdout", 0},
+     "Toggle readable rendering of large numbers (duckbox only)", 0, ""},
+    {"log", 2, ToggleLog, "FILE|off", "Turn logging on or off.  FILE can be stderr/stdout", 0, ""},
     {"maxrows", 0, SetMaxRows, "COUNT",
-     "Sets the maximum number of rows for display (default: 40). Only for duckbox mode.", 0},
+     "Sets the maximum number of rows for display (default: 40). Only for duckbox mode.", 0, ""},
     {"maxwidth", 0, SetMaxWidth, "COUNT",
-     "Sets the maximum width in characters. 0 defaults to terminal width. Only for duckbox mode.", 0},
-    {"mode", 0, SetOutputMode, "MODE ?TABLE?", "Set output mode", 0},
+     "Sets the maximum width in characters. 0 defaults to terminal width. Only for duckbox mode.", 0, ""},
+    {"mode", 0, SetOutputMode, "MODE ?TABLE?", "Set output mode", 0,
+     "MODE is one of:\n\tascii\tColumns/rows delimited by 0x1F and 0x1E\n\t* box\tTables using unicode box-drawing "
+     "characters\n\t* csv\tComma-separated values\n\t* column\tOutput in columns.\t(See .width)\n\t* duckbox\tTables "
+     "with extensive features\n\t* html\tHTML <table> code\n\t* insert\tSQL insert statements for TABLE\n\t* "
+     "json\tResults in a JSON array\n\t* jsonlines Results in a NDJSON\n\t* latex\tLaTeX tabular environment code\n\t* "
+     "line\tOne value per line\n\t* list\tValues delimited by \"|\"\n\t* markdown\tMarkdown table format\n\t* "
+     "quote\tEscape answers as for SQL\n\t* table\tASCII-art table\n\t* tabs\tTab-separated values\n\t* tcl\tTCL list "
+     "elements\n\t* trash\tNo output"},
 #ifdef HAVE_LINENOISE
-    {"multiline", 1, ToggleMultiLine, "", "Sets the render mode to multi-line", 0},
+    {"multiline", 1, ToggleMultiLine, "", "Sets the render mode to multi-line", 0, ""},
 #endif
-    {"nullvalue", 2, SetNullValue, "STRING", "Use STRING in place of NULL values", 0},
+    {"nullvalue", 2, SetNullValue, "STRING", "Use STRING in place of NULL values", 0, ""},
 
-    {"open", 0, OpenDatabase, "?OPTIONS? ?FILE?", "Close existing database and reopen FILE", 2},
-    {"once", 0, SetOutputOnce, "?FILE?", "Output for the next SQL command only to FILE", 0},
-    {"output", 0, SetOutput, "?FILE?", "Send output to FILE or stdout if FILE is omitted", 0},
-    {"print", 0, PrintArguments, "STRING...", "Print literal STRING", 3},
-    {"prompt", 0, SetPrompt, "MAIN CONTINUE", "Replace the standard prompts", 0},
+    {"open", 0, OpenDatabase, "?OPTIONS? ?FILE?", "Close existing database and reopen FILE", 2,
+     "Options:\n\t--new\tInitialize FILE to an empty database\n\t--nofollow\tDo not follow symbolic "
+     "links\n\t--readonly\tOpen FILE in read-only mode"},
+    {"once", 0, SetOutputOnce, "?FILE?", "Output for the next SQL command only to FILE", 0,
+     "If FILE begins with '|' then open as a pipe\n\t--bom\tPut a UTF8 byte-order mark at the beginning\n\t-e\tSend "
+     "output to the system text editor\n\t-x\tSend output as CSV to a spreadsheet (same as \".excel\")"},
+    {"output", 0, SetOutput, "?FILE?", "Send output to FILE or stdout if FILE is omitted", 0,
+     "If FILE begins with '|' then open as a pipe\n\t--bom\tPut a UTF8 byte-order mark at the beginning\n\t-e\tSend "
+     "output to the system text editor\n\t-x\tSend output as CSV to a spreadsheet (same as \".excel\")"},
+    {"print", 0, PrintArguments, "STRING...", "Print literal STRING", 3, ""},
+    {"prompt", 0, SetPrompt, "MAIN CONTINUE", "Replace the standard prompts", 0, ""},
 
-    {"quit", 0, QuitProcess, "", "Exit this program", 0},
-    {"read", 2, ReadFromFile, "FILE", "Read input from FILE", 3},
+    {"quit", 0, QuitProcess, "", "Exit this program", 0, ""},
+    {"read", 2, ReadFromFile, "FILE", "Read input from FILE", 3, ""},
 #ifdef HAVE_LINENOISE
     {"render_color", 3, SetRenderHighlightColor, "?COMP? ?COLOR?",
-     "Configure highlighting colors for the interactive prompt", 0},
+     "Configure highlighting colors for the interactive prompt", 0, ""},
     {"render_completion", 2, ToggleCompletionRendering, "on|off",
-     "Toggle displaying of completion prompts in the shell on/off", 0},
-    {"render_errors", 2, ToggleErrorRendering, "on|off", "Toggle rendering of errors in the shell on/off", 0},
+     "Toggle displaying of completion prompts in the shell on/off", 0, ""},
+    {"render_errors", 2, ToggleErrorRendering, "on|off", "Toggle rendering of errors in the shell on/off", 0, ""},
 #endif
-    {"rows", 1, SetRowRendering, "", "Row-wise rendering of query results (default)", 0},
-    {"restore", 0, nullptr, "", "", 3},
-    {"save", 0, nullptr, "?DB? FILE", "Backup DB (default \"main\") to FILE", 3},
-    {"safe_mode", 0, EnableSafeMode, "", "enable safe-mode", 0},
-    {"separator", 0, SetSeparator, "COL ?ROW?", "Change the column and row separators", 0},
-    {"schema", 0, DisplaySchemas, "?PATTERN?", "Show the CREATE statements matching PATTERN", 0},
-    {"shell", 0, RunShellCommand, "CMD ARGS...", "Run CMD ARGS... in a system shell", 0},
-    {"show", 1, ShowConfiguration, "", "Show the current values for various settings", 0},
+    {"rows", 1, SetRowRendering, "", "Row-wise rendering of query results (default)", 0, ""},
+    {"restore", 0, nullptr, "", "", 3, ""},
+    {"save", 0, nullptr, "?DB? FILE", "Backup DB (default \"main\") to FILE", 3, ""},
+    {"safe_mode", 0, EnableSafeMode, "", "enable safe-mode", 0, ""},
+    {"separator", 0, SetSeparator, "COL ?ROW?", "Change the column and row separators", 0, ""},
+    {"schema", 0, DisplaySchemas, "?PATTERN?", "Show the CREATE statements matching PATTERN", 0,
+     "Options:\n\t--indent\tTry to pretty-print the schema"},
+    {"shell", 0, RunShellCommand, "CMD ARGS...", "Run CMD ARGS... in a system shell", 0, ""},
+    {"show", 1, ShowConfiguration, "", "Show the current values for various settings", 0, ""},
 #ifdef HAVE_LINENOISE
-    {"singleline", 1, ToggleSingleLine, "", "Sets the render mode to single-line", 0},
+    {"singleline", 1, ToggleSingleLine, "", "Sets the render mode to single-line", 0, ""},
 #endif
-    {"system", 0, RunShellCommand, "CMD ARGS...", "Run CMD ARGS... in a system shell", 0},
-    {"tables", 0, ShowTables, "?TABLE?", "List names of tables matching LIKE pattern TABLE", 2},
+    {"system", 0, RunShellCommand, "CMD ARGS...", "Run CMD ARGS... in a system shell", 0, ""},
+    {"tables", 0, ShowTables, "?TABLE?", "List names of tables matching LIKE pattern TABLE", 2, ""},
     {"thousand_sep", 0, SetThousandSep, "SEP",
-     "Sets the thousand separator used when rendering numbers. Only for duckbox mode.", 4},
-    {"timeout", 0, nullptr, "", "", 5},
-    {"timer", 2, ToggleTimer, "on|off", "Turn SQL timer on or off", 0},
-    {"ui_command", 0, SetUICommand, "[command]", "Set the UI command", 0},
-    {"version", 1, ShowVersion, "", "Show the version", 0},
-    {"width", 0, SetWidths, "NUM1 NUM2 ...", "Set minimum column widths for columnar output", 0},
+     "Sets the thousand separator used when rendering numbers. Only for duckbox mode.", 4, ""},
+    {"timeout", 0, nullptr, "", "", 5, ""},
+    {"timer", 2, ToggleTimer, "on|off", "Turn SQL timer on or off", 0, ""},
+    {"ui_command", 0, SetUICommand, "[command]", "Set the UI command", 0, ""},
+    {"version", 1, ShowVersion, "", "Show the version", 0, ""},
+    {"width", 0, SetWidths, "NUM1 NUM2 ...", "Set minimum column widths for columnar output", 0,
+     "Negative values right-justify"},
 #if defined(_WIN32) || defined(WIN32)
-    {"utf8", 1, SetUTF8Mode, "", "Enable experimental UTF-8 console output mode", 0},
+    {"utf8", 1, SetUTF8Mode, "", "Enable experimental UTF-8 console output mode", 0, ""},
 #endif
-
-    {nullptr, 0, nullptr}};
+    {nullptr, 0, nullptr, 0, nullptr}};
 
 /*
 ** If an input line begins with "." then invoke this routine to

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3501,7 +3501,6 @@ MetadataResult SetHighlightingColor(ShellState &state, const vector<string> &arg
 #endif
 
 static const MetadataCommand metadata_commands[] = {
-    {"backup", 0, nullptr, "?DB? FILE", "Backup DB (default \"main\") to FILE", 3, ""},
     {"bail", 2, ToggleBail, "on|off", "Stop after hitting an error.  Default OFF", 3, ""},
     {"binary", 2, ToggleBinary, "on|off", "Turn binary output on or off.  Default OFF", 3, ""},
     {"cd", 2, ChangeDirectory, "DIRECTORY", "Change the working directory to DIRECTORY", 0, ""},
@@ -3617,7 +3616,6 @@ static const MetadataCommand metadata_commands[] = {
     {"render_errors", 2, ToggleErrorRendering, "on|off", "Toggle rendering of errors in the shell on/off", 0, ""},
 #endif
     {"rows", 1, SetRowRendering, "", "Row-wise rendering of query results (default)", 0, ""},
-    {"save", 0, nullptr, "?DB? FILE", "Backup DB (default \"main\") to FILE", 3, ""},
     {"safe_mode", 0, EnableSafeMode, "", "enable safe-mode", 0, ""},
     {"separator", 0, SetSeparator, "COL ?ROW?", "Change the column and row separators", 0, ""},
     {"schema", 0, DisplaySchemas, "?PATTERN?", "Show the CREATE statements matching PATTERN", 0,

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -97,11 +97,6 @@ def test_invalid_cast(shell):
     result = test.run()
     result.check_stderr("Could not convert")
 
-def test_invalid_backup(shell, random_filepath):
-    test = ShellTest(shell).statement(f'.backup {random_filepath.as_posix()}')
-    result = test.run()
-    result.check_stderr("unsupported in the current version of the CLI")
-
 def test_newline_in_value(shell):
     test = (
         ShellTest(shell)
@@ -335,31 +330,6 @@ def test_show_basic(shell):
     )
     result = test.run()
     result.check_stdout("rowseparator")
-
-def test_timeout(shell):
-    test = (
-        ShellTest(shell)
-        .statement(".timeout")
-    )
-    result = test.run()
-    result.check_stderr("unsupported in the current version of the CLI")
-
-
-def test_save(shell, random_filepath):
-    test = (
-        ShellTest(shell)
-        .statement(f".save {random_filepath.as_posix()}")
-    )
-    result = test.run()
-    result.check_stderr("unsupported in the current version of the CLI")
-
-def test_restore(shell, random_filepath):
-    test = (
-        ShellTest(shell)
-        .statement(f".restore {random_filepath.as_posix()}")
-    )
-    result = test.run()
-    result.check_stderr("unsupported in the current version of the CLI")
 
 @pytest.mark.parametrize("cmd", [
     ".vfsinfo",


### PR DESCRIPTION
This has a number of advantages:

* We no longer need to both add the command and document it separately
* We can automatically infer alignment for printing, no need to manually do this

Example highlighting:

<img width="1044" height="448" alt="Screenshot 2025-10-29 at 14 31 00" src="https://github.com/user-attachments/assets/8ed6a164-35bb-479f-9183-640bfa46e71d" />
