### PR TITLE
[Dev] Disable the use of `ZSTD` if the block_manager is the `InMemoryBlockManager`

### DIFF
--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -142,6 +142,11 @@ public:
 unique_ptr<AnalyzeState> ZSTDStorage::StringInitAnalyze(ColumnData &col_data, PhysicalType type) {
 	// check if the storage version we are writing to supports sztd
 	auto &storage = col_data.GetStorageManager();
+	auto &block_manager = col_data.GetBlockManager();
+	if (block_manager.InMemory()) {
+		//! Can't use ZSTD in in-memory environment
+		return nullptr;
+	}
 	if (storage.GetStorageVersion() < 4) {
 		// compatibility mode with old versions - disable zstd
 		return nullptr;

--- a/test/sql/storage/memory/in_memory_disabled_zstd.test
+++ b/test/sql/storage/memory/in_memory_disabled_zstd.test
@@ -1,0 +1,28 @@
+# name: test/sql/storage/memory/in_memory_disabled_zstd.test
+# group: [memory]
+
+statement ok
+attach ':memory:' as db2 (compress);
+
+statement ok
+use db2;
+
+statement ok
+pragma force_compression='zstd';
+
+statement ok
+create table tbl as
+select
+    i // 5_000 as num,
+    num::varchar || list_reduce([uuid()::varchar for x in range(10)], lambda x, y: concat(x, y)) str
+from range(20_000) t(i) order by num;
+
+# Because we're running in In-Memory mode, we have explicitly disabled ZSTD
+# Since the InMemoryBlockManager doesn't support the methods required by ZSTD
+statement ok
+force checkpoint;
+
+query I
+select distinct compression = 'Uncompressed' from pragma_storage_info('tbl') where segment_type = 'VARCHAR'
+----
+true


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/6319

This has to be done because the InMemoryBlockManager doesnt support GetFreeBlockId, which is required by the zstd compression method.

I couldn't produce a test for this because I can't reproduce the problem in the unittester, only in the CLI
(I assume the storage version prevents in-memory compression???)