### PR TITLE
CLI: Refactor command-line parameters into a struct similar to MetadataCommands, and add better errors + syntax highlighting

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -22,9 +22,9 @@ enum class MetadataResult : uint8_t;
 
 namespace duckdb_shell {
 using duckdb::make_uniq;
+using duckdb::string;
 using duckdb::unique_ptr;
-using std::string;
-using std::vector;
+using duckdb::vector;
 struct ColumnarResult;
 struct RowResult;
 class ColumnRenderer;

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -217,6 +217,7 @@ public:
 	static bool StringGlob(const char *zGlobPattern, const char *zString);
 	static bool StringLike(const char *zPattern, const char *zStr, unsigned int esc);
 	static void Sleep(idx_t ms);
+	void PrintUsage();
 #if defined(_WIN32) || defined(WIN32)
 	static unique_ptr<uint8_t[]> Win32Utf8ToUnicode(const char *zText);
 	static string Win32UnicodeToUtf8(void *zWideText);

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -124,6 +124,8 @@ public:
 	string ui_command = "CALL start_ui()";
 	idx_t last_changes = 0;
 	idx_t total_changes = 0;
+	bool readStdin = true;
+	string initFile;
 
 public:
 	void PushOutputMode();
@@ -174,7 +176,7 @@ public:
 	SuccessState RenderDuckBoxResult(duckdb::QueryResult &res);
 
 	void PrintDatabaseError(const string &zErr);
-	int RunInitialCommand(char *sql, bool bail);
+	int RunInitialCommand(const char *sql, bool bail);
 	void AddError();
 
 	int RenderRow(RowRenderer &renderer, RowResult &result);

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4391,15 +4391,15 @@ static void usage(int showDetail) {
 }
 
 struct CommandLineOption {
-    const char *option;
-    idx_t argument_count;
-    const char *arguments;
-    metadata_command_t pre_init_callback;
-    metadata_command_t post_init_callback;
-    const char *description;
+	const char *option;
+	idx_t argument_count;
+	const char *arguments;
+	metadata_command_t pre_init_callback;
+	metadata_command_t post_init_callback;
+	const char *description;
 };
 
-template<RenderMode output_mode>
+template <RenderMode output_mode>
 MetadataResult ToggleOutputMode(ShellState &state, const vector<string> &args) {
 	state.cMode = state.mode = output_mode;
 	return MetadataResult::SUCCESS;
@@ -4438,7 +4438,7 @@ MetadataResult SetReadOnlyMode(ShellState &state, const vector<string> &args) {
 	return MetadataResult::SUCCESS;
 }
 
-template<bool HEADER>
+template <bool HEADER>
 MetadataResult ToggleHeader(ShellState &state, const vector<string> &args) {
 	state.showHeader = HEADER;
 	return MetadataResult::SUCCESS;
@@ -4466,7 +4466,7 @@ MetadataResult AllowUnsigned(ShellState &state, const vector<string> &args) {
 
 MetadataResult ShowVersionAndExit(ShellState &state, const vector<string> &args) {
 	printf("%s (%s) %s\n", duckdb::DuckDB::LibraryVersion(), duckdb::DuckDB::ReleaseCodename(),
-		   duckdb::DuckDB::SourceID());
+	       duckdb::DuckDB::SourceID());
 	return MetadataResult::EXIT;
 }
 
@@ -4494,14 +4494,11 @@ MetadataResult SetNewlineSeparator(ShellState &state, const vector<string> &args
 MetadataResult SetStorageVersion(ShellState &state, const vector<string> &args) {
 	auto &storage_version = args[1];
 	try {
-		state.config.options.serialization_compatibility =
-			duckdb::SerializationCompatibility::FromString("latest");
-	} catch(std::exception &ex) {
+		state.config.options.serialization_compatibility = duckdb::SerializationCompatibility::FromString("latest");
+	} catch (std::exception &ex) {
 		duckdb::ErrorData error(ex);
-		utf8_printf(
-			stderr,
-			"%s: Error: unknown argument (%s) for '-storage-version': %s\n",
-			program_name, storage_version.c_str(), error.Message().c_str());
+		utf8_printf(stderr, "%s: Error: unknown argument (%s) for '-storage-version': %s\n", program_name,
+		            storage_version.c_str(), error.Message().c_str());
 		return MetadataResult::EXIT;
 	}
 	return MetadataResult::SUCCESS;
@@ -4520,13 +4517,12 @@ MetadataResult ProcessFile(ShellState &state, const vector<string> &args) {
 	return MetadataResult::SUCCESS;
 }
 
-
 MetadataResult SetInitFile(ShellState &state, const vector<string> &args) {
 	state.initFile = args[1];
 	return MetadataResult::SUCCESS;
 }
 
-template<bool EXIT>
+template <bool EXIT>
 MetadataResult RunCommand(ShellState &state, const vector<string> &args) {
 	if (EXIT) {
 		state.readStdin = false;
@@ -4571,14 +4567,14 @@ static const CommandLineOption command_line_options[] = {
     {"s", 1, "COMMAND", EnableBatch, RunCommand<true>, "run \"COMMAND\" before reading stdin"},
     {"safe", 0, "", EnableSafeMode, nullptr, "enable safe-mode"},
     {"separator", 1, "SEP", nullptr, SetSeparator, "set output column separator. Default: '|'"},
-    {"storage-version", 1, "VERSION", SetStorageVersion, nullptr, "database storage compatibility version to use. Default: 'v0.10.0'"},
+    {"storage-version", 1, "VERSION", SetStorageVersion, nullptr,
+     "database storage compatibility version to use. Default: 'v0.10.0'"},
     {"table", 0, "", nullptr, ToggleOutputMode<RenderMode::TABLE>, "set output mode to 'table'"},
     {"ui", 0, "", nullptr, LaunchUI, "launches a web interface using the ui extension (configurable with .ui_command)"},
     {"unredacted", 0, "", AllowUnredacted, nullptr, "allow printing unredacted secrets"},
     {"unsigned", 0, "", AllowUnsigned, nullptr, "allow loading of unsigned extensions"},
     {"version", 0, "", nullptr, ShowVersionAndExit, "show DuckDB version"},
     {nullptr, 0, nullptr, nullptr, nullptr, nullptr}};
-
 
 /*
 ** Initialize the state information in data

--- a/tools/shell/tests/test_command_line_arguments.py
+++ b/tools/shell/tests/test_command_line_arguments.py
@@ -1,0 +1,80 @@
+# fmt: off
+
+import pytest
+import subprocess
+import sys
+from typing import List
+from conftest import ShellTest
+import os
+from pathlib import Path
+
+def test_headers(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 42 as wilbur")
+        .add_argument("-csv", "-header")
+    )
+    result = test.run()
+    result.check_stdout("wilbur")
+
+def test_no_headers(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 42 as wilbur")
+        .add_argument("-csv", "-noheader")
+    )
+    result = test.run()
+    result.check_not_exist("wilbur")
+def test_storage_version_latest(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 42")
+        .add_argument("-storage_version", "latest")
+    )
+    result = test.run()
+    result.check_stdout("42")
+
+def test_command(shell):
+    test = (
+        ShellTest(shell)
+        .add_argument("-c", "SELECT 42")
+    )
+    result = test.run()
+    result.check_stdout("42")
+
+def test_version(shell):
+    test = (
+        ShellTest(shell)
+        .add_argument("-version")
+    )
+    result = test.run()
+    result.check_stdout("v")
+
+def test_csv_options(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 42 a, NULL b")
+        .add_argument("-csv", "-nullvalue", "MYNULL", "-separator", "MYSEP")
+    )
+    result = test.run()
+    result.check_stdout("42MYSEPMYNULL")
+
+def test_echo(shell):
+    test = (
+        ShellTest(shell, ['-echo'])
+        .statement("SELECT 42;")
+    )
+    result = test.run()
+    result.check_stdout("SELECT 42")
+
+def test_storage_version_error(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 42")
+        .add_argument("-storage-version", "XXX")
+    )
+    result = test.run()
+    result.check_stderr("XXX")
+
+
+# fmt: on

--- a/tools/shell/tests/test_highlighting.py
+++ b/tools/shell/tests/test_highlighting.py
@@ -44,7 +44,7 @@ def test_custom_highlight_error(shell):
     result.check_stderr("Unknown element 'column_nameXX'")
     result.check_stderr("Unknown color 'redXX'")
     result.check_stderr("Unknown intensity 'boldXX'")
-    result.check_stderr("Usage: .highlight_colors")
+    result.check_stderr("Usage")
 
 @pytest.mark.skipif(os.name == 'nt', reason="Linenoise not supported on Windows")
 def test_linenoise_highlighting(shell):
@@ -58,6 +58,6 @@ def test_linenoise_highlighting(shell):
     result = test.run()
     result.check_stderr("Unknown component 'XX'")
     result.check_stderr("Unknown highlighting color 'redXX'")
-    result.check_stderr("Usage: .render_color")
+    result.check_stderr("Usage")
 
 # fmt: on

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -492,7 +492,7 @@ def test_clone_error(shell):
         .statement(".clone")
     )
     result = test.run()
-    result.check_stderr('Error: unknown command or invalid arguments:  "clone". Enter ".help" for help')
+    result.check_stderr('Unrecognized command')
 
 def test_sha3sum(shell):
     test = (
@@ -863,17 +863,6 @@ def test_eqp(shell):
     result = test.run()
     result.check_stdout('DUMMY_SCAN')
 
-def test_clone(shell, random_filepath):
-    test = (
-        ShellTest(shell)
-        .statement("CREATE TABLE a (I INTEGER)")
-        .statement("INSERT INTO a VALUES (42)")
-        .statement(f".clone {random_filepath.as_posix()}")
-    )
-    result = test.run()
-    result.check_stderr('unknown command or invalid arguments')
-
-
 def test_databases(shell):
     test = (
         ShellTest(shell)
@@ -1101,12 +1090,12 @@ def test_tables_invalid_pattern_handling(shell):
     )
     result = test.run()
     # Should show usage message for invalid pattern
-    result.check_stderr("Usage: .tables ?TABLE?")
+    result.check_stderr("Usage")
 
 def test_help_prints_to_stdout(shell):
     test = ShellTest(shell, ["--help"])
     result = test.run()
-    result.check_stdout("OPTIONS include:")
+    result.check_stdout("OPTIONS")
 
 
 # fmt: on

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -194,6 +194,7 @@ def test_print(shell):
 def test_headers(shell):
     test = (
         ShellTest(shell)
+        .statement(".mode csv")
         .statement(".headers on")
         .statement("SELECT 42 as wilbur")
     )
@@ -578,28 +579,43 @@ def test_log(shell, random_filepath):
     result = test.run()
     result.check_stdout('')
 
-def test_mode_ascii(shell):
+@pytest.mark.parametrize("dot_command", [
+    ".mode ascii",
+    ""
+])
+def test_mode_ascii(shell, dot_command):
+    args = ['-ascii'] if len(dot_command) == 0 else []
     test = (
-        ShellTest(shell)
-        .statement(".mode ascii")
+        ShellTest(shell, args)
+        .statement(dot_command)
         .statement("SELECT NULL, 42, 'fourty-two', 42.0;")
     )
     result = test.run()
     result.check_stdout('fourty-two')
 
-def test_mode_csv(shell):
+@pytest.mark.parametrize("dot_command", [
+    ".mode csv",
+    ""
+])
+def test_mode_csv(shell, dot_command):
+    args = ['-csv'] if len(dot_command) == 0 else []
     test = (
-        ShellTest(shell)
-        .statement(".mode csv")
+        ShellTest(shell, args)
+        .statement(dot_command)
         .statement("SELECT NULL, 42, 'fourty-two', 42.0;")
     )
     result = test.run()
     result.check_stdout(',fourty-two,')
 
-def test_mode_column(shell):
+@pytest.mark.parametrize("dot_command", [
+    ".mode column",
+    ""
+])
+def test_mode_column(shell, dot_command):
+    args = ['-column'] if len(dot_command) == 0 else []
     test = (
-        ShellTest(shell)
-        .statement(".mode column")
+        ShellTest(shell, args)
+        .statement(dot_command)
         .statement("SELECT NULL, 42, 'fourty-two', 42.0;")
     )
     result = test.run()
@@ -614,10 +630,15 @@ def test_mode_html(shell):
     result = test.run()
     result.check_stdout('<td>fourty-two</td>')
 
-def test_mode_html_escapes(shell):
+@pytest.mark.parametrize("dot_command", [
+    ".mode html",
+    ""
+])
+def test_mode_html_escapes(shell, dot_command):
+    args = ['-html'] if len(dot_command) == 0 else []
     test = (
-        ShellTest(shell)
-        .statement(".mode html")
+        ShellTest(shell, args)
+        .statement(dot_command)
         .statement("SELECT '<&>\"\'\'' AS \"&><\"\"\'\";")
     )
     result = test.run()
@@ -641,10 +662,16 @@ def test_mode_csv_escapes(shell):
     result = test.run()
     result.check_stdout('"BEGINHEADER"",\nENDHEADER"\r\n"BEGINVAL,\n""ENDVAL"')
 
-def test_mode_json_infinity(shell):
+
+@pytest.mark.parametrize("dot_command", [
+    ".mode json",
+    ""
+])
+def test_mode_json_infinity(shell, dot_command):
+    args = ['-json'] if len(dot_command) == 0 else []
     test = (
-        ShellTest(shell)
-        .statement(".mode json")
+        ShellTest(shell, args)
+        .statement(dot_command)
         .statement("SELECT 'inf'::DOUBLE AS inf, '-inf'::DOUBLE AS ninf, 'nan'::DOUBLE AS nan, '-nan'::DOUBLE AS nnan;")
     )
     result = test.run()
@@ -674,29 +701,45 @@ def test_mode_insert_table(shell):
     result = test.run()
     result.check_stdout('my_table')
 
-def test_mode_line(shell):
+@pytest.mark.parametrize("dot_command", [
+    ".mode line",
+    ""
+])
+def test_mode_line(shell, dot_command):
+    args = ['-line'] if len(dot_command) == 0 else []
     test = (
-        ShellTest(shell)
-        .statement(".mode line")
+        ShellTest(shell, args)
+        .statement(dot_command)
         .statement("SELECT NULL, 42, 'fourty-two' x, 42.0;")
     )
     result = test.run()
     result.check_stdout('x = fourty-two')
 
-def test_mode_list(shell):
+@pytest.mark.parametrize("dot_command", [
+    ".mode list",
+    ""
+])
+def test_mode_list(shell, dot_command):
+    args = ['-list'] if len(dot_command) == 0 else []
     test = (
-        ShellTest(shell)
-        .statement(".mode list")
+        ShellTest(shell, args)
+        .statement(dot_command)
         .statement("SELECT NULL, 42, 'fourty-two' x, 42.0;")
     )
     result = test.run()
     result.check_stdout('|fourty-two|')
 
 # Original comment: FIXME sqlite3_column_blob and %! format specifier
-def test_mode_quote(shell):
+
+@pytest.mark.parametrize("dot_command", [
+    ".mode quote",
+    ""
+])
+def test_mode_quote(shell, dot_command):
+    args = ['-quote'] if len(dot_command) == 0 else []
     test = (
-        ShellTest(shell)
-        .statement(".mode quote")
+        ShellTest(shell, args)
+        .statement(dot_command)
         .statement("SELECT NULL, 42, 'fourty-two' x, 42.0;")
     )
     result = test.run()

--- a/tools/shell/tests/test_shell_rendering.py
+++ b/tools/shell/tests/test_shell_rendering.py
@@ -9,10 +9,15 @@ import os
 from pathlib import Path
 
 
-def test_left_align(shell):
+@pytest.mark.parametrize("dot_command", [
+    ".mode box",
+    ""
+])
+def test_left_align(shell, dot_command):
+    args = ['-box'] if len(dot_command) == 0 else []
     test = (
-        ShellTest(shell)
-        .statement(".mode box")
+        ShellTest(shell, args)
+        .statement(dot_command)
         .statement(".width 5")
         .statement(f'select 100 AS r')
     )
@@ -31,10 +36,15 @@ def test_right_align(shell):
     result = test.run()
     result.check_stdout("│   100 │")
 
-def test_markdown(shell):
+@pytest.mark.parametrize("dot_command", [
+    ".mode markdown",
+    ""
+])
+def test_markdown(shell, dot_command):
+    args = ['-markdown'] if len(dot_command) == 0 else []
     test = (
-        ShellTest(shell)
-        .statement(".mode markdown")
+        ShellTest(shell, args)
+        .statement(dot_command)
         .statement("select 42 a, 'hello' str")
     )
 


### PR DESCRIPTION
Similar to https://github.com/duckdb/duckdb/pull/14503 but for command line parameters:

```cpp

struct CommandLineOption {
	const char *option;
	idx_t argument_count;
	const char *arguments;
	metadata_command_t pre_init_callback;
	metadata_command_t post_init_callback;
	const char *description;
};

static const CommandLineOption command_line_options[] = {
    {"ascii", 0, "", nullptr, ToggleASCIIMode, "set output mode to 'ascii'"},
    {"bail", 0, "", nullptr, EnableBail, "stop after hitting an error'"},
    {"batch", 0, "", EnableBatch, EnableBatch, "force batch I/O'"},
    ...
```

This provides a more structured way of defining command line parameters, also enabling pretty printing and better error handling (e.g. suggesting different options when a typo is made).