### PR TITLE
Add Profiler output to logger interface

### DIFF
--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -20,6 +20,7 @@ class PhysicalOperator;
 class AttachedDatabase;
 class RowGroup;
 struct DataTableInfo;
+enum class MetricsType : uint8_t;
 
 //! Log types provide some structure to the formats that the different log messages can have
 //! For now, this holds a type that the VARCHAR value will be auto-cast into.
@@ -104,6 +105,19 @@ public:
 
 	static string ConstructLogMessage(const PhysicalOperator &op, const string &class_p, const string &event,
 	                                  const vector<pair<string, string>> &info);
+};
+
+class MetricsLogType : public LogType {
+public:
+	static constexpr const char *NAME = "Metrics";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_INFO;
+
+	//! Construct the log type
+	MetricsLogType();
+
+	static LogicalType GetLogType();
+
+	static string ConstructLogMessage(const MetricsType &type, const Value &value);
 };
 
 class CheckpointLogType : public LogType {

--- a/src/include/duckdb/main/profiling_info.hpp
+++ b/src/include/duckdb/main/profiling_info.hpp
@@ -53,6 +53,7 @@ public:
 
 public:
 	string GetMetricAsString(const MetricsType metric) const;
+	void WriteMetricsToLog(ClientContext &context);
 	void WriteMetricsToJSON(duckdb_yyjson::yyjson_mut_doc *doc, duckdb_yyjson::yyjson_mut_val *destination);
 
 public:

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -208,6 +208,7 @@ public:
 	static Value JSONSanitize(const Value &input);
 	static string JSONSanitize(const string &text);
 	static string DrawPadded(const string &str, idx_t width);
+	DUCKDB_API void ToLog() const;
 	DUCKDB_API string ToJSON() const;
 	DUCKDB_API void WriteToFile(const char *path, string &info) const;
 

--- a/src/logging/log_manager.cpp
+++ b/src/logging/log_manager.cpp
@@ -266,6 +266,7 @@ void LogManager::RegisterDefaultLogTypes() {
 	RegisterLogType(make_uniq<HTTPLogType>());
 	RegisterLogType(make_uniq<QueryLogType>());
 	RegisterLogType(make_uniq<PhysicalOperatorLogType>());
+	RegisterLogType(make_uniq<MetricsLogType>());
 }
 
 } // namespace duckdb

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -14,6 +14,7 @@ constexpr LogLevel FileSystemLogType::LEVEL;
 constexpr LogLevel QueryLogType::LEVEL;
 constexpr LogLevel HTTPLogType::LEVEL;
 constexpr LogLevel PhysicalOperatorLogType::LEVEL;
+constexpr LogLevel MetricsLogType::LEVEL;
 constexpr LogLevel CheckpointLogType::LEVEL;
 
 //===--------------------------------------------------------------------===//
@@ -147,6 +148,29 @@ string PhysicalOperatorLogType::ConstructLogMessage(const PhysicalOperator &phys
 
 	return Value::STRUCT(std::move(child_list)).ToString();
 }
+
+//===--------------------------------------------------------------------===//
+// MetricsLogType
+//===--------------------------------------------------------------------===//
+MetricsLogType::MetricsLogType() : LogType(NAME, LEVEL, GetLogType()) {
+}
+
+LogicalType MetricsLogType::GetLogType() {
+	child_list_t<LogicalType> child_list = {
+	    {"metric", LogicalType::VARCHAR},
+	    {"value", LogicalType::VARCHAR},
+	};
+	return LogicalType::STRUCT(child_list);
+}
+
+string MetricsLogType::ConstructLogMessage(const MetricsType &metric, const Value &value) {
+	child_list_t<Value> child_list = {
+	    {"metric", EnumUtil::ToString(metric)},
+	    {"value", value.ToString()},
+	};
+	return Value::STRUCT(std::move(child_list)).ToString();
+}
+
 //===--------------------------------------------------------------------===//
 // CheckpointLogType
 //===--------------------------------------------------------------------===//

--- a/src/main/profiling_info.cpp
+++ b/src/main/profiling_info.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/main/query_profiler.hpp"
+#include "duckdb/logging/log_type.hpp"
 
 #include "yyjson.hpp"
 
@@ -179,6 +180,12 @@ string ProfilingInfo::GetMetricAsString(const MetricsType metric) const {
 		return EnumUtil::ToString(type);
 	}
 	return metrics.at(metric).ToString();
+}
+
+void ProfilingInfo::WriteMetricsToLog(ClientContext &context) {
+	for (auto &metric : settings) {
+		DUCKDB_LOG(context, MetricsLogType, metric, metrics[metric]);
+	}
 }
 
 void ProfilingInfo::WriteMetricsToJSON(yyjson_mut_doc *doc, yyjson_mut_val *dest) {

--- a/src/main/profiling_info.cpp
+++ b/src/main/profiling_info.cpp
@@ -183,8 +183,12 @@ string ProfilingInfo::GetMetricAsString(const MetricsType metric) const {
 }
 
 void ProfilingInfo::WriteMetricsToLog(ClientContext &context) {
-	for (auto &metric : settings) {
-		DUCKDB_LOG(context, MetricsLogType, metric, metrics[metric]);
+	auto &logger = Logger::Get(context);
+	if (logger.ShouldLog(MetricsLogType::NAME, MetricsLogType::LEVEL)) {
+		for (auto &metric : settings) {
+			logger.WriteLog(MetricsLogType::NAME, MetricsLogType::LEVEL,
+			                MetricsLogType::ConstructLogMessage(metric, metrics[metric]));
+		}
 	}
 }
 

--- a/src/main/profiling_info.cpp
+++ b/src/main/profiling_info.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/main/query_profiler.hpp"
-#include "duckdb/logging/log_type.hpp"
+#include "duckdb/logging/log_manager.hpp"
 
 #include "yyjson.hpp"
 

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -888,11 +888,9 @@ static string StringifyAndFree(ConvertedJSONHolder &json_holder, yyjson_mut_val 
 void QueryProfiler::ToLog() const {
 	lock_guard<std::mutex> guard(lock);
 
-	if (query_metrics.query.empty() && !root) {
-		// Empty
-	}
 	if (!root) {
-		// Error
+		// No root, not much to do
+		return;
 	}
 
 	auto &settings = root->GetProfilingInfo();

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -317,6 +317,9 @@ void QueryProfiler::EndQuery() {
 
 	guard.unlock();
 
+	// To log is inexpensive, whether to log or not depends on whether logging is active
+	ToLog();
+
 	if (emit_output) {
 		string tree = ToString();
 		auto save_location = GetSaveLocation();
@@ -880,6 +883,21 @@ static string StringifyAndFree(ConvertedJSONHolder &json_holder, yyjson_mut_val 
 	}
 	auto result = string(json_holder.stringified_json);
 	return result;
+}
+
+void QueryProfiler::ToLog() const {
+	lock_guard<std::mutex> guard(lock);
+
+	if (query_metrics.query.empty() && !root) {
+		// Empty
+	}
+	if (!root) {
+		// Error
+	}
+
+	auto &settings = root->GetProfilingInfo();
+
+	settings.WriteMetricsToLog(context);
 }
 
 string QueryProfiler::ToJSON() const {

--- a/test/sql/pragma/profiling/test_logging_interaction.test
+++ b/test/sql/pragma/profiling/test_logging_interaction.test
@@ -1,0 +1,37 @@
+# name: test/sql/pragma/profiling/test_logging_interaction.test
+# description: Test profiling all operator types.
+# group: [profiling]
+
+require skip_reload
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/profile_attach.json';
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+ATTACH '__TEST_DIR__/profiler_logger.db' AS my_db;
+
+statement ok
+USE my_db;
+
+statement ok
+call enable_logging();
+
+statement ok
+CREATE TABLE small AS FROM range(100);
+
+statement ok
+CREATE TABLE medium AS FROM range(10000);
+
+statement ok
+CREATE TABLE big AS FROM range(1000000);
+
+statement ok
+PRAGMA disable_profiling;
+
+query I
+SELECT count(*) FROM duckdb_logs() WHERE type == 'Metrics' AND message ILIKE '%CPU_TIME%';
+----
+3


### PR DESCRIPTION
Idea is: if both profiler and logger are enabled, then you can access root level profiler output also via logger.

This is on top / independent of the current choices for where to output the profiler (JSON / graphviz / query-tree / ...). While this might be somewhat wasteful, it's allow for an easier PR and leave un-opinionated what should the SQL interface be. Also given ToLog() call is inexpensive (in particular if the logger is disabled), and that it's unclear if logger alone can satisfy profiler necessities, I think going additive is the best path here.

Demo:
```sql
ATTACH 'my_db.db';
USE my_db;

---- enable profiling to json file
PRAGMA profiling_output = 'profiling_output.json';
PRAGMA enable_profiling = 'json';
---- enable logging (to in-memory table)
call enable_logging();

---- some 
CREATE TABLE small AS FROM range(1000);
CREATE TABLE medium AS FROM range(1000000);
CREATE TABLE big AS FROM range(1000000000);

PRAGMA disable_profiling;

SELECT * EXCLUDE timestamp FROM duckdb_logs() WHERE type == 'Metrics' ORDER BY message.split(',')[1], context_id;
```
Will result in for example in:
```
┌────────────┬─────────┬───────────┬────────────────────────────────────────────────────────────┐
│ context_id │  type   │ log_level │                          message                           │
│   uint64   │ varchar │  varchar  │                          varchar                           │
├────────────┼─────────┼───────────┼────────────────────────────────────────────────────────────┤
│         39 │ Metrics │ INFO      │ {'metric': CHECKPOINT_LATENCY, 'value': 0.0}               │
│         44 │ Metrics │ INFO      │ {'metric': CHECKPOINT_LATENCY, 'value': 0.0}               │
│         49 │ Metrics │ INFO      │ {'metric': CHECKPOINT_LATENCY, 'value': 0.017832}          │
│         39 │ Metrics │ INFO      │ {'metric': COMMIT_WRITE_WAL_LATENCY, 'value': 0.000305292} │
│         44 │ Metrics │ INFO      │ {'metric': COMMIT_WRITE_WAL_LATENCY, 'value': 0.003793958} │
│         49 │ Metrics │ INFO      │ {'metric': COMMIT_WRITE_WAL_LATENCY, 'value': 0.0}         │
│         39 │ Metrics │ INFO      │ {'metric': CPU_TIME, 'value': 0.000110209}                 │
│         44 │ Metrics │ INFO      │ {'metric': CPU_TIME, 'value': 0.009471759999999997}        │
│         49 │ Metrics │ INFO      │ {'metric': CPU_TIME, 'value': 8.241736770029297}           │
│          · │    ·    │  ·        │                   ·                                        │
│          · │    ·    │  ·        │                   ·                                        │
│          · │    ·    │  ·        │                   ·                                        │
│         39 │ Metrics │ INFO      │ {'metric': SYSTEM_PEAK_BUFFER_MEMORY, 'value': 36864}      │
│         44 │ Metrics │ INFO      │ {'metric': SYSTEM_PEAK_BUFFER_MEMORY, 'value': 6625280}    │
│         49 │ Metrics │ INFO      │ {'metric': SYSTEM_PEAK_BUFFER_MEMORY, 'value': 63510528}   │
│         39 │ Metrics │ INFO      │ {'metric': TOTAL_BYTES_WRITTEN, 'value': 0}                │
│         44 │ Metrics │ INFO      │ {'metric': TOTAL_BYTES_WRITTEN, 'value': 262144}           │
│         49 │ Metrics │ INFO      │ {'metric': TOTAL_BYTES_WRITTEN, 'value': 12587008}         │
│          · │    ·    │  ·        │                   ·                                        │
│          · │    ·    │  ·        │                   ·                                        │
│          · │    ·    │  ·        │                   ·                                        │
├────────────┴─────────┴───────────┴────────────────────────────────────────────────────────────┤
│ 57 rows (? shown)                                                                   4 columns │
└───────────────────────────────────────────────────────────────────────────────────────────────┘
```

This is in my mind already useful, for easy access to profiling metrics output over a set of queries, say from CLI or unittester, thanks to this being self-contained in SQL.

This could use a follow up where a specific macro to get metrics out unnested (similar to what happen for HTTP logs for example), so they are more easily available to query, and possibly a single command to enable say `PRAGMA enable_profiling = 'logger';`, but this patch is both useful and self-contained, so I would more forward.

Also this handle only aggregate profile metrics on the root note, this could be used also for the rest of the tree, but that requires some more metric-specific thinking (and might tie to previous point).

I have not checked what the cost of enabling the logger is, so this might be not suitable in production, but allow easier access of profiling through SQL, that might be handy to add tests in various contexts.