### PR TITLE
Count also time blocked waiting for the lock in BLOCKED_THREADS_TIME

### DIFF
--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -188,7 +188,7 @@ public:
 	//! Adds the timings gathered by an OperatorProfiler to this query profiler
 	DUCKDB_API void Flush(OperatorProfiler &profiler);
 	//! Adds the top level query information to the global profiler.
-	DUCKDB_API void SetInfo(const double &blocked_thread_time);
+	DUCKDB_API void SetBlockedTime(const double &blocked_thread_time);
 
 	DUCKDB_API void StartPhase(MetricsType phase_metric);
 	DUCKDB_API void EndPhase();

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -648,7 +648,7 @@ void QueryProfiler::Flush(OperatorProfiler &profiler) {
 	profiler.operator_infos.clear();
 }
 
-void QueryProfiler::SetInfo(const double &blocked_thread_time) {
+void QueryProfiler::SetBlockedTime(const double &blocked_thread_time) {
 	lock_guard<std::mutex> guard(lock);
 	if (!IsEnabled() || !running) {
 		return;

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -462,17 +462,23 @@ void Executor::SignalTaskRescheduled(lock_guard<mutex> &) {
 
 void Executor::WaitForTask() {
 #ifndef DUCKDB_NO_THREADS
-	static constexpr std::chrono::milliseconds WAIT_TIME_MS = std::chrono::milliseconds(WAIT_TIME);
+	static constexpr std::chrono::microseconds WAIT_TIME_MS = std::chrono::microseconds(WAIT_TIME * 1000);
+	auto begin = std::chrono::high_resolution_clock::now();
 	std::unique_lock<mutex> l(executor_lock);
+	auto end = std::chrono::high_resolution_clock::now();
+	auto dur = end - begin;
+	auto ms = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
 	if (to_be_rescheduled_tasks.empty()) {
+		blocked_thread_time += ms;
 		return;
 	}
 	if (ResultCollectorIsBlocked()) {
 		// If the result collector is blocked, it won't get unblocked until the connection calls Fetch
+		blocked_thread_time += ms;
 		return;
 	}
 
-	blocked_thread_time++;
+	blocked_thread_time += ms + WAIT_TIME_MS.count();
 	task_reschedule.wait_for(l, WAIT_TIME_MS);
 #endif
 }
@@ -671,13 +677,12 @@ void Executor::ThrowException() {
 }
 
 void Executor::Flush(ThreadContext &thread_context) {
-	static constexpr std::chrono::milliseconds WAIT_TIME_MS = std::chrono::milliseconds(WAIT_TIME);
 	auto global_profiler = profiler;
 	if (global_profiler) {
 		global_profiler->Flush(thread_context.profiler);
 
 		auto blocked_time = blocked_thread_time.load();
-		global_profiler->SetInfo(double(blocked_time * WAIT_TIME_MS.count()) / 1000);
+		global_profiler->SetBlockedTime(double(blocked_time) / 1000.0 / 1000.0);
 	}
 }
 


### PR DESCRIPTION
I bumped into this looking to add a metric around number of scheduled tasks / average task length, but found cases where lock contention would be somewhat significant. Unsure if significant enough to pay the price of 2 calls to `std::chrono::high_resolution_clock::now` (likely locking is significantly more expensive, but...), open for feedback.

And nitpick, changing naming from `SetInfo` to `SetBlockedTime`.