### PR TITLE
CLI: Make last query result queryable through the `_` token

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -22,6 +22,7 @@ enum class MetadataResult : uint8_t;
 
 namespace duckdb_shell {
 using duckdb::make_uniq;
+using duckdb::MaterializedQueryResult;
 using duckdb::string;
 using duckdb::unique_ptr;
 using duckdb::vector;
@@ -126,8 +127,11 @@ public:
 	idx_t total_changes = 0;
 	bool readStdin = true;
 	string initFile;
+	unique_ptr<duckdb::MaterializedQueryResult> last_result;
 
 public:
+	static ShellState &Get();
+
 	void PushOutputMode();
 	void PopOutputMode();
 	void OutputCSV(const char *z, int bSep);

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -777,7 +777,7 @@ bool Linenoise::AddCompletionMarker(const char *buf, idx_t len, string &result_b
 		if (!IsCompletionCharacter(buf[cpos])) {
 			break;
 		}
-		if (completion.completions[0].completion[cpos] != buf[cpos]) {
+		if (tolower(completion.completions[0].completion[cpos]) != tolower(buf[cpos])) {
 			return false;
 		}
 	}

--- a/tools/shell/tests/test_last_result.py
+++ b/tools/shell/tests/test_last_result.py
@@ -1,0 +1,54 @@
+# fmt: off
+
+import pytest
+import subprocess
+import sys
+import os
+from typing import List
+from conftest import ShellTest
+
+# test that we can query the last result using _
+def test_last_result(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 42 a")
+        .statement('SELECT a + 100 FROM _')
+    )
+    result = test.run()
+    result.check_stdout("142")
+
+# no result available
+def test_no_last_result(shell):
+    test = (
+        ShellTest(shell)
+        .statement('FROM _')
+    )
+    result = test.run()
+    result.check_stderr("no result available")
+
+def test_stacking_last_result(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 42 a")
+        .statement('SELECT a * 10 a FROM _')
+        .statement('SELECT a * 10 a FROM _')
+        .statement('SELECT a * 10 a FROM _')
+        .statement('SELECT a * 10 a FROM _')
+        .statement('SELECT a * 10 a FROM _')
+    )
+    result = test.run()
+    result.check_stdout("4200000")
+
+# errors do not overwrite last results
+def test_last_result_error(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 42 a")
+        .statement('select eek')
+        .statement('SELECT a * 10 a FROM _')
+    )
+    result = test.run()
+    assert '420' in result.stdout
+
+
+# fmt: on


### PR DESCRIPTION
This PR adds support for querying the last result in the CLI using the underscore, e.g.:

```sql
select 42 AS a;
┌───────┐
│   a   │
│ int32 │
├───────┤
│  42   │
└───────┘
select a + 100 AS b FROM _;
┌───────┐
│   b   │
│ int32 │
├───────┤
│  142  │
└───────┘
```

This is useful if, after running a (potentially long) query, you decide you want to do something else with the result (e.g. query it further, store it somewhere, etc).