### PR TITLE
Add no_wal mode setting

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -689,6 +689,13 @@
         "default_value": "5"
     },
     {
+        "name": "no_wal_mode",
+        "description": "Disable WAL mode for the database",
+        "type": "BOOLEAN",
+        "default_scope": "global",
+        "default_value": "false"
+    },
+    {
         "name": "old_implicit_casting",
         "description": "Allow implicit casting to/from VARCHAR",
         "type": "BOOLEAN",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -690,7 +690,7 @@
     },
     {
         "name": "no_wal_mode",
-        "description": "Disable WAL mode for the database",
+        "description": "Disable WAL mode for the database. Use with caution, disables recovery from crashes for persistent files.",
         "type": "BOOLEAN",
         "default_scope": "global",
         "default_value": "false"

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -960,6 +960,15 @@ struct NestedLoopJoinThresholdSetting {
 	static constexpr SetScope DefaultScope = SetScope::SESSION;
 };
 
+struct NoWalModeSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "no_wal_mode";
+	static constexpr const char *Description = "Disable WAL mode for the database";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SetScope DefaultScope = SetScope::GLOBAL;
+};
+
 struct OldImplicitCastingSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "old_implicit_casting";

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -963,7 +963,8 @@ struct NestedLoopJoinThresholdSetting {
 struct NoWalModeSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "no_wal_mode";
-	static constexpr const char *Description = "Disable WAL mode for the database";
+	static constexpr const char *Description =
+	    "Disable WAL mode for the database. Use with caution, disables recovery from crashes for persistent files.";
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SetScope DefaultScope = SetScope::GLOBAL;

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -146,6 +146,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(MaxVacuumTasksSetting),
     DUCKDB_SETTING(MergeJoinThresholdSetting),
     DUCKDB_SETTING(NestedLoopJoinThresholdSetting),
+    DUCKDB_SETTING(NoWalModeSetting),
     DUCKDB_SETTING(OldImplicitCastingSetting),
     DUCKDB_SETTING(OrderByNonIntegerLiteralSetting),
     DUCKDB_SETTING_CALLBACK(OrderedAggregateThresholdSetting),
@@ -182,10 +183,10 @@ static const ConfigurationOption internal_options[] = {
 
 static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 84),
                                                      DUCKDB_SETTING_ALIAS("null_order", 34),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 103),
-                                                     DUCKDB_SETTING_ALIAS("user", 118),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 104),
+                                                     DUCKDB_SETTING_ALIAS("user", 119),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 21),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 117),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 118),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -280,10 +280,8 @@ void SingleFileStorageManager::LoadDatabase(QueryContext context) {
 		block_manager = std::move(sf_block_manager);
 		table_io_manager = make_uniq<SingleFileTableIOManager>(*block_manager, row_group_size);
 
-		if (context.GetClientContext() != nullptr) {
-			if (!DBConfig::GetSetting<NoWalModeSetting>(*context.GetClientContext())) {
-				wal = make_uniq<WriteAheadLog>(db, wal_path);
-			}
+		if (!DBConfig::GetSetting<NoWalModeSetting>(db.GetDatabase())) {
+			wal = make_uniq<WriteAheadLog>(db, wal_path);
 		}
 	} else {
 		// Either the file exists, or we are in read-only mode, so we
@@ -356,11 +354,10 @@ void SingleFileStorageManager::LoadDatabase(QueryContext context) {
 		}
 
 		// Replay the WAL.
+
 		auto wal_path = GetWALPath();
-		if (context.GetClientContext() != nullptr) {
-			if (!DBConfig::GetSetting<NoWalModeSetting>(*context.GetClientContext())) {
-				wal = WriteAheadLog::Replay(context, fs, db, wal_path);
-			}
+		if (!DBConfig::GetSetting<NoWalModeSetting>(db.GetDatabase())) {
+			wal = WriteAheadLog::Replay(context, fs, db, wal_path);
 		}
 
 		// End timing the WAL replay step.

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -273,7 +273,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 
 		auto &profiler = *context.client_data->profiler;
 		profiler.StartTimer(MetricsType::COMMIT_WRITE_WAL_LATENCY);
-		if (!DBConfig::GetSetting<NoWalModeSetting>(context)) {
+		if (!DBConfig::GetSetting<NoWalModeSetting>(db.GetDatabase())) {
 			error = transaction.WriteToWAL(db, commit_state);
 		}
 		profiler.EndTimer(MetricsType::COMMIT_WRITE_WAL_LATENCY);

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -273,7 +273,9 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 
 		auto &profiler = *context.client_data->profiler;
 		profiler.StartTimer(MetricsType::COMMIT_WRITE_WAL_LATENCY);
-		error = transaction.WriteToWAL(db, commit_state);
+		if (!DBConfig::GetSetting<NoWalModeSetting>(context)) {
+			error = transaction.WriteToWAL(db, commit_state);
+		}
 		profiler.EndTimer(MetricsType::COMMIT_WRITE_WAL_LATENCY);
 
 		// after we finish writing to the WAL we grab the transaction lock again

--- a/test/sql/pragma/test_no_wal_mode.test
+++ b/test/sql/pragma/test_no_wal_mode.test
@@ -1,0 +1,181 @@
+# name: test/sql/pragma/test_no_wal_mode.test
+# description: Measure WAL metrics, turn no_wal_mode on, check that WAL replay is not performed.
+# group: [pragma]
+
+require json
+
+require noforcestorage
+
+require skip_reload
+
+statement ok
+SET threads = 1;
+
+statement ok
+SET wal_autocheckpoint = '1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+ATTACH '__TEST_DIR__/wal_latency.db' AS wal_latency;
+
+statement ok
+CREATE TABLE wal_latency.tbl AS SELECT range AS id, 0 AS v FROM range(500_000);
+
+# Perform a large change in a single transaction so COMMIT must write a big WAL
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+UPDATE wal_latency.tbl SET v = id;
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/wal_commit.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"COMMIT_WRITE_WAL_LATENCY": "true"}';
+
+statement ok
+SET profiling_coverage='ALL';
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+COMMIT;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE commit_metrics AS SELECT * FROM '__TEST_DIR__/wal_commit.json';
+
+query I
+SELECT CASE WHEN commit_write_wal_latency > 0 THEN 'true' ELSE 'false' END FROM commit_metrics;
+----
+true
+
+statement ok
+DETACH wal_latency;
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/wal_replay.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"WAL_REPLAY_ENTRY_COUNT": "true", "ATTACH_REPLAY_WAL_LATENCY": "true", "ATTACH_LOAD_STORAGE_LATENCY": "true"}';
+
+statement ok
+SET profiling_coverage='ALL';
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+ATTACH '__TEST_DIR__/wal_latency.db' AS wal_latency;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE replay_metrics AS SELECT * FROM '__TEST_DIR__/wal_replay.json';
+
+query I
+SELECT CASE WHEN wal_replay_entry_count > 0 THEN 'true' ELSE 'false' END FROM replay_metrics;
+----
+true
+
+query I
+SELECT CASE WHEN attach_replay_wal_latency > 0 THEN 'true' ELSE 'false' END FROM replay_metrics;
+----
+true
+
+query I
+SELECT CASE WHEN attach_load_storage_latency > 0 THEN 'true' ELSE 'false' END FROM replay_metrics;
+----
+true
+
+#--------------------------------------
+# Turn no_wal_mode on
+#--------------------------------------
+
+statement ok
+PRAGMA no_wal_mode = "true";
+
+statement ok
+ATTACH '__TEST_DIR__/no_wal_latency.db' AS no_wal_latency;
+
+statement ok
+CREATE TABLE no_wal_latency.tbl AS SELECT range AS id, 0 AS v FROM range(500_000);
+
+# Perform a large change in a single transaction so COMMIT must write a big WAL
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+UPDATE no_wal_latency.tbl SET v = id;
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/wal_commit.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"COMMIT_WRITE_WAL_LATENCY": "true"}';
+
+statement ok
+SET profiling_coverage='ALL';
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+COMMIT;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE commit_metrics AS SELECT * FROM '__TEST_DIR__/wal_commit.json';
+
+query I
+SELECT commit_write_wal_latency FROM commit_metrics;
+----
+0
+
+statement ok
+DETACH no_wal_latency;
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/wal_replay.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"WAL_REPLAY_ENTRY_COUNT": "true", "ATTACH_REPLAY_WAL_LATENCY": "true", "ATTACH_LOAD_STORAGE_LATENCY": "true"}';
+
+statement ok
+SET profiling_coverage='ALL';
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+ATTACH '__TEST_DIR__/no_wal_latency.db' AS no_wal_latency;
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE replay_metrics AS SELECT * FROM '__TEST_DIR__/wal_replay.json';
+
+query I
+SELECT wal_replay_entry_count FROM replay_metrics;
+----
+0
+
+query I
+SELECT round(attach_replay_wal_latency, 0) from replay_metrics;
+----
+0
+
+query I
+SELECT round(attach_load_storage_latency, 0) FROM replay_metrics;
+----
+0


### PR DESCRIPTION
Introduces a `no_wal_mode` setting to disable the use of WAL.

"no-WAL-mode" should be used with caution, as it disables recovery from crashes for persistent files. If your recovery strategy can compensate that, e.g., your source of truth is not the file, then a "no-WAL-mode" might speed up operations such as COMMIT of changes on persistent files and ATTACH (no WAL replay).

Closes: https://github.com/duckdblabs/duckdb-internal/issues/6390