### PR TITLE
Release relevant tests to still be run on all builds

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -141,15 +141,18 @@ jobs:
       run: |
         python3 scripts/run_tests_one_by_one.py build/release/test/unittest "*" --time_execution
 
+    - name: Release specific tests
+      shell: bash
+      run: |
+        ./build/release/test/unittest --select-tag release
+
     - name: Tools Tests
       shell: bash
-      if: ${{ inputs.skip_tests != 'true' }}
       run: |
         python3 -m pytest tools/shell/tests --shell-binary build/release/duckdb
 
     - name: Examples
       shell: bash
-      if: ${{ inputs.skip_tests != 'true' }}
       run: |
         build/release/benchmark/benchmark_runner benchmark/micro/update/update_with_join.benchmark
         build/release/duckdb -c "COPY (SELECT 42) TO '/dev/stdout' (FORMAT PARQUET)" | cat

--- a/test/sql/pragma/test_pragma_version.test
+++ b/test/sql/pragma/test_pragma_version.test
@@ -2,6 +2,8 @@
 # description: Test version pragma
 # group: [pragma]
 
+tags release
+
 statement ok
 PRAGMA version;
 
@@ -35,4 +37,10 @@ statement ok
 SET VARIABLE v_or_latest = (select CASE WHEN getvariable('v') ILIKE 'v%-dev%' THEN 'latest' WHEN getvariable('v') ILIKE 'v0.0.1' THEN 'latest' ELSE getvariable('v') END);
 
 statement ok
-ATTACH 'somefile.db' (STORAGE_VERSION getvariable('v_or_latest'));
+SET VARIABLE codename = (select CASE WHEN getvariable('v') ILIKE 'v%-dev%' THEN 'Development Version' WHEN getvariable('v') ILIKE 'v0.0.1' THEN 'Unknown Version' ELSE '%' END);
+
+query I
+select count(*) FROM (select codename from pragma_version() WHERE codename LIKE getvariable('codename'));
+----
+1
+


### PR DESCRIPTION
I would propose, at least for the Linux builds, to add back a minimal amount of tests also on release builds.

They will ensure at a minimum that:
* for a given release, the corresponding storage_version is valid
* for a minor release, that the corresponding name has been set

There are more tests that we might consider basic enough AND connected to behaviour specific of a release that we might want to add to the `release` tag.

Fixes https://github.com/duckdb/duckdb/issues/19354 (together with https://github.com/duckdb/duckdb/pull/19525 that actually added the name).

Note that given the current release process happens in advance, eventual test failure are annoying but not fatal, but they will require changes to code. I am not sure if it's worth having a `keep_going_in_all_cases` option, basically turning the boolean into a set, but I think it can be done when need arise.