### PR TITLE
Python SQLLogicTest - show results in a consistent order

### DIFF
--- a/test/optimizer/pushdown/timestamp_to_date_pushdown.test
+++ b/test/optimizer/pushdown/timestamp_to_date_pushdown.test
@@ -13,16 +13,16 @@ statement ok
 create or replace table t1 (ts timestamp, i int);
 
 statement ok
-insert into t1 select '2024-05-01 00:00:00'::timestamp, i from generate_series(1, 2000) g(i);
+insert into t1 select '2024-05-01 00:00:00'::timestamp ts, i from generate_series(1, 2000) g(i);
 
 statement ok
-insert into t1 select '2024-05-02 00:00:00'::timestamp, i from generate_series(1, 1000) g(i);
+insert into t1 select '2024-05-02 00:00:00'::timestamp ts, i from generate_series(1, 1000) g(i);
 
 statement ok
-insert into t1 select '2024-05-02 00:22:00'::timestamp, i from generate_series(1, 1000) g(i);
+insert into t1 select '2024-05-02 00:22:00'::timestamp ts, i from generate_series(1, 1000) g(i);
 
 statement ok
-insert into t1 select '2024-05-03 00:00:00'::timestamp, i from generate_series(1, 2000) g(i);
+insert into t1 select '2024-05-03 00:00:00'::timestamp ts, i from generate_series(1, 2000) g(i);
 
 query II
 explain select * from t1 where ts::date == '2024-05-02';
@@ -39,14 +39,14 @@ statement ok
 pragma disable_optimizer;
 
 query II nosort no_opt_result
-select * from t1 where ts::date == '2024-05-02';
+select * from t1 where ts::date == '2024-05-02' order by ts, i;
 ----
 
 statement ok
 pragma enable_optimizer;
 
 query II nosort no_opt_result
-select * from t1 where ts::date == '2024-05-02';
+select * from t1 where ts::date == '2024-05-02' order by ts, i;
 ----
 
 # pattern is still recognized in conjunction


### PR DESCRIPTION
Fixes: https://github.com/duckdblabs/duckdb-internal/issues/5557

This PR fixes a bug in the nightly tests related to the Python implementation of SQLLogicTest. Previously, when running the tests using Python, the result order could vary, causing hash mismatches and test failures. Changed the test to ensure the results are in consistent order, irrespective of how we run it.

I am not sure if Python SQLLogicTest is being used at the moment, but I am pushing the fix anyway as it can cause problems in the future.