### PR TITLE
Fix: list_concat(NULL) returns NULL

### DIFF
--- a/test/sql/types/list/list_concat_null.test
+++ b/test/sql/types/list/list_concat_null.test
@@ -1,10 +1,8 @@
 # name: test/sql/types/list/list_concat_null.test
-# description: Issue #6656 - Segmentation Fault on Select query on table with column of array type
+# description: list_concat with NULLS
 # group: [list]
 
-statement ok
-PRAGMA enable_verification
-
+#Issue #6656 - Segmentation Fault on Select query on table with column of array type
 statement ok
 CREATE table x1 (b INT[]);
 
@@ -54,3 +52,34 @@ query I
 select list_concat([1]::INT[1], [2, 3]::INT[2]);
 ----
 [1, 2, 3]
+
+# [duckdb-fuzzer/#4296] When args are all NULL return NULL
+
+query I
+SELECT list_concat(NULL)
+----
+NULL
+
+query I
+SELECT list_concat(NULL, NULL)
+----
+NULL
+
+# test operator
+
+query I
+SELECT NULL || NULL
+----
+NULL
+
+# test 'string' concat
+
+query I
+SELECT concat(NULL)
+----
+NULL
+
+query I
+SELECT concat(NULL, NULL)
+----
+NULL


### PR DESCRIPTION
Fixes: https://github.com/duckdb/duckdb-fuzzer/issues/4296

`SELECT list_concat(NULL)` was throwing:
```
ABORT THROWN BY INTERNAL EXCEPTION: Failed to find function array_cat(VARCHAR)
```

Now it returns `NULL` which is consistent with our other nested functions. However the previous implementation, probably by conincidence, matched PostgreSQL:
```sql
postgres=# select array_cat(NULL);
ERROR:  function array_cat(unknown) does not exist
LINE 1: select array_cat(NULL);
               ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
```

`SELECT list_concat(NULL, NULL)` also returned an error before but this has now been changed to also return `NULL`. This does match PostgreSQL:
```sql
postgres=# select array_cat(NULL, NULL);
 array_cat 
-----------
 
(1 row)
```