### PR TITLE
Allow Table `function` to opt-in to return arbitrary combinations of [0, output.size()] x [HAVE_MORE_OUTPUT, FINISHED]

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -499,6 +499,12 @@ jobs:
       run: |
         ./build/release/test/unittest --test-config test/configs/compressed_in_memory.json
 
+    - name: Test sycnronous table scan implementation
+      if: (success() || failure()) && steps.build.conclusion == 'success'
+      shell: bash
+      run: |
+        ./build/release/test/unittest --on-init "SET debug_physical_table_scan_execution_strategy=SYNCHRONOUS;"
+
     - name: Test block prefetching
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -209,7 +209,6 @@ private:
 	              shared_ptr<ParquetFileMetadataCache> metadata);
 
 	void InitializeSchema(ClientContext &context);
-	bool ScanInternal(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
 	//! Parse the schema of the file
 	unique_ptr<ParquetColumnSchema> ParseSchema(ClientContext &context);
 	ParquetColumnSchema ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat, idx_t &next_schema_idx,

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1272,7 +1272,7 @@ void ParquetReader::GetPartitionStats(const duckdb_parquet::FileMetaData &metada
 AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
 	result.Reset();
 	if (state.finished) {
-		return AsyncResult(SourceResultType::FINISHED);
+		return SourceResultType::FINISHED;
 	}
 
 	// see if we have to switch to the next row group in the parquet file
@@ -1286,7 +1286,7 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 
 		if ((idx_t)state.current_group == state.group_idx_list.size()) {
 			state.finished = true;
-			return AsyncResult(SourceResultType::FINISHED);
+			return SourceResultType::FINISHED;
 		}
 
 		// TODO: only need this if we have a deletion vector?
@@ -1359,7 +1359,7 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 			}
 		}
 		result.Reset();
-		return AsyncResult(SourceResultType::HAVE_MORE_OUTPUT);
+		return SourceResultType::HAVE_MORE_OUTPUT;
 	}
 
 	auto scan_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, GetGroup(state).num_rows - state.offset_in_group);
@@ -1368,7 +1368,7 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 	if (scan_count == 0) {
 		state.finished = true;
 		// end of last group, we are done
-		return AsyncResult(SourceResultType::FINISHED);
+		return SourceResultType::FINISHED;
 	}
 
 	auto &deletion_filter = state.root_reader->Reader().deletion_filter;
@@ -1454,7 +1454,7 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 
 	rows_read += scan_count;
 	state.offset_in_group += scan_count;
-	return AsyncResult(SourceResultType::HAVE_MORE_OUTPUT);
+	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
 } // namespace duckdb

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -103,6 +103,7 @@
 #include "duckdb/execution/index/bound_index.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_option.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_state.hpp"
+#include "duckdb/execution/physical_table_scan_enum.hpp"
 #include "duckdb/execution/reservoir_sample.hpp"
 #include "duckdb/function/aggregate_state.hpp"
 #include "duckdb/function/compression_function.hpp"
@@ -3468,6 +3469,26 @@ const char* EnumUtil::ToChars<PhysicalOperatorType>(PhysicalOperatorType value) 
 template<>
 PhysicalOperatorType EnumUtil::FromString<PhysicalOperatorType>(const char *value) {
 	return static_cast<PhysicalOperatorType>(StringUtil::StringToEnum(GetPhysicalOperatorTypeValues(), 82, "PhysicalOperatorType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetPhysicalTableScanExecutionStrategyValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(PhysicalTableScanExecutionStrategy::DEFAULT), "DEFAULT" },
+		{ static_cast<uint32_t>(PhysicalTableScanExecutionStrategy::TASK_EXECUTOR), "TASK_EXECUTOR" },
+		{ static_cast<uint32_t>(PhysicalTableScanExecutionStrategy::SYNCHRONOUS), "SYNCHRONOUS" },
+		{ static_cast<uint32_t>(PhysicalTableScanExecutionStrategy::TASK_EXECUTOR_BUT_FORCE_SYNC_CHECKS), "TASK_EXECUTOR_BUT_FORCE_SYNC_CHECKS" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<PhysicalTableScanExecutionStrategy>(PhysicalTableScanExecutionStrategy value) {
+	return StringUtil::EnumToString(GetPhysicalTableScanExecutionStrategyValues(), 4, "PhysicalTableScanExecutionStrategy", static_cast<uint32_t>(value));
+}
+
+template<>
+PhysicalTableScanExecutionStrategy EnumUtil::FromString<PhysicalTableScanExecutionStrategy>(const char *value) {
+	return static_cast<PhysicalTableScanExecutionStrategy>(StringUtil::StringToEnum(GetPhysicalTableScanExecutionStrategyValues(), 4, "PhysicalTableScanExecutionStrategy", value));
 }
 
 const StringUtil::EnumStringLiteral *GetPhysicalTypeValues() {

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -233,11 +233,7 @@
         "description": "DEBUG SETTING: force use of given strategy for executing physical table scans",
         "type": "ENUM<PhysicalTableScanExecutionStrategy>",
         "default_scope": "global",
-        "default_value": "DEFAULT",
-        "on_callbacks": [
-            "set",
-            "reset"
-        ]
+        "default_value": "DEFAULT"
     },
     {
         "name": "debug_skip_checkpoint_on_commit",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -229,6 +229,17 @@
         "default_value": "false"
     },
     {
+        "name": "debug_physical_table_scan_execution_strategy",
+        "description": "DEBUG SETTING: force use of given strategy for executing physical table scans",
+        "type": "ENUM<PhysicalTableScanExecutionStrategy>",
+        "default_scope": "global",
+        "default_value": "DEFAULT",
+        "on_callbacks": [
+            "set",
+            "reset"
+        ]
+    },
+    {
         "name": "debug_skip_checkpoint_on_commit",
         "description": "DEBUG SETTING: skip checkpointing on commit",
         "type": "BOOLEAN",

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/transaction/transaction.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/execution/physical_table_scan_enum.hpp"
+#include "duckdb/main/settings.hpp"
 
 #include <utility>
 
@@ -28,13 +29,8 @@ PhysicalTableScan::PhysicalTableScan(PhysicalPlan &physical_plan, vector<Logical
 class TableScanGlobalSourceState : public GlobalSourceState {
 public:
 	TableScanGlobalSourceState(ClientContext &context, const PhysicalTableScan &op) {
-		Value tmp_value;
-		if (context.TryGetCurrentSetting("debug_physical_table_scan_execution_strategy", tmp_value)) {
-			physical_table_scan_execution_strategy =
-			    EnumUtil::FromString<PhysicalTableScanExecutionStrategy>(tmp_value.ToString());
-		} else {
-			physical_table_scan_execution_strategy = PhysicalTableScanExecutionStrategy::TASK_EXECUTOR;
-		}
+		physical_table_scan_execution_strategy =
+		    DBConfig::GetSetting<DebugPhysicalTableScanExecutionStrategySetting>(context);
 
 		if (op.dynamic_filters && op.dynamic_filters->HasFilters()) {
 			table_filters = op.dynamic_filters->GetFinalTableFilters(op, op.table_filters.get());

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -147,6 +147,11 @@ static void ValidateAsyncStrategyResult(const PhysicalTableScanExecutionStrategy
 		}
 		break;
 	default:
+		if (result_post == AsyncResultType::BLOCKED) {
+			if (output_chunk_size > 0) {
+				throw InternalException("ValidateAsyncStrategyResult: found BLOCKED with non-empty chunk");
+			}
+		}
 		break;
 	}
 }

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -133,12 +133,12 @@ static void ValidateAsyncStrategyResult(const PhysicalTableScanExecutionStrategy
 		case AsyncResultType::BLOCKED:
 			throw InternalException("ValidateAsyncStrategyResult: found BLOCKED");
 		case AsyncResultType::FINISHED:
-			if (output_chunk_size) {
+			if (output_chunk_size > 0) {
 				throw InternalException("ValidateAsyncStrategyResult: found FINISHED with non-empty chunk");
 			}
 			break;
 		case AsyncResultType::HAVE_MORE_OUTPUT:
-			if (output_chunk_size) {
+			if (output_chunk_size == 0) {
 				throw InternalException("ValidateAsyncStrategyResult: found HAVE_MORE_OUTPUT with empty chunk");
 			}
 			break;

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -18,6 +18,7 @@ PhysicalTableScan::PhysicalTableScan(PhysicalPlan &physical_plan, vector<Logical
                                      idx_t estimated_cardinality, ExtraOperatorInfo extra_info,
                                      vector<Value> parameters_p, virtual_column_map_t virtual_columns_p)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::TABLE_SCAN, std::move(types), estimated_cardinality),
+
       function(std::move(function_p)), bind_data(std::move(bind_data_p)), returned_types(std::move(returned_types_p)),
       column_ids(std::move(column_ids_p)), projection_ids(std::move(projection_ids_p)), names(std::move(names_p)),
       table_filters(std::move(table_filters_p)), extra_info(std::move(extra_info)), parameters(std::move(parameters_p)),
@@ -29,12 +30,11 @@ public:
 	TableScanGlobalSourceState(ClientContext &context, const PhysicalTableScan &op) {
 		Value tmp_value;
 		if (context.TryGetCurrentSetting("debug_physical_table_scan_execution_strategy", tmp_value)) {
-			physical_table_scan_execution_strategy = EnumUtil::FromString<PhysicalTableScanExecutionStrategy>(tmp_value.ToString());
+			physical_table_scan_execution_strategy =
+			    EnumUtil::FromString<PhysicalTableScanExecutionStrategy>(tmp_value.ToString());
 		} else {
 			physical_table_scan_execution_strategy = PhysicalTableScanExecutionStrategy::TASK_EXECUTOR;
 		}
-
-
 
 		if (op.dynamic_filters && op.dynamic_filters->HasFilters()) {
 			table_filters = op.dynamic_filters->GetFinalTableFilters(op, op.table_filters.get());

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -308,6 +308,8 @@ enum class PendingExecutionResult : uint8_t;
 
 enum class PhysicalOperatorType : uint8_t;
 
+enum class PhysicalTableScanExecutionStrategy : uint8_t;
+
 enum class PhysicalType : uint8_t;
 
 enum class PragmaType : uint8_t;
@@ -870,6 +872,9 @@ const char* EnumUtil::ToChars<PendingExecutionResult>(PendingExecutionResult val
 
 template<>
 const char* EnumUtil::ToChars<PhysicalOperatorType>(PhysicalOperatorType value);
+
+template<>
+const char* EnumUtil::ToChars<PhysicalTableScanExecutionStrategy>(PhysicalTableScanExecutionStrategy value);
 
 template<>
 const char* EnumUtil::ToChars<PhysicalType>(PhysicalType value);
@@ -1507,6 +1512,9 @@ PendingExecutionResult EnumUtil::FromString<PendingExecutionResult>(const char *
 
 template<>
 PhysicalOperatorType EnumUtil::FromString<PhysicalOperatorType>(const char *value);
+
+template<>
+PhysicalTableScanExecutionStrategy EnumUtil::FromString<PhysicalTableScanExecutionStrategy>(const char *value);
 
 template<>
 PhysicalType EnumUtil::FromString<PhysicalType>(const char *value);

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -634,7 +634,10 @@ public:
 				return;
 			}
 
-			D_ASSERT(res.GetResultType() == AsyncResultType::FINISHED);
+			if (res.GetResultType() != AsyncResultType::FINISHED) {
+				throw InternalException("Unexpected result in MultiFileScan, must be FINISHED, is %s",
+				                        EnumUtil::ToChars(res.GetResultType()));
+			}
 
 			if (!TryInitializeNextBatch(context, bind_data, data, gstate)) {
 				data_p.async_result = SourceResultType::FINISHED;

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -597,7 +597,7 @@ public:
 		auto &gstate = data_p.global_state->Cast<MultiFileGlobalState>();
 		auto &bind_data = data_p.bind_data->CastNoConst<MultiFileBindData>();
 
-		do {
+		{
 			auto &scan_chunk = data.scan_chunk;
 			scan_chunk.Reset();
 
@@ -627,18 +627,27 @@ public:
 				bind_data.multi_file_reader->FinalizeChunk(context, bind_data, *data.reader, *data.reader_data,
 				                                           scan_chunk, output, data.executor,
 				                                           gstate.multi_file_reader_state);
+			}
+			if (res.GetResultType() == AsyncResultType::HAVE_MORE_OUTPUT) {
+				// Loop back to the same block
 				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
 				return;
 			}
 
-			scan_chunk.Reset();
+			D_ASSERT(res.GetResultType() == AsyncResultType::FINISHED);
+
 			if (!TryInitializeNextBatch(context, bind_data, data, gstate)) {
 				data_p.async_result = SourceResultType::FINISHED;
-				return;
+			} else {
+				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
 			}
+<<<<<<< HEAD
 		} while (true);
 		// This is not expected to be ever taken
 		throw InternalException("MultiFileScan is malformed");
+=======
+		}
+>>>>>>> 38d993c294 (MultiFileScan: Handle newer available returns combinations)
 	}
 
 	static unique_ptr<BaseStatistics> MultiFileScanStats(ClientContext &context, const FunctionData *bind_data_p,

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -597,7 +597,7 @@ public:
 		auto &gstate = data_p.global_state->Cast<MultiFileGlobalState>();
 		auto &bind_data = data_p.bind_data->CastNoConst<MultiFileBindData>();
 
-		{
+		do {
 			auto &scan_chunk = data.scan_chunk;
 			scan_chunk.Reset();
 
@@ -628,7 +628,7 @@ public:
 				                                           scan_chunk, output, data.executor,
 				                                           gstate.multi_file_reader_state);
 			}
-			if (res.GetResultType() == AsyncResultType::ONGOING) {
+			if (res.GetResultType() == AsyncResultType::HAVE_MORE_OUTPUT) {
 				// Loop back to the same block
 				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
 				return;
@@ -641,13 +641,8 @@ public:
 			} else {
 				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
 			}
-<<<<<<< HEAD
+			return;
 		} while (true);
-		// This is not expected to be ever taken
-		throw InternalException("MultiFileScan is malformed");
-=======
-		}
->>>>>>> 38d993c294 (MultiFileScan: Handle newer available returns combinations)
 	}
 
 	static unique_ptr<BaseStatistics> MultiFileScanStats(ClientContext &context, const FunctionData *bind_data_p,

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -628,7 +628,7 @@ public:
 				                                           scan_chunk, output, data.executor,
 				                                           gstate.multi_file_reader_state);
 			}
-			if (res.GetResultType() == AsyncResultType::HAVE_MORE_OUTPUT) {
+			if (res.GetResultType() == AsyncResultType::ONGOING) {
 				// Loop back to the same block
 				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
 				return;

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -166,6 +166,7 @@ struct MultiFileGlobalState : public GlobalTableFunctionState {
 	vector<LogicalType> scanned_types;
 	vector<ColumnIndex> column_indexes;
 	optional_ptr<TableFilterSet> filters;
+	atomic<bool> finished {false};
 
 	unique_ptr<GlobalTableFunctionState> global_state;
 

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/common/extra_operator_info.hpp"
 #include "duckdb/common/column_index.hpp"
+#include "duckdb/execution/physical_table_scan_enum.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/execution/physical_table_scan_enum.hpp
+++ b/src/include/duckdb/execution/physical_table_scan_enum.hpp
@@ -14,7 +14,6 @@ namespace duckdb {
 
 enum class PhysicalTableScanExecutionStrategy : uint8_t {
 	DEFAULT,
-
 	TASK_EXECUTOR,
 	SYNCHRONOUS,
 	TASK_EXECUTOR_BUT_FORCE_SYNC_CHECKS

--- a/src/include/duckdb/execution/physical_table_scan_enum.hpp
+++ b/src/include/duckdb/execution/physical_table_scan_enum.hpp
@@ -8,13 +8,16 @@
 
 #pragma once
 
+#include <stdint.h>
+
 namespace duckdb {
 
 enum class PhysicalTableScanExecutionStrategy : uint8_t {
 	DEFAULT,
+
 	TASK_EXECUTOR,
 	SYNCHRONOUS,
 	TASK_EXECUTOR_BUT_FORCE_SYNC_CHECKS
 };
 
-}; // namespace
+}; // namespace duckdb

--- a/src/include/duckdb/execution/physical_table_scan_enum.hpp
+++ b/src/include/duckdb/execution/physical_table_scan_enum.hpp
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/physical_table_scan_enum.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace duckdb {
+
+enum class PhysicalTableScanExecutionStrategy : uint8_t {
+	DEFAULT,
+	TASK_EXECUTOR,
+	SYNCHRONOUS,
+	TASK_EXECUTOR_BUT_FORCE_SYNC_CHECKS
+};
+
+}; // namespace

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -341,6 +341,17 @@ struct DebugForceNoCrossProductSetting {
 	static constexpr SetScope DefaultScope = SetScope::SESSION;
 };
 
+struct DebugPhysicalTableScanExecutionStrategySetting {
+	using RETURN_TYPE = PhysicalTableScanExecutionStrategy;
+	static constexpr const char *Name = "debug_physical_table_scan_execution_strategy";
+	static constexpr const char *Description =
+	    "DEBUG SETTING: force use of given strategy for executing physical table scans";
+	static constexpr const char *InputType = "VARCHAR";
+	static constexpr const char *DefaultValue = "DEFAULT";
+	static constexpr SetScope DefaultScope = SetScope::GLOBAL;
+	static void OnSet(SettingCallbackInfo &info, Value &input);
+};
+
 struct DebugSkipCheckpointOnCommitSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "debug_skip_checkpoint_on_commit";

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -349,6 +349,7 @@ struct DebugPhysicalTableScanExecutionStrategySetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "DEFAULT";
 	static constexpr SetScope DefaultScope = SetScope::GLOBAL;
+	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DebugSkipCheckpointOnCommitSetting {

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -349,7 +349,6 @@ struct DebugPhysicalTableScanExecutionStrategySetting {
 	static constexpr const char *InputType = "VARCHAR";
 	static constexpr const char *DefaultValue = "DEFAULT";
 	static constexpr SetScope DefaultScope = SetScope::GLOBAL;
-	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct DebugSkipCheckpointOnCommitSetting {

--- a/src/include/duckdb/parallel/async_result.hpp
+++ b/src/include/duckdb/parallel/async_result.hpp
@@ -62,6 +62,9 @@ public:
 	static vector<unique_ptr<AsyncTask>> GenerateTestTasks();
 #endif
 
+	static AsyncResultsExecutionMode
+	ConvertToAsyncResultExecutionMode(const PhysicalTableScanExecutionStrategy &execution_mode);
+
 private:
 	AsyncResultType result_type {AsyncResultType::INVALID};
 	vector<unique_ptr<AsyncTask>> async_tasks {};

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -152,7 +152,7 @@ private:
 	OperatorResultType Execute(DataChunk &input, DataChunk &result, idx_t initial_index = 0);
 
 	//! Notifies the sink that a new batch has started
-	SinkNextBatchType NextBatch(DataChunk &source_chunk);
+	SinkNextBatchType NextBatch(DataChunk &source_chunk, const bool have_more_output);
 
 	//! Tries to flush all state from intermediate operators. Will return true if all state is flushed, false in the
 	//! case of a blocked sink.

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -86,7 +86,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(DebugCheckpointAbortSetting),
     DUCKDB_LOCAL(DebugForceExternalSetting),
     DUCKDB_SETTING(DebugForceNoCrossProductSetting),
-    DUCKDB_SETTING_CALLBACK(DebugPhysicalTableScanExecutionStrategySetting),
+    DUCKDB_SETTING(DebugPhysicalTableScanExecutionStrategySetting),
     DUCKDB_SETTING(DebugSkipCheckpointOnCommitSetting),
     DUCKDB_SETTING_CALLBACK(DebugVerifyVectorSetting),
     DUCKDB_SETTING_CALLBACK(DebugWindowModeSetting),

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -86,7 +86,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(DebugCheckpointAbortSetting),
     DUCKDB_LOCAL(DebugForceExternalSetting),
     DUCKDB_SETTING(DebugForceNoCrossProductSetting),
-    DUCKDB_SETTING(DebugPhysicalTableScanExecutionStrategySetting),
+    DUCKDB_SETTING_CALLBACK(DebugPhysicalTableScanExecutionStrategySetting),
     DUCKDB_SETTING(DebugSkipCheckpointOnCommitSetting),
     DUCKDB_SETTING_CALLBACK(DebugVerifyVectorSetting),
     DUCKDB_SETTING_CALLBACK(DebugWindowModeSetting),

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -86,6 +86,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(DebugCheckpointAbortSetting),
     DUCKDB_LOCAL(DebugForceExternalSetting),
     DUCKDB_SETTING(DebugForceNoCrossProductSetting),
+    DUCKDB_SETTING_CALLBACK(DebugPhysicalTableScanExecutionStrategySetting),
     DUCKDB_SETTING(DebugSkipCheckpointOnCommitSetting),
     DUCKDB_SETTING_CALLBACK(DebugVerifyVectorSetting),
     DUCKDB_SETTING_CALLBACK(DebugWindowModeSetting),
@@ -180,12 +181,12 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 84),
-                                                     DUCKDB_SETTING_ALIAS("null_order", 34),
-                                                     DUCKDB_SETTING_ALIAS("profiling_output", 103),
-                                                     DUCKDB_SETTING_ALIAS("user", 118),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 85),
+                                                     DUCKDB_SETTING_ALIAS("null_order", 35),
+                                                     DUCKDB_SETTING_ALIAS("profiling_output", 104),
+                                                     DUCKDB_SETTING_ALIAS("user", 119),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 21),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 117),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 118),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -32,7 +32,6 @@
 #include "duckdb/common/http_util.hpp"
 #include "mbedtls_wrapper.hpp"
 #include "duckdb/main/database_file_path_manager.hpp"
-#include "duckdb/execution/physical_table_scan_enum.hpp"
 
 #ifndef DUCKDB_NO_THREADS
 #include "duckdb/common/thread.hpp"

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -32,6 +32,7 @@
 #include "duckdb/common/http_util.hpp"
 #include "mbedtls_wrapper.hpp"
 #include "duckdb/main/database_file_path_manager.hpp"
+#include "duckdb/execution/physical_table_scan_enum.hpp"
 
 #ifndef DUCKDB_NO_THREADS
 #include "duckdb/common/thread.hpp"

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -255,6 +255,13 @@ Value DebugForceExternalSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
+// Debug Physical Table Scan Execution Strategy
+//===----------------------------------------------------------------------===//
+void DebugPhysicalTableScanExecutionStrategySetting::OnSet(SettingCallbackInfo &info, Value &parameter) {
+	EnumUtil::FromString<PhysicalTableScanExecutionStrategy>(StringValue::Get(parameter));
+}
+
+//===----------------------------------------------------------------------===//
 // Debug Verify Vector
 //===----------------------------------------------------------------------===//
 void DebugVerifyVectorSetting::OnSet(SettingCallbackInfo &info, Value &parameter) {

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -255,13 +255,6 @@ Value DebugForceExternalSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
-// Debug Physical Table Scan Execution Strategy
-//===----------------------------------------------------------------------===//
-void DebugPhysicalTableScanExecutionStrategySetting::OnSet(SettingCallbackInfo &info, Value &parameter) {
-	EnumUtil::FromString<PhysicalTableScanExecutionStrategy>(StringValue::Get(parameter));
-}
-
-//===----------------------------------------------------------------------===//
 // Debug Verify Vector
 //===----------------------------------------------------------------------===//
 void DebugVerifyVectorSetting::OnSet(SettingCallbackInfo &info, Value &parameter) {

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/execution/executor.hpp"
+#include "duckdb/execution/physical_table_scan_enum.hpp"
 
 #ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
 #include "duckdb/parallel/sleep_async_task.hpp"
@@ -174,5 +175,18 @@ vector<unique_ptr<AsyncTask>> AsyncResult::GenerateTestTasks() {
 	return tasks;
 }
 #endif
+
+AsyncResultsExecutionMode
+AsyncResult::ConvertToAsyncResultExecutionMode(const PhysicalTableScanExecutionStrategy &execution_mode) {
+	switch (execution_mode) {
+	case PhysicalTableScanExecutionStrategy::DEFAULT:
+	case PhysicalTableScanExecutionStrategy::TASK_EXECUTOR:
+	case PhysicalTableScanExecutionStrategy::TASK_EXECUTOR_BUT_FORCE_SYNC_CHECKS:
+		return AsyncResultsExecutionMode::TASK_EXECUTOR;
+	case PhysicalTableScanExecutionStrategy::SYNCHRONOUS:
+		return AsyncResultsExecutionMode::SYNCHRONOUS;
+	}
+	throw InternalException("ConvertToAsyncResultExecutionMode passed an unexpected execution_mode");
+}
 
 } // namespace duckdb

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -129,7 +129,7 @@ SinkNextBatchType PipelineExecutor::NextBatch(DataChunk &source_chunk, const boo
 	// by default set it to the maximum valid batch index value for the current pipeline
 	auto &partition_info = local_sink_state->partition_info;
 	OperatorPartitionData next_data(max_batch_index);
-	if (( source_chunk.size() > 0 )) {
+	if ((source_chunk.size() > 0)) {
 		D_ASSERT(local_source_state);
 		D_ASSERT(pipeline.source_state);
 		// if we retrieved data - initialize the next batch index

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -221,7 +221,7 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 				}
 			}
 		} else if (!exhausted_source || next_batch_blocked) {
-			SourceResultType source_result = SourceResultType::BLOCKED;
+			SourceResultType source_result = SourceResultType::HAVE_MORE_OUTPUT;
 			if (!next_batch_blocked) {
 				// "Regular" path: fetch a chunk from the source and push it through the pipeline
 				source_chunk.Reset();

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -221,7 +221,7 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 				}
 			}
 		} else if (!exhausted_source || next_batch_blocked) {
-			SourceResultType source_result;
+			SourceResultType source_result = SourceResultType::BLOCKED;
 			if (!next_batch_blocked) {
 				// "Regular" path: fetch a chunk from the source and push it through the pipeline
 				source_chunk.Reset();
@@ -243,7 +243,6 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 			}
 
 			if (exhausted_source && source_chunk.size() == 0) {
-				// To ensure that we're not early-terminating the pipeline
 				continue;
 			}
 

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -91,6 +91,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"ordered_aggregate_threshold", {Value::UBIGINT(idx_t(1) << 12)}},
 	    {"null_order", {"NULLS_FIRST"}},
 	    {"debug_verify_vector", {"dictionary_expression"}},
+	    {"debug_physical_table_scan_execution_strategy", {"default"}},
 	    {"perfect_ht_threshold", {0}},
 	    {"pivot_filter_threshold", {999}},
 	    {"pivot_limit", {999}},


### PR DESCRIPTION
Follow up to https://github.com/duckdb/duckdb/pull/19422.

File readers might have enough information to know a given amount of rows needs to be returned, and those are the last ones.
Currently this means `{[...some rows...], HAVE_MORE_OUTPUT} + {[], FINISHED}`, while this could be just a `{[... some rows ... ], FINISHED}`.

Conversely `{[], HAVE_MORE_OUTPUT}` was currently forbidden, meaning a scan would have to loop looking for at least a single row, that might block for a while in case of very selective filters.

With this PR, when opting in away from the `results_execution_mode = AsyncResultsExecutionMode::SYNCHRONOUS` then one can freely implicitly return any of the following states:
* `{[...some rows], HAVE_MORE_OUTPUT}`
* `{[...some rows], FINISHED}`
* `{[], HAVE_MORE_OUTPUT}`
* `{[], FINISHED}`
* `{[], BLOCKED}`

While in the default, not opted in case, only 1st, 4th and 5th are available.

Note that as per this PR this does change the behaviour of scans, but not really in a visible way, since the file readers are not taking advantage (yet).

Added testing code that checks both old mode (used in legacy code such as some extensions) and new code works via a setting that allows to change execution strategy.

Examples:
```
./build/release/test/unittest
--- expected to work
./build/release/test/unittest --on-init "SET debug_physical_table_scan_execution_strategy=TASK_EXECUTOR;"
--- equivalent to default, expected to work
./build/release/test/unittest --on-init "SET debug_physical_table_scan_execution_strategy=SYNCHRONOUS;"
--- equivalent to old default, expected to work, a configuration is added to test this case specifically in Main.yml
./build/release/test/unittest --on-init "SET debug_physical_table_scan_execution_strategy=TASK_EXECUTOR_BUT_FORCE_SYNC_CHECKS;" 
---- expected to NOT work in general, will fail in 200 some tests, that are the one where there is a change in behaviour
```