### PR TITLE
Fix edge case in uncompressed validity scan with offset and fix off-by-one in ArrayColumnData::Select

### DIFF
--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -287,6 +287,13 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 			// otherwise the subsequent bitwise & will modify values outside of the range of values we want to alter
 			input_mask |= ValidityUncompressed::UPPER_MASKS[shift_amount];
 
+			if (pos == 0) {
+				// We also need to set the lower bits, which are to the left of the relevant bits (x), to 1
+				// These are the bits that are "behind" this scan window, and should not affect this scan
+				auto non_relevant_mask = ValidityUncompressed::LOWER_MASKS[result_idx];
+				input_mask |= non_relevant_mask;
+			}
+
 			// after this, we move to the next input_entry
 			offset = ValidityMask::BITS_PER_VALUE - input_idx;
 			input_entry++;

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -120,7 +120,7 @@ void ArrayColumnData::Select(TransactionData transaction, idx_t vector_index, Co
 				// not consecutive - break
 				break;
 			}
-			end_idx = next_idx;
+			end_idx = next_idx + 1;
 		}
 		consecutive_ranges++;
 	}


### PR DESCRIPTION
This PR fixes a off-by-one in the consecutive-array-scan optimization implemented in https://github.com/duckdb/duckdb/pull/16356 as well as an edge case in our uncompressed validity data scan.

Fixes https://github.com/duckdb/duckdb/issues/19377

I can't figure out how to write a test for this, it seems like no matter what I do I'm unable to replicate the same storage characteristics as the database file provided in the issue above.

In the repro we do a scan+skip+scan, where part of the first `validity_t` in the second scan contains a bunch of zeroes at the positions "before" the scan window that remain even after shifting. I've solved it by setting all lower bits up to `result_idx` in the first `validity_t` we scan, but not sure if this is the most elegant solution.

Strangely enough If we remove all bitwise logic and just do the same "fall-back" logic as ifdef:ed for `VECTOR_SIZE < 128` it all works though, so the issue has to be part of the bit-manipulation. 
