### PR TITLE
[v1.4-andium] Add Profiler output to logger interface

### DIFF
--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -20,6 +20,7 @@ class PhysicalOperator;
 class AttachedDatabase;
 class RowGroup;
 struct DataTableInfo;
+enum class MetricsType : uint8_t;
 
 //! Log types provide some structure to the formats that the different log messages can have
 //! For now, this holds a type that the VARCHAR value will be auto-cast into.
@@ -104,6 +105,19 @@ public:
 
 	static string ConstructLogMessage(const PhysicalOperator &op, const string &class_p, const string &event,
 	                                  const vector<pair<string, string>> &info);
+};
+
+class MetricsLogType : public LogType {
+public:
+	static constexpr const char *NAME = "Metrics";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_INFO;
+
+	//! Construct the log type
+	MetricsLogType();
+
+	static LogicalType GetLogType();
+
+	static string ConstructLogMessage(const MetricsType &type, const Value &value);
 };
 
 class CheckpointLogType : public LogType {

--- a/src/include/duckdb/main/profiling_info.hpp
+++ b/src/include/duckdb/main/profiling_info.hpp
@@ -56,6 +56,7 @@ public:
 
 public:
 	string GetMetricAsString(const MetricsType metric) const;
+	void WriteMetricsToLog(ClientContext &context);
 	void WriteMetricsToJSON(duckdb_yyjson::yyjson_mut_doc *doc, duckdb_yyjson::yyjson_mut_val *destination);
 
 public:

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -183,6 +183,7 @@ public:
 	static InsertionOrderPreservingMap<string> JSONSanitize(const InsertionOrderPreservingMap<string> &input);
 	static string JSONSanitize(const string &text);
 	static string DrawPadded(const string &str, idx_t width);
+	DUCKDB_API void ToLog() const;
 	DUCKDB_API string ToJSON() const;
 	DUCKDB_API void WriteToFile(const char *path, string &info) const;
 

--- a/src/logging/log_manager.cpp
+++ b/src/logging/log_manager.cpp
@@ -266,6 +266,7 @@ void LogManager::RegisterDefaultLogTypes() {
 	RegisterLogType(make_uniq<HTTPLogType>());
 	RegisterLogType(make_uniq<QueryLogType>());
 	RegisterLogType(make_uniq<PhysicalOperatorLogType>());
+	RegisterLogType(make_uniq<MetricsLogType>());
 }
 
 } // namespace duckdb

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -14,6 +14,7 @@ constexpr LogLevel FileSystemLogType::LEVEL;
 constexpr LogLevel QueryLogType::LEVEL;
 constexpr LogLevel HTTPLogType::LEVEL;
 constexpr LogLevel PhysicalOperatorLogType::LEVEL;
+constexpr LogLevel MetricsLogType::LEVEL;
 constexpr LogLevel CheckpointLogType::LEVEL;
 
 //===--------------------------------------------------------------------===//
@@ -147,6 +148,29 @@ string PhysicalOperatorLogType::ConstructLogMessage(const PhysicalOperator &phys
 
 	return Value::STRUCT(std::move(child_list)).ToString();
 }
+
+//===--------------------------------------------------------------------===//
+// MetricsLogType
+//===--------------------------------------------------------------------===//
+MetricsLogType::MetricsLogType() : LogType(NAME, LEVEL, GetLogType()) {
+}
+
+LogicalType MetricsLogType::GetLogType() {
+	child_list_t<LogicalType> child_list = {
+	    {"metric", LogicalType::VARCHAR},
+	    {"value", LogicalType::VARCHAR},
+	};
+	return LogicalType::STRUCT(child_list);
+}
+
+string MetricsLogType::ConstructLogMessage(const MetricsType &metric, const Value &value) {
+	child_list_t<Value> child_list = {
+	    {"metric", EnumUtil::ToString(metric)},
+	    {"value", value.ToString()},
+	};
+	return Value::STRUCT(std::move(child_list)).ToString();
+}
+
 //===--------------------------------------------------------------------===//
 // CheckpointLogType
 //===--------------------------------------------------------------------===//

--- a/src/main/profiling_info.cpp
+++ b/src/main/profiling_info.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/main/query_profiler.hpp"
+#include "duckdb/logging/log_manager.hpp"
 
 #include "yyjson.hpp"
 
@@ -167,6 +168,16 @@ string ProfilingInfo::GetMetricAsString(const MetricsType metric) const {
 		return EnumUtil::ToString(type);
 	}
 	return metrics.at(metric).ToString();
+}
+
+void ProfilingInfo::WriteMetricsToLog(ClientContext &context) {
+	auto &logger = Logger::Get(context);
+	if (logger.ShouldLog(MetricsLogType::NAME, MetricsLogType::LEVEL)) {
+		for (auto &metric : settings) {
+			logger.WriteLog(MetricsLogType::NAME, MetricsLogType::LEVEL,
+			                MetricsLogType::ConstructLogMessage(metric, metrics[metric]));
+		}
+	}
 }
 
 void ProfilingInfo::WriteMetricsToJSON(yyjson_mut_doc *doc, yyjson_mut_val *dest) {

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -297,6 +297,9 @@ void QueryProfiler::EndQuery() {
 
 	guard.unlock();
 
+	// To log is inexpensive, whether to log or not depends on whether logging is active
+	ToLog();
+
 	if (emit_output) {
 		string tree = ToString();
 		auto save_location = GetSaveLocation();
@@ -795,6 +798,19 @@ static string StringifyAndFree(yyjson_mut_doc *doc, yyjson_mut_val *object) {
 	free(data);
 	yyjson_mut_doc_free(doc);
 	return result;
+}
+
+void QueryProfiler::ToLog() const {
+	lock_guard<std::mutex> guard(lock);
+
+	if (!root) {
+		// No root, not much to do
+		return;
+	}
+
+	auto &settings = root->GetProfilingInfo();
+
+	settings.WriteMetricsToLog(context);
 }
 
 string QueryProfiler::ToJSON() const {

--- a/test/sql/pragma/profiling/test_logging_interaction.test
+++ b/test/sql/pragma/profiling/test_logging_interaction.test
@@ -1,0 +1,37 @@
+# name: test/sql/pragma/profiling/test_logging_interaction.test
+# description: Test profiling all operator types.
+# group: [profiling]
+
+require skip_reload
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/profile_attach.json';
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+ATTACH '__TEST_DIR__/profiler_logger.db' AS my_db;
+
+statement ok
+USE my_db;
+
+statement ok
+call enable_logging();
+
+statement ok
+CREATE TABLE small AS FROM range(100);
+
+statement ok
+CREATE TABLE medium AS FROM range(10000);
+
+statement ok
+CREATE TABLE big AS FROM range(1000000);
+
+statement ok
+PRAGMA disable_profiling;
+
+query I
+SELECT count(*) FROM duckdb_logs() WHERE type == 'Metrics' AND message ILIKE '%CPU_TIME%';
+----
+3


### PR DESCRIPTION
This is https://github.com/duckdb/duckdb/pull/19546 backported to `v1.4-andium` branch, see conversation there.

---

Idea is: if both profiler and logger are enabled, then you can access profiler output also via logger.

This is on top / independent of the current choices for where to output the profiler (JSON / graphviz / query-tree / ...). While this might be somewhat wasteful, it's allow for an easier PR and leave unopinionated what should the SQL interface be. Also given ToLog() call is inexpensive (in particular if the logger is disabled), and that it's unclear if logger alone can satisfy profiler necessities, I think going additive is the best path here.

Demo:
```sql
ATTACH 'my_db.db';
USE my_db;

---- enable profiling to json file
PRAGMA profiling_output = 'profiling_output.json';
PRAGMA enable_profiling = 'json';
---- enable logging (to in-memory table)
call enable_logging();

----
CREATE TABLE small AS FROM range(100);
CREATE TABLE medium AS FROM range(10000);
CREATE TABLE big AS FROM range(1000000);

PRAGMA disable_profiling;

SELECT query_id, type, metric, value FROM duckdb_logs_parsed('Metrics') WHERE metric == 'CPU_TIME';
```
Will result in for example in:
```
┌──────────┬─────────┬──────────┬───────────────────────┐
│ query_id │  type   │  metric  │         value         │
│  uint64  │ varchar │ varchar  │        varchar        │
├──────────┼─────────┼──────────┼───────────────────────┤
│       10 │ Metrics │ CPU_TIME │ 8.1041e-05            │
│       11 │ Metrics │ CPU_TIME │ 0.0002499510000000001 │
│       12 │ Metrics │ CPU_TIME │ 0.02776677799999981   │
└──────────┴─────────┴──────────┴───────────────────────┘
```

A more complex example would be for example:
With the duckdb cli, execute:
```sql
PRAGMA profiling_output = 'metrics_folder/tmp_profiling_output.json';
PRAGMA enable_profiling = 'json';
CALL enable_logging(storage='file', storage_path='./metrics_folder');

--- arbitrary queryies
CREATE TABLE small AS FROM range(100);
CREATE TABLE medium AS FROM range(10000);
CREATE TABLE big AS FROM range(1000000);
```
then close, restart duckdb cli, and query what's persisted in the `metric_folder` folder:
```sql
PRAGMA disable_profiling;
CALL enable_logging(storage='file', storage_path='./metrics_folder');
SELECT queries.message, metrics.metric, TRY_CAST(metrics.value AS DOUBLE) as value
         FROM duckdb_logs_parsed('QueryLog') queries,
                     duckdb_logs_parsed('Metrics') metrics
         WHERE queries.query_id = metrics.query_id AND metrics.metric = 'CPU_TIME';```
```
```
┌─────────────────────────────────────────────┬──────────┬─────────────────────────────────────┐
│                   message                   │  metric  │ TRY_CAST(metrics."value" AS DOUBLE) │
│                   varchar                   │ varchar  │               double                │
├─────────────────────────────────────────────┼──────────┼─────────────────────────────────────┤
│ CREATE TABLE small AS FROM range(100);      │ CPU_TIME │                          8.1041e-05 │
│ CREATE TABLE medium AS FROM range(10000);   │ CPU_TIME │               0.0002499510000000001 │
│ CREATE TABLE big AS FROM range(1000000);    │ CPU_TIME │                 0.02776677799999981 │
└─────────────────────────────────────────────┴──────────┴─────────────────────────────────────┘
```