### PR TITLE
Add a Mermaid Flowchart transformer for EXPLAIN output

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1504,19 +1504,20 @@ const StringUtil::EnumStringLiteral *GetExplainFormatValues() {
 		{ static_cast<uint32_t>(ExplainFormat::JSON), "JSON" },
 		{ static_cast<uint32_t>(ExplainFormat::HTML), "HTML" },
 		{ static_cast<uint32_t>(ExplainFormat::GRAPHVIZ), "GRAPHVIZ" },
-		{ static_cast<uint32_t>(ExplainFormat::YAML), "YAML" }
+		{ static_cast<uint32_t>(ExplainFormat::YAML), "YAML" },
+		{ static_cast<uint32_t>(ExplainFormat::MERMAID), "MERMAID" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<ExplainFormat>(ExplainFormat value) {
-	return StringUtil::EnumToString(GetExplainFormatValues(), 6, "ExplainFormat", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetExplainFormatValues(), 7, "ExplainFormat", static_cast<uint32_t>(value));
 }
 
 template<>
 ExplainFormat EnumUtil::FromString<ExplainFormat>(const char *value) {
-	return static_cast<ExplainFormat>(StringUtil::StringToEnum(GetExplainFormatValues(), 6, "ExplainFormat", value));
+	return static_cast<ExplainFormat>(StringUtil::StringToEnum(GetExplainFormatValues(), 7, "ExplainFormat", value));
 }
 
 const StringUtil::EnumStringLiteral *GetExplainOutputTypeValues() {
@@ -3589,19 +3590,20 @@ const StringUtil::EnumStringLiteral *GetProfilerPrintFormatValues() {
 		{ static_cast<uint32_t>(ProfilerPrintFormat::QUERY_TREE_OPTIMIZER), "QUERY_TREE_OPTIMIZER" },
 		{ static_cast<uint32_t>(ProfilerPrintFormat::NO_OUTPUT), "NO_OUTPUT" },
 		{ static_cast<uint32_t>(ProfilerPrintFormat::HTML), "HTML" },
-		{ static_cast<uint32_t>(ProfilerPrintFormat::GRAPHVIZ), "GRAPHVIZ" }
+		{ static_cast<uint32_t>(ProfilerPrintFormat::GRAPHVIZ), "GRAPHVIZ" },
+		{ static_cast<uint32_t>(ProfilerPrintFormat::MERMAID), "MERMAID" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<ProfilerPrintFormat>(ProfilerPrintFormat value) {
-	return StringUtil::EnumToString(GetProfilerPrintFormatValues(), 6, "ProfilerPrintFormat", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetProfilerPrintFormatValues(), 7, "ProfilerPrintFormat", static_cast<uint32_t>(value));
 }
 
 template<>
 ProfilerPrintFormat EnumUtil::FromString<ProfilerPrintFormat>(const char *value) {
-	return static_cast<ProfilerPrintFormat>(StringUtil::StringToEnum(GetProfilerPrintFormatValues(), 6, "ProfilerPrintFormat", value));
+	return static_cast<ProfilerPrintFormat>(StringUtil::StringToEnum(GetProfilerPrintFormatValues(), 7, "ProfilerPrintFormat", value));
 }
 
 const StringUtil::EnumStringLiteral *GetProfilingCoverageValues() {

--- a/src/common/tree_renderer.cpp
+++ b/src/common/tree_renderer.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/tree_renderer/html_tree_renderer.hpp"
 #include "duckdb/common/tree_renderer/graphviz_tree_renderer.hpp"
 #include "duckdb/common/tree_renderer/yaml_tree_renderer.hpp"
+#include "duckdb/common/tree_renderer/mermaid_tree_renderer.hpp"
 
 #include <sstream>
 
@@ -22,6 +23,8 @@ unique_ptr<TreeRenderer> TreeRenderer::CreateRenderer(ExplainFormat format) {
 		return make_uniq<GRAPHVIZTreeRenderer>();
 	case ExplainFormat::YAML:
 		return make_uniq<YAMLTreeRenderer>();
+	case ExplainFormat::MERMAID:
+		return make_uniq<MermaidTreeRenderer>();
 	default:
 		throw NotImplementedException("ExplainFormat %s not implemented", EnumUtil::ToString(format));
 	}

--- a/src/common/tree_renderer/CMakeLists.txt
+++ b/src/common/tree_renderer/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library_unity(
   graphviz_tree_renderer.cpp
   text_tree_renderer.cpp
   yaml_tree_renderer.cpp
+  mermaid_tree_renderer.cpp
   tree_renderer.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_common_tree_renderer>

--- a/src/common/tree_renderer/mermaid_tree_renderer.cpp
+++ b/src/common/tree_renderer/mermaid_tree_renderer.cpp
@@ -1,0 +1,133 @@
+#include "duckdb/common/tree_renderer/mermaid_tree_renderer.hpp"
+
+#include "duckdb/common/pair.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
+#include "duckdb/execution/operator/join/physical_delim_join.hpp"
+#include "duckdb/execution/operator/scan/physical_positional_scan.hpp"
+#include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/parallel/pipeline.hpp"
+#include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/main/query_profiler.hpp"
+#include "utf8proc_wrapper.hpp"
+
+#include <sstream>
+
+namespace duckdb {
+
+string MermaidTreeRenderer::ToString(const LogicalOperator &op) {
+	duckdb::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+string MermaidTreeRenderer::ToString(const PhysicalOperator &op) {
+	duckdb::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+string MermaidTreeRenderer::ToString(const ProfilingNode &op) {
+	duckdb::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+string MermaidTreeRenderer::ToString(const Pipeline &op) {
+	duckdb::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+void MermaidTreeRenderer::Render(const LogicalOperator &op, std::ostream &ss) {
+	auto tree = RenderTree::CreateRenderTree(op);
+	ToStream(*tree, ss);
+}
+
+void MermaidTreeRenderer::Render(const PhysicalOperator &op, std::ostream &ss) {
+	auto tree = RenderTree::CreateRenderTree(op);
+	ToStream(*tree, ss);
+}
+
+void MermaidTreeRenderer::Render(const ProfilingNode &op, std::ostream &ss) {
+	auto tree = RenderTree::CreateRenderTree(op);
+	ToStream(*tree, ss);
+}
+
+void MermaidTreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
+	auto tree = RenderTree::CreateRenderTree(op);
+	ToStream(*tree, ss);
+}
+
+static string SanitizeMermaidLabel(const string &text) {
+	string result;
+	result.reserve(text.size() * 2); // Reserve more space for potential escape sequences
+	for (size_t i = 0; i < text.size(); i++) {
+		char c = text[i];
+		// Escape backticks and quotes
+		if (c == '`') {
+			result += "\\`";
+		} else if (c == '"') {
+			result += "\\\"";
+		} else if (c == '\\' && i + 1 < text.size() && text[i + 1] == 'n') {
+			// Replace literal "\n" with actual newline for Mermaid markdown
+			result += "\n\t";
+			i++; // Skip the 'n'
+		} else {
+			result += c;
+		}
+	}
+	return result;
+}
+
+void MermaidTreeRenderer::ToStreamInternal(RenderTree &root, std::ostream &ss) {
+	vector<string> nodes;
+	vector<string> edges;
+
+	const string node_format = "    node_%d_%d[\"`**%s**%s`\"]";
+
+	for (idx_t y = 0; y < root.height; y++) {
+		for (idx_t x = 0; x < root.width; x++) {
+			auto node = root.GetNode(x, y);
+			if (!node) {
+				continue;
+			}
+
+			// Build node label with markdown formatting
+			string extra_info;
+			for (auto &item : node->extra_text) {
+				auto &key = item.first;
+				auto &value_raw = item.second;
+
+				auto value = QueryProfiler::JSONSanitize(value_raw);
+				// Add newline and key-value pair
+				extra_info += StringUtil::Format("\n\t%s: %s", key, SanitizeMermaidLabel(value));
+			}
+
+			// Create node with bold operator name and extra info (trim name to remove trailing spaces)
+			auto trimmed_name = node->name;
+			StringUtil::Trim(trimmed_name);
+			nodes.push_back(StringUtil::Format(node_format, x, y, SanitizeMermaidLabel(trimmed_name), extra_info));
+
+			// Create Edge(s)
+			for (auto &coord : node->child_positions) {
+				edges.push_back(StringUtil::Format("    node_%d_%d --> node_%d_%d", x, y, coord.x, coord.y));
+			}
+		}
+	}
+
+	// Output Mermaid flowchart
+	ss << "flowchart TD\n";
+
+	// Output nodes
+	for (auto &node : nodes) {
+		ss << node << "\n\n";
+	}
+
+	// Output edges
+	for (auto &edge : edges) {
+		ss << edge << "\n";
+	}
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/common/enums/explain_format.hpp
+++ b/src/include/duckdb/common/enums/explain_format.hpp
@@ -12,6 +12,6 @@
 
 namespace duckdb {
 
-enum class ExplainFormat : uint8_t { DEFAULT, TEXT, JSON, HTML, GRAPHVIZ, YAML };
+enum class ExplainFormat : uint8_t { DEFAULT, TEXT, JSON, HTML, GRAPHVIZ, YAML, MERMAID };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/enums/profiler_format.hpp
+++ b/src/include/duckdb/common/enums/profiler_format.hpp
@@ -12,6 +12,6 @@
 
 namespace duckdb {
 
-enum class ProfilerPrintFormat : uint8_t { QUERY_TREE, JSON, QUERY_TREE_OPTIMIZER, NO_OUTPUT, HTML, GRAPHVIZ };
+enum class ProfilerPrintFormat : uint8_t { QUERY_TREE, JSON, QUERY_TREE_OPTIMIZER, NO_OUTPUT, HTML, GRAPHVIZ, MERMAID };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/tree_renderer/mermaid_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/mermaid_tree_renderer.hpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/mermaid_tree_renderer.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/main/profiling_node.hpp"
+#include "duckdb/common/tree_renderer.hpp"
+#include "duckdb/common/render_tree.hpp"
+
+namespace duckdb {
+class LogicalOperator;
+class PhysicalOperator;
+class Pipeline;
+struct PipelineRenderNode;
+
+class MermaidTreeRenderer : public TreeRenderer {
+public:
+	explicit MermaidTreeRenderer() {
+	}
+	~MermaidTreeRenderer() override {
+	}
+
+public:
+	string ToString(const LogicalOperator &op);
+	string ToString(const PhysicalOperator &op);
+	string ToString(const ProfilingNode &op);
+	string ToString(const Pipeline &op);
+
+	void Render(const LogicalOperator &op, std::ostream &ss);
+	void Render(const PhysicalOperator &op, std::ostream &ss);
+	void Render(const ProfilingNode &op, std::ostream &ss) override;
+	void Render(const Pipeline &op, std::ostream &ss);
+
+	void ToStreamInternal(RenderTree &root, std::ostream &ss) override;
+};
+
+} // namespace duckdb

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -53,6 +53,8 @@ ProfilerPrintFormat QueryProfiler::GetPrintFormat(ExplainFormat format) const {
 		return ProfilerPrintFormat::HTML;
 	case ExplainFormat::GRAPHVIZ:
 		return ProfilerPrintFormat::GRAPHVIZ;
+	case ExplainFormat::MERMAID:
+		return ProfilerPrintFormat::MERMAID;
 	default:
 		throw NotImplementedException("No mapping from ExplainFormat::%s to ProfilerPrintFormat",
 		                              EnumUtil::ToString(format));
@@ -70,6 +72,8 @@ ExplainFormat QueryProfiler::GetExplainFormat(ProfilerPrintFormat format) const 
 		return ExplainFormat::HTML;
 	case ProfilerPrintFormat::GRAPHVIZ:
 		return ExplainFormat::GRAPHVIZ;
+	case ProfilerPrintFormat::MERMAID:
+		return ExplainFormat::MERMAID;
 	case ProfilerPrintFormat::NO_OUTPUT:
 		throw InternalException("Should not attempt to get ExplainFormat for ProfilerPrintFormat::NO_OUTPUT");
 	default:
@@ -416,7 +420,8 @@ string QueryProfiler::ToString(ProfilerPrintFormat format) const {
 	case ProfilerPrintFormat::NO_OUTPUT:
 		return "";
 	case ProfilerPrintFormat::HTML:
-	case ProfilerPrintFormat::GRAPHVIZ: {
+	case ProfilerPrintFormat::GRAPHVIZ:
+	case ProfilerPrintFormat::MERMAID: {
 		lock_guard<std::mutex> guard(lock);
 		// checking the tree to ensure the query is really empty
 		// the query string is empty when a logical plan is deserialized
@@ -991,6 +996,12 @@ string QueryProfiler::RenderDisabledMessage(ProfilerPrintFormat format) const {
 				    node_0_0 [label="Query profiling is disabled. Use 'PRAGMA enable_profiling;' to enable profiling!"];
 				}
 			)";
+	case ProfilerPrintFormat::MERMAID:
+		return R"(flowchart TD
+    node_0_0["`**DISABLED**
+Query profiling is disabled.
+Use 'PRAGMA enable_profiling;' to enable profiling!`"]
+)";
 	case ProfilerPrintFormat::JSON: {
 		ConvertedJSONHolder json_holder;
 		json_holder.doc = yyjson_mut_doc_new(nullptr);

--- a/src/parser/transform/statement/transform_explain.cpp
+++ b/src/parser/transform/statement/transform_explain.cpp
@@ -11,7 +11,8 @@ ExplainFormat ParseFormat(const Value &val) {
 	auto format_val = val.GetValue<string>();
 	case_insensitive_map_t<ExplainFormat> format_mapping {
 	    {"default", ExplainFormat::DEFAULT}, {"text", ExplainFormat::TEXT},         {"json", ExplainFormat::JSON},
-	    {"html", ExplainFormat::HTML},       {"graphviz", ExplainFormat::GRAPHVIZ}, {"yaml", ExplainFormat::YAML}};
+	    {"html", ExplainFormat::HTML},       {"graphviz", ExplainFormat::GRAPHVIZ}, {"yaml", ExplainFormat::YAML},
+	    {"mermaid", ExplainFormat::MERMAID}};
 	auto it = format_mapping.find(format_val);
 	if (it != format_mapping.end()) {
 		return it->second;

--- a/test/sql/explain/test_explain.test
+++ b/test/sql/explain/test_explain.test
@@ -45,3 +45,8 @@ query II
 EXPLAIN (FORMAT YAML) SELECT SUM(i) FROM (SELECT * FROM integers i1, integers i2 UNION ALL SELECT * FROM integers i1, integers i2);
 ----
 logical_opt	<REGEX>:.*- name: "CROSS_PRODUCT".*
+
+query II
+EXPLAIN (FORMAT MERMAID) SELECT SUM(i) FROM (SELECT * FROM integers i1, integers i2 UNION ALL SELECT * FROM integers i1, integers i2);
+----
+logical_opt	<REGEX>:.*node_0_.*\["`\*\*CROSS_PRODUCT\*\*.*

--- a/test/sql/explain/test_explain_analyze.test
+++ b/test/sql/explain/test_explain_analyze.test
@@ -88,6 +88,11 @@ EXPLAIN (ANALYZE, FORMAT html) SELECT SUM(i) FROM integers
 ----
 analyzed_plan	<REGEX>:.+<div class="title">EXPLAIN_ANALYZE</div>.*
 
+query II
+EXPLAIN (ANALYZE, FORMAT mermaid) SELECT SUM(i) FROM integers
+----
+analyzed_plan	<REGEX>:.+\*\*EXPLAIN_ANALYZE\*\*.*
+
 # Make sure that EXPLAIN ANALYZE still works when no output is specified
 statement ok
 PRAGMA enable_profiling = 'no_output';


### PR DESCRIPTION
# Add Mermaid Format Support for EXPLAIN Plans

This PR adds a new `MERMAID` format option to DuckDB's EXPLAIN statement, enabling visualization of query plans as Mermaid flowchart diagrams.

## What was built
- New `ExplainFormat::MERMAID` and `ProfilerPrintFormat::MERMAID` enum values
- `MermaidTreeRenderer` class that transforms query plans into Mermaid flowchart syntax
- Support for both `EXPLAIN` and `EXPLAIN ANALYZE` statements
- Test coverage following existing format test patterns

## Key features
- Generates valid Mermaid flowchart syntax (`flowchart TD`)
- Uses markdown formatting with bold operator names (`**OPERATOR**`)
- Consistent tab indentation for multi-line node content
- Proper sanitization of special characters (backticks, quotes)
- Clean spacing between node definitions for readability

## Usage
```sql
EXPLAIN (FORMAT MERMAID) SELECT * FROM table;
EXPLAIN (ANALYZE, FORMAT MERMAID) SELECT * FROM table;