### PR TITLE
CLI: Make startup-text display configurable using the .startup_text

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -73,7 +73,7 @@ enum class RenderMode : uint32_t {
 
 enum class PrintOutput { STDOUT, STDERR };
 
-enum class InputMode { STANDARD, FILE };
+enum class InputMode { STANDARD, FILE, DUCKDB_RC };
 
 enum class LargeNumberRendering { NONE = 0, FOOTER = 1, ALL = 2, DEFAULT = 3 };
 
@@ -90,6 +90,7 @@ enum class ShellFlags : uint32_t {
 enum class ShellOpenFlags { EXIT_ON_FAILURE, KEEP_ALIVE_ON_FAILURE };
 enum class SuccessState { SUCCESS, FAILURE };
 enum class OptionType { DEFAULT, ON, OFF };
+enum class StartupText { ALL, VERSION, NONE };
 
 enum class MetadataResult : uint8_t { SUCCESS = 0, FAIL = 1, EXIT = 2, PRINT_USAGE = 3 };
 
@@ -192,6 +193,12 @@ public:
 	OptionType highlight_errors = OptionType::DEFAULT;
 	//! Whether or not we are highlighting results
 	OptionType highlight_results = OptionType::DEFAULT;
+	//! Path to .duckdbrc file
+	string duckdb_rc_path;
+	//! Startup text to display
+	StartupText startup_text = StartupText::ALL;
+	//! Whether or not the loading resources message was displayed
+	bool displayed_loading_resources_message = false;
 
 	/*
 	** Prompt strings. Initialized in main. Settable with

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -375,6 +375,27 @@ MetadataResult ShowConfiguration(ShellState &state, const vector<string> &args) 
 	return MetadataResult::SUCCESS;
 }
 
+MetadataResult SetStartupText(ShellState &state, const vector<string> &args) {
+	auto prev_display = state.startup_text;
+	if (args[1] == "all") {
+		state.startup_text = StartupText::ALL;
+	} else if (args[1] == "version") {
+		state.startup_text = StartupText::VERSION;
+	} else if (args[1] == "none") {
+		state.startup_text = StartupText::NONE;
+	} else {
+		return MetadataResult::PRINT_USAGE;
+	}
+	if (state.displayed_loading_resources_message && prev_display == StartupText::ALL &&
+	    state.startup_text != StartupText::ALL) {
+		ShellHighlight highlight(state);
+		string warning = "WARNING: .startup_text should be on top of your ~/.duckdbrc in order to "
+		                 "prevent the \"Loading resources\" message from being displayed\n";
+		highlight.PrintText(warning, PrintOutput::STDERR, HighlightElementType::STARTUP_TEXT);
+	}
+	return MetadataResult::SUCCESS;
+}
+
 MetadataResult ShowVersion(ShellState &state, const vector<string> &args) {
 	state.PrintF("DuckDB %s (%s) %s\n" /*extra-version-info*/, duckdb::DuckDB::LibraryVersion(),
 	             duckdb::DuckDB::ReleaseCodename(), duckdb::DuckDB::SourceID());
@@ -664,6 +685,8 @@ static const MetadataCommand metadata_commands[] = {
 #ifdef HAVE_LINENOISE
     {"singleline", 1, ToggleSingleLine, "", "Sets the render mode to single-line", 0, ""},
 #endif
+    {"startup_text", 2, SetStartupText, "none|version|all",
+     "Start-up text to display. Set this as the first line in .duckdbrc", 0, ""},
     {"system", 0, RunShellCommand, "CMD ARGS...", "Run CMD ARGS... in a system shell", 0, ""},
     {"tables", 0, ShowTables, "?TABLE?", "List names of tables matching LIKE pattern TABLE", 2, ""},
     {"thousand_sep", 0, SetThousandSep, "SEP",


### PR DESCRIPTION
This PR makes the start-up text that is displayed when launching the CLI configurable using the `.startup_text` command, e.g.:

```
.startup_text [none|version|all]
```

 The default text is as follows:

<img width="564" height="86" alt="Screenshot 2025-11-01 at 12 09 57" src="https://github.com/user-attachments/assets/9e5a8950-3268-48c0-94a6-e340a64f5ad3" />

`.startup_text version` will print only the version:

<img width="584" height="50" alt="Screenshot 2025-11-01 at 12 10 37" src="https://github.com/user-attachments/assets/02be3801-3100-4a5a-8e8c-dfb61c27b241" />

`.startup_text none` will print nothing:

<img width="406" height="30" alt="Screenshot 2025-11-01 at 12 10 20" src="https://github.com/user-attachments/assets/d0b48f78-668e-4a20-97a6-6718207225ee" />

Note that, because the text `-- Loading resources from /Users/myth/.duckdbrc` is printed **before** reading `.duckdbrc` - we hide this text through a small hack. The **first line** of the `.duckdbrc` must contain the `.startup_text` parameter. If it is placed later on in the file, a warning is printed:

<img width="1337" height="70" alt="Screenshot 2025-11-01 at 12 11 51" src="https://github.com/user-attachments/assets/e365de0f-7469-49e4-a4e4-29871b1b9182" />

