### PR TITLE
Skip compiling remote optimizer test when TSAN Is enabled

### DIFF
--- a/test/extension/CMakeLists.txt
+++ b/test/extension/CMakeLists.txt
@@ -22,6 +22,9 @@ if(NOT WIN32 AND NOT SUN)
     ../extension/loadable_extension_optimizer_demo.cpp)
 
   if(${ENABLE_UNITTEST_CPP_TESTS})
+    if(${ENABLE_THREAD_SANITIZER})
+      add_definitions(-DTHREAD_SANITIZER_ENABLED)
+    endif()
     set(TEST_EXT_OBJECTS test_remote_optimizer.cpp)
 
     add_library_unity(test_extensions OBJECT ${TEST_EXT_OBJECTS})

--- a/test/extension/CMakeLists.txt
+++ b/test/extension/CMakeLists.txt
@@ -21,10 +21,7 @@ if(NOT WIN32 AND NOT SUN)
     ${PARAMETERS}
     ../extension/loadable_extension_optimizer_demo.cpp)
 
-  if(${ENABLE_UNITTEST_CPP_TESTS})
-    if(${ENABLE_THREAD_SANITIZER})
-      add_definitions(-DTHREAD_SANITIZER_ENABLED)
-    endif()
+  if(${ENABLE_UNITTEST_CPP_TESTS} AND NOT (${ENABLE_THREAD_SANITIZER}))
     set(TEST_EXT_OBJECTS test_remote_optimizer.cpp)
 
     add_library_unity(test_extensions OBJECT ${TEST_EXT_OBJECTS})

--- a/test/extension/test_remote_optimizer.cpp
+++ b/test/extension/test_remote_optimizer.cpp
@@ -28,6 +28,9 @@ using namespace duckdb;
 using namespace std;
 
 TEST_CASE("Test using a remote optimizer pass in case thats important to someone", "[extension]") {
+#ifdef THREAD_SANITIZER_ENABLED
+	return;
+#endif
 	pid_t pid = fork();
 
 	int port = 4242;

--- a/test/extension/test_remote_optimizer.cpp
+++ b/test/extension/test_remote_optimizer.cpp
@@ -28,9 +28,6 @@ using namespace duckdb;
 using namespace std;
 
 TEST_CASE("Test using a remote optimizer pass in case thats important to someone", "[extension]") {
-#ifdef THREAD_SANITIZER_ENABLED
-	return;
-#endif
 	pid_t pid = fork();
 
 	int port = 4242;


### PR DESCRIPTION
This test uses `fork` which seems to mess up the thread sanitizer, causing strange errors to occur sporadically.