### PR TITLE
Fix uninitialized sorted_tuples member

### DIFF
--- a/src/common/sort/sort.cpp
+++ b/src/common/sort/sort.cpp
@@ -161,8 +161,8 @@ class SortGlobalSinkState : public GlobalSinkState {
 public:
 	explicit SortGlobalSinkState(ClientContext &context)
 	    : num_threads(NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads())),
-	      temporary_memory_state(TemporaryMemoryManager::Get(context).Register(context)),
-	      sorted_tuples(0), external(ClientConfig::GetConfig(context).force_external), any_combined(false), total_count(0),
+	      temporary_memory_state(TemporaryMemoryManager::Get(context).Register(context)), sorted_tuples(0),
+	      external(ClientConfig::GetConfig(context).force_external), any_combined(false), total_count(0),
 	      partition_size(0) {
 	}
 

--- a/src/common/sort/sort.cpp
+++ b/src/common/sort/sort.cpp
@@ -162,7 +162,7 @@ public:
 	explicit SortGlobalSinkState(ClientContext &context)
 	    : num_threads(NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads())),
 	      temporary_memory_state(TemporaryMemoryManager::Get(context).Register(context)),
-	      external(ClientConfig::GetConfig(context).force_external), any_combined(false), total_count(0),
+	      sorted_tuples(0), external(ClientConfig::GetConfig(context).force_external), any_combined(false), total_count(0),
 	      partition_size(0) {
 	}
 


### PR DESCRIPTION
This patch fixes uninitialized `sorted_tuples` member in `SortGlobalSinkState` constructor.

Static analyzers flag that `sorted_tuples` was not initialized in the constructor. This change explicitly initializes it to 0 in the member initializer list.

**Changes:**
- Added initialization of `sorted_tuples` to 0 in constructor member initializer list

This ensures all members are properly initialized and fixes compiler warnings.

**Files changed:**
- `src/common/sort/sort.cpp`