### PR TITLE
Tweak Relation::Query()

### DIFF
--- a/src/main/relation.cpp
+++ b/src/main/relation.cpp
@@ -337,7 +337,9 @@ unique_ptr<QueryResult> Relation::Query(const string &sql) const {
 }
 
 unique_ptr<QueryResult> Relation::Query(const string &name, const string &sql) {
-	CreateView(name);
+    bool replace = true;
+    bool temp = IsReadOnly();
+	CreateView(name, replace, temp);
 	return Query(sql);
 }
 

--- a/src/main/relation.cpp
+++ b/src/main/relation.cpp
@@ -337,8 +337,8 @@ unique_ptr<QueryResult> Relation::Query(const string &sql) const {
 }
 
 unique_ptr<QueryResult> Relation::Query(const string &name, const string &sql) {
-    bool replace = true;
-    bool temp = IsReadOnly();
+	bool replace = true;
+	bool temp = IsReadOnly();
 	CreateView(name, replace, temp);
 	return Query(sql);
 }


### PR DESCRIPTION
This patch modifies the `Relation::Query()` method to use temporary views for read-only relations.

The previous implementation would create permanent views which could cause issues with read-only database connections. This change makes the view creation depend on whether the relation is read-only, creating temporary views in that case.

**Changes:**
- Modified `Relation::Query(name, sql)` to use `replace=true` and `temp=IsReadOnly()`
- `CreateView` is now called with appropriate flags for read-only relations

This fixes issue duckdb/duckdb-r#138.

**Files changed:**
- `src/main/relation.cpp`

**Reference:**
https://github.com/duckdb/duckdb-r/issues/138