### PR TITLE
New EXTENSION_RELATION type

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3714,19 +3714,20 @@ const StringUtil::EnumStringLiteral *GetRelationTypeValues() {
 		{ static_cast<uint32_t>(RelationType::VIEW_RELATION), "VIEW_RELATION" },
 		{ static_cast<uint32_t>(RelationType::QUERY_RELATION), "QUERY_RELATION" },
 		{ static_cast<uint32_t>(RelationType::DELIM_JOIN_RELATION), "DELIM_JOIN_RELATION" },
-		{ static_cast<uint32_t>(RelationType::DELIM_GET_RELATION), "DELIM_GET_RELATION" }
+		{ static_cast<uint32_t>(RelationType::DELIM_GET_RELATION), "DELIM_GET_RELATION" },
+		{ static_cast<uint32_t>(RelationType::EXTENSION_RELATION), "EXTENSION_RELATION" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<RelationType>(RelationType value) {
-	return StringUtil::EnumToString(GetRelationTypeValues(), 28, "RelationType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetRelationTypeValues(), 29, "RelationType", static_cast<uint32_t>(value));
 }
 
 template<>
 RelationType EnumUtil::FromString<RelationType>(const char *value) {
-	return static_cast<RelationType>(StringUtil::StringToEnum(GetRelationTypeValues(), 28, "RelationType", value));
+	return static_cast<RelationType>(StringUtil::StringToEnum(GetRelationTypeValues(), 29, "RelationType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetRenderModeValues() {

--- a/src/common/enums/relation_type.cpp
+++ b/src/common/enums/relation_type.cpp
@@ -61,6 +61,8 @@ string RelationTypeToString(RelationType type) {
 		return "VIEW_RELATION";
 	case RelationType::QUERY_RELATION:
 		return "QUERY_RELATION";
+	case RelationType::EXTENSION_RELATION:
+		return "EXTENSION_RELATION";
 	case RelationType::INVALID_RELATION:
 		break;
 	}

--- a/src/include/duckdb/common/enums/relation_type.hpp
+++ b/src/include/duckdb/common/enums/relation_type.hpp
@@ -43,7 +43,8 @@ enum class RelationType : uint8_t {
 	VIEW_RELATION,
 	QUERY_RELATION,
 	DELIM_JOIN_RELATION,
-	DELIM_GET_RELATION
+	DELIM_GET_RELATION,
+	EXTENSION_RELATION = 255
 };
 
 string RelationTypeToString(RelationType type);


### PR DESCRIPTION
This patch adds support for `EXTENSION_RELATION` type to the `RelationType` enum.

This change adds a new relation type (`EXTENSION_RELATION = 255`) to support extension-defined relations. The enum utilities are updated to include this new type in string conversions.

**Changes:**
- Added `EXTENSION_RELATION = 255` to `RelationType` enum in `relation_type.hpp`
- Added `EXTENSION_RELATION` case to `RelationTypeToString()` in `relation_type.cpp`
- Updated enum string utilities in `enum_util.cpp` to include `EXTENSION_RELATION`
- Updated array size from 28 to 29 elements in `EnumUtil` template functions

This allows DuckDB extensions to define custom relation types.

**Files changed:**
- `src/common/enum_util.cpp`
- `src/common/enums/relation_type.cpp`
- `src/include/duckdb/common/enums/relation_type.hpp`