### PR TITLE
Fix uninitialized members in CachedFile constructor

### DIFF
--- a/src/storage/external_file_cache.cpp
+++ b/src/storage/external_file_cache.cpp
@@ -57,7 +57,8 @@ void ExternalFileCache::CachedFileRange::VerifyCheckSum() {
 #endif
 }
 
-ExternalFileCache::CachedFile::CachedFile(string path_p) : path(std::move(path_p)) {
+ExternalFileCache::CachedFile::CachedFile(string path_p)
+    : path(std::move(path_p)), file_size(0), last_modified(0), can_seek(false), on_disk_file(false) {
 }
 
 void ExternalFileCache::CachedFile::Verify(const unique_ptr<StorageLockKey> &guard) const {


### PR DESCRIPTION
This patch fixes uninitialized member variables in `CachedFile` constructor.

Static analyzers flag that several member variables in `CachedFile` were not initialized in the constructor. This change explicitly initializes `file_size`, `last_modified`, `can_seek`, and `on_disk_file` to their default values.

**Changes:**
- Added initialization of `file_size` to 0
- Added initialization of `last_modified` to 0
- Added initialization of `can_seek` to false
- Added initialization of `on_disk_file` to false

This fixes compiler warnings and ensures predictable initial state.

**Files changed:**
- `src/storage/external_file_cache.cpp`