### PR TITLE
Fix uninitialized members in HashJoinGlobalSourceState

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1157,7 +1157,8 @@ unique_ptr<LocalSourceState> PhysicalHashJoin::GetLocalSourceState(ExecutionCont
 HashJoinGlobalSourceState::HashJoinGlobalSourceState(const PhysicalHashJoin &op, const ClientContext &context)
     : op(op), global_stage(HashJoinSourceStage::INIT), build_chunk_count(0), build_chunk_done(0), probe_chunk_count(0),
       probe_chunk_done(0), probe_count(op.children[0].get().estimated_cardinality),
-      parallel_scan_chunk_count(context.config.verify_parallelism ? 1 : 120) {
+      parallel_scan_chunk_count(context.config.verify_parallelism ? 1 : 120), full_outer_chunk_count(0),
+      full_outer_chunk_done(0) {
 }
 
 void HashJoinGlobalSourceState::Initialize(HashJoinGlobalSinkState &sink) {


### PR DESCRIPTION
This patch fixes uninitialized member variables in `HashJoinGlobalSourceState` constructor.

Static analyzers flag that `full_outer_chunk_count` and `full_outer_chunk_done` were not initialized in the constructor. This change explicitly initializes them to 0.

**Changes:**
- Added initialization of `full_outer_chunk_count` to 0
- Added initialization of `full_outer_chunk_done` to 0

This fixes compiler warnings and ensures predictable initial state for hash join operations.

**Files changed:**
- `src/execution/operator/join/physical_hash_join.cpp`