### PR TITLE
Guard printing in CSV scanner

### DIFF
--- a/src/include/duckdb/execution/operator/csv_scanner/csv_state_machine.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_state_machine.hpp
@@ -129,12 +129,14 @@ public:
 	}
 
 	void Print() const {
+#ifndef DUCKDB_DISABLE_PRINT
 		std::cout << "State Machine Options" << '\n';
 		std::cout << "Delim: " << state_machine_options.delimiter.GetValue() << '\n';
 		std::cout << "Quote: " << state_machine_options.quote.GetValue() << '\n';
 		std::cout << "Escape: " << state_machine_options.escape.GetValue() << '\n';
 		std::cout << "Comment: " << state_machine_options.comment.GetValue() << '\n';
 		std::cout << "---------------------" << '\n';
+#endif
 	}
 	//! The Transition Array is a Finite State Machine
 	//! It holds the transitions of all states, on all 256 possible different characters

--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -258,8 +258,10 @@ void BufferingLogStorage::UpdateConfigInternal(DatabaseInstance &db, case_insens
 }
 
 void StdOutLogStorage::StdOutWriteStream::WriteData(const_data_ptr_t buffer, idx_t write_size) {
+#ifndef DUCKDB_DISABLE_PRINT
 	std::cout.write(const_char_ptr_cast(buffer), NumericCast<int64_t>(write_size));
 	std::cout.flush();
+#endif
 }
 
 StdOutLogStorage::StdOutLogStorage(DatabaseInstance &db) : CSVLogStorage(db, false, 1) {


### PR DESCRIPTION
This patch conditionally disables debug printing in CSV scanner and logging.

CRAN policies discourage packages from printing to stdout/stderr. This change guards CSV state machine and log storage printing with `#ifndef DUCKDB_DISABLE_PRINT`.

**Changes:**
- Wrapped `CSVStateMachine::Print()` std::cout usage in `#ifndef DUCKDB_DISABLE_PRINT`
- Wrapped `StdOutWriteStream::WriteData()` std::cout usage in `#ifndef DUCKDB_DISABLE_PRINT`

This allows CRAN builds to disable debug printing while keeping it available for development.

**Files changed:**
- `src/include/duckdb/execution/operator/csv_scanner/csv_state_machine.hpp`
- `src/logging/log_storage.cpp`