### PR TITLE
Replace deprecated <ctgmath> header

### DIFF
--- a/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
@@ -9,7 +9,8 @@
 #pragma once
 
 #include "duckdb/function/aggregate_function.hpp"
-#include <ctgmath>
+#include <complex>
+#include <cmath>
 
 namespace duckdb {
 


### PR DESCRIPTION
This patch replaces deprecated `<ctgmath>` header with standard C++ headers.

The `<ctgmath>` header is deprecated in C++17 and removed in C++20. This change uses `<complex>` and `<cmath>` instead, which provide the same functionality and are the modern C++ approach.

**Changes:**
- Replaced `#include <ctgmath>` with `#include <complex>` and `#include <cmath>`
- Applied to `stddev.hpp` in `core_functions` aggregate

This ensures compatibility with newer C++ standards and avoids deprecation warnings.

**Files changed:**
- `extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp`