### PR TITLE
const-safe: Add const handling for list_entry_t

### DIFF
--- a/src/include/duckdb/common/type_util.hpp
+++ b/src/include/duckdb/common/type_util.hpp
@@ -73,7 +73,7 @@ PhysicalType GetTypeId() {
 		return PhysicalType::VARCHAR;
 	} else if (std::is_same<T, interval_t>()) {
 		return PhysicalType::INTERVAL;
-	} else if (std::is_same<T, list_entry_t>()) {
+	} else if (std::is_same<T, const list_entry_t>() || std::is_same<T, list_entry_t>()) {
 		return PhysicalType::LIST;
 	} else if (std::is_pointer<T>() || std::is_same<T, uintptr_t>()) {
 		if (sizeof(uintptr_t) == sizeof(uint32_t)) {

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -501,6 +501,13 @@ struct FlatVector {
 };
 
 struct ListVector {
+	static inline const list_entry_t *GetData(const Vector &v) {
+		if (v.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+			auto &child = DictionaryVector::Child(v);
+			return GetData(child);
+		}
+		return FlatVector::GetData<const list_entry_t>(v);
+	}
 	static inline list_entry_t *GetData(Vector &v) {
 		if (v.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 			auto &child = DictionaryVector::Child(v);


### PR DESCRIPTION
This patch adds const-safe handling for `list_entry_t` in vector operations.

The code was missing support for `const list_entry_t` in `GetTypeId()` template and `ListVector::GetData()`. This change adds proper const handling to avoid compilation errors when working with const vectors.

**Changes:**
- Added `std::is_same<T, const list_entry_t>()` check in `GetTypeId()` template
- Added const overload of `ListVector::GetData()` that returns `const list_entry_t*`
- The const version properly handles dictionary vectors by recursing to child

This improves const-correctness and enables working with const vector types.

**Files changed:**
- `src/include/duckdb/common/type_util.hpp`
- `src/include/duckdb/common/types/vector.hpp`