### PR TITLE
Fix uninitialized physical_type in move constructor

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -32,7 +32,8 @@ namespace duckdb {
 UnifiedVectorFormat::UnifiedVectorFormat() : sel(nullptr), data(nullptr), physical_type(PhysicalType::INVALID) {
 }
 
-UnifiedVectorFormat::UnifiedVectorFormat(UnifiedVectorFormat &&other) noexcept : sel(nullptr), data(nullptr) {
+UnifiedVectorFormat::UnifiedVectorFormat(UnifiedVectorFormat &&other) noexcept
+    : sel(nullptr), data(nullptr), physical_type(PhysicalType::INVALID) {
 	bool refers_to_self = other.sel == &other.owned_sel;
 	std::swap(sel, other.sel);
 	std::swap(data, other.data);


### PR DESCRIPTION
This patch fixes uninitialized member variable in `UnifiedVectorFormat` move constructor.

Static analyzers flag that `physical_type` was not initialized in the move constructor. This change explicitly initializes it to `PhysicalType::INVALID` to match the default constructor.

**Changes:**
- Added initialization of `physical_type` to `PhysicalType::INVALID` in move constructor

This ensures consistent initialization across all constructors and fixes compiler warnings.

**Files changed:**
- `src/common/types/vector.cpp`