### PR TITLE
Use std::remove_cv for physical type id fetching

### DIFF
--- a/src/include/duckdb/common/type_util.hpp
+++ b/src/include/duckdb/common/type_util.hpp
@@ -22,60 +22,62 @@ struct bignum_t;
 //! Returns the PhysicalType for the given type
 template <class T>
 PhysicalType GetTypeId() {
-	if (std::is_same<T, bool>()) {
+	using TYPE = std::remove_cv<T>::type;
+
+	if (std::is_same<TYPE, bool>()) {
 		return PhysicalType::BOOL;
-	} else if (std::is_same<T, int8_t>()) {
+	} else if (std::is_same<TYPE, int8_t>()) {
 		return PhysicalType::INT8;
-	} else if (std::is_same<T, int16_t>()) {
+	} else if (std::is_same<TYPE, int16_t>()) {
 		return PhysicalType::INT16;
-	} else if (std::is_same<T, int32_t>()) {
+	} else if (std::is_same<TYPE, int32_t>()) {
 		return PhysicalType::INT32;
-	} else if (std::is_same<T, int64_t>()) {
+	} else if (std::is_same<TYPE, int64_t>()) {
 		return PhysicalType::INT64;
-	} else if (std::is_same<T, uint8_t>()) {
+	} else if (std::is_same<TYPE, uint8_t>()) {
 		return PhysicalType::UINT8;
-	} else if (std::is_same<T, uint16_t>()) {
+	} else if (std::is_same<TYPE, uint16_t>()) {
 		return PhysicalType::UINT16;
-	} else if (std::is_same<T, uint32_t>()) {
+	} else if (std::is_same<TYPE, uint32_t>()) {
 		return PhysicalType::UINT32;
-	} else if (std::is_same<T, uint64_t>()) {
+	} else if (std::is_same<TYPE, uint64_t>()) {
 		return PhysicalType::UINT64;
-	} else if (std::is_same<T, idx_t>() || std::is_same<T, const idx_t>()) {
+	} else if (std::is_same<TYPE, idx_t>() || std::is_same<TYPE, const idx_t>()) {
 		return PhysicalType::UINT64;
-	} else if (std::is_same<T, hugeint_t>()) {
+	} else if (std::is_same<TYPE, hugeint_t>()) {
 		return PhysicalType::INT128;
-	} else if (std::is_same<T, uhugeint_t>()) {
+	} else if (std::is_same<TYPE, uhugeint_t>()) {
 		return PhysicalType::UINT128;
-	} else if (std::is_same<T, date_t>()) {
+	} else if (std::is_same<TYPE, date_t>()) {
 		return PhysicalType::INT32;
-	} else if (std::is_same<T, dtime_t>()) {
+	} else if (std::is_same<TYPE, dtime_t>()) {
 		return PhysicalType::INT64;
-	} else if (std::is_same<T, dtime_tz_t>()) {
+	} else if (std::is_same<TYPE, dtime_tz_t>()) {
 		return PhysicalType::INT64;
-	} else if (std::is_same<T, dtime_ns_t>()) {
+	} else if (std::is_same<TYPE, dtime_ns_t>()) {
 		return PhysicalType::INT64;
-	} else if (std::is_same<T, timestamp_t>()) {
+	} else if (std::is_same<TYPE, timestamp_t>()) {
 		return PhysicalType::INT64;
-	} else if (std::is_same<T, timestamp_sec_t>()) {
+	} else if (std::is_same<TYPE, timestamp_sec_t>()) {
 		return PhysicalType::INT64;
-	} else if (std::is_same<T, timestamp_ms_t>()) {
+	} else if (std::is_same<TYPE, timestamp_ms_t>()) {
 		return PhysicalType::INT64;
-	} else if (std::is_same<T, timestamp_ns_t>()) {
+	} else if (std::is_same<TYPE, timestamp_ns_t>()) {
 		return PhysicalType::INT64;
-	} else if (std::is_same<T, timestamp_tz_t>()) {
+	} else if (std::is_same<TYPE, timestamp_tz_t>()) {
 		return PhysicalType::INT64;
-	} else if (std::is_same<T, float>() || std::is_same<T, float_na_equal>()) {
+	} else if (std::is_same<TYPE, float>() || std::is_same<TYPE, float_na_equal>()) {
 		return PhysicalType::FLOAT;
-	} else if (std::is_same<T, double>() || std::is_same<T, double_na_equal>()) {
+	} else if (std::is_same<TYPE, double>() || std::is_same<TYPE, double_na_equal>()) {
 		return PhysicalType::DOUBLE;
-	} else if (std::is_same<T, const char *>() || std::is_same<T, char *>() || std::is_same<T, string_t>() ||
-	           std::is_same<T, bignum_t>()) {
+	} else if (std::is_same<TYPE, const char *>() || std::is_same<TYPE, char *>() || std::is_same<TYPE, string_t>() ||
+	           std::is_same<TYPE, bignum_t>()) {
 		return PhysicalType::VARCHAR;
-	} else if (std::is_same<T, interval_t>()) {
+	} else if (std::is_same<TYPE, interval_t>()) {
 		return PhysicalType::INTERVAL;
-	} else if (std::is_same<T, const list_entry_t>() || std::is_same<T, list_entry_t>()) {
+	} else if (std::is_same<TYPE, list_entry_t>()) {
 		return PhysicalType::LIST;
-	} else if (std::is_pointer<T>() || std::is_same<T, uintptr_t>()) {
+	} else if (std::is_pointer<T>() || std::is_same<TYPE, uintptr_t>()) {
 		if (sizeof(uintptr_t) == sizeof(uint32_t)) {
 			return PhysicalType::UINT32;
 		} else if (sizeof(uintptr_t) == sizeof(uint64_t)) {
@@ -90,10 +92,10 @@ PhysicalType GetTypeId() {
 
 template <class T>
 bool StorageTypeCompatible(PhysicalType type) {
-	if (std::is_same<T, int8_t>()) {
+	if (std::is_same<TYPE, int8_t>()) {
 		return type == PhysicalType::INT8 || type == PhysicalType::BOOL;
 	}
-	if (std::is_same<T, uint8_t>()) {
+	if (std::is_same<TYPE, uint8_t>()) {
 		return type == PhysicalType::UINT8 || type == PhysicalType::BOOL;
 	}
 	return type == GetTypeId<T>();
@@ -101,8 +103,8 @@ bool StorageTypeCompatible(PhysicalType type) {
 
 template <class T>
 bool TypeIsNumber() {
-	return std::is_integral<T>() || std::is_floating_point<T>() || std::is_same<T, hugeint_t>() ||
-	       std::is_same<T, uhugeint_t>();
+	return std::is_integral<T>() || std::is_floating_point<T>() || std::is_same<TYPE, hugeint_t>() ||
+	       std::is_same<TYPE, uhugeint_t>();
 }
 
 template <class T>

--- a/src/include/duckdb/common/type_util.hpp
+++ b/src/include/duckdb/common/type_util.hpp
@@ -22,7 +22,7 @@ struct bignum_t;
 //! Returns the PhysicalType for the given type
 template <class T>
 PhysicalType GetTypeId() {
-	using TYPE = std::remove_cv<T>::type;
+	using TYPE = typename std::remove_cv<T>::type;
 
 	if (std::is_same<TYPE, bool>()) {
 		return PhysicalType::BOOL;
@@ -77,7 +77,7 @@ PhysicalType GetTypeId() {
 		return PhysicalType::INTERVAL;
 	} else if (std::is_same<TYPE, list_entry_t>()) {
 		return PhysicalType::LIST;
-	} else if (std::is_pointer<T>() || std::is_same<TYPE, uintptr_t>()) {
+	} else if (std::is_pointer<TYPE>() || std::is_same<TYPE, uintptr_t>()) {
 		if (sizeof(uintptr_t) == sizeof(uint32_t)) {
 			return PhysicalType::UINT32;
 		} else if (sizeof(uintptr_t) == sizeof(uint64_t)) {
@@ -92,6 +92,8 @@ PhysicalType GetTypeId() {
 
 template <class T>
 bool StorageTypeCompatible(PhysicalType type) {
+	using TYPE = typename std::remove_cv<T>::type;
+
 	if (std::is_same<TYPE, int8_t>()) {
 		return type == PhysicalType::INT8 || type == PhysicalType::BOOL;
 	}
@@ -103,7 +105,9 @@ bool StorageTypeCompatible(PhysicalType type) {
 
 template <class T>
 bool TypeIsNumber() {
-	return std::is_integral<T>() || std::is_floating_point<T>() || std::is_same<TYPE, hugeint_t>() ||
+	using TYPE = typename std::remove_cv<T>::type;
+
+	return std::is_integral<TYPE>() || std::is_floating_point<TYPE>() || std::is_same<TYPE, hugeint_t>() ||
 	       std::is_same<TYPE, uhugeint_t>();
 }
 


### PR DESCRIPTION
This PR follows https://github.com/duckdb/duckdb/pull/19603.
My understanding is: if one of the types could be `const`, same thing could happen for other types as well, the best solution is to remove const and volatile specifier before matching.

Some TODO items after C++ upgrade to C++17:
- `std::remove_cv_t` could be leveraged
- `if constexpr` is supported in C++17 to enable compile-time calculation