### PR TITLE
Improve error message around compression type deprecation/availability checks

### DIFF
--- a/scripts/generate_enum_util.py
+++ b/scripts/generate_enum_util.py
@@ -15,6 +15,7 @@ blacklist = [
     "DictionaryAppendState",
     "DictFSSTMode",
     "ComplexJSONType",
+    "UnavailableReason",
 ]
 
 enum_util_header_file = os.path.join("..", "src", "include", "duckdb", "common", "enum_util.hpp")

--- a/src/include/duckdb/common/enums/compression_type.hpp
+++ b/src/include/duckdb/common/enums/compression_type.hpp
@@ -37,6 +37,7 @@ enum class CompressionType : uint8_t {
 };
 
 struct CompressionAvailabilityResult {
+private:
 	enum class UnavailableReason : uint8_t {
 		AVAILABLE,
 		//! Introduced later, not available to this version

--- a/src/include/duckdb/common/enums/compression_type.hpp
+++ b/src/include/duckdb/common/enums/compression_type.hpp
@@ -36,8 +36,47 @@ enum class CompressionType : uint8_t {
 	COMPRESSION_COUNT // This has to stay the last entry of the type!
 };
 
-bool CompressionTypeIsDeprecated(CompressionType compression_type,
-                                 optional_ptr<StorageManager> storage_manager = nullptr);
+struct CompressionAvailabilityResult {
+	enum class UnavailableReason : uint8_t {
+		AVAILABLE,
+		//! Introduced later, not available to this version
+		NOT_AVAILABLE_YET,
+		//! Used to be available, but isnt anymore
+		DEPRECATED
+	};
+
+public:
+	CompressionAvailabilityResult() = default;
+	static CompressionAvailabilityResult Deprecated() {
+		return CompressionAvailabilityResult(UnavailableReason::DEPRECATED);
+	}
+	static CompressionAvailabilityResult NotAvailableYet() {
+		return CompressionAvailabilityResult(UnavailableReason::NOT_AVAILABLE_YET);
+	}
+
+public:
+	bool IsAvailable() const {
+		return reason == UnavailableReason::AVAILABLE;
+	}
+	bool IsDeprecated() {
+		D_ASSERT(!IsAvailable());
+		return reason == UnavailableReason::DEPRECATED;
+	}
+	bool IsNotAvailableYet() {
+		D_ASSERT(!IsAvailable());
+		return reason == UnavailableReason::NOT_AVAILABLE_YET;
+	}
+
+private:
+	explicit CompressionAvailabilityResult(UnavailableReason reason) : reason(reason) {
+	}
+
+public:
+	UnavailableReason reason = UnavailableReason::AVAILABLE;
+};
+
+CompressionAvailabilityResult CompressionTypeIsAvailable(CompressionType compression_type,
+                                                         optional_ptr<StorageManager> storage_manager = nullptr);
 vector<string> ListCompressionTypes(void);
 CompressionType CompressionTypeFromString(const string &str);
 string CompressionTypeToString(CompressionType type);

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -961,9 +961,15 @@ void ForceCompressionSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, 
 	} else {
 		auto compression_type = CompressionTypeFromString(compression);
 		//! FIXME: do we want to try to retrieve the AttachedDatabase here to get the StorageManager ??
-		if (CompressionTypeIsDeprecated(compression_type)) {
-			throw ParserException("Attempted to force a deprecated compression type (%s)",
-			                      CompressionTypeToString(compression_type));
+		auto compression_availability_result = CompressionTypeIsAvailable(compression_type);
+		if (!compression_availability_result.IsAvailable()) {
+			if (compression_availability_result.IsDeprecated()) {
+				throw ParserException("Attempted to force a deprecated compression type (%s)",
+				                      CompressionTypeToString(compression_type));
+			} else {
+				throw ParserException("Attempted to force a compression type that isn't available yet (%s)",
+				                      CompressionTypeToString(compression_type));
+			}
 		}
 		if (compression_type == CompressionType::COMPRESSION_AUTO) {
 			auto compression_types = StringUtil::Join(ListCompressionTypes(), ", ");

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -112,7 +112,7 @@ CompressionType ForceCompression(StorageManager &storage_manager,
 	// auto compression_availability_result = CompressionTypeIsAvailable(compression_type, storage_manager);
 	// if (!compression_availability_result.IsAvailable()) {
 	//	throw InvalidInputException("The forced compression method (%s) is not available in the current storage
-	//version", CompressionTypeToString(compression_type));
+	// version", CompressionTypeToString(compression_type));
 	//}
 
 	bool found = false;

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -109,9 +109,10 @@ CompressionType ForceCompression(StorageManager &storage_manager,
                                  CompressionType compression_type) {
 	// One of the force_compression flags has been set
 	// check if this compression method is available
-	// if (CompressionTypeIsDeprecated(compression_type, storage_manager)) {
+	// auto compression_availability_result = CompressionTypeIsAvailable(compression_type, storage_manager);
+	// if (!compression_availability_result.IsAvailable()) {
 	//	throw InvalidInputException("The forced compression method (%s) is not available in the current storage
-	// version", 	                            CompressionTypeToString(compression_type));
+	//version", CompressionTypeToString(compression_type));
 	//}
 
 	bool found = false;

--- a/test/sql/storage/compression/test_using_compression.test
+++ b/test/sql/storage/compression/test_using_compression.test
@@ -24,3 +24,8 @@ statement ok
 CREATE OR REPLACE TABLE t(
 	x VARCHAR USING COMPRESSION Dictionary
 );
+
+statement error
+create table foo (str VARCHAR USING COMPRESSION 'dict_fsst');
+----
+Binder Error: Can't compress using user-provided compression type 'DICT_FSST', that type is not available yet


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/6436

The old code kept only a list of "deprecated" types, and returned a boolean, losing the context whether the compression type was available at one point and is now deprecated OR is newly introduced and not available yet in the storage version that is currently used.