### PR TITLE
Bump: spatial

### DIFF
--- a/.github/config/extensions/spatial.cmake
+++ b/.github/config/extensions/spatial.cmake
@@ -3,7 +3,7 @@ if (${BUILD_COMPLETE_EXTENSION_SET})
 duckdb_extension_load(spatial
     DONT_LINK LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-spatial
-    GIT_TAG 61ede09becdc06c4a3d0df1c1e8361be478142be
+    GIT_TAG d83faf88cd7e4d4cca4edd056a530382c5018654
     INCLUDE_DIR src/spatial
     TEST_DIR test/sql
     )

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -599,6 +599,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"st_envelope", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"st_envelope_agg", "spatial", CatalogType::AGGREGATE_FUNCTION_ENTRY},
     {"st_equals", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"st_expand", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"st_extent", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"st_extent_agg", "spatial", CatalogType::AGGREGATE_FUNCTION_ENTRY},
     {"st_extent_approx", "spatial", CatalogType::SCALAR_FUNCTION_ENTRY},


### PR DESCRIPTION
This PR bumps the following extensions:
- `spatial` from `61ede09bec` to `d83faf88cd`
