### PR TITLE
Increase cast-cost of old-style implicit cast to string

### DIFF
--- a/src/function/cast/cast_function_set.cpp
+++ b/src/function/cast/cast_function_set.cpp
@@ -184,7 +184,9 @@ int64_t CastFunctionSet::ImplicitCastCost(optional_ptr<ClientContext> context, c
 			old_implicit_casting = DBConfig::GetSetting<OldImplicitCastingSetting>(*config);
 		}
 		if (old_implicit_casting) {
-			score = 149;
+			// very high cost to avoid choosing this cast if any other option is available
+			// (it should be more costly than casting to TEMPLATE if that is available)
+			score = 10000000000;
 		}
 	}
 	return score;

--- a/test/sql/binder/old_implicit_cast_template.test
+++ b/test/sql/binder/old_implicit_cast_template.test
@@ -1,0 +1,22 @@
+# name: test/sql/binder/old_implicit_cast_template.test
+# description: Test old_implicit_cast setting
+# group: [binder]
+
+# Old-style casting should not select an overload by casting to string
+# if there is a templated overload that fits better.
+
+statement ok
+create table t1 as select * from values ('1-2', '3-4', 'a-z', NULL) as r(v);
+
+query I
+SELECT list_extract(string_split(v, '-'), 1) FROM t1;
+----
+1
+
+statement ok
+SET old_implicit_casting = true;
+
+query I
+SELECT list_extract(string_split(v, '-'), 1) FROM t1;
+----
+1


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb-python/issues/148

The issue is that `list_extract` now has two overloads, one for a templated list `LIST<T>` and for concrete `VARCHAR` inputs. When binding a function we add a really high cost to selecting a templated overload to ensure we always pick something more specific if available. With our current casting rules, we are unable to cast `VARHCAR[]` to `VARCHAR`, and therefore fall back to the list-template as expected. But with old-style casting rules we allow `VARCHAR[]` to `VARCHAR` by also adding a high cost penalty, but its still lower than the cost of casting to the template - even though that would be the better alternative. 

With old-style casting we basically always have a lower-cost "fallback" option than selecting a template overload. While we should overhaul our casting system to evaluate the cast cost along more axes than just "score", this PR fixes this specific case by just cranking up the cost of old-style implicit to-string casts.