### PR TITLE
fix: treat HAVING without GROUP BY/aggregates as global aggregation

### DIFF
--- a/test/sql/aggregate/having/test_scalar_having.test
+++ b/test/sql/aggregate/having/test_scalar_having.test
@@ -81,3 +81,8 @@ query R
 SELECT SUM(a) FROM test HAVING COUNT(*)>10;
 ----
 
+# HAVING without GROUP BY and without aggregates should evaluate once, not per input row
+query I
+SELECT 1 AS one FROM (values(1,2),(2,3)) HAVING 1 < 2;
+----
+1


### PR DESCRIPTION
Add test for single-row HAVING evaluation to ensure HAVING clauses without GROUP BY operate on a single global group, matching PostgreSQL semantics.

Fixes https://github.com/duckdb/duckdb/issues/19313

Cherry picked from: https://github.com/duckdb/duckdb/pull/19401
Authored: @AdrianAcala
