### PR TITLE
Enable running all extensions tests as part of the build step

### DIFF
--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -2,5 +2,4 @@ duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
     GIT_TAG 2554312f71916ba11530c838b5c8c65b4786825c
-    LOAD_TESTS
 )

--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -2,4 +2,5 @@ duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
     GIT_TAG 2554312f71916ba11530c838b5c8c65b4786825c
+    LOAD_TESTS
 )

--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,5 +1,11 @@
+IF (NOT WIN32)
+    set(LOAD_HTTPFS_TESTS "LOAD_TESTS")
+else ()
+    set(LOAD_HTTPFS_TESTS "")
+endif()
 duckdb_extension_load(httpfs
-    LOAD_TESTS
+    # TODO: restore once httpfs is fixed
+    ${LOAD_HTTPFS_TESTS}
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG 8356a9017444f54018159718c8017ff7db4ea756
     INCLUDE_DIR src/include

--- a/.github/config/extensions/vortex.cmake
+++ b/.github/config/extensions/vortex.cmake
@@ -5,5 +5,6 @@ if (NOT WIN32 AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
             GIT_TAG 9ea698117199440f62a7cf1673afb647dc6437c7
             SUBMODULES vortex
             APPLY_PATCHES
+            LOAD_TESTS
     )
 endif()

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -93,7 +93,7 @@ jobs:
 
     env:
       # NOTE: on PRs we exclude some archs to speed things up
-      BASE_EXCLUDE_ARCHS: ${{ (github.event_name == 'pull_request' || inputs.run_all != 'true') && 'wasm_eh;wasm_threads;windows_amd64_mingw;osx_amd64;linux_arm64;linux_amd64_musl;' || '' }}
+      BASE_EXCLUDE_ARCHS: ${{ (github.event_name == 'pull_request' || inputs.run_all != 'true') && 'wasm_mvp;wasm_threads;windows_amd64_mingw;osx_amd64;linux_arm64;linux_amd64_musl;' || '' }}
       EXTRA_EXCLUDE_ARCHS: ${{ inputs.extra_exclude_archs }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -136,7 +136,7 @@ jobs:
         name: Configure External extensions
         env:
           CONFIG_FILE: .github/config/external_extensions.cmake
-          DEFAULT_EXCLUDE_ARCHS: ''
+          DEFAULT_EXCLUDE_ARCHS: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_amd64_musl'
         run: |
           echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$BASE_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
           external_extensions="`cat .github/config/external_extensions.cmake`"

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -64,5 +64,7 @@ jobs:
       skip_tests: ${{ inputs.skip_tests }}
       save_cache: ${{ inputs.save_cache }}
 
+      # This forces tests to be run for all extensions in the config
+      extensions_test_selection: 'complete'
       # The extension_config.cmake configuration that gets built
       extra_extension_config: ${{ inputs.extension_config }}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,7 +34,9 @@ if(NOT WIN32 AND NOT SUN)
   if(${BUILD_TPCE})
     add_subdirectory(tpce)
   endif()
-  add_subdirectory(persistence)
+  if(${ENABLE_UNITTEST_CPP_TESTS})
+    add_subdirectory(persistence)
+  endif()
 endif()
 
 set(UNITTEST_ROOT_DIRECTORY


### PR DESCRIPTION
This is enabled via https://github.com/duckdb/extension-ci-tools/pull/278, that introduced a way to hook into running tests for all extension of a given configuration (as opposed to a single one).

Also few minor fixes I bumped into:
* disable unused platforms from the external extension builds
* remove `[persistence]` tests to be always run
* enable `vortex` tests
* avoid `httpfs` tests on Windows, to be reverted in a follow up