### PR TITLE
Fix incorrect partition calculation due to missing vector_type

### DIFF
--- a/src/common/radix_partitioning.cpp
+++ b/src/common/radix_partitioning.cpp
@@ -98,6 +98,7 @@ struct ComputePartitionIndicesFunctor {
 			const auto source_data = UnifiedVectorFormat::GetData<hash_t>(format);
 			const auto &source_sel = *format.sel;
 
+			partition_indices.SetVectorType(VectorType::FLAT_VECTOR);
 			const auto target = FlatVector::GetData<hash_t>(partition_indices);
 
 			if (source_sel.IsSet()) {

--- a/test/sql/aggregate/distinct/issue19616.test
+++ b/test/sql/aggregate/distinct/issue19616.test
@@ -1,0 +1,37 @@
+# name: test/sql/aggregate/distinct/issue19616.test
+# description: Issue #19616: Missing setting vector_type produces incorrect result
+# group: [distinct]
+
+statement ok
+CREATE TABLE test (
+	col1 int,
+	col2 int,
+	col3 int
+);
+
+statement ok
+INSERT INTO test
+VALUES (22, 6, 8),
+	(28, 57, 45),
+	(82, 44, 71);
+
+statement ok
+SET threads = 4;
+
+loop i 0 10
+
+query I
+SELECT *
+FROM (
+	SELECT DISTINCT col2
+	FROM test
+	GROUP BY ROLLUP (col1, col2, col3)
+)
+ORDER BY col2;
+----
+6
+44
+57
+NULL
+
+endloop


### PR DESCRIPTION
Fix [#19616 ](https://github.com/duckdb/duckdb/issues/19616)
When the input hashes is a CONSTANT_VECTOR, the partition_indices vector incorrectly retains this CONSTANT_VECTOR type flag permanently.