### PR TITLE
Fix z/OS-specific issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,7 +419,11 @@ option(EXTENSION_STATIC_BUILD
         "Extension build linking statically with DuckDB. Required for building linux loadable extensions."
         FALSE)
 
-if(WIN32 OR ZOS)
+if(ZOS)
+  set(EXTENSION_STATIC_BUILD TRUE)
+endif()
+
+if(WIN32)
   set(EXTENSION_STATIC_BUILD TRUE)
   add_definitions(-D_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS=1)
 endif()

--- a/extension/icu/third_party/icu/common/unicode/ucnv.h
+++ b/extension/icu/third_party/icu/common/unicode/ucnv.h
@@ -1,0 +1,11 @@
+/**
+ * Converter option for EBCDIC SBCS or mixed-SBCS/DBCS (stateful) codepages.
+ * Swaps Unicode mappings for EBCDIC LF and NL codes, as used on
+ * S/390 (z/OS) Unix System Services (Open Edition).
+ * For example, ucnv_open("ibm-1047,swaplfnl", &errorCode);
+ * See convrtrs.txt.
+ *
+ * @see ucnv_open
+ * @stable ICU 2.4
+ */
+#define UCNV_SWAP_LFNL_OPTION_STRING ",swaplfnl"

--- a/src/common/encryption_key_manager.cpp
+++ b/src/common/encryption_key_manager.cpp
@@ -31,6 +31,8 @@ EncryptionKey::~EncryptionKey() {
 void EncryptionKey::LockEncryptionKey(data_ptr_t key, idx_t key_len) {
 #if defined(_WIN32)
 	VirtualLock(key, key_len);
+#elif defined(__MVS__)
+	__mlockall(_BPX_NONSWAP);
 #else
 	mlock(key, key_len);
 #endif
@@ -40,6 +42,8 @@ void EncryptionKey::UnlockEncryptionKey(data_ptr_t key, idx_t key_len) {
 	memset(key, 0, key_len);
 #if defined(_WIN32)
 	VirtualUnlock(key, key_len);
+#elif defined(__MVS__)
+	__mlockall(_BPX_SWAP);
 #else
 	munlock(key, key_len);
 #endif

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -30,10 +30,7 @@
 #include <unistd.h>
 
 #ifdef __MVS__
-#define _XOPEN_SOURCE_EXTENDED 1
 #include <sys/resource.h>
-// enjoy - https://reviews.llvm.org/D92110
-#define PATH_MAX _XOPEN_PATH_MAX
 #endif
 
 #else

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -613,7 +613,7 @@ bool LocalFileSystem::DirectoryExists(const string &directory, optional_ptr<File
 		if (access(normalized_dir, 0) == 0) {
 			struct stat status;
 			stat(normalized_dir, &status);
-			if (status.st_mode & S_IFDIR) {
+			if (S_ISDIR(status.st_mode)) {
 				return true;
 			}
 		}
@@ -719,7 +719,7 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 		if (res != 0) {
 			continue;
 		}
-		if (!(status.st_mode & S_IFREG) && !(status.st_mode & S_IFDIR)) {
+		if (!S_ISREG(status.st_mode) && !S_ISDIR(status.st_mode)) {
 			// not a file or directory: skip
 			continue;
 		}
@@ -727,7 +727,7 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 		info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 		auto &options = info.extended_info->options;
 		// file type
-		Value file_type(status.st_mode & S_IFDIR ? "directory" : "file");
+		Value file_type(S_ISDIR(status.st_mode) ? "directory" : "file");
 		options.emplace("type", std::move(file_type));
 		// file size
 		options.emplace("file_size", Value::BIGINT(UnsafeNumericCast<int64_t>(status.st_size)));

--- a/src/storage/compression/dict_fsst/compression.cpp
+++ b/src/storage/compression/dict_fsst/compression.cpp
@@ -4,6 +4,10 @@
 #include "fsst.h"
 #include "duckdb/common/fsst.hpp"
 
+#if defined(__MVS__) && !defined(alloca)
+#define alloca __builtin_alloca
+#endif
+
 namespace duckdb {
 namespace dict_fsst {
 

--- a/third_party/libpg_query/include/pg_functions.hpp
+++ b/third_party/libpg_query/include/pg_functions.hpp
@@ -3,7 +3,9 @@
 #include <stdlib.h>
 #include <string>
 
+#ifndef __MVS__
 #define fprintf(...)
+#endif
 
 #include "pg_definitions.hpp"
 

--- a/third_party/libpg_query/pg_functions.cpp
+++ b/third_party/libpg_query/pg_functions.cpp
@@ -30,13 +30,8 @@ struct pg_parser_state_str {
 };
 
 #ifdef __MVS__
-// --------------------------------------------------------
-// Permanent - WIP
-// static __tlssim<parser_state> pg_parser_state_impl();
-// #define pg_parser_state (*pg_parser_state_impl.access())
-// --------------------------------------------------------
-// Temporary
-static parser_state pg_parser_state;
+static __tlssim<parser_state> pg_parser_state_impl;
+#define pg_parser_state (*pg_parser_state_impl.access())
 #else
 static __thread parser_state pg_parser_state;
 #endif

--- a/third_party/re2/re2/re2.h
+++ b/third_party/re2/re2/re2.h
@@ -985,7 +985,7 @@ namespace hooks {
 // As per https://github.com/google/re2/issues/325, thread_local support in
 // MinGW seems to be buggy. (FWIW, Abseil folks also avoid it.)
 #define RE2_HAVE_THREAD_LOCAL
-#if (defined(__APPLE__) && !(defined(TARGET_OS_OSX) && TARGET_OS_OSX)) || defined(__MINGW32__)
+#if (defined(__APPLE__) && !(defined(TARGET_OS_OSX) && TARGET_OS_OSX)) || defined(__MINGW32__) || defined(__MVS__)
 #undef RE2_HAVE_THREAD_LOCAL
 #endif
 


### PR DESCRIPTION
Thanks for the great product!

The PR renews z/OS support, which was added a while ago with [these PRs](https://github.com/duckdb/duckdb/pulls?q=is%3Apr+author%3Av1gnesh).

The support needs renewal to accommodate the latest DuckDB version / `zoslib` changes and to fix issues that were missed in the first place:
- compilation errors (for debug / release builds and extensions);
- unittests being unable to discover SQL logic tests.


CC @v1gnesh