### PR TITLE
Bump MySQL scanner

### DIFF
--- a/.github/config/extensions/mysql_scanner.cmake
+++ b/.github/config/extensions/mysql_scanner.cmake
@@ -3,6 +3,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
             DONT_LINK
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-mysql
-            GIT_TAG c80647b33972c150f0bd0001c35085cefdc82d1e
+            GIT_TAG 7a8c7269dcf452665e7fe05cce0f6e7cab137300
             )
 endif()


### PR DESCRIPTION
Updating the MySQL scanner to include the time zone handling fix to duckdb/duckdb-mysql#166.