### PR TITLE
Remove `FlushAll` from `DETACH`

### DIFF
--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -272,10 +272,6 @@ void AttachedDatabase::Close() {
 	catalog.reset();
 	storage.reset();
 	stored_database_path.reset();
-
-	if (Allocator::SupportsFlush()) {
-		Allocator::FlushAll();
-	}
 }
 
 } // namespace duckdb


### PR DESCRIPTION
This was initially added to reduce RSS after `DETACH`ing, but it is now creating a large bottleneck for workloads that aggressively `ATTACH`/`DETACH`. RSS will be freed by further allocation activity, or when `SET allocator_background_threads=true;` is enabled.