### PR TITLE
CLI: Fix cursor rendering in multi-line editing mode

### DIFF
--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -941,9 +941,6 @@ void Linenoise::RefreshMultiLine() {
 	Linenoise::Log("pos %d", pos);
 	Linenoise::Log("max cols %d", ws.ws_col);
 
-	Linenoise::Log("\n");
-	old_cursor_rows = new_cursor_row;
-
 	if (rendered_completion_lines > 0 || (render_completion_suggestion && !completion_list.completions.empty())) {
 		// if we are tab-completing - write the list of completions one line below
 		if (rendered_completion_lines == 0) {
@@ -1049,6 +1046,13 @@ void Linenoise::RefreshMultiLine() {
 		}
 	}
 
+	/* Go up till we reach the expected position. */
+	if (rows - new_cursor_row > 0) {
+		Linenoise::Log("go-up %d", rows - new_cursor_row);
+		snprintf(seq, 64, "\x1b[%dA", rows - new_cursor_row);
+		append_buffer.Append(seq);
+	}
+
 	/* Set column. */
 	col = new_cursor_x;
 	Linenoise::Log("set col %d", 1 + col);
@@ -1059,6 +1063,8 @@ void Linenoise::RefreshMultiLine() {
 	}
 	append_buffer.Append(seq);
 
+	Linenoise::Log("\n");
+	old_cursor_rows = new_cursor_row;
 	append_buffer.Write(fd);
 }
 


### PR DESCRIPTION
Accidentally borked in https://github.com/duckdb/duckdb/pull/19626