### PR TITLE
duckdb_logs_parsed to do case-insensitive matching

### DIFF
--- a/src/catalog/default/default_table_functions.cpp
+++ b/src/catalog/default/default_table_functions.cpp
@@ -69,7 +69,7 @@ FROM histogram_values(source, col_name, bin_count := bin_count, technique := tec
 	{DEFAULT_SCHEMA, "duckdb_logs_parsed", {"log_type"}, {}, R"(
 SELECT * EXCLUDE (message), UNNEST(parse_duckdb_log_message(log_type, message))
 FROM duckdb_logs(denormalized_table=1)
-WHERE type = log_type
+WHERE type ILIKE log_type
 )"},
 	{nullptr, nullptr, {nullptr}, {{nullptr, nullptr}}, nullptr}
 	};

--- a/test/sql/logging/logging_file_bind_replace.test
+++ b/test/sql/logging/logging_file_bind_replace.test
@@ -30,6 +30,11 @@ SELECT message FROM duckdb_logs_parsed('QueryLog') WHERE starts_with(message, 'S
 ----
 SELECT 1 as a
 
+query I
+SELECT message FROM duckdb_logs_parsed('querylog') WHERE starts_with(message, 'SELECT 1');
+----
+SELECT 1 as a
+
 statement ok
 CALL truncate_duckdb_logs();
 


### PR DESCRIPTION
This is something me and @Tmonster bumped into while helping a customer debugging an issue.

I think it's more intuitive and friendly that user facing functions are case insensitive, given that is the general user expectation around SQL.

I am not sure `ILIKE` is the best way to do so (an alternative would be filtering on `lower(1) = lower(2)`).

Note that passing `%` signs is currently checked elsewhere, for example:
```sql
SELECT message FROM duckdb_logs_parsed('query%') WHERE starts_with(message, 'SELECT 1');
```
would throw
```
Invalid Input Error: structured_log_schema: 'query%' not found
```
(while `querylog` already work, see test case, given there case-insensitivity comparison was already used)