### PR TITLE
Categorize ParseLogMessage as CAN_THROW_RUNTIME_ERROR

### DIFF
--- a/src/function/scalar/system/parse_log_message.cpp
+++ b/src/function/scalar/system/parse_log_message.cpp
@@ -77,8 +77,10 @@ void ParseLogMessageFunction(DataChunk &args, ExpressionState &state, Vector &re
 } // namespace
 
 ScalarFunction ParseLogMessage::GetFunction() {
-	return ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::ANY, ParseLogMessageFunction,
-	                      ParseLogMessageBind, nullptr, nullptr, nullptr, LogicalType(LogicalTypeId::INVALID));
+	auto fun = ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::ANY, ParseLogMessageFunction,
+	                          ParseLogMessageBind, nullptr, nullptr, nullptr, LogicalType(LogicalTypeId::INVALID));
+	fun.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	return fun;
 }
 
 } // namespace duckdb

--- a/test/sql/pragma/profiling/test_logging_interaction.test
+++ b/test/sql/pragma/profiling/test_logging_interaction.test
@@ -32,6 +32,6 @@ statement ok
 PRAGMA disable_profiling;
 
 query I
-SELECT count(*) FROM duckdb_logs() WHERE type == 'Metrics' AND message ILIKE '%CPU_TIME%';
+SELECT count(*) FROM duckdb_logs_parsed('Metrics') WHERE metric == 'CPU_TIME';
 ----
 3


### PR DESCRIPTION
Currently we rely on filtering on query type AND executing scalar function `parse_duckdb_log_message` to not be reordered.

This is somehow brittle, and have found locally cases where this cause problems that will result in wrong casts, such as:
```
Conversion Error:
Type VARCHAR with value 'ColumnDataCheckpointer FinalAnalyze(COMPRESSION_UNCOMPRESSED) result for main.big.0(VALIDITY): 15360' can't be cast to the destination type STRUCT(metric VARCHAR, "value" VARCHAR)
```
Looking at the executed plan, it would look like:
```
                             ┌─────────────┴─────────────┐
                             │           FILTER          │
                             │    ────────────────────   │
                             │  ((type = 'Metrics') AND  │
                             │      (struct_extract      │
                             │ (parse_duckdb_log_message(│
                             │   'Metrics', message),    │
                             │  'metric') = 'CPU_TIME')) │
                             │                           │
                             │          ~0 rows          │
                             └─────────────┬─────────────┘
```

Tagging `parse_duckdb_log_message` as potentially throwing on some input avoids reordering, and avoid the problem while improving the usability of logs.

An alternative solution would be use explicit DefaultTryCast (instead of TryCast), at https://github.com/duckdb/duckdb/blob/v1.4-andium/src/function/scalar/system/parse_log_message.cpp#L70, either allow to solve the problem.