### PR TITLE
CLI - store action as just a char to avoid sanitizer complaints

### DIFF
--- a/tools/shell/linenoise/include/terminal.hpp
+++ b/tools/shell/linenoise/include/terminal.hpp
@@ -101,7 +101,7 @@ struct KeyPress {
 	      action(ESC), sequence(sequence) {
 	}
 
-	KEY_ACTION action = KEY_NULL;
+	char action = KEY_NULL;
 	EscapeSequence sequence = EscapeSequence::INVALID;
 };
 

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -1284,11 +1284,11 @@ bool Linenoise::TryGetKeyPress(int fd, KeyPress &key_press) {
 				if (key_press.sequence != EscapeSequence::INVALID) {
 					key_press.action = ESC;
 				} else {
-					key_press.action = (KEY_ACTION)c;
+					key_press.action = c;
 				}
 				// add the key press to the list of key presses
 			} else {
-				key_press.action = (KEY_ACTION)c;
+				key_press.action = c;
 			}
 			remaining_presses.push_back(key_press);
 		}
@@ -1312,7 +1312,7 @@ bool Linenoise::TryGetKeyPress(int fd, KeyPress &key_press) {
 	if (!has_more_data) {
 		HandleTerminalResize();
 	}
-	key_press.action = (KEY_ACTION)c;
+	key_press.action = c;
 	if (key_press.action == ESC) {
 		// for ESC we need to read an escape sequence
 		key_press.sequence = Terminal::ReadEscapeSequence(ifd);


### PR DESCRIPTION
We use `action` both as list of options (`ESC`, `CTRL_C`, etc) and as a literal byte value. The sanitizer does not seem to like that - so just keep it as a `char`.