### PR TITLE
Log total probe matches in hash join

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -164,6 +164,11 @@ public:
 		}
 	}
 
+	~HashJoinGlobalSinkState() override {
+		DUCKDB_LOG(context, PhysicalOperatorLogType, op, "PhysicalHashJoin", "GetData",
+		           {{"total_probe_matches", to_string(hash_table->total_probe_matches)}});
+	}
+
 	void ScheduleFinalize(Pipeline &pipeline, Event &event);
 	void InitializeProbeSpill();
 

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -277,6 +277,8 @@ public:
 	uint64_t bitmask = DConstants::INVALID_INDEX;
 	//! Whether or not we error on multiple rows found per match in a SINGLE join
 	bool single_join_error_on_multiple_rows = true;
+	//! Number of probe matches
+	atomic<idx_t> total_probe_matches {0};
 
 	struct {
 		mutex mj_lock;

--- a/test/sql/logging/physical_operator_logging.test_slow
+++ b/test/sql/logging/physical_operator_logging.test_slow
@@ -43,6 +43,11 @@ select count(*) from duckdb_logs_parsed('PhysicalOperator') where class = 'JoinH
 ----
 16
 
+query I
+select info.total_probe_matches from duckdb_logs_parsed('PhysicalOperator') where class = 'PhysicalHashJoin' and event = 'GetData'
+----
+3000000
+
 # all flushed row groups should be logged, these should be equal
 query I
 select count(*) = (


### PR DESCRIPTION
This is usually evident from the number of tuples coming out of a join, but it can be hard to understand what's going on when doing a `LEFT`/`RIGHT`/`OUTER` join. This PR adds one log call at the end of the hash join to report how many probe matches there were.

```sql
D CALL enable_logging('PhysicalOperator');
┌─────────┐
│ Success │
│ boolean │
├─────────┤
│ 0 rows  │
└─────────┘
D SELECT count(*)
  FROM range(3_000_000) t1(i)
  LEFT JOIN range(1_000_000, 2_000_000) t2(i)
  USING (i);
┌────────────────┐
│  count_star()  │
│     int64      │
├────────────────┤
│    3000000     │
│ (3.00 million) │
└────────────────┘
D CALL disable_logging();
┌─────────┐
│ Success │
│ boolean │
├─────────┤
│ 0 rows  │
└─────────┘
D SELECT info.total_probe_matches::BIGINT total_probe_matches
  FROM duckdb_logs_parsed('PhysicalOperator')
  WHERE class = 'PhysicalHashJoin' AND event = 'GetData';
┌─────────────────────┐
│ total_probe_matches │
│        int64        │
├─────────────────────┤
│       1000000       │
│   (1.00 million)    │
└─────────────────────┘
```
Here we are able to see that the hash join produced 1M matches, but emitted 3M tuples.