### PR TITLE
SegmentTree: move `next` and `index` out of SegmentBase and into SegmentNode

### DIFF
--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -24,12 +24,14 @@ class LocalTableStorage;
 class RowGroup;
 class UpdateSegment;
 class TableCatalogEntry;
+template <class T>
+struct SegmentNode;
 
 struct TableAppendState;
 
 struct ColumnAppendState {
 	//! The current segment of the append
-	ColumnSegment *current;
+	optional_ptr<SegmentNode<ColumnSegment>> current;
 	//! Child append states
 	vector<ColumnAppendState> child_appends;
 	//! The write lock that is held by the append
@@ -67,7 +69,7 @@ struct TableAppendState {
 	//! The total number of rows appended by the append operation
 	idx_t total_append_count;
 	//! The first row-group that has been appended to
-	RowGroup *start_row_group;
+	optional_ptr<SegmentNode<RowGroup>> start_row_group;
 	//! The transaction data
 	TransactionData transaction;
 	//! Table statistics

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -50,6 +50,8 @@ class MetadataManager;
 class RowVersionManager;
 class ScanFilterInfo;
 class StorageCommitState;
+template <class T>
+struct SegmentNode;
 
 struct RowGroupWriteInfo {
 	RowGroupWriteInfo(PartialBlockManager &manager, const vector<CompressionType> &compression_types,
@@ -113,7 +115,7 @@ public:
 
 	unique_ptr<RowGroup> AlterType(RowGroupCollection &collection, const LogicalType &target_type, idx_t changed_idx,
 	                               ExpressionExecutor &executor, CollectionScanState &scan_state,
-	                               DataChunk &scan_chunk);
+	                               SegmentNode<RowGroup> &node, DataChunk &scan_chunk);
 	unique_ptr<RowGroup> AddColumn(RowGroupCollection &collection, ColumnDefinition &new_column,
 	                               ExpressionExecutor &executor, Vector &intermediate);
 	unique_ptr<RowGroup> RemoveColumn(RowGroupCollection &collection, idx_t removed_column);
@@ -125,8 +127,8 @@ public:
 	bool HasChanges() const;
 
 	//! Initialize a scan over this row_group
-	bool InitializeScan(CollectionScanState &state);
-	bool InitializeScanWithOffset(CollectionScanState &state, idx_t vector_offset);
+	bool InitializeScan(CollectionScanState &state, SegmentNode<RowGroup> &node);
+	bool InitializeScanWithOffset(CollectionScanState &state, SegmentNode<RowGroup> &node, idx_t vector_offset);
 	//! Checks the given set of table filters against the row-group statistics. Returns false if the entire row group
 	//! can be skipped.
 	bool CheckZonemap(ScanFilterInfo &filters);

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -68,8 +68,8 @@ public:
 	void InitializeScanWithOffset(const QueryContext &context, CollectionScanState &state,
 	                              const vector<StorageIndex> &column_ids, idx_t start_row, idx_t end_row);
 	static bool InitializeScanInRowGroup(const QueryContext &context, CollectionScanState &state,
-	                                     RowGroupCollection &collection, RowGroup &row_group, idx_t vector_index,
-	                                     idx_t max_row);
+	                                     RowGroupCollection &collection, SegmentNode<RowGroup> &row_group,
+	                                     idx_t vector_index, idx_t max_row);
 	void InitializeParallelScan(ParallelCollectionScanState &state);
 	bool NextParallelScan(ClientContext &context, ParallelCollectionScanState &state, CollectionScanState &scan_state);
 
@@ -110,7 +110,7 @@ public:
 	void Checkpoint(TableDataWriter &writer, TableStatistics &global_stats);
 
 	void InitializeVacuumState(CollectionCheckpointState &checkpoint_state, VacuumState &state,
-	                           vector<SegmentNode<RowGroup>> &segments);
+	                           vector<unique_ptr<SegmentNode<RowGroup>>> &segments);
 	bool ScheduleVacuumTasks(CollectionCheckpointState &checkpoint_state, VacuumState &state, idx_t segment_idx,
 	                         bool schedule_vacuum);
 	unique_ptr<CheckpointTask> GetCheckpointTask(CollectionCheckpointState &checkpoint_state, idx_t segment_idx);
@@ -155,7 +155,7 @@ public:
 private:
 	bool IsEmpty(SegmentLock &) const;
 
-	optional_ptr<RowGroup> NextUpdateRowGroup(row_t *ids, idx_t &pos, idx_t count) const;
+	optional_ptr<SegmentNode<RowGroup>> NextUpdateRowGroup(row_t *ids, idx_t &pos, idx_t count) const;
 
 private:
 	//! BlockManager

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -23,15 +23,11 @@ struct MetaBlockPointer;
 
 class RowVersionManager {
 public:
-	explicit RowVersionManager(BufferManager &buffer_manager, idx_t start) noexcept;
+	explicit RowVersionManager(BufferManager &buffer_manager) noexcept;
 
-	idx_t GetStart() const {
-		return start;
-	}
 	FixedSizeAllocator &GetAllocator() {
 		return allocator;
 	}
-	void SetStart(idx_t start);
 	idx_t GetCommittedDeletedCount(idx_t count);
 
 	idx_t GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count);
@@ -48,13 +44,11 @@ public:
 	void CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info);
 
 	vector<MetaBlockPointer> Checkpoint(MetadataManager &manager);
-	static shared_ptr<RowVersionManager> Deserialize(MetaBlockPointer delete_pointer, MetadataManager &manager,
-	                                                 idx_t start);
+	static shared_ptr<RowVersionManager> Deserialize(MetaBlockPointer delete_pointer, MetadataManager &manager);
 
 private:
 	mutex version_lock;
 	FixedSizeAllocator allocator;
-	idx_t start;
 	vector<unique_ptr<ChunkInfo>> vector_info;
 	bool has_changes;
 	vector<MetaBlockPointer> storage_pointers;

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -42,6 +42,8 @@ struct AdaptiveFilterState;
 struct TableScanOptions;
 struct ScanSamplingInfo;
 struct TableFilterState;
+template <class T>
+struct SegmentNode;
 
 struct SegmentScanState {
 	virtual ~SegmentScanState() {
@@ -81,7 +83,7 @@ struct ColumnScanState {
 	//! The query context for this scan
 	QueryContext context;
 	//! The column segment that is currently being scanned
-	ColumnSegment *current = nullptr;
+	optional_ptr<SegmentNode<ColumnSegment>> current;
 	//! Column segment tree
 	ColumnSegmentTree *segment_tree = nullptr;
 	//! The current row index of the scan
@@ -189,8 +191,8 @@ enum class OrderByColumnType { NUMERIC, STRING };
 class RowGroupReorderer {
 public:
 	explicit RowGroupReorderer(const RowGroupOrderOptions &options);
-	optional_ptr<RowGroup> GetNextRowGroup(optional_ptr<RowGroup> row_group);
-	optional_ptr<RowGroup> GetRootSegment(RowGroupSegmentTree &row_groups);
+	optional_ptr<SegmentNode<RowGroup>> GetRootSegment(RowGroupSegmentTree &row_groups);
+	optional_ptr<SegmentNode<RowGroup>> GetNextRowGroup(SegmentNode<RowGroup> &row_group);
 
 private:
 	const column_t column_idx;
@@ -200,7 +202,7 @@ private:
 
 	idx_t offset;
 	bool initialized;
-	vector<optional_ptr<RowGroup>> ordered_row_groups;
+	vector<reference<SegmentNode<RowGroup>>> ordered_row_groups;
 
 private:
 	static Value RetrieveStat(const BaseStatistics &stats, OrderByStatistics order_by, OrderByColumnType column_type);
@@ -211,7 +213,7 @@ public:
 	explicit CollectionScanState(TableScanState &parent_p);
 
 	//! The current row_group we are scanning
-	RowGroup *row_group;
+	optional_ptr<SegmentNode<RowGroup>> row_group;
 	//! The vector index within the row_group
 	idx_t vector_index;
 	//! The maximum row within the row group
@@ -238,9 +240,9 @@ public:
 	ScanFilterInfo &GetFilterInfo();
 	ScanSamplingInfo &GetSamplingInfo();
 	TableScanOptions &GetOptions();
-	optional_ptr<RowGroup> GetNextRowGroup(optional_ptr<RowGroup> row_group) const;
-	optional_ptr<RowGroup> GetNextRowGroup(SegmentLock &l, optional_ptr<RowGroup> row_group) const;
-	optional_ptr<RowGroup> GetRootSegment() const;
+	optional_ptr<SegmentNode<RowGroup>> GetNextRowGroup(SegmentNode<RowGroup> &row_group) const;
+	optional_ptr<SegmentNode<RowGroup>> GetNextRowGroup(SegmentLock &l, SegmentNode<RowGroup> &row_group) const;
+	optional_ptr<SegmentNode<RowGroup>> GetRootSegment() const;
 	bool Scan(DuckTransaction &transaction, DataChunk &result);
 	bool ScanCommitted(DataChunk &result, TableScanType type);
 	bool ScanCommitted(DataChunk &result, SegmentLock &l, TableScanType type);
@@ -306,12 +308,13 @@ private:
 
 struct ParallelCollectionScanState {
 	ParallelCollectionScanState();
-	optional_ptr<RowGroup> GetRootSegment(RowGroupSegmentTree &row_groups) const;
-	optional_ptr<RowGroup> GetNextRowGroup(RowGroupSegmentTree &row_groups, optional_ptr<RowGroup> row_group) const;
+	optional_ptr<SegmentNode<RowGroup>> GetRootSegment(RowGroupSegmentTree &row_groups) const;
+	optional_ptr<SegmentNode<RowGroup>> GetNextRowGroup(RowGroupSegmentTree &row_groups,
+	                                                    SegmentNode<RowGroup> &row_group) const;
 
 	//! The row group collection we are scanning
 	RowGroupCollection *collection;
-	RowGroup *current_row_group;
+	optional_ptr<SegmentNode<RowGroup>> current_row_group;
 	idx_t vector_index;
 	idx_t max_row;
 	idx_t batch_index;

--- a/src/include/duckdb/storage/table/segment_base.hpp
+++ b/src/include/duckdb/storage/table/segment_base.hpp
@@ -16,28 +16,13 @@ namespace duckdb {
 template <class T>
 class SegmentBase {
 public:
-	SegmentBase(idx_t start, idx_t count) : start(start), count(count), next(nullptr) {
-	}
-	T *Next() {
-#ifndef DUCKDB_R_BUILD
-		return next.load();
-#else
-		return next;
-#endif
+	SegmentBase(idx_t start, idx_t count) : start(start), count(count) {
 	}
 
 	//! The start row id of this chunk
 	idx_t start;
 	//! The amount of entries in this storage chunk
 	atomic<idx_t> count;
-	//! The next segment after this one
-#ifndef DUCKDB_R_BUILD
-	atomic<T *> next;
-#else
-	T *next;
-#endif
-	//! The index within the segment tree
-	idx_t index;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -148,7 +148,7 @@ public:
 	}
 	optional_ptr<SegmentNode<T>> GetNextSegment(SegmentLock &l, SegmentNode<T> &node) {
 #ifdef DEBUG
-		D_ASSERT(RefersToSameObject(*nodes[node.index].node, node));
+		D_ASSERT(RefersToSameObject(*nodes[node.index], node));
 #endif
 		return GetSegmentByIndex(l, UnsafeNumericCast<int64_t>(node.index + 1));
 	}

--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -19,8 +19,28 @@ namespace duckdb {
 
 template <class T>
 struct SegmentNode {
+	SegmentNode() : next(nullptr) {
+	}
+
 	idx_t row_start;
 	unique_ptr<T> node;
+	//! The next segment after this one
+#ifndef DUCKDB_R_BUILD
+	atomic<SegmentNode<T> *> next;
+#else
+	SegmentNode<T> *next;
+#endif
+	//! The index within the segment tree
+	idx_t index;
+
+public:
+	optional_ptr<SegmentNode<T>> Next() {
+#ifndef DUCKDB_R_BUILD
+		return next.load();
+#else
+		return next;
+#endif
+	}
 };
 
 //! The SegmentTree maintains a list of all segments of a specific column in a table, and allows searching for a segment
@@ -29,6 +49,7 @@ template <class T, bool SUPPORTS_LAZY_LOADING = false>
 class SegmentTree {
 private:
 	class SegmentIterationHelper;
+	class SegmentNodeIterationHelper;
 
 public:
 	explicit SegmentTree() : finished_loading(true) {
@@ -47,39 +68,39 @@ public:
 	}
 
 	//! Gets a pointer to the first segment. Useful for scans.
-	T *GetRootSegment() {
+	optional_ptr<SegmentNode<T>> GetRootSegment() {
 		auto l = Lock();
 		return GetRootSegment(l);
 	}
 
-	T *GetRootSegment(SegmentLock &l) {
+	optional_ptr<SegmentNode<T>> GetRootSegment(SegmentLock &l) {
 		if (nodes.empty()) {
 			LoadNextSegment(l);
 		}
 		return GetRootSegmentInternal();
 	}
 	//! Obtains ownership of the data of the segment tree
-	vector<SegmentNode<T>> MoveSegments(SegmentLock &l) {
+	vector<unique_ptr<SegmentNode<T>>> MoveSegments(SegmentLock &l) {
 		LoadAllSegments(l);
 		return std::move(nodes);
 	}
-	vector<SegmentNode<T>> MoveSegments() {
+	vector<unique_ptr<SegmentNode<T>>> MoveSegments() {
 		auto l = Lock();
 		return MoveSegments(l);
 	}
 
-	const vector<SegmentNode<T>> &ReferenceSegments(SegmentLock &l) {
+	const vector<unique_ptr<SegmentNode<T>>> &ReferenceSegments(SegmentLock &l) {
 		LoadAllSegments(l);
 		return nodes;
 	}
-	const vector<SegmentNode<T>> &ReferenceSegments() {
+	const vector<unique_ptr<SegmentNode<T>>> &ReferenceSegments() {
 		auto l = Lock();
 		return ReferenceSegments(l);
 	}
-	vector<SegmentNode<T>> &ReferenceLoadedSegmentsMutable(SegmentLock &l) {
+	vector<unique_ptr<SegmentNode<T>>> &ReferenceLoadedSegmentsMutable(SegmentLock &l) {
 		return nodes;
 	}
-	const vector<SegmentNode<T>> &ReferenceLoadedSegments(SegmentLock &l) const {
+	const vector<unique_ptr<SegmentNode<T>>> &ReferenceLoadedSegments(SegmentLock &l) const {
 		return nodes;
 	}
 
@@ -91,11 +112,11 @@ public:
 		return nodes.size();
 	}
 	//! Gets a pointer to the nth segment. Negative numbers start from the back.
-	T *GetSegmentByIndex(int64_t index) {
+	optional_ptr<SegmentNode<T>> GetSegmentByIndex(int64_t index) {
 		auto l = Lock();
 		return GetSegmentByIndex(l, index);
 	}
-	T *GetSegmentByIndex(SegmentLock &l, int64_t index) {
+	optional_ptr<SegmentNode<T>> GetSegmentByIndex(SegmentLock &l, int64_t index) {
 		if (index < 0) {
 			// load all segments
 			LoadAllSegments(l);
@@ -103,7 +124,7 @@ public:
 			if (index < 0) {
 				return nullptr;
 			}
-			return nodes[UnsafeNumericCast<idx_t>(index)].node.get();
+			return nodes[UnsafeNumericCast<idx_t>(index)].get();
 		} else {
 			// lazily load segments until we reach the specific segment
 			while (idx_t(index) >= nodes.size() && LoadNextSegment(l)) {
@@ -111,59 +132,56 @@ public:
 			if (idx_t(index) >= nodes.size()) {
 				return nullptr;
 			}
-			return nodes[UnsafeNumericCast<idx_t>(index)].node.get();
+			return nodes[UnsafeNumericCast<idx_t>(index)].get();
 		}
 	}
 	//! Gets the next segment
-	T *GetNextSegment(T *segment) {
+	optional_ptr<SegmentNode<T>> GetNextSegment(SegmentNode<T> &node) {
 		if (!SUPPORTS_LAZY_LOADING) {
-			return segment->Next();
+			return node.Next();
 		}
 		if (finished_loading) {
-			return segment->Next();
+			return node.Next();
 		}
 		auto l = Lock();
-		return GetNextSegment(l, segment);
+		return GetNextSegment(l, node);
 	}
-	T *GetNextSegment(SegmentLock &l, T *segment) {
-		if (!segment) {
-			return nullptr;
-		}
+	optional_ptr<SegmentNode<T>> GetNextSegment(SegmentLock &l, SegmentNode<T> &node) {
 #ifdef DEBUG
-		D_ASSERT(nodes[segment->index].node.get() == segment);
+		D_ASSERT(RefersToSameObject(*nodes[node.index].node, node));
 #endif
-		return GetSegmentByIndex(l, UnsafeNumericCast<int64_t>(segment->index + 1));
+		return GetSegmentByIndex(l, UnsafeNumericCast<int64_t>(node.index + 1));
 	}
 
 	//! Gets a pointer to the last segment. Useful for appends.
-	T *GetLastSegment(SegmentLock &l) {
+	optional_ptr<SegmentNode<T>> GetLastSegment(SegmentLock &l) {
 		LoadAllSegments(l);
 		if (nodes.empty()) {
 			return nullptr;
 		}
-		return nodes.back().node.get();
+		return nodes.back().get();
 	}
 	//! Gets a pointer to a specific column segment for the given row
-	T *GetSegment(idx_t row_number) {
+	optional_ptr<SegmentNode<T>> GetSegment(idx_t row_number) {
 		auto l = Lock();
 		return GetSegment(l, row_number);
 	}
-	T *GetSegment(SegmentLock &l, idx_t row_number) {
-		return nodes[GetSegmentIndex(l, row_number)].node.get();
+	optional_ptr<SegmentNode<T>> GetSegment(SegmentLock &l, idx_t row_number) {
+		return nodes[GetSegmentIndex(l, row_number)].get();
 	}
 
 	//! Append a column segment to the tree
 	void AppendSegmentInternal(SegmentLock &l, unique_ptr<T> segment) {
 		D_ASSERT(segment);
 		// add the node to the list of nodes
+		auto node = make_uniq<SegmentNode<T>>();
 		if (!nodes.empty()) {
-			nodes.back().node->next = segment.get();
+			nodes.back()->next = node.get();
 		}
-		SegmentNode<T> node;
-		segment->index = nodes.size();
-		segment->next = nullptr;
-		node.row_start = segment->start;
-		node.node = std::move(segment);
+		node->row_start = segment->start;
+		node->node = std::move(segment);
+		node->index = nodes.size();
+		node->next = nullptr;
 		nodes.push_back(std::move(node));
 	}
 	void AppendSegment(unique_ptr<T> segment) {
@@ -175,12 +193,12 @@ public:
 		AppendSegmentInternal(l, std::move(segment));
 	}
 	//! Debug method, check whether the segment is in the segment tree
-	bool HasSegment(T *segment) {
+	bool HasSegment(SegmentNode<T> &segment) {
 		auto l = Lock();
 		return HasSegment(l, segment);
 	}
-	bool HasSegment(SegmentLock &, T *segment) {
-		return segment->index < nodes.size() && nodes[segment->index].node.get() == segment;
+	bool HasSegment(SegmentLock &, SegmentNode<T> &segment) {
+		return segment.index < nodes.size() && RefersToSameObject(*nodes[segment.index], segment);
 	}
 
 	//! Erase all segments after a specific segment
@@ -201,15 +219,15 @@ public:
 		string error;
 		error = StringUtil::Format("Attempting to find row number \"%lld\" in %lld nodes\n", row_number, nodes.size());
 		for (idx_t i = 0; i < nodes.size(); i++) {
-			error += StringUtil::Format("Node %lld: Start %lld, Count %lld", i, nodes[i].row_start,
-			                            nodes[i].node->count.load());
+			error += StringUtil::Format("Node %lld: Start %lld, Count %lld", i, nodes[i]->row_start,
+			                            nodes[i]->node->count.load());
 		}
 		throw InternalException("Could not find node in column segment tree!\n%s", error);
 	}
 
 	bool TryGetSegmentIndex(SegmentLock &l, idx_t row_number, idx_t &result) {
 		// load segments until the row number is within bounds
-		while (nodes.empty() || (row_number >= (nodes.back().row_start + nodes.back().node->count))) {
+		while (nodes.empty() || (row_number >= (nodes.back()->row_start + nodes.back()->node->count))) {
 			if (!LoadNextSegment(l)) {
 				break;
 			}
@@ -225,12 +243,12 @@ public:
 			if (index >= nodes.size()) {
 				string segments;
 				for (auto &entry : nodes) {
-					segments += StringUtil::Format("Start %d Count %d", entry.row_start, entry.node->count.load());
+					segments += StringUtil::Format("Start %d Count %d", entry->row_start, entry->node->count.load());
 				}
 				throw InternalException("Segment tree index not found for row number %d\nSegments:%s", row_number,
 				                        segments);
 			}
-			auto &entry = nodes[index];
+			auto &entry = *nodes[index];
 			D_ASSERT(entry.row_start == entry.node->start);
 			if (row_number < entry.row_start) {
 				upper = index - 1;
@@ -246,11 +264,11 @@ public:
 
 	void Verify(SegmentLock &) {
 #ifdef DEBUG
-		idx_t base_start = nodes.empty() ? 0 : nodes[0].node->start;
+		idx_t base_start = nodes.empty() ? 0 : nodes[0]->node->start;
 		for (idx_t i = 0; i < nodes.size(); i++) {
-			D_ASSERT(nodes[i].row_start == nodes[i].node->start);
-			D_ASSERT(nodes[i].node->start == base_start);
-			base_start += nodes[i].node->count;
+			D_ASSERT(nodes[i]->row_start == nodes[i]->node->start);
+			D_ASSERT(nodes[i]->node->start == base_start);
+			base_start += nodes[i]->node->count;
 		}
 #endif
 	}
@@ -269,17 +287,25 @@ public:
 		return SegmentIterationHelper(*this, l);
 	}
 
+	SegmentNodeIterationHelper SegmentNodes() {
+		return SegmentNodeIterationHelper(*this);
+	}
+
+	SegmentNodeIterationHelper SegmentNodes(SegmentLock &l) {
+		return SegmentNodeIterationHelper(*this, l);
+	}
+
 	void Reinitialize() {
 		if (nodes.empty()) {
 			return;
 		}
-		idx_t offset = nodes[0].node->start;
+		idx_t offset = nodes[0]->node->start;
 		for (auto &entry : nodes) {
-			if (entry.node->start != offset) {
+			if (entry->node->start != offset) {
 				throw InternalException("In SegmentTree::Reinitialize - gap found between nodes!");
 			}
-			entry.row_start = offset;
-			offset += entry.node->count;
+			entry->row_start = offset;
+			offset += entry->node->count;
 		}
 	}
 
@@ -291,17 +317,40 @@ protected:
 		return nullptr;
 	}
 
-	T *GetRootSegmentInternal() const {
-		return nodes.empty() ? nullptr : nodes[0].node.get();
+	optional_ptr<SegmentNode<T>> GetRootSegmentInternal() const {
+		return nodes.empty() ? nullptr : nodes[0].get();
 	}
 
 private:
 	//! The nodes in the tree, can be binary searched
-	vector<SegmentNode<T>> nodes;
+	vector<unique_ptr<SegmentNode<T>>> nodes;
 	//! Lock to access or modify the nodes
 	mutable mutex node_lock;
 
 private:
+	class BaseSegmentIterator {
+	public:
+		BaseSegmentIterator(SegmentTree &tree_p, optional_ptr<SegmentNode<T>> current_p, optional_ptr<SegmentLock> lock)
+		    : tree(tree_p), current(current_p), lock(lock) {
+		}
+
+		SegmentTree &tree;
+		optional_ptr<SegmentNode<T>> current;
+		optional_ptr<SegmentLock> lock;
+
+	public:
+		void Next() {
+			current = lock ? tree.GetNextSegment(*lock, *current) : tree.GetNextSegment(*current);
+		}
+
+		BaseSegmentIterator &operator++() {
+			Next();
+			return *this;
+		}
+		bool operator!=(const BaseSegmentIterator &other) const {
+			return current != other.current;
+		}
+	};
 	class SegmentIterationHelper {
 	public:
 		explicit SegmentIterationHelper(SegmentTree &tree) : tree(tree) {
@@ -314,31 +363,46 @@ private:
 		optional_ptr<SegmentLock> lock;
 
 	private:
-		class SegmentIterator {
+		class SegmentIterator : public BaseSegmentIterator {
 		public:
-			SegmentIterator(SegmentTree &tree_p, T *current_p, optional_ptr<SegmentLock> lock)
-			    : tree(tree_p), current(current_p), lock(lock) {
+			SegmentIterator(SegmentTree &tree_p, optional_ptr<SegmentNode<T>> current_p, optional_ptr<SegmentLock> lock)
+			    : BaseSegmentIterator(tree_p, current_p, lock) {
 			}
 
-			SegmentTree &tree;
-			T *current;
-			optional_ptr<SegmentLock> lock;
-
-		public:
-			void Next() {
-				current = lock ? tree.GetNextSegment(*lock, current) : tree.GetNextSegment(current);
-			}
-
-			SegmentIterator &operator++() {
-				Next();
-				return *this;
-			}
-			bool operator!=(const SegmentIterator &other) const {
-				return current != other.current;
-			}
 			T &operator*() const {
-				D_ASSERT(current);
-				return *current;
+				return *BaseSegmentIterator::current->node;
+			}
+		};
+
+	public:
+		SegmentIterator begin() { // NOLINT: match stl API
+			auto root = lock ? tree.GetRootSegment(*lock) : tree.GetRootSegment();
+			return SegmentIterator(tree, root, lock);
+		}
+		SegmentIterator end() { // NOLINT: match stl API
+			return SegmentIterator(tree, nullptr, lock);
+		}
+	};
+	class SegmentNodeIterationHelper {
+	public:
+		explicit SegmentNodeIterationHelper(SegmentTree &tree) : tree(tree) {
+		}
+		SegmentNodeIterationHelper(SegmentTree &tree, SegmentLock &l) : tree(tree), lock(l) {
+		}
+
+	private:
+		SegmentTree &tree;
+		optional_ptr<SegmentLock> lock;
+
+	private:
+		class SegmentIterator : public BaseSegmentIterator {
+		public:
+			SegmentIterator(SegmentTree &tree_p, optional_ptr<SegmentNode<T>> current_p, optional_ptr<SegmentLock> lock)
+			    : BaseSegmentIterator(tree_p, current_p, lock) {
+			}
+
+			SegmentNode<T> &operator*() {
+				return *BaseSegmentIterator::current;
 			}
 		};
 

--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -175,13 +175,13 @@ public:
 		D_ASSERT(segment);
 		// add the node to the list of nodes
 		auto node = make_uniq<SegmentNode<T>>();
-		if (!nodes.empty()) {
-			nodes.back()->next = node.get();
-		}
 		node->row_start = segment->start;
 		node->node = std::move(segment);
 		node->index = nodes.size();
 		node->next = nullptr;
+		if (!nodes.empty()) {
+			nodes.back()->next = node.get();
+		}
 		nodes.push_back(std::move(node));
 	}
 	void AppendSegment(unique_ptr<T> segment) {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1058,7 +1058,8 @@ void DataTable::ScanTableSegment(DuckTransaction &transaction, idx_t row_start, 
 	CreateIndexScanState state;
 
 	InitializeScanWithOffset(transaction, state, column_ids, row_start, row_start + count);
-	auto row_start_aligned = state.table_state.row_group->start + state.table_state.vector_index * STANDARD_VECTOR_SIZE;
+	auto row_start_aligned =
+	    state.table_state.row_group->node->start + state.table_state.vector_index * STANDARD_VECTOR_SIZE;
 
 	idx_t current_row = row_start_aligned;
 	while (current_row < end) {

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -81,14 +81,14 @@ bool ColumnData::HasChanges() const {
 	auto l = data.Lock();
 	auto &nodes = data.ReferenceLoadedSegments(l);
 	for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
-		auto segment = nodes[segment_idx].node.get();
-		if (segment->segment_type == ColumnSegmentType::TRANSIENT) {
+		auto &segment = *nodes[segment_idx]->node;
+		if (segment.segment_type == ColumnSegmentType::TRANSIENT) {
 			// transient segment: always need to write to disk
 			return true;
 		}
 		// persistent segment; check if there were any updates or deletions in this segment
-		idx_t start_row_idx = segment->start - start;
-		idx_t end_row_idx = start_row_idx + segment->count;
+		idx_t start_row_idx = segment.start - start;
+		idx_t end_row_idx = start_row_idx + segment.count;
 		if (HasChanges(start_row_idx, end_row_idx)) {
 			return true;
 		}
@@ -112,7 +112,7 @@ idx_t ColumnData::GetMaxEntry() {
 void ColumnData::InitializeScan(ColumnScanState &state) {
 	state.current = data.GetRootSegment();
 	state.segment_tree = &data;
-	state.row_index = state.current ? state.current->start : 0;
+	state.row_index = state.current ? state.current->row_start : 0;
 	state.internal_index = state.row_index;
 	state.initialized = false;
 	state.scan_state.reset();
@@ -123,7 +123,7 @@ void ColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx)
 	state.current = data.GetSegment(row_idx);
 	state.segment_tree = &data;
 	state.row_index = row_idx;
-	state.internal_index = state.current->start;
+	state.internal_index = state.current->row_start;
 	state.initialized = false;
 	state.scan_state.reset();
 	state.last_offset = 0;
@@ -139,7 +139,8 @@ ScanVectorType ColumnData::GetVectorScanType(ColumnScanState &state, idx_t scan_
 		return ScanVectorType::SCAN_FLAT_VECTOR;
 	}
 	// check if the current segment has enough data remaining
-	idx_t remaining_in_segment = state.current->start + state.current->count - state.row_index;
+	auto &current = *state.current->node;
+	idx_t remaining_in_segment = current.start + current.count - state.row_index;
 	if (remaining_in_segment < scan_count) {
 		// there is not enough data remaining in the current segment so we need to scan across segments
 		// we need flat vectors here
@@ -155,19 +156,20 @@ void ColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanSta
 	}
 	if (!scan_state.initialized) {
 		// need to prefetch for the current segment if we have not yet initialized the scan for this segment
-		scan_state.current->InitializePrefetch(prefetch_state, scan_state);
+		current_segment->node->InitializePrefetch(prefetch_state, scan_state);
 	}
 	idx_t row_index = scan_state.row_index;
 	while (remaining > 0) {
-		idx_t scan_count = MinValue<idx_t>(remaining, current_segment->start + current_segment->count - row_index);
+		auto &current = *current_segment->node;
+		idx_t scan_count = MinValue<idx_t>(remaining, current.start + current.count - row_index);
 		remaining -= scan_count;
 		row_index += scan_count;
 		if (remaining > 0) {
-			auto next = data.GetNextSegment(current_segment);
+			auto next = data.GetNextSegment(*current_segment);
 			if (!next) {
 				break;
 			}
-			next->InitializePrefetch(prefetch_state, scan_state);
+			next->node->InitializePrefetch(prefetch_state, scan_state);
 			current_segment = next;
 		}
 	}
@@ -176,17 +178,18 @@ void ColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanSta
 void ColumnData::BeginScanVectorInternal(ColumnScanState &state) {
 	state.previous_states.clear();
 	if (!state.initialized) {
-		D_ASSERT(state.current);
-		state.current->InitializeScan(state);
-		state.internal_index = state.current->start;
+		auto &current = *state.current->node;
+		current.InitializeScan(state);
+		state.internal_index = current.start;
 		state.initialized = true;
 	}
-	D_ASSERT(data.HasSegment(state.current));
+	D_ASSERT(data.HasSegment(*state.current));
 	D_ASSERT(state.internal_index <= state.row_index);
 	if (state.internal_index < state.row_index) {
-		state.current->Skip(state);
+		auto &current = *state.current->node;
+		current.Skip(state);
 	}
-	D_ASSERT(state.current->type == type);
+	D_ASSERT(state.current->node->type == type);
 }
 
 idx_t ColumnData::ScanVector(ColumnScanState &state, Vector &result, idx_t remaining, ScanVectorType scan_type,
@@ -197,19 +200,19 @@ idx_t ColumnData::ScanVector(ColumnScanState &state, Vector &result, idx_t remai
 	BeginScanVectorInternal(state);
 	idx_t initial_remaining = remaining;
 	while (remaining > 0) {
-		D_ASSERT(state.row_index >= state.current->start &&
-		         state.row_index <= state.current->start + state.current->count);
-		idx_t scan_count = MinValue<idx_t>(remaining, state.current->start + state.current->count - state.row_index);
+		auto &current = *state.current->node;
+		D_ASSERT(state.row_index >= current.start && state.row_index <= current.start + current.count);
+		idx_t scan_count = MinValue<idx_t>(remaining, current.start + current.count - state.row_index);
 		idx_t result_offset = base_result_offset + initial_remaining - remaining;
 		if (scan_count > 0) {
 			if (state.scan_options && state.scan_options->force_fetch_row) {
 				for (idx_t i = 0; i < scan_count; i++) {
 					ColumnFetchState fetch_state;
-					state.current->FetchRow(fetch_state, UnsafeNumericCast<row_t>(state.row_index + i), result,
-					                        result_offset + i);
+					current.FetchRow(fetch_state, UnsafeNumericCast<row_t>(state.row_index + i), result,
+					                 result_offset + i);
 				}
 			} else {
-				state.current->Scan(state, scan_count, result, result_offset, scan_type);
+				current.Scan(state, scan_count, result, result_offset, scan_type);
 			}
 
 			state.row_index += scan_count;
@@ -217,16 +220,16 @@ idx_t ColumnData::ScanVector(ColumnScanState &state, Vector &result, idx_t remai
 		}
 
 		if (remaining > 0) {
-			auto next = data.GetNextSegment(state.current);
+			auto next = data.GetNextSegment(*state.current);
 			if (!next) {
 				break;
 			}
 			state.previous_states.emplace_back(std::move(state.scan_state));
 			state.current = next;
-			state.current->InitializeScan(state);
+			state.current->node->InitializeScan(state);
 			state.segment_checked = false;
-			D_ASSERT(state.row_index >= state.current->start &&
-			         state.row_index <= state.current->start + state.current->count);
+			D_ASSERT(state.row_index >= state.current->node->start &&
+			         state.row_index <= state.current->node->start + state.current->node->count);
 		}
 	}
 	state.internal_index = state.row_index;
@@ -236,17 +239,18 @@ idx_t ColumnData::ScanVector(ColumnScanState &state, Vector &result, idx_t remai
 void ColumnData::SelectVector(ColumnScanState &state, Vector &result, idx_t target_count, const SelectionVector &sel,
                               idx_t sel_count) {
 	BeginScanVectorInternal(state);
-	if (state.current->start + state.current->count - state.row_index < target_count) {
+	auto &current = *state.current->node;
+	if (current.start + current.count - state.row_index < target_count) {
 		throw InternalException("ColumnData::SelectVector should be able to fetch everything from one segment");
 	}
 	if (state.scan_options && state.scan_options->force_fetch_row) {
 		for (idx_t i = 0; i < sel_count; i++) {
 			auto source_idx = sel.get_index(i);
 			ColumnFetchState fetch_state;
-			state.current->FetchRow(fetch_state, UnsafeNumericCast<row_t>(state.row_index + source_idx), result, i);
+			current.FetchRow(fetch_state, UnsafeNumericCast<row_t>(state.row_index + source_idx), result, i);
 		}
 	} else {
-		state.current->Select(state, target_count, result, sel, sel_count);
+		current.Select(state, target_count, result, sel, sel_count);
 	}
 	state.row_index += target_count;
 	state.internal_index = state.row_index;
@@ -255,10 +259,11 @@ void ColumnData::SelectVector(ColumnScanState &state, Vector &result, idx_t targ
 void ColumnData::FilterVector(ColumnScanState &state, Vector &result, idx_t target_count, SelectionVector &sel,
                               idx_t &sel_count, const TableFilter &filter, TableFilterState &filter_state) {
 	BeginScanVectorInternal(state);
-	if (state.current->start + state.current->count - state.row_index < target_count) {
+	auto &current = *state.current->node;
+	if (current.start + current.count - state.row_index < target_count) {
 		throw InternalException("ColumnData::Filter should be able to fetch everything from one segment");
 	}
-	state.current->Filter(state, target_count, result, sel, sel_count, filter, filter_state);
+	current.Filter(state, target_count, result, sel, sel_count, filter, filter_state);
 	state.row_index += target_count;
 	state.internal_index = state.row_index;
 }
@@ -420,7 +425,7 @@ FilterPropagateResult ColumnData::CheckZonemap(ColumnScanState &state, TableFilt
 	FilterPropagateResult prune_result;
 	{
 		lock_guard<mutex> l(stats_lock);
-		prune_result = filter.CheckStatistics(state.current->stats.statistics);
+		prune_result = filter.CheckStatistics(state.current->node->stats.statistics);
 		if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
@@ -478,18 +483,20 @@ void ColumnData::InitializeAppend(ColumnAppendState &state) {
 		AppendTransientSegment(l, start);
 	}
 	auto segment = data.GetLastSegment(l);
-	if (segment->segment_type == ColumnSegmentType::PERSISTENT || !segment->GetCompressionFunction().init_append) {
+	auto &last_segment = *segment->node;
+	if (last_segment.segment_type == ColumnSegmentType::PERSISTENT ||
+	    !last_segment.GetCompressionFunction().init_append) {
 		// we cannot append to this segment - append a new segment
-		auto total_rows = segment->start + segment->count;
+		auto total_rows = last_segment.start + last_segment.count;
 		AppendTransientSegment(l, total_rows);
 		state.current = data.GetLastSegment(l);
 	} else {
 		state.current = segment;
 	}
-
-	D_ASSERT(state.current->segment_type == ColumnSegmentType::TRANSIENT);
-	state.current->InitializeAppend(state);
-	D_ASSERT(state.current->GetCompressionFunction().append);
+	auto &append_segment = *state.current->node;
+	D_ASSERT(append_segment.segment_type == ColumnSegmentType::TRANSIENT);
+	append_segment.InitializeAppend(state);
+	D_ASSERT(append_segment.GetCompressionFunction().append);
 }
 
 void ColumnData::AppendData(BaseStatistics &append_stats, ColumnAppendState &state, UnifiedVectorFormat &vdata,
@@ -497,9 +504,10 @@ void ColumnData::AppendData(BaseStatistics &append_stats, ColumnAppendState &sta
 	idx_t offset = 0;
 	while (true) {
 		// append the data from the vector
-		idx_t copied_elements = state.current->Append(state, vdata, offset, append_count);
+		auto &append_segment = *state.current->node;
+		idx_t copied_elements = append_segment.Append(state, vdata, offset, append_count);
 		this->count += copied_elements;
-		append_stats.Merge(state.current->stats.statistics);
+		append_stats.Merge(append_segment.stats.statistics);
 		if (copied_elements == append_count) {
 			// finished copying everything
 			break;
@@ -508,9 +516,9 @@ void ColumnData::AppendData(BaseStatistics &append_stats, ColumnAppendState &sta
 		// we couldn't fit everything we wanted in the current column segment, create a new one
 		{
 			auto l = data.Lock();
-			AppendTransientSegment(l, state.current->start + state.current->count);
+			AppendTransientSegment(l, append_segment.start + append_segment.count);
 			state.current = data.GetLastSegment(l);
-			state.current->InitializeAppend(state);
+			state.current->node->InitializeAppend(state);
 		}
 		offset += copied_elements;
 		append_count -= copied_elements;
@@ -521,19 +529,20 @@ void ColumnData::RevertAppend(row_t start_row_p) {
 	idx_t start_row = NumericCast<idx_t>(start_row_p);
 	auto l = data.Lock();
 	// check if this row is in the segment tree at all
-	auto last_segment = data.GetLastSegment(l);
-	if (!last_segment) {
+	auto last_segment_node = data.GetLastSegment(l);
+	if (!last_segment_node) {
 		return;
 	}
-	if (start_row >= last_segment->start + last_segment->count) {
+	auto &last_segment = *last_segment_node->node;
+	if (start_row >= last_segment.start + last_segment.count) {
 		// the start row is equal to the final portion of the column data: nothing was ever appended here
-		D_ASSERT(start_row == last_segment->start + last_segment->count);
+		D_ASSERT(start_row == last_segment.start + last_segment.count);
 		return;
 	}
 	// find the segment index that the current row belongs to
 	idx_t segment_index = data.GetSegmentIndex(l, start_row);
 	auto segment = data.GetSegmentByIndex(l, UnsafeNumericCast<int64_t>(segment_index));
-	if (segment->start == start_row) {
+	if (segment->node->start == start_row) {
 		// we are truncating exactly this segment - erase it entirely
 		data.EraseSegments(l, segment_index);
 	} else {
@@ -541,7 +550,7 @@ void ColumnData::RevertAppend(row_t start_row_p) {
 		// remove any segments AFTER this segment: they should be deleted entirely
 		data.EraseSegments(l, segment_index + 1);
 
-		auto &transient = *segment;
+		auto &transient = *segment->node;
 		D_ASSERT(transient.segment_type == ColumnSegmentType::TRANSIENT);
 		segment->next = nullptr;
 		transient.RevertAppend(start_row);
@@ -557,7 +566,7 @@ idx_t ColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &result) {
 	state.row_index =
 	    start + ((UnsafeNumericCast<idx_t>(row_id) - start) / STANDARD_VECTOR_SIZE * STANDARD_VECTOR_SIZE);
 	state.current = data.GetSegment(state.row_index);
-	state.internal_index = state.current->start;
+	state.internal_index = state.current->node->start;
 	return ScanVector(state, result, STANDARD_VECTOR_SIZE, ScanVectorType::SCAN_FLAT_VECTOR);
 }
 
@@ -566,7 +575,7 @@ void ColumnData::FetchRow(TransactionData transaction, ColumnFetchState &state, 
 	auto segment = data.GetSegment(UnsafeNumericCast<idx_t>(row_id));
 
 	// now perform the fetch within the segment
-	segment->FetchRow(state, row_id, result, result_idx);
+	segment->node->FetchRow(state, row_id, result, result_idx);
 	// merge any updates made to this row
 
 	FetchUpdateRow(transaction, row_id, result, result_idx);
@@ -926,40 +935,39 @@ void ColumnData::GetColumnSegmentInfo(const QueryContext &context, idx_t row_gro
 
 	// iterate over the segments
 	idx_t segment_idx = 0;
-	auto segment = data.GetRootSegment();
-	while (segment) {
+	for (auto &segment : data.Segments()) {
 		ColumnSegmentInfo column_info;
 		column_info.row_group_index = row_group_index;
 		column_info.column_id = col_path[0];
 		column_info.column_path = col_path_str;
 		column_info.segment_idx = segment_idx;
 		column_info.segment_type = type.ToString();
-		column_info.segment_start = segment->start;
-		column_info.segment_count = segment->count;
-		column_info.compression_type = CompressionTypeToString(segment->GetCompressionFunction().type);
+		column_info.segment_start = segment.start;
+		column_info.segment_count = segment.count;
+		column_info.compression_type = CompressionTypeToString(segment.GetCompressionFunction().type);
 		{
 			lock_guard<mutex> l(stats_lock);
-			column_info.segment_stats = segment->stats.statistics.ToString();
+			column_info.segment_stats = segment.stats.statistics.ToString();
 		}
 		column_info.has_updates = ColumnData::HasUpdates();
 		// persistent
 		// block_id
 		// block_offset
-		if (segment->segment_type == ColumnSegmentType::PERSISTENT) {
+		if (segment.segment_type == ColumnSegmentType::PERSISTENT) {
 			column_info.persistent = true;
-			column_info.block_id = segment->GetBlockId();
-			column_info.block_offset = segment->GetBlockOffset();
+			column_info.block_id = segment.GetBlockId();
+			column_info.block_offset = segment.GetBlockOffset();
 		} else {
 			column_info.persistent = false;
 		}
-		auto &compression_function = segment->GetCompressionFunction();
-		auto segment_state = segment->GetSegmentState();
+		auto &compression_function = segment.GetCompressionFunction();
+		auto segment_state = segment.GetSegmentState();
 		if (segment_state) {
 			column_info.segment_info = segment_state->GetSegmentInfo();
 			column_info.additional_blocks = segment_state->GetAdditionalBlocks();
 		}
 		if (compression_function.get_segment_info) {
-			auto segment_info = compression_function.get_segment_info(context, *segment);
+			auto segment_info = compression_function.get_segment_info(context, segment);
 			vector<string> sinfo;
 			for (auto &item : segment_info) {
 				auto &mode = item.first;
@@ -971,7 +979,6 @@ void ColumnData::GetColumnSegmentInfo(const QueryContext &context, idx_t row_gro
 		result.emplace_back(column_info);
 
 		segment_idx++;
-		segment = data.GetNextSegment(segment);
 	}
 }
 

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -994,11 +994,11 @@ void ColumnData::Verify(RowGroup &parent) {
 	idx_t current_index = 0;
 	idx_t current_start = this->start;
 	idx_t total_count = 0;
-	for (auto &segment : data.Segments()) {
+	for (auto &segment : data.SegmentNodes()) {
 		D_ASSERT(segment.index == current_index);
-		D_ASSERT(segment.start == current_start);
-		current_start += segment.count;
-		total_count += segment.count;
+		D_ASSERT(segment.row_start == current_start);
+		current_start += segment.node->count;
+		total_count += segment.node->count;
 		current_index++;
 	}
 	D_ASSERT(this->count == total_count);

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -86,9 +86,10 @@ void ColumnDataCheckpointer::ScanSegments(const std::function<void(Vector &, idx
 
 	// TODO: scan all the nodes from all segments, no need for CheckpointScan to virtualize this I think..
 	for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
-		auto &segment = *nodes[segment_idx].node;
+		auto &segment_node = *nodes[segment_idx];
+		auto &segment = *segment_node.node;
 		ColumnScanState scan_state;
-		scan_state.current = &segment;
+		scan_state.current = segment_node;
 		segment.InitializeScan(scan_state);
 
 		for (idx_t base_row_index = 0; base_row_index < segment.count; base_row_index += STANDARD_VECTOR_SIZE) {
@@ -284,8 +285,8 @@ void ColumnDataCheckpointer::DropSegments() {
 
 		// Drop the segments, as we'll be replacing them with new ones, because there are changes
 		for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
-			auto segment = nodes[segment_idx].node.get();
-			segment->CommitDropSegment();
+			auto &segment = *nodes[segment_idx]->node;
+			segment.CommitDropSegment();
 		}
 	}
 }
@@ -373,12 +374,12 @@ void ColumnDataCheckpointer::WritePersistentSegments(ColumnCheckpointState &stat
 
 	idx_t current_row = row_group.start;
 	for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
-		auto segment = nodes[segment_idx].node.get();
-		if (segment->start != current_row) {
+		auto &segment = *nodes[segment_idx]->node;
+		if (segment.start != current_row) {
 			string extra_info;
 			for (auto &s : nodes) {
 				extra_info += "\n";
-				extra_info += StringUtil::Format("Start %d, count %d", s.node->start, s.node->count.load());
+				extra_info += StringUtil::Format("Start %d, count %d", segment.start, segment.count.load());
 			}
 			const_reference<ColumnData> root = col_data;
 			while (root.get().HasParent()) {
@@ -388,18 +389,18 @@ void ColumnDataCheckpointer::WritePersistentSegments(ColumnCheckpointState &stat
 			    "Failure in RowGroup::Checkpoint - column data pointer is unaligned with row group "
 			    "start\nRow group start: %d\nRow group count %d\nCurrent row: %d\nSegment start: %d\nColumn index: "
 			    "%d\nColumn type: %s\nRoot type: %s\nTable: %s.%s\nAll segments:%s",
-			    row_group.start, row_group.count.load(), current_row, segment->start, root.get().column_index,
+			    row_group.start, row_group.count.load(), current_row, segment.start, root.get().column_index,
 			    col_data.type, root.get().type, root.get().info.GetSchemaName(), root.get().info.GetTableName(),
 			    extra_info);
 		}
-		current_row += segment->count;
-		auto pointer = segment->GetDataPointer();
+		current_row += segment.count;
+		auto pointer = segment.GetDataPointer();
 
 		// merge the persistent stats into the global column stats
-		state.global_stats->Merge(segment->stats.statistics);
+		state.global_stats->Merge(segment.stats.statistics);
 
 		// directly append the current segment to the new tree
-		state.new_tree.AppendSegment(std::move(nodes[segment_idx].node));
+		state.new_tree.AppendSegment(std::move(nodes[segment_idx]->node));
 
 		state.data_pointers.push_back(std::move(pointer));
 	}
@@ -446,7 +447,7 @@ void ColumnDataCheckpointer::FinalizeCheckpoint() {
 		auto new_segments = state.new_tree.MoveSegments();
 		auto l = col_data.data.Lock();
 		for (auto &new_segment : new_segments) {
-			col_data.AppendSegment(l, std::move(new_segment.node));
+			col_data.AppendSegment(l, std::move(new_segment->node));
 		}
 		col_data.ClearUpdates();
 	}

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -58,7 +58,7 @@ uint64_t ListColumnData::FetchListOffset(idx_t row_idx) {
 	auto segment = data.GetSegment(row_idx);
 	ColumnFetchState fetch_state;
 	Vector result(LogicalType::UBIGINT, 1);
-	segment->FetchRow(fetch_state, UnsafeNumericCast<row_t>(row_idx), result, 0U);
+	segment->node->FetchRow(fetch_state, UnsafeNumericCast<row_t>(row_idx), result, 0U);
 
 	// initialize the child scan with the required offset
 	return FlatVector::GetData<uint64_t>(result)[0];

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -86,12 +86,6 @@ void RowGroup::MoveToCollection(RowGroupCollection &collection_p, idx_t new_star
 	if (row_id_is_loaded) {
 		row_id_column_data->SetStart(new_start);
 	}
-	if (!HasUnloadedDeletes()) {
-		auto vinfo = GetVersionInfo();
-		if (vinfo) {
-			vinfo->SetStart(new_start);
-		}
-	}
 }
 
 RowGroup::~RowGroup() {
@@ -716,7 +710,7 @@ optional_ptr<RowVersionManager> RowGroup::GetVersionInfo() {
 	}
 	// deletes are not loaded - reload
 	auto root_delete = deletes_pointers[0];
-	auto loaded_info = RowVersionManager::Deserialize(root_delete, GetBlockManager().GetMetadataManager(), start);
+	auto loaded_info = RowVersionManager::Deserialize(root_delete, GetBlockManager().GetMetadataManager());
 	SetVersionInfo(std::move(loaded_info));
 	deletes_is_loaded = true;
 	return version_info;
@@ -732,7 +726,7 @@ shared_ptr<RowVersionManager> RowGroup::GetOrCreateVersionInfoInternal() {
 	lock_guard<mutex> lock(row_group_lock);
 	if (!owned_version_info) {
 		auto &buffer_manager = GetBlockManager().GetBufferManager();
-		auto new_info = make_shared_ptr<RowVersionManager>(buffer_manager, start);
+		auto new_info = make_shared_ptr<RowVersionManager>(buffer_manager);
 		SetVersionInfo(std::move(new_info));
 	}
 	return owned_version_info;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -379,7 +379,7 @@ void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppe
 		AppendRowGroup(l, row_start + total_rows);
 	}
 	state.start_row_group = row_groups->GetLastSegment(l);
-	D_ASSERT(this->row_start + total_rows == state.start_row_group->start + state.start_row_group->count);
+	D_ASSERT(this->row_start + total_rows == state.start_row_group->row_start + state.start_row_group->node->count);
 	state.start_row_group->node->InitializeAppend(state.row_group_append_state);
 	state.transaction = transaction;
 
@@ -1029,7 +1029,7 @@ bool RowGroupCollection::ScheduleVacuumTasks(CollectionCheckpointState &checkpoi
 	}
 	if (state.row_group_counts[segment_idx] == 0) {
 		// segment was already dropped - skip
-		D_ASSERT(!checkpoint_state.segments[segment_idx].node);
+		D_ASSERT(!checkpoint_state.segments[segment_idx]->node);
 		return false;
 	}
 	if (!schedule_vacuum) {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -134,7 +134,11 @@ void RowGroupCollection::AppendRowGroup(SegmentLock &l, idx_t start_row) {
 }
 
 optional_ptr<RowGroup> RowGroupCollection::GetRowGroup(int64_t index) {
-	return row_groups->GetSegmentByIndex(index);
+	auto result = row_groups->GetSegmentByIndex(index);
+	if (!result) {
+		return nullptr;
+	}
+	return result->node.get();
 }
 
 void RowGroupCollection::Verify() {
@@ -163,7 +167,7 @@ void RowGroupCollection::InitializeScan(const QueryContext &context, CollectionS
 	state.row_groups = row_groups.get();
 	state.max_row = row_start + total_rows;
 	state.Initialize(context, GetTypes());
-	while (row_group && !row_group->InitializeScan(state)) {
+	while (row_group && !row_group->node->InitializeScan(state, *row_group)) {
 		row_group = state.GetNextRowGroup(*row_group);
 	}
 }
@@ -180,14 +184,14 @@ void RowGroupCollection::InitializeScanWithOffset(const QueryContext &context, C
 	state.row_groups = row_groups.get();
 	state.max_row = end_row;
 	state.Initialize(context, GetTypes());
-	idx_t start_vector = (start_row - row_group->start) / STANDARD_VECTOR_SIZE;
-	if (!row_group->InitializeScanWithOffset(state, start_vector)) {
+	idx_t start_vector = (start_row - row_group->node->start) / STANDARD_VECTOR_SIZE;
+	if (!row_group->node->InitializeScanWithOffset(state, *row_group, start_vector)) {
 		throw InternalException("Failed to initialize row group scan with offset");
 	}
 }
 
 bool RowGroupCollection::InitializeScanInRowGroup(const QueryContext &context, CollectionScanState &state,
-                                                  RowGroupCollection &collection, RowGroup &row_group,
+                                                  RowGroupCollection &collection, SegmentNode<RowGroup> &row_group,
                                                   idx_t vector_index, idx_t max_row) {
 	state.max_row = max_row;
 	state.row_groups = collection.row_groups.get();
@@ -195,12 +199,12 @@ bool RowGroupCollection::InitializeScanInRowGroup(const QueryContext &context, C
 		// initialize the scan state
 		state.Initialize(context, collection.GetTypes());
 	}
-	return row_group.InitializeScanWithOffset(state, vector_index);
+	return row_group.node->InitializeScanWithOffset(state, row_group, vector_index);
 }
 
 void RowGroupCollection::InitializeParallelScan(ParallelCollectionScanState &state) {
 	state.collection = this;
-	state.current_row_group = state.GetRootSegment(*row_groups).get();
+	state.current_row_group = state.GetRootSegment(*row_groups);
 	state.vector_index = 0;
 	state.max_row = row_start + total_rows;
 	state.batch_index = 0;
@@ -213,32 +217,36 @@ bool RowGroupCollection::NextParallelScan(ClientContext &context, ParallelCollec
 		idx_t vector_index;
 		idx_t max_row;
 		RowGroupCollection *collection;
-		RowGroup *row_group;
+		optional_ptr<SegmentNode<RowGroup>> row_group;
 		{
 			// select the next row group to scan from the parallel state
 			lock_guard<mutex> l(state.lock);
-			if (!state.current_row_group || state.current_row_group->count == 0) {
+			if (!state.current_row_group) {
 				// no more data left to scan
+				break;
+			}
+			auto &current_row_group = *state.current_row_group->node;
+			if (current_row_group.count == 0) {
 				break;
 			}
 			collection = state.collection;
 			row_group = state.current_row_group;
 			if (ClientConfig::GetConfig(context).verify_parallelism) {
 				vector_index = state.vector_index;
-				max_row = state.current_row_group->start +
-				          MinValue<idx_t>(state.current_row_group->count,
+				max_row = current_row_group.start +
+				          MinValue<idx_t>(current_row_group.count,
 				                          STANDARD_VECTOR_SIZE * state.vector_index + STANDARD_VECTOR_SIZE);
-				D_ASSERT(vector_index * STANDARD_VECTOR_SIZE < state.current_row_group->count);
+				D_ASSERT(vector_index * STANDARD_VECTOR_SIZE < current_row_group.count);
 				state.vector_index++;
-				if (state.vector_index * STANDARD_VECTOR_SIZE >= state.current_row_group->count) {
-					state.current_row_group = state.GetNextRowGroup(*row_groups, row_group).get();
+				if (state.vector_index * STANDARD_VECTOR_SIZE >= current_row_group.count) {
+					state.current_row_group = state.GetNextRowGroup(*row_groups, *row_group).get();
 					state.vector_index = 0;
 				}
 			} else {
-				state.processed_rows += state.current_row_group->count;
+				state.processed_rows += current_row_group.count;
 				vector_index = 0;
-				max_row = state.current_row_group->start + state.current_row_group->count;
-				state.current_row_group = state.GetNextRowGroup(*row_groups, row_group).get();
+				max_row = current_row_group.start + current_row_group.count;
+				state.current_row_group = state.GetNextRowGroup(*row_groups, *row_group).get();
 			}
 			max_row = MinValue<idx_t>(max_row, state.max_row);
 			scan_state.batch_index = ++state.batch_index;
@@ -305,7 +313,7 @@ void RowGroupCollection::Fetch(TransactionData transaction, DataChunk &result, c
 	idx_t count = 0;
 	for (idx_t i = 0; i < fetch_count; i++) {
 		auto row_id = row_ids[i];
-		RowGroup *row_group;
+		optional_ptr<SegmentNode<RowGroup>> row_group;
 		{
 			idx_t segment_index;
 			auto l = row_groups->Lock();
@@ -315,17 +323,18 @@ void RowGroupCollection::Fetch(TransactionData transaction, DataChunk &result, c
 			}
 			row_group = row_groups->GetSegmentByIndex(l, UnsafeNumericCast<int64_t>(segment_index));
 		}
-		if (!row_group->Fetch(transaction, UnsafeNumericCast<idx_t>(row_id) - row_group->start)) {
+		auto &current_row_group = *row_group->node;
+		if (!current_row_group.Fetch(transaction, UnsafeNumericCast<idx_t>(row_id) - current_row_group.start)) {
 			continue;
 		}
-		row_group->FetchRow(transaction, state, column_ids, row_id, result, count);
+		current_row_group.FetchRow(transaction, state, column_ids, row_id, result, count);
 		count++;
 	}
 	result.SetCardinality(count);
 }
 
 bool RowGroupCollection::CanFetch(TransactionData transaction, const row_t row_id) {
-	RowGroup *row_group;
+	optional_ptr<SegmentNode<RowGroup>> row_group;
 	{
 		idx_t segment_index;
 		auto l = row_groups->Lock();
@@ -334,7 +343,8 @@ bool RowGroupCollection::CanFetch(TransactionData transaction, const row_t row_i
 		}
 		row_group = row_groups->GetSegmentByIndex(l, UnsafeNumericCast<int64_t>(segment_index));
 	}
-	return row_group->Fetch(transaction, UnsafeNumericCast<idx_t>(row_id) - row_group->start);
+	auto &current_row_group = *row_group->node;
+	return current_row_group.Fetch(transaction, UnsafeNumericCast<idx_t>(row_id) - current_row_group.start);
 }
 
 //===--------------------------------------------------------------------===//
@@ -370,7 +380,7 @@ void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppe
 	}
 	state.start_row_group = row_groups->GetLastSegment(l);
 	D_ASSERT(this->row_start + total_rows == state.start_row_group->start + state.start_row_group->count);
-	state.start_row_group->InitializeAppend(state.row_group_append_state);
+	state.start_row_group->node->InitializeAppend(state.row_group_append_state);
 	state.transaction = transaction;
 
 	// initialize thread-local stats so we have less lock contention when updating distinct statistics
@@ -421,7 +431,7 @@ bool RowGroupCollection::Append(DataChunk &chunk, TableAppendState &state) {
 			AppendRowGroup(l, next_start);
 			// set up the append state for this row_group
 			auto last_row_group = row_groups->GetLastSegment(l);
-			last_row_group->InitializeAppend(state.row_group_append_state);
+			last_row_group->node->InitializeAppend(state.row_group_append_state);
 			continue;
 		} else {
 			break;
@@ -445,10 +455,11 @@ void RowGroupCollection::FinalizeAppend(TransactionData transaction, TableAppend
 	auto remaining = state.total_append_count;
 	auto row_group = state.start_row_group;
 	while (remaining > 0) {
-		auto append_count = MinValue<idx_t>(remaining, row_group_size - row_group->count);
-		row_group->AppendVersionInfo(transaction, append_count);
+		auto &current_row_group = *row_group->node;
+		auto append_count = MinValue<idx_t>(remaining, row_group_size - current_row_group.count);
+		current_row_group.AppendVersionInfo(transaction, append_count);
 		remaining -= append_count;
-		row_group = row_groups->GetNextSegment(row_group);
+		row_group = row_groups->GetNextSegment(*row_group);
 	}
 	total_rows += state.total_append_count;
 
@@ -478,17 +489,18 @@ void RowGroupCollection::CommitAppend(transaction_t commit_id, idx_t row_start, 
 	idx_t current_row = row_start;
 	idx_t remaining = count;
 	while (true) {
-		idx_t start_in_row_group = current_row - row_group->start;
-		idx_t append_count = MinValue<idx_t>(row_group->count - start_in_row_group, remaining);
+		auto &current_row_group = *row_group->node;
+		idx_t start_in_row_group = current_row - current_row_group.start;
+		idx_t append_count = MinValue<idx_t>(current_row_group.count - start_in_row_group, remaining);
 
-		row_group->CommitAppend(commit_id, start_in_row_group, append_count);
+		current_row_group.CommitAppend(commit_id, start_in_row_group, append_count);
 
 		current_row += append_count;
 		remaining -= append_count;
 		if (remaining == 0) {
 			break;
 		}
-		row_group = row_groups->GetNextSegment(row_group);
+		row_group = row_groups->GetNextSegment(*row_group);
 	}
 }
 
@@ -508,7 +520,7 @@ void RowGroupCollection::RevertAppendInternal(idx_t start_row) {
 		segment_index = segment_count - 1;
 	}
 	auto &segment = *row_groups->GetSegmentByIndex(l, UnsafeNumericCast<int64_t>(segment_index));
-	if (segment.start == start_row) {
+	if (segment.row_start == start_row) {
 		// we are truncating exactly this row group - erase it entirely
 		row_groups->EraseSegments(l, segment_index);
 	} else {
@@ -517,7 +529,7 @@ void RowGroupCollection::RevertAppendInternal(idx_t start_row) {
 		row_groups->EraseSegments(l, segment_index + 1);
 
 		segment.next = nullptr;
-		segment.RevertAppend(start_row);
+		segment.node->RevertAppend(start_row);
 	}
 }
 
@@ -527,17 +539,18 @@ void RowGroupCollection::CleanupAppend(transaction_t lowest_transaction, idx_t s
 	idx_t current_row = start;
 	idx_t remaining = count;
 	while (true) {
-		idx_t start_in_row_group = current_row - row_group->start;
-		idx_t append_count = MinValue<idx_t>(row_group->count - start_in_row_group, remaining);
+		auto &current_row_group = *row_group->node;
+		idx_t start_in_row_group = current_row - current_row_group.start;
+		idx_t append_count = MinValue<idx_t>(current_row_group.count - start_in_row_group, remaining);
 
-		row_group->CleanupAppend(lowest_transaction, start_in_row_group, append_count);
+		current_row_group.CleanupAppend(lowest_transaction, start_in_row_group, append_count);
 
 		current_row += append_count;
 		remaining -= append_count;
 		if (remaining == 0) {
 			break;
 		}
-		row_group = row_groups->GetNextSegment(row_group);
+		row_group = row_groups->GetNextSegment(*row_group);
 	}
 }
 
@@ -563,7 +576,7 @@ void RowGroupCollection::MergeStorage(RowGroupCollection &data, optional_ptr<Dat
 	idx_t optimistically_written_count = 0;
 	if (commit_state) {
 		for (auto &entry : segments) {
-			auto &row_group = *entry.node;
+			auto &row_group = *entry->node;
 			if (!row_group.IsPersistent()) {
 				break;
 			}
@@ -574,7 +587,7 @@ void RowGroupCollection::MergeStorage(RowGroupCollection &data, optional_ptr<Dat
 		}
 	}
 	for (auto &entry : segments) {
-		auto &row_group = entry.node;
+		auto &row_group = entry->node;
 		row_group->MoveToCollection(*this, index);
 
 		if (commit_state && (index - start_index) < optimistically_written_count) {
@@ -607,19 +620,21 @@ idx_t RowGroupCollection::Delete(TransactionData transaction, DataTable &table, 
 	do {
 		idx_t start = pos;
 		auto row_group = row_groups->GetSegment(UnsafeNumericCast<idx_t>(ids[start]));
+
+		auto &current_row_group = *row_group->node;
 		for (pos++; pos < count; pos++) {
 			D_ASSERT(ids[pos] >= 0);
 			// check if this id still belongs to this row group
-			if (idx_t(ids[pos]) < row_group->start) {
+			if (idx_t(ids[pos]) < current_row_group.start) {
 				// id is before row_group start -> it does not
 				break;
 			}
-			if (idx_t(ids[pos]) >= row_group->start + row_group->count) {
+			if (idx_t(ids[pos]) >= current_row_group.start + current_row_group.count) {
 				// id is after row group end -> it does not
 				break;
 			}
 		}
-		delete_count += row_group->Delete(transaction, table, ids + start, pos - start);
+		delete_count += current_row_group.Delete(transaction, table, ids + start, pos - start);
 	} while (pos < count);
 
 	return delete_count;
@@ -628,14 +643,15 @@ idx_t RowGroupCollection::Delete(TransactionData transaction, DataTable &table, 
 //===--------------------------------------------------------------------===//
 // Update
 //===--------------------------------------------------------------------===//
-optional_ptr<RowGroup> RowGroupCollection::NextUpdateRowGroup(row_t *ids, idx_t &pos, idx_t count) const {
+optional_ptr<SegmentNode<RowGroup>> RowGroupCollection::NextUpdateRowGroup(row_t *ids, idx_t &pos, idx_t count) const {
 	auto row_group = row_groups->GetSegment(UnsafeNumericCast<idx_t>(ids[pos]));
 
-	row_t base_id =
-	    UnsafeNumericCast<row_t>(row_group->start + ((UnsafeNumericCast<idx_t>(ids[pos]) - row_group->start) /
-	                                                 STANDARD_VECTOR_SIZE * STANDARD_VECTOR_SIZE));
-	auto max_id =
-	    MinValue<row_t>(base_id + STANDARD_VECTOR_SIZE, UnsafeNumericCast<row_t>(row_group->start + row_group->count));
+	auto &current_row_group = *row_group->node;
+	row_t base_id = UnsafeNumericCast<row_t>(
+	    current_row_group.start +
+	    ((UnsafeNumericCast<idx_t>(ids[pos]) - current_row_group.start) / STANDARD_VECTOR_SIZE * STANDARD_VECTOR_SIZE));
+	auto max_id = MinValue<row_t>(base_id + STANDARD_VECTOR_SIZE,
+	                              UnsafeNumericCast<row_t>(current_row_group.start + current_row_group.count));
 	for (pos++; pos < count; pos++) {
 		D_ASSERT(ids[pos] >= 0);
 		// check if this id still belongs to this vector in this row group
@@ -658,12 +674,14 @@ void RowGroupCollection::Update(TransactionData transaction, DataTable &data_tab
 	do {
 		idx_t start = pos;
 		auto row_group = NextUpdateRowGroup(ids, pos, updates.size());
-		row_group->Update(transaction, data_table, updates, ids, start, pos - start, column_ids);
+
+		auto &current_row_group = *row_group->node;
+		current_row_group.Update(transaction, data_table, updates, ids, start, pos - start, column_ids);
 
 		auto l = stats.GetLock();
 		for (idx_t i = 0; i < column_ids.size(); i++) {
 			auto column_id = column_ids[i];
-			stats.MergeStats(*l, column_id.index, *row_group->GetStatistics(column_id.index));
+			stats.MergeStats(*l, column_id.index, *current_row_group.GetStatistics(column_id.index));
 		}
 	} while (pos < updates.size());
 }
@@ -720,13 +738,15 @@ void RowGroupCollection::RemoveFromIndexes(const QueryContext &context, TableInd
 		// Figure out which row_group to fetch from.
 		auto row_id = row_ids[r];
 		auto row_group = row_groups->GetSegment(UnsafeNumericCast<idx_t>(row_id));
-		auto row_group_vector_idx = (UnsafeNumericCast<idx_t>(row_id) - row_group->start) / STANDARD_VECTOR_SIZE;
-		auto base_row_id = row_group_vector_idx * STANDARD_VECTOR_SIZE + row_group->start;
+
+		auto &current_row_group = *row_group->node;
+		auto row_group_vector_idx = (UnsafeNumericCast<idx_t>(row_id) - current_row_group.start) / STANDARD_VECTOR_SIZE;
+		auto base_row_id = row_group_vector_idx * STANDARD_VECTOR_SIZE + current_row_group.start;
 
 		// Fetch the current vector into fetch_chunk.
 		state.table_state.Initialize(context, GetTypes());
-		row_group->InitializeScanWithOffset(state.table_state, row_group_vector_idx);
-		row_group->ScanCommitted(state.table_state, fetch_chunk, TableScanType::TABLE_SCAN_COMMITTED_ROWS);
+		current_row_group.InitializeScanWithOffset(state.table_state, *row_group, row_group_vector_idx);
+		current_row_group.ScanCommitted(state.table_state, fetch_chunk, TableScanType::TABLE_SCAN_COMMITTED_ROWS);
 		fetch_chunk.Verify();
 
 		// Check for any remaining row ids, if they also fall into this vector.
@@ -779,11 +799,13 @@ void RowGroupCollection::UpdateColumn(TransactionData transaction, DataTable &da
 	do {
 		idx_t start = pos;
 		auto row_group = NextUpdateRowGroup(ids, pos, updates.size());
-		row_group->UpdateColumn(transaction, data_table, updates, row_ids, start, pos - start, column_path);
+		auto &current_row_group = *row_group->node;
+		current_row_group.UpdateColumn(transaction, data_table, updates, row_ids, start, pos - start, column_path);
 
 		auto lock = stats.GetLock();
 		auto primary_column_idx = column_path[0];
-		row_group->MergeIntoStatistics(primary_column_idx, stats.GetStats(*lock, primary_column_idx).Statistics());
+		current_row_group.MergeIntoStatistics(primary_column_idx,
+		                                      stats.GetStats(*lock, primary_column_idx).Statistics());
 	} while (pos < updates.size());
 }
 
@@ -792,7 +814,7 @@ void RowGroupCollection::UpdateColumn(TransactionData transaction, DataTable &da
 //===--------------------------------------------------------------------===//
 struct CollectionCheckpointState {
 	CollectionCheckpointState(RowGroupCollection &collection, TableDataWriter &writer,
-	                          vector<SegmentNode<RowGroup>> &segments, TableStatistics &global_stats)
+	                          vector<unique_ptr<SegmentNode<RowGroup>>> &segments, TableStatistics &global_stats)
 	    : collection(collection), writer(writer), executor(writer.CreateTaskExecutor()), segments(segments),
 	      global_stats(global_stats) {
 		writers.resize(segments.size());
@@ -802,7 +824,7 @@ struct CollectionCheckpointState {
 	RowGroupCollection &collection;
 	TableDataWriter &writer;
 	unique_ptr<TaskExecutor> executor;
-	vector<SegmentNode<RowGroup>> &segments;
+	vector<unique_ptr<SegmentNode<RowGroup>>> &segments;
 	vector<unique_ptr<RowGroupWriter>> writers;
 	vector<RowGroupWriteData> write_data;
 	TableStatistics &global_stats;
@@ -827,8 +849,8 @@ public:
 
 	void ExecuteTask() override {
 		auto &entry = checkpoint_state.segments[index];
-		auto &row_group = *entry.node;
-		checkpoint_state.writers[index] = checkpoint_state.writer.GetRowGroupWriter(*entry.node);
+		auto &row_group = *entry->node;
+		checkpoint_state.writers[index] = checkpoint_state.writer.GetRowGroupWriter(row_group);
 		checkpoint_state.write_data[index] = row_group.WriteToDisk(*checkpoint_state.writers[index]);
 	}
 
@@ -904,9 +926,9 @@ public:
 			}
 			merged_groups++;
 
-			auto &current_row_group = *checkpoint_state.segments[c_idx].node;
+			auto &current_row_group = *checkpoint_state.segments[c_idx]->node;
 
-			current_row_group.InitializeScan(scan_state.table_state);
+			current_row_group.InitializeScan(scan_state.table_state, *checkpoint_state.segments[c_idx]);
 			while (true) {
 				scan_chunk.Reset();
 
@@ -936,7 +958,7 @@ public:
 			}
 			// drop the row group after merging
 			current_row_group.CommitDrop();
-			checkpoint_state.segments[c_idx].node.reset();
+			checkpoint_state.segments[c_idx]->node.reset();
 		}
 		idx_t total_append_count = 0;
 		for (idx_t target_idx = 0; target_idx < target_count; target_idx++) {
@@ -944,7 +966,7 @@ public:
 			row_group->Verify();
 
 			// assign the new row group to the current segment
-			checkpoint_state.segments[segment_idx + target_idx].node = std::move(row_group);
+			checkpoint_state.segments[segment_idx + target_idx]->node = std::move(row_group);
 			total_append_count += append_counts[target_idx];
 		}
 		if (total_append_count != merge_rows) {
@@ -971,7 +993,7 @@ private:
 };
 
 void RowGroupCollection::InitializeVacuumState(CollectionCheckpointState &checkpoint_state, VacuumState &state,
-                                               vector<SegmentNode<RowGroup>> &segments) {
+                                               vector<unique_ptr<SegmentNode<RowGroup>>> &segments) {
 	auto checkpoint_type = checkpoint_state.writer.GetCheckpointType();
 	bool vacuum_is_allowed = checkpoint_type != CheckpointType::CONCURRENT_CHECKPOINT;
 	// currently we can only vacuum deletes if we are doing a full checkpoint and there are no indexes
@@ -982,12 +1004,12 @@ void RowGroupCollection::InitializeVacuumState(CollectionCheckpointState &checkp
 	// obtain the set of committed row counts for each row group
 	state.row_group_counts.reserve(segments.size());
 	for (auto &entry : segments) {
-		auto &row_group = *entry.node;
+		auto &row_group = *entry->node;
 		auto row_group_count = row_group.GetCommittedRowCount();
 		if (row_group_count == 0) {
 			// empty row group - we can drop it entirely
 			row_group.CommitDrop();
-			entry.node.reset();
+			entry->node.reset();
 		}
 		state.row_group_counts.push_back(row_group_count);
 	}
@@ -1109,19 +1131,20 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 				total_vacuum_tasks++;
 				continue;
 			}
-			if (!entry.node) {
+			if (!entry->node) {
 				// row group was vacuumed/dropped - skip
 				continue;
 			}
 			// schedule a checkpoint task for this row group
-			entry.node->MoveToCollection(*this, vacuum_state.row_start);
+			auto &row_group = *entry->node;
+			row_group.MoveToCollection(*this, vacuum_state.row_start);
 			if (writer.GetCheckpointType() != CheckpointType::VACUUM_ONLY) {
 				DUCKDB_LOG(checkpoint_state.writer.GetDatabase(), CheckpointLogType, GetAttached(), *info, segment_idx,
-				           *entry.node);
+				           row_group);
 				auto checkpoint_task = GetCheckpointTask(checkpoint_state, segment_idx);
 				checkpoint_state.executor->ScheduleTask(std::move(checkpoint_task));
 			}
-			vacuum_state.row_start += entry.node->count;
+			vacuum_state.row_start += row_group.count;
 		}
 	} catch (const std::exception &e) {
 		ErrorData error(e);
@@ -1138,7 +1161,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 		bool table_has_changes = false;
 		for (idx_t segment_idx = 0; segment_idx < segments.size(); segment_idx++) {
 			auto &entry = segments[segment_idx];
-			if (!entry.node) {
+			if (!entry->node) {
 				table_has_changes = true;
 				break;
 			}
@@ -1155,11 +1178,11 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 			auto &metadata_manager = writer.GetMetadataManager();
 			for (idx_t segment_idx = 0; segment_idx < segments.size(); segment_idx++) {
 				auto &entry = segments[segment_idx];
-				auto &row_group = *entry.node;
+				auto &row_group = *entry->node;
 				auto &write_state = checkpoint_state.write_data[segment_idx];
 				metadata_manager.ClearModifiedBlocks(write_state.existing_pointers);
 				metadata_manager.ClearModifiedBlocks(row_group.GetDeletesPointers());
-				row_groups->AppendSegment(l, std::move(entry.node));
+				row_groups->AppendSegment(l, std::move(entry->node));
 			}
 			writer.WriteUnchangedTable(metadata_pointer, total_rows.load());
 			return;
@@ -1169,15 +1192,15 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 	idx_t new_total_rows = 0;
 	for (idx_t segment_idx = 0; segment_idx < segments.size(); segment_idx++) {
 		auto &entry = segments[segment_idx];
-		if (!entry.node) {
+		if (!entry->node) {
 			// row group was vacuumed/dropped - skip
 			continue;
 		}
-		auto &row_group = *entry.node;
+		auto &row_group = *entry->node;
 		if (!checkpoint_state.writers[segment_idx]) {
 			// row group was not checkpointed - this can happen if compressing is disabled for in-memory tables
 			D_ASSERT(writer.GetCheckpointType() == CheckpointType::VACUUM_ONLY);
-			row_groups->AppendSegment(l, std::move(entry.node));
+			row_groups->AppendSegment(l, std::move(entry->node));
 			new_total_rows += row_group.count;
 			continue;
 		}
@@ -1188,7 +1211,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 		auto pointer =
 		    row_group.Checkpoint(std::move(checkpoint_state.write_data[segment_idx]), *row_group_writer, global_stats);
 		writer.AddRowGroup(std::move(pointer), std::move(row_group_writer));
-		row_groups->AppendSegment(l, std::move(entry.node));
+		row_groups->AppendSegment(l, std::move(entry->node));
 		new_total_rows += row_group.count;
 	}
 	total_rows = new_total_rows;
@@ -1220,7 +1243,7 @@ void RowGroupCollection::Destroy() {
 
 	TaskExecutor executor(TaskScheduler::GetScheduler(GetAttached().GetDatabase()));
 	for (auto &segment : segments) {
-		auto destroy_task = make_uniq<DestroyTask>(executor, std::move(segment.node));
+		auto destroy_task = make_uniq<DestroyTask>(executor, std::move(segment->node));
 		executor.ScheduleTask(std::move(destroy_task));
 	}
 	executor.WorkOnTasks();
@@ -1258,8 +1281,9 @@ vector<PartitionStatistics> RowGroupCollection::GetPartitionStats() const {
 vector<ColumnSegmentInfo> RowGroupCollection::GetColumnSegmentInfo(const QueryContext &context) {
 	vector<ColumnSegmentInfo> result;
 	auto lock = row_groups->Lock();
-	for (auto &row_group : row_groups->Segments(lock)) {
-		row_group.GetColumnSegmentInfo(context, row_group.index, result);
+	for (auto &node : row_groups->SegmentNodes(lock)) {
+		auto &row_group = *node.node;
+		row_group.GetColumnSegmentInfo(context, node.index, result);
 	}
 	return result;
 }
@@ -1347,9 +1371,10 @@ shared_ptr<RowGroupCollection> RowGroupCollection::AlterType(ClientContext &cont
 	// now alter the type of the column within all of the row_groups individually
 	auto lock = result->stats.GetLock();
 	auto &changed_stats = result->stats.GetStats(*lock, changed_idx);
-	for (auto &current_row_group : row_groups->Segments()) {
+	for (auto &node : row_groups->SegmentNodes()) {
+		auto &current_row_group = *node.node;
 		auto new_row_group = current_row_group.AlterType(*result, target_type, changed_idx, executor,
-		                                                 scan_state.table_state, scan_chunk);
+		                                                 scan_state.table_state, node, scan_chunk);
 		new_row_group->MergeIntoStatistics(changed_idx, changed_stats.Statistics());
 		result->row_groups->AppendSegment(std::move(new_row_group));
 	}

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -7,22 +7,10 @@
 
 namespace duckdb {
 
-RowVersionManager::RowVersionManager(BufferManager &buffer_manager_p, idx_t start) noexcept
+RowVersionManager::RowVersionManager(BufferManager &buffer_manager_p) noexcept
     : allocator(STANDARD_VECTOR_SIZE * sizeof(transaction_t), buffer_manager_p.GetTemporaryBlockManager(),
                 MemoryTag::BASE_TABLE),
-      start(start), has_changes(false) {
-}
-
-void RowVersionManager::SetStart(idx_t new_start) {
-	lock_guard<mutex> l(version_lock);
-	this->start = new_start;
-	idx_t current_start = start;
-	for (auto &info : vector_info) {
-		if (info) {
-			info->start = current_start;
-		}
-		current_start += STANDARD_VECTOR_SIZE;
-	}
+      has_changes(false) {
 }
 
 idx_t RowVersionManager::GetCommittedDeletedCount(idx_t count) {
@@ -106,7 +94,7 @@ void RowVersionManager::AppendVersionInfo(TransactionData transaction, idx_t cou
 		    vector_idx == end_vector_idx ? row_group_end - end_vector_idx * STANDARD_VECTOR_SIZE : STANDARD_VECTOR_SIZE;
 		if (vector_start == 0 && vector_end == STANDARD_VECTOR_SIZE) {
 			// entire vector is encapsulated by append: append a single constant
-			auto constant_info = make_uniq<ChunkConstantInfo>(start + vector_idx * STANDARD_VECTOR_SIZE);
+			auto constant_info = make_uniq<ChunkConstantInfo>(vector_idx * STANDARD_VECTOR_SIZE);
 			constant_info->insert_id = transaction.transaction_id;
 			constant_info->delete_id = NOT_DELETED_ID;
 			vector_info[vector_idx] = std::move(constant_info);
@@ -115,7 +103,7 @@ void RowVersionManager::AppendVersionInfo(TransactionData transaction, idx_t cou
 			optional_ptr<ChunkVectorInfo> new_info;
 			if (!vector_info[vector_idx]) {
 				// first time appending to this vector: create new info
-				auto insert_info = make_uniq<ChunkVectorInfo>(allocator, start + vector_idx * STANDARD_VECTOR_SIZE);
+				auto insert_info = make_uniq<ChunkVectorInfo>(allocator, vector_idx * STANDARD_VECTOR_SIZE);
 				new_info = insert_info.get();
 				vector_info[vector_idx] = std::move(insert_info);
 			} else if (vector_info[vector_idx]->type == ChunkInfoType::VECTOR_INFO) {
@@ -191,12 +179,11 @@ ChunkVectorInfo &RowVersionManager::GetVectorInfo(idx_t vector_idx) {
 
 	if (!vector_info[vector_idx]) {
 		// no info yet: create it
-		vector_info[vector_idx] = make_uniq<ChunkVectorInfo>(allocator, start + vector_idx * STANDARD_VECTOR_SIZE);
+		vector_info[vector_idx] = make_uniq<ChunkVectorInfo>(allocator, vector_idx * STANDARD_VECTOR_SIZE);
 	} else if (vector_info[vector_idx]->type == ChunkInfoType::CONSTANT_INFO) {
 		auto &constant = vector_info[vector_idx]->Cast<ChunkConstantInfo>();
 		// info exists but it's a constant info: convert to a vector info
-		auto new_info =
-		    make_uniq<ChunkVectorInfo>(allocator, start + vector_idx * STANDARD_VECTOR_SIZE, constant.insert_id);
+		auto new_info = make_uniq<ChunkVectorInfo>(allocator, vector_idx * STANDARD_VECTOR_SIZE, constant.insert_id);
 		vector_info[vector_idx] = std::move(new_info);
 	}
 	D_ASSERT(vector_info[vector_idx]->type == ChunkInfoType::VECTOR_INFO);
@@ -257,12 +244,12 @@ vector<MetaBlockPointer> RowVersionManager::Checkpoint(MetadataManager &manager)
 	return storage_pointers;
 }
 
-shared_ptr<RowVersionManager> RowVersionManager::Deserialize(MetaBlockPointer delete_pointer, MetadataManager &manager,
-                                                             idx_t start) {
+shared_ptr<RowVersionManager> RowVersionManager::Deserialize(MetaBlockPointer delete_pointer,
+                                                             MetadataManager &manager) {
 	if (!delete_pointer.IsValid()) {
 		return nullptr;
 	}
-	auto version_info = make_shared_ptr<RowVersionManager>(manager.GetBufferManager(), start);
+	auto version_info = make_shared_ptr<RowVersionManager>(manager.GetBufferManager());
 	MetadataReader source(manager, delete_pointer, &version_info->storage_pointers);
 	auto chunk_count = source.Read<idx_t>();
 	D_ASSERT(chunk_count > 0);


### PR DESCRIPTION
This PR reworks the segment tree class so that the actual traversal of nodes within the segment tree happens fully within the `SegmentNode` - and is not mixed between the segment tree and the `SegmentBase` (`RowGroup` or `ColumnSegment`). This isolates the logic for traversing the segment tree and decouples the `RowGroup` from the segment tree traversal.

This doesn't accomplish much in and of itself - but a follow-up PR based on this changeset can allow row groups to be stored in multiple different segment trees simultaneously. This could then allow checkpoints to be done in a lock-free manner while threads by constructing a new segment tree, while other threads could still be scanning the old segment tree. 