### PR TITLE
Add request timing to HTTP log

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/enums/http_status_code.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 #include <functional>
 
 namespace duckdb {
@@ -142,6 +143,11 @@ struct BaseRequest {
 	HTTPParams &params;
 	//! Whether or not to return failed requests (instead of throwing)
 	bool try_request = false;
+
+	// Requests will optionally contain their timings
+	bool have_request_timing = false;
+	timestamp_t request_start;
+	timestamp_t request_end;
 
 	template <class TARGET>
 	TARGET &Cast() {

--- a/src/logging/log_types.cpp
+++ b/src/logging/log_types.cpp
@@ -58,6 +58,8 @@ LogicalType HTTPLogType::GetLogType() {
 	child_list_t<LogicalType> request_child_list = {
 	    {"type", LogicalType::VARCHAR},
 	    {"url", LogicalType::VARCHAR},
+	    {"start_time", LogicalType::TIMESTAMP_TZ},
+	    {"duration_ms", LogicalType::BIGINT},
 	    {"headers", LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)},
 	};
 	auto request_type = LogicalType::STRUCT(request_child_list);
@@ -90,7 +92,10 @@ string HTTPLogType::ConstructLogMessage(BaseRequest &request, optional_ptr<HTTPR
 	    {"type", Value(EnumUtil::ToString(request.type))},
 	    {"url", Value(request.url)},
 	    {"headers", CreateHTTPHeadersValue(request.headers)},
-	};
+	    {"start_time", request.have_request_timing ? Value::TIMESTAMP(request.request_start) : Value()},
+	    {"duration_ms", request.have_request_timing ? Value::BIGINT(Timestamp::GetEpochMs(request.request_end) -
+	                                                                Timestamp::GetEpochMs(request.request_start))
+	                                                : Value()}};
 	auto request_value = Value::STRUCT(request_child_list);
 	Value response_value;
 	if (response) {

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -230,7 +230,9 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 		unique_ptr<HTTPResponse> response;
 
 		// When logging is enabled, we collect request timings
-		request.have_request_timing = request.params.logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
+		if (request.params.logger) {
+			request.have_request_timing = request.params.logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
+		}
 
 		try {
 			if (request.have_request_timing) {

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -228,11 +228,24 @@ unique_ptr<HTTPResponse> HTTPUtil::SendRequest(BaseRequest &request, unique_ptr<
 
 	std::function<unique_ptr<HTTPResponse>(void)> on_request([&]() {
 		unique_ptr<HTTPResponse> response;
+
+		// When logging is enabled, we collect request timings
+		request.have_request_timing = request.params.logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
+
 		try {
+			if (request.have_request_timing) {
+				request.request_start = Timestamp::GetCurrentTimestamp();
+			}
 			response = client->Request(request);
 		} catch (...) {
+			if (request.have_request_timing) {
+				request.request_end = Timestamp::GetCurrentTimestamp();
+			}
 			LogRequest(request, nullptr);
 			throw;
+		}
+		if (request.have_request_timing) {
+			request.request_end = Timestamp::GetCurrentTimestamp();
 		}
 		LogRequest(request, response ? response.get() : nullptr);
 		return response;

--- a/test/sql/logging/http_log_timing.test
+++ b/test/sql/logging/http_log_timing.test
@@ -1,0 +1,26 @@
+# name: test/sql/logging/http_log_timing.test
+# description: Test basic logging functionality
+# group: [logging]
+
+require noforcestorage
+
+require httpfs
+
+statement ok
+CALL enable_logging('HTTP')
+
+statement ok
+FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/title.principals.tsv'
+
+# Confirm that our request timing returns something reasonable
+query  III
+SELECT 
+	request.type, 
+	request.duration_ms >= 0,
+	request.duration_ms <= 1000 * 1000
+FROM 
+	duckdb_logs_parsed('HTTP')
+WHERE 
+	request.type='HEAD'
+----
+HEAD	true	true


### PR DESCRIPTION
Demo:

```SQL
D call enable_logging('HTTP');
D from read_csv_auto('s3://duckdblabs-testing/test.csv');
D select request.type, request.url, request.start_time, request.duration_ms from duckdb_logs_parsed('HTTP');
┌─────────┬────────────────────────────────────────────────────────────────┬───────────────────────────────┬─────────────┐
│  type   │                              url                               │          start_time           │ duration_ms │
│ varchar │                            varchar                             │   timestamp with time zone    │    int64    │
├─────────┼────────────────────────────────────────────────────────────────┼───────────────────────────────┼─────────────┤
│ HEAD    │ https://duckdblabs-testing.s3.us-east-1.amazonaws.com/test.csv │ 2025-11-07 10:17:56.052202+00 │         417 │
│ GET     │ https://duckdblabs-testing.s3.us-east-1.amazonaws.com/test.csv │ 2025-11-07 10:17:56.478847+00 │         104 │
└─────────┴────────────────────────────────────────────────────────────────┴───────────────────────────────┴─────────────┘
```

