### PR TITLE
Fix #19575: Fix illegal utf8 character

### DIFF
--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -50,6 +50,7 @@ public:
 	//! If this returns true - this sorts "in_list" as a side-effect
 	static bool IsDenseRange(vector<Value> &in_list);
 	static bool ContainsNull(vector<Value> &in_list);
+	static bool FindNextLegalUTF8(string &prefix_string);
 
 	void GenerateFilters(const std::function<void(unique_ptr<Expression> filter)> &callback);
 	bool HasFilters();

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -427,11 +427,11 @@ FilterPushdownResult FilterCombiner::TryPushdownPrefixFilter(TableFilterSet &tab
 	auto lower_bound = make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value(prefix_string));
 	table_filters.PushFilter(column_index, std::move(lower_bound));
 	if (FilterCombiner::FindNextLegalUTF8(prefix_string)) {
-		// could not find next legal utf8 string - skip upper bound
 		auto upper_bound = make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHAN, Value(prefix_string));
 		table_filters.PushFilter(column_index, std::move(upper_bound));
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
+	// could not find next legal utf8 string - skip upper bound
 	return FilterPushdownResult::NO_PUSHDOWN;
 }
 

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/scalar/string_common.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_between_expression.hpp"
@@ -283,6 +284,32 @@ static bool SupportedFilterComparison(ExpressionType expression_type) {
 	}
 }
 
+bool FilterCombiner::FindNextLegalUTF8(string &prefix_string) {
+	// find the start of the last codepoint
+	idx_t last_codepoint_start;
+	for (last_codepoint_start = prefix_string.size() - 1; last_codepoint_start >= 0; last_codepoint_start--) {
+		if (IsCharacter(prefix_string[last_codepoint_start])) {
+			break;
+		}
+	}
+	D_ASSERT(last_codepoint_start >= 0);
+	int codepoint_size;
+	auto codepoint = Utf8Proc::UTF8ToCodepoint(prefix_string.c_str() + last_codepoint_start, codepoint_size) + 1;
+	if (codepoint >= 0xD800 && codepoint <= 0xDFFF) {
+		// next codepoint falls within surrogate range increment to next valid character
+		codepoint = 0xE000;
+	}
+	char next_codepoint_text[4];
+	int next_codepoint_size;
+	if (!Utf8Proc::CodepointToUtf8(codepoint, next_codepoint_size, next_codepoint_text)) {
+		// invalid codepoint
+		return false;
+	}
+	auto s = static_cast<idx_t>(next_codepoint_size);
+	prefix_string = prefix_string.substr(0, last_codepoint_start) + string(next_codepoint_text, s);
+	return true;
+}
+
 bool TypeSupportsConstantFilter(const LogicalType &type) {
 	if (TypeIsNumeric(type.InternalType())) {
 		return true;
@@ -399,12 +426,13 @@ FilterPushdownResult FilterCombiner::TryPushdownPrefixFilter(TableFilterSet &tab
 	//! Replace prefix with a set of comparisons
 	auto lower_bound = make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value(prefix_string));
 	table_filters.PushFilter(column_index, std::move(lower_bound));
-	prefix_string[prefix_string.size() - 1]++;
-	if (Utf8Proc::Analyze(prefix_string.c_str(), prefix_string.size()) != UnicodeType::INVALID) {
+	if (FilterCombiner::FindNextLegalUTF8(prefix_string)) {
+		// could not find next legal utf8 string - skip upper bound
 		auto upper_bound = make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHAN, Value(prefix_string));
 		table_filters.PushFilter(column_index, std::move(upper_bound));
+		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
-	return FilterPushdownResult::PUSHED_DOWN_FULLY;
+	return FilterPushdownResult::NO_PUSHDOWN;
 }
 
 FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table_filters,

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -287,12 +287,15 @@ static bool SupportedFilterComparison(ExpressionType expression_type) {
 bool FilterCombiner::FindNextLegalUTF8(string &prefix_string) {
 	// find the start of the last codepoint
 	idx_t last_codepoint_start;
-	for (last_codepoint_start = prefix_string.size() - 1; last_codepoint_start >= 0; last_codepoint_start--) {
-		if (IsCharacter(prefix_string[last_codepoint_start])) {
+	for (last_codepoint_start = prefix_string.size(); last_codepoint_start > 0; last_codepoint_start--) {
+		if (IsCharacter(prefix_string[last_codepoint_start - 1])) {
 			break;
 		}
 	}
-	D_ASSERT(last_codepoint_start >= 0);
+	if (last_codepoint_start == 0) {
+		throw InvalidInputException("Invalid UTF8 found in string \"%s\"", prefix_string);
+	}
+	last_codepoint_start--;
 	int codepoint_size;
 	auto codepoint = Utf8Proc::UTF8ToCodepoint(prefix_string.c_str() + last_codepoint_start, codepoint_size) + 1;
 	if (codepoint >= 0xD800 && codepoint <= 0xDFFF) {

--- a/test/issues/general/test_19575.test
+++ b/test/issues/general/test_19575.test
@@ -1,0 +1,24 @@
+# name: test/issues/general/test_19575.test
+# description: Issue 19575 - [1.4.1] Interesting error with like expression on some character. (Invalid unicode)
+# group: [general]
+
+statement ok
+create or replace table aaa(name varchar);
+
+statement ok
+insert into aaa values('绿色');
+
+query I
+select * from aaa;
+----
+绿色
+
+query I
+select * from aaa where name like '绿%';
+----
+绿色
+
+query I
+select count(*) from aaa where name like '红%';
+----
+0

--- a/test/issues/general/test_19575.test
+++ b/test/issues/general/test_19575.test
@@ -6,12 +6,12 @@ statement ok
 create or replace table aaa(name varchar);
 
 statement ok
-insert into aaa values('绿色');
+insert into aaa values('绿色'),(chr('0x10FFFF')),(chr('0xD7FF'));
 
 query I
-select * from aaa;
+select count(*) from aaa;
 ----
-绿色
+3
 
 query I
 select * from aaa where name like '绿%';
@@ -22,3 +22,15 @@ query I
 select count(*) from aaa where name like '红%';
 ----
 0
+
+# (0xD7FF + 1) go into unicode surrogate range 
+query II
+explain select * from aaa where name like concat(chr('0xD7FF'),'%');
+----
+physical_plan	<!REGEX>:.*Filters.*prefix.*
+
+# (0x10FFFF + 1) would be illegal utf8
+query II
+explain select * from aaa where name like concat(chr('0x10FFFF'),'%');
+----
+physical_plan	<REGEX>:.*Filters.*prefix.*

--- a/test/issues/general/test_19575.test
+++ b/test/issues/general/test_19575.test
@@ -29,8 +29,18 @@ explain select * from aaa where name like concat(chr('0xD7FF'),'%');
 ----
 physical_plan	<!REGEX>:.*Filters.*prefix.*
 
+query I
+select count(*) from aaa where name like concat(chr('0xD7FF'),'%');
+----
+1
+
 # (0x10FFFF + 1) would be illegal utf8
 query II
 explain select * from aaa where name like concat(chr('0x10FFFF'),'%');
 ----
 physical_plan	<REGEX>:.*Filters.*prefix.*
+
+query I
+select count(*) from aaa where name like concat(chr('0x10FFFF'),'%');
+----
+1


### PR DESCRIPTION
This PR is a simple fix for #19575. If we still want to create a ``COMPARE_LESSTHAN`` filter, we need to handle the ``prefix_string`` at the character encoding level, not the byte level.