### PR TITLE
Fix empty result pullup for ANTI joins

### DIFF
--- a/test/sql/optimizer/plan/test_anti_join_empty_child.test
+++ b/test/sql/optimizer/plan/test_anti_join_empty_child.test
@@ -1,0 +1,16 @@
+# name: test/sql/optimizer/plan/test_anti_join_empty_child.test
+# description: Ensure ANTI joins with empty probe-side child fold into the left input
+# group: [plan]
+
+statement ok
+pragma explain_output='OPTIMIZED_ONLY'
+
+query I
+SELECT lhs.id FROM (SELECT 1 id) lhs ANTI JOIN (SELECT 1 id WHERE FALSE) rhs ON lhs.id = rhs.id
+----
+1
+
+query II
+EXPLAIN SELECT lhs.id FROM (SELECT 1 id) lhs ANTI JOIN (SELECT 1 id WHERE FALSE) rhs ON lhs.id = rhs.id
+----
+logical_opt	<!REGEX>:.*ANTI.*

--- a/test/sql/optimizer/plan/test_except_empty_rhs.test
+++ b/test/sql/optimizer/plan/test_except_empty_rhs.test
@@ -1,0 +1,25 @@
+# name: test/sql/optimizer/plan/test_except_empty_rhs.test
+# description: EXCEPT should keep its logical operator even when the RHS is empty
+# group: [plan]
+
+statement ok
+pragma explain_output='OPTIMIZED_ONLY'
+
+query I
+SELECT * FROM (SELECT 1) lhs
+EXCEPT
+SELECT * FROM (SELECT 1 WHERE 1=0) rhs
+----
+1
+
+query II
+EXPLAIN SELECT * FROM (SELECT 1) lhs
+EXCEPT
+SELECT * FROM (SELECT 1 WHERE 1=0) rhs
+----
+logical_opt	<REGEX>:.*EXCEPT.*
+
+query I
+SELECT * FROM (SELECT 42 EXCEPT SELECT 43) tbl(i) WHERE i = 42
+----
+42


### PR DESCRIPTION
## Summary
  - Guard `EmptyResultPullup::PullUpEmptyJoinChildren` so only non-EXCEPT ANTI joins fold away empty right children; EXCEPT (`LogicalSetOperation`) stays intact to preserve its column bindings.
  - Add two sqllogictests:
    - `test/sql/optimizer/plan/test_anti_join_empty_child.test` proves ANTI joins with empty probe sides collapse to the left input and the optimized plan no longer contains an `ANTI` node.
    - `test/sql/optimizer/plan/test_except_empty_rhs.test` ensures EXCEPT still produces the correct result, keeps the logical operator in EXPLAIN output, and allows aliases like `tbl(i)` to bind.

  ## Testing
  - `make unit`

  ## Known Issue
  `test/sql/logging/logging.test` currently fails on both this branch and `main` because `enable_logging=true` now persists QueryMetrics into `duckdb_logs`, so the query that expects a single QueryLog row returns ~20 metric rows. This failure is unrelated to this PR.