### PR TITLE
[Dev] Fix assertion failure for empty ColumnData serialization

### DIFF
--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -868,7 +868,8 @@ bool PersistentCollectionData::HasUpdates() const {
 }
 
 PersistentColumnData ColumnData::Serialize() {
-	PersistentColumnData result(type.InternalType(), GetDataPointers());
+	auto result = count ? PersistentColumnData(type.InternalType(), GetDataPointers())
+	                    : PersistentColumnData(type.InternalType());
 	result.has_updates = HasUpdates();
 	return result;
 }

--- a/test/sql/storage/types/struct/struct_of_empty_list.test
+++ b/test/sql/storage/types/struct/struct_of_empty_list.test
@@ -1,0 +1,10 @@
+# name: test/sql/storage/types/struct/struct_of_empty_list.test
+# group: [struct]
+
+load __TEST_DIR__/empty_list_in_struct.db
+
+statement ok
+create table tbl (col STRUCT(a VARCHAR[]))
+
+statement ok
+insert into tbl SELECT {'a': []} from range(122881)


### PR DESCRIPTION
The `PersistentColumnData` constructor asserts that the pointers aren't empty.
This assertion will fail if we try to serialize the child of a list, if all lists are empty (as the child will be entirely empty then)

Backported fix for problem found by: #19674 