### PR TITLE
Bump: delta, ducklake, httpfs

### DIFF
--- a/.github/config/extensions/delta.cmake
+++ b/.github/config/extensions/delta.cmake
@@ -1,7 +1,7 @@
 if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(delta
             GIT_URL https://github.com/duckdb/duckdb-delta
-            GIT_TAG 0747c23791c6ad53dfc22f58dc73008d49d2a8ae
+            GIT_TAG 6515bb2560772956f9b74a18a47782f18ed4d827
             SUBMODULES extension-ci-tools
     )
 endif()

--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG 022cfb137383e69ca61aec3528ce15ada6f8d3a8
+    GIT_TAG 77f2512a6774d51c99f9c0a165df76c5ae213a6d
 )

--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -7,6 +7,6 @@ duckdb_extension_load(httpfs
     # TODO: restore once httpfs is fixed
     ${LOAD_HTTPFS_TESTS}
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG b80c680f86dff6061614536d908d4b08c85c9ef4
+    GIT_TAG 041a782b0b33495448a7eaa68973cf8c2174feb6
     INCLUDE_DIR src/include
 )


### PR DESCRIPTION
This PR bumps the following extensions:
- `delta` from `0747c23791` to `6515bb2560`
- `ducklake` from `022cfb1373` to `77f2512a67`
- `httpfs` from `b80c680f86` to `041a782b0b`
