### PR TITLE
Fix #19700: correctly sort output selection vector in nested selection operations

### DIFF
--- a/src/execution/expression_executor/execute_comparison.cpp
+++ b/src/execution/expression_executor/execute_comparison.cpp
@@ -138,8 +138,19 @@ static idx_t TemplatedSelectOperation(Vector &left, Vector &right, optional_ptr<
 		                                                      false_sel.get());
 	case PhysicalType::LIST:
 	case PhysicalType::STRUCT:
-	case PhysicalType::ARRAY:
-		return NestedSelectOperation<OP>(left, right, sel, count, true_sel, false_sel, null_mask);
+	case PhysicalType::ARRAY: {
+		auto result_count = NestedSelectOperation<OP>(left, right, sel, count, true_sel, false_sel, null_mask);
+		if (true_sel && result_count > 0) {
+			std::sort(true_sel->data(), true_sel->data() + result_count);
+		}
+		if (false_sel) {
+			idx_t false_count = count - result_count;
+			if (false_count > 0) {
+				std::sort(false_sel->data(), false_sel->data() + false_count);
+			}
+		}
+		return result_count;
+	}
 	default:
 		throw InternalException("Invalid type for comparison");
 	}

--- a/test/sql/storage/compression/rle/rle_select_list.test
+++ b/test/sql/storage/compression/rle/rle_select_list.test
@@ -1,0 +1,38 @@
+# name: test/sql/storage/compression/rle/rle_select_list.test
+# description: Test selecting from RLE compression with a list comparison pushed down
+# group: [rle]
+
+load __TEST_DIR__/rle_select_bug.db
+
+statement ok
+pragma force_compression='rle';
+
+statement ok
+create table tbl as SELECT * FROM (
+    VALUES
+        (['first name', 'last name', 'username'], 60),
+        (['first name'], 0),
+        (['username'], 0),
+        (['first name', 'last name', 'username'], 0),
+        (['first name', 'last name', 'username'], 0),
+        (['username'], 0),
+        (['username'], 0)
+) AS t(attributes, minutes_duration);
+
+statement ok
+checkpoint
+
+query I
+SELECT
+   "minutes_duration"
+FROM
+   tbl
+WHERE NOT list_sort(['first name']) = tbl."attributes"
+ORDER BY ALL
+----
+0
+0
+0
+0
+0
+60


### PR DESCRIPTION
Fixes #19700

This probably should be maintained during the actual select - but for now just sorting it afterwards solves the issue.