### PR TITLE
CLI: Refactor BoxRenderer, add wrapping support for large values, and add pretty printing / highlighting for nested types, JSON and variant

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -840,6 +840,18 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 				collection_rows.push_back(std::move(row));
 			}
 		}
+		if (config.large_number_rendering == LargeNumberRendering::FOOTER) {
+			// when rendering the large number footer we align to the middle
+			for (auto &row : collection_rows) {
+				for (auto &value : row.values) {
+					value.alignment = ValueRenderAlignment::MIDDLE;
+				}
+			}
+			// large number footers should be rendered as NULL values
+			for (auto &row : collection_rows[1].values) {
+				row.render_mode = ResultRenderType::NULL_VALUE;
+			}
+		}
 		if (invert) {
 			// the bottom collection is inverted - so flip the rows
 			std::reverse(collection_rows.begin(), collection_rows.end());
@@ -932,7 +944,6 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 	bool added_split_column = false;
 	vector<idx_t> new_widths;
 	vector<optional_idx> column_map;
-	bool large_number_footer = config.large_number_rendering == LargeNumberRendering::FOOTER;
 	for (idx_t c = 0; c < column_count; c++) {
 		if (pruned_columns.find(c) == pruned_columns.end()) {
 			column_map.push_back(c);

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -826,9 +826,10 @@ string BoxRendererImplementation::GetRenderValue(ColumnDataRowCollection &rows, 
 }
 
 struct JSONParser {
-protected:
+public:
 	virtual ~JSONParser() = default;
 
+protected:
 	enum class JSONState { REGULAR, IN_QUOTE, ESCAPE };
 
 	struct Separator {

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -997,7 +997,7 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 			if (row.row_type != RenderRowType::ROW_VALUES) {
 				continue;
 			}
-			bool need_extra_row = +1 != render_rows.size();
+			bool need_extra_row = r + 1 != render_rows.size();
 			idx_t min_rows = need_extra_row ? 2 : 1;
 			if (rows_left < min_rows) {
 				// no rows left to expand

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -356,7 +356,7 @@ void BoxRendererImplementation::RenderValue(const string &value, idx_t column_wi
 		idx_t pos = 0;
 		idx_t current_render_width = config.DOTDOTDOT_LENGTH;
 		small_value = TruncateValue(value, column_width, pos, current_render_width);
-		max_render_pos = pos;
+		max_render_pos = small_value.size();
 		small_value += config.DOTDOTDOT;
 		render_width = current_render_width;
 		render_value = const_reference<string>(small_value);
@@ -387,13 +387,13 @@ void BoxRendererImplementation::RenderValue(const string &value, idx_t column_wi
 		idx_t pos = 0;
 		ResultRenderType active_render_mode = render_mode;
 		for (auto &annotation : annotations) {
-			if (annotation.start >= render_value.get().size()) {
+			if (annotation.start >= max_render_pos) {
 				break;
 			}
 			auto render_end = MinValue<idx_t>(max_render_pos, annotation.start);
 			ss.Render(active_render_mode, render_value.get().substr(pos, render_end - pos));
 			active_render_mode = annotation.render_mode;
-			pos = annotation.start;
+			pos = render_end;
 		}
 		if (pos < render_value.get().size()) {
 			ss.Render(active_render_mode, render_value.get().substr(pos, render_value.get().size() - pos));

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -154,7 +154,7 @@ private:
 	list<ColumnDataCollection> PivotCollections(list<ColumnDataCollection> input, idx_t row_count);
 	void ComputeRenderWidths(list<ColumnDataCollection> &collections, idx_t min_width, idx_t max_width);
 	void RenderValues();
-	void UpdateColumnCountFooter(idx_t column_count, const unordered_set<idx_t> &column_map);
+	void UpdateColumnCountFooter(idx_t column_count, const unordered_set<idx_t> &pruned_columns);
 
 	void ComputeRowFooter(idx_t row_count, idx_t rendered_rows);
 	void RenderFooter(idx_t row_count, idx_t column_count);
@@ -289,7 +289,7 @@ void BoxRendererImplementation::Render() {
 	RenderValues();
 
 	// render the row count and column count
-	idx_t column_count = column_map.size();
+	idx_t column_count = result_types.size();
 	RenderFooter(row_count, column_count);
 }
 
@@ -918,12 +918,11 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 
 void BoxRendererImplementation::RenderLayoutLine(const char *layout, const char *boundary, const char *left_corner,
                                                  const char *right_corner) {
-	auto column_count = column_map.size();
 	// render the top line
 	ss << left_corner;
 	idx_t column_index = 0;
 	for (idx_t k = 0; k < total_render_length - 2; k++) {
-		if (column_index + 1 < column_count && k == column_boundary_positions[column_index]) {
+		if (column_index < column_boundary_positions.size() && k == column_boundary_positions[column_index]) {
 			ss << boundary;
 			column_index++;
 		} else {

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -94,7 +94,7 @@ struct BoxRenderValue {
 	ResultRenderType render_mode;
 };
 
-enum class RenderRowType { ROW_VALUES, SEPARATOR };
+enum class RenderRowType { ROW_VALUES, SEPARATOR, DIVIDER };
 
 struct BoxRenderRow {
 	BoxRenderRow(RenderRowType row_type = RenderRowType::ROW_VALUES) // NOLINT: allow implicit conversion
@@ -124,7 +124,7 @@ private:
 	vector<idx_t> column_widths;
 	vector<idx_t> column_boundary_positions;
 	vector<idx_t> column_map;
-	idx_t total_render_length;
+	idx_t total_render_length = 0;
 	vector<BoxRenderRow> render_rows;
 
 private:
@@ -765,6 +765,7 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 	// add a separator
 	render_rows.emplace_back(RenderRowType::SEPARATOR);
 	// prepare the values
+	bool added_divider = false;
 	for (auto &collection : collections) {
 		for (auto &chunk : collection.Chunks()) {
 			vector<BoxRenderRow> chunk_rows;
@@ -787,6 +788,13 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 			for(auto &row : chunk_rows) {
 				render_rows.push_back(std::move(row));
 			}
+		}
+		if (!added_divider && collections.size() > 1) {
+			// render divider between top and bottom collection
+			for(idx_t i = 0; i < 3; i++) {
+				render_rows.emplace_back(RenderRowType::DIVIDER);
+			}
+			added_divider = true;
 		}
 	}
 

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -903,8 +903,10 @@ bool JSONParser::Process(const string &value) {
 		if (state == JSONState::REGULAR) {
 			if (can_parse_value) {
 				// check if this is "null"
-				if (pos + 4 < value.size() && c == 'n' && value[pos + 1] == 'u' && value[pos + 2] == 'l' &&
-				    value[pos + 3] == 'l') {
+				if (pos + 4 < value.size() && StringUtil::CharacterToLower(c) == 'n' &&
+				    StringUtil::CharacterToLower(value[pos + 1]) == 'u' &&
+				    StringUtil::CharacterToLower(value[pos + 2]) == 'l' &&
+				    StringUtil::CharacterToLower(value[pos + 3]) == 'l') {
 					HandleNull();
 					pos += 3;
 					continue;
@@ -1193,6 +1195,10 @@ protected:
 						if (peek_component.type == JSONComponentType::BRACKET_OPEN) {
 							peek_depth++;
 						} else if (peek_component.type == JSONComponentType::BRACKET_CLOSE) {
+							if (peek_depth == 0) {
+								inline_comma = true;
+								break;
+							}
 							peek_depth--;
 						}
 						if (peek_depth == 0 && peek_component.type == JSONComponentType::COMMA &&
@@ -1579,7 +1585,7 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 			if (row.row_type != RenderRowType::ROW_VALUES) {
 				continue;
 			}
-			bool need_extra_row = r + 1 != render_rows.size();
+			bool need_extra_row = r + 1 != render_rows.size() && r != 1;
 			idx_t min_rows = need_extra_row ? 2 : 1;
 			if (rows_left < min_rows) {
 				// no rows left to expand

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -129,8 +129,6 @@ struct BoxRendererConfig {
 };
 
 class BoxRenderer {
-	static const idx_t SPLIT_COLUMN;
-
 public:
 	explicit BoxRenderer(BoxRendererConfig config_p = BoxRendererConfig());
 
@@ -143,37 +141,6 @@ public:
 private:
 	//! The configuration used for rendering
 	BoxRendererConfig config;
-
-private:
-	void RenderValue(BaseResultRenderer &ss, const string &value, idx_t column_width, ResultRenderType render_mode,
-	                 ValueRenderAlignment alignment = ValueRenderAlignment::MIDDLE);
-	string RenderType(const LogicalType &type);
-	ValueRenderAlignment TypeAlignment(const LogicalType &type);
-	string GetRenderValue(BaseResultRenderer &ss, ColumnDataRowCollection &rows, idx_t c, idx_t r,
-	                      const LogicalType &type, ResultRenderType &render_mode);
-	list<ColumnDataCollection> FetchRenderCollections(ClientContext &context, const ColumnDataCollection &result,
-	                                                  idx_t top_rows, idx_t bottom_rows);
-	list<ColumnDataCollection> PivotCollections(ClientContext &context, list<ColumnDataCollection> input,
-	                                            vector<string> &column_names, vector<LogicalType> &result_types,
-	                                            idx_t row_count);
-	vector<idx_t> ComputeRenderWidths(const vector<string> &names, const vector<LogicalType> &result_types,
-	                                  list<ColumnDataCollection> &collections, idx_t min_width, idx_t max_width,
-	                                  vector<idx_t> &column_map, idx_t &total_length);
-	void RenderHeader(const vector<string> &names, const vector<LogicalType> &result_types,
-	                  const vector<idx_t> &column_map, const vector<idx_t> &widths, const vector<idx_t> &boundaries,
-	                  idx_t total_length, bool has_results, BaseResultRenderer &renderer);
-	void RenderValues(const list<ColumnDataCollection> &collections, const vector<idx_t> &column_map,
-	                  const vector<idx_t> &widths, const vector<LogicalType> &result_types, BaseResultRenderer &ss);
-	void RenderRowCount(string &row_count_str, string &readable_rows_str, string &shown_str,
-	                    const string &column_count_str, const vector<idx_t> &boundaries, bool has_hidden_rows,
-	                    bool has_hidden_columns, idx_t total_length, idx_t row_count, idx_t column_count,
-	                    idx_t minimum_row_length, BaseResultRenderer &ss);
-
-	string FormatNumber(const string &input);
-	string ConvertRenderValue(const string &input, const LogicalType &type);
-	string ConvertRenderValue(const string &input);
-	//! Try to format a large number in a readable way (e.g. 1234567 -> 1.23 million)
-	string TryFormatLargeNumber(const string &numeric);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -20,7 +20,7 @@ class ColumnDataRowCollection;
 enum class ValueRenderAlignment { LEFT, MIDDLE, RIGHT };
 enum class RenderMode : uint8_t { ROWS, COLUMNS };
 
-enum class ResultRenderType { LAYOUT, COLUMN_NAME, COLUMN_TYPE, VALUE, NULL_VALUE, FOOTER };
+enum class ResultRenderType { LAYOUT, COLUMN_NAME, COLUMN_TYPE, VALUE, NULL_VALUE, FOOTER, STRING_LITERAL };
 
 class BaseResultRenderer {
 public:
@@ -32,6 +32,9 @@ public:
 	virtual void RenderType(const string &text) = 0;
 	virtual void RenderValue(const string &text, const LogicalType &type) = 0;
 	virtual void RenderNull(const string &text, const LogicalType &type) = 0;
+	virtual void RenderStringLiteral(const string &text, const LogicalType &type) {
+		RenderValue(text, type);
+	}
 	virtual void RenderFooter(const string &text) = 0;
 
 	BaseResultRenderer &operator<<(char c);

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -195,6 +195,7 @@ bool Linenoise::CompleteLine(KeyPress &next_key) {
 				break;
 			}
 			default:
+				next_key = key_press;
 				accept_completion = true;
 				stop = true;
 				break;

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1389,6 +1389,10 @@ public:
 		}
 	}
 
+	void RenderStringLiteral(const string &text, const duckdb::LogicalType &type) override {
+		PrintText(text, HighlightElementType::STRING_CONSTANT);
+	}
+
 	void RenderNull(const string &text, const duckdb::LogicalType &type) override {
 		PrintText(text, HighlightElementType::NULL_VALUE);
 	}

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1890,7 +1890,7 @@ string ShellState::GetSystemPager() {
 	return "more";
 #else
 	// On other systems, use 'less' as default pager
-	return "less -RX";
+	return "less -SRX";
 #endif
 }
 

--- a/tools/shell/tests/conftest.py
+++ b/tools/shell/tests/conftest.py
@@ -53,7 +53,6 @@ class TestResult:
             print(self.stdout, file=sys.stderr)
             assert not is_needle_in_haystack(not_exist, self.stdout)
 
-
     def check_stderr(self, expected):
         if expected is None:
             assert self.stderr == ""

--- a/tools/shell/tests/conftest.py
+++ b/tools/shell/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from typing import List, Union
+import sys
 
 import pytest
 
@@ -40,13 +41,18 @@ class TestResult:
         if isinstance(expected, list):
             expected = "\n".join(expected)
         assert self.status_code == 0
-        assert is_needle_in_haystack(expected, self.stdout)
+        if not is_needle_in_haystack(expected, self.stdout):
+            print(self.stdout, file=sys.stderr)
+            assert is_needle_in_haystack(expected, self.stdout)
 
     def check_not_exist(self, not_exist: Union[str, List[str], bytes]):
         if isinstance(not_exist, list):
             not_exist = "\n".join(not_exist)
         assert self.status_code == 0
-        assert not is_needle_in_haystack(not_exist, self.stdout)
+        if is_needle_in_haystack(not_exist, self.stdout):
+            print(self.stdout, file=sys.stderr)
+            assert not is_needle_in_haystack(not_exist, self.stdout)
+
 
     def check_stderr(self, expected):
         if expected is None:

--- a/tools/shell/tests/test_large_value_rendering.py
+++ b/tools/shell/tests/test_large_value_rendering.py
@@ -1,0 +1,142 @@
+# fmt: off
+
+import pytest
+import subprocess
+import sys
+import os
+from typing import List
+from conftest import ShellTest
+
+long_string = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+
+nested_view = '''NESTED_VIEW
+create view special_characters as select {
+	'" this ''name contains \\special" characters "': 420, 'a': ' this ''value contains \\special" characters ', 'b': 84, 'c': DATE '2020-01-01', 'd': (SELECT lineitem FROM 'data/parquet-testing/lineitem-top10000.gzip.parquet' LIMIT 1),
+	'e': range(10),
+	'f': NULL
+	} s;
+NESTED_VIEW'''
+
+json_widespace = '''
+{
+"error"
+:
+false,
+"statements"
+:
+[
+1
+,
+2
+,
+3
+],
+"thisisalongstring"
+:
+{
+"nested"
+:
+"thisisalongvalue"
+}
+}
+'''
+
+big_json = '''
+{
+  "error": false,
+  "statements": [
+    {
+      "node": {
+        "type": "SELECT_NODE",
+        "modifiers": [],
+        "cte_map": {"map": []},
+        "select_list": [
+          {
+            "class": "CONSTANT",
+            "type": "VALUE_CONSTANT",
+            "alias": "",
+            "query_location": 18446744073709551615,
+            "value": {"type": {"id": "BLOB", "type_info": null}, "is_null": false, "value": "10"}
+          }
+        ],
+        "from_table": {"type": "EMPTY", "alias": "", "sample": null, "query_location": 18446744073709551615},
+        "where_clause": null,
+        "group_expressions": [],
+        "group_sets": [],
+        "aggregate_handling": "STANDARD_HANDLING",
+        "having": null,
+        "sample": null,
+        "qualify": null
+      },
+      "named_param_map": []
+    }
+  ]
+}
+'''
+
+def test_long_string(shell):
+    test = (
+        ShellTest(shell)
+        .statement(f"SELECT '{long_string}' s")
+    )
+    result = test.run()
+    # verify the entire string is printed
+    result.check_stdout("laborum")
+
+def test_extremely_long_string(shell):
+    test = (
+        ShellTest(shell)
+        .statement(f"SELECT repeat('abcdefghijklmnopqrstuvwxyz', 10000)")
+    )
+    result = test.run()
+    # there's a limit to how much wrap-around we can do
+    # if the string is too long we end up truncating it still
+    result.check_stdout("…")
+
+def test_multiple_long_strings(shell):
+    test = (
+        ShellTest(shell)
+        .statement(f"SELECT '{long_string}' s1, '{long_string}' s2, '{long_string}' s3")
+    )
+    result = test.run()
+    # verify the entire string is printed
+    result.check_stdout("laborum")
+
+def test_multiple_long_strings_many_rows(shell):
+    test = (
+        ShellTest(shell)
+        .statement(f"SELECT '{long_string}' s1, '{long_string}' s2, '{long_string}' s3 FROM range(100)")
+    )
+    result = test.run()
+    # if we have many long strings they are not stretched out
+    result.check_not_exist("laborum")
+
+    # UNLESS we increase the max rows printed
+    test = (
+        ShellTest(shell)
+        .statement('.maxrows -1')
+        .statement(f"SELECT '{long_string}' s1, '{long_string}' s2, '{long_string}' s3 FROM range(100)")
+    )
+    result = test.run()
+    result.check_stdout("laborum")
+
+def test_big_json(shell):
+    test = (
+        ShellTest(shell)
+        .statement('.maxwidth 80')
+        .statement(f"SELECT '{big_json}'::JSON s")
+    )
+    result = test.run()
+    result.check_stdout("named_param_map")
+
+def test_json_newlines(shell):
+    # verify there's no literal \n in the output
+    test = (
+        ShellTest(shell)
+        .statement('.maxwidth 80')
+        .statement(f"SELECT '{json_widespace}'::JSON s")
+    )
+    result = test.run()
+    result.check_not_exist("\\n")
+
+# fmt: on


### PR DESCRIPTION
This PR does a code refactor of the BoxRenderer - cleaning up the code by splitting up the generating of values to render from the actual rendering. 

### Wrapping
In addition, this PR adds support for wrapping for large values. The way this works is that, when we select fewer rows than the `.maxrows`, we allow the result rendering to use multiple lines to display a single row in the query result. Larger values can then be stretched out over multiple lines instead of being truncated, allowing them to be visible. For example:

```sql
select 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.' as lorem_ipsum;
┌────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                          lorem_ipsum                                           │
│                                            varchar                                             │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut   │
│ labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco lab  │
│ oris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in volup  │
│ tate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non  │
│  proident, sunt in culpa qui officia deserunt mollit anim id est laborum.                      │
└────────────────────────────────────────────────────────────────────────────────────────────────┘
```

If we exceed the `maxrows`, we don't wrap, but still truncate:

```sql
.maxrows 10
select 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.' as lorem_ipsum
from range(100);
┌────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                          lorem_ipsum                                           │
│                                            varchar                                             │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut…  │
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut…  │
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut…  │
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut…  │
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut…  │
│                                               ·                                                │
│                                               ·                                                │
│                                               ·                                                │
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut…  │
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut…  │
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut…  │
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut…  │
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut…  │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│                                      100 rows (10 shown)                                       │
└────────────────────────────────────────────────────────────────────────────────────────────────┘
``` 

Similarly, we only allow wrapping until the `maxrows` is reached. If we have a gigantic string we will be able to fit more of it in the result, but still not everything:

```
select repeat('abcdefghijklmnopqrstuvwxyz', 10000) r;
┌────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                               r                                                │
│                                            varchar                                             │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│ abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmno  │
│ pqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcd  │
│ efghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrs  │
│ tuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefgh  │
│ ijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw  │
│ xyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl  │
│ mnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz…  │
└────────────────────────────────────────────────────────────────────────────────────────────────┘
```

If we select multiple large strings, we might be able to do some wrapping - but we never exceed `.maxrows`. The wrapping is done greedily (i.e. we try to add wrapping for the first value, then the second one, etc). For example:

```sql
memory D select 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.' as lorem_ipsum
from range(2);
┌─────────────────────────────────────────────────────────────────────────────────────────┐
│                                       lorem_ipsum                                       │
│                                         varchar                                         │
├─────────────────────────────────────────────────────────────────────────────────────────┤
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incidid  │
│ unt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitati  │
│ on ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in r  │
│ eprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur  │
│  sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim…  │
├─────────────────────────────────────────────────────────────────────────────────────────┤
│ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incidi…  │
└─────────────────────────────────────────────────────────────────────────────────────────┘
```


### Nested types / JSON / VARIANT

When doing this wrapping for nested types, JSON or variant, we add a "pretty print" step that tries to format the JSON in a nice way - provided it fits on the screen. For example:

##### file.json
```json
{
  "aliceblue": "#f0f8ff",
  "antiquewhite": "#faebd7",
  "aqua": "#00ffff",
  "aquamarine": "#7fffd4",
  "azure": "#f0ffff",
  "beige": "#f5f5dc",
  "bisque": "#ffe4c4",
  "black": "#000000",
  "blanchedalmond": "#ffebcd",
  "blue": "#0000ff",
  "blueviolet": "#8a2be2",
  "brown": "#a52a2a",
}
```

```sql
from read_json_objects('file.json');
┌────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                              json                                              │
│                                              json                                              │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│ {                                                                                              │
│   "aliceblue": "#f0f8ff",                                                                      │
│   "antiquewhite": "#faebd7",                                                                   │
│   "aqua": "#00ffff",                                                                           │
│   "aquamarine": "#7fffd4",                                                                     │
│   "azure": "#f0ffff",                                                                          │
│   "beige": "#f5f5dc",                                                                          │
│   "bisque": "#ffe4c4",                                                                         │
│   "black": "#000000",                                                                          │
│   "blanchedalmond": "#ffebcd",                                                                 │
│   "blue": "#0000ff",                                                                           │
│   "blueviolet": "#8a2be2",                                                                     │
│   "brown": "#a52a2a"                                                                           │
│ }                                                                                              │
└────────────────────────────────────────────────────────────────────────────────────────────────┘
```

The formatter will try to adapt to the max width of the terminal, and use a more compact rendering if the terminal width is exceeded by the simpler one. For example:

```sql
select json_serialize_sql($$select '10'::blob$$);
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                          json_serialize_sql('select ''10''::blob')                                          │
│                                                            json                                                             │
├─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ {                                                                                                                           │
│   "error": false,                                                                                                           │
│   "statements": [                                                                                                           │
│     {                                                                                                                       │
│       "node": {                                                                                                             │
│         "type": "SELECT_NODE",                                                                                              │
│         "modifiers": [],                                                                                                    │
│         "cte_map": {"map": []},                                                                                             │
│         "select_list": [                                                                                                    │
│           {                                                                                                                 │
│             "class": "CONSTANT",                                                                                            │
│             "type": "VALUE_CONSTANT",                                                                                       │
│             "alias": "",                                                                                                    │
│             "query_location": 18446744073709551615,                                                                         │
│             "value": {"type": {"id": "BLOB", "type_info": null}, "is_null": false, "value": "10"}                           │
│           }                                                                                                                 │
│         ],                                                                                                                  │
│         "from_table": {"type": "EMPTY", "alias": "", "sample": null, "query_location": 18446744073709551615},               │
│         "where_clause": null,                                                                                               │
│         "group_expressions": [],                                                                                            │
│         "group_sets": [],                                                                                                   │
│         "aggregate_handling": "STANDARD_HANDLING",                                                                          │
│         "having": null,                                                                                                     │
│         "sample": null,                                                                                                     │
│         "qualify": null                                                                                                     │
│       },                                                                                                                    │
│       "named_param_map": []                                                                                                 │
│     }                                                                                                                       │
│   ]                                                                                                                         │
│ }                                                                                                                           │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────┐
│                        json_serialize_sql('select ''10''::blob')                         │
│                                           json                                           │
├──────────────────────────────────────────────────────────────────────────────────────────┤
│ {                                                                                        │
│   "error": false,                                                                        │
│   "statements": [{                                                                       │
│       "node": {                                                                          │
│         "type": "SELECT_NODE", "modifiers": [], "cte_map": {"map": []},                  │
│         "select_list": [{                                                                │
│             "class": "CONSTANT", "type": "VALUE_CONSTANT", "alias": "",                  │
│             "query_location": 18446744073709551615,                                      │
│             "value": {                                                                   │
│               "type": {"id": "BLOB", "type_info": null}, "is_null": false,               │
│               "value": "10"                                                              │
│             }                                                                            │
│           }                                                                              │
│         ],                                                                               │
│         "from_table": {                                                                  │
│           "type": "EMPTY", "alias": "", "sample": null,                                  │
│           "query_location": 18446744073709551615                                         │
│         }, "where_clause": null, "group_expressions": [], "group_sets": [],              │
│         "aggregate_handling": "STANDARD_HANDLING", "having": null, "sample": null,       │
│         "qualify": null                                                                  │
│       }, "named_param_map": []                                                           │
│     }                                                                                    │
│   ]                                                                                      │
│ }                                                                                        │
└──────────────────────────────────────────────────────────────────────────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────┐
│                  json_serialize_sql('select ''10''::blob')                   │
│                                     json                                     │
├──────────────────────────────────────────────────────────────────────────────┤
│ {                                                                            │
│   "error": false,                                                            │
│   "statements": [{                                                           │
│       "node": {                                                              │
│         "type": "SELECT_NODE", "modifiers": [], "cte_map": {"map": []},      │
│         "select_list": [{                                                    │
│             "class": "CONSTANT", "type": "VALUE_CONSTANT", "alias": "",      │
│             "query_location": 18446744073709551615,                          │
│             "value": {                                                       │
│               "type": {"id": "BLOB", "type_info": null}, "is_null": false,   │
│               "value": "10"                                                  │
│             }                                                                │
│           }                                                                  │
│         ],                                                                   │
│         "from_table": {                                                      │
│           "type": "EMPTY", "alias": "", "sample": null,                      │
│           "query_location": 18446744073709551615                             │
│         }, "where_clause": null, "group_expressions": [], "group_sets": [],  │
│         "aggregate_handling": "STANDARD_HANDLING", "having": null,           │
│         "sample": null, "qualify": null                                      │
│       }, "named_param_map": []                                               │
│     }                                                                        │
│   ]                                                                          │
│ }                                                                            │
└──────────────────────────────────────────────────────────────────────────────┘
```

Just like with wrapping, this formatting is only done if there is space for it, e.g.:

```sql
select json_serialize_sql($$select '10'::blob$$) from range(100);
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                       json_serialize_sql('select ''10''::blob')                                       │
│                                                         json                                                          │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ {"error":false,"statements":[{"node":{"type":"SELECT_NODE","modifiers":[],"cte_map":{"map":[]},"select_list":[{"cla…  │
│ {"error":false,"statements":[{"node":{"type":"SELECT_NODE","modifiers":[],"cte_map":{"map":[]},"select_list":[{"cla…  │
│ {"error":false,"statements":[{"node":{"type":"SELECT_NODE","modifiers":[],"cte_map":{"map":[]},"select_list":[{"cla…  │
│ {"error":false,"statements":[{"node":{"type":"SELECT_NODE","modifiers":[],"cte_map":{"map":[]},"select_list":[{"cla…  │
│ {"error":false,"statements":[{"node":{"type":"SELECT_NODE","modifiers":[],"cte_map":{"map":[]},"select_list":[{"cla…  │
│                                                           ·                                                           │
│                                                           ·                                                           │
│                                                           ·                                                           │
│ {"error":false,"statements":[{"node":{"type":"SELECT_NODE","modifiers":[],"cte_map":{"map":[]},"select_list":[{"cla…  │
│ {"error":false,"statements":[{"node":{"type":"SELECT_NODE","modifiers":[],"cte_map":{"map":[]},"select_list":[{"cla…  │
│ {"error":false,"statements":[{"node":{"type":"SELECT_NODE","modifiers":[],"cte_map":{"map":[]},"select_list":[{"cla…  │
│ {"error":false,"statements":[{"node":{"type":"SELECT_NODE","modifiers":[],"cte_map":{"map":[]},"select_list":[{"cla…  │
│ {"error":false,"statements":[{"node":{"type":"SELECT_NODE","modifiers":[],"cte_map":{"map":[]},"select_list":[{"cla…  │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│                                                  100 rows (10 shown)                                                  │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

More space can always be made by the user by running e.g. `.maxrows -1`.

#### Highlighting

We also add highlighting support for JSON / VARIANT / nested types in results, e.g.:

<img width="1216" height="762" alt="Screenshot 2025-11-10 at 13 03 26" src="https://github.com/user-attachments/assets/351ac4ad-24e6-4a19-9c3a-c39e61d85f34" />
