### PR TITLE
implement proper equals for table functions

### DIFF
--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -259,7 +259,7 @@ bool PhysicalTableScan::Equals(const PhysicalOperator &other_p) const {
 		return false;
 	}
 	auto &other = other_p.Cast<PhysicalTableScan>();
-	if (function.function != other.function.function) {
+	if (function != other.function) {
 		return false;
 	}
 	if (column_ids != other.column_ids) {

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -37,6 +37,30 @@ TableFunction::TableFunction(const vector<LogicalType> &arguments, table_functio
 TableFunction::TableFunction() : TableFunction("", {}, nullptr, nullptr, nullptr, nullptr) {
 }
 
+bool TableFunction::operator==(const TableFunction &rhs) const {
+	return name == rhs.name && arguments == rhs.arguments && varargs == rhs.varargs && bind == rhs.bind &&
+	       bind_replace == rhs.bind_replace && bind_operator == rhs.bind_operator && init_global == rhs.init_global &&
+	       init_local == rhs.init_local && function == rhs.function && in_out_function == rhs.in_out_function &&
+	       in_out_function_final == rhs.in_out_function_final && statistics == rhs.statistics &&
+	       dependency == rhs.dependency && cardinality == rhs.cardinality &&
+	       pushdown_complex_filter == rhs.pushdown_complex_filter && pushdown_expression == rhs.pushdown_expression &&
+	       to_string == rhs.to_string && dynamic_to_string == rhs.dynamic_to_string &&
+	       table_scan_progress == rhs.table_scan_progress && get_partition_data == rhs.get_partition_data &&
+	       get_bind_info == rhs.get_bind_info && type_pushdown == rhs.type_pushdown &&
+	       get_multi_file_reader == rhs.get_multi_file_reader && supports_pushdown_type == rhs.supports_pushdown_type &&
+	       get_partition_info == rhs.get_partition_info && get_partition_stats == rhs.get_partition_stats &&
+	       get_virtual_columns == rhs.get_virtual_columns && get_row_id_columns == rhs.get_row_id_columns &&
+	       serialize == rhs.serialize && deserialize == rhs.deserialize &&
+	       verify_serialization == rhs.verify_serialization && projection_pushdown == rhs.projection_pushdown &&
+	       filter_pushdown == rhs.filter_pushdown && filter_prune == rhs.filter_prune &&
+	       sampling_pushdown == rhs.sampling_pushdown && late_materialization == rhs.late_materialization &&
+	       global_initialization == rhs.global_initialization;
+}
+
+bool TableFunction::operator!=(const TableFunction &rhs) const {
+	return !(*this == rhs);
+}
+
 bool TableFunction::Equal(const TableFunction &rhs) const {
 	// number of types
 	if (this->arguments.size() != rhs.arguments.size()) {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -432,6 +432,8 @@ public:
 	TableFunctionInitialization global_initialization = TableFunctionInitialization::INITIALIZE_ON_EXECUTE;
 
 	DUCKDB_API bool Equal(const TableFunction &rhs) const;
+	DUCKDB_API bool operator==(const TableFunction &rhs) const;
+	DUCKDB_API bool operator!=(const TableFunction &rhs) const;
 };
 
 } // namespace duckdb

--- a/test/sql/types/nested/unnest_range_plan.test
+++ b/test/sql/types/nested/unnest_range_plan.test
@@ -9,5 +9,5 @@ FROM UNNEST(ARRAY[6]) AS x
 UNION ALL
 SELECT 2 FROM generate_series(1, 1);
 ----
-6
 2
+6

--- a/test/sql/types/nested/unnest_range_plan.test
+++ b/test/sql/types/nested/unnest_range_plan.test
@@ -1,0 +1,13 @@
+# name: test/sql/types/nested/unnest_range_plan.test
+# group: [nested]
+
+# Fix issue #19645
+
+query I rowsort
+SELECT *
+FROM UNNEST(ARRAY[6]) AS x
+UNION ALL
+SELECT 2 FROM generate_series(1, 1);
+----
+6
+2


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/19645

The issue is that during pipeline verification we compare all the operators across pipelines and ensure that their equality is reflexive (which is kind of a strange check actually), but in the case of table scans we only compare the normal table function callback pointer. In the MRE in the linked issue, the pipeline contains a UNNEST and a RANGE, which are both table-in-out functions, but not _normal_ table functions, so the function pointer(s) are null on both sides and they are assumed to be equal. 

I've fixed it by actually implementing the `==` and `!=` operates for `TableFunction`s that compare all the properties, similar to how its done for `ScalarFunction`. 
