### PR TITLE
Add explicit Initialize(HTTPParam&) method to HTTPClient

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -9,4 +9,5 @@ duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG b80c680f86dff6061614536d908d4b08c85c9ef4
     INCLUDE_DIR src/include
+    APPLY_PATCHES
 )

--- a/.github/patches/extensions/httpfs/initialize.patch
+++ b/.github/patches/extensions/httpfs/initialize.patch
@@ -1,0 +1,31 @@
+diff --git a/src/httpfs_curl_client.cpp b/src/httpfs_curl_client.cpp
+index 6de3c85dad1..a7e4637a924 100644
+--- a/src/httpfs_curl_client.cpp
++++ b/src/httpfs_curl_client.cpp
+@@ -115,6 +115,11 @@ static idx_t httpfs_client_count = 0;
+ class HTTPFSCurlClient : public HTTPClient {
+ public:
+ 	HTTPFSCurlClient(HTTPFSParams &http_params, const string &proto_host_port) {
++		// FIXME: proto_host_port is not used
++		Initialize(http_params);
++	}
++	void Initialize(HTTPParams &http_p) override {
++		HTTPFSParams &http_params = (HTTPFSParams&)http_p;
+ 		auto bearer_token = "";
+ 		if (!http_params.bearer_token.empty()) {
+ 			bearer_token = http_params.bearer_token.c_str();
+diff --git a/src/httpfs_httplib_client.cpp b/src/httpfs_httplib_client.cpp
+index 239a11248c7..cf1b854075a 100644
+--- a/src/httpfs_httplib_client.cpp
++++ b/src/httpfs_httplib_client.cpp
+@@ -9,6 +9,10 @@ class HTTPFSClient : public HTTPClient {
+ public:
+ 	HTTPFSClient(HTTPFSParams &http_params, const string &proto_host_port) {
+ 		client = make_uniq<duckdb_httplib_openssl::Client>(proto_host_port);
++		Initialize(http_params);
++	}
++	void Initialize(HTTPParams &http_p) override {
++		HTTPFSParams &http_params = (HTTPFSParams&)http_p;
+ 		client->set_follow_location(http_params.follow_location);
+ 		client->set_keep_alive(http_params.keep_alive);
+ 		if (!http_params.ca_cert_file.empty()) {

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -216,6 +216,7 @@ struct PostRequestInfo : public BaseRequest {
 class HTTPClient {
 public:
 	virtual ~HTTPClient() = default;
+	virtual void Initialize(HTTPParams &http_params) = 0;
 
 	virtual unique_ptr<HTTPResponse> Get(GetRequestInfo &info) = 0;
 	virtual unique_ptr<HTTPResponse> Put(PutRequestInfo &info) = 0;

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -130,9 +130,12 @@ BaseRequest::BaseRequest(RequestType type, const string &url, const HTTPHeaders 
 class HTTPLibClient : public HTTPClient {
 public:
 	HTTPLibClient(HTTPParams &http_params, const string &proto_host_port) {
+		client = make_uniq<duckdb_httplib::Client>(proto_host_port);
+		Initialize(http_params);
+	}
+	void Initialize(HTTPParams &http_params) override {
 		auto sec = static_cast<time_t>(http_params.timeout);
 		auto usec = static_cast<time_t>(http_params.timeout_usec);
-		client = make_uniq<duckdb_httplib::Client>(proto_host_port);
 		client->set_follow_location(http_params.follow_location);
 		client->set_keep_alive(http_params.keep_alive);
 		client->set_write_timeout(sec, usec);


### PR DESCRIPTION
This allow explicit re-initialization of specific parts of HTTPClient(s)

This diff would allow patterns such reusing partially constructed (but properly re-initialized) HTTPClient objects

```c++
struct CrossQueryState {
    // in some state kept around
    unique_ptr<HTTPClient>& client;
};

void SomeFunction() {
    // ...
    http_util.Request(get_request, client);
    // some more logic, same query
    http_util.Request(get_request, client);
}
void SomeOtherFunction() {
    // Re-initialize part of the client, given some settings might have changed
    auto http_params = HTTPParams(http_util)
    client->Initialize(http_params);
    // ...
    http_util.Request(get_request, client);
    // some more logic, same query
    http_util.Request(get_request, client);
}
```

Note that PR is fully opt-in from users, while if you implement a file-system abstraction inheriting from HTTPClient you should get a compiler error pointing to implementing the relevant function.