### PR TITLE
`in_bytes` representation in `duckdb_settings()` table function

### DIFF
--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -33,7 +33,7 @@ struct DuckDBSettingsBindData : TableFunctionData {
 	unique_ptr<FunctionData> Copy() const override {
 		auto res = make_uniq<DuckDBSettingsBindData>();
 		res->in_bytes = in_bytes;
-		return move(res);
+		return std::move(res);
 	}
 
 	bool Equals(const FunctionData &other_p) const override {

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -140,7 +140,7 @@ void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, 
 
 	// We can infer from the value column type that we are in byte mode or not, because of the binding step
 	const auto value_column = output.data[1];
-	const auto& value_type = value_column.GetType();
+	const auto &value_type = value_column.GetType();
 	const bool in_bytes = value_type.id() == LogicalTypeId::UBIGINT;
 
 	if (data.offset >= data.settings.size()) {

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -24,7 +24,7 @@ struct DuckDBSettingsBindData : public TableFunctionData {
 	unique_ptr<FunctionData> Copy() const override {
 		auto res = make_uniq<DuckDBSettingsBindData>();
 		res->in_bytes = in_bytes;
-		return res;
+		return unique_ptr<FunctionData>(std::move(res));
 	}
 
 	bool Equals(const FunctionData &other_p) const override {

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -145,12 +145,12 @@ static optional_idx TryParseBytes(const string &str) {
 void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &data = data_p.global_state->Cast<DuckDBSettingsData>();
 
-	// We can if we're in bytes-mode according to the existence of the `memory_in_bytes` column
+	// We can infer if we're in bytes-mode according to the number of columns
 	// This is covered in tests, so if someone adds another column / an option that changes column, they will have to
 	// update this implicit inferring logic
-	const auto in_bytes = output.ColumnCount() >= 7;
+	const auto in_bytes = output.ColumnCount() == 7;
 	if (in_bytes) {
-		D_ASSERT(output.data[6].GetType() == LogicalType::UBIGINT || !in_bytes);
+		D_ASSERT(output.data[6].GetType() == LogicalType::UBIGINT);
 	}
 
 	if (data.offset >= data.settings.size()) {

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/exception/parser_exception.hpp"
 
 namespace duckdb {
 

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -197,7 +197,6 @@ void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, 
 
 void DuckDBSettingsFun::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction fun("duckdb_settings", {}, DuckDBSettingsFunction, DuckDBSettingsBind, DuckDBSettingsInit);
-	// It should be Boolean, but if we do so, we cannot have the validation we have in `extract_in_bytes_argument`
 	fun.named_parameters["in_bytes"] = LogicalType::BOOLEAN;
 	set.AddFunction(fun);
 }

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -145,10 +145,9 @@ static optional_idx TryParseBytes(const string &str) {
 void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &data = data_p.global_state->Cast<DuckDBSettingsData>();
 
-	// We can infer from the value column type that we are in byte mode or not, because of the binding step
-	const auto value_column = output.data[1];
-	const auto &value_type = value_column.GetType();
-	const bool in_bytes = value_type.id() == LogicalTypeId::UBIGINT;
+	// TODO - check if explicitly passing the `in_bytes` mode boolean via `BindData` is acceptable
+	// We can if we're in bytes-mode according to the existence of the `memory_in_bytes` column
+	const auto in_bytes = output.ColumnCount() >= 7;
 
 	if (data.offset >= data.settings.size()) {
 		// finished returning values
@@ -182,7 +181,7 @@ void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, 
 			if (parsed.IsValid()) {
 				output.SetValue(6, count, Value::UBIGINT(parsed.GetIndex()));
 			} else {
-				output.SetValue(6, count, Value());
+				output.SetValue(6, count, Value(nullptr));
 			}
 		}
 

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -31,9 +31,8 @@ static bool extract_in_bytes_argument(const TableFunctionBindInput &input) {
 	auto it = input.named_parameters.find("in_bytes");
 	if (it != input.named_parameters.end()) {
 		const auto &param = it->second;
-		if (param.IsNull() || param.type().id() != LogicalTypeId::BOOLEAN) {
-			throw InvalidInputException(
-			    "duckdb_settings: named parameter 'in_bytes' must be a non-NULL BOOLEAN (true/false)");
+		if (param.IsNull()) {
+			throw BinderException("'in_bytes' parameter cannot be NULL");
 		}
 		in_bytes = param.GetValue<bool>();
 	};
@@ -199,7 +198,7 @@ void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, 
 void DuckDBSettingsFun::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction fun("duckdb_settings", {}, DuckDBSettingsFunction, DuckDBSettingsBind, DuckDBSettingsInit);
 	// It should be Boolean, but if we do so, we cannot have the validation we have in `extract_in_bytes_argument`
-	fun.named_parameters["in_bytes"] = LogicalType::ANY;
+	fun.named_parameters["in_bytes"] = LogicalType::BOOLEAN;
 	set.AddFunction(fun);
 }
 

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -130,9 +130,7 @@ static optional_idx TryParseBytes(const string &str) {
 	try {
 		auto val = DBConfig::ParseMemoryLimit(str);
 		return optional_idx(val);
-	} catch (ParserException &e) {
-		return optional_idx();
-	} catch (InvalidInputException &e) {
+	} catch (Exception &e) {
 		return optional_idx();
 	}
 }

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -130,7 +130,9 @@ static optional_idx TryParseBytes(const string &str) {
 	try {
 		auto val = DBConfig::ParseMemoryLimit(str);
 		return optional_idx(val);
-	} catch (Exception &e) {
+	} catch (ParserException &e) {
+		return optional_idx();
+	} catch (InvalidInputException &e) {
 		return optional_idx();
 	}
 }

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -27,7 +27,7 @@ struct DuckDBSettingsData : public GlobalTableFunctionState {
 	idx_t offset;
 };
 
-static bool extract_in_bytes_argument(const TableFunctionBindInput &input) {
+static bool ExtractInBytesArgument(const TableFunctionBindInput &input) {
 	bool in_bytes = false;
 	auto it = input.named_parameters.find("in_bytes");
 	if (it != input.named_parameters.end()) {
@@ -47,7 +47,7 @@ static unique_ptr<FunctionData> DuckDBSettingsBind(ClientContext &context, Table
 
 	names.emplace_back("value");
 
-	bool in_bytes = extract_in_bytes_argument(input);
+	bool in_bytes = ExtractInBytesArgument(input);
 	if (in_bytes) {
 		return_types.emplace_back(LogicalType::UBIGINT);
 	} else {

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -145,9 +145,13 @@ static optional_idx TryParseBytes(const string &str) {
 void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &data = data_p.global_state->Cast<DuckDBSettingsData>();
 
-	// TODO - check if explicitly passing the `in_bytes` mode boolean via `BindData` is acceptable
 	// We can if we're in bytes-mode according to the existence of the `memory_in_bytes` column
+	// This is covered in tests, so if someone adds another column / an option that changes column, they will have to
+	// update this implicit inferring logic
 	const auto in_bytes = output.ColumnCount() >= 7;
+	if (in_bytes) {
+		D_ASSERT(output.data[6].GetType() == LogicalType::UBIGINT || !in_bytes);
+	}
 
 	if (data.offset >= data.settings.size()) {
 		// finished returning values

--- a/test/sql/table_function/duckdb_settings_in_bytes.test
+++ b/test/sql/table_function/duckdb_settings_in_bytes.test
@@ -105,12 +105,3 @@ statement error
 SELECT * FROM duckdb_settings(in_bytes=NULL);
 ----
 Binder Error: 'in_bytes' parameter cannot be NULL
-
-# When `in_bytes` is set to true, we should have exctly 7 columns
-query IIIIIII
-SELECT * FROM duckdb_settings(in_bytes=true) WHERE 1=0;
-----
-
-# When `in_bytes` is set to false, we should have exactly 6 columns
-query IIIIII
-SELECT * FROM duckdb_settings() WHERE 1=0;

--- a/test/sql/table_function/duckdb_settings_in_bytes.test
+++ b/test/sql/table_function/duckdb_settings_in_bytes.test
@@ -12,6 +12,12 @@ SELECT typeof(value) FROM duckdb_settings() WHERE name IN ('wal_autocheckpoint')
 ----
 VARCHAR
 
+# in_bytes=false should behave like default (VARCHAR)
+query I
+SELECT typeof(value) FROM duckdb_settings(in_bytes=false) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
+----
+VARCHAR
+
 # In bytes mode the value should be a number (UBIGINT) for memory-like settings
 query I
 SELECT typeof(value) FROM duckdb_settings(in_bytes=true) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
@@ -31,3 +37,37 @@ SET default_collation='nfc';
 query I
 SELECT value IS NULL FROM duckdb_settings(in_bytes=true) WHERE name='default_collation';
 ----
+
+# Incorrect inputs should error
+# - in_bytes must be boolean true/false
+statement error
+SELECT * FROM duckdb_settings(in_bytes=42);
+----
+Invalid Input Error: duckdb_settings: named parameter 'in_bytes' must be a non-NULL BOOLEAN (true/false)
+
+# - unknown named parameter
+statement error
+SELECT * FROM duckdb_settings(hello=true);
+----
+Binder Error: Invalid named parameter "hello" for function duckdb_settings
+
+# single value
+statement error
+SELECT * FROM duckdb_settings(true);
+----
+
+# 0/1/NULL should be rejected
+statement error
+SELECT * FROM duckdb_settings(in_bytes=0);
+----
+Invalid Input Error: duckdb_settings: named parameter 'in_bytes' must be a non-NULL BOOLEAN (true/false)
+
+statement error
+SELECT * FROM duckdb_settings(in_bytes=1);
+----
+Invalid Input Error: duckdb_settings: named parameter 'in_bytes' must be a non-NULL BOOLEAN (true/false)
+
+statement error
+SELECT * FROM duckdb_settings(in_bytes=NULL);
+----
+Invalid Input Error: duckdb_settings: named parameter 'in_bytes' must be a non-NULL BOOLEAN (true/false)

--- a/test/sql/table_function/duckdb_settings_in_bytes.test
+++ b/test/sql/table_function/duckdb_settings_in_bytes.test
@@ -30,6 +30,12 @@ SELECT value FROM duckdb_settings(in_bytes=true) WHERE name IN ('wal_autocheckpo
 ----
 1024
 
+# the 0 should be considered as false
+query I
+SELECT typeof(value) FROM duckdb_settings(in_bytes=0) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
+----
+VARCHAR
+
 # Non-byte settings should not be returned at all
 statement ok
 SET default_collation='nfc';
@@ -38,13 +44,20 @@ query I
 SELECT value IS NULL FROM duckdb_settings(in_bytes=true) WHERE name='default_collation';
 ----
 
-# Incorrect inputs should error
-# - in_bytes must be boolean true/false
-statement error
-SELECT * FROM duckdb_settings(in_bytes=42);
-----
-Invalid Input Error: duckdb_settings: named parameter 'in_bytes' must be a non-NULL BOOLEAN (true/false)
 
+# We consider 1 as true
+query I
+SELECT value FROM duckdb_settings(in_bytes=1) WHERE name IN ('wal_autocheckpoint') LIMIT 1;;
+----
+1024
+
+# - non-zero should be consider true
+query I
+SELECT value FROM duckdb_settings(in_bytes=true) WHERE name IN ('wal_autocheckpoint') LIMIT 1;;
+----
+1024
+
+# Incorrect inputs should error
 # - unknown named parameter
 statement error
 SELECT * FROM duckdb_settings(hello=true);
@@ -56,18 +69,8 @@ statement error
 SELECT * FROM duckdb_settings(true);
 ----
 
-# 0/1/NULL should be rejected
-statement error
-SELECT * FROM duckdb_settings(in_bytes=0);
-----
-Invalid Input Error: duckdb_settings: named parameter 'in_bytes' must be a non-NULL BOOLEAN (true/false)
-
-statement error
-SELECT * FROM duckdb_settings(in_bytes=1);
-----
-Invalid Input Error: duckdb_settings: named parameter 'in_bytes' must be a non-NULL BOOLEAN (true/false)
-
+# NULL
 statement error
 SELECT * FROM duckdb_settings(in_bytes=NULL);
 ----
-Invalid Input Error: duckdb_settings: named parameter 'in_bytes' must be a non-NULL BOOLEAN (true/false)
+Binder Error: 'in_bytes' parameter cannot be NULL

--- a/test/sql/table_function/duckdb_settings_in_bytes.test
+++ b/test/sql/table_function/duckdb_settings_in_bytes.test
@@ -81,11 +81,11 @@ SELECT * FROM duckdb_settings(in_bytes=NULL);
 ----
 Binder Error: 'in_bytes' parameter cannot be NULL
 
-# When `in_bytes` is set to true, we should have excatly 7 columns
+# When `in_bytes` is set to true, we should have exctly 7 columns
 query IIIIIII
 SELECT * FROM duckdb_settings(in_bytes=true) WHERE 1=0;
 ----
 
-# When `in_bytes` is set to false, we should have excatly 6 columns
+# When `in_bytes` is set to false, we should have exactly 6 columns
 query IIIIII
 SELECT * FROM duckdb_settings() WHERE 1=0;

--- a/test/sql/table_function/duckdb_settings_in_bytes.test
+++ b/test/sql/table_function/duckdb_settings_in_bytes.test
@@ -80,3 +80,12 @@ statement error
 SELECT * FROM duckdb_settings(in_bytes=NULL);
 ----
 Binder Error: 'in_bytes' parameter cannot be NULL
+
+# When `in_bytes` is set to true, we should have excatly 7 columns
+query IIIIIII
+SELECT * FROM duckdb_settings(in_bytes=true) WHERE 1=0;
+----
+
+# When `in_bytes` is set to false, we should have excatly 6 columns
+query IIIIII
+SELECT * FROM duckdb_settings() WHERE 1=0;

--- a/test/sql/table_function/duckdb_settings_in_bytes.test
+++ b/test/sql/table_function/duckdb_settings_in_bytes.test
@@ -1,0 +1,33 @@
+# name: test/sql/table_function/duckdb_settings_in_bytes.test
+# description: Test duckdb_settings(in_bytes=...) returns bytes for memory-like settings
+# group: [table_function]
+
+# Configuring a setting
+statement ok
+PRAGMA wal_autocheckpoint='1 KiB';
+
+# Default behavior unchanged (VARCHAR)
+query I
+SELECT typeof(value) FROM duckdb_settings() WHERE name IN ('wal_autocheckpoint') LIMIT 1;
+----
+VARCHAR
+
+# In bytes mode the value should be a number (UBIGINT) for memory-like settings
+query I
+SELECT typeof(value) FROM duckdb_settings(in_bytes=true) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
+----
+UBIGINT
+
+# The numeric value should match 1024 for the memory-like setting we just set
+query I
+SELECT value FROM duckdb_settings(in_bytes=true) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
+----
+1024
+
+# Non-byte settings should not be returned at all
+statement ok
+SET default_collation='nfc';
+
+query I
+SELECT value IS NULL FROM duckdb_settings(in_bytes=true) WHERE name='default_collation';
+----

--- a/test/sql/table_function/duckdb_settings_in_bytes.test
+++ b/test/sql/table_function/duckdb_settings_in_bytes.test
@@ -42,14 +42,39 @@ SELECT memory_in_bytes FROM duckdb_settings(in_bytes=0) WHERE name IN ('wal_auto
 ----
 Binder Error: Referenced column "memory_in_bytes" not found in FROM clause
 
-# Non-byte settings should be returned as null in the memory_in_bytes column
+# Non-byte settings
 statement ok
 SET default_collation='nfc';
 
+# The memory_in_bytes column should be NULL for non-byte settings (like default_collation)
 query I
 SELECT memory_in_bytes IS NULL FROM duckdb_settings(in_bytes=true) WHERE name='default_collation';
 ----
 true
+
+# Another non-byte settings, should be returned as null in the memory_in_bytes column
+query I
+SELECT value FROM duckdb_settings(in_bytes=true) WHERE name='access_mode';
+----
+automatic
+
+# The memory_in_bytes column should be NULL for non-byte settings (like access_mode)
+query I
+SELECT memory_in_bytes IS NULL FROM duckdb_settings(in_bytes=true) WHERE name='access_mode';
+----
+true
+
+# The original column should not change for non-byte settings
+query I
+SELECT value FROM duckdb_settings(in_bytes=true) WHERE name='default_collation';
+----
+nfc
+
+# The original column should not change for byte settings
+query I
+SELECT value FROM duckdb_settings(in_bytes=true) WHERE name='wal_autocheckpoint';
+----
+1.0 KiB
 
 # We consider 1 as true
 query I

--- a/test/sql/table_function/duckdb_settings_in_bytes.test
+++ b/test/sql/table_function/duckdb_settings_in_bytes.test
@@ -6,54 +6,60 @@
 statement ok
 PRAGMA wal_autocheckpoint='1 KiB';
 
-# Default behavior unchanged (VARCHAR)
+# Default behavior unchanged, value still exists as VARCHAR
 query I
 SELECT typeof(value) FROM duckdb_settings() WHERE name IN ('wal_autocheckpoint') LIMIT 1;
 ----
 VARCHAR
 
-# in_bytes=false should behave like default (VARCHAR)
-query I
-SELECT typeof(value) FROM duckdb_settings(in_bytes=false) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
+# Default behavior unchanged, the memory column still does not exist
+statement error
+SELECT memory_in_bytes FROM duckdb_settings() WHERE name IN ('wal_autocheckpoint') LIMIT 1;
 ----
-VARCHAR
+Binder Error: Referenced column "memory_in_bytes" not found in FROM clause
 
-# In bytes mode the value should be a number (UBIGINT) for memory-like settings
+# when in_bytes=false, Default behavior unchanged, the memory column still does not exist
+statement error
+SELECT memory_in_bytes FROM duckdb_settings(in_bytes=false) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
+----
+Binder Error: Referenced column "memory_in_bytes" not found in FROM clause
+
+# In bytes mode the memory column should be a number (UBIGINT) for memory-like settings
 query I
-SELECT typeof(value) FROM duckdb_settings(in_bytes=true) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
+SELECT typeof(memory_in_bytes) FROM duckdb_settings(in_bytes=true) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
 ----
 UBIGINT
 
 # The numeric value should match 1024 for the memory-like setting we just set
 query I
-SELECT value FROM duckdb_settings(in_bytes=true) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
+SELECT memory_in_bytes FROM duckdb_settings(in_bytes=true) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
 ----
 1024
 
 # the 0 should be considered as false
-query I
-SELECT typeof(value) FROM duckdb_settings(in_bytes=0) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
+statement error
+SELECT memory_in_bytes FROM duckdb_settings(in_bytes=0) WHERE name IN ('wal_autocheckpoint') LIMIT 1;
 ----
-VARCHAR
+Binder Error: Referenced column "memory_in_bytes" not found in FROM clause
 
-# Non-byte settings should not be returned at all
+# Non-byte settings should be returned as null in the memory_in_bytes column
 statement ok
 SET default_collation='nfc';
 
 query I
-SELECT value IS NULL FROM duckdb_settings(in_bytes=true) WHERE name='default_collation';
+SELECT memory_in_bytes IS NULL FROM duckdb_settings(in_bytes=true) WHERE name='default_collation';
 ----
-
+true
 
 # We consider 1 as true
 query I
-SELECT value FROM duckdb_settings(in_bytes=1) WHERE name IN ('wal_autocheckpoint') LIMIT 1;;
+SELECT memory_in_bytes FROM duckdb_settings(in_bytes=1) WHERE name IN ('wal_autocheckpoint') LIMIT 1;;
 ----
 1024
 
 # - non-zero should be consider true
 query I
-SELECT value FROM duckdb_settings(in_bytes=true) WHERE name IN ('wal_autocheckpoint') LIMIT 1;;
+SELECT memory_in_bytes FROM duckdb_settings(in_bytes=true) WHERE name IN ('wal_autocheckpoint') LIMIT 1;;
 ----
 1024
 


### PR DESCRIPTION
## Summary
The Pull Request introduces a new `in_bytes` parameter to the `duckdb_settings` table function, to retrieve all memory-like settings in bytes unit representation

<img width="1546" height="292" alt="image" src="https://github.com/user-attachments/assets/2aeb18a4-c284-4d0a-a8c0-746df3c5951d" />
