### PR TITLE
Export re2 symbols

### DIFF
--- a/third_party/re2/CMakeLists.txt
+++ b/third_party/re2/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 project(RE2 CXX)
 
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET default)
 
 include(CTest)
 


### PR DESCRIPTION
Export RE2 symbols, allowing others to easier use DDB RE2