### PR TITLE
Logs to be case-insensitive also at enable_logging callsite

### DIFF
--- a/src/logging/log_manager.cpp
+++ b/src/logging/log_manager.cpp
@@ -205,7 +205,7 @@ void LogManager::SetEnableStructuredLoggers(vector<string> &enabled_logger_types
 			throw InvalidInputException("Unknown log type: '%s'", enabled_logger_type);
 		}
 
-		new_config.enabled_log_types.insert(enabled_logger_type);
+		new_config.enabled_log_types.insert(lookup->name);
 
 		min_log_level = MinValue(min_log_level, lookup->level);
 	}

--- a/test/sql/logging/logging_call_functions.test
+++ b/test/sql/logging/logging_call_functions.test
@@ -93,7 +93,7 @@ logging_storage	memory
 ###
 
 statement ok
-CALL enable_logging(['QueryLog', 'FileSystem']);
+CALL enable_logging(['QueryLog', 'filesystem']);
 
 # Use sorted list to avoid indeterministic result
 query II


### PR DESCRIPTION
Currently `CALL enable_logging('http');` would succeed, but then select an empty subset of the available logs (`http` != `HTTP`), due to a quirk in the code. This PR fixes that up.