### PR TITLE
Add `Stats` API to filesystem interfaces

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -453,6 +453,10 @@ FileType FileSystem::GetFileType(FileHandle &handle) {
 	return FileType::FILE_TYPE_INVALID;
 }
 
+FileMetadata FileSystem::Stats(FileHandle& handle) {
+	throw NotImplementedException("%s: Stats is not implemented!", GetName());
+}
+
 void FileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 	throw NotImplementedException("%s: Truncate is not implemented!", GetName());
 }
@@ -798,6 +802,10 @@ void FileHandle::Truncate(int64_t new_size) {
 
 FileType FileHandle::GetType() {
 	return file_system.GetFileType(*this);
+}
+
+FileMetadata FileHandle::Stats() {
+	return file_system.Stats(*this);
 }
 
 void FileHandle::TryAddLogger(FileOpener &opener) {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -453,7 +453,7 @@ FileType FileSystem::GetFileType(FileHandle &handle) {
 	return FileType::FILE_TYPE_INVALID;
 }
 
-FileMetadata FileSystem::Stats(FileHandle& handle) {
+FileMetadata FileSystem::Stats(FileHandle &handle) {
 	throw NotImplementedException("%s: Stats is not implemented!", GetName());
 }
 

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -167,11 +167,11 @@ public:
 	};
 };
 
-static FileMetadata StatsInternal(int fd, const string& path) {
+static FileMetadata StatsInternal(int fd, const string &path) {
 	struct stat s;
 	if (fstat(fd, &s) == -1) {
-		throw IOException({{"errno", std::to_string(errno)}}, "Failed to get stats for file \"%s\": %s",
-		                  path, strerror(errno));
+		throw IOException({{"errno", std::to_string(errno)}}, "Failed to get stats for file \"%s\": %s", path,
+		                  strerror(errno));
 	}
 
 	FileMetadata file_metadata;
@@ -597,9 +597,9 @@ FileType LocalFileSystem::GetFileType(FileHandle &handle) {
 	return file_metadata.file_type;
 }
 
-FileMetadata LocalFileSystem::Stats(FileHandle& handle) {
+FileMetadata LocalFileSystem::Stats(FileHandle &handle) {
 	int fd = handle.Cast<UnixFileHandle>().fd;
-	auto file_metadata = StatsInternal(fd, handle.GetPath());	
+	auto file_metadata = StatsInternal(fd, handle.GetPath());
 	return file_metadata;
 }
 
@@ -826,14 +826,14 @@ static FileMetadata StatsInternal(HANDLE hFile, const string &path) {
 	}
 
 	FileMetadata file_metadata;
-	
+
 	// Get file size from high and low parts
-	file_metadata.file_size = (static_cast<int64_t>(file_info.nFileSizeHigh) << 32) | 
-	                          static_cast<int64_t>(file_info.nFileSizeLow);
-	
+	file_metadata.file_size =
+	    (static_cast<int64_t>(file_info.nFileSizeHigh) << 32) | static_cast<int64_t>(file_info.nFileSizeLow);
+
 	// Get last modification time
 	file_metadata.last_modification_time = FiletimeToTimeStamp(file_info.ftLastWriteTime);
-	
+
 	// Get file type from attributes
 	if (strncmp(path.c_str(), PIPE_PREFIX, strlen(PIPE_PREFIX)) == 0) {
 		// pipes in windows are just files in '\\.\pipe\' folder
@@ -849,7 +849,7 @@ static FileMetadata StatsInternal(HANDLE hFile, const string &path) {
 	} else {
 		file_metadata.file_type = FileType::FILE_TYPE_INVALID;
 	}
-	
+
 	return file_metadata;
 }
 

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -181,20 +181,28 @@ static FileMetadata StatsInternal(int fd, const string &path) {
 	switch (s.st_mode & S_IFMT) {
 	case S_IFBLK:
 		file_metadata.file_type = FileType::FILE_TYPE_BLOCKDEV;
+		break;
 	case S_IFCHR:
 		file_metadata.file_type = FileType::FILE_TYPE_CHARDEV;
+		break;
 	case S_IFIFO:
 		file_metadata.file_type = FileType::FILE_TYPE_FIFO;
+		break;
 	case S_IFDIR:
 		file_metadata.file_type = FileType::FILE_TYPE_DIR;
+		break;
 	case S_IFLNK:
 		file_metadata.file_type = FileType::FILE_TYPE_LINK;
+		break;
 	case S_IFREG:
 		file_metadata.file_type = FileType::FILE_TYPE_REGULAR;
+		break;
 	case S_IFSOCK:
 		file_metadata.file_type = FileType::FILE_TYPE_SOCKET;
+		break;
 	default:
 		file_metadata.file_type = FileType::FILE_TYPE_INVALID;
+		break;
 	}
 
 	return file_metadata;

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -88,6 +88,9 @@ string VirtualFileSystem::GetVersionTag(FileHandle &handle) {
 FileType VirtualFileSystem::GetFileType(FileHandle &handle) {
 	return handle.file_system.GetFileType(handle);
 }
+FileMetadata VirtualFileSystem::Stats(FileHandle& handle) {
+	return handle.file_system.Stats(handle);
+}
 
 void VirtualFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 	handle.file_system.Truncate(handle, new_size);

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -88,7 +88,7 @@ string VirtualFileSystem::GetVersionTag(FileHandle &handle) {
 FileType VirtualFileSystem::GetFileType(FileHandle &handle) {
 	return handle.file_system.GetFileType(handle);
 }
-FileMetadata VirtualFileSystem::Stats(FileHandle& handle) {
+FileMetadata VirtualFileSystem::Stats(FileHandle &handle) {
 	return handle.file_system.Stats(handle);
 }
 

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -10,16 +10,18 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/file_compression_type.hpp"
-#include "duckdb/common/exception.hpp"
-#include "duckdb/common/file_buffer.hpp"
-#include "duckdb/common/unordered_map.hpp"
-#include "duckdb/common/vector.hpp"
 #include "duckdb/common/enums/file_glob_options.hpp"
-#include "duckdb/common/optional_ptr.hpp"
-#include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/error_data.hpp"
+#include "duckdb/common/file_buffer.hpp"
 #include "duckdb/common/file_open_flags.hpp"
 #include "duckdb/common/open_file_info.hpp"
+#include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/vector.hpp"
+
 #include <functional>
 
 #undef CreateDirectory
@@ -55,6 +57,15 @@ enum class FileType {
 	FILE_TYPE_INVALID,
 };
 
+struct FileMetadata {
+	int64_t file_size = -1;
+	timestamp_t last_modification_time = timestamp_t::ninfinity();
+	FileType file_type = FileType::FILE_TYPE_INVALID;
+
+	// A key-value pair of the extended file metadata, which could store any attributes.
+	unordered_map<string, string> extended_file_info;
+};
+
 struct FileHandle {
 public:
 	DUCKDB_API FileHandle(FileSystem &file_system, string path, FileOpenFlags flags);
@@ -87,6 +98,7 @@ public:
 	DUCKDB_API bool OnDiskFile();
 	DUCKDB_API idx_t GetFileSize();
 	DUCKDB_API FileType GetType();
+	DUCKDB_API FileMetadata Stats();
 
 	DUCKDB_API void TryAddLogger(FileOpener &opener);
 
@@ -158,6 +170,8 @@ public:
 	DUCKDB_API virtual string GetVersionTag(FileHandle &handle);
 	//! Returns the file type of the attached handle
 	DUCKDB_API virtual FileType GetFileType(FileHandle &handle);
+	//! Returns the file stats of the attached handle.
+	DUCKDB_API virtual FileMetadata Stats(FileHandle& handle);
 	//! Truncate a file to a maximum size of new_size, new_size should be smaller than or equal to the current size of
 	//! the file
 	DUCKDB_API virtual void Truncate(FileHandle &handle, int64_t new_size);

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -19,6 +19,7 @@
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/string.hpp"
+#include "duckdb/common/types/value.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
 
@@ -63,7 +64,7 @@ struct FileMetadata {
 	FileType file_type = FileType::FILE_TYPE_INVALID;
 
 	// A key-value pair of the extended file metadata, which could store any attributes.
-	unordered_map<string, string> extended_file_info;
+	unordered_map<string, Value> extended_file_info;
 };
 
 struct FileHandle {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -171,7 +171,7 @@ public:
 	//! Returns the file type of the attached handle
 	DUCKDB_API virtual FileType GetFileType(FileHandle &handle);
 	//! Returns the file stats of the attached handle.
-	DUCKDB_API virtual FileMetadata Stats(FileHandle& handle);
+	DUCKDB_API virtual FileMetadata Stats(FileHandle &handle);
 	//! Truncate a file to a maximum size of new_size, new_size should be smaller than or equal to the current size of
 	//! the file
 	DUCKDB_API virtual void Truncate(FileHandle &handle, int64_t new_size);

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -40,6 +40,8 @@ public:
 	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
 	//! Returns the file last modified time of a file handle, returns timespec with zero on all attributes on error
 	FileType GetFileType(FileHandle &handle) override;
+	//! Returns the file stats of the attached handle.
+	FileMetadata Stats(FileHandle& handle) override;
 	//! Truncate a file to a maximum size of new_size, new_size should be smaller than or equal to the current size of
 	//! the file
 	void Truncate(FileHandle &handle, int64_t new_size) override;

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -41,7 +41,7 @@ public:
 	//! Returns the file last modified time of a file handle, returns timespec with zero on all attributes on error
 	FileType GetFileType(FileHandle &handle) override;
 	//! Returns the file stats of the attached handle.
-	FileMetadata Stats(FileHandle& handle) override;
+	FileMetadata Stats(FileHandle &handle) override;
 	//! Truncate a file to a maximum size of new_size, new_size should be smaller than or equal to the current size of
 	//! the file
 	void Truncate(FileHandle &handle, int64_t new_size) override;

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -50,7 +50,7 @@ public:
 	FileType GetFileType(FileHandle &handle) override {
 		return GetFileSystem().GetFileType(handle);
 	}
-	FileMetadata Stats(FileHandle& handle) override {
+	FileMetadata Stats(FileHandle &handle) override {
 		return GetFileSystem().Stats(handle);
 	}
 

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -50,6 +50,9 @@ public:
 	FileType GetFileType(FileHandle &handle) override {
 		return GetFileSystem().GetFileType(handle);
 	}
+	FileMetadata Stats(FileHandle& handle) override {
+		return GetFileSystem().Stats(handle);
+	}
 
 	void Truncate(FileHandle &handle, int64_t new_size) override {
 		GetFileSystem().Truncate(handle, new_size);

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -30,6 +30,7 @@ public:
 	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
 	string GetVersionTag(FileHandle &handle) override;
 	FileType GetFileType(FileHandle &handle) override;
+	FileMetadata Stats(FileHandle& handle) override;
 
 	void Truncate(FileHandle &handle, int64_t new_size) override;
 

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -30,7 +30,7 @@ public:
 	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
 	string GetVersionTag(FileHandle &handle) override;
 	FileType GetFileType(FileHandle &handle) override;
-	FileMetadata Stats(FileHandle& handle) override;
+	FileMetadata Stats(FileHandle &handle) override;
 
 	void Truncate(FileHandle &handle, int64_t new_size) override;
 

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -171,6 +171,12 @@ TEST_CASE("Test file operations", "[file_system]") {
 	}
 	// now open the file for reading
 	REQUIRE_NOTHROW(handle = fs->OpenFile(fname, FileFlags::FILE_FLAGS_READ));
+	// Check file stats.
+	const auto file_metadata = fs->Stats(*handle);
+	REQUIRE(file_metadata.file_size == 512);
+	REQUIRE(file_metadata.file_type == FileType::FILE_TYPE_REGULAR);
+	REQUIRE(file_metadata.last_modification_time > timestamp_t{-1});
+
 	// read the 10 integers back
 	REQUIRE_NOTHROW(handle->Read(QueryContext(), (void *)test_data, sizeof(int64_t) * INTEGER_COUNT, 0));
 	// check the values of the integers

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -173,7 +173,7 @@ TEST_CASE("Test file operations", "[file_system]") {
 	REQUIRE_NOTHROW(handle = fs->OpenFile(fname, FileFlags::FILE_FLAGS_READ));
 	// Check file stats.
 	const auto file_metadata = fs->Stats(*handle);
-	REQUIRE(file_metadata.file_size == 512);
+	REQUIRE(file_metadata.file_size == 4096);
 	REQUIRE(file_metadata.file_type == FileType::FILE_TYPE_REGULAR);
 	REQUIRE(file_metadata.last_modification_time > timestamp_t {-1});
 

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -175,7 +175,7 @@ TEST_CASE("Test file operations", "[file_system]") {
 	const auto file_metadata = fs->Stats(*handle);
 	REQUIRE(file_metadata.file_size == 512);
 	REQUIRE(file_metadata.file_type == FileType::FILE_TYPE_REGULAR);
-	REQUIRE(file_metadata.last_modification_time > timestamp_t{-1});
+	REQUIRE(file_metadata.last_modification_time > timestamp_t {-1});
 
 	// read the 10 integers back
 	REQUIRE_NOTHROW(handle->Read(QueryContext(), (void *)test_data, sizeof(int64_t) * INTEGER_COUNT, 0));


### PR DESCRIPTION
This PR adds a `Stats` API to filesystem interfaces, there're a few motivations in short:
- Simplify the code. Currently a few other stats access APIs leverage syscalls like `fstat`, having a unified stats function reduces code duplication.
- Easier for metadata caching. With `Stats` API, metadata cache could hold the whole function result, instead of separate function returns like getting modification timestamp, getting file size, etc.
- Most (if not all) existing filesystem instances support `Stats` semantics already
  + For local filesystem it's syscalls
  + Here's the implementation for httpfs: https://github.com/duckdb/duckdb-httpfs/blob/50dc3b2c9022df436ff036074d7872c3f62b8d98/src/httpfs.cpp#L701-L757

For more details, please refer to https://github.com/duckdb/duckdb/discussions/18489

TODO items:
I will followup with httpfs, azure filesystem, and a few other extensions with metadata cache support to leverage the API.