### PR TITLE
BoxRenderer: Fix rendering of empty results

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -1350,8 +1350,6 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 	if (config.render_mode == RenderMode::ROWS) {
 		render_rows.push_back(std::move(type_row));
 	}
-	// add a separator if there are any rows
-	render_rows.emplace_back(RenderRowType::SEPARATOR);
 	// prepare the values
 	bool first_render = true;
 	bool invert = false;
@@ -1359,7 +1357,10 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 		if (collection.Count() == 0) {
 			continue;
 		}
-		if (!first_render) {
+		if (first_render) {
+			// add a separator if there are any rows
+			render_rows.emplace_back(RenderRowType::SEPARATOR);
+		} else {
 			// render divider between top and bottom collection
 			render_rows.emplace_back(RenderRowType::DIVIDER);
 		}
@@ -1894,10 +1895,8 @@ void BoxRendererImplementation::RenderFooter(idx_t row_count, idx_t column_count
 		render_anything = false;
 	}
 	// render the bottom of the result values, if there are any
-	if (row_count > 0) {
-		RenderLayoutLine(config.HORIZONTAL, config.DMIDDLE, render_anything ? config.LMIDDLE : config.LDCORNER,
-		                 render_anything ? config.RMIDDLE : config.RDCORNER);
-	}
+	RenderLayoutLine(config.HORIZONTAL, config.DMIDDLE, render_anything ? config.LMIDDLE : config.LDCORNER,
+	                 render_anything ? config.RMIDDLE : config.RDCORNER);
 	if (!render_anything) {
 		return;
 	}

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -166,7 +166,6 @@ std::string Utf8Proc::RemoveInvalid(const char *s, size_t len) {
 	std::string result;
 	result.reserve(len); // Reserve the maximum possible size
 
-	UnicodeType type = UnicodeType::ASCII;
 	for (size_t i = 0; i < len; i++) {
 		int c = (int)s[i];
 		if ((c & 0x80) == 0) {
@@ -179,15 +178,15 @@ std::string Utf8Proc::RemoveInvalid(const char *s, size_t len) {
 		if ((c & 0xE0) == 0xC0) {
 			/* 2 byte sequence */
 			int utf8char = c & 0x1F;
-			type = UTF8ExtraByteLoop<1, 0x000780>(first_pos_seq, utf8char, i, s, len, nullptr, nullptr);
+			UTF8ExtraByteLoop<1, 0x000780>(first_pos_seq, utf8char, i, s, len, nullptr, nullptr);
 		} else if ((c & 0xF0) == 0xE0) {
 			/* 3 byte sequence */
 			int utf8char = c & 0x0F;
-			type = UTF8ExtraByteLoop<2, 0x00F800>(first_pos_seq, utf8char, i, s, len, nullptr, nullptr);
+			UTF8ExtraByteLoop<2, 0x00F800>(first_pos_seq, utf8char, i, s, len, nullptr, nullptr);
 		} else if ((c & 0xF8) == 0xF0) {
 			/* 4 byte sequence */
 			int utf8char = c & 0x07;
-			type = UTF8ExtraByteLoop<3, 0x1F0000>(first_pos_seq, utf8char, i, s, len, nullptr, nullptr);
+			UTF8ExtraByteLoop<3, 0x1F0000>(first_pos_seq, utf8char, i, s, len, nullptr, nullptr);
 		} else {
 			// invalid, do not write to output
 			continue;


### PR DESCRIPTION
Avoid adding an unnecessary extra separator when rendering empty results