### PR TITLE
Add alias reference support (`alias.<name>`)

### DIFF
--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -78,6 +78,10 @@ public:
 		return false;
 	}
 
+	virtual bool DoesColumnAliasExist(const ColumnRefExpression &colref) {
+		return false;
+	}
+
 	// Returns true if the ColumnRef could be an alias reference (unqualified or qualified with table name "alias")
 	static bool IsPotentialAlias(const ColumnRefExpression &colref);
 

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -74,6 +74,16 @@ public:
 	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false);
 	virtual ~ExpressionBinder();
 
+	// Returns true if alias_ref('name') references are allowed in this binder context
+	virtual bool SupportsAliasReference() const {
+		return false;
+	}
+	// Try to resolve alias_ref('name') in contexts that support it; default returns nullptr to defer
+	virtual unique_ptr<Expression> TryResolveAliasReference(const string &alias_name,
+	                                                        const FunctionExpression &function) {
+		return nullptr;
+	}
+
 	//! The target type that should result from the binder. If the result is not of this type, a cast to this type will
 	//! be added. Defaults to INVALID.
 	LogicalType target_type;

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -75,9 +75,13 @@ public:
 	virtual ~ExpressionBinder();
 
 	// legacy unqualified alias binding
-	virtual bool TryBindRegularAlias(ColumnRefExpression &colref, BindResult &result) { return false; }
+	virtual bool TryBindRegularAlias(ColumnRefExpression &colref, BindResult &result) {
+		return false;
+	}
 	// explicit qualified alias reference resolution (alias.<name>) with deep-binding
-	virtual bool TryResolveAliasReference(ColumnRefExpression &colref, BindResult &result) { return false; }
+	virtual bool TryResolveAliasReference(ColumnRefExpression &colref, BindResult &result) {
+		return false;
+	}
 
 	// Returns true if the ColumnRef could be an alias reference (unqualified or qualified with table name "alias")
 	static bool IsPotentialAlias(const ColumnRefExpression &colref);

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -74,7 +74,7 @@ public:
 	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false);
 	virtual ~ExpressionBinder();
 
-	// legacy unqualified alias binding (e.g., SELECT x AS y; then later y)
+	// legacy unqualified alias binding
 	virtual bool TryBindRegularAlias(ColumnRefExpression &colref, BindResult &result) { return false; }
 	// explicit qualified alias reference resolution (alias.<name>) with deep-binding
 	virtual bool TryResolveAliasReference(ColumnRefExpression &colref, BindResult &result) { return false; }

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -74,11 +74,6 @@ public:
 	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false);
 	virtual ~ExpressionBinder();
 
-	// legacy unqualified alias binding
-	virtual bool TryBindRegularAlias(ColumnRefExpression &colref, idx_t depth, BindResult &result) {
-		return false;
-	}
-	// explicit qualified alias reference resolution (alias.<name>) with deep-binding
 	virtual bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) {
 		return false;
 	}

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -75,7 +75,7 @@ public:
 	virtual ~ExpressionBinder();
 
 	virtual bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression,
-	                                      BindResult &result) {
+	                                      BindResult &result, unique_ptr<ParsedExpression> &expr_ptr) {
 		return false;
 	}
 
@@ -174,7 +174,8 @@ protected:
 	BindResult BindExpression(CaseExpression &expr, idx_t depth);
 	BindResult BindExpression(CollateExpression &expr, idx_t depth);
 	BindResult BindExpression(CastExpression &expr, idx_t depth);
-	BindResult BindExpression(ColumnRefExpression &expr, idx_t depth, bool root_expression);
+	BindResult BindExpression(ColumnRefExpression &expr, idx_t depth, bool root_expression,
+	                          unique_ptr<ParsedExpression> &expr_ptr);
 	BindResult BindExpression(LambdaRefExpression &expr, idx_t depth);
 	BindResult BindExpression(ComparisonExpression &expr, idx_t depth);
 	BindResult BindExpression(ConjunctionExpression &expr, idx_t depth);

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -145,8 +145,6 @@ public:
 	static bool ContainsType(const LogicalType &type, LogicalTypeId target);
 	static LogicalType ExchangeType(const LogicalType &type, LogicalTypeId target, LogicalType new_type);
 
-	virtual bool QualifyColumnAlias(const ColumnRefExpression &colref);
-
 	//! Bind the given expression. Unlike Bind(), this does *not* mute the given ParsedExpression.
 	//! Exposed to be used from sub-binders that aren't subclasses of ExpressionBinder.
 	virtual BindResult BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,
@@ -207,7 +205,7 @@ protected:
 
 	BindResult BindUnsupportedExpression(ParsedExpression &expr, idx_t depth, const string &message);
 
-	optional_ptr<CatalogEntry> BindAndQualifyFunction(FunctionExpression &function, bool allow_throw);
+	optional_ptr<CatalogEntry> BindAndQualifyFunction(FunctionExpression &function, idx_t depth, bool allow_throw);
 
 protected:
 	virtual BindResult BindGroupingFunction(OperatorExpression &op, idx_t depth);

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -74,7 +74,8 @@ public:
 	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false);
 	virtual ~ExpressionBinder();
 
-	virtual bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result) {
+	virtual bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression,
+	                                      BindResult &result) {
 		return false;
 	}
 

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -74,13 +74,13 @@ public:
 	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false);
 	virtual ~ExpressionBinder();
 
-	// Returns true if alias_ref('name') references are allowed in this binder context
+	// Returns true if alias.name references are allowed in this binder context
 	virtual bool SupportsAliasReference() const {
 		return false;
 	}
-	// Try to resolve alias_ref('name') in contexts that support it; default returns nullptr to defer
+	// Try to resolve alias.name in contexts that support it; default returns nullptr to defer
 	virtual unique_ptr<Expression> TryResolveAliasReference(const string &alias_name,
-	                                                        const FunctionExpression &function) {
+	                                                        const ColumnRefExpression &col_ref_p) {
 		return nullptr;
 	}
 

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -74,7 +74,7 @@ public:
 	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false);
 	virtual ~ExpressionBinder();
 
-	virtual bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) {
+	virtual bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result) {
 		return false;
 	}
 

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -205,7 +205,7 @@ protected:
 
 	BindResult BindUnsupportedExpression(ParsedExpression &expr, idx_t depth, const string &message);
 
-	optional_ptr<CatalogEntry> BindAndQualifyFunction(FunctionExpression &function, idx_t depth, bool allow_throw);
+	optional_ptr<CatalogEntry> BindAndQualifyFunction(FunctionExpression &function, bool allow_throw);
 
 protected:
 	virtual BindResult BindGroupingFunction(OperatorExpression &op, idx_t depth);

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -75,11 +75,11 @@ public:
 	virtual ~ExpressionBinder();
 
 	// legacy unqualified alias binding
-	virtual bool TryBindRegularAlias(ColumnRefExpression &colref, BindResult &result) {
+	virtual bool TryBindRegularAlias(ColumnRefExpression &colref, idx_t depth, BindResult &result) {
 		return false;
 	}
 	// explicit qualified alias reference resolution (alias.<name>) with deep-binding
-	virtual bool TryResolveAliasReference(ColumnRefExpression &colref, BindResult &result) {
+	virtual bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) {
 		return false;
 	}
 

--- a/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
@@ -24,7 +24,7 @@ public:
 	bool BindAlias(ExpressionBinder &enclosing_binder, unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,
 	               bool root_expression, BindResult &result);
 	// Check if the column reference is an SELECT item alias.
-	bool QualifyColumnAlias(const ColumnRefExpression &colref);
+	bool DoesColumnAliasExist(const ColumnRefExpression &colref);
 
 private:
 	SelectBindState &bind_state;

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -36,8 +36,8 @@ protected:
 	BindResult BindColumnRef(ColumnRefExpression &expr, unique_ptr<ParsedExpression> &expr_ptr);
 	BindResult BindConstant(ConstantExpression &expr);
 
-	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression,
-	                              BindResult &result, unique_ptr<ParsedExpression> &expr_ptr) override;
+	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result,
+	                              unique_ptr<ParsedExpression> &expr_ptr) override;
 
 	SelectNode &node;
 	SelectBindState &bind_state;

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -35,12 +35,18 @@ protected:
 	BindResult BindSelectRef(idx_t entry);
 	BindResult BindColumnRef(ColumnRefExpression &expr);
 	BindResult BindConstant(ConstantExpression &expr);
-	bool TryBindAlias(ColumnRefExpression &colref, bool root_expression, BindResult &result) override;
+
+	// Two-step alias binding overrides for GROUP BY
+	bool TryBindRegularAlias(ColumnRefExpression &colref, BindResult &result) override;
+	bool TryResolveAliasReference(ColumnRefExpression &colref, BindResult &result) override;
 
 	SelectNode &node;
 	SelectBindState &bind_state;
 	case_insensitive_map_t<idx_t> &group_alias_map;
 	unordered_set<idx_t> used_aliases;
+
+	// tracks whether we are binding the root GROUP BY expression to enforce alias usage rules
+	bool in_root_group_ref = false;
 
 	idx_t group_index;
 };

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -36,7 +36,8 @@ protected:
 	BindResult BindColumnRef(ColumnRefExpression &expr);
 	BindResult BindConstant(ConstantExpression &expr);
 
-	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result) override;
+	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression,
+	                              BindResult &result) override;
 
 	SelectNode &node;
 	SelectBindState &bind_state;

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -35,9 +35,7 @@ protected:
 	BindResult BindSelectRef(idx_t entry);
 	BindResult BindColumnRef(ColumnRefExpression &expr);
 	BindResult BindConstant(ConstantExpression &expr);
-
-	// Two-step alias binding overrides for GROUP BY
-	bool TryBindRegularAlias(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
+	
 	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
 
 	SelectNode &node;

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -33,11 +33,11 @@ protected:
 	string UnsupportedAggregateMessage() override;
 
 	BindResult BindSelectRef(idx_t entry);
-	BindResult BindColumnRef(ColumnRefExpression &expr);
+	BindResult BindColumnRef(ColumnRefExpression &expr, unique_ptr<ParsedExpression> &expr_ptr);
 	BindResult BindConstant(ConstantExpression &expr);
 
 	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression,
-	                              BindResult &result) override;
+	                              BindResult &result, unique_ptr<ParsedExpression> &expr_ptr) override;
 
 	SelectNode &node;
 	SelectBindState &bind_state;

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -35,8 +35,9 @@ protected:
 	BindResult BindSelectRef(idx_t entry);
 	BindResult BindColumnRef(ColumnRefExpression &expr);
 	BindResult BindConstant(ConstantExpression &expr);
-	
+
 	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
+	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
 
 	SelectNode &node;
 	SelectBindState &bind_state;

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -37,7 +37,6 @@ protected:
 	BindResult BindConstant(ConstantExpression &expr);
 
 	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
-	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
 
 	SelectNode &node;
 	SelectBindState &bind_state;

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -36,7 +36,7 @@ protected:
 	BindResult BindColumnRef(ColumnRefExpression &expr);
 	BindResult BindConstant(ConstantExpression &expr);
 
-	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
+	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result) override;
 
 	SelectNode &node;
 	SelectBindState &bind_state;

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -43,9 +43,6 @@ protected:
 	case_insensitive_map_t<idx_t> &group_alias_map;
 	unordered_set<idx_t> used_aliases;
 
-	// tracks whether we are binding the root GROUP BY expression to enforce alias usage rules
-	bool in_root_group_ref = false;
-
 	idx_t group_index;
 };
 

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -37,8 +37,8 @@ protected:
 	BindResult BindConstant(ConstantExpression &expr);
 
 	// Two-step alias binding overrides for GROUP BY
-	bool TryBindRegularAlias(ColumnRefExpression &colref, BindResult &result) override;
-	bool TryResolveAliasReference(ColumnRefExpression &colref, BindResult &result) override;
+	bool TryBindRegularAlias(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
+	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
 
 	SelectNode &node;
 	SelectBindState &bind_state;

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -17,8 +17,8 @@ class SelectBinder : public BaseSelectBinder {
 public:
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
-	bool TryBindRegularAlias(ColumnRefExpression &colref, BindResult &result) override;
-	bool TryResolveAliasReference(ColumnRefExpression &colref, BindResult &result) override;
+	bool TryBindRegularAlias(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
+	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
 
 protected:
 	void ThrowIfUnnestInLambda(const ColumnBinding &column_binding) override;

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -17,6 +17,11 @@ class SelectBinder : public BaseSelectBinder {
 public:
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
+	bool SupportsAliasReference() const override {
+		return true;
+	}
+	unique_ptr<Expression> TryResolveAliasReference(const string &alias_name, const FunctionExpression &function) override;
+
 protected:
 	void ThrowIfUnnestInLambda(const ColumnBinding &column_binding) override;
 	BindResult BindUnnest(FunctionExpression &function, idx_t depth, bool root_expression) override;

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -17,7 +17,6 @@ class SelectBinder : public BaseSelectBinder {
 public:
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
-	bool TryBindRegularAlias(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
 	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
 
 protected:

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -23,7 +23,6 @@ public:
 protected:
 	void ThrowIfUnnestInLambda(const ColumnBinding &column_binding) override;
 	BindResult BindUnnest(FunctionExpression &function, idx_t depth, bool root_expression) override;
-	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
 
 	bool QualifyColumnAlias(const ColumnRefExpression &colref) override;
 	unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name) override;

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -17,8 +17,8 @@ class SelectBinder : public BaseSelectBinder {
 public:
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
-	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression,
-	                              BindResult &result, unique_ptr<ParsedExpression> &expr_ptr) override;
+	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result,
+	                              unique_ptr<ParsedExpression> &expr_ptr) override;
 	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
 
 protected:

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -17,7 +17,8 @@ class SelectBinder : public BaseSelectBinder {
 public:
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
-	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result) override;
+	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression,
+	                              BindResult &result) override;
 	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
 
 protected:

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -24,7 +24,6 @@ protected:
 	void ThrowIfUnnestInLambda(const ColumnBinding &column_binding) override;
 	BindResult BindUnnest(FunctionExpression &function, idx_t depth, bool root_expression) override;
 
-	bool QualifyColumnAlias(const ColumnRefExpression &colref) override;
 	unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name) override;
 
 protected:

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -17,11 +17,8 @@ class SelectBinder : public BaseSelectBinder {
 public:
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
-	bool SupportsAliasReference() const override {
-		return true;
-	}
-	unique_ptr<Expression> TryResolveAliasReference(const string &alias_name,
-	                                                const ColumnRefExpression &column_ref_p) override;
+	bool TryBindRegularAlias(ColumnRefExpression &colref, BindResult &result) override;
+	bool TryResolveAliasReference(ColumnRefExpression &colref, BindResult &result) override;
 
 protected:
 	void ThrowIfUnnestInLambda(const ColumnBinding &column_binding) override;

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -20,7 +20,8 @@ public:
 	bool SupportsAliasReference() const override {
 		return true;
 	}
-	unique_ptr<Expression> TryResolveAliasReference(const string &alias_name, const FunctionExpression &function) override;
+	unique_ptr<Expression> TryResolveAliasReference(const string &alias_name,
+	                                                const FunctionExpression &function) override;
 
 protected:
 	void ThrowIfUnnestInLambda(const ColumnBinding &column_binding) override;

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -17,7 +17,7 @@ class SelectBinder : public BaseSelectBinder {
 public:
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
-	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
+	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result) override;
 	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
 
 protected:

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -21,7 +21,7 @@ public:
 		return true;
 	}
 	unique_ptr<Expression> TryResolveAliasReference(const string &alias_name,
-	                                                const FunctionExpression &function) override;
+	                                                const ColumnRefExpression &column_ref_p) override;
 
 protected:
 	void ThrowIfUnnestInLambda(const ColumnBinding &column_binding) override;

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -18,7 +18,7 @@ public:
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
 	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression,
-	                              BindResult &result) override;
+	                              BindResult &result, unique_ptr<ParsedExpression> &expr_ptr) override;
 	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
 
 protected:

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -18,6 +18,7 @@ public:
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
 	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) override;
+	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
 
 protected:
 	void ThrowIfUnnestInLambda(const ColumnBinding &column_binding) override;

--- a/src/include/duckdb/planner/expression_binder/where_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/where_binder.hpp
@@ -25,7 +25,8 @@ protected:
 
 	string UnsupportedAggregateMessage() override;
 
-	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result, unique_ptr<ParsedExpression> &expr_ptr) override;
+	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result,
+	                              unique_ptr<ParsedExpression> &expr_ptr) override;
 
 	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
 

--- a/src/include/duckdb/planner/expression_binder/where_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/where_binder.hpp
@@ -25,6 +25,8 @@ protected:
 
 	string UnsupportedAggregateMessage() override;
 
+	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
+
 private:
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression);
 

--- a/src/include/duckdb/planner/expression_binder/where_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/where_binder.hpp
@@ -24,7 +24,6 @@ protected:
 	                          bool root_expression = false) override;
 
 	string UnsupportedAggregateMessage() override;
-	bool QualifyColumnAlias(const ColumnRefExpression &colref) override;
 
 private:
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression);

--- a/src/include/duckdb/planner/expression_binder/where_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/where_binder.hpp
@@ -25,6 +25,8 @@ protected:
 
 	string UnsupportedAggregateMessage() override;
 
+	bool TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result, unique_ptr<ParsedExpression> &expr_ptr) override;
+
 	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
 
 private:

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -155,7 +155,7 @@ void ExpressionBinder::QualifyColumnNames(unique_ptr<ParsedExpression> &expr,
 		// Special-handling for lambdas, which are inside function expressions.
 		auto &function = expr->Cast<FunctionExpression>();
 		if (!IsUnnestFunction(function.function_name)) {
-			BindAndQualifyFunction(function, depth, false);
+			BindAndQualifyFunction(function, false);
 		}
 		if (function.IsLambdaFunction()) {
 			return QualifyColumnNamesInLambda(function, lambda_params);

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -516,20 +516,24 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 		// column wasn't found, try the unified two-step alias binding
 		if (ExpressionBinder::IsPotentialAlias(col_ref_p)) {
 			BindResult alias_result;
-			auto found_alias = TryBindRegularAlias(col_ref_p, alias_result);
+			auto found_alias = TryBindRegularAlias(col_ref_p, depth, alias_result);
 			if (found_alias) {
 				return alias_result;
 			}
-			found_alias = QualifyColumnAlias(col_ref_p);
-			if (!found_alias && !col_ref_p.IsQualified()) {
-				auto value_function = GetSQLValueFunction(col_ref_p.GetColumnName());
-				if (value_function) {
-					return BindExpression(value_function, depth);
+			if (col_ref_p.IsQualified()) {
+				// Meaning it's `alias.<name>`
+				found_alias = TryResolveAliasReference(col_ref_p, depth, alias_result);
+				if (found_alias) {
+					return alias_result;
 				}
-			}
-			found_alias = TryResolveAliasReference(col_ref_p, alias_result);
-			if (found_alias) {
-				return alias_result;
+			} else {
+				found_alias = QualifyColumnAlias(col_ref_p);
+				if (!found_alias) {
+					auto value_function = GetSQLValueFunction(col_ref_p.GetColumnName());
+					if (value_function) {
+						return BindExpression(value_function, depth);
+					}
+				}
 			}
 		}
 		error.AddQueryLocation(col_ref_p);

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -513,7 +513,7 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 	ErrorData error;
 	auto expr = QualifyColumnName(col_ref_p, error);
 	if (!expr) {
-		// column wasn't found, try the unified two-step alias binding
+		// column wasn't found
 		if (ExpressionBinder::IsPotentialAlias(col_ref_p)) {
 			BindResult alias_result;
 			auto found_alias = TryResolveAliasReference(col_ref_p, depth, root_expression, alias_result);

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -527,7 +527,7 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 					return BindExpression(value_function, depth);
 				}
 			}
-			found_alias = TryBindRegularAlias(col_ref_p, alias_result);
+			found_alias = TryResolveAliasReference(col_ref_p, alias_result);
 			if (found_alias) {
 				return alias_result;
 			}

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -516,21 +516,14 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 		// column wasn't found, try the unified two-step alias binding
 		if (ExpressionBinder::IsPotentialAlias(col_ref_p)) {
 			BindResult alias_result;
-			auto found_alias = TryBindRegularAlias(col_ref_p, depth, alias_result);
+			auto found_alias = TryResolveAliasReference(col_ref_p, depth, alias_result);
 			if (found_alias) {
 				return alias_result;
 			}
-			if (col_ref_p.IsQualified()) {
-				// Meaning it's `alias.<name>`
-				found_alias = TryResolveAliasReference(col_ref_p, depth, alias_result);
-				if (found_alias) {
-					return alias_result;
-				}
-			} else {
-				auto value_function = GetSQLValueFunction(col_ref_p.GetColumnName());
-				if (value_function) {
-					return BindExpression(value_function, depth);
-				}
+
+			auto value_function = GetSQLValueFunction(col_ref_p.GetColumnName());
+			if (value_function) {
+				return BindExpression(value_function, depth);
 			}
 		}
 		error.AddQueryLocation(col_ref_p);

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -510,27 +510,26 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 		return BindResult(make_uniq<BoundConstantExpression>(Value(LogicalType::SQLNULL)));
 	}
 
-	if (col_ref_p.IsQualified() && StringUtil::CIEquals(col_ref_p.GetTableName(), "alias")) {
-		if (!SupportsAliasReference()) {
-			throw BinderException(col_ref_p, "alias.* references are only valid in a SELECT projection list");
-		}
-		const auto &alias_name = col_ref_p.GetColumnName();
-
-		auto resolved = TryResolveAliasReference(alias_name, col_ref_p);
-		if (!resolved) {
-			throw BinderException(col_ref_p,
-				"alias.%s refers to an unknown or not-yet-defined alias in SELECT list", alias_name);
-		}
-		resolved->SetQueryLocation(col_ref_p.GetQueryLocation());
-		return BindResult(std::move(resolved));
-	}
-
 	ErrorData error;
 	auto expr = QualifyColumnName(col_ref_p, error);
 	if (!expr) {
-		if (!col_ref_p.IsQualified()) {
-			// column was not found
-			// first try to bind it as an alias
+		// column wasn't found, we're trying to bind it as an alias
+		if (col_ref_p.IsQualified()) {
+			if (StringUtil::CIEquals(col_ref_p.GetTableName(), "alias")) {
+				if (!SupportsAliasReference()) {
+					throw BinderException(col_ref_p, "alias.* references are only valid in a SELECT projection list");
+				}
+				const auto &alias_name = col_ref_p.GetColumnName();
+
+				auto resolved = TryResolveAliasReference(alias_name, col_ref_p);
+				if (!resolved) {
+					throw BinderException(
+					    col_ref_p, "alias.%s refers to an unknown or not-yet-defined alias in SELECT list", alias_name);
+				}
+				resolved->SetQueryLocation(col_ref_p.GetQueryLocation());
+				return BindResult(std::move(resolved));
+			}
+		} else {
 			BindResult alias_result;
 			auto found_alias = TryBindAlias(col_ref_p, root_expression, alias_result);
 			if (found_alias) {

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -504,7 +504,8 @@ BindResult ExpressionBinder::BindExpression(LambdaRefExpression &lambda_ref, idx
 	return (*lambda_bindings)[lambda_ref.lambda_idx].Bind(lambda_ref, depth);
 }
 
-BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_t depth, bool root_expression, unique_ptr<ParsedExpression> &expr_ptr) {
+BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_t depth, bool root_expression,
+                                            unique_ptr<ParsedExpression> &expr_ptr) {
 	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES ||
 	    binder.GetBindingMode() == BindingMode::EXTRACT_QUALIFIED_NAMES) {
 		return BindResult(make_uniq<BoundConstantExpression>(Value(LogicalType::SQLNULL)));

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -155,7 +155,7 @@ void ExpressionBinder::QualifyColumnNames(unique_ptr<ParsedExpression> &expr,
 		// Special-handling for lambdas, which are inside function expressions.
 		auto &function = expr->Cast<FunctionExpression>();
 		if (!IsUnnestFunction(function.function_name)) {
-			BindAndQualifyFunction(function, false);
+			BindAndQualifyFunction(function, depth, false);
 		}
 		if (function.IsLambdaFunction()) {
 			return QualifyColumnNamesInLambda(function, lambda_params);
@@ -527,12 +527,9 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 					return alias_result;
 				}
 			} else {
-				found_alias = QualifyColumnAlias(col_ref_p);
-				if (!found_alias) {
-					auto value_function = GetSQLValueFunction(col_ref_p.GetColumnName());
-					if (value_function) {
-						return BindExpression(value_function, depth);
-					}
+				auto value_function = GetSQLValueFunction(col_ref_p.GetColumnName());
+				if (value_function) {
+					return BindExpression(value_function, depth);
 				}
 			}
 		}
@@ -581,9 +578,4 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 	return result;
 }
 
-bool ExpressionBinder::QualifyColumnAlias(const ColumnRefExpression &col_ref) {
-	// only the BaseSelectBinder will have a valid column alias map,
-	// otherwise we return false
-	return false;
-}
 } // namespace duckdb

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -516,7 +516,7 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 		// column wasn't found, try the unified two-step alias binding
 		if (ExpressionBinder::IsPotentialAlias(col_ref_p)) {
 			BindResult alias_result;
-			auto found_alias = TryResolveAliasReference(col_ref_p, depth, alias_result);
+			auto found_alias = TryResolveAliasReference(col_ref_p, depth, root_expression, alias_result);
 			if (found_alias) {
 				return alias_result;
 			}

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -504,7 +504,7 @@ BindResult ExpressionBinder::BindExpression(LambdaRefExpression &lambda_ref, idx
 	return (*lambda_bindings)[lambda_ref.lambda_idx].Bind(lambda_ref, depth);
 }
 
-BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_t depth, bool root_expression) {
+BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_t depth, bool root_expression, unique_ptr<ParsedExpression> &expr_ptr) {
 	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES ||
 	    binder.GetBindingMode() == BindingMode::EXTRACT_QUALIFIED_NAMES) {
 		return BindResult(make_uniq<BoundConstantExpression>(Value(LogicalType::SQLNULL)));
@@ -516,7 +516,7 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 		// column wasn't found
 		if (ExpressionBinder::IsPotentialAlias(col_ref_p)) {
 			BindResult alias_result;
-			auto found_alias = TryResolveAliasReference(col_ref_p, depth, root_expression, alias_result);
+			auto found_alias = TryResolveAliasReference(col_ref_p, depth, root_expression, alias_result, expr_ptr);
 			if (found_alias) {
 				return alias_result;
 			}

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -516,10 +516,19 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 		// column wasn't found, try the unified two-step alias binding
 		if (ExpressionBinder::IsPotentialAlias(col_ref_p)) {
 			BindResult alias_result;
-			if (TryBindRegularAlias(col_ref_p, alias_result)) {
+			auto found_alias = TryBindRegularAlias(col_ref_p, alias_result);
+			if (found_alias) {
 				return alias_result;
 			}
-			if (TryResolveAliasReference(col_ref_p, alias_result)) {
+			found_alias = QualifyColumnAlias(col_ref_p);
+			if (!found_alias && !col_ref_p.IsQualified()) {
+				auto value_function = GetSQLValueFunction(col_ref_p.GetColumnName());
+				if (value_function) {
+					return BindExpression(value_function, depth);
+				}
+			}
+			found_alias = TryBindRegularAlias(col_ref_p, alias_result);
+			if (found_alias) {
 				return alias_result;
 			}
 		}

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -135,9 +135,7 @@ optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpr
 
 BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t depth,
                                             unique_ptr<ParsedExpression> &expr_ptr) {
-	// Handle alias_ref specially without requiring a catalog entry
 	if (StringUtil::CIEquals(function.function_name, "alias_ref")) {
-		// Only intercept alias_ref() when called with a single string literal argument
 		if (function.children.size() == 1 && function.children[0]->GetExpressionClass() == ExpressionClass::CONSTANT) {
 			auto &const_expr = function.children[0]->Cast<ConstantExpression>();
 			if (const_expr.value.IsNull() || const_expr.value.type().id() != LogicalTypeId::VARCHAR) {
@@ -158,6 +156,7 @@ BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t 
 			    BinderException(function, "alias_ref(name): must be called with a single string literal argument"));
 		}
 	}
+
 	auto func = BindAndQualifyFunction(function, true);
 
 	if (func->type != CatalogType::AGGREGATE_FUNCTION_ENTRY &&

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -68,7 +68,7 @@ BindResult ExpressionBinder::TryBindLambdaOrJson(FunctionExpression &function, i
 	                  json_bind_result.error.RawMessage());
 }
 
-optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpression &function, idx_t depth, bool allow_throw) {
+optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpression &function, bool allow_throw) {
 	D_ASSERT(!IsUnnestFunction(function.function_name));
 	// lookup the function in the catalog
 	QueryErrorContext error_context(function.GetQueryLocation());
@@ -108,7 +108,8 @@ optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpr
 				if (error.HasError()) {
 					// could not find the column - try to qualify the alias
 					BindResult result;
-					if (!TryBindRegularAlias(*colref, depth, result)) {
+					// The depth here isn't relevant, we're just checking for the existence of the alias
+					if (!TryBindRegularAlias(*colref, 0, result)) {
 						if (!allow_throw) {
 							return func;
 						}
@@ -136,7 +137,7 @@ optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpr
 
 BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t depth,
                                             unique_ptr<ParsedExpression> &expr_ptr) {
-	auto func = BindAndQualifyFunction(function, depth, true);
+	auto func = BindAndQualifyFunction(function, true);
 
 	if (func->type != CatalogType::AGGREGATE_FUNCTION_ENTRY &&
 	    (function.distinct || function.filter || !function.order_bys->orders.empty())) {

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -135,28 +135,6 @@ optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpr
 
 BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t depth,
                                             unique_ptr<ParsedExpression> &expr_ptr) {
-	if (StringUtil::CIEquals(function.function_name, "alias_ref")) {
-		if (function.children.size() == 1 && function.children[0]->GetExpressionClass() == ExpressionClass::CONSTANT) {
-			auto &const_expr = function.children[0]->Cast<ConstantExpression>();
-			if (const_expr.value.IsNull() || const_expr.value.type().id() != LogicalTypeId::VARCHAR) {
-				return BindResult(
-				    BinderException(function, "alias_ref(name): argument must be a non-NULL string literal"));
-			}
-			if (!SupportsAliasReference()) {
-				return BindResult(BinderException(function, "can only be used inside a SELECT projection list"));
-			}
-			auto alias_name = const_expr.value.GetValue<string>();
-			auto resolved = TryResolveAliasReference(alias_name, function);
-			if (resolved) {
-				resolved->SetQueryLocation(function.GetQueryLocation());
-				return BindResult(std::move(resolved));
-			}
-		} else {
-			return BindResult(
-			    BinderException(function, "alias_ref(name): must be called with a single string literal argument"));
-		}
-	}
-
 	auto func = BindAndQualifyFunction(function, true);
 
 	if (func->type != CatalogType::AGGREGATE_FUNCTION_ENTRY &&

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -135,6 +135,27 @@ optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpr
 
 BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t depth,
                                             unique_ptr<ParsedExpression> &expr_ptr) {
+	// Handle alias_ref specially without requiring a catalog entry
+	if (StringUtil::CIEquals(function.function_name, "alias_ref")) {
+		// Only intercept alias_ref() when called with a single string literal argument
+		if (function.children.size() == 1 && function.children[0]->GetExpressionClass() == ExpressionClass::CONSTANT) {
+			auto &const_expr = function.children[0]->Cast<ConstantExpression>();
+			if (const_expr.value.IsNull() || const_expr.value.type().id() != LogicalTypeId::VARCHAR) {
+				return BindResult(BinderException(function, "alias_ref(name): argument must be a non-NULL string literal"));
+			}
+			if (!SupportsAliasReference()) {
+				return BindResult(BinderException(function, "can only be used inside a SELECT projection list"));
+			}
+			auto alias_name = const_expr.value.GetValue<string>();
+			auto resolved = TryResolveAliasReference(alias_name, function);
+			if (resolved) {
+				resolved->SetQueryLocation(function.GetQueryLocation());
+				return BindResult(std::move(resolved));
+			}
+		} else {
+			return BindResult(BinderException(function, "alias_ref(name): must be called with a single string literal argument"));
+		}
+	}
 	auto func = BindAndQualifyFunction(function, true);
 
 	if (func->type != CatalogType::AGGREGATE_FUNCTION_ENTRY &&

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -107,8 +107,6 @@ optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpr
 				auto new_colref = QualifyColumnName(*colref, error);
 				if (error.HasError()) {
 					// could not find the column - try to qualify the alias
-					BindResult result;
-					// The depth here isn't relevant, we're just checking for the existence of the alias
 					if (!DoesColumnAliasExist(*colref)) {
 						if (!allow_throw) {
 							return func;

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -141,7 +141,8 @@ BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t 
 		if (function.children.size() == 1 && function.children[0]->GetExpressionClass() == ExpressionClass::CONSTANT) {
 			auto &const_expr = function.children[0]->Cast<ConstantExpression>();
 			if (const_expr.value.IsNull() || const_expr.value.type().id() != LogicalTypeId::VARCHAR) {
-				return BindResult(BinderException(function, "alias_ref(name): argument must be a non-NULL string literal"));
+				return BindResult(
+				    BinderException(function, "alias_ref(name): argument must be a non-NULL string literal"));
 			}
 			if (!SupportsAliasReference()) {
 				return BindResult(BinderException(function, "can only be used inside a SELECT projection list"));
@@ -153,7 +154,8 @@ BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t 
 				return BindResult(std::move(resolved));
 			}
 		} else {
-			return BindResult(BinderException(function, "alias_ref(name): must be called with a single string literal argument"));
+			return BindResult(
+			    BinderException(function, "alias_ref(name): must be called with a single string literal argument"));
 		}
 	}
 	auto func = BindAndQualifyFunction(function, true);

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -109,7 +109,7 @@ optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpr
 					// could not find the column - try to qualify the alias
 					BindResult result;
 					// The depth here isn't relevant, we're just checking for the existence of the alias
-					if (!TryBindRegularAlias(*colref, 0, result)) {
+					if (!TryResolveAliasReference(*colref, 0, result)) {
 						if (!allow_throw) {
 							return func;
 						}

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -68,7 +68,7 @@ BindResult ExpressionBinder::TryBindLambdaOrJson(FunctionExpression &function, i
 	                  json_bind_result.error.RawMessage());
 }
 
-optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpression &function, bool allow_throw) {
+optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpression &function, idx_t depth, bool allow_throw) {
 	D_ASSERT(!IsUnnestFunction(function.function_name));
 	// lookup the function in the catalog
 	QueryErrorContext error_context(function.GetQueryLocation());
@@ -107,7 +107,8 @@ optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpr
 				auto new_colref = QualifyColumnName(*colref, error);
 				if (error.HasError()) {
 					// could not find the column - try to qualify the alias
-					if (!QualifyColumnAlias(*colref)) {
+					BindResult result;
+					if (!TryBindRegularAlias(*colref, depth, result)) {
 						if (!allow_throw) {
 							return func;
 						}
@@ -135,7 +136,7 @@ optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpr
 
 BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t depth,
                                             unique_ptr<ParsedExpression> &expr_ptr) {
-	auto func = BindAndQualifyFunction(function, true);
+	auto func = BindAndQualifyFunction(function, depth, true);
 
 	if (func->type != CatalogType::AGGREGATE_FUNCTION_ENTRY &&
 	    (function.distinct || function.filter || !function.order_bys->orders.empty())) {

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -109,7 +109,7 @@ optional_ptr<CatalogEntry> ExpressionBinder::BindAndQualifyFunction(FunctionExpr
 					// could not find the column - try to qualify the alias
 					BindResult result;
 					// The depth here isn't relevant, we're just checking for the existence of the alias
-					if (!TryResolveAliasReference(*colref, 0, result)) {
+					if (!DoesColumnAliasExist(*colref)) {
 						if (!allow_throw) {
 							return func;
 						}

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/main/client_config.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 
@@ -398,7 +399,14 @@ bool ExpressionBinder::IsUnnestFunction(const string &function_name) {
 	return function_name == "unnest" || function_name == "unlist";
 }
 
-bool ExpressionBinder::TryBindAlias(ColumnRefExpression &colref, bool root_expression, BindResult &result) {
+bool ExpressionBinder::IsPotentialAlias(const ColumnRefExpression &colref) {
+	// traditional alias (unqualified), or qualified with table name "alias"
+	if (!colref.IsQualified()) {
+		return true;
+	}
+	if (colref.column_names.size() == 2) {
+		return StringUtil::CIEquals(colref.GetTableName(), "alias");
+	}
 	return false;
 }
 

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -71,7 +71,7 @@ BindResult ExpressionBinder::BindExpression(unique_ptr<ParsedExpression> &expr, 
 	case ExpressionClass::COLLATE:
 		return BindExpression(expr_ref.Cast<CollateExpression>(), depth);
 	case ExpressionClass::COLUMN_REF:
-		return BindExpression(expr_ref.Cast<ColumnRefExpression>(), depth, root_expression);
+		return BindExpression(expr_ref.Cast<ColumnRefExpression>(), depth, root_expression, expr);
 	case ExpressionClass::LAMBDA_REF:
 		return BindExpression(expr_ref.Cast<LambdaRefExpression>(), depth);
 	case ExpressionClass::COMPARISON:

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -41,11 +41,8 @@ bool ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, unique_ptr
 	return true;
 }
 
-bool ColumnAliasBinder::QualifyColumnAlias(const ColumnRefExpression &colref) {
-	if (!colref.IsQualified()) {
-		return bind_state.alias_map.find(colref.column_names[0]) != bind_state.alias_map.end();
-	}
-	return false;
+bool ColumnAliasBinder::DoesColumnAliasExist(const ColumnRefExpression &colref) {
+	return bind_state.alias_map.find(colref.column_names.back()) != bind_state.alias_map.end();
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -16,13 +16,25 @@ bool ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, unique_ptr
 	D_ASSERT(expr_ptr->GetExpressionClass() == ExpressionClass::COLUMN_REF);
 	auto &expr = expr_ptr->Cast<ColumnRefExpression>();
 
-	// Qualified columns cannot be aliases.
-	if (expr.IsQualified()) {
+	if (!ExpressionBinder::IsPotentialAlias(expr)) {
 		return false;
 	}
 
+	string alias_name;
+	if (expr.IsQualified()) {
+		if (expr.column_names.size() == 2 && StringUtil::CIEquals(expr.GetTableName(), "alias")) {
+			// Handle explicit qualified alias references: alias.<name>
+			alias_name = expr.GetColumnName();
+		} else {
+			// Qualified columns that are not `alias.<name>` cannot be aliases
+			return false;
+		}
+	} else {
+		alias_name = expr.column_names[0];
+	}
+
 	// We try to find the alias in the alias_map and return false, if no alias exists.
-	auto alias_entry = bind_state.alias_map.find(expr.column_names[0]);
+	auto alias_entry = bind_state.alias_map.find(alias_name);
 	if (alias_entry == bind_state.alias_map.end()) {
 		return false;
 	}

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -20,21 +20,8 @@ bool ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, unique_ptr
 		return false;
 	}
 
-	string alias_name;
-	if (expr.IsQualified()) {
-		if (expr.column_names.size() == 2 && StringUtil::CIEquals(expr.GetTableName(), "alias")) {
-			// Handle explicit qualified alias references: alias.<name>
-			alias_name = expr.GetColumnName();
-		} else {
-			// Qualified columns that are not `alias.<name>` cannot be aliases
-			return false;
-		}
-	} else {
-		alias_name = expr.column_names[0];
-	}
-
 	// We try to find the alias in the alias_map and return false, if no alias exists.
-	auto alias_entry = bind_state.alias_map.find(alias_name);
+	auto alias_entry = bind_state.alias_map.find(expr.column_names.back());
 	if (alias_entry == bind_state.alias_map.end()) {
 		return false;
 	}

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -113,11 +113,11 @@ bool GroupBinder::TryResolveAliasReference(ColumnRefExpression &colref, BindResu
 	// handle qualified alias.<name>
 	// In this implementation we don't restrict the alias to be used as a part of an expression
 	// We don't unify the two-step alias binding here as each one of them has its own semantics
-	if (!colref.IsQualified() || colref.column_names.size() != 2 ||
-	    !StringUtil::CIEquals(colref.GetTableName(), "alias")) {
+	if (!ExpressionBinder::IsPotentialAlias(colref)) {
 		return false;
 	}
-	const auto &alias_name = colref.GetColumnName();
+
+	const auto &alias_name = colref.column_names.back();
 	auto entry = bind_state.alias_map.find(alias_name);
 	if (entry == bind_state.alias_map.end()) {
 		return false;

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -80,7 +80,8 @@ BindResult GroupBinder::BindConstant(ConstantExpression &constant) {
 	return BindSelectRef(index - 1);
 }
 
-bool GroupBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result) {
+bool GroupBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression,
+                                           BindResult &result) {
 	// failed to bind the column and the node is the root expression with depth = 0
 	// check if refers to an alias in the select clause
 

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -92,9 +92,9 @@ bool GroupBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t de
 	}
 	if (!in_root_group_ref) {
 		result = BindResult(BinderException(
-			colref,
-			"Alias with name \"%s\" exists, but aliases cannot be used as part of an expression in the GROUP BY",
-			alias_name));
+		    colref,
+		    "Alias with name \"%s\" exists, but aliases cannot be used as part of an expression in the GROUP BY",
+		    alias_name));
 		return true;
 	}
 	result = BindResult(BindSelectRef(entry->second));

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -113,7 +113,8 @@ bool GroupBinder::TryResolveAliasReference(ColumnRefExpression &colref, BindResu
 	// handle qualified alias.<name>
 	// In this implementation we don't restrict the alias to be used as a part of an expression
 	// We don't unify the two-step alias binding here as each one of them has its own semantics
-	if (!colref.IsQualified() || colref.column_names.size() != 2 || !StringUtil::CIEquals(colref.GetTableName(), "alias")) {
+	if (!colref.IsQualified() || colref.column_names.size() != 2 ||
+	    !StringUtil::CIEquals(colref.GetTableName(), "alias")) {
 		return false;
 	}
 	const auto &alias_name = colref.GetColumnName();
@@ -140,8 +141,12 @@ BindResult GroupBinder::BindColumnRef(ColumnRefExpression &colref) {
 	// mark that we are binding the root GROUP BY expression so alias rules apply
 	struct RootGuard {
 		bool &flag;
-		explicit RootGuard(bool &f) : flag(f) { flag = true; }
-		~RootGuard() { flag = false; }
+		explicit RootGuard(bool &f) : flag(f) {
+			flag = true;
+		}
+		~RootGuard() {
+			flag = false;
+		}
 	};
 	RootGuard guard(in_root_group_ref);
 	return ExpressionBinder::BindExpression(colref, 0, true);

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -80,7 +80,7 @@ BindResult GroupBinder::BindConstant(ConstantExpression &constant) {
 	return BindSelectRef(index - 1);
 }
 
-bool GroupBinder::TryBindRegularAlias(ColumnRefExpression &colref, BindResult &result) {
+bool GroupBinder::TryBindRegularAlias(ColumnRefExpression &colref, idx_t depth, BindResult &result) {
 	// failed to bind the column and the node is the root expression with depth = 0
 	// check if refers to an alias in the select clause
 
@@ -109,7 +109,7 @@ bool GroupBinder::TryBindRegularAlias(ColumnRefExpression &colref, BindResult &r
 	return true;
 }
 
-bool GroupBinder::TryResolveAliasReference(ColumnRefExpression &colref, BindResult &result) {
+bool GroupBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) {
 	// handle qualified alias.<name>
 	// In this implementation we don't restrict the alias to be used as a part of an expression
 	// We don't unify the two-step alias binding here as each one of them has its own semantics

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -31,7 +31,7 @@ unique_ptr<ParsedExpression> HavingBinder::QualifyColumnName(ColumnRefExpression
 	if (group_index != DConstants::INVALID_INDEX) {
 		return qualified_colref;
 	}
-	if (column_alias_binder.QualifyColumnAlias(colref)) {
+	if (column_alias_binder.DoesColumnAliasExist(colref)) {
 		return nullptr;
 	}
 	return qualified_colref;

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -76,19 +76,11 @@ optional_idx OrderBinder::TryGetProjectionReference(ParsedExpression &expr) cons
 	}
 	case ExpressionClass::COLUMN_REF: {
 		auto &colref = expr.Cast<ColumnRefExpression>();
-
-		string alias_name;
-		if (colref.IsQualified()) {
-			if (colref.column_names.size() == 2 && StringUtil::CIEquals(colref.GetTableName(), "alias")) {
-				// support explicit alias.<name> as a projection reference
-				alias_name = colref.GetColumnName();
-			} else {
-				// Qualified column reference that is not alias.<name> has no meaning as a projection reference
-				break;
-			}
-		} else {
-			alias_name = colref.column_names[0];
+		if (!ExpressionBinder::IsPotentialAlias(colref)) {
+			break;
 		}
+
+		string alias_name = colref.column_names.back();
 		// check the alias list
 		auto entry = bind_state.alias_map.find(alias_name);
 		if (entry == bind_state.alias_map.end()) {

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -89,7 +89,7 @@ optional_idx OrderBinder::TryGetProjectionReference(ParsedExpression &expr) cons
 		} else {
 			alias_name = colref.column_names[0];
 		}
-		// unqualified: check the alias list
+		// check the alias list
 		auto entry = bind_state.alias_map.find(alias_name);
 		if (entry == bind_state.alias_map.end()) {
 			break;

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -9,7 +9,7 @@ SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNo
     : BaseSelectBinder(binder, context, node, info) {
 }
 
-bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) {
+bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result) {
 	// must be a qualified alias.<name>
 	if (!ExpressionBinder::IsPotentialAlias(colref)) {
 		return false;

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -9,7 +9,7 @@ SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNo
     : BaseSelectBinder(binder, context, node, info) {
 }
 
-bool SelectBinder::TryBindRegularAlias(ColumnRefExpression &colref, BindResult &result) {
+bool SelectBinder::TryBindRegularAlias(ColumnRefExpression &colref, idx_t depth, BindResult &result) {
 	if (!colref.IsQualified()) {
 		auto &bind_state = node.bind_state;
 		auto alias_entry = node.bind_state.alias_map.find(colref.column_names[0]);
@@ -27,14 +27,14 @@ bool SelectBinder::TryBindRegularAlias(ColumnRefExpression &colref, BindResult &
 				                      colref.column_names[0]);
 			}
 			auto copied_expression = node.bind_state.BindAlias(index);
-			result = BindExpression(copied_expression, 0, false);
+			result = BindExpression(copied_expression, depth, false);
 			return true;
 		}
 	}
 	return false;
 }
 
-bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, BindResult &result) {
+bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, BindResult &result) {
 	// must be a qualified alias.<name>
 	if (!ExpressionBinder::IsPotentialAlias(colref)) {
 		return false;

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -36,12 +36,11 @@ bool SelectBinder::TryBindRegularAlias(ColumnRefExpression &colref, BindResult &
 
 bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, BindResult &result) {
 	// must be a qualified alias.<name>
-	if (!colref.IsQualified() || colref.column_names.size() != 2 ||
-	    !StringUtil::CIEquals(colref.GetTableName(), "alias")) {
+	if (!ExpressionBinder::IsPotentialAlias(colref)) {
 		return false;
 	}
 
-	const auto &alias_name = colref.GetColumnName();
+	const auto &alias_name = colref.column_names.back();
 	auto entry = node.bind_state.alias_map.find(alias_name);
 	if (entry == node.bind_state.alias_map.end()) {
 		throw BinderException(colref, "alias.%s referenced, but no such alias exists in the SELECT list", alias_name);

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -10,7 +10,7 @@ SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNo
 }
 
 bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression,
-                                            BindResult &result) {
+                                            BindResult &result, unique_ptr<ParsedExpression> &expr_ptr) {
 	// must be a qualified alias.<name>
 	if (!ExpressionBinder::IsPotentialAlias(colref)) {
 		return false;

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -25,7 +25,9 @@ bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t d
 	auto alias_index = entry->second;
 	// Simple way to prevent circular aliasing (`SELECT alias.y as x, alias.x as y;`)
 	if (alias_index >= node.bound_column_count) {
-		throw BinderException(colref, "alias.%s references an alias defined after the current expression", alias_name);
+		throw BinderException("Column \"%s\" referenced that exists in the SELECT clause - but this column "
+		                      "cannot be referenced before it is defined",
+		                      colref.column_names[0]);
 	}
 
 	if (node.bind_state.AliasHasSubquery(alias_index)) {

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -38,6 +38,13 @@ bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t d
 	return true;
 }
 
+bool SelectBinder::DoesColumnAliasExist(const ColumnRefExpression &colref) {
+	// Using `back()` to support both qualified and unqualified aliasing
+	auto alias_name = colref.column_names.back();
+	return node.bind_state.alias_map.find(alias_name) != node.bind_state.alias_map.end();
+}
+
+
 unique_ptr<ParsedExpression> SelectBinder::GetSQLValueFunction(const string &column_name) {
 	auto alias_entry = node.bind_state.alias_map.find(column_name);
 	if (alias_entry != node.bind_state.alias_map.end()) {

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -9,7 +9,8 @@ SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNo
     : BaseSelectBinder(binder, context, node, info) {
 }
 
-bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression, BindResult &result) {
+bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t depth, bool root_expression,
+                                            BindResult &result) {
 	// must be a qualified alias.<name>
 	if (!ExpressionBinder::IsPotentialAlias(colref)) {
 		return false;

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -44,7 +44,6 @@ bool SelectBinder::DoesColumnAliasExist(const ColumnRefExpression &colref) {
 	return node.bind_state.alias_map.find(alias_name) != node.bind_state.alias_map.end();
 }
 
-
 unique_ptr<ParsedExpression> SelectBinder::GetSQLValueFunction(const string &column_name) {
 	auto alias_entry = node.bind_state.alias_map.find(column_name);
 	if (alias_entry != node.bind_state.alias_map.end()) {

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -74,15 +74,6 @@ unique_ptr<ParsedExpression> SelectBinder::GetSQLValueFunction(const string &col
 	return ExpressionBinder::GetSQLValueFunction(column_name);
 }
 
-BindResult SelectBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
-	// first try to bind the column reference regularly
-	auto result = BaseSelectBinder::BindColumnRef(expr_ptr, depth, root_expression);
-	if (!result.HasError()) {
-		return result;
-	}
-	return result;
-}
-
 bool SelectBinder::QualifyColumnAlias(const ColumnRefExpression &colref) {
 	if (!colref.IsQualified()) {
 		return node.bind_state.alias_map.find(colref.column_names[0]) != node.bind_state.alias_map.end();

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -11,17 +11,17 @@ SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNo
 
 unique_ptr<Expression> SelectBinder::TryResolveAliasReference(const string &alias_name,
                                                               const ColumnRefExpression &column_ref_expr) {
-	// resolve alias_ref(name) within SELECT list
+	// resolve alias.name within SELECT list
 	auto entry = node.bind_state.alias_map.find(alias_name);
 	if (entry == node.bind_state.alias_map.end()) {
-		throw BinderException(column_ref_expr, "alias_ref('%s') referenced, but no such alias exists in the SELECT list",
+		throw BinderException(column_ref_expr, "alias.%s referenced, but no such alias exists in the SELECT list",
 		                      alias_name);
 	}
 	auto alias_index = entry->second;
 
-	// Simple way to prevent circular aliasing (`SELECT alias_ref('y') as x, alias_ref('x') as y;`)
+	// Simple way to prevent circular aliasing (`SELECT alias.y as x, alias.x as y;`)
 	if (alias_index >= node.bound_column_count) {
-		throw BinderException(column_ref_expr, "alias_ref('%s') references an alias defined after the current expression",
+		throw BinderException(column_ref_expr, "alias.%s references an alias defined after the current expression",
 		                      alias_name);
 	}
 

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -10,24 +10,24 @@ SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNo
 }
 
 unique_ptr<Expression> SelectBinder::TryResolveAliasReference(const string &alias_name,
-                                                              const FunctionExpression &function) {
+                                                              const ColumnRefExpression &column_ref_expr) {
 	// resolve alias_ref(name) within SELECT list
 	auto entry = node.bind_state.alias_map.find(alias_name);
 	if (entry == node.bind_state.alias_map.end()) {
-		throw BinderException(function, "alias_ref('%s') referenced, but no such alias exists in the SELECT list",
+		throw BinderException(column_ref_expr, "alias_ref('%s') referenced, but no such alias exists in the SELECT list",
 		                      alias_name);
 	}
 	auto alias_index = entry->second;
 
 	// Simple way to prevent circular aliasing (`SELECT alias_ref('y') as x, alias_ref('x') as y;`)
 	if (alias_index >= node.bound_column_count) {
-		throw BinderException(function, "alias_ref('%s') references an alias defined after the current expression",
+		throw BinderException(column_ref_expr, "alias_ref('%s') references an alias defined after the current expression",
 		                      alias_name);
 	}
 
 	// Restricting alias references to subqueries as we will need to define some caveats we want to enforce
 	if (node.bind_state.AliasHasSubquery(alias_index)) {
-		throw BinderException(function,
+		throw BinderException(column_ref_expr,
 		                      "Alias \"%s\" referenced in a SELECT clause - but the expression has a subquery. This is "
 		                      "not yet supported.",
 		                      alias_name);

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -27,7 +27,7 @@ bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t d
 	if (alias_index >= node.bound_column_count) {
 		throw BinderException("Column \"%s\" referenced that exists in the SELECT clause - but this column "
 		                      "cannot be referenced before it is defined",
-		                      colref.column_names[0]);
+		                      colref.column_names.back());
 	}
 
 	if (node.bind_state.AliasHasSubquery(alias_index)) {

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -19,7 +19,7 @@ bool SelectBinder::TryResolveAliasReference(ColumnRefExpression &colref, idx_t d
 	const auto &alias_name = colref.column_names.back();
 	auto entry = node.bind_state.alias_map.find(alias_name);
 	if (entry == node.bind_state.alias_map.end()) {
-		throw BinderException(colref, "alias.%s referenced, but no such alias exists in the SELECT list", alias_name);
+		return false;
 	}
 
 	auto alias_index = entry->second;

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -73,11 +73,4 @@ unique_ptr<ParsedExpression> SelectBinder::GetSQLValueFunction(const string &col
 	return ExpressionBinder::GetSQLValueFunction(column_name);
 }
 
-bool SelectBinder::QualifyColumnAlias(const ColumnRefExpression &colref) {
-	if (!colref.IsQualified()) {
-		return node.bind_state.alias_map.find(colref.column_names[0]) != node.bind_state.alias_map.end();
-	}
-	return false;
-}
-
 } // namespace duckdb

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -1,11 +1,34 @@
 #include "duckdb/planner/expression_binder/select_binder.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 
 namespace duckdb {
 
 SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info)
     : BaseSelectBinder(binder, context, node, info) {
+}
+
+unique_ptr<Expression> SelectBinder::TryResolveAliasReference(const string &alias_name, const FunctionExpression &function) {
+	// resolve alias_ref(name) within SELECT list
+	auto entry = node.bind_state.alias_map.find(alias_name);
+	if (entry == node.bind_state.alias_map.end()) {
+		throw BinderException(function, "alias_ref('%s') referenced, but no such alias exists in the SELECT list", alias_name);
+	}
+	auto alias_index = entry->second;
+
+	// Simple way to prevent circular aliasing (`SELECT alias_ref('y') as x, alias_ref('x') as y;`)
+	if (alias_index >= node.bound_column_count) {
+		throw BinderException(function, "alias_ref('%s') references an alias defined after the current expression", alias_name);
+	}
+
+	// Restricting alias references to subqueries as we will need to define some caveats we want to enforce
+	if (node.bind_state.AliasHasSubquery(alias_index)) {
+		throw BinderException(function, "Alias \"%s\" referenced in a SELECT clause - but the expression has a subquery. This is not yet supported.", alias_name);
+	}
+	// bind a fresh copy of the original unbound expression
+	auto copied_unbound = node.bind_state.BindAlias(alias_index);
+	return Bind(copied_unbound);
 }
 
 unique_ptr<ParsedExpression> SelectBinder::GetSQLValueFunction(const string &column_name) {

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -32,7 +32,6 @@ unique_ptr<Expression> SelectBinder::TryResolveAliasReference(const string &alia
 		                      "not yet supported.",
 		                      alias_name);
 	}
-	// bind a fresh copy of the original unbound expression
 	auto copied_unbound = node.bind_state.BindAlias(alias_index);
 	return Bind(copied_unbound);
 }

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -45,7 +45,6 @@ bool WhereBinder::DoesColumnAliasExist(const ColumnRefExpression &colref) {
 	return false;
 }
 
-
 string WhereBinder::UnsupportedAggregateMessage() {
 	return "WHERE clause cannot contain aggregates!";
 }

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -42,11 +42,4 @@ string WhereBinder::UnsupportedAggregateMessage() {
 	return "WHERE clause cannot contain aggregates!";
 }
 
-bool WhereBinder::QualifyColumnAlias(const ColumnRefExpression &colref) {
-	if (column_alias_binder) {
-		return column_alias_binder->QualifyColumnAlias(colref);
-	}
-	return false;
-}
-
 } // namespace duckdb

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -38,6 +38,14 @@ BindResult WhereBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr, i
 	}
 }
 
+bool WhereBinder::DoesColumnAliasExist(const ColumnRefExpression &colref) {
+	if (column_alias_binder) {
+		return column_alias_binder->DoesColumnAliasExist(colref);
+	}
+	return false;
+}
+
+
 string WhereBinder::UnsupportedAggregateMessage() {
 	return "WHERE clause cannot contain aggregates!";
 }

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -38,15 +38,15 @@ BindResult WhereBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr, i
 	}
 }
 
+string WhereBinder::UnsupportedAggregateMessage() {
+	return "WHERE clause cannot contain aggregates!";
+}
+
 bool WhereBinder::DoesColumnAliasExist(const ColumnRefExpression &colref) {
 	if (column_alias_binder) {
 		return column_alias_binder->DoesColumnAliasExist(colref);
 	}
 	return false;
-}
-
-string WhereBinder::UnsupportedAggregateMessage() {
-	return "WHERE clause cannot contain aggregates!";
 }
 
 } // namespace duckdb

--- a/test/sql/binder/alias_function_errors.test
+++ b/test/sql/binder/alias_function_errors.test
@@ -2,9 +2,6 @@
 # description: Negative tests for alias_ref('name') resolution
 # group: [binder]
 
-statement ok
-PRAGMA enable_verification
-
 # forward reference should error
 statement error
 SELECT alias_ref('x') + 1 AS y, 1 AS x

--- a/test/sql/binder/alias_function_errors.test
+++ b/test/sql/binder/alias_function_errors.test
@@ -14,6 +14,12 @@ SELECT alias_ref('nope')
 ----
 no such alias exists in the SELECT list
 
+# alias to a subquery should error
+statement error
+SELECT (SELECT 1) AS x, alias_ref('x')
+----
+Alias "x" referenced in a SELECT clause - but the expression has a subquery. This is not yet supported
+
 # alias_ref() not allowed in WHERE
 statement error
 SELECT 1 AS x WHERE alias_ref('x') = 1

--- a/test/sql/binder/alias_function_errors.test
+++ b/test/sql/binder/alias_function_errors.test
@@ -1,0 +1,36 @@
+# name: test/sql/binder/alias_function_errors.test
+# description: Negative tests for alias_ref('name') resolution
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+# forward reference should error
+statement error
+SELECT alias_ref('x') + 1 AS y, 1 AS x
+----
+alias_ref('x') references an alias defined after the current expression
+
+# unknown alias should error
+statement error
+SELECT alias_ref('nope')
+----
+no such alias exists in the SELECT list
+
+# alias_ref() not allowed in WHERE
+statement error
+SELECT 1 AS x WHERE alias_ref('x') = 1
+----
+can only be used inside a SELECT projection list
+
+# alias_ref() not allowed in GROUP BY
+statement error
+SELECT 1 AS x GROUP BY alias_ref('x')
+----
+can only be used inside a SELECT projection list
+
+# alias_ref with multiple arguments should error
+statement error
+SELECT 5 as x, 8 as y, alias_ref('x', 'y');
+----
+alias_ref(name): must be called with a single string literal argument

--- a/test/sql/binder/alias_function_errors.test
+++ b/test/sql/binder/alias_function_errors.test
@@ -1,51 +1,46 @@
 # name: test/sql/binder/alias_function_errors.test
-# description: Negative tests for alias_ref('name') resolution
+# description: Negative tests for alias.name resolution
 # group: [binder]
 
 # forward reference should error
 statement error
-SELECT alias_ref('x') + 1 AS y, 1 AS x
+SELECT alias.x + 1 AS y, 1 AS x
 ----
-alias_ref('x') references an alias defined after the current expression
+alias.x references an alias defined after the current expression
 
 # unknown alias should error
 statement error
-SELECT alias_ref('nope')
+SELECT alias.nope;
 ----
-no such alias exists in the SELECT list
+Binder Error: alias.nope referenced, but no such alias exists in the SELECT list
 
 # alias to a subquery should error
 statement error
-SELECT (SELECT 1) AS x, alias_ref('x')
+SELECT (SELECT 1) AS x, alias.x
 ----
 Alias "x" referenced in a SELECT clause - but the expression has a subquery. This is not yet supported
 
-# alias_ref() not allowed in WHERE
+# alias. is not allowed in WHERE
 statement error
-SELECT 1 AS x WHERE alias_ref('x') = 1
+SELECT 1 AS x WHERE alias.x = 1
 ----
-can only be used inside a SELECT projection list
+Binder Error: alias.* references are only valid in a SELECT projection list
 
-# alias_ref() not allowed in GROUP BY
+# alias. not allowed in GROUP BY
 statement error
-SELECT 1 AS x GROUP BY alias_ref('x')
+SELECT 1 AS x GROUP BY alias.x
 ----
-can only be used inside a SELECT projection list
+Binder Error: alias.* references are only valid in a SELECT projection list
 
-# alias_ref with multiple arguments should error
+# alias ref with non-string argument should error already in the parsing phase
 statement error
-SELECT 5 as x, 8 as y, alias_ref('x', 'y');
+SELECT 5 as x, alias.123;
 ----
-alias_ref(name): must be called with a single string literal argument
+Parser Error: syntax error at or near ".123"
 
-# alias_ref with non-string argument should error
+# alias ref with NULL argument will actually be considered as a column name, but since no such alias exists, it should
+# error
 statement error
-SELECT 5 as x, alias_ref(123);
+SELECT 5 as x, alias.NULL;
 ----
-alias_ref(name): argument must be a non-NULL string literal
-
-# alias_ref with NULL argument should error
-statement error
-SELECT 5 as x, alias_ref(NULL);
-----
-alias_ref(name): argument must be a non-NULL string literal
+Binder Error: alias.NULL referenced, but no such alias exists in the SELECT list

--- a/test/sql/binder/alias_function_errors.test
+++ b/test/sql/binder/alias_function_errors.test
@@ -34,3 +34,15 @@ statement error
 SELECT 5 as x, 8 as y, alias_ref('x', 'y');
 ----
 alias_ref(name): must be called with a single string literal argument
+
+# alias_ref with non-string argument should error
+statement error
+SELECT 5 as x, alias_ref(123);
+----
+alias_ref(name): argument must be a non-NULL string literal
+
+# alias_ref with NULL argument should error
+statement error
+SELECT 5 as x, alias_ref(NULL);
+----
+alias_ref(name): argument must be a non-NULL string literal

--- a/test/sql/binder/alias_function_select_projection.test
+++ b/test/sql/binder/alias_function_select_projection.test
@@ -2,9 +2,6 @@
 # description: Test alias_ref('name') resolution in SELECT projection
 # group: [binder]
 
-statement ok
-PRAGMA enable_verification
-
 query II
 SELECT
   a + 1 AS x,

--- a/test/sql/binder/alias_function_select_projection.test
+++ b/test/sql/binder/alias_function_select_projection.test
@@ -1,0 +1,14 @@
+# name: test/sql/binder/alias_function_select_projection.test
+# description: Test alias_ref('name') resolution in SELECT projection
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+query II
+SELECT
+  a + 1 AS x,
+  alias_ref('x') + 2 AS y
+FROM (VALUES (42)) t(a);
+----
+43	45

--- a/test/sql/binder/alias_function_select_projection.test
+++ b/test/sql/binder/alias_function_select_projection.test
@@ -1,5 +1,5 @@
 # name: test/sql/binder/alias_function_select_projection.test
-# description: Test alias_ref('name') resolution in SELECT projection
+# description: Test alias.name resolution in SELECT projection
 # group: [binder]
 
 query II

--- a/test/sql/binder/alias_function_select_projection.test
+++ b/test/sql/binder/alias_function_select_projection.test
@@ -5,7 +5,7 @@
 query II
 SELECT
   a + 1 AS x,
-  alias_ref('x') + 2 AS y
+  alias.x + 2 AS y
 FROM (VALUES (42)) t(a);
 ----
 43	45

--- a/test/sql/binder/alias_qualification_errors.test
+++ b/test/sql/binder/alias_qualification_errors.test
@@ -6,7 +6,7 @@
 statement error
 SELECT alias.x + 1 AS y, 1 AS x
 ----
-Binder Error: Column "alias" referenced that exists in the SELECT clause - but this column cannot be referenced before it is defined
+Binder Error: Column "x" referenced that exists in the SELECT clause - but this column cannot be referenced before it is defined
 
 # unknown alias should error
 statement error

--- a/test/sql/binder/alias_qualification_errors.test
+++ b/test/sql/binder/alias_qualification_errors.test
@@ -20,18 +20,6 @@ SELECT (SELECT 1) AS x, alias.x
 ----
 Alias "x" referenced in a SELECT clause - but the expression has a subquery. This is not yet supported
 
-# alias. is not allowed in WHERE
-statement error
-SELECT 1 AS x WHERE alias.x = 1
-----
-Binder Error: alias.* references are only valid in a SELECT projection list
-
-# alias. not allowed in GROUP BY
-statement error
-SELECT 1 AS x GROUP BY alias.x
-----
-Binder Error: alias.* references are only valid in a SELECT projection list
-
 # alias ref with non-string argument should error already in the parsing phase
 statement error
 SELECT 5 as x, alias.123;

--- a/test/sql/binder/alias_qualification_errors.test
+++ b/test/sql/binder/alias_qualification_errors.test
@@ -6,7 +6,7 @@
 statement error
 SELECT alias.x + 1 AS y, 1 AS x
 ----
-alias.x references an alias defined after the current expression
+Binder Error: Column "alias" referenced that exists in the SELECT clause - but this column cannot be referenced before it is defined
 
 # unknown alias should error
 statement error
@@ -25,10 +25,3 @@ statement error
 SELECT 5 as x, alias.123;
 ----
 Parser Error: syntax error at or near ".123"
-
-# alias ref with NULL argument will actually be considered as a column name, but since no such alias exists, it should
-# error
-statement error
-SELECT 5 as x, alias.NULL;
-----
-Binder Error: alias.NULL referenced, but no such alias exists in the SELECT list

--- a/test/sql/binder/alias_qualification_errors.test
+++ b/test/sql/binder/alias_qualification_errors.test
@@ -1,4 +1,4 @@
-# name: test/sql/binder/alias_function_errors.test
+# name: test/sql/binder/alias_qualification_errors.test
 # description: Negative tests for alias.name resolution
 # group: [binder]
 

--- a/test/sql/binder/alias_qualification_errors.test
+++ b/test/sql/binder/alias_qualification_errors.test
@@ -12,7 +12,7 @@ alias.x references an alias defined after the current expression
 statement error
 SELECT alias.nope;
 ----
-Binder Error: alias.nope referenced, but no such alias exists in the SELECT list
+Binder Error:
 
 # alias to a subquery should error
 statement error

--- a/test/sql/binder/alias_qualification_group_by.test
+++ b/test/sql/binder/alias_qualification_group_by.test
@@ -1,0 +1,59 @@
+# name: test/sql/binder/alias_qualification_group_by.test
+# description: Test alias.name resolution in GROUP BY clause
+# group: [binder]
+
+# grouping by a projection alias
+query II
+SELECT a % 2 AS x, COUNT(*) AS cnt
+FROM (VALUES (1),(2),(3),(4)) t(a)
+GROUP BY alias.x
+ORDER BY x;
+----
+0	2
+1	2
+
+# alias chaining in select list, grouping by the later alias
+query III
+SELECT a + 1 AS x, alias.x % 2 AS y, SUM(a) AS s
+FROM (VALUES (1),(2),(3)) t(a)
+GROUP BY alias.y
+ORDER BY y;
+----
+0	0	4
+1	1	2
+
+# GROUP BY for inside-expression alias
+query IIII
+SELECT a as x FROM (VALUES (1),(2),(3)) t(a)
+GROUP BY alias.x + 1
+ORDER BY alias.x;
+----
+2
+3
+4
+
+# quoted alias in GROUP BY
+query II
+SELECT (a/2)::INT AS "Half", COUNT(*) AS c
+FROM (VALUES (1),(2),(3),(4)) t(a)
+GROUP BY alias."Half"
+ORDER BY "Half";
+----
+0	1
+1	1
+2	2
+
+# Table actually named `alias` should keep working and be prioritized over alias references
+statement ok
+CREATE TABLE alias (g INT);
+
+statement ok
+INSERT INTO alias VALUES (1), (1), (2);
+
+query II
+SELECT g AS x, COUNT(*) c FROM alias
+GROUP BY alias.g
+ORDER BY x;
+----
+1	2
+2	1

--- a/test/sql/binder/alias_qualification_group_by.test
+++ b/test/sql/binder/alias_qualification_group_by.test
@@ -23,7 +23,7 @@ ORDER BY y;
 1	1	2
 
 # GROUP BY for inside-expression alias
-query IIII
+query I
 SELECT a as x FROM (VALUES (1),(2),(3)) t(a)
 GROUP BY alias.x + 1
 ORDER BY alias.x;

--- a/test/sql/binder/alias_qualification_group_by.test
+++ b/test/sql/binder/alias_qualification_group_by.test
@@ -12,26 +12,6 @@ ORDER BY x;
 0	2
 1	2
 
-# alias chaining in select list, grouping by the later alias
-query III
-SELECT a + 1 AS x, alias.x % 2 AS y, SUM(a) AS s
-FROM (VALUES (1),(2),(3)) t(a)
-GROUP BY alias.y
-ORDER BY y;
-----
-0	0	4
-1	1	2
-
-# GROUP BY for inside-expression alias
-query I
-SELECT a as x FROM (VALUES (1),(2),(3)) t(a)
-GROUP BY alias.x + 1
-ORDER BY alias.x;
-----
-2
-3
-4
-
 # quoted alias in GROUP BY
 query II
 SELECT (a/2)::INT AS "Half", COUNT(*) AS c
@@ -57,3 +37,20 @@ ORDER BY x;
 ----
 1	2
 2	1
+
+# GROUP BY on values that are a part of an expression 
+statement error
+SELECT a + 1 AS x, alias.x % 2 AS y, SUM(a) AS s
+FROM (VALUES (1),(2),(3)) t(a)
+GROUP BY alias.y
+ORDER BY y;
+----
+Binder Error
+
+# GROUP BY for inside-expression alias calling from the GROUP BY clause
+statement error
+SELECT a as x FROM (VALUES (1),(2),(3)) t(a)
+GROUP BY alias.x + 1
+ORDER BY alias.x;
+----
+Binder Error

--- a/test/sql/binder/alias_qualification_having.test
+++ b/test/sql/binder/alias_qualification_having.test
@@ -1,0 +1,50 @@
+# name: test/sql/binder/alias_qualification_having.test
+# description: Test alias.name resolution in HAVING clause
+# group: [binder]
+
+# basic HAVING filter using a projection alias
+query II
+SELECT a % 2 AS x, SUM(a) AS s
+FROM (VALUES (1),(2),(3),(4)) t(a)
+GROUP BY alias.x
+HAVING alias.s >= 6
+ORDER BY x;
+----
+0	6
+
+# chaining aliases and using the later alias in HAVING
+query III
+SELECT a + 1 AS x, alias.x % 2 AS y, SUM(a) AS s
+FROM (VALUES (1),(2),(3),(4)) t(a)
+GROUP BY alias.y
+HAVING alias.s > 5
+ORDER BY y;
+----
+1	1	6
+
+# quoted alias in HAVING
+query II
+SELECT (a/2)::INT AS "Half", COUNT(*) AS c
+FROM (VALUES (1),(2),(3),(4)) t(a)
+GROUP BY alias."Half"
+HAVING alias.c >= 1
+ORDER BY "Half";
+----
+0	1
+1	1
+2	2
+
+# Table actually named `alias` should be prioritized over alias references
+statement ok
+CREATE TABLE alias (g INT);
+
+statement ok
+INSERT INTO alias VALUES (1), (1), (2);
+
+query II
+SELECT g AS x, COUNT(*) c FROM alias
+GROUP BY alias.g
+HAVING alias.c = 2
+ORDER BY x;
+----
+1	2

--- a/test/sql/binder/alias_qualification_having.test
+++ b/test/sql/binder/alias_qualification_having.test
@@ -16,11 +16,12 @@ ORDER BY x;
 query III
 SELECT a + 1 AS x, alias.x % 2 AS y, SUM(a) AS s
 FROM (VALUES (1),(2),(3),(4)) t(a)
-GROUP BY alias.y
-HAVING alias.s > 5
+GROUP BY a
+HAVING alias.s > 2
 ORDER BY y;
 ----
-1	1	6
+4	0	3
+5	1	4
 
 # quoted alias in HAVING
 query II

--- a/test/sql/binder/alias_qualification_order_by.test
+++ b/test/sql/binder/alias_qualification_order_by.test
@@ -1,0 +1,44 @@
+# name: test/sql/binder/alias_qualification_order_by.test
+# description: Test alias.name resolution in ORDER BY clause
+# group: [binder]
+
+# simple ordering by projection alias
+query I
+SELECT a AS x FROM (VALUES (3),(1),(2)) t(a)
+ORDER BY alias.x;
+----
+1
+2
+3
+
+# ordering by a later alias derived from a prior alias
+query II
+SELECT a + 1 AS x, alias.x * 10 AS y FROM (VALUES (1),(3),(2)) t(a)
+ORDER BY alias.y DESC;
+----
+4	40
+3	30
+2	20
+
+# quoted alias in ORDER BY
+query I
+SELECT a AS "MiXeD" FROM (VALUES (2),(1)) t(a)
+ORDER BY alias."MiXeD";
+----
+1
+2
+
+# ensure a table actually named `alias` still works and does not conflict with alias references
+statement ok
+CREATE TABLE alias (v INT);
+
+statement ok
+INSERT INTO alias VALUES (20), (10);
+
+# Table-qualified column should be prioritized when resolving alias.<name>
+query I
+SELECT v AS x FROM alias
+ORDER BY alias.v;
+----
+10
+20

--- a/test/sql/binder/alias_qualification_qualify.test
+++ b/test/sql/binder/alias_qualification_qualify.test
@@ -1,0 +1,46 @@
+# name: test/sql/binder/alias_qualification_qualify.test
+# description: Test alias.name resolution in QUALIFY clause
+# group: [binder]
+
+# basic QUALIFY using a projection alias for a window expression
+query II
+SELECT a, row_number() OVER (ORDER BY a) AS rn
+FROM (VALUES (3),(1),(2)) t(a)
+QUALIFY alias.rn <= 2
+ORDER BY a;
+----
+1	1
+2	2
+
+# chaining aliases: later alias based on earlier alias and used in QUALIFY
+query II
+SELECT a + 1 AS x, row_number() OVER (ORDER BY alias.x) AS rx
+FROM (VALUES (10),(20),(30)) t(a)
+QUALIFY alias.rx = 2
+ORDER BY a;
+----
+21	2
+
+# quoted alias used in QUALIFY
+query II
+SELECT a AS "MiXeD", row_number() OVER (ORDER BY a) AS r
+FROM (VALUES (2),(1)) t(a)
+QUALIFY alias.r = 1
+ORDER BY a;
+----
+1	1
+
+# ensure a table actually named `alias` still works and is prioritized
+statement ok
+CREATE TABLE alias (v INT);
+
+statement ok
+INSERT INTO alias VALUES (2), (1), (3);
+
+query II
+SELECT v AS x, row_number() OVER (ORDER BY v) r FROM alias
+QUALIFY alias.r <= 2
+ORDER BY v;
+----
+1	1
+2	2

--- a/test/sql/binder/alias_qualification_select_projection.test
+++ b/test/sql/binder/alias_qualification_select_projection.test
@@ -84,3 +84,22 @@ SELECT
 FROM (VALUES (1)) t(a);
 ----
 hi	hi!
+
+# making sure that SELECT on a table under the name of `alias` works correctly
+statement ok
+CREATE TABLE alias (col1 INT, col2 INT);
+
+statement ok
+INSERT INTO alias VALUES (11, 22);
+
+query II
+SELECT alias.col1, alias.col2 FROM alias;
+----
+11	22
+
+# even if we have an alias reference in the projection, it should not conflict with the table named `alias`,
+# but the table columns should be prioritised
+query II
+SELECT col1 * 10 AS col2, alias.col2 AS projected_col2 FROM alias;
+----
+110	22

--- a/test/sql/binder/alias_qualification_select_projection.test
+++ b/test/sql/binder/alias_qualification_select_projection.test
@@ -103,3 +103,9 @@ query II
 SELECT col1 * 10 AS col2, alias.col2 AS projected_col2 FROM alias;
 ----
 110	22
+
+# mmethod call on alias reference
+query II
+SELECT 'AbC' AS s, alias.s.lower();
+----
+AbC	abc

--- a/test/sql/binder/alias_qualification_select_projection.test
+++ b/test/sql/binder/alias_qualification_select_projection.test
@@ -1,4 +1,4 @@
-# name: test/sql/binder/alias_function_select_projection.test
+# name: test/sql/binder/alias_qualification_select_projection.test
 # description: Test alias.name resolution in SELECT projection
 # group: [binder]
 

--- a/test/sql/binder/alias_qualification_select_projection.test
+++ b/test/sql/binder/alias_qualification_select_projection.test
@@ -9,3 +9,78 @@ SELECT
 FROM (VALUES (42)) t(a);
 ----
 43	45
+
+# chained alias references within SELECT projection
+query IIII
+SELECT
+  a AS a,
+  a + 1 AS x,
+  alias.x + 2 AS y,
+  alias.y * 2 AS z
+FROM (VALUES (10)) t(a);
+----
+10	11	13	26
+
+# multiple references to the same alias
+query III
+SELECT
+  a + 1 AS x,
+  alias.x AS x2,
+  alias.x + alias.x AS xsum
+FROM (VALUES (5)) t(a);
+----
+6	6	12
+
+# quoted alias names with mixed case
+query II
+SELECT
+  a + 1 AS "MiXeD",
+  alias."MiXeD" + 1 AS y
+FROM (VALUES (1)) t(a);
+----
+2	3
+
+# alias usage with window function in earlier alias
+query III
+SELECT
+  a,
+  row_number() OVER (ORDER BY a) AS rn,
+  alias.rn + 1 AS rn2
+FROM (VALUES (3),(1),(2)) t(a)
+ORDER BY a;
+----
+1	1	2
+2	2	3
+3	3	4
+
+# alias with DISTINCT and deterministic ordering
+query II
+SELECT DISTINCT
+  a AS x,
+  alias.x + 0 AS y
+FROM (VALUES (1),(1),(2)) t(a)
+ORDER BY x;
+----
+1	1
+2	2
+
+# alias inside CASE expression across multiple rows
+query IT
+SELECT
+  a AS x,
+  CASE WHEN alias.x % 2 = 0 THEN 'even' ELSE 'odd' END AS parity
+FROM (VALUES (1),(2),(3)) t(a)
+ORDER BY a;
+----
+1	odd
+2	even
+3	odd
+
+# string alias usage
+query TT
+SELECT
+  'hi' AS s,
+  alias.s || '!' AS ex
+FROM (VALUES (1)) t(a);
+----
+hi	hi!

--- a/test/sql/binder/alias_qualification_where.test
+++ b/test/sql/binder/alias_qualification_where.test
@@ -1,0 +1,42 @@
+# name: test/sql/binder/alias_qualification_where.test
+# description: Test alias.name resolution in WHERE clause
+# group: [binder]
+
+# basic filtering using projection alias in WHERE
+query I
+SELECT a AS x FROM (VALUES (1),(2),(3)) t(a)
+WHERE alias.x > 1
+ORDER BY a;
+----
+2
+3
+
+# alias chaining shouldn't be necessary in WHERE, but referencing another alias should work
+query II
+SELECT a + 1 AS x, alias.x * 2 AS y FROM (VALUES (1),(2)) t(a)
+WHERE alias.y >= 6
+ORDER BY a;
+----
+3	6
+
+# quoted alias in WHERE
+query I
+SELECT a AS "MiXeD" FROM (VALUES (0),(1)) t(a)
+WHERE alias."MiXeD" = 1;
+----
+1
+
+# ensure a table actually named `alias` still works and does not conflict with alias references
+statement ok
+CREATE TABLE alias (v INT);
+
+statement ok
+INSERT INTO alias VALUES (10), (20);
+
+# The table-qualified column reference should still be prioritized over alias references
+query I
+SELECT v AS x FROM alias
+WHERE alias.v > 10
+ORDER BY v;
+----
+20


### PR DESCRIPTION
### Summary of Changes
- Added support for `alias.name` in SELECT projection:
  - Introduced `SupportsAliasReference` and `TryResolveAliasReference` in `ExpressionBinder`.
  - Implemented `TryResolveAliasReference` specifically in `SelectBinder`.
  - Included robust tests for both valid aliases and edge cases.

Related issue: https://github.com/duckdb/duckdb/issues/13991#issuecomment-2357781600

<img width="281" height="229" alt="image" src="https://github.com/user-attachments/assets/31b673a3-0835-4618-add3-e4196abc1e2f" />

Works with:
- `SELECT`
- `GROUP BY` (works also with inside-expression aliases, `GROUP BY alias.x + 1`, which was impossible in legacy aliasing)
- `WHERE` / `HAVING` / `QUALIFY`
- `ORDER BY`