### PR TITLE
Fix major big-endian issues

### DIFF
--- a/src/function/scalar/compressed_materialization/compress_string.cpp
+++ b/src/function/scalar/compressed_materialization/compress_string.cpp
@@ -44,7 +44,7 @@ inline RESULT_TYPE StringCompressInternal(const string_t &input) {
 		memset(result_ptr, '\0', remainder);
 	}
 	result_ptr[0] = UnsafeNumericCast<data_t>(input.GetSize());
-	return result;
+	return BSwapIfBE(result);
 }
 
 template <class RESULT_TYPE>
@@ -55,13 +55,15 @@ inline RESULT_TYPE StringCompress(const string_t &input) {
 
 template <class RESULT_TYPE>
 inline RESULT_TYPE MiniStringCompress(const string_t &input) {
+	RESULT_TYPE result;
 	if (sizeof(RESULT_TYPE) <= string_t::INLINE_LENGTH) {
-		return UnsafeNumericCast<RESULT_TYPE>(input.GetSize() + *const_data_ptr_cast(input.GetPrefix()));
+		result = UnsafeNumericCast<RESULT_TYPE>(input.GetSize() + *const_data_ptr_cast(input.GetPrefix()));
 	} else if (input.GetSize() == 0) {
-		return 0;
+		result = 0;
 	} else {
-		return UnsafeNumericCast<RESULT_TYPE>(input.GetSize() + *const_data_ptr_cast(input.GetPointer()));
+		result = UnsafeNumericCast<RESULT_TYPE>(input.GetSize() + *const_data_ptr_cast(input.GetPointer()));
 	}
+	return BSwapIfBE(result);
 }
 
 template <>
@@ -126,19 +128,20 @@ public:
 
 template <class INPUT_TYPE>
 inline string_t StringDecompress(const INPUT_TYPE &input, ArenaAllocator &allocator) {
-	const auto input_ptr = const_data_ptr_cast(&input);
-	string_t result(input_ptr[0]);
+	const auto le_input = BSwapIfBE(input);
+	const auto le_input_str = const_data_ptr_cast(&le_input);
+	string_t result(le_input_str[0]);
 	if (sizeof(INPUT_TYPE) <= string_t::INLINE_LENGTH) {
 		const auto result_ptr = data_ptr_cast(result.GetPrefixWriteable());
-		TemplatedReverseMemCpy<sizeof(INPUT_TYPE)>(result_ptr, input_ptr);
+		TemplatedReverseMemCpy<sizeof(INPUT_TYPE)>(result_ptr, le_input_str);
 		memset(result_ptr + sizeof(INPUT_TYPE) - 1, '\0', string_t::INLINE_LENGTH - sizeof(INPUT_TYPE) + 1);
 	} else if (result.GetSize() <= string_t::INLINE_LENGTH) {
 		static constexpr auto REMAINDER = sizeof(INPUT_TYPE) - string_t::INLINE_LENGTH;
 		const auto result_ptr = data_ptr_cast(result.GetPrefixWriteable());
-		TemplatedReverseMemCpy<string_t::INLINE_LENGTH>(result_ptr, input_ptr + REMAINDER);
+		TemplatedReverseMemCpy<string_t::INLINE_LENGTH>(result_ptr, le_input_str + REMAINDER);
 	} else {
 		result.SetPointer(char_ptr_cast(allocator.Allocate(sizeof(INPUT_TYPE))));
-		TemplatedReverseMemCpy<sizeof(INPUT_TYPE)>(data_ptr_cast(result.GetPointer()), input_ptr);
+		TemplatedReverseMemCpy<sizeof(INPUT_TYPE)>(data_ptr_cast(result.GetPointer()), le_input_str);
 		memcpy(result.GetPrefixWriteable(), result.GetPointer(), string_t::PREFIX_LENGTH);
 	}
 	return result;
@@ -146,7 +149,8 @@ inline string_t StringDecompress(const INPUT_TYPE &input, ArenaAllocator &alloca
 
 template <class INPUT_TYPE>
 inline string_t MiniStringDecompress(const INPUT_TYPE &input, ArenaAllocator &allocator) {
-	if (input == 0) {
+	const auto le_input = BSwapIfBE(input);
+	if (le_input == 0) {
 		string_t result(uint32_t(0));
 		memset(result.GetPrefixWriteable(), '\0', string_t::INLINE_BYTES);
 		return result;
@@ -155,10 +159,10 @@ inline string_t MiniStringDecompress(const INPUT_TYPE &input, ArenaAllocator &al
 	string_t result(1);
 	if (sizeof(INPUT_TYPE) <= string_t::INLINE_LENGTH) {
 		memset(result.GetPrefixWriteable(), '\0', string_t::INLINE_BYTES);
-		*data_ptr_cast(result.GetPrefixWriteable()) = input - 1;
+		*data_ptr_cast(result.GetPrefixWriteable()) = le_input - 1;
 	} else {
 		result.SetPointer(char_ptr_cast(allocator.Allocate(1)));
-		*data_ptr_cast(result.GetPointer()) = input - 1;
+		*data_ptr_cast(result.GetPointer()) = le_input - 1;
 		memset(result.GetPrefixWriteable(), '\0', string_t::PREFIX_LENGTH);
 		*result.GetPrefixWriteable() = *result.GetPointer();
 	}

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -711,7 +711,7 @@ void FinalizeSortData(Vector &result, idx_t size, const SortKeyLengthInfo &key_l
 	case LogicalTypeId::BIGINT: {
 		auto result_data = FlatVector::GetData<int64_t>(result);
 		for (idx_t r = 0; r < size; r++) {
-			result_data[r] = BSwap(result_data[r]);
+			result_data[r] = BSwapIfLE(result_data[r]);
 		}
 		break;
 	}
@@ -1213,13 +1213,13 @@ static void DecodeSortKeyFunction(DataChunk &args, ExpressionState &state, Vecto
 			for (idx_t i = 0; i < count; i++) {
 				const auto idx = sort_key_vec_format.sel->get_index(i);
 				D_ASSERT(sort_key_vec_format.validity.RowIsValid(idx));
-				bswapped_ints[i] = BSwap(sort_keys[idx]);
+				bswapped_ints[i] = BSwapIfLE(sort_keys[idx]);
 				decode_data[i] = DecodeSortKeyData(bswapped_ints[i]);
 			}
 		} else {
 			for (idx_t i = 0; i < count; i++) {
 				D_ASSERT(sort_key_vec_format.validity.RowIsValid(i));
-				bswapped_ints[i] = BSwap(sort_keys[i]);
+				bswapped_ints[i] = BSwapIfLE(sort_keys[i]);
 				decode_data[i] = DecodeSortKeyData(bswapped_ints[i]);
 			}
 		}

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -409,10 +409,10 @@ static void UUIDConversion(Vector &vector, const ArrowArray &array, idx_t chunk_
 		if (!validity_mask.RowIsValid(row)) {
 			continue;
 		}
-		tgt_ptr[row].lower = static_cast<uint64_t>(BSwap(src_ptr[row].upper));
+		tgt_ptr[row].lower = static_cast<uint64_t>(BSwapIfLE(src_ptr[row].upper));
 		// flip Upper MSD
-		tgt_ptr[row].upper =
-		    static_cast<int64_t>(static_cast<uint64_t>(BSwap(src_ptr[row].lower)) ^ (static_cast<uint64_t>(1) << 63));
+		tgt_ptr[row].upper = static_cast<int64_t>(static_cast<uint64_t>(BSwapIfLE(src_ptr[row].lower)) ^
+		                                          (static_cast<uint64_t>(1) << 63));
 	}
 }
 

--- a/src/include/duckdb/common/arrow/appender/scalar_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/scalar_data.hpp
@@ -71,9 +71,10 @@ struct ArrowUUIDBlobConverter {
 	template <class TGT, class SRC>
 	static TGT Operation(hugeint_t input) {
 		// Turn into big-end
-		auto upper = BSwap(input.lower);
+		auto upper = BSwapIfLE(input.lower);
 		// flip Upper MSD
-		auto lower = BSwap(static_cast<int64_t>(static_cast<uint64_t>(input.upper) ^ (static_cast<uint64_t>(1) << 63)));
+		auto lower =
+		    BSwapIfLE(static_cast<int64_t>(static_cast<uint64_t>(input.upper) ^ (static_cast<uint64_t>(1) << 63)));
 		return {static_cast<int64_t>(upper), static_cast<uint64_t>(lower)};
 	}
 

--- a/src/include/duckdb/common/bswap.hpp
+++ b/src/include/duckdb/common/bswap.hpp
@@ -79,6 +79,24 @@ static inline hugeint_t BSwap(const hugeint_t &x) {
 	return hugeint_t(static_cast<int64_t>(BSWAP64(x.upper)), BSWAP64(x.lower));
 }
 
+static inline float BSwap(const float &x) {
+	uint32_t temp;
+	std::memcpy(&temp, &x, sizeof(temp));
+	temp = BSWAP32(temp);
+	float result;
+	std::memcpy(&result, &temp, sizeof(result));
+	return result;
+}
+
+static inline double BSwap(const double &x) {
+	uint64_t temp;
+	std::memcpy(&temp, &x, sizeof(temp));
+	temp = BSWAP64(temp);
+	double result;
+	std::memcpy(&result, &temp, sizeof(result));
+	return result;
+}
+
 template <class T>
 static inline T BSwapIfLE(const T &x) {
 #if DUCKDB_IS_BIG_ENDIAN

--- a/src/include/duckdb/common/bswap.hpp
+++ b/src/include/duckdb/common/bswap.hpp
@@ -11,6 +11,8 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 
+#include <cstring>
+
 namespace duckdb {
 
 #ifndef DUCKDB_IS_BIG_ENDIAN

--- a/src/include/duckdb/common/bswap.hpp
+++ b/src/include/duckdb/common/bswap.hpp
@@ -13,6 +13,19 @@
 
 namespace duckdb {
 
+#ifndef DUCKDB_IS_BIG_ENDIAN
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define DUCKDB_IS_BIG_ENDIAN 1
+#else
+#define DUCKDB_IS_BIG_ENDIAN 0
+#endif
+#endif
+
+#if defined(__clang__) || defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
+#define BSWAP16(x) __builtin_bswap16(static_cast<uint16_t>(x))
+#define BSWAP32(x) __builtin_bswap32(static_cast<uint32_t>(x))
+#define BSWAP64(x) __builtin_bswap64(static_cast<uint64_t>(x))
+#else
 #define BSWAP16(x) ((uint16_t)((((uint16_t)(x)&0xff00) >> 8) | (((uint16_t)(x)&0x00ff) << 8)))
 
 #define BSWAP32(x)                                                                                                     \
@@ -24,6 +37,11 @@ namespace duckdb {
 	            (((uint64_t)(x)&0x0000ff0000000000ull) >> 24) | (((uint64_t)(x)&0x000000ff00000000ull) >> 8) |         \
 	            (((uint64_t)(x)&0x00000000ff000000ull) << 8) | (((uint64_t)(x)&0x0000000000ff0000ull) << 24) |         \
 	            (((uint64_t)(x)&0x000000000000ff00ull) << 40) | (((uint64_t)(x)&0x00000000000000ffull) << 56)))
+#endif
+
+static inline int8_t BSwap(const int8_t &x) {
+	return x;
+}
 
 static inline uint8_t BSwap(const uint8_t &x) {
 	return x;
@@ -33,8 +51,16 @@ static inline uint16_t BSwap(const uint16_t &x) {
 	return BSWAP16(x);
 }
 
+static inline int16_t BSwap(const int16_t &x) {
+	return static_cast<int16_t>(BSWAP16(x));
+}
+
 static inline uint32_t BSwap(const uint32_t &x) {
 	return BSWAP32(x);
+}
+
+static inline int32_t BSwap(const int32_t &x) {
+	return static_cast<int32_t>(BSWAP32(x));
 }
 
 static inline uint64_t BSwap(const uint64_t &x) {
@@ -43,6 +69,32 @@ static inline uint64_t BSwap(const uint64_t &x) {
 
 static inline int64_t BSwap(const int64_t &x) {
 	return static_cast<int64_t>(BSWAP64(x));
+}
+
+static inline uhugeint_t BSwap(const uhugeint_t &x) {
+	return uhugeint_t(BSWAP64(x.upper), BSWAP64(x.lower));
+}
+
+static inline hugeint_t BSwap(const hugeint_t &x) {
+	return hugeint_t(static_cast<int64_t>(BSWAP64(x.upper)), BSWAP64(x.lower));
+}
+
+template <class T>
+static inline T BSwapIfLE(const T &x) {
+#if DUCKDB_IS_BIG_ENDIAN
+	return x;
+#else
+	return BSwap(x);
+#endif
+}
+
+template <class T>
+static inline T BSwapIfBE(const T &x) {
+#if DUCKDB_IS_BIG_ENDIAN
+	return BSwap(x);
+#else
+	return x;
+#endif
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/operator/numeric_cast.hpp
+++ b/src/include/duckdb/common/operator/numeric_cast.hpp
@@ -32,7 +32,7 @@ static bool TryCastWithOverflowCheck(SRC value, DST &result) {
 		if (NumericLimits<SRC>::IsSigned()) {
 			// signed to unsigned conversion
 			if (NumericLimits<SRC>::Digits() > NumericLimits<DST>::Digits()) {
-				if (value < 0 || value > (SRC)NumericLimits<DST>::Maximum()) {
+				if (value < 0 || value > static_cast<SRC>(NumericLimits<DST>::Maximum())) {
 					return false;
 				}
 			} else {
@@ -40,31 +40,31 @@ static bool TryCastWithOverflowCheck(SRC value, DST &result) {
 					return false;
 				}
 			}
-			result = (DST)value;
+			result = static_cast<DST>(value);
 			return true;
 		} else {
 			// unsigned to signed conversion
 			if (NumericLimits<SRC>::Digits() >= NumericLimits<DST>::Digits()) {
-				if (value <= (SRC)NumericLimits<DST>::Maximum()) {
-					result = (DST)value;
+				if (value <= static_cast<SRC>(NumericLimits<DST>::Maximum())) {
+					result = static_cast<DST>(value);
 					return true;
 				}
 				return false;
 			} else {
-				result = (DST)value;
+				result = static_cast<DST>(value);
 				return true;
 			}
 		}
 	} else {
 		// same sign conversion
 		if (NumericLimits<DST>::Digits() >= NumericLimits<SRC>::Digits()) {
-			result = (DST)value;
+			result = static_cast<DST>(value);
 			return true;
 		} else {
 			if (value < SRC(NumericLimits<DST>::Minimum()) || value > SRC(NumericLimits<DST>::Maximum())) {
 				return false;
 			}
-			result = (DST)value;
+			result = static_cast<DST>(value);
 			return true;
 		}
 	}

--- a/src/include/duckdb/common/radix.hpp
+++ b/src/include/duckdb/common/radix.hpp
@@ -24,15 +24,6 @@ namespace duckdb {
 
 struct Radix {
 public:
-	static inline bool IsLittleEndian() {
-		int n = 1;
-		if (*char_ptr_cast(&n) == 1) {
-			return true;
-		} else {
-			return false;
-		}
-	}
-
 	template <class T>
 	static inline void EncodeData(data_ptr_t dataptr, T value) {
 		throw NotImplementedException("Cannot create data from this type");
@@ -177,7 +168,7 @@ void Radix::EncodeSigned(data_ptr_t dataptr, T value) {
 	using UNSIGNED = typename MakeUnsigned<T>::type;
 	UNSIGNED bytes;
 	Store<T>(value, data_ptr_cast(&bytes));
-	Store<UNSIGNED>(BSwap(bytes), dataptr);
+	Store<UNSIGNED>(BSwapIfLE(bytes), dataptr);
 	dataptr[0] = FlipSign(dataptr[0]);
 }
 
@@ -208,17 +199,17 @@ inline void Radix::EncodeData(data_ptr_t dataptr, uint8_t value) {
 
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, uint16_t value) {
-	Store<uint16_t>(BSwap(value), dataptr);
+	Store<uint16_t>(BSwapIfLE(value), dataptr);
 }
 
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, uint32_t value) {
-	Store<uint32_t>(BSwap(value), dataptr);
+	Store<uint32_t>(BSwapIfLE(value), dataptr);
 }
 
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, uint64_t value) {
-	Store<uint64_t>(BSwap(value), dataptr);
+	Store<uint64_t>(BSwapIfLE(value), dataptr);
 }
 
 template <>
@@ -236,13 +227,13 @@ inline void Radix::EncodeData(data_ptr_t dataptr, uhugeint_t value) {
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, float value) {
 	uint32_t converted_value = EncodeFloat(value);
-	Store<uint32_t>(BSwap(converted_value), dataptr);
+	Store<uint32_t>(BSwapIfLE(converted_value), dataptr);
 }
 
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, double value) {
 	uint64_t converted_value = EncodeDouble(value);
-	Store<uint64_t>(BSwap(converted_value), dataptr);
+	Store<uint64_t>(BSwapIfLE(converted_value), dataptr);
 }
 
 template <>
@@ -266,7 +257,7 @@ T Radix::DecodeSigned(const_data_ptr_t input) {
 	auto bytes_data = data_ptr_cast(&bytes);
 	bytes_data[0] = FlipSign(bytes_data[0]);
 	T result;
-	Store<UNSIGNED>(BSwap(bytes), data_ptr_cast(&result));
+	Store<UNSIGNED>(BSwapIfLE(bytes), data_ptr_cast(&result));
 	return result;
 }
 
@@ -297,17 +288,17 @@ inline uint8_t Radix::DecodeData(const_data_ptr_t input) {
 
 template <>
 inline uint16_t Radix::DecodeData(const_data_ptr_t input) {
-	return BSwap(Load<uint16_t>(input));
+	return BSwapIfLE(Load<uint16_t>(input));
 }
 
 template <>
 inline uint32_t Radix::DecodeData(const_data_ptr_t input) {
-	return BSwap(Load<uint32_t>(input));
+	return BSwapIfLE(Load<uint32_t>(input));
 }
 
 template <>
 inline uint64_t Radix::DecodeData(const_data_ptr_t input) {
-	return BSwap(Load<uint64_t>(input));
+	return BSwapIfLE(Load<uint64_t>(input));
 }
 
 template <>
@@ -328,12 +319,12 @@ inline uhugeint_t Radix::DecodeData(const_data_ptr_t input) {
 
 template <>
 inline float Radix::DecodeData(const_data_ptr_t input) {
-	return DecodeFloat(BSwap(Load<uint32_t>(input)));
+	return DecodeFloat(BSwapIfLE(Load<uint32_t>(input)));
 }
 
 template <>
 inline double Radix::DecodeData(const_data_ptr_t input) {
-	return DecodeDouble(BSwap(Load<uint64_t>(input)));
+	return DecodeDouble(BSwapIfLE(Load<uint64_t>(input)));
 }
 
 template <>

--- a/src/include/duckdb/common/sorting/sort_key.hpp
+++ b/src/include/duckdb/common/sorting/sort_key.hpp
@@ -102,7 +102,7 @@ public:
 	void ByteSwap() {
 		auto &sort_key = static_cast<SORT_KEY &>(*this);
 		for (idx_t i = 0; i < SORT_KEY::PARTS; i++) {
-			(&sort_key.part0)[i] = BSwap((&sort_key.part0)[i]);
+			(&sort_key.part0)[i] = BSwapIfLE((&sort_key.part0)[i]);
 		}
 	}
 
@@ -172,7 +172,7 @@ public:
 	void ByteSwap() {
 		auto &sort_key = static_cast<SORT_KEY &>(*this);
 		for (idx_t i = 0; i < SORT_KEY::PARTS; i++) {
-			(&sort_key.part0)[i] = BSwap((&sort_key.part0)[i]);
+			(&sort_key.part0)[i] = BSwapIfLE((&sort_key.part0)[i]);
 		}
 	}
 

--- a/src/include/duckdb/common/types/bit.hpp
+++ b/src/include/duckdb/common/types/bit.hpp
@@ -101,8 +101,9 @@ template <class T>
 void Bit::NumericToBit(T numeric, bitstring_t &output_str) {
 	D_ASSERT(output_str.GetSize() >= sizeof(T) + 1);
 
+	auto le_numeric = BSwapIfBE(numeric);
 	auto output = output_str.GetDataWriteable();
-	auto data = const_data_ptr_cast(&numeric);
+	auto data = const_data_ptr_cast(&le_numeric);
 
 	*output = 0; // set padding to 0
 	++output;
@@ -141,6 +142,7 @@ void Bit::BitToNumeric(bitstring_t bit, T &output_num) {
 	for (idx_t idx = padded_byte_idx + 1; idx < sizeof(T); ++idx) {
 		output[sizeof(T) - 1 - idx] = data[1 + idx - padded_byte_idx];
 	}
+	output_num = BSwapIfBE(output_num);
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/assert.hpp"
+#include "duckdb/common/bswap.hpp"
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/numeric_utils.hpp"
@@ -194,22 +195,14 @@ public:
 			uint32_t a_prefix = Load<uint32_t>(const_data_ptr_cast(left.GetPrefix()));
 			uint32_t b_prefix = Load<uint32_t>(const_data_ptr_cast(right.GetPrefix()));
 
-			// Utility to move 0xa1b2c3d4 into 0xd4c3b2a1, basically inverting the order byte-a-byte
-			auto byte_swap = [](uint32_t v) -> uint32_t {
-				uint32_t t1 = (v >> 16u) | (v << 16u);
-				uint32_t t2 = t1 & 0x00ff00ff;
-				uint32_t t3 = t1 & 0xff00ff00;
-				return (t2 << 8u) | (t3 >> 8u);
-			};
-
 			// Check on prefix -----
-			// We dont' need to mask since:
+			// We don't need to mask since:
 			//	if the prefix is greater(after bswap), it will stay greater regardless of the extra bytes
 			// 	if the prefix is smaller(after bswap), it will stay smaller regardless of the extra bytes
 			//	if the prefix is equal, the extra bytes are guaranteed to be /0 for the shorter one
 
 			if (a_prefix != b_prefix) {
-				return byte_swap(a_prefix) > byte_swap(b_prefix);
+				return BSwapIfLE(a_prefix) > BSwapIfLE(b_prefix);
 			}
 #endif
 			auto memcmp_res = memcmp(left.GetData(), right.GetData(), min_length);

--- a/src/include/duckdb/main/capi/cast/from_decimal.hpp
+++ b/src/include/duckdb/main/capi/cast/from_decimal.hpp
@@ -20,22 +20,21 @@ bool CastDecimalCInternal(duckdb_result *source, RESULT_TYPE &result, idx_t col,
 	auto &source_type = query_result->types[col];
 	auto width = duckdb::DecimalType::GetWidth(source_type);
 	auto scale = duckdb::DecimalType::GetScale(source_type);
-	void *source_address = UnsafeFetchPtr<hugeint_t>(source, col, row);
-
+	auto source_value = UnsafeFetch<hugeint_t>(source, col, row);
 	CastParameters parameters;
 	switch (source_type.InternalType()) {
 	case duckdb::PhysicalType::INT16:
-		return duckdb::TryCastFromDecimal::Operation<int16_t, RESULT_TYPE>(UnsafeFetchFromPtr<int16_t>(source_address),
-		                                                                   result, parameters, width, scale);
+		return duckdb::TryCastFromDecimal::Operation<int16_t, RESULT_TYPE>(static_cast<int16_t>(source_value), result,
+		                                                                   parameters, width, scale);
 	case duckdb::PhysicalType::INT32:
-		return duckdb::TryCastFromDecimal::Operation<int32_t, RESULT_TYPE>(UnsafeFetchFromPtr<int32_t>(source_address),
-		                                                                   result, parameters, width, scale);
+		return duckdb::TryCastFromDecimal::Operation<int32_t, RESULT_TYPE>(static_cast<int32_t>(source_value), result,
+		                                                                   parameters, width, scale);
 	case duckdb::PhysicalType::INT64:
-		return duckdb::TryCastFromDecimal::Operation<int64_t, RESULT_TYPE>(UnsafeFetchFromPtr<int64_t>(source_address),
-		                                                                   result, parameters, width, scale);
+		return duckdb::TryCastFromDecimal::Operation<int64_t, RESULT_TYPE>(static_cast<int64_t>(source_value), result,
+		                                                                   parameters, width, scale);
 	case duckdb::PhysicalType::INT128:
-		return duckdb::TryCastFromDecimal::Operation<hugeint_t, RESULT_TYPE>(
-		    UnsafeFetchFromPtr<hugeint_t>(source_address), result, parameters, width, scale);
+		return duckdb::TryCastFromDecimal::Operation<hugeint_t, RESULT_TYPE>(source_value, result, parameters, width,
+		                                                                     scale);
 	default:
 		throw duckdb::InternalException("Unimplemented internal type for decimal");
 	}

--- a/src/main/capi/cast/from_decimal-c.cpp
+++ b/src/main/capi/cast/from_decimal-c.cpp
@@ -13,23 +13,22 @@ bool CastDecimalCInternal(duckdb_result *source, duckdb_string &result, idx_t co
 	auto scale = duckdb::DecimalType::GetScale(source_type);
 	duckdb::Vector result_vec(duckdb::LogicalType::VARCHAR, false, false);
 	duckdb::string_t result_string;
-	void *source_address = UnsafeFetchPtr<hugeint_t>(source, col, row);
+	auto source_value = UnsafeFetch<hugeint_t>(source, col, row);
 	switch (source_type.InternalType()) {
 	case duckdb::PhysicalType::INT16:
-		result_string = duckdb::StringCastFromDecimal::Operation<int16_t>(UnsafeFetchFromPtr<int16_t>(source_address),
-		                                                                  width, scale, result_vec);
+		result_string = duckdb::StringCastFromDecimal::Operation<int16_t>(static_cast<int16_t>(source_value), width,
+		                                                                  scale, result_vec);
 		break;
 	case duckdb::PhysicalType::INT32:
-		result_string = duckdb::StringCastFromDecimal::Operation<int32_t>(UnsafeFetchFromPtr<int32_t>(source_address),
-		                                                                  width, scale, result_vec);
+		result_string = duckdb::StringCastFromDecimal::Operation<int32_t>(static_cast<int32_t>(source_value), width,
+		                                                                  scale, result_vec);
 		break;
 	case duckdb::PhysicalType::INT64:
-		result_string = duckdb::StringCastFromDecimal::Operation<int64_t>(UnsafeFetchFromPtr<int64_t>(source_address),
-		                                                                  width, scale, result_vec);
+		result_string = duckdb::StringCastFromDecimal::Operation<int64_t>(static_cast<int64_t>(source_value), width,
+		                                                                  scale, result_vec);
 		break;
 	case duckdb::PhysicalType::INT128:
-		result_string = duckdb::StringCastFromDecimal::Operation<hugeint_t>(
-		    UnsafeFetchFromPtr<hugeint_t>(source_address), width, scale, result_vec);
+		result_string = duckdb::StringCastFromDecimal::Operation<hugeint_t>(source_value, width, scale, result_vec);
 		break;
 	default:
 		throw duckdb::InternalException("Unimplemented internal type for decimal");
@@ -48,10 +47,11 @@ duckdb_hugeint FetchInternals(void *source_address) {
 
 template <>
 duckdb_hugeint FetchInternals<int16_t>(void *source_address) {
+	const int16_t source_value = static_cast<int16_t>(UnsafeFetchFromPtr<int64_t>(source_address));
 	duckdb_hugeint result;
 	int16_t intermediate_result;
 
-	if (!TryCast::Operation<int16_t, int16_t>(UnsafeFetchFromPtr<int16_t>(source_address), intermediate_result)) {
+	if (!TryCast::Operation<int16_t, int16_t>(source_value, intermediate_result)) {
 		intermediate_result = FetchDefaultValue::Operation<int16_t>();
 	}
 	hugeint_t hugeint_result = Hugeint::Cast<int16_t>(intermediate_result);
@@ -61,10 +61,11 @@ duckdb_hugeint FetchInternals<int16_t>(void *source_address) {
 }
 template <>
 duckdb_hugeint FetchInternals<int32_t>(void *source_address) {
+	const int32_t source_value = static_cast<int32_t>(UnsafeFetchFromPtr<int64_t>(source_address));
 	duckdb_hugeint result;
 	int32_t intermediate_result;
 
-	if (!TryCast::Operation<int32_t, int32_t>(UnsafeFetchFromPtr<int32_t>(source_address), intermediate_result)) {
+	if (!TryCast::Operation<int32_t, int32_t>(source_value, intermediate_result)) {
 		intermediate_result = FetchDefaultValue::Operation<int32_t>();
 	}
 	hugeint_t hugeint_result = Hugeint::Cast<int32_t>(intermediate_result);
@@ -74,10 +75,11 @@ duckdb_hugeint FetchInternals<int32_t>(void *source_address) {
 }
 template <>
 duckdb_hugeint FetchInternals<int64_t>(void *source_address) {
+	const int64_t source_value = UnsafeFetchFromPtr<int64_t>(source_address);
 	duckdb_hugeint result;
 	int64_t intermediate_result;
 
-	if (!TryCast::Operation<int64_t, int64_t>(UnsafeFetchFromPtr<int64_t>(source_address), intermediate_result)) {
+	if (!TryCast::Operation<int64_t, int64_t>(source_value, intermediate_result)) {
 		intermediate_result = FetchDefaultValue::Operation<int64_t>();
 	}
 	hugeint_t hugeint_result = Hugeint::Cast<int64_t>(intermediate_result);
@@ -87,10 +89,11 @@ duckdb_hugeint FetchInternals<int64_t>(void *source_address) {
 }
 template <>
 duckdb_hugeint FetchInternals<hugeint_t>(void *source_address) {
+	const hugeint_t source_value = UnsafeFetchFromPtr<hugeint_t>(source_address);
 	duckdb_hugeint result;
 	hugeint_t intermediate_result;
 
-	if (!TryCast::Operation<hugeint_t, hugeint_t>(UnsafeFetchFromPtr<hugeint_t>(source_address), intermediate_result)) {
+	if (!TryCast::Operation<hugeint_t, hugeint_t>(source_value, intermediate_result)) {
 		intermediate_result = FetchDefaultValue::Operation<hugeint_t>();
 	}
 	result.lower = intermediate_result.lower;

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -71,7 +71,7 @@ static bitpacking_metadata_encoded_t EncodeMeta(bitpacking_metadata_t metadata) 
 }
 static bitpacking_metadata_t DecodeMeta(bitpacking_metadata_encoded_t *metadata_encoded) {
 	bitpacking_metadata_t metadata;
-	metadata.mode = Load<BitpackingMode>(data_ptr_cast(metadata_encoded) + 3);
+	metadata.mode = static_cast<BitpackingMode>((*metadata_encoded >> 24) & 0xFF);
 	metadata.offset = *metadata_encoded & 0x00FFFFFF;
 	return metadata;
 }

--- a/src/storage/index.cpp
+++ b/src/storage/index.cpp
@@ -7,9 +7,6 @@ namespace duckdb {
 Index::Index(const vector<column_t> &column_ids, TableIOManager &table_io_manager, AttachedDatabase &db)
 
     : column_ids(column_ids), table_io_manager(table_io_manager), db(db) {
-	if (!Radix::IsLittleEndian()) {
-		throw NotImplementedException("indexes are not supported on big endian architectures");
-	}
 	// create the column id set
 	column_id_set.insert(column_ids.begin(), column_ids.end());
 }

--- a/test/api/capi/test_capi_appender.cpp
+++ b/test/api/capi/test_capi_appender.cpp
@@ -157,7 +157,7 @@ TEST_CASE("Test NULL struct Appender", "[capi]") {
 	auto second_child_vector = duckdb_struct_vector_get_child(struct_vector, 1);
 
 	// set two values
-	auto first_child_ptr = (int64_t *)duckdb_vector_get_data(first_child_vector);
+	auto first_child_ptr = static_cast<int32_t *>(duckdb_vector_get_data(first_child_vector));
 	*first_child_ptr = 42;
 	duckdb_vector_assign_string_element(second_child_vector, 0, "hello");
 

--- a/test/arrow/arrow_test_helper.cpp
+++ b/test/arrow/arrow_test_helper.cpp
@@ -172,7 +172,7 @@ bool ArrowTestHelper::CompareResults(Connection &con, unique_ptr<QueryResult> ar
 		for (idx_t i = 0; i < materialized_arrow.types.size(); i++) {
 			if (materialized_arrow.types[i] != duck->types[i] && duck->types[i].id() != LogicalTypeId::ENUM) {
 				mismatch_error = true;
-				error_msg << "Column " << i << "mismatch. DuckDB: '" << duck->types[i].ToString() << "'. Arrow '"
+				error_msg << "Column " << i << " mismatch. DuckDB: '" << duck->types[i].ToString() << "'. Arrow '"
 				          << materialized_arrow.types[i].ToString() << "'\n";
 			}
 		}


### PR DESCRIPTION
I'm aware that big-endian platforms are officially not supported, but as far as I see from the [previous](https://github.com/duckdb/duckdb/issues/5548) [discussions](https://github.com/duckdb/duckdb/issues/9714), patches are welcome.

The PR fixes major big-endian related issues, which include the areas:
- sorting and ART indices;
- numeric conversion in C API;
- arrow UUID conversion;
- bit-packing;
- BIT conversion.

The intention was to do it in the least invasive way possible, even if it means slightly suboptimal logic for big-endian path.
Please let me know if you want me to split it to several PRs.

The PR doesn't fix known big-endian issues with these:
- GEOMETRY;
- storage file portability;
- parquet;
- optional extensions.

If the PR is merged, they will be fixed in the next one.

Related issues: #9714, #5548.