### PR TITLE
fix bug in generate_grammar script

### DIFF
--- a/scripts/generate_grammar.py
+++ b/scripts/generate_grammar.py
@@ -101,7 +101,8 @@ for kw in reserved_keywords:
     kwdict[kw] = 'RESERVED_KEYWORD'
 
 kwlist = [(x, kwdict[x]) for x in kwdict.keys()]
-kwlist.sort(key=lambda x: strip_p(x[0]))
+# sorting uppercase is different from lowercase: A-Z < _ < a-z
+kwlist.sort(key=lambda x: strip_p(x[0].lower()))
 
 # now generate kwlist.h
 # PG_KEYWORD("abort", ABORT_P, UNRESERVED_KEYWORD)


### PR DESCRIPTION
Hi everyone,

there is a small bug in the `generate_grammar.py` script. 

In the python script, keywords are sorted being uppercase. However bison/c++ seems to work with lowercase sorting. Since `[A-Z] < _ < [a-z]` that can result in different "sorting" or looking for keywords containing underscores. With the wrong order enforced by the script, the parser is actually never able to match keywords that contain an underscore. (I realised this when working on the `MATCH_RECOGNIZE` grammar.)

It's a corner case since keywords with underscore are extremely rare. But an easy fix. :)