### PR TITLE
Issue #19647: Constant Window Allocators

### DIFF
--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -953,11 +953,6 @@ void WindowGlobalSourceState::FinishTask(TaskPtr task) {
 
 bool WindowLocalSourceState::TryAssignTask() {
 	D_ASSERT(TaskFinished());
-	if (task && task->stage == WindowGroupStage::GETDATA) {
-		// If this state completed the last block in the previous iteration,
-		// release our local state memory.
-		ReleaseLocalStates();
-	}
 	// Because downstream operators may be using our internal buffers,
 	// we can't "finish" a task until we are about to get the next one.
 

--- a/src/function/window/window_aggregate_states.cpp
+++ b/src/function/window/window_aggregate_states.cpp
@@ -2,8 +2,9 @@
 
 namespace duckdb {
 
-WindowAggregateStates::WindowAggregateStates(const AggregateObject &aggr)
-    : aggr(aggr), state_size(aggr.function.state_size(aggr.function)), allocator(Allocator::DefaultAllocator()) {
+WindowAggregateStates::WindowAggregateStates(ClientContext &client, const AggregateObject &aggr)
+    : client(client), aggr(aggr), state_size(aggr.function.state_size(aggr.function)),
+      allocator(Allocator::Get(client)) {
 }
 
 void WindowAggregateStates::Initialize(idx_t count) {
@@ -25,7 +26,7 @@ void WindowAggregateStates::Initialize(idx_t count) {
 	statef->SetVectorType(VectorType::FLAT_VECTOR);
 }
 
-void WindowAggregateStates::Combine(WindowAggregateStates &target, AggregateCombineType combine_type) {
+void WindowAggregateStates::Combine(WindowAggregateStates &target) {
 	AggregateInputData aggr_input_data(aggr.GetFunctionData(), allocator, AggregateCombineType::ALLOW_DESTRUCTIVE);
 	aggr.function.combine(*statef, *target.statef, aggr_input_data, GetCount());
 }

--- a/src/function/window/window_constant_aggregator.cpp
+++ b/src/function/window/window_constant_aggregator.cpp
@@ -30,11 +30,11 @@ public:
 	unique_ptr<Vector> results;
 };
 
-WindowConstantAggregatorGlobalState::WindowConstantAggregatorGlobalState(ClientContext &context,
+WindowConstantAggregatorGlobalState::WindowConstantAggregatorGlobalState(ClientContext &client,
                                                                          const WindowConstantAggregator &aggregator,
                                                                          idx_t group_count,
                                                                          const ValidityMask &partition_mask)
-    : WindowAggregatorGlobalState(context, aggregator, STANDARD_VECTOR_SIZE), statef(aggr) {
+    : WindowAggregatorGlobalState(client, aggregator, STANDARD_VECTOR_SIZE), statef(client, aggr) {
 	// Locate the partition boundaries
 	if (partition_mask.AllValid()) {
 		partition_offsets.emplace_back(0);
@@ -103,8 +103,8 @@ public:
 
 WindowConstantAggregatorLocalState::WindowConstantAggregatorLocalState(
     ExecutionContext &context, const WindowConstantAggregatorGlobalState &gstate)
-    : WindowAggregatorLocalState(context), gstate(gstate), statep(Value::POINTER(0)), statef(gstate.statef.aggr),
-      partition(0) {
+    : WindowAggregatorLocalState(context), gstate(gstate), statep(Value::POINTER(0)),
+      statef(context.client, gstate.statef.aggr), partition(0) {
 	matches.Initialize();
 
 	//	Start the aggregates
@@ -113,7 +113,7 @@ WindowConstantAggregatorLocalState::WindowConstantAggregatorLocalState(
 	statef.Initialize(partition_offsets.size() - 1);
 
 	// Set up shared buffer
-	inputs.Initialize(Allocator::DefaultAllocator(), aggregator.arg_types);
+	inputs.Initialize(context.client, aggregator.arg_types);
 	payload_chunk.InitializeEmpty(inputs.GetTypes());
 
 	gstate.locals++;
@@ -237,7 +237,7 @@ void WindowConstantAggregatorLocalState::Sink(ExecutionContext &context, DataChu
 		payload_chunk.data[c].Reference(sink_chunk.data[child_idx[c]]);
 	}
 
-	AggregateInputData aggr_input_data(aggr.GetFunctionData(), allocator);
+	AggregateInputData aggr_input_data(aggr.GetFunctionData(), statef.allocator);
 	idx_t begin = 0;
 	idx_t filter_idx = 0;
 	auto partition_end = partition_offsets[partition + 1];

--- a/src/function/window/window_constant_aggregator.cpp
+++ b/src/function/window/window_constant_aggregator.cpp
@@ -22,14 +22,6 @@ public:
 		statef.Destroy();
 	}
 
-	void Finalize() {
-		//	Make sure the memory from the local state is not still in use
-		const auto source_count = partition_offsets.size() - 1;
-		Vector source(aggregator.result_type, source_count);
-		statef.Finalize(source);
-		VectorOperations::Copy(source, *results, source_count, 0, 0);
-	}
-
 	//! Partition starts
 	vector<idx_t> partition_offsets;
 	//! Reused result state container for the window functions
@@ -322,7 +314,7 @@ void WindowConstantAggregator::Finalize(ExecutionContext &context, CollectionPtr
 	lastate.statef.Destroy();
 
 	if (!--gastate.locals) {
-		gastate.Finalize();
+		gastate.statef.Finalize(*gastate.results);
 	}
 }
 

--- a/src/function/window/window_constant_aggregator.cpp
+++ b/src/function/window/window_constant_aggregator.cpp
@@ -22,6 +22,14 @@ public:
 		statef.Destroy();
 	}
 
+	void Finalize() {
+		//	Make sure the memory from the local state is not still in use
+		const auto source_count = partition_offsets.size() - 1;
+		Vector source(aggregator.result_type, source_count);
+		statef.Finalize(source);
+		VectorOperations::Copy(source, *results, source_count, 0, 0);
+	}
+
 	//! Partition starts
 	vector<idx_t> partition_offsets;
 	//! Reused result state container for the window functions
@@ -314,7 +322,7 @@ void WindowConstantAggregator::Finalize(ExecutionContext &context, CollectionPtr
 	lastate.statef.Destroy();
 
 	if (!--gastate.locals) {
-		gastate.statef.Finalize(*gastate.results);
+		gastate.Finalize();
 	}
 }
 

--- a/src/function/window/window_distinct_aggregator.cpp
+++ b/src/function/window/window_distinct_aggregator.cpp
@@ -123,7 +123,7 @@ WindowDistinctAggregatorGlobalState::WindowDistinctAggregatorGlobalState(ClientC
                                                                          const WindowDistinctAggregator &aggregator,
                                                                          idx_t group_count)
     : WindowAggregatorGlobalState(client, aggregator, group_count), stage(WindowDistinctSortStage::INIT),
-      tasks_assigned(0), tasks_completed(0), merge_sort_tree(*this, group_count), levels_flat_native(aggr) {
+      tasks_assigned(0), tasks_completed(0), merge_sort_tree(*this, group_count), levels_flat_native(client, aggr) {
 	//	1:	functionComputePrevIdcs(𝑖𝑛)
 	//	2:		sorted ← []
 	//	We sort the aggregate arguments and use the partition index as a tie-breaker.
@@ -135,7 +135,7 @@ WindowDistinctAggregatorGlobalState::WindowDistinctAggregatorGlobalState(ClientC
 	vector<BoundOrderByNode> orders;
 	for (const auto &type : sort_types) {
 		auto expr = make_uniq<BoundReferenceExpression>(type, orders.size());
-		orders.emplace_back(BoundOrderByNode(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST, std::move(expr)));
+		orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST, std::move(expr));
 		sort_cols.emplace_back(sort_cols.size());
 	}
 
@@ -237,7 +237,7 @@ WindowDistinctAggregatorLocalState::WindowDistinctAggregatorLocalState(
     ExecutionContext &context, const WindowDistinctAggregatorGlobalState &gdstate)
     : WindowAggregatorLocalState(context), tree_allocator(gdstate.CreateTreeAllocator()),
       update_v(LogicalType::POINTER), source_v(LogicalType::POINTER), target_v(LogicalType::POINTER), gdstate(gdstate),
-      statef(gdstate.aggr), statep(LogicalType::POINTER), statel(LogicalType::POINTER), flush_count(0) {
+      statef(context.client, gdstate.aggr), statep(LogicalType::POINTER), statel(LogicalType::POINTER), flush_count(0) {
 	InitSubFrames(frames, gdstate.aggregator.exclude_mode);
 
 	sort_chunk.Initialize(Allocator::DefaultAllocator(), gdstate.sort_types);

--- a/src/function/window/window_segment_tree.cpp
+++ b/src/function/window/window_segment_tree.cpp
@@ -294,9 +294,9 @@ void WindowSegmentTreePart::Finalize(Vector &result, idx_t count) {
 	}
 }
 
-WindowSegmentTreeGlobalState::WindowSegmentTreeGlobalState(ClientContext &context, const WindowSegmentTree &aggregator,
+WindowSegmentTreeGlobalState::WindowSegmentTreeGlobalState(ClientContext &client, const WindowSegmentTree &aggregator,
                                                            idx_t group_count)
-    : WindowAggregatorGlobalState(context, aggregator, group_count), tree(aggregator), levels_flat_native(aggr) {
+    : WindowAggregatorGlobalState(client, aggregator, group_count), tree(aggregator), levels_flat_native(client, aggr) {
 	D_ASSERT(!aggregator.wexpr.children.empty());
 
 	// compute space required to store internal nodes of segment tree

--- a/src/include/duckdb/function/window/window_aggregate_states.hpp
+++ b/src/include/duckdb/function/window/window_aggregate_states.hpp
@@ -13,7 +13,7 @@
 namespace duckdb {
 
 struct WindowAggregateStates {
-	explicit WindowAggregateStates(const AggregateObject &aggr);
+	WindowAggregateStates(ClientContext &client, const AggregateObject &aggr);
 	~WindowAggregateStates() {
 		Destroy();
 	}
@@ -34,13 +34,14 @@ struct WindowAggregateStates {
 	//! Initialise all the states
 	void Initialize(idx_t count);
 	//! Combine the states into the target
-	void Combine(WindowAggregateStates &target,
-	             AggregateCombineType combine_type = AggregateCombineType::PRESERVE_INPUT);
+	void Combine(WindowAggregateStates &target);
 	//! Finalize the states into an output vector
 	void Finalize(Vector &result);
 	//! Destroy the states
 	void Destroy();
 
+	//! The context to use for memory etc.
+	ClientContext &client;
 	//! A description of the aggregator
 	const AggregateObject aggr;
 	//! The size of each state

--- a/test/configs/enable_verification.json
+++ b/test/configs/enable_verification.json
@@ -114,7 +114,8 @@
         "test/sql/copy/parquet/union_by_name_hive_partitioning.test",
         "test/sql/optimizer/test_in_rewrite_rule.test",
         "test/sql/storage/compression/rle/rle_constant.test",
-        "test/sql/types/geo/geometry_stats.test"
+        "test/sql/types/geo/geometry_stats.test",
+        "test/sql/window/test_window_constant_allocator.test"
       ]
     },
     {

--- a/test/sql/window/test_window_constant_allocator.test
+++ b/test/sql/window/test_window_constant_allocator.test
@@ -1,0 +1,27 @@
+# name: test/sql/window/test_window_constant_allocator.test
+# description: Test "constant" aggregation allocator usage
+# group: [window]
+
+# Test ArenaAllocation usage
+# Original issue was an assertion failure, 
+# but the output is unstable under multi-theading 
+# because STRING_AGG is order-sensitive.
+statement ok
+WITH cte AS (
+    SELECT 1 AS ext
+    UNION ALL
+    SELECT 2
+    UNION ALL
+    SELECT 3
+    UNION ALL
+    SELECT 4
+)
+SELECT
+    CASE
+        WHEN ext % 2 = 0 THEN 'even'
+        ELSE 'odd'
+        END AS pred,
+    TRUE AS eof,
+    CAST(NULL AS BOOLEAN) AS converter,
+    STRING_AGG(cte.ext, 'abc') OVER () AS str_agg
+FROM cte;


### PR DESCRIPTION
* Use the correct ArenaAllocator in Sink.
* Prevent enable_verification in new unstable test.
* Don't release hash group local memory until the group is completely done.

fixes: duckdb/duckdb#19647
fixes: duckdblabs/duckdb-internal#6471