### PR TITLE
Add Seek() to TupleDataCollection for IEJoin optimization

### DIFF
--- a/src/common/types/row/tuple_data_collection.cpp
+++ b/src/common/types/row/tuple_data_collection.cpp
@@ -623,6 +623,43 @@ bool TupleDataCollection::Scan(TupleDataParallelScanState &gstate, TupleDataLoca
 	return true;
 }
 
+idx_t TupleDataCollection::Seek(TupleDataScanState &state, const idx_t target_chunk) {
+	D_ASSERT(state.pin_state.properties == TupleDataPinProperties::UNPIN_AFTER_DONE);
+	state.pin_state.row_handles.clear();
+	state.pin_state.heap_handles.clear();
+
+	// early return for empty collection
+	if (segments.empty()) {
+		return 0;
+	}
+
+	idx_t current_chunk = 0;
+	idx_t total_rows = 0;
+	for (idx_t seg_idx = 0; seg_idx < segments.size(); seg_idx++) {
+		auto &segment = segments[seg_idx];
+		idx_t chunk_count = segment->ChunkCount();
+
+		if (current_chunk + chunk_count <= target_chunk) {
+			total_rows += segment->count;
+			current_chunk += chunk_count;
+		} else {
+			idx_t chunk_idx_in_segment = target_chunk - current_chunk;
+			for (idx_t chunk_idx = 0; chunk_idx < chunk_idx_in_segment; chunk_idx++) {
+				total_rows += segment->chunks[chunk_idx]->count;
+			}
+			current_chunk += chunk_count;
+
+			// reset scan state to target segment
+			state.segment_index = seg_idx;
+			state.chunk_index = chunk_idx_in_segment;
+			break;
+		}
+	}
+
+	D_ASSERT(target_chunk < current_chunk);
+	return total_rows;
+}
+
 bool TupleDataCollection::ScanComplete(const TupleDataScanState &state) const {
 	if (Count() == 0) {
 		return true;

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -381,13 +381,7 @@ idx_t IEJoinUnion::AppendKey(ExecutionContext &context, InterruptState &interrup
 
 	DataChunk scanned;
 	source.InitializeScanChunk(scanner, scanned);
-
-	// TODO: Random access into TupleDataCollection (NextScanIndex is private...)
-	idx_t table_idx = 0;
-	for (idx_t i = 0; i < chunk_begin; ++i) {
-		source.Scan(scanner, scanned);
-		table_idx += scanned.size();
-	}
+	idx_t table_idx = source.Seek(scanner, chunk_begin);
 
 	// Writing
 	auto &sort = *marked.sort;

--- a/src/include/duckdb/common/types/row/tuple_data_collection.hpp
+++ b/src/include/duckdb/common/types/row/tuple_data_collection.hpp
@@ -196,6 +196,8 @@ public:
 	bool Scan(TupleDataParallelScanState &gstate, TupleDataLocalScanState &lstate, DataChunk &result);
 	//! Whether the last scan has been completed on this TupleDataCollection
 	bool ScanComplete(const TupleDataScanState &state) const;
+	//! Seeks to the specified chunk index, returning the total row count before it
+	idx_t Seek(TupleDataScanState &state, const idx_t target_chunk);
 
 	//! Gathers a DataChunk from the TupleDataCollection, given the specific row locations (requires full pin)
 	void Gather(Vector &row_locations, const SelectionVector &scan_sel, const idx_t scan_count, DataChunk &result,


### PR DESCRIPTION
This PR adds a `Seek()` method on TupleDataCollection to support chunk positioning, which optimizes the `AppendKey` method in IEJoin.

The old way was scanning sequentially from chunk 0 up to `chunk_begin`. Each scan would pin a chunk to the buffer pool via `ScanAtIndex()` → `InitializeChunkState()`, then unpin it afterward (UNPIN_AFTER_DONE), which is a waste of I/O and buffer pool operations.

Now we seek to the target chunk by traversing segments and counting the rows without actual data scanning or touching the buffer pool, then return the total row count before the target chunk.