### PR TITLE
Bump iceberg to now default available extension

### DIFF
--- a/.github/config/extensions/iceberg.cmake
+++ b/.github/config/extensions/iceberg.cmake
@@ -8,6 +8,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG db7c01e9271bda329172872a204470893ea4eae1
+            GIT_TAG 5f5cd041285ab37b1eea9ec6d3bdda72a67fc1e4
             )
 endif()

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1045,6 +1045,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"http_retry_wait_ms", "httpfs"},
     {"http_timeout", "httpfs"},
     {"httpfs_client_implementation", "httpfs"},
+    {"iceberg_via_aws_sdk_for_catalog_interactions", "iceberg"},
     {"mysql_bit1_as_boolean", "mysql_scanner"},
     {"mysql_debug_show_queries", "mysql_scanner"},
     {"mysql_experimental_filter_pushdown", "mysql_scanner"},


### PR DESCRIPTION
This brings in a duckdb-iceberg PR moving default for doing catalog interactions on S3Tables from AWS's SDK to DuckDB own network stack: https://github.com/duckdb/duckdb-iceberg/pull/576.

This PR just bump iceberg in `v1.4-andium`, so that change is now encoded in the code.