### PR TITLE
Support reading pipes with `read_text`

### DIFF
--- a/src/common/pipe_file_system.cpp
+++ b/src/common/pipe_file_system.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/main/client_context.hpp"
 
@@ -51,6 +52,11 @@ int64_t PipeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes
 
 int64_t PipeFileSystem::GetFileSize(FileHandle &handle) {
 	return 0;
+}
+
+timestamp_t PipeFileSystem::GetLastModifiedTime(FileHandle &handle) {
+	auto &child_handle = *handle.Cast<PipeFile>().child_handle;
+	return child_handle.file_system.GetLastModifiedTime(child_handle);
 }
 
 void PipeFileSystem::FileSync(FileHandle &handle) {

--- a/src/common/serializer/memory_stream.cpp
+++ b/src/common/serializer/memory_stream.cpp
@@ -59,6 +59,12 @@ MemoryStream &MemoryStream::operator=(MemoryStream &&other) noexcept {
 }
 
 void MemoryStream::WriteData(const_data_ptr_t source, idx_t write_size) {
+	GrowCapacity(write_size);
+	memcpy(data + position, source, write_size);
+	position += write_size;
+}
+
+void MemoryStream::GrowCapacity(idx_t write_size) {
 	const auto old_capacity = capacity;
 	while (position + write_size > capacity) {
 		if (allocator) {
@@ -70,8 +76,6 @@ void MemoryStream::WriteData(const_data_ptr_t source, idx_t write_size) {
 	if (capacity != old_capacity) {
 		data = allocator->ReallocateData(data, old_capacity, capacity);
 	}
-	memcpy(data + position, source, write_size);
-	position += write_size;
 }
 
 void MemoryStream::ReadData(data_ptr_t destination, idx_t read_size) {

--- a/src/function/table/direct_file_reader.cpp
+++ b/src/function/table/direct_file_reader.cpp
@@ -98,9 +98,7 @@ AsyncResult DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionSt
 
 				// Initialize write stream if not yet done
 				if (!state.stream) {
-					// This needs to be initialized to at least 1
-					state.stream =
-					    make_uniq<MemoryStream>(BufferAllocator::Get(context), MaxValue<idx_t>(file_size, 1));
+					state.stream = make_uniq<MemoryStream>(BufferAllocator::Get(context), NextPowerOfTwo(file_size));
 				}
 				state.stream->Rewind();
 

--- a/src/function/table/direct_file_reader.cpp
+++ b/src/function/table/direct_file_reader.cpp
@@ -115,7 +115,7 @@ AsyncResult DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionSt
 						data_ptr_t read_ptr;
 						actually_read = NumericCast<idx_t>(bytes_to_read);
 						auto buffer_handle = file_handle->Read(read_ptr, actually_read);
-						state.stream->ReadData(read_ptr, actually_read);
+						state.stream->WriteData(read_ptr, actually_read);
 					} else {
 						// Local file: non-caching read
 						actually_read = NumericCast<idx_t>(file_handle->GetFileHandle().Read(

--- a/src/include/duckdb/common/pipe_file_system.hpp
+++ b/src/include/duckdb/common/pipe_file_system.hpp
@@ -20,6 +20,7 @@ public:
 	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 
 	int64_t GetFileSize(FileHandle &handle) override;
+	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
 
 	void Reset(FileHandle &handle) override;
 	bool OnDiskFile(FileHandle &handle) override {

--- a/src/include/duckdb/common/serializer/memory_stream.hpp
+++ b/src/include/duckdb/common/serializer/memory_stream.hpp
@@ -50,6 +50,7 @@ public:
 	//! Write data to the stream.
 	//! Throws if the write would exceed the capacity of the stream and the backing buffer is not owned by the stream
 	void WriteData(const_data_ptr_t buffer, idx_t write_size) override;
+	void GrowCapacity(idx_t write_size);
 
 	//! Read data from the stream.
 	//! Throws if the read would exceed the capacity of the stream

--- a/src/include/duckdb/function/table/read_file.hpp
+++ b/src/include/duckdb/function/table/read_file.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/multi_file/multi_file_function.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
 #include "utf8proc_wrapper.hpp"
 
 namespace duckdb {
@@ -29,6 +30,8 @@ struct ReadFileGlobalState : public GlobalTableFunctionState {
 	shared_ptr<MultiFileList> file_list;
 	vector<idx_t> column_ids;
 	bool requires_file_open = false;
+
+	unique_ptr<MemoryStream> stream;
 };
 
 } // namespace duckdb

--- a/tools/shell/tests/test_read_from_stdin.py
+++ b/tools/shell/tests/test_read_from_stdin.py
@@ -25,6 +25,7 @@ class TestReadFromStdin(object):
         result = test.run()
         result.check_stdout("len")
         result.check_stdout('77780')
+
     def test_read_stdin_csv(self, shell):
         test = (
             ShellTest(shell)

--- a/tools/shell/tests/test_read_from_stdin.py
+++ b/tools/shell/tests/test_read_from_stdin.py
@@ -10,6 +10,21 @@ import os
 
 @pytest.mark.skipif(os.name == 'nt', reason="Skipped on windows")
 class TestReadFromStdin(object):
+
+    def test_read_stdin_direct(self, shell):
+        test = (
+            ShellTest(shell)
+            .input_file('data/csv/test/test.csv')
+            .statement("""create table mytable as select * from read_text('/dev/stdin')""")
+            .statement("select length(content) as len from mytable;")
+            .add_argument(
+                '-csv',
+                ':memory:'
+            )
+        )
+        result = test.run()
+        result.check_stdout("len")
+        result.check_stdout('77780')
     def test_read_stdin_csv(self, shell):
         test = (
             ShellTest(shell)


### PR DESCRIPTION
This was not supported because the `DirectFileReader` could only read files for which the size was known beforehand. This PR allows these to be read in a streaming fashion using a `MemoryStream`. For non-pipe files, we already read in batches, so it was possible to unify these code paths.