### PR TITLE
Fix TopN Pruning Test

### DIFF
--- a/test/sql/topn/top_n_hard_limit.test
+++ b/test/sql/topn/top_n_hard_limit.test
@@ -13,7 +13,7 @@ USE db
 # 0 1 2 3 4 5 6 7 8 9	 ASC     DESC
 # [     ]              : 0       10240
 # [     ]              : 2       4097
-#   [     ]            : 4097    4097
+#   [       ]          : 4097    4097
 #         [   ]        : 8192    2049
 #               [ ]    : 10240   2048
 
@@ -24,7 +24,7 @@ statement ok
 INSERT INTO t SELECT 0 i UNION ALL SELECT i FROM repeat(3, 2047) t1(i)
 
 statement ok
-INSERT INTO t SELECT 1 i UNION ALL SELECT i FROM repeat(4, 2047) t1(i)
+INSERT INTO t SELECT 1 i UNION ALL SELECT i FROM repeat(5, 2047) t1(i)
 
 statement ok
 INSERT INTO t SELECT i FROM repeat(4, 2047) t1(i) UNION ALL SELECT 6 i
@@ -90,11 +90,6 @@ query II
 EXPLAIN ANALYZE SELECT * FROM t ORDER BY i DESC LIMIT 4097
 ----
 analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
-
-query II
-EXPLAIN ANALYZE SELECT * FROM t ORDER BY i DESC LIMIT 4098
-----
-analyzed_plan	<REGEX>:.*TABLE_SCAN.*10,240 rows.*
 
 statement ok
 INSERT INTO t SELECT 9 i UNION ALL SELECT i FROM repeat(NULL, 2046) t1(i) UNION ALL SELECT 10 i


### PR DESCRIPTION
There were two test cases in which the table scan's dynamic filter could prune additional row groups depending on the order of each thread's filter value update. The tests are now changed so that every unpruned row group contains at least one tuple of the result set to ensure consistent results with multi-threading.