### PR TITLE
Correctly use a lock when accessing the EncryptionKeyManager

### DIFF
--- a/src/common/encryption_key_manager.cpp
+++ b/src/common/encryption_key_manager.cpp
@@ -72,21 +72,25 @@ string EncryptionKeyManager::GenerateRandomKeyID() {
 }
 
 void EncryptionKeyManager::AddKey(const string &key_name, data_ptr_t key) {
+	lock_guard<mutex> guard(lock);
 	derived_keys.emplace(key_name, EncryptionKey(key));
 	// Zero-out the encryption key
 	duckdb_mbedtls::MbedTlsWrapper::AESStateMBEDTLS::SecureClearData(key, DERIVED_KEY_LENGTH);
 }
 
 bool EncryptionKeyManager::HasKey(const string &key_name) const {
+	lock_guard<mutex> guard(lock);
 	return derived_keys.find(key_name) != derived_keys.end();
 }
 
 const_data_ptr_t EncryptionKeyManager::GetKey(const string &key_name) const {
 	D_ASSERT(HasKey(key_name));
+	lock_guard<mutex> guard(lock);
 	return derived_keys.at(key_name).GetPtr();
 }
 
 void EncryptionKeyManager::DeleteKey(const string &key_name) {
+	lock_guard<mutex> guard(lock);
 	derived_keys.erase(key_name);
 }
 

--- a/src/include/duckdb/common/encryption_key_manager.hpp
+++ b/src/include/duckdb/common/encryption_key_manager.hpp
@@ -76,6 +76,7 @@ public:
 	static constexpr idx_t DERIVED_KEY_LENGTH = 32;
 
 private:
+	mutable mutex lock;
 	std::unordered_map<std::string, EncryptionKey> derived_keys;
 };
 

--- a/test/sql/copy/encryption/concurrent_encrypted_attach.test
+++ b/test/sql/copy/encryption/concurrent_encrypted_attach.test
@@ -1,0 +1,11 @@
+# name: test/sql/copy/encryption/concurrent_encrypted_attach.test
+# group: [encryption]
+
+require httpfs
+
+concurrentloop i 0 10
+
+statement ok
+ATTACH '__TEST_DIR__/concurrent_encrypted${i}.duckdb' AS encrypted${i} (ENCRYPTION_KEY 'asdf${i}');
+
+endloop


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/19754

When attaching encrypted databases in parallel through different connections we can access the encryption key cache in parallel, so we need a lock.