### PR TITLE
Respect collations in unique constraints (#19675)

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -43,10 +43,11 @@ IndexStorageInfo GetIndexInfo(const IndexConstraintType type, const bool v1_0_0_
 	return index_info;
 }
 
-static unique_ptr<CreateIndexInfo>
-CreateConstraintIndexInfo(const string &table_name, const string &schema_name, Catalog &catalog,
-                          const ColumnList &columns, const vector<LogicalIndex> &column_indexes,
-                          const string &index_name, IndexConstraintType constraint_type) {
+static unique_ptr<CreateIndexInfo> CreateConstraintIndexInfo(const string &table_name, const string &schema_name,
+                                                             Catalog &catalog, const ColumnList &columns,
+                                                             const vector<LogicalIndex> &column_indexes,
+                                                             const string &index_name,
+                                                             IndexConstraintType constraint_type) {
 	auto create_info = make_uniq<CreateIndexInfo>();
 	create_info->table = table_name;
 	create_info->schema = schema_name;

--- a/src/planner/collation_binding.cpp
+++ b/src/planner/collation_binding.cpp
@@ -57,12 +57,19 @@ bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source
 			// not a combinable collation - ignore
 			return false;
 		}
-		vector<unique_ptr<Expression>> children;
-		children.push_back(std::move(source));
+	string alias;
+	if (source) {
+		alias = source->GetAlias();
+	}
+	vector<unique_ptr<Expression>> children;
+	children.push_back(std::move(source));
 
-		FunctionBinder function_binder(context);
-		auto function = function_binder.BindScalarFunction(collation_entry.function, std::move(children));
-		source = std::move(function);
+	FunctionBinder function_binder(context);
+	auto function = function_binder.BindScalarFunction(collation_entry.function, std::move(children));
+	if (!alias.empty()) {
+		function->SetAlias(alias);
+	}
+	source = std::move(function);
 	}
 	return true;
 }
@@ -80,11 +87,18 @@ bool PushTimeTZCollation(ClientContext &context, unique_ptr<Expression> &source,
 		throw InternalException("timetz_byte_comparable should only have a single overload");
 	}
 	auto &scalar_function = function_entry.functions.GetFunctionReferenceByOffset(0);
+	string alias;
+	if (source) {
+		alias = source->GetAlias();
+	}
 	vector<unique_ptr<Expression>> children;
 	children.push_back(std::move(source));
 
 	FunctionBinder function_binder(context);
 	auto function = function_binder.BindScalarFunction(scalar_function, std::move(children));
+	if (!alias.empty()) {
+		function->SetAlias(alias);
+	}
 	source = std::move(function);
 	return true;
 }
@@ -101,11 +115,18 @@ bool PushIntervalCollation(ClientContext &context, unique_ptr<Expression> &sourc
 		throw InternalException("normalized_interval should only have a single overload");
 	}
 	auto &scalar_function = function_entry.functions.GetFunctionReferenceByOffset(0);
+	string alias;
+	if (source) {
+		alias = source->GetAlias();
+	}
 	vector<unique_ptr<Expression>> children;
 	children.push_back(std::move(source));
 
 	FunctionBinder function_binder(context);
 	auto function = function_binder.BindScalarFunction(scalar_function, std::move(children));
+	if (!alias.empty()) {
+		function->SetAlias(alias);
+	}
 	source = std::move(function);
 	return true;
 }

--- a/src/planner/collation_binding.cpp
+++ b/src/planner/collation_binding.cpp
@@ -57,19 +57,19 @@ bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source
 			// not a combinable collation - ignore
 			return false;
 		}
-	string alias;
-	if (source) {
-		alias = source->GetAlias();
-	}
-	vector<unique_ptr<Expression>> children;
-	children.push_back(std::move(source));
+		string alias;
+		if (source) {
+			alias = source->GetAlias();
+		}
+		vector<unique_ptr<Expression>> children;
+		children.push_back(std::move(source));
 
-	FunctionBinder function_binder(context);
-	auto function = function_binder.BindScalarFunction(collation_entry.function, std::move(children));
-	if (!alias.empty()) {
-		function->SetAlias(alias);
-	}
-	source = std::move(function);
+		FunctionBinder function_binder(context);
+		auto function = function_binder.BindScalarFunction(collation_entry.function, std::move(children));
+		if (!alias.empty()) {
+			function->SetAlias(alias);
+		}
+		source = std::move(function);
 	}
 	return true;
 }

--- a/src/planner/expression_binder/index_binder.cpp
+++ b/src/planner/expression_binder/index_binder.cpp
@@ -38,7 +38,11 @@ unique_ptr<BoundIndex> IndexBinder::BindIndex(const UnboundIndex &unbound_index)
 	unbound_expressions.reserve(parsed_expressions.size());
 	for (auto &expr : parsed_expressions) {
 		auto copy = expr->Copy();
-		unbound_expressions.push_back(Bind(copy));
+		auto bound_expr = Bind(copy);
+		if (bound_expr) {
+			ExpressionBinder::PushCollation(context, bound_expr, bound_expr->return_type);
+		}
+		unbound_expressions.push_back(std::move(bound_expr));
 	}
 
 	CreateIndexInput input(unbound_index.table_io_manager, unbound_index.db, create_info.constraint_type,

--- a/src/planner/expression_binder/index_binder.cpp
+++ b/src/planner/expression_binder/index_binder.cpp
@@ -88,7 +88,11 @@ unique_ptr<LogicalOperator> IndexBinder::BindCreateIndex(ClientContext &context,
 	// Bind the index expressions.
 	vector<unique_ptr<Expression>> expressions;
 	for (auto &expr : create_index_info->expressions) {
-		expressions.push_back(Bind(expr));
+		auto bound_expr = Bind(expr);
+		if (bound_expr) {
+			ExpressionBinder::PushCollation(context, bound_expr, bound_expr->return_type);
+		}
+		expressions.push_back(std::move(bound_expr));
 	}
 
 	auto &get = plan->Cast<LogicalGet>();

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -578,6 +578,7 @@ void DataTable::VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> stora
 
 	// Global constraint verification.
 	auto &data_table = table_entry.GetStorage();
+	data_table.BindIndexes(context);
 	data_table.info->indexes.VerifyForeignKey(storage, dst_keys_ptr, dst_chunk, global_conflict_manager);
 
 	// Check if we can insert the chunk into the local storage.

--- a/test/sql/constraints/unique_collation.test
+++ b/test/sql/constraints/unique_collation.test
@@ -26,3 +26,47 @@ query I
 SELECT str FROM unique_nocase;
 ----
 A
+
+# Explicit UNIQUE index should also respect collations specified in the index expression
+statement ok
+CREATE TABLE nocase_index_tbl(str VARCHAR);
+
+statement ok
+CREATE UNIQUE INDEX nocase_idx ON nocase_index_tbl((str COLLATE NOCASE));
+
+statement ok
+INSERT INTO nocase_index_tbl VALUES ('Hello');
+
+statement error
+INSERT INTO nocase_index_tbl VALUES ('hello');
+----
+<REGEX>:Constraint Error.*violates unique constraint.*
+
+query I
+SELECT COUNT(*) FROM nocase_index_tbl;
+----
+1
+
+# Multi-column UNIQUE constraints mix collated and non-collated columns
+statement ok
+CREATE TABLE multi_unique (
+    first VARCHAR COLLATE NOCASE,
+    second INTEGER,
+    UNIQUE(first, second)
+);
+
+statement ok
+INSERT INTO multi_unique VALUES ('Key', 1);
+
+statement ok
+INSERT INTO multi_unique VALUES ('key', 2);
+
+statement error
+INSERT INTO multi_unique VALUES ('KEY', 1);
+----
+<REGEX>:Constraint Error.*violates unique constraint.*
+
+query I
+SELECT COUNT(*) FROM multi_unique;
+----
+2

--- a/test/sql/constraints/unique_collation.test
+++ b/test/sql/constraints/unique_collation.test
@@ -1,0 +1,28 @@
+# name: test/sql/constraints/unique_collation.test
+# description: UNIQUE/PK constraints must honor column collations
+# group: [constraints]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE unique_nocase(str VARCHAR COLLATE NOCASE UNIQUE);
+
+statement ok
+INSERT INTO unique_nocase VALUES ('A');
+
+# The second insert should violate the UNIQUE constraint because NOCASE collation treats 'A' == 'a'
+statement error
+INSERT INTO unique_nocase VALUES ('a');
+----
+<REGEX>:Constraint Error.*violates unique constraint.*
+
+query I
+SELECT COUNT(*) FROM unique_nocase;
+----
+1
+
+query I
+SELECT str FROM unique_nocase;
+----
+A


### PR DESCRIPTION
Summary

  - Fixes Issue #19675, where UNIQUE/PK/FK constraints ignored column collations because we short-circuited index creation and never pushed the collation onto the index keys.
  - Constraint indexes now go through `CreateConstraintIndexInfo` → `AddConstraintIndex`, so they become real `UnboundIndex` objects and hit `IndexBinder` like normal indexes do.
  - `IndexBinder::BindIndex` and `IndexBinder::BindCreateIndex` both call `ExpressionBinder::PushCollation`, which means manual `CREATE INDEX … COLLATE …` finally behaves the same as constraint-backed indexes.
  - Collation wrappers keep the original alias, and we bind delayed indexes before FK checks or local-storage creation so nothing runs with a half-built index.
  - Added `test/sql/constraints/unique_collation.test` with three scenarios: column-level NOCASE + UNIQUE, explicit `CREATE UNIQUE INDEX (str COLLATE NOCASE)`, and a mixed multi-column UNIQUE. All of them now reject case-insensitive duplicates.

  Testing

  - `make allunit`