### PR TITLE
Wrap PhysicalOperator::GetData (virtual) into GetOperatorData (non virtual)

### DIFF
--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -476,7 +476,7 @@ SourceResultType PhysicalMergeInto::GetData(ExecutionContext &context, DataChunk
 		auto &child_lstate = *lstate.local_states[lstate.index];
 		OperatorSourceInput source_input {child_gstate, child_lstate, input.interrupt_state};
 
-		auto result = action.op->GetData(context, lstate.scan_chunk, source_input);
+		auto result = action.op->GetOperatorData(context, lstate.scan_chunk, source_input);
 		if (lstate.scan_chunk.size() > 0) {
 			// construct the result chunk
 			for (idx_t c = 0; c < lstate.scan_chunk.ColumnCount(); c++) {

--- a/src/execution/operator/scan/physical_positional_scan.cpp
+++ b/src/execution/operator/scan/physical_positional_scan.cpp
@@ -66,7 +66,7 @@ public:
 
 				InterruptState interrupt_state;
 				OperatorSourceInput source_input {global_state, *local_state, interrupt_state};
-				auto source_result = table.GetData(context, source, source_input);
+				auto source_result = table.GetOperatorData(context, source, source_input);
 				if (source_result == SourceResultType::BLOCKED) {
 					throw NotImplementedException(
 					    "Unexpected interrupt from table Source in PositionalTableScanner refill");

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -123,6 +123,11 @@ unique_ptr<GlobalSourceState> PhysicalOperator::GetGlobalSourceState(ClientConte
 }
 
 // LCOV_EXCL_START
+SourceResultType PhysicalOperator::GetOperatorData(ExecutionContext &context, DataChunk &chunk,
+                                                   OperatorSourceInput &input) const {
+	return GetData(context, chunk, input);
+}
+
 SourceResultType PhysicalOperator::GetData(ExecutionContext &context, DataChunk &chunk,
                                            OperatorSourceInput &input) const {
 	throw InternalException("Calling GetData on a node that is not a source!");

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -123,7 +123,12 @@ public:
 	virtual unique_ptr<LocalSourceState> GetLocalSourceState(ExecutionContext &context,
 	                                                         GlobalSourceState &gstate) const;
 	virtual unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const;
+
+private:
 	virtual SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const;
+
+public:
+	SourceResultType GetOperatorData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const;
 
 	virtual OperatorPartitionData GetPartitionData(ExecutionContext &context, DataChunk &chunk,
 	                                               GlobalSourceState &gstate, LocalSourceState &lstate,

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -502,7 +502,7 @@ SourceResultType PipelineExecutor::GetData(DataChunk &chunk, OperatorSourceInput
 	}
 #endif
 
-	return pipeline.source->GetData(context, chunk, input);
+	return pipeline.source->GetOperatorData(context, chunk, input);
 }
 
 SinkResultType PipelineExecutor::Sink(DataChunk &chunk, OperatorSinkInput &input) {


### PR DESCRIPTION
This allows a single entry point to add testing code, that would have caught issues such as https://github.com/duckdb/duckdb/issues/19741 earlier.

Basic example of such code would be:
```diff
diff --git a/src/execution/physical_operator.cpp b/src/execution/physical_operator.cpp
index 43f80a1363..fb5843ea24 100644
--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -125,6 +125,10 @@ unique_ptr<GlobalSourceState> PhysicalOperator::GetGlobalSourceState(ClientConte
 // LCOV_EXCL_START
 SourceResultType PhysicalOperator::GetOperatorData(ExecutionContext &context, DataChunk &chunk,
                                                    OperatorSourceInput &input) const {
+       if (rand() % 8) {
+               return SourceResultType::HAVE_MORE_OUTPUT;
+       }
+
        return GetData(context, chunk, input);
 }
 
```
That would allow to stress test more and find locations where there is the assumption that GetData return values is basically equivalent to `chunk.size() ? HAVE_MORE_OUTPUT : FINISHED`. Adding `BLOCKED` would also likely stress test the system more.

Implementation side moving `GetData` to private (still overloaded) and adding a public `GetOperatorData` that act as wrapper seems the more solid option, given there are few lines of code of changes, and if something fails, it fails at compile-time (say for extensions that might also be calling `GetData`).