### PR TITLE
Change back default strategy for debug_physical_table_scan_execution_strategy

### DIFF
--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -180,6 +180,8 @@ AsyncResultsExecutionMode
 AsyncResult::ConvertToAsyncResultExecutionMode(const PhysicalTableScanExecutionStrategy &execution_mode) {
 	switch (execution_mode) {
 	case PhysicalTableScanExecutionStrategy::DEFAULT:
+		// FIXME: Once PositionalJoin logic has been fixed, this needs to revert to be TASK_EXECUTOR by default
+		return AsyncResultsExecutionMode::SYNCHRONOUS;
 	case PhysicalTableScanExecutionStrategy::TASK_EXECUTOR:
 	case PhysicalTableScanExecutionStrategy::TASK_EXECUTOR_BUT_FORCE_SYNC_CHECKS:
 		return AsyncResultsExecutionMode::TASK_EXECUTOR;


### PR DESCRIPTION
This will need to be reverted once other fixes (uncovered by new task execution strategy but pre-existent) are in place

Fixes https://github.com/duckdb/duckdb/issues/19741, so that manual workaround are not needed anymore.