### PR TITLE
Specify shared deletion option on windows

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -994,7 +994,10 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 	flags.Verify();
 
 	DWORD desired_access;
-	DWORD share_mode;
+	// For windows platform, by default deletion fails when the file is accessed by other thread/process.
+	// To keep deletion behavior compatible with unix platform, which physically deletes a file when reference count
+	// drops to 0, open files with [`FILE_SHARE_DELETE`].
+	DWORD share_mode = FILE_SHARE_DELETE;
 	DWORD creation_disposition = OPEN_EXISTING;
 	DWORD flags_and_attributes = FILE_ATTRIBUTE_NORMAL;
 	bool open_read = flags.OpenForReading();

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1010,12 +1010,10 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 	}
 	switch (flags.Lock()) {
 	case FileLockType::NO_LOCK:
-		// Allow other handles to read, write, and delete while this handle is open
-		share_mode = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
+		share_mode = FILE_SHARE_READ | FILE_SHARE_WRITE;
 		break;
 	case FileLockType::READ_LOCK:
-		// Allow shared reads and deletion while this handle holds a read lock
-		share_mode = FILE_SHARE_READ | FILE_SHARE_DELETE;
+		share_mode = FILE_SHARE_READ;
 		break;
 	case FileLockType::WRITE_LOCK:
 		share_mode = 0;

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -996,7 +996,7 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 	DWORD desired_access;
 	// For windows platform, by default deletion fails when the file is accessed by other thread/process.
 	// To keep deletion behavior compatible with unix platform, which physically deletes a file when reference count
-	// drops to 0, open files with [`FILE_SHARE_DELETE`].
+	// drops to 0 without interfering with already opened file handles, open files with [`FILE_SHARE_DELETE`].
 	DWORD share_mode = FILE_SHARE_DELETE;
 	DWORD creation_disposition = OPEN_EXISTING;
 	DWORD flags_and_attributes = FILE_ATTRIBUTE_NORMAL;

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -242,3 +242,35 @@ TEST_CASE("re-register subsystem", "[file_system]") {
 	auto second_local_filesystem = FileSystem::CreateLocal();
 	REQUIRE_THROWS(vfs.RegisterSubSystem(std::move(second_local_filesystem)));
 }
+
+TEST_CASE("filesystem concurrent access and deletion", "[file_system]") {
+	auto fs = FileSystem::CreateLocal();
+
+	auto fname = TestCreatePath("concurrent_delete_test_file");
+	const string payload = "DELETE_WHILE_OPEN_CONTENT";
+
+	// Open first handle to create/write, then close it.
+	auto write_handle = fs->OpenFile(fname, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+	write_handle->Write(QueryContext(), static_cast<void *>(const_cast<char *>(payload.c_str())), payload.size(),
+	                    /*location=*/0);
+	write_handle->Sync();
+	write_handle.reset();
+	REQUIRE(fs->FileExists(fname));
+
+	// Open second handle for reading.
+	auto read_handle = fs->OpenFile(fname, FileFlags::FILE_FLAGS_READ);
+
+	// Delete the file while the read handle is still open.
+	fs->RemoveFile(fname);
+	REQUIRE(!fs->FileExists(fname));
+
+	// Reading from the already-open read handle should still return the content.
+	string read_back(payload.size(), '\0');
+	read_handle->Read(QueryContext(), static_cast<void *>(const_cast<char *>(read_back.data())), payload.size(),
+	                  /*location=*/0);
+	REQUIRE(read_back == payload);
+
+	// Close the remaining handle; the file should not exist.
+	read_handle.reset();
+	REQUIRE(!fs->FileExists(fname));
+}


### PR DESCRIPTION
Currently, the `RemoveFile` semantics is not very consistent across different platforms, in detail
- Internally, `std::remove` is invoked
- On unix platform, reference count is maintained for opened file handles, and deleted physically when ref count drops to 0
- On windows platform, with file opened with option, deletion attempts would fail

In this PR, I proposed to keep deletion behavior consistent, by adding shared deletion option on every file open on windows.
For more details, please refer to discussion thread: https://github.com/duckdb/duckdb/discussions/19735

Test script:
```c++
#include <windows.h>
#include <cstdio>

int main() {
    const wchar_t *path = L"C:\\Users\\Hao\\Desktop\\test_file.txt";

    // 1. Create a test file
    HANDLE hCreate = CreateFileW(
        path,
        GENERIC_WRITE,
        0,
        nullptr,
        CREATE_ALWAYS,
        FILE_ATTRIBUTE_NORMAL,
        nullptr
    );
    if (hCreate == INVALID_HANDLE_VALUE) {
        printf("Failed to create file\n");
        return 1;
    }
    const char *data = "Hello world\n";
    DWORD written;
    WriteFile(hCreate, data, (DWORD)strlen(data), &written, nullptr);
    CloseHandle(hCreate);

    // 2. Re-open with FILE_SHARE_DELETE
    HANDLE hFile = CreateFileW(
        path,
        GENERIC_READ,
        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,  // <-- IMPORTANT
        nullptr,
        OPEN_EXISTING,
        FILE_ATTRIBUTE_NORMAL,
        nullptr
    );
    if (hFile == INVALID_HANDLE_VALUE) {
        printf("Failed to open file with FILE_SHARE_DELETE\n");
        return 1;
    }

    printf("File opened with FILE_SHARE_DELETE.\n");

    // 3. Delete the file while it is still open
    int ret = std::remove("C:\\Users\\Hao\\Desktop\\test_file.txt");
    if (ret != 0) {
        printf("DeleteFileW failed\n");
    } else {
        printf("DeleteFileW SUCCEEDED while file was still open.\n");
    }

    // 4. Try reading after deletion
    char buffer[64];
    DWORD read = 0;
    BOOL read_ok = ReadFile(hFile, buffer, sizeof(buffer)-1, &read, nullptr);

    if (read_ok && read > 0) {
        buffer[read] = '\0';
        printf("Read after deletion: %s\n", buffer);
    } else {
        printf("Read after deletion failed or returned no data.\n");
    }

    Sleep(5000);

    // 5. Close the last handle → file is physically gone now
    CloseHandle(hFile);
    printf("Closed handle. After this, the file is truly deleted.\n");

    return 0;
}
```
- With `FILE_SHARE_DELETE` specified, `std::remove` succeeds and file being physically deleted; already opened file handles can still read the content with no problem
- Without such file open option, `std::remove` fails, with file left there untouched