### PR TITLE
Disable `sleep()` function if DuckDB isn't compiled with threads

### DIFF
--- a/extension/core_functions/scalar/debug/sleep.cpp
+++ b/extension/core_functions/scalar/debug/sleep.cpp
@@ -2,8 +2,11 @@
 
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
-#include <thread>
-#include <chrono>
+
+#include "duckdb/common/chrono.hpp"
+#ifndef DUCKDB_NO_THREADS
+#include "duckdb/common/thread.hpp"
+#endif
 
 namespace duckdb {
 
@@ -19,6 +22,7 @@ static void SleepFunction(DataChunk &input, ExpressionState &state, Vector &resu
 	input.Flatten();
 	GenericExecutor::ExecuteUnary<PrimitiveType<int64_t>, NullResultType>(
 	    input.data[0], result, input.size(), [](PrimitiveType<int64_t> input) {
+#ifndef DUCKDB_NO_THREADS
 		    // Sleep for the specified number of milliseconds (clamp negative values to 0)
 		    int64_t sleep_ms = input.val;
 		    if (sleep_ms < 0) {
@@ -26,6 +30,9 @@ static void SleepFunction(DataChunk &input, ExpressionState &state, Vector &resu
 		    }
 		    std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
 		    return NullResultType();
+#else
+	    	throw InvalidInputException("Function sleep() only available if DuckDB is compiled with threads");
+#endif
 	    });
 }
 

--- a/test/sql/function/generic/test_sleep.test
+++ b/test/sql/function/generic/test_sleep.test
@@ -126,7 +126,7 @@ statement ok
 CREATE OR REPLACE TABLE sleep_profiling_multi AS SELECT * FROM read_json('__TEST_DIR__/sleep_profiling_multi.json')
 
 query T
-SELECT cpu_time >= 0.05 AND cpu_time < 0.10 FROM sleep_profiling_multi WHERE contains(extra_info, 'sleep_ms') OR contains(query_name, 'sleep_ms') LIMIT 1
+SELECT cpu_time >= 0.04 AND cpu_time < 0.15 FROM sleep_profiling_multi WHERE contains(extra_info, 'sleep_ms') OR contains(query_name, 'sleep_ms') LIMIT 1
 ----
 true
 


### PR DESCRIPTION
And slightly wider margins for a sleep test, as I've seen this fail in my fork CI run

CC @carlopi 