### PR TITLE
[ADBC] Fix bug in StatementGetParameterSchema when no params are set

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -548,7 +548,7 @@ static int get_schema(struct ArrowArrayStream *stream, struct ArrowSchema *out) 
 
 	auto arrow_options = duckdb_result_get_arrow_options(&result_wrapper->result);
 
-	auto res = duckdb_to_arrow_schema(arrow_options, &types[0], names.data(), count, out);
+	auto res = duckdb_to_arrow_schema(arrow_options, types.data(), names.data(), count, out);
 	duckdb_destroy_arrow_options(&arrow_options);
 	for (auto &type : types) {
 		duckdb_destroy_logical_type(&type);
@@ -805,7 +805,7 @@ AdbcStatusCode StatementGetParameterSchema(struct AdbcStatement *statement, stru
 	duckdb_arrow_options arrow_options;
 	duckdb_connection_get_arrow_options(wrapper->connection, &arrow_options);
 
-	auto res = duckdb_to_arrow_schema(arrow_options, &types[0], names.data(), count, schema);
+	auto res = duckdb_to_arrow_schema(arrow_options, types.data(), names.data(), count, schema);
 
 	for (auto &type : types) {
 		duckdb_destroy_logical_type(&type);

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -18,9 +18,14 @@ using duckdb::QueryResultType;
 
 duckdb_error_data duckdb_to_arrow_schema(duckdb_arrow_options arrow_options, duckdb_logical_type *types,
                                          const char **names, idx_t column_count, struct ArrowSchema *out_schema) {
-	if (!types || !names || !arrow_options || !out_schema) {
+	if (!arrow_options || !out_schema) {
 		return duckdb_create_error_data(DUCKDB_ERROR_INVALID_INPUT, "Invalid argument(s) to duckdb_to_arrow_schema");
 	}
+	// types and names can be nullptr when column_count is 0
+	if (column_count > 0 && (!types || !names)) {
+		return duckdb_create_error_data(DUCKDB_ERROR_INVALID_INPUT, "Invalid argument(s) to duckdb_to_arrow_schema");
+	}
+
 	duckdb::vector<LogicalType> schema_types;
 	duckdb::vector<std::string> schema_names;
 	for (idx_t i = 0; i < column_count; i++) {

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -803,7 +803,8 @@ TEST_CASE("Test ADBC Statement with Zero Parameters", "[adbc]") {
 	{
 		AdbcStatement adbc_statement;
 		REQUIRE(SUCCESS(AdbcStatementNew(&adbc_connection, &adbc_statement, &adbc_error)));
-		REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&adbc_statement, "CREATE TABLE test_zero_params (id INTEGER)", &adbc_error)));
+		REQUIRE(SUCCESS(
+		    AdbcStatementSetSqlQuery(&adbc_statement, "CREATE TABLE test_zero_params (id INTEGER)", &adbc_error)));
 		REQUIRE(SUCCESS(AdbcStatementPrepare(&adbc_statement, &adbc_error)));
 
 		// Get parameter schema - should have 0 children

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -780,6 +780,83 @@ TEST_CASE("Test ADBC Statement Bind", "[adbc]") {
 	adbc_error.release(&adbc_error);
 }
 
+TEST_CASE("Test ADBC Statement with Zero Parameters", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+
+	AdbcDatabase adbc_database;
+	AdbcConnection adbc_connection;
+	AdbcError adbc_error;
+	InitializeADBCError(&adbc_error);
+
+	// Create connection
+	REQUIRE(SUCCESS(AdbcDatabaseNew(&adbc_database, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "driver", duckdb_lib, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "entrypoint", "duckdb_adbc_init", &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "path", ":memory:", &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseInit(&adbc_database, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcConnectionNew(&adbc_connection, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcConnectionInit(&adbc_connection, &adbc_database, &adbc_error)));
+
+	// Test 1: Query with no parameters (CREATE TABLE)
+	{
+		AdbcStatement adbc_statement;
+		REQUIRE(SUCCESS(AdbcStatementNew(&adbc_connection, &adbc_statement, &adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&adbc_statement, "CREATE TABLE test_zero_params (id INTEGER)", &adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementPrepare(&adbc_statement, &adbc_error)));
+
+		// Get parameter schema - should have 0 children
+		ArrowSchema param_schema;
+		param_schema.release = nullptr;
+		REQUIRE(SUCCESS(AdbcStatementGetParameterSchema(&adbc_statement, &param_schema, &adbc_error)));
+		REQUIRE(param_schema.n_children == 0);
+		REQUIRE(param_schema.format != nullptr);
+		REQUIRE(strcmp(param_schema.format, "+s") == 0); // Should be a struct
+		param_schema.release(&param_schema);
+
+		// Execute the statement without binding any parameters
+		ArrowArrayStream arrow_stream;
+		arrow_stream.release = nullptr;
+		REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&adbc_statement, &arrow_stream, nullptr, &adbc_error)));
+		arrow_stream.release(&arrow_stream);
+
+		REQUIRE(SUCCESS(AdbcStatementRelease(&adbc_statement, &adbc_error)));
+	}
+
+	// Test 2: Query with no parameters (SELECT constant)
+	{
+		AdbcStatement adbc_statement;
+		REQUIRE(SUCCESS(AdbcStatementNew(&adbc_connection, &adbc_statement, &adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&adbc_statement, "SELECT 42", &adbc_error)));
+		REQUIRE(SUCCESS(AdbcStatementPrepare(&adbc_statement, &adbc_error)));
+
+		// Get parameter schema - should have 0 children
+		ArrowSchema param_schema;
+		param_schema.release = nullptr;
+		REQUIRE(SUCCESS(AdbcStatementGetParameterSchema(&adbc_statement, &param_schema, &adbc_error)));
+		REQUIRE(param_schema.n_children == 0);
+		param_schema.release(&param_schema);
+
+		// Execute and verify result
+		ArrowArrayStream arrow_stream;
+		arrow_stream.release = nullptr;
+		REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&adbc_statement, &arrow_stream, nullptr, &adbc_error)));
+
+		ArrowSchema result_schema;
+		arrow_stream.get_schema(&arrow_stream, &result_schema);
+		REQUIRE(result_schema.n_children == 1); // One column in result
+		result_schema.release(&result_schema);
+
+		arrow_stream.release(&arrow_stream);
+		REQUIRE(SUCCESS(AdbcStatementRelease(&adbc_statement, &adbc_error)));
+	}
+
+	REQUIRE(SUCCESS(AdbcConnectionRelease(&adbc_connection, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseRelease(&adbc_database, &adbc_error)));
+	adbc_error.release(&adbc_error);
+}
+
 TEST_CASE("Test ADBC Transactions", "[adbc]") {
 	if (!duckdb_lib) {
 		return;


### PR DESCRIPTION
Modifies StatementGetParameterSchema to fix a bug in how parameter binding works for statements without any. Adds unit tests to cover zero parameters and fixes some UB I found with the new tests.

I found this while testing some basic Go database/sql code,

```go
	_, err = db.ExecContext(context.Background(), "CREATE TABLE test (id INTEGER)")
```

Closes https://github.com/duckdb/duckdb/issues/19311