### PR TITLE
Skip test block_allocator_memory.test on 32bit platforms

### DIFF
--- a/test/sql/settings/block_allocator_memory.test
+++ b/test/sql/settings/block_allocator_memory.test
@@ -31,6 +31,8 @@ SELECT value FROM duckdb_settings() WHERE name = 'block_allocator_memory';
 ----
 150.0 MiB
 
+require 64bit
+
 # cannot be reduced
 statement error
 RESET block_allocator_memory;


### PR DESCRIPTION
Minor, fixes red CI in forks / nightly.

There might be a problem of clarity in the interface, already `SET block_allocator_memory='100MiB';` should arguably fail (and the require be moved up).