### PR TITLE
CLI: Improve array rendering by no longer adding newlines after every array entry unless there are complex objects in the array

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -1124,6 +1124,9 @@ protected:
 				return;
 			}
 			AddNewline(format_state);
+			if (format_state.format_result != JSONFormattingResult::SUCCESS) {
+				return;
+			}
 		}
 		result += text;
 		line_length += render_width;

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -321,7 +321,7 @@ string BoxRenderer::TruncateValue(const string &value, idx_t column_width, idx_t
 		}
 		// check if this character fits...
 		auto char_size = Utf8Proc::RenderWidth(value.c_str(), value.size(), pos);
-		if (current_render_width + char_size >= column_width) {
+		if (current_render_width + char_size > column_width) {
 			// it doesn't! stop
 			break;
 		}
@@ -1102,23 +1102,37 @@ protected:
 		JSONFormattingResult format_result = JSONFormattingResult::SUCCESS;
 	};
 
-	bool LiteralFits(FormatState &format_state, const string &text) {
+	bool LiteralFits(FormatState &format_state, idx_t render_width) {
 		auto &line_length = format_state.line_length;
-		idx_t render_width = Utf8Proc::RenderWidth(text);
 		if (line_length + render_width > format_state.max_width) {
 			return false;
 		}
 		return true;
 	}
 
-	void AddLiteral(FormatState &format_state, const string &text) {
+	bool LiteralFits(FormatState &format_state, const string &text) {
+		idx_t render_width = Utf8Proc::RenderWidth(text);
+		return LiteralFits(format_state, render_width);
+	}
+
+	void AddLiteral(FormatState &format_state, const string &text, bool skip_adding_if_does_not_fit = false) {
 		auto &result = format_state.result;
 		auto &line_length = format_state.line_length;
+		idx_t render_width = Utf8Proc::RenderWidth(text);
+		if (!LiteralFits(format_state, render_width)) {
+			if (skip_adding_if_does_not_fit) {
+				return;
+			}
+			AddNewline(format_state);
+		}
 		result += text;
-		line_length += Utf8Proc::RenderWidth(text);
+		line_length += render_width;
 		if (line_length > format_state.max_width) {
 			format_state.format_result = JSONFormattingResult::TOO_WIDE;
 		}
+	}
+	void AddSpace(FormatState &format_state) {
+		AddLiteral(format_state, " ", true);
 	}
 	void AddNewline(FormatState &format_state) {
 		auto &result = format_state.result;
@@ -1126,34 +1140,36 @@ protected:
 		auto &row_count = format_state.row_count;
 		auto &line_length = format_state.line_length;
 		result += '\n';
-		result += string(format_state.indentation_size * depth, ' ');
+		result += string(depth, ' ');
 		row_count++;
 		if (row_count > format_state.max_rows) {
 			format_state.format_result = JSONFormattingResult::TOO_MANY_ROWS;
 			return;
 		}
-		line_length = format_state.indentation_size * depth;
+		line_length = depth;
 		if (line_length > format_state.max_width) {
 			format_state.format_result = JSONFormattingResult::TOO_WIDE;
 		}
 	}
 
-	void FormatComponent(FormatState &format_state, JSONComponent &component, bool inlined) {
+	enum class InlineMode { STANDARD, INLINED_SINGLE_LINE, INLINED_MULTI_LINE };
+
+	void FormatComponent(FormatState &format_state, JSONComponent &component, InlineMode inline_mode) {
 		auto &depth = format_state.depth;
 		auto &line_length = format_state.line_length;
 		auto &max_width = format_state.max_width;
 		auto &c = format_state.component_idx;
 		switch (component.type) {
 		case JSONComponentType::BRACKET_OPEN: {
-			depth++;
+			depth += component.text == "{" ? format_state.indentation_size : 1;
 			AddLiteral(format_state, component.text);
-			if (!inlined) {
+			if (inline_mode == InlineMode::STANDARD) {
 				// not inlined
 				// look forward until the corresponding bracket open - can we inline and not exceed the column width?
 				idx_t peek_depth = 0;
 				idx_t render_size = line_length;
 				idx_t peek_idx;
-				bool inline_bracket = false;
+				InlineMode inline_child_mode = InlineMode::STANDARD;
 				for (peek_idx = c + 1; peek_idx < components.size() && render_size <= max_width; peek_idx++) {
 					auto &peek_component = components[peek_idx];
 					if (peek_component.type == JSONComponentType::BRACKET_OPEN) {
@@ -1161,7 +1177,10 @@ protected:
 					} else if (peek_component.type == JSONComponentType::BRACKET_CLOSE) {
 						if (peek_depth == 0) {
 							// close!
-							inline_bracket = render_size + 1 < max_width;
+							if (render_size + 1 < max_width) {
+								// fits within a single line - inline on a single line
+								inline_child_mode = InlineMode::INLINED_SINGLE_LINE;
+							}
 							break;
 						}
 						peek_depth--;
@@ -1172,11 +1191,42 @@ protected:
 						render_size++;
 					}
 				}
-				if (inline_bracket) {
+				if (component.text == "[") {
+					// for arrays - we always inline them UNLESS there are complex objects INSIDE of the bracket
+					// scan forward until the end of the array to figure out if this is true or not
+					for (peek_idx = c + 1; peek_idx < components.size(); peek_idx++) {
+						auto &peek_component = components[peek_idx];
+						peek_depth = 0;
+						if (peek_component.type == JSONComponentType::BRACKET_OPEN) {
+							if (peek_component.text == "{") {
+								// nested structure within the array
+								break;
+							}
+							peek_depth++;
+						}
+						if (peek_component.type == JSONComponentType::BRACKET_CLOSE) {
+							if (peek_depth == 0) {
+								inline_child_mode = InlineMode::INLINED_MULTI_LINE;
+								break;
+							}
+							peek_depth--;
+						}
+					}
+				}
+				if (inline_child_mode != InlineMode::STANDARD) {
 					// we can inline! do it
 					for (idx_t inline_idx = c + 1; inline_idx <= peek_idx; inline_idx++) {
 						auto &inline_component = components[inline_idx];
-						FormatComponent(format_state, inline_component, true);
+						if (inline_child_mode == InlineMode::INLINED_MULTI_LINE && inline_idx + 1 <= peek_idx) {
+							auto &next_component = components[inline_idx + 1];
+							if (next_component.type == JSONComponentType::COMMA ||
+							    next_component.type == JSONComponentType::BRACKET_CLOSE) {
+								if (!LiteralFits(format_state, inline_component.text + next_component.text)) {
+									AddNewline(format_state);
+								}
+							}
+						}
+						FormatComponent(format_state, inline_component, inline_child_mode);
 					}
 					c = peek_idx;
 					return;
@@ -1192,21 +1242,22 @@ protected:
 			}
 			break;
 		}
-		case JSONComponentType::BRACKET_CLOSE:
-			depth--;
-			if (!inlined) {
+		case JSONComponentType::BRACKET_CLOSE: {
+			idx_t depth_diff = component.text == "}" ? format_state.indentation_size : 1;
+			if (depth < depth_diff) {
+				// shouldn't happen - but guard against underflows
+				depth = 0;
+			} else {
+				depth -= depth_diff;
+			}
+			if (inline_mode == InlineMode::STANDARD) {
 				AddNewline(format_state);
 			}
 			AddLiteral(format_state, component.text);
 			break;
+		}
 		case JSONComponentType::COMMA:
 		case JSONComponentType::COLON:
-			if (format_state.mode != JSONFormattingMode::STANDARD) {
-				// add a newline if the comma does not fit
-				if (!LiteralFits(format_state, component.text)) {
-					AddNewline(format_state);
-				}
-			}
 			AddLiteral(format_state, component.text);
 			bool always_inline;
 			if (format_state.mode == JSONFormattingMode::COMPACT_HORIZONTAL) {
@@ -1216,8 +1267,8 @@ protected:
 				// in normal processing we always inline colons
 				always_inline = component.type == JSONComponentType::COLON;
 			}
-			if (inlined || always_inline) {
-				AddLiteral(format_state, " ");
+			if (inline_mode != InlineMode::STANDARD || always_inline) {
+				AddSpace(format_state);
 			} else {
 				if (format_state.mode != JSONFormattingMode::STANDARD) {
 					// if we are not inlining in compact mode, try to inline until the next comma
@@ -1249,10 +1300,10 @@ protected:
 					}
 					if (inline_comma) {
 						// we can inline until the next comma! do it
-						AddLiteral(format_state, " ");
+						AddSpace(format_state);
 						for (idx_t inline_idx = c + 1; inline_idx < peek_idx; inline_idx++) {
 							auto &inline_component = components[inline_idx];
-							FormatComponent(format_state, inline_component, true);
+							FormatComponent(format_state, inline_component, InlineMode::INLINED_SINGLE_LINE);
 						}
 						c = peek_idx - 1;
 						return;
@@ -1281,7 +1332,7 @@ protected:
 		                                     format_state.format_result == JSONFormattingResult::SUCCESS;
 		     format_state.component_idx++) {
 			auto &component = components[format_state.component_idx];
-			FormatComponent(format_state, component, false);
+			FormatComponent(format_state, component, InlineMode::STANDARD);
 		}
 
 		if (format_state.format_result != JSONFormattingResult::SUCCESS) {

--- a/src/common/printer.cpp
+++ b/src/common/printer.cpp
@@ -31,8 +31,7 @@ void Printer::RawPrint(OutputStream stream, const string &str) {
 }
 
 void Printer::DefaultLinePrint(OutputStream stream, const string &str) {
-	Printer::RawPrint(stream, str);
-	Printer::RawPrint(stream, "\n");
+	Printer::RawPrint(stream, str + "\n");
 }
 
 line_printer_f Printer::line_printer = Printer::DefaultLinePrint;

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -131,6 +131,7 @@ bool Linenoise::CompleteLine(KeyPress &next_key) {
 	render_completion_suggestion = false;
 	if (completions.empty()) {
 		Terminal::Beep();
+		next_key.action = KEY_NULL;
 	} else {
 		bool stop = false;
 		bool accept_completion = false;


### PR DESCRIPTION
Follow-up fix from https://github.com/duckdb/duckdb/pull/19721

When rendering an array that does not contain any complex objects, wrap it on multiple lines instead of adding newlines after every comma, e.g. we render it as this:

```
[1, 2, 3, 4,
 5, 6, 7, 8]
```

Instead of this:

```
[
   1,
   2,
   3,
   4,
   5,
   6,
   7,
   8
]
```