### PR TITLE
[swift] fix compiler warnings for deprecated @_implementationOnly

### DIFF
--- a/tools/swift/duckdb-swift/Sources/DuckDB/Appender.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Appender.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 import Foundation
 
 /// An object that efficiently appends data to a DuckDB table

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Column.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Column.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 import Foundation
 
 /// A DuckDB result set column

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Configuration.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Configuration.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 
 public extension Database {
   

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Connection.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Connection.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 
 /// An object representing a connection to a DuckDB database
 ///

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Database.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Database.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 import Foundation
 
 /// DuckDB index type

--- a/tools/swift/duckdb-swift/Sources/DuckDB/DatabaseType.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/DatabaseType.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 
 /// The underlying database type of a DuckDB column
 ///

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Internal/CTypeUtilities.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Internal/CTypeUtilities.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 import Foundation
 
 // MARK: - Type Layouts

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Internal/DataChunk.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Internal/DataChunk.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 import Foundation
 
 final class DataChunk: Sendable {

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Internal/Vector.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Internal/Vector.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 import Foundation
 
 struct Vector {

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Internal/VectorElementDecoder.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Internal/VectorElementDecoder.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 import Foundation
 
 // MARK: - Top Level Decoder

--- a/tools/swift/duckdb-swift/Sources/DuckDB/LogicalType.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/LogicalType.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 import Foundation
 
 public final class LogicalType {

--- a/tools/swift/duckdb-swift/Sources/DuckDB/PreparedStatement.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/PreparedStatement.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 import Foundation
 
 /// An object representing a DuckDB prepared statement

--- a/tools/swift/duckdb-swift/Sources/DuckDB/ResultSet.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/ResultSet.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 import Foundation
 
 /// An object representing a DuckDB result set

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Types/Date.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Types/Date.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 
 /// A date in the Gregorian calendar
 ///

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Types/Interval.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Types/Interval.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 
 /// A period of time
 ///

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Types/Time.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Types/Time.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 
 /// A point in absolute time
 ///

--- a/tools/swift/duckdb-swift/Sources/DuckDB/Types/Timestamp.swift
+++ b/tools/swift/duckdb-swift/Sources/DuckDB/Types/Timestamp.swift
@@ -22,7 +22,11 @@
 //  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 //  IN THE SOFTWARE.
 
+#if compiler(>=6.0)
+internal import Cduckdb
+#else
 @_implementationOnly import Cduckdb
+#endif
 
 /// A point in absolute time
 ///


### PR DESCRIPTION
Usage of private annotation @implementationOnly as been deprecated and raises warnings on Swift 6. Replace by access level imports following https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md 