### PR TITLE
Fix flaky sleep test

### DIFF
--- a/test/sql/function/generic/test_sleep.test
+++ b/test/sql/function/generic/test_sleep.test
@@ -126,7 +126,7 @@ statement ok
 CREATE OR REPLACE TABLE sleep_profiling_multi AS SELECT * FROM read_json('__TEST_DIR__/sleep_profiling_multi.json')
 
 query T
-SELECT cpu_time >= 0.04 AND cpu_time < 0.15 FROM sleep_profiling_multi WHERE contains(extra_info, 'sleep_ms') OR contains(query_name, 'sleep_ms') LIMIT 1
+SELECT cpu_time >= 0.04 FROM sleep_profiling_multi WHERE contains(extra_info, 'sleep_ms') OR contains(query_name, 'sleep_ms') LIMIT 1
 ----
 true
 


### PR DESCRIPTION
Remove an additional validation step in the query to fix a flaky test.
The test fails intermittently only in the macOS Release GitHub Action.