### PR TITLE
Fix incorrect results with NOT EXISTS and IS DISTINCT FROM operator (#19680)

### DIFF
--- a/src/common/enums/expression_type.cpp
+++ b/src/common/enums/expression_type.cpp
@@ -287,6 +287,12 @@ ExpressionType NegateComparisonExpression(ExpressionType type) {
 	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
 		negated_type = ExpressionType::COMPARE_LESSTHAN;
 		break;
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		negated_type = ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+		break;
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		negated_type = ExpressionType::COMPARE_DISTINCT_FROM;
+		break;
 	default:
 		throw InternalException("Unsupported comparison type in negation");
 	}

--- a/src/optimizer/deliminator.cpp
+++ b/src/optimizer/deliminator.cpp
@@ -214,7 +214,10 @@ bool Deliminator::RemoveJoinWithDelimGet(LogicalComparisonJoin &delim_join, cons
 		auto &other_colref = other_side.Cast<BoundColumnRefExpression>();
 		replacement_bindings.emplace_back(delim_colref.binding, other_colref.binding);
 
-		if (cond.comparison != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+		// Only add IS NOT NULL filter for regular equality/inequality comparisons
+		// Do NOT add for DISTINCT FROM variants, as they handle NULL correctly
+		if (cond.comparison != ExpressionType::COMPARE_NOT_DISTINCT_FROM &&
+		    cond.comparison != ExpressionType::COMPARE_DISTINCT_FROM) {
 			auto is_not_null_expr =
 			    make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType::BOOLEAN);
 			is_not_null_expr->children.push_back(other_side.Copy());
@@ -334,6 +337,7 @@ bool Deliminator::RemoveInequalityJoinWithDelimGet(LogicalComparisonJoin &delim_
 			auto &colref = delim_side.Cast<BoundColumnRefExpression>();
 			if (colref.binding == traced_binding) {
 				auto join_comparison = join_condition.comparison;
+				auto original_join_comparison = join_condition.comparison; // Save original for later check
 				if (delim_condition.comparison == ExpressionType::COMPARE_DISTINCT_FROM ||
 				    delim_condition.comparison == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
 					// We need to compare NULL values
@@ -352,7 +356,13 @@ bool Deliminator::RemoveInequalityJoinWithDelimGet(LogicalComparisonJoin &delim_
 				// join condition was a not equal and filtered out all NULLS.
 				// DELIM JOIN need to do that for not DELIM_GET side. Easiest way is to change the
 				// comparison expression type. See duckdb/duckdb#16803
-				if (delim_join.join_type != JoinType::MARK) {
+				// NOTE: We should NOT convert DISTINCT FROM to != in general, as they have different NULL semantics
+				// - DISTINCT FROM: NULL IS DISTINCT FROM NULL = FALSE (NULL-aware)
+				// - !=: NULL != NULL = NULL (filters out NULL)
+				// Only convert if the ORIGINAL join had != or = (not DISTINCT FROM variants)
+				if (delim_join.join_type != JoinType::MARK &&
+				    original_join_comparison != ExpressionType::COMPARE_DISTINCT_FROM &&
+				    original_join_comparison != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
 					if (delim_condition.comparison == ExpressionType::COMPARE_DISTINCT_FROM) {
 						delim_condition.comparison = ExpressionType::COMPARE_NOTEQUAL;
 					}

--- a/src/optimizer/deliminator.cpp
+++ b/src/optimizer/deliminator.cpp
@@ -356,9 +356,6 @@ bool Deliminator::RemoveInequalityJoinWithDelimGet(LogicalComparisonJoin &delim_
 				// join condition was a not equal and filtered out all NULLS.
 				// DELIM JOIN need to do that for not DELIM_GET side. Easiest way is to change the
 				// comparison expression type. See duckdb/duckdb#16803
-				// NOTE: We should NOT convert DISTINCT FROM to != in general, as they have different NULL semantics
-				// - DISTINCT FROM: NULL IS DISTINCT FROM NULL = FALSE (NULL-aware)
-				// - !=: NULL != NULL = NULL (filters out NULL)
 				// Only convert if the ORIGINAL join had != or = (not DISTINCT FROM variants)
 				if (delim_join.join_type != JoinType::MARK &&
 				    original_join_comparison != ExpressionType::COMPARE_DISTINCT_FROM &&

--- a/src/parser/transform/expression/transform_bool_expr.cpp
+++ b/src/parser/transform/expression/transform_bool_expr.cpp
@@ -33,10 +33,13 @@ unique_ptr<ParsedExpression> Transformer::TransformBoolExpr(duckdb_libpgquery::P
 				// convert COMPARE_IN to COMPARE_NOT_IN
 				next->SetExpressionTypeUnsafe(ExpressionType::COMPARE_NOT_IN);
 				result = std::move(next);
-			} else if (next->GetExpressionType() >= ExpressionType::COMPARE_EQUAL &&
-			           next->GetExpressionType() <= ExpressionType::COMPARE_GREATERTHANOREQUALTO) {
+			} else if ((next->GetExpressionType() >= ExpressionType::COMPARE_EQUAL &&
+			            next->GetExpressionType() <= ExpressionType::COMPARE_GREATERTHANOREQUALTO) ||
+			           next->GetExpressionType() == ExpressionType::COMPARE_DISTINCT_FROM ||
+			           next->GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
 				// NOT on a comparison: we can negate the comparison
 				// e.g. NOT(x > y) is equivalent to x <= y
+				// NOT(x IS DISTINCT FROM y) is equivalent to x IS NOT DISTINCT FROM y
 				next->SetExpressionTypeUnsafe(NegateComparisonExpression(next->GetExpressionType()));
 				result = std::move(next);
 			} else {

--- a/test/sql/subquery/exists/test_correlated_exists_with_derived_table.test
+++ b/test/sql/subquery/exists/test_correlated_exists_with_derived_table.test
@@ -1,0 +1,37 @@
+# name: test/sql/subquery/exists/test_correlated_exists_with_derived_table.test
+# description: Test correlated EXISTS with nested derived table containing same table name
+# group: [exists]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t0(c2 INT);
+
+statement ok
+INSERT INTO t0(c2) VALUES (NULL), (1);
+
+query I
+SELECT t0.c2 FROM t0
+WHERE NOT EXISTS (
+  SELECT 1 FROM (
+    SELECT t0.c2 AS col0 FROM t0
+  ) AS subQuery
+  WHERE ((t0.c2) IS DISTINCT FROM (subQuery.col0))
+);
+----
+
+# Test parser optimization: NOT (x IS DISTINCT FROM y) -> x IS NOT DISTINCT FROM y
+query I
+SELECT t0.c2 FROM t0
+WHERE NOT EXISTS (
+  SELECT 1 FROM (
+    SELECT t0.c2 AS col0 FROM t0
+  ) AS subQuery
+  WHERE NOT ((t0.c2) IS DISTINCT FROM (subQuery.col0))
+);
+----
+
+# Clean up
+statement ok
+DROP TABLE t0;


### PR DESCRIPTION
Fixes #19680

This fixes a bug where queries using `NOT EXISTS` with `IS DISTINCT FROM` returned incorrect results due to improper handling of NULL semantics in the optimizer.

The issue was that the optimizer's deliminator incorrectly treated `DISTINCT FROM` variants the same as regular equality/inequality comparisons, which have different NULL handling:
  - `IS DISTINCT FROM`: NULL-aware (NULL IS DISTINCT FROM NULL = FALSE)
  - != or =: NULL-unaware (NULL != NULL = NULL, filters out NULLs)


### Incorrect Query Plan

```
┌───────────────────────────┐
│         PROJECTION        │
│    ────────────────────   │
│             c2            │
│                           │
│          ~0 rows          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│             #5            │
│__internal_decompress_integ│
│     ral_integer(#3, 1)    │
│             #1            │
│                           │
│          ~0 rows          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│      NESTED_LOOP_JOIN     │
│    ────────────────────   │
│      Join Type: ANTI      │
│    Conditions: c2 != c2   ├──────────────┐
│                           │              │
│          ~0 rows          │              │
└─────────────┬─────────────┘              │
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         PROJECTION        ││         PROJECTION        │
│    ────────────────────   ││    ────────────────────   │
│            NULL           ││            NULL           │
│             #2            ││             #2            │
│            NULL           ││            NULL           │
│             #1            ││             #1            │
│            NULL           ││            NULL           │
│             #0            ││             #0            │
│            NULL           ││            NULL           │
│                           ││                           │
│          ~2 rows          ││           ~1 row          │
└─────────────┬─────────────┘└─────────────┬─────────────┘
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         PROJECTION        ││         PROJECTION        │
│    ────────────────────   ││    ────────────────────   │
│             #0            ││             #0            │
│__internal_compress_integra││__internal_compress_integra│
│     l_utinyint(#1, 1)     ││     l_utinyint(#1, 1)     │
│             #2            ││             #2            │
│                           ││                           │
│          ~2 rows          ││           ~1 row          │
└─────────────┬─────────────┘└─────────────┬─────────────┘
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         PROJECTION        ││         PROJECTION        │
│    ────────────────────   ││    ────────────────────   │
│            NULL           ││            NULL           │
│             #0            ││             #0            │
│            NULL           ││            NULL           │
│                           ││                           │
│          ~2 rows          ││           ~1 row          │
└─────────────┬─────────────┘└─────────────┬─────────────┘
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         SEQ_SCAN          ││           FILTER          │
│    ────────────────────   ││    ────────────────────   │
│         Table: t0         ││     (col0 IS NOT NULL)    │
│   Type: Sequential Scan   ││                           │
│      Projections: c2      ││                           │
│                           ││                           │
│          ~2 rows          ││           ~1 row          │
└───────────────────────────┘└─────────────┬─────────────┘
                             ┌─────────────┴─────────────┐
                             │         SEQ_SCAN          │
                             │    ────────────────────   │
                             │         Table: t0         │
                             │   Type: Sequential Scan   │
                             │      Projections: c2      │
                             │                           │
                             │          ~2 rows          │
                             └───────────────────────────┘
```

  The buggy plan shows two critical issues:
```
  ┌─────────────┴─────────────┐
  │      NESTED_LOOP_JOIN     │
  │      Join Type: ANTI      │
  │    Conditions: c2 != c2   │  ← ❌ Wrong(the join conditions should be c2 IS DISTINCT FROM c2)
  │          ~0 rows          │
  └─────────────┬─────────────┘
                │
                └─────────────┐
                             ┌┴─────────────┐
                             │   FILTER     │
                             │ (col0 IS NOT │  ← ❌ Wrong(the filter should be removed)
                             │    NULL)     │
                             └──────────────┘
```

### Solution

This PR adds proper support for DISTINCT FROM operators throughout the optimization pipeline:

1. Preserve DISTINCT FROM semantics in join conversion.(src/optimizer/deliminator.cpp)
```
// NOTE: We should NOT convert DISTINCT FROM to != in general
// Only convert if the ORIGINAL join had != or = (not DISTINCT FROM variants)
if (delim_join.join_type != JoinType::MARK &&
    original_join_comparison != ExpressionType::COMPARE_DISTINCT_FROM &&
    original_join_comparison != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
    // Safe to convert
}
```
2. Skip NULL filters for DISTINCT FROM variants.(src/optimizer/deliminator.cpp)
```
// Only add IS NOT NULL filter for regular equality/inequality comparisons
// Do NOT add for DISTINCT FROM variants, as they handle NULL correctly
if (cond.comparison != ExpressionType::COMPARE_NOT_DISTINCT_FROM &&
    cond.comparison != ExpressionType::COMPARE_DISTINCT_FROM) {
    // Add IS NOT NULL filter
}
```
3. Added negation support for COMPARE_DISTINCT_FROM and COMPARE_NOT_DISTINCT_FROM
    in expression type handling.(src/common/enums/expression_type.cpp)
4. Updated parser to properly negate IS DISTINCT FROM expressions when wrapped with NOT. (src/parser/transform/expression/transform_bool_expr.cpp)
5. Added regression test in test/sql/subquery/exists/test_correlated_exists_with_derived_table.test 
