### PR TITLE
PEG Transformer template script

### DIFF
--- a/extension/autocomplete/grammar/statements/expression.gram
+++ b/extension/autocomplete/grammar/statements/expression.gram
@@ -180,7 +180,7 @@ DotOperator <- '.' (FunctionExpression / ColLabel)
 SliceExpression <- '[' SliceBound ']'
 SliceBound <- Expression? EndSliceBound? StepSliceBound?
 EndSliceBound <- ':' (Expression / '-')?
-StepSliceBOund <- ':' Expression?
+StepSliceBound <- ':' Expression?
 PostfixOperator <- '!'
 
 

--- a/scripts/generate_peg_transformer.py
+++ b/scripts/generate_peg_transformer.py
@@ -128,13 +128,13 @@ def find_factory_registrations(factory_file_path):
 def generate_declaration_stub(rule_name):
     """Generates the C++ method declaration (for the .hpp file)."""
     return f"""// TODO: Verify this return type is correct
-    static unique_ptr<SQLStatement> Transform{rule_name}(PEGTransformer &transformer, optional_ptr<ParseResult> parse_result);
+static unique_ptr<SQLStatement> Transform{rule_name}(PEGTransformer &transformer, optional_ptr<ParseResult> parse_result);
 """
 
 
 def generate_registration_stub(rule_name):
     """Generates the C++ registration line (for peg_transformer_factory.cpp)."""
-    return f"REGISTER_TRANSFORM(Transform{rule_name});"
+    return f"REGISTER_TRANSFORM(Transform{rule_name});\n"
 
 
 def generate_implementation_stub(rule_name):

--- a/scripts/generate_peg_transformer.py
+++ b/scripts/generate_peg_transformer.py
@@ -7,19 +7,23 @@ import sys
 # --- Configuration ---
 GRAMMAR_DIR = "../extension/autocomplete/grammar/statements"
 TRANSFORMER_DIR = "../extension/autocomplete/transformer"
-ENUM_RULES_FILE = "../extension/autocomplete/transformer/peg_transformer_factory.cpp"
+FACTORY_REG_FILE = "../extension/autocomplete/transformer/peg_transformer_factory.cpp"
 
 # Regex to find grammar rule names (e.g., "AlterStatement")
 # Matches: RuleName <- ...
 GRAMMAR_REGEX = re.compile(r"^(\w+)\s*<-")
 
-# Regex to find transformer rule names (e.g., "AlterStatement")
+# Regex to find transformer function implementations (e.g., "AlterStatement")
 # Matches: PEGTransformerFactory::TransformRuleName(
 TRANSFORMER_REGEX = re.compile(r"PEGTransformerFactory::Transform(\w+)\s*\(")
 
 # Regex to find enum-registered rule names (e.g., "LocalScope")
 # Matches: RegisterEnum<...>("RuleName", ...);
 ENUM_RULE_REGEX = re.compile(r'RegisterEnum<[^>]+>\s*\(\s*"(\w+)"\s*,')
+
+# Regex to find registered transformer functions (e.g., "AlterStatement")
+# Matches: REGISTER_TRANSFORM(TransformRuleName)
+REGISTER_TRANSFORM_REGEX = re.compile(r"REGISTER_TRANSFORM\s*\(\s*Transform(\w+)\s*\)")
 
 # --- Phase 1: Find all Grammar Rules ---
 
@@ -59,12 +63,12 @@ def find_grammar_rules(grammar_path):
 
     return all_rules_by_file
 
-# --- Phase 2: Find all Transformer Rules ---
+# --- Phase 2: Find all Transformer Implementations ---
 
 def find_transformer_rules(transformer_path):
     """
-    Scans the transformer directory for *.cpp files and extracts all rule names
-    from PEGTransformerFactory::Transform...() functions.
+    Scans the transformer directory for *.cpp files and extracts all
+    PEGTransformerFactory::Transform...() function implementations.
 
     Returns a set of all found rule names:
     { "AlterStatement", "AlterTableStmt", ... }
@@ -95,34 +99,42 @@ def find_transformer_rules(transformer_path):
 
     return transformer_rules
 
-# --- Phase 3: Find all Enum-Registered Rules ---
+# --- Phase 3 & 4: Find Enum Rules and Registrations ---
 
-def find_enum_rules(enum_file_path):
+def find_factory_registrations(factory_file_path):
     """
-    Scans the specified file for RegisterEnum<...>("RuleName", ...) calls.
+    Scans the factory file for RegisterEnum<...> and REGISTER_TRANSFORM(...)
 
-    Returns a set of all found rule names:
-    { "LocalScope", "GlobalScope", ... }
+    Returns two sets:
+    (enum_rules, registered_rules)
     """
     enum_rules = set()
+    registered_rules = set()
 
-    if not enum_file_path.is_file():
-        print(f"Error: Enum rules file not found: {enum_file_path}", file=sys.stderr)
-        return enum_rules # Return empty set, but proceed
+    if not factory_file_path.is_file():
+        print(f"Error: Factory file not found: {factory_file_path}", file=sys.stderr)
+        return enum_rules, registered_rules
 
-    print(f"🔍 Scanning enum rules file: {enum_file_path}...")
+    print(f"🔍 Scanning factory file: {factory_file_path}...")
 
     try:
-        with enum_file_path.open("r", encoding="utf-8") as f:
+        with factory_file_path.open("r", encoding="utf-8") as f:
             content = f.read()
-            matches = ENUM_RULE_REGEX.finditer(content)
-            for match in matches:
-                # group(1) is the captured rule name (e.g., "LocalScope")
-                enum_rules.add(match.group(1))
-    except Exception as e:
-        print(f"Error reading {enum_file_path}: {e}", file=sys.stderr)
 
-    return enum_rules
+            # Find enums
+            enum_matches = ENUM_RULE_REGEX.finditer(content)
+            for match in enum_matches:
+                enum_rules.add(match.group(1))
+
+            # Find transformer registrations
+            reg_matches = REGISTER_TRANSFORM_REGEX.finditer(content)
+            for match in reg_matches:
+                registered_rules.add(match.group(1))
+
+    except Exception as e:
+        print(f"Error reading {factory_file_path}: {e}", file=sys.stderr)
+
+    return enum_rules, registered_rules
 
 # --- Main Execution ---
 
@@ -131,27 +143,27 @@ def main():
     Main script to find rules, compare them, and print a report.
     """
     grammar_rules_by_file = find_grammar_rules(Path(GRAMMAR_DIR))
-    transformer_rules = find_transformer_rules(Path(TRANSFORMER_DIR))
-    enum_rules = find_enum_rules(Path(ENUM_RULES_FILE))
+    transformer_impls = find_transformer_rules(Path(TRANSFORMER_DIR))
+    enum_rules, registered_rules = find_factory_registrations(Path(FACTORY_REG_FILE))
 
     if not grammar_rules_by_file:
         print("Error: Could not find grammar rules. Exiting.", file=sys.stderr)
         sys.exit(1)
 
-    # Combine both sets of "covered" rules
-    covered_rules = transformer_rules.union(enum_rules)
-
     print("\n--- 📋 Rule Coverage Check ---")
 
-    missing_rules_by_file = {}
     total_grammar_rules = 0
-    total_found = 0
+    total_found_enum = 0
+    total_found_registered = 0
+    total_missing_registration = 0
+    total_missing_implementation = 0
     all_grammar_rules_flat = set()
+    missing_rules_by_file = {}
 
     # Iterate through each file and its rules
     for file_name, grammar_rules in sorted(grammar_rules_by_file.items()):
         print(f"\n--- File: {file_name} ---")
-        missing_in_this_file = 0
+        missing_count_this_file = 0
 
         if not grammar_rules:
             print("  (No grammar rules found in this file)")
@@ -161,44 +173,86 @@ def main():
             all_grammar_rules_flat.add(rule_name)
             total_grammar_rules += 1
 
-            # Check if the grammar rule exists in the combined set of covered rules
-            if rule_name in covered_rules:
-                print(f"  [ ✅ FOUND ]   {rule_name}")
-                total_found += 1
+            is_enum = rule_name in enum_rules
+            is_transformer = rule_name in transformer_impls
+            is_registered = rule_name in registered_rules
+
+            status_str = ""
+            if is_enum:
+                status_str = "[ ✅ ENUM ]"
+                total_found_enum += 1
+            elif is_transformer:
+                if is_registered:
+                    status_str = "[ ✅ FOUND ]"
+                    total_found_registered += 1
+                else:
+                    status_str = "[ ⚠️ NOT REG'D ]"
+                    total_missing_registration += 1
+                    missing_count_this_file += 1
             else:
-                print(f"  [ ❌ MISSING ] {rule_name}")
-                missing_in_this_file += 1
+                status_str = "[ ❌ MISSING ]"
+                total_missing_implementation += 1
+                missing_count_this_file += 1
 
-        missing_rules_by_file[file_name] = missing_in_this_file
+            # Use f-string padding to align to 14 characters
+            print(f"  {status_str:<14} {rule_name}")
 
-    total_missing = total_grammar_rules - total_found
+        if missing_count_this_file > 0:
+            missing_rules_by_file[file_name] = missing_count_this_file
+
+    total_covered = total_found_enum + total_found_registered
+    total_issues = total_missing_implementation + total_missing_registration
+    coverage = (total_covered / total_grammar_rules) * 100 if total_grammar_rules > 0 else 0
 
     # --- Print Summary Report ---
-    print("\n--- 📊 Summary: Missing Rules Per File ---")
-    for file_name, count in sorted(missing_rules_by_file.items()):
-        if count > 0:
-            print(f"  {file_name:<25} : {count} missing")
-
-    print("-----------------------------------------")
+    print("\n--- 📊 Summary: Rule Coverage ---")
     print(f"  {'TOTAL GRAMMAR RULES':<25} : {total_grammar_rules}")
-    print(f"  {'TOTAL FOUND':<25} : {total_found}")
-    print(f"  {'TOTAL MISSING':<25} : {total_missing}")
+    print(f"  {'TOTAL COVERED':<25} : {total_covered} ({coverage:.2f}%)")
+    print(f"    {'  - Enum':<23} : {total_found_enum}")
+    print(f"    {'  - Registered':<23} : {total_found_registered}")
+    print(f"  {'TOTAL ISSUES':<25} : {total_issues}")
+    print(f"    {'  - Missing Impl':<23} : {total_missing_implementation}")
+    print(f"    {'  - Not Registered':<23} : {total_missing_registration}")
 
-    coverage = (total_found / total_grammar_rules) * 100 if total_grammar_rules > 0 else 0
-    print(f"  {'COVERAGE':<25} : {coverage:.2f}%")
 
-    # --- Check for "Orphan" Rules ---
-    orphan_transformers = transformer_rules - all_grammar_rules_flat
+    if missing_rules_by_file:
+        print("\n--- 📊 Summary: Issues Per File ---")
+        for file_name, count in sorted(missing_rules_by_file.items()):
+            print(f"  {file_name:<25} : {count} issues")
+
+    # --- Check for "Orphan" Rules (Implementation without Grammar) ---
+    print("\n--- ⚠️  Orphan / Mismatch Check ---")
+
+    orphan_transformers = transformer_impls - all_grammar_rules_flat
     if orphan_transformers:
-        print("\n--- ⚠️  Orphan Transformer Functions (No matching grammar rule) ---")
-        for orphan_rule in sorted(list(orphan_transformers)):
-            print(f"  [ ❓ ORPHAN ]  Transform{orphan_rule}")
+        print("\n  [!] Orphan Transformer Functions (No matching grammar rule):")
+        for rule in sorted(list(orphan_transformers)):
+            print(f"    - Transform{rule}")
 
     orphan_enums = enum_rules - all_grammar_rules_flat
     if orphan_enums:
-        print("\n--- ⚠️  Orphan Enum Rules (No matching grammar rule) ---")
-        for orphan_rule in sorted(list(orphan_enums)):
-            print(f"  [ ❓ ORPHAN ]  RegisterEnum(\"{orphan_rule}\")")
+        print("\n  [!] Orphan Enum Rules (No matching grammar rule):")
+        for rule in sorted(list(orphan_enums)):
+            print(f"    - RegisterEnum(\"{rule}\")")
+
+    orphan_registrations = registered_rules - all_grammar_rules_flat
+    if orphan_registrations:
+        print("\n  [!] Orphan Registrations (No matching grammar rule):")
+        for rule in sorted(list(orphan_registrations)):
+            print(f"    - REGISTER_TRANSFORM(Transform{rule})")
+
+    # --- Check for Mismatches ---
+    missing_impl = registered_rules - transformer_impls
+    if missing_impl:
+        print("\n  [!] Registered but NOT Implemented (Will cause C++ error):")
+        for rule in sorted(list(missing_impl)):
+            print(f"    - REGISTER_TRANSFORM(Transform{rule})")
+
+    unnecessary_reg = registered_rules.intersection(enum_rules)
+    if unnecessary_reg:
+        print("\n  [!] Rule registered as BOTH Enum and Transformer (Ambiguous):")
+        for rule in sorted(list(unnecessary_reg)):
+            print(f"    - {rule}")
 
     print("\n✅ Done.")
 

--- a/scripts/generate_peg_transformer.py
+++ b/scripts/generate_peg_transformer.py
@@ -22,7 +22,6 @@ REGISTER_TRANSFORM_REGEX = re.compile(r"REGISTER_TRANSFORM\s*\(\s*Transform(\w+)
 
 EXCLUDED_RULES = {"FunctionType", "IfExists"}
 
-
 def find_grammar_rules(grammar_path):
     """
     Scans the grammar directory for *.gram files and extracts all rule names.
@@ -55,10 +54,6 @@ def find_grammar_rules(grammar_path):
         all_rules_by_file[file_path.name] = (file_path, rules_in_file)
 
     return all_rules_by_file
-
-
-# --- Phase 2: Find all Transformer Implementations ---
-
 
 def find_transformer_rules(transformer_path):
     """
@@ -94,10 +89,6 @@ def find_transformer_rules(transformer_path):
 
     return transformer_rules
 
-
-# --- Phase 3 & 4: Find Enum Rules and Registrations ---
-
-
 def find_factory_registrations(factory_file_path):
     """
     Scans the factory file for RegisterEnum<...> and REGISTER_TRANSFORM(...)
@@ -132,19 +123,6 @@ def find_factory_registrations(factory_file_path):
         print(f"Error reading {factory_file_path}: {e}", file=sys.stderr)
 
     return enum_rules, registered_rules
-
-
-# --- NEW: Phase 5: Code Generation ---
-
-
-def guess_return_type(rule_name):
-    """
-    Makes an educated guess about the C++ return type for a rule.
-    """
-    if rule_name.endswith("Statement"):
-        return "unique_ptr<SQLStatement>"
-    # Default to a common base class for expressions
-    return "unique_ptr<ParsedExpression>"
 
 
 def generate_declaration_stub(rule_name):
@@ -285,8 +263,10 @@ def main():
                 missing_count_this_file += 1
                 missing_rules_for_gen.append(rule_name)
 
-            if args.skip_found and not ("FOUND" in status_str or "ENUM" in status_str):
-                print(f"{status_str:<14} {rule_name}")
+            if args.skip_found and ("FOUND" in status_str or "ENUM" in status_str):
+                continue
+
+            print(f"{status_str:<14} {rule_name}")
 
         if missing_count_this_file > 0:
             missing_rules_by_file[file_name] = missing_count_this_file

--- a/scripts/generate_peg_transformer.py
+++ b/scripts/generate_peg_transformer.py
@@ -1,34 +1,29 @@
-#!/usr/bin/env python3
-
 import re
 from pathlib import Path
 import sys
-import argparse  # Import argparse
+import argparse
 
-# --- Configuration ---
-# Paths are relative to the script's location
-SCRIPT_DIR = Path(__file__).parent
-GRAMMAR_DIR = SCRIPT_DIR / "../extension/autocomplete/grammar/statements"
-TRANSFORMER_DIR = SCRIPT_DIR / "../extension/autocomplete/transformer"
-FACTORY_REG_FILE = SCRIPT_DIR / "../extension/autocomplete/transformer/peg_transformer_factory.cpp"
+GRAMMAR_DIR = Path("../extension/autocomplete/grammar/statements")
+TRANSFORMER_DIR = Path("../extension/autocomplete/transformer")
+FACTORY_REG_FILE = Path("../extension/autocomplete/transformer/peg_transformer_factory.cpp")
+FACTORY_HPP_FILE = Path("../extension/autocomplete/include/transformer/peg_transformer.hpp")
 
-# Regex to find grammar rule names (e.g., "AlterStatement")
 # Matches: RuleName <- ...
 GRAMMAR_REGEX = re.compile(r"^(\w+)\s*<-")
 
-# Regex to find transformer function implementations (e.g., "AlterStatement")
 # Matches: PEGTransformerFactory::TransformRuleName(
 TRANSFORMER_REGEX = re.compile(r"PEGTransformerFactory::Transform(\w+)\s*\(")
 
-# Regex to find enum-registered rule names (e.g., "LocalScope")
 # Matches: RegisterEnum<...>("RuleName", ...);
 ENUM_RULE_REGEX = re.compile(r'RegisterEnum<[^>]+>\s*\(\s*"(\w+)"\s*,')
 
-# Regex to find registered transformer functions (e.g., "AlterStatement")
 # Matches: REGISTER_TRANSFORM(TransformRuleName)
 REGISTER_TRANSFORM_REGEX = re.compile(r"REGISTER_TRANSFORM\s*\(\s*Transform(\w+)\s*\)")
 
-# --- Phase 1: Find all Grammar Rules ---
+EXCLUDED_RULES = {
+    "FunctionType",
+    "IfExists"
+}
 
 def find_grammar_rules(grammar_path):
     """
@@ -47,9 +42,6 @@ def find_grammar_rules(grammar_path):
     if not gram_files:
         print(f"Error: No *.gram files found in {grammar_path}", file=sys.stderr)
         sys.exit(1)
-
-    print(f"🔍 Scanning {len(gram_files)} grammar files in {grammar_path}...")
-
     for file_path in gram_files:
         rules_in_file = []
         try:
@@ -87,7 +79,7 @@ def find_transformer_rules(transformer_path):
         print(f"Error: No *.cpp files found in {transformer_path}", file=sys.stderr)
         sys.exit(1)
 
-    print(f"🔍 Scanning {len(cpp_files)} transformer files in {transformer_path}...")
+    print(f"Scanning {len(cpp_files)} transformer files in {transformer_path}...")
 
     for file_path in cpp_files:
         try:
@@ -118,7 +110,7 @@ def find_factory_registrations(factory_file_path):
         print(f"Error: Factory file not found: {factory_file_path}", file=sys.stderr)
         return enum_rules, registered_rules
 
-    print(f"🔍 Scanning factory file: {factory_file_path}...")
+    print(f"Scanning factory file: {factory_file_path}...")
 
     try:
         with factory_file_path.open("r", encoding="utf-8") as f:
@@ -141,59 +133,74 @@ def find_factory_registrations(factory_file_path):
 
 # --- NEW: Phase 5: Code Generation ---
 
-def generate_stub_for_rule(rule_name):
+def guess_return_type(rule_name):
     """
-    Generates a C++ stub string for a given rule name.
-    We use unique_ptr<SQLStatement> as a common placeholder,
-    as requested in the prompt. This may need to be manually
-    changed for rules that don't return a statement.
+    Makes an educated guess about the C++ return type for a rule.
     """
-    return f"""
+    if rule_name.endswith("Statement"):
+        return "unique_ptr<SQLStatement>"
+    # Default to a common base class for expressions
+    return "unique_ptr<ParsedExpression>"
+
+def generate_declaration_stub(rule_name):
+    """Generates the C++ method declaration (for the .hpp file)."""
+    return f"""// TODO: Verify this return type is correct
+    static unique_ptr<SQLStatement> Transform{rule_name}(PEGTransformer &transformer, optional_ptr<ParseResult> parse_result);
+"""
+
+def generate_registration_stub(rule_name):
+    """Generates the C++ registration line (for peg_transformer_factory.cpp)."""
+    return f"REGISTER_TRANSFORM(Transform{rule_name});"
+
+def generate_implementation_stub(rule_name):
+    """Generates the C++ method implementation (for the transform_...cpp file)."""
+    return f"""// TODO: Verify this return type is correct
 unique_ptr<SQLStatement> PEGTransformerFactory::Transform{rule_name}(PEGTransformer &transformer,
                                                                    optional_ptr<ParseResult> parse_result) {{
 	throw NotImplementedException("Transform{rule_name} has not yet been implemented");
 }}
 """
 
-def generate_missing_stubs(generation_queue):
+def generate_code_for_missing_rules(generation_queue):
     """
-    Iterates the generation queue and prints stub code.
-    Checks that the target .cpp file exists before printing.
+    Iterates the generation queue and prints stub code, grouped by rule.
     """
     if not generation_queue:
-        print("\n✅ No missing rules to generate.")
+        print("\nNo missing rules to generate.")
         return
 
-    print("\n--- ✂️  Code Generation: Missing Stubs ---")
+    print("\n--- Code Generation: Missing Stubs ---")
     print("Copy and paste the code below into the correct files.")
 
+    rules_to_generate = [] # List of (rule_name, cpp_filename)
     for cpp_filename, rules in generation_queue.items():
+        for rule in rules:
+            rules_to_generate.append((rule, cpp_filename))
+
+    # Sort by rule name
+    for rule_name, cpp_filename in sorted(rules_to_generate):
         cpp_path = TRANSFORMER_DIR / cpp_filename
 
         # Constraint: Do not generate code for non-existent files
         if not cpp_path.is_file():
-            print(f"\n// --- SKIPPING: {cpp_filename} (File not found) ---")
-            for rule in rules:
-                print(f"//   - (Skipped) Transform{rule}")
+            print(f"\n// --- SKIPPING: {rule_name} (File not found: {cpp_filename}) ---")
             continue
 
-        print(f"\n// --- Add to: {cpp_path.relative_to(SCRIPT_DIR.parent)} ---")
-        print("\nnamespace duckdb {\n")
+        print(f"--- Generation for rule: {rule_name} ---")
+        print(f"1. Add DECLARATION to: {FACTORY_HPP_FILE}")
+        print(generate_declaration_stub(rule_name))
 
-        for rule_name in rules:
-            print(generate_stub_for_rule(rule_name))
+        print(f"2. Add REGISTRATION to: {FACTORY_REG_FILE}\n\tInside the appropriate Register...() function:")
+        print(generate_registration_stub(rule_name))
 
-        print("\n} // namespace duckdb\n")
-        print("// --- End of {cpp_filename} ---")
-
-
-# --- Main Execution ---
+        print(f"3. Add IMPLEMENTATION to: {cpp_path}")
+        print(generate_implementation_stub(rule_name))
+        print(f"--- End of {rule_name} ---")
 
 def main():
     """
     Main script to find rules, compare them, and print a report.
     """
-    # --- NEW: Argument Parsing ---
     parser = argparse.ArgumentParser(
         description="Check transformer coverage and optionally generate stubs."
     )
@@ -201,11 +208,10 @@ def main():
         "-g",
         "--generate",
         action="store_true",
-        help="Generate C++ stubs for missing transformer rules."
+        help="Generate C++ stubs (declaration, registration, implementation) for missing rules."
     )
     args = parser.parse_args()
 
-    # --- Run Phases 1-4 ---
     grammar_rules_by_file = find_grammar_rules(Path(GRAMMAR_DIR))
     transformer_impls = find_transformer_rules(Path(TRANSFORMER_DIR))
     enum_rules, registered_rules = find_factory_registrations(Path(FACTORY_REG_FILE))
@@ -214,7 +220,7 @@ def main():
         print("Error: Could not find grammar rules. Exiting.", file=sys.stderr)
         sys.exit(1)
 
-    print("\n--- 📋 Rule Coverage Check ---")
+    print("\n--- Rule Coverage Check ---")
 
     total_grammar_rules = 0
     total_found_enum = 0
@@ -224,7 +230,6 @@ def main():
     all_grammar_rules_flat = set()
     missing_rules_by_file = {}
 
-    # NEW: Dictionary to hold { "transform_file.cpp": ["Rule1", "Rule2"] }
     generation_queue = {}
 
     # Iterate through each file and its rules
@@ -232,17 +237,19 @@ def main():
         print(f"\n--- File: {file_name} ---")
         missing_count_this_file = 0
 
-        # --- NEW: Prepare for generation ---
-        # Map 'alter.gram' -> 'transform_alter.cpp'
         stem = file_path.stem
         cpp_filename = f"transform_{stem}.cpp"
         missing_rules_for_gen = []
 
         if not grammar_rules:
-            print("  (No grammar rules found in this file)")
+            print("(No grammar rules found in this file)")
             continue
 
         for rule_name in sorted(grammar_rules):
+            if rule_name in EXCLUDED_RULES:
+                print(f"{'[ EXCLUDED ]':<14} {rule_name}")
+                continue
+
             all_grammar_rules_flat.add(rule_name)
             total_grammar_rules += 1
 
@@ -251,93 +258,81 @@ def main():
             is_registered = rule_name in registered_rules
 
             if is_enum:
-                status_str = "[ ✅ ENUM ]"
+                status_str = "[ ENUM ]"
                 total_found_enum += 1
             elif is_transformer:
                 if is_registered:
-                    status_str = "[ ✅ FOUND ]"
+                    status_str = "[ FOUND ]"
                     total_found_registered += 1
                 else:
-                    status_str = "[ ⚠️ NOT REG'D ]"
+                    status_str = "[ NOT REG'D ]"
                     total_missing_registration += 1
                     missing_count_this_file += 1
             else:
-                status_str = "[ ❌ MISSING ]"
+                status_str = "[ MISSING ]"
                 total_missing_implementation += 1
                 missing_count_this_file += 1
-                # NEW: Add to generation queue
                 missing_rules_for_gen.append(rule_name)
 
-            # Use f-string padding to align to 14 characters
-            print(f"  {status_str:<14} {rule_name}")
+            print(f"{status_str:<14} {rule_name}")
 
         if missing_count_this_file > 0:
             missing_rules_by_file[file_name] = missing_count_this_file
 
-        # NEW: Add this file's missing rules to the main queue
         if missing_rules_for_gen:
             generation_queue[cpp_filename] = missing_rules_for_gen
 
-    # ... (Rest of the summary/orphan reports, no changes) ...
     total_covered = total_found_enum + total_found_registered
     total_issues = total_missing_implementation + total_missing_registration
     coverage = (total_covered / total_grammar_rules) * 100 if total_grammar_rules > 0 else 0
 
-    # --- Print Summary Report ---
-    print("\n--- 📊 Summary: Rule Coverage ---")
-    print(f"  {'TOTAL GRAMMAR RULES':<25} : {total_grammar_rules}")
-    print(f"  {'TOTAL COVERED':<25} : {total_covered} ({coverage:.2f}%)")
-    print(f"    {'  - Enum':<23} : {total_found_enum}")
-    print(f"    {'  - Registered':<23} : {total_found_registered}")
-    print(f"  {'TOTAL ISSUES':<25} : {total_issues}")
-    print(f"    {'  - Missing Impl':<23} : {total_missing_implementation}")
-    print(f"    {'  - Not Registered':<23} : {total_missing_registration}")
-
+    print("\n--- Summary: Rule Coverage ---")
+    print(f"{'TOTAL GRAMMAR RULES':<25} : {total_grammar_rules}")
+    print(f"{'TOTAL COVERED':<25} : {total_covered} ({coverage:.2f}%)")
+    print(f"  {'  - Enum':<23} : {total_found_enum}")
+    print(f"  {'  - Registered':<23} : {total_found_registered}")
+    print(f"{'TOTAL ISSUES':<25} : {total_issues}")
+    print(f"  {'  - Missing Impl':<23} : {total_missing_implementation}")
+    print(f"  {'  - Not Registered':<23} : {total_missing_registration}")
 
     if missing_rules_by_file:
-        print("\n--- 📊 Summary: Issues Per File ---")
+        print("\n--- Summary: Issues Per File ---")
         for file_name, count in sorted(missing_rules_by_file.items()):
-            print(f"  {file_name:<25} : {count} issues")
+            print(f"{file_name:<25} : {count} issues")
 
-    # --- Check for "Orphan" Rules (Implementation without Grammar) ---
-    print("\n--- ⚠️  Orphan / Mismatch Check ---")
-
-    orphan_transformers = transformer_impls - all_grammar_rules_flat
+    print("\n--- Orphan / Mismatch Check ---")
+    orphan_transformers = transformer_impls - all_grammar_rules_flat - EXCLUDED_RULES
     if orphan_transformers:
-        print("\n  [!] Orphan Transformer Functions (No matching grammar rule):")
+        print("\n[!] Orphan Transformer Functions (No matching grammar rule):")
         for rule in sorted(list(orphan_transformers)):
-            print(f"    - Transform{rule}")
+            print(f"  - Transform{rule}")
 
-    orphan_enums = enum_rules - all_grammar_rules_flat
+    orphan_enums = enum_rules - all_grammar_rules_flat - EXCLUDED_RULES
     if orphan_enums:
-        print("\n  [!] Orphan Enum Rules (No matching grammar rule):")
+        print("\n[!] Orphan Enum Rules (No matching grammar rule):")
         for rule in sorted(list(orphan_enums)):
-            print(f"    - RegisterEnum(\"{rule}\")")
+            print(f"  - RegisterEnum(\"{rule}\")")
 
-    orphan_registrations = registered_rules - all_grammar_rules_flat
+    orphan_registrations = registered_rules - all_grammar_rules_flat - EXCLUDED_RULES
     if orphan_registrations:
-        print("\n  [!] Orphan Registrations (No matching grammar rule):")
+        print("\n[!] Orphan Registrations (No matching grammar rule):")
         for rule in sorted(list(orphan_registrations)):
-            print(f"    - REGISTER_TRANSFORM(Transform{rule})")
+            print(f"  - REGISTER_TRANSFORM(Transform{rule})")
 
-    # --- Check for Mismatches ---
     missing_impl = registered_rules - transformer_impls
     if missing_impl:
         print("\n  [!] Registered but NOT Implemented (Will cause C++ error):")
         for rule in sorted(list(missing_impl)):
-            print(f"    - REGISTER_TRANSFORM(Transform{rule})")
+            print(f"  - REGISTER_TRANSFORM(Transform{rule})")
 
     unnecessary_reg = registered_rules.intersection(enum_rules)
     if unnecessary_reg:
-        print("\n  [!] Rule registered as BOTH Enum and Transformer (Ambiguous):")
+        print("\n[!] Rule registered as BOTH Enum and Transformer (Ambiguous):")
         for rule in sorted(list(unnecessary_reg)):
-            print(f"    - {rule}")
+            print(f"  - {rule}")
 
-    print("\n✅ Done.")
-
-    # --- NEW: Run Generation if Flag is Set ---
     if args.generate:
-        generate_missing_stubs(generation_queue)
+        generate_code_for_missing_rules(generation_queue)
 
 
 if __name__ == "__main__":

--- a/scripts/generate_peg_transformer.py
+++ b/scripts/generate_peg_transformer.py
@@ -190,12 +190,12 @@ def generate_code_for_missing_rules(generation_queue):
         print(f"1. Add DECLARATION to: {FACTORY_HPP_FILE}")
         print(generate_declaration_stub(rule_name))
 
-        print(f"2. Add REGISTRATION to: {FACTORY_REG_FILE}\n\tInside the appropriate Register...() function:")
+        print(f"2. Add REGISTRATION to: {FACTORY_REG_FILE}\nInside the appropriate Register...() function:")
         print(generate_registration_stub(rule_name))
 
         print(f"3. Add IMPLEMENTATION to: {cpp_path}")
         print(generate_implementation_stub(rule_name))
-        print(f"--- End of {rule_name} ---")
+        print(f"--- End of {rule_name} ---\n")
 
 def main():
     """
@@ -223,6 +223,7 @@ def main():
     print("\n--- Rule Coverage Check ---")
 
     total_grammar_rules = 0
+    total_rules_scanned = 0
     total_found_enum = 0
     total_found_registered = 0
     total_missing_registration = 0
@@ -246,6 +247,7 @@ def main():
             continue
 
         for rule_name in sorted(grammar_rules):
+            total_rules_scanned += 1
             if rule_name in EXCLUDED_RULES:
                 print(f"{'[ EXCLUDED ]':<14} {rule_name}")
                 continue
@@ -287,13 +289,14 @@ def main():
     coverage = (total_covered / total_grammar_rules) * 100 if total_grammar_rules > 0 else 0
 
     print("\n--- Summary: Rule Coverage ---")
-    print(f"{'TOTAL GRAMMAR RULES':<25} : {total_grammar_rules}")
+    print(f"{'TOTAL RULES SCANNED':<25} : {total_rules_scanned}")
+    print(f"  {'  - Excluded':<23} : {len(EXCLUDED_RULES)}")
+    print("---------------------------------------")
+    print(f"{'TOTAL ACTIONABLE RULES':<25} : {total_grammar_rules}")
     print(f"{'TOTAL COVERED':<25} : {total_covered} ({coverage:.2f}%)")
     print(f"  {'  - Enum':<23} : {total_found_enum}")
     print(f"  {'  - Registered':<23} : {total_found_registered}")
     print(f"{'TOTAL ISSUES':<25} : {total_issues}")
-    print(f"  {'  - Missing Impl':<23} : {total_missing_implementation}")
-    print(f"  {'  - Not Registered':<23} : {total_missing_registration}")
 
     if missing_rules_by_file:
         print("\n--- Summary: Issues Per File ---")

--- a/scripts/generate_peg_transformer.py
+++ b/scripts/generate_peg_transformer.py
@@ -210,6 +210,13 @@ def main():
         action="store_true",
         help="Generate C++ stubs (declaration, registration, implementation) for missing rules."
     )
+    parser.add_argument(
+        "-s",
+        "--skip-found",
+        action="store_true",
+        help="Skip output of [ FOUND ] rules"
+    )
+
     args = parser.parse_args()
 
     grammar_rules_by_file = find_grammar_rules(Path(GRAMMAR_DIR))
@@ -276,7 +283,8 @@ def main():
                 missing_count_this_file += 1
                 missing_rules_for_gen.append(rule_name)
 
-            print(f"{status_str:<14} {rule_name}")
+            if args.skip_found and not ("FOUND" in status_str or "ENUM" in status_str):
+                print(f"{status_str:<14} {rule_name}")
 
         if missing_count_this_file > 0:
             missing_rules_by_file[file_name] = missing_count_this_file

--- a/scripts/generate_peg_transformer.py
+++ b/scripts/generate_peg_transformer.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+
+import re
+from pathlib import Path
+import sys
+
+# --- Configuration ---
+GRAMMAR_DIR = "../extension/autocomplete/grammar/statements"
+TRANSFORMER_DIR = "../extension/autocomplete/transformer"
+ENUM_RULES_FILE = "../extension/autocomplete/transformer/peg_transformer_factory.cpp"
+
+# Regex to find grammar rule names (e.g., "AlterStatement")
+# Matches: RuleName <- ...
+GRAMMAR_REGEX = re.compile(r"^(\w+)\s*<-")
+
+# Regex to find transformer rule names (e.g., "AlterStatement")
+# Matches: PEGTransformerFactory::TransformRuleName(
+TRANSFORMER_REGEX = re.compile(r"PEGTransformerFactory::Transform(\w+)\s*\(")
+
+# Regex to find enum-registered rule names (e.g., "LocalScope")
+# Matches: RegisterEnum<...>("RuleName", ...);
+ENUM_RULE_REGEX = re.compile(r'RegisterEnum<[^>]+>\s*\(\s*"(\w+)"\s*,')
+
+# --- Phase 1: Find all Grammar Rules ---
+
+def find_grammar_rules(grammar_path):
+    """
+    Scans the grammar directory for *.gram files and extracts all rule names.
+
+    Returns a dictionary mapping:
+    { "filename.gram": ["Rule1", "Rule2"], ... }
+    """
+    all_rules_by_file = {}
+
+    if not grammar_path.is_dir():
+        print(f"Error: Grammar directory not found: {grammar_path}", file=sys.stderr)
+        sys.exit(1)
+
+    gram_files = sorted(list(grammar_path.glob("*.gram")))
+    if not gram_files:
+        print(f"Error: No *.gram files found in {grammar_path}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"🔍 Scanning {len(gram_files)} grammar files in {grammar_path}...")
+
+    for file_path in gram_files:
+        rules_in_file = []
+        try:
+            with file_path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    match = GRAMMAR_REGEX.match(line)
+                    if match:
+                        rules_in_file.append(match.group(1))
+        except Exception as e:
+            print(f"Error reading {file_path}: {e}", file=sys.stderr)
+            continue
+
+        all_rules_by_file[file_path.name] = rules_in_file
+
+    return all_rules_by_file
+
+# --- Phase 2: Find all Transformer Rules ---
+
+def find_transformer_rules(transformer_path):
+    """
+    Scans the transformer directory for *.cpp files and extracts all rule names
+    from PEGTransformerFactory::Transform...() functions.
+
+    Returns a set of all found rule names:
+    { "AlterStatement", "AlterTableStmt", ... }
+    """
+    transformer_rules = set()
+
+    if not transformer_path.is_dir():
+        print(f"Error: Transformer directory not found: {transformer_path}", file=sys.stderr)
+        sys.exit(1)
+
+    cpp_files = sorted(list(transformer_path.glob("*.cpp")))
+    if not cpp_files:
+        print(f"Error: No *.cpp files found in {transformer_path}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"🔍 Scanning {len(cpp_files)} transformer files in {transformer_path}...")
+
+    for file_path in cpp_files:
+        try:
+            with file_path.open("r", encoding="utf-8") as f:
+                content = f.read()
+                matches = TRANSFORMER_REGEX.finditer(content)
+                for match in matches:
+                    transformer_rules.add(match.group(1))
+        except Exception as e:
+            print(f"Error reading {file_path}: {e}", file=sys.stderr)
+            continue
+
+    return transformer_rules
+
+# --- Phase 3: Find all Enum-Registered Rules ---
+
+def find_enum_rules(enum_file_path):
+    """
+    Scans the specified file for RegisterEnum<...>("RuleName", ...) calls.
+
+    Returns a set of all found rule names:
+    { "LocalScope", "GlobalScope", ... }
+    """
+    enum_rules = set()
+
+    if not enum_file_path.is_file():
+        print(f"Error: Enum rules file not found: {enum_file_path}", file=sys.stderr)
+        return enum_rules # Return empty set, but proceed
+
+    print(f"🔍 Scanning enum rules file: {enum_file_path}...")
+
+    try:
+        with enum_file_path.open("r", encoding="utf-8") as f:
+            content = f.read()
+            matches = ENUM_RULE_REGEX.finditer(content)
+            for match in matches:
+                # group(1) is the captured rule name (e.g., "LocalScope")
+                enum_rules.add(match.group(1))
+    except Exception as e:
+        print(f"Error reading {enum_file_path}: {e}", file=sys.stderr)
+
+    return enum_rules
+
+# --- Main Execution ---
+
+def main():
+    """
+    Main script to find rules, compare them, and print a report.
+    """
+    grammar_rules_by_file = find_grammar_rules(Path(GRAMMAR_DIR))
+    transformer_rules = find_transformer_rules(Path(TRANSFORMER_DIR))
+    enum_rules = find_enum_rules(Path(ENUM_RULES_FILE))
+
+    if not grammar_rules_by_file:
+        print("Error: Could not find grammar rules. Exiting.", file=sys.stderr)
+        sys.exit(1)
+
+    # Combine both sets of "covered" rules
+    covered_rules = transformer_rules.union(enum_rules)
+
+    print("\n--- 📋 Rule Coverage Check ---")
+
+    missing_rules_by_file = {}
+    total_grammar_rules = 0
+    total_found = 0
+    all_grammar_rules_flat = set()
+
+    # Iterate through each file and its rules
+    for file_name, grammar_rules in sorted(grammar_rules_by_file.items()):
+        print(f"\n--- File: {file_name} ---")
+        missing_in_this_file = 0
+
+        if not grammar_rules:
+            print("  (No grammar rules found in this file)")
+            continue
+
+        for rule_name in sorted(grammar_rules):
+            all_grammar_rules_flat.add(rule_name)
+            total_grammar_rules += 1
+
+            # Check if the grammar rule exists in the combined set of covered rules
+            if rule_name in covered_rules:
+                print(f"  [ ✅ FOUND ]   {rule_name}")
+                total_found += 1
+            else:
+                print(f"  [ ❌ MISSING ] {rule_name}")
+                missing_in_this_file += 1
+
+        missing_rules_by_file[file_name] = missing_in_this_file
+
+    total_missing = total_grammar_rules - total_found
+
+    # --- Print Summary Report ---
+    print("\n--- 📊 Summary: Missing Rules Per File ---")
+    for file_name, count in sorted(missing_rules_by_file.items()):
+        if count > 0:
+            print(f"  {file_name:<25} : {count} missing")
+
+    print("-----------------------------------------")
+    print(f"  {'TOTAL GRAMMAR RULES':<25} : {total_grammar_rules}")
+    print(f"  {'TOTAL FOUND':<25} : {total_found}")
+    print(f"  {'TOTAL MISSING':<25} : {total_missing}")
+
+    coverage = (total_found / total_grammar_rules) * 100 if total_grammar_rules > 0 else 0
+    print(f"  {'COVERAGE':<25} : {coverage:.2f}%")
+
+    # --- Check for "Orphan" Rules ---
+    orphan_transformers = transformer_rules - all_grammar_rules_flat
+    if orphan_transformers:
+        print("\n--- ⚠️  Orphan Transformer Functions (No matching grammar rule) ---")
+        for orphan_rule in sorted(list(orphan_transformers)):
+            print(f"  [ ❓ ORPHAN ]  Transform{orphan_rule}")
+
+    orphan_enums = enum_rules - all_grammar_rules_flat
+    if orphan_enums:
+        print("\n--- ⚠️  Orphan Enum Rules (No matching grammar rule) ---")
+        for orphan_rule in sorted(list(orphan_enums)):
+            print(f"  [ ❓ ORPHAN ]  RegisterEnum(\"{orphan_rule}\")")
+
+    print("\n✅ Done.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_peg_transformer.py
+++ b/scripts/generate_peg_transformer.py
@@ -20,7 +20,16 @@ ENUM_RULE_REGEX = re.compile(r'RegisterEnum<[^>]+>\s*\(\s*"(\w+)"\s*,')
 # Matches: REGISTER_TRANSFORM(TransformRuleName)
 REGISTER_TRANSFORM_REGEX = re.compile(r"REGISTER_TRANSFORM\s*\(\s*Transform(\w+)\s*\)")
 
-EXCLUDED_RULES = {"FunctionType", "IfExists"}
+EXCLUDED_RULES = {
+    "FunctionType",
+    "IfExists",
+    "AbortOrRollback",
+    "CommitOrEnd",
+    "StartOrBegin",
+    "Transaction",
+    "VariableAssign",
+}
+
 
 def find_grammar_rules(grammar_path):
     """
@@ -55,6 +64,7 @@ def find_grammar_rules(grammar_path):
 
     return all_rules_by_file
 
+
 def find_transformer_rules(transformer_path):
     """
     Scans the transformer directory for *.cpp files and extracts all
@@ -88,6 +98,7 @@ def find_transformer_rules(transformer_path):
             continue
 
     return transformer_rules
+
 
 def find_factory_registrations(factory_file_path):
     """

--- a/scripts/generate_peg_transformer.py
+++ b/scripts/generate_peg_transformer.py
@@ -20,10 +20,8 @@ ENUM_RULE_REGEX = re.compile(r'RegisterEnum<[^>]+>\s*\(\s*"(\w+)"\s*,')
 # Matches: REGISTER_TRANSFORM(TransformRuleName)
 REGISTER_TRANSFORM_REGEX = re.compile(r"REGISTER_TRANSFORM\s*\(\s*Transform(\w+)\s*\)")
 
-EXCLUDED_RULES = {
-    "FunctionType",
-    "IfExists"
-}
+EXCLUDED_RULES = {"FunctionType", "IfExists"}
+
 
 def find_grammar_rules(grammar_path):
     """
@@ -58,7 +56,9 @@ def find_grammar_rules(grammar_path):
 
     return all_rules_by_file
 
+
 # --- Phase 2: Find all Transformer Implementations ---
+
 
 def find_transformer_rules(transformer_path):
     """
@@ -94,7 +94,9 @@ def find_transformer_rules(transformer_path):
 
     return transformer_rules
 
+
 # --- Phase 3 & 4: Find Enum Rules and Registrations ---
+
 
 def find_factory_registrations(factory_file_path):
     """
@@ -131,7 +133,9 @@ def find_factory_registrations(factory_file_path):
 
     return enum_rules, registered_rules
 
+
 # --- NEW: Phase 5: Code Generation ---
+
 
 def guess_return_type(rule_name):
     """
@@ -142,15 +146,18 @@ def guess_return_type(rule_name):
     # Default to a common base class for expressions
     return "unique_ptr<ParsedExpression>"
 
+
 def generate_declaration_stub(rule_name):
     """Generates the C++ method declaration (for the .hpp file)."""
     return f"""// TODO: Verify this return type is correct
     static unique_ptr<SQLStatement> Transform{rule_name}(PEGTransformer &transformer, optional_ptr<ParseResult> parse_result);
 """
 
+
 def generate_registration_stub(rule_name):
     """Generates the C++ registration line (for peg_transformer_factory.cpp)."""
     return f"REGISTER_TRANSFORM(Transform{rule_name});"
+
 
 def generate_implementation_stub(rule_name):
     """Generates the C++ method implementation (for the transform_...cpp file)."""
@@ -160,6 +167,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::Transform{rule_name}(PEGTransfor
 	throw NotImplementedException("Transform{rule_name} has not yet been implemented");
 }}
 """
+
 
 def generate_code_for_missing_rules(generation_queue):
     """
@@ -172,7 +180,7 @@ def generate_code_for_missing_rules(generation_queue):
     print("\n--- Code Generation: Missing Stubs ---")
     print("Copy and paste the code below into the correct files.")
 
-    rules_to_generate = [] # List of (rule_name, cpp_filename)
+    rules_to_generate = []  # List of (rule_name, cpp_filename)
     for cpp_filename, rules in generation_queue.items():
         for rule in rules:
             rules_to_generate.append((rule, cpp_filename))
@@ -197,25 +205,19 @@ def generate_code_for_missing_rules(generation_queue):
         print(generate_implementation_stub(rule_name))
         print(f"--- End of {rule_name} ---\n")
 
+
 def main():
     """
     Main script to find rules, compare them, and print a report.
     """
-    parser = argparse.ArgumentParser(
-        description="Check transformer coverage and optionally generate stubs."
-    )
+    parser = argparse.ArgumentParser(description="Check transformer coverage and optionally generate stubs.")
     parser.add_argument(
         "-g",
         "--generate",
         action="store_true",
-        help="Generate C++ stubs (declaration, registration, implementation) for missing rules."
+        help="Generate C++ stubs (declaration, registration, implementation) for missing rules.",
     )
-    parser.add_argument(
-        "-s",
-        "--skip-found",
-        action="store_true",
-        help="Skip output of [ FOUND ] rules"
-    )
+    parser.add_argument("-s", "--skip-found", action="store_true", help="Skip output of [ FOUND ] rules")
 
     args = parser.parse_args()
 

--- a/scripts/generate_peg_transformer.py
+++ b/scripts/generate_peg_transformer.py
@@ -177,7 +177,6 @@ def main():
             is_transformer = rule_name in transformer_impls
             is_registered = rule_name in registered_rules
 
-            status_str = ""
             if is_enum:
                 status_str = "[ ✅ ENUM ]"
                 total_found_enum += 1


### PR DESCRIPTION
Part of epic: https://github.com/duckdblabs/duckdb-internal/issues/6380

Hi there,
This PR introduces a script `generate_peg_transformer.py` that looks at all the grammar files in `autocomplete/statement` and tries to find the corresponding transformer rule. 
It outputs per `*.gram` file which rules are still missing a transformer rule. In most cases, every grammar rule corresponds to a transformer rule for the PEG parser. Rules can be excluded if we don't require a transformer rule. 
For `alter.gram` for instance, the output will as follows to indicate that these transformer rules are still missing: 
```
--- File: alter.gram ---
[ MISSING ]    AlterSchemaStmt
[ MISSING ]    SetData
``` 

Additionally, when using the `-g` argument, the script prints a template for every missing transformer rule (in alphabetical order). It will output three parts:
1. The method declaration that should be pasted into `peg_transformer.hpp`
2. The method implementation 
3. The transformer rule registation
The standard type that is used is `unique_ptr<SQLStatement>`. This is most likely not correct, but at the moment it is not possible to know the type in this template script. We could add a file where we can specify the return type for every rule if this is important enough. For now I added a `// TODO` to remind users to check the return type. 

I decided against letting this script modify the `transform_*.cpp` files directly to avoid making the script overly complex. Perhaps in a future update this could be looked into. 

For example, for `WithinGroupClause`: 
```
--- Generation for rule: WithinGroupClause ---
1. Add DECLARATION to: ../extension/autocomplete/include/transformer/peg_transformer.hpp
// TODO: Verify this return type is correct
    static unique_ptr<SQLStatement> TransformWithinGroupClause(PEGTransformer &transformer, optional_ptr<ParseResult> parse_result);

3. Add REGISTRATION to: ../extension/autocomplete/transformer/peg_transformer_factory.cpp
Inside the appropriate Register...() function:
REGISTER_TRANSFORM(TransformWithinGroupClause);

4. Add IMPLEMENTATION to: ../extension/autocomplete/transformer/transform_expression.cpp
// TODO: Verify this return type is correct
unique_ptr<SQLStatement> PEGTransformerFactory::TransformWithinGroupClause(PEGTransformer &transformer,
                                                                   optional_ptr<ParseResult> parse_result) {
	throw NotImplementedException("TransformWithinGroupClause has not yet been implemented");
}

--- End of WithinGroupClause ---
```

In a future PR, when the transformer is close to completion, I would like to use this file in a workflow to check for missing transformer rules.

Finally, it will output orphan rules, transformer rules that don't have a corresponding grammar rule. To avoid keeping transformer rules around that don't do anything. 

There are currently two arguments: 
- `-g` or `--generate`: 
- `-s` or `--skip-found`: Skips the rules that have the status [ FOUND ] or [ ENUM ] to keep the output a bit cleaner. 