### PR TITLE
CLI: Silence auto-complete failures instead of exiting

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3544,6 +3544,9 @@ static void linenoise_completion(const char *zLine, linenoiseCompletions *lc) {
 
 		auto &con = *state.conn;
 		auto result = con.Query(zSql);
+		if (result->HasError()) {
+			return;
+		}
 		for (auto &row : *result) {
 			auto zCompletion = row.GetValue<string>(0);
 			idx_t iStart = row.GetValue<idx_t>(1);
@@ -3551,9 +3554,7 @@ static void linenoise_completion(const char *zLine, linenoiseCompletions *lc) {
 			linenoiseAddCompletion(lc, zLine, zCompletion.c_str(), zCompletion.size(), iStart, completion_type.c_str());
 		}
 	} catch (std::exception &ex) {
-		ErrorData error(ex);
-		state.PrintF(PrintOutput::STDERR, "Failure during auto-completion: %s\n", error.Message());
-		exit(1);
+		return;
 	}
 }
 #endif


### PR DESCRIPTION
These are not critical - we can just ignore failures here. This fixes e.g. exiting if the extension is not loaded when trying to auto-complete.