### PR TITLE
Use PLAIN_DICTIONARY for Parquet version 1

### DIFF
--- a/extension/parquet/include/writer/templated_column_writer.hpp
+++ b/extension/parquet/include/writer/templated_column_writer.hpp
@@ -126,7 +126,8 @@ public:
 public:
 	unique_ptr<ColumnWriterState> InitializeWriteState(duckdb_parquet::RowGroup &row_group) override {
 		auto result = make_uniq<StandardColumnWriterState<SRC, TGT, OP>>(writer, row_group, row_group.columns.size());
-		result->encoding = duckdb_parquet::Encoding::RLE_DICTIONARY;
+		result->encoding = writer.GetParquetVersion() == ParquetVersion::V1 ? duckdb_parquet::Encoding::PLAIN_DICTIONARY
+		                                                                    : duckdb_parquet::Encoding::RLE_DICTIONARY;
 		RegisterToRowGroup(row_group);
 		return std::move(result);
 	}
@@ -150,6 +151,8 @@ public:
 			}
 			page_state.dbp_encoder.FinishWrite(temp_writer);
 			break;
+		case duckdb_parquet::Encoding::PLAIN_DICTIONARY:
+			// PLAIN_DICTIONARY can be treated the same as RLE_DICTIONARY
 		case duckdb_parquet::Encoding::RLE_DICTIONARY:
 			D_ASSERT(page_state.dict_bit_width != 0);
 			if (!page_state.dict_written_value) {
@@ -266,7 +269,8 @@ public:
 
 	bool HasDictionary(PrimitiveColumnWriterState &state_p) override {
 		auto &state = state_p.Cast<StandardColumnWriterState<SRC, TGT, OP>>();
-		return state.encoding == duckdb_parquet::Encoding::RLE_DICTIONARY;
+		return state.encoding == duckdb_parquet::Encoding::RLE_DICTIONARY ||
+		       state.encoding == duckdb_parquet::Encoding::PLAIN_DICTIONARY;
 	}
 
 	idx_t DictionarySize(PrimitiveColumnWriterState &state_p) override {
@@ -286,7 +290,8 @@ public:
 
 	void FlushDictionary(PrimitiveColumnWriterState &state_p, ColumnWriterStatistics *stats) override {
 		auto &state = state_p.Cast<StandardColumnWriterState<SRC, TGT, OP>>();
-		D_ASSERT(state.encoding == duckdb_parquet::Encoding::RLE_DICTIONARY);
+		D_ASSERT(state.encoding == duckdb_parquet::Encoding::RLE_DICTIONARY ||
+		         state.encoding == duckdb_parquet::Encoding::PLAIN_DICTIONARY);
 
 		if (writer.EnableBloomFilters()) {
 			state.bloom_filter =
@@ -311,7 +316,8 @@ public:
 	idx_t GetRowSize(const Vector &vector, const idx_t index,
 	                 const PrimitiveColumnWriterState &state_p) const override {
 		auto &state = state_p.Cast<StandardColumnWriterState<SRC, TGT, OP>>();
-		if (state.encoding == duckdb_parquet::Encoding::RLE_DICTIONARY) {
+		if (state.encoding == duckdb_parquet::Encoding::RLE_DICTIONARY ||
+		    state.encoding == duckdb_parquet::Encoding::PLAIN_DICTIONARY) {
 			return (state.key_bit_width + 7) / 8;
 		} else {
 			return OP::template GetRowSize<SRC, TGT>(vector, index);
@@ -329,6 +335,8 @@ private:
 		const auto *data_ptr = FlatVector::GetData<SRC>(input_column);
 
 		switch (page_state.encoding) {
+		case duckdb_parquet::Encoding::PLAIN_DICTIONARY:
+			// PLAIN_DICTIONARY can be treated the same as RLE_DICTIONARY
 		case duckdb_parquet::Encoding::RLE_DICTIONARY: {
 			idx_t r = chunk_start;
 			if (!page_state.dict_written_value) {

--- a/test/sql/copy/parquet/alltypes-dictionaries.test
+++ b/test/sql/copy/parquet/alltypes-dictionaries.test
@@ -3,6 +3,9 @@
 
 require parquet
 
+#
+# do tests with IMPLICIT parquet_version, (default is v1)
+#
 
 foreach type TINYINT SMALLINT INTEGER BIGINT HUGEINT UTINYINT USMALLINT UINTEGER UBIGINT UHUGEINT FLOAT DOUBLE VARCHAR
 
@@ -12,7 +15,7 @@ copy (select (r1.range * 10)::${type} r from range(10) r1, range(1000) r2) to '_
 query I
 select first(encodings) from parquet_metadata('__TEST_DIR__/dict-${type}.parquet') group by encodings;
 ----
-RLE_DICTIONARY
+PLAIN_DICTIONARY
 
 query I
 SELECT COUNT(*) from '__TEST_DIR__/dict-${type}.parquet' WHERE r='20'
@@ -26,6 +29,68 @@ select column_id, BOOL_AND(bloom_filter_offset > 4), BOOL_AND(bloom_filter_lengt
 
 #query I
 #SELECT bloom_filter_excludes FROM parquet_bloom_probe('__TEST_DIR__/dict-${type}.parquet', 'r', '11');
+#----
+#true
+
+endloop
+
+#
+# same tests with EXPLICIT parquet_version v1
+#
+
+foreach type TINYINT SMALLINT INTEGER BIGINT HUGEINT UTINYINT USMALLINT UINTEGER UBIGINT UHUGEINT FLOAT DOUBLE VARCHAR
+
+statement ok
+copy (select (r1.range * 10)::${type} r from range(10) r1, range(1000) r2) to '__TEST_DIR__/dict-${type}-v1.parquet' (row_group_size 2048, parquet_version v1);
+
+query I
+select first(encodings) from parquet_metadata('__TEST_DIR__/dict-${type}-v1.parquet') group by encodings;
+----
+PLAIN_DICTIONARY
+
+query I
+SELECT COUNT(*) from '__TEST_DIR__/dict-${type}-v1.parquet' WHERE r='20'
+----
+1000
+
+query III
+select column_id, BOOL_AND(bloom_filter_offset > 4), BOOL_AND(bloom_filter_length > 1)  from parquet_metadata('__TEST_DIR__/dict-${type}-v1.parquet') group by column_id order by column_id;
+----
+0	true	true
+
+#query I
+#SELECT bloom_filter_excludes FROM parquet_bloom_probe('__TEST_DIR__/dict-${type}-v1.parquet', 'r', '11');
+#----
+#true
+
+endloop
+
+#
+# same tests with EXPLICIT parquet_version v2
+#
+
+foreach type TINYINT SMALLINT INTEGER BIGINT HUGEINT UTINYINT USMALLINT UINTEGER UBIGINT UHUGEINT FLOAT DOUBLE VARCHAR
+
+statement ok
+copy (select (r1.range * 10)::${type} r from range(10) r1, range(1000) r2) to '__TEST_DIR__/dict-${type}-v2.parquet' (row_group_size 2048, parquet_version v2);
+
+query I
+select first(encodings) from parquet_metadata('__TEST_DIR__/dict-${type}-v2.parquet') group by encodings;
+----
+RLE_DICTIONARY
+
+query I
+SELECT COUNT(*) from '__TEST_DIR__/dict-${type}-v2.parquet' WHERE r='20'
+----
+1000
+
+query III
+select column_id, BOOL_AND(bloom_filter_offset > 4), BOOL_AND(bloom_filter_length > 1)  from parquet_metadata('__TEST_DIR__/dict-${type}-v2.parquet') group by column_id order by column_id;
+----
+0	true	true
+
+#query I
+#SELECT bloom_filter_excludes FROM parquet_bloom_probe('__TEST_DIR__/dict-${type}-v1.parquet', 'r', '11');
 #----
 #true
 

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -273,21 +273,31 @@ from range(100) r1, range(100) order by r) to '__TEST_DIR__/bloom9.parquet' (for
 ----
 Binder Error
 
-# test some repeated large strings
-# this should give dictionary
+# test some repeated large strings (with default parquet_version v1)
+# this should give PLAIN_DICTIONARY dictionary
 statement ok
 copy (select repeat('abc', 500_000) || (range % 10) s from range(100)) to '__TEST_DIR__/my.parquet';
 
 query I
 select encodings from parquet_metadata('__TEST_DIR__/my.parquet');
 ----
+PLAIN_DICTIONARY
+
+# test some repeated large strings with parquet_version v2
+# this should give RLE_DICTIONARY dictionary
+statement ok
+copy (select repeat('abc', 500_000) || (range % 10) s from range(100)) to '__TEST_DIR__/my.parquet' (parquet_version v2);
+
+query I
+select encodings from parquet_metadata('__TEST_DIR__/my.parquet');
+----
 RLE_DICTIONARY
 
-# this cannot do dictionary because the strings exceed the limit
+# this cannot do any dictionaries because the strings exceed the limit
 statement ok
 copy (select repeat('abc', 500_000) || (range % 10) s from range(100)) to '__TEST_DIR__/my.parquet' (STRING_DICTIONARY_PAGE_SIZE_LIMIT 4_000_000);
 
 query I
-select encodings = 'RLE_DICTIONARY' from parquet_metadata('__TEST_DIR__/my.parquet');
+select encodings in ('PLAIN_DICTIONARY', 'RLE_DICTIONARY') from parquet_metadata('__TEST_DIR__/my.parquet');
 ----
 false

--- a/test/sql/copy/parquet/writer/parquet_write_strings_v1.test
+++ b/test/sql/copy/parquet/writer/parquet_write_strings_v1.test
@@ -1,5 +1,5 @@
-# name: test/sql/copy/parquet/writer/parquet_write_strings.test
-# description: Strings tests with Parquet v2 format.
+# name: test/sql/copy/parquet/writer/parquet_write_strings_v1.test
+# description: Strings tests with Parquet v1 format. Other than that, same as test/sql/copy/parquet/writer/parquet_write_strings.test.
 # group: [writer]
 
 require parquet
@@ -21,12 +21,12 @@ INSERT INTO strings VALUES
     ('happy'), ('happy'), ('joy'), ('joy'), ('surprise');
 
 statement ok
-COPY strings TO '__TEST_DIR__/strings.parquet' (FORMAT PARQUET, PARQUET_VERSION v2);
+COPY strings TO '__TEST_DIR__/strings.parquet' (FORMAT PARQUET, PARQUET_VERSION v1);
 
 query I
 SELECT encodings FROM parquet_metadata('__TEST_DIR__/strings.parquet')
 ----
-RLE_DICTIONARY
+PLAIN_DICTIONARY
 
 query I
 SELECT * FROM '__TEST_DIR__/strings.parquet'


### PR DESCRIPTION
Since RLE_DICTIONARY was introduced in Parquet v2, using it with v1 technically violates the specification.

One example where this is a problem is Apache Impara 3.x (prior 4). Impara 3.x does not support `RLE_DICTIONARY`, and therefore cannot read parquet files generated by DuckDB. The final version of Impara 3.x was released just last year and is currently being used by several data warehouse cloud services.

Therefore, I think DuckDB needs an option to select `PLAIN_DICTIONARY` instead of `RLE_DICTIONARY`, and using `parquet_version` would be a reasonable option for this.

I believe I added the necessary tests, but I couldn't find a way to parameterize `parquet_version`, so I think it's a bit redundant.

I could have set `parquet_version` to v2 by default, but I decided against it, as I thought the impact would be too large to propose in this PR.

For reference, here is a link to my previous statement on this: https://github.com/duckdb/duckdb/pull/18855#issuecomment-3291517851