### PR TITLE
PositionalScan: handle also HAVE_MORE_OUTPUT + empty chunk via iteration

### DIFF
--- a/src/execution/operator/scan/physical_positional_scan.cpp
+++ b/src/execution/operator/scan/physical_positional_scan.cpp
@@ -67,10 +67,14 @@ public:
 
 				InterruptState interrupt_state;
 				OperatorSourceInput source_input {global_state, *local_state, interrupt_state};
-				auto source_result = table.GetData(context, source, source_input);
-				if (source_result == SourceResultType::BLOCKED) {
-					throw NotImplementedException(
-					    "Unexpected interrupt from table Source in PositionalTableScanner refill");
+				auto source_result = SourceResultType::HAVE_MORE_OUTPUT;
+				while (source_result == SourceResultType::HAVE_MORE_OUTPUT && source.size() == 0) {
+					// TODO: this could as well just be propagated further, but for now iterating it is
+					source_result = table.GetData(context, source, source_input);
+					if (source_result == SourceResultType::BLOCKED) {
+						throw NotImplementedException(
+						    "Unexpected interrupt from table Source in PositionalTableScanner refill");
+					}
 				}
 			}
 			source_offset = 0;


### PR DESCRIPTION
This is (in v1.4-andium) a case might only hit with weird plans, but still a bug.
This has been uncovered in the `main` branch, where this becomes a more common cases (and so more stress tested)

Note: there are still cases not properly handled, such as BLOCKED or FINISHED + non-empty chunk, but those are to be fixed separately.