### PR TITLE
Fix positional scan and restore task executor

### DIFF
--- a/src/execution/operator/scan/physical_positional_scan.cpp
+++ b/src/execution/operator/scan/physical_positional_scan.cpp
@@ -66,10 +66,14 @@ public:
 
 				InterruptState interrupt_state;
 				OperatorSourceInput source_input {global_state, *local_state, interrupt_state};
-				auto source_result = table.GetData(context, source, source_input);
-				if (source_result == SourceResultType::BLOCKED) {
-					throw NotImplementedException(
-					    "Unexpected interrupt from table Source in PositionalTableScanner refill");
+				auto source_result = SourceResultType::HAVE_MORE_OUTPUT;
+				while (source_result == SourceResultType::HAVE_MORE_OUTPUT && source.size() == 0) {
+					// TODO: this could as well just be propagated further, but for now iterating it is
+					source_result = table.GetData(context, source, source_input);
+					if (source_result == SourceResultType::BLOCKED) {
+						throw NotImplementedException(
+						    "Unexpected interrupt from table Source in PositionalTableScanner refill");
+					}
 				}
 			}
 			source_offset = 0;

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -180,8 +180,6 @@ AsyncResultsExecutionMode
 AsyncResult::ConvertToAsyncResultExecutionMode(const PhysicalTableScanExecutionStrategy &execution_mode) {
 	switch (execution_mode) {
 	case PhysicalTableScanExecutionStrategy::DEFAULT:
-		// FIXME: Once PositionalJoin logic has been fixed, this needs to revert to be TASK_EXECUTOR by default
-		return AsyncResultsExecutionMode::SYNCHRONOUS;
 	case PhysicalTableScanExecutionStrategy::TASK_EXECUTOR:
 	case PhysicalTableScanExecutionStrategy::TASK_EXECUTOR_BUT_FORCE_SYNC_CHECKS:
 		return AsyncResultsExecutionMode::TASK_EXECUTOR;


### PR DESCRIPTION
Cherry-pick https://github.com/duckdb/duckdb/pull/19824, to be reviewed first (filed vs `v1.4-andium`, now cherry-picked on `main` as well), that allows to the revert https://github.com/duckdb/duckdb/pull/19778.

Combined, this fixes a pre-existing bug and re-enable the async-of-sort behaviour, so unblocking more work in that area.

