### PR TITLE
AttachDatabase: first set whether file is remote, then do the rest

### DIFF
--- a/test/sql/attach/remote_file_concurrently.test
+++ b/test/sql/attach/remote_file_concurrently.test
@@ -1,0 +1,12 @@
+# name: test/sql/attach/remote_file_concurrently.test
+# description: Concurrently attach the same read only database
+# group: [attach]
+
+require httpfs
+
+statement ok con1
+ATTACH 'https://raw.githubusercontent.com/duckdb/duckdb/main/data/attach_test/attach.db' AS db;
+
+statement ok con2
+ATTACH 'https://raw.githubusercontent.com/duckdb/duckdb/main/data/attach_test/attach.db' AS db2;
+


### PR DESCRIPTION
Shuffle code around, while avoiding behavioural changes but for the fact that we should go into `InsertDatabasePath` with the `access_mode` properly set.

This avoids that when `access_mode` is `AUTOMATIC`, it's stored in the Database cache without having considered that remote files needs to be `READ_ONLY`.

This causes issues such as the added testcase, where adding the same remote file twice (with different names) is invalid in automatic mode (but valid if `READ_ONLY` is explicit)