### PR TITLE
[Wal][Index] Unbound Index (de)serialization

### DIFF
--- a/src/include/duckdb/execution/index/unbound_index.hpp
+++ b/src/include/duckdb/execution/index/unbound_index.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "duckdb/common/case_insensitive_map.hpp"
-#include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/parsed_data/create_index_info.hpp"
 #include "duckdb/storage/index.hpp"
 #include "duckdb/storage/storage_index.hpp"

--- a/src/include/duckdb/execution/index/unbound_index.hpp
+++ b/src/include/duckdb/execution/index/unbound_index.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/parsed_data/create_index_info.hpp"
 #include "duckdb/storage/index.hpp"
 #include "duckdb/storage/storage_index.hpp"
@@ -84,9 +86,14 @@ public:
 	vector<BufferedIndexData> &GetBufferedReplays() {
 		return buffered_replays;
 	}
+	const vector<BufferedIndexData> &GetBufferedReplays() const {
+		return buffered_replays;
+	}
 	const vector<StorageIndex> &GetMappedColumnIds() const {
 		return mapped_column_ids;
 	}
+
+	IndexStorageInfo SerializeToDisk(const case_insensitive_map_t<Value> &options);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/index_storage_info.hpp
+++ b/src/include/duckdb/storage/index_storage_info.hpp
@@ -20,6 +20,8 @@ namespace duckdb {
 
 class ColumnDataCollection;
 class Allocator;
+
+// Forward Declaration for BufferedIndexReplay type in unbound_index.hpp
 enum class BufferedIndexReplay : uint8_t;
 
 //! Information to serialize a FixedSizeAllocator, which holds the index data

--- a/src/include/duckdb/storage/serialization/storage.json
+++ b/src/include/duckdb/storage/serialization/storage.json
@@ -56,9 +56,51 @@
     "pointer_type": "none"
   },
   {
+    "class": "BufferedIndexDataInfo",
+    "includes": [
+      "duckdb/execution/index/unbound_index.hpp",
+      "duckdb/common/types.hpp"
+    ],
+    "members": [
+      {
+        "id": 100,
+        "name": "replay_type",
+        "type": "BufferedIndexReplay"
+      },
+      {
+        "id": 101,
+        "name": "types",
+        "type": "vector<LogicalType>"
+      },
+      {
+        "id": 102,
+        "name": "values",
+        "type": "vector<vector<Value>>"
+      }
+    ],
+    "pointer_type": "none"
+  },
+  {
+    "class": "StorageIndex",
+    "members": [
+      {
+        "id": 100,
+        "name": "index",
+        "type": "idx_t"
+      },
+      {
+        "id": 101,
+        "name": "child_indexes",
+        "type": "vector<StorageIndex>"
+      }
+    ],
+    "pointer_type": "none"
+  },
+  {
     "class": "IndexStorageInfo",
     "includes": [
-      "duckdb/storage/table_storage_info.hpp"
+      "duckdb/storage/table_storage_info.hpp",
+      "duckdb/storage/storage_index.hpp"
     ],
     "members": [
       {
@@ -81,6 +123,16 @@
         "name": "options",
         "type": "case_insensitive_map_t<Value>",
         "default": "case_insensitive_map_t<Value>()"
+      },
+      {
+        "id": 104,
+        "name": "mapped_column_ids",
+        "type": "vector<StorageIndex>"
+      },
+      {
+        "id": 105,
+        "name": "buffered_replay_data",
+        "type": "vector<BufferedIndexDataInfo>"
       }
     ],
     "pointer_type": "none"

--- a/src/include/duckdb/storage/serialization/storage.json
+++ b/src/include/duckdb/storage/serialization/storage.json
@@ -81,27 +81,8 @@
     "pointer_type": "none"
   },
   {
-    "class": "StorageIndex",
-    "members": [
-      {
-        "id": 100,
-        "name": "index",
-        "type": "idx_t"
-      },
-      {
-        "id": 101,
-        "name": "child_indexes",
-        "type": "vector<StorageIndex>"
-      }
-    ],
-    "pointer_type": "none"
-  },
-  {
     "class": "IndexStorageInfo",
-    "includes": [
-      "duckdb/storage/table_storage_info.hpp",
-      "duckdb/storage/storage_index.hpp"
-    ],
+    "custom_implementation": true,
     "members": [
       {
         "id": 100,
@@ -127,7 +108,7 @@
       {
         "id": 104,
         "name": "mapped_column_ids",
-        "type": "vector<StorageIndex>"
+        "type": "vector<idx_t>"
       },
       {
         "id": 105,

--- a/src/include/duckdb/storage/serialization/storage.json
+++ b/src/include/duckdb/storage/serialization/storage.json
@@ -57,10 +57,7 @@
   },
   {
     "class": "BufferedIndexDataInfo",
-    "includes": [
-      "duckdb/execution/index/unbound_index.hpp",
-      "duckdb/common/types.hpp"
-    ],
+    "custom_implementation": true,
     "members": [
       {
         "id": 100,

--- a/src/include/duckdb/storage/storage_index.hpp
+++ b/src/include/duckdb/storage/storage_index.hpp
@@ -13,9 +13,6 @@
 
 namespace duckdb {
 
-class Serializer;
-class Deserializer;
-
 struct StorageIndex {
 	StorageIndex() : index(DConstants::INVALID_INDEX) {
 	}
@@ -64,9 +61,6 @@ struct StorageIndex {
 	bool IsRowIdColumn() const {
 		return index == DConstants::INVALID_INDEX;
 	}
-
-	void Serialize(Serializer &serializer) const;
-	static StorageIndex Deserialize(Deserializer &deserializer);
 
 private:
 	idx_t index;

--- a/src/include/duckdb/storage/storage_index.hpp
+++ b/src/include/duckdb/storage/storage_index.hpp
@@ -13,6 +13,9 @@
 
 namespace duckdb {
 
+class Serializer;
+class Deserializer;
+
 struct StorageIndex {
 	StorageIndex() : index(DConstants::INVALID_INDEX) {
 	}
@@ -61,6 +64,9 @@ struct StorageIndex {
 	bool IsRowIdColumn() const {
 		return index == DConstants::INVALID_INDEX;
 	}
+
+	void Serialize(Serializer &serializer) const;
+	static StorageIndex Deserialize(Deserializer &deserializer);
 
 private:
 	idx_t index;

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library_unity(
   block.cpp
   data_pointer.cpp
   data_table.cpp
+  index_storage_info.cpp
   external_file_cache.cpp
   index.cpp
   local_storage.cpp

--- a/src/storage/index_storage_info.cpp
+++ b/src/storage/index_storage_info.cpp
@@ -26,10 +26,8 @@ BufferedIndexDataInfo BufferedIndexDataInfo::FromCollection(BufferedIndexReplay 
 }
 
 unique_ptr<ColumnDataCollection> BufferedIndexDataInfo::ToColumnDataCollection(Allocator &allocator) const {
+	D_ASSERT(!values.empty() && !types.empty());
 	auto collection = make_uniq<ColumnDataCollection>(allocator, types);
-	if (values.empty() || types.empty()) {
-		return collection;
-	}
 	DataChunk chunk;
 	chunk.Initialize(allocator, types);
 

--- a/src/storage/index_storage_info.cpp
+++ b/src/storage/index_storage_info.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/storage/index_storage_info.hpp"
 
 #include "duckdb/common/allocator.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 
@@ -46,6 +48,43 @@ unique_ptr<ColumnDataCollection> BufferedIndexDataInfo::ToColumnDataCollection(A
 		collection->Append(chunk);
 	}
 	return collection;
+}
+
+void IndexStorageInfo::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<string>(100, "name", name);
+	serializer.WritePropertyWithDefault<idx_t>(101, "root", root);
+	serializer.WritePropertyWithDefault<vector<FixedSizeAllocatorInfo>>(102, "allocator_infos", allocator_infos);
+	serializer.WritePropertyWithDefault<case_insensitive_map_t<Value>>(103, "options", options,
+	                                                                   case_insensitive_map_t<Value>());
+	// Serialize mapped_column_ids as vector<idx_t> (since we never use child_indexes).
+	vector<idx_t> mapped_ids;
+	mapped_ids.reserve(mapped_column_ids.size());
+	for (auto &col_id : mapped_column_ids) {
+		mapped_ids.push_back(col_id.GetPrimaryIndex());
+	}
+	serializer.WritePropertyWithDefault<vector<idx_t>>(104, "mapped_column_ids", mapped_ids);
+	serializer.WritePropertyWithDefault<vector<BufferedIndexDataInfo>>(105, "buffered_replay_data",
+	                                                                   buffered_replay_data);
+}
+
+IndexStorageInfo IndexStorageInfo::Deserialize(Deserializer &deserializer) {
+	IndexStorageInfo result;
+	deserializer.ReadPropertyWithDefault<string>(100, "name", result.name);
+	deserializer.ReadPropertyWithDefault<idx_t>(101, "root", result.root);
+	deserializer.ReadPropertyWithDefault<vector<FixedSizeAllocatorInfo>>(102, "allocator_infos",
+	                                                                     result.allocator_infos);
+	deserializer.ReadPropertyWithExplicitDefault<case_insensitive_map_t<Value>>(103, "options", result.options,
+	                                                                            case_insensitive_map_t<Value>());
+	// Deserialize mapped_column_ids as vector<idx_t> and convert to vector<StorageIndex>
+	vector<idx_t> mapped_ids;
+	deserializer.ReadPropertyWithDefault<vector<idx_t>>(104, "mapped_column_ids", mapped_ids);
+	result.mapped_column_ids.reserve(mapped_ids.size());
+	for (auto &col_id : mapped_ids) {
+		result.mapped_column_ids.emplace_back(col_id);
+	}
+	deserializer.ReadPropertyWithDefault<vector<BufferedIndexDataInfo>>(105, "buffered_replay_data",
+	                                                                    result.buffered_replay_data);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/storage/index_storage_info.cpp
+++ b/src/storage/index_storage_info.cpp
@@ -60,6 +60,7 @@ void IndexStorageInfo::Serialize(Serializer &serializer) const {
 	vector<idx_t> mapped_ids;
 	mapped_ids.reserve(mapped_column_ids.size());
 	for (auto &col_id : mapped_column_ids) {
+		D_ASSERT(!col_id.HasChildren());
 		mapped_ids.push_back(col_id.GetPrimaryIndex());
 	}
 	serializer.WritePropertyWithDefault<vector<idx_t>>(104, "mapped_column_ids", mapped_ids);

--- a/src/storage/index_storage_info.cpp
+++ b/src/storage/index_storage_info.cpp
@@ -1,0 +1,51 @@
+#include "duckdb/storage/index_storage_info.hpp"
+
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+
+namespace duckdb {
+
+BufferedIndexDataInfo BufferedIndexDataInfo::FromCollection(BufferedIndexReplay replay_type,
+                                                            const ColumnDataCollection &collection) {
+	BufferedIndexDataInfo info;
+	info.replay_type = replay_type;
+	const auto column_count = collection.ColumnCount();
+	info.types = collection.Types();
+	info.values.resize(column_count);
+	for (auto &chunk : collection.Chunks()) {
+		for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
+			for (idx_t r = 0; r < chunk.size(); r++) {
+				info.values[c].push_back(chunk.GetValue(c, r));
+			}
+		}
+	}
+	return info;
+}
+
+unique_ptr<ColumnDataCollection> BufferedIndexDataInfo::ToColumnDataCollection(Allocator &allocator) const {
+	auto collection = make_uniq<ColumnDataCollection>(allocator, types);
+	if (values.empty() || types.empty()) {
+		return collection;
+	}
+	DataChunk chunk;
+	chunk.Initialize(allocator, types);
+
+	const idx_t row_count = values[0].size();
+	for (idx_t row = 0; row < row_count; row++) {
+		for (idx_t col = 0; col < types.size(); col++) {
+			chunk.SetValue(col, chunk.size(), values[col][row]);
+		}
+		chunk.SetCardinality(chunk.size() + 1);
+		if (chunk.size() == STANDARD_VECTOR_SIZE) {
+			collection->Append(chunk);
+			chunk.Reset();
+		}
+	}
+	if (chunk.size() > 0) {
+		collection->Append(chunk);
+	}
+	return collection;
+}
+
+} // namespace duckdb

--- a/src/storage/index_storage_info.cpp
+++ b/src/storage/index_storage_info.cpp
@@ -48,6 +48,20 @@ unique_ptr<ColumnDataCollection> BufferedIndexDataInfo::ToColumnDataCollection(A
 	return collection;
 }
 
+void BufferedIndexDataInfo::Serialize(Serializer &serializer) const {
+	serializer.WriteProperty<BufferedIndexReplay>(100, "replay_type", replay_type);
+	serializer.WriteProperty<vector<LogicalType>>(101, "types", types);
+	serializer.WriteProperty<vector<vector<Value>>>(102, "values", values);
+}
+
+BufferedIndexDataInfo BufferedIndexDataInfo::Deserialize(Deserializer &deserializer) {
+	BufferedIndexDataInfo result;
+	deserializer.ReadProperty<BufferedIndexReplay>(100, "replay_type", result.replay_type);
+	deserializer.ReadProperty<vector<LogicalType>>(101, "types", result.types);
+	deserializer.ReadProperty<vector<vector<Value>>>(102, "values", result.values);
+	return result;
+}
+
 void IndexStorageInfo::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(100, "name", name);
 	serializer.WritePropertyWithDefault<idx_t>(101, "root", root);

--- a/src/storage/serialization/serialize_storage.cpp
+++ b/src/storage/serialization/serialize_storage.cpp
@@ -6,8 +6,6 @@
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/storage/block.hpp"
-#include "duckdb/execution/index/unbound_index.hpp"
-#include "duckdb/common/types.hpp"
 #include "duckdb/storage/data_pointer.hpp"
 #include "duckdb/storage/statistics/distinct_statistics.hpp"
 
@@ -22,20 +20,6 @@ BlockPointer BlockPointer::Deserialize(Deserializer &deserializer) {
 	auto block_id = deserializer.ReadProperty<block_id_t>(100, "block_id");
 	auto offset = deserializer.ReadPropertyWithDefault<uint32_t>(101, "offset");
 	BlockPointer result(block_id, offset);
-	return result;
-}
-
-void BufferedIndexDataInfo::Serialize(Serializer &serializer) const {
-	serializer.WriteProperty<BufferedIndexReplay>(100, "replay_type", replay_type);
-	serializer.WritePropertyWithDefault<vector<LogicalType>>(101, "types", types);
-	serializer.WritePropertyWithDefault<vector<vector<Value>>>(102, "values", values);
-}
-
-BufferedIndexDataInfo BufferedIndexDataInfo::Deserialize(Deserializer &deserializer) {
-	BufferedIndexDataInfo result;
-	deserializer.ReadProperty<BufferedIndexReplay>(100, "replay_type", result.replay_type);
-	deserializer.ReadPropertyWithDefault<vector<LogicalType>>(101, "types", result.types);
-	deserializer.ReadPropertyWithDefault<vector<vector<Value>>>(102, "values", result.values);
 	return result;
 }
 

--- a/src/storage/serialization/serialize_storage.cpp
+++ b/src/storage/serialization/serialize_storage.cpp
@@ -8,8 +8,6 @@
 #include "duckdb/storage/block.hpp"
 #include "duckdb/execution/index/unbound_index.hpp"
 #include "duckdb/common/types.hpp"
-#include "duckdb/storage/table_storage_info.hpp"
-#include "duckdb/storage/storage_index.hpp"
 #include "duckdb/storage/data_pointer.hpp"
 #include "duckdb/storage/statistics/distinct_statistics.hpp"
 
@@ -101,26 +99,6 @@ FixedSizeAllocatorInfo FixedSizeAllocatorInfo::Deserialize(Deserializer &deseria
 	return result;
 }
 
-void IndexStorageInfo::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<string>(100, "name", name);
-	serializer.WritePropertyWithDefault<idx_t>(101, "root", root);
-	serializer.WritePropertyWithDefault<vector<FixedSizeAllocatorInfo>>(102, "allocator_infos", allocator_infos);
-	serializer.WritePropertyWithDefault<case_insensitive_map_t<Value>>(103, "options", options, case_insensitive_map_t<Value>());
-	serializer.WritePropertyWithDefault<vector<StorageIndex>>(104, "mapped_column_ids", mapped_column_ids);
-	serializer.WritePropertyWithDefault<vector<BufferedIndexDataInfo>>(105, "buffered_replay_data", buffered_replay_data);
-}
-
-IndexStorageInfo IndexStorageInfo::Deserialize(Deserializer &deserializer) {
-	IndexStorageInfo result;
-	deserializer.ReadPropertyWithDefault<string>(100, "name", result.name);
-	deserializer.ReadPropertyWithDefault<idx_t>(101, "root", result.root);
-	deserializer.ReadPropertyWithDefault<vector<FixedSizeAllocatorInfo>>(102, "allocator_infos", result.allocator_infos);
-	deserializer.ReadPropertyWithExplicitDefault<case_insensitive_map_t<Value>>(103, "options", result.options, case_insensitive_map_t<Value>());
-	deserializer.ReadPropertyWithDefault<vector<StorageIndex>>(104, "mapped_column_ids", result.mapped_column_ids);
-	deserializer.ReadPropertyWithDefault<vector<BufferedIndexDataInfo>>(105, "buffered_replay_data", result.buffered_replay_data);
-	return result;
-}
-
 void MetaBlockPointer::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<idx_t>(100, "block_pointer", block_pointer);
 	serializer.WritePropertyWithDefault<uint32_t>(101, "offset", offset);
@@ -130,18 +108,6 @@ MetaBlockPointer MetaBlockPointer::Deserialize(Deserializer &deserializer) {
 	auto block_pointer = deserializer.ReadPropertyWithDefault<idx_t>(100, "block_pointer");
 	auto offset = deserializer.ReadPropertyWithDefault<uint32_t>(101, "offset");
 	MetaBlockPointer result(block_pointer, offset);
-	return result;
-}
-
-void StorageIndex::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<idx_t>(100, "index", index);
-	serializer.WritePropertyWithDefault<vector<StorageIndex>>(101, "child_indexes", child_indexes);
-}
-
-StorageIndex StorageIndex::Deserialize(Deserializer &deserializer) {
-	StorageIndex result;
-	deserializer.ReadPropertyWithDefault<idx_t>(100, "index", result.index);
-	deserializer.ReadPropertyWithDefault<vector<StorageIndex>>(101, "child_indexes", result.child_indexes);
 	return result;
 }
 

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -247,7 +247,7 @@ vector<IndexStorageInfo> TableIndexList::SerializeToDisk(QueryContext context,
 			continue;
 		}
 
-		auto info = index.Cast<UnboundIndex>().GetStorageInfo();
+		auto info = index.Cast<UnboundIndex>().SerializeToDisk(options);
 		D_ASSERT(!info.name.empty());
 		infos.push_back(info);
 	}

--- a/test/sql/index/art/storage/test_art_detach_no_context.test
+++ b/test/sql/index/art/storage/test_art_detach_no_context.test
@@ -1,0 +1,54 @@
+# name: test/sql/index/art/storage/test_art_detach_no_context.test
+# description: Ensure DETACH triggers checkpoint without original context
+# group: [storage]
+
+statement ok
+SET threads = 1;
+
+statement ok
+SET checkpoint_threshold = '10.0 GB';
+
+# The only place we checkpoint without context is during DETACH.
+# However, with this pragma in place, we now no longer checkpoint during DETACH.
+# Meaning all other checkpoints now have the context.
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+ATTACH '__TEST_DIR__/detach_no_context.db';
+
+statement ok
+CREATE TABLE detach_no_context.t (i INT);
+
+statement ok
+CREATE UNIQUE INDEX idx_detach_no_context ON detach_no_context.t(i);
+
+statement ok
+INSERT INTO detach_no_context.t VALUES (1);
+
+statement ok
+DETACH detach_no_context;
+
+# Here we should have buffered appends afterwards.
+# Let's also disable our pragma
+
+statement ok
+PRAGMA enable_checkpoint_on_shutdown;
+
+statement ok
+ATTACH '__TEST_DIR__/detach_no_context.db';
+
+# Checkpoint without context.
+
+statement ok
+DETACH detach_no_context;
+
+statement ok
+ATTACH '__TEST_DIR__/detach_no_context.db';
+
+statement error
+INSERT INTO detach_no_context.t VALUES (1), (2);
+----
+violates unique constraint
+

--- a/test/sql/index/art/storage/test_art_wal_checkpoint_buffer_interleaved.test
+++ b/test/sql/index/art/storage/test_art_wal_checkpoint_buffer_interleaved.test
@@ -1,0 +1,85 @@
+# name: test/sql/index/art/storage/test_art_wal_checkpoint_buffer_interleaved.test
+# description: Ensure interleaved buffered operations serialize/deserialize correctly for single-column indexes
+# group: [storage]
+
+load __TEST_DIR__/test_art_wal_checkpoint_buffer_interleaved.db
+
+statement ok
+SET index_scan_max_count = 1;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+CREATE TABLE wal_checkpoint_interleaved(b INTEGER);
+
+statement ok
+CREATE UNIQUE INDEX wal_checkpoint_interleaved_idx ON wal_checkpoint_interleaved(b);
+
+statement ok
+INSERT INTO wal_checkpoint_interleaved SELECT range FROM range(200);
+
+statement ok
+DELETE FROM wal_checkpoint_interleaved WHERE b % 2 = 0;
+
+statement ok
+INSERT INTO wal_checkpoint_interleaved SELECT range + 200 FROM range(50);
+
+statement ok
+DELETE FROM wal_checkpoint_interleaved WHERE b % 5 = 1;
+
+statement ok
+INSERT INTO wal_checkpoint_interleaved VALUES (501);
+
+statement ok
+DELETE FROM wal_checkpoint_interleaved WHERE b = 501;
+
+query I
+SELECT COUNT(*) FROM wal_checkpoint_interleaved;
+----
+120
+
+query II
+EXPLAIN ANALYZE SELECT * FROM wal_checkpoint_interleaved WHERE b = 17;
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query I
+SELECT * FROM wal_checkpoint_interleaved WHERE b = 17;
+----
+17
+
+query I
+SELECT * FROM wal_checkpoint_interleaved WHERE b = 10;
+----
+
+restart
+
+statement ok
+CHECKPOINT;
+
+restart
+
+query I
+SELECT COUNT(*) FROM wal_checkpoint_interleaved;
+----
+120
+
+query II
+EXPLAIN ANALYZE SELECT * FROM wal_checkpoint_interleaved WHERE b = 17;
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query I
+SELECT * FROM wal_checkpoint_interleaved WHERE b = 17;
+----
+17
+
+query I
+SELECT * FROM wal_checkpoint_interleaved WHERE b = 10;
+----
+
+

--- a/test/sql/index/art/storage/test_art_wal_checkpoint_buffer_minimal.test
+++ b/test/sql/index/art/storage/test_art_wal_checkpoint_buffer_minimal.test
@@ -1,5 +1,5 @@
 # name: test/sql/index/art/storage/test_art_wal_checkpoint_buffer_minimal.test
-# description: Minimal serialize -> deserialize -> serialize flow with unique index
+# description: buffered index operations serialization/deserialization test.
 # group: [storage]
 
 load __TEST_DIR__/test_art_wal_checkpoint_buffer_minimal.db
@@ -21,8 +21,6 @@ CREATE UNIQUE INDEX idx_minimal ON minimal_tbl(i);
 
 statement ok
 INSERT INTO minimal_tbl VALUES (42);
-
-restart
 
 restart
 

--- a/test/sql/index/art/storage/test_art_wal_checkpoint_buffer_minimal.test
+++ b/test/sql/index/art/storage/test_art_wal_checkpoint_buffer_minimal.test
@@ -1,0 +1,68 @@
+# name: test/sql/index/art/storage/test_art_wal_checkpoint_buffer_minimal.test
+# description: Minimal serialize -> deserialize -> serialize flow with unique index
+# group: [storage]
+
+load __TEST_DIR__/test_art_wal_checkpoint_buffer_minimal.db
+
+statement ok
+SET index_scan_max_count = 1;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+CREATE TABLE minimal_tbl(i INTEGER);
+
+statement ok
+CREATE UNIQUE INDEX idx_minimal ON minimal_tbl(i);
+
+statement ok
+INSERT INTO minimal_tbl VALUES (42);
+
+restart
+
+restart
+
+statement ok
+INSERT INTO minimal_tbl VALUES (43);
+
+restart
+
+statement ok
+DELETE FROM minimal_tbl where i = 42
+
+restart
+
+statement ok
+CHECKPOINT;
+
+statement ok
+INSERT INTO minimal_tbl VALUES (44);
+
+restart
+
+statement ok
+CHECKPOINT;
+
+statement ok
+INSERT INTO minimal_tbl VALUES (42);
+
+statement error
+INSERT INTO minimal_tbl VALUES (43);
+----
+violates unique constraint
+
+statement error
+INSERT INTO minimal_tbl VALUES (44);
+----
+violates unique constraint
+
+query I
+SELECT COUNT(*) FROM minimal_tbl;
+----
+3
+
+

--- a/test/sql/storage/many_checkpoint_index.test
+++ b/test/sql/storage/many_checkpoint_index.test
@@ -22,3 +22,4 @@ CHECKPOINT
 statement error
 INSERT INTO test VALUES (11, 33, 'hello');
 ----
+Constraint Error: Duplicate key "a: 11" violates unique constraint.

--- a/test/sql/storage/many_checkpoint_index.test
+++ b/test/sql/storage/many_checkpoint_index.test
@@ -1,0 +1,24 @@
+# name: test/sql/storage/many_checkpoint_index.test
+# description: Test many checkpoints
+# group: [storage]
+
+load __TEST_DIR__/many_checkpoints_index.db
+
+statement ok
+CREATE TABLE test (a INTEGER, b INTEGER, c VARCHAR);
+
+statement ok
+CREATE UNIQUE INDEX idx_a on test(a);
+
+statement ok
+CHECKPOINT
+
+statement ok
+INSERT INTO test VALUES (11, 22, 'hello')
+
+statement ok
+CHECKPOINT
+
+statement error
+INSERT INTO test VALUES (11, 33, 'hello');
+----


### PR DESCRIPTION
This PR adds support for unbound index serialization/deserialization. 

This fixes a bug where if we are ever in WAL replay (unbound index state), and replayed index operations are buffered into an unbound index, and then we do something like a checkpoint, the unbound index and its replays are not serialized to disk, so the WAL index replay operations were being dropped. This was an issue only for indexes originating from create index statements, not constraint indexes, since constraint indexes are being eagerly bound. 

This should help in making constraint indexes unbound during WAL replay scenarios, which would allow adding support for collation on indexes: https://github.com/duckdb/duckdb/issues/19675