### PR TITLE
Enable macros in DuckLake

### DIFF
--- a/src/include/duckdb/catalog/catalog_entry/table_macro_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_macro_catalog_entry.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/catalog/catalog_entry/macro_catalog_entry.hpp
+// duckdb/catalog/catalog_entry/table_macro_catalog_entry.hpp
 //
 //
 //===----------------------------------------------------------------------===//

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -220,17 +220,13 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 
 	// Figure out if we can store typed macro parameters
 	auto &attached = catalog.GetAttached();
-	auto store_types = info.temporary || attached.IsTemporary();
+	auto store_types = true;
 	if (attached.HasStorageManager()) {
+		// If DuckDB is used as a storage, we must check the version.
 		auto &storage_manager = attached.GetStorageManager();
 		const auto since = SerializationCompatibility::FromString("v1.4.0").serialization_version;
 		store_types |= storage_manager.InMemory() || storage_manager.GetStorageVersion() >= since;
-	} else {
-		// If it does not have a storage manager, we check it from the catalog.
-		auto catalog_type = catalog.GetCatalogType();
-		store_types = catalog_type == "ducklake";
 	}
-
 	// try to bind each of the included functions
 	vector_of_logical_type_set_t type_overloads;
 	auto &base = info.Cast<CreateMacroInfo>();

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -225,6 +225,10 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 		auto &storage_manager = attached.GetStorageManager();
 		const auto since = SerializationCompatibility::FromString("v1.4.0").serialization_version;
 		store_types |= storage_manager.InMemory() || storage_manager.GetStorageVersion() >= since;
+	} else {
+		// If it does not have a storage manager, we check it from the catalog.
+		auto catalog_type = catalog.GetCatalogType();
+		store_types = catalog_type == "ducklake";
 	}
 
 	// try to bind each of the included functions

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -225,7 +225,8 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 		// If DuckDB is used as a storage, we must check the version.
 		auto &storage_manager = attached.GetStorageManager();
 		const auto since = SerializationCompatibility::FromString("v1.4.0").serialization_version;
-		store_types |= storage_manager.InMemory() || storage_manager.GetStorageVersion() >= since;
+		store_types = info.temporary || attached.IsTemporary() || storage_manager.InMemory() ||
+		              storage_manager.GetStorageVersion() >= since;
 	}
 	// try to bind each of the included functions
 	vector_of_logical_type_set_t type_overloads;


### PR DESCRIPTION
Necessary for: https://github.com/duckdb/ducklake/pull/506

We could also achieve the same with catalog function inheritance if that's preferable.