### PR TITLE
DuckIndexScanState::TableScanFunc, split into 2 explicit phases

### DIFF
--- a/test/sql/index/art/scan/test_random_uuid.test
+++ b/test/sql/index/art/scan/test_random_uuid.test
@@ -1,0 +1,113 @@
+# name: test/sql/index/art/scan/test_random_uuid.test
+# description: Test ART index with many random uuid in transaction
+# group: [scan]
+
+statement ok
+create or replace table t as select id: uuid(), v: i from generate_series(1, 700000) s(i);
+
+# create a table with the values [0, 1, 0, 1, ..., 0, 1]
+statement ok
+create unique index uid on t(id);
+
+statement ok
+set variable u1 = uuid();
+
+statement ok
+set variable u2 = uuid();
+
+statement ok
+set variable u3 = uuid();
+
+statement ok
+set variable u4 = uuid();
+
+statement ok
+start transaction;
+
+statement ok
+insert into t select * replace (getvariable('u1') as id) from t using sample 1 rows;
+
+statement ok
+select * from t where id = getvariable('u1');
+
+statement ok
+insert into t select * replace (getvariable('u2') as id) from t using sample 1 rows;
+
+statement ok
+select * from t where id = getvariable('u2');
+
+statement ok
+insert into t select * replace (getvariable('u3') as id) from t using sample 1 rows;
+
+statement ok r4
+select * from t where id = getvariable('u4');
+
+statement ok
+commit;
+
+statement ok r1
+select * from t where id = getvariable('u1');
+
+statement ok r2
+select * from t where id = getvariable('u2');
+
+statement ok r3
+select * from t where id = getvariable('u3');
+
+statement ok r4
+select * from t where id = getvariable('u4');
+
+statement ok
+start transaction;
+
+statement ok
+drop index uid;
+
+statement ok r1
+select * from t where id = getvariable('u1');
+
+statement ok r2
+select * from t where id = getvariable('u2');
+
+statement ok r3
+select * from t where id = getvariable('u3');
+
+statement ok r4
+select * from t where id = getvariable('u4');
+
+statement ok
+rollback;
+
+statement ok
+start transaction;
+
+statement ok
+drop index uid;
+
+statement ok r1
+select * from t where id = getvariable('u1');
+
+statement ok r2
+select * from t where id = getvariable('u2');
+
+statement ok r3
+select * from t where id = getvariable('u3');
+
+statement ok r4
+select * from t where id = getvariable('u4');
+
+statement ok
+commit;
+
+statement ok r1
+select * from t where id = getvariable('u1');
+
+statement ok r2
+select * from t where id = getvariable('u2');
+
+statement ok r3
+select * from t where id = getvariable('u3');
+
+statement ok r4
+select * from t where id = getvariable('u4');
+


### PR DESCRIPTION
First phase is performed in parallel, second phase is in charge of the first thread that starts it

I bumped into this rework while looking into adding TASK_EXECUTOR-like behaviour into the sibling DuckTableScanState::TableScanFunc, then looked at this method, noticed it was hard to reason, and followed the intuition down the rabbit hole.

Sketch is as follow:
* first phase, each thread in parallel, exactly as before, BUT loop back in case `output` is empty
* second phase, single threaded, where the first thread to get there takes ownership, over the Transaction LocalStorage

Fixes https://github.com/duckdb/duckdb/issues/18782