### PR TITLE
Add CacheBehavior::AUTOMATIC to DBInstanceCache that automatically does the right thing™

### DIFF
--- a/src/include/duckdb/main/db_instance_cache.hpp
+++ b/src/include/duckdb/main/db_instance_cache.hpp
@@ -26,6 +26,8 @@ struct DatabaseCacheEntry {
 	mutex update_database_mutex;
 };
 
+enum class CacheBehavior { AUTOMATIC, ALWAYS_CACHE, NEVER_CACHE };
+
 class DBInstanceCache {
 public:
 	DBInstanceCache();
@@ -40,6 +42,9 @@ public:
 
 	//! Either returns an existing entry, or creates and caches a new DB Instance
 	shared_ptr<DuckDB> GetOrCreateInstance(const string &database, DBConfig &config_dict, bool cache_instance,
+	                                       const std::function<void(DuckDB &)> &on_create = nullptr);
+	shared_ptr<DuckDB> GetOrCreateInstance(const string &database, DBConfig &config_dict,
+	                                       CacheBehavior cache_behavior = CacheBehavior::AUTOMATIC,
 	                                       const std::function<void(DuckDB &)> &on_create = nullptr);
 
 private:

--- a/src/main/capi/duckdb-c.cpp
+++ b/src/main/capi/duckdb-c.cpp
@@ -41,7 +41,7 @@ duckdb_state duckdb_open_internal(DBInstanceCacheWrapper *cache, const char *pat
 			if (path) {
 				path_str = path;
 			}
-			wrapper->database = cache->instance_cache->GetOrCreateInstance(path_str, *db_config, true);
+			wrapper->database = cache->instance_cache->GetOrCreateInstance(path_str, *db_config);
 		} else {
 			wrapper->database = duckdb::make_shared_ptr<DuckDB>(path, db_config);
 		}

--- a/src/main/db_instance_cache.cpp
+++ b/src/main/db_instance_cache.cpp
@@ -137,9 +137,23 @@ shared_ptr<DuckDB> DBInstanceCache::CreateInstance(const string &database, DBCon
 shared_ptr<DuckDB> DBInstanceCache::GetOrCreateInstance(const string &database, DBConfig &config_dict,
                                                         bool cache_instance,
                                                         const std::function<void(DuckDB &)> &on_create) {
-	unique_lock<mutex> lock(cache_lock, std::defer_lock);
-	if (cache_instance) {
+	auto cache_behavior = cache_instance ? CacheBehavior::ALWAYS_CACHE : CacheBehavior::NEVER_CACHE;
+	return GetOrCreateInstance(database, config_dict, cache_behavior, on_create);
+}
 
+shared_ptr<DuckDB> DBInstanceCache::GetOrCreateInstance(const string &database, DBConfig &config_dict,
+                                                        CacheBehavior cache_behavior,
+                                                        const std::function<void(DuckDB &)> &on_create) {
+	unique_lock<mutex> lock(cache_lock, std::defer_lock);
+	bool cache_instance = cache_behavior == CacheBehavior::ALWAYS_CACHE;
+	if (cache_behavior == CacheBehavior::AUTOMATIC) {
+		// cache all unnamed in-memory connections
+		cache_instance = true;
+		if (database == IN_MEMORY_PATH || database.empty()) {
+			cache_instance = false;
+		}
+	}
+	if (cache_instance) {
 		// While we do not own the lock, we cannot definitively say that the database instance does not exist.
 		while (!lock.owns_lock()) {
 			// The problem is, that we have to unlock the mutex in GetInstanceInternal, so we can non-blockingly wait


### PR DESCRIPTION
This PR adds a `CacheBehavior` enum to the instance cache, instead of the current true / false:

```cpp
enum class CacheBehavior { AUTOMATIC, ALWAYS_CACHE, NEVER_CACHE };
```

The default value if none is supplied is `CacheBehavior::AUTOMATIC`. This does what you would expect:

* Unnamed in-memory connections are not cached (`:memory:` and `<empty>`)
* Named in-memory connections are cached (`:memory:label`)
* Regular connections are cached

This PR also switches the C API to using `CacheBehavior::AUTOMATIC`. 