### PR TITLE
Make RowGroup::Checkpoint and ColumnData::Checkpoint generate a new RowGroup/ColumnData - instead of checkpointing them in-place

### DIFF
--- a/benchmark/tpch/storage/partial_checkpoint.benchmark
+++ b/benchmark/tpch/storage/partial_checkpoint.benchmark
@@ -1,0 +1,23 @@
+# name: benchmark/tpch/storage/partial_checkpoint.benchmark
+# description: Run a partial checkpoint over a subset of a column
+# group: [storage]
+
+require tpch
+
+argument sf 1
+
+load
+CALL dbgen(sf=${sf});
+SET checkpoint_threshold='1TB'; -- ensure we are timing
+ATTACH IF NOT EXISTS '${BENCHMARK_DIR}/partial_checkpoint.db';
+CREATE OR REPLACE TABLE partial_checkpoint.lineitem AS FROM lineitem;
+CHECKPOINT partial_checkpoint;
+UPDATE lineitem SET l_orderkey=l_orderkey+1 WHERE l_orderkey BETWEEN 100_000 AND 110_000;
+
+run
+CHECKPOINT partial_checkpoint;
+
+cleanup
+CREATE OR REPLACE TABLE partial_checkpoint.lineitem AS FROM lineitem;
+CHECKPOINT partial_checkpoint;
+UPDATE lineitem SET l_orderkey=l_orderkey+1 WHERE l_orderkey BETWEEN 100_000 AND 110_000;

--- a/src/include/duckdb/common/compatible_with_ipp.hpp
+++ b/src/include/duckdb/common/compatible_with_ipp.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/likely.hpp"
+#include "duckdb/common/memory_safety.hpp"
+
+#include <memory>
+#include <type_traits>
+
+namespace duckdb {
+
+// This implementation is taken from the llvm-project, at this commit hash:
+// https://github.com/llvm/llvm-project/blob/08bb121835be432ac52372f92845950628ce9a4a/libcxx/include/__memory/shared_ptr.h#353
+// originally named '__compatible_with'
+
+#if _LIBCPP_STD_VER >= 17
+template <class U, class T>
+struct __bounded_convertible_to_unbounded : std::false_type {};
+
+template <class _Up, std::size_t _Np, class T>
+struct __bounded_convertible_to_unbounded<_Up[_Np], T> : std::is_same<std::remove_cv<T>, _Up[]> {};
+
+template <class U, class T>
+struct compatible_with_t : std::_Or<std::is_convertible<U *, T *>, __bounded_convertible_to_unbounded<U, T>> {};
+#else
+template <class U, class T>
+struct compatible_with_t : std::is_convertible<U *, T *> {}; // NOLINT: invalid case style
+#endif // _LIBCPP_STD_VER >= 17
+
+} // namespace duckdb

--- a/src/include/duckdb/common/enable_shared_from_this_ipp.hpp
+++ b/src/include/duckdb/common/enable_shared_from_this_ipp.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "duckdb/common/compatible_with_ipp.hpp"
+#include "duckdb/common/shared_ptr_ipp.hpp"
+#include "duckdb/common/weak_ptr_ipp.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/common/enable_shared_from_this_ipp.hpp
+++ b/src/include/duckdb/common/enable_shared_from_this_ipp.hpp
@@ -1,3 +1,7 @@
+#pragma once
+
+#include "duckdb/common/compatible_with_ipp.hpp"
+
 namespace duckdb {
 
 template <class T>

--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -136,20 +136,6 @@ shared_ptr<TGT> shared_ptr_cast(shared_ptr<SRC> src) { // NOLINT: mimic std styl
 	return shared_ptr<TGT>(std::static_pointer_cast<TGT, SRC>(src.internal));
 }
 
-struct SharedConstructor {
-	template <class T, typename... ARGS>
-	static shared_ptr<T> Create(ARGS &&...args) {
-		return make_shared_ptr<T>(std::forward<ARGS>(args)...);
-	}
-};
-
-struct UniqueConstructor {
-	template <class T, typename... ARGS>
-	static unique_ptr<T> Create(ARGS &&...args) {
-		return make_uniq<T>(std::forward<ARGS>(args)...);
-	}
-};
-
 #ifdef DUCKDB_DEBUG_MOVE
 template<class T>
 typename std::remove_reference<T>::type&& move(T&& t) noexcept {

--- a/src/include/duckdb/common/shared_ptr.hpp
+++ b/src/include/duckdb/common/shared_ptr.hpp
@@ -8,45 +8,7 @@
 
 #pragma once
 
-#include "duckdb/common/unique_ptr.hpp"
-#include "duckdb/common/likely.hpp"
-#include "duckdb/common/memory_safety.hpp"
-
-#include <memory>
-#include <type_traits>
-
-namespace duckdb {
-
-// This implementation is taken from the llvm-project, at this commit hash:
-// https://github.com/llvm/llvm-project/blob/08bb121835be432ac52372f92845950628ce9a4a/libcxx/include/__memory/shared_ptr.h#353
-// originally named '__compatible_with'
-
-#if _LIBCPP_STD_VER >= 17
-template <class U, class T>
-struct __bounded_convertible_to_unbounded : std::false_type {};
-
-template <class _Up, std::size_t _Np, class T>
-struct __bounded_convertible_to_unbounded<_Up[_Np], T> : std::is_same<std::remove_cv<T>, _Up[]> {};
-
-template <class U, class T>
-struct compatible_with_t : std::_Or<std::is_convertible<U *, T *>, __bounded_convertible_to_unbounded<U, T>> {};
-#else
-template <class U, class T>
-struct compatible_with_t : std::is_convertible<U *, T *> {}; // NOLINT: invalid case style
-#endif // _LIBCPP_STD_VER >= 17
-
-} // namespace duckdb
-
+#include "duckdb/common/compatible_with_ipp.hpp"
 #include "duckdb/common/shared_ptr_ipp.hpp"
 #include "duckdb/common/weak_ptr_ipp.hpp"
 #include "duckdb/common/enable_shared_from_this_ipp.hpp"
-
-namespace duckdb {
-
-template <typename T>
-using unsafe_shared_ptr = shared_ptr<T, false>;
-
-template <typename T>
-using unsafe_weak_ptr = weak_ptr<T, false>;
-
-} // namespace duckdb

--- a/src/include/duckdb/common/shared_ptr_ipp.hpp
+++ b/src/include/duckdb/common/shared_ptr_ipp.hpp
@@ -79,10 +79,11 @@ public:
 	shared_ptr(shared_ptr<U> &&ref) noexcept // NOLINT: not marked as explicit
 	    : internal(std::move(ref.internal)) {
 	}
+	// move constructor
 #ifdef DUCKDB_CLANG_TIDY
 	[[clang::reinitializes]]
 #endif
-	shared_ptr(shared_ptr<T> &&other) // NOLINT: not marked as explicit
+	shared_ptr(shared_ptr<T, SAFE> &&other) noexcept
 	    : internal(std::move(other.internal)) {
 	}
 
@@ -115,7 +116,7 @@ public:
 	~shared_ptr() = default;
 
 	// Assign from shared_ptr copy
-	shared_ptr<T> &operator=(const shared_ptr &other) noexcept {
+	shared_ptr<T, SAFE> &operator=(const shared_ptr<T, SAFE> &other) noexcept {
 		if (this == &other) {
 			return *this;
 		}
@@ -130,13 +131,13 @@ public:
 	}
 
 	// Assign from moved shared_ptr
-	shared_ptr<T> &operator=(shared_ptr &&other) noexcept {
+	shared_ptr<T, SAFE> &operator=(shared_ptr &&other) noexcept {
 		// Create a new shared_ptr using the move constructor, then swap out the ownership to *this
 		shared_ptr(std::move(other)).swap(*this);
 		return *this;
 	}
 	template <class U, typename std::enable_if<compatible_with_t<U, T>::value, int>::type = 0>
-	shared_ptr<T> &operator=(shared_ptr<U> &&other) {
+	shared_ptr<T, SAFE> &operator=(shared_ptr<U> &&other) {
 		shared_ptr(std::move(other)).swap(*this);
 		return *this;
 	}
@@ -146,7 +147,7 @@ public:
 	          typename std::enable_if<compatible_with_t<U, T>::value &&
 	                                      std::is_convertible<typename unique_ptr<U, DELETER>::pointer, T *>::value,
 	                                  int>::type = 0>
-	shared_ptr<T> &operator=(unique_ptr<U, DELETER, SAFE_P> &&ref) {
+	shared_ptr<T, SAFE> &operator=(unique_ptr<U, DELETER, SAFE_P> &&ref) {
 		shared_ptr(std::move(ref)).swap(*this);
 		return *this;
 	}

--- a/src/include/duckdb/common/shared_ptr_ipp.hpp
+++ b/src/include/duckdb/common/shared_ptr_ipp.hpp
@@ -1,4 +1,6 @@
-#include <memory>
+#pragma once
+
+#include "duckdb/common/compatible_with_ipp.hpp"
 
 namespace duckdb {
 
@@ -267,5 +269,8 @@ private:
 	void __enable_weak_this(...) noexcept { // NOLINT: invalid case style
 	}
 };
+
+template <typename T>
+using unsafe_shared_ptr = shared_ptr<T, false>;
 
 } // namespace duckdb

--- a/src/include/duckdb/common/shared_ptr_ipp.hpp
+++ b/src/include/duckdb/common/shared_ptr_ipp.hpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 namespace duckdb {
 
 template <typename T, bool SAFE = true>

--- a/src/include/duckdb/common/weak_ptr_ipp.hpp
+++ b/src/include/duckdb/common/weak_ptr_ipp.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "duckdb/common/compatible_with_ipp.hpp"
+#include "duckdb/common/shared_ptr_ipp.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/common/weak_ptr_ipp.hpp
+++ b/src/include/duckdb/common/weak_ptr_ipp.hpp
@@ -1,3 +1,7 @@
+#pragma once
+
+#include "duckdb/common/compatible_with_ipp.hpp"
+
 namespace duckdb {
 
 template <typename T, bool SAFE>
@@ -113,5 +117,8 @@ public:
 		return internal >= other.internal;
 	}
 };
+
+template <typename T>
+using unsafe_weak_ptr = weak_ptr<T, false>;
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/optimistic_data_writer.hpp
+++ b/src/include/duckdb/storage/optimistic_data_writer.hpp
@@ -41,7 +41,7 @@ public:
 	//! Final flush of the optimistic writer - fully flushes the partial block manager
 	void FinalFlush();
 	//! Flushes a specific row group to disk
-	void FlushToDisk(OptimisticWriteCollection &collection, const vector<reference<RowGroup>> &row_groups);
+	void FlushToDisk(OptimisticWriteCollection &collection, const vector<const_reference<RowGroup>> &row_groups);
 	//! Merge the partially written blocks from one optimistic writer into another
 	void Merge(OptimisticDataWriter &other);
 	void Merge(unique_ptr<PartialBlockManager> &other_manager);

--- a/src/include/duckdb/storage/optimistic_data_writer.hpp
+++ b/src/include/duckdb/storage/optimistic_data_writer.hpp
@@ -40,8 +40,6 @@ public:
 	void WriteLastRowGroup(OptimisticWriteCollection &row_groups);
 	//! Final flush of the optimistic writer - fully flushes the partial block manager
 	void FinalFlush();
-	//! Flushes a specific row group to disk
-	void FlushToDisk(OptimisticWriteCollection &collection, const vector<const_reference<RowGroup>> &row_groups);
 	//! Merge the partially written blocks from one optimistic writer into another
 	void Merge(OptimisticDataWriter &other);
 	void Merge(unique_ptr<PartialBlockManager> &other_manager);
@@ -56,6 +54,9 @@ public:
 private:
 	//! Prepare a write to disk
 	bool PrepareWrite();
+	//! Flushes a specific row group to disk
+	void FlushToDisk(OptimisticWriteCollection &collection, const vector<const_reference<RowGroup>> &row_groups,
+	                 const vector<int64_t> &segment_indexes);
 
 private:
 	//! The client context in which we're writing the data.

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -26,6 +26,7 @@ class UpdateSegment;
 class TableCatalogEntry;
 template <class T>
 struct SegmentNode;
+class RowGroupSegmentTree;
 
 struct TableAppendState;
 
@@ -69,6 +70,8 @@ struct TableAppendState {
 	//! The total number of rows appended by the append operation
 	idx_t total_append_count;
 	idx_t row_group_start;
+	//! The row group segment tree we are appending to
+	shared_ptr<RowGroupSegmentTree> row_groups;
 	//! The first row-group that has been appended to
 	optional_ptr<SegmentNode<RowGroup>> start_row_group;
 	//! The transaction data

--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -20,6 +20,7 @@ public:
 	                ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
 public:
+	shared_ptr<ValidityColumnData> &GetValidityData() override;
 	void SetDataType(ColumnDataType data_type) override;
 	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 
@@ -70,8 +71,7 @@ protected:
 	//! The child-column of the list
 	shared_ptr<ColumnData> child_column;
 	//! The validity column data of the array
-	shared_ptr<ValidityColumnData> validity_data;
-	ValidityColumnData &validity;
+	shared_ptr<ValidityColumnData> validity;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -19,11 +19,6 @@ public:
 	ArrayColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, LogicalType type,
 	                ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
-	//! The child-column of the list
-	unique_ptr<ColumnData> child_column;
-	//! The validity column data of the array
-	ValidityColumnData validity;
-
 public:
 	void SetDataType(ColumnDataType data_type) override;
 	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
@@ -70,6 +65,13 @@ public:
 	                          vector<duckdb::idx_t> col_path, vector<duckdb::ColumnSegmentInfo> &result) override;
 
 	void Verify(RowGroup &parent) override;
+
+protected:
+	//! The child-column of the list
+	shared_ptr<ColumnData> child_column;
+	//! The validity column data of the array
+	shared_ptr<ValidityColumnData> validity_data;
+	ValidityColumnData &validity;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -66,6 +66,9 @@ public:
 
 	void Verify(RowGroup &parent) override;
 
+	void SetValidityData(shared_ptr<ValidityColumnData> validity);
+	void SetChildData(shared_ptr<ColumnData> child_column);
+
 protected:
 	//! The child-column of the list
 	shared_ptr<ColumnData> child_column;

--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -20,7 +20,6 @@ public:
 	                ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
 public:
-	shared_ptr<ValidityColumnData> &GetValidityData() override;
 	void SetDataType(ColumnDataType data_type) override;
 	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 

--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -52,9 +52,9 @@ public:
 
 	void CommitDropColumn() override;
 
-	unique_ptr<ColumnCheckpointState> CreateCheckpointState(RowGroup &row_group,
+	unique_ptr<ColumnCheckpointState> CreateCheckpointState(const RowGroup &row_group,
 	                                                        PartialBlockManager &partial_block_manager) override;
-	unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) override;
+	unique_ptr<ColumnCheckpointState> Checkpoint(const RowGroup &row_group, ColumnCheckpointInfo &info) override;
 
 	bool IsPersistent() override;
 	bool HasAnyChanges() const override;

--- a/src/include/duckdb/storage/table/column_checkpoint_state.hpp
+++ b/src/include/duckdb/storage/table/column_checkpoint_state.hpp
@@ -38,24 +38,9 @@ protected:
 	shared_ptr<ColumnData> result_column;
 
 public:
-	virtual shared_ptr<ColumnData> CreateEmptyColumnData() {
-		throw InternalException("CreateEmptyColumnData not implemented for this column checkpoint state");
-	}
-	virtual ColumnData &GetResultColumn() {
-		if (!result_column) {
-			result_column = CreateEmptyColumnData();
-		}
-		return *result_column;
-	}
-	virtual shared_ptr<ColumnData> GetFinalResult() {
-		if (!result_column) {
-			// no result column instantiated - that means we haven't changed anything and can directly return the
-			// original column
-			return original_column.shared_from_this();
-		}
-		result_column->SetCount(original_column.count.load());
-		return result_column;
-	}
+	virtual shared_ptr<ColumnData> CreateEmptyColumnData();
+	virtual ColumnData &GetResultColumn();
+	virtual shared_ptr<ColumnData> GetFinalResult();
 
 	virtual unique_ptr<BaseStatistics> GetStatistics();
 

--- a/src/include/duckdb/storage/table/column_checkpoint_state.hpp
+++ b/src/include/duckdb/storage/table/column_checkpoint_state.hpp
@@ -54,6 +54,7 @@ public:
 			// original column
 			return original_column.shared_from_this();
 		}
+		result_column->SetCount(original_column.count.load());
 		return result_column;
 	}
 

--- a/src/include/duckdb/storage/table/column_checkpoint_state.hpp
+++ b/src/include/duckdb/storage/table/column_checkpoint_state.hpp
@@ -25,10 +25,11 @@ class PartialBlockManager;
 class TableDataWriter;
 
 struct ColumnCheckpointState {
-	ColumnCheckpointState(RowGroup &row_group, ColumnData &original_column, PartialBlockManager &partial_block_manager);
+	ColumnCheckpointState(const RowGroup &row_group, ColumnData &original_column,
+	                      PartialBlockManager &partial_block_manager);
 	virtual ~ColumnCheckpointState();
 
-	RowGroup &row_group;
+	const RowGroup &row_group;
 	const ColumnData &original_column;
 	vector<DataPointer> data_pointers;
 	unique_ptr<BaseStatistics> global_stats;

--- a/src/include/duckdb/storage/table/column_checkpoint_state.hpp
+++ b/src/include/duckdb/storage/table/column_checkpoint_state.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "validity_column_data.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/data_pointer.hpp"

--- a/src/include/duckdb/storage/table/column_checkpoint_state.hpp
+++ b/src/include/duckdb/storage/table/column_checkpoint_state.hpp
@@ -29,13 +29,16 @@ struct ColumnCheckpointState {
 	virtual ~ColumnCheckpointState();
 
 	RowGroup &row_group;
-	ColumnData &original_column;
+	const ColumnData &original_column;
 	vector<DataPointer> data_pointers;
 	unique_ptr<BaseStatistics> global_stats;
 
 protected:
 	PartialBlockManager &partial_block_manager;
 	shared_ptr<ColumnData> result_column;
+
+private:
+	ColumnData &original_column_mutable;
 
 public:
 	virtual shared_ptr<ColumnData> CreateEmptyColumnData();

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -99,7 +99,6 @@ public:
 		return parent != nullptr;
 	}
 	void SetParent(optional_ptr<ColumnData> parent) {
-		D_ASSERT(!HasParent());
 		this->parent = parent;
 	}
 	const ColumnData &Parent() const {
@@ -112,9 +111,10 @@ public:
 	ColumnSegmentTree &GetSegmentTree() {
 		return data;
 	}
+	void SetCount(idx_t new_count) {
+		this->count = new_count;
+	}
 
-	//! The root type of the column
-	const LogicalType &RootType() const;
 	//! Whether or not the column has any updates
 	bool HasUpdates() const;
 	bool HasChanges(idx_t start_row, idx_t end_row) const;

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -52,7 +52,7 @@ private:
 	RowGroupWriteInfo &info;
 };
 
-enum class ColumnDataType { MAIN_TABLE, INITIAL_TRANSACTION_LOCAL, TRANSACTION_LOCAL };
+enum class ColumnDataType { MAIN_TABLE, INITIAL_TRANSACTION_LOCAL, TRANSACTION_LOCAL, CHECKPOINT_TARGET };
 
 class ColumnData : public enable_shared_from_this<ColumnData> {
 	friend class ColumnDataCheckpointer;
@@ -82,7 +82,6 @@ public:
 	DatabaseInstance &GetDatabase() const;
 	DataTableInfo &GetTableInfo() const;
 	StorageManager &GetStorageManager() const;
-	virtual shared_ptr<ValidityColumnData> &GetValidityData();
 	virtual idx_t GetMaxEntry();
 
 	idx_t GetAllocationSize() const {
@@ -98,6 +97,10 @@ public:
 
 	bool HasParent() const {
 		return parent != nullptr;
+	}
+	void SetParent(optional_ptr<ColumnData> parent) {
+		D_ASSERT(!HasParent());
+		this->parent = parent;
 	}
 	const ColumnData &Parent() const {
 		D_ASSERT(HasParent());

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -53,7 +53,7 @@ private:
 
 enum class ColumnDataType { MAIN_TABLE, INITIAL_TRANSACTION_LOCAL, TRANSACTION_LOCAL };
 
-class ColumnData {
+class ColumnData : public enable_shared_from_this<ColumnData> {
 	friend class ColumnDataCheckpointer;
 
 public:
@@ -100,6 +100,9 @@ public:
 	const ColumnData &Parent() const {
 		D_ASSERT(HasParent());
 		return *parent;
+	}
+	const LogicalType &GetType() const {
+		return type;
 	}
 
 	//! The root type of the column
@@ -193,10 +196,6 @@ public:
 	                                           const LogicalType &type,
 	                                           ColumnDataType data_type = ColumnDataType::MAIN_TABLE,
 	                                           optional_ptr<ColumnData> parent = nullptr);
-	static unique_ptr<ColumnData> CreateColumnUnique(BlockManager &block_manager, DataTableInfo &info,
-	                                                 idx_t column_index, const LogicalType &type,
-	                                                 ColumnDataType data_type = ColumnDataType::MAIN_TABLE,
-	                                                 optional_ptr<ColumnData> parent = nullptr);
 
 	void MergeStatistics(const BaseStatistics &other);
 	void MergeIntoStatistics(BaseStatistics &other);

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -76,7 +76,7 @@ public:
 public:
 	virtual FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter);
 
-	BlockManager &GetBlockManager() {
+	BlockManager &GetBlockManager() const {
 		return block_manager;
 	}
 	DatabaseInstance &GetDatabase() const;
@@ -183,7 +183,7 @@ public:
 	                                                                PartialBlockManager &partial_block_manager);
 	virtual unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info);
 
-	virtual void CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count, Vector &scan_vector);
+	virtual void CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count, Vector &scan_vector) const;
 
 	virtual bool IsPersistent();
 	vector<DataPointer> GetDataPointers();

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -179,9 +179,9 @@ public:
 
 	virtual void CommitDropColumn();
 
-	virtual unique_ptr<ColumnCheckpointState> CreateCheckpointState(RowGroup &row_group,
+	virtual unique_ptr<ColumnCheckpointState> CreateCheckpointState(const RowGroup &row_group,
 	                                                                PartialBlockManager &partial_block_manager);
-	virtual unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info);
+	virtual unique_ptr<ColumnCheckpointState> Checkpoint(const RowGroup &row_group, ColumnCheckpointInfo &info);
 
 	virtual void CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count, Vector &scan_vector) const;
 

--- a/src/include/duckdb/storage/table/column_data_checkpointer.hpp
+++ b/src/include/duckdb/storage/table/column_data_checkpointer.hpp
@@ -86,7 +86,7 @@ private:
 	Vector intermediate;
 	ColumnCheckpointInfo &checkpoint_info;
 
-	vector<bool> has_changes;
+	bool has_changes = false;
 	//! For every column data that is being checkpointed, the applicable functions
 	vector<vector<optional_ptr<CompressionFunction>>> compression_functions;
 	//! For every column data that is being checkpointed, the analyze state of functions being tried

--- a/src/include/duckdb/storage/table/column_data_checkpointer.hpp
+++ b/src/include/duckdb/storage/table/column_data_checkpointer.hpp
@@ -73,7 +73,6 @@ private:
 	void ScanSegments(const std::function<void(Vector &, idx_t)> &callback);
 	vector<CheckpointAnalyzeResult> DetectBestCompressionMethod();
 	void WriteToDisk();
-	bool HasChanges(ColumnData &col_data);
 	void WritePersistentSegments(ColumnCheckpointState &state);
 	void InitAnalyze();
 	void DropSegments();

--- a/src/include/duckdb/storage/table/column_data_checkpointer.hpp
+++ b/src/include/duckdb/storage/table/column_data_checkpointer.hpp
@@ -22,7 +22,7 @@ public:
 	ColumnDataCheckpointData() {
 	}
 	ColumnDataCheckpointData(ColumnCheckpointState &checkpoint_state, ColumnData &col_data, DatabaseInstance &db,
-	                         RowGroup &row_group, ColumnCheckpointInfo &checkpoint_info,
+	                         const RowGroup &row_group, ColumnCheckpointInfo &checkpoint_info,
 	                         StorageManager &storage_manager)
 	    : checkpoint_state(checkpoint_state), col_data(col_data), db(db), row_group(row_group),
 	      checkpoint_info(checkpoint_info), storage_manager(storage_manager) {
@@ -32,7 +32,7 @@ public:
 	CompressionFunction &GetCompressionFunction(CompressionType type);
 	const LogicalType &GetType() const;
 	ColumnData &GetColumnData();
-	RowGroup &GetRowGroup();
+	const RowGroup &GetRowGroup();
 	ColumnCheckpointState &GetCheckpointState();
 	DatabaseInstance &GetDatabase();
 	StorageManager &GetStorageManager();
@@ -41,7 +41,7 @@ private:
 	optional_ptr<ColumnCheckpointState> checkpoint_state;
 	optional_ptr<ColumnData> col_data;
 	optional_ptr<DatabaseInstance> db;
-	optional_ptr<RowGroup> row_group;
+	optional_ptr<const RowGroup> row_group;
 	optional_ptr<ColumnCheckpointInfo> checkpoint_info;
 	optional_ptr<StorageManager> storage_manager;
 };
@@ -63,7 +63,7 @@ public:
 class ColumnDataCheckpointer {
 public:
 	ColumnDataCheckpointer(vector<reference<ColumnCheckpointState>> &states, StorageManager &storage_manager,
-	                       RowGroup &row_group, ColumnCheckpointInfo &checkpoint_info);
+	                       const RowGroup &row_group, ColumnCheckpointInfo &checkpoint_info);
 
 public:
 	void Checkpoint();
@@ -81,7 +81,7 @@ private:
 private:
 	vector<reference<ColumnCheckpointState>> &checkpoint_states;
 	StorageManager &storage_manager;
-	RowGroup &row_group;
+	const RowGroup &row_group;
 	Vector intermediate;
 	ColumnCheckpointInfo &checkpoint_info;
 

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -50,9 +50,9 @@ public:
 
 	void CommitDropColumn() override;
 
-	unique_ptr<ColumnCheckpointState> CreateCheckpointState(RowGroup &row_group,
+	unique_ptr<ColumnCheckpointState> CreateCheckpointState(const RowGroup &row_group,
 	                                                        PartialBlockManager &partial_block_manager) override;
-	unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) override;
+	unique_ptr<ColumnCheckpointState> Checkpoint(const RowGroup &row_group, ColumnCheckpointInfo &info) override;
 
 	bool IsPersistent() override;
 	bool HasAnyChanges() const override;

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -20,7 +20,6 @@ public:
 	               ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
 public:
-	shared_ptr<ValidityColumnData> &GetValidityData() override;
 	void SetDataType(ColumnDataType data_type) override;
 	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -62,6 +62,9 @@ public:
 	void GetColumnSegmentInfo(const QueryContext &context, duckdb::idx_t row_group_index,
 	                          vector<duckdb::idx_t> col_path, vector<duckdb::ColumnSegmentInfo> &result) override;
 
+	void SetValidityData(shared_ptr<ValidityColumnData> validity_p);
+	void SetChildData(shared_ptr<ColumnData> child_column_p);
+
 protected:
 	//! The child-column of the list
 	shared_ptr<ColumnData> child_column;

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -20,6 +20,7 @@ public:
 	               ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
 public:
+	shared_ptr<ValidityColumnData> &GetValidityData() override;
 	void SetDataType(ColumnDataType data_type) override;
 	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 
@@ -66,8 +67,7 @@ protected:
 	//! The child-column of the list
 	shared_ptr<ColumnData> child_column;
 	//! The validity column data of the list
-	shared_ptr<ValidityColumnData> validity_data;
-	ValidityColumnData &validity;
+	shared_ptr<ValidityColumnData> validity;
 
 private:
 	uint64_t FetchListOffset(idx_t row_idx);

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -19,11 +19,6 @@ public:
 	ListColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, LogicalType type,
 	               ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
-	//! The child-column of the list
-	unique_ptr<ColumnData> child_column;
-	//! The validity column data of the list
-	ValidityColumnData validity;
-
 public:
 	void SetDataType(ColumnDataType data_type) override;
 	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
@@ -66,6 +61,13 @@ public:
 
 	void GetColumnSegmentInfo(const QueryContext &context, duckdb::idx_t row_group_index,
 	                          vector<duckdb::idx_t> col_path, vector<duckdb::ColumnSegmentInfo> &result) override;
+
+protected:
+	//! The child-column of the list
+	shared_ptr<ColumnData> child_column;
+	//! The validity column data of the list
+	shared_ptr<ValidityColumnData> validity_data;
+	ValidityColumnData &validity;
 
 private:
 	uint64_t FetchListOffset(idx_t row_idx);

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -75,6 +75,7 @@ private:
 };
 
 struct RowGroupWriteData {
+	shared_ptr<RowGroup> result_row_group;
 	vector<unique_ptr<ColumnCheckpointState>> states;
 	vector<BaseStatistics> statistics;
 	bool reuse_existing_metadata_blocks = false;
@@ -167,6 +168,8 @@ public:
 
 	static vector<RowGroupWriteData> WriteToDisk(RowGroupWriteInfo &info,
 	                                             const vector<const_reference<RowGroup>> &row_groups);
+	//! Write the data inside this RowGroup to disk and return a struct with information about the write
+	//! Including the new RowGroup that contains the columns in their written-to-disk form
 	RowGroupWriteData WriteToDisk(RowGroupWriteInfo &info) const;
 	//! Returns the number of committed rows (count - committed deletes)
 	idx_t GetCommittedRowCount();

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -110,7 +110,7 @@ public:
 	void Checkpoint(TableDataWriter &writer, TableStatistics &global_stats);
 
 	void InitializeVacuumState(CollectionCheckpointState &checkpoint_state, VacuumState &state,
-	                           vector<unique_ptr<SegmentNode<RowGroup>>> &segments);
+	                           const vector<shared_ptr<SegmentNode<RowGroup>>> &segments);
 	bool ScheduleVacuumTasks(CollectionCheckpointState &checkpoint_state, VacuumState &state, idx_t segment_idx,
 	                         bool schedule_vacuum);
 	unique_ptr<CheckpointTask> GetCheckpointTask(CollectionCheckpointState &checkpoint_state, idx_t segment_idx);

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -160,6 +160,9 @@ private:
 
 	optional_ptr<SegmentNode<RowGroup>> NextUpdateRowGroup(row_t *ids, idx_t &pos, idx_t count) const;
 
+	shared_ptr<RowGroupSegmentTree> GetRowGroupPointer();
+	void SetRowGroups(shared_ptr<RowGroupSegmentTree> row_groups);
+
 private:
 	//! BlockManager
 	BlockManager &block_manager;
@@ -171,8 +174,12 @@ private:
 	shared_ptr<DataTableInfo> info;
 	//! The column types of the row group collection
 	vector<LogicalType> types;
+	//! Lock held when accessing or modifying the owned_row_groups pointer
+	mutex row_group_pointer_lock;
+	//! The owning pointer of the segment tree
+	shared_ptr<RowGroupSegmentTree> owned_row_groups;
 	//! The segment trees holding the various row_groups of the table
-	shared_ptr<RowGroupSegmentTree> row_groups;
+	reference<RowGroupSegmentTree> row_groups;
 	//! Table statistics
 	TableStatistics stats;
 	//! Allocation size, only tracked for appends

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -156,11 +156,10 @@ public:
 	void SetAppendRequiresNewRowGroup();
 
 private:
-	bool IsEmpty(SegmentLock &) const;
+	optional_ptr<SegmentNode<RowGroup>> NextUpdateRowGroup(RowGroupSegmentTree &row_groups, row_t *ids, idx_t &pos,
+	                                                       idx_t count) const;
 
-	optional_ptr<SegmentNode<RowGroup>> NextUpdateRowGroup(row_t *ids, idx_t &pos, idx_t count) const;
-
-	shared_ptr<RowGroupSegmentTree> GetRowGroupPointer();
+	shared_ptr<RowGroupSegmentTree> GetRowGroups() const;
 	void SetRowGroups(shared_ptr<RowGroupSegmentTree> row_groups);
 
 private:
@@ -175,11 +174,9 @@ private:
 	//! The column types of the row group collection
 	vector<LogicalType> types;
 	//! Lock held when accessing or modifying the owned_row_groups pointer
-	mutex row_group_pointer_lock;
+	mutable mutex row_group_pointer_lock;
 	//! The owning pointer of the segment tree
 	shared_ptr<RowGroupSegmentTree> owned_row_groups;
-	//! The segment trees holding the various row_groups of the table
-	reference<RowGroupSegmentTree> row_groups;
 	//! Table statistics
 	TableStatistics stats;
 	//! Allocation size, only tracked for appends

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -59,6 +59,8 @@ public:
 	void AppendRowGroup(SegmentLock &l, idx_t start_row);
 	//! Get the nth row-group, negative numbers start from the back (so -1 is the last row group, etc)
 	optional_ptr<RowGroup> GetRowGroup(int64_t index);
+	//! Overrides a row group - should only be used if you know what you're doing (will likely be removed in the future)
+	void SetRowGroup(int64_t index, shared_ptr<RowGroup> new_row_group);
 	void Verify();
 	void Destroy();
 

--- a/src/include/duckdb/storage/table/row_group_segment_tree.hpp
+++ b/src/include/duckdb/storage/table/row_group_segment_tree.hpp
@@ -28,12 +28,12 @@ public:
 	}
 
 protected:
-	unique_ptr<RowGroup> LoadSegment() override;
+	unique_ptr<RowGroup> LoadSegment() const override;
 
 	RowGroupCollection &collection;
-	idx_t current_row_group;
-	idx_t max_row_group;
-	unique_ptr<MetadataReader> reader;
+	mutable idx_t current_row_group;
+	mutable idx_t max_row_group;
+	mutable unique_ptr<MetadataReader> reader;
 	MetaBlockPointer root_pointer;
 };
 

--- a/src/include/duckdb/storage/table/row_group_segment_tree.hpp
+++ b/src/include/duckdb/storage/table/row_group_segment_tree.hpp
@@ -28,7 +28,7 @@ public:
 	}
 
 protected:
-	unique_ptr<RowGroup> LoadSegment() const override;
+	shared_ptr<RowGroup> LoadSegment() const override;
 
 	RowGroupCollection &collection;
 	mutable idx_t current_row_group;

--- a/src/include/duckdb/storage/table/row_id_column_data.hpp
+++ b/src/include/duckdb/storage/table/row_id_column_data.hpp
@@ -56,9 +56,9 @@ public:
 
 	void CommitDropColumn() override;
 
-	unique_ptr<ColumnCheckpointState> CreateCheckpointState(RowGroup &row_group,
+	unique_ptr<ColumnCheckpointState> CreateCheckpointState(const RowGroup &row_group,
 	                                                        PartialBlockManager &partial_block_manager) override;
-	unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) override;
+	unique_ptr<ColumnCheckpointState> Checkpoint(const RowGroup &row_group, ColumnCheckpointInfo &info) override;
 
 	void CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count,
 	                    Vector &scan_vector) const override;

--- a/src/include/duckdb/storage/table/row_id_column_data.hpp
+++ b/src/include/duckdb/storage/table/row_id_column_data.hpp
@@ -60,7 +60,8 @@ public:
 	                                                        PartialBlockManager &partial_block_manager) override;
 	unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) override;
 
-	void CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count, Vector &scan_vector) override;
+	void CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count,
+	                    Vector &scan_vector) const override;
 
 	bool IsPersistent() override;
 };

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -228,8 +228,8 @@ public:
 	idx_t max_row_group_row;
 	//! Child column scans
 	unsafe_vector<ColumnScanState> column_scans;
-	//! Row group segment tree
-	optional_ptr<RowGroupSegmentTree> row_groups;
+	//! Row group segment tree we are scanning
+	shared_ptr<RowGroupSegmentTree> row_groups;
 	//! The total maximum row index
 	idx_t max_row;
 	//! The current batch index
@@ -322,6 +322,7 @@ struct ParallelCollectionScanState {
 
 	//! The row group collection we are scanning
 	RowGroupCollection *collection;
+	shared_ptr<RowGroupSegmentTree> row_groups;
 	optional_ptr<SegmentNode<RowGroup>> current_row_group;
 	idx_t vector_index;
 	idx_t max_row;
@@ -352,6 +353,7 @@ struct PrefetchState {
 
 class CreateIndexScanState : public TableScanState {
 public:
+	shared_ptr<RowGroupSegmentTree> row_groups;
 	vector<unique_ptr<StorageLockKey>> locks;
 	unique_lock<mutex> append_lock;
 	SegmentLock segment_lock;

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -199,7 +199,7 @@ enum class OrderByColumnType { NUMERIC, STRING };
 class RowGroupReorderer {
 public:
 	explicit RowGroupReorderer(const RowGroupOrderOptions &options);
-	optional_ptr<SegmentNode<RowGroup>> GetRootSegment(RowGroupSegmentTree &row_groups);
+	optional_ptr<SegmentNode<RowGroup>> GetRootSegment(const RowGroupSegmentTree &row_groups);
 	optional_ptr<SegmentNode<RowGroup>> GetNextRowGroup(SegmentNode<RowGroup> &row_group);
 
 	static Value RetrieveStat(const BaseStatistics &stats, OrderByStatistics order_by, OrderByColumnType column_type);
@@ -229,7 +229,7 @@ public:
 	//! Child column scans
 	unsafe_vector<ColumnScanState> column_scans;
 	//! Row group segment tree
-	RowGroupSegmentTree *row_groups;
+	optional_ptr<RowGroupSegmentTree> row_groups;
 	//! The total maximum row index
 	idx_t max_row;
 	//! The current batch index

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -20,7 +20,6 @@ public:
 	                   ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
 public:
-	shared_ptr<ValidityColumnData> &GetValidityData() override;
 	void SetDataType(ColumnDataType data_type) override;
 
 	ScanVectorType GetVectorScanType(ColumnScanState &state, idx_t scan_count, Vector &result) override;
@@ -68,6 +67,8 @@ public:
 	void InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) override;
 
 	void Verify(RowGroup &parent) override;
+
+	void SetValidityData(shared_ptr<ValidityColumnData> validity);
 
 protected:
 	//! The validity column data

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -19,9 +19,6 @@ public:
 	StandardColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, LogicalType type,
 	                   ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
-	//! The validity column data
-	ValidityColumnData validity;
-
 public:
 	void SetDataType(ColumnDataType data_type) override;
 
@@ -70,6 +67,11 @@ public:
 	void InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) override;
 
 	void Verify(RowGroup &parent) override;
+
+protected:
+	//! The validity column data
+	shared_ptr<ValidityColumnData> validity_data;
+	ValidityColumnData &validity;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -53,9 +53,9 @@ public:
 
 	void CommitDropColumn() override;
 
-	unique_ptr<ColumnCheckpointState> CreateCheckpointState(RowGroup &row_group,
+	unique_ptr<ColumnCheckpointState> CreateCheckpointState(const RowGroup &row_group,
 	                                                        PartialBlockManager &partial_block_manager) override;
-	unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) override;
+	unique_ptr<ColumnCheckpointState> Checkpoint(const RowGroup &row_group, ColumnCheckpointInfo &info) override;
 	void CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count,
 	                    Vector &scan_vector) const override;
 

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -56,7 +56,8 @@ public:
 	unique_ptr<ColumnCheckpointState> CreateCheckpointState(RowGroup &row_group,
 	                                                        PartialBlockManager &partial_block_manager) override;
 	unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) override;
-	void CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count, Vector &scan_vector) override;
+	void CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count,
+	                    Vector &scan_vector) const override;
 
 	void GetColumnSegmentInfo(const QueryContext &context, duckdb::idx_t row_group_index,
 	                          vector<duckdb::idx_t> col_path, vector<duckdb::ColumnSegmentInfo> &result) override;

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -20,6 +20,7 @@ public:
 	                   ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
 public:
+	shared_ptr<ValidityColumnData> &GetValidityData() override;
 	void SetDataType(ColumnDataType data_type) override;
 
 	ScanVectorType GetVectorScanType(ColumnScanState &state, idx_t scan_count, Vector &result) override;
@@ -70,8 +71,7 @@ public:
 
 protected:
 	//! The validity column data
-	shared_ptr<ValidityColumnData> validity_data;
-	ValidityColumnData &validity;
+	shared_ptr<ValidityColumnData> validity;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -50,9 +50,9 @@ public:
 
 	void CommitDropColumn() override;
 
-	unique_ptr<ColumnCheckpointState> CreateCheckpointState(RowGroup &row_group,
+	unique_ptr<ColumnCheckpointState> CreateCheckpointState(const RowGroup &row_group,
 	                                                        PartialBlockManager &partial_block_manager) override;
-	unique_ptr<ColumnCheckpointState> Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) override;
+	unique_ptr<ColumnCheckpointState> Checkpoint(const RowGroup &row_group, ColumnCheckpointInfo &info) override;
 
 	bool IsPersistent() override;
 	bool HasAnyChanges() const override;

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -20,7 +20,6 @@ public:
 	                 ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
 public:
-	shared_ptr<ValidityColumnData> &GetValidityData() override;
 	void SetDataType(ColumnDataType data_type) override;
 	idx_t GetMaxEntry() override;
 

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -64,6 +64,9 @@ public:
 
 	void Verify(RowGroup &parent) override;
 
+	void SetValidityData(shared_ptr<ValidityColumnData> validity_p);
+	void SetChildData(idx_t i, shared_ptr<ColumnData> child_column_p);
+
 protected:
 	//! The sub-columns of the struct
 	vector<shared_ptr<ColumnData>> sub_columns;

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -19,11 +19,6 @@ public:
 	StructColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, LogicalType type,
 	                 ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
-	//! The sub-columns of the struct
-	vector<unique_ptr<ColumnData>> sub_columns;
-	//! The validity column data of the struct
-	ValidityColumnData validity;
-
 public:
 	void SetDataType(ColumnDataType data_type) override;
 	idx_t GetMaxEntry() override;
@@ -68,6 +63,13 @@ public:
 	                          vector<duckdb::idx_t> col_path, vector<duckdb::ColumnSegmentInfo> &result) override;
 
 	void Verify(RowGroup &parent) override;
+
+protected:
+	//! The sub-columns of the struct
+	vector<shared_ptr<ColumnData>> sub_columns;
+	//! The validity column data of the struct
+	shared_ptr<ValidityColumnData> validity_data;
+	ValidityColumnData &validity;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -20,6 +20,7 @@ public:
 	                 ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
 public:
+	shared_ptr<ValidityColumnData> &GetValidityData() override;
 	void SetDataType(ColumnDataType data_type) override;
 	idx_t GetMaxEntry() override;
 
@@ -68,8 +69,7 @@ protected:
 	//! The sub-columns of the struct
 	vector<shared_ptr<ColumnData>> sub_columns;
 	//! The validity column data of the struct
-	shared_ptr<ValidityColumnData> validity_data;
-	ValidityColumnData &validity;
+	shared_ptr<ValidityColumnData> validity;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/validity_column_data.hpp
+++ b/src/include/duckdb/storage/table/validity_column_data.hpp
@@ -26,6 +26,8 @@ public:
 	void AppendData(BaseStatistics &stats, ColumnAppendState &state, UnifiedVectorFormat &vdata, idx_t count) override;
 	unique_ptr<ColumnCheckpointState> CreateCheckpointState(RowGroup &row_group,
 	                                                        PartialBlockManager &partial_block_manager) override;
+
+	void Verify(RowGroup &parent) override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/validity_column_data.hpp
+++ b/src/include/duckdb/storage/table/validity_column_data.hpp
@@ -24,7 +24,7 @@ public:
 public:
 	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 	void AppendData(BaseStatistics &stats, ColumnAppendState &state, UnifiedVectorFormat &vdata, idx_t count) override;
-	unique_ptr<ColumnCheckpointState> CreateCheckpointState(RowGroup &row_group,
+	unique_ptr<ColumnCheckpointState> CreateCheckpointState(const RowGroup &row_group,
 	                                                        PartialBlockManager &partial_block_manager) override;
 
 	void Verify(RowGroup &parent) override;

--- a/src/include/duckdb/storage/table/validity_column_data.hpp
+++ b/src/include/duckdb/storage/table/validity_column_data.hpp
@@ -17,7 +17,10 @@ class ValidityColumnData : public ColumnData {
 	friend class StandardColumnData;
 
 public:
-	ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, ColumnData &parent);
+	ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
+					   ColumnData &parent);
+	ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
+					   ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
 public:
 	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;

--- a/src/include/duckdb/storage/table/validity_column_data.hpp
+++ b/src/include/duckdb/storage/table/validity_column_data.hpp
@@ -17,14 +17,15 @@ class ValidityColumnData : public ColumnData {
 	friend class StandardColumnData;
 
 public:
-	ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
-					   ColumnData &parent);
-	ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
-					   ColumnDataType data_type, optional_ptr<ColumnData> parent);
+	ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, ColumnData &parent);
+	ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, ColumnDataType data_type,
+	                   optional_ptr<ColumnData> parent);
 
 public:
 	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 	void AppendData(BaseStatistics &stats, ColumnAppendState &state, UnifiedVectorFormat &vdata, idx_t count) override;
+	unique_ptr<ColumnCheckpointState> CreateCheckpointState(RowGroup &row_group,
+	                                                        PartialBlockManager &partial_block_manager) override;
 };
 
 } // namespace duckdb

--- a/src/storage/optimistic_data_writer.cpp
+++ b/src/storage/optimistic_data_writer.cpp
@@ -69,10 +69,13 @@ void OptimisticDataWriter::WriteNewRowGroup(OptimisticWriteCollection &row_group
 	if (unflushed_row_groups >= DBConfig::GetSetting<WriteBufferRowGroupCountSetting>(context)) {
 		// we have crossed our flush threshold - flush any unwritten row groups to disk
 		vector<const_reference<RowGroup>> to_flush;
+		vector<int64_t> segment_indexes;
 		for (idx_t i = row_groups.last_flushed; i < row_groups.complete_row_groups; i++) {
-			to_flush.push_back(*row_groups.collection->GetRowGroup(NumericCast<int64_t>(i)));
+			auto segment_index = NumericCast<int64_t>(i);
+			to_flush.push_back(*row_groups.collection->GetRowGroup(segment_index));
+			segment_indexes.push_back(segment_index);
 		}
-		FlushToDisk(row_groups, to_flush);
+		FlushToDisk(row_groups, to_flush, segment_indexes);
 		row_groups.last_flushed = row_groups.complete_row_groups;
 	}
 }
@@ -84,12 +87,17 @@ void OptimisticDataWriter::WriteLastRowGroup(OptimisticWriteCollection &row_grou
 	}
 	// flush the last batch of row groups
 	vector<const_reference<RowGroup>> to_flush;
+	vector<int64_t> segment_indexes;
 	for (idx_t i = row_groups.last_flushed; i < row_groups.complete_row_groups; i++) {
-		to_flush.push_back(*row_groups.collection->GetRowGroup(NumericCast<int64_t>(i)));
+		auto segment_index = NumericCast<int64_t>(i);
+		to_flush.push_back(*row_groups.collection->GetRowGroup(segment_index));
+		segment_indexes.push_back(segment_index);
 	}
 	// add the last (incomplete) row group
 	to_flush.push_back(*row_groups.collection->GetRowGroup(-1));
-	FlushToDisk(row_groups, to_flush);
+	segment_indexes.push_back(-1);
+
+	FlushToDisk(row_groups, to_flush, segment_indexes);
 
 	for (auto &partial_manager : row_groups.partial_block_managers) {
 		Merge(partial_manager);
@@ -98,7 +106,8 @@ void OptimisticDataWriter::WriteLastRowGroup(OptimisticWriteCollection &row_grou
 }
 
 void OptimisticDataWriter::FlushToDisk(OptimisticWriteCollection &collection,
-                                       const vector<const_reference<RowGroup>> &row_groups) {
+                                       const vector<const_reference<RowGroup>> &row_groups,
+                                       const vector<int64_t> &segment_indexes) {
 	//! The set of column compression types (if any)
 	vector<CompressionType> compression_types;
 	D_ASSERT(compression_types.empty());
@@ -107,7 +116,10 @@ void OptimisticDataWriter::FlushToDisk(OptimisticWriteCollection &collection,
 	}
 	RowGroupWriteInfo info(*partial_manager, compression_types, collection.partial_block_managers);
 	auto result = RowGroup::WriteToDisk(info, row_groups);
-	throw InternalException("FIXME: move new row groups from write to disk to original collection");
+	// move new (checkpointed) row groups to the row group collection
+	for (idx_t i = 0; i < row_groups.size(); i++) {
+		collection.collection->SetRowGroup(segment_indexes[i], std::move(result[i].result_row_group));
+	}
 }
 
 void OptimisticDataWriter::Merge(unique_ptr<PartialBlockManager> &other_manager) {

--- a/src/storage/optimistic_data_writer.cpp
+++ b/src/storage/optimistic_data_writer.cpp
@@ -68,7 +68,7 @@ void OptimisticDataWriter::WriteNewRowGroup(OptimisticWriteCollection &row_group
 	auto unflushed_row_groups = row_groups.complete_row_groups - row_groups.last_flushed;
 	if (unflushed_row_groups >= DBConfig::GetSetting<WriteBufferRowGroupCountSetting>(context)) {
 		// we have crossed our flush threshold - flush any unwritten row groups to disk
-		vector<reference<RowGroup>> to_flush;
+		vector<const_reference<RowGroup>> to_flush;
 		for (idx_t i = row_groups.last_flushed; i < row_groups.complete_row_groups; i++) {
 			to_flush.push_back(*row_groups.collection->GetRowGroup(NumericCast<int64_t>(i)));
 		}
@@ -83,7 +83,7 @@ void OptimisticDataWriter::WriteLastRowGroup(OptimisticWriteCollection &row_grou
 		return;
 	}
 	// flush the last batch of row groups
-	vector<reference<RowGroup>> to_flush;
+	vector<const_reference<RowGroup>> to_flush;
 	for (idx_t i = row_groups.last_flushed; i < row_groups.complete_row_groups; i++) {
 		to_flush.push_back(*row_groups.collection->GetRowGroup(NumericCast<int64_t>(i)));
 	}
@@ -98,7 +98,7 @@ void OptimisticDataWriter::WriteLastRowGroup(OptimisticWriteCollection &row_grou
 }
 
 void OptimisticDataWriter::FlushToDisk(OptimisticWriteCollection &collection,
-                                       const vector<reference<RowGroup>> &row_groups) {
+                                       const vector<const_reference<RowGroup>> &row_groups) {
 	//! The set of column compression types (if any)
 	vector<CompressionType> compression_types;
 	D_ASSERT(compression_types.empty());
@@ -106,7 +106,8 @@ void OptimisticDataWriter::FlushToDisk(OptimisticWriteCollection &collection,
 		compression_types.push_back(column.CompressionType());
 	}
 	RowGroupWriteInfo info(*partial_manager, compression_types, collection.partial_block_managers);
-	RowGroup::WriteToDisk(info, row_groups);
+	auto result = RowGroup::WriteToDisk(info, row_groups);
+	throw InternalException("FIXME: move new row groups from write to disk to original collection");
 }
 
 void OptimisticDataWriter::Merge(unique_ptr<PartialBlockManager> &other_manager) {

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -18,10 +18,6 @@ ArrayColumnData::ArrayColumnData(BlockManager &block_manager, DataTableInfo &inf
 	child_column = CreateColumn(block_manager, info, 1, child_type, data_type, this);
 }
 
-shared_ptr<ValidityColumnData> &ArrayColumnData::GetValidityData() {
-	return validity;
-}
-
 void ArrayColumnData::SetDataType(ColumnDataType data_type) {
 	ColumnData::SetDataType(data_type);
 	child_column->SetDataType(data_type);

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -290,7 +290,8 @@ void ArrayColumnData::SetChildData(shared_ptr<ColumnData> child_column_p) {
 }
 
 struct ArrayColumnCheckpointState : public ColumnCheckpointState {
-	ArrayColumnCheckpointState(RowGroup &row_group, ColumnData &column_data, PartialBlockManager &partial_block_manager)
+	ArrayColumnCheckpointState(const RowGroup &row_group, ColumnData &column_data,
+	                           PartialBlockManager &partial_block_manager)
 	    : ColumnCheckpointState(row_group, column_data, partial_block_manager) {
 		global_stats = ArrayStats::CreateEmpty(column_data.type).ToUnique();
 	}
@@ -330,12 +331,12 @@ public:
 	}
 };
 
-unique_ptr<ColumnCheckpointState> ArrayColumnData::CreateCheckpointState(RowGroup &row_group,
+unique_ptr<ColumnCheckpointState> ArrayColumnData::CreateCheckpointState(const RowGroup &row_group,
                                                                          PartialBlockManager &partial_block_manager) {
 	return make_uniq<ArrayColumnCheckpointState>(row_group, *this, partial_block_manager);
 }
 
-unique_ptr<ColumnCheckpointState> ArrayColumnData::Checkpoint(RowGroup &row_group,
+unique_ptr<ColumnCheckpointState> ArrayColumnData::Checkpoint(const RowGroup &row_group,
                                                               ColumnCheckpointInfo &checkpoint_info) {
 	auto &partial_block_manager = checkpoint_info.GetPartialBlockManager();
 	auto checkpoint_state = make_uniq<ArrayColumnCheckpointState>(row_group, *this, partial_block_manager);

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -11,11 +11,11 @@ namespace duckdb {
 ArrayColumnData::ArrayColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
                                  LogicalType type_p, ColumnDataType data_type, optional_ptr<ColumnData> parent)
     : ColumnData(block_manager, info, column_index, std::move(type_p), data_type, parent),
-      validity(block_manager, info, 0, *this) {
+      validity_data(make_shared_ptr<ValidityColumnData>(block_manager, info, 0, *this)), validity(*validity_data) {
 	D_ASSERT(type.InternalType() == PhysicalType::ARRAY);
 	auto &child_type = ArrayType::GetChildType(type);
 	// the child column, with column index 1 (0 is the validity mask)
-	child_column = ColumnData::CreateColumnUnique(block_manager, info, 1, child_type, data_type, this);
+	child_column = CreateColumn(block_manager, info, 1, child_type, data_type, this);
 }
 
 void ArrayColumnData::SetDataType(ColumnDataType data_type) {

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -10,12 +10,14 @@ namespace duckdb {
 
 ArrayColumnData::ArrayColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
                                  LogicalType type_p, ColumnDataType data_type, optional_ptr<ColumnData> parent)
-    : ColumnData(block_manager, info, column_index, std::move(type_p), data_type, parent),
-      validity(make_shared_ptr<ValidityColumnData>(block_manager, info, 0, *this)) {
+    : ColumnData(block_manager, info, column_index, std::move(type_p), data_type, parent) {
 	D_ASSERT(type.InternalType() == PhysicalType::ARRAY);
-	auto &child_type = ArrayType::GetChildType(type);
-	// the child column, with column index 1 (0 is the validity mask)
-	child_column = CreateColumn(block_manager, info, 1, child_type, data_type, this);
+	if (data_type != ColumnDataType::CHECKPOINT_TARGET) {
+		auto &child_type = ArrayType::GetChildType(type);
+		validity = make_shared_ptr<ValidityColumnData>(block_manager, info, 0, *this);
+		// the child column, with column index 1 (0 is the validity mask)
+		child_column = CreateColumn(block_manager, info, 1, child_type, data_type, this);
+	}
 }
 
 void ArrayColumnData::SetDataType(ColumnDataType data_type) {
@@ -271,6 +273,22 @@ void ArrayColumnData::CommitDropColumn() {
 	child_column->CommitDropColumn();
 }
 
+void ArrayColumnData::SetValidityData(shared_ptr<ValidityColumnData> validity_p) {
+	if (validity) {
+		throw InternalException("ArrayColumnData::SetValidityData cannot be used to overwrite existing validity");
+	}
+	validity_p->SetParent(this);
+	this->validity = std::move(validity_p);
+}
+
+void ArrayColumnData::SetChildData(shared_ptr<ColumnData> child_column_p) {
+	if (child_column) {
+		throw InternalException("ArrayColumnData::SetChildData cannot be used to overwrite existing data");
+	}
+	child_column_p->SetParent(this);
+	this->child_column = std::move(child_column_p);
+}
+
 struct ArrayColumnCheckpointState : public ColumnCheckpointState {
 	ArrayColumnCheckpointState(RowGroup &row_group, ColumnData &column_data, PartialBlockManager &partial_block_manager)
 	    : ColumnCheckpointState(row_group, column_data, partial_block_manager) {
@@ -281,6 +299,23 @@ struct ArrayColumnCheckpointState : public ColumnCheckpointState {
 	unique_ptr<ColumnCheckpointState> child_state;
 
 public:
+	shared_ptr<ColumnData> CreateEmptyColumnData() override {
+		return make_shared_ptr<ArrayColumnData>(original_column.GetBlockManager(), original_column.GetTableInfo(),
+		                                        original_column.column_index, original_column.type,
+		                                        ColumnDataType::CHECKPOINT_TARGET, nullptr);
+	}
+
+	shared_ptr<ColumnData> GetFinalResult() override {
+		if (!result_column) {
+			result_column = CreateEmptyColumnData();
+		}
+		auto &column_data = result_column->Cast<ArrayColumnData>();
+		auto validity_child = validity_state->GetFinalResult();
+		column_data.SetValidityData(shared_ptr_cast<ColumnData, ValidityColumnData>(std::move(validity_child)));
+		column_data.SetChildData(child_state->GetFinalResult());
+		return ColumnCheckpointState::GetFinalResult();
+	}
+
 	unique_ptr<BaseStatistics> GetStatistics() override {
 		auto stats = global_stats->Copy();
 		ArrayStats::SetChildStats(stats, child_state->GetStatistics());

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -11,7 +11,8 @@ namespace duckdb {
 
 ColumnCheckpointState::ColumnCheckpointState(RowGroup &row_group, ColumnData &original_column,
                                              PartialBlockManager &partial_block_manager)
-    : row_group(row_group), original_column(original_column), partial_block_manager(partial_block_manager) {
+    : row_group(row_group), original_column(original_column), partial_block_manager(partial_block_manager),
+      original_column_mutable(original_column) {
 }
 
 ColumnCheckpointState::~ColumnCheckpointState() {
@@ -37,7 +38,7 @@ shared_ptr<ColumnData> ColumnCheckpointState::GetFinalResult() {
 	if (!result_column) {
 		// no result column instantiated - that means we haven't changed anything and can directly return the
 		// original column
-		return original_column.shared_from_this();
+		return original_column_mutable.shared_from_this();
 	}
 	result_column->SetCount(original_column.count.load());
 	return result_column;

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -9,7 +9,7 @@
 
 namespace duckdb {
 
-ColumnCheckpointState::ColumnCheckpointState(RowGroup &row_group, ColumnData &original_column,
+ColumnCheckpointState::ColumnCheckpointState(const RowGroup &row_group, ColumnData &original_column,
                                              PartialBlockManager &partial_block_manager)
     : row_group(row_group), original_column(original_column), partial_block_manager(partial_block_manager),
       original_column_mutable(original_column) {

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -43,6 +43,7 @@ shared_ptr<ColumnData> ColumnCheckpointState::GetFinalResult() {
 	result_column->SetCount(original_column.count.load());
 	return result_column;
 }
+
 PartialBlockForCheckpoint::PartialBlockForCheckpoint(ColumnData &data, ColumnSegment &segment, PartialBlockState state,
                                                      BlockManager &block_manager)
     : PartialBlock(state, block_manager, segment.block) {

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -22,6 +22,26 @@ unique_ptr<BaseStatistics> ColumnCheckpointState::GetStatistics() {
 	return std::move(global_stats);
 }
 
+shared_ptr<ColumnData> ColumnCheckpointState::CreateEmptyColumnData() {
+	throw InternalException("CreateEmptyColumnData not implemented for this column checkpoint state");
+}
+
+ColumnData &ColumnCheckpointState::GetResultColumn() {
+	if (!result_column) {
+		result_column = CreateEmptyColumnData();
+	}
+	return *result_column;
+}
+
+shared_ptr<ColumnData> ColumnCheckpointState::GetFinalResult() {
+	if (!result_column) {
+		// no result column instantiated - that means we haven't changed anything and can directly return the
+		// original column
+		return original_column.shared_from_this();
+	}
+	result_column->SetCount(original_column.count.load());
+	return result_column;
+}
 PartialBlockForCheckpoint::PartialBlockForCheckpoint(ColumnData &data, ColumnSegment &segment, PartialBlockState state,
                                                      BlockManager &block_manager)
     : PartialBlock(state, block_manager, segment.block) {

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -202,7 +202,8 @@ void ColumnCheckpointState::FlushSegmentInternal(unique_ptr<ColumnSegment> segme
 }
 
 PersistentColumnData ColumnCheckpointState::ToPersistentData() {
-	PersistentColumnData data(result_column->type.InternalType());
+	auto &type = result_column ? result_column->type : original_column.type;
+	PersistentColumnData data(type.InternalType());
 	data.pointers = std::move(data_pointers);
 	return data;
 }

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -49,6 +49,10 @@ StorageManager &ColumnData::GetStorageManager() const {
 	return info.GetDB().GetStorageManager();
 }
 
+shared_ptr<ValidityColumnData> &ColumnData::GetValidityData() {
+	throw InternalException("ColumnData::GetValidityData - ColumnData does not have validity data");
+}
+
 const LogicalType &ColumnData::RootType() const {
 	if (parent) {
 		return parent->RootType();
@@ -92,11 +96,6 @@ bool ColumnData::HasChanges() const {
 
 bool ColumnData::HasAnyChanges() const {
 	return HasChanges();
-}
-
-void ColumnData::ClearUpdates() {
-	lock_guard<mutex> update_guard(update_lock);
-	updates.reset();
 }
 
 idx_t ColumnData::GetMaxEntry() {
@@ -1012,7 +1011,7 @@ shared_ptr<ColumnData> ColumnData::CreateColumn(BlockManager &block_manager, Dat
 	} else if (type.InternalType() == PhysicalType::ARRAY) {
 		return make_shared_ptr<ArrayColumnData>(block_manager, info, column_index, type, data_type, parent);
 	} else if (type.id() == LogicalTypeId::VALIDITY) {
-		return make_shared_ptr<ValidityColumnData>(block_manager, info, column_index, *parent);
+		return make_shared_ptr<ValidityColumnData>(block_manager, info, column_index, data_type, parent);
 	}
 	return make_shared_ptr<StandardColumnData>(block_manager, info, column_index, type, data_type, parent);
 }

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -653,7 +653,7 @@ void ColumnData::CommitDropColumn() {
 	}
 }
 
-unique_ptr<ColumnCheckpointState> ColumnData::CreateCheckpointState(RowGroup &row_group,
+unique_ptr<ColumnCheckpointState> ColumnData::CreateCheckpointState(const RowGroup &row_group,
                                                                     PartialBlockManager &partial_block_manager) {
 	return make_uniq<ColumnCheckpointState>(row_group, *this, partial_block_manager);
 }
@@ -676,7 +676,8 @@ void ColumnData::CheckpointScan(ColumnSegment &segment, ColumnScanState &state, 
 	}
 }
 
-unique_ptr<ColumnCheckpointState> ColumnData::Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &checkpoint_info) {
+unique_ptr<ColumnCheckpointState> ColumnData::Checkpoint(const RowGroup &row_group,
+                                                         ColumnCheckpointInfo &checkpoint_info) {
 	// scan the segments of the column data
 	// set up the checkpoint state
 	auto &partial_block_manager = checkpoint_info.GetPartialBlockManager();

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -25,8 +25,7 @@ ColumnData::ColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t c
                        ColumnDataType data_type_p, optional_ptr<ColumnData> parent)
     : count(0), block_manager(block_manager), info(info), column_index(column_index), type(std::move(type_p)),
       allocation_size(0),
-      data_type(data_type_p == ColumnDataType::CHECKPOINT_TARGET ? ColumnDataType::MAIN_TABLE : data_type_p),
-      parent(parent) {
+      data_type(data_type_p == ColumnDataType::CHECKPOINT_TARGET ? ColumnDataType::MAIN_TABLE : data_type_p) {
 	if (!parent) {
 		stats = make_uniq<SegmentStatistics>(type);
 	}
@@ -49,13 +48,6 @@ DataTableInfo &ColumnData::GetTableInfo() const {
 
 StorageManager &ColumnData::GetStorageManager() const {
 	return info.GetDB().GetStorageManager();
-}
-
-const LogicalType &ColumnData::RootType() const {
-	if (parent) {
-		return parent->RootType();
-	}
-	return type;
 }
 
 bool ColumnData::HasUpdates() const {
@@ -403,7 +395,7 @@ void ColumnData::Append(BaseStatistics &append_stats, ColumnAppendState &state, 
 }
 
 void ColumnData::Append(ColumnAppendState &state, Vector &vector, idx_t append_count) {
-	if (parent || !stats) {
+	if (!stats) {
 		throw InternalException("ColumnData::Append called on a column with a parent or without stats");
 	}
 	lock_guard<mutex> l(stats_lock);

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -24,7 +24,9 @@ namespace duckdb {
 ColumnData::ColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, LogicalType type_p,
                        ColumnDataType data_type_p, optional_ptr<ColumnData> parent)
     : count(0), block_manager(block_manager), info(info), column_index(column_index), type(std::move(type_p)),
-      allocation_size(0), data_type(data_type_p), parent(parent) {
+      allocation_size(0),
+      data_type(data_type_p == ColumnDataType::CHECKPOINT_TARGET ? ColumnDataType::MAIN_TABLE : data_type_p),
+      parent(parent) {
 	if (!parent) {
 		stats = make_uniq<SegmentStatistics>(type);
 	}
@@ -47,10 +49,6 @@ DataTableInfo &ColumnData::GetTableInfo() const {
 
 StorageManager &ColumnData::GetStorageManager() const {
 	return info.GetDB().GetStorageManager();
-}
-
-shared_ptr<ValidityColumnData> &ColumnData::GetValidityData() {
-	throw InternalException("ColumnData::GetValidityData - ColumnData does not have validity data");
 }
 
 const LogicalType &ColumnData::RootType() const {

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -1002,33 +1002,19 @@ void ColumnData::Verify(RowGroup &parent) {
 #endif
 }
 
-template <class RET, class OP>
-static RET CreateColumnInternal(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
-                                const LogicalType &type, ColumnDataType data_type, optional_ptr<ColumnData> parent) {
-	if (type.InternalType() == PhysicalType::STRUCT) {
-		return OP::template Create<StructColumnData>(block_manager, info, column_index, type, data_type, parent);
-	} else if (type.InternalType() == PhysicalType::LIST) {
-		return OP::template Create<ListColumnData>(block_manager, info, column_index, type, data_type, parent);
-	} else if (type.InternalType() == PhysicalType::ARRAY) {
-		return OP::template Create<ArrayColumnData>(block_manager, info, column_index, type, data_type, parent);
-	} else if (type.id() == LogicalTypeId::VALIDITY) {
-		return OP::template Create<ValidityColumnData>(block_manager, info, column_index, *parent);
-	}
-	return OP::template Create<StandardColumnData>(block_manager, info, column_index, type, data_type, parent);
-}
-
 shared_ptr<ColumnData> ColumnData::CreateColumn(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
                                                 const LogicalType &type, ColumnDataType data_type,
                                                 optional_ptr<ColumnData> parent) {
-	return CreateColumnInternal<shared_ptr<ColumnData>, SharedConstructor>(block_manager, info, column_index, type,
-	                                                                       data_type, parent);
-}
-
-unique_ptr<ColumnData> ColumnData::CreateColumnUnique(BlockManager &block_manager, DataTableInfo &info,
-                                                      idx_t column_index, const LogicalType &type,
-                                                      ColumnDataType data_type, optional_ptr<ColumnData> parent) {
-	return CreateColumnInternal<unique_ptr<ColumnData>, UniqueConstructor>(block_manager, info, column_index, type,
-	                                                                       data_type, parent);
+	if (type.InternalType() == PhysicalType::STRUCT) {
+		return make_shared_ptr<StructColumnData>(block_manager, info, column_index, type, data_type, parent);
+	} else if (type.InternalType() == PhysicalType::LIST) {
+		return make_shared_ptr<ListColumnData>(block_manager, info, column_index, type, data_type, parent);
+	} else if (type.InternalType() == PhysicalType::ARRAY) {
+		return make_shared_ptr<ArrayColumnData>(block_manager, info, column_index, type, data_type, parent);
+	} else if (type.id() == LogicalTypeId::VALIDITY) {
+		return make_shared_ptr<ValidityColumnData>(block_manager, info, column_index, *parent);
+	}
+	return make_shared_ptr<StandardColumnData>(block_manager, info, column_index, type, data_type, parent);
 }
 
 } // namespace duckdb

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -22,10 +22,11 @@
 namespace duckdb {
 
 ColumnData::ColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, LogicalType type_p,
-                       ColumnDataType data_type_p, optional_ptr<ColumnData> parent)
+                       ColumnDataType data_type_p, optional_ptr<ColumnData> parent_p)
     : count(0), block_manager(block_manager), info(info), column_index(column_index), type(std::move(type_p)),
       allocation_size(0),
-      data_type(data_type_p == ColumnDataType::CHECKPOINT_TARGET ? ColumnDataType::MAIN_TABLE : data_type_p) {
+      data_type(data_type_p == ColumnDataType::CHECKPOINT_TARGET ? ColumnDataType::MAIN_TABLE : data_type_p),
+      parent(parent_p) {
 	if (!parent) {
 		stats = make_uniq<SegmentStatistics>(type);
 	}

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -658,7 +658,8 @@ unique_ptr<ColumnCheckpointState> ColumnData::CreateCheckpointState(RowGroup &ro
 	return make_uniq<ColumnCheckpointState>(row_group, *this, partial_block_manager);
 }
 
-void ColumnData::CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count, Vector &scan_vector) {
+void ColumnData::CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count,
+                                Vector &scan_vector) const {
 	if (state.scan_options && state.scan_options->force_fetch_row) {
 		for (idx_t i = 0; i < count; i++) {
 			ColumnFetchState fetch_state;

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -330,10 +330,6 @@ void ColumnDataCheckpointer::WriteToDisk() {
 	}
 }
 
-bool ColumnDataCheckpointer::HasChanges(ColumnData &col_data) {
-	return col_data.HasChanges();
-}
-
 void ColumnDataCheckpointer::WritePersistentSegments(ColumnCheckpointState &state) {
 	// all segments are persistent and there are no updates
 	// we only need to write the metadata
@@ -375,7 +371,7 @@ void ColumnDataCheckpointer::Checkpoint() {
 	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
 		auto &state = checkpoint_states[i];
 		auto &col_data = state.get().original_column;
-		if (HasChanges(col_data)) {
+		if (col_data.HasChanges()) {
 			has_changes = true;
 			break;
 		}

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -152,7 +152,6 @@ void ColumnDataCheckpointer::InitAnalyze() {
 		auto &states = analyze_states[i];
 		auto &checkpoint_state = checkpoint_states[i];
 		auto &coldata = checkpoint_state.get().GetResultColumn();
-		coldata.count = checkpoint_state.get().original_column.count.load();
 		states.resize(functions.size());
 		for (idx_t j = 0; j < functions.size(); j++) {
 			auto &func = functions[j];
@@ -385,9 +384,6 @@ void ColumnDataCheckpointer::WritePersistentSegments(ColumnCheckpointState &stat
 				extra_info += StringUtil::Format("Start %d, count %d", s->row_start, s->node->count.load());
 			}
 			const_reference<ColumnData> root = col_data;
-			while (root.get().HasParent()) {
-				root = root.get().Parent();
-			}
 			throw InternalException(
 			    "Failure in RowGroup::Checkpoint - column data pointer is unaligned with row group "
 			    "start\nRow group start: %d\nRow group count %d\nCurrent row: %d\nSegment start: %d\nColumn index: "

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -432,7 +432,6 @@ void ColumnDataCheckpointer::FinalizeCheckpoint() {
 		auto &state = checkpoint_states[i].get();
 		if (!has_changes[i]) {
 			// no changes - copy over the original column
-			state.SetUnchanged();
 			WritePersistentSegments(state);
 		}
 	}

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -31,7 +31,7 @@ ColumnData &ColumnDataCheckpointData::GetColumnData() {
 	return *col_data;
 }
 
-RowGroup &ColumnDataCheckpointData::GetRowGroup() {
+const RowGroup &ColumnDataCheckpointData::GetRowGroup() {
 	return *row_group;
 }
 
@@ -61,7 +61,7 @@ static Vector CreateIntermediateVector(vector<reference<ColumnCheckpointState>> 
 }
 
 ColumnDataCheckpointer::ColumnDataCheckpointer(vector<reference<ColumnCheckpointState>> &checkpoint_states,
-                                               StorageManager &storage_manager, RowGroup &row_group,
+                                               StorageManager &storage_manager, const RowGroup &row_group,
                                                ColumnCheckpointInfo &checkpoint_info)
     : checkpoint_states(checkpoint_states), storage_manager(storage_manager), row_group(row_group),
       intermediate(CreateIntermediateVector(checkpoint_states)), checkpoint_info(checkpoint_info) {

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -18,10 +18,6 @@ ListColumnData::ListColumnData(BlockManager &block_manager, DataTableInfo &info,
 	child_column = CreateColumn(block_manager, info, 1, child_type, data_type, this);
 }
 
-shared_ptr<ValidityColumnData> &ListColumnData::GetValidityData() {
-	return validity;
-}
-
 void ListColumnData::SetDataType(ColumnDataType data_type) {
 	ColumnData::SetDataType(data_type);
 	child_column->SetDataType(data_type);

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -349,7 +349,8 @@ void ListColumnData::SetChildData(shared_ptr<ColumnData> child_column_p) {
 }
 
 struct ListColumnCheckpointState : public ColumnCheckpointState {
-	ListColumnCheckpointState(RowGroup &row_group, ColumnData &column_data, PartialBlockManager &partial_block_manager)
+	ListColumnCheckpointState(const RowGroup &row_group, ColumnData &column_data,
+	                          PartialBlockManager &partial_block_manager)
 	    : ColumnCheckpointState(row_group, column_data, partial_block_manager) {
 		global_stats = ListStats::CreateEmpty(column_data.type).ToUnique();
 	}
@@ -388,12 +389,12 @@ public:
 	}
 };
 
-unique_ptr<ColumnCheckpointState> ListColumnData::CreateCheckpointState(RowGroup &row_group,
+unique_ptr<ColumnCheckpointState> ListColumnData::CreateCheckpointState(const RowGroup &row_group,
                                                                         PartialBlockManager &partial_block_manager) {
 	return make_uniq<ListColumnCheckpointState>(row_group, *this, partial_block_manager);
 }
 
-unique_ptr<ColumnCheckpointState> ListColumnData::Checkpoint(RowGroup &row_group,
+unique_ptr<ColumnCheckpointState> ListColumnData::Checkpoint(const RowGroup &row_group,
                                                              ColumnCheckpointInfo &checkpoint_info) {
 	auto base_state = ColumnData::Checkpoint(row_group, checkpoint_info);
 	auto validity_state = validity->Checkpoint(row_group, checkpoint_info);

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -11,17 +11,21 @@ namespace duckdb {
 ListColumnData::ListColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, LogicalType type_p,
                                ColumnDataType data_type, optional_ptr<ColumnData> parent)
     : ColumnData(block_manager, info, column_index, std::move(type_p), data_type, parent),
-      validity_data(make_shared_ptr<ValidityColumnData>(block_manager, info, 0, *this)), validity(*validity_data) {
+      validity(make_shared_ptr<ValidityColumnData>(block_manager, info, 0, *this)) {
 	D_ASSERT(type.InternalType() == PhysicalType::LIST);
 	auto &child_type = ListType::GetChildType(type);
 	// the child column, with column index 1 (0 is the validity mask)
 	child_column = CreateColumn(block_manager, info, 1, child_type, data_type, this);
 }
 
+shared_ptr<ValidityColumnData> &ListColumnData::GetValidityData() {
+	return validity;
+}
+
 void ListColumnData::SetDataType(ColumnDataType data_type) {
 	ColumnData::SetDataType(data_type);
 	child_column->SetDataType(data_type);
-	validity.SetDataType(data_type);
+	validity->SetDataType(data_type);
 }
 
 FilterPropagateResult ListColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
@@ -31,7 +35,7 @@ FilterPropagateResult ListColumnData::CheckZonemap(ColumnScanState &state, Table
 
 void ListColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {
 	ColumnData::InitializePrefetch(prefetch_state, scan_state, rows);
-	validity.InitializePrefetch(prefetch_state, scan_state.child_states[0], rows);
+	validity->InitializePrefetch(prefetch_state, scan_state.child_states[0], rows);
 
 	// we can't know how many rows we need to prefetch for the child of this list without looking at the actual data
 	// we make an estimation by looking at how many rows the child column has versus this column
@@ -48,7 +52,7 @@ void ListColumnData::InitializeScan(ColumnScanState &state) {
 
 	// initialize the validity segment
 	D_ASSERT(state.child_states.size() == 2);
-	validity.InitializeScan(state.child_states[0]);
+	validity->InitializeScan(state.child_states[0]);
 
 	// initialize the child scan
 	child_column->InitializeScan(state.child_states[1]);
@@ -74,7 +78,7 @@ void ListColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t row_
 
 	// initialize the validity segment
 	D_ASSERT(state.child_states.size() == 2);
-	validity.InitializeScanWithOffset(state.child_states[0], row_idx);
+	validity->InitializeScanWithOffset(state.child_states[0], row_idx);
 
 	// we need to read the list at position row_idx to get the correct row offset of the child
 	auto child_offset = FetchListOffset(row_idx - 1);
@@ -108,7 +112,7 @@ idx_t ListColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t co
 	Vector offset_vector(LogicalType::UBIGINT, count);
 	idx_t scan_count = ScanVector(state, offset_vector, count, ScanVectorType::SCAN_FLAT_VECTOR);
 	D_ASSERT(scan_count > 0);
-	validity.ScanCount(state.child_states[0], result, count);
+	validity->ScanCount(state.child_states[0], result, count);
 
 	UnifiedVectorFormat offsets;
 	offset_vector.ToUnifiedFormat(scan_count, offsets);
@@ -147,7 +151,7 @@ idx_t ListColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t co
 
 void ListColumnData::Skip(ColumnScanState &state, idx_t count) {
 	// skip inside the validity segment
-	validity.Skip(state.child_states[0], count);
+	validity->Skip(state.child_states[0], count);
 
 	// we need to read the list entries/offsets to figure out how much to skip
 	// note that we only need to read the first and last entry
@@ -176,7 +180,7 @@ void ListColumnData::InitializeAppend(ColumnAppendState &state) {
 
 	// initialize the validity append
 	ColumnAppendState validity_append_state;
-	validity.InitializeAppend(validity_append_state);
+	validity->InitializeAppend(validity_append_state);
 	state.child_appends.push_back(std::move(validity_append_state));
 
 	// initialize the child column append
@@ -246,12 +250,12 @@ void ListColumnData::Append(BaseStatistics &stats, ColumnAppendState &state, Vec
 	ColumnData::AppendData(stats, state, vdata, count);
 	// append the validity data
 	vdata.validity = append_mask;
-	validity.AppendData(stats, state.child_appends[0], vdata, count);
+	validity->AppendData(stats, state.child_appends[0], vdata, count);
 }
 
 void ListColumnData::RevertAppend(row_t new_count) {
 	ColumnData::RevertAppend(new_count);
-	validity.RevertAppend(new_count);
+	validity->RevertAppend(new_count);
 	auto column_count = GetMaxEntry();
 	if (column_count > 0) {
 		// revert append in the child column
@@ -293,15 +297,15 @@ void ListColumnData::FetchRow(TransactionData transaction, ColumnFetchState &sta
 	// now perform the fetch within the segment
 	auto start_offset = row_id == 0 ? 0 : FetchListOffset(UnsafeNumericCast<idx_t>(row_id - 1));
 	auto end_offset = FetchListOffset(UnsafeNumericCast<idx_t>(row_id));
-	validity.FetchRow(transaction, *state.child_states[0], row_id, result, result_idx);
+	validity->FetchRow(transaction, *state.child_states[0], row_id, result, result_idx);
 
-	auto &validity = FlatVector::Validity(result);
+	auto &validity_mask = FlatVector::Validity(result);
 	auto list_data = FlatVector::GetData<list_entry_t>(result);
 	auto &list_entry = list_data[result_idx];
 	// set the list entry offset to the size of the current list
 	list_entry.offset = ListVector::GetListSize(result);
 	list_entry.length = end_offset - start_offset;
-	if (!validity.RowIsValid(result_idx)) {
+	if (!validity_mask.RowIsValid(result_idx)) {
 		// the list is NULL! no need to fetch the child
 		D_ASSERT(list_entry.length == 0);
 		return;
@@ -326,7 +330,7 @@ void ListColumnData::FetchRow(TransactionData transaction, ColumnFetchState &sta
 
 void ListColumnData::CommitDropColumn() {
 	ColumnData::CommitDropColumn();
-	validity.CommitDropColumn();
+	validity->CommitDropColumn();
 	child_column->CommitDropColumn();
 }
 
@@ -362,7 +366,7 @@ unique_ptr<ColumnCheckpointState> ListColumnData::CreateCheckpointState(RowGroup
 unique_ptr<ColumnCheckpointState> ListColumnData::Checkpoint(RowGroup &row_group,
                                                              ColumnCheckpointInfo &checkpoint_info) {
 	auto base_state = ColumnData::Checkpoint(row_group, checkpoint_info);
-	auto validity_state = validity.Checkpoint(row_group, checkpoint_info);
+	auto validity_state = validity->Checkpoint(row_group, checkpoint_info);
 	auto child_state = child_column->Checkpoint(row_group, checkpoint_info);
 
 	auto &checkpoint_state = base_state->Cast<ListColumnCheckpointState>();
@@ -372,23 +376,23 @@ unique_ptr<ColumnCheckpointState> ListColumnData::Checkpoint(RowGroup &row_group
 }
 
 bool ListColumnData::IsPersistent() {
-	return ColumnData::IsPersistent() && validity.IsPersistent() && child_column->IsPersistent();
+	return ColumnData::IsPersistent() && validity->IsPersistent() && child_column->IsPersistent();
 }
 
 bool ListColumnData::HasAnyChanges() const {
-	return ColumnData::HasAnyChanges() || validity.HasAnyChanges() || child_column->HasAnyChanges();
+	return ColumnData::HasAnyChanges() || validity->HasAnyChanges() || child_column->HasAnyChanges();
 }
 
 PersistentColumnData ListColumnData::Serialize() {
 	auto persistent_data = ColumnData::Serialize();
-	persistent_data.child_columns.push_back(validity.Serialize());
+	persistent_data.child_columns.push_back(validity->Serialize());
 	persistent_data.child_columns.push_back(child_column->Serialize());
 	return persistent_data;
 }
 
 void ListColumnData::InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) {
 	ColumnData::InitializeColumn(column_data, target_stats);
-	validity.InitializeColumn(column_data.child_columns[0], target_stats);
+	validity->InitializeColumn(column_data.child_columns[0], target_stats);
 	auto &child_stats = ListStats::GetChildStats(target_stats);
 	child_column->InitializeColumn(column_data.child_columns[1], child_stats);
 }
@@ -397,7 +401,7 @@ void ListColumnData::GetColumnSegmentInfo(const QueryContext &context, idx_t row
                                           vector<ColumnSegmentInfo> &result) {
 	ColumnData::GetColumnSegmentInfo(context, row_group_index, col_path, result);
 	col_path.push_back(0);
-	validity.GetColumnSegmentInfo(context, row_group_index, col_path, result);
+	validity->GetColumnSegmentInfo(context, row_group_index, col_path, result);
 	col_path.back() = 1;
 	child_column->GetColumnSegmentInfo(context, row_group_index, col_path, result);
 }

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -11,11 +11,11 @@ namespace duckdb {
 ListColumnData::ListColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, LogicalType type_p,
                                ColumnDataType data_type, optional_ptr<ColumnData> parent)
     : ColumnData(block_manager, info, column_index, std::move(type_p), data_type, parent),
-      validity(block_manager, info, 0, *this) {
+      validity_data(make_shared_ptr<ValidityColumnData>(block_manager, info, 0, *this)), validity(*validity_data) {
 	D_ASSERT(type.InternalType() == PhysicalType::LIST);
 	auto &child_type = ListType::GetChildType(type);
 	// the child column, with column index 1 (0 is the validity mask)
-	child_column = ColumnData::CreateColumnUnique(block_manager, info, 1, child_type, data_type, this);
+	child_column = CreateColumn(block_manager, info, 1, child_type, data_type, this);
 }
 
 void ListColumnData::SetDataType(ColumnDataType data_type) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1008,6 +1008,9 @@ vector<RowGroupWriteData> RowGroup::WriteToDisk(RowGroupWriteInfo &info,
 			auto stats = checkpoint_state->GetStatistics();
 			D_ASSERT(stats);
 
+			// FIXME: temporary - we shouldn't be modifying the row group in-place but emitting a new one
+			AssignSharedPointer(row_group.GetColumns()[column_idx], checkpoint_state->GetResultColumnPointer());
+
 			row_group_write_data.statistics.push_back(stats->Copy());
 			row_group_write_data.states.push_back(std::move(checkpoint_state));
 		}

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1008,7 +1008,7 @@ vector<RowGroupWriteData> RowGroup::WriteToDisk(RowGroupWriteInfo &info,
 			// FIXME: we should get rid of the checkpoint state statistics - and instead use the stats in the ColumnData
 			// directly
 			auto stats = checkpoint_state->GetStatistics();
-			result_col->MergeIntoStatistics(*stats);
+			result_col->MergeStatistics(*stats);
 
 			// FIXME: temporary - we shouldn't be modifying the row group in-place but emitting a new one
 			row_group.GetColumns()[column_idx] = std::move(result_col);

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1009,7 +1009,7 @@ vector<RowGroupWriteData> RowGroup::WriteToDisk(RowGroupWriteInfo &info,
 			D_ASSERT(stats);
 
 			// FIXME: temporary - we shouldn't be modifying the row group in-place but emitting a new one
-			AssignSharedPointer(row_group.GetColumns()[column_idx], checkpoint_state->GetResultColumnPointer());
+			AssignSharedPointer(row_group.GetColumns()[column_idx], checkpoint_state->GetFinalResult());
 
 			row_group_write_data.statistics.push_back(stats->Copy());
 			row_group_write_data.states.push_back(std::move(checkpoint_state));

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1031,6 +1031,8 @@ vector<RowGroupWriteData> RowGroup::WriteToDisk(RowGroupWriteInfo &info,
 		auto &row_group = row_groups[row_group_idx].get();
 		auto result_row_group = make_shared_ptr<RowGroup>(row_group.GetCollection(), row_group.count);
 		result_row_group->columns = std::move(result_columns[row_group_idx]);
+		result_row_group->version_info = row_group.version_info.load();
+		result_row_group->owned_version_info = row_group.owned_version_info;
 
 		row_group_write_data.result_row_group = std::move(result_row_group);
 	}

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -39,7 +39,7 @@ void RowGroupSegmentTree::Initialize(PersistentTableData &data) {
 	root_pointer = data.block_pointer;
 }
 
-unique_ptr<RowGroup> RowGroupSegmentTree::LoadSegment() {
+unique_ptr<RowGroup> RowGroupSegmentTree::LoadSegment() const {
 	if (current_row_group >= max_row_group) {
 		reader.reset();
 		finished_loading = true;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -858,7 +858,6 @@ struct CollectionCheckpointState {
 	vector<unique_ptr<RowGroupWriter>> writers;
 	vector<RowGroupWriteData> write_data;
 	TableStatistics &global_stats;
-	mutex write_lock;
 };
 
 class BaseCheckpointTask : public BaseExecutorTask {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -560,7 +560,8 @@ void RowGroupCollection::RevertAppendInternal(idx_t start_row) {
 }
 
 void RowGroupCollection::CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count) {
-	auto row_group = row_groups->GetSegment(start);
+	auto segment_tree = row_groups;
+	auto row_group = segment_tree->GetSegment(start);
 	D_ASSERT(row_group);
 	idx_t current_row = start;
 	idx_t remaining = count;
@@ -576,7 +577,7 @@ void RowGroupCollection::CleanupAppend(transaction_t lowest_transaction, idx_t s
 		if (remaining == 0) {
 			break;
 		}
-		row_group = row_groups->GetNextSegment(*row_group);
+		row_group = segment_tree->GetNextSegment(*row_group);
 	}
 }
 

--- a/src/storage/table/row_id_column_data.cpp
+++ b/src/storage/table/row_id_column_data.cpp
@@ -160,12 +160,12 @@ void RowIdColumnData::CommitDropColumn() {
 	throw InternalException("RowIdColumnData cannot be dropped");
 }
 
-unique_ptr<ColumnCheckpointState> RowIdColumnData::CreateCheckpointState(RowGroup &row_group,
+unique_ptr<ColumnCheckpointState> RowIdColumnData::CreateCheckpointState(const RowGroup &row_group,
                                                                          PartialBlockManager &partial_block_manager) {
 	throw InternalException("RowIdColumnData cannot be checkpointed");
 }
 
-unique_ptr<ColumnCheckpointState> RowIdColumnData::Checkpoint(RowGroup &row_group, ColumnCheckpointInfo &info) {
+unique_ptr<ColumnCheckpointState> RowIdColumnData::Checkpoint(const RowGroup &row_group, ColumnCheckpointInfo &info) {
 	throw InternalException("RowIdColumnData cannot be checkpointed");
 }
 

--- a/src/storage/table/row_id_column_data.cpp
+++ b/src/storage/table/row_id_column_data.cpp
@@ -169,7 +169,8 @@ unique_ptr<ColumnCheckpointState> RowIdColumnData::Checkpoint(RowGroup &row_grou
 	throw InternalException("RowIdColumnData cannot be checkpointed");
 }
 
-void RowIdColumnData::CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count, Vector &scan_vector) {
+void RowIdColumnData::CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count,
+                                     Vector &scan_vector) const {
 	throw InternalException("RowIdColumnData cannot be checkpointed");
 }
 

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -235,7 +235,7 @@ void SetRowGroupVectorWithLimit(const multimap<Value, RowGroupMapEntry> &row_gro
 	}
 }
 
-optional_ptr<SegmentNode<RowGroup>> RowGroupReorderer::GetRootSegment(RowGroupSegmentTree &row_groups) {
+optional_ptr<SegmentNode<RowGroup>> RowGroupReorderer::GetRootSegment(const RowGroupSegmentTree &row_groups) {
 	if (initialized) {
 		if (ordered_row_groups.empty()) {
 			return nullptr;

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -282,8 +282,7 @@ unique_ptr<ColumnCheckpointState> StandardColumnData::Checkpoint(RowGroup &row_g
 	auto &checkpoint_state = base_state->Cast<StandardColumnCheckpointState>();
 	checkpoint_state.validity_state = std::move(validity_state_p);
 
-	auto &nodes = data.ReferenceSegments();
-	if (nodes.empty()) {
+	if (!data.GetRootSegment()) {
 		// empty table: flush the empty list
 		return base_state;
 	}

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -296,6 +296,9 @@ unique_ptr<ColumnCheckpointState> StandardColumnData::Checkpoint(RowGroup &row_g
 	checkpointer.Checkpoint();
 	checkpointer.FinalizeCheckpoint();
 
+	// merge validity stats into base stats
+	base_state->global_stats->Merge(*validity_state.global_stats);
+
 	return base_state;
 }
 

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -302,7 +302,7 @@ unique_ptr<ColumnCheckpointState> StandardColumnData::Checkpoint(RowGroup &row_g
 }
 
 void StandardColumnData::CheckpointScan(ColumnSegment &segment, ColumnScanState &state, idx_t count,
-                                        Vector &scan_vector) {
+                                        Vector &scan_vector) const {
 	ColumnData::CheckpointScan(segment, state, count, scan_vector);
 
 	idx_t offset_in_row_group = state.offset_in_column;

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -14,7 +14,7 @@ namespace duckdb {
 StandardColumnData::StandardColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
                                        LogicalType type, ColumnDataType data_type, optional_ptr<ColumnData> parent)
     : ColumnData(block_manager, info, column_index, std::move(type), data_type, parent),
-      validity(block_manager, info, 0, *this) {
+      validity_data(make_shared_ptr<ValidityColumnData>(block_manager, info, 0, *this)), validity(*validity_data) {
 }
 
 void StandardColumnData::SetDataType(ColumnDataType data_type) {

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -225,7 +225,7 @@ void StandardColumnData::SetValidityData(shared_ptr<ValidityColumnData> validity
 }
 
 struct StandardColumnCheckpointState : public ColumnCheckpointState {
-	StandardColumnCheckpointState(RowGroup &row_group, ColumnData &column_data,
+	StandardColumnCheckpointState(const RowGroup &row_group, ColumnData &column_data,
 	                              PartialBlockManager &partial_block_manager)
 	    : ColumnCheckpointState(row_group, column_data, partial_block_manager) {
 	}
@@ -261,11 +261,11 @@ public:
 };
 
 unique_ptr<ColumnCheckpointState>
-StandardColumnData::CreateCheckpointState(RowGroup &row_group, PartialBlockManager &partial_block_manager) {
+StandardColumnData::CreateCheckpointState(const RowGroup &row_group, PartialBlockManager &partial_block_manager) {
 	return make_uniq<StandardColumnCheckpointState>(row_group, *this, partial_block_manager);
 }
 
-unique_ptr<ColumnCheckpointState> StandardColumnData::Checkpoint(RowGroup &row_group,
+unique_ptr<ColumnCheckpointState> StandardColumnData::Checkpoint(const RowGroup &row_group,
                                                                  ColumnCheckpointInfo &checkpoint_info) {
 	// we need to checkpoint the main column data first
 	// that is because the checkpointing of the main column data ALSO scans the validity data

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -12,7 +12,7 @@ namespace duckdb {
 StructColumnData::StructColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
                                    LogicalType type_p, ColumnDataType data_type, optional_ptr<ColumnData> parent)
     : ColumnData(block_manager, info, column_index, std::move(type_p), data_type, parent),
-      validity(block_manager, info, 0, *this) {
+      validity_data(make_shared_ptr<ValidityColumnData>(block_manager, info, 0, *this)), validity(*validity_data) {
 	D_ASSERT(type.InternalType() == PhysicalType::STRUCT);
 	auto &child_types = StructType::GetChildTypes(type);
 	D_ASSERT(!child_types.empty());
@@ -26,7 +26,7 @@ StructColumnData::StructColumnData(BlockManager &block_manager, DataTableInfo &i
 	idx_t sub_column_index = 1;
 	for (auto &child_type : child_types) {
 		sub_columns.push_back(
-		    ColumnData::CreateColumnUnique(block_manager, info, sub_column_index, child_type.second, data_type, this));
+		    ColumnData::CreateColumn(block_manager, info, sub_column_index, child_type.second, data_type, this));
 		sub_column_index++;
 	}
 }

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -301,7 +301,7 @@ void StructColumnData::SetChildData(idx_t i, shared_ptr<ColumnData> child_column
 }
 
 struct StructColumnCheckpointState : public ColumnCheckpointState {
-	StructColumnCheckpointState(RowGroup &row_group, ColumnData &column_data,
+	StructColumnCheckpointState(const RowGroup &row_group, ColumnData &column_data,
 	                            PartialBlockManager &partial_block_manager)
 	    : ColumnCheckpointState(row_group, column_data, partial_block_manager) {
 		global_stats = StructStats::CreateEmpty(column_data.type).ToUnique();
@@ -347,12 +347,12 @@ public:
 	}
 };
 
-unique_ptr<ColumnCheckpointState> StructColumnData::CreateCheckpointState(RowGroup &row_group,
+unique_ptr<ColumnCheckpointState> StructColumnData::CreateCheckpointState(const RowGroup &row_group,
                                                                           PartialBlockManager &partial_block_manager) {
 	return make_uniq<StructColumnCheckpointState>(row_group, *this, partial_block_manager);
 }
 
-unique_ptr<ColumnCheckpointState> StructColumnData::Checkpoint(RowGroup &row_group,
+unique_ptr<ColumnCheckpointState> StructColumnData::Checkpoint(const RowGroup &row_group,
                                                                ColumnCheckpointInfo &checkpoint_info) {
 	auto &partial_block_manager = checkpoint_info.GetPartialBlockManager();
 	auto checkpoint_state = make_uniq<StructColumnCheckpointState>(row_group, *this, partial_block_manager);

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -31,10 +31,6 @@ StructColumnData::StructColumnData(BlockManager &block_manager, DataTableInfo &i
 	}
 }
 
-shared_ptr<ValidityColumnData> &StructColumnData::GetValidityData() {
-	return validity;
-}
-
 void StructColumnData::SetDataType(ColumnDataType data_type) {
 	ColumnData::SetDataType(data_type);
 	for (auto &sub_column : sub_columns) {
@@ -233,7 +229,7 @@ void StructColumnData::UpdateColumn(TransactionData transaction, DataTable &data
 	if (update_column == 0) {
 		// update the validity column
 		validity->UpdateColumn(transaction, data_table, column_path, update_vector, row_ids, update_count, depth + 1,
-		                      row_group_start);
+		                       row_group_start);
 	} else {
 		if (update_column > sub_columns.size()) {
 			throw InternalException("Update column_path out of range");

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -12,7 +12,7 @@ namespace duckdb {
 StructColumnData::StructColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
                                    LogicalType type_p, ColumnDataType data_type, optional_ptr<ColumnData> parent)
     : ColumnData(block_manager, info, column_index, std::move(type_p), data_type, parent),
-      validity_data(make_shared_ptr<ValidityColumnData>(block_manager, info, 0, *this)), validity(*validity_data) {
+      validity(make_shared_ptr<ValidityColumnData>(block_manager, info, 0, *this)) {
 	D_ASSERT(type.InternalType() == PhysicalType::STRUCT);
 	auto &child_types = StructType::GetChildTypes(type);
 	D_ASSERT(!child_types.empty());
@@ -31,12 +31,16 @@ StructColumnData::StructColumnData(BlockManager &block_manager, DataTableInfo &i
 	}
 }
 
+shared_ptr<ValidityColumnData> &StructColumnData::GetValidityData() {
+	return validity;
+}
+
 void StructColumnData::SetDataType(ColumnDataType data_type) {
 	ColumnData::SetDataType(data_type);
 	for (auto &sub_column : sub_columns) {
 		sub_column->SetDataType(data_type);
 	}
-	validity.SetDataType(data_type);
+	validity->SetDataType(data_type);
 }
 
 idx_t StructColumnData::GetMaxEntry() {
@@ -44,7 +48,7 @@ idx_t StructColumnData::GetMaxEntry() {
 }
 
 void StructColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {
-	validity.InitializePrefetch(prefetch_state, scan_state.child_states[0], rows);
+	validity->InitializePrefetch(prefetch_state, scan_state.child_states[0], rows);
 	for (idx_t i = 0; i < sub_columns.size(); i++) {
 		if (!scan_state.scan_child_column[i]) {
 			continue;
@@ -59,7 +63,7 @@ void StructColumnData::InitializeScan(ColumnScanState &state) {
 	state.current = nullptr;
 
 	// initialize the validity segment
-	validity.InitializeScan(state.child_states[0]);
+	validity->InitializeScan(state.child_states[0]);
 
 	// initialize the sub-columns
 	for (idx_t i = 0; i < sub_columns.size(); i++) {
@@ -77,7 +81,7 @@ void StructColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t ro
 	state.current = nullptr;
 
 	// initialize the validity segment
-	validity.InitializeScanWithOffset(state.child_states[0], row_idx);
+	validity->InitializeScanWithOffset(state.child_states[0], row_idx);
 
 	// initialize the sub-columns
 	for (idx_t i = 0; i < sub_columns.size(); i++) {
@@ -90,7 +94,7 @@ void StructColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t ro
 
 idx_t StructColumnData::Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
                              idx_t target_count) {
-	auto scan_count = validity.Scan(transaction, vector_index, state.child_states[0], result, target_count);
+	auto scan_count = validity->Scan(transaction, vector_index, state.child_states[0], result, target_count);
 	auto &child_entries = StructVector::GetEntries(result);
 	for (idx_t i = 0; i < sub_columns.size(); i++) {
 		auto &target_vector = *child_entries[i];
@@ -107,7 +111,7 @@ idx_t StructColumnData::Scan(TransactionData transaction, idx_t vector_index, Co
 
 idx_t StructColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
                                       idx_t target_count) {
-	auto scan_count = validity.ScanCommitted(vector_index, state.child_states[0], result, allow_updates, target_count);
+	auto scan_count = validity->ScanCommitted(vector_index, state.child_states[0], result, allow_updates, target_count);
 	auto &child_entries = StructVector::GetEntries(result);
 	for (idx_t i = 0; i < sub_columns.size(); i++) {
 		auto &target_vector = *child_entries[i];
@@ -124,7 +128,7 @@ idx_t StructColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state
 }
 
 idx_t StructColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset) {
-	auto scan_count = validity.ScanCount(state.child_states[0], result, count);
+	auto scan_count = validity->ScanCount(state.child_states[0], result, count);
 	auto &child_entries = StructVector::GetEntries(result);
 	for (idx_t i = 0; i < sub_columns.size(); i++) {
 		auto &target_vector = *child_entries[i];
@@ -140,7 +144,7 @@ idx_t StructColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t 
 }
 
 void StructColumnData::Skip(ColumnScanState &state, idx_t count) {
-	validity.Skip(state.child_states[0], count);
+	validity->Skip(state.child_states[0], count);
 
 	// skip inside the sub-columns
 	for (idx_t child_idx = 0; child_idx < sub_columns.size(); child_idx++) {
@@ -153,7 +157,7 @@ void StructColumnData::Skip(ColumnScanState &state, idx_t count) {
 
 void StructColumnData::InitializeAppend(ColumnAppendState &state) {
 	ColumnAppendState validity_append;
-	validity.InitializeAppend(validity_append);
+	validity->InitializeAppend(validity_append);
 	state.child_appends.push_back(std::move(validity_append));
 
 	for (auto &sub_column : sub_columns) {
@@ -172,7 +176,7 @@ void StructColumnData::Append(BaseStatistics &stats, ColumnAppendState &state, V
 	}
 
 	// append the null values
-	validity.Append(stats, state.child_appends[0], vector, count);
+	validity->Append(stats, state.child_appends[0], vector, count);
 
 	auto &child_entries = StructVector::GetEntries(vector);
 	for (idx_t i = 0; i < child_entries.size(); i++) {
@@ -183,7 +187,7 @@ void StructColumnData::Append(BaseStatistics &stats, ColumnAppendState &state, V
 }
 
 void StructColumnData::RevertAppend(row_t new_count) {
-	validity.RevertAppend(new_count);
+	validity->RevertAppend(new_count);
 	for (auto &sub_column : sub_columns) {
 		sub_column->RevertAppend(new_count);
 	}
@@ -200,7 +204,7 @@ idx_t StructColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &resu
 		state.child_states.push_back(std::move(child_state));
 	}
 	// fetch the validity state
-	idx_t scan_count = validity.Fetch(state.child_states[0], row_id, result);
+	idx_t scan_count = validity->Fetch(state.child_states[0], row_id, result);
 	// fetch the sub-column states
 	for (idx_t i = 0; i < child_entries.size(); i++) {
 		sub_columns[i]->Fetch(state.child_states[i + 1], row_id, *child_entries[i]);
@@ -210,7 +214,7 @@ idx_t StructColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &resu
 
 void StructColumnData::Update(TransactionData transaction, DataTable &data_table, idx_t column_index,
                               Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t row_group_start) {
-	validity.Update(transaction, data_table, column_index, update_vector, row_ids, update_count, row_group_start);
+	validity->Update(transaction, data_table, column_index, update_vector, row_ids, update_count, row_group_start);
 	auto &child_entries = StructVector::GetEntries(update_vector);
 	for (idx_t i = 0; i < child_entries.size(); i++) {
 		sub_columns[i]->Update(transaction, data_table, column_index, *child_entries[i], row_ids, update_count,
@@ -228,7 +232,7 @@ void StructColumnData::UpdateColumn(TransactionData transaction, DataTable &data
 	auto update_column = column_path[depth];
 	if (update_column == 0) {
 		// update the validity column
-		validity.UpdateColumn(transaction, data_table, column_path, update_vector, row_ids, update_count, depth + 1,
+		validity->UpdateColumn(transaction, data_table, column_path, update_vector, row_ids, update_count, depth + 1,
 		                      row_group_start);
 	} else {
 		if (update_column > sub_columns.size()) {
@@ -242,7 +246,7 @@ void StructColumnData::UpdateColumn(TransactionData transaction, DataTable &data
 unique_ptr<BaseStatistics> StructColumnData::GetUpdateStatistics() {
 	// check if any child column has updates
 	auto stats = BaseStatistics::CreateEmpty(type);
-	auto validity_stats = validity.GetUpdateStatistics();
+	auto validity_stats = validity->GetUpdateStatistics();
 	if (validity_stats) {
 		stats.Merge(*validity_stats);
 	}
@@ -265,7 +269,7 @@ void StructColumnData::FetchRow(TransactionData transaction, ColumnFetchState &s
 		state.child_states.push_back(std::move(child_state));
 	}
 	// fetch the validity state
-	validity.FetchRow(transaction, *state.child_states[0], row_id, result, result_idx);
+	validity->FetchRow(transaction, *state.child_states[0], row_id, result, result_idx);
 	// fetch the sub-column states
 	for (idx_t i = 0; i < child_entries.size(); i++) {
 		sub_columns[i]->FetchRow(transaction, *state.child_states[i + 1], row_id, *child_entries[i], result_idx);
@@ -273,7 +277,7 @@ void StructColumnData::FetchRow(TransactionData transaction, ColumnFetchState &s
 }
 
 void StructColumnData::CommitDropColumn() {
-	validity.CommitDropColumn();
+	validity->CommitDropColumn();
 	for (auto &sub_column : sub_columns) {
 		sub_column->CommitDropColumn();
 	}
@@ -317,7 +321,7 @@ unique_ptr<ColumnCheckpointState> StructColumnData::Checkpoint(RowGroup &row_gro
                                                                ColumnCheckpointInfo &checkpoint_info) {
 	auto &partial_block_manager = checkpoint_info.GetPartialBlockManager();
 	auto checkpoint_state = make_uniq<StructColumnCheckpointState>(row_group, *this, partial_block_manager);
-	checkpoint_state->validity_state = validity.Checkpoint(row_group, checkpoint_info);
+	checkpoint_state->validity_state = validity->Checkpoint(row_group, checkpoint_info);
 	for (auto &sub_column : sub_columns) {
 		checkpoint_state->child_states.push_back(sub_column->Checkpoint(row_group, checkpoint_info));
 	}
@@ -325,7 +329,7 @@ unique_ptr<ColumnCheckpointState> StructColumnData::Checkpoint(RowGroup &row_gro
 }
 
 bool StructColumnData::IsPersistent() {
-	if (!validity.IsPersistent()) {
+	if (!validity->IsPersistent()) {
 		return false;
 	}
 	for (auto &child_col : sub_columns) {
@@ -337,7 +341,7 @@ bool StructColumnData::IsPersistent() {
 }
 
 bool StructColumnData::HasAnyChanges() const {
-	if (validity.HasAnyChanges()) {
+	if (validity->HasAnyChanges()) {
 		return true;
 	}
 	for (auto &child_col : sub_columns) {
@@ -350,7 +354,7 @@ bool StructColumnData::HasAnyChanges() const {
 
 PersistentColumnData StructColumnData::Serialize() {
 	PersistentColumnData persistent_data(PhysicalType::STRUCT);
-	persistent_data.child_columns.push_back(validity.Serialize());
+	persistent_data.child_columns.push_back(validity->Serialize());
 	for (auto &sub_column : sub_columns) {
 		persistent_data.child_columns.push_back(sub_column->Serialize());
 	}
@@ -358,18 +362,18 @@ PersistentColumnData StructColumnData::Serialize() {
 }
 
 void StructColumnData::InitializeColumn(PersistentColumnData &column_data, BaseStatistics &target_stats) {
-	validity.InitializeColumn(column_data.child_columns[0], target_stats);
+	validity->InitializeColumn(column_data.child_columns[0], target_stats);
 	for (idx_t c_idx = 0; c_idx < sub_columns.size(); c_idx++) {
 		auto &child_stats = StructStats::GetChildStats(target_stats, c_idx);
 		sub_columns[c_idx]->InitializeColumn(column_data.child_columns[c_idx + 1], child_stats);
 	}
-	this->count = validity.count.load();
+	this->count = validity->count.load();
 }
 
 void StructColumnData::GetColumnSegmentInfo(const QueryContext &context, idx_t row_group_index, vector<idx_t> col_path,
                                             vector<ColumnSegmentInfo> &result) {
 	col_path.push_back(0);
-	validity.GetColumnSegmentInfo(context, row_group_index, col_path, result);
+	validity->GetColumnSegmentInfo(context, row_group_index, col_path, result);
 	for (idx_t i = 0; i < sub_columns.size(); i++) {
 		col_path.back() = i + 1;
 		sub_columns[i]->GetColumnSegmentInfo(context, row_group_index, col_path, result);
@@ -379,7 +383,7 @@ void StructColumnData::GetColumnSegmentInfo(const QueryContext &context, idx_t r
 void StructColumnData::Verify(RowGroup &parent) {
 #ifdef DEBUG
 	ColumnData::Verify(parent);
-	validity.Verify(parent);
+	validity->Verify(parent);
 	for (auto &sub_column : sub_columns) {
 		sub_column->Verify(parent);
 	}

--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/storage/table/validity_column_data.hpp"
-#include "duckdb/storage/table/scan_state.hpp"
-#include "duckdb/storage/table/update_segment.hpp"
+#include "duckdb/storage/table/column_checkpoint_state.hpp"
 
 namespace duckdb {
 

--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -43,4 +43,9 @@ ValidityColumnData::CreateCheckpointState(RowGroup &row_group, PartialBlockManag
 	return make_uniq<ValidityColumnCheckpointState>(row_group, *this, partial_block_manager);
 }
 
+void ValidityColumnData::Verify(RowGroup &parent) {
+	D_ASSERT(HasParent());
+	ColumnData::Verify(parent);
+}
+
 } // namespace duckdb

--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -24,7 +24,7 @@ void ValidityColumnData::AppendData(BaseStatistics &stats, ColumnAppendState &st
 }
 
 struct ValidityColumnCheckpointState : public ColumnCheckpointState {
-	ValidityColumnCheckpointState(RowGroup &row_group, ColumnData &column_data,
+	ValidityColumnCheckpointState(const RowGroup &row_group, ColumnData &column_data,
 	                              PartialBlockManager &partial_block_manager)
 	    : ColumnCheckpointState(row_group, column_data, partial_block_manager) {
 	}
@@ -38,7 +38,7 @@ public:
 };
 
 unique_ptr<ColumnCheckpointState>
-ValidityColumnData::CreateCheckpointState(RowGroup &row_group, PartialBlockManager &partial_block_manager) {
+ValidityColumnData::CreateCheckpointState(const RowGroup &row_group, PartialBlockManager &partial_block_manager) {
 	return make_uniq<ValidityColumnCheckpointState>(row_group, *this, partial_block_manager);
 }
 

--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -4,11 +4,15 @@
 
 namespace duckdb {
 
-ValidityColumnData::ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
-                                       ColumnData &parent)
-    : ColumnData(block_manager, info, column_index, LogicalType(LogicalTypeId::VALIDITY), parent.GetDataType(),
-                 &parent) {
+	ValidityColumnData::ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
+						   ColumnDataType data_type, optional_ptr<ColumnData> parent)
+    : ColumnData(block_manager, info, column_index, LogicalType(LogicalTypeId::VALIDITY), data_type,
+                 parent) {
 }
+
+ValidityColumnData::ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
+					   ColumnData &parent) :
+	ValidityColumnData(block_manager, info, column_index, parent.GetDataType(), parent){}
 
 FilterPropagateResult ValidityColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;

--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -4,15 +4,15 @@
 
 namespace duckdb {
 
-	ValidityColumnData::ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
-						   ColumnDataType data_type, optional_ptr<ColumnData> parent)
-    : ColumnData(block_manager, info, column_index, LogicalType(LogicalTypeId::VALIDITY), data_type,
-                 parent) {
+ValidityColumnData::ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
+                                       ColumnDataType data_type, optional_ptr<ColumnData> parent)
+    : ColumnData(block_manager, info, column_index, LogicalType(LogicalTypeId::VALIDITY), data_type, parent) {
 }
 
 ValidityColumnData::ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,
-					   ColumnData &parent) :
-	ValidityColumnData(block_manager, info, column_index, parent.GetDataType(), parent){}
+                                       ColumnData &parent)
+    : ValidityColumnData(block_manager, info, column_index, parent.GetDataType(), parent) {
+}
 
 FilterPropagateResult ValidityColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
@@ -23,4 +23,24 @@ void ValidityColumnData::AppendData(BaseStatistics &stats, ColumnAppendState &st
 	lock_guard<mutex> l(stats_lock);
 	ColumnData::AppendData(stats, state, vdata, count);
 }
+
+struct ValidityColumnCheckpointState : public ColumnCheckpointState {
+	ValidityColumnCheckpointState(RowGroup &row_group, ColumnData &column_data,
+	                              PartialBlockManager &partial_block_manager)
+	    : ColumnCheckpointState(row_group, column_data, partial_block_manager) {
+	}
+
+public:
+	shared_ptr<ColumnData> CreateEmptyColumnData() override {
+		return make_shared_ptr<ValidityColumnData>(original_column.GetBlockManager(), original_column.GetTableInfo(),
+		                                           original_column.column_index, ColumnDataType::CHECKPOINT_TARGET,
+		                                           nullptr);
+	}
+};
+
+unique_ptr<ColumnCheckpointState>
+ValidityColumnData::CreateCheckpointState(RowGroup &row_group, PartialBlockManager &partial_block_manager) {
+	return make_uniq<ValidityColumnCheckpointState>(row_group, *this, partial_block_manager);
+}
+
 } // namespace duckdb


### PR DESCRIPTION

Follow-up from https://github.com/duckdb/duckdb/pull/19761

This PR reworks the way that checkpointing row groups work. Previously, calling `WriteToDisk` would do an in-place rewrite of any `ColumnData` segments that had changes (either newly appended, or updated). We would then clear the segments of the old segment tree and re-insert the new (in-place modified) segments.

All of this in-place modification makes it difficult to reason about any sort of parallelism while checkpointing - which is why we have a big lock around checkpoint operations.

This PR moves further towards removing that lock by making all of the Checkpoint operations generate new entries instead. When checkpoint a `RowGroup` - we now generate a new RowGroup. The old `RowGroup` is left as-is in its old location. We also generate a new `RowGroupSegmentTree` that holds the newly created row groups, instead of modifying the old one in-place.

In order to facilitate re-use, the various components have been turned into shared pointers. Several of these components were already shared pointers (e.g. `shared_ptr<ColumnData>` in the `RowGroup` class, `shared_ptr<RowGroupSegmentTree>` in the `RowGroupCollection`). Several of these have been made shared pointers (`shared_ptr<SegmentNode>` in the SegmentTree, `shared_ptr<ColumnData>` as child members of a ColumnData). When checkpointing a RowGroup, we still only write and create new versions of components that have changed. The unchanged components will still point towards the old versions.

For example, take the below example storing `s STRUCT(x INT, y INT)`, stored as follows in the `RowGroupSegmentTree`:

```
row_start: 0
RowGroup1
   StructColumnData "s"
      ValidityColumnData
      StandardColumnData ("x")
         ValidityColumnData
      StandardColumnData ("y")
         ValidityColumnData

row_start: 122_880
RowGroup2
   StructColumnData "s"
      ValidityColumnData
      StandardColumnData ("x")
         ValidityColumnData
      StandardColumnData ("y")
         ValidityColumnData
```

If we run an operation like:

```sql
UPDATE tbl SET s.x = s.x + 1
WHERE rowid BETWEEN 150_000 AND 151_000 -- only affects second row group
```

Our new row groups will look as follows:


```
row_start: 0
RowGroup1 (RE-USED)

row_start: 122_880
RowGroup2
   StructColumnData "s"
      ValidityColumnData (RE-USED)
      StandardColumnData ("x")
         ValidityColumnData (RE-USED)
      StandardColumnData (RE-USED)
```

Effectively, we only rewrite the `StandardColumnData` of the struct child. The rest of the column data remains the same. This effectively keeps the same performance / behavior as before - but without any in-place modifications.

A side-effect of this change is that we would also be able to checkpoint without first creating a RowGroup, e.g. we could directly go from `ColumnDataCollection -> checkpointed RowGroup` instead of having to first go to an uncompressed `RowGroup` and then checkpointing that in-place. I'm unsure if this will be useful currently - but there's a chance this might speed up bulk insertions which now use the `RowGroupCollection` and could now theoretically be switched to using the `ColumnDataCollection`.

Actually removing the lock requires some more changes to the way we handle free blocks - that is planned for a follow-up.
