### PR TITLE
`GEOMETRY` Rework: Part 4 - Step 2 - Adjust WKB conversion functions

### DIFF
--- a/src/include/duckdb/common/types/geometry.hpp
+++ b/src/include/duckdb/common/types/geometry.hpp
@@ -209,7 +209,7 @@ public:
 
 	//! Convert from WKB
 	DUCKDB_API static bool FromBinary(const string_t &wkb, string_t &result, Vector &result_vector, bool strict);
-	DUCKDB_API static void FromBinary(Vector &source, Vector &result, idx_t count, bool strict);
+	DUCKDB_API static bool FromBinary(Vector &source, Vector &result, idx_t count, bool strict);
 
 	//! Convert to WKB
 	DUCKDB_API static void ToBinary(Vector &source, Vector &result, idx_t count);


### PR DESCRIPTION
This is a followup PR that builds on top of https://github.com/duckdb/duckdb/pull/19476. Please have a look at https://github.com/duckdb/duckdb/pull/19136 for the context behind this PR.

I realized I the `Geometry::FromBinary`/`Geometry::ToBinary` helper functions need to be adjusted slightly so that they can be used to implement the cast functions provided in `duckdb-spatial`. These casts may move to core eventually, but for now this is required to integrate the spatial extension with the new geometry type smoothly.