### PR TITLE
[Wal] Delete Replay Chunks

### DIFF
--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -942,21 +942,20 @@ void WriteAheadLogDeserializer::ReplayDelete() {
 	}
 
 	D_ASSERT(chunk.ColumnCount() == 1 && chunk.data[0].GetType() == LogicalType::ROW_TYPE);
-	row_t row_ids[1];
-	Vector row_identifiers(LogicalType::ROW_TYPE, data_ptr_cast(row_ids));
-	auto source_ids = FlatVector::GetData<row_t>(chunk.data[0]);
+	auto &row_identifiers = chunk.data[0];
+	row_identifiers.Flatten(chunk.size());
+	auto source_ids = FlatVector::GetData<row_t>(row_identifiers);
 
 	// Delete the row IDs from the current table.
 	auto &storage = state.current_table->GetStorage();
 	auto total_rows = storage.GetTotalRows();
-	TableDeleteState delete_state;
 	for (idx_t i = 0; i < chunk.size(); i++) {
 		if (source_ids[i] >= UnsafeNumericCast<row_t>(total_rows)) {
 			throw SerializationException("invalid row ID delete in WAL");
 		}
-		row_ids[0] = source_ids[i];
-		storage.Delete(delete_state, context, row_identifiers, 1);
 	}
+	TableDeleteState delete_state;
+	storage.Delete(delete_state, context, row_identifiers, chunk.size());
 }
 
 void WriteAheadLogDeserializer::ReplayUpdate() {


### PR DESCRIPTION
WriteAheadLogDeserializer::ReplayDelete was deleting one row at a time, which was causing memory to blow up for a large sequence of index deletes being replayed. However, I am not certain if there was a reason for it to be happening one row at a time.

This is only a fix for the specific scenario of consecutive deletes; the bigger issue is over-allocation of memory and lack of buffer management for ColumnDataCollections along the index WAL buffering/replay code path, for example, a sequence of many interleaved index (insert -> delete) operations causes the same problem of memory over-allocation for each replay operation. 



