### PR TITLE
Change the LogLevel of MetricsLogType to LOG_TRACE

### DIFF
--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -110,7 +110,7 @@ public:
 class MetricsLogType : public LogType {
 public:
 	static constexpr const char *NAME = "Metrics";
-	static constexpr LogLevel LEVEL = LogLevel::LOG_INFO;
+	static constexpr LogLevel LEVEL = LogLevel::LOG_TRACE;
 
 	//! Construct the log type
 	MetricsLogType();

--- a/src/include/duckdb/logging/log_type.hpp
+++ b/src/include/duckdb/logging/log_type.hpp
@@ -110,7 +110,7 @@ public:
 class MetricsLogType : public LogType {
 public:
 	static constexpr const char *NAME = "Metrics";
-	static constexpr LogLevel LEVEL = LogLevel::LOG_TRACE;
+	static constexpr LogLevel LEVEL = LogLevel::LOG_DEBUG;
 
 	//! Construct the log type
 	MetricsLogType();

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -23,11 +23,6 @@ Connection::Connection(DatabaseInstance &database)
 	auto &connection_manager = ConnectionManager::Get(database);
 	connection_manager.AddConnection(*context);
 	connection_manager.AssignConnectionId(*this);
-
-#ifdef DEBUG
-	EnableProfiling();
-	context->config.emit_profiler_output = false;
-#endif
 }
 
 Connection::Connection(DuckDB &database) : Connection(*database.instance) {


### PR DESCRIPTION
Previously `MetricsLogType` logs we're always printed in `DEBUG` mode, now they are only printed when the log level is set to `LOG_TRACE`, or they are explicitly enabled. 

Fixes: https://github.com/duckdblabs/duckdb-internal/issues/6460, https://github.com/duckdblabs/duckdb-internal/issues/6442, https://github.com/duckdblabs/duckdb-internal/issues/6623