### PR TITLE
Bump httpfs and iceberg

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(httpfs
     LOAD TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 6c187d86edde066adb2c51a411f3b6020da79e12
+    GIT_TAG 8ff2283fb14b443e673c58e2e9621e3c3215d794
     INCLUDE_DIR src/include
 )

--- a/.github/config/extensions/iceberg.cmake
+++ b/.github/config/extensions/iceberg.cmake
@@ -8,6 +8,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 5f5cd041285ab37b1eea9ec6d3bdda72a67fc1e4
+            GIT_TAG 6cec0127c340bc7e83c7e6b2390e27cb555a9d0a
             )
 endif()


### PR DESCRIPTION
Iceberg to the extension now by default available for v1.4.2, `httpfs` to latest of `v1.4-andium`.