### PR TITLE
[Testing][Dev] Extend tests covered by the `storage_compatibility` test config

### DIFF
--- a/test/configs/storage_compatibility.json
+++ b/test/configs/storage_compatibility.json
@@ -57,7 +57,37 @@
         "test/geoparquet/roundtrip.test",
         "test/geoparquet/unsupported.test",
         "test/geoparquet/versions.text",
-        "test/sql/types/variant/variant_distinct.test"
+        "test/sql/types/variant/variant_distinct.test",
+        "test/sql/storage/compression/roaring/roaring_bool_array_simple.test",
+        "test/sql/storage/compression/roaring/roaring_bool_array_simple_w_null.test",
+        "test/sql/storage/compression/roaring/roaring_bool_bitset_simple.test",
+        "test/sql/storage/compression/roaring/roaring_bool_bitset_simple_w_null.test",
+        "test/sql/storage/compression/roaring/roaring_bool_fetch_row.test",
+        "test/sql/storage/compression/roaring/roaring_bool_first_is_null.test",
+        "test/sql/storage/compression/roaring/roaring_bool_inverted_array_simple.test",
+        "test/sql/storage/compression/roaring/roaring_bool_inverted_run_simple.test",
+        "test/sql/storage/compression/roaring/roaring_bool_run_simple.test",
+        "test/sql/storage/compression/roaring/roaring_bool_run_simple_w_null.test",
+        "test/sql/storage/compression/roaring/roaring_bool_smaller_than_vector.test",
+        "test/sql/storage/compression/roaring/roaring_bool_uncompressed_under_v1_5_0.test"
+      ]
+    },
+    {
+      "reason": "Use of load that fails when the path is replaced",
+      "paths": [
+        "test/fuzzer/sqlsmith/nullif_map_with_config.test",
+        "test/sql/alter/add_pk/test_add_pk_attach.test",
+        "test/sql/catalog/comment_on_column.test",
+        "test/sql/catalog/function/test_table_macro_copy.test",
+        "test/sql/copy_database/copy_database_gen_col.test",
+        "test/sql/storage/temp_directory/max_swap_space_persistent.test",
+        "test/sql/storage/test_index_checkpoint.test",
+        "test/sql/create/create_objects_readonly.test",
+        "test/sql/index/art/storage/test_art_readonly.test",
+        "test/sql/pragma/pragma_database_size_readonly.test",
+        "test/sql/index/art/storage/test_art_duckdb_versions.test",
+        "test/sql/attach/attach_read_only.test",
+        "test/sql/function/list/lambdas/test_lambda_storage.test"
       ]
     }
   ]

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -1165,6 +1165,10 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			} else {
 				load_db_path = string();
 			}
+			auto initial_db = test_config.GetInitialDBPath();
+			if (!initial_db.empty() && !is_read_only && (!db || db->instance->config.options.database_path.empty())) {
+				load_db_path = initial_db;
+			}
 
 			auto command = make_uniq<LoadCommand>(*this, load_db_path, is_read_only, version);
 			ExecuteCommand(std::move(command));


### PR DESCRIPTION
Also replace the `load` paths when we're running the `storage_compatibility` test config.

As can be seen by the updated list of skipped tests, we now also properly test the Roaring boolean tests, and have to skip them because they are (correctly) not forwards-compatible.

I've had to add a new list of skipped tests because of various problems with doing this path replacement for `load`, such as:
- `load` can be used multiple times in a test, with different paths
- The paths used in `load` can be referenced by the test (detach, attach, export, import, etc..)

Parts of these could be fixed by turning the loaded path into a variable, so we could reference `${ACTIVE_DATABASE_PATH}` for example.

### Misc changes

Fixed an uncaught error if the provided version isn't valid (the download fails)
Print the errors to stderr rather than stdout, for easier filtering of the script output.
Added prints for various reasons that a test was already being skipped without being marked as `[SKIPPED]`, for better debugging of the script.