### PR TITLE
Keep cte_root alive while binding materialized CTEs in MERGE INTO children

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -405,7 +405,7 @@ private:
 
 	unique_ptr<QueryNode> BindTableMacro(FunctionExpression &function, TableMacroCatalogEntry &macro_func, idx_t depth);
 
-	unique_ptr<BoundCTENode> BindMaterializedCTE(CommonTableExpressionMap &cte_map);
+	unique_ptr<BoundCTENode> BindMaterializedCTE(CommonTableExpressionMap &cte_map, unique_ptr<CTENode> &cte_root);
 	unique_ptr<BoundCTENode> BindCTE(CTENode &statement);
 
 	unique_ptr<BoundQueryNode> BindNode(SelectNode &node);

--- a/test/sql/cte/cte_on_conflict_issue.test
+++ b/test/sql/cte/cte_on_conflict_issue.test
@@ -1,0 +1,28 @@
+# name: test/sql/cte/cte_on_conflict_issue.test
+# description: Test CTE with ON CONFLICT rewrite
+# group: [cte]
+
+statement ok
+CREATE TABLE t1 (
+    t1c1 BIGINT,
+    t1c2 BIGINT,
+    PRIMARY KEY (t1c1, t1c2)
+);
+
+statement ok
+CREATE TABLE t2 (
+    t2c1 BIGINT
+);
+
+statement error
+WITH
+cte1 AS (
+    SELECT 42 AS cte1c1, [84] AS cte1c2
+),
+cte2 AS (
+    SELECT *
+    FROM t2 s
+)
+INSERT OR REPLACE INTO t1
+SELECT * FROM cte2;
+----


### PR DESCRIPTION
Fixes a lifetime issue in the old CTE binding code