### PR TITLE
CLI: Enable support for mouse clicks in Linenoise - pressing Ctrl+Q allows a single mouse-click to be consumed to change the cursor position

### DIFF
--- a/tools/shell/linenoise/include/linenoise.hpp
+++ b/tools/shell/linenoise/include/linenoise.hpp
@@ -114,6 +114,7 @@ public:
 	void EditRemoveSpaces();
 	void EditSwapCharacter();
 	void EditSwapWord();
+	void SetCursorPosition(int x, int y);
 
 	void StartSearch();
 	void CancelSearch();

--- a/tools/shell/linenoise/include/terminal.hpp
+++ b/tools/shell/linenoise/include/terminal.hpp
@@ -31,6 +31,7 @@ enum KEY_ACTION {
 	CTRL_N = 14,    /* Ctrl-n */
 	CTRL_O = 15,    /* Ctrl-O */
 	CTRL_P = 16,    /* Ctrl-p */
+	CTRL_Q = 17,    /* Ctrl-q */
 	CTRL_R = 18,    /* Ctrl-r */
 	CTRL_S = 19,    /* Ctrl-s */
 	CTRL_T = 20,    /* Ctrl-t */
@@ -88,7 +89,13 @@ enum class EscapeSequence {
 	ALT_RIGHT_ARROW,
 	ALT_BACKSLASH,
 	CTRL_UP,
-	CTRL_DOWN
+	CTRL_DOWN,
+	MOUSE_CLICK
+};
+
+struct TerminalSize {
+	int ws_col = 0;
+	int ws_row = 0;
 };
 
 struct KeyPress {
@@ -105,11 +112,7 @@ struct KeyPress {
 
 	char action = KEY_NULL;
 	EscapeSequence sequence = EscapeSequence::INVALID;
-};
-
-struct TerminalSize {
-	int ws_col = 0;
-	int ws_row = 0;
+	TerminalSize position;
 };
 
 class Terminal {
@@ -117,6 +120,8 @@ public:
 	static int IsUnsupportedTerm();
 	static int EnableRawMode();
 	static void DisableRawMode();
+	static void EnableMouseTracking();
+	static void DisableMouseTracking();
 	static bool IsMultiline();
 	static void SetMultiLine(int ml);
 
@@ -130,7 +135,7 @@ public:
 	static char *EditNoTTY();
 	static int EditRaw(char *buf, size_t buflen, const char *prompt);
 
-	static EscapeSequence ReadEscapeSequence(int ifd);
+	static EscapeSequence ReadEscapeSequence(int ifd, KeyPress &key_press);
 
 #if defined(_WIN32) || defined(WIN32)
 	static HANDLE GetConsoleInput();

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -426,7 +426,7 @@ size_t Linenoise::ColAndRowToPosition(int target_row, int target_col) const {
 		if (cols >= ws.ws_col) {
 			// exceeded width - move to next line
 			rows++;
-			cols = 0;
+			cols = plen;
 		}
 		if (rows > target_row) {
 			// we have skipped our target row - that means "target_col" was out of range for this row
@@ -825,6 +825,22 @@ void Linenoise::EditSwapWord() {
 void Linenoise::EditDeleteAll() {
 	buf[0] = '\0';
 	pos = len = 0;
+	RefreshLine();
+}
+
+void Linenoise::SetCursorPosition(int x, int y) {
+	int current_row, current_col, cols, rows;
+	// key presses are *relative to the current cursor*
+	// first get the current cursor location
+	PositionToColAndRow(pos, current_row, current_col, rows, cols);
+	// adjust the location based on the provided x / y
+	current_col += x;
+	current_row += y;
+	if (current_col < 0 || current_row < 0 || current_row > rows) {
+		// out of bounds - ignore
+		return;
+	}
+	pos = ColAndRowToPosition(current_row, current_col);
 	RefreshLine();
 }
 
@@ -1360,7 +1376,7 @@ bool Linenoise::TryGetKeyPress(int fd, KeyPress &key_press) {
 	key_press.action = c;
 	if (key_press.action == ESC) {
 		// for ESC we need to read an escape sequence
-		key_press.sequence = Terminal::ReadEscapeSequence(ifd);
+		key_press.sequence = Terminal::ReadEscapeSequence(ifd, key_press);
 	}
 	return true;
 #endif
@@ -1664,6 +1680,10 @@ int Linenoise::Edit() {
 			case EscapeSequence::DELETE_KEY:
 				EditDelete();
 				break;
+			case EscapeSequence::MOUSE_CLICK:
+				// mouse click
+				SetCursorPosition(key_press.position.ws_col, key_press.position.ws_row);
+				break;
 			default:
 				Linenoise::Log("Unrecognized escape\n");
 				break;
@@ -1694,6 +1714,9 @@ int Linenoise::Edit() {
 			break;
 		case CTRL_X: /* ctrl+x, insert newline */
 			EditInsertMulti("\r\n");
+			break;
+		case CTRL_Q: /* ctrl+q enables mouse tracking for a single click */
+			Terminal::EnableMouseTracking();
 			break;
 		case CTRL_Y:
 			// unsupported


### PR DESCRIPTION
This PR enables mouse click support for changing the cursor position through the `Ctrl+Q` shortcut. After pressing `Ctrl+Q` - a single mouse event is consumed. If this event is a left click, the cursor is moved to the position where the mouse is clicked. This can be useful for navigating around a large query without having to repeatedly use the arrow keys.

Unfortunately this is more or less the best we can do with mouse support in the Linux / MacOS CLI due to the way mouse support works there. Effectively mouse events are kind of "all or nothing" - either you ignore mouse events, or you consume all mouse events, and all other mouse behavior in the terminal is disabled - i.e. you can't scroll anymore, select text anymore, etc.

I think this is a decent compromise. Consuming a single mouse event and then reverting also prevents users from accidentally getting stuck in this mode and getting confused. Feedback is welcome/appreciated.


This PR only enables this for Linux. Interestingly enough the Windows terminal input support is much better and we could provide much better mouse support there in theory - but we'll leave that for a future iteration.

