### PR TITLE
[Compression] Fix an existing and a new bug in Roaring compression

### DIFF
--- a/src/include/duckdb/storage/compression/roaring/roaring.hpp
+++ b/src/include/duckdb/storage/compression/roaring/roaring.hpp
@@ -342,7 +342,8 @@ public:
 
 public:
 	idx_t GetContainerIndex();
-	idx_t GetRemainingSpace();
+	idx_t GetUsedDataSpace();
+	idx_t GetAvailableSpace();
 	bool CanStore(idx_t container_size, const ContainerMetadata &metadata);
 	void InitializeContainer();
 	void CreateEmptySegment();

--- a/src/storage/compression/roaring/common.cpp
+++ b/src/storage/compression/roaring/common.cpp
@@ -226,7 +226,8 @@ void ExtractValidityMaskToData(Vector &src, Vector &dst, idx_t offset, idx_t sca
 		memset(dst.GetData() + offset, 1, scan_count); // 1 is for valid
 	} else {
 		// "Bit-Unpack" src's validity_mask and put it in dst's data
-		BitpackingPrimitives::UnPackBuffer<uint8_t>(dst.GetData() + offset, data_ptr_cast(validity.GetData()), scan_count, 1);
+		BitpackingPrimitives::UnPackBuffer<uint8_t>(dst.GetData() + offset, data_ptr_cast(validity.GetData()),
+		                                            scan_count, 1);
 	}
 }
 void RoaringScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,

--- a/src/storage/compression/roaring/common.cpp
+++ b/src/storage/compression/roaring/common.cpp
@@ -86,6 +86,7 @@ void SetInvalidRange(ValidityMask &result, idx_t start, idx_t end) {
 	if (end <= start) {
 		throw InternalException("SetInvalidRange called with end (%d) <= start (%d)", end, start);
 	}
+	D_ASSERT(result.Capacity() >= end);
 	result.EnsureWritable();
 	auto result_data = (validity_t *)result.GetData();
 
@@ -217,15 +218,15 @@ unique_ptr<SegmentScanState> RoaringInitScan(const QueryContext &context, Column
 //===--------------------------------------------------------------------===//
 // Scan base data
 //===--------------------------------------------------------------------===//
-void ExtractValidityMaskToData(Vector &src, Vector &dst, idx_t scan_count) {
+void ExtractValidityMaskToData(Vector &src, Vector &dst, idx_t offset, idx_t scan_count) {
 	// Get src's validity mask
 	auto &validity = FlatVector::Validity(src);
 
 	if (validity.AllValid()) {
-		memset(dst.GetData(), 1, scan_count); // 1 is for valid
+		memset(dst.GetData() + offset, 1, scan_count); // 1 is for valid
 	} else {
 		// "Bit-Unpack" src's validity_mask and put it in dst's data
-		BitpackingPrimitives::UnPackBuffer<uint8_t>(dst.GetData(), data_ptr_cast(validity.GetData()), scan_count, 1);
+		BitpackingPrimitives::UnPackBuffer<uint8_t>(dst.GetData() + offset, data_ptr_cast(validity.GetData()), scan_count, 1);
 	}
 }
 void RoaringScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
@@ -241,8 +242,8 @@ void RoaringScanPartialBoolean(ColumnSegment &segment, ColumnScanState &state, i
 	auto start = state.GetPositionInSegment();
 
 	Vector dummy(LogicalType::UBIGINT, false, false, scan_count);
-	scan_state.ScanPartial(start, dummy, result_offset, scan_count);
-	ExtractValidityMaskToData(dummy, result, scan_count);
+	scan_state.ScanPartial(start, dummy, 0, scan_count);
+	ExtractValidityMaskToData(dummy, result, result_offset, scan_count);
 }
 void RoaringScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
 	RoaringScanPartial(segment, state, scan_count, result, 0);
@@ -253,7 +254,7 @@ void RoaringScanBoolean(ColumnSegment &segment, ColumnScanState &state, idx_t sc
 	// scanned data in the vector's validity mask
 	Vector dummy(LogicalType::UBIGINT, false, false, scan_count);
 	RoaringScan(segment, state, scan_count, dummy);
-	ExtractValidityMaskToData(dummy, result, scan_count);
+	ExtractValidityMaskToData(dummy, result, 0, scan_count);
 }
 
 //===--------------------------------------------------------------------===//
@@ -278,7 +279,7 @@ void RoaringFetchRowBoolean(ColumnSegment &segment, ColumnFetchState &state, row
 
 	Vector dummy(LogicalType::UBIGINT, false, false, 1);
 	scan_state.ScanInternal(container_state, 1, dummy, result_idx);
-	ExtractValidityMaskToData(dummy, result, 1);
+	ExtractValidityMaskToData(dummy, result, result_idx, 1);
 }
 
 void RoaringSkip(ColumnSegment &segment, ColumnScanState &state, idx_t skip_count) {

--- a/src/storage/compression/roaring/compress.cpp
+++ b/src/storage/compression/roaring/compress.cpp
@@ -225,12 +225,14 @@ bool RoaringCompressState::CanStore(idx_t container_size_in_tuples, const Contai
 	idx_t runs_count = metadata_collection.GetRunContainerCount();
 	idx_t arrays_count = metadata_collection.GetArrayAndBitsetContainerCount();
 #ifdef DEBUG
-	//! Assert that whatever is already stored can actually fit on the segment
-	idx_t current_metadata_size = metadata_collection.GetMetadataSize(runs_count + arrays_count, runs_count, arrays_count);
-	(void)current_metadata_size;
-	auto used_data_space = GetUsedDataSpace();
-	used_data_space = AlignValue<idx_t, 8>(used_data_space);
-	D_ASSERT(used_data_space + current_metadata_size <= GetAvailableSpace());
+	{
+		//! Assert that whatever is already stored can actually fit on the segment
+		idx_t current_metadata_size = metadata_collection.GetMetadataSize(runs_count + arrays_count, runs_count, arrays_count);
+		(void)current_metadata_size;
+		auto used_data_space = GetUsedDataSpace();
+		used_data_space = AlignValue<idx_t, 8>(used_data_space);
+		D_ASSERT(used_data_space + current_metadata_size <= GetAvailableSpace());
+	}
 #endif
 	idx_t new_data_space = 0;
 	if (metadata.IsUncompressed()) {

--- a/src/storage/compression/roaring/compress.cpp
+++ b/src/storage/compression/roaring/compress.cpp
@@ -227,7 +227,8 @@ bool RoaringCompressState::CanStore(idx_t container_size_in_tuples, const Contai
 #ifdef DEBUG
 	{
 		//! Assert that whatever is already stored can actually fit on the segment
-		idx_t current_metadata_size = metadata_collection.GetMetadataSize(runs_count + arrays_count, runs_count, arrays_count);
+		idx_t current_metadata_size =
+		    metadata_collection.GetMetadataSize(runs_count + arrays_count, runs_count, arrays_count);
 		(void)current_metadata_size;
 		auto used_data_space = GetUsedDataSpace();
 		used_data_space = AlignValue<idx_t, 8>(used_data_space);

--- a/src/storage/compression/roaring/compress.cpp
+++ b/src/storage/compression/roaring/compress.cpp
@@ -212,34 +212,46 @@ idx_t RoaringCompressState::GetContainerIndex() {
 	return index;
 }
 
-idx_t RoaringCompressState::GetRemainingSpace() {
-	return static_cast<idx_t>(metadata_ptr - data_ptr);
+idx_t RoaringCompressState::GetUsedDataSpace() {
+	return static_cast<idx_t>(data_ptr - (handle.Ptr() + sizeof(idx_t)));
 }
 
-bool RoaringCompressState::CanStore(idx_t container_size, const ContainerMetadata &metadata) {
-	idx_t required_space = 0;
-	if (metadata.IsUncompressed()) {
-		// Account for the alignment we might need for this container
-		required_space += (AlignValue<idx_t>(reinterpret_cast<idx_t>(data_ptr))) - reinterpret_cast<idx_t>(data_ptr);
-	}
-	required_space += metadata.GetDataSizeInBytes(container_size);
+idx_t RoaringCompressState::GetAvailableSpace() {
+	return static_cast<idx_t>(metadata_ptr - (handle.Ptr() + sizeof(idx_t)));
+}
 
+bool RoaringCompressState::CanStore(idx_t container_size_in_tuples, const ContainerMetadata &metadata) {
+	//! Required space for all the containers already stored + this additional container
 	idx_t runs_count = metadata_collection.GetRunContainerCount();
 	idx_t arrays_count = metadata_collection.GetArrayAndBitsetContainerCount();
 #ifdef DEBUG
-	idx_t current_size = metadata_collection.GetMetadataSize(runs_count + arrays_count, runs_count, arrays_count);
-	(void)current_size;
-	D_ASSERT(required_space + current_size <= GetRemainingSpace());
+	//! Assert that whatever is already stored can actually fit on the segment
+	idx_t current_metadata_size = metadata_collection.GetMetadataSize(runs_count + arrays_count, runs_count, arrays_count);
+	(void)current_metadata_size;
+	auto used_data_space = GetUsedDataSpace();
+	used_data_space = AlignValue<idx_t, 8>(used_data_space);
+	D_ASSERT(used_data_space + current_metadata_size <= GetAvailableSpace());
 #endif
+	idx_t new_data_space = 0;
+	if (metadata.IsUncompressed()) {
+		//! Account for the alignment we might need for this container
+		//! Up to 7 bytes extra space required to align the data_ptr (see InitializeContainer)
+		new_data_space += (AlignValue<idx_t>(reinterpret_cast<idx_t>(data_ptr))) - reinterpret_cast<idx_t>(data_ptr);
+	}
+	//! Additional space required to store this new container
+	new_data_space += metadata.GetDataSizeInBytes(container_size_in_tuples);
+
 	if (metadata.IsRun()) {
 		runs_count++;
 	} else {
+		//! arrays_count contains both uncompressed and array container count
 		arrays_count++;
 	}
-	idx_t metadata_size = metadata_collection.GetMetadataSize(runs_count + arrays_count, runs_count, arrays_count);
-	required_space += metadata_size;
+	idx_t new_metadata_space = metadata_collection.GetMetadataSize(runs_count + arrays_count, runs_count, arrays_count);
 
-	if (required_space > GetRemainingSpace()) {
+	auto used_data_space = GetUsedDataSpace();
+	auto required_data_space = AlignValue<idx_t, 8>(used_data_space + new_data_space);
+	if (required_data_space + new_metadata_space > GetAvailableSpace()) {
 		return false;
 	}
 	return true;
@@ -300,7 +312,7 @@ void RoaringCompressState::FlushSegment() {
 	// +======================================+
 
 	// x: metadata_offset (to the "right" of it)
-	// d: data of the containers
+	// d: data of the containers (+ alignment)
 	// m: metadata of the containers
 
 	// This is after 'x'
@@ -308,7 +320,7 @@ void RoaringCompressState::FlushSegment() {
 
 	// Size of the 'd' part
 	auto unaligned_data_size = NumericCast<idx_t>(data_ptr - base_ptr);
-	auto data_size = AlignValue(unaligned_data_size);
+	auto data_size = AlignValue<idx_t, 8>(unaligned_data_size);
 	data_ptr += data_size - unaligned_data_size;
 
 	// Size of the 'm' part

--- a/src/storage/compression/roaring/metadata.cpp
+++ b/src/storage/compression/roaring/metadata.cpp
@@ -144,14 +144,14 @@ idx_t ContainerMetadataCollection::Serialize(data_ptr_t dest) const {
 
 	idx_t types_offset = container_type.size() - count_in_segment;
 	data_ptr_t types_data = (data_ptr_t)(container_type.data()); // NOLINT: c-style cast (for const)
-	BitpackingPrimitives::PackBuffer<uint8_t, true>(dest, types_data + types_offset, count_in_segment,
+	BitpackingPrimitives::PackBuffer<uint8_t>(dest, types_data + types_offset, count_in_segment,
 	                                                CONTAINER_TYPE_BITWIDTH);
 	dest += types_size;
 
 	if (!number_of_runs.empty()) {
 		idx_t runs_offset = number_of_runs.size() - runs_in_segment;
 		data_ptr_t run_data = (data_ptr_t)(number_of_runs.data()); // NOLINT: c-style cast (for const)
-		BitpackingPrimitives::PackBuffer<uint8_t, true>(dest, run_data + runs_offset, runs_in_segment,
+		BitpackingPrimitives::PackBuffer<uint8_t>(dest, run_data + runs_offset, runs_in_segment,
 		                                                RUN_CONTAINER_SIZE_BITWIDTH);
 		dest += runs_size;
 	}

--- a/src/storage/compression/roaring/metadata.cpp
+++ b/src/storage/compression/roaring/metadata.cpp
@@ -145,14 +145,14 @@ idx_t ContainerMetadataCollection::Serialize(data_ptr_t dest) const {
 	idx_t types_offset = container_type.size() - count_in_segment;
 	data_ptr_t types_data = (data_ptr_t)(container_type.data()); // NOLINT: c-style cast (for const)
 	BitpackingPrimitives::PackBuffer<uint8_t, true>(dest, types_data + types_offset, count_in_segment,
-	                                          CONTAINER_TYPE_BITWIDTH);
+	                                                CONTAINER_TYPE_BITWIDTH);
 	dest += types_size;
 
 	if (!number_of_runs.empty()) {
 		idx_t runs_offset = number_of_runs.size() - runs_in_segment;
 		data_ptr_t run_data = (data_ptr_t)(number_of_runs.data()); // NOLINT: c-style cast (for const)
 		BitpackingPrimitives::PackBuffer<uint8_t, true>(dest, run_data + runs_offset, runs_in_segment,
-		                                          RUN_CONTAINER_SIZE_BITWIDTH);
+		                                                RUN_CONTAINER_SIZE_BITWIDTH);
 		dest += runs_size;
 	}
 

--- a/src/storage/compression/roaring/metadata.cpp
+++ b/src/storage/compression/roaring/metadata.cpp
@@ -144,14 +144,14 @@ idx_t ContainerMetadataCollection::Serialize(data_ptr_t dest) const {
 
 	idx_t types_offset = container_type.size() - count_in_segment;
 	data_ptr_t types_data = (data_ptr_t)(container_type.data()); // NOLINT: c-style cast (for const)
-	BitpackingPrimitives::PackBuffer<uint8_t>(dest, types_data + types_offset, count_in_segment,
+	BitpackingPrimitives::PackBuffer<uint8_t, true>(dest, types_data + types_offset, count_in_segment,
 	                                          CONTAINER_TYPE_BITWIDTH);
 	dest += types_size;
 
 	if (!number_of_runs.empty()) {
 		idx_t runs_offset = number_of_runs.size() - runs_in_segment;
 		data_ptr_t run_data = (data_ptr_t)(number_of_runs.data()); // NOLINT: c-style cast (for const)
-		BitpackingPrimitives::PackBuffer<uint8_t>(dest, run_data + runs_offset, runs_in_segment,
+		BitpackingPrimitives::PackBuffer<uint8_t, true>(dest, run_data + runs_offset, runs_in_segment,
 		                                          RUN_CONTAINER_SIZE_BITWIDTH);
 		dest += runs_size;
 	}

--- a/src/storage/compression/roaring/metadata.cpp
+++ b/src/storage/compression/roaring/metadata.cpp
@@ -145,14 +145,14 @@ idx_t ContainerMetadataCollection::Serialize(data_ptr_t dest) const {
 	idx_t types_offset = container_type.size() - count_in_segment;
 	data_ptr_t types_data = (data_ptr_t)(container_type.data()); // NOLINT: c-style cast (for const)
 	BitpackingPrimitives::PackBuffer<uint8_t>(dest, types_data + types_offset, count_in_segment,
-	                                                CONTAINER_TYPE_BITWIDTH);
+	                                          CONTAINER_TYPE_BITWIDTH);
 	dest += types_size;
 
 	if (!number_of_runs.empty()) {
 		idx_t runs_offset = number_of_runs.size() - runs_in_segment;
 		data_ptr_t run_data = (data_ptr_t)(number_of_runs.data()); // NOLINT: c-style cast (for const)
 		BitpackingPrimitives::PackBuffer<uint8_t>(dest, run_data + runs_offset, runs_in_segment,
-		                                                RUN_CONTAINER_SIZE_BITWIDTH);
+		                                          RUN_CONTAINER_SIZE_BITWIDTH);
 		dest += runs_size;
 	}
 


### PR DESCRIPTION
This PR fixes #19875

During flushing of the segment we use `AlignValue` before writing the metadata, because it has to be 8-byte aligned.
The existing bug is that we are not accounting for this extra space that will be required, when determining whether we will have enough space to store a container.
This resulted in rare cases in creating a segment size that exceeded the size of a block, thankfully causing an InternalException.

The other bug is in the RoaringBoolean's ScanPartial / FetchRow implementations. It was reading at an offset that was out of bounds of the dummy vector that was created.
And the scanned data was written to the result Vector at a wrong offset.

Thankfully none of these were bugs in the compression logic, so no borked files were created as a result of these bugs.