### PR TITLE
Fix #19517: preserve relation name for table-qualified star LIKE expression

### DIFF
--- a/src/planner/binder/expression/bind_star_expression.cpp
+++ b/src/planner/binder/expression/bind_star_expression.cpp
@@ -216,7 +216,7 @@ void TryTransformStarLike(unique_ptr<ParsedExpression> &root) {
 		child_expr = std::move(list_filter);
 	}
 
-	auto columns_expr = make_uniq<StarExpression>();
+	auto columns_expr = make_uniq<StarExpression>(star.relation_name);
 	columns_expr->columns = true;
 	columns_expr->expr = std::move(child_expr);
 	columns_expr->SetAlias(std::move(original_alias));

--- a/test/sql/projection/select_star_like.test
+++ b/test/sql/projection/select_star_like.test
@@ -105,3 +105,34 @@ statement error
 SELECT * RENAME (col1 AS other_) SIMILAR TO '.*col.*' FROM integers
 ----
 Rename list cannot be combined with a filtering operation
+
+# Create two tables with overlapping column name
+statement ok
+CREATE TABLE t1(id INTEGER, col1 INTEGER, col2 INTEGER)
+
+statement ok
+INSERT INTO t1 VALUES (1, 10, 20)
+
+statement ok
+CREATE TABLE t2(name VARCHAR, category VARCHAR, col2 INTEGER)
+
+statement ok
+INSERT INTO t2 VALUES ('foo', 'bar', 30)
+
+# t1.* LIKE should only select from t1 table
+query II
+SELECT t1.* LIKE 'col%' FROM t1, t2
+----
+10	20
+
+# t2.* LIKE should only select from t2 table
+query I
+SELECT t2.* LIKE 'col%' FROM t1, t2
+----
+30
+
+# Combining both tables - each should only select from its own table
+query III
+SELECT t1.* LIKE 'col%', t2.* LIKE 'col%' FROM t1, t2
+----
+10	20	30


### PR DESCRIPTION
### Summary

Fix table-qualified star expressions with `LIKE/SIMILAR TO` in multi-table queries.

When using `t1.* LIKE` 'pattern' in a query with multiple tables, columns from all tables were incorrectly included instead of only columns from the specified table.

### Root Cause

In `TryTransformStarLike` (`src/planner/binder/expression/bind_star_expression.cpp:231`), when transforming * LIKE 'pattern' into a COLUMNS(...) expression, the new `StarExpression` was created without preserving the original relation_name:

```
// Before (incorrect)
auto columns_expr = make_uniq<StarExpression>();

// After (fixed)
auto columns_expr = make_uniq<StarExpression>(star.relation_name);
```

This caused the table qualifier to be lost, so `t1.* LIKE 'col%'` was effectively treated as `* LIKE 'col%'`, selecting matching columns from all tables in the FROM clause.

### Test Plan

Added test cases for multi-table scenarios in test/sql/projection/select_star_like.test