### PR TITLE
Improve join filter pushdown for ON clause conditions

### DIFF
--- a/src/include/duckdb/planner/operator/logical_comparison_join.hpp
+++ b/src/include/duckdb/planner/operator/logical_comparison_join.hpp
@@ -52,7 +52,7 @@ public:
 	                                              unique_ptr<LogicalOperator> left_child,
 	                                              unique_ptr<LogicalOperator> right_child,
 	                                              unique_ptr<Expression> condition);
-	static unique_ptr<LogicalOperator> CreateJoin(ClientContext &context, JoinType type, JoinRefType ref_type,
+	static unique_ptr<LogicalOperator> CreateJoin(JoinType type, JoinRefType ref_type,
 	                                              unique_ptr<LogicalOperator> left_child,
 	                                              unique_ptr<LogicalOperator> right_child,
 	                                              vector<JoinCondition> conditions,

--- a/src/optimizer/pushdown/pushdown_cross_product.cpp
+++ b/src/optimizer/pushdown/pushdown_cross_product.cpp
@@ -52,9 +52,9 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<Logi
 		                                             op->children[1], left_bindings, right_bindings, join_expressions,
 		                                             conditions, arbitrary_expressions);
 		// create the join from the join conditions
-		auto new_op = LogicalComparisonJoin::CreateJoin(GetContext(), join_type, join_ref_type,
-		                                                std::move(op->children[0]), std::move(op->children[1]),
-		                                                std::move(conditions), std::move(arbitrary_expressions));
+		auto new_op = LogicalComparisonJoin::CreateJoin(join_type, join_ref_type, std::move(op->children[0]),
+		                                                std::move(op->children[1]), std::move(conditions),
+		                                                std::move(arbitrary_expressions));
 
 		// possible cases are: AnyJoin, ComparisonJoin, or Filter + ComparisonJoin
 		if (op->has_estimated_cardinality) {

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -20,6 +20,9 @@
 namespace duckdb {
 
 //! Check if a filter can be safely pushed to the left child
+//! This is used ONLY for join conditions in the ON clause, not for WHERE clause filters.
+//! The logic determines whether a condition that references only the left side can be
+//! pushed down as a filter on the left child operator.
 static bool CanPushToLeftChild(JoinType type) {
 	switch (type) {
 	case JoinType::INNER:
@@ -36,6 +39,9 @@ static bool CanPushToLeftChild(JoinType type) {
 }
 
 //! Check if a filter can be safely pushed to the right child
+//! This is used ONLY for join conditions in the ON clause, not for WHERE clause filters.
+//! The logic determines whether a condition that references only the right side can be
+//! pushed down as a filter on the right child operator.
 static bool CanPushToRightChild(JoinType type) {
 	switch (type) {
 	case JoinType::INNER:

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -117,6 +117,23 @@ static bool IsJoinTypeCondition(const JoinRefType ref_type, const ExpressionType
 	}
 }
 
+//! Check an expression is a usable comparison expression
+static bool IsComparisonExpression(const Expression &expr) {
+	switch (expr.GetExpressionType()) {
+	case ExpressionType::COMPARE_EQUAL:
+	case ExpressionType::COMPARE_NOTEQUAL:
+	case ExpressionType::COMPARE_LESSTHAN:
+	case ExpressionType::COMPARE_GREATERTHAN:
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return true;
+	default:
+		return false;
+	}
+}
+
 //! Create a JoinCondition from a comparison
 static bool CreateJoinCondition(Expression &expr, const unordered_set<idx_t> &left_bindings,
                                 const unordered_set<idx_t> &right_bindings, vector<JoinCondition> &conditions) {

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -171,7 +171,7 @@ void LogicalComparisonJoin::ExtractJoinConditions(
 
 		if (side == JoinSide::NONE) {
 			if (CanEliminate(context, type, expr)) {
-				continue; // Successfully eliminated
+				continue;
 			}
 		} else if (side == JoinSide::LEFT) {
 			if (CanPushToLeftChild(type)) {
@@ -230,10 +230,6 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(JoinType type, Joi
 
 	// validate ASOF join conditions
 	if (is_asof) {
-		if (conditions.empty()) {
-			throw BinderException("ASOF JOIN requires at least one inequality condition");
-		}
-
 		idx_t asof_idx = conditions.size();
 		for (size_t c = 0; c < conditions.size(); ++c) {
 			auto &cond = conditions[c];
@@ -301,7 +297,7 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(JoinType type, Joi
 	// Case 3: Has join conditions and arbitrary expressions - decide based on join type
 	if (!arbitrary_expressions.empty()) {
 		// for inner and semi join create comparison join + filter on top
-		if (type == JoinType::INNER || type == JoinType::SEMI) {
+		if (type == JoinType::INNER) {
 			auto comp_join = make_uniq<LogicalComparisonJoin>(type, LogicalOperatorType::LOGICAL_COMPARISON_JOIN);
 			comp_join->conditions = std::move(conditions);
 			comp_join->children.push_back(std::move(left_child));

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -296,7 +296,7 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(JoinType type, Joi
 
 	// Case 3: Has join conditions and arbitrary expressions - decide based on join type
 	if (!arbitrary_expressions.empty()) {
-		// for inner and semi join create comparison join + filter on top
+		// for inner join create comparison join + filter on top
 		if (type == JoinType::INNER) {
 			auto comp_join = make_uniq<LogicalComparisonJoin>(type, LogicalOperatorType::LOGICAL_COMPARISON_JOIN);
 			comp_join->conditions = std::move(conditions);

--- a/test/sql/join/asof/test_asof_join_filter_pushdown.test
+++ b/test/sql/join/asof/test_asof_join_filter_pushdown.test
@@ -63,3 +63,20 @@ SELECT * FROM left_table l
 ASOF JOIN right_table r
 ON l.symbol = r.symbol AND l.ts >= r.ts AND false;
 ----
+
+query IITTIITTI rowsort
+SELECT * FROM left_table l
+ASOF JOIN right_table r
+ON l.symbol = r.symbol AND l.ts >= r.ts AND l.price + r.bid > 300;
+----
+2	2024-01-01 10:05:00	A	151.000	2	2024-01-01 10:04:00	A	150.500	0
+3	2024-01-01 10:10:00	B	380.000	3	2024-01-01 10:09:00	B	379.000	1
+
+query IITTIITTI rowsort
+SELECT * FROM left_table l
+ASOF LEFT JOIN right_table r
+ON l.symbol = r.symbol AND l.ts >= r.ts AND l.price + r.bid > 300;
+----
+1	2024-01-01 10:00:00	A	150.000	NULL	NULL	NULL	NULL	NULL
+2	2024-01-01 10:05:00	A	151.000	2	2024-01-01 10:04:00	A	150.500	0
+3	2024-01-01 10:10:00	B	380.000	3	2024-01-01 10:09:00	B	379.000	1

--- a/test/sql/join/asof/test_asof_join_filter_pushdown.test
+++ b/test/sql/join/asof/test_asof_join_filter_pushdown.test
@@ -1,0 +1,65 @@
+# name: test/sql/join/asof/test_asof_join_filter_pushdown.test
+# description: Test ASOF JOIN filter pushdown correctness
+# group: [asof]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE left_table (id INTEGER, ts TIMESTAMP, symbol VARCHAR, price DECIMAL);
+
+statement ok
+INSERT INTO left_table VALUES
+(1, '2024-01-01 10:00:00', 'A', 150.00),
+(2, '2024-01-01 10:05:00', 'A', 151.00),
+(3, '2024-01-01 10:10:00', 'B', 380.00);
+
+statement ok
+CREATE TABLE right_table (id INTEGER, ts TIMESTAMP, symbol VARCHAR, bid DECIMAL, active BOOLEAN);
+
+statement ok
+INSERT INTO right_table VALUES
+(1, '2024-01-01 09:59:00', 'A', 149.50, true),
+(2, '2024-01-01 10:04:00', 'A', 150.50, false),
+(3, '2024-01-01 10:09:00', 'B', 379.00, true);
+
+query IITTIITTI rowsort
+SELECT * FROM left_table l
+ASOF JOIN right_table r
+ON l.symbol = r.symbol AND l.ts >= r.ts AND l.price > 150 AND r.active = true;
+----
+2	2024-01-01 10:05:00	A	151.000	1	2024-01-01 09:59:00	A	149.500	1
+3	2024-01-01 10:10:00	B	380.000	3	2024-01-01 10:09:00	B	379.000	1
+
+query IITTIITTI rowsort
+SELECT * FROM left_table l
+ASOF JOIN right_table r
+ON l.symbol = r.symbol AND l.ts >= r.ts AND r.active = true;
+----
+1	2024-01-01 10:00:00	A	150.000	1	2024-01-01 09:59:00	A	149.500	1
+2	2024-01-01 10:05:00	A	151.000	1	2024-01-01 09:59:00	A	149.500	1
+3	2024-01-01 10:10:00	B	380.000	3	2024-01-01 10:09:00	B	379.000	1
+
+query IITTIITTI rowsort
+SELECT * FROM left_table l
+ASOF LEFT JOIN right_table r
+ON l.symbol = r.symbol AND l.ts >= r.ts AND l.price > 150;
+----
+1	2024-01-01 10:00:00	A	150.000	NULL	NULL	NULL	NULL	NULL
+2	2024-01-01 10:05:00	A	151.000	2	2024-01-01 10:04:00	A	150.500	0
+3	2024-01-01 10:10:00	B	380.000	3	2024-01-01 10:09:00	B	379.000	1
+
+query IITTIITTI rowsort
+SELECT * FROM left_table l
+ASOF JOIN right_table r
+ON l.symbol = r.symbol AND l.ts >= r.ts AND true;
+----
+1	2024-01-01 10:00:00	A	150.000	1	2024-01-01 09:59:00	A	149.500	1
+2	2024-01-01 10:05:00	A	151.000	2	2024-01-01 10:04:00	A	150.500	0
+3	2024-01-01 10:10:00	B	380.000	3	2024-01-01 10:09:00	B	379.000	1
+
+query IITTIITTI rowsort
+SELECT * FROM left_table l
+ASOF JOIN right_table r
+ON l.symbol = r.symbol AND l.ts >= r.ts AND false;
+----

--- a/test/sql/join/asof/test_asof_join_filter_pushdown.test
+++ b/test/sql/join/asof/test_asof_join_filter_pushdown.test
@@ -42,15 +42,6 @@ ON l.symbol = r.symbol AND l.ts >= r.ts AND r.active = true;
 
 query IITTIITTI rowsort
 SELECT * FROM left_table l
-ASOF LEFT JOIN right_table r
-ON l.symbol = r.symbol AND l.ts >= r.ts AND l.price > 150;
-----
-1	2024-01-01 10:00:00	A	150.000	NULL	NULL	NULL	NULL	NULL
-2	2024-01-01 10:05:00	A	151.000	2	2024-01-01 10:04:00	A	150.500	0
-3	2024-01-01 10:10:00	B	380.000	3	2024-01-01 10:09:00	B	379.000	1
-
-query IITTIITTI rowsort
-SELECT * FROM left_table l
 ASOF JOIN right_table r
 ON l.symbol = r.symbol AND l.ts >= r.ts AND true;
 ----
@@ -70,6 +61,24 @@ ASOF JOIN right_table r
 ON l.symbol = r.symbol AND l.ts >= r.ts AND l.price + r.bid > 300;
 ----
 2	2024-01-01 10:05:00	A	151.000	2	2024-01-01 10:04:00	A	150.500	0
+3	2024-01-01 10:10:00	B	380.000	3	2024-01-01 10:09:00	B	379.000	1
+
+query IITTIITTI rowsort
+SELECT * FROM left_table l
+ASOF LEFT JOIN right_table r
+ON l.symbol = r.symbol AND l.ts >= r.ts AND l.price > 150;
+----
+1	2024-01-01 10:00:00	A	150.000	NULL	NULL	NULL	NULL	NULL
+2	2024-01-01 10:05:00	A	151.000	2	2024-01-01 10:04:00	A	150.500	0
+3	2024-01-01 10:10:00	B	380.000	3	2024-01-01 10:09:00	B	379.000	1
+
+query IITTIITTI rowsort
+SELECT * FROM left_table l
+ASOF LEFT JOIN right_table r
+ON l.symbol = r.symbol AND l.ts >= r.ts AND r.active = true;
+----
+1	2024-01-01 10:00:00	A	150.000	1	2024-01-01 09:59:00	A	149.500	1
+2	2024-01-01 10:05:00	A	151.000	1	2024-01-01 09:59:00	A	149.500	1
 3	2024-01-01 10:10:00	B	380.000	3	2024-01-01 10:09:00	B	379.000	1
 
 query IITTIITTI rowsort

--- a/test/sql/join/inner/test_inner_join_filter_pushdown.test
+++ b/test/sql/join/inner/test_inner_join_filter_pushdown.test
@@ -1,0 +1,50 @@
+# name: test/sql/join/inner/test_inner_join_filter_pushdown.test
+# description: Test INNER JOIN filter pushdown correctness
+# group: [inner]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE left_table (id INTEGER, val INTEGER, amount INTEGER);
+
+statement ok
+INSERT INTO left_table VALUES (1, 1, 50), (2, 1, 75), (3, 2, 60), (4, 2, 90), (5, 3, 100);
+
+statement ok
+CREATE TABLE right_table (id INTEGER, category INTEGER, budget INTEGER);
+
+statement ok
+INSERT INTO right_table VALUES (1, 1, 1000), (2, 2, 2000), (3, 1, 1500);
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+INNER JOIN right_table r ON l.id = r.id AND l.val > 1 AND r.category = 1;
+----
+3	2	60	3	1	1500
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+INNER JOIN right_table r ON l.id = r.id AND r.category = 1;
+----
+1	1	50	1	1	1000
+3	2	60	3	1	1500
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+INNER JOIN right_table r ON l.id = r.id AND l.val > 1;
+----
+3	2	60	3	1	1500
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+INNER JOIN right_table r ON l.id = r.id AND true;
+----
+1	1	50	1	1	1000
+2	1	75	2	2	2000
+3	2	60	3	1	1500
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+INNER JOIN right_table r ON l.id = r.id AND false;
+----

--- a/test/sql/join/inner/test_inner_join_filter_pushdown.test
+++ b/test/sql/join/inner/test_inner_join_filter_pushdown.test
@@ -48,3 +48,10 @@ query IIIIII rowsort
 SELECT * FROM left_table l
 INNER JOIN right_table r ON l.id = r.id AND false;
 ----
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+INNER JOIN right_table r ON l.id = r.id AND l.amount + r.budget > 1100;
+----
+2	1	75	2	2	2000
+3	2	60	3	1	1500

--- a/test/sql/join/left_outer/test_left_join_filter_pushdown.test
+++ b/test/sql/join/left_outer/test_left_join_filter_pushdown.test
@@ -66,3 +66,13 @@ LEFT JOIN right_table r ON l.id = r.id AND false;
 3	2	60	NULL	NULL	NULL
 4	2	90	NULL	NULL	NULL
 5	99	100	NULL	NULL	NULL
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+LEFT JOIN right_table r ON l.id = r.id AND l.amount + r.budget > 1100;
+----
+1	1	50	NULL	NULL	NULL
+2	1	75	2	2	2000
+3	2	60	3	1	1500
+4	2	90	NULL	NULL	NULL
+5	99	100	NULL	NULL	NULL

--- a/test/sql/join/left_outer/test_left_join_filter_pushdown.test
+++ b/test/sql/join/left_outer/test_left_join_filter_pushdown.test
@@ -1,0 +1,68 @@
+# name: test/sql/join/left_outer/test_left_join_filter_pushdown.test
+# description: Test LEFT JOIN filter pushdown correctness
+# group: [left_outer]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE left_table (id INTEGER, val INTEGER, amount INTEGER);
+
+statement ok
+INSERT INTO left_table VALUES (1, 1, 50), (2, 1, 75), (3, 2, 60), (4, 2, 90), (5, 99, 100);
+
+statement ok
+CREATE TABLE right_table (id INTEGER, category INTEGER, budget INTEGER);
+
+statement ok
+INSERT INTO right_table VALUES (1, 1, 1000), (2, 2, 2000), (3, 1, 1500);
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+LEFT JOIN right_table r ON l.id = r.id AND l.val > 1 AND r.category = 1;
+----
+1	1	50	NULL	NULL	NULL
+2	1	75	NULL	NULL	NULL
+3	2	60	3	1	1500
+4	2	90	NULL	NULL	NULL
+5	99	100	NULL	NULL	NULL
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+LEFT JOIN right_table r ON l.id = r.id AND r.category = 1;
+----
+1	1	50	1	1	1000
+2	1	75	NULL	NULL	NULL
+3	2	60	3	1	1500
+4	2	90	NULL	NULL	NULL
+5	99	100	NULL	NULL	NULL
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+LEFT JOIN right_table r ON l.id = r.id AND l.val > 1;
+----
+1	1	50	NULL	NULL	NULL
+2	1	75	NULL	NULL	NULL
+3	2	60	3	1	1500
+4	2	90	NULL	NULL	NULL
+5	99	100	NULL	NULL	NULL
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+LEFT JOIN right_table r ON l.id = r.id AND true;
+----
+1	1	50	1	1	1000
+2	1	75	2	2	2000
+3	2	60	3	1	1500
+4	2	90	NULL	NULL	NULL
+5	99	100	NULL	NULL	NULL
+
+query IIIIII rowsort
+SELECT * FROM left_table l
+LEFT JOIN right_table r ON l.id = r.id AND false;
+----
+1	1	50	NULL	NULL	NULL
+2	1	75	NULL	NULL	NULL
+3	2	60	NULL	NULL	NULL
+4	2	90	NULL	NULL	NULL
+5	99	100	NULL	NULL	NULL

--- a/test/sql/join/right_outer/test_right_join_filter_pushdown.test
+++ b/test/sql/join/right_outer/test_right_join_filter_pushdown.test
@@ -1,0 +1,72 @@
+# name: test/sql/join/right_outer/test_right_join_filter_pushdown.test
+# description: Test RIGHT JOIN filter pushdown correctness
+# group: [right_outer]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE left_table (id INTEGER, val INTEGER);
+
+statement ok
+INSERT INTO left_table VALUES (1, 1), (2, 1), (3, 2);
+
+statement ok
+CREATE TABLE right_table (id INTEGER, category INTEGER);
+
+statement ok
+INSERT INTO right_table VALUES (1, 1), (2, 2), (3, 1), (4, 1);
+
+query IIII rowsort
+SELECT * FROM left_table l
+RIGHT JOIN right_table r ON l.id = r.id AND l.val > 1 AND r.category = 1;
+----
+3	2	3	1
+NULL	NULL	1	1
+NULL	NULL	2	2
+NULL	NULL	4	1
+
+query IIII rowsort
+SELECT * FROM left_table l
+RIGHT JOIN right_table r ON l.id = r.id AND r.category = 1;
+----
+1	1	1	1
+3	2	3	1
+NULL	NULL	2	2
+NULL	NULL	4	1
+
+query IIII rowsort
+SELECT * FROM left_table l
+RIGHT JOIN right_table r ON l.id = r.id AND l.val > 1;
+----
+3	2	3	1
+NULL	NULL	1	1
+NULL	NULL	2	2
+NULL	NULL	4	1
+
+query IIII rowsort
+SELECT * FROM left_table l
+RIGHT JOIN right_table r ON l.id = r.id AND true;
+----
+1	1	1	1
+2	1	2	2
+3	2	3	1
+NULL	NULL	4	1
+
+query IIII rowsort
+SELECT * FROM left_table l
+RIGHT JOIN right_table r ON l.id = r.id AND false;
+----
+NULL	NULL	1	1
+NULL	NULL	2	2
+NULL	NULL	3	1
+NULL	NULL	4	1
+
+query IIII rowsort
+SELECT * FROM left_table l
+RIGHT JOIN right_table r ON l.id = r.id AND l.val + r.category > 2;
+----
+2	1	2	2
+3	2	3	1
+NULL	NULL	1	1
+NULL	NULL	4	1

--- a/test/sql/join/semianti/test_semianti_join_filter_pushdown.test
+++ b/test/sql/join/semianti/test_semianti_join_filter_pushdown.test
@@ -1,0 +1,80 @@
+# name: test/sql/join/semianti/test_semianti_join_filter_pushdown.test
+# description: Test SEMI and ANTI JOIN filter pushdown correctness
+# group: [semianti]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE left_table (id INTEGER, val INTEGER, amount INTEGER);
+
+statement ok
+INSERT INTO left_table VALUES (1, 1, 50), (2, 1, 75), (3, 2, 60), (4, 2, 90), (5, 3, 100);
+
+statement ok
+CREATE TABLE right_table (id INTEGER, category INTEGER, budget INTEGER);
+
+statement ok
+INSERT INTO right_table VALUES (1, 1, 1000), (2, 2, 2000), (3, 1, 1500);
+
+statement ok
+CREATE TABLE empty_table (id INTEGER, category INTEGER);
+
+query III rowsort
+SELECT * FROM left_table l
+SEMI JOIN right_table r ON l.id = r.id AND l.val > 1 AND r.category = 1;
+----
+3	2	60
+
+query III rowsort
+SELECT * FROM left_table l
+SEMI JOIN right_table r ON l.id = r.id AND r.category = 1;
+----
+1	1	50
+3	2	60
+
+query III rowsort
+SELECT * FROM left_table l
+SEMI JOIN right_table r ON l.id = r.id AND l.val > 1;
+----
+3	2	60
+
+query III rowsort
+SELECT * FROM left_table l
+SEMI JOIN empty_table e ON l.id = e.id;
+----
+
+query III rowsort
+SELECT * FROM left_table l
+ANTI JOIN right_table r ON l.id = r.id AND l.val > 1 AND r.category = 1;
+----
+1	1	50
+2	1	75
+4	2	90
+5	3	100
+
+query III rowsort
+SELECT * FROM left_table l
+ANTI JOIN right_table r ON l.id = r.id AND r.category = 1;
+----
+2	1	75
+4	2	90
+5	3	100
+
+query III rowsort
+SELECT * FROM left_table l
+ANTI JOIN right_table r ON l.id = r.id AND l.val = 1;
+----
+3	2	60
+4	2	90
+5	3	100
+
+query III rowsort
+SELECT * FROM left_table l
+ANTI JOIN empty_table e ON l.id = e.id;
+----
+1	1	50
+2	1	75
+3	2	60
+4	2	90
+5	3	100

--- a/test/sql/join/semianti/test_semianti_join_filter_pushdown.test
+++ b/test/sql/join/semianti/test_semianti_join_filter_pushdown.test
@@ -78,3 +78,18 @@ ANTI JOIN empty_table e ON l.id = e.id;
 3	2	60
 4	2	90
 5	3	100
+
+query III rowsort
+SELECT * FROM left_table l
+SEMI JOIN right_table r ON l.id = r.id AND l.amount + r.budget > 1100;
+----
+2	1	75
+3	2	60
+
+query III rowsort
+SELECT * FROM left_table l
+ANTI JOIN right_table r ON l.id = r.id AND l.amount + r.budget > 1100;
+----
+1	1	50
+4	2	90
+5	3	100

--- a/test/sql/join/test_join_always_true_conditions.test
+++ b/test/sql/join/test_join_always_true_conditions.test
@@ -1,0 +1,89 @@
+# name: test/sql/join/test_join_always_true_conditions.test
+# description: Test all join types with ON TRUE condition
+# group: [join]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE left_table (id INTEGER, val INTEGER);
+
+statement ok
+INSERT INTO left_table VALUES (1, 10), (2, 20);
+
+statement ok
+CREATE TABLE right_table (id INTEGER, category INTEGER);
+
+statement ok
+INSERT INTO right_table VALUES (1, 100), (2, 200);
+
+statement ok
+CREATE TABLE empty_table (id INTEGER, category INTEGER);
+
+# INNER JOIN with ON TRUE
+query IIII rowsort
+SELECT * FROM left_table l
+INNER JOIN right_table r ON TRUE;
+----
+1	10	1	100
+1	10	2	200
+2	20	1	100
+2	20	2	200
+
+# LEFT JOIN with ON TRUE
+query IIII rowsort
+SELECT * FROM left_table l
+LEFT JOIN right_table r ON TRUE;
+----
+1	10	1	100
+1	10	2	200
+2	20	1	100
+2	20	2	200
+
+# RIGHT JOIN with ON TRUE
+query IIII rowsort
+SELECT * FROM left_table l
+RIGHT JOIN right_table r ON TRUE;
+----
+1	10	1	100
+1	10	2	200
+2	20	1	100
+2	20	2	200
+
+# FULL OUTER JOIN with ON TRUE
+query IIII rowsort
+SELECT * FROM left_table l
+FULL OUTER JOIN right_table r ON TRUE;
+----
+1	10	1	100
+1	10	2	200
+2	20	1	100
+2	20	2	200
+
+# SEMI JOIN with ON TRUE (non-empty right table)
+query II rowsort
+SELECT * FROM left_table l
+SEMI JOIN right_table r ON TRUE;
+----
+1	10
+2	20
+
+# SEMI JOIN with ON TRUE (empty right table)
+query II rowsort
+SELECT * FROM left_table l
+SEMI JOIN empty_table e ON TRUE;
+----
+
+# ANTI JOIN with ON TRUE (non-empty right table)
+query II rowsort
+SELECT * FROM left_table l
+ANTI JOIN right_table r ON TRUE;
+----
+
+# ANTI JOIN with ON TRUE (empty right table)
+query II rowsort
+SELECT * FROM left_table l
+ANTI JOIN empty_table e ON TRUE;
+----
+1	10
+2	20


### PR DESCRIPTION
## Outline

This PR improves join filter pushdown for conditions in the ON clause in the binder. Previously, the binder categorized join conditions into two groups: join conditions and arbitrary conditions. When the join type was LEFT OUTER, it would push filters that referenced only the right-hand side (RHS), but all other join types missed this optimization opportunity.

## Changes

This PR categorizes join conditions into four categories based on what they reference:

- **Both tables** - References columns from both left and right sides
- **Right only** - References only right-side columns
- **Left only** - References only left-side columns
- **None** - Constants or expressions with no column references

For each category, the binder now makes smarter decisions:

- **NONE**: Check if the expression evaluates to TRUE and can be eliminated. If not, add it to `arbitrary conditions`
- **LEFT**: Check if it can be pushed to the left child. If not, add it to `arbitrary conditions`
- **RIGHT**: Check if it can be pushed to the right child. If not, add it to `arbitrary conditions`
- **BOTH**: Check if it's a comparison that can become a join condition. If not, add it to `arbitrary conditions`

## Correctness Proof

**INNER JOIN**: Both left-side and right-side filters can be pushed down safely. Any tuple that doesn't satisfy the filter won't appear in the result set anyway.

**LEFT OUTER JOIN**: Only right-side filters can be pushed down. Left-side filters would eliminate rows that should appear with NULL-extended right columns.

**RIGHT OUTER JOIN**: Only left-side filters can be pushed down (symmetric to LEFT OUTER).

**SEMI and ANTI JOINs**: These require more careful analysis. Consider a set called `RHS_MATCH_SET` containing all right-side tuples that satisfy the join condition for each left-side tuple.

- *Right-side filters (SEMI and ANTI)*: If a right-side row is filtered out, it won't be in `RHS_MATCH_SET`. This doesn't affect correctness for either SEMI or ANTI joins, so pushing right-side filters is safe.
- *Left-side filters on SEMI JOIN*: If a left tuple doesn't satisfy the filter, `RHS_MATCH_SET` would be empty anyway (the tuple wouldn't match). Early elimination is safe because SEMI only returns left rows with matches.
- *Left-side filters on ANTI JOIN*: If a left tuple doesn't satisfy the filter, `RHS_MATCH_SET` is empty, which means the tuple WOULD be returned by ANTI (no matches = return the row). Pushing the filter would eliminate rows that should be in the result, so it's NOT safe.

## Performance Impact

This optimization allows some joins to use HASH JOIN instead of nested loop join (NLJ), which significantly improves performance depending on relation sizes (10x to 10,000x speedup in some cases).

Using the benchmark from #19213, SEMI JOIN was **2200x slower** than INNER JOIN. After this fix, SEMI JOIN is actually slightly faster than INNER JOIN since it can now use HASH JOIN properly.

## Related Issue

Fixes #19213