### PR TITLE
No longer auto-enable profiling on DEBUG mode

### DIFF
--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -23,11 +23,6 @@ Connection::Connection(DatabaseInstance &database)
 	auto &connection_manager = ConnectionManager::Get(database);
 	connection_manager.AddConnection(*context);
 	connection_manager.AssignConnectionId(*this);
-
-#ifdef DEBUG
-	EnableProfiling();
-	context->config.emit_profiler_output = false;
-#endif
 }
 
 Connection::Connection(DuckDB &database) : Connection(*database.instance) {

--- a/test/sql/logging/http_log_timing.test
+++ b/test/sql/logging/http_log_timing.test
@@ -10,7 +10,11 @@ statement ok
 CALL enable_logging('HTTP')
 
 statement ok
-FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/title.principals.tsv'
+set http_retries=2
+
+statement error
+FROM "http://localhost:2338/test.csv"
+----
 
 # Confirm that our request timing returns something reasonable
 query  III
@@ -23,4 +27,6 @@ FROM
 WHERE 
 	request.type='HEAD'
 ----
+HEAD	true	true
+HEAD	true	true
 HEAD	true	true


### PR DESCRIPTION
This PR removes auto-enabling the profiler for debug builds.

Supercedes: https://github.com/duckdb/duckdb/pull/19856

Fixes: https://github.com/duckdblabs/duckdb-internal/issues/6460, https://github.com/duckdblabs/duckdb-internal/issues/6442, https://github.com/duckdblabs/duckdb-internal/issues/6623