### PR TITLE
CLI: Refactor shell rendering code, move everything to `ShellRenderer`, and perform various fixes

### DIFF
--- a/.github/patches/extensions/ducklake/getdatainternal.patch
+++ b/.github/patches/extensions/ducklake/getdatainternal.patch
@@ -1,3 +1,18 @@
+diff --git a/src/functions/ducklake_add_data_files.cpp b/src/functions/ducklake_add_data_files.cpp
+index 27f3051..5264af9 100644
+--- a/src/functions/ducklake_add_data_files.cpp
++++ b/src/functions/ducklake_add_data_files.cpp
+@@ -184,8 +184,8 @@ FROM parquet_full_metadata(%s)
+ 	}
+ 
+ 	for (auto &row : *result) {
+-		auto &chunk = *row.iterator.chunk;
+-		idx_t row_idx = row.row;
++		auto &chunk = row.GetChunk();
++		idx_t row_idx = row.GetRowInChunk();
+ 
+ 		auto &file_metadata_vec = chunk.data[0];
+ 		auto &parquet_metadata_vec = chunk.data[1];
 diff --git a/src/functions/ducklake_compaction_functions.cpp b/src/functions/ducklake_compaction_functions.cpp
 index 65793fd..dc56801 100644
 --- a/src/functions/ducklake_compaction_functions.cpp
@@ -137,6 +152,47 @@ index 51ffef0..e55ffd0 100644
                                                OperatorSourceInput &input) const {
  	return SourceResultType::FINISHED;
  }
+diff --git a/src/storage/ducklake_metadata_manager.cpp b/src/storage/ducklake_metadata_manager.cpp
+index 7ebb3ed..5fe0a8e 100644
+--- a/src/storage/ducklake_metadata_manager.cpp
++++ b/src/storage/ducklake_metadata_manager.cpp
+@@ -2158,9 +2158,7 @@ WHERE table_id=tid AND column_id=cid
+ 	}
+ }
+ 
+-template <class T>
+-static timestamp_tz_t GetTimestampTZFromRow(ClientContext &context, const T &row, idx_t col_idx) {
+-	auto val = row.iterator.chunk->GetValue(col_idx, row.row);
++static timestamp_tz_t GetTimestampTZFromRow(ClientContext &context, const Value &val) {
+ 	return val.CastAs(context, LogicalType::TIMESTAMP_TZ).template GetValue<timestamp_tz_t>();
+ }
+ 
+@@ -2183,12 +2181,12 @@ ORDER BY snapshot_id
+ 	for (auto &row : *res) {
+ 		DuckLakeSnapshotInfo snapshot_info;
+ 		snapshot_info.id = row.GetValue<idx_t>(0);
+-		snapshot_info.time = GetTimestampTZFromRow(*context, row, 1);
++		snapshot_info.time = GetTimestampTZFromRow(*context, row.GetBaseValue(1));
+ 		snapshot_info.schema_version = row.GetValue<idx_t>(2);
+ 		snapshot_info.change_info.changes_made = row.IsNull(3) ? string() : row.GetValue<string>(3);
+-		snapshot_info.author = row.iterator.chunk->GetValue(4, row.row);
+-		snapshot_info.commit_message = row.iterator.chunk->GetValue(5, row.row);
+-		snapshot_info.commit_extra_info = row.iterator.chunk->GetValue(6, row.row);
++		snapshot_info.author = row.GetBaseValue(4);
++		snapshot_info.commit_message = row.GetBaseValue(5);
++		snapshot_info.commit_extra_info = row.GetBaseValue(6);
+ 		snapshots.push_back(std::move(snapshot_info));
+ 	}
+ 	return snapshots;
+@@ -2212,7 +2210,7 @@ FROM {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion
+ 		path.path = row.GetValue<string>(1);
+ 		path.path_is_relative = row.GetValue<bool>(2);
+ 		info.path = FromRelativePath(path);
+-		info.time = GetTimestampTZFromRow(*context, row, 3);
++		info.time = GetTimestampTZFromRow(*context, row.GetBaseValue(3));
+ 		result.push_back(std::move(info));
+ 	}
+ 	return result;
 diff --git a/src/storage/ducklake_update.cpp b/src/storage/ducklake_update.cpp
 index f0bd68e..74d645f 100644
 --- a/src/storage/ducklake_update.cpp

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -9,7 +9,6 @@
 #include "duckdb/common/types/timestamp.hpp"
 
 #include <cstdint>
-
 #ifdef DUCKDB_DEBUG_ALLOCATION
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/pair.hpp"

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/box_renderer.hpp"
+#include "duckdb/main/client_context.hpp"
 
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
@@ -566,6 +567,9 @@ list<ColumnDataCollection> BoxRendererImplementation::FetchRenderCollections(con
 	idx_t chunk_idx = 0;
 	idx_t row_idx = 0;
 	while (row_idx < top_rows) {
+		if (context.IsInterrupted()) {
+			break;
+		}
 		fetch_result.Reset();
 		insert_result.Reset();
 		// fetch the next chunk
@@ -623,6 +627,9 @@ list<ColumnDataCollection> BoxRendererImplementation::FetchRenderCollections(con
 	row_idx = 0;
 	chunk_idx = result.ChunkCount() - 1;
 	while (row_idx < bottom_rows) {
+		if (context.IsInterrupted()) {
+			break;
+		}
 		fetch_result.Reset();
 		insert_result.Reset();
 		// fetch the next chunk
@@ -686,6 +693,9 @@ list<ColumnDataCollection> BoxRendererImplementation::PivotCollections(list<Colu
 		row_chunk.SetValue(current_index++, row_index, RenderType(result_types[c]));
 		for (auto &collection : input) {
 			for (auto &chunk : collection.Chunks(column_ids)) {
+				if (context.IsInterrupted()) {
+					break;
+				}
 				for (idx_t r = 0; r < chunk.size(); r++) {
 					row_chunk.SetValue(current_index++, row_index, chunk.GetValue(0, r));
 				}

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -1757,7 +1757,7 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 						}
 						rows_left--;
 					}
-					bool can_add_extra_row = rows_left > min_leftover_rows;
+					bool can_add_extra_row = current_row + 1 < extra_rows.size() || rows_left > min_leftover_rows;
 					auto &extra_row = extra_rows[current_row++];
 					idx_t start_pos = current_pos;
 					// stretch out the remainder on this row

--- a/src/common/types/column/column_data_collection_segment.cpp
+++ b/src/common/types/column/column_data_collection_segment.cpp
@@ -246,7 +246,7 @@ idx_t ColumnDataCollectionSegment::ReadVector(ChunkManagementState &state, Vecto
 			}
 		}
 		if (state.properties == ColumnDataScanProperties::DISALLOW_ZERO_COPY) {
-			VectorOperations::Copy(result, result, vdata.count, 0, 0);
+			VectorOperations::Copy(result, result, vcount, 0, 0);
 		}
 	}
 	return vcount;

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -97,6 +97,7 @@ public:
 
 	//! Interrupt execution of a query
 	DUCKDB_API void Interrupt();
+	DUCKDB_API bool IsInterrupted() const;
 	DUCKDB_API void CancelTransaction();
 
 	//! Enable query profiling

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -135,56 +135,54 @@ private:
 	class QueryResultIterator;
 	class QueryResultRow {
 	public:
-		explicit QueryResultRow(QueryResultIterator &iterator_p, idx_t row_idx) : iterator(iterator_p), row(0) {
+		explicit QueryResultRow() : row(0) {
 		}
 
-		QueryResultIterator &iterator;
+		shared_ptr<DataChunk> chunk;
 		idx_t row;
 
 		bool IsNull(idx_t col_idx) const {
-			return iterator.chunk->GetValue(col_idx, row).IsNull();
+			return chunk->GetValue(col_idx, row).IsNull();
 		}
 		template <class T>
 		T GetValue(idx_t col_idx) const {
-			return iterator.chunk->GetValue(col_idx, row).GetValue<T>();
+			return chunk->GetValue(col_idx, row).GetValue<T>();
 		}
 		Value GetBaseValue(idx_t col_idx) const {
-			return iterator.chunk->GetValue(col_idx, row);
+			return chunk->GetValue(col_idx, row);
 		}
 	};
 	//! The row-based query result iterator. Invoking the
 	class QueryResultIterator {
 	public:
-		explicit QueryResultIterator(optional_ptr<QueryResult> result_p)
-		    : current_row(*this, 0), result(result_p), base_row(0) {
+		explicit QueryResultIterator(optional_ptr<QueryResult> result_p = nullptr) : result(result_p), base_row(0) {
 			if (result) {
-				chunk = shared_ptr<DataChunk>(result->Fetch().release());
-				if (!chunk) {
+				current_row.chunk = shared_ptr<DataChunk>(result->Fetch().release());
+				if (!current_row.chunk) {
 					result = nullptr;
 				}
 			}
 		}
 
 		QueryResultRow current_row;
-		shared_ptr<DataChunk> chunk;
 		optional_ptr<QueryResult> result;
 		idx_t base_row;
 
 	public:
 		void Next() {
-			if (!chunk) {
+			if (!current_row.chunk) {
 				return;
 			}
 			current_row.row++;
-			if (current_row.row >= chunk->size()) {
-				base_row += chunk->size();
-				chunk = shared_ptr<DataChunk>(result->Fetch().release());
+			if (current_row.row >= current_row.chunk->size()) {
+				base_row += current_row.chunk->size();
+				current_row.chunk = shared_ptr<DataChunk>(result->Fetch().release());
 				current_row.row = 0;
-				if (!chunk || chunk->size() == 0) {
+				if (!current_row.chunk || current_row.chunk->size() == 0) {
 					// exhausted all rows
 					base_row = 0;
 					result = nullptr;
-					chunk.reset();
+					current_row.chunk.reset();
 				}
 			}
 		}
@@ -196,16 +194,21 @@ private:
 		bool operator!=(const QueryResultIterator &other) const {
 			return result != other.result || base_row != other.base_row || current_row.row != other.current_row.row;
 		}
+		bool operator==(const QueryResultIterator &other) const {
+			return !(*this != other);
+		}
 		const QueryResultRow &operator*() const {
 			return current_row;
 		}
 	};
 
 public:
-	QueryResultIterator begin() { // NOLINT: match stl API
+	using iterator = QueryResultIterator;
+
+	iterator begin() { // NOLINT: match stl API
 		return QueryResultIterator(this);
 	}
-	QueryResultIterator end() { // NOLINT: match stl API
+	iterator end() { // NOLINT: match stl API
 		return QueryResultIterator(nullptr);
 	}
 

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -134,12 +134,11 @@ protected:
 private:
 	class QueryResultIterator;
 	class QueryResultRow {
+		friend class QueryResultIterator;
+
 	public:
 		explicit QueryResultRow() : row(0) {
 		}
-
-		shared_ptr<DataChunk> chunk;
-		idx_t row;
 
 		bool IsNull(idx_t col_idx) const {
 			return chunk->GetValue(col_idx, row).IsNull();
@@ -151,6 +150,16 @@ private:
 		Value GetBaseValue(idx_t col_idx) const {
 			return chunk->GetValue(col_idx, row);
 		}
+		DataChunk &GetChunk() const {
+			return *chunk;
+		}
+		idx_t GetRowInChunk() const {
+			return row;
+		}
+
+	private:
+		shared_ptr<DataChunk> chunk;
+		idx_t row;
 	};
 	//! The row-based query result iterator. Invoking the
 	class QueryResultIterator {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1116,6 +1116,10 @@ void ClientContext::Interrupt() {
 	interrupted = true;
 }
 
+bool ClientContext::IsInterrupted() const {
+	return interrupted;
+}
+
 void ClientContext::CancelTransaction() {
 	auto lock = LockContext();
 	InitialCleanup(*lock);

--- a/test/api/test_results.cpp
+++ b/test/api/test_results.cpp
@@ -49,8 +49,8 @@ TEST_CASE("Test iterating over results", "[api]") {
 	idx_t row_count = 0;
 	auto result = con.Query("SELECT * FROM data;");
 	for (auto &row : *result) {
-		REQUIRE(row.GetValue<int>(0) == i_values[row.row]);
-		REQUIRE(row.GetValue<string>(1) == j_values[row.row]);
+		REQUIRE(row.GetValue<int>(0) == i_values[row_count]);
+		REQUIRE(row.GetValue<string>(1) == j_values[row_count]);
 		row_count++;
 	}
 	REQUIRE(row_count == 2);

--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -33,10 +33,12 @@ struct RowData {
 };
 
 struct RenderingQueryResult {
-	explicit RenderingQueryResult(duckdb::QueryResult &result) : result(result), metadata(result), is_converted(false) {
+	RenderingQueryResult(duckdb::QueryResult &result, ShellRenderer &renderer)
+	    : result(result), renderer(renderer), metadata(result), is_converted(false) {
 	}
 
 	duckdb::QueryResult &result;
+	ShellRenderer &renderer;
 	ResultMetadata metadata;
 	vector<vector<string>> data;
 	bool is_converted = false;

--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -13,20 +13,6 @@
 namespace duckdb_shell {
 struct ShellState;
 
-class ShellRenderer {
-public:
-	explicit ShellRenderer(ShellState &state);
-	virtual ~ShellRenderer() = default;
-
-	ShellState &state;
-	bool show_header;
-	string col_sep;
-	string row_sep;
-
-public:
-	static bool IsColumnar(RenderMode mode);
-};
-
 struct ResultMetadata {
 	explicit ResultMetadata(duckdb::QueryResult &result);
 
@@ -56,6 +42,22 @@ struct RowData {
 	idx_t row_index = 0;
 };
 
+class ShellRenderer {
+public:
+	explicit ShellRenderer(ShellState &state);
+	virtual ~ShellRenderer() = default;
+
+	ShellState &state;
+	bool show_header;
+	string col_sep;
+	string row_sep;
+
+public:
+	virtual void RenderHeader(ResultMetadata &result) = 0;
+	virtual void RenderRow(ResultMetadata &result, RowData &row) = 0;
+	virtual void RenderFooter(ResultMetadata &result);
+	static bool IsColumnar(RenderMode mode);
+};
 
 class ColumnRenderer : public ShellRenderer {
 public:
@@ -63,9 +65,7 @@ public:
 
 	void Analyze(ColumnarResult &result);
 	virtual string ConvertValue(const char *value);
-	virtual void RenderHeader(ResultMetadata &result) = 0;
-	virtual void RenderRow(RowData &row);
-	virtual void RenderFooter(ResultMetadata &result);
+	virtual void RenderRow(ResultMetadata &result, RowData &row) override;
 
 	virtual const char *GetColumnSeparator() = 0;
 	virtual const char *GetRowSeparator() = 0;
@@ -85,9 +85,7 @@ public:
 	explicit RowRenderer(ShellState &state);
 
 public:
-	virtual void RenderHeader(ResultMetadata &result);
-	virtual void RenderRow(ResultMetadata &result, RowData &row) = 0;
-	virtual void RenderFooter(ResultMetadata &result);
+	virtual void RenderHeader(ResultMetadata &result) override;
 	virtual string NullValue();
 };
 

--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -31,8 +31,6 @@ struct ColumnarResult {
 	idx_t column_count = 0;
 	vector<vector<string>> data;
 	vector<duckdb::LogicalType> types;
-	vector<idx_t> column_width;
-	vector<bool> right_align;
 	vector<string> type_names;
 };
 
@@ -51,8 +49,10 @@ class ColumnRenderer : public ShellRenderer {
 public:
 	explicit ColumnRenderer(ShellState &state);
 
+	void Analyze(ColumnarResult &result);
 	virtual string ConvertValue(const char *value);
 	virtual void RenderHeader(ColumnarResult &result) = 0;
+	virtual void RenderRow(RowData &row);
 	virtual void RenderFooter(ColumnarResult &result);
 
 	virtual const char *GetColumnSeparator() = 0;
@@ -62,6 +62,10 @@ public:
 	}
 
 	void RenderAlignedValue(ColumnarResult &result, idx_t c);
+
+protected:
+	vector<idx_t> column_width;
+	vector<bool> right_align;
 };
 
 class RowRenderer : public ShellRenderer {

--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -39,6 +39,7 @@ struct ColumnarResult {
 struct RowData {
 	vector<string> data;
 	vector<bool> is_null;
+	idx_t row_index = 0;
 };
 
 struct ResultMetadata {
@@ -67,15 +68,10 @@ class RowRenderer : public ShellRenderer {
 public:
 	explicit RowRenderer(ShellState &state);
 
-	bool first_row = true;
-
 public:
-	virtual void Render(ResultMetadata &result, RowData &row);
-
 	virtual void RenderHeader(ResultMetadata &result);
 	virtual void RenderRow(ResultMetadata &result, RowData &row) = 0;
 	virtual void RenderFooter(ResultMetadata &result);
-
 	virtual string NullValue();
 };
 

--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -36,11 +36,14 @@ struct ColumnarResult {
 	vector<string> type_names;
 };
 
-struct RowResult {
-	vector<string> column_names;
+struct RowData {
 	vector<string> data;
-	vector<duckdb::LogicalType> types;
 	vector<bool> is_null;
+};
+
+struct ResultMetadata {
+	vector<string> column_names;
+	vector<duckdb::LogicalType> types;
 };
 
 class ColumnRenderer : public ShellRenderer {
@@ -67,11 +70,11 @@ public:
 	bool first_row = true;
 
 public:
-	virtual void Render(RowResult &result);
+	virtual void Render(ResultMetadata &result, RowData &row);
 
-	virtual void RenderHeader(RowResult &result);
-	virtual void RenderRow(RowResult &result) = 0;
-	virtual void RenderFooter(RowResult &result);
+	virtual void RenderHeader(ResultMetadata &result);
+	virtual void RenderRow(ResultMetadata &result, RowData &row) = 0;
+	virtual void RenderFooter(ResultMetadata &result);
 
 	virtual string NullValue();
 };

--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -29,7 +29,7 @@ public:
 
 struct ColumnarResult {
 	idx_t column_count = 0;
-	vector<string> data;
+	vector<vector<string>> data;
 	vector<duckdb::LogicalType> types;
 	vector<idx_t> column_width;
 	vector<bool> right_align;
@@ -61,7 +61,7 @@ public:
 		return nullptr;
 	}
 
-	void RenderAlignedValue(ColumnarResult &result, idx_t i);
+	void RenderAlignedValue(ColumnarResult &result, idx_t c);
 };
 
 class RowRenderer : public ShellRenderer {

--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -65,8 +65,8 @@ public:
 public:
 	virtual SuccessState RenderQueryResult(ShellState &state, RenderingQueryResult &result);
 	virtual void Analyze(RenderingQueryResult &result);
-	virtual void RenderHeader(ResultMetadata &result) = 0;
-	virtual void RenderRow(ResultMetadata &result, RowData &row) = 0;
+	virtual void RenderHeader(ResultMetadata &result);
+	virtual void RenderRow(ResultMetadata &result, RowData &row);
 	virtual void RenderFooter(ResultMetadata &result);
 	static bool IsColumnar(RenderMode mode);
 	virtual string NullValue();
@@ -99,6 +99,13 @@ public:
 
 public:
 	virtual void RenderHeader(ResultMetadata &result) override;
+};
+
+class ModeDuckBoxRenderer : public ShellRenderer {
+public:
+	explicit ModeDuckBoxRenderer(ShellState &state);
+
+	SuccessState RenderQueryResult(ShellState &state, RenderingQueryResult &result) override;
 };
 
 } // namespace duckdb_shell

--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -63,6 +63,7 @@ public:
 	string row_sep;
 
 public:
+	virtual SuccessState RenderQueryResult(ShellState &state, RenderingQueryResult &result);
 	virtual void Analyze(RenderingQueryResult &result);
 	virtual void RenderHeader(ResultMetadata &result) = 0;
 	virtual void RenderRow(ResultMetadata &result, RowData &row) = 0;

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -310,7 +310,6 @@ public:
 	void Print(PrintOutput output, const string &str);
 	void Print(const char *str);
 	void Print(const string &str);
-	void PrintPadded(const char *str, idx_t len);
 	template <typename... ARGS>
 	void PrintF(PrintOutput stream, const string &str, ARGS... params) {
 		Print(stream, StringUtil::Format(str, params...));

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -335,8 +335,6 @@ public:
 	int RunInitialCommand(const char *sql, bool bail);
 	void AddError();
 
-	int RenderRow(RowRenderer &renderer, RowResult &result);
-
 	SuccessState ExecuteSQL(const string &zSql);
 	void RunSchemaDumpQuery(const string &zQuery);
 	void RunTableDumpQuery(const string &zSelect);

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -29,8 +29,7 @@ using duckdb::unique_ptr;
 using duckdb::vector;
 struct ColumnarResult;
 struct RowResult;
-class ColumnRenderer;
-class RowRenderer;
+class ShellRenderer;
 using duckdb::atomic;
 using duckdb::ErrorData;
 using duckdb::KeywordHelper;
@@ -319,11 +318,8 @@ public:
 		PrintF(PrintOutput::STDOUT, str, std::forward<ARGS>(params)...);
 	}
 	bool ColumnTypeIsInteger(const char *type);
-	void ConvertColumnarResult(ColumnRenderer &renderer, duckdb::QueryResult &res, ColumnarResult &result);
-	unique_ptr<ColumnRenderer> GetColumnRenderer();
-	unique_ptr<RowRenderer> GetRowRenderer();
-	unique_ptr<RowRenderer> GetRowRenderer(RenderMode mode);
-	void RenderColumnarResult(duckdb::QueryResult &res);
+	unique_ptr<ShellRenderer> GetRenderer();
+	unique_ptr<ShellRenderer> GetRenderer(RenderMode mode);
 	vector<string> TableColumnList(const char *zTab);
 	SuccessState ExecuteStatement(unique_ptr<duckdb::SQLStatement> statement);
 	SuccessState RenderDuckBoxResult(duckdb::QueryResult &res);
@@ -404,8 +400,8 @@ public:
 	ExecuteSQLSingleValueResult ExecuteSQLSingleValue(duckdb::Connection &con, const string &sql, string &result_value);
 	//! Execute a SQL query and renders the result using the given renderer.
 	//! On fail - prints the error and returns FAILURE
-	SuccessState RenderQuery(RowRenderer &renderer, const string &query);
-	SuccessState RenderQueryResult(RowRenderer &renderer, duckdb::QueryResult &result);
+	SuccessState RenderQuery(ShellRenderer &renderer, const string &query);
+	SuccessState RenderQueryResult(ShellRenderer &renderer, duckdb::QueryResult &result);
 	bool HighlightErrors() const;
 	bool HighlightResults() const;
 

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -322,7 +322,6 @@ public:
 	unique_ptr<ShellRenderer> GetRenderer(RenderMode mode);
 	vector<string> TableColumnList(const char *zTab);
 	SuccessState ExecuteStatement(unique_ptr<duckdb::SQLStatement> statement);
-	SuccessState RenderDuckBoxResult(duckdb::QueryResult &res);
 	SuccessState RenderDescribe(duckdb::QueryResult &res);
 	static bool UseDescribeRenderMode(const duckdb::SQLStatement &stmt, string &describe_table_name);
 	void RenderTableMetadata(vector<ShellTableInfo> &result);

--- a/tools/shell/linenoise/include/linenoise.hpp
+++ b/tools/shell/linenoise/include/linenoise.hpp
@@ -75,11 +75,6 @@ public:
 	int Edit();
 
 	static void SetCompletionCallback(linenoiseCompletionCallback *fn);
-	static void SetHintsCallback(linenoiseHintsCallback *fn);
-	static void SetFreeHintsCallback(linenoiseFreeHintsCallback *fn);
-
-	static linenoiseHintsCallback *HintsCallback();
-	static linenoiseFreeHintsCallback *FreeHintsCallback();
 
 	static void SetPrompt(const char *continuation, const char *continuationSelected);
 	static size_t ComputeRenderWidth(const char *buf, size_t len);
@@ -132,7 +127,6 @@ public:
 	void RefreshMultiLine();
 	void RefreshSingleLine() const;
 	void RefreshSearch();
-	void RefreshShowHints(AppendBuffer &append_buffer, int plen) const;
 
 	size_t PrevChar() const;
 	size_t NextChar() const;
@@ -141,6 +135,7 @@ public:
 	void PositionToColAndRow(size_t target_pos, int &out_row, int &out_col, int &rows, int &cols) const;
 	void PositionToColAndRow(int plen, const char *buf, idx_t len, size_t target_pos, int &out_row, int &out_col,
 	                         int &rows, int &cols) const;
+	size_t ColAndRowToPosition(int plen, const char *buf, idx_t len, int target_row, int target_col) const;
 	size_t ColAndRowToPosition(int target_row, int target_col) const;
 	static bool HandleANSIEscape(const char *buf, size_t len, size_t &cpos);
 

--- a/tools/shell/linenoise/linenoise-c.cpp
+++ b/tools/shell/linenoise/linenoise-c.cpp
@@ -100,18 +100,6 @@ void linenoiseSetCompletionCallback(linenoiseCompletionCallback *fn) {
 	Linenoise::SetCompletionCallback(fn);
 }
 
-/* Register a hits function to be called to show hits to the user at the
- * right of the prompt. */
-void linenoiseSetHintsCallback(linenoiseHintsCallback *fn) {
-	Linenoise::SetHintsCallback(fn);
-}
-
-/* Register a function to free the hints returned by the hints callback
- * registered with linenoiseSetHintsCallback(). */
-void linenoiseSetFreeHintsCallback(linenoiseFreeHintsCallback *fn) {
-	Linenoise::SetFreeHintsCallback(fn);
-}
-
 void linenoiseSetMultiLine(int ml) {
 	Terminal::SetMultiLine(ml);
 }

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -787,6 +787,9 @@ void Linenoise::RefreshMultiLine() {
 		max_rows_to_render--;
 	}
 	if (rows > max_rows_to_render) {
+		if (max_rows_to_render == ws.ws_row && rendered_completion_lines > 0) {
+			y_scroll--;
+		}
 		// the text does not fit in the terminal (too many rows)
 		// enable scrolling mode
 		// check if, given the current y_scroll, the cursor is visible
@@ -1050,8 +1053,8 @@ void Linenoise::RefreshMultiLine() {
 		                    completion_rows, completion_cols);
 		append_buffer.Append(completion_text.c_str(), completion_text.size());
 
-		rendered_completion_lines = completion_rows + 1;
-		rows += rendered_completion_lines;
+		rendered_completion_lines = completion_rows;
+		rows += static_cast<int>(rendered_completion_lines);
 		maxrows += rendered_completion_lines;
 	} else {
 		rendered_completion_lines = 0;

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -62,41 +62,6 @@ void Linenoise::SetPrompt(const char *continuation, const char *continuationSele
 	continuationSelectedPrompt = continuationSelected;
 }
 
-/* Helper of refreshSingleLine() and refreshMultiLine() to show hints
- * to the right of the prompt. */
-void Linenoise::RefreshShowHints(AppendBuffer &append_buffer, int plen) const {
-	char seq[64];
-	auto hints_callback = Linenoise::HintsCallback();
-	if (hints_callback && plen + len < size_t(ws.ws_col)) {
-		int color = -1, bold = 0;
-		char *hint = hints_callback(buf, &color, &bold);
-		if (hint) {
-			int hintlen = strlen(hint);
-			int hintmaxlen = ws.ws_col - (plen + len);
-			if (hintlen > hintmaxlen) {
-				hintlen = hintmaxlen;
-			}
-			if (bold == 1 && color == -1)
-				color = 37;
-			if (color != -1 || bold != 0) {
-				snprintf(seq, 64, "\033[%d;%d;49m", bold, color);
-			} else {
-				seq[0] = '\0';
-			}
-			append_buffer.Append(seq, strlen(seq));
-			append_buffer.Append(hint, hintlen);
-			if (color != -1 || bold != 0) {
-				append_buffer.Append("\033[0m");
-			}
-			/* Call the function to free the hint returned. */
-			auto free_hints_callback = Linenoise::FreeHintsCallback();
-			if (free_hints_callback) {
-				free_hints_callback(hint);
-			}
-		}
-	}
-}
-
 static void renderText(size_t &render_pos, char *&buf, size_t &len, size_t pos, size_t cols, size_t plen,
                        std::string &highlight_buffer, bool highlight) {
 	if (duckdb::Utf8Proc::IsValid(buf, len)) {
@@ -177,8 +142,6 @@ void Linenoise::RefreshSingleLine() const {
 	/* Write the prompt and the current buffer content */
 	append_buffer.Append(prompt);
 	append_buffer.Append(render_buf, render_len);
-	/* Show hits if any. */
-	RefreshShowHints(append_buffer, plen);
 	/* Erase to right */
 	append_buffer.Append("\x1b[0K");
 	/* Move cursor to original position. */
@@ -820,7 +783,7 @@ void Linenoise::RefreshMultiLine() {
 	}
 	idx_t max_rows_to_render = ws.ws_row;
 	if (render_completion_suggestion && !completion_list.completions.empty()) {
-		// if we are rendering completions keep one line clear for rendering them
+		// if we are rendering completions keep at least one line clear for rendering them
 		max_rows_to_render--;
 	}
 	if (rows > max_rows_to_render) {
@@ -847,8 +810,8 @@ void Linenoise::RefreshMultiLine() {
 		new_cursor_row -= y_scroll;
 		render_buf += render_start;
 		render_len = render_end - render_start;
-		Linenoise::Log("truncate to rows %d - %d (render bytes %d to %d)", y_scroll, y_scroll + max_rows_to_render, render_start,
-		               render_end);
+		Linenoise::Log("truncate to rows %d - %d (render bytes %d to %d)", y_scroll, y_scroll + max_rows_to_render,
+		               render_start, render_end);
 		rows = max_rows_to_render;
 	} else {
 		y_scroll = 0;
@@ -932,9 +895,6 @@ void Linenoise::RefreshMultiLine() {
 	}
 	append_buffer.Append(render_buf, render_len);
 
-	/* Show hints if any. */
-	RefreshShowHints(append_buffer, plen);
-
 	/* If we are at the very end of the screen with our prompt, we need to
 	 * emit a newline and move the prompt to the first column. */
 	Linenoise::Log("pos > 0 %d", pos > 0 ? 1 : 0);
@@ -951,6 +911,152 @@ void Linenoise::RefreshMultiLine() {
 			maxrows = rows;
 		}
 	}
+
+	if (render_completion_suggestion && !completion_list.completions.empty()) {
+		// if we are tab-completing - write the list of completions one line below
+		append_buffer.Append("\r\n");
+
+		// figure out how to align the completions
+		// we need to figure out how many "columns" we render
+		idx_t max_length = 0;
+		idx_t max_split_length = (ws.ws_col / 2) - 2;
+		for (auto &completion : completion_list.completions) {
+			auto &completion_text = completion.original_completion;
+			if (!completion.original_completion_length.IsValid()) {
+				completion.original_completion_length =
+				    linenoiseComputeRenderWidth(completion_text.c_str(), completion_text.size());
+			}
+			idx_t completion_length = completion.original_completion_length.GetIndex();
+			if (completion_length > max_split_length) {
+				// oversized value - we treat these differently / separately - ignore here
+			} else if (completion_length > max_length) {
+				max_length = completion_length;
+			}
+		}
+
+		// now based on the max width determine the column count
+		// we need at least one space between each entry
+		max_length++;
+		string completion_text;
+		idx_t column_count = ws.ws_col / max_length;
+		idx_t column_index = 0;
+		idx_t rendered_rows = 1;
+		for (idx_t i = 0; i < completion_list.completions.size(); i++) {
+			auto &completion = completion_list.completions[i];
+			auto &rendered_text = completion.original_completion;
+			auto element_type = duckdb_shell::HighlightElementType::NONE;
+			switch (completion.completion_type) {
+			case CompletionType::KEYWORD:
+			case CompletionType::TYPE_NAME:
+				element_type = duckdb_shell::HighlightElementType::KEYWORD;
+				break;
+			case CompletionType::CATALOG_NAME:
+				element_type = duckdb_shell::HighlightElementType::SUGGESTION_CATALOG_NAME;
+				break;
+			case CompletionType::SCHEMA_NAME:
+				element_type = duckdb_shell::HighlightElementType::SUGGESTION_SCHEMA_NAME;
+				break;
+			case CompletionType::TABLE_NAME:
+				element_type = duckdb_shell::HighlightElementType::SUGGESTION_TABLE_NAME;
+				break;
+			case CompletionType::COLUMN_NAME:
+				element_type = duckdb_shell::HighlightElementType::SUGGESTION_COLUMN_NAME;
+				break;
+			case CompletionType::FILE_NAME:
+				element_type = duckdb_shell::HighlightElementType::SUGGESTION_FILE_NAME;
+				break;
+			case CompletionType::DIRECTORY_NAME:
+				element_type = duckdb_shell::HighlightElementType::SUGGESTION_DIRECTORY_NAME;
+				break;
+			case CompletionType::SCALAR_FUNCTION:
+			case CompletionType::TABLE_FUNCTION:
+			case CompletionType::PRAGMA_FUNCTION:
+				element_type = duckdb_shell::HighlightElementType::SUGGESTION_FUNCTION_NAME;
+				break;
+			case CompletionType::SETTING_NAME:
+				element_type = duckdb_shell::HighlightElementType::SUGGESTION_SETTING_NAME;
+				break;
+			default:
+				break;
+			}
+			auto &element = duckdb_shell::ShellHighlight::GetHighlightElement(element_type);
+			auto color = element.color;
+			auto intensity = element.intensity;
+			if (completion_idx.IsValid() && i == completion_idx.GetIndex()) {
+				// underline selected completion
+				if (intensity == duckdb_shell::PrintIntensity::BOLD) {
+					intensity = duckdb_shell::PrintIntensity::BOLD_UNDERLINE;
+				} else {
+					intensity = duckdb_shell::PrintIntensity::UNDERLINE;
+				}
+			}
+			auto completion_length = completion.original_completion_length.GetIndex();
+			bool is_oversized_value = completion_length > max_split_length;
+			if (is_oversized_value) {
+				// oversized column - start a new line if this is not the beginning of a line
+				if (column_index > 0) {
+					// have to wrap around - add a newline
+					if (rendered_rows + 1 + rows > ws.ws_row) {
+						// too many rows - stop rendering completion results
+						break;
+					}
+					completion_text += "\r\n";
+					column_index = 0;
+					rendered_rows++;
+				}
+				// oversized values might need multiple lines - check if there is space
+				idx_t total_lines = completion_length / ws.ws_row;
+				if (rendered_rows + total_lines + rows > ws.ws_row) {
+					// no space - truncate to a single line
+					idx_t max_render_pos =
+					    ColAndRowToPosition(0, rendered_text.c_str(), rendered_text.size(), 0, ws.ws_col);
+					rendered_text = rendered_text.substr(0, max_render_pos);
+				} else {
+					// if there is space increment the total rendered rows
+					rendered_rows += total_lines;
+				}
+			}
+			auto terminal_text = duckdb_shell::ShellHighlight::TerminalCode(color, intensity);
+			completion_text += terminal_text;
+			completion_text += rendered_text;
+			if (!terminal_text.empty()) {
+				completion_text += duckdb_shell::ShellHighlight::ResetTerminalCode();
+			}
+			if (i + 1 == completion_list.completions.size()) {
+				continue;
+			}
+			// add spaces to pad so we get nicely aligned suggestions
+			// unless this is an oversized value
+			column_index++;
+			if (column_index >= column_count || is_oversized_value) {
+				// have to wrap around - add a newline
+				if (rendered_rows + 1 + rows > ws.ws_row) {
+					// too many rows - stop rendering completion results
+					break;
+				}
+				completion_text += "\r\n";
+				column_index = 0;
+				rendered_rows++;
+			} else {
+				idx_t space_count = max_length - completion_length;
+				completion_text += string(space_count, ' ');
+			}
+		}
+
+		// write the set of tab completions
+		int completion_rows, completion_cols;
+		int unused_row, unused_x;
+		PositionToColAndRow(0, completion_text.c_str(), completion_text.size(), 0, unused_row, unused_x,
+		                    completion_rows, completion_cols);
+		append_buffer.Append(completion_text.c_str(), completion_text.size());
+
+		rendered_completion_lines = completion_rows + 1;
+		rows += rendered_completion_lines;
+		maxrows += rendered_completion_lines;
+	} else {
+		rendered_completion_lines = 0;
+	}
+
 	Linenoise::Log("render %d rows (old rows %d)", rows, old_rows);
 
 	/* Move cursor to right position. */
@@ -960,153 +1066,6 @@ void Linenoise::RefreshMultiLine() {
 	Linenoise::Log("old_cursor_rows %d", old_cursor_rows);
 	Linenoise::Log("pos %d", pos);
 	Linenoise::Log("max cols %d", ws.ws_col);
-
-	if ((rendered_completion_lines > 0 && rows < ws.ws_row) || (render_completion_suggestion && !completion_list.completions.empty())) {
-		// if we are tab-completing - write the list of completions one line below
-		if (rendered_completion_lines == 0) {
-			// move to the next line if we haven't rendered completions yet
-			append_buffer.Append("\n");
-		} else {
-			// if we have already rendered then just jump down to the last line that contains the completions
-			Linenoise::Log("go down %d", int(rendered_completion_lines));
-			snprintf(seq, 64, "\x1b[%dB", int(rendered_completion_lines));
-			append_buffer.Append(seq);
-
-			/* Now for every row clear it, go up. */
-			for (idx_t j = 0; j < rendered_completion_lines - 1; j++) {
-				Linenoise::Log("clear+up");
-				append_buffer.Append("\r\x1b[0K\x1b[1A");
-			}
-		}
-
-		/* Clean the top line. */
-		Linenoise::Log("clear");
-		append_buffer.Append("\r\x1b[0K");
-
-		if (!completion_list.completions.empty()) {
-			// figure out how to align the completions
-			// we need to figure out how many "columns" we render
-			idx_t max_length = 0;
-			for (auto &completion : completion_list.completions) {
-				auto &completion_text = completion.original_completion;
-				if (!completion.original_completion_length.IsValid()) {
-					completion.original_completion_length =
-					    linenoiseComputeRenderWidth(completion_text.c_str(), completion_text.size());
-				}
-				idx_t completion_length = completion.original_completion_length.GetIndex();
-				if (completion_length > max_length) {
-					max_length = completion_length;
-				}
-			}
-
-			// now based on the max width determine the column count
-			// we need at least one space between each entry
-			max_length++;
-			string completion_text;
-			idx_t column_count = ws.ws_col / max_length;
-			idx_t column_index = 0;
-			idx_t rendered_rows = 1;
-			for (idx_t i = 0; i < completion_list.completions.size(); i++) {
-				auto &completion = completion_list.completions[i];
-				auto &rendered_text = completion.original_completion;
-				auto element_type = duckdb_shell::HighlightElementType::NONE;
-				switch (completion.completion_type) {
-				case CompletionType::KEYWORD:
-				case CompletionType::TYPE_NAME:
-					element_type = duckdb_shell::HighlightElementType::KEYWORD;
-					break;
-				case CompletionType::CATALOG_NAME:
-					element_type = duckdb_shell::HighlightElementType::SUGGESTION_CATALOG_NAME;
-					break;
-				case CompletionType::SCHEMA_NAME:
-					element_type = duckdb_shell::HighlightElementType::SUGGESTION_SCHEMA_NAME;
-					break;
-				case CompletionType::TABLE_NAME:
-					element_type = duckdb_shell::HighlightElementType::SUGGESTION_TABLE_NAME;
-					break;
-				case CompletionType::COLUMN_NAME:
-					element_type = duckdb_shell::HighlightElementType::SUGGESTION_COLUMN_NAME;
-					break;
-				case CompletionType::FILE_NAME:
-					element_type = duckdb_shell::HighlightElementType::SUGGESTION_FILE_NAME;
-					break;
-				case CompletionType::DIRECTORY_NAME:
-					element_type = duckdb_shell::HighlightElementType::SUGGESTION_DIRECTORY_NAME;
-					break;
-				case CompletionType::SCALAR_FUNCTION:
-				case CompletionType::TABLE_FUNCTION:
-				case CompletionType::PRAGMA_FUNCTION:
-					element_type = duckdb_shell::HighlightElementType::SUGGESTION_FUNCTION_NAME;
-					break;
-				case CompletionType::SETTING_NAME:
-					element_type = duckdb_shell::HighlightElementType::SUGGESTION_SETTING_NAME;
-					break;
-				default:
-					break;
-				}
-				auto &element = duckdb_shell::ShellHighlight::GetHighlightElement(element_type);
-				auto color = element.color;
-				auto intensity = element.intensity;
-				if (completion_idx.IsValid() && i == completion_idx.GetIndex()) {
-					// underline selected completion
-					if (intensity == duckdb_shell::PrintIntensity::BOLD) {
-						intensity = duckdb_shell::PrintIntensity::BOLD_UNDERLINE;
-					} else {
-						intensity = duckdb_shell::PrintIntensity::UNDERLINE;
-					}
-				}
-				auto terminal_text = duckdb_shell::ShellHighlight::TerminalCode(color, intensity);
-				completion_text += terminal_text;
-				completion_text += rendered_text;
-				if (!terminal_text.empty()) {
-					completion_text += duckdb_shell::ShellHighlight::ResetTerminalCode();
-				}
-				if (i + 1 == completion_list.completions.size()) {
-					continue;
-				}
-				if (column_count == 0) {
-					// if we cannot fit even a single column because our completion is too long
-					// just space separate the entries and don't try to align them
-					completion_text += " ";
-					continue;
-				}
-				// if we have columns - add spaces to pad so we get nicely aligned suggestions
-				column_index++;
-				if (column_index >= column_count) {
-					// have to wrap around - add a newline
-					if (rendered_rows + 1 + rows > ws.ws_row) {
-						// too many rows - stop rendering completion results
-						break;
-					}
-					completion_text += "\r\n";
-					column_index = 0;
-					rendered_rows++;
-				} else {
-					idx_t space_count = max_length - completion.original_completion_length.GetIndex();
-					completion_text += string(space_count, ' ');
-				}
-			}
-
-			// write the set of tab completions
-			int completion_rows, completion_cols;
-			int unused_row, unused_x;
-			PositionToColAndRow(0, completion_text.c_str(), completion_text.size(), 0, unused_row, unused_x,
-			                    completion_rows, completion_cols);
-			append_buffer.Append(completion_text.c_str(), completion_text.size());
-			rendered_completion_lines = completion_rows;
-
-			// jump back up the amount of rendered lines
-			snprintf(seq, 64, "\x1b[%dA", int(rendered_completion_lines));
-			append_buffer.Append(seq);
-		} else {
-			// we are just clearing the completion lines - reset to 0
-			rendered_completion_lines = 0;
-
-			// jump back up one last line
-			snprintf(seq, 64, "\x1b[1A");
-			append_buffer.Append(seq);
-		}
-	}
 
 	/* Go up till we reach the expected position. */
 	if (rows - new_cursor_row > 0) {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1291,6 +1291,9 @@ SuccessState ShellState::RenderQueryResult(RowRenderer &renderer, duckdb::QueryR
 	RowData row_data;
 	row_data.data.resize(nCol, string());
 	row_data.is_null.resize(nCol, false);
+	row_data.row_index = 0;
+
+	renderer.RenderHeader(result);
 	for (auto &row : query_result) {
 		if (seenInterrupt) {
 			PrintF("Interrupt\n");
@@ -1305,7 +1308,8 @@ SuccessState ShellState::RenderQueryResult(RowRenderer &renderer, duckdb::QueryR
 				row_data.data[c] = row.GetValue<string>(c);
 			}
 		}
-		renderer.Render(result, row_data);
+		renderer.RenderRow(result, row_data);
+		row_data.row_index++;
 	}
 	renderer.RenderFooter(result);
 	return SuccessState::SUCCESS;

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1352,9 +1352,12 @@ SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> state
 	if (cMode == RenderMode::DUCKBOX) {
 		return RenderDuckBoxResult(res);
 	}
-	// row rendering
+	// render the query result
 	auto renderer = GetRenderer();
-	return RenderQueryResult(*renderer, res);
+	RenderingQueryResult render_result(res, *renderer);
+
+	renderer->Analyze(render_result);
+	return renderer->RenderQueryResult(*this, render_result);
 }
 
 SuccessState ShellState::RenderDuckBoxResult(duckdb::QueryResult &res) {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1051,9 +1051,6 @@ static void interrupt_handler(int NotUsed) {
 	UNUSED_PARAMETER(NotUsed);
 	auto &state = ShellState::Get();
 	state.seenInterrupt++;
-	if (state.seenInterrupt > 2) {
-		exit(1);
-	}
 	if (state.conn) {
 		state.conn->Interrupt();
 	}

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1363,14 +1363,17 @@ SuccessState ShellState::RenderDuckBoxResult(duckdb::QueryResult &res) {
 		duckdb::BoxRendererConfig config;
 		config.max_rows = max_rows;
 		config.max_width = max_width;
-		if (!outfile.empty() && outfile[0] != '|') {
-			config.max_rows = (size_t)-1;
-			config.max_width = (size_t)-1;
+		if (config.max_width == 0) {
+			// if max_width is set to 0 (auto) - set it to infinite if we are writing to a file
+			if (!outfile.empty() && outfile[0] != '|') {
+				config.max_rows = (size_t)-1;
+				config.max_width = (size_t)-1;
+			}
+			if (!stdout_is_console) {
+				config.max_width = (size_t)-1;
+			}
 		}
 		LargeNumberRendering large_rendering = large_number_rendering;
-		if (!stdout_is_console) {
-			config.max_width = (size_t)-1;
-		}
 		if (large_rendering == LargeNumberRendering::DEFAULT) {
 			large_rendering = stdout_is_console ? LargeNumberRendering::FOOTER : LargeNumberRendering::NONE;
 		}

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -411,6 +411,10 @@ const string EVAL_SQL_NULL = "#NULL#";
 const string EVAL_SQL_EMPTY = "#EMPTY#";
 
 void ShellState::Print(PrintOutput output, const char *str) {
+	if (seenInterrupt) {
+		// no more printing after seeing an interrupt
+		return;
+	}
 	utf8_printf(output == PrintOutput::STDOUT ? out : stderr, "%s", str);
 }
 
@@ -1051,6 +1055,9 @@ static void interrupt_handler(int NotUsed) {
 	UNUSED_PARAMETER(NotUsed);
 	auto &state = ShellState::Get();
 	state.seenInterrupt++;
+	if (state.seenInterrupt >= 2) {
+		exit(1);
+	}
 	if (state.conn) {
 		state.conn->Interrupt();
 	}

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -427,10 +427,6 @@ void ShellState::Print(const string &str) {
 	Print(PrintOutput::STDOUT, str.c_str());
 }
 
-void ShellState::PrintPadded(const char *str, idx_t len) {
-	utf8_printf(out, "%*s", int(len), str);
-}
-
 /* Indicate out-of-memory and exit. */
 static void shell_out_of_memory(void) {
 	fprintf(stderr, "Error: out of memory\n");
@@ -1969,7 +1965,7 @@ bool ShellState::ShouldUsePager(duckdb::QueryResult &result) {
 		if (cMode == RenderMode::DUCKBOX) {
 			// in duckbox mode the output is automatically truncated to "max_rows"
 			// if "max_rows" is smaller than pager_min_rows in this mode, we never show the pager
-			if (max_rows < pager_min_rows) {
+			if (max_rows < pager_min_rows && max_width == 0) {
 				return false;
 			}
 		}

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3832,6 +3832,7 @@ int wmain(int argc, wchar_t **wargv) {
 		}
 	}
 	data.SetTableName(0);
+	data.last_result.reset();
 	data.db.reset();
 	data.conn.reset();
 	data.ResetOutput();

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1303,7 +1303,7 @@ void ShellState::RenderColumnarResult(duckdb::QueryResult &res) {
 		row_data.data = std::move(result.data[r]);
 		row_data.row_index = r;
 
-		column_renderer->RenderRow(row_data);
+		column_renderer->RenderRow(result.metadata, row_data);
 	}
 	column_renderer->RenderFooter(result.metadata);
 }

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1055,7 +1055,7 @@ static void interrupt_handler(int NotUsed) {
 	UNUSED_PARAMETER(NotUsed);
 	auto &state = ShellState::Get();
 	state.seenInterrupt++;
-	if (state.seenInterrupt >= 2) {
+	if (state.seenInterrupt > 2) {
 		exit(1);
 	}
 	if (state.conn) {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1541,7 +1541,6 @@ SuccessState ShellState::RenderDuckBoxResult(duckdb::QueryResult &res) {
 		}
 		config.decimal_separator = decimal_separator;
 		config.thousand_separator = thousand_separator;
-		config.max_width = max_width;
 		config.large_number_rendering = static_cast<duckdb::LargeNumberRendering>(static_cast<int>(large_rendering));
 		duckdb::BoxRenderer renderer(config);
 		auto &materialized = res.Cast<duckdb::MaterializedQueryResult>();

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -109,9 +109,6 @@ MetadataResult DumpTable(ShellState &state, const vector<string> &args) {
 		}
 	}
 
-	/* When playing back a "dump", the content might appear in an order
-	** which causes immediate foreign key constraints to be violated.
-	** So disable foreign-key constraint enforcement to prevent problems. */
 	state.PrintF("BEGIN TRANSACTION;\n");
 	state.showHeader = 0;
 	state.nErr = 0;

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -749,11 +749,13 @@ public:
 		if (!show_header) {
 			return;
 		}
+		state.SetBinaryMode();
 		auto &col_names = result.column_names;
 		for (idx_t i = 0; i < col_names.size(); i++) {
 			state.OutputCSV(col_names[i].c_str(), i < col_names.size() - 1);
 		}
 		state.Print(row_sep);
+		state.SetTextMode();
 	}
 
 	void RenderRow(ResultMetadata &result, RowData &row) override {

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1112,9 +1112,6 @@ public:
 	}
 
 	void PrintText(const string &text, HighlightElementType element_type) {
-		if (shell_highlight.state.seenInterrupt) {
-			return;
-		}
 		if (highlight) {
 			shell_highlight.PrintText(text, output, element_type);
 		} else {

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -309,18 +309,18 @@ unique_ptr<ColumnRenderer> ShellState::GetColumnRenderer() {
 RowRenderer::RowRenderer(ShellState &state) : ShellRenderer(state) {
 }
 
-void RowRenderer::Render(RowResult &result) {
+void RowRenderer::Render(ResultMetadata &result, RowData &row) {
 	if (first_row) {
 		RenderHeader(result);
 		first_row = false;
 	}
-	RenderRow(result);
+	RenderRow(result, row);
 }
 
-void RowRenderer::RenderHeader(RowResult &result) {
+void RowRenderer::RenderHeader(ResultMetadata &result) {
 }
 
-void RowRenderer::RenderFooter(RowResult &result) {
+void RowRenderer::RenderFooter(ResultMetadata &result) {
 }
 
 string RowRenderer::NullValue() {
@@ -332,7 +332,7 @@ public:
 	explicit ModeLineRenderer(ShellState &state) : RowRenderer(state) {
 	}
 
-	void Render(RowResult &result) override {
+	void Render(ResultMetadata &result, RowData &row) override {
 		if (first_row) {
 			auto &col_names = result.column_names;
 			// determine the render width by going over the column names
@@ -348,11 +348,11 @@ public:
 			state.Print(state.rowSeparator);
 		}
 		// render the row
-		RenderRow(result);
+		RenderRow(result, row);
 	}
 
-	void RenderRow(RowResult &result) override {
-		auto &data = result.data;
+	void RenderRow(ResultMetadata &result, RowData &row) override {
+		auto &data = row.data;
 		auto &col_names = result.column_names;
 		for (idx_t i = 0; i < data.size(); i++) {
 			idx_t space_count = header_width - col_names[i].size();
@@ -374,8 +374,8 @@ public:
 	explicit ModeExplainRenderer(ShellState &state) : RowRenderer(state) {
 	}
 
-	void RenderRow(RowResult &result) override {
-		auto &data = result.data;
+	void RenderRow(ResultMetadata &result, RowData &row) override {
+		auto &data = row.data;
 		if (data.size() != 2) {
 			return;
 		}
@@ -402,7 +402,7 @@ public:
 	explicit ModeListRenderer(ShellState &state) : RowRenderer(state) {
 	}
 
-	void RenderHeader(RowResult &result) override {
+	void RenderHeader(ResultMetadata &result) override {
 		if (!show_header) {
 			return;
 		}
@@ -416,8 +416,8 @@ public:
 		state.Print(row_sep);
 	}
 
-	void RenderRow(RowResult &result) override {
-		auto &data = result.data;
+	void RenderRow(ResultMetadata &result, RowData &row) override {
+		auto &data = row.data;
 		for (idx_t i = 0; i < data.size(); i++) {
 			if (i > 0) {
 				state.Print(col_sep);
@@ -433,7 +433,7 @@ public:
 	explicit ModeHtmlRenderer(ShellState &state) : RowRenderer(state) {
 	}
 
-	void RenderHeader(RowResult &result) override {
+	void RenderHeader(ResultMetadata &result) override {
 		if (!show_header) {
 			return;
 		}
@@ -447,8 +447,8 @@ public:
 		state.Print("</tr>\n");
 	}
 
-	void RenderRow(RowResult &result) override {
-		auto &data = result.data;
+	void RenderRow(ResultMetadata &result, RowData &row) override {
+		auto &data = row.data;
 		state.Print("<tr>");
 		for (idx_t i = 0; i < data.size(); i++) {
 			state.Print("<td>");
@@ -494,7 +494,7 @@ public:
 	explicit ModeTclRenderer(ShellState &state) : RowRenderer(state) {
 	}
 
-	void RenderHeader(RowResult &result) override {
+	void RenderHeader(ResultMetadata &result) override {
 		if (!show_header) {
 			return;
 		}
@@ -508,8 +508,8 @@ public:
 		state.Print(row_sep);
 	}
 
-	void RenderRow(RowResult &result) override {
-		auto &data = result.data;
+	void RenderRow(ResultMetadata &result, RowData &row) override {
+		auto &data = row.data;
 		for (idx_t i = 0; i < data.size(); i++) {
 			if (i > 0) {
 				state.Print(col_sep);
@@ -525,12 +525,12 @@ public:
 	explicit ModeCsvRenderer(ShellState &state) : RowRenderer(state) {
 	}
 
-	void Render(RowResult &result) override {
+	void Render(ResultMetadata &result, RowData &row) override {
 		state.SetBinaryMode();
-		RowRenderer::Render(result);
+		RowRenderer::Render(result, row);
 		state.SetTextMode();
 	}
-	void RenderHeader(RowResult &result) override {
+	void RenderHeader(ResultMetadata &result) override {
 		if (!show_header) {
 			return;
 		}
@@ -541,8 +541,8 @@ public:
 		state.Print(row_sep);
 	}
 
-	void RenderRow(RowResult &result) override {
-		auto &data = result.data;
+	void RenderRow(ResultMetadata &result, RowData &row) override {
+		auto &data = row.data;
 		for (idx_t i = 0; i < data.size(); i++) {
 			state.OutputCSV(data[i].c_str(), i < data.size() - 1);
 		}
@@ -557,7 +557,7 @@ public:
 		row_sep = "\n";
 	}
 
-	void RenderHeader(RowResult &result) override {
+	void RenderHeader(ResultMetadata &result) override {
 		if (!show_header) {
 			return;
 		}
@@ -571,8 +571,8 @@ public:
 		state.Print(row_sep);
 	}
 
-	void RenderRow(RowResult &result) override {
-		auto &data = result.data;
+	void RenderRow(ResultMetadata &result, RowData &row) override {
+		auto &data = row.data;
 		for (idx_t i = 0; i < data.size(); i++) {
 			if (i > 0) {
 				state.Print(col_sep);
@@ -588,7 +588,7 @@ public:
 	explicit ModeQuoteRenderer(ShellState &state) : RowRenderer(state) {
 	}
 
-	void RenderHeader(RowResult &result) override {
+	void RenderHeader(ResultMetadata &result) override {
 		if (!show_header) {
 			return;
 		}
@@ -602,10 +602,10 @@ public:
 		state.Print(row_sep);
 	}
 
-	void RenderRow(RowResult &result) override {
-		auto &data = result.data;
+	void RenderRow(ResultMetadata &result, RowData &row) override {
+		auto &data = row.data;
 		auto &types = result.types;
-		auto &is_null = result.is_null;
+		auto &is_null = row.is_null;
 		for (idx_t i = 0; i < data.size(); i++) {
 			if (i > 0) {
 				state.Print(col_sep);
@@ -629,7 +629,7 @@ public:
 	explicit ModeJsonRenderer(ShellState &state, bool json_array) : RowRenderer(state), json_array(json_array) {
 	}
 
-	void Render(RowResult &result) override {
+	void Render(ResultMetadata &result, RowData &row) override {
 		if (first_row) {
 			if (json_array) {
 				// wrap all JSON objects in an array
@@ -644,14 +644,14 @@ public:
 			}
 			state.Print("\n{");
 		}
-		RenderRow(result);
+		RenderRow(result, row);
 	}
 
-	void RenderRow(RowResult &result) override {
-		auto &data = result.data;
+	void RenderRow(ResultMetadata &result, RowData &row) override {
+		auto &data = row.data;
 		auto &types = result.types;
 		auto &col_names = result.column_names;
-		auto &is_null = result.is_null;
+		auto &is_null = row.is_null;
 		for (idx_t i = 0; i < col_names.size(); i++) {
 			if (i > 0) {
 				state.Print(",");
@@ -682,7 +682,7 @@ public:
 		state.Print("}");
 	}
 
-	void RenderFooter(RowResult &result) override {
+	void RenderFooter(ResultMetadata &result) override {
 		if (json_array) {
 			state.Print("]\n");
 		} else {
@@ -702,11 +702,11 @@ public:
 	explicit ModeInsertRenderer(ShellState &state) : RowRenderer(state) {
 	}
 
-	void RenderRow(RowResult &result) override {
-		auto &data = result.data;
+	void RenderRow(ResultMetadata &result, RowData &row) override {
+		auto &data = row.data;
 		auto &types = result.types;
 		auto &col_names = result.column_names;
-		auto &is_null = result.is_null;
+		auto &is_null = row.is_null;
 
 		state.Print("INSERT INTO ");
 		state.Print(state.zDestTable);
@@ -741,9 +741,9 @@ public:
 	explicit ModeSemiRenderer(ShellState &state) : RowRenderer(state) {
 	}
 
-	void RenderRow(RowResult &result) override {
+	void RenderRow(ResultMetadata &result, RowData &row) override {
 		/* .schema and .fullschema output */
-		state.PrintSchemaLine(result.data[0].c_str(), "\n");
+		state.PrintSchemaLine(row.data[0].c_str(), "\n");
 	}
 };
 
@@ -756,8 +756,8 @@ public:
 		return duckdb::StringUtil::CharacterIsSpace(c);
 	}
 
-	void RenderRow(RowResult &result) override {
-		auto &data = result.data;
+	void RenderRow(ResultMetadata &result, RowData &row) override {
+		auto &data = row.data;
 		/* .schema and .fullschema with --indent */
 		if (data.size() != 1) {
 			throw std::runtime_error("row must have exactly one value for pretty rendering");

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -73,6 +73,7 @@ public:
 			for (idx_t c = 0; c < nCol; c++) {
 				if (row.IsNull(c)) {
 					row_data.is_null[c] = true;
+					row_data.data[c] = result->renderer.NullValue();
 				} else {
 					row_data.is_null[c] = false;
 					row_data.data[c] = row.GetValue<string>(c);
@@ -123,7 +124,7 @@ RenderingResultIterator RenderingQueryResult::end() {
 }
 
 SuccessState ShellState::RenderQueryResult(ShellRenderer &renderer, duckdb::QueryResult &query_result) {
-	RenderingQueryResult result(query_result);
+	RenderingQueryResult result(query_result, renderer);
 
 	renderer.Analyze(result);
 

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -23,6 +23,9 @@ ShellRenderer::ShellRenderer(ShellState &state)
     : state(state), show_header(state.showHeader), col_sep(state.colSeparator), row_sep(state.rowSeparator) {
 }
 
+void ShellRenderer::RenderFooter(ResultMetadata &result) {
+}
+
 //===--------------------------------------------------------------------===//
 // Result Metadata
 //===--------------------------------------------------------------------===//
@@ -90,9 +93,6 @@ string ColumnRenderer::ConvertValue(const char *value) {
 	return value ? value : state.nullValue;
 }
 
-void ColumnRenderer::RenderFooter(ResultMetadata &result) {
-}
-
 void ColumnRenderer::RenderAlignedValue(ResultMetadata &result, idx_t c) {
 	auto &header_value = result.column_names[c];
 	idx_t w = column_width[c];
@@ -132,7 +132,7 @@ void ColumnRenderer::Analyze(ColumnarResult &result) {
 	}
 }
 
-void ColumnRenderer::RenderRow(RowData &row) {
+void ColumnRenderer::RenderRow(ResultMetadata &result, RowData &row) {
 	auto &state = ShellState::Get();
 	auto colSep = GetColumnSeparator();
 	auto rowSep = GetRowSeparator();
@@ -423,9 +423,6 @@ RowRenderer::RowRenderer(ShellState &state) : ShellRenderer(state) {
 }
 
 void RowRenderer::RenderHeader(ResultMetadata &result) {
-}
-
-void RowRenderer::RenderFooter(ResultMetadata &result) {
 }
 
 string RowRenderer::NullValue() {

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -108,7 +108,6 @@ public:
 	}
 	bool operator!=(const RenderingResultIterator &other) const {
 		return result != other.result;
-		;
 	}
 	RowData &operator*() {
 		return row_data;
@@ -127,16 +126,19 @@ SuccessState ShellState::RenderQueryResult(ShellRenderer &renderer, duckdb::Quer
 	RenderingQueryResult result(query_result, renderer);
 
 	renderer.Analyze(result);
+	return renderer.RenderQueryResult(*this, result);
+}
 
-	renderer.RenderHeader(result.metadata);
+SuccessState ShellRenderer::RenderQueryResult(ShellState &state, RenderingQueryResult &result) {
+	RenderHeader(result.metadata);
 	for (auto &row_data : result) {
-		if (seenInterrupt) {
-			PrintF("Interrupt\n");
+		if (state.seenInterrupt) {
+			state.PrintF("Interrupt\n");
 			return SuccessState::FAILURE;
 		}
-		renderer.RenderRow(result.metadata, row_data);
+		RenderRow(result.metadata, row_data);
 	}
-	renderer.RenderFooter(result.metadata);
+	RenderFooter(result.metadata);
 	return SuccessState::SUCCESS;
 }
 

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -39,9 +39,11 @@ void ColumnRenderer::RenderFooter(ColumnarResult &result) {
 void ColumnRenderer::RenderAlignedValue(ColumnarResult &result, idx_t i) {
 	idx_t w = result.column_width[i];
 	idx_t n = state.RenderLength(result.data[i]);
-	state.PrintPadded("", (w - n) / 2);
+	idx_t lspace = (w - n) / 2;
+	idx_t rspace = (w - n + 1) / 2;
+	state.Print(string(lspace, ' '));
 	state.Print(result.data[i]);
-	state.PrintPadded("", (w - n + 1) / 2);
+	state.Print(string(rspace, ' '));
 }
 
 class ModeColumnRenderer : public ColumnRenderer {
@@ -353,9 +355,13 @@ public:
 		auto &data = result.data;
 		auto &col_names = result.column_names;
 		for (idx_t i = 0; i < data.size(); i++) {
-			state.PrintPadded(col_names[i].c_str(), header_width);
+			idx_t space_count = header_width - col_names[i].size();
+			if (space_count > 0) {
+				state.Print(string(space_count, ' '));
+			}
+			state.Print(col_names[i]);
 			state.Print(" = ");
-			state.Print(data[i].c_str());
+			state.Print(data[i]);
 			state.Print(state.rowSeparator);
 		}
 	}

--- a/tools/shell/tests/test_large_value_rendering.py
+++ b/tools/shell/tests/test_large_value_rendering.py
@@ -78,6 +78,7 @@ big_json = '''
 def test_long_string(shell):
     test = (
         ShellTest(shell)
+        .statement('.maxwidth 160')
         .statement(f"SELECT '{long_string}' s")
     )
     result = test.run()
@@ -87,6 +88,7 @@ def test_long_string(shell):
 def test_extremely_long_string(shell):
     test = (
         ShellTest(shell)
+        .statement('.maxwidth 160')
         .statement(f"SELECT repeat('abcdefghijklmnopqrstuvwxyz', 10000)")
     )
     result = test.run()
@@ -97,6 +99,7 @@ def test_extremely_long_string(shell):
 def test_multiple_long_strings(shell):
     test = (
         ShellTest(shell)
+        .statement('.maxwidth 160')
         .statement(f"SELECT '{long_string}' s1, '{long_string}' s2, '{long_string}' s3")
     )
     result = test.run()
@@ -106,6 +109,7 @@ def test_multiple_long_strings(shell):
 def test_multiple_long_strings_many_rows(shell):
     test = (
         ShellTest(shell)
+        .statement('.maxwidth 160')
         .statement(f"SELECT '{long_string}' s1, '{long_string}' s2, '{long_string}' s3 FROM range(100)")
     )
     result = test.run()
@@ -115,6 +119,7 @@ def test_multiple_long_strings_many_rows(shell):
     # UNLESS we increase the max rows printed
     test = (
         ShellTest(shell)
+        .statement('.maxwidth 160')
         .statement('.maxrows -1')
         .statement(f"SELECT '{long_string}' s1, '{long_string}' s2, '{long_string}' s3 FROM range(100)")
     )

--- a/tools/shell/tests/test_rendering_mode_regression.py
+++ b/tools/shell/tests/test_rendering_mode_regression.py
@@ -759,4 +759,3 @@ expected_results['tcl'] = '''"l_orderkey" "l_partkey" "l_suppkey" "l_linenumber"
 
 def get_expected_output(mode):
     return expected_results[mode]
-

--- a/tools/shell/tests/test_rendering_mode_regression.py
+++ b/tools/shell/tests/test_rendering_mode_regression.py
@@ -1,0 +1,762 @@
+# fmt: off
+
+import pytest
+from conftest import ShellTest
+
+@pytest.mark.parametrize("mode", ['ascii', 'box', 'column', 'csv', 'duckbox', 'html', 'insert', 'json', 'jsonlines', 'latex', 'line', 'list', 'markdown', 'quote', 'table', 'tabs', 'tcl'])
+def test_mode_regression(shell, mode):
+    test = (
+        ShellTest(shell)
+        .statement(f".mode {mode}")
+        .statement("FROM 'data/parquet-testing/lineitem-top10000.gzip.parquet' LIMIT 10")
+    )
+
+    result = test.run()
+    lines = [x.strip() for x in get_expected_output(mode).split('\n')]
+    for line in lines:
+        if len(line) == 0:
+            continue
+        result.check_stdout(line)
+
+
+expected_results = {}
+
+expected_results['ascii'] = '''l_orderkey
+l_partkey
+l_suppkey
+l_linenumber
+l_quantity
+l_extendedprice
+l_discount
+l_tax
+l_returnflag
+l_linestatus
+l_shipdate
+l_commitdate
+l_receiptdate
+l_shipinstruct
+l_shipmode
+l_comment
+1
+155190
+7706
+1
+17
+21168.23
+0.04
+0.02
+N
+O
+1996-03-13
+1996-02-12
+1996-03-22
+DELIVER IN PERSON
+TRUCK
+egular courts above the
+1
+67310
+7311
+2
+36
+45983.16
+0.09
+0.06
+N
+O
+1996-04-12
+1996-02-28
+1996-04-20
+TAKE BACK RETURN
+MAIL
+ly final dependencies: slyly bold 
+1
+63700
+3701
+3
+8
+13309.6
+0.1
+0.02
+N
+O
+1996-01-29
+1996-03-05
+1996-01-31
+TAKE BACK RETURN
+REG AIR
+riously. regular, express dep
+1
+2132
+4633
+4
+28
+28955.64
+0.09
+0.06
+N
+O
+1996-04-21
+1996-03-30
+1996-05-16
+NONE
+AIR
+lites. fluffily even de
+1
+24027
+1534
+5
+24
+22824.48
+0.1
+0.04
+N
+O
+1996-03-30
+1996-03-14
+1996-04-01
+NONE
+FOB
+ pending foxes. slyly re
+1
+15635
+638
+6
+32
+49620.16
+0.07
+0.02
+N
+O
+1996-01-30
+1996-02-07
+1996-02-03
+DELIVER IN PERSON
+MAIL
+arefully slyly ex
+2
+106170
+1191
+1
+38
+44694.46
+0.0
+0.05
+N
+O
+1997-01-28
+1997-01-14
+1997-02-02
+TAKE BACK RETURN
+RAIL
+ven requests. deposits breach a
+3
+4297
+1798
+1
+45
+54058.05
+0.06
+0.0
+R
+F
+1994-02-02
+1994-01-04
+1994-02-23
+NONE
+AIR
+ongside of the furiously brave acco
+3
+19036
+6540
+2
+49
+46796.47
+0.1
+0.0
+R
+F
+1993-11-09
+1993-12-20
+1993-11-24
+TAKE BACK RETURN
+RAIL
+ unusual accounts. eve
+3
+128449
+3474
+3
+27
+39890.88
+0.06
+0.07
+A
+F
+1994-01-16
+1993-11-22
+1994-01-23
+DELIVER IN PERSON
+SHIP
+nal foxes wake. 
+'''
+
+expected_results['box'] = '''┌────────────┬───────────┬───────────┬──────────────┬────────────┬─────────────────┬────────────┬───────┬──────────────┬──────────────┬────────────┬──────────────┬───────────────┬───────────────────┬────────────┬─────────────────────────────────────┐
+│ l_orderkey │ l_partkey │ l_suppkey │ l_linenumber │ l_quantity │ l_extendedprice │ l_discount │ l_tax │ l_returnflag │ l_linestatus │ l_shipdate │ l_commitdate │ l_receiptdate │  l_shipinstruct   │ l_shipmode │              l_comment              │
+├────────────┼───────────┼───────────┼──────────────┼────────────┼─────────────────┼────────────┼───────┼──────────────┼──────────────┼────────────┼──────────────┼───────────────┼───────────────────┼────────────┼─────────────────────────────────────┤
+│ 1          │ 155190    │ 7706      │ 1            │ 17         │ 21168.23        │ 0.04       │ 0.02  │ N            │ O            │ 1996-03-13 │ 1996-02-12   │ 1996-03-22    │ DELIVER IN PERSON │ TRUCK      │ egular courts above the             │
+│ 1          │ 67310     │ 7311      │ 2            │ 36         │ 45983.16        │ 0.09       │ 0.06  │ N            │ O            │ 1996-04-12 │ 1996-02-28   │ 1996-04-20    │ TAKE BACK RETURN  │ MAIL       │ ly final dependencies: slyly bold   │
+│ 1          │ 63700     │ 3701      │ 3            │ 8          │ 13309.6         │ 0.1        │ 0.02  │ N            │ O            │ 1996-01-29 │ 1996-03-05   │ 1996-01-31    │ TAKE BACK RETURN  │ REG AIR    │ riously. regular, express dep       │
+│ 1          │ 2132      │ 4633      │ 4            │ 28         │ 28955.64        │ 0.09       │ 0.06  │ N            │ O            │ 1996-04-21 │ 1996-03-30   │ 1996-05-16    │ NONE              │ AIR        │ lites. fluffily even de             │
+│ 1          │ 24027     │ 1534      │ 5            │ 24         │ 22824.48        │ 0.1        │ 0.04  │ N            │ O            │ 1996-03-30 │ 1996-03-14   │ 1996-04-01    │ NONE              │ FOB        │  pending foxes. slyly re            │
+│ 1          │ 15635     │ 638       │ 6            │ 32         │ 49620.16        │ 0.07       │ 0.02  │ N            │ O            │ 1996-01-30 │ 1996-02-07   │ 1996-02-03    │ DELIVER IN PERSON │ MAIL       │ arefully slyly ex                   │
+│ 2          │ 106170    │ 1191      │ 1            │ 38         │ 44694.46        │ 0.0        │ 0.05  │ N            │ O            │ 1997-01-28 │ 1997-01-14   │ 1997-02-02    │ TAKE BACK RETURN  │ RAIL       │ ven requests. deposits breach a     │
+│ 3          │ 4297      │ 1798      │ 1            │ 45         │ 54058.05        │ 0.06       │ 0.0   │ R            │ F            │ 1994-02-02 │ 1994-01-04   │ 1994-02-23    │ NONE              │ AIR        │ ongside of the furiously brave acco │
+│ 3          │ 19036     │ 6540      │ 2            │ 49         │ 46796.47        │ 0.1        │ 0.0   │ R            │ F            │ 1993-11-09 │ 1993-12-20   │ 1993-11-24    │ TAKE BACK RETURN  │ RAIL       │  unusual accounts. eve              │
+│ 3          │ 128449    │ 3474      │ 3            │ 27         │ 39890.88        │ 0.06       │ 0.07  │ A            │ F            │ 1994-01-16 │ 1993-11-22   │ 1994-01-23    │ DELIVER IN PERSON │ SHIP       │ nal foxes wake.                     │
+└────────────┴───────────┴───────────┴──────────────┴────────────┴─────────────────┴────────────┴───────┴──────────────┴──────────────┴────────────┴──────────────┴───────────────┴───────────────────┴────────────┴─────────────────────────────────────┘
+'''
+
+expected_results['column'] = '''l_orderkey  l_partkey  l_suppkey  l_linenumber  l_quantity  l_extendedprice  l_discount  l_tax  l_returnflag  l_linestatus  l_shipdate  l_commitdate  l_receiptdate  l_shipinstruct     l_shipmode  l_comment                          
+----------  ---------  ---------  ------------  ----------  ---------------  ----------  -----  ------------  ------------  ----------  ------------  -------------  -----------------  ----------  -----------------------------------
+1           155190     7706       1             17          21168.23         0.04        0.02   N             O             1996-03-13  1996-02-12    1996-03-22     DELIVER IN PERSON  TRUCK       egular courts above the            
+1           67310      7311       2             36          45983.16         0.09        0.06   N             O             1996-04-12  1996-02-28    1996-04-20     TAKE BACK RETURN   MAIL        ly final dependencies: slyly bold  
+1           63700      3701       3             8           13309.6          0.1         0.02   N             O             1996-01-29  1996-03-05    1996-01-31     TAKE BACK RETURN   REG AIR     riously. regular, express dep      
+1           2132       4633       4             28          28955.64         0.09        0.06   N             O             1996-04-21  1996-03-30    1996-05-16     NONE               AIR         lites. fluffily even de            
+1           24027      1534       5             24          22824.48         0.1         0.04   N             O             1996-03-30  1996-03-14    1996-04-01     NONE               FOB          pending foxes. slyly re           
+1           15635      638        6             32          49620.16         0.07        0.02   N             O             1996-01-30  1996-02-07    1996-02-03     DELIVER IN PERSON  MAIL        arefully slyly ex                  
+2           106170     1191       1             38          44694.46         0.0         0.05   N             O             1997-01-28  1997-01-14    1997-02-02     TAKE BACK RETURN   RAIL        ven requests. deposits breach a    
+3           4297       1798       1             45          54058.05         0.06        0.0    R             F             1994-02-02  1994-01-04    1994-02-23     NONE               AIR         ongside of the furiously brave acco
+3           19036      6540       2             49          46796.47         0.1         0.0    R             F             1993-11-09  1993-12-20    1993-11-24     TAKE BACK RETURN   RAIL         unusual accounts. eve             
+3           128449     3474       3             27          39890.88         0.06        0.07   A             F             1994-01-16  1993-11-22    1994-01-23     DELIVER IN PERSON  SHIP        nal foxes wake.                    
+'''
+
+expected_results['csv'] = '''l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment
+1,155190,7706,1,17,21168.23,0.04,0.02,N,O,1996-03-13,1996-02-12,1996-03-22,DELIVER IN PERSON,TRUCK,egular courts above the
+1,67310,7311,2,36,45983.16,0.09,0.06,N,O,1996-04-12,1996-02-28,1996-04-20,TAKE BACK RETURN,MAIL,ly final dependencies: slyly bold 
+1,63700,3701,3,8,13309.6,0.1,0.02,N,O,1996-01-29,1996-03-05,1996-01-31,TAKE BACK RETURN,REG AIR,"riously. regular, express dep"
+1,2132,4633,4,28,28955.64,0.09,0.06,N,O,1996-04-21,1996-03-30,1996-05-16,NONE,AIR,lites. fluffily even de
+1,24027,1534,5,24,22824.48,0.1,0.04,N,O,1996-03-30,1996-03-14,1996-04-01,NONE,FOB, pending foxes. slyly re
+1,15635,638,6,32,49620.16,0.07,0.02,N,O,1996-01-30,1996-02-07,1996-02-03,DELIVER IN PERSON,MAIL,arefully slyly ex
+2,106170,1191,1,38,44694.46,0.0,0.05,N,O,1997-01-28,1997-01-14,1997-02-02,TAKE BACK RETURN,RAIL,ven requests. deposits breach a
+3,4297,1798,1,45,54058.05,0.06,0.0,R,F,1994-02-02,1994-01-04,1994-02-23,NONE,AIR,ongside of the furiously brave acco
+3,19036,6540,2,49,46796.47,0.1,0.0,R,F,1993-11-09,1993-12-20,1993-11-24,TAKE BACK RETURN,RAIL, unusual accounts. eve
+3,128449,3474,3,27,39890.88,0.06,0.07,A,F,1994-01-16,1993-11-22,1994-01-23,DELIVER IN PERSON,SHIP,nal foxes wake. 
+'''
+
+expected_results['duckbox'] = '''┌────────────┬───────────┬───────────┬──────────────┬────────────┬─────────────────┬────────────┬────────┬──────────────┬──────────────┬────────────┬──────────────┬───────────────┬───────────────────┬────────────┬─────────────────────────────────────┐
+│ l_orderkey │ l_partkey │ l_suppkey │ l_linenumber │ l_quantity │ l_extendedprice │ l_discount │ l_tax  │ l_returnflag │ l_linestatus │ l_shipdate │ l_commitdate │ l_receiptdate │  l_shipinstruct   │ l_shipmode │              l_comment              │
+│   int64    │   int64   │   int64   │    int32     │   int32    │     double      │   double   │ double │   varchar    │   varchar    │  varchar   │   varchar    │    varchar    │      varchar      │  varchar   │               varchar               │
+├────────────┼───────────┼───────────┼──────────────┼────────────┼─────────────────┼────────────┼────────┼──────────────┼──────────────┼────────────┼──────────────┼───────────────┼───────────────────┼────────────┼─────────────────────────────────────┤
+│          1 │    155190 │      7706 │            1 │         17 │        21168.23 │       0.04 │   0.02 │ N            │ O            │ 1996-03-13 │ 1996-02-12   │ 1996-03-22    │ DELIVER IN PERSON │ TRUCK      │ egular courts above the             │
+│          1 │     67310 │      7311 │            2 │         36 │        45983.16 │       0.09 │   0.06 │ N            │ O            │ 1996-04-12 │ 1996-02-28   │ 1996-04-20    │ TAKE BACK RETURN  │ MAIL       │ ly final dependencies: slyly bold   │
+│          1 │     63700 │      3701 │            3 │          8 │         13309.6 │        0.1 │   0.02 │ N            │ O            │ 1996-01-29 │ 1996-03-05   │ 1996-01-31    │ TAKE BACK RETURN  │ REG AIR    │ riously. regular, express dep       │
+│          1 │      2132 │      4633 │            4 │         28 │        28955.64 │       0.09 │   0.06 │ N            │ O            │ 1996-04-21 │ 1996-03-30   │ 1996-05-16    │ NONE              │ AIR        │ lites. fluffily even de             │
+│          1 │     24027 │      1534 │            5 │         24 │        22824.48 │        0.1 │   0.04 │ N            │ O            │ 1996-03-30 │ 1996-03-14   │ 1996-04-01    │ NONE              │ FOB        │  pending foxes. slyly re            │
+│          1 │     15635 │       638 │            6 │         32 │        49620.16 │       0.07 │   0.02 │ N            │ O            │ 1996-01-30 │ 1996-02-07   │ 1996-02-03    │ DELIVER IN PERSON │ MAIL       │ arefully slyly ex                   │
+│          2 │    106170 │      1191 │            1 │         38 │        44694.46 │        0.0 │   0.05 │ N            │ O            │ 1997-01-28 │ 1997-01-14   │ 1997-02-02    │ TAKE BACK RETURN  │ RAIL       │ ven requests. deposits breach a     │
+│          3 │      4297 │      1798 │            1 │         45 │        54058.05 │       0.06 │    0.0 │ R            │ F            │ 1994-02-02 │ 1994-01-04   │ 1994-02-23    │ NONE              │ AIR        │ ongside of the furiously brave acco │
+│          3 │     19036 │      6540 │            2 │         49 │        46796.47 │        0.1 │    0.0 │ R            │ F            │ 1993-11-09 │ 1993-12-20   │ 1993-11-24    │ TAKE BACK RETURN  │ RAIL       │  unusual accounts. eve              │
+│          3 │    128449 │      3474 │            3 │         27 │        39890.88 │       0.06 │   0.07 │ A            │ F            │ 1994-01-16 │ 1993-11-22   │ 1994-01-23    │ DELIVER IN PERSON │ SHIP       │ nal foxes wake.                     │
+├────────────┴───────────┴───────────┴──────────────┴────────────┴─────────────────┴────────────┴────────┴──────────────┴──────────────┴────────────┴──────────────┴───────────────┴───────────────────┴────────────┴─────────────────────────────────────┤
+│ 10 rows                                                                                                                                                                                                                                      16 columns │
+└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+'''
+
+expected_results['html'] = '''<tr><th>l_orderkey</th>
+<th>l_partkey</th>
+<th>l_suppkey</th>
+<th>l_linenumber</th>
+<th>l_quantity</th>
+<th>l_extendedprice</th>
+<th>l_discount</th>
+<th>l_tax</th>
+<th>l_returnflag</th>
+<th>l_linestatus</th>
+<th>l_shipdate</th>
+<th>l_commitdate</th>
+<th>l_receiptdate</th>
+<th>l_shipinstruct</th>
+<th>l_shipmode</th>
+<th>l_comment</th>
+</tr>
+<tr><td>1</td>
+<td>155190</td>
+<td>7706</td>
+<td>1</td>
+<td>17</td>
+<td>21168.23</td>
+<td>0.04</td>
+<td>0.02</td>
+<td>N</td>
+<td>O</td>
+<td>1996-03-13</td>
+<td>1996-02-12</td>
+<td>1996-03-22</td>
+<td>DELIVER IN PERSON</td>
+<td>TRUCK</td>
+<td>egular courts above the</td>
+</tr>
+<tr><td>1</td>
+<td>67310</td>
+<td>7311</td>
+<td>2</td>
+<td>36</td>
+<td>45983.16</td>
+<td>0.09</td>
+<td>0.06</td>
+<td>N</td>
+<td>O</td>
+<td>1996-04-12</td>
+<td>1996-02-28</td>
+<td>1996-04-20</td>
+<td>TAKE BACK RETURN</td>
+<td>MAIL</td>
+<td>ly final dependencies: slyly bold </td>
+</tr>
+<tr><td>1</td>
+<td>63700</td>
+<td>3701</td>
+<td>3</td>
+<td>8</td>
+<td>13309.6</td>
+<td>0.1</td>
+<td>0.02</td>
+<td>N</td>
+<td>O</td>
+<td>1996-01-29</td>
+<td>1996-03-05</td>
+<td>1996-01-31</td>
+<td>TAKE BACK RETURN</td>
+<td>REG AIR</td>
+<td>riously. regular, express dep</td>
+</tr>
+<tr><td>1</td>
+<td>2132</td>
+<td>4633</td>
+<td>4</td>
+<td>28</td>
+<td>28955.64</td>
+<td>0.09</td>
+<td>0.06</td>
+<td>N</td>
+<td>O</td>
+<td>1996-04-21</td>
+<td>1996-03-30</td>
+<td>1996-05-16</td>
+<td>NONE</td>
+<td>AIR</td>
+<td>lites. fluffily even de</td>
+</tr>
+<tr><td>1</td>
+<td>24027</td>
+<td>1534</td>
+<td>5</td>
+<td>24</td>
+<td>22824.48</td>
+<td>0.1</td>
+<td>0.04</td>
+<td>N</td>
+<td>O</td>
+<td>1996-03-30</td>
+<td>1996-03-14</td>
+<td>1996-04-01</td>
+<td>NONE</td>
+<td>FOB</td>
+<td> pending foxes. slyly re</td>
+</tr>
+<tr><td>1</td>
+<td>15635</td>
+<td>638</td>
+<td>6</td>
+<td>32</td>
+<td>49620.16</td>
+<td>0.07</td>
+<td>0.02</td>
+<td>N</td>
+<td>O</td>
+<td>1996-01-30</td>
+<td>1996-02-07</td>
+<td>1996-02-03</td>
+<td>DELIVER IN PERSON</td>
+<td>MAIL</td>
+<td>arefully slyly ex</td>
+</tr>
+<tr><td>2</td>
+<td>106170</td>
+<td>1191</td>
+<td>1</td>
+<td>38</td>
+<td>44694.46</td>
+<td>0.0</td>
+<td>0.05</td>
+<td>N</td>
+<td>O</td>
+<td>1997-01-28</td>
+<td>1997-01-14</td>
+<td>1997-02-02</td>
+<td>TAKE BACK RETURN</td>
+<td>RAIL</td>
+<td>ven requests. deposits breach a</td>
+</tr>
+<tr><td>3</td>
+<td>4297</td>
+<td>1798</td>
+<td>1</td>
+<td>45</td>
+<td>54058.05</td>
+<td>0.06</td>
+<td>0.0</td>
+<td>R</td>
+<td>F</td>
+<td>1994-02-02</td>
+<td>1994-01-04</td>
+<td>1994-02-23</td>
+<td>NONE</td>
+<td>AIR</td>
+<td>ongside of the furiously brave acco</td>
+</tr>
+<tr><td>3</td>
+<td>19036</td>
+<td>6540</td>
+<td>2</td>
+<td>49</td>
+<td>46796.47</td>
+<td>0.1</td>
+<td>0.0</td>
+<td>R</td>
+<td>F</td>
+<td>1993-11-09</td>
+<td>1993-12-20</td>
+<td>1993-11-24</td>
+<td>TAKE BACK RETURN</td>
+<td>RAIL</td>
+<td> unusual accounts. eve</td>
+</tr>
+<tr><td>3</td>
+<td>128449</td>
+<td>3474</td>
+<td>3</td>
+<td>27</td>
+<td>39890.88</td>
+<td>0.06</td>
+<td>0.07</td>
+<td>A</td>
+<td>F</td>
+<td>1994-01-16</td>
+<td>1993-11-22</td>
+<td>1994-01-23</td>
+<td>DELIVER IN PERSON</td>
+<td>SHIP</td>
+<td>nal foxes wake. </td>
+</tr>
+'''
+
+expected_results['insert'] = '''INSERT INTO "table"(l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment) VALUES(1,155190,7706,1,17,21168.23,0.04,0.02,'N','O','1996-03-13','1996-02-12','1996-03-22','DELIVER IN PERSON','TRUCK','egular courts above the');
+INSERT INTO "table"(l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment) VALUES(1,67310,7311,2,36,45983.16,0.09,0.06,'N','O','1996-04-12','1996-02-28','1996-04-20','TAKE BACK RETURN','MAIL','ly final dependencies: slyly bold ');
+INSERT INTO "table"(l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment) VALUES(1,63700,3701,3,8,13309.6,0.1,0.02,'N','O','1996-01-29','1996-03-05','1996-01-31','TAKE BACK RETURN','REG AIR','riously. regular, express dep');
+INSERT INTO "table"(l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment) VALUES(1,2132,4633,4,28,28955.64,0.09,0.06,'N','O','1996-04-21','1996-03-30','1996-05-16','NONE','AIR','lites. fluffily even de');
+INSERT INTO "table"(l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment) VALUES(1,24027,1534,5,24,22824.48,0.1,0.04,'N','O','1996-03-30','1996-03-14','1996-04-01','NONE','FOB',' pending foxes. slyly re');
+INSERT INTO "table"(l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment) VALUES(1,15635,638,6,32,49620.16,0.07,0.02,'N','O','1996-01-30','1996-02-07','1996-02-03','DELIVER IN PERSON','MAIL','arefully slyly ex');
+INSERT INTO "table"(l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment) VALUES(2,106170,1191,1,38,44694.46,0.0,0.05,'N','O','1997-01-28','1997-01-14','1997-02-02','TAKE BACK RETURN','RAIL','ven requests. deposits breach a');
+INSERT INTO "table"(l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment) VALUES(3,4297,1798,1,45,54058.05,0.06,0.0,'R','F','1994-02-02','1994-01-04','1994-02-23','NONE','AIR','ongside of the furiously brave acco');
+INSERT INTO "table"(l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment) VALUES(3,19036,6540,2,49,46796.47,0.1,0.0,'R','F','1993-11-09','1993-12-20','1993-11-24','TAKE BACK RETURN','RAIL',' unusual accounts. eve');
+INSERT INTO "table"(l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment) VALUES(3,128449,3474,3,27,39890.88,0.06,0.07,'A','F','1994-01-16','1993-11-22','1994-01-23','DELIVER IN PERSON','SHIP','nal foxes wake. ');
+'''
+
+expected_results['json'] = '''[{"l_orderkey":1,"l_partkey":155190,"l_suppkey":7706,"l_linenumber":1,"l_quantity":17,"l_extendedprice":21168.23,"l_discount":0.04,"l_tax":0.02,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-03-13","l_commitdate":"1996-02-12","l_receiptdate":"1996-03-22","l_shipinstruct":"DELIVER IN PERSON","l_shipmode":"TRUCK","l_comment":"egular courts above the"},
+{"l_orderkey":1,"l_partkey":67310,"l_suppkey":7311,"l_linenumber":2,"l_quantity":36,"l_extendedprice":45983.16,"l_discount":0.09,"l_tax":0.06,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-04-12","l_commitdate":"1996-02-28","l_receiptdate":"1996-04-20","l_shipinstruct":"TAKE BACK RETURN","l_shipmode":"MAIL","l_comment":"ly final dependencies: slyly bold "},
+{"l_orderkey":1,"l_partkey":63700,"l_suppkey":3701,"l_linenumber":3,"l_quantity":8,"l_extendedprice":13309.6,"l_discount":0.1,"l_tax":0.02,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-01-29","l_commitdate":"1996-03-05","l_receiptdate":"1996-01-31","l_shipinstruct":"TAKE BACK RETURN","l_shipmode":"REG AIR","l_comment":"riously. regular, express dep"},
+{"l_orderkey":1,"l_partkey":2132,"l_suppkey":4633,"l_linenumber":4,"l_quantity":28,"l_extendedprice":28955.64,"l_discount":0.09,"l_tax":0.06,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-04-21","l_commitdate":"1996-03-30","l_receiptdate":"1996-05-16","l_shipinstruct":"NONE","l_shipmode":"AIR","l_comment":"lites. fluffily even de"},
+{"l_orderkey":1,"l_partkey":24027,"l_suppkey":1534,"l_linenumber":5,"l_quantity":24,"l_extendedprice":22824.48,"l_discount":0.1,"l_tax":0.04,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-03-30","l_commitdate":"1996-03-14","l_receiptdate":"1996-04-01","l_shipinstruct":"NONE","l_shipmode":"FOB","l_comment":" pending foxes. slyly re"},
+{"l_orderkey":1,"l_partkey":15635,"l_suppkey":638,"l_linenumber":6,"l_quantity":32,"l_extendedprice":49620.16,"l_discount":0.07,"l_tax":0.02,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-01-30","l_commitdate":"1996-02-07","l_receiptdate":"1996-02-03","l_shipinstruct":"DELIVER IN PERSON","l_shipmode":"MAIL","l_comment":"arefully slyly ex"},
+{"l_orderkey":2,"l_partkey":106170,"l_suppkey":1191,"l_linenumber":1,"l_quantity":38,"l_extendedprice":44694.46,"l_discount":0.0,"l_tax":0.05,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1997-01-28","l_commitdate":"1997-01-14","l_receiptdate":"1997-02-02","l_shipinstruct":"TAKE BACK RETURN","l_shipmode":"RAIL","l_comment":"ven requests. deposits breach a"},
+{"l_orderkey":3,"l_partkey":4297,"l_suppkey":1798,"l_linenumber":1,"l_quantity":45,"l_extendedprice":54058.05,"l_discount":0.06,"l_tax":0.0,"l_returnflag":"R","l_linestatus":"F","l_shipdate":"1994-02-02","l_commitdate":"1994-01-04","l_receiptdate":"1994-02-23","l_shipinstruct":"NONE","l_shipmode":"AIR","l_comment":"ongside of the furiously brave acco"},
+{"l_orderkey":3,"l_partkey":19036,"l_suppkey":6540,"l_linenumber":2,"l_quantity":49,"l_extendedprice":46796.47,"l_discount":0.1,"l_tax":0.0,"l_returnflag":"R","l_linestatus":"F","l_shipdate":"1993-11-09","l_commitdate":"1993-12-20","l_receiptdate":"1993-11-24","l_shipinstruct":"TAKE BACK RETURN","l_shipmode":"RAIL","l_comment":" unusual accounts. eve"},
+{"l_orderkey":3,"l_partkey":128449,"l_suppkey":3474,"l_linenumber":3,"l_quantity":27,"l_extendedprice":39890.88,"l_discount":0.06,"l_tax":0.07,"l_returnflag":"A","l_linestatus":"F","l_shipdate":"1994-01-16","l_commitdate":"1993-11-22","l_receiptdate":"1994-01-23","l_shipinstruct":"DELIVER IN PERSON","l_shipmode":"SHIP","l_comment":"nal foxes wake. "}]
+'''
+
+expected_results['jsonlines'] = '''{"l_orderkey":1,"l_partkey":155190,"l_suppkey":7706,"l_linenumber":1,"l_quantity":17,"l_extendedprice":21168.23,"l_discount":0.04,"l_tax":0.02,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-03-13","l_commitdate":"1996-02-12","l_receiptdate":"1996-03-22","l_shipinstruct":"DELIVER IN PERSON","l_shipmode":"TRUCK","l_comment":"egular courts above the"}
+{"l_orderkey":1,"l_partkey":67310,"l_suppkey":7311,"l_linenumber":2,"l_quantity":36,"l_extendedprice":45983.16,"l_discount":0.09,"l_tax":0.06,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-04-12","l_commitdate":"1996-02-28","l_receiptdate":"1996-04-20","l_shipinstruct":"TAKE BACK RETURN","l_shipmode":"MAIL","l_comment":"ly final dependencies: slyly bold "}
+{"l_orderkey":1,"l_partkey":63700,"l_suppkey":3701,"l_linenumber":3,"l_quantity":8,"l_extendedprice":13309.6,"l_discount":0.1,"l_tax":0.02,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-01-29","l_commitdate":"1996-03-05","l_receiptdate":"1996-01-31","l_shipinstruct":"TAKE BACK RETURN","l_shipmode":"REG AIR","l_comment":"riously. regular, express dep"}
+{"l_orderkey":1,"l_partkey":2132,"l_suppkey":4633,"l_linenumber":4,"l_quantity":28,"l_extendedprice":28955.64,"l_discount":0.09,"l_tax":0.06,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-04-21","l_commitdate":"1996-03-30","l_receiptdate":"1996-05-16","l_shipinstruct":"NONE","l_shipmode":"AIR","l_comment":"lites. fluffily even de"}
+{"l_orderkey":1,"l_partkey":24027,"l_suppkey":1534,"l_linenumber":5,"l_quantity":24,"l_extendedprice":22824.48,"l_discount":0.1,"l_tax":0.04,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-03-30","l_commitdate":"1996-03-14","l_receiptdate":"1996-04-01","l_shipinstruct":"NONE","l_shipmode":"FOB","l_comment":" pending foxes. slyly re"}
+{"l_orderkey":1,"l_partkey":15635,"l_suppkey":638,"l_linenumber":6,"l_quantity":32,"l_extendedprice":49620.16,"l_discount":0.07,"l_tax":0.02,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1996-01-30","l_commitdate":"1996-02-07","l_receiptdate":"1996-02-03","l_shipinstruct":"DELIVER IN PERSON","l_shipmode":"MAIL","l_comment":"arefully slyly ex"}
+{"l_orderkey":2,"l_partkey":106170,"l_suppkey":1191,"l_linenumber":1,"l_quantity":38,"l_extendedprice":44694.46,"l_discount":0.0,"l_tax":0.05,"l_returnflag":"N","l_linestatus":"O","l_shipdate":"1997-01-28","l_commitdate":"1997-01-14","l_receiptdate":"1997-02-02","l_shipinstruct":"TAKE BACK RETURN","l_shipmode":"RAIL","l_comment":"ven requests. deposits breach a"}
+{"l_orderkey":3,"l_partkey":4297,"l_suppkey":1798,"l_linenumber":1,"l_quantity":45,"l_extendedprice":54058.05,"l_discount":0.06,"l_tax":0.0,"l_returnflag":"R","l_linestatus":"F","l_shipdate":"1994-02-02","l_commitdate":"1994-01-04","l_receiptdate":"1994-02-23","l_shipinstruct":"NONE","l_shipmode":"AIR","l_comment":"ongside of the furiously brave acco"}
+{"l_orderkey":3,"l_partkey":19036,"l_suppkey":6540,"l_linenumber":2,"l_quantity":49,"l_extendedprice":46796.47,"l_discount":0.1,"l_tax":0.0,"l_returnflag":"R","l_linestatus":"F","l_shipdate":"1993-11-09","l_commitdate":"1993-12-20","l_receiptdate":"1993-11-24","l_shipinstruct":"TAKE BACK RETURN","l_shipmode":"RAIL","l_comment":" unusual accounts. eve"}
+{"l_orderkey":3,"l_partkey":128449,"l_suppkey":3474,"l_linenumber":3,"l_quantity":27,"l_extendedprice":39890.88,"l_discount":0.06,"l_tax":0.07,"l_returnflag":"A","l_linestatus":"F","l_shipdate":"1994-01-16","l_commitdate":"1993-11-22","l_receiptdate":"1994-01-23","l_shipinstruct":"DELIVER IN PERSON","l_shipmode":"SHIP","l_comment":"nal foxes wake. "}
+'''
+
+expected_results['latex'] = '''\\begin{tabular}{|rrrrrrrrllllllll|}
+\\hline
+l_orderkey & l_partkey & l_suppkey & l_linenumber & l_quantity & l_extendedprice & l_discount & l_tax & l_returnflag & l_linestatus & l_shipdate & l_commitdate & l_receiptdate &  l_shipinstruct   & l_shipmode &              l_comment              \\\\
+\\hline
+1          & 155190    & 7706      & 1            & 17         & 21168.23        & 0.04       & 0.02  & N            & O            & 1996-03-13 & 1996-02-12   & 1996-03-22    & DELIVER IN PERSON & TRUCK      & egular courts above the             \\\\
+1          & 67310     & 7311      & 2            & 36         & 45983.16        & 0.09       & 0.06  & N            & O            & 1996-04-12 & 1996-02-28   & 1996-04-20    & TAKE BACK RETURN  & MAIL       & ly final dependencies: slyly bold   \\\\
+1          & 63700     & 3701      & 3            & 8          & 13309.6         & 0.1        & 0.02  & N            & O            & 1996-01-29 & 1996-03-05   & 1996-01-31    & TAKE BACK RETURN  & REG AIR    & riously. regular, express dep       \\\\
+1          & 2132      & 4633      & 4            & 28         & 28955.64        & 0.09       & 0.06  & N            & O            & 1996-04-21 & 1996-03-30   & 1996-05-16    & NONE              & AIR        & lites. fluffily even de             \\\\
+1          & 24027     & 1534      & 5            & 24         & 22824.48        & 0.1        & 0.04  & N            & O            & 1996-03-30 & 1996-03-14   & 1996-04-01    & NONE              & FOB        &  pending foxes. slyly re            \\\\
+1          & 15635     & 638       & 6            & 32         & 49620.16        & 0.07       & 0.02  & N            & O            & 1996-01-30 & 1996-02-07   & 1996-02-03    & DELIVER IN PERSON & MAIL       & arefully slyly ex                   \\\\
+2          & 106170    & 1191      & 1            & 38         & 44694.46        & 0.0        & 0.05  & N            & O            & 1997-01-28 & 1997-01-14   & 1997-02-02    & TAKE BACK RETURN  & RAIL       & ven requests. deposits breach a     \\\\
+3          & 4297      & 1798      & 1            & 45         & 54058.05        & 0.06       & 0.0   & R            & F            & 1994-02-02 & 1994-01-04   & 1994-02-23    & NONE              & AIR        & ongside of the furiously brave acco \\\\
+3          & 19036     & 6540      & 2            & 49         & 46796.47        & 0.1        & 0.0   & R            & F            & 1993-11-09 & 1993-12-20   & 1993-11-24    & TAKE BACK RETURN  & RAIL       &  unusual accounts. eve              \\\\
+3          & 128449    & 3474      & 3            & 27         & 39890.88        & 0.06       & 0.07  & A            & F            & 1994-01-16 & 1993-11-22   & 1994-01-23    & DELIVER IN PERSON & SHIP       & nal foxes wake.                     \\\\
+\\hline
+\\end{tabular}
+'''
+
+expected_results['line'] = '''     l_orderkey = 1
+      l_partkey = 155190
+      l_suppkey = 7706
+   l_linenumber = 1
+     l_quantity = 17
+l_extendedprice = 21168.23
+     l_discount = 0.04
+          l_tax = 0.02
+   l_returnflag = N
+   l_linestatus = O
+     l_shipdate = 1996-03-13
+   l_commitdate = 1996-02-12
+  l_receiptdate = 1996-03-22
+ l_shipinstruct = DELIVER IN PERSON
+     l_shipmode = TRUCK
+      l_comment = egular courts above the
+
+     l_orderkey = 1
+      l_partkey = 67310
+      l_suppkey = 7311
+   l_linenumber = 2
+     l_quantity = 36
+l_extendedprice = 45983.16
+     l_discount = 0.09
+          l_tax = 0.06
+   l_returnflag = N
+   l_linestatus = O
+     l_shipdate = 1996-04-12
+   l_commitdate = 1996-02-28
+  l_receiptdate = 1996-04-20
+ l_shipinstruct = TAKE BACK RETURN
+     l_shipmode = MAIL
+      l_comment = ly final dependencies: slyly bold 
+
+     l_orderkey = 1
+      l_partkey = 63700
+      l_suppkey = 3701
+   l_linenumber = 3
+     l_quantity = 8
+l_extendedprice = 13309.6
+     l_discount = 0.1
+          l_tax = 0.02
+   l_returnflag = N
+   l_linestatus = O
+     l_shipdate = 1996-01-29
+   l_commitdate = 1996-03-05
+  l_receiptdate = 1996-01-31
+ l_shipinstruct = TAKE BACK RETURN
+     l_shipmode = REG AIR
+      l_comment = riously. regular, express dep
+
+     l_orderkey = 1
+      l_partkey = 2132
+      l_suppkey = 4633
+   l_linenumber = 4
+     l_quantity = 28
+l_extendedprice = 28955.64
+     l_discount = 0.09
+          l_tax = 0.06
+   l_returnflag = N
+   l_linestatus = O
+     l_shipdate = 1996-04-21
+   l_commitdate = 1996-03-30
+  l_receiptdate = 1996-05-16
+ l_shipinstruct = NONE
+     l_shipmode = AIR
+      l_comment = lites. fluffily even de
+
+     l_orderkey = 1
+      l_partkey = 24027
+      l_suppkey = 1534
+   l_linenumber = 5
+     l_quantity = 24
+l_extendedprice = 22824.48
+     l_discount = 0.1
+          l_tax = 0.04
+   l_returnflag = N
+   l_linestatus = O
+     l_shipdate = 1996-03-30
+   l_commitdate = 1996-03-14
+  l_receiptdate = 1996-04-01
+ l_shipinstruct = NONE
+     l_shipmode = FOB
+      l_comment =  pending foxes. slyly re
+
+     l_orderkey = 1
+      l_partkey = 15635
+      l_suppkey = 638
+   l_linenumber = 6
+     l_quantity = 32
+l_extendedprice = 49620.16
+     l_discount = 0.07
+          l_tax = 0.02
+   l_returnflag = N
+   l_linestatus = O
+     l_shipdate = 1996-01-30
+   l_commitdate = 1996-02-07
+  l_receiptdate = 1996-02-03
+ l_shipinstruct = DELIVER IN PERSON
+     l_shipmode = MAIL
+      l_comment = arefully slyly ex
+
+     l_orderkey = 2
+      l_partkey = 106170
+      l_suppkey = 1191
+   l_linenumber = 1
+     l_quantity = 38
+l_extendedprice = 44694.46
+     l_discount = 0.0
+          l_tax = 0.05
+   l_returnflag = N
+   l_linestatus = O
+     l_shipdate = 1997-01-28
+   l_commitdate = 1997-01-14
+  l_receiptdate = 1997-02-02
+ l_shipinstruct = TAKE BACK RETURN
+     l_shipmode = RAIL
+      l_comment = ven requests. deposits breach a
+
+     l_orderkey = 3
+      l_partkey = 4297
+      l_suppkey = 1798
+   l_linenumber = 1
+     l_quantity = 45
+l_extendedprice = 54058.05
+     l_discount = 0.06
+          l_tax = 0.0
+   l_returnflag = R
+   l_linestatus = F
+     l_shipdate = 1994-02-02
+   l_commitdate = 1994-01-04
+  l_receiptdate = 1994-02-23
+ l_shipinstruct = NONE
+     l_shipmode = AIR
+      l_comment = ongside of the furiously brave acco
+
+     l_orderkey = 3
+      l_partkey = 19036
+      l_suppkey = 6540
+   l_linenumber = 2
+     l_quantity = 49
+l_extendedprice = 46796.47
+     l_discount = 0.1
+          l_tax = 0.0
+   l_returnflag = R
+   l_linestatus = F
+     l_shipdate = 1993-11-09
+   l_commitdate = 1993-12-20
+  l_receiptdate = 1993-11-24
+ l_shipinstruct = TAKE BACK RETURN
+     l_shipmode = RAIL
+      l_comment =  unusual accounts. eve
+
+     l_orderkey = 3
+      l_partkey = 128449
+      l_suppkey = 3474
+   l_linenumber = 3
+     l_quantity = 27
+l_extendedprice = 39890.88
+     l_discount = 0.06
+          l_tax = 0.07
+   l_returnflag = A
+   l_linestatus = F
+     l_shipdate = 1994-01-16
+   l_commitdate = 1993-11-22
+  l_receiptdate = 1994-01-23
+ l_shipinstruct = DELIVER IN PERSON
+     l_shipmode = SHIP
+      l_comment = nal foxes wake. 
+'''
+
+expected_results['list'] = '''l_orderkey|l_partkey|l_suppkey|l_linenumber|l_quantity|l_extendedprice|l_discount|l_tax|l_returnflag|l_linestatus|l_shipdate|l_commitdate|l_receiptdate|l_shipinstruct|l_shipmode|l_comment
+1|155190|7706|1|17|21168.23|0.04|0.02|N|O|1996-03-13|1996-02-12|1996-03-22|DELIVER IN PERSON|TRUCK|egular courts above the
+1|67310|7311|2|36|45983.16|0.09|0.06|N|O|1996-04-12|1996-02-28|1996-04-20|TAKE BACK RETURN|MAIL|ly final dependencies: slyly bold 
+1|63700|3701|3|8|13309.6|0.1|0.02|N|O|1996-01-29|1996-03-05|1996-01-31|TAKE BACK RETURN|REG AIR|riously. regular, express dep
+1|2132|4633|4|28|28955.64|0.09|0.06|N|O|1996-04-21|1996-03-30|1996-05-16|NONE|AIR|lites. fluffily even de
+1|24027|1534|5|24|22824.48|0.1|0.04|N|O|1996-03-30|1996-03-14|1996-04-01|NONE|FOB| pending foxes. slyly re
+1|15635|638|6|32|49620.16|0.07|0.02|N|O|1996-01-30|1996-02-07|1996-02-03|DELIVER IN PERSON|MAIL|arefully slyly ex
+2|106170|1191|1|38|44694.46|0.0|0.05|N|O|1997-01-28|1997-01-14|1997-02-02|TAKE BACK RETURN|RAIL|ven requests. deposits breach a
+3|4297|1798|1|45|54058.05|0.06|0.0|R|F|1994-02-02|1994-01-04|1994-02-23|NONE|AIR|ongside of the furiously brave acco
+3|19036|6540|2|49|46796.47|0.1|0.0|R|F|1993-11-09|1993-12-20|1993-11-24|TAKE BACK RETURN|RAIL| unusual accounts. eve
+3|128449|3474|3|27|39890.88|0.06|0.07|A|F|1994-01-16|1993-11-22|1994-01-23|DELIVER IN PERSON|SHIP|nal foxes wake. 
+'''
+
+expected_results['markdown'] = '''| l_orderkey | l_partkey | l_suppkey | l_linenumber | l_quantity | l_extendedprice | l_discount | l_tax | l_returnflag | l_linestatus | l_shipdate | l_commitdate | l_receiptdate |  l_shipinstruct   | l_shipmode |              l_comment              |
+|-----------:|----------:|----------:|-------------:|-----------:|----------------:|-----------:|------:|--------------|--------------|------------|--------------|---------------|-------------------|------------|-------------------------------------|
+| 1          | 155190    | 7706      | 1            | 17         | 21168.23        | 0.04       | 0.02  | N            | O            | 1996-03-13 | 1996-02-12   | 1996-03-22    | DELIVER IN PERSON | TRUCK      | egular courts above the             |
+| 1          | 67310     | 7311      | 2            | 36         | 45983.16        | 0.09       | 0.06  | N            | O            | 1996-04-12 | 1996-02-28   | 1996-04-20    | TAKE BACK RETURN  | MAIL       | ly final dependencies: slyly bold   |
+| 1          | 63700     | 3701      | 3            | 8          | 13309.6         | 0.1        | 0.02  | N            | O            | 1996-01-29 | 1996-03-05   | 1996-01-31    | TAKE BACK RETURN  | REG AIR    | riously. regular, express dep       |
+| 1          | 2132      | 4633      | 4            | 28         | 28955.64        | 0.09       | 0.06  | N            | O            | 1996-04-21 | 1996-03-30   | 1996-05-16    | NONE              | AIR        | lites. fluffily even de             |
+| 1          | 24027     | 1534      | 5            | 24         | 22824.48        | 0.1        | 0.04  | N            | O            | 1996-03-30 | 1996-03-14   | 1996-04-01    | NONE              | FOB        |  pending foxes. slyly re            |
+| 1          | 15635     | 638       | 6            | 32         | 49620.16        | 0.07       | 0.02  | N            | O            | 1996-01-30 | 1996-02-07   | 1996-02-03    | DELIVER IN PERSON | MAIL       | arefully slyly ex                   |
+| 2          | 106170    | 1191      | 1            | 38         | 44694.46        | 0.0        | 0.05  | N            | O            | 1997-01-28 | 1997-01-14   | 1997-02-02    | TAKE BACK RETURN  | RAIL       | ven requests. deposits breach a     |
+| 3          | 4297      | 1798      | 1            | 45         | 54058.05        | 0.06       | 0.0   | R            | F            | 1994-02-02 | 1994-01-04   | 1994-02-23    | NONE              | AIR        | ongside of the furiously brave acco |
+| 3          | 19036     | 6540      | 2            | 49         | 46796.47        | 0.1        | 0.0   | R            | F            | 1993-11-09 | 1993-12-20   | 1993-11-24    | TAKE BACK RETURN  | RAIL       |  unusual accounts. eve              |
+| 3          | 128449    | 3474      | 3            | 27         | 39890.88        | 0.06       | 0.07  | A            | F            | 1994-01-16 | 1993-11-22   | 1994-01-23    | DELIVER IN PERSON | SHIP       | nal foxes wake.                     |
+'''
+
+expected_results['quote'] = ''''l_orderkey','l_partkey','l_suppkey','l_linenumber','l_quantity','l_extendedprice','l_discount','l_tax','l_returnflag','l_linestatus','l_shipdate','l_commitdate','l_receiptdate','l_shipinstruct','l_shipmode','l_comment'
+1,155190,7706,1,17,21168.23,0.04,0.02,'N','O','1996-03-13','1996-02-12','1996-03-22','DELIVER IN PERSON','TRUCK','egular courts above the'
+1,67310,7311,2,36,45983.16,0.09,0.06,'N','O','1996-04-12','1996-02-28','1996-04-20','TAKE BACK RETURN','MAIL','ly final dependencies: slyly bold '
+1,63700,3701,3,8,13309.6,0.1,0.02,'N','O','1996-01-29','1996-03-05','1996-01-31','TAKE BACK RETURN','REG AIR','riously. regular, express dep'
+1,2132,4633,4,28,28955.64,0.09,0.06,'N','O','1996-04-21','1996-03-30','1996-05-16','NONE','AIR','lites. fluffily even de'
+1,24027,1534,5,24,22824.48,0.1,0.04,'N','O','1996-03-30','1996-03-14','1996-04-01','NONE','FOB',' pending foxes. slyly re'
+1,15635,638,6,32,49620.16,0.07,0.02,'N','O','1996-01-30','1996-02-07','1996-02-03','DELIVER IN PERSON','MAIL','arefully slyly ex'
+2,106170,1191,1,38,44694.46,0.0,0.05,'N','O','1997-01-28','1997-01-14','1997-02-02','TAKE BACK RETURN','RAIL','ven requests. deposits breach a'
+3,4297,1798,1,45,54058.05,0.06,0.0,'R','F','1994-02-02','1994-01-04','1994-02-23','NONE','AIR','ongside of the furiously brave acco'
+3,19036,6540,2,49,46796.47,0.1,0.0,'R','F','1993-11-09','1993-12-20','1993-11-24','TAKE BACK RETURN','RAIL',' unusual accounts. eve'
+3,128449,3474,3,27,39890.88,0.06,0.07,'A','F','1994-01-16','1993-11-22','1994-01-23','DELIVER IN PERSON','SHIP','nal foxes wake. '
+'''
+
+expected_results['table'] = '''+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+-------------------------------------+
+| l_orderkey | l_partkey | l_suppkey | l_linenumber | l_quantity | l_extendedprice | l_discount | l_tax | l_returnflag | l_linestatus | l_shipdate | l_commitdate | l_receiptdate |  l_shipinstruct   | l_shipmode |              l_comment              |
++------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+-------------------------------------+
+| 1          | 155190    | 7706      | 1            | 17         | 21168.23        | 0.04       | 0.02  | N            | O            | 1996-03-13 | 1996-02-12   | 1996-03-22    | DELIVER IN PERSON | TRUCK      | egular courts above the             |
+| 1          | 67310     | 7311      | 2            | 36         | 45983.16        | 0.09       | 0.06  | N            | O            | 1996-04-12 | 1996-02-28   | 1996-04-20    | TAKE BACK RETURN  | MAIL       | ly final dependencies: slyly bold   |
+| 1          | 63700     | 3701      | 3            | 8          | 13309.6         | 0.1        | 0.02  | N            | O            | 1996-01-29 | 1996-03-05   | 1996-01-31    | TAKE BACK RETURN  | REG AIR    | riously. regular, express dep       |
+| 1          | 2132      | 4633      | 4            | 28         | 28955.64        | 0.09       | 0.06  | N            | O            | 1996-04-21 | 1996-03-30   | 1996-05-16    | NONE              | AIR        | lites. fluffily even de             |
+| 1          | 24027     | 1534      | 5            | 24         | 22824.48        | 0.1        | 0.04  | N            | O            | 1996-03-30 | 1996-03-14   | 1996-04-01    | NONE              | FOB        |  pending foxes. slyly re            |
+| 1          | 15635     | 638       | 6            | 32         | 49620.16        | 0.07       | 0.02  | N            | O            | 1996-01-30 | 1996-02-07   | 1996-02-03    | DELIVER IN PERSON | MAIL       | arefully slyly ex                   |
+| 2          | 106170    | 1191      | 1            | 38         | 44694.46        | 0.0        | 0.05  | N            | O            | 1997-01-28 | 1997-01-14   | 1997-02-02    | TAKE BACK RETURN  | RAIL       | ven requests. deposits breach a     |
+| 3          | 4297      | 1798      | 1            | 45         | 54058.05        | 0.06       | 0.0   | R            | F            | 1994-02-02 | 1994-01-04   | 1994-02-23    | NONE              | AIR        | ongside of the furiously brave acco |
+| 3          | 19036     | 6540      | 2            | 49         | 46796.47        | 0.1        | 0.0   | R            | F            | 1993-11-09 | 1993-12-20   | 1993-11-24    | TAKE BACK RETURN  | RAIL       |  unusual accounts. eve              |
+| 3          | 128449    | 3474      | 3            | 27         | 39890.88        | 0.06       | 0.07  | A            | F            | 1994-01-16 | 1993-11-22   | 1994-01-23    | DELIVER IN PERSON | SHIP       | nal foxes wake.                     |
++------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+-------------------------------------+
+'''
+
+expected_results['tabs'] = '''l_orderkey	l_partkey	l_suppkey	l_linenumber	l_quantity	l_extendedprice	l_discount	l_tax	l_returnflag	l_linestatus	l_shipdate	l_commitdate	l_receiptdate	l_shipinstruct	l_shipmode	l_comment
+1	155190	7706	1	17	21168.23	0.04	0.02	N	O	1996-03-13	1996-02-12	1996-03-22	DELIVER IN PERSON	TRUCK	egular courts above the
+1	67310	7311	2	36	45983.16	0.09	0.06	N	O	1996-04-12	1996-02-28	1996-04-20	TAKE BACK RETURN	MAIL	ly final dependencies: slyly bold 
+1	63700	3701	3	8	13309.6	0.1	0.02	N	O	1996-01-29	1996-03-05	1996-01-31	TAKE BACK RETURN	REG AIR	riously. regular, express dep
+1	2132	4633	4	28	28955.64	0.09	0.06	N	O	1996-04-21	1996-03-30	1996-05-16	NONE	AIR	lites. fluffily even de
+1	24027	1534	5	24	22824.48	0.1	0.04	N	O	1996-03-30	1996-03-14	1996-04-01	NONE	FOB	 pending foxes. slyly re
+1	15635	638	6	32	49620.16	0.07	0.02	N	O	1996-01-30	1996-02-07	1996-02-03	DELIVER IN PERSON	MAIL	arefully slyly ex
+2	106170	1191	1	38	44694.46	0.0	0.05	N	O	1997-01-28	1997-01-14	1997-02-02	TAKE BACK RETURN	RAIL	ven requests. deposits breach a
+3	4297	1798	1	45	54058.05	0.06	0.0	R	F	1994-02-02	1994-01-04	1994-02-23	NONE	AIR	ongside of the furiously brave acco
+3	19036	6540	2	49	46796.47	0.1	0.0	R	F	1993-11-09	1993-12-20	1993-11-24	TAKE BACK RETURN	RAIL	 unusual accounts. eve
+3	128449	3474	3	27	39890.88	0.06	0.07	A	F	1994-01-16	1993-11-22	1994-01-23	DELIVER IN PERSON	SHIP	nal foxes wake. 
+'''
+
+expected_results['tcl'] = '''"l_orderkey" "l_partkey" "l_suppkey" "l_linenumber" "l_quantity" "l_extendedprice" "l_discount" "l_tax" "l_returnflag" "l_linestatus" "l_shipdate" "l_commitdate" "l_receiptdate" "l_shipinstruct" "l_shipmode" "l_comment"
+"1" "155190" "7706" "1" "17" "21168.23" "0.04" "0.02" "N" "O" "1996-03-13" "1996-02-12" "1996-03-22" "DELIVER IN PERSON" "TRUCK" "egular courts above the"
+"1" "67310" "7311" "2" "36" "45983.16" "0.09" "0.06" "N" "O" "1996-04-12" "1996-02-28" "1996-04-20" "TAKE BACK RETURN" "MAIL" "ly final dependencies: slyly bold "
+"1" "63700" "3701" "3" "8" "13309.6" "0.1" "0.02" "N" "O" "1996-01-29" "1996-03-05" "1996-01-31" "TAKE BACK RETURN" "REG AIR" "riously. regular, express dep"
+"1" "2132" "4633" "4" "28" "28955.64" "0.09" "0.06" "N" "O" "1996-04-21" "1996-03-30" "1996-05-16" "NONE" "AIR" "lites. fluffily even de"
+"1" "24027" "1534" "5" "24" "22824.48" "0.1" "0.04" "N" "O" "1996-03-30" "1996-03-14" "1996-04-01" "NONE" "FOB" " pending foxes. slyly re"
+"1" "15635" "638" "6" "32" "49620.16" "0.07" "0.02" "N" "O" "1996-01-30" "1996-02-07" "1996-02-03" "DELIVER IN PERSON" "MAIL" "arefully slyly ex"
+"2" "106170" "1191" "1" "38" "44694.46" "0.0" "0.05" "N" "O" "1997-01-28" "1997-01-14" "1997-02-02" "TAKE BACK RETURN" "RAIL" "ven requests. deposits breach a"
+"3" "4297" "1798" "1" "45" "54058.05" "0.06" "0.0" "R" "F" "1994-02-02" "1994-01-04" "1994-02-23" "NONE" "AIR" "ongside of the furiously brave acco"
+"3" "19036" "6540" "2" "49" "46796.47" "0.1" "0.0" "R" "F" "1993-11-09" "1993-12-20" "1993-11-24" "TAKE BACK RETURN" "RAIL" " unusual accounts. eve"
+"3" "128449" "3474" "3" "27" "39890.88" "0.06" "0.07" "A" "F" "1994-01-16" "1993-11-22" "1994-01-23" "DELIVER IN PERSON" "SHIP" "nal foxes wake. "
+'''
+
+def get_expected_output(mode):
+    return expected_results[mode]
+


### PR DESCRIPTION
This PR refactors the shell rendering code by moving everything to the shared `ShellRenderer` class instead of having special cases for `duckbox` and the `ColumnRenderer`. In addition we fix several issues:

* Fix a number of auto-complete rendering issues
* Add better support for interruptions during rendering
* Fix a bug in the buffer-managed `ColumnDataCollection` where strings were not correctly copied for long lists when we were doing a scan with zero-copy disabled