### PR TITLE
avoid underflow/"inf" loop while reporting unittest summary (backport…

### DIFF
--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -16428,18 +16428,21 @@ private:
     bool printInfoMessages;
 };
 
-std::size_t makeRatio(std::size_t number, std::size_t total) {
-    std::size_t ratio = total > 0 ? CATCH_CONFIG_CONSOLE_WIDTH * number / total : 0;
-    return (ratio == 0 && number > 0) ? 1 : ratio;
+std::size_t makeRatio(std::uint64_t number, std::uint64_t total) {
+    const auto ratio = total > 0 ? CATCH_CONFIG_CONSOLE_WIDTH * number / total : 0;
+    return (ratio == 0 && number > 0) ? 1 : static_cast<std::size_t>(ratio);
 }
 
-std::size_t& findMax(std::size_t& i, std::size_t& j, std::size_t& k) {
-    if (i > j && i > k)
+std::size_t&
+findMax( std::size_t& i, std::size_t& j, std::size_t& k, std::size_t& l ) {
+    if (i > j && i > k && i > l)
         return i;
-    else if (j > k)
+    else if (j > k && j > l)
         return j;
-    else
+    else if (k > l)
         return k;
+    else
+        return l;
 }
 
 struct ColumnInfo {
@@ -16924,13 +16927,15 @@ void ConsoleReporter::printSummaryRow(std::string const& label, std::vector<Summ
 
 void ConsoleReporter::printTotalsDivider(Totals const& totals) {
     if (totals.testCases.total() > 0) {
-        std::size_t failedRatio = makeRatio(totals.testCases.failed, totals.testCases.total());
-        std::size_t failedButOkRatio = makeRatio(totals.testCases.failedButOk + totals.skippedTests, totals.testCases.total());
-        std::size_t passedRatio = makeRatio(totals.testCases.passed - totals.skippedTests, totals.testCases.total());
-        while (failedRatio + failedButOkRatio + passedRatio < CATCH_CONFIG_CONSOLE_WIDTH - 1)
-            findMax(failedRatio, failedButOkRatio, passedRatio)++;
-        while (failedRatio + failedButOkRatio + passedRatio > CATCH_CONFIG_CONSOLE_WIDTH - 1)
-            findMax(failedRatio, failedButOkRatio, passedRatio)--;
+		const std::size_t total = totals.testCases.total() + totals.skippedTests;
+        std::size_t failedRatio = makeRatio(totals.testCases.failed, total);
+        std::size_t failedButOkRatio = makeRatio(totals.testCases.failedButOk, total);
+        std::size_t passedRatio = makeRatio(totals.testCases.passed, total);
+		std::size_t skippedRatio = makeRatio(totals.skippedTests, total);
+        while (failedRatio + failedButOkRatio + passedRatio + skippedRatio < CATCH_CONFIG_CONSOLE_WIDTH - 1)
+            findMax(failedRatio, failedButOkRatio, passedRatio, skippedRatio)++;
+        while (failedRatio + failedButOkRatio + passedRatio + skippedRatio > CATCH_CONFIG_CONSOLE_WIDTH - 1)
+            findMax(failedRatio, failedButOkRatio, passedRatio, skippedRatio)--;
 
         stream << Colour(Colour::Error) << std::string(failedRatio, '=');
         stream << Colour(Colour::ResultExpectedFailure) << std::string(failedButOkRatio, '=');


### PR DESCRIPTION
… catch2 update)

By sheer (bad?) luck I came across a hung unittest -- ran all the tests but didn't exit. After attaching debugger, I found this underflow:

```
(lldb) p/x passedRatio
(std::size_t) 0x1555554fde30c486
```

when `passedRatio` should be roughly between 0-120 (console_width).

Backporting the latest catch2 code around this bit avoids the underflow trivially. The backport is semantically imperfect since the underlying stat structures also got changed, but it's close enough and avoids the hung test problem.