### PR TITLE
fix: make row_start an optional_idx in `PartitionStatistics`

### DIFF
--- a/src/include/duckdb/function/partition_stats.hpp
+++ b/src/include/duckdb/function/partition_stats.hpp
@@ -32,7 +32,7 @@ struct PartitionStatistics {
 	PartitionStatistics();
 
 	//! The row id start
-	idx_t row_start;
+	optional_idx row_start;
 	//! The amount of rows in the partition
 	idx_t count;
 	//! Whether or not the count is exact or approximate

--- a/src/include/duckdb/function/partition_stats.hpp
+++ b/src/include/duckdb/function/partition_stats.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/common/optional_idx.hpp"
 
 namespace duckdb {
 


### PR DESCRIPTION
Address #19801 