### PR TITLE
Bump: ducklake, mysql_scanner

### DIFF
--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG 77f2512a6774d51c99f9c0a165df76c5ae213a6d
+    GIT_TAG ce40b303c0dbaf474d2949988bcb93eceb215cc8
 )

--- a/.github/config/extensions/mysql_scanner.cmake
+++ b/.github/config/extensions/mysql_scanner.cmake
@@ -3,6 +3,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
             DONT_LINK
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-mysql
-            GIT_TAG 7a8c7269dcf452665e7fe05cce0f6e7cab137300
+            GIT_TAG 97e3c89a0887ecc3f16e5735fe661bc76a8cf00f
             )
 endif()


### PR DESCRIPTION
This PR bumps the following extensions:
- `ducklake` from `77f2512a67` to `ce40b303c0`
- `mysql_scanner` from `7a8c7269dc` to `97e3c89a08`
