### PR TITLE
remove large limit optimization whenever there is a filter

### DIFF
--- a/src/optimizer/late_materialization.cpp
+++ b/src/optimizer/late_materialization.cpp
@@ -432,6 +432,11 @@ bool LateMaterialization::OptimizeLargeLimit(LogicalLimit &limit, idx_t limit_va
 		}
 		current_op = *current_op.get().children[0];
 	}
+	// if there are any filters we shouldn't do large limit optimization
+	auto &get = current_op.get().Cast<LogicalGet>();
+	if (!get.table_filters.filters.empty()) {
+		return false;
+	}
 	return true;
 }
 

--- a/test/optimizer/pushdown/filters_on_limit_optimizer.test
+++ b/test/optimizer/pushdown/filters_on_limit_optimizer.test
@@ -1,0 +1,15 @@
+# name: test/optimizer/pushdown/filters_on_limit_optimizer.test
+# description: Test disabling large limit optimizations when filters are applied
+# group: [pushdown]
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+statement ok
+create table t as select range a from range(2_000_000);
+
+# Checks if the limit is applied after the filter is pushed down
+query II
+explain select * from T where a < 50 limit 100;
+----
+logical_opt	<REGEX>:.*LIMIT.*SEQ_SCAN.*


### PR DESCRIPTION
We found this issue when using the python client (because of the `.show() method propagating a LIMIT), that large limit optimizations were getting in the way of filter pushdowns. The idea is to push the filter before applying the limit whenever there is a filter. The idea is from @Mytherin, I just added a test.

**Original Optimized logical plan:**

```text
┌─────────────────────────────┐
│┌───────────────────────────┐│
││  Optimized Logical Plan   ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│         PROJECTION        │
│    ────────────────────   │
│       Expressions: a      │
│                           │
│          ~0 rows          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│       Expressions: a      │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│        Expressions:       │
│__internal_decompress_integ│
│     ral_bigint(#0, 0)     │
│             #1            │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│          ORDER_BY         │
│    ────────────────────   │
│           rowid           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│        Expressions:       │
│__internal_compress_integra│
│     l_uinteger(#0, 0)     │
│             #1            │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│      COMPARISON_JOIN      │
│    ────────────────────   │
│      Join Type: SEMI      │
│                           ├──────────────┐
│        Conditions:        │              │
│      (rowid = rowid)      │              │
└─────────────┬─────────────┘              │
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│          SEQ_SCAN         ││           LIMIT           │
│    ────────────────────   ││    ────────────────────   │
│          Table: t         ││                           │
│   Type: Sequential Scan   ││                           │
└───────────────────────────┘└─────────────┬─────────────┘
                             ┌─────────────┴─────────────┐
                             │          SEQ_SCAN         │
                             │    ────────────────────   │
                             │       Filters: a<50       │
                             │          Table: t         │
                             │   Type: Sequential Scan   │
                             │                           │
                             │       ~400,000 rows       │
                             └───────────────────────────┘
```

Logical plan after this PR:

```text
┌─────────────────────────────┐
│┌───────────────────────────┐│
││  Optimized Logical Plan   ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│         PROJECTION        │
│    ────────────────────   │
│       Expressions: a      │
│                           │
│          ~0 rows          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│           LIMIT           │
│    ────────────────────   │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│          SEQ_SCAN         │
│    ────────────────────   │
│       Filters: a<50       │
│          Table: t         │
│   Type: Sequential Scan   │
│                           │
│       ~400,000 rows       │
└───────────────────────────┘
```