### PR TITLE
Fix optimizer incorrectly remove ORDER BY clause from aggregates

### DIFF
--- a/src/execution/physical_plan/plan_aggregate.cpp
+++ b/src/execution/physical_plan/plan_aggregate.cpp
@@ -236,7 +236,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalAggregate &op) {
 	D_ASSERT(op.children.size() == 1);
 
 	reference<PhysicalOperator> plan = CreatePlan(*op.children[0]);
-	plan = ExtractAggregateExpressions(plan, op.expressions, op.groups);
+	plan = ExtractAggregateExpressions(plan, op.expressions, op.groups, op.grouping_sets);
 
 	bool can_use_simple_aggregation = true;
 	for (auto &expression : op.expressions) {
@@ -305,7 +305,8 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalAggregate &op) {
 
 PhysicalOperator &PhysicalPlanGenerator::ExtractAggregateExpressions(PhysicalOperator &child,
                                                                      vector<unique_ptr<Expression>> &aggregates,
-                                                                     vector<unique_ptr<Expression>> &groups) {
+                                                                     vector<unique_ptr<Expression>> &groups,
+                                                                     optional_ptr<vector<GroupingSet>> grouping_sets) {
 	vector<unique_ptr<Expression>> expressions;
 	vector<LogicalType> types;
 
@@ -314,7 +315,7 @@ PhysicalOperator &PhysicalPlanGenerator::ExtractAggregateExpressions(PhysicalOpe
 		auto &bound_aggr = aggr->Cast<BoundAggregateExpression>();
 		if (bound_aggr.order_bys) {
 			// sorted aggregate!
-			FunctionBinder::BindSortedAggregate(context, bound_aggr, groups);
+			FunctionBinder::BindSortedAggregate(context, bound_aggr, groups, grouping_sets);
 		}
 	}
 	for (auto &group : groups) {

--- a/src/execution/physical_plan/plan_distinct.cpp
+++ b/src/execution/physical_plan/plan_distinct.cpp
@@ -65,7 +65,8 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalDistinct &op) {
 
 			if (ClientConfig::GetConfig(context).enable_optimizer) {
 				bool changes_made = false;
-				auto new_expr = OrderedAggregateOptimizer::Apply(context, *first_aggregate, groups, changes_made);
+				auto new_expr =
+				    OrderedAggregateOptimizer::Apply(context, *first_aggregate, groups, nullptr, changes_made);
 				if (new_expr) {
 					D_ASSERT(new_expr->return_type == first_aggregate->return_type);
 					D_ASSERT(new_expr->GetExpressionType() == ExpressionType::BOUND_AGGREGATE);
@@ -81,7 +82,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalDistinct &op) {
 		}
 	}
 
-	child = ExtractAggregateExpressions(child, aggregates, groups);
+	child = ExtractAggregateExpressions(child, aggregates, groups, nullptr);
 
 	// we add a physical hash aggregation in the plan to select the distinct groups
 	auto &group_by = Make<PhysicalHashAggregate>(context, aggregate_types, std::move(aggregates), std::move(groups),

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -677,14 +677,15 @@ struct SortedAggregateFunction {
 } // namespace
 
 void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateExpression &expr,
-                                         const vector<unique_ptr<Expression>> &groups) {
+                                         const vector<unique_ptr<Expression>> &groups,
+                                         optional_ptr<vector<GroupingSet>> grouping_sets) {
 	if (!expr.order_bys || expr.order_bys->orders.empty() || expr.children.empty()) {
 		// not a sorted aggregate: return
 		return;
 	}
 	// Remove unnecessary ORDER BY clauses and return if nothing remains
 	if (context.config.enable_optimizer) {
-		if (expr.order_bys->Simplify(groups)) {
+		if (expr.order_bys->Simplify(groups, grouping_sets)) {
 			expr.order_bys.reset();
 			return;
 		}
@@ -741,7 +742,7 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpr
 	}
 	// Remove unnecessary ORDER BY clauses and return if nothing remains
 	if (context.config.enable_optimizer) {
-		if (BoundOrderModifier::Simplify(expr.arg_orders, expr.partitions)) {
+		if (BoundOrderModifier::Simplify(expr.arg_orders, expr.partitions, nullptr)) {
 			expr.arg_orders.clear();
 			return;
 		}

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/parser/group_by_node.hpp"
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/logical_tokens.hpp"
 #include "duckdb/planner/joinside.hpp"
@@ -152,7 +153,8 @@ protected:
 	PhysicalOperator &PlanComparisonJoin(LogicalComparisonJoin &op);
 	PhysicalOperator &PlanDelimJoin(LogicalComparisonJoin &op);
 	PhysicalOperator &ExtractAggregateExpressions(PhysicalOperator &child, vector<unique_ptr<Expression>> &expressions,
-	                                              vector<unique_ptr<Expression>> &groups);
+	                                              vector<unique_ptr<Expression>> &groups,
+	                                              optional_ptr<vector<GroupingSet>> grouping_sets);
 
 private:
 	ClientContext &context;

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -70,7 +70,8 @@ public:
 	                      AggregateType aggr_type = AggregateType::NON_DISTINCT);
 
 	DUCKDB_API static void BindSortedAggregate(ClientContext &context, BoundAggregateExpression &expr,
-	                                           const vector<unique_ptr<Expression>> &groups);
+	                                           const vector<unique_ptr<Expression>> &groups,
+	                                           optional_ptr<vector<GroupingSet>> grouping_sets);
 	DUCKDB_API static void BindSortedAggregate(ClientContext &context, BoundWindowExpression &expr);
 
 	//! Cast a set of expressions to the arguments of this function

--- a/src/include/duckdb/optimizer/rule/ordered_aggregate_optimizer.hpp
+++ b/src/include/duckdb/optimizer/rule/ordered_aggregate_optimizer.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/optimizer/rule.hpp"
 #include "duckdb/parser/expression_map.hpp"
+#include "duckdb/parser/group_by_node.hpp"
 
 namespace duckdb {
 
@@ -18,7 +19,8 @@ public:
 	explicit OrderedAggregateOptimizer(ExpressionRewriter &rewriter);
 
 	static unique_ptr<Expression> Apply(ClientContext &context, BoundAggregateExpression &aggr,
-	                                    vector<unique_ptr<Expression>> &groups, bool &changes_made);
+	                                    vector<unique_ptr<Expression>> &groups,
+	                                    optional_ptr<vector<GroupingSet>> grouping_sets, bool &changes_made);
 	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
 	                             bool is_root) override;
 };

--- a/src/include/duckdb/planner/bound_result_modifier.hpp
+++ b/src/include/duckdb/planner/bound_result_modifier.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/limits.hpp"
+#include "duckdb/parser/group_by_node.hpp"
 #include "duckdb/parser/result_modifier.hpp"
 #include "duckdb/planner/bound_statement.hpp"
 #include "duckdb/planner/expression.hpp"
@@ -155,8 +156,9 @@ public:
 
 	//! Remove unneeded/duplicate order elements.
 	//! Returns true of orders is not empty.
-	static bool Simplify(vector<BoundOrderByNode> &orders, const vector<unique_ptr<Expression>> &groups);
-	bool Simplify(const vector<unique_ptr<Expression>> &groups);
+	static bool Simplify(vector<BoundOrderByNode> &orders, const vector<unique_ptr<Expression>> &groups,
+	                     optional_ptr<vector<GroupingSet>> grouping_sets);
+	bool Simplify(const vector<unique_ptr<Expression>> &groups, optional_ptr<vector<GroupingSet>> grouping_sets);
 };
 
 enum class DistinctType : uint8_t { DISTINCT = 0, DISTINCT_ON = 1 };

--- a/src/optimizer/rule/ordered_aggregate_optimizer.cpp
+++ b/src/optimizer/rule/ordered_aggregate_optimizer.cpp
@@ -17,7 +17,9 @@ OrderedAggregateOptimizer::OrderedAggregateOptimizer(ExpressionRewriter &rewrite
 }
 
 unique_ptr<Expression> OrderedAggregateOptimizer::Apply(ClientContext &context, BoundAggregateExpression &aggr,
-                                                        vector<unique_ptr<Expression>> &groups, bool &changes_made) {
+                                                        vector<unique_ptr<Expression>> &groups,
+                                                        optional_ptr<vector<GroupingSet>> grouping_sets,
+                                                        bool &changes_made) {
 	if (!aggr.order_bys) {
 		// no ORDER BYs defined
 		return nullptr;
@@ -30,7 +32,7 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(ClientContext &context, 
 	}
 
 	// Remove unnecessary ORDER BY clauses and return if nothing remains
-	if (aggr.order_bys->Simplify(groups)) {
+	if (aggr.order_bys->Simplify(groups, grouping_sets)) {
 		aggr.order_bys.reset();
 		changes_made = true;
 		return nullptr;
@@ -90,7 +92,8 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(ClientContext &context, 
 unique_ptr<Expression> OrderedAggregateOptimizer::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
                                                         bool &changes_made, bool is_root) {
 	auto &aggr = bindings[0].get().Cast<BoundAggregateExpression>();
-	return Apply(rewriter.context, aggr, op.Cast<LogicalAggregate>().groups, changes_made);
+	return Apply(rewriter.context, aggr, op.Cast<LogicalAggregate>().groups, op.Cast<LogicalAggregate>().grouping_sets,
+	             changes_made);
 }
 
 } // namespace duckdb

--- a/test/optimizer/expression_rewriter/ordered_aggregate_incorrectly_remove_order.test
+++ b/test/optimizer/expression_rewriter/ordered_aggregate_incorrectly_remove_order.test
@@ -1,0 +1,19 @@
+# name: test/optimizer/expression_rewriter/ordered_aggregate_incorrectly_remove_order.test
+# description: When there are multiple GroupingSets in aggregates, optimizer may incorrectly remove the ORDER BY clause from aggregates.
+# group: [expression_rewriter]
+
+statement ok
+CREATE TABLE t1(col1 INT, col2 INT);
+
+statement ok
+INSERT INTO t1 VALUES (2, 1), (1, 2);
+
+query I
+SELECT GROUP_CONCAT(col1 ORDER BY col1) AS c1
+FROM t1
+GROUP BY ROLLUP (col1)
+ORDER BY c1;
+----
+1
+1,2
+2


### PR DESCRIPTION
Fix [#19924 ](https://github.com/duckdb/duckdb/issues/19924)

When removing ORDER BY from aggregates, we need to check that the ORDER BY expression exists in each GroupingSet, not just whether it exists in the groups.