### PR TITLE
fix: prevent removal of ORDER BY for order sensitive aggregate functions by optimizer

### DIFF
--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -683,7 +683,8 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateE
 	}
 	// Remove unnecessary ORDER BY clauses and return if nothing remains
 	if (context.config.enable_optimizer) {
-		if (expr.order_bys->Simplify(groups)) {
+		if (expr.order_bys->Simplify(groups,
+		                             expr.function.order_dependent == AggregateOrderDependent::ORDER_DEPENDENT)) {
 			expr.order_bys.reset();
 			return;
 		}
@@ -741,7 +742,8 @@ void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundWindowExpr
 	}
 	// Remove unnecessary ORDER BY clauses and return if nothing remains
 	if (context.config.enable_optimizer) {
-		if (BoundOrderModifier::Simplify(expr.arg_orders, expr.partitions)) {
+		if (BoundOrderModifier::Simplify(expr.arg_orders, expr.partitions,
+		                                 aggregate.GetOrderDependent() == AggregateOrderDependent::ORDER_DEPENDENT)) {
 			expr.arg_orders.clear();
 			return;
 		}

--- a/src/include/duckdb/planner/bound_result_modifier.hpp
+++ b/src/include/duckdb/planner/bound_result_modifier.hpp
@@ -155,8 +155,9 @@ public:
 
 	//! Remove unneeded/duplicate order elements.
 	//! Returns true of orders is not empty.
-	static bool Simplify(vector<BoundOrderByNode> &orders, const vector<unique_ptr<Expression>> &groups);
-	bool Simplify(const vector<unique_ptr<Expression>> &groups);
+	static bool Simplify(vector<BoundOrderByNode> &orders, const vector<unique_ptr<Expression>> &groups,
+	                     bool is_order_dependent);
+	bool Simplify(const vector<unique_ptr<Expression>> &groups, bool is_order_dependent);
 };
 
 enum class DistinctType : uint8_t { DISTINCT = 0, DISTINCT_ON = 1 };

--- a/src/optimizer/rule/ordered_aggregate_optimizer.cpp
+++ b/src/optimizer/rule/ordered_aggregate_optimizer.cpp
@@ -22,15 +22,17 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(ClientContext &context, 
 		// no ORDER BYs defined
 		return nullptr;
 	}
-	if (aggr.function.GetOrderDependent() == AggregateOrderDependent::NOT_ORDER_DEPENDENT) {
-		// not an order dependent aggregate but we have an ORDER BY clause - remove it
+
+	// Remove unnecessary ORDER BY clauses and return if nothing remains
+	if (aggr.order_bys->Simplify(groups,
+	                             aggr.function.GetOrderDependent() == AggregateOrderDependent::ORDER_DEPENDENT)) {
 		aggr.order_bys.reset();
 		changes_made = true;
 		return nullptr;
 	}
 
-	// Remove unnecessary ORDER BY clauses and return if nothing remains
-	if (aggr.order_bys->Simplify(groups)) {
+	if (aggr.function.GetOrderDependent() == AggregateOrderDependent::NOT_ORDER_DEPENDENT) {
+		// not an order dependent aggregate but we have an ORDER BY clause - remove it
 		aggr.order_bys.reset();
 		changes_made = true;
 		return nullptr;

--- a/test/optimizer/ordered_aggregate.test
+++ b/test/optimizer/ordered_aggregate.test
@@ -26,11 +26,11 @@ query I nosort order_by_agg_grp
 EXPLAIN SELECT grp, FIRST(i ORDER BY i) FROM integers GROUP BY grp ORDER BY grp
 ----
 
-query I nosort order_by_agg_grp
+query I nosort order_by_agg_grp_2
 EXPLAIN SELECT grp, FIRST(i ORDER BY grp, i) FROM integers GROUP BY grp ORDER BY grp
 ----
 
-query I nosort order_by_agg_grp
+query I nosort order_by_agg_grp_2
 EXPLAIN SELECT grp, FIRST(i ORDER BY grp, i, grp DESC, i DESC) FROM integers GROUP BY grp ORDER BY grp
 ----
 
@@ -39,11 +39,11 @@ query I nosort order_by_none
 EXPLAIN SELECT grp, FIRST(i) FROM integers GROUP BY grp ORDER BY grp
 ----
 
-query I nosort order_by_none
+query I nosort order_by_none_2
 EXPLAIN SELECT grp, FIRST(i ORDER BY grp) FROM integers GROUP BY grp ORDER BY grp
 ----
 
-query I nosort order_by_none
+query I nosort order_by_none_2
 EXPLAIN SELECT grp, FIRST(i ORDER BY grp, grp DESC, grp DESC NULLS FIRST) FROM integers GROUP BY grp ORDER BY grp
 ----
 


### PR DESCRIPTION
When using an **order-dependent aggregate function**, the optimizer currently removes all `ORDER BY` clauses if they match the `GROUP BY` expressions. Normally this is safe, since `GROUP BY` expressions evaluate to a single value per group.

However, if there is **no remaining `ORDER BY`**, the aggregate may execute in parallel. For order-dependent aggregates, this changes the evaluation order—and in some cases the internal state layout—leading to incorrect or nondeterministic results.

One concrete example is a hashing aggregate that consumes rows sequentially to produce a final hash. If the rows are processed out of order or in parallel with separate hash states, the final hash value will differ.

This PR fixes the issue by extending the `Simplify()` call with a flag that indicates whether the aggregate function is order-dependent. If so, and all `ORDER BY` clauses would otherwise be removed, the optimizer now **retains the first `ORDER BY` clause** to preserve deterministic behavior.

This change addresses the issue discussed here:

https://github.com/duckdb/duckdb/issues/19892#issuecomment-3575593005