### PR TITLE
Avoid eagerly grabbing the checkpoint lock when performing inserts, instead grab a shared table lock

### DIFF
--- a/extension/tpcds/tpcds_extension.cpp
+++ b/extension/tpcds/tpcds_extension.cpp
@@ -46,7 +46,10 @@ static duckdb::unique_ptr<FunctionData> DsdgenBind(ClientContext &context, Table
 	if (input.binder) {
 		auto &catalog = Catalog::GetCatalog(context, result->catalog);
 		auto &properties = input.binder->GetStatementProperties();
-		properties.RegisterDBModify(catalog, context);
+		DatabaseModificationType modification;
+		modification |= DatabaseModificationType::CREATE_CATALOG_ENTRY;
+		modification |= DatabaseModificationType::INSERT_DATA;
+		properties.RegisterDBModify(catalog, context, modification);
 	}
 	return_types.emplace_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");

--- a/extension/tpch/tpch_extension.cpp
+++ b/extension/tpch/tpch_extension.cpp
@@ -53,7 +53,10 @@ static duckdb::unique_ptr<FunctionData> DbgenBind(ClientContext &context, TableF
 	if (input.binder) {
 		auto &catalog = Catalog::GetCatalog(context, result->catalog);
 		auto &properties = input.binder->GetStatementProperties();
-		properties.RegisterDBModify(catalog, context);
+		DatabaseModificationType modification;
+		modification |= DatabaseModificationType::CREATE_CATALOG_ENTRY;
+		modification |= DatabaseModificationType::INSERT_DATA;
+		properties.RegisterDBModify(catalog, context, modification);
 	}
 	return_types.emplace_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");

--- a/src/common/enums/statement_type.cpp
+++ b/src/common/enums/statement_type.cpp
@@ -96,7 +96,6 @@ void StatementProperties::RegisterDBModify(Catalog &catalog, ClientContext &cont
                                            DatabaseModificationType modification) {
 	auto catalog_identity = CatalogIdentity {catalog.GetOid(), catalog.GetCatalogVersion(context)};
 	auto entry = modified_databases.insert(make_pair(catalog.GetName(), ModificationInfo()));
-	;
 	if (entry.second) {
 		// new entry - set the identity
 		entry.first->second.identity = catalog_identity;

--- a/src/function/scalar/sequence/nextval.cpp
+++ b/src/function/scalar/sequence/nextval.cpp
@@ -132,7 +132,7 @@ void NextValModifiedDatabases(ClientContext &context, FunctionModifiedDatabasesI
 		return;
 	}
 	auto &seq = input.bind_data->Cast<NextvalBindData>();
-	input.properties.RegisterDBModify(seq.sequence.ParentCatalog(), context);
+	input.properties.RegisterDBModify(seq.sequence.ParentCatalog(), context, DatabaseModificationType::SEQUENCE);
 }
 
 } // namespace

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -24,6 +24,7 @@
 
 namespace duckdb {
 struct AlterInfo;
+struct ChangeOwnershipInfo;
 
 class ClientContext;
 class LogicalDependencyList;

--- a/src/include/duckdb/common/enums/database_modification_type.hpp
+++ b/src/include/duckdb/common/enums/database_modification_type.hpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/database_modification_type.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types.hpp"
+
+namespace duckdb {
+
+struct DatabaseModificationType {
+public:
+	static constexpr idx_t INSERT_DATA = 1ULL << 0ULL;
+	static constexpr idx_t DELETE_DATA = 1ULL << 1ULL;
+	static constexpr idx_t UPDATE_DATA = 1ULL << 2ULL;
+	static constexpr idx_t ALTER_TABLE = 1ULL << 3ULL;
+	static constexpr idx_t CREATE_CATALOG_ENTRY = 1ULL << 4ULL;
+	static constexpr idx_t DROP_CATALOG_ENTRY = 1ULL << 5ULL;
+	static constexpr idx_t SEQUENCE = 1ULL << 6ULL;
+	static constexpr idx_t CREATE_INDEX = 1ULL << 7ULL;
+
+	constexpr DatabaseModificationType() : value(0) {
+	}
+	constexpr DatabaseModificationType(idx_t value) : value(value) { // NOLINT : allow implicit conversion
+	}
+
+	inline constexpr DatabaseModificationType operator|(DatabaseModificationType b) const {
+		return DatabaseModificationType(value | b.value);
+	}
+	inline DatabaseModificationType &operator|=(DatabaseModificationType b) {
+		value |= b.value;
+		return *this;
+	}
+
+	bool InsertData() const {
+		return value | INSERT_DATA;
+	}
+	bool DeleteData() const {
+		return value | DELETE_DATA;
+	}
+	bool UpdateData() const {
+		return value | UPDATE_DATA;
+	}
+	bool AlterTable() const {
+		return value | ALTER_TABLE;
+	}
+	bool CreateCatalogEntry() const {
+		return value | CREATE_CATALOG_ENTRY;
+	}
+	bool DropCatalogEntry() const {
+		return value | DROP_CATALOG_ENTRY;
+	}
+	bool Sequence() const {
+		return value | SEQUENCE;
+	}
+	bool CreateIndex() const {
+		return value | CREATE_INDEX;
+	}
+
+private:
+	idx_t value;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/enums/database_modification_type.hpp
+++ b/src/include/duckdb/common/enums/database_modification_type.hpp
@@ -37,28 +37,28 @@ public:
 	}
 
 	bool InsertData() const {
-		return value | INSERT_DATA;
+		return value & INSERT_DATA;
 	}
 	bool DeleteData() const {
-		return value | DELETE_DATA;
+		return value & DELETE_DATA;
 	}
 	bool UpdateData() const {
-		return value | UPDATE_DATA;
+		return value & UPDATE_DATA;
 	}
 	bool AlterTable() const {
-		return value | ALTER_TABLE;
+		return value & ALTER_TABLE;
 	}
 	bool CreateCatalogEntry() const {
-		return value | CREATE_CATALOG_ENTRY;
+		return value & CREATE_CATALOG_ENTRY;
 	}
 	bool DropCatalogEntry() const {
-		return value | DROP_CATALOG_ENTRY;
+		return value & DROP_CATALOG_ENTRY;
 	}
 	bool Sequence() const {
-		return value | SEQUENCE;
+		return value & SEQUENCE;
 	}
 	bool CreateIndex() const {
-		return value | CREATE_INDEX;
+		return value & CREATE_INDEX;
 	}
 
 private:

--- a/src/include/duckdb/common/enums/statement_type.hpp
+++ b/src/include/duckdb/common/enums/statement_type.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/main/query_parameters.hpp"
+#include "duckdb/common/enums/database_modification_type.hpp"
 
 namespace duckdb {
 
@@ -86,10 +87,15 @@ struct StatementProperties {
 		}
 	};
 
+	struct ModificationInfo {
+		CatalogIdentity identity;
+		DatabaseModificationType modifications;
+	};
+
 	//! The set of databases this statement will read from
 	unordered_map<string, CatalogIdentity> read_databases;
 	//! The set of databases this statement will modify
-	unordered_map<string, CatalogIdentity> modified_databases;
+	unordered_map<string, ModificationInfo> modified_databases;
 	//! Whether or not the statement requires a valid transaction. Almost all statements require this, with the
 	//! exception of ROLLBACK
 	bool requires_valid_transaction;
@@ -109,8 +115,7 @@ struct StatementProperties {
 	}
 
 	void RegisterDBRead(Catalog &catalog, ClientContext &context);
-
-	void RegisterDBModify(Catalog &catalog, ClientContext &context);
+	void RegisterDBModify(Catalog &catalog, ClientContext &context, DatabaseModificationType modification);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parser_extension.hpp
+++ b/src/include/duckdb/parser/parser_extension.hpp
@@ -67,7 +67,7 @@ struct ParserExtensionPlanResult { // NOLINT: work-around bug in clang-tidy
 	//! Parameters to the function
 	vector<Value> parameters;
 	//! The set of databases that will be modified by this statement (empty for a read-only statement)
-	unordered_map<string, StatementProperties::CatalogIdentity> modified_databases;
+	unordered_map<string, StatementProperties::ModificationInfo> modified_databases;
 	//! Whether or not the statement requires a valid transaction to be executed
 	bool requires_valid_transaction = true;
 	//! What type of result set the statement returns

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -70,7 +70,7 @@ struct CopyInfo;
 struct CopyOption;
 struct BoundSetOpChild;
 struct BoundCTEData;
-
+enum class CopyToType : uint8_t;
 template <class T, class INDEX_TYPE>
 class IndexVector;
 

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -27,6 +27,7 @@ class TableCatalogEntry;
 template <class T>
 struct SegmentNode;
 class RowGroupSegmentTree;
+class CheckpointLock;
 
 struct TableAppendState;
 
@@ -65,6 +66,7 @@ struct TableAppendState {
 
 	RowGroupAppendState row_group_append_state;
 	unique_lock<mutex> append_lock;
+	shared_ptr<CheckpointLock> table_lock;
 	row_t row_start;
 	row_t current_row;
 	//! The total number of rows appended by the append operation

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -51,7 +51,7 @@ public:
 	void PushCatalogEntry(CatalogEntry &entry, data_ptr_t extra_data, idx_t extra_data_size);
 	void PushAttach(AttachedDatabase &db);
 
-	void SetReadWrite() override;
+	void SetModifications(DatabaseModificationType type) override;
 
 	bool ShouldWriteToWAL(AttachedDatabase &db);
 	ErrorData WriteToWAL(ClientContext &context, AttachedDatabase &db,

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -63,6 +63,8 @@ public:
 
 	//! Obtains a shared lock to the checkpoint lock
 	unique_ptr<StorageLockKey> SharedCheckpointLock();
+	//! Try to obtain an exclusive checkpoint lock
+	unique_ptr<StorageLockKey> TryGetCheckpointLock();
 	unique_ptr<StorageLockKey> TryUpgradeCheckpointLock(StorageLockKey &lock);
 
 	//! Returns the current version of the catalog (incremented whenever anything changes, not stored between restarts)

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -21,6 +21,7 @@
 namespace duckdb {
 class AttachedDatabase;
 class ClientContext;
+struct DatabaseModificationType;
 class Transaction;
 
 enum class TransactionState { UNCOMMITTED, COMMITTED, ROLLED_BACK };

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -68,7 +68,7 @@ public:
 
 	void SetReadOnly();
 	bool IsReadOnly() const;
-	void ModifyDatabase(AttachedDatabase &db);
+	void ModifyDatabase(AttachedDatabase &db, DatabaseModificationType modification);
 	optional_ptr<AttachedDatabase> ModifiedDatabase() {
 		return modified_database;
 	}

--- a/src/include/duckdb/transaction/transaction.hpp
+++ b/src/include/duckdb/transaction/transaction.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/atomic.hpp"
 
 namespace duckdb {
+class Catalog;
 class SequenceCatalogEntry;
 class SchemaCatalogEntry;
 
@@ -33,6 +34,7 @@ class ChunkVectorInfo;
 
 struct DeleteInfo;
 struct UpdateInfo;
+struct DatabaseModificationType;
 
 //! The transaction object holds information about a currently running or past
 //! transaction
@@ -57,6 +59,8 @@ public:
 	DUCKDB_API bool IsReadOnly();
 	//! Promotes the transaction to a read-write transaction
 	DUCKDB_API virtual void SetReadWrite();
+	//! Sets the database modifications that are planned to be performed in this transaction
+	DUCKDB_API virtual void SetModifications(DatabaseModificationType type);
 
 	virtual bool IsDuckTransaction() const {
 		return false;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -511,7 +511,7 @@ void ClientContext::CheckIfPreparedStatementIsExecutable(PreparedStatementData &
 			    "Cannot execute statement of type \"%s\" on database \"%s\" which is attached in read-only mode!",
 			    StatementTypeToString(statement.statement_type), modified_database));
 		}
-		meta_transaction.ModifyDatabase(*entry);
+		meta_transaction.ModifyDatabase(*entry, it.second.modifications);
 	}
 }
 

--- a/src/main/prepared_statement_data.cpp
+++ b/src/main/prepared_statement_data.cpp
@@ -71,7 +71,7 @@ bool PreparedStatementData::RequireRebind(ClientContext &context,
 		}
 	}
 	for (auto &it : properties.modified_databases) {
-		if (!CheckCatalogIdentity(context, it.first, it.second)) {
+		if (!CheckCatalogIdentity(context, it.first, it.second.identity)) {
 			return true;
 		}
 	}

--- a/src/planner/binder/statement/bind_copy_database.cpp
+++ b/src/planner/binder/statement/bind_copy_database.cpp
@@ -126,7 +126,11 @@ BoundStatement Binder::Bind(CopyDatabaseStatement &stmt) {
 	auto &properties = GetStatementProperties();
 	properties.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
 	properties.return_type = StatementReturnType::NOTHING;
-	properties.RegisterDBModify(target_catalog, context);
+
+	DatabaseModificationType modification;
+	modification |= DatabaseModificationType::INSERT_DATA;
+	modification |= DatabaseModificationType::CREATE_CATALOG_ENTRY;
+	properties.RegisterDBModify(target_catalog, context, modification);
 	return result;
 }
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -136,7 +136,7 @@ SchemaCatalogEntry &Binder::BindSchema(CreateInfo &info) {
 	info.schema = schema_obj.name;
 	if (!info.temporary) {
 		auto &properties = GetStatementProperties();
-		properties.RegisterDBModify(schema_obj.catalog, context);
+		properties.RegisterDBModify(schema_obj.catalog, context, DatabaseModificationType::CREATE_CATALOG_ENTRY);
 	}
 	return schema_obj;
 }
@@ -505,7 +505,8 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 	case CatalogType::SCHEMA_ENTRY: {
 		auto &base = stmt.info->Cast<CreateInfo>();
 		auto catalog = BindCatalog(base.catalog);
-		properties.RegisterDBModify(Catalog::GetCatalog(context, catalog), context);
+		properties.RegisterDBModify(Catalog::GetCatalog(context, catalog), context,
+		                            DatabaseModificationType::CREATE_CATALOG_ENTRY);
 		result.plan = make_uniq<LogicalCreate>(LogicalOperatorType::LOGICAL_CREATE_SCHEMA, std::move(stmt.info));
 		break;
 	}
@@ -558,7 +559,7 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 		if (table.temporary) {
 			stmt.info->temporary = true;
 		}
-		properties.RegisterDBModify(table.catalog, context);
+		properties.RegisterDBModify(table.catalog, context, DatabaseModificationType::CREATE_INDEX);
 		result.plan = table.catalog.BindCreateIndex(*this, stmt, table, std::move(plan));
 		break;
 	}

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -26,7 +26,7 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 	if (!table.temporary) {
 		// delete from persistent table: not read only!
 		auto &properties = GetStatementProperties();
-		properties.RegisterDBModify(table.catalog, context);
+		properties.RegisterDBModify(table.catalog, context, DatabaseModificationType::DELETE_DATA);
 	}
 
 	// plan any tables from the various using clauses

--- a/src/planner/binder/statement/bind_drop.cpp
+++ b/src/planner/binder/statement/bind_drop.cpp
@@ -23,7 +23,7 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 	case CatalogType::SCHEMA_ENTRY: {
 		// dropping a schema is never read-only because there are no temporary schemas
 		auto &catalog = Catalog::GetCatalog(context, stmt.info->catalog);
-		properties.RegisterDBModify(catalog, context);
+		properties.RegisterDBModify(catalog, context, DatabaseModificationType::DROP_CATALOG_ENTRY);
 		break;
 	}
 	case CatalogType::VIEW_ENTRY:
@@ -76,7 +76,7 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 		stmt.info->catalog = entry->ParentCatalog().GetName();
 		if (!entry->temporary) {
 			// we can only drop temporary schema entries in read-only mode
-			properties.RegisterDBModify(entry->ParentCatalog(), context);
+			properties.RegisterDBModify(entry->ParentCatalog(), context, DatabaseModificationType::DROP_CATALOG_ENTRY);
 		}
 		stmt.info->schema = entry->ParentSchema().name;
 		break;

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -514,7 +514,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 	if (!table.temporary) {
 		// inserting into a non-temporary table: alters underlying database
 		auto &properties = GetStatementProperties();
-		properties.RegisterDBModify(table.catalog, context);
+		properties.RegisterDBModify(table.catalog, context, DatabaseModificationType::INSERT_DATA);
 	}
 
 	auto insert = make_uniq<LogicalInsert>(table, GenerateTableIndex());

--- a/src/planner/binder/statement/bind_simple.cpp
+++ b/src/planner/binder/statement/bind_simple.cpp
@@ -81,7 +81,7 @@ BoundStatement Binder::Bind(AlterStatement &stmt) {
 	if (stmt.info->type == AlterType::ALTER_DATABASE) {
 		auto &properties = GetStatementProperties();
 		properties.return_type = StatementReturnType::NOTHING;
-		properties.RegisterDBModify(Catalog::GetSystemCatalog(context), context);
+		properties.RegisterDBModify(Catalog::GetSystemCatalog(context), context, DatabaseModificationType::ALTER_TABLE);
 		result.plan = make_uniq<LogicalSimple>(LogicalOperatorType::LOGICAL_ALTER, std::move(stmt.info));
 		return result;
 	}
@@ -114,7 +114,7 @@ BoundStatement Binder::Bind(AlterStatement &stmt) {
 	}
 	if (!entry->temporary) {
 		// We can only alter temporary tables and views in read-only mode.
-		properties.RegisterDBModify(catalog, context);
+		properties.RegisterDBModify(catalog, context, DatabaseModificationType::ALTER_TABLE);
 	}
 	stmt.info->catalog = catalog.GetName();
 	stmt.info->schema = entry->ParentSchema().name;

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -135,7 +135,7 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 	if (!table.temporary) {
 		// update of persistent table: not read only!
 		auto &properties = GetStatementProperties();
-		properties.RegisterDBModify(table.catalog, context);
+		properties.RegisterDBModify(table.catalog, context, DatabaseModificationType::UPDATE_DATA);
 	}
 	auto update = make_uniq<LogicalUpdate>(table);
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1020,6 +1020,7 @@ void DataTable::InitializeAppend(DuckTransaction &transaction, TableAppendState 
 	if (!state.append_lock) {
 		throw InternalException("DataTable::AppendLock should be called before DataTable::InitializeAppend");
 	}
+	state.table_lock = transaction.SharedLockTable(*info);
 	row_groups->InitializeAppend(transaction, state);
 }
 
@@ -1132,6 +1133,7 @@ void DataTable::RevertAppendInternal(idx_t start_row) {
 
 void DataTable::RevertAppend(DuckTransaction &transaction, idx_t start_row, idx_t count) {
 	lock_guard<mutex> lock(append_lock);
+	auto table_lock = transaction.SharedLockTable(*info);
 
 	// revert any appends to indexes
 	if (!info->indexes.Empty()) {

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -533,6 +533,11 @@ void ColumnData::RevertAppend(row_t new_count_p) {
 	if (segment->GetRowStart() == new_count) {
 		// we are truncating exactly this segment - erase it entirely
 		data.EraseSegments(l, segment_index);
+		if (segment_index > 0) {
+			// if we have a previous segment, we need to update the next pointer
+			auto previous_segment = data.GetSegmentByIndex(l, UnsafeNumericCast<int64_t>(segment_index - 1));
+			previous_segment->SetNext(nullptr);
+		}
 	} else {
 		// we need to truncate within the segment
 		// remove any segments AFTER this segment: they should be deleted entirely

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -561,6 +561,12 @@ void RowGroupCollection::RevertAppendInternal(idx_t start_row) {
 	if (segment.GetRowStart() == start_row) {
 		// we are truncating exactly this row group - erase it entirely
 		row_groups->EraseSegments(l, segment_index);
+
+		if (segment_index > 0) {
+			// if we have a previous segment, we need to update the next pointer
+			auto previous_segment = row_groups->GetSegmentByIndex(l, UnsafeNumericCast<int64_t>(segment_index - 1));
+			previous_segment->SetNext(nullptr);
+		}
 	} else {
 		// we need to truncate within a row group
 		// remove any segments AFTER this segment: they should be deleted entirely

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -289,7 +289,7 @@ unique_ptr<WriteAheadLog> WriteAheadLog::ReplayInternal(QueryContext context, At
 	}
 
 	con.BeginTransaction();
-	MetaTransaction::Get(*con.context).ModifyDatabase(database);
+	MetaTransaction::Get(*con.context).ModifyDatabase(database, DatabaseModificationType());
 
 	auto &config = DBConfig::GetConfig(database.GetDatabase());
 	// first deserialize the WAL to look for a checkpoint flag
@@ -368,7 +368,7 @@ unique_ptr<WriteAheadLog> WriteAheadLog::ReplayInternal(QueryContext context, At
 					break;
 				}
 				con.BeginTransaction();
-				MetaTransaction::Get(*con.context).ModifyDatabase(database);
+				MetaTransaction::Get(*con.context).ModifyDatabase(database, DatabaseModificationType());
 			}
 		}
 	} catch (std::exception &ex) { // LCOV_EXCL_START

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -296,7 +296,7 @@ void DuckTransaction::SetModifications(DatabaseModificationType type) {
 		// already have a write lock
 		return;
 	}
-	bool require_write_lock = true;
+	bool require_write_lock = false;
 	require_write_lock = require_write_lock || type.DeleteData();
 	require_write_lock = require_write_lock || type.UpdateData();
 	require_write_lock = require_write_lock || type.AlterTable();
@@ -313,9 +313,10 @@ void DuckTransaction::SetModifications(DatabaseModificationType type) {
 
 unique_ptr<StorageLockKey> DuckTransaction::TryGetCheckpointLock() {
 	if (!write_lock) {
-		throw InternalException("TryUpgradeCheckpointLock - but thread has no shared lock!?");
+		return transaction_manager.TryGetCheckpointLock();
+	} else {
+		return transaction_manager.TryUpgradeCheckpointLock(*write_lock);
 	}
-	return transaction_manager.TryUpgradeCheckpointLock(*write_lock);
 }
 
 shared_ptr<CheckpointLock> DuckTransaction::SharedLockTable(DataTableInfo &info) {

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -229,6 +229,10 @@ unique_ptr<StorageLockKey> DuckTransactionManager::TryUpgradeCheckpointLock(Stor
 	return checkpoint_lock.TryUpgradeCheckpointLock(lock);
 }
 
+unique_ptr<StorageLockKey> DuckTransactionManager::TryGetCheckpointLock() {
+	return checkpoint_lock.TryGetExclusiveLock();
+}
+
 transaction_t DuckTransactionManager::GetCommitTimestamp() {
 	auto commit_ts = current_start_timestamp++;
 	last_commit = commit_ts;
@@ -258,14 +262,6 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		// if we are committing changes and we are not checkpointing, we need to write to the WAL
 		// since WAL writes can take a long time - we grab the WAL lock here and unlock the transaction lock
 		// read-only transactions can bypass this branch and start/commit while the WAL write is happening
-		if (!transaction.HasWriteLock()) {
-			// sanity check - this transaction should have a write lock
-			// the write lock prevents other transactions from checkpointing until this transaction is fully finished
-			// if we do not hold the write lock here, other transactions can bypass this branch by auto-checkpoint
-			// this would lead to a checkpoint WHILE this thread is writing to the WAL
-			// this should never happen
-			throw InternalException("Transaction writing to WAL does not have the write lock");
-		}
 		// unlock the transaction lock while we write to the WAL
 		t_lock.unlock();
 		// grab the WAL lock and hold it until the entire commit is finished

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -263,13 +263,13 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		// since WAL writes can take a long time - we grab the WAL lock here and unlock the transaction lock
 		// read-only transactions can bypass this branch and start/commit while the WAL write is happening
 		// unlock the transaction lock while we write to the WAL
+		t_lock.unlock();
 		unique_ptr<StorageLockKey> wal_checkpoint_lock;
-		if (!transaction.HasWriteLock()) {
+		if (!lock && !transaction.HasWriteLock()) {
 			// if this transaction does not have the checkpoint lock we need to grab it
 			// otherwise another transaction can instantiate a checkpoint while we are writing to the WAL
 			wal_checkpoint_lock = SharedCheckpointLock();
 		}
-		t_lock.unlock();
 		// grab the WAL lock and hold it until the entire commit is finished
 		held_wal_lock = make_uniq<lock_guard<mutex>>(wal_lock);
 

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -226,7 +226,7 @@ AttachedDatabase &MetaTransaction::UseDatabase(shared_ptr<AttachedDatabase> &dat
 	return db_ref;
 }
 
-void MetaTransaction::ModifyDatabase(AttachedDatabase &db) {
+void MetaTransaction::ModifyDatabase(AttachedDatabase &db, DatabaseModificationType modification) {
 	if (IsReadOnly()) {
 		throw TransactionException("Cannot write to database \"%s\" - transaction is launched in read-only mode",
 		                           db.GetName());
@@ -235,6 +235,7 @@ void MetaTransaction::ModifyDatabase(AttachedDatabase &db) {
 	if (transaction.IsReadOnly()) {
 		transaction.SetReadWrite();
 	}
+	transaction.SetModifications(modification);
 	if (db.IsSystem() || db.IsTemporary()) {
 		// we can always modify the system and temp databases
 		return;

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -21,4 +21,7 @@ void Transaction::SetReadWrite() {
 	is_read_only = false;
 }
 
+void Transaction::SetModifications(DatabaseModificationType type) {
+}
+
 } // namespace duckdb

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -278,7 +278,7 @@ TEST_CASE("Logical types with aliases", "[capi]") {
 	auto &catalog_name = DatabaseManager::GetDefaultDatabase(*connection->context);
 	auto &transaction = MetaTransaction::Get(*connection->context);
 	auto &catalog = Catalog::GetCatalog(*connection->context, catalog_name);
-	transaction.ModifyDatabase(catalog.GetAttached());
+	transaction.ModifyDatabase(catalog.GetAttached(), DatabaseModificationType::CREATE_CATALOG_ENTRY);
 	catalog.CreateType(*connection->context, info);
 
 	connection->Commit();

--- a/test/sql/storage/checkpoint/checkpoint_with_outstanding_insertions.test
+++ b/test/sql/storage/checkpoint/checkpoint_with_outstanding_insertions.test
@@ -1,0 +1,52 @@
+# name: test/sql/storage/checkpoint/checkpoint_with_outstanding_insertions.test
+# description: Test checkpoint with a transaction that needs to read old data
+# group: [checkpoint]
+
+load __TEST_DIR__/insert_checkpoint.db
+
+statement ok
+create or replace table z(id integer);
+
+statement ok
+insert into z from range(200_000);
+
+statement ok
+set checkpoint_threshold='1TB'
+
+statement ok
+set immediate_transaction_mode=true
+
+statement ok con1
+begin
+
+statement ok con1
+insert into z from range(200_000, 400_000)
+
+statement ok con2
+checkpoint
+
+query II con1
+select min(id), max(id) from z;
+----
+0	399999
+
+query II con2
+select min(id), max(id) from z;
+----
+0	199999
+
+statement ok con1
+commit
+
+query II
+select min(id), max(id) from z;
+----
+0	399999
+
+restart
+
+query II
+select min(id), max(id) from z;
+----
+0	399999
+


### PR DESCRIPTION
Currently whenever a database is intended to be modified using a statement such as `INSERT`, `DELETE`, etc we eagerly grab the `SharedCheckpointLock` and store in the `DuckTransaction`. As long as that transaction lives, we can then not initiate a checkpoint. This can keep on applying also after the transaction has concluded as the lock is only released when the transaction is cleaned up, which only happens when there are no active transactions that depend on the data stored within that transaction anymore. If there are readers that need an old snapshot of the data for a long time, these transactions might not be cleaned up for a long time as well.

This has two negative effects in concurrent scenarios with several writers, or even a single writer and a single (separate) checkpointer:
* Checkpoints can fail to be performed, as the checkpoint lock cannot be grabbed. As a result, we might not checkpoint for extended periods of time, leading to the WAL file continuously growing, data not being compressed / vacuumed, etc.
* When a checkpoint is performed (either forcibly through `FORCE CHECKPOINT`, or when the lock manages to be grabbed) writers must wait for the checkpoint to complete, preventing them from continuing operations and potentially introducing large latency spikes.

This PR makes an initial move towards grabbing the checkpoint lock less and allowing more operations to happen while a checkpoint is performed (and vice versa - allowing a checkpoint to start in more scenarios). This PR removes the eager grabbing of the `SharedCheckpointLock` for appends (through e.g. an `INSERT INTO` statement). This is accomplished by passing the intended database modification to `RegisterDBModify`.

If the modification is an append, we allow it to proceed without grabbing the shared checkpoint lock. Instead, when performing an append on a table, we grab a shared lock to the table (that was previously used for scans). Checkpoints can then still start, but need to wait for an append to finish on a table level (and vice versa).

Note that this is still rather limited - because we still grab the `SharedCheckpointLock` when writing to the WAL. That means that we still cannot *commit* transactions that have inserted data while a checkpoint is happening (and cannot start a checkpoint while a transaction that inserted is writing to the WAL). I plan to tackle that in a follow-up PR.
