### PR TITLE
Parquet reader: allow Prefetch to be scheduled in parallel (via TaskExecutor)

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -247,7 +247,8 @@ void ColumnReader::PrepareRead(optional_ptr<const TableFilter> filter, optional_
 		// 256 bytes should cover almost all headers (unless it's a V2 header with really LONG string statistics)
 		static constexpr idx_t ASSUMED_HEADER_SIZE = 256;
 		const auto prefetch_size = MinValue(trans.GetSize() - trans.GetLocation(), ASSUMED_HEADER_SIZE);
-		trans.Prefetch(trans.GetLocation(), prefetch_size);
+		auto res = trans.Prefetch(trans.GetLocation(), prefetch_size);
+		res.ExecuteTasksSynchronously();
 		reader.Read(page_hdr, *protocol);
 		trans.ClearPrefetch();
 	}

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -606,7 +606,8 @@ bool ParquetStatisticsUtils::BloomFilterExcludes(const TableFilter &duckdb_filte
 	auto &transport = reinterpret_cast<ThriftFileTransport &>(*file_proto.getTransport());
 	transport.SetLocation(column_meta_data.bloom_filter_offset);
 	if (column_meta_data.__isset.bloom_filter_length && column_meta_data.bloom_filter_length > 0) {
-		transport.Prefetch(column_meta_data.bloom_filter_offset, column_meta_data.bloom_filter_length);
+		transport.Prefetch(column_meta_data.bloom_filter_offset, column_meta_data.bloom_filter_length)
+		    .ExecuteTasksSynchronously();
 	}
 
 	duckdb_parquet::BloomFilterHeader filter_header;


### PR DESCRIPTION
Incremental step on top of infrastructure added previously in https://github.com/duckdb/duckdb/pull/19422 and partially in https://github.com/duckdb/duckdb/pull/19566

This allows for some codepaths of ParquetReader to create a task for each range to be prefetched, and have those be executed in parallel, with the main task restarting afterward.

This is most visible when doing query like:
```sql
SELECT column_2, column_5, column_12 FROM 'https://some-endpoint.com/my_file.parquet' LIMIT 1000000;
```
where one need to fetch only certain columns that are spaced apart AND row_group level parallelism potential can't be unlocked.

In this case before this PR a single task would do different sub-tasks like:
```
---preparatory_work----fetch_#2-----fetch_#5---fetch_#12----final_work----|
```
and afterward:
```
---preparatory_work--|
                      --fetch_#2----|
                      -fetch_#5-|
                      --fetch_#12--|
                                     --final_work----|
```
Where the subtasks are split (but with dependency on each other) and handled by the DuckDB own TaskExecutor. Note that the same logical thread might end up being scheduled for doing all the work (say system is already busy), but splitting subtasks into proper task is at very least more scheduling friendly.

Note that for the call-sites with a pattern like:
```c++
		auto res = transport.Prefetch(file_size - prefetch_size, prefetch_size);
		res.ExecuteTasksSynchronously();
```
That means Task are still executed as sub-tasks (and doing so sequentially). Only when the tasks (packaged as `AsyncResult` are returned up to the PhysicalTableScan they are there and then scheduled.

Main item that could use an extra pair of reviewer eyes: lifetime management of the referenced objects, especially in case of query cancellation.