### PR TITLE
Bump: spatial

### DIFF
--- a/.github/config/extensions/spatial.cmake
+++ b/.github/config/extensions/spatial.cmake
@@ -3,7 +3,7 @@ if (${BUILD_COMPLETE_EXTENSION_SET})
 duckdb_extension_load(spatial
     DONT_LINK LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-spatial
-    GIT_TAG d83faf88cd7e4d4cca4edd056a530382c5018654
+    GIT_TAG 91a6649a3f92217201a9e7a15b11879e3e0ae358
     INCLUDE_DIR src/spatial
     TEST_DIR test/sql
     )


### PR DESCRIPTION
This PR bumps the following extensions:
- `spatial` from `d83faf88cd` to `91a6649a3f`
