### PR TITLE
Fix correlated column binding in ConstantBinder

### DIFF
--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/stack_checker.hpp"
 #include "duckdb/common/error_data.hpp"
+#include "duckdb/common/exception/binder_exception.hpp"
 #include "duckdb/parser/expression/bound_expression.hpp"
 #include "duckdb/parser/expression/lambdaref_expression.hpp"
 #include "duckdb/parser/parsed_expression.hpp"

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -10,9 +10,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/stack_checker.hpp"
-#include "duckdb/common/exception/binder_exception.hpp"
 #include "duckdb/common/error_data.hpp"
-#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/parser/expression/bound_expression.hpp"
 #include "duckdb/parser/expression/lambdaref_expression.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
@@ -71,9 +69,12 @@ class ExpressionBinder {
 	friend class StackChecker<ExpressionBinder>;
 
 public:
-	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false,
-	                 bool bind_correlated_columns_p = true);
+	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false);
 	virtual ~ExpressionBinder();
+
+	virtual bool BindsUnfoldableExpressions() const {
+		return true;
+	}
 
 	//! The target type that should result from the binder. If the result is not of this type, a cast to this type will
 	//! be added. Defaults to INVALID.
@@ -81,7 +82,6 @@ public:
 
 	optional_ptr<DummyBinding> macro_binding;
 	optional_ptr<vector<DummyBinding>> lambda_bindings;
-	const bool bind_correlated_columns;
 
 public:
 	unique_ptr<Expression> Bind(unique_ptr<ParsedExpression> &expr, optional_ptr<LogicalType> result_type = nullptr,

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -81,7 +81,7 @@ public:
 
 	optional_ptr<DummyBinding> macro_binding;
 	optional_ptr<vector<DummyBinding>> lambda_bindings;
-	const bool bind_correlated_columns = true;
+	const bool bind_correlated_columns;
 
 public:
 	unique_ptr<Expression> Bind(unique_ptr<ParsedExpression> &expr, optional_ptr<LogicalType> result_type = nullptr,

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -71,7 +71,8 @@ class ExpressionBinder {
 	friend class StackChecker<ExpressionBinder>;
 
 public:
-	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false);
+	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false,
+	                 bool bind_correlated_columns_p = true);
 	virtual ~ExpressionBinder();
 
 	//! The target type that should result from the binder. If the result is not of this type, a cast to this type will
@@ -80,6 +81,7 @@ public:
 
 	optional_ptr<DummyBinding> macro_binding;
 	optional_ptr<vector<DummyBinding>> lambda_bindings;
+	const bool bind_correlated_columns = true;
 
 public:
 	unique_ptr<Expression> Bind(unique_ptr<ParsedExpression> &expr, optional_ptr<LogicalType> result_type = nullptr,

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -73,10 +73,6 @@ public:
 	ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder = false);
 	virtual ~ExpressionBinder();
 
-	virtual bool BindsUnfoldableExpressions() const {
-		return true;
-	}
-
 	//! The target type that should result from the binder. If the result is not of this type, a cast to this type will
 	//! be added. Defaults to INVALID.
 	LogicalType target_type;

--- a/src/include/duckdb/planner/expression_binder/constant_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/constant_binder.hpp
@@ -17,10 +17,6 @@ class ConstantBinder : public ExpressionBinder {
 public:
 	ConstantBinder(Binder &binder, ClientContext &context, string clause);
 
-	bool BindsUnfoldableExpressions() const override {
-		return false;
-	}
-
 	//! The location where this binder is used, used for error messages
 	string clause;
 

--- a/src/include/duckdb/planner/expression_binder/constant_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/constant_binder.hpp
@@ -17,6 +17,10 @@ class ConstantBinder : public ExpressionBinder {
 public:
 	ConstantBinder(Binder &binder, ClientContext &context, string clause);
 
+	bool BindsUnfoldableExpressions() const override {
+		return false;
+	}
+
 	//! The location where this binder is used, used for error messages
 	string clause;
 

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -319,10 +319,6 @@ unique_ptr<Expression> ExpressionBinder::Bind(unique_ptr<ParsedExpression> &expr
 	// bind the main expression
 	auto error_msg = Bind(expr, 0, root_expression);
 	if (error_msg.HasError()) {
-		if (!BindsUnfoldableExpressions()) {
-			// We are in a constant binder and therefore do not try to bind the correlated column
-			error_msg.Throw();
-		}
 		// Try binding the correlated column. If binding the correlated column
 		// has error messages, those should be propagated up. So for the test case
 		// having subquery failed to bind:14 the real error message should be something like

--- a/src/planner/expression_binder/constant_binder.cpp
+++ b/src/planner/expression_binder/constant_binder.cpp
@@ -1,10 +1,12 @@
 #include "duckdb/planner/expression_binder/constant_binder.hpp"
+
+#include "duckdb/common/exception/binder_exception.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 
 namespace duckdb {
 
 ConstantBinder::ConstantBinder(Binder &binder, ClientContext &context, string clause)
-    : ExpressionBinder(binder, context, false, false), clause(std::move(clause)) {
+    : ExpressionBinder(binder, context), clause(std::move(clause)) {
 }
 
 BindResult ConstantBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {

--- a/src/planner/expression_binder/constant_binder.cpp
+++ b/src/planner/expression_binder/constant_binder.cpp
@@ -1,6 +1,4 @@
 #include "duckdb/planner/expression_binder/constant_binder.hpp"
-
-#include "duckdb/common/exception/binder_exception.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 
 namespace duckdb {

--- a/src/planner/expression_binder/constant_binder.cpp
+++ b/src/planner/expression_binder/constant_binder.cpp
@@ -19,7 +19,7 @@ BindResult ConstantBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr
 				return BindExpression(expr_ptr, depth, root_expression);
 			}
 		}
-		return BindUnsupportedExpression(expr, depth, clause + " cannot contain column names");
+		throw BinderException::Unsupported(expr, clause + " cannot contain column names");
 	}
 	case ExpressionClass::SUBQUERY:
 		throw BinderException(clause + " cannot contain subqueries");

--- a/src/planner/expression_binder/constant_binder.cpp
+++ b/src/planner/expression_binder/constant_binder.cpp
@@ -4,7 +4,7 @@
 namespace duckdb {
 
 ConstantBinder::ConstantBinder(Binder &binder, ClientContext &context, string clause)
-    : ExpressionBinder(binder, context), clause(std::move(clause)) {
+    : ExpressionBinder(binder, context, false, false), clause(std::move(clause)) {
 }
 
 BindResult ConstantBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {

--- a/test/sql/error/correlated_at_clause.test
+++ b/test/sql/error/correlated_at_clause.test
@@ -1,0 +1,13 @@
+# name: test/sql/error/correlated_at_clause.test
+# description: Reference a column from an outer subquery within an at clause
+# group: [error]
+
+statement ok
+CREATE TABLE t (i VARCHAR)
+
+# See https://github.com/duckdb/duckdb/issues/16826
+statement error
+FROM t, t AT (VERSION => i)
+----
+<REGEX>:Binder Error.*AT clause cannot contain column names.*
+


### PR DESCRIPTION
Prevent `ConstantBinder` from trying to bind correlated columns

Fixes #16826
Fixes duckdblabs/duckdb-internal#4507