### PR TITLE
Null assertion on denormalized_table argument

### DIFF
--- a/src/function/table/system/duckdb_log.cpp
+++ b/src/function/table/system/duckdb_log.cpp
@@ -62,6 +62,9 @@ unique_ptr<TableRef> DuckDBLogBindReplace(ClientContext &context, TableFunctionB
 	bool denormalized_table = false;
 	auto denormalized_table_setting = input.named_parameters.find("denormalized_table");
 	if (denormalized_table_setting != input.named_parameters.end()) {
+		if (denormalized_table_setting->second.IsNull()) {
+			throw InvalidInputException("denormalized_table cannot be NULL");
+		}
 		denormalized_table = denormalized_table_setting->second.GetValue<bool>();
 	}
 

--- a/test/fuzzer/duckfuzz/logger_null.test
+++ b/test/fuzzer/duckfuzz/logger_null.test
@@ -1,4 +1,4 @@
-# name: test/fuzzer/duckfuzz/list_zip_no_args.test
+# name: test/fuzzer/duckfuzz/logger_null.test
 # description: Test table function with named parameter that is NULL
 # group: [duckfuzz]
 

--- a/test/fuzzer/duckfuzz/logger_null.test
+++ b/test/fuzzer/duckfuzz/logger_null.test
@@ -4,6 +4,6 @@
 
 # https://github.com/duckdb/duckdb-fuzzer/issues/4206
 statement error
-SELECT 8099 FROM duckdb_logs(denormalized_table := NULL)
+FROM duckdb_logs(denormalized_table := NULL)
 ----
 Invalid Input Error: denormalized_table cannot be NULL

--- a/test/fuzzer/duckfuzz/logger_null.test
+++ b/test/fuzzer/duckfuzz/logger_null.test
@@ -1,0 +1,9 @@
+# name: test/fuzzer/duckfuzz/list_zip_no_args.test
+# description: Test table function with named parameter that is NULL
+# group: [duckfuzz]
+
+# https://github.com/duckdb/duckdb-fuzzer/issues/4206
+statement error
+SELECT 8099 FROM duckdb_logs(denormalized_table := NULL)
+----
+Invalid Input Error: denormalized_table cannot be NULL


### PR DESCRIPTION
Fix https://github.com/duckdblabs/duckdb-internal/issues/6167

First check if the value is NULL before fetching the value. 
I think this is the most appropriate behavior when encountering a NULL value here, but I am not sure. 

