### PR TITLE
fix: allow table in/out functions to indicate if they support parallelism

### DIFF
--- a/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -19,6 +19,13 @@ public:
 	TableInOutGlobalState() {
 	}
 
+	idx_t MaxThreads(idx_t source_max_threads) override {
+		if (!global_state) {
+			return source_max_threads;
+		}
+		return global_state->MaxThreads();
+	}
+
 	unique_ptr<GlobalTableFunctionState> global_state;
 };
 
@@ -69,15 +76,6 @@ void PhysicalTableInOutFunction::SetOrdinality(DataChunk &chunk, const optional_
 		constexpr idx_t step = 1;
 		chunk.data[ordinality_column_idx.GetIndex()].Sequence(static_cast<int64_t>(ordinality_idx), step, ordinality);
 	}
-}
-
-bool PhysicalTableInOutFunction::ParallelOperator() const {
-	auto &gstate = op_state->Cast<TableInOutGlobalState>();
-	if (!gstate.global_state) {
-		return true;
-	}
-
-	return gstate.global_state->MaxThreads() > 1;
 }
 
 OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,

--- a/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -71,6 +71,15 @@ void PhysicalTableInOutFunction::SetOrdinality(DataChunk &chunk, const optional_
 	}
 }
 
+bool PhysicalTableInOutFunction::ParallelOperator() const {
+	auto &gstate = op_state->Cast<TableInOutGlobalState>();
+	if (!gstate.global_state) {
+		return true;
+	}
+
+	return gstate.global_state->MaxThreads() > 1;
+}
+
 OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
                                                        GlobalOperatorState &gstate_p, OperatorState &state_p) const {
 	auto &gstate = gstate_p.Cast<TableInOutGlobalState>();

--- a/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -20,6 +20,7 @@ public:
 	}
 
 	idx_t MaxThreads(idx_t source_max_threads) override {
+		// If no state assume maximum parallelism as the source.
 		if (!global_state) {
 			return source_max_threads;
 		}

--- a/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
@@ -33,7 +33,9 @@ public:
 	OperatorFinalizeResultType FinalExecute(ExecutionContext &context, DataChunk &chunk, GlobalOperatorState &gstate,
 	                                        OperatorState &state) const override;
 
-	bool ParallelOperator() const override;
+	bool ParallelOperator() const override {
+		return true;
+	}
 
 	bool RequiresFinalExecute() const override {
 		return function.in_out_function_final;

--- a/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
@@ -33,9 +33,7 @@ public:
 	OperatorFinalizeResultType FinalExecute(ExecutionContext &context, DataChunk &chunk, GlobalOperatorState &gstate,
 	                                        OperatorState &state) const override;
 
-	bool ParallelOperator() const override {
-		return true;
-	}
+	bool ParallelOperator() const override;
 
 	bool RequiresFinalExecute() const override {
 		return function.in_out_function_final;

--- a/src/include/duckdb/execution/physical_operator_states.hpp
+++ b/src/include/duckdb/execution/physical_operator_states.hpp
@@ -63,6 +63,10 @@ public:
 		DynamicCastCheck<TARGET>(this);
 		return reinterpret_cast<const TARGET &>(*this);
 	}
+
+	virtual idx_t MaxThreads(idx_t source_max_threads) {
+		return source_max_threads;
+	}
 };
 
 class GlobalSinkState : public StateWithBlockableTasks {


### PR DESCRIPTION
As part of #19939 this PR now consults the `MaxThreads()` method to determine if the table in/out function can operate in parallel.