### PR TITLE
Unbound index binding with context

### DIFF
--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -122,7 +122,7 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 	// If there is a context available, bind indexes before serialization.
 	// This is necessary so that buffered index operations are replayed before we checkpoint, otherwise
 	// we would lose them if there was a restart after this.
-	if (context != nullptr) {
+	if (context && context->transaction.HasActiveTransaction()) {
 		info.BindIndexes(*context);
 	}
 	// FIXME: If we do not have a context, however, the unbound indexes have to be serialized to disk.

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -118,6 +118,12 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 	if (!v1_0_0_storage) {
 		options.emplace("v1_0_0_storage", v1_0_0_storage);
 	}
+
+	// If there is a context available, bind indexes before serialization.
+	if (context != nullptr) {
+		info.BindIndexes(*context);
+	}
+
 	auto index_storage_infos = info.GetIndexes().SerializeToDisk(context, options);
 
 	auto debug_verify_blocks = DBConfig::GetSetting<DebugVerifyBlocksSetting>(GetDatabase());

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -120,9 +120,12 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 	}
 
 	// If there is a context available, bind indexes before serialization.
+	// This is necessary so that buffered index operations are replayed before we checkpoint, otherwise
+	// we would lose them if there was a restart after this.
 	if (context != nullptr) {
 		info.BindIndexes(*context);
 	}
+	// FIXME: If we do not have a context, however, the unbound indexes have to be serialized to disk.
 
 	auto index_storage_infos = info.GetIndexes().SerializeToDisk(context, options);
 

--- a/test/sql/index/art/storage/test_art_wal_checkpoint_minimal.test
+++ b/test/sql/index/art/storage/test_art_wal_checkpoint_minimal.test
@@ -1,0 +1,52 @@
+# name: test/sql/index/art/storage/test_art_wal_checkpoint_minimal.test
+# description: buffered index binding on checkpoint (when context is available).
+# group: [storage]
+
+load __TEST_DIR__/test_art_wal_checkpoint_buffer_minimal.db
+
+statement ok
+SET index_scan_max_count = 1;
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+CREATE TABLE minimal_tbl(i INTEGER);
+
+statement ok
+CREATE UNIQUE INDEX idx_minimal ON minimal_tbl(i);
+
+statement ok
+INSERT INTO minimal_tbl VALUES (42);
+
+statement ok
+INSERT INTO minimal_tbl VALUES (43);
+
+statement ok
+INSERT INTO minimal_tbl VALUES (44);
+
+statement ok
+DELETE FROM minimal_tbl where i = 42
+
+restart
+
+statement ok
+CHECKPOINT;
+
+restart
+
+statement ok
+INSERT INTO minimal_tbl VALUES (42);
+
+statement error
+INSERT INTO minimal_tbl VALUES (43);
+----
+violates unique constraint
+
+statement error
+INSERT INTO minimal_tbl VALUES (44);
+----
+violates unique constraint


### PR DESCRIPTION
If we have a restart -> checkpoint -> restart, it is possible that there are buffered unbound index operations that have not been replayed, and are currently being dropped. During checkpointing we may or may not have a context. This PR fixes the scenario where there is a context + active transaction, as we can just bind the indexes before serialization to replay the buffered operations. (A separate PR is in the works for if there isn't a context, which requires serialization of unbound indexes). 

Technically the unbound index serialization PR would fix the context case as well, but this is going in as a separate PR since it is better to just bind the indexes and replay buffered operations if we have the context available, instead of serializing them to disk. 