### PR TITLE
feat: add `OperatorOrder()` to table functions to indicate ordering needs.

### DIFF
--- a/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
@@ -46,6 +46,10 @@ public:
 	//! Information for WITH ORDINALITY
 	optional_idx ordinality_idx;
 
+	OrderPreservationType OperatorOrder() const override {
+		return function.order_preservation_type;
+	}
+
 private:
 	//! The table function
 	TableFunction function;

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -61,6 +61,10 @@ public:
 
 	bool Equals(const PhysicalOperator &other) const override;
 
+	OrderPreservationType OperatorOrder() const override {
+		return function.order_preservation_type;
+	}
+
 public:
 	unique_ptr<LocalSourceState> GetLocalSourceState(ExecutionContext &context,
 	                                                 GlobalSourceState &gstate) const override;

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -61,7 +61,7 @@ public:
 
 	bool Equals(const PhysicalOperator &other) const override;
 
-	OrderPreservationType OperatorOrder() const override {
+	OrderPreservationType SourceOrder() const override {
 		return function.order_preservation_type;
 	}
 

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -20,6 +20,7 @@
 #include "duckdb/parallel/async_result.hpp"
 #include "duckdb/function/partition_stats.hpp"
 #include "duckdb/common/exception/binder_exception.hpp"
+#include "duckdb/common/enums/order_preservation_type.hpp"
 
 #include <functional>
 
@@ -468,6 +469,8 @@ public:
 	bool late_materialization;
 	//! Additional function info, passed to the bind
 	shared_ptr<TableFunctionInfo> function_info;
+	//! The order preservation type of the table function
+	OrderPreservationType order_preservation_type = OrderPreservationType::INSERTION_ORDER;
 
 	//! When to call init_global
 	//! By default init_global is called when the pipeline is ready for execution


### PR DESCRIPTION
Table in/out functions may be dependent or sensitive to the ordering of their input.  To properly indicate this add a new field to `TableFunction` which is referenced in the `SinkOrderDependent()` method of `PhysicalTableInOutFunction`.
