### PR TITLE
remove sha from artifacts

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -218,19 +218,19 @@ jobs:
       - uses: actions/download-artifact@v4
         name: Download main extensions
         with:
-          pattern: main-extensions-${{ github.sha }}*
+          pattern: main-extensions*
           path: /tmp/repository_generation/main-extensions
 
       - uses: actions/download-artifact@v4
         name: Download rust-based extensions
         with:
-          pattern: rust-based-extensions-${{ github.sha }}*
+          pattern: rust-based-extensions*
           path: /tmp/repository_generation/rust-based-extensions
 
       - uses: actions/download-artifact@v4
         name: Download external extensions
         with:
-          pattern: external-extensions-${{ github.sha }}*
+          pattern: external-extensions*
           path: /tmp/repository_generation/external-extensions
 
       - name: Print all extensions
@@ -246,7 +246,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: extension-repository-${{ github.sha }}
+          name: extension-repository
           path: |
             /tmp/merged_repository/**/*.duckdb_extension*
 
@@ -273,13 +273,13 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: extension-repository-${{ github.sha }}
+          pattern: extension-repository
           path: /tmp
 
       - name: List extensions to deploy
         shell: bash
         run: |
-          tree /tmp/extension-repository-${{ github.sha }}
+          tree /tmp/extension-repository
 
       - name: Deploy extensions
         shell: bash
@@ -291,7 +291,7 @@ jobs:
           DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
         run: |
           pip install awscli
-          ./scripts/extension-upload-repository.sh /tmp/extension-repository-${{ github.sha }}
+          ./scripts/extension-upload-repository.sh /tmp/extension-repository
 
   autoload-tests:
     name: Extension Autoloading Tests
@@ -318,13 +318,13 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: extension-repository-${{ github.sha }}
+          pattern: extension-repository
           path: /tmp
 
       - name: List extensions to test with
         shell: bash
         run: |
-          tree /tmp/extension-repository-${{ github.sha }}
+          tree /tmp/extension-repository
 
       - name: Build DuckDB
         env:
@@ -340,7 +340,7 @@ jobs:
 
       - name: Run Tests
         env:
-          LOCAL_EXTENSION_REPO: /tmp/extension-repository-${{ github.sha }}
+          LOCAL_EXTENSION_REPO: /tmp/extension-repository
         run: |
           ./build/release/test/unittest --autoloading available --skip-compiled
 
@@ -385,13 +385,13 @@ jobs:
       - uses: actions/download-artifact@v4
         name: Download extension repository artifact
         with:
-          pattern: extension-repository-${{ github.sha }}
+          pattern: extension-repository
           path: /tmp
 
       - name: Copy over local extension repository
         shell: bash
         run: |
-          cp -r /tmp/extension-repository-${{ github.sha }} build/release/repository
+          cp -r /tmp/extension-repository build/release/repository
           tree build/release/repository
           find build/release/repository -type f ! -path "build/release/repository/*/linux_amd64/*" -delete
           tree build/release/repository


### PR DESCRIPTION
fix for https://github.com/duckdblabs/duckdb-internal/issues/6712

## current situation
As per PR: [duckdb/duckdb#19881](https://github.com/duckdb/duckdb/pull/19881), the naming of the artifacts changed a bit for nightly builds.

The current situation is now as follows:

### nightly triggered extension build
branch name 'v1.4-andium' ends up in the artifact name


| Repo                            | Workflow                      | calls                         | with                                 |
|---------------------------------|-------------------------------|-------------------------------|--------------------------------------|
| duckdb-workflow-trigger  | Workflow-Trigger.yml          | InvokeCI.yml                  | "git_ref": "v1.4-andium"             |
| duckdb                   | InvokeCI.yml                  | Extensions.yml                | "git_ref": "git_ref"                 |
| duckdb                   | Extensions.yml                | _extension_distribution.yml   | "override_duckdb_version": "git_ref" |
| duckdb                   | _extension_distribution.yml   | _extension_distribution.yml   | "duckdb_version":  "override_duckdb_version" (fallback github.sha)  |
| extension-ci-tools       | _extension_distribution.yml | uses `duckdb_version` in artifact name | |


### manually triggered extension build
| Repo                            | Workflow                      | calls                         | with                                              |
|---------------------------------|-------------------------------|-------------------------------|---------------------------------------------------|
| duckdb                          | _manual_extension_deploy.yml  | _extension_distribution.yml   | "override_duckdb_version": "duckdb_ref" |
| duckdb                          | _extension_distribution.yml   | _extension_distribution.yml   | "duckdb_version":  "override_duckdb_version" (fallback github.sha)  |
| extension-ci-tools              | _extension_distribution.yml   | uses `duckdb_version` in artifact name | |


### extensions in manually triggered release build
`git_ref` is (typically) not set, so `github.sha` is used in artifact name

| Repo                            | Workflow                      | calls                         | with                                 |
|---------------------------------|-------------------------------|-------------------------------|--------------------------------------|
|                          | github cli                        | InvokeCI.yml                  | "git_ref": not set            |
| duckdb                   | InvokeCI.yml                  | Extensions.yml                | "git_ref": "git_ref"                 |
| duckdb                   | Extensions.yml                | _extension_distribution.yml   | "override_duckdb_version": "git_ref" |
| duckdb                   | _extension_distribution.yml   | _extension_distribution.yml   | "duckdb_version":  "override_duckdb_version" (fallback github.sha)  |
| extension-ci-tools       | _extension_distribution.yml | uses `duckdb_version` in artifact name | |

## analysis
For nightly builds, `"git_ref": "v1.4-andium"` ends up in the name of the extension artifacts, while the process that downloads it expects the `${{ github.sha }}` to be in the name instead.
The `${{ github.sha }}`, however is not correct, as it is the duckdb sha of CI current run, and not necessarily the duckdb sha used while building the extension.

## solution
When downloading the extensions, we no longer filter on the `${{ github.sha }}`, as it was not (always) meaningful anyway.