### PR TITLE
[Parquet] Fix prepared copy option parameter

### DIFF
--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -422,7 +422,14 @@ vector<Value> BindCopyOption(ClientContext &context, TableFunctionBinder &option
 			return result;
 		}
 	}
+	auto expr_copy = expr->Copy();
 	auto bound_expr = option_binder.Bind(expr);
+	if (!bound_expr->IsFoldable()) {
+		if (bound_expr->HasParameter()) {
+			throw ParameterNotResolvedException();
+		}
+		throw BinderException("Can't evaluate the COPY option (%s), only foldable/constant expressions are allowed", expr_copy->ToString());
+	}
 	auto val = ExpressionExecutor::EvaluateScalar(context, *bound_expr);
 	if (val.IsNull()) {
 		throw BinderException("NULL is not supported as a valid option for COPY option \"" + name + "\"");

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -422,16 +422,11 @@ vector<Value> BindCopyOption(ClientContext &context, TableFunctionBinder &option
 			return result;
 		}
 	}
-	auto expr_copy = expr->Copy();
 	auto bound_expr = option_binder.Bind(expr);
-	if (!bound_expr->IsFoldable()) {
-		if (bound_expr->HasParameter()) {
-			throw ParameterNotResolvedException();
-		}
-		throw BinderException("Can't evaluate the COPY option (%s), only foldable/constant expressions are allowed",
-		                      expr_copy->ToString());
+	if (bound_expr->HasParameter()) {
+		throw ParameterNotResolvedException();
 	}
-	auto val = ExpressionExecutor::EvaluateScalar(context, *bound_expr);
+	auto val = ExpressionExecutor::EvaluateScalar(context, *bound_expr, true);
 	if (val.IsNull()) {
 		throw BinderException("NULL is not supported as a valid option for COPY option \"" + name + "\"");
 	}

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -428,7 +428,8 @@ vector<Value> BindCopyOption(ClientContext &context, TableFunctionBinder &option
 		if (bound_expr->HasParameter()) {
 			throw ParameterNotResolvedException();
 		}
-		throw BinderException("Can't evaluate the COPY option (%s), only foldable/constant expressions are allowed", expr_copy->ToString());
+		throw BinderException("Can't evaluate the COPY option (%s), only foldable/constant expressions are allowed",
+		                      expr_copy->ToString());
 	}
 	auto val = ExpressionExecutor::EvaluateScalar(context, *bound_expr);
 	if (val.IsNull()) {

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -39,7 +39,10 @@ bool BoundFunctionExpression::IsFoldable() const {
 			}
 		}
 	}
-	return function.stability == FunctionStability::VOLATILE ? false : Expression::IsFoldable();
+	if (function.stability == FunctionStability::VOLATILE) {
+		return false;
+	}
+	return Expression::IsFoldable();
 }
 
 bool BoundFunctionExpression::CanThrow() const {

--- a/test/sql/copy/parquet/copy_option_non_foldable.test
+++ b/test/sql/copy/parquet/copy_option_non_foldable.test
@@ -3,7 +3,7 @@
 
 require parquet
 
-statement error
+statement ok
 PREPARE statement2 as COPY (
 	SELECT
 		42 AS number,
@@ -14,5 +14,11 @@ PREPARE statement2 as COPY (
 		number: random()
 	}
 );
+
+statement ok
+EXECUTE statement2;
+
+query II
+select * from '__TEST_DIR__/non_foldable_copy_option.parquet'
 ----
-Binder Error: Can't evaluate the COPY option (main.struct_pack(number := random())), only foldable/constant expressions are allowed
+42	true

--- a/test/sql/copy/parquet/copy_option_non_foldable.test
+++ b/test/sql/copy/parquet/copy_option_non_foldable.test
@@ -1,0 +1,15 @@
+require parquet
+
+statement error
+PREPARE statement2 as COPY (
+	SELECT
+		42 AS number,
+		true AS is_even
+) TO '__TEST_DIR__/non_foldable_copy_option.parquet' (
+	FORMAT parquet,
+	KV_METADATA {
+		number: random()
+	}
+);
+----
+Binder Error: Can't evaluate the COPY option (main.struct_pack(number := random())), only foldable/constant expressions are allowed

--- a/test/sql/copy/parquet/copy_option_non_foldable.test
+++ b/test/sql/copy/parquet/copy_option_non_foldable.test
@@ -1,3 +1,6 @@
+# name: test/sql/copy/parquet/copy_option_non_foldable.test
+# group: [parquet]
+
 require parquet
 
 statement error

--- a/test/sql/copy/parquet/copy_option_prepared.test
+++ b/test/sql/copy/parquet/copy_option_prepared.test
@@ -1,0 +1,21 @@
+require parquet
+
+statement ok
+PREPARE statement as COPY (
+	SELECT
+		42 AS number,
+		true AS is_even
+) TO '__TEST_DIR__/prepared_parquet_copy.parquet' (
+	FORMAT parquet,
+	KV_METADATA {
+		number: $1,
+	}
+);
+
+statement ok
+execute statement(42)
+
+query II
+select * from '__TEST_DIR__/prepared_parquet_copy.parquet';
+----
+42	true

--- a/test/sql/copy/parquet/copy_option_prepared.test
+++ b/test/sql/copy/parquet/copy_option_prepared.test
@@ -1,3 +1,6 @@
+# name: test/sql/copy/parquet/copy_option_prepared.test
+# group: [parquet]
+
 require parquet
 
 statement ok


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb/issues/19884

I've added a check to see if the expression is foldable, otherwise it can't be used in EvaluateScalar.
If it's not foldable, we'll check if it has a parameter expression and throw ParameterNotResolved if that's the case, otherwise we throw a BinderException.