### PR TITLE
[Fix] Bug in `FetchRow` after update on indexed table with `dict_fsst` compression

### DIFF
--- a/src/include/duckdb/storage/table/validity_column_data.hpp
+++ b/src/include/duckdb/storage/table/validity_column_data.hpp
@@ -23,6 +23,8 @@ public:
 public:
 	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 	void AppendData(BaseStatistics &stats, ColumnAppendState &state, UnifiedVectorFormat &vdata, idx_t count) override;
+	void UpdateWithBase(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
+	                    row_t *row_ids, idx_t update_count, ColumnData &base);
 };
 
 } // namespace duckdb

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -588,7 +588,6 @@ void ColumnData::Update(TransactionData transaction, DataTable &data_table, idx_
 	Vector base_vector(type);
 	ColumnScanState state;
 	FetchUpdateData(state, row_ids, base_vector);
-
 	UpdateInternal(transaction, data_table, column_index, update_vector, row_ids, update_count, base_vector);
 }
 

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -200,8 +200,8 @@ void StandardColumnData::FetchRow(TransactionData transaction, ColumnFetchState 
 		auto child_state = make_uniq<ColumnFetchState>();
 		state.child_states.push_back(std::move(child_state));
 	}
-	validity.FetchRow(transaction, *state.child_states[0], row_id, result, result_idx);
 	ColumnData::FetchRow(transaction, state, row_id, result, result_idx);
+	validity.FetchRow(transaction, *state.child_states[0], row_id, result, result_idx);
 }
 
 void StandardColumnData::CommitDropColumn() {

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -170,12 +170,12 @@ void StandardColumnData::UpdateColumn(TransactionData transaction, DataTable &da
                                       const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
                                       idx_t update_count, idx_t depth) {
 	if (depth >= column_path.size()) {
-		// update this column
+		// Update the column.
 		ColumnData::Update(transaction, data_table, column_path[0], update_vector, row_ids, update_count);
-	} else {
-		// update the child column (i.e. the validity column)
-		validity.UpdateColumn(transaction, data_table, column_path, update_vector, row_ids, update_count, depth + 1);
+		return;
 	}
+	// Update the child column, which is the validity column.
+	validity.UpdateWithBase(transaction, data_table, column_path[0], update_vector, row_ids, update_count, *this);
 }
 
 unique_ptr<BaseStatistics> StandardColumnData::GetUpdateStatistics() {

--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/storage/table/validity_column_data.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/storage/table/update_segment.hpp"
+#include "duckdb/storage/table/standard_column_data.hpp"
 
 namespace duckdb {
 
@@ -11,6 +12,22 @@ ValidityColumnData::ValidityColumnData(BlockManager &block_manager, DataTableInf
 
 FilterPropagateResult ValidityColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
+void ValidityColumnData::UpdateWithBase(TransactionData transaction, DataTable &data_table, idx_t column_index,
+                                        Vector &update_vector, row_t *row_ids, idx_t update_count, ColumnData &base) {
+	Vector base_vector(base.type);
+	ColumnScanState validity_scan_state;
+	FetchUpdateData(validity_scan_state, row_ids, base_vector);
+
+	if (validity_scan_state.current->GetCompressionFunction().type == CompressionType::COMPRESSION_EMPTY) {
+		// The validity is actually covered by the data, so we read it to get the validity for UpdateInternal.
+		ColumnScanState data_scan_state;
+		auto fetch_count = base.Fetch(data_scan_state, row_ids[0], base_vector);
+		base_vector.Flatten(fetch_count);
+	}
+
+	UpdateInternal(transaction, data_table, column_index, update_vector, row_ids, update_count, base_vector);
 }
 
 void ValidityColumnData::AppendData(BaseStatistics &stats, ColumnAppendState &state, UnifiedVectorFormat &vdata,

--- a/test/sql/index/art/insert_update_delete/test_art_update_with_dict_fsst.test
+++ b/test/sql/index/art/insert_update_delete/test_art_update_with_dict_fsst.test
@@ -1,0 +1,25 @@
+# name: test/sql/index/art/insert_update_delete/test_art_update_with_dict_fsst.test
+# description: Test
+# group: [insert_update_delete]
+
+load __TEST_DIR__/foo.db readwrite v1.4.2
+
+statement ok
+CREATE OR REPLACE TABLE bar (col1 VARCHAR, col2 VARCHAR UNIQUE)
+
+statement ok
+INSERT INTO bar (col1, col2) VALUES (NULL, 'one');
+
+statement ok
+CHECKPOINT
+
+statement ok
+SET wal_autocheckpoint='1TB'
+
+statement ok
+UPDATE bar AS original SET col1 = 'a'
+
+query I
+SELECT col1 FROM bar WHERE col2 = 'one'
+----
+a

--- a/test/sql/index/art/insert_update_delete/test_art_update_with_dict_fsst_and_replay.test
+++ b/test/sql/index/art/insert_update_delete/test_art_update_with_dict_fsst_and_replay.test
@@ -1,8 +1,14 @@
-# name: test/sql/index/art/insert_update_delete/test_art_update_with_dict_fsst.test
-# description: Test updating a column with an index that is compressed with DICT_FSST.
+# name: test/sql/index/art/insert_update_delete/test_art_update_with_dict_fsst_and_replay.test
+# description: Test updating a column with an index that is compressed with DICT_FSST, then replay the update.
 # group: [insert_update_delete]
 
 load __TEST_DIR__/foo.db readwrite v1.4.2
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+SET wal_autocheckpoint='1TB'
 
 statement ok
 CREATE OR REPLACE TABLE bar (col1 VARCHAR, col2 VARCHAR UNIQUE)
@@ -14,10 +20,9 @@ statement ok
 CHECKPOINT
 
 statement ok
-SET wal_autocheckpoint='1TB'
-
-statement ok
 UPDATE bar AS original SET col1 = 'a'
+
+restart
 
 query I
 SELECT col1 FROM bar WHERE col2 = 'one'


### PR DESCRIPTION
One-liner but a bit of a journey to get here (cc @Tishj).

Fixes https://github.com/duckdblabs/duckdb-internal/issues/6709.