### PR TITLE
Add comments to cardinality estimator code

### DIFF
--- a/src/optimizer/join_order/cost_model.cpp
+++ b/src/optimizer/join_order/cost_model.cpp
@@ -8,6 +8,8 @@ CostModel::CostModel(QueryGraphManager &query_graph_manager)
     : query_graph_manager(query_graph_manager), cardinality_estimator() {
 }
 
+// Currently cost of a join only factors in the cardinalities.
+// If join types and join algorithms are to be considered, they should be added here.
 double CostModel::ComputeCost(DPJoinNode &left, DPJoinNode &right) {
 	auto &combination = query_graph_manager.set_manager.Union(left.set, right.set);
 	auto join_card = cardinality_estimator.EstimateCardinalityWithSet<double>(combination);

--- a/src/optimizer/join_order/plan_enumerator.cpp
+++ b/src/optimizer/join_order/plan_enumerator.cpp
@@ -451,7 +451,7 @@ void PlanEnumerator::InitLeafPlans() {
 	auto relation_stats = query_graph_manager.relation_manager.GetRelationStats();
 
 	cost_model.cardinality_estimator.InitEquivalentRelations(query_graph_manager.GetFilterBindings());
-	cost_model.cardinality_estimator.AddRelationNamesToTdoms(relation_stats);
+	cost_model.cardinality_estimator.AddRelationNamesToRelationStats(relation_stats);
 
 	// then update the total domains based on the cardinalities of each relation.
 	for (idx_t i = 0; i < relation_stats.size(); i++) {


### PR DESCRIPTION
With @hawkfish working on IEJoin improvements and all of the previous work on ASOF joins, it may be a good idea to update our cardinality estimation logic given these new join types/algorithms. 

With that in mind, I thought I would spend a bit of time cleaning up code & renaming structures/classes so that it becomes easier for future engineers to modify the logic to account for different join types. 

This PR is strictly adding comments and changing variable names. There should be no actual logic changes (if there are please point them out).

Most of changing of struct names/class names is to move away from the one statistic during CE of `tdom` to many possible statistics. `tdom` has also been renamed to `distinct_count` as I believe that better describes what HLL measures. If we add extra statistics during `Extract<LogicalOperatorType>Statistics` we can better estimate cardinalities of ASOF and IE joins. 