### PR TITLE
Add z/OS support for block allocator

### DIFF
--- a/test/persistence/test_locking.cpp
+++ b/test/persistence/test_locking.cpp
@@ -7,10 +7,6 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-#ifdef __MVS__
-#define MAP_ANONYMOUS 0x0
-#endif
-
 using namespace duckdb;
 using namespace std;
 

--- a/test/persistence/test_persistence.cpp
+++ b/test/persistence/test_persistence.cpp
@@ -7,10 +7,6 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-#ifdef __MVS__
-#define MAP_ANONYMOUS 0x0
-#endif
-
 using namespace duckdb;
 using namespace std;
 


### PR DESCRIPTION
The PR adds z/OS support for block allocator (PR https://github.com/duckdb/duckdb/pull/19678) and as well fixes a couple of minor z/OS related issues.