### PR TITLE
No sampling over 281TB

### DIFF
--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -89,6 +89,7 @@ private:
 };
 
 class Allocator {
+public:
 	// 281TB ought to be enough for anybody
 	static constexpr const idx_t MAXIMUM_ALLOC_SIZE = 281474976710656ULL;
 

--- a/src/include/duckdb/parser/parsed_data/sample_options.hpp
+++ b/src/include/duckdb/parser/parsed_data/sample_options.hpp
@@ -23,6 +23,9 @@ enum class SampleMethod : uint8_t { SYSTEM_SAMPLE = 0, BERNOULLI_SAMPLE = 1, RES
 string SampleMethodToString(SampleMethod method);
 
 class SampleOptions {
+public:
+	// 1 billion rows should be enough.
+	static constexpr idx_t MAX_SAMPLE_ROWS = 1000000000;
 
 public:
 	explicit SampleOptions(int64_t seed_ = -1);

--- a/src/parser/transform/helpers/transform_sample.cpp
+++ b/src/parser/transform/helpers/transform_sample.cpp
@@ -44,9 +44,9 @@ unique_ptr<SampleOptions> Transformer::TransformSampleOptions(optional_ptr<duckd
 	} else {
 		// sample size is given in rows: use reservoir sampling
 		auto rows = sample_value.GetValue<int64_t>();
-		if (rows < 0 || sample_value.GetValue<uint64_t>() >= Allocator::MAXIMUM_ALLOC_SIZE) {
+		if (rows < 0 || sample_value.GetValue<uint64_t>() >= SampleOptions::MAX_SAMPLE_ROWS) {
 			throw ParserException("Sample rows %lld out of range, must be between 0 and %lld", rows,
-			                      Allocator::MAXIMUM_ALLOC_SIZE);
+			                      SampleOptions::MAX_SAMPLE_ROWS);
 		}
 		result->sample_size = Value::BIGINT(rows);
 		result->method = SampleMethod::RESERVOIR_SAMPLE;

--- a/src/parser/transform/helpers/transform_sample.cpp
+++ b/src/parser/transform/helpers/transform_sample.cpp
@@ -44,11 +44,8 @@ unique_ptr<SampleOptions> Transformer::TransformSampleOptions(optional_ptr<duckd
 	} else {
 		// sample size is given in rows: use reservoir sampling
 		auto rows = sample_value.GetValue<int64_t>();
-		if (rows < 0) {
-			throw ParserException("Sample rows %lld out of range, must be bigger than or equal to 0", rows);
-		}
-		if (rows >= Allocator::MAXIMUM_ALLOC_SIZE) {
-			throw ParserException("Cannot sample over %d rows. Please use percentage instead",
+		if (rows < 0 || sample_value.GetValue<uint64_t>() >= Allocator::MAXIMUM_ALLOC_SIZE) {
+			throw ParserException("Sample rows %lld out of range, must be between 0 and %lld", rows,
 			                      Allocator::MAXIMUM_ALLOC_SIZE);
 		}
 		result->sample_size = Value::BIGINT(rows);

--- a/src/parser/transform/helpers/transform_sample.cpp
+++ b/src/parser/transform/helpers/transform_sample.cpp
@@ -47,6 +47,10 @@ unique_ptr<SampleOptions> Transformer::TransformSampleOptions(optional_ptr<duckd
 		if (rows < 0) {
 			throw ParserException("Sample rows %lld out of range, must be bigger than or equal to 0", rows);
 		}
+		if (rows >= Allocator::MAXIMUM_ALLOC_SIZE) {
+			throw ParserException("Cannot sample over %d rows. Please use percentage instead",
+			                      Allocator::MAXIMUM_ALLOC_SIZE);
+		}
 		result->sample_size = Value::BIGINT(rows);
 		result->method = SampleMethod::RESERVOIR_SAMPLE;
 	}

--- a/src/parser/transform/helpers/transform_sample.cpp
+++ b/src/parser/transform/helpers/transform_sample.cpp
@@ -44,7 +44,7 @@ unique_ptr<SampleOptions> Transformer::TransformSampleOptions(optional_ptr<duckd
 	} else {
 		// sample size is given in rows: use reservoir sampling
 		auto rows = sample_value.GetValue<int64_t>();
-		if (rows < 0 || sample_value.GetValue<uint64_t>() >= SampleOptions::MAX_SAMPLE_ROWS) {
+		if (rows < 0 || sample_value.GetValue<uint64_t>() > SampleOptions::MAX_SAMPLE_ROWS) {
 			throw ParserException("Sample rows %lld out of range, must be between 0 and %lld", rows,
 			                      SampleOptions::MAX_SAMPLE_ROWS);
 		}

--- a/test/sql/sample/test_sample_too_big.test
+++ b/test/sql/sample/test_sample_too_big.test
@@ -17,3 +17,17 @@ statement error
 SELECT * FROM t1 WHERE a IN (SELECT * FROM t1 TABLESAMPLE RESERVOIR(1222222220022220));
 ----
 <REGEX>:.*Sample rows.*out of range.*
+
+statement error
+SELECT * FROM t1 WHERE a IN (SELECT * FROM t1 TABLESAMPLE RESERVOIR(1000000001));
+----
+<REGEX>:.*Sample rows.*out of range.*
+
+query I
+SELECT * FROM t1 WHERE a IN (SELECT * FROM t1 TABLESAMPLE RESERVOIR(1000000000)) order by all
+----
+1
+2
+3
+3
+5

--- a/test/sql/sample/test_sample_too_big.test
+++ b/test/sql/sample/test_sample_too_big.test
@@ -11,9 +11,9 @@ INSERT INTO t1 VALUES(1), (2), (3), (3), (5);
 statement error
 SELECT * FROM t1 TABLESAMPLE RESERVOIR(1222222220022220);
 ----
-<REGEX>:.*Cannot sample over.*
+<REGEX>:.*Sample rows.*out of range.*
 
 statement error
 SELECT * FROM t1 WHERE a IN (SELECT * FROM t1 TABLESAMPLE RESERVOIR(1222222220022220));
 ----
-<REGEX>:.*Cannot sample over.*
+<REGEX>:.*Sample rows.*out of range.*

--- a/test/sql/sample/test_sample_too_big.test
+++ b/test/sql/sample/test_sample_too_big.test
@@ -1,0 +1,19 @@
+# name: test/sql/sample/test_sample_too_big.test
+# description: Test SAMPLE keyword
+# group: [sample]
+
+statement ok
+CREATE TABLE t1(a INT);
+
+statement ok
+INSERT INTO t1 VALUES(1), (2), (3), (3), (5);
+
+statement error
+SELECT * FROM t1 TABLESAMPLE RESERVOIR(1222222220022220);
+----
+<REGEX>:.*Cannot sample over.*
+
+statement error
+SELECT * FROM t1 WHERE a IN (SELECT * FROM t1 TABLESAMPLE RESERVOIR(1222222220022220));
+----
+<REGEX>:.*Cannot sample over.*


### PR DESCRIPTION
Disable sampling over the Allocator::MAXIMUM_ALLOC_SIZE.

Error is thrown in the same place as what might happen if someone samples -1 rows.

Fixes https://github.com/duckdb/duckdb/issues/17780
Fixes https://github.com/duckdblabs/duckdb-internal/issues/5065