### PR TITLE
Adding extension alias lookup in GetDatabaseType

### DIFF
--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -321,7 +321,8 @@ void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, 
 		return;
 	}
 
-	if (config.storage_extensions.find(options.db_type) != config.storage_extensions.end()) {
+	auto extension_name = ExtensionHelper::ApplyExtensionAlias(options.db_type);
+	if (config.storage_extensions.find(extension_name) != config.storage_extensions.end()) {
 		// If the database type is already registered, we don't need to load it again.
 		return;
 	}

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_API_OBJECTS
     test_custom_allocator.cpp
     test_extension_setting_autoload.cpp
     test_instance_cache.cpp
+    test_storage_extension_alias.cpp
     test_results.cpp
     test_reset.cpp
     test_get_table_names.cpp

--- a/test/api/test_storage_extension_alias.cpp
+++ b/test/api/test_storage_extension_alias.cpp
@@ -10,57 +10,57 @@ using namespace duckdb;
 // Test to see if extensions can be loaded with their normal name and aliases.
 
 struct DummyStorageExtension : StorageExtension {
-    DummyStorageExtension() {
-        attach = [](optional_ptr<StorageExtensionInfo>, ClientContext &, AttachedDatabase &db, const string &,
-                    AttachInfo &info, AttachOptions &) -> unique_ptr<Catalog> {
-            return make_uniq_base<Catalog, DuckCatalog>(db);
-        };
-        create_transaction_manager = [](optional_ptr<StorageExtensionInfo>, AttachedDatabase &db,
-                                        Catalog &) -> unique_ptr<TransactionManager> {
-            return make_uniq<DuckTransactionManager>(db);
-        };
-    }
+	DummyStorageExtension() {
+		attach = [](optional_ptr<StorageExtensionInfo>, ClientContext &, AttachedDatabase &db, const string &,
+		            AttachInfo &info, AttachOptions &) -> unique_ptr<Catalog> {
+			return make_uniq_base<Catalog, DuckCatalog>(db);
+		};
+		create_transaction_manager = [](optional_ptr<StorageExtensionInfo>, AttachedDatabase &db,
+		                                Catalog &) -> unique_ptr<TransactionManager> {
+			return make_uniq<DuckTransactionManager>(db);
+		};
+	}
 };
 
 TEST_CASE("Test storage extension lookup full-name", "[api]") {
-    DBConfig config;
+	DBConfig config;
 
-    // Register a storage extension under its CANONICAL name "sqlite_scanner"
-    // This mimics how the real sqlite_scanner extension registers itself
-    // There is a hard-coded alias "sqlite" for "sqlite_scanner"
-    config.storage_extensions["sqlite_scanner"] = make_uniq<DummyStorageExtension>();
+	// Register a storage extension under its CANONICAL name "sqlite_scanner"
+	// This mimics how the real sqlite_scanner extension registers itself
+	// There is a hard-coded alias "sqlite" for "sqlite_scanner"
+	config.storage_extensions["sqlite_scanner"] = make_uniq<DummyStorageExtension>();
 
-    DuckDB db(nullptr, &config);
-    Connection con(db);
+	DuckDB db(nullptr, &config);
+	Connection con(db);
 
-    // this works since it is the full name
-    auto query = string("ATTACH ':memory:' AS db1 (TYPE SQLITE_SCANNER)");
-    auto result = con.Query(query);
-    if (result->HasError()) {
-        FAIL("Query failed even though sqlite_scanner is registered."
-             "Query: " + query + "\n" +
-             "Error: " + result->GetError());
-    }
+	// this works since it is the full name
+	auto query = string("ATTACH ':memory:' AS db1 (TYPE SQLITE_SCANNER)");
+	auto result = con.Query(query);
+	if (result->HasError()) {
+		FAIL("Query failed even though sqlite_scanner is registered."
+		     "Query: " +
+		     query + "\n" + "Error: " + result->GetError());
+	}
 }
 
 TEST_CASE("Test storage extension lookup alias", "[api]") {
-    DBConfig config;
+	DBConfig config;
 
-    // Register a storage extension under its CANONICAL name "sqlite_scanner"
-    // This mimics how the real sqlite_scanner extension registers itself
-    // there is a hard-coded alias "sqlite" for "sqlite_scanner"
-    config.storage_extensions["sqlite_scanner"] = make_uniq<DummyStorageExtension>();
+	// Register a storage extension under its CANONICAL name "sqlite_scanner"
+	// This mimics how the real sqlite_scanner extension registers itself
+	// there is a hard-coded alias "sqlite" for "sqlite_scanner"
+	config.storage_extensions["sqlite_scanner"] = make_uniq<DummyStorageExtension>();
 
-    DuckDB db(nullptr, &config);
-    Connection con(db);
+	DuckDB db(nullptr, &config);
+	Connection con(db);
 
-    // Without ApplyExtensionAlias in database_manager.cpp,
-    // this fails with an error about not finding the extension
-    auto query = string("ATTACH ':memory:' AS db1 (TYPE SQLITE)");
-    auto result = con.Query(query);
-    if (result->HasError()) {
-        FAIL("Query failed even though sqlite_scanner is registered.\n"
-             "Query: " + query + "\n" +
-             "Error: " + result->GetError());
-    }
+	// Without ApplyExtensionAlias in database_manager.cpp,
+	// this fails with an error about not finding the extension
+	auto query = string("ATTACH ':memory:' AS db1 (TYPE SQLITE)");
+	auto result = con.Query(query);
+	if (result->HasError()) {
+		FAIL("Query failed even though sqlite_scanner is registered.\n"
+		     "Query: " +
+		     query + "\n" + "Error: " + result->GetError());
+	}
 }

--- a/test/api/test_storage_extension_alias.cpp
+++ b/test/api/test_storage_extension_alias.cpp
@@ -1,0 +1,66 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/storage/storage_extension.hpp"
+#include "duckdb/transaction/duck_transaction_manager.hpp"
+#include "duckdb/catalog/duck_catalog.hpp"
+
+using namespace duckdb;
+
+// Test to see if extensions can be loaded with their normal name and aliases.
+
+struct DummyStorageExtension : StorageExtension {
+    DummyStorageExtension() {
+        attach = [](optional_ptr<StorageExtensionInfo>, ClientContext &, AttachedDatabase &db, const string &,
+                    AttachInfo &info, AttachOptions &) -> unique_ptr<Catalog> {
+            return make_uniq_base<Catalog, DuckCatalog>(db);
+        };
+        create_transaction_manager = [](optional_ptr<StorageExtensionInfo>, AttachedDatabase &db,
+                                        Catalog &) -> unique_ptr<TransactionManager> {
+            return make_uniq<DuckTransactionManager>(db);
+        };
+    }
+};
+
+TEST_CASE("Test storage extension lookup full-name", "[api]") {
+    DBConfig config;
+
+    // Register a storage extension under its CANONICAL name "sqlite_scanner"
+    // This mimics how the real sqlite_scanner extension registers itself
+    // There is a hard-coded alias "sqlite" for "sqlite_scanner"
+    config.storage_extensions["sqlite_scanner"] = make_uniq<DummyStorageExtension>();
+
+    DuckDB db(nullptr, &config);
+    Connection con(db);
+
+    // this works since it is the full name
+    auto query = string("ATTACH ':memory:' AS db1 (TYPE SQLITE_SCANNER)");
+    auto result = con.Query(query);
+    if (result->HasError()) {
+        FAIL("Query failed even though sqlite_scanner is registered."
+             "Query: " + query + "\n" +
+             "Error: " + result->GetError());
+    }
+}
+
+TEST_CASE("Test storage extension lookup alias", "[api]") {
+    DBConfig config;
+
+    // Register a storage extension under its CANONICAL name "sqlite_scanner"
+    // This mimics how the real sqlite_scanner extension registers itself
+    // there is a hard-coded alias "sqlite" for "sqlite_scanner"
+    config.storage_extensions["sqlite_scanner"] = make_uniq<DummyStorageExtension>();
+
+    DuckDB db(nullptr, &config);
+    Connection con(db);
+
+    // Without ApplyExtensionAlias in database_manager.cpp,
+    // this fails with an error about not finding the extension
+    auto query = string("ATTACH ':memory:' AS db1 (TYPE SQLITE)");
+    auto result = con.Query(query);
+    if (result->HasError()) {
+        FAIL("Query failed even though sqlite_scanner is registered.\n"
+             "Query: " + query + "\n" +
+             "Error: " + result->GetError());
+    }
+}


### PR DESCRIPTION
This change adds a test to see if extensions can be loaded
with their normal name and aliases.

It also adds an extension alias lookup in GetDatabaseType,
similar to how it is done in CreateAttachedDatabase.