### PR TITLE
[fix] ClientBufferManager::Pin to also propagate context when available

### DIFF
--- a/src/main/client_data.cpp
+++ b/src/main/client_data.cpp
@@ -86,7 +86,7 @@ public:
 		return Pin(QueryContext(), handle);
 	}
 	BufferHandle Pin(const QueryContext &context, shared_ptr<BlockHandle> &handle) override {
-		return buffer_manager.Pin(handle);
+		return buffer_manager.Pin(context, handle);
 	}
 	void Prefetch(vector<shared_ptr<BlockHandle>> &handles) override {
 		return buffer_manager.Prefetch(handles);


### PR DESCRIPTION
Very minor, but can as well just be propagated further down.