### PR TITLE
CLI: Fully unify result rendering, and fix automatic pager mode

### DIFF
--- a/src/include/duckdb/main/materialized_query_result.hpp
+++ b/src/include/duckdb/main/materialized_query_result.hpp
@@ -44,7 +44,6 @@ public:
 		return (T)value.GetValue<int64_t>();
 	}
 
-	DUCKDB_API bool MoreRowsThan(idx_t row_count) override;
 	DUCKDB_API idx_t RowCount() const;
 
 	//! Returns a reference to the underlying column data collection

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -111,9 +111,6 @@ public:
 	//! Returns true if the two results are identical; false otherwise. Note that this method is destructive; it calls
 	//! Fetch() until both results are exhausted. The data in the results will be lost.
 	DUCKDB_API bool Equals(QueryResult &other);
-	//! Returns true if the query result has more rows than the given amount.
-	//! This might involve fetching up to that many rows - but wil not exhaust any
-	DUCKDB_API virtual bool MoreRowsThan(idx_t row_count);
 
 	bool TryFetch(unique_ptr<DataChunk> &result, ErrorData &error) {
 		try {
@@ -220,10 +217,6 @@ public:
 	iterator end() { // NOLINT: match stl API
 		return QueryResultIterator(nullptr);
 	}
-
-protected:
-	vector<unique_ptr<DataChunk>> stored_chunks;
-	bool result_exhausted = false;
 
 protected:
 	DUCKDB_API string HeaderToString();

--- a/src/main/materialized_query_result.cpp
+++ b/src/main/materialized_query_result.cpp
@@ -62,10 +62,6 @@ idx_t MaterializedQueryResult::RowCount() const {
 	return collection ? collection->Count() : 0;
 }
 
-bool MaterializedQueryResult::MoreRowsThan(idx_t row_count) {
-	return RowCount() >= row_count;
-}
-
 ColumnDataCollection &MaterializedQueryResult::Collection() {
 	if (HasError()) {
 		throw InvalidInputException("Attempting to get collection from an unsuccessful query result\n: Error %s",

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -111,39 +111,7 @@ unique_ptr<DataChunk> QueryResult::Fetch() {
 }
 
 unique_ptr<DataChunk> QueryResult::FetchRaw() {
-	if (!stored_chunks.empty()) {
-		auto result = std::move(stored_chunks.back());
-		stored_chunks.pop_back();
-		return result;
-	}
-	if (result_exhausted) {
-		return nullptr;
-	}
 	return FetchInternal();
-}
-
-bool QueryResult::MoreRowsThan(idx_t row_count) {
-	// fetch chunks until we have seen more than "row_count" - OR the result is exhausted
-	// store any fetched chunks in "stored_chunks" - we return these again in "Fetch" upon request
-	idx_t result_row_count = 0;
-	if (!stored_chunks.empty()) {
-		std::reverse(stored_chunks.begin(), stored_chunks.end());
-		for (auto &chunk : stored_chunks) {
-			result_row_count += chunk->size();
-		}
-	}
-	while (result_row_count < row_count) {
-		auto chunk = FetchInternal();
-		if (!chunk) {
-			// exhausted result
-			result_exhausted = true;
-			break;
-		}
-		result_row_count += chunk->size();
-		stored_chunks.push_back(std::move(chunk));
-	}
-	std::reverse(stored_chunks.begin(), stored_chunks.end());
-	return result_row_count >= row_count;
 }
 
 bool QueryResult::Equals(QueryResult &other) { // LCOV_EXCL_START

--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -60,9 +60,18 @@ public:
 	explicit PrintStream(ShellState &state);
 	virtual ~PrintStream() = default;
 
-	virtual void Print(const string &str) = 0;
-	virtual void SetBinaryMode() = 0;
-	virtual void SetTextMode() = 0;
+	virtual void Print(const string &str) {
+		state.Print(str);
+	}
+	virtual void SetBinaryMode() {
+		state.SetBinaryMode();
+	}
+	virtual void SetTextMode() {
+		state.SetTextMode();
+	}
+	virtual bool SupportsHighlight() {
+		return true;
+	}
 
 	void RenderAlignedValue(const string &str, idx_t width, TextAlignment alignment = TextAlignment::CENTER);
 	void PrintDashes(idx_t N);
@@ -84,7 +93,7 @@ public:
 	string row_sep;
 
 public:
-	virtual SuccessState RenderQueryResult(ShellState &state, RenderingQueryResult &result);
+	virtual SuccessState RenderQueryResult(PrintStream &out, ShellState &state, RenderingQueryResult &result);
 	virtual void Analyze(RenderingQueryResult &result);
 	virtual void RenderHeader(PrintStream &out, ResultMetadata &result);
 	virtual void RenderRow(PrintStream &out, ResultMetadata &result, RowData &row);

--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -68,8 +68,8 @@ public:
 	virtual void RenderHeader(ResultMetadata &result);
 	virtual void RenderRow(ResultMetadata &result, RowData &row);
 	virtual void RenderFooter(ResultMetadata &result);
-	static bool IsColumnar(RenderMode mode);
 	virtual string NullValue();
+	virtual bool RequireMaterializedResult() const = 0;
 };
 
 class ColumnRenderer : public ShellRenderer {
@@ -85,6 +85,9 @@ public:
 	virtual const char *GetRowStart() {
 		return nullptr;
 	}
+	bool RequireMaterializedResult() const override {
+		return true;
+	}
 
 	void RenderAlignedValue(ResultMetadata &result, idx_t c);
 
@@ -99,13 +102,9 @@ public:
 
 public:
 	virtual void RenderHeader(ResultMetadata &result) override;
-};
-
-class ModeDuckBoxRenderer : public ShellRenderer {
-public:
-	explicit ModeDuckBoxRenderer(ShellState &state);
-
-	SuccessState RenderQueryResult(ShellState &state, RenderingQueryResult &result) override;
+	bool RequireMaterializedResult() const override {
+		return false;
+	}
 };
 
 } // namespace duckdb_shell

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -284,19 +284,9 @@ public:
 	void PushOutputMode();
 	void PopOutputMode();
 	void OutputCSV(const char *z, int bSep);
-	void PrintRowSeparator(idx_t nArg, const char *zSep, const vector<idx_t> &actualWidth);
-	void PrintMarkdownSeparator(idx_t nArg, const char *zSep, const vector<duckdb::LogicalType> &colTypes,
-	                            const vector<idx_t> &actualWidth);
-	void OutputCString(const char *z);
-	void OutputQuotedString(const char *z);
-	void OutputQuotedEscapedString(const char *z);
-	void OutputHexBlob(const void *pBlob, int nBlob);
-	void PrintSchemaLine(const char *z, const char *zTail);
-	void PrintSchemaLineN(char *z, int n, const char *zTail);
-	void PrintOptionallyQuotedIdentifier(const char *z);
-	void OutputJSONString(const char *z, int n);
-	void PrintDashes(idx_t N);
-	void UTF8WidthPrint(idx_t w, const string &str, bool right_align);
+	string EscapeCString(const string &z);
+	string GetSchemaLine(const string &str, const string &tail);
+	string GetSchemaLineN(const string &str, idx_t n, const string &tail);
 	bool SetOutputMode(const string &mode, const char *tbl_name);
 	bool ImportData(const vector<string> &args);
 	bool OpenDatabase(const vector<string> &args);

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -46,6 +46,7 @@ struct Prompt;
 struct ShellProgressBar;
 struct PagerState;
 struct ShellTableInfo;
+struct RenderingQueryResult;
 enum class HighlightElementType : uint32_t;
 
 using idx_t = uint64_t;
@@ -355,9 +356,10 @@ public:
 		shellFlgs &= ~static_cast<uint32_t>(flag);
 	}
 	void ResetOutput();
-	bool ShouldUsePager(duckdb::QueryResult &result);
+	bool ShouldUsePager(ShellRenderer &renderer, RenderingQueryResult &result);
 	bool ShouldUsePager();
 	bool ShouldUsePager(idx_t line_count);
+	idx_t GetMaxRenderWidth() const;
 	string GetSystemPager();
 	unique_ptr<PagerState> SetupPager();
 	static void StartPagerDisplay();

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -201,6 +201,8 @@ public:
 	unique_ptr<duckdb::MaterializedQueryResult> last_result;
 	//! If the following flag is set, then command execution stops at an error
 	bool bail_on_error = false;
+	//! Table name when rendering a DESCRIBE statement
+	string describe_table_name;
 
 	/*
 	** Treat stdin as an interactive input if the following variable
@@ -328,7 +330,6 @@ public:
 	unique_ptr<ShellRenderer> GetRenderer(RenderMode mode);
 	vector<string> TableColumnList(const char *zTab);
 	SuccessState ExecuteStatement(unique_ptr<duckdb::SQLStatement> statement);
-	SuccessState RenderDescribe(duckdb::QueryResult &res);
 	static bool UseDescribeRenderMode(const duckdb::SQLStatement &stmt, string &describe_table_name);
 	void RenderTableMetadata(vector<ShellTableInfo> &result);
 
@@ -424,9 +425,6 @@ public:
 private:
 	ShellState();
 	~ShellState();
-
-private:
-	string describe_table_name;
 };
 
 struct PagerState {

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -264,8 +264,6 @@ public:
 	string pager_command;
 	// In automatic mode, only show a pager when this row count is exceeded
 	idx_t pager_min_rows = 50;
-	// In automatic mode, only show a pager when this column count is exceeded
-	idx_t pager_min_columns = 5;
 	//! Whether or not the pager is currently active
 	bool pager_is_active = false;
 	//! Shell highlighting mode

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1294,10 +1294,6 @@ SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> state
 		// we should use a pager
 		pager_setup = SetupPager();
 	}
-	if (cMode == RenderMode::DESCRIBE) {
-		RenderDescribe(res);
-		return SuccessState::SUCCESS;
-	}
 	// render the query result
 	auto renderer = GetRenderer();
 	RenderingQueryResult render_result(res, *renderer);
@@ -2451,31 +2447,6 @@ void ShellState::ShowConfiguration() {
 	}
 	PrintF("\n");
 	PrintF("%12.12s: %s\n", "filename", zDbFilename.c_str());
-}
-
-SuccessState ShellState::RenderDescribe(duckdb::QueryResult &res) {
-	vector<ShellTableInfo> result;
-	ShellTableInfo table;
-	table.table_name = describe_table_name;
-	for (auto &row : res) {
-		ShellColumnInfo column;
-		column.column_name = row.GetValue<string>(0);
-		column.column_type = row.GetValue<string>(1);
-		if (!row.IsNull(2)) {
-			column.is_not_null = row.GetValue<string>(2) == "NO";
-		}
-		if (!row.IsNull(3)) {
-			column.is_primary_key = row.GetValue<string>(3) == "PRI";
-			column.is_unique = row.GetValue<string>(3) == "UNI";
-		}
-		if (!row.IsNull(4)) {
-			column.default_value = row.GetValue<string>(4);
-		}
-		table.columns.push_back(std::move(column));
-	}
-	result.push_back(std::move(table));
-	RenderTableMetadata(result);
-	return SuccessState::SUCCESS;
 }
 
 MetadataResult ShellState::DisplayTables(const vector<string> &args) {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1003,7 +1003,8 @@ SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> state
 		pager_setup = SetupPager();
 	}
 	// render the query result
-	return renderer->RenderQueryResult(*this, render_result);
+	PrintStream print_stream(*this);
+	return renderer->RenderQueryResult(print_stream, *this, render_result);
 }
 
 /*

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -456,41 +456,6 @@ void ShellState::Destroy() {
 	last_result.reset();
 }
 
-/*
-** Output string zUtf to stream pOut as w characters.  If w is negative,
-** then right-justify the text.  W is the width in UTF-8 characters, not
-** in bytes.  This is different from the %*.*s specification in printf
-** since with %*.*s the width is measured in bytes, not characters.
-*/
-void ShellState::UTF8WidthPrint(idx_t w, const string &str, bool right_align) {
-	auto zUtf = str.c_str();
-	int i;
-	int n;
-	int aw = w < 0 ? -w : w;
-#ifdef HAVE_LINENOISE
-	i = linenoiseGetRenderPosition(zUtf, strlen(zUtf), aw, &n);
-	if (i < 0)
-#endif
-		for (i = n = 0; zUtf[i]; i++) {
-			if ((zUtf[i] & 0xc0) != 0x80) {
-				n++;
-				if (n == aw) {
-					do {
-						i++;
-					} while ((zUtf[i] & 0xc0) == 0x80);
-					break;
-				}
-			}
-		}
-	if (n >= aw) {
-		utf8_printf(out, "%.*s", i, zUtf);
-	} else if (right_align) {
-		utf8_printf(out, "%*s%s", aw - n, "", zUtf);
-	} else {
-		utf8_printf(out, "%s%*s", zUtf, aw - n, "");
-	}
-}
-
 bool ShellState::IsSpace(char c) {
 	return duckdb::StringUtil::CharacterIsSpace(c);
 }
@@ -821,231 +786,32 @@ void ShellState::PopOutputMode() {
 }
 
 /*
-** Output the given string as a hex-encoded blob (eg. X'1234' )
-*/
-void ShellState::OutputHexBlob(const void *pBlob, int nBlob) {
-	int i;
-	char *zBlob = (char *)pBlob;
-	PrintF("X'");
-	for (i = 0; i < nBlob; i++) {
-		PrintF("%02x", zBlob[i] & 0xff);
-	}
-	PrintF("'");
-}
-
-/*
-** Output the given string as a quoted string using SQL quoting conventions.
-**
-** See also: output_quoted_escaped_string()
-*/
-void ShellState::OutputQuotedString(const char *z) {
-	int i;
-	char c;
-	SetBinaryMode();
-	for (i = 0; (c = z[i]) != 0 && c != '\''; i++) {
-	}
-	if (c == 0) {
-		PrintF("'%s'", z);
-	} else {
-		Print("'");
-		while (*z) {
-			for (i = 0; (c = z[i]) != 0 && c != '\''; i++) {
-			}
-			if (c == '\'') {
-				i++;
-			};
-			if (i) {
-				Print(string(z, i));
-				z += i;
-			}
-			if (c == '\'') {
-				Print("'");
-				continue;
-			}
-			if (c == 0) {
-				break;
-			}
-			z++;
-		}
-		Print("'");
-	}
-	SetTextMode();
-}
-
-/*
-** Output the given string as a quoted string using SQL quoting conventions.
-** Additionallly , escape the "\n" and "\r" characters so that they do not
-** get corrupted by end-of-line translation facilities in some operating
-** systems.
-**
-** This is like output_quoted_string() but with the addition of the \r\n
-** escape mechanism.
-*/
-void ShellState::OutputQuotedEscapedString(const char *z) {
-	bool needs_quoting = false;
-	bool needs_concat = false;
-	for (idx_t i = 0; z[i]; i++) {
-		if (z[i] == '\n' || z[i] == '\r') {
-			needs_quoting = true;
-			needs_concat = true;
-			break;
-		}
-		if (z[i] == '\'') {
-			needs_quoting = true;
-		}
-	}
-	if (!needs_quoting) {
-		PrintF("'%s'", z);
-		return;
-	}
-	string res;
-	if (needs_concat) {
-		res = "concat('";
-	} else {
-		res = "'";
-	}
-	for (idx_t i = 0; z[i]; i++) {
-		switch (z[i]) {
-		case '\n':
-		case '\r':
-			// newline - finish the current string literal and write the newline with a chr function
-			res += "', chr(";
-			if (z[i] == '\n') {
-				res += "10";
-			} else {
-				res += "13";
-			}
-			res += "), '";
-			break;
-		case '\'':
-			// escape the quote
-			res += "''";
-			break;
-		default:
-			res += z[i];
-			break;
-		}
-	}
-	res += "'";
-	if (needs_concat) {
-		res += ")";
-	}
-	PrintF("%s", res.c_str());
-}
-
-/*
 ** Output the given string as a quoted according to C or TCL quoting rules.
 */
-void ShellState::OutputCString(const char *z) {
-	unsigned int c;
-	fputc('"', out);
-	while ((c = *(z++)) != 0) {
+string ShellState::EscapeCString(const string &str) {
+	string result = "\"";
+	for (auto c : str) {
 		if (c == '\\') {
-			fputc(c, out);
-			fputc(c, out);
+			result += "\\\\";
 		} else if (c == '"') {
-			fputc('\\', out);
-			fputc('"', out);
+			result += "\\\"";
 		} else if (c == '\t') {
-			fputc('\\', out);
-			fputc('t', out);
+			result += "\\t";
 		} else if (c == '\n') {
-			fputc('\\', out);
-			fputc('n', out);
+			result += "\\n";
 		} else if (c == '\r') {
-			fputc('\\', out);
-			fputc('r', out);
+			result += "\\r";
 		} else if (!isprint(c & 0xff)) {
-			PrintF("\\%03o", c & 0xff);
+			result += "\\";
+			char buf[4];
+			snprintf(buf, 4, "%03o", c & 0xFF);
+			result += buf;
 		} else {
-			fputc(c, out);
+			result += c;
 		}
 	}
-	fputc('"', out);
-}
-
-/*
-** Output the given string as a quoted according to JSON quoting rules.
-*/
-void ShellState::OutputJSONString(const char *z, int n) {
-	unsigned int c;
-	if (n < 0)
-		n = (int)strlen(z);
-	fputc('"', out);
-	while (n--) {
-		c = *(z++);
-		if (c == '\\' || c == '"') {
-			fputc('\\', out);
-			fputc(c, out);
-		} else if (c <= 0x1f) {
-			fputc('\\', out);
-			if (c == '\b') {
-				fputc('b', out);
-			} else if (c == '\f') {
-				fputc('f', out);
-			} else if (c == '\n') {
-				fputc('n', out);
-			} else if (c == '\r') {
-				fputc('r', out);
-			} else if (c == '\t') {
-				fputc('t', out);
-			} else {
-				PrintF("u%04x", c);
-			}
-		} else {
-			fputc(c, out);
-		}
-	}
-	fputc('"', out);
-}
-
-/*
-** If a field contains any character identified by a 1 in the following
-** array, then the string must be quoted for CSV.
-*/
-static const char needCsvQuote[] = {
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0,
-    0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-};
-
-void ShellState::PrintOptionallyQuotedIdentifier(const char *input) {
-	Print(StringUtil::Format("%s", SQLIdentifier(input)));
-}
-
-/*
-** Output a single term of CSV.  Actually, p->colSeparator is used for
-** the separator, which may or may not be a comma.  p->nullValue is
-** the null value.  Strings are quoted if necessary.  The separator
-** is only issued if bSep is true.
-*/
-void ShellState::OutputCSV(const char *z, int bSep) {
-	if (!z) {
-		Print(nullValue);
-	} else {
-		int i;
-		int nSep = colSeparator.size();
-		for (i = 0; z[i]; i++) {
-			if (needCsvQuote[((unsigned char *)z)[i]] ||
-			    (z[i] == colSeparator[0] && (nSep == 1 || memcmp(z, colSeparator.c_str(), nSep) == 0))) {
-				i = 0;
-				break;
-			}
-		}
-		if (i == 0) {
-			auto zQuoted = StringUtil::Format("%s", SQLIdentifier(z));
-			Print(zQuoted);
-		} else {
-			Print(z);
-		}
-	}
-	if (bSep) {
-		Print(colSeparator);
-	}
+	result += "\"";
+	return result;
 }
 
 /*
@@ -1077,74 +843,15 @@ static BOOL WINAPI ConsoleCtrlHandler(DWORD dwCtrlType /* One of the CTRL_*_EVEN
 }
 #endif
 
-/*
-** Print a schema statement.  Part of RenderMode::Semi and RenderMode::Pretty output.
-**
-** This routine converts some CREATE TABLE statements for shadow tables
-** in FTS3/4/5 into CREATE TABLE IF NOT EXISTS statements.
-*/
-void ShellState::PrintSchemaLine(const char *z, const char *zTail) {
-	if (!z || !zTail) {
-		return;
-	}
-	if (StringGlob("CREATE TABLE ['\"]*", z)) {
-		PrintF("CREATE TABLE IF NOT EXISTS %s%s", z + 13, zTail);
-	} else {
-		PrintF("%s%s", z, zTail);
-	}
-}
-void ShellState::PrintSchemaLineN(char *z, int n, const char *zTail) {
-	char c = z[n];
-	z[n] = 0;
-	PrintSchemaLine(z, zTail);
-	z[n] = c;
+string ShellState::GetSchemaLine(const string &str, const string &tail) {
+	return str + tail;
 }
 
-/*
-** Print N dashes
-*/
-void ShellState::PrintDashes(idx_t N) {
-	const char zDash[] = "--------------------------------------------------";
-	const idx_t nDash = sizeof(zDash) - 1;
-	while (N > nDash) {
-		fputs(zDash, out);
-		N -= nDash;
+string ShellState::GetSchemaLineN(const string &str, idx_t n, const string &tail) {
+	if (str.size() < n) {
+		return GetSchemaLine(str.substr(n), tail);
 	}
-	utf8_printf(out, "%.*s", static_cast<int>(N), zDash);
-}
-
-/*
-** Print a markdown or table-style row separator using ascii-art
-*/
-void ShellState::PrintRowSeparator(idx_t nArg, const char *zSep, const vector<idx_t> &actualWidth) {
-	if (nArg > 0) {
-		fputs(zSep, out);
-		PrintDashes(actualWidth[0] + 2);
-		for (idx_t i = 1; i < nArg; i++) {
-			fputs(zSep, out);
-			PrintDashes(actualWidth[i] + 2);
-		}
-		fputs(zSep, out);
-	}
-	fputs("\n", out);
-}
-
-void ShellState::PrintMarkdownSeparator(idx_t nArg, const char *zSep, const vector<duckdb::LogicalType> &colTypes,
-                                        const vector<idx_t> &actualWidth) {
-	if (nArg > 0) {
-		for (idx_t i = 0; i < nArg; i++) {
-			Print(zSep);
-			if (colTypes[i].IsNumeric()) {
-				// right-align numerics in tables
-				PrintDashes(actualWidth[i] + 1);
-				Print(":");
-			} else {
-				PrintDashes(actualWidth[i] + 2);
-			}
-		}
-		Print(zSep);
-	}
-	Print("\n");
+	return GetSchemaLine(str, tail);
 }
 
 void ShellState::SetBinaryMode() {
@@ -1417,7 +1124,7 @@ void ShellState::RunSchemaDumpQuery(const string &zQuery) {
 		auto zSql = row.GetValue<string>(2);
 
 		// print sql
-		PrintSchemaLine(zSql.c_str(), ";\n");
+		Print(GetSchemaLine(zSql, ";\n"));
 		if (zType == "table") {
 			// dump table contents
 			string sSelect;
@@ -2412,14 +2119,14 @@ void ShellState::ShowConfiguration() {
 	PrintF("%12.12s: %s\n", "headers", showHeader ? "on" : "off");
 	PrintF("%12.12s: %s\n", "mode", ModeToString(mode));
 	PrintF("%12.12s: ", "nullvalue");
-	OutputCString(nullValue.c_str());
+	Print(EscapeCString(nullValue));
 	PrintF("\n");
 	PrintF("%12.12s: %s\n", "output", !outfile.empty() ? outfile.c_str() : "stdout");
 	PrintF("%12.12s: ", "colseparator");
-	OutputCString(colSeparator.c_str());
+	Print(EscapeCString(colSeparator));
 	PrintF("\n");
 	PrintF("%12.12s: ", "rowseparator");
-	OutputCString(rowSeparator.c_str());
+	Print(EscapeCString(rowSeparator));
 	PrintF("\n");
 	PrintF("%12.12s: ", "width");
 	for (auto w : colWidth) {

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -713,24 +713,25 @@ MetadataResult SetPager(ShellState &state, const vector<string> &args) {
 		}
 		state.PrintF("Pager mode: %s\n", mode_str);
 		if (state.pager_mode == PagerMode::PAGER_AUTOMATIC) {
-			state.PrintF("Trigger pager when rows exceed %d or columns exceed %d\n", state.pager_min_rows,
-			             state.pager_min_columns);
+			string page_mode = StringUtil::Format("Trigger pager when rows exceed %d", state.pager_min_rows);
+			if (state.max_width == 0) {
+				page_mode += " or result set is wider than terminal";
+			} else {
+				page_mode += StringUtil::Format(" or result set is wider than %d characters", state.max_width);
+			}
+			state.Print(page_mode);
 		}
 		if (state.pager_mode != PagerMode::PAGER_OFF || !state.pager_command.empty()) {
 			state.PrintF("Pager command: %s\n", state.pager_command);
 		}
 		return MetadataResult::SUCCESS;
 	}
-	if (args[1] == "set_row_threshold" || args[1] == "set_column_threshold") {
+	if (args[1] == "set_row_threshold") {
 		if (args.size() != 3) {
 			return MetadataResult::PRINT_USAGE;
 		}
 		idx_t limit = (idx_t)state.StringToInt(args[2]);
-		if (args[1] == "set_row_threshold") {
-			state.pager_min_rows = limit;
-		} else {
-			state.pager_min_columns = limit;
-		}
+		state.pager_min_rows = limit;
 		return MetadataResult::SUCCESS;
 	}
 	if (args.size() != 2) {

--- a/tools/shell/shell_render_table_metadata.cpp
+++ b/tools/shell/shell_render_table_metadata.cpp
@@ -428,11 +428,16 @@ void RenderLineDisplay(ShellHighlight &highlight, string &text, idx_t total_rend
 	highlight.PrintText(middle_line, PrintOutput::STDOUT, element_type);
 }
 
-void ShellState::RenderTableMetadata(vector<ShellTableInfo> &tables) {
+idx_t ShellState::GetMaxRenderWidth() const {
 	idx_t max_render_width = max_width == 0 ? duckdb::Printer::TerminalWidth() : max_width;
 	if (max_render_width < 80) {
 		max_render_width = 80;
 	}
+	return max_render_width;
+}
+
+void ShellState::RenderTableMetadata(vector<ShellTableInfo> &tables) {
+	idx_t max_render_width = GetMaxRenderWidth();
 	duckdb::BoxRendererConfig config;
 	// figure out the render width of each table
 	vector<ShellTableRenderInfo> table_list;

--- a/tools/shell/tests/test_dump.py
+++ b/tools/shell/tests/test_dump.py
@@ -144,7 +144,7 @@ def test_dump_quoted_schema(shell):
     )
     result = test.run()
     result.check_stdout('CREATE SCHEMA IF NOT EXISTS "my-schema";')
-    result.check_stdout('CREATE TABLE IF NOT EXISTS "my-schema"."my-table"(a INTEGER);')
+    result.check_stdout('CREATE TABLE "my-schema"."my-table"(a INTEGER);')
 
 def test_dump_if_not_exists(shell):
     test = (


### PR DESCRIPTION
This PR fully unifies the result rendering code, and uses the newly unified result rendering to fix up the automatic pager mode. Instead of guessing whether or not a result is wide by the amount of columns, we now actually measure how wide the result set will be and enable the pager based on that.

We also do some random clean-up, e.g. removing `QueryResult:: MoreRowsThan` again and moving the iteration / caching to the shell renderers.