### PR TITLE
Fix INSERT OR REPLACE BY NAME with partial columns(#19845)

### DIFF
--- a/test/sql/insert/insert_by_name.test
+++ b/test/sql/insert/insert_by_name.test
@@ -95,3 +95,32 @@ explicit column list
 
 statement ok
 INSERT INTO integers BY POSITION VALUES (42, 84);
+
+statement ok
+CREATE TABLE tbl2 (a INTEGER, b INTEGER PRIMARY KEY);
+
+statement ok
+INSERT INTO tbl2 BY NAME (SELECT 22 AS b);
+
+query II
+FROM tbl2
+----
+NULL	22
+
+# INSERT OR REPLACE BY NAME with partial columns
+statement ok
+INSERT OR REPLACE INTO tbl2 BY NAME (SELECT 22 AS b);
+
+query II
+FROM tbl2
+----
+NULL	22
+
+# INSERT OR REPLACE BY NAME with all columns
+statement ok
+INSERT OR REPLACE INTO tbl2 BY NAME (SELECT 22 AS b, 1 as a);
+
+query II
+FROM tbl2
+----
+1	22


### PR DESCRIPTION
## Problem

When using `INSERT OR REPLACE INTO...BY NAME` with a source that only contains a subset of the target table's columns (e.g., only the primary key column), the binder incorrectly attempts to update all table columns and fails with:

Binder Error: Values list 'excluded' does not have a column named 'col1'

**Reproduction:**
 ```sql
CREATE TABLE target (col1 VARCHAR, id INT PRIMARY KEY);
CREATE TABLE source (id INT);

INSERT OR REPLACE INTO target BY NAME SELECT id FROM source;
-- Error: Values list 'excluded' does not have a column named 'col1'
```

## Root Cause

- INSERT OR REPLACE is internally converted to MERGE INTO
- For BY NAME semantics, `update_info` was generated for all table columns in `bind_insert.cpp`
- But the excluded table only contains columns present in the source data.
- This mismatch caused the binder to fail when trying to reference columns that exist in the target table but not in the source

## Solution

The fix defers `update_info` generation for INSERT_BY_NAME cases to avoid the column mismatch:

1. Delay `update_info` generation (`bind_insert.cpp`):
  - Skip generating update_info for all table columns during `CreateSetInfoForReplace()`
  - Defer generation to `BindMergeAction()` where we have access to actual source column names
2. Generate correct UPDATE SET clause (`bind_merge_into.cpp`):
  - Extract columns used in the join condition
  - For BY NAME updates, only include columns that:
      - Exist in the source data
      - Are NOT used in the join condition (since they're already used for row matching)
3. Key implementation details:
  - Added `ExtractTargetColumnNames()` helper to parse join conditions and identify join columns
  - Modified `BindMergeAction()` signature to accept join_column_names parameter
  - For INSERT_BY_NAME, iterate through source columns and exclude join columns from UPDATE SET
