### PR TITLE
ADBC: Set append data error in Ingest()

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -814,6 +814,9 @@ AdbcStatusCode Ingest(duckdb_connection connection, const char *table_name, cons
 			affected += static_cast<int64_t>(chunk->size());
 		}
 		if (duckdb_append_data_chunk(appender.Get(), out_chunk.chunk) != DuckDBSuccess) {
+			auto error_data = duckdb_appender_error_data(appender.Get());
+			SetError(error, duckdb_error_data_message(error_data));
+			duckdb_destroy_error_data(&error_data);
 			return ADBC_STATUS_INTERNAL;
 		}
 		arrow_array_wrapper = duckdb::ArrowArrayWrapper();


### PR DESCRIPTION
If we don't set `SetError()`, users can't know why the ingest is failed.