### PR TITLE
CLI: Change return value from `-1` to `false` in `TryGetBackgroundColor`

### DIFF
--- a/tools/shell/linenoise/terminal.cpp
+++ b/tools/shell/linenoise/terminal.cpp
@@ -419,7 +419,7 @@ bool Terminal::TryGetBackgroundColor(TerminalColor &color) {
 	int ofd = STDOUT_FILENO;
 
 	if (Terminal::EnableRawMode() == -1) {
-		return -1;
+		return false;
 	}
 
 	bool success = false;


### PR DESCRIPTION
Since this function's return type is bool, we should return false instead of -1 when something goes wrong.