### PR TITLE
Disable block allocator test on non-64bit

### DIFF
--- a/test/sql/settings/block_allocator_memory.test
+++ b/test/sql/settings/block_allocator_memory.test
@@ -2,6 +2,8 @@
 # description: Test block_allocator_memory setting
 # group: [settings]
 
+require 64bit
+
 # defaults to 0, resetting to 0 is ok
 statement ok
 RESET block_allocator_memory;


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/6596