### PR TITLE
Enable windows_arm64 arch for main extensions

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -19,6 +19,10 @@ on:
         type: boolean
         required: false
         default: true
+      opt_in_archs:
+        type: string
+        required: false
+        default: 'windows_arm64;'
   workflow_dispatch:
     inputs:
       override_git_describe:
@@ -34,6 +38,11 @@ on:
         type: string
         required: false
         default: ''
+      opt_in_archs:
+        description: 'semicolon-separated list of architectures to opt into'
+        type: string
+        required: false
+        default: 'windows_arm64;'
       skip_tests:
         description: 'Set to true to skip all testing'
         type: boolean
@@ -96,6 +105,7 @@ jobs:
     outputs:
       main_extensions_config: ${{ steps.set-main-extensions.outputs.extension_config }}
       main_extensions_exclude_archs: ${{ steps.set-main-extensions.outputs.exclude_archs }}
+      main_extensions_opt_in_archs: ${{ steps.set-main-extensions.outputs.opt_in_archs }}
       rust_based_extensions_config: ${{ steps.set-rust-based-extensions.outputs.extension_config }}
       rust_based_extensions_exclude_archs: ${{ steps.set-rust-based-extensions.outputs.exclude_archs }}
       external_extensions_config: ${{ steps.set-external-extensions.outputs.extension_config }}
@@ -105,6 +115,7 @@ jobs:
       # NOTE: on PRs we exclude some archs to speed things up
       BASE_EXCLUDE_ARCHS: ${{ (github.event_name == 'pull_request' || inputs.run_all != 'true') && 'wasm_mvp;wasm_threads;windows_amd64_mingw;osx_amd64;linux_arm64;linux_amd64_musl;' || '' }}
       EXTRA_EXCLUDE_ARCHS: ${{ inputs.extra_exclude_archs }}
+      OPT_IN_ARCHS: ${{ github.event_name == 'pull_request' && 'windows_arm64;' || inputs.opt_in_archs }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -120,6 +131,7 @@ jobs:
         run: |
           # Set config
           echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$BASE_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
+          echo opt_in_archs="$OPT_IN_ARCHS" >> $GITHUB_OUTPUT
           in_tree_extensions="`cat $IN_TREE_CONFIG_FILE`"
           out_of_tree_extensions="`cat $OUT_OF_TREE_CONFIG_FILE`"
           echo "extension_config<<EOF" >> $GITHUB_OUTPUT
@@ -164,6 +176,7 @@ jobs:
     with:
       artifact_prefix: main-extensions
       exclude_archs: ${{ needs.load-extension-configs.outputs.main_extensions_exclude_archs }}
+      opt_in_archs: ${{ needs.load-extension-configs.outputs.main_extensions_opt_in_archs }}
       extension_config: ${{ needs.load-extension-configs.outputs.main_extensions_config }}
       override_tag: ${{ inputs.override_git_describe }}
       override_duckdb_version: ${{ inputs.git_ref }}

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -22,7 +22,7 @@ on:
       opt_in_archs:
         type: string
         required: false
-        default: 'windows_arm64;'
+        default: ''
   workflow_dispatch:
     inputs:
       override_git_describe:
@@ -39,7 +39,7 @@ on:
         required: false
         default: ''
       opt_in_archs:
-        description: 'semicolon-separated list of architectures to opt into'
+        description: 'Semicolon-separated list of architectures to opt into'
         type: string
         required: false
         default: 'windows_arm64;'
@@ -115,7 +115,7 @@ jobs:
       # NOTE: on PRs we exclude some archs to speed things up
       BASE_EXCLUDE_ARCHS: ${{ (github.event_name == 'pull_request' || inputs.run_all != 'true') && 'wasm_mvp;wasm_threads;windows_amd64_mingw;osx_amd64;linux_arm64;linux_amd64_musl;' || '' }}
       EXTRA_EXCLUDE_ARCHS: ${{ inputs.extra_exclude_archs }}
-      OPT_IN_ARCHS: ${{ github.event_name == 'pull_request' && 'windows_arm64;' || inputs.opt_in_archs }}
+      OPT_IN_ARCHS: ${{ inputs.opt_in_archs }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -27,6 +27,7 @@ jobs:
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
       run_all: ${{ inputs.run_all }}
+      opt_in_archs: 'windows_arm64;'
 
   osx:
     uses: ./.github/workflows/OSX.yml

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
         default: ''
+      opt_in_archs:
+        required: false
+        type: string
+        default: ''
       extra_toolchains:
         required: false
         type: string
@@ -55,6 +59,7 @@ jobs:
       ci_tools_version: main
 
       exclude_archs: ${{ inputs.exclude_archs }}
+      opt_in_archs: ${{ inputs.opt_in_archs }}
 
       extra_toolchains: ${{ inputs.extra_toolchains }}
       use_merged_vcpkg_manifest: '1'


### PR DESCRIPTION
This change adds `opt_in_archs` argument to the `Extensions.yml` workflow and passes it down to `_extension_distribution.yml`.

The default value is set to `windows_arm64;` with the intention to keep it there (if it will work correctly and will not cause problems) to have Windows ARM64 extension builds enabled by default.

This change only enables it for Main extensions. Rust-based extensions (`delta`) can be added later - it requires Python wheel re-build (for `configure` step, until `windows_arm64` binary wheel is available). It works on CI, but takes additional 35 mins.