### PR TITLE
Take in consideration if the sniffer used unstrictness while selecting candidates

### DIFF
--- a/data/19578.csv
+++ b/data/19578.csv
@@ -1,0 +1,2 @@
+Country;Location;Count;Date
+China;"35.86166;104.19397";97100,7;04/07/20

--- a/src/execution/operator/csv_scanner/scanner/base_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/base_scanner.cpp
@@ -26,6 +26,10 @@ BaseScanner::BaseScanner(shared_ptr<CSVBufferManager> buffer_manager_p, shared_p
 	}
 }
 
+void BaseScanner::Print() const {
+	state_machine->Print();
+}
+
 string BaseScanner::RemoveSeparator(const char *value_ptr, const idx_t size, char thousands_separator) {
 	string result;
 	result.reserve(size);

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -22,7 +22,7 @@ StringValueResult::StringValueResult(CSVStates &states, CSVStateMachine &state_m
                                      idx_t result_size_p, idx_t buffer_position, CSVErrorHandler &error_hander_p,
                                      CSVIterator &iterator_p, bool store_line_size_p,
                                      shared_ptr<CSVFileScan> csv_file_scan_p, idx_t &lines_read_p, bool sniffing_p,
-                                     string path_p, idx_t scan_id)
+                                     string path_p, idx_t scan_id, bool &used_unstrictness)
     : ScannerResult(states, state_machine, result_size_p),
       number_of_columns(NumericCast<uint32_t>(state_machine.dialect_options.num_cols)),
       null_padding(state_machine.options.null_padding), ignore_errors(state_machine.options.ignore_errors.GetValue()),
@@ -30,7 +30,7 @@ StringValueResult::StringValueResult(CSVStates &states, CSVStateMachine &state_m
                                 ? 0
                                 : state_machine.dialect_options.state_machine_options.delimiter.GetValue().size() - 1),
       error_handler(error_hander_p), iterator(iterator_p), store_line_size(store_line_size_p),
-      csv_file_scan(std::move(csv_file_scan_p)), lines_read(lines_read_p),
+      csv_file_scan(std::move(csv_file_scan_p)), lines_read(lines_read_p), used_unstrictness(used_unstrictness),
       current_errors(scan_id, state_machine.options.IgnoreErrors()), sniffing(sniffing_p), path(std::move(path_p)) {
 	// Vector information
 	D_ASSERT(number_of_columns > 0);
@@ -154,23 +154,26 @@ inline bool IsValueNull(const char *null_str_ptr, const char *value_ptr, const i
 }
 
 bool StringValueResult::HandleTooManyColumnsError(const char *value_ptr, const idx_t size) {
-	if (cur_col_id >= number_of_columns && state_machine.state_machine_options.strict_mode.GetValue()) {
-		bool error = true;
-		if (cur_col_id == number_of_columns && ((quoted && state_machine.options.allow_quoted_nulls) || !quoted)) {
-			// we make an exception if the first over-value is null
-			bool is_value_null = false;
-			for (idx_t i = 0; i < null_str_count; i++) {
-				is_value_null = is_value_null || IsValueNull(null_str_ptr[i], value_ptr, size);
+	if (cur_col_id >= number_of_columns) {
+		if (state_machine.state_machine_options.strict_mode.GetValue()) {
+			bool error = true;
+			if (cur_col_id == number_of_columns && ((quoted && state_machine.options.allow_quoted_nulls) || !quoted)) {
+				// we make an exception if the first over-value is null
+				bool is_value_null = false;
+				for (idx_t i = 0; i < null_str_count; i++) {
+					is_value_null = is_value_null || IsValueNull(null_str_ptr[i], value_ptr, size);
+				}
+				error = !is_value_null;
 			}
-			error = !is_value_null;
+			if (error) {
+				// We error pointing to the current value error.
+				current_errors.Insert(TOO_MANY_COLUMNS, cur_col_id, chunk_col_id, last_position);
+				cur_col_id++;
+			}
+			// We had an error
+			return true;
 		}
-		if (error) {
-			// We error pointing to the current value error.
-			current_errors.Insert(TOO_MANY_COLUMNS, cur_col_id, chunk_col_id, last_position);
-			cur_col_id++;
-		}
-		// We had an error
-		return true;
+		used_unstrictness = true;
 	}
 	return false;
 }
@@ -231,6 +234,7 @@ void StringValueResult::AddValueToVector(const char *value_ptr, idx_t size, bool
 	}
 	if (cur_col_id >= number_of_columns) {
 		if (!state_machine.state_machine_options.strict_mode.GetValue()) {
+			used_unstrictness = true;
 			return;
 		}
 		bool error = true;
@@ -549,6 +553,7 @@ void StringValueResult::AddPossiblyEscapedValue(StringValueResult &result, const
 		}
 		if (result.cur_col_id >= result.number_of_columns &&
 		    !result.state_machine.state_machine_options.strict_mode.GetValue()) {
+			result.used_unstrictness = true;
 			return;
 		}
 		if (!result.HandleTooManyColumnsError(value_ptr, length)) {
@@ -980,7 +985,7 @@ StringValueScanner::StringValueScanner(idx_t scanner_idx_p, const shared_ptr<CSV
       result(states, *state_machine, cur_buffer_handle, BufferAllocator::Get(buffer_manager->context), result_size,
              iterator.pos.buffer_pos, *error_handler, iterator,
              buffer_manager->context.client_data->debug_set_max_line_length, csv_file_scan, lines_read, sniffing,
-             buffer_manager->GetFilePath(), scanner_idx_p),
+             buffer_manager->GetFilePath(), scanner_idx_p, used_unstrictness),
       start_pos(0) {
 	if (scanner_idx == 0 && csv_file_scan) {
 		lines_read += csv_file_scan->skipped_rows;
@@ -997,7 +1002,7 @@ StringValueScanner::StringValueScanner(const shared_ptr<CSVBufferManager> &buffe
       result(states, *state_machine, cur_buffer_handle, Allocator::DefaultAllocator(), result_size,
              iterator.pos.buffer_pos, *error_handler, iterator,
              buffer_manager->context.client_data->debug_set_max_line_length, csv_file_scan, lines_read, sniffing,
-             buffer_manager->GetFilePath(), 0),
+             buffer_manager->GetFilePath(), 0, used_unstrictness),
       start_pos(0) {
 	if (scanner_idx == 0 && csv_file_scan) {
 		lines_read += csv_file_scan->skipped_rows;
@@ -1939,14 +1944,17 @@ void StringValueScanner::FinalizeChunkProcess() {
 		if (result.current_errors.HandleErrors(result)) {
 			result.number_of_rows++;
 		}
-		if (states.IsQuotedCurrent() && !found_error &&
-		    state_machine->dialect_options.state_machine_options.strict_mode.GetValue()) {
-			type = UNTERMINATED_QUOTES;
-			// If we finish the execution of a buffer, and we end in a quoted state, it means we have unterminated
-			// quotes
-			result.current_errors.Insert(type, result.cur_col_id, result.chunk_col_id, result.last_position);
-			if (result.current_errors.HandleErrors(result)) {
-				result.number_of_rows++;
+		if (states.IsQuotedCurrent() && !found_error) {
+			if (state_machine->dialect_options.state_machine_options.strict_mode.GetValue()) {
+				type = UNTERMINATED_QUOTES;
+				// If we finish the execution of a buffer, and we end in a quoted state, it means we have unterminated
+				// quotes
+				result.current_errors.Insert(type, result.cur_col_id, result.chunk_col_id, result.last_position);
+				if (result.current_errors.HandleErrors(result)) {
+					result.number_of_rows++;
+				}
+			} else {
+				used_unstrictness = true;
 			}
 		}
 		if (!iterator.done) {

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -22,7 +22,7 @@ StringValueResult::StringValueResult(CSVStates &states, CSVStateMachine &state_m
                                      idx_t result_size_p, idx_t buffer_position, CSVErrorHandler &error_hander_p,
                                      CSVIterator &iterator_p, bool store_line_size_p,
                                      shared_ptr<CSVFileScan> csv_file_scan_p, idx_t &lines_read_p, bool sniffing_p,
-                                     string path_p, idx_t scan_id, bool &used_unstrictness)
+                                     const string &path_p, idx_t scan_id, bool &used_unstrictness)
     : ScannerResult(states, state_machine, result_size_p),
       number_of_columns(NumericCast<uint32_t>(state_machine.dialect_options.num_cols)),
       null_padding(state_machine.options.null_padding), ignore_errors(state_machine.options.ignore_errors.GetValue()),
@@ -31,7 +31,7 @@ StringValueResult::StringValueResult(CSVStates &states, CSVStateMachine &state_m
                                 : state_machine.dialect_options.state_machine_options.delimiter.GetValue().size() - 1),
       error_handler(error_hander_p), iterator(iterator_p), store_line_size(store_line_size_p),
       csv_file_scan(std::move(csv_file_scan_p)), lines_read(lines_read_p), used_unstrictness(used_unstrictness),
-      current_errors(scan_id, state_machine.options.IgnoreErrors()), sniffing(sniffing_p), path(std::move(path_p)) {
+      current_errors(scan_id, state_machine.options.IgnoreErrors()), sniffing(sniffing_p), path(path_p) {
 	// Vector information
 	D_ASSERT(number_of_columns > 0);
 	if (!buffer_handle) {

--- a/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
@@ -14,7 +14,7 @@ CSVSniffer::CSVSniffer(CSVReaderOptions &options_p, const MultiFileOptions &file
 		auto &logical_type = format_template.first;
 		best_format_candidates[logical_type].clear();
 	}
-	// Initialize max columns found to either 0 or however many were set
+	// Initialize max columns found to either 0, or however many were set
 	max_columns_found = set_columns.Size();
 	error_handler = make_shared_ptr<CSVErrorHandler>(options.ignore_errors.GetValue());
 	detection_error_handler = make_shared_ptr<CSVErrorHandler>(true);

--- a/src/include/duckdb/execution/operator/csv_scanner/sniffer/csv_sniffer.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/sniffer/csv_sniffer.hpp
@@ -116,6 +116,7 @@ private:
 	//! Highest number of columns found
 	idx_t max_columns_found = 0;
 	idx_t max_columns_found_error = 0;
+	bool best_candidate_is_strict = false;
 	//! Current Candidates being considered
 	vector<unique_ptr<ColumnCountScanner>> candidates;
 	//! Reference to original CSV Options, it will be modified as a result of the sniffer.

--- a/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
@@ -176,7 +176,7 @@ public:
 	                  const shared_ptr<CSVBufferHandle> &buffer_handle, Allocator &buffer_allocator,
 	                  idx_t result_size_p, idx_t buffer_position, CSVErrorHandler &error_handler, CSVIterator &iterator,
 	                  bool store_line_size, shared_ptr<CSVFileScan> csv_file_scan, idx_t &lines_read, bool sniffing,
-	                  string path, idx_t scan_id);
+	                  string path, idx_t scan_id, bool &used_unstrictness);
 
 	~StringValueResult();
 
@@ -225,6 +225,7 @@ public:
 
 	shared_ptr<CSVFileScan> csv_file_scan;
 	idx_t &lines_read;
+	bool &used_unstrictness;
 	//! Information regarding projected columns
 	unsafe_unique_array<bool> projected_columns;
 	bool projecting_columns = false;

--- a/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
@@ -176,7 +176,7 @@ public:
 	                  const shared_ptr<CSVBufferHandle> &buffer_handle, Allocator &buffer_allocator,
 	                  idx_t result_size_p, idx_t buffer_position, CSVErrorHandler &error_handler, CSVIterator &iterator,
 	                  bool store_line_size, shared_ptr<CSVFileScan> csv_file_scan, idx_t &lines_read, bool sniffing,
-	                  string path, idx_t scan_id, bool &used_unstrictness);
+	                  const string &path, idx_t scan_id, bool &used_unstrictness);
 
 	~StringValueResult();
 

--- a/test/sql/copy/csv/19578.test
+++ b/test/sql/copy/csv/19578.test
@@ -1,0 +1,16 @@
+# name: test/sql/copy/csv/19578.test
+# description: Test for issue #19758
+# group: [csv]
+
+statement ok
+PRAGMA enable_verification
+
+query III
+SELECT Delimiter, Quote, Escape FROM sniff_csv("data/19578.csv");
+----
+;	"	(empty)
+
+query III
+SELECT Delimiter, Quote, Escape FROM sniff_csv("data/19578.csv",  strict_mode=false);
+----
+;	"	(empty)


### PR DESCRIPTION
In this PR, we mark the CSV scanners with a variable that stores if the scanner had to use any of the unstrict states while parsing. This is then used to help us select the most suitable candidate during sniffing.

Related to: https://github.com/duckdblabs/duckdb-internal/issues/6424