### PR TITLE
[Compression] Fix an issue with NULL updates to a column compressed with DICT_FSST

### DIFF
--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -363,7 +363,7 @@ void ColumnDataCheckpointer::WriteToDisk() {
 }
 
 bool ColumnDataCheckpointer::HasChanges(ColumnData &col_data) {
-	return col_data.HasChanges();
+	return col_data.HasAnyChanges();
 }
 
 void ColumnDataCheckpointer::WritePersistentSegments(ColumnCheckpointState &state) {

--- a/test/sql/storage/compression/dict_fsst/test_null_update.test
+++ b/test/sql/storage/compression/dict_fsst/test_null_update.test
@@ -1,0 +1,25 @@
+# name: test/sql/storage/compression/dict_fsst/test_null_update.test
+# group: [dict_fsst]
+
+load __TEST_DIR__/missing_null.db readwrite v1.4.2
+
+statement ok
+CREATE OR REPLACE TABLE t(
+	compressed VARCHAR USING COMPRESSION 'DICT_FSST'
+);
+
+statement ok
+INSERT INTO t VALUES
+	('Error3');
+
+statement ok
+UPDATE t SET compressed = NULL;
+
+# Only the validity is changed, no data changes occurred
+statement ok
+CHECKPOINT;
+
+query I
+SELECT * FROM t AS e WHERE e.compressed IS NULL;
+----
+NULL


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/6656

The problem was that during CHECKPOINT, we check if the ColumnData has any changes, which for DICT_FSST would mean the question: "are the strings changed?"
If that answer is no, but the validity *has* changed, we should still rewrite the data.

This mimics behavior on `main`, which also rewrites everything when either validity or data has changes.