### PR TITLE
Bump: delta, ducklake, iceberg

### DIFF
--- a/.github/config/extensions/delta.cmake
+++ b/.github/config/extensions/delta.cmake
@@ -1,7 +1,7 @@
 if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(delta
             GIT_URL https://github.com/duckdb/duckdb-delta
-            GIT_TAG 6515bb2560772956f9b74a18a47782f18ed4d827
+            GIT_TAG 77b0f303b7918f1539947833b1ced1eab8e825fc
             SUBMODULES extension-ci-tools
     )
 endif()

--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG ce40b303c0dbaf474d2949988bcb93eceb215cc8
+    GIT_TAG a75383de129d9a66bb301aa94cb9647352b2a44e
 )

--- a/.github/config/extensions/iceberg.cmake
+++ b/.github/config/extensions/iceberg.cmake
@@ -8,6 +8,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 6cec0127c340bc7e83c7e6b2390e27cb555a9d0a
+            GIT_TAG 79d34f41fb2ed8e983c4d56bf6b8ad0421179989
             )
 endif()


### PR DESCRIPTION
This PR bumps the following extensions:
- `delta` from `6515bb2560` to `77b0f303b7`
- `ducklake` from `ce40b303c0` to `a75383de12`
- `iceberg` from `6cec0127c3` to `79d34f41fb`
