### PR TITLE
Fix #19984: shouldn't use outer table distinct info to eliminate join

### DIFF
--- a/src/optimizer/join_elimination.cpp
+++ b/src/optimizer/join_elimination.cpp
@@ -244,12 +244,16 @@ unique_ptr<LogicalOperator> JoinElimination::TryEliminateJoin() {
 		}
 	}
 
-	for (auto &distinct : left_child->pipe_info.distinct_groups) {
-		pipe_info.distinct_groups[distinct.first] = distinct.second;
+	if (inner_idx == 1) {
+		for (auto &distinct : right_child->pipe_info.distinct_groups) {
+			pipe_info.distinct_groups[distinct.first] = distinct.second;
+		}
+	} else {
+		for (auto &distinct : left_child->pipe_info.distinct_groups) {
+			pipe_info.distinct_groups[distinct.first] = distinct.second;
+		}
 	}
-	for (auto &distinct : right_child->pipe_info.distinct_groups) {
-		pipe_info.distinct_groups[distinct.first] = distinct.second;
-	}
+
 	if (pipe_info.distinct_groups.empty()) {
 		return std::move(pipe_info.root);
 	}

--- a/test/optimizer/join_elimination.test
+++ b/test/optimizer/join_elimination.test
@@ -227,3 +227,20 @@ physical_plan	<!REGEX>:.*JOIN.*
 
 statement ok
 select b.* from b left join (select distinct a.ida from a ) as a on a.ida=b.idb union all select b.*  from b left join (select distinct a.ida from a ) as a on a.ida=b.idb;
+
+# we cannot use distinct statistics from outer child
+statement ok
+select a.ida from (select ida from a group by ida) as a left join b on ida < idb;
+
+query II
+explain select a.ida from (select ida from a group by ida) as a left join b on ida < idb;
+----
+physical_plan	<REGEX>:.*JOIN.*
+
+statement ok
+select a.ida from b right join (select ida from a group by ida) as a on ida < idb;
+
+query II
+explain select a.ida from b right join (select ida from a group by ida) as a on ida < idb;
+----
+physical_plan	<REGEX>:.*JOIN.*


### PR DESCRIPTION
This pr try to fix #19984 that introduced in eliminate join optimizer, distinct info could be used in inner table or after join.

so below should be ok
```
select distinct b.* from b left join a on a.ida=b.idb;
select  b.* from b left join (select a.ida from a group by ida) as a1 on b.idb=a1.ida;
```

but distinct in outer table **cannot** eliminate join:
```
select a.ida from b right join (select ida from a group by ida) as a on ida < idb;
```
