### PR TITLE
Headers missing from http logs

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -139,7 +139,7 @@ struct BaseRequest {
 	const string &url;
 	string path;
 	string proto_host_port;
-	const HTTPHeaders &headers;
+	HTTPHeaders headers;
 	HTTPParams &params;
 	//! Whether or not to return failed requests (instead of throwing)
 	bool try_request = false;
@@ -156,6 +156,14 @@ struct BaseRequest {
 	template <class TARGET>
 	const TARGET &Cast() const {
 		return reinterpret_cast<const TARGET &>(*this);
+	}
+
+	static HTTPHeaders MergeHeaders(const HTTPHeaders &headers, HTTPParams &params) {
+		HTTPHeaders result = headers;
+		for (const auto &header : params.extra_headers) {
+			result.Insert(header.first, header.second);
+		}
+		return result;
 	}
 };
 

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -123,7 +123,7 @@ unique_ptr<HTTPResponse> HTTPUtil::Request(BaseRequest &request, unique_ptr<HTTP
 }
 
 BaseRequest::BaseRequest(RequestType type, const string &url, const HTTPHeaders &headers, HTTPParams &params)
-    : type(type), url(url), headers(headers), params(params) {
+    : type(type), url(url), headers(MergeHeaders(headers, params)), params(params) {
 	HTTPUtil::DecomposeURL(url, path, proto_host_port);
 }
 

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -191,9 +191,6 @@ private:
 		for (auto &entry : header_map) {
 			headers.insert(entry);
 		}
-		for (auto &entry : params.extra_headers) {
-			headers.insert(entry);
-		}
 		return headers;
 	}
 


### PR DESCRIPTION
The extra_headers (settable through HTTP type secrets) would not show up in the http logs.

After this PR, instead of merging the extra_headers into the requests on every request, we just copy all headers into the requestinfo. This pays a small price of copying all headers for each request, but `select request.headers from duckdb_logs_parsed('HTTP');` will now correctly show the headers that are added to the request. I think this is worth the cost given the context of a network request and how confusing it is to have requests be sent with invisible headers.

### possible optimization
We can improve this by only copying the headers when extra_headers are present and having the requestinfo hold either a owning pointer or a non-owning pointer
