### PR TITLE
Fix mark join decorrelation

### DIFF
--- a/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
+++ b/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
@@ -33,7 +33,7 @@ private:
 	                                 bool parent_is_dependent_join = false);
 
 	//! Mark entire subtree of Logical Operators as correlated by adding them to the has_correlated_expressions map.
-	bool MarkSubtreeCorrelated(LogicalOperator &op);
+	bool MarkSubtreeCorrelated(LogicalOperator &op, idx_t cte_index);
 
 	//! Push the dependent join down a LogicalOperator
 	unique_ptr<LogicalOperator> PushDownDependentJoin(unique_ptr<LogicalOperator> plan,

--- a/test/issues/general/test_19504.test
+++ b/test/issues/general/test_19504.test
@@ -1,0 +1,17 @@
+# name: test/issues/general/test_19504.test
+# description: Issue 19504 - Regression due to optimization in 1.4.0
+# group: [general]
+
+query II
+SELECT query,
+       (WITH t AS MATERIALIZED (SELECT query)
+         SELECT *
+         FROM (VALUES ('cat')) AS _(x)
+         WHERE x IN (SELECT * FROM t)
+       ) AS broken
+FROM   (VALUES ('cat'), ('dog'), ('duck')) AS queries(query)
+ORDER BY query;
+----
+cat	cat
+dog	NULL
+duck	NULL


### PR DESCRIPTION
Mark joins without correlation on the left side could not be handled correctly without this PR. Information regarding the correlated columns was simply lost, which could lead to wrong query behavior. This PR fixes this and introduces correct decorrelation of mark joins without correlation on the left side.

----

Fix: #19504