### PR TITLE
Bloom filter row group skipping

### DIFF
--- a/src/planner/filter/bloom_filter.cpp
+++ b/src/planner/filter/bloom_filter.cpp
@@ -147,7 +147,7 @@ static FilterPropagateResult TemplatedCheckStatistics(const BloomFilter &bf, con
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE; // Invalid stats
 	}
 	T range_typed;
-	if (!TrySubtractOperator::Operation(max, min, range_typed) || range_typed < 2048) {
+	if (!TrySubtractOperator::Operation(max, min, range_typed) || range_typed > 2048) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE; // Overflow or too wide of a range
 	}
 	const auto range = NumericCast<idx_t>(range_typed);


### PR DESCRIPTION
Follow-up of https://github.com/duckdb/duckdb/pull/19502

Uses the newly added join bloom filters to skip row groups with tight ranges, i.e., if `max - min <= 2048`. Doesn't seem to be doing much for the benchmarks we run in our CI, but seems like a valid optimization nonetheless.