### PR TITLE
Bump: httpfs

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(httpfs
     LOAD TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 8ff2283fb14b443e673c58e2e9621e3c3215d794
+    GIT_TAG 9c7d34977b10346d0b4cbbde5df807d1dab0b2bf
     INCLUDE_DIR src/include
 )

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1046,6 +1046,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"http_timeout", "httpfs"},
     {"httpfs_client_implementation", "httpfs"},
     {"iceberg_via_aws_sdk_for_catalog_interactions", "iceberg"},
+    {"merge_http_secret_into_s3_request", "httpfs"},
     {"mysql_bit1_as_boolean", "mysql_scanner"},
     {"mysql_debug_show_queries", "mysql_scanner"},
     {"mysql_experimental_filter_pushdown", "mysql_scanner"},


### PR DESCRIPTION
This PR bumps the following extensions:
- `httpfs` from `8ff2283fb1` to `9c7d34977b`
