### PR TITLE
Fix #20034: correctly move correlated columns for lazy CTEs

### DIFF
--- a/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_cte_node.cpp
@@ -138,6 +138,7 @@ BoundCTEData Binder::PrepareCTE(const string &ctename, CommonTableExpressionInfo
 BoundStatement Binder::FinishCTE(BoundCTEData &bound_cte, BoundStatement child) {
 	if (!bound_cte.cte_bind_state->IsBound()) {
 		// CTE was not bound - just ignore it
+		MoveCorrelatedExpressions(*bound_cte.child_binder);
 		return child;
 	}
 	auto &bind_state = *bound_cte.cte_bind_state;

--- a/test/sql/cte/lazy_cte_bind_correlated.test
+++ b/test/sql/cte/lazy_cte_bind_correlated.test
@@ -1,0 +1,16 @@
+# name: test/sql/cte/lazy_cte_bind_correlated.test
+# description: Test lazy CTE binding with correlated columns
+# group: [cte]
+
+query II rowsort
+SELECT query,
+    (WITH t AS (SELECT query)
+     SELECT x FROM (VALUES ('cat')) AS _(x)
+     WHERE x IN (SELECT query)) AS broken
+FROM   (VALUES ('cat'),
+               ('dog'),
+               ('duck')) AS queries(query)
+----
+cat	cat
+dog	NULL
+duck	NULL


### PR DESCRIPTION
Fixes #20034