### PR TITLE
Fix #20014: correctly use numeric_limits<T>::min for NumericLimits::Min so that stats are initialized to -infinity for floating points

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -534,10 +534,10 @@ ColumnWriter::CreateWriterRecursive(ClientContext &context, ParquetWriter &write
 template <>
 struct NumericLimits<float_na_equal> {
 	static constexpr float Minimum() {
-		return std::numeric_limits<float>::lowest();
+		return NumericLimits<float>::Minimum();
 	};
 	static constexpr float Maximum() {
-		return std::numeric_limits<float>::max();
+		return NumericLimits<float>::Maximum();
 	};
 	static constexpr bool IsSigned() {
 		return std::is_signed<float>::value;
@@ -550,10 +550,10 @@ struct NumericLimits<float_na_equal> {
 template <>
 struct NumericLimits<double_na_equal> {
 	static constexpr double Minimum() {
-		return std::numeric_limits<double>::lowest();
+		return NumericLimits<double>::Minimum();
 	};
 	static constexpr double Maximum() {
-		return std::numeric_limits<double>::max();
+		return NumericLimits<double>::Maximum();
 	};
 	static constexpr bool IsSigned() {
 		return std::is_signed<double>::value;

--- a/src/function/table/system/test_all_types.cpp
+++ b/src/function/table/system/test_all_types.cpp
@@ -70,9 +70,9 @@ vector<TestType> TestAllTypesFun::GetTestTypes(const bool use_large_enum, const 
 
 	// More complex numeric types.
 	result.emplace_back(LogicalType::FLOAT, "float", Value::FLOAT(std::numeric_limits<float>::lowest()),
-	                    Value::MaximumValue(LogicalType::FLOAT));
+	                    Value::FLOAT(std::numeric_limits<float>::max()));
 	result.emplace_back(LogicalType::DOUBLE, "double", Value::DOUBLE(std::numeric_limits<double>::lowest()),
-	                    Value::MaximumValue(LogicalType::DOUBLE));
+	                    Value::DOUBLE(std::numeric_limits<double>::max()));
 	result.emplace_back(LogicalType::DECIMAL(4, 1), "dec_4_1");
 	result.emplace_back(LogicalType::DECIMAL(9, 4), "dec_9_4");
 	result.emplace_back(LogicalType::DECIMAL(18, 6), "dec_18_6");

--- a/src/function/table/system/test_all_types.cpp
+++ b/src/function/table/system/test_all_types.cpp
@@ -69,8 +69,10 @@ vector<TestType> TestAllTypesFun::GetTestTypes(const bool use_large_enum, const 
 	result.emplace_back(LogicalType::TIMESTAMP_TZ, "timestamp_tz");
 
 	// More complex numeric types.
-	result.emplace_back(LogicalType::FLOAT, "float");
-	result.emplace_back(LogicalType::DOUBLE, "double");
+	result.emplace_back(LogicalType::FLOAT, "float", Value::FLOAT(std::numeric_limits<float>::lowest()),
+	                    Value::MaximumValue(LogicalType::FLOAT));
+	result.emplace_back(LogicalType::DOUBLE, "double", Value::DOUBLE(std::numeric_limits<double>::lowest()),
+	                    Value::MaximumValue(LogicalType::DOUBLE));
 	result.emplace_back(LogicalType::DECIMAL(4, 1), "dec_4_1");
 	result.emplace_back(LogicalType::DECIMAL(9, 4), "dec_9_4");
 	result.emplace_back(LogicalType::DECIMAL(18, 6), "dec_18_6");

--- a/src/include/duckdb/common/limits.hpp
+++ b/src/include/duckdb/common/limits.hpp
@@ -24,7 +24,7 @@ namespace duckdb {
 template <class T>
 struct NumericLimits {
 	static constexpr T Minimum() {
-		return std::numeric_limits<T>::lowest();
+		return std::numeric_limits<T>::min();
 	}
 	static constexpr T Maximum() {
 		return std::numeric_limits<T>::max();

--- a/src/include/duckdb/common/limits.hpp
+++ b/src/include/duckdb/common/limits.hpp
@@ -24,10 +24,12 @@ namespace duckdb {
 template <class T>
 struct NumericLimits {
 	static constexpr T Minimum() {
-		return std::numeric_limits<T>::min();
+		return std::numeric_limits<T>::has_infinity ? -std::numeric_limits<T>::infinity()
+		                                            : std::numeric_limits<T>::lowest();
 	}
 	static constexpr T Maximum() {
-		return std::numeric_limits<T>::max();
+		return std::numeric_limits<T>::has_infinity ? std::numeric_limits<T>::infinity()
+		                                            : std::numeric_limits<T>::max();
 	}
 	static constexpr bool IsSigned() {
 		return std::is_signed<T>::value;

--- a/test/sql/copy/parquet/copy_ninf_stats.test
+++ b/test/sql/copy/parquet/copy_ninf_stats.test
@@ -1,0 +1,13 @@
+# name: test/sql/copy/parquet/copy_ninf_stats.test
+# description: Negative infinity stats
+# group: [parquet]
+
+require parquet
+
+statement ok
+copy (select '-infinity'::double ninf) to '__TEST_DIR__/ninf.parquet';
+
+query II
+SELECT stats_min, stats_max FROM parquet_metadata('__TEST_DIR__/ninf.parquet')
+----
+NULL	NULL


### PR DESCRIPTION
Fix #20014