### PR TITLE
Fix #20029: accept "\e\\" as termination sequence, and add a timeout to TryGetBackgroundColor

### DIFF
--- a/tools/shell/linenoise/include/terminal.hpp
+++ b/tools/shell/linenoise/include/terminal.hpp
@@ -135,7 +135,7 @@ public:
 	static void Beep();
 
 	static bool IsAtty();
-	static int HasMoreData(int fd);
+	static int HasMoreData(int fd, idx_t timeout_micros = 0);
 	static TerminalSize GetTerminalSize();
 	static bool TryGetBackgroundColor(TerminalColor &color);
 


### PR DESCRIPTION
Fixes #20029