### PR TITLE
propagate gate status in Node4::DeleteChild

### DIFF
--- a/src/execution/index/art/base_node.cpp
+++ b/src/execution/index/art/base_node.cpp
@@ -95,7 +95,9 @@ void Node4::DeleteChild(ART &art, Node &node, Node &parent, const uint8_t byte, 
 
 	auto prev_node4_status = node.GetGateStatus();
 	Node::FreeNode(art, node);
-	Prefix::Concat(art, parent, node, child, remaining_byte, prev_node4_status);
+	// Propagate both the prev_node_4 status and the general gate status (if the gate was earlier on),
+	// since the concatenation logic depends on both.
+	Prefix::Concat(art, parent, node, child, remaining_byte, prev_node4_status, status);
 }
 
 void Node4::ShrinkNode16(ART &art, Node &node4, Node &node16) {

--- a/src/execution/index/art/prefix.cpp
+++ b/src/execution/index/art/prefix.cpp
@@ -65,8 +65,8 @@ void Prefix::New(ART &art, reference<Node> &ref, const ARTKey &key, const idx_t 
 	}
 }
 
-void Prefix::Concat(ART &art, Node &parent, Node &node4, const Node child, uint8_t byte,
-                    const GateStatus node4_status) {
+void Prefix::Concat(ART &art, Node &parent, Node &node4, const Node child, uint8_t byte, const GateStatus node4_status,
+                    const GateStatus status) {
 	// We have four situations from which we enter here:
 	// 1: PREFIX (parent) - Node4 (prev_node4) - PREFIX (child) - INLINED_LEAF, or
 	// 2: PREFIX (parent) - Node4 (prev_node4) - INLINED_LEAF (child), or
@@ -90,10 +90,7 @@ void Prefix::Concat(ART &art, Node &parent, Node &node4, const Node child, uint8
 		ConcatChildIsGate(art, parent, node4, child, byte);
 		return;
 	}
-
-	auto inside_gate = parent.GetGateStatus() == GateStatus::GATE_SET;
-	ConcatInternal(art, parent, node4, child, byte, inside_gate);
-	return;
+	ConcatInternal(art, parent, node4, child, byte, status);
 }
 
 void Prefix::Reduce(ART &art, Node &node, const idx_t pos) {
@@ -286,9 +283,9 @@ Prefix Prefix::GetTail(ART &art, const Node &node) {
 }
 
 void Prefix::ConcatInternal(ART &art, Node &parent, Node &node4, const Node child, uint8_t byte,
-                            const bool inside_gate) {
+                            const GateStatus status) {
 	if (child.GetType() == NType::LEAF_INLINED) {
-		if (inside_gate) {
+		if (status == GateStatus::GATE_SET) {
 			if (parent.GetType() == NType::PREFIX) {
 				// The parent only contained the Node4, so we can now inline 'all the way up',
 				// and the gate is no longer nested.

--- a/src/include/duckdb/execution/index/art/art_operator.hpp
+++ b/src/include/duckdb/execution/index/art/art_operator.hpp
@@ -256,6 +256,8 @@ public:
 				if (parent.get().GetType() == NType::PREFIX) {
 					// We might have to compress:
 					// PREFIX (greatgrandparent) - Node4 (grandparent) - PREFIX - INLINED_LEAF.
+					// The parent does not have to be passed in, as it is a child of the possibly being compressed N4.
+					// Then, when we delete that child, we also free it.
 					Node::DeleteChild(art, grandparent, greatgrandparent, current_key.get()[grandparent_depth], status,
 					                  row_id);
 					return;

--- a/src/include/duckdb/execution/index/art/prefix.hpp
+++ b/src/include/duckdb/execution/index/art/prefix.hpp
@@ -48,7 +48,7 @@ public:
 
 	//! Concatenates parent -> prev_node4 -> child.
 	static void Concat(ART &art, Node &parent, Node &node4, const Node child, uint8_t byte,
-	                   const GateStatus node4_status);
+	                   const GateStatus node4_status, const GateStatus status);
 
 	//! Removes up to pos bytes from the prefix.
 	//! Shifts all subsequent bytes by pos. Frees empty nodes.
@@ -72,7 +72,7 @@ private:
 	static Prefix GetTail(ART &art, const Node &node);
 
 	static void ConcatInternal(ART &art, Node &parent, Node &node4, const Node child, uint8_t byte,
-	                           const bool inside_gate);
+	                           const GateStatus status);
 	static void ConcatNode4WasGate(ART &art, Node &node4, const Node child, uint8_t byte);
 	static void ConcatChildIsGate(ART &art, Node &parent, Node &node4, const Node child, uint8_t byte);
 	static void ConcatOutsideGate(ART &art, Node &parent, Node &node4, const Node child, uint8_t byte);


### PR DESCRIPTION
Bugfix for https://github.com/duckdb/duckdb/issues/19975

Propagate gate status in Node4::DeleteChild, since Prefix::Concat logic depends on both the prev_node4 gate status (was the node4 being freed a gate node), as well as the overall gate status (did we enter through a gate at some point earlier). The latter was not being propagated correctly, and node compression logic for nested ARTs storing rowids depends on this, since we do not need to maintain prefix chains, as they are implicit in the rowid's. 

Unfortunately it is not possible to create a minimal test for this scenario, however once https://github.com/duckdblabs/duckdb-internal/issues/6083 is solved, there is a large reproducer for this scenario that I downloaded from the person who opened this issue (and the data/sql file is not confidential, so can be used). 

Thank you @taniabogatsch for dealing the final blow to this bug! 