### PR TITLE
Fix unnecessary dependent join rewrite

### DIFF
--- a/src/include/duckdb/planner/subquery/rewrite_cte_scan.hpp
+++ b/src/include/duckdb/planner/subquery/rewrite_cte_scan.hpp
@@ -17,13 +17,14 @@ namespace duckdb {
 //! Helper class to rewrite correlated cte scans within a single LogicalOperator
 class RewriteCTEScan : public LogicalOperatorVisitor {
 public:
-	RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns);
+	RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns, bool rewrite_dependent_joins = false);
 
 	void VisitOperator(LogicalOperator &op) override;
 
 private:
 	idx_t table_index;
 	const CorrelatedColumns &correlated_columns;
+	bool rewrite_dependent_joins = false;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/subquery/rewrite_cte_scan.hpp
+++ b/src/include/duckdb/planner/subquery/rewrite_cte_scan.hpp
@@ -17,7 +17,8 @@ namespace duckdb {
 //! Helper class to rewrite correlated cte scans within a single LogicalOperator
 class RewriteCTEScan : public LogicalOperatorVisitor {
 public:
-	RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns, bool rewrite_dependent_joins = false);
+	RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns,
+	               bool rewrite_dependent_joins = false);
 
 	void VisitOperator(LogicalOperator &op) override;
 

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -1031,7 +1031,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			}
 		}
 
-		RewriteCTEScan cte_rewriter(table_index, correlated_columns);
+		RewriteCTEScan cte_rewriter(table_index, correlated_columns, plan->type == LogicalOperatorType::LOGICAL_RECURSIVE_CTE);
 		cte_rewriter.VisitOperator(*plan->children[1]);
 
 		parent_propagate_null_values = false;

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -1031,7 +1031,8 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			}
 		}
 
-		RewriteCTEScan cte_rewriter(table_index, correlated_columns, plan->type == LogicalOperatorType::LOGICAL_RECURSIVE_CTE);
+		RewriteCTEScan cte_rewriter(table_index, correlated_columns,
+		                            plan->type == LogicalOperatorType::LOGICAL_RECURSIVE_CTE);
 		cte_rewriter.VisitOperator(*plan->children[1]);
 
 		parent_propagate_null_values = false;

--- a/src/planner/subquery/rewrite_cte_scan.cpp
+++ b/src/planner/subquery/rewrite_cte_scan.cpp
@@ -14,8 +14,10 @@
 
 namespace duckdb {
 
-RewriteCTEScan::RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns, bool rewrite_dependent_joins)
-    : table_index(table_index), correlated_columns(correlated_columns), rewrite_dependent_joins(rewrite_dependent_joins) {
+RewriteCTEScan::RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns,
+                               bool rewrite_dependent_joins)
+    : table_index(table_index), correlated_columns(correlated_columns),
+      rewrite_dependent_joins(rewrite_dependent_joins) {
 }
 
 void RewriteCTEScan::VisitOperator(LogicalOperator &op) {

--- a/src/planner/subquery/rewrite_cte_scan.cpp
+++ b/src/planner/subquery/rewrite_cte_scan.cpp
@@ -14,8 +14,8 @@
 
 namespace duckdb {
 
-RewriteCTEScan::RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns)
-    : table_index(table_index), correlated_columns(correlated_columns) {
+RewriteCTEScan::RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns, bool rewrite_dependent_joins)
+    : table_index(table_index), correlated_columns(correlated_columns), rewrite_dependent_joins(rewrite_dependent_joins) {
 }
 
 void RewriteCTEScan::VisitOperator(LogicalOperator &op) {
@@ -29,7 +29,7 @@ void RewriteCTEScan::VisitOperator(LogicalOperator &op) {
 			}
 			cteref.correlated_columns += correlated_columns.size();
 		}
-	} else if (op.type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN) {
+	} else if (op.type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN && rewrite_dependent_joins) {
 		// There is another DependentJoin below the correlated recursive CTE.
 		// We have to add the correlated columns of the recursive CTE to the
 		// set of columns of this operator.

--- a/test/issues/general/test_20016.test
+++ b/test/issues/general/test_20016.test
@@ -1,0 +1,22 @@
+# name: test/issues/general/test_20016.test
+# description: Issue 20016 - "INTERNAL Error: Failed to bind column reference" with CTE and generate_series
+# group: [general]
+
+query I
+select (
+    with cte_1 as (
+        select sum(1)
+        from generate_series(1, col_outer)
+    ), cte_2 as (
+        select (
+            select sum(1)
+            from generate_series(1, col_inner)
+        )
+        from (select 1 as col_inner) as inner_gen
+    )
+    select 1
+    from cte_1, cte_2
+) as middle
+from (select 1 as col_outer) as outer_gen;
+----
+1


### PR DESCRIPTION
During CTE decorrelation, the `RewriteCTEScan` class adds correlated columns (in case of multiple dependent joins) to child dependent joins. However, this is only required for recursive CTEs.

----

Fix: https://github.com/duckdb/duckdb/issues/20016