### PR TITLE
Allow Late Materialization for Parquet in TopNWindowElimination

### DIFF
--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -20,12 +20,6 @@ statement ok
 CREATE TABLE tbl2 AS SELECT * FROM VALUES (0, 'a'), (1, 'b'), (null, 'c'), t(x, y)
 
 statement ok
-COPY (SELECT * FROM VALUES (0, {'x': 0}, 0, 0), (0, {'x': 1}, 1, 1), (1, {'x': 2}, 2, 2), (null, {'x': 3}, 3, 3), (null, {'x': 4}, 4, 4), t(grp, a, b, x)) TO '__TEST_DIR__/window_elim_1.parquet'
-
-statement ok
-COPY (SELECT * FROM VALUES (0, {'x': 0}, 0, 0), (0, {'x': 1}, 1, 1), (1, {'x': 2}, 2, 2), (null, {'x': 3}, 3, 3), (null, {'x': 4}, 4, 4), t(grp, a, b, x)) TO '__TEST_DIR__/window_elim_2.parquet'
-
-statement ok
 CREATE MACRO window_fun(table_name, col_names, sort_order, topn) AS TABLE
 FROM query(
 	'SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ' || sort_order || ') as rn, ' || array_to_string(col_names, ',') || ' FROM ' || table_name || ' QUALIFY rn <= ' || topn || ') ORDER BY ALL'
@@ -102,23 +96,6 @@ query II
 EXPLAIN SELECT * FROM lateral_join('${sort_order}', ${topn})
 ----
 logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
-
-# late materialization on parquet
-query II
-EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM '__TEST_DIR__/window_elim_1.parquet' QUALIFY rn <= ${topn}) ORDER BY ALL
-----
-logical_opt	<REGEX>:.*COMPARISON_JOIN.*file_index.*=.*file_index.*file_row_number.*=.*file_row_number.*AGGREGATE.*
-
-query II
-EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM '__TEST_DIR__/window_elim_*.parquet' QUALIFY rn <= ${topn}) ORDER BY ALL
-----
-logical_opt	<REGEX>:.*COMPARISON_JOIN.*file_index.*=.*file_index.*file_row_number.*=.*file_row_number.*AGGREGATE.*
-
-statement ok
-SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM '__TEST_DIR__/window_elim_1.parquet' QUALIFY rn <= ${topn}) ORDER BY ALL
-
-statement ok
-SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM '__TEST_DIR__/window_elim_*.parquet' QUALIFY rn <= ${topn}) ORDER BY ALL
 
 statement ok
 CREATE TABLE ${sort_order}${topn}_1 AS SELECT * FROM window_fun('tbl', ['grp', 'a', 'b'], '${sort_order}', ${topn})

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -20,7 +20,10 @@ statement ok
 CREATE TABLE tbl2 AS SELECT * FROM VALUES (0, 'a'), (1, 'b'), (null, 'c'), t(x, y)
 
 statement ok
-COPY (SELECT * FROM VALUES (0, {'x': 0}, 0, 0), (0, {'x': 1}, 1, 1), (1, {'x': 2}, 2, 2), (null, {'x': 3}, 3, 3), (null, {'x': 4}, 4, 4), t(grp, a, b, x)) TO '__TEST_DIR__/window_elim.parquet'
+COPY (SELECT * FROM VALUES (0, {'x': 0}, 0, 0), (0, {'x': 1}, 1, 1), (1, {'x': 2}, 2, 2), (null, {'x': 3}, 3, 3), (null, {'x': 4}, 4, 4), t(grp, a, b, x)) TO '__TEST_DIR__/window_elim_1.parquet'
+
+statement ok
+COPY (SELECT * FROM VALUES (0, {'x': 0}, 0, 0), (0, {'x': 1}, 1, 1), (1, {'x': 2}, 2, 2), (null, {'x': 3}, 3, 3), (null, {'x': 4}, 4, 4), t(grp, a, b, x)) TO '__TEST_DIR__/window_elim_2.parquet'
 
 statement ok
 CREATE MACRO window_fun(table_name, col_names, sort_order, topn) AS TABLE
@@ -102,9 +105,20 @@ logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
 
 # late materialization on parquet
 query II
-EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM '__TEST_DIR__/window_elim.parquet' QUALIFY rn <= ${topn}) ORDER BY ALL
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM '__TEST_DIR__/window_elim_1.parquet' QUALIFY rn <= ${topn}) ORDER BY ALL
 ----
-logical_opt	<REGEX>:.*COMPARISON_JOIN.*rowid = rowid.*AGGREGATE.*
+logical_opt	<REGEX>:.*COMPARISON_JOIN.*file_index.*=.*file_index.*file_row_number.*=.*file_row_number.*AGGREGATE.*
+
+query II
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM '__TEST_DIR__/window_elim_*.parquet' QUALIFY rn <= ${topn}) ORDER BY ALL
+----
+logical_opt	<REGEX>:.*COMPARISON_JOIN.*file_index.*=.*file_index.*file_row_number.*=.*file_row_number.*AGGREGATE.*
+
+statement ok
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM '__TEST_DIR__/window_elim_1.parquet' QUALIFY rn <= ${topn}) ORDER BY ALL
+
+statement ok
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM '__TEST_DIR__/window_elim_*.parquet' QUALIFY rn <= ${topn}) ORDER BY ALL
 
 statement ok
 CREATE TABLE ${sort_order}${topn}_1 AS SELECT * FROM window_fun('tbl', ['grp', 'a', 'b'], '${sort_order}', ${topn})

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -2,6 +2,8 @@
 # description: Test Top-N Window Elimination Rule
 # group: [optimizer]
 
+require parquet
+
 statement ok
 PRAGMA enable_verification
 
@@ -16,6 +18,9 @@ CREATE TABLE tbl_with_null AS SELECT * FROM VALUES (0, [0], null), (0, [1], 1), 
 
 statement ok
 CREATE TABLE tbl2 AS SELECT * FROM VALUES (0, 'a'), (1, 'b'), (null, 'c'), t(x, y)
+
+statement ok
+COPY (SELECT * FROM VALUES (0, {'x': 0}, 0, 0), (0, {'x': 1}, 1, 1), (1, {'x': 2}, 2, 2), (null, {'x': 3}, 3, 3), (null, {'x': 4}, 4, 4), t(grp, a, b, x)) TO '__TEST_DIR__/window_elim.parquet'
 
 statement ok
 CREATE MACRO window_fun(table_name, col_names, sort_order, topn) AS TABLE
@@ -94,6 +99,12 @@ query II
 EXPLAIN SELECT * FROM lateral_join('${sort_order}', ${topn})
 ----
 logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+# late materialization on parquet
+query II
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM '__TEST_DIR__/window_elim.parquet' QUALIFY rn <= ${topn}) ORDER BY ALL
+----
+logical_opt	<REGEX>:.*COMPARISON_JOIN.*rowid = rowid.*AGGREGATE.*
 
 statement ok
 CREATE TABLE ${sort_order}${topn}_1 AS SELECT * FROM window_fun('tbl', ['grp', 'a', 'b'], '${sort_order}', ${topn})

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -17,7 +17,10 @@ statement ok
 CREATE TABLE tbl_with_null AS SELECT * FROM VALUES (0, [0], null), (0, [1], 1), (1, [2], null), (null, [3], 3), (null, [4], 4), t(grp, a, b)
 
 statement ok
-CREATE TABLE tbl2 AS SELECT * FROM VALUES (0, 'a'), (1, 'b'), (null, 'c'), t(x, y)
+CREATE TABLE tbl2(generated_col AS (x + 1), x INTEGER, y VARCHAR)
+
+statement ok
+INSERT INTO tbl2 VALUES (0, 'a'), (1, 'b'), (null, 'c')
 
 statement ok
 CREATE MACRO window_fun(table_name, col_names, sort_order, topn) AS TABLE

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -2,8 +2,6 @@
 # description: Test Top-N Window Elimination Rule
 # group: [optimizer]
 
-require parquet
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/optimizer/topn_window_elimination_parquet.test_slow
+++ b/test/optimizer/topn_window_elimination_parquet.test_slow
@@ -1,0 +1,122 @@
+# name: test/optimizer/topn_window_elimination_parquet.test_slow
+# description: Test Top-N Window Elimination Rule
+# group: [optimizer]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+statement ok
+COPY (SELECT * FROM VALUES (0, {'x': 0}, 0), (0, {'x': 1}, 1), (1, {'x': 2}, 2), (null, {'x': 3}, 3), (null, {'x': 4}, 4), t(grp, a, b)) TO '__TEST_DIR__/tbl.parquet'
+
+statement ok
+COPY (SELECT * FROM VALUES (0, [0], null), (0, [1], 1), (1, [2], null), (null, [3], 3), (null, [4], 4), t(grp, a, b)) TO '__TEST_DIR__/tbl_with_null.parquet'
+
+statement ok
+COPY (SELECT * FROM VALUES (0, 'a'), (1, 'b'), (null, 'c'), t(x, y)) TO '__TEST_DIR__/tbl2.parquet'
+
+# test min_max
+foreach sort_order ASC DESC
+
+# test topn sizes
+loop topn 1 3
+
+# min/max
+query II
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp FROM read_parquet('__TEST_DIR__/tbl.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+----
+logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+statement ok
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp FROM read_parquet('__TEST_DIR__/tbl.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+
+# arg_min/max, no struct_pack
+query II
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a FROM read_parquet('__TEST_DIR__/tbl.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+----
+logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+statement ok
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a FROM read_parquet('__TEST_DIR__/tbl.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+
+# arg_min/max with struct_pack
+query II
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b FROM read_parquet('__TEST_DIR__/tbl.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+----
+logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+statement ok
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b FROM read_parquet('__TEST_DIR__/tbl.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+
+# min/max and nulls
+query II
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp FROM read_parquet('__TEST_DIR__/tbl_with_null.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+----
+logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+statement ok
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp FROM read_parquet('__TEST_DIR__/tbl_with_null.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+
+# arg_min/max, no struct_pack and nulls
+query II
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a FROM read_parquet('__TEST_DIR__/tbl_with_null.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+----
+logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+statement ok
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a FROM read_parquet('__TEST_DIR__/tbl_with_null.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+
+
+# arg_min/max with struct_pack and nulls
+query II
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b FROM read_parquet('__TEST_DIR__/tbl_with_null.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+----
+logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+statement ok
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b FROM read_parquet('__TEST_DIR__/tbl_with_null.parquet') QUALIFY rn <= ${topn}) ORDER BY ALL
+
+# window function with join and one-sided projections
+query II
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b FROM read_parquet('__TEST_DIR__/tbl.parquet') JOIN read_parquet('__TEST_DIR__/tbl2.parquet') ON grp = x QUALIFY rn <= ${topn}) ORDER BY ALL
+----
+logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+statement ok
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b FROM read_parquet('__TEST_DIR__/tbl.parquet') JOIN read_parquet('__TEST_DIR__/tbl2.parquet') ON grp = x QUALIFY rn <= ${topn}) ORDER BY ALL
+
+# window function with join and one-sided projections + join column
+# expect no late materialization as struct size is not smaller than 2
+query II
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM read_parquet('__TEST_DIR__/tbl.parquet') JOIN read_parquet('__TEST_DIR__/tbl2.parquet') ON grp = x QUALIFY rn <= ${topn}) ORDER BY ALL
+----
+logical_opt	<!REGEX>:.*COMPARISON_JOIN.*rowid = rowid.*AGGREGATE.*
+
+statement ok
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, x FROM read_parquet('__TEST_DIR__/tbl.parquet') JOIN read_parquet('__TEST_DIR__/tbl2.parquet') ON grp = x QUALIFY rn <= ${topn}) ORDER BY ALL
+
+# window function with join and two-sided projections
+query II
+EXPLAIN SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, y FROM read_parquet('__TEST_DIR__/tbl.parquet') JOIN read_parquet('__TEST_DIR__/tbl2.parquet') ON grp = x QUALIFY rn <= ${topn}) ORDER BY ALL
+----
+logical_opt	<!REGEX>:.*COMPARISON_JOIN.*rowid = rowid.*AGGREGATE.*
+
+statement ok
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY grp ORDER BY b ${sort_order}) as rn, grp, a, b, y FROM read_parquet('__TEST_DIR__/tbl.parquet') JOIN read_parquet('__TEST_DIR__/tbl2.parquet') ON grp = x QUALIFY rn <= ${topn}) ORDER BY ALL
+
+# test lateral join
+query II
+EXPLAIN SELECT t1.* FROM read_parquet('__TEST_DIR__/tbl.parquet') t1 INNER JOIN LATERAL (SELECT * FROM read_parquet('__TEST_DIR__/tbl.parquet') t2 WHERE t1.grp = t2.grp ORDER BY b ${sort_order} LIMIT ${topn}) ON true
+----
+logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+statement ok
+SELECT t1.* FROM read_parquet('__TEST_DIR__/tbl.parquet') t1 INNER JOIN LATERAL (SELECT * FROM read_parquet('__TEST_DIR__/tbl.parquet') t2 WHERE t1.grp = t2.grp ORDER BY b ${sort_order} LIMIT ${topn}) ON true
+
+endloop
+
+endloop

--- a/test/optimizer/topn_window_elimination_parquet.test_slow
+++ b/test/optimizer/topn_window_elimination_parquet.test_slow
@@ -2,8 +2,6 @@
 # description: Test Top-N Window Elimination Rule
 # group: [optimizer]
 
-require parquet
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/optimizer/topn_window_elimination_parquet.test_slow
+++ b/test/optimizer/topn_window_elimination_parquet.test_slow
@@ -2,6 +2,8 @@
 # description: Test Top-N Window Elimination Rule
 # group: [optimizer]
 
+require parquet
+
 statement ok
 PRAGMA enable_verification
 


### PR DESCRIPTION
This is a follow-up on https://github.com/duckdb/duckdb/pull/19463.

This PR enables late materialization also for Parquet files in the `TopNWindowEliminationRule`. The performance benefit here is expected to be a bit smaller compared to DuckDBs own storage as we still have to `struct_pack` Parquet's two virtual rowid columns. However, this can still be very useful for reducing data transfer with remote parquet files.