### PR TITLE
 fix(adbc): return error when setting an empty sql query

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -13,6 +13,8 @@
 #include "duckdb/common/adbc/single_batch_array_stream.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/common/adbc/wrappers.hpp"
+#include <algorithm>
+#include <cstring>
 #include <stdlib.h>
 #include <string.h>
 
@@ -871,6 +873,10 @@ AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct Arr
 			out->release = nullptr;
 			out->get_last_error = nullptr;
 		}
+
+		if (rows_affected) {
+			*rows_affected = 0;
+		}
 		return ADBC_STATUS_OK;
 	}
 
@@ -998,7 +1004,9 @@ AdbcStatusCode StatementSetSqlQuery(struct AdbcStatement *statement, const char 
 		SetError(error, "Missing query");
 		return ADBC_STATUS_INVALID_ARGUMENT;
 	}
-	if (strlen(query) == 0) {
+
+	auto query_len = strlen(query);
+	if (std::all_of(query, query + query_len, duckdb::StringUtil::CharacterIsSpace)) {
 		SetError(error, "No statements found");
 		return ADBC_STATUS_INVALID_ARGUMENT;
 	}

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -146,13 +146,7 @@ TEST_CASE("ADBC - non-empty query without actual statements", "[adbc]") {
 	}
 	ADBCTestDatabase db;
 
-	SECTION("Whitespace") {
-		REQUIRE(db.QueryAndCheck(" "));
-	}
-
-	SECTION("Line comment") {
-		REQUIRE(db.QueryAndCheck("--"));
-	}
+	REQUIRE(db.QueryAndCheck("--"));
 }
 
 TEST_CASE("ADBC - Test ingestion", "[adbc]") {
@@ -1221,7 +1215,13 @@ TEST_CASE("ADBC - Empty sql (unhappy)", "[adbc]") {
 	AdbcError adbc_error;
 	InitializeADBCError(&adbc_error);
 
-	string query = "";
+	string query;
+	SECTION("Empty") {
+		query = "";
+	}
+	SECTION("Whitespace") {
+		query = " \n";
+	}
 
 	// Create connection - database and whatnot
 	REQUIRE(SUCCESS(AdbcDatabaseNew(&adbc_database, &adbc_error)));

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -140,6 +140,21 @@ TEST_CASE("ADBC - Select 42", "[adbc]") {
 	REQUIRE(db.QueryAndCheck("SELECT 42"));
 }
 
+TEST_CASE("ADBC - non-empty query without actual statements", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+	ADBCTestDatabase db;
+
+	SECTION("Whitespace") {
+		REQUIRE(db.QueryAndCheck(" "));
+	}
+
+	SECTION("Line comment") {
+		REQUIRE(db.QueryAndCheck("--"));
+	}
+}
+
 TEST_CASE("ADBC - Test ingestion", "[adbc]") {
 	if (!duckdb_lib) {
 		return;
@@ -1193,6 +1208,43 @@ TEST_CASE("Test AdbcConnectionGetTableTypes", "[adbc]") {
 	auto res = db.Query("Select * from result");
 	REQUIRE((res->ColumnCount() == 1));
 	REQUIRE((res->GetValue(0, 0).ToString() == "BASE TABLE"));
+	adbc_error.release(&adbc_error);
+}
+
+TEST_CASE("ADBC - Empty sql (unhappy)", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+	AdbcDatabase adbc_database;
+	AdbcConnection adbc_connection;
+
+	AdbcError adbc_error;
+	InitializeADBCError(&adbc_error);
+
+	string query = "";
+
+	// Create connection - database and whatnot
+	REQUIRE(SUCCESS(AdbcDatabaseNew(&adbc_database, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "driver", duckdb_lib, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "entrypoint", "duckdb_adbc_init", &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "path", ":memory:", &adbc_error)));
+
+	REQUIRE(SUCCESS(AdbcDatabaseInit(&adbc_database, &adbc_error)));
+
+	REQUIRE(SUCCESS(AdbcConnectionNew(&adbc_connection, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcConnectionInit(&adbc_connection, &adbc_database, &adbc_error)));
+
+	AdbcStatement adbc_statement;
+	REQUIRE(SUCCESS(AdbcStatementNew(&adbc_connection, &adbc_statement, &adbc_error)));
+	auto status = AdbcStatementSetSqlQuery(&adbc_statement, query.c_str(), &adbc_error);
+
+	REQUIRE((status == ADBC_STATUS_INVALID_ARGUMENT));
+
+	REQUIRE(SUCCESS(AdbcStatementRelease(&adbc_statement, &adbc_error)));
+
+	REQUIRE(SUCCESS(AdbcConnectionRelease(&adbc_connection, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseRelease(&adbc_database, &adbc_error)));
+
 	adbc_error.release(&adbc_error);
 }
 

--- a/test/arrow/arrow_test_helper.cpp
+++ b/test/arrow/arrow_test_helper.cpp
@@ -153,6 +153,11 @@ bool ArrowTestHelper::CompareResults(Connection &con, unique_ptr<QueryResult> ar
                                      unique_ptr<MaterializedQueryResult> duck, const string &query) {
 	auto &materialized_arrow = (MaterializedQueryResult &)*arrow;
 	// compare the results
+	if (materialized_arrow.statement_type == StatementType::INVALID_STATEMENT ||
+	    duck->statement_type == StatementType::INVALID_STATEMENT) {
+		return materialized_arrow.type == duck->type;
+	}
+
 	string error;
 
 	auto arrow_collection = materialized_arrow.TakeCollection();
@@ -273,12 +278,22 @@ bool ArrowTestHelper::RunArrowComparison(Connection &con, const string &query, b
 }
 
 bool ArrowTestHelper::RunArrowComparison(Connection &con, const string &query, ArrowArrayStream &arrow_stream) {
-	// construct the arrow scan
-	auto params = ConstructArrowScan(arrow_stream);
+	unique_ptr<QueryResult> arrow_result;
+	if (!arrow_stream.private_data) {
+		// no data, treat as empty result
+		StatementProperties properties;
+		vector<string> names;
+		auto collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator());
+		arrow_result = make_uniq<MaterializedQueryResult>(StatementType::INVALID_STATEMENT, properties,
+		                                                  std::move(names), std::move(collection), ClientProperties());
+	} else {
+		// construct the arrow scan
+		auto params = ConstructArrowScan(arrow_stream);
 
-	// run the arrow scan over the result
-	auto arrow_result = ScanArrowObject(con, params);
-	arrow_stream.release = nullptr;
+		// run the arrow scan over the result
+		arrow_result = ScanArrowObject(con, params);
+		arrow_stream.release = nullptr;
+	}
 
 	if (!arrow_result) {
 		printf("Query: %s\n", query.c_str());


### PR DESCRIPTION
Return an error instead of a segmentation fault.

This is also an issue in the main branch.

Fixes #20050