### PR TITLE
CLI: Improve rendering of wide values, and improve auto-complete

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -83,6 +83,7 @@ bool PreferCaseMatching(SuggestionState suggestion_state) {
 	case SuggestionState::SUGGEST_TABLE_FUNCTION_NAME:
 	case SuggestionState::SUGGEST_PRAGMA_NAME:
 	case SuggestionState::SUGGEST_SETTING_NAME:
+	case SuggestionState::SUGGEST_FILE_NAME:
 		return true;
 	default:
 		return false;
@@ -115,11 +116,12 @@ static vector<AutoCompleteSuggestion> ComputeSuggestions(vector<AutoCompleteCand
 
 		D_ASSERT(BASE_SCORE - bonus >= 0);
 		auto score = idx_t(BASE_SCORE - bonus);
+		idx_t match_score = 0;
 		if (prefix.empty()) {
 		} else if (prefix.size() < str.size()) {
-			score += StringUtil::SimilarityScore(str.substr(0, prefix.size()), prefix);
+			match_score = StringUtil::SimilarityScore(str.substr(0, prefix.size()), prefix);
 		} else {
-			score += StringUtil::SimilarityScore(str, prefix);
+			match_score = StringUtil::SimilarityScore(str, prefix);
 		}
 		auto type = available_suggestions[i].suggestion_type;
 		if (str[0] == '.') {
@@ -133,9 +135,10 @@ static vector<AutoCompleteSuggestion> ComputeSuggestions(vector<AutoCompleteCand
 			score += SUBSTRING_PENALTY;
 		} else if (PreferCaseMatching(type) && !StringUtil::Contains(str, prefix)) {
 			// for types for which we prefer case matching - add a small penalty if we are not matching case
-			score++;
+			match_score++;
 		}
-		suggestion.score = score;
+		score += match_score;
+		suggestion.score = match_score;
 		scores.emplace_back(str, score);
 	}
 	idx_t fuzzy_suggestion_count = parameters.max_suggestion_count;

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -1723,7 +1723,9 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 		row.values = std::move(values);
 	}
 	// check if we shortened any columns that would be rendered and if we can expand them
-	if (shortened_columns && config.render_mode == RenderMode::ROWS && render_rows.size() < config.max_rows) {
+	// we only expand columns in the ".mode rows", and only if we haven't hidden any columns
+	if (shortened_columns && config.render_mode == RenderMode::ROWS && render_rows.size() < config.max_rows &&
+	    !added_split_column) {
 		// if we have shortened any columns - try to expand them
 		// how many rows do we have left to expand before we hit the max row limit?
 		idx_t max_rows_per_row = config.max_rows / render_rows.size();

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -1759,10 +1759,6 @@ void BoxRendererImplementation::ComputeRenderWidths(list<ColumnDataCollection> &
 				auto render_width = row.values[c].render_width.GetIndex();
 				if (render_width <= column_widths[c]) {
 					// not shortened - skip
-					if (c == 0) {
-						// if the first row is not stretched out, we don't need to add a separator
-						need_extra_row = false;
-					}
 					continue;
 				}
 				// this value was shortened! try to stretch it out


### PR DESCRIPTION
* When shortening wide columns, prefer to shorten the widest columns first before shortening less wide columns, instead of shortening everything by an equal percentage. This means that if we have a table that is e.g. `name, description` - where `name` is slightly above the "wide" threshold (20 bytes) and "description" is significantly above this threshold, we will only shorten the description field - keeping `name` readable.
* When stretching out values across rows, give all rows the same amount of space for stretching out, instead of greedily stretching out the first rows
* Don't stretch out columns across rows if there are hidden columns in the result set 
* Always add a separator between rows if we are stretching out columns
* For auto-complete, use only the match score instead of the "adjusted sort score" when determining if there are ties or not. This way if we have a directory that has e.g. `my_dir/` and `my_file.parquet` as auto-complete options, `my_` will not instantly auto-complete to `my_dir/` but instead consider this a tie. `my_dir/` will still appear first in the sorted suggestion list, however.