### PR TITLE
feat: Implement CountWindowElimination optimizer rule

### DIFF
--- a/src/common/enums/metric_type.cpp
+++ b/src/common/enums/metric_type.cpp
@@ -172,7 +172,7 @@ MetricType MetricsUtils::GetOptimizerMetricByType(OptimizerType type) {
 	const auto idx = static_cast<uint8_t>(type) - base_opt;
 
 	const auto metric_u8 = static_cast<uint8_t>(START_OPTIMIZER + idx);
-	if (metric_u8 < START_OPTIMIZER || metric_u8 > END_OPTIMIZER) {
+    if (metric_u8 < START_OPTIMIZER || metric_u8 > END_OPTIMIZER) { // This shouldn't happen, but we want to fail gracefully if it does
 		throw InternalException("OptimizerType out of MetricType optimizer range");
 	}
 	return static_cast<MetricType>(metric_u8);

--- a/src/common/enums/optimizer_type.cpp
+++ b/src/common/enums/optimizer_type.cpp
@@ -45,6 +45,7 @@ static const DefaultOptimizerType internal_optimizer_types[] = {
     {"cte_inlining", OptimizerType::CTE_INLINING},
     {"common_subplan", OptimizerType::COMMON_SUBPLAN},
     {"join_elimination", OptimizerType::JOIN_ELIMINATION},
+    {"count_window_elimination", OptimizerType::COUNT_WINDOW_ELIMINATION},
     {nullptr, OptimizerType::INVALID}};
 
 string OptimizerTypeToString(OptimizerType type) {

--- a/src/include/duckdb/common/enums/metric_type.hpp
+++ b/src/include/duckdb/common/enums/metric_type.hpp
@@ -93,6 +93,7 @@ enum class MetricType : uint8_t {
 	OPTIMIZER_CTE_INLINING,
 	OPTIMIZER_COMMON_SUBPLAN,
 	OPTIMIZER_JOIN_ELIMINATION,
+	OPTIMIZER_COUNT_WINDOW_ELIMINATION,
 	// PhaseTiming metrics
 	ALL_OPTIMIZERS,
 	CUMULATIVE_OPTIMIZER_TIMING,
@@ -128,7 +129,7 @@ public:
 	static constexpr uint8_t END_OPERATOR = static_cast<uint8_t>(MetricType::OPERATOR_TYPE);
 
 	static constexpr uint8_t START_OPTIMIZER = static_cast<uint8_t>(MetricType::OPTIMIZER_EXPRESSION_REWRITER);
-	static constexpr uint8_t END_OPTIMIZER = static_cast<uint8_t>(MetricType::OPTIMIZER_JOIN_ELIMINATION);
+	static constexpr uint8_t END_OPTIMIZER = static_cast<uint8_t>(MetricType::OPTIMIZER_COUNT_WINDOW_ELIMINATION);
 
 	static constexpr uint8_t START_PHASE_TIMING = static_cast<uint8_t>(MetricType::ALL_OPTIMIZERS);
 	static constexpr uint8_t END_PHASE_TIMING = static_cast<uint8_t>(MetricType::PLANNER_BINDING);

--- a/src/include/duckdb/common/enums/optimizer_type.hpp
+++ b/src/include/duckdb/common/enums/optimizer_type.hpp
@@ -46,7 +46,8 @@ enum class OptimizerType : uint32_t {
 	LATE_MATERIALIZATION,
 	CTE_INLINING,
 	COMMON_SUBPLAN,
-	JOIN_ELIMINATION
+	JOIN_ELIMINATION,
+	COUNT_WINDOW_ELIMINATION
 };
 
 string OptimizerTypeToString(OptimizerType type);

--- a/src/include/duckdb/optimizer/count_window_elimination.hpp
+++ b/src/include/duckdb/optimizer/count_window_elimination.hpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/count_window_elimination.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/optimizer/optimizer.hpp"
+
+#include "duckdb/optimizer/column_binding_replacer.hpp"
+
+namespace duckdb {
+
+class CountWindowElimination {
+public:
+	explicit CountWindowElimination(Optimizer &optimizer);
+
+	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op);
+
+private:
+	unique_ptr<LogicalOperator> OptimizeInternal(unique_ptr<LogicalOperator> op, ColumnBindingReplacer &replacer);
+
+	Optimizer &optimizer;
+};
+
+} // namespace duckdb

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library_unity(
   common_aggregate_optimizer.cpp
   common_subplan_optimizer.cpp
   compressed_materialization.cpp
+  count_window_elimination.cpp
   cse_optimizer.cpp
   cte_filter_pusher.cpp
   cte_inlining.cpp

--- a/src/optimizer/count_window_elimination.cpp
+++ b/src/optimizer/count_window_elimination.cpp
@@ -1,0 +1,271 @@
+#include "duckdb/optimizer/count_window_elimination.hpp"
+#include "duckdb/common/printer.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_window.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/planner/expression/bound_window_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/aggregate_state.hpp"
+#include "duckdb/planner/operator/logical_cross_product.hpp"
+#include "duckdb/planner/operator/logical_dummy_scan.hpp"
+#include "duckdb/planner/logical_operator_visitor.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+
+namespace duckdb {
+
+class TableRebinder : public LogicalOperatorVisitor {
+public:
+	TableRebinder(Optimizer &optimizer) : optimizer(optimizer) {
+	}
+
+	unordered_map<idx_t, idx_t> table_map;
+	Optimizer &optimizer;
+
+	void VisitOperator(LogicalOperator &op) override {
+		// Rebind definitions
+		if (op.type == LogicalOperatorType::LOGICAL_GET) {
+			auto &get = op.Cast<LogicalGet>();
+			auto new_idx = optimizer.binder.GenerateTableIndex();
+			table_map[get.table_index] = new_idx;
+			get.table_index = new_idx;
+		}
+		if (op.type == LogicalOperatorType::LOGICAL_PROJECTION) {
+			auto &proj = op.Cast<LogicalProjection>();
+			auto new_idx = optimizer.binder.GenerateTableIndex();
+			table_map[proj.table_index] = new_idx;
+			proj.table_index = new_idx;
+		}
+		if (op.type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
+			auto &agg = op.Cast<LogicalAggregate>();
+			auto new_agg_idx = optimizer.binder.GenerateTableIndex();
+			auto new_grp_idx = optimizer.binder.GenerateTableIndex();
+			table_map[agg.aggregate_index] = new_agg_idx;
+			table_map[agg.group_index] = new_grp_idx;
+			agg.aggregate_index = new_agg_idx;
+			agg.group_index = new_grp_idx;
+		}
+		// TODO: Handle other operators defining tables if needed
+		// But Get/Projection/Aggregate are most common in subplans.
+
+		VisitOperatorChildren(op);
+		VisitOperatorExpressions(op);
+	}
+
+	void VisitExpression(unique_ptr<Expression> *expression) override {
+		auto &expr = *expression;
+		if (expr->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+			auto &bound = expr->Cast<BoundColumnRefExpression>();
+			if (table_map.count(bound.binding.table_index)) {
+				bound.binding.table_index = table_map[bound.binding.table_index];
+			}
+		}
+		VisitExpressionChildren(**expression);
+	}
+};
+
+CountWindowElimination::CountWindowElimination(Optimizer &optimizer) : optimizer(optimizer) {
+}
+
+unique_ptr<LogicalOperator> CountWindowElimination::Optimize(unique_ptr<LogicalOperator> op) {
+	ColumnBindingReplacer replacer;
+	op = OptimizeInternal(std::move(op), replacer);
+	if (!replacer.replacement_bindings.empty()) {
+		replacer.VisitOperator(*op);
+	}
+	return op;
+}
+
+unique_ptr<LogicalOperator> CountWindowElimination::OptimizeInternal(unique_ptr<LogicalOperator> op,
+                                                                     ColumnBindingReplacer &replacer) {
+	if (op->type == LogicalOperatorType::LOGICAL_FILTER) {
+		auto &filter = op->Cast<LogicalFilter>();
+		if (filter.expressions.size() == 1 && filter.children.size() == 1 &&
+		    filter.children[0]->type == LogicalOperatorType::LOGICAL_WINDOW) {
+			auto &window = filter.children[0]->Cast<LogicalWindow>();
+
+			// Check recursively
+			window.children[0] = OptimizeInternal(std::move(window.children[0]), replacer);
+
+			if (window.expressions.size() != 1) {
+				return op;
+			}
+			if (window.expressions[0]->type != ExpressionType::WINDOW_AGGREGATE) {
+				return op;
+			}
+
+			// We can only optimize if there is a single window function equality comparison
+			// Check matches
+			if (filter.expressions[0]->type != ExpressionType::COMPARE_EQUAL) {
+				return op;
+			}
+			auto &comp = filter.expressions[0]->Cast<BoundComparisonExpression>();
+			if (comp.left->type != ExpressionType::BOUND_COLUMN_REF) {
+				return op;
+			}
+			auto &col_ref = comp.left->Cast<BoundColumnRefExpression>();
+			auto t_idx = col_ref.binding.table_index;
+			auto c_idx = col_ref.binding.column_index;
+			auto w_idx = window.window_index;
+
+			if (t_idx != w_idx || c_idx != 0) {
+				return op;
+			}
+
+			// Check right side is constant 1
+			if (comp.right->type != ExpressionType::VALUE_CONSTANT) {
+				return op;
+			}
+			auto &const_expr = comp.right->Cast<BoundConstantExpression>();
+			if (!const_expr.value.type().IsIntegral()) {
+				return op;
+			}
+			if (const_expr.value.GetValue<int64_t>() != 1) {
+				return op;
+			}
+
+			auto &w_expr = window.expressions[0]->Cast<BoundWindowExpression>();
+			if (w_expr.aggregate->name != "count" && w_expr.aggregate->name != "count_star") {
+				return op;
+			}
+			if (!w_expr.orders.empty()) {
+				return op;
+			}
+			if (w_expr.partitions.empty()) {
+				return op;
+			}
+
+			// --- Transformation ---
+
+			auto original_child = std::move(window.children[0]);
+			auto copy_child = original_child->Copy(optimizer.context);
+
+			// Rebind copy_child to avoid duplicate table indices
+			TableRebinder rebinder(optimizer);
+			rebinder.VisitOperator(*copy_child);
+
+			auto aggregate_index = optimizer.binder.GenerateTableIndex();
+			auto group_index = optimizer.binder.GenerateTableIndex();
+
+			vector<unique_ptr<Expression>> groups;
+			vector<unique_ptr<Expression>> aggregates;
+
+			// Create Aggregate Operator
+			for (auto &part : w_expr.partitions) {
+				auto part_copy = part->Copy();
+				rebinder.VisitExpression(&part_copy); // Update bindings
+				groups.push_back(std::move(part_copy));
+			}
+
+			auto count_func = *w_expr.aggregate;
+			unique_ptr<FunctionData> bind_info;
+			if (w_expr.bind_info) {
+				bind_info = w_expr.bind_info->Copy();
+			} else {
+				bind_info = nullptr;
+			}
+
+			vector<unique_ptr<Expression>> children;
+			for (auto &child : w_expr.children) {
+				auto child_copy = child->Copy();
+				rebinder.VisitExpression(&child_copy); // Update bindings
+				children.push_back(std::move(child_copy));
+			}
+
+			auto aggr_type = w_expr.distinct ? AggregateType::DISTINCT : AggregateType::NON_DISTINCT;
+
+			auto agg_expr = make_uniq<BoundAggregateExpression>(std::move(count_func), std::move(children), nullptr,
+			                                                    std::move(bind_info), aggr_type);
+
+			aggregates.push_back(std::move(agg_expr));
+
+			// args: group_index, aggregate_index, ...
+			auto agg_op = make_uniq<LogicalAggregate>(group_index, aggregate_index, std::move(aggregates));
+
+			agg_op->groups = std::move(groups);
+			agg_op->children.push_back(std::move(copy_child));
+			agg_op->ResolveOperatorTypes();
+
+			if (agg_op->types.size() <= agg_op->groups.size()) {
+				throw InternalException("LogicalAggregate types size mismatch");
+			}
+
+			// Filter on aggregate: count = 1
+			// Count is the first aggregate, so it's at agg_op->groups.size() in the types list
+			// Bindings: Aggregates are at aggregate_index
+			auto cnt_ref = make_uniq<BoundColumnRefExpression>(agg_op->types[agg_op->groups.size()],
+			                                                   ColumnBinding(aggregate_index, 0));
+
+			auto filter_expr =
+			    make_uniq<BoundComparisonExpression>(ExpressionType::COMPARE_EQUAL, std::move(cnt_ref),
+			                                         make_uniq<BoundConstantExpression>(Value::BIGINT(1)));
+
+			auto rhs_filter = make_uniq<LogicalFilter>();
+			rhs_filter->expressions.push_back(std::move(filter_expr));
+			rhs_filter->children.push_back(std::move(agg_op));
+			rhs_filter->ResolveOperatorTypes();
+
+			// Semi Join
+			auto join = make_uniq<LogicalComparisonJoin>(JoinType::SEMI);
+
+			for (size_t i = 0; i < w_expr.partitions.size(); ++i) {
+				JoinCondition cond;
+				cond.comparison = ExpressionType::COMPARE_EQUAL;
+				cond.left = w_expr.partitions[i]->Copy();
+				cond.right = make_uniq<BoundColumnRefExpression>(w_expr.partitions[i]->return_type,
+				                                                 ColumnBinding(group_index, i));
+				join->conditions.push_back(std::move(cond));
+			}
+
+			join->children.push_back(std::move(original_child));
+			join->children.push_back(std::move(rhs_filter));
+			join->ResolveOperatorTypes();
+
+			// Create Constant 1
+			auto dummy_index = optimizer.binder.GenerateTableIndex();
+			auto dummy = make_uniq<LogicalDummyScan>(dummy_index);
+			dummy->ResolveOperatorTypes();
+
+			auto const_one = make_uniq<BoundConstantExpression>(Value::BIGINT(1));
+			const_one->alias = "count_window_result";
+
+			auto proj_index = optimizer.binder.GenerateTableIndex();
+			vector<unique_ptr<Expression>> proj_expressions;
+			proj_expressions.push_back(std::move(const_one));
+
+			auto projection = make_uniq<LogicalProjection>(proj_index, std::move(proj_expressions));
+			projection->children.push_back(std::move(dummy));
+			projection->ResolveOperatorTypes();
+
+			// Cross Product
+			auto cross = make_uniq<LogicalCrossProduct>(std::move(join), std::move(projection));
+			cross->ResolveOperatorTypes();
+
+			// Replace Count binding
+			// Old window column: (window.window_index, 0)
+			// New constant column: (proj_index, 0)
+			ColumnBinding old_binding(window.window_index, 0);
+			ColumnBinding new_binding(proj_index, 0);
+
+			replacer.replacement_bindings.emplace_back(old_binding, new_binding);
+
+			// We do NOT need to replace other bindings because CrossProduct preserves left child bindings,
+			// and Window (presumably) passed through input bindings without re-binding.
+
+			return std::move(cross);
+		}
+	} else if (!op->children.empty()) {
+		for (auto &child : op->children) {
+			child = OptimizeInternal(std::move(child), replacer);
+		}
+	}
+	return op;
+}
+
+} // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -38,6 +38,7 @@
 #include "duckdb/optimizer/unnest_rewriter.hpp"
 #include "duckdb/optimizer/late_materialization.hpp"
 #include "duckdb/optimizer/common_subplan_optimizer.hpp"
+#include "duckdb/optimizer/count_window_elimination.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/planner.hpp"
 
@@ -184,6 +185,11 @@ void Optimizer::RunBuiltInOptimizers() {
 	RunOptimizer(OptimizerType::EMPTY_RESULT_PULLUP, [&]() {
 		EmptyResultPullup empty_result_pullup;
 		plan = empty_result_pullup.Optimize(std::move(plan));
+	});
+
+	RunOptimizer(OptimizerType::COUNT_WINDOW_ELIMINATION, [&]() {
+		CountWindowElimination count_window_elimination(*this);
+		plan = count_window_elimination.Optimize(std::move(plan));
 	});
 
 	// then we perform the join ordering optimization

--- a/test/sql/optimizer/test_count_window_elimination.test
+++ b/test/sql/optimizer/test_count_window_elimination.test
@@ -1,0 +1,75 @@
+# name: test/sql/optimizer/test_count_window_elimination.test
+# description: Test Count Window Elimination optimizer
+# group: [optimizer]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE services (date DATE, train_number INT);
+
+statement ok
+INSERT INTO services VALUES ('2024-01-01', 100), ('2024-01-01', 100), ('2024-01-01', 101), ('2024-01-02', 100);
+
+# 1. Basic Case: count(*) = 1
+# Should be optimized to SEMI JOIN
+query II
+EXPLAIN FROM services QUALIFY count(*) OVER(PARTITION BY date, train_number) = 1;
+----
+physical_plan	<REGEX>:.*Join Type: SEMI.*
+
+query II
+FROM services QUALIFY count(*) OVER(PARTITION BY date, train_number) = 1;
+----
+2024-01-01	101
+2024-01-02	100
+
+# 2. Case with explicit count(*) function (if different syntax supported)
+# DuckDB treats count(*) same as count() usually.
+
+# 3. Case where optimization should NOT apply: count(*) > 1
+query II
+EXPLAIN FROM services QUALIFY count(*) OVER(PARTITION BY date, train_number) > 1;
+----
+physical_plan	<REGEX>:.*WINDOW.*
+
+query II
+FROM services QUALIFY count(*) OVER(PARTITION BY date, train_number) > 1;
+----
+2024-01-01	100
+2024-01-01	100
+
+# 4. Case where optimization should NOT apply: count(*) = 2
+query II
+EXPLAIN FROM services QUALIFY count(*) OVER(PARTITION BY date, train_number) = 2;
+----
+physical_plan	<REGEX>:.*WINDOW.*
+
+# 5. Case with no partitions (should not optimize per current logic)
+query II
+EXPLAIN FROM services QUALIFY count(*) OVER() = 1;
+----
+physical_plan	<REGEX>:.*WINDOW.*
+
+# 6. Case with ORDER BY (should not optimize)
+query II
+EXPLAIN FROM services QUALIFY count(*) OVER(PARTITION BY date ORDER BY train_number) = 1;
+----
+physical_plan	<REGEX>:.*WINDOW.*
+
+# 7. Larger dataset / complex types (optional, but good for verification)
+statement ok
+CREATE TABLE items (id INT, category VARCHAR);
+
+statement ok
+INSERT INTO items VALUES (1, 'A'), (2, 'A'), (3, 'B'), (4, 'C'), (5, 'C');
+
+query IT
+FROM items QUALIFY count(*) OVER(PARTITION BY category) = 1;
+----
+3	B
+
+query IT
+EXPLAIN FROM items QUALIFY count(*) OVER(PARTITION BY category) = 1;
+----
+physical_plan	<REGEX>:.*Join Type: SEMI.*


### PR DESCRIPTION
## Summary
This PR implements a new optimizer rule `CountWindowElimination` that transforms queries like:
```sql
SELECT * FROM t QUALIFY count(*) OVER(PARTITION BY a) = 1
```
into equivalent `SEMI JOIN` operations, which avoids the expensive window function materialization and sorting.

## Changes
- Added `CountWindowElimination` optimizer rule in `src/optimizer/count_window_elimination.cpp`
- Added corresponding header file
- Registered the optimizer in `optimizer.cpp`
- Added `COUNT_WINDOW_ELIMINATION` to `OptimizerType` and `MetricType` enums
- Added unit tests in `test/sql/optimizer/test_count_window_elimination.test`

## Implementation Details
The transformation uses:
- `LogicalComparisonJoin` (SEMI JOIN) for efficient filtering
- `LogicalCrossProduct` with `LogicalDummyScan` to produce the constant window result
- `TableRebinder` visitor to handle table index rebinding for copied subplans

## Testing
- All new tests pass
- Verified optimization produces correct results