### PR TITLE
Don't throw permission error during binder when LocalFileSystem is disabled

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -621,6 +621,10 @@ bool FileSystem::SubSystemIsDisabled(const string &name) {
 	throw NotImplementedException("%s: Non-virtual file system does not have subsystems", GetName());
 }
 
+bool FileSystem::IsDisabledForPath(const string &path) {
+	throw NotImplementedException("%s: Non-virtual file system does not have subsystems", GetName());
+}
+
 vector<string> FileSystem::ListSubSystems() {
 	throw NotImplementedException("%s: Can't list sub systems on a non-virtual file system", GetName());
 }

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -228,6 +228,17 @@ bool VirtualFileSystem::SubSystemIsDisabled(const string &name) {
 	return disabled_file_systems.find(name) != disabled_file_systems.end();
 }
 
+bool VirtualFileSystem::IsDisabledForPath(const string &path) {
+	if (disabled_file_systems.empty()) {
+		return false;
+	}
+	auto fs = FindFileSystemInternal(path);
+	if (!fs) {
+		fs = default_fs.get();
+	}
+	return disabled_file_systems.find(fs->GetName()) != disabled_file_systems.end();
+}
+
 FileSystem &VirtualFileSystem::FindFileSystem(const string &path, optional_ptr<FileOpener> opener) {
 	return FindFileSystem(path, FileOpener::TryGetDatabase(opener));
 }

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -297,6 +297,8 @@ public:
 
 	DUCKDB_API virtual void SetDisabledFileSystems(const vector<string> &names);
 	DUCKDB_API virtual bool SubSystemIsDisabled(const string &name);
+	//! Check if the filesystem that would handle this path is disabled
+	DUCKDB_API virtual bool IsDisabledForPath(const string &path);
 
 	DUCKDB_API static bool IsDirectory(const OpenFileInfo &info);
 

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -150,6 +150,10 @@ public:
 		return GetFileSystem().SubSystemIsDisabled(name);
 	}
 
+	bool IsDisabledForPath(const string &path) override {
+		return GetFileSystem().IsDisabledForPath(path);
+	}
+
 	vector<string> ListSubSystems() override {
 		return GetFileSystem().ListSubSystems();
 	}

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -66,6 +66,7 @@ public:
 
 	void SetDisabledFileSystems(const vector<string> &names) override;
 	bool SubSystemIsDisabled(const string &name) override;
+	bool IsDisabledForPath(const string &path) override;
 
 	string PathSeparator(const string &path) override;
 

--- a/src/include/duckdb/storage/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/caching_file_system_wrapper.hpp
@@ -121,6 +121,7 @@ public:
 
 	DUCKDB_API void SetDisabledFileSystems(const vector<string> &names) override;
 	DUCKDB_API bool SubSystemIsDisabled(const string &name) override;
+	DUCKDB_API bool IsDisabledForPath(const string &path) override;
 
 protected:
 	DUCKDB_API unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &path, FileOpenFlags flags,

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -206,7 +206,7 @@ BoundStatement Binder::Bind(BaseTableRef &ref) {
 		if (context.config.use_replacement_scans && config.options.enable_external_access &&
 		    ExtensionHelper::IsFullPath(full_path)) {
 			auto &fs = FileSystem::GetFileSystem(context);
-			if (fs.FileExists(full_path)) {
+			if (!fs.IsDisabledForPath(full_path) && fs.FileExists(full_path)) {
 				throw BinderException(
 				    "No extension found that is capable of reading the file \"%s\"\n* If this file is a supported file "
 				    "format you can explicitly use the reader functions, such as read_csv, read_json or read_parquet",

--- a/src/storage/caching_file_system_wrapper.cpp
+++ b/src/storage/caching_file_system_wrapper.cpp
@@ -365,4 +365,8 @@ bool CachingFileSystemWrapper::SubSystemIsDisabled(const string &name) {
 	return underlying_file_system.SubSystemIsDisabled(name);
 }
 
+bool CachingFileSystemWrapper::IsDisabledForPath(const string &path) {
+	return underlying_file_system.IsDisabledForPath(path);
+}
+
 } // namespace duckdb

--- a/test/sql/settings/test_disabled_file_systems.test
+++ b/test/sql/settings/test_disabled_file_systems.test
@@ -48,3 +48,20 @@ statement error
 SET disabled_filesystems='';
 ----
 has been disabled previously
+
+# querying a non-existent catalog or schema should not trigger the disabled filesystem error
+statement error
+SELECT * FROM abc.main.t1;
+----
+Catalog "abc" does not exist
+
+statement error
+SELECT * FROM abc.t1;
+----
+schema "abc" does not exist
+
+# but querying a known extension should still trigger the disabled filesystem error
+statement error
+SELECT * FROM abc.csv;
+----
+File system LocalFileSystem has been disabled by configuration


### PR DESCRIPTION
Without this change you'll get this very confusing error message when the `LocalFileSystem` is disabled and you try to query from a table that does not exist:

```
duckdb -c "set disabled_filesystems='LocalFileSystem'; select * from nonexistentdb.main.t1;"
Permission Error:
File system LocalFileSystem has been disabled by configuration
```

This changes that to the more sensible:
```
Binder Error:
Catalog "nonexistentdb" does not exist!
```
