### PR TITLE
fix: link error on linux with multiple definition of LogicalType::VARCHAR in `shell_renderer.cpp`

### DIFF
--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -281,7 +281,7 @@ unique_ptr<duckdb::DataChunk> ShellRenderer::ConvertChunk(duckdb::DataChunk &chu
 	auto varchar_chunk = make_uniq<duckdb::DataChunk>();
 	vector<duckdb::LogicalType> all_varchar;
 	for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
-		all_varchar.emplace_back(duckdb::LogicalType::VARCHAR);
+		all_varchar.emplace_back(duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR));
 	}
 	varchar_chunk->Initialize(duckdb::Allocator::DefaultAllocator(), all_varchar);
 
@@ -1264,7 +1264,7 @@ public:
 		vector<duckdb::LogicalType> all_json;
 		for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
 			if (!RequiresJSONCast(chunk.data[c].GetType())) {
-				all_json.emplace_back(duckdb::LogicalType::VARCHAR);
+				all_json.emplace_back(duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR));
 			} else {
 				all_json.emplace_back(duckdb::LogicalType::JSON());
 			}


### PR DESCRIPTION
Hi DuckDB Team,

When I used Linux to build the main branch of DuckDB with my `adbc_scanner` extension I often encountered this link error in CI.  This PR resolves it by not using `LogicalType::VARCHAR` instead using `LogicalType(LogicalTypeId::VARCHAR)`.  The code that is changed is in `shell_renderer.cpp` so not anywhere in my extension code.  With this change the compilation succeeds.

Build error:

```
[2/3] Linking CXX executable duckdb
FAILED: duckdb 
: && /usr/bin/c++ -g -g -O0 -DDEBUG -Wall    -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -Wunused -Werror=vla -Wnarrowing -pedantic  tools/shell/linenoise/CMakeFiles/duckdb_linenoise.dir/highlighting.cpp.o tools/shell/linenoise/CMakeFiles/duckdb_linenoise.dir/history.cpp.o tools/shell/linenoise/CMakeFiles/duckdb_linenoise.dir/linenoise.cpp.o tools/shell/linenoise/CMakeFiles/duckdb_linenoise.dir/linenoise-c.cpp.o tools/shell/linenoise/CMakeFiles/duckdb_linenoise.dir/rendering.cpp.o tools/shell/linenoise/CMakeFiles/duckdb_linenoise.dir/terminal.cpp.o extension/CMakeFiles/duckdb_generated_extension_loader.dir/__/codegen/src/generated_extension_loader.cpp.o tools/shell/CMakeFiles/shell.dir/shell_command_line_option.cpp.o tools/shell/CMakeFiles/shell.dir/shell_extension.cpp.o tools/shell/CMakeFiles/shell.dir/shell.cpp.o tools/shell/CMakeFiles/shell.dir/shell_helpers.cpp.o tools/shell/CMakeFiles/shell.dir/shell_metadata_command.cpp.o tools/shell/CMakeFiles/shell.dir/shell_prompt.cpp.o tools/shell/CMakeFiles/shell.dir/shell_renderer.cpp.o tools/shell/CMakeFiles/shell.dir/shell_highlight.cpp.o tools/shell/CMakeFiles/shell.dir/shell_progress_bar.cpp.o tools/shell/CMakeFiles/shell.dir/shell_render_table_metadata.cpp.o tools/shell/CMakeFiles/shell.dir/shell_windows.cpp.o -o duckdb  src/libduckdb_static.a  extension/adbc_scanner/libadbc_scanner_extension.a  extension/core_functions/libcore_functions_extension.a  extension/parquet/libparquet_extension.a  extension/jemalloc/libjemalloc_extension.a  third_party/utf8proc/libduckdb_utf8proc.a  vcpkg_installed/x64-linux/debug/lib/libadbc_driver_manager.a  vcpkg_installed/x64-linux/debug/lib/libtomlplusplus.a  vcpkg_installed/x64-linux/debug/lib/libnanoarrow_static.a  src/libduckdb_static.a  -ldl && :
/usr/bin/ld: src/libduckdb_static.a(ub_duckdb_common.cpp.o):(.rodata+0x4460): multiple definition of `duckdb::LogicalType::VARCHAR'; tools/shell/CMakeFiles/shell.dir/shell_renderer.cpp.o:(.rodata._ZN6duckdb11LogicalType7VARCHARE[_ZN6duckdb11LogicalType7VARCHARE]+0x0): first defined here
collect2: error: ld returned 1 exit status
```

Distro information: Amazon Linux 2023 on AWS

Linux ip-172-16-3-91.ec2.internal 6.1.158-178.288.amzn2023.x86_64 #1 SMP PREEMPT_DYNAMIC Mon Nov  3 18:38:36 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux

```
[ec2-user@ip-172-16-3-91 duckdb]$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-amazon-linux/11/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-amazon-linux
Configured with: ../configure --enable-bootstrap --enable-host-pie --enable-host-bind-now --enable-languages=c,c++,fortran,lto --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://github.com/amazonlinux/amazon-linux-2022 --enable-shared --enable-threads=posix --enable-checking=release --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --enable-plugin --enable-initfini-array --with-isl=/builddir/build/BUILD/gcc-11.5.0-20240719/obj-x86_64-amazon-linux/isl-install --enable-multilib --with-linker-hash-style=gnu --enable-offload-targets=nvptx-none --without-cuda-driver --enable-gnu-indirect-function --enable-cet --with-tune=generic --with-arch_64=x86-64-v2 --with-arch_32=x86-64 --build=x86_64-amazon-linux --with-build-config=bootstrap-lto --enable-link-serialization=1
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 11.5.0 20240719 (Red Hat 11.5.0-5) (GCC) 
```

I only knew how to resolve it from past patterns where I've seen the same problem in other extensions.

You can see a full build failure here:

https://github.com/Query-farm/adbc_scanner/actions/runs/20048370767/job/57498881373

Thanks,

Rusty
