### PR TITLE
Cast Fix: Correctly handle negative exponent with a number with a decimal in VARCHAR -> INTEGER cast

### DIFF
--- a/src/include/duckdb/common/operator/integer_cast_operator.hpp
+++ b/src/include/duckdb/common/operator/integer_cast_operator.hpp
@@ -103,9 +103,12 @@ struct IntegerDecimalCastOperation : IntegerCastOperation {
 		int16_t e = exponent;
 		// Negative Exponent
 		if (e < 0) {
-			while (state.result != 0 && e++ < 0) {
+			while (e++ < 0) {
 				state.decimal = state.result % 10;
 				state.result /= 10;
+				if (state.result == 0 && state.decimal == 0) {
+					break;
+				}
 			}
 			if (state.decimal < 0) {
 				state.decimal = -state.decimal;

--- a/test/sql/cast/string_to_integer_exponent_cast.test
+++ b/test/sql/cast/string_to_integer_exponent_cast.test
@@ -108,6 +108,11 @@ select '-1.235e-2'::${type};
 0
 
 query I
+select '5.5e-1'::bigint;
+----
+1
+
+query I
 select '9.5e-5'::${type};
 ----
 0

--- a/test/sql/cast/string_to_integer_exponent_cast.test
+++ b/test/sql/cast/string_to_integer_exponent_cast.test
@@ -9,7 +9,6 @@ PRAGMA enable_verification
 foreach type <integral>
 
 # Positive Number - Positive Exponent
-
 query I
 select '1e2'::${type};
 ----
@@ -105,6 +104,11 @@ select '-1584.92e-2'::${type};
 
 query I
 select '-1.235e-2'::${type};
+----
+0
+
+query I
+select '9.5e-5'::${type};
 ----
 0
 


### PR DESCRIPTION
We need to keep looking until **both** the integer result and the decimal are zero when handling a negative exponent - otherwise we could incorrectly return `1` instead of `0` for decimals >= 5.