### PR TITLE
[Storage] Fix NULL filter check for constant segments

### DIFF
--- a/src/storage/compression/numeric_constant.cpp
+++ b/src/storage/compression/numeric_constant.cpp
@@ -156,7 +156,8 @@ void FiltersNullValues(const LogicalType &type, const TableFilter &filter, bool 
 		auto &expr_filter = filter.Cast<ExpressionFilter>();
 		auto &state = filter_state.Cast<ExpressionFilterState>();
 		Value val(type);
-		filters_nulls = expr_filter.EvaluateWithConstant(state.executor, val);
+		//! If the expression evaluates to true, containing only a NULL vector, it *must* be an IS NULL filter
+		filters_nulls = !expr_filter.EvaluateWithConstant(state.executor, val);
 		filters_valid_values = false;
 		break;
 	}

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -242,9 +242,7 @@ void ColumnSegment::ConvertToPersistent(QueryContext context, optional_ptr<Block
 	// Thus, we set the compression function to constant and reset the block buffer.
 	D_ASSERT(stats.statistics.IsConstant());
 	auto &config = DBConfig::GetConfig(db);
-	if (GetCompressionFunction().type != CompressionType::COMPRESSION_EMPTY) {
-		function = *config.GetCompressionFunction(CompressionType::COMPRESSION_CONSTANT, type.InternalType());
-	}
+	function = *config.GetCompressionFunction(CompressionType::COMPRESSION_CONSTANT, type.InternalType());
 	block.reset();
 }
 


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/6797

#19913 turned out to be a bandaid
If the stats say it's constant, then it's actually constant, otherwise it wouldn't get there.