### PR TITLE
Remove undefined loop

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -149,11 +149,6 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, BoundConstraint 
 
 	// ALTER COLUMN to add a new constraint.
 
-	// Clone the storage info vector or the table.
-	for (const auto &index_info : parent.info->index_storage_infos) {
-		info->index_storage_infos.push_back(IndexStorageInfo(index_info.name));
-	}
-
 	// Bind all indexes.
 	info->BindIndexes(context);
 


### PR DESCRIPTION
This loop is undefined behavior since info and parent.info are both shared_ptr's to the same DataTableInfo, and thus pointing to the same vector in the loop iteration, which can possibly cause a reallocation with the push_back. The standard only says that references before an insert that causes a reallocation are valid, so anything goes here. 

More generally, however, IndexStorageInfo's are not used at this point, as they should be already contained in UnboundIndexes (which are immediately bound at the start of this constructor), or if the indexes were already bound, they can stop being used there (and then later on they are recreated again from bound indexes for serialization). 

Will most likely make a separate PR on main that more explicitly manages the lifetimes of IndexStorageInfos to make this clear. 