### PR TITLE
Fix ALIAS function in filter pushdown to preserve column aliases(#20008)

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -367,7 +367,7 @@ FilterPushdownResult FilterCombiner::TryPushdownConstantFilter(TableFilterSet &t
 void ReplaceWithBoundReference(unique_ptr<Expression> &root_expr) {
 	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
 	    root_expr, [&](BoundColumnRefExpression &col_ref, unique_ptr<Expression> &expr) {
-		    expr = make_uniq<BoundReferenceExpression>(col_ref.return_type, 0ULL);
+		    expr = make_uniq<BoundReferenceExpression>(col_ref.alias, col_ref.return_type, 0ULL);
 	    });
 }
 

--- a/test/sql/optimizer/plan/test_filter_pushdown.test
+++ b/test/sql/optimizer/plan/test_filter_pushdown.test
@@ -231,3 +231,15 @@ ORDER BY ALL;
 ----
 1	2021-01-01	2021-01-01	2010-01-01
 1	2021-01-01	2021-02-15	2010-01-01
+
+# test ALIAS function in WHERE clause with column comparison
+statement ok
+CREATE TABLE t0(c0 VARCHAR(500));
+
+statement ok
+INSERT INTO t0(c0) VALUES ('2');
+
+query T
+SELECT * FROM t0 WHERE (t0.c0<(ALIAS(t0.c0)));
+----
+2


### PR DESCRIPTION
## Problem
The `ALIAS()` function was returning internal column indices (like `#0`) instead of actual column names when
used in WHERE clauses, causing incorrect query results.

## Reproduction
```sql
CREATE TABLE t0(c0 VARCHAR(500));
INSERT INTO t0(c0) VALUES ('2');

-- This query incorrectly returns 0 rows (should return 1 row)
SELECT * FROM t0 WHERE (t0.c0 < ALIAS(t0.c0));
```
Expected behavior: Should return 1 row, comparing '2' < 'c0' (evaluates to true)
Actual behavior (before fix): Returns 0 rows, comparing '2' < '#0' (evaluates to false)

## Root Cause
The issue occurred in two optimizer paths where `BoundReferenceExpression` was created without preserving column alias information:
 1. **Filter Pushdown (`FilterCombiner::ReplaceWithBoundReference`)**
    - When pushing generic filters down to table scans, `BoundColumnRefExpression` is replaced with
 `BoundReferenceExpression`
    - The replacement was using the constructor without the `alias` parameter
    - This caused `BoundReferenceExpression::ToString()` to return `"#0"` instead of the actual column name
 2. **Statistics Propagation (`StatisticsPropagator::PropagateTableFilter`)**
    - When creating `BoundReferenceExpression` for table filter propagation and statistics updates
    - Column alias information was not extracted or propagated
    - Same issue: `ToString()` returns internal index instead of column name

 Since `ALIAS()` function returns the string representation of an expression (via `ToString()`), it was getting
  the internal index `"#0"` instead of the column name `"c0"`.

 ## Solution
 - Modified `ReplaceWithBoundReference` to pass `col_ref.alias` when creating `BoundReferenceExpression`
 - Updated `PropagateTableFilter` to pass column alias when creating both `BoundColumnRefExpression` and
 `BoundReferenceExpression`
