### PR TITLE
[C-API] Add support for scalar function local states

### DIFF
--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -632,6 +632,15 @@ typedef struct {
 	idx_t (*duckdb_scalar_function_bind_get_argument_count)(duckdb_bind_info info);
 	duckdb_expression (*duckdb_scalar_function_bind_get_argument)(duckdb_bind_info info, idx_t index);
 	void (*duckdb_scalar_function_set_bind_data_copy)(duckdb_bind_info info, duckdb_copy_callback_t copy);
+	// New functions to configure local states for scalar functions
+
+	void *(*duckdb_scalar_function_get_state)(duckdb_function_info info);
+	void (*duckdb_scalar_function_set_init)(duckdb_scalar_function scalar_function, duckdb_scalar_function_init_t init);
+	void (*duckdb_scalar_function_init_set_error)(duckdb_init_info info, const char *error);
+	void (*duckdb_scalar_function_init_set_state)(duckdb_init_info info, void *state, duckdb_delete_callback_t destroy);
+	void (*duckdb_scalar_function_init_get_client_context)(duckdb_init_info info, duckdb_client_context *out_context);
+	void *(*duckdb_scalar_function_init_get_bind_data)(duckdb_init_info info);
+	void *(*duckdb_scalar_function_init_get_extra_info)(duckdb_init_info info);
 	// New string functions that are added
 
 	char *(*duckdb_value_to_string)(duckdb_value value);
@@ -1188,6 +1197,13 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_scalar_function_bind_get_argument_count = duckdb_scalar_function_bind_get_argument_count;
 	result.duckdb_scalar_function_bind_get_argument = duckdb_scalar_function_bind_get_argument;
 	result.duckdb_scalar_function_set_bind_data_copy = duckdb_scalar_function_set_bind_data_copy;
+	result.duckdb_scalar_function_get_state = duckdb_scalar_function_get_state;
+	result.duckdb_scalar_function_set_init = duckdb_scalar_function_set_init;
+	result.duckdb_scalar_function_init_set_error = duckdb_scalar_function_init_set_error;
+	result.duckdb_scalar_function_init_set_state = duckdb_scalar_function_init_set_state;
+	result.duckdb_scalar_function_init_get_client_context = duckdb_scalar_function_init_get_client_context;
+	result.duckdb_scalar_function_init_get_bind_data = duckdb_scalar_function_init_get_bind_data;
+	result.duckdb_scalar_function_init_get_extra_info = duckdb_scalar_function_init_get_extra_info;
 	result.duckdb_value_to_string = duckdb_value_to_string;
 	result.duckdb_table_description_get_column_count = duckdb_table_description_get_column_count;
 	result.duckdb_table_description_get_column_type = duckdb_table_description_get_column_type;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_scalar_function_state_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_scalar_function_state_functions.json
@@ -1,0 +1,13 @@
+{
+  "version": "unstable_new_scalar_function_state_functions",
+  "description": "New functions to configure local states for scalar functions",
+  "entries": [
+    "duckdb_scalar_function_get_state",
+    "duckdb_scalar_function_set_init",
+    "duckdb_scalar_function_init_set_error",
+    "duckdb_scalar_function_init_set_state",
+    "duckdb_scalar_function_init_get_client_context",
+    "duckdb_scalar_function_init_get_bind_data",
+    "duckdb_scalar_function_init_get_extra_info"
+  ]
+}

--- a/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
@@ -507,6 +507,146 @@
                 },
                 "return_value": "The input argument at index. Must be destroyed with `duckdb_destroy_expression`."
             }
+        },
+        {
+            "name": "duckdb_scalar_function_get_state",
+            "return_type": "void *",
+            "params": [
+                {
+                    "type": "duckdb_function_info",
+                    "name": "info"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the state pointer of the function info.\n\n",
+                "param_comments": {
+                    "info": "The function info object."
+                },
+                "return_value": "The state pointer."
+            }
+        },
+        {
+            "name": "duckdb_scalar_function_set_init",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_scalar_function",
+                    "name": "scalar_function"
+                },
+                {
+                    "type": "duckdb_scalar_function_init_t",
+                    "name": "init"
+                }
+            ],
+            "comment": {
+                "description": "Sets the (optional) state init function of the scalar function.\nThis is called once for each worker thread that begins executing the function\n",
+                "param_comments": {
+                    "scalar_function": "The scalar function.",
+                    "init": "The init function."
+                }
+            }
+        },
+        {
+            "name": "duckdb_scalar_function_init_set_error",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_init_info",
+                    "name": "info"
+                },
+                {
+                    "type": "const char *",
+                    "name": "error"
+                }
+            ],
+            "comment": {
+                "description": "Report that an error has occurred while calling init on a scalar function.\n\n",
+                "param_comments": {
+                    "info": "The init info object.",
+                    "error": "The error message."
+                }
+            }
+        },
+        {
+            "name": "duckdb_scalar_function_init_set_state",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_init_info",
+                    "name": "info"
+                },
+                {
+                    "type": "void *",
+                    "name": "state"
+                },
+                {
+                    "type": "duckdb_delete_callback_t",
+                    "name": "destroy"
+                }
+            ],
+            "comment": {
+                "description": "Sets the state pointer in the init info of the scalar function.\n\n",
+                "param_comments": {
+                    "info": "The init info object.",
+                    "state": "The state pointer.",
+                    "destroy": "The callback to destroy the state (if any)."
+                }
+            }
+        },
+        {
+            "name": "duckdb_scalar_function_init_get_client_context",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_init_info",
+                    "name": "info"
+                },
+                {
+                    "type": "duckdb_client_context *",
+                    "name": "out_context"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the client context of the init info of a scalar function.\n\n",
+                "param_comments": {
+                    "info": "The init info object of the scalar function.",
+                    "out_context": "The client context of the init info. Must be destroyed with `duckdb_destroy_client_context`."
+                }
+            }
+        },
+        {
+            "name": "duckdb_scalar_function_init_get_bind_data",
+            "return_type": "void *",
+            "params": [
+                {
+                    "type": "duckdb_init_info",
+                    "name": "info"
+                }
+            ],
+            "comment": {
+                "description": "Gets the scalar function's bind data set by `duckdb_scalar_function_set_bind_data`.\nNote that the bind data is read-only.\n\n",
+                "param_comments": {
+                    "info": "The init info object."
+                },
+                "return_value": "The bind data object."
+            }
+        },
+        {
+            "name": "duckdb_scalar_function_init_get_extra_info",
+            "return_type": "void *",
+            "params": [
+                {
+                    "type": "duckdb_init_info",
+                    "name": "info"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the extra info of the function as set in the init info.\n\n",
+                "param_comments": {
+                    "info": "The init info object."
+                },
+                "return_value": "The extra info."
+            }
         }
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -650,6 +650,12 @@ typedef struct _duckdb_bind_info {
 	void *internal_ptr;
 } * duckdb_bind_info;
 
+//! Additional function initialization info.
+//! When setting this info, it is necessary to pass a destroy-callback function.
+typedef struct _duckdb_init_info {
+	void *internal_ptr;
+} * duckdb_init_info;
+
 //===--------------------------------------------------------------------===//
 // Scalar function types
 //===--------------------------------------------------------------------===//
@@ -666,6 +672,9 @@ typedef struct _duckdb_scalar_function_set {
 
 //! The bind function callback of the scalar function.
 typedef void (*duckdb_scalar_function_bind_t)(duckdb_bind_info info);
+
+//! The thread-local initialization function of the scalar function.
+typedef void (*duckdb_scalar_function_init_t)(duckdb_init_info info);
 
 //! The function to execute the scalar function on an input chunk.
 typedef void (*duckdb_scalar_function_t)(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
@@ -718,12 +727,6 @@ typedef void (*duckdb_aggregate_finalize_t)(duckdb_function_info info, duckdb_ag
 typedef struct _duckdb_table_function {
 	void *internal_ptr;
 } * duckdb_table_function;
-
-//! Additional function initialization info.
-//! When setting this info, it is necessary to pass a destroy-callback function.
-typedef struct _duckdb_init_info {
-	void *internal_ptr;
-} * duckdb_init_info;
 
 //! The bind function of the table function.
 typedef void (*duckdb_table_function_bind_t)(duckdb_bind_info info);

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -727,6 +727,17 @@ typedef struct {
 	void (*duckdb_scalar_function_set_bind_data_copy)(duckdb_bind_info info, duckdb_copy_callback_t copy);
 #endif
 
+// New functions to configure local states for scalar functions
+#ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
+	void *(*duckdb_scalar_function_get_state)(duckdb_function_info info);
+	void (*duckdb_scalar_function_set_init)(duckdb_scalar_function scalar_function, duckdb_scalar_function_init_t init);
+	void (*duckdb_scalar_function_init_set_error)(duckdb_init_info info, const char *error);
+	void (*duckdb_scalar_function_init_set_state)(duckdb_init_info info, void *state, duckdb_delete_callback_t destroy);
+	void (*duckdb_scalar_function_init_get_client_context)(duckdb_init_info info, duckdb_client_context *out_context);
+	void *(*duckdb_scalar_function_init_get_bind_data)(duckdb_init_info info);
+	void *(*duckdb_scalar_function_init_get_extra_info)(duckdb_init_info info);
+#endif
+
 // New string functions that are added
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
 	char *(*duckdb_value_to_string)(duckdb_value value);
@@ -1328,6 +1339,15 @@ typedef struct {
 #define duckdb_scalar_function_get_client_context      duckdb_ext_api.duckdb_scalar_function_get_client_context
 #define duckdb_scalar_function_bind_get_argument_count duckdb_ext_api.duckdb_scalar_function_bind_get_argument_count
 #define duckdb_scalar_function_bind_get_argument       duckdb_ext_api.duckdb_scalar_function_bind_get_argument
+
+// Version unstable_new_scalar_function_state_functions
+#define duckdb_scalar_function_get_state               duckdb_ext_api.duckdb_scalar_function_get_state
+#define duckdb_scalar_function_set_init                duckdb_ext_api.duckdb_scalar_function_set_init
+#define duckdb_scalar_function_init_set_error          duckdb_ext_api.duckdb_scalar_function_init_set_error
+#define duckdb_scalar_function_init_set_state          duckdb_ext_api.duckdb_scalar_function_init_set_state
+#define duckdb_scalar_function_init_get_client_context duckdb_ext_api.duckdb_scalar_function_init_get_client_context
+#define duckdb_scalar_function_init_get_bind_data      duckdb_ext_api.duckdb_scalar_function_init_get_bind_data
+#define duckdb_scalar_function_init_get_extra_info     duckdb_ext_api.duckdb_scalar_function_init_get_extra_info
 
 // Version unstable_new_string_functions
 #define duckdb_value_to_string duckdb_ext_api.duckdb_value_to_string

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -642,3 +642,105 @@ TEST_CASE("Test Scalar Functions - LIST", "[capi]") {
 	REQUIRE_NO_FAIL(*result);
 	REQUIRE(result->Fetch<uint64_t>(0, 0) == 0);
 }
+
+static void CounterFunctionBind(duckdb_bind_info info) {
+	// Get the start counter from the extra info.
+	auto extra_info_ptr = duckdb_scalar_function_bind_get_extra_info(info);
+	auto &extra_info = *static_cast<int64_t *>(extra_info_ptr);
+
+	auto bind_data_ptr = malloc(sizeof(int64_t));
+	auto &bind_data = *reinterpret_cast<int64_t *>(bind_data_ptr);
+
+	bind_data = extra_info + 10;
+
+	duckdb_scalar_function_set_bind_data(info, bind_data_ptr, free);
+}
+
+static void CounterFunctionInit(duckdb_init_info info) {
+	auto extra_info_ptr = duckdb_scalar_function_init_get_extra_info(info);
+	auto &extra_info = *static_cast<int64_t *>(extra_info_ptr);
+
+	auto bind_data_ptr = duckdb_scalar_function_init_get_bind_data(info);
+	auto &bind_data = *reinterpret_cast<int64_t *>(bind_data_ptr);
+
+	// Ensure we can get the client context
+	duckdb_client_context context;
+	duckdb_scalar_function_init_get_client_context(info, &context);
+	REQUIRE(context != nullptr);
+	duckdb_destroy_client_context(&context);
+
+	if (extra_info < 0) {
+		duckdb_scalar_function_init_set_error(info, "lower limit cannot be negative");
+		return;
+	}
+	if (bind_data > 100) {
+		duckdb_scalar_function_init_set_error(info, "upper limit cannot be greater than 100");
+		return;
+	}
+
+	auto state_ptr = malloc(sizeof(int64_t));
+	auto &state = *reinterpret_cast<int64_t *>(state_ptr);
+
+	state = extra_info;
+
+	duckdb_scalar_function_init_set_state(info, state_ptr, free);
+}
+
+static void CounterFunctionExec(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
+	auto state_ptr = duckdb_scalar_function_get_state(info);
+	auto &state = *reinterpret_cast<int64_t *>(state_ptr);
+
+	auto input_size = duckdb_data_chunk_get_size(input);
+	auto result_data = reinterpret_cast<int64_t *>(duckdb_vector_get_data(output));
+	for (idx_t row = 0; row < input_size; row++) {
+		result_data[row] = state;
+		state++;
+	}
+}
+
+static void CAPIRegisterCounterFunction(duckdb_connection connection, const char *name, int64_t start) {
+	duckdb_state status;
+
+	auto function = duckdb_create_scalar_function();
+	duckdb_scalar_function_set_name(function, name);
+
+	auto bigint_type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+	duckdb_scalar_function_add_parameter(function, bigint_type);
+	duckdb_scalar_function_set_return_type(function, bigint_type);
+	duckdb_destroy_logical_type(&bigint_type);
+
+	duckdb_scalar_function_set_bind(function, CounterFunctionBind);
+	duckdb_scalar_function_set_init(function, CounterFunctionInit);
+	duckdb_scalar_function_set_function(function, CounterFunctionExec);
+	duckdb_scalar_function_set_extra_info(function, new int64_t(start),
+	                                      [](void *ptr) { delete reinterpret_cast<int64_t *>(ptr); });
+
+	status = duckdb_register_scalar_function(connection, function);
+	REQUIRE(status == DuckDBSuccess);
+	duckdb_destroy_scalar_function(&function);
+}
+
+TEST_CASE("Test Scalar Functions - Local State", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	CAPIRegisterCounterFunction(tester.connection, "my_counter", 5);
+
+	result = tester.Query("SELECT my_counter(i) FROM range(3) r(i)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<idx_t>(0, 0) == 5);
+	REQUIRE(result->Fetch<idx_t>(0, 1) == 6);
+	REQUIRE(result->Fetch<idx_t>(0, 2) == 7);
+
+	// Now test error conditions.
+	CAPIRegisterCounterFunction(tester.connection, "my_counter_error_low", -5);
+	result = tester.Query("SELECT my_counter_error_low(0)");
+	REQUIRE_FAIL(result);
+	REQUIRE(StringUtil::Contains(result->ErrorMessage(), "lower limit cannot be negative"));
+
+	CAPIRegisterCounterFunction(tester.connection, "my_counter_error_high", 95);
+	result = tester.Query("SELECT my_counter_error_high(0) FROM range(10)");
+	REQUIRE_FAIL(result);
+	REQUIRE(StringUtil::Contains(result->ErrorMessage(), "upper limit cannot be greater than 100"));
+}


### PR DESCRIPTION
After this we only need support for compressed execution (e.g. constant/flat/dict-vectors) in scalar functions to start moving over some more complex extensions to the C-API. (e.g half of spatial).