### PR TITLE
Unify column renaming behavior of CTEs with other places in the system

### DIFF
--- a/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_cte_node.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/planner/operator/logical_materialized_cte.hpp"
 #include "duckdb/parser/query_node/list.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
+#include "duckdb/main/query_result.hpp"
 
 namespace duckdb {
 

--- a/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_cte_node.cpp
@@ -96,19 +96,7 @@ void CTEBindState::Bind(CTEBinding &binding) {
 	}
 
 	// Rename columns if duplicate names are detected
-	vector<string> new_names;
-	// Use a case-insensitive map to track names and their counts
-	case_insensitive_map_t<idx_t> name_counts;
-	for (auto &n : names) {
-		string name = n;
-		while (name_counts.find(name) != name_counts.end()) {
-			name_counts[name] += 1;
-			name = n + "_" + std::to_string(name_counts[name]);
-		}
-		name_counts[name] = 0;
-		new_names.push_back(name);
-	}
-	names = std::move(new_names);
+	QueryResult::DeduplicateColumns(names);
 }
 
 BoundCTEData Binder::PrepareCTE(const string &ctename, CommonTableExpressionInfo &statement) {

--- a/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_cte_node.cpp
@@ -96,17 +96,17 @@ void CTEBindState::Bind(CTEBinding &binding) {
 	}
 
 	// Rename columns if duplicate names are detected
-	idx_t index = 1;
 	vector<string> new_names;
-	// Use a case-insensitive set to track names
-	case_insensitive_set_t ci_names;
+	// Use a case-insensitive map to track names and their counts
+	case_insensitive_map_t<idx_t> name_counts;
 	for (auto &n : names) {
 		string name = n;
-		while (ci_names.find(name) != ci_names.end()) {
-			name = n + "_" + std::to_string(index++);
+		while (name_counts.find(name) != name_counts.end()) {
+			name_counts[name] += 1;
+			name = n + "_" + std::to_string(name_counts[name]);
 		}
+		name_counts[name] = 0;
 		new_names.push_back(name);
-		ci_names.insert(name);
 	}
 	names = std::move(new_names);
 }


### PR DESCRIPTION
Consider query:

```sql
WITH tmp AS (
    SELECT 1 AS a, 2 AS b, 3 AS a, 4 AS b, 5 AS a, 6 AS b
)
SELECT * FROM tmp
```

The system used to create this schema:

```
┌───────┬───────┬───────┬───────┬───────┬───────┐
│   a   │   b   │  a_1  │  b_2  │  a_3  │  b_4  │
│ int32 │ int32 │ int32 │ int32 │ int32 │ int32 │
├───────┼───────┼───────┼───────┼───────┼───────┤
│     1 │     2 │     3 │     4 │     5 │     6 │
└───────┴───────┴───────┴───────┴───────┴───────┘
```

With this PR, the names are de-duplicated in a grouped manner, rather than globally:

```
┌───────┬───────┬───────┬───────┬───────┬───────┐
│   a   │   b   │  a_1  │  b_1  │  a_2  │  b_2  │
│ int32 │ int32 │ int32 │ int32 │ int32 │ int32 │
├───────┼───────┼───────┼───────┼───────┼───────┤
│     1 │     2 │     3 │     4 │     5 │     6 │
└───────┴───────┴───────┴───────┴───────┴───────┘
```

----

Fix: #20115