### PR TITLE
feat: add profiler result hook function callbacks

### DIFF
--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -26,6 +26,8 @@ class PreparedStatementData;
 
 typedef std::function<PhysicalOperator &(ClientContext &context, PreparedStatementData &data)> get_result_collector_t;
 
+typedef std::function<void(ClientContext &context, string &output)> profile_result_hook_t;
+
 struct ClientConfig {
 	//! The home directory used by the system (if any)
 	string home_directory;
@@ -45,6 +47,8 @@ struct ClientConfig {
 	//! Allows suppressing profiler output, even if enabled. We turn on the profiler on all test runs but don't want
 	//! to output anything
 	bool emit_profiler_output = true;
+	//! Hooks that are called with the profiling result after query execution
+	vector<profile_result_hook_t> profile_result_hooks;
 
 	//! system-wide progress bar disable.
 	const char *system_progress_bar_disable_reason = nullptr;


### PR DESCRIPTION
Hi DuckDB Team,

The work on the DuckDB profiler is excellent. **Mad respect** to the developers who've done such great work on it.

<img width="128" height="100" alt="image" src="https://github.com/user-attachments/assets/ecc193f6-962c-4147-8140-6f5c0b1c8b49" />

As an extension author who sits at the outer reaches of the DuckDB solar system, I would love the ability to create an extension that could be called with the JSON results of the profiler. You know... to do fun and interesting things.

This PR adds a new member to `ClientConfig`, `profile_result_hooks`, which is a `vector` of callback functions that extensions can register to be called when a query executes.

Right now, in this PR, if an extension adds a profile hook function, it enables profiling of all queries while there are any hook functions registered, but the profiling output configuration remains unchanged. Users won't be surprised if a profile hook function is added because their experience remains the same.

I'm keeping this PR small because I know how busy all the reviewers are. Some questions for discussion would be:

0. Are you cool with this idea? 
1. Enhancing hook function registration to allow them to specify what format of profiling output they want.
2. Allowing users more control over what gets profiled even if hook functions are enabled.

Rusty