### PR TITLE
Fix parsing of dollar quoted strings in various places

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -451,8 +451,8 @@ bool ReplaceUnicodeSpaces(const string &query, string &new_query, const vector<U
 }
 
 bool IsValidDollarQuotedStringTagFirstChar(const unsigned char &c) {
-	// the first character can be between A-Z, a-z, or \200 - \377
-	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c >= 0x80;
+	// the first character can be between A-Z, a-z, underscore, or \200 - \377
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_' || c >= 0x80;
 }
 
 bool IsValidDollarQuotedStringTagSubsequentChar(const unsigned char &c) {

--- a/extension/autocomplete/tokenizer.cpp
+++ b/extension/autocomplete/tokenizer.cpp
@@ -145,11 +145,20 @@ void BaseTokenizer::PushToken(idx_t start, idx_t end) {
 	tokens.emplace_back(std::move(last_token), start);
 }
 
+// Valid characters can be between A-Z, a-z, 0-9, underscore, or \200 - \377
+// Note: 0-9 are only valid after the first character. Callers are expected to validate that before calling this
+// function.
 bool BaseTokenizer::IsValidDollarTagCharacter(char c) {
 	if (c >= 'A' && c <= 'Z') {
 		return true;
 	}
 	if (c >= 'a' && c <= 'z') {
+		return true;
+	}
+	if (c >= '0' && c <= '9') {
+		return true;
+	}
+	if (c == '_') {
 		return true;
 	}
 	if (c >= '\200' && c <= '\377') {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -42,8 +42,8 @@ static bool ReplaceUnicodeSpaces(const string &query, string &new_query, vector<
 }
 
 static bool IsValidDollarQuotedStringTagFirstChar(const unsigned char &c) {
-	// the first character can be between A-Z, a-z, or \200 - \377
-	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c >= 0x80;
+	// the first character can be between A-Z, a-z, underscore, or \200 - \377
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_' || c >= 0x80;
 }
 
 static bool IsValidDollarQuotedStringTagSubsequentChar(const unsigned char &c) {

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -485,11 +485,14 @@ void Linenoise::AddErrorHighlighting(idx_t render_start, idx_t render_end, vecto
 						next_dollar = idx;
 						break;
 					}
-					// all characters can be between A-Z, a-z or \200 - \377
+					// all characters can be between A-Z, a-z, underscore, or \200 - \377
 					if (buf[idx] >= 'A' && buf[idx] <= 'Z') {
 						continue;
 					}
 					if (buf[idx] >= 'a' && buf[idx] <= 'z') {
+						continue;
+					}
+					if (buf[idx] == '_') {
 						continue;
 					}
 					if (buf[idx] >= '\200' && buf[idx] <= '\377') {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2636,11 +2636,14 @@ bool ShellState::SQLIsComplete(const char *zSql) {
 					next_dollar = idx;
 					break;
 				}
-				// all characters can be between A-Z, a-z or \200 - \377
+				// all characters can be between A-Z, a-z, underscore, or \200 - \377
 				if (zSql[idx] >= 'A' && zSql[idx] <= 'Z') {
 					continue;
 				}
 				if (zSql[idx] >= 'a' && zSql[idx] <= 'z') {
+					continue;
+				}
+				if (zSql[idx] == '_') {
 					continue;
 				}
 				if (zSql[idx] >= '\200' && zSql[idx] <= '\377') {


### PR DESCRIPTION
In a bunch of places the parsing of dollar quoted strings was slightly
different than [what was actually done by libpg_query][1]. This fixes
those places. In particular, underscores are allowed and numbers are
allowed in anything but the first character.

[1]: https://github.com/duckdb/duckdb/blob/bb0452e215d98aefc237e0a21f0cc7655a4f245f/third_party/libpg_query/scan.l#L259-L269
