### PR TITLE
Do not autocomplete within dollar-quoted strings

### DIFF
--- a/extension/autocomplete/tokenizer.cpp
+++ b/extension/autocomplete/tokenizer.cpp
@@ -401,7 +401,8 @@ bool BaseTokenizer::TokenizeInput() {
 		break;
 	case TokenizeState::SINGLE_LINE_COMMENT:
 	case TokenizeState::MULTI_LINE_COMMENT:
-		// no suggestions in comments
+	case TokenizeState::DOLLAR_QUOTED_STRING:
+		// no suggestions in comments or dollar-quoted strings
 		return false;
 	default:
 		break;


### PR DESCRIPTION
While working on #20121 I found that auto-complete behaviour in
dollar-quoted strings felt off. In particular the following:

```sql
SELECT $a$ <tab>
-- Note the space between $a$ and <tab>
```

would autocomplete to:

```sql
SELECT $
```

This disables autocomplete in dollar-quoted strings, just like we do for
comments.
