### PR TITLE
Fix concurrent test failure

### DIFF
--- a/test/sql/storage/concurrent_wal/concurrent_checkpoint_abort.test_slow
+++ b/test/sql/storage/concurrent_wal/concurrent_checkpoint_abort.test_slow
@@ -68,7 +68,7 @@ ATTACH '__TEST_DIR__/concurrent_other_db.db' AS other_db (READ_ONLY)
 
 # verify all data was correctly written
 query I
-SELECT CASE WHEN max_i + 1 >= max_end THEN NULL ELSE CONCAT('Found min ', min_i, ', max ', max_i, ' which does not fall within range ', begin_range, ' - ', max_end, ' (all ranges: ', (SELECT LIST(r ORDER BY begin_range) FROM other_db.ranges r)::VARCHAR, ')') END
+SELECT CASE WHEN max_i + 1 >= max_end OR max_end IS NULL THEN NULL ELSE CONCAT('Found min ', min_i, ', max ', max_i, ' which does not fall within range ', begin_range, ' - ', max_end, ' (all ranges: ', (SELECT LIST(r ORDER BY begin_range) FROM other_db.ranges r)::VARCHAR, ')') END
 FROM (SELECT MIN(i) min_i, MAX(i) max_i FROM main_db.integers), (SELECT MIN(begin_range) begin_range, MAX(end_range) max_end FROM other_db.ranges)
 ----
 NULL


### PR DESCRIPTION
This test is sporadically failing in CI due to the test itself being wrong.

We write, in-order, to `main_db.integers` followed by writing to `other_db.ranges`. Depending on when the abort happens, data can be either (1) in `main_db.integers`, (2) in both `main_db.integers` and `other_db.ranges`, or (3) in neither of them. It is therefore completely valid for the data not to be in `other_db.ranges`. The current code assumes at least *some* data makes it to `other_db.ranges` and fails if that table is empty - but that is not always the case. Depending on when the abort is triggered that table might be empty. This PR fixes the test to reflect that correctly.