### PR TITLE
Fix vector sizes CI 

### DIFF
--- a/test/sql/copy/parquet/test_parquet_scan.test
+++ b/test/sql/copy/parquet/test_parquet_scan.test
@@ -248,4 +248,4 @@ SELECT FIRST(comments) OVER w, LAST(comments) OVER w FROM userdata1 WINDOW w AS 
 statement error
 SELECT * FROM parquet_scan('{DATA_DIR}/parquet-testing/broken-arrow.parquet')
 ----
-<REGEX>:.*Invalid Error: Out of buffer.*
+<REGEX>:.*Invalid Error:.*


### PR DESCRIPTION
Fixes duckdblabs/duckdb-internal#6850

We're getting a different exception due to the vector size. On larger vector sizes, we run out of buffer. On smaller vector sizes, we get a dictionary offset out of range.

Fixed by making the expected error in the test more lenient.