### PR TITLE
Fix minio nightly tests

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -332,16 +332,17 @@ jobs:
         run: CORE_EXTENSIONS="tpch" make
 
       - name: Start Minio
-        working-directory: $GITHUB_WORKSPACE/duckdb-httpfs
+        working-directory: ${{ github.workspace }}/duckdb-httpfs
         shell: bash
         run: |
+          export PATH="${{ github.workspace }}/build/release:$PATH"
           sudo ./scripts/install_s3_test_server.sh
           ./scripts/generate_presigned_url.sh
           source ./scripts/run_s3_test_server.sh
           source ./scripts/set_s3_test_server_variables.sh
           sleep 60
 
-      - name: Build
+      - name: Run Extension Medata Tests
         shell: bash
         run: |
           ./scripts/run_extension_medata_tests.sh

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -296,6 +296,10 @@ jobs:
           sudo rm -rf /var/lib/apt/lists/*
           docker system prune -af || true
           rm -rf ~/.cache
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           echo "Disk usage after clean up:"
           df -h
 

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -288,20 +288,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Cleanup disk before build
-        run: |
-          echo "Disk usage before clean up:"
-          df -h
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          docker system prune -af || true
-          rm -rf ~/.cache
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          echo "Disk usage after clean up:"
-          df -h
+
+      - uses: ./.github/actions/cleanup_runner
 
       - name: Checkout duckdb-httpfs
         uses: actions/checkout@v4

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -288,6 +288,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Cleanup disk before build
+        run: |
+          echo "Disk usage before clean up:"
+          df -h
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          docker system prune -af || true
+          rm -rf ~/.cache
+          echo "Disk usage after clean up:"
+          df -h
 
       - name: Checkout duckdb-httpfs
         uses: actions/checkout@v4

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -289,6 +289,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout duckdb-httpfs
+        uses: actions/checkout@v4
+        with:
+          repository: duckdb/duckdb-httpfs
+          path: duckdb-httpfs
+          sparse-checkout: scripts
+
       - name: Install
         shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
@@ -312,6 +319,7 @@ jobs:
         run: CORE_EXTENSIONS="tpch" make
 
       - name: Start Minio
+        working-directory: $GITHUB_WORKSPACE/duckdb-httpfs
         shell: bash
         run: |
           sudo ./scripts/install_s3_test_server.sh

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -308,7 +308,6 @@ jobs:
         with:
           repository: duckdb/duckdb-httpfs
           path: duckdb-httpfs
-          sparse-checkout: scripts
 
       - name: Install
         shell: bash

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -307,6 +307,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: duckdb/duckdb-httpfs
+          submodules: 'true'
           path: duckdb-httpfs
 
       - name: Install


### PR DESCRIPTION
fix for: https://github.com/duckdblabs/duckdb-internal/issues/6746

Job [Extension updating test](https://github.com/duckdb/duckdb/actions/runs/19688595758/job/56400411410) fails with error: `sudo: ./scripts/install_s3_test_server.sh: command not found`

This PR fixes NightlyTest by fetching the minio scripts from their new current location (duckdb-httpfs)

This is needed because the minio scripts have moved to the `duckdb-httpfs` repo.
See:
-  https://github.com/duckdb/duckdb/pull/19140  (scripts removed from `duckdb/duckdb`)
-  https://github.com/duckdb/duckdb-httpfs/pull/132  (scripts added to `duckdb-httpfs`)

Note that the minio server is required only for `test/extension/update_extensions_ci.test`.
This test is supposed to run as part of the NightlyTest via `scripts/run_extension_medata_tests.sh`

Backported disk clean-up from main: https://github.com/duckdb/duckdb/pull/19214