### PR TITLE
Remove hash (#) from required quotes per RFC 4180

### DIFF
--- a/src/common/csv_writer.cpp
+++ b/src/common/csv_writer.cpp
@@ -34,7 +34,6 @@ CSVWriterOptions::CSVWriterOptions(const string &delim, const char &quote, const
 	requires_quotes = vector<bool>(256, false);
 	requires_quotes['\n'] = true;
 	requires_quotes['\r'] = true;
-	requires_quotes['#'] = true;
 	requires_quotes[NumericCast<idx_t>(delim[0])] = true;
 	requires_quotes[NumericCast<idx_t>(quote)] = true;
 

--- a/test/sql/copy/csv/test_csv_hash_minimal_quoting.test
+++ b/test/sql/copy/csv/test_csv_hash_minimal_quoting.test
@@ -1,0 +1,64 @@
+# name: test/sql/copy/csv/test_csv_hash_minimal_quoting.test
+# description: Test that hash (#) characters are not quoted per RFC 4180
+# group: [csv]
+
+# Test 1: Hash at the beginning should not be quoted
+statement ok
+COPY (SELECT '#test' as value) TO '__TEST_DIR__/hash_start.csv' (HEADER false);
+
+query I
+SELECT * FROM read_csv_auto('__TEST_DIR__/hash_start.csv', header=false);
+----
+#test
+
+# Test 2: Hash in the middle (like the issue example)
+statement ok
+COPY (SELECT 'Elvis 30 #1 Hits' as title, 'vinyl' as format) TO '__TEST_DIR__/hash_middle.csv' (HEADER true);
+
+query II
+SELECT * FROM read_csv_auto('__TEST_DIR__/hash_middle.csv', header=true);
+----
+Elvis 30 #1 Hits	vinyl
+
+# Test 3: Multiple hashes
+statement ok
+COPY (SELECT '##test##' as value) TO '__TEST_DIR__/hash_multiple.csv' (HEADER false);
+
+query I
+SELECT * FROM read_csv_auto('__TEST_DIR__/hash_multiple.csv', header=false);
+----
+##test##
+
+# Test 4: Ensure comma still gets quoted
+statement ok
+COPY (SELECT 'a,b,c' as value) TO '__TEST_DIR__/comma.csv' (HEADER false);
+
+query I
+SELECT * FROM read_csv_auto('__TEST_DIR__/comma.csv', header=false);
+----
+a,b,c
+
+# Test 5: Ensure newline still gets quoted
+statement ok
+COPY (SELECT 'line1
+line2' as value) TO '__TEST_DIR__/newline.csv' (HEADER false);
+
+query I
+SELECT COUNT(*) FROM read_csv_auto('__TEST_DIR__/newline.csv', header=false);
+----
+1
+
+query I
+SELECT LENGTH(column0) FROM read_csv_auto('__TEST_DIR__/newline.csv', header=false);
+# 5 + 1 + 5 = "line1" + newline + "line2"
+----
+11
+
+# Test 6: Ensure quote character still gets escaped
+statement ok
+COPY (SELECT 'hello "world"' as value) TO '__TEST_DIR__/quotes.csv' (HEADER false);
+
+query I
+SELECT * FROM read_csv_auto('__TEST_DIR__/quotes.csv', header=false);
+----
+hello "world"


### PR DESCRIPTION
Fixes #20095 

- This PR addresses the issue where hash characters were unnecessarily quoted in CSV output.

## Solution
Modified the CSV writer to exclude hash characters from the list of characters requiring quotes. Now only the characters. mandated by RFC 4180 are quoted: delimiters (comma), quote marks ("), and line breaks.

## Changes
- Removed hash character from the list of characters that require quoting in CSV output.
- Added tests  to verify hash characters are not quoted while maintaining RFC 4180 compliance for commas, newlines, and quotes.
