### PR TITLE
HashCSVStateMachineConfig to return hash_t

### DIFF
--- a/src/include/duckdb/execution/operator/csv_scanner/csv_state_machine_cache.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_state_machine_cache.hpp
@@ -47,7 +47,7 @@ public:
 
 //! Hash function used in out state machine cache, it hashes and combines all options used to generate a state machine
 struct HashCSVStateMachineConfig {
-	size_t operator()(CSVStateMachineOptions const &config) const noexcept {
+	hash_t operator()(CSVStateMachineOptions const &config) const noexcept {
 		auto h_delimiter = Hash(config.delimiter.GetValue().c_str());
 		auto h_quote = Hash(config.quote.GetValue());
 		auto h_escape = Hash(config.escape.GetValue());


### PR DESCRIPTION
Minor, but given the type is a uint64_t, I don't see the point of converting it to size_t (that might be 32 or 64, platform dependent).