### PR TITLE
[Dev] Fix failure on `extension_entries.hpp` on main

### DIFF
--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -794,6 +794,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"|", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"~", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
 }; // END_OF_EXTENSION_FUNCTIONS
+
 static constexpr ExtensionFunctionOverloadEntry EXTENSION_FUNCTION_OVERLOADS[] = {
     {"age", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY, "[TIMESTAMP]>INTERVAL"},
     {"age", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY, "[TIMESTAMP,TIMESTAMP]>INTERVAL"},


### PR DESCRIPTION
title ^

I ran:
```
GENERATE_EXTENSION_ENTRIES=1 CORE_EXTENSIONS="core_functions" make release
```
```
python3 scripts/generate_extensions_function.py
```
```
make format-main
```

came up with this diff 🤷 
Can't really explain why this randomly breaks after not being touched for a year, but I think the formatting version silently updated??