### PR TITLE
Fix use-after-free in mode aggregate Combine function

### DIFF
--- a/extension/core_functions/aggregate/holistic/mode.cpp
+++ b/extension/core_functions/aggregate/holistic/mode.cpp
@@ -234,15 +234,12 @@ struct BaseModeFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
 		if (!source.frequency_map) {
 			return;
 		}
 		if (!target.frequency_map) {
-			// Copy - don't destroy! Otherwise windowing will break.
-			target.frequency_map = new typename STATE::Counts(*source.frequency_map);
-			target.count = source.count;
-			return;
+			target.frequency_map = TYPE_OP::CreateEmpty(aggr_input_data.allocator);
 		}
 		for (auto &val : *source.frequency_map) {
 			auto &i = (*target.frequency_map)[val.first];

--- a/test/sql/aggregate/aggregates/test_mode.test
+++ b/test/sql/aggregate/aggregates/test_mode.test
@@ -306,3 +306,18 @@ VALUES
 )items_per_order(order_occurrences, item_count);
 ----
 1000
+
+# Parallel combine with UTF-8 strings (use-after-free bug in Combine)
+statement ok
+PRAGMA threads=4;
+
+statement ok
+CREATE TABLE mode_utf8 AS
+SELECT g, (['চৌদ্দগ্রাম', 'São Paulo', '東京都', 'Região Geográfica'])[1 + (g+s) % 4] AS v
+FROM generate_series(0,100000) _(g), generate_series(0,2) __(s);
+
+query I
+SELECT count(*) FROM (SELECT g, mode(v) AS m FROM mode_utf8 GROUP BY g)
+WHERE m IN ('চৌদ্দগ্রাম', 'São Paulo', '東京都', 'Região Geográfica');
+----
+100001


### PR DESCRIPTION
## Problem

Fix for issue #20090

The `mode()` aggregate function produces corrupted strings when combining states during parallel execution with VARCHAR columns containing UTF-8 strings.

The `Combine` function in `mode.cpp` used the default copy constructor to duplicate the frequency map when the target map was null:

```cpp
target.frequency_map = new typename STATE::Counts(*source.frequency_map);
```

This caused a use-after-free because OwningStringMap's default copy constructor shallow-copies string pointers that reference the source's allocator memory. When the source state is destroyed, the target still holds dangling pointers to freed memory.

## Solution

Instead of copying the map, create a new empty map with the target's allocator and iterate through the source to properly copy entries:

```cpp
target.frequency_map = TYPE_OP::CreateEmpty(aggr_input_data.allocator);
```

The iteration through operator[] properly copies strings via OwningStringMap::CopyString, ensuring each state owns its own memory.

## Testing

Added a test in `test_mode.test` which verifies that mode() on 100k groups with UTF-8 strings produces valid results during parallel execution.

Yes, I noticed the comment `"// Copy - don't destroy! Otherwise windowing will break."`, but this fix didn't break windowing.