### PR TITLE
Added pagination variable for glob filesystem

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -661,7 +661,7 @@ vector<OpenFileInfo> FileSystem::GlobFiles(const string &pattern, ClientContext 
 }
 
 unique_ptr<PaginatedResult<OpenFileInfo>> FileSystem::PaginatedGlobFiles(const string &pattern, ClientContext &context,
-																		 const FileGlobInput &input) {
+                                                                         const FileGlobInput &input) {
 	auto result = PaginatedGlob(pattern);
 	if (!result->FetchNextPage()) {
 		if (input.behavior == FileGlobOptions::FALLBACK_GLOB && !HasGlob(pattern)) {

--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -4,10 +4,8 @@
 #include "duckdb/common/hive_partitioning.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/function/function_set.hpp"
-#include "duckdb/function/table_function.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
-#include "duckdb/common/string_util.hpp"
 
 #include <algorithm>
 
@@ -276,6 +274,7 @@ idx_t SimpleMultiFileList::GetTotalFileCount() {
 //===--------------------------------------------------------------------===//
 GlobMultiFileList::GlobMultiFileList(ClientContext &context_p, vector<OpenFileInfo> paths_p, FileGlobInput glob_input)
     : MultiFileList(std::move(paths_p), std::move(glob_input)), context(context_p), current_path(0) {
+	paginated_files.resize(paths.size());
 }
 
 unique_ptr<MultiFileList> GlobMultiFileList::ComplexFilterPushdown(ClientContext &context_p,
@@ -313,8 +312,9 @@ GlobMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFile
 	// Expand all paths into a copy
 	// FIXME: lazy expansion and push filters into glob
 	idx_t path_index = current_path;
+	vector<unique_ptr<PaginatedResult<OpenFileInfo>>> paginated_files;
 	auto file_list = expanded_files;
-	while (ExpandPathInternal(path_index, file_list)) {
+	while (ExpandPathInternal(path_index, file_list, paginated_files)) {
 	}
 
 	auto res = PushdownInternal(context, options, names, types, column_ids, filters, file_list);
@@ -367,22 +367,36 @@ OpenFileInfo GlobMultiFileList::GetFileInternal(idx_t i) {
 	return expanded_files[i];
 }
 
-bool GlobMultiFileList::ExpandPathInternal(idx_t &current_path, vector<OpenFileInfo> &result) const {
+bool GlobMultiFileList::ExpandPathInternal(idx_t &current_path, vector<OpenFileInfo> &result,
+                                           vector<unique_ptr<PaginatedResult<OpenFileInfo>>> &paginated_files) const {
 	if (current_path >= paths.size()) {
 		return false;
 	}
-
 	auto &fs = FileSystem::GetFileSystem(context);
-	auto glob_files = fs.GlobFiles(paths[current_path].path, context, glob_input);
-	std::sort(glob_files.begin(), glob_files.end());
-	result.insert(result.end(), glob_files.begin(), glob_files.end());
+	const auto &current_file_path = paths[current_path].path;
+	if (fs.SupportsPaginatedGlobbing(current_file_path, context)) {
+		auto &pagination_result = paginated_files[current_path];
+		if (pagination_result == nullptr) {
+			pagination_result = fs.PaginatedGlobFiles(current_file_path, context, glob_input);
+		}
 
-	current_path++;
-	return true;
+		if (pagination_result->FetchNextPage()) {
+			auto next_page = pagination_result->ClaimNextPage();
+			result.insert(result.end(), next_page.begin(), next_page.end());
+		} else {
+			current_path++;
+		}
+		return true;
+	} else {
+		auto glob_files = fs.GlobFiles(current_file_path, context, glob_input);
+		result.insert(result.end(), glob_files.begin(), glob_files.end());
+		current_path++;
+		return true;
+	}
 }
 
 bool GlobMultiFileList::ExpandNextPath() {
-	return ExpandPathInternal(current_path, expanded_files);
+	return ExpandPathInternal(current_path, expanded_files, paginated_files);
 }
 
 bool GlobMultiFileList::IsFullyExpanded() const {

--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -312,7 +312,8 @@ GlobMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFile
 	// Expand all paths into a copy
 	// FIXME: lazy expansion and push filters into glob
 	idx_t path_index = current_path;
-	vector<unique_ptr<PaginatedResult<OpenFileInfo>>> paginated_files;
+	vector<unique_ptr<PaginatedResult<OpenFileInfo>>> paginated_files{};
+	paginated_files.resize(paths.size());
 	auto file_list = expanded_files;
 	while (ExpandPathInternal(path_index, file_list, paginated_files)) {
 	}

--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -312,7 +312,7 @@ GlobMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFile
 	// Expand all paths into a copy
 	// FIXME: lazy expansion and push filters into glob
 	idx_t path_index = current_path;
-	vector<unique_ptr<PaginatedResult<OpenFileInfo>>> paginated_files{};
+	vector<unique_ptr<PaginatedResult<OpenFileInfo>>> paginated_files {};
 	paginated_files.resize(paths.size());
 	auto file_list = expanded_files;
 	while (ExpandPathInternal(path_index, file_list, paginated_files)) {

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -144,6 +144,14 @@ vector<OpenFileInfo> VirtualFileSystem::Glob(const string &path, FileOpener *ope
 	return FindFileSystem(path, opener).Glob(path, opener);
 }
 
+unique_ptr<PaginatedResult<OpenFileInfo>> VirtualFileSystem::PaginatedGlob(const string &path, FileOpener *opener) {
+	return FindFileSystem(path, opener).PaginatedGlob(path, opener);
+}
+
+bool VirtualFileSystem::SupportsPaginatedGlobbing(const string &fpath, ClientContext &context) {
+	return FindFileSystem(fpath, context.db).SupportsPaginatedGlobbing(fpath, context);
+}
+
 void VirtualFileSystem::RegisterSubSystem(unique_ptr<FileSystem> fs) {
 	sub_systems.push_back(std::move(fs));
 }

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -36,6 +36,40 @@ class Logger;
 class ClientContext;
 class QueryContext;
 
+template <typename T>
+struct PaginatedResult {
+	PaginatedResult() = default;
+
+	virtual ~PaginatedResult() = default;
+
+	bool FetchNextPage() {
+		if (page_buffer.empty()) {
+			page_buffer = GetNextPageInternal();
+		}
+		return !page_buffer.empty();
+	}
+
+	vector<T> ClaimNextPage() {
+		return std::move(page_buffer);
+	}
+
+	vector<T> ClaimAllPages() {
+		vector<T> result;
+		while (FetchNextPage()) {
+			auto next_page = ClaimNextPage();
+			result.insert(result.end(), std::make_move_iterator(next_page.begin()),
+			              std::make_move_iterator(next_page.end()));
+		}
+		return result;
+	}
+
+protected:
+	virtual vector<T> GetNextPageInternal() = 0;
+
+private:
+	std::vector<T> page_buffer;
+};
+
 enum class FileType {
 	//! Regular file
 	FILE_TYPE_REGULAR,
@@ -233,8 +267,16 @@ public:
 	DUCKDB_API static bool HasGlob(const string &str);
 	//! Runs a glob on the file system, returning a list of matching files
 	DUCKDB_API virtual vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr);
+	//! Runs a glob on the file system, returning a list of matching files in a paginated fashion
+	DUCKDB_API virtual unique_ptr<PaginatedResult<OpenFileInfo>> PaginatedGlob(const string &path,
+	                                                                           FileOpener *opener = nullptr);
 	DUCKDB_API vector<OpenFileInfo> GlobFiles(const string &path, ClientContext &context,
 	                                          const FileGlobInput &input = FileGlobOptions::DISALLOW_EMPTY);
+
+	//! Runs a glob on the file system, returning a list of matching files in a paginated fashion
+	DUCKDB_API unique_ptr<PaginatedResult<OpenFileInfo>>
+	PaginatedGlobFiles(const string &path, ClientContext &context,
+	                   const FileGlobInput &input = FileGlobOptions::DISALLOW_EMPTY);
 
 	//! registers a sub-file system to handle certain file name prefixes, e.g. http:// etc.
 	DUCKDB_API virtual void RegisterSubSystem(unique_ptr<FileSystem> sub_fs);
@@ -252,6 +294,9 @@ public:
 
 	//! Whether or not a sub-system can handle a specific file path
 	DUCKDB_API virtual bool CanHandleFile(const string &fpath);
+
+	//! Whether or not the file system supports paginated globbing for a specific file path
+	DUCKDB_API virtual bool SupportsPaginatedGlobbing(const string &fpath, ClientContext &context);
 
 	//! Set the file pointer of a file handle to a specified location. Reads and writes will happen from this location
 	DUCKDB_API virtual void Seek(FileHandle &handle, idx_t location);

--- a/src/include/duckdb/common/multi_file/multi_file_list.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_list.hpp
@@ -182,7 +182,8 @@ protected:
 	//! Grabs the next path and expands it into Expanded paths: returns false if no more files to expand
 	bool ExpandNextPath();
 	//! Grabs the next path and expands it into Expanded paths: returns false if no more files to expand
-	bool ExpandPathInternal(idx_t &current_path, vector<OpenFileInfo> &result) const;
+	bool ExpandPathInternal(idx_t &current_path, vector<OpenFileInfo> &result,
+	                        vector<unique_ptr<PaginatedResult<OpenFileInfo>>> &paginated_files) const;
 	//! Whether all files have been expanded
 	bool IsFullyExpanded() const;
 
@@ -190,6 +191,8 @@ protected:
 	ClientContext &context;
 	//! The current path to expand
 	idx_t current_path;
+	//! The paginated results for each path
+	vector<unique_ptr<PaginatedResult<OpenFileInfo>>> paginated_files;
 	//! The expanded files
 	vector<OpenFileInfo> expanded_files;
 

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -123,6 +123,16 @@ public:
 		return GetFileSystem().Glob(path, GetOpener().get());
 	}
 
+	unique_ptr<PaginatedResult<OpenFileInfo>> PaginatedGlob(const string &path, FileOpener *opener) override {
+		VerifyNoOpener(opener);
+		VerifyCanAccessFile(path);
+		return GetFileSystem().PaginatedGlob(path, GetOpener().get());
+	}
+
+	bool SupportsPaginatedGlobbing(const string &fpath, ClientContext &context) override {
+		return GetFileSystem().SupportsPaginatedGlobbing(fpath, context);
+	}
+
 	std::string GetName() const override {
 		return "OpenerFileSystem - " + GetFileSystem().GetName();
 	}

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -51,6 +51,10 @@ public:
 
 	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;
 
+	unique_ptr<PaginatedResult<OpenFileInfo>> PaginatedGlob(const string &path, FileOpener *opener = nullptr) override;
+
+	bool SupportsPaginatedGlobbing(const string &fpath, ClientContext &context) override;
+
 	void RegisterSubSystem(unique_ptr<FileSystem> fs) override;
 
 	void UnregisterSubSystem(const string &name) override;

--- a/test/parquet/test_filename_column.test
+++ b/test/parquet/test_filename_column.test
@@ -55,7 +55,7 @@ SELECT my_cool_filename FROM read_parquet('{DATA_DIR}/parquet-testing/enum.parqu
 {DATA_DIR}/parquet-testing/enum.parquet
 
 query III
-SELECT parse_filename(file_name), row_group_id, bloom_filter_excludes FROM parquet_bloom_probe('{DATA_DIR}/parquet-testing/multi_bloom_*.parquet', 'a', 1)
+SELECT parse_filename(file_name), row_group_id, bloom_filter_excludes FROM parquet_bloom_probe('{DATA_DIR}/parquet-testing/multi_bloom_*.parquet', 'a', 1) ORDER BY file_name
 ----
 multi_bloom_a.parquet	0	false
 multi_bloom_b.parquet	0	true

--- a/test/parquet/test_filename_column.test
+++ b/test/parquet/test_filename_column.test
@@ -55,7 +55,7 @@ SELECT my_cool_filename FROM read_parquet('{DATA_DIR}/parquet-testing/enum.parqu
 {DATA_DIR}/parquet-testing/enum.parquet
 
 query III
-SELECT parse_filename(file_name), row_group_id, bloom_filter_excludes FROM parquet_bloom_probe('{DATA_DIR}/parquet-testing/multi_bloom_*.parquet', 'a', 1) ORDER BY file_name
+SELECT parse_filename(file_name), row_group_id, bloom_filter_excludes FROM parquet_bloom_probe('{DATA_DIR}/parquet-testing/multi_bloom_*.parquet', 'a', 1)
 ----
 multi_bloom_a.parquet	0	false
 multi_bloom_b.parquet	0	true

--- a/test/sql/copy/csv/rejects/csv_incorrect_columns_amount_rejects.test
+++ b/test/sql/copy/csv/rejects/csv_incorrect_columns_amount_rejects.test
@@ -110,32 +110,32 @@ SELECT * FROM read_csv(
     columns = {'a': 'INTEGER', 'b': 'INTEGER', 'c': 'INTEGER', 'd': 'INTEGER'},
    store_rejects=true, auto_detect=false, header = 1, strict_mode=True);
 
-query IIIIIIIII rowsort
-SELECT * EXCLUDE (scan_id) FROM reject_errors order by all
+query IIIIIIII
+SELECT * EXCLUDE (scan_id, file_id) FROM reject_errors order by line, line_byte_position, byte_position, column_idx ASC
 ----
-0	1814	14505	14510	3	d	MISSING COLUMNS	1,2,3	Expected Number of Columns: 4 Found: 3
-0	1823	14575	14576	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
-0	1823	14575	14576	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
-0	1823	14575	14576	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
-0	2378	19009	19010	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
-0	2378	19009	19010	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
-0	2378	19009	19010	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
-0	2762	22075	22078	2	c	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 2
-0	2762	22075	22078	3	d	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 3
-1	1096	8761	8768	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
-1	1096	8761	8770	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
-1	1159	9269	9276	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
-1	1159	9269	9278	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
-1	1206	9649	9656	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5
-1	2769	22155	22162	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5
-2	1604	12825	12826	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
-2	1604	12825	12826	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
-2	1604	12825	12826	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
-2	1671	13355	13362	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
-2	1671	13355	13364	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
-2	2751	21999	22002	2	c	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 2
-2	2751	21999	22002	3	d	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 3
-2	2768	22131	22138	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
-2	2768	22131	22140	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
-3	3	17	24	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5
-3	4	27	32	3	d	MISSING COLUMNS	1,2,3	Expected Number of Columns: 4 Found: 3
+3	17	24	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5
+4	27	32	3	d	MISSING COLUMNS	1,2,3	Expected Number of Columns: 4 Found: 3
+1096	8761	8768	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
+1096	8761	8770	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
+1159	9269	9276	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
+1159	9269	9278	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
+1206	9649	9656	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5
+1604	12825	12826	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
+1604	12825	12826	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
+1604	12825	12826	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
+1671	13355	13362	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
+1671	13355	13364	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
+1814	14505	14510	3	d	MISSING COLUMNS	1,2,3	Expected Number of Columns: 4 Found: 3
+1823	14575	14576	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
+1823	14575	14576	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
+1823	14575	14576	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
+2378	19009	19010	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
+2378	19009	19010	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
+2378	19009	19010	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
+2751	21999	22002	2	c	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 2
+2751	21999	22002	3	d	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 3
+2762	22075	22078	2	c	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 2
+2762	22075	22078	3	d	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 3
+2768	22131	22138	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
+2768	22131	22140	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
+2769	22155	22162	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5

--- a/test/sql/copy/csv/rejects/csv_incorrect_columns_amount_rejects.test
+++ b/test/sql/copy/csv/rejects/csv_incorrect_columns_amount_rejects.test
@@ -110,32 +110,32 @@ SELECT * FROM read_csv(
     columns = {'a': 'INTEGER', 'b': 'INTEGER', 'c': 'INTEGER', 'd': 'INTEGER'},
    store_rejects=true, auto_detect=false, header = 1, strict_mode=True);
 
-query IIIIIIII
-SELECT * EXCLUDE (scan_id, file_id) FROM reject_errors order by line, line_byte_position, byte_position, column_idx ASC
+query IIIIIIIII rowsort
+SELECT * EXCLUDE (scan_id) FROM reject_errors order by all
 ----
-3	17	24	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5
-4	27	32	3	d	MISSING COLUMNS	1,2,3	Expected Number of Columns: 4 Found: 3
-1096	8761	8768	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
-1096	8761	8770	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
-1159	9269	9276	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
-1159	9269	9278	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
-1206	9649	9656	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5
-1604	12825	12826	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
-1604	12825	12826	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
-1604	12825	12826	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
-1671	13355	13362	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
-1671	13355	13364	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
-1814	14505	14510	3	d	MISSING COLUMNS	1,2,3	Expected Number of Columns: 4 Found: 3
-1823	14575	14576	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
-1823	14575	14576	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
-1823	14575	14576	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
-2378	19009	19010	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
-2378	19009	19010	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
-2378	19009	19010	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
-2751	21999	22002	2	c	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 2
-2751	21999	22002	3	d	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 3
-2762	22075	22078	2	c	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 2
-2762	22075	22078	3	d	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 3
-2768	22131	22138	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
-2768	22131	22140	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
-2769	22155	22162	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5
+0	1814	14505	14510	3	d	MISSING COLUMNS	1,2,3	Expected Number of Columns: 4 Found: 3
+0	1823	14575	14576	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
+0	1823	14575	14576	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
+0	1823	14575	14576	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
+0	2378	19009	19010	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
+0	2378	19009	19010	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
+0	2378	19009	19010	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
+0	2762	22075	22078	2	c	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 2
+0	2762	22075	22078	3	d	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 3
+1	1096	8761	8768	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
+1	1096	8761	8770	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
+1	1159	9269	9276	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
+1	1159	9269	9278	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
+1	1206	9649	9656	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5
+1	2769	22155	22162	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5
+2	1604	12825	12826	1	b	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 1
+2	1604	12825	12826	2	c	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 2
+2	1604	12825	12826	3	d	MISSING COLUMNS	1	Expected Number of Columns: 4 Found: 3
+2	1671	13355	13362	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
+2	1671	13355	13364	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
+2	2751	21999	22002	2	c	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 2
+2	2751	21999	22002	3	d	MISSING COLUMNS	1,2	Expected Number of Columns: 4 Found: 3
+2	2768	22131	22138	5	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 5
+2	2768	22131	22140	6	NULL	TOO MANY COLUMNS	1,2,3,4,5,6	Expected Number of Columns: 4 Found: 6
+3	3	17	24	5	NULL	TOO MANY COLUMNS	1,2,3,4,5	Expected Number of Columns: 4 Found: 5
+3	4	27	32	3	d	MISSING COLUMNS	1,2,3	Expected Number of Columns: 4 Found: 3

--- a/test/sql/copy/csv/rejects/csv_rejects_auto.test
+++ b/test/sql/copy/csv/rejects/csv_rejects_auto.test
@@ -15,13 +15,13 @@ SELECT typeof(first(column0)), typeof(first(column1)), COUNT(*), SUM(column0), M
 ----
 BIGINT	VARCHAR	11044	11044	2
 
-query IIIIIIIII rowsort
-SELECT * EXCLUDE (scan_id) FROM reject_errors order by all;
+query IIIIIIII
+SELECT * EXCLUDE (scan_id, file_id) FROM reject_errors order by line, line_byte_position, byte_position, column_idx ASC;
 ----
-0	2176	10876	10876	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
-0	4176	20876	20876	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
-1	3680	18396	18396	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
-1	5680	28396	28396	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
+2176	10876	10876	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
+3680	18396	18396	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
+4176	20876	20876	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
+5680	28396	28396	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
 
 statement ok
 DROP TABLE reject_errors;

--- a/test/sql/copy/csv/rejects/csv_rejects_maximum_line.test
+++ b/test/sql/copy/csv/rejects/csv_rejects_maximum_line.test
@@ -74,13 +74,13 @@ SELECT * FROM read_csv(
     columns = {'a': 'VARCHAR', 'b': 'INTEGER'},
      store_rejects = true, auto_detect=false, header = 1, max_line_size=10);
 
-query IIIIIIIII
-SELECT * EXCLUDE (scan_id) FROM reject_errors order by all;
+query IIIIIIII
+SELECT * EXCLUDE (scan_id, file_id) FROM reject_errors order by line, line_byte_position, byte_position, column_idx ASC;
 ----
-0	5	23	23	NULL	NULL	LINE SIZE OVER MAXIMUM	blaaaaaaaaaaaaaa,4	Maximum line size of 10 bytes exceeded. Actual Size:18 bytes.
-1	2282	13685	13685	NULL	NULL	LINE SIZE OVER MAXIMUM	blaaaaaaaaaaaaaaaaaaaa,1	Maximum line size of 10 bytes exceeded. Actual Size:24 bytes.
-1	2591	15558	15558	NULL	NULL	LINE SIZE OVER MAXIMUM	blaaaaaaaaaaaaaaaaaaaa,1	Maximum line size of 10 bytes exceeded. Actual Size:24 bytes.
-1	2923	17569	17569	NULL	NULL	LINE SIZE OVER MAXIMUM	blaaaaaaaaaaaaaaaaaaaa,3	Maximum line size of 10 bytes exceeded. Actual Size:24 bytes.
+5	23	23	NULL	NULL	LINE SIZE OVER MAXIMUM	blaaaaaaaaaaaaaa,4	Maximum line size of 10 bytes exceeded. Actual Size:18 bytes.
+2282	13685	13685	NULL	NULL	LINE SIZE OVER MAXIMUM	blaaaaaaaaaaaaaaaaaaaa,1	Maximum line size of 10 bytes exceeded. Actual Size:24 bytes.
+2591	15558	15558	NULL	NULL	LINE SIZE OVER MAXIMUM	blaaaaaaaaaaaaaaaaaaaa,1	Maximum line size of 10 bytes exceeded. Actual Size:24 bytes.
+2923	17569	17569	NULL	NULL	LINE SIZE OVER MAXIMUM	blaaaaaaaaaaaaaaaaaaaa,3	Maximum line size of 10 bytes exceeded. Actual Size:24 bytes.
 
 statement ok
 DROP TABLE reject_errors;

--- a/test/sql/copy/csv/rejects/csv_rejects_read.test
+++ b/test/sql/copy/csv/rejects/csv_rejects_read.test
@@ -148,13 +148,13 @@ SELECT SUM(num) FROM read_csv(
 ----
 11044
 
-query IIIIIIIII
-SELECT * EXCLUDE (scan_id) FROM reject_errors ORDER BY ALL;
+query IIIIIIII
+SELECT * EXCLUDE (scan_id, file_id) FROM reject_errors ORDER BY line, line_byte_position, byte_position, column_idx ASC;
 ----
-0	2176	10876	10876	1	num	CAST	B, A	Error when converting column "num". Could not convert string "B" to 'INTEGER'
-0	4176	20876	20876	1	num	CAST	C, A	Error when converting column "num". Could not convert string "C" to 'INTEGER'
-1	3680	18396	18396	1	num	CAST	B, A	Error when converting column "num". Could not convert string "B" to 'INTEGER'
-1	5680	28396	28396	1	num	CAST	C, A	Error when converting column "num". Could not convert string "C" to 'INTEGER'
+2176	10876	10876	1	num	CAST	B, A	Error when converting column "num". Could not convert string "B" to 'INTEGER'
+3680	18396	18396	1	num	CAST	B, A	Error when converting column "num". Could not convert string "B" to 'INTEGER'
+4176	20876	20876	1	num	CAST	C, A	Error when converting column "num". Could not convert string "C" to 'INTEGER'
+5680	28396	28396	1	num	CAST	C, A	Error when converting column "num". Could not convert string "C" to 'INTEGER'
 
 statement ok
 DROP TABLE reject_errors;

--- a/test/sql/copy/csv/rejects/csv_rejects_two_tables.test
+++ b/test/sql/copy/csv/rejects/csv_rejects_two_tables.test
@@ -16,19 +16,19 @@ SELECT typeof(first(column0)), typeof(first(column1)), COUNT(*), SUM(column0), M
 BIGINT	VARCHAR	11044	11044	2
 
 
-query IIIIIIIIIIII
-SELECT * EXCLUDE (scan_id) FROM reject_scans order by all;
+query IIIIIIIIIII
+SELECT * EXCLUDE (scan_id, file_id) FROM reject_scans order by file_path;
 ----
-0	{DATA_DIR}/csv/error/mismatch/big_bad.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	sample_size=1, store_rejects=true
-1	{DATA_DIR}/csv/error/mismatch/big_bad2.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	sample_size=1, store_rejects=true
+{DATA_DIR}/csv/error/mismatch/big_bad.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	sample_size=1, store_rejects=true
+{DATA_DIR}/csv/error/mismatch/big_bad2.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	sample_size=1, store_rejects=true
 
-query IIIIIIIII
-SELECT * EXCLUDE (scan_id) FROM reject_errors order by all;
+query IIIIIIII
+SELECT * EXCLUDE (scan_id, file_id) FROM reject_errors order by line, line_byte_position, byte_position, column_idx ASC;
 ----
-0	2176	10876	10876	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
-0	4176	20876	20876	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
-1	3680	18396	18396	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
-1	5680	28396	28396	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
+2176	10876	10876	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
+3680	18396	18396	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
+4176	20876	20876	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
+5680	28396	28396	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
 
 # Test giving the name of errors table
 statement error
@@ -51,19 +51,19 @@ SELECT typeof(first(column0)), typeof(first(column1)), COUNT(*), SUM(column0), M
 ----
 BIGINT	VARCHAR	11044	11044	2
 
-query IIIIIIIIIIII
-SELECT * EXCLUDE (scan_id) FROM reject_scans order by all;
+query IIIIIIIIIII
+SELECT * EXCLUDE (scan_id, file_id) FROM reject_scans order by file_path;
 ----
-0	{DATA_DIR}/csv/error/mismatch/big_bad.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_table='rejects_errors_2', sample_size=1
-1	{DATA_DIR}/csv/error/mismatch/big_bad2.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_table='rejects_errors_2', sample_size=1
+{DATA_DIR}/csv/error/mismatch/big_bad.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_table='rejects_errors_2', sample_size=1
+{DATA_DIR}/csv/error/mismatch/big_bad2.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_table='rejects_errors_2', sample_size=1
 
-query IIIIIIIII
-SELECT * EXCLUDE (scan_id) FROM rejects_errors_2 order by all;
+query IIIIIIII
+SELECT * EXCLUDE (scan_id, file_id) FROM rejects_errors_2 order by line, line_byte_position, byte_position, column_idx ASC;
 ----
-0	2176	10876	10876	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
-0	4176	20876	20876	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
-1	3680	18396	18396	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
-1	5680	28396	28396	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
+2176	10876	10876	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
+3680	18396	18396	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
+4176	20876	20876	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
+5680	28396	28396	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
 
 statement ok
 drop table reject_errors;
@@ -77,19 +77,19 @@ SELECT typeof(first(column0)), typeof(first(column1)), COUNT(*), SUM(column0), M
 ----
 BIGINT	VARCHAR	11044	11044	2
 
-query IIIIIIIIIIII
-SELECT * EXCLUDE (scan_id) FROM rejects_scan_2 order by all;
+query IIIIIIIIIII
+SELECT * EXCLUDE (scan_id, file_id) FROM rejects_scan_2 order by file_path;
 ----
-0	{DATA_DIR}/csv/error/mismatch/big_bad.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_scan='rejects_scan_2', sample_size=1
-1	{DATA_DIR}/csv/error/mismatch/big_bad2.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_scan='rejects_scan_2', sample_size=1
+{DATA_DIR}/csv/error/mismatch/big_bad.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_scan='rejects_scan_2', sample_size=1
+{DATA_DIR}/csv/error/mismatch/big_bad2.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_scan='rejects_scan_2', sample_size=1
 
-query IIIIIIIII
-SELECT * EXCLUDE (scan_id) FROM reject_errors order by all;
+query IIIIIIII
+SELECT * EXCLUDE (scan_id, file_id) FROM reject_errors order by line, line_byte_position, byte_position, column_idx ASC;
 ----
-0	2176	10876	10876	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
-0	4176	20876	20876	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
-1	3680	18396	18396	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
-1	5680	28396	28396	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
+2176	10876	10876	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
+3680	18396	18396	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
+4176	20876	20876	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
+5680	28396	28396	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
 
 # Test giving the name of both tables
 query IIIII
@@ -102,20 +102,20 @@ SELECT typeof(first(column0)), typeof(first(column1)), COUNT(*), SUM(column0), M
 ----
 BIGINT	VARCHAR	11044	11044	2
 
-query IIIIIIIIIIII
-SELECT * EXCLUDE (scan_id)
-FROM rejects_scan_3 order by all;
+query IIIIIIIIIII
+SELECT * EXCLUDE (scan_id, file_id)
+FROM rejects_scan_3 order by file_path;
 ----
-0	{DATA_DIR}/csv/error/mismatch/big_bad.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_scan='rejects_scan_3', rejects_table='rejects_errors_3', sample_size=1
-1	{DATA_DIR}/csv/error/mismatch/big_bad2.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_scan='rejects_scan_3', rejects_table='rejects_errors_3', sample_size=1
+{DATA_DIR}/csv/error/mismatch/big_bad.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_scan='rejects_scan_3', rejects_table='rejects_errors_3', sample_size=1
+{DATA_DIR}/csv/error/mismatch/big_bad2.csv	,	(empty)	(empty)	\n	0	0	{'column0': 'BIGINT','column1': 'VARCHAR'}	NULL	NULL	rejects_scan='rejects_scan_3', rejects_table='rejects_errors_3', sample_size=1
 
-query IIIIIIIII
-SELECT * EXCLUDE (scan_id) FROM rejects_errors_3 order by all;
+query IIIIIIII
+SELECT * EXCLUDE (scan_id, file_id) FROM rejects_errors_3 order by line, line_byte_position, byte_position, column_idx ASC;
 ----
-0	2176	10876	10876	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
-0	4176	20876	20876	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
-1	3680	18396	18396	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
-1	5680	28396	28396	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
+2176	10876	10876	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
+3680	18396	18396	1	column0	CAST	B, A	Error when converting column "column0". Could not convert string "B" to 'BIGINT'
+4176	20876	20876	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
+5680	28396	28396	1	column0	CAST	C, A	Error when converting column "column0". Could not convert string "C" to 'BIGINT'
 
 statement ok
 drop table reject_errors;

--- a/test/sql/copy/csv/test_filename_filter.test
+++ b/test/sql/copy/csv/test_filename_filter.test
@@ -6,7 +6,7 @@ statement ok
 PRAGMA enable_verification
 
 query IIII
-SELECT column1, column2, column3, parse_filename(filename) FROM read_csv('{DATA_DIR}/csv/filename_filter/*.csv', filename=true);
+SELECT column1, column2, column3, parse_filename(filename) FROM read_csv('{DATA_DIR}/csv/filename_filter/*.csv', filename=true) ORDER BY filename, column1;
 ----
 1	2	3	a.csv
 4	5	6	b.csv

--- a/test/sql/copy/csv/test_filename_filter.test
+++ b/test/sql/copy/csv/test_filename_filter.test
@@ -6,7 +6,7 @@ statement ok
 PRAGMA enable_verification
 
 query IIII
-SELECT column1, column2, column3, parse_filename(filename) FROM read_csv('{DATA_DIR}/csv/filename_filter/*.csv', filename=true) ORDER BY filename, column1;
+SELECT column1, column2, column3, parse_filename(filename) FROM read_csv('{DATA_DIR}/csv/filename_filter/*.csv', filename=true);
 ----
 1	2	3	a.csv
 4	5	6	b.csv

--- a/test/sql/copy/csv/test_union_by_name.test
+++ b/test/sql/copy/csv/test_union_by_name.test
@@ -213,9 +213,12 @@ NULL	100	Monday	ubn4.csv
 NULL	200	Sunday	ubn4.csv
 NULL	300	Friday	ubn4.csv
 
+statement ok
+SET VARIABLE union_by_name_csv_files = (SELECT list(file ORDER BY file) FROM glob('{DATA_DIR}/csv/union-by-name/part=[ab]/*'));
+
 # Test hive_partition with union_by_name
 statement error
-SELECT * FROM read_csv_auto('{DATA_DIR}/csv/union-by-name/part=[ab]/*',HIVE_PARTITIONING=TRUE, null_padding=0)
+SELECT * FROM read_csv_auto(getvariable('union_by_name_csv_files'), HIVE_PARTITIONING=TRUE, null_padding=0) ORDER BY id
 ----
 If you are trying to read files with different schemas, try setting union_by_name=True
 
@@ -232,9 +235,12 @@ statement error
 SELECT * FROM read_csv_auto('{DATA_DIR}/csv/union-by-name/*[!a]/*',HIVE_PARTITIONING=TRUE ,UNION_BY_NAME=TRUE)
 ----
 
+statement ok
+set variable union_by_name_2_csv_files = (SELECT list(file ORDER BY file) FROM glob('{DATA_DIR}/csv/union_by_name_2/*.csv'));
+
 # Test one thread per file CSV union by name where file only had header.
 query IIII
-from read_csv('{DATA_DIR}/csv/union_by_name_2/*.csv', union_by_name=True, parallel = false);
+from read_csv(getvariable('union_by_name_2_csv_files'), union_by_name=True, parallel = false);
 ----
 1	1	1	NULL
 

--- a/test/sql/json/issues/issue18301.test
+++ b/test/sql/json/issues/issue18301.test
@@ -30,4 +30,4 @@ SELECT info->>'$.outcome.by' as outcome_by
 FROM cricket_staging
 WHERE info->>'$.city' = 'Colombo';
 ----
-{"runs":175,"wickets":null,"innings":1}
+{"wickets":null,"innings":1,"runs":175}

--- a/test/sql/json/issues/issue18301.test
+++ b/test/sql/json/issues/issue18301.test
@@ -26,8 +26,8 @@ SELECT * FROM read_json('{DATA_DIR}/json/18301/*.json',
 );
 
 query I
-SELECT info->>'$.outcome.by' as outcome_by
+SELECT list_sort(map_entries((info->'$.outcome.by')::MAP(VARCHAR, VARCHAR))) as outcome_by
 FROM cricket_staging
 WHERE info->>'$.city' = 'Colombo';
 ----
-{"wickets":null,"innings":1,"runs":175}
+[{'key': innings, 'value': 1}, {'key': runs, 'value': 175}, {'key': wickets, 'value': NULL}]

--- a/test/sql/json/issues/issue18301.test
+++ b/test/sql/json/issues/issue18301.test
@@ -26,8 +26,8 @@ SELECT * FROM read_json('{DATA_DIR}/json/18301/*.json',
 );
 
 query I
-SELECT info->>'$.outcome.by' as outcome_by
+SELECT list_sort(map_entries((info->'$.outcome.by')::MAP(VARCHAR, VARCHAR))) as outcome_by
 FROM cricket_staging
 WHERE info->>'$.city' = 'Colombo';
 ----
-{"runs":175,"wickets":null,"innings":1}
+[{'key': innings, 'value': 1}, {'key': runs, 'value': 175}, {'key': wickets, 'value': NULL}]

--- a/test/sql/json/issues/issue18301.test
+++ b/test/sql/json/issues/issue18301.test
@@ -26,8 +26,8 @@ SELECT * FROM read_json('{DATA_DIR}/json/18301/*.json',
 );
 
 query I
-SELECT list_sort(map_entries((info->'$.outcome.by')::MAP(VARCHAR, VARCHAR))) as outcome_by
+SELECT info->>'$.outcome.by' as outcome_by
 FROM cricket_staging
 WHERE info->>'$.city' = 'Colombo';
 ----
-[{'key': innings, 'value': 1}, {'key': runs, 'value': 175}, {'key': wickets, 'value': NULL}]
+{"runs":175,"wickets":null,"innings":1}

--- a/test/sql/types/struct/struct_cast_superset.test
+++ b/test/sql/types/struct/struct_cast_superset.test
@@ -25,8 +25,11 @@ COPY t1 TO '__TEST_DIR__/struct_cast_t1.parquet' (FORMAT 'parquet');
 statement ok
 COPY t2 TO '__TEST_DIR__/struct_cast_t2.parquet' (FORMAT 'parquet');
 
+statement ok
+SET VARIABLE struct_cast_files = (SELECT list(file ORDER BY file) FROM glob('__TEST_DIR__/struct_cast_*.parquet'));
+
 query I
-SELECT * FROM read_parquet('__TEST_DIR__/struct_cast_*.parquet', union_by_name = TRUE);
+SELECT * FROM read_parquet(getvariable('struct_cast_files'), union_by_name = TRUE);
 ----
 {'a': 42, 'b': 43, 'c': NULL}
 {'a': 100, 'b': NULL, 'c': 101}


### PR DESCRIPTION
This PR introduces optional pagination support for the Glob function in the Filesystem class. This enables efficient file listing for large storage backends like S3 without requiring all results to be fetched and sorted upfront.

We're building an S3 explorer in the MotherDuck UI, and the current non-paginated Glob implementation becomes very slow for large S3 buckets. The existing approach requires fetching and sorting all matching files before returning results, which doesn't scale well when buckets contain millions of objects.

**Changes:** 
Added a paginated variant of the Glob function to the Filesystem class.
The default behavior remains unchanged—Glob uses the non-paginated version unless a paginated implementation is provided.
Filesystem implementations can opt into pagination by implementing the new paginated interface

**Note:** The Glob function no longer sorts all files globally, as results might be returned incrementally if the pagination API is used. This required updates to some tests that previously relied on sorted output.