### PR TITLE
Do not exit shell on Ctrl+C

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -785,9 +785,7 @@ string ShellState::EscapeCString(const string &str) {
 }
 
 /**
- ** This routine may be called from the signal handler,
- ** POSIX 'write' and WinAPI 'WriteConsole' are supposed
- ** to be safe to be used from there.
+ ** Uses non-buffered output calls (that are also signal-safe) to print the message.
  */
 static void PrintCtrlDHint() {
 	string msg = "Interrupted, use Ctrl+D to exit\n";
@@ -811,11 +809,11 @@ static void interrupt_handler(int NotUsed) {
 	UNUSED_PARAMETER(NotUsed);
 	auto &state = ShellState::Get();
 	state.seenInterrupt++;
+	if (state.seenInterrupt > 2) {
+		exit(1);
+	}
 	if (state.conn) {
 		state.conn->Interrupt();
-	}
-	if (state.seenInterrupt > 2) {
-		PrintCtrlDHint();
 	}
 }
 

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -796,9 +796,11 @@ static void PrintCtrlDHint() {
 	if (hc == INVALID_HANDLE_VALUE) {
 		return;
 	}
-	WriteConsoleA(hc, msg.c_str(), msg.length(), nullptr, nullptr);
+	auto status = WriteConsoleA(hc, msg.c_str(), static_cast<DWORD>(msg.length()), nullptr, nullptr);
+	(void)status;
 #else  // !_WIN32
-	write(STDERR_FILENO, msg.c_str(), msg.length());
+	auto written = write(STDERR_FILENO, msg.c_str(), msg.length());
+	(void)written;
 #endif // _WIN32
 }
 


### PR DESCRIPTION
This PR changes the Ctlr+C handling in the DuckDB shell. Currently typing Ctrl+C twice makes the whole process to exit. This is changed to print the message instead:

```
Interrupted, use Ctrl+D to exit
```

This behaviour follows what Python shell is doing (it prints `KeyboardInterrupt` on Ctrl+C).

The exit logic was used from the terminal input handler and also from the signal handler. ~~It is supposed that signal handler code path is not triggered after the terminal is initialized. Still, for consistency, the handling is changed on both code paths.~~ edit: the exit logic from the signal handler is restored, it is supposed to be triggered only if the running query cannot be interrupted.

Testing: tested manually on Linux and Windows.

Fixes: #14906