### PR TITLE
Parallel `TupleDataCollection` destructor

### DIFF
--- a/src/include/duckdb/common/types/row/tuple_data_collection.hpp
+++ b/src/include/duckdb/common/types/row/tuple_data_collection.hpp
@@ -270,6 +270,8 @@ private:
 	void Verify() const;
 
 private:
+	//! Database instance ref for parallel destruction
+	DatabaseInstance &db;
 	//! Shared allocator for STL allocations
 	shared_ptr<ArenaAllocator> stl_allocator;
 	//! The layout of the TupleDataCollection

--- a/src/include/duckdb/common/types/row/tuple_data_collection.hpp
+++ b/src/include/duckdb/common/types/row/tuple_data_collection.hpp
@@ -224,6 +224,8 @@ public:
 private:
 	//! Initializes the TupleDataCollection (called by the constructor)
 	void Initialize();
+	//! Destroys the TupleDataCollection (parallelized over segments, called by the destructor)
+	void Destroy();
 	//! Gets all column ids
 	void GetAllColumnIDs(vector<column_t> &column_ids);
 	//! Adds a segment to this TupleDataCollection


### PR DESCRIPTION
While most of DuckDB is fully parallel, some destructors of large objects are called by a single thread. The `TupleDataCollection` is one such object. This PR implements a parallel destructor for `TupleDataCollection`s. It uses the same logic as the parallel destruction of row groups.

CC: @hawkfish 