### PR TITLE
Profiling: Fix rows_scanned

### DIFF
--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -405,10 +405,11 @@ InsertionOrderPreservingMap<string> PhysicalTableScan::ExtraSourceParams(GlobalS
 	return function.dynamic_to_string(input);
 }
 
-optional_idx PhysicalTableScan::GetRowsScanned(LocalSourceState &lstate) const {
+optional_idx PhysicalTableScan::GetRowsScanned(GlobalSourceState &gstate_p, LocalSourceState &lstate) const {
 	if (function.rows_scanned) {
+		auto &gstate = gstate_p.Cast<TableScanGlobalSourceState>();
 		auto &state = lstate.Cast<TableScanLocalSourceState>();
-		return function.rows_scanned(*state.local_state);
+		return function.rows_scanned(*gstate.global_state, *state.local_state);
 	}
 	return optional_idx();
 }

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/transaction/transaction.hpp"
@@ -402,6 +403,14 @@ InsertionOrderPreservingMap<string> PhysicalTableScan::ExtraSourceParams(GlobalS
 	TableFunctionDynamicToStringInput input(function, bind_data.get(), state.local_state.get(),
 	                                        gstate.global_state.get());
 	return function.dynamic_to_string(input);
+}
+
+optional_idx PhysicalTableScan::GetRowsScanned(LocalSourceState &lstate) const {
+	if (function.rows_scanned) {
+		auto &state = lstate.Cast<TableScanLocalSourceState>();
+		return function.rows_scanned(*state.local_state);
+	}
+	return optional_idx();
 }
 
 } // namespace duckdb

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -15,7 +15,6 @@
 #include "duckdb/main/client_config.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
@@ -23,16 +22,13 @@
 #include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/storage/storage_index.hpp"
 #include "duckdb/main/client_data.hpp"
-#include "duckdb/common/algorithm.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
-#include "duckdb/planner/filter/selectivity_optional_filter.hpp"
 #include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/common/types/value_map.hpp"
 #include "duckdb/main/settings.hpp"
-#include <list>
 
 namespace duckdb {
 

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -41,6 +41,8 @@ struct TableScanLocalState : public LocalTableFunctionState {
 	//! The DataChunk containing all read columns.
 	//! This includes filter columns, which are immediately removed.
 	DataChunk all_columns;
+	//! The number of scanned rows.
+	idx_t rows_scanned = 0;
 };
 
 struct IndexScanLocalState : public LocalTableFunctionState {
@@ -323,6 +325,9 @@ public:
 			if (output.size() > 0) {
 				return;
 			}
+
+			// We have processed a row group. Add to scanned_rows
+			l_state.rows_scanned += l_state.scan_state.local_state.row_group->GetCount();
 
 			auto next = storage.NextParallelScan(context, state, l_state.scan_state);
 			if (data_p.results_execution_mode == AsyncResultsExecutionMode::TASK_EXECUTOR) {

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/function/table_function.hpp"
+#include <cstddef>
 
 namespace duckdb {
 
@@ -20,9 +21,9 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
     : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
       bind_operator(nullptr), init_global(init_global), init_local(init_local), function(function_),
       in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr), dependency(nullptr),
-      cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr), to_string(nullptr),
-      dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr), get_bind_info(nullptr),
-      type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
+      cardinality(nullptr), rows_scanned(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
+      to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
+      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
       get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
       get_row_id_columns(nullptr), set_scan_order(nullptr), serialize(nullptr), deserialize(nullptr),
       projection_pushdown(false), filter_pushdown(false), filter_prune(false), sampling_pushdown(false),
@@ -35,9 +36,9 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
     : SimpleNamedParameterFunction(std::move(name), arguments), bind(bind), bind_replace(nullptr),
       bind_operator(nullptr), init_global(init_global), init_local(init_local), function(nullptr),
       in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr), dependency(nullptr),
-      cardinality(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr), to_string(nullptr),
-      dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr), get_bind_info(nullptr),
-      type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
+      cardinality(nullptr), rows_scanned(nullptr), pushdown_complex_filter(nullptr), pushdown_expression(nullptr),
+      to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
+      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
       get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr),
       get_row_id_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
       filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -1,5 +1,4 @@
 #include "duckdb/function/table_function.hpp"
-#include <cstddef>
 
 namespace duckdb {
 

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -88,7 +88,7 @@ public:
 
 	InsertionOrderPreservingMap<string> ExtraSourceParams(GlobalSourceState &gstate,
 	                                                      LocalSourceState &lstate) const override;
-	optional_idx GetRowsScanned(LocalSourceState &lstate) const;
+	optional_idx GetRowsScanned(GlobalSourceState &gstate_p, LocalSourceState &lstate) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/execution/physical_operator_states.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/data_table.hpp"
@@ -86,6 +88,7 @@ public:
 
 	InsertionOrderPreservingMap<string> ExtraSourceParams(GlobalSourceState &gstate,
 	                                                      LocalSourceState &lstate) const override;
+	optional_idx GetRowsScanned(LocalSourceState &lstate) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/enums/operator_result_type.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/execution/execution_context.hpp"
+#include "duckdb/execution/physical_operator_states.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/storage/statistics/node_statistics.hpp"
@@ -306,6 +307,7 @@ typedef double (*table_function_progress_t)(ClientContext &context, const Functi
 typedef void (*table_function_dependency_t)(LogicalDependencyList &dependencies, const FunctionData *bind_data);
 typedef unique_ptr<NodeStatistics> (*table_function_cardinality_t)(ClientContext &context,
                                                                    const FunctionData *bind_data);
+typedef idx_t (*table_function_rows_scanned_t)(LocalTableFunctionState &local_state);
 typedef void (*table_function_pushdown_complex_filter_t)(ClientContext &context, LogicalGet &get,
                                                          FunctionData *bind_data,
                                                          vector<unique_ptr<Expression>> &filters);
@@ -417,6 +419,8 @@ public:
 	//! (Optional) cardinality function
 	//! Returns the expected cardinality of this scan
 	table_function_cardinality_t cardinality;
+	//! (Optional) returns the number of rows that have benn scanned
+	table_function_rows_scanned_t rows_scanned;
 	//! (Optional) pushdown a set of arbitrary filter expressions, rather than only simple comparisons with a constant
 	//! Any functions remaining in the expression list will be pushed as a regular filter after the scan
 	table_function_pushdown_complex_filter_t pushdown_complex_filter;

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -307,7 +307,8 @@ typedef double (*table_function_progress_t)(ClientContext &context, const Functi
 typedef void (*table_function_dependency_t)(LogicalDependencyList &dependencies, const FunctionData *bind_data);
 typedef unique_ptr<NodeStatistics> (*table_function_cardinality_t)(ClientContext &context,
                                                                    const FunctionData *bind_data);
-typedef idx_t (*table_function_rows_scanned_t)(LocalTableFunctionState &local_state);
+typedef idx_t (*table_function_rows_scanned_t)(GlobalTableFunctionState &global_state,
+                                               LocalTableFunctionState &local_state);
 typedef void (*table_function_pushdown_complex_filter_t)(ClientContext &context, LogicalGet &get,
                                                          FunctionData *bind_data,
                                                          vector<unique_ptr<Expression>> &filters);

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -23,8 +23,6 @@
 #include "duckdb/common/exception/binder_exception.hpp"
 #include "duckdb/common/enums/order_preservation_type.hpp"
 
-#include <functional>
-
 namespace duckdb {
 
 class BaseStatistics;

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -46,6 +46,7 @@ struct OperatorInformation {
 	idx_t result_set_size = 0;
 	idx_t system_peak_buffer_manager_memory = 0;
 	idx_t system_peak_temp_directory_size = 0;
+	idx_t rows_scanned = 0;
 
 	InsertionOrderPreservingMap<string> extra_info;
 
@@ -71,6 +72,10 @@ struct OperatorInformation {
 		if (used_swap > system_peak_temp_directory_size) {
 			system_peak_temp_directory_size = used_swap;
 		}
+	}
+
+	void AddRowsScanned(idx_t n_rows_scanned) {
+		rows_scanned += n_rows_scanned;
 	}
 };
 

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -10,8 +10,10 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/deque.hpp"
+#include "duckdb/common/enums/metric_type.hpp"
 #include "duckdb/common/enums/profiler_format.hpp"
 #include "duckdb/common/enums/explain_format.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/profiler.hpp"
 #include "duckdb/common/reference_map.hpp"
@@ -50,32 +52,36 @@ struct OperatorInformation {
 
 	InsertionOrderPreservingMap<string> extra_info;
 
-	void AddTime(double n_time) {
-		time += n_time;
-	}
-
-	void AddReturnedElements(idx_t n_elements) {
-		elements_returned += n_elements;
-	}
-
-	void AddResultSetSize(idx_t n_result_set_size) {
-		result_set_size += n_result_set_size;
-	}
-
-	void UpdateSystemPeakBufferManagerMemory(idx_t used_memory) {
-		if (used_memory > system_peak_buffer_manager_memory) {
-			system_peak_buffer_manager_memory = used_memory;
+	template <typename T>
+	void AddMetric(MetricType type, T metric) {
+		switch (type) {
+		case MetricType::OPERATOR_TIMING:
+			time += metric;
+			break;
+		case MetricType::OPERATOR_CARDINALITY:
+			elements_returned += metric;
+			break;
+		case MetricType::RESULT_SET_SIZE:
+			result_set_size += metric;
+			break;
+		case MetricType::SYSTEM_PEAK_BUFFER_MEMORY: {
+			if (metric > system_peak_buffer_manager_memory) {
+				system_peak_buffer_manager_memory += metric;
+			}
+			break;
 		}
-	}
-
-	void UpdateSystemPeakTempDirectorySize(idx_t used_swap) {
-		if (used_swap > system_peak_temp_directory_size) {
-			system_peak_temp_directory_size = used_swap;
+		case MetricType::SYSTEM_PEAK_TEMP_DIR_SIZE: {
+			if (metric > system_peak_temp_directory_size) {
+				system_peak_temp_directory_size = metric;
+			}
+			break;
 		}
-	}
-
-	void AddRowsScanned(idx_t n_rows_scanned) {
-		rows_scanned += n_rows_scanned;
+		case MetricType::OPERATOR_ROWS_SCANNED:
+			rows_scanned = metric;
+			break;
+		default:
+			throw InternalException("OperatorProfiler: Unknown metric type");
+		}
 	}
 };
 

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -86,7 +86,7 @@ public:
 	//! Returns the maximum amount of threads that should be assigned to scan this data table
 	idx_t MaxThreads(ClientContext &context) const;
 	void InitializeParallelScan(ClientContext &context, ParallelTableScanState &state);
-	bool NextParallelScan(ClientContext &context, ParallelTableScanState &state, TableScanState &scan_state);
+	idx_t NextParallelScan(ClientContext &context, ParallelTableScanState &state, TableScanState &scan_state);
 
 	//! Scans up to STANDARD_VECTOR_SIZE elements from the table starting
 	//! from offset and store them in result. Offset is incremented with how many

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/profiling_utils.hpp"
+#include "duckdb/main/profiling_info.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/buffer/buffer_pool.hpp"
 #include "yyjson.hpp"
@@ -441,6 +442,11 @@ void OperatorProfiler::FinishSource(GlobalSourceState &gstate, LocalSourceState 
 					info.extra_info.insert(std::move(new_info));
 				}
 			}
+		}
+		if (ProfilingInfo::Enabled(settings, MetricsType::OPERATOR_ROWS_SCANNED) &&
+		    active_operator.get()->type == PhysicalOperatorType::TABLE_SCAN) {
+			// TODO: Use local source to add rows_scanned
+			// TODO: Maybe custom function.get_rows_scanned(lstate) ?
 		}
 	}
 }

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -442,7 +442,7 @@ void OperatorProfiler::FinishSource(GlobalSourceState &gstate, LocalSourceState 
 		if (ProfilingInfo::Enabled(settings, MetricType::OPERATOR_ROWS_SCANNED) &&
 		    active_operator.get()->type == PhysicalOperatorType::TABLE_SCAN) {
 			const auto &table_scan = active_operator->Cast<PhysicalTableScan>();
-			const auto rows_scanned = table_scan.GetRowsScanned(lstate);
+			const auto rows_scanned = table_scan.GetRowsScanned(gstate, lstate);
 			if (rows_scanned.IsValid()) {
 				auto &info = GetOperatorInfo(*active_operator);
 				info.AddRowsScanned(rows_scanned.GetIndex());

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -1,14 +1,11 @@
 #include "duckdb/main/query_profiler.hpp"
 
 #include "duckdb/common/fstream.hpp"
-#include "duckdb/common/limits.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/tree_renderer/text_tree_renderer.hpp"
-#include "duckdb/execution/expression_executor.hpp"
-#include "duckdb/execution/operator/helper/physical_execute.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/main/client_config.hpp"
@@ -16,12 +13,10 @@
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/profiling_utils.hpp"
 #include "duckdb/main/profiling_info.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/buffer/buffer_pool.hpp"
 #include "yyjson.hpp"
 #include "yyjson_utils.hpp"
 
-#include <algorithm>
 #include <utility>
 
 using namespace duckdb_yyjson; // NOLINT

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/storage/data_table.hpp"
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
-#include "duckdb/common/chrono.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/common/helper.hpp"
@@ -26,7 +25,6 @@
 #include "duckdb/storage/table/persistent_table_data.hpp"
 #include "duckdb/storage/table/row_group.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
-#include "duckdb/storage/table/standard_column_data.hpp"
 #include "duckdb/storage/table/update_state.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -277,16 +277,16 @@ void DataTable::InitializeParallelScan(ClientContext &context, ParallelTableScan
 	local_storage.InitializeParallelScan(*this, state.local_state);
 }
 
-bool DataTable::NextParallelScan(ClientContext &context, ParallelTableScanState &state, TableScanState &scan_state) {
+idx_t DataTable::NextParallelScan(ClientContext &context, ParallelTableScanState &state, TableScanState &scan_state) {
 	if (row_groups->NextParallelScan(context, state.scan_state, scan_state.table_state)) {
-		return true;
+		return scan_state.table_state.row_group->GetCount();
 	}
 	auto &local_storage = LocalStorage::Get(context, db);
 	if (local_storage.NextParallelScan(context, *this, state.local_state, scan_state.local_state)) {
-		return true;
+		return scan_state.local_state.row_group->GetCount();
 	} else {
 		// finished all scans: no more scans remaining
-		return false;
+		return 0;
 	}
 }
 

--- a/test/sql/pragma/profiling/test_custom_profiling_rows_scanned.test
+++ b/test/sql/pragma/profiling/test_custom_profiling_rows_scanned.test
@@ -36,7 +36,7 @@ SELECT cumulative_cardinality, cumulative_rows_scanned FROM metrics_output;
 
 query I
 SELECT
-	CASE WHEN cumulative_rows_scanned > 0 THEN 'true'
+	CASE WHEN cumulative_rows_scanned = 8 THEN 'true'
 	ELSE 'false' END
 FROM metrics_output;
 ----


### PR DESCRIPTION
At the moment, `rows_scanned` in the profiling metrics does not work as expected but simply returns `table_cardinality * thread_count`. With this PR, `rows_scanned` displays the number of rows scanned as all the rows of row groups that have not been pruned away. This only works for the regular DuckDB scan so far but should probably be implemented for Parquet at some point as well.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/6852