### PR TITLE
MergeInto: correctly clean-up buffer and handle non trivial GetData

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   build:
     name: Build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.3
     with:
       # We piggy-back extension-template to build the extensions in extension_config, it's hacky, but it works ¯\_(ツ)_/¯
       override_repository: duckdb/extension-template
@@ -56,7 +56,7 @@ jobs:
 
       # CI tools is pinned to main
       override_ci_tools_repository: duckdb/extension-ci-tools
-      ci_tools_version: main
+      ci_tools_version: v1.4.3
 
       exclude_archs: ${{ inputs.exclude_archs }}
       opt_in_archs: ${{ inputs.opt_in_archs }}

--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -477,6 +477,7 @@ SourceResultType PhysicalMergeInto::GetData(ExecutionContext &context, DataChunk
 		auto &child_lstate = *lstate.local_states[lstate.index];
 		OperatorSourceInput source_input {child_gstate, child_lstate, input.interrupt_state};
 
+		lstate.scan_chunk.Reset();
 		auto result = action.op->GetData(context, lstate.scan_chunk, source_input);
 		if (lstate.scan_chunk.size() > 0) {
 			// construct the result chunk
@@ -505,9 +506,13 @@ SourceResultType PhysicalMergeInto::GetData(ExecutionContext &context, DataChunk
 
 		if (result != SourceResultType::FINISHED) {
 			return result;
-		}
-		if (chunk.size() != 0) {
-			return SourceResultType::HAVE_MORE_OUTPUT;
+		} else {
+			lstate.index++;
+			if (lstate.index < actions.size()) {
+				return SourceResultType::HAVE_MORE_OUTPUT;
+			} else {
+				return SourceResultType::FINISHED;
+			}
 		}
 	}
 	return SourceResultType::FINISHED;

--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -473,6 +473,8 @@ SourceResultType PhysicalMergeInto::GetData(ExecutionContext &context, DataChunk
 			// no action to scan from
 			continue;
 		}
+		// found a good one
+		break;
 	}
 	if (lstate.index < actions.size()) {
 		auto &action = *actions[lstate.index];

--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -473,6 +473,10 @@ SourceResultType PhysicalMergeInto::GetData(ExecutionContext &context, DataChunk
 			// no action to scan from
 			continue;
 		}
+	}
+	if (lstate.index < actions.size()) {
+		auto &action = *actions[lstate.index];
+
 		auto &child_gstate = *gstate.global_states[lstate.index];
 		auto &child_lstate = *lstate.local_states[lstate.index];
 		OperatorSourceInput source_input {child_gstate, child_lstate, input.interrupt_state};


### PR DESCRIPTION
This has been made visible through testing code in `main` branch, but this is currently off in case of GetData returning non trivial GetData such as `HAVE_MORE_OUTPUT` and 0 results (both since it will not loop back AND since it will NOT cleanup results).