### PR TITLE
Only pushdown varchar if the arrow type is not a string view

### DIFF
--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -245,10 +245,10 @@ static bool CanPushdown(const ArrowType &type) {
 	case LogicalTypeId::UBIGINT:
 	case LogicalTypeId::FLOAT:
 	case LogicalTypeId::DOUBLE:
-	case LogicalTypeId::VARCHAR:
 		return true;
+	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::BLOB:
-		// PyArrow doesn't support binary view filters yet
+		// PyArrow doesn't support binary and string view filters yet
 		return type.GetTypeInfo<ArrowStringInfo>().GetSizeType() != ArrowVariableSizeType::VIEW;
 	case LogicalTypeId::DECIMAL: {
 		switch (duck_type.InternalType()) {


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-python/issues/187

The arrow table scan function relies on pyarrow for pushed down filters. Pyarrow does not support comparisons for view types yet, so we should not push filters down for those types.