### PR TITLE
test_plan_serialization_bwc don't need tpch

### DIFF
--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -11,6 +11,11 @@
 duckdb_extension_load(core_functions)
 duckdb_extension_load(parquet)
 
+# tpch extension is needed for some tests (cf. test/api)
+if(NOT WIN32 AND ${ENABLE_UNITTEST_CPP_TESTS})
+  duckdb_extension_load(tpch)
+endif()
+
 
 # The Linux allocator has issues so we use jemalloc, but only on x86 because page sizes are fixed at 4KB.
 # Configuring jemalloc properly for 32bit is a hassle, and not worth it so we only enable on 64bit

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -43,7 +43,7 @@ if(NOT WIN32)
 endif()
 
 if(DUCKDB_EXTENSION_TPCH_SHOULD_LINK)
-  include_directories(../../extension/tpch/include)
+  include_directories(${PROJECT_SOURCE_DIR}/extension/tpch/include)
   set(TEST_API_OBJECTS
       ${TEST_API_OBJECTS} test_tpch_with_relations.cpp
       test_tpch_with_streaming.cpp

--- a/test/api/serialized_plans/test_plan_serialization_bwc.cpp
+++ b/test/api/serialized_plans/test_plan_serialization_bwc.cpp
@@ -7,7 +7,6 @@
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
 #include "test_helpers.hpp"
-#include "tpch_extension.hpp"
 
 #include <fstream>
 


### PR DESCRIPTION
Minor PR on something I spotted a while ago - the `test_plan_serialization_bwc` test doesn't need Tpch extension. So:

* we can remove the unused header in test file;
* we can add the test file in `TEST_API_OBJECTS`, hence increasing cases when it will be compiled