### PR TITLE
Revert linux toolchain downgrade

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -100,12 +100,7 @@ jobs:
         quay.io/pypa/manylinux_2_28_${{ matrix.config.image }}                  \
         bash -c "
           set -e
-          yum install -y perl-IPC-Cmd gcc-toolset-12 gcc-toolset-12-gcc-c++
-        
-          source /opt/rh/gcc-toolset-12/enable
-          export CC=gcc
-          export CXX=g++
-
+          yum install -y perl-IPC-Cmd
           git config --global --add safe.directory $PWD
           make -C $PWD
         "


### PR DESCRIPTION
We used to use GCC 12 instead of the manylinux-default GCC 14 for compatibility reasons. This seems no longer required, and the GCC14 Arm bug with UUID has been resolved in https://github.com/duckdb/duckdb/pull/19318