### PR TITLE
Split statements by semicolon

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -171,15 +171,12 @@ vector<string> SplitQueryStringIntoStatements(const string &query) {
 	auto tokens = Parser::Tokenize(query);
 	idx_t next_statement_start = 0;
 	for (idx_t i = 1; i < tokens.size(); ++i) {
-		auto &t_prev = tokens[i - 1];
 		auto &t = tokens[i];
-		if (t_prev.type == SimplifiedTokenType::SIMPLIFIED_TOKEN_OPERATOR) {
+		if (t.type == SimplifiedTokenType::SIMPLIFIED_TOKEN_OPERATOR) {
 			// LCOV_EXCL_START
-			for (idx_t c = t_prev.start; c <= t.start; ++c) {
-				if (query.c_str()[c] == ';') {
-					query_statements.emplace_back(query.substr(next_statement_start, t.start - next_statement_start));
-					next_statement_start = tokens[i].start;
-				}
+			if (query.c_str()[t.start] == ';') {
+				query_statements.emplace_back(query.substr(next_statement_start, t.start - next_statement_start));
+				next_statement_start = tokens[i].start;
 			}
 			// LCOV_EXCL_STOP
 		}

--- a/test/extension/CMakeLists.txt
+++ b/test/extension/CMakeLists.txt
@@ -23,7 +23,8 @@ if(NOT WIN32 AND NOT SUN)
 
   message(${ENABLE_UNITTEST_CPP_TESTS})
   if(${ENABLE_UNITTEST_CPP_TESTS} AND NOT (${ENABLE_THREAD_SANITIZER}))
-    set(TEST_EXT_OBJECTS test_remote_optimizer.cpp test_splitting_extension_statements.cpp)
+    set(TEST_EXT_OBJECTS test_remote_optimizer.cpp
+                         test_splitting_extension_statements.cpp)
 
     add_library_unity(test_extensions OBJECT ${TEST_EXT_OBJECTS})
     set(ALL_OBJECT_FILES

--- a/test/extension/CMakeLists.txt
+++ b/test/extension/CMakeLists.txt
@@ -21,8 +21,9 @@ if(NOT WIN32 AND NOT SUN)
     ${PARAMETERS}
     ../extension/loadable_extension_optimizer_demo.cpp)
 
+  message(${ENABLE_UNITTEST_CPP_TESTS})
   if(${ENABLE_UNITTEST_CPP_TESTS} AND NOT (${ENABLE_THREAD_SANITIZER}))
-    set(TEST_EXT_OBJECTS test_remote_optimizer.cpp)
+    set(TEST_EXT_OBJECTS test_remote_optimizer.cpp test_splitting_extension_statements.cpp)
 
     add_library_unity(test_extensions OBJECT ${TEST_EXT_OBJECTS})
     set(ALL_OBJECT_FILES

--- a/test/extension/test_splitting_extension_statements.cpp
+++ b/test/extension/test_splitting_extension_statements.cpp
@@ -11,8 +11,7 @@ TEST_CASE("Parser Extension query splitting", "[parser-extension]") {
 	DuckDB db;
 	Connection conn(*db.instance);
 	ParserExtension parser_extension;
-	parser_extension.parse_function = [](ParserExtensionInfo *,
-										 const std::string &) -> ParserExtensionParseResult {
+	parser_extension.parse_function = [](ParserExtensionInfo *, const std::string &) -> ParserExtensionParseResult {
 		duckdb::unique_ptr<ParserExtensionParseData> empty_data {};
 		return ParserExtensionParseResult {std::move(empty_data)};
 	};
@@ -22,14 +21,13 @@ TEST_CASE("Parser Extension query splitting", "[parser-extension]") {
 	options.extensions = &parser_extensions;
 
 	auto query = GENERATE( // Normal CTAS query
-		"create or syntaxerror table my_object as from (\n	select 1\n	where starts_with('name', "
-		"'test_simple_share') -- ;	\n);",
-		// Extension query, replacing the table with result
-		"create or replace result my_object as from (\n	select 1\n	where starts_with('name', "
-		"'test_simple_share') -- ;	\n);",
-		// Trying other queries
-		"CREATE OR replace result my_object as FROM (SELECT 1); -- ;"
-		);
+	    "create or syntaxerror table my_object as from (\n	select 1\n	where starts_with('name', "
+	    "'test_simple_share') -- ;	\n);",
+	    // Extension query, replacing the table with result
+	    "create or replace result my_object as from (\n	select 1\n	where starts_with('name', "
+	    "'test_simple_share') -- ;	\n);",
+	    // Trying other queries
+	    "CREATE OR replace result my_object as FROM (SELECT 1); -- ;");
 
 	Parser parser {options};
 	REQUIRE_NOTHROW(parser.ParseQuery(query));
@@ -40,8 +38,7 @@ TEST_CASE("Parser Extension multi-query splitting", "[parser-extension]") {
 	DuckDB db;
 	Connection conn(*db.instance);
 	ParserExtension parser_extension;
-	parser_extension.parse_function = [](ParserExtensionInfo *,
-										 const std::string &) -> ParserExtensionParseResult {
+	parser_extension.parse_function = [](ParserExtensionInfo *, const std::string &) -> ParserExtensionParseResult {
 		duckdb::unique_ptr<ParserExtensionParseData> empty_data {};
 		return ParserExtensionParseResult {std::move(empty_data)};
 	};
@@ -51,11 +48,9 @@ TEST_CASE("Parser Extension multi-query splitting", "[parser-extension]") {
 	options.extensions = &parser_extensions;
 
 	auto multi_statement_query = GENERATE( // Normal CTAS query
-		"CREATE OR REPLACE result my_object as FROM (SELECT 1); -- ; \n SELECT 1;"
-		);
+	    "CREATE OR REPLACE result my_object as FROM (SELECT 1); -- ; \n SELECT 1;");
 
 	Parser parser {options};
 	REQUIRE_NOTHROW(parser.ParseQuery(multi_statement_query));
 	REQUIRE(parser.statements.size() == 2);
-
 }

--- a/test/extension/test_splitting_extension_statements.cpp
+++ b/test/extension/test_splitting_extension_statements.cpp
@@ -22,13 +22,13 @@ TEST_CASE("Parser Extension query splitting", "[parser-extension]") {
 	options.extensions = &parser_extensions;
 
 	auto query = GENERATE( // Normal CTAS query
-		"create or replace table my_object as from (\n	select 1\n	where starts_with('name', "
+		"create or syntaxerror table my_object as from (\n	select 1\n	where starts_with('name', "
 		"'test_simple_share') -- ;	\n);",
 		// Extension query, replacing the table with result
 		"create or replace result my_object as from (\n	select 1\n	where starts_with('name', "
 		"'test_simple_share') -- ;	\n);",
 		// Trying other queries
-		"CREATE OR REPLACE TABLE my_object as FROM (SELECT 1); ; ; ;"
+		"CREATE OR replace result my_object as FROM (SELECT 1); -- ;"
 		);
 
 	Parser parser {options};
@@ -51,7 +51,7 @@ TEST_CASE("Parser Extension multi-query splitting", "[parser-extension]") {
 	options.extensions = &parser_extensions;
 
 	auto multi_statement_query = GENERATE( // Normal CTAS query
-		"CREATE OR REPLACE TABLE my_object as FROM (SELECT 1);SELECT 1;"
+		"CREATE OR REPLACE result my_object as FROM (SELECT 1); -- ; \n SELECT 1;"
 		);
 
 	Parser parser {options};

--- a/test/extension/test_splitting_extension_statements.cpp
+++ b/test/extension/test_splitting_extension_statements.cpp
@@ -33,10 +33,6 @@ TEST_CASE("Parser Extension query splitting", "[parser-extension]") {
 
 	Parser parser {options};
 	REQUIRE_NOTHROW(parser.ParseQuery(query));
-	for (uint64_t i = 0; i < parser.statements.size(); i++) {
-		auto &stmt = parser.statements[i];
-		duckdb::Printer::PrintF("Parsed query %llu: %s\n", i, stmt->query.c_str());
-	}
 	REQUIRE(parser.statements.size() == 1);
 }
 
@@ -60,11 +56,6 @@ TEST_CASE("Parser Extension multi-query splitting", "[parser-extension]") {
 
 	Parser parser {options};
 	REQUIRE_NOTHROW(parser.ParseQuery(multi_statement_query));
-
-	for (uint64_t i = 0; i < parser.statements.size(); i++) {
-		auto &stmt = parser.statements[i];
-		duckdb::Printer::PrintF("Parsed query %llu: %s\n", i, stmt->query.c_str());
-	}
 	REQUIRE(parser.statements.size() == 2);
 
 }

--- a/test/extension/test_splitting_extension_statements.cpp
+++ b/test/extension/test_splitting_extension_statements.cpp
@@ -1,0 +1,38 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/parser_extension.hpp"
+#include "duckdb/parser/parser_options.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+TEST_CASE("Parser Extension query splitting", "[parser-extension]") {
+	DuckDB db;
+	Connection conn(*db.instance);
+	ParserExtension parser_extension;
+	parser_extension.parse_function = [](ParserExtensionInfo *,
+										 const std::string &) -> ParserExtensionParseResult {
+		duckdb::unique_ptr<ParserExtensionParseData> empty_data {};
+		return ParserExtensionParseResult {std::move(empty_data)};
+	};
+
+	ParserOptions options;
+	duckdb::vector<ParserExtension> parser_extensions {parser_extension};
+	options.extensions = &parser_extensions;
+
+	auto query = GENERATE( // Normal CTAS query
+		"create or replace table my_object as from (\n	select 1\n	where starts_with('name', "
+		"'test_simple_share') -- ;	\n);",
+		// Extension query, replacing the table with result
+		"create or replace result my_object as from (\n	select 1\n	where starts_with('name', "
+		"'test_simple_share') -- ;	\n);");
+
+	Parser parser {options};
+	REQUIRE_NOTHROW(parser.ParseQuery(query));
+	for (uint64_t i = 0; i < parser.statements.size(); i++) {
+		auto &stmt = parser.statements[i];
+		duckdb::Printer::PrintF("Parsed query %llu: %s\n", i, stmt->query.c_str());
+	}
+	REQUIRE(parser.statements.size() == 1);
+}


### PR DESCRIPTION
Fixes: https://github.com/duckdblabs/duckdb-internal/issues/6851

Previously we look through every character query (after tokenizing) to look for the semicolon. This caused us to incorrectly split if a semicolon was inside a comment `SELECT 1; -- ; `. Resulting in this case in 2 queries rather than 1. 

For this query: 
```sql
create or replace result my_result as from (
    select 1
    where starts_with('name', 'test_simple_share') -- ;
    );
```    

Re the tokenization, I don't think the problem lies in the fact that `) -- ;` is returned as a single token (though comments should maybe become something separate), but rather that we were not looking for the `;` token properly in the splitting logic, rather going character by character. 


Also this logic is already fixed on main, but slightly differently. Perhaps I should reuse that.  