### PR TITLE
CLI: Several rendering fixes / improvements

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -383,6 +383,7 @@ public:
 	static bool StringLike(const char *zPattern, const char *zStr, unsigned int esc);
 	static void Sleep(idx_t ms);
 	void PrintUsage();
+	void DetectDarkLightMode();
 #if defined(_WIN32) || defined(WIN32)
 	static std::wstring Win32Utf8ToUnicode(const string &zText);
 	static string Win32UnicodeToUtf8(const std::wstring &zWideText);

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -245,8 +245,14 @@ public:
 	*/
 	static constexpr idx_t MAX_PROMPT_SIZE = 20;
 	unique_ptr<Prompt> main_prompt;
-	char continuePrompt[MAX_PROMPT_SIZE];         /* Continuation prompt. default: "   ...> " */
-	char continuePromptSelected[MAX_PROMPT_SIZE]; /* Selected continuation prompt. default: "   ...> " */
+	//! Continuation prompt
+	char continuePrompt[MAX_PROMPT_SIZE];
+	//! Selected continuation prompt
+	char continuePromptSelected[MAX_PROMPT_SIZE];
+	//! Prompt showing there is more text available up
+	char scrollUpPrompt[MAX_PROMPT_SIZE];
+	//! Prompt showing there is more text available down
+	char scrollDownPrompt[MAX_PROMPT_SIZE];
 	//! Progress bar used to render the components that are displayed when query status / progress is rendered
 	unique_ptr<ShellProgressBar> progress_bar;
 	//! User-configured highlight elements

--- a/tools/shell/linenoise/include/linenoise.h
+++ b/tools/shell/linenoise/include/linenoise.h
@@ -75,7 +75,8 @@ void linenoiseSetErrorRendering(int enabled);
 void linenoiseSetCompletionRendering(int enabled);
 size_t linenoiseComputeRenderWidth(const char *buf, size_t len);
 int linenoiseGetRenderPosition(const char *buf, size_t len, int max_width, int *n);
-void linenoiseSetPrompt(const char *continuation, const char *continuationSelected);
+void linenoiseSetPrompt(const char *continuation, const char *continuationSelected, const char *scrollUp,
+                        const char *scrollDown);
 int linenoiseGetTerminalColorMode();
 
 #ifdef __cplusplus

--- a/tools/shell/linenoise/include/linenoise.hpp
+++ b/tools/shell/linenoise/include/linenoise.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/queue.hpp"
 #include "terminal.hpp"
 #include "linenoise.h"
 
@@ -65,6 +66,22 @@ struct Completion {
 
 struct TabCompletion {
 	vector<Completion> completions;
+};
+
+struct BufferedKeyPresses {
+public:
+	static BufferedKeyPresses &Get();
+
+	static void BufferKeyPress(KeyPress key_press);
+	static bool TryGetKeyPress(KeyPress &result);
+	static bool HasMoreData();
+
+private:
+	//! Remaining key presses that haven't been consumed yet
+	queue<KeyPress> remaining_presses;
+
+private:
+	BufferedKeyPresses();
 };
 
 class Linenoise {
@@ -215,7 +232,6 @@ public:
 	optional_idx completion_idx;             //! Index in set of tab completions
 	idx_t rendered_completion_lines;         //! The number of completion lines rendered
 	bool render_completion_suggestion;       //! Whether or not to render auto-complete suggestions
-	vector<KeyPress> remaining_presses;      //! Remaining key presses that haven't been consumed yet
 };
 
 } // namespace duckdb

--- a/tools/shell/linenoise/include/linenoise.hpp
+++ b/tools/shell/linenoise/include/linenoise.hpp
@@ -68,6 +68,8 @@ struct TabCompletion {
 	vector<Completion> completions;
 };
 
+enum class RenderTruncation { NO_TRUNCATE, TRUNCATE_TOP, TRUNCATE_BOTTOM, TRUNCATE_BOTH };
+
 struct BufferedKeyPresses {
 public:
 	static BufferedKeyPresses &Get();
@@ -93,7 +95,8 @@ public:
 
 	static void SetCompletionCallback(linenoiseCompletionCallback *fn);
 
-	static void SetPrompt(const char *continuation, const char *continuationSelected);
+	static void SetPrompt(const char *continuation, const char *continuationSelected, const char *scrollUpPrompt,
+	                      const char *scrollDownPrompt);
 	static size_t ComputeRenderWidth(const char *buf, size_t len);
 	static int GetRenderPosition(const char *buf, size_t len, int max_width, int *n);
 
@@ -157,8 +160,8 @@ public:
 	size_t ColAndRowToPosition(int target_row, int target_col) const;
 	static bool HandleANSIEscape(const char *buf, size_t len, size_t &cpos);
 
-	string AddContinuationMarkers(const char *buf, size_t len, int plen, int cursor_row,
-	                              vector<highlightToken> &tokens) const;
+	string AddContinuationMarkers(const char *buf, size_t len, int plen, int cursor_row, idx_t rows_to_render,
+	                              vector<highlightToken> &tokens, RenderTruncation truncation) const;
 	void AddErrorHighlighting(idx_t render_start, idx_t render_end, vector<highlightToken> &tokens) const;
 
 	bool AddCompletionMarker(const char *buf, idx_t len, string &result_buffer, vector<highlightToken> &tokens) const;

--- a/tools/shell/linenoise/include/terminal.hpp
+++ b/tools/shell/linenoise/include/terminal.hpp
@@ -142,6 +142,9 @@ public:
 	static char *EditNoTTY();
 	static int EditRaw(char *buf, size_t buflen, const char *prompt);
 
+	//! Consume all available input and store it for later consumption
+	static void BufferAvailableInput();
+
 	static EscapeSequence ReadEscapeSequence(int ifd, KeyPress &key_press);
 
 #if defined(_WIN32) || defined(WIN32)

--- a/tools/shell/linenoise/linenoise-c.cpp
+++ b/tools/shell/linenoise/linenoise-c.cpp
@@ -120,8 +120,9 @@ void linenoiseSetCompletionRendering(int enabled) {
 	}
 }
 
-void linenoiseSetPrompt(const char *continuation, const char *continuationSelected) {
-	Linenoise::SetPrompt(continuation, continuationSelected);
+void linenoiseSetPrompt(const char *continuation, const char *continuationSelected, const char *scrollUp,
+                        const char *scrollDown) {
+	Linenoise::SetPrompt(continuation, continuationSelected, scrollUp, scrollDown);
 }
 
 /* This function is used by the callback function registered by the user

--- a/tools/shell/linenoise/linenoise-c.cpp
+++ b/tools/shell/linenoise/linenoise-c.cpp
@@ -156,6 +156,9 @@ void linenoiseClearScreen(void) {
 }
 
 int linenoiseGetTerminalColorMode() {
+	// buffer any available input - we need to interact with stdin
+	Terminal::BufferAvailableInput();
+
 	duckdb::TerminalColor background_color;
 	if (!duckdb::Terminal::TryGetBackgroundColor(background_color)) {
 		return LINENOISE_UNKNOWN_MODE;

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -409,7 +409,7 @@ size_t Linenoise::ColAndRowToPosition(int plen, const char *buf, idx_t len, int 
 		if (cols >= ws.ws_col) {
 			// exceeded width - move to next line
 			rows++;
-			cols = plen;
+			cols = 0;
 		}
 		if (rows > target_row) {
 			// we have skipped our target row - that means "target_col" was out of range for this row

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -13,6 +13,8 @@
 namespace duckdb {
 static const char *continuationPrompt = "> ";
 static const char *continuationSelectedPrompt = "> ";
+static const char *scrollUpPrompt = "^ ";
+static const char *scrollDownPrompt = "v ";
 static bool enableCompletionRendering = false;
 static bool enableErrorRendering = true;
 
@@ -57,9 +59,12 @@ private:
 	std::string buffer;
 };
 
-void Linenoise::SetPrompt(const char *continuation, const char *continuationSelected) {
+void Linenoise::SetPrompt(const char *continuation, const char *continuationSelected, const char *scrollUp,
+                          const char *scrollDown) {
 	continuationPrompt = continuation;
 	continuationSelectedPrompt = continuationSelected;
+	scrollUpPrompt = scrollUp;
+	scrollDownPrompt = scrollDown;
 }
 
 static void renderText(size_t &render_pos, char *&buf, size_t &len, size_t pos, size_t cols, size_t plen,
@@ -230,8 +235,8 @@ void Linenoise::RefreshSearch() {
 	plen = clone.plen;
 }
 
-string Linenoise::AddContinuationMarkers(const char *buf, size_t len, int plen, int cursor_row,
-                                         vector<highlightToken> &tokens) const {
+string Linenoise::AddContinuationMarkers(const char *buf, size_t len, int plen, int cursor_row, idx_t rows_to_render,
+                                         vector<highlightToken> &tokens, RenderTruncation truncation) const {
 	std::string result;
 	int rows = 1;
 	int cols = plen;
@@ -241,6 +246,9 @@ string Linenoise::AddContinuationMarkers(const char *buf, size_t len, int plen, 
 	size_t token_position = 0; // token position
 	vector<highlightToken> new_tokens;
 	new_tokens.reserve(tokens.size());
+	bool truncate_top = truncation == RenderTruncation::TRUNCATE_TOP || truncation == RenderTruncation::TRUNCATE_BOTH;
+	bool truncate_bottom =
+	    truncation == RenderTruncation::TRUNCATE_BOTTOM || truncation == RenderTruncation::TRUNCATE_BOTH;
 	while (cpos < len) {
 		bool is_newline = IsNewline(buf[cpos]);
 		NextPosition(buf, len, cpos, rows, cols, plen);
@@ -249,7 +257,16 @@ string Linenoise::AddContinuationMarkers(const char *buf, size_t len, int plen, 
 		}
 		if (is_newline) {
 			bool is_cursor_row = rows == cursor_row;
-			const char *prompt = is_cursor_row ? continuationSelectedPrompt : continuationPrompt;
+			const char *prompt;
+			if (is_cursor_row) {
+				prompt = continuationSelectedPrompt;
+			} else if (truncate_top && rows == 2) {
+				prompt = scrollUpPrompt;
+			} else if (truncate_bottom && rows == rows_to_render + 1) {
+				prompt = scrollDownPrompt;
+			} else {
+				prompt = continuationPrompt;
+			}
 			if (!continuation_markers) {
 				prompt = "";
 			}
@@ -768,6 +785,7 @@ void Linenoise::RefreshMultiLine() {
 	char seq[64];
 	int plen = GetPromptWidth();
 	// utf8 in prompt, get render width
+	RenderTruncation truncation = RenderTruncation::NO_TRUNCATE;
 	int rows, cols;
 	int new_cursor_row, new_cursor_x;
 	PositionToColAndRow(pos, new_cursor_row, new_cursor_x, rows, cols);
@@ -803,15 +821,25 @@ void Linenoise::RefreshMultiLine() {
 			y_scroll = new_cursor_row - max_rows_to_render;
 		}
 		// display only characters up to the current scroll position
+		bool truncate_top = false, truncate_bottom = false;
 		if (y_scroll == 0) {
 			render_start = 0;
 		} else {
 			render_start = ColAndRowToPosition(y_scroll, 0);
+			truncate_top = true;
 		}
 		if (int(y_scroll) + int(max_rows_to_render) >= rows) {
 			render_end = len;
 		} else {
 			render_end = ColAndRowToPosition(y_scroll + max_rows_to_render, 99999);
+			truncate_bottom = true;
+		}
+		if (truncate_top && truncate_bottom) {
+			truncation = RenderTruncation::TRUNCATE_BOTH;
+		} else if (truncate_top) {
+			truncation = RenderTruncation::TRUNCATE_TOP;
+		} else if (truncate_bottom) {
+			truncation = RenderTruncation::TRUNCATE_BOTTOM;
 		}
 		new_cursor_row -= y_scroll;
 		render_buf += render_start;
@@ -863,8 +891,9 @@ void Linenoise::RefreshMultiLine() {
 	}
 	if (rows > 1) {
 		// add continuation markers
-		highlight_buffer = AddContinuationMarkers(render_buf, render_len, plen,
-		                                          y_scroll > 0 ? new_cursor_row + 1 : new_cursor_row, tokens);
+		highlight_buffer =
+		    AddContinuationMarkers(render_buf, render_len, plen, y_scroll > 0 ? new_cursor_row + 1 : new_cursor_row,
+		                           y_scroll > 0 ? rows : rows - 1, tokens, truncation);
 		render_buf = (char *)highlight_buffer.c_str();
 		render_len = highlight_buffer.size();
 	}

--- a/tools/shell/linenoise/terminal.cpp
+++ b/tools/shell/linenoise/terminal.cpp
@@ -415,6 +415,18 @@ bool ParseTerminalColor(TerminalColor &color, const char *buf, idx_t buflen) {
 	return true;
 }
 
+void Terminal::BufferAvailableInput() {
+	// consume available input and add it to the buffer
+	int ifd = STDIN_FILENO;
+	while (HasMoreData(ifd)) {
+		char buf[1];
+		if (read(ifd, buf, 1) != 1) {
+			break;
+		}
+		BufferedKeyPresses::BufferKeyPress((KEY_ACTION)buf[0]);
+	}
+}
+
 bool Terminal::TryGetBackgroundColor(TerminalColor &color) {
 	int ifd = STDIN_FILENO;
 	int ofd = STDOUT_FILENO;

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -409,8 +409,10 @@ ShellState::ShellState() : seenInterrupt(0), program_name("duckdb") {
 	    "extensions are disabled by configuration.\nStart the shell with the -unsigned parameter to allow this "
 	    "(e.g. duckdb -unsigned).");
 	nullValue = "NULL";
-	strcpy(continuePrompt, "· ");
+	strcpy(continuePrompt, "  ");
 	strcpy(continuePromptSelected, "‣ ");
+	strcpy(scrollUpPrompt, "⇡ ");
+	strcpy(scrollDownPrompt, "⇣ ");
 }
 
 ShellState::~ShellState() {
@@ -3007,7 +3009,7 @@ void ShellState::Initialize() {
 	}
 #ifdef HAVE_LINENOISE
 	if (rl_version == ReadLineVersion::LINENOISE) {
-		linenoiseSetPrompt(continuePrompt, continuePromptSelected);
+		linenoiseSetPrompt(continuePrompt, continuePromptSelected, scrollUpPrompt, scrollDownPrompt);
 	}
 #endif
 }

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3047,6 +3047,8 @@ void ShellState::DetectDarkLightMode() {
 	} else if (terminal_color == LINENOISE_LIGHT_MODE) {
 		highlight_mode = HighlightMode::LIGHT_MODE;
 		highlight.ToggleMode(HighlightMode::LIGHT_MODE);
+	} else {
+		highlight_mode = HighlightMode::MIXED_MODE;
 	}
 #endif
 }

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1483,6 +1483,9 @@ void ShellState::PrintDatabaseError(const string &zErr) {
 		PrintF(PrintOutput::STDERR, "%s\n", zErr.c_str());
 		return;
 	}
+	// detect dark-light mode if we haven't yet
+	DetectDarkLightMode();
+	// print the error
 	ShellHighlight shell_highlight(*this);
 	shell_highlight.PrintError(zErr);
 }
@@ -3023,6 +3026,29 @@ struct ShellStateDestroyer {
 	}
 };
 
+void ShellState::DetectDarkLightMode() {
+#ifdef HAVE_LINENOISE
+	ShellHighlight highlight(*this);
+	if (highlight_mode != HighlightMode::AUTOMATIC) {
+		// highlight mode is specified by the user - avoid setting manually
+		return;
+	}
+	if (!stdout_is_console && !stderr_is_console) {
+		// not printing to console - don't auto-detect
+		return;
+	}
+	// detect terminal colors
+	auto terminal_color = linenoiseGetTerminalColorMode();
+	if (terminal_color == LINENOISE_DARK_MODE) {
+		highlight_mode = HighlightMode::DARK_MODE;
+		highlight.ToggleMode(HighlightMode::DARK_MODE);
+	} else if (terminal_color == LINENOISE_LIGHT_MODE) {
+		highlight_mode = HighlightMode::LIGHT_MODE;
+		highlight.ToggleMode(HighlightMode::LIGHT_MODE);
+	}
+#endif
+}
+
 #if SQLITE_SHELL_IS_UTF8
 int main(int argc, const char **argv) {
 #else
@@ -3143,18 +3169,7 @@ int wmain(int argc, wchar_t **wargv) {
 		return 1;
 	}
 
-	ShellHighlight highlight(data);
-#ifdef HAVE_LINENOISE
-	if (data.highlight_mode == HighlightMode::AUTOMATIC && data.stdout_is_console && data.stderr_is_console) {
-		// detect terminal colors
-		auto terminal_color = linenoiseGetTerminalColorMode();
-		if (terminal_color == LINENOISE_DARK_MODE) {
-			highlight.ToggleMode(HighlightMode::DARK_MODE);
-		} else if (terminal_color == LINENOISE_LIGHT_MODE) {
-			highlight.ToggleMode(HighlightMode::LIGHT_MODE);
-		}
-	}
-#endif
+	data.DetectDarkLightMode();
 
 	/* Make a second pass through the command-line argument and set
 	** options.  This second pass is delayed until after the initialization
@@ -3196,6 +3211,7 @@ int wmain(int argc, wchar_t **wargv) {
 		if (data.stdin_is_interactive) {
 			string zHome;
 			const char *zHistory;
+			ShellHighlight highlight(data);
 
 			auto startup_version = StringUtil::Format("DuckDB %s (%s", duckdb::DuckDB::LibraryVersion(),
 			                                          duckdb::DuckDB::ReleaseCodename());

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3143,6 +3143,19 @@ int wmain(int argc, wchar_t **wargv) {
 		return 1;
 	}
 
+	ShellHighlight highlight(data);
+#ifdef HAVE_LINENOISE
+	if (data.highlight_mode == HighlightMode::AUTOMATIC && data.stdout_is_console && data.stderr_is_console) {
+		// detect terminal colors
+		auto terminal_color = linenoiseGetTerminalColorMode();
+		if (terminal_color == LINENOISE_DARK_MODE) {
+			highlight.ToggleMode(HighlightMode::DARK_MODE);
+		} else if (terminal_color == LINENOISE_LIGHT_MODE) {
+			highlight.ToggleMode(HighlightMode::LIGHT_MODE);
+		}
+	}
+#endif
+
 	/* Make a second pass through the command-line argument and set
 	** options.  This second pass is delayed until after the initialization
 	** file is processed so that the command-line arguments will override
@@ -3183,18 +3196,6 @@ int wmain(int argc, wchar_t **wargv) {
 		if (data.stdin_is_interactive) {
 			string zHome;
 			const char *zHistory;
-			ShellHighlight highlight(data);
-#ifdef HAVE_LINENOISE
-			if (data.highlight_mode == HighlightMode::AUTOMATIC && data.stdout_is_console && data.stderr_is_console) {
-				// detect terminal colors
-				auto terminal_color = linenoiseGetTerminalColorMode();
-				if (terminal_color == LINENOISE_DARK_MODE) {
-					highlight.ToggleMode(HighlightMode::DARK_MODE);
-				} else if (terminal_color == LINENOISE_LIGHT_MODE) {
-					highlight.ToggleMode(HighlightMode::LIGHT_MODE);
-				}
-			}
-#endif
 
 			auto startup_version = StringUtil::Format("DuckDB %s (%s", duckdb::DuckDB::LibraryVersion(),
 			                                          duckdb::DuckDB::ReleaseCodename());

--- a/tools/shell/shell_command_line_option.cpp
+++ b/tools/shell/shell_command_line_option.cpp
@@ -149,7 +149,7 @@ MetadataResult RunCommand(ShellState &state, const vector<string> &args) {
 
 static const CommandLineOption command_line_options[] = {
     {"ascii", 0, "", nullptr, ToggleASCIIMode, "set output mode to 'ascii'"},
-    {"bail", 0, "", nullptr, EnableBail, "stop after hitting an error'"},
+    {"bail", 0, "", nullptr, EnableBail, "stop after hitting an error"},
     {"batch", 0, "", EnableBatch, EnableBatch, "force batch I/O'"},
     {"box", 0, "", nullptr, ToggleOutputMode<RenderMode::BOX>, "set output mode to 'box'"},
     {"column", 0, "", nullptr, ToggleOutputMode<RenderMode::COLUMN>, "set output mode to 'column'"},
@@ -160,7 +160,7 @@ static const CommandLineOption command_line_options[] = {
     {"f", 1, "FILENAME", EnableBatch, ProcessFile, "read/process named file and exit"},
     {"init", 1, "FILENAME", SetInitFile, nullptr, "read/process named file"},
     {"header", 0, "", nullptr, ToggleHeader<true>, "turn headers on"},
-    {"help", 0, "", PrintHelpAndExit, nullptr, "show this message"},
+    {"help", 0, "", EnableBatch, PrintHelpAndExit, "show this message"},
     {"html", 0, "", nullptr, ToggleOutputMode<RenderMode::HTML>, "set output mode to HTML"},
     {"interactive", 0, "", nullptr, DisableBatch, "force interactive I/O"},
     {"json", 0, "", nullptr, ToggleOutputMode<RenderMode::JSON>, "set output mode to 'json'"},

--- a/tools/shell/shell_command_line_option.cpp
+++ b/tools/shell/shell_command_line_option.cpp
@@ -208,15 +208,15 @@ optional_ptr<const CommandLineOption> ShellState::FindCommandLineOption(const st
 	}
 	if (!c.IsValid()) {
 		// not found
-		string error = StringUtil::Format("Unknown Option Error: Unrecognized option '-%s'\n", option);
+		error_msg = StringUtil::Format("Unknown Option Error: Unrecognized option '-%s'\n", option);
 		vector<string> option_names;
 		for (idx_t c = 0; command_line_options[c].option; c++) {
 			auto &option = command_line_options[c];
 			option_names.push_back(string("-") + option.option);
 		}
 		auto candidates_msg = StringUtil::CandidatesErrorMessage(option_names, "-" + option, "Did you mean");
-		error += candidates_msg + "\n";
-		error += StringUtil::Format("Run '%s -help' for a list of options.\n", program_name);
+		error_msg += candidates_msg + "\n";
+		error_msg += StringUtil::Format("Run '%s -help' for a list of options.\n", program_name);
 		return nullptr;
 	}
 	return command_line_options[c.GetIndex()];

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -307,6 +307,12 @@ MetadataResult SetPrompt(ShellState &state, const vector<string> &args) {
 	if (args.size() >= 4) {
 		ShellState::SetPrompt(state.continuePromptSelected, args[3]);
 	}
+	if (args.size() >= 5) {
+		ShellState::SetPrompt(state.scrollUpPrompt, args[4]);
+	}
+	if (args.size() >= 6) {
+		ShellState::SetPrompt(state.scrollDownPrompt, args[5]);
+	}
 	return MetadataResult::SUCCESS;
 }
 

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1773,7 +1773,7 @@ void ShellLogStorage::WriteLogEntry(duckdb::timestamp_t timestamp, duckdb::LogLe
 
 	const auto log_level = duckdb::EnumUtil::ToString(level);
 	shell_highlight.PrintText(log_level + ":\n", PrintOutput::STDOUT, element_type);
-	shell_highlight.PrintText(log_message + "\n\n", PrintOutput::STDOUT, HighlightElementType::NONE);
+	shell_highlight.PrintText(log_message + "\n\n", PrintOutput::STDOUT, element_type);
 }
 
 } // namespace duckdb_shell

--- a/tools/shell/tests/test_command_line_arguments.py
+++ b/tools/shell/tests/test_command_line_arguments.py
@@ -8,6 +8,16 @@ from conftest import ShellTest
 import os
 from pathlib import Path
 
+def test_missing_arg(shell):
+    test = (
+        ShellTest(shell)
+        .statement("SELECT 42")
+        .add_argument("-xyz")
+    )
+    result = test.run()
+    result.check_stderr("Unrecognized option")
+    result.check_stderr("xyz")
+
 def test_headers(shell):
     test = (
         ShellTest(shell)


### PR DESCRIPTION
* Generalize buffering input, and buffer available input when trying to get the background color to prevent input from being lost
* Correctly trigger dark / light mode in batch mode
* Make warnings all orange
* Correctly print error message on wrong shell command line argument
* Add rendering for up / down scroll arrows when rendering a large query that does not fit within the terminal window
* Fix issue in `ColAndRowToPosition` with long wrapping lines
