### PR TITLE
fix: remove extra space in GetName() for PhysicalTableScan in profiler output

### DIFF
--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -272,7 +272,7 @@ OperatorPartitionData PhysicalTableScan::GetPartitionData(ExecutionContext &cont
 }
 
 string PhysicalTableScan::GetName() const {
-	return StringUtil::Upper(function.name + " " + function.extra_info);
+	return StringUtil::Upper(function.name + (function.extra_info.empty() ? "" : " " + function.extra_info));
 }
 
 void AddProjectionNames(const ColumnIndex &index, const string &name, const LogicalType &type, string &result) {


### PR DESCRIPTION
Hi DuckDB Team,

I was reviewing the JSON formatted output of the profiler and often it was adding an extra space to `operator_name`:

Example of profiler output, notice `"READ_CSV_AUTO "` rather than `"READ_CSV_AUTO"`:

```json
{
  "system_peak_temp_dir_size": 0,
  "system_peak_buffer_memory": 0,
  "result_set_size": 480000,
  "operator_cardinality": 60000,
  "operator_rows_scanned": 469392,
  "cpu_time": 0.135243666,
  "operator_name": "READ_CSV_AUTO ",
  "extra_info": {
    "Function": "READ_CSV_AUTO",
    "Projections": "range",
    "Estimated Cardinality": "58674",
    "Total Files Read": "6"
  },
  "operator_type": "TABLE_SCAN",
  "cumulative_rows_scanned": 469392,
  "operator_timing": 0.135243666,
  "cumulative_cardinality": 60000,
  "children": []
}
```

This change removes the extra space if there is no `extra_info`.

Thanks,

Rusty
