### PR TITLE
Add days_in_month  internal macro for retrieving number of days in a month

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -160,6 +160,9 @@ static const DefaultMacro internal_macros[] = {
 	// date functions
 	{DEFAULT_SCHEMA, "date_add", {"date", "interval", nullptr}, {{nullptr, nullptr}}, "date + interval"},
 
+	// date functions - convenience macro for getting days in month
+	{DEFAULT_SCHEMA, "days_in_month", {"date", nullptr}, {{nullptr, nullptr}}, "day(last_day(date))"},
+
 	// regexp functions
 	{DEFAULT_SCHEMA, "regexp_split_to_table", {"text", "pattern", nullptr}, {{nullptr, nullptr}}, "unnest(string_split_regex(text, pattern))"},
 


### PR DESCRIPTION
Hi, duckdb team, this is the internal macro version of days_in_month. 
This link leads to a previous PR discussion, i accidentally turned it off.
https://github.com/duckdb/duckdb/pull/20144