### PR TITLE
fix: add schema and catalog to table scan explain output

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -768,7 +768,8 @@ unique_ptr<NodeStatistics> TableScanCardinality(ClientContext &context, const Fu
 InsertionOrderPreservingMap<string> TableScanToString(TableFunctionToStringInput &input) {
 	InsertionOrderPreservingMap<string> result;
 	auto &bind_data = input.bind_data->Cast<TableScanBindData>();
-	result["Table"] = bind_data.table.name;
+	result["Table"] = ParseInfo::QualifierToString(bind_data.table.schema.catalog.GetName(),
+	                                               bind_data.table.schema.name, bind_data.table.name);
 	result["Type"] = bind_data.is_index_scan ? "Index Scan" : "Sequential Scan";
 	return result;
 }

--- a/test/sql/explain/test_explain_table_scan.test
+++ b/test/sql/explain/test_explain_table_scan.test
@@ -14,4 +14,4 @@ INSERT INTO integers VALUES (1, 1), (2, 2), (3, 3), (NULL, NULL)
 query II
 EXPLAIN SELECT * FROM integers
 ----
-physical_plan	<REGEX>:.*Table: integers.*
+physical_plan	<REGEX>:.*Table: .*.integers.*


### PR DESCRIPTION
Hi DuckDB Team,

When using the profiler for queries that have the same table name in different schemas, it was impossible to determine which node was scanning which table.  This PR adds the catalog and schema name to the `TableScanToString` method so that the particular table in a catalog and schema can be identified.

Thanks,

Rusty