### PR TITLE
feat: add filenames to MultiFileDynamicToString

### DIFF
--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -808,7 +808,22 @@ public:
 	static InsertionOrderPreservingMap<string> MultiFileDynamicToString(TableFunctionDynamicToStringInput &input) {
 		auto &gstate = input.global_state->Cast<MultiFileGlobalState>();
 		InsertionOrderPreservingMap<string> result;
-		result.insert(make_pair("Total Files Read", std::to_string(gstate.file_index.load())));
+		auto files_loaded = gstate.file_index.load();
+		result.insert(make_pair("Total Files Read", std::to_string(files_loaded)));
+
+		constexpr size_t FILE_NAME_LIST_LIMIT = 5;
+		auto file_paths = gstate.file_list.GetPaths();
+		if (!file_paths.empty()) {
+			vector<std::string> file_path_names;
+			for (idx_t i = 0; i < MinValue<idx_t>(file_paths.size(), FILE_NAME_LIST_LIMIT); i++) {
+				file_path_names.push_back(file_paths[i].path);
+			}
+			if (files_loaded > FILE_NAME_LIST_LIMIT) {
+				file_path_names.push_back("...");
+			}
+			auto list_of_types = StringUtil::Join(file_path_names, ", ");
+			result.insert(make_pair("Filename(s)", list_of_types));
+		}
 		return result;
 	}
 


### PR DESCRIPTION
Hi DuckDB Team,

When reviewing `EXPLAIN ANALYZE` output, operations backed by `MultiFileReader` are often reported like this:

```json
{
  "system_peak_temp_dir_size": 0,
  "system_peak_buffer_memory": 0,
  "result_set_size": 480000,
  "operator_cardinality": 60000,
  "operator_rows_scanned": 469392,
  "cpu_time": 0.135243666,
  "operator_name": "READ_CSV_AUTO ",
  "extra_info": {
    "Function": "READ_CSV_AUTO",
    "Projections": "range",
    "Estimated Cardinality": "58674",
    "Total Files Read": "6"
  },
  "operator_type": "TABLE_SCAN",
  "cumulative_rows_scanned": 469392,
  "operator_timing": 0.135243666,
  "cumulative_cardinality": 60000,
  "children": []
}
```

This PR extends `extra_info` with a new key, `"Filename(s)"`, which reports the first five filenames provided by the user. This makes it much easier to distinguish between multiple calls to `read_csv_auto` (or other functions built on the `MultiFileReader` infrastructure) within the same query, since the specific files being read are now visible.

A few notes:

1. I intentionally avoided logging the fully expanded filenames; this might be worth reconsidering.
2. The limit of five filenames is arbitrary and mainly intended to keep the output concise.
3. It would be nice if `extra_info` could accept a full `duckdb::Value` instead of only strings—this would allow representing filenames as a `LIST()` of strings, which would be more natural in the JSON output.

Thank you!

Rusty
