### PR TITLE
fix: simplify platform detection in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,12 +157,12 @@ endif()
 
 if(APPLE)
   set(OS_NAME "osx")
-endif()
-if(WIN32)
+elseif(WIN32)
   set(OS_NAME "windows")
-endif()
-if(UNIX AND NOT APPLE)
+elseif(UNIX)
   set(OS_NAME "linux") # sorry BSD
+else()
+  set(OS_NAME "unknown")
 endif()
 
 option(FORCE_WARN_UNUSED "Unused code objects lead to compiler warnings." FALSE)


### PR DESCRIPTION
Optimize OS detection logic by using elseif statements instead of multiple if statements to avoid unnecessary checks after a match is found. This improves performance and adds an explicit fallback for unknown platforms.

Before:
- Multiple independent if statements that always execute
- No fallback for unknown platforms

After:
- Sequential elseif statements that stop after first match
- Explicit else() clause for unknown platforms