### PR TITLE
feat: preserve ATTACH options and return via duckdb_databases()

### DIFF
--- a/src/function/table/system/duckdb_databases.cpp
+++ b/src/function/table/system/duckdb_databases.cpp
@@ -44,6 +44,9 @@ static unique_ptr<FunctionData> DuckDBDatabasesBind(ClientContext &context, Tabl
 
 	names.emplace_back("cipher");
 	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("options");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
 	return nullptr;
 }
 
@@ -108,6 +111,12 @@ void DuckDBDatabasesFunction(ClientContext &context, TableFunctionInput &data_p,
 		output.SetValue(col++, count, Value::BOOLEAN(catalog.IsEncrypted()));
 		// cipher, VARCHAR
 		output.SetValue(col++, count, cipher_str.empty() ? Value() : Value(cipher_str));
+		// options, MAP
+		InsertionOrderPreservingMap<string> options_map;
+		for (const auto &option : attached.GetAttachOptions()) {
+			options_map.insert(option.first, option.second.ToString());
+		}
+		output.SetValue(col++, count, Value::MAP(options_map));
 
 		count++;
 	}

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -129,6 +129,9 @@ public:
 	AttachVisibility GetVisibility() const {
 		return visibility;
 	}
+	const unordered_map<string, Value> &GetAttachOptions() const {
+		return attach_options;
+	}
 	string StoredPath() const;
 
 	static bool NameIsReserved(const string &name);
@@ -147,6 +150,7 @@ private:
 	AttachVisibility visibility = AttachVisibility::SHOWN;
 	bool is_initial_database = false;
 	bool is_closed = false;
+	unordered_map<string, Value> attach_options;
 };
 
 } // namespace duckdb

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -103,7 +103,8 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, AttachedDatabaseType ty
 
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, string name_p, string file_path_p,
                                    AttachOptions &options)
-    : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p) {
+    : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p),
+      attach_options(options.options) {
 	if (options.access_mode == AccessMode::READ_ONLY) {
 		type = AttachedDatabaseType::READ_ONLY_DATABASE;
 	} else {
@@ -123,7 +124,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, StorageExtension &storage_extension_p,
                                    ClientContext &context, string name_p, AttachInfo &info, AttachOptions &options)
     : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p),
-      storage_extension(&storage_extension_p) {
+      storage_extension(&storage_extension_p), attach_options(options.options) {
 	if (options.access_mode == AccessMode::READ_ONLY) {
 		type = AttachedDatabaseType::READ_ONLY_DATABASE;
 	} else {

--- a/test/sql/attach/attach_database_options.test
+++ b/test/sql/attach/attach_database_options.test
@@ -1,0 +1,20 @@
+# name: test/sql/attach/attach_database_options.test
+# description: Test ATTACH with database options being persisted
+# group: [attach]
+
+statement ok
+PRAGMA enable_verification
+
+# attach a new database
+statement ok
+ATTACH DATABASE ':memory:' AS new_database (BLOCK_SIZE 262144, ROW_GROUP_SIZE 2048);
+
+query I
+SELECT options['block_size'] from duckdb_databases() where database_name = 'new_database';
+----
+262144
+
+query I
+SELECT options['row_group_size'] from duckdb_databases() where database_name = 'new_database';
+----
+2048


### PR DESCRIPTION
Hi DuckDB Team,

I think it would be very useful to preserve the options supplied to `ATTACH`, so that I can determine how a database was attached. This PR stores the `ATTACH` options on the `AttachedDatabase` object and also exposes them via the `duckdb_databases()` table-returning function.

Because options are represented as a map from strings to `duckdb::Value`, I’ve changed all option values to strings. This avoids having to pick a single `LogicalType` for the new `options` column, since different database backends may use the same option name with different option value types.

For example:

```sql
DuckDB v1.5.0-dev4506 (Development Version, 1d558536e0)
Enter ".help" for usage hints.
memory D attach 'foo2.db' as foo2 (BLOCK_SIZE 262144, ROW_GROUP_SIZE 2048);
memory D .mode line
memory D select * from duckdb_databases();
database_name = foo2
 database_oid = 1328
         path = foo2.db
      comment = NULL
         tags = {storage_version=v1.0.0+}
     internal = false
         type = duckdb
     readonly = false
    encrypted = false
       cipher = NULL
      options = {block_size=262144, row_group_size=2048}
```

Thanks,
Rusty
