### PR TITLE
[minor] Avoid divide by 0 for json progress report

### DIFF
--- a/extension/json/json_reader.cpp
+++ b/extension/json/json_reader.cpp
@@ -368,11 +368,14 @@ bool JSONReader::HasThrown() {
 
 double JSONReader::GetProgress() const {
 	lock_guard<mutex> guard(lock);
-	if (HasFileHandle()) {
-		return 100.0 - 100.0 * double(file_handle->Remaining()) / double(file_handle->FileSize());
-	} else {
+	if (!HasFileHandle()) {
 		return 0;
 	}
+	const auto file_size = file_handle->FileSize();
+	if (file_size == 0) {
+		return 0;
+	}
+	return 100.0 - 100.0 * double(file_handle->Remaining()) / double(file_size);
 }
 
 static inline void TrimWhitespace(JSONString &line) {


### PR DESCRIPTION
Defensive programming: I see file handle could be pipe handle, which is of size 0; this PR checks file size and avoid potential divide by 0 error.