### PR TITLE
[Encryption] Adding random IV and tag for canary encryption

### DIFF
--- a/src/common/encryption_state.cpp
+++ b/src/common/encryption_state.cpp
@@ -56,6 +56,16 @@ EncryptionTypes::CipherType EncryptionTypes::StringToCipher(const string &encryp
 	return INVALID;
 }
 
+EncryptionTypes::EncryptionVersion EncryptionTypes::StringToVersion(const string &encryption_version_p) {
+	if (encryption_version_p == "0") {
+		return V0_0;
+	} else if (encryption_version_p == "1") {
+		return V0_1;
+	} else {
+		throw NotImplementedException("No encryption version higher then 1 exists yet");
+	}
+}
+
 string EncryptionTypes::KDFToString(KeyDerivationFunction kdf_p) {
 	switch (kdf_p) {
 	case SHA256:

--- a/src/common/encryption_state.cpp
+++ b/src/common/encryption_state.cpp
@@ -29,6 +29,8 @@ void EncryptionState::GenerateRandomData(data_ptr_t, idx_t) {
 	throw NotImplementedException("EncryptionState Abstract Class is called");
 }
 
+static constexpr EncryptionTypes::EncryptionVersion MAX_VERSION = EncryptionTypes::V0_1;
+
 string EncryptionTypes::CipherToString(CipherType cipher_p) {
 	switch (cipher_p) {
 	case GCM:
@@ -57,12 +59,13 @@ EncryptionTypes::CipherType EncryptionTypes::StringToCipher(const string &encryp
 }
 
 EncryptionTypes::EncryptionVersion EncryptionTypes::StringToVersion(const string &encryption_version_p) {
-	if (encryption_version_p == "0") {
+	if (encryption_version_p == "v0") {
 		return V0_0;
-	} else if (encryption_version_p == "1") {
+	} else if (encryption_version_p == "v1") {
 		return V0_1;
 	} else {
-		throw NotImplementedException("No encryption version higher then 1 exists yet");
+		throw NotImplementedException("No encryption version higher then v%d is supported yet in this DuckDB version",
+		                              MAX_VERSION);
 	}
 }
 

--- a/src/include/duckdb/common/encryption_state.hpp
+++ b/src/include/duckdb/common/encryption_state.hpp
@@ -18,11 +18,13 @@ public:
 	enum CipherType : uint8_t { INVALID = 0, GCM = 1, CTR = 2, CBC = 3 };
 	enum KeyDerivationFunction : uint8_t { DEFAULT = 0, SHA256 = 1, PBKDF2 = 2 };
 	enum Mode { ENCRYPT, DECRYPT };
+	enum EncryptionVersion : uint8_t { V0_0 = 0, V0_1 = 1, NONE = 127 };
 
 	static string CipherToString(CipherType cipher_p);
 	static CipherType StringToCipher(const string &encryption_cipher_p);
 	static string KDFToString(KeyDerivationFunction kdf_p);
 	static KeyDerivationFunction StringToKDF(const string &key_derivation_function_p);
+	static EncryptionVersion StringToVersion(const string &encryption_version_p);
 };
 
 class EncryptionState {

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -39,6 +39,8 @@ struct EncryptionOptions {
 	uint32_t key_length = MainHeader::DEFAULT_ENCRYPTION_KEY_LENGTH;
 	//! User key pointer (to StorageOptions)
 	shared_ptr<string> user_key;
+	//! Version of duckdb-encryption (default = 0)
+	uint8_t version = 0;
 };
 
 struct StorageManagerOptions {
@@ -156,6 +158,8 @@ private:
 	static void StoreEncryptedCanary(AttachedDatabase &db, MainHeader &main_header, const string &key_id);
 	static void StoreDBIdentifier(MainHeader &main_header, const data_ptr_t db_identifier);
 	void StoreEncryptionMetadata(MainHeader &main_header) const;
+	template <typename T>
+	static void WriteEncryptionData(MemoryStream &stream, const T &val);
 
 	//! Check and adding Encryption Keys
 	void CheckAndAddEncryptionKey(MainHeader &main_header, string &user_key);

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -39,8 +39,8 @@ struct EncryptionOptions {
 	uint32_t key_length = MainHeader::DEFAULT_ENCRYPTION_KEY_LENGTH;
 	//! User key pointer (to StorageOptions)
 	shared_ptr<string> user_key;
-	//! Version of duckdb-encryption (default = 0)
-	uint8_t version = 0;
+	//! Version of duckdb-encryption
+	EncryptionTypes::EncryptionVersion encryption_version = EncryptionTypes::NONE;
 };
 
 struct StorageManagerOptions {

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -138,8 +138,8 @@ public:
 		return static_cast<EncryptionTypes::CipherType>(encryption_metadata[2]);
 	}
 
-	uint8_t GetEncryptionVersion() const {
-		return encryption_metadata[3];
+	EncryptionTypes::EncryptionVersion GetEncryptionVersion() const {
+		return static_cast<EncryptionTypes::EncryptionVersion>(encryption_metadata[3]);
 	}
 
 	void SetDBIdentifier(data_ptr_t source) {

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -96,6 +96,8 @@ public:
 	uint64_t version_number;
 	//! The set of flags used by the database.
 	uint64_t flags[FLAG_COUNT];
+	//! Encryption version
+	uint8_t encryption_version;
 
 	//! The length of the unique database identifier.
 	static constexpr idx_t DB_IDENTIFIER_LEN = 16;
@@ -123,6 +125,9 @@ public:
 	void SetEncrypted() {
 		flags[0] |= MainHeader::ENCRYPTED_DATABASE_FLAG;
 	}
+	void SetEncryptionVersion(uint8_t version) {
+		encryption_version = version;
+	}
 
 	void SetEncryptionMetadata(data_ptr_t source) {
 		memset(encryption_metadata, 0, ENCRYPTION_METADATA_LEN);
@@ -131,6 +136,10 @@ public:
 
 	EncryptionTypes::CipherType GetEncryptionCipher() {
 		return static_cast<EncryptionTypes::CipherType>(encryption_metadata[2]);
+	}
+
+	uint8_t GetEncryptionVersion() const {
+		return encryption_metadata[3];
 	}
 
 	void SetDBIdentifier(data_ptr_t source) {
@@ -143,8 +152,26 @@ public:
 		memcpy(encrypted_canary, source, CANARY_BYTE_SIZE);
 	}
 
+	void SetCanaryIV(data_ptr_t source) {
+		memset(canary_iv, 0, AES_IV_LEN);
+		memcpy(canary_iv, source, AES_IV_LEN);
+	}
+
+	void SetCanaryTag(data_ptr_t source) {
+		memset(canary_tag, 0, AES_TAG_LEN);
+		memcpy(canary_tag, source, AES_TAG_LEN);
+	}
+
 	data_ptr_t GetDBIdentifier() {
 		return db_identifier;
+	}
+
+	data_ptr_t GetIV() {
+		return canary_iv;
+	}
+
+	data_ptr_t GetTag() {
+		return canary_tag;
 	}
 
 	static bool CompareDBIdentifiers(const data_ptr_t db_identifier_1, const data_ptr_t db_identifier_2) {
@@ -170,6 +197,8 @@ private:
 	//! The unique database identifier and optional encryption salt.
 	data_t db_identifier[DB_IDENTIFIER_LEN];
 	data_t encrypted_canary[CANARY_BYTE_SIZE];
+	data_t canary_iv[AES_IV_LEN];
+	data_t canary_tag[AES_IV_LEN];
 };
 
 //! The DatabaseHeader contains information about the current state of the database. Every storage file has two

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -132,6 +132,9 @@ public:
 	bool IsEncrypted() const {
 		return storage_options.encryption;
 	}
+	uint8_t GetEncryptionVersion() const {
+		return storage_options.encryption_version;
+	}
 
 protected:
 	virtual void LoadDatabase(QueryContext context) = 0;

--- a/src/include/duckdb/storage/storage_options.hpp
+++ b/src/include/duckdb/storage/storage_options.hpp
@@ -39,6 +39,7 @@ struct StorageOptions {
 	//! encryption version (set default to 1)
 	EncryptionTypes::EncryptionVersion encryption_version = EncryptionTypes::NONE;
 
+	void SetEncryptionVersion(string &storage_version_user_provided);
 	void Initialize(const unordered_map<string, Value> &options);
 };
 

--- a/src/include/duckdb/storage/storage_options.hpp
+++ b/src/include/duckdb/storage/storage_options.hpp
@@ -36,6 +36,8 @@ struct StorageOptions {
 	//! encryption key
 	//! FIXME: change to a unique_ptr in the future
 	shared_ptr<string> user_key;
+	//! encryption version (set default to 1)
+	EncryptionTypes::EncryptionVersion encryption_version = EncryptionTypes::NONE;
 
 	void Initialize(const unordered_map<string, Value> &options);
 };

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -247,7 +247,7 @@ MainHeader MainHeader::Read(ReadStream &source) {
 	for (idx_t i = 0; i < FLAG_COUNT; i++) {
 		header.flags[i] = source.Read<uint64_t>();
 	}
-	` DeserializeVersionNumber(source, header.library_git_desc);
+	DeserializeVersionNumber(source, header.library_git_desc);
 	DeserializeVersionNumber(source, header.library_git_hash);
 
 	// We always deserialize, and read zeros, if not set.

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -496,6 +496,7 @@ void SingleFileBlockManager::CreateNewDatabase(QueryContext context) {
 		if (options.encryption_options.encryption_version == EncryptionTypes::NONE) {
 			throw InvalidConfigurationException("No Encryption type set");
 		}
+
 		main_header.SetEncryptionVersion(options.encryption_options.encryption_version);
 
 		// The derived key is wiped in AddKeyToCache.

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -579,17 +579,8 @@ void SingleFileBlockManager::LoadExistingDatabase(QueryContext context) {
 	MainHeader main_header = DeserializeMainHeader(header_buffer.buffer - delta);
 	memcpy(options.db_identifier, main_header.GetDBIdentifier(), MainHeader::DB_IDENTIFIER_LEN);
 
-	if (options.encryption_options.encryption_version != EncryptionTypes::NONE &&
-	    (options.encryption_options.encryption_version != main_header.GetEncryptionVersion())) {
-		throw InvalidInputException(
-		    "Encryption version mismatch. Database encryption version is %d, attempted to decrypt version %d",
-		    options.encryption_options.encryption_version, main_header.GetEncryptionVersion());
-	}
-
-	if (options.encryption_options.encryption_version == EncryptionTypes::NONE) {
-		// encryption version is not explicitly set on attach (default)
-		options.encryption_options.encryption_version = main_header.GetEncryptionVersion();
-	}
+	// encryption version can be overridden by the real encryption version
+	options.encryption_options.encryption_version = main_header.GetEncryptionVersion();
 
 	if (!main_header.IsEncrypted() && options.encryption_options.encryption_enabled) {
 		throw CatalogException("A key is explicitly specified, but database \"%s\" is not encrypted", path);

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -493,23 +493,8 @@ void SingleFileBlockManager::CreateNewDatabase(QueryContext context) {
 		// Set the encrypted DB bit to 1.
 		main_header.SetEncrypted();
 
-		if (options.encryption_options.encryption_version == EncryptionTypes::V0_1) {
-			if (db.GetStorageManager().GetStorageVersion() <
-			    SerializationCompatibility::FromString("v1.5.0").serialization_version) {
-				throw InvalidConfigurationException(
-				    "Encryption version 1+ is incompatible with a storage version lower then v1.5.0");
-			}
-		} else if (options.encryption_options.encryption_version == EncryptionTypes::NONE) {
-			// no explicit encryption options
-			if (db.GetStorageManager().GetStorageVersion() <
-			    SerializationCompatibility::FromString("v1.5.0").serialization_version) {
-				options.encryption_options.encryption_version = EncryptionTypes::V0_0;
-			} else {
-				options.encryption_options.encryption_version = EncryptionTypes::V0_1;
-				// for the newer encrypted versions, set the storage version to 1.5.0
-				db.GetStorageManager().SetStorageVersion(
-				    SerializationCompatibility::FromString("v1.5.0").serialization_version);
-			}
+		if (options.encryption_options.encryption_version == EncryptionTypes::NONE) {
+			throw InvalidConfigurationException("No Encryption type set");
 		}
 		main_header.SetEncryptionVersion(options.encryption_options.encryption_version);
 

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -247,8 +247,7 @@ MainHeader MainHeader::Read(ReadStream &source) {
 	for (idx_t i = 0; i < FLAG_COUNT; i++) {
 		header.flags[i] = source.Read<uint64_t>();
 	}
-
-	DeserializeVersionNumber(source, header.library_git_desc);
+	` DeserializeVersionNumber(source, header.library_git_desc);
 	DeserializeVersionNumber(source, header.library_git_hash);
 
 	// We always deserialize, and read zeros, if not set.

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -24,6 +24,7 @@ namespace duckdb {
 using SHA256State = duckdb_mbedtls::MbedTlsWrapper::SHA256State;
 
 void StorageOptions::SetEncryptionVersion(string &storage_version_user_provided) {
+
 	// storage version < v1.4.0
 	if (!storage_version.IsValid() ||
 	    storage_version.GetIndex() < SerializationCompatibility::FromString("v1.4.0").serialization_version) {
@@ -52,7 +53,6 @@ void StorageOptions::SetEncryptionVersion(string &storage_version_user_provided)
 			if (!storage_version_user_provided.empty()) {
 				if (encryption_version == target_encryption_version) {
 					// encryption version is explicitly given, but not compatible with < v1.5.0
-					if (!storage_version_user_provided.empty()) {
 						throw InvalidInputException("Explicit provided STORAGE_VERSION (\"%s\") is not compatible with "
 						                            "'debug_encryption_version = v1' (storage >= "
 						                            "v1.5.0)",
@@ -63,7 +63,6 @@ void StorageOptions::SetEncryptionVersion(string &storage_version_user_provided)
 					target_encryption_version = EncryptionTypes::V0_0;
 					break;
 				}
-			}
 		}
 
 		break;

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -62,6 +62,8 @@ void StorageOptions::Initialize(const unordered_map<string, Value> &options) {
 			} else {
 				compress_in_memory = CompressInMemory::DO_NOT_COMPRESS;
 			}
+		} else if (entry.first == "debug_encryption_version") {
+			encryption_version = EncryptionTypes::StringToVersion(entry.second.ToString());
 		} else {
 			throw BinderException("Unrecognized option for attach \"%s\"", entry.first);
 		}
@@ -325,6 +327,7 @@ void SingleFileStorageManager::LoadDatabase(QueryContext context) {
 		D_ASSERT(storage_options.block_header_size == DEFAULT_ENCRYPTION_BLOCK_HEADER_SIZE);
 		options.encryption_options.encryption_enabled = true;
 		options.encryption_options.user_key = std::move(storage_options.user_key);
+		options.encryption_options.encryption_version = storage_options.encryption_version;
 	}
 
 	idx_t row_group_size = DEFAULT_ROW_GROUP_SIZE;

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -88,10 +88,14 @@ void StorageOptions::Initialize(const unordered_map<string, Value> &options) {
 			encryption_version = EncryptionTypes::V0_0;
 		}
 
-		if (encryption_version == EncryptionTypes::NONE || encryption_version == EncryptionTypes::V0_1) {
-			encryption_version = EncryptionTypes::V0_1;
+		if (storage_version_user_provided.empty()) {
 			// set storage version explicitly
 			storage_version = SerializationCompatibility::FromString("v1.5.0").serialization_version;
+		}
+
+		if (encryption_version == EncryptionTypes::NONE) {
+			// set default to encryption version v1
+			encryption_version = EncryptionTypes::V0_1;
 		}
 	}
 }

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -24,7 +24,6 @@ namespace duckdb {
 using SHA256State = duckdb_mbedtls::MbedTlsWrapper::SHA256State;
 
 void StorageOptions::SetEncryptionVersion(string &storage_version_user_provided) {
-
 	// storage version < v1.4.0
 	if (!storage_version.IsValid() ||
 	    storage_version.GetIndex() < SerializationCompatibility::FromString("v1.4.0").serialization_version) {
@@ -53,16 +52,16 @@ void StorageOptions::SetEncryptionVersion(string &storage_version_user_provided)
 			if (!storage_version_user_provided.empty()) {
 				if (encryption_version == target_encryption_version) {
 					// encryption version is explicitly given, but not compatible with < v1.5.0
-						throw InvalidInputException("Explicit provided STORAGE_VERSION (\"%s\") is not compatible with "
-						                            "'debug_encryption_version = v1' (storage >= "
-						                            "v1.5.0)",
-						                            storage_version_user_provided);
-					}
-				} else {
-					// encryption version needs to be lowered, because storage version < v1.5.0
-					target_encryption_version = EncryptionTypes::V0_0;
-					break;
+					throw InvalidInputException("Explicit provided STORAGE_VERSION (\"%s\") is not compatible with "
+					                            "'debug_encryption_version = v1' (storage >= "
+					                            "v1.5.0)",
+					                            storage_version_user_provided);
 				}
+			} else {
+				// encryption version needs to be lowered, because storage version < v1.5.0
+				target_encryption_version = EncryptionTypes::V0_0;
+				break;
+			}
 		}
 
 		break;

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -76,8 +76,21 @@ void StorageOptions::Initialize(const unordered_map<string, Value> &options) {
 			    "Explicit provided STORAGE_VERSION (\"%s\") and ENCRYPTION_KEY (storage >= v1.4.0) are not compatible",
 			    storage_version_user_provided);
 		}
-		// set storage version to v1.4.0
-		storage_version = SerializationCompatibility::FromString("v1.4.0").serialization_version;
+		// explicit storage version input
+		if (!storage_version_user_provided.empty() &&
+		    storage_version.GetIndex() < SerializationCompatibility::FromString("v1.5.0").serialization_version) {
+			// user input: encryption v1
+			if (encryption_version == EncryptionTypes::V0_1) {
+				throw InvalidConfigurationException(
+				    "Encryption version explicitly set to V1, but storage version is not compatible");
+			}
+			// no user input for encryption, but input storage version DuckDB < 1.5.0
+			if (encryption_version == EncryptionTypes::NONE) {
+				// we automatically change the encryption version to a supported version
+				encryption_version = EncryptionTypes::V0_0;
+			}
+		}
+		storage_version = SerializationCompatibility::FromString("v1.5.0").serialization_version;
 	}
 }
 

--- a/test/sql/attach/attach_encryption_block_header.test
+++ b/test/sql/attach/attach_encryption_block_header.test
@@ -70,7 +70,7 @@ SELECT SUM(i) FROM encrypted.tbl
 query I
 SELECT tags FROM duckdb_databases() WHERE database_name LIKE '%encrypted%' ORDER BY database_name;
 ----
-{storage_version=v1.4.0+}
+{storage_version=v1.5.0+}
 {storage_version=v1.0.0+}
 
 statement ok

--- a/test/sql/copy/encryption/reencrypt.test_slow
+++ b/test/sql/copy/encryption/reencrypt.test_slow
@@ -48,7 +48,7 @@ DETACH reencrypted
 statement error
 ATTACH '__TEST_DIR__/reencrypted.duckdb' AS reencrypted (ENCRYPTION_KEY 'asdf');
 ----
-Wrong encryption key used to open the database file
+Invalid Input Error: Wrong encryption key used to open the database file
 
 statement ok
 ATTACH '__TEST_DIR__/reencrypted.duckdb' AS reencrypted (ENCRYPTION_KEY 'xxxx');

--- a/test/sql/copy/encryption/test_different_encryption_versions.test
+++ b/test/sql/copy/encryption/test_different_encryption_versions.test
@@ -14,7 +14,7 @@ PRAGMA enable_verification
 statement error
 ATTACH '__TEST_DIR__/encrypted_invalid.duckdb' AS encrypted_invalid (ENCRYPTION_KEY 'asdf', STORAGE_VERSION 'v1.4.0', debug_encryption_version 'v1');
 ----
-Encryption version 1+ is incompatible with a storage version lower then v1.5.0
+Encryption version explicitly set to V1, but storage version is not compatible
 
 statement ok
 ATTACH '__TEST_DIR__/encrypted_storage.duckdb' AS encrypted_storage_version (ENCRYPTION_KEY 'asdf', STORAGE_VERSION 'v1.4.0');

--- a/test/sql/copy/encryption/test_different_encryption_versions.test
+++ b/test/sql/copy/encryption/test_different_encryption_versions.test
@@ -14,16 +14,31 @@ PRAGMA enable_verification
 statement error
 ATTACH '__TEST_DIR__/encrypted_invalid.duckdb' AS encrypted_invalid (ENCRYPTION_KEY 'asdf', STORAGE_VERSION 'v1.4.0', debug_encryption_version 'v1');
 ----
-Encryption version explicitly set to V1, but storage version is not compatible
+Invalid Input Error: Explicit provided STORAGE_VERSION ("v1.4.0") is not compatible with 'debug_encryption_version=v1' (storage >= v1.5.0)
 
 statement ok
 ATTACH '__TEST_DIR__/encrypted_storage.duckdb' AS encrypted_storage_version (ENCRYPTION_KEY 'asdf', STORAGE_VERSION 'v1.4.0');
 
+query I
+SELECT tags['storage_version'] FROM duckdb_databases() WHERE database_name='encrypted_storage_version'
+----
+v1.4.0+
+
 statement ok
 ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v0');
 
+query I
+SELECT tags['storage_version'] FROM duckdb_databases() WHERE database_name='encrypted_v0'
+----
+v1.5.0+
+
 statement ok
 ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v1');
+
+query I
+SELECT tags['storage_version'] FROM duckdb_databases() WHERE database_name='encrypted_v1'
+----
+v1.5.0+
 
 statement error
 ATTACH '__TEST_DIR__/encrypted_error.duckdb' AS encrypted_error (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v2');

--- a/test/sql/copy/encryption/test_different_encryption_versions.test
+++ b/test/sql/copy/encryption/test_different_encryption_versions.test
@@ -1,0 +1,92 @@
+# name: test/sql/copy/encryption/test_different_encryption_versions.test
+# group: [encryption]
+
+require skip_reload
+
+require tpch
+
+# We need httpfs to do encrypted writes
+require httpfs
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version '0');
+
+statement ok
+ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version '1');
+
+statement ok
+ATTACH '__TEST_DIR__/unencrypted.duckdb' as unencrypted;
+
+statement ok
+USE unencrypted;
+
+statement ok
+CALL dbgen(sf=0.01);
+
+statement ok
+COPY FROM DATABASE unencrypted to encrypted_v0;
+
+statement ok
+COPY FROM DATABASE unencrypted to encrypted_v1;
+
+statement ok
+ATTACH '__TEST_DIR__/not_relevant.duckdb' AS other;
+
+statement ok
+USE other;
+
+statement ok
+DETACH unencrypted
+
+statement ok
+DETACH encrypted_v0
+
+statement ok
+DETACH encrypted_v1
+
+statement error
+ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version '1');
+----
+Invalid Input Error: Encryption version mismatch. Database encryption version is 1, attempted to decrypt version 0
+
+statement error
+ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version '0');
+----
+Invalid Input Error: Encryption version mismatch. Database encryption version is 0, attempted to decrypt version 1
+
+statement ok
+ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version '0');
+
+statement ok
+ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version '1');
+
+query I
+SELECT l_suppkey FROM encrypted_v0.lineitem limit 10;
+----
+93
+75
+38
+48
+23
+10
+33
+19
+70
+60
+
+query I
+SELECT l_suppkey FROM encrypted_v1.lineitem limit 10;
+----
+93
+75
+38
+48
+23
+10
+33
+19
+70
+60

--- a/test/sql/copy/encryption/test_different_encryption_versions.test
+++ b/test/sql/copy/encryption/test_different_encryption_versions.test
@@ -66,26 +66,17 @@ DETACH encrypted_v0
 statement ok
 DETACH encrypted_v1
 
-statement error
+# the setting of debug_encryption_version gets overridden
+# if the (de)serialized encryption version differs
+statement ok
 ATTACH '__TEST_DIR__/encrypted_storage.duckdb' AS encrypted_storage_version (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v1');
-----
-Invalid Input Error: Encryption version mismatch. Database encryption version is 1, attempted to decrypt version 0
 
-statement error
-ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v1');
-----
-Invalid Input Error: Encryption version mismatch. Database encryption version is 1, attempted to decrypt version 0
-
-statement error
+statement ok
 ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v0');
-----
-Invalid Input Error: Encryption version mismatch. Database encryption version is 0, attempted to decrypt version 1
 
 statement ok
 ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v0');
 
-statement ok
-ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v1');
 
 query I
 SELECT l_suppkey FROM encrypted_v0.lineitem limit 10;

--- a/test/sql/copy/encryption/test_different_encryption_versions.test
+++ b/test/sql/copy/encryption/test_different_encryption_versions.test
@@ -14,7 +14,7 @@ PRAGMA enable_verification
 statement error
 ATTACH '__TEST_DIR__/encrypted_invalid.duckdb' AS encrypted_invalid (ENCRYPTION_KEY 'asdf', STORAGE_VERSION 'v1.4.0', debug_encryption_version 'v1');
 ----
-Invalid Input Error: Explicit provided STORAGE_VERSION ("v1.4.0") is not compatible with 'debug_encryption_version=v1' (storage >= v1.5.0)
+Explicit provided STORAGE_VERSION ("v1.4.0") is not compatible with 'debug_encryption_version = v1' (storage >= v1.5.0)
 
 statement ok
 ATTACH '__TEST_DIR__/encrypted_storage.duckdb' AS encrypted_storage_version (ENCRYPTION_KEY 'asdf', STORAGE_VERSION 'v1.4.0');

--- a/test/sql/copy/encryption/test_different_encryption_versions.test
+++ b/test/sql/copy/encryption/test_different_encryption_versions.test
@@ -11,11 +11,24 @@ require httpfs
 statement ok
 PRAGMA enable_verification
 
-statement ok
-ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version '0');
+statement error
+ATTACH '__TEST_DIR__/encrypted_invalid.duckdb' AS encrypted_invalid (ENCRYPTION_KEY 'asdf', STORAGE_VERSION 'v1.4.0', debug_encryption_version 'v1');
+----
+Encryption version 1+ is incompatible with a storage version lower then v1.5.0
 
 statement ok
-ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version '1');
+ATTACH '__TEST_DIR__/encrypted_storage.duckdb' AS encrypted_storage_version (ENCRYPTION_KEY 'asdf', STORAGE_VERSION 'v1.4.0');
+
+statement ok
+ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v0');
+
+statement ok
+ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v1');
+
+statement error
+ATTACH '__TEST_DIR__/encrypted_error.duckdb' AS encrypted_error (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v2');
+----
+Not implemented Error: No encryption version higher then v1 is supported yet in this DuckDB version
 
 statement ok
 ATTACH '__TEST_DIR__/unencrypted.duckdb' as unencrypted;
@@ -25,6 +38,9 @@ USE unencrypted;
 
 statement ok
 CALL dbgen(sf=0.01);
+
+statement ok
+COPY FROM DATABASE unencrypted to encrypted_storage_version;
 
 statement ok
 COPY FROM DATABASE unencrypted to encrypted_v0;
@@ -39,6 +55,9 @@ statement ok
 USE other;
 
 statement ok
+DETACH encrypted_storage_version;
+
+statement ok
 DETACH unencrypted
 
 statement ok
@@ -48,20 +67,25 @@ statement ok
 DETACH encrypted_v1
 
 statement error
-ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version '1');
+ATTACH '__TEST_DIR__/encrypted_storage.duckdb' AS encrypted_storage_version (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v1');
 ----
 Invalid Input Error: Encryption version mismatch. Database encryption version is 1, attempted to decrypt version 0
 
 statement error
-ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version '0');
+ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v1');
+----
+Invalid Input Error: Encryption version mismatch. Database encryption version is 1, attempted to decrypt version 0
+
+statement error
+ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v0');
 ----
 Invalid Input Error: Encryption version mismatch. Database encryption version is 0, attempted to decrypt version 1
 
 statement ok
-ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version '0');
+ATTACH '__TEST_DIR__/encrypted_v0_0.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v0');
 
 statement ok
-ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version '1');
+ATTACH '__TEST_DIR__/encrypted_v0_1.duckdb' AS encrypted_v1 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v1');
 
 query I
 SELECT l_suppkey FROM encrypted_v0.lineitem limit 10;

--- a/test/sql/copy/encryption/write_encrypted_database.test
+++ b/test/sql/copy/encryption/write_encrypted_database.test
@@ -30,7 +30,7 @@ ATTACH '__TEST_DIR__/encrypted.duckdb' AS encrypted;
 statement error
 ATTACH '__TEST_DIR__/encrypted.duckdb' AS encrypted (ENCRYPTION_KEY 'xxxxx');
 ----
-IO Error: Wrong encryption key used to open the database file
+Invalid Input Error: Wrong encryption key used to open the database file
 
 statement ok
 ATTACH '__TEST_DIR__/encrypted.duckdb' AS encrypted (ENCRYPTION_KEY 'asdf');


### PR DESCRIPTION
This PR makes sure to use a randomized IV/nonce and tag for the encrypted canary, which is necessary to meet the NIST requirements. To strengthen the security a bit, in newer encrypted files the canary is always en/decrypted with AES GCM.

I used an extra byte of the encryption metadata, which now indicates the DuckDB encryption version. Reading older versions of encrypted database files remains possible. Writing older (v0) encrypted files is also still possible, but it requires explicitly setting the older version with `debug_encryption_version 'v0'`, such that:

`ATTACH 'encrypted.duckdb' AS encrypted_v0 (ENCRYPTION_KEY 'asdf', debug_encryption_version 'v0');` 

Note that changing the IV/nonce to 12-bytes will be addressed in a follow-up PR since this requires some more refactoring for backwards compatibility, and for the OpenSSL API (the GCM cipher requires a 12-byte input IV and for CTR this is 16: 12 bytes + the 4-byte counter which we need to initialize ourselves). However, changing back the default IV size is not strictly necessary for meeting the NIST requirements.

Fixes https://github.com/duckdb/duckdb/issues/20162 and https://github.com/duckdblabs/duckdb-internal/issues/6891

