### PR TITLE
Fix try cast for variant to incompatible struct types

### DIFF
--- a/test/sql/types/variant/try_cast_from_variant.test
+++ b/test/sql/types/variant/try_cast_from_variant.test
@@ -12,6 +12,16 @@ select try_cast('hello world'::variant as STRUCT(a varchar, b boolean));
 NULL
 
 query I
+select try_cast({'a': true, 'b': 'foo'}::variant as STRUCT(a varchar, b boolean));
+----
+NULL
+
+query I
+select try_cast({'c': true, 'd': 'foo'}::variant as STRUCT(a varchar, b boolean));
+----
+NULL
+
+query I
 select try_cast('hello world'::variant as INTEGER[]);
 ----
 NULL


### PR DESCRIPTION
Doing a try_cast on a variant value containing a struct that had no matching members with the cast target struct was failing with `Binder Error: STRUCT to STRUCT cast must have at least one matching member`.

This adds a test for that case and handles it correctly by setting it to null.