### PR TITLE
[minor] Address compilation warnings

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -390,7 +390,7 @@ void ColumnReader::PreparePage(PageHeader &page_hdr) {
 	}
 
 	if (chunk->meta_data.codec == CompressionCodec::UNCOMPRESSED) {
-		if (compressed_page_size != page_hdr.uncompressed_page_size) {
+		if (compressed_page_size != static_cast<uint32_t>(page_hdr.uncompressed_page_size)) {
 			throw std::runtime_error("Page size mismatch");
 		}
 		ReadData(block->ptr, compressed_page_size, page_hdr.type);

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -24,9 +24,10 @@
 
 #include "zstd.h"
 
-#include "duckdb/storage/table/column_segment.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/types/bit.hpp"
+#include "duckdb/storage/table/column_segment.hpp"
 
 #include "parquet_crypto.hpp"
 
@@ -390,7 +391,7 @@ void ColumnReader::PreparePage(PageHeader &page_hdr) {
 	}
 
 	if (chunk->meta_data.codec == CompressionCodec::UNCOMPRESSED) {
-		if (compressed_page_size != static_cast<uint32_t>(page_hdr.uncompressed_page_size)) {
+		if (compressed_page_size != NumericCast<uint32_t>(page_hdr.uncompressed_page_size)) {
 			throw std::runtime_error("Page size mismatch");
 		}
 		ReadData(block->ptr, compressed_page_size, page_hdr.type);

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2459,7 +2459,7 @@ int ShellState::DoMetaCommand(const string &zLine) {
 				PrintF(PrintOutput::STDERR, "Command \"%s\" is unsupported in the current version of the CLI\n",
 				       command.command);
 				result = MetadataResult::FAIL;
-			} else if (command.argument_count == 0 || int(command.argument_count) == args.size()) {
+			} else if (command.argument_count == 0 || command.argument_count == args.size()) {
 				result = command.callback(*this, args);
 			}
 			if (result == MetadataResult::PRINT_USAGE) {

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -655,7 +655,7 @@ private:
 	*/
 	void PrintBoxRowSeparator(PrintStream &out, idx_t nArg, const char *zSep1, const char *zSep2, const char *zSep3,
 	                          const vector<idx_t> &actualWidth) {
-		int i;
+		idx_t i;
 		if (nArg > 0) {
 			out.Print(zSep1);
 			PrintBoxLine(out, actualWidth[0] + 2);


### PR DESCRIPTION
I get the following compilation warnings under debug build.
```sh
/home/vscode/duckdb/tools/shell/shell.cpp: In member function 'int duckdb_shell::ShellState::DoMetaCommand(const std::string&)':
/home/vscode/duckdb/tools/shell/shell.cpp:2462:95: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char>, std::allocator<std::__cxx11::basic_string<char> > >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
 2462 |                         } else if (command.argument_count == 0 || int(command.argument_count) == args.size()) {
      |                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
/home/vscode/duckdb/tools/shell/shell_renderer.cpp: In member function 'void duckdb_shell::ModeBoxRenderer::PrintBoxRowSeparator(duckdb_shell::PrintStream&, duckdb_shell::idx_t, const char*, const char*, const char*, const duckdb::vector<long unsigned int>&)':
/home/vscode/duckdb/tools/shell/shell_renderer.cpp:662:39: warning: comparison of integer expressions of different signedness: 'int' and 'duckdb_shell::idx_t' {aka 'long unsigned int'} [-Wsign-compare]
  662 |                         for (i = 1; i < nArg; i++) {
      |                                     ~~^~~~~~

/home/vscode/duckdb/extension/parquet/column_reader.cpp:393:42: warning: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'int32_t' {aka 'int'} [-Wsign-compare]
  393 |                 if (compressed_page_size != page_hdr.uncompressed_page_size) {
      |                     ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```