### PR TITLE
Set payload pointers when copying sort keys to tuple data

### DIFF
--- a/src/common/sort/sorted_run.cpp
+++ b/src/common/sort/sorted_run.cpp
@@ -372,12 +372,18 @@ static void TemplatedReorder(ClientContext &context, unique_ptr<TupleDataCollect
 		for (idx_t i = 0; i < next; i++) {
 			key_ptrs[i] = &*it++;
 		}
-		if (!SORT_KEY::CONSTANT_SIZE) {
-			ReorderKeyData<SORT_KEY>(*new_key_data, new_key_data_append_state, new_key_data_input, next);
-		}
 		if (SORT_KEY::HAS_PAYLOAD) {
 			ReorderPayloadData<SORT_KEY>(*new_payload_data, new_payload_data_append_state, key_ptrs,
 			                             new_payload_data_input, next);
+			const auto new_payload_locations =
+			    FlatVector::GetData<const data_ptr_t>(new_payload_data_append_state.chunk_state.row_locations);
+			for (idx_t i = 0; i < next; i++) {
+				auto &key = *key_ptrs[i];
+				key.SetPayload(new_payload_locations[i]);
+			}
+		}
+		if (!SORT_KEY::CONSTANT_SIZE) {
+			ReorderKeyData<SORT_KEY>(*new_key_data, new_key_data_append_state, new_key_data_input, next);
 		}
 		index += next;
 	}

--- a/src/common/types/row/tuple_data_allocator.cpp
+++ b/src/common/types/row/tuple_data_allocator.cpp
@@ -353,16 +353,16 @@ template <SortKeyType SORT_KEY_TYPE>
 void TemplatedSortKeySetPayload(const data_ptr_t row_locations[], const idx_t offset, const idx_t count,
                                 TupleDataChunkState &sort_key_chunk_state) {
 	using SORT_KEY = SortKey<SORT_KEY_TYPE>;
-	const auto sort_keys = FlatVector::GetData<SORT_KEY *const>(sort_key_chunk_state.row_locations);
+	const auto sort_keys =
+	    reinterpret_cast<SORT_KEY **const>(FlatVector::GetData<data_ptr_t>(sort_key_chunk_state.row_locations));
 
 	lock_guard<mutex> guard(*sort_key_chunk_state.chunk_lock);
-	if (sort_keys[offset]->GetPayload() == row_locations[offset]) {
-		return; // Still the same
-	}
-
-	// Changed: set new pointers
-	for (idx_t i = offset; i < offset + count; i++) {
-		sort_keys[i]->SetPayload(row_locations[i]);
+	// Set new pointers
+	for (idx_t i = 0; i < count; i++) {
+		auto &sort_key = sort_keys[offset + i];
+		if (sort_key->GetPayload() != row_locations[offset + i]) {
+			sort_key->SetPayload(row_locations[offset + i]);
+		}
 	}
 }
 
@@ -412,7 +412,7 @@ void TupleDataAllocator::InitializeChunkStateInternal(TupleDataPinState &pin_sta
 		}
 
 		if (sort_key_payload_state) {
-			D_ASSERT(!layout.IsSortKeyLayout());
+			D_ASSERT(!layout.IsSortKeyLayout()); // This must be the payload collection
 			lock_guard<mutex> guard(part.lock);
 			SortKeySetPayload(row_locations, offset, next, *sort_key_payload_state);
 		}


### PR DESCRIPTION
Made a wrong assumption in https://github.com/duckdb/duckdb/pull/20059. The pointers weren't set; this PR sets them.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/6858