### PR TITLE
Throw exception if there is ARTKey mismatch

### DIFF
--- a/src/execution/index/art/art_key.cpp
+++ b/src/execution/index/art/art_key.cpp
@@ -160,7 +160,7 @@ idx_t ARTKey::GetMismatchPos(const ARTKey &other, const idx_t start) const {
 			return i;
 		}
 	}
-	return DConstants::INVALID_INDEX;
+	throw InternalException("ARTKey::GetMismatchPos: INVALID INDEX");
 }
 
 } // namespace duckdb

--- a/src/execution/index/art/art_key.cpp
+++ b/src/execution/index/art/art_key.cpp
@@ -160,7 +160,7 @@ idx_t ARTKey::GetMismatchPos(const ARTKey &other, const idx_t start) const {
 			return i;
 		}
 	}
-	throw InternalException("ARTKey::GetMismatchPos: INVALID INDEX");
+	throw FatalException("Corrupted ART index - likely the same row id was inserted twice into the same ART");
 }
 
 } // namespace duckdb


### PR DESCRIPTION
For https://github.com/duckdblabs/duckdb-internal/issues/6841 -- not an important bug fix, just improving error output to make it throw instead of crash, so this is going on main.

Throw an exception if there is an ARTKey mismatch. Before, it was returning an INVALID_INDEX constant which was not being handled anywhere, which led to a SIGSEGV failure.

Technically, this could be handled higher up, but this function is only invoked from one place, and the likely scenario is attempting to insert a duplicate rowid on a corrupted ART (since to get to the end of the loop, all the bytes have to match). Throwing here avoids having to either 1) do a check on the return value of the function in the majority of cases where the ART is not corrupted or 2) only having the check work on debug mode. 