### PR TITLE
Fix extentension-ci-tools to latest release version in the v1.4-andium branch

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   build:
     name: Build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.3
     with:
       # We piggy-back extension-template to build the extensions in extension_config, it's hacky, but it works ¯\_(ツ)_/¯
       override_repository: duckdb/extension-template
@@ -56,7 +56,7 @@ jobs:
 
       # CI tools is pinned to main
       override_ci_tools_repository: duckdb/extension-ci-tools
-      ci_tools_version: main
+      ci_tools_version: v1.4.3
 
       exclude_archs: ${{ inputs.exclude_archs }}
       opt_in_archs: ${{ inputs.opt_in_archs }}


### PR DESCRIPTION
This would need to be first merged into main, and then reverted, for added fun, somewhat similarly to the MAIN_BRANCH_VERSIONING.