### PR TITLE
Merge `v1.4-andium` into `main`

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(httpfs
     LOAD TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 9c7d34977b10346d0b4cbbde5df807d1dab0b2bf
+    GIT_TAG 7bd8c9cb1801dab374b63ac15ade1ba29c501b1e
     INCLUDE_DIR src/include
 )

--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,7 +1,7 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 7bd8c9cb1801dab374b63ac15ade1ba29c501b1e
+    GIT_TAG 6c187d86edde066adb2c51a411f3b6020da79e12
     APPLY_PATCHES
     INCLUDE_DIR src/include
 )

--- a/.github/patches/extensions/httpfs/skip_header_test.patch
+++ b/.github/patches/extensions/httpfs/skip_header_test.patch
@@ -1,0 +1,14 @@
+diff --git a/test/sql/test_headers_parsed.test b/test/sql/test_headers_parsed.test
+index 566ffe5..f288c4d 100644
+--- a/test/sql/test_headers_parsed.test
++++ b/test/sql/test_headers_parsed.test
+@@ -6,6 +6,9 @@ require httpfs
+ 
+ require parquet
+ 
++# Needs to be understood what's wrong with this test after changes in both duckdb & duckdb-httpfs
++mode skip
++
+ statement ok
+ SET httpfs_client_implementation='curl';
+ 

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -332,16 +332,17 @@ jobs:
         run: CORE_EXTENSIONS="tpch" make
 
       - name: Start Minio
-        working-directory: $GITHUB_WORKSPACE/duckdb-httpfs
+        working-directory: ${{ github.workspace }}/duckdb-httpfs
         shell: bash
         run: |
+          export PATH="${{ github.workspace }}/build/release:$PATH"
           sudo ./scripts/install_s3_test_server.sh
           ./scripts/generate_presigned_url.sh
           source ./scripts/run_s3_test_server.sh
           source ./scripts/set_s3_test_server_variables.sh
           sleep 60
 
-      - name: Build
+      - name: Run Extension Medata Tests
         shell: bash
         run: |
           ./scripts/run_extension_medata_tests.sh

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -296,6 +296,10 @@ jobs:
           sudo rm -rf /var/lib/apt/lists/*
           docker system prune -af || true
           rm -rf ~/.cache
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           echo "Disk usage after clean up:"
           df -h
 

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -288,20 +288,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Cleanup disk before build
-        run: |
-          echo "Disk usage before clean up:"
-          df -h
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          docker system prune -af || true
-          rm -rf ~/.cache
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          echo "Disk usage after clean up:"
-          df -h
+
+      - uses: ./.github/actions/cleanup_runner
 
       - name: Checkout duckdb-httpfs
         uses: actions/checkout@v4

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -288,6 +288,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Cleanup disk before build
+        run: |
+          echo "Disk usage before clean up:"
+          df -h
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          docker system prune -af || true
+          rm -rf ~/.cache
+          echo "Disk usage after clean up:"
+          df -h
 
       - name: Checkout duckdb-httpfs
         uses: actions/checkout@v4

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -289,6 +289,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout duckdb-httpfs
+        uses: actions/checkout@v4
+        with:
+          repository: duckdb/duckdb-httpfs
+          path: duckdb-httpfs
+          sparse-checkout: scripts
+
       - name: Install
         shell: bash
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
@@ -312,6 +319,7 @@ jobs:
         run: CORE_EXTENSIONS="tpch" make
 
       - name: Start Minio
+        working-directory: $GITHUB_WORKSPACE/duckdb-httpfs
         shell: bash
         run: |
           sudo ./scripts/install_s3_test_server.sh

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -308,7 +308,6 @@ jobs:
         with:
           repository: duckdb/duckdb-httpfs
           path: duckdb-httpfs
-          sparse-checkout: scripts
 
       - name: Install
         shell: bash

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -307,6 +307,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: duckdb/duckdb-httpfs
+          submodules: 'true'
           path: duckdb-httpfs
 
       - name: Install

--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -47,4 +47,4 @@ jobs:
          GH_TOKEN: ${{ secrets.GH_TOKEN }}
        run: |
          python3 scripts/asset-upload-gha.py to_be_uploaded/*
-         aws s3 cp to_be_uploaded/* "s3://duckdb-install/${{ inputs.target_git_describe }}
+         aws s3 sync --content-type application/octet-stream to_be_uploaded "s3://duckdb-install/${{ inputs.target_git_describe }}"

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   build:
     name: Build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.3
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       # We piggy-back extension-template to build the extensions in extension_config, it's hacky, but it works ¯\_(ツ)_/¯
       override_repository: duckdb/extension-template
@@ -56,7 +56,7 @@ jobs:
 
       # CI tools is pinned to main
       override_ci_tools_repository: duckdb/extension-ci-tools
-      ci_tools_version: v1.4.3
+      ci_tools_version: main
 
       exclude_archs: ${{ inputs.exclude_archs }}
       opt_in_archs: ${{ inputs.opt_in_archs }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   build:
     name: Build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.3
     with:
       # We piggy-back extension-template to build the extensions in extension_config, it's hacky, but it works ¯\_(ツ)_/¯
       override_repository: duckdb/extension-template
@@ -56,7 +56,7 @@ jobs:
 
       # CI tools is pinned to main
       override_ci_tools_repository: duckdb/extension-ci-tools
-      ci_tools_version: main
+      ci_tools_version: v1.4.3
 
       exclude_archs: ${{ inputs.exclude_archs }}
       opt_in_archs: ${{ inputs.opt_in_archs }}

--- a/extension/core_functions/aggregate/holistic/mode.cpp
+++ b/extension/core_functions/aggregate/holistic/mode.cpp
@@ -234,15 +234,12 @@ struct BaseModeFunction {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
 		if (!source.frequency_map) {
 			return;
 		}
 		if (!target.frequency_map) {
-			// Copy - don't destroy! Otherwise windowing will break.
-			target.frequency_map = new typename STATE::Counts(*source.frequency_map);
-			target.count = source.count;
-			return;
+			target.frequency_map = TYPE_OP::CreateEmpty(aggr_input_data.allocator);
 		}
 		for (auto &val : *source.frequency_map) {
 			auto &i = (*target.frequency_map)[val.first];

--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -1161,12 +1161,21 @@ AdbcStatusCode StatementSetOption(struct AdbcStatement *statement, const char *k
 	return ADBC_STATUS_INVALID_ARGUMENT;
 }
 
+std::string createFilter(const char *input) {
+	if (input) {
+		auto quoted = duckdb::KeywordHelper::WriteQuoted(input, '\'');
+		return quoted;
+	}
+	return "'%'";
+}
+
 AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth, const char *catalog,
                                     const char *db_schema, const char *table_name, const char **table_type,
                                     const char *column_name, struct ArrowArrayStream *out, struct AdbcError *error) {
-	std::string catalog_filter = catalog ? catalog : "%";
-	std::string db_schema_filter = db_schema ? db_schema : "%";
-	std::string table_name_filter = table_name ? table_name : "%";
+	std::string catalog_filter = createFilter(catalog);
+	std::string db_schema_filter = createFilter(db_schema);
+	std::string table_name_filter = createFilter(table_name);
+	std::string column_name_filter = createFilter(column_name);
 	std::string table_type_condition = "";
 	if (table_type && table_type[0]) {
 		table_type_condition = " AND table_type IN (";
@@ -1182,13 +1191,10 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 			if (i > 0) {
 				table_type_condition += ", ";
 			}
-			table_type_condition += "'";
-			table_type_condition += table_type[i];
-			table_type_condition += "'";
+			table_type_condition += createFilter(table_type[i]);
 		}
 		table_type_condition += ")";
 	}
-	std::string column_name_filter = column_name ? column_name : "%";
 
 	std::string query;
 	switch (depth) {
@@ -1233,7 +1239,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 					)[] catalog_db_schemas
 				FROM
 					information_schema.schemata
-				WHERE catalog_name LIKE '%s'
+				WHERE catalog_name LIKE %s
 				GROUP BY catalog_name
 				)",
 		                                   catalog_filter);
@@ -1246,7 +1252,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 						catalog_name,
 						schema_name,
 					FROM information_schema.schemata
-					WHERE schema_name LIKE '%s'
+					WHERE schema_name LIKE %s
 				)
 
 				SELECT
@@ -1289,7 +1295,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 					information_schema.schemata
 				LEFT JOIN db_schemas dbs
 				USING (catalog_name, schema_name)
-				WHERE catalog_name LIKE '%s'
+				WHERE catalog_name LIKE %s
 				GROUP BY catalog_name
 				)",
 		                                   db_schema_filter, catalog_filter);
@@ -1333,7 +1339,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 							)[],
 						}) db_schema_tables
 					FROM information_schema.tables
-					WHERE table_name LIKE '%s'%s
+					WHERE table_name LIKE %s%s
 					GROUP BY table_catalog, table_schema
 				),
 				db_schemas AS (
@@ -1344,7 +1350,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 					FROM information_schema.schemata
 					LEFT JOIN tables
 					USING (catalog_name, schema_name)
-					WHERE schema_name LIKE '%s'
+					WHERE schema_name LIKE %s
 				)
 
 				SELECT
@@ -1357,7 +1363,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 					information_schema.schemata
 				LEFT JOIN db_schemas dbs
 				USING (catalog_name, schema_name)
-				WHERE catalog_name LIKE '%s'
+				WHERE catalog_name LIKE %s
 				GROUP BY catalog_name
 				)",
 		                                   table_name_filter, table_type_condition, db_schema_filter, catalog_filter);
@@ -1392,7 +1398,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 							xdbc_is_generatedcolumn: NULL::BOOLEAN,
 						}) table_columns
 					FROM information_schema.columns
-					WHERE column_name LIKE '%s'
+					WHERE column_name LIKE %s
 					GROUP BY table_catalog, table_schema, table_name
 				),
 				constraints AS (
@@ -1421,7 +1427,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 							constraint_column_names,
 							list_filter(
 								constraint_column_names,
-								lambda name: name LIKE '%s'
+								lambda name: name LIKE %s
 							)
 						)
 					GROUP BY database_name, schema_name, table_name
@@ -1441,7 +1447,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 					USING (table_catalog, table_schema, table_name)
 					LEFT JOIN constraints
 					USING (table_catalog, table_schema, table_name)
-					WHERE table_name LIKE '%s'%s
+					WHERE table_name LIKE %s%s
 					GROUP BY table_catalog, table_schema
 				),
 				db_schemas AS (
@@ -1452,7 +1458,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 					FROM information_schema.schemata
 					LEFT JOIN tables
 					USING (catalog_name, schema_name)
-					WHERE schema_name LIKE '%s'
+					WHERE schema_name LIKE %s
 				)
 
 				SELECT
@@ -1465,7 +1471,7 @@ AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth
 					information_schema.schemata
 				LEFT JOIN db_schemas dbs
 				USING (catalog_name, schema_name)
-				WHERE catalog_name LIKE '%s'
+				WHERE catalog_name LIKE %s
 				GROUP BY catalog_name
 				)",
 		                                   column_name_filter, column_name_filter, table_name_filter,

--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -477,6 +477,7 @@ SourceResultType PhysicalMergeInto::GetData(ExecutionContext &context, DataChunk
 		auto &child_lstate = *lstate.local_states[lstate.index];
 		OperatorSourceInput source_input {child_gstate, child_lstate, input.interrupt_state};
 
+		lstate.scan_chunk.Reset();
 		auto result = action.op->GetData(context, lstate.scan_chunk, source_input);
 		if (lstate.scan_chunk.size() > 0) {
 			// construct the result chunk
@@ -505,9 +506,13 @@ SourceResultType PhysicalMergeInto::GetData(ExecutionContext &context, DataChunk
 
 		if (result != SourceResultType::FINISHED) {
 			return result;
-		}
-		if (chunk.size() != 0) {
-			return SourceResultType::HAVE_MORE_OUTPUT;
+		} else {
+			lstate.index++;
+			if (lstate.index < actions.size()) {
+				return SourceResultType::HAVE_MORE_OUTPUT;
+			} else {
+				return SourceResultType::FINISHED;
+			}
 		}
 	}
 	return SourceResultType::FINISHED;

--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -473,6 +473,8 @@ SourceResultType PhysicalMergeInto::GetData(ExecutionContext &context, DataChunk
 			// no action to scan from
 			continue;
 		}
+		// found a good one
+		break;
 	}
 	if (lstate.index < actions.size()) {
 		auto &action = *actions[lstate.index];

--- a/src/execution/operator/persistent/physical_merge_into.cpp
+++ b/src/execution/operator/persistent/physical_merge_into.cpp
@@ -473,6 +473,10 @@ SourceResultType PhysicalMergeInto::GetData(ExecutionContext &context, DataChunk
 			// no action to scan from
 			continue;
 		}
+	}
+	if (lstate.index < actions.size()) {
+		auto &action = *actions[lstate.index];
+
 		auto &child_gstate = *gstate.global_states[lstate.index];
 		auto &child_lstate = *lstate.local_states[lstate.index];
 		OperatorSourceInput source_input {child_gstate, child_lstate, input.interrupt_state};

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -245,10 +245,10 @@ static bool CanPushdown(const ArrowType &type) {
 	case LogicalTypeId::UBIGINT:
 	case LogicalTypeId::FLOAT:
 	case LogicalTypeId::DOUBLE:
-	case LogicalTypeId::VARCHAR:
 		return true;
+	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::BLOB:
-		// PyArrow doesn't support binary view filters yet
+		// PyArrow doesn't support binary and string view filters yet
 		return type.GetTypeInfo<ArrowStringInfo>().GetSizeType() != ArrowVariableSizeType::VIEW;
 	case LogicalTypeId::DECIMAL: {
 		switch (duck_type.InternalType()) {

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -139,7 +139,7 @@ struct BaseRequest {
 	const string &url;
 	string path;
 	string proto_host_port;
-	const HTTPHeaders &headers;
+	HTTPHeaders headers;
 	HTTPParams &params;
 	//! Whether or not to return failed requests (instead of throwing)
 	bool try_request = false;
@@ -156,6 +156,14 @@ struct BaseRequest {
 	template <class TARGET>
 	const TARGET &Cast() const {
 		return reinterpret_cast<const TARGET &>(*this);
+	}
+
+	static HTTPHeaders MergeHeaders(const HTTPHeaders &headers, HTTPParams &params) {
+		HTTPHeaders result = headers;
+		for (const auto &header : params.extra_headers) {
+			result.Insert(header.first, header.second);
+		}
+		return result;
 	}
 };
 

--- a/src/include/duckdb/execution/merge_sort_tree.hpp
+++ b/src/include/duckdb/execution/merge_sort_tree.hpp
@@ -86,6 +86,8 @@ struct MergeSortTree {
 	using RunElements = array<RunElement, F>;
 	using Games = array<RunElement, F - 1>;
 
+	static constexpr ElementType INVALID = std::numeric_limits<ElementType>::max();
+
 	struct CompareElements {
 		explicit CompareElements(const CMP &cmp) : cmp(cmp) {
 		}
@@ -122,6 +124,9 @@ struct MergeSortTree {
 	pair<idx_t, idx_t> SelectNth(const SubFrames &frames, idx_t n) const;
 
 	inline ElementType NthElement(idx_t i) const {
+		if (tree.empty() || tree.front().first.empty()) {
+			return INVALID;
+		}
 		return tree.front().first[i];
 	}
 

--- a/src/include/duckdb/execution/operator/aggregate/physical_streaming_window.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_streaming_window.hpp
@@ -50,13 +50,13 @@ public:
 
 private:
 	void ExecuteFunctions(ExecutionContext &context, DataChunk &chunk, DataChunk &delayed,
-	                      GlobalOperatorState &gstate_p, OperatorState &state_p) const;
+	                      GlobalOperatorState &gstate_p) const;
 	void ExecuteInput(ExecutionContext &context, DataChunk &delayed, DataChunk &input, DataChunk &chunk,
-	                  GlobalOperatorState &gstate, OperatorState &state) const;
+	                  GlobalOperatorState &gstate) const;
 	void ExecuteDelayed(ExecutionContext &context, DataChunk &delayed, DataChunk &input, DataChunk &chunk,
-	                    GlobalOperatorState &gstate, OperatorState &state) const;
+	                    GlobalOperatorState &gstate) const;
 	void ExecuteShifted(ExecutionContext &context, DataChunk &delayed, DataChunk &input, DataChunk &chunk,
-	                    GlobalOperatorState &gstate, OperatorState &state) const;
+	                    GlobalOperatorState &gstate) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/aggregate/physical_streaming_window.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_streaming_window.hpp
@@ -30,7 +30,6 @@ public:
 
 public:
 	unique_ptr<GlobalOperatorState> GetGlobalOperatorState(ClientContext &context) const override;
-	unique_ptr<OperatorState> GetOperatorState(ExecutionContext &context) const override;
 
 	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
 	                           GlobalOperatorState &gstate, OperatorState &state) const override;

--- a/src/include/duckdb/function/window/window_collection.hpp
+++ b/src/include/duckdb/function/window/window_collection.hpp
@@ -86,6 +86,10 @@ public:
 	WindowCursor(const WindowCollection &paged, column_t col_idx);
 	WindowCursor(const WindowCollection &paged, vector<column_t> column_ids);
 
+	//! The row count of the paged collection
+	idx_t Count() const {
+		return paged.size();
+	}
 	//! Is the scan in range?
 	inline bool RowIsVisible(idx_t row_idx) const {
 		return (row_idx < state.next_row_index && state.current_row_index <= row_idx);

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -123,7 +123,7 @@ unique_ptr<HTTPResponse> HTTPUtil::Request(BaseRequest &request, unique_ptr<HTTP
 }
 
 BaseRequest::BaseRequest(RequestType type, const string &url, const HTTPHeaders &headers, HTTPParams &params)
-    : type(type), url(url), headers(headers), params(params) {
+    : type(type), url(url), headers(MergeHeaders(headers, params)), params(params) {
 	HTTPUtil::DecomposeURL(url, path, proto_host_port);
 }
 

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -191,9 +191,6 @@ private:
 		for (auto &entry : header_map) {
 			headers.insert(entry);
 		}
-		for (auto &entry : params.extra_headers) {
-			headers.insert(entry);
-		}
 		return headers;
 	}
 

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -367,7 +367,7 @@ FilterPushdownResult FilterCombiner::TryPushdownConstantFilter(TableFilterSet &t
 void ReplaceWithBoundReference(unique_ptr<Expression> &root_expr) {
 	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
 	    root_expr, [&](BoundColumnRefExpression &col_ref, unique_ptr<Expression> &expr) {
-		    expr = make_uniq<BoundReferenceExpression>(col_ref.return_type, 0ULL);
+		    expr = make_uniq<BoundReferenceExpression>(col_ref.alias, col_ref.return_type, 0ULL);
 	    });
 }
 

--- a/src/storage/compression/numeric_constant.cpp
+++ b/src/storage/compression/numeric_constant.cpp
@@ -156,7 +156,8 @@ void FiltersNullValues(const LogicalType &type, const TableFilter &filter, bool 
 		auto &expr_filter = filter.Cast<ExpressionFilter>();
 		auto &state = filter_state.Cast<ExpressionFilterState>();
 		Value val(type);
-		filters_nulls = expr_filter.EvaluateWithConstant(state.executor, val);
+		//! If the expression evaluates to true, containing only a NULL vector, it *must* be an IS NULL filter
+		filters_nulls = !expr_filter.EvaluateWithConstant(state.executor, val);
 		filters_valid_values = false;
 		break;
 	}

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -149,11 +149,6 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, BoundConstraint 
 
 	// ALTER COLUMN to add a new constraint.
 
-	// Clone the storage info vector or the table.
-	for (const auto &index_info : parent.info->index_storage_infos) {
-		info->index_storage_infos.push_back(IndexStorageInfo(index_info.name));
-	}
-
 	// Bind all indexes.
 	info->BindIndexes(context);
 

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -242,9 +242,7 @@ void ColumnSegment::ConvertToPersistent(QueryContext context, optional_ptr<Block
 	// Thus, we set the compression function to constant and reset the block buffer.
 	D_ASSERT(stats.statistics.IsConstant());
 	auto &config = DBConfig::GetConfig(db);
-	if (GetCompressionFunction().type != CompressionType::COMPRESSION_EMPTY) {
-		function = *config.GetCompressionFunction(CompressionType::COMPRESSION_CONSTANT, type.InternalType());
-	}
+	function = *config.GetCompressionFunction(CompressionType::COMPRESSION_CONSTANT, type.InternalType());
 	block.reset();
 }
 

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -2368,5 +2368,44 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		                "Table type must be \"LOCAL TABLE\", \"BASE TABLE\" or \"VIEW\": \"INVALID\"") == 0));
 		adbc_error.release(&adbc_error);
 	}
+
+	// Test input quoting protection
+	{
+		ADBCTestDatabase db("test_input_quoting");
+		db.CreateTable("test_table", db.QueryArrow("SELECT 42 as value"));
+
+		AdbcError adbc_error;
+		InitializeADBCError(&adbc_error);
+		ArrowArrayStream arrow_stream;
+
+		// Test catalog filter with special characters
+		auto status =
+		    AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_CATALOGS, "'; DROP TABLE test_table; --",
+		                             nullptr, nullptr, nullptr, nullptr, &arrow_stream, &adbc_error);
+		REQUIRE(status == ADBC_STATUS_OK);
+		// Verify table still exists after special characters in filter
+		auto res = db.Query("SELECT * FROM test_table");
+		REQUIRE(res->RowCount() == 1);
+		arrow_stream.release(&arrow_stream);
+
+		// Test schema filter with special characters
+		status = AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_DB_SCHEMAS, nullptr,
+		                                  "'; DROP TABLE test_table; --", nullptr, nullptr, nullptr, &arrow_stream,
+		                                  &adbc_error);
+		REQUIRE(status == ADBC_STATUS_OK);
+		// Verify table still exists
+		res = db.Query("SELECT * FROM test_table");
+		REQUIRE(res->RowCount() == 1);
+		arrow_stream.release(&arrow_stream);
+
+		// Test table name filter with special characters
+		status = AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, nullptr, nullptr,
+		                                  "'; DROP TABLE test_table; --", nullptr, nullptr, &arrow_stream, &adbc_error);
+		REQUIRE(status == ADBC_STATUS_OK);
+		// Verify table still exists
+		res = db.Query("SELECT * FROM test_table");
+		REQUIRE(res->RowCount() == 1);
+		arrow_stream.release(&arrow_stream);
+	}
 }
 } // namespace duckdb

--- a/test/sql/aggregate/aggregates/test_mode.test
+++ b/test/sql/aggregate/aggregates/test_mode.test
@@ -306,3 +306,18 @@ VALUES
 )items_per_order(order_occurrences, item_count);
 ----
 1000
+
+# Parallel combine with UTF-8 strings (use-after-free bug in Combine)
+statement ok
+PRAGMA threads=4;
+
+statement ok
+CREATE TABLE mode_utf8 AS
+SELECT g, (['চৌদ্দগ্রাম', 'São Paulo', '東京都', 'Região Geográfica'])[1 + (g+s) % 4] AS v
+FROM generate_series(0,100000) _(g), generate_series(0,2) __(s);
+
+query I
+SELECT count(*) FROM (SELECT g, mode(v) AS m FROM mode_utf8 GROUP BY g)
+WHERE m IN ('চৌদ্দগ্রাম', 'São Paulo', '東京都', 'Região Geográfica');
+----
+100001

--- a/test/sql/optimizer/plan/test_filter_pushdown.test
+++ b/test/sql/optimizer/plan/test_filter_pushdown.test
@@ -231,3 +231,15 @@ ORDER BY ALL;
 ----
 1	2021-01-01	2021-01-01	2010-01-01
 1	2021-01-01	2021-02-15	2010-01-01
+
+# test ALIAS function in WHERE clause with column comparison
+statement ok
+CREATE TABLE t0(c0 VARCHAR(500));
+
+statement ok
+INSERT INTO t0(c0) VALUES ('2');
+
+query T
+SELECT * FROM t0 WHERE (t0.c0<(ALIAS(t0.c0)));
+----
+2

--- a/test/sql/window/test_streaming_window.test
+++ b/test/sql/window/test_streaming_window.test
@@ -446,3 +446,16 @@ SELECT
 	STDDEV_SAMP(k) OVER (ROWS UNBOUNDED PRECEDING) std_wf 
 FROM issue17621 
 GROUP BY ROLLUP(k)
+
+# UNION multiple local states
+query II
+WITH start_and_inputs AS (
+    SELECT 50 AS moves
+    UNION ALL
+    SELECT 50 AS moves
+)
+SELECT moves, sum(moves) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS sum
+FROM start_and_inputs;
+----
+50	50
+50	100

--- a/test/sql/window/test_value_orderby.test
+++ b/test/sql/window/test_value_orderby.test
@@ -45,3 +45,34 @@ FROM DATA
 2.0
 2.0
 4.0
+
+# All null handling
+statement ok
+CREATE TABLE all_nulls (order_col int,value_col float,partition_col int);
+
+statement ok
+INSERT INTO all_nulls VALUES (2,NULL,10);
+
+statement ok
+INSERT INTO all_nulls VALUES (1,NULL,10);
+
+query I
+SELECT first_value(value_col ORDER BY order_col IGNORE NULLS) over (PARTITION BY partition_col) 
+FROM all_nulls;
+----
+NULL
+NULL
+
+query I
+SELECT last_value(value_col ORDER BY order_col IGNORE NULLS) over (PARTITION BY partition_col) 
+FROM all_nulls;
+----
+NULL
+NULL
+
+query I
+SELECT nth_value(value_col, 1 ORDER BY order_col IGNORE NULLS) over (PARTITION BY partition_col) 
+FROM all_nulls;
+----
+NULL
+NULL


### PR DESCRIPTION
Basically all automatic, BUT for https://github.com/duckdb/duckdb/commit/1cc1ab7bd0f3536e638e1d40cde80e4d103f5292 that needs to be reverted via https://github.com/duckdb/duckdb/commit/d29f8cb3cedd0cc855825fb0ab6d1eeb05a52685.

Note: on 1.4.4 and subsequent minor releases on v1.4-andium branch, same dance again.

See more details at https://github.com/duckdb/duckdb/pull/20227#event-21611325876 and linked conversations.