### PR TITLE
[minor] Address more compile warnings

### DIFF
--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -57,7 +57,7 @@ struct OperatorInformation {
 	void AddMetric(MetricType type, T metric) {
 		switch (type) {
 		case MetricType::OPERATOR_TIMING:
-			time += LossyNumericCast<idx_t>(metric);
+			time += metric;
 			break;
 		case MetricType::OPERATOR_CARDINALITY:
 			elements_returned += LossyNumericCast<idx_t>(metric);

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -57,28 +57,28 @@ struct OperatorInformation {
 	void AddMetric(MetricType type, T metric) {
 		switch (type) {
 		case MetricType::OPERATOR_TIMING:
-			time += NumericCast<idx_t>(metric);
+			time += LossyNumericCast<idx_t>(metric);
 			break;
 		case MetricType::OPERATOR_CARDINALITY:
-			elements_returned += NumericCast<idx_t>(metric);
+			elements_returned += LossyNumericCast<idx_t>(metric);
 			break;
 		case MetricType::RESULT_SET_SIZE:
-			result_set_size += NumericCast<idx_t>(metric);
+			result_set_size += LossyNumericCast<idx_t>(metric);
 			break;
 		case MetricType::SYSTEM_PEAK_BUFFER_MEMORY: {
 			if (metric > system_peak_buffer_manager_memory) {
-				system_peak_buffer_manager_memory += NumericCast<idx_t>(metric);
+				system_peak_buffer_manager_memory += LossyNumericCast<idx_t>(metric);
 			}
 			break;
 		}
 		case MetricType::SYSTEM_PEAK_TEMP_DIR_SIZE: {
 			if (metric > system_peak_temp_directory_size) {
-				system_peak_temp_directory_size = NumericCast<idx_t>(metric);
+				system_peak_temp_directory_size = LossyNumericCast<idx_t>(metric);
 			}
 			break;
 		}
 		case MetricType::OPERATOR_ROWS_SCANNED:
-			rows_scanned = NumericCast<idx_t>(metric);
+			rows_scanned = LossyNumericCast<idx_t>(metric);
 			break;
 		default:
 			throw InternalException("OperatorProfiler: Unknown metric type");

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/enums/profiler_format.hpp"
 #include "duckdb/common/enums/explain_format.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/profiler.hpp"
 #include "duckdb/common/reference_map.hpp"
@@ -56,28 +57,28 @@ struct OperatorInformation {
 	void AddMetric(MetricType type, T metric) {
 		switch (type) {
 		case MetricType::OPERATOR_TIMING:
-			time += metric;
+			time += NumericCast<idx_t>(metric);
 			break;
 		case MetricType::OPERATOR_CARDINALITY:
-			elements_returned += metric;
+			elements_returned += NumericCast<idx_t>(metric);
 			break;
 		case MetricType::RESULT_SET_SIZE:
-			result_set_size += metric;
+			result_set_size += NumericCast<idx_t>(metric);
 			break;
 		case MetricType::SYSTEM_PEAK_BUFFER_MEMORY: {
 			if (metric > system_peak_buffer_manager_memory) {
-				system_peak_buffer_manager_memory += metric;
+				system_peak_buffer_manager_memory += NumericCast<idx_t>(metric);
 			}
 			break;
 		}
 		case MetricType::SYSTEM_PEAK_TEMP_DIR_SIZE: {
 			if (metric > system_peak_temp_directory_size) {
-				system_peak_temp_directory_size = metric;
+				system_peak_temp_directory_size = NumericCast<idx_t>(metric);
 			}
 			break;
 		}
 		case MetricType::OPERATOR_ROWS_SCANNED:
-			rows_scanned = metric;
+			rows_scanned = NumericCast<idx_t>(metric);
 			break;
 		default:
 			throw InternalException("OperatorProfiler: Unknown metric type");

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -131,7 +131,7 @@ TEST_CASE("CachingFileSystemWrapper caches reads", "[file_system][caching]") {
 
 	// Test 1: Read the same content multiple times, which should only hit underlying FS once
 	{
-		tracking_fs_ptr->Reset();
+		tracking_fs_ptr->Clear();
 
 		// Create OpenFileInfo with validation disabled to allow caching to work
 		OpenFileInfo file_info(test_file.GetPath());
@@ -172,7 +172,7 @@ TEST_CASE("CachingFileSystemWrapper caches reads", "[file_system][caching]") {
 		const string test_content2 = "This is test content for chunked read testing. It has enough content.";
 		TestFileGuard test_file2("test_caching_file2.txt", test_content2);
 
-		tracking_fs_ptr->Reset();
+		tracking_fs_ptr->Clear();
 
 		// Create OpenFileInfo with validation disabled
 		OpenFileInfo file_info(test_file2.GetPath());
@@ -214,7 +214,7 @@ TEST_CASE("CachingFileSystemWrapper sequential reads", "[file_system][caching]")
 
 	// Test sequential reads using location-based reads
 	{
-		tracking_fs_ptr->Reset();
+		tracking_fs_ptr->Clear();
 
 		auto handle = caching_wrapper.OpenFile(test_file.GetPath(), FileFlags::FILE_FLAGS_READ);
 		string buffer(TEST_BUFFER_SIZE, '\0');

--- a/tools/shell/linenoise/terminal.cpp
+++ b/tools/shell/linenoise/terminal.cpp
@@ -453,7 +453,7 @@ bool Terminal::TryGetBackgroundColor(TerminalColor &color) {
 			if (buf[i] == '\a') {
 				break;
 			}
-			if (i > 2 && buf[i - 1] == '\e' && buf[i] == '\\') {
+			if (i > 2 && buf[i - 1] == '\x1b' && buf[i] == '\\') {
 				i--;
 				break;
 			}


### PR DESCRIPTION
I usually do dev on ubuntu with libstdc++/gcc and compile with reldebug build.
But when I switch to my mac, with toolchain setup libc++/clang and compiling with debug build, I often spot some compilation errors.
This PR should fix all but one compilation warnings, which I don't have a good idea :(
```sh
/Users/hjiang/Desktop/duckdb/src/storage/block_allocator.cpp:203:46: warning: declaration requires an exit-time destructor [-Wexit-time-destructors]
  203 |         thread_local BlockAllocatorThreadLocalState local_state(block_allocator);
      |                                                     ^
```