### PR TITLE
Big-endian patches (FSST, arrow, types, md5)

### DIFF
--- a/src/common/arrow/schema_metadata.cpp
+++ b/src/common/arrow/schema_metadata.cpp
@@ -97,13 +97,13 @@ unsafe_unique_array<char> ArrowSchemaMetadata::SerializeMetadata() const {
 	auto metadata_array_ptr = make_unsafe_uniq_array<char>(total_size);
 	auto metadata_ptr = metadata_array_ptr.get();
 	// 1. number of key-value pairs (int32)
-	const idx_t map_size = schema_metadata_map.size();
+	const int32_t map_size = static_cast<int32_t>(schema_metadata_map.size());
 	memcpy(metadata_ptr, &map_size, sizeof(int32_t));
 	metadata_ptr += sizeof(int32_t);
 	// Iterate through each key-value pair in the map
 	for (const auto &pair : schema_metadata_map) {
 		const std::string &key = pair.first;
-		idx_t key_size = key.size();
+		int32_t key_size = static_cast<int32_t>(key.size());
 		// Length of the key (int32)
 		memcpy(metadata_ptr, &key_size, sizeof(int32_t));
 		metadata_ptr += sizeof(int32_t);
@@ -111,7 +111,7 @@ unsafe_unique_array<char> ArrowSchemaMetadata::SerializeMetadata() const {
 		memcpy(metadata_ptr, key.c_str(), key_size);
 		metadata_ptr += key_size;
 		const std::string &value = pair.second;
-		const idx_t value_size = value.size();
+		const int32_t value_size = static_cast<int32_t>(value.size());
 		// Length of the value (int32)
 		memcpy(metadata_ptr, &value_size, sizeof(int32_t));
 		metadata_ptr += sizeof(int32_t);

--- a/src/common/types/geometry.cpp
+++ b/src/common/types/geometry.cpp
@@ -1050,8 +1050,7 @@ static uint32_t ParseVerticesInternal(BlobReader &reader, GeometryExtent &extent
 #if DUCKDB_IS_BIG_ENDIAN
 		auto vert_ofs = vert_idx * sizeof(VERTEX_TYPE);
 		for (idx_t i = 0; i < sizeof(VERTEX_TYPE) / sizeof(double); ++i) {
-			auto le_value = Load<double>(ptr + vert_ofs + i * sizeof(double));
-			be_buffer[i] = BSwapIfBE(le_value);
+			be_buffer[i] = LoadLE<double>(ptr + vert_ofs + i * sizeof(double));
 		}
 		VERTEX_TYPE vertex = Load<VERTEX_TYPE>(be_ptr);
 #else

--- a/src/common/types/hash.cpp
+++ b/src/common/types/hash.cpp
@@ -84,7 +84,7 @@ hash_t HashBytes(const_data_ptr_t ptr, const idx_t len) noexcept {
 	// Hash/combine in blocks of 8 bytes
 	const auto remainder = len & 7U;
 	for (const auto end = ptr + len - remainder; ptr != end; ptr += 8U) {
-		h ^= BSwapIfBE(Load<hash_t>(ptr));
+		h ^= LoadLE<hash_t>(ptr);
 		h *= 0xd6e8feb86659fd93U;
 	}
 
@@ -93,7 +93,7 @@ hash_t HashBytes(const_data_ptr_t ptr, const idx_t len) noexcept {
 			D_ASSERT(len >= 8);
 			// Load remaining (<8) bytes (with a Load instead of a memcpy)
 			const auto inv_rem = 8U - remainder;
-			const auto hr = BSwapIfBE(Load<hash_t>(ptr - inv_rem)) >> (inv_rem * 8U);
+			const auto hr = LoadLE<hash_t>(ptr - inv_rem) >> (inv_rem * 8U);
 
 			h ^= hr;
 			h *= 0xd6e8feb86659fd93U;
@@ -123,7 +123,7 @@ hash_t Hash(string_t val) {
 
 		// Hash/combine the first 8-byte block
 		if (!val.Empty()) {
-			h ^= BSwapIfBE(Load<hash_t>(const_data_ptr_cast(val.GetPrefix())));
+			h ^= LoadLE<hash_t>(const_data_ptr_cast(val.GetPrefix()));
 			h *= 0xd6e8feb86659fd93U;
 		}
 

--- a/src/common/types/hash.cpp
+++ b/src/common/types/hash.cpp
@@ -84,7 +84,7 @@ hash_t HashBytes(const_data_ptr_t ptr, const idx_t len) noexcept {
 	// Hash/combine in blocks of 8 bytes
 	const auto remainder = len & 7U;
 	for (const auto end = ptr + len - remainder; ptr != end; ptr += 8U) {
-		h ^= Load<hash_t>(ptr);
+		h ^= BSwapIfBE(Load<hash_t>(ptr));
 		h *= 0xd6e8feb86659fd93U;
 	}
 
@@ -93,7 +93,7 @@ hash_t HashBytes(const_data_ptr_t ptr, const idx_t len) noexcept {
 			D_ASSERT(len >= 8);
 			// Load remaining (<8) bytes (with a Load instead of a memcpy)
 			const auto inv_rem = 8U - remainder;
-			const auto hr = Load<hash_t>(ptr - inv_rem) >> (inv_rem * 8U);
+			const auto hr = BSwapIfBE(Load<hash_t>(ptr - inv_rem)) >> (inv_rem * 8U);
 
 			h ^= hr;
 			h *= 0xd6e8feb86659fd93U;
@@ -101,6 +101,7 @@ hash_t HashBytes(const_data_ptr_t ptr, const idx_t len) noexcept {
 			// Load remaining (<8) bytes (with a memcpy)
 			hash_t hr = 0;
 			memcpy(&hr, ptr, remainder);
+			hr = BSwapIfBE(hr);
 
 			h ^= hr;
 			h *= 0xd6e8feb86659fd93U;
@@ -122,7 +123,7 @@ hash_t Hash(string_t val) {
 
 		// Hash/combine the first 8-byte block
 		if (!val.Empty()) {
-			h ^= Load<hash_t>(const_data_ptr_cast(val.GetPrefix()));
+			h ^= BSwapIfBE(Load<hash_t>(const_data_ptr_cast(val.GetPrefix())));
 			h *= 0xd6e8feb86659fd93U;
 		}
 
@@ -130,6 +131,7 @@ hash_t Hash(string_t val) {
 		if (val.GetSize() > sizeof(hash_t)) {
 			hash_t hr = 0;
 			memcpy(&hr, const_data_ptr_cast(val.GetPrefix()) + sizeof(hash_t), 4U);
+			hr = BSwapIfBE(hr);
 
 			h ^= hr;
 			h *= 0xd6e8feb86659fd93U;

--- a/src/function/scalar/string/md5.cpp
+++ b/src/function/scalar/string/md5.cpp
@@ -28,7 +28,7 @@ struct MD5Number128Operator {
 		MD5Context context;
 		context.Add(input);
 		context.Finish(digest);
-		return *reinterpret_cast<uhugeint_t *>(digest);
+		return BSwapIfBE(*reinterpret_cast<uhugeint_t *>(digest));
 	}
 };
 

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -55,7 +55,7 @@ static void GetValidityMask(ValidityMask &mask, ArrowArray &array, idx_t chunk_o
 	if (array.null_count != 0 && array.n_buffers > 0 && array.buffers[0]) {
 		auto bit_offset = GetEffectiveOffset(array, parent_offset, chunk_offset, nested_offset);
 		mask.EnsureWritable();
-#if STANDARD_VECTOR_SIZE > 64
+#if STANDARD_VECTOR_SIZE > 64 && !DUCKDB_IS_BIG_ENDIAN
 		auto n_bitmask_bytes = (size + 8 - 1) / 8;
 		if (bit_offset % 8 == 0) {
 			//! just memcpy nullmask

--- a/src/include/duckdb/common/bswap.hpp
+++ b/src/include/duckdb/common/bswap.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "duckdb/common/common.hpp"
-#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/hugeint.hpp"
+#include "duckdb/common/uhugeint.hpp"
 
 #include <cstring>
 

--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/bswap.hpp"
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include <string.h>
@@ -218,6 +219,11 @@ const T Load(const_data_ptr_t ptr) {
 	T ret;
 	memcpy(&ret, ptr, sizeof(ret)); // NOLINT
 	return ret;
+}
+
+template <typename T>
+const T LoadLE(const_data_ptr_t ptr) {
+	return BSwapIfBE(Load<T>(ptr));
 }
 
 template <typename T>


### PR DESCRIPTION
The PR fixes big-endian related issues with these:
- FSST compression ("gracefully" merges the latest of https://github.com/cwida/fsst to pick up [BE support](https://github.com/cwida/fsst/pull/36));
- arrow conversion;
- GEOMETRY and HASH types;
- md5 functions.