### PR TITLE
Do not call UnregisterBlock from destructor

### DIFF
--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -180,6 +180,9 @@ public:
 		return reinterpret_cast<const TARGET &>(*this);
 	}
 
+protected:
+	bool in_destruction = false;
+
 private:
 	//! The lock for the set of blocks
 	mutex blocks_lock;

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -61,7 +61,7 @@ class SingleFileBlockManager : public BlockManager {
 
 public:
 	SingleFileBlockManager(AttachedDatabase &db_p, const string &path_p, const StorageManagerOptions &options_p);
-	~SingleFileBlockManager();
+	~SingleFileBlockManager() override;
 
 	FileOpenFlags GetFileFlags(bool create_new) const;
 	//! Creates a new database.

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -61,6 +61,7 @@ class SingleFileBlockManager : public BlockManager {
 
 public:
 	SingleFileBlockManager(AttachedDatabase &db_p, const string &path_p, const StorageManagerOptions &options_p);
+	~SingleFileBlockManager();
 
 	FileOpenFlags GetFileFlags(bool create_new) const;
 	//! Creates a new database.

--- a/src/storage/buffer/block_manager.cpp
+++ b/src/storage/buffer/block_manager.cpp
@@ -120,6 +120,9 @@ void BlockManager::UnregisterBlock(block_id_t id) {
 }
 
 void BlockManager::UnregisterBlock(BlockHandle &block) {
+	if (in_destruction) {
+		return;
+	}
 	auto id = block.BlockId();
 	if (id >= MAXIMUM_BLOCK) {
 		// in-memory buffer: buffer could have been offloaded to disk: remove the file

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -254,6 +254,11 @@ SingleFileBlockManager::SingleFileBlockManager(AttachedDatabase &db_p, const str
       iteration_count(0), options(options) {
 }
 
+SingleFileBlockManager::~SingleFileBlockManager() {
+	// flip the flag to not perform UnregisterBlock on the block manager that is being destructed
+	this->in_destruction = true;
+}
+
 FileOpenFlags SingleFileBlockManager::GetFileFlags(bool create_new) const {
 	FileOpenFlags result;
 	if (options.read_only) {


### PR DESCRIPTION
As part of investigation of CI failures related to #19415 I was looking into the following Windows-only test crash:

```
[2789/4211] (66%): test/sql/logging/file_system_logging_attach.test
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
unittest.exe is a Catch v2.13.7 host application.
Run with -? for options
-------------------------------------------------------------------------------
test/sql/logging/file_system_logging_attach.test
-------------------------------------------------------------------------------
D:\a\duckdb\duckdb\test\sqlite\test_sqllogictest.cpp(261)
...............................................................................
D:\a\duckdb\duckdb\test\sqlite\test_sqllogictest.cpp(261): FAILED:
{Unknown expression after the reported line}
due to a fatal error condition:
SIGSEGV - Segmentation violation signal
```

It appeared, that [SingleFileBlockManager::UnregisterBlock](https://github.com/duckdb/duckdb/blob/8a469a87b974e99e763061977b9e46d5bdaac5b5/src/storage/single_file_block_manager.cpp#L1230-L1241) can be called from `SingleFileBlockManager` destructor with the following stack trace:

```
unittest.exe!std::_Tree<std::_Tset_traits<__int64,std::less<__int64>,std::allocator<__int64>,0>>::_Find_lower_bound<__int64>(const __int64 & _Keyval) Line 1632
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\xtree(1632)
unittest.exe!std::_Tree<std::_Tset_traits<__int64,std::less<__int64>,std::allocator<__int64>,0>>::_Find<__int64>(const __int64 & _Keyval) Line 1384
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\xtree(1384)
unittest.exe!std::_Tree<std::_Tset_traits<__int64,std::less<__int64>,std::allocator<__int64>,0>>::find(const __int64 & _Keyval) Line 1394
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\xtree(1394)
unittest.exe!duckdb::SingleFileBlockManager::UnregisterBlock(__int64 id) Line 1235
    at C:\projects\duckdb\src\storage\single_file_block_manager.cpp(1235)
unittest.exe!duckdb::BlockManager::UnregisterBlock(duckdb::BlockHandle & block) Line 128
    at C:\projects\duckdb\src\storage\buffer\block_manager.cpp(128)
unittest.exe!duckdb::BlockHandle::~BlockHandle() Line 56
    at C:\projects\duckdb\src\storage\buffer\block_handle.cpp(56)
unittest.exe!duckdb::BlockHandle::`scalar deleting destructor'(unsigned int)
unittest.exe!std::_Destroy_in_place<duckdb::BlockHandle>(duckdb::BlockHandle & _Obj) Line 324
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\xmemory(324)
unittest.exe!std::_Ref_count_obj2<duckdb::BlockHandle>::_Destroy() Line 2118
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(2118)
unittest.exe!std::_Ref_count_base::_Decref() Line 1161
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(1161)
unittest.exe!std::_Ptr_base<duckdb::BlockHandle>::_Decref() Line 1385
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(1385)
unittest.exe!std::shared_ptr<duckdb::BlockHandle>::~shared_ptr<duckdb::BlockHandle>() Line 1690
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(1690)
unittest.exe!duckdb::shared_ptr<duckdb::BlockHandle,1>::~shared_ptr<duckdb::BlockHandle,1>() Line 120
    at C:\projects\duckdb\src\include\duckdb\common\shared_ptr_ipp.hpp(120)
unittest.exe!duckdb::MetadataBlock::~MetadataBlock()
unittest.exe!std::pair<__int64 const ,duckdb::MetadataBlock>::~pair<__int64 const ,duckdb::MetadataBlock>()
unittest.exe!std::pair<__int64 const ,duckdb::MetadataBlock>::`scalar deleting destructor'(unsigned int)
unittest.exe!std::_Default_allocator_traits<std::allocator<std::_List_node<std::pair<__int64 const ,duckdb::MetadataBlock>,void *>>>::destroy<std::pair<__int64 const ,duckdb::MetadataBlock>>(std::allocator<std::_List_node<std::pair<__int64 const ,duckdb::MetadataBlock>,void *>> & __formal, std::pair<__int64 const ,duckdb::MetadataBlock> * const _Ptr) Line 741
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\xmemory(741)
unittest.exe!std::_List_node<std::pair<__int64 const ,duckdb::MetadataBlock>,void *>::_Freenode<std::allocator<std::_List_node<std::pair<__int64 const ,duckdb::MetadataBlock>,void *>>>(std::allocator<std::_List_node<std::pair<__int64 const ,duckdb::MetadataBlock>,void *>> & _Al, std::_List_node<std::pair<__int64 const ,duckdb::MetadataBlock>,void *> * _Ptr) Line 318
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\list(318)
unittest.exe!std::_List_node<std::pair<__int64 const ,duckdb::MetadataBlock>,void *>::_Free_non_head<std::allocator<std::_List_node<std::pair<__int64 const ,duckdb::MetadataBlock>,void *>>>(std::allocator<std::_List_node<std::pair<__int64 const ,duckdb::MetadataBlock>,void *>> & _Al, std::_List_node<std::pair<__int64 const ,duckdb::MetadataBlock>,void *> * _Head) Line 329
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\list(329)
unittest.exe!std::list<std::pair<__int64 const ,duckdb::MetadataBlock>,std::allocator<std::pair<__int64 const ,duckdb::MetadataBlock>>>::_Tidy() Line 1519
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\list(1519)
unittest.exe!std::list<std::pair<__int64 const ,duckdb::MetadataBlock>,std::allocator<std::pair<__int64 const ,duckdb::MetadataBlock>>>::~list<std::pair<__int64 const ,duckdb::MetadataBlock>,std::allocator<std::pair<__int64 const ,duckdb::MetadataBlock>>>() Line 1063
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\list(1063)
unittest.exe!std::_Hash<std::_Umap_traits<__int64,duckdb::MetadataBlock,std::_Uhash_compare<__int64,std::hash<__int64>,std::equal_to<__int64>>,std::allocator<std::pair<__int64 const ,duckdb::MetadataBlock>>,0>>::~_Hash<std::_Umap_traits<__int64,duckdb::MetadataBlock,std::_Uhash_compare<__int64,std::hash<__int64>,std::equal_to<__int64>>,std::allocator<std::pair<__int64 const ,duckdb::MetadataBlock>>,0>>()
unittest.exe!std::unordered_map<__int64,duckdb::MetadataBlock,std::hash<__int64>,std::equal_to<__int64>,std::allocator<std::pair<__int64 const ,duckdb::MetadataBlock>>>::~unordered_map<__int64,duckdb::MetadataBlock,std::hash<__int64>,std::equal_to<__int64>,std::allocator<std::pair<__int64 const ,duckdb::MetadataBlock>>>()
unittest.exe!duckdb::MetadataManager::~MetadataManager() Line 52
    at C:\projects\duckdb\src\storage\metadata\metadata_manager.cpp(52)
unittest.exe!duckdb::MetadataManager::`scalar deleting destructor'(unsigned int)
unittest.exe!std::default_delete<duckdb::MetadataManager>::operator()(duckdb::MetadataManager * _Ptr) Line 3309
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(3309)
unittest.exe!std::unique_ptr<duckdb::MetadataManager,std::default_delete<duckdb::MetadataManager>>::~unique_ptr<duckdb::MetadataManager,std::default_delete<duckdb::MetadataManager>>() Line 3427
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(3427)
unittest.exe!duckdb::unique_ptr<duckdb::MetadataManager,std::default_delete<duckdb::MetadataManager>,1>::~unique_ptr<duckdb::MetadataManager,std::default_delete<duckdb::MetadataManager>,1>()
unittest.exe!duckdb::BlockManager::~BlockManager() Line 36
    at C:\projects\duckdb\src\include\duckdb\storage\block_manager.hpp(36)
unittest.exe!duckdb::SingleFileBlockManager::~SingleFileBlockManager()
unittest.exe!duckdb::SingleFileBlockManager::`scalar deleting destructor'(unsigned int)
unittest.exe!std::default_delete<duckdb::BlockManager>::operator()(duckdb::BlockManager * _Ptr) Line 3309
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(3309)
unittest.exe!std::unique_ptr<duckdb::BlockManager,std::default_delete<duckdb::BlockManager>>::~unique_ptr<duckdb::BlockManager,std::default_delete<duckdb::BlockManager>>() Line 3427
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(3427)
unittest.exe!duckdb::unique_ptr<duckdb::BlockManager,std::default_delete<duckdb::BlockManager>,1>::~unique_ptr<duckdb::BlockManager,std::default_delete<duckdb::BlockManager>,1>()
unittest.exe!duckdb::SingleFileStorageManager::~SingleFileStorageManager()
unittest.exe!duckdb::SingleFileStorageManager::`scalar deleting destructor'(unsigned int)
unittest.exe!std::default_delete<duckdb::StorageManager>::operator()(duckdb::StorageManager * _Ptr) Line 3309
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(3309)
unittest.exe!std::unique_ptr<duckdb::StorageManager,std::default_delete<duckdb::StorageManager>>::reset(duckdb::StorageManager * _Ptr) Line 3471
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(3471)
unittest.exe!duckdb::unique_ptr<duckdb::StorageManager,std::default_delete<duckdb::StorageManager>,1>::reset(duckdb::StorageManager * ptr) Line 54
    at C:\projects\duckdb\src\include\duckdb\common\unique_ptr.hpp(54)
unittest.exe!duckdb::AttachedDatabase::Close() Line 297
    at C:\projects\duckdb\src\main\attached_database.cpp(297)
unittest.exe!duckdb::AttachedDatabase::~AttachedDatabase() Line 154
    at C:\projects\duckdb\src\main\attached_database.cpp(154)
unittest.exe!duckdb::AttachedDatabase::`scalar deleting destructor'(unsigned int)
unittest.exe!std::_Destroy_in_place<duckdb::AttachedDatabase>(duckdb::AttachedDatabase & _Obj) Line 324
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\xmemory(324)
unittest.exe!std::_Ref_count_obj2<duckdb::AttachedDatabase>::_Destroy() Line 2118
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(2118)
unittest.exe!std::_Ref_count_base::_Decref() Line 1161
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(1161)
unittest.exe!std::_Ptr_base<duckdb::AttachedDatabase>::_Decref() Line 1385
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(1385)
unittest.exe!std::shared_ptr<duckdb::AttachedDatabase>::~shared_ptr<duckdb::AttachedDatabase>() Line 1690
    at C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\memory(1690)
unittest.exe!duckdb::shared_ptr<duckdb::AttachedDatabase,1>::~shared_ptr<duckdb::AttachedDatabase,1>() Line 120
    at C:\projects\duckdb\src\include\duckdb\common\shared_ptr_ipp.hpp(120)
unittest.exe!duckdb::DatabaseManager::DetachDatabase(duckdb::ClientContext & context, const std::string & name, duckdb::OnEntryNotFound if_not_found) Line 211
    at C:\projects\duckdb\src\main\database_manager.cpp(211)
unittest.exe!duckdb::PhysicalDetach::GetDataInternal(duckdb::ExecutionContext & context, duckdb::DataChunk & chunk, duckdb::OperatorSourceInput & input) Line 19
    at C:\projects\duckdb\src\execution\operator\schema\physical_detach.cpp(19)
unittest.exe!duckdb::PhysicalOperator::GetData(duckdb::ExecutionContext & context, duckdb::DataChunk & chunk, duckdb::OperatorSourceInput & input) Line 129
    at C:\projects\duckdb\src\execution\physical_operator.cpp(129)
unittest.exe!duckdb::PipelineExecutor::GetData(duckdb::DataChunk & chunk, duckdb::OperatorSourceInput & input) Line 507
    at C:\projects\duckdb\src\parallel\pipeline_executor.cpp(507)
unittest.exe!duckdb::PipelineExecutor::FetchFromSource(duckdb::DataChunk & result) Line 532
    at C:\projects\duckdb\src\parallel\pipeline_executor.cpp(532)
unittest.exe!duckdb::PipelineExecutor::Execute(unsigned __int64 max_chunks) Line 232
    at C:\projects\duckdb\src\parallel\pipeline_executor.cpp(232)
unittest.exe!duckdb::PipelineTask::ExecuteTask(duckdb::TaskExecutionMode mode) Line 41
    at C:\projects\duckdb\src\parallel\pipeline.cpp(41)
unittest.exe!duckdb::ExecutorTask::Execute(duckdb::TaskExecutionMode mode) Line 52
    at C:\projects\duckdb\src\parallel\executor_task.cpp(52)
unittest.exe!duckdb::Executor::ExecuteTask(bool dry_run) Line 578
    at C:\projects\duckdb\src\parallel\executor.cpp(578)
unittest.exe!duckdb::ClientContext::ExecuteTaskInternal(duckdb::ClientContextLock & lock, duckdb::BaseQueryResult & result, bool dry_run) Line 606
    at C:\projects\duckdb\src\main\client_context.cpp(606)
unittest.exe!duckdb::PendingQueryResult::ExecuteTaskInternal(duckdb::ClientContextLock & lock) Line 69
    at C:\projects\duckdb\src\main\pending_query_result.cpp(69)
unittest.exe!duckdb::PendingQueryResult::ExecuteInternal(duckdb::ClientContextLock & lock) Line 75
    at C:\projects\duckdb\src\main\pending_query_result.cpp(75)
unittest.exe!duckdb::ClientContext::ExecutePendingQueryInternal(duckdb::ClientContextLock & lock, duckdb::PendingQueryResult & query) Line 1112
    at C:\projects\duckdb\src\main\client_context.cpp(1112)
unittest.exe!duckdb::ClientContext::Query(const std::string & query, duckdb::QueryParameters query_parameters) Line 1005
    at C:\projects\duckdb\src\main\client_context.cpp(1005)
unittest.exe!duckdb::Command::ExecuteQuery(duckdb::ExecuteContext & context, duckdb::Connection * connection, std::string file_name, unsigned __int64 query_line) Line 192
    at C:\projects\duckdb\test\sqlite\sqllogic_command.cpp(192)
unittest.exe!duckdb::Statement::ExecuteInternal(duckdb::ExecuteContext & context) Line 593
    at C:\projects\duckdb\test\sqlite\sqllogic_command.cpp(593)
unittest.exe!duckdb::Command::Execute(duckdb::ExecuteContext & context) Line 285
    at C:\projects\duckdb\test\sqlite\sqllogic_command.cpp(285)
unittest.exe!duckdb::SQLLogicTestRunner::ExecuteCommand(duckdb::unique_ptr<duckdb::Command,std::default_delete<duckdb::Command>,1> command) Line 88
    at C:\projects\duckdb\test\sqlite\sqllogic_test_runner.cpp(88)
unittest.exe!duckdb::SQLLogicTestRunner::ExecuteFile(std::string script) Line 876
    at C:\projects\duckdb\test\sqlite\sqllogic_test_runner.cpp(876)
unittest.exe!testRunner<0,0>() Line 93
    at C:\projects\duckdb\test\sqlite\test_sqllogictest.cpp(93)
unittest.exe!Catch::TestInvokerAsFunction::invoke() Line 14535
    at C:\projects\duckdb\third_party\catch\catch.hpp(14535)
unittest.exe!Catch::TestCase::invoke() Line 14370
    at C:\projects\duckdb\third_party\catch\catch.hpp(14370)
unittest.exe!Catch::RunContext::invokeActiveTestCase() Line 13136
    at C:\projects\duckdb\third_party\catch\catch.hpp(13136)
unittest.exe!Catch::RunContext::runCurrentTest(std::string & redirectedCout, std::string & redirectedCerr) Line 13109
    at C:\projects\duckdb\third_party\catch\catch.hpp(13109)
unittest.exe!Catch::RunContext::runTest(const Catch::TestCase & testCase) Line 12854
    at C:\projects\duckdb\third_party\catch\catch.hpp(12854)
unittest.exe!Catch::`anonymous namespace'::TestGroup::execute() Line 13551
    at C:\projects\duckdb\third_party\catch\catch.hpp(13551)
unittest.exe!Catch::Session::runInternal() Line 13763
    at C:\projects\duckdb\third_party\catch\catch.hpp(13763)
unittest.exe!Catch::Session::run() Line 13719
    at C:\projects\duckdb\third_party\catch\catch.hpp(13719)
unittest.exe!Catch::Session::run<char>(int argc, const char * const * argv) Line 13347
    at C:\projects\duckdb\third_party\catch\catch.hpp(13347)
unittest.exe!main(int argc_in, char * * argv) Line 59
    at C:\projects\duckdb\test\unittest.cpp(59)
unittest.exe!invoke_main() Line 79
    at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl(79)
unittest.exe!__scrt_common_main_seh() Line 288
    at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl(288)
unittest.exe!__scrt_common_main() Line 331
    at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl(331)
unittest.exe!mainCRTStartup(void * __formal) Line 17
    at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp(17)
kernel32.dll!00007ff929e7e8d7()
ntdll.dll!00007ff92b04c53c()
```

So it crashes while accessing `free_blocks_in_use` field.

The crash does not happen on Linux (and I believe on macOS) because for some reason `UnregisterBlock` method of the superclass is called instead:

```
duckdb::BlockManager::UnregisterBlock(duckdb::BlockManager * const this, duckdb::block_id_t id) (/home/alex/projects/duckdb/src/storage/buffer/block_manager.cpp:116)
duckdb::BlockManager::UnregisterBlock(duckdb::BlockManager * const this, duckdb::BlockHandle & block) (/home/alex/projects/duckdb/src/storage/buffer/block_manager.cpp:128)
duckdb::BlockHandle::~BlockHandle(duckdb::BlockHandle * const this) (/home/alex/projects/duckdb/src/storage/buffer/block_handle.cpp:56)
std::_Destroy<duckdb::BlockHandle>(duckdb::BlockHandle * __pointer) (/usr/include/c++/15/bits/stl_construct.h:166)
std::allocator_traits<std::allocator<void> >::destroy<duckdb::BlockHandle>(duckdb::BlockHandle * __p) (/usr/include/c++/15/bits/alloc_traits.h:819)
std::_Sp_counted_ptr_inplace<duckdb::BlockHandle, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose(std::_Sp_counted_ptr_inplace<duckdb::BlockHandle, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:615)
std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use(std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:174)
std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold(std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:198)
std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release(std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:352)
std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count(std::__shared_count<(__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:1069)
std::__shared_ptr<duckdb::BlockHandle, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr(std::__shared_ptr<duckdb::BlockHandle, (__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:1531)
std::shared_ptr<duckdb::BlockHandle>::~shared_ptr(std::shared_ptr<duckdb::BlockHandle> * const this) (/usr/include/c++/15/bits/shared_ptr.h:175)
duckdb::shared_ptr<duckdb::BlockHandle, true>::~shared_ptr(duckdb::shared_ptr<duckdb::BlockHandle, true> * const this) (/home/alex/projects/duckdb/src/include/duckdb/common/shared_ptr_ipp.hpp:120)
duckdb::MetadataBlock::~MetadataBlock(duckdb::MetadataBlock * const this) (/home/alex/projects/duckdb/src/include/duckdb/storage/metadata/metadata_manager.hpp:22)
std::pair<long const, duckdb::MetadataBlock>::~pair(std::pair<long const, duckdb::MetadataBlock> * const this) (/usr/include/c++/15/bits/stl_pair.h:302)
std::__new_allocator<std::__detail::_Hash_node<std::pair<long const, duckdb::MetadataBlock>, false> >::destroy<std::pair<long const, duckdb::MetadataBlock> >(std::__new_allocator<std::__detail::_Hash_node<std::pair<long const, duckdb::MetadataBlock>, false> > * const this, std::pair<long const, duckdb::MetadataBlock> * __p) (/usr/include/c++/15/bits/new_allocator.h:198)
std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<long const, duckdb::MetadataBlock>, false> > >::destroy<std::pair<long const, duckdb::MetadataBlock> >(std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<long const, duckdb::MetadataBlock>, false> > >::allocator_type & __a, std::pair<long const, duckdb::MetadataBlock> * __p) (/usr/include/c++/15/bits/alloc_traits.h:696)
std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<long const, duckdb::MetadataBlock>, false> > >::_M_deallocate_node(std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<long const, duckdb::MetadataBlock>, false> > > * const this, std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<long const, duckdb::MetadataBlock>, false> > >::__node_ptr __n) (/usr/include/c++/15/bits/hashtable_policy.h:1572)
std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<long const, duckdb::MetadataBlock>, false> > >::_M_deallocate_nodes(std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<long const, duckdb::MetadataBlock>, false> > > * const this, std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<long const, duckdb::MetadataBlock>, false> > >::__node_ptr __n) (/usr/include/c++/15/bits/hashtable_policy.h:1594)
std::_Hashtable<long, std::pair<long const, duckdb::MetadataBlock>, std::allocator<std::pair<long const, duckdb::MetadataBlock> >, std::__detail::_Select1st, std::equal_to<long>, std::hash<long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::~_Hashtable(std::_Hashtable<long, std::pair<long const, duckdb::MetadataBlock>, std::allocator<std::pair<long const, duckdb::MetadataBlock> >, std::__detail::_Select1st, std::equal_to<long>, std::hash<long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> > * const this) (/usr/include/c++/15/bits/hashtable.h:1852)
std::unordered_map<long, duckdb::MetadataBlock, std::hash<long>, std::equal_to<long>, std::allocator<std::pair<long const, duckdb::MetadataBlock> > >::~unordered_map(std::unordered_map<long, duckdb::MetadataBlock, std::hash<long>, std::equal_to<long>, std::allocator<std::pair<long const, duckdb::MetadataBlock> > > * const this) (/usr/include/c++/15/bits/unordered_map.h:112)
duckdb::MetadataManager::~MetadataManager(duckdb::MetadataManager * const this) (/home/alex/projects/duckdb/src/storage/metadata/metadata_manager.cpp:52)
std::default_delete<duckdb::MetadataManager>::operator()(const std::default_delete<duckdb::MetadataManager> * const this, duckdb::MetadataManager * __ptr) (/usr/include/c++/15/bits/unique_ptr.h:92)
std::unique_ptr<duckdb::MetadataManager, std::default_delete<duckdb::MetadataManager> >::~unique_ptr(std::unique_ptr<duckdb::MetadataManager, std::default_delete<duckdb::MetadataManager> > * const this) (/usr/include/c++/15/bits/unique_ptr.h:398)
duckdb::unique_ptr<duckdb::MetadataManager, std::default_delete<duckdb::MetadataManager>, true>::~unique_ptr(duckdb::unique_ptr<duckdb::MetadataManager, std::default_delete<duckdb::MetadataManager>, true> * const this) (/home/alex/projects/duckdb/src/include/duckdb/common/unique_ptr.hpp:14)
duckdb::BlockManager::~BlockManager(duckdb::BlockManager * const this) (/home/alex/projects/duckdb/src/include/duckdb/storage/block_manager.hpp:36)
duckdb::SingleFileBlockManager::~SingleFileBlockManager(duckdb::SingleFileBlockManager * const this) (/home/alex/projects/duckdb/src/include/duckdb/storage/single_file_block_manager.hpp:58)
duckdb::SingleFileBlockManager::~SingleFileBlockManager(duckdb::SingleFileBlockManager * const this) (/home/alex/projects/duckdb/src/include/duckdb/storage/single_file_block_manager.hpp:58)
std::default_delete<duckdb::BlockManager>::operator()(const std::default_delete<duckdb::BlockManager> * const this, duckdb::BlockManager * __ptr) (/usr/include/c++/15/bits/unique_ptr.h:92)
std::unique_ptr<duckdb::BlockManager, std::default_delete<duckdb::BlockManager> >::~unique_ptr(std::unique_ptr<duckdb::BlockManager, std::default_delete<duckdb::BlockManager> > * const this) (/usr/include/c++/15/bits/unique_ptr.h:398)
duckdb::unique_ptr<duckdb::BlockManager, std::default_delete<duckdb::BlockManager>, true>::~unique_ptr(duckdb::unique_ptr<duckdb::BlockManager, std::default_delete<duckdb::BlockManager>, true> * const this) (/home/alex/projects/duckdb/src/include/duckdb/common/unique_ptr.hpp:14)
duckdb::SingleFileStorageManager::~SingleFileStorageManager(duckdb::SingleFileStorageManager * const this) (/home/alex/projects/duckdb/src/include/duckdb/storage/storage_manager.hpp:177)
duckdb::SingleFileStorageManager::~SingleFileStorageManager(duckdb::SingleFileStorageManager * const this) (/home/alex/projects/duckdb/src/include/duckdb/storage/storage_manager.hpp:177)
std::default_delete<duckdb::StorageManager>::operator()(const std::default_delete<duckdb::StorageManager> * const this, duckdb::StorageManager * __ptr) (/usr/include/c++/15/bits/unique_ptr.h:92)
std::__uniq_ptr_impl<duckdb::StorageManager, std::default_delete<duckdb::StorageManager> >::reset(std::__uniq_ptr_impl<duckdb::StorageManager, std::default_delete<duckdb::StorageManager> > * const this, std::__uniq_ptr_impl<duckdb::StorageManager, std::default_delete<duckdb::StorageManager> >::pointer __p) (/usr/include/c++/15/bits/unique_ptr.h:204)
std::unique_ptr<duckdb::StorageManager, std::default_delete<duckdb::StorageManager> >::reset(std::unique_ptr<duckdb::StorageManager, std::default_delete<duckdb::StorageManager> > * const this, std::unique_ptr<duckdb::StorageManager, std::default_delete<duckdb::StorageManager> >::pointer __p) (/usr/include/c++/15/bits/unique_ptr.h:511)
duckdb::unique_ptr<duckdb::StorageManager, std::default_delete<duckdb::StorageManager>, true>::reset(duckdb::unique_ptr<duckdb::StorageManager, std::default_delete<duckdb::StorageManager>, true> * const this, std::unique_ptr<duckdb::StorageManager, std::default_delete<duckdb::StorageManager> >::pointer ptr) (/home/alex/projects/duckdb/src/include/duckdb/common/unique_ptr.hpp:54)
duckdb::AttachedDatabase::Close(duckdb::AttachedDatabase * const this) (/home/alex/projects/duckdb/src/main/attached_database.cpp:296)
duckdb::AttachedDatabase::~AttachedDatabase(duckdb::AttachedDatabase * const this) (/home/alex/projects/duckdb/src/main/attached_database.cpp:154)
std::_Destroy<duckdb::AttachedDatabase>(duckdb::AttachedDatabase * __pointer) (/usr/include/c++/15/bits/stl_construct.h:166)
std::allocator_traits<std::allocator<void> >::destroy<duckdb::AttachedDatabase>(duckdb::AttachedDatabase * __p) (/usr/include/c++/15/bits/alloc_traits.h:819)
std::_Sp_counted_ptr_inplace<duckdb::AttachedDatabase, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose(std::_Sp_counted_ptr_inplace<duckdb::AttachedDatabase, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:615)
std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use(std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:174)
std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold(std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:198)
std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release(std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:352)
std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count(std::__shared_count<(__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:1069)
std::__shared_ptr<duckdb::AttachedDatabase, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr(std::__shared_ptr<duckdb::AttachedDatabase, (__gnu_cxx::_Lock_policy)2> * const this) (/usr/include/c++/15/bits/shared_ptr_base.h:1531)
std::shared_ptr<duckdb::AttachedDatabase>::~shared_ptr(std::shared_ptr<duckdb::AttachedDatabase> * const this) (/usr/include/c++/15/bits/shared_ptr.h:175)
duckdb::shared_ptr<duckdb::AttachedDatabase, true>::~shared_ptr(duckdb::shared_ptr<duckdb::AttachedDatabase, true> * const this) (/home/alex/projects/duckdb/src/include/duckdb/common/shared_ptr_ipp.hpp:120)
duckdb::DatabaseManager::DetachDatabase(duckdb::DatabaseManager * const this, duckdb::ClientContext & context, const std::string & name, duckdb::OnEntryNotFound if_not_found) (/home/alex/projects/duckdb/src/main/database_manager.cpp:211)
duckdb::PhysicalDetach::GetDataInternal(const duckdb::PhysicalDetach * const this, duckdb::ExecutionContext & context, duckdb::DataChunk & chunk, duckdb::OperatorSourceInput & input) (/home/alex/projects/duckdb/src/execution/operator/schema/physical_detach.cpp:17)
duckdb::PhysicalOperator::GetData(const duckdb::PhysicalOperator * const this, duckdb::ExecutionContext & context, duckdb::DataChunk & chunk, duckdb::OperatorSourceInput & input) (/home/alex/projects/duckdb/src/execution/physical_operator.cpp:128)
duckdb::PipelineExecutor::GetData(duckdb::PipelineExecutor * const this, duckdb::DataChunk & chunk, duckdb::OperatorSourceInput & input) (/home/alex/projects/duckdb/src/parallel/pipeline_executor.cpp:506)
duckdb::PipelineExecutor::FetchFromSource(duckdb::PipelineExecutor * const this, duckdb::DataChunk & result) (/home/alex/projects/duckdb/src/parallel/pipeline_executor.cpp:532)
duckdb::PipelineExecutor::Execute(duckdb::PipelineExecutor * const this, duckdb::idx_t max_chunks) (/home/alex/projects/duckdb/src/parallel/pipeline_executor.cpp:232)
duckdb::PipelineTask::ExecuteTask(duckdb::PipelineTask * const this, duckdb::TaskExecutionMode mode) (/home/alex/projects/duckdb/src/parallel/pipeline.cpp:41)
duckdb::ExecutorTask::Execute(duckdb::ExecutorTask * const this, duckdb::TaskExecutionMode mode) (/home/alex/projects/duckdb/src/parallel/executor_task.cpp:52)
duckdb::Executor::ExecuteTask(duckdb::Executor * const this, bool dry_run) (/home/alex/projects/duckdb/src/parallel/executor.cpp:578)
duckdb::ClientContext::ExecuteTaskInternal(duckdb::ClientContext * const this, duckdb::ClientContextLock & lock, duckdb::BaseQueryResult & result, bool dry_run) (/home/alex/projects/duckdb/src/main/client_context.cpp:606)
duckdb::PendingQueryResult::ExecuteTaskInternal(duckdb::PendingQueryResult * const this, duckdb::ClientContextLock & lock) (/home/alex/projects/duckdb/src/main/pending_query_result.cpp:68)
duckdb::PendingQueryResult::ExecuteInternal(duckdb::PendingQueryResult * const this, duckdb::ClientContextLock & lock) (/home/alex/projects/duckdb/src/main/pending_query_result.cpp:75)
duckdb::ClientContext::ExecutePendingQueryInternal(duckdb::ClientContext * const this, duckdb::ClientContextLock & lock, duckdb::PendingQueryResult & query) (/home/alex/projects/duckdb/src/main/client_context.cpp:1112)
duckdb::ClientContext::Query(duckdb::ClientContext * const this, const std::string & query, duckdb::QueryParameters query_parameters) (/home/alex/projects/duckdb/src/main/client_context.cpp:1005)
duckdb::Command::ExecuteQuery(const duckdb::Command * const this, duckdb::ExecuteContext & context, duckdb::Connection * connection, std::string file_name, duckdb::idx_t query_line) (/home/alex/projects/duckdb/test/sqlite/sqllogic_command.cpp:192)
duckdb::Statement::ExecuteInternal(const duckdb::Statement * const this, duckdb::ExecuteContext & context) (/home/alex/projects/duckdb/test/sqlite/sqllogic_command.cpp:593)
duckdb::Command::Execute(const duckdb::Command * const this, duckdb::ExecuteContext & context) (/home/alex/projects/duckdb/test/sqlite/sqllogic_command.cpp:285)
duckdb::SQLLogicTestRunner::ExecuteCommand(duckdb::SQLLogicTestRunner * const this, duckdb::unique_ptr<duckdb::Command, std::default_delete<duckdb::Command>, true> command) (/home/alex/projects/duckdb/test/sqlite/sqllogic_test_runner.cpp:88)
duckdb::SQLLogicTestRunner::ExecuteFile(duckdb::SQLLogicTestRunner * const this, std::string script) (/home/alex/projects/duckdb/test/sqlite/sqllogic_test_runner.cpp:876)
testRunner<false>() (/home/alex/projects/duckdb/test/sqlite/test_sqllogictest.cpp:93)
Catch::TestInvokerAsFunction::invoke(const Catch::TestInvokerAsFunction * const this) (/home/alex/projects/duckdb/third_party/catch/catch.hpp:14535)
Catch::TestCase::invoke(const Catch::TestCase * const this) (/home/alex/projects/duckdb/third_party/catch/catch.hpp:14370)
Catch::RunContext::invokeActiveTestCase(Catch::RunContext * const this) (/home/alex/projects/duckdb/third_party/catch/catch.hpp:13136)
Catch::RunContext::runCurrentTest(Catch::RunContext * const this, std::string & redirectedCout, std::string & redirectedCerr) (/home/alex/projects/duckdb/third_party/catch/catch.hpp:13109)
Catch::RunContext::runTest(Catch::RunContext * const this, const Catch::TestCase & testCase) (/home/alex/projects/duckdb/third_party/catch/catch.hpp:12854)
Catch::(anonymous namespace)::TestGroup::execute(Catch::(anonymous namespace)::TestGroup * const this) (/home/alex/projects/duckdb/third_party/catch/catch.hpp:13551)
Catch::Session::runInternal(Catch::Session * const this) (/home/alex/projects/duckdb/third_party/catch/catch.hpp:13763)
Catch::Session::run(Catch::Session * const this) (/home/alex/projects/duckdb/third_party/catch/catch.hpp:13719)
Catch::Session::run<char>(Catch::Session * const this, int argc, const char * const * argv) (/home/alex/projects/duckdb/third_party/catch/catch.hpp:13347)
main(int argc_in, char ** argv) (/home/alex/projects/duckdb/test/unittest.cpp:59)
```

This PR adds a flag to `BlockManager` to be flipped in the destructor of the subclass (because it is called first) and adds a check for this flag in `UnregisterBlock` method.

Testing: checked that with this change the problematic test passes on Windows.