### PR TITLE
Optimize arg_min/max struct pruning for unnest

### DIFF
--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/array.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/vector_operations/aggregate_executor.hpp"
 #include "duckdb/function/aggregate_state.hpp"
 #include "duckdb/planner/bound_result_modifier.hpp"
@@ -283,6 +284,17 @@ public:
 		distinct_dependent = value;
 	}
 
+	void SetStructArgumentPruning(optional_idx arg_index) {
+		// Marks which argument returns the struct that can be pruned based on downstream field usage.
+		struct_argument_pruning = arg_index;
+	}
+	optional_idx GetStructArgumentPruning() const {
+		return struct_argument_pruning;
+	}
+	bool SupportsStructArgumentPruning() const {
+		return struct_argument_pruning.IsValid();
+	}
+
 	//! Additional function info, passed to the bind
 	shared_ptr<AggregateFunctionInfo> function_info;
 
@@ -425,6 +437,10 @@ public:
 	static void StateDestroy(Vector &states, AggregateInputData &aggr_input_data, idx_t count) {
 		AggregateExecutor::Destroy<STATE, OP>(states, aggr_input_data, count);
 	}
+
+private:
+	//! Optional index of a struct argument that can be pruned based on downstream field references.
+	optional_idx struct_argument_pruning;
 };
 
 } // namespace duckdb

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -581,7 +581,9 @@ bool PruneStructPack(BoundAggregateExpression &aggregate, idx_t argument_index, 
 	vector<pair<string, LogicalType>> new_child_types;
 	new_children.reserve(required_indexes.size());
 	new_child_types.reserve(required_indexes.size());
+	D_ASSERT(struct_pack.children.size() == child_types.size());
 	for (auto idx : required_indexes) {
+		D_ASSERT(idx < struct_pack.children.size());
 		new_children.push_back(struct_pack.children[idx]->Copy());
 		new_child_types.push_back(child_types[idx]);
 	}
@@ -608,14 +610,17 @@ bool PruneStructPack(BoundAggregateExpression &aggregate, idx_t argument_index, 
 			} else if (child->type == ExpressionType::BOUND_REF) {
 				child->Cast<BoundReferenceExpression>().return_type = new_struct_type;
 			}
+			bool found = false;
 			for (idx_t new_idx = 0; new_idx < required_indexes.size(); new_idx++) {
 				if (required_indexes[new_idx] == extract_bind.index) {
 					extract_bind.index = new_idx;
 					extract_func->return_type = new_child_types[new_idx].second;
 					extract_func->function.return_type = extract_func->return_type;
+					found = true;
 					break;
 				}
 			}
+			D_ASSERT(found);
 		}
 	}
 	return true;

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
@@ -23,9 +24,98 @@
 #include "duckdb/planner/operator/logical_simple.hpp"
 #include "duckdb/function/scalar/struct_utils.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/common/string_util.hpp"
+#include <algorithm>
+#include <unordered_set>
 #include <utility>
 
 namespace duckdb {
+
+bool PruneStructPack(BoundAggregateExpression &aggregate, const vector<idx_t> &required_indexes,
+                     vector<BoundFunctionExpression *> *extracts);
+
+namespace {
+bool IsArgMinMax(const AggregateFunction &function) {
+	return StringUtil::StartsWith(function.name, "arg_min") || StringUtil::StartsWith(function.name, "arg_max");
+}
+
+vector<idx_t> GetRequiredStructFields(ReferencedColumn &column) {
+	if (column.child_columns.empty()) {
+		return {};
+	}
+	unordered_set<idx_t> required_indexes;
+	auto add_path = [&](const ColumnIndex &path) {
+		required_indexes.insert(path.GetPrimaryIndex());
+	};
+	if (!column.unique_paths.empty()) {
+		for (auto &path : column.unique_paths) {
+			add_path(path);
+		}
+	} else {
+		for (auto &path : column.child_columns) {
+			add_path(path);
+		}
+	}
+	vector<idx_t> result(required_indexes.begin(), required_indexes.end());
+	std::sort(result.begin(), result.end());
+	return result;
+}
+
+vector<BoundFunctionExpression *> GetStructExtractFunctions(ReferencedColumn &column) {
+	vector<BoundFunctionExpression *> extract_functions;
+	for (auto &extract : column.struct_extracts) {
+		if (extract.expr.empty()) {
+			continue;
+		}
+		auto &leaf_expr = extract.expr.back().get();
+		auto *leaf_ptr = leaf_expr.get();
+		if (!leaf_ptr || leaf_ptr->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+			continue;
+		}
+		auto &function = leaf_ptr->Cast<BoundFunctionExpression>();
+		if (function.function.name != "struct_extract" && function.function.name != "struct_extract_at") {
+			continue;
+		}
+		extract_functions.push_back(&function);
+	}
+	return extract_functions;
+}
+
+bool TryPruneArgMinMaxStructs(column_binding_map_t<ReferencedColumn> &column_references, LogicalAggregate &op) {
+	bool pruned_structs = false;
+	for (idx_t agg_idx = 0; agg_idx < op.expressions.size(); agg_idx++) {
+		auto &expr = op.expressions[agg_idx];
+		if (expr->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
+			continue;
+		}
+		auto &aggregate = expr->Cast<BoundAggregateExpression>();
+		if (!IsArgMinMax(aggregate.function)) {
+			continue;
+		}
+
+		auto binding = ColumnBinding(op.aggregate_index, agg_idx);
+		auto entry = column_references.find(binding);
+		if (entry == column_references.end()) {
+			continue;
+		}
+		auto required_indexes = GetRequiredStructFields(entry->second);
+		if (required_indexes.empty()) {
+			continue;
+		}
+
+		auto extract_functions = GetStructExtractFunctions(entry->second);
+		auto *extract_ptr = extract_functions.empty() ? nullptr : &extract_functions;
+		if (PruneStructPack(aggregate, required_indexes, extract_ptr)) {
+			pruned_structs = true;
+		}
+	}
+	if (pruned_structs) {
+		op.types.clear();
+		op.ResolveOperatorTypes();
+	}
+	return pruned_structs;
+}
+} // namespace
 
 idx_t BaseColumnPruner::ReplaceBinding(ColumnBinding current_binding, ColumnBinding new_binding) {
 	auto colrefs = column_references.find(current_binding);
@@ -99,6 +189,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		if (aggr.grouping_sets.size() > 1) {
 			new_root = true;
 		}
+		TryPruneArgMinMaxStructs(column_references, aggr);
 		if (!everything_referenced && !new_root) {
 			// FIXME: groups that are not referenced need to stay -> but they don't need to be scanned and output!
 			ClearUnusedExpressions(aggr.expressions, aggr.aggregate_index);
@@ -464,6 +555,69 @@ void RemoveUnusedColumns::RewriteExpressions(LogicalProjection &proj, idx_t expr
 		}
 	}
 	proj.expressions = std::move(expressions);
+}
+
+bool PruneStructPack(BoundAggregateExpression &aggregate, const vector<idx_t> &required_indexes,
+                     vector<BoundFunctionExpression *> *extracts) {
+	if (aggregate.children.empty()) {
+		return false;
+	}
+	auto &arg = aggregate.children[0];
+	if (arg->expression_class != ExpressionClass::BOUND_FUNCTION) {
+		return false;
+	}
+	auto &struct_pack = arg->Cast<BoundFunctionExpression>();
+	if (struct_pack.function.name != "struct_pack" && struct_pack.function.name != "row") {
+		return false;
+	}
+	auto &bind_data = struct_pack.bind_info->Cast<VariableReturnBindData>();
+	auto &child_types = StructType::GetChildTypes(bind_data.stype);
+	if (required_indexes.empty() || required_indexes.size() >= child_types.size()) {
+		return false;
+	}
+
+	vector<unique_ptr<Expression>> new_children;
+	vector<pair<string, LogicalType>> new_child_types;
+	new_children.reserve(required_indexes.size());
+	new_child_types.reserve(required_indexes.size());
+	for (auto idx : required_indexes) {
+		new_children.push_back(struct_pack.children[idx]->Copy());
+		new_child_types.push_back(child_types[idx]);
+	}
+	struct_pack.children = std::move(new_children);
+
+	LogicalType new_struct_type = LogicalType::STRUCT(new_child_types);
+	bind_data.stype = new_struct_type;
+	struct_pack.return_type = new_struct_type;
+	struct_pack.function.return_type = new_struct_type;
+	arg->return_type = new_struct_type;
+
+	aggregate.return_type = new_struct_type;
+	aggregate.function.return_type = new_struct_type;
+	if (!aggregate.function.arguments.empty()) {
+		aggregate.function.arguments[0] = new_struct_type;
+	}
+
+	if (extracts) {
+		for (auto *extract_func : *extracts) {
+			auto &extract_bind = extract_func->bind_info->Cast<StructExtractBindData>();
+			auto &child = extract_func->children[0];
+			if (child->type == ExpressionType::BOUND_COLUMN_REF) {
+				child->Cast<BoundColumnRefExpression>().return_type = new_struct_type;
+			} else if (child->type == ExpressionType::BOUND_REF) {
+				child->Cast<BoundReferenceExpression>().return_type = new_struct_type;
+			}
+			for (idx_t new_idx = 0; new_idx < required_indexes.size(); new_idx++) {
+				if (required_indexes[new_idx] == extract_bind.index) {
+					extract_bind.index = new_idx;
+					extract_func->return_type = new_child_types[new_idx].second;
+					extract_func->function.return_type = extract_func->return_type;
+					break;
+				}
+			}
+		}
+	}
+	return true;
 }
 
 void RemoveUnusedColumns::CheckPushdownExtract(LogicalOperator &op) {

--- a/test/sql/optimizer/plan/plan_arg_max_struct_pruning.test
+++ b/test/sql/optimizer/plan/plan_arg_max_struct_pruning.test
@@ -17,3 +17,23 @@ FROM (
 );
 ----
 physical_plan	<REGEX>:.*struct_pack\(col_1, col_2,[\s\S]*col_3\).*
+
+query II
+EXPLAIN SELECT col_2
+FROM (
+  SELECT UNNEST(arg_min(argmax_prune, col_5))
+  FROM argmax_prune
+  GROUP BY col_1
+);
+----
+physical_plan	<REGEX>:.*struct_pack\(col_2\).*
+
+query II
+EXPLAIN SELECT col_1, col_3
+FROM (
+  SELECT UNNEST(arg_max_nulls_last(argmax_prune, col_5))
+  FROM argmax_prune
+  GROUP BY col_1, col_2
+);
+----
+physical_plan	<REGEX>:.*struct_pack\(col_1,[\s\S]*col_3\).*

--- a/test/sql/optimizer/plan/plan_arg_max_struct_pruning.test
+++ b/test/sql/optimizer/plan/plan_arg_max_struct_pruning.test
@@ -16,7 +16,7 @@ FROM (
   GROUP BY col_1, col_2
 );
 ----
-physical_plan	<REGEX>:.*struct_pack\(col_1, col_2,[\s\S]*col_3\).*
+physical_plan	<REGEX>:.*struct_pack\(col_1, col_2,\s*col_3\).*
 
 query II
 EXPLAIN SELECT col_2
@@ -36,4 +36,4 @@ FROM (
   GROUP BY col_1, col_2
 );
 ----
-physical_plan	<REGEX>:.*struct_pack\(col_1,[\s\S]*col_3\).*
+physical_plan	<REGEX>:.*struct_pack\(col_1,\s*col_3\).*

--- a/test/sql/optimizer/plan/plan_arg_max_struct_pruning.test
+++ b/test/sql/optimizer/plan/plan_arg_max_struct_pruning.test
@@ -16,7 +16,17 @@ FROM (
   GROUP BY col_1, col_2
 );
 ----
-physical_plan	<REGEX>:.*struct_pack\(col_1, col_2,\s*col_3\).*
+physical_plan	<REGEX>:.*struct_pack\(col_1, col_2,.*col_3\).*
+
+query II
+EXPLAIN SELECT col_1, col_2, col_3
+FROM (
+  SELECT UNNEST(arg_max(argmax_prune, col_5))
+  FROM argmax_prune
+  GROUP BY col_1, col_2
+);
+----
+physical_plan	<!REGEX>:.*struct_pack\([^)]*col_4[^)]*\).*
 
 query II
 EXPLAIN SELECT col_2
@@ -29,6 +39,26 @@ FROM (
 physical_plan	<REGEX>:.*struct_pack\(col_2\).*
 
 query II
+EXPLAIN SELECT col_2
+FROM (
+  SELECT UNNEST(arg_min(argmax_prune, col_5))
+  FROM argmax_prune
+  GROUP BY col_1
+);
+----
+physical_plan	<!REGEX>:.*struct_pack\([^)]*col_1[^)]*\).*
+
+query II
+EXPLAIN SELECT col_2
+FROM (
+  SELECT UNNEST(arg_min(argmax_prune, col_5))
+  FROM argmax_prune
+  GROUP BY col_1
+);
+----
+physical_plan	<!REGEX>:.*struct_pack\([^)]*col_3[^)]*\).*
+
+query II
 EXPLAIN SELECT col_1, col_3
 FROM (
   SELECT UNNEST(arg_max_nulls_last(argmax_prune, col_5))
@@ -36,4 +66,14 @@ FROM (
   GROUP BY col_1, col_2
 );
 ----
-physical_plan	<REGEX>:.*struct_pack\(col_1,\s*col_3\).*
+physical_plan	<REGEX>:.*struct_pack\(col_1,.*col_3\).*
+
+query II
+EXPLAIN SELECT col_1, col_3
+FROM (
+  SELECT UNNEST(arg_max_nulls_last(argmax_prune, col_5))
+  FROM argmax_prune
+  GROUP BY col_1, col_2
+);
+----
+physical_plan	<!REGEX>:.*struct_pack\([^)]*col_2[^)]*\).*

--- a/test/sql/optimizer/plan/plan_arg_max_struct_pruning.test
+++ b/test/sql/optimizer/plan/plan_arg_max_struct_pruning.test
@@ -1,0 +1,19 @@
+# name: test/sql/optimizer/plan/plan_arg_max_struct_pruning.test
+# description: Prune unused struct_pack fields for arg_max/arg_min in UNNEST projections
+# group: [plan]
+
+statement ok
+CREATE TABLE argmax_prune(col_1 TEXT, col_2 TEXT, col_3 TEXT, col_4 TEXT, col_5 INTEGER);
+
+statement ok
+PRAGMA explain_output = 'PHYSICAL_ONLY';
+
+query II
+EXPLAIN SELECT col_1, col_2, col_3
+FROM (
+  SELECT UNNEST(arg_max(argmax_prune, col_5))
+  FROM argmax_prune
+  GROUP BY col_1, col_2
+);
+----
+physical_plan	<REGEX>:.*struct_pack\(col_1, col_2,[\s\S]*col_3\).*


### PR DESCRIPTION
This PR fixes #20185 by pushing projection pruning through `unnest(arg_min/arg_max(...))`. The optimizer now identifies which struct fields are actually referenced downstream and prunes unused fields from the aggregate’s struct input, so wide rows are no longer materialized unnecessarily. The pruning is metadata‑driven: aggregate functions declare which argument returns a prunable struct, and RemoveUnusedColumns uses that to safely rewrite struct_pack/row and update types and struct_extract bindings. Plan tests cover arg_max/arg_min/arg_max_nulls_last to guard against regressions.

 - Fixes #20185