### PR TITLE
Fix last parallel destructor race condition (hopefully)

### DIFF
--- a/src/common/sort/sorted_run_merger.cpp
+++ b/src/common/sort/sorted_run_merger.cpp
@@ -824,13 +824,13 @@ unique_ptr<SortedRun> SortedRunMergerLocalState::TemplatedMaterializePartition(S
 //===--------------------------------------------------------------------===//
 SortedRunMerger::SortedRunMerger(const Sort &sort_p, vector<unique_ptr<SortedRun>> &&sorted_runs_p,
                                  idx_t partition_size_p, bool external_p, bool is_index_sort_p)
-    : db(*sort_p.context.db), sort(sort_p), sorted_runs(std::move(sorted_runs_p)),
+    : scheduler(TaskScheduler::GetScheduler(*sort_p.context.db)), sort(sort_p), sorted_runs(std::move(sorted_runs_p)),
       total_count(SortedRunsTotalCount(sorted_runs)), partition_size(partition_size_p), external(external_p),
       is_index_sort(is_index_sort_p) {
 }
 
 SortedRunMerger::~SortedRunMerger() {
-	ParallelDestroyTask<decltype(sorted_runs)>::Schedule(db, sorted_runs);
+	ParallelDestroyTask<decltype(sorted_runs)>::Schedule(scheduler, sorted_runs);
 }
 
 unique_ptr<LocalSourceState> SortedRunMerger::GetLocalSourceState(ExecutionContext &,

--- a/src/common/types/row/tuple_data_collection.cpp
+++ b/src/common/types/row/tuple_data_collection.cpp
@@ -16,7 +16,7 @@ using ValidityBytes = TupleDataLayout::ValidityBytes;
 
 TupleDataCollection::TupleDataCollection(BufferManager &buffer_manager, shared_ptr<TupleDataLayout> layout_ptr_p,
                                          MemoryTag tag_p, shared_ptr<ArenaAllocator> stl_allocator_p)
-    : db(buffer_manager.GetDatabase()),
+    : scheduler(TaskScheduler::GetScheduler(buffer_manager.GetDatabase())),
       stl_allocator(stl_allocator_p ? std::move(stl_allocator_p)
                                     : make_shared_ptr<ArenaAllocator>(buffer_manager.GetBufferAllocator())),
       layout_ptr(std::move(layout_ptr_p)), layout(*layout_ptr), tag(tag_p),
@@ -32,7 +32,7 @@ TupleDataCollection::TupleDataCollection(ClientContext &context, shared_ptr<Tupl
 }
 
 TupleDataCollection::~TupleDataCollection() {
-	ParallelDestroyTask<decltype(segments)>::Schedule(db, segments);
+	ParallelDestroyTask<decltype(segments)>::Schedule(scheduler, segments);
 }
 
 void TupleDataCollection::Initialize() {

--- a/src/include/duckdb/common/sorting/sorted_run_merger.hpp
+++ b/src/include/duckdb/common/sorting/sorted_run_merger.hpp
@@ -18,6 +18,7 @@ struct BoundOrderByNode;
 struct ProgressData;
 class SortedRun;
 enum class SortKeyType : uint8_t;
+class TaskScheduler;
 
 class SortedRunMerger {
 	friend class SortedRunMergerLocalState;
@@ -47,7 +48,7 @@ public:
 	unique_ptr<SortedRun> GetSortedRun(GlobalSourceState &global_state);
 
 private:
-	DatabaseInstance &db;
+	TaskScheduler &scheduler;
 
 public:
 	const Sort &sort;

--- a/src/include/duckdb/common/types/row/tuple_data_collection.hpp
+++ b/src/include/duckdb/common/types/row/tuple_data_collection.hpp
@@ -268,8 +268,8 @@ private:
 	void Verify() const;
 
 private:
-	//! DB ref for parallel destruction
-	DatabaseInstance &db;
+	//! Task scheduler for parallel destruction
+	TaskScheduler &scheduler;
 	//! Shared allocator for STL allocations
 	shared_ptr<ArenaAllocator> stl_allocator;
 	//! The layout of the TupleDataCollection

--- a/src/include/duckdb/parallel/parallel_destroy_task.hpp
+++ b/src/include/duckdb/parallel/parallel_destroy_task.hpp
@@ -25,11 +25,11 @@ public:
 		elem.reset();
 	}
 
-	static void Schedule(DatabaseInstance &db, ITERABLE &elements) {
+	static void Schedule(TaskScheduler &scheduler, ITERABLE &elements) {
 		// This is used in destructors and is therefore not allowed to throw
 		// Similar approach to AttachedDatabase::Close(), just swallow the exception
 		try {
-			TaskExecutor executor(TaskScheduler::GetScheduler(db));
+			TaskExecutor executor(scheduler);
 			for (auto &segment : elements) {
 				auto destroy_task = make_uniq<ParallelDestroyTask>(executor, std::move(segment));
 				executor.ScheduleTask(std::move(destroy_task));


### PR DESCRIPTION
Follow-up of https://github.com/duckdb/duckdb/pull/20200

Linux ThreadSan seemed happy after I ran `test/sql/storage/lazy_load/lazy_load_limit.test` for an hour - hopefully that's the last of it.