### PR TITLE
Optimize prepared statement parameter lookups

### DIFF
--- a/src/include/duckdb/main/capi/capi_internal.hpp
+++ b/src/include/duckdb/main/capi/capi_internal.hpp
@@ -53,6 +53,7 @@ struct PreparedStatementWrapper {
 	unique_ptr<PreparedStatement> statement;
 	bool success = true;
 	ErrorData error_data;
+	std::vector<std::string> param_index_to_name;
 };
 
 struct ExtractStatementsWrapper {

--- a/src/include/duckdb/main/capi/capi_internal.hpp
+++ b/src/include/duckdb/main/capi/capi_internal.hpp
@@ -53,7 +53,7 @@ struct PreparedStatementWrapper {
 	unique_ptr<PreparedStatement> statement;
 	bool success = true;
 	ErrorData error_data;
-	std::vector<std::string> param_index_to_name;
+	unordered_map<idx_t, string> param_index_to_name;
 };
 
 struct ExtractStatementsWrapper {

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -113,15 +113,15 @@ static duckdb::string duckdb_parameter_name_internal(duckdb_prepared_statement p
 	if (!wrapper || !wrapper->statement || wrapper->statement->HasError()) {
 		return duckdb::string();
 	}
-	auto &named = wrapper->statement->named_param_map;
-	if (index == 0 || index > named.size()) {
+	auto &named_param_map = wrapper->statement->named_param_map;
+	if (index == 0 || index > named_param_map.size()) {
 		return duckdb::string();
 	}
 
 	auto &cache = wrapper->param_index_to_name;
-	if (cache.size() != named.size() + 1) {
-		cache.assign(named.size() + 1, duckdb::string());
-		for (auto &kv : named) {
+	if (cache.size() != named_param_map.size() + 1) {
+		cache.assign(named_param_map.size() + 1, duckdb::string());
+		for (auto &kv : named_param_map) {
 			auto idx = kv.second;
 			if (idx < cache.size() && cache[idx].empty()) {
 				cache[idx] = kv.first;

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -41,7 +41,7 @@ idx_t duckdb_extract_statements(duckdb_connection connection, const char *query,
 	return wrapper->statements.size();
 }
 
-static void duckdb_prepare_reversed_named_params_map(PreparedStatementWrapper *wrapper) {
+static void duckdb_prepare_reversed_named_params_map_internal(PreparedStatementWrapper *wrapper) {
 	auto &named_param_map = wrapper->statement->named_param_map;
 	auto &cache = wrapper->param_index_to_name;
 	for (auto &kv : named_param_map) {
@@ -65,7 +65,7 @@ duckdb_state duckdb_prepare_extracted_statement(duckdb_connection connection,
 		if (wrapper->statement->HasError()) {
 			return DuckDBError;
 		}
-		duckdb_prepare_reversed_named_params_map(wrapper);
+		duckdb_prepare_reversed_named_params_map_internal(wrapper);
 		return DuckDBSuccess;
 	} catch (...) {
 		delete wrapper;
@@ -94,7 +94,7 @@ duckdb_state duckdb_prepare(duckdb_connection connection, const char *query,
 		if (wrapper->statement->HasError()) {
 			return DuckDBError;
 		}
-		duckdb_prepare_reversed_named_params_map(wrapper);
+		duckdb_prepare_reversed_named_params_map_internal(wrapper);
 		return DuckDBSuccess;
 	} catch (...) {
 		delete wrapper;

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -41,7 +41,7 @@ idx_t duckdb_extract_statements(duckdb_connection connection, const char *query,
 	return wrapper->statements.size();
 }
 
-static void duckdb_prepare_reversed_named_params_map_internal(PreparedStatementWrapper *wrapper) {
+static void duckdb_prepare_param_index_to_name_map(PreparedStatementWrapper *wrapper) {
 	auto &named_param_map = wrapper->statement->named_param_map;
 	auto &cache = wrapper->param_index_to_name;
 	for (auto &kv : named_param_map) {
@@ -65,7 +65,7 @@ duckdb_state duckdb_prepare_extracted_statement(duckdb_connection connection,
 		if (wrapper->statement->HasError()) {
 			return DuckDBError;
 		}
-		duckdb_prepare_reversed_named_params_map_internal(wrapper);
+		duckdb_prepare_param_index_to_name_map(wrapper);
 		return DuckDBSuccess;
 	} catch (...) {
 		delete wrapper;
@@ -94,7 +94,7 @@ duckdb_state duckdb_prepare(duckdb_connection connection, const char *query,
 		if (wrapper->statement->HasError()) {
 			return DuckDBError;
 		}
-		duckdb_prepare_reversed_named_params_map_internal(wrapper);
+		duckdb_prepare_param_index_to_name_map(wrapper);
 		return DuckDBSuccess;
 	} catch (...) {
 		delete wrapper;

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -128,6 +128,7 @@ static duckdb::string duckdb_parameter_name_internal(duckdb_prepared_statement p
 			}
 		}
 	}
+	// No parameter was found with this index when there is nothing in the cache (default value is `duckdb::string()`)
 	return cache[index];
 }
 

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -41,7 +41,7 @@ idx_t duckdb_extract_statements(duckdb_connection connection, const char *query,
 	return wrapper->statements.size();
 }
 
-static void duckdb_prepare_param_index_to_name_map(PreparedStatementWrapper *wrapper) {
+static void duckdb_prepare_param_index_to_name_map_internal(PreparedStatementWrapper *wrapper) {
 	auto &named_param_map = wrapper->statement->named_param_map;
 	auto &cache = wrapper->param_index_to_name;
 	for (auto &kv : named_param_map) {
@@ -65,7 +65,7 @@ duckdb_state duckdb_prepare_extracted_statement(duckdb_connection connection,
 		if (wrapper->statement->HasError()) {
 			return DuckDBError;
 		}
-		duckdb_prepare_param_index_to_name_map(wrapper);
+		duckdb_prepare_param_index_to_name_map_internal(wrapper);
 		return DuckDBSuccess;
 	} catch (...) {
 		delete wrapper;
@@ -94,7 +94,7 @@ duckdb_state duckdb_prepare(duckdb_connection connection, const char *query,
 		if (wrapper->statement->HasError()) {
 			return DuckDBError;
 		}
-		duckdb_prepare_param_index_to_name_map(wrapper);
+		duckdb_prepare_param_index_to_name_map_internal(wrapper);
 		return DuckDBSuccess;
 	} catch (...) {
 		delete wrapper;


### PR DESCRIPTION
This PR improves the performance of `duckdb_parameter_name` in the C API by memoizing the mapping from parameter indexes to their names.

# Impact
This change eliminates redundant iterations over the parameter map whenever a client / internal-function retrieves parameter names, which is particularly beneficial for prepared statements with a large number of parameters.

## Context
1. In drivers such as `duckdb-go`, when preparing a query with `args` we call `duckdb_bind_value` for each parameter.
2. `duckdb_bind_value` calls `duckdb_parameter_name`, which (before this improvement)  used to iterate the whole `named_param_map`.
3. Which means - the whole parameters preparation used to be always `O(n^2)`.
4. Now, when "reversing" the named-param (which is initially calculated by the query parser), and storing it under the `PreparedStatementWrapper`, we can use it from `duckdb_parameter_name` instead of iterating again the whole map.
5. The reversed map is `unordered_map`, which is `O(1)` for the average case.

For instance, for benchmarked prepared statements preparation with 20K params I observed an improvement of 100%! (Debugging, local environment)