### PR TITLE
Fix wrong error message when add primary key to a view(#20239)

### DIFF
--- a/src/planner/binder/statement/bind_simple.cpp
+++ b/src/planner/binder/statement/bind_simple.cpp
@@ -30,6 +30,10 @@ unique_ptr<LogicalOperator> DuckCatalog::BindAlterAddIndex(Binder &binder, Table
 
 BoundStatement Binder::BindAlterAddIndex(BoundStatement &result, CatalogEntry &entry,
                                          unique_ptr<AlterInfo> alter_info) {
+	if (entry.type != CatalogType::TABLE_ENTRY) {
+		throw BinderException("Cannot execute the `ALTER TABLE` statement on `%s`, only `Table` entries are accepted.",
+		                      CatalogTypeToString(entry.type));
+	}
 	auto &table_info = alter_info->Cast<AlterTableInfo>();
 	auto &constraint_info = table_info.Cast<AddConstraintInfo>();
 	auto &table = entry.Cast<TableCatalogEntry>();

--- a/test/sql/alter/add_pk/test_add_pk.test
+++ b/test/sql/alter/add_pk/test_add_pk.test
@@ -97,3 +97,16 @@ query TTI
 SELECT table_name, database_name, temporary FROM duckdb_tables() WHERE table_name='temp_pk_test'
 ----
 temp_pk_test	temp	true
+
+
+# Try to add a primary key to the view - should give clear error message
+statement ok
+CREATE VIEW view_test AS SELECT 'hello' AS name, 42 AS value
+
+statement error
+ALTER TABLE view_test ADD PRIMARY KEY (name)
+----
+<REGEX>:Binder Error.*Cannot execute the `ALTER TABLE` statement on `.*`, only `Table` entries are accepted.*
+
+statement ok
+DROP VIEW view_test


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb/issues/20239.
Add target restrictions when executing the `alert table` statement