### PR TITLE
Internal #6462: Implement AGO Macro

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -164,7 +164,7 @@ static const DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "days_in_month", {"date", nullptr}, {{nullptr, nullptr}}, "day(last_day(date))"},
 
 	// timestamptz functions
-	{DEFAULT_SCHEMA, "ago", {"interval", nullptr}, {{nullptr, nullptr}}, "current_timestamp - interval"},
+	{DEFAULT_SCHEMA, "ago", {"i", nullptr}, {{nullptr, nullptr}}, "current_timestamp - i::interval"},
 
 	// regexp functions
 	{DEFAULT_SCHEMA, "regexp_split_to_table", {"text", "pattern", nullptr}, {{nullptr, nullptr}}, "unnest(string_split_regex(text, pattern))"},

--- a/test/sql/function/timestamp/current_timestamp.test
+++ b/test/sql/function/timestamp/current_timestamp.test
@@ -39,9 +39,11 @@ endloop
 
 foreach unit millennia century decade year month day hour minute second
 
-query I
-select current_timestamp - interval 1 ${unit} = ago(interval 1 ${unit});
+query II
+select 
+	current_timestamp - interval 1 ${unit} = ago(interval 1 ${unit}),
+	current_timestamp - interval 1 ${unit} = ago('1 ${unit}');
 ----
-True
+True	True
 
 endloop


### PR DESCRIPTION
* Add cast so `ago('1 h')` works.