### PR TITLE
Grab `StorageBlockPrefetch` setting once per scan state, instead of once per fetch

### DIFF
--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -23,6 +23,7 @@ class BufferManager;
 class ClientContext;
 class DatabaseInstance;
 class MetadataManager;
+enum class StorageBlockPrefetch : uint8_t;
 
 enum class ConvertToPersistentMode { DESTRUCTIVE, THREAD_SAFE };
 
@@ -92,7 +93,7 @@ public:
 	//! Whether or not the attached database is in-memory
 	virtual bool InMemory() = 0;
 	//! Whether or not to prefetch
-	virtual bool Prefetch() {
+	virtual bool Prefetch(StorageBlockPrefetch prefetch) {
 		return false;
 	}
 

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -122,7 +122,7 @@ public:
 	//! Whether or not the attached database is a remote file
 	bool IsRemote() override;
 	//! Whether or not to prefetch
-	bool Prefetch() override;
+	bool Prefetch(StorageBlockPrefetch prefetch) override;
 
 	//! Return the checkpoint iteration of the file.
 	uint64_t GetCheckpointIteration() const {

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -233,8 +233,8 @@ public:
 	idx_t batch_index;
 	//! The valid selection
 	SelectionVector valid_sel;
-	//! How to prefetch blocks
-	StorageBlockPrefetch block_prefetch;
+	//! How to prefetch blocks (initialized on the first prefetch)
+	unique_ptr<StorageBlockPrefetch> block_prefetch;
 
 	RandomEngine random;
 

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -17,6 +17,7 @@
 #include "duckdb/common/random_engine.hpp"
 #include "duckdb/storage/table/segment_lock.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/parser/parsed_data/sample_options.hpp"
 #include "duckdb/storage/storage_index.hpp"
 #include "duckdb/planner/table_filter_state.hpp"
@@ -232,6 +233,8 @@ public:
 	idx_t batch_index;
 	//! The valid selection
 	SelectionVector valid_sel;
+	//! How to prefetch blocks
+	StorageBlockPrefetch block_prefetch;
 
 	RandomEngine random;
 

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -311,7 +311,8 @@ void SingleFileCheckpointReader::LoadFromStorage() {
 		return;
 	}
 
-	if (block_manager.Prefetch()) {
+	auto prefetch = DBConfig::GetSetting<StorageBlockPrefetchSetting>(block_manager.GetBufferManager().GetDatabase());
+	if (block_manager.Prefetch(prefetch)) {
 		auto metadata_blocks = metadata_manager.GetBlocks();
 		auto &buffer_manager = BufferManager::GetBufferManager(storage.GetDatabase());
 		buffer_manager.Prefetch(metadata_blocks);

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -962,8 +962,8 @@ bool SingleFileBlockManager::IsRemote() {
 	return !handle->OnDiskFile();
 }
 
-bool SingleFileBlockManager::Prefetch() {
-	switch (DBConfig::GetSetting<StorageBlockPrefetchSetting>(db.GetDatabase())) {
+bool SingleFileBlockManager::Prefetch(StorageBlockPrefetch prefetch) {
+	switch (prefetch) {
 	case StorageBlockPrefetch::NEVER:
 		return false;
 	case StorageBlockPrefetch::DEBUG_FORCE_ALWAYS:

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -303,6 +303,7 @@ void CollectionScanState::Initialize(const QueryContext &context, const vector<L
 		auto &type = types[index];
 		column_scans[i].Initialize(context, type, column_ids[i], &GetOptions());
 	}
+	block_prefetch = DBConfig::GetSetting<StorageBlockPrefetchSetting>(*context.GetClientContext()->db);
 }
 
 bool RowGroup::InitializeScanWithOffset(CollectionScanState &state, SegmentNode<RowGroup> &node, idx_t vector_offset) {
@@ -634,7 +635,7 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 			count = max_count;
 		}
 		auto &block_manager = GetBlockManager();
-		if (block_manager.Prefetch()) {
+		if (block_manager.Prefetch(state.block_prefetch)) {
 			PrefetchState prefetch_state;
 			for (idx_t i = 0; i < column_ids.size(); i++) {
 				const auto &column = column_ids[i];

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -195,7 +195,7 @@ ParallelCollectionScanState::GetNextRowGroup(RowGroupSegmentTree &row_groups, Se
 
 CollectionScanState::CollectionScanState(TableScanState &parent_p)
     : row_group(nullptr), vector_index(0), max_row_group_row(0), row_groups(nullptr), max_row(0), batch_index(0),
-      valid_sel(STANDARD_VECTOR_SIZE), random(-1), parent(parent_p) {
+      valid_sel(STANDARD_VECTOR_SIZE), block_prefetch(StorageBlockPrefetch::REMOTE_ONLY), random(-1), parent(parent_p) {
 }
 
 optional_ptr<SegmentNode<RowGroup>> CollectionScanState::GetNextRowGroup(SegmentNode<RowGroup> &row_group) const {

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -195,7 +195,7 @@ ParallelCollectionScanState::GetNextRowGroup(RowGroupSegmentTree &row_groups, Se
 
 CollectionScanState::CollectionScanState(TableScanState &parent_p)
     : row_group(nullptr), vector_index(0), max_row_group_row(0), row_groups(nullptr), max_row(0), batch_index(0),
-      valid_sel(STANDARD_VECTOR_SIZE), block_prefetch(StorageBlockPrefetch::REMOTE_ONLY), random(-1), parent(parent_p) {
+      valid_sel(STANDARD_VECTOR_SIZE), random(-1), parent(parent_p) {
 }
 
 optional_ptr<SegmentNode<RowGroup>> CollectionScanState::GetNextRowGroup(SegmentNode<RowGroup> &row_group) const {


### PR DESCRIPTION
Grabbing this setting started showing up in profiling, which it really shouldn't. Improves TPC-H Q6 and Q8 by ~7% on my laptop at SF100. Some Regression CI outputs below:

TPC-H
```
Old timing geometric mean: 0.042638162172456605
New timing geometric mean: 0.03945930776468366, roughly 7% faster
```

TPC-DS
```
Old timing geometric mean: 0.033171986683035344
New timing geometric mean: 0.03138457708251394, roughly 5% faster
```

IMDB:
```
Old timing geometric mean: 0.14430608504493508
New timing geometric mean: 0.13551959933912244, roughly 6% faster
```