### PR TITLE
Fix  function chain in qualify(#20233)

### DIFF
--- a/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
@@ -19,6 +19,8 @@ class QualifyBinder : public BaseSelectBinder {
 public:
 	QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
+	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
+
 protected:
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
 

--- a/src/planner/expression_binder/qualify_binder.cpp
+++ b/src/planner/expression_binder/qualify_binder.cpp
@@ -14,6 +14,10 @@ QualifyBinder::QualifyBinder(Binder &binder, ClientContext &context, BoundSelect
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }
 
+bool QualifyBinder::DoesColumnAliasExist(const ColumnRefExpression &colref) {
+	return column_alias_binder.DoesColumnAliasExist(colref);
+}
+
 BindResult QualifyBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
 	auto result = duckdb::BaseSelectBinder::BindColumnRef(expr_ptr, depth, root_expression);
 	if (!result.HasError()) {

--- a/test/sql/binder/alias_qualification_qualify.test
+++ b/test/sql/binder/alias_qualification_qualify.test
@@ -44,3 +44,18 @@ ORDER BY v;
 ----
 1	1
 2	2
+
+
+# Test function chain in QUALIFY
+query II
+SELECT c1, row_number() over(partition BY c1 order by c2) as rk FROM VALUES ('a', 1), ('b', 2), ('b', 3), ('c', 4) AS t(c1, c2) qualify rk.add(1) > 2
+----
+b	2
+
+
+query I
+FROM VALUES ('CS', 'Bachelor'), ('CS', 'Bachelor'), ('CS', 'PhD'), ('Math', 'Masters') AS t(c1, c2)
+SELECT list(c2) over(partition BY c1) AS "c3"
+QUALIFY "c3".len() = 1;
+----
+[Masters]


### PR DESCRIPTION
This PR try fixes issue https://github.com/duckdb/duckdb/issues/20233.
hi duckdb team，I added the `DoesColumnAliasExist` function to `QualifyBinder` based on the code in the `where_bingder.cpp` file. Testing shows that it works correctly, but I'm not sure if it will affect other modules. thanks~