### PR TITLE
Reuse correct table-level metadata during checkpoints

### DIFF
--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -29,7 +29,8 @@ public:
 public:
 	void WriteTableData(Serializer &metadata_serializer);
 
-	virtual void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) = 0;
+	virtual void WriteUnchangedTable(MetaBlockPointer pointer, const vector<MetaBlockPointer> &metadata_pointers,
+	                                 idx_t total_rows) = 0;
 	virtual void FinalizeTable(const TableStatistics &global_stats, DataTableInfo &info, RowGroupCollection &collection,
 	                           Serializer &serializer) = 0;
 	virtual unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) = 0;
@@ -54,7 +55,8 @@ public:
 	                          MetadataWriter &table_data_writer);
 
 public:
-	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) override;
+	void WriteUnchangedTable(MetaBlockPointer pointer, const vector<MetaBlockPointer> &metadata_pointers,
+	                         idx_t total_rows) override;
 	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo &info, RowGroupCollection &collection,
 	                   Serializer &serializer) override;
 	unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) override;

--- a/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
+++ b/src/include/duckdb/storage/table/in_memory_checkpoint.hpp
@@ -49,7 +49,8 @@ public:
 	InMemoryTableDataWriter(InMemoryCheckpointer &checkpoint_manager, TableCatalogEntry &table);
 
 public:
-	void WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) override;
+	void WriteUnchangedTable(MetaBlockPointer pointer, const vector<MetaBlockPointer> &metadata_pointers,
+	                         idx_t total_rows) override;
 	void FinalizeTable(const TableStatistics &global_stats, DataTableInfo &info, RowGroupCollection &collection,
 	                   Serializer &serializer) override;
 	unique_ptr<RowGroupWriter> GetRowGroupWriter(RowGroup &row_group) override;

--- a/src/include/duckdb/storage/table/persistent_table_data.hpp
+++ b/src/include/duckdb/storage/table/persistent_table_data.hpp
@@ -23,6 +23,7 @@ public:
 	~PersistentTableData();
 
 	MetaBlockPointer base_table_pointer;
+	vector<MetaBlockPointer> read_metadata_pointers;
 	TableStatistics table_stats;
 	idx_t total_rows;
 	idx_t row_group_count;

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -52,7 +52,7 @@ public:
 	void Initialize(PersistentCollectionData &data);
 	void Initialize(PersistentTableData &data);
 	void InitializeEmpty();
-	void FinalizeCheckpoint(MetaBlockPointer pointer);
+	void FinalizeCheckpoint(MetaBlockPointer pointer, const vector<MetaBlockPointer> &existing_pointers);
 
 	bool IsEmpty() const;
 
@@ -175,6 +175,8 @@ private:
 	atomic<idx_t> allocation_size;
 	//! Root metadata pointer, if the collection is loaded from disk
 	MetaBlockPointer metadata_pointer;
+	//! Other metadata pointers
+	vector<MetaBlockPointer> metadata_pointers;
 	//! Whether or not we need to append a new row group prior to appending
 	bool requires_new_row_group;
 };

--- a/src/include/duckdb/storage/table/row_group_segment_tree.hpp
+++ b/src/include/duckdb/storage/table/row_group_segment_tree.hpp
@@ -21,7 +21,7 @@ public:
 	explicit RowGroupSegmentTree(RowGroupCollection &collection);
 	~RowGroupSegmentTree() override;
 
-	void Initialize(PersistentTableData &data);
+	void Initialize(PersistentTableData &data, optional_ptr<vector<MetaBlockPointer>> read_pointers = nullptr);
 
 	MetaBlockPointer GetRootPointer() const {
 		return root_pointer;

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -116,7 +116,7 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 		metadata_manager.ClearModifiedBlocks(existing_pointers);
 
 		// verify that existing_pointers indeed corresponds to the metadata blocks
-		if (debug_verify_blocks || true) {
+		if (debug_verify_blocks) {
 			vector<MetaBlockPointer> read_pointers;
 			MetadataReader reader(metadata_manager, pointer, read_pointers);
 			auto bound_info = Binder::BindCreateTableCheckpoint(table.GetInfo(), table.schema);

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -2,10 +2,13 @@
 
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/serializer/binary_deserializer.hpp"
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
+#include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+#include "duckdb/storage/checkpoint/table_data_reader.hpp"
 #include "duckdb/storage/table/column_checkpoint_state.hpp"
 #include "duckdb/storage/table/table_statistics.hpp"
 #include "duckdb/storage/metadata/metadata_reader.hpp"
@@ -59,8 +62,11 @@ MetadataManager &SingleFileTableDataWriter::GetMetadataManager() {
 	return checkpoint_manager.GetMetadataManager();
 }
 
-void SingleFileTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) {
+void SingleFileTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer,
+                                                    const vector<MetaBlockPointer> &metadata_pointers,
+                                                    idx_t total_rows) {
 	existing_pointer = pointer;
+	existing_pointers = metadata_pointers;
 	existing_rows = total_rows;
 }
 
@@ -68,11 +74,14 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
                                               RowGroupCollection &collection, Serializer &serializer) {
 	MetaBlockPointer pointer;
 	idx_t total_rows;
+	auto debug_verify_blocks = DBConfig::GetSetting<DebugVerifyBlocksSetting>(GetDatabase());
 	if (!existing_pointer.IsValid()) {
 		// write the metadata
 		// store the current position in the metadata writer
 		// this is where the row groups for this table start
 		pointer = table_data_writer.GetMetaBlockPointer();
+		vector<MetaBlockPointer> written_pointers;
+		table_data_writer.SetWrittenPointers(written_pointers);
 
 		// Serialize statistics as a single unit
 		BinarySerializer stats_serializer(table_data_writer, serializer.GetOptions());
@@ -95,7 +104,8 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 			RowGroup::Serialize(row_group_pointer, row_group_serializer);
 			row_group_serializer.End();
 		}
-		collection.FinalizeCheckpoint(pointer);
+		table_data_writer.SetWrittenPointers(nullptr);
+		collection.FinalizeCheckpoint(pointer, written_pointers);
 	} else {
 		// we have existing metadata and the table is unchanged - write a pointer to the existing metadata
 		pointer = existing_pointer;
@@ -103,9 +113,44 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 
 		// label the blocks as used again to prevent them from being freed
 		auto &metadata_manager = checkpoint_manager.GetMetadataManager();
-		MetadataReader reader(metadata_manager, pointer);
-		auto blocks = reader.GetRemainingBlocks();
-		metadata_manager.ClearModifiedBlocks(blocks);
+		metadata_manager.ClearModifiedBlocks(existing_pointers);
+
+		// verify that existing_pointers indeed corresponds to the metadata blocks
+		if (debug_verify_blocks || true) {
+			vector<MetaBlockPointer> read_pointers;
+			MetadataReader reader(metadata_manager, pointer, read_pointers);
+			auto bound_info = Binder::BindCreateTableCheckpoint(table.GetInfo(), table.schema);
+			TableDataReader data_reader(reader, *bound_info, pointer);
+			data_reader.ReadTableData();
+			for (idx_t row_group = 0; row_group < bound_info->data->row_group_count; ++row_group) {
+				BinaryDeserializer deserializer(reader);
+				deserializer.Begin();
+				auto row_group_pointer = RowGroup::Deserialize(deserializer);
+				deserializer.End();
+			}
+			set<idx_t> existing_block_ids;
+			for (auto &ptr : existing_pointers) {
+				existing_block_ids.insert(ptr.block_pointer);
+			}
+			set<idx_t> all_read_block_ids;
+			for (auto &ptr : read_pointers) {
+				all_read_block_ids.insert(ptr.block_pointer);
+			}
+			if (existing_block_ids != all_read_block_ids) {
+				std::stringstream oss;
+				oss << "Existing: ";
+				for (auto &block : existing_pointers) {
+					oss << block << ", ";
+				}
+				oss << "\n";
+				oss << "Read: ";
+				for (auto &block : read_pointers) {
+					oss << block << ", ";
+				}
+				oss << "\n";
+				throw InternalException("Reading existing blocks does not yield same blocks: " + oss.str());
+			}
+		}
 	}
 
 	// Now begin the metadata as a unit
@@ -129,7 +174,6 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 
 	auto index_storage_infos = info.GetIndexes().SerializeToDisk(context, options);
 
-	auto debug_verify_blocks = DBConfig::GetSetting<DebugVerifyBlocksSetting>(GetDatabase());
 	if (debug_verify_blocks) {
 		for (auto &entry : index_storage_infos) {
 			for (auto &allocator : entry.allocator_infos) {

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -596,11 +596,13 @@ void CheckpointReader::ReadTableData(CatalogTransaction transaction, Deserialize
 	auto &binary_deserializer = dynamic_cast<BinaryDeserializer &>(deserializer);
 	auto &reader = dynamic_cast<MetadataReader &>(binary_deserializer.GetStream());
 
-	MetadataReader table_data_reader(reader.GetMetadataManager(), table_pointer);
+	vector<MetaBlockPointer> read_pointers;
+	MetadataReader table_data_reader(reader.GetMetadataManager(), table_pointer, read_pointers);
 	TableDataReader data_reader(table_data_reader, bound_info, table_pointer);
 	data_reader.ReadTableData();
 
 	bound_info.data->total_rows = total_rows;
+	bound_info.data->read_metadata_pointers = read_pointers;
 }
 
 } // namespace duckdb

--- a/src/storage/table/in_memory_checkpoint.cpp
+++ b/src/storage/table/in_memory_checkpoint.cpp
@@ -86,7 +86,8 @@ InMemoryTableDataWriter::InMemoryTableDataWriter(InMemoryCheckpointer &checkpoin
     : TableDataWriter(table, checkpoint_manager.GetClientContext()), checkpoint_manager(checkpoint_manager) {
 }
 
-void InMemoryTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer, idx_t total_rows) {
+void InMemoryTableDataWriter::WriteUnchangedTable(MetaBlockPointer pointer,
+                                                  const vector<MetaBlockPointer> &metadata_pointers, idx_t total_rows) {
 }
 
 void InMemoryTableDataWriter::FinalizeTable(const TableStatistics &global_stats, DataTableInfo &info,

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -30,12 +30,12 @@ RowGroupSegmentTree::RowGroupSegmentTree(RowGroupCollection &collection)
 RowGroupSegmentTree::~RowGroupSegmentTree() {
 }
 
-void RowGroupSegmentTree::Initialize(PersistentTableData &data) {
+void RowGroupSegmentTree::Initialize(PersistentTableData &data, optional_ptr<vector<MetaBlockPointer>> read_pointers) {
 	D_ASSERT(data.row_group_count > 0);
 	current_row_group = 0;
 	max_row_group = data.row_group_count;
 	finished_loading = false;
-	reader = make_uniq<MetadataReader>(collection.GetMetadataManager(), data.block_pointer);
+	reader = make_uniq<MetadataReader>(collection.GetMetadataManager(), data.block_pointer, read_pointers);
 	root_pointer = data.block_pointer;
 }
 
@@ -97,13 +97,16 @@ void RowGroupCollection::Initialize(PersistentTableData &data) {
 	D_ASSERT(this->row_start == 0);
 	auto l = row_groups->Lock();
 	this->total_rows = data.total_rows;
-	row_groups->Initialize(data);
-	stats.Initialize(types, data);
 	metadata_pointer = data.base_table_pointer;
+	metadata_pointers = data.read_metadata_pointers;
+	row_groups->Initialize(data, metadata_pointers);
+	stats.Initialize(types, data);
 }
 
-void RowGroupCollection::FinalizeCheckpoint(MetaBlockPointer pointer) {
+void RowGroupCollection::FinalizeCheckpoint(MetaBlockPointer pointer,
+                                            const vector<MetaBlockPointer> &existing_pointers) {
 	metadata_pointer = pointer;
+	metadata_pointers = existing_pointers;
 }
 
 void RowGroupCollection::Initialize(PersistentCollectionData &data) {
@@ -1176,7 +1179,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 				row_group.CheckpointDeletes(metadata_manager);
 				row_groups->AppendSegment(l, std::move(entry.node));
 			}
-			writer.WriteUnchangedTable(metadata_pointer, total_rows.load());
+			writer.WriteUnchangedTable(metadata_pointer, metadata_pointers, total_rows.load());
 			return;
 		}
 	}


### PR DESCRIPTION
We've noticed that checkpoints were occasionally reading a lot of metadata (Gigabytes) when the `experimental_metadata_reuse` functionality was enabled. The reason for this is that when an unchanged table was finalized, `SingleFileTableDataWriter::FinalizeTable` would reread and pin all of the metadata blocks that were written in a prior checkpoint (not just for this table, but other tables too). The logic that would do this in `SingleFileTableDataWriter::FinalizeTable` would do:
```
MetadataReader reader(metadata_manager, pointer);
auto blocks = reader.GetRemainingBlocks();
metadata_manager.ClearModifiedBlocks(blocks);
```
As the metadata is written out by a single MetadataWriter for all tables, this would potentially load and repin the metadata for all tables (as `reader.GetRemainingBlocks()` would not know when to stop reading).

The PR here changes the code in `SingleFileTableDataWriter::FinalizeTable` to instead identify the metadata blocks of the given table that are left unchanged (and keep exactly those around).