### PR TITLE
[Optimizer] Push down `variant_extract` + cast into the storage layer

### DIFF
--- a/benchmark/tpch/variant/tpch_q1_variant.benchmark
+++ b/benchmark/tpch/variant/tpch_q1_variant.benchmark
@@ -1,0 +1,44 @@
+# name: benchmark/tpch/variant/tpch_q1_variant.benchmark
+# description: Run Q01 over lineitem stored in variants
+# group: [variant]
+
+name Q01 variants
+group tpch
+subgroup sf1
+storage persistent
+
+require tpch
+
+cache tpch_variant_sf1.duckdb
+
+load
+CALL dbgen(sf=1, suffix='_normalized');
+SET variant_minimum_shredding_size = 0;
+create table lineitem_variant as select
+	struct_pack(*COLUMNS(lineitem_normalized.* EXCLUDE l_shipdate))::VARIANT lineitem,
+	l_shipdate
+from lineitem_normalized;
+checkpoint;
+CREATE VIEW lineitem AS SELECT
+	lineitem.l_orderkey::DECIMAL(15,2) l_orderkey,
+	lineitem.l_partkey::DECIMAL(15,2) l_partkey,
+	lineitem.l_suppkey::DECIMAL(15,2) l_suppkey,
+	lineitem.l_linenumber::DECIMAL(15,2) l_linenumber,
+	lineitem.l_quantity::DECIMAL(15,2) l_quantity,
+	lineitem.l_extendedprice::DECIMAL(15,2) l_extendedprice,
+	lineitem.l_discount::DECIMAL(15,2) l_discount,
+	lineitem.l_tax::DECIMAL(15,2) l_tax,
+	lineitem.l_returnflag::VARCHAR l_returnflag,
+	lineitem.l_linestatus::VARCHAR l_linestatus,
+	l_shipdate,
+	lineitem.l_commitdate::DATE l_commitdate,
+	lineitem.l_receiptdate::DATE l_receiptdate,
+	lineitem.l_shipinstruct::VARCHAR l_shipinstruct,
+	lineitem.l_shipmode::VARCHAR l_shipmode,
+	lineitem.l_comment::VARCHAR l_comment
+FROM
+	lineitem_variant
+
+run extension/tpch/dbgen/queries/q01.sql
+
+result extension/tpch/dbgen/answers/sf1/q01.csv

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -5113,6 +5113,7 @@ UnionInvalidReason EnumUtil::FromString<UnionInvalidReason>(const char *value) {
 
 const StringUtil::EnumStringLiteral *GetVariantChildLookupModeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(VariantChildLookupMode::INVALID), "INVALID" },
 		{ static_cast<uint32_t>(VariantChildLookupMode::BY_KEY), "BY_KEY" },
 		{ static_cast<uint32_t>(VariantChildLookupMode::BY_INDEX), "BY_INDEX" }
 	};
@@ -5121,12 +5122,12 @@ const StringUtil::EnumStringLiteral *GetVariantChildLookupModeValues() {
 
 template<>
 const char* EnumUtil::ToChars<VariantChildLookupMode>(VariantChildLookupMode value) {
-	return StringUtil::EnumToString(GetVariantChildLookupModeValues(), 2, "VariantChildLookupMode", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetVariantChildLookupModeValues(), 3, "VariantChildLookupMode", static_cast<uint32_t>(value));
 }
 
 template<>
 VariantChildLookupMode EnumUtil::FromString<VariantChildLookupMode>(const char *value) {
-	return static_cast<VariantChildLookupMode>(StringUtil::StringToEnum(GetVariantChildLookupModeValues(), 2, "VariantChildLookupMode", value));
+	return static_cast<VariantChildLookupMode>(StringUtil::StringToEnum(GetVariantChildLookupModeValues(), 3, "VariantChildLookupMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetVariantLogicalTypeValues() {

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -285,10 +285,26 @@ void AddProjectionNames(const ColumnIndex &index, const string &name, const Logi
 		result += name;
 		return;
 	}
-	auto &child_types = StructType::GetChildTypes(type);
-	for (auto &child_index : index.GetChildIndexes()) {
-		auto &ele = child_types[child_index.GetPrimaryIndex()];
-		AddProjectionNames(child_index, name + "." + ele.first, ele.second, result);
+
+	if (type.id() == LogicalTypeId::STRUCT) {
+		auto &child_types = StructType::GetChildTypes(type);
+		for (auto &child_index : index.GetChildIndexes()) {
+			if (child_index.HasPrimaryIndex()) {
+				auto &ele = child_types[child_index.GetPrimaryIndex()];
+				AddProjectionNames(child_index, name + "." + ele.first, ele.second, result);
+			} else {
+				auto field_type = child_index.HasType() ? child_index.GetType() : LogicalType::VARIANT();
+				AddProjectionNames(child_index, name + "." + child_index.GetFieldName(), field_type, result);
+			}
+		}
+	} else if (type.id() == LogicalTypeId::VARIANT) {
+		for (auto &child_index : index.GetChildIndexes()) {
+			D_ASSERT(!child_index.HasPrimaryIndex());
+			auto field_type = child_index.HasType() ? child_index.GetType() : LogicalType::VARIANT();
+			AddProjectionNames(child_index, name + "." + child_index.GetFieldName(), field_type, result);
+		}
+	} else {
+		throw InternalException("Unexpected type (%s) in AddProjectionNames", type.ToString());
 	}
 }
 

--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -8,42 +8,21 @@
 
 namespace duckdb {
 
-namespace {
-
-struct BindData : public FunctionData {
-public:
-	explicit BindData(const string &str);
-	explicit BindData(uint32_t index);
-	BindData(const BindData &other) = default;
-
-public:
-	unique_ptr<FunctionData> Copy() const override;
-	bool Equals(const FunctionData &other) const override;
-
-public:
-	VariantPathComponent component;
-};
-
-} // namespace
-
-BindData::BindData(const string &str) : FunctionData() {
-	component.lookup_mode = VariantChildLookupMode::BY_KEY;
-	component.key = str;
+VariantExtractBindData::VariantExtractBindData(const string &str) : FunctionData(), component(str) {
 }
-BindData::BindData(uint32_t index) : FunctionData() {
+VariantExtractBindData::VariantExtractBindData(uint32_t index) : FunctionData() {
 	if (index == 0) {
 		throw BinderException("Extracting index 0 from VARIANT(ARRAY) is invalid, indexes are 1-based");
 	}
-	component.lookup_mode = VariantChildLookupMode::BY_INDEX;
-	component.index = index - 1;
+	component = VariantPathComponent(index - 1);
 }
 
-unique_ptr<FunctionData> BindData::Copy() const {
-	return make_uniq<BindData>(*this);
+unique_ptr<FunctionData> VariantExtractBindData::Copy() const {
+	return make_uniq<VariantExtractBindData>(*this);
 }
 
-bool BindData::Equals(const FunctionData &other) const {
-	auto &bind_data = other.Cast<BindData>();
+bool VariantExtractBindData::Equals(const FunctionData &other) const {
+	auto &bind_data = other.Cast<VariantExtractBindData>();
 	if (bind_data.component.lookup_mode != component.lookup_mode) {
 		return false;
 	}
@@ -68,62 +47,26 @@ static bool GetConstantArgument(ClientContext &context, Expression &expr, Value 
 	return false;
 }
 
-optional_ptr<const BaseStatistics> FindShreddedStats(const BaseStatistics &shredded,
-                                                     const VariantPathComponent &component) {
-	D_ASSERT(shredded.GetType().id() == LogicalTypeId::STRUCT);
-	D_ASSERT(StructType::GetChildTypes(shredded.GetType()).size() == 2);
-
-	auto &typed_value_type = StructType::GetChildTypes(shredded.GetType())[1].second;
-	auto &typed_value_stats = StructStats::GetChildStats(shredded, 1);
-	switch (component.lookup_mode) {
-	case VariantChildLookupMode::BY_INDEX: {
-		if (typed_value_type.id() != LogicalTypeId::LIST) {
-			return nullptr;
-		}
-		auto &child_stats = ListStats::GetChildStats(typed_value_stats);
-		return child_stats;
-	}
-	case VariantChildLookupMode::BY_KEY: {
-		if (typed_value_type.id() != LogicalTypeId::STRUCT) {
-			return nullptr;
-		}
-		auto &object_fields = StructType::GetChildTypes(typed_value_type);
-		for (idx_t i = 0; i < object_fields.size(); i++) {
-			auto &object_field = object_fields[i];
-			if (StringUtil::CIEquals(object_field.first, component.key)) {
-				return StructStats::GetChildStats(typed_value_stats, i);
-			}
-		}
-		return nullptr;
-	}
-	default:
-		throw InternalException("VariantChildLookupMode::%s not implemented for FindShreddedStats",
-		                        EnumUtil::ToString(component.lookup_mode));
-	}
-}
-
 static unique_ptr<BaseStatistics> VariantExtractPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto &child_stats = input.child_stats;
 	auto &bind_data = input.bind_data;
 
-	auto &info = bind_data->Cast<BindData>();
+	auto &info = bind_data->Cast<VariantExtractBindData>();
 	auto &variant_stats = child_stats[0];
 	const bool is_shredded = VariantStats::IsShredded(variant_stats);
 	if (!is_shredded) {
 		return nullptr;
 	}
 	auto &shredded_stats = VariantStats::GetShreddedStats(variant_stats);
-	auto found_stats = FindShreddedStats(shredded_stats, info.component);
-	if (!found_stats) {
+	if (!VariantShreddedStats::IsFullyShredded(shredded_stats)) {
+		return nullptr;
+	}
+	auto found_stats = VariantShreddedStats::FindChildStats(shredded_stats, info.component);
+	if (!found_stats || !VariantShreddedStats::IsFullyShredded(*found_stats)) {
 		return nullptr;
 	}
 
-	auto &unshredded_stats = VariantStats::GetUnshreddedStats(variant_stats);
-	auto child_variant_stats = VariantStats::CreateShredded(found_stats->GetType());
-	VariantStats::SetUnshreddedStats(child_variant_stats, unshredded_stats);
-	VariantStats::SetShreddedStats(child_variant_stats, *found_stats);
-
-	return child_variant_stats.ToUnique();
+	return VariantStats::WrapExtractedFieldAsVariant(variant_stats, *found_stats);
 }
 
 static unique_ptr<FunctionData> VariantExtractBind(ClientContext &context, ScalarFunction &bound_function,
@@ -143,29 +86,16 @@ static unique_ptr<FunctionData> VariantExtractBind(ClientContext &context, Scala
 	}
 
 	if (constant_arg.type().id() == LogicalTypeId::VARCHAR) {
-		return make_uniq<BindData>(constant_arg.GetValue<string>());
+		return make_uniq<VariantExtractBindData>(constant_arg.GetValue<string>());
 	} else if (constant_arg.type().id() == LogicalTypeId::UINTEGER) {
-		return make_uniq<BindData>(constant_arg.GetValue<uint32_t>());
+		return make_uniq<VariantExtractBindData>(constant_arg.GetValue<uint32_t>());
 	} else {
 		throw InternalException("Constant-folded argument was not of type UINTEGER or VARCHAR");
 	}
 }
 
-//! FIXME: it could make sense to allow a third argument: 'default'
-//! This can currently be achieved with COALESCE(TRY(<extract method>), 'default')
-static void VariantExtractFunction(DataChunk &input, ExpressionState &state, Vector &result) {
-	auto count = input.size();
-
-	D_ASSERT(input.ColumnCount() == 2);
-	auto &variant_vec = input.data[0];
-	D_ASSERT(variant_vec.GetType() == LogicalType::VARIANT());
-
-	auto &path = input.data[1];
-	D_ASSERT(path.GetVectorType() == VectorType::CONSTANT_VECTOR);
-	(void)path;
-
-	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
-	auto &info = func_expr.bind_info->Cast<BindData>();
+void VariantUtils::VariantExtract(Vector &variant_vec, const vector<VariantPathComponent> &components, Vector &result,
+                                  idx_t count) {
 	auto &allocator = Allocator::DefaultAllocator();
 
 	RecursiveUnifiedVectorFormat source_format;
@@ -176,58 +106,48 @@ static void VariantExtractFunction(DataChunk &input, ExpressionState &state, Vec
 	//! Extract always starts by looking at value_index 0
 	SelectionVector value_index_sel;
 	value_index_sel.Initialize(count);
-	for (idx_t i = 0; i < count; i++) {
-		value_index_sel[i] = 0;
-	}
 
 	SelectionVector new_value_index_sel;
 	new_value_index_sel.Initialize(count);
 
+	for (idx_t i = 0; i < count; i++) {
+		value_index_sel[i] = 0;
+	}
+
 	auto owned_nested_data = allocator.Allocate(sizeof(VariantNestedData) * count);
 	auto nested_data = reinterpret_cast<VariantNestedData *>(owned_nested_data.get());
 
-	auto &component = info.component;
-	auto expected_type = component.lookup_mode == VariantChildLookupMode::BY_INDEX ? VariantLogicalType::ARRAY
-	                                                                               : VariantLogicalType::OBJECT;
-	auto collection_result = VariantUtils::CollectNestedData(
-	    variant, expected_type, value_index_sel, count, optional_idx(), 0, nested_data, FlatVector::Validity(result));
-	if (!collection_result.success) {
-		if (expected_type == VariantLogicalType::ARRAY) {
-			throw InvalidInputException("Can't extract index %d from a VARIANT(%s)", component.index,
-			                            EnumUtil::ToString(collection_result.wrong_type));
-		} else {
-			D_ASSERT(expected_type == VariantLogicalType::OBJECT);
-			throw InvalidInputException("Can't extract key '%s' from a VARIANT(%s)", component.key,
-			                            EnumUtil::ToString(collection_result.wrong_type));
-		}
-	}
+	//! Perform the extract
+	ValidityMask validity(count);
+	for (idx_t i = 0; i < components.size(); i++) {
+		auto &component = components[i];
+		auto &input_indices = i % 2 == 0 ? value_index_sel : new_value_index_sel;
+		auto &output_indices = i % 2 == 0 ? new_value_index_sel : value_index_sel;
 
-	//! Look up the value_index of the child we're extracting
-	ValidityMask lookup_validity(count);
-	VariantUtils::FindChildValues(variant, component, nullptr, new_value_index_sel, lookup_validity, nested_data,
-	                              count);
-	if (!lookup_validity.AllValid()) {
-		optional_idx index;
-		for (idx_t i = 0; i < count; i++) {
-			if (!lookup_validity.RowIsValid(i)) {
-				index = i;
-				break;
+		auto expected_type = component.lookup_mode == VariantChildLookupMode::BY_INDEX ? VariantLogicalType::ARRAY
+		                                                                               : VariantLogicalType::OBJECT;
+
+		(void)VariantUtils::CollectNestedData(variant, expected_type, input_indices, count, optional_idx(), 0,
+		                                      nested_data, validity);
+		//! Look up the value_index of the child we're extracting
+		ValidityMask lookup_validity(count);
+		VariantUtils::FindChildValues(variant, component, nullptr, output_indices, lookup_validity, nested_data,
+		                              validity, count);
+
+		for (idx_t j = 0; j < count; j++) {
+			if (!validity.RowIsValid(j)) {
+				continue;
 			}
-		}
-		D_ASSERT(index.IsValid());
-		switch (component.lookup_mode) {
-		case VariantChildLookupMode::BY_INDEX: {
-			auto nested_index = index.GetIndex();
-			throw InvalidInputException("VARIANT(ARRAY(%d)) is missing index %d", nested_data[nested_index].child_count,
-			                            component.index);
-		}
-		case VariantChildLookupMode::BY_KEY: {
-			auto nested_index = index.GetIndex();
-			auto row_index = nested_index;
-			auto object_keys = VariantUtils::GetObjectKeys(variant, row_index, nested_data[nested_index]);
-			throw InvalidInputException("VARIANT(OBJECT(%s)) is missing key '%s'", StringUtil::Join(object_keys, ","),
-			                            component.key);
-		}
+			if (!lookup_validity.AllValid() && !lookup_validity.RowIsValid(j)) {
+				//! No child could be extracted, set to NULL
+				validity.SetInvalid(j);
+				continue;
+			}
+			//! Get the index into 'values'
+			auto type_id = variant.GetTypeId(j, output_indices[j]);
+			if (type_id == VariantLogicalType::VARIANT_NULL) {
+				validity.SetInvalid(j);
+			}
 		}
 	}
 
@@ -256,14 +176,16 @@ static void VariantExtractFunction(DataChunk &input, ExpressionState &state, Vec
 		result_values_data[i] = values_data[values.sel->get_index(i)];
 	}
 
+	auto &result_indices = components.size() % 2 == 0 ? value_index_sel : new_value_index_sel;
+
 	//! Prepare the selection vector to remap index 0 of each row
 	SelectionVector new_sel(0, values_list_size);
 	for (idx_t i = 0; i < count; i++) {
-		if (nested_data[i].is_null) {
+		if (!validity.RowIsValid(i)) {
 			continue;
 		}
 		auto &list_entry = values_data[values.sel->get_index(i)];
-		new_sel.set_index(list_entry.offset, list_entry.offset + new_value_index_sel[i]);
+		new_sel.set_index(list_entry.offset, list_entry.offset + result_indices[i]);
 	}
 
 	auto &result_type_id = VariantVector::GetValuesTypeId(result);
@@ -273,17 +195,42 @@ static void VariantExtractFunction(DataChunk &input, ExpressionState &state, Vec
 	result_byte_offset.Dictionary(VariantVector::GetValuesByteOffset(variant_vec), values_list_size, new_sel,
 	                              values_list_size);
 
-	auto value_is_null = VariantUtils::ValueIsNull(variant, new_value_index_sel, count, optional_idx());
-	if (!value_is_null.empty()) {
-		result.Flatten(count);
-		for (auto &i : value_is_null) {
-			FlatVector::SetNull(result, i, true);
+	if (!validity.AllValid()) {
+		//! Create a copy of the vector, because we used Reference before, and we now need to adjust the data
+		//! Which is a problem if we're still sharing the memory with 'input'
+		Vector other(result.GetType(), count);
+		VectorOperations::Copy(result, other, count, 0, 0);
+		result.Reference(other);
+
+		for (idx_t i = 0; i < count; i++) {
+			if (!validity.RowIsValid(i)) {
+				FlatVector::SetNull(result, i, true);
+			}
 		}
 	}
 
-	if (input.AllConstant()) {
+	if (variant_vec.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
+	result.Verify(count);
+}
+
+//! FIXME: it could make sense to allow a third argument: 'default'
+//! This can currently be achieved with COALESCE(TRY(<extract method>), 'default')
+static void VariantExtractFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto count = input.size();
+
+	D_ASSERT(input.ColumnCount() == 2);
+	auto &variant_vec = input.data[0];
+	D_ASSERT(variant_vec.GetType() == LogicalType::VARIANT());
+
+	auto &path = input.data[1];
+	D_ASSERT(path.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	(void)path;
+
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	auto &info = func_expr.bind_info->Cast<VariantExtractBindData>();
+	VariantUtils::VariantExtract(variant_vec, {info.component}, result, count);
 }
 
 ScalarFunctionSet VariantExtractFun::GetFunctions() {

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -823,7 +823,7 @@ static bool TableSupportsPushdownExtract(const FunctionData &bind_data_ref, cons
 		return false;
 	}
 	auto column_type = column.GetType();
-	if (column_type.id() != LogicalTypeId::STRUCT) {
+	if (column_type.id() != LogicalTypeId::STRUCT && column_type.id() != LogicalTypeId::VARIANT) {
 		return false;
 	}
 	return true;

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -198,8 +198,9 @@ void VariantShredding::WriteTypedObjectValues(UnifiedVariantVectorData &variant,
 		path_component.key = key;
 
 		ValidityMask lookup_validity(count);
+		ValidityMask all_valid_validity(count);
 		VariantUtils::FindChildValues(variant, path_component, sel, child_values_indexes, lookup_validity,
-		                              nested_data.get(), count);
+		                              nested_data.get(), all_valid_validity, count);
 
 		if (!lookup_validity.AllValid()) {
 			auto &child_variant_vectors = StructVector::GetEntries(child_vec);

--- a/src/include/duckdb/common/column_index_map.hpp
+++ b/src/include/duckdb/common/column_index_map.hpp
@@ -9,7 +9,8 @@ namespace duckdb {
 
 struct ColumnIndexHashFunction {
 	uint64_t operator()(const ColumnIndex &index) const {
-		auto hasher = std::hash<idx_t>();
+		auto index_hasher = std::hash<idx_t>();
+		auto field_hasher = std::hash<string>();
 		queue<reference<const ColumnIndex>> to_hash;
 
 		hash_t result = 0;
@@ -20,7 +21,12 @@ struct ColumnIndexHashFunction {
 			for (auto &child : children) {
 				to_hash.push(child);
 			}
-			result ^= hasher(current.get().GetPrimaryIndex());
+
+			if (current.get().HasPrimaryIndex()) {
+				result ^= index_hasher(current.get().GetPrimaryIndex());
+			} else {
+				result ^= field_hasher(current.get().GetFieldName());
+			}
 			to_hash.pop();
 		}
 		return result;

--- a/src/include/duckdb/common/types/variant.hpp
+++ b/src/include/duckdb/common/types/variant.hpp
@@ -17,9 +17,18 @@ struct UnifiedVariantVector;
 struct RecursiveUnifiedVectorFormat;
 struct UnifiedVectorFormat;
 
-enum class VariantChildLookupMode : uint8_t { BY_KEY, BY_INDEX };
+enum class VariantChildLookupMode : uint8_t { INVALID, BY_KEY, BY_INDEX };
 
 struct VariantPathComponent {
+public:
+	explicit VariantPathComponent() : lookup_mode(VariantChildLookupMode::INVALID) {
+	}
+	explicit VariantPathComponent(const string &key) : lookup_mode(VariantChildLookupMode::BY_KEY), key(key) {
+	}
+	explicit VariantPathComponent(uint32_t index) : lookup_mode(VariantChildLookupMode::BY_INDEX), index(index) {
+	}
+
+public:
 	VariantChildLookupMode lookup_mode;
 	string key;
 	uint32_t index;
@@ -30,8 +39,6 @@ struct VariantNestedData {
 	uint32_t child_count;
 	//! Index of the first child
 	uint32_t children_idx;
-	//! Whether the row is null
-	bool is_null;
 };
 
 struct VariantDecimalData {

--- a/src/include/duckdb/function/scalar/variant_utils.hpp
+++ b/src/include/duckdb/function/scalar/variant_utils.hpp
@@ -16,6 +16,20 @@
 
 namespace duckdb {
 
+struct VariantExtractBindData : public FunctionData {
+public:
+	explicit VariantExtractBindData(const string &str);
+	explicit VariantExtractBindData(uint32_t index);
+	VariantExtractBindData(const VariantExtractBindData &other) = default;
+
+public:
+	unique_ptr<FunctionData> Copy() const override;
+	bool Equals(const FunctionData &other) const override;
+
+public:
+	VariantPathComponent component;
+};
+
 struct VariantNestedDataCollectionResult {
 public:
 	VariantNestedDataCollectionResult() : success(true) {
@@ -73,10 +87,11 @@ struct VariantUtils {
 	DUCKDB_API static void FindChildValues(const UnifiedVariantVectorData &variant,
 	                                       const VariantPathComponent &component,
 	                                       optional_ptr<const SelectionVector> sel, SelectionVector &res,
-	                                       ValidityMask &res_validity, VariantNestedData *nested_data, idx_t count);
+	                                       ValidityMask &res_validity, const VariantNestedData *nested_data,
+	                                       const ValidityMask &validity, idx_t count);
 	DUCKDB_API static VariantNestedDataCollectionResult
 	CollectNestedData(const UnifiedVariantVectorData &variant, VariantLogicalType expected_type,
-	                  const SelectionVector &sel, idx_t count, optional_idx row, idx_t offset,
+	                  const SelectionVector &value_index_sel, idx_t count, optional_idx row, idx_t offset,
 	                  VariantNestedData *child_data, ValidityMask &validity);
 	DUCKDB_API static vector<uint32_t> ValueIsNull(const UnifiedVariantVectorData &variant, const SelectionVector &sel,
 	                                               idx_t count, optional_idx row);
@@ -85,6 +100,8 @@ struct VariantUtils {
 	DUCKDB_API static bool Verify(Vector &variant, const SelectionVector &sel_p, idx_t count);
 	DUCKDB_API static void FinalizeVariantKeys(Vector &variant, OrderedOwningStringMap<uint32_t> &dictionary,
 	                                           SelectionVector &sel, idx_t sel_size);
+	DUCKDB_API static void VariantExtract(Vector &input, const vector<VariantPathComponent> &components, Vector &result,
+	                                      idx_t count);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/expression_heuristics.hpp
+++ b/src/include/duckdb/optimizer/expression_heuristics.hpp
@@ -46,6 +46,6 @@ private:
 	static idx_t ExpressionCost(BoundFunctionExpression &expr);
 	static idx_t ExpressionCost(BoundOperatorExpression &expr, ExpressionType expr_type);
 	static idx_t ExpressionCost(PhysicalType return_type, idx_t multiplier);
-	static idx_t Cost(TableFilter &filter);
+	static idx_t Cost(const TableFilter &filter);
 };
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
+++ b/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
@@ -57,7 +57,7 @@ public:
 	static constexpr double DEFAULT_SELECTIVITY = 0.2;
 
 public:
-	static idx_t InspectTableFilter(idx_t cardinality, idx_t column_index, TableFilter &filter,
+	static idx_t InspectTableFilter(idx_t cardinality, idx_t column_index, const TableFilter &filter,
 	                                BaseStatistics &base_stats);
 	//	static idx_t InspectConjunctionOR(idx_t cardinality, idx_t column_index, ConjunctionOrFilter &filter,
 	//	                                  BaseStatistics &base_stats);

--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -89,13 +89,16 @@ protected:
 	//! ret: The amount of bindings created
 	idx_t ReplaceBinding(ColumnBinding current_binding, ColumnBinding new_binding);
 
-	bool HandleStructExtract(unique_ptr<Expression> *expression,
-	                         optional_ptr<unique_ptr<Expression>> cast_expression = nullptr);
+	bool HandleExtractExpression(unique_ptr<Expression> *expression,
+	                             optional_ptr<unique_ptr<Expression>> cast_expression = nullptr);
 
-	bool HandleStructExtractRecursive(unique_ptr<Expression> &expr, optional_ptr<BoundColumnRefExpression> &colref,
-	                                  vector<idx_t> &indexes, vector<ReferencedExtractComponent> &expressions);
+	bool HandleStructExtract(unique_ptr<Expression> &expr, optional_ptr<BoundColumnRefExpression> &colref,
+	                         reference<ColumnIndex> &path_ref, vector<ReferencedExtractComponent> &expressions);
+	bool HandleVariantExtract(unique_ptr<Expression> &expr, optional_ptr<BoundColumnRefExpression> &colref,
+	                          reference<ColumnIndex> &path_ref, vector<ReferencedExtractComponent> &expressions);
+	bool HandleExtractRecursive(unique_ptr<Expression> &expr, optional_ptr<BoundColumnRefExpression> &colref,
+	                            reference<ColumnIndex> &path_ref, vector<ReferencedExtractComponent> &expressions);
 	void SetMode(BaseColumnPrunerMode mode);
-	bool HandleStructPack(Expression &expr);
 	BaseColumnPrunerMode GetMode() const;
 
 private:
@@ -134,6 +137,6 @@ private:
 	void RewriteExpressions(LogicalProjection &proj, idx_t expression_count);
 	void WritePushdownExtractColumns(
 	    const ColumnBinding &binding, ReferencedColumn &col, idx_t original_idx, const LogicalType &column_type,
-	    const std::function<idx_t(const ColumnIndex &new_index, optional_ptr<LogicalType> cast_type)> &callback);
+	    const std::function<idx_t(const ColumnIndex &new_index, optional_ptr<const LogicalType> cast_type)> &callback);
 };
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -81,7 +81,7 @@ private:
 	//! Run a comparison between the statistics and the table filter; returns the prune result
 	FilterPropagateResult PropagateTableFilter(ColumnBinding stats_binding, BaseStatistics &stats, TableFilter &filter);
 	//! Update filter statistics from a TableFilter
-	void UpdateFilterStatistics(BaseStatistics &input, TableFilter &filter);
+	void UpdateFilterStatistics(BaseStatistics &input, const TableFilter &filter);
 
 	//! Add cardinalities together (i.e. new max is stats.max + new_stats.max): used for union
 	void AddCardinalities(unique_ptr<NodeStatistics> &stats, NodeStatistics &new_stats);

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -1096,6 +1096,18 @@
         "name": "type",
         "type": "LogicalType",
         "default": "LogicalType::INVALID"
+      },
+      {
+        "id": 5,
+        "name": "field",
+        "type": "string",
+        "default": "\"\""
+      },
+      {
+        "id": 6,
+        "name": "has_index",
+        "type": "bool",
+        "default": "true"
       }
     ],
     "pointer_type": "none"

--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -89,7 +89,7 @@ public:
 
 	void Set(StatsInfo info);
 	void CombineValidity(const BaseStatistics &left, const BaseStatistics &right);
-	void CopyValidity(BaseStatistics &stats);
+	void CopyValidity(const BaseStatistics &stats);
 	//! Set that the CURRENT level can have null values
 	//! Note that this is not correct for nested types unless this information is propagated in a different manner
 	//! Use Set(StatsInfo::CAN_HAVE_NULL_VALUES) in the general case

--- a/src/include/duckdb/storage/statistics/variant_stats.hpp
+++ b/src/include/duckdb/storage/statistics/variant_stats.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/types/variant.hpp"
 #include "duckdb/common/types/selection_vector.hpp"
+#include "duckdb/storage/storage_index.hpp"
 
 namespace duckdb {
 class BaseStatistics;
@@ -25,6 +26,8 @@ struct VariantStatsData {
 struct VariantShreddedStats {
 public:
 	DUCKDB_API static bool IsFullyShredded(const BaseStatistics &stats);
+	DUCKDB_API static optional_ptr<const BaseStatistics> FindChildStats(const BaseStatistics &stats,
+	                                                                    const VariantPathComponent &component);
 };
 
 //! VARIANT as a type can hold arbitrarily typed values within the same column.
@@ -65,6 +68,8 @@ public:
 
 	DUCKDB_API static bool MergeShredding(BaseStatistics &stats, const BaseStatistics &other,
 	                                      BaseStatistics &new_stats);
+	DUCKDB_API static unique_ptr<BaseStatistics> WrapExtractedFieldAsVariant(const BaseStatistics &base_variant,
+	                                                                         const BaseStatistics &extracted_field);
 
 public:
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
@@ -75,6 +80,8 @@ public:
 	DUCKDB_API static void Merge(BaseStatistics &stats, const BaseStatistics &other);
 	DUCKDB_API static void Verify(const BaseStatistics &stats, Vector &vector, const SelectionVector &sel, idx_t count);
 	DUCKDB_API static void Copy(BaseStatistics &stats, const BaseStatistics &other);
+	DUCKDB_API static unique_ptr<BaseStatistics> PushdownExtract(const BaseStatistics &stats,
+	                                                             const StorageIndex &index);
 
 private:
 	static VariantStatsData &GetDataUnsafe(BaseStatistics &stats);

--- a/src/include/duckdb/storage/storage_index.hpp
+++ b/src/include/duckdb/storage/storage_index.hpp
@@ -19,12 +19,20 @@ enum class StorageIndexType : uint8_t { FULL_READ, PUSHDOWN_EXTRACT };
 
 struct StorageIndex {
 public:
-	StorageIndex() : index(COLUMN_IDENTIFIER_ROW_ID), index_type(StorageIndexType::FULL_READ) {
+	StorageIndex() : has_index(true), index(COLUMN_IDENTIFIER_ROW_ID), index_type(StorageIndexType::FULL_READ) {
 	}
-	explicit StorageIndex(idx_t index) : index(index), index_type(StorageIndexType::FULL_READ) {
+	explicit StorageIndex(idx_t index) : has_index(true), index(index), index_type(StorageIndexType::FULL_READ) {
+	}
+	explicit StorageIndex(const string &field)
+	    : has_index(false), field(field), index_type(StorageIndexType::FULL_READ) {
 	}
 	StorageIndex(idx_t index, vector<StorageIndex> child_indexes_p)
-	    : index(index), index_type(StorageIndexType::FULL_READ), child_indexes(std::move(child_indexes_p)) {
+	    : has_index(true), index(index), index_type(StorageIndexType::FULL_READ),
+	      child_indexes(std::move(child_indexes_p)) {
+	}
+	StorageIndex(const string &field, vector<StorageIndex> child_indexes_p)
+	    : has_index(false), field(field), index_type(StorageIndexType::FULL_READ),
+	      child_indexes(std::move(child_indexes_p)) {
 	}
 
 	inline bool operator==(const StorageIndex &rhs) const {
@@ -43,7 +51,12 @@ public:
 		for (auto &child_id : column_id.GetChildIndexes()) {
 			result.push_back(StorageIndex::FromColumnIndex(child_id));
 		}
-		auto storage_index = StorageIndex(column_id.GetPrimaryIndex(), std::move(result));
+		StorageIndex storage_index;
+		if (column_id.HasPrimaryIndex()) {
+			storage_index = StorageIndex(column_id.GetPrimaryIndex(), std::move(result));
+		} else {
+			storage_index = StorageIndex(column_id.GetFieldName(), std::move(result));
+		}
 		if (column_id.HasType()) {
 			storage_index.SetType(column_id.GetType());
 		}
@@ -54,14 +67,30 @@ public:
 	}
 
 public:
+	bool HasPrimaryIndex() const {
+		return has_index;
+	}
 	idx_t GetPrimaryIndex() const {
+		D_ASSERT(has_index);
 		return index;
 	}
+	const string &GetFieldName() const {
+		D_ASSERT(!has_index);
+		return field;
+	}
 	PhysicalIndex ToPhysical() const {
+		D_ASSERT(has_index);
 		return PhysicalIndex(index);
 	}
 	bool HasType() const {
 		return type.id() != LogicalTypeId::INVALID;
+	}
+	const LogicalType &GetScanType() const {
+		D_ASSERT(HasType());
+		if (IsPushdownExtract()) {
+			return child_indexes[0].GetScanType();
+		}
+		return GetType();
 	}
 	const LogicalType &GetType() const {
 		return type;
@@ -95,14 +124,21 @@ public:
 		return index_type == StorageIndexType::PUSHDOWN_EXTRACT;
 	}
 	void SetIndex(idx_t new_index) {
+		D_ASSERT(has_index);
 		index = new_index;
 	}
 	bool IsRowIdColumn() const {
+		if (!has_index) {
+			return false;
+		}
 		return index == DConstants::INVALID_INDEX;
 	}
 
 private:
+	bool has_index = true;
 	idx_t index;
+	string field;
+
 	LogicalType type = LogicalType::INVALID;
 	StorageIndexType index_type;
 	vector<StorageIndex> child_indexes;

--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -67,6 +67,8 @@ public:
 	void SetValidityData(shared_ptr<ValidityColumnData> validity);
 	void SetChildData(shared_ptr<ColumnData> child_column);
 
+	const BaseStatistics &GetChildStats(const ColumnData &child) const override;
+
 protected:
 	//! The child-column of the list
 	shared_ptr<ColumnData> child_column;

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -104,6 +104,9 @@ public:
 		D_ASSERT(HasParent());
 		return *parent;
 	}
+
+	virtual const BaseStatistics &GetChildStats(const ColumnData &child) const;
+
 	const LogicalType &GetType() const {
 		return type;
 	}
@@ -202,6 +205,7 @@ public:
 	void MergeStatistics(const BaseStatistics &other);
 	void MergeIntoStatistics(BaseStatistics &other);
 	unique_ptr<BaseStatistics> GetStatistics() const;
+	const BaseStatistics &GetStatisticsRef() const;
 
 protected:
 	//! Append a transient segment

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -63,6 +63,8 @@ public:
 	void SetValidityData(shared_ptr<ValidityColumnData> validity_p);
 	void SetChildData(shared_ptr<ColumnData> child_column_p);
 
+	const BaseStatistics &GetChildStats(const ColumnData &child) const override;
+
 protected:
 	//! The child-column of the list
 	shared_ptr<ColumnData> child_column;

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -70,7 +70,7 @@ public:
 	void InitializeCreateIndexScan(CreateIndexScanState &state);
 	void InitializeScanWithOffset(const QueryContext &context, CollectionScanState &state,
 	                              const vector<StorageIndex> &column_ids, idx_t start_row, idx_t end_row);
-	static bool InitializeScanInRowGroup(const QueryContext &context, CollectionScanState &state,
+	static bool InitializeScanInRowGroup(ClientContext &context, CollectionScanState &state,
 	                                     RowGroupCollection &collection, SegmentNode<RowGroup> &row_group,
 	                                     idx_t vector_index, idx_t max_row);
 	void InitializeParallelScan(ParallelCollectionScanState &state);

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -133,6 +133,9 @@ struct ColumnScanState {
 	UpdateScanType update_scan_type = UpdateScanType::STANDARD;
 
 public:
+	void PushDownCast(const LogicalType &original_type, const LogicalType &cast_type);
+
+public:
 	void Initialize(const QueryContext &context_p, const LogicalType &type, const StorageIndex &column_id,
 	                optional_ptr<TableScanOptions> options);
 	void Initialize(const QueryContext &context_p, const LogicalType &type, optional_ptr<TableScanOptions> options);

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -16,6 +16,20 @@ namespace duckdb {
 //! Struct column data represents a struct
 class StructColumnData : public ColumnData {
 public:
+	struct StructColumnDataChild {
+	public:
+		StructColumnDataChild(ColumnData &col, optional_idx vector_index, ColumnScanState &child, bool should_scan)
+		    : col(col), vector_index(vector_index), state(child), should_scan(should_scan) {
+		}
+
+	public:
+		ColumnData &col;
+		optional_idx vector_index;
+		ColumnScanState &state;
+		bool should_scan;
+	};
+
+public:
 	StructColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, LogicalType type,
 	                 ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
@@ -27,8 +41,7 @@ public:
 	void InitializeScan(ColumnScanState &state) override;
 	void InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) override;
 
-	void IterateFields(ColumnScanState &state,
-	                   const std::function<void(idx_t child_index, optional_idx, ColumnScanState &, bool)> &callback);
+	vector<StructColumnDataChild> GetStructChildren(ColumnScanState &state) const;
 
 	idx_t Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	           idx_t scan_count) override;
@@ -67,6 +80,9 @@ public:
 
 	void SetValidityData(shared_ptr<ValidityColumnData> validity_p);
 	void SetChildData(idx_t i, shared_ptr<ColumnData> child_column_p);
+	const ColumnData &GetChildColumn(idx_t index) const;
+
+	const BaseStatistics &GetChildStats(const ColumnData &child) const override;
 
 protected:
 	//! The sub-columns of the struct

--- a/src/include/duckdb/storage/table/variant_column_data.hpp
+++ b/src/include/duckdb/storage/table/variant_column_data.hpp
@@ -33,7 +33,6 @@ public:
 	void InitializeScan(ColumnScanState &state) override;
 	void InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) override;
 
-	Vector CreateUnshreddingIntermediate(idx_t count);
 	idx_t Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	           idx_t scan_count) override;
 	idx_t ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset = 0) override;
@@ -76,9 +75,14 @@ public:
 	void SetChildData(vector<shared_ptr<ColumnData>> child_data);
 
 private:
+	Vector CreateUnshreddingIntermediate(idx_t count) const;
 	vector<shared_ptr<ColumnData>> WriteShreddedData(const RowGroup &row_group, const LogicalType &shredded_type,
 	                                                 BaseStatistics &stats);
+	bool PushdownShreddedFieldExtract(const StorageIndex &variant_extract, StorageIndex &out_struct_extract) const;
 	void CreateScanStates(ColumnScanState &state);
+	idx_t ScanWithCallback(ColumnScanState &state, Vector &result, idx_t target_count,
+	                       const std::function<idx_t(ColumnData &column, ColumnScanState &child_state,
+	                                                 Vector &target_vector, idx_t count)> &callback) const;
 	LogicalType GetShreddedType();
 };
 

--- a/src/optimizer/expression_heuristics.cpp
+++ b/src/optimizer/expression_heuristics.cpp
@@ -222,7 +222,7 @@ idx_t ExpressionHeuristics::Cost(Expression &expr) {
 	return 1000;
 }
 
-idx_t ExpressionHeuristics::Cost(TableFilter &filter) {
+idx_t ExpressionHeuristics::Cost(const TableFilter &filter) {
 	switch (filter.filter_type) {
 	case TableFilterType::DYNAMIC_FILTER:
 	case TableFilterType::OPTIONAL_FILTER:

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -354,6 +354,10 @@ FilterPushdownResult FilterCombiner::TryPushdownConstantFilter(TableFilterSet &t
 	if (!TryGetBoundColumnIndex(column_ids, expr, column_index)) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
+	if (column_index.IsPushdownExtract()) {
+		//! FIXME: can't push down filters on a column that has a pushed down extract currently
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
 
 	auto &constant_list = constant_values.find(equiv_set)->second;
 	for (auto &constant_cmp : constant_list) {
@@ -400,6 +404,10 @@ FilterPushdownResult FilterCombiner::TryPushdownGenericExpression(LogicalGet &ge
 	auto &column_ids = get.GetColumnIds();
 	auto expr_filter = make_uniq<ExpressionFilter>(std::move(filter_expr));
 	auto &column_index = column_ids[bindings[0].column_index];
+	if (column_index.IsPushdownExtract()) {
+		//! FIXME: can't support filters on a pushed down extract currently
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
 	get.table_filters.PushFilter(column_index, std::move(expr_filter));
 	return FilterPushdownResult::PUSHED_DOWN_FULLY;
 }
@@ -426,6 +434,10 @@ FilterPushdownResult FilterCombiner::TryPushdownPrefixFilter(TableFilterSet &tab
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	auto &column_index = column_ids[column_ref.binding.column_index];
+	if (column_index.IsPushdownExtract()) {
+		//! FIXME: can't support filter pushdown on pushed down extract currently
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
 	//! Replace prefix with a set of comparisons
 	auto lower_bound = make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value(prefix_string));
 	table_filters.PushFilter(column_index, std::move(lower_bound));
@@ -457,6 +469,11 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 	auto &column_ref = func.children[0]->Cast<BoundColumnRefExpression>();
 	auto &constant_value_expr = func.children[1]->Cast<BoundConstantExpression>();
 	auto &column_index = column_ids[column_ref.binding.column_index];
+	if (column_index.IsPushdownExtract()) {
+		//! FIXME: can't support filter pushdown on pushed down extract currently
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+
 	// constant value expr can sometimes be null. if so, push is not null filter, which will
 	// make the filter unsatisfiable and return no results.
 	if (constant_value_expr.value.IsNull()) {
@@ -508,6 +525,11 @@ FilterPushdownResult FilterCombiner::TryPushdownInFilter(TableFilterSet &table_f
 	}
 	auto &column_ref = func.children[0]->Cast<BoundColumnRefExpression>();
 	auto &column_index = column_ids[column_ref.binding.column_index];
+	if (column_index.IsPushdownExtract()) {
+		//! FIXME: can't support filter pushdown on pushed down extract currently
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+
 	//! check if all children are const expr
 	bool children_constant = true;
 	for (size_t i {1}; i < func.children.size(); i++) {
@@ -603,6 +625,10 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 		if (i == 0) {
 			auto &col_id = column_ids[column_ref->binding.column_index];
 			column_id = col_id.GetPrimaryIndex();
+			if (col_id.IsPushdownExtract()) {
+				//! FIXME: can't support filter pushdown on pushed down extract currently
+				return FilterPushdownResult::NO_PUSHDOWN;
+			}
 		} else if (column_id != column_ids[column_ref->binding.column_index].GetPrimaryIndex()) {
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -443,7 +443,7 @@ RelationStats RelationStatisticsHelper::ExtractEmptyResultStats(LogicalEmptyResu
 	return stats;
 }
 
-idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, idx_t column_index, TableFilter &filter,
+idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, idx_t column_index, const TableFilter &filter,
                                                    BaseStatistics &base_stats) {
 	auto cardinality_after_filters = cardinality;
 	switch (filter.filter_type) {

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -53,9 +53,10 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 		return make_uniq<LogicalEmptyResult>(std::move(op));
 	}
 
+	auto &column_ids = get.GetColumnIds();
 	//! We generate the table filters that will be executed during the table scan
 	vector<FilterPushdownResult> pushdown_results;
-	get.table_filters = combiner.GenerateTableScanFilters(get.GetColumnIds(), pushdown_results);
+	get.table_filters = combiner.GenerateTableScanFilters(column_ids, pushdown_results);
 
 	GenerateFilters();
 

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -15,7 +15,7 @@
 
 namespace duckdb {
 
-static void GetColumnIndex(unique_ptr<Expression> &expr, idx_t &index, string &alias) {
+static void GetColumnIndex(const unique_ptr<Expression> &expr, idx_t &index, string &alias) {
 	if (expr->type == ExpressionType::BOUND_REF) {
 		auto &bound_ref = expr->Cast<BoundReferenceExpression>();
 		index = bound_ref.index;
@@ -59,7 +59,7 @@ FilterPropagateResult StatisticsPropagator::PropagateTableFilter(ColumnBinding s
 	return filter.CheckStatistics(stats);
 }
 
-void StatisticsPropagator::UpdateFilterStatistics(BaseStatistics &input, TableFilter &filter) {
+void StatisticsPropagator::UpdateFilterStatistics(BaseStatistics &input, const TableFilter &filter) {
 	// FIXME: update stats...
 	switch (filter.filter_type) {
 	case TableFilterType::CONJUNCTION_AND: {
@@ -79,7 +79,7 @@ void StatisticsPropagator::UpdateFilterStatistics(BaseStatistics &input, TableFi
 	}
 }
 
-static bool IsConstantOrNullFilter(TableFilter &table_filter) {
+static bool IsConstantOrNullFilter(const TableFilter &table_filter) {
 	if (table_filter.filter_type != TableFilterType::EXPRESSION_FILTER) {
 		return false;
 	}
@@ -91,7 +91,7 @@ static bool IsConstantOrNullFilter(TableFilter &table_filter) {
 	return ConstantOrNull::IsConstantOrNull(func, Value::BOOLEAN(true));
 }
 
-static bool CanReplaceConstantOrNull(TableFilter &table_filter) {
+static bool CanReplaceConstantOrNull(const TableFilter &table_filter) {
 	if (!IsConstantOrNullFilter(table_filter)) {
 		throw InternalException("CanReplaceConstantOrNull() called on unexepected Table Filter");
 	}

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -220,6 +220,8 @@ void ColumnIndex::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<ColumnIndex>>(2, "child_indexes", child_indexes);
 	serializer.WritePropertyWithDefault<ColumnIndexType>(3, "index_type", index_type, ColumnIndexType::FULL_READ);
 	serializer.WritePropertyWithDefault<LogicalType>(4, "type", type, LogicalType::INVALID);
+	serializer.WritePropertyWithDefault<string>(5, "field", field, "");
+	serializer.WritePropertyWithDefault<bool>(6, "has_index", has_index, true);
 }
 
 ColumnIndex ColumnIndex::Deserialize(Deserializer &deserializer) {
@@ -228,6 +230,8 @@ ColumnIndex ColumnIndex::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadPropertyWithDefault<vector<ColumnIndex>>(2, "child_indexes", result.child_indexes);
 	deserializer.ReadPropertyWithExplicitDefault<ColumnIndexType>(3, "index_type", result.index_type, ColumnIndexType::FULL_READ);
 	deserializer.ReadPropertyWithExplicitDefault<LogicalType>(4, "type", result.type, LogicalType::INVALID);
+	deserializer.ReadPropertyWithExplicitDefault<string>(5, "field", result.field, "");
+	deserializer.ReadPropertyWithExplicitDefault<bool>(6, "has_index", result.has_index, true);
 	return result;
 }
 

--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -269,6 +269,8 @@ unique_ptr<BaseStatistics> BaseStatistics::PushdownExtract(const StorageIndex &i
 	switch (stats_type) {
 	case StatisticsType::STRUCT_STATS:
 		return StructStats::PushdownExtract(*this, index);
+	case StatisticsType::VARIANT_STATS:
+		return VariantStats::PushdownExtract(*this, index);
 	default:
 		throw InternalException("PushdownExtract not supported for StatisticsType::%s", EnumUtil::ToString(stats_type));
 	}
@@ -346,7 +348,7 @@ void BaseStatistics::CombineValidity(const BaseStatistics &left, const BaseStati
 	has_no_null = left.has_no_null || right.has_no_null;
 }
 
-void BaseStatistics::CopyValidity(BaseStatistics &stats) {
+void BaseStatistics::CopyValidity(const BaseStatistics &stats) {
 	has_null = stats.has_null;
 	has_no_null = stats.has_no_null;
 }

--- a/src/storage/statistics/variant_stats.cpp
+++ b/src/storage/statistics/variant_stats.cpp
@@ -105,6 +105,39 @@ static void AssertShreddedStats(const BaseStatistics &stats) {
 	}
 }
 
+optional_ptr<const BaseStatistics> VariantShreddedStats::FindChildStats(const BaseStatistics &stats,
+                                                                        const VariantPathComponent &component) {
+	AssertShreddedStats(stats);
+
+	auto &typed_value_stats = StructStats::GetChildStats(stats, 1);
+	auto &typed_value_type = typed_value_stats.GetType();
+	switch (component.lookup_mode) {
+	case VariantChildLookupMode::BY_INDEX: {
+		if (typed_value_type.id() != LogicalTypeId::LIST) {
+			return nullptr;
+		}
+		auto &child_stats = ListStats::GetChildStats(typed_value_stats);
+		return child_stats;
+	}
+	case VariantChildLookupMode::BY_KEY: {
+		if (typed_value_type.id() != LogicalTypeId::STRUCT) {
+			return nullptr;
+		}
+		auto &object_fields = StructType::GetChildTypes(typed_value_type);
+		for (idx_t i = 0; i < object_fields.size(); i++) {
+			auto &object_field = object_fields[i];
+			if (StringUtil::CIEquals(object_field.first, component.key)) {
+				return StructStats::GetChildStats(typed_value_stats, i);
+			}
+		}
+		return nullptr;
+	}
+	default:
+		throw InternalException("VariantChildLookupMode::%s not implemented for FindShreddedStats",
+		                        EnumUtil::ToString(component.lookup_mode));
+	}
+}
+
 bool VariantShreddedStats::IsFullyShredded(const BaseStatistics &stats) {
 	AssertShreddedStats(stats);
 
@@ -307,6 +340,18 @@ static BaseStatistics WrapTypedValue(BaseStatistics &untyped_value_index, BaseSt
 	StructStats::GetChildStats(shredded, 0).Copy(untyped_value_index);
 	StructStats::GetChildStats(shredded, 1).Copy(typed_value);
 	return shredded;
+}
+
+unique_ptr<BaseStatistics> VariantStats::WrapExtractedFieldAsVariant(const BaseStatistics &base_variant,
+                                                                     const BaseStatistics &extracted_field) {
+	D_ASSERT(base_variant.type.id() == LogicalTypeId::VARIANT);
+	AssertShreddedStats(extracted_field);
+
+	BaseStatistics copy = BaseStatistics::CreateUnknown(base_variant.GetType());
+	copy.Copy(base_variant);
+	copy.child_stats[1] = BaseStatistics::CreateUnknown(extracted_field.GetType());
+	copy.child_stats[1].Copy(extracted_field);
+	return copy.ToUnique();
 }
 
 bool VariantStats::MergeShredding(BaseStatistics &stats, const BaseStatistics &other, BaseStatistics &new_stats) {
@@ -520,6 +565,60 @@ const VariantStatsData &VariantStats::GetDataUnsafe(const BaseStatistics &stats)
 VariantStatsData &VariantStats::GetDataUnsafe(BaseStatistics &stats) {
 	AssertVariant(stats);
 	return stats.stats_union.variant_data;
+}
+
+static bool CanUseShreddedStats(optional_ptr<const BaseStatistics> shredded_stats) {
+	return shredded_stats && VariantShreddedStats::IsFullyShredded(*shredded_stats);
+}
+
+unique_ptr<BaseStatistics> VariantStats::PushdownExtract(const BaseStatistics &stats, const StorageIndex &index) {
+	if (!VariantStats::IsShredded(stats)) {
+		//! Not shredded at all, no stats available
+		return nullptr;
+	}
+
+	optional_ptr<const BaseStatistics> res(VariantStats::GetShreddedStats(stats));
+	if (!CanUseShreddedStats(res)) {
+		//! Not fully shredded, can't say anything meaningful about the stats
+		return nullptr;
+	}
+
+	reference<const StorageIndex> index_iter(index);
+	while (true) {
+		auto &current = index_iter.get();
+		D_ASSERT(!current.HasPrimaryIndex());
+		auto &field_name = current.GetFieldName();
+		VariantPathComponent path(field_name);
+		res = VariantShreddedStats::FindChildStats(*res, path);
+		if (!CanUseShreddedStats(res)) {
+			//! Not fully shredded, can't say anything meaningful about the stats
+			return nullptr;
+		}
+		if (!index_iter.get().HasChildren()) {
+			break;
+		}
+	}
+	auto &shredded_child_stats = *res;
+
+	auto &typed_value_stats = StructStats::GetChildStats(shredded_child_stats, 1);
+	auto &last_index = index_iter.get();
+	auto &child_type = typed_value_stats.type;
+	if (!last_index.HasType() || last_index.GetType().id() == LogicalTypeId::VARIANT) {
+		//! Return the variant stats, not the 'typed_value' (non-variant) stats, since there's no cast pushed down
+		return WrapExtractedFieldAsVariant(stats, shredded_child_stats);
+	}
+	if (!VariantShreddedStats::IsFullyShredded(shredded_child_stats)) {
+		//! Not all data is shredded, so there are values in the column that are not of the shredded type
+		return nullptr;
+	}
+
+	auto &cast_type = last_index.GetType();
+	if (child_type != cast_type) {
+		//! FIXME: support try_cast
+		return StatisticsPropagator::TryPropagateCast(typed_value_stats, child_type, cast_type);
+	}
+	auto result = typed_value_stats.ToUnique();
+	return result;
 }
 
 } // namespace duckdb

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -268,6 +268,14 @@ void ArrayColumnData::VisitBlockIds(BlockIdVisitor &visitor) const {
 	child_column->VisitBlockIds(visitor);
 }
 
+const BaseStatistics &ArrayColumnData::GetChildStats(const ColumnData &child) const {
+	if (!RefersToSameObject(child, *child_column)) {
+		throw InternalException("ArrayColumnData::GetChildStats provided column data is not a child of this array");
+	}
+	auto &stats = GetStatisticsRef();
+	return ArrayStats::GetChildStats(stats);
+}
+
 void ArrayColumnData::SetValidityData(shared_ptr<ValidityColumnData> validity_p) {
 	if (validity) {
 		throw InternalException("ArrayColumnData::SetValidityData cannot be used to overwrite existing validity");

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -326,6 +326,14 @@ void ListColumnData::VisitBlockIds(BlockIdVisitor &visitor) const {
 	child_column->VisitBlockIds(visitor);
 }
 
+const BaseStatistics &ListColumnData::GetChildStats(const ColumnData &child) const {
+	if (!RefersToSameObject(child, *child_column)) {
+		throw InternalException("ListColumnData::GetChildStats provided column data is not a child of this list");
+	}
+	auto &stats = GetStatisticsRef();
+	return ListStats::GetChildStats(stats);
+}
+
 void ListColumnData::SetValidityData(shared_ptr<ValidityColumnData> validity_p) {
 	if (validity) {
 		throw InternalException("ListColumnData::SetValidityData cannot be used to overwrite existing validity");

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -187,16 +187,18 @@ void RowGroup::InitializeEmpty(const vector<LogicalType> &types, ColumnDataType 
 	}
 }
 
-static unique_ptr<PushedDownExpressionState> CreateCast(ClientContext &context, const LogicalType &original_type,
-                                                        const LogicalType &cast_type) {
-	auto input = make_uniq<BoundReferenceExpression>(original_type, 0U);
-	auto cast_expression = BoundCastExpression::AddCastToType(context, std::move(input), cast_type);
-	auto res = make_uniq<PushedDownExpressionState>(context);
-	res->target.Initialize(context, {cast_type});
-	res->input.Initialize(context, {original_type});
-	res->executor.AddExpression(*cast_expression);
-	res->expression = std::move(cast_expression);
-	return res;
+void ColumnScanState::PushDownCast(const LogicalType &original_type, const LogicalType &cast_type) {
+	D_ASSERT(context.Valid());
+	D_ASSERT(!expression_state);
+	auto &client_context = *context.GetClientContext();
+
+	auto input = make_uniq<BoundReferenceExpression>(original_type, 0);
+	auto cast_expression = BoundCastExpression::AddCastToType(client_context, std::move(input), cast_type);
+	expression_state = make_uniq<PushedDownExpressionState>(client_context);
+	expression_state->target.Initialize(client_context, {cast_type});
+	expression_state->input.Initialize(client_context, {original_type});
+	expression_state->executor.AddExpression(*cast_expression);
+	expression_state->expression = std::move(cast_expression);
 }
 
 void ColumnScanState::Initialize(const QueryContext &context_p, const LogicalType &type, const StorageIndex &column_id,
@@ -217,6 +219,13 @@ void ColumnScanState::Initialize(const QueryContext &context_p, const LogicalTyp
 		// variant - column scan states are created later
 		// this is done because the internal shape of the VARIANT is different per rowgroup
 		scan_child_column.resize(2, true);
+		if (!storage_index.IsPushdownExtract()) {
+			return;
+		}
+		auto &scan_type = storage_index.GetScanType();
+		if (scan_type.id() != LogicalTypeId::VARIANT) {
+			PushDownCast(type, scan_type);
+		}
 		return;
 	}
 
@@ -244,7 +253,7 @@ void ColumnScanState::Initialize(const QueryContext &context_p, const LogicalTyp
 				auto child_index = child.GetPrimaryIndex();
 				auto &child_type = StructType::GetChildTypes(type)[child_index].second;
 				if (!child.HasChildren() && child_type != child.GetType()) {
-					expression_state = CreateCast(*context.GetClientContext(), child_type, child.GetType());
+					PushDownCast(child_type, child.GetType());
 				}
 				child_states[1].Initialize(context, struct_children[child_index].second, child, options);
 			} else {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -227,7 +227,7 @@ void RowGroupCollection::InitializeScanWithOffset(const QueryContext &context, C
 	}
 }
 
-bool RowGroupCollection::InitializeScanInRowGroup(const QueryContext &context, CollectionScanState &state,
+bool RowGroupCollection::InitializeScanInRowGroup(ClientContext &context, CollectionScanState &state,
                                                   RowGroupCollection &collection, SegmentNode<RowGroup> &row_group,
                                                   idx_t vector_index, idx_t max_row) {
 	state.max_row = max_row;

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -48,9 +48,8 @@ idx_t StructColumnData::GetMaxEntry() {
 	return sub_columns[0]->GetMaxEntry();
 }
 
-void StructColumnData::IterateFields(
-    ColumnScanState &state,
-    const std::function<void(idx_t child_index, optional_idx, ColumnScanState &, bool)> &callback) {
+vector<StructColumnData::StructColumnDataChild> StructColumnData::GetStructChildren(ColumnScanState &state) const {
+	vector<StructColumnData::StructColumnDataChild> res;
 	if (state.storage_index.IsPushdownExtract()) {
 		auto &index_children = state.storage_index.GetChildIndexes();
 		D_ASSERT(index_children.size() == 1);
@@ -58,25 +57,25 @@ void StructColumnData::IterateFields(
 		auto child_index = child_storage_index.GetPrimaryIndex();
 		auto &field_state = state.child_states[1];
 		D_ASSERT(state.scan_child_column[0]);
-		callback(child_index, optional_idx(), field_state, true);
+		res.emplace_back(*sub_columns[child_index], optional_idx(), field_state, true);
 	} else {
 		for (idx_t i = 0; i < sub_columns.size(); i++) {
 			auto &field_state = state.child_states[1 + i];
-			callback(i, i, field_state, state.scan_child_column[i]);
+			res.emplace_back(*sub_columns[i], i, field_state, state.scan_child_column[i]);
 		}
 	}
+	return res;
 }
 
 void StructColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {
 	validity->InitializePrefetch(prefetch_state, scan_state.child_states[0], rows);
-	IterateFields(scan_state, [&](idx_t child_index, optional_idx field_vector_index, ColumnScanState &field_state,
-	                              bool should_scan) {
-		if (!should_scan) {
-			return;
+	auto struct_children = GetStructChildren(scan_state);
+	for (auto &child : struct_children) {
+		if (!child.should_scan) {
+			continue;
 		}
-		auto &field = *sub_columns[child_index];
-		field.InitializePrefetch(prefetch_state, field_state, rows);
-	});
+		child.col.InitializePrefetch(prefetch_state, child.state, rows);
+	}
 }
 
 void StructColumnData::InitializeScan(ColumnScanState &state) {
@@ -87,14 +86,13 @@ void StructColumnData::InitializeScan(ColumnScanState &state) {
 	validity->InitializeScan(state.child_states[0]);
 
 	// initialize the sub-columns
-	IterateFields(
-	    state, [&](idx_t child_index, optional_idx field_vector_index, ColumnScanState &field_state, bool should_scan) {
-		    if (!should_scan) {
-			    return;
-		    }
-		    auto &field = *sub_columns[child_index];
-		    field.InitializeScan(field_state);
-	    });
+	auto struct_children = GetStructChildren(state);
+	for (auto &child : struct_children) {
+		if (!child.should_scan) {
+			continue;
+		}
+		child.col.InitializeScan(child.state);
+	}
 }
 
 void StructColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) {
@@ -106,14 +104,13 @@ void StructColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t ro
 	validity->InitializeScanWithOffset(state.child_states[0], row_idx);
 
 	// initialize the sub-columns
-	IterateFields(
-	    state, [&](idx_t child_index, optional_idx field_vector_index, ColumnScanState &field_state, bool should_scan) {
-		    if (!should_scan) {
-			    return;
-		    }
-		    auto &field = *sub_columns[child_index];
-		    field.InitializeScanWithOffset(field_state, row_idx);
-	    });
+	auto struct_children = GetStructChildren(state);
+	for (auto &child : struct_children) {
+		if (!child.should_scan) {
+			continue;
+		}
+		child.col.InitializeScanWithOffset(child.state, row_idx);
+	}
 }
 
 static Vector &GetFieldVectorForScan(Vector &result, optional_idx field_index) {
@@ -148,39 +145,38 @@ static void ScanChild(ColumnScanState &state, Vector &result, const std::functio
 idx_t StructColumnData::Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
                              idx_t target_count) {
 	auto scan_count = validity->Scan(transaction, vector_index, state.child_states[0], result, target_count);
-	IterateFields(
-	    state, [&](idx_t child_index, optional_idx field_vector_index, ColumnScanState &field_state, bool should_scan) {
-		    auto &target_vector = GetFieldVectorForScan(result, field_vector_index);
-		    if (!should_scan) {
-			    // if we are not scanning this vector - set it to NULL
-			    target_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
-			    ConstantVector::SetNull(target_vector, true);
-			    return;
-		    }
-		    auto &field = *sub_columns[child_index];
-		    ScanChild(state, target_vector, [&](Vector &child_result) {
-			    return field.Scan(transaction, vector_index, field_state, child_result, target_count);
-		    });
-	    });
+	auto struct_children = GetStructChildren(state);
+	for (auto &child : struct_children) {
+		auto &target_vector = GetFieldVectorForScan(result, child.vector_index);
+		if (!child.should_scan) {
+			// if we are not scanning this vector - set it to NULL
+			target_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(target_vector, true);
+			continue;
+		}
+		ScanChild(state, target_vector, [&](Vector &child_result) {
+			return child.col.Scan(transaction, vector_index, child.state, child_result, target_count);
+		});
+	}
 	return scan_count;
 }
 
 idx_t StructColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset) {
 	auto scan_count = validity->ScanCount(state.child_states[0], result, count);
-	IterateFields(
-	    state, [&](idx_t child_index, optional_idx field_vector_index, ColumnScanState &field_state, bool should_scan) {
-		    auto &target_vector = GetFieldVectorForScan(result, field_vector_index);
-		    if (!should_scan) {
-			    // if we are not scanning this vector - set it to NULL
-			    target_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
-			    ConstantVector::SetNull(target_vector, true);
-			    return;
-		    }
-		    auto &field = *sub_columns[child_index];
-		    ScanChild(state, target_vector, [&](Vector &child_result) {
-			    return field.ScanCount(field_state, child_result, count, result_offset);
-		    });
-	    });
+
+	auto struct_children = GetStructChildren(state);
+	for (auto &child : struct_children) {
+		auto &target_vector = GetFieldVectorForScan(result, child.vector_index);
+		if (!child.should_scan) {
+			// if we are not scanning this vector - set it to NULL
+			target_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(target_vector, true);
+			continue;
+		}
+		ScanChild(state, target_vector, [&](Vector &child_result) {
+			return child.col.ScanCount(child.state, child_result, count, result_offset);
+		});
+	}
 	return scan_count;
 }
 
@@ -188,14 +184,13 @@ void StructColumnData::Skip(ColumnScanState &state, idx_t count) {
 	validity->Skip(state.child_states[0], count);
 
 	// skip inside the sub-columns
-	IterateFields(
-	    state, [&](idx_t child_index, optional_idx field_vector_index, ColumnScanState &field_state, bool should_scan) {
-		    if (!should_scan) {
-			    return;
-		    }
-		    auto &field = *sub_columns[child_index];
-		    field.Skip(field_state, count);
-	    });
+	auto struct_children = GetStructChildren(state);
+	for (auto &child : struct_children) {
+		if (!child.should_scan) {
+			continue;
+		}
+		child.col.Skip(child.state, count);
+	}
 }
 
 void StructColumnData::InitializeAppend(ColumnAppendState &state) {
@@ -355,6 +350,29 @@ void StructColumnData::SetChildData(idx_t i, shared_ptr<ColumnData> child_column
 	}
 	child_column_p->SetParent(this);
 	this->sub_columns[i] = std::move(child_column_p);
+}
+
+const ColumnData &StructColumnData::GetChildColumn(idx_t index) const {
+	D_ASSERT(index < sub_columns.size());
+	return *sub_columns[index];
+}
+
+const BaseStatistics &StructColumnData::GetChildStats(const ColumnData &child) const {
+	optional_idx index;
+	for (idx_t i = 0; i < sub_columns.size(); i++) {
+		if (RefersToSameObject(child, *sub_columns[i])) {
+			index = i;
+			break;
+		}
+	}
+	if (!index.IsValid()) {
+		throw InternalException("StructColumnData::GetChildStats: Could not find a matching child index for the "
+		                        "provided child (of type %s)",
+		                        child.type.ToString());
+	}
+	auto idx = index.GetIndex();
+	auto &stats = GetStatisticsRef();
+	return StructStats::GetChildStats(stats, idx);
 }
 
 struct StructColumnCheckpointState : public ColumnCheckpointState {

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -1,10 +1,13 @@
 #include "duckdb/storage/table/variant_column_data.hpp"
+#include "duckdb/storage/table/struct_column_data.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/storage/table/column_checkpoint_state.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/storage/statistics/variant_stats.hpp"
+#include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/function/variant/variant_shredding.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
 
 namespace duckdb {
 
@@ -27,6 +30,106 @@ VariantColumnData::VariantColumnData(BlockManager &block_manager, DataTableInfo 
 	}
 }
 
+bool FindShreddedColumnInternal(const StructColumnData &shredded, reference<const BaseStatistics> &stats,
+                                reference<const StorageIndex> &path_iter, ColumnIndex &out) {
+	auto &path = path_iter.get();
+	D_ASSERT(!path.HasPrimaryIndex());
+	auto &field_name = path.GetFieldName();
+
+	D_ASSERT(shredded.type.id() == LogicalTypeId::STRUCT);
+	auto &typed_value = shredded.GetChildColumn(1);
+	auto &parent_stats = stats.get();
+
+	stats = StructStats::GetChildStats(parent_stats, 1);
+	if (typed_value.type.id() != LogicalTypeId::STRUCT) {
+		//! Not shredded on an OBJECT, but we're looking for a specific OBJECT field
+		return false;
+	}
+	if (!VariantShreddedStats::IsFullyShredded(parent_stats)) {
+		//! Can't push down to the shredded data, stats are inconsistent
+		return false;
+	}
+	//! shredded.typed_value
+	out.AddChildIndex(ColumnIndex(1));
+	auto &typed_value_index = out.GetChildIndex(0);
+
+	auto &object_children = StructType::GetChildTypes(typed_value.type);
+	optional_idx opt_index;
+	for (idx_t i = 0; i < object_children.size(); i++) {
+		if (StringUtil::CIEquals(field_name, object_children[i].first)) {
+			opt_index = i;
+			break;
+		}
+	}
+	if (!opt_index.IsValid()) {
+		//! OBJECT doesn't contain a field with this name
+		return false;
+	}
+
+	auto child_index = opt_index.GetIndex();
+	auto &typed_value_struct = typed_value.Cast<StructColumnData>();
+	auto &object_field = typed_value_struct.GetChildColumn(child_index);
+	stats = StructStats::GetChildStats(stats.get(), child_index);
+
+	//! typed_value.<child_name>
+	typed_value_index.AddChildIndex(ColumnIndex(child_index));
+	auto &child_column = typed_value_index.GetChildIndex(0);
+
+	if (!path.HasChildren()) {
+		if (!VariantShreddedStats::IsFullyShredded(stats.get())) {
+			//! Child isn't fully shredded, can't use it
+			return false;
+		}
+		//! We're done, we've found the field referenced by the path!
+		//! typed_value_index.<child_name>.typed_value
+		child_column.AddChildIndex(ColumnIndex(1));
+		stats = StructStats::GetChildStats(stats.get(), 1);
+		return true;
+	}
+	path_iter = path.GetChildIndex(0);
+
+	//! Child of object is always a STRUCT(untyped_value_index UINTEGER, typed_value <...>)
+	D_ASSERT(object_field.type.id() == LogicalTypeId::STRUCT);
+	auto &struct_field = object_field.Cast<StructColumnData>();
+
+	return FindShreddedColumnInternal(struct_field, stats, path_iter, child_column);
+}
+
+bool VariantColumnData::PushdownShreddedFieldExtract(const StorageIndex &variant_extract,
+                                                     StorageIndex &out_struct_extract) const {
+	D_ASSERT(IsShredded());
+	auto &shredded = *sub_columns[1];
+	D_ASSERT(shredded.type.id() == LogicalTypeId::STRUCT);
+	D_ASSERT(StructType::GetChildCount(shredded.type) == 2);
+	D_ASSERT(StructType::GetChildTypes(shredded.type)[0].second.id() == LogicalTypeId::UINTEGER);
+	auto &variant_stats = GetStatisticsRef();
+
+	if (!VariantStats::IsShredded(variant_stats)) {
+		//! FIXME: this happens when we Checkpoint but don't restart, the stats of the ColumnData aren't updated by
+		//! Checkpoint The variant is shredded, but there are no stats / the stats are cluttered (?)
+		return false;
+	}
+
+	//! shredded.typed_value
+	ColumnIndex column_index(0);
+	auto &struct_column = shredded.Cast<StructColumnData>();
+
+	reference<const BaseStatistics> shredded_stats(VariantStats::GetShreddedStats(variant_stats));
+	reference<const StorageIndex> path_iter(variant_extract);
+	if (!FindShreddedColumnInternal(struct_column, shredded_stats, path_iter, column_index)) {
+		return false;
+	}
+	if (shredded_stats.get().GetType().IsNested()) {
+		//! Can't push down an extract if the leaf we're extracting is not a primitive
+		//! (Since the shredded representation for OBJECT/ARRAY is interleaved with 'untyped_value_index' fields)
+		return false;
+	}
+
+	column_index.SetPushdownExtractType(shredded.type, path_iter.get().GetType());
+	out_struct_extract = StorageIndex::FromColumnIndex(column_index);
+	return true;
+}
+
 void VariantColumnData::CreateScanStates(ColumnScanState &state) {
 	//! Re-initialize the scan state, since VARIANT can have a different shape for every RowGroup
 	state.child_states.clear();
@@ -37,9 +140,22 @@ void VariantColumnData::CreateScanStates(ColumnScanState &state) {
 	auto unshredded_type = VariantShredding::GetUnshreddedType();
 	state.child_states.emplace_back(state.parent);
 	state.child_states[1].Initialize(state.context, unshredded_type, state.scan_options);
+
+	const bool is_pushed_down_cast =
+	    state.storage_index.HasType() && state.storage_index.GetScanType().id() != LogicalTypeId::VARIANT;
 	if (IsShredded()) {
 		auto &shredded_column = sub_columns[1];
 		state.child_states.emplace_back(state.parent);
+		if (state.storage_index.IsPushdownExtract() && is_pushed_down_cast) {
+			StorageIndex struct_extract;
+			if (PushdownShreddedFieldExtract(state.storage_index.GetChildIndex(0), struct_extract)) {
+				//! Shredded field exists and is fully shredded,
+				//! add the storage index to create a pushed-down 'struct_extract' to get the leaf
+				state.child_states[2].Initialize(state.context, shredded_column->type, struct_extract,
+				                                 state.scan_options);
+				return;
+			}
+		}
 		state.child_states[2].Initialize(state.context, shredded_column->type, state.scan_options);
 	}
 }
@@ -49,6 +165,7 @@ idx_t VariantColumnData::GetMaxEntry() {
 }
 
 void VariantColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {
+	//! FIXME: does this also need CreateScanStates ??
 	validity->InitializePrefetch(prefetch_state, scan_state.child_states[0], rows);
 	for (idx_t i = 0; i < sub_columns.size(); i++) {
 		sub_columns[i]->InitializePrefetch(prefetch_state, scan_state.child_states[i + 1], rows);
@@ -81,7 +198,7 @@ void VariantColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t r
 	}
 }
 
-Vector VariantColumnData::CreateUnshreddingIntermediate(idx_t count) {
+Vector VariantColumnData::CreateUnshreddingIntermediate(idx_t count) const {
 	D_ASSERT(IsShredded());
 	D_ASSERT(sub_columns.size() == 2);
 
@@ -93,26 +210,119 @@ Vector VariantColumnData::CreateUnshreddingIntermediate(idx_t count) {
 	return intermediate;
 }
 
-idx_t VariantColumnData::Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
-                              idx_t target_count) {
-	if (IsShredded()) {
-		auto intermediate = CreateUnshreddingIntermediate(target_count);
-		auto &child_vectors = StructVector::GetEntries(intermediate);
-		sub_columns[0]->Scan(transaction, vector_index, state.child_states[1], *child_vectors[0], target_count);
-		sub_columns[1]->Scan(transaction, vector_index, state.child_states[2], *child_vectors[1], target_count);
-		auto scan_count = validity->Scan(transaction, vector_index, state.child_states[0], intermediate, target_count);
+idx_t VariantColumnData::ScanWithCallback(
+    ColumnScanState &state, Vector &result, idx_t target_count,
+    const std::function<idx_t(ColumnData &column, ColumnScanState &child_state, Vector &target_vector, idx_t count)>
+        &callback) const {
+	if (state.storage_index.IsPushdownExtract()) {
+		if (IsShredded() && state.child_states[2].storage_index.IsPushdownExtract()) {
+			//! FIXME: We could also push down the extract if we're returning VARIANT
+			//! Then we can do the unshredding on the extracted data, rather than falling back to unshredding+extracting
+			//! This invariant is ensured by CreateScanStates
+			D_ASSERT(result.GetType().id() != LogicalTypeId::VARIANT);
 
-		VariantColumnData::UnshredVariantData(intermediate, result, target_count);
+			//! In the initialize we have verified that the field exists and the data is fully shredded (for this
+			//! rowgroup) We have created a scan state that performs a 'struct_extract' in the shredded data, to extract
+			//! the requested field.s
+			auto res = callback(*sub_columns[1], state.child_states[2], result, target_count);
+			if (result.GetType().id() == LogicalTypeId::LIST) {
+				//! Shredded ARRAY Variant looks like:
+				//! LIST(STRUCT(untyped_value_index UINTEGER, typed_value <child_type>))
+				//! We need to transform this to:
+				//! LIST(<child_type>)
+
+				auto &list_child = ListVector::GetEntry(result);
+				D_ASSERT(list_child.GetType().id() == LogicalTypeId::STRUCT);
+				D_ASSERT(StructType::GetChildCount(list_child.GetType()) == 2);
+
+				auto &typed_value = *StructVector::GetEntries(list_child)[1];
+				auto list_res = Vector(LogicalType::LIST(typed_value.GetType()));
+				ListVector::SetListSize(list_res, ListVector::GetListSize(result));
+				list_res.CopyBuffer(result);
+				ListVector::GetEntry(list_res).Reference(typed_value);
+				return res;
+			}
+			return res;
+		}
+		//! Fall back to unshredding
+		Vector intermediate(LogicalType::VARIANT(), target_count);
+		idx_t scan_count;
+		if (IsShredded()) {
+			auto unshredding_intermediate = CreateUnshreddingIntermediate(target_count);
+			auto &child_vectors = StructVector::GetEntries(unshredding_intermediate);
+
+			callback(*sub_columns[0], state.child_states[1], *child_vectors[0], target_count);
+			callback(*sub_columns[1], state.child_states[2], *child_vectors[1], target_count);
+			scan_count = callback(*validity, state.child_states[0], unshredding_intermediate, target_count);
+
+			VariantColumnData::UnshredVariantData(unshredding_intermediate, intermediate, target_count);
+		} else {
+			scan_count = callback(*validity, state.child_states[0], intermediate, target_count);
+			callback(*sub_columns[0], state.child_states[1], intermediate, target_count);
+		}
+
+		Vector extract_intermediate(LogicalType::VARIANT(), target_count);
+		vector<VariantPathComponent> components;
+		reference<const StorageIndex> path_iter(state.storage_index.GetChildIndex(0));
+
+		while (true) {
+			auto &current = path_iter.get();
+			auto &field_name = current.GetFieldName();
+			components.emplace_back(field_name);
+			if (!current.HasChildren()) {
+				break;
+			}
+			path_iter = current.GetChildIndex(0);
+		}
+		VariantUtils::VariantExtract(intermediate, components, extract_intermediate, target_count);
+
+		if (state.expression_state) {
+			auto &expression_state = *state.expression_state;
+			auto &executor = expression_state.executor;
+
+			auto &input = expression_state.input;
+			auto &target = expression_state.target;
+			input.Reset();
+			target.Reset();
+			input.data[0].Reference(extract_intermediate);
+			input.SetCardinality(scan_count);
+			executor.Execute(input, target);
+			result.Reference(target.data[0]);
+		} else {
+			result.Reference(extract_intermediate);
+		}
+		return scan_count;
+	} else {
+		if (IsShredded()) {
+			auto intermediate = CreateUnshreddingIntermediate(target_count);
+			auto &child_vectors = StructVector::GetEntries(intermediate);
+
+			callback(*sub_columns[0], state.child_states[1], *child_vectors[0], target_count);
+			callback(*sub_columns[1], state.child_states[2], *child_vectors[1], target_count);
+			auto scan_count = callback(*validity, state.child_states[0], intermediate, target_count);
+
+			VariantColumnData::UnshredVariantData(intermediate, result, target_count);
+			return scan_count;
+		}
+		auto scan_count = callback(*validity, state.child_states[0], result, target_count);
+		callback(*sub_columns[0], state.child_states[1], result, target_count);
 		return scan_count;
 	}
-	auto scan_count = validity->Scan(transaction, vector_index, state.child_states[0], result, target_count);
-	sub_columns[0]->Scan(transaction, vector_index, state.child_states[1], result, target_count);
-	return scan_count;
+}
+
+idx_t VariantColumnData::Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
+                              idx_t target_count) {
+	return ScanWithCallback(state, result, target_count,
+	                        [&](ColumnData &col, ColumnScanState &child_state, Vector &target_vector, idx_t count) {
+		                        return col.Scan(transaction, vector_index, child_state, target_vector, count);
+	                        });
 }
 
 idx_t VariantColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset) {
-	auto scan_count = sub_columns[0]->ScanCount(state.child_states[1], result, count, result_offset);
-	return scan_count;
+	return ScanWithCallback(state, result, count,
+	                        [&](ColumnData &col, ColumnScanState &child_state, Vector &target_vector, idx_t count) {
+		                        return col.ScanCount(child_state, target_vector, count, result_offset);
+	                        });
 }
 
 void VariantColumnData::Skip(ColumnScanState &state, idx_t count) {
@@ -242,35 +452,73 @@ unique_ptr<BaseStatistics> VariantColumnData::GetUpdateStatistics() {
 
 void VariantColumnData::FetchRow(TransactionData transaction, ColumnFetchState &state,
                                  const StorageIndex &storage_index, row_t row_id, Vector &result, idx_t result_idx) {
-	// insert any child states that are required
-	for (idx_t i = state.child_states.size(); i < sub_columns.size() + 1; i++) {
-		auto child_state = make_uniq<ColumnFetchState>();
-		state.child_states.push_back(std::move(child_state));
+	if (storage_index.IsPushdownExtract() && IsShredded()) {
+		StorageIndex struct_extract;
+		if (PushdownShreddedFieldExtract(storage_index.GetChildIndex(0), struct_extract)) {
+			//! Shredded field exists and is fully shredded,
+			//! add the storage index to create a pushed-down 'struct_extract' to get the leaf
+			sub_columns[1]->FetchRow(transaction, state, struct_extract, row_id, result, result_idx);
+			return;
+		}
 	}
-
+	Vector variant_vec(LogicalType::VARIANT(), result_idx + 1);
+	validity->FetchRow(transaction, state, storage_index, row_id, variant_vec, result_idx);
 	if (IsShredded()) {
 		auto intermediate = CreateUnshreddingIntermediate(result_idx + 1);
 		auto &child_vectors = StructVector::GetEntries(intermediate);
 		// fetch the validity state
-		validity->FetchRow(transaction, *state.child_states[0], storage_index, row_id, result, result_idx);
 		// fetch the sub-column states
+		StorageIndex empty(0);
 		for (idx_t i = 0; i < sub_columns.size(); i++) {
-			sub_columns[i]->FetchRow(transaction, *state.child_states[i + 1], storage_index, row_id, *child_vectors[i],
-			                         result_idx);
+			sub_columns[i]->FetchRow(transaction, state, empty, row_id, *child_vectors[i], result_idx);
 		}
 		if (result_idx) {
 			intermediate.SetValue(0, intermediate.GetValue(result_idx));
 		}
 
-		//! FIXME: adjust UnshredVariantData so we can write the value in place into 'result' directly.
-		Vector unshredded(result.GetType(), 1);
+		//! FIXME: adjust UnshredVariantData so we can write the value in place directly.
+		Vector unshredded(variant_vec.GetType(), 1);
 		VariantColumnData::UnshredVariantData(intermediate, unshredded, 1);
-		result.SetValue(result_idx, unshredded.GetValue(0));
+		variant_vec.SetValue(0, unshredded.GetValue(0));
+	} else {
+		sub_columns[0]->FetchRow(transaction, state, storage_index, row_id, variant_vec, result_idx);
+		if (result_idx) {
+			variant_vec.SetValue(0, variant_vec.GetValue(result_idx));
+		}
+	}
+
+	if (!storage_index.IsPushdownExtract()) {
+		//! No extract required
+		D_ASSERT(result.GetType().id() == LogicalTypeId::VARIANT);
+		result.SetValue(result_idx, variant_vec.GetValue(0));
 		return;
 	}
 
-	validity->FetchRow(transaction, *state.child_states[0], storage_index, row_id, result, result_idx);
-	sub_columns[0]->FetchRow(transaction, *state.child_states[1], storage_index, row_id, result, result_idx);
+	Vector extracted_variant(variant_vec.GetType(), 1);
+	vector<VariantPathComponent> components;
+	reference<const StorageIndex> path_iter(storage_index.GetChildIndex(0));
+
+	while (true) {
+		auto &current = path_iter.get();
+		auto &field_name = current.GetFieldName();
+		components.emplace_back(field_name);
+		if (!current.HasChildren()) {
+			break;
+		}
+		path_iter = current.GetChildIndex(0);
+	}
+	VariantUtils::VariantExtract(variant_vec, components, extracted_variant, 1);
+
+	if (result.GetType().id() == LogicalTypeId::VARIANT) {
+		//! No cast required
+		result.SetValue(result_idx, extracted_variant.GetValue(0));
+		return;
+	}
+
+	//! Need to perform the cast here as well
+	auto context = transaction.transaction->context.lock();
+	auto fetched_row = extracted_variant.GetValue(0).CastAs(*context, result.GetType());
+	result.SetValue(result_idx, fetched_row);
 }
 
 void VariantColumnData::VisitBlockIds(BlockIdVisitor &visitor) const {
@@ -345,11 +593,13 @@ public:
 
 	PersistentColumnData ToPersistentData() override {
 		PersistentColumnData data(original_column.type);
-		auto &variant_column_data = GetResultColumn().Cast<VariantColumnData>();
 		if (child_states.size() == 2) {
-			D_ASSERT(variant_column_data.sub_columns.size() == 2);
-			D_ASSERT(variant_column_data.sub_columns[1]->type.id() == LogicalTypeId::STRUCT);
-			data.SetVariantShreddedType(variant_column_data.sub_columns[1]->type);
+			//! Use the type of the column data we used to create the Checkpoint
+			//! This will either be a pointer to shredded_data[1] if we decided to shred
+			//! Or to the existing shredded column data if we didn't decide to reshred
+			auto &shredded_state = child_states[1];
+			D_ASSERT(shredded_state->original_column.type.id() == LogicalTypeId::STRUCT);
+			data.SetVariantShreddedType(shredded_state->original_column.type);
 		}
 		data.child_columns.push_back(validity_state->ToPersistentData());
 		for (auto &child_state : child_states) {

--- a/test/configs/peg_parser_strict.json
+++ b/test/configs/peg_parser_strict.json
@@ -189,6 +189,7 @@
         "test/sql/settings/allowed_directories.test",
         "test/sql/types/enum/test_enum.test",
         "test/sql/types/struct/nested_struct_projection_pushdown.test",
+        "test/sql/types/struct/struct_projection_pushdown.test",
         "test/sql/types/struct/struct_cast_superset.test",
         "test/sql/attach/attach_new_compression.test",
         "test/sql/attach/attach_wal_alter.test",

--- a/test/sql/function/variant/variant_extract.test
+++ b/test/sql/function/variant/variant_extract.test
@@ -35,10 +35,11 @@ CREATE MACRO struct_cast_data() AS TABLE (
 	]}::VARIANT
 );
 
-statement error
+query I
 select variant_extract(a, 'a[1].c') from struct_cast_data();
 ----
-Invalid Input Error: VARIANT(OBJECT(a)) is missing key 'a[1].c'
+NULL
+NULL
 
 query I
 select variant_extract(a, 'a').variant_extract(1::UINTEGER).variant_extract('c') from struct_cast_data();
@@ -59,15 +60,15 @@ select ('{"a": 42, "b": [true, "test", true]}'::JSON::VARIANT)['b'][2];
 test
 
 # When the argument is a string, it's taken as an object field, not an array index
-statement error
+query I
 select ('{"a": 42, "b": [true, "test", true]}'::JSON::VARIANT)['b']['1'];
 ----
-Invalid Input Error: Can't extract key '1' from a VARIANT(ARRAY)
+NULL
 
-statement error
+query I
 select ('{"a": 42, "b": [true, "test", true]}'::JSON::VARIANT)['b[2]'];
 ----
-Invalid Input Error: VARIANT(OBJECT(a,b)) is missing key 'b[2]'
+NULL
 
 query I
 select ('{"a": 42, "b": [true, "test", true]}'::JSON::VARIANT)['b'][2];

--- a/test/sql/function/variant/variant_extract_try_cast.test
+++ b/test/sql/function/variant/variant_extract_try_cast.test
@@ -1,0 +1,63 @@
+# name: test/sql/function/variant/variant_extract_try_cast.test
+# group: [variant]
+
+load __TEST_DIR__/variant_extract_try_cast.db
+
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+statement ok
+create table tbl(col VARIANT);
+
+statement ok
+insert into tbl SELECT * FROM UNNEST([
+	{'almost_a_number': c} for c in ['12', '24', '25a6', '24c', '16']
+])
+
+statement ok
+checkpoint
+
+restart
+
+query I
+from tbl order by all
+----
+{'almost_a_number': 12}
+{'almost_a_number': 16}
+{'almost_a_number': 24}
+{'almost_a_number': 24c}
+{'almost_a_number': 25a6}
+
+query I
+select col.almost_a_number from tbl order by all
+----
+12
+16
+24
+24c
+25a6
+
+# Can't use CAST
+statement error
+select col.almost_a_number::BIGINT from tbl order by all
+----
+Conversion Error: Could not convert string '25a6' to INT64
+
+# Use TRY_CAST instead
+query I
+select TRY_CAST(col.almost_a_number AS BIGINT) from tbl order by all
+----
+12
+16
+24
+NULL
+NULL
+
+statement ok
+set explain_output='optimized_only';
+
+# Very that the EXPLAIN plan doesn't contain a pushed down extract
+query II
+EXPLAIN select TRY_CAST(col.almost_a_number AS BIGINT) from tbl order by all
+----
+logical_opt	<REGEX>:.*Expressions:.*TRY_CAST.*

--- a/test/sql/function/variant/variant_shredded_extract_nested.test
+++ b/test/sql/function/variant/variant_shredded_extract_nested.test
@@ -1,0 +1,78 @@
+# name: test/sql/function/variant/variant_shredded_extract_nested.test
+# group: [variant]
+
+load __TEST_DIR__/nested_types.db
+
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+statement ok
+create table list_variant as select
+	{
+		'id': l_orderkey,
+		'my_list': [
+			l_orderkey,
+			l_orderkey + 1,
+			l_orderkey + 2
+		],
+		'my_struct': {
+			'a': l_orderkey,
+			'b': l_orderkey + 30
+		}
+	}::variant as list_variant
+from
+	range(5) t(l_orderkey)
+
+statement ok
+checkpoint
+
+# Extract of a LIST without a CAST
+query I
+select
+	list_variant.my_list
+from
+	list_variant
+limit
+	1;
+----
+[0, 1, 2]
+
+# Extract of a LIST with a CAST
+query I
+select
+	list_variant.my_list::BIGINT[]
+from
+	list_variant
+limit
+	1;
+----
+[0, 1, 2]
+
+# Extract of a STRUCT without a CAST
+query I
+select
+	list_variant.my_struct
+from
+	list_variant
+limit 1;
+----
+{'a': 0, 'b': 30}
+
+# Extract of a STRUCT with a CAST
+query I
+select
+	list_variant.my_struct::STRUCT(b BIGINT, a BIGINT)
+from
+	list_variant
+limit 1;
+----
+{'b': 30, 'a': 0}
+
+query I
+select
+	(list_variant.my_struct::STRUCT(b VARCHAR, a VARCHAR)).b[1]
+from
+	list_variant
+limit 1;
+----
+3

--- a/test/sql/storage/types/variant/list_of_variant.test
+++ b/test/sql/storage/types/variant/list_of_variant.test
@@ -1,0 +1,90 @@
+# name: test/sql/storage/types/variant/list_of_variant.test
+# group: [variant]
+
+load __TEST_DIR__/list_of_variant.db
+
+# Always shred
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+statement ok
+CREATE TABLE variant_list(col VARIANT[]);
+
+statement ok
+insert into variant_list select [{'a': 42, 'b': [1,2,3]}::VARIANT, NULL, 84] from range(122881)
+
+statement ok
+checkpoint
+
+restart
+
+query I
+select list_aggr([x.a::INTEGER for x in col if variant_typeof(x).starts_with('OBJECT')], 'sum') from variant_list limit 10
+----
+42
+42
+42
+42
+42
+42
+42
+42
+42
+42
+
+statement ok
+delete from variant_list
+
+statement ok
+insert into variant_list select [{'a': i::INTEGER}, {'a': i::INTEGER}, {'a': i::INTEGER}] from range(100) t(i)
+
+statement ok
+checkpoint
+
+restart
+
+query I
+select [x.a::INTEGER for x in col] from variant_list offset 50 limit 10
+----
+[50, 50, 50]
+[51, 51, 51]
+[52, 52, 52]
+[53, 53, 53]
+[54, 54, 54]
+[55, 55, 55]
+[56, 56, 56]
+[57, 57, 57]
+[58, 58, 58]
+[59, 59, 59]
+
+statement ok
+delete from variant_list
+
+statement ok
+insert into variant_list select [{'a': i::INTEGER}, {'a': i::INTEGER}, {'a': i::INTEGER}] from range(122881) t(i)
+
+statement ok
+checkpoint
+
+restart
+
+query I
+select [x.a::INTEGER for x in col] from variant_list offset 122880
+----
+[122880, 122880, 122880]
+
+statement ok
+delete from variant_list
+
+statement ok
+insert into variant_list select [{'a': i::INTEGER} for i in range(122881)]
+
+statement ok
+checkpoint
+
+restart
+
+query I
+select list_aggr([x.a::INTEGER for x in col], 'max') from variant_list
+----
+122880

--- a/test/sql/storage/types/variant/struct_of_variant.test
+++ b/test/sql/storage/types/variant/struct_of_variant.test
@@ -1,0 +1,49 @@
+# name: test/sql/storage/types/variant/struct_of_variant.test
+# group: [variant]
+
+load __TEST_DIR__/list_of_variant.db
+
+# Always shred
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+statement ok
+CREATE TABLE variant_list(
+	col STRUCT(
+		f1 INTEGER,
+		f2 VARIANT,
+		f3 VARCHAR,
+		f4 BOOL
+	)
+);
+
+statement ok
+INSERT INTO variant_list SELECT {
+	'f1': i,
+	'f2': {'a': i::INTEGER, 'b': 'val' || i},
+	'f3': 'test',
+	'f4': i % 2 == 0
+} from range(1000) t(i)
+
+statement ok
+checkpoint;
+
+restart
+
+query III
+select
+	col.f2.a::INTEGER,
+	col.f2.b::VARCHAR,
+	col.f4
+from variant_list limit 10
+----
+0	val0	true
+1	val1	false
+2	val2	true
+3	val3	false
+4	val4	true
+5	val5	false
+6	val6	true
+7	val7	false
+8	val8	true
+9	val9	false

--- a/test/sql/storage/types/variant/test_all_types_single_object.test
+++ b/test/sql/storage/types/variant/test_all_types_single_object.test
@@ -1,0 +1,53 @@
+# name: test/sql/storage/types/variant/test_all_types_single_object.test
+# group: [variant]
+
+load __TEST_DIR__/variant_test_all_types_single_table.db
+
+# Always shred
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+statement ok
+create table tbl (
+	col VARIANT
+)
+
+statement ok
+insert into tbl select t::VARIANT var from test_all_types() t
+
+statement ok
+checkpoint
+
+restart
+
+foreach col bool tinyint smallint int bigint hugeint uhugeint utinyint usmallint uint ubigint date time timestamp timestamp_s timestamp_ms timestamp_ns time_tz timestamp_tz float double dec_4_1 dec_9_4 dec_18_6 dec38_10 uuid interval varchar blob bit int_array double_array date_array timestamp_array timestamptz_array varchar_array nested_int_array struct struct_of_arrays array_of_structs map fixed_int_array fixed_varchar_array fixed_nested_int_array fixed_nested_varchar_array fixed_struct_array struct_of_fixed_array fixed_array_of_int_list list_of_fixed_int_array
+
+statement ok
+set variable col_type = (select typeof("${col}") from test_all_types() limit 1);
+
+statement ok
+set variable col_name = (select '${col}');
+
+# Select the regular column from 'test_all_types'
+query I nosort expected_res
+select "${col}" from test_all_types();
+----
+
+# Pushed down the extract + the cast
+# SELECT col.${col}::<col_type> from tbl
+query I nosort expected_res
+from query($$select col."$$ || getvariable('col_name') || $$"::$$ || getvariable('col_type') || ' from tbl');
+
+# Push down only the extract
+statement ok
+create or replace table intermediate as
+	from query($$select col."$$ || getvariable('col_name') || $$" extracted from tbl$$);
+
+# Add the cast to the regular type, to make the comparison work
+# SELECT extracted::<col_type> from intermediate
+query I nosort expected_res
+from query('select extracted::' || getvariable('col_type') || ' from intermediate');
+
+reset label expected_res
+
+endloop

--- a/test/sql/storage/types/variant/tpcds_sf1.test_slow
+++ b/test/sql/storage/types/variant/tpcds_sf1.test_slow
@@ -3,7 +3,7 @@
 
 require tpcds
 
-load __TEST_DIR__/tpcds_sf1_variant.db
+load __TEST_DIR__/tpcds_sf001_variant.db
 
 statement ok
 call dsdgen(sf=0.01, suffix='_normal')
@@ -62,7 +62,7 @@ CREATE VIEW web_site as SELECT
     web_site.web_gmt_offset::DECIMAL(5,2) as web_gmt_offset,
     web_site.web_tax_percentage::DECIMAL(5,2) as web_tax_percentage
 FROM
-    tpcds_sf1_variant.web_site_variant;
+    tpcds_sf001_variant.web_site_variant;
 
 statement ok
 CREATE VIEW web_sales as SELECT
@@ -101,7 +101,7 @@ CREATE VIEW web_sales as SELECT
     web_sales.ws_net_paid_inc_ship_tax::DECIMAL(7,2) as ws_net_paid_inc_ship_tax,
     web_sales.ws_net_profit::DECIMAL(7,2) as ws_net_profit
 FROM
-    tpcds_sf1_variant.web_sales_variant;
+    tpcds_sf001_variant.web_sales_variant;
 
 statement ok
 CREATE VIEW web_returns as SELECT
@@ -130,7 +130,7 @@ CREATE VIEW web_returns as SELECT
     web_returns.wr_account_credit::DECIMAL(7,2) as wr_account_credit,
     web_returns.wr_net_loss::DECIMAL(7,2) as wr_net_loss
 FROM
-    tpcds_sf1_variant.web_returns_variant;
+    tpcds_sf001_variant.web_returns_variant;
 
 statement ok
 CREATE VIEW web_page as SELECT
@@ -149,7 +149,7 @@ CREATE VIEW web_page as SELECT
     web_page.wp_image_count::BIGINT as wp_image_count,
     web_page.wp_max_ad_count::INTEGER as wp_max_ad_count
 FROM
-    tpcds_sf1_variant.web_page_variant;
+    tpcds_sf001_variant.web_page_variant;
 
 statement ok
 CREATE VIEW warehouse as SELECT
@@ -168,7 +168,7 @@ CREATE VIEW warehouse as SELECT
     warehouse.w_country::VARCHAR as w_country,
     warehouse.w_gmt_offset::DECIMAL(5,2) as w_gmt_offset
 FROM
-    tpcds_sf1_variant.warehouse_variant;
+    tpcds_sf001_variant.warehouse_variant;
 
 statement ok
 CREATE VIEW time_dim as SELECT
@@ -183,7 +183,7 @@ CREATE VIEW time_dim as SELECT
     time_dim.t_sub_shift::VARCHAR as t_sub_shift,
     time_dim.t_meal_time::VARCHAR as t_meal_time
 FROM
-    tpcds_sf1_variant.time_dim_variant;
+    tpcds_sf001_variant.time_dim_variant;
 
 statement ok
 CREATE VIEW store_sales as SELECT
@@ -211,7 +211,7 @@ CREATE VIEW store_sales as SELECT
     store_sales.ss_net_paid_inc_tax::DECIMAL(7,2) as ss_net_paid_inc_tax,
     store_sales.ss_net_profit::DECIMAL(7,2) as ss_net_profit
 FROM
-    tpcds_sf1_variant.store_sales_variant;
+    tpcds_sf001_variant.store_sales_variant;
 
 statement ok
 CREATE VIEW store_returns as SELECT
@@ -236,7 +236,7 @@ CREATE VIEW store_returns as SELECT
     store_returns.sr_store_credit::DECIMAL(7,2) as sr_store_credit,
     store_returns.sr_net_loss::DECIMAL(7,2) as sr_net_loss
 FROM
-    tpcds_sf1_variant.store_returns_variant;
+    tpcds_sf001_variant.store_returns_variant;
 
 statement ok
 CREATE VIEW store as SELECT
@@ -270,7 +270,7 @@ CREATE VIEW store as SELECT
     store.s_gmt_offset::DECIMAL(5,2) as s_gmt_offset,
     store.s_tax_percentage::DECIMAL(5,2) as s_tax_percentage
 FROM
-    tpcds_sf1_variant.store_variant;
+    tpcds_sf001_variant.store_variant;
 
 statement ok
 CREATE VIEW ship_mode as SELECT
@@ -281,7 +281,7 @@ CREATE VIEW ship_mode as SELECT
     ship_mode.sm_carrier::VARCHAR as sm_carrier,
     ship_mode.sm_contract::VARCHAR as sm_contract
 FROM
-    tpcds_sf1_variant.ship_mode_variant;
+    tpcds_sf001_variant.ship_mode_variant;
 
 statement ok
 CREATE VIEW reason as SELECT
@@ -289,7 +289,7 @@ CREATE VIEW reason as SELECT
     reason.r_reason_id::VARCHAR as r_reason_id,
     reason.r_reason_desc::VARCHAR as r_reason_desc
 FROM
-    tpcds_sf1_variant.reason_variant;
+    tpcds_sf001_variant.reason_variant;
 
 statement ok
 CREATE VIEW promotion as SELECT
@@ -313,7 +313,7 @@ CREATE VIEW promotion as SELECT
     promotion.p_purpose::VARCHAR as p_purpose,
     promotion.p_discount_active::VARCHAR as p_discount_active
 FROM
-    tpcds_sf1_variant.promotion_variant;
+    tpcds_sf001_variant.promotion_variant;
 
 statement ok
 CREATE VIEW item as SELECT
@@ -340,7 +340,7 @@ CREATE VIEW item as SELECT
     item.i_manager_id::BIGINT as i_manager_id,
     item.i_product_name::VARCHAR as i_product_name
 FROM
-    tpcds_sf1_variant.item_variant;
+    tpcds_sf001_variant.item_variant;
 
 statement ok
 CREATE VIEW inventory as SELECT
@@ -349,7 +349,7 @@ CREATE VIEW inventory as SELECT
     inventory.inv_warehouse_sk::BIGINT as inv_warehouse_sk,
     inventory.inv_quantity_on_hand::INTEGER as inv_quantity_on_hand
 FROM
-    tpcds_sf1_variant.inventory_variant;
+    tpcds_sf001_variant.inventory_variant;
 
 statement ok
 CREATE VIEW income_band as SELECT
@@ -357,7 +357,7 @@ CREATE VIEW income_band as SELECT
     income_band.ib_lower_bound::BIGINT as ib_lower_bound,
     income_band.ib_upper_bound::INTEGER as ib_upper_bound
 FROM
-    tpcds_sf1_variant.income_band_variant;
+    tpcds_sf001_variant.income_band_variant;
 
 statement ok
 CREATE VIEW household_demographics as SELECT
@@ -367,7 +367,7 @@ CREATE VIEW household_demographics as SELECT
     household_demographics.hd_dep_count::BIGINT as hd_dep_count,
     household_demographics.hd_vehicle_count::INTEGER as hd_vehicle_count
 FROM
-    tpcds_sf1_variant.household_demographics_variant;
+    tpcds_sf001_variant.household_demographics_variant;
 
 statement ok
 CREATE VIEW date_dim as SELECT
@@ -400,7 +400,7 @@ CREATE VIEW date_dim as SELECT
     date_dim.d_current_quarter::VARCHAR as d_current_quarter,
     date_dim.d_current_year::VARCHAR as d_current_year
 FROM
-    tpcds_sf1_variant.date_dim_variant;
+    tpcds_sf001_variant.date_dim_variant;
 
 statement ok
 CREATE VIEW customer_demographics as SELECT
@@ -414,7 +414,7 @@ CREATE VIEW customer_demographics as SELECT
     customer_demographics.cd_dep_employed_count::BIGINT as cd_dep_employed_count,
     customer_demographics.cd_dep_college_count::INTEGER as cd_dep_college_count
 FROM
-    tpcds_sf1_variant.customer_demographics_variant;
+    tpcds_sf001_variant.customer_demographics_variant;
 
 statement ok
 CREATE VIEW customer_address as SELECT
@@ -432,7 +432,7 @@ CREATE VIEW customer_address as SELECT
     customer_address.ca_gmt_offset::DECIMAL(5,2) as ca_gmt_offset,
     customer_address.ca_location_type::VARCHAR as ca_location_type
 FROM
-    tpcds_sf1_variant.customer_address_variant;
+    tpcds_sf001_variant.customer_address_variant;
 
 statement ok
 CREATE VIEW customer as SELECT
@@ -455,7 +455,7 @@ CREATE VIEW customer as SELECT
     customer.c_email_address::VARCHAR as c_email_address,
     customer.c_last_review_date_sk::INTEGER as c_last_review_date_sk
 FROM
-    tpcds_sf1_variant.customer_variant;
+    tpcds_sf001_variant.customer_variant;
 
 statement ok
 CREATE VIEW catalog_sales as SELECT
@@ -494,7 +494,7 @@ CREATE VIEW catalog_sales as SELECT
     catalog_sales.cs_net_paid_inc_ship_tax::DECIMAL(7,2) as cs_net_paid_inc_ship_tax,
     catalog_sales.cs_net_profit::DECIMAL(7,2) as cs_net_profit
 FROM
-    tpcds_sf1_variant.catalog_sales_variant;
+    tpcds_sf001_variant.catalog_sales_variant;
 
 statement ok
 CREATE VIEW catalog_returns as SELECT
@@ -526,7 +526,7 @@ CREATE VIEW catalog_returns as SELECT
     catalog_returns.cr_store_credit::DECIMAL(7,2) as cr_store_credit,
     catalog_returns.cr_net_loss::DECIMAL(7,2) as cr_net_loss
 FROM
-    tpcds_sf1_variant.catalog_returns_variant;
+    tpcds_sf001_variant.catalog_returns_variant;
 
 statement ok
 CREATE VIEW catalog_page as SELECT
@@ -540,7 +540,7 @@ CREATE VIEW catalog_page as SELECT
     catalog_page.cp_description::VARCHAR as cp_description,
     catalog_page.cp_type::VARCHAR as cp_type
 FROM
-    tpcds_sf1_variant.catalog_page_variant;
+    tpcds_sf001_variant.catalog_page_variant;
 
 statement ok
 CREATE VIEW call_center as SELECT
@@ -576,7 +576,7 @@ CREATE VIEW call_center as SELECT
     call_center.cc_gmt_offset::DECIMAL(5,2) as cc_gmt_offset,
     call_center.cc_tax_percentage::DECIMAL(5,2) as cc_tax_percentage
 FROM
-    tpcds_sf1_variant.call_center_variant;
+    tpcds_sf001_variant.call_center_variant;
 
 # --- Run queries ---
 

--- a/test/sql/storage/types/variant/variant_extract_stats.test
+++ b/test/sql/storage/types/variant/variant_extract_stats.test
@@ -42,10 +42,11 @@ select stats(col) from tbl limit 1;
 
 # ------------------------------ Extracting the child from the list is not possible for some rows ------------------------------
 
-statement error
-select stats(col[1]) from tbl offset 5;
+# Result is inconsistent, data isn't fully shredded
+query I
+select stats(col[1]) from tbl offset 5 limit 1;
 ----
-Invalid Input Error: Can't extract index 0 from a VARIANT(INT32)
+shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]
 
 statement ok
 delete from tbl where not variant_typeof(col).starts_with('ARRAY')
@@ -63,7 +64,7 @@ checkpoint
 query I
 select stats(col[1]) from tbl offset 5 limit 1;
 ----
-<REGEX>:.*shredding_state: SHREDDED.*fully_shredded: false}.*
+shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]
 
 statement ok
 delete from tbl;
@@ -83,6 +84,11 @@ shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]
 statement ok
 delete from tbl;
 
+statement ok
+checkpoint
+
+restart
+
 # ------------------------------ Tests with OBJECT and the OBJECT's fields ------------------------------
 
 statement ok
@@ -94,6 +100,8 @@ insert into tbl select {'a': 'test', 'b': false}
 statement ok
 checkpoint
 
+restart
+
 # Field 'a' is fully shredded
 query I
 select stats(col.a) from tbl limit 1;
@@ -104,7 +112,7 @@ select stats(col.a) from tbl limit 1;
 query I
 select stats(col.b) from tbl limit 1;
 ----
-<REGEX>:.*shredding_state: SHREDDED.*fully_shredded: false}.*
+shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]
 
 # OBJECT is fully shredded
 query I
@@ -134,7 +142,7 @@ select stats(col) from tbl limit 1;
 query I
 select stats(col.a) from tbl limit 1;
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: false.*
+shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]
 
 # Insert an object with additional field(s)
 statement ok
@@ -175,8 +183,8 @@ select stats(col) from tbl limit 1;
 ----
 <REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: false.*
 
-# We have no stats for field 'c' because it's not part of our shredding
+# Data is not fully shredded on the extracted field, result is inconsistent
 query I
-select stats(col.c) from tbl offset 2 limit 1;
+select stats(col.c) from tbl order by rowid offset 2 limit 1;
 ----
 shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]

--- a/test/sql/types/struct/nested_struct_projection_pushdown.test
+++ b/test/sql/types/struct/nested_struct_projection_pushdown.test
@@ -2,14 +2,24 @@
 # description: Test nested struct projection pushdown
 # group: [struct]
 
+load __TEST_DIR__/nested_struct_projection_pushdown.db
+
 require parquet
+
+# Always shred
+statement ok
+SET variant_minimum_shredding_size = 0;
 
 statement ok
 PRAGMA enable_verification
 
+foreach type struct variant
+
 # 2 layers of nesting
+
+onlyif type=struct
 statement ok
-CREATE TABLE test_structs(
+CREATE OR REPLACE TABLE test_structs(
 	id INT,
 	s STRUCT(
 		name STRUCT(
@@ -23,12 +33,24 @@ CREATE TABLE test_structs(
 	)
 );
 
+onlyif type=variant
+statement ok
+CREATE OR REPLACE TABLE test_structs(
+	id INT,
+	s VARIANT
+);
+
 statement ok
 INSERT INTO test_structs
 VALUES (1, {'name': {'v': 'Row 1', 'id': 1}, 'nested_struct': {'a': 42, 'b': true}}),
        (2, NULL),
        (3, {'name': {'v': 'Row 3', 'id': 3}, 'nested_struct': {'a': 84, 'b': NULL}}),
        (4, {'name': NULL, 'nested_struct': {'a': NULL, 'b': false}});
+
+statement ok
+checkpoint
+
+restart
 
 statement ok
 COPY test_structs TO '__TEST_DIR__/test_structs.parquet'
@@ -141,11 +163,18 @@ SELECT s.name.v FROM ${source} WHERE s.nested_struct.b
 ----
 Row 1
 
+# source
 endloop
 
 # 3 layers of nesting
+
+onlyif type=struct
 statement ok
-CREATE TABLE test_structs_nested(id INT, base STRUCT(s STRUCT(name STRUCT(v VARCHAR, id INT), nested_struct STRUCT(a integer, b bool))));
+CREATE OR REPLACE TABLE test_structs_nested(id INT, base STRUCT(s STRUCT(name STRUCT(v VARCHAR, id INT), nested_struct STRUCT(a integer, b bool))));
+
+onlyif type=variant
+statement ok
+CREATE OR REPLACE TABLE test_structs_nested(id INT, base VARIANT);
 
 statement ok
 INSERT INTO test_structs_nested
@@ -154,6 +183,10 @@ VALUES (1, {'s': {'name': {'v': 'Row 1', 'id': 1}, 'nested_struct': {'a': 42, 'b
        (3, {'s': {'name': {'v': 'Row 3', 'id': 3}, 'nested_struct': {'a': 84, 'b': NULL}}}),
        (4, {'s': {'name': NULL, 'nested_struct': {'a': NULL, 'b': false}}});
 
+statement ok
+checkpoint
+
+restart
 
 statement ok
 COPY test_structs_nested TO '__TEST_DIR__/test_structs.parquet'
@@ -200,12 +233,22 @@ NULL	NULL
 84	{'a': 84, 'b': NULL}
 NULL	{'a': NULL, 'b': false}
 
+onlyif type=struct
 query II
 SELECT base.s.nested_struct.a, base.s FROM ${source}
 ----
 42	{'name': {'v': Row 1, 'id': 1}, 'nested_struct': {'a': 42, 'b': true}}
 NULL	NULL
 84	{'name': {'v': Row 3, 'id': 3}, 'nested_struct': {'a': 84, 'b': NULL}}
+NULL	{'name': NULL, 'nested_struct': {'a': NULL, 'b': false}}
+
+onlyif type=variant
+query II
+SELECT base.s.nested_struct.a, variant_normalize(base.s) FROM ${source}
+----
+42	{'name': {'id': 1, 'v': Row 1}, 'nested_struct': {'a': 42, 'b': true}}
+NULL	NULL
+84	{'name': {'id': 3, 'v': Row 3}, 'nested_struct': {'a': 84, 'b': NULL}}
 NULL	{'name': NULL, 'nested_struct': {'a': NULL, 'b': false}}
 
 query II
@@ -229,4 +272,8 @@ SELECT base.s.name.v FROM ${source} WHERE base.s.nested_struct.b
 ----
 Row 1
 
+# source
+endloop
+
+# type
 endloop

--- a/test/sql/types/struct/struct_projection_pushdown.test
+++ b/test/sql/types/struct/struct_projection_pushdown.test
@@ -2,41 +2,44 @@
 # description: Test struct projection pushdown
 # group: [struct]
 
+load __TEST_DIR__/struct_projection_pushdown.db
+
 require parquet
+
+# Always shred
+statement ok
+SET variant_minimum_shredding_size = 0;
 
 statement ok
 PRAGMA enable_verification
 
+foreach type struct variant
+
+onlyif type=struct
 statement ok
-CREATE TABLE test_structs(
-	id INT,
-	s STRUCT(
-		a integer,
-		b bool
-	)
-);
+CREATE OR REPLACE TABLE test_structs(id INT, s STRUCT(a integer, b bool));
+
+onlyif type=variant
+statement ok
+CREATE OR REPLACE TABLE test_structs(id INT, s VARIANT);
 
 statement ok
-INSERT INTO test_structs VALUES
-	(
-		1, {
-			'a': 42,
-			'b': true
-		}
-	),
+INSERT INTO test_structs
+	VALUES (1, {
+		'a': 42,
+		'b': true
+	}),
 	(2, NULL),
-	(
-		3, {
-			'a': 84,
-			'b': NULL
-		}
-	),
-	(
-		4, {
-			'a': NULL,
-			'b': false
-		}
-	);
+	(3, {
+		'a': 84,
+		'b': NULL
+	}),
+	(4, {'a': NULL, 'b': false});
+
+statement ok
+checkpoint
+
+restart
 
 statement ok
 COPY test_structs TO '__TEST_DIR__/test_structs.parquet'
@@ -107,12 +110,19 @@ SELECT s FROM ${source} WHERE s.b
 ----
 {'a': 42, 'b': true}
 
+onlyif type=struct
 query I
 SELECT a FROM (SELECT UNNEST(s) FROM ${source}) WHERE b
 ----
 42
 
-# Add a cast
+onlyif type=variant
+statement error
+SELECT a FROM (SELECT UNNEST(s) FROM ${source}) WHERE b
+----
+Binder Error: UNNEST() can only be applied to lists, structs and NULL, not VARIANT
+
+onlyif type=struct
 query I
 SELECT a::BIGINT FROM (SELECT UNNEST(s) FROM ${source}) WHERE b::INTEGER
 ----
@@ -132,3 +142,5 @@ query II
 SELECT s['b'], s.a FROM test_structs WHERE id=2
 ----
 false	84
+
+endloop

--- a/test/sql/types/struct/struct_projection_pushdown_index.test_slow
+++ b/test/sql/types/struct/struct_projection_pushdown_index.test_slow
@@ -2,21 +2,50 @@
 # description: Test struct projection pushdown with an index
 # group: [struct]
 
+load __TEST_DIR__/struct_projection_pushdown_index.db
+
+# Always shred
 statement ok
-CREATE TABLE test_structs(id INT PRIMARY KEY, s STRUCT(a integer, b bool, c varchar, d int[]));
+SET variant_minimum_shredding_size = 0;
+
+foreach type struct variant
+
+onlyif type=struct
+statement ok
+CREATE TABLE test_structs(
+	id INT PRIMARY KEY,
+	s STRUCT(
+		a integer,
+		b bool,
+		c varchar,
+		d int[]
+	)
+);
+
+onlyif type=variant
+statement ok
+CREATE OR REPLACE TABLE test_structs(
+	id INT PRIMARY KEY,
+	s VARIANT
+);
 
 statement ok
 INSERT INTO test_structs
 SELECT i, case when i%10=0 then null else {'a': i, b: i%2, c: 'thisisastring' || i::VARCHAR, 'd': [i, i + 2]} end
 FROM range(1000000) t(i);
 
+statement ok
+checkpoint
+
+restart
+
 query II
-SELECT SUM(LENGTH(s.c)), COUNT(s.c) FROM test_structs
+SELECT SUM(LENGTH(s.c::VARCHAR)), COUNT(s.c::VARCHAR) FROM test_structs
 ----
 17000001	900000
 
 query I
-SELECT s.c FROM test_structs WHERE id=473564
+SELECT s.c::VARCHAR FROM test_structs WHERE id=473564
 ----
 thisisastring473564
 
@@ -27,11 +56,13 @@ SELECT s.c::BLOB FROM test_structs WHERE id=473564
 thisisastring473564
 
 query I
-SELECT s.d FROM test_structs WHERE id=473564
+SELECT s.d::INT[] FROM test_structs WHERE id=473564
 ----
 [473564, 473566]
 
 query II
-SELECT SUM(LENGTH(s.c)), COUNT(s.c) FROM test_structs WHERE id > 47356
+SELECT SUM(LENGTH(s.c::VARCHAR)), COUNT(s.c::VARCHAR) FROM test_structs WHERE id > 47356
 ----
 16242822	857379
+
+endloop

--- a/test/sql/types/variant/implicit_cast_from_variant.test
+++ b/test/sql/types/variant/implicit_cast_from_variant.test
@@ -252,12 +252,12 @@ select v::int from (values ({'a': 42}::variant)) t(v);
 ----
 Conversion Error: Can't convert VARIANT(OBJECT) value '{'a': 42}' to 'INTEGER'
 
-statement error
+query I
 select v.a.b from (values ({'a': 42}::variant)) t(v);
 ----
-Invalid Input Error: Can't extract key 'b' from a VARIANT(INT32)
+NULL
 
-statement error
+query I
 select v['helo'] from (values ({'hello': 42}::variant)) t(v);
 ----
-Invalid Input Error: VARIANT(OBJECT(hello)) is missing key 'helo'
+NULL

--- a/test/sql/types/variant/tpch_test.test
+++ b/test/sql/types/variant/tpch_test.test
@@ -9,10 +9,20 @@ statement ok
 call dbgen(sf=0.001)
 
 statement ok
-create table variant_lineitem as select variant_normalize(STRUCT_PACK(*COLUMNS(*))::VARIANT) from lineitem;
+attach '__TEST_DIR__/tpch_sf0001_variant.db' as foo
+
+statement ok
+create table foo.variant_lineitem as select variant_normalize(STRUCT_PACK(*COLUMNS(*))::VARIANT) from lineitem;
+
+# Always shred
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+statement ok
+checkpoint;
 
 query I
-select * from variant_lineitem limit 10;
+select * from foo.variant_lineitem limit 10;
 ----
 {'l_comment': to beans x-ray carefull, 'l_commitdate': 1996-02-12, 'l_discount': 0.04, 'l_extendedprice': 17954.55, 'l_linenumber': 1, 'l_linestatus': O, 'l_orderkey': 1, 'l_partkey': 156, 'l_quantity': 17.00, 'l_receiptdate': 1996-03-22, 'l_returnflag': N, 'l_shipdate': 1996-03-13, 'l_shipinstruct': DELIVER IN PERSON, 'l_shipmode': TRUCK, 'l_suppkey': 4, 'l_tax': 0.02}
 {'l_comment': ' according to the final foxes. qui', 'l_commitdate': 1996-02-28, 'l_discount': 0.09, 'l_extendedprice': 34850.16, 'l_linenumber': 2, 'l_linestatus': O, 'l_orderkey': 1, 'l_partkey': 68, 'l_quantity': 36.00, 'l_receiptdate': 1996-04-20, 'l_returnflag': N, 'l_shipdate': 1996-04-12, 'l_shipinstruct': TAKE BACK RETURN, 'l_shipmode': MAIL, 'l_suppkey': 9, 'l_tax': 0.06}
@@ -26,7 +36,7 @@ select * from variant_lineitem limit 10;
 {'l_comment': e carefully fina, 'l_commitdate': 1993-11-22, 'l_discount': 0.06, 'l_extendedprice': 27786.24, 'l_linenumber': 3, 'l_linestatus': F, 'l_orderkey': 3, 'l_partkey': 129, 'l_quantity': 27.00, 'l_receiptdate': 1994-01-23, 'l_returnflag': A, 'l_shipdate': 1994-01-16, 'l_shipinstruct': DELIVER IN PERSON, 'l_shipmode': SHIP, 'l_suppkey': 8, 'l_tax': 0.07}
 
 query I
-select COLUMNS(*)::JSON from variant_lineitem limit 10;
+select COLUMNS(*)::JSON from foo.variant_lineitem limit 10;
 ----
 {"l_comment":"to beans x-ray carefull","l_commitdate":"1996-02-12","l_discount":0.04,"l_extendedprice":17954.55,"l_linenumber":1,"l_linestatus":"O","l_orderkey":1,"l_partkey":156,"l_quantity":17.00,"l_receiptdate":"1996-03-22","l_returnflag":"N","l_shipdate":"1996-03-13","l_shipinstruct":"DELIVER IN PERSON","l_shipmode":"TRUCK","l_suppkey":4,"l_tax":0.02}
 {"l_comment":" according to the final foxes. qui","l_commitdate":"1996-02-28","l_discount":0.09,"l_extendedprice":34850.16,"l_linenumber":2,"l_linestatus":"O","l_orderkey":1,"l_partkey":68,"l_quantity":36.00,"l_receiptdate":"1996-04-20","l_returnflag":"N","l_shipdate":"1996-04-12","l_shipinstruct":"TAKE BACK RETURN","l_shipmode":"MAIL","l_suppkey":9,"l_tax":0.06}


### PR DESCRIPTION
We previously implemented #20063 and #20250 which were stepping stones towards this PR.

For a variant, the pushdown really matters.
If we have shredded the VARIANT (store the variant data in a structured format on disk).
When we scan the VARIANT column, we have to "unshred", i.e transform that structured data back into the VARIANT format, which is not a cheap transform.

If we then have a `variant_extract` in our projections, paired with a CAST expression, we end up going *back* from VARIANT format into a structured format.

In the best case, we can cut out **both** these transformations if we push this to the storage.

### Summary of Changes
- `VariantExtractBindData` is no longer local to `variant_extract.cpp`, so it can be read by the optimizer to figure out the path(s) requested.
- `ColumnIndex` and `StorageIndex` are extended with a `string field;`, indexes now have either an `idx_t` or a `string` as primary identifier.
- `RemoveUnusedColumns` is extended to also push down `variant_extract` expressions, can be chained with struct extract as well (only field extracts are supported, array index extracts aren't).
- Added `GetChildStats` to all nested column data implementations, as well as `GetStatsRef` to `ColumnData`, in order to fetch stats for a given column data element, no matter how far it's nested
- Made a fix to `variant_extract`, as it wasn't properly copying the input if NULLs were found in the extract (which is required because NULL at the root means the row's validity has to be set to NULL - and we aren't allowed to modify the input vector)

### TODO
- find a better way to hold the cast/expression to perform - perhaps it makes sense to add the expression to the `StorageIndex` ?
- Check if there is a reason why we don't support array index extracts (other than the fact that that's harder to communicate through the ColumnIndex/StorageIndex)
- Write up benchmarks (tpch/tpcds) to test the variant extract pushdown performance