### PR TITLE
Minor python fixes

### DIFF
--- a/scripts/metrics/emit_enum_cpp.py
+++ b/scripts/metrics/emit_enum_cpp.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from asyncore import file_wrapper
 from typing import Dict, List, Tuple
 from pathlib import Path
 

--- a/scripts/metrics/paths.py
+++ b/scripts/metrics/paths.py
@@ -35,7 +35,7 @@ FORMAT_SCRIPT = REPO_ROOT / "scripts" / "format.py"
 
 
 def path_from_duckdb(path: Path):
-    return str(path).split('duckdb/', 1)[1]
+    return path.relative_to(REPO_ROOT)
 
 
 def format_file(path: Path):


### PR DESCRIPTION
- fix `make generate-files` to also work in case the root of the repo is not checked out in directory `duckdb`
- removed deprecated `asyncore` import, not longer supported since `Python 3.12`
  - see: https://docs.python.org/3/library/asyncore.html