### PR TITLE
Add encryption CLI arguments

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -205,6 +205,10 @@ struct DBConfigOptions {
 	string custom_user_agent;
 	//! Encrypt the temp files
 	bool temp_file_encryption = false;
+	//! Encryption key for the main database (if any). Empty string means no encryption.
+	string encryption_key;
+	//! Encryption cipher for the main database (GCM or CTR). Empty string means default (GCM).
+	string encryption_cipher;
 	//! The default block allocation size for new duckdb database files (new as-in, they do not yet exist).
 	idx_t default_block_alloc_size = DEFAULT_BLOCK_ALLOC_SIZE;
 	//! The default block header size for new duckdb database files.

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -33,6 +33,14 @@ void StoredDatabasePath::OnDetach() {
 //===--------------------------------------------------------------------===//
 AttachOptions::AttachOptions(const DBConfigOptions &options)
     : access_mode(options.access_mode), db_type(options.database_type) {
+	// Copy encryption key if provided
+	if (!options.encryption_key.empty()) {
+		this->options["encryption_key"] = Value(options.encryption_key);
+	}
+	// Copy encryption cipher if provided
+	if (!options.encryption_cipher.empty()) {
+		this->options["encryption_cipher"] = Value(options.encryption_cipher);
+	}
 }
 
 AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options, const AccessMode default_access_mode)

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -318,6 +318,14 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 
 	LoadExtensionSettings();
 
+	// Preload httpfs extension if encryption is enabled for the main database (write mode only).
+	// The httpfs extension provides the crypto module needed for encrypted database writes.
+	// Read-only mode can use the built-in mbedtls module.
+	if (!config.options.encryption_key.empty() && config.options.access_mode != AccessMode::READ_ONLY) {
+		DuckDB temp_db(*this);
+		ExtensionHelper::LoadExtension(temp_db, "httpfs");
+	}
+
 	if (!db_manager->HasDefaultDatabase()) {
 		CreateMainDatabase();
 	}

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3151,6 +3151,17 @@ int wmain(int argc, wchar_t **wargv) {
 	if (data.zDbFilename.empty()) {
 		data.zDbFilename = ":memory:";
 	}
+
+	// Validate: encryption key requires a file database, not in-memory
+	if (!data.config.options.encryption_key.empty()) {
+		if (data.zDbFilename == ":memory:") {
+			data.PrintF(PrintOutput::STDERR,
+			            "%s: Error: -encryption-key requires a database file path, not an in-memory database\n",
+			            data.program_name);
+			return 1;
+		}
+	}
+
 	data.out = stdout;
 
 	// Open the database file

--- a/tools/shell/shell_command_line_option.cpp
+++ b/tools/shell/shell_command_line_option.cpp
@@ -126,7 +126,8 @@ MetadataResult SetEncryptionKey(ShellState &state, const vector<string> &args) {
 MetadataResult SetEncryptionCipher(ShellState &state, const vector<string> &args) {
 	auto cipher = duckdb::StringUtil::Upper(args[1]);
 	if (cipher != "GCM" && cipher != "CTR") {
-		state.PrintF(PrintOutput::STDERR, "%s: Error: invalid encryption cipher '%s'. Valid options are 'GCM' or 'CTR'\n",
+		state.PrintF(PrintOutput::STDERR,
+		             "%s: Error: invalid encryption cipher '%s'. Valid options are 'GCM' or 'CTR'\n",
 		             state.program_name, args[1].c_str());
 		return MetadataResult::EXIT;
 	}
@@ -178,7 +179,8 @@ static const CommandLineOption command_line_options[] = {
     {"csv", 0, "", nullptr, ToggleCSVMode, "set output mode to 'csv'"},
     {"c", 1, "COMMAND", EnableBatch, RunCommand<true>, "run \"COMMAND\" and exit"},
     {"echo", 0, "", nullptr, EnableEcho, "print commands before execution"},
-    {"encryption-cipher", 1, "CIPHER", SetEncryptionCipher, nullptr, "set encryption cipher (GCM or CTR, default: GCM)"},
+    {"encryption-cipher", 1, "CIPHER", SetEncryptionCipher, nullptr,
+     "set encryption cipher (GCM or CTR, default: GCM)"},
     {"encryption-key", 1, "KEY", SetEncryptionKey, nullptr, "encrypt the database file with the given key"},
     {"f", 1, "FILENAME", EnableBatch, ProcessFile, "read/process named file and exit"},
     {"init", 1, "FILENAME", SetInitFile, nullptr, "read/process named file"},

--- a/tools/shell/shell_command_line_option.cpp
+++ b/tools/shell/shell_command_line_option.cpp
@@ -113,6 +113,27 @@ MetadataResult SetStorageVersion(ShellState &state, const vector<string> &args) 
 	return MetadataResult::SUCCESS;
 }
 
+MetadataResult SetEncryptionKey(ShellState &state, const vector<string> &args) {
+	auto &key = args[1];
+	if (key.empty()) {
+		state.PrintF(PrintOutput::STDERR, "%s: Error: encryption key cannot be empty\n", state.program_name);
+		return MetadataResult::EXIT;
+	}
+	state.config.options.encryption_key = key;
+	return MetadataResult::SUCCESS;
+}
+
+MetadataResult SetEncryptionCipher(ShellState &state, const vector<string> &args) {
+	auto cipher = duckdb::StringUtil::Upper(args[1]);
+	if (cipher != "GCM" && cipher != "CTR") {
+		state.PrintF(PrintOutput::STDERR, "%s: Error: invalid encryption cipher '%s'. Valid options are 'GCM' or 'CTR'\n",
+		             state.program_name, args[1].c_str());
+		return MetadataResult::EXIT;
+	}
+	state.config.options.encryption_cipher = cipher;
+	return MetadataResult::SUCCESS;
+}
+
 MetadataResult ProcessFile(ShellState &state, const vector<string> &args) {
 	state.readStdin = false;
 	auto old_bail = state.bail_on_error;
@@ -157,6 +178,8 @@ static const CommandLineOption command_line_options[] = {
     {"csv", 0, "", nullptr, ToggleCSVMode, "set output mode to 'csv'"},
     {"c", 1, "COMMAND", EnableBatch, RunCommand<true>, "run \"COMMAND\" and exit"},
     {"echo", 0, "", nullptr, EnableEcho, "print commands before execution"},
+    {"encryption-cipher", 1, "CIPHER", SetEncryptionCipher, nullptr, "set encryption cipher (GCM or CTR, default: GCM)"},
+    {"encryption-key", 1, "KEY", SetEncryptionKey, nullptr, "encrypt the database file with the given key"},
     {"f", 1, "FILENAME", EnableBatch, ProcessFile, "read/process named file and exit"},
     {"init", 1, "FILENAME", SetInitFile, nullptr, "read/process named file"},
     {"header", 0, "", nullptr, ToggleHeader<true>, "turn headers on"},

--- a/tools/shell/tests/test_command_line_arguments.py
+++ b/tools/shell/tests/test_command_line_arguments.py
@@ -86,5 +86,100 @@ def test_storage_version_error(shell):
     result = test.run()
     result.check_stderr("XXX")
 
+def test_encryption_key_requires_file(shell):
+    # encryption key should fail with in-memory database
+    test = (
+        ShellTest(shell)
+        .add_argument("-encryption-key", "my_secret_key")
+        .add_argument("-c", "SELECT 42")
+    )
+    result = test.run()
+    result.check_stderr("requires a database file path")
+
+def test_encryption_cipher_invalid(shell):
+    # invalid cipher should fail
+    test = (
+        ShellTest(shell)
+        .add_argument("-encryption-cipher", "INVALID")
+        .add_argument("-c", "SELECT 42")
+    )
+    result = test.run()
+    result.check_stderr("invalid encryption cipher")
+
+def test_encryption_cipher_valid(shell):
+    # valid cipher should not error on its own
+    test = (
+        ShellTest(shell)
+        .add_argument("-encryption-cipher", "CTR")
+        .add_argument("-c", "SELECT 42")
+    )
+    result = test.run()
+    result.check_stdout("42")
+
+def test_encryption_key_with_file(shell, tmp_path):
+    # encryption with file database should work
+    db_path = tmp_path / "encrypted.db"
+    test = (
+        ShellTest(shell)
+        .add_argument(str(db_path))
+        .add_argument("-encryption-key", "my_secret_key")
+        .add_argument("-c", "CREATE TABLE t(i INTEGER); INSERT INTO t VALUES (42); SELECT * FROM t;")
+    )
+    result = test.run()
+    result.check_stdout("42")
+
+def test_encryption_reopen_with_key(shell, tmp_path):
+    # create encrypted database
+    db_path = tmp_path / "encrypted.db"
+    test1 = (
+        ShellTest(shell)
+        .add_argument(str(db_path))
+        .add_argument("-encryption-key", "my_secret_key")
+        .add_argument("-c", "CREATE TABLE t(i INTEGER); INSERT INTO t VALUES (42);")
+    )
+    test1.run()
+    # reopen with correct key
+    test2 = (
+        ShellTest(shell)
+        .add_argument(str(db_path))
+        .add_argument("-encryption-key", "my_secret_key")
+        .add_argument("-c", "SELECT * FROM t;")
+    )
+    result = test2.run()
+    result.check_stdout("42")
+
+def test_encryption_wrong_key(shell, tmp_path):
+    # create encrypted database
+    db_path = tmp_path / "encrypted.db"
+    test1 = (
+        ShellTest(shell)
+        .add_argument(str(db_path))
+        .add_argument("-encryption-key", "my_secret_key")
+        .add_argument("-c", "CREATE TABLE t(i INTEGER);")
+    )
+    test1.run()
+    # reopen with wrong key
+    test2 = (
+        ShellTest(shell)
+        .add_argument(str(db_path))
+        .add_argument("-encryption-key", "wrong_key")
+        .add_argument("-c", "SELECT 1;")
+    )
+    result = test2.run()
+    result.check_stderr("Wrong encryption key")
+
+def test_encryption_with_cipher(shell, tmp_path):
+    # encryption with CTR cipher
+    db_path = tmp_path / "encrypted_ctr.db"
+    test = (
+        ShellTest(shell)
+        .add_argument(str(db_path))
+        .add_argument("-encryption-key", "my_secret_key")
+        .add_argument("-encryption-cipher", "CTR")
+        .add_argument("-c", "CREATE TABLE t(i INTEGER); INSERT INTO t VALUES (99); SELECT * FROM t;")
+    )
+    result = test.run()
+    result.check_stdout("99")
+
 
 # fmt: on


### PR DESCRIPTION
# Add `-encryption-key` and `-encryption-cipher` CLI arguments for encrypted databases

Adds support for opening or creating encrypted database files directly from the command line.

## Usage

```bash
# Create a new encrypted database (default GCM cipher)
duckdb mydb.db -encryption-key "my_secret_key"

# Open an existing encrypted database
duckdb mydb.db -encryption-key "my_secret_key"

# Use CTR cipher instead of default GCM
duckdb mydb.db -encryption-key "my_secret_key" -encryption-cipher CTR

# Read-only access to encrypted database
duckdb mydb.db -encryption-key "my_secret_key" -readonly
```

## Changes
- Added encryption_key and encryption_cipher fields to DBConfigOptions
- Added -encryption-key and -encryption-cipher CLI options in shell
- Modified AttachOptions constructor to pass encryption options to storage layer
- Preload httpfs extension when encryption is enabled in write mode (required for encrypted writes)
- Validate that encryption requires a file database (not :memory:)
- Validate cipher is GCM or CTR (case-insensitive)

## Tests
- Added 7 new tests in tools/shell/tests/test_command_line_arguments.py:
  - test_encryption_key_requires_file - verifies in-memory rejection
  - test_encryption_cipher_invalid - verifies invalid cipher rejection
  - test_encryption_cipher_valid - verifies valid cipher acceptance
  - test_encryption_key_with_file - creates and queries encrypted database
  - test_encryption_reopen_with_key - reopens with correct key
  - test_encryption_wrong_key - verifies wrong key rejection
  - test_encryption_with_cipher - creates encrypted database with CTR cipher

## Notes
- Mirrors the existing ATTACH ... (ENCRYPTION_KEY 'key', ENCRYPTION_CIPHER 'CTR') functionality
- Requires httpfs extension for write operations (read-only works with built-in mbedtls)
- GCM is the default cipher (secure authenticated encryption)
