### PR TITLE
return_stats fix floating stats for +-infinity values during copy

### DIFF
--- a/extension/parquet/include/writer/parquet_write_stats.hpp
+++ b/extension/parquet/include/writer/parquet_write_stats.hpp
@@ -10,6 +10,7 @@
 
 #include "column_writer.hpp"
 #include "parquet_geometry.hpp"
+#include <limits>
 
 namespace duckdb {
 
@@ -76,6 +77,15 @@ template <class SRC, class T, class OP>
 class FloatingPointStatisticsState : public NumericStatisticsState<SRC, T, OP> {
 public:
 	bool has_nan = false;
+
+	FloatingPointStatisticsState() {
+		// initialize floating point stats to +/- infinity so that updates with
+		// -inf/+inf values are handled correctly (instead of using finite
+		// numeric limits which would cause incorrect max/min when the only
+		// value is infinite)
+		this->min = std::numeric_limits<T>::infinity();
+		this->max = -std::numeric_limits<T>::infinity();
+	}
 
 public:
 	bool CanHaveNaN() override {

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -19,8 +19,15 @@ BaseStatistics NumericStats::CreateUnknown(LogicalType type) {
 BaseStatistics NumericStats::CreateEmpty(LogicalType type) {
 	BaseStatistics result(std::move(type));
 	result.InitializeEmpty();
-	SetMin(result, Value::MaximumValue(result.GetType()));
-	SetMax(result, Value::MinimumValue(result.GetType()));
+
+	if (result.GetType() == LogicalType::FLOAT || result.GetType() == LogicalType::DOUBLE) {
+		SetMin(result, Value::Infinity(result.GetType()));
+		SetMax(result, Value::NegativeInfinity(result.GetType()));
+	} else {
+		SetMin(result, Value::MaximumValue(result.GetType()));
+		SetMax(result, Value::MinimumValue(result.GetType()));
+	}
+
 	return result;
 }
 

--- a/test/sql/copy/return_stats.test
+++ b/test/sql/copy/return_stats.test
@@ -17,6 +17,9 @@ statement ok
 CREATE TABLE floating_point_nan AS SELECT case when i%10=0 then 'nan'::double when i%4=0 then null else i/10.0 end as fp FROM range(2500) t(i)
 
 statement ok
+CREATE TABLE floating_point_inf AS SELECT 'inf'::float as a, '-inf'::float as b, 'inf'::double as c, '-inf'::double as d
+
+statement ok
 CREATE TABLE fp_nan_only AS SELECT 'nan'::float as float_val
 
 statement ok
@@ -144,6 +147,11 @@ query IIIIII
 COPY fp_nan_only TO '__TEST_DIR__/fp_nan_only.parquet' (RETURN_STATS);
 ----
 <REGEX>:.*fp_nan_only.parquet	1	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:{'"float_val"'={column_size_bytes=\d+, has_nan=true, null_count=0}}	NULL
+
+query IIIIII
+COPY floating_point_inf TO '__TEST_DIR__/fp_inf.parquet' (RETURN_STATS);
+----
+<REGEX>:.*fp_inf.parquet	1	<REGEX>:\d+	<REGEX>:\d+	<REGEX>:{'"a"'={column_size_bytes=\d+, has_nan=false, max=inf, min=inf, null_count=0}, '"b"'={column_size_bytes=\d+, has_nan=false, max=-inf, min=-inf, null_count=0}, '"c"'={column_size_bytes=\d+, has_nan=false, max=inf, min=inf, null_count=0}, '"d"'={column_size_bytes=\d+, has_nan=false, max=-inf, min=-inf, null_count=0}}	NULL
 
 # large strings are truncated to the nearest valid UTF8 string
 query IIIIII


### PR DESCRIPTION
Previously min and max when infinity is inserted is shown below:
```sql
# copy (select '-inf'::float as a) to '/tmp/test.parquet' with (return_stats);
max => '-3.4028235e+38' (float::min)
min => '-inf'
```

Now it is fixed as below:
```sql
# copy (select '-inf'::float as a) to '/tmp/test.parquet' with (return_stats);
max => '-inf'
min => '-inf'
```