### PR TITLE
peg grammar: start rule first

### DIFF
--- a/extension/autocomplete/include/inlined_grammar.gram
+++ b/extension/autocomplete/include/inlined_grammar.gram
@@ -1,3 +1,153 @@
+Statement <-
+	CreateStatement /
+	SelectStatement /
+	SetStatement /
+	PragmaStatement /
+	CallStatement /
+	InsertStatement /
+	DropStatement /
+	CopyStatement /
+	ExplainStatement /
+	UpdateStatement /
+	PrepareStatement /
+	ExecuteStatement /
+	AlterStatement /
+	TransactionStatement /
+	DeleteStatement /
+	AttachStatement /
+	UseStatement /
+	DetachStatement /
+	CheckpointStatement /
+	VacuumStatement /
+	ResetStatement /
+	ExportStatement /
+	ImportStatement /
+	CommentStatement /
+	DeallocateStatement /
+	TruncateStatement /
+	LoadStatement /
+	InstallStatement /
+	AnalyzeStatement /
+	MergeIntoStatement
+
+CatalogName <- Identifier
+SchemaName <- Identifier
+ReservedSchemaName <- Identifier
+TableName <- Identifier
+ReservedTableName <- Identifier
+ReservedIdentifier <- Identifier
+ColumnName <- Identifier
+ReservedColumnName <- Identifier
+IndexName <- Identifier
+SettingName <- Identifier
+PragmaName <- Identifier
+FunctionName <- Identifier
+ReservedFunctionName <- Identifier
+TableFunctionName <- Identifier
+ConstraintName <- ColIdOrString
+SequenceName <- Identifier
+CollationName <- Identifier
+CopyOptionName <- ColLabel
+SecretName <- ColId
+
+NumberLiteral <- < [+-]?[0-9]*([.][0-9]*)? >
+StringLiteral <- '\'' [^\']* '\''
+
+Type <- (TimeType / IntervalType / BitType / RowType / MapType / UnionType / NumericType / SetofType / SimpleType) ArrayBounds*
+SimpleType <- (QualifiedTypeName / CharacterType) TypeModifiers?
+CharacterType <- ('CHARACTER' 'VARYING'?) /
+                 ('CHAR' 'VARYING'?) /
+                 ('NATIONAL' 'CHARACTER' 'VARYING'?) /
+                 ('NATIONAL' 'CHAR' 'VARYING'?) /
+                 ('NCHAR' 'VARYING'?) /
+                 'VARCHAR'
+
+IntervalType <- IntervalInterval / IntervalNumber
+IntervalInterval <- 'INTERVAL' Interval?
+IntervalNumber <- 'INTERVAL' Parens(NumberLiteral)
+
+YearKeyword         <- 'YEAR' / 'YEARS'
+MonthKeyword        <- 'MONTH' / 'MONTHS'
+DayKeyword          <- 'DAY' / 'DAYS'
+HourKeyword         <- 'HOUR' / 'HOURS'
+MinuteKeyword       <- 'MINUTE' / 'MINUTES'
+SecondKeyword       <- 'SECOND' / 'SECONDS'
+MillisecondKeyword  <- 'MILLISECOND' / 'MILLISECONDS'
+MicrosecondKeyword  <- 'MICROSECOND' / 'MICROSECONDS'
+WeekKeyword         <- 'WEEK' / 'WEEKS'
+QuarterKeyword      <- 'QUARTER' / 'QUARTERS'
+DecadeKeyword       <- 'DECADE' / 'DECADES'
+CenturyKeyword      <- 'CENTURY' / 'CENTURIES'
+MillenniumKeyword   <- 'MILLENNIUM' / 'MILLENNIA'
+
+Interval <- YearKeyword /
+    MonthKeyword /
+    DayKeyword /
+    HourKeyword /
+    MinuteKeyword /
+    SecondKeyword /
+    MillisecondKeyword /
+    MicrosecondKeyword /
+    WeekKeyword /
+    QuarterKeyword /
+    DecadeKeyword /
+    CenturyKeyword /
+    MillenniumKeyword /
+    (YearKeyword 'TO' MonthKeyword) /
+    (DayKeyword 'TO' HourKeyword) /
+    (DayKeyword 'TO' MinuteKeyword) /
+    (DayKeyword 'TO' SecondKeyword) /
+    (HourKeyword 'TO' MinuteKeyword) /
+    (HourKeyword 'TO' SecondKeyword) /
+    (MinuteKeyword 'TO' SecondKeyword)
+
+BitType <- 'BIT' 'VARYING'? Parens(List(Expression))?
+
+NumericType <- SimpleNumericType / DecimalNumericType
+SimpleNumericType <- IntType / IntegerType / SmallintType /
+                BigintType / RealType / BooleanType / DoubleType
+DecimalNumericType <- FloatType / DecimalType / DecType / NumericModType
+
+IntType <- 'INT'
+IntegerType <- 'INTEGER'
+SmallintType <- 'SMALLINT'
+BigintType <- 'BIGINT'
+RealType <- 'REAL'
+BooleanType <- 'BOOLEAN'
+DoubleType <- ('DOUBLE' 'PRECISION')
+
+FloatType <- 'FLOAT' Parens(NumberLiteral)?
+DecimalType <- 'DECIMAL' TypeModifiers?
+DecType <- 'DEC' TypeModifiers?
+NumericModType <- 'NUMERIC' TypeModifiers?
+
+QualifiedTypeName <- CatalogQualification? SchemaQualification? TypeName
+TypeModifiers <- Parens(List(Expression)?)
+RowType <- RowOrStruct ColIdTypeList
+SetofType <- 'SETOF' Type
+UnionType <- 'UNION' ColIdTypeList
+ColIdTypeList <- Parens(List(ColIdType))
+MapType <- 'MAP' Parens(List(Type))
+ColIdType <- ColId Type
+ArrayBounds <- SquareBracketsArray / 'ARRAY'
+ArrayKeyword <- 'ARRAY'
+SquareBracketsArray <- '[' NumberLiteral? ']'
+TimeType <- TimeOrTimestamp TypeModifiers? TimeZone?
+TimeOrTimestamp <- TimeTypeId / TimestampTypeId
+TimeTypeId <- 'TIME'
+TimestampTypeId <- 'TIMESTAMP'
+TimeZone <- WithOrWithout 'TIME' 'ZONE'
+WithOrWithout <- WithRule / WithoutRule
+WithRule <- 'WITH'
+WithoutRule <- 'WITHOUT'
+
+RowOrStruct <- 'ROW' / 'STRUCT'
+
+# internal definitions
+%whitespace <- [ \t\n\r]*
+List(D) <- D (',' D)* ','?
+Parens(D) <- '(' D ')'
+
 UnreservedKeyword <- 'ABORT' /
 'ABSOLUTE' /
 'ACCESS' /
@@ -1266,156 +1416,6 @@ SeqOwnedBy <- 'OWNED' 'BY' QualifiedName
 SeqMinOrMax <- MinValue / MaxValue
 MinValue <- 'MINVALUE'
 MaxValue <- 'MAXVALUE'
-Statement <-
-	CreateStatement /
-	SelectStatement /
-	SetStatement /
-	PragmaStatement /
-	CallStatement /
-	InsertStatement /
-	DropStatement /
-	CopyStatement /
-	ExplainStatement /
-	UpdateStatement /
-	PrepareStatement /
-	ExecuteStatement /
-	AlterStatement /
-	TransactionStatement /
-	DeleteStatement /
-	AttachStatement /
-	UseStatement /
-	DetachStatement /
-	CheckpointStatement /
-	VacuumStatement /
-	ResetStatement /
-	ExportStatement /
-	ImportStatement /
-	CommentStatement /
-	DeallocateStatement /
-	TruncateStatement /
-	LoadStatement /
-	InstallStatement /
-	AnalyzeStatement /
-	MergeIntoStatement
-
-CatalogName <- Identifier
-SchemaName <- Identifier
-ReservedSchemaName <- Identifier
-TableName <- Identifier
-ReservedTableName <- Identifier
-ReservedIdentifier <- Identifier
-ColumnName <- Identifier
-ReservedColumnName <- Identifier
-IndexName <- Identifier
-SettingName <- Identifier
-PragmaName <- Identifier
-FunctionName <- Identifier
-ReservedFunctionName <- Identifier
-TableFunctionName <- Identifier
-ConstraintName <- ColIdOrString
-SequenceName <- Identifier
-CollationName <- Identifier
-CopyOptionName <- ColLabel
-SecretName <- ColId
-
-NumberLiteral <- < [+-]?[0-9]*([.][0-9]*)? >
-StringLiteral <- '\'' [^\']* '\''
-
-Type <- (TimeType / IntervalType / BitType / RowType / MapType / UnionType / NumericType / SetofType / SimpleType) ArrayBounds*
-SimpleType <- (QualifiedTypeName / CharacterType) TypeModifiers?
-CharacterType <- ('CHARACTER' 'VARYING'?) /
-                 ('CHAR' 'VARYING'?) /
-                 ('NATIONAL' 'CHARACTER' 'VARYING'?) /
-                 ('NATIONAL' 'CHAR' 'VARYING'?) /
-                 ('NCHAR' 'VARYING'?) /
-                 'VARCHAR'
-
-IntervalType <- IntervalInterval / IntervalNumber
-IntervalInterval <- 'INTERVAL' Interval?
-IntervalNumber <- 'INTERVAL' Parens(NumberLiteral)
-
-YearKeyword         <- 'YEAR' / 'YEARS'
-MonthKeyword        <- 'MONTH' / 'MONTHS'
-DayKeyword          <- 'DAY' / 'DAYS'
-HourKeyword         <- 'HOUR' / 'HOURS'
-MinuteKeyword       <- 'MINUTE' / 'MINUTES'
-SecondKeyword       <- 'SECOND' / 'SECONDS'
-MillisecondKeyword  <- 'MILLISECOND' / 'MILLISECONDS'
-MicrosecondKeyword  <- 'MICROSECOND' / 'MICROSECONDS'
-WeekKeyword         <- 'WEEK' / 'WEEKS'
-QuarterKeyword      <- 'QUARTER' / 'QUARTERS'
-DecadeKeyword       <- 'DECADE' / 'DECADES'
-CenturyKeyword      <- 'CENTURY' / 'CENTURIES'
-MillenniumKeyword   <- 'MILLENNIUM' / 'MILLENNIA'
-
-Interval <- YearKeyword /
-    MonthKeyword /
-    DayKeyword /
-    HourKeyword /
-    MinuteKeyword /
-    SecondKeyword /
-    MillisecondKeyword /
-    MicrosecondKeyword /
-    WeekKeyword /
-    QuarterKeyword /
-    DecadeKeyword /
-    CenturyKeyword /
-    MillenniumKeyword /
-    (YearKeyword 'TO' MonthKeyword) /
-    (DayKeyword 'TO' HourKeyword) /
-    (DayKeyword 'TO' MinuteKeyword) /
-    (DayKeyword 'TO' SecondKeyword) /
-    (HourKeyword 'TO' MinuteKeyword) /
-    (HourKeyword 'TO' SecondKeyword) /
-    (MinuteKeyword 'TO' SecondKeyword)
-
-BitType <- 'BIT' 'VARYING'? Parens(List(Expression))?
-
-NumericType <- SimpleNumericType / DecimalNumericType
-SimpleNumericType <- IntType / IntegerType / SmallintType /
-                BigintType / RealType / BooleanType / DoubleType
-DecimalNumericType <- FloatType / DecimalType / DecType / NumericModType
-
-IntType <- 'INT'
-IntegerType <- 'INTEGER'
-SmallintType <- 'SMALLINT'
-BigintType <- 'BIGINT'
-RealType <- 'REAL'
-BooleanType <- 'BOOLEAN'
-DoubleType <- ('DOUBLE' 'PRECISION')
-
-FloatType <- 'FLOAT' Parens(NumberLiteral)?
-DecimalType <- 'DECIMAL' TypeModifiers?
-DecType <- 'DEC' TypeModifiers?
-NumericModType <- 'NUMERIC' TypeModifiers?
-
-QualifiedTypeName <- CatalogQualification? SchemaQualification? TypeName
-TypeModifiers <- Parens(List(Expression)?)
-RowType <- RowOrStruct ColIdTypeList
-SetofType <- 'SETOF' Type
-UnionType <- 'UNION' ColIdTypeList
-ColIdTypeList <- Parens(List(ColIdType))
-MapType <- 'MAP' Parens(List(Type))
-ColIdType <- ColId Type
-ArrayBounds <- SquareBracketsArray / 'ARRAY'
-ArrayKeyword <- 'ARRAY'
-SquareBracketsArray <- '[' NumberLiteral? ']'
-TimeType <- TimeOrTimestamp TypeModifiers? TimeZone?
-TimeOrTimestamp <- TimeTypeId / TimestampTypeId
-TimeTypeId <- 'TIME'
-TimestampTypeId <- 'TIMESTAMP'
-TimeZone <- WithOrWithout 'TIME' 'ZONE'
-WithOrWithout <- WithRule / WithoutRule
-WithRule <- 'WITH'
-WithoutRule <- 'WITHOUT'
-
-RowOrStruct <- 'ROW' / 'STRUCT'
-
-# internal definitions
-%whitespace <- [ \t\n\r]*
-List(D) <- D (',' D)* ','?
-Parens(D) <- '(' D ')'
-
 ExplainStatement <- 'EXPLAIN' 'ANALYZE'? ExplainOptions? Statement
 
 ExplainOptions <- Parens(GenericCopyOptionList)

--- a/extension/autocomplete/inline_grammar.py
+++ b/extension/autocomplete/inline_grammar.py
@@ -112,6 +112,8 @@ def filename_to_upper_camel(file):
     parts = name.split('_')  # ['column', 'name', 'keywords']
     return ''.join(p.capitalize() for p in parts)
 
+with open(os.path.join(statements_dir, "common.gram"), 'r') as f:
+    contents += f.read() + "\n"
 
 for file in os.listdir(keywords_dir):
     if not file.endswith('.list'):
@@ -126,8 +128,9 @@ for file in os.listdir(keywords_dir):
 for file in os.listdir(statements_dir):
     if not file.endswith('.gram'):
         raise Exception(f"File {file} does not end with .gram")
-    with open(os.path.join(statements_dir, file), 'r') as f:
-        contents += f.read() + "\n"
+    if not file == "common.gram":
+        with open(os.path.join(statements_dir, file), 'r') as f:
+            contents += f.read() + "\n"
 
 if args.print:
     print(contents)

--- a/extension/autocomplete/inline_grammar.py
+++ b/extension/autocomplete/inline_grammar.py
@@ -112,6 +112,7 @@ def filename_to_upper_camel(file):
     parts = name.split('_')  # ['column', 'name', 'keywords']
     return ''.join(p.capitalize() for p in parts)
 
+
 with open(os.path.join(statements_dir, "common.gram"), 'r') as f:
     contents += f.read() + "\n"
 


### PR DESCRIPTION
A small change to the script that generates the inlined PEG grammar to move the start rule first, by moving `common.gram` first.

This allows parsers like cpp-peglib, which expect the start rule to be first, to produce a sensible grammar out of this file. (This will also help with the cpp-peglib-compatible JS PEG parser I'm working on.)