### PR TITLE
[chore] Remove `numeric_cast.hpp` import and other tidy stuff

### DIFF
--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -703,8 +703,9 @@ void FinalizeSortData(Vector &result, idx_t size, const SortKeyLengthInfo &key_l
 		auto result_data = FlatVector::GetData<string_t>(result);
 		// call Finalize on the result
 		for (idx_t r = 0; r < size; r++) {
-			result_data[r].SetSizeAndFinalize(offsets[r],
-			                                  key_lengths.variable_lengths[r] + key_lengths.constant_length);
+			const auto offset = static_cast<uint32_t>(offsets[r]);
+			const auto allocated_size = key_lengths.variable_lengths[r] + key_lengths.constant_length;
+			result_data[r].SetSizeAndFinalize(offset, allocated_size);
 		}
 		break;
 	}

--- a/src/include/duckdb/common/operator/numeric_cast.hpp
+++ b/src/include/duckdb/common/operator/numeric_cast.hpp
@@ -552,7 +552,7 @@ bool TryCastWithOverflowCheck(int32_t value, uhugeint_t &result) {
 }
 
 template <>
-inline bool TryCastWithOverflowCheck(int64_t value, uhugeint_t &result) {
+bool TryCastWithOverflowCheck(int64_t value, uhugeint_t &result) {
 	return Uhugeint::TryConvert(value, result);
 }
 
@@ -577,12 +577,12 @@ bool TryCastWithOverflowCheck(uint64_t value, uhugeint_t &result) {
 }
 
 template <>
-inline bool TryCastWithOverflowCheck(float value, uhugeint_t &result) {
+bool TryCastWithOverflowCheck(float value, uhugeint_t &result) {
 	return Uhugeint::TryConvert(std::nearbyintf(value), result);
 }
 
 template <>
-inline bool TryCastWithOverflowCheck(double value, uhugeint_t &result) {
+bool TryCastWithOverflowCheck(double value, uhugeint_t &result) {
 	return Uhugeint::TryConvert(std::nearbyint(value), result);
 }
 

--- a/src/include/duckdb/common/operator/numeric_cast.hpp
+++ b/src/include/duckdb/common/operator/numeric_cast.hpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+//! NOTE: This file should not be included directly.
+//! NOTE: When included directly, this file produces 'unused static method' warnings/errors.
+//! NOTE: The methods in this file should be used through the TryCast:: methods defined in 'cast_operators.hpp'.
+
 #pragma once
 
 #include "duckdb/common/operator/cast_operators.hpp"
@@ -19,20 +23,18 @@
 
 namespace duckdb {
 
-//! Note: this should not be included directly, when these methods are required
-//! They should be used through the TryCast:: methods defined in 'cast_operators.hpp'
-//! This file produces 'unused static method' warnings/errors when included
-
 template <class SRC, class DST>
 static bool TryCastWithOverflowCheck(SRC value, DST &result) {
 	if (!Value::IsFinite<SRC>(value)) {
 		return false;
 	}
+
+	// SRC and DST do not have the same sign.
 	if (NumericLimits<SRC>::IsSigned() != NumericLimits<DST>::IsSigned()) {
+		// SRC is signed.
 		if (NumericLimits<SRC>::IsSigned()) {
-			// signed to unsigned conversion
 			if (NumericLimits<SRC>::Digits() > NumericLimits<DST>::Digits()) {
-				if (value < 0 || value > (SRC)NumericLimits<DST>::Maximum()) {
+				if (value < 0 || value > static_cast<SRC>(NumericLimits<DST>::Maximum())) {
 					return false;
 				}
 			} else {
@@ -40,34 +42,33 @@ static bool TryCastWithOverflowCheck(SRC value, DST &result) {
 					return false;
 				}
 			}
-			result = (DST)value;
+			result = static_cast<DST>(value);
 			return true;
-		} else {
-			// unsigned to signed conversion
-			if (NumericLimits<SRC>::Digits() >= NumericLimits<DST>::Digits()) {
-				if (value <= (SRC)NumericLimits<DST>::Maximum()) {
-					result = (DST)value;
-					return true;
-				}
-				return false;
-			} else {
-				result = (DST)value;
+		}
+
+		// SRC is unsigned.
+		if (NumericLimits<SRC>::Digits() >= NumericLimits<DST>::Digits()) {
+			if (value <= static_cast<SRC>(NumericLimits<DST>::Maximum())) {
+				result = static_cast<DST>(value);
 				return true;
 			}
+			return false;
 		}
-	} else {
-		// same sign conversion
-		if (NumericLimits<DST>::Digits() >= NumericLimits<SRC>::Digits()) {
-			result = (DST)value;
-			return true;
-		} else {
-			if (value < SRC(NumericLimits<DST>::Minimum()) || value > SRC(NumericLimits<DST>::Maximum())) {
-				return false;
-			}
-			result = (DST)value;
-			return true;
-		}
+		result = static_cast<DST>(value);
+		return true;
 	}
+
+	// SRC and DST have the same sign.
+	if (NumericLimits<DST>::Digits() >= NumericLimits<SRC>::Digits()) {
+		result = static_cast<DST>(value);
+		return true;
+	}
+
+	if (value < SRC(NumericLimits<DST>::Minimum()) || value > SRC(NumericLimits<DST>::Maximum())) {
+		return false;
+	}
+	result = static_cast<DST>(value);
+	return true;
 }
 
 template <class SRC, class T>
@@ -551,7 +552,7 @@ bool TryCastWithOverflowCheck(int32_t value, uhugeint_t &result) {
 }
 
 template <>
-bool TryCastWithOverflowCheck(int64_t value, uhugeint_t &result) {
+inline bool TryCastWithOverflowCheck(int64_t value, uhugeint_t &result) {
 	return Uhugeint::TryConvert(value, result);
 }
 
@@ -576,12 +577,12 @@ bool TryCastWithOverflowCheck(uint64_t value, uhugeint_t &result) {
 }
 
 template <>
-bool TryCastWithOverflowCheck(float value, uhugeint_t &result) {
+inline bool TryCastWithOverflowCheck(float value, uhugeint_t &result) {
 	return Uhugeint::TryConvert(std::nearbyintf(value), result);
 }
 
 template <>
-bool TryCastWithOverflowCheck(double value, uhugeint_t &result) {
+inline bool TryCastWithOverflowCheck(double value, uhugeint_t &result) {
 	return Uhugeint::TryConvert(std::nearbyint(value), result);
 }
 
@@ -594,14 +595,14 @@ struct NumericTryCastToBit {
 
 struct NumericTryCast {
 	template <class SRC, class DST>
-	static inline bool Operation(SRC input, DST &result, bool strict = false) {
+	static bool Operation(SRC input, DST &result, bool strict = false) {
 		return TryCastWithOverflowCheck(input, result);
 	}
 };
 
 struct NumericCast {
 	template <class SRC, class DST>
-	static inline DST Operation(SRC input) {
+	static DST Operation(SRC input) {
 		DST result;
 		if (!NumericTryCast::Operation(input, result)) {
 			throw InvalidInputException(CastExceptionText<SRC, DST>(input));

--- a/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
+++ b/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
@@ -24,10 +24,14 @@ applications, and to alter it and redistribute it freely, subject to the followi
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/fast_mem.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/operator/numeric_cast.hpp"
 
 #include <algorithm>
 #include <cstddef>
+#include <functional>
+#include <iterator>
 #include <utility>
 
 namespace duckdb_pdqsort {

--- a/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
+++ b/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
@@ -24,14 +24,10 @@ applications, and to alter it and redistribute it freely, subject to the followi
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/fast_mem.hpp"
 #include "duckdb/common/helper.hpp"
-#include "duckdb/common/types.hpp"
 #include "duckdb/common/unique_ptr.hpp"
-#include "duckdb/common/operator/numeric_cast.hpp"
 
 #include <algorithm>
 #include <cstddef>
-#include <functional>
-#include <iterator>
 #include <utility>
 
 namespace duckdb_pdqsort {

--- a/src/include/duckdb/common/types/row/block_iterator.hpp
+++ b/src/include/duckdb/common/types/row/block_iterator.hpp
@@ -119,11 +119,11 @@ public:
 		return GetValueAtIndex<T>(block_idx, tuple_idx);
 	}
 
-	void SetKeepPinned(const bool &) {
+	static void SetKeepPinned(const bool &) {
 		// NOP
 	}
 
-	void SetPinPayload(const bool &) {
+	static void SetPinPayload(const bool &) {
 		// NOP
 	}
 


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/11082. 

Fixed debug warnings spam.