### PR TITLE
_extension_distribution: Pin to `v1.4-andium` branch of extension-ci-tools

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -80,6 +80,7 @@ on:
       - '.github/patches/duckdb-wasm/**'
       - '.github/workflows/**'
       - '!.github/workflows/Extensions.yml'
+      - '!.github/workflows/_extension_distribution.yml'
 
 concurrency:
   group: extensions-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   build:
     name: Build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.3
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4-andium
     with:
       # We piggy-back extension-template to build the extensions in extension_config, it's hacky, but it works ¯\_(ツ)_/¯
       override_repository: duckdb/extension-template
@@ -56,7 +56,7 @@ jobs:
 
       # CI tools is pinned to main
       override_ci_tools_repository: duckdb/extension-ci-tools
-      ci_tools_version: v1.4.3
+      ci_tools_version: v1.4-andium
 
       exclude_archs: ${{ inputs.exclude_archs }}
       opt_in_archs: ${{ inputs.opt_in_archs }}


### PR DESCRIPTION
Improved version of https://github.com/duckdb/duckdb/pull/20227, now that we set on having a `v1.4-andium` branch in extension-ci-tools, this also will need some care while merging with `main`.

Also fixing a bug where opening a PR that changes only .github/workflows/_extension_distribution.yml will not trigger CI.