### PR TITLE
Preserve uppercase chars in DB filename on Windows

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -228,7 +228,7 @@ bool FileSystem::IsPathAbsolute(const string &path) {
 
 string FileSystem::NormalizeAbsolutePath(const string &path) {
 	D_ASSERT(IsPathAbsolute(path));
-	auto result = StringUtil::Lower(FileSystem::ConvertSeparators(path));
+	auto result = FileSystem::ConvertSeparators(path);
 	if (StartsWithSingleBackslash(result)) {
 		// Path starts with a single backslash or forward slash
 		// prepend drive letter

--- a/src/include/duckdb/main/database_file_path_manager.hpp
+++ b/src/include/duckdb/main/database_file_path_manager.hpp
@@ -48,7 +48,11 @@ private:
 	//! A set containing all attached database path
 	//! This allows to attach many databases efficiently, and to avoid attaching the
 	//! same file path twice
+#if defined(_WIN32) || defined(__APPLE__)
 	case_insensitive_map_t<DatabasePathInfo> db_paths;
+#else  // !(_WIN32 or __APPLE__)
+	unordered_map<string, DatabasePathInfo> db_paths;
+#endif // _WIN32 or __APPLE__
 };
 
 } // namespace duckdb

--- a/src/main/db_instance_cache.cpp
+++ b/src/main/db_instance_cache.cpp
@@ -13,7 +13,7 @@ DatabaseCacheEntry::DatabaseCacheEntry(const shared_ptr<DuckDB> &database_p) : d
 DatabaseCacheEntry::~DatabaseCacheEntry() {
 }
 
-string GetDBAbsolutePath(const string &database_p, FileSystem &fs) {
+static string GetDBAbsolutePath(const string &database_p, FileSystem &fs) {
 	auto database = FileSystem::ExpandPath(database_p, nullptr);
 	if (database.empty()) {
 		return IN_MEMORY_PATH;
@@ -32,6 +32,23 @@ string GetDBAbsolutePath(const string &database_p, FileSystem &fs) {
 	return fs.NormalizeAbsolutePath(fs.JoinPath(FileSystem::GetWorkingDirectory(), database));
 }
 
+static string GetCacheKey(const string &database_p, const DBConfig &config) {
+	// Currently the cache key is derived directly from the abs path,
+	// but it can apply more transformations to the path if necessary
+	string abs_database_path;
+	if (config.file_system) {
+		abs_database_path = GetDBAbsolutePath(database_p, *config.file_system);
+	} else {
+		auto tmp_fs = FileSystem::CreateLocal();
+		abs_database_path = GetDBAbsolutePath(database_p, *tmp_fs);
+	}
+#if defined(_WIN32) || defined(__APPLE__)
+	return StringUtil::Lower(abs_database_path);
+#else  // !(_WIN32 or __APPLE__)
+	return abs_database_path;
+#endif // _WIN32 or __APPLE__
+}
+
 DBInstanceCache::DBInstanceCache() {
 	path_manager = make_shared_ptr<DatabaseFilePathManager>();
 }
@@ -42,9 +59,8 @@ DBInstanceCache::~DBInstanceCache() {
 shared_ptr<DuckDB> DBInstanceCache::GetInstanceInternal(const string &database, const DBConfig &config,
                                                         std::unique_lock<std::mutex> &db_instances_lock) {
 	D_ASSERT(db_instances_lock.owns_lock());
-	auto local_fs = FileSystem::CreateLocal();
-	auto abs_database_path = GetDBAbsolutePath(database, *local_fs);
-	auto entry = db_instances.find(abs_database_path);
+	auto cache_key = GetCacheKey(database, config);
+	auto entry = db_instances.find(cache_key);
 	if (entry == db_instances.end()) {
 		// path does not exist in the list yet - no cache entry
 		return nullptr;
@@ -73,7 +89,7 @@ shared_ptr<DuckDB> DBInstanceCache::GetInstanceInternal(const string &database, 
 		D_ASSERT(!cache_entry);
 		// the cache entry has now been deleted - clear it from the set of database instances and return
 		db_instances_lock.lock();
-		db_instances.erase(abs_database_path);
+		db_instances.erase(cache_key);
 		db_instances_lock.unlock();
 		return nullptr;
 	}
@@ -110,12 +126,13 @@ shared_ptr<DuckDB> DBInstanceCache::CreateInstanceInternal(const string &databas
 	shared_ptr<DuckDB> db_instance;
 	config.path_manager = path_manager;
 	if (cache_instance) {
-		D_ASSERT(db_instances.find(abs_database_path) == db_instances.end());
+		string cache_key = GetCacheKey(database, config);
+		D_ASSERT(db_instances.find(cache_key) == db_instances.end());
 		shared_ptr<DatabaseCacheEntry> cache_entry = make_shared_ptr<DatabaseCacheEntry>();
 		config.db_cache_entry = cache_entry;
 		// Create the new instance after unlocking to avoid new ddb creation requests to be blocked
 		lock_guard<mutex> create_db_lock(cache_entry->update_database_mutex);
-		db_instances[abs_database_path] = cache_entry;
+		db_instances[cache_key] = cache_entry;
 		db_instances_lock.unlock();
 		db_instance = make_shared_ptr<DuckDB>(instance_path, &config);
 		cache_entry->database = db_instance;

--- a/test/api/capi/test_capi_instance_cache.cpp
+++ b/test/api/capi/test_capi_instance_cache.cpp
@@ -128,6 +128,8 @@ TEST_CASE("Test the database instance cache with case-insensitive FS", "[capi]")
 		REQUIRE(count == 0);
 #endif // _WIN32 or __APPLE__
        // Cleanup
+		duckdb_destroy_data_chunk(&chunk);
+		duckdb_destroy_result(&result);
 		duckdb_disconnect(&conn2);
 		duckdb_close(&db2);
 		duckdb_disconnect(&conn1);

--- a/test/api/capi/test_capi_instance_cache.cpp
+++ b/test/api/capi/test_capi_instance_cache.cpp
@@ -134,8 +134,11 @@ TEST_CASE("Test the database instance cache with case-insensitive FS", "[capi]")
 		duckdb_close(&db2);
 		duckdb_disconnect(&conn1);
 		duckdb_close(&db1);
-		fs->RemoveFile(db_path);
-		fs->RemoveFile(attached_db_path);
+		if (count == 0) {
+			fs->TryRemoveFile(db_path_lower);
+		}
+		fs->TryRemoveFile(db_path);
+		fs->TryRemoveFile(attached_db_path);
 	}
 	duckdb_destroy_instance_cache(&instance_cache);
 }

--- a/test/api/capi/test_capi_instance_cache.cpp
+++ b/test/api/capi/test_capi_instance_cache.cpp
@@ -1,5 +1,6 @@
 #include "capi_tester.hpp"
 #include "duckdb.h"
+#include "test_helpers.hpp"
 
 #include <chrono>
 #include <thread>
@@ -63,5 +64,76 @@ TEST_CASE("Test the database instance cache in the C API with a memory path", "[
 	auto state = duckdb_get_or_create_from_cache(instance_cache, ":memory:", &db, nullptr, nullptr);
 	REQUIRE(state == DuckDBSuccess);
 	duckdb_close(&db);
+	duckdb_destroy_instance_cache(&instance_cache);
+}
+
+TEST_CASE("Test the database instance cache with case-insensitive FS", "[capi]") {
+	// Check that file on disk is created in user-specified case
+	// independently whether FS is case-sensitive or not.
+	// FS access can be eventually changed to CAPI FS.
+	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
+	string work_dir = TestDirectoryPath();
+	auto instance_cache = duckdb_create_instance_cache();
+
+	std::vector<string> db_file_list = {"Test1.db", "TEST2.db", "TeSt3.db"};
+	for (const string &db_file : db_file_list) {
+		string db_path = TestJoinPath(work_dir, db_file);
+		string attached_db_path = TestJoinPath(work_dir, "attached_" + db_file);
+		fs->TryRemoveFile(db_path);
+		fs->TryRemoveFile(attached_db_path);
+
+		duckdb_database db1 = nullptr;
+		REQUIRE(duckdb_get_or_create_from_cache(instance_cache, db_path.c_str(), &db1, nullptr, nullptr) ==
+		        DuckDBSuccess);
+		duckdb_connection conn1 = nullptr;
+		REQUIRE(duckdb_connect(db1, &conn1) == DuckDBSuccess);
+		REQUIRE(duckdb_query(conn1, (string("ATTACH '") + attached_db_path + "' AS attached").c_str(), nullptr) ==
+		        DuckDBSuccess);
+		REQUIRE(duckdb_query(conn1, "CREATE TABLE attached.tab1 (col1 INT)", nullptr) == DuckDBSuccess);
+
+		// Check the file with originally specified case exists in FS
+		bool found = false;
+		fs->ListFiles(work_dir, [&db_file, &found](const string &name, bool) {
+			if (name == db_file) {
+				found = true;
+			}
+		});
+		REQUIRE(found);
+
+		// Get the DB from cache using different case and check that instance is the same
+		// (when the FS and instance cache are case-insensitive) and different (when case-sensitive)
+		string db_file_lower = db_file;
+		std::transform(db_file_lower.begin(), db_file_lower.end(), db_file_lower.begin(),
+		               [](unsigned char c) { return tolower(c); });
+		string db_path_lower = TestJoinPath(work_dir, db_file_lower);
+		fs->TryRemoveFile(db_path_lower);
+		duckdb_database db2 = nullptr;
+		REQUIRE(duckdb_get_or_create_from_cache(instance_cache, db_path_lower.c_str(), &db2, nullptr, nullptr) ==
+		        DuckDBSuccess);
+		duckdb_connection conn2 = nullptr;
+		REQUIRE(duckdb_connect(db2, &conn2) == DuckDBSuccess);
+		duckdb_result result;
+		memset(&result, '\0', sizeof(result));
+		REQUIRE(duckdb_query(conn2, "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'tab1'",
+		                     &result) == DuckDBSuccess);
+		duckdb_data_chunk chunk = duckdb_fetch_chunk(result);
+		REQUIRE(chunk != nullptr);
+		duckdb_vector vec = duckdb_data_chunk_get_vector(chunk, 0);
+		REQUIRE(vec != nullptr);
+		int32_t *data = reinterpret_cast<int32_t *>(duckdb_vector_get_data(vec));
+		int32_t count = data[0];
+#if defined(_WIN32) || defined(__APPLE__) // case insensitive, attached
+		REQUIRE(count == 1);
+#else  // !(_WIN32 or __APPLE__): case sensitive, not attached
+		REQUIRE(count == 0);
+#endif // _WIN32 or __APPLE__
+       // Cleanup
+		duckdb_disconnect(&conn2);
+		duckdb_close(&db2);
+		duckdb_disconnect(&conn1);
+		duckdb_close(&db1);
+		fs->RemoveFile(db_path);
+		fs->RemoveFile(attached_db_path);
+	}
 	duckdb_destroy_instance_cache(&instance_cache);
 }

--- a/test/api/capi/test_starting_database.cpp
+++ b/test/api/capi/test_starting_database.cpp
@@ -97,6 +97,6 @@ TEST_CASE("On Disk DB File Name Case Preserved", "[simplestartup]") {
 				fs->TryRemoveFile(db_path_lower);
 			}
 		}
-		fs->RemoveFile(db_path);
+		fs->TryRemoveFile(db_path);
 	}
 }

--- a/test/api/capi/test_starting_database.cpp
+++ b/test/api/capi/test_starting_database.cpp
@@ -1,8 +1,8 @@
-#include "catch.hpp"
+#include "capi_tester.hpp"
 #include "duckdb.h"
-
 #include "test_helpers.hpp"
 
+using namespace duckdb;
 using namespace std;
 
 TEST_CASE("Simple In-Memory DB Start Up and Shutdown", "[simplestartup]") {
@@ -89,6 +89,8 @@ TEST_CASE("On Disk DB File Name Case Preserved", "[simplestartup]") {
 #else  // !(_WIN32 or __APPLE__): case sensitive, different files
 			REQUIRE(count == 0);
 #endif // _WIN32 or __APPLE__
+			duckdb_destroy_data_chunk(&chunk);
+			duckdb_destroy_result(&result);
 			duckdb_disconnect(&conn);
 			duckdb_close(&database);
 			if (count == 0) {

--- a/test/api/capi/test_starting_database.cpp
+++ b/test/api/capi/test_starting_database.cpp
@@ -1,6 +1,8 @@
 #include "catch.hpp"
 #include "duckdb.h"
 
+#include "test_helpers.hpp"
+
 using namespace std;
 
 TEST_CASE("Simple In-Memory DB Start Up and Shutdown", "[simplestartup]") {
@@ -31,5 +33,68 @@ TEST_CASE("Multiple In-Memory DB Start Up and Shutdown", "[multiplestartup]") {
 			duckdb_disconnect(&connection[i * 10 + j]);
 		}
 		duckdb_close(&database[i]);
+	}
+}
+
+TEST_CASE("On Disk DB File Name Case Preserved", "[simplestartup]") {
+	// Check that file on disk is created in user-specified case
+	// independently whether FS is case-sensitive or not.
+	// FS access can be eventually changed to CAPI FS.
+	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
+	string work_dir = TestDirectoryPath();
+	std::vector<string> db_file_list = {"Test1.db", "TEST2.db", "TeSt3.db"};
+	for (const string &db_file : db_file_list) {
+		string db_path = TestJoinPath(work_dir, db_file);
+		fs->TryRemoveFile(db_path);
+		{
+			duckdb_database database = nullptr;
+			REQUIRE(duckdb_open(db_path.c_str(), &database) == DuckDBSuccess);
+			duckdb_connection conn = nullptr;
+			REQUIRE(duckdb_connect(database, &conn) == DuckDBSuccess);
+			REQUIRE(duckdb_query(conn, "CREATE TABLE tab1 (col1 INT)", nullptr) == DuckDBSuccess);
+			duckdb_disconnect(&conn);
+			duckdb_close(&database);
+		}
+		bool found = false;
+		fs->ListFiles(work_dir, [&db_file, &found](const string &name, bool) {
+			if (name == db_file) {
+				found = true;
+			}
+		});
+		REQUIRE(found);
+		{
+			// Open a connection to a lower-cased version of the path
+			string db_file_lower = db_file;
+			std::transform(db_file_lower.begin(), db_file_lower.end(), db_file_lower.begin(),
+			               [](unsigned char c) { return tolower(c); });
+			string db_path_lower = TestJoinPath(work_dir, db_file_lower);
+			duckdb_database database;
+			REQUIRE(duckdb_open(db_path_lower.c_str(), &database) == DuckDBSuccess);
+			// Run a query to check that we've opened the existing DB file or created a new one
+			// depending whether the FS is case-sensitive or not
+			duckdb_connection conn = nullptr;
+			REQUIRE(duckdb_connect(database, &conn) == DuckDBSuccess);
+			duckdb_result result;
+			memset(&result, '\0', sizeof(result));
+			REQUIRE(duckdb_query(conn, "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'tab1'",
+			                     &result) == DuckDBSuccess);
+			duckdb_data_chunk chunk = duckdb_fetch_chunk(result);
+			REQUIRE(chunk != nullptr);
+			duckdb_vector vec = duckdb_data_chunk_get_vector(chunk, 0);
+			REQUIRE(vec != nullptr);
+			int32_t *data = reinterpret_cast<int32_t *>(duckdb_vector_get_data(vec));
+			int32_t count = data[0];
+#if defined(_WIN32) || defined(__APPLE__) // case insensitive, same file
+			REQUIRE(count == 1);
+#else  // !(_WIN32 or __APPLE__): case sensitive, different files
+			REQUIRE(count == 0);
+#endif // _WIN32 or __APPLE__
+			duckdb_disconnect(&conn);
+			duckdb_close(&database);
+			if (count == 0) {
+				fs->TryRemoveFile(db_path_lower);
+			}
+		}
+		fs->RemoveFile(db_path);
 	}
 }

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -201,9 +201,9 @@ TEST_CASE("absolute paths", "[file_system]") {
 	REQUIRE(fs.IsPathAbsolute(network));
 	REQUIRE(fs.IsPathAbsolute("C:\\folder\\filename.csv"));
 	REQUIRE(fs.IsPathAbsolute("C:/folder\\filename.csv"));
-	REQUIRE(fs.NormalizeAbsolutePath("C:/folder\\filename.csv") == "c:\\folder\\filename.csv");
+	REQUIRE(fs.NormalizeAbsolutePath("C:/folder\\filename.csv") == "C:\\folder\\filename.csv");
 	REQUIRE(fs.NormalizeAbsolutePath(network) == network);
-	REQUIRE(fs.NormalizeAbsolutePath(long_path) == "\\\\?\\d:\\very long network\\");
+	REQUIRE(fs.NormalizeAbsolutePath(long_path) == "\\\\?\\D:\\very long network\\");
 #endif
 }
 


### PR DESCRIPTION
When connections are opened to a DB file specified in different case (like `Test1.db` and `test1.db`) the logic for accessing the file is different depending when the file system is case-sensitive or not. On case-insensitive FS the `Test1.db` and `test1.db` refer to the same file, on case-sensitive FS they refer to different files. The DB instance caching logic needs to take this into account and be consistent with the FS. Also, even with case-insensitive FS it may be better to not modify the user-specified case of the DB file name without reason - while `Test1.db` and `test1.db` point to the same file, the name case may be important to users (affect FS paths sorting etc).

There are (at least) 3 places that can affect this logic:

1. opening a DB file directly without DB instance cache using `duckdb_open`

2. opening a DB file, which DB instance may or may not be already cached in this process, using `duckdb_get_or_create_from_cache`

3. attaching a DB files to an existing DB instance (with `DatabaseFilePathManager` caching in place)

Current logic is the following:

1. when DB file is created through `duckdb_open` uses-specified case is preserved.

2. when DB file is created through `duckdb_get_or_create_from_cache` user-specified case is preserved on Linux and macOS, but NOT preserved on Windows - it is lowered.

3. DB instance cache uses lower-case absolute path as a cache key on Windows and original-cased absolute path on other platforms

4.  `DatabaseFilePathManager` uses case-insensitive path cache on all platforms.

This PR adds test coverage for the following scenarios:

1. direct open:

 - connection is opened directly (without cache) to a mixed-cased DB file
 - first connection is closed
 - another connection is opened directly to the same DB file in lower case
 - on case-sensitive FS these connections must go to different DB files
 - on case-insensitive FS both connections must go to the same file

2. DB instance cache and `DatabaseFilePathManager`:

 - connection is opened with DB instance cache to a mixed-cased DB file (and kept open)
 - another connection is opened with DB instance cache to the same DB file in lower case
 - on case-sensitive FS second connection must create a new DB file in different case
 - on case-insensitive FS second connection must get the same cached DB instance that was created by the first connection

The following changes are applied to make these tests to pass:

1. the caching in `DatabaseFilePathManager` is made case-sensitive for case-sensitive file systems, this is necessary because otherwise `DatabaseFilePathManager` does not allow to create new DB file in different case

2. DB instance cache key is separated from the DB path - original user-specified path is used to create the file. Lower cased path is used with case-insensitive FS and original path is used with case-sensitive FS. This is necessary to preserve the file name case on case-insensitive FS.

On FS case sensitivity: 

 - the same file system (like NTFS) can be configured to be case-sensitive or case-insensitive
 - on the same OS instance multiple FS can be mounted, some of them being case-sensitive and some are not
 - currently in DuckDB there is no detection of FS case-sensitivity
 
In this PR "FS case-sensitivity" is interpreted as "case-sensitive in default OS configuration", thus Windows and macOS are treated as "case-insensitive", other OSes (Linux) are treated as "case-sensitive".

Fixes: #19997

edit: PR description is rewritten because changes to `DatabaseFilePathManager` were required.