### PR TITLE
Use eager min/max aggregation on parquet statistics

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/storage/caching_file_system.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/encryption_functions.hpp"
@@ -206,7 +207,9 @@ public:
 	void AddVirtualColumn(column_t virtual_column_id) override;
 
 	void GetPartitionStats(vector<PartitionStatistics> &result);
-	static void GetPartitionStats(const duckdb_parquet::FileMetaData &metadata, vector<PartitionStatistics> &result);
+	static void GetPartitionStats(const duckdb_parquet::FileMetaData &metadata, vector<PartitionStatistics> &result,
+	                              optional_ptr<ParquetColumnSchema> root_schema = nullptr,
+	                              optional_ptr<ParquetOptions> parquet_options = nullptr);
 	static bool MetadataCacheEnabled(ClientContext &context);
 	static shared_ptr<ParquetFileMetadataCache> GetMetadataCacheEntry(ClientContext &context, const OpenFileInfo &file);
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -3,43 +3,28 @@
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/function/partition_stats.hpp"
 #include "parquet_types.h"
-#include "reader/boolean_column_reader.hpp"
-#include "reader/callback_column_reader.hpp"
 #include "column_reader.hpp"
-#include "duckdb.hpp"
 #include "reader/expression_column_reader.hpp"
 #include "parquet_geometry.hpp"
 #include "reader/list_column_reader.hpp"
 #include "parquet_crypto.hpp"
 #include "parquet_file_metadata_cache.hpp"
 #include "parquet_statistics.hpp"
-#include "parquet_timestamp.hpp"
 #include "mbedtls_wrapper.hpp"
 #include "reader/row_number_column_reader.hpp"
-#include "reader/string_column_reader.hpp"
 #include "reader/variant_column_reader.hpp"
 #include "reader/struct_column_reader.hpp"
-#include "reader/templated_column_reader.hpp"
 #include "thrift_tools.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/common/encryption_state.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/helper.hpp"
-#include "duckdb/common/hive_partitioning.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/object_cache.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/planner/table_filter_state.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
-#include "duckdb/logging/log_manager.hpp"
-#include "duckdb/common/multi_file/multi_file_column_mapper.hpp"
-#include "duckdb/common/encryption_functions.hpp"
-
-#include <cassert>
-#include <chrono>
-#include <cstring>
-#include <sstream>
 
 namespace duckdb {
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1253,14 +1253,22 @@ struct ParquetPartitionRowGroup : public PartitionRowGroup {
 	const idx_t row_group_idx;
 
 	unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) override {
+		const idx_t primary_index = storage_index.GetPrimaryIndex();
+		D_ASSERT(metadata.row_groups.size() > row_group_idx);
+		D_ASSERT(root_schema->children.size() > primary_index);
+
 		const auto &row_group = metadata.row_groups[row_group_idx];
-		const auto &column_schema = root_schema->children[storage_index.GetPrimaryIndex()];
+		const auto &column_schema = root_schema->children[primary_index];
 		return column_schema.Stats(metadata, *parquet_options, row_group_idx, row_group.columns);
 	}
 
 	bool MinMaxIsExact(const BaseStatistics &, const StorageIndex &storage_index) override {
+		const idx_t primary_index = storage_index.GetPrimaryIndex();
+		D_ASSERT(metadata.row_groups.size() > row_group_idx);
+		D_ASSERT(root_schema->children.size() > primary_index);
+
 		const auto &row_group = metadata.row_groups[row_group_idx];
-		const auto &column_chunk = row_group.columns[storage_index.GetPrimaryIndex()];
+		const auto &column_chunk = row_group.columns[primary_index];
 
 		if (column_chunk.__isset.meta_data && column_chunk.meta_data.__isset.statistics &&
 		    column_chunk.meta_data.statistics.__isset.is_min_value_exact &&

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1248,10 +1248,9 @@ struct ParquetPartitionRowGroup : public PartitionRowGroup {
 	}
 
 	const duckdb_parquet::FileMetaData &metadata;
-	optional_ptr<ParquetColumnSchema> root_schema;
-	optional_ptr<ParquetOptions> parquet_options;
-	idx_t row_group_idx;
-	bool is_exact = false;
+	const optional_ptr<ParquetColumnSchema> root_schema;
+	const optional_ptr<ParquetOptions> parquet_options;
+	const idx_t row_group_idx;
 
 	unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) override {
 		const auto &row_group = metadata.row_groups[row_group_idx];

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1284,7 +1284,7 @@ void ParquetReader::GetPartitionStats(const duckdb_parquet::FileMetaData &metada
 		partition_stats.count_type = CountType::COUNT_EXACT;
 		if (root_schema && parquet_options) {
 			partition_stats.partition_row_group =
-			    make_shared_ptr<ParquetPartitionRowGroup>(metadata, *root_schema, *parquet_options, i);
+			    make_shared_ptr<ParquetPartitionRowGroup>(metadata, root_schema, parquet_options, i);
 		}
 		offset += row_group.num_rows;
 		result.push_back(partition_stats);

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1251,7 +1251,7 @@ struct ParquetPartitionRowGroup : public PartitionRowGroup {
 	optional_ptr<ParquetColumnSchema> root_schema;
 	optional_ptr<ParquetOptions> parquet_options;
 	idx_t row_group_idx;
-	bool is_exact;
+	bool is_exact = false;
 
 	unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) override {
 		const auto &row_group = metadata.row_groups[row_group_idx];

--- a/src/include/duckdb/function/partition_stats.hpp
+++ b/src/include/duckdb/function/partition_stats.hpp
@@ -29,7 +29,7 @@ enum class CountType { COUNT_EXACT, COUNT_APPROXIMATE };
 struct PartitionRowGroup {
 	virtual ~PartitionRowGroup() = default;
 	virtual unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) = 0;
-	virtual bool MinMaxIsExact(const BaseStatistics &stats) = 0;
+	virtual bool MinMaxIsExact(const BaseStatistics &stats, const StorageIndex &storage_index) = 0;
 };
 
 struct PartitionStatistics {

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -73,7 +73,7 @@ bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &
 		return false;
 	}
 	auto column_stats = stats.partition_row_group->GetColumnStatistics(storage_index);
-	if (!stats.partition_row_group->MinMaxIsExact(*column_stats)) {
+	if (!stats.partition_row_group->MinMaxIsExact(*column_stats, storage_index)) {
 		return false;
 	}
 	if (column_stats->GetStatsType() == StatisticsType::NUMERIC_STATS) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -191,7 +191,7 @@ void RowGroup::InitializeEmpty(const vector<LogicalType> &types, ColumnDataType 
 
 static unique_ptr<PushedDownExpressionState> CreateCast(ClientContext &context, const LogicalType &original_type,
                                                         const LogicalType &cast_type) {
-	auto input = make_uniq<BoundReferenceExpression>(original_type, 0);
+	auto input = make_uniq<BoundReferenceExpression>(original_type, NumericCast<storage_t>(0));
 	auto cast_expression = BoundCastExpression::AddCastToType(context, std::move(input), cast_type);
 	auto res = make_uniq<PushedDownExpressionState>(context);
 	res->target.Initialize(context, {cast_type});

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1429,7 +1429,7 @@ struct DuckDBPartitionRowGroup : public PartitionRowGroup {
 		return row_group.GetStatistics(storage_index);
 	}
 
-	bool MinMaxIsExact(const BaseStatistics &stats) override {
+	bool MinMaxIsExact(const BaseStatistics &stats, const StorageIndex &) override {
 		if (!is_exact || row_group.HasChanges()) {
 			return false;
 		}

--- a/test/optimizer/eager_aggregate_execution.test
+++ b/test/optimizer/eager_aggregate_execution.test
@@ -36,7 +36,7 @@ DETACH tmp
 query II
 EXPLAIN SELECT count(*), min(i), max(i) FROM t
 ----
-physical_plan	<!REGEX>:.*GROUP_BY.*
+physical_plan	<!REGEX>:.*AGGREGATE.*
 
 query II
 EXPLAIN SELECT count(*), min(i), max(i) FROM t GROUP BY i
@@ -46,7 +46,7 @@ physical_plan	<REGEX>:.*GROUP_BY.*
 query II
 EXPLAIN SELECT count(*), min(i), max(i) FROM t WHERE i > 100
 ----
-physical_plan	<!REGEX>:.*GROUP_BY.*
+physical_plan	<REGEX>:.*AGGREGATE.*
 
 query III
 SELECT count(*), min(i), max(i) FROM t

--- a/test/optimizer/eager_aggregate_execution_parquet.test
+++ b/test/optimizer/eager_aggregate_execution_parquet.test
@@ -2,10 +2,6 @@
 # description: Test eager count_star, min, and max execution on parquet
 # group: [optimizer]
 
-# TODO: Do we still need this?
-# Alternative verify disables eager aggregate execution
-require no_alternative_verify
-
 require parquet
 
 statement ok

--- a/test/optimizer/eager_aggregate_execution_parquet.test
+++ b/test/optimizer/eager_aggregate_execution_parquet.test
@@ -1,0 +1,38 @@
+# name: test/optimizer/eager_aggregate_execution_parquet.test
+# description: Test eager count_star, min, and max execution on parquet
+# group: [optimizer]
+
+# TODO: Do we still need this?
+# Alternative verify disables eager aggregate execution
+require no_alternative_verify
+
+require parquet
+
+statement ok
+COPY (FROM range (8192) t(i)) TO '__TEST_DIR__/eager_agg.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+
+query II
+EXPLAIN SELECT count(*), min(i), max(i) FROM '__TEST_DIR__/eager_agg.parquet'
+----
+physical_plan	<!REGEX>:.*AGGREGATE.*
+
+query II
+EXPLAIN SELECT count(*), min(i), max(i) FROM '__TEST_DIR__/eager_agg.parquet' GROUP BY i
+----
+physical_plan	<REGEX>:.*GROUP_BY.*
+
+query II
+EXPLAIN SELECT count(*), min(i), max(i) FROM '__TEST_DIR__/eager_agg.parquet' WHERE i > 100
+----
+physical_plan	<REGEX>:.*AGGREGATE.*
+
+query III
+SELECT count(*), min(i), max(i) FROM '__TEST_DIR__/eager_agg.parquet'
+----
+8192	0	8191
+
+query III
+SELECT max(i), count(i), min(i) FROM '__TEST_DIR__/eager_agg.parquet'
+----
+8191	8192	0
+


### PR DESCRIPTION
Follow-up on https://github.com/duckdb/duckdb/pull/19906

This PR allows eagerly executing ungrouped min/max aggregates with Parquet row group statistics analogous to the DuckDB file format.