### PR TITLE
c-api: adding out_file against NULL check

### DIFF
--- a/src/main/capi/file_system-c.cpp
+++ b/src/main/capi/file_system-c.cpp
@@ -99,11 +99,17 @@ void duckdb_destroy_file_open_options(duckdb_file_open_options *options) {
 duckdb_state duckdb_file_system_open(duckdb_file_system fs, const char *path, duckdb_file_open_options options,
                                      duckdb_file_handle *out_file) {
 	if (!fs) {
-		*out_file = nullptr;
+		if (out_file) {
+			*out_file = nullptr;
+		}
 		return DuckDBError;
 	}
 	auto cfs = reinterpret_cast<duckdb::CFileSystem *>(fs);
-	if (!path || !options || !out_file) {
+	if (!out_file) {
+		cfs->SetError("Invalid out file to duckdb_file_system_open");
+		return DuckDBError;
+	}
+	if (!path || !options) {
 		cfs->SetError("Invalid input to duckdb_file_system_open");
 		*out_file = nullptr;
 		return DuckDBError;

--- a/test/api/capi/capi_file_system.cpp
+++ b/test/api/capi/capi_file_system.cpp
@@ -25,6 +25,35 @@ static void test_file_system(duckdb_file_system fs, string file_name) {
 	REQUIRE(error_type == DUCKDB_ERROR_IO);
 	duckdb_destroy_error_data(&error_data);
 
+	// Try to open file without options
+	state = duckdb_file_system_open(fs, file_path.c_str(), nullptr, &file);
+	REQUIRE(state == DuckDBError);
+	error_data = duckdb_file_system_error_data(fs);
+	error_type = duckdb_error_data_error_type(error_data);
+	REQUIRE(error_type == DUCKDB_ERROR_IO);
+	duckdb_destroy_error_data(&error_data);
+
+	// Try to open incorrect file
+	state = duckdb_file_system_open(fs, file_path.c_str(), options, nullptr);
+	REQUIRE(state == DuckDBError);
+	error_data = duckdb_file_system_error_data(fs);
+	error_type = duckdb_error_data_error_type(error_data);
+	REQUIRE(error_type == DUCKDB_ERROR_IO);
+	duckdb_destroy_error_data(&error_data);
+
+	// Try to open file with incorrect filename
+	state = duckdb_file_system_open(fs, nullptr, options, &file);
+	REQUIRE(state == DuckDBError);
+	error_data = duckdb_file_system_error_data(fs);
+	error_type = duckdb_error_data_error_type(error_data);
+	REQUIRE(error_type == DUCKDB_ERROR_IO);
+	duckdb_destroy_error_data(&error_data);
+
+	// Try to open with all incorrect input parameters
+	// fs is incorrect, error message verification is not possible
+	state = duckdb_file_system_open(nullptr, nullptr, nullptr, nullptr);
+	REQUIRE(state == DuckDBError);
+
 	// Try to write to a null file handle
 	auto failed_bytes_written = duckdb_file_handle_write(file, "data", 4);
 	REQUIRE(failed_bytes_written == -1);


### PR DESCRIPTION
The pointer was used incorrectly, but it was checked against NULL.

Fixes: d4f7b546b2 ("add support for opening duckdb filesystem from c-api")