### PR TITLE
fix binder: handle errors with over in where inside subquery

### DIFF
--- a/src/include/duckdb/parser/expression/window_expression.hpp
+++ b/src/include/duckdb/parser/expression/window_expression.hpp
@@ -92,6 +92,8 @@ public:
 
 	static bool Equal(const WindowExpression &a, const WindowExpression &b);
 
+	bool HasBoundedParts();
+
 	unique_ptr<ParsedExpression> Copy() const override;
 
 	void Serialize(Serializer &serializer) const override;

--- a/src/parser/expression/window_expression.cpp
+++ b/src/parser/expression/window_expression.cpp
@@ -134,6 +134,32 @@ bool WindowExpression::Equal(const WindowExpression &a, const WindowExpression &
 	return true;
 }
 
+bool WindowExpression::HasBoundedParts() {
+	for (auto &child : children) {
+		if ((*child).GetExpressionClass() == ExpressionClass::BOUND_EXPRESSION) {
+			return true;
+		}
+	}
+	for (auto &partition : partitions) {
+		if ((*partition).GetExpressionClass() == ExpressionClass::BOUND_EXPRESSION) {
+			return true;
+		}
+	}
+
+	for (auto &o : orders) {
+		if ((*o.expression).GetExpressionClass() == ExpressionClass::BOUND_EXPRESSION) {
+			return true;
+		}
+	}
+
+	for (auto &o : arg_orders) {
+		if ((*o.expression).GetExpressionClass() == ExpressionClass::BOUND_EXPRESSION) {
+			return true;
+		}
+	}
+	return false;
+}
+
 unique_ptr<ParsedExpression> WindowExpression::Copy() const {
 	auto new_window = make_uniq<WindowExpression>(type, catalog, schema, function_name);
 	new_window->CopyProperties(*this);

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -365,6 +365,16 @@ ErrorData ExpressionBinder::Bind(unique_ptr<ParsedExpression> &expr, idx_t depth
 		// already bound, don't bind it again
 		return ErrorData();
 	}
+	if (expression.GetExpressionClass() == ExpressionClass::WINDOW) {
+		auto &w = expression.Cast<WindowExpression>();
+		if (w.HasBoundedParts()) {
+			BindResult result =
+			    BindResult(BinderException::Unsupported(*expr, "window expression is not supported here"));
+			if (result.HasError()) {
+				return std::move(result.error);
+			}
+		}
+	}
 	// bind the expression
 	BindResult result = BindExpression(expr, depth, root_expression);
 	if (result.HasError()) {

--- a/test/fuzzer/public/window_subquery_error.test
+++ b/test/fuzzer/public/window_subquery_error.test
@@ -11,4 +11,4 @@ CREATE TABLE v00 (c01 INT, c02 STRING);
 statement error
 SELECT 'string' IN ( SELECT string_agg ('str') OVER ( PARTITION BY c02 + 'string' IN ( SELECT 'string' )) );
 ----
-correlated columns in window functions not supported
+window expression is not supported here

--- a/test/fuzzer/public/window_subquery_with_functions_error.test
+++ b/test/fuzzer/public/window_subquery_with_functions_error.test
@@ -1,0 +1,14 @@
+# name: test/fuzzer/public/window_subquery_with_functions_error.test
+# description: Test window function with a subquery that generates an error message
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE v0 ( v1 INTEGER ) ;
+
+statement error
+SELECT ( SELECT to_centuries ( v1 ) FROM v0 WHERE fmod ( fmod ( v1 , 3.100000 ) , 3.100000 ) OVER( ORDER BY v1 ) = 70000 ) AS century_result;
+----
+window expression is not supported here


### PR DESCRIPTION
Fixes #20263 

```
memory D SELECT ( SELECT to_centuries ( v1 ) FROM v0 WHERE fmod ( fmod ( v1 , 3.100000 ) , 3.100000 ) OVER( ORDER BY v1 ) = 70000 ) AS century_result ;
Binder Error:
WINDOW expression is not supported here

LINE 1: SELECT ( SELECT to_centuries ( v1 ) FROM v0 WHERE fmod ( fmod ( v1 , 3.100000 ) , 3.100000 ) OVER( ORDER BY...
                                                          ^
memory D

```