### PR TITLE
fix __builtin_clzl triggers D_ASSERT in bit_utils.hpp when building with MSVC + Clang GNU CLI

### DIFF
--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -147,9 +147,14 @@ function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTEN
             elseif (ZOS)
                 target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS})
             else()
-                # For GNU we rely on fvisibility=hidden to hide the extension symbols and use -exclude-libs to hide the duckdb symbols
-                set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
-                target_link_libraries(${TARGET_NAME} duckdb_static dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,--gc-sections -Wl,--exclude-libs,ALL)
+                if (MSVC_VERSION)
+                    # MSVC + Clang GNU CLI build combo
+                    target_link_libraries(${TARGET_NAME} duckdb_static dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS})
+                else()
+                    # For GNU we rely on fvisibility=hidden to hide the extension symbols and use -exclude-libs to hide the duckdb symbols
+                    set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+                    target_link_libraries(${TARGET_NAME} duckdb_static dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,--gc-sections -Wl,--exclude-libs,ALL)
+                endif()
             endif()
         elseif (WIN32)
             target_link_libraries(${TARGET_NAME} duckdb_static dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,9 @@ endif()
 
 set(DUCKDB_SYSTEM_LIBS ${CMAKE_DL_LIBS})
 
-if(MSVC OR MINGW)
+if(MSVC
+   OR MINGW
+   OR MSVC_VERSION)
   set(DUCKDB_SYSTEM_LIBS ${DUCKDB_SYSTEM_LIBS} ws2_32 rstrtmgr)
 endif()
 if(MSVC)

--- a/src/include/duckdb/common/bit_utils.hpp
+++ b/src/include/duckdb/common/bit_utils.hpp
@@ -41,7 +41,7 @@ struct CountZeros<uint64_t> {
 		value |= value >> 16;
 		value |= value >> 32;
 		auto result = 63 - index64msb[(value * debruijn64msb) >> 58];
-#ifdef __clang__
+#if defined(__clang__) && !defined(_MSC_VER)
 		D_ASSERT(result == static_cast<uint64_t>(__builtin_clzl(value_in)));
 #endif
 		return result;
@@ -58,7 +58,7 @@ struct CountZeros<uint64_t> {
 		                                   56, 45, 25, 31, 35, 16, 9,  12, 44, 24, 15, 8,  23, 7,  6,  5};
 		constexpr uint64_t debruijn64lsb = 0x07EDD5E59A4E28C2ULL;
 		auto result = index64lsb[((value & -value) * debruijn64lsb) >> 58];
-#ifdef __clang__
+#if defined(__clang__) && !defined(_MSC_VER)
 		D_ASSERT(result == static_cast<uint64_t>(__builtin_ctzl(value_in)));
 #endif
 		return result;

--- a/third_party/re2/CMakeLists.txt
+++ b/third_party/re2/CMakeLists.txt
@@ -47,7 +47,9 @@ elseif(CYGWIN OR MINGW)
   # See https://stackoverflow.com/questions/38139631 for details.
   add_compile_options(-std=gnu++11)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  add_compile_options(-std=c++11)
+  if(NOT DEFINED MSVC_VERSION)
+    add_compile_options(-std=c++11)
+  endif()
 endif()
 
 add_definitions(-DRE2_ON_VALGRIND)


### PR DESCRIPTION

## **Summary of the Fix**

When Clang is used in GNU CLI mode with the MSVC backend:

- `__clang__` is defined  
- `_MSC_VER` is also defined  
- `__builtin_clzl` and `__builtin_ctzl` do **not** behave consistently with the MSVC ABI  

DuckDB currently validates the De Bruijn CTZ/CLZ implementation using:

```cpp
#ifdef __clang__
    D_ASSERT(result == static_cast<uint64_t>(__builtin_clzl(value_in)));
#endif
```

Under this toolchain, the builtin comparison produces false‑positive assertion failures during insertion, even though the De Bruijn implementation is correct.

This PR updates the condition to:

```cpp
#if defined(__clang__) && !defined(_MSC_VER)
```

This preserves validation for:

- Clang on Linux  
- Clang on macOS  

and disables it only when Clang targets the MSVC backend (including clang‑cl and Clang GNU CLI), where the builtin behavior is unreliable.

---

## **Optional CMake Improvements**

This PR also includes optional CMake adjustments that improve compatibility when building DuckDB with Clang (GNU CLI)
These commits are isolated and can be included or omitted at the maintainers’ discretion.

---

## **Build Configuration for MSVC + Clang GNU CLI**

To build, the following CMake options are required:

```cmake
set(DUCKDB_EXPLICIT_PLATFORM windows_amd64)
set(ENABLE_SANITIZER OFF CACHE BOOL "" FORCE)
set(ENABLE_UBSAN OFF CACHE BOOL "" FORCE)
```

---

## **Reproduction Steps**

After building with the configuration above, the issue can be reproduced using the DuckDB CLI:

```sql
CREATE TABLE IF NOT EXISTS test_table (key VARCHAR PRIMARY KEY,value VARCHAR);
INSERT INTO test_table (key, value)  VALUES ('aaa', 'bbb') ON CONFLICT(key) DO UPDATE SET value = excluded.value;
```

This triggers:

```
INTERNAL Error:
Assertion triggered in file ".../duckdb/src/include\duckdb/common/bit_utils.hpp" on line 45: result == static_cast<uint64_t>(__builtin_clzl(value_in))
This error signals an assertion failure within DuckDB. This usually occurs due to unexpected conditions or errors in the program's logic.
For more information, see https://duckdb.org/docs/stable/dev/internal_errors
```