### PR TITLE
Fix caching filesystem `CanSeek`

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -171,7 +171,7 @@
 #include "duckdb/planner/bound_result_modifier.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/buffer/block_handle.hpp"
-#include "duckdb/storage/caching_file_system_wrapper.hpp"
+#include "duckdb/storage/caching_mode.hpp"
 #include "duckdb/storage/compression/bitpacking.hpp"
 #include "duckdb/storage/magic_bytes.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
@@ -910,19 +910,20 @@ CacheValidationMode EnumUtil::FromString<CacheValidationMode>(const char *value)
 const StringUtil::EnumStringLiteral *GetCachingModeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(CachingMode::ALWAYS_CACHE), "ALWAYS_CACHE" },
-		{ static_cast<uint32_t>(CachingMode::CACHE_REMOTE_ONLY), "CACHE_REMOTE_ONLY" }
+		{ static_cast<uint32_t>(CachingMode::CACHE_REMOTE_ONLY), "CACHE_REMOTE_ONLY" },
+		{ static_cast<uint32_t>(CachingMode::NO_CACHING), "NO_CACHING" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<CachingMode>(CachingMode value) {
-	return StringUtil::EnumToString(GetCachingModeValues(), 2, "CachingMode", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetCachingModeValues(), 3, "CachingMode", static_cast<uint32_t>(value));
 }
 
 template<>
 CachingMode EnumUtil::FromString<CachingMode>(const char *value) {
-	return static_cast<CachingMode>(StringUtil::StringToEnum(GetCachingModeValues(), 2, "CachingMode", value));
+	return static_cast<CachingMode>(StringUtil::StringToEnum(GetCachingModeValues(), 3, "CachingMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetCatalogLookupBehaviorValues() {

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -47,10 +47,8 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 	if (flags.GetCachingMode() != CachingMode::NO_CACHING) {
 		auto caching_filesystem =
 		    make_shared_ptr<CachingFileSystemWrapper>(internal_filesystem, opener, flags.GetCachingMode());
+		// caching filesystem's lifecycle is extended inside of caching file handle. 
 		file_handle = caching_filesystem->OpenFile(file, flags, opener);
-		// CachingFileSystemWrapper is not stored within VFS, so pin its lifecycle inside of file handle.
-		auto &caching_file_handle = file_handle->Cast<CachingFileHandleWrapper>();
-		caching_file_handle.PinCachingFileSystem(std::move(caching_filesystem));
 	} else {
 		file_handle = internal_filesystem.OpenFile(file, flags, opener);
 	}

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -47,7 +47,7 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 	if (flags.GetCachingMode() != CachingMode::NO_CACHING) {
 		auto caching_filesystem =
 		    make_shared_ptr<CachingFileSystemWrapper>(internal_filesystem, opener, flags.GetCachingMode());
-		// caching filesystem's lifecycle is extended inside of caching file handle. 
+		// caching filesystem's lifecycle is extended inside of caching file handle.
 		file_handle = caching_filesystem->OpenFile(file, flags, opener);
 	} else {
 		file_handle = internal_filesystem.OpenFile(file, flags, opener);

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -38,17 +38,18 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 	// open the base file handle in UNCOMPRESSED mode
 	flags.SetCompression(FileCompressionType::UNCOMPRESSED);
 
-	auto& internal_filesystem = FindFileSystem(file.path, opener);
+	auto &internal_filesystem = FindFileSystem(file.path, opener);
 
 	// File handle gets created.
 	unique_ptr<FileHandle> file_handle = nullptr;
 
 	// Handle caching logic.
 	if (flags.GetCachingMode() != CachingMode::NO_CACHING) {
-		auto caching_filesystem = make_shared_ptr<CachingFileSystemWrapper>(internal_filesystem, opener, flags.GetCachingMode());
+		auto caching_filesystem =
+		    make_shared_ptr<CachingFileSystemWrapper>(internal_filesystem, opener, flags.GetCachingMode());
 		file_handle = caching_filesystem->OpenFile(file, flags, opener);
 		// CachingFileSystemWrapper is not stored within VFS, so pin its lifecycle inside of file handle.
-		auto& caching_file_handle = file_handle->Cast<CachingFileHandleWrapper>();
+		auto &caching_file_handle = file_handle->Cast<CachingFileHandleWrapper>();
 		caching_file_handle.PinCachingFileSystem(std::move(caching_filesystem));
 	} else {
 		file_handle = internal_filesystem.OpenFile(file, flags, opener);

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/pipe_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/storage/caching_file_system_wrapper.hpp"
 
 namespace duckdb {
 
@@ -33,14 +34,30 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 			compression = FileCompressionType::UNCOMPRESSED;
 		}
 	}
-	// open the base file handle in UNCOMPRESSED mode
 
+	// open the base file handle in UNCOMPRESSED mode
 	flags.SetCompression(FileCompressionType::UNCOMPRESSED);
-	auto file_handle = FindFileSystem(file.path, opener).OpenFile(file, flags, opener);
+
+	auto& internal_filesystem = FindFileSystem(file.path, opener);
+
+	// File handle gets created.
+	unique_ptr<FileHandle> file_handle = nullptr;
+
+	// Handle caching logic.
+	if (flags.GetCachingMode() != CachingMode::NO_CACHING) {
+		auto caching_filesystem = make_shared_ptr<CachingFileSystemWrapper>(internal_filesystem, opener, flags.GetCachingMode());
+		file_handle = caching_filesystem->OpenFile(file, flags, opener);
+		// CachingFileSystemWrapper is not stored within VFS, so pin its lifecycle inside of file handle.
+		auto& caching_file_handle = file_handle->Cast<CachingFileHandleWrapper>();
+		caching_file_handle.PinCachingFileSystem(std::move(caching_filesystem));
+	} else {
+		file_handle = internal_filesystem.OpenFile(file, flags, opener);
+	}
 	if (!file_handle) {
 		return nullptr;
 	}
 
+	// Evaluate and apply compression option then.
 	const auto context = !flags.MultiClientAccess() ? FileOpener::TryGetClientContext(opener) : QueryContext();
 	if (file_handle->GetType() == FileType::FILE_TYPE_FIFO) {
 		file_handle = PipeFileSystem::OpenPipe(context, std::move(file_handle));

--- a/src/function/table/direct_file_reader.cpp
+++ b/src/function/table/direct_file_reader.cpp
@@ -56,7 +56,7 @@ AsyncResult DirectFileReader::Scan(ClientContext &context, GlobalTableFunctionSt
 
 	auto files = state.file_list;
 
-	auto& fs = FileSystem::GetFileSystem(context);
+	auto &fs = FileSystem::GetFileSystem(context);
 	const idx_t out_idx = 0;
 
 	// We utilize projection pushdown here to only read the file content if the 'data' column is requested

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/file_compression_type.hpp"
+#include "duckdb/storage/caching_mode.hpp"
 
 namespace duckdb {
 
@@ -52,6 +53,10 @@ public:
 		return a == FileCompressionType::UNCOMPRESSED ? b : a;
 	}
 
+	static constexpr CachingMode MergeCachingMode(CachingMode a, CachingMode b) {
+		return a == CachingMode::NO_CACHING ? b : a;
+	}
+
 	inline constexpr FileOpenFlags operator|(FileOpenFlags b) const {
 		return FileOpenFlags(flags | b.flags, MergeLock(lock, b.lock), MergeCompression(compression, b.compression));
 	}
@@ -59,6 +64,7 @@ public:
 		flags |= b.flags;
 		lock = MergeLock(lock, b.lock);
 		compression = MergeCompression(compression, b.compression);
+		caching_mode = MergeCachingMode(caching_mode, b.caching_mode);
 		return *this;
 	}
 
@@ -72,6 +78,13 @@ public:
 
 	void SetCompression(FileCompressionType new_compression) {
 		compression = new_compression;
+	}
+
+	CachingMode GetCachingMode() {
+		return caching_mode;
+	}
+	void SetCachingMode(CachingMode new_caching_mode) {
+		caching_mode = new_caching_mode;
 	}
 
 	void Verify();
@@ -122,6 +135,7 @@ public:
 private:
 	idx_t flags = 0;
 	FileLockType lock = FileLockType::NO_LOCK;
+	CachingMode caching_mode = CachingMode::NO_CACHING;
 	FileCompressionType compression = FileCompressionType::UNCOMPRESSED;
 };
 

--- a/src/include/duckdb/storage/caching_file_system.hpp
+++ b/src/include/duckdb/storage/caching_file_system.hpp
@@ -126,10 +126,10 @@ public:
 private:
 	//! The Client FileSystem (needs to be client-specific so we can do, e.g., HTTPFS profiling)
 	FileSystem &file_system;
-	//! The External File Cache that caches the files
-	ExternalFileCache &external_file_cache;
 	//! The DatabaseInstance.
 	DatabaseInstance &db;
+	//! The External File Cache that caches the files
+	ExternalFileCache &external_file_cache;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/caching_file_system_wrapper.hpp
@@ -8,9 +8,10 @@
 
 #pragma once
 
-#include "duckdb/common/winapi.hpp"
+#include "duckdb/common/enable_shared_from_this_ipp.hpp"
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/winapi.hpp"
 #include "duckdb/storage/caching_file_system.hpp"
 #include "duckdb/storage/caching_mode.hpp"
 
@@ -28,21 +29,14 @@ class CachingFileHandleWrapper : public FileHandle {
 	friend class CachingFileSystemWrapper;
 
 public:
-	DUCKDB_API CachingFileHandleWrapper(CachingFileSystemWrapper &file_system, unique_ptr<CachingFileHandle> handle,
-	                                    FileOpenFlags flags);
-	DUCKDB_API CachingFileHandleWrapper(shared_ptr<CachingFileHandleWrapper> file_system,
+	DUCKDB_API CachingFileHandleWrapper(shared_ptr<CachingFileSystemWrapper> file_system,
 	                                    unique_ptr<CachingFileHandle> handle, FileOpenFlags flags);
-
-	// API used to pin caching filesystem's lifecycle inside of the file handle.
-	DUCKDB_API void PinCachingFileSystem(shared_ptr<CachingFileSystemWrapper> caching_filesystem_p);
 
 	DUCKDB_API ~CachingFileHandleWrapper() override;
 
 	DUCKDB_API void Close() override;
 
 private:
-	// Optional caching filesystem.
-	//
 	// CachingFileSystem is not kept within VFS as other filesystems, so sometimes it's necessary to pin it inside of
 	// file handle and ensure it's valid.
 	shared_ptr<CachingFileSystemWrapper> caching_file_system;
@@ -55,7 +49,7 @@ private:
 //! read, the wrapper class always copies requested byted into the provided address.
 //!
 //! NOTICE: Currently only read and seek operations are supported, write operations are disabled.
-class CachingFileSystemWrapper : public FileSystem {
+class CachingFileSystemWrapper : public FileSystem, public enable_shared_from_this<CachingFileSystemWrapper> {
 public:
 	DUCKDB_API CachingFileSystemWrapper(FileSystem &file_system, DatabaseInstance &db,
 	                                    CachingMode mode = CachingMode::CACHE_REMOTE_ONLY);

--- a/src/include/duckdb/storage/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/caching_file_system_wrapper.hpp
@@ -30,7 +30,8 @@ class CachingFileHandleWrapper : public FileHandle {
 public:
 	DUCKDB_API CachingFileHandleWrapper(CachingFileSystemWrapper &file_system, unique_ptr<CachingFileHandle> handle,
 	                                    FileOpenFlags flags);
-	DUCKDB_API CachingFileHandleWrapper(shared_ptr<CachingFileHandleWrapper> file_system, unique_ptr<CachingFileHandle> handle, FileOpenFlags flags);
+	DUCKDB_API CachingFileHandleWrapper(shared_ptr<CachingFileHandleWrapper> file_system,
+	                                    unique_ptr<CachingFileHandle> handle, FileOpenFlags flags);
 
 	// API used to pin caching filesystem's lifecycle inside of the file handle.
 	DUCKDB_API void PinCachingFileSystem(shared_ptr<CachingFileSystemWrapper> caching_filesystem_p);
@@ -42,7 +43,8 @@ public:
 private:
 	// Optional caching filesystem.
 	//
-	// CachingFileSystem is not kept within VFS as other filesystems, so sometimes it's necessary to pin it inside of file handle and ensure it's valid.
+	// CachingFileSystem is not kept within VFS as other filesystems, so sometimes it's necessary to pin it inside of
+	// file handle and ensure it's valid.
 	shared_ptr<CachingFileSystemWrapper> caching_file_system;
 
 	unique_ptr<CachingFileHandle> caching_handle;
@@ -57,7 +59,8 @@ class CachingFileSystemWrapper : public FileSystem {
 public:
 	DUCKDB_API CachingFileSystemWrapper(FileSystem &file_system, DatabaseInstance &db,
 	                                    CachingMode mode = CachingMode::CACHE_REMOTE_ONLY);
-	DUCKDB_API CachingFileSystemWrapper(FileSystem &file_system, optional_ptr<FileOpener> file_opener, CachingMode mode = CachingMode::CACHE_REMOTE_ONLY);
+	DUCKDB_API CachingFileSystemWrapper(FileSystem &file_system, optional_ptr<FileOpener> file_opener,
+	                                    CachingMode mode = CachingMode::CACHE_REMOTE_ONLY);
 	DUCKDB_API ~CachingFileSystemWrapper() override;
 
 	DUCKDB_API static CachingFileSystemWrapper Get(ClientContext &context,

--- a/src/include/duckdb/storage/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/caching_file_system_wrapper.hpp
@@ -57,9 +57,6 @@ public:
 	                                    CachingMode mode = CachingMode::CACHE_REMOTE_ONLY);
 	DUCKDB_API ~CachingFileSystemWrapper() override;
 
-	DUCKDB_API static CachingFileSystemWrapper Get(ClientContext &context,
-	                                               CachingMode mode = CachingMode::CACHE_REMOTE_ONLY);
-
 	DUCKDB_API std::string GetName() const override;
 
 	DUCKDB_API unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,

--- a/src/include/duckdb/storage/caching_mode.hpp
+++ b/src/include/duckdb/storage/caching_mode.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/cache_mode.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cstdint>
+
+namespace duckdb {
+
+//! Caching mode for CachingFileSystemWrapper.
+//! By default only remote files will be cached, but it's also allowed to cache local for direct IO use case.
+enum class CachingMode : uint8_t {
+	// Cache all files.
+	ALWAYS_CACHE = 0,
+	// Only cache remote files, bypass cache for local files.
+	CACHE_REMOTE_ONLY = 1,
+	// Doesn't perform caching.
+	NO_CACHING = 2,
+};
+
+}  // namespace duckdb

--- a/src/include/duckdb/storage/caching_mode.hpp
+++ b/src/include/duckdb/storage/caching_mode.hpp
@@ -23,4 +23,4 @@ enum class CachingMode : uint8_t {
 	NO_CACHING = 2,
 };
 
-}  // namespace duckdb
+} // namespace duckdb

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/chrono.hpp"
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/enums/cache_validation_mode.hpp"
+#include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/enums/memory_tag.hpp"
 #include "duckdb/common/string_util.hpp"

--- a/src/storage/caching_file_system_wrapper.cpp
+++ b/src/storage/caching_file_system_wrapper.cpp
@@ -54,10 +54,6 @@ CachingFileSystemWrapper::CachingFileSystemWrapper(FileSystem &file_system, opti
       caching_mode(mode) {
 }
 
-CachingFileSystemWrapper CachingFileSystemWrapper::Get(ClientContext &context, CachingMode mode) {
-	return CachingFileSystemWrapper(FileSystem::GetFileSystem(context), *context.db, mode);
-}
-
 bool CachingFileSystemWrapper::ShouldUseCache(const string &path) const {
 	if (caching_mode == CachingMode::ALWAYS_CACHE) {
 		return true;

--- a/src/storage/caching_file_system_wrapper.cpp
+++ b/src/storage/caching_file_system_wrapper.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 
 namespace {
 // Get database instance from file opener, throw InvalidInput exception.
-DatabaseInstance& GetDatabaseInstance(optional_ptr<FileOpener> file_opener) {
+DatabaseInstance &GetDatabaseInstance(optional_ptr<FileOpener> file_opener) {
 	if (file_opener == nullptr) {
 		throw InvalidInputException("Cannot get database instance out of file opener, because file opener is nullptr.");
 	}
@@ -54,8 +54,10 @@ CachingFileSystemWrapper::CachingFileSystemWrapper(FileSystem &file_system, Data
     : caching_file_system(file_system, db), underlying_file_system(file_system), caching_mode(mode) {
 }
 
-CachingFileSystemWrapper::CachingFileSystemWrapper(FileSystem &file_system, optional_ptr<FileOpener> file_opener, CachingMode mode) 
-	: caching_file_system(file_system, GetDatabaseInstance(file_opener)), underlying_file_system(file_system), caching_mode(mode) {
+CachingFileSystemWrapper::CachingFileSystemWrapper(FileSystem &file_system, optional_ptr<FileOpener> file_opener,
+                                                   CachingMode mode)
+    : caching_file_system(file_system, GetDatabaseInstance(file_opener)), underlying_file_system(file_system),
+      caching_mode(mode) {
 }
 
 CachingFileSystemWrapper CachingFileSystemWrapper::Get(ClientContext &context, CachingMode mode) {

--- a/src/storage/caching_file_system_wrapper.cpp
+++ b/src/storage/caching_file_system_wrapper.cpp
@@ -26,8 +26,9 @@ DatabaseInstance &GetDatabaseInstance(optional_ptr<FileOpener> file_opener) {
 // CachingFileHandleWrapper implementation
 //===----------------------------------------------------------------------===//
 CachingFileHandleWrapper::CachingFileHandleWrapper(shared_ptr<CachingFileSystemWrapper> file_system,
-	                                    unique_ptr<CachingFileHandle> handle, FileOpenFlags flags)
-    : FileHandle(*file_system, handle->GetPath(), flags), caching_file_system(std::move(file_system)), caching_handle(std::move(handle)) {
+                                                   unique_ptr<CachingFileHandle> handle, FileOpenFlags flags)
+    : FileHandle(*file_system, handle->GetPath(), flags), caching_file_system(std::move(file_system)),
+      caching_handle(std::move(handle)) {
 	D_ASSERT(!flags.OpenForWriting());
 	D_ASSERT(!flags.OpenForAppending());
 }

--- a/test/common/test_caching_file_system_wrapper.cpp
+++ b/test/common/test_caching_file_system_wrapper.cpp
@@ -94,7 +94,8 @@ TEST_CASE("CachingFileSystemWrapper write operations not allowed", "[file_system
 	DuckDB db(":memory:");
 	auto &db_instance = *db.instance;
 	auto tracking_fs = make_uniq<TrackingFileSystem>();
-	auto caching_wrapper = make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
 
 	const string test_content = "This is test content for write testing.";
 	TestFileGuard test_file("test_caching_write.txt", test_content);
@@ -138,7 +139,8 @@ TEST_CASE("CachingFileSystemWrapper caches reads", "[file_system][caching]") {
 	auto &db_instance = *db.instance;
 	auto tracking_fs = make_uniq<TrackingFileSystem>();
 	auto tracking_fs_ptr = tracking_fs.get();
-	auto caching_wrapper = make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
 
 	const string test_content = "This is test content for caching verification. It should only be read once.";
 	TestFileGuard test_file("test_caching_file.txt", test_content);
@@ -221,7 +223,8 @@ TEST_CASE("CachingFileSystemWrapper sequential reads", "[file_system][caching]")
 	auto &db_instance = *db.instance;
 	auto tracking_fs = make_uniq<TrackingFileSystem>();
 	auto tracking_fs_ptr = tracking_fs.get();
-	auto caching_wrapper = make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
 
 	const string test_content = "This is test content for sequential read testing.";
 	TestFileGuard test_file("test_caching_sequential.txt", test_content);
@@ -250,7 +253,8 @@ TEST_CASE("CachingFileSystemWrapper seek operations", "[file_system][caching]") 
 	DuckDB db(":memory:");
 	auto &db_instance = *db.instance;
 	auto tracking_fs = make_uniq<TrackingFileSystem>();
-	auto caching_wrapper = make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
 
 	const string test_content = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 	TestFileGuard test_file("test_caching_seek.txt", test_content);
@@ -328,7 +332,8 @@ TEST_CASE("CachingFileSystemWrapper list operations", "[file_system][caching]") 
 	DuckDB db(":memory:");
 	auto &db_instance = *db.instance;
 	auto tracking_fs = make_uniq<TrackingFileSystem>();
-	auto caching_wrapper = make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
 
 	// Create a test directory
 	auto test_dir = TestCreatePath("test_list_dir");
@@ -373,7 +378,8 @@ TEST_CASE("CachingFileSystemWrapper read with parallel accesses", "[file_system]
 	DuckDB db(":memory:");
 	auto &db_instance = *db.instance;
 	auto tracking_fs = make_uniq<TrackingFileSystem>();
-	auto caching_wrapper = make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
+	auto caching_wrapper =
+	    make_shared_ptr<CachingFileSystemWrapper>(*tracking_fs, db_instance, CachingMode::ALWAYS_CACHE);
 
 	const string test_content =
 	    "Test content for parallel read access. This is a longer string to allow multiple reads.";


### PR DESCRIPTION
I met this issue when I tried to wrap `JsonReader`'s filesystem with caching filesystem.

Current implementation for `CachingFileSystemWrapper` is buggy for `CanSeek`:
- There're two types of filesystem instances in duckdb
  + One is raw filesystem, which interacts directly with storage backends, for example, local filesystem and S3 filesystem
  + Another is wrapper filesystem, which wraps filesystem(s) and provides additional features (i.e., virtual FS provides abstraction layer over multiple FS, caching FS enables read cache)
- File handle's invocation [delegates to](https://github.com/duckdb/duckdb/blob/041f4cac6889afa6604c8deee9e6574b8d6ae3aa/src/common/file_system.cpp#L748-L750) filesystem's
- For caching fs wrapper, it's the [cache-wrapped internal filesystem](https://github.com/duckdb/duckdb/blob/041f4cac6889afa6604c8deee9e6574b8d6ae3aa/src/storage/caching_file_system_wrapper.cpp#L339-L341), which could be either raw filesystem or wrapped filesystem and they should be treated separately

~~Proposed solution implemented in this PR:~~
~~- Seek-ability is an immutable attribute for a filesystem~~
~~+ For raw file systems, `CanSeek` (the one with no arguments provided) has been already implemented~~
~~+ For wrapped filesystems, the function call should be properly delegated to internal filesystem instances, just as what we do for other APIs~~

Update: follow Lauren's suggestion to integrate `CachingMode` into `FileOpenFlags` to get the caching work handled inside of VirtualFileSystem.
