### PR TITLE
Add RemoveFiles to FileSystem

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -575,6 +575,12 @@ bool FileSystem::TryRemoveFile(const string &filename, optional_ptr<FileOpener> 
 	return false;
 }
 
+void FileSystem::RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener) {
+	for (const auto &filename : filenames) {
+		TryRemoveFile(filename, opener);
+	}
+}
+
 void FileSystem::FileSync(FileHandle &handle) {
 	throw NotImplementedException("%s: FileSync is not implemented!", GetName());
 }

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -138,6 +138,17 @@ bool VirtualFileSystem::TryRemoveFile(const string &filename, optional_ptr<FileO
 	return FindFileSystem(filename).TryRemoveFile(filename, opener);
 }
 
+void VirtualFileSystem::RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener) {
+	unordered_map<FileSystem *, vector<string>> files_by_fs;
+	for (const auto &filename : filenames) {
+		auto &fs = FindFileSystem(filename);
+		files_by_fs[&fs].push_back(filename);
+	}
+	for (auto &entry : files_by_fs) {
+		entry.first->RemoveFiles(entry.second, opener);
+	}
+}
+
 string VirtualFileSystem::PathSeparator(const string &path) {
 	return FindFileSystem(path).PathSeparator(path);
 }

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -139,13 +139,13 @@ bool VirtualFileSystem::TryRemoveFile(const string &filename, optional_ptr<FileO
 }
 
 void VirtualFileSystem::RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener) {
-	unordered_map<FileSystem *, vector<string>> files_by_fs;
+	reference_map_t<FileSystem, vector<string>> files_by_fs;
 	for (const auto &filename : filenames) {
 		auto &fs = FindFileSystem(filename);
-		files_by_fs[&fs].push_back(filename);
+		files_by_fs[fs].push_back(filename);
 	}
 	for (auto &entry : files_by_fs) {
-		entry.first->RemoveFiles(entry.second, opener);
+		entry.first.get().RemoveFiles(entry.second, opener);
 	}
 }
 

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -412,9 +412,7 @@ void CheckDirectory(FileSystem &fs, const string &file_path, CopyOverwriteMode o
 		return;
 	}
 	if (overwrite_mode == CopyOverwriteMode::COPY_OVERWRITE) {
-		for (auto &file : file_list) {
-			fs.RemoveFile(file);
-		}
+		fs.RemoveFiles(file_list);
 	} else {
 		throw IOException("Directory \"%s\" is not empty! Enable OVERWRITE option to overwrite files", file_path);
 	}

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -205,6 +205,8 @@ public:
 	DUCKDB_API virtual void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr);
 	//! Remvoe a file from disk if it exists - if it does not exist, return false
 	DUCKDB_API virtual bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr);
+	//! Remove multiple files from disk - does not error if any file does not exist
+	DUCKDB_API virtual void RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener = nullptr);
 	//! Sync a file handle to disk
 	DUCKDB_API virtual void FileSync(FileHandle &handle);
 	//! Sets the working directory

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -116,6 +116,14 @@ public:
 		return GetFileSystem().TryRemoveFile(filename, GetOpener());
 	}
 
+	void RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener) override {
+		VerifyNoOpener(opener);
+		for (const auto &filename : filenames) {
+			VerifyCanAccessFile(filename);
+		}
+		GetFileSystem().RemoveFiles(filenames, GetOpener());
+	}
+
 	string PathSeparator(const string &path) override {
 		return GetFileSystem().PathSeparator(path);
 	}

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -49,6 +49,7 @@ public:
 	bool IsPipe(const string &filename, optional_ptr<FileOpener> opener) override;
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener) override;
 	bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) override;
+	void RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener) override;
 
 	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;
 

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -761,9 +761,12 @@ TemporaryDirectoryHandle::~TemporaryDirectoryHandle() {
 			// we want to remove all files in the directory
 			fs.RemoveDirectory(temp_directory);
 		} else {
+			vector<string> full_path_files_to_delete;
+			full_path_files_to_delete.reserve(files_to_delete.size());
 			for (auto &file : files_to_delete) {
-				fs.RemoveFile(fs.JoinPath(temp_directory, file));
+				full_path_files_to_delete.push_back(fs.JoinPath(temp_directory, file));
 			}
+			fs.RemoveFiles(full_path_files_to_delete);
 		}
 	}
 }

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -207,6 +207,37 @@ TEST_CASE("absolute paths", "[file_system]") {
 #endif
 }
 
+TEST_CASE("Test RemoveFiles", "[file_system]") {
+	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
+	auto dname = TestCreatePath("test_remove_files");
+
+	if (fs->DirectoryExists(dname)) {
+		fs->RemoveDirectory(dname);
+	}
+	fs->CreateDirectory(dname);
+
+	auto file1 = fs->JoinPath(dname, "file1.txt");
+	auto file2 = fs->JoinPath(dname, "file2.txt");
+	auto file3 = fs->JoinPath(dname, "file3.txt");
+	auto file4 = fs->JoinPath(dname, "file4.txt");
+	create_dummy_file(file1);
+	create_dummy_file(file2);
+	create_dummy_file(file3);
+
+	REQUIRE(fs->FileExists(file1));
+	REQUIRE(fs->FileExists(file2));
+	REQUIRE(fs->FileExists(file3));
+	REQUIRE(!fs->FileExists(file4));
+
+	fs->RemoveFiles({file1, file2});
+	REQUIRE(!fs->FileExists(file1));
+	REQUIRE(!fs->FileExists(file2));
+	REQUIRE(fs->FileExists(file3));
+	REQUIRE(!fs->FileExists(file4));
+
+	fs->RemoveDirectory(dname);
+}
+
 TEST_CASE("extract subsystem", "[file_system]") {
 	duckdb::VirtualFileSystem vfs;
 	auto local_filesystem = FileSystem::CreateLocal();


### PR DESCRIPTION
This PR adds support for file bulk deletion via the `RemoveFiles` filesystem method. 

It builds on [this discussion](https://github.com/duckdb/ducklake/discussions/384). I’m particularly interested in this for DuckLake, where cleaning up old files can be significantly faster when the underlying filesystem is S3 (or similar remote object stores).

In the current implementation, `RemoveFiles` does not error if some files are not found. By default, it calls `TryRemoveFile` in a loop, while filesystem implementations can override it to take advantage of native bulk deletion APIs. I chose this behavior because - especially for S3 - the native bulk delete API does not report errors (or even indicate) when some of the requested files do not exist. Happy to revisit this behavior if you think stricter semantics are needed!