### PR TITLE
Increase reserved size for paths in SetPathsInternal

### DIFF
--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -283,7 +283,7 @@ void CatalogSearchPath::SetPathsInternal(vector<CatalogSearchEntry> new_paths) {
 	this->set_paths = std::move(new_paths);
 
 	paths.clear();
-	paths.reserve(set_paths.size() + 3);
+	paths.reserve(set_paths.size() + 4);
 	paths.emplace_back(TEMP_CATALOG, DEFAULT_SCHEMA);
 	for (auto &path : set_paths) {
 		paths.push_back(path);


### PR DESCRIPTION
In `CatalogSearchPath::SetPathsInternal`, four additional items are added to the vector. The reserved size should therefore be `set_paths.size() + 4`.