### PR TITLE
[Fix] Defensive infinite loop guard and UTF-8 check in C API

### DIFF
--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -42,13 +42,8 @@ static idx_t GetResultLength(const char *input_data, idx_t input_length) {
 		auto codepoint = Utf8Proc::UTF8ToCodepoint(input_data + i, sz);
 		auto converted = IS_UPPER ? Utf8Proc::CodepointToUpper(codepoint) : Utf8Proc::CodepointToLower(codepoint);
 		auto new_sz = Utf8Proc::CodepointLength(converted);
-		D_ASSERT(new_sz >= 0);
 		output_length += UnsafeNumericCast<idx_t>(new_sz);
-
-		// If "sz" did not change, then this will loop indefinitely.
-		if (sz == 0) {
-			throw InternalException("infinite loop length detected, likely due to invalid UTF-8");
-		}
+		D_ASSERT(sz != 0);
 		i += UnsafeNumericCast<idx_t>(sz);
 	}
 	return output_length;

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -3268,7 +3268,8 @@ This allows NULL values to be written to the vector, regardless of whether a val
 DUCKDB_C_API void duckdb_vector_ensure_validity_writable(duckdb_vector vector);
 
 /*!
-Assigns a string element in the vector at the specified location.
+Assigns a string element in the vector at the specified location. Should only be used for VARCHAR vectors and expects
+valid UTF-8. Otherwise, the function does nothing.
 
 * @param vector The vector to alter
 * @param index The row position in the vector to assign the string to
@@ -3277,7 +3278,8 @@ Assigns a string element in the vector at the specified location.
 DUCKDB_C_API void duckdb_vector_assign_string_element(duckdb_vector vector, idx_t index, const char *str);
 
 /*!
-Assigns a string element in the vector at the specified location. You may also use this function to assign BLOBs.
+Assigns a string element in the vector at the specified location. The vector type can be VARCHAR or BLOB. In the case of
+VARCHAR, you need to pass valid UTF-8. Otherwise, the function does nothing.
 
 * @param vector The vector to alter
 * @param index The row position in the vector to assign the string to

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -3268,8 +3268,8 @@ This allows NULL values to be written to the vector, regardless of whether a val
 DUCKDB_C_API void duckdb_vector_ensure_validity_writable(duckdb_vector vector);
 
 /*!
-Assigns a string element in the vector at the specified location. Should only be used for VARCHAR vectors and expects
-valid UTF-8. Otherwise, the function does nothing.
+Assigns a string element in the vector at the specified location. The vector type must be VARCHAR and the input must be
+valid UTF-8. Otherwise, undefined behavior is expected at later stages.
 
 * @param vector The vector to alter
 * @param index The row position in the vector to assign the string to
@@ -3279,7 +3279,7 @@ DUCKDB_C_API void duckdb_vector_assign_string_element(duckdb_vector vector, idx_
 
 /*!
 Assigns a string element in the vector at the specified location. The vector type can be VARCHAR or BLOB. In the case of
-VARCHAR, you need to pass valid UTF-8. Otherwise, the function does nothing.
+VARCHAR, you must pass valid UTF-8. Otherwise, undefined behavior is expected at later stages.
 
 * @param vector The vector to alter
 * @param index The row position in the vector to assign the string to

--- a/src/include/duckdb/main/capi/header_generation/functions/vector_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/vector_interface.json
@@ -125,7 +125,7 @@
                 }
             ],
             "comment": {
-                "description": "Assigns a string element in the vector at the specified location. Should only be used for VARCHAR vectors and expects valid UTF-8. Otherwise, the function does nothing.\n\n",
+                "description": "Assigns a string element in the vector at the specified location. The vector type must be VARCHAR and the input must be valid UTF-8. Otherwise, undefined behavior is expected at later stages.\n\n",
                 "param_comments": {
                     "vector": "The vector to alter",
                     "index": "The row position in the vector to assign the string to",
@@ -155,7 +155,7 @@
                 }
             ],
             "comment": {
-                "description": "Assigns a string element in the vector at the specified location. The vector type can be VARCHAR or BLOB. In the case of VARCHAR, you need to pass valid UTF-8. Otherwise, the function does nothing.\n\n",
+                "description": "Assigns a string element in the vector at the specified location. The vector type can be VARCHAR or BLOB. In the case of VARCHAR, you must pass valid UTF-8. Otherwise, undefined behavior is expected at later stages.\n\n",
                 "param_comments": {
                     "vector": "The vector to alter",
                     "index": "The row position in the vector to assign the string to",

--- a/src/include/duckdb/main/capi/header_generation/functions/vector_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/vector_interface.json
@@ -125,7 +125,7 @@
                 }
             ],
             "comment": {
-                "description": "Assigns a string element in the vector at the specified location.\n\n",
+                "description": "Assigns a string element in the vector at the specified location. Should only be used for VARCHAR vectors and expects valid UTF-8. Otherwise, the function does nothing.\n\n",
                 "param_comments": {
                     "vector": "The vector to alter",
                     "index": "The row position in the vector to assign the string to",
@@ -155,7 +155,7 @@
                 }
             ],
             "comment": {
-                "description": "Assigns a string element in the vector at the specified location. You may also use this function to assign BLOBs.\n\n",
+                "description": "Assigns a string element in the vector at the specified location. The vector type can be VARCHAR or BLOB. In the case of VARCHAR, you need to pass valid UTF-8. Otherwise, the function does nothing.\n\n",
                 "param_comments": {
                     "vector": "The vector to alter",
                     "index": "The row position in the vector to assign the string to",

--- a/src/main/capi/data_chunk-c.cpp
+++ b/src/main/capi/data_chunk-c.cpp
@@ -2,7 +2,6 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
-#include "utf8proc_wrapper.hpp"
 
 #include <string.h>
 
@@ -145,18 +144,7 @@ void duckdb_vector_assign_string_element_len(duckdb_vector vector, idx_t index, 
 	if (!vector) {
 		return;
 	}
-
-	// UTF-8 analysis for VARCHAR vectors, which expect valid UTF-8.
 	auto v = reinterpret_cast<duckdb::Vector *>(vector);
-	if (v->GetType().id() == duckdb::LogicalTypeId::VARCHAR) {
-		duckdb::UnicodeInvalidReason reason;
-		size_t pos;
-		auto utf_type = duckdb::Utf8Proc::Analyze(str, str_len, &reason, &pos);
-		if (utf_type == duckdb::UnicodeType::INVALID) {
-			return;
-		}
-	}
-
 	auto data = duckdb::FlatVector::GetData<duckdb::string_t>(*v);
 	data[index] = duckdb::StringVector::AddStringOrBlob(*v, str, str_len);
 }

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -524,33 +524,6 @@ TEST_CASE("Test DataChunk write BLOB", "[capi]") {
 	duckdb_destroy_logical_type(&type);
 }
 
-TEST_CASE("Test DataChunk write invalid UTF-8 to VARCHAR", "[capi]") {
-	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
-	duckdb_logical_type types[] = {type};
-
-	auto chunk = duckdb_create_data_chunk(types, 1);
-	duckdb_destroy_logical_type(&type);
-	duckdb_data_chunk_set_size(chunk, 1);
-	auto vector = duckdb_data_chunk_get_vector(chunk, 0);
-
-	string valid_utf8 = "é";
-	// strlen does not include NULL-termination. Remove the first byte only.
-	idx_t len = strlen(valid_utf8.c_str());
-	auto invalid_utf8 = static_cast<char *>(malloc(len));
-	memcpy(invalid_utf8, valid_utf8.c_str() + 1, len);
-
-	// Write a valid string to initialize the data.
-	duckdb_vector_assign_string_element(vector, 0, valid_utf8.c_str());
-	// Write an invalid string and ensure it does not overwrite.
-	duckdb_vector_assign_string_element(vector, 0, invalid_utf8);
-	free(invalid_utf8);
-
-	// Ensure that nothing was written and the vector still contains the valid data.
-	auto string_data = static_cast<duckdb_string_t *>(duckdb_vector_get_data(vector));
-	REQUIRE((string_data[0].value.inlined.length == valid_utf8.length()));
-	duckdb_destroy_data_chunk(&chunk);
-}
-
 TEST_CASE("Test DataChunk write BIGNUM", "[capi]") {
 	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_BIGNUM);
 	REQUIRE(type);

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -524,6 +524,33 @@ TEST_CASE("Test DataChunk write BLOB", "[capi]") {
 	duckdb_destroy_logical_type(&type);
 }
 
+TEST_CASE("Test DataChunk write invalid UTF-8 to VARCHAR", "[capi]") {
+	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+	duckdb_logical_type types[] = {type};
+
+	auto chunk = duckdb_create_data_chunk(types, 1);
+	duckdb_destroy_logical_type(&type);
+	duckdb_data_chunk_set_size(chunk, 1);
+	auto vector = duckdb_data_chunk_get_vector(chunk, 0);
+
+	string valid_utf8 = "é";
+	// strlen does not include NULL-termination. Remove the first byte only.
+	idx_t len = strlen(valid_utf8.c_str());
+	auto invalid_utf8 = static_cast<char *>(malloc(len));
+	memcpy(invalid_utf8, valid_utf8.c_str() + 1, len);
+
+	// Write a valid string to initialize the data.
+	duckdb_vector_assign_string_element(vector, 0, valid_utf8.c_str());
+	// Write an invalid string and ensure it does not overwrite.
+	duckdb_vector_assign_string_element(vector, 0, invalid_utf8);
+	free(invalid_utf8);
+
+	// Ensure that nothing was written and the vector still contains the valid data.
+	auto string_data = static_cast<duckdb_string_t *>(duckdb_vector_get_data(vector));
+	REQUIRE((string_data[0].value.inlined.length == valid_utf8.length()));
+	duckdb_destroy_data_chunk(&chunk);
+}
+
 TEST_CASE("Test DataChunk write BIGNUM", "[capi]") {
 	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_BIGNUM);
 	REQUIRE(type);

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -308,7 +308,7 @@ int Utf8Proc::CodepointLength(int cp) {
 		return 2;
 	}
 	 if (0xd800 <= cp && cp <= 0xdfff) {
-	 	return -1;
+	 	throw InternalException("invalid code point detected in Utf8Proc::CodepointLength (0xd800 to 0xdfff), likely due to invalid UTF-8");
 	}
 	 if (cp <= 0xFFFF) {
 		return 3;
@@ -333,7 +333,7 @@ int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz) {
 		return (u0 - 192) * 64 + (u1 - 128);
 	}
 	if (u[0] == 0xed && (u[1] & 0xa0) == 0xa0) {
-		return -1; // code points, 0xd800 to 0xdfff
+		throw InternalException("invalid code point detected in Utf8Proc::UTF8ToCodepoint (0xd800 to 0xdfff), likely due to invalid UTF-8");
 	}
 	unsigned char u2 = u[2];
 	if (u0 >= 224 && u0 <= 239) {

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -303,16 +303,20 @@ bool Utf8Proc::CodepointToUtf8(int cp, int &sz, char *c) {
 int Utf8Proc::CodepointLength(int cp) {
 	if (cp <= 0x7F) {
 		return 1;
-	} else if (cp <= 0x7FF) {
+	}
+	 if (cp <= 0x7FF) {
 		return 2;
-	} else if (0xd800 <= cp && cp <= 0xdfff) {
-		return -1;
-	} else if (cp <= 0xFFFF) {
+	}
+	 if (0xd800 <= cp && cp <= 0xdfff) {
+	 	return -1;
+	}
+	 if (cp <= 0xFFFF) {
 		return 3;
-	} else if (cp <= 0x10FFFF) {
+	}
+	 if (cp <= 0x10FFFF) {
 		return 4;
 	}
-	return -1;
+	throw InternalException("invalid code point detected in Utf8Proc::CodepointLength, likely due to invalid UTF-8");
 }
 
 int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz) {
@@ -341,7 +345,7 @@ int32_t Utf8Proc::UTF8ToCodepoint(const char *u_input, int &sz) {
 		sz = 4;
 		return (u0 - 240) * 262144 + (u1 - 128) * 4096 + (u2 - 128) * 64 + (u3 - 128);
 	}
-	return -1;
+	throw InternalException("invalid code point detected in Utf8Proc::UTF8ToCodepoint, likely due to invalid UTF-8");
 }
 
 size_t Utf8Proc::RenderWidth(const char *s, size_t len, size_t pos) {


### PR DESCRIPTION
Related issue: https://github.com/duckdblabs/duckdb-internal/issues/7002, where invalid UTF-8 strings can cause hangs during scalar function execution. 

The hang is due to incorrect API usage, but we did not sufficiently enforce it. Thus, it was possible for invalid UTF-8 to "slip through" and later on cause a hang. All vectors with a logical type `VARCHAR` are expected to contain valid UTF-8, which is now enforced in the C API. 

@lnkuiper - do you think the performance implication of calling `auto utf_type = duckdb::Utf8Proc::Analyze(str, str_len, &reason, &pos);` for each string here is acceptable, or should we expose an additional function? Or maybe only perform the check behind a `#ifdef DEBUG` guard?