### PR TITLE
Fix #20308: Added collation binding to the join conditions

### DIFF
--- a/src/execution/physical_plan/plan_set_operation.cpp
+++ b/src/execution/physical_plan/plan_set_operation.cpp
@@ -23,11 +23,15 @@ static vector<unique_ptr<Expression>> CreatePartitionedRowNumExpression(const ve
 	return res;
 }
 
-static JoinCondition CreateNotDistinctComparison(const LogicalType &type, idx_t i) {
+static JoinCondition CreateNotDistinctComparison(ClientContext &context, const LogicalType &type, idx_t i) {
 	JoinCondition cond;
 	cond.left = make_uniq<BoundReferenceExpression>(type, i);
 	cond.right = make_uniq<BoundReferenceExpression>(type, i);
 	cond.comparison = ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+
+	ExpressionBinder::PushCollation(context, cond.left, type);
+	ExpressionBinder::PushCollation(context, cond.right, type);
+
 	return cond;
 }
 
@@ -59,7 +63,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalSetOperation &op) {
 		vector<JoinCondition> conditions;
 		// create equality condition for all columns
 		for (idx_t i = 0; i < types.size(); i++) {
-			conditions.push_back(CreateNotDistinctComparison(types[i], i));
+			conditions.push_back(CreateNotDistinctComparison(context, types[i], i));
 		}
 		// For EXCEPT ALL / INTERSECT ALL we push a window operator with a ROW_NUMBER into the scans and join to get bag
 		// semantics.
@@ -80,7 +84,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalSetOperation &op) {
 			right = right_window;
 
 			// add window expression result to join condition
-			conditions.push_back(CreateNotDistinctComparison(LogicalType::BIGINT, types.size()));
+			conditions.push_back(CreateNotDistinctComparison(context, LogicalType::BIGINT, types.size()));
 			// join (created below) now includes the row number result column
 			op.types.push_back(LogicalType::BIGINT);
 		}

--- a/test/sql/setops/test_except.test
+++ b/test/sql/setops/test_except.test
@@ -25,3 +25,28 @@ select * from a intersect select * from b
 ----
 43
 
+statement ok
+CREATE TABLE t1(a VARCHAR COLLATE NOCASE);
+
+statement ok
+INSERT INTO t1 VALUES ('ABC'), ('def'), ('GHI');
+
+statement ok
+CREATE TABLE t2(a VARCHAR COLLATE NOCASE);
+
+statement ok
+INSERT INTO t2 VALUES ('abc'), ('DEF');
+
+# Test EXCEPT with NOCASE
+query I
+SELECT * FROM t1 EXCEPT SELECT * FROM t2 ORDER BY a;
+----
+GHI
+
+# Test INTERSECT with NOCASE
+query I
+SELECT * FROM t1 INTERSECT SELECT * FROM t2 ORDER BY a;
+----
+ABC
+def
+


### PR DESCRIPTION
FIX #20308 EXCEPT/INTERSECT with NOCASE collation
Added collation binding to the join conditions created for EXCEPT/INTERSECT operations. This ensures that comparisons respects the collation from the column types.