### PR TITLE
Fixup comparison to wrong iterator on abdc's driver

### DIFF
--- a/src/common/adbc/driver_manager.cpp
+++ b/src/common/adbc/driver_manager.cpp
@@ -690,7 +690,7 @@ AdbcStatusCode AdbcDatabaseGetOptionBytes(struct AdbcDatabase *database, const c
 	}
 	const auto *args = reinterpret_cast<const TempDatabase *>(database->private_data);
 	const auto it = args->bytes_options.find(key);
-	if (it == args->options.end()) {
+	if (it == args->bytes_options.end()) {
 		return ADBC_STATUS_NOT_FOUND;
 	}
 	const std::string &result = it->second;
@@ -984,7 +984,7 @@ AdbcStatusCode AdbcConnectionGetOptionBytes(struct AdbcConnection *connection, c
 		// Init not yet called, get the saved option
 		const auto *args = reinterpret_cast<const TempConnection *>(connection->private_data);
 		const auto it = args->bytes_options.find(key);
-		if (it == args->options.end()) {
+		if (it == args->bytes_options.end()) {
 			return ADBC_STATUS_NOT_FOUND;
 		}
 		if (*length >= it->second.size() + 1) {

--- a/src/common/adbc/driver_manager.cpp
+++ b/src/common/adbc/driver_manager.cpp
@@ -987,10 +987,10 @@ AdbcStatusCode AdbcConnectionGetOptionBytes(struct AdbcConnection *connection, c
 		if (it == args->bytes_options.end()) {
 			return ADBC_STATUS_NOT_FOUND;
 		}
-		if (*length >= it->second.size() + 1) {
-			std::memcpy(value, it->second.data(), it->second.size() + 1);
+		if (*length >= it->second.size()) {
+			std::memcpy(value, it->second.data(), it->second.size());
 		}
-		*length = it->second.size() + 1;
+		*length = it->second.size();
 		return ADBC_STATUS_OK;
 	}
 	INIT_ERROR(error, connection);


### PR DESCRIPTION
Depending on platform this might be fine, like when end() is represented as `null`, or problematic.