### PR TITLE
fix render mode for qualified show tables statements

### DIFF
--- a/tools/shell/shell_render_table_metadata.cpp
+++ b/tools/shell/shell_render_table_metadata.cpp
@@ -27,7 +27,7 @@ bool ShellState::UseDescribeRenderMode(const duckdb::SQLStatement &statement, st
 		return false;
 	}
 	auto &showref = select_node.from_table->Cast<duckdb::ShowRef>();
-	if (showref.show_type == duckdb::ShowType::SUMMARY) {
+	if (showref.show_type == duckdb::ShowType::SUMMARY || showref.show_type == duckdb::ShowType::SHOW_FROM) {
 		return false;
 	}
 	if (showref.table_name == "\"databases\"" || showref.table_name == "\"tables\"" ||

--- a/tools/shell/tests/test_table_metadata_rendering.py
+++ b/tools/shell/tests/test_table_metadata_rendering.py
@@ -100,3 +100,14 @@ def test_search_path_influences_table_name(shell):
 
     result = test.run()
     result.check_not_exist("mydb.s2")
+
+
+def test_qualified_show_tables(shell):
+    test = (
+        ShellTest(shell)
+        .statement("create table t1 as from range(10)")
+        .statement('show tables from memory.main')
+    )
+
+    result = test.run()
+    result.check_stdout("t1")


### PR DESCRIPTION
This PR fixes issue: https://github.com/duckdblabs/duckdb-internal/issues/6967

Without this PR, qualified statements like `SHOW TABLES FROM my_schema` would use `RenderMode::DESCRIBE` (which is only meant to be used with statements like `DESCRIBE tbl;` and `DESCRIBE SELECT * FROM tbl;`).

### notes
- While this is the most straightforward fix for this bug, the handling of SHOW/DESCRIBE/SUMMARIZE statements can benefit from some refactoring (see for example: [this comment](https://github.com/duckdb/duckdb/blob/4b7a6b7bd0f8c968bfecab08e801cdc1f0a5cdfd/tools/shell/shell_render_table_metadata.cpp#L29-L38)). This will be addressed in https://github.com/duckdb/duckdb/pull/20202, that also adds support for `SHOW schemas`.
- A scenario similar to that from the bug-report was already included in the test set, in `test/sql/pragma/test_show_tables_from.test` -> `SHOW TABLES FROM db.main`. This test however didn't discover the issue, because it succeeded even with the error present. Running the queries one by one in the CLI would result in the error. The reason this is possible is (I assume) that the test runner doesn't bother with the RenderMode. This also has to be looked into separately. 
- for clarity (and note to self): statements `SHOW` AND `DESCRIBE` are 100% aliases, even though they are typically used in different use-cases.
