### PR TITLE
Allow linked_libs to be included statically in bundle target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -535,6 +535,12 @@ bundle-setup:
 	cp extension/*/lib*_extension.a bundle/. && \
 	mkdir -p vcpkg_installed && \
 	find vcpkg_installed -name '*.a' -exec cp {} bundle/. \; && \
+	mkdir -p _deps && \
+	if [ -f linked_libs.txt ]; then \
+		while IFS= read -r libline || [ -n "$$libline" ]; do \
+			find _deps -path "*/$$libline" -exec cp {} bundle/. \; 2>/dev/null || true; \
+		done < linked_libs.txt; \
+	fi && \
 	cd bundle && \
 	find . -name '*.a' -exec mkdir -p {}.objects \; -exec mv {} {}.objects \; && \
 	find . -name '*.a' -execdir ${AR} -x {} \;

--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -420,6 +420,12 @@ function(duckdb_extension_load NAME)
     string(TOLOWER ${NAME} EXTENSION_NAME_LOWERCASE)
     string(TOUPPER ${NAME} EXTENSION_NAME_UPPERCASE)
 
+    # Aggregate LINKED_LIBS globally
+    if(duckdb_extension_load_LINKED_LIBS)
+        list(APPEND DUCKDB_ALL_LINKED_LIBS ${duckdb_extension_load_LINKED_LIBS})
+        set(DUCKDB_ALL_LINKED_LIBS ${DUCKDB_ALL_LINKED_LIBS} PARENT_SCOPE)
+    endif()
+
     # If extension was set already, we ignore subsequent calls
     list (FIND DUCKDB_EXTENSION_NAMES ${EXTENSION_NAME_LOWERCASE} _index)
     if (${_index} GREATER -1)
@@ -547,6 +553,12 @@ endif()
 
 # Load base extension config
 include(${CMAKE_CURRENT_SOURCE_DIR}/extension/extension_config.cmake)
+
+# Write linked libs to file for bundle-setup
+if(DUCKDB_ALL_LINKED_LIBS)
+    string(REPLACE ";" "\n" LINKED_LIBS_CONTENT "${DUCKDB_ALL_LINKED_LIBS}")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/linked_libs.txt" "${LINKED_LIBS_CONTENT}")
+endif()
 
 # For extensions whose tests were loaded, but not linked into duckdb, we need to ensure they are registered to have
 # the sqllogictest "require" statement load the loadable extensions instead of the baked in static one


### PR DESCRIPTION
When extensions (such as nanoarrow) specify dependencies (such as apache arrow-nano) through the cmake fetchcontent construct, those don't make it to the `bundle` directory for the `bundle-setup` target. This PR aggregates all specified linked_libs and writes them to a file which is then used by the bundle-setup target to copy appropriate libs.