### PR TITLE
feat(adbc): support the experimental `adbc.ingest.target_catalog` option and improve ingest name resolution

### DIFF
--- a/src/include/duckdb/common/adbc/adbc.hpp
+++ b/src/include/duckdb/common/adbc/adbc.hpp
@@ -18,8 +18,9 @@ namespace duckdb_adbc {
 
 class AppenderWrapper {
 public:
-	AppenderWrapper(duckdb_connection conn, const char *schema, const char *table) : appender(nullptr) {
-		if (duckdb_appender_create(conn, schema, table, &appender) != DuckDBSuccess) {
+	AppenderWrapper(duckdb_connection conn, const char *catalog, const char *schema, const char *table)
+	    : appender(nullptr) {
+		if (duckdb_appender_create_ext(conn, catalog, schema, table, &appender) != DuckDBSuccess) {
 			appender = nullptr;
 		}
 	}


### PR DESCRIPTION
Add support for `adbc.ingest.target_catalog` in the DuckDB ADBC ingest path.

Close #20128

This allows ingesting into attached databases (catalogs) by propagating the catalog into both the CREATE/DROP SQL and the appender.

When only target_catalog is provided (no target_db_schema), the driver defaults the schema to `main` and uses a fully-qualified 3-part name (`catalog_name.main.table_name`) to avoid DuckDB’s catalog/schema ambiguity with 2-part names.

Temporary ingestion is also updated to align with common ADBC expectations: temporary tables are created in the `temp` schema and are distinct from persistent tables with the same name.
`temporary` remains incompatible with target_db_schema / target_catalog at execution time, but enabling `temporary` after setting schema/catalog clears those options so ingest can proceed (mirroring behavior in the Postgres driver in the arrow-adbc repo).

cc @lidavidm