### PR TITLE
Add interruption check to optimizer execution

### DIFF
--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -89,6 +89,10 @@ bool Optimizer::OptimizerDisabled(ClientContext &context_p, OptimizerType type) 
 }
 
 void Optimizer::RunOptimizer(OptimizerType type, const std::function<void()> &callback) {
+	if (context.IsInterrupted()) {
+		throw InterruptException();
+	}
+
 	if (OptimizerDisabled(type)) {
 		// optimizer is marked as disabled: skip
 		return;


### PR DESCRIPTION
Adding a check to allow interruption during optimizer execution

This change goes along with the effort of making short-circuits to honor context interrupts from drivers.
An example is https://github.com/duckdb/duckdb-go/pull/88 that this PR goes along with, by periodically sending interrupts to DuckDB.

In a query I took as my baseline, where we have a query with 40K args (in the prepared statement, described in the duckdb-go PR), I noticed that the preparing / planning time before execution was unusual. By making the change in this PR (along with the change in duckdb-go I mentioned above), the query finished before execution:
<img width="678" height="354" alt="image" src="https://github.com/user-attachments/assets/8834b265-763b-4894-a429-7aa3767910b9" />

* I added a `print` before throwing the `InterruptError` for demonstration purposes
* For the demonstration, in the `duckdb-go` PR, I also removed the early-out statement we have in the `prepareExtractedStmt` function.

I started with an interruption check in the `optimizer`, but my plan is to add more interruptions checks around the binder and the planner.
