### PR TITLE
fix compilation with FORCE_QUERY_LOG=1

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -942,9 +942,8 @@ void ClientContext::LogQueryInternal(ClientContextLock &, const string &query) {
 #ifdef DUCKDB_FORCE_QUERY_LOG
 		try {
 			string log_path(DUCKDB_FORCE_QUERY_LOG);
-			client_data->log_query_writer =
-			    make_uniq<BufferedFileWriter>(FileSystem::GetFileSystem(*this), log_path,
-			                                  BufferedFileWriter::DEFAULT_OPEN_FLAGS, client_data->file_opener.get());
+			client_data->log_query_writer = make_uniq<BufferedFileWriter>(FileSystem::GetFileSystem(*this), log_path,
+			                                                              BufferedFileWriter::DEFAULT_OPEN_FLAGS);
 		} catch (...) {
 			return;
 		}


### PR DESCRIPTION
Fix #20386 

The `BufferedFileWriter` constructor only takes 3 arguments: https://github.com/duckdb/duckdb/blob/beb1d69f7b9c6116d23a087ab87b0600447758ed/src/include/duckdb/common/serializer/buffered_file_writer.hpp#L24