### PR TITLE
Add QueryContext also to Write(void *buffer, idx_t nr_bytes), so that BytesWritten are updated also there

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -708,6 +708,14 @@ int64_t FileHandle::Write(void *buffer, idx_t nr_bytes) {
 	return file_system.Write(*this, buffer, UnsafeNumericCast<int64_t>(nr_bytes));
 }
 
+int64_t FileHandle::Write(QueryContext context, void *buffer, idx_t nr_bytes) {
+	if (context.GetClientContext() != nullptr) {
+		context.GetClientContext()->client_data->profiler->AddBytesWritten(nr_bytes);
+	}
+
+	return file_system.Write(*this, buffer, UnsafeNumericCast<int64_t>(nr_bytes));
+}
+
 void FileHandle::Read(void *buffer, idx_t nr_bytes, idx_t location) {
 	file_system.Read(*this, buffer, UnsafeNumericCast<int64_t>(nr_bytes), location);
 }

--- a/src/common/gzip_file_system.cpp
+++ b/src/common/gzip_file_system.cpp
@@ -111,7 +111,7 @@ void MiniZStreamWrapper::Initialize(QueryContext context, CompressedFile &file, 
 		total_size = 0;
 
 		MiniZStream::InitializeGZIPHeader(gzip_hdr);
-		file.child_handle->Write(gzip_hdr, GZIP_HEADER_MINSIZE);
+		file.child_handle->Write(context, gzip_hdr, GZIP_HEADER_MINSIZE);
 
 		auto ret = mz_deflateInit2(mz_stream_ptr.get(), duckdb_miniz::MZ_DEFAULT_LEVEL, MZ_DEFLATED,
 		                           -MZ_DEFAULT_WINDOW_BITS, 1, 0);

--- a/src/common/pipe_file_system.cpp
+++ b/src/common/pipe_file_system.cpp
@@ -32,7 +32,7 @@ int64_t PipeFile::ReadChunk(void *buffer, int64_t nr_bytes) {
 	return child_handle->Read(context, buffer, UnsafeNumericCast<idx_t>(nr_bytes));
 }
 int64_t PipeFile::WriteChunk(void *buffer, int64_t nr_bytes) {
-	return child_handle->Write(buffer, UnsafeNumericCast<idx_t>(nr_bytes));
+	return child_handle->Write(context, buffer, UnsafeNumericCast<idx_t>(nr_bytes));
 }
 
 void PipeFileSystem::Reset(FileHandle &handle) {

--- a/src/function/copy_blob.cpp
+++ b/src/function/copy_blob.cpp
@@ -99,6 +99,8 @@ void WriteBlobSink(ExecutionContext &context, FunctionData &bind_data, GlobalFun
 	input.data[0].ToUnifiedFormat(input.size(), vdata);
 	const auto blobs = UnifiedVectorFormat::GetData<string_t>(vdata);
 
+	QueryContext query_context(context.client);
+
 	for (idx_t row_idx = 0; row_idx < input.size(); row_idx++) {
 		const auto out_idx = vdata.sel->get_index(row_idx);
 		if (vdata.validity.RowIsValid(out_idx)) {
@@ -109,7 +111,7 @@ void WriteBlobSink(ExecutionContext &context, FunctionData &bind_data, GlobalFun
 			auto blob_end = blob_ptr + blob_len;
 
 			while (blob_ptr < blob_end) {
-				auto written = handle->Write(blob_ptr, blob_len);
+				auto written = handle->Write(query_context, blob_ptr, blob_len);
 				if (written <= 0) {
 					throw IOException("Failed to write to file!");
 				}

--- a/src/function/copy_blob.cpp
+++ b/src/function/copy_blob.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/function/built_in_functions.hpp"
 #include "duckdb/function/copy_function.hpp"
+#include "duckdb/main/client_context.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -66,6 +66,7 @@ public:
 	DUCKDB_API int64_t Read(void *buffer, idx_t nr_bytes);
 	DUCKDB_API int64_t Read(QueryContext context, void *buffer, idx_t nr_bytes);
 	DUCKDB_API int64_t Write(void *buffer, idx_t nr_bytes);
+	DUCKDB_API int64_t Write(QueryContext context, void *buffer, idx_t nr_bytes);
 	// Read at [nr_bytes] bytes into [buffer].
 	// File offset will not be changed.
 	DUCKDB_API void Read(void *buffer, idx_t nr_bytes, idx_t location);

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -174,10 +174,11 @@ static unsafe_unique_array<data_t> ReadExtensionFileFromDisk(FileSystem &fs, con
 	return in_buffer;
 }
 
-static void WriteExtensionFileToDisk(FileSystem &fs, const string &path, void *data, idx_t data_size) {
+static void WriteExtensionFileToDisk(QueryContext &query_context, FileSystem &fs, const string &path, void *data,
+                                     idx_t data_size) {
 	auto target_file = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_APPEND |
 	                                         FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
-	target_file->Write(data, data_size);
+	target_file->Write(query_context, data, data_size);
 	target_file->Close();
 	target_file.reset();
 }
@@ -236,10 +237,11 @@ static void CheckExtensionMetadataOnInstall(DatabaseInstance &db, void *in_buffe
 //   1. Crash after extension removal: extension is now uninstalled, metadata file still present
 //   2. Crash after metadata removal: extension is now uninstalled, extension dir is clean
 //   3. Crash after extension move: extension is now uninstalled, new metadata file present
-static void WriteExtensionFiles(FileSystem &fs, const string &temp_path, const string &local_extension_path,
-                                void *in_buffer, idx_t file_size, ExtensionInstallInfo &info) {
+static void WriteExtensionFiles(QueryContext &query_context, FileSystem &fs, const string &temp_path,
+                                const string &local_extension_path, void *in_buffer, idx_t file_size,
+                                ExtensionInstallInfo &info) {
 	// Write extension to tmp file
-	WriteExtensionFileToDisk(fs, temp_path, in_buffer, file_size);
+	WriteExtensionFileToDisk(query_context, fs, temp_path, in_buffer, file_size);
 
 	// Write metadata to tmp file
 	auto metadata_tmp_path = temp_path + ".info";
@@ -327,7 +329,9 @@ static unique_ptr<ExtensionInstallInfo> DirectInstallExtension(DatabaseInstance 
 		info.repository_url = options.repository->path;
 	}
 
-	WriteExtensionFiles(fs, temp_path, local_extension_path, extension_decompressed, extension_decompressed_size, info);
+	QueryContext query_context(context);
+	WriteExtensionFiles(query_context, fs, temp_path, local_extension_path, extension_decompressed,
+	                    extension_decompressed_size, info);
 
 	return make_uniq<ExtensionInstallInfo>(info);
 }
@@ -416,8 +420,9 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 		info.full_path = url;
 	}
 
+	QueryContext query_context(context);
 	auto fs = FileSystem::CreateLocal();
-	WriteExtensionFiles(*fs, temp_path, local_extension_path, (void *)decompressed_body.data(),
+	WriteExtensionFiles(query_context, *fs, temp_path, local_extension_path, (void *)decompressed_body.data(),
 	                    decompressed_body.size(), info);
 
 	return make_uniq<ExtensionInstallInfo>(info);


### PR DESCRIPTION
Plus handle the same for:
* extensions install
* copy to binary
* writing to pipe

This is minor, but could as well be fixed.
Bumped while investigating a fix that would require QueryContext on Install and copy-to-binary `Write` call-sites and depends on this.