### PR TITLE
Use forward-compatible std::shuffle

### DIFF
--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -14,9 +14,11 @@
 #include "sqllogic_test_logger.hpp"
 #include "catch.hpp"
 
-#include <list>
-#include <thread>
+#include <algorithm>
 #include <chrono>
+#include <list>
+#include <random>
+#include <thread>
 
 namespace duckdb {
 
@@ -407,7 +409,9 @@ void LoopCommand::ExecuteInternal(ExecuteContext &context) const {
 				break;
 			}
 		}
-		std::random_shuffle(loop_indexes.begin(), loop_indexes.end());
+		std::random_device rd;
+		std::mt19937 g(rd());
+		std::shuffle(loop_indexes.begin(), loop_indexes.end(), g);
 
 		// parallel loop: launch threads
 		std::list<ParallelExecuteContext> contexts;


### PR DESCRIPTION
`std::random_shuffle` is deprecated in C++14 and was removed in C++17. While DuckDB does not claim to be forward compatible in any way; in practice it is -- and it would be nice to keep it that way.

The alternative `std::shuffle` was introduced in C++11, so works for compilation with older and newer standards.

https://en.cppreference.com/w/cpp/algorithm/random_shuffle.html