### PR TITLE
Give preference do variables set in config

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -467,7 +467,8 @@ vector<ConfigSetting> TestConfiguration::GetConfigSettings() {
 }
 
 string TestConfiguration::GetTestEnv(const string &key, const string &default_value) {
-	if (test_env.empty() && options.find("test_env") != options.end()) {
+	if (!test_env_from_config_loaded && options.find("test_env") != options.end()) {
+		test_env_from_config_loaded = true;
 		auto entry = options["test_env"];
 		auto list_children = ListValue::GetChildren(entry);
 		for (const auto &value : list_children) {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -95,6 +95,8 @@ public:
 	static void AppendSkipTagSet(const Value &tag_set);
 
 private:
+	//! Give preference to settings from loaded configs
+	bool test_env_from_config_loaded = false;
 	case_insensitive_map_t<Value> options;
 	unordered_set<string> tests_to_be_skipped;
 

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -1075,9 +1075,9 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			auto env_actual = test_config.GetTestEnv(env_var, token.parameters[1]);
 
 			// Check if we have something defining from our test
-			if (environment_variables.count(env_var)) {
-				parser.Fail(StringUtil::Format("Environment/Test variable '%s' has already been defined", env_var));
-			}
+			// if (environment_variables.count(env_var)) {
+			// 	parser.Fail(StringUtil::Format("Environment/Test variable '%s' has already been defined", env_var));
+			// }
 
 			environment_variables[env_var] = env_actual;
 			add_env_tag(file_tags, env_var, &env_actual);

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -1073,12 +1073,6 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			}
 			auto env_var = token.parameters[0];
 			auto env_actual = test_config.GetTestEnv(env_var, token.parameters[1]);
-
-			// Check if we have something defining from our test
-			// if (environment_variables.count(env_var)) {
-			// 	parser.Fail(StringUtil::Format("Environment/Test variable '%s' has already been defined", env_var));
-			// }
-
 			environment_variables[env_var] = env_actual;
 			add_env_tag(file_tags, env_var, &env_actual);
 


### PR DESCRIPTION
In https://github.com/duckdb/duckdb/commit/e7b1a6d55b8571ab4846c895f033f23f1e6b114d UpdateEnvironment populates test_env before the config file is read. This silently broke some of DuckLake's CI. This change simply enforces that the config file will always have priority.

Kudos to @utay for spotting the issue.