### PR TITLE
Improve format script compatibility on Windows

### DIFF
--- a/scripts/format.py
+++ b/scripts/format.py
@@ -359,7 +359,7 @@ def format_file(f, full_path, directory, ext):
             difference_files.append(full_path)
     else:
         tmpfile = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
-        with open_utf8(tmpfile, 'w+') as f:
+        with open_utf8(tmpfile, 'w+', newline='\n') as f:
             f.write(new_text)
         shutil.move(tmpfile, full_path)
 

--- a/scripts/format_test_benchmark.py
+++ b/scripts/format_test_benchmark.py
@@ -18,7 +18,7 @@ def format_file_content(full_path, lines):
 
     # Extract group name (use 'unknown' for stdin if no full_path, else derive from path)
     group_name = Path(full_path).parent.name if full_path != '-' else 'unknown'
-    new_path_line = f'# name: {full_path}\n'
+    new_path_line = f'# name: {Path(full_path).as_posix()}\n'
     new_group_line = f'# group: [{group_name}]\n'
 
     # Find description

--- a/scripts/python_helpers.py
+++ b/scripts/python_helpers.py
@@ -1,10 +1,10 @@
-def open_utf8(fpath, flags):
+def open_utf8(fpath, flags, **kwargs):
     import sys
 
     if sys.version_info[0] < 3:
-        return open(fpath, flags)
+        return open(fpath, flags, **kwargs)
     else:
-        return open(fpath, flags, encoding="utf8")
+        return open(fpath, flags, encoding="utf8", **kwargs)
 
 
 def normalize_path(path):


### PR DESCRIPTION
This PR resolves several Windows‑specific inconsistencies in DuckDB’s formatting scripts, ensuring they behave deterministically across Windows and Unix‑like environments.

### **Improvements**
- **Force Linux‑style line endings (`\n`)** when writing temporary formatted files.  
  The `open_utf8` helper now forwards `newline='\n'` (and any additional keyword arguments), preventing Windows from injecting `\r\n` and causing spurious diffs in `scripts/format.py`.

- **Normalize all paths to POSIX (`/`) form** when generating test metadata.  
  `format_test_benchmark.py` now uses `Path(...).as_posix()` to ensure stable, platform‑independent `# name:` headers.

  **Example:**
  ```
  good
  # name: benchmark/appian_benchmarks/q01.benchmark
  # description: Run query 01 from the appian benchmarks

  bad
  # name: benchmark\appian_benchmarks\q01.benchmark
  # description: Run query 01 from the appian benchmarks
  ```

### **Why This Matters**
These changes eliminate Windows‑specific formatting noise, making the formatting scripts fully deterministic across developer environments. This improves contributor experience and prevents CI failures caused by platform‑dependent EOL or path differences.

### **Scope**
- No functional changes to DuckDB itself  
- Only affects developer tooling under `scripts/`  
