### PR TITLE
Don't add a semicolon to final query when splitting statements

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -184,7 +184,6 @@ vector<string> SplitQueries(const string &input_query) {
 	string final_segment = input_query.substr(last_split);
 	StringUtil::Trim(final_segment);
 	if (!final_segment.empty()) {
-		final_segment.append(";");
 		queries.push_back(std::move(final_segment));
 	}
 	return queries;

--- a/test/extension/test_splitting_extension_statements.cpp
+++ b/test/extension/test_splitting_extension_statements.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Extension parser adds semicolon", "[parser-extension]") {
 
 	parser_extension.parser_info = info;
 	parser_extension.parse_function = [](duckdb::ParserExtensionInfo *info,
-										 const std::string &query) -> duckdb::ParserExtensionParseResult {
+	                                     const std::string &query) -> duckdb::ParserExtensionParseResult {
 		auto *test_info = static_cast<TestParserInfo *>(info);
 		test_info->received_query = query;
 		duckdb::unique_ptr<duckdb::ParserExtensionParseData> empty_data {};


### PR DESCRIPTION
Fixes: https://github.com/duckdblabs/duckdb-internal/issues/6984

For the final query after splitting I always added a semicolon, but that's problematic for parsers later using these results. 
