### PR TITLE
feat: reduce access invalid file

### DIFF
--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -590,6 +590,9 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 }
 
 void StandardBufferManager::DeleteTemporaryFile(BlockHandle &block) {
+	if (!block.IsUnloaded()) {
+		return;
+	}
 	auto id = block.BlockId();
 	if (temporary_directory.path.empty()) {
 		// no temporary directory specified: nothing to delete


### PR DESCRIPTION
Frequently accessing non-existent files will lead to increased Linux slab memory usage;
Therefore, I implemented temporary file tracking in StandardBufferManager to solve this issue.