### PR TITLE
Backport client data cleanup

### DIFF
--- a/src/main/client_data.cpp
+++ b/src/main/client_data.cpp
@@ -182,6 +182,9 @@ ClientData::ClientData(ClientContext &context) : catalog_search_path(make_uniq<C
 }
 
 ClientData::~ClientData() {
+	// This needs to be destroyed first because PreparedStatementData holds a PhysicalPlan,
+	// and the PhysicalPlan holds objects that might rely on the client file opener/file system/buffer manager
+	prepared_statements.clear();
 }
 
 ClientData &ClientData::Get(ClientContext &context) {


### PR DESCRIPTION
Cherry-picking [some of the changes on `main`](https://github.com/duckdb/duckdb/pull/20200/changes#diff-0b8a99c3124077c6bc909e4dee4eef6e09c1667a60909dc74a220abb8921e559) to be backported here. 