### PR TITLE
No catalog found Nightly test fix

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -72,7 +72,6 @@ jobs:
          python3 test/memoryleak/test_memory_leaks.py
 
   release-assert:
-    # trigger nightly
     name: Release Assertions
     runs-on: ubuntu-latest
     needs: linux-memory-leaks

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -72,6 +72,7 @@ jobs:
          python3 test/memoryleak/test_memory_leaks.py
 
   release-assert:
+    # trigger nightly
     name: Release Assertions
     runs-on: ubuntu-latest
     needs: linux-memory-leaks

--- a/test/sql/storage/encryption/temp_files/encrypted_offloading_block_files.test_slow
+++ b/test/sql/storage/encryption/temp_files/encrypted_offloading_block_files.test_slow
@@ -12,17 +12,14 @@ load __TEST_DIR__/offloading_block_files.db
 
 # ATTACH DB
 statement ok
-ATTACH '__TEST_DIR__/encrypted.db' as enc (ENCRYPTION_KEY 'asdf', ENCRYPTION_CIPHER '${cipher}');
+ATTACH '__TEST_DIR__/encrypted_${cipher}.db' as enc (ENCRYPTION_KEY 'asdf', ENCRYPTION_CIPHER '${cipher}');
 
 statement ok
 SET temp_file_encryption=true;
 
-statement ok
-USE enc;
-
 # 500M row table.
 statement ok
-CREATE TABLE tbl AS FROM
+CREATE TABLE enc.tbl AS FROM
 	range(100) t1(i)
 	CROSS JOIN range(100) t2(j)
 	CROSS JOIN range(100) t3(k)
@@ -37,7 +34,7 @@ statement ok
 SET memory_limit = '1GB';
 
 statement error
-SELECT * FROM tbl ORDER BY random_value;
+SELECT * FROM enc.tbl ORDER BY random_value;
 ----
 
 restart


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/6956 and https://github.com/duckdblabs/duckdb-internal/issues/7005

Test failed due to usage of `USE db_name` + `restart`. This pattern fails in any case, i.e.

```
loop i 1 2

statement ok
ATTACH '__TEST_DIR__/test.db' as test;

statement ok
USE test

restart

endloop
```

also fails with 

```
Catalog Error: SET search_path: No catalog + schema named "test.main" found.
```

removing `USE` and using declarative `db_name.tbl` solved the issue.

Not 100% sure if this is desired behavior, but I would assume so.