### PR TITLE
Fix file opener propagation

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -800,7 +800,7 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
                              shared_ptr<ParquetFileMetadataCache> metadata_p)
     : BaseFileReader(std::move(file_p)), fs(CachingFileSystem::Get(context_p)),
       allocator(BufferAllocator::Get(context_p)), parquet_options(std::move(parquet_options_p)) {
-	file_handle = fs.OpenFile(context_p, file, FileFlags::FILE_FLAGS_READ, /*opener=*/nullptr);
+	file_handle = fs.OpenFile(context_p, file, FileFlags::FILE_FLAGS_READ);
 	if (!file_handle->CanSeek()) {
 		throw NotImplementedException(
 		    "Reading parquet files from a FIFO stream is not supported and cannot be efficiently supported since "
@@ -1219,7 +1219,7 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 			state.prefetch_mode = false;
 		}
 
-		state.file_handle = fs.OpenFile(context, file, flags, /*opener=*/nullptr);
+		state.file_handle = fs.OpenFile(context, file, flags);
 	}
 	state.adaptive_filter.reset();
 	state.scan_filters.clear();

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -800,7 +800,7 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
                              shared_ptr<ParquetFileMetadataCache> metadata_p)
     : BaseFileReader(std::move(file_p)), fs(CachingFileSystem::Get(context_p)),
       allocator(BufferAllocator::Get(context_p)), parquet_options(std::move(parquet_options_p)) {
-	file_handle = fs.OpenFile(context_p, file, FileFlags::FILE_FLAGS_READ);
+	file_handle = fs.OpenFile(context_p, file, FileFlags::FILE_FLAGS_READ, /*opener=*/nullptr);
 	if (!file_handle->CanSeek()) {
 		throw NotImplementedException(
 		    "Reading parquet files from a FIFO stream is not supported and cannot be efficiently supported since "
@@ -1219,7 +1219,7 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 			state.prefetch_mode = false;
 		}
 
-		state.file_handle = fs.OpenFile(context, file, flags);
+		state.file_handle = fs.OpenFile(context, file, flags, /*opener=*/nullptr);
 	}
 	state.adaptive_filter.reset();
 	state.scan_filters.clear();

--- a/src/include/duckdb/storage/caching_file_system.hpp
+++ b/src/include/duckdb/storage/caching_file_system.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/enums/cache_validation_mode.hpp"
+#include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_open_flags.hpp"
 #include "duckdb/common/open_file_info.hpp"
 #include "duckdb/common/winapi.hpp"
@@ -35,7 +36,7 @@ public:
 
 public:
 	DUCKDB_API CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system, const OpenFileInfo &path,
-	                             FileOpenFlags flags, CachedFile &cached_file);
+	                             FileOpenFlags flags, optional_ptr<FileOpener> opener, CachedFile &cached_file);
 	DUCKDB_API ~CachingFileHandle();
 
 public:
@@ -89,6 +90,8 @@ private:
 	OpenFileInfo path;
 	//! Flags used to open the file
 	FileOpenFlags flags;
+	//! File opener, which contains file open context.
+	optional_ptr<FileOpener> opener;
 	//! Cache validation mode for this file
 	CacheValidationMode validate;
 	//! The associated CachedFile with cached ranges
@@ -119,9 +122,9 @@ public:
 public:
 	DUCKDB_API static CachingFileSystem Get(ClientContext &context);
 
-	DUCKDB_API unique_ptr<CachingFileHandle> OpenFile(const OpenFileInfo &path, FileOpenFlags flags);
+	DUCKDB_API unique_ptr<CachingFileHandle> OpenFile(const OpenFileInfo &path, FileOpenFlags flags, optional_ptr<FileOpener> opener);
 	DUCKDB_API unique_ptr<CachingFileHandle> OpenFile(QueryContext context, const OpenFileInfo &path,
-	                                                  FileOpenFlags flags);
+	                                                  FileOpenFlags flags, optional_ptr<FileOpener> opener);
 
 private:
 	//! The Client FileSystem (needs to be client-specific so we can do, e.g., HTTPFS profiling)

--- a/src/include/duckdb/storage/caching_file_system.hpp
+++ b/src/include/duckdb/storage/caching_file_system.hpp
@@ -122,9 +122,10 @@ public:
 public:
 	DUCKDB_API static CachingFileSystem Get(ClientContext &context);
 
-	DUCKDB_API unique_ptr<CachingFileHandle> OpenFile(const OpenFileInfo &path, FileOpenFlags flags, optional_ptr<FileOpener> opener);
+	DUCKDB_API unique_ptr<CachingFileHandle> OpenFile(const OpenFileInfo &path, FileOpenFlags flags,
+	                                                  optional_ptr<FileOpener> opener = nullptr);
 	DUCKDB_API unique_ptr<CachingFileHandle> OpenFile(QueryContext context, const OpenFileInfo &path,
-	                                                  FileOpenFlags flags, optional_ptr<FileOpener> opener);
+	                                                  FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr);
 
 private:
 	//! The Client FileSystem (needs to be client-specific so we can do, e.g., HTTPFS profiling)

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -62,21 +62,21 @@ CachingFileSystem CachingFileSystem::Get(ClientContext &context) {
 	return CachingFileSystem(FileSystem::GetFileSystem(context), *context.db);
 }
 
-unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(const OpenFileInfo &path, FileOpenFlags flags) {
-	return make_uniq<CachingFileHandle>(QueryContext(), *this, path, flags,
+unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(const OpenFileInfo &path, FileOpenFlags flags, optional_ptr<FileOpener> opener) {
+	return make_uniq<CachingFileHandle>(QueryContext(), *this, path, flags, opener,
 	                                    external_file_cache.GetOrCreateCachedFile(path.path));
 }
 
 unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(QueryContext context, const OpenFileInfo &path,
-                                                          FileOpenFlags flags) {
-	return make_uniq<CachingFileHandle>(context, *this, path, flags,
+                                                          FileOpenFlags flags, optional_ptr<FileOpener> opener) {
+	return make_uniq<CachingFileHandle>(context, *this, path, flags, opener,
 	                                    external_file_cache.GetOrCreateCachedFile(path.path));
 }
 
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,
-                                     const OpenFileInfo &path_p, FileOpenFlags flags_p, CachedFile &cached_file_p)
+                                     const OpenFileInfo &path_p, FileOpenFlags flags_p, optional_ptr<FileOpener> opener_p, CachedFile &cached_file_p)
     : context(context), caching_file_system(caching_file_system_p),
-      external_file_cache(caching_file_system.external_file_cache), path(path_p), flags(flags_p),
+      external_file_cache(caching_file_system.external_file_cache), path(path_p), flags(flags_p), opener(opener_p),
       validate(
           ExternalFileCacheUtil::GetCacheValidationMode(path_p, context.GetClientContext(), caching_file_system_p.db)),
       cached_file(cached_file_p), position(0) {
@@ -98,7 +98,7 @@ CachingFileHandle::~CachingFileHandle() {
 
 FileHandle &CachingFileHandle::GetFileHandle() {
 	if (!file_handle) {
-		file_handle = caching_file_system.file_system.OpenFile(path, flags);
+		file_handle = caching_file_system.file_system.OpenFile(path, flags, opener);
 		last_modified = caching_file_system.file_system.GetLastModifiedTime(*file_handle);
 		version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
 

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -62,7 +62,8 @@ CachingFileSystem CachingFileSystem::Get(ClientContext &context) {
 	return CachingFileSystem(FileSystem::GetFileSystem(context), *context.db);
 }
 
-unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(const OpenFileInfo &path, FileOpenFlags flags, optional_ptr<FileOpener> opener) {
+unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(const OpenFileInfo &path, FileOpenFlags flags,
+                                                          optional_ptr<FileOpener> opener) {
 	return make_uniq<CachingFileHandle>(QueryContext(), *this, path, flags, opener,
 	                                    external_file_cache.GetOrCreateCachedFile(path.path));
 }
@@ -74,7 +75,8 @@ unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(QueryContext context, 
 }
 
 CachingFileHandle::CachingFileHandle(QueryContext context, CachingFileSystem &caching_file_system_p,
-                                     const OpenFileInfo &path_p, FileOpenFlags flags_p, optional_ptr<FileOpener> opener_p, CachedFile &cached_file_p)
+                                     const OpenFileInfo &path_p, FileOpenFlags flags_p,
+                                     optional_ptr<FileOpener> opener_p, CachedFile &cached_file_p)
     : context(context), caching_file_system(caching_file_system_p),
       external_file_cache(caching_file_system.external_file_cache), path(path_p), flags(flags_p), opener(opener_p),
       validate(

--- a/src/storage/caching_file_system_wrapper.cpp
+++ b/src/storage/caching_file_system_wrapper.cpp
@@ -138,7 +138,7 @@ unique_ptr<FileHandle> CachingFileSystemWrapper::OpenFileExtended(const OpenFile
 	}
 
 	if (ShouldUseCache(path.path)) {
-		auto caching_handle = caching_file_system.OpenFile(path, flags);
+		auto caching_handle = caching_file_system.OpenFile(path, flags, opener);
 		return make_uniq<CachingFileHandleWrapper>(shared_from_this(), std::move(caching_handle), flags);
 	}
 	// Bypass cache, use underlying file system directly.


### PR DESCRIPTION
`FileOpener` is needed for HTTP utils, which should be propagated from virtual filesystem, to caching wrapper, to caching filesystem.

Checked with previously failed SQL and confirmed to work:
```sql
memory D select
             unnest(data) as customers
         from
             read_json('https://non.existant/endpoint');
IO Error:
Could not establish connection error for HTTP HEAD to 'https://non.existant/endpoint'

LINE 4:     read_json('https://non.existant/endpoint');
            ^
```