### PR TITLE
Bump multiple extensions

### DIFF
--- a/.github/config/extensions/aws.cmake
+++ b/.github/config/extensions/aws.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(aws
             ### TODO: re-enable LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG 55bf3621fb7db254b473c94ce6360643ca38fac0
+            GIT_TAG bc15d211f282d1d78fc0d9fda3d09957ba776423
             )
 endif()

--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(ducklake
     DONT_LINK
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG de813ff4d052bffe3e9e7ffcdc31d18ca38e5ecd
+    GIT_TAG f7d151e819b8a4d608b0dd474f481dbd4cf198f9
 )

--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(httpfs
     LOAD TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 7bd8c9cb1801dab374b63ac15ade1ba29c501b1e
+    GIT_TAG c57776e0fba762e974d6e2270b11666cdfcaa36b
     INCLUDE_DIR src/include
 )

--- a/.github/config/extensions/iceberg.cmake
+++ b/.github/config/extensions/iceberg.cmake
@@ -8,6 +8,6 @@ if (NOT MINGW)
     duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 90c059e2dd876a483e63a2f1b04ef66fa45a0c85
+            GIT_TAG 92837bdaa25ca0fc78300c4ced004228044991f7
             )
 endif()

--- a/.github/config/extensions/mysql_scanner.cmake
+++ b/.github/config/extensions/mysql_scanner.cmake
@@ -3,6 +3,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
             DONT_LINK
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-mysql
-            GIT_TAG ecb76de715dfe0b5bba52f4fc8bde87186dd486f
+            GIT_TAG 35d1b2cd51800096271802cfedf68e13bf7fa8cb
             )
 endif()


### PR DESCRIPTION
This PR bumps the following extensions:
- `aws` from `55bf3621fb` to `bc15d211f2`
- `ducklake` from `de813ff4d0` to `f7d151e819`
- `httpfs` from `7bd8c9cb18` to `c57776e0fb`
- `iceberg` from `90c059e2dd` to `92837bdaa2`
- `mysql_scanner` from `ecb76de715` to `35d1b2cd51`
