### PR TITLE
Cleanup RowGroup Scan code, and make BoundIndex::Delete throw an error if the rows are not present in the index

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -57,7 +57,6 @@
 #include "duckdb/common/enums/profiler_format.hpp"
 #include "duckdb/common/enums/quantile_enum.hpp"
 #include "duckdb/common/enums/relation_type.hpp"
-#include "duckdb/common/enums/scan_options.hpp"
 #include "duckdb/common/enums/set_operation_type.hpp"
 #include "duckdb/common/enums/set_scope.hpp"
 #include "duckdb/common/enums/set_type.hpp"
@@ -4842,27 +4841,6 @@ const char* EnumUtil::ToChars<TableReferenceType>(TableReferenceType value) {
 template<>
 TableReferenceType EnumUtil::FromString<TableReferenceType>(const char *value) {
 	return static_cast<TableReferenceType>(StringUtil::StringToEnum(GetTableReferenceTypeValues(), 13, "TableReferenceType", value));
-}
-
-const StringUtil::EnumStringLiteral *GetTableScanTypeValues() {
-	static constexpr StringUtil::EnumStringLiteral values[] {
-		{ static_cast<uint32_t>(TableScanType::TABLE_SCAN_REGULAR), "TABLE_SCAN_REGULAR" },
-		{ static_cast<uint32_t>(TableScanType::TABLE_SCAN_COMMITTED_ROWS), "TABLE_SCAN_COMMITTED_ROWS" },
-		{ static_cast<uint32_t>(TableScanType::TABLE_SCAN_COMMITTED_ROWS_DISALLOW_UPDATES), "TABLE_SCAN_COMMITTED_ROWS_DISALLOW_UPDATES" },
-		{ static_cast<uint32_t>(TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED), "TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED" },
-		{ static_cast<uint32_t>(TableScanType::TABLE_SCAN_LATEST_COMMITTED_ROWS), "TABLE_SCAN_LATEST_COMMITTED_ROWS" }
-	};
-	return values;
-}
-
-template<>
-const char* EnumUtil::ToChars<TableScanType>(TableScanType value) {
-	return StringUtil::EnumToString(GetTableScanTypeValues(), 5, "TableScanType", static_cast<uint32_t>(value));
-}
-
-template<>
-TableScanType EnumUtil::FromString<TableScanType>(const char *value) {
-	return static_cast<TableScanType>(StringUtil::StringToEnum(GetTableScanTypeValues(), 5, "TableScanType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetTaskExecutionModeValues() {

--- a/src/execution/index/bound_index.cpp
+++ b/src/execution/index/bound_index.cpp
@@ -83,12 +83,11 @@ void BoundIndex::Delete(DataChunk &entries, Vector &row_identifiers) {
 }
 
 void BoundIndex::Delete(IndexLock &state, DataChunk &entries, Vector &row_identifiers) {
-	TryDelete(state, entries, row_identifiers);
-	// FIXME: enable this
-	// if (deleted_rows != entries.size()) {
-	// 	throw InvalidInputException("Failed to delete all rows from index. Only deleted %d out of %d rows.\nChunk: %s",
-	// deleted_rows, entries.size(), entries.ToString());
-	// }
+	auto deleted_rows = TryDelete(state, entries, row_identifiers);
+	if (deleted_rows != entries.size()) {
+		throw InvalidInputException("Failed to delete all rows from index. Only deleted %d out of %d rows.\nChunk: %s",
+		                            deleted_rows, entries.size(), entries.ToString());
+	}
 }
 
 ErrorData BoundIndex::Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) {

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -94,7 +94,7 @@ public:
 
 				while (true) {
 					scan_chunk.Reset();
-					scan_state.local_state.ScanCommitted(scan_chunk, TableScanType::TABLE_SCAN_COMMITTED_ROWS);
+					scan_state.local_state.ScanCommitted(scan_chunk, TableScanType::TABLE_SCAN_ALL_ROWS);
 					if (scan_chunk.size() == 0) {
 						break;
 					}

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -94,7 +94,7 @@ public:
 
 				while (true) {
 					scan_chunk.Reset();
-					scan_state.local_state.ScanCommitted(scan_chunk, TableScanType::TABLE_SCAN_ALL_ROWS);
+					scan_state.local_state.Scan(scan_chunk, TableScanType::TABLE_SCAN_ALL_ROWS);
 					if (scan_chunk.size() == 0) {
 						break;
 					}

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -300,8 +300,7 @@ public:
 
 		do {
 			if (bind_data.is_create_index) {
-				storage.CreateIndexScan(l_state.scan_state, output,
-				                        TableScanType::TABLE_SCAN_OMIT_PERMANENTLY_DELETED);
+				storage.CreateIndexScan(l_state.scan_state, output);
 			} else if (CanRemoveFilterColumns()) {
 				l_state.all_columns.Reset();
 				storage.Scan(tx, l_state.all_columns, l_state.scan_state);

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -301,7 +301,7 @@ public:
 		do {
 			if (bind_data.is_create_index) {
 				storage.CreateIndexScan(l_state.scan_state, output,
-				                        TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED);
+				                        TableScanType::TABLE_SCAN_OMIT_PERMANENTLY_DELETED);
 			} else if (CanRemoveFilterColumns()) {
 				l_state.all_columns.Reset();
 				storage.Scan(tx, l_state.all_columns, l_state.scan_state);

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -432,8 +432,6 @@ enum class TablePartitionInfo : uint8_t;
 
 enum class TableReferenceType : uint8_t;
 
-enum class TableScanType : uint8_t;
-
 enum class TaskExecutionMode : uint8_t;
 
 enum class TaskExecutionResult : uint8_t;
@@ -1090,9 +1088,6 @@ const char* EnumUtil::ToChars<TablePartitionInfo>(TablePartitionInfo value);
 
 template<>
 const char* EnumUtil::ToChars<TableReferenceType>(TableReferenceType value);
-
-template<>
-const char* EnumUtil::ToChars<TableScanType>(TableScanType value);
 
 template<>
 const char* EnumUtil::ToChars<TaskExecutionMode>(TaskExecutionMode value);
@@ -1778,9 +1773,6 @@ TablePartitionInfo EnumUtil::FromString<TablePartitionInfo>(const char *value);
 
 template<>
 TableReferenceType EnumUtil::FromString<TableReferenceType>(const char *value);
-
-template<>
-TableScanType EnumUtil::FromString<TableScanType>(const char *value);
 
 template<>
 TaskExecutionMode EnumUtil::FromString<TaskExecutionMode>(const char *value);

--- a/src/include/duckdb/common/enums/scan_options.hpp
+++ b/src/include/duckdb/common/enums/scan_options.hpp
@@ -23,8 +23,6 @@ enum class DeletedScanType {
 	STANDARD,
 	//! include all rows, including all deleted rows
 	INCLUDE_ALL_DELETED,
-	//! omit committed deleted rows
-	OMIT_COMMITTED_DELETES,
 	//! omit deleted rows that have been fully deleted - i.e. no active transaction still depends on them
 	OMIT_FULLY_COMMITTED_DELETES
 };

--- a/src/include/duckdb/common/enums/scan_options.hpp
+++ b/src/include/duckdb/common/enums/scan_options.hpp
@@ -47,8 +47,6 @@ enum class TableScanType {
 	TABLE_SCAN_REGULAR = 0,
 	//! Scan all rows, including any deleted rows. Committed updates are merged in.
 	TABLE_SCAN_COMMITTED_ROWS = 1,
-	//! Scan all rows, including any deleted rows. Throws an exception if there are any uncommitted updates.
-	TABLE_SCAN_COMMITTED_ROWS_DISALLOW_UPDATES = 2,
 	//! Scan all rows, excluding any permanently deleted rows.
 	//! Permanently deleted rows are rows which no transaction will ever need again.
 	TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED = 3,

--- a/src/include/duckdb/common/enums/scan_options.hpp
+++ b/src/include/duckdb/common/enums/scan_options.hpp
@@ -36,7 +36,7 @@ enum class UpdateScanType {
 	DISALLOW_UPDATES
 };
 
-struct TScanType {
+struct ScanOptions {
 	InsertedScanType insert_type = InsertedScanType::STANDARD;
 	DeletedScanType delete_type = DeletedScanType::STANDARD;
 	UpdateScanType update_type = UpdateScanType::STANDARD;

--- a/src/include/duckdb/common/enums/scan_options.hpp
+++ b/src/include/duckdb/common/enums/scan_options.hpp
@@ -42,7 +42,7 @@ struct TScanType {
 	UpdateScanType update_type = UpdateScanType::STANDARD;
 };
 
-enum class TableScanType : uint8_t {
+enum class TableScanType {
 	//! Regular table scan: scan all tuples that are relevant for the current transaction
 	TABLE_SCAN_REGULAR = 0,
 	//! Scan all rows, including any deleted rows. Committed updates are merged in.

--- a/src/include/duckdb/common/enums/scan_options.hpp
+++ b/src/include/duckdb/common/enums/scan_options.hpp
@@ -12,6 +12,13 @@
 
 namespace duckdb {
 
+enum class UpdateScanType {
+	//! allow updates
+	STANDARD,
+	// disallow updates - throw on updates
+	DISALLOW_UPDATES
+};
+
 enum class TableScanType : uint8_t {
 	//! Regular table scan: scan all tuples that are relevant for the current transaction
 	TABLE_SCAN_REGULAR = 0,

--- a/src/include/duckdb/common/enums/scan_options.hpp
+++ b/src/include/duckdb/common/enums/scan_options.hpp
@@ -12,11 +12,39 @@
 
 namespace duckdb {
 
+enum class InsertedScanType {
+	// get all rows valid for the transaction
+	STANDARD,
+	// scan all rows including transaction local rows
+	ALL_ROWS
+};
+enum class DeletedScanType {
+	//! omit any rows that are deleted
+	STANDARD,
+	//! include all rows, including all deleted rows
+	INCLUDE_ALL_DELETED,
+	//! only omit permanently committed deleted rows (i.e. rows that no transaction still depends on)
+	OMIT_PERMANENTLY_COMMITTED
+};
+
 enum class UpdateScanType {
 	//! allow updates
 	STANDARD,
 	// disallow updates - throw on updates
 	DISALLOW_UPDATES
+};
+
+struct TScanType {
+	InsertedScanType insert_type = InsertedScanType::STANDARD;
+	DeletedScanType delete_type = DeletedScanType::STANDARD;
+	UpdateScanType update_type = UpdateScanType::STANDARD;
+	static TScanType IndexScan() {
+		TScanType type;
+		type.insert_type = InsertedScanType::ALL_ROWS;
+		type.delete_type = DeletedScanType::OMIT_PERMANENTLY_COMMITTED;
+		type.update_type = UpdateScanType::DISALLOW_UPDATES;
+		return type;
+	}
 };
 
 enum class TableScanType : uint8_t {

--- a/src/include/duckdb/common/enums/scan_options.hpp
+++ b/src/include/duckdb/common/enums/scan_options.hpp
@@ -18,13 +18,14 @@ enum class InsertedScanType {
 	// scan all rows including transaction local rows
 	ALL_ROWS
 };
+
 enum class DeletedScanType {
 	//! omit any rows that are deleted
 	STANDARD,
 	//! include all rows, including all deleted rows
 	INCLUDE_ALL_DELETED,
-	//! omit deleted rows that have been fully deleted - i.e. no active transaction still depends on them
-	OMIT_FULLY_COMMITTED_DELETES
+	//! omit only deleted rows that have been committed and have a commit ts lower than the transaction start
+	OMIT_COMMITTED_DELETES
 };
 
 enum class UpdateScanType {

--- a/src/include/duckdb/common/enums/scan_options.hpp
+++ b/src/include/duckdb/common/enums/scan_options.hpp
@@ -43,15 +43,13 @@ struct TScanType {
 };
 
 enum class TableScanType {
-	//! Regular table scan: scan all tuples that are relevant for the current transaction
-	TABLE_SCAN_REGULAR = 0,
 	//! Scan all rows, including any deleted rows. Committed updates are merged in.
-	TABLE_SCAN_COMMITTED_ROWS = 1,
+	TABLE_SCAN_ALL_ROWS = 1,
 	//! Scan all rows, excluding any permanently deleted rows.
 	//! Permanently deleted rows are rows which no transaction will ever need again.
-	TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED = 3,
+	TABLE_SCAN_OMIT_PERMANENTLY_DELETED = 2,
 	//! Scan the latest committed rows
-	TABLE_SCAN_LATEST_COMMITTED_ROWS = 4
+	TABLE_SCAN_COMMITTED_ROWS = 3
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/enums/scan_options.hpp
+++ b/src/include/duckdb/common/enums/scan_options.hpp
@@ -23,8 +23,10 @@ enum class DeletedScanType {
 	STANDARD,
 	//! include all rows, including all deleted rows
 	INCLUDE_ALL_DELETED,
-	//! only omit permanently committed deleted rows (i.e. rows that no transaction still depends on)
-	OMIT_PERMANENTLY_COMMITTED
+	//! omit committed deleted rows
+	OMIT_COMMITTED_DELETES,
+	//! omit deleted rows that have been fully deleted - i.e. no active transaction still depends on them
+	OMIT_FULLY_COMMITTED_DELETES
 };
 
 enum class UpdateScanType {
@@ -38,13 +40,6 @@ struct TScanType {
 	InsertedScanType insert_type = InsertedScanType::STANDARD;
 	DeletedScanType delete_type = DeletedScanType::STANDARD;
 	UpdateScanType update_type = UpdateScanType::STANDARD;
-	static TScanType IndexScan() {
-		TScanType type;
-		type.insert_type = InsertedScanType::ALL_ROWS;
-		type.delete_type = DeletedScanType::OMIT_PERMANENTLY_COMMITTED;
-		type.update_type = UpdateScanType::DISALLOW_UPDATES;
-		return type;
-	}
 };
 
 enum class TableScanType : uint8_t {

--- a/src/include/duckdb/common/enums/scan_options.hpp
+++ b/src/include/duckdb/common/enums/scan_options.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "duckdb/common/constants.hpp"
+#include "duckdb/transaction/transaction_data.hpp"
 
 namespace duckdb {
 
@@ -37,6 +37,9 @@ enum class UpdateScanType {
 };
 
 struct ScanOptions {
+	ScanOptions(TransactionData transaction); // NOLINT: allow implicit conversion from transaction
+
+	TransactionData transaction;
 	InsertedScanType insert_type = InsertedScanType::STANDARD;
 	DeletedScanType delete_type = DeletedScanType::STANDARD;
 	UpdateScanType update_type = UpdateScanType::STANDARD;

--- a/src/include/duckdb/common/enums/scan_vector_type.hpp
+++ b/src/include/duckdb/common/enums/scan_vector_type.hpp
@@ -14,6 +14,4 @@ namespace duckdb {
 
 enum class ScanVectorType { SCAN_ENTIRE_VECTOR, SCAN_FLAT_VECTOR };
 
-enum class ScanVectorMode { REGULAR_SCAN, SCAN_COMMITTED, SCAN_COMMITTED_NO_UPDATES };
-
 } // namespace duckdb

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -239,7 +239,7 @@ public:
 	vector<ColumnSegmentInfo> GetColumnSegmentInfo(const QueryContext &context);
 
 	//! Scans the next chunk for the CREATE INDEX operator
-	bool CreateIndexScan(TableScanState &state, DataChunk &result, TableScanType type);
+	bool CreateIndexScan(TableScanState &state, DataChunk &result);
 	//! Returns true, if the index name is unique (i.e., no PK, UNIQUE, FK constraint has the same name)
 	//! FIXME: This is only necessary until we treat all indexes as catalog entries, allowing to alter constraints
 	bool IndexNameIsUnique(const string &name);

--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -29,8 +29,6 @@ public:
 
 	idx_t Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	           idx_t scan_count) override;
-	idx_t ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-	                    idx_t scan_count) override;
 	idx_t ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset = 0) override;
 
 	void Select(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/execution/index/index_pointer.hpp"
+#include "duckdb/common/enums/scan_options.hpp"
 
 namespace duckdb {
 class RowGroup;
@@ -40,8 +41,8 @@ public:
 public:
 	//! Gets up to max_count entries from the chunk info. If the ret is 0>ret>max_count, the selection vector is filled
 	//! with the tuples
-	virtual idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector,
-	                           idx_t max_count) const = 0;
+	virtual idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
+	                           TScanType type = TScanType()) const = 0;
 	virtual idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
 	                                    SelectionVector &sel_vector, idx_t max_count) = 0;
 	virtual idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count) = 0;
@@ -86,8 +87,8 @@ public:
 	transaction_t delete_id;
 
 public:
-	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector,
-	                   idx_t max_count) const override;
+	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
+	                   TScanType type = TScanType()) const override;
 	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
 	                            SelectionVector &sel_vector, idx_t max_count) override;
 	idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count) override;
@@ -116,8 +117,8 @@ public:
 	~ChunkVectorInfo() override;
 
 public:
-	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector,
-	                   idx_t max_count) const override;
+	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
+	                   TScanType type = TScanType()) const override;
 	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
 	                            SelectionVector &sel_vector, idx_t max_count) override;
 	idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count) override;

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -101,7 +101,7 @@ public:
 	static unique_ptr<ChunkInfo> Read(ReadStream &reader);
 
 private:
-	template <class OP>
+	template <class INSERT_OP, class DELETE_OP>
 	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,
 	                            idx_t max_count) const;
 };
@@ -146,7 +146,7 @@ public:
 	static unique_ptr<ChunkInfo> Read(FixedSizeAllocator &allocator, ReadStream &reader);
 
 private:
-	template <class OP>
+	template <class INSERT_OP, class DELETE_OP>
 	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,
 	                            idx_t max_count) const;
 

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -40,7 +40,8 @@ public:
 public:
 	//! Gets up to max_count entries from the chunk info. If the ret is 0>ret>max_count, the selection vector is filled
 	//! with the tuples
-	virtual idx_t GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) const = 0;
+	virtual idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector,
+	                           idx_t max_count) const = 0;
 	virtual idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
 	                                    SelectionVector &sel_vector, idx_t max_count) = 0;
 	virtual idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count) = 0;
@@ -85,7 +86,8 @@ public:
 	transaction_t delete_id;
 
 public:
-	idx_t GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) const override;
+	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector,
+	                   idx_t max_count) const override;
 	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
 	                            SelectionVector &sel_vector, idx_t max_count) override;
 	idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count) override;
@@ -114,9 +116,8 @@ public:
 	~ChunkVectorInfo() override;
 
 public:
-	idx_t GetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,
-	                   idx_t max_count) const;
-	idx_t GetSelVector(TransactionData transaction, SelectionVector &sel_vector, idx_t max_count) const override;
+	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector,
+	                   idx_t max_count) const override;
 	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
 	                            SelectionVector &sel_vector, idx_t max_count) override;
 	idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count) override;

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -42,7 +42,7 @@ public:
 	//! Gets up to max_count entries from the chunk info. If the ret is 0>ret>max_count, the selection vector is filled
 	//! with the tuples
 	virtual idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
-	                           TScanType type = TScanType()) const = 0;
+	                           ScanOptions options = ScanOptions()) const = 0;
 	idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count);
 	//! Returns whether or not a single row in the ChunkInfo should be used or not for the given transaction
 	virtual bool Fetch(TransactionData transaction, row_t row) = 0;
@@ -86,7 +86,7 @@ public:
 
 public:
 	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
-	                   TScanType type = TScanType()) const override;
+	                   ScanOptions options = ScanOptions()) const override;
 	bool Fetch(TransactionData transaction, row_t row) override;
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
 	bool Cleanup(transaction_t lowest_transaction) const override;
@@ -112,7 +112,7 @@ public:
 
 public:
 	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
-	                   TScanType type = TScanType()) const override;
+	                   ScanOptions options = ScanOptions()) const override;
 	bool Fetch(TransactionData transaction, row_t row) override;
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
 	bool Cleanup(transaction_t lowest_transaction) const override;

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -43,13 +43,13 @@ public:
 	//! with the tuples
 	virtual idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
 	                           TScanType type = TScanType()) const = 0;
-	virtual idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
-	                                    SelectionVector &sel_vector, idx_t max_count) = 0;
-	virtual idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count) = 0;
+	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
+	                            SelectionVector &sel_vector, idx_t max_count);
+	idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count);
 	//! Returns whether or not a single row in the ChunkInfo should be used or not for the given transaction
 	virtual bool Fetch(TransactionData transaction, row_t row) = 0;
 	virtual void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) = 0;
-	virtual idx_t GetCommittedDeletedCount(idx_t max_count) const = 0;
+	idx_t GetCommittedDeletedCount(idx_t max_count) const;
 	virtual bool Cleanup(transaction_t lowest_transaction) const;
 	virtual string ToString(idx_t max_count) const = 0;
 
@@ -89,12 +89,8 @@ public:
 public:
 	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
 	                   TScanType type = TScanType()) const override;
-	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
-	                            SelectionVector &sel_vector, idx_t max_count) override;
-	idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count) override;
 	bool Fetch(TransactionData transaction, row_t row) override;
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
-	idx_t GetCommittedDeletedCount(idx_t max_count) const override;
 	bool Cleanup(transaction_t lowest_transaction) const override;
 	string ToString(idx_t max_count) const override;
 
@@ -119,13 +115,9 @@ public:
 public:
 	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
 	                   TScanType type = TScanType()) const override;
-	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
-	                            SelectionVector &sel_vector, idx_t max_count) override;
-	idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count) override;
 	bool Fetch(TransactionData transaction, row_t row) override;
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
 	bool Cleanup(transaction_t lowest_transaction) const override;
-	idx_t GetCommittedDeletedCount(idx_t max_count) const override;
 	string ToString(idx_t max_count) const override;
 
 	void Append(idx_t start, idx_t end, transaction_t commit_id);

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -41,8 +41,8 @@ public:
 public:
 	//! Gets up to max_count entries from the chunk info. If the ret is 0>ret>max_count, the selection vector is filled
 	//! with the tuples
-	virtual idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
-	                           ScanOptions options = ScanOptions()) const = 0;
+	virtual idx_t GetSelVector(ScanOptions options, optional_ptr<SelectionVector> sel_vector,
+	                           idx_t max_count) const = 0;
 	idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count);
 	//! Returns whether or not a single row in the ChunkInfo should be used or not for the given transaction
 	virtual bool Fetch(TransactionData transaction, row_t row) = 0;
@@ -85,8 +85,7 @@ public:
 	transaction_t delete_id;
 
 public:
-	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
-	                   ScanOptions options = ScanOptions()) const override;
+	idx_t GetSelVector(ScanOptions options, optional_ptr<SelectionVector> sel_vector, idx_t max_count) const override;
 	bool Fetch(TransactionData transaction, row_t row) override;
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
 	bool Cleanup(transaction_t lowest_transaction) const override;
@@ -111,8 +110,7 @@ public:
 	~ChunkVectorInfo() override;
 
 public:
-	idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
-	                   ScanOptions options = ScanOptions()) const override;
+	idx_t GetSelVector(ScanOptions options, optional_ptr<SelectionVector> sel_vector, idx_t max_count) const override;
 	bool Fetch(TransactionData transaction, row_t row) override;
 	void CommitAppend(transaction_t commit_id, idx_t start, idx_t end) override;
 	bool Cleanup(transaction_t lowest_transaction) const override;

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -102,8 +102,7 @@ public:
 
 private:
 	template <class INSERT_OP, class DELETE_OP>
-	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id,
-	                            idx_t max_count) const;
+	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id, idx_t max_count) const;
 };
 
 class ChunkVectorInfo : public ChunkInfo {
@@ -147,8 +146,8 @@ public:
 
 private:
 	template <class INSERT_OP, class DELETE_OP>
-	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id, optional_ptr<SelectionVector> sel_vector,
-	                            idx_t max_count) const;
+	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id,
+	                            optional_ptr<SelectionVector> sel_vector, idx_t max_count) const;
 
 	IndexPointer GetInsertedPointer() const;
 	IndexPointer GetDeletedPointer() const;

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -102,7 +102,7 @@ public:
 
 private:
 	template <class INSERT_OP, class DELETE_OP>
-	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,
+	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id,
 	                            idx_t max_count) const;
 };
 
@@ -147,7 +147,7 @@ public:
 
 private:
 	template <class INSERT_OP, class DELETE_OP>
-	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,
+	idx_t TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id, optional_ptr<SelectionVector> sel_vector,
 	                            idx_t max_count) const;
 
 	IndexPointer GetInsertedPointer() const;

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -43,8 +43,6 @@ public:
 	//! with the tuples
 	virtual idx_t GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector, idx_t max_count,
 	                           TScanType type = TScanType()) const = 0;
-	idx_t GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
-	                            SelectionVector &sel_vector, idx_t max_count);
 	idx_t GetCheckpointRowCount(TransactionData transaction, idx_t max_count);
 	//! Returns whether or not a single row in the ChunkInfo should be used or not for the given transaction
 	virtual bool Fetch(TransactionData transaction, row_t row) = 0;

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -134,11 +134,8 @@ public:
 	virtual void InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx);
 	//! Scan the next vector from the column
 	idx_t Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result);
-	idx_t ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates);
 	virtual idx_t Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	                   idx_t scan_count);
-	virtual idx_t ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-	                            idx_t scan_count);
 
 	virtual void ScanCommittedRange(idx_t row_group_start, idx_t offset_in_row_group, idx_t count, Vector &result);
 	virtual idx_t ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset = 0);
@@ -148,8 +145,6 @@ public:
 	                    SelectionVector &sel, idx_t &count, const TableFilter &filter, TableFilterState &filter_state);
 	virtual void Select(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	                    SelectionVector &sel, idx_t count);
-	virtual void SelectCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, SelectionVector &sel,
-	                             idx_t count, bool allow_updates);
 
 	//! Skip the scan forward by "count" rows
 	virtual void Skip(ColumnScanState &state, idx_t count = STANDARD_VECTOR_SIZE);
@@ -220,16 +215,16 @@ protected:
 	                 idx_t result_offset = 0);
 	//! Scans a vector from the column merged with any potential updates
 	idx_t ScanVector(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
-	                 idx_t target_scan, ScanVectorType scan_type, ScanVectorMode mode);
+	                 idx_t target_scan, ScanVectorType scan_type, UpdateScanType update_type);
 	idx_t ScanVector(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
-	                 idx_t target_scan, ScanVectorMode mode);
+	                 idx_t target_scan, UpdateScanType update_type);
 	void SelectVector(ColumnScanState &state, Vector &result, idx_t target_count, const SelectionVector &sel,
 	                  idx_t sel_count);
 	void FilterVector(ColumnScanState &state, Vector &result, idx_t target_count, SelectionVector &sel,
 	                  idx_t &sel_count, const TableFilter &filter, TableFilterState &filter_state);
 
 	void FetchUpdates(TransactionData transaction, idx_t vector_index, Vector &result, idx_t scan_count,
-	                  bool allow_updates, bool scan_committed);
+	                  UpdateScanType update_type);
 	void FetchUpdateRow(TransactionData transaction, row_t row_id, Vector &result, idx_t result_idx);
 	void UpdateInternal(TransactionData transaction, DataTable &data_table, idx_t column_index, Vector &update_vector,
 	                    row_t *row_ids, idx_t update_count, Vector &base_vector, idx_t row_group_start);

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -29,8 +29,6 @@ public:
 
 	idx_t Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	           idx_t scan_count) override;
-	idx_t ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-	                    idx_t scan_count) override;
 	idx_t ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset = 0) override;
 
 	void Skip(ColumnScanState &state, idx_t count = STANDARD_VECTOR_SIZE) override;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -140,14 +140,12 @@ public:
 	//! Checks the given set of table filters against the per-segment statistics. Returns false if any segments were
 	//! skipped.
 	bool CheckZonemapSegments(CollectionScanState &state);
-	void Scan(TransactionData transaction, CollectionScanState &state, DataChunk &result,
-	          ScanOptions options = ScanOptions());
+	void Scan(ScanOptions options, CollectionScanState &state, DataChunk &result);
 	void Scan(CollectionScanState &state, DataChunk &result, TableScanType type);
 
 	//! Whether or not this RowGroup should be
 	bool ShouldCheckpointRowGroup(transaction_t checkpoint_id) const;
-	idx_t GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count,
-	                   ScanOptions options);
+	idx_t GetSelVector(ScanOptions options, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count);
 
 	//! For a specific row, returns true if it should be used for the transaction and false otherwise.
 	bool Fetch(TransactionData transaction, idx_t row);

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -145,9 +145,8 @@ public:
 
 	//! Whether or not this RowGroup should be
 	bool ShouldCheckpointRowGroup(transaction_t checkpoint_id) const;
-	idx_t GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count);
-	idx_t GetCommittedSelVector(transaction_t start_time, transaction_t transaction_id, idx_t vector_idx,
-	                            SelectionVector &sel_vector, idx_t max_count);
+	idx_t GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count,
+	                   TScanType type);
 
 	//! For a specific row, returns true if it should be used for the transaction and false otherwise.
 	bool Fetch(TransactionData transaction, idx_t row);

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -140,8 +140,8 @@ public:
 	//! Checks the given set of table filters against the per-segment statistics. Returns false if any segments were
 	//! skipped.
 	bool CheckZonemapSegments(CollectionScanState &state);
-	void Scan(TransactionData transaction, CollectionScanState &state, DataChunk &result);
-	void ScanCommitted(CollectionScanState &state, DataChunk &result, TableScanType type);
+	void Scan(TransactionData transaction, CollectionScanState &state, DataChunk &result, TScanType type = TScanType());
+	void Scan(CollectionScanState &state, DataChunk &result, TableScanType type);
 
 	//! Whether or not this RowGroup should be
 	bool ShouldCheckpointRowGroup(transaction_t checkpoint_id) const;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -140,13 +140,14 @@ public:
 	//! Checks the given set of table filters against the per-segment statistics. Returns false if any segments were
 	//! skipped.
 	bool CheckZonemapSegments(CollectionScanState &state);
-	void Scan(TransactionData transaction, CollectionScanState &state, DataChunk &result, TScanType type = TScanType());
+	void Scan(TransactionData transaction, CollectionScanState &state, DataChunk &result,
+	          ScanOptions options = ScanOptions());
 	void Scan(CollectionScanState &state, DataChunk &result, TableScanType type);
 
 	//! Whether or not this RowGroup should be
 	bool ShouldCheckpointRowGroup(transaction_t checkpoint_id) const;
 	idx_t GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count,
-	                   TScanType type);
+	                   ScanOptions options);
 
 	//! For a specific row, returns true if it should be used for the transaction and false otherwise.
 	bool Fetch(TransactionData transaction, idx_t row);
@@ -233,8 +234,6 @@ private:
 	vector<shared_ptr<ColumnData>> &GetColumns();
 	void LoadRowIdColumnData() const;
 	void SetCount(idx_t count);
-
-	void ScanInternal(TransactionData transaction, CollectionScanState &state, DataChunk &result, TScanType type);
 
 	bool HasUnloadedDeletes() const;
 

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -234,7 +234,7 @@ private:
 	void LoadRowIdColumnData() const;
 	void SetCount(idx_t count);
 
-	void ScanInternal(TransactionData transaction, CollectionScanState &state, DataChunk &result, TableScanType TYPE);
+	void ScanInternal(TransactionData transaction, CollectionScanState &state, DataChunk &result, TScanType type);
 
 	bool HasUnloadedDeletes() const;
 

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -234,8 +234,7 @@ private:
 	void LoadRowIdColumnData() const;
 	void SetCount(idx_t count);
 
-	template <TableScanType TYPE>
-	void TemplatedScan(TransactionData transaction, CollectionScanState &state, DataChunk &result);
+	void ScanInternal(TransactionData transaction, CollectionScanState &state, DataChunk &result, TableScanType TYPE);
 
 	bool HasUnloadedDeletes() const;
 

--- a/src/include/duckdb/storage/table/row_id_column_data.hpp
+++ b/src/include/duckdb/storage/table/row_id_column_data.hpp
@@ -23,8 +23,6 @@ public:
 
 	idx_t Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	           idx_t scan_count) override;
-	idx_t ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-	                    idx_t scan_count) override;
 	void ScanCommittedRange(idx_t row_group_start, idx_t offset_in_row_group, idx_t count, Vector &result) override;
 	idx_t ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset = 0) override;
 
@@ -32,8 +30,6 @@ public:
 	            SelectionVector &sel, idx_t &count, const TableFilter &filter, TableFilterState &filter_state) override;
 	void Select(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	            SelectionVector &sel, idx_t count) override;
-	void SelectCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, SelectionVector &sel, idx_t count,
-	                     bool allow_updates) override;
 
 	idx_t Fetch(ColumnScanState &state, row_t row_id, Vector &result) override;
 	void FetchRow(TransactionData transaction, ColumnFetchState &state, const StorageIndex &storage_index, row_t row_id,

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -28,8 +28,7 @@ public:
 	idx_t GetCommittedDeletedCount(idx_t count);
 
 	bool ShouldCheckpointRowGroup(transaction_t checkpoint_id, idx_t count);
-	idx_t GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count,
-	                   ScanOptions options);
+	idx_t GetSelVector(ScanOptions options, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count);
 	bool Fetch(TransactionData transaction, idx_t row);
 
 	void AppendVersionInfo(TransactionData transaction, idx_t count, idx_t row_group_start, idx_t row_group_end);

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -28,9 +28,8 @@ public:
 	idx_t GetCommittedDeletedCount(idx_t count);
 
 	bool ShouldCheckpointRowGroup(transaction_t checkpoint_id, idx_t count);
-	idx_t GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count);
-	idx_t GetCommittedSelVector(transaction_t start_time, transaction_t transaction_id, idx_t vector_idx,
-	                            SelectionVector &sel_vector, idx_t max_count);
+	idx_t GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count,
+	                   TScanType type);
 	bool Fetch(TransactionData transaction, idx_t row);
 
 	void AppendVersionInfo(TransactionData transaction, idx_t count, idx_t row_group_start, idx_t row_group_end);

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -29,7 +29,7 @@ public:
 
 	bool ShouldCheckpointRowGroup(transaction_t checkpoint_id, idx_t count);
 	idx_t GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count,
-	                   TScanType type);
+	                   ScanOptions options);
 	bool Fetch(TransactionData transaction, idx_t row);
 
 	void AppendVersionInfo(TransactionData transaction, idx_t count, idx_t row_group_start, idx_t row_group_end);

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -131,6 +131,8 @@ struct ColumnScanState {
 	optional_ptr<TableScanOptions> scan_options;
 	//! (optionally) the expression state for any pushed down expression(s)
 	unique_ptr<PushedDownExpressionState> expression_state;
+	//! Whether or not updates should be allowed
+	UpdateScanType update_scan_type = UpdateScanType::STANDARD;
 
 public:
 	void Initialize(const QueryContext &context_p, const LogicalType &type, const StorageIndex &column_id,

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -258,8 +258,7 @@ public:
 	optional_ptr<SegmentNode<RowGroup>> GetNextRowGroup(SegmentLock &l, SegmentNode<RowGroup> &row_group) const;
 	optional_ptr<SegmentNode<RowGroup>> GetRootSegment() const;
 	bool Scan(DuckTransaction &transaction, DataChunk &result);
-	bool ScanCommitted(DataChunk &result, TableScanType type);
-	bool ScanCommitted(DataChunk &result, SegmentLock &l, TableScanType type);
+	bool Scan(DataChunk &result, TableScanType type, optional_ptr<SegmentLock> l = nullptr);
 
 private:
 	TableScanState &parent;

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -29,8 +29,6 @@ public:
 
 	idx_t Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	           idx_t target_count) override;
-	idx_t ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-	                    idx_t target_count) override;
 	idx_t ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset) override;
 
 	void Filter(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -32,8 +32,6 @@ public:
 
 	idx_t Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	           idx_t scan_count) override;
-	idx_t ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-	                    idx_t scan_count) override;
 	idx_t ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset = 0) override;
 
 	void Skip(ColumnScanState &state, idx_t count = STANDARD_VECTOR_SIZE) override;

--- a/src/include/duckdb/storage/table/variant_column_data.hpp
+++ b/src/include/duckdb/storage/table/variant_column_data.hpp
@@ -36,8 +36,6 @@ public:
 	Vector CreateUnshreddingIntermediate(idx_t count);
 	idx_t Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	           idx_t scan_count) override;
-	idx_t ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-	                    idx_t scan_count) override;
 	idx_t ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset = 0) override;
 
 	void Skip(ColumnScanState &state, idx_t count = STANDARD_VECTOR_SIZE) override;

--- a/src/include/duckdb/transaction/transaction_data.hpp
+++ b/src/include/duckdb/transaction/transaction_data.hpp
@@ -22,6 +22,10 @@ struct TransactionData {
 	optional_ptr<DuckTransaction> transaction;
 	transaction_t transaction_id;
 	transaction_t start_time;
+
+	static TransactionData Committed() {
+		return TransactionData(MAX_TRANSACTION_ID, 0);
+	}
 };
 
 } // namespace duckdb

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1338,7 +1338,7 @@ void DataTable::RevertIndexAppend(TableAppendState &state, DataChunk &chunk, Vec
 	D_ASSERT(IsMainTable());
 	info->indexes.Scan([&](Index &index) {
 		auto &main_index = index.Cast<BoundIndex>();
-		main_index.Delete(chunk, row_identifiers);
+		main_index.TryDelete(chunk, row_identifiers);
 		return false;
 	});
 }

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -296,8 +296,8 @@ void DataTable::Scan(DuckTransaction &transaction, DataChunk &result, TableScanS
 	local_storage.Scan(state.local_state, state.GetColumnIds(), result);
 }
 
-bool DataTable::CreateIndexScan(TableScanState &state, DataChunk &result, TableScanType type) {
-	return state.table_state.ScanCommitted(result, type);
+bool DataTable::CreateIndexScan(TableScanState &state, DataChunk &result) {
+	return state.table_state.Scan(result, TableScanType::TABLE_SCAN_OMIT_PERMANENTLY_DELETED);
 }
 
 //===--------------------------------------------------------------------===//
@@ -1092,7 +1092,7 @@ void DataTable::ScanTableSegment(DuckTransaction &transaction, idx_t row_start, 
 
 	idx_t current_row = row_start_aligned;
 	while (current_row < end) {
-		state.table_state.ScanCommitted(chunk, TableScanType::TABLE_SCAN_ALL_ROWS);
+		state.table_state.Scan(chunk, TableScanType::TABLE_SCAN_ALL_ROWS);
 		if (chunk.size() == 0) {
 			break;
 		}

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1092,7 +1092,7 @@ void DataTable::ScanTableSegment(DuckTransaction &transaction, idx_t row_start, 
 
 	idx_t current_row = row_start_aligned;
 	while (current_row < end) {
-		state.table_state.ScanCommitted(chunk, TableScanType::TABLE_SCAN_COMMITTED_ROWS);
+		state.table_state.ScanCommitted(chunk, TableScanType::TABLE_SCAN_ALL_ROWS);
 		if (chunk.size() == 0) {
 			break;
 		}

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1338,7 +1338,7 @@ void DataTable::RevertIndexAppend(TableAppendState &state, DataChunk &chunk, Vec
 	D_ASSERT(IsMainTable());
 	info->indexes.Scan([&](Index &index) {
 		auto &main_index = index.Cast<BoundIndex>();
-		main_index.TryDelete(chunk, row_identifiers);
+		main_index.Delete(chunk, row_identifiers);
 		return false;
 	});
 }

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -232,6 +232,10 @@ void LocalTableStorage::AppendToIndexes(DuckTransaction &transaction, TableAppen
 		row_t current_row = append_state.row_start;
 		// Remove the data from the indexes, if any.
 		collection.Scan(transaction, [&](DataChunk &chunk) -> bool {
+			if (current_row >= append_state.current_row) {
+				// Finished deleting all rows from the index.
+				return false;
+			}
 			// Remove the chunk.
 			try {
 				table.RevertIndexAppend(append_state, chunk, current_row);
@@ -241,10 +245,6 @@ void LocalTableStorage::AppendToIndexes(DuckTransaction &transaction, TableAppen
 			} // LCOV_EXCL_STOP
 
 			current_row += UnsafeNumericCast<row_t>(chunk.size());
-			if (current_row >= append_state.current_row) {
-				// Finished deleting all rows from the index.
-				return false;
-			}
 			return true;
 		});
 

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -82,11 +82,6 @@ idx_t ArrayColumnData::Scan(TransactionData transaction, idx_t vector_index, Col
 	return ScanCount(state, result, scan_count);
 }
 
-idx_t ArrayColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-                                     idx_t scan_count) {
-	return ScanCount(state, result, scan_count);
-}
-
 idx_t ArrayColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset) {
 	// Scan validity
 	auto scan_count = validity->ScanCount(state.child_states[0], result, count, result_offset);

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -90,7 +90,7 @@ idx_t ChunkConstantInfo::TemplatedGetSelVector(transaction_t start_time, transac
 }
 
 idx_t ChunkConstantInfo::GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector,
-                                      idx_t max_count) const {
+                                      idx_t max_count, TScanType type) const {
 	return TemplatedGetSelVector<StandardInsertOperator, StandardDeleteOperator>(transaction.start_time,
 	                                                                             transaction.transaction_id, max_count);
 }
@@ -260,7 +260,7 @@ idx_t ChunkVectorInfo::GetCommittedSelVector(transaction_t min_start_id, transac
 }
 
 idx_t ChunkVectorInfo::GetSelVector(TransactionData transaction, optional_ptr<SelectionVector> sel_vector,
-                                    idx_t max_count) const {
+                                    idx_t max_count, TScanType type) const {
 	return TemplatedGetSelVector<StandardInsertOperator, StandardDeleteOperator>(
 	    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
 }

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -72,14 +72,6 @@ unique_ptr<ChunkInfo> ChunkInfo::Read(FixedSizeAllocator &allocator, ReadStream 
 	}
 }
 
-idx_t ChunkInfo::GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
-                                       SelectionVector &sel_vector, idx_t max_count) {
-	TScanType type;
-	type.insert_type = InsertedScanType::ALL_ROWS;
-	type.delete_type = DeletedScanType::OMIT_FULLY_COMMITTED_DELETES;
-	return GetSelVector(TransactionData(min_transaction_id, min_start_id), sel_vector, max_count, type);
-}
-
 idx_t ChunkInfo::GetCommittedDeletedCount(idx_t max_count) const {
 	TScanType type;
 	type.insert_type = InsertedScanType::ALL_ROWS;

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -70,7 +70,7 @@ unique_ptr<ChunkInfo> ChunkInfo::Read(FixedSizeAllocator &allocator, ReadStream 
 idx_t ChunkInfo::GetCommittedDeletedCount(idx_t max_count) const {
 	ScanOptions options(TransactionData(0, TRANSACTION_ID_START));
 	options.insert_type = InsertedScanType::ALL_ROWS;
-	options.delete_type = DeletedScanType::OMIT_FULLY_COMMITTED_DELETES;
+	options.delete_type = DeletedScanType::OMIT_COMMITTED_DELETES;
 	idx_t not_deleted_count = GetSelVector(options, nullptr, max_count);
 	return max_count - not_deleted_count;
 }
@@ -111,7 +111,7 @@ idx_t ChunkConstantInfo::GetSelVector(ScanOptions options, optional_ptr<Selectio
 		if (StandardDeleteOperator::IsDeleted(transaction.start_time, transaction.transaction_id, delete_id)) {
 			return 0;
 		}
-	} else if (options.delete_type == DeletedScanType::OMIT_FULLY_COMMITTED_DELETES) {
+	} else if (options.delete_type == DeletedScanType::OMIT_COMMITTED_DELETES) {
 		if (CommittedDeleteOperator::IsDeleted(transaction.start_time, transaction.transaction_id, delete_id)) {
 			return 0;
 		}
@@ -272,7 +272,7 @@ idx_t ChunkVectorInfo::GetSelVector(ScanOptions options, optional_ptr<SelectionV
 			return TemplatedGetSelVector<StandardInsertOperator, IncludeAllDeletedOperator>(
 			    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
 		}
-		if (options.delete_type == DeletedScanType::OMIT_FULLY_COMMITTED_DELETES) {
+		if (options.delete_type == DeletedScanType::OMIT_COMMITTED_DELETES) {
 			return TemplatedGetSelVector<StandardInsertOperator, CommittedDeleteOperator>(
 			    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
 		}
@@ -282,7 +282,7 @@ idx_t ChunkVectorInfo::GetSelVector(ScanOptions options, optional_ptr<SelectionV
 			return TemplatedGetSelVector<IncludeAllInsertedOperator, StandardDeleteOperator>(
 			    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
 		}
-		if (options.delete_type == DeletedScanType::OMIT_FULLY_COMMITTED_DELETES) {
+		if (options.delete_type == DeletedScanType::OMIT_COMMITTED_DELETES) {
 			return TemplatedGetSelVector<IncludeAllInsertedOperator, CommittedDeleteOperator>(
 			    transaction.start_time, transaction.transaction_id, sel_vector, max_count);
 		}

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -92,11 +92,6 @@ idx_t ListColumnData::Scan(TransactionData transaction, idx_t vector_index, Colu
 	return ScanCount(state, result, scan_count);
 }
 
-idx_t ListColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-                                    idx_t scan_count) {
-	return ScanCount(state, result, scan_count);
-}
-
 idx_t ListColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset) {
 	if (result_offset > 0) {
 		throw InternalException("ListColumnData::ScanCount not supported with result_offset > 0");

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -651,7 +651,11 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 				const auto &column = column_ids[i];
 				auto &col_data = GetColumn(column);
 				if (TYPE != TableScanType::TABLE_SCAN_REGULAR) {
-					col_data.ScanCommitted(state.vector_index, state.column_scans[i], result.data[i], ALLOW_UPDATES);
+					if (!ALLOW_UPDATES) {
+						state.column_scans[i].update_scan_type = UpdateScanType::DISALLOW_UPDATES;
+					}
+					col_data.Scan(TransactionData::Committed(), state.vector_index, state.column_scans[i],
+					              result.data[i]);
 				} else {
 					col_data.Scan(transaction, state.vector_index, state.column_scans[i], result.data[i]);
 				}
@@ -729,8 +733,11 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 					col_data.Select(transaction, state.vector_index, state.column_scans[i], result.data[i], sel,
 					                approved_tuple_count);
 				} else {
-					col_data.SelectCommitted(state.vector_index, state.column_scans[i], result.data[i], sel,
-					                         approved_tuple_count, ALLOW_UPDATES);
+					if (!ALLOW_UPDATES) {
+						state.column_scans[i].update_scan_type = UpdateScanType::DISALLOW_UPDATES;
+					}
+					col_data.Select(TransactionData::Committed(), state.vector_index, state.column_scans[i],
+					                result.data[i], sel, approved_tuple_count);
 				}
 			}
 			filter_info.EndFilter(filter_state);

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -383,7 +383,7 @@ unique_ptr<RowGroup> RowGroup::AlterType(RowGroupCollection &new_collection, con
 	while (true) {
 		// scan the table
 		scan_chunk.Reset();
-		ScanCommitted(scan_state, scan_chunk, TableScanType::TABLE_SCAN_COMMITTED_ROWS);
+		ScanCommitted(scan_state, scan_chunk, TableScanType::TABLE_SCAN_ALL_ROWS);
 		if (scan_chunk.size() == 0) {
 			break;
 		}
@@ -731,7 +731,7 @@ void RowGroup::ScanCommitted(CollectionScanState &state, DataChunk &result, Tabl
 
 	transaction_t start_ts;
 	transaction_t transaction_id;
-	if (type == TableScanType::TABLE_SCAN_LATEST_COMMITTED_ROWS) {
+	if (type == TableScanType::TABLE_SCAN_COMMITTED_ROWS) {
 		start_ts = transaction_manager.GetLastCommit() + 1;
 		transaction_id = MAX_TRANSACTION_ID;
 	} else {
@@ -743,11 +743,11 @@ void RowGroup::ScanCommitted(CollectionScanState &state, DataChunk &result, Tabl
 	TScanType scan_type;
 	scan_type.insert_type = InsertedScanType::ALL_ROWS;
 	switch (type) {
-	case TableScanType::TABLE_SCAN_COMMITTED_ROWS:
+	case TableScanType::TABLE_SCAN_ALL_ROWS:
 		scan_type.delete_type = DeletedScanType::INCLUDE_ALL_DELETED;
 		break;
-	case TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED:
-	case TableScanType::TABLE_SCAN_LATEST_COMMITTED_ROWS:
+	case TableScanType::TABLE_SCAN_OMIT_PERMANENTLY_DELETED:
+	case TableScanType::TABLE_SCAN_COMMITTED_ROWS:
 		scan_type.delete_type = DeletedScanType::OMIT_FULLY_COMMITTED_DELETES;
 		scan_type.update_type = UpdateScanType::DISALLOW_UPDATES;
 		break;

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -383,7 +383,7 @@ unique_ptr<RowGroup> RowGroup::AlterType(RowGroupCollection &new_collection, con
 	while (true) {
 		// scan the table
 		scan_chunk.Reset();
-		ScanCommitted(scan_state, scan_chunk, TableScanType::TABLE_SCAN_ALL_ROWS);
+		Scan(scan_state, scan_chunk, TableScanType::TABLE_SCAN_ALL_ROWS);
 		if (scan_chunk.size() == 0) {
 			break;
 		}
@@ -722,11 +722,11 @@ void RowGroup::ScanInternal(TransactionData transaction, CollectionScanState &st
 	}
 }
 
-void RowGroup::Scan(TransactionData transaction, CollectionScanState &state, DataChunk &result) {
-	ScanInternal(transaction, state, result, TScanType());
+void RowGroup::Scan(TransactionData transaction, CollectionScanState &state, DataChunk &result, TScanType type) {
+	ScanInternal(transaction, state, result, type);
 }
 
-void RowGroup::ScanCommitted(CollectionScanState &state, DataChunk &result, TableScanType type) {
+void RowGroup::Scan(CollectionScanState &state, DataChunk &result, TableScanType type) {
 	auto &transaction_manager = DuckTransactionManager::Get(GetCollection().GetAttached());
 
 	transaction_t start_ts;
@@ -754,7 +754,7 @@ void RowGroup::ScanCommitted(CollectionScanState &state, DataChunk &result, Tabl
 	default:
 		throw InternalException("Unrecognized table scan type");
 	}
-	ScanInternal(transaction, state, result, scan_type);
+	Scan(transaction, state, result, scan_type);
 }
 
 optional_ptr<RowVersionManager> RowGroup::GetVersionInfo() {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -738,21 +738,16 @@ void RowGroup::ScanCommitted(CollectionScanState &state, DataChunk &result, Tabl
 		start_ts = transaction_manager.LowestActiveStart();
 		transaction_id = transaction_manager.LowestActiveId();
 	}
-	TScanType scan_type;
 	TransactionData transaction(transaction_id, start_ts);
+
+	TScanType scan_type;
+	scan_type.insert_type = InsertedScanType::ALL_ROWS;
 	switch (type) {
 	case TableScanType::TABLE_SCAN_COMMITTED_ROWS:
-		scan_type.insert_type = InsertedScanType::ALL_ROWS;
 		scan_type.delete_type = DeletedScanType::INCLUDE_ALL_DELETED;
-		break;
-	case TableScanType::TABLE_SCAN_COMMITTED_ROWS_DISALLOW_UPDATES:
-		scan_type.insert_type = InsertedScanType::ALL_ROWS;
-		scan_type.delete_type = DeletedScanType::INCLUDE_ALL_DELETED;
-		scan_type.update_type = UpdateScanType::DISALLOW_UPDATES;
 		break;
 	case TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED:
 	case TableScanType::TABLE_SCAN_LATEST_COMMITTED_ROWS:
-		scan_type.insert_type = InsertedScanType::ALL_ROWS;
 		scan_type.delete_type = DeletedScanType::OMIT_FULLY_COMMITTED_DELETES;
 		scan_type.update_type = UpdateScanType::DISALLOW_UPDATES;
 		break;

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -746,7 +746,7 @@ void RowGroup::Scan(CollectionScanState &state, DataChunk &result, TableScanType
 		break;
 	case TableScanType::TABLE_SCAN_OMIT_PERMANENTLY_DELETED:
 	case TableScanType::TABLE_SCAN_COMMITTED_ROWS:
-		options.delete_type = DeletedScanType::OMIT_FULLY_COMMITTED_DELETES;
+		options.delete_type = DeletedScanType::OMIT_COMMITTED_DELETES;
 		options.update_type = UpdateScanType::DISALLOW_UPDATES;
 		break;
 	default:

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1156,7 +1156,7 @@ public:
 			while (true) {
 				scan_chunk.Reset();
 
-				current_row_group.ScanCommitted(scan_state.table_state, scan_chunk,
+				current_row_group.Scan(scan_state.table_state, scan_chunk,
 				                                TableScanType::TABLE_SCAN_COMMITTED_ROWS);
 				if (scan_chunk.size() == 0) {
 					break;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1157,7 +1157,7 @@ public:
 				scan_chunk.Reset();
 
 				current_row_group.ScanCommitted(scan_state.table_state, scan_chunk,
-				                                TableScanType::TABLE_SCAN_LATEST_COMMITTED_ROWS);
+				                                TableScanType::TABLE_SCAN_COMMITTED_ROWS);
 				if (scan_chunk.size() == 0) {
 					break;
 				}
@@ -1864,7 +1864,7 @@ void RowGroupCollection::VerifyNewConstraint(const QueryContext &context, DataTa
 
 	// Use SCAN_COMMITTED to scan the latest data.
 	CreateIndexScanState state;
-	auto scan_type = TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED;
+	auto scan_type = TableScanType::TABLE_SCAN_OMIT_PERMANENTLY_DELETED;
 	state.Initialize(column_ids, nullptr);
 	InitializeScan(context, state.table_state, column_ids, nullptr);
 

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1156,8 +1156,7 @@ public:
 			while (true) {
 				scan_chunk.Reset();
 
-				current_row_group.Scan(scan_state.table_state, scan_chunk,
-				                                TableScanType::TABLE_SCAN_COMMITTED_ROWS);
+				current_row_group.Scan(scan_state.table_state, scan_chunk, TableScanType::TABLE_SCAN_COMMITTED_ROWS);
 				if (scan_chunk.size() == 0) {
 					break;
 				}
@@ -1872,7 +1871,7 @@ void RowGroupCollection::VerifyNewConstraint(const QueryContext &context, DataTa
 
 	while (true) {
 		scan_chunk.Reset();
-		state.table_state.ScanCommitted(scan_chunk, state.segment_lock, scan_type);
+		state.table_state.Scan(scan_chunk, scan_type, state.segment_lock);
 		if (scan_chunk.size() == 0) {
 			break;
 		}

--- a/src/storage/table/row_id_column_data.cpp
+++ b/src/storage/table/row_id_column_data.cpp
@@ -37,11 +37,6 @@ void RowIdColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t row
 
 idx_t RowIdColumnData::Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
                             idx_t scan_count) {
-	return ScanCommitted(vector_index, state, result, true, scan_count);
-}
-
-idx_t RowIdColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-                                     idx_t scan_count) {
 	return ScanCount(state, result, scan_count, 0);
 }
 
@@ -98,11 +93,6 @@ void RowIdColumnData::Filter(TransactionData transaction, idx_t vector_index, Co
 
 void RowIdColumnData::Select(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
                              SelectionVector &sel, idx_t count) {
-	SelectCommitted(vector_index, state, result, sel, count, true);
-}
-
-void RowIdColumnData::SelectCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, SelectionVector &sel,
-                                      idx_t count, bool allow_updates) {
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<row_t>(result);
 	auto row_start = state.parent->row_group->GetRowStart();

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -82,14 +82,14 @@ bool RowVersionManager::ShouldCheckpointRowGroup(transaction_t checkpoint_id, id
 	return true;
 }
 
-idx_t RowVersionManager::GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector,
-                                      idx_t max_count, ScanOptions options) {
+idx_t RowVersionManager::GetSelVector(ScanOptions options, idx_t vector_idx, SelectionVector &sel_vector,
+                                      idx_t max_count) {
 	lock_guard<mutex> l(version_lock);
 	auto chunk_info = GetChunkInfo(vector_idx);
 	if (!chunk_info) {
 		return max_count;
 	}
-	return chunk_info->GetSelVector(transaction, sel_vector, max_count, type);
+	return chunk_info->GetSelVector(options, sel_vector, max_count);
 }
 
 bool RowVersionManager::Fetch(TransactionData transaction, idx_t row) {

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -83,23 +83,13 @@ bool RowVersionManager::ShouldCheckpointRowGroup(transaction_t checkpoint_id, id
 }
 
 idx_t RowVersionManager::GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector,
-                                      idx_t max_count) {
+                                      idx_t max_count, TScanType type) {
 	lock_guard<mutex> l(version_lock);
 	auto chunk_info = GetChunkInfo(vector_idx);
 	if (!chunk_info) {
 		return max_count;
 	}
-	return chunk_info->GetSelVector(transaction, sel_vector, max_count);
-}
-
-idx_t RowVersionManager::GetCommittedSelVector(transaction_t start_time, transaction_t transaction_id, idx_t vector_idx,
-                                               SelectionVector &sel_vector, idx_t max_count) {
-	lock_guard<mutex> l(version_lock);
-	auto info = GetChunkInfo(vector_idx);
-	if (!info) {
-		return max_count;
-	}
-	return info->GetCommittedSelVector(start_time, transaction_id, sel_vector, max_count);
+	return chunk_info->GetSelVector(transaction, sel_vector, max_count, type);
 }
 
 bool RowVersionManager::Fetch(TransactionData transaction, idx_t row) {

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -83,7 +83,7 @@ bool RowVersionManager::ShouldCheckpointRowGroup(transaction_t checkpoint_id, id
 }
 
 idx_t RowVersionManager::GetSelVector(TransactionData transaction, idx_t vector_idx, SelectionVector &sel_vector,
-                                      idx_t max_count, TScanType type) {
+                                      idx_t max_count, ScanOptions options) {
 	lock_guard<mutex> l(version_lock);
 	auto chunk_info = GetChunkInfo(vector_idx);
 	if (!chunk_info) {

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -223,52 +223,41 @@ bool CollectionScanState::Scan(DuckTransaction &transaction, DataChunk &result) 
 		row_group->GetNode().Scan(transaction, *this, result);
 		if (result.size() > 0) {
 			return true;
-		} else if (max_row <= row_group->GetRowStart() + row_group->GetNode().count) {
+		}
+		if (max_row <= row_group->GetRowStart() + row_group->GetNode().count) {
 			row_group = nullptr;
 			return false;
-		} else {
-			do {
-				row_group = GetNextRowGroup(*row_group).get();
-				if (row_group) {
-					if (row_group->GetRowStart() >= max_row) {
-						row_group = nullptr;
-						break;
-					}
-					bool scan_row_group = row_group->GetNode().InitializeScan(*this, *row_group);
-					if (scan_row_group) {
-						// scan this row group
-						break;
-					}
-				}
-			} while (row_group);
 		}
-	}
-	return false;
-}
-
-bool CollectionScanState::ScanCommitted(DataChunk &result, SegmentLock &l, TableScanType type) {
-	while (row_group) {
-		row_group->GetNode().Scan(*this, result, type);
-		if (result.size() > 0) {
-			return true;
-		} else {
-			row_group = GetNextRowGroup(l, *row_group).get();
+		do {
+			row_group = GetNextRowGroup(*row_group).get();
 			if (row_group) {
-				row_group->GetNode().InitializeScan(*this, *row_group);
+				if (row_group->GetRowStart() >= max_row) {
+					row_group = nullptr;
+					break;
+				}
+				bool scan_row_group = row_group->GetNode().InitializeScan(*this, *row_group);
+				if (scan_row_group) {
+					// scan this row group
+					break;
+				}
 			}
-		}
+		} while (row_group);
 	}
 	return false;
 }
 
-bool CollectionScanState::ScanCommitted(DataChunk &result, TableScanType type) {
+bool CollectionScanState::Scan(DataChunk &result, TableScanType type, optional_ptr<SegmentLock> l) {
 	while (row_group) {
 		row_group->GetNode().Scan(*this, result, type);
 		if (result.size() > 0) {
 			return true;
 		}
-
-		row_group = GetNextRowGroup(*row_group).get();
+		// move to the next row group
+		if (l) {
+			row_group = GetNextRowGroup(*l, *row_group).get();
+		} else {
+			row_group = GetNextRowGroup(*row_group).get();
+		}
 		if (row_group) {
 			row_group->GetNode().InitializeScan(*this, *row_group);
 		}

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -248,7 +248,7 @@ bool CollectionScanState::Scan(DuckTransaction &transaction, DataChunk &result) 
 
 bool CollectionScanState::ScanCommitted(DataChunk &result, SegmentLock &l, TableScanType type) {
 	while (row_group) {
-		row_group->GetNode().ScanCommitted(*this, result, type);
+		row_group->GetNode().Scan(*this, result, type);
 		if (result.size() > 0) {
 			return true;
 		} else {
@@ -263,7 +263,7 @@ bool CollectionScanState::ScanCommitted(DataChunk &result, SegmentLock &l, Table
 
 bool CollectionScanState::ScanCommitted(DataChunk &result, TableScanType type) {
 	while (row_group) {
-		row_group->GetNode().ScanCommitted(*this, result, type);
+		row_group->GetNode().Scan(*this, result, type);
 		if (result.size() > 0) {
 			return true;
 		}

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -220,7 +220,7 @@ optional_ptr<SegmentNode<RowGroup>> CollectionScanState::GetRootSegment() const 
 
 bool CollectionScanState::Scan(DuckTransaction &transaction, DataChunk &result) {
 	while (row_group) {
-		row_group->GetNode().Scan(transaction, *this, result);
+		row_group->GetNode().Scan(TransactionData(transaction), *this, result);
 		if (result.size() > 0) {
 			return true;
 		}

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -62,17 +62,10 @@ idx_t StandardColumnData::Scan(TransactionData transaction, idx_t vector_index, 
                                idx_t target_count) {
 	D_ASSERT(state.offset_in_column == state.child_states[0].offset_in_column);
 	auto scan_type = GetVectorScanType(state, target_count, result);
-	auto mode = ScanVectorMode::REGULAR_SCAN;
-	auto scan_count = ScanVector(transaction, vector_index, state, result, target_count, scan_type, mode);
-	validity->ScanVector(transaction, vector_index, state.child_states[0], result, target_count, scan_type, mode);
-	return scan_count;
-}
-
-idx_t StandardColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-                                        idx_t target_count) {
-	D_ASSERT(state.offset_in_column == state.child_states[0].offset_in_column);
-	auto scan_count = ColumnData::ScanCommitted(vector_index, state, result, allow_updates, target_count);
-	validity->ScanCommitted(vector_index, state.child_states[0], result, allow_updates, target_count);
+	auto scan_count =
+	    ScanVector(transaction, vector_index, state, result, target_count, scan_type, state.update_scan_type);
+	validity->ScanVector(transaction, vector_index, state.child_states[0], result, target_count, scan_type,
+	                     state.update_scan_type);
 	return scan_count;
 }
 

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -167,26 +167,6 @@ idx_t StructColumnData::Scan(TransactionData transaction, idx_t vector_index, Co
 	return scan_count;
 }
 
-idx_t StructColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates,
-                                      idx_t target_count) {
-	auto scan_count = validity->ScanCommitted(vector_index, state.child_states[0], result, allow_updates, target_count);
-	IterateFields(
-	    state, [&](idx_t child_index, optional_idx field_vector_index, ColumnScanState &field_state, bool should_scan) {
-		    auto &target_vector = GetFieldVectorForScan(result, field_vector_index);
-		    if (!should_scan) {
-			    // if we are not scanning this vector - set it to NULL
-			    target_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
-			    ConstantVector::SetNull(target_vector, true);
-			    return;
-		    }
-		    auto &field = *sub_columns[child_index];
-		    ScanChild(state, target_vector, [&](Vector &child_result) {
-			    return field.ScanCommitted(vector_index, field_state, child_result, allow_updates, target_count);
-		    });
-	    });
-	return scan_count;
-}
-
 idx_t StructColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset) {
 	auto scan_count = validity->ScanCount(state.child_states[0], result, count);
 	IterateFields(

--- a/test/sql/transactions/test_index_pending_delete_rollback.test
+++ b/test/sql/transactions/test_index_pending_delete_rollback.test
@@ -1,0 +1,35 @@
+# name: test/sql/transactions/test_index_pending_delete_rollback.test
+# description: Test index with pending deletes that are rolled back
+# group: [transactions]
+
+# we can create an index with pending deletes
+statement ok con1
+CREATE TABLE integers(i INTEGER)
+
+statement ok con1
+INSERT INTO integers VALUES (1), (2), (3)
+
+# delete a value
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con2
+DELETE FROM integers WHERE i=1
+
+# we can create an index with pending deletes
+statement ok con1
+CREATE INDEX i_index ON integers using art(i)
+
+query I con2
+SELECT COUNT(*) FROM integers WHERE i=1
+----
+0
+
+# now we rollback
+statement ok con2
+ROLLBACK
+
+query I
+SELECT COUNT(*) FROM integers WHERE i=1
+----
+1


### PR DESCRIPTION
This PR cleans up the RowGroup scan code - in particular `ScanCommitted`. This method was originally intended to scan only committed rows, but had a bunch of options bolted onto it (e.g. scanning all rows including any deleted rows, only including deletes that are no longer referenced by any transactions). This also lead to a bunch of code duplication and added complexity. This PR refactors this and cleans up these methods, also removing a bunch of unnecessary / unused methods. These scans can now be performed by passing in `ScanOptions` that determines how the data should be scanned.

This was all just yak shaving when trying to fix a bug uncovered by making `BoundIndex::Delete` throw an error when attempting to delete entries from an index that were not present in the index. This PR also introduces that and fixes two issues uncovered by that change. 