### PR TITLE
Fix #20410: fix for RIGHT SEMI/ANTI - cannot fully label chain as found if there are non-equality predicates present in the join condition

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1130,10 +1130,36 @@ void ScanStructure::NextRightSemiOrAntiJoin(DataChunk &keys) {
 		// resolve the equality_predicates for this set of keys
 		idx_t result_count = ResolvePredicates(keys, chain_match_sel_vector, nullptr);
 
-		// for each match - mark the match as found
-		for (idx_t i = 0; i < result_count; i++) {
-			auto idx = chain_match_sel_vector.get_index(i);
-			Store<bool>(true, ptrs[idx] + ht.tuple_size);
+		if (ht.non_equality_predicates.empty()) {
+			// we only have equality predicates - the match is found for the entire chain
+			for (idx_t i = 0; i < result_count; i++) {
+				const auto idx = chain_match_sel_vector.get_index(i);
+				auto &ptr = ptrs[idx];
+				if (Load<bool>(ptr + ht.tuple_size)) { // Early out: chain has been fully marked as found before
+					ptr = ht.dead_end.get();
+					continue;
+				}
+
+				// Fully mark chain as found
+				while (true) {
+					// NOTE: threadsan reports this as a data race because this can be set concurrently by separate
+					// threads Technically it is, but it does not matter, since the only value that can be written is
+					// "true"
+					Store<bool>(true, ptr + ht.tuple_size);
+					auto next_ptr = LoadPointer(ptr + ht.pointer_offset);
+					if (!next_ptr) {
+						break;
+					}
+					ptr = next_ptr;
+				}
+			}
+		} else {
+			// we have non-equality predicates - we need to evaluate the join condition for every row
+			// for each match found in the current pass - mark the match as found
+			for (idx_t i = 0; i < result_count; i++) {
+				auto idx = chain_match_sel_vector.get_index(i);
+				Store<bool>(true, ptrs[idx] + ht.tuple_size);
+			}
 		}
 
 		// check the next set of pointers

--- a/test/sql/join/semianti/mix_equality_inequality.test
+++ b/test/sql/join/semianti/mix_equality_inequality.test
@@ -1,0 +1,49 @@
+# name: test/sql/join/semianti/mix_equality_inequality.test
+# description: Test SEMI/ANTI join with a mix of equality and inequality predicates
+# group: [semianti]
+
+query II
+WITH cte1 AS MATERIALIZED (
+    SELECT
+        'col1' AS col1,
+        UNNEST(
+            [TIMESTAMPTZ '2025-01-01 00:00:11+00', TIMESTAMPTZ '2025-01-01 00:00:41+00']
+        ) AS col2
+),
+cte2 AS (
+    SELECT
+        'col1' AS col1,
+        TIMESTAMPTZ '2025-01-01 00:00:40+00' AS col2,
+        'col3' AS col3,
+)
+SELECT
+    *
+FROM
+    cte1 ANTI
+    JOIN cte2 ON cte1.col1 = cte2.col1
+    AND cte1.col2 > cte2.col2;
+----
+col1	2025-01-01 00:00:11+00
+
+query II
+WITH cte1 AS MATERIALIZED (
+    SELECT
+        'col1' AS col1,
+        UNNEST(
+            [TIMESTAMPTZ '2025-01-01 00:00:11+00', TIMESTAMPTZ '2025-01-01 00:00:41+00']
+        ) AS col2
+),
+cte2 AS (
+    SELECT
+        'col1' AS col1,
+        TIMESTAMPTZ '2025-01-01 00:00:40+00' AS col2,
+        'col3' AS col3,
+)
+SELECT
+    *
+FROM
+    cte1 SEMI
+    JOIN cte2 ON cte1.col1 = cte2.col1
+    AND cte1.col2 > cte2.col2;
+----
+col1	2025-01-01 00:00:41+00


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/20410

This fixes an issue in the hash join implementation for `RIGHT_SEMI / RIGHT_ANTI`. In the previous implementation, upon finding a match, we would label the entire chain as having found that match. That is only correct when there are only equality predicates. If there are a mix of equality / inequality predicates, we need to call `ResolvePredicates` for every row in the hash table.