### PR TITLE
[ART] Iterative TransformToDeprecated

### DIFF
--- a/src/execution/index/art/node.cpp
+++ b/src/execution/index/art/node.cpp
@@ -368,8 +368,6 @@ static void TransformToDeprecatedPushChildren(ART &art, Node &node, NType type, 
 }
 
 void Node::TransformToDeprecated(ART &art, Node &node, TransformToDeprecatedState &state) {
-	D_ASSERT(node.HasMetadata());
-
 	vector<reference<Node>> stack;
 	stack.emplace_back(node);
 

--- a/src/execution/index/art/prefix_handle.cpp
+++ b/src/execution/index/art/prefix_handle.cpp
@@ -48,7 +48,7 @@ PrefixHandle PrefixHandle::NewDeprecated(FixedSizeAllocator &allocator, Node &no
 	return handle;
 }
 
-Node *PrefixHandle::TransformToDeprecated(ART &art, Node &node, TransformToDeprecatedState &state) {
+optional_ptr<Node> PrefixHandle::TransformToDeprecated(ART &art, Node &node, TransformToDeprecatedState &state) {
 	// Early-out, if we do not need any transformations.
 	if (!state.HasAllocator()) {
 		reference<Node> ref(node);
@@ -60,7 +60,7 @@ Node *PrefixHandle::TransformToDeprecated(ART &art, Node &node, TransformToDepre
 			PrefixHandle handle(art, ref);
 			ref = *handle.child;
 		}
-		return &ref.get();
+		return ref.get();
 	}
 
 	// We need to create a new prefix (chain) in the deprecated format.

--- a/src/include/duckdb/execution/index/art/node.hpp
+++ b/src/include/duckdb/execution/index/art/node.hpp
@@ -225,15 +225,6 @@ public:
 	inline void operator=(const IndexPointer &ptr) {
 		Set(ptr.Get());
 	}
-
-private:
-	template <class NODE>
-	static void TransformToDeprecatedInternal(ART &art, unsafe_optional_ptr<NODE> ptr,
-	                                          TransformToDeprecatedState &state) {
-		if (ptr) {
-			NODE::Iterator(*ptr, [&](Node &child) { Node::TransformToDeprecated(art, child, state); });
-		}
-	}
 };
 
 //! NodeChildren holds the extracted bytes of a node, and their respective children.

--- a/src/include/duckdb/execution/index/art/prefix_handle.hpp
+++ b/src/include/duckdb/execution/index/art/prefix_handle.hpp
@@ -39,7 +39,7 @@ public:
 	//! Create a new deprecated prefix node and return a handle to it.
 	static PrefixHandle NewDeprecated(FixedSizeAllocator &allocator, Node &node);
 
-	static void TransformToDeprecated(ART &art, Node &node, TransformToDeprecatedState &state);
+	static Node *TransformToDeprecated(ART &art, Node &node, TransformToDeprecatedState &state);
 
 private:
 	PrefixHandle TransformToDeprecatedAppend(ART &art, FixedSizeAllocator &allocator, const uint8_t byte);

--- a/src/include/duckdb/execution/index/art/prefix_handle.hpp
+++ b/src/include/duckdb/execution/index/art/prefix_handle.hpp
@@ -39,7 +39,10 @@ public:
 	//! Create a new deprecated prefix node and return a handle to it.
 	static PrefixHandle NewDeprecated(FixedSizeAllocator &allocator, Node &node);
 
-	static Node *TransformToDeprecated(ART &art, Node &node, TransformToDeprecatedState &state);
+	//! Transform prefix chain to deprecated format.
+	//! nullptr denotes an early out optimization (the prefix has not been loaded from storage, hence we do not need
+	//! to transform it. Otherwise, we get a pointer to the child node at the end of the prefix chain.
+	static optional_ptr<Node> TransformToDeprecated(ART &art, Node &node, TransformToDeprecatedState &state);
 
 private:
 	PrefixHandle TransformToDeprecatedAppend(ART &art, FixedSizeAllocator &allocator, const uint8_t byte);


### PR DESCRIPTION
Rewrite TransformToDeprecated to be iterative instead of recursive. This is the last piece of ART code that has to be made iterative before the key size restriction can be lifted (other than Verify and ToString, which are used for debugging. Those can also be made iterative in case the need arises to debug scenarios with long keys). 

(Some notes for the future, when this is rewritten to use node handles): Initially, I tried to rewrite this into being iterative as well as using the node handles which will be used to allow for buffer management. However I think it requires some more thought, and since this is the last piece of code to make iterative, and it is a fairly small rewrite, I thought it would be better that we can remove the key size restriction for 1.5, and pay the cost of rewriting it again using node handles later. 

The problem here was having multiple templated node handle types, and no variant type (C++17) that can easily store them on the same stack. The solution here is to probably have a wrapper for the templated nodes that can treat them all as the same type, and interpret the underlying storage accordingly (also prefix handles have a slightly different underlying layout).

It also seemed that this is similar to the ART scanner, which uses a stack for iteration. We may want something similar but for node handles, where each time we push a node handle onto the stack, that pins it in memory while we process its subchildren. Then perhaps the transform code path and other code paths can use this node handle scanner. I basically want to try rewriting some other parts of the code base to use node handles first, to see if there is some unified abstraction for scanning node handles that may be useful, before hacking something together that would work just for this code path. For example, when we do a prefix chain transform, we would need to be careful to return the PrefixHandle node, not just the child pointer, to push the prefixHandle onto the stack and keep it pinned while the child subtree is transformed. Right now we can just store nodes references since the places the node references point to are always in memory.