### PR TITLE
Write lock on install and binary copy

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -420,7 +420,7 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 					} else {
 						extended_error = AdditionalProcessInfo(*this, fl.l_pid);
 					}
-					if (flags.Lock() == FileLockType::WRITE_LOCK) {
+					if (flags.Lock() == FileLockType::WRITE_LOCK && flags.IsDatabaseFile()) {
 						// maybe we can get a read lock instead and tell this to the user.
 						fl.l_type = F_RDLCK;
 						rc = fcntl(fd, F_SETLK, &fl);

--- a/src/function/copy_blob.cpp
+++ b/src/function/copy_blob.cpp
@@ -66,7 +66,8 @@ unique_ptr<GlobalFunctionData> WriteBlobInitializeGlobal(ClientContext &context,
 	auto &bdata = bind_data.Cast<WriteBlobBindData>();
 	auto &fs = FileSystem::GetFileSystem(context);
 
-	auto flags = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW | bdata.compression_type;
+	auto flags = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW | bdata.compression_type |
+	             FileLockType::WRITE_LOCK;
 	auto handle = fs.OpenFile(file_path, flags);
 
 	auto result = make_uniq<WriteBlobGlobalState>();

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -118,11 +118,18 @@ public:
 	inline idx_t GetFlagsInternal() const {
 		return flags;
 	}
+	void SetDatabaseFile(bool _is_database = true) {
+		is_database = _is_database;
+	}
+	inline bool IsDatabaseFile() const {
+		return is_database;
+	}
 
 private:
 	idx_t flags = 0;
 	FileLockType lock = FileLockType::NO_LOCK;
 	FileCompressionType compression = FileCompressionType::UNCOMPRESSED;
+	bool is_database = false;
 };
 
 class FileFlags {

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -177,7 +177,7 @@ static unsafe_unique_array<data_t> ReadExtensionFileFromDisk(FileSystem &fs, con
 static void WriteExtensionFileToDisk(QueryContext &query_context, FileSystem &fs, const string &path, void *data,
                                      idx_t data_size) {
 	auto target_file = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_APPEND |
-	                                         FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	                                         FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileLockType::WRITE_LOCK);
 	target_file->Write(query_context, data, data_size);
 	target_file->Close();
 	target_file.reset();

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -378,7 +378,7 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 		return false;
 	}
 
-	auto handle = fs.OpenFile(filename, FileFlags::FILE_FLAGS_READ);
+	auto handle = fs.OpenFile(filename, FileFlags::FILE_FLAGS_READ | FileLockType::READ_LOCK);
 
 	// Parse the extension metadata from the extension binary
 	auto parsed_metadata = ParseExtensionMetaData(*handle);

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -271,6 +271,9 @@ FileOpenFlags SingleFileBlockManager::GetFileFlags(bool create_new) const {
 	// database files can be read from in parallel
 	result |= FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
 	result |= FileFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS;
+
+	result.SetDatabaseFile();
+
 	return result;
 }
 


### PR DESCRIPTION
Note: a retry mechanism is currently not in place, so that retry would need to be explicit user side.