### PR TITLE
Avoid directly bundling skiplist library (it's coming in with core_functions)

### DIFF
--- a/extension/core_functions/CMakeLists.txt
+++ b/extension/core_functions/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CORE_FUNCTION_FILES ${CORE_FUNCTION_FILES} core_functions_extension.cpp
                         function_list.cpp lambda_functions.cpp)
 
 build_static_extension(core_functions ${CORE_FUNCTION_FILES})
+target_link_libraries(core_functions_extension duckdb_skiplistlib)
 set(PARAMETERS "-warnings")
 build_loadable_extension(core_functions ${PARAMETERS} ${CORE_FUNCTION_FILES})
 target_link_libraries(core_functions_loadable_extension duckdb_skiplistlib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,7 +80,6 @@ set(DUCKDB_LINK_LIBS
     duckdb_utf8proc
     duckdb_hyperloglog
     duckdb_fastpforlib
-    duckdb_skiplistlib
     duckdb_mbedtls
     duckdb_yyjson
     duckdb_zstd)


### PR DESCRIPTION
Without this PR building without `core_functions` will result in compile time issues.