### PR TITLE
Expose ArenaAllocator from PlanGenerator

### DIFF
--- a/src/execution/physical_plan_generator.cpp
+++ b/src/execution/physical_plan_generator.cpp
@@ -185,4 +185,11 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalOperator &op) {
 	throw InternalException("Physical plan generator - no plan generated");
 }
 
+ArenaAllocator &PhysicalPlanGenerator::ArenaRef() {
+	if (!physical_plan) {
+		physical_plan = make_uniq<PhysicalPlan>(Allocator::Get(context));
+	}
+	return physical_plan->ArenaRef();
+}
+
 } // namespace duckdb

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -100,6 +100,10 @@ public:
 		return physical_plan->Make<T>(std::forward<ARGS>(args)...);
 	}
 
+	//! Get a reference to the ArenaAllocator of the underlying physical plan.
+	//! Creates a new (empty) physical plan if none exists yet.
+	ArenaAllocator &ArenaRef();
+
 public:
 	PhysicalOperator &ResolveDefaultsProjection(LogicalInsert &op, PhysicalOperator &child);
 


### PR DESCRIPTION
As discussed a while ago with @Tmonster / @taniabogatsch (https://github.com/duckdblabs/motherduck/issues/406), we need to expose the `ArenaAllocator` from the PlanGenerator to enable operators to create new operators during `CreatePlan`.

Namely, the set operators like Union now take multiple children in an `ArenaLinkedList`. Creating such a list is only possible if we give access to the correct arena allocator.

I'm open to feedback whether `&ArenaRef()` should create a new plan if none exists; or if it should fail with an exception.. I think there's nothing wrong with creating a new empty plan since `PlanInternal` already re-uses an existing plan.