### PR TITLE
CMake: export also duckdb_generated_extension_loader

### DIFF
--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -106,3 +106,9 @@ add_library(duckdb_generated_extension_loader OBJECT ${GENERATED_CPP_FILE})
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_generated_extension_loader>
     PARENT_SCOPE)
+
+install(
+  TARGETS duckdb_generated_extension_loader
+  EXPORT "${DUCKDB_EXPORT_SET}"
+  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")


### PR DESCRIPTION
Bumped while building duckdb-wasm, I would expect other clients or packagers of duckdb might also hit this, and fix is simple.