### PR TITLE
Reset cached dictionaries in `TRY` expression

### DIFF
--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -119,6 +119,18 @@ bool ExecuteFunctionState::TryExecuteDictionaryExpression(const BoundFunctionExp
 	return true;
 }
 
+void ExecuteFunctionState::ResetDictionaryStates() {
+
+	// Clear the cached dictionary information
+	current_input_dictionary_id.clear();
+	output_dictionary_id.clear();
+	output_dictionary.reset();
+
+	for (const auto &child_state : child_states) {
+		child_state->ResetDictionaryStates();
+	}
+}
+
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundFunctionExpression &expr,
                                                                 ExpressionExecutorState &root) {
 	auto result = make_uniq<ExecuteFunctionState>(expr, root);

--- a/src/execution/expression_executor/execute_operator.cpp
+++ b/src/execution/expression_executor/execute_operator.cpp
@@ -123,12 +123,19 @@ void ExpressionExecutor::Execute(const BoundOperatorExpression &expr, Expression
 				throw;
 			}
 		}
+
+		// On error, evaluate per row
 		SelectionVector selvec(1);
 		DataChunk intermediate;
 		intermediate.Initialize(GetAllocator(), {result.GetType()}, 1);
 		for (idx_t i = 0; i < count; i++) {
 			intermediate.Reset();
 			intermediate.SetCardinality(1);
+
+			// Make sure to clear any dictionary states in the child expression, so that it actually
+			// gets executed anew for every row
+			child_state.ResetDictionaryStates();
+
 			selvec.set_index(0, sel ? sel->get_index(i) : i);
 			Value val(result.GetType());
 			try {

--- a/src/execution/expression_executor_state.cpp
+++ b/src/execution/expression_executor_state.cpp
@@ -52,6 +52,12 @@ void ExpressionState::Verify(ExpressionExecutorState &root_executor) {
 	}
 }
 
+void ExpressionState::ResetDictionaryStates() {
+	for (const auto &child : child_states) {
+		child->ResetDictionaryStates();
+	}
+}
+
 void ExpressionExecutorState::Verify() {
 	D_ASSERT(executor);
 	root_state->Verify(*this);

--- a/src/include/duckdb/execution/expression_executor_state.hpp
+++ b/src/include/duckdb/execution/expression_executor_state.hpp
@@ -41,6 +41,9 @@ public:
 
 	void Verify(ExpressionExecutorState &root);
 
+	//! Reset any cached dictionary expression states in this expression state and its children
+	virtual void ResetDictionaryStates();
+
 public:
 	template <class TARGET>
 	TARGET &Cast() {
@@ -66,6 +69,8 @@ public:
 
 	bool TryExecuteDictionaryExpression(const BoundFunctionExpression &expr, DataChunk &args, ExpressionState &state,
 	                                    Vector &result);
+
+	void ResetDictionaryStates() override;
 
 public:
 	unique_ptr<FunctionLocalState> local_state;


### PR DESCRIPTION
So, it is possible that if you 
1. execute a TRY expression on top of 
2. a dictionary producing expression, 
3. which in turn call a function that can throw errors (but is not marked as CAN_THROW_RUNTIME_ERROR) 
4. which returns a VARCHAR/BLOB
4. and pulls its input from dictionary-producing compressed storage

You may run into a crash. This is because the "second" time the TRY expression tries to invoke the child expression row-by-row to null-out the erroring rows, the child expression doesn't get executed again because the `ExecuteFunctionState::TryExecuteDictionaryExpression` realizes that the dictionary id hasn't changed and so just returns the same selection again. If the child expression originally produced a string (but threw the exception before it could fill up all the results), the "failing" rows will contain garbage pointers causing the `TRY` executor to crash when it attempts to extract the value from the row.

An easy fix is to just reset all the cached dictionary states recursively in the child execution state when executing a `TRY` operator, which this PR implements. But you could also make the case that not marking a throwing function as "CAN_THROW_RUNTIME_ERROR" is a user (or developer error) and should rightfully lead to "undefined" behavior. But given that this flag is currently "opt in" and this crash is so specific I feel like maybe having some extra guard rails here would be worth it? But also since all of our internal/core functions do mark this properly, it's kind of impossible to write a test that triggers this (even though I ran into it when trying to debug an internal issue from a customer)

So all in all this is a bit of a weird PR, and I'm not sure if we actually want it in or not. WDYT?
