### PR TITLE
Nightly test encryption fixes

### DIFF
--- a/test/sql/storage/encryption/temp_files/encrypt_asof_join_merge.test_slow
+++ b/test/sql/storage/encryption/temp_files/encrypt_asof_join_merge.test_slow
@@ -14,9 +14,6 @@ statement ok
 SET temp_file_encryption=true;
 
 statement ok
-USE enc;
-
-statement ok
 PRAGMA memory_limit='400M'
 
 statement ok

--- a/test/sql/storage/encryption/temp_files/encrypted_tpch_join.test_slow
+++ b/test/sql/storage/encryption/temp_files/encrypted_tpch_join.test_slow
@@ -17,20 +17,17 @@ statement ok
 ATTACH '__TEST_DIR__/tpch_enc_${cipher}.db' as enc (ENCRYPTION_KEY 'asdf', ENCRYPTION_CIPHER '${cipher}');
 
 statement ok
-USE enc;
+CALL dbgen(sf = 1, catalog = 'enc');
 
 statement ok
-CALL dbgen (sf = 1) ;
+ALTER TABLE enc.lineitem RENAME TO lineitem1;
 
 statement ok
-ALTER TABLE lineitem RENAME TO lineitem1;
+CREATE TABLE enc.lineitem2 AS FROM enc.lineitem1;
 
 statement ok
-CREATE TABLE lineitem2 AS FROM lineitem1;
-
-statement ok
-CREATE OR REPLACE TABLE ans as select l1.* , l2.* from lineitem1 l1
-JOIN lineitem2 l2 USING (l_orderkey , l_linenumber);
+CREATE OR REPLACE TABLE enc.ans as select l1.* , l2.* from enc.lineitem1 l1
+JOIN enc.lineitem2 l2 USING (l_orderkey , l_linenumber);
 
 restart
 


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/7080 and other potential nightly test failures related to USE + restart in encryption tests.

Same cause as here https://github.com/duckdb/duckdb/pull/20409

Was https://github.com/duckdb/duckdb/pull/20450, now targeted to the right branch 