### PR TITLE
Fix segfault in hive partitioning with NULL values

### DIFF
--- a/data/csv/null/hive_partition_null_overwrite.csv
+++ b/data/csv/null/hive_partition_null_overwrite.csv
@@ -1,0 +1,3 @@
+id,symbol,year,month,payload
+1,,2025,9,0.1
+2,model_a,2025,9,0.2

--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -245,35 +245,13 @@ static void TemplatedGetHivePartitionValues(Vector &input, vector<HivePartitionK
 
 	const auto &type = input.GetType();
 
-	const bool reinterpret = [&]() {
-		for (idx_t i = 0; i < count; i++) {
-			const auto idx = sel.get_index(i);
-			if (validity.RowIsValid(idx)) {
-				return Value::CreateValue<T>(data[idx]).GetTypeMutable() != type;
-			}
-		}
-		return false;
-	}();
-
-	if (reinterpret) {
-		for (idx_t i = 0; i < count; i++) {
-			auto &key = keys[i];
-			const auto idx = sel.get_index(i);
-			if (validity.RowIsValid(idx)) {
-				key.values[col_idx] = GetHiveKeyValue(data[idx], type);
-			} else {
-				key.values[col_idx] = GetHiveKeyNullValue(type);
-			}
-		}
-	} else {
-		for (idx_t i = 0; i < count; i++) {
-			auto &key = keys[i];
-			const auto idx = sel.get_index(i);
-			if (validity.RowIsValid(idx)) {
-				key.values[col_idx] = GetHiveKeyValue(data[idx]);
-			} else {
-				key.values[col_idx] = GetHiveKeyNullValue(type);
-			}
+	for (idx_t i = 0; i < count; i++) {
+		auto &key = keys[i];
+		const auto idx = sel.get_index(i);
+		if (validity.RowIsValid(idx)) {
+			key.values[col_idx] = GetHiveKeyValue(data[idx], type);
+		} else {
+			key.values[col_idx] = GetHiveKeyNullValue(type);
 		}
 	}
 }

--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -245,7 +245,16 @@ static void TemplatedGetHivePartitionValues(Vector &input, vector<HivePartitionK
 
 	const auto &type = input.GetType();
 
-	const auto reinterpret = Value::CreateValue<T>(data[sel.get_index(0)]).GetTypeMutable() != type;
+	const bool reinterpret = [&]() {
+		for (idx_t i = 0; i < count; i++) {
+			const auto idx = sel.get_index(i);
+			if (validity.RowIsValid(idx)) {
+				return Value::CreateValue<T>(data[idx]).GetTypeMutable() != type;
+			}
+		}
+		return false;
+	}();
+
 	if (reinterpret) {
 		for (idx_t i = 0; i < count; i++) {
 			auto &key = keys[i];

--- a/test/sql/copy/hive_partition_null_overwrite.test
+++ b/test/sql/copy/hive_partition_null_overwrite.test
@@ -1,20 +1,4 @@
-# Regression test: avoid segfault when hive partitioning sees NULL in partition column
-# (multiple partitioned writes with OVERWRITE)
-
-statement ok
-PRAGMA threads=1;
-
 statement ok
 COPY (SELECT * FROM read_csv_auto('{DATA_DIR}/csv/null/hive_partition_null_overwrite.csv'))
 TO '{TEST_DIR}/repro_min'
 (FORMAT csv, PARTITION_BY (symbol, year, month), OVERWRITE);
-
-statement ok
-COPY (SELECT * FROM read_csv_auto('{DATA_DIR}/csv/null/hive_partition_null_overwrite.csv'))
-TO '{TEST_DIR}/repro_min'
-(FORMAT csv, PARTITION_BY (symbol, year, month), OVERWRITE);
-
-query I
-SELECT 42;
-----
-42

--- a/test/sql/copy/hive_partition_null_overwrite.test
+++ b/test/sql/copy/hive_partition_null_overwrite.test
@@ -1,0 +1,20 @@
+# Regression test: avoid segfault when hive partitioning sees NULL in partition column
+# (multiple partitioned writes with OVERWRITE)
+
+statement ok
+PRAGMA threads=1;
+
+statement ok
+COPY (SELECT * FROM read_csv_auto('{DATA_DIR}/csv/null/hive_partition_null_overwrite.csv'))
+TO '{TEST_DIR}/repro_min'
+(FORMAT csv, PARTITION_BY (symbol, year, month), OVERWRITE);
+
+statement ok
+COPY (SELECT * FROM read_csv_auto('{DATA_DIR}/csv/null/hive_partition_null_overwrite.csv'))
+TO '{TEST_DIR}/repro_min'
+(FORMAT csv, PARTITION_BY (symbol, year, month), OVERWRITE);
+
+query I
+SELECT 42;
+----
+42

--- a/test/sql/copy/hive_partition_null_overwrite.test
+++ b/test/sql/copy/hive_partition_null_overwrite.test
@@ -1,3 +1,6 @@
+# name: test/sql/copy/hive_partition_null_overwrite.test
+# group: [copy]
+
 statement ok
 COPY (SELECT * FROM read_csv_auto('{DATA_DIR}/csv/null/hive_partition_null_overwrite.csv'))
 TO '{TEST_DIR}/repro_min'


### PR DESCRIPTION
This PR fixes a segfault in DuckDB core when running COPY … PARTITION_BY … OVERWRITE with NULL partition values. The issue was reported in duckdb-python but reproduced in the DuckDB CLI. Adds a minimal regression test. CI passes on fork.

Fixes https://github.com/duckdb/duckdb-python/issues/127
