### PR TITLE
Skip concurrent_encrypted_attach due to race in autoloading httpfs

### DIFF
--- a/test/sql/copy/encryption/concurrent_encrypted_attach.test
+++ b/test/sql/copy/encryption/concurrent_encrypted_attach.test
@@ -3,6 +3,8 @@
 
 require httpfs
 
+require no_extension_autoloading "FIXME: there are timing issues in autoloading httpfs"
+
 concurrentloop i 0 10
 
 statement ok


### PR DESCRIPTION
Longer discussion at https://github.com/duckdblabs/duckdb-internal/issues/6813#issuecomment-3729579534, for now skipping in autoloading mode.