### PR TITLE
rewrite unaligned scan

### DIFF
--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -296,14 +296,20 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 	while (pos < scan_count) {
 		validity_t input_mask = input_data[input_entry];
 		idx_t bits_left = scan_count - pos;
+
+		// these are bits left within the current entries (possibly extra than what we need).
 		idx_t input_bits_left = ValidityMask::BITS_PER_VALUE - input_idx;
 		idx_t result_bits_left = ValidityMask::BITS_PER_VALUE - result_idx;
+
+		// these are the bits left within the current entries that need to be processed.
 		idx_t input_window_size = MinValue(bits_left, input_bits_left);
 		idx_t result_window_size = MinValue(bits_left, result_bits_left);
+
+		// the smaller of the two is our next window to copy from input to result.
 		idx_t window_size = MinValue(input_window_size, result_window_size);
 
 		// Now within each loop iteration, we can think of the general case that handles all scenarios as just
-		// copying one window from input into an equal sized window in the result.
+		// copying the window from the starting index in input to the window in the starting index of result.
 
 		// First, line up the windows:
 		if (result_idx < input_idx) {
@@ -369,9 +375,11 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 		// Now update pos, entries, and indexes for the next iteration.
 		pos += window_size;
 
+		// Windows can only go until the end of the current entry, so the mod can only wrap to 0 here.
 		input_idx = (input_idx + window_size) % ValidityMask::BITS_PER_VALUE;
 		result_idx = (result_idx + window_size) % ValidityMask::BITS_PER_VALUE;
 
+		// Advance entries if the mod was 0.
 		if (input_idx == 0) {
 			input_entry++;
 		}

--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -269,7 +269,7 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 	// and to do this using bit operations on 64 bit fields.
 	//
 	// On each loop iteration, we are inspecting a 64 bit field in both the input and result, starting at a certain
-	// index (in the code, these are denoted by input(result)_entry and input(result)index, respectively.
+	// index (in the code, these are denoted by input(result)_entry and input(result)_index, respectively.
 	//
 	// For example, on the first loop iteration for the diagram, both entries are entry 0, and the starting indexes are
 	// the index of window 1 in each entry.
@@ -314,7 +314,7 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 			// |XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX[=============WINDOW=============]XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
 			// +--------------------------------------------------------------------------------------------------+
 			// 								                                     ^
-			// 						                                     current_input_idx
+			// 						                                         input_idx
 			//
 			// RESULT ENTRY:
 			// 63                                                                                                 0
@@ -322,7 +322,7 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 			// |PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP[=============WINDOW=============]PPPPPPPPPPPPPPPPPPPPPP|
 			// +--------------------------------------------------------------------------------------------------+
 			// 										                                       ^
-			// 								                                       current_result_idx
+			// 								                                           result_idx
 			//
 			idx_t shift_amount = input_idx - result_idx;
 			input_mask = input_mask >> shift_amount;
@@ -341,7 +341,7 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 			// |000000000000XXXXXXXXXXXXXXXXXXXX[=============WINDOW=============]XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
 			// +--------------------------------------------------------------------------------------------------+
 			// 																     ^
-			// 											                  current_input_idx
+			// 											                     input_idx
 			//
 			// RESULT ENTRY:
 			// 63                                                                                                 0
@@ -349,7 +349,7 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 			// |PPPPPPPPPPPPPPPPPPPP[=============WINDOW=============]PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP|
 			// +--------------------------------------------------------------------------------------------------+
 			// 													     ^
-			// 									              current_result_idx
+			// 									                 result_idx
 			input_mask = input_mask << shift_amount;
 		}
 


### PR DESCRIPTION
This is a fix for https://github.com/duckdblabs/duckdb-internal/issues/6821 - the issue was that the unaligned scan was corrupting bits in the result mask not in the scan range. However it seemed there may have been more edge cases that may not have been covered when I was looking at the code, so I ended up rewriting the function with a different way of thinking about the logic, which handles all possible edge cases. 

The way to reason about the correctness here is to decompose it into the overall window scan loop of the algorithm, i.e. define how the loop works, and within each loop define the bit shifting operation that needs to happen. 

The overarching loop is scanning over same size "windows" in 64 bit fields. Input_window and result_window are defined as the current respective starting point to the end of the current bit field ("entry") (or earlier, if the range of bits we are copying ends within the current bitfield). Since the scans are unaligned, but we only want to look at one bitfield at a time for each, we necessarily have to take the smaller of the two, and copy that number of bits over from the input to result. The smaller of the two is the current "window", i.e. the first loop iteration is window 1 in the diagram, the next iteration is window 2. 

Then, within each loop iteration, we are just copying one window to another which is simple to reason about in terms of bit masking/operations. 

edit: it would also be possible to make each loop iteration branchless, but it would be quite convoluted and I don't think it's worth the effort since we're only copying a max of 2048 bits here I think. It would basically require figuring out how many windows there are, doing one before the loop if there are an odd number of windows, then having two cases where the loop either shifts left then right on each loop iteration, or shifts right then left. 

```cpp
// INPUT:
//  0                             63|                             127|                             191
//  +-------------------------------+--------------------------------+--------------------------------+
//  |                      [   1   ]|[          2         ][   3    ]|[          4         ][   5   ]|
//  +-------------------------------+--------------------------------+--------------------------------+
//
//  RESULT:
//  0                             63|                             127|                             191
//  +-------------------------------+--------------------------------+--------------------------------+
//   [   1   ][          2         ]|[   3    ][          4         ]|[   5    ]                      |
//  +-------------------------------+--------------------------------+--------------------------------+
```