### PR TITLE
Add hook for extensions to plan lateral joins

### DIFF
--- a/src/include/duckdb/optimizer/optimizer_extension.hpp
+++ b/src/include/duckdb/optimizer/optimizer_extension.hpp
@@ -31,6 +31,15 @@ struct OptimizerExtensionInput {
 typedef void (*optimize_function_t)(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
 typedef void (*pre_optimize_function_t)(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
 
+struct PlanExtensionInput {
+	Binder &binder;
+	optional_ptr<OptimizerExtensionInfo> info;
+};
+
+// Callback when planning. Return true if the extension has modified the plan and no additional
+// extension planners should be called at this time.
+typedef bool (*extension_planner_function_t)(PlanExtensionInput &input, unique_ptr<LogicalOperator> &plan);
+
 class OptimizerExtension {
 public:
 	//! The optimize function of the optimizer extension.
@@ -41,6 +50,9 @@ public:
 	//! Takes a logical query plan as an input, which it can modify in place
 	//! This runs, before the DuckDB optimizers have run
 	pre_optimize_function_t pre_optimize_function = nullptr;
+
+	//! Called when planning a LATERAL JOIN
+	extension_planner_function_t plan_lateral_join_function = nullptr;
 
 	//! Additional optimizer info passed to the optimize functions
 	shared_ptr<OptimizerExtensionInfo> optimizer_info;

--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/function/scalar/generic_functions.hpp"
 #include "duckdb/function/scalar/struct_functions.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
 
 namespace duckdb {
@@ -440,7 +441,8 @@ void Binder::PlanSubqueries(unique_ptr<Expression> &expr_ptr, unique_ptr<Logical
 }
 
 static void TryPlanExtensionLateralJoin(Binder &binder, unique_ptr<LogicalOperator> &plan) {
-	for (auto &optimizer : binder.context.db->config.optimizer_extensions) {
+	auto &config = DBConfig::GetConfig(binder.context);
+	for (auto &optimizer : config.optimizer_extensions) {
 		if (optimizer.plan_lateral_join_function) {
 			PlanExtensionInput input {binder, optimizer.optimizer_info};
 			bool modified = optimizer.plan_lateral_join_function(input, plan);


### PR DESCRIPTION
Both vss and spatial does (and wants to do) KNN-style lateral join optimizations to find the closest vectors/closest geometries. Right now this is implemented in an [extremely complex and fragile way in vss](https://github.com/duckdb/duckdb-vss/blob/d796205e45ba38f894fb16bbbf1b89374d3be2e5/src/hnsw/hnsw_optimize_join.cpp#L352-L700) using a optimizer extension that tries to fold-back the resulting duplicate-eliminated join, but this is easy to break in very subtle ways (e.g. the optimization now conflicts with https://github.com/duckdb/duckdb/pull/19280) and is in general a lot of pain to maintain. 

This PR adds a hook in the ExtensionOptimizer class to participate in planning a a much earlier point when the lateral join is still a "LogicalDependentJoin", optimizers haven't been applied and the delim-join-window-rewrite that we normally do for lateral joins hasn't completely exploded the plan.

In the future we may want to add other hooks like this for e.g. regular JOIN planning.

