### PR TITLE
Fix Issue #20233: Fix function chain in having

### DIFF
--- a/src/include/duckdb/planner/expression_binder/having_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/having_binder.hpp
@@ -27,6 +27,8 @@ protected:
 
 	unique_ptr<ParsedExpression> QualifyColumnName(ColumnRefExpression &col_ref, ErrorData &error) override;
 
+	bool DoesColumnAliasExist(const ColumnRefExpression &colref) override;
+
 private:
 	ColumnAliasBinder column_alias_binder;
 	AggregateHandling aggregate_handling;

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -15,6 +15,10 @@ HavingBinder::HavingBinder(Binder &binder, ClientContext &context, BoundSelectNo
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }
 
+bool HavingBinder::DoesColumnAliasExist(const ColumnRefExpression &colref) {
+	return column_alias_binder.DoesColumnAliasExist(colref);
+}
+
 BindResult HavingBinder::BindLambdaReference(LambdaRefExpression &expr, idx_t depth) {
 	D_ASSERT(lambda_bindings && expr.lambda_idx < lambda_bindings->size());
 	auto &lambda_ref = expr.Cast<LambdaRefExpression>();

--- a/test/sql/binder/alias_qualification_having.test
+++ b/test/sql/binder/alias_qualification_having.test
@@ -58,7 +58,7 @@ c	4
 
 query II
 FROM VALUES ('CS', 'Bachelor'), ('CS', 'Bachelor'), ('CS', 'PhD'), ('Math', 'Masters') AS t(c1, c2)
-SELECT c1, STRING_AGG(c2, ',') as c3
+SELECT c1, STRING_AGG(c2, ',' order by c2) as c3
 GROUP BY c1
 HAVING len(c3) > 7
 ----
@@ -67,7 +67,7 @@ CS	Bachelor,Bachelor,PhD
 
 query II
 FROM VALUES ('CS', 'Bachelor'), ('CS', 'Bachelor'), ('CS', 'PhD'), ('Math', 'Masters') AS t(c1, c2)
-SELECT c1, STRING_AGG(c2, ',') as c3
+SELECT c1, STRING_AGG(c2, ',' order by c2) as c3
 GROUP BY c1
 HAVING c3.len() > 7
 ----

--- a/test/sql/binder/alias_qualification_having.test
+++ b/test/sql/binder/alias_qualification_having.test
@@ -49,3 +49,26 @@ HAVING alias.c = 2
 ORDER BY x;
 ----
 1	2
+
+query II
+SELECT c1, sum(c2) as c3 FROM VALUES ('a', 1), ('b', 2), ('b', 3), ('c', 4), ('d', null) AS t(c1, c2) group by c1 having c3.add(1) > 2 order by c1;
+----
+b	5
+c	4
+
+query II
+FROM VALUES ('CS', 'Bachelor'), ('CS', 'Bachelor'), ('CS', 'PhD'), ('Math', 'Masters') AS t(c1, c2)
+SELECT c1, STRING_AGG(c2, ',') as c3
+GROUP BY c1
+HAVING len(c3) > 7
+----
+CS	Bachelor,Bachelor,PhD
+
+
+query II
+FROM VALUES ('CS', 'Bachelor'), ('CS', 'Bachelor'), ('CS', 'PhD'), ('Math', 'Masters') AS t(c1, c2)
+SELECT c1, STRING_AGG(c2, ',') as c3
+GROUP BY c1
+HAVING c3.len() > 7
+----
+CS	Bachelor,Bachelor,PhD


### PR DESCRIPTION
This PR try fixes issue: https://github.com/duckdb/duckdb/issues/20233
this issue `function chain in qualify` has been fixed. but the comments on this issue added that the problem also exists in `having`.

example sql
```
FROM VALUES ('CS', 'Bachelor'), ('CS', 'Bachelor'), ('CS', 'PhD'), ('Math', 'Masters') AS t(c1, c2)
SELECT c1, STRING_AGG(c2, ',') as c3
GROUP BY c1
HAVING c3.len() > 7
```

it will throw error
```
Binder Error:
Referenced column "c3" not found in FROM clause!
Candidate bindings: "c1", "c2"
```

i think the fix code is similar to `qualify`. thanks~~~