### PR TITLE
[Fix] Directly retrieve the logical column index during `MERGE INTO` binding

### DIFF
--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -392,9 +392,10 @@ unique_ptr<MergeIntoStatement> Binder::GenerateMergeInto(InsertStatement &stmt, 
 				named_column_map.push_back(col.Logical());
 			}
 		} else {
+			// Ensure that the columns are valid.
 			for (auto &col_name : stmt.columns) {
-				auto &col = table.GetColumn(col_name);
-				named_column_map.push_back(col.Logical());
+				auto col_idx = table.GetColumnIndex(col_name);
+				named_column_map.push_back(col_idx);
 			}
 		}
 		ExpandDefaultInValuesList(stmt, table, values_list, named_column_map);

--- a/test/sql/merge/merge_into.test
+++ b/test/sql/merge/merge_into.test
@@ -3,9 +3,6 @@
 # group: [merge]
 
 statement ok
-PRAGMA enable_verification
-
-statement ok
 CREATE TABLE Stock(item_id int, balance int);
 
 statement ok

--- a/test/sql/merge/merge_into_invalid_column.test
+++ b/test/sql/merge/merge_into_invalid_column.test
@@ -1,0 +1,11 @@
+# name: test/sql/merge/merge_into_invalid_column.test
+# description: Test MERGE INTO via UPSERT with an invalid column
+# group: [merge]
+
+statement ok
+CREATE TABLE v0 (v1 INTEGER PRIMARY KEY);
+
+statement error
+INSERT INTO v0(x) VALUES (2) ON CONFLICT DO NOTHING;
+----
+<REGEX>:Binder Error.*does not have a column with name.*


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/20476