### PR TITLE
Don't lower case save_location of profiling

### DIFF
--- a/src/function/table/system/enable_profiling.cpp
+++ b/src/function/table/system/enable_profiling.cpp
@@ -78,7 +78,7 @@ static unique_ptr<FunctionData> BindEnableProfiling(ClientContext &context, Tabl
 			bind_data->coverage = StringUtil::Lower(named_param.second.ToString());
 			break;
 		case ProfilingParameterNames::SAVE_LOCATION:
-			bind_data->save_location = StringUtil::Lower(named_param.second.ToString());
+			bind_data->save_location = named_param.second.ToString();
 			break;
 		case ProfilingParameterNames::MODE:
 			bind_data->mode = StringUtil::Lower(named_param.second.ToString());


### PR DESCRIPTION
I saw that test "test/sql/pragma/profiling/call_enable_profiling_function.test" was failing becausae the save location of profiling doesn't match the expected path.

Currently, the path is saved after lower-casing it. Therefore, this does not match the expected `__TEST_DIR__/other_file.txt`. This PR saves save_location as is to the bind data.

```
statement ok
CALL enable_profiling(save_location='__TEST_DIR__/other_file.txt')

# fails here because /users/jeewonheo/... <> /Users/jeewonheo/...
query I
SELECT CURRENT_SETTING('profiling_output');
----
__TEST_DIR__/other_file.txt 
```