### PR TITLE
[Copy] Fix #20324 `partition_by` option binding

### DIFF
--- a/src/include/duckdb/planner/expression_binder/table_function_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/table_function_binder.hpp
@@ -17,7 +17,13 @@ class TableFunctionBinder : public ExpressionBinder {
 public:
 	TableFunctionBinder(Binder &binder, ClientContext &context, string table_function_name = string(),
 	                    string clause = "Table function");
-
+public:
+	void DisableSQLValueFunctions() {
+		accept_sql_value_functions = false;
+	}
+	void EnableSQLValueFunctions() {
+		accept_sql_value_functions = true;
+	}
 protected:
 	BindResult BindLambdaReference(LambdaRefExpression &expr, idx_t depth);
 	BindResult BindColumnReference(unique_ptr<ParsedExpression> &expr, idx_t depth, bool root_expression);
@@ -28,6 +34,8 @@ protected:
 private:
 	string table_function_name;
 	string clause;
+	//! Whether sql_value_functions (GetSQLValueFunctionName) are considered when binding column refs
+	bool accept_sql_value_functions = true;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/table_function_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/table_function_binder.hpp
@@ -17,6 +17,7 @@ class TableFunctionBinder : public ExpressionBinder {
 public:
 	TableFunctionBinder(Binder &binder, ClientContext &context, string table_function_name = string(),
 	                    string clause = "Table function");
+
 public:
 	void DisableSQLValueFunctions() {
 		accept_sql_value_functions = false;
@@ -24,6 +25,7 @@ public:
 	void EnableSQLValueFunctions() {
 		accept_sql_value_functions = true;
 	}
+
 protected:
 	BindResult BindLambdaReference(LambdaRefExpression &expr, idx_t depth);
 	BindResult BindColumnReference(unique_ptr<ParsedExpression> &expr, idx_t depth, bool root_expression);

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -422,10 +422,20 @@ vector<Value> BindCopyOption(ClientContext &context, TableFunctionBinder &option
 			return result;
 		}
 	}
+	const bool is_partition_by = StringUtil::CIEquals(name, "partition_by");
+
+	if (is_partition_by) {
+		//! When binding the 'partition_by' option, we don't want to resolve a column reference to a SQLValueFunction (like 'user')
+		option_binder.DisableSQLValueFunctions();
+	}
 	auto bound_expr = option_binder.Bind(expr);
 	if (bound_expr->HasParameter()) {
 		throw ParameterNotResolvedException();
 	}
+	if (is_partition_by) {
+		option_binder.EnableSQLValueFunctions();
+	}
+
 	auto val = ExpressionExecutor::EvaluateScalar(context, *bound_expr, true);
 	if (val.IsNull()) {
 		throw BinderException("NULL is not supported as a valid option for COPY option \"" + name + "\"");

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -425,7 +425,8 @@ vector<Value> BindCopyOption(ClientContext &context, TableFunctionBinder &option
 	const bool is_partition_by = StringUtil::CIEquals(name, "partition_by");
 
 	if (is_partition_by) {
-		//! When binding the 'partition_by' option, we don't want to resolve a column reference to a SQLValueFunction (like 'user')
+		//! When binding the 'partition_by' option, we don't want to resolve a column reference to a SQLValueFunction
+		//! (like 'user')
 		option_binder.DisableSQLValueFunctions();
 	}
 	auto bound_expr = option_binder.Bind(expr);

--- a/src/planner/expression_binder/table_function_binder.cpp
+++ b/src/planner/expression_binder/table_function_binder.cpp
@@ -51,9 +51,11 @@ BindResult TableFunctionBinder::BindColumnReference(unique_ptr<ParsedExpression>
 		}
 	}
 
-	auto value_function = ExpressionBinder::GetSQLValueFunction(column_names.back());
-	if (value_function) {
-		return BindExpression(value_function, depth, root_expression);
+	if (accept_sql_value_functions) {
+		auto value_function = ExpressionBinder::GetSQLValueFunction(column_names.back());
+		if (value_function) {
+			return BindExpression(value_function, depth, root_expression);
+		}
 	}
 	if (table_function_name.empty()) {
 		throw BinderException(query_location,

--- a/test/sql/copy/parquet/partition_by_bind_issues.test
+++ b/test/sql/copy/parquet/partition_by_bind_issues.test
@@ -1,3 +1,6 @@
+# name: test/sql/copy/parquet/partition_by_bind_issues.test
+# group: [parquet]
+
 require parquet
 
 statement ok

--- a/test/sql/copy/parquet/partition_by_bind_issues.test
+++ b/test/sql/copy/parquet/partition_by_bind_issues.test
@@ -1,0 +1,22 @@
+require parquet
+
+statement ok
+CREATE TABLE test AS SELECT
+	'test' AS user,
+	'2025' AS year,
+	'01' AS month,
+	'01' AS day,
+	'123' AS run_id,
+	'test' AS payload;
+
+# 'user' is also the name of a SQLValueFunction, this used to bind incorrectly (#20324)
+statement ok
+COPY (
+	SELECT
+		*
+	FROM
+		test
+) TO './test.parquet' (
+	FORMAT PARQUET,
+	PARTITION_BY user
+)

--- a/test/sql/copy/parquet/partition_by_bind_issues.test
+++ b/test/sql/copy/parquet/partition_by_bind_issues.test
@@ -3,11 +3,7 @@ require parquet
 statement ok
 CREATE TABLE test AS SELECT
 	'test' AS user,
-	'2025' AS year,
-	'01' AS month,
-	'01' AS day,
-	'123' AS run_id,
-	'test' AS payload;
+	'2025' AS year
 
 # 'user' is also the name of a SQLValueFunction, this used to bind incorrectly (#20324)
 statement ok
@@ -16,7 +12,12 @@ COPY (
 		*
 	FROM
 		test
-) TO './test.parquet' (
+) TO '__TEST_DIR__/partition_by_test.parquet' (
 	FORMAT PARQUET,
 	PARTITION_BY user
 )
+
+query II
+select * from '__TEST_DIR__/partition_by_test.parquet'
+----
+2025	test


### PR DESCRIPTION
This PR fixes #20324

The `PARTITION_BY` copy option used to be able to bind to SQLValueFunctions (like `user`), this PR fixes that problem.