### PR TITLE
Respect __HIVE_DEFAULT_PARTITION__ for null values per Hive standard

### DIFF
--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -126,7 +126,7 @@ std::map<string, string> HivePartitioning::Parse(const string &filename) {
 Value HivePartitioning::GetValue(ClientContext &context, const string &key, const string &str_val,
                                  const LogicalType &type) {
 	// Handle nulls
-	if (StringUtil::CIEquals(str_val, "NULL")) {
+	if (StringUtil::CIEquals(str_val, "NULL") || str_val == "__HIVE_DEFAULT_PARTITION__") {
 		return Value(type);
 	}
 	if (type.id() == LogicalTypeId::VARCHAR) {

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -120,7 +120,11 @@ public:
 				string p_dir;
 				p_dir += HivePartitioning::Escape(partition_col_name);
 				p_dir += "=";
-				p_dir += HivePartitioning::Escape(partition_value.ToString());
+				if (partition_value.IsNull()) {
+					p_dir += "__HIVE_DEFAULT_PARTITION__";
+				} else {
+					p_dir += HivePartitioning::Escape(partition_value.ToString());
+				}
 				path = fs.JoinPath(path, p_dir);
 				CreateDir(path, fs);
 			}

--- a/test/sql/copy/parquet/parquet_hive_null.test
+++ b/test/sql/copy/parquet/parquet_hive_null.test
@@ -51,12 +51,17 @@ ORDER BY ALL
 NULL	NULL	NULL
 
 # Test __HIVE_DEFAULT_PARTITION__ is treated as NULL when reading
+# First create the nested directory structure using a dummy partitioned write
+statement ok
+copy (select 0 as c, NULL::INT as a, NULL::INT as b) to '__TEST_DIR__/hive-default-partition-test' (PARTITION_BY (a, b), FORMAT 'parquet', OVERWRITE);
+
+# Now overwrite the file in that directory to test reading __HIVE_DEFAULT_PARTITION__
 statement ok
 copy (select 1 as c) to '__TEST_DIR__/hive-default-partition-test/a=__HIVE_DEFAULT_PARTITION__/b=__HIVE_DEFAULT_PARTITION__/data.parquet' (FORMAT 'parquet');
 
 query III
 select *
-from parquet_scan('__TEST_DIR__/hive-default-partition-test/**/*.parquet', hive_partitioning=1, hive_types={'a': INT, 'b': INT})
+from parquet_scan('__TEST_DIR__/hive-default-partition-test/a=__HIVE_DEFAULT_PARTITION__/b=__HIVE_DEFAULT_PARTITION__/data.parquet', hive_partitioning=1, hive_types={'a': INT, 'b': INT})
 ORDER BY ALL
 ----
 1	NULL	NULL

--- a/test/sql/copy/parquet/parquet_hive_null.test
+++ b/test/sql/copy/parquet/parquet_hive_null.test
@@ -49,3 +49,35 @@ ORDER BY ALL
 8	3	0
 9	4	1
 NULL	NULL	NULL
+
+# Test __HIVE_DEFAULT_PARTITION__ is treated as NULL when reading
+statement ok
+copy (select 1 as c) to '__TEST_DIR__/hive-default-partition-test/a=__HIVE_DEFAULT_PARTITION__/b=__HIVE_DEFAULT_PARTITION__/data.parquet' (FORMAT 'parquet');
+
+query III
+select *
+from parquet_scan('__TEST_DIR__/hive-default-partition-test/**/*.parquet', hive_partitioning=1, hive_types={'a': INT, 'b': INT})
+ORDER BY ALL
+----
+1	NULL	NULL
+
+# Test that NULL values are written as __HIVE_DEFAULT_PARTITION__
+statement ok
+create table test_null_write as select 1 as c, NULL::INT as a, NULL::INT as b;
+
+statement ok
+copy test_null_write to '__TEST_DIR__/hive-null-write-test' (PARTITION_BY (a,b), FORMAT 'parquet');
+
+# Verify we can read the data back (proves __HIVE_DEFAULT_PARTITION__ is used and read correctly)
+query III
+select *
+from parquet_scan('__TEST_DIR__/hive-null-write-test/**/*.parquet', hive_partitioning=1, hive_types={'a': INT, 'b': INT})
+ORDER BY ALL
+----
+1	NULL	NULL
+
+# Verify the directory structure uses __HIVE_DEFAULT_PARTITION__
+query I
+select count(*) from glob('__TEST_DIR__/hive-null-write-test/a=__HIVE_DEFAULT_PARTITION__/b=__HIVE_DEFAULT_PARTITION__/*.parquet');
+----
+1


### PR DESCRIPTION
Resolves https://github.com/duckdb/duckdb/issues/19189, https://github.com/duckdb/duckdb/discussions/11809

On both read and write, we currently use `NULL` in lieu of the designated `__HIVE_DEFAULT_PARTITION__`, leading to compatibility issues with engines like Spark. Currently, to read Spark- or Polars-written hive-partitioned datasets in DuckDB, the user has to do a bit acrobatics with their query, something like

```sql
CREATE VIEW repaired AS
WITH raw AS (
    SELECT * FROM read_parquet(<files>)
)
SELECT raw.* REPLACE(
    TRY_CAST(NULLIF(<col>, '__HIVE_DEFAULT_PARTITION__') AS INT) AS <col>
)
FROM raw;
```