### PR TITLE
Revert "Remove pointer indirection in ExtAccess"

### DIFF
--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -882,9 +882,9 @@ def create_duckdb_c_ext_h(file, ext_api_version, function_groups, api_struct_def
 	    DUCKDB_CAPI_ENTRY_VISIBILITY DUCKDB_EXTENSION_API bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api)(\
 	    duckdb_extension_info info, struct duckdb_extension_access *access) {\
 		DUCKDB_EXTENSION_API_INIT(info, access, DUCKDB_EXTENSION_API_VERSION_STRING);\
-		duckdb_database db = access->get_database(info);\
+		duckdb_database *db = access->get_database(info);\
 		duckdb_connection conn;\
-		if (duckdb_connect(db, &conn) == DuckDBError) {\
+		if (duckdb_connect(*db, &conn) == DuckDBError) {\
 			access->set_error(info, "Failed to open connection to database");\
 			return false;\
 		}\

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -903,7 +903,7 @@ struct duckdb_extension_access {
 	//! Indicate that an error has occurred.
 	void (*set_error)(duckdb_extension_info info, const char *error);
 	//! Fetch the database on which to register the extension.
-	duckdb_database (*get_database)(duckdb_extension_info info);
+	duckdb_database *(*get_database)(duckdb_extension_info info);
 	//! Fetch the API struct pointer.
 	const void *(*get_api)(duckdb_extension_info info, const char *version);
 };

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -902,7 +902,7 @@ struct duckdb_extension_access {
 	//! Indicate that an error has occurred.
 	void (*set_error)(duckdb_extension_info info, const char *error);
 	//! Fetch the database on which to register the extension.
-	duckdb_database (*get_database)(duckdb_extension_info info);
+	duckdb_database *(*get_database)(duckdb_extension_info info);
 	//! Fetch the API struct pointer.
 	const void *(*get_api)(duckdb_extension_info info, const char *version);
 };

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -1416,9 +1416,9 @@ typedef struct {
 	DUCKDB_EXTENSION_EXTERN_C_GUARD_OPEN DUCKDB_CAPI_ENTRY_VISIBILITY DUCKDB_EXTENSION_API bool DUCKDB_EXTENSION_GLUE( \
 	    DUCKDB_EXTENSION_NAME, _init_c_api)(duckdb_extension_info info, struct duckdb_extension_access * access) {     \
 		DUCKDB_EXTENSION_API_INIT(info, access, DUCKDB_EXTENSION_API_VERSION_STRING);                                  \
-		duckdb_database db = access->get_database(info);                                                               \
+		duckdb_database *db = access->get_database(info);                                                              \
 		duckdb_connection conn;                                                                                        \
-		if (duckdb_connect(db, &conn) == DuckDBError) {                                                                \
+		if (duckdb_connect(*db, &conn) == DuckDBError) {                                                               \
 			access->set_error(info, "Failed to open connection to database");                                          \
 			return false;                                                                                              \
 		}                                                                                                              \

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -81,14 +81,14 @@ struct ExtensionAccess {
 	}
 
 	//! Called by the extension get a pointer to the database that is loading it
-	static duckdb_database GetDatabase(duckdb_extension_info info) {
+	static duckdb_database *GetDatabase(duckdb_extension_info info) {
 		auto &load_state = DuckDBExtensionLoadState::Get(info);
 
 		try {
 			// Create the duckdb_database
 			load_state.database_data = make_uniq<DatabaseWrapper>();
 			load_state.database_data->database = make_shared_ptr<DuckDB>(load_state.db);
-			return reinterpret_cast<duckdb_database>(load_state.database_data.get());
+			return reinterpret_cast<duckdb_database *>(load_state.database_data.get());
 		} catch (std::exception &ex) {
 			load_state.has_error = true;
 			load_state.error_data = ErrorData(ex);


### PR DESCRIPTION
This reverts commit ef2d693b873924d2600714872912b69519f2ed8f.

While the change introduced in #19529 is not a breaking change for C/C++ extensions, it was discovered that it can cause problems for other language extensions that use C API.

Ref: duckdblabs/duckdb-internal#6369