### PR TITLE
TryRemoveFile should be robust to file being removed out of band

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -568,8 +568,12 @@ void FileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> ope
 
 bool FileSystem::TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
 	if (FileExists(filename, opener)) {
-		RemoveFile(filename, opener);
-		return true;
+		try {
+			RemoveFile(filename, opener);
+			return true;
+		} catch (...) {
+			return false;
+		}
 	}
 	return false;
 }


### PR DESCRIPTION
Current code assumes that if file is there, then RemoveFile should happens without throws, but that's not the case if a separate instance happens to be trying to remove the same file. Depending on timings, both can have FileExists return true, but then one will actually be successful in removing, while the other will throw.
I think having TryRemoveFile try-catch is OK, and caller could check return value to check wheter operation was successful.