### PR TITLE
Bump: excel

### DIFF
--- a/.github/config/extensions/excel.cmake
+++ b/.github/config/extensions/excel.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(excel
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-excel
-    GIT_TAG 8504be9ec8183e4082141f9359b53a64d3a440b7
+    GIT_TAG 9421a2d75bd7544336caa73e5f9e6063cc7f6992
     INCLUDE_DIR src/excel/include
     )

--- a/.github/config/extensions/vss.cmake
+++ b/.github/config/extensions/vss.cmake
@@ -2,6 +2,6 @@ duckdb_extension_load(vss
         LOAD_TESTS
         DONT_LINK
         GIT_URL https://github.com/duckdb/duckdb-vss
-        GIT_TAG d796205e45ba38f894fb16bbbf1b89374d3be2e5
+        GIT_TAG c8a4efe05003d8ef6eaad34f5521cf50126c9967
         TEST_DIR test/sql
     )

--- a/.github/config/extensions/vss.cmake
+++ b/.github/config/extensions/vss.cmake
@@ -2,6 +2,6 @@ duckdb_extension_load(vss
         LOAD_TESTS
         DONT_LINK
         GIT_URL https://github.com/duckdb/duckdb-vss
-        GIT_TAG c8a4efe05003d8ef6eaad34f5521cf50126c9967
+        GIT_TAG d796205e45ba38f894fb16bbbf1b89374d3be2e5
         TEST_DIR test/sql
     )


### PR DESCRIPTION
This PR bumps the following extensions:
- `excel` from `8504be9ec8` to `9421a2d75b`
