### PR TITLE
Add Linux releases for musl libc

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -91,17 +91,24 @@ jobs:
         export PWD=`pwd`
         docker run                                                             \
         -v$PWD:$PWD                                                            \
-        -e CMAKE_BUILD_PARALLEL_LEVEL=2                                        \
+        -e GEN=ninja                                                           \
+        -e CC='ccache gcc'                                                     \
+        -e CXX='ccache g++'                                                    \
+        -e CCACHE_DIR=$PWD/.ccache                                             \
         -e OVERRIDE_GIT_DESCRIBE=$OVERRIDE_GIT_DESCRIBE                        \
         -e EXTENSION_CONFIGS="$PWD/.github/config/bundled_extensions.cmake"    \
         -e ENABLE_EXTENSION_AUTOLOADING=1                                      \
         -e ENABLE_EXTENSION_AUTOINSTALL=1                                      \
         -e BUILD_BENCHMARK=1                                                   \
         -e FORCE_WARN_UNUSED=1                                                 \
-        quay.io/pypa/manylinux_2_28_${{ matrix.config.image }}                  \
+        quay.io/pypa/manylinux_2_28_${{ matrix.config.image }}                 \
         bash -c "
           set -e
-          yum install -y perl-IPC-Cmd
+          cat /etc/os-release
+          dnf install -y \
+            ccache       \
+            ninja-build  \
+            perl-IPC-Cmd
           git config --global --add safe.directory $PWD
           make -C $PWD
         "
@@ -152,6 +159,102 @@ jobs:
       run: |
         build/release/benchmark/benchmark_runner benchmark/micro/update/update_with_join.benchmark
         build/release/duckdb -c "COPY (SELECT 42) TO '/dev/stdout' (FORMAT PARQUET)" | cat
+
+ linux-musl-release-cli:
+    needs:
+      - check-draft
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [ { runner: ubuntu-latest, arch: amd64}, {runner: ubuntu-24.04-arm, arch: arm64}]
+
+    name: Linux CLI (${{ matrix.config.arch }}-musl)
+    runs-on: ${{ matrix.config.runner }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
+
+    - name: Build
+      shell: bash
+      run: |
+        export PWD=`pwd`
+        docker run                                                          \
+        -v$PWD:$PWD                                                         \
+        -e GEN=ninja                                                        \
+        -e CC='ccache gcc'                                                  \
+        -e CXX='ccache g++'                                                 \
+        -e CCACHE_DIR=$PWD/.ccache                                          \
+        -e OVERRIDE_GIT_DESCRIBE=$OVERRIDE_GIT_DESCRIBE                     \
+        -e EXTENSION_CONFIGS="$PWD/.github/config/bundled_extensions.cmake" \
+        -e ENABLE_EXTENSION_AUTOLOADING=1                                   \
+        -e ENABLE_EXTENSION_AUTOINSTALL=1                                   \
+        -e BUILD_BENCHMARK=1                                                \
+        -e FORCE_WARN_UNUSED=1                                              \
+        alpine:3.22                                                         \
+        sh -c "
+          set -e
+          cat /etc/os-release
+          apk add   \
+            ccache  \
+            cmake   \
+            g++     \
+            git     \
+            make    \
+            samurai
+          git config --global --add safe.directory $PWD
+          make -C $PWD
+        "
+
+    - name: Deploy
+      shell: bash
+      env:
+        AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
+      run: |
+        python3 scripts/amalgamation.py
+        zip -j duckdb_cli-linux-${{ matrix.config.arch }}-musl.zip build/release/duckdb
+        gzip -9 -k -n -c build/release/duckdb > duckdb_cli-linux-${{ matrix.config.arch }}-musl.gz
+        zip -j libduckdb-linux-${{ matrix.config.arch }}-musl.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
+        ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-${{ matrix.config.arch }}-musl.zip duckdb_cli-linux-${{ matrix.config.arch }}-musl.zip duckdb_cli-linux-${{ matrix.config.arch }}-musl.gz
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: duckdb-binaries-linux-${{ matrix.config.arch }}-musl
+        path: |
+          libduckdb-linux-${{ matrix.config.arch }}-musl.zip
+          duckdb_cli-linux-${{ matrix.config.arch }}-musl.zip
+          duckdb_cli-linux-${{ matrix.config.arch }}-musl.gz
+
+    - name: Test
+      shell: bash
+      if: ${{ inputs.skip_tests != 'true' }}
+      run: |
+        export PWD=`pwd`
+        docker run   \
+        -v$PWD:$PWD  \
+        alpine:3.22                                                         \
+        sh -c "
+          set -e
+          cat /etc/os-release
+          apk add      \
+            python3    \
+            py3-pytest
+          cd $PWD
+          echo Tests
+          python3 scripts/run_tests_one_by_one.py build/release/test/unittest \"*\" --time_execution
+          echo Release specific tests
+          ./build/release/test/unittest --select-tag release
+          echo Tools Tests
+          python3 -m pytest tools/shell/tests --shell-binary build/release/duckdb
+          echo Examples
+          build/release/benchmark/benchmark_runner benchmark/micro/update/update_with_join.benchmark
+          build/release/duckdb -c \"COPY (SELECT 42) TO '/dev/stdout' (FORMAT PARQUET)\" | cat
+        "
 
  upload-libduckdb-src:
     name: Upload libduckdb-src.zip


### PR DESCRIPTION
This PR adds `linux_amd64_musl` and `linux_arm64_musl` to Linux releases CI builds.

The builds are done in Alpine containers in a similar way to glibc builds.

Additionally both glibc and musl builds are made ccache-ready. Caching is not enabled right now, but can be enabled with
`./.github/actions/ccache-action` when #20466 will land in 1.5 branch. Caching is not expected to be very effective (key is `github.job` and these builds run only once during the build), but still can be useful for faster rebuilds for tests rerun.

The same test suite is run for musl, as for glibc, just it runs inside Alpine container, so all tests are packed into a single job step.

Ref: duckdblabs/duckdb-internal#4616