### PR TITLE
[Fix] Add the new extension loader symbol to the bundled / gathered libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -532,6 +532,7 @@ bundle-setup:
 	mkdir -p bundle && \
 	cp src/libduckdb_static.a bundle/. && \
 	cp third_party/*/libduckdb_*.a bundle/. && \
+	cp extension/lib*_extension_loader.a bundle/. && \
 	cp extension/*/lib*_extension.a bundle/. && \
 	mkdir -p vcpkg_installed && \
 	find vcpkg_installed -name '*.a' -exec cp {} bundle/. \; && \
@@ -556,4 +557,5 @@ gather-libs: release
 	mkdir -p libs && \
 	cp src/libduckdb_static.a libs/. && \
 	cp third_party/*/libduckdb_*.a libs/. && \
+	cp extension/lib*_extension_loader.a bundle/. && \
 	cp extension/*/lib*_extension.a libs/.

--- a/Makefile
+++ b/Makefile
@@ -557,5 +557,5 @@ gather-libs: release
 	mkdir -p libs && \
 	cp src/libduckdb_static.a libs/. && \
 	cp third_party/*/libduckdb_*.a libs/. && \
-	cp extension/lib*_extension_loader.a bundle/. && \
+	cp extension/lib*_extension_loader.a libs/. && \
 	cp extension/*/lib*_extension.a libs/.


### PR DESCRIPTION
Currently, using `make gather-libs` or `make bundle-library` on  `v1.5-variegata`  breaks when linking to, e.g., duckdb-go with the following missing symbol: 

```
Undefined symbols for architecture arm64:
  "duckdb::ExtensionHelper::LoadAllExtensions(duckdb::DuckDB&)", referenced from:
      duckdb::DuckDB::DuckDB(char const*, duckdb::DBConfig*) in libduckdb_bundle.a[245](ub_duckdb_main.cpp.o)
ld: symbol(s) not found for architecture arm64
```