### PR TITLE
Make extending `VirtualFileSystem` thread-safe

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -611,10 +611,6 @@ void FileSystem::RegisterSubSystem(FileCompressionType compression_type, unique_
 	throw NotImplementedException("%s: Can't register a sub system on a non-virtual file system", GetName());
 }
 
-void FileSystem::UnregisterSubSystem(const string &name) {
-	throw NotImplementedException("%s: Can't unregister a sub system on a non-virtual file system", GetName());
-}
-
 unique_ptr<FileSystem> FileSystem::ExtractSubSystem(const string &name) {
 	throw NotImplementedException("%s: Can't extract a sub system on a non-virtual file system", GetName());
 }

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -9,11 +9,106 @@
 
 namespace duckdb {
 
+struct FileSystemHandle {
+	explicit FileSystemHandle(unique_ptr<FileSystem> fs) : file_system(std::move(fs)) {
+	}
+
+	unique_ptr<FileSystem> file_system;
+};
+
+//! The FileSystemRegistry holds the set of file systems that are registered.
+//! Note that it should be treated as read-only.
+//! When a change is made (e.g. by registering new file system) a copy of the registry is made
+struct FileSystemRegistry {
+	explicit FileSystemRegistry(unique_ptr<FileSystem> fs)
+	    : default_fs(make_shared_ptr<FileSystemHandle>(std::move(fs))) {
+	}
+
+	vector<shared_ptr<FileSystemHandle>> sub_systems;
+	map<FileCompressionType, shared_ptr<FileSystemHandle>> compressed_fs;
+	const shared_ptr<FileSystemHandle> default_fs;
+	unordered_set<string> disabled_file_systems;
+
+public:
+	shared_ptr<FileSystemRegistry> RegisterSubSystem(unique_ptr<FileSystem> fs) const;
+	shared_ptr<FileSystemRegistry> RegisterSubSystem(FileCompressionType compression_type,
+	                                                 unique_ptr<FileSystem> fs) const;
+	shared_ptr<FileSystemRegistry> SetDisabledFileSystems(const vector<string> &names) const;
+	shared_ptr<FileSystemRegistry> ExtractSubSystem(const string &name, unique_ptr<FileSystem> &result) const;
+};
+
+shared_ptr<FileSystemRegistry> FileSystemRegistry::RegisterSubSystem(unique_ptr<FileSystem> fs) const {
+	auto new_registry = make_shared_ptr<FileSystemRegistry>(*this);
+	const auto &name = fs->GetName();
+	for (auto &sub_system : new_registry->sub_systems) {
+		if (sub_system->file_system->GetName() == name) {
+			throw InvalidInputException("Filesystem with name %s has already been registered, cannot re-register!",
+			                            name);
+		}
+	}
+	new_registry->sub_systems.push_back(make_shared_ptr<FileSystemHandle>(std::move(fs)));
+	return new_registry;
+}
+
+shared_ptr<FileSystemRegistry> FileSystemRegistry::RegisterSubSystem(FileCompressionType compression_type,
+                                                                     unique_ptr<FileSystem> fs) const {
+	auto new_registry = make_shared_ptr<FileSystemRegistry>(*this);
+	new_registry->compressed_fs[compression_type] = make_shared_ptr<FileSystemHandle>(std::move(fs));
+	return new_registry;
+}
+
+shared_ptr<FileSystemRegistry> FileSystemRegistry::SetDisabledFileSystems(const vector<string> &names) const {
+	auto new_registry = make_shared_ptr<FileSystemRegistry>(*this);
+	unordered_set<string> new_disabled_file_systems;
+	for (auto &name : names) {
+		if (name.empty()) {
+			continue;
+		}
+		if (new_disabled_file_systems.find(name) != new_disabled_file_systems.end()) {
+			throw InvalidInputException("Duplicate disabled file system \"%s\"", name);
+		}
+		new_disabled_file_systems.insert(name);
+	}
+	for (auto &disabled_fs : disabled_file_systems) {
+		if (new_disabled_file_systems.find(disabled_fs) == new_disabled_file_systems.end()) {
+			throw InvalidInputException("File system \"%s\" has been disabled previously, it cannot be re-enabled",
+			                            disabled_fs);
+		}
+	}
+	new_registry->disabled_file_systems = std::move(new_disabled_file_systems);
+	return new_registry;
+}
+
+shared_ptr<FileSystemRegistry> FileSystemRegistry::ExtractSubSystem(const string &name,
+                                                                    unique_ptr<FileSystem> &result) const {
+	auto new_registry = make_shared_ptr<FileSystemRegistry>(*this);
+	// If the subsystem has been disabled, we don't allow extraction and return nullptr here.
+	if (disabled_file_systems.find(name) != disabled_file_systems.end()) {
+		return nullptr;
+	}
+
+	for (auto iter = new_registry->sub_systems.begin(); iter != new_registry->sub_systems.end(); ++iter) {
+		auto &cur_filesystem = (*iter)->file_system;
+		if (cur_filesystem->GetName() == name) {
+			result = std::move(cur_filesystem);
+			new_registry->sub_systems.erase(iter);
+			return new_registry;
+		}
+	}
+
+	// Requested subfilesystem is not registered.
+	return nullptr;
+}
+
 VirtualFileSystem::VirtualFileSystem() : VirtualFileSystem(FileSystem::CreateLocal()) {
 }
 
-VirtualFileSystem::VirtualFileSystem(unique_ptr<FileSystem> &&inner) : default_fs(std::move(inner)) {
+VirtualFileSystem::VirtualFileSystem(unique_ptr<FileSystem> &&inner)
+    : file_system_registry(make_shared_ptr<FileSystemRegistry>(std::move(inner))) {
 	VirtualFileSystem::RegisterSubSystem(FileCompressionType::GZIP, make_uniq<GZipFileSystem>());
+}
+
+VirtualFileSystem::~VirtualFileSystem() {
 }
 
 unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
@@ -38,7 +133,8 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 	// open the base file handle in UNCOMPRESSED mode
 	flags.SetCompression(FileCompressionType::UNCOMPRESSED);
 
-	auto &internal_filesystem = FindFileSystem(file.path, opener);
+	auto registry = file_system_registry.atomic_load();
+	auto &internal_filesystem = FindFileSystem(registry, file.path, opener);
 
 	// File handle gets created.
 	unique_ptr<FileHandle> file_handle = nullptr;
@@ -61,8 +157,8 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 	if (file_handle->GetType() == FileType::FILE_TYPE_FIFO) {
 		file_handle = PipeFileSystem::OpenPipe(context, std::move(file_handle));
 	} else if (compression != FileCompressionType::UNCOMPRESSED) {
-		auto entry = compressed_fs.find(compression);
-		if (entry == compressed_fs.end()) {
+		auto entry = registry->compressed_fs.find(compression);
+		if (entry == registry->compressed_fs.end()) {
 			if (compression == FileCompressionType::ZSTD) {
 				throw NotImplementedException(
 				    "Attempting to open a compressed file, but the compression type is not supported.\nConsider "
@@ -71,7 +167,8 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFileExtended(const OpenFileInfo &f
 			throw NotImplementedException(
 			    "Attempting to open a compressed file, but the compression type is not supported");
 		}
-		file_handle = entry->second->OpenCompressedFile(context, std::move(file_handle), flags.OpenForWriting());
+		auto &compressed_fs = *entry->second->file_system;
+		file_handle = compressed_fs.OpenCompressedFile(context, std::move(file_handle), flags.OpenForWriting());
 	}
 	return file_handle;
 }
@@ -118,14 +215,14 @@ void VirtualFileSystem::FileSync(FileHandle &handle) {
 
 // need to look up correct fs for this
 bool VirtualFileSystem::DirectoryExists(const string &directory, optional_ptr<FileOpener> opener) {
-	return FindFileSystem(directory).DirectoryExists(directory, opener);
+	return FindFileSystem(directory, opener).DirectoryExists(directory, opener);
 }
 void VirtualFileSystem::CreateDirectory(const string &directory, optional_ptr<FileOpener> opener) {
-	FindFileSystem(directory).CreateDirectory(directory, opener);
+	FindFileSystem(directory, opener).CreateDirectory(directory, opener);
 }
 
 void VirtualFileSystem::RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener) {
-	FindFileSystem(directory).RemoveDirectory(directory, opener);
+	FindFileSystem(directory, opener).RemoveDirectory(directory, opener);
 }
 
 bool VirtualFileSystem::ListFilesExtended(const string &directory,
@@ -135,7 +232,7 @@ bool VirtualFileSystem::ListFilesExtended(const string &directory,
 }
 
 void VirtualFileSystem::MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener) {
-	FindFileSystem(source).MoveFile(source, target, opener);
+	FindFileSystem(source, opener).MoveFile(source, target, opener);
 }
 
 bool VirtualFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
@@ -143,21 +240,21 @@ bool VirtualFileSystem::FileExists(const string &filename, optional_ptr<FileOpen
 }
 
 bool VirtualFileSystem::IsPipe(const string &filename, optional_ptr<FileOpener> opener) {
-	return FindFileSystem(filename).IsPipe(filename, opener);
+	return FindFileSystem(filename, opener).IsPipe(filename, opener);
 }
 
 void VirtualFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
-	FindFileSystem(filename).RemoveFile(filename, opener);
+	FindFileSystem(filename, opener).RemoveFile(filename, opener);
 }
 
 bool VirtualFileSystem::TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
-	return FindFileSystem(filename).TryRemoveFile(filename, opener);
+	return FindFileSystem(filename, opener).TryRemoveFile(filename, opener);
 }
 
 void VirtualFileSystem::RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener) {
 	reference_map_t<FileSystem, vector<string>> files_by_fs;
 	for (const auto &filename : filenames) {
-		auto &fs = FindFileSystem(filename);
+		auto &fs = FindFileSystem(filename, opener);
 		files_by_fs[fs].push_back(filename);
 	}
 	for (auto &entry : files_by_fs) {
@@ -166,7 +263,7 @@ void VirtualFileSystem::RemoveFiles(const vector<string> &filenames, optional_pt
 }
 
 string VirtualFileSystem::PathSeparator(const string &path) {
-	return FindFileSystem(path).PathSeparator(path);
+	return FindFileSystem(path, nullptr).PathSeparator(path);
 }
 
 vector<OpenFileInfo> VirtualFileSystem::Glob(const string &path, FileOpener *opener) {
@@ -174,55 +271,38 @@ vector<OpenFileInfo> VirtualFileSystem::Glob(const string &path, FileOpener *ope
 }
 
 void VirtualFileSystem::RegisterSubSystem(unique_ptr<FileSystem> fs) {
-	// Sub-filesystem number is not expected to be huge, also filesystem registration should be called infrequently.
-	const auto &name = fs->GetName();
-	for (auto sub_system = sub_systems.begin(); sub_system != sub_systems.end(); sub_system++) {
-		if (sub_system->get()->GetName() == name) {
-			throw InvalidInputException("Filesystem with name %s has already been registered, cannot re-register!",
-			                            name);
-		}
-	}
-	sub_systems.push_back(std::move(fs));
-}
-
-void VirtualFileSystem::UnregisterSubSystem(const string &name) {
-	for (auto sub_system = sub_systems.begin(); sub_system != sub_systems.end(); sub_system++) {
-		if (sub_system->get()->GetName() == name) {
-			sub_systems.erase(sub_system);
-			return;
-		}
-	}
-	throw InvalidInputException("Could not find filesystem with name %s", name);
+	lock_guard<mutex> guard(registry_lock);
+	auto new_registry = file_system_registry->RegisterSubSystem(std::move(fs));
+	file_system_registry.atomic_store(new_registry);
 }
 
 void VirtualFileSystem::RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) {
-	compressed_fs[compression_type] = std::move(fs);
+	lock_guard<mutex> guard(registry_lock);
+	auto new_registry = file_system_registry->RegisterSubSystem(compression_type, std::move(fs));
+	file_system_registry.atomic_store(new_registry);
 }
 
+void VirtualFileSystem::SetDisabledFileSystems(const vector<string> &names) {
+	lock_guard<mutex> guard(registry_lock);
+	auto new_registry = file_system_registry->SetDisabledFileSystems(names);
+	file_system_registry.atomic_store(new_registry);
+}
 unique_ptr<FileSystem> VirtualFileSystem::ExtractSubSystem(const string &name) {
-	// If the subsystem has been disabled, we don't allow extraction and return nullptr here.
-	if (disabled_file_systems.find(name) != disabled_file_systems.end()) {
-		return nullptr;
+	lock_guard<mutex> guard(registry_lock);
+	unique_ptr<FileSystem> result;
+	auto new_registry = file_system_registry->ExtractSubSystem(name, result);
+	if (new_registry) {
+		file_system_registry.atomic_store(new_registry);
 	}
-
-	unique_ptr<FileSystem> extracted_filesystem;
-	for (auto iter = sub_systems.begin(); iter != sub_systems.end(); ++iter) {
-		auto &cur_filesystem = *iter;
-		if (cur_filesystem->GetName() == name) {
-			extracted_filesystem = std::move(cur_filesystem);
-			sub_systems.erase(iter);
-			return extracted_filesystem;
-		}
-	}
-
-	// Requested subfilesystem is not registered.
-	return nullptr;
+	return result;
 }
 
 vector<string> VirtualFileSystem::ListSubSystems() {
-	vector<string> names(sub_systems.size());
-	for (idx_t i = 0; i < sub_systems.size(); i++) {
-		names[i] = sub_systems[i]->GetName();
+	auto registry = file_system_registry.atomic_load();
+	auto &sub_systems = registry->sub_systems;
+	vector<string> names;
+	for (auto &sub_system : sub_systems) {
+		names.push_back(sub_system->file_system->GetName());
 	}
 	return names;
 }
@@ -231,47 +311,31 @@ std::string VirtualFileSystem::GetName() const {
 	return "VirtualFileSystem";
 }
 
-void VirtualFileSystem::SetDisabledFileSystems(const vector<string> &names) {
-	unordered_set<string> new_disabled_file_systems;
-	for (auto &name : names) {
-		if (name.empty()) {
-			continue;
-		}
-		if (new_disabled_file_systems.find(name) != new_disabled_file_systems.end()) {
-			throw InvalidInputException("Duplicate disabled file system \"%s\"", name);
-		}
-		new_disabled_file_systems.insert(name);
-	}
-	for (auto &disabled_fs : disabled_file_systems) {
-		if (new_disabled_file_systems.find(disabled_fs) == new_disabled_file_systems.end()) {
-			throw InvalidInputException("File system \"%s\" has been disabled previously, it cannot be re-enabled",
-			                            disabled_fs);
-		}
-	}
-	disabled_file_systems = std::move(new_disabled_file_systems);
-}
-
 bool VirtualFileSystem::SubSystemIsDisabled(const string &name) {
+	auto registry = file_system_registry.atomic_load();
+	auto &disabled_file_systems = registry->disabled_file_systems;
 	return disabled_file_systems.find(name) != disabled_file_systems.end();
 }
 
 bool VirtualFileSystem::IsDisabledForPath(const string &path) {
+	auto registry = file_system_registry.atomic_load();
+	auto &disabled_file_systems = registry->disabled_file_systems;
 	if (disabled_file_systems.empty()) {
 		return false;
 	}
-	auto fs = FindFileSystemInternal(path);
-	if (!fs) {
-		fs = default_fs.get();
-	}
-	return disabled_file_systems.find(fs->GetName()) != disabled_file_systems.end();
+	auto &fs = FindFileSystem(path, nullptr);
+	return disabled_file_systems.find(fs.GetName()) != disabled_file_systems.end();
 }
 
 FileSystem &VirtualFileSystem::FindFileSystem(const string &path, optional_ptr<FileOpener> opener) {
-	return FindFileSystem(path, FileOpener::TryGetDatabase(opener));
+	auto registry = file_system_registry.atomic_load();
+	return FindFileSystem(registry, path, opener);
 }
 
-FileSystem &VirtualFileSystem::FindFileSystem(const string &path, optional_ptr<DatabaseInstance> db_instance) {
-	auto fs = FindFileSystemInternal(path);
+FileSystem &VirtualFileSystem::FindFileSystem(shared_ptr<FileSystemRegistry> &registry, const string &path,
+                                              optional_ptr<FileOpener> opener) {
+	auto db_instance = FileOpener::TryGetDatabase(opener);
+	auto fs = FindFileSystemInternal(*registry, path);
 
 	if (!fs && db_instance) {
 		string required_extension;
@@ -292,48 +356,35 @@ FileSystem &VirtualFileSystem::FindFileSystem(const string &path, optional_ptr<D
 			// an extension is required to read this file, but it is not loaded - try to load it
 			ExtensionHelper::AutoLoadExtension(*db_instance, required_extension);
 		}
+		// refresh the registry after loading extensions
+		registry = file_system_registry.atomic_load();
 
 		// Retry after having autoloaded
-		fs = FindFileSystem(path);
+		fs = FindFileSystemInternal(*registry, path);
 	}
 
 	if (!fs) {
-		fs = default_fs;
+		fs = registry->default_fs->file_system;
 	}
+	auto &disabled_file_systems = registry->disabled_file_systems;
 	if (!disabled_file_systems.empty() && disabled_file_systems.find(fs->GetName()) != disabled_file_systems.end()) {
 		throw PermissionException("File system %s has been disabled by configuration", fs->GetName());
 	}
 	return *fs;
 }
 
-FileSystem &VirtualFileSystem::FindFileSystem(const string &path) {
-	auto fs = FindFileSystemInternal(path);
-	if (!fs) {
-		fs = default_fs;
-	}
-	if (!disabled_file_systems.empty() && disabled_file_systems.find(fs->GetName()) != disabled_file_systems.end()) {
-		throw PermissionException("File system %s has been disabled by configuration", fs->GetName());
-	}
-	return *fs;
-}
-
-optional_ptr<FileSystem> VirtualFileSystem::FindFileSystemInternal(const string &path) {
-	FileSystem *fs = nullptr;
-
-	for (auto &sub_system : sub_systems) {
-		if (sub_system->CanHandleFile(path)) {
-			if (sub_system->IsManuallySet()) {
-				return *sub_system;
+optional_ptr<FileSystem> VirtualFileSystem::FindFileSystemInternal(FileSystemRegistry &registry, const string &path) {
+	optional_ptr<FileSystem> fs;
+	for (auto &sub_system : registry.sub_systems) {
+		auto &sub_fs = *sub_system->file_system;
+		if (sub_fs.CanHandleFile(path)) {
+			if (sub_fs.IsManuallySet()) {
+				return sub_fs;
 			}
-			fs = sub_system.get();
+			fs = sub_fs;
 		}
 	}
-	if (fs) {
-		return *fs;
-	}
-
-	// We could use default_fs, that's on the caller
-	return nullptr;
+	return fs;
 }
 
 } // namespace duckdb

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -323,8 +323,11 @@ bool VirtualFileSystem::IsDisabledForPath(const string &path) {
 	if (disabled_file_systems.empty()) {
 		return false;
 	}
-	auto &fs = FindFileSystem(path, nullptr);
-	return disabled_file_systems.find(fs.GetName()) != disabled_file_systems.end();
+	auto fs = FindFileSystemInternal(*registry, path);
+	if (!fs) {
+		fs = registry->default_fs->file_system;
+	}
+	return disabled_file_systems.find(fs->GetName()) != disabled_file_systems.end();
 }
 
 FileSystem &VirtualFileSystem::FindFileSystem(const string &path, optional_ptr<FileOpener> opener) {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -258,9 +258,6 @@ public:
 	DUCKDB_API virtual void RegisterSubSystem(unique_ptr<FileSystem> sub_fs);
 	DUCKDB_API virtual void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs);
 
-	//! Unregister a sub-filesystem by name
-	DUCKDB_API virtual void UnregisterSubSystem(const string &name);
-
 	// !Extract a sub-filesystem by name, with ownership transfered, return nullptr if not registered or the subsystem
 	// has been disabled.
 	DUCKDB_API virtual unique_ptr<FileSystem> ExtractSubSystem(const string &name);

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -146,10 +146,6 @@ public:
 		GetFileSystem().RegisterSubSystem(compression_type, std::move(fs));
 	}
 
-	void UnregisterSubSystem(const string &name) override {
-		GetFileSystem().UnregisterSubSystem(name);
-	}
-
 	void SetDisabledFileSystems(const vector<string> &names) override {
 		GetFileSystem().SetDisabledFileSystems(names);
 	}

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -14,12 +14,14 @@
 #include "duckdb/main/extension_helper.hpp"
 
 namespace duckdb {
+struct FileSystemRegistry;
 
 // bunch of wrappers to allow registering protocol handlers
 class VirtualFileSystem : public FileSystem {
 public:
 	VirtualFileSystem();
 	explicit VirtualFileSystem(unique_ptr<FileSystem> &&inner_file_system);
+	~VirtualFileSystem() override;
 
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
@@ -54,9 +56,6 @@ public:
 	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener = nullptr) override;
 
 	void RegisterSubSystem(unique_ptr<FileSystem> fs) override;
-
-	void UnregisterSubSystem(const string &name) override;
-
 	void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override;
 
 	unique_ptr<FileSystem> ExtractSubSystem(const string &name) override;
@@ -87,15 +86,13 @@ protected:
 
 private:
 	FileSystem &FindFileSystem(const string &path, optional_ptr<FileOpener> file_opener);
-	FileSystem &FindFileSystem(const string &path, optional_ptr<DatabaseInstance> database_instance);
-	FileSystem &FindFileSystem(const string &path);
-	optional_ptr<FileSystem> FindFileSystemInternal(const string &path);
+	FileSystem &FindFileSystem(shared_ptr<FileSystemRegistry> &registry, const string &path,
+	                           optional_ptr<FileOpener> file_opener);
+	optional_ptr<FileSystem> FindFileSystemInternal(FileSystemRegistry &registry, const string &path);
 
 private:
-	vector<unique_ptr<FileSystem>> sub_systems;
-	map<FileCompressionType, unique_ptr<FileSystem>> compressed_fs;
-	const unique_ptr<FileSystem> default_fs;
-	unordered_set<string> disabled_file_systems;
+	mutex registry_lock;
+	shared_ptr<FileSystemRegistry> file_system_registry;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/caching_file_system_wrapper.hpp
@@ -101,7 +101,6 @@ public:
 
 	DUCKDB_API void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override;
 	DUCKDB_API void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override;
-	DUCKDB_API void UnregisterSubSystem(const string &name) override;
 	DUCKDB_API unique_ptr<FileSystem> ExtractSubSystem(const string &name) override;
 	DUCKDB_API vector<string> ListSubSystems() override;
 	DUCKDB_API bool CanHandleFile(const string &fpath) override;

--- a/src/storage/caching_file_system_wrapper.cpp
+++ b/src/storage/caching_file_system_wrapper.cpp
@@ -312,10 +312,6 @@ void CachingFileSystemWrapper::RegisterSubSystem(FileCompressionType compression
 	underlying_file_system.RegisterSubSystem(compression_type, std::move(fs));
 }
 
-void CachingFileSystemWrapper::UnregisterSubSystem(const string &name) {
-	underlying_file_system.UnregisterSubSystem(name);
-}
-
 unique_ptr<FileSystem> CachingFileSystemWrapper::ExtractSubSystem(const string &name) {
 	return underlying_file_system.ExtractSubSystem(name);
 }


### PR DESCRIPTION

Extensions that are loaded can modify the `VirtualFileSystem`, primarily through registering additional file systems. For example, `httpfs` registers the `HTTPFSFileSystem` and the `S3FileSystem`. Currently this is not thread-safe, and problems can arise when one connection loads an extension while another connection is using the file system. While this is a rare scenario, it can trigger more frequently with extension auto-loading, and should be fixed.

This PR fixes the issue by moving the `VirtualFileSystem` state into a separate struct - the `FileSystemRegistry`:

```cpp
struct FileSystemHandle {
	unique_ptr<FileSystem> file_system;
};

struct FileSystemRegistry {
	vector<shared_ptr<FileSystemHandle>> sub_systems;
	map<FileCompressionType, shared_ptr<FileSystemHandle>> compressed_fs;
	const shared_ptr<FileSystemHandle> default_fs;
	unordered_set<string> disabled_file_systems;
};
```

The `FileSystemRegistry` is read-only - i.e. after it is created, we don't modify it anymore. Instead, when registering additional file systems, we create a copy of the current registry and apply the modification. For example:


```cpp
shared_ptr<FileSystemRegistry> FileSystemRegistry::RegisterSubSystem(unique_ptr<FileSystem> fs) const {
	auto new_registry = make_shared_ptr<FileSystemRegistry>(*this);
	new_registry->sub_systems.push_back(make_shared_ptr<FileSystemHandle>(std::move(fs)));
	return new_registry;
}
```

We then use an atomic operation to overwrite the current file system registry:

```cpp
void VirtualFileSystem::RegisterSubSystem(unique_ptr<FileSystem> fs) {
	lock_guard<mutex> guard(registry_lock);
	auto new_registry = file_system_registry->RegisterSubSystem(std::move(fs));
	file_system_registry.atomic_store(new_registry);
}
```

On read, we start off by obtaining a shared reference to the *current* registry using an atomic load. Since the registry is read-only, we can then use that registry as much as we want.

```cpp
FileSystem &VirtualFileSystem::FindFileSystem(const string &path, optional_ptr<FileOpener> opener) {
	return FindFileSystem(path, FileOpener::TryGetDatabase(opener));
	auto registry = file_system_registry.atomic_load();
	// ..
}
```

#### `UnregisterSubSystem`

The `UnregisterSubSystem` is removed in this PR. This does not appear to be used anywhere - and removing (destroying) a file-system is potentially unsafe in the current implementation. As such, we remove this API call to prevent it from being used in the future.