### PR TITLE
Fail fast extension

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -63,6 +63,7 @@ constexpr FileOpenFlags FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_EXISTS;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_DISABLE_LOGGING;
+constexpr FileOpenFlags FileFlags::FILE_FLAGS_ENABLE_EXTENSION_FOLDER;
 
 void FileOpenFlags::Verify() {
 #ifdef DEBUG

--- a/src/common/opener_file_system.cpp
+++ b/src/common/opener_file_system.cpp
@@ -27,12 +27,13 @@ void OpenerFileSystem::VerifyCanAccessFileInternal(const string &path, FileType 
 }
 
 void OpenerFileSystem::VerifyCanWriteFile(const string &path) {
-
+	// Goal here is checkign whether path is NOT within the current extension folder, we check in a somewhat inefficient
+	// way by converting both path to be checked AND extension path to absolute paths, normalizing, and then checking
+	// for a match
 	auto opener = GetOpener();
 	if (!opener) {
 		return;
 	}
-
 	auto db = opener->TryGetDatabase();
 	if (!db) {
 		return;
@@ -52,7 +53,6 @@ void OpenerFileSystem::VerifyCanWriteFile(const string &path) {
 	if (extension_folder[0] != '/') {
 		extension_folder = config.SanitizeAllowedPath(GetWorkingDirectory() + '/' + extension_folder);
 	}
-
 	// Now extension folder is absolute
 
 	string absolute_path = "";

--- a/src/common/opener_file_system.cpp
+++ b/src/common/opener_file_system.cpp
@@ -49,6 +49,9 @@ void OpenerFileSystem::VerifyCanWriteFile(const string &path) {
 	    !config.options.extension_directory.empty() ? config.options.extension_directory : default_extension_folder;
 
 	extension_folder = FileSystem::ExpandPath(extension_folder, nullptr);
+	if (extension_folder[0] != '/') {
+		extension_folder = config.SanitizeAllowedPath(GetWorkingDirectory() + '/' + extension_folder);
+	}
 
 	// Now extension folder is absolute
 

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -30,6 +30,7 @@ public:
 	static constexpr idx_t FILE_FLAGS_NULL_IF_EXISTS = idx_t(1 << 10);
 	static constexpr idx_t FILE_FLAGS_MULTI_CLIENT_ACCESS = idx_t(1 << 11);
 	static constexpr idx_t FILE_FLAGS_DISABLE_LOGGING = idx_t(1 << 12);
+	static constexpr idx_t FILE_FLAGS_ENABLE_EXTENSION_FOLDER = idx_t(1 << 13);
 
 public:
 	FileOpenFlags() = default;
@@ -115,6 +116,9 @@ public:
 	inline bool DisableLogging() const {
 		return flags & FILE_FLAGS_DISABLE_LOGGING;
 	}
+	inline bool EnableInExtensionFolder() const {
+		return flags & FILE_FLAGS_ENABLE_EXTENSION_FOLDER;
+	}
 	inline idx_t GetFlagsInternal() const {
 		return flags;
 	}
@@ -159,6 +163,9 @@ public:
 	//! Disables logging to avoid infinite loops when using FileHandle-backed log storage
 	static constexpr FileOpenFlags FILE_FLAGS_DISABLE_LOGGING =
 	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_DISABLE_LOGGING);
+	//! Allow writing into extension folder
+	static constexpr FileOpenFlags FILE_FLAGS_ENABLE_EXTENSION_FOLDER =
+	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_ENABLE_EXTENSION_FOLDER);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -21,6 +21,7 @@ public:
 	void VerifyNoOpener(optional_ptr<FileOpener> opener);
 	void VerifyCanAccessDirectory(const string &path);
 	void VerifyCanAccessFile(const string &path);
+	void VerifyCanWriteFile(const string &path);
 
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
 		GetFileSystem().Read(handle, buffer, nr_bytes, location);
@@ -156,6 +157,9 @@ protected:
 	                                        optional_ptr<FileOpener> opener = nullptr) override {
 		VerifyNoOpener(opener);
 		VerifyCanAccessFile(file.path);
+		if (flags.OpenForWriting() && !flags.EnableInExtensionFolder()) {
+			VerifyCanWriteFile(file.path);
+		}
 		return GetFileSystem().OpenFile(file, flags, GetOpener());
 	}
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -177,14 +177,14 @@ static unsafe_unique_array<data_t> ReadExtensionFileFromDisk(FileSystem &fs, con
 static void WriteExtensionFileToDisk(QueryContext &query_context, FileSystem &fs, const string &path, void *data,
                                      idx_t data_size) {
 	auto target_file = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_APPEND |
-	                                         FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	                                         FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileFlags::FILE_FLAGS_ENABLE_EXTENSION_FOLDER);
 	target_file->Write(query_context, data, data_size);
 	target_file->Close();
 	target_file.reset();
 }
 
 static void WriteExtensionMetadataFileToDisk(FileSystem &fs, const string &path, ExtensionInstallInfo &metadata) {
-	auto file_writer = BufferedFileWriter(fs, path);
+	auto file_writer = BufferedFileWriter(fs, path, BufferedFileWriter::DEFAULT_OPEN_FLAGS | FileFlags::FILE_FLAGS_ENABLE_EXTENSION_FOLDER);
 	BinarySerializer::Serialize(metadata, file_writer);
 	file_writer.Sync();
 }

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -365,6 +365,10 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 		filename = fs.JoinPath(local_path, extension_name + ".duckdb_extension");
 #endif
 	} else {
+		if (!db.config.options.allow_unsigned_extensions) {
+			throw PermissionException(
+			    "Loading extensions from arbitrary paths is forbidden through configuration, consider `LOAD <name>`");
+		}
 		direct_load = true;
 		filename = fs.ExpandPath(filename);
 	}

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -996,7 +996,7 @@ void HomeDirectorySetting::SetLocal(ClientContext &context, const Value &input) 
 	if (!input.IsNull() && FileSystem::GetFileSystem(context).IsRemoteFile(input.ToString())) {
 		throw InvalidInputException("Cannot set the home directory to a remote path");
 	}
-	config.home_directory = input.IsNull() ? string() : input.ToString();
+	config.home_directory = input.IsNull() ? string() : FileSystem::ExpandPath(input.ToString(), nullptr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/sql/extensions/checked_load.test
+++ b/test/sql/extensions/checked_load.test
@@ -27,4 +27,4 @@ SET allow_unsigned_extensions=false;
 statement error
 LOAD 'README.md';
 ----
-The file is not a DuckDB extension. The metadata at the end of the file is invalid
+Permission Error: Loading extensions from arbitrary paths is forbidden through configuration, consider

--- a/test/sql/extensions/copy_into_extension.test
+++ b/test/sql/extensions/copy_into_extension.test
@@ -1,0 +1,12 @@
+# name: test/sql/extensions/copy_into_extension.test
+# description: Test that writing into extension folder is forbidden
+# group: [extensions]
+
+statement ok
+SET extension_directory = 'folder';
+
+statement error
+COPY (SELECT 42) TO 'folder/a.csv';
+----
+<REGEX>:Permission Error: Cannot access .* - writing to extension directory is disabled by configuration.*
+

--- a/test/sql/extensions/load_arbitrary_path.test
+++ b/test/sql/extensions/load_arbitrary_path.test
@@ -1,0 +1,12 @@
+# name: test/sql/extensions/load_arbitrary_path.test
+# description: Test that loading extensions from arbitrary paths is forbidden
+# group: [extensions]
+
+statement ok
+SET allow_unsigned_extensions = false;
+
+statement error
+LOAD 'folder/a.csv';
+----
+Permission Error: Loading extensions from arbitrary paths is forbidden through configuration
+

--- a/test/sql/settings/home_directory.test
+++ b/test/sql/settings/home_directory.test
@@ -1,0 +1,13 @@
+# name: test/sql/settings/home_directory.test
+# description: Test behavior of home_directory
+# group: [settings]
+
+require skip_reload
+
+statement ok
+SET home_directory = '~';
+
+query I
+SELECT current_setting('home_directory') != '~';
+----
+true


### PR DESCRIPTION
Add 3 changes that will tighten what is possible using default duckdb settings.

### Forbid writes within the extension folder
Writing into `~/.duckdb/extensions/` OR the current config specified extension folder is forbidden, for example one can't override info files or extension files while using default settings.
This covers against accidental problems where one would make the extension folder in an inconsistent state.

### Forbid LOADs from arbitrary paths
Load are now allowed only from within an extension folder (again, either at `~/.duckdb/extensions` OR specified via current configuration).
When unsigned extensions are enabled, this restriction is lifted.

### Check on `INSTALL` that the installed extension would be loadable in the current configuration
If unsigned extensions are disabled, extensions are checked for signatures also on `INSTALL`.
If community extensions are disabled, `INSTALL` from community signed extensions are also disabled.
This means that under regular usage, extension directory will not contain unloadable extensions.
Checks on `LOAD` are still in place, but this should avoid some pitfalls.

---

All three together aim at making it more complex to invalidate the state of the extension folder, in the case of a single or multiple duckdb extensions operating using regular patterns.
This is NOT stating that arbitrary SQL can be executed safely, but that regular usage of one or multiple instances of duckdb using the same set of configurations (like extension directories are shared AND all disable unsigned extension) will avoid issues such as an INSTALL is followed by a failure on LOAD, since whenever INSTALL is successful now a LOAD will be successful as well.

Again, those are for quality of life, but this do not guards against any arbitrary configurations and arbitrary SQL statement being executed. Consider https://duckdb.org/docs/stable/operations_manual/securing_duckdb/overview documentation.