### PR TITLE
Add min compatibility version to core extensions

### DIFF
--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -25,7 +25,7 @@ struct DefaultExtension {
 	const char *name;
 	const char *description;
 	bool statically_loaded;
-	const char *min_compat_version;
+	const char *api_version;
 };
 
 struct ExtensionAlias {
@@ -163,10 +163,10 @@ public:
 	static string GetExtensionName(const string &extension);
 	static bool IsFullPath(const string &extension);
 
-	//! For C API default extensions - returns the minimal version of DuckDB (example: 'v1.2.0')
+	//! For C API default extensions - returns the minimal version of C API (example: 'v1.2.0-api')
 	//! that is supported by this extension, to be used in HTTP URL during installation;
 	//! for C++ extensions and unknown extensions - returns an empty string
-	static string GetExtensionMinCompatVersion(const string &extension_name);
+	static string GetExtensionApiVersion(const string &extension_name);
 
 	//! Lookup a name + type in an ExtensionFunctionEntry list
 	template <size_t N>

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -25,6 +25,7 @@ struct DefaultExtension {
 	const char *name;
 	const char *description;
 	bool statically_loaded;
+	const char *min_compat_version;
 };
 
 struct ExtensionAlias {
@@ -161,6 +162,11 @@ public:
 
 	static string GetExtensionName(const string &extension);
 	static bool IsFullPath(const string &extension);
+
+	//! For C API default extensions - returns the minimal version of DuckDB (example: 'v1.2.0')
+	//! that is supported by this extension, to be used in HTTP URL during installation;
+	//! for C++ extensions and unknown extensions - returns an empty string
+	static string GetExtensionMinCompatVersion(const string &extension_name);
 
 	//! Lookup a name + type in an ExtensionFunctionEntry list
 	template <size_t N>

--- a/src/main/extension/extension_alias.cpp
+++ b/src/main/extension/extension_alias.cpp
@@ -11,6 +11,7 @@ static const ExtensionAlias internal_aliases[] = {{"http", "httpfs"}, // httpfs
                                                   {"sqlite", "sqlite_scanner"},     // sqlite
                                                   {"sqlite3", "sqlite_scanner"},
                                                   {"uc_catalog", "unity_catalog"}, // old name for compatibility
+                                                  {"odbc", "odbc_scanner"},        // odbc
                                                   {nullptr, nullptr}};
 
 idx_t ExtensionHelper::ExtensionAliasCount() {

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -126,7 +126,7 @@ static const DefaultExtension internal_extensions[] = {
     {"fts", "Adds support for Full-Text Search Indexes", false, nullptr},
     {"ui", "Adds local UI for DuckDB", false, nullptr},
     {"ducklake", "Adds support for DuckLake, SQL as a Lakehouse Format", false, nullptr},
-    {"odbc_scanner", "Adds support for connecting to remote databases over ODBC", false, "v1.2.0"},
+    {"odbc_scanner", "Adds support for connecting to remote databases over ODBC", false, "v1.2.0-api"},
     {nullptr, nullptr, false, nullptr}};
 
 idx_t ExtensionHelper::DefaultExtensionCount() {
@@ -141,11 +141,11 @@ DefaultExtension ExtensionHelper::GetDefaultExtension(idx_t index) {
 	return internal_extensions[index];
 }
 
-string ExtensionHelper::GetExtensionMinCompatVersion(const string &extension_name) {
+string ExtensionHelper::GetExtensionApiVersion(const string &extension_name) {
 	for (const DefaultExtension &default_extension : internal_extensions) {
 		if (default_extension.name != nullptr && strcmp(extension_name.c_str(), default_extension.name) == 0) {
-			if (default_extension.min_compat_version != nullptr) {
-				return std::string(default_extension.min_compat_version);
+			if (default_extension.api_version != nullptr) {
+				return std::string(default_extension.api_version);
 			} else {
 				return "";
 			}

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -143,7 +143,7 @@ DefaultExtension ExtensionHelper::GetDefaultExtension(idx_t index) {
 
 string ExtensionHelper::GetExtensionMinCompatVersion(const string &extension_name) {
 	for (const DefaultExtension &default_extension : internal_extensions) {
-		if (strcmp(extension_name.c_str(), default_extension.name) == 0) {
+		if (default_extension.name != nullptr && strcmp(extension_name.c_str(), default_extension.name) == 0) {
 			if (default_extension.min_compat_version != nullptr) {
 				return std::string(default_extension.min_compat_version);
 			} else {

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -100,32 +100,34 @@ namespace duckdb {
 // Default Extensions
 //===--------------------------------------------------------------------===//
 static const DefaultExtension internal_extensions[] = {
-    {"core_functions", "Core function library", DUCKDB_EXTENSION_CORE_FUNCTIONS_LINKED},
-    {"icu", "Adds support for time zones and collations using the ICU library", DUCKDB_EXTENSION_ICU_LINKED},
-    {"excel", "Adds support for Excel-like format strings", DUCKDB_EXTENSION_EXCEL_LINKED},
-    {"parquet", "Adds support for reading and writing parquet files", DUCKDB_EXTENSION_PARQUET_LINKED},
-    {"tpch", "Adds TPC-H data generation and query support", DUCKDB_EXTENSION_TPCH_LINKED},
-    {"tpcds", "Adds TPC-DS data generation and query support", DUCKDB_EXTENSION_TPCDS_LINKED},
-    {"httpfs", "Adds support for reading and writing files over a HTTP(S) connection", DUCKDB_EXTENSION_HTTPFS_LINKED},
-    {"json", "Adds support for JSON operations", DUCKDB_EXTENSION_JSON_LINKED},
-    {"jemalloc", "Overwrites system allocator with JEMalloc", DUCKDB_EXTENSION_JEMALLOC_LINKED},
-    {"autocomplete", "Adds support for autocomplete in the shell", DUCKDB_EXTENSION_AUTOCOMPLETE_LINKED},
-    {"motherduck", "Enables motherduck integration with the system", false},
-    {"mysql_scanner", "Adds support for connecting to a MySQL database", false},
-    {"sqlite_scanner", "Adds support for reading and writing SQLite database files", false},
-    {"postgres_scanner", "Adds support for connecting to a Postgres database", false},
-    {"inet", "Adds support for IP-related data types and functions", false},
-    {"spatial", "Geospatial extension that adds support for working with spatial data and functions", false},
-    {"aws", "Provides features that depend on the AWS SDK", false},
-    {"azure", "Adds a filesystem abstraction for Azure blob storage to DuckDB", false},
-    {"encodings", "All unicode encodings to UTF-8", false},
-    {"iceberg", "Adds support for Apache Iceberg", false},
-    {"vss", "Adds indexing support to accelerate Vector Similarity Search", false},
-    {"delta", "Adds support for Delta Lake", false},
-    {"fts", "Adds support for Full-Text Search Indexes", false},
-    {"ui", "Adds local UI for DuckDB", false},
-    {"ducklake", "Adds support for DuckLake, SQL as a Lakehouse Format", false},
-    {nullptr, nullptr, false}};
+    {"core_functions", "Core function library", DUCKDB_EXTENSION_CORE_FUNCTIONS_LINKED, nullptr},
+    {"icu", "Adds support for time zones and collations using the ICU library", DUCKDB_EXTENSION_ICU_LINKED, nullptr},
+    {"excel", "Adds support for Excel-like format strings", DUCKDB_EXTENSION_EXCEL_LINKED, nullptr},
+    {"parquet", "Adds support for reading and writing parquet files", DUCKDB_EXTENSION_PARQUET_LINKED, nullptr},
+    {"tpch", "Adds TPC-H data generation and query support", DUCKDB_EXTENSION_TPCH_LINKED, nullptr},
+    {"tpcds", "Adds TPC-DS data generation and query support", DUCKDB_EXTENSION_TPCDS_LINKED, nullptr},
+    {"httpfs", "Adds support for reading and writing files over a HTTP(S) connection", DUCKDB_EXTENSION_HTTPFS_LINKED,
+     nullptr},
+    {"json", "Adds support for JSON operations", DUCKDB_EXTENSION_JSON_LINKED, nullptr},
+    {"jemalloc", "Overwrites system allocator with JEMalloc", DUCKDB_EXTENSION_JEMALLOC_LINKED, nullptr},
+    {"autocomplete", "Adds support for autocomplete in the shell", DUCKDB_EXTENSION_AUTOCOMPLETE_LINKED, nullptr},
+    {"motherduck", "Enables motherduck integration with the system", false, nullptr},
+    {"mysql_scanner", "Adds support for connecting to a MySQL database", false, nullptr},
+    {"sqlite_scanner", "Adds support for reading and writing SQLite database files", false, nullptr},
+    {"postgres_scanner", "Adds support for connecting to a Postgres database", false, nullptr},
+    {"inet", "Adds support for IP-related data types and functions", false, nullptr},
+    {"spatial", "Geospatial extension that adds support for working with spatial data and functions", false, nullptr},
+    {"aws", "Provides features that depend on the AWS SDK", false, nullptr},
+    {"azure", "Adds a filesystem abstraction for Azure blob storage to DuckDB", false, nullptr},
+    {"encodings", "All unicode encodings to UTF-8", false, nullptr},
+    {"iceberg", "Adds support for Apache Iceberg", false, nullptr},
+    {"vss", "Adds indexing support to accelerate Vector Similarity Search", false, nullptr},
+    {"delta", "Adds support for Delta Lake", false, nullptr},
+    {"fts", "Adds support for Full-Text Search Indexes", false, nullptr},
+    {"ui", "Adds local UI for DuckDB", false, nullptr},
+    {"ducklake", "Adds support for DuckLake, SQL as a Lakehouse Format", false, nullptr},
+    {"odbc_scanner", "Adds support for connecting to remote databases over ODBC", false, "v1.2.0"},
+    {nullptr, nullptr, false, nullptr}};
 
 idx_t ExtensionHelper::DefaultExtensionCount() {
 	idx_t index;
@@ -137,6 +139,19 @@ idx_t ExtensionHelper::DefaultExtensionCount() {
 DefaultExtension ExtensionHelper::GetDefaultExtension(idx_t index) {
 	D_ASSERT(index < DefaultExtensionCount());
 	return internal_extensions[index];
+}
+
+string ExtensionHelper::GetExtensionMinCompatVersion(const string &extension_name) {
+	for (const DefaultExtension &default_extension : internal_extensions) {
+		if (strcmp(extension_name.c_str(), default_extension.name) == 0) {
+			if (default_extension.min_compat_version != nullptr) {
+				return std::string(default_extension.min_compat_version);
+			} else {
+				return "";
+			}
+		}
+	}
+	return "";
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -253,7 +253,7 @@ string ExtensionHelper::ExtensionUrlTemplate(optional_ptr<const DatabaseInstance
 }
 
 string ExtensionHelper::ExtensionFinalizeUrlTemplate(const string &url_template, const string &extension_name) {
-	string version = ExtensionHelper::GetExtensionMinCompatVersion(extension_name);
+	string version = ExtensionHelper::GetExtensionApiVersion(extension_name);
 	if (version.empty()) {
 		version = GetVersionDirectoryName();
 	}

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -253,7 +253,11 @@ string ExtensionHelper::ExtensionUrlTemplate(optional_ptr<const DatabaseInstance
 }
 
 string ExtensionHelper::ExtensionFinalizeUrlTemplate(const string &url_template, const string &extension_name) {
-	auto url = StringUtil::Replace(url_template, "${REVISION}", GetVersionDirectoryName());
+	string version = ExtensionHelper::GetExtensionMinCompatVersion(extension_name);
+	if (version.empty()) {
+		version = GetVersionDirectoryName();
+	}
+	auto url = StringUtil::Replace(url_template, "${REVISION}", version);
 	url = StringUtil::Replace(url, "${PLATFORM}", DuckDB::Platform());
 	url = StringUtil::Replace(url, "${NAME}", extension_name);
 	return url;


### PR DESCRIPTION
When an extension is installed by name, the version of the running DuckDB instance is used in the download URL. For C++ extensions this version must match sctrictly with the S3/CF directory name in which the extension resides. For C API extensions that are portable between multiple versions of the engine - the strict match is not necessary.

This PR introduces the internal `min_compat_version` field for the internal registry of core extensions. The idea is to store in this field the minimal version of DuckDB with which this extension can be loaded.

The intention is to have this new field in a free form string. C API extensions created from the [extension-template-c](https://github.com/duckdb/extension-template-c) by default are compatible with DuckDB 1.2.0, so the `min_compat_version` string for them is `v1.2.0`.

While for C++ extensions this field is `nullptr`, it is anticipated that at some point in the future such extensions can begin using [duckdb-cpp-api](https://github.com/duckdb/duckdb-cpp-api) and thus will become portable between versions.

In current implementation the min version field does not affect the local directory in which the extension is installed. So when a C API extension is installed from multiple versions of DuckDB (for example, `1.5.0` and `1.5.1`) - the extension binary will be downloaded (from the remote `min_compat_version` directory) independently into local directories `v1.5.0` and `v1.5.1`. Note, that C API extensions does not have the engine symbols statically linked into them, so their size is expected to be under 1MB.

This PR also adds [odbc_scanner](https://github.com/duckdb/odbc-scanner) extension to the list of core extension with the min version `v1.2.0`. The alias `odbc` is added for it the same way as such aliases work for `postgres` and `mysql` extensions.

Testing: no automated tests are added as the URL change is currently only effective for the `odbc_scanner` - for all other extensions the URL creation logic remains the same as before. It is checked manually, that with this change the `odbc_scanner` can be installed using:

```sql
INSTALL odbc FROM core_nightly;
```