### PR TITLE
Fix CheckDirectory for remote fileystems

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -416,7 +416,12 @@ void CheckDirectory(FileSystem &fs, const string &file_path, CopyOverwriteMode o
 	for (idx_t dir_idx = 0; dir_idx < directory_list.size(); dir_idx++) {
 		auto directory = directory_list[dir_idx];
 		fs.ListFiles(directory, [&](const string &path, bool is_directory) {
-			auto full_path = fs.JoinPath(directory, path);
+			string full_path;
+			if (FileSystem::IsRemoteFile(path) || fs.IsPathAbsolute(path)) {
+				full_path = path;
+			} else {
+				full_path = fs.JoinPath(directory, path);
+			}
 			if (is_directory) {
 				directory_list.emplace_back(std::move(full_path));
 			} else {


### PR DESCRIPTION
This PR follows up on https://github.com/duckdb/duckdb/commit/9315536f74ce4ee63297acee86bd910157263ca8 and is related to https://github.com/duckdb/duckdb-httpfs/pull/181.

When using `COPY ... OVERWRITE` on remote file systems (e.g., S3), the `CheckDirectory` function would incorrectly join paths returned by `ListFiles` because the S3 implementation of this function returns the full path.

The alternative is to fix `ListFiles` in duckdb-httpfs/src/s3fs.cpp to return the relative path. 