### PR TITLE
Support generated columns in DELETE RETURNING optimization

### DIFF
--- a/benchmark/micro/delete_returning/delete_returning_3col_generated.benchmark
+++ b/benchmark/micro/delete_returning/delete_returning_3col_generated.benchmark
@@ -1,5 +1,5 @@
 # name: benchmark/micro/delete_returning/delete_returning_3col_generated.benchmark
-# description: DELETE RETURNING with 3 columns including generated (fallback fetch-by-rowid path)
+# description: DELETE RETURNING with 3 columns including generated column
 # group: [delete_returning]
 
 load

--- a/src/execution/operator/persistent/physical_delete.cpp
+++ b/src/execution/operator/persistent/physical_delete.cpp
@@ -83,6 +83,7 @@ SinkResultType PhysicalDelete::Sink(ExecutionContext &context, DataChunk &chunk,
 
 	if (use_input_columns) {
 		// Use columns from the input chunk - they were passed through from the scan
+		// Only physical columns are passed; generated columns are computed in the RETURNING projection
 		for (idx_t i = 0; i < table.ColumnCount(); i++) {
 			D_ASSERT(return_columns[i] != DConstants::INVALID_INDEX);
 			l_state.delete_chunk.data[i].Reference(chunk.data[return_columns[i]]);
@@ -91,7 +92,6 @@ SinkResultType PhysicalDelete::Sink(ExecutionContext &context, DataChunk &chunk,
 	} else {
 		// Fall back to fetching columns by row ID
 		// This path is used when:
-		// - Table has generated columns (can't be scanned, must be computed)
 		// - Unique indexes exist but no RETURNING (need indexed columns for delete tracking)
 		// - MERGE INTO operations (optimization not implemented there yet)
 		auto &transaction = DuckTransaction::Get(context.client, table.db);

--- a/test/sql/returning/returning_delete.test
+++ b/test/sql/returning/returning_delete.test
@@ -323,7 +323,8 @@ statement ok
 DROP TABLE test_where_returning;
 
 # ============================================================
-# Tests for DELETE RETURNING with generated columns (fallback path)
+# Tests for DELETE RETURNING with generated columns
+# Generated columns are computed at execution time from physical columns
 # ============================================================
 
 # Test DELETE RETURNING with VIRTUAL generated column


### PR DESCRIPTION
## Summary

This PR extends the DELETE RETURNING optimization from PR #20485 to support tables with generated columns.

## Problem

Previously, DELETE RETURNING would fall back to the slower row-ID-fetch path when the table had generated columns because generated columns cannot be scanned directly from disk - they must be computed from their expressions.

## Solution

Instead of falling back, we now:
1. Scan all physical columns and pass them through from the scan (same as before for non-generated tables)
2. Let the RETURNING projection compute generated columns using their expressions

This is the same approach already used by INSERT RETURNING and UPDATE RETURNING.

## Changes

- `bind_delete.cpp`: Removed the `HasGeneratedColumns()` check that was skipping the optimization
- `physical_delete.cpp`: Updated comment to reflect that generated columns are no longer a fallback reason
- `returning_delete.test`: Updated test comments
- `delete_returning_3col_generated.benchmark`: Updated description

## Testing

All existing tests pass, including the tests for DELETE RETURNING with generated columns.