### PR TITLE
Bump httpfs

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,6 +1,6 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG add35a03c1adfe530bb4ef69133b94fe8ec8ea35
+    GIT_TAG b914a304e17e6fe57240fbbd8e7feaff09d1f24e
     INCLUDE_DIR src/include
 )


### PR DESCRIPTION
The default networking backend has been updated from `httplib` to `curl`. This change is intended to provide a more robust HTTP library while preserving the same functionality as before. Users should expect feature parity with the previous backend. However, there may be subtle behavioral differences (e.g. in error handling or edge cases) that  might not have yet been fully accounted for. While no regressions are expected, be aware that unexpected behavior may still occur as a result of the backend change.

Users who wish to keep the previous behavior can explicitly opt back into the old implementation via:
```
SET httpfs_client_implementation = httplib;
```