### PR TITLE
exclude MacOS extension builds for PRs

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -123,7 +123,7 @@ jobs:
 
     env:
       # NOTE: on PRs we exclude some archs to speed things up
-      BASE_EXCLUDE_ARCHS: ${{ (github.event_name == 'pull_request' || inputs.run_all != 'true') && 'wasm_mvp;wasm_threads;windows_amd64_mingw;osx_amd64;linux_arm64;linux_amd64_musl;' || '' }}
+      BASE_EXCLUDE_ARCHS: ${{ (github.event_name == 'pull_request' || inputs.run_all != 'true') && 'wasm_mvp;wasm_threads;windows_amd64_mingw;osx_amd64;osx_arm64;linux_arm64;linux_amd64_musl;' || '' }}
       EXTRA_EXCLUDE_ARCHS: ${{ inputs.extra_exclude_archs }}
       OPT_IN_ARCHS: ${{ inputs.opt_in_archs }}
     steps:


### PR DESCRIPTION
Work item: https://github.com/duckdblabs/duckdb-internal/issues/7142

With this PR the MacOS extensions are no longer build for PRs for `duckdb/duckdb`

### changes
Workflow `Extensions.yml` triggers on PRs.
Variable `BASE_EXCLUDE_ARCHS` is used to list the excluded architectures specifically for PR triggers.
Note that when `InvokeCI` runs `Extensions.yml`, the archs in `BASE_EXCLUDE_ARCHS` are NOT excluded.

Propagation of var `BASE_EXCLUDE_ARCHS`:

| repo               | file                                           | Variable             |
|--------------------|------------------------------------------------|----------------------|
| duckdb             | .github/workflows/Extensions.yml               | BASE_EXCLUDE_ARCHS   |
| duckdb             | .github/workflows/Extensions.yml               | exclude_archs        |
| duckdb             | .github/workflows/_extension_distribution.yml  | exclude_archs        |
| extension-ci-tools | .github/workflows/_extension_distribution.yml  | exclude_archs        |
| extension-ci-tools | scripts/modify_distribution_matrix.py          | excluded_arch_values |
| extension-ci-tools | config/distribution_matrix.json                | duckdb_arch          |