### PR TITLE
fix a concurrency bug where prepared statements created from a single…

### DIFF
--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -70,19 +70,34 @@ case_insensitive_map_t<LogicalType> PreparedStatement::GetExpectedParameterTypes
 
 unique_ptr<QueryResult> PreparedStatement::Execute(case_insensitive_map_t<BoundParameterData> &named_values,
                                                    bool allow_stream_result) {
-	auto pending = PendingQuery(named_values, allow_stream_result);
-	if (pending->HasError()) {
-		return make_uniq<MaterializedQueryResult>(pending->GetErrorObject());
+	if (!success) {
+		return make_uniq<MaterializedQueryResult>(
+		    ErrorData(InvalidInputException("Attempting to execute an unsuccessfully prepared statement!")));
 	}
-	return pending->Execute();
+
+	try {
+		VerifyParameters(named_values, named_param_map);
+	} catch (const std::exception &ex) {
+		return make_uniq<MaterializedQueryResult>(ErrorData(ex));
+	}
+
+	PendingQueryParameters parameters;
+	parameters.parameters = &named_values;
+	D_ASSERT(data);
+	parameters.query_parameters.output_type =
+	    allow_stream_result && data->properties.output_type == QueryResultOutputType::ALLOW_STREAMING
+	        ? QueryResultOutputType::ALLOW_STREAMING
+	        : QueryResultOutputType::FORCE_MATERIALIZED;
+
+	return context->Execute(query, data, parameters);
 }
 
 unique_ptr<QueryResult> PreparedStatement::Execute(vector<Value> &values, bool allow_stream_result) {
-	auto pending = PendingQuery(values, allow_stream_result);
-	if (pending->HasError()) {
-		return make_uniq<MaterializedQueryResult>(pending->GetErrorObject());
+	case_insensitive_map_t<BoundParameterData> named_values;
+	for (idx_t i = 0; i < values.size(); i++) {
+		named_values[std::to_string(i + 1)] = BoundParameterData(values[i]);
 	}
-	return pending->Execute();
+	return Execute(named_values, allow_stream_result);
 }
 
 unique_ptr<PendingQueryResult> PreparedStatement::PendingQuery(vector<Value> &values, bool allow_stream_result) {

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -686,11 +686,11 @@ TEST_CASE("Test concurrent prepared statement execution race condition MRE", "[c
 	duckdb_connection conn;
 	REQUIRE(duckdb_connect(db, &conn) == DuckDBSuccess);
 
-	std::atomic<int> failures {0};
-	std::atomic<int> completed {0};
+	std::atomic<idx_t> failures {0};
+	std::atomic<idx_t> completed {0};
 
-	constexpr int NUM_THREADS = 4;
-	constexpr int ITERATIONS = 1000;
+	constexpr idx_t NUM_THREADS = 4;
+	constexpr idx_t ITERATIONS = 1000;
 
 	duckdb::vector<std::thread> threads;
 	for (int t = 0; t < NUM_THREADS; t++) {

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -1,4 +1,7 @@
 #include "capi_tester.hpp"
+#include <atomic>
+#include <random>
+#include <thread>
 
 using namespace duckdb;
 using namespace std;
@@ -670,6 +673,56 @@ TEST_CASE("Test STRING LITERAL parameter type", "[capi]") {
 	REQUIRE(duckdb_bind_varchar(stmt, 1, "a") == DuckDBSuccess);
 	REQUIRE(duckdb_param_type(stmt, 1) == DUCKDB_TYPE_STRING_LITERAL);
 	duckdb_destroy_prepare(&stmt);
+
+	duckdb_disconnect(&conn);
+	duckdb_close(&db);
+}
+
+TEST_CASE("Test concurrent prepared statement execution race condition MRE", "[capi]") {
+	// This test is a minimal reproducible example for the race condition described in #7187 (internal).
+	duckdb_database db;
+	REQUIRE(duckdb_open(nullptr, &db) == DuckDBSuccess);
+
+	duckdb_connection conn;
+	REQUIRE(duckdb_connect(db, &conn) == DuckDBSuccess);
+
+	std::atomic<int> failures {0};
+	std::atomic<int> completed {0};
+
+	constexpr int NUM_THREADS = 4;
+	constexpr int ITERATIONS = 1000;
+
+	duckdb::vector<std::thread> threads;
+	for (int t = 0; t < NUM_THREADS; t++) {
+		threads.emplace_back([ITERATIONS, &conn, &failures, &completed]() {
+			for (int i = 0; i < ITERATIONS; i++) {
+				duckdb_prepared_statement stmt = nullptr;
+				if (duckdb_prepare(conn, "SELECT 1", &stmt) != DuckDBSuccess) {
+					++failures;
+					continue;
+				}
+
+				duckdb_result result;
+				if (duckdb_execute_prepared(stmt, &result) != DuckDBSuccess) {
+					++failures;
+					duckdb_destroy_prepare(&stmt);
+					continue;
+				}
+
+				duckdb_destroy_result(&result);
+				duckdb_destroy_prepare(&stmt);
+				++completed;
+			}
+		});
+	}
+
+	for (auto &t : threads) {
+		t.join();
+	}
+
+	// All executions should succeed
+	REQUIRE(failures == 0);
+	REQUIRE(completed == NUM_THREADS * ITERATIONS);
 
 	duckdb_disconnect(&conn);
 	duckdb_close(&db);


### PR DESCRIPTION
… connection may override during execution.

Ref: https://github.com/duckdblabs/duckdb-internal/issues/7187.

The TL;DR is that when users:
* share a single connection across multiple threads and
* create, bind and execute prepared statements within these threads, then...

... a thread may override the `active_query` that was set in the `ClientContext` by a different thread, because the client context lock is released and re-acquired between setting the active query and executing it.