### PR TITLE
Avoid numeric statistics propagation on non-numeric CAST expressions

### DIFF
--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -5,6 +5,10 @@ namespace duckdb {
 
 static unique_ptr<BaseStatistics> StatisticsOperationsNumericNumericCast(const BaseStatistics &input,
                                                                          const LogicalType &target) {
+	// Bail out if the stats are not numeric
+	if (input.GetStatsType() != StatisticsType::NUMERIC_STATS) {
+		return nullptr;
+	}
 	if (!NumericStats::HasMinMax(input)) {
 		return nullptr;
 	}

--- a/test/optimizer/stats_non_numeric_cast.test
+++ b/test/optimizer/stats_non_numeric_cast.test
@@ -1,0 +1,18 @@
+# name: test/optimizer/stats_non_numeric_cast.test
+# description: test statistics propagation for non-numeric cast
+# group: [optimizer]
+
+statement ok
+pragma disabled_optimizers='expression_rewriter';
+
+statement ok
+CREATE TABLE t(n_name VARCHAR);
+
+statement ok
+INSERT INTO t VALUES ('FRANCE'), ('GERMANY');
+
+query II
+SELECT * FROM t a JOIN t b ON ( (a.n_name = 'FRANCE' AND b.n_name = 'GERMANY') OR (a.n_name = 'GERMANY' AND b.n_name = 'FRANCE'));
+----
+GERMANY	FRANCE
+FRANCE	GERMANY


### PR DESCRIPTION
`StatisticsPropagator::TryPropagateCast` assumes that all propagated statistics are numeric, causing a crash when it encounters cast expressions with non-numeric statistics (e.g., VARCHAR). This issue never popped up because the `EXPRESSION_REWRITER` would remove casts from the plan, preventing `TryPropagateCast` from being called on non-numeric expressions. For example, a query with VARCHAR comparisons can produce a plan with casts like:

```
┌─────────────┴─────────────┐
│          ANY_JOIN         │
│    ────────────────────   │
│         Condition:        │
│ (((n_name = CAST('FRANCE' │
│  AS VARCHAR)) AND (n_name │
│    = CAST('GERMANY' AS    |
│  VARCHAR))) OR ((n_name = │              
│  CAST('GERMANY' AS VARCHAR│              
│   )) AND (n_name = CAST(  │              
│  'FRANCE' AS VARCHAR))))  │              
└─────────────┬─────────────┘              
```

This PR adds a type check to enusre that statistics are actually numeric before propagating and attempting numeric operations.

Fixes: https://github.com/duckdblabs/duckdb-internal/issues/6513
