### PR TITLE
Rename checkpoint / recovery WAL to no longer be valid WAL files

### DIFF
--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -703,8 +703,8 @@ void EnableExternalAccessSetting::OnSet(SettingCallbackInfo &info, Value &input)
 		for (auto &path : attached_paths) {
 			config.AddAllowedPath(path);
 			config.AddAllowedPath(path + ".wal");
-			config.AddAllowedPath(path + ".checkpoint.wal");
-			config.AddAllowedPath(path + ".recovery.wal");
+			config.AddAllowedPath(path + ".wal.checkpoint");
+			config.AddAllowedPath(path + ".wal.recovery");
 		}
 	}
 	if (config.options.use_temporary_directory && !config.options.temporary_directory.empty()) {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -282,11 +282,11 @@ string StorageManager::GetWALPath(const string &suffix) {
 }
 
 string StorageManager::GetCheckpointWALPath() {
-	return GetWALPath(".checkpoint.wal");
+	return GetWALPath(".wal.checkpoint");
 }
 
 string StorageManager::GetRecoveryWALPath() {
-	return GetWALPath(".recovery.wal");
+	return GetWALPath(".wal.recovery");
 }
 
 bool StorageManager::InMemory() const {

--- a/test/sql/storage/concurrent_wal/concurrent_checkpoint_abort.test_slow
+++ b/test/sql/storage/concurrent_wal/concurrent_checkpoint_abort.test_slow
@@ -75,7 +75,7 @@ NULL
 
 # neither checkpoint WAL nor WAL is cleared when attaching in read-only mode
 query I
-SELECT COUNT(*) FROM glob('__TEST_DIR__/concurrent_abort.db.*wal')
+SELECT COUNT(*) FROM glob('__TEST_DIR__/concurrent_abort.db.wal*')
 ----
 2
 


### PR DESCRIPTION
The checkpoint / recovery WAL files introduced in https://github.com/duckdb/duckdb/pull/20052 are now named `.wal.checkpoint` and `.wal.recovery` to prevent them from being valid WAL files themselves (i.e. `x.checkpoint.wal` would still be a valid WAL file for a database called `x.checkpoint`)