### PR TITLE
Bump Iceberg v1.4

### DIFF
--- a/.github/config/extensions/iceberg.cmake
+++ b/.github/config/extensions/iceberg.cmake
@@ -8,6 +8,6 @@ if (NOT MINGW)
     duckdb_extension_load(iceberg
             ${LOAD_ICEBERG_TESTS}
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 0ba81364951e89ed2a4c45678b850da5894ae95a
+            GIT_TAG 1095c1fa9f097ca46b492125ac064c75f06deadf
             )
 endif()


### PR DESCRIPTION
Need to bump iceberg again. Current v1.4-implementation uses unsupported url for certain catalogs. 
only includes the following fix

https://github.com/duckdb/duckdb-iceberg/pull/658