### PR TITLE
Fail fast extensions

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -63,7 +63,7 @@ constexpr FileOpenFlags FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_EXISTS;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_DISABLE_LOGGING;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_ENABLE_DUCKDB_EXTENSION;
+constexpr FileOpenFlags FileFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL;
 
 void FileOpenFlags::Verify() {
 #ifdef DEBUG

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -63,6 +63,7 @@ constexpr FileOpenFlags FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_EXISTS;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_DISABLE_LOGGING;
+constexpr FileOpenFlags FileFlags::FILE_FLAGS_ENABLE_DUCKDB_EXTENSION;
 
 void FileOpenFlags::Verify() {
 #ifdef DEBUG

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -30,7 +30,7 @@ public:
 	static constexpr idx_t FILE_FLAGS_NULL_IF_EXISTS = idx_t(1 << 10);
 	static constexpr idx_t FILE_FLAGS_MULTI_CLIENT_ACCESS = idx_t(1 << 11);
 	static constexpr idx_t FILE_FLAGS_DISABLE_LOGGING = idx_t(1 << 12);
-	static constexpr idx_t FILE_FLAGS_ENABLE_DUCKDB_EXTENSION = idx_t(1 << 13);
+	static constexpr idx_t FILE_FLAGS_ENABLE_EXTENSION_INSTALL = idx_t(1 << 13);
 
 public:
 	FileOpenFlags() = default;
@@ -116,8 +116,8 @@ public:
 	inline bool DisableLogging() const {
 		return flags & FILE_FLAGS_DISABLE_LOGGING;
 	}
-	inline bool EnableAsDuckDBExtension() const {
-		return flags & FILE_FLAGS_ENABLE_DUCKDB_EXTENSION;
+	inline bool EnableExtensionInstall() const {
+		return flags & FILE_FLAGS_ENABLE_EXTENSION_INSTALL;
 	}
 	inline idx_t GetFlagsInternal() const {
 		return flags;
@@ -164,8 +164,8 @@ public:
 	static constexpr FileOpenFlags FILE_FLAGS_DISABLE_LOGGING =
 	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_DISABLE_LOGGING);
 	//! Opened file might be a duckdb_extension file
-	static constexpr FileOpenFlags FILE_FLAGS_ENABLE_DUCKDB_EXTENSION =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_ENABLE_DUCKDB_EXTENSION);
+	static constexpr FileOpenFlags FILE_FLAGS_ENABLE_EXTENSION_INSTALL =
+	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -163,7 +163,7 @@ public:
 	//! Disables logging to avoid infinite loops when using FileHandle-backed log storage
 	static constexpr FileOpenFlags FILE_FLAGS_DISABLE_LOGGING =
 	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_DISABLE_LOGGING);
-	//! Opened file might be a duckdb_extension file
+	//! Opened file is allowed to be a duckdb_extension
 	static constexpr FileOpenFlags FILE_FLAGS_ENABLE_EXTENSION_INSTALL =
 	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL);
 };

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -30,6 +30,7 @@ public:
 	static constexpr idx_t FILE_FLAGS_NULL_IF_EXISTS = idx_t(1 << 10);
 	static constexpr idx_t FILE_FLAGS_MULTI_CLIENT_ACCESS = idx_t(1 << 11);
 	static constexpr idx_t FILE_FLAGS_DISABLE_LOGGING = idx_t(1 << 12);
+	static constexpr idx_t FILE_FLAGS_ENABLE_DUCKDB_EXTENSION = idx_t(1 << 13);
 
 public:
 	FileOpenFlags() = default;
@@ -115,6 +116,9 @@ public:
 	inline bool DisableLogging() const {
 		return flags & FILE_FLAGS_DISABLE_LOGGING;
 	}
+	inline bool EnableAsDuckDBExtension() const {
+		return flags & FILE_FLAGS_ENABLE_DUCKDB_EXTENSION;
+	}
 	inline idx_t GetFlagsInternal() const {
 		return flags;
 	}
@@ -159,6 +163,9 @@ public:
 	//! Disables logging to avoid infinite loops when using FileHandle-backed log storage
 	static constexpr FileOpenFlags FILE_FLAGS_DISABLE_LOGGING =
 	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_DISABLE_LOGGING);
+	//! Opened file might be a duckdb_extension file
+	static constexpr FileOpenFlags FILE_FLAGS_ENABLE_DUCKDB_EXTENSION =
+	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_ENABLE_DUCKDB_EXTENSION);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -80,6 +80,10 @@ public:
 		VerifyNoOpener(opener);
 		VerifyCanAccessFile(source);
 		VerifyCanAccessFile(target);
+		if (StringUtil::EndsWith(target, "duckdb_extension") && !StringUtil::EndsWith(source, "duckdb_extension")) {
+			throw PermissionException("File '%s' cannot be moved to '%s' due to the suffix 'duckdb_extension'", source,
+			                          target);
+		}
 		GetFileSystem().MoveFile(source, target, GetOpener());
 	}
 
@@ -156,6 +160,11 @@ protected:
 	                                        optional_ptr<FileOpener> opener = nullptr) override {
 		VerifyNoOpener(opener);
 		VerifyCanAccessFile(file.path);
+		if (flags.OpenForWriting() && !flags.EnableAsDuckDBExtension() &&
+		    StringUtil::EndsWith(file.path, "duckdb_extension")) {
+			throw PermissionException("File '%s' cannot be open in write mode due to the suffix 'duckdb_extension'",
+			                          file.path);
+		}
 		return GetFileSystem().OpenFile(file, flags, GetOpener());
 	}
 

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -163,7 +163,7 @@ protected:
 	                                        optional_ptr<FileOpener> opener = nullptr) override {
 		VerifyNoOpener(opener);
 		VerifyCanAccessFile(file.path);
-		if (flags.OpenForWriting() && !flags.EnableAsDuckDBExtension() &&
+		if (flags.OpenForWriting() && !flags.EnableExtensionInstall() &&
 		    StringUtil::EndsWith(file.path, "duckdb_extension")) {
 			throw PermissionException(
 			    "File '%s' cannot be opened for writing since files ending with duckdb_extension are reserved for "

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -81,8 +81,11 @@ public:
 		VerifyCanAccessFile(source);
 		VerifyCanAccessFile(target);
 		if (StringUtil::EndsWith(target, "duckdb_extension") && !StringUtil::EndsWith(source, "duckdb_extension")) {
-			throw PermissionException("File '%s' cannot be moved to '%s' due to the suffix 'duckdb_extension'", source,
-			                          target);
+			throw PermissionException(
+			    "File '%s' cannot be moved to '%s', files ending with duckdb_extension are reserved for DuckDB "
+			    "extensions, and these can only be installed through the INSTALL command, or moved if both are "
+			    "extensions'",
+			    source, target);
 		}
 		GetFileSystem().MoveFile(source, target, GetOpener());
 	}
@@ -162,8 +165,10 @@ protected:
 		VerifyCanAccessFile(file.path);
 		if (flags.OpenForWriting() && !flags.EnableAsDuckDBExtension() &&
 		    StringUtil::EndsWith(file.path, "duckdb_extension")) {
-			throw PermissionException("File '%s' cannot be open in write mode due to the suffix 'duckdb_extension'",
-			                          file.path);
+			throw PermissionException(
+			    "File '%s' cannot be opened for writing since files ending with duckdb_extension are reserved for "
+			    "DuckDB extensions, and these can only be installed through the INSTALL command",
+			    file.path);
 		}
 		return GetFileSystem().OpenFile(file, flags, GetOpener());
 	}

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -24,14 +24,14 @@ public:
 	void VerifyCanAccessExtension(const string &path, const FileOpenFlags &flags) {
 		if (flags.OpenForWriting() && !flags.EnableExtensionInstall()) {
 			throw PermissionException(
-			    "File '%s' cannot be opened for writing since files ending with duckdb_extension are reserved for "
+			    "File '%s' cannot be opened for writing since files ending with '.duckdb_extension' are reserved for "
 			    "DuckDB extensions, and these can only be installed through the INSTALL command",
 			    path);
 		}
 	}
 
 	bool IsDuckDBExtensionName(const string &path) {
-		return StringUtil::EndsWith(path, "duckdb_extension");
+		return StringUtil::EndsWith(path, ".duckdb_extension");
 	}
 
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
@@ -94,7 +94,7 @@ public:
 		VerifyCanAccessFile(target);
 		if (IsDuckDBExtensionName(target) && !IsDuckDBExtensionName(source)) {
 			throw PermissionException(
-			    "File '%s' cannot be moved to '%s', files ending with duckdb_extension are reserved for DuckDB "
+			    "File '%s' cannot be moved to '%s', files ending with '.duckdb_extension' are reserved for DuckDB "
 			    "extensions, and these can only be installed through the INSTALL command, or moved if both are "
 			    "extensions'",
 			    source, target);

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -126,8 +126,15 @@ public:
 	static string GetExtensionDirectoryPath(ClientContext &context);
 	static string GetExtensionDirectoryPath(DatabaseInstance &db, FileSystem &fs);
 
+	// Check signature of an Extension stored as FileHandle
 	static bool CheckExtensionSignature(FileHandle &handle, ParsedExtensionMetaData &parsed_metadata,
 	                                    const bool allow_community_extensions);
+	// Check signature of an Extension, represented by a buffer and total_buffer_length, and a signature to be added
+	static bool CheckExtensionBufferSignature(const char *buffer, idx_t buffer_length, const string &signature,
+	                                          const bool allow_community_extensions);
+	// Check signature of an Extension, represented by a buffer and total_buffer_length
+	static bool CheckExtensionBufferSignature(const char *buffer, idx_t total_buffer_length,
+	                                          const bool allow_community_extensions);
 	static ParsedExtensionMetaData ParseExtensionMetaData(const char *metadata) noexcept;
 	static ParsedExtensionMetaData ParseExtensionMetaData(FileHandle &handle);
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -176,8 +176,9 @@ static unsafe_unique_array<data_t> ReadExtensionFileFromDisk(FileSystem &fs, con
 
 static void WriteExtensionFileToDisk(QueryContext &query_context, FileSystem &fs, const string &path, void *data,
                                      idx_t data_size) {
-	auto target_file = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_APPEND |
-	                                         FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	auto target_file =
+	    fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_APPEND |
+	                          FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileFlags::FILE_FLAGS_ENABLE_DUCKDB_EXTENSION);
 	target_file->Write(query_context, data, data_size);
 	target_file->Close();
 	target_file.reset();
@@ -489,7 +490,10 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtensionInternal(Datab
 
 	auto extension_name = ApplyExtensionAlias(fs.ExtractBaseName(extension));
 	string local_extension_path = fs.JoinPath(local_path, extension_name + ".duckdb_extension");
-	string temp_path = local_extension_path + ".tmp-" + UUID::ToString(UUID::GenerateRandomUUID());
+	string temp_path =
+	    local_extension_path + ".tmp-" + UUID::ToString(UUID::GenerateRandomUUID()) + "-duckdb_extension";
+
+	// Note the missing '.', this is NOT yet a valid extension
 
 	if (fs.FileExists(local_extension_path) && !options.force_install) {
 		// File exists: throw error if origin mismatches

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -178,7 +178,7 @@ static void WriteExtensionFileToDisk(QueryContext &query_context, FileSystem &fs
                                      idx_t data_size, DBConfig &config) {
 	// Open target_file, at this points ending with '?duckdb_extension' (but not '.')
 	auto target_file =
-	    fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_APPEND |
+	    fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_APPEND |
 	                          FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileFlags::FILE_FLAGS_ENABLE_DUCKDB_EXTENSION);
 	// Write content to the file
 	target_file->Write(query_context, data, data_size);

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -178,7 +178,7 @@ static void WriteExtensionFileToDisk(QueryContext &query_context, FileSystem &fs
                                      idx_t data_size, DBConfig &config) {
 	if (!config.options.allow_unsigned_extensions) {
 		const bool signature_valid = ExtensionHelper::CheckExtensionBufferSignature(
-		    (const char *)data, data_size, config.options.allow_community_extensions);
+		    static_cast<char *>(data), data_size, config.options.allow_community_extensions);
 		if (!signature_valid) {
 			throw IOException("Attempting to install an extension file that doesn't have a valid signature, see "
 			                  "https://duckdb.org/docs/stable/operations_manual/securing_duckdb/securing_extensions");

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -179,7 +179,7 @@ static void WriteExtensionFileToDisk(QueryContext &query_context, FileSystem &fs
 	// Open target_file, at this points ending with '?duckdb_extension' (but not '.')
 	auto target_file =
 	    fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_APPEND |
-	                          FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileFlags::FILE_FLAGS_ENABLE_DUCKDB_EXTENSION);
+	                          FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL);
 	// Write content to the file
 	target_file->Write(query_context, data, data_size);
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -267,11 +267,18 @@ static void WriteExtensionFiles(QueryContext &query_context, FileSystem &fs, con
                                 const string &local_extension_path, void *in_buffer, idx_t file_size,
                                 ExtensionInstallInfo &info, DBConfig &config) {
 	// temp_path ends with 'duckdb_extension', but NOT preceded by a '.'
-	D_ASSERT(StringUtil::EndsWith(temp_path, "duckdb_extension") &&
-	         !StringUtil::EndsWith(temp_path, ".duckdb_extension"));
+	if (!StringUtil::EndsWith(temp_path, "duckdb_extension") || StringUtil::EndsWith(temp_path, ".duckdb_extension")) {
+		throw InternalException(
+		    "Extension install temp_path of '%s' is not valid, should end in 'duckdb_extension' not preceded by a '.'",
+		    temp_path);
+	}
 	// local_extension_path ends with '.duckdb_extension', and given it will be written only after signature checks,
 	// it's now loadable
-	D_ASSERT(StringUtil::EndsWith(local_extension_path, "duckdb_extension"));
+	if (!StringUtil::EndsWith(local_extension_path, ".duckdb_extension")) {
+		throw InternalException("Extension install local_extension_path of '%s' is not valid, should end in "
+		                        "'duckdb_extension' not preceded by a '.'",
+		                        temp_path);
+	}
 
 	// Write extension to tmp file
 	WriteExtensionFileToDisk(query_context, fs, temp_path, in_buffer, file_size, config);

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -365,6 +365,10 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 		filename = fs.JoinPath(local_path, extension_name + ".duckdb_extension");
 #endif
 	} else {
+		if (!db.config.options.allow_unsigned_extensions) {
+			throw PermissionException("Loading extensions from arbitrary paths is forbidden through configuration, "
+			                          "consider 'INSTALL <path>; LOAD <name>;'");
+		}
 		direct_load = true;
 		filename = fs.ExpandPath(filename);
 	}

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -34,6 +34,7 @@ struct DuckDBExtensionLoadState {
 	//! Create a DuckDBExtensionLoadState reference from a C API opaque pointer
 	static DuckDBExtensionLoadState &Get(duckdb_extension_info info) {
 		D_ASSERT(info);
+
 		return *reinterpret_cast<duckdb::DuckDBExtensionLoadState *>(info);
 	}
 
@@ -369,8 +370,10 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 		filename = fs.ExpandPath(filename);
 	}
 	if (!StringUtil::EndsWith(filename, ".duckdb_extension")) {
-		throw PermissionException("Loading extensions from path not ending with '.duckdb_extension' is forbidden",
-		                          "consider 'INSTALL <path>; LOAD <name>;'");
+		throw PermissionException(
+		    "DuckDB extensions are files ending with '.duckdb_extension', loading different "
+		    "files is not possible, error while loading from '%s', consider 'INSTALL <path>; LOAD <name>;'",
+		    filename);
 	}
 	if (!fs.FileExists(filename)) {
 		string message;

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -365,12 +365,12 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 		filename = fs.JoinPath(local_path, extension_name + ".duckdb_extension");
 #endif
 	} else {
-		if (!db.config.options.allow_unsigned_extensions) {
-			throw PermissionException("Loading extensions from arbitrary paths is forbidden through configuration, "
-			                          "consider 'INSTALL <path>; LOAD <name>;'");
-		}
 		direct_load = true;
 		filename = fs.ExpandPath(filename);
+	}
+	if (!StringUtil::EndsWith(filename, ".duckdb_extension")) {
+		throw PermissionException("Loading extensions from path not ending with '.duckdb_extension' is forbidden",
+		                          "consider 'INSTALL <path>; LOAD <name>;'");
 	}
 	if (!fs.FileExists(filename)) {
 		string message;

--- a/test/sql/extensions/checked_load.test
+++ b/test/sql/extensions/checked_load.test
@@ -27,4 +27,4 @@ SET allow_unsigned_extensions=false;
 statement error
 LOAD 'README.md';
 ----
-The file is not a DuckDB extension. The metadata at the end of the file is invalid
+Permission Error: Loading extensions from arbitrary paths is forbidden through configuration, consider

--- a/test/sql/extensions/checked_load.test
+++ b/test/sql/extensions/checked_load.test
@@ -5,7 +5,7 @@
 statement error
 LOAD 'README.md';
 ----
-The file is not a DuckDB extension. The metadata at the end of the file is invalid
+Permission Error: DuckDB extensions are files ending with '.duckdb_extension', loading different files is not possible, error while loading from 'README.md', consider 'INSTALL <path>; LOAD <name>;'
 
 statement ok
 SET allow_extensions_metadata_mismatch=true;
@@ -14,12 +14,12 @@ SET allow_extensions_metadata_mismatch=true;
 statement error
 LOAD 'README.md';
 ----
-Error: Extension "README.md" could not be loaded
+Permission Error: DuckDB extensions are files ending with '.duckdb_extension', loading different files is not possible, error while loading from 'README.md', consider 'INSTALL <path>; LOAD <name>;'
 
 statement error
 LOAD '{DATA_DIR}/csv/no_opt.csv';
 ----
-is not a DuckDB extension. Valid DuckDB extensions must be at least 512 bytes
+Permission Error: DuckDB extensions are files ending with '.duckdb_extension', loading different files is not possible, error while loading from
 
 statement ok
 SET allow_unsigned_extensions=false;
@@ -27,4 +27,4 @@ SET allow_unsigned_extensions=false;
 statement error
 LOAD 'README.md';
 ----
-Permission Error: Loading extensions from arbitrary paths is forbidden through configuration, consider
+Permission Error: DuckDB extensions are files ending with '.duckdb_extension', loading different files is not possible, error while loading from 'README.md', consider 'INSTALL <path>; LOAD <name>;'

--- a/test/sql/extensions/load_arbitrary_path.test
+++ b/test/sql/extensions/load_arbitrary_path.test
@@ -2,11 +2,7 @@
 # description: Test that loading extensions from arbitrary paths is forbidden
 # group: [extensions]
 
-statement ok
-SET allow_unsigned_extensions = false;
-
 statement error
 LOAD 'folder/a.csv';
 ----
-Permission Error: Loading extensions from arbitrary paths is forbidden through configuration
-
+Permission Error: Loading extensions from path not ending with '.duckdb_extension' is forbidden

--- a/test/sql/extensions/load_arbitrary_path.test
+++ b/test/sql/extensions/load_arbitrary_path.test
@@ -5,4 +5,4 @@
 statement error
 LOAD 'folder/a.csv';
 ----
-Permission Error: Loading extensions from path not ending with '.duckdb_extension' is forbidden
+Permission Error: DuckDB extensions are files ending with '.duckdb_extension', loading different files is not possible

--- a/test/sql/extensions/load_arbitrary_path.test
+++ b/test/sql/extensions/load_arbitrary_path.test
@@ -1,0 +1,12 @@
+# name: test/sql/extensions/load_arbitrary_path.test
+# description: Test that loading extensions from arbitrary paths is forbidden
+# group: [extensions]
+
+statement ok
+SET allow_unsigned_extensions = false;
+
+statement error
+LOAD 'folder/a.csv';
+----
+Permission Error: Loading extensions from arbitrary paths is forbidden through configuration
+

--- a/test/sql/extensions/permissions_duckdb_extension.test
+++ b/test/sql/extensions/permissions_duckdb_extension.test
@@ -5,17 +5,17 @@
 statement error
 COPY (SELECT 42) TO 'name.duckdb_extension';
 ----
-Permission Error: File 'name.duckdb_extension' cannot be open in write mode due to the suffix 'duckdb_extension'
+Permission Error: File 'name.duckdb_extension' cannot be opened for writing since files ending with duckdb_extension are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
 
 statement error
 COPY (SELECT 42) TO 'name_duckdb_extension';
 ----
-Permission Error: File 'name_duckdb_extension' cannot be open in write mode due to the suffix 'duckdb_extension'
+Permission Error: File 'name_duckdb_extension' cannot be opened for writing since files ending with duckdb_extension are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
 
 statement error
 COPY (SELECT NULL::BLOB) TO 'name.duckdb_extension' (FORMAT BLOB);
 ----
-Permission Error: File 'name.duckdb_extension' cannot be open in write mode due to the suffix 'duckdb_extension'
+Permission Error: File 'name.duckdb_extension' cannot be opened for writing since files ending with duckdb_extension are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
 
 statement ok
 COPY (SELECT NULL::BLOB) TO 'name.duckdb_extensionz' (FORMAT BLOB);
@@ -23,12 +23,12 @@ COPY (SELECT NULL::BLOB) TO 'name.duckdb_extensionz' (FORMAT BLOB);
 statement error
 ATTACH 'my_name.duckdb_extension'
 ----
-Permission Error: File 'my_name.duckdb_extension' cannot be open in write mode due to the suffix 'duckdb_extension'
+Permission Error: File 'my_name.duckdb_extension' cannot be opened for writing since files ending with duckdb_extension are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
 
 statement error
 ATTACH 'my_name_duckdb_extension'
 ----
-Permission Error: File 'my_name_duckdb_extension' cannot be open in write mode due to the suffix 'duckdb_extension'
+Permission Error: File 'my_name_duckdb_extension' cannot be opened for writing since files ending with duckdb_extension are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
 
 statement ok
 FROM read_blob('build/*/repository/*/*/parquet.duckdb_extension');

--- a/test/sql/extensions/permissions_duckdb_extension.test
+++ b/test/sql/extensions/permissions_duckdb_extension.test
@@ -5,17 +5,15 @@
 statement error
 COPY (SELECT 42) TO 'name.duckdb_extension';
 ----
-Permission Error: File 'name.duckdb_extension' cannot be opened for writing since files ending with duckdb_extension are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
+Permission Error: File 'name.duckdb_extension' cannot be opened for writing since files ending with '.duckdb_extension' are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
 
-statement error
+statement ok
 COPY (SELECT 42) TO 'name_duckdb_extension';
-----
-Permission Error: File 'name_duckdb_extension' cannot be opened for writing since files ending with duckdb_extension are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
 
 statement error
 COPY (SELECT NULL::BLOB) TO 'name.duckdb_extension' (FORMAT BLOB);
 ----
-Permission Error: File 'name.duckdb_extension' cannot be opened for writing since files ending with duckdb_extension are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
+Permission Error: File 'name.duckdb_extension' cannot be opened for writing since files ending with '.duckdb_extension' are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
 
 statement ok
 COPY (SELECT NULL::BLOB) TO 'name.duckdb_extensionz' (FORMAT BLOB);
@@ -23,12 +21,10 @@ COPY (SELECT NULL::BLOB) TO 'name.duckdb_extensionz' (FORMAT BLOB);
 statement error
 ATTACH 'my_name.duckdb_extension'
 ----
-Permission Error: File 'my_name.duckdb_extension' cannot be opened for writing since files ending with duckdb_extension are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
+Permission Error: File 'my_name.duckdb_extension' cannot be opened for writing since files ending with '.duckdb_extension' are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
 
-statement error
+statement ok
 ATTACH 'my_name_duckdb_extension'
-----
-Permission Error: File 'my_name_duckdb_extension' cannot be opened for writing since files ending with duckdb_extension are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
 
 statement ok
 FROM read_blob('build/*/repository/*/*/parquet.duckdb_extension');

--- a/test/sql/extensions/permissions_duckdb_extension.test
+++ b/test/sql/extensions/permissions_duckdb_extension.test
@@ -1,0 +1,34 @@
+# name: test/sql/extensions/permissions_duckdb_extension.test
+# description: Test that writing (but not reading) into file ending with '.duckdb_extension' is forbidden
+# group: [extensions]
+
+statement error
+COPY (SELECT 42) TO 'name.duckdb_extension';
+----
+Permission Error: File 'name.duckdb_extension' cannot be open in write mode due to the suffix 'duckdb_extension'
+
+statement error
+COPY (SELECT 42) TO 'name_duckdb_extension';
+----
+Permission Error: File 'name_duckdb_extension' cannot be open in write mode due to the suffix 'duckdb_extension'
+
+statement error
+COPY (SELECT NULL::BLOB) TO 'name.duckdb_extension' (FORMAT BLOB);
+----
+Permission Error: File 'name.duckdb_extension' cannot be open in write mode due to the suffix 'duckdb_extension'
+
+statement ok
+COPY (SELECT NULL::BLOB) TO 'name.duckdb_extensionz' (FORMAT BLOB);
+
+statement error
+ATTACH 'my_name.duckdb_extension'
+----
+Permission Error: File 'my_name.duckdb_extension' cannot be open in write mode due to the suffix 'duckdb_extension'
+
+statement error
+ATTACH 'my_name_duckdb_extension'
+----
+Permission Error: File 'my_name_duckdb_extension' cannot be open in write mode due to the suffix 'duckdb_extension'
+
+statement ok
+FROM read_blob('build/*/repository/*/*/parquet.duckdb_extension');


### PR DESCRIPTION
Changes so that INSTALL also performs signature checks (according to database configuration).
This is somewhat redundant, BUT avoids cases where one might successful install an extension that can't be then loaded.

Logic is as follows:
1. files ending in ".duckdb_extension" can only be created in the INSTALL path
2. when moving, either ending ".duckdb_extension" is present both in source and target, OR it should not be present on target
3. on install, we first verify signature of the buffer, then copy data to "name.tmp-UUID.duckdb_extension", then move it to "name.duckdb_extension". Note that this is legal with both 1 & 2, and makes so that all files (written by duckdb) that ends in '.duckdb_extension' are signature checked
4. on load, we load only from files eneding in ".duckdb_extension"

Basically there are 3 families of files:
* **A**: those ending in '.duckdb_extension'
* **B**. the other files

**B** can be created and moved into freely
**A**  can only be created during install path (since it's the only place where we pass the flag, and we will only create **B**)
**A** can only be moved into from other **A** files, while **A** can be moved to a **B**
**A** is the only type of file we would load from