### PR TITLE
Fix KeyValueSecretReader init

### DIFF
--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -252,7 +252,7 @@ public:
 class KeyValueSecretReader {
 public:
 	//! Manually pass in a secret reference
-	KeyValueSecretReader(const KeyValueSecret &secret_p, FileOpener &opener_p) : secret(secret_p) {};
+	KeyValueSecretReader(const KeyValueSecret &secret_p, FileOpener &opener_p);
 
 	//! Initializes the KeyValueSecretReader by fetching the secret automatically
 	KeyValueSecretReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info, const char **secret_types,

--- a/src/main/secret/secret.cpp
+++ b/src/main/secret/secret.cpp
@@ -163,6 +163,11 @@ void KeyValueSecretReader::Initialize(const char **secret_types, idx_t secret_ty
 	}
 }
 
+KeyValueSecretReader::KeyValueSecretReader(const KeyValueSecret &secret_p, FileOpener &opener_p) : secret(secret_p) {
+	db = opener_p.TryGetDatabase();
+	context = opener_p.TryGetClientContext();
+}
+
 KeyValueSecretReader::KeyValueSecretReader(FileOpener &opener_p, optional_ptr<FileOpenerInfo> info,
                                            const char **secret_types, idx_t secret_types_len) {
 	db = opener_p.TryGetDatabase();


### PR DESCRIPTION
Initialize both `db` and `context` which where previously forgotten by one of the constructors of `KeyValueSecretReader`