### PR TITLE
update azure ref for v1.5 (cherry pick of v1.4.4 bump)

### DIFF
--- a/.github/config/extensions/azure.cmake
+++ b/.github/config/extensions/azure.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
   duckdb_extension_load(azure
         LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb-azure
-        GIT_TAG f4d55b658c14d3de40bac9d1c68f08f3cf116374
+        GIT_TAG 7e1ac3333d946a6bf5b4552722743e03f30a47cd
   )
 endif()


### PR DESCRIPTION
cherry-pick of #20506 to v1.5-variegata

azure updates for experimental writes include:
- write/API fixes for Blob/az:
- new support for ADLSv2/abfss: