### PR TITLE
Fix missing extension loader static library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -535,7 +535,7 @@ bundle-setup:
 	mkdir -p bundle && \
 	cp src/libduckdb_static.a bundle/. && \
 	cp third_party/*/libduckdb_*.a bundle/. && \
-	cp extension/lib*_extension_loader.a bundle/. && \
+	cp extension/libduckdb_generated_extension_loader.a bundle/. && \
 	cp extension/*/lib*_extension.a bundle/. && \
 	mkdir -p vcpkg_installed && \
 	find vcpkg_installed -name '*.a' -exec cp {} bundle/. \; && \

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -9,7 +9,7 @@
 # include generated includes
 include_directories("${PROJECT_BINARY_DIR}/codegen/include/")
 
-add_library(dummy_static_extension_loader
+add_library(dummy_static_extension_loader STATIC
             loader/dummy_static_extension_loader.cpp)
 
 install(
@@ -101,7 +101,7 @@ add_definitions(-DDUCKDB_MAJOR_VERSION=${DUCKDB_MAJOR_VERSION})
 add_definitions(-DDUCKDB_MINOR_VERSION=${DUCKDB_MINOR_VERSION})
 add_definitions(-DDUCKDB_PATCH_VERSION=${DUCKDB_PATCH_VERSION})
 
-add_library(duckdb_generated_extension_loader ${GENERATED_CPP_FILE})
+add_library(duckdb_generated_extension_loader STATIC ${GENERATED_CPP_FILE})
 
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_generated_extension_loader>

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -101,7 +101,7 @@ add_definitions(-DDUCKDB_MAJOR_VERSION=${DUCKDB_MAJOR_VERSION})
 add_definitions(-DDUCKDB_MINOR_VERSION=${DUCKDB_MINOR_VERSION})
 add_definitions(-DDUCKDB_PATCH_VERSION=${DUCKDB_PATCH_VERSION})
 
-add_library(duckdb_generated_extension_loader OBJECT ${GENERATED_CPP_FILE})
+add_library(duckdb_generated_extension_loader ${GENERATED_CPP_FILE})
 
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_generated_extension_loader>


### PR DESCRIPTION
Previously, only `dummy_static_extension_loader.a` was being created as a static library, while `duckdb_generated_extension_loader.a` was being created as an object file. Now both are created as static libraries, but only `duckdb_generated_extension_loader.a` is added to the static library bundle with `make bundle-library`.
