### PR TITLE
Move implementation of `TransformStringToLogicalType` behind `DBConfig` indirection

### DIFF
--- a/extension/autocomplete/transformer/transform_analyze.cpp
+++ b/extension/autocomplete/transformer/transform_analyze.cpp
@@ -17,7 +17,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformAnalyzeStatement(PEGTra
 		result->info->ref = std::move(target.ref);
 		result->info->has_table = true;
 	}
-	return result;
+	return std::move(result);
 }
 
 AnalyzeTarget PEGTransformerFactory::TransformAnalyzeTarget(PEGTransformer &transformer,

--- a/extension/autocomplete/transformer/transform_vacuum.cpp
+++ b/extension/autocomplete/transformer/transform_vacuum.cpp
@@ -16,7 +16,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformVacuumStatement(PEGTran
 		result->info->ref = std::move(target.ref);
 		result->info->has_table = true;
 	}
-	return result;
+	return std::move(result);
 }
 
 VacuumOptions PEGTransformerFactory::TransformVacuumOptions(PEGTransformer &transformer,

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -25,6 +25,8 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/parser/expression/type_expression.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
 
 #include <cmath>
 

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -17,17 +17,13 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/uhugeint.hpp"
 #include "duckdb/function/cast_rules.hpp"
-#include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_data.hpp"
-#include "duckdb/main/config.hpp"
-#include "duckdb/main/database.hpp"
-#include "duckdb/main/database_manager.hpp"
+#include "duckdb/common/types/type_manager.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/main/settings.hpp"
-#include "duckdb/planner/binder.hpp"
 #include "duckdb/parser/expression/type_expression.hpp"
 
 #include <cmath>
@@ -534,80 +530,8 @@ LogicalTypeId TransformStringToLogicalTypeId(const string &str) {
 	return type;
 }
 
-LogicalType TransformStringToUnboundType(const string &str) {
-	if (StringUtil::Lower(str) == "null") {
-		return LogicalType::SQLNULL;
-	}
-	ColumnList column_list;
-	try {
-		column_list = Parser::ParseColumnList("dummy " + str);
-	} catch (const std::runtime_error &e) {
-		const vector<string> suggested_types {"BIGINT",
-		                                      "INT8",
-		                                      "LONG",
-		                                      "BIT",
-		                                      "BITSTRING",
-		                                      "BLOB",
-		                                      "BYTEA",
-		                                      "BINARY,",
-		                                      "VARBINARY",
-		                                      "BOOLEAN",
-		                                      "BOOL",
-		                                      "LOGICAL",
-		                                      "DATE",
-		                                      "DECIMAL(prec, scale)",
-		                                      "DOUBLE",
-		                                      "FLOAT8",
-		                                      "FLOAT",
-		                                      "FLOAT4",
-		                                      "REAL",
-		                                      "HUGEINT",
-		                                      "INTEGER",
-		                                      "INT4",
-		                                      "INT",
-		                                      "SIGNED",
-		                                      "INTERVAL",
-		                                      "SMALLINT",
-		                                      "INT2",
-		                                      "SHORT",
-		                                      "TIME",
-		                                      "TIMESTAMPTZ",
-		                                      "TIMESTAMP",
-		                                      "DATETIME",
-		                                      "TINYINT",
-		                                      "INT1",
-		                                      "UBIGINT",
-		                                      "UHUGEINT",
-		                                      "UINTEGER",
-		                                      "USMALLINT",
-		                                      "UTINYINT",
-		                                      "UUID",
-		                                      "VARCHAR",
-		                                      "CHAR",
-		                                      "BPCHAR",
-		                                      "TEXT",
-		                                      "STRING",
-		                                      "MAP(INTEGER, VARCHAR)",
-		                                      "UNION(num INTEGER, text VARCHAR)"};
-		std::ostringstream error;
-		error << "Value \"" << str << "\" can not be converted to a DuckDB Type." << '\n';
-		error << "Possible examples as suggestions: " << '\n';
-		auto suggestions = StringUtil::TopNJaroWinkler(suggested_types, str);
-		for (auto &suggestion : suggestions) {
-			error << "* " << suggestion << '\n';
-		}
-		throw InvalidInputException(error.str());
-	}
-	return column_list.GetColumn(LogicalIndex(0)).Type();
-}
-
 LogicalType TransformStringToLogicalType(const string &str, ClientContext &context) {
-	auto type = TransformStringToUnboundType(str);
-	if (type.IsUnbound()) {
-		auto binder = Binder::CreateBinder(context, nullptr);
-		binder->BindLogicalType(type);
-	}
-	return type;
+	return TypeManager::Get(context).ParseLogicalType(str, context);
 }
 
 bool LogicalType::IsIntegral() const {

--- a/src/common/types/CMakeLists.txt
+++ b/src/common/types/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library_unity(
   string_heap.cpp
   string_type.cpp
   timestamp.cpp
+  type_manager.cpp
   time.cpp
   validity_mask.cpp
   value.cpp

--- a/src/common/types/type_manager.cpp
+++ b/src/common/types/type_manager.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/main/config.hpp"
 
 namespace duckdb {
 

--- a/src/common/types/type_manager.cpp
+++ b/src/common/types/type_manager.cpp
@@ -1,0 +1,106 @@
+#include "duckdb/common/types/type_manager.hpp"
+#include "duckdb/function/cast/cast_function_set.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/binder.hpp"
+
+namespace duckdb {
+
+CastFunctionSet &TypeManager::GetCastFunctions() {
+	return *cast_functions;
+}
+
+static LogicalType TransformStringToUnboundType(const string &str) {
+	if (StringUtil::Lower(str) == "null") {
+		return LogicalType::SQLNULL;
+	}
+	ColumnList column_list;
+	try {
+		column_list = Parser::ParseColumnList("dummy " + str);
+	} catch (const std::runtime_error &e) {
+		const vector<string> suggested_types {"BIGINT",
+		                                      "INT8",
+		                                      "LONG",
+		                                      "BIT",
+		                                      "BITSTRING",
+		                                      "BLOB",
+		                                      "BYTEA",
+		                                      "BINARY,",
+		                                      "VARBINARY",
+		                                      "BOOLEAN",
+		                                      "BOOL",
+		                                      "LOGICAL",
+		                                      "DATE",
+		                                      "DECIMAL(prec, scale)",
+		                                      "DOUBLE",
+		                                      "FLOAT8",
+		                                      "FLOAT",
+		                                      "FLOAT4",
+		                                      "REAL",
+		                                      "HUGEINT",
+		                                      "INTEGER",
+		                                      "INT4",
+		                                      "INT",
+		                                      "SIGNED",
+		                                      "INTERVAL",
+		                                      "SMALLINT",
+		                                      "INT2",
+		                                      "SHORT",
+		                                      "TIME",
+		                                      "TIMESTAMPTZ",
+		                                      "TIMESTAMP",
+		                                      "DATETIME",
+		                                      "TINYINT",
+		                                      "INT1",
+		                                      "UBIGINT",
+		                                      "UHUGEINT",
+		                                      "UINTEGER",
+		                                      "USMALLINT",
+		                                      "UTINYINT",
+		                                      "UUID",
+		                                      "VARCHAR",
+		                                      "CHAR",
+		                                      "BPCHAR",
+		                                      "TEXT",
+		                                      "STRING",
+		                                      "MAP(INTEGER, VARCHAR)",
+		                                      "UNION(num INTEGER, text VARCHAR)"};
+		std::ostringstream error;
+		error << "Value \"" << str << "\" can not be converted to a DuckDB Type." << '\n';
+		error << "Possible examples as suggestions: " << '\n';
+		auto suggestions = StringUtil::TopNJaroWinkler(suggested_types, str);
+		for (auto &suggestion : suggestions) {
+			error << "* " << suggestion << '\n';
+		}
+		throw InvalidInputException(error.str());
+	}
+	return column_list.GetColumn(LogicalIndex(0)).Type();
+}
+
+// This has to be called with a level of indirection (through "parse_function") in order to avoid being included in
+// extensions that statically link the core DuckDB library.
+static LogicalType ParseLogicalTypeInternal(const string &type_str, ClientContext &context) {
+	auto type = TransformStringToUnboundType(type_str);
+	if (type.IsUnbound()) {
+		auto binder = Binder::CreateBinder(context, nullptr);
+		binder->BindLogicalType(type);
+	}
+	return type;
+}
+
+LogicalType TypeManager::ParseLogicalType(const string &type_str, ClientContext &context) const {
+	return parse_function(type_str, context);
+}
+
+TypeManager &TypeManager::Get(ClientContext &context) {
+	return DBConfig::GetConfig(context).GetTypeManager();
+}
+
+TypeManager::TypeManager(DBConfig &config_p) {
+	cast_functions = make_uniq<CastFunctionSet>(config_p);
+	parse_function = ParseLogicalTypeInternal;
+}
+
+TypeManager::~TypeManager() {
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/common/types/type_manager.hpp
+++ b/src/include/duckdb/common/types/type_manager.hpp
@@ -7,7 +7,7 @@ namespace duckdb {
 
 class ClientContext;
 class CastFunctionSet;
-class DBConfig;
+struct DBConfig;
 
 class TypeManager {
 public:

--- a/src/include/duckdb/common/types/type_manager.hpp
+++ b/src/include/duckdb/common/types/type_manager.hpp
@@ -11,7 +11,7 @@ struct DBConfig;
 
 class TypeManager {
 public:
-	TypeManager(DBConfig &config);
+	explicit TypeManager(DBConfig &config);
 
 	~TypeManager();
 

--- a/src/include/duckdb/common/types/type_manager.hpp
+++ b/src/include/duckdb/common/types/type_manager.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/types/string.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+class CastFunctionSet;
+class DBConfig;
+
+class TypeManager {
+public:
+	TypeManager(DBConfig &config);
+
+	~TypeManager();
+
+	//! Get the CastFunctionSet from the TypeManager
+	CastFunctionSet &GetCastFunctions();
+
+	//! Try to parse and bind a logical type from a string. Throws an exception if the type could not be parsed.
+	LogicalType ParseLogicalType(const string &type_str, ClientContext &context) const;
+
+	//! Get the TypeManager from the ClientContext
+	static TypeManager &Get(ClientContext &context);
+
+private:
+	//! This has to be a function pointer to avoid the compiler inlining the implementation and
+	//! blowing up the binary size of extensions that include type_manager.hpp
+	LogicalType (*parse_function)(const string &, ClientContext &);
+
+	//! The set of cast functions
+	unique_ptr<CastFunctionSet> cast_functions;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -36,6 +36,7 @@
 #include "duckdb/logging/log_manager.hpp"
 #include "duckdb/main/user_settings.hpp"
 #include "duckdb/parser/parsed_data/create_info.hpp"
+#include "duckdb/common/types/type_manager.hpp"
 
 namespace duckdb {
 
@@ -57,6 +58,7 @@ class EncryptionUtil;
 class HTTPUtil;
 class DatabaseFilePathManager;
 class ExtensionCallbackManager;
+class TypeManager;
 
 struct CompressionFunctionSet;
 struct DatabaseCacheEntry;
@@ -275,6 +277,7 @@ public:
 	bool operator!=(const DBConfig &other);
 
 	DUCKDB_API CastFunctionSet &GetCastFunctions();
+	DUCKDB_API TypeManager &GetTypeManager();
 	DUCKDB_API CollationBinding &GetCollationBinding();
 	DUCKDB_API IndexTypeSet &GetIndexTypes();
 	static idx_t GetSystemMaxThreads(FileSystem &fs);
@@ -306,7 +309,7 @@ private:
 	unique_ptr<CompressionFunctionSet> compression_functions;
 	unique_ptr<EncodingFunctionSet> encoding_functions;
 	unique_ptr<ArrowTypeExtensionSet> arrow_extensions;
-	unique_ptr<CastFunctionSet> cast_functions;
+	unique_ptr<TypeManager> type_manager;
 	unique_ptr<CollationBinding> collation_bindings;
 	unique_ptr<IndexTypeSet> index_types;
 	unique_ptr<ExtensionCallbackManager> callback_manager;

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -506,7 +506,11 @@ bool DBConfig::IsInMemoryDatabase(const char *database_path) {
 }
 
 CastFunctionSet &DBConfig::GetCastFunctions() {
-	return *cast_functions;
+	return type_manager->GetCastFunctions();
+}
+
+TypeManager &DBConfig::GetTypeManager() {
+	return *type_manager;
 }
 
 CollationBinding &DBConfig::GetCollationBinding() {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/execution/index/index_type_set.hpp"
 #include "duckdb/execution/operator/helper/physical_set.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
+#include "duckdb/common/types/type_manager.hpp"
 #include "duckdb/function/compression_function.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -48,7 +49,7 @@ DBConfig::DBConfig() {
 	encoding_functions->Initialize(*this);
 	arrow_extensions = make_uniq<ArrowTypeExtensionSet>();
 	arrow_extensions->Initialize(*this);
-	cast_functions = make_uniq<CastFunctionSet>(*this);
+	type_manager = make_uniq<TypeManager>(*this);
 	collation_bindings = make_uniq<CollationBinding>();
 	index_types = make_uniq<IndexTypeSet>();
 	error_manager = make_uniq<ErrorManager>();


### PR DESCRIPTION
This PR is a followup to #20355 which introduced a regression of some extension binary sizes. 

The problem was that `TransformStringToLogicalType(string, ClientContext)`, used by e.g. the parquet extension when parsing user provided schemas, now requires the parser _and_ binder to resolve the type. This causes a bunch of binder code (which the linker could previously trim out as it was unused in most extensions) to be included, blowing up the binary size.

The fix in this PR is to move the implementation behind a wrapper class in the DBConfig (the `TypeManager`, which now also holds the `CastFunctionSet`), which in turn indirectly invokes the type parsing code through a function pointer. Since extensions never instantiate their own `DBConfig` themselves, but always operate on the main systems provided DBConfig pointer, the linker can trim out this code path.