### PR TITLE
Improve lazy glob expansion in MultiFileList and Glob

### DIFF
--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -146,12 +146,15 @@ void MultiFileList::InitializeScan(MultiFileListScanData &iterator) const {
 	iterator.current_file_idx = 0;
 }
 
-vector<OpenFileInfo> MultiFileList::GetDisplayFileList(idx_t max_files) const {
+vector<OpenFileInfo> MultiFileList::GetDisplayFileList(optional_idx max_files) const {
 	vector<OpenFileInfo> files;
-	for (idx_t i = 0; i < max_files; i++) {
+	for (idx_t i = 0;; i++) {
+		if (max_files.IsValid() && files.size() >= max_files.GetIndex()) {
+			break;
+		}
 		auto file = GetFile(i);
 		if (file.path.empty()) {
-			continue;
+			break;
 		}
 		files.push_back(std::move(file));
 	}
@@ -319,10 +322,13 @@ GlobMultiFileList::GlobMultiFileList(ClientContext &context_p, vector<string> gl
     : context(context_p), globs(std::move(globs_p)), glob_input(std::move(glob_input_p)), current_glob(0) {
 }
 
-vector<OpenFileInfo> GlobMultiFileList::GetDisplayFileList(idx_t max_files) const {
+vector<OpenFileInfo> GlobMultiFileList::GetDisplayFileList(optional_idx max_files) const {
 	// for globs we display the actual globs in the ToString() - instead of expanding to the files read
 	vector<OpenFileInfo> result;
 	for (auto &glob : globs) {
+		if (max_files.IsValid() && result.size() >= max_files.GetIndex()) {
+			break;
+		}
 		result.emplace_back(glob);
 	}
 	return result;

--- a/src/execution/operator/helper/physical_streaming_limit.cpp
+++ b/src/execution/operator/helper/physical_streaming_limit.cpp
@@ -54,6 +54,9 @@ OperatorResultType PhysicalStreamingLimit::Execute(ExecutionContext &context, Da
 	if (PhysicalLimit::HandleOffset(input, current_offset, offset.GetIndex(), limit.GetIndex())) {
 		chunk.Reference(input);
 	}
+	if (current_offset >= limit.GetIndex() + offset.GetIndex()) {
+		return OperatorResultType::HAVE_MORE_OUTPUT;
+	}
 	return OperatorResultType::NEED_MORE_INPUT;
 }
 

--- a/src/execution/operator/helper/physical_streaming_limit.cpp
+++ b/src/execution/operator/helper/physical_streaming_limit.cpp
@@ -54,9 +54,6 @@ OperatorResultType PhysicalStreamingLimit::Execute(ExecutionContext &context, Da
 	if (PhysicalLimit::HandleOffset(input, current_offset, offset.GetIndex(), limit.GetIndex())) {
 		chunk.Reference(input);
 	}
-	if (current_offset >= limit.GetIndex() + offset.GetIndex()) {
-		return OperatorResultType::HAVE_MORE_OUTPUT;
-	}
 	return OperatorResultType::NEED_MORE_INPUT;
 }
 

--- a/src/function/table/glob.cpp
+++ b/src/function/table/glob.cpp
@@ -41,6 +41,7 @@ static void GlobFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 	auto &bind_data = data_p.bind_data->Cast<GlobFunctionBindData>();
 	auto &state = data_p.global_state->Cast<GlobFunctionState>();
 
+	state.file_list_scan.scan_type = MultiFileListScanType::ALWAYS_FETCH;
 	idx_t count = 0;
 	while (count < STANDARD_VECTOR_SIZE) {
 		OpenFileInfo file;
@@ -48,6 +49,7 @@ static void GlobFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 			break;
 		}
 		output.data[0].SetValue(count++, file.path);
+		state.file_list_scan.scan_type = MultiFileListScanType::FETCH_IF_AVAILABLE;
 	}
 	output.SetCardinality(count);
 }

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -776,7 +776,7 @@ public:
 		auto &bind_data = bind_data_p->Cast<MultiFileBindData>();
 
 		vector<Value> file_path;
-		for (const auto &file : bind_data.file_list->Files()) {
+		for (const auto &file : bind_data.file_list->GetDisplayFileList()) {
 			file_path.emplace_back(file.path);
 		}
 

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -708,7 +708,22 @@ public:
 	                                const GlobalTableFunctionState *global_state) {
 		auto &gstate = global_state->Cast<MultiFileGlobalState>();
 
-		auto total_count = gstate.file_list.GetTotalFileCount();
+		// get the file count - for >100 files we allow a lower bound to be given instead
+		auto count_info = gstate.file_list.GetFileCount(100);
+		while (count_info.type != FileExpansionType::ALL_FILES_EXPANDED) {
+			// the entire glob has not yet been expanded - we don't know how many files there are exactly
+			// we try to postpone expanding the glob by only expanding it once we have scanned 1% of the files
+			// check if we have reached AT LEAST 1% of progress
+			idx_t one_percent_min = count_info.count / 100;
+			if (gstate.completed_file_index < one_percent_min) {
+				// we have not - just report 0%
+				return 0.0;
+			}
+			// we have reached 1% given the currently known (incomplete) list of files
+			// retrieve more files to scan
+			count_info = gstate.file_list.GetFileCount(count_info.count + 1);
+		}
+		auto total_count = count_info.count;
 		if (total_count == 0) {
 			return 100.0;
 		}
@@ -754,7 +769,14 @@ public:
 		if (file_list_cardinality_estimate) {
 			return file_list_cardinality_estimate;
 		}
-		return data.interface->GetCardinality(data, data.file_list->GetTotalFileCount());
+		// get the file count - for >500 files we allow an estimate
+		auto count_info = data.file_list->GetFileCount(500);
+		idx_t estimated_file_count = count_info.count;
+		if (count_info.type != FileExpansionType::ALL_FILES_EXPANDED) {
+			// not all files have been expanded - it's probably twice as many files
+			estimated_file_count *= 2;
+		}
+		return data.interface->GetCardinality(data, estimated_file_count);
 	}
 
 	static void MultiFileComplexFilterPushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data_p,

--- a/src/include/duckdb/common/multi_file/multi_file_list.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_list.hpp
@@ -19,9 +19,20 @@ class MultiFileList;
 enum class FileExpandResult : uint8_t { NO_FILES, SINGLE_FILE, MULTIPLE_FILES };
 enum class MultiFileListScanType { ALWAYS_FETCH, FETCH_IF_AVAILABLE };
 
+enum class FileExpansionType { ALL_FILES_EXPANDED, NOT_ALL_FILES_KNOWN };
+
 struct MultiFileListScanData {
 	idx_t current_file_idx = DConstants::INVALID_INDEX;
 	MultiFileListScanType scan_type = MultiFileListScanType::ALWAYS_FETCH;
+};
+
+struct MultiFileCount {
+	explicit MultiFileCount(idx_t count, FileExpansionType type = FileExpansionType::ALL_FILES_EXPANDED)
+	    : count(count), type(type) {
+	}
+
+	idx_t count;
+	FileExpansionType type;
 };
 
 class MultiFileListIterationHelper {
@@ -102,6 +113,9 @@ public:
 	virtual FileExpandResult GetExpandResult() const = 0;
 	//! Get the total file count - forces all files to be expanded / known so the exact count can be computed
 	virtual idx_t GetTotalFileCount() const = 0;
+	//! Get the file count - anything under "min_exact_count" is allowed to be incomplete (i.e. `NOT_ALL_FILES_KNOWN`)
+	//! This allows us to get a rough idea of the file count
+	virtual MultiFileCount GetFileCount(idx_t min_exact_count = 0) const;
 	virtual vector<OpenFileInfo> GetDisplayFileList(optional_idx max_files = optional_idx()) const;
 
 	virtual unique_ptr<NodeStatistics> GetCardinality(ClientContext &context) const;
@@ -155,6 +169,7 @@ public:
 	vector<OpenFileInfo> GetAllFiles() const override;
 	FileExpandResult GetExpandResult() const override;
 	idx_t GetTotalFileCount() const override;
+	MultiFileCount GetFileCount(idx_t min_exact_count = 0) const override;
 
 protected:
 	bool FileIsAvailable(idx_t i) const override;
@@ -163,10 +178,15 @@ protected:
 	//! Grabs the next path and expands it into Expanded paths: returns false if no more files to expand
 	virtual bool ExpandNextPath() const = 0;
 
+private:
+	bool ExpandNextPathInternal() const;
+
 protected:
 	mutable mutex lock;
 	//! The expanded files
 	mutable vector<OpenFileInfo> expanded_files;
+	//! Whether or not all files have been expanded
+	mutable bool all_files_expanded = false;
 };
 
 //! MultiFileList that takes a list of globs and resolves all of the globs lazily into files

--- a/src/include/duckdb/common/multi_file/multi_file_list.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_list.hpp
@@ -100,8 +100,9 @@ public:
 
 	virtual vector<OpenFileInfo> GetAllFiles() const = 0;
 	virtual FileExpandResult GetExpandResult() const = 0;
+	//! Get the total file count - forces all files to be expanded / known so the exact count can be computed
 	virtual idx_t GetTotalFileCount() const = 0;
-	virtual vector<OpenFileInfo> GetDisplayFileList(idx_t max_files) const;
+	virtual vector<OpenFileInfo> GetDisplayFileList(optional_idx max_files = optional_idx()) const;
 
 	virtual unique_ptr<NodeStatistics> GetCardinality(ClientContext &context) const;
 	virtual unique_ptr<MultiFileList> Copy() const;
@@ -173,7 +174,7 @@ class GlobMultiFileList : public LazyMultiFileList {
 public:
 	GlobMultiFileList(ClientContext &context, vector<string> globs, FileGlobInput input);
 
-	vector<OpenFileInfo> GetDisplayFileList(idx_t max_files) const override;
+	vector<OpenFileInfo> GetDisplayFileList(optional_idx max_files = optional_idx()) const override;
 
 protected:
 	bool ExpandNextPath() const override;


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/20619

This PR improves lazy glob expansion by avoiding expanding the glob in more cases:

* The `glob` table function now returns results in a paginated manner instead of always filling up to `STANDARD_VECTOR_SIZE` - this allows subsequent `LIMIT` or other short-circuits to do short-circuiting as early as possible
* In `MultiFileGetBindInfo` we avoid expanding the entire file list - instead we push only the displayed files (i.e. we push the original glob, instead of the expanded / resolved glob).
* We add `MultiFileList::GetFileCount(idx_t min_exact_count)` - this function can be used to get a lower bound on the file count based on the current glob expansion instead of using `GetTotalFileCount()` which requires a full glob expansion.

`MultiFileList::GetFileCount` is used in two places:

* During cardinality estimation we expand the glob until at least 500 files using `MultiFileList::GetFileCount(500)`. If that leaves the glob un-expanded we estimate 2 * n as the total file count where `n` is how many files were currently expanded.
* During progress reporting, we expand at least 100 files. We then report 0% progress as long as we haven't scanned **at least 1%** of the currently known set of files. 

For example, assume there are 500 files, and we expand 100 at a time. That means our initial glob returns 100 files with `NOT_ALL_FILES_KNOWN`.

* After completing the scan of 1 file, we expand the glob to 200 files, and return 0% progress
* After completing the scan of 2 files, we expand the glob to 300 files, and return 0% progress
* After completing the scan of 3 files, we expand the glob to 400 files, and return 0% progress
* After completing the scan of 4 files, we expand the glob to 500 files, and return 0% progress
* After completing the scan of 5 files, we have fully expanded the glob and return 1% progress

This allows us to report accurate progress while postponing glob expansion during execution. It does mean we are still relatively eager in expanding globs (i.e. we have already fully expanded the glob after scanning only 1% of the files of that glob) - however, we are lazier than before and we can now actually do the glob expansion during execution.

There is still an issue with `PhysicalStreamingLimit` that makes us expand globs more than required in case of a `LIMIT` over `glob`, but that seems to be a bit more complex than originally thought so I will leave that for a future PR. 