### PR TITLE
[C API] Make string functions UTF-8 safe and test embedded null support

### DIFF
--- a/src/include/duckdb/main/capi/capi_internal.hpp
+++ b/src/include/duckdb/main/capi/capi_internal.hpp
@@ -110,6 +110,7 @@ idx_t GetCTypeSize(const duckdb_type type);
 duckdb_statement_type StatementTypeToC(const StatementType type);
 duckdb_error_type ErrorTypeToC(const ExceptionType type);
 ExceptionType ErrorTypeFromC(const duckdb_error_type type);
+duckdb_error_data UTF8Analyze(const char *str, size_t len);
 
 duckdb_state DuckDBTranslateResult(unique_ptr<QueryResult> result, duckdb_result *out);
 bool DeprecatedMaterializeResult(duckdb_result *result);

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -659,6 +659,9 @@ typedef struct {
 	duckdb_value (*duckdb_create_union_value)(duckdb_logical_type union_type, idx_t tag_index, duckdb_value value);
 	duckdb_value (*duckdb_create_time_ns)(duckdb_time_ns input);
 	duckdb_time_ns (*duckdb_get_time_ns)(duckdb_value val);
+	duckdb_value (*duckdb_safe_create_varchar)(const char *text, duckdb_error_data *out_error_data);
+	duckdb_value (*duckdb_safe_create_varchar_length)(const char *text, idx_t length,
+	                                                  duckdb_error_data *out_error_data);
 	// API to create and manipulate vector types
 
 	duckdb_vector (*duckdb_create_vector)(duckdb_logical_type type, idx_t capacity);
@@ -672,6 +675,8 @@ typedef struct {
 	void (*duckdb_vector_copy_sel)(duckdb_vector src, duckdb_vector dst, duckdb_selection_vector sel, idx_t src_count,
 	                               idx_t src_offset, idx_t dst_offset);
 	duckdb_error_data (*duckdb_vector_safe_assign_string_element)(duckdb_vector vector, idx_t index, const char *str);
+	duckdb_error_data (*duckdb_vector_safe_assign_string_element_len)(duckdb_vector vector, idx_t index,
+	                                                                  const char *str, idx_t str_len);
 } duckdb_ext_api_v1;
 
 //===--------------------------------------------------------------------===//
@@ -1213,6 +1218,8 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_create_union_value = duckdb_create_union_value;
 	result.duckdb_create_time_ns = duckdb_create_time_ns;
 	result.duckdb_get_time_ns = duckdb_get_time_ns;
+	result.duckdb_safe_create_varchar = duckdb_safe_create_varchar;
+	result.duckdb_safe_create_varchar_length = duckdb_safe_create_varchar_length;
 	result.duckdb_create_vector = duckdb_create_vector;
 	result.duckdb_destroy_vector = duckdb_destroy_vector;
 	result.duckdb_slice_vector = duckdb_slice_vector;
@@ -1223,6 +1230,7 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_selection_vector_get_data_ptr = duckdb_selection_vector_get_data_ptr;
 	result.duckdb_vector_copy_sel = duckdb_vector_copy_sel;
 	result.duckdb_vector_safe_assign_string_element = duckdb_vector_safe_assign_string_element;
+	result.duckdb_vector_safe_assign_string_element_len = duckdb_vector_safe_assign_string_element_len;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_value_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_value_functions.json
@@ -5,6 +5,8 @@
       "duckdb_create_map_value",
       "duckdb_create_union_value",
       "duckdb_create_time_ns",
-      "duckdb_get_time_ns"
+      "duckdb_get_time_ns",
+      "duckdb_safe_create_varchar",
+      "duckdb_safe_create_varchar_length"
   ]
 }

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_vector_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_vector_functions.json
@@ -11,6 +11,7 @@
     "duckdb_destroy_selection_vector",
     "duckdb_selection_vector_get_data_ptr",
     "duckdb_vector_copy_sel",
-    "duckdb_vector_safe_assign_string_element"
+    "duckdb_vector_safe_assign_string_element",
+    "duckdb_vector_safe_assign_string_element_len"
   ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/bind_values_to_prepared_statements.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/bind_values_to_prepared_statements.json
@@ -462,7 +462,7 @@
                 }
             ],
             "comment": {
-                "description": "Binds a null-terminated varchar value to the prepared statement at the specified index.\n"
+                "description": "Binds a null-terminated VARCHAR value to the prepared statement at the specified index. The input must be valid UTF-8. Otherwise, undefined behavior is expected at later stages.\n"
             }
         },
         {
@@ -487,7 +487,7 @@
                 }
             ],
             "comment": {
-                "description": "Binds a varchar value to the prepared statement at the specified index.\n"
+                "description": "Binds a VARCHAR value to the prepared statement at the specified index. The input must be valid UTF-8. Otherwise, undefined behavior is expected at later stages.\n"
             }
         },
         {

--- a/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
@@ -20,6 +20,28 @@
             }
         },
         {
+            "name": "duckdb_safe_create_varchar",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "const char *",
+                    "name": "text"
+                },
+                {
+                    "type": "duckdb_error_data *",
+                    "name": "out_error_data"
+                }
+            ],
+            "comment": {
+                "description": "Creates a value from a null-terminated string. Supersedes `duckdb_create_varchar`. The input must be valid UTF-8. Otherwise, `out_error_data` contains an invalid Unicode error.\n\n",
+                "param_comments": {
+                    "text": "The null-terminated string.",
+                    "out_error_data": "If valid UTF-8, then `nullptr`, else error information. If not `nullptr`, then the parameter must be destroyed with `duckdb_destroy_error_data`."
+                },
+                "return_value": "The value, which must be destroyed with `duckdb_destroy_value`."
+            }
+        },
+        {
             "name": "duckdb_create_varchar",
             "return_type": "duckdb_value",
             "params": [
@@ -29,11 +51,38 @@
                 }
             ],
             "comment": {
-                "description": "Creates a value from a null-terminated string\n\n",
+                "description": "Creates a value from a null-terminated string. The input must be valid UTF-8. Otherwise, undefined behavior is expected at later stages.\n\n",
                 "param_comments": {
                     "text": "The null-terminated string"
                 },
-                "return_value": "The value. This must be destroyed with `duckdb_destroy_value`."
+                "return_value": "The value, which must be destroyed with `duckdb_destroy_value`."
+            }
+        },
+        {
+            "name": "duckdb_safe_create_varchar_length",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "const char *",
+                    "name": "text"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "length"
+                },
+                {
+                    "type": "duckdb_error_data *",
+                    "name": "out_error_data"
+                }
+            ],
+            "comment": {
+                "description": "Creates a value from a string. Supersedes `duckdb_create_varchar_length`. The input must be valid UTF-8. Otherwise, `out_error_data` contains an invalid Unicode error.\n\n",
+                "param_comments": {
+                    "text": "The string.",
+                    "length": "The length of the string.",
+                    "out_error_data": "If valid UTF-8, then `nullptr`, else error information. If not `nullptr`, then the parameter must be destroyed with `duckdb_destroy_error_data`."
+                },
+                "return_value": "The value, which must be destroyed with `duckdb_destroy_value`."
             }
         },
         {
@@ -50,12 +99,12 @@
                 }
             ],
             "comment": {
-                "description": "Creates a value from a string\n\n",
+                "description": "Creates a value from a string. The input must be valid UTF-8. Otherwise, undefined behavior is expected at later stages.\n\n",
                 "param_comments": {
-                    "text": "The text",
-                    "length": "The length of the text"
+                    "text": "The string.",
+                    "length": "The length of the string."
                 },
-                "return_value": "The value. This must be destroyed with `duckdb_destroy_value`."
+                "return_value": "The value, which must be destroyed with `duckdb_destroy_value`."
             }
         },
         {

--- a/src/include/duckdb/main/capi/header_generation/functions/vector_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/vector_interface.json
@@ -126,7 +126,7 @@
                 }
             ],
             "comment": {
-                "description": "Safely assigns a string element in the vector at the specified location. Supersedes `duckdb_vector_assign_string_element`. The vector type must be VARCHAR and the input must be\nvalid UTF-8. Otherwise, it returns an invalid Unicode error.\n\n",
+                "description": "Safely assigns a null-terminated string element in the vector at the specified location. Supersedes `duckdb_vector_assign_string_element`. The vector type must be VARCHAR and the input must be\nvalid UTF-8. Otherwise, it returns an invalid Unicode error.\n\n",
                 "param_comments": {
                     "vector": "The vector to alter",
                     "index": "The row position in the vector to assign the string to",
@@ -159,6 +159,38 @@
                     "index": "The row position in the vector to assign the string to",
                     "str": "The null-terminated string"
                 }
+            }
+        },
+        {
+            "name": "duckdb_vector_safe_assign_string_element_len",
+            "return_type": "duckdb_error_data",
+            "params": [
+                {
+                    "type": "duckdb_vector",
+                    "name": "vector"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "index"
+                },
+                {
+                    "type": "const char *",
+                    "name": "str"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "str_len"
+                }
+            ],
+            "comment": {
+                "description": "Safely assigns a string element in the vector at the specified location. Supersedes `duckdb_vector_assign_string_element_len`. The vector type can be VARCHAR or BLOB. In the case of VARCHAR, you must pass valid UTF-8. Otherwise, it returns an invalid Unicode error.\n\n",
+                "param_comments": {
+                    "vector": "The vector to alter",
+                    "index": "The row position in the vector to assign the string to",
+                    "str": "The string",
+                    "str_len": "The length of the string (in bytes)"
+                },
+                "return_value": "If valid UTF-8, then `nullptr`, else error information. If not `nullptr`, then the return value must be destroyed with `duckdb_destroy_error_data`."
             }
         },
         {

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -762,6 +762,9 @@ typedef struct {
 	duckdb_value (*duckdb_create_union_value)(duckdb_logical_type union_type, idx_t tag_index, duckdb_value value);
 	duckdb_value (*duckdb_create_time_ns)(duckdb_time_ns input);
 	duckdb_time_ns (*duckdb_get_time_ns)(duckdb_value val);
+	duckdb_value (*duckdb_safe_create_varchar)(const char *text, duckdb_error_data *out_error_data);
+	duckdb_value (*duckdb_safe_create_varchar_length)(const char *text, idx_t length,
+	                                                  duckdb_error_data *out_error_data);
 #endif
 
 // API to create and manipulate vector types
@@ -777,6 +780,8 @@ typedef struct {
 	void (*duckdb_vector_copy_sel)(duckdb_vector src, duckdb_vector dst, duckdb_selection_vector sel, idx_t src_count,
 	                               idx_t src_offset, idx_t dst_offset);
 	duckdb_error_data (*duckdb_vector_safe_assign_string_element)(duckdb_vector vector, idx_t index, const char *str);
+	duckdb_error_data (*duckdb_vector_safe_assign_string_element_len)(duckdb_vector vector, idx_t index,
+	                                                                  const char *str, idx_t str_len);
 #endif
 
 } duckdb_ext_api_v1;
@@ -1361,22 +1366,25 @@ typedef struct {
 #define duckdb_table_function_get_client_context duckdb_ext_api.duckdb_table_function_get_client_context
 
 // Version unstable_new_value_functions
-#define duckdb_create_time_ns     duckdb_ext_api.duckdb_create_time_ns
-#define duckdb_get_time_ns        duckdb_ext_api.duckdb_get_time_ns
-#define duckdb_create_map_value   duckdb_ext_api.duckdb_create_map_value
-#define duckdb_create_union_value duckdb_ext_api.duckdb_create_union_value
+#define duckdb_safe_create_varchar        duckdb_ext_api.duckdb_safe_create_varchar
+#define duckdb_safe_create_varchar_length duckdb_ext_api.duckdb_safe_create_varchar_length
+#define duckdb_create_time_ns             duckdb_ext_api.duckdb_create_time_ns
+#define duckdb_get_time_ns                duckdb_ext_api.duckdb_get_time_ns
+#define duckdb_create_map_value           duckdb_ext_api.duckdb_create_map_value
+#define duckdb_create_union_value         duckdb_ext_api.duckdb_create_union_value
 
 // Version unstable_new_vector_functions
-#define duckdb_create_vector                     duckdb_ext_api.duckdb_create_vector
-#define duckdb_destroy_vector                    duckdb_ext_api.duckdb_destroy_vector
-#define duckdb_vector_safe_assign_string_element duckdb_ext_api.duckdb_vector_safe_assign_string_element
-#define duckdb_slice_vector                      duckdb_ext_api.duckdb_slice_vector
-#define duckdb_vector_copy_sel                   duckdb_ext_api.duckdb_vector_copy_sel
-#define duckdb_vector_reference_value            duckdb_ext_api.duckdb_vector_reference_value
-#define duckdb_vector_reference_vector           duckdb_ext_api.duckdb_vector_reference_vector
-#define duckdb_create_selection_vector           duckdb_ext_api.duckdb_create_selection_vector
-#define duckdb_destroy_selection_vector          duckdb_ext_api.duckdb_destroy_selection_vector
-#define duckdb_selection_vector_get_data_ptr     duckdb_ext_api.duckdb_selection_vector_get_data_ptr
+#define duckdb_create_vector                         duckdb_ext_api.duckdb_create_vector
+#define duckdb_destroy_vector                        duckdb_ext_api.duckdb_destroy_vector
+#define duckdb_vector_safe_assign_string_element     duckdb_ext_api.duckdb_vector_safe_assign_string_element
+#define duckdb_vector_safe_assign_string_element_len duckdb_ext_api.duckdb_vector_safe_assign_string_element_len
+#define duckdb_slice_vector                          duckdb_ext_api.duckdb_slice_vector
+#define duckdb_vector_copy_sel                       duckdb_ext_api.duckdb_vector_copy_sel
+#define duckdb_vector_reference_value                duckdb_ext_api.duckdb_vector_reference_value
+#define duckdb_vector_reference_vector               duckdb_ext_api.duckdb_vector_reference_vector
+#define duckdb_create_selection_vector               duckdb_ext_api.duckdb_create_selection_vector
+#define duckdb_destroy_selection_vector              duckdb_ext_api.duckdb_destroy_selection_vector
+#define duckdb_selection_vector_get_data_ptr         duckdb_ext_api.duckdb_selection_vector_get_data_ptr
 
 //===--------------------------------------------------------------------===//
 // Struct Global Macros

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -29,8 +29,20 @@ void duckdb_destroy_value(duckdb_value *value) {
 	}
 }
 
+duckdb_value duckdb_safe_create_varchar_length(const char *text, idx_t length, duckdb_error_data *out_error_data) {
+	*out_error_data = duckdb::UTF8Analyze(text, length);
+	if (*out_error_data) {
+		return nullptr;
+	}
+	return WrapValue(new duckdb::Value(std::string(text, length)));
+}
+
 duckdb_value duckdb_create_varchar_length(const char *text, idx_t length) {
 	return WrapValue(new duckdb::Value(std::string(text, length)));
+}
+
+duckdb_value duckdb_safe_create_varchar(const char *text, duckdb_error_data *out_error_data) {
+	return duckdb_safe_create_varchar_length(text, strlen(text), out_error_data);
 }
 
 duckdb_value duckdb_create_varchar(const char *text) {

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/main/capi/capi_internal.hpp"
+#include "utf8proc_wrapper.hpp"
 
 namespace duckdb {
 
@@ -482,6 +483,17 @@ ExceptionType ErrorTypeFromC(const duckdb_error_type type) {
 	default:
 		return ExceptionType::INVALID;
 	}
+}
+
+duckdb_error_data UTF8Analyze(const char *str, size_t len) {
+	UnicodeInvalidReason reason;
+	size_t pos;
+	auto utf_type = Utf8Proc::Analyze(str, len, &reason, &pos);
+	if (utf_type == UnicodeType::INVALID) {
+		return duckdb_create_error_data(DUCKDB_ERROR_INVALID_INPUT,
+		                                "invalid Unicode detected, str must be valid UTF-8");
+	}
+	return nullptr;
 }
 
 } // namespace duckdb

--- a/test/api/capi/test_capi_values.cpp
+++ b/test/api/capi/test_capi_values.cpp
@@ -436,3 +436,54 @@ TEST_CASE("Test SQL string conversion", "[capi]") {
 	duckdb_destroy_value(&uint_val);
 	duckdb_free(uint_val_str);
 }
+
+TEST_CASE("Test UTF-8 string creation with and without embedded nulls", "[capi]") {
+	// Create a valid and an invalid null-terminated string without non-termination null-bytes.
+	string valid_utf8 = "é";
+	idx_t len = strlen(valid_utf8.c_str());
+	auto invalid_utf8 = static_cast<char *>(malloc(len));
+	memcpy(invalid_utf8, valid_utf8.c_str() + 1, len);
+
+	duckdb_error_data error_data;
+	auto value = duckdb_safe_create_varchar(valid_utf8.c_str(), &error_data);
+	REQUIRE(value);
+	REQUIRE(!error_data);
+	auto res = duckdb_get_varchar(value);
+	REQUIRE(StringUtil::Equals(res, valid_utf8));
+	duckdb_free(res);
+	duckdb_destroy_value(&value);
+	value = duckdb_safe_create_varchar(invalid_utf8, &error_data);
+	free(invalid_utf8);
+	REQUIRE(!value);
+	REQUIRE(error_data);
+	REQUIRE(duckdb_error_data_has_error(error_data));
+	auto err_type = duckdb_error_data_error_type(error_data);
+	REQUIRE(err_type == DUCKDB_ERROR_INVALID_INPUT);
+	auto err_msg = duckdb_error_data_message(error_data);
+	REQUIRE(StringUtil::Contains(err_msg, "invalid Unicode detected, str must be valid UTF-8"));
+	duckdb_destroy_error_data(&error_data);
+
+	// Create a valid and an invalid null-terminated string with non-termination null-bytes.
+	constexpr idx_t VALID_NULL_UTF8_LEN = 6;
+	string valid_null_utf8("é\0b\0c\0", VALID_NULL_UTF8_LEN);
+	auto invalid_null_utf8 = static_cast<char *>(malloc(VALID_NULL_UTF8_LEN));
+	memcpy(invalid_null_utf8, valid_null_utf8.c_str() + 1, VALID_NULL_UTF8_LEN);
+
+	value = duckdb_safe_create_varchar_length(valid_null_utf8.c_str(), VALID_NULL_UTF8_LEN, &error_data);
+	REQUIRE(value);
+	REQUIRE(!error_data);
+	res = duckdb_get_varchar(value);
+	REQUIRE(StringUtil::Equals(res, valid_null_utf8));
+	duckdb_free(res);
+	duckdb_destroy_value(&value);
+	value = duckdb_safe_create_varchar_length(invalid_null_utf8, VALID_NULL_UTF8_LEN - 1, &error_data);
+	free(invalid_null_utf8);
+	REQUIRE(!value);
+	REQUIRE(error_data);
+	REQUIRE(duckdb_error_data_has_error(error_data));
+	err_type = duckdb_error_data_error_type(error_data);
+	REQUIRE(err_type == DUCKDB_ERROR_INVALID_INPUT);
+	err_msg = duckdb_error_data_message(error_data);
+	REQUIRE(StringUtil::Contains(err_msg, "invalid Unicode detected, str must be valid UTF-8"));
+	duckdb_destroy_error_data(&error_data);
+}


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/20467. 

Related internal issue: https://github.com/duckdblabs/duckdb-internal/issues/7002

I think we should better guard the C API `VARCHAR` entry points against invalid UTF-8 in the remaining places. I've also added more testing around strings with null embeddings, related to https://github.com/duckdb/duckdb-go/pull/109.

EDIT: note that I have not changed/exposed new functions for the `VARCHAR`-bind functions, as they're superseded already by `duckdb_bind_value`.