### PR TITLE
Optimize MERGE INTO DELETE RETURNING by passing columns through from scan

### DIFF
--- a/src/execution/physical_plan/plan_merge_into.cpp
+++ b/src/execution/physical_plan/plan_merge_into.cpp
@@ -41,9 +41,11 @@ unique_ptr<MergeIntoOperator> PlanMergeIntoAction(ClientContext &context, Logica
 		break;
 	}
 	case MergeActionType::MERGE_DELETE: {
+		// Use delete_return_columns if available (for optimized RETURNING path)
+		vector<idx_t> return_columns = op.delete_return_columns;
 		result->op = planner.Make<PhysicalDelete>(std::move(return_types), op.table, op.table.GetStorage(),
 		                                          std::move(bound_constraints), op.row_id_start, cardinality,
-		                                          op.return_chunk, vector<idx_t>());
+		                                          op.return_chunk, std::move(return_columns));
 		break;
 	}
 	case MergeActionType::MERGE_INSERT: {

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -397,6 +397,15 @@ private:
 	BoundStatement Bind(MergeIntoStatement &stmt);
 
 	void BindRowIdColumns(TableCatalogEntry &table, LogicalGet &get, vector<unique_ptr<Expression>> &expressions);
+	//! Build a mapping from storage column index to scan chunk index for RETURNING.
+	//! Ensures all physical columns are present in the scan.
+	//! return_columns[storage_idx] = scan_chunk_idx
+	void BindDeleteReturningColumns(TableCatalogEntry &table, LogicalGet &get, vector<idx_t> &return_columns);
+	//! Overload for MERGE INTO: also creates projection expressions and maps to projection indices
+	//! return_columns[storage_idx] = projection_expr_idx
+	void BindDeleteReturningColumns(TableCatalogEntry &table, LogicalGet &get, vector<idx_t> &return_columns,
+	                                vector<unique_ptr<Expression>> &projection_expressions,
+	                                LogicalOperator &target_binding);
 	BoundStatement BindReturning(vector<unique_ptr<ParsedExpression>> returning_list, TableCatalogEntry &table,
 	                             const string &alias, idx_t update_table_index,
 	                             unique_ptr<LogicalOperator> child_operator,

--- a/src/include/duckdb/planner/operator/logical_merge_into.hpp
+++ b/src/include/duckdb/planner/operator/logical_merge_into.hpp
@@ -54,6 +54,9 @@ public:
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
 	//! Whether or not to return the input data
 	bool return_chunk = false;
+	//! For DELETE with RETURNING: maps storage_idx -> input chunk position
+	//! Used to pass columns through instead of fetching by row ID
+	vector<idx_t> delete_return_columns;
 
 	map<MergeActionCondition, vector<unique_ptr<BoundMergeIntoAction>>> actions;
 

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -867,6 +867,11 @@
         "id": 206,
         "name": "return_chunk",
         "type": "bool"
+      },
+      {
+        "id": 207,
+        "name": "delete_return_columns",
+        "type": "vector<idx_t>"
       }
     ],
     "constructor": ["$ClientContext", "table_info&"]

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -19,7 +19,9 @@
 #include "duckdb/parser/tableref/table_function_ref.hpp"
 #include "duckdb/planner/bound_query_node.hpp"
 #include "duckdb/planner/expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression_binder/returning_binder.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_sample.hpp"
 #include "duckdb/planner/query_node/list.hpp"
@@ -363,6 +365,69 @@ void VerifyNotExcluded(const ParsedExpression &root_expr) {
 			        "'excluded' qualified columns are not supported in the RETURNING clause yet");
 		    }
 	    });
+}
+
+void Binder::BindDeleteReturningColumns(TableCatalogEntry &table, LogicalGet &get, vector<idx_t> &return_columns) {
+	// Build a mapping from storage column index to scan chunk index for RETURNING.
+	// This allows PhysicalDelete to pass columns through from the scan instead of
+	// fetching them by row ID. Generated columns will be computed by the RETURNING projection.
+	auto &column_ids = get.GetColumnIds();
+	auto &columns = table.GetColumns();
+	auto physical_count = columns.PhysicalColumnCount();
+
+	// Initialize the mapping with INVALID_INDEX
+	return_columns.resize(physical_count, DConstants::INVALID_INDEX);
+
+	// First, map columns already in the scan to their storage indices
+	for (idx_t chunk_idx = 0; chunk_idx < column_ids.size(); chunk_idx++) {
+		auto &col_id = column_ids[chunk_idx];
+		if (col_id.IsVirtualColumn()) {
+			continue;
+		}
+		// Get the column by logical index, then get its storage index
+		auto logical_idx = col_id.GetPrimaryIndex();
+		auto &col = columns.GetColumn(LogicalIndex(logical_idx));
+		if (!col.Generated()) {
+			auto storage_idx = col.StorageOid();
+			return_columns[storage_idx] = chunk_idx;
+		}
+	}
+
+	// Add any missing physical columns to the scan
+	for (auto &col : columns.Physical()) {
+		auto storage_idx = col.StorageOid();
+		if (return_columns[storage_idx] == DConstants::INVALID_INDEX) {
+			return_columns[storage_idx] = column_ids.size();
+			get.AddColumnId(col.Logical().index);
+		}
+	}
+}
+
+void Binder::BindDeleteReturningColumns(TableCatalogEntry &table, LogicalGet &get, vector<idx_t> &return_columns,
+                                        vector<unique_ptr<Expression>> &projection_expressions,
+                                        LogicalOperator &target_binding) {
+	// First, use the base helper to ensure all physical columns are in the scan
+	vector<idx_t> scan_return_columns;
+	BindDeleteReturningColumns(table, get, scan_return_columns);
+
+	// Resolve types after adding columns to the scan
+	target_binding.ResolveOperatorTypes();
+	auto target_bindings = target_binding.GetColumnBindings();
+	auto &target_types = target_binding.types;
+
+	// Convert scan mapping to projection expression mapping
+	// return_columns[storage_idx] = projection_expr_idx
+	auto physical_count = table.GetColumns().PhysicalColumnCount();
+	return_columns.resize(physical_count, DConstants::INVALID_INDEX);
+
+	for (idx_t storage_idx = 0; storage_idx < scan_return_columns.size(); storage_idx++) {
+		auto scan_idx = scan_return_columns[storage_idx];
+		if (scan_idx != DConstants::INVALID_INDEX && scan_idx < target_bindings.size()) {
+			return_columns[storage_idx] = projection_expressions.size();
+			auto col_ref = make_uniq<BoundColumnRefExpression>(target_types[scan_idx], target_bindings[scan_idx]);
+			projection_expressions.push_back(std::move(col_ref));
+		}
+	}
 }
 
 BoundStatement Binder::BindReturning(vector<unique_ptr<ParsedExpression>> returning_list, TableCatalogEntry &table,

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -68,36 +68,7 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 	// instead of having to fetch them by row ID in PhysicalDelete.
 	// Generated columns will be computed in the RETURNING projection by the binder.
 	if (!stmt.returning_list.empty()) {
-		auto &column_ids = get.GetColumnIds();
-		auto &columns = table.GetColumns();
-		auto physical_count = columns.PhysicalColumnCount();
-
-		// Build a map from storage index -> input chunk index
-		// return_columns[storage_idx] = input_chunk_idx
-		del->return_columns.resize(physical_count, DConstants::INVALID_INDEX);
-
-		// First, map columns already in the scan to their storage indices
-		for (idx_t chunk_idx = 0; chunk_idx < column_ids.size(); chunk_idx++) {
-			auto &col_id = column_ids[chunk_idx];
-			if (col_id.IsVirtualColumn()) {
-				continue;
-			}
-			// Get the column by logical index, then get its storage index
-			auto logical_idx = col_id.GetPrimaryIndex();
-			if (!columns.GetColumn(LogicalIndex(logical_idx)).Generated()) {
-				auto storage_idx = columns.GetColumn(LogicalIndex(logical_idx)).StorageOid();
-				del->return_columns[storage_idx] = chunk_idx;
-			}
-		}
-
-		// Add any missing physical columns to the scan
-		for (auto &col : columns.Physical()) {
-			auto storage_idx = col.StorageOid();
-			if (del->return_columns[storage_idx] == DConstants::INVALID_INDEX) {
-				del->return_columns[storage_idx] = column_ids.size();
-				get.AddColumnId(col.Logical().index);
-			}
-		}
+		BindDeleteReturningColumns(table, get, del->return_columns);
 	}
 
 	del->AddChild(std::move(root));

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -368,6 +368,68 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 		projection_expressions.push_back(std::move(marker_ref));
 	}
 
+	// If RETURNING is present and we have a DELETE action, add all physical columns to the scan
+	// so we can pass them through instead of fetching by row ID in PhysicalDelete
+	if (!stmt.returning_list.empty()) {
+		bool has_delete_action = false;
+		for (auto &entry : merge_into->actions) {
+			for (auto &action : entry.second) {
+				if (action->action_type == MergeActionType::MERGE_DELETE) {
+					has_delete_action = true;
+					break;
+				}
+			}
+			if (has_delete_action) {
+				break;
+			}
+		}
+
+		if (has_delete_action) {
+		auto &column_ids = get.GetColumnIds();
+		auto &columns = table.GetColumns();
+		auto physical_count = columns.PhysicalColumnCount();
+
+		// Step 1: Add any missing physical columns to the scan
+		for (auto &col : columns.Physical()) {
+			bool found = false;
+			for (auto &col_id : column_ids) {
+				if (!col_id.IsVirtualColumn() && col_id.GetPrimaryIndex() == col.Logical().index) {
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				get.AddColumnId(col.Logical().index);
+			}
+		}
+
+		// Step 2: Resolve types and get bindings once
+		auto &target_binding = join_ref.get().children[inverted ? 0 : 1];
+		target_binding->ResolveOperatorTypes();
+		auto target_bindings = target_binding->GetColumnBindings();
+		auto &target_types = target_binding->types;
+
+		// Step 3: Build the mapping from storage index -> projection expression index
+		merge_into->delete_return_columns.resize(physical_count, DConstants::INVALID_INDEX);
+		auto &updated_column_ids = get.GetColumnIds();
+
+		for (idx_t scan_idx = 0; scan_idx < updated_column_ids.size() && scan_idx < target_bindings.size(); scan_idx++) {
+			auto &col_id = updated_column_ids[scan_idx];
+			if (col_id.IsVirtualColumn()) {
+				continue;
+			}
+			auto logical_idx = col_id.GetPrimaryIndex();
+			auto &col = columns.GetColumn(LogicalIndex(logical_idx));
+			if (!col.Generated()) {
+				auto storage_idx = col.StorageOid();
+				merge_into->delete_return_columns[storage_idx] = projection_expressions.size();
+				auto col_ref = make_uniq<BoundColumnRefExpression>(target_types[scan_idx], target_bindings[scan_idx]);
+				projection_expressions.push_back(std::move(col_ref));
+			}
+		}
+		}
+	}
+
 	merge_into->row_id_start = projection_expressions.size();
 	// finally bind the row id column and add them to the projection list
 	BindRowIdColumns(table, get, projection_expressions);

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -385,48 +385,50 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 		}
 
 		if (has_delete_action) {
-		auto &column_ids = get.GetColumnIds();
-		auto &columns = table.GetColumns();
-		auto physical_count = columns.PhysicalColumnCount();
+			auto &column_ids = get.GetColumnIds();
+			auto &columns = table.GetColumns();
+			auto physical_count = columns.PhysicalColumnCount();
 
-		// Step 1: Add any missing physical columns to the scan
-		for (auto &col : columns.Physical()) {
-			bool found = false;
-			for (auto &col_id : column_ids) {
-				if (!col_id.IsVirtualColumn() && col_id.GetPrimaryIndex() == col.Logical().index) {
-					found = true;
-					break;
+			// Step 1: Add any missing physical columns to the scan
+			for (auto &col : columns.Physical()) {
+				bool found = false;
+				for (auto &col_id : column_ids) {
+					if (!col_id.IsVirtualColumn() && col_id.GetPrimaryIndex() == col.Logical().index) {
+						found = true;
+						break;
+					}
+				}
+				if (!found) {
+					get.AddColumnId(col.Logical().index);
 				}
 			}
-			if (!found) {
-				get.AddColumnId(col.Logical().index);
-			}
-		}
 
-		// Step 2: Resolve types and get bindings once
-		auto &target_binding = join_ref.get().children[inverted ? 0 : 1];
-		target_binding->ResolveOperatorTypes();
-		auto target_bindings = target_binding->GetColumnBindings();
-		auto &target_types = target_binding->types;
+			// Step 2: Resolve types and get bindings once
+			auto &target_binding = join_ref.get().children[inverted ? 0 : 1];
+			target_binding->ResolveOperatorTypes();
+			auto target_bindings = target_binding->GetColumnBindings();
+			auto &target_types = target_binding->types;
 
-		// Step 3: Build the mapping from storage index -> projection expression index
-		merge_into->delete_return_columns.resize(physical_count, DConstants::INVALID_INDEX);
-		auto &updated_column_ids = get.GetColumnIds();
+			// Step 3: Build the mapping from storage index -> projection expression index
+			merge_into->delete_return_columns.resize(physical_count, DConstants::INVALID_INDEX);
+			auto &updated_column_ids = get.GetColumnIds();
 
-		for (idx_t scan_idx = 0; scan_idx < updated_column_ids.size() && scan_idx < target_bindings.size(); scan_idx++) {
-			auto &col_id = updated_column_ids[scan_idx];
-			if (col_id.IsVirtualColumn()) {
-				continue;
+			for (idx_t scan_idx = 0; scan_idx < updated_column_ids.size() && scan_idx < target_bindings.size();
+			     scan_idx++) {
+				auto &col_id = updated_column_ids[scan_idx];
+				if (col_id.IsVirtualColumn()) {
+					continue;
+				}
+				auto logical_idx = col_id.GetPrimaryIndex();
+				auto &col = columns.GetColumn(LogicalIndex(logical_idx));
+				if (!col.Generated()) {
+					auto storage_idx = col.StorageOid();
+					merge_into->delete_return_columns[storage_idx] = projection_expressions.size();
+					auto col_ref =
+					    make_uniq<BoundColumnRefExpression>(target_types[scan_idx], target_bindings[scan_idx]);
+					projection_expressions.push_back(std::move(col_ref));
+				}
 			}
-			auto logical_idx = col_id.GetPrimaryIndex();
-			auto &col = columns.GetColumn(LogicalIndex(logical_idx));
-			if (!col.Generated()) {
-				auto storage_idx = col.StorageOid();
-				merge_into->delete_return_columns[storage_idx] = projection_expressions.size();
-				auto col_ref = make_uniq<BoundColumnRefExpression>(target_types[scan_idx], target_bindings[scan_idx]);
-				projection_expressions.push_back(std::move(col_ref));
-			}
-		}
 		}
 	}
 

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -617,7 +617,6 @@ void LogicalMergeInto::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<optional_idx>(204, "source_marker", source_marker);
 	serializer.WritePropertyWithDefault<map<MergeActionCondition, vector<unique_ptr<BoundMergeIntoAction>>>>(205, "actions", actions);
 	serializer.WritePropertyWithDefault<bool>(206, "return_chunk", return_chunk);
-	serializer.WritePropertyWithDefault<vector<idx_t>>(207, "delete_return_columns", delete_return_columns);
 }
 
 unique_ptr<LogicalOperator> LogicalMergeInto::Deserialize(Deserializer &deserializer) {
@@ -629,7 +628,6 @@ unique_ptr<LogicalOperator> LogicalMergeInto::Deserialize(Deserializer &deserial
 	deserializer.ReadProperty<optional_idx>(204, "source_marker", result->source_marker);
 	deserializer.ReadPropertyWithDefault<map<MergeActionCondition, vector<unique_ptr<BoundMergeIntoAction>>>>(205, "actions", result->actions);
 	deserializer.ReadPropertyWithDefault<bool>(206, "return_chunk", result->return_chunk);
-	deserializer.ReadPropertyWithDefault<vector<idx_t>>(207, "delete_return_columns", result->delete_return_columns);
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -617,6 +617,7 @@ void LogicalMergeInto::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<optional_idx>(204, "source_marker", source_marker);
 	serializer.WritePropertyWithDefault<map<MergeActionCondition, vector<unique_ptr<BoundMergeIntoAction>>>>(205, "actions", actions);
 	serializer.WritePropertyWithDefault<bool>(206, "return_chunk", return_chunk);
+	serializer.WritePropertyWithDefault<vector<idx_t>>(207, "delete_return_columns", delete_return_columns);
 }
 
 unique_ptr<LogicalOperator> LogicalMergeInto::Deserialize(Deserializer &deserializer) {
@@ -628,6 +629,7 @@ unique_ptr<LogicalOperator> LogicalMergeInto::Deserialize(Deserializer &deserial
 	deserializer.ReadProperty<optional_idx>(204, "source_marker", result->source_marker);
 	deserializer.ReadPropertyWithDefault<map<MergeActionCondition, vector<unique_ptr<BoundMergeIntoAction>>>>(205, "actions", result->actions);
 	deserializer.ReadPropertyWithDefault<bool>(206, "return_chunk", result->return_chunk);
+	deserializer.ReadPropertyWithDefault<vector<idx_t>>(207, "delete_return_columns", result->delete_return_columns);
 	return std::move(result);
 }
 

--- a/test/sql/returning/returning_delete.test
+++ b/test/sql/returning/returning_delete.test
@@ -323,6 +323,25 @@ statement ok
 DROP TABLE test_where_returning;
 
 # ============================================================
+# Virtual columns like rowid are not supported in RETURNING
+# ============================================================
+
+statement ok
+CREATE TABLE test_rowid_not_supported (id INTEGER, name VARCHAR);
+
+statement ok
+INSERT INTO test_rowid_not_supported VALUES (1, 'one');
+
+# rowid is not supported in DELETE RETURNING
+statement error
+DELETE FROM test_rowid_not_supported WHERE id = 1 RETURNING rowid;
+----
+<REGEX>:Binder Error.*Referenced column "rowid" not found.*
+
+statement ok
+DROP TABLE test_rowid_not_supported;
+
+# ============================================================
 # Tests for DELETE RETURNING with generated columns
 # Generated columns are computed at execution time from physical columns
 # ============================================================
@@ -502,3 +521,33 @@ DROP TABLE merge_multi_gen;
 
 statement ok
 DROP TABLE merge_delete_source;
+
+# ============================================================
+# Virtual columns like rowid are not supported in MERGE INTO RETURNING
+# ============================================================
+
+statement ok
+CREATE TABLE merge_rowid_target (id INT, val INT);
+
+statement ok
+INSERT INTO merge_rowid_target VALUES (1, 10), (2, 20);
+
+statement ok
+CREATE TABLE merge_rowid_source (id INT);
+
+statement ok
+INSERT INTO merge_rowid_source VALUES (1);
+
+# rowid is not supported in MERGE INTO DELETE RETURNING
+statement error
+MERGE INTO merge_rowid_target t USING merge_rowid_source s ON t.id = s.id
+WHEN MATCHED THEN DELETE
+RETURNING t.rowid, t.id, t.val;
+----
+<REGEX>:Binder Error.*does not have a column named "rowid".*
+
+statement ok
+DROP TABLE merge_rowid_target;
+
+statement ok
+DROP TABLE merge_rowid_source;

--- a/test/sql/returning/returning_delete.test
+++ b/test/sql/returning/returning_delete.test
@@ -432,3 +432,73 @@ Hello, Bob!
 
 statement ok
 DROP TABLE test_generated_varchar;
+
+# ============================================================
+# Tests for MERGE INTO DELETE RETURNING with generated columns
+# ============================================================
+
+statement ok
+CREATE TABLE merge_gen_target(id INT, x INT, gen AS (x * 2));
+
+statement ok
+INSERT INTO merge_gen_target(id, x) VALUES (1, 10), (2, 20), (3, 30);
+
+statement ok
+CREATE TABLE merge_source(id INT);
+
+statement ok
+INSERT INTO merge_source VALUES (1), (2);
+
+# MERGE INTO DELETE RETURNING with generated column
+query IIII
+MERGE INTO merge_gen_target USING merge_source ON merge_gen_target.id = merge_source.id
+WHEN MATCHED THEN DELETE
+RETURNING *, merge_action;
+----
+1	10	20	DELETE
+2	20	40	DELETE
+
+# Verify remaining row
+query III
+SELECT * FROM merge_gen_target;
+----
+3	30	60
+
+statement ok
+DROP TABLE merge_gen_target;
+
+statement ok
+DROP TABLE merge_source;
+
+# MERGE INTO DELETE RETURNING with multiple generated columns
+statement ok
+CREATE TABLE merge_multi_gen(
+    id INT,
+    a INT,
+    b INT,
+    sum_ab INT GENERATED ALWAYS AS (a + b) VIRTUAL,
+    prod_ab INT GENERATED ALWAYS AS (a * b) VIRTUAL
+);
+
+statement ok
+INSERT INTO merge_multi_gen(id, a, b) VALUES (1, 2, 3), (2, 4, 5), (3, 6, 7);
+
+statement ok
+CREATE TABLE merge_delete_source(id INT);
+
+statement ok
+INSERT INTO merge_delete_source VALUES (1), (3);
+
+query IIIIII
+MERGE INTO merge_multi_gen t USING merge_delete_source s ON t.id = s.id
+WHEN MATCHED THEN DELETE
+RETURNING t.id, t.a, t.b, t.sum_ab, t.prod_ab, merge_action;
+----
+1	2	3	5	6	DELETE
+3	6	7	13	42	DELETE
+
+statement ok
+DROP TABLE merge_multi_gen;
+
+statement ok
+DROP TABLE merge_delete_source;


### PR DESCRIPTION
This PR optimizes MERGE INTO DELETE RETURNING by passing physical columns through from the scan instead of fetching them by row ID in the fallback path.

## Changes
- Add `delete_return_columns` vector to `LogicalMergeInto` to map physical columns to their positions in the projection
- Populate `delete_return_columns` in `bind_merge_into.cpp` when RETURNING is used with a DELETE action
- Add serialization for the new field
- Add tests for MERGE INTO DELETE RETURNING with generated columns

## Context
This optimization mirrors the approach used in regular DELETE RETURNING (PR #20485) but extends it to MERGE INTO statements. Previously, MERGE INTO DELETE RETURNING would fall back to fetching columns by row ID, which is slower than passing them through from the scan.

## Testing
- Added tests for MERGE INTO DELETE RETURNING with generated columns
- Existing tests pass