### PR TITLE
Immediately short-circuit streaming limit instead of fetching one more input chunk prior to short-circuiting

### DIFF
--- a/src/execution/operator/helper/physical_streaming_limit.cpp
+++ b/src/execution/operator/helper/physical_streaming_limit.cpp
@@ -54,6 +54,9 @@ OperatorResultType PhysicalStreamingLimit::Execute(ExecutionContext &context, Da
 	if (PhysicalLimit::HandleOffset(input, current_offset, offset.GetIndex(), limit.GetIndex())) {
 		chunk.Reference(input);
 	}
+	if (current_offset >= limit.GetIndex() + offset.GetIndex()) {
+		return chunk.size() == 0 ? OperatorResultType::FINISHED : OperatorResultType::HAVE_MORE_OUTPUT;
+	}
 	return OperatorResultType::NEED_MORE_INPUT;
 }
 

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -262,8 +262,8 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 		}
 
 		if (result == OperatorResultType::FINISHED) {
+			D_ASSERT(in_process_operators.empty());
 			exhausted_pipeline = true;
-			break;
 		}
 	} while (chunk_budget.Next());
 


### PR DESCRIPTION
Currently the streaming limit returns the last chunk with code `OperatorResultType::NEEDS_MORE_INPUT`. The next time it is called, it will immediately return `OperatorResultType::FINISHED`. This causes an additional chunk to be fetched from the source data unnecessarily.

This PR addresses this by instead returning `OperatorResultType::HAVE_MORE_OUTPUT` when the limit has been reached - causing the streaming limit to be called again instead of going back to the source. Afterwards, we return `OperatorResultType::FINISHED` to end execution.

This also requires a fix in the pipeline executor. Currently when returning `OperatorResultType::FINISHED` execution is incorrectly immediately terminated. Instead, we need to flush any caches in operators that happen AFTER the operator that has called `OperatorResultType::FINISHED` - otherwise any cached data will be incorrectly lost.