### PR TITLE
test/issues/general/test_1248.test: remove require vector_size 2048

### DIFF
--- a/test/issues/general/test_1248.test
+++ b/test/issues/general/test_1248.test
@@ -73,9 +73,6 @@ order by all;
 20
 21
 
-#FIXME: currently the next query will fail when vector_size = 2 AND optimizers are disabled
-require vector_size 2048
-
 query I
 with recursive test(round) as (
     select 0


### PR DESCRIPTION
Fixed in https://github.com/duckdb/duckdb/pull/20641, before that this would fail in a configuration when `PRAGMA disable_optimizer` is run before running the test.