### PR TITLE
Better Github Actions annotations for errors

### DIFF
--- a/test/helpers/CMakeLists.txt
+++ b/test/helpers/CMakeLists.txt
@@ -1,8 +1,9 @@
 add_definitions(-DDUCKDB_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}"
                 -DDUCKDB_BUILD_DIRECTORY="${PROJECT_BINARY_DIR}")
 
-set(DUCKDB_TEST_HELPERS_UNITS test_helpers.cpp capi_tester.cpp pid.cpp
-                              test_config.cpp)
+set(DUCKDB_TEST_HELPERS_UNITS
+    test_helpers.cpp capi_tester.cpp pid.cpp test_config.cpp gha_annotation.cpp
+    gha_annotation_listener.cpp)
 
 add_library(test_helpers STATIC ${DUCKDB_TEST_HELPERS_UNITS})
 

--- a/test/helpers/gha_annotation.cpp
+++ b/test/helpers/gha_annotation.cpp
@@ -4,7 +4,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
-#include <regex>
 #include <sstream>
 
 namespace duckdb {
@@ -28,12 +27,6 @@ std::string StripWorkspacePrefix(const std::string &path) {
 		return path.substr(prefix.length());
 	}
 	return path;
-}
-
-std::string StripAnsiCodes(const std::string &str) {
-	// ANSI escape sequences: ESC [ ... m (where ... is digits and semicolons)
-	static const std::regex ansi_regex("\x1b\\[[0-9;]*m");
-	return std::regex_replace(str, ansi_regex, "");
 }
 
 // Encode the annotation message body - Otherwise it cannot contain newlines
@@ -135,7 +128,6 @@ void EndAnnotation() {
 	}
 	std::string full_summary = FailureSummary::GetFailureSummaryAlways();
 	std::string message = full_summary.substr(annotation_state.start_position);
-	message = StripAnsiCodes(message);
 	EmitError(annotation_state.file, annotation_state.line, annotation_state.title, message);
 	annotation_state.active = false;
 }

--- a/test/helpers/gha_annotation.cpp
+++ b/test/helpers/gha_annotation.cpp
@@ -1,0 +1,144 @@
+#include "gha_annotation.hpp"
+#include "test_config.hpp"
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <regex>
+#include <sstream>
+
+namespace duckdb {
+namespace gha {
+
+bool IsGitHubActions() {
+	const char *ci = std::getenv("CI");
+	return ci && std::strcmp(ci, "true") == 0;
+}
+
+std::string StripWorkspacePrefix(const std::string &path) {
+	const char *workspace = std::getenv("GITHUB_WORKSPACE");
+	if (!workspace) {
+		return path;
+	}
+	std::string prefix(workspace);
+	if (!prefix.empty() && prefix.back() != '/') {
+		prefix += '/';
+	}
+	if (path.compare(0, prefix.length(), prefix) == 0) {
+		return path.substr(prefix.length());
+	}
+	return path;
+}
+
+std::string StripAnsiCodes(const std::string &str) {
+	// ANSI escape sequences: ESC [ ... m (where ... is digits and semicolons)
+	static const std::regex ansi_regex("\x1b\\[[0-9;]*m");
+	return std::regex_replace(str, ansi_regex, "");
+}
+
+// Encode the annotation message body - Otherwise it cannot contain newlines
+std::string EncodeMessage(const std::string &msg) {
+	std::ostringstream result;
+	for (char c : msg) {
+		switch (c) {
+		case '%':
+			result << "%25";
+			break;
+		case '\r':
+			result << "%0D";
+			break;
+		case '\n':
+			result << "%0A";
+			break;
+		default:
+			result << c;
+			break;
+		}
+	}
+	return result.str();
+}
+
+// Encode the title parameter - Escapes newlines, but also commas so it's not interpreted as the next parameter
+// after one.
+std::string EncodeTitle(const std::string &msg) {
+	std::ostringstream result;
+	for (char c : msg) {
+		switch (c) {
+		case '%':
+			result << "%25";
+			break;
+		case '\r':
+			result << "%0D";
+			break;
+		case '\n':
+			result << "%0A";
+			break;
+		case ',':
+			result << "%2C";
+			break;
+		default:
+			result << c;
+			break;
+		}
+	}
+	return result.str();
+}
+
+void EmitError(const std::string &file, int line, const std::string &title, const std::string &message) {
+	if (!IsGitHubActions()) {
+		return;
+	}
+
+	std::ostringstream annotation;
+	annotation << "::error";
+
+	// Add optional parameters
+	bool has_params = false;
+	if (!file.empty()) {
+		annotation << " file=" << StripWorkspacePrefix(file);
+		has_params = true;
+	}
+	if (line > 0) {
+		annotation << (has_params ? "," : " ") << "line=" << line;
+		has_params = true;
+	}
+	if (!title.empty()) {
+		annotation << (has_params ? "," : " ") << "title=" << EncodeTitle(title);
+	}
+
+	annotation << "::" << EncodeMessage(message) << "\n";
+
+	std::cerr << annotation.str();
+}
+
+// Thread-local state for annotation metadata and start position in FailureSummary
+static thread_local struct {
+	std::string file;
+	int line = 0;
+	std::string title;
+	size_t start_position = 0;
+	bool active = false;
+} annotation_state;
+
+void BeginAnnotation(const std::string &file, int line, const std::string &title) {
+	EndAnnotation(); // Emit any previous annotation
+	annotation_state.file = file;
+	annotation_state.line = line;
+	annotation_state.title = title;
+	annotation_state.start_position = FailureSummary::GetFailureSummaryAlways().size();
+	annotation_state.active = true;
+}
+
+void EndAnnotation() {
+	if (!annotation_state.active) {
+		return;
+	}
+	std::string full_summary = FailureSummary::GetFailureSummaryAlways();
+	std::string message = full_summary.substr(annotation_state.start_position);
+	message = StripAnsiCodes(message);
+	EmitError(annotation_state.file, annotation_state.line, annotation_state.title, message);
+	annotation_state.active = false;
+}
+
+} // namespace gha
+} // namespace duckdb

--- a/test/helpers/gha_annotation_listener.cpp
+++ b/test/helpers/gha_annotation_listener.cpp
@@ -1,0 +1,61 @@
+#include "gha_annotation_listener.hpp"
+
+#include "gha_annotation.hpp"
+
+namespace duckdb {
+
+GHAAnnotationListener::GHAAnnotationListener(Catch::ReporterConfig const &config)
+    : Catch::TestEventListenerBase(config) {
+}
+
+bool GHAAnnotationListener::assertionEnded(Catch::AssertionStats const &stats) {
+	if (stats.assertionResult.isOk()) {
+		return true;
+	}
+
+	const auto &result = stats.assertionResult;
+	auto src = result.getSourceInfo();
+
+	std::string file = src.file ? src.file : "";
+	int line = static_cast<int>(src.line);
+
+	// Skip explicit failures from .test files - SQLLogicTestLogger already emits
+	// detailed annotations for those, so the FAIL() call is redundant
+	if (result.getResultType() == Catch::ResultWas::ExplicitFailure) {
+		if (file.size() >= 5 && file.substr(file.size() - 5) == ".test") {
+			return true;
+		}
+	}
+
+	std::string title = ResultTypeToTitle(result.getResultType());
+	title += " (" + Catch::getResultCapture().getCurrentTestName() + ")";
+
+	std::string message = title;
+	if (result.hasMessage()) {
+		message = result.getMessage();
+	} else if (result.hasExpression()) {
+		message = result.getExpressionInMacro();
+	}
+
+	gha::EmitError(file, line, title, message);
+	return true;
+}
+
+std::string GHAAnnotationListener::ResultTypeToTitle(Catch::ResultWas::OfType type) {
+	switch (type) {
+	case Catch::ResultWas::ExpressionFailed:
+		return "Assertion failed";
+	case Catch::ResultWas::ThrewException:
+		return "Unexpected exception";
+	case Catch::ResultWas::FatalErrorCondition:
+		return "Fatal error";
+	case Catch::ResultWas::DidntThrowException:
+		return "Expected exception not thrown";
+	case Catch::ResultWas::ExplicitFailure:
+		return "Explicit failure";
+	default:
+		return "Test failure";
+	}
+}
+
+} // namespace duckdb

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -591,6 +591,10 @@ string FailureSummary::GetFailureSummary() {
 	if (!test_config.GetSummarizeFailures()) {
 		return string();
 	}
+	return GetFailureSummaryAlways();
+}
+
+string FailureSummary::GetFailureSummaryAlways() {
 	auto &summary = FailureSummary::Instance();
 	lock_guard<mutex> guard(summary.failures_lock);
 	std::ostringstream oss;

--- a/test/include/gha_annotation.hpp
+++ b/test/include/gha_annotation.hpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// gha_annotation.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <string>
+
+namespace duckdb {
+namespace gha {
+
+//! Returns true if running in GitHub Actions (CI=true environment variable)
+bool IsGitHubActions();
+
+//! Strips the workspace prefix from a path so GitHub can map it to the repo root.
+//! Uses GITHUB_WORKSPACE env var if available, otherwise falls back to known CI paths.
+std::string StripWorkspacePrefix(const std::string &path);
+
+//! Encodes a message for GitHub Actions workflow commands (newlines -> %0A, % -> %25)
+std::string EncodeMessage(const std::string &msg);
+
+//! Strips ANSI escape codes from a string (for cleaner annotation messages)
+std::string StripAnsiCodes(const std::string &str);
+
+//! Emits a GitHub Actions error annotation to stderr.
+//! Format: ::error file=path,line=N,title=Title::Message
+void EmitError(const std::string &file, int line, const std::string &title, const std::string &message);
+
+//! Begin an annotation. Records current position in FailureSummary.
+//! Call EndAnnotation() to emit content logged since this call.
+void BeginAnnotation(const std::string &file, int line, const std::string &title);
+
+//! Emit annotation with content logged since BeginAnnotation, then reset.
+void EndAnnotation();
+
+} // namespace gha
+} // namespace duckdb

--- a/test/include/gha_annotation_listener.hpp
+++ b/test/include/gha_annotation_listener.hpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// gha_annotation_listener.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#define CATCH_CONFIG_EXTERNAL_INTERFACES
+
+#include "catch.hpp"
+
+namespace duckdb {
+
+//! Catch2 listener that emits GitHub Actions annotations for assertion failures.
+//! Annotations include file/line information so they appear inline in the PR Files view.
+class GHAAnnotationListener : public Catch::TestEventListenerBase {
+public:
+	explicit GHAAnnotationListener(Catch::ReporterConfig const &config);
+
+	bool assertionEnded(Catch::AssertionStats const &stats) override;
+
+private:
+	static std::string ResultTypeToTitle(Catch::ResultWas::OfType type);
+};
+
+} // namespace duckdb

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -120,6 +120,10 @@ public:
 
 	static void Log(string message);
 	static string GetFailureSummary();
+	//! Returns the failure summary content regardless of the summarize_failures setting.
+	//! Used by the annotation system which needs to capture error messages even when
+	//! the summary won't be printed at the end.
+	static string GetFailureSummaryAlways();
 	static idx_t GetSummaryCounter();
 	static bool SkipLoggingSameError(const string &file_name);
 

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -57,7 +57,6 @@ public:
 
 	static void AppendFailure(const string &log_message);
 	static void LogFailure(const string &log_message);
-	static void LogFailureAnnotation(const string &log_message);
 
 private:
 	lock_guard<mutex> log_lock;

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -3,11 +3,14 @@
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "gha_annotation_listener.hpp"
 #include "sqlite/sqllogic_test_logger.hpp"
 #include "test_helpers.hpp"
 #include "test_config.hpp"
 
 using namespace duckdb;
+
+CATCH_REGISTER_LISTENER(GHAAnnotationListener);
 
 int main(int argc_in, char *argv[]) {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();


### PR DESCRIPTION
The sqllogictest runner had some minimal support for emitting Github Action annotations. They did not include most of the error info though, and they also didn't link to the relevant test files. And because of the annotation in the output part of the output would be duplicated in the log.

Furthermore the C++ tests did not have this integration.

This makes a bunch of changes to make github action annotation output much more feature complete.