### PR TITLE
[Parquet] Fix `column_orders` written to the parquet file

### DIFF
--- a/extension/parquet/include/column_writer.hpp
+++ b/extension/parquet/include/column_writer.hpp
@@ -145,7 +145,7 @@ public:
 		throw NotImplementedException("Writer doesn't require an AnalyzeSchemaFinalize pass");
 	}
 
-	virtual void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) = 0;
+	virtual idx_t FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) = 0;
 
 	//! Create the column writer for a specific type recursively
 	static unique_ptr<ColumnWriter> CreateWriterRecursive(ClientContext &context, ParquetWriter &writer,

--- a/extension/parquet/include/writer/list_column_writer.hpp
+++ b/extension/parquet/include/writer/list_column_writer.hpp
@@ -44,7 +44,7 @@ public:
 	void BeginWrite(ColumnWriterState &state) override;
 	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override;
 	void FinalizeWrite(ColumnWriterState &state) override;
-	void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
+	idx_t FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
 
 protected:
 	ColumnWriter &GetChildWriter();

--- a/extension/parquet/include/writer/primitive_column_writer.hpp
+++ b/extension/parquet/include/writer/primitive_column_writer.hpp
@@ -74,7 +74,7 @@ public:
 	void BeginWrite(ColumnWriterState &state) override;
 	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override;
 	void FinalizeWrite(ColumnWriterState &state) override;
-	void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
+	idx_t FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
 
 protected:
 	static void WriteLevels(Allocator &allocator, WriteStream &temp_writer, const unsafe_vector<uint16_t> &levels,

--- a/extension/parquet/include/writer/struct_column_writer.hpp
+++ b/extension/parquet/include/writer/struct_column_writer.hpp
@@ -32,7 +32,7 @@ public:
 	void BeginWrite(ColumnWriterState &state) override;
 	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override;
 	void FinalizeWrite(ColumnWriterState &state) override;
-	void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
+	idx_t FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/writer/variant_column_writer.hpp
+++ b/extension/parquet/include/writer/variant_column_writer.hpp
@@ -72,7 +72,7 @@ public:
 	~VariantColumnWriter() override = default;
 
 public:
-	void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
+	idx_t FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
 	unique_ptr<ParquetAnalyzeSchemaState> AnalyzeSchemaInit() override;
 	void AnalyzeSchema(ParquetAnalyzeSchemaState &state, Vector &input, idx_t count) override;
 	void AnalyzeSchemaFinalize(const ParquetAnalyzeSchemaState &state) override;

--- a/extension/parquet/writer/list_column_writer.cpp
+++ b/extension/parquet/writer/list_column_writer.cpp
@@ -146,7 +146,7 @@ ColumnWriter &ListColumnWriter::GetChildWriter() {
 	return *child_writers[0];
 }
 
-void ListColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) {
+idx_t ListColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) {
 	idx_t schema_idx = schemas.size();
 
 	auto &schema = column_schema;
@@ -189,7 +189,7 @@ void ListColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &sch
 		//! Instead, the "key_value" struct will be marked as REPEATED
 		D_ASSERT(GetChildWriter().Schema().repetition_type == FieldRepetitionType::REPEATED);
 	}
-	GetChildWriter().FinalizeSchema(schemas);
+	return GetChildWriter().FinalizeSchema(schemas);
 }
 
 } // namespace duckdb

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -431,7 +431,7 @@ void PrimitiveColumnWriter::WriteDictionary(PrimitiveColumnWriterState &state, u
 	state.write_info.insert(state.write_info.begin(), std::move(write_info));
 }
 
-void PrimitiveColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) {
+idx_t PrimitiveColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) {
 	idx_t schema_idx = schemas.size();
 
 	auto &schema = column_schema;
@@ -458,6 +458,7 @@ void PrimitiveColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement>
 	schemas.push_back(std::move(schema_element));
 
 	D_ASSERT(child_writers.empty());
+	return 1;
 }
 
 } // namespace duckdb

--- a/extension/parquet/writer/struct_column_writer.cpp
+++ b/extension/parquet/writer/struct_column_writer.cpp
@@ -105,7 +105,7 @@ void StructColumnWriter::FinalizeWrite(ColumnWriterState &state_p) {
 	}
 }
 
-void StructColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) {
+idx_t StructColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) {
 	idx_t schema_idx = schemas.size();
 
 	auto &schema = column_schema;
@@ -129,9 +129,11 @@ void StructColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &s
 	}
 	schemas.push_back(std::move(schema_element));
 
+	idx_t unique_columns = 0;
 	for (auto &child_writer : child_writers) {
-		child_writer->FinalizeSchema(schemas);
+		unique_columns += child_writer->FinalizeSchema(schemas);
 	}
+	return unique_columns;
 }
 
 } // namespace duckdb

--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -810,7 +810,7 @@ static void ToParquetVariant(DataChunk &input, ExpressionState &state, Vector &r
 	}
 }
 
-void VariantColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) {
+idx_t VariantColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) {
 	idx_t schema_idx = schemas.size();
 
 	auto &schema = Schema();
@@ -832,9 +832,11 @@ void VariantColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &
 	top_element.name = name;
 	schemas.push_back(std::move(top_element));
 
+	idx_t unique_columns = 0;
 	for (auto &child_writer : child_writers) {
-		child_writer->FinalizeSchema(schemas);
+		unique_columns += child_writer->FinalizeSchema(schemas);
 	}
+	return unique_columns;
 }
 
 LogicalType VariantColumnWriter::TransformTypedValueRecursive(const LogicalType &type) {


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/7213

There needs to be an entry in the `column_orders` for every struct field as well, not just the root columns.