### PR TITLE
Fix group column binding order in TopNWindowElimination optimizer

### DIFF
--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -298,3 +298,23 @@ CREATE TABLE tab2(col0 INTEGER, col1 INTEGER, col2 INTEGER)
 
 statement ok
 SELECT ALL 37 + 24 * - 44 FROM tab2 GROUP BY col1, col0, col0 HAVING col1 * col1 + - COALESCE ( - 56, COUNT ( * ) * + col1 ) IN ( CAST ( NULL AS INTEGER ) + + 78 )
+
+# Test array function with multiple groups
+statement ok
+CREATE TABLE a (a_vec FLOAT[3], a_id INT)
+
+statement ok
+CREATE TABLE b (b_vec FLOAT[3], b_str VARCHAR)
+
+statement ok
+INSERT INTO a VALUES (ARRAY[1.0, 2.0, 3.0], 1), (ARRAY[4.0, 5.0, 6.0], 2)
+
+statement ok
+INSERT INTO b VALUES (ARRAY[4.0, 5.0, 6.0], 'b'), (ARRAY[1.0, 2.0, 3.0], 'a')
+
+query IIIII
+SELECT * FROM a, LATERAL (SELECT *, a_id AS id_dup FROM b ORDER BY array_distance(a.a_vec, b.b_vec) LIMIT 1) ORDER BY ALL
+----
+[1.0, 2.0, 3.0]	1	[1.0, 2.0, 3.0]	a	1
+[4.0, 5.0, 6.0]	2	[4.0, 5.0, 6.0]	b	2
+


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/7215

The TopNWindowElimination optimizer replaces combinations of `row_number` window functions and filters on the row number with aggregates and for that needs to recreate the column order that is expected by the filter's parent operator. 

This PR fixes a bug, in which the topmost projection that the optimizer creates already brings the window function partitions into the target order. In a post-processing step, the optimizer already re-orders the column bindings to the target order so that it would actually undo the ordering. Now, the bindings for the group columns are only re-ordered in the post-processing step as the projection operator is not created in all cases.