### PR TITLE
Add missing import of type_visitor.hpp

### DIFF
--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -23,6 +23,7 @@
 #include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/common/type_visitor.hpp"
 
 namespace duckdb {
 


### PR DESCRIPTION
Without this, debug builds of duckdb-python @ v1.5-variegata fail. `make debug` in core still succeeds, I think because the unity build hides the missing import. CLion also complains about not being able to resolve `TypeVisitor` on line 701.