### PR TITLE
Fix schema resolution for unqualified FOREIGN KEY references

### DIFF
--- a/src/parser/constraints/foreign_key_constraint.cpp
+++ b/src/parser/constraints/foreign_key_constraint.cpp
@@ -24,7 +24,7 @@ string ForeignKeyConstraint::ToString() const {
 			base += KeywordHelper::WriteOptionallyQuoted(fk_columns[i]);
 		}
 		base += ") REFERENCES ";
-		if (!info.schema.empty()) {
+		if (!info.schema.empty() && info.schema != DEFAULT_SCHEMA) {
 			base += info.schema;
 			base += ".";
 		}

--- a/src/parser/transform/constraint/transform_constraint.cpp
+++ b/src/parser/transform/constraint/transform_constraint.cpp
@@ -10,7 +10,9 @@ static void ParseSchemaTableNameFK(duckdb_libpgquery::PGRangeVar &input, Foreign
 	if (input.catalogname) {
 		throw ParserException("FOREIGN KEY constraints cannot be defined cross-database");
 	}
-	fk_info.schema = input.schemaname ? input.schemaname : "";
+	if (input.schemaname) {
+		fk_info.schema = input.schemaname;
+	}
 	fk_info.table = input.relname;
 }
 

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -562,6 +562,7 @@ static void BindCreateTableConstraints(CreateTableInfo &create_info, CatalogEntr
 		}
 
 		auto &pk_table_entry_ptr = table_entry->Cast<TableCatalogEntry>();
+		fk.info.schema = pk_table_entry_ptr.schema.name;
 		if (&pk_table_entry_ptr.schema != &schema) {
 			throw BinderException("Creating foreign keys across different schemas or catalogs is not supported");
 		}

--- a/test/sql/constraints/foreignkey/fk_20530.test
+++ b/test/sql/constraints/foreignkey/fk_20530.test
@@ -1,0 +1,56 @@
+# name: test/sql/constraints/foreignkey/fk_20530.test
+# description: Issue #20530: Unqualified foreign key schema resolution
+# group: [foreignkey]
+
+statement ok
+CREATE SCHEMA freddy;
+
+statement ok
+SET schema = freddy;
+
+statement ok
+CREATE TABLE zippy(
+    id INTEGER PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE george(
+    zippy_id INTEGER,
+    FOREIGN KEY (zippy_id) REFERENCES zippy(id)
+);
+
+statement ok
+INSERT INTO zippy VALUES (1);
+
+statement ok
+INSERT INTO george VALUES (1);
+
+query I
+SELECT constraint_text
+FROM duckdb_constraints()
+WHERE table_name = 'george'
+  AND constraint_type = 'FOREIGN KEY';
+----
+FOREIGN KEY (zippy_id) REFERENCES freddy.zippy(id)
+
+statement ok
+SET schema = main;
+
+statement ok
+CREATE TABLE zippy_main(
+    id INTEGER PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE george_main(
+    zippy_id INTEGER,
+    FOREIGN KEY (zippy_id) REFERENCES zippy_main(id)
+);
+
+query I
+SELECT constraint_text
+FROM duckdb_constraints()
+WHERE table_name = 'george_main'
+  AND constraint_type = 'FOREIGN KEY';
+----
+FOREIGN KEY (zippy_id) REFERENCES zippy_main(id)


### PR DESCRIPTION
### Summary

This PR fixes an issue where unqualified FOREIGN KEY references created in a non-default schema could lose the current schema context during binding.

Previously, constraints such as:

```sql
FOREIGN KEY (zippy_id) REFERENCES zippy(id)
```

when created with a non-default schema set as the current schema (e.g. via `SET schema`), could later fail at runtime with `table not found` errors on `INSERT`.

This change defers schema resolution to the bind phase and resolves the referenced table using the session's current schema/search path, consistent with SQL name resolution semantics.

### Tests

Added a regression test `test/sql/constraints/foreignkey/fk_20530.test` covering unqualified foreign key references in a non-default schema.

### Related Issue

Fixes #20530