### PR TITLE
Expose LIMIT and OFFSET in EXPLAIN output for LIMIT operators

### DIFF
--- a/src/execution/operator/helper/physical_limit.cpp
+++ b/src/execution/operator/helper/physical_limit.cpp
@@ -244,4 +244,20 @@ Value PhysicalLimit::GetDelimiter(ExecutionContext &context, DataChunk &input, c
 	return limit_value;
 }
 
+InsertionOrderPreservingMap<string> PhysicalLimit::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	if (limit_val.Type() == LimitNodeType::CONSTANT_VALUE) {
+		result["Limit"] = to_string(limit_val.GetConstantValue());
+	} else if (limit_val.Type() == LimitNodeType::CONSTANT_PERCENTAGE) {
+		result["Limit"] = to_string(limit_val.GetConstantPercentage()) + "%";
+	}
+	if (offset_val.Type() == LimitNodeType::CONSTANT_VALUE) {
+		auto offset = offset_val.GetConstantValue();
+		if (offset > 0) {
+			result["Offset"] = to_string(offset);
+		}
+	}
+	return result;
+}
+
 } // namespace duckdb

--- a/src/execution/operator/helper/physical_limit_percent.cpp
+++ b/src/execution/operator/helper/physical_limit_percent.cpp
@@ -164,4 +164,18 @@ SourceResultType PhysicalLimitPercent::GetDataInternal(ExecutionContext &context
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
+InsertionOrderPreservingMap<string> PhysicalLimitPercent::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	if (limit_val.Type() == LimitNodeType::CONSTANT_PERCENTAGE) {
+		result["Limit"] = to_string(limit_val.GetConstantPercentage()) + "%";
+	}
+	if (offset_val.Type() == LimitNodeType::CONSTANT_VALUE) {
+		auto offset = offset_val.GetConstantValue();
+		if (offset > 0) {
+			result["Offset"] = to_string(offset);
+		}
+	}
+	return result;
+}
+
 } // namespace duckdb

--- a/src/execution/operator/helper/physical_streaming_limit.cpp
+++ b/src/execution/operator/helper/physical_streaming_limit.cpp
@@ -65,4 +65,20 @@ bool PhysicalStreamingLimit::ParallelOperator() const {
 	return parallel;
 }
 
+InsertionOrderPreservingMap<string> PhysicalStreamingLimit::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	if (limit_val.Type() == LimitNodeType::CONSTANT_VALUE) {
+		result["Limit"] = to_string(limit_val.GetConstantValue());
+	} else if (limit_val.Type() == LimitNodeType::CONSTANT_PERCENTAGE) {
+		result["Limit"] = to_string(limit_val.GetConstantPercentage()) + "%";
+	}
+	if (offset_val.Type() == LimitNodeType::CONSTANT_VALUE) {
+		auto offset = offset_val.GetConstantValue();
+		if (offset > 0) {
+			result["Offset"] = to_string(offset);
+		}
+	}
+	return result;
+}
+
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/helper/physical_limit.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_limit.hpp
@@ -70,6 +70,8 @@ public:
 	                          const BoundLimitNode &offset_val);
 	static bool HandleOffset(DataChunk &input, idx_t &current_offset, idx_t offset, idx_t limit);
 	static Value GetDelimiter(ExecutionContext &context, DataChunk &input, const Expression &expr);
+
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/helper/physical_limit_percent.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_limit_percent.hpp
@@ -49,6 +49,8 @@ public:
 	bool IsSink() const override {
 		return true;
 	}
+
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/helper/physical_streaming_limit.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_streaming_limit.hpp
@@ -35,6 +35,8 @@ public:
 
 	OrderPreservationType OperatorOrder() const override;
 	bool ParallelOperator() const override;
+
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
 };
 
 } // namespace duckdb

--- a/test/sql/explain/test_explain_limit.test
+++ b/test/sql/explain/test_explain_limit.test
@@ -1,0 +1,24 @@
+# name: test/sql/explain/test_explain_limit.test
+# description: Test that LIMIT and OFFSET values are exposed in EXPLAIN output
+# group: [explain]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers AS SELECT * FROM range(100) tbl(i)
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM integers LIMIT 10
+----
+physical_plan	<REGEX>:.*"Limit":\s*"10".*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM integers LIMIT 10 OFFSET 5
+----
+physical_plan	<REGEX>:.*"Limit":\s*"10".*"Offset":\s*"5".*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM integers LIMIT 10%
+----
+physical_plan	<REGEX>:.*"Limit":\s*"10\.0+%".*


### PR DESCRIPTION
## Summary

This PR exposes `LIMIT` and `OFFSET` values in the `EXPLAIN` output for `LIMIT` operators by implementing `ParamsToString()`.

## Problem
Currently, `PhysicalLimit`, `PhysicalStreamingLimit`, and `PhysicalLimitPercent` do not expose their limit/offset values in EXPLAIN output in `JSON`.

## Solution
Add `ParamsToString()` override to the three LIMIT operators:
- `PhysicalLimit`: Exposes Limit/Offset
- `PhysicalStreamingLimit`: Exposes Limit/Offset
- `PhysicalLimitPercent`: Exposes Limit (percentage)/Offset

Handles `CONSTANT_VALUE` and `CONSTANT_PERCENTAGE` limit types. The offset is shown only when `> 0`.

## Example

```sql
EXPLAIN (FORMAT JSON) SELECT * FROM integers LIMIT 10 OFFSET 5;
```

Now includes:
```json
"extra_info": {
  "Limit": "10",
  "Offset": "5"
}
```