### PR TITLE
Pass down optional_ptr<ClientContext> into LazyMultiFileList, and if available use to check interrupts

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -2,4 +2,5 @@ duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG 64a109592051759ae1605162ed8771caecdd076e
+    APPLY_PATCHES
 )

--- a/.github/patches/extensions/httpfs/multi_file_list.patch
+++ b/.github/patches/extensions/httpfs/multi_file_list.patch
@@ -1,0 +1,13 @@
+diff --git a/src/s3fs.cpp b/src/s3fs.cpp
+index 0034c0e..833063d 100644
+--- a/src/s3fs.cpp
++++ b/src/s3fs.cpp
+@@ -1137,7 +1137,7 @@ private:
+ };
+ 
+ S3GlobResult::S3GlobResult(S3FileSystem &fs, const string &glob_pattern_p, optional_ptr<FileOpener> opener)
+-    : glob_pattern(glob_pattern_p), opener(opener) {
++    : LazyMultiFileList(FileOpener::TryGetClientContext(opener)), glob_pattern(glob_pattern_p), opener(opener) {
+ 	if (!opener) {
+ 		throw InternalException("Cannot S3 Glob without FileOpener");
+ 	}

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1528,7 +1528,7 @@ private:
 
 LocalGlobResult::LocalGlobResult(LocalFileSystem &fs, const string &path_p, FileGlobOptions options_p,
                                  optional_ptr<FileOpener> opener)
-    : fs(fs), path(path_p), opener(opener) {
+    : LazyMultiFileList(FileOpener::TryGetClientContext(opener)), fs(fs), path(path_p), opener(opener) {
 	if (path.empty()) {
 		finished = true;
 		return;

--- a/src/include/duckdb/common/multi_file/multi_file_list.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_list.hpp
@@ -164,7 +164,7 @@ protected:
 //! Lazily expanded MultiFileList
 class LazyMultiFileList : public MultiFileList {
 public:
-	LazyMultiFileList();
+	explicit LazyMultiFileList(optional_ptr<ClientContext> context);
 
 	vector<OpenFileInfo> GetAllFiles() const override;
 	FileExpandResult GetExpandResult() const override;
@@ -187,6 +187,7 @@ protected:
 	mutable vector<OpenFileInfo> expanded_files;
 	//! Whether or not all files have been expanded
 	mutable bool all_files_expanded = false;
+	optional_ptr<ClientContext> context;
 };
 
 //! MultiFileList that takes a list of globs and resolves all of the globs lazily into files

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1172,6 +1172,7 @@ void ClientContext::RunFunctionInTransactionInternal(ClientContextLock &lock, co
 	if (require_new_transaction) {
 		D_ASSERT(!active_query);
 		transaction.BeginTransaction();
+		interrupted = false;
 	}
 	try {
 		fun();


### PR DESCRIPTION
Now interrupting a query like `FROM glob('**')` mid-execution will not require the glob to complete the in-depth visit.