### PR TITLE
Run `TransformStringToLogicalType` in transaction

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -533,7 +533,7 @@ LogicalTypeId TransformStringToLogicalTypeId(const string &str) {
 }
 
 LogicalType TransformStringToLogicalType(const string &str, ClientContext &context) {
-	return TypeManager::Get(context).ParseLogicalType(str, context);
+	return context.ParseLogicalType(str);
 }
 
 bool LogicalType::IsIntegral() const {

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -533,7 +533,7 @@ LogicalTypeId TransformStringToLogicalTypeId(const string &str) {
 }
 
 LogicalType TransformStringToLogicalType(const string &str, ClientContext &context) {
-	return context.ParseLogicalType(str);
+	return TypeManager::Get(context).ParseLogicalType(str, context);
 }
 
 bool LogicalType::IsIntegral() const {

--- a/src/common/types/type_manager.cpp
+++ b/src/common/types/type_manager.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/main/client_context.hpp"
 
 namespace duckdb {
 
@@ -82,8 +83,10 @@ static LogicalType TransformStringToUnboundType(const string &str) {
 static LogicalType ParseLogicalTypeInternal(const string &type_str, ClientContext &context) {
 	auto type = TransformStringToUnboundType(type_str);
 	if (type.IsUnbound()) {
-		auto binder = Binder::CreateBinder(context, nullptr);
-		binder->BindLogicalType(type);
+		context.RunFunctionInTransaction([&] {
+			auto binder = Binder::CreateBinder(context, nullptr);
+			binder->BindLogicalType(type);
+		});
 	}
 	return type;
 }

--- a/src/common/types/type_manager.cpp
+++ b/src/common/types/type_manager.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
 
 namespace duckdb {
 

--- a/src/common/types/type_manager.cpp
+++ b/src/common/types/type_manager.cpp
@@ -102,6 +102,10 @@ TypeManager &TypeManager::Get(DatabaseInstance &db) {
 	return DBConfig::GetConfig(db).GetTypeManager();
 }
 
+TypeManager &TypeManager::Get(ClientContext &context) {
+	return DBConfig::GetConfig(context).GetTypeManager();
+}
+
 TypeManager::TypeManager(DBConfig &config_p) {
 	cast_functions = make_uniq<CastFunctionSet>(config_p);
 	parse_function = ParseLogicalTypeInternal;

--- a/src/include/duckdb/common/types/type_manager.hpp
+++ b/src/include/duckdb/common/types/type_manager.hpp
@@ -21,8 +21,8 @@ public:
 	//! Try to parse and bind a logical type from a string. Throws an exception if the type could not be parsed.
 	LogicalType ParseLogicalType(const string &type_str, ClientContext &context) const;
 
-	//! Get the TypeManager from the ClientContext
-	static TypeManager &Get(ClientContext &context);
+	//! Get the TypeManager from the DatabaseInstance
+	static TypeManager &Get(DatabaseInstance &db);
 
 private:
 	//! This has to be a function pointer to avoid the compiler inlining the implementation and

--- a/src/include/duckdb/common/types/type_manager.hpp
+++ b/src/include/duckdb/common/types/type_manager.hpp
@@ -24,6 +24,7 @@ public:
 
 	//! Get the TypeManager from the DatabaseInstance
 	static TypeManager &Get(DatabaseInstance &db);
+	static TypeManager &Get(ClientContext &context);
 
 private:
 	//! This has to be a function pointer to avoid the compiler inlining the implementation and

--- a/src/include/duckdb/common/types/type_manager.hpp
+++ b/src/include/duckdb/common/types/type_manager.hpp
@@ -6,6 +6,7 @@
 namespace duckdb {
 
 class ClientContext;
+class DatabaseInstance;
 class CastFunctionSet;
 struct DBConfig;
 

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -233,6 +233,8 @@ public:
 	//! Process an error for display to the user
 	DUCKDB_API void ProcessError(ErrorData &error, const string &query) const;
 
+	DUCKDB_API LogicalType ParseLogicalType(const string &type);
+
 private:
 	//! Parse statements and resolve pragmas from a query
 	vector<unique_ptr<SQLStatement>> ParseStatements(ClientContextLock &lock, const string &query);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1494,7 +1494,10 @@ bool ClientContext::ExecutionIsFinished() {
 
 LogicalType ClientContext::ParseLogicalType(const string &type) {
 	auto lock = LockContext();
-	RunFunctionInTransactionInternal(*lock, [&]() { return TypeManager::Get(*db).ParseLogicalType(type, *this); });
+	LogicalType logical_type;
+	RunFunctionInTransactionInternal(*lock,
+	                                 [&]() { logical_type = TypeManager::Get(*db).ParseLogicalType(type, *this); });
+	return logical_type;
 }
 
 } // namespace duckdb

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1492,4 +1492,9 @@ bool ClientContext::ExecutionIsFinished() {
 	return active_query->executor->ExecutionIsFinished();
 }
 
+LogicalType ClientContext::ParseLogicalType(const string &type) {
+	auto lock = LockContext();
+	RunFunctionInTransactionInternal(*lock, [&]() { return TypeManager::Get(*db).ParseLogicalType(type, *this); });
+}
+
 } // namespace duckdb


### PR DESCRIPTION
Because this function now does catalog lookups, it requires an active transaction and will throw an internal exception otherwise.

This is normally not a problem since this function is almost always called from within a query in duckdb, but it turns out it can also be called outside, for example in the python client when we convert user type annotations to logical types.

This PR fixes this by performing the binding in a new transaction if there is no current transaction, using the `ClientContext::RunFunctionInTransaction` function.

Closes https://github.com/duckdblabs/duckdb-internal/issues/7230