### PR TITLE
Split path in test correctly

### DIFF
--- a/test/sql/storage/read_duckdb/read_duckdb_virtual_columns.test
+++ b/test/sql/storage/read_duckdb/read_duckdb_virtual_columns.test
@@ -16,7 +16,7 @@ DETACH rd
 endloop
 
 query III
-SELECT rowid, (filename.replace('\', '/').split('/'))[3], * FROM read_duckdb('__TEST_DIR__/read_duckdb_virt[1-2].db') ORDER BY filename, rowid
+SELECT rowid, (filename.replace('\', '/').split('/')[-1]), * FROM read_duckdb('__TEST_DIR__/read_duckdb_virt[1-2].db') ORDER BY filename, rowid
 ----
 0	read_duckdb_virt1.db	42
 0	read_duckdb_virt2.db	42


### PR DESCRIPTION
I had funny failures on my machine for this sql logic test:

```
Expected result:
================================================================================
0       read_duckdb_virt1.db    42
0       read_duckdb_virt2.db    42
1       read_duckdb_virt2.db    43

================================================================================
Actual result:
================================================================================
0       philipp 42
0       philipp 42
1       philipp 43
```

If I understand correctly; the code selects the 3rd part of the file path .. which of course differs from machine to machine. To fix that we can extract the last part of the path instead.

I'm also not 100% sure about the parenthesis but this version works for me :)