### PR TITLE
Fix ASAN issue in `variant_extract` due to uninitialized values in the 'values' list

### DIFF
--- a/src/function/scalar/variant/variant_extract.cpp
+++ b/src/function/scalar/variant/variant_extract.cpp
@@ -172,7 +172,12 @@ void VariantUtils::VariantExtract(Vector &variant_vec, const vector<VariantPathC
 	ListVector::Reserve(result_values, values_list_size);
 	ListVector::SetListSize(result_values, values_list_size);
 	auto result_values_data = FlatVector::GetData<list_entry_t>(result_values);
+	auto &result_values_validity = FlatVector::Validity(result_values);
 	for (idx_t i = 0; i < count; i++) {
+		if (!validity.RowIsValid(i)) {
+			result_values_validity.SetInvalid(i);
+			continue;
+		}
 		result_values_data[i] = values_data[values.sel->get_index(i)];
 	}
 

--- a/test/sql/function/variant/variant_extract.test
+++ b/test/sql/function/variant/variant_extract.test
@@ -74,3 +74,14 @@ query I
 select ('{"a": 42, "b": [true, "test", true]}'::JSON::VARIANT)['b'][2];
 ----
 test
+
+query I
+SELECT [
+	x.a for x in [
+		{'a': 42, 'b': [1,2,3]}::VARIANT,
+		NULL,
+		84
+	]
+]
+----
+[42, NULL, NULL]


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/7217