### PR TITLE
expose dependencies

### DIFF
--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -86,6 +86,7 @@ public:
 	ClientContext &GetClientContext();
 
 	void AddDependency(shared_ptr<Pipeline> &pipeline);
+	vector<weak_ptr<Pipeline>> GetDependencies() const;
 
 	void Ready();
 	void Reset();

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -255,6 +255,10 @@ void Pipeline::AddDependency(shared_ptr<Pipeline> &pipeline) {
 	pipeline->parents.push_back(weak_ptr<Pipeline>(shared_from_this()));
 }
 
+vector<weak_ptr<Pipeline>> Pipeline::GetDependencies() const {
+	return dependencies;
+}
+
 string Pipeline::ToString() const {
 	TextTreeRenderer renderer;
 	return renderer.ToString(*this);


### PR DESCRIPTION
Adds a public method to access pipeline dependencies. Now, `dependencies` can be read externally, for instance, by an extension that needs to track/build depedencies.