### PR TITLE
UnalignedScan CI failure fix

### DIFF
--- a/src/include/duckdb/storage/segment/uncompressed.hpp
+++ b/src/include/duckdb/storage/segment/uncompressed.hpp
@@ -30,6 +30,13 @@ struct ValidityUncompressed {
 public:
 	static CompressionFunction GetFunction(PhysicalType data_type);
 	static void AlignedScan(data_ptr_t input, idx_t input_start, Vector &result, idx_t scan_count);
+
+	//! ANDs scan_count validity bits from input (starting at input_start) into the result validity mask
+	//! (starting at result_offset). If a bit in the result is already invalid (0), it remains invalid
+	//! regardless of the input bit value - i.e., the operation is result[i] &= input[i].
+	//! This function should be used, as the name suggests, if the starting points are unaligned relative to
+	//! ValidityMask::BITS_PER_VALUE, otherwise AlignedScan should be used (however this function will
+	//! still work).
 	static void UnalignedScan(data_ptr_t input, idx_t input_size, idx_t input_start, Vector &result,
 	                          idx_t result_offset, idx_t scan_count);
 

--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -224,10 +224,6 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 	auto input_data = reinterpret_cast<validity_t *>(input);
 
 #ifdef DEBUG
-	// this method relies on all the bits we are going to write to being set to valid
-	for (idx_t i = 0; i < scan_count; i++) {
-		D_ASSERT(result_mask.RowIsValid(result_offset + i));
-	}
 	// save boundary entries to verify we don't corrupt surrounding bits later.
 	idx_t debug_first_entry = result_offset / ValidityMask::BITS_PER_VALUE;
 	idx_t debug_last_entry = (result_offset + scan_count - 1) / ValidityMask::BITS_PER_VALUE;

--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -393,6 +393,12 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 #endif
 
 #ifdef DEBUG
+	// FIXME: Previously, this function had an assumption that all the bits in the result range we are copying
+	// to were all set to valid. with dict_fsst compression, this is no longer the case, so if we want to have
+	// a debug verification of the result here, we need to check that all the bits that were initially valid
+	// in the result range have the same value as the corresponding bit in the input, and if they are invalid
+	// they remain invalid.
+
 	// verify surrounding bits weren't modified
 	auto debug_final_result_data = (validity_t *)result_mask.GetData();
 	validity_t debug_final_first_entry =

--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -393,11 +393,6 @@ void ValidityUncompressed::UnalignedScan(data_ptr_t input, idx_t input_size, idx
 #endif
 
 #ifdef DEBUG
-	// verify that we actually accomplished the bitwise ops equivalent that we wanted to do
-	ValidityMask input_mask(input_data, input_size);
-	for (idx_t i = 0; i < scan_count; i++) {
-		D_ASSERT(result_mask.RowIsValid(result_offset + i) == input_mask.RowIsValid(input_start + i));
-	}
 	// verify surrounding bits weren't modified
 	auto debug_final_result_data = (validity_t *)result_mask.GetData();
 	validity_t debug_final_first_entry =


### PR DESCRIPTION
There are some CI failures happening due to an assertion failure in ValidityUncompressed::UnalignedScan, after talking to @Tishj  he said the assert in question no longer holds due to dict_fsst compression, and we may remove this assert. 

