### PR TITLE
Skip aggregate state type test in PEG strict mode (CI fix)

### DIFF
--- a/test/configs/peg_parser_strict.json
+++ b/test/configs/peg_parser_strict.json
@@ -194,6 +194,12 @@
       ]
     },
     {
+      "reason": "PEG Transformer does not support EXPORT_STATE yet",
+      "paths": [
+        "test/sql/aggregate/aggregates/test_aggregate_state_type.test"
+      ]
+    },
+    {
       "reason": "Unclassified failures",
       "paths": [
         "test/extension/install_extension.test",


### PR DESCRIPTION
The `test_aggregate_state_type.test` is currently failing in the "Test PEG Parser + transformer in strict mode" CI configuration

### Root cause
This test uses EXPORT_STATE with aggregate functions in INSERT statements:
```sql
INSERT INTO t1_DOUBLE SELECT avg((range::DOUBLE + 10.0)::DOUBLE) EXPORT_STATE FROM range(10);
```
which fails due to a [recent change](https://github.com/duckdb/duckdb/pull/20586) that makes `INSERT` statement supported in the PEG transformer, that I didn't sync into the PR that introduced the test before it was merged (keeping forks synced is important 🤭)

This is a temporary solution to release CI blockage