### PR TITLE
Optimize DELETE by scanning indexed columns at bind time

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -408,6 +408,13 @@ private:
 	void BindDeleteReturningColumns(TableCatalogEntry &table, LogicalGet &get, vector<idx_t> &return_columns,
 	                                vector<unique_ptr<Expression>> &projection_expressions,
 	                                LogicalOperator &target_binding);
+	//! Build a sparse mapping for unique index columns only (for DELETE without RETURNING)
+	//! return_columns[storage_idx] = scan_chunk_idx (only for indexed columns)
+	void BindDeleteIndexColumns(TableCatalogEntry &table, LogicalGet &get, vector<idx_t> &return_columns);
+	//! Overload for MERGE INTO: builds projection expressions and maps storage_idx -> projection_expr_idx
+	void BindDeleteIndexColumns(TableCatalogEntry &table, LogicalGet &get, vector<idx_t> &return_columns,
+	                            vector<unique_ptr<Expression>> &projection_expressions,
+	                            LogicalOperator &target_binding);
 	BoundStatement BindReturning(vector<unique_ptr<ParsedExpression>> returning_list, TableCatalogEntry &table,
 	                             const string &alias, idx_t update_table_index,
 	                             unique_ptr<LogicalOperator> child_operator,

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -71,8 +71,8 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 	if (!stmt.returning_list.empty()) {
 		// Add all physical columns for RETURNING
 		BindDeleteReturningColumns(table, get, del->return_columns);
-	} else {
-		// Check if table has unique indexes - if so, add indexed columns to scan
+	} else if (table.IsDuckTable()) {
+		// Only optimize for DuckDB tables (not attached external tables like SQLite)
 		auto &storage = table.GetStorage();
 		if (storage.HasUniqueIndexes()) {
 			BindDeleteIndexColumns(table, get, del->return_columns);

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/storage/data_table.hpp"
 
 namespace duckdb {
 

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -368,28 +368,37 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 		projection_expressions.push_back(std::move(marker_ref));
 	}
 
-	// If RETURNING is present and we have a DELETE action, add all physical columns to the scan
-	// so we can pass them through instead of fetching by row ID in PhysicalDelete.
-	// Generated columns will be computed in the RETURNING projection by the binder.
-	if (!stmt.returning_list.empty()) {
-		bool has_delete_action = false;
-		for (auto &entry : merge_into->actions) {
-			for (auto &action : entry.second) {
-				if (action->action_type == MergeActionType::MERGE_DELETE) {
-					has_delete_action = true;
-					break;
-				}
-			}
-			if (has_delete_action) {
+	// Check if we have a DELETE action
+	bool has_delete_action = false;
+	for (auto &entry : merge_into->actions) {
+		for (auto &action : entry.second) {
+			if (action->action_type == MergeActionType::MERGE_DELETE) {
+				has_delete_action = true;
 				break;
 			}
 		}
-
 		if (has_delete_action) {
+			break;
+		}
+	}
+
+	// If RETURNING is present and we have a DELETE action, add all physical columns to the scan
+	// so we can pass them through instead of fetching by row ID in PhysicalDelete.
+	// Generated columns will be computed in the RETURNING projection by the binder.
+	if (has_delete_action) {
+		if (!stmt.returning_list.empty()) {
 			// Use the overloaded helper to add physical columns to the scan and build projection expressions
 			auto &target_binding = join_ref.get().children[inverted ? 0 : 1];
 			BindDeleteReturningColumns(table, get, merge_into->delete_return_columns, projection_expressions,
 			                           *target_binding);
+		} else {
+			// If no RETURNING, but unique indexes exist, add indexed columns to the scan
+			auto &storage = table.GetStorage();
+			if (storage.HasUniqueIndexes()) {
+				auto &target_binding = join_ref.get().children[inverted ? 0 : 1];
+				BindDeleteIndexColumns(table, get, merge_into->delete_return_columns, projection_expressions,
+				                       *target_binding);
+			}
 		}
 	}
 

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -391,8 +391,8 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 			auto &target_binding = join_ref.get().children[inverted ? 0 : 1];
 			BindDeleteReturningColumns(table, get, merge_into->delete_return_columns, projection_expressions,
 			                           *target_binding);
-		} else {
-			// If no RETURNING, but unique indexes exist, add indexed columns to the scan
+		} else if (table.IsDuckTable()) {
+			// Only optimize for DuckDB tables (not attached external tables like SQLite)
 			auto &storage = table.GetStorage();
 			if (storage.HasUniqueIndexes()) {
 				auto &target_binding = join_ref.get().children[inverted ? 0 : 1];

--- a/test/sql/delete/test_delete_indexed.test
+++ b/test/sql/delete/test_delete_indexed.test
@@ -159,3 +159,141 @@ SELECT * FROM t WHERE j >= 20 ORDER BY j;
 ----
 2	new_20	20
 3	new_30	30
+
+# -----------------------------------------------------------------------------
+# MERGE INTO DELETE with indexed table
+# -----------------------------------------------------------------------------
+
+# reset table
+statement ok
+DELETE FROM t;
+
+statement ok
+INSERT INTO t VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30);
+
+# create source table for merge
+statement ok
+CREATE TABLE source (id INT, s TEXT, j BIGINT);
+
+statement ok
+INSERT INTO source VALUES (2, 'x', 200), (3, 'y', 300);
+
+# MERGE INTO DELETE using primary key
+statement ok
+MERGE INTO t USING source ON t.id = source.id
+WHEN MATCHED THEN DELETE;
+
+query III
+SELECT * FROM t ORDER BY id;
+----
+1	a	10
+
+# verify we can insert rows with the deleted primary keys
+statement ok
+INSERT INTO t VALUES (2, 'new_b', 25), (3, 'new_c', 35);
+
+query III
+SELECT * FROM t ORDER BY id;
+----
+1	a	10
+2	new_b	25
+3	new_c	35
+
+# verify index lookup works
+query III
+SELECT * FROM t WHERE j = 25;
+----
+2	new_b	25
+
+# -----------------------------------------------------------------------------
+# MERGE INTO DELETE and INSERT in same transaction with overlapping values
+# -----------------------------------------------------------------------------
+
+statement ok
+DELETE FROM t;
+
+statement ok
+INSERT INTO t VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30);
+
+statement ok
+DELETE FROM source;
+
+statement ok
+INSERT INTO source VALUES (2, 'x', 200), (3, 'y', 300);
+
+statement ok
+BEGIN TRANSACTION;
+
+# MERGE INTO DELETE rows with id=2,3
+statement ok
+MERGE INTO t USING source ON t.id = source.id
+WHEN MATCHED THEN DELETE;
+
+# insert new rows with same ids
+statement ok
+INSERT INTO t VALUES (2, 'merge_20', 20), (3, 'merge_30', 30);
+
+# verify index lookup during transaction
+query III
+SELECT * FROM t WHERE j = 20;
+----
+2	merge_20	20
+
+query III
+SELECT * FROM t WHERE j = 30;
+----
+3	merge_30	30
+
+statement ok
+COMMIT;
+
+# verify index lookups after commit
+query III
+SELECT * FROM t WHERE j = 20;
+----
+2	merge_20	20
+
+query III
+SELECT * FROM t WHERE j = 30;
+----
+3	merge_30	30
+
+# -----------------------------------------------------------------------------
+# MERGE INTO DELETE with rollback
+# -----------------------------------------------------------------------------
+
+statement ok
+BEGIN TRANSACTION;
+
+# MERGE INTO DELETE rows
+statement ok
+MERGE INTO t USING source ON t.id = source.id
+WHEN MATCHED THEN DELETE;
+
+# insert rows with same ids
+statement ok
+INSERT INTO t VALUES (2, 'tmp_20', 20), (3, 'tmp_30', 30);
+
+# verify during transaction
+query III
+SELECT * FROM t WHERE j = 20;
+----
+2	tmp_20	20
+
+statement ok
+ROLLBACK;
+
+# verify index lookups after rollback - should see original values
+query III
+SELECT * FROM t WHERE j = 20;
+----
+2	merge_20	20
+
+query III
+SELECT * FROM t WHERE j = 30;
+----
+3	merge_30	30
+
+# cleanup
+statement ok
+DROP TABLE source;

--- a/test/sql/returning/returning_delete.test
+++ b/test/sql/returning/returning_delete.test
@@ -551,3 +551,93 @@ DROP TABLE merge_rowid_target;
 
 statement ok
 DROP TABLE merge_rowid_source;
+
+# ============================================================
+# DELETE RETURNING with indexed table - verify index is updated
+# ============================================================
+
+statement ok
+CREATE TABLE indexed_returning (id INT PRIMARY KEY, val VARCHAR, amount INT);
+
+statement ok
+CREATE INDEX idx_amount ON indexed_returning(amount);
+
+statement ok
+INSERT INTO indexed_returning VALUES (1, 'a', 100), (2, 'b', 200), (3, 'c', 300);
+
+# DELETE with RETURNING should update the index
+query I
+DELETE FROM indexed_returning WHERE amount >= 200 RETURNING val;
+----
+b
+c
+
+# Verify only row 1 remains
+query III
+SELECT * FROM indexed_returning ORDER BY id;
+----
+1	a	100
+
+# Verify index lookup works
+query III
+SELECT * FROM indexed_returning WHERE amount = 100;
+----
+1	a	100
+
+# Verify deleted keys are no longer in index
+query I
+SELECT COUNT(*) FROM indexed_returning WHERE amount = 200;
+----
+0
+
+# Insert new rows with previously deleted primary keys
+statement ok
+INSERT INTO indexed_returning VALUES (2, 'new_b', 250), (3, 'new_c', 350);
+
+# Verify index lookup for new values
+query III
+SELECT * FROM indexed_returning WHERE amount = 250;
+----
+2	new_b	250
+
+query III
+SELECT * FROM indexed_returning WHERE amount = 350;
+----
+3	new_c	350
+
+# DELETE RETURNING with primary key index in same transaction
+statement ok
+BEGIN TRANSACTION;
+
+query III
+DELETE FROM indexed_returning WHERE id = 2 RETURNING *;
+----
+2	new_b	250
+
+# Can insert with same primary key within transaction
+statement ok
+INSERT INTO indexed_returning VALUES (2, 'tx_b', 225);
+
+# Verify index lookup during transaction
+query III
+SELECT * FROM indexed_returning WHERE amount = 225;
+----
+2	tx_b	225
+
+statement ok
+COMMIT;
+
+# Verify after commit
+query III
+SELECT * FROM indexed_returning WHERE amount = 225;
+----
+2	tx_b	225
+
+# Verify primary key lookup
+query III
+SELECT * FROM indexed_returning WHERE id = 2;
+----
+2	tx_b	225
+
+statement ok
+DROP TABLE indexed_returning;


### PR DESCRIPTION
This PR eliminates the fallback path in PhysicalDelete that fetched columns by row ID when unique indexes exist but no RETURNING clause is present.

Changes:
- Add BindDeleteIndexColumns helper to scan indexed columns at bind time
- Add MERGE INTO overload that builds projection expressions
- Extract common ConvertScanToProjectionMapping helper to reduce duplication
- Remove fallback fetch-by-row-ID path in physical_delete.cpp
- Add tests for DELETE and MERGE INTO DELETE with indexed tables

The optimization passes indexed columns through from the scan, avoiding the need to fetch them separately during DELETE execution.