### PR TITLE
Secret Manager: Ensure secrets are created exactly once

### DIFF
--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -564,12 +564,17 @@ optional_ptr<CatalogEntry> CatalogSet::CreateDefaultEntry(CatalogTransaction tra
 		// no defaults either: return null
 		return nullptr;
 	}
-	read_lock.unlock();
+	auto unlock = !defaults->LockDuringCreate();
+	if (unlock) {
+		read_lock.unlock();
+	}
 	// this catalog set has a default map defined
 	// check if there is a default entry that we can create with this name
 	auto entry = defaults->CreateDefaultEntry(transaction, name);
 
-	read_lock.lock();
+	if (unlock) {
+		read_lock.lock();
+	}
 	if (!entry) {
 		// no default entry
 		return nullptr;
@@ -582,7 +587,9 @@ optional_ptr<CatalogEntry> CatalogSet::CreateDefaultEntry(CatalogTransaction tra
 	// we found a default entry, but failed
 	// this means somebody else created the entry first
 	// just retry?
-	read_lock.unlock();
+	if (unlock) {
+		read_lock.unlock();
+	}
 	return GetEntry(transaction, name);
 }
 
@@ -653,6 +660,7 @@ void CatalogSet::CreateDefaultEntries(CatalogTransaction transaction, unique_loc
 	if (!defaults || defaults->created_all_entries) {
 		return;
 	}
+	auto unlock = !defaults->LockDuringCreate();
 	// this catalog set has a default set defined:
 	auto default_entries = defaults->GetDefaultEntries();
 	for (auto &default_entry : default_entries) {
@@ -660,13 +668,17 @@ void CatalogSet::CreateDefaultEntries(CatalogTransaction transaction, unique_loc
 		if (!entry_value) {
 			// we unlock during the CreateEntry, since it might reference other catalog sets...
 			// specifically for views this can happen since the view will be bound
-			read_lock.unlock();
+			if (unlock) {
+				read_lock.unlock();
+			}
 			auto entry = defaults->CreateDefaultEntry(transaction, default_entry);
 			if (!entry) {
 				throw InternalException("Failed to create default entry for %s", default_entry);
 			}
 
-			read_lock.lock();
+			if (unlock) {
+				read_lock.lock();
+			}
 			CreateCommittedEntry(std::move(entry));
 		}
 	}

--- a/src/include/duckdb/catalog/default/default_generator.hpp
+++ b/src/include/duckdb/catalog/default/default_generator.hpp
@@ -28,6 +28,12 @@ public:
 	virtual unique_ptr<CatalogEntry> CreateDefaultEntry(CatalogTransaction transaction, const string &entry_name);
 	//! Get a list of all default entries in the generator
 	virtual vector<string> GetDefaultEntries() = 0;
+	//! Whether or not we should keep the lock while calling CreateDefaultEntry
+	//! If this is set to false, CreateDefaultEntry might be called multiple times in parallel also for the same entry
+	//! Otherwise it will be called exactly once per entry
+	virtual bool LockDuringCreate() const {
+		return false;
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -217,6 +217,9 @@ public:
 	unique_ptr<CatalogEntry> CreateDefaultEntry(CatalogTransaction transaction, const string &entry_name) override;
 	unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name) override;
 	vector<string> GetDefaultEntries() override;
+	bool LockDuringCreate() const override {
+		return true;
+	}
 
 protected:
 	unique_ptr<CatalogEntry> CreateDefaultEntryInternal(const string &entry_name);


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-httpfs/issues/169

Currently we read a persistent secret once in `DefaultSecretGenerator::CreateDefaultEntryInternal`, and short-circuit on subsequent attempts to read a persistent secret. This goes subtly wrong when immediately launching multiple threads that need these secrets in parallel. Returning `nullptr` from `CreateDefaultEntry` results in an `InternalException` - `Failed to create default entry` - so this can result in that exception being thrown.

This PR adds the option for default generators to keep the catalog set lock while the entry is being created - ensuring the entry is created exactly once. This option is enabled only for secrets. Other catalog types handle this situation by just creating the default entry twice - which is generally cheap - and then discarding the duplicate entry at a later step in the process.