### PR TITLE
Fix compiler warnings on `main`

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -38,11 +38,11 @@ JoinHashTable::InsertState::InsertState(const JoinHashTable &ht)
 JoinHashTable::JoinHashTable(ClientContext &context_p, const PhysicalOperator &op_p,
                              const vector<JoinCondition> &conditions_p, vector<LogicalType> btypes, JoinType type_p,
                              const vector<idx_t> &output_columns_p, unique_ptr<ResidualPredicateInfo> residual_p,
-                             Expression *predicate_ptr, const vector<idx_t> &output_in_probe)
+                             optional_ptr<Expression> predicate_ptr, const vector<idx_t> &output_in_probe)
     : context(context_p), op(op_p), buffer_manager(BufferManager::GetBufferManager(context)), conditions(conditions_p),
       build_types(std::move(btypes)), output_columns(output_columns_p), entry_size(0), tuple_size(0),
       vfound(Value::BOOLEAN(false)), join_type(type_p), finalized(false), has_null(false),
-      radix_bits(INITIAL_RADIX_BITS), residual_predicate(predicate_ptr) {
+      residual_predicate(predicate_ptr), radix_bits(INITIAL_RADIX_BITS) {
 	// store residual predicate information
 	residual_info = std::move(residual_p);
 	lhs_output_in_probe = output_in_probe;

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -194,7 +194,7 @@ public:
 
 	JoinHashTable(ClientContext &context, const PhysicalOperator &op, const vector<JoinCondition> &conditions,
 	              vector<LogicalType> build_types, JoinType type, const vector<idx_t> &output_columns,
-	              unique_ptr<ResidualPredicateInfo> residual_p, Expression *predicate_ptr = nullptr,
+	              unique_ptr<ResidualPredicateInfo> residual_p, optional_ptr<Expression> predicate_ptr = nullptr,
 	              const vector<idx_t> &output_in_probe = {});
 	~JoinHashTable();
 
@@ -307,7 +307,7 @@ public:
 	//! Number of probe matches
 	atomic<idx_t> total_probe_matches {0};
 	//! Residual predicate to evaluate during probing
-	Expression *residual_predicate;
+	optional_ptr<Expression> residual_predicate;
 	//! Residual predicate mapping info
 	unique_ptr<ResidualPredicateInfo> residual_info;
 	//! Mapping from lhs_output_columns positions to lhs_probe_data positions

--- a/src/optimizer/deliminator.cpp
+++ b/src/optimizer/deliminator.cpp
@@ -383,8 +383,8 @@ bool Deliminator::RemoveInequalityJoinWithDelimGet(LogicalComparisonJoin &delim_
 						final_comparison = ExpressionType::COMPARE_EQUAL;
 					}
 					delim_conditions[cond_idx] =
-					    JoinCondition(std::move(delim_conditions[cond_idx].LeftReference()->Copy()),
-					                  std::move(delim_conditions[cond_idx].RightReference()->Copy()), final_comparison);
+					    JoinCondition(delim_conditions[cond_idx].LeftReference()->Copy(),
+					                  delim_conditions[cond_idx].RightReference()->Copy(), final_comparison);
 				}
 				found = true;
 				break;

--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -562,7 +562,7 @@ bool RelationManager::ExtractBindings(Expression &expression, unordered_set<idx_
 }
 
 //! Flatten a predicate into individual conjuncts
-static void FlattenConjunction(Expression &expr, vector<unique_ptr<Expression>> &result) {
+static inline void FlattenConjunction(Expression &expr, vector<unique_ptr<Expression>> &result) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
 		auto &conj = expr.Cast<BoundConjunctionExpression>();
 		if (conj.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -694,7 +694,7 @@ TEST_CASE("Test concurrent prepared statement execution race condition MRE", "[c
 
 	duckdb::vector<std::thread> threads;
 	for (idx_t t = 0; t < NUM_THREADS; t++) {
-		threads.emplace_back([ITERATIONS, &conn, &failures, &completed]() {
+		threads.emplace_back([&]() {
 			for (idx_t i = 0; i < ITERATIONS; i++) {
 				duckdb_prepared_statement stmt = nullptr;
 				if (duckdb_prepare(conn, "SELECT 1", &stmt) != DuckDBSuccess) {


### PR DESCRIPTION
We just merged v1.5 into main again but also merged one or more PRs that created new warnings so the `Linux Debug` run broke. This PR should (hopefully) fix CI again.