### PR TITLE
PEGTransformerFactory::TransformMergeIntoStatement: Fixup via unique_ptr_cast

### DIFF
--- a/extension/autocomplete/transformer/transform_merge_into.cpp
+++ b/extension/autocomplete/transformer/transform_merge_into.cpp
@@ -42,7 +42,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformMergeIntoStatement(PEGT
 		result->actions[entry.first].push_back(std::move(entry.second));
 	}
 	transformer.TransformOptional<vector<unique_ptr<ParsedExpression>>>(list_pr, 7, result->returning_list);
-	return result;
+	return unique_ptr_cast<MergeIntoStatement, SQLStatement>(std::move(result));
 }
 
 unique_ptr<TableRef> PEGTransformerFactory::TransformMergeIntoUsingClause(PEGTransformer &transformer,


### PR DESCRIPTION
This should restore, or at least move forward, `Bundle Static Libraries` CI job.

I think it might be a good idea to include `autocomplete` also in other CI jobs, so this is caught earlier.

Issue would be like:
```
/home/runner/work/duckdb/duckdb/extension/autocomplete/transformer/transform_merge_into.cpp: In static member function ‘static duckdb::unique_ptr<duckdb::SQLStatement> duckdb::PEGTransformerFactory::TransformMergeIntoStatement(duckdb::PEGTransformer&, duckdb::optional_ptr<duckdb::ParseResult>)’:
/home/runner/work/duckdb/duckdb/extension/autocomplete/transformer/transform_merge_into.cpp:45:16: error: could not convert ‘result’ from ‘unique_ptr<duckdb::MergeIntoStatement>’ to ‘unique_ptr<duckdb::SQLStatement>’
   45 |         return result;
      |                ^~~~~~
      |                |
      |                unique_ptr<duckdb::MergeIntoStatement>
```