### PR TITLE
Initialize `set_scan_order` in all TableFunction constructors

### DIFF
--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -39,8 +39,8 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
       pushdown_expression(nullptr), to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr),
       get_partition_data(nullptr), get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr),
       supports_pushdown_type(nullptr), supports_pushdown_extract(nullptr), get_partition_info(nullptr),
-      get_partition_stats(nullptr), get_virtual_columns(nullptr), get_row_id_columns(nullptr), serialize(nullptr),
-      deserialize(nullptr), projection_pushdown(false), filter_pushdown(false), filter_prune(false),
+      get_partition_stats(nullptr), get_virtual_columns(nullptr), get_row_id_columns(nullptr), set_scan_order(nullptr),
+      serialize(nullptr), deserialize(nullptr), projection_pushdown(false), filter_pushdown(false), filter_prune(false),
       sampling_pushdown(false), late_materialization(false) {
 }
 


### PR DESCRIPTION
This constructor was missing the initialization, leading to garbage data where a function pointer should be.

For me, that crashed in `RowGroupPruner::TryOptimize`, which calls `logical_get->function.set_scan_order`.