### PR TITLE
Add back `UnregisterSubSystem` and make `ExtractSubSystem` work with `OpenerFileSystem`

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -636,6 +636,10 @@ void FileSystem::RegisterSubSystem(FileCompressionType compression_type, unique_
 	throw NotImplementedException("%s: Can't register a sub system on a non-virtual file system", GetName());
 }
 
+void FileSystem::UnregisterSubSystem(const string &name) {
+	throw NotImplementedException("%s: Can't unregister a sub system on a non-virtual file system", GetName());
+}
+
 unique_ptr<FileSystem> FileSystem::ExtractSubSystem(const string &name) {
 	throw NotImplementedException("%s: Can't extract a sub system on a non-virtual file system", GetName());
 }

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -284,6 +284,13 @@ void VirtualFileSystem::RegisterSubSystem(FileCompressionType compression_type, 
 	file_system_registry.atomic_store(new_registry);
 }
 
+void VirtualFileSystem::UnregisterSubSystem(const string &name) {
+	auto sub_system = ExtractSubSystem(name);
+
+	lock_guard<mutex> guard(registry_lock);
+	unregistered_file_systems.push_back(std::move(sub_system));
+}
+
 void VirtualFileSystem::SetDisabledFileSystems(const vector<string> &names) {
 	lock_guard<mutex> guard(registry_lock);
 	auto new_registry = file_system_registry->SetDisabledFileSystems(names);

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -263,6 +263,9 @@ public:
 	DUCKDB_API virtual void RegisterSubSystem(unique_ptr<FileSystem> sub_fs);
 	DUCKDB_API virtual void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs);
 
+	//! Unregister a sub-filesystem by name
+	DUCKDB_API virtual void UnregisterSubSystem(const string &name);
+
 	// !Extract a sub-filesystem by name, with ownership transfered, return nullptr if not registered or the subsystem
 	// has been disabled.
 	DUCKDB_API virtual unique_ptr<FileSystem> ExtractSubSystem(const string &name);

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -170,7 +170,7 @@ public:
 		GetFileSystem().UnregisterSubSystem(name);
 	}
 
-	unique_ptr<FileSystem> ExtractSubSystem(const string &name) {
+	unique_ptr<FileSystem> ExtractSubSystem(const string &name) override {
 		GetFileSystem().ExtractSubSystem(name);
 	}
 

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -171,7 +171,7 @@ public:
 	}
 
 	unique_ptr<FileSystem> ExtractSubSystem(const string &name) override {
-		GetFileSystem().ExtractSubSystem(name);
+		return GetFileSystem().ExtractSubSystem(name);
 	}
 
 	void SetDisabledFileSystems(const vector<string> &names) override {

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -170,6 +170,10 @@ public:
 		GetFileSystem().UnregisterSubSystem(name);
 	}
 
+	unique_ptr<FileSystem> ExtractSubSystem(const string &name) {
+		GetFileSystem().ExtractSubSystem(name);
+	}
+
 	void SetDisabledFileSystems(const vector<string> &names) override {
 		GetFileSystem().SetDisabledFileSystems(names);
 	}

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -166,6 +166,10 @@ public:
 		GetFileSystem().RegisterSubSystem(compression_type, std::move(fs));
 	}
 
+	void UnregisterSubSystem(const string &name) override {
+		GetFileSystem().UnregisterSubSystem(name);
+	}
+
 	void SetDisabledFileSystems(const vector<string> &names) override {
 		GetFileSystem().SetDisabledFileSystems(names);
 	}

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -55,7 +55,7 @@ public:
 
 	void RegisterSubSystem(unique_ptr<FileSystem> fs) override;
 	void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override;
-
+	void UnregisterSubSystem(const string &name) override;
 	unique_ptr<FileSystem> ExtractSubSystem(const string &name) override;
 
 	vector<string> ListSubSystems() override;
@@ -97,6 +97,7 @@ private:
 private:
 	mutex registry_lock;
 	shared_ptr<FileSystemRegistry> file_system_registry;
+	vector<unique_ptr<FileSystem>> unregistered_file_systems;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/caching_file_system_wrapper.hpp
+++ b/src/include/duckdb/storage/caching_file_system_wrapper.hpp
@@ -101,6 +101,7 @@ public:
 
 	DUCKDB_API void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override;
 	DUCKDB_API void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override;
+	DUCKDB_API void UnregisterSubSystem(const string &name) override;
 	DUCKDB_API unique_ptr<FileSystem> ExtractSubSystem(const string &name) override;
 	DUCKDB_API vector<string> ListSubSystems() override;
 	DUCKDB_API bool CanHandleFile(const string &fpath) override;

--- a/src/storage/caching_file_system_wrapper.cpp
+++ b/src/storage/caching_file_system_wrapper.cpp
@@ -312,6 +312,10 @@ void CachingFileSystemWrapper::RegisterSubSystem(FileCompressionType compression
 	underlying_file_system.RegisterSubSystem(compression_type, std::move(fs));
 }
 
+void CachingFileSystemWrapper::UnregisterSubSystem(const string &name) {
+	underlying_file_system.UnregisterSubSystem(name);
+}
+
 unique_ptr<FileSystem> CachingFileSystemWrapper::ExtractSubSystem(const string &name) {
 	return underlying_file_system.ExtractSubSystem(name);
 }


### PR DESCRIPTION
This PR adds back the `UnregisterSubSystem ` method removed in https://github.com/duckdb/duckdb/pull/20547. This is made thread-safe by **only** unregistering, i.e. the file system is not actually deleted. The file system is kept around as we don't have any guarantees at this point about existing files still being open that use that file system. As such it only prevents new files from using the file system.

CC @evertlammerts 