### PR TITLE
Make `ORDER BY [column_name]` work if we have a single qualified column with that name in the projection list

### DIFF
--- a/extension/tpcds/dsdgen/queries/58.sql
+++ b/extension/tpcds/dsdgen/queries/58.sql
@@ -65,7 +65,7 @@ WHERE ss_items.item_id=cs_items.item_id
   AND cs_item_rev BETWEEN 0.9 * ws_item_rev AND 1.1 * ws_item_rev
   AND ws_item_rev BETWEEN 0.9 * ss_item_rev AND 1.1 * ss_item_rev
   AND ws_item_rev BETWEEN 0.9 * cs_item_rev AND 1.1 * cs_item_rev
-ORDER BY ss_items.item_id NULLS FIRST,
+ORDER BY item_id NULLS FIRST,
          ss_item_rev NULLS FIRST
 LIMIT 100;
 

--- a/test/sql/binder/column_ref_as_alias.test
+++ b/test/sql/binder/column_ref_as_alias.test
@@ -1,0 +1,34 @@
+# name: test/sql/binder/column_ref_as_alias.test
+# description: Test alias.name resolution in HAVING clause
+# group: [binder]
+
+statement ok
+create table ss_items as select 1 item_id, 10 ss_item_rev;
+
+statement ok
+create table cs_items as select 1 item_id, 100 cs_item_rev;
+
+query I
+select ss_items.item_id
+from ss_items,cs_items
+where ss_items.item_id = cs_items.item_id
+order by item_id;
+----
+1
+
+statement error
+select ss_items.item_id, cs_items.item_id
+from ss_items,cs_items
+where ss_items.item_id = cs_items.item_id
+order by item_id;
+----
+ss_items.item_id
+
+statement error
+select ss_items.item_id
+from ss_items,cs_items
+where ss_items.item_id = cs_items.item_id
+group by item_id;
+----
+ss_items.item_id
+


### PR DESCRIPTION
Currently this throws an ambiguity exception:


```sql
create table ss_items as select 1 item_id, 10 ss_item_rev;
create table cs_items as select 1 item_id, 100 cs_item_rev;

select ss_items.item_id
from ss_items,cs_items
where ss_items.item_id = cs_items.item_id
order by item_id;

-- Ambiguous reference to column name "item_id" (use: "ss_items.item_id" or "cs_items.item_id")
```

The reason it's not actually ambiguous is because the `ORDER BY` list should prefer elements in the select list, and we only have a single column named `item_id` in the select list (`ss_items.item_id`). This same query works in Postgres.

This PR makes this query work by expanding the OrderBinder to also look for a single qualified columns with the same name as the `ORDER BY` element.