### PR TITLE
PEGTransformerFactory::TransformMergeIntoStatement: Fixup via move

### DIFF
--- a/extension/autocomplete/transformer/transform_merge_into.cpp
+++ b/extension/autocomplete/transformer/transform_merge_into.cpp
@@ -42,7 +42,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformMergeIntoStatement(PEGT
 		result->actions[entry.first].push_back(std::move(entry.second));
 	}
 	transformer.TransformOptional<vector<unique_ptr<ParsedExpression>>>(list_pr, 7, result->returning_list);
-	return result;
+	return std::move(result);
 }
 
 unique_ptr<TableRef> PEGTransformerFactory::TransformMergeIntoUsingClause(PEGTransformer &transformer,


### PR DESCRIPTION
Alternative to https://github.com/duckdb/duckdb/pull/20690, restoring `Bundle Static Libraries` CI job.