### PR TITLE
Fixup duckdb_generated_extension_loader linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -559,5 +559,5 @@ gather-libs: release
 	mkdir -p libs && \
 	cp src/libduckdb_static.a libs/. && \
 	cp third_party/*/libduckdb_*.a libs/. && \
-	cp extension/lib*_extension_loader.a libs/. && \
+	cp extension/libduckdb_generated_extension_loader.a libs/. && \
 	cp extension/*/lib*_extension.a libs/.

--- a/Makefile
+++ b/Makefile
@@ -534,7 +534,7 @@ bundle-setup:
 	mkdir -p bundle && \
 	cp src/libduckdb_static.a bundle/. && \
 	cp third_party/*/libduckdb_*.a bundle/. && \
-	cp extension/lib*_extension_loader.a bundle/. && \
+	cp extension/libduckdb_generated_extension_loader.a bundle/. && \
 	cp extension/*/lib*_extension.a bundle/. && \
 	mkdir -p vcpkg_installed && \
 	find vcpkg_installed -name '*.a' -exec cp {} bundle/. \; && \

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -9,7 +9,7 @@
 # include generated includes
 include_directories("${PROJECT_BINARY_DIR}/codegen/include/")
 
-add_library(dummy_static_extension_loader
+add_library(dummy_static_extension_loader STATIC
             loader/dummy_static_extension_loader.cpp)
 
 install(
@@ -101,7 +101,7 @@ add_definitions(-DDUCKDB_MAJOR_VERSION=${DUCKDB_MAJOR_VERSION})
 add_definitions(-DDUCKDB_MINOR_VERSION=${DUCKDB_MINOR_VERSION})
 add_definitions(-DDUCKDB_PATCH_VERSION=${DUCKDB_PATCH_VERSION})
 
-add_library(duckdb_generated_extension_loader ${GENERATED_CPP_FILE})
+add_library(duckdb_generated_extension_loader STATIC ${GENERATED_CPP_FILE})
 
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_generated_extension_loader>

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -101,7 +101,7 @@ add_definitions(-DDUCKDB_MAJOR_VERSION=${DUCKDB_MAJOR_VERSION})
 add_definitions(-DDUCKDB_MINOR_VERSION=${DUCKDB_MINOR_VERSION})
 add_definitions(-DDUCKDB_PATCH_VERSION=${DUCKDB_PATCH_VERSION})
 
-add_library(duckdb_generated_extension_loader OBJECT ${GENERATED_CPP_FILE})
+add_library(duckdb_generated_extension_loader ${GENERATED_CPP_FILE})
 
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_generated_extension_loader>

--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -53,6 +53,7 @@ function(get_statically_linked_extensions DUCKDB_EXTENSION_NAMES OUT_VARIABLE)
 endfunction()
 
 function(link_extension_libraries LIBRARY LINKAGE)
+    target_link_libraries(${LIBRARY} ${LINKAGE} duckdb_generated_extension_loader)
     get_statically_linked_extensions("${DUCKDB_EXTENSION_NAMES}" STATICALLY_LINKED_EXTENSIONS)
     # Now link against any registered out-of-tree extensions
     foreach(EXT_NAME IN LISTS STATICALLY_LINKED_EXTENSIONS)
@@ -61,7 +62,6 @@ function(link_extension_libraries LIBRARY LINKAGE)
             target_link_libraries(${LIBRARY} ${LINKAGE} ${EXT_NAME}_extension)
         endif()
     endforeach()
-    target_link_libraries(${LIBRARY} ${LINKAGE} duckdb_generated_extension_loader)
 endfunction()
 
 function(link_threads LIBRARY LINKAGE)


### PR DESCRIPTION
This is additive, in the sense it should not change anything for current workflows, but make so the published libraries can bundled together (also with default extensions linked in).

This solves that both the builds based on `bundle static libraries` CI job AND the Wasm build are restored to be working properly, the extension linking improvements are follow ups to https://github.com/duckdb/duckdb/pull/19369 that reworked the way linking now works.

Together with @maiadegraaf.

EDIT: @evertlammerts points out that this description (and the code likely) misses an important detail: ordering matters. In particular, when statically link libraries (in Linux!), the compiler will optimise out symbols, so first one needs to link in the libraries with dependecies, and only later the libraries you depend on.