### PR TITLE
Recheck result types after optimizers run

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -410,7 +410,9 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 		logical_plan = optimizer.Optimize(std::move(logical_plan));
 		D_ASSERT(logical_plan);
 		profiler.EndPhase();
-
+		// Update result types from the optimized plan (in case optimizers modified them)
+		logical_plan->ResolveOperatorTypes();
+		result->types = logical_plan->types;
 #ifdef DEBUG
 		logical_plan->Verify(*this);
 #endif


### PR DESCRIPTION
I'm writing an extension that wants to modify the result type (cast some "unsupported" types to other types), and that's implemented as a extension pre_optimizer. It doesn't quite work as the unoptimized plan currently already determines the result types and that is never expected to change later. Here's a minimal change that would make it work. 