### PR TITLE
CLI: Assume black terminal color on Windows

### DIFF
--- a/tools/shell/linenoise/terminal.cpp
+++ b/tools/shell/linenoise/terminal.cpp
@@ -427,6 +427,13 @@ void Terminal::BufferAvailableInput() {
 }
 
 bool Terminal::TryGetBackgroundColor(TerminalColor &color) {
+#if defined(_WIN32) || defined(WIN32)
+	// FIXME: always emit black background on Windows
+	color.r = 0;
+	color.g = 0;
+	color.b = 0;
+	return true;
+#else
 	int ifd = STDIN_FILENO;
 	int ofd = STDOUT_FILENO;
 
@@ -464,6 +471,7 @@ bool Terminal::TryGetBackgroundColor(TerminalColor &color) {
 	}
 	Terminal::DisableRawMode();
 	return success;
+#endif
 }
 
 /* Try to get the number of columns in the current terminal, or assume 80


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/20678

The background detection terminal codes are not supported on Windows, so just assume black for now