### PR TITLE
CLI: Lock configuration in safe mode

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1180,6 +1180,7 @@ void ShellState::OpenDB(ShellOpenFlags flags) {
 		db->LoadStaticExtension<duckdb::ShellExtension>();
 		if (safe_mode) {
 			ExecuteQuery("SET enable_external_access=false");
+			ExecuteQuery("SET lock_configuration=true");
 		}
 		if (stdout_is_console) {
 			ExecuteQuery("PRAGMA enable_progress_bar");
@@ -1564,6 +1565,7 @@ MetadataResult ShellState::EnableSafeMode(ShellState &state, const vector<string
 	if (state.db) {
 		// db has been opened - disable external access
 		state.ExecuteQuery("SET enable_external_access=false");
+		state.ExecuteQuery("SET lock_configuration=true");
 	}
 	return MetadataResult::SUCCESS;
 }

--- a/tools/shell/tests/test_safe_mode.py
+++ b/tools/shell/tests/test_safe_mode.py
@@ -62,4 +62,14 @@ def test_safe_mode_query(shell, random_filepath, sql, persistent):
     result = test.run()
     result.check_stderr('disabled')
 
+
+def test_lock_config(shell, random_filepath):
+    arguments = ['-safe']
+    test = (
+        ShellTest(shell, arguments)
+        .statement("SET memory_limit='-1'")
+    )
+    result = test.run()
+    result.check_stderr('locked')
+
 # fmt: on


### PR DESCRIPTION
We generally recommend users to lock configuration as changing configuration can influence the running of the system in various manners - as such it seems like a good idea for this to also apply to the CLI `safe` mode which is intended to offer a locked down version of the system.