### PR TITLE
Fix union type casting rules

### DIFF
--- a/src/function/cast/union_casts.cpp
+++ b/src/function/cast/union_casts.cpp
@@ -17,8 +17,8 @@ namespace duckdb {
 //--------------------------------------------------------------------------------------------------
 // if the source can be implicitly cast to a member of the target union, the cast is valid
 
-static unique_ptr<BoundCastData> BindToUnionCast(BindCastInput &input, const LogicalType &source,
-                                                 const LogicalType &target) {
+static unique_ptr<BoundCastData> BindToUnionMemberCast(BindCastInput &input, const LogicalType &source,
+                                                       const LogicalType &target) {
 	D_ASSERT(target.id() == LogicalTypeId::UNION);
 
 	vector<UnionBoundCastData> candidates;
@@ -81,57 +81,24 @@ static unique_ptr<BoundCastData> BindToUnionCast(BindCastInput &input, const Log
 	return make_uniq<UnionBoundCastData>(std::move(selected_cast));
 }
 
-static unique_ptr<FunctionLocalState> InitToUnionLocalState(CastLocalStateParameters &parameters) {
-	auto &cast_data = parameters.cast_data->Cast<UnionBoundCastData>();
-	if (!cast_data.member_cast_info.HasInitLocalState()) {
-		return nullptr;
-	}
-	CastLocalStateParameters child_parameters(parameters, cast_data.member_cast_info.GetCastData());
-	return cast_data.member_cast_info.InitLocalState(child_parameters);
-}
-
-static bool ToUnionCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-	D_ASSERT(result.GetType().id() == LogicalTypeId::UNION);
-	auto &cast_data = parameters.cast_data->Cast<UnionBoundCastData>();
-	auto &selected_member_vector = UnionVector::GetMember(result, cast_data.tag);
-
-	CastParameters child_parameters(parameters, cast_data.member_cast_info.GetCastData(), parameters.local_state);
-	if (!cast_data.member_cast_info.Cast(source, selected_member_vector, count, child_parameters)) {
-		return false;
-	}
-
-	// cast succeeded, create union vector
-	UnionVector::SetToMember(result, cast_data.tag, selected_member_vector, count, true);
-
-	result.Verify(count);
-
-	return true;
-}
-
-BoundCastInfo DefaultCasts::ImplicitToUnionCast(BindCastInput &input, const LogicalType &source,
-                                                const LogicalType &target) {
-	D_ASSERT(target.id() == LogicalTypeId::UNION);
-	if (StructToUnionCast::AllowImplicitCastFromStruct(source, target)) {
-		return StructToUnionCast::Bind(input, source, target);
-	}
-	auto cast_data = BindToUnionCast(input, source, target);
-	return BoundCastInfo(&ToUnionCast, std::move(cast_data), InitToUnionLocalState);
-}
-
 //--------------------------------------------------------------------------------------------------
 // UNION -> UNION
 //--------------------------------------------------------------------------------------------------
-// if the source member tags is a subset of the target member tags, and all the source members can be
-// implicitly cast to the corresponding target members, the cast is valid.
+// if the source member tags is a subset of the target member tags, and all the source
+// members can be implicitly cast to the corresponding target members, the cast is valid.
+// If this fails and the source can be implicitly cast to a member of target, the cast is also
+// valid.
 //
 // VALID: 	UNION(A, B) 	-> 	UNION(A, B, C)
+// VALID: 	UNION(A, C) 	-> 	UNION(A, UNION(A, C)) will result in A -> A and C -> UNION(A, C)
+// VALID: 	UNION(A, C) 	-> 	UNION(UNION(A, C)) will result in C -> UNION(A, C)
 // VALID: 	UNION(A, B) 	-> 	UNION(A, C)		if B can be implicitly cast to C
 //
 // INVALID: UNION(A, B, C)	->	UNION(A, B)
 // INVALID:	UNION(A, B) 	->	UNION(A, C)		if B can't be implicitly cast to C
 // INVALID:	UNION(A, B, D) 	->	UNION(A, B, C)
 
-struct UnionUnionBoundCastData : public BoundCastData {
+struct UnionMemberBoundCastData : public BoundCastData {
 	// mapping from source member index to target member index
 	// these are always the same size as the source member count
 	// (since all source members must be present in the target)
@@ -140,7 +107,7 @@ struct UnionUnionBoundCastData : public BoundCastData {
 
 	LogicalType target_type;
 
-	UnionUnionBoundCastData(vector<idx_t> tag_map, vector<BoundCastInfo> member_casts, LogicalType target_type)
+	UnionMemberBoundCastData(vector<idx_t> tag_map, vector<BoundCastInfo> member_casts, LogicalType target_type)
 	    : tag_map(std::move(tag_map)), member_casts(std::move(member_casts)), target_type(std::move(target_type)) {
 	}
 
@@ -150,7 +117,7 @@ public:
 		for (auto &member_cast : member_casts) {
 			member_casts_copy.push_back(member_cast.Copy());
 		}
-		return make_uniq<UnionUnionBoundCastData>(tag_map, std::move(member_casts_copy), target_type);
+		return make_uniq<UnionMemberBoundCastData>(tag_map, std::move(member_casts_copy), target_type);
 	}
 };
 
@@ -182,6 +149,12 @@ static unique_ptr<BoundCastData> BindUnionToUnionCast(BindCastInput &input, cons
 			}
 		}
 		if (!found) {
+			// Try casting source to a member of target, but if it fails
+			// use our error message.
+			try {
+				return BindToUnionMemberCast(input, source, target);
+			} catch (ConversionException &_) {
+			};
 			// no matching member tag found in the target set
 			auto message =
 			    StringUtil::Format("Type %s can't be cast as %s. The member '%s' is not present in target union",
@@ -190,26 +163,54 @@ static unique_ptr<BoundCastData> BindUnionToUnionCast(BindCastInput &input, cons
 		}
 	}
 
-	return make_uniq<UnionUnionBoundCastData>(tag_map, std::move(member_casts), target);
+	return make_uniq<UnionMemberBoundCastData>(tag_map, std::move(member_casts), target);
 }
 
-static unique_ptr<FunctionLocalState> InitUnionToUnionLocalState(CastLocalStateParameters &parameters) {
-	auto &cast_data = parameters.cast_data->Cast<UnionUnionBoundCastData>();
-	auto result = make_uniq<StructCastLocalState>();
-
-	for (auto &entry : cast_data.member_casts) {
-		unique_ptr<FunctionLocalState> child_state;
-		if (entry.HasInitLocalState()) {
-			CastLocalStateParameters child_params(parameters, entry.GetCastData());
-			child_state = entry.InitLocalState(child_params);
+static unique_ptr<FunctionLocalState> InitToUnionLocalState(CastLocalStateParameters &parameters) {
+	if (dynamic_cast<UnionBoundCastData *>(&*parameters.cast_data)) {
+		auto &cast_data = parameters.cast_data->Cast<UnionBoundCastData>();
+		if (!cast_data.member_cast_info.HasInitLocalState()) {
+			return nullptr;
 		}
-		result->local_states.push_back(std::move(child_state));
+		CastLocalStateParameters child_parameters(parameters, cast_data.member_cast_info.GetCastData());
+		return cast_data.member_cast_info.InitLocalState(child_parameters);
+	} else {
+		// Casting a union to union via member mapping
+		auto &cast_data = parameters.cast_data->Cast<UnionMemberBoundCastData>();
+		auto result = make_uniq<StructCastLocalState>();
+
+		for (auto &entry : cast_data.member_casts) {
+			unique_ptr<FunctionLocalState> child_state;
+			if (entry.HasInitLocalState()) {
+				CastLocalStateParameters child_params(parameters, entry.GetCastData());
+				child_state = entry.InitLocalState(child_params);
+			}
+			result->local_states.push_back(std::move(child_state));
+		}
+		return std::move(result);
 	}
-	return std::move(result);
 }
 
-static bool UnionToUnionCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-	auto &cast_data = parameters.cast_data->Cast<UnionUnionBoundCastData>();
+static bool ToUnionMemberCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+	D_ASSERT(result.GetType().id() == LogicalTypeId::UNION);
+	auto &cast_data = parameters.cast_data->Cast<UnionBoundCastData>();
+	auto &selected_member_vector = UnionVector::GetMember(result, cast_data.tag);
+
+	CastParameters child_parameters(parameters, cast_data.member_cast_info.GetCastData(), parameters.local_state);
+	if (!cast_data.member_cast_info.Cast(source, selected_member_vector, count, child_parameters)) {
+		return false;
+	}
+
+	// cast succeeded, create union vector
+	UnionVector::SetToMember(result, cast_data.tag, selected_member_vector, count, true);
+
+	result.Verify(count);
+
+	return true;
+}
+
+static bool UnionMemberToMemberCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+	auto &cast_data = parameters.cast_data->Cast<UnionMemberBoundCastData>();
 	auto &lstate = parameters.local_state->Cast<StructCastLocalState>();
 
 	auto source_member_count = UnionType::GetMemberCount(source.GetType());
@@ -294,13 +295,33 @@ static bool UnionToUnionCast(Vector &source, Vector &result, idx_t count, CastPa
 	return true;
 }
 
+static bool ToUnionCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+	D_ASSERT(result.GetType().id() == LogicalTypeId::UNION);
+	if (dynamic_cast<UnionBoundCastData *>(&*parameters.cast_data)) {
+		ToUnionMemberCast(source, result, count, parameters);
+	} else {
+		UnionMemberToMemberCast(source, result, count, parameters);
+	}
+	return true;
+}
+
+BoundCastInfo DefaultCasts::ImplicitToUnionCast(BindCastInput &input, const LogicalType &source,
+                                                const LogicalType &target) {
+	D_ASSERT(target.id() == LogicalTypeId::UNION);
+	if (StructToUnionCast::AllowImplicitCastFromStruct(source, target)) {
+		return StructToUnionCast::Bind(input, source, target);
+	}
+	auto cast_data = BindToUnionMemberCast(input, source, target);
+	return BoundCastInfo(&ToUnionCast, std::move(cast_data), InitToUnionLocalState);
+}
+
 static bool UnionToVarcharCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	auto constant = source.GetVectorType() == VectorType::CONSTANT_VECTOR;
 	// first cast all union members to varchar
-	auto &cast_data = parameters.cast_data->Cast<UnionUnionBoundCastData>();
+	auto &cast_data = parameters.cast_data->Cast<UnionMemberBoundCastData>();
 	Vector varchar_union(cast_data.target_type, count);
 
-	UnionToUnionCast(source, varchar_union, count, parameters);
+	ToUnionCast(source, varchar_union, count, parameters);
 
 	// now construct the actual varchar vector
 	// varchar_union.Flatten(count);
@@ -346,10 +367,10 @@ BoundCastInfo DefaultCasts::UnionCastSwitch(BindCastInput &input, const LogicalT
 		}
 		auto varchar_type = LogicalType::UNION(std::move(varchar_members));
 		return BoundCastInfo(UnionToVarcharCast, BindUnionToUnionCast(input, source, varchar_type),
-		                     InitUnionToUnionLocalState);
+		                     InitToUnionLocalState);
 	}
 	case LogicalTypeId::UNION:
-		return BoundCastInfo(UnionToUnionCast, BindUnionToUnionCast(input, source, target), InitUnionToUnionLocalState);
+		return BoundCastInfo(ToUnionCast, BindUnionToUnionCast(input, source, target), InitToUnionLocalState);
 	default:
 		return TryVectorNullCast;
 	}

--- a/src/function/cast/union_casts.cpp
+++ b/src/function/cast/union_casts.cpp
@@ -1,16 +1,52 @@
 #include "duckdb/common/vector/constant_vector.hpp"
 #include "duckdb/common/vector/flat_vector.hpp"
-#include "duckdb/common/vector/string_vector.hpp"
 #include "duckdb/common/vector/union_vector.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
-#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/function/cast/bound_cast_data.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/function/cast/default_casts.hpp"
-#include "duckdb/function/cast/bound_cast_data.hpp"
-
-#include <algorithm> // for std::sort
 
 namespace duckdb {
+
+struct UnionMemberBoundCastData : public BoundCastData {
+	// mapping from source member index to target member index
+	// these are always the same size as the source member count
+	// (since all source members must be present in the target)
+	vector<union_tag_t> tag_map;
+	vector<BoundCastInfo> member_casts;
+
+	LogicalType type;
+
+	bool is_member_to_member;
+
+	UnionMemberBoundCastData(vector<union_tag_t> tag_map, vector<BoundCastInfo> member_casts, const LogicalType &type,
+	                         bool is_member_to_member)
+	    : tag_map(std::move(tag_map)), member_casts(std::move(member_casts)), type(type.Copy()),
+	      is_member_to_member(is_member_to_member) {
+	}
+
+	UnionMemberBoundCastData(vector<union_tag_t> tag_map, vector<BoundCastInfo> member_cast_infos,
+	                         const LogicalType &type)
+	    : tag_map(std::move(tag_map)), member_casts(std::move(member_cast_infos)), type(type.Copy()),
+	      is_member_to_member(true) {
+	}
+
+	// This is ugly to take a vector of BoundCastInfo, however otherwise the compiler complains
+	UnionMemberBoundCastData(union_tag_t member_idx, BoundCastInfo member_cast_info, const LogicalType &type)
+	    : tag_map(1, member_idx), type(type.Copy()), is_member_to_member(false) {
+		member_casts = vector<BoundCastInfo>();
+		member_casts.emplace_back(member_cast_info.Copy());
+	}
+
+public:
+	unique_ptr<BoundCastData> Copy() const override {
+		vector<BoundCastInfo> member_casts_copy;
+		for (auto &member_cast : member_casts) {
+			member_casts_copy.push_back(member_cast.Copy());
+		}
+		return make_uniq<UnionMemberBoundCastData>(tag_map, std::move(member_casts_copy), type, is_member_to_member);
+	}
+};
 
 //--------------------------------------------------------------------------------------------------
 // ??? -> UNION
@@ -21,16 +57,24 @@ static unique_ptr<BoundCastData> BindToUnionMemberCast(BindCastInput &input, con
                                                        const LogicalType &target) {
 	D_ASSERT(target.id() == LogicalTypeId::UNION);
 
-	vector<UnionBoundCastData> candidates;
+	// Vector of names/candidates that are optimal for cost
+	vector<string> names;
+	vector<UnionMemberBoundCastData> candidates;
+
+	int64_t best_cost = std::numeric_limits<int64_t>::max();
 
 	for (idx_t member_idx = 0; member_idx < UnionType::GetMemberCount(target); member_idx++) {
 		auto member_type = UnionType::GetMemberType(target, member_idx);
 		auto member_name = UnionType::GetMemberName(target, member_idx);
 		auto member_cast_cost = input.function_set.ImplicitCastCost(nullptr, source, member_type);
-		if (member_cast_cost != -1) {
-			auto member_cast_info = input.GetCastFunction(source, member_type);
-			candidates.emplace_back(member_idx, member_name, member_type, member_cast_cost,
-			                        std::move(member_cast_info));
+		if (member_cast_cost >= 0 && member_cast_cost <= best_cost) {
+			if (member_cast_cost != best_cost) {
+				names.clear();
+				candidates.clear();
+				best_cost = member_cast_cost;
+			}
+			names.emplace_back(member_name);
+			candidates.emplace_back(member_idx, std::move(input.GetCastFunction(source, member_type)), member_type);
 		}
 	};
 
@@ -51,25 +95,16 @@ static unique_ptr<BoundCastData> BindToUnionMemberCast(BindCastInput &input, con
 		throw ConversionException(message);
 	}
 
-	// sort the candidate casts by cost
-	std::sort(candidates.begin(), candidates.end(), UnionBoundCastData::SortByCostAscending);
-
-	// select the lowest possible cost cast
-	auto &selected_cast = candidates[0];
-	auto selected_cost = candidates[0].cost;
-
 	// check if the cast is ambiguous (2 or more casts have the same cost)
-	if (candidates.size() > 1 && candidates[1].cost == selected_cost) {
+	if (candidates.size() > 1) {
 		// collect all the ambiguous types
 		auto message = StringUtil::Format(
 		    "Type %s can't be cast as %s. The cast is ambiguous, multiple possible members in target: ", source,
 		    target);
 		for (size_t i = 0; i < candidates.size(); i++) {
-			if (candidates[i].cost == selected_cost) {
-				message += StringUtil::Format("'%s (%s)'", candidates[i].name, candidates[i].type.ToString());
-				if (i < candidates.size() - 1) {
-					message += ", ";
-				}
+			message += StringUtil::Format("'%s (%s)'", names[i], candidates[i].type.ToString());
+			if (i < candidates.size() - 1) {
+				message += ", ";
 			}
 		}
 		message += ". Disambiguate the target type by using the 'union_value(<tag> := <arg>)' function to promote the "
@@ -78,7 +113,7 @@ static unique_ptr<BoundCastData> BindToUnionMemberCast(BindCastInput &input, con
 	}
 
 	// otherwise, return the selected cast
-	return make_uniq<UnionBoundCastData>(std::move(selected_cast));
+	return make_uniq<UnionMemberBoundCastData>(std::move(candidates[0]));
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -98,29 +133,6 @@ static unique_ptr<BoundCastData> BindToUnionMemberCast(BindCastInput &input, con
 // INVALID:	UNION(A, B) 	->	UNION(A, C)		if B can't be implicitly cast to C
 // INVALID:	UNION(A, B, D) 	->	UNION(A, B, C)
 
-struct UnionMemberBoundCastData : public BoundCastData {
-	// mapping from source member index to target member index
-	// these are always the same size as the source member count
-	// (since all source members must be present in the target)
-	vector<idx_t> tag_map;
-	vector<BoundCastInfo> member_casts;
-
-	LogicalType target_type;
-
-	UnionMemberBoundCastData(vector<idx_t> tag_map, vector<BoundCastInfo> member_casts, LogicalType target_type)
-	    : tag_map(std::move(tag_map)), member_casts(std::move(member_casts)), target_type(std::move(target_type)) {
-	}
-
-public:
-	unique_ptr<BoundCastData> Copy() const override {
-		vector<BoundCastInfo> member_casts_copy;
-		for (auto &member_cast : member_casts) {
-			member_casts_copy.push_back(member_cast.Copy());
-		}
-		return make_uniq<UnionMemberBoundCastData>(tag_map, std::move(member_casts_copy), target_type);
-	}
-};
-
 static unique_ptr<BoundCastData> BindUnionToUnionCast(BindCastInput &input, const LogicalType &source,
                                                       const LogicalType &target) {
 	D_ASSERT(source.id() == LogicalTypeId::UNION);
@@ -128,7 +140,7 @@ static unique_ptr<BoundCastData> BindUnionToUnionCast(BindCastInput &input, cons
 
 	auto source_member_count = UnionType::GetMemberCount(source);
 
-	auto tag_map = vector<idx_t>(source_member_count);
+	auto tag_map = vector<union_tag_t>(source_member_count);
 	auto member_casts = vector<BoundCastInfo>();
 
 	for (idx_t source_idx = 0; source_idx < source_member_count; source_idx++) {
@@ -167,16 +179,9 @@ static unique_ptr<BoundCastData> BindUnionToUnionCast(BindCastInput &input, cons
 }
 
 static unique_ptr<FunctionLocalState> InitToUnionLocalState(CastLocalStateParameters &parameters) {
-	if (dynamic_cast<UnionBoundCastData *>(&*parameters.cast_data)) {
-		auto &cast_data = parameters.cast_data->Cast<UnionBoundCastData>();
-		if (!cast_data.member_cast_info.HasInitLocalState()) {
-			return nullptr;
-		}
-		CastLocalStateParameters child_parameters(parameters, cast_data.member_cast_info.GetCastData());
-		return cast_data.member_cast_info.InitLocalState(child_parameters);
-	} else {
-		// Casting a union to union via member mapping
-		auto &cast_data = parameters.cast_data->Cast<UnionMemberBoundCastData>();
+	auto &cast_data = parameters.cast_data->Cast<UnionMemberBoundCastData>();
+
+	if (cast_data.is_member_to_member) {
 		auto result = make_uniq<StructCastLocalState>();
 
 		for (auto &entry : cast_data.member_casts) {
@@ -187,22 +192,30 @@ static unique_ptr<FunctionLocalState> InitToUnionLocalState(CastLocalStateParame
 			}
 			result->local_states.push_back(std::move(child_state));
 		}
-		return std::move(result);
+		return result;
+	} else {
+		auto member_cast_info = cast_data.member_casts[0].Copy();
+		if (!member_cast_info.HasInitLocalState()) {
+			return nullptr;
+		}
+		CastLocalStateParameters child_parameters(parameters, member_cast_info.GetCastData());
+		return member_cast_info.InitLocalState(child_parameters);
 	}
 }
 
 static bool ToUnionMemberCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	D_ASSERT(result.GetType().id() == LogicalTypeId::UNION);
-	auto &cast_data = parameters.cast_data->Cast<UnionBoundCastData>();
-	auto &selected_member_vector = UnionVector::GetMember(result, cast_data.tag);
+	auto &cast_data = parameters.cast_data->Cast<UnionMemberBoundCastData>();
+	auto &selected_member_vector = UnionVector::GetMember(result, cast_data.tag_map[0]);
+	auto member_cast_info = cast_data.member_casts[0].Copy();
 
-	CastParameters child_parameters(parameters, cast_data.member_cast_info.GetCastData(), parameters.local_state);
-	if (!cast_data.member_cast_info.Cast(source, selected_member_vector, count, child_parameters)) {
+	CastParameters child_parameters(parameters, member_cast_info.GetCastData(), parameters.local_state);
+	if (!member_cast_info.Cast(source, selected_member_vector, count, child_parameters)) {
 		return false;
 	}
 
 	// cast succeeded, create union vector
-	UnionVector::SetToMember(result, cast_data.tag, selected_member_vector, count, true);
+	UnionVector::SetToMember(result, cast_data.tag_map[0], selected_member_vector, count, true);
 
 	result.Verify(count);
 
@@ -297,10 +310,12 @@ static bool UnionMemberToMemberCast(Vector &source, Vector &result, idx_t count,
 
 static bool ToUnionCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	D_ASSERT(result.GetType().id() == LogicalTypeId::UNION);
-	if (dynamic_cast<UnionBoundCastData *>(&*parameters.cast_data)) {
-		ToUnionMemberCast(source, result, count, parameters);
-	} else {
+	auto &cast_data = parameters.cast_data->Cast<UnionMemberBoundCastData>();
+
+	if (cast_data.is_member_to_member) {
 		UnionMemberToMemberCast(source, result, count, parameters);
+	} else {
+		ToUnionMemberCast(source, result, count, parameters);
 	}
 	return true;
 }
@@ -319,7 +334,7 @@ static bool UnionToVarcharCast(Vector &source, Vector &result, idx_t count, Cast
 	auto constant = source.GetVectorType() == VectorType::CONSTANT_VECTOR;
 	// first cast all union members to varchar
 	auto &cast_data = parameters.cast_data->Cast<UnionMemberBoundCastData>();
-	Vector varchar_union(cast_data.target_type, count);
+	Vector varchar_union(cast_data.type, count);
 
 	ToUnionCast(source, varchar_union, count, parameters);
 

--- a/src/function/cast_rules.cpp
+++ b/src/function/cast_rules.cpp
@@ -354,6 +354,26 @@ bool LogicalTypeIsValid(const LogicalType &type) {
 	}
 }
 
+int64_t ImplicitCastToUnionMember(const LogicalType &from, const LogicalType &to) {
+	// check that the union type is fully resolved.
+	if (to.AuxInfo() == nullptr) {
+		return -1;
+	}
+	// check if the union contains something castable from the source type
+	// in which case the least expensive (most specific) cast should be used
+	bool found = false;
+	auto cost = NumericLimits<int64_t>::Maximum();
+	for (idx_t i = 0; i < UnionType::GetMemberCount(to); i++) {
+		auto target_member = UnionType::GetMemberType(to, i);
+		auto target_cost = CastRules::ImplicitCast(from, target_member);
+		if (target_cost != -1) {
+			found = true;
+			cost = MinValue(cost, target_cost);
+		}
+	}
+	return found ? cost : -1;
+}
+
 int64_t CastRules::ImplicitCast(const LogicalType &from, const LogicalType &to) {
 	if (from.id() == LogicalTypeId::SQLNULL && to.id() == LogicalTypeId::TEMPLATE) {
 		// Prefer the TEMPLATE type for NULL casts, as it is the most generic
@@ -400,8 +420,15 @@ int64_t CastRules::ImplicitCast(const LogicalType &from, const LogicalType &to) 
 		// in any other case we use the casting rules of the preferred type of the literal
 		return CastRules::ImplicitCast(IntegerLiteral::GetType(from), to);
 	}
+
 	if (from.GetAlias() != to.GetAlias()) {
 		// if aliases are different, an implicit cast is not possible
+
+		// Special case: Anything can be cast to a union if the source type is a member of the union
+		if (to.id() == LogicalTypeId::UNION) {
+			return ImplicitCastToUnionMember(from, to);
+		}
+
 		return -1;
 	}
 	if (from.id() == LogicalTypeId::LIST && to.id() == LogicalTypeId::LIST) {
@@ -476,7 +503,10 @@ int64_t CastRules::ImplicitCast(const LogicalType &from, const LogicalType &to) 
 				return -1;
 			}
 		}
-		return cost;
+		// If not found, try casting source to member of target (below)
+		if (cost != -1) {
+			return cost;
+		}
 	}
 	if ((from.id() == LogicalTypeId::STRUCT || from.IsAggregateStateStructType()) &&
 	    (to.id() == LogicalTypeId::STRUCT || to.IsAggregateStateStructType())) {
@@ -544,26 +574,9 @@ int64_t CastRules::ImplicitCast(const LogicalType &from, const LogicalType &to) 
 		// arguments match: do nothing
 		return 0;
 	}
-
 	// Special case: Anything can be cast to a union if the source type is a member of the union
 	if (to.id() == LogicalTypeId::UNION) {
-		// check that the union type is fully resolved.
-		if (to.AuxInfo() == nullptr) {
-			return -1;
-		}
-		// check if the union contains something castable from the source type
-		// in which case the least expensive (most specific) cast should be used
-		bool found = false;
-		auto cost = NumericLimits<int64_t>::Maximum();
-		for (idx_t i = 0; i < UnionType::GetMemberCount(to); i++) {
-			auto target_member = UnionType::GetMemberType(to, i);
-			auto target_cost = ImplicitCast(from, target_member);
-			if (target_cost != -1) {
-				found = true;
-				cost = MinValue(cost, target_cost);
-			}
-		}
-		return found ? cost : -1;
+		return ImplicitCastToUnionMember(from, to);
 	}
 
 	switch (from.id()) {

--- a/src/include/duckdb/function/cast/bound_cast_data.hpp
+++ b/src/include/duckdb/function/cast/bound_cast_data.hpp
@@ -141,29 +141,6 @@ public:
 	vector<unique_ptr<FunctionLocalState>> value_states;
 };
 
-struct UnionBoundCastData : public BoundCastData {
-	UnionBoundCastData(union_tag_t member_idx, string name, LogicalType type, int64_t cost,
-	                   BoundCastInfo member_cast_info)
-	    : tag(member_idx), name(std::move(name)), type(std::move(type)), cost(cost),
-	      member_cast_info(std::move(member_cast_info)) {
-	}
-
-	union_tag_t tag;
-	string name;
-	LogicalType type;
-	int64_t cost;
-	BoundCastInfo member_cast_info;
-
-public:
-	unique_ptr<BoundCastData> Copy() const override {
-		return make_uniq<UnionBoundCastData>(tag, name, type, cost, member_cast_info.Copy());
-	}
-
-	static bool SortByCostAscending(const UnionBoundCastData &left, const UnionBoundCastData &right) {
-		return left.cost < right.cost;
-	}
-};
-
 struct StructToUnionCast {
 public:
 	static bool AllowImplicitCastFromStruct(const LogicalType &source, const LogicalType &target);

--- a/test/extension/test_custom_type_modifier.test_slow
+++ b/test/extension/test_custom_type_modifier.test_slow
@@ -193,3 +193,10 @@ query I
 SELECT parameter_types from duckdb_functions() where function_name = 'bounded_add';
 ----
 [BOUNDED, BOUNDED]
+
+query I
+SELECT can_cast_implicitly(i, i::UNION(a BOUNDED(200))) FROM t1;
+----
+true
+true
+true

--- a/test/sql/cast/union_cast.test
+++ b/test/sql/cast/union_cast.test
@@ -1,0 +1,28 @@
+# name: test/sql/cast/union_cast.test
+# description: Test union casts
+# group: [cast]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t1 (i UNION(a INT));
+
+statement ok
+INSERT INTO t1 VALUES (1),(2),(3);
+
+# UNION -> UNION
+query I
+SELECT i::UNION(a UNION(a INT)) FROM t1;
+----
+1
+2
+3
+
+# Make sure that the value ends up in the right union member
+query I
+SELECT (i::UNION(a INT, b UNION(a INT))).a FROM t1;
+----
+1
+2
+3


### PR DESCRIPTION
This fixes #20702, for both implicit and explicit casting.

Casting union members to union members still takes priority, so that there is no breaking change. The only modified behavior is in cases where previously the casting failed when it should not.

For explicit casts, the code essentially gives priority to casting member to members, and when it fails it also tries casting source to a member of target.
