### PR TITLE
Choose your semantics: `RECURRING` for all recursive CTEs

### DIFF
--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -176,6 +176,20 @@ SourceResultType PhysicalRecursiveCTE::GetDataInternal(ExecutionContext &context
 					// Append the result to the recurring table.
 					recurring_table->Append(result);
 				}
+			} else if (ref_recurring && gstate.intermediate_table.Count() != 0) {
+				// we need to populate the recurring table from the intermediate table
+				// careful: we can not just use Combine here, because this destroys the intermediate table
+				// instead we need to scan and append to create a copy
+				// Note: as we are in the "normal" recursion case here, not the USING KEY case,
+				// we can just scan the intermediate table directly, instead of going through the HT
+				ColumnDataScanState scan_state;
+				gstate.intermediate_table.InitializeScan(scan_state);
+				DataChunk result;
+				result.Initialize(Allocator::DefaultAllocator(), chunk.GetTypes());
+
+				while (gstate.intermediate_table.Scan(scan_state, result)) {
+					recurring_table->Append(result);
+				}
 			}
 
 			working_table->Reset();

--- a/src/execution/physical_plan/plan_recursive_cte.cpp
+++ b/src/execution/physical_plan/plan_recursive_cte.cpp
@@ -26,10 +26,14 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
 	// If the logical operator has no key targets or all columns are referenced,
 	// then we create a normal recursive CTE operator.
 	if (op.key_targets.empty()) {
+		auto recurring_table = make_shared_ptr<ColumnDataCollection>(context, op.types);
+		recurring_cte_tables[op.table_index] = recurring_table;
 		auto &right = CreatePlan(*op.children[1]);
 		auto &cte = Make<PhysicalRecursiveCTE>(op.ctename, op.table_index, op.types, op.union_all, left, right,
 		                                       op.estimated_cardinality);
 		auto &cast_cte = cte.Cast<PhysicalRecursiveCTE>();
+		cast_cte.ref_recurring = op.ref_recurring;
+		cast_cte.recurring_table = recurring_table;
 		cast_cte.distinct_types = op.types;
 		cast_cte.working_table = working_table;
 		return cte;

--- a/test/sql/cte/recursive_cte_key_variant.test_slow
+++ b/test/sql/cte/recursive_cte_key_variant.test_slow
@@ -113,15 +113,17 @@ SELECT * FROM  recurring.tbl;
 Catalog Error: Table with name "recurring.tbl" does not exist because schema "recurring" does not exist.
 
 # no using key
-statement error
+query I
 WITH RECURSIVE tbl2(a) AS (SELECT 1 UNION SELECT a.a + 1 FROM tbl2 AS a, recurring.tbl2 AS b WHERE a.a < 2) SELECT * FROM tbl2;
 ----
-does not exist
+1
+2
 
-statement error
+query II
 WITH RECURSIVE tbl2(a,b) AS (SELECT 1, NULL UNION SELECT a.a+1, a.b FROM tbl2 AS a, (SELECT * FROM recurring.tbl2) AS b WHERE a.a < 2) SELECT * FROM tbl2;
 ----
-does not exist
+1	NULL
+2	NULL
 
 # second cte references recurring table of first cte while first cte does not
 statement error
@@ -137,10 +139,11 @@ tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;
 ----
 does not exist
 
-statement error
+query I
 WITH RECURSIVE tbl2(a) AS (SELECT 1 UNION SELECT a.a+1 FROM tbl2 AS a, (SELECT * FROM recurring.tbl2) AS b WHERE a.a < 2) SELECT * FROM tbl2;
 ----
-does not exist
+1
+2
 
 statement error
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS (SELECT 5, 1 UNION SELECT a, b + 1 FROM tbl WHERE b < a),tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;

--- a/test/sql/cte/test_recursive_cte_recurring.test
+++ b/test/sql/cte/test_recursive_cte_recurring.test
@@ -101,3 +101,34 @@ c2
 c3
 c4
 c5
+
+query II
+WITH RECURSIVE
+parent(p,c) AS (
+  VALUES ('c1','c2'),
+         ('c1','c3'),
+         ('c3','c4'),
+         ('c3','c5'),
+         ('c4','c6'),
+         ('c4','c7')
+),
+ancestor(a,c) AS (
+  FROM parent
+    UNION
+  SELECT a1.x, a2.y
+  FROM   recurring.ancestor AS a1(x,z) NATURAL JOIN recurring.ancestor AS a2(z,y)
+)
+FROM ancestor ORDER BY ALL;
+----
+c1	c2
+c1	c3
+c1	c4
+c1	c5
+c1	c6
+c1	c7
+c3	c4
+c3	c5
+c3	c6
+c3	c7
+c4	c6
+c4	c7

--- a/test/sql/cte/test_recursive_cte_recurring.test
+++ b/test/sql/cte/test_recursive_cte_recurring.test
@@ -1,0 +1,46 @@
+# name: test/sql/cte/test_recursive_cte_recurring.test
+# description: Recursive CTEs with access to the UNION table
+# group: [cte]
+
+statement ok
+PRAGMA enable_verification;
+
+query II
+WITH RECURSIVE deduction AS (
+	-- P, (not P or Q), (not Q)
+	SELECT clause FROM (VALUES ([1]), ([-1, 2]), ([-2])) AS kb(clause)
+		UNION
+	SELECT
+	-- Create new clause by merging and removing resolved literals
+	list_distinct(
+		list_concat(
+			list_filter(p_new.clause, lambda x: x <> lit),
+				list_filter(p_old.clause, lambda x: x <> -lit)
+			)
+		) AS new_clause
+	FROM deduction p_new -- Newly added clauses
+	CROSS JOIN UNNEST(p_new.clause) AS t_lit(lit)
+	-- We join with the UNION table to find the negation of that literal
+	JOIN recurring.deduction p_old ON list_contains(p_old.clause, -lit)
+	WHERE
+		-- A resolution step is only useful if it doesn't create a tautology (like [P, not P]).
+		NOT EXISTS (
+			SELECT 1 FROM (
+				-- Check all literals in the potential new clause
+				SELECT UNNEST(list_concat(
+					list_filter(p_new.clause, lambda x: x <> lit),
+						list_filter(p_old.clause, lambda x: x <> -lit)
+				)) AS l
+			)
+			GROUP BY abs(l)
+			HAVING count(distinct l) > 1 -- Found both X and -X
+		)
+)
+-- If we deduced an empty clause [], it means the input was contradictory.
+SELECT CASE WHEN EXISTS (SELECT 1 FROM deduction WHERE len(clause) = 0)
+            THEN 'CONTRADICTION FOUND'
+            ELSE 'LOGICALLY CONSISTENT'
+       END AS result,
+       (SELECT list(clause) FROM deduction) AS all_deduced_clauses;
+----
+CONTRADICTION FOUND	[[1], [-1, 2], [-2], [2], [-1], []]

--- a/test/sql/cte/test_recursive_cte_recurring.test
+++ b/test/sql/cte/test_recursive_cte_recurring.test
@@ -41,6 +41,6 @@ SELECT CASE WHEN EXISTS (SELECT 1 FROM deduction WHERE len(clause) = 0)
             THEN 'CONTRADICTION FOUND'
             ELSE 'LOGICALLY CONSISTENT'
        END AS result,
-       (SELECT list(clause) FROM deduction) AS all_deduced_clauses;
+       (SELECT list(clause ORDER BY clause) FROM deduction) AS all_deduced_clauses;
 ----
-CONTRADICTION FOUND	[[1], [-1, 2], [-2], [2], [-1], []]
+CONTRADICTION FOUND	[[], [-2], [-1], [-1, 2], [1], [2]]

--- a/test/sql/cte/test_recursive_cte_recurring.test
+++ b/test/sql/cte/test_recursive_cte_recurring.test
@@ -44,3 +44,60 @@ SELECT CASE WHEN EXISTS (SELECT 1 FROM deduction WHERE len(clause) = 0)
        (SELECT list(clause ORDER BY clause) FROM deduction) AS all_deduced_clauses;
 ----
 CONTRADICTION FOUND	[[], [-2], [-1], [-1, 2], [1], [2]]
+
+# Find broken parts whose primary AND secondary supporting dependencies
+# are broken.  Derived from Example 1.2 (Nonlinear Query) in
+#
+# I. S. Mumick, S. J. Finkelstein, Hamid Pirahesh, and Raghu
+# Ramakrishnan. 1990. "Magic is relevant". SIGMOD Rec. 19, 2 (Jun.
+# 1990), 247–258. DOI:https://doi.org/10.1145/93605.98734.
+# Sample component hierarchy
+# (a component is broken if its primary AND secondary
+#  dependencies are broken)
+#
+#      c1
+#    ᵖ/  \ˢ
+#  ᵇc2    c3
+#        /  \
+#     ᵇc4    c5ᵇ
+#     /  \
+#   c6    c7
+#
+# If c2, c4, c5 are broken, then
+#  - c3 is broken, and in turn
+#  - c1 is broken
+query I
+WITH RECURSIVE
+"primary"(c,p) AS (
+  VALUES ('c1', 'c2'),
+         ('c3', 'c4'),
+         ('c4', 'c6')
+),
+secondary(c,s) AS (
+  VALUES ('c1', 'c3'),
+         ('c3', 'c5'),
+         ('c4', 'c7')
+),
+broken(c) AS (
+  VALUES ('c2'),
+         ('c4'),
+         ('c5')
+),
+fail(c) AS (
+  SELECT b.c
+  FROM   broken AS b
+    UNION
+  SELECT p.c
+  FROM  "primary" AS p, secondary AS s, recurring.fail AS f1, recurring.fail AS f2
+  WHERE f1.c = p.p
+  AND   f2.c = s.s
+  AND   p.c = s.c
+)
+TABLE fail
+ORDER BY c;
+----
+c1
+c2
+c3
+c4
+c5


### PR DESCRIPTION
There has been lots of debate about recursive CTEs, specifically about their semantics.
More specifically, I'm interested in the semantics when there are multiple recursive references
in the recursive term. For example, consider the following recursive CTE:

```sql
WITH RECURSIVE example_cte AS (
    SELECT 1 AS value
    UNION
    SELECT e1.value + e2.value
    FROM example_cte AS e1,
         example_cte AS e2
    WHERE e1.value < 3 AND e2.value < 2
)
SELECT * FROM example_cte;

┌───────┐
│ value │
│ int32 │
├───────┤
│     1 │
│     2 │
└───────┘
```

The SQL standard straight out forbids such non-linear recursion and does not
define its semantics. However, some systems (like DuckDB) allow it anyway but
stay at the semi-naive evaluation strategy. Datalog folks wish for a different
semantic, where the recursive reference does not yield only the new results from
the previous iteration, but all results computed so far. In case of the above example,
the result would be "incomplete", because in Datalog semantics, we would expect
to see the value "3" as well.

There has been some discussion about this topic in the DuckDB community:

https://github.com/duckdb/duckdb/issues/13974
https://github.com/duckdb/duckdb/issues/13038

Now, what I propose is the following: Instead of picking one of the two semantics (semi-naive vs. all-results-so-far),
why not simply allow both? With the introduction of the `USING KEY` semantics for recursive CTEs
(https://github.com/duckdb/duckdb/pull/12430), we have already established a way to access what's
called the "recurring" table (the one that holds all current key values). This feature was
previously only allowed in combination with `USING KEY`, but with this PR, I simply allow it
in any recursive CTE. Problem solved?

Here is the modified version of the previous example, now using the `RECURRING` table:

```sql
WITH RECURSIVE example_cte AS (
    SELECT 1 AS value
    UNION
    SELECT e1.value + e2.value
    FROM recurring.example_cte AS e1,
         recurring.example_cte AS e2
    WHERE e1.value < 3 AND e2.value < 2
)
SELECT * FROM example_cte;

┌───────┐
│ value │
│ int32 │
├───────┤
│     1 │
│     2 │
│     3 │
└───────┘
```

Now, we can see the value "3" as well, because we are explicitly asking to use
all results computed so far. This way, we can have both semantics in the same system,
and the user can decide which one to use by either referencing the `recurring` table
or not, or any combination thereof. This approach is flexible and does not force
a single semantic onto all users.