### PR TITLE
avro.cmake: don't DONT_LINK

### DIFF
--- a/.github/config/extensions/avro.cmake
+++ b/.github/config/extensions/avro.cmake
@@ -1,6 +1,6 @@
 if (NOT MINGW)
     duckdb_extension_load(avro
-            LOAD_TESTS DONT_LINK
+            LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-avro
             GIT_TAG 93da8a19b41eb577add83d0552c6946a16e97c83
             APPLY_PATCHES


### PR DESCRIPTION
This should restore:
```
USE_MERGED_VCPKG_MANIFEST=1 CORE_EXTENSIONS="httpfs;parquet;avro;iceberg" VCPKG_TOOLCHAIN_PATH=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake GEN=ninja make
./build/release/duckdb
```
to a working state