### PR TITLE
Add support for PlannerExtension with a post_bind_function hook

### DIFF
--- a/src/include/duckdb/main/extension_callback_manager.hpp
+++ b/src/include/duckdb/main/extension_callback_manager.hpp
@@ -21,6 +21,7 @@ class ExtensionCallback;
 class OperatorExtension;
 class OptimizerExtension;
 class ParserExtension;
+class PlannerExtension;
 class StorageExtension;
 struct ExtensionCallbackRegistry;
 
@@ -37,6 +38,7 @@ public:
 	static const ExtensionCallbackManager &Get(const ClientContext &context);
 
 	void Register(ParserExtension extension);
+	void Register(PlannerExtension extension);
 	void Register(OptimizerExtension extension);
 	void Register(shared_ptr<OperatorExtension> extension);
 	void Register(const string &name, shared_ptr<StorageExtension> extension);
@@ -45,6 +47,7 @@ public:
 	ExtensionCallbackIteratorHelper<shared_ptr<OperatorExtension>> OperatorExtensions() const;
 	ExtensionCallbackIteratorHelper<OptimizerExtension> OptimizerExtensions() const;
 	ExtensionCallbackIteratorHelper<ParserExtension> ParserExtensions() const;
+	ExtensionCallbackIteratorHelper<PlannerExtension> PlannerExtensions() const;
 	ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>> ExtensionCallbacks() const;
 	optional_ptr<StorageExtension> FindStorageExtension(const string &name) const;
 	bool HasParserExtensions() const;

--- a/src/include/duckdb/planner/planner_extension.hpp
+++ b/src/include/duckdb/planner/planner_extension.hpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/planner_extension.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/planner/bound_statement.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
+
+namespace duckdb {
+struct DBConfig;
+class Binder;
+class ClientContext;
+
+//! The PlannerExtensionInfo holds static information relevant to the planner extension
+struct PlannerExtensionInfo {
+	virtual ~PlannerExtensionInfo() {
+	}
+};
+
+struct PlannerExtensionInput {
+	ClientContext &context;
+	Binder &binder;
+	optional_ptr<PlannerExtensionInfo> info;
+};
+
+//! The post_bind function runs after binding succeeds, allowing modification of the bound statement
+typedef void (*post_bind_function_t)(PlannerExtensionInput &input, BoundStatement &statement);
+
+class PlannerExtension {
+public:
+	//! The post-bind function of the planner extension.
+	//! Takes a bound statement as input, which it can modify in place.
+	//! This runs after the binder has successfully bound the statement,
+	//! allowing modification of the plan and result types.
+	post_bind_function_t post_bind_function = nullptr;
+
+	//! Additional planner info passed to the functions
+	shared_ptr<PlannerExtensionInfo> planner_info;
+
+	static void Register(DBConfig &config, PlannerExtension extension);
+	static ExtensionCallbackIteratorHelper<PlannerExtension> Iterate(ClientContext &context) {
+		return ExtensionCallbackManager::Get(context).PlannerExtensions();
+	}
+};
+
+} // namespace duckdb

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/parser/statement/multi_statement.hpp"
 #include "duckdb/planner/subquery/flatten_dependent_join.hpp"
 #include "duckdb/planner/operator_extension.hpp"
+#include "duckdb/planner/planner_extension.hpp"
 
 namespace duckdb {
 
@@ -30,6 +31,15 @@ static void CheckTreeDepth(const LogicalOperator &op, idx_t max_depth, idx_t dep
 	}
 	for (auto &child : op.children) {
 		CheckTreeDepth(*child, max_depth, depth + 1);
+	}
+}
+
+static void RunPostBindExtensions(ClientContext &context, Binder &binder, BoundStatement &statement) {
+	for (auto &planner_extension : PlannerExtension::Iterate(context)) {
+		if (planner_extension.post_bind_function) {
+			PlannerExtensionInput input {context, binder, planner_extension.planner_info.get()};
+			planner_extension.post_bind_function(input, statement);
+		}
 	}
 }
 
@@ -46,6 +56,8 @@ void Planner::CreatePlan(SQLStatement &statement) {
 		binder->SetParameters(bound_parameters);
 		auto bound_statement = binder->Bind(statement);
 		profiler.EndPhase();
+
+		RunPostBindExtensions(context, *binder, bound_statement);
 
 		this->names = bound_statement.names;
 		this->types = bound_statement.types;
@@ -64,6 +76,8 @@ void Planner::CreatePlan(SQLStatement &statement) {
 				auto bound_statement =
 				    extension_op->Bind(context, *this->binder, extension_op->operator_info.get(), statement);
 				if (bound_statement.plan != nullptr) {
+					RunPostBindExtensions(context, *this->binder, bound_statement);
+
 					this->names = bound_statement.names;
 					this->types = bound_statement.types;
 					this->plan = std::move(bound_statement.plan);


### PR DESCRIPTION
Some extensions want to make changes to the plan after binding. Right now that's only possible in optimizer hooks. But if the extensions are not actually optimizers than that behaviour is incorrect.

This change allows extensions to register as a `PlannerExtension` and implement a post_bind_function hook.

Related to #20700
Related to #20480
