### PR TITLE
Relax platform check for windows_amd64_mingw

### DIFF
--- a/src/main/extension.cpp
+++ b/src/main/extension.cpp
@@ -80,7 +80,9 @@ string ParsedExtensionMetaData::GetInvalidMetadataError() {
 		throw InternalException("Unknown ABI type for extension: '%s'", extension_abi_metadata);
 	}
 
-	if (engine_platform != platform) {
+	if (engine_platform != platform && !(abi_type == ExtensionABIType::C_STRUCT &&
+	                                     ((engine_platform == "windows_amd64_mingw" && platform == "windows_amd64") ||
+	                                      (engine_platform == "windows_amd64" && platform == "windows_amd64_mingw")))) {
 		if (!result.empty()) {
 			result += " Also, t";
 		} else {


### PR DESCRIPTION
When DuckDB installs/loads an extension it performs platform check that extension is built for the same platform as the engine.

It appeared that for `windows_amd64_mingw` platform this check is overly strict: both `windows_amd64_mingw` (GCC) and `windows_amd64` (MSVC) platforms share the same C ABI and loading DLLs built by different toolchains in the same process is a normal situation on Windows.

This PR relaxes the check allowing to load stable C API extensions between `windows_amd64_mingw` and `windows_amd64`.

Testing: I cannot see an easy way to add an automated check here, tested manually on a MinGW build with the following:

```sql
INSTALL 'http://nightly-extensions.duckdb.org/v1.2.0/windows_amd64/odbc_scanner.duckdb_extension.gz';
LOAD odbc_scanner;
FROM odbc_list_drivers();
```

Fixes: duckdb/odbc-scanner#117