### PR TITLE
Change directory to temp_dir to avoid creating files during testing

### DIFF
--- a/test/sql/extensions/permissions_duckdb_extension.test
+++ b/test/sql/extensions/permissions_duckdb_extension.test
@@ -3,28 +3,28 @@
 # group: [extensions]
 
 statement error
-COPY (SELECT 42) TO 'name.duckdb_extension';
+COPY (SELECT 42) TO '{TEMP_DIR}/name.duckdb_extension';
 ----
-Permission Error: File 'name.duckdb_extension' cannot be opened for writing since files ending with '.duckdb_extension' are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
+<REGEX>:Permission Error.*duckdb_extension.*cannot be opened for writing since files ending with '.duckdb_extension' are reserved for DuckDB extensions.*
 
 statement ok
-COPY (SELECT 42) TO 'name_duckdb_extension';
+COPY (SELECT 42) TO '{TEMP_DIR}/name_duckdb_extension';
 
 statement error
-COPY (SELECT NULL::BLOB) TO 'name.duckdb_extension' (FORMAT BLOB);
+COPY (SELECT NULL::BLOB) TO '{TEMP_DIR}/name.duckdb_extension' (FORMAT BLOB);
 ----
-Permission Error: File 'name.duckdb_extension' cannot be opened for writing since files ending with '.duckdb_extension' are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
+<REGEX>:Permission Error.*duckdb_extension.*cannot be opened for writing since files ending with '.duckdb_extension' are reserved for DuckDB extensions.*
 
 statement ok
-COPY (SELECT NULL::BLOB) TO 'name.duckdb_extensionz' (FORMAT BLOB);
+COPY (SELECT NULL::BLOB) TO '{TEMP_DIR}/name.duckdb_extensionz' (FORMAT BLOB);
 
 statement error
-ATTACH 'my_name.duckdb_extension'
+ATTACH '{TEMP_DIR}/my_name.duckdb_extension'
 ----
-Permission Error: File 'my_name.duckdb_extension' cannot be opened for writing since files ending with '.duckdb_extension' are reserved for DuckDB extensions, and these can only be installed through the INSTALL command
+<REGEX>:Permission Error.*duckdb_extension.*cannot be opened for writing since files ending with '.duckdb_extension' are reserved for DuckDB extensions.*
 
 statement ok
-ATTACH 'my_name_duckdb_extension'
+ATTACH '{TEMP_DIR}/my_name_duckdb_extension'
 
 statement ok
 FROM read_blob('build/*/repository/*/*/parquet.duckdb_extension');


### PR DESCRIPTION
I noticed that some files were being created in the working directory when testing. Writing them to `{TEMP_DIR}` to avoid this issue.
@carlopi not sure if you were aware, I couldn't find an issue about these files. 