### PR TITLE
Report error location on ambiguous column reference error

### DIFF
--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -46,7 +46,8 @@ public:
 public:
 	//! Given a column name, find the matching table it belongs to. Throws an
 	//! exception if no table has a column of the given name.
-	optional_ptr<Binding> GetMatchingBinding(const string &column_name);
+	optional_ptr<Binding> GetMatchingBinding(const string &column_name,
+	                                         QueryErrorContext context = QueryErrorContext());
 	//! Like GetMatchingBinding, but instead of throwing an error if multiple tables have the same binding it will
 	//! return a list of all the matching ones
 	vector<reference<Binding>> GetMatchingBindings(const string &column_name);

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -116,7 +116,8 @@ public:
 	BindResult BindQualifiedColumnName(ColumnRefExpression &colref, const string &table_name);
 
 	//! Returns a qualified column reference from a column name
-	unique_ptr<ParsedExpression> QualifyColumnName(const string &column_name, ErrorData &error);
+	unique_ptr<ParsedExpression> QualifyColumnName(const ParsedExpression &expr, const string &column_name,
+	                                               ErrorData &error);
 	//! Returns a qualified column reference from a column reference with column_names.size() > 2
 	unique_ptr<ParsedExpression> QualifyColumnNameWithManyDots(ColumnRefExpression &col_ref, ErrorData &error);
 	//! Returns a qualified column reference from a column reference

--- a/test/sql/binder/column_ref_as_alias.test
+++ b/test/sql/binder/column_ref_as_alias.test
@@ -32,3 +32,18 @@ group by item_id;
 ----
 ss_items.item_id
 
+# check that error location is reported
+statement error
+select item_id
+from ss_items,cs_items
+where ss_items.item_id = cs_items.item_id;
+----
+^
+
+statement error
+select ss_items.item_id, cs_items.item_id
+from ss_items,cs_items
+where ss_items.item_id = cs_items.item_id
+order by item_id
+----
+^


### PR DESCRIPTION
Currently the ambiguous column reference error message does not specify where in the query this occurs - this PR modifies it so that it does, e.g.:


```sql
D select item_id
  from ss_items,cs_items
  where ss_items.item_id = cs_items.item_id;;

Binder Error:
Ambiguous reference to column name "item_id" (use: "ss_items.item_id" or "cs_items.item_id")

LINE 1: select item_id
               ^
```