### PR TITLE
Avoid triggering optimistic writes during WAL replay in read-only mode

### DIFF
--- a/src/storage/optimistic_data_writer.cpp
+++ b/src/storage/optimistic_data_writer.cpp
@@ -23,7 +23,9 @@ OptimisticDataWriter::~OptimisticDataWriter() {
 
 bool OptimisticDataWriter::PrepareWrite() {
 	// check if we should pre-emptively write the table to disk
-	if (table.IsTemporary() || StorageManager::Get(table.GetAttached()).InMemory()) {
+	auto &attached = table.GetAttached();
+	auto &storage_manager = StorageManager::Get(attached);
+	if (table.IsTemporary() || storage_manager.InMemory() || attached.IsReadOnly()) {
 		return false;
 	}
 	// we should! write the second-to-last row group to disk

--- a/test/sql/storage/test_read_only_wal_replay.test
+++ b/test/sql/storage/test_read_only_wal_replay.test
@@ -1,0 +1,27 @@
+# name: test/sql/storage/test_read_only_wal_replay.test
+# description: Test read-only WAL replay
+# group: [storage]
+
+statement ok
+SET checkpoint_threshold='1TB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+ATTACH '__TEST_DIR__/read_only_wal_replay.db' AS db;
+
+statement ok
+CREATE TABLE db.my_tbl(i INTEGER PRIMARY KEY);
+
+statement ok
+INSERT INTO db.my_tbl FROM range(200_000);
+
+statement ok
+DETACH db;
+
+statement ok
+ATTACH '__TEST_DIR__/read_only_wal_replay.db' AS db (READ_ONLY)
+
+statement ok
+DETACH db


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/5983