### PR TITLE
Use std::function for progress_bar_display_create_func_t

### DIFF
--- a/src/include/duckdb/common/progress_bar/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar/progress_bar.hpp
@@ -17,7 +17,7 @@
 namespace duckdb {
 
 struct ClientConfig;
-typedef unique_ptr<ProgressBarDisplay> (*progress_bar_display_create_func_t)();
+typedef std::function<unique_ptr<ProgressBarDisplay>()> progress_bar_display_create_func_t;
 
 struct QueryProgress {
 	friend class ProgressBar;


### PR DESCRIPTION
When creating a custom progress bar you might want to pass some variables to the constructor of your custom progress bar. Currently this is not possible as it uses a C style function pointer without any arguments. Changing this to a std::function allows one to pass variables to the constructor, without requiring a change for existing progress bars.