### PR TITLE
chore: add extension_name to duckdb_functions

### DIFF
--- a/src/include/duckdb/catalog/catalog_entry/function_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/function_entry.hpp
@@ -20,11 +20,13 @@ public:
 	    : StandardEntry(type, schema, catalog, info.name) {
 		descriptions = std::move(info.descriptions);
 		alias_of = std::move(info.alias_of);
+		extension_name = std::move(info.extension_name);
 		this->dependencies = info.dependencies;
 		this->internal = info.internal;
 	}
 
 	string alias_of;
+	string extension_name;
 	vector<FunctionDescription> descriptions;
 };
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/create_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_function_info.hpp
@@ -34,6 +34,8 @@ struct CreateFunctionInfo : public CreateInfo {
 	string alias_of;
 	//! Function description
 	vector<FunctionDescription> descriptions;
+	//! Extension that registered this function (empty for builtins/user-defined)
+	string extension_name;
 
 	DUCKDB_API void CopyFunctionProperties(CreateFunctionInfo &other) const;
 };

--- a/src/main/extension/extension_loader.cpp
+++ b/src/main/extension/extension_loader.cpp
@@ -56,6 +56,7 @@ void ExtensionLoader::RegisterFunction(ScalarFunctionSet function) {
 }
 
 void ExtensionLoader::RegisterFunction(CreateScalarFunctionInfo function) {
+	function.extension_name = extension_name;
 	D_ASSERT(!function.functions.name.empty());
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
@@ -75,6 +76,7 @@ void ExtensionLoader::RegisterFunction(AggregateFunctionSet function) {
 }
 
 void ExtensionLoader::RegisterFunction(CreateAggregateFunctionInfo function) {
+	function.extension_name = extension_name;
 	D_ASSERT(!function.functions.name.empty());
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
@@ -101,6 +103,7 @@ void ExtensionLoader::RegisterFunction(TableFunctionSet function) {
 }
 
 void ExtensionLoader::RegisterFunction(CreateTableFunctionInfo info) {
+	info.extension_name = extension_name;
 	D_ASSERT(!info.functions.name.empty());
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
@@ -118,6 +121,7 @@ void ExtensionLoader::RegisterFunction(PragmaFunctionSet function) {
 	D_ASSERT(!function.name.empty());
 	auto function_name = function.name;
 	CreatePragmaFunctionInfo info(std::move(function_name), std::move(function));
+	info.extension_name = extension_name;
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
 	system_catalog.CreatePragmaFunction(data, info);
@@ -131,6 +135,7 @@ void ExtensionLoader::RegisterFunction(CopyFunction function) {
 }
 
 void ExtensionLoader::RegisterFunction(CreateMacroInfo &info) {
+	info.extension_name = extension_name;
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
 	system_catalog.CreateFunction(data, info);
@@ -144,6 +149,7 @@ void ExtensionLoader::RegisterCollation(CreateCollationInfo &info) {
 
 	// Also register as a function for serialisation
 	CreateScalarFunctionInfo finfo(info.function);
+	finfo.extension_name = extension_name;
 	finfo.on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
 	system_catalog.CreateFunction(data, finfo);
 }

--- a/src/parser/parsed_data/create_function_info.cpp
+++ b/src/parser/parsed_data/create_function_info.cpp
@@ -13,6 +13,7 @@ void CreateFunctionInfo::CopyFunctionProperties(CreateFunctionInfo &other) const
 	other.name = name;
 	other.alias_of = alias_of;
 	other.descriptions = descriptions;
+	other.extension_name = extension_name;
 }
 
 } // namespace duckdb


### PR DESCRIPTION
**tl;dr**: when running the table function `from duckdb_functions();` there's a new column `extension_name` that specifies the extension; i.e., core_functions, parquet, shell, etc.

It's often helpful to reference which functions are at your disposal from different extensions. This provides a means of quickly differentiating where functions are coming from.