### PR TITLE
PhysicalEmptyResult should support partitioning

### DIFF
--- a/src/include/duckdb/execution/operator/scan/physical_empty_result.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_empty_result.hpp
@@ -28,5 +28,9 @@ public:
 	bool IsSource() const override {
 		return true;
 	}
+
+	bool SupportsPartitioning(const OperatorPartitionInfo &partition_info) const override {
+		return true;
+	}
 };
 } // namespace duckdb


### PR DESCRIPTION
PhysicalEmptyResult should be a PhysicalOperator which supports partitioning. 

The reason for this change is the following test case:

```
CREATE TABLE t1 (id INT, col1 INT, col2 VARCHAR);
CREATE TABLE t2 (id INT, col1 INT, col2 VARCHAR);
insert into t1 select i, random() * 10000, md5(cast(i as varchar)) from generate_series(99999999) s(i);
insert into t2 select i + 100000000, random() * 10000, md5(cast(i as varchar)) from generate_series(99999999) s(i);
```

The query 1:
```
select * from (select * from t1) WHERE id < 100000000 and col1 = 1;
```

The query 2:
```
select * from (select * from t1 union all select * from t2) WHERE id < 100000000 and col1 = 1;
```

Query 1 and Query 2 shouldn't have a significant performance difference, because `select * from t2` should be optimized to `EmptyResult`, but in reality, their performance differs by a factor of ten. The reason is that PhysicalEmptyResult doesn't support UseBatchIndex. So, the ResultCollector of this query will be PhysicalMaterializedCollector which uses single thread. 
No chunks will be fetched from PhysicalEmptyResult, so I think it's safe to make PhysicalEmptyResult support partitioning.