### PR TITLE
Bump httpfs: remove windows test to be investigated, and compilation & CMake fixes

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG fdf3d6fccdfd8b9633b59026f7885dda8dc9c444
+    GIT_TAG 058cc2dd691249562e9ded2e769e3e006fcb5a47
 )


### PR DESCRIPTION
Built on top of https://github.com/duckdb/duckdb/pull/20735, that adds support for bulk deletes, with some extra commits that should unlock https://github.com/duckdb/duckdb/pull/20734.

Merging both https://github.com/duckdb/duckdb/pull/20734 and this PR should restore `spatial` and `ducklake` with a green CI.