### PR TITLE
Add banned symbol check, that checks for banned C(++) symbols in a CI run

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -205,3 +205,7 @@ jobs:
     - name: Symbol Leakage Test
       shell: bash
       run: python3 scripts/exported_symbols_check.py build/release/src/libduckdb*.so
+
+    - name: Banned Symbol Check
+      shell: bash
+      run: python3 scripts/banned_symbols_check.py --directory build/release/src

--- a/scripts/banned_symbols_check.py
+++ b/scripts/banned_symbols_check.py
@@ -5,60 +5,55 @@ import argparse
 
 
 banned_symbols = [
-  "std::basic_ofstream",
-  "std::basic_ifstream",
-  "std::basic_fstream",
+    "std::basic_ofstream",
+    "std::basic_ifstream",
+    "std::basic_fstream",
 ]
-parser = argparse.ArgumentParser(
-  description="Check object files for banned symbols"
-)
+parser = argparse.ArgumentParser(description="Check object files for banned symbols")
 parser.add_argument(
-  "--directory",
-  type=Path,
-  action='store',
-  help="Directory to search for .o files",
-  default='build/release/src'
+    "--directory", type=Path, action='store', help="Directory to search for .o files", default='build/release/src'
 )
 args = parser.parse_args()
 
 if not args.directory.is_dir():
-  sys.exit(f"Error: '{args.directory}' is not a directory")
+    sys.exit(f"Error: '{args.directory}' is not a directory")
+
 
 def check_object_file(path: Path) -> list[tuple[str, str]]:
-  global banned_symbols
-  """Run nm -C on an object file and return any banned symbols found."""
-  try:
-      result = subprocess.run(
-          ["nm", "-C", str(path)],
-          capture_output=True,
-          text=True,
-      )
-  except FileNotFoundError:
-      sys.exit("Error: 'nm' command not found")
+    global banned_symbols
+    """Run nm -C on an object file and return any banned symbols found."""
+    try:
+        result = subprocess.run(
+            ["nm", "-C", str(path)],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        sys.exit("Error: 'nm' command not found")
 
-  violations = []
-  for line in result.stdout.splitlines():
-      for banned in banned_symbols:
-          if banned in line:
-              violations.append((banned, line.strip()))
-  return violations
+    violations = []
+    for line in result.stdout.splitlines():
+        for banned in banned_symbols:
+            if banned in line:
+                violations.append((banned, line.strip()))
+    return violations
 
 
 all_violations = {}
 
 for obj_file in args.directory.rglob("*.o"):
-  print(obj_file)
-  violations = check_object_file(obj_file)
-  if violations:
-      all_violations[obj_file] = violations
+    print(obj_file)
+    violations = check_object_file(obj_file)
+    if violations:
+        all_violations[obj_file] = violations
 
 if all_violations:
-  print("ERROR: Banned symbols found:\n")
-  for path, violations in all_violations.items():
-      print(f"{path}:")
-      for symbol, line in violations:
-          print(f"  [{symbol}] {line}")
-      print()
-  sys.exit(1)
+    print("ERROR: Banned symbols found:\n")
+    for path, violations in all_violations.items():
+        print(f"{path}:")
+        for symbol, line in violations:
+            print(f"  [{symbol}] {line}")
+        print()
+    sys.exit(1)
 
 print("No banned symbols found.")

--- a/scripts/banned_symbols_check.py
+++ b/scripts/banned_symbols_check.py
@@ -1,0 +1,64 @@
+import subprocess
+import sys
+from pathlib import Path
+import argparse
+
+
+banned_symbols = [
+  "std::basic_ofstream",
+  "std::basic_ifstream",
+  "std::basic_fstream",
+]
+parser = argparse.ArgumentParser(
+  description="Check object files for banned symbols"
+)
+parser.add_argument(
+  "--directory",
+  type=Path,
+  action='store',
+  help="Directory to search for .o files",
+  default='build/release/src'
+)
+args = parser.parse_args()
+
+if not args.directory.is_dir():
+  sys.exit(f"Error: '{args.directory}' is not a directory")
+
+def check_object_file(path: Path) -> list[tuple[str, str]]:
+  global banned_symbols
+  """Run nm -C on an object file and return any banned symbols found."""
+  try:
+      result = subprocess.run(
+          ["nm", "-C", str(path)],
+          capture_output=True,
+          text=True,
+      )
+  except FileNotFoundError:
+      sys.exit("Error: 'nm' command not found")
+
+  violations = []
+  for line in result.stdout.splitlines():
+      for banned in banned_symbols:
+          if banned in line:
+              violations.append((banned, line.strip()))
+  return violations
+
+
+all_violations = {}
+
+for obj_file in args.directory.rglob("*.o"):
+  print(obj_file)
+  violations = check_object_file(obj_file)
+  if violations:
+      all_violations[obj_file] = violations
+
+if all_violations:
+  print("ERROR: Banned symbols found:\n")
+  for path, violations in all_violations.items():
+      print(f"{path}:")
+      for symbol, line in violations:
+          print(f"  [{symbol}] {line}")
+      print()
+  sys.exit(1)
+
+print("No banned symbols found.")


### PR DESCRIPTION
This PR introduces the `banned_symbols_check.py` script and CI run that allows us to ban certain STL functions / classes from being used. It looks through all of the object files and checks if any symbols in the ban list are present - and reports an error if there are. This is currently used to ban `ofstream` and `ifstream`. The idea is that we should never use these classes to read / write files as they circumvent our FileSystem class, which then also circumvents our controls on file access (e.g. `enable_external_access`, etc). We can expand on this list in the future.