### PR TITLE
Fix JSON file_extension option

### DIFF
--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -55,6 +55,9 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 				csv_copy_options["suffix"] = {"\n]\n"};
 				csv_copy_options["new_line"] = {",\n\t"};
 			}
+		} else if (loption == "file_extension") {
+			// Since we set the file extension to "json" above, we need to override it
+			csv_copy_options["file_extension"] = {StringValue::Get(kv.second.back())};
 		} else if (SUPPORTED_BASE_OPTIONS.find(loption) != SUPPORTED_BASE_OPTIONS.end()) {
 			// We support these base options
 			csv_copy_options.insert(kv);

--- a/test/sql/json/test_json_copy.test_slow
+++ b/test/sql/json/test_json_copy.test_slow
@@ -172,6 +172,22 @@ select * from '{TEMP_DIR}/out.json'
 ----
 42	43
 
+# test issue #20739
+statement ok
+copy (
+    select * from values (1) t1(key)
+) to '{TEMP_DIR}/jsonl_files' (
+    format json,
+    file_size_bytes 100,
+    file_extension 'jsonl'
+);
+
+# the copy statement should have generated files with the 'jsonl' extension
+query I
+select key from '{TEMP_DIR}/jsonl_files/data_0.jsonl';
+----
+1
+
 statement ok
 create table conclusions (conclusion varchar)
 


### PR DESCRIPTION
Resolves https://github.com/duckdb/duckdb/issues/20739

This PR adds support for overriding the `FILE_EXTENSION` option in a `COPY...TO` statement with `FORMAT JSON`.