### PR TITLE
Fix optimizer crash in JDBC by ensuring active_query is set during prepare

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -83,6 +83,26 @@ private:
 	BaseQueryResult *open_result = nullptr;
 };
 
+//! RAII wrapper that ensures the active query is reset if an exception occurs during preparation
+struct ActiveQueryGuard {
+	unique_ptr<ActiveQueryContext> &active_query;
+	bool set_active_query;
+
+	ActiveQueryGuard(unique_ptr<ActiveQueryContext> &active_query_p, const string &query)
+	    : active_query(active_query_p), set_active_query(false) {
+		if (!active_query) {
+			active_query = make_uniq<ActiveQueryContext>();
+			set_active_query = true;
+			active_query->query = query;
+		}
+	}
+	~ActiveQueryGuard() {
+		if (set_active_query) {
+			active_query.reset();
+		}
+	}
+};
+
 #ifdef DEBUG
 struct DebugClientContextState : public ClientContextState {
 	~DebugClientContextState() override {
@@ -722,7 +742,11 @@ unique_ptr<PreparedStatement> ClientContext::PrepareInternal(ClientContextLock &
 	shared_ptr<PreparedStatementData> prepared_data;
 	auto unbound_statement = statement->Copy();
 	RunFunctionInTransactionInternal(
-	    lock, [&]() { prepared_data = CreatePreparedStatement(lock, statement_query, std::move(statement), {}); },
+	    lock,
+	    [&]() {
+		    ActiveQueryGuard guard(active_query, statement_query);
+		    prepared_data = CreatePreparedStatement(lock, statement_query, std::move(statement), {});
+	    },
 	    false);
 	prepared_data->unbound_statement = std::move(unbound_statement);
 	return make_uniq<PreparedStatement>(shared_from_this(), std::move(prepared_data), std::move(statement_query),


### PR DESCRIPTION
This PR fixes a crash/NPE encountered when using optimizer extensions with the JDBC driver.

Related to https://github.com/duckdb/duckdb-java/issues/549

### Issue
When `Connection.prepareStatement()` is called, `ClientContext::PrepareInternal` is executed. Previously, `active_query` was not set in the `ClientContext` during this phase. If an optimizer extension (hooked into `PreparedStatement` creation) attempted to access `context.GetCurrentQuery()`, it would dereference a null pointer (or hit an assertion in debug builds), causing a crash.
    
### Solution
The `ClientContext` requires an initialized `active_query` state for the optimizer to function correctly (e.g., to access the query string). This state was previously missing during the JDBC prepare phase (`PrepareInternal`), which caused the crash.

We now correctly initialize `active_query` within `PrepareInternal` using a new RAII helper struct `ActiveQueryGuard`. This ensures the context is fully populated for the duration of the preparation, satisfying the requirements of optimizer extensions.

- The `ActiveQueryGuard` sets `active_query` upon initialization.
- It guarantees `active_query` is reset to `nullptr` when the scope exits, preserving `ClientContext` invariants.
- The implementation is exception-safe: even if an exception occurs during statement preparation or memory allocation, the destructor ensures proper cleanup.