### PR TITLE
Refactor LruCache to have a generic Payload object

### DIFF
--- a/src/include/duckdb/common/lru_cache.hpp
+++ b/src/include/duckdb/common/lru_cache.hpp
@@ -21,9 +21,15 @@
 
 namespace duckdb {
 
+struct DefaultPayload {
+	idx_t GetWeight() const {
+		return 1;
+	}
+};
+
 // A LRU cache implementation, whose value could be accessed in a shared manner with shared pointer.
 // Notice, it's not thread-safe.
-template <typename Key, typename Val, typename Payload, typename KeyHash = std::hash<Key>,
+template <typename Key, typename Val, typename Payload = DefaultPayload, typename KeyHash = std::hash<Key>,
           typename KeyEqual = std::equal_to<Key>>
 class SharedLruCache {
 public:

--- a/src/include/duckdb/common/lru_cache.hpp
+++ b/src/include/duckdb/common/lru_cache.hpp
@@ -103,9 +103,9 @@ public:
 
 	// Evict entries based on their access, until we've freed at least the target number of bytes or there's no entries
 	// in the cache. Return number of bytes freed.
-	idx_t EvictToReduceMemory(idx_t target_bytes) {
+	idx_t EvictToReduceAtLeast(idx_t target_weight) {
 		idx_t freed = 0;
-		while (!lru_list.empty() && freed < target_bytes) {
+		while (!lru_list.empty() && freed < target_weight) {
 			const auto &stale_key = lru_list.back();
 			auto stale_it = entry_map.find(stale_key);
 			D_ASSERT(stale_it != entry_map.end());
@@ -115,10 +115,10 @@ public:
 		return freed;
 	}
 
-	idx_t MaxMemory() const {
+	idx_t Capacity() const {
 		return max_total_weight;
 	}
-	idx_t CurrentMemory() const {
+	idx_t CurrentTotalWeight() const {
 		return current_total_weight;
 	}
 	size_t Size() const {

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -19,6 +19,18 @@
 
 namespace duckdb {
 
+struct BufferPoolPayload {
+	BufferPoolPayload(unique_ptr<TempBufferPoolReservation> &&res) : reservation(std::move(res)) {
+	}
+	~BufferPoolPayload() {
+		reservation->Resize(0);
+	}
+	idx_t GetWeight() const {
+		return reservation->size;
+	}
+	unique_ptr<BufferPoolReservation> reservation;
+};
+
 // Forward declaration.
 class BufferPool;
 
@@ -106,7 +118,7 @@ public:
 		auto reservation =
 		    make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, estimated_memory.GetIndex());
 		idx_t reservation_size = reservation->size;
-		lru_cache.Put(key, value, std::move(reservation), reservation_size);
+		lru_cache.Put(key, value, std::move(reservation));
 		return value;
 	}
 
@@ -126,7 +138,7 @@ public:
 		auto reservation =
 		    make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, estimated_memory.GetIndex());
 		auto reservation_size = reservation->size;
-		lru_cache.Put(std::move(key), std::move(value), std::move(reservation), reservation_size);
+		lru_cache.Put(std::move(key), std::move(value), std::move(reservation));
 	}
 
 	void Delete(const string &key) {
@@ -166,7 +178,8 @@ public:
 private:
 	mutable mutex lock_mutex;
 	//! LRU cache for evictable entries
-	SharedLruCache<string, ObjectCacheEntry, BufferPoolReservation, CleanupBufferPool> lru_cache;
+
+	SharedLruCache<string, ObjectCacheEntry, duckdb::BufferPoolPayload> lru_cache;
 	//! Separate storage for non-evictable entries (i.e., encryption keys)
 	unordered_map<string, shared_ptr<ObjectCacheEntry>> non_evictable_entries;
 	//! Used to create buffer pool reservation on entries creation.

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -117,7 +117,6 @@ public:
 
 		auto reservation =
 		    make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, estimated_memory.GetIndex());
-		idx_t reservation_size = reservation->size;
 		lru_cache.Put(key, value, std::move(reservation));
 		return value;
 	}
@@ -137,7 +136,6 @@ public:
 
 		auto reservation =
 		    make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, estimated_memory.GetIndex());
-		auto reservation_size = reservation->size;
 		lru_cache.Put(std::move(key), std::move(value), std::move(reservation));
 	}
 

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -153,11 +153,11 @@ public:
 
 	idx_t GetMaxMemory() const {
 		const lock_guard<mutex> lock(lock_mutex);
-		return lru_cache.MaxMemory();
+		return lru_cache.Capacity();
 	}
 	idx_t GetCurrentMemory() const {
 		const lock_guard<mutex> lock(lock_mutex);
-		return lru_cache.CurrentMemory();
+		return lru_cache.CurrentTotalWeight();
 	}
 	size_t GetEntryCount() const {
 		const lock_guard<mutex> lock(lock_mutex);
@@ -170,7 +170,7 @@ public:
 
 	idx_t EvictToReduceMemory(idx_t target_bytes) {
 		const lock_guard<mutex> lock(lock_mutex);
-		return lru_cache.EvictToReduceMemory(target_bytes);
+		return lru_cache.EvictToReduceAtLeast(target_bytes);
 	}
 
 private:

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -20,7 +20,7 @@
 namespace duckdb {
 
 struct BufferPoolPayload {
-	BufferPoolPayload(unique_ptr<TempBufferPoolReservation> &&res) : reservation(std::move(res)) {
+	explicit BufferPoolPayload(unique_ptr<TempBufferPoolReservation> &&res) : reservation(std::move(res)) {
 	}
 	~BufferPoolPayload() {
 		reservation->Resize(0);

--- a/test/common/test_lru_cache.cpp
+++ b/test/common/test_lru_cache.cpp
@@ -27,13 +27,12 @@ TEST_CASE("LRU Cache Basic Operations", "[lru_cache]") {
 	auto &context = *con.context;
 	auto &buffer_pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
 
-	SharedLruCache<string, TestValue, BufferPoolReservation, CleanupBufferPool> cache(1000);
+	SharedLruCache<string, TestValue, BufferPoolPayload> cache(1000);
 
 	SECTION("Put and Get") {
 		auto val1 = make_shared_ptr<TestValue>(42, 100);
 		auto reservation = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/100);
-		auto reservation_size = reservation->size;
-		cache.Put("key1", val1, std::move(reservation), reservation_size);
+		cache.Put("key1", val1, std::move(reservation));
 
 		auto result = cache.Get("key1");
 		REQUIRE(result != nullptr);
@@ -52,12 +51,10 @@ TEST_CASE("LRU Cache Basic Operations", "[lru_cache]") {
 		auto val2 = make_shared_ptr<TestValue>(2, 150);
 
 		auto reservation1 = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/100);
-		auto reservation1_size = reservation1->size;
-		cache.Put("key1", val1, std::move(reservation1), reservation1_size);
+		cache.Put("key1", val1, std::move(reservation1));
 
 		auto reservation2 = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/150);
-		auto reservation2_size = reservation2->size;
-		cache.Put("key1", val2, std::move(reservation2), reservation2_size);
+		cache.Put("key1", val2, std::move(reservation2));
 
 		auto result = cache.Get("key1");
 		REQUIRE(result != nullptr);
@@ -68,8 +65,7 @@ TEST_CASE("LRU Cache Basic Operations", "[lru_cache]") {
 	SECTION("Delete") {
 		auto val1 = make_shared_ptr<TestValue>(42, 100);
 		auto reservation = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/100);
-		auto reservation_size = reservation->size;
-		cache.Put("key1", val1, std::move(reservation), reservation_size);
+		cache.Put("key1", val1, std::move(reservation));
 
 		bool deleted = cache.Delete("key1");
 		REQUIRE(deleted == true);
@@ -89,23 +85,20 @@ TEST_CASE("LRU Cache Eviction", "[lru_cache]") {
 	auto &buffer_pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
 
 	SECTION("Evict LRU when exceeding max weight") {
-		SharedLruCache<string, TestValue, BufferPoolReservation, CleanupBufferPool> cache(500);
+		SharedLruCache<string, TestValue, BufferPoolPayload> cache(500);
 
 		auto val1 = make_shared_ptr<TestValue>(1, 200);
 		auto val2 = make_shared_ptr<TestValue>(2, 200);
 		auto val3 = make_shared_ptr<TestValue>(3, 200);
 
 		auto reservation1 = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/200);
-		auto reservation1_size = reservation1->size;
-		cache.Put("key1", val1, std::move(reservation1), reservation1_size);
+		cache.Put("key1", val1, std::move(reservation1));
 
 		auto reservation2 = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/200);
-		auto reservation2_size = reservation2->size;
-		cache.Put("key2", val2, std::move(reservation2), reservation2_size);
+		cache.Put("key2", val2, std::move(reservation2));
 
 		auto reservation3 = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/200);
-		auto reservation3_size = reservation3->size;
-		cache.Put("key3", val3, std::move(reservation3), reservation3_size);
+		cache.Put("key3", val3, std::move(reservation3));
 
 		REQUIRE(cache.Get("key1") == nullptr);
 		REQUIRE(cache.Get("key2") != nullptr);
@@ -115,7 +108,7 @@ TEST_CASE("LRU Cache Eviction", "[lru_cache]") {
 	}
 
 	SECTION("LRU ordering") {
-		SharedLruCache<string, TestValue, BufferPoolReservation, CleanupBufferPool> cache(300);
+		SharedLruCache<string, TestValue, BufferPoolPayload> cache(300);
 
 		auto val1 = make_shared_ptr<TestValue>(1, 100);
 		auto val2 = make_shared_ptr<TestValue>(2, 100);
@@ -123,22 +116,18 @@ TEST_CASE("LRU Cache Eviction", "[lru_cache]") {
 		auto val4 = make_shared_ptr<TestValue>(4, 100);
 
 		auto reservation1 = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/100);
-		auto reservation1_size = reservation1->size;
-		cache.Put("key1", val1, std::move(reservation1), reservation1_size);
+		cache.Put("key1", val1, std::move(reservation1));
 
 		auto reservation2 = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/100);
-		auto reservation2_size = reservation2->size;
-		cache.Put("key2", val2, std::move(reservation2), reservation2_size);
+		cache.Put("key2", val2, std::move(reservation2));
 
 		auto reservation3 = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/100);
-		auto reservation3_size = reservation3->size;
-		cache.Put("key3", val3, std::move(reservation3), reservation3_size);
+		cache.Put("key3", val3, std::move(reservation3));
 
 		cache.Get("key1");
 
 		auto reservation4 = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/100);
-		auto reservation4_size = reservation4->size;
-		cache.Put("key4", val4, std::move(reservation4), reservation4_size);
+		cache.Put("key4", val4, std::move(reservation4));
 
 		REQUIRE(cache.Get("key1") != nullptr);
 		REQUIRE(cache.Get("key2") == nullptr);
@@ -153,13 +142,12 @@ TEST_CASE("LRU Cache Unlimited Memory", "[lru_cache]") {
 	auto &context = *con.context;
 	auto &buffer_pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
 
-	SharedLruCache<string, TestValue, BufferPoolReservation, CleanupBufferPool> cache(0);
+	SharedLruCache<string, TestValue, BufferPoolPayload> cache(0);
 
 	for (int idx = 0; idx < 100; ++idx) {
 		auto val = make_shared_ptr<TestValue>(idx, 100);
 		auto reservation = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/100);
-		auto reservation_size = reservation->size;
-		cache.Put("key" + std::to_string(idx), val, std::move(reservation), reservation_size);
+		cache.Put("key" + std::to_string(idx), val, std::move(reservation));
 	}
 
 	REQUIRE(cache.Size() == 100);
@@ -171,18 +159,16 @@ TEST_CASE("LRU Cache Clear", "[lru_cache]") {
 	auto &context = *con.context;
 	auto &buffer_pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
 
-	SharedLruCache<string, TestValue, BufferPoolReservation, CleanupBufferPool> cache(1000);
+	SharedLruCache<string, TestValue, BufferPoolPayload> cache(1000);
 
 	auto val1 = make_shared_ptr<TestValue>(1, 100);
 	auto val2 = make_shared_ptr<TestValue>(2, 100);
 
 	auto reservation1 = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/100);
-	auto reservation1_size = reservation1->size;
-	cache.Put("key1", val1, std::move(reservation1), reservation1_size);
+	cache.Put("key1", val1, std::move(reservation1));
 
 	auto reservation2 = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, /*size=*/100);
-	auto reservation2_size = reservation2->size;
-	cache.Put("key2", val2, std::move(reservation2), reservation2_size);
+	cache.Put("key2", val2, std::move(reservation2));
 
 	cache.Clear();
 
@@ -199,15 +185,14 @@ TEST_CASE("LRU Cache Evict To Reduce Memory", "[lru_cache]") {
 	auto &buffer_pool = DatabaseInstance::GetDatabase(context).GetBufferPool();
 
 	// Set max memory to a large value, which exceeds all entries emplaced.
-	SharedLruCache<string, TestValue, BufferPoolReservation, CleanupBufferPool> cache(20000);
+	SharedLruCache<string, TestValue, BufferPoolPayload> cache(20000);
 
 	// Put a few entries, and check memory consumption.
 	constexpr idx_t obj_size = 1000;
 	for (int idx = 0; idx < 10; ++idx) {
 		auto val = make_shared_ptr<TestValue>(idx, obj_size);
 		auto reservation = make_uniq<TempBufferPoolReservation>(MemoryTag::OBJECT_CACHE, buffer_pool, obj_size);
-		auto reservation_size = reservation->size;
-		cache.Put(StringUtil::Format("key%d", idx), val, std::move(reservation), reservation_size);
+		cache.Put(StringUtil::Format("key%d", idx), val, std::move(reservation));
 	}
 	REQUIRE(cache.Size() == 10);
 	REQUIRE(cache.CurrentMemory() == 10 * obj_size);


### PR DESCRIPTION
This prepares LruCache to be used in more places, sharing the same (templated) implementation in a more agnostic way