### PR TITLE
Fix escape handling in AddEscapes function

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Please also refer to our [Build Guide](https://duckdb.org/docs/stable/dev/buildi
 ## Support
 
 See the [Support Options](https://duckdblabs.com/support/) page.
+ 

--- a/src/common/csv_writer.cpp
+++ b/src/common/csv_writer.cpp
@@ -228,25 +228,26 @@ void CSVWriter::WriteQuoteOrEscape(WriteStream &writer, char quote_or_escape) {
 }
 
 string CSVWriter::AddEscapes(char to_be_escaped, char escape, const string &val) {
-	idx_t i = 0;
-	string new_val = "";
-	idx_t found = val.find(to_be_escaped);
+    if (escape == '\0') {
+        return val;
+    }
+    idx_t i = 0;
+    string new_val = "";
+    idx_t found = val.find(to_be_escaped);
 
-	while (found != string::npos) {
-		while (i < found) {
-			new_val += val[i];
-			i++;
-		}
-		if (escape != '\0') {
-			new_val += escape;
-			found = val.find(to_be_escaped, found + 1);
-		}
-	}
-	while (i < val.length()) {
-		new_val += val[i];
-		i++;
-	}
-	return new_val;
+    while (found != string::npos) {
+        while (i < found) {
+            new_val += val[i];
+            i++;
+        }
+        new_val += escape;
+        found = val.find(to_be_escaped, found + 1);
+    }
+    while (i < val.length()) {
+        new_val += val[i];
+        i++;
+    }
+    return new_val;
 }
 
 bool CSVWriter::RequiresQuotes(const char *str, idx_t len, const string &null_str,

--- a/src/common/csv_writer.cpp
+++ b/src/common/csv_writer.cpp
@@ -228,26 +228,26 @@ void CSVWriter::WriteQuoteOrEscape(WriteStream &writer, char quote_or_escape) {
 }
 
 string CSVWriter::AddEscapes(char to_be_escaped, char escape, const string &val) {
-    if (escape == '\0') {
-        return val;
-    }
-    idx_t i = 0;
-    string new_val = "";
-    idx_t found = val.find(to_be_escaped);
+	if (escape == '\0') {
+		return val;
+	}
+	idx_t i = 0;
+	string new_val = "";
+	idx_t found = val.find(to_be_escaped);
 
-    while (found != string::npos) {
-        while (i < found) {
-            new_val += val[i];
-            i++;
-        }
-        new_val += escape;
-        found = val.find(to_be_escaped, found + 1);
-    }
-    while (i < val.length()) {
-        new_val += val[i];
-        i++;
-    }
-    return new_val;
+	while (found != string::npos) {
+		while (i < found) {
+			new_val += val[i];
+			i++;
+		}
+		new_val += escape;
+		found = val.find(to_be_escaped, found + 1);
+	}
+	while (i < val.length()) {
+		new_val += val[i];
+		i++;
+	}
+	return new_val;
 }
 
 bool CSVWriter::RequiresQuotes(const char *str, idx_t len, const string &null_str,

--- a/test/sql/copy/csv/test_infinite_loop_escape.test
+++ b/test/sql/copy/csv/test_infinite_loop_escape.test
@@ -1,0 +1,18 @@
+# name: test/sql/copy/csv/test_infinite_loop_escape.test
+# description: Test that CSV writer does not loop infinitely when ESCAPE is empty
+# group: [csv]
+
+statement ok
+PRAGMA enable_verification
+
+# Create a table with a value that needs escaping (a quote)
+statement ok
+CREATE TABLE trigger_loop (a VARCHAR);
+
+statement ok
+INSERT INTO trigger_loop VALUES ('"');
+
+# This command used to trigger an infinite loop because it found the quote
+# but added an empty escape character, finding the same quote again forever.
+statement ok
+COPY trigger_loop TO '__TEST_DIR__/infinite_loop_fix.csv' (FORMAT CSV, QUOTE '"', ESCAPE '');


### PR DESCRIPTION
Supersedes the previous PR.

This applies the infinite loop fix cleanly on top of `v1.4-andium`.
- Simplified logic: returns early if the escape character is empty.
- Includes regression test (added in next commit).