### PR TITLE
Remove return_chunk parameter from PhysicalDelete

### DIFF
--- a/src/execution/physical_plan/plan_delete.cpp
+++ b/src/execution/physical_plan/plan_delete.cpp
@@ -12,8 +12,7 @@ PhysicalOperator &DuckCatalog::PlanDelete(ClientContext &context, PhysicalPlanGe
 	// Get the row_id column index.
 	auto &bound_ref = op.expressions[0]->Cast<BoundReferenceExpression>();
 	auto &del = planner.Make<PhysicalDelete>(op.types, op.table, op.table.GetStorage(), std::move(op.bound_constraints),
-	                                         bound_ref.index, op.estimated_cardinality, op.return_chunk,
-	                                         std::move(op.return_columns));
+	                                         bound_ref.index, op.estimated_cardinality, std::move(op.return_columns));
 	del.children.push_back(plan);
 	return del;
 }

--- a/src/execution/physical_plan/plan_merge_into.cpp
+++ b/src/execution/physical_plan/plan_merge_into.cpp
@@ -45,7 +45,7 @@ unique_ptr<MergeIntoOperator> PlanMergeIntoAction(ClientContext &context, Logica
 		vector<idx_t> return_columns = op.delete_return_columns;
 		result->op = planner.Make<PhysicalDelete>(std::move(return_types), op.table, op.table.GetStorage(),
 		                                          std::move(bound_constraints), op.row_id_start, cardinality,
-		                                          op.return_chunk, std::move(return_columns));
+		                                          std::move(return_columns));
 		break;
 	}
 	case MergeActionType::MERGE_INSERT: {

--- a/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_delete.hpp
@@ -22,14 +22,18 @@ public:
 public:
 	PhysicalDelete(PhysicalPlan &physical_plan, vector<LogicalType> types, TableCatalogEntry &tableref,
 	               DataTable &table, vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t row_id_index,
-	               idx_t estimated_cardinality, bool return_chunk, vector<idx_t> return_columns);
+	               idx_t estimated_cardinality, vector<idx_t> return_columns);
 
 	TableCatalogEntry &tableref;
 	DataTable &table;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
 	idx_t row_id_index;
-	bool return_chunk;
 	vector<idx_t> return_columns;
+
+	//! Whether to return the deleted rows (derived from return_columns)
+	bool ReturnChunk() const {
+		return !return_columns.empty();
+	}
 
 public:
 	// Source interface


### PR DESCRIPTION
Derive return_chunk from return_columns.empty() instead of storing it as a separate member. This simplifies the interface since:
- For RETURNING: return_columns has all columns mapped
- For index-only: return_columns has indexed columns mapped (sparse)
- For neither: return_columns is empty

The logical operators (LogicalDelete, LogicalMergeInto) still retain return_chunk for serialization backward/forward compatibility.