### PR TITLE
fix ubigint casting failures to bigint (issue #17135)

### DIFF
--- a/extension/json/include/json_structure.hpp
+++ b/extension/json/include/json_structure.hpp
@@ -80,6 +80,9 @@ public:
 
 	//! Candidate types (if auto-detecting and type == LogicalTypeId::VARCHAR)
 	vector<LogicalTypeId> candidate_types;
+
+	//! Whether any UBIGINT value exceeds the BIGINT range (i.e., >= 2^63)
+	bool has_large_ubigint = false;
 };
 
 struct JSONStructure {

--- a/test/sql/json/issues/issue17135.test
+++ b/test/sql/json/issues/issue17135.test
@@ -1,0 +1,57 @@
+# name: test/sql/json/issues/issue17135.test
+# description: Test issue 17135 - read_json fails to read integers exceeding BIGINT range
+# group: [issues]
+
+require json
+
+statement ok
+pragma enable_verification
+
+# value exactly at 2^63 (exceeds BIGINT max of 2^63-1)
+statement ok
+copy (select * from (values ('{"id":9223372036854775808}'))) to '__TEST_DIR__/ubigint.json' (format csv, quote '', header 0)
+
+query II
+select typeof(id), id from read_json('__TEST_DIR__/ubigint.json')
+----
+HUGEINT	9223372036854775808
+
+# max UBIGINT value
+statement ok
+copy (select * from (values ('{"id":18446744073709551615}'))) to '__TEST_DIR__/ubigint_max.json' (format csv, quote '', header 0)
+
+query II
+select typeof(id), id from read_json('__TEST_DIR__/ubigint_max.json')
+----
+HUGEINT	18446744073709551615
+
+# json_structure should still detect UBIGINT for large values
+query T
+select json_structure('{"id":9223372036854775808}')
+----
+{"id":"UBIGINT"}
+
+# json_structure detects UBIGINT for small positive integers too (yyjson tags all positive ints as UINT)
+query T
+select json_structure('{"id":42}')
+----
+{"id":"UBIGINT"}
+
+# small positive integers should still be BIGINT from read_json
+statement ok
+copy (select * from (values ('{"id":42}'))) to '__TEST_DIR__/bigint.json' (format csv, quote '', header 0)
+
+query II
+select typeof(id), id from read_json('__TEST_DIR__/bigint.json')
+----
+BIGINT	42
+
+# mixed negative and large unsigned values should use HUGEINT
+statement ok
+copy (select * from (values ('{"id":-5}'), ('{"id":9223372036854775808}'))) to '__TEST_DIR__/mixed.json' (format csv, quote '', header 0)
+
+query II
+select typeof(id), id from read_json('__TEST_DIR__/mixed.json')
+----
+HUGEINT	-5
+HUGEINT	9223372036854775808


### PR DESCRIPTION
The current implementation forces all UBIGINT to BIGINT. This leads to problems when the UBIGINT number is too large for a BIGINT (>= 2^63). This PR keeps the current behavior to cast UBIGINT to BIGINT as long as the number fits to BIGINT. If it doesn't fit it uses HUGEINT.


### Summary
- Fixes read_json() failing with “Failed to cast value to numerical” for JSON integers >= 2^63
- Adds a has_large_ubigint flag to JSONStructureDescription to track when sampled values exceed the BIGINT range
- When the flag is set, StructureToType returns HUGEINT instead of BIGINT, which can represent both signed and unsigned 64-bit values
- Small positive integers continue to auto-detect as BIGINT (no change to existing behavior)
- json_structure() output is unchanged

fixes #17135