### PR TITLE
[chore] Skip building spatial, needs a patch, needs to be reverted

### DIFF
--- a/.github/config/extensions/spatial.cmake
+++ b/.github/config/extensions/spatial.cmake
@@ -1,3 +1,4 @@
+if (FALSE)
 if (${BUILD_COMPLETE_EXTENSION_SET})
 ################# SPATIAL
 duckdb_extension_load(spatial
@@ -7,4 +8,5 @@ duckdb_extension_load(spatial
     INCLUDE_DIR src/spatial
     TEST_DIR test/sql
     )
+endif()
 endif()


### PR DESCRIPTION
Unsure if we want this in as a temporary measure while conflict between https://github.com/duckdb/duckdb/pull/20759 and the reintroduction of `spatial` is sorted out on a side (and then this needs to be reverted)