### PR TITLE
[chore] Fixup autocomplete missing std::move

### DIFF
--- a/extension/autocomplete/transformer/transform_analyze.cpp
+++ b/extension/autocomplete/transformer/transform_analyze.cpp
@@ -17,7 +17,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformAnalyzeStatement(PEGTra
 		result->info->ref = std::move(target.ref);
 		result->info->has_table = true;
 	}
-	return result;
+	return std::move(result);
 }
 
 AnalyzeTarget PEGTransformerFactory::TransformAnalyzeTarget(PEGTransformer &transformer,

--- a/extension/autocomplete/transformer/transform_create_view.cpp
+++ b/extension/autocomplete/transformer/transform_create_view.cpp
@@ -29,7 +29,7 @@ unique_ptr<QueryNode> PEGTransformerFactory::ToRecursiveCTE(unique_ptr<QueryNode
 	recursive_node->right = std::move(owned_set_node->children[1]);
 	recursive_node->union_all = owned_set_node->setop_all;
 
-	return recursive_node;
+	return std::move(recursive_node);
 }
 
 void PEGTransformerFactory::WrapRecursiveView(unique_ptr<CreateViewInfo> &info, unique_ptr<QueryNode> inner_node) {

--- a/extension/autocomplete/transformer/transform_describe.cpp
+++ b/extension/autocomplete/transformer/transform_describe.cpp
@@ -21,7 +21,7 @@ unique_ptr<QueryNode> PEGTransformerFactory::TransformShowSelect(PEGTransformer 
 	auto select_node = make_uniq<SelectNode>();
 	select_node->select_list.push_back(make_uniq<StarExpression>());
 	select_node->from_table = std::move(result);
-	return select_node;
+	return std::move(select_node);
 }
 
 unique_ptr<QueryNode> PEGTransformerFactory::TransformShowAllTables(PEGTransformer &transformer,
@@ -33,7 +33,7 @@ unique_ptr<QueryNode> PEGTransformerFactory::TransformShowAllTables(PEGTransform
 	auto select_node = make_uniq<SelectNode>();
 	select_node->select_list.push_back(make_uniq<StarExpression>());
 	select_node->from_table = std::move(result);
-	return select_node;
+	return std::move(select_node);
 }
 
 unique_ptr<QueryNode> PEGTransformerFactory::TransformShowQualifiedName(PEGTransformer &transformer,
@@ -71,7 +71,7 @@ unique_ptr<QueryNode> PEGTransformerFactory::TransformShowQualifiedName(PEGTrans
 	auto select_node = make_uniq<SelectNode>();
 	select_node->select_list.push_back(make_uniq<StarExpression>());
 	select_node->from_table = std::move(result);
-	return select_node;
+	return std::move(select_node);
 }
 
 ShowType PEGTransformerFactory::TransformShowOrDescribeOrSummarize(PEGTransformer &transformer,

--- a/extension/autocomplete/transformer/transform_expression.cpp
+++ b/extension/autocomplete/transformer/transform_expression.cpp
@@ -1926,6 +1926,6 @@ PEGTransformerFactory::TransformGroupingExpression(PEGTransformer &transformer,
 		grouping_expressions.push_back(transformer.Transform<unique_ptr<ParsedExpression>>(expr));
 	}
 	auto result = make_uniq<OperatorExpression>(ExpressionType::GROUPING_FUNCTION, std::move(grouping_expressions));
-	return result;
+	return std::move(result);
 }
 } // namespace duckdb

--- a/extension/autocomplete/transformer/transform_select.cpp
+++ b/extension/autocomplete/transformer/transform_select.cpp
@@ -1313,7 +1313,7 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformWindowDefinition(PE
 	auto &list_pr = parse_result->Cast<ListParseResult>();
 	auto window_function = transformer.Transform<unique_ptr<WindowExpression>>(list_pr.Child<ListParseResult>(2));
 	window_function->alias = list_pr.Child<IdentifierParseResult>(0).identifier;
-	return window_function;
+	return std::move(window_function);
 }
 
 } // namespace duckdb

--- a/extension/autocomplete/transformer/transform_vacuum.cpp
+++ b/extension/autocomplete/transformer/transform_vacuum.cpp
@@ -16,7 +16,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformVacuumStatement(PEGTran
 		result->info->ref = std::move(target.ref);
 		result->info->has_table = true;
 	}
-	return result;
+	return std::move(result);
 }
 
 VacuumOptions PEGTransformerFactory::TransformVacuumOptions(PEGTransformer &transformer,


### PR DESCRIPTION
I think it would be handy to consider either Bundle (at leat on Linux) by default on CI, or some equivalent CI run to catch those earlier.