### PR TITLE
Add DELETE RETURNING virtual columns support

### DIFF
--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -91,8 +91,10 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 		del->table_index = update_table_index;
 
 		unique_ptr<LogicalOperator> del_as_logicaloperator = std::move(del);
+		// Include virtual columns (like rowid) so they can be referenced in RETURNING
+		auto virtual_columns = table.GetVirtualColumns();
 		return BindReturning(std::move(stmt.returning_list), table, stmt.table->alias, update_table_index,
-		                     std::move(del_as_logicaloperator));
+		                     std::move(del_as_logicaloperator), std::move(virtual_columns));
 	}
 	BoundStatement result;
 	result.plan = std::move(del);

--- a/src/planner/operator/logical_delete.cpp
+++ b/src/planner/operator/logical_delete.cpp
@@ -30,7 +30,9 @@ vector<idx_t> LogicalDelete::GetTableIndex() const {
 
 vector<ColumnBinding> LogicalDelete::GetColumnBindings() {
 	if (return_chunk) {
-		return GenerateColumnBindings(table_index, table.GetTypes().size());
+		// Include table columns + virtual columns (e.g., rowid)
+		auto virtual_columns = table.GetVirtualColumns();
+		return GenerateColumnBindings(table_index, table.GetTypes().size() + virtual_columns.size());
 	}
 	return {ColumnBinding(0, 0)};
 }
@@ -38,6 +40,11 @@ vector<ColumnBinding> LogicalDelete::GetColumnBindings() {
 void LogicalDelete::ResolveTypes() {
 	if (return_chunk) {
 		types = table.GetTypes();
+		// Add virtual columns (e.g., rowid)
+		auto virtual_columns = table.GetVirtualColumns();
+		for (auto &entry : virtual_columns) {
+			types.push_back(entry.second.type);
+		}
 	} else {
 		types.emplace_back(LogicalType::BIGINT);
 	}

--- a/test/fuzzer/pedro/returning_clause_with_rowid.test
+++ b/test/fuzzer/pedro/returning_clause_with_rowid.test
@@ -30,10 +30,14 @@ UPDATE t0 SET c0 = 5 WHERE c0 = 0 RETURNING rowid;
 ----
 Binder Error: Referenced column "rowid" not found in FROM clause!
 
-statement error
+# DELETE RETURNING rowid is now supported
+statement ok
+INSERT INTO t0 VALUES (0);
+
+query I
 DELETE FROM t0 WHERE c0 = 0 RETURNING rowid;
 ----
-Binder Error: Referenced column "rowid" not found in FROM clause!
+0
 
 # make sure you can still return the alias rowid
 # More tests could be written, but the returning binder doesn't allow

--- a/test/sql/returning/returning_delete.test
+++ b/test/sql/returning/returning_delete.test
@@ -323,23 +323,121 @@ statement ok
 DROP TABLE test_where_returning;
 
 # ============================================================
-# Virtual columns like rowid are not supported in RETURNING
+# Virtual columns like rowid ARE supported in RETURNING
 # ============================================================
 
 statement ok
-CREATE TABLE test_rowid_not_supported (id INTEGER, name VARCHAR);
+CREATE TABLE test_rowid_supported (id INTEGER, name VARCHAR);
 
 statement ok
-INSERT INTO test_rowid_not_supported VALUES (1, 'one');
+INSERT INTO test_rowid_supported VALUES (1, 'one'), (2, 'two'), (3, 'three');
 
-# rowid is not supported in DELETE RETURNING
-statement error
-DELETE FROM test_rowid_not_supported WHERE id = 1 RETURNING rowid;
+# rowid can be returned in DELETE RETURNING
+query I
+DELETE FROM test_rowid_supported WHERE id = 1 RETURNING rowid;
 ----
-<REGEX>:Binder Error.*Referenced column "rowid" not found.*
+0
+
+# rowid with other columns
+query III
+DELETE FROM test_rowid_supported WHERE id = 2 RETURNING id, name, rowid;
+----
+2	two	1
+
+# rowid with star (rowid is not included in *, must be explicit)
+query III
+DELETE FROM test_rowid_supported WHERE id = 3 RETURNING *, rowid;
+----
+3	three	2
 
 statement ok
-DROP TABLE test_rowid_not_supported;
+DROP TABLE test_rowid_supported;
+
+# ============================================================
+# Tests for DELETE RETURNING rowid with generated columns
+# This tests the virtual_column_offset mechanism
+# ============================================================
+
+statement ok
+CREATE TABLE test_rowid_generated (
+    id INTEGER,
+    val INTEGER,
+    computed INTEGER GENERATED ALWAYS AS (val * 2) VIRTUAL
+);
+
+statement ok
+INSERT INTO test_rowid_generated (id, val) VALUES (1, 10), (2, 20), (3, 30);
+
+# Return rowid with generated column table
+query I
+DELETE FROM test_rowid_generated WHERE id = 1 RETURNING rowid;
+----
+0
+
+# Return all columns plus rowid (rowid should be at correct position)
+query IIII
+DELETE FROM test_rowid_generated WHERE id = 2 RETURNING *, rowid;
+----
+2	20	40	1
+
+# Return specific columns including generated and rowid
+query III
+DELETE FROM test_rowid_generated WHERE id = 3 RETURNING computed, id, rowid;
+----
+60	3	2
+
+statement ok
+DROP TABLE test_rowid_generated;
+
+# Test rowid with multiple generated columns
+statement ok
+CREATE TABLE test_rowid_multi_gen (
+    id INTEGER,
+    a INTEGER,
+    b INTEGER,
+    sum_ab INTEGER GENERATED ALWAYS AS (a + b) VIRTUAL,
+    prod_ab INTEGER GENERATED ALWAYS AS (a * b) VIRTUAL
+);
+
+statement ok
+INSERT INTO test_rowid_multi_gen (id, a, b) VALUES (1, 2, 3), (2, 4, 5);
+
+query IIIIII
+DELETE FROM test_rowid_multi_gen WHERE id = 1 RETURNING *, rowid;
+----
+1	2	3	5	6	0
+
+query III
+DELETE FROM test_rowid_multi_gen WHERE id = 2 RETURNING rowid, sum_ab, prod_ab;
+----
+1	9	20
+
+statement ok
+DROP TABLE test_rowid_multi_gen;
+
+# Test rowid with generated column in middle of table definition
+statement ok
+CREATE TABLE test_rowid_gen_middle (
+    a INTEGER,
+    gen INTEGER GENERATED ALWAYS AS (a + c) VIRTUAL,
+    c INTEGER
+);
+
+statement ok
+INSERT INTO test_rowid_gen_middle (a, c) VALUES (1, 100), (2, 200);
+
+query IIII
+DELETE FROM test_rowid_gen_middle WHERE a = 1 RETURNING *, rowid;
+----
+1	101	100	0
+
+query II
+DELETE FROM test_rowid_gen_middle WHERE a = 2 RETURNING rowid, gen;
+----
+1	202
+
+statement ok
+DROP TABLE test_rowid_gen_middle;
 
 # ============================================================
 # Tests for DELETE RETURNING with generated columns


### PR DESCRIPTION
This change allows rowid to be returned in DELETE RETURNING statements.

Changes:
- bind_delete.cpp: Pass virtual columns (including rowid) to BindReturning
- logical_delete.cpp: Include rowid in output types and column bindings
- physical_delete.cpp: Add rowid to delete_chunk when return_chunk is true

Tests added for:
- DELETE RETURNING rowid (basic)
- DELETE RETURNING rowid with generated columns
