### PR TITLE
Fixup test/extension/update_extensions_ci.test [v1.4-andium]

### DIFF
--- a/test/extension/update_extensions_ci.test
+++ b/test/extension/update_extensions_ci.test
@@ -380,12 +380,14 @@ restart
 statement ok
 set allow_unsigned_extensions=false
 
-# Installing is still fine
-statement ok
+# Installing is not working
+statement error
 FORCE INSTALL '${DIRECT_INSTALL_DIR}/json.duckdb_extension';
+----
+IO Error: Attempting to install an extension file that doesn't have a valid signature
 
 # But loading is not
 statement error
-LOAD json;
+LOAD '${DIRECT_INSTALL_DIR}/json.duckdb_extension';
 ----
  Also, the file was built for the platform 'test_platform', but we can only load extensions built for platform


### PR DESCRIPTION
Tested on fork's CI to be working, according to changes that landed in https://github.com/duckdb/duckdb/pull/20605.

Should make so nightly CI for `v1.4-varieagata` (and later other brances as well) should pass for "Extension updating test".