### PR TITLE
Pass client context to index constructor

### DIFF
--- a/src/include/duckdb/execution/index/index_type.hpp
+++ b/src/include/duckdb/execution/index/index_type.hpp
@@ -26,8 +26,10 @@ class Expression;
 class TableIOManager;
 class AttachedDatabase;
 struct IndexStorageInfo;
+class ClientContext;
 
 struct CreateIndexInput {
+	ClientContext &context;
 	TableIOManager &table_io_manager;
 	AttachedDatabase &db;
 	IndexConstraintType constraint_type;
@@ -37,11 +39,11 @@ struct CreateIndexInput {
 	const IndexStorageInfo &storage_info;
 	const case_insensitive_map_t<Value> &options;
 
-	CreateIndexInput(TableIOManager &table_io_manager, AttachedDatabase &db, IndexConstraintType constraint_type,
-	                 const string &name, const vector<column_t> &column_ids,
+	CreateIndexInput(ClientContext &context, TableIOManager &table_io_manager, AttachedDatabase &db,
+	                 IndexConstraintType constraint_type, const string &name, const vector<column_t> &column_ids,
 	                 const vector<unique_ptr<Expression>> &unbound_expressions, const IndexStorageInfo &storage_info,
 	                 const case_insensitive_map_t<Value> &options)
-	    : table_io_manager(table_io_manager), db(db), constraint_type(constraint_type), name(name),
+	    : context(context), table_io_manager(table_io_manager), db(db), constraint_type(constraint_type), name(name),
 	      column_ids(column_ids), unbound_expressions(unbound_expressions), storage_info(storage_info),
 	      options(options) {};
 };

--- a/src/planner/expression_binder/index_binder.cpp
+++ b/src/planner/expression_binder/index_binder.cpp
@@ -41,7 +41,7 @@ unique_ptr<BoundIndex> IndexBinder::BindIndex(const UnboundIndex &unbound_index)
 		unbound_expressions.push_back(Bind(copy));
 	}
 
-	CreateIndexInput input(unbound_index.table_io_manager, unbound_index.db, create_info.constraint_type,
+	CreateIndexInput input(context, unbound_index.table_io_manager, unbound_index.db, create_info.constraint_type,
 	                       create_info.index_name, create_info.column_ids, unbound_expressions, storage_info,
 	                       create_info.options);
 

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -766,7 +766,7 @@ void WriteAheadLogDeserializer::ReplayAlter() {
 	}
 
 	auto &storage = table.GetStorage();
-	CreateIndexInput input(TableIOManager::Get(storage), storage.db, IndexConstraintType::PRIMARY,
+	CreateIndexInput input(context, TableIOManager::Get(storage), storage.db, IndexConstraintType::PRIMARY,
 	                       index_storage_info.name, column_ids, unbound_expressions, index_storage_info,
 	                       index_storage_info.options);
 


### PR DESCRIPTION
This enables me to construct a cast/conversion expression when instantiating r-tree indexes on top of legacy geometry columns, and I imagine it could be useful for other index types too if they want to create a expression executor to compute keys from some expression.