### PR TITLE
Keep exact track of which row groups have not yet been flushed in the optimistic writer

### DIFF
--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -106,9 +106,9 @@ public:
 				data_table.ResetOptimisticCollection(context, collection_indexes[i]);
 			}
 			result_collection.FinalizeAppend(TransactionData(0, 0), append_state);
-			writer.WriteLastRowGroup(optimistic_collection);
+			writer.WriteUnflushedRowGroups(optimistic_collection);
 		} else if (batch_type == RowGroupBatchType::NOT_FLUSHED) {
-			writer.WriteLastRowGroup(optimistic_collection);
+			writer.WriteUnflushedRowGroups(optimistic_collection);
 		}
 
 		collection_indexes.clear();
@@ -380,7 +380,7 @@ void BatchInsertGlobalState::AddCollection(ClientContext &context, const idx_t b
 	auto new_count = collection.GetTotalRows();
 	auto batch_type = new_count < row_group_size ? RowGroupBatchType::NOT_FLUSHED : RowGroupBatchType::FLUSHED;
 	if (batch_type == RowGroupBatchType::FLUSHED && writer) {
-		writer->WriteLastRowGroup(optimistic_collection);
+		writer->WriteUnflushedRowGroups(optimistic_collection);
 	}
 	lock_guard<mutex> l(lock);
 	insert_count += new_count;

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -707,7 +707,7 @@ SinkCombineResultType PhysicalInsert::Combine(ExecutionContext &context, Operato
 		storage.FinalizeLocalAppend(append_state);
 	} else {
 		// we have written rows to disk optimistically - merge directly into the transaction-local storage
-		lstate.optimistic_writer->WriteLastRowGroup(optimistic_collection);
+		lstate.optimistic_writer->WriteUnflushedRowGroups(optimistic_collection);
 		lstate.optimistic_writer->FinalFlush();
 		gstate.table.GetStorage().LocalMerge(context.client, optimistic_collection);
 		auto &optimistic_writer = gstate.table.GetStorage().GetOptimisticWriter(context.client);

--- a/src/include/duckdb/storage/optimistic_data_writer.hpp
+++ b/src/include/duckdb/storage/optimistic_data_writer.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/storage/table/row_group_collection.hpp"
+#include "duckdb/common/set.hpp"
 
 namespace duckdb {
 class PartialBlockManager;
@@ -17,7 +18,7 @@ struct OptimisticWriteCollection {
 	~OptimisticWriteCollection();
 
 	shared_ptr<RowGroupCollection> collection;
-	unordered_set<idx_t> unflushed_row_groups;
+	set<idx_t> unflushed_row_groups;
 	idx_t complete_row_groups = 0;
 	vector<unique_ptr<PartialBlockManager>> partial_block_managers;
 

--- a/src/include/duckdb/storage/optimistic_data_writer.hpp
+++ b/src/include/duckdb/storage/optimistic_data_writer.hpp
@@ -17,9 +17,11 @@ struct OptimisticWriteCollection {
 	~OptimisticWriteCollection();
 
 	shared_ptr<RowGroupCollection> collection;
-	idx_t last_flushed = 0;
+	unordered_set<idx_t> unflushed_row_groups;
 	idx_t complete_row_groups = 0;
 	vector<unique_ptr<PartialBlockManager>> partial_block_managers;
+
+	void MergeStorage(OptimisticWriteCollection &collection);
 };
 
 enum class OptimisticWritePartialManagers { PER_COLUMN, GLOBAL };
@@ -36,8 +38,8 @@ public:
 	                 OptimisticWritePartialManagers type = OptimisticWritePartialManagers::PER_COLUMN);
 	//! Write a new row group to disk (if possible)
 	void WriteNewRowGroup(OptimisticWriteCollection &row_groups);
-	//! Write the last row group of a collection to disk
-	void WriteLastRowGroup(OptimisticWriteCollection &row_groups);
+	//! Write any unflushed row groups of a collection to disk
+	void WriteUnflushedRowGroups(OptimisticWriteCollection &row_groups);
 	//! Final flush of the optimistic writer - fully flushes the partial block manager
 	void FinalFlush();
 	//! Merge the partially written blocks from one optimistic writer into another

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -50,6 +50,7 @@ public:
 
 public:
 	idx_t GetTotalRows() const;
+	idx_t GetRowGroupCount() const;
 	Allocator &GetAllocator() const;
 
 	void Initialize(PersistentCollectionData &data);

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -61,8 +61,6 @@ public:
 	//! The main optimistic data writer associated with this table.
 	OptimisticDataWriter optimistic_writer;
 
-	//! Whether or not storage was merged
-	bool merged_storage = false;
 	//! Whether or not the storage was dropped
 	bool is_dropped = false;
 
@@ -91,6 +89,7 @@ public:
 	OptimisticDataWriter &GetOptimisticWriter();
 
 	RowGroupCollection &GetCollection();
+	OptimisticWriteCollection &GetPrimaryCollection();
 
 private:
 	mutex collections_lock;

--- a/src/storage/optimistic_data_writer.cpp
+++ b/src/storage/optimistic_data_writer.cpp
@@ -65,23 +65,24 @@ void OptimisticDataWriter::WriteNewRowGroup(OptimisticWriteCollection &row_group
 		return;
 	}
 
+	row_groups.unflushed_row_groups.insert(row_groups.complete_row_groups);
 	row_groups.complete_row_groups++;
-	auto unflushed_row_groups = row_groups.complete_row_groups - row_groups.last_flushed;
+	auto unflushed_row_groups = row_groups.unflushed_row_groups.size();
 	if (unflushed_row_groups >= Settings::Get<WriteBufferRowGroupCountSetting>(context)) {
 		// we have crossed our flush threshold - flush any unwritten row groups to disk
 		vector<const_reference<RowGroup>> to_flush;
 		vector<int64_t> segment_indexes;
-		for (idx_t i = row_groups.last_flushed; i < row_groups.complete_row_groups; i++) {
-			auto segment_index = NumericCast<int64_t>(i);
+		for(auto &unflushed_idx : row_groups.unflushed_row_groups) {
+			auto segment_index = NumericCast<int64_t>(unflushed_idx);
 			to_flush.push_back(*row_groups.collection->GetRowGroup(segment_index));
 			segment_indexes.push_back(segment_index);
 		}
 		FlushToDisk(row_groups, to_flush, segment_indexes);
-		row_groups.last_flushed = row_groups.complete_row_groups;
+		row_groups.unflushed_row_groups.clear();
 	}
 }
 
-void OptimisticDataWriter::WriteLastRowGroup(OptimisticWriteCollection &row_groups) {
+void OptimisticDataWriter::WriteUnflushedRowGroups(OptimisticWriteCollection &row_groups) {
 	// we finished writing a complete row group
 	if (!PrepareWrite()) {
 		return;
@@ -89,8 +90,8 @@ void OptimisticDataWriter::WriteLastRowGroup(OptimisticWriteCollection &row_grou
 	// flush the last batch of row groups
 	vector<const_reference<RowGroup>> to_flush;
 	vector<int64_t> segment_indexes;
-	for (idx_t i = row_groups.last_flushed; i < row_groups.complete_row_groups; i++) {
-		auto segment_index = NumericCast<int64_t>(i);
+	for(auto &unflushed_idx : row_groups.unflushed_row_groups) {
+		auto segment_index = NumericCast<int64_t>(unflushed_idx);
 		to_flush.push_back(*row_groups.collection->GetRowGroup(segment_index));
 		segment_indexes.push_back(segment_index);
 	}
@@ -103,7 +104,33 @@ void OptimisticDataWriter::WriteLastRowGroup(OptimisticWriteCollection &row_grou
 	for (auto &partial_manager : row_groups.partial_block_managers) {
 		Merge(partial_manager);
 	}
+	row_groups.unflushed_row_groups.clear();
 	row_groups.partial_block_managers.clear();
+}
+
+void OptimisticWriteCollection::MergeStorage(OptimisticWriteCollection &merge_collection) {
+	auto &merge_row_groups = *merge_collection.collection;
+	if (merge_row_groups.GetTotalRows() == 0) {
+		// no rows to merge - done
+		return;
+	}
+	// when merging the other row group is appended to the END of this row group
+	// that means any trailing row groups that are not yet complete are now complete (even if they are half empty)
+	// add them to the unflushed set
+	idx_t current_row_group_count = collection->GetRowGroupCount();
+	for(idx_t i = complete_row_groups; i < current_row_group_count; i++) {
+		unflushed_row_groups.insert(i);
+		complete_row_groups++;
+	}
+
+	// now we merge the target collection into this one - take over any unflushed row groups but adjust their index
+	idx_t merge_row_group_count = merge_row_groups.GetRowGroupCount();
+	for(auto &unflushed_idx : merge_collection.unflushed_row_groups) {
+		unflushed_row_groups.insert(current_row_group_count + unflushed_idx);
+	}
+	complete_row_groups += merge_collection.complete_row_groups;
+	// finally perform the actual merge
+	collection->MergeStorage(merge_row_groups, nullptr, nullptr);
 }
 
 void OptimisticDataWriter::FlushToDisk(OptimisticWriteCollection &collection,

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -680,8 +680,10 @@ void RowGroupCollection::MergeStorage(RowGroupCollection &data, optional_ptr<Dat
 			auto &row_group = entry->GetNode();
 			if (!row_group.IsPersistent()) {
 				if (optimistically_written_count > 0) {
+#ifdef DEBUG
 					throw InternalException("Partially optimistically written data at position %d (row start %d)",
 					                        entry->GetIndex(), entry->GetRowStart());
+#endif
 				}
 				break;
 			}

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -680,7 +680,8 @@ void RowGroupCollection::MergeStorage(RowGroupCollection &data, optional_ptr<Dat
 			auto &row_group = entry->GetNode();
 			if (!row_group.IsPersistent()) {
 				if (optimistically_written_count > 0) {
-					throw InternalException("Partially optimistically written data");
+					throw InternalException("Partially optimistically written data at position %d (row start %d)",
+					                        entry->GetIndex(), entry->GetRowStart());
 				}
 				break;
 			}

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -5,9 +5,11 @@
 #include "duckdb/main/connection_manager.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
+#include "duckdb/storage/storage_manager.hpp"
 
 #include <chrono>
 #include <thread>
+#include <duckdb/common/local_file_system.hpp>
 
 using namespace duckdb;
 using namespace std;
@@ -19,6 +21,56 @@ TEST_CASE("Test comment in CPP API", "[api]") {
 	con.SendQuery("--ups");
 	//! Should not crash
 	REQUIRE(1);
+}
+
+TEST_CASE("Test wal spil", "[boaz]") {
+	int threads = 10;
+	int rows = DEFAULT_ROW_GROUP_SIZE * threads - DEFAULT_STANDARD_VECTOR_SIZE;
+	bool use_preservation_order = true;
+	bool use_join = true;
+	std::string q = "CREATE TABLE long_wal AS SELECT a FROM tbl1";
+	if (use_join) {
+		q+= " WHERE a not in (select b from tbl2)";
+	}
+
+	LocalFileSystem lfs;
+	{
+		std::remove("/tmp/long_wal.db.wal");
+		std::remove("/tmp/long_wal.db");
+		DBConfig config;
+		config.options.checkpoint_on_shutdown = false;
+		config.SetOption("debug_skip_checkpoint_on_commit", true);
+		DuckDB db("/tmp/long_wal.db", &config);
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE IF NOT EXISTS tbl1 AS SELECT 'item_' || range AS a FROM RANGE(" + std::to_string(rows) + ")"));
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE IF NOT EXISTS tbl2 AS SELECT 'non_item_' || range AS b FROM RANGE(3)"));
+		REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+		REQUIRE_NO_FAIL(con.Query("set threads = " + std::to_string(threads)));
+		if (!use_preservation_order) {
+			REQUIRE_NO_FAIL(con.Query("set preserve_insertion_order = false;"));
+		}
+		printf("%s\n", con.Query("explain " + q)->ToString().c_str());
+		REQUIRE_NO_FAIL(con.Query(q));
+	}
+	;
+	printf("wal size: %lluMB\n", lfs.OpenFile("/tmp/long_wal.db.wal", FileOpenFlags::FILE_FLAGS_READ, nullptr)->GetFileSize() / 1024 / 1024);
+	for (int iter = 0; iter < 10; iter++ )
+	{
+		std::remove("/tmp/long_wal.db.wal");
+		{
+			DBConfig config;
+			config.options.checkpoint_on_shutdown = false;
+			config.SetOption("debug_skip_checkpoint_on_commit", true);
+			DuckDB db("/tmp/long_wal.db", &config);
+			Connection con(db);
+			if (!use_preservation_order) {
+				REQUIRE_NO_FAIL(con.Query("set preserve_insertion_order = false;"));
+			}
+			REQUIRE_NO_FAIL(con.Query("set threads = " + std::to_string(threads)));
+			REQUIRE_NO_FAIL(con.Query(q));
+		}
+		printf("wal size: %lluMB\n", lfs.OpenFile("/tmp/long_wal.db.wal", FileOpenFlags::FILE_FLAGS_READ, nullptr)->GetFileSize() / 1024 / 1024);
+	}
 }
 
 TEST_CASE("Test StarExpression replace_list parameter", "[api]") {

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Test wal spil", "[boaz]") {
 	bool use_join = true;
 	std::string q = "CREATE TABLE long_wal AS SELECT a FROM tbl1";
 	if (use_join) {
-		q+= " WHERE a not in (select b from tbl2)";
+		q += " WHERE a not in (select b from tbl2)";
 	}
 
 	LocalFileSystem lfs;
@@ -42,7 +42,8 @@ TEST_CASE("Test wal spil", "[boaz]") {
 		config.SetOption("debug_skip_checkpoint_on_commit", true);
 		DuckDB db("/tmp/long_wal.db", &config);
 		Connection con(db);
-		REQUIRE_NO_FAIL(con.Query("CREATE TABLE IF NOT EXISTS tbl1 AS SELECT 'item_' || range AS a FROM RANGE(" + std::to_string(rows) + ")"));
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE IF NOT EXISTS tbl1 AS SELECT 'item_' || range AS a FROM RANGE(" +
+		                          std::to_string(rows) + ")"));
 		REQUIRE_NO_FAIL(con.Query("CREATE TABLE IF NOT EXISTS tbl2 AS SELECT 'non_item_' || range AS b FROM RANGE(3)"));
 		REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
 		REQUIRE_NO_FAIL(con.Query("set threads = " + std::to_string(threads)));
@@ -51,11 +52,10 @@ TEST_CASE("Test wal spil", "[boaz]") {
 		}
 		printf("%s\n", con.Query("explain " + q)->ToString().c_str());
 		REQUIRE_NO_FAIL(con.Query(q));
-	}
-	;
-	printf("wal size: %lluMB\n", lfs.OpenFile("/tmp/long_wal.db.wal", FileOpenFlags::FILE_FLAGS_READ, nullptr)->GetFileSize() / 1024 / 1024);
-	for (int iter = 0; iter < 10; iter++ )
-	{
+	};
+	printf("wal size: %lluMB\n",
+	       lfs.OpenFile("/tmp/long_wal.db.wal", FileOpenFlags::FILE_FLAGS_READ, nullptr)->GetFileSize() / 1024 / 1024);
+	for (int iter = 0; iter < 10; iter++) {
 		std::remove("/tmp/long_wal.db.wal");
 		{
 			DBConfig config;
@@ -69,7 +69,9 @@ TEST_CASE("Test wal spil", "[boaz]") {
 			REQUIRE_NO_FAIL(con.Query("set threads = " + std::to_string(threads)));
 			REQUIRE_NO_FAIL(con.Query(q));
 		}
-		printf("wal size: %lluMB\n", lfs.OpenFile("/tmp/long_wal.db.wal", FileOpenFlags::FILE_FLAGS_READ, nullptr)->GetFileSize() / 1024 / 1024);
+		printf("wal size: %lluMB\n",
+		       lfs.OpenFile("/tmp/long_wal.db.wal", FileOpenFlags::FILE_FLAGS_READ, nullptr)->GetFileSize() / 1024 /
+		           1024);
 	}
 }
 

--- a/test/sql/storage/wal/wal_size_unaligned_appends.test_slow
+++ b/test/sql/storage/wal/wal_size_unaligned_appends.test_slow
@@ -1,0 +1,54 @@
+# name: test/sql/storage/wal/wal_size_unaligned_appends.test_slow
+# description: Verify that unaligned insertions end up in the WAL
+# group: [wal]
+
+load __TEST_DIR__/wal_size_unaligned_appends.db
+
+statement ok
+CREATE TABLE IF NOT EXISTS tbl1 AS SELECT 'item_' || range AS a FROM RANGE(1226752)
+
+statement ok
+CREATE TABLE IF NOT EXISTS tbl2 AS SELECT 'non_item_' || range AS b FROM RANGE(3)
+
+statement ok
+CHECKPOINT
+
+restart
+
+statement ok
+SET threads=10
+
+statement ok
+SET debug_skip_checkpoint_on_commit=true
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+CREATE TABLE long_wal AS SELECT a FROM tbl1 WHERE a not in (select b from tbl2)
+
+# wal should be small (but exist)
+query I
+SELECT CASE WHEN size > 500 AND size < 10_000 THEN NULL ELSE size END FROM read_blob('__TEST_DIR__/wal_size_unaligned_appends.db.wal')
+----
+NULL
+
+query I
+SELECT COUNT(*) FROM long_wal
+----
+1226752
+
+query I
+FROM tbl1 EXCEPT ALL FROM long_wal
+----
+
+restart
+
+query I
+FROM tbl1 EXCEPT ALL FROM long_wal
+----
+
+query I
+SELECT COUNT(*) FROM long_wal
+----
+1226752


### PR DESCRIPTION
This fixes an issue where, if we are appending and appends have a mix of `>= row_group_size` and `< row_group_size` batches, some of the batches would not be optimistically written. This could then cause large parts of the optimistically written data to be rewritten to the WAL.