### PR TITLE
Assign next batch index in union pipelines correctly

### DIFF
--- a/src/execution/operator/set/physical_union.cpp
+++ b/src/execution/operator/set/physical_union.cpp
@@ -87,6 +87,8 @@ void PhysicalUnion::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipelin
 				last_child_ptr = meta_pipeline.GetLastChild();
 			}
 		}
+		// Assign proper batch index to the union pipeline
+		meta_pipeline.AssignNextBatchIndex(union_pipeline);
 		// build the union pipeline
 		children[i].get().BuildPipelines(union_pipeline, meta_pipeline);
 
@@ -94,9 +96,6 @@ void PhysicalUnion::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipelin
 			// the pointer was set, set up the dependencies
 			meta_pipeline.AddRecursiveDependencies(dependencies, *last_child_ptr);
 		}
-		// Assign proper batch index to the union pipeline
-		// This needs to happen after the pipelines have been built because unions can be nested
-		meta_pipeline.AssignNextBatchIndex(union_pipeline);
 	}
 }
 


### PR DESCRIPTION
The current code for batch index assignment with unions with bushy trees is subtly wrong, e.g. in the following plan:

```
│   BATCH_CREATE_TABLE_AS   │
│    ────────────────────   │
│                           │
│           1 row           │
│           0.18s           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│           UNION           │
│    ────────────────────   │
│                           ├──────────────┐
│           0 rows          │              │
│           0.00s           │              │
└─────────────┬─────────────┘              │
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         TABLE_SCAN        ││           UNION           │
│    ────────────────────   ││    ────────────────────   │
│         Function:         ││                           │
│        PARQUET_SCAN       ││                           │
│                           ││           0.00s           │
│    Total Files Read: 1    ││                           │
│                           ││                           │
│        Filename(s):       ││                           │
│  duckdb_unittest_tempdir  ││                           ├───────────────────────────────────────────┐
│  /24929/mix_batches_small ││                           │                                           │
│          .parquet         ││                           │                                           │
│                           ││                           │                                           │
│                           ││                           │                                           │
│                           ││                           │                                           │
│        100,000 rows       ││           0 rows          │                                           │
│           0.02s           ││          (0.00s)          │                                           │
└───────────────────────────┘└─────────────┬─────────────┘                                           │
                             ┌─────────────┴─────────────┐                             ┌─────────────┴─────────────┐
                             │           UNION           │                             │         TABLE_SCAN        │
                             │    ────────────────────   │                             │    ────────────────────   │
                             │                           │                             │         Function:         │
                             │                           │                             │        PARQUET_SCAN       │
                             │           0.00s           │                             │                           │
                             │                           │                             │    Total Files Read: 1    │
                             │                           │                             │                           │
                             │                           │                             │        Filename(s):       │
                             │                           ├──────────────┐              │  duckdb_unittest_tempdir  │
                             │                           │              │              │/24929/mix_batches_odd_agai│
                             │                           │              │              │         n.parquet         │
                             │                           │              │              │                           │
                             │                           │              │              │                           │
                             │                           │              │              │                           │
                             │           0 rows          │              │              │        300,000 rows       │
                             │          (0.00s)          │              │              │           0.04s           │
                             └─────────────┬─────────────┘              │              └───────────────────────────┘
                             ┌─────────────┴─────────────┐┌─────────────┴─────────────┐
                             │         TABLE_SCAN        ││         TABLE_SCAN        │
                             │    ────────────────────   ││    ────────────────────   │
                             │         Function:         ││         Function:         │
                             │        PARQUET_SCAN       ││        PARQUET_SCAN       │
                             │                           ││                           │
                             │    Total Files Read: 1    ││    Total Files Read: 1    │
                             │                           ││                           │
                             │        Filename(s):       ││        Filename(s):       │
                             │  duckdb_unittest_tempdir  ││  duckdb_unittest_tempdir  │
                             │  /24929/mix_batches_large ││   /24929/mix_batches_odd  │
                             │          .parquet         ││          .parquet         │
                             │                           ││                           │
                             │                           ││                           │
                             │                           ││                           │
                             │        300,000 rows       ││        300,000 rows       │
                             │           0.04s           ││           1.37s           │
                             └───────────────────────────┘└───────────────────────────┘
```

The correct read order is:

```
mix_batches_small.parquet
mix_batches_large.parquet
mix_batches_odd.parquet
mix_batches_odd_again.parquet
```

With the current code `mix_batches_odd.parquet` and `mix_batches_large.parquet` are swapped.

It's hard to generate a union plan like this since we fold unions into a single operator since https://github.com/duckdb/duckdb/pull/19109 - but it is still possible when deserializing from old plans.

Repro where this goes wrong now (fixed by this PR) is:

```
build/reldebug/test/unittest --test-config test/configs/force_storage_restart.json test/sql/storage/parallel/batch_insert_mix_batches.test_slow 
```
