### PR TITLE
Add Reservoir Sampling Pushdown Support to Table Functions

### DIFF
--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -26,7 +26,7 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
       supports_pushdown_type(nullptr), supports_pushdown_extract(nullptr), get_partition_info(nullptr),
       get_partition_stats(nullptr), get_virtual_columns(nullptr), get_row_id_columns(nullptr), set_scan_order(nullptr),
       serialize(nullptr), deserialize(nullptr), projection_pushdown(false), filter_pushdown(false), filter_prune(false),
-      sampling_pushdown(false), late_materialization(false) {
+      sampling_pushdown(false), reservoir_sampling_pushdown(false), late_materialization(false) {
 }
 
 TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, std::nullptr_t function_,
@@ -41,7 +41,7 @@ TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, 
       supports_pushdown_type(nullptr), supports_pushdown_extract(nullptr), get_partition_info(nullptr),
       get_partition_stats(nullptr), get_virtual_columns(nullptr), get_row_id_columns(nullptr), set_scan_order(nullptr),
       serialize(nullptr), deserialize(nullptr), projection_pushdown(false), filter_pushdown(false), filter_prune(false),
-      sampling_pushdown(false), late_materialization(false) {
+      sampling_pushdown(false), reservoir_sampling_pushdown(false), late_materialization(false) {
 }
 
 TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function_,
@@ -74,8 +74,9 @@ bool TableFunction::operator==(const TableFunction &rhs) const {
 	       serialize == rhs.serialize && deserialize == rhs.deserialize &&
 	       verify_serialization == rhs.verify_serialization && projection_pushdown == rhs.projection_pushdown &&
 	       filter_pushdown == rhs.filter_pushdown && filter_prune == rhs.filter_prune &&
-	       sampling_pushdown == rhs.sampling_pushdown && late_materialization == rhs.late_materialization &&
-	       global_initialization == rhs.global_initialization;
+	       sampling_pushdown == rhs.sampling_pushdown &&
+	       reservoir_sampling_pushdown == rhs.reservoir_sampling_pushdown &&
+	       late_materialization == rhs.late_materialization && global_initialization == rhs.global_initialization;
 }
 
 bool TableFunction::operator!=(const TableFunction &rhs) const {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -488,6 +488,9 @@ public:
 	//! Whether or not the table function supports sampling pushdown. If not supported a sample will be taken after the
 	//! table function.
 	bool sampling_pushdown;
+	//! Whether or not the table function supports reservoir sampling pushdown. If not supported a reservoir sample will
+	//! be taken after the table function.
+	bool reservoir_sampling_pushdown;
 	//! Whether or not the table function supports late materialization
 	bool late_materialization;
 	//! Additional function info, passed to the bind

--- a/src/optimizer/sampling_pushdown.cpp
+++ b/src/optimizer/sampling_pushdown.cpp
@@ -1,19 +1,25 @@
 #include "duckdb/optimizer/sampling_pushdown.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_sample.hpp"
-#include "duckdb/common/types/value.hpp"
 namespace duckdb {
 
 unique_ptr<LogicalOperator> SamplingPushdown::Optimize(unique_ptr<LogicalOperator> op) {
-	if (op->type == LogicalOperatorType::LOGICAL_SAMPLE &&
-	    op->Cast<LogicalSample>().sample_options->method == SampleMethod::SYSTEM_SAMPLE &&
-	    op->Cast<LogicalSample>().sample_options->is_percentage && !op->children.empty() &&
-	    op->children[0]->type == LogicalOperatorType::LOGICAL_GET &&
-	    op->children[0]->Cast<LogicalGet>().function.sampling_pushdown && op->children[0]->children.empty()) {
+	if (op->type == LogicalOperatorType::LOGICAL_SAMPLE && !op->children.empty() &&
+	    op->children[0]->type == LogicalOperatorType::LOGICAL_GET && op->children[0]->children.empty()) {
+		auto &sample_op = op->Cast<LogicalSample>();
 		auto &get = op->children[0]->Cast<LogicalGet>();
-		// set sampling option
-		get.extra_info.sample_options = std::move(op->Cast<LogicalSample>().sample_options);
-		op = std::move(op->children[0]);
+		const auto &sample_options = *sample_op.sample_options;
+		const bool can_push_system_sample = get.function.sampling_pushdown &&
+		                                    sample_options.method == SampleMethod::SYSTEM_SAMPLE &&
+		                                    sample_options.is_percentage;
+		const bool can_push_reservoir_sample = get.function.reservoir_sampling_pushdown &&
+		                                       sample_options.method == SampleMethod::RESERVOIR_SAMPLE &&
+		                                       !sample_options.is_percentage;
+		if (can_push_system_sample || can_push_reservoir_sample) {
+			// set sampling option
+			get.extra_info.sample_options = std::move(sample_op.sample_options);
+			op = std::move(op->children[0]);
+		}
 	}
 	for (auto &child : op->children) {
 		child = Optimize(std::move(child));

--- a/test/optimizer/sampling_pushdown.test
+++ b/test/optimizer/sampling_pushdown.test
@@ -50,3 +50,21 @@ query II
 EXPLAIN SELECT * FROM integers1, integers2 where integers1.i = integers2.i USING SAMPLE SYSTEM(25%)
 ----
 physical_plan	<REGEX>:.*System.*SEQ_SCAN.*
+
+# reservoir sampling with row count: no pushdown by default, but table functions can enable it
+query II
+EXPLAIN SELECT i FROM integers1 USING SAMPLE RESERVOIR(2)
+----
+physical_plan	<REGEX>:.*RESERVOIR_SAMPLE.*SEQ_SCAN.*
+
+# reservoir sampling with row count using ROWS syntax: no pushdown by default, but table functions can enable it
+query II
+EXPLAIN SELECT i FROM integers1 USING SAMPLE 2 ROWS
+----
+physical_plan	<REGEX>:.*RESERVOIR_SAMPLE.*SEQ_SCAN.*
+
+# reservoir sampling with REPEATABLE: no pushdown by default, but table functions can enable it
+query II
+EXPLAIN SELECT i FROM integers1 USING SAMPLE RESERVOIR(2) REPEATABLE(42)
+----
+physical_plan	<REGEX>:.*RESERVOIR_SAMPLE.*SEQ_SCAN.*


### PR DESCRIPTION
Currently, DuckDB's `SamplingPushdown` optimizer only pushes down `SYSTEM_SAMPLE` (with percentage-based sampling) into table scans.

This PR adds support for pushing down RESERVOIR sampling (with row counts) to table functions.

This is particularly problematic for storage extensions and table formats that manage large datasets across many files (e.g., DuckLake) as a query like `SELECT * FROM large_table USING SAMPLE 100 ROWS` on a 700M row table currently scans all data files, reads ~700M rows, and takes seconds, despite only needing 100 rows in the result.

I'll follow-up with a DuckLake PR, which should absolutely handle this at the metadata level.

By default, reservoir sampling is not pushed down (maintaining backward compatibility), but table functions can now opt-in by setting `reservoir_sampling_pushdown = true`. This makes it a bit complex to test, as no implemented functions have opt-in.

Details:

- Added a new `reservoir_sampling_pushdown` boolean flag to `TableFunction` to allow table functions to opt-in to reservoir sampling pushdown
- Updated the `SamplingPushdown` optimizer to check for both system sampling and reservoir sampling pushdown capabilities
- Modified the optimizer logic to push down reservoir sampling when appropriate
- Added tests
