### PR TITLE
[Profiling] Fix Incorrect Latency Timings

### DIFF
--- a/src/include/duckdb/main/profiling_utils.hpp
+++ b/src/include/duckdb/main/profiling_utils.hpp
@@ -53,6 +53,9 @@ public:
         for(idx_t i = 0; i < ACTIVELY_TRACKED_METRICS; i++) {
             active_metrics[i] = 0;
         }
+
+    	latency_timer.reset();
+    	query_name = "";
     }
 
     void Merge(const QueryMetrics &other) {


### PR DESCRIPTION
Properly reset latency after each query.

Fixes: https://github.com/duckdblabs/duckdb-internal/issues/6888