### PR TITLE
Add a benchmark with deeply nested macros to test for regressions

### DIFF
--- a/.github/regression/micro.csv
+++ b/.github/regression/micro.csv
@@ -35,3 +35,4 @@ benchmark/micro/logger/storage/file/log_message_size/small_string.benchmark
 benchmark/micro/filter/choose_correct_filter_function.benchmark
 benchmark/micro/optimizer/topn_window_elimination.benchmark
 benchmark/micro/aggregate/group_two_string_dictionaries.benchmark
+benchmark/micro/functions/nested_macros.benchmark

--- a/benchmark/micro/functions/nested_macros.benchmark
+++ b/benchmark/micro/functions/nested_macros.benchmark
@@ -1,17 +1,17 @@
 # name: benchmark/micro/functions/nested_macros.benchmark
-# description: Run a query with deep nested macros to check for regressions.
+# description: Run a query with deeply nested macros to check for regressions.
 # group: [functions]
 
 load
 CREATE OR REPLACE TABLE foo (
-    c1 INT, c2 INT, c3 INT, c4 INT, c5 INT, c6 INT, c7 INT, c8 INT,
-    c9 INT, c10 INT, c11 INT, c12 INT, c13 INT
+    c0 INT, c1 INT, c2 INT, c3 INT, c4 INT, c5 INT,
+    c6 INT, c7 INT, c8 INT, c9 INT, c10 INT, c11 INT
 );
 
 run
-SELECT NULLIF(ADD(c5,
-    NULLIF(ADD(c10,NULLIF(ADD(c2,NULLIF(ADD(c1,
-    NULLIF(ADD(c3,NULLIF(ADD(c6,NULLIF(ADD(c8,
-    NULLIF(ADD(c11,NULLIF(ADD(c4,NULLIF(ADD(c12,
-    NULLIF(ADD(c7, c13),0)),0)),0)),0)),0)),0)),0)),0)),0)),0)),0)
+SELECT NULLIF(ADD(c4,
+    NULLIF(ADD(c8,NULLIF(ADD(c1,NULLIF(ADD(c0,
+    NULLIF(ADD(c2,NULLIF(ADD(c5,NULLIF(ADD(c7,
+    NULLIF(ADD(c9,NULLIF(ADD(c3,NULLIF(ADD(c10,
+    NULLIF(ADD(c6, c11),0)),0)),0)),0)),0)),0)),0)),0)),0)),0)),0)
 FROM foo;

--- a/benchmark/micro/functions/nested_macros.benchmark
+++ b/benchmark/micro/functions/nested_macros.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/functions/nested_macros.benchmark
+# description: Run a query with deep nested macros to check for regressions.
+# group: [functions]
+
+load
+CREATE OR REPLACE TABLE foo (
+    c1 INT, c2 INT, c3 INT, c4 INT, c5 INT, c6 INT, c7 INT, c8 INT,
+    c9 INT, c10 INT, c11 INT, c12 INT, c13 INT
+);
+
+run
+SELECT NULLIF(ADD(c5,
+    NULLIF(ADD(c10,NULLIF(ADD(c2,NULLIF(ADD(c1,
+    NULLIF(ADD(c3,NULLIF(ADD(c6,NULLIF(ADD(c8,
+    NULLIF(ADD(c11,NULLIF(ADD(c4,NULLIF(ADD(c12,
+    NULLIF(ADD(c7, c13),0)),0)),0)),0)),0)),0)),0)),0)),0)),0)),0)
+FROM foo;


### PR DESCRIPTION
In response to https://github.com/duckdblabs/duckdb-internal/issues/7178, this PR adds a new micro-benchmark to track performance regressions in queries with deeply nested macros.

v1.3.2
```
name    run     timing
benchmark/micro/functions/nested_macros.benchmark       1       1.686539
benchmark/micro/functions/nested_macros.benchmark       2       1.685015
benchmark/micro/functions/nested_macros.benchmark       3       1.690306
benchmark/micro/functions/nested_macros.benchmark       4       1.682219
benchmark/micro/functions/nested_macros.benchmark       5       1.685668
```

v1.5
```
name    run     timing
benchmark/micro/functions/nested_macros.benchmark       1       0.122120
benchmark/micro/functions/nested_macros.benchmark       2       0.120145
benchmark/micro/functions/nested_macros.benchmark       3       0.121152
benchmark/micro/functions/nested_macros.benchmark       4       0.118920
benchmark/micro/functions/nested_macros.benchmark       5       0.119575
```

**Edit**: The difference observed between v1.3.2 and v1.5 reflects existing behavior and is not result of this PR. It's here only to demonstrate that the benchmark correctly captures the regression