### PR TITLE
Backport various race condition fixes to v1.4

### DIFF
--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -94,6 +94,7 @@ private:
 	//! Whether or not we can checkpoint
 	CheckpointDecision CanCheckpoint(DuckTransaction &transaction, unique_ptr<StorageLockKey> &checkpoint_lock,
 	                                 const UndoBufferProperties &properties);
+	void CleanupTransactions();
 
 private:
 	//! The current start timestamp used by transactions

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -595,7 +595,6 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage, optional_
 
 	TableAppendState append_state;
 	table.AppendLock(append_state);
-	transaction.PushAppend(table, NumericCast<idx_t>(append_state.row_start), append_count);
 	if ((append_state.row_start == 0 || storage.row_groups->GetTotalRows() >= row_group_size) &&
 	    storage.deleted_rows == 0) {
 		// table is currently empty OR we are bulk appending: move over the storage directly
@@ -615,6 +614,7 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage, optional_
 		// append to the indexes and append to the base table
 		storage.AppendToIndexes(transaction, append_state, true);
 	}
+	transaction.PushAppend(table, NumericCast<idx_t>(append_state.row_start), append_count);
 
 #ifdef DEBUG
 	// Verify that our index memory is stable.

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -156,11 +156,8 @@ void StandardColumnData::Update(TransactionData transaction, DataTable &data_tab
                                 Vector &update_vector, row_t *row_ids, idx_t update_count) {
 	ColumnScanState standard_state, validity_state;
 	Vector base_vector(type);
-	auto standard_fetch = FetchUpdateData(standard_state, row_ids, base_vector);
-	auto validity_fetch = validity.FetchUpdateData(validity_state, row_ids, base_vector);
-	if (standard_fetch != validity_fetch) {
-		throw InternalException("Unaligned fetch in validity and main column data for update");
-	}
+	FetchUpdateData(standard_state, row_ids, base_vector);
+	validity.FetchUpdateData(validity_state, row_ids, base_vector);
 
 	UpdateInternal(transaction, data_table, column_index, update_vector, row_ids, update_count, base_vector);
 	validity.UpdateInternal(transaction, data_table, column_index, update_vector, row_ids, update_count, base_vector);


### PR DESCRIPTION
Fixes are part of https://github.com/duckdb/duckdb/pull/20803 - this is the low risk fixes backported to v1.4

* When flushing local storage, first finish flushing the rows before pushing an append log to the UndoBuffer logs. Otherwise in case of an abort due to a unique constraint violation we might incorrectly have an append log in the UndoBuffer for rows which were never appended by this transaction. This could then cause the transaction to revert appends made by another transaction, subsequently causing `Could not find node in column segment tree` errors.
* Removing unnecessary internal exception in `StandardColumnData::Update`.
* In `DuckTransactionManager`, move `CleanupTransactions()` to a separate function and clean up **all** transactions in the clean-up queue instead of only the top-level transaction. Cleaning up only the top level transaction leads to a fun race issue where we might be cleaning up a different transactions' entry which can cause issues when checkpointing following an update statement as that depends on our own transaction having been cleaned up. 
