### PR TITLE
Prevent warnings being printed multiple times in the CLI

### DIFF
--- a/tools/shell/include/shell_renderer.hpp
+++ b/tools/shell/include/shell_renderer.hpp
@@ -178,6 +178,12 @@ protected:
 
 private:
 	ShellHighlight shell_highlight;
+
+	// Logs that have already been printed to avoid spamming the shell
+	duckdb::unordered_set<uint64_t> printed_logs;
+
+	// lock to ensure thread safety of the printed_logs set
+	mutable duckdb::mutex lock;
 };
 
 } // namespace duckdb_shell

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1814,7 +1814,7 @@ unique_ptr<ShellRenderer> ShellState::GetRenderer(RenderMode mode) {
 
 void ShellLogStorage::WriteLogEntry(duckdb::timestamp_t timestamp, duckdb::LogLevel level, const string &log_type,
                                     const string &log_message, const duckdb::RegisteredLoggingContext &context) {
-	lock.lock();
+	duckdb::lock_guard<duckdb::mutex> l(lock);
 
 	HighlightElementType element_type;
 	switch (level) {
@@ -1841,7 +1841,6 @@ void ShellLogStorage::WriteLogEntry(duckdb::timestamp_t timestamp, duckdb::LogLe
 	// check if the log has already been printed
 	auto log_id = duckdb::StringUtil::CIHash(log_message);
 	if (printed_logs.find(log_id) != printed_logs.end()) {
-		lock.unlock();
 		return;
 	}
 	printed_logs.emplace(log_id);
@@ -1849,7 +1848,6 @@ void ShellLogStorage::WriteLogEntry(duckdb::timestamp_t timestamp, duckdb::LogLe
 	const auto log_level = duckdb::EnumUtil::ToString(level);
 	shell_highlight.PrintText(log_level + ":\n", PrintOutput::STDOUT, element_type);
 	shell_highlight.PrintText(log_message + "\n\n", PrintOutput::STDOUT, element_type);
-	lock.unlock();
 }
 
 } // namespace duckdb_shell

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1814,6 +1814,8 @@ unique_ptr<ShellRenderer> ShellState::GetRenderer(RenderMode mode) {
 
 void ShellLogStorage::WriteLogEntry(duckdb::timestamp_t timestamp, duckdb::LogLevel level, const string &log_type,
                                     const string &log_message, const duckdb::RegisteredLoggingContext &context) {
+	lock.lock();
+
 	HighlightElementType element_type;
 	switch (level) {
 	case duckdb::LogLevel::LOG_TRACE:
@@ -1836,9 +1838,18 @@ void ShellLogStorage::WriteLogEntry(duckdb::timestamp_t timestamp, duckdb::LogLe
 		throw std::runtime_error("Unsupported log level for WriteLogEntry");
 	}
 
+	// check if the log has already been printed
+	auto log_id = duckdb::StringUtil::CIHash(log_message);
+	if (printed_logs.find(log_id) != printed_logs.end()) {
+		lock.unlock();
+		return;
+	}
+	printed_logs.emplace(log_id);
+
 	const auto log_level = duckdb::EnumUtil::ToString(level);
 	shell_highlight.PrintText(log_level + ":\n", PrintOutput::STDOUT, element_type);
 	shell_highlight.PrintText(log_message + "\n\n", PrintOutput::STDOUT, element_type);
+	lock.unlock();
 }
 
 } // namespace duckdb_shell

--- a/tools/shell/tests/test_warning.py
+++ b/tools/shell/tests/test_warning.py
@@ -54,6 +54,18 @@ def test_warning(shell):
     result.check_stdout("[1]")
 
 
+# Make sure that the same warning is not printed multiple times
+def test_multiple_warnings(shell):
+    test = ShellTest(shell).statement(
+        "select list_filter([1,2,3], x -> x > 2) l1, list_filter([1,2,3], x -> x > 2) l2, list_filter([1,2,3], x -> x > 2) l3;"
+    )
+
+    result = test.run()
+    assert result.stdout.count("WARNING:") == 1
+    result.check_stdout("Deprecated lambda arrow (->) detected.")
+    result.check_stdout("│ [3]     │ [3]     │ [3]     │")
+
+
 def test_changing_logging_settings(shell, tmp_path):
     test = ShellTest(shell).statement("CALL enable_logging(storage = 'file', storage_config = {'path': 'hello'});")
 


### PR DESCRIPTION
This PR introduces an `unordered_set` in the `ShellLogStorage` to store a hash of each printed log. This can then be used to ensure no duplicate logs are printed. 

Fixes: https://github.com/duckdblabs/duckdb-internal/issues/6894