### PR TITLE
Fix TopNWindowElimination crash with DEBUG verification projections

### DIFF
--- a/src/include/duckdb/optimizer/topn_window_elimination.hpp
+++ b/src/include/duckdb/optimizer/topn_window_elimination.hpp
@@ -51,8 +51,9 @@ private:
 
 	vector<unique_ptr<Expression>> GenerateAggregatePayload(const vector<ColumnBinding> &bindings,
 	                                                        const LogicalWindow &window, map<idx_t, idx_t> &group_idxs);
-	vector<ColumnBinding> TraverseProjectionBindings(const std::vector<ColumnBinding> &old_bindings,
-	                                                 reference<LogicalOperator> &op);
+	vector<ColumnBinding>
+	TraverseProjectionBindings(std::vector<ColumnBinding> &topmost_bindings, reference<LogicalOperator> &op,
+	                           vector<pair<ColumnBinding, unique_ptr<Expression>>> &constant_bindings);
 	unique_ptr<Expression> CreateAggregateExpression(vector<unique_ptr<Expression>> aggregate_params, bool requires_arg,
 	                                                 const TopNWindowEliminationParameters &params) const;
 	unique_ptr<Expression> CreateRowNumberGenerator(unique_ptr<Expression> aggregate_column_ref) const;

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -318,3 +318,77 @@ SELECT * FROM a, LATERAL (SELECT *, a_id AS id_dup FROM b ORDER BY array_distanc
 [1.0, 2.0, 3.0]	1	[1.0, 2.0, 3.0]	a	1
 [4.0, 5.0, 6.0]	2	[4.0, 5.0, 6.0]	b	2
 
+# Test that constant expressions in projections between Filter and Window are handled correctly
+statement ok
+CREATE TABLE small_test AS SELECT i % 3 as grp, i as val FROM range(20) t(i);
+
+query I
+SELECT count(*) FROM (
+    SELECT row_number() OVER (PARTITION BY grp ORDER BY val DESC) as rk, grp, val
+    FROM small_test
+) WHERE rk <= 3;
+----
+9
+
+statement ok
+SET disabled_optimizers = 'filter_pushdown';
+
+query IIII
+SELECT * FROM (
+    SELECT 1 AS one, row_number() OVER (PARTITION BY grp ORDER BY val DESC) as rk, grp, val
+    FROM small_test
+) WHERE rk <= 3
+ORDER BY grp, rk;
+----
+1	1	0	18
+1	2	0	15
+1	3	0	12
+1	1	1	19
+1	2	1	16
+1	3	1	13
+1	1	2	17
+1	2	2	14
+1	3	2	11
+
+query II
+EXPLAIN SELECT * FROM (
+    SELECT 1 AS one, row_number() OVER (PARTITION BY grp ORDER BY val DESC) as rk, grp, val
+    FROM small_test
+) WHERE rk <= 3;
+----
+logical_opt	<!REGEX>:.*FILTER.*WINDOW.*
+
+query IIII
+SELECT * FROM (
+    SELECT one + grp, rk, grp, val FROM (
+        SELECT 1 AS one, row_number() OVER (PARTITION BY grp ORDER BY val DESC) as rk, grp, val
+        FROM small_test
+    ) t
+) WHERE rk <= 3
+ORDER BY grp, rk;
+----
+1	1	0	18
+1	2	0	15
+1	3	0	12
+2	1	1	19
+2	2	1	16
+2	3	1	13
+3	1	2	17
+3	2	2	14
+3	3	2	11
+
+# Outer projection references multiple columns (one + grp), violates CanOptimize check
+# that ensures each projection expression references at most one column
+query II
+EXPLAIN SELECT * FROM (
+    SELECT one + grp, rk, grp, val FROM (
+        SELECT 1 AS one, row_number() OVER (PARTITION BY grp ORDER BY val DESC) as rk, grp, val
+        FROM small_test
+    ) t
+) WHERE rk <= 3;
+----
+logical_opt	<REGEX>:.*FILTER.*WINDOW.*
+
+statement ok
+SET disabled_optimizers = '';
+


### PR DESCRIPTION
## Promblem

In DEBUG builds, `ColumnLifetimeAnalyzer::AddVerificationProjection` inserts a projection node between the FILTER and WINDOW operators. This verification projection replaces unreferenced columns with NULL constants to catch lifetime issues.

```
┌─────────────┴─────────────┐
│           FILTER          │
│    ────────────────────   │
│        Expressions:       │
│         (rk <= 3)         │
│                           │
│          ~4 rows          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│        Expressions:       │
│            NULL           │
│           #[5.0]          │
│            NULL           │    <======= the projection with NULL constants
│           #[0.1]          │
│            NULL           │
│           #[0.0]          │
│            NULL           │
│                           │
│          ~20 rows         │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│           WINDOW          │
│    ────────────────────   │
│        Expressions:       │
│     ROW_NUMBER() OVER     │
│ (PARTITION BY grp ORDER BY│
│    val DESC NULLS LAST)   │
│                           │
│          ~20 rows         │
└─────────────┬─────────────┘
```


The `TopNWindowElimination` optimizer pass assumes that all expressions in intermediate projections are column references. In TraverseProjectionBindings, it calls VisitExpression on each binding's corresponding projection expression and immediately dereferences **column_references.begin()**. However, when `VisitExpression` encounters a NULL constant (which contains no column references), column_references is empty, and dereferencing `begin()` on an empty map causes a crash.

## Reproducing
```
CREATE TABLE small_test AS SELECT i % 3 as grp, i as val FROM range(20) t(i);

SELECT count(*) FROM (
  SELECT row_number() OVER (PARTITION BY grp ORDER BY val DESC) as rk, grp, val
  FROM small_test
) WHERE rk <= 3;

[1]    34915 segmentation fault  /.../build/debug/duckdb
```
This crashes in DEBUG builds but works in release builds (since verification projections are only inserted in DEBUG mode).

## Fix
Before traversing the projection chain in `TraverseProjectionBindings`, filter out bindings that point to constant expressions (NULL values from verification projections). These bindings are removed from both new_bindings and topmost_bindings
so they are excluded from subsequent processing. This filtering is wrapped in #ifdef DEBUG since verification projections only exist in DEBUG builds.