### PR TITLE
Optimizing String Serialization

### DIFF
--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -1,7 +1,13 @@
 include_directories(../../third_party/sqlite/include)
 add_library(
-  duckdb_benchmark_micro OBJECT append.cpp append_mix.cpp bulkupdate.cpp
-                                cast.cpp in.cpp storage.cpp)
+  duckdb_benchmark_micro OBJECT
+  append.cpp
+  append_mix.cpp
+  bulkupdate.cpp
+  cast.cpp
+  in.cpp
+  storage.cpp
+  string_serialize.cpp)
 
 set(BENCHMARK_OBJECT_FILES
     ${BENCHMARK_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_benchmark_micro>

--- a/benchmark/micro/string_serialize.cpp
+++ b/benchmark/micro/string_serialize.cpp
@@ -21,15 +21,11 @@ static void InitStringVector() {
 	}
 }
 
-DUCKDB_BENCHMARK(StringSerializationNew, "[string_serializer]")
-void Load(DuckDBBenchmarkState *state) override {
-	InitStringVector();
-}
-void RunBenchmark(DuckDBBenchmarkState *state) override {
+static void RunStringSerializationBenchmark(idx_t serialization_version) {
 	for (idx_t i = 0; i < 10000; i++) {
 		MemoryStream stream;
 		SerializationOptions options;
-		options.serialization_compatibility = SerializationCompatibility::FromIndex(8);
+		options.serialization_compatibility = SerializationCompatibility::FromIndex(serialization_version);
 		BinarySerializer serializer(stream, options);
 		serializer.Begin();
 		string_vector.Serialize(serializer, STANDARD_VECTOR_SIZE, true);
@@ -40,6 +36,14 @@ void RunBenchmark(DuckDBBenchmarkState *state) override {
 		Vector result(LogicalType::VARCHAR, STANDARD_VECTOR_SIZE);
 		result.Deserialize(deserializer, STANDARD_VECTOR_SIZE);
 	}
+}
+
+DUCKDB_BENCHMARK(StringSerializationNew, "[string_serializer]")
+void Load(DuckDBBenchmarkState *state) override {
+	InitStringVector();
+}
+void RunBenchmark(DuckDBBenchmarkState *state) override {
+	RunStringSerializationBenchmark(8);
 }
 string VerifyResult(QueryResult *result) override {
 	return string();
@@ -54,20 +58,7 @@ void Load(DuckDBBenchmarkState *state) override {
 	InitStringVector();
 }
 void RunBenchmark(DuckDBBenchmarkState *state) override {
-	for (idx_t i = 0; i < 1000; i++) {
-		MemoryStream stream;
-		SerializationOptions options;
-		options.serialization_compatibility = SerializationCompatibility::FromIndex(7);
-		BinarySerializer serializer(stream, options);
-		serializer.Begin();
-		string_vector.Serialize(serializer, STANDARD_VECTOR_SIZE, true);
-		serializer.End();
-
-		stream.SetPosition(0);
-		BinaryDeserializer deserializer(stream);
-		Vector result(LogicalType::VARCHAR, STANDARD_VECTOR_SIZE);
-		result.Deserialize(deserializer, STANDARD_VECTOR_SIZE);
-	}
+	RunStringSerializationBenchmark(7);
 }
 string VerifyResult(QueryResult *result) override {
 	return string();

--- a/benchmark/micro/string_serialize.cpp
+++ b/benchmark/micro/string_serialize.cpp
@@ -64,6 +64,6 @@ string VerifyResult(QueryResult *result) override {
 	return string();
 }
 string BenchmarkInfo() override {
-	return "Test string serialization performance - new version";
+	return "Test string serialization performance - old version";
 }
 FINISH_BENCHMARK(StringSerializationOld)

--- a/benchmark/micro/string_serialize.cpp
+++ b/benchmark/micro/string_serialize.cpp
@@ -1,0 +1,78 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark_macro.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/serializer/binary_serializer.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/common/serializer/binary_deserializer.hpp"
+
+using namespace duckdb;
+
+static Vector string_vector(LogicalType::VARCHAR, STANDARD_VECTOR_SIZE);
+
+static void InitStringVector() {
+	auto string_data = FlatVector::GetData<string_t>(string_vector);
+	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+		string_data[i] = StringVector::AddString(string_vector, StringUtil::Repeat("X", i % 100));
+		if (i % 10 == 0) {
+			FlatVector::SetNull(string_vector, i, true);
+		}
+	}
+}
+
+DUCKDB_BENCHMARK(StringSerializationNew, "[string_serializer]")
+void Load(DuckDBBenchmarkState *state) override {
+	InitStringVector();
+}
+void RunBenchmark(DuckDBBenchmarkState *state) override {
+	for (idx_t i = 0; i < 10000; i++) {
+		MemoryStream stream();
+		SerializationOptions options;
+		options.serialization_compatibility = SerializationCompatibility::FromIndex(8);
+		BinarySerializer serializer(stream, options);
+		serializer.Begin();
+		string_vector.Serialize(serializer, STANDARD_VECTOR_SIZE, true);
+		serializer.End();
+
+		stream.SetPosition(0);
+		BinaryDeserializer deserializer(stream);
+		Vector result(LogicalType::VARCHAR, STANDARD_VECTOR_SIZE);
+		result.Deserialize(deserializer, STANDARD_VECTOR_SIZE);
+	}
+}
+string VerifyResult(QueryResult *result) override {
+	return string();
+}
+string BenchmarkInfo() override {
+	return "Test string serialization performance - new version";
+}
+FINISH_BENCHMARK(StringSerializationNew)
+
+DUCKDB_BENCHMARK(StringSerializationOld, "[string_serializer]")
+void Load(DuckDBBenchmarkState *state) override {
+	InitStringVector();
+}
+void RunBenchmark(DuckDBBenchmarkState *state) override {
+	for (idx_t i = 0; i < 1000; i++) {
+		MemoryStream stream;
+		SerializationOptions options;
+		options.serialization_compatibility = SerializationCompatibility::FromIndex(7);
+		BinarySerializer serializer(stream, options);
+		serializer.Begin();
+		string_vector.Serialize(serializer, STANDARD_VECTOR_SIZE, true);
+		serializer.End();
+
+		stream.SetPosition(0);
+		BinaryDeserializer deserializer(stream);
+		Vector result(LogicalType::VARCHAR, STANDARD_VECTOR_SIZE);
+		result.Deserialize(deserializer, STANDARD_VECTOR_SIZE);
+	}
+}
+string VerifyResult(QueryResult *result) override {
+	return string();
+}
+string BenchmarkInfo() override {
+	return "Test string serialization performance - new version";
+}
+FINISH_BENCHMARK(StringSerializationOld)

--- a/benchmark/micro/string_serialize.cpp
+++ b/benchmark/micro/string_serialize.cpp
@@ -26,8 +26,8 @@ void Load(DuckDBBenchmarkState *state) override {
 	InitStringVector();
 }
 void RunBenchmark(DuckDBBenchmarkState *state) override {
-	for (idx_t i = 0; i < 10000; i++) {
-		MemoryStream stream();
+	for (idx_t i = 0; i < 1000; i++) {
+		MemoryStream stream;
 		SerializationOptions options;
 		options.serialization_compatibility = SerializationCompatibility::FromIndex(8);
 		BinarySerializer serializer(stream, options);

--- a/benchmark/micro/string_serialize.cpp
+++ b/benchmark/micro/string_serialize.cpp
@@ -26,7 +26,7 @@ void Load(DuckDBBenchmarkState *state) override {
 	InitStringVector();
 }
 void RunBenchmark(DuckDBBenchmarkState *state) override {
-	for (idx_t i = 0; i < 1000; i++) {
+	for (idx_t i = 0; i < 10000; i++) {
 		MemoryStream stream;
 		SerializationOptions options;
 		options.serialization_compatibility = SerializationCompatibility::FromIndex(8);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1375,13 +1375,10 @@ void Vector::Serialize(Serializer &serializer, idx_t count, bool compressed_seri
 				// write the bytes
 				auto byte_data = make_unsafe_uniq_array_uninitialized<data_t>(byte_data_length);
 				// write the non-null strings
-				auto string_write_ptr = reinterpret_cast<data_t *>(byte_data.get()) + sizeof(uint32_t) * count;
+				auto string_write_ptr = byte_data.get();
 				for (idx_t i = 0; i < count; i++) {
 					auto idx = vdata.sel->get_index(i);
-					if (!vdata.validity.RowIsValid(idx)) {
-						continue;
-					}
-					auto this_length = strings[idx].GetSize();
+					auto this_length = vdata.validity.RowIsValid(idx) ?  strings[idx].GetSize() : 0;
 					memcpy(string_write_ptr, strings[idx].GetData(), this_length);
 					string_write_ptr += this_length;
 				}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1504,7 +1504,8 @@ void Vector::Deserialize(Deserializer &deserializer, idx_t count) {
 		switch (logical_type.InternalType()) {
 		case PhysicalType::VARCHAR: {
 			auto strings = FlatVector::GetData<string_t>(*this);
-			auto byte_data_length = deserializer.ReadProperty<optional_idx>(108, "byte_data_length");
+			auto byte_data_length =
+			    deserializer.ReadPropertyWithExplicitDefault<optional_idx>(108, "byte_data_length", optional_idx());
 			if (byte_data_length.IsValid()) { // new serialization
 				auto length_data_length = count * sizeof(uint32_t);
 				auto length_data = make_unsafe_uniq_array_uninitialized<data_t>(length_data_length);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1353,13 +1353,49 @@ void Vector::Serialize(Serializer &serializer, idx_t count, bool compressed_seri
 		switch (logical_type.InternalType()) {
 		case PhysicalType::VARCHAR: {
 			auto strings = UnifiedVectorFormat::GetData<string_t>(vdata);
+			// new way to serialize strings, two blobs, first lengths, then string bytes
+			if (serializer.ShouldSerialize(8)) {
+				// we write all the lengths whether the string is null or not. lets not pull a parquet.
+				auto length_data_length = sizeof(uint32_t) * count;
+				auto length_data = make_unsafe_uniq_array_uninitialized<data_t>(length_data_length);
+				idx_t byte_data_length = 0;
 
-			// Serialize data as a list
-			serializer.WriteList(102, "data", count, [&](Serializer::List &list, idx_t i) {
-				auto idx = vdata.sel->get_index(i);
-				auto str = !vdata.validity.RowIsValid(idx) ? NullValue<string_t>() : strings[idx];
-				list.WriteElement(str);
-			});
+				// write all the lengths
+				auto lenghs_write_ptr = reinterpret_cast<uint32_t *>(length_data.get());
+				for (idx_t i = 0; i < count; i++) {
+					auto idx = vdata.sel->get_index(i);
+					auto this_length = vdata.validity.RowIsValid(idx) ? strings[idx].GetSize() : 0;
+					lenghs_write_ptr[i] = UnsafeNumericCast<uint32_t>(this_length);
+					byte_data_length += this_length;
+				}
+				// this is not strictly required because its implicit from count and length type
+				serializer.WriteProperty(107, "length_data_length", optional_idx(length_data_length));
+				serializer.WriteProperty(108, "length_data", length_data.get(), length_data_length);
+
+				// write the bytes
+				auto byte_data = make_unsafe_uniq_array_uninitialized<data_t>(byte_data_length);
+				// write the non-null strings
+				auto string_write_ptr = reinterpret_cast<data_t *>(byte_data.get()) + sizeof(uint32_t) * count;
+				for (idx_t i = 0; i < count; i++) {
+					auto idx = vdata.sel->get_index(i);
+					if (!vdata.validity.RowIsValid(idx)) {
+						continue;
+					}
+					auto this_length = strings[idx].GetSize();
+					memcpy(string_write_ptr, strings[idx].GetData(), this_length);
+					string_write_ptr += this_length;
+				}
+				// ship it!
+				serializer.WriteProperty(109, "byte_data_length", optional_idx(byte_data_length));
+				serializer.WriteProperty(110, "byte_data", byte_data.get(), byte_data_length);
+			} else { // old and slow way: list
+				serializer.WriteList(102, "data", count, [&](Serializer::List &list, idx_t i) {
+					auto idx = vdata.sel->get_index(i);
+					auto str = !vdata.validity.RowIsValid(idx) ? NullValue<string_t>() : strings[idx];
+					list.WriteElement(str);
+				});
+			}
+
 			break;
 		}
 		case PhysicalType::STRUCT: {
@@ -1421,6 +1457,14 @@ void Vector::Serialize(Serializer &serializer, idx_t count, bool compressed_seri
 	}
 }
 
+class StringDeserializeBuffer : public VectorBuffer {
+public:
+	StringDeserializeBuffer(idx_t size) : VectorBuffer(VectorBufferType::OPAQUE_BUFFER) {
+		data = unique_ptr<data_t[]>(new data_t[size]);
+	}
+	unique_ptr<data_t[]> data;
+};
+
 void Vector::Deserialize(Deserializer &deserializer, idx_t count) {
 	auto &logical_type = GetType();
 	const auto vtype = // older versions that only supported flat vectors did not serialize vector_type,
@@ -1465,12 +1509,37 @@ void Vector::Deserialize(Deserializer &deserializer, idx_t count) {
 		switch (logical_type.InternalType()) {
 		case PhysicalType::VARCHAR: {
 			auto strings = FlatVector::GetData<string_t>(*this);
-			deserializer.ReadList(102, "data", [&](Deserializer::List &list, idx_t i) {
-				auto str = list.ReadElement<string>();
-				if (validity.RowIsValid(i)) {
-					strings[i] = StringVector::AddStringOrBlob(*this, str);
+			auto length_data_length = deserializer.ReadPropertyWithExplicitDefault<optional_idx>(
+			    107, "length_data_length", optional_idx::Invalid());
+
+			if (length_data_length.IsValid()) { // new serialization
+				D_ASSERT(length_data_length.GetIndex() == count * sizeof(uint32_t));
+				auto length_data = make_unsafe_uniq_array_uninitialized<data_t>(length_data_length.GetIndex());
+				deserializer.ReadProperty(108, "length_data", length_data.get(), length_data_length.GetIndex());
+
+				auto byte_data_length = deserializer.ReadProperty<optional_idx>(109, "byte_data_length");
+				auto byte_data_buffer = make_buffer<StringDeserializeBuffer>(byte_data_length.GetIndex());
+				// directly read into a string buffer we can glue to the vector
+				deserializer.ReadProperty(110, "byte_data", byte_data_buffer->data.get(), byte_data_length.GetIndex());
+				auto lengths_read_ptr = reinterpret_cast<uint32_t *>(length_data.get());
+				auto byte_read_ptr = reinterpret_cast<const char *>(byte_data_buffer->data.get());
+				StringVector::AddBuffer(*this, byte_data_buffer);
+
+				for (idx_t i = 0; i < count; ++i) {
+					if (!validity.RowIsValid(i)) {
+						continue;
+					}
+					strings[i] = string_t(byte_read_ptr, lengths_read_ptr[i]);
+					byte_read_ptr += byte_read_ptr[i];
 				}
-			});
+			} else { // this is ye olde way of string serialization, it is no longer produced but we can still decode it
+				deserializer.ReadList(102, "data", [&](Deserializer::List &list, idx_t i) {
+					auto str = list.ReadElement<string>();
+					if (validity.RowIsValid(i)) {
+						strings[i] = StringVector::AddStringOrBlob(*this, str);
+					}
+				});
+			}
 			break;
 		}
 		case PhysicalType::STRUCT: {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1454,7 +1454,7 @@ void Vector::Serialize(Serializer &serializer, idx_t count, bool compressed_seri
 
 class StringDeserializeBuffer : public VectorBuffer {
 public:
-	StringDeserializeBuffer(idx_t size) : VectorBuffer(VectorBufferType::OPAQUE_BUFFER) {
+	explicit StringDeserializeBuffer(idx_t size) : VectorBuffer(VectorBufferType::OPAQUE_BUFFER) {
 		data = unique_ptr<data_t[]>(new data_t[size]);
 	}
 	unique_ptr<data_t[]> data;


### PR DESCRIPTION
When serializing string vectors, we used to rely on the serializer's list functionality. However, this is pretty slow. This PR changes the string serialization to bulk mode, we write three fields:

- a byte blob that contains string lengths, `uint32_t` for each entry in the vector
- a length of the actual string values byte blob
- a byte blob with all the string values in the vector, back-to-back

This should be backwards-compatible in that we can still produce and consume the 'old' way, but will use the 'new' way when the compatibility version allows for it.

This PR also adds a benchmark to test the new serialization method, on my MacBook:

```
StringSerializationNew	1	0.247558
StringSerializationNew	2	0.246929
StringSerializationNew	3	0.246703
StringSerializationNew	4	0.256129
StringSerializationNew	5	0.250203
StringSerializationOld	1	1.404589
StringSerializationOld	2	1.413293
StringSerializationOld	3	1.403808
StringSerializationOld	4	1.399365
StringSerializationOld	5	1.401175
```

roughly a 5x speed up. 