### PR TITLE
[PEG Parser] Fix statement length and offset not being set correctly

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -840,16 +840,22 @@ public:
 				auto statement = transformer.Transform(tokenized_statement, options);
 				if (statement) {
 					statement->stmt_location = NumericCast<idx_t>(tokenized_statement[0].offset);
-					auto last_pos = tokenized_statement[tokenized_statement.size() - 1].offset +
-					                tokenized_statement[tokenized_statement.size() - 1].length;
-					statement->stmt_length = last_pos - tokenized_statement[0].offset;
 				}
 				statement->query = query;
-				if (statement->type == StatementType::CREATE_STATEMENT) {
-					auto &create = statement->Cast<CreateStatement>();
-					create.info->sql = statement->query;
-				}
 				result.push_back(std::move(statement));
+			}
+			if (!result.empty()) {
+				auto &last_statement = result.back();
+				last_statement->stmt_length = query.size() - last_statement->stmt_location;
+				for (auto &statement : result) {
+					statement->query = query.substr(statement->stmt_location, statement->stmt_length);
+					statement->stmt_location = 0;
+					statement->stmt_length = statement->query.size();
+					if (statement->type == StatementType::CREATE_STATEMENT) {
+						auto &create = statement->Cast<CreateStatement>();
+						create.info->sql = statement->query;
+					}
+				}
 			}
 			return ParserOverrideResult(std::move(result));
 		} catch (std::exception &e) {

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -838,18 +838,20 @@ public:
 				}
 				auto &transformer = PEGTransformerFactory::GetInstance();
 				auto statement = transformer.Transform(tokenized_statement, options);
-				if (statement) {
-					statement->stmt_location = NumericCast<idx_t>(tokenized_statement[0].offset);
-					statement->stmt_length =
-					    NumericCast<idx_t>(tokenized_statement[tokenized_statement.size() - 1].offset +
-					                       tokenized_statement[tokenized_statement.size() - 1].length);
-				}
-				statement->query = query;
-				if (statement->type == StatementType::CREATE_STATEMENT) {
-					auto &create = statement->Cast<CreateStatement>();
-					create.info->sql = statement->query;
-				}
 				result.push_back(std::move(statement));
+			}
+			if (!result.empty()) {
+				auto &last_statement = result.back();
+				last_statement->stmt_length = query.size() - last_statement->stmt_location;
+				for (auto &statement : result) {
+					statement->query = query.substr(statement->stmt_location, statement->stmt_length);
+					statement->stmt_location = 0;
+					statement->stmt_length = statement->query.size();
+					if (statement->type == StatementType::CREATE_STATEMENT) {
+						auto &create = statement->Cast<CreateStatement>();
+						create.info->sql = statement->query;
+					}
+				}
 			}
 			return ParserOverrideResult(std::move(result));
 		} catch (std::exception &e) {

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -838,6 +838,10 @@ public:
 				}
 				auto &transformer = PEGTransformerFactory::GetInstance();
 				auto statement = transformer.Transform(tokenized_statement, options);
+				if (statement) {
+					// Only location seems to be used, offset is determined in the loop below
+					statement->stmt_location = tokenized_statement[0].offset;
+				}
 				result.push_back(std::move(statement));
 			}
 			if (!result.empty()) {

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -839,10 +839,6 @@ public:
 				auto &transformer = PEGTransformerFactory::GetInstance();
 				auto statement = transformer.Transform(tokenized_statement, options);
 				if (statement) {
-					// Only location seems to be used, offset is determined in the loop below
-					statement->stmt_location = tokenized_statement[0].offset;
-				}
-				if (statement) {
 					statement->stmt_location = NumericCast<idx_t>(tokenized_statement[0].offset);
 					auto last_pos = tokenized_statement[tokenized_statement.size() - 1].offset +
 					                tokenized_statement[tokenized_statement.size() - 1].length;

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -840,6 +840,9 @@ public:
 				auto statement = transformer.Transform(tokenized_statement, options);
 				if (statement) {
 					statement->stmt_location = NumericCast<idx_t>(tokenized_statement[0].offset);
+					auto last_pos = tokenized_statement[tokenized_statement.size() - 1].offset +
+					                tokenized_statement[tokenized_statement.size() - 1].length;
+					statement->stmt_length = last_pos - tokenized_statement[0].offset;
 				}
 				statement->query = query;
 				result.push_back(std::move(statement));

--- a/test/sql/peg_parser/transformer/statement_length.test
+++ b/test/sql/peg_parser/transformer/statement_length.test
@@ -1,0 +1,20 @@
+# name: test/sql/peg_parser/transformer/alter_statement.test
+# description: Test setting the statement length and offset 
+# group: [transformer]
+
+require autocomplete
+
+statement ok
+SET allow_parser_override_extension = strict;
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok 
+ATTACH ':memory:' AS memory_compressed (COMPRESS);
+
+statement ok 
+ATTACH ':memory:' AS memory_comp;
+
+statement ok 
+COPY FROM DATABASE memory_comp TO memory_compressed;

--- a/test/sql/peg_parser/transformer/statement_length.test
+++ b/test/sql/peg_parser/transformer/statement_length.test
@@ -1,5 +1,5 @@
-# name: test/sql/peg_parser/transformer/alter_statement.test
-# description: Test setting the statement length and offset 
+# name: test/sql/peg_parser/transformer/statement_length.test
+# description: Test setting the statement length and offset
 # group: [transformer]
 
 require autocomplete


### PR DESCRIPTION
Part of epic: https://github.com/duckdblabs/duckdb-internal/issues/6380

Turns out I wasn't setting the statement length and statement offset properly if we need to transform multiple statements. 

The following case would crash: 
```sql
SET allow_parser_override_extension = strict;
PRAGMA enable_verification;
ATTACH ':memory:' AS memory_compressed (COMPRESS);
ATTACH ':memory:' AS memory_comp;
COPY FROM DATABASE memory_comp TO memory_compressed;
```

```bash
Invalid Error:
basic_string
```

The `COPY` becomes `PRAGMA copy_database('memory_comp', 'memory_compressed');` which in turn triggers: 
```sql
COPY FROM DATABASE memory_comp TO memory_compressed (SCHEMA);\nCOPY FROM DATABASE memory_comp TO memory_compressed (DATA)
```


Thanks @carlopi for the bug report!