### PR TITLE
LateMaterialize LHS missing table filters

### DIFF
--- a/src/include/duckdb/planner/table_filter.hpp
+++ b/src/include/duckdb/planner/table_filter.hpp
@@ -113,6 +113,15 @@ public:
 		return left->Equals(*right);
 	}
 
+	void CopyIntoFiltering(TableFilterSet &into,
+	                       const std::function<bool(TableFilterType)> &filter_type_predicate) const {
+		for (auto &it : filters) {
+			if (filter_type_predicate(it.second->filter_type)) {
+				into.filters.emplace(it.first, it.second->Copy());
+			}
+		}
+	}
+
 	unique_ptr<TableFilterSet> Copy() const {
 		auto copy = make_uniq<TableFilterSet>();
 		for (auto &it : filters) {

--- a/src/main/user_settings.cpp
+++ b/src/main/user_settings.cpp
@@ -125,9 +125,11 @@ shared_ptr<CachedGlobalSettings> GlobalUserSettings::GetSettings(shared_ptr<Cach
 	}
 	lock_guard<mutex> guard(lock);
 	// check if another thread updated the cache while we were waiting for the lock
-	if (cache && current_version == cache->version) {
+	auto updated_cache = cache.atomic_load(std::memory_order_relaxed);
+	auto updated_version = settings_version.load(std::memory_order_relaxed);
+	if (updated_cache && updated_version == updated_cache->version) {
 		// already written - load
-		return cache;
+		return updated_cache;
 	}
 	auto new_cache = make_shared_ptr<CachedGlobalSettings>(settings_version, settings_map);
 	cache.atomic_store(new_cache);

--- a/src/optimizer/late_materialization_helper.cpp
+++ b/src/optimizer/late_materialization_helper.cpp
@@ -13,6 +13,10 @@ unique_ptr<LogicalGet> LateMaterializationHelper::CreateLHSGet(const LogicalGet 
 	new_get->named_parameters = rhs.named_parameters;
 	new_get->input_table_types = rhs.input_table_types;
 	new_get->input_table_names = rhs.input_table_names;
+	rhs.table_filters.CopyIntoFiltering(new_get->table_filters, [](TableFilterType filter_type) {
+		// Exclude filters not required for correctness
+		return filter_type != TableFilterType::OPTIONAL_FILTER;
+	});
 	return new_get;
 }
 

--- a/test/sql/optimizer/late_materialization_table_filter.test
+++ b/test/sql/optimizer/late_materialization_table_filter.test
@@ -1,0 +1,22 @@
+# name: test/sql/optimizer/late_materialization_table_filter.test
+# description: Test that table filters are correctly applied to LHS in late materialization
+# group: [optimizer]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE test as SELECT i, 100 - i AS j FROM range(100) t(i);
+
+statement ok
+SET explain_output='optimized_only'
+
+# Verify late materialization is triggered and filter is pushed to BOTH scans
+# The filter i>=90 must appear twice in the plan (once for each scan)
+# Without the fix, the LHS scan has no filter, causing full table scans
+query II
+EXPLAIN SELECT * FROM test WHERE i >= 90 ORDER BY j DESC LIMIT 3;
+----
+logical_opt	<REGEX>:.*i>=90.*i>=90.*


### PR DESCRIPTION
This caused a bug in DuckLake queries: adding an offset and limit would trigger a full-table scan of a potentially huge, partitioned dataset because the filters were missing on the LHS. The join was probably filtering out all the incorrect rows normally, so the result set was correct, but it did unnecessary work in the process.

While debugging this, I hit an ASAN violation and fixed that in a separate commit.

This should fix: https://github.com/duckdb/ducklake/issues/745