### PR TITLE
Bring back 'cli' as duckdb_api for shell/CLI

### DIFF
--- a/tools/shell/shell_extension.cpp
+++ b/tools/shell/shell_extension.cpp
@@ -9,6 +9,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifndef DUCKDB_API_CLI
+#define DUCKDB_API_CLI "cli"
+#endif
+
 namespace duckdb {
 
 static void GetEnvFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -49,6 +53,7 @@ void ShellExtension::Load(ExtensionLoader &loader) {
 	    ScalarFunction("getenv", {LogicalType::VARCHAR}, LogicalType::VARCHAR, GetEnvFunction, GetEnvBind));
 
 	auto &config = duckdb::DBConfig::GetConfig(loader.GetDatabaseInstance());
+	config.SetOptionByName("duckdb_api", DUCKDB_API_CLI);
 	config.replacement_scans.push_back(duckdb::ReplacementScan(duckdb::ShellScanLastResult));
 }
 


### PR DESCRIPTION
Stripped down version of https://github.com/duckdb/duckdb/pull/20813

v1.4.4:
```
duckdb -c "PRAGMA user_agent;"
┌──────────────────────────────┐
│          user_agent          │
│           varchar            │
├──────────────────────────────┤
│ duckdb/v1.4.4(osx_arm64) cli │
└──────────────────────────────┘
```

v1.5-variegata:
```
make && ./build/release/duckdb -c "PRAGMA user_agent;"
┌──────────────────────────────────────┐
│              user_agent              │
│               varchar                │
├──────────────────────────────────────┤
│ duckdb/v1.5.0-dev6852(osx_arm64) cpp │
└──────────────────────────────────────┘
```

After the PR:
```
make && ./build/release/duckdb -c "PRAGMA user_agent;"
┌──────────────────────────────────────┐
│              user_agent              │
│               varchar                │
├──────────────────────────────────────┤
│ duckdb/v1.5.0-dev6853(osx_arm64) cli │
└──────────────────────────────────────┘
```