### PR TITLE
Use WHOLE_ARCHIVE instead of relying on link ordering for duckdb_generated_extension_loader

### DIFF
--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -103,10 +103,6 @@ add_definitions(-DDUCKDB_PATCH_VERSION=${DUCKDB_PATCH_VERSION})
 
 add_library(duckdb_generated_extension_loader STATIC ${GENERATED_CPP_FILE})
 
-set(ALL_OBJECT_FILES
-    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_generated_extension_loader>
-    PARENT_SCOPE)
-
 install(
   TARGETS duckdb_generated_extension_loader
   EXPORT "${DUCKDB_EXPORT_SET}"

--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -53,9 +53,9 @@ function(get_statically_linked_extensions DUCKDB_EXTENSION_NAMES OUT_VARIABLE)
 endfunction()
 
 function(link_extension_libraries LIBRARY LINKAGE)
-    target_link_libraries(${LIBRARY} ${LINKAGE} duckdb_generated_extension_loader)
+    target_link_libraries(${LIBRARY} ${LINKAGE} "$<LINK_LIBRARY:WHOLE_ARCHIVE,duckdb_generated_extension_loader>")
     get_statically_linked_extensions("${DUCKDB_EXTENSION_NAMES}" STATICALLY_LINKED_EXTENSIONS)
-    # Now link against any registered out-of-tree extensions
+    # Link against any registered out-of-tree extensions
     foreach(EXT_NAME IN LISTS STATICALLY_LINKED_EXTENSIONS)
         string(TOUPPER ${EXT_NAME} EXT_NAME_UPPERCASE)
         if (${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_SHOULD_LINK})


### PR DESCRIPTION
Followup on https://github.com/duckdb/duckdb/pull/20698

The linking on Linux can be brittle for upstream consumers of `duckdb_generated_extension_loader` if we rely on the ordering of the linking.

On Linux the `--as-needed` flag is set by default when linking. This will remove symbols if the linker hasn't seen any usages up to that point. If `duckdb_static`, which depends on `duckdb_generated_extension_loader`, is linked in later, then at that point the symbols have already been removed. For Python, this resulted in a runtime resolution problem:

```
  ImportError: /Users/evert/projects/duckdb-python/lima/workspace/temp/.venv/lib/python3
  .12/site-packages/_duckdb.cpython-312d-aarch64-linux-gnu.so: undefined symbol:
  _ZN6duckdb15ExtensionHelper17LoadAllExtensionsERNS_6DuckDBE
```

The initial fix by @carlopi worked because it made sure that the order was correct. This fix uses [WHOLE_ARCHIVE](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_LINK_LIBRARY_USING_FEATURE.html#predefined-features), which removes the `--as-needed` flag and replaces it with `--whole-archive`, which makes sure the symbols are included even if the linker did not see usage yet.