### PR TITLE
Add `-h` alias for `-help` command line option

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -120,6 +120,7 @@ struct CommandLineOption {
 	metadata_command_t pre_init_callback;
 	metadata_command_t post_init_callback;
 	const char *description;
+	const duckdb::unordered_set<string> aliases;
 };
 
 struct MetadataCommand {

--- a/tools/shell/shell_command_line_option.cpp
+++ b/tools/shell/shell_command_line_option.cpp
@@ -160,7 +160,7 @@ static const CommandLineOption command_line_options[] = {
     {"f", 1, "FILENAME", EnableBatch, ProcessFile, "read/process named file and exit"},
     {"init", 1, "FILENAME", SetInitFile, nullptr, "read/process named file"},
     {"header", 0, "", nullptr, ToggleHeader<true>, "turn headers on"},
-    {"help", 0, "", EnableBatch, PrintHelpAndExit, "show this message"},
+    {"help", 0, "", EnableBatch, PrintHelpAndExit, "show this message", {"h"}},
     {"html", 0, "", nullptr, ToggleOutputMode<RenderMode::HTML>, "set output mode to HTML"},
     {"interactive", 0, "", nullptr, DisableBatch, "force interactive I/O"},
     {"json", 0, "", nullptr, ToggleOutputMode<RenderMode::JSON>, "set output mode to 'json'"},
@@ -189,6 +189,13 @@ optional_idx FindOption(const char *name) {
 	for (idx_t c = 0; command_line_options[c].option; c++) {
 		auto &option = command_line_options[c];
 		if (!StringUtil::Equals(name, option.option)) {
+			// check aliases
+			for (auto &alias : option.aliases) {
+				if (StringUtil::Equals(name, alias)) {
+					return c;
+				}
+			}
+
 			// not this one
 			continue;
 		}

--- a/tools/shell/tests/test_command_line_arguments.py
+++ b/tools/shell/tests/test_command_line_arguments.py
@@ -86,5 +86,19 @@ def test_storage_version_error(shell):
     result = test.run()
     result.check_stderr("XXX")
 
+def test_help_alias(shell):
+    test = (
+        ShellTest(shell)
+        .add_argument("--help")
+    )
+    result = test.run()
+    result.check_stdout("Usage:")
+
+    test = (
+        ShellTest(shell)
+        .add_argument("-h")
+    )
+    result = test.run()
+    result.check_stdout("Usage:")
 
 # fmt: on


### PR DESCRIPTION
Closes: https://github.com/duckdblabs/duckdb-internal/issues/7322