### PR TITLE
Make row group pruner deal correctly with all-null row groups

### DIFF
--- a/src/optimizer/row_group_pruner.cpp
+++ b/src/optimizer/row_group_pruner.cpp
@@ -79,6 +79,9 @@ bool RowGroupPruner::TryOptimize(LogicalOperator &op) const {
 	const auto &primary_order = logical_order->orders[0];
 	auto options = CreateRowGroupReordererOptions(row_limit, row_offset, primary_order, *logical_get, storage_index,
 	                                              logical_limit);
+	if (!options) {
+		return false;
+	}
 	logical_get->SetScanOrder(std::move(options));
 
 	return true;

--- a/test/sql/topn/top_n_pruning.test
+++ b/test/sql/topn/top_n_pruning.test
@@ -152,15 +152,16 @@ EXPLAIN ANALYZE SELECT * FROM t ORDER BY i LIMIT 1 OFFSET 2
 ----
 analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
 
-query II
-EXPLAIN ANALYZE SELECT * FROM t ORDER BY i LIMIT 2 OFFSET 6144
-----
-analyzed_plan	<REGEX>:.*TABLE_SCAN.*4,096 rows.*
+# FIXME: we don't yet do pruning with NULL values
+# query II
+# EXPLAIN ANALYZE SELECT * FROM t ORDER BY i LIMIT 2 OFFSET 6144
+# ----
+# analyzed_plan	<REGEX>:.*TABLE_SCAN.*4,096 rows.*
 
-query II
-EXPLAIN ANALYZE SELECT * FROM t ORDER BY i LIMIT 1 OFFSET 8192
-----
-analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
+# query II
+# EXPLAIN ANALYZE SELECT * FROM t ORDER BY i LIMIT 1 OFFSET 8192
+# ----
+# analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
 
 statement ok
 INSERT INTO t SELECT 9 i UNION ALL SELECT i FROM repeat(NULL, 2046) t1(i) UNION ALL SELECT 10 i


### PR DESCRIPTION
The current row group pruner does not deal correctly with all null row groups (in fact, it does not look at the `NULLS FIRST / NULLS LAST` ordering at all). As a result, the logic is incorrect, leading to potentially wrong results. For example:

```
build/reldebug/test/unittest test/sql/topn/test_top_n_nulls_large.test_slow --test-config test/configs/force_storage_restart.json
```
```
================================================================================
SELECT i FROM integers ORDER BY i NULLS LAST LIMIT 5 OFFSET 1000000;
================================================================================
Actual result:
================================================================================
Invalid Error: Unoptimized statement differs from original result!
Original Result:
i	
BIGINT	
[ Rows: 5]
983040
983041
983042
983043
983044

Unoptimized:
i	
BIGINT	
[ Rows: 5]
NULL
NULL
NULL
NULL
NULL
```

This PR makes row groups disables pruning for row groups that are all `NULL`. In the future this should ideally be re-enabled, but I think that can only be done by extending the optimizer to take `NULLS FIRST / NULLS LAST` into account.