### PR TITLE
Avoid throwing internal exception when writing variant with UINT128 to Parquet

### DIFF
--- a/extension/parquet/writer/variant/analyze_variant.cpp
+++ b/extension/parquet/writer/variant/analyze_variant.cpp
@@ -165,7 +165,7 @@ void VariantColumnWriter::AnalyzeSchemaFinalize(const ParquetAnalyzeSchemaState 
 	auto shredded_type = ConstructShreddedType(state.analyze_data);
 	is_analyzed = true;
 
-	if (shredded_type.id() == LogicalTypeId::VARIANT) {
+	if (shredded_type.id() == LogicalTypeId::VARIANT || shredded_type.id() == LogicalTypeId::INVALID) {
 		//! Can't shred, keep the original children
 		return;
 	}

--- a/test/parquet/variant/variant_invalid_type.test
+++ b/test/parquet/variant/variant_invalid_type.test
@@ -1,0 +1,9 @@
+# name: test/parquet/variant/variant_invalid_type.test
+# group: [variant]
+
+require parquet
+
+statement error
+COPY (SELECT 1::hugeint::variant) TO '__TEST_DIR__/invalid_parquet_variant.parquet';
+----
+Can't convert


### PR DESCRIPTION
Instead we throw the expected "Can't convert UINT128" error