### PR TITLE
Respect affinity mask of main process when pinning

### DIFF
--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -547,8 +547,10 @@ void TaskScheduler::RelaunchThreadsInternal(int32_t n) {
 		current_thread_count = NumericCast<int32_t>(threads.size() + external_threads);
 		return;
 	}
-	if (threads.size() > new_thread_count) {
-		// we are reducing the number of threads: clear all threads first
+	if (threads.size() != new_thread_count) {
+		// we are changing the number of threads: clear all threads first
+		// we do this even when increasing the number of threads to make sure that all threads follow the current
+		// affinity mask
 		for (idx_t i = 0; i < threads.size(); i++) {
 			*markers[i] = false;
 		}

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -525,15 +525,16 @@ static vector<int> GetProcessCPUMask() {
 
 static void SetThreadAffinity(thread &thread, const vector<int> &available_cpus, idx_t thread_idx) {
 #if defined(__GLIBC__)
-	D_ASSERT(thread_idx < available_cpus.size());
-	const auto cpu_id = available_cpus[thread_idx];
-	cpu_set_t cpuset;
-	CPU_ZERO(&cpuset);
-	CPU_SET(cpu_id, &cpuset);
+	if (thread_idx < available_cpus.size()) {
+		const auto cpu_id = available_cpus[thread_idx];
+		cpu_set_t cpuset;
+		CPU_ZERO(&cpuset);
+		CPU_SET(cpu_id, &cpuset);
 
-	// note that we don't care about the return value here
-	// if we did not manage to set affinity, the thread just does not have affinity, which is OK
-	pthread_setaffinity_np(thread.native_handle(), sizeof(cpu_set_t), &cpuset);
+		// note that we don't care about the return value here
+		// if we did not manage to set affinity, the thread just does not have affinity, which is OK
+		pthread_setaffinity_np(thread.native_handle(), sizeof(cpu_set_t), &cpuset);
+	}
 #endif
 }
 #endif


### PR DESCRIPTION
Currently, DuckDB automatically pins threads to cores sequentially (0, 1, ...). This leads to unexpected behavior when the main process is started with a specific affinity mask (for example, via taskset or numactl) because threads may be pinned to cores that are outside the allowed mask. An affinity mask can also be generated in some cases automatically, for example when using clusters managed by Slurm.

This PR changes the pinning behavior so that threads are only pinned to cores present in the affinity mask of the original process.

Consider the example of running DuckDB with `taskset -c 0,1,100,101` using 4 threads.
**Before this PR**: Threads get pinned to cores 0, 1, 2, 3.
**After this PR:** Threads get pinned to cores 0, 1, 100, 101.

