### PR TITLE
Remove index list assertion

### DIFF
--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -182,8 +182,7 @@ void TableIndexList::Bind(ClientContext &context, DataTableInfo &table_info, con
 			}
 		}
 		if (!index_entry) {
-			// We bound all indexes.
-			D_ASSERT(unbound_count == 0);
+			// We bound all indexes. (of this type)
 			break;
 		}
 		if (index_entry->bind_state == IndexBindState::BINDING) {


### PR DESCRIPTION
This assertion doesn't hold if there are other indexes of a different _type_ on the table. E.g. I ran into this in spatial where I tried to delete from a r-tree indexed table with a range filter after a restart, causing the ART index-scan optimizer to try to bind art indexes and then hit this assertion because even if there are no art indexes to bind, we still have a r-tree index left that in this case still is unbound.