### PR TITLE
Start CLI search with what is already in buffer [Retarget to v1.5-variegata]

### DIFF
--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -875,9 +875,10 @@ void Linenoise::EditCapitalizeNextWord(Capitalization capitalization) {
 void Linenoise::StartSearch() {
 	// initiate reverse search
 	search = true;
-	search_buf = std::string();
+	search_buf = std::string(buf, len);
 	search_matches.clear();
 	search_index = 0;
+	PerformSearch();
 	RefreshSearch();
 }
 


### PR DESCRIPTION
Same as https://github.com/duckdb/duckdb/pull/20834 but retargeted for v1.5-variegata

I really like to use the search history in the CLI, but it always starts with an empty search buffer. This PR changes search that it takes what is already written as the start of the search. I think historically search in terminals started with an empty buffer, but my `zsh` takes what's already in the buffer as a start as well, which is where I got the inspiration from.  

Let me know what you think :)

**New behaviour:** 
```sql
memory D set
```
After `CTRL + R` 
```sql
set                   6/24> SET integer_division=true;
```


**Old behaviour:** 
```sql
memory D set
```
After `CTRL + R`
```sql
search                    > (type to search)
```
