### PR TITLE
UHugeInt conversion to Arrow Decimal

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -160,6 +160,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 	case LogicalTypeId::FLOAT:
 		child.format = "f";
 		break;
+	case LogicalTypeId::UHUGEINT:
 	case LogicalTypeId::HUGEINT: {
 		if (options.arrow_lossless_conversion) {
 			SetArrowExtension(root_holder, child, type, context);

--- a/test/arrow/arrow_roundtrip.cpp
+++ b/test/arrow/arrow_roundtrip.cpp
@@ -101,6 +101,21 @@ TEST_CASE("Test Arrow Extension Types", "[arrow][.]") {
 	TestArrowRoundtrip("SELECT '170141183460469231731687303715884105727'::UHUGEINT str FROM range(5) tbl(i)", false,
 	                   true);
 
+	// UHUGEINT (lossy - should export as Decimal(38,0), not extension type)
+	{
+		DuckDB db;
+		Connection con(db);
+		auto client_properties = con.context->GetClientProperties();
+		ArrowSchema schema;
+		schema.Init();
+		vector<LogicalType> types = {LogicalType::UHUGEINT};
+		vector<string> names = {"col"};
+		ArrowConverter::ToArrowSchema(&schema, types, names, client_properties);
+		REQUIRE(schema.n_children == 1);
+		REQUIRE(string(schema.children[0]->format) == "d:38,0");
+		schema.release(&schema);
+	}
+
 	// BIT
 	TestArrowRoundtrip("SELECT '0101011'::BIT str FROM range(5) tbl(i)", false, true);
 


### PR DESCRIPTION
This fixes issue 2 reported in https://github.com/duckdb/duckdb-python/issues/104

For some reason we did not do a lossy conversion from UHugeInt to Arrow decimal if arrow extensions / lossless conversion were disabled. We emitted an extension type anyway. For HugeInt we _did_ already do that. This PR fixes that.