### PR TITLE
Add VERIFY_SSL option as an optional parameter for HTTP secret creation

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -41,6 +41,8 @@ struct HTTPParams {
 	float retry_backoff = DEFAULT_RETRY_BACKOFF;
 	bool keep_alive = DEFAULT_KEEP_ALIVE;
 	bool follow_location = true;
+	bool override_verify_ssl = false;
+	bool verify_ssl = true;
 
 	string http_proxy;
 	idx_t http_proxy_port;

--- a/src/main/secret/default_secrets.cpp
+++ b/src/main/secret/default_secrets.cpp
@@ -26,6 +26,7 @@ vector<CreateSecretFunction> CreateHTTPSecretFunctions::GetDefaultSecretFunction
 	http_config_fun.provider = "config";
 	http_config_fun.function = CreateHTTPSecretFromConfig;
 
+	http_config_fun.named_parameters["verify_ssl"] = LogicalType::BOOLEAN;
 	http_config_fun.named_parameters["http_proxy"] = LogicalType::VARCHAR;
 	http_config_fun.named_parameters["http_proxy_password"] = LogicalType::VARCHAR;
 	http_config_fun.named_parameters["http_proxy_username"] = LogicalType::VARCHAR;
@@ -41,6 +42,7 @@ vector<CreateSecretFunction> CreateHTTPSecretFunctions::GetDefaultSecretFunction
 	http_env_fun.provider = "env";
 	http_env_fun.function = CreateHTTPSecretFromEnv;
 
+	http_env_fun.named_parameters["verify_ssl"] = LogicalType::BOOLEAN;
 	http_env_fun.named_parameters["http_proxy"] = LogicalType::VARCHAR;
 	http_env_fun.named_parameters["http_proxy_password"] = LogicalType::VARCHAR;
 	http_env_fun.named_parameters["http_proxy_username"] = LogicalType::VARCHAR;
@@ -78,6 +80,7 @@ unique_ptr<BaseSecret> CreateHTTPSecretFunctions::CreateHTTPSecretFromEnv(Client
 	}
 
 	// Allow overwrites
+	secret->TrySetValue("verify_ssl", input);
 	secret->TrySetValue("http_proxy", input);
 	secret->TrySetValue("http_proxy_password", input);
 	secret->TrySetValue("http_proxy_username", input);
@@ -92,6 +95,7 @@ unique_ptr<BaseSecret> CreateHTTPSecretFunctions::CreateHTTPSecretFromConfig(Cli
                                                                              CreateSecretInput &input) {
 	auto secret = make_uniq<KeyValueSecret>(input.scope, input.type, input.provider, input.name);
 
+	secret->TrySetValue("verify_ssl", input);
 	secret->TrySetValue("http_proxy", input);
 	secret->TrySetValue("http_proxy_password", input);
 	secret->TrySetValue("http_proxy_username", input);

--- a/test/configs/peg_parser.json
+++ b/test/configs/peg_parser.json
@@ -142,6 +142,10 @@
     {
       "reason": "DESCRIBE with CTE not supported",
       "paths": ["test/sql/cte/cte_describe.test"]
+    },
+    {
+      "reason": "FIXME: CREATE SECRET not properly supported",
+      "paths": ["test/sql/secrets/create_secret_expression.test"]
     }
   ]
 }

--- a/test/configs/peg_parser_strict.json
+++ b/test/configs/peg_parser_strict.json
@@ -187,6 +187,10 @@
     {
       "reason": "DESCRIBE with CTE not supported",
       "paths": ["test/sql/cte/cte_describe.test"]
+    },
+    {
+      "reason": "FIXME: CREATE SECRET not properly supported",
+      "paths": ["test/sql/secrets/create_secret_expression.test"]
     }
   ]
 }

--- a/test/sql/secrets/create_secret_expression.test
+++ b/test/sql/secrets/create_secret_expression.test
@@ -29,3 +29,30 @@ query I
 select scope from duckdb_secrets() where name='scope_as_struct'
 ----
 [hi, hello]
+
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, SCOPE 'https://duckdb.org');
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, SCOPE ['https://duckdb.org', 'http://extensions.duckdb.org']);
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, BEARER_TOKEN getvariable('my_bearer_token'));
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, HTTP_PROXY 'http://some-proxy/');
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, VERIFY_SSL 0);
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, VERIFY_SSL 1);
+
+statement error
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, VERIFY_SSL something);
+----
+Binder Error: Failed to cast option 'verify_ssl' to type 'BOOLEAN'
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, SCOPE ['https://duckdb.org', 'http://extensions.duckdb.org'], BEARER_TOKEN getvariable('my_bearer_token'), HTTP_PROXY 'http://some-proxy/', VERIFY_SSL 1);

--- a/test/sql/secrets/create_secret_expression.test
+++ b/test/sql/secrets/create_secret_expression.test
@@ -17,9 +17,9 @@ statement ok
 CREATE SECRET http (TYPE HTTP, BEARER_TOKEN getvariable('my_bearer_token'));
 
 query I
-SELECT secret_string.split(';')[-1] FROM duckdb_secrets() where name='http';
+SELECT sum(#1 == 'bearer_token=hocus pocus this token is bogus') FROM (SELECT unnest(secret_string.split(';')) FROM duckdb_secrets() where name='http');
 ----
-bearer_token=hocus pocus this token is bogus
+1
 
 # Test "old" syntax from before expressions were allowed
 statement ok


### PR DESCRIPTION
If specified (for a given scope), this will be used to control whether to override whether
to perform SSL verification.

This decouples the protocol from whetehr certificate verification it's run or not, and can be used both directions.

This PR it's step 1 of 3:
1. add verify_ssl as option to HTTP secrets, at the syntax level
2. implement this in httpfs
3. bump httpfs

Once those are in, it would allow to decouples the protocol from whether certificate verification it's run or not, and can be used both directions.

```sql
CREATE SECRET my_secret (TYPE http, HTTP_PROXY 'http://proxy-location:8080');
```
Will have all traffic go through the proxy and certificate will be verified according to whether it's http or https traffic

```sql
CREATE SECRET my_secret (TYPE http, HTTP_PROXY 'http://proxy-location:8080', VERIFY_SSL 1);
```
Will have all traffic go through the proxy have certificate to be verified

```sql
CREATE SECRET my_secret (TYPE http, HTTP_PROXY 'http://proxy-location:8080', VERIFY_SSL 0);
```
Will have all traffic go through the proxy have certificate to be NOT verified

Note that changing default has security implications, so this is to be used with care, expecially with in mind improving local debugging experience.