### PR TITLE
Fixed the issue where `prepared` parameters in a subquery assigned th…

### DIFF
--- a/test/sql/prepared/test_basic_prepare.test
+++ b/test/sql/prepared/test_basic_prepare.test
@@ -77,3 +77,27 @@ PREPARE s2 AS SELECT (SELECT $1)
 statement ok
 PREPARE s3 AS SELECT $1=$2
 
+
+
+
+statement ok
+CREATE TABLE t0(c0 BOOLEAN);
+
+statement ok
+CREATE TABLE t1(c0 VARCHAR, c1 REAL, c2 DATE);
+
+statement ok
+INSERT INTO t1(c1, c2) VALUES (-330443717, TIMESTAMP '1969-12-28 12:12:36');
+
+statement ok
+INSERT INTO t0(c0) VALUES (682835472);
+
+statement ok
+INSERT INTO t1(c2, c1, c0) VALUES (DEFAULT, 0.9487549980256919, 2132590828);
+
+statement ok
+PREPARE prepare_query AS SELECT ? FROM t0 WHERE ((? IS NOT NULL) IN ((SELECT t1.rowid FROM t1 OFFSET ?)));
+
+query I
+EXECUTE prepare_query(TIMESTAMP '1970-01-07 19:02:10', NULL, 163837685);
+----


### PR DESCRIPTION
this pr try fix issue: https://github.com/duckdb/duckdb/issues/20792
i think this issue is caused by a mismatch in the subquery parameter numbers due to expression transformation.
thanks~  :)