### PR TITLE
Optimized calculate the number of bytes to skip directly in file decode_utils.hpp

### DIFF
--- a/extension/parquet/include/decode_utils.hpp
+++ b/extension/parquet/include/decode_utils.hpp
@@ -68,13 +68,11 @@ public:
 			SkipAligned(src, aligned_count, width);
 			count = remainder;
 		}
-		// FIXME: we should be able to just do this in one go instead of having this loop
+		// Optimized version: calculate the number of bytes to skip directly
 		for (idx_t i = 0; i < count; i++) {
 			bitpack_pos += width;
-			while (bitpack_pos > BITPACK_DLEN) {
-				src.unsafe_inc(1);
-				bitpack_pos -= BITPACK_DLEN;
-			}
+			src.unsafe_inc((bitpack_pos - 1) / BITPACK_DLEN);
+			bitpack_pos = (bitpack_pos - 1) % BITPACK_DLEN + 1;
 		}
 	}
 


### PR DESCRIPTION
I noticed a FIXME description in the `decode_utils.hpp` file, so I tried optimizing according to the description, reducing the loop and optimized calculate the number of bytes to skip directly
hope this helps you, thanks~