### PR TITLE
Add CI runner cleanup before Linux CLI builds

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -75,6 +75,8 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
 
     steps:
+    - uses: ./.github/actions/cleanup_runner
+
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -172,6 +174,8 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
 
     steps:
+    - uses: ./.github/actions/cleanup_runner
+
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -75,12 +75,12 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
 
     steps:
-    - uses: ./.github/actions/cleanup_runner
-
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
+
+    - uses: ./.github/actions/cleanup_runner
 
     - name: Install pytest
       run: |
@@ -174,12 +174,12 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
 
     steps:
-    - uses: ./.github/actions/cleanup_runner
-
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
+
+    - uses: ./.github/actions/cleanup_runner
 
     - name: Build
       shell: bash


### PR DESCRIPTION
As a follow-up to #20537 - attempt to fix the following CI failure with `linux_musl`: https://github.com/duckdb/duckdb/actions/runs/21771073041/job/62818578774

Ref: duckdblabs/duckdb-internal#7362