### PR TITLE
CLI: Add "use .last to show entire result" suggestion to the bottom of the box renderer result when rows / columns are hidden

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -2216,7 +2216,8 @@ void BoxRendererImplementation::RenderFooter(BaseResultRenderer &ss, idx_t row_c
 			ss.Render(ResultRenderType::FOOTER, extra_render_str);
 		}
 		// can we add the hidden rows hint to this line?
-		if (!config.hidden_rows_hint.empty() && padding >= config.hidden_rows_hint.size() + 10) {
+		if ((has_hidden_columns || has_hidden_rows) && !config.hidden_rows_hint.empty() &&
+		    padding >= config.hidden_rows_hint.size() + 10) {
 			// we can
 			padding -= config.hidden_rows_hint.size();
 			auto lpadding = padding / 2;

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -2215,7 +2215,19 @@ void BoxRendererImplementation::RenderFooter(BaseResultRenderer &ss, idx_t row_c
 		if (!extra_render_str.empty()) {
 			ss.Render(ResultRenderType::FOOTER, extra_render_str);
 		}
-		ss << string(padding, ' ');
+		// can we add the hidden rows hint to this line?
+		if (!config.hidden_rows_hint.empty() && padding >= config.hidden_rows_hint.size() + 10) {
+			// we can
+			padding -= config.hidden_rows_hint.size();
+			auto lpadding = padding / 2;
+			auto rpadding = padding - lpadding;
+			ss << string(lpadding, ' ');
+			ss.Render(ResultRenderType::FOOTER, config.hidden_rows_hint);
+			ss << string(rpadding, ' ');
+		} else {
+			// we can't - don't render it
+			ss << string(padding, ' ');
+		}
 		ss.Render(ResultRenderType::FOOTER, column_count_str);
 	} else if (render_rows) {
 		idx_t lpadding = padding / 2;

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -95,6 +95,8 @@ struct BoxRendererConfig {
 	RenderMode render_mode = RenderMode::ROWS;
 	//! How to render large numbers
 	LargeNumberRendering large_number_rendering = LargeNumberRendering::NONE;
+	//! Hidden rows hint
+	string hidden_rows_hint;
 
 #ifndef DUCKDB_ASCII_TREE_RENDERER
 	const char *LTCORNER = "\342\224\214"; // NOLINT: "┌";

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1631,6 +1631,7 @@ ModeDuckBoxRenderer::ModeDuckBoxRenderer(ShellState &state) : ShellRenderer(stat
 	config.decimal_separator = state.decimal_separator;
 	config.thousand_separator = state.thousand_separator;
 	config.large_number_rendering = static_cast<duckdb::LargeNumberRendering>(static_cast<int>(large_rendering));
+	config.hidden_rows_hint = "use .last to show entire result";
 }
 
 void ModeDuckBoxRenderer::RemoveRenderLimits() {


### PR DESCRIPTION
Suggests usage of the new `.last` feature which uses the pager