### PR TITLE
Turn stats into a variant, and return variant from `stats` and as part of `pragma_storage_info`

### DIFF
--- a/extension/core_functions/scalar/generic/stats.cpp
+++ b/extension/core_functions/scalar/generic/stats.cpp
@@ -5,7 +5,7 @@ namespace duckdb {
 
 namespace {
 struct StatsBindData : public FunctionData {
-	explicit StatsBindData(Value stats_p = Value()) : stats(std::move(stats_p)) {
+	explicit StatsBindData(Value stats_p = Value(LogicalType::VARIANT())) : stats(std::move(stats_p)) {
 	}
 
 	Value stats;

--- a/src/function/table/system/pragma_storage_info.cpp
+++ b/src/function/table/system/pragma_storage_info.cpp
@@ -63,7 +63,7 @@ static unique_ptr<FunctionData> PragmaStorageInfoBind(ClientContext &context, Ta
 	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("stats");
-	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(LogicalType::VARIANT());
 
 	names.emplace_back("has_updates");
 	return_types.emplace_back(LogicalType::BOOLEAN);
@@ -134,7 +134,7 @@ static void PragmaStorageInfoFunction(ClientContext &context, TableFunctionInput
 		// compression
 		output.SetValue(col_idx++, count, Value(entry.compression_type));
 		// stats
-		output.SetValue(col_idx++, count, Value(entry.segment_stats));
+		output.SetValue(col_idx++, count, entry.segment_stats);
 		// has_updates
 		output.SetValue(col_idx++, count, Value::BOOLEAN(entry.has_updates));
 		// persistent

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -224,6 +224,12 @@ public:
 	bool operator<(const string_t &r) const {
 		return r > *this;
 	}
+	bool operator<=(const string_t &r) const {
+		return !(r < *this);
+	}
+	bool operator>=(const string_t &r) const {
+		return !(*this < r);
+	}
 
 private:
 	union {

--- a/src/include/duckdb/storage/statistics/array_stats.hpp
+++ b/src/include/duckdb/storage/statistics/array_stats.hpp
@@ -30,7 +30,7 @@ struct ArrayStats {
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);
 
-	DUCKDB_API static string ToString(const BaseStatistics &stats);
+	DUCKDB_API static child_list_t<Value> ToStruct(const BaseStatistics &stats);
 
 	DUCKDB_API static void Merge(BaseStatistics &stats, const BaseStatistics &other);
 	DUCKDB_API static void Copy(BaseStatistics &stats, const BaseStatistics &other);

--- a/src/include/duckdb/storage/statistics/array_stats.hpp
+++ b/src/include/duckdb/storage/statistics/array_stats.hpp
@@ -17,6 +17,7 @@ struct SelectionVector;
 class Vector;
 class Serializer;
 class Deserializer;
+class Value;
 
 struct ArrayStats {
 	DUCKDB_API static void Construct(BaseStatistics &stats);

--- a/src/include/duckdb/storage/statistics/array_stats.hpp
+++ b/src/include/duckdb/storage/statistics/array_stats.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/types.hpp"
 
 namespace duckdb {
 class BaseStatistics;

--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -121,6 +121,7 @@ public:
 	void Verify(Vector &vector, const SelectionVector &sel, idx_t count, bool ignore_has_null = false) const;
 	void Verify(Vector &vector, idx_t count) const;
 
+	Value ToStruct() const;
 	string ToString() const;
 
 	idx_t GetDistinctCount();

--- a/src/include/duckdb/storage/statistics/geometry_stats.hpp
+++ b/src/include/duckdb/storage/statistics/geometry_stats.hpp
@@ -277,7 +277,7 @@ struct GeometryStats {
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);
 
-	DUCKDB_API static string ToString(const BaseStatistics &stats);
+	DUCKDB_API static child_list_t<Value> ToStruct(const BaseStatistics &stats);
 
 	DUCKDB_API static void Update(BaseStatistics &stats, const string_t &value);
 	DUCKDB_API static void Merge(BaseStatistics &stats, const BaseStatistics &other);

--- a/src/include/duckdb/storage/statistics/list_stats.hpp
+++ b/src/include/duckdb/storage/statistics/list_stats.hpp
@@ -15,6 +15,7 @@ namespace duckdb {
 class BaseStatistics;
 struct SelectionVector;
 class Vector;
+class Value;
 
 struct ListStats {
 	DUCKDB_API static void Construct(BaseStatistics &stats);

--- a/src/include/duckdb/storage/statistics/list_stats.hpp
+++ b/src/include/duckdb/storage/statistics/list_stats.hpp
@@ -28,7 +28,7 @@ struct ListStats {
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);
 
-	DUCKDB_API static string ToString(const BaseStatistics &stats);
+	DUCKDB_API static child_list_t<Value> ToStruct(const BaseStatistics &stats);
 
 	DUCKDB_API static void Merge(BaseStatistics &stats, const BaseStatistics &other);
 	DUCKDB_API static void Copy(BaseStatistics &stats, const BaseStatistics &other);

--- a/src/include/duckdb/storage/statistics/list_stats.hpp
+++ b/src/include/duckdb/storage/statistics/list_stats.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/types.hpp"
 
 namespace duckdb {
 class BaseStatistics;

--- a/src/include/duckdb/storage/statistics/numeric_stats.hpp
+++ b/src/include/duckdb/storage/statistics/numeric_stats.hpp
@@ -77,7 +77,7 @@ struct NumericStats {
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &stats);
 
-	DUCKDB_API static string ToString(const BaseStatistics &stats);
+	DUCKDB_API static child_list_t<Value> ToStruct(const BaseStatistics &stats);
 
 	template <class T>
 	static inline void UpdateValue(T new_value, T &min, T &max) {

--- a/src/include/duckdb/storage/statistics/numeric_stats.hpp
+++ b/src/include/duckdb/storage/statistics/numeric_stats.hpp
@@ -19,6 +19,7 @@ namespace duckdb {
 class BaseStatistics;
 struct SelectionVector;
 class Vector;
+class Value;
 
 struct NumericStatsData {
 	//! Whether or not the value has a max value

--- a/src/include/duckdb/storage/statistics/string_stats.hpp
+++ b/src/include/duckdb/storage/statistics/string_stats.hpp
@@ -18,6 +18,7 @@ namespace duckdb {
 class BaseStatistics;
 struct SelectionVector;
 class Vector;
+class Value;
 
 struct StringStatsData {
 	constexpr static uint32_t MAX_STRING_MINMAX_SIZE = 8;

--- a/src/include/duckdb/storage/statistics/string_stats.hpp
+++ b/src/include/duckdb/storage/statistics/string_stats.hpp
@@ -60,7 +60,7 @@ struct StringStats {
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);
 
-	DUCKDB_API static string ToString(const BaseStatistics &stats);
+	DUCKDB_API static child_list_t<Value> ToStruct(const BaseStatistics &stats);
 
 	DUCKDB_API static FilterPropagateResult CheckZonemap(const BaseStatistics &stats, ExpressionType comparison_type,
 	                                                     array_ptr<const Value> constants);

--- a/src/include/duckdb/storage/statistics/struct_stats.hpp
+++ b/src/include/duckdb/storage/statistics/struct_stats.hpp
@@ -15,6 +15,7 @@ namespace duckdb {
 class BaseStatistics;
 struct SelectionVector;
 class Vector;
+class Value;
 struct StorageIndex;
 
 struct StructStats {

--- a/src/include/duckdb/storage/statistics/struct_stats.hpp
+++ b/src/include/duckdb/storage/statistics/struct_stats.hpp
@@ -31,7 +31,7 @@ struct StructStats {
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);
 
-	DUCKDB_API static string ToString(const BaseStatistics &stats);
+	DUCKDB_API static child_list_t<Value> ToStruct(const BaseStatistics &stats);
 
 	DUCKDB_API static void Merge(BaseStatistics &stats, const BaseStatistics &other);
 	DUCKDB_API static void Copy(BaseStatistics &stats, const BaseStatistics &other);

--- a/src/include/duckdb/storage/statistics/struct_stats.hpp
+++ b/src/include/duckdb/storage/statistics/struct_stats.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/types.hpp"
 
 namespace duckdb {
 class BaseStatistics;

--- a/src/include/duckdb/storage/statistics/variant_stats.hpp
+++ b/src/include/duckdb/storage/statistics/variant_stats.hpp
@@ -6,6 +6,7 @@
 
 namespace duckdb {
 class BaseStatistics;
+class Value;
 
 enum class VariantStatsShreddingState : uint8_t {
 	//! Uninitialized, not unshredded/shredded

--- a/src/include/duckdb/storage/statistics/variant_stats.hpp
+++ b/src/include/duckdb/storage/statistics/variant_stats.hpp
@@ -75,7 +75,7 @@ public:
 	DUCKDB_API static void Serialize(const BaseStatistics &stats, Serializer &serializer);
 	DUCKDB_API static void Deserialize(Deserializer &deserializer, BaseStatistics &base);
 
-	DUCKDB_API static string ToString(const BaseStatistics &stats);
+	DUCKDB_API static child_list_t<Value> ToStruct(const BaseStatistics &stats);
 
 	DUCKDB_API static void Merge(BaseStatistics &stats, const BaseStatistics &other);
 	DUCKDB_API static void Verify(const BaseStatistics &stats, Vector &vector, const SelectionVector &sel, idx_t count);

--- a/src/include/duckdb/storage/table_storage_info.hpp
+++ b/src/include/duckdb/storage/table_storage_info.hpp
@@ -25,7 +25,7 @@ struct ColumnSegmentInfo {
 	idx_t segment_start;
 	idx_t segment_count;
 	string compression_type;
-	string segment_stats;
+	Value segment_stats;
 	bool has_updates;
 	bool persistent;
 	block_id_t block_id;

--- a/src/storage/statistics/array_stats.cpp
+++ b/src/storage/statistics/array_stats.cpp
@@ -83,9 +83,11 @@ void ArrayStats::Deserialize(Deserializer &deserializer, BaseStatistics &base) {
 	deserializer.Unset<LogicalType>();
 }
 
-string ArrayStats::ToString(const BaseStatistics &stats) {
+child_list_t<Value> ArrayStats::ToStruct(const BaseStatistics &stats) {
 	auto &child_stats = ArrayStats::GetChildStats(stats);
-	return StringUtil::Format("[%s]", child_stats.ToString());
+	child_list_t<Value> result;
+	result.emplace_back("child_stats", child_stats.ToStruct());
+	return result;
 }
 
 void ArrayStats::Verify(const BaseStatistics &stats, Vector &vector, const SelectionVector &sel, idx_t count) {

--- a/src/storage/statistics/geometry_stats.cpp
+++ b/src/storage/statistics/geometry_stats.cpp
@@ -139,10 +139,14 @@ child_list_t<Value> GeometryStats::ToStruct(const BaseStatistics &stats) {
 	extent.emplace_back("x_max", Value::DOUBLE(data.extent.x_max));
 	extent.emplace_back("y_min", Value::DOUBLE(data.extent.y_min));
 	extent.emplace_back("y_max", Value::DOUBLE(data.extent.y_max));
-	extent.emplace_back("z_min", Value::DOUBLE(data.extent.z_min));
-	extent.emplace_back("z_max", Value::DOUBLE(data.extent.z_max));
-	extent.emplace_back("m_min", Value::DOUBLE(data.extent.m_min));
-	extent.emplace_back("m_max", Value::DOUBLE(data.extent.m_max));
+	if (Value::IsFinite(data.extent.z_min) || Value::IsFinite(data.extent.z_max)) {
+		extent.emplace_back("z_min", Value::DOUBLE(data.extent.z_min));
+		extent.emplace_back("z_max", Value::DOUBLE(data.extent.z_max));
+	}
+	if (Value::IsFinite(data.extent.m_min) || Value::IsFinite(data.extent.m_max)) {
+		extent.emplace_back("m_min", Value::DOUBLE(data.extent.m_min));
+		extent.emplace_back("m_max", Value::DOUBLE(data.extent.m_max));
+	}
 
 	result.emplace_back("extent", Value::STRUCT(std::move(extent)));
 

--- a/src/storage/statistics/geometry_stats.cpp
+++ b/src/storage/statistics/geometry_stats.cpp
@@ -130,21 +130,26 @@ void GeometryStats::Deserialize(Deserializer &deserializer, BaseStatistics &base
 	deserializer.ReadPropertyWithDefault<uint8_t>(202, "flags", data.flags.flags);
 }
 
-string GeometryStats::ToString(const BaseStatistics &stats) {
+child_list_t<Value> GeometryStats::ToStruct(const BaseStatistics &stats) {
 	const auto &data = GetDataUnsafe(stats);
-	string result;
+	child_list_t<Value> result;
+	child_list_t<Value> extent;
 
-	result += "[";
-	result += StringUtil::Format("Extent: [X: [%f, %f], Y: [%f, %f], Z: [%f, %f], M: [%f, %f]]", data.extent.x_min,
-	                             data.extent.x_max, data.extent.y_min, data.extent.y_max, data.extent.z_min,
-	                             data.extent.z_max, data.extent.m_min, data.extent.m_max);
-	result += StringUtil::Format(", Types: [%s]", StringUtil::Join(data.types.ToString(true), ", "));
-	result += StringUtil::Format(
-	    ", Flags: [Has Empty Geom: %s, Has No Empty Geom: %s, Has Empty Part: %s, Has No Empty Part: %s]",
-	    data.flags.HasEmptyGeometry() ? "true" : "false", data.flags.HasNonEmptyGeometry() ? "true" : "false",
-	    data.flags.HasEmptyPart() ? "true" : "false", data.flags.HasNonEmptyPart() ? "true" : "false");
+	extent.emplace_back("x_min", Value::DOUBLE(data.extent.x_min));
+	extent.emplace_back("x_max", Value::DOUBLE(data.extent.x_max));
+	extent.emplace_back("y_min", Value::DOUBLE(data.extent.y_min));
+	extent.emplace_back("y_max", Value::DOUBLE(data.extent.y_max));
+	extent.emplace_back("z_min", Value::DOUBLE(data.extent.z_min));
+	extent.emplace_back("z_max", Value::DOUBLE(data.extent.z_max));
+	extent.emplace_back("m_min", Value::DOUBLE(data.extent.m_min));
+	extent.emplace_back("m_max", Value::DOUBLE(data.extent.m_max));
 
-	result += "]";
+	result.emplace_back("extent", Value::STRUCT(std::move(extent)));
+
+	result.emplace_back("has_empty_geom", Value::BOOLEAN(data.flags.HasEmptyGeometry()));
+	result.emplace_back("has_non_empty_geom", Value::BOOLEAN(data.flags.HasNonEmptyGeometry()));
+	result.emplace_back("has_empty_part", Value::BOOLEAN(data.flags.HasEmptyPart()));
+	result.emplace_back("has_non_empty_part", Value::BOOLEAN(data.flags.HasNonEmptyPart()));
 	return result;
 }
 

--- a/src/storage/statistics/list_stats.cpp
+++ b/src/storage/statistics/list_stats.cpp
@@ -84,9 +84,11 @@ void ListStats::Deserialize(Deserializer &deserializer, BaseStatistics &base) {
 	deserializer.Unset<LogicalType>();
 }
 
-string ListStats::ToString(const BaseStatistics &stats) {
+child_list_t<Value> ListStats::ToStruct(const BaseStatistics &stats) {
 	auto &child_stats = ListStats::GetChildStats(stats);
-	return StringUtil::Format("[%s]", child_stats.ToString());
+	child_list_t<Value> result;
+	result.emplace_back("child_stats", child_stats.ToStruct());
+	return result;
 }
 
 void ListStats::Verify(const BaseStatistics &stats, Vector &vector, const SelectionVector &sel, idx_t count) {

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -547,9 +547,11 @@ void NumericStats::Deserialize(Deserializer &deserializer, BaseStatistics &resul
 	});
 }
 
-string NumericStats::ToString(const BaseStatistics &stats) {
-	return StringUtil::Format("[Min: %s, Max: %s]", NumericStats::MinOrNull(stats).ToString(),
-	                          NumericStats::MaxOrNull(stats).ToString());
+child_list_t<Value> NumericStats::ToStruct(const BaseStatistics &stats) {
+	child_list_t<Value> result;
+	result.emplace_back("min", NumericStats::MinOrNull(stats));
+	result.emplace_back("max", NumericStats::MaxOrNull(stats));
+	return result;
 }
 
 template <class T>

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -549,8 +549,10 @@ void NumericStats::Deserialize(Deserializer &deserializer, BaseStatistics &resul
 
 child_list_t<Value> NumericStats::ToStruct(const BaseStatistics &stats) {
 	child_list_t<Value> result;
-	result.emplace_back("min", NumericStats::MinOrNull(stats));
-	result.emplace_back("max", NumericStats::MaxOrNull(stats));
+	if (NumericStats::HasMinMax(stats)) {
+		result.emplace_back("min", NumericStats::MinOrNull(stats));
+		result.emplace_back("max", NumericStats::MaxOrNull(stats));
+	}
 	return result;
 }
 

--- a/src/storage/statistics/string_stats.cpp
+++ b/src/storage/statistics/string_stats.cpp
@@ -271,10 +271,15 @@ child_list_t<Value> StringStats::ToStruct(const BaseStatistics &stats) {
 	auto &string_data = StringStats::GetDataUnsafe(stats);
 	auto min_len = GetValidMinMaxSubstring(string_data.min);
 	auto max_len = GetValidMinMaxSubstring(string_data.max);
-	result.emplace_back("min", Blob::ToString(string_t(const_char_ptr_cast(string_data.min), min_len)));
-	result.emplace_back("max", Blob::ToString(string_t(const_char_ptr_cast(string_data.max), max_len)));
+	string_t min_str(const_char_ptr_cast(string_data.min), min_len);
+	string_t max_str(const_char_ptr_cast(string_data.max), max_len);
+	// if min > max the stats are empty and min/max is not yet initialized - so don't emit
+	if (min_str <= max_str) {
+		result.emplace_back("min", Blob::ToString(min_str));
+		result.emplace_back("max", Blob::ToString(max_str));
+	}
 	result.emplace_back("has_unicode", Value::BOOLEAN(string_data.has_unicode));
-	if (string_data.has_max_string_length) {
+	if (StringStats::HasMaxStringLength(stats)) {
 		result.emplace_back("max_string_length", Value::UBIGINT(string_data.max_string_length));
 	}
 	return result;

--- a/src/storage/statistics/string_stats.cpp
+++ b/src/storage/statistics/string_stats.cpp
@@ -266,15 +266,18 @@ static uint32_t GetValidMinMaxSubstring(const_data_ptr_t data) {
 	return StringStatsData::MAX_STRING_MINMAX_SIZE;
 }
 
-string StringStats::ToString(const BaseStatistics &stats) {
+child_list_t<Value> StringStats::ToStruct(const BaseStatistics &stats) {
+	child_list_t<Value> result;
 	auto &string_data = StringStats::GetDataUnsafe(stats);
-	uint32_t min_len = GetValidMinMaxSubstring(string_data.min);
-	uint32_t max_len = GetValidMinMaxSubstring(string_data.max);
-	return StringUtil::Format("[Min: %s, Max: %s, Has Unicode: %s, Max String Length: %s]",
-	                          Blob::ToString(string_t(const_char_ptr_cast(string_data.min), min_len)),
-	                          Blob::ToString(string_t(const_char_ptr_cast(string_data.max), max_len)),
-	                          string_data.has_unicode ? "true" : "false",
-	                          string_data.has_max_string_length ? to_string(string_data.max_string_length) : "?");
+	auto min_len = GetValidMinMaxSubstring(string_data.min);
+	auto max_len = GetValidMinMaxSubstring(string_data.max);
+	result.emplace_back("min", Blob::ToString(string_t(const_char_ptr_cast(string_data.min), min_len)));
+	result.emplace_back("max", Blob::ToString(string_t(const_char_ptr_cast(string_data.max), max_len)));
+	result.emplace_back("has_unicode", Value::BOOLEAN(string_data.has_unicode));
+	if (string_data.has_max_string_length) {
+		result.emplace_back("max_string_length", Value::UBIGINT(string_data.max_string_length));
+	}
+	return result;
 }
 
 void StringStats::Verify(const BaseStatistics &stats, Vector &vector, const SelectionVector &sel, idx_t count) {

--- a/src/storage/statistics/struct_stats.cpp
+++ b/src/storage/statistics/struct_stats.cpp
@@ -116,17 +116,14 @@ void StructStats::Deserialize(Deserializer &deserializer, BaseStatistics &base) 
 	});
 }
 
-string StructStats::ToString(const BaseStatistics &stats) {
-	string result;
-	result += " {";
+child_list_t<Value> StructStats::ToStruct(const BaseStatistics &stats) {
+	child_list_t<Value> result;
+	child_list_t<Value> child_info;
 	auto &child_types = StructType::GetChildTypes(stats.GetType());
 	for (idx_t i = 0; i < child_types.size(); i++) {
-		if (i > 0) {
-			result += ", ";
-		}
-		result += child_types[i].first + ": " + stats.child_stats[i].ToString();
+		child_info.emplace_back(child_types[i].first, stats.child_stats[i].ToStruct());
 	}
-	result += "}";
+	result.emplace_back("child_stats", Value::STRUCT(std::move(child_info)));
 	return result;
 }
 

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -1103,7 +1103,7 @@ void ColumnData::GetColumnSegmentInfo(const QueryContext &context, idx_t row_gro
 		column_info.compression_type = CompressionTypeToString(segment.GetCompressionFunction().type);
 		{
 			lock_guard<mutex> l(stats_lock);
-			column_info.segment_stats = segment.stats.statistics.ToString();
+			column_info.segment_stats = segment.stats.statistics.ToStruct();
 		}
 		column_info.has_updates = ColumnData::HasUpdates();
 		// persistent

--- a/test/fuzzer/pedro/vacuum_table_with_generated_column.test
+++ b/test/fuzzer/pedro/vacuum_table_with_generated_column.test
@@ -32,15 +32,15 @@ statement ok
 INSERT INTO test SELECT range % 5000 FROM range(10000);
 
 # The approximate unique count is inaccurate due to sampling.
-query T
-SELECT stats(x) FROM test LIMIT 1;
+query TTTTT
+SELECT s.min, s.max, s.has_null, s.has_no_null, s.approx_unique FROM (SELECT stats(x) s FROM test LIMIT 1);
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 10000]
+0	4999	false	true	10000
 
-query T
-SELECT stats(y) FROM test LIMIT 1;
+query TTTT
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT stats(y) s FROM test LIMIT 1);
 ----
-[Min: 100, Max: 5099][Has Null: false, Has No Null: true]
+100	5099	false	true
 
 statement ok
 PRAGMA verify_parallelism;
@@ -55,12 +55,12 @@ statement ok
 PRAGMA disable_verify_parallelism;
 
 # The approximate unique count is more accurate now.
-query T
-SELECT stats(x) FROM test LIMIT 1;
+query TTTTT
+SELECT s.min, s.max, s.has_null, s.has_no_null, s.approx_unique FROM (SELECT stats(x) s FROM test LIMIT 1);
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 5661]
+0	4999	false	true	5661
 
-query T
-SELECT stats(y) FROM test LIMIT 1;
+query TTTT
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT stats(y) s FROM test LIMIT 1);
 ----
-[Min: 100, Max: 5099][Has Null: false, Has No Null: true]
+100	5099	false	true

--- a/test/optimizer/compressed_materialization.test_slow
+++ b/test/optimizer/compressed_materialization.test_slow
@@ -162,13 +162,16 @@ statement ok
 copy (select hash(range + 1) i, null::varchar j, null::bigint k from range(100,200)) to '__TEST_DIR__/cm2.parquet'
 
 # has NULL, and does not have non-NULL
-query II
+query IIII
+select sj.has_null, sj.has_no_null, sk.has_null, sk.has_no_null
+from (
 select
-    stats(j) LIKE '%[Has Null: true, Has No Null: false]%',
-    stats(k) LIKE '%[Has Null: true, Has No Null: false]%'
+    stats(j) sj,
+    stats(k) sk
 from read_parquet('__TEST_DIR__/cm*.parquet', union_by_name=true) limit 1
+)
 ----
-true	true
+true	false	true	false
 
 # this should lead to a plan where both all-NULL columns (varchar j and bigint k) are compressed
 statement ok

--- a/test/parquet/parquet_stats_function.test
+++ b/test/parquet/parquet_stats_function.test
@@ -9,37 +9,37 @@ statement ok
 copy (select null i) to '__TEST_DIR__/all_null.parquet'
 
 # "Has No Null" is "false", meaning there are no non-NULL values
-query I
-select stats(i) from '__TEST_DIR__/all_null.parquet'
+query II
+SELECT s.has_null, s.has_no_null FROM (select stats(i) s from '__TEST_DIR__/all_null.parquet')
 ----
-[Min: NULL, Max: NULL][Has Null: true, Has No Null: false]
+true	false
 
 # create 0-9 with no NULL
 statement ok
 copy (select range i from range(10)) to '__TEST_DIR__/parquet_stats_function1.parquet'
 
-query I
-select stats(i) from read_parquet('__TEST_DIR__/parquet_stats_function1.parquet', union_by_name=true) limit 1
+query IIII
+select s.min, s.max, s.has_null, s.has_no_null from (select stats(i) s from read_parquet('__TEST_DIR__/parquet_stats_function1.parquet', union_by_name=true) limit 1)
 ----
-[Min: 0, Max: 9][Has Null: false, Has No Null: true]
+0	9	false	true
 
 # create 100-109 with NULL
 statement ok
 copy (select range i from range(100, 110) union all select null i) to '__TEST_DIR__/parquet_stats_function2.parquet'
 
-query I
-select stats(i) from read_parquet('__TEST_DIR__/parquet_stats_function2.parquet', union_by_name=true) limit 1
+query IIII
+select s.min, s.max, s.has_null, s.has_no_null from (select stats(i) s from read_parquet('__TEST_DIR__/parquet_stats_function2.parquet', union_by_name=true) limit 1)
 ----
-[Min: 100, Max: 109][Has Null: true, Has No Null: true]
+100	109	true	true
 
 # query combined WITHOUT union_by_name (should give back no stats)
-query I
-select stats(i) from read_parquet('__TEST_DIR__/parquet_stats_function*.parquet', union_by_name=false) limit 1
+query IIII
+select s.min, s.max, s.has_null, s.has_no_null from (select stats(i) s from read_parquet('__TEST_DIR__/parquet_stats_function*.parquet', union_by_name=false) limit 1)
 ----
-[Min: NULL, Max: NULL][Has Null: true, Has No Null: true]
+NULL	NULL	true	true
 
 # now query combined WITH union_by_name (should give back stats)
-query I
-select stats(i) from read_parquet('__TEST_DIR__/parquet_stats_function*.parquet', union_by_name=true) limit 1
+query IIII
+select s.min, s.max, s.has_null, s.has_no_null from (select stats(i) s from read_parquet('__TEST_DIR__/parquet_stats_function*.parquet', union_by_name=true) limit 1)
 ----
-[Min: 0, Max: 109][Has Null: true, Has No Null: true]
+0	109	true	true

--- a/test/sql/copy/parquet/parquet_row_number.test
+++ b/test/sql/copy/parquet/parquet_row_number.test
@@ -54,10 +54,10 @@ select row_group_id, row_group_num_rows, stats_min, stats_max from parquet_metad
 8	1000	8000	8999
 9	1000	9000	9999
 
-query I
-select stats(seq) from parquet_scan('{DATA_DIR}/parquet-testing/file_row_number.parquet') limit 1
+query IIII
+select s.min, s.max, s.has_null, s.has_no_null from (select stats(seq) s from parquet_scan('{DATA_DIR}/parquet-testing/file_row_number.parquet') limit 1)
 ----
-[Min: 0, Max: 9999][Has Null: false, Has No Null: true]
+0	9999	false	true
 
 query III
 select min(file_row_number), max(file_row_number), count(*) from parquet_scan('{DATA_DIR}/parquet-testing/file_row_number.parquet', file_row_number=1) where seq > 6500;
@@ -66,10 +66,10 @@ select min(file_row_number), max(file_row_number), count(*) from parquet_scan('{
 
 
 # stats tests
-query I
-select first(stats(file_row_number)) from parquet_scan('{DATA_DIR}/parquet-testing/lineitem-top10000.gzip.parquet', file_row_number=1);
+query IIII
+select s.min, s.max, s.has_null, s.has_no_null from (select first(stats(file_row_number)) s from parquet_scan('{DATA_DIR}/parquet-testing/lineitem-top10000.gzip.parquet', file_row_number=1));
 ----
-[Min: 0, Max: 10000][Has Null: false, Has No Null: true]
+0	10000	false	true
 
 statement ok
 PRAGMA explain_output = OPTIMIZED_ONLY;

--- a/test/sql/copy/parquet/shredded_variant_stats.test
+++ b/test/sql/copy/parquet/shredded_variant_stats.test
@@ -12,10 +12,10 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/fully_shredded_primitive.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/fully_shredded_primitive.parquet' limit 1;
+query IIIII
+select s.shredding_state, s.fully_shredded.stats.min, s.fully_shredded.stats.max, s.fully_shredded.stats.has_null, s.fully_shredded.stats.has_no_null FROM (select stats(col) s from '__TEST_DIR__/fully_shredded_primitive.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: INTEGER, stats: {fully_shredded: true}}[Has Null: true, Has No Null: true]
+SHREDDED	21	42	false	true
 
 statement ok
 COPY (SELECT * from (VALUES
@@ -26,11 +26,12 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/fully_shredded_primitive_with_nulls.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/fully_shredded_primitive_with_nulls.parquet' limit 1;
+query IIIII
+select s.shredding_state, s.fully_shredded.stats.min, s.fully_shredded.stats.max, s.fully_shredded.stats.has_null, s.fully_shredded.stats.has_no_null from (select stats(col) s from '__TEST_DIR__/fully_shredded_primitive_with_nulls.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: INTEGER, stats: {fully_shredded: true}}[Has Null: true, Has No Null: true]
+SHREDDED	21	42	true	true
 
+# partially shredded stats
 statement ok
 COPY (SELECT * from (VALUES
         (['test']::VARIANT),
@@ -39,13 +40,14 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/not_fully_shredded_primitive.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/not_fully_shredded_primitive.parquet' limit 1;
+query IIIII
+select s.shredding_state, s.partially_shredded.stats.min, s.partially_shredded.stats.max, s.partially_shredded.stats.has_null, s.partially_shredded.stats.has_no_null from (select stats(col) s from '__TEST_DIR__/not_fully_shredded_primitive.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: INTEGER, stats: {fully_shredded: false}}[Has Null: true, Has No Null: true]
+SHREDDED	21	42	true	true
 
 # ARRAY
 
+# FIXME: has_null for top-level variant is wrong (true even though there are no NULL values)
 statement ok
 COPY (SELECT * from (VALUES
         (['test']::VARIANT),
@@ -53,10 +55,10 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/fully_shredded_list.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/fully_shredded_list.parquet' limit 1;
+query III
+select s.shredding_state, s.has_null, s.has_no_null from (select stats(col) s from '__TEST_DIR__/fully_shredded_list.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: INTEGER[], stats: {fully_shredded: true, child: fully_shredded: false}}[Has Null: true, Has No Null: true]
+SHREDDED	true	true
 
 statement ok
 COPY (SELECT * from (VALUES
@@ -68,10 +70,10 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/fully_shredded_list_with_nulls.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/fully_shredded_list_with_nulls.parquet' limit 1;
+query III
+select s.shredding_state, s.has_null, s.has_no_null from (select stats(col) s from '__TEST_DIR__/fully_shredded_list_with_nulls.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: INTEGER[], stats: {fully_shredded: true, child: fully_shredded: false}}[Has Null: true, Has No Null: true]
+SHREDDED	true	true
 
 statement ok
 COPY (SELECT * from (VALUES
@@ -84,10 +86,10 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/not_fully_shredded_list.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/not_fully_shredded_list.parquet' limit 1;
+query III
+select s.shredding_state, s.has_null, s.has_no_null from (select stats(col) s from '__TEST_DIR__/not_fully_shredded_list.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: VARCHAR[], stats: {fully_shredded: false, child: fully_shredded: true}}[Has Null: true, Has No Null: true]
+SHREDDED	true	true
 
 # ARRAY - Element
 
@@ -98,10 +100,11 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/fully_shredded_list_element.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/fully_shredded_list_element.parquet' limit 1;
+# check element stats
+query IIII
+select s.min, s.max, s.has_null, s.has_no_null from (select stats(col).fully_shredded.child_stats.stats s from '__TEST_DIR__/fully_shredded_list_element.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: VARCHAR[], stats: {fully_shredded: true, child: fully_shredded: true}}[Has Null: true, Has No Null: true]
+hello	test	false	true
 
 statement ok
 COPY (SELECT * from (VALUES
@@ -110,10 +113,10 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/fully_shredded_list_element_with_nulls.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/fully_shredded_list_element_with_nulls.parquet' limit 1;
+query IIII
+select s.min, s.max, s.has_null, s.has_no_null from (select stats(col).fully_shredded.child_stats.stats s from '__TEST_DIR__/fully_shredded_list_element_with_nulls.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: VARCHAR[], stats: {fully_shredded: true, child: fully_shredded: true}}[Has Null: true, Has No Null: true]
+hello	world	true	true
 
 statement ok
 COPY (SELECT * from (VALUES
@@ -122,10 +125,11 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/not_fully_shredded_list_element.parquet'
 
+# element is inconsistent - no stats
 query I
-select stats(col) from '__TEST_DIR__/not_fully_shredded_list_element.parquet' limit 1;
+select s.fully_shredded from (select stats(col) s from '__TEST_DIR__/not_fully_shredded_list_element.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: VARCHAR[], stats: {fully_shredded: true, child: fully_shredded: false}}[Has Null: true, Has No Null: true]
+NULL
 
 # OBJECT
 
@@ -136,10 +140,10 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/fully_shredded_object.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/fully_shredded_object.parquet' limit 1;
+query II
+select s.fully_shredded.a.stats, s.fully_shredded.c.stats from (select stats(col) s from '__TEST_DIR__/fully_shredded_object.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: STRUCT(a INTEGER, b BOOLEAN, c VARCHAR), stats: {fully_shredded: true, children: {a: fully_shredded: true, b: fully_shredded: true, c: fully_shredded: true}}}[Has Null: true, Has No Null: true]
+{'min': 21, 'max': 42, 'has_null': false, 'has_no_null': true}	{'min': test, 'max': test, 'has_unicode': true, 'has_null': true, 'has_no_null': true}
 
 statement ok
 COPY (SELECT * from (VALUES
@@ -150,10 +154,10 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/fully_shredded_object_with_nulls.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/fully_shredded_object_with_nulls.parquet' limit 1;
+query II
+select s.fully_shredded.a.stats, s.fully_shredded.c.stats from (select stats(col) s from '__TEST_DIR__/fully_shredded_object_with_nulls.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: STRUCT(a INTEGER, b BOOLEAN, c VARCHAR), stats: {fully_shredded: true, children: {a: fully_shredded: true, b: fully_shredded: true, c: fully_shredded: true}}}[Has Null: true, Has No Null: true]
+{'min': 21, 'max': 42, 'has_null': true, 'has_no_null': true}	{'min': test, 'max': test, 'has_unicode': true, 'has_null': true, 'has_no_null': true}
 
 statement ok
 COPY (SELECT * from (VALUES
@@ -165,10 +169,11 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/not_fully_shredded_object.parquet'
 
+# mixed - no shredding information
 query I
-select stats(col) from '__TEST_DIR__/not_fully_shredded_object.parquet' limit 1;
+select s.fully_shredded from (select stats(col) s from '__TEST_DIR__/not_fully_shredded_object.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: STRUCT(a INTEGER, b BOOLEAN, c VARCHAR), stats: {fully_shredded: false, children: {a: fully_shredded: true, b: fully_shredded: true, c: fully_shredded: true}}}[Has Null: true, Has No Null: true]
+NULL
 
 # OBJECT - field
 
@@ -181,10 +186,11 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/not_fully_shredded_object_field.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/not_fully_shredded_object_field.parquet' limit 1;
+# a is inconsistent - so no fully shredded stats
+query II
+select s.fully_shredded.a, s.fully_shredded.c.stats from (select stats(col) s from '__TEST_DIR__/not_fully_shredded_object_field.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: STRUCT(a INTEGER, b BOOLEAN, c VARCHAR), stats: {fully_shredded: true, children: {a: fully_shredded: false, b: fully_shredded: true, c: fully_shredded: true}}}[Has Null: true, Has No Null: true]
+NULL	{'min': test, 'max': test, 'has_unicode': true, 'has_null': true, 'has_no_null': true}
 
 statement ok
 COPY (SELECT * from (VALUES
@@ -195,7 +201,8 @@ COPY (SELECT * from (VALUES
     ) t(col)
 ) to '__TEST_DIR__/fully_shredded_object_field_with_nulls.parquet'
 
-query I
-select stats(col) from '__TEST_DIR__/fully_shredded_object_field_with_nulls.parquet' limit 1;
+# a is consistent again here
+query IIII
+select s.fully_shredded.a.type, s.fully_shredded.a.stats, s.fully_shredded.c.type, s.fully_shredded.c.stats from (select stats(col) s from '__TEST_DIR__/fully_shredded_object_field_with_nulls.parquet' limit 1);
 ----
-shredding_state: SHREDDED, shredding: {typed_value_type: STRUCT(a INTEGER, b BOOLEAN, c VARCHAR), stats: {fully_shredded: true, children: {a: fully_shredded: true, b: fully_shredded: true, c: fully_shredded: true}}}[Has Null: true, Has No Null: true]
+INTEGER	{'min': 42, 'max': 42, 'has_null': true, 'has_no_null': true}	VARCHAR	{'min': test, 'max': test, 'has_unicode': true, 'has_null': true, 'has_no_null': true}

--- a/test/sql/copy/parquet/writer/parquet_write_decimals.test
+++ b/test/sql/copy/parquet/writer/parquet_write_decimals.test
@@ -81,7 +81,7 @@ endloop
 statement ok
 PRAGMA disable_verification
 
-query IIII
-SELECT stats(dec4), stats(dec9), stats(dec18), stats(dec38) FROM '__TEST_DIR__/decimals.parquet' LIMIT 1
+query IIIIIIII
+SELECT sdec4.min, sdec4.max, sdec9.min, sdec9.max, sdec18.min, sdec18.max, sdec38.min, sdec38.max FROM (SELECT stats(dec4) sdec4, stats(dec9) sdec9, stats(dec18) sdec18, stats(dec38) sdec38 FROM '__TEST_DIR__/decimals.parquet' LIMIT 1)
 ----
-[Min: -42.0, Max: 42.0][Has Null: true, Has No Null: true]	[Min: -42.00, Max: 42.00][Has Null: true, Has No Null: true]	[Min: -42.000, Max: 42.000][Has Null: true, Has No Null: true]	[Min: -42.0000, Max: 42.0000][Has Null: true, Has No Null: true]
+-42.0	42.0	-42.00	42.00	-42.000	42.000	-42.0000	42.0000

--- a/test/sql/function/date/test_date_trunc.test
+++ b/test/sql/function/date/test_date_trunc.test
@@ -280,32 +280,32 @@ SELECT date_trunc('duck', TIMESTAMP '2019-01-06 04:03:02') FROM timestamps LIMIT
 statement ok
 PRAGMA disable_verification
 
-query I
-SELECT stats(date_trunc('year', d)) FROM dates LIMIT 1;
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT stats(date_trunc('year', d)) s FROM dates LIMIT 1);
 ----
-[Min: 1992-01-01 00:00:00, Max: 2022-01-01 00:00:00][Has Null: false, Has No Null: true]
+1992-01-01 00:00:00	2022-01-01 00:00:00	false	true
 
-query I
-SELECT stats(date_trunc('quarter', d)) FROM dates LIMIT 1;
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT stats(date_trunc('quarter', d)) s FROM dates LIMIT 1);
 ----
-[Min: 1992-10-01 00:00:00, Max: 2022-01-01 00:00:00][Has Null: false, Has No Null: true]
+1992-10-01 00:00:00	2022-01-01 00:00:00	false	true
 
-query I
-SELECT stats(date_trunc('month', d)) FROM dates LIMIT 1;
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT stats(date_trunc('month', d)) s FROM dates LIMIT 1);
 ----
-[Min: 1992-12-01 00:00:00, Max: 2022-01-01 00:00:00][Has Null: false, Has No Null: true]
+1992-12-01 00:00:00	2022-01-01 00:00:00	false	true
 
-query I
-SELECT stats(date_trunc('day', d)) FROM dates LIMIT 1;
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT stats(date_trunc('day', d)) s FROM dates LIMIT 1);
 ----
-[Min: 1992-12-02 00:00:00, Max: 2022-01-01 00:00:00][Has Null: false, Has No Null: true]
+1992-12-02 00:00:00	2022-01-01 00:00:00	false	true
 
 foreach daypart millennium century decade year quarter month week day
 
-query I
-SELECT stats(date_trunc('${daypart}', d)) FROM timestamps LIMIT 1;
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT stats(date_trunc('${daypart}', d)) s FROM timestamps LIMIT 1);
 ----
-[Min: -infinity, Max: infinity][Has Null: false, Has No Null: true]
+-infinity	infinity	false	true
 
 endloop
 

--- a/test/sql/function/generic/test_stats.test
+++ b/test/sql/function/generic/test_stats.test
@@ -6,31 +6,27 @@ statement ok
 select 1=1
 
 # scalar stats
-query I
-SELECT STATS(5);
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT STATS(5) s);
 ----
-<REGEX>:.*5.*5.*
+5	5	false	true
 
-query I
-SELECT STATS(7);
+query IIIIII
+SELECT s.min, s.max, s.has_null, s.has_no_null, s.has_unicode, s.max_string_length FROM (SELECT STATS('hello') s);
 ----
-<REGEX>:.*7.*7.*
+hello	hello	false	true	false	5
 
-query I
-SELECT STATS('hello');
-----
-<REGEX>:.*hello.*hello.*
 
-query I
-SELECT STATS('1234567ü');
+query IIIIII
+SELECT s.min, s.max, s.has_null, s.has_no_null, s.has_unicode, s.max_string_length FROM (SELECT STATS('1234567ü') s);
 ----
-<REGEX>:.*1234567.*1234567.*
+1234567\xC3	1234567\xC3	false	true	true	9
 
 # arithmetic
-query I
-SELECT STATS(5+2);
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT STATS(5 + 2) s);
 ----
-<REGEX>:.*7.*7.*
+7	7	false	true
 
 # non-scalar stats
 statement ok
@@ -40,31 +36,31 @@ statement ok
 INSERT INTO integers VALUES (1), (2), (3);
 
 # read stats
-query I
-SELECT STATS(i) FROM integers LIMIT 1;
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT STATS(i) s FROM integers LIMIT 1);
 ----
-<REGEX>:.*1.*3.*
+1	3	false	true
 
 # arithmetic
-query I
-SELECT STATS(i+2) FROM integers LIMIT 1;
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT STATS(i + 2) s FROM integers LIMIT 1);
 ----
-<REGEX>:.*3.*5.*
+3	5	false	true
 
-query I
-SELECT STATS(i-5) FROM integers LIMIT 1;
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT STATS(i - 5) s FROM integers LIMIT 1);
 ----
-<REGEX>:.*-4.*-2.*
+-4	-2	false	true
 
-query I
-SELECT STATS(i*2) FROM integers LIMIT 1;
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT STATS(i * 2) s FROM integers LIMIT 1);
 ----
-<REGEX>:.*2.*6.*
+2	6	false	true
 
-query I
-SELECT STATS(i*-1) FROM integers LIMIT 1;
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT STATS(i * -1) s FROM integers LIMIT 1);
 ----
-<REGEX>:.*-3.*-1.*
+-3	-1	false	true
 
 # disabling statistics propagation means there will be no stats
 statement ok
@@ -73,13 +69,13 @@ PRAGMA disable_optimizer
 query I
 SELECT STATS(i+1) FROM integers LIMIT 1;
 ----
-No statistics
+NULL
 
 # we can enable the optimizer again
 statement ok
 PRAGMA enable_optimizer
 
-query I
-SELECT STATS(i*-1) FROM integers LIMIT 1;
+query IIII
+SELECT s.min, s.max, s.has_null, s.has_no_null FROM (SELECT STATS(i * -1) s FROM integers LIMIT 1);
 ----
-<REGEX>:.*-3.*-1.*
+-3	-1	false	true

--- a/test/sql/parallelism/interquery/concurrent_checkpoint_wal.test
+++ b/test/sql/parallelism/interquery/concurrent_checkpoint_wal.test
@@ -29,7 +29,7 @@ INSERT INTO concurrent_checkpoint_wal.integers SELECT * FROM range(${threadid} *
 
 onlyif threadid<>10
 query I
-SELECT CASE WHEN MAX(i) <= ANY_VALUE(regexp_extract(s, 'Max: (\d+)', 1)::INT) THEN NULL ELSE CONCAT('Stats ', ANY_VALUE(s), ' but got value ', MAX(i)) END
+SELECT CASE WHEN MAX(i) <= ANY_VALUE(s.max::INT) THEN NULL ELSE CONCAT('Stats ', ANY_VALUE(s), ' but got value ', MAX(i)) END
 FROM (SELECT stats(i) s, i FROM concurrent_checkpoint_wal.integers)
 ----
 NULL

--- a/test/sql/parallelism/interquery/concurrent_checkpoint_wal.test_slow
+++ b/test/sql/parallelism/interquery/concurrent_checkpoint_wal.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/parallelism/interquery/concurrent_checkpoint_wal.test
+# name: test/sql/parallelism/interquery/concurrent_checkpoint_wal.test_slow
 # description: Test concurrent appends to persistent while checkpointing
 # group: [interquery]
 

--- a/test/sql/storage/types/variant/variant_extract_stats.test
+++ b/test/sql/storage/types/variant/variant_extract_stats.test
@@ -25,9 +25,9 @@ checkpoint
 # ------------------------------ Extract the child from the list ------------------------------
 
 query I
-select stats(col[1]) from tbl limit 1;
+select s.fully_shredded.stats from (select stats(col[1]) s from tbl limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: true}.*
+{'min': hello, 'max': world, 'has_unicode': false, 'max_string_length': 5, 'has_null': false, 'has_no_null': true}
 
 statement ok
 insert into tbl select 42::INTEGER from range(5) t(i)
@@ -36,17 +36,17 @@ statement ok
 checkpoint
 
 query I
-select stats(col) from tbl limit 1;
+select s.fully_shredded from (select stats(col) s from tbl limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*fully_shredded: false, child: fully_shredded: true.*
+NULL
 
 # ------------------------------ Extracting the child from the list is not possible for some rows ------------------------------
 
 # Result is inconsistent, data isn't fully shredded
 query I
-select stats(col[1]) from tbl offset 5 limit 1;
+select stats(col[1]).shredding_state from tbl offset 5 limit 1;
 ----
-shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]
+INCONSISTENT
 
 statement ok
 delete from tbl where not variant_typeof(col).starts_with('ARRAY')
@@ -62,9 +62,9 @@ checkpoint
 # ------------------------------ Child of the list is no longer fully shredded, types differ ------------------------------
 
 query I
-select stats(col[1]) from tbl offset 5 limit 1;
+select stats(col[1]).shredding_state from tbl offset 5 limit 1;
 ----
-shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]
+INCONSISTENT
 
 statement ok
 delete from tbl;
@@ -77,9 +77,9 @@ checkpoint
 
 # We're shredded on VARCHAR[], so we can't propagate any stats for a field extract
 query I
-select stats(col.a) from tbl limit 1;
+select stats(col.a).shredding_state from tbl limit 1;
 ----
-shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]
+INCONSISTENT
 
 statement ok
 delete from tbl;
@@ -104,45 +104,45 @@ restart
 
 # Field 'a' is fully shredded
 query I
-select stats(col.a) from tbl limit 1;
+select s.fully_shredded.stats from (select stats(col.a) s from tbl limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*fully_shredded: true}.*
+{'min': test, 'max': test, 'has_unicode': false, 'max_string_length': 4, 'has_null': false, 'has_no_null': true}
 
 # Field 'b' is not shredded
 query I
-select stats(col.b) from tbl limit 1;
+select stats(col.b).shredding_state from tbl limit 1;
 ----
-shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]
+INCONSISTENT
 
 # OBJECT is fully shredded
 query I
-select stats(col) from tbl limit 1;
+select s.fully_shredded.a.stats from (select stats(col) s from tbl limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: true.*
+{'min': test, 'max': test, 'has_unicode': false, 'max_string_length': 4, 'has_null': false, 'has_no_null': true}
 
 statement ok
 insert into tbl select {'a': 42::INTEGER, 'b': false}
 
 # OBJECT is fully shredded, but we've inserted unshredded data so its INCONSISTENT
 query I
-select stats(col) from tbl limit 1;
+select stats(col).shredding_state from tbl limit 1;
 ----
-<REGEX>:.*shredding_state: INCONSISTENT.*
+INCONSISTENT
 
 statement ok
 checkpoint
 
 # We inserted a field a that's not a VARCHAR, but it's still an object, so the root remains fully shredded
 query I
-select stats(col) from tbl limit 1;
+select stats(col).shredding_state from tbl limit 1;
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: true.*
+SHREDDED
 
 # But field a isn't fully shredded anymore:
 query I
-select stats(col.a) from tbl limit 1;
+select stats(col.a).shredding_state from tbl limit 1;
 ----
-shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]
+INCONSISTENT
 
 # Insert an object with additional field(s)
 statement ok
@@ -153,9 +153,9 @@ checkpoint
 
 # Root is still fully shredded, even with an additional field it's always an OBJECT
 query I
-select stats(col) from tbl limit 1;
+select stats(col).shredding_state from tbl limit 1;
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: true.*
+SHREDDED
 
 # Insert an object that's missing shredded field(s)
 statement ok
@@ -166,9 +166,9 @@ checkpoint
 
 # Root is still shredded
 query I
-select stats(col) from tbl limit 1;
+select stats(col).shredding_state from tbl limit 1;
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: true.*
+SHREDDED
 
 # Now insert something that's NOT an OBJECT
 statement ok
@@ -179,12 +179,12 @@ checkpoint;
 
 # Now the root is no longer fully shredded
 query I
-select stats(col) from tbl limit 1;
+select s.fully_shredded from (select stats(col) s from tbl limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: false.*
+NULL
 
 # Data is not fully shredded on the extracted field, result is inconsistent
 query I
-select stats(col.c) from tbl order by rowid offset 2 limit 1;
+select stats(col.c).shredding_state from tbl order by rowid offset 2 limit 1;
 ----
-shredding_state: INCONSISTENT[Has Null: true, Has No Null: true]
+INCONSISTENT

--- a/test/sql/storage/types/variant/variant_shredding.test_slow
+++ b/test/sql/storage/types/variant/variant_shredding.test_slow
@@ -24,9 +24,9 @@ checkpoint
 
 # untyped_value_index is entirely NULL, indicating the VARIANT is fully shredded
 query I
-select stats(col) from shredded_integer limit 1;
+select s.fully_shredded.stats from (select stats(col) s from shredded_integer limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*fully_shredded: true.*
+{'min': 0, 'max': 99, 'has_null': false, 'has_no_null': true}
 
 # ------------------------------ Nothing is shredded ------------------------------
 
@@ -42,9 +42,9 @@ checkpoint
 
 # untyped_value_index is entirely non-NULL, indicating none of the VARIANT values are shredded
 query I
-select stats(col) from nothing_is_shredded limit 1;
+select s.fully_shredded from (select stats(col) s from nothing_is_shredded limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*fully_shredded: false.*
+NULL
 
 # ------------------------------ Partially shredded primitive ------------------------------
 
@@ -64,9 +64,9 @@ checkpoint
 
 # untyped_value_index contains NULL, indicating at least some of the VARIANT values are shredded
 query I
-select stats(col) from partial_primitive_shredding limit 1;
+select s.partially_shredded.stats from (select stats(col) s from partial_primitive_shredding limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*fully_shredded: false.*
+{'min': 42, 'max': 42, 'has_null': true, 'has_no_null': true}
 
 # ------------------------------ Fully shredded OBJECT ------------------------------
 
@@ -87,10 +87,10 @@ checkpoint
 
 # For both 'a' and 'b' the 'typed_value' stats have "Has Null: false"
 # Showing that for all values the fields are present and shredded
-query I
-select stats(col) from fully_shredded_object limit 1;
+query II
+select s.fully_shredded.a.stats, s.fully_shredded.b.stats from (select stats(col) s from fully_shredded_object limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*{a: fully_shredded: true, b: fully_shredded: true}.*
+{'min': 0, 'max': 99, 'has_null': false, 'has_no_null': true}	{'min': true, 'max': true, 'has_null': false, 'has_no_null': true}
 
 # ------------------------------ Partially shredded OBJECT ------------------------------
 
@@ -111,9 +111,9 @@ checkpoint
 
 # Now the 'typed_value' for 'a' is "Has Null: true", because at least *some* of the values are not an OBJECT with an 'a INTEGER' field
 query I
-select stats(col) from partially_shredded_object limit 1;
+select s.fully_shredded.a from (select stats(col) s from partially_shredded_object limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: true, children: {a: fully_shredded: false, b: fully_shredded: true}}.*
+NULL
 
 statement ok
 delete from partially_shredded_object;
@@ -136,9 +136,9 @@ restart
 
 # This makes the 'a' field "missing" for the newly added row, which doesn't affect shredding ('a' is still fully shredded)
 query I
-select stats(col) from partially_shredded_object limit 1;
+select s.fully_shredded.a.type from (select stats(col) s from partially_shredded_object limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: true, children: {a: fully_shredded: true, b: fully_shredded: true}}.*
+INTEGER
 
 statement ok
 insert into partially_shredded_object select {
@@ -152,10 +152,10 @@ checkpoint
 restart
 
 # 'a' is not fully shredded anymore, because we've added a value of type VARCHAR, instead of INTEGER
-query I
-select stats(col) from partially_shredded_object limit 1;
+query II
+select s.fully_shredded.a, s.fully_shredded.b.stats from (select stats(col) s from partially_shredded_object limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: true, children: {a: fully_shredded: false, b: fully_shredded: true}}.*
+NULL	{'min': true, 'max': true, 'has_null': false, 'has_no_null': true}
 
 # ------------------------------ Fully shredded ARRAY ------------------------------
 
@@ -173,9 +173,9 @@ checkpoint
 
 # typed_value does not contain any NULLs now, because all values are of type VARCHAR[]
 query I
-select stats(col) from fully_shredded_array limit 1;
+select s.fully_shredded.child_stats.stats from (select stats(col) s from fully_shredded_array limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: true, child: fully_shredded: true}.*
+{'min': a, 'max': 'this is ', 'has_unicode': false, 'max_string_length': 21, 'has_null': false, 'has_no_null': true}
 
 # ------------------------------ Partially shredded ARRAY ------------------------------
 
@@ -195,9 +195,9 @@ checkpoint
 # because there are both shredded and unshredded list children
 # Only the child elements aren't all of type VARCHAR, so the child's 'untyped_value_index' should contain NULL values
 query I
-select stats(col) from partially_shredded_array limit 1;
+select s.fully_shredded from (select stats(col) s from partially_shredded_array limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: true, child: fully_shredded: false}.*
+NULL
 
 statement ok
 delete from partially_shredded_array;
@@ -214,6 +214,6 @@ checkpoint
 # The children of the list do not contain nulls, but the list itself *does*,
 # because now there are unshredded rows containing the 42::INTEGER value
 query I
-select stats(col) from partially_shredded_array limit 1;
+select s.fully_shredded from (select stats(col) s from partially_shredded_array limit 1);
 ----
-<REGEX>:.*shredding_state: SHREDDED.*stats: {fully_shredded: false, child: fully_shredded: true}.*
+NULL

--- a/test/sql/storage/types/variant/variant_stats_merging.test_slow
+++ b/test/sql/storage/types/variant/variant_stats_merging.test_slow
@@ -23,10 +23,11 @@ checkpoint
 
 restart
 
+# only nulls, so no min/max
 query I
-select stats(col) from tbl limit 1;
+select s.fully_shredded.child_stats.stats from (select stats(col) s from tbl limit 1);
 ----
-<REGEX>:.*typed_value_type: VARCHAR\[\].*
+{'has_unicode': false, 'max_string_length': 0, 'has_null': false, 'has_no_null': false}
 
 # -------------------------- Shred 'tbl' on INTEGER[] --------------------------
 
@@ -43,9 +44,9 @@ restart
 
 # Mixing VARCHAR[] + INTEGER[] results in inconsistent stats
 query I
-select stats(col) from tbl limit 1;
+select s.shredding_state from (select stats(col) s from tbl limit 1);
 ----
-<REGEX>:shredding_state: INCONSISTENT.*
+INCONSISTENT
 
 # -------------------------- Shred 'tbl2' on OBJECT(a INTEGER, b VARCHAR, c BOOLEAN) --------------------------
 
@@ -63,10 +64,10 @@ checkpoint
 
 restart
 
-query I
-select stats(col) from tbl2 limit 1;
+query III
+select s.fully_shredded.a.type, s.fully_shredded.b.type, s.fully_shredded.c.type from (select stats(col) s from tbl2 limit 1);
 ----
-<REGEX>:.*typed_value_type: STRUCT\(a INTEGER, b VARCHAR, c BOOLEAN\).*
+INTEGER	VARCHAR	BOOLEAN
 
 # -------------------------- Shred 'tbl2' on OBJECT(b VARCHAR, a INTEGER, c BOOLEAN) --------------------------
 
@@ -82,10 +83,10 @@ checkpoint
 restart
 
 # Order of fields shouldn't matter
-query I
-select stats(col) from tbl2 limit 1;
+query III
+select s.fully_shredded.a.type, s.fully_shredded.b.type, s.fully_shredded.c.type from (select stats(col) s from tbl2 limit 1);
 ----
-<REGEX>:.*typed_value_type: STRUCT\(a INTEGER, b VARCHAR, c BOOLEAN\).*
+INTEGER	VARCHAR	BOOLEAN
 
 # -------------------------- Shred 'tbl2' on OBJECT(b VARCHAR, a INTEGER, c INTEGER) --------------------------
 
@@ -101,10 +102,10 @@ checkpoint
 restart
 
 # We lose field 'c' because its type is different
-query I
-select stats(col) from tbl2 limit 1;
+query II
+select s.fully_shredded.a.type, s.fully_shredded.b.type from (select stats(col) s from tbl2 limit 1);
 ----
-<REGEX>:.*typed_value_type: STRUCT\(a INTEGER, b VARCHAR\).*
+INTEGER	VARCHAR
 
 # -------------------------- Shred 'tbl2' on OBJECT(b VARCHAR, c BOOLEAN) --------------------------
 
@@ -120,6 +121,6 @@ checkpoint
 restart
 
 query I
-select stats(col) from tbl2 limit 1;
+select s.fully_shredded.b.type from (select stats(col) s from tbl2 limit 1);
 ----
-<REGEX>:.*typed_value_type: STRUCT\(b VARCHAR\).*
+VARCHAR

--- a/test/sql/types/geo/geometry_stats.test
+++ b/test/sql/types/geo/geometry_stats.test
@@ -10,52 +10,50 @@ create table t1(id INT, g GEOMETRY);
 statement ok
 insert into t1 values (0, 'POINT(0 0)'::GEOMETRY);
 
-query I
-select stats(g) from t1 limit 1;
+query IIIIIII
+select s.extent, s.has_empty_geom, s.has_non_empty_geom, s.has_empty_part, s.has_non_empty_part, s.has_null, s.has_no_null from (select stats(g) s from t1 limit 1);
 ----
-[Extent: [X: [0.000000, 0.000000], Y: [0.000000, 0.000000], Z: [inf, -inf], M: [inf, -inf]], Types: [point], Flags: [Has Empty Geom: false, Has No Empty Geom: true, Has Empty Part: false, Has No Empty Part: true]][Has Null: false, Has No Null: true][Approx Unique: 1]
+{'x_min': 0.0, 'x_max': 0.0, 'y_min': 0.0, 'y_max': 0.0}	false	true	false	true	false	true
 
 statement ok
 insert into t1 values (1, 'POINT(-2 2)'::GEOMETRY);
 
-query I
-select stats(g) from t1 limit 1;
+query IIIIIII
+select s.extent, s.has_empty_geom, s.has_non_empty_geom, s.has_empty_part, s.has_non_empty_part, s.has_null, s.has_no_null from (select stats(g) s from t1 limit 1);
 ----
-[Extent: [X: [-2.000000, 0.000000], Y: [0.000000, 2.000000], Z: [inf, -inf], M: [inf, -inf]], Types: [point], Flags: [Has Empty Geom: false, Has No Empty Geom: true, Has Empty Part: false, Has No Empty Part: true]][Has Null: false, Has No Null: true][Approx Unique: 2]
+{'x_min': -2.0, 'x_max': 0.0, 'y_min': 0.0, 'y_max': 2.0}	false	true	false	true	false	true
 
 statement ok
 insert into t1 values (3, 'POINT(2 -2)'::GEOMETRY);
 
-query I
-select stats(g) from t1 limit 1;
+query IIIIIII
+select s.extent, s.has_empty_geom, s.has_non_empty_geom, s.has_empty_part, s.has_non_empty_part, s.has_null, s.has_no_null from (select stats(g) s from t1 limit 1);
 ----
-[Extent: [X: [-2.000000, 2.000000], Y: [-2.000000, 2.000000], Z: [inf, -inf], M: [inf, -inf]], Types: [point], Flags: [Has Empty Geom: false, Has No Empty Geom: true, Has Empty Part: false, Has No Empty Part: true]][Has Null: false, Has No Null: true][Approx Unique: 3]
+{'x_min': -2.0, 'x_max': 2.0, 'y_min': -2.0, 'y_max': 2.0}	false	true	false	true	false	true
 
 # Insert Z-Value Geometry
 statement ok
 insert into t1 values (4, 'LINESTRING Z (0 0 0, 1 1 1, 2 2 2)'::GEOMETRY);
 
-query I
-select stats(g) from t1 limit 1;
+query IIIIIII
+select s.extent, s.has_empty_geom, s.has_non_empty_geom, s.has_empty_part, s.has_non_empty_part, s.has_null, s.has_no_null from (select stats(g) s from t1 limit 1);
 ----
-[Extent: [X: [-2.000000, 2.000000], Y: [-2.000000, 2.000000], Z: [0.000000, 2.000000], M: [inf, -inf]], Types: [point, linestring_z], Flags: [Has Empty Geom: false, Has No Empty Geom: true, Has Empty Part: false, Has No Empty Part: true]][Has Null: false, Has No Null: true][Approx Unique: 4]
+{'x_min': -2.0, 'x_max': 2.0, 'y_min': -2.0, 'y_max': 2.0, 'z_min': 0.0, 'z_max': 2.0}	false	true	false	true	false	true
 
 # Insert M-Value Geometry
 statement ok
 insert into t1 values (5, 'POLYGON M ((0 0 2, 4 0 2, 4 4 2, 0 4 2, 0 0 2))'::GEOMETRY);
 
-query I
-select stats(g) from t1 limit 1;
+query IIIIIII
+select s.extent, s.has_empty_geom, s.has_non_empty_geom, s.has_empty_part, s.has_non_empty_part, s.has_null, s.has_no_null from (select stats(g) s from t1 limit 1);
 ----
-[Extent: [X: [-2.000000, 4.000000], Y: [-2.000000, 4.000000], Z: [0.000000, 2.000000], M: [2.000000, 2.000000]], Types: [point, linestring_z, polygon_m], Flags: [Has Empty Geom: false, Has No Empty Geom: true, Has Empty Part: false, Has No Empty Part: true]][Has Null: false, Has No Null: true][Approx Unique: 5]
+{'x_min': -2.0, 'x_max': 4.0, 'y_min': -2.0, 'y_max': 4.0, 'z_min': 0.0, 'z_max': 2.0, 'm_min': 2.0, 'm_max': 2.0}	false	true	false	true	false	true
 
 # Insert ZM-Value Geometry
 statement ok
 insert into t1 values (6, 'MULTILINESTRING ZM ((0 0 -10 10, 1 1 -10 10), (2 2 2 1, 3 3 3 1))'::GEOMETRY);
 
-query I
-select stats(g) from t1 limit 1;
+query IIIIIII
+select s.extent, s.has_empty_geom, s.has_non_empty_geom, s.has_empty_part, s.has_non_empty_part, s.has_null, s.has_no_null from (select stats(g) s from t1 limit 1);
 ----
-[Extent: [X: [-2.000000, 4.000000], Y: [-2.000000, 4.000000], Z: [-10.000000, 3.000000], M: [1.000000, 10.000000]], Types: [point, linestring_z, polygon_m, multilinestring_zm], Flags: [Has Empty Geom: false, Has No Empty Geom: true, Has Empty Part: false, Has No Empty Part: true]][Has Null: false, Has No Null: true][Approx Unique: 6]
-
-
+{'x_min': -2.0, 'x_max': 4.0, 'y_min': -2.0, 'y_max': 4.0, 'z_min': -10.0, 'z_max': 3.0, 'm_min': 1.0, 'm_max': 10.0}	false	true	false	true	false	true

--- a/test/sql/types/list/list_stats.test
+++ b/test/sql/types/list/list_stats.test
@@ -2,21 +2,21 @@
 # description: Test stats propagation for lists
 # group: [list]
 
-# struct stats
-query I
-SELECT STATS([3, 4])
+# list stats
+query II
+SELECT s.child_stats.min, s.child_stats.max FROM (SELECT STATS([3, 4]) s)
 ----
-<REGEX>:.*3.*4.*
+3	4
 
 query I
 SELECT [3, 4]
 ----
 [3, 4]
 
-query I
-SELECT STATS(NULL::INT[])
+query II
+SELECT s.has_null, s.has_no_null FROM (SELECT STATS(NULL::INT[]) s)
 ----
-<REGEX>:.*Has Null: true.*
+true	false
 
 query I
 SELECT NULL::INT[]
@@ -45,10 +45,10 @@ CREATE TABLE integers(i integer)
 statement ok
 insert into integers values (3), (4);
 
-query I
-SELECT STATS([i]) FROM integers LIMIT 1
+query IIII
+SELECT s.child_stats.min, s.child_stats.max, s.child_stats.has_null, s.has_null FROM (SELECT STATS([i]) s FROM integers LIMIT 1)
 ----
-<REGEX>:.*3.*4.*Has Null: false.*
+3	4	false	false
 
 query I
 SELECT [i] FROM integers
@@ -59,10 +59,10 @@ SELECT [i] FROM integers
 statement ok
 insert into integers values (NULL);
 
-query I
-SELECT STATS([i]) FROM integers LIMIT 1
+query IIII
+SELECT s.child_stats.min, s.child_stats.max, s.child_stats.has_null, s.has_null FROM (SELECT STATS([i]) s FROM integers LIMIT 1)
 ----
-<REGEX>:.*3.*4.*Has Null: true.*
+3	4	true	false
 
 query I
 SELECT [i] FROM integers
@@ -75,10 +75,10 @@ statement ok
 CREATE TABLE lists AS SELECT [3, 4] l
 
 # list_extract always propagates a null
-query I
-SELECT STATS(l[1]) FROM lists LIMIT 1
+query III
+SELECT s.min, s.max, s.has_null FROM (SELECT STATS(l[1]) s FROM lists LIMIT 1)
 ----
-<REGEX>:.*3.*4.*Has Null: true.*
+3	4	true
 
 query I
 SELECT l[1] FROM lists
@@ -89,10 +89,10 @@ SELECT l[1] FROM lists
 statement ok
 INSERT INTO lists VALUES ([])
 
-query I
-SELECT STATS(l[1]) FROM lists LIMIT 1
+query III
+SELECT s.min, s.max, s.has_null FROM (SELECT STATS(l[1]) s FROM lists LIMIT 1)
 ----
-<REGEX>:.*3.*4.*Has Null: true.*
+3	4	true
 
 query I
 SELECT l[1] FROM lists
@@ -104,10 +104,10 @@ NULL
 statement ok
 INSERT INTO lists VALUES (NULL)
 
-query I
-SELECT STATS(l[1]) FROM lists LIMIT 1
+query III
+SELECT s.min, s.max, s.has_null FROM (SELECT STATS(l[1]) s FROM lists LIMIT 1)
 ----
-<REGEX>:.*3.*4.*Has Null: true.*
+3	4	true
 
 query I
 SELECT l[1] FROM lists
@@ -121,10 +121,10 @@ NULL
 statement ok
 INSERT INTO lists VALUES ([NULL])
 
-query I
-SELECT STATS(l[1]) FROM lists LIMIT 1
+query III
+SELECT s.min, s.max, s.has_null FROM (SELECT STATS(l[1]) s FROM lists LIMIT 1)
 ----
-<REGEX>:.*3.*4.*Has Null: true.*
+3	4	true
 
 query I
 SELECT l[1] FROM lists

--- a/test/sql/types/nested/array/array_statistics.test
+++ b/test/sql/types/nested/array/array_statistics.test
@@ -1,12 +1,10 @@
 # name: test/sql/types/nested/array/array_statistics.test
 # group: [array]
 
-# TODO: this does not work with verification, bug is reproducible on main (with list_value), issue has been filed.
-
-query I
-SELECT STATS(array_value(1,2));
+query IIII
+SELECT s.child_stats.min, s.child_stats.max, s.has_no_null, s.has_null FROM (SELECT STATS(array_value(1,2)) s)
 ----
-[[Min: 1, Max: 2][Has Null: false, Has No Null: true]][Has Null: false, Has No Null: true][Approx Unique: 1]
+1	2	true	false
 
 
 # Trigger unknown statistics propagation

--- a/test/sql/types/nested/array/array_storage.test_slow
+++ b/test/sql/types/nested/array/array_storage.test_slow
@@ -18,14 +18,14 @@ INSERT INTO t1 VALUES(1, [1, 2, 3]::INT[3]);
 statement ok
 checkpoint;
 
-query IIIIIIIIIIIIIII rowsort
-SELECT * EXCLUDE additional_block_ids FROM pragma_storage_info('t1');
+query IIIIIIIIIIIIII rowsort
+SELECT * EXCLUDE (additional_block_ids, stats) FROM pragma_storage_info('t1');
 ----
-0	a	1	[1, 0]		0	VALIDITY	0	1	Constant		[Has Null: false, Has No Null: true]					false	true	-1	0	(empty)
-0	a	1	[1, 1, 0]	0	VALIDITY	0	3	Constant		[Has Null: false, Has No Null: true]					false	true	-1	0	(empty)
-0	a	1	[1, 1]		0	INTEGER		0	3	Uncompressed	[Min: 1, Max: 3][Has Null: false, Has No Null: true]	false	true	1	0	(empty)
-0	i	0	[0, 0]		0	VALIDITY	0	1	Constant		[Has Null: false, Has No Null: true]					false	true	-1	0	(empty)
-0	i	0	[0]			0	INTEGER		0	1	Constant		[Min: 1, Max: 1][Has Null: false, Has No Null: true]	false	true	-1	0	(empty)
+0	a	1	[1, 0]		0	VALIDITY	0	1	Constant		false	true	-1	0	(empty)
+0	a	1	[1, 1, 0]	0	VALIDITY	0	3	Constant		false	true	-1	0	(empty)
+0	a	1	[1, 1]		0	INTEGER		0	3	Uncompressed	false	true	1	0	(empty)
+0	i	0	[0, 0]		0	VALIDITY	0	1	Constant		false	true	-1	0	(empty)
+0	i	0	[0]			0	INTEGER		0	1	Constant		false	true	-1	0	(empty)
 
 
 statement ok

--- a/test/sql/types/struct/struct_stats.test
+++ b/test/sql/types/struct/struct_stats.test
@@ -3,28 +3,28 @@
 # group: [struct]
 
 # struct stats
-query I
-SELECT STATS({'i': 3, 'j': 4})
+query II
+SELECT s.child_stats.i.min, s.child_stats.j.min FROM (SELECT STATS({'i': 3, 'j': 4}) s)
 ----
-<REGEX>:.*3.*4.*
+3	4
 
 query I
-SELECT STATS(NULL::ROW(i INTEGER))
+SELECT STATS(NULL::ROW(i INTEGER)).has_null
 ----
-<REGEX>:.*Has Null: true.*
+true
 
 statement ok
 CREATE TABLE integers AS SELECT 3 i, 4 j
 
-query I
-SELECT STATS({'i': i, 'j': j}) FROM integers
+query II
+SELECT s.child_stats.i.min, s.child_stats.j.min FROM (SELECT STATS({'i': i, 'j': j}) s FROM integers)
 ----
-<REGEX>:.*3.*4.*
+3	4
 
 statement ok
 CREATE TABLE structs AS SELECT {'i': 3, 'j': 4} s
 
-query I
-SELECT STATS(s['i']) FROM structs
+query II
+SELECT s.min, s.max FROM (SELECT STATS(s['i']) s FROM structs)
 ----
-<REGEX>:.*3.*3.*
+3	3

--- a/test/sql/vacuum/test_analyze.test
+++ b/test/sql/vacuum/test_analyze.test
@@ -44,15 +44,15 @@ statement ok
 INSERT INTO test SELECT range % 5000, range % 5000 FROM range(10000);
 
 # The approximate unique count is inaccurate due to sampling.
-query T
-SELECT stats(i) FROM test LIMIT 1;
+query TTTTT
+SELECT s.min, s.max, s.has_null, s.has_no_null, s.approx_unique FROM (SELECT stats(i) s FROM test LIMIT 1);
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 10000]
+0	4999	false	true	10000
 
-query T
-SELECT stats(j) FROM test LIMIT 1;
+query TTTTT
+SELECT s.min, s.max, s.has_null, s.has_no_null, s.approx_unique FROM (SELECT stats(j) s FROM test LIMIT 1);
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 10000]
+0	4999	false	true	10000
 
 statement ok
 PRAGMA verify_parallelism;
@@ -68,15 +68,14 @@ PRAGMA disable_verify_parallelism;
 
 # The approximate unique count for i is more accurate now.
 query T
-SELECT stats(i) FROM test LIMIT 1;
+SELECT s.approx_unique FROM (SELECT stats(i) s FROM test LIMIT 1);
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 5661]
+5661
 
-# The approximate unique count for j is not yet accurate.
 query T
-SELECT stats(j) FROM test LIMIT 1;
+SELECT s.approx_unique FROM (SELECT stats(j) s FROM test LIMIT 1);
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 10000]
+10000
 
 # Now we analyze the entire table.
 statement ok
@@ -90,11 +89,11 @@ PRAGMA disable_verify_parallelism;
 
 # The approximate unique count for i and j is more accurate now.
 query T
-SELECT stats(i) FROM test LIMIT 1;
+SELECT s.approx_unique FROM (SELECT stats(i) s FROM test LIMIT 1);
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 5661]
+5661
 
 query T
-SELECT stats(j) FROM test LIMIT 1;
+SELECT s.approx_unique FROM (SELECT stats(j) s FROM test LIMIT 1);
 ----
-[Min: 0, Max: 4999][Has Null: false, Has No Null: true][Approx Unique: 5661]
+5661


### PR DESCRIPTION
Currently `stats` returns a strangely formatted string that is hard to operate on:

```sql
select stats(42);
┌──────────────────────────────────────────────────────────────────────────┐
│                                stats(42)                                 │
│                                 varchar                                  │
├──────────────────────────────────────────────────────────────────────────┤
│ [Min: 42, Max: 42][Has Null: false, Has No Null: true][Approx Unique: 1] │
└──────────────────────────────────────────────────────────────────────────┘
```

This PR changes it to instead return a structured variant:

```sql
select stats(42);
┌────────────────────────────────────────────────────────────────────────────────────┐
│                                     stats(42)                                      │
│                                      variant                                       │
├────────────────────────────────────────────────────────────────────────────────────┤
│ {'min': 42, 'max': 42, 'has_null': false, 'has_no_null': true, 'approx_unique': 1} │
└────────────────────────────────────────────────────────────────────────────────────┘
```

This allows you to e.g. grab specific components, which are themselves all typed:

```sql
select stats(42).min as min, variant_typeof(stats(42).min) as min_type;
┌─────────┬──────────┐
│   min   │ min_type │
│ variant │ varchar  │
├─────────┼──────────┤
│ 42      │ INT32    │
└─────────┴──────────┘
```