### PR TITLE
Peg secrets wip

### DIFF
--- a/src/include/duckdb/parser/parsed_data/create_secret_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_secret_info.hpp
@@ -24,7 +24,6 @@ public:
 	~CreateSecretInfo() override;
 
 	//! How to handle conflict
-	OnCreateConflict on_conflict;
 	//! Whether the secret can be persisted
 	SecretPersistType persist_type;
 	//! The type of secret

--- a/src/parser/parsed_data/create_secret_info.cpp
+++ b/src/parser/parsed_data/create_secret_info.cpp
@@ -4,8 +4,9 @@
 
 namespace duckdb {
 
-CreateSecretInfo::CreateSecretInfo(OnCreateConflict on_conflict, SecretPersistType persist_type)
-    : CreateInfo(CatalogType::SECRET_ENTRY), on_conflict(on_conflict), persist_type(persist_type), options() {
+CreateSecretInfo::CreateSecretInfo(OnCreateConflict on_conflict_, SecretPersistType persist_type)
+    : CreateInfo(CatalogType::SECRET_ENTRY), persist_type(persist_type), options() {
+	on_conflict = on_conflict_;
 }
 
 CreateSecretInfo::~CreateSecretInfo() {

--- a/test/sql/secrets/create_secret_expression.test
+++ b/test/sql/secrets/create_secret_expression.test
@@ -36,7 +36,7 @@ CREATE SECRET IF NOT EXISTS a (TYPE http);
 statement error
 CREATE OR REPLACE SECRET IF NOT EXISTS a (TYPE http);
 ----
-Parser Error: syntax error at or near
+Parser Error
 
 statement ok
 PRAGMA enable_verification;

--- a/test/sql/secrets/create_secret_expression.test
+++ b/test/sql/secrets/create_secret_expression.test
@@ -5,6 +5,18 @@
 require noforcestorage
 
 statement ok
+set allow_parser_override_extension=strict;
+
+statement ok
+CREATE SECRET a (TYPE http);
+
+statement ok
+CREATE SECRET IF NOT EXISTS a (TYPE http);
+
+statement ok
+CREATE SECRET IF NOT EXISTS a (TYPE http);
+
+statement ok
 PRAGMA enable_verification;
 
 statement ok

--- a/test/sql/secrets/create_secret_expression.test
+++ b/test/sql/secrets/create_secret_expression.test
@@ -10,11 +10,33 @@ set allow_parser_override_extension=strict;
 statement ok
 CREATE SECRET a (TYPE http);
 
+statement error
+CREATE SECRET a (TYPE http);
+----
+Invalid Input Error: Temporary secret with name 'a' already exists!
+
+#### FIXME: these currently will NOT generate a persistent secret
+#statement ok
+#CREATE PERSISTENT SECRET a (TYPE http);
+#
+#statement ok
+#CREATE PERSISTENT SECRET b (TYPE http);
+#
+#statement error
+#CREATE PERSISTENT SECRET b (TYPE http);
+#----
+#Invalid Input Error: Persistent secret with name 'b' already exists in secret storage 'local_file'!
+
 statement ok
-CREATE SECRET IF NOT EXISTS a (TYPE http);
+CREATE OR REPLACE SECRET a (TYPE http);
 
 statement ok
 CREATE SECRET IF NOT EXISTS a (TYPE http);
+
+statement error
+CREATE OR REPLACE SECRET IF NOT EXISTS a (TYPE http);
+----
+Parser Error: syntax error at or near
 
 statement ok
 PRAGMA enable_verification;


### PR DESCRIPTION
Small detour from httpfs work, where I realized new parser would not correctly handle some secrets options correctly.

This PR attempts to fix handling for:
```sql
set allow_parser_override_extension=strict;
CREATE OR REPLACE SECRET xxxx (TYPE http);
CREATE OR REPLACE SECRET xxxx (TYPE http);
```
Where currently the third query would fail since `OR REPLACE` would be ignored.

Still open proper support for `PERSISTENT` modifier for secrets