### PR TITLE
Bump odbc_scanner

### DIFF
--- a/.github/config/extensions/odbc_scanner.cmake
+++ b/.github/config/extensions/odbc_scanner.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(odbc_scanner
             DONT_LINK
             GIT_URL https://github.com/duckdb/odbc-scanner
-            GIT_TAG 673190598d85d556a793006a24691bc7e20acc46
+            GIT_TAG 5140d1d976c7060f7aded4dbe294f97c3d8382ea
             )
 endif()

--- a/.github/config/extensions/odbc_scanner.cmake
+++ b/.github/config/extensions/odbc_scanner.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(odbc_scanner
             DONT_LINK
             GIT_URL https://github.com/duckdb/odbc-scanner
-            GIT_TAG 5140d1d976c7060f7aded4dbe294f97c3d8382ea
+            GIT_TAG 52e168c1ea88298af7df1d82df2c99ba60251ef6
             )
 endif()


### PR DESCRIPTION
Update `odbc_scanner` extension to support cross-compiling it on macOS.

Depends on: duckdb/extension-ci-tools#319

Ref: duckdblabs/duckdb-internal#7373