### PR TITLE
Fix correlated CTE binding order and dependent-join propagation

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -114,6 +114,10 @@ public:
 		correlated_columns.insert(correlated_columns.begin(), std::move(info));
 		delim_index++;
 	}
+	void AddColumnToBack(container_type::value_type info) {
+		// Add to end
+		correlated_columns.push_back(std::move(info));
+	}
 
 	void SetDelimIndexToZero() {
 		delim_index = 0;

--- a/src/include/duckdb/planner/subquery/rewrite_cte_scan.hpp
+++ b/src/include/duckdb/planner/subquery/rewrite_cte_scan.hpp
@@ -17,8 +17,8 @@ namespace duckdb {
 //! Helper class to rewrite correlated cte scans within a single LogicalOperator
 class RewriteCTEScan : public LogicalOperatorVisitor {
 public:
-	RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns,
-	               bool rewrite_dependent_joins = false, bool recursive_cte = false);
+	RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns, bool rewrite_dependent_joins = false,
+	               bool recursive_cte = false);
 
 	void VisitOperator(LogicalOperator &op) override;
 

--- a/src/include/duckdb/planner/subquery/rewrite_cte_scan.hpp
+++ b/src/include/duckdb/planner/subquery/rewrite_cte_scan.hpp
@@ -14,19 +14,28 @@
 
 namespace duckdb {
 
+//! Controls whether RewriteCTEScan rewrites only CTE_REF nodes or also dependent joins.
+enum class CTEScanRewriteMode {
+	//! Only rewrite LOGICAL_CTE_REF nodes; do not rewrite LOGICAL_DEPENDENT_JOIN nodes.
+	CTE_REF_ONLY,
+	//! Rewrite LOGICAL_CTE_REF nodes and non-recursive dependent joins that reference the target CTE.
+	WITH_NON_RECURSIVE_DEPENDENT_JOINS,
+	//! Rewrite LOGICAL_CTE_REF nodes and dependent joins for recursive CTE rewrites (preserving recursive order).
+	WITH_RECURSIVE_DEPENDENT_JOINS
+};
+
 //! Helper class to rewrite correlated cte scans within a single LogicalOperator
 class RewriteCTEScan : public LogicalOperatorVisitor {
 public:
-	RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns, bool rewrite_dependent_joins = false,
-	               bool recursive_cte = false);
+	RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns,
+	               CTEScanRewriteMode mode = CTEScanRewriteMode::CTE_REF_ONLY);
 
 	void VisitOperator(LogicalOperator &op) override;
 
 private:
 	idx_t table_index;
 	const CorrelatedColumns &correlated_columns;
-	bool rewrite_dependent_joins = false;
-	bool recursive_cte = false;
+	CTEScanRewriteMode mode;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/subquery/rewrite_cte_scan.hpp
+++ b/src/include/duckdb/planner/subquery/rewrite_cte_scan.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 class RewriteCTEScan : public LogicalOperatorVisitor {
 public:
 	RewriteCTEScan(idx_t table_index, const CorrelatedColumns &correlated_columns,
-	               bool rewrite_dependent_joins = false);
+	               bool rewrite_dependent_joins = false, bool recursive_cte = false);
 
 	void VisitOperator(LogicalOperator &op) override;
 
@@ -26,6 +26,7 @@ private:
 	idx_t table_index;
 	const CorrelatedColumns &correlated_columns;
 	bool rewrite_dependent_joins = false;
+	bool recursive_cte = false;
 };
 
 } // namespace duckdb

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -373,7 +373,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 
 				auto &rec_cte_op = rec_cte->second->Cast<LogicalCTE>();
 				if (op.correlated_columns == 0) {
-					RewriteCTEScan cte_rewriter(op.cte_index, rec_cte_op.correlated_columns);
+					RewriteCTEScan cte_rewriter(op.cte_index, rec_cte_op.correlated_columns, true, true);
 					cte_rewriter.VisitOperator(*plan);
 				}
 			}
@@ -1072,7 +1072,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			}
 		}
 
-		RewriteCTEScan cte_rewriter(table_index, correlated_columns,
+		RewriteCTEScan cte_rewriter(table_index, correlated_columns, true,
 		                            plan->type == LogicalOperatorType::LOGICAL_RECURSIVE_CTE);
 		cte_rewriter.VisitOperator(*plan->children[1]);
 

--- a/test/sql/subquery/scalar/test_scalar_subquery_cte.test
+++ b/test/sql/subquery/scalar/test_scalar_subquery_cte.test
@@ -126,6 +126,16 @@ SELECT a, (WITH cte AS (SELECT SUM(b) FROM test tsub WHERE test.a=tsub.a) SELECT
 12	21.000000
 13	22.000000
 
+query III
+SELECT n, x, (WITH cte AS (SELECT n AS v) SELECT (SELECT v FROM cte WHERE x = 10 LIMIT 1)) AS z
+FROM (VALUES (1,10),(1,20),(2,10),(2,20)) t(n,x)
+ORDER BY n, x
+----
+1	10	1
+1	20	NULL
+2	10	2
+2	20	NULL
+
 query II
 SELECT a, (WITH cte AS (SELECT CASE WHEN test.a=11 THEN 22 ELSE NULL END) SELECT * FROM cte) FROM test ORDER BY a
 ----


### PR DESCRIPTION
This fixes a wrong-result bug where correlated scalar subqueries referencing a CTE could swap bindings (e.g., x vs v in the example below) after RewriteCTEScan extended dependent-join correlation. The root cause was prepending CTE correlated columns: RewriteCorrelatedExpressions uses positional indices into correlated_columns, so prepending shifted indices and caused binding collisions. The fix appends CTE columns for non-recursive CTEs to keep indices stable and limits propagation to subtrees that actually reference the CTE, avoiding unrelated joins picking up CTE correlation.

Example:
```
SELECT n, x,
  (WITH cte AS (SELECT n AS v)
   SELECT (SELECT v FROM cte WHERE x = 10 LIMIT 1)) AS z
FROM (VALUES (1,10),(1,20),(2,10),(2,20)) t(n,x)
ORDER BY n, x;

Actual output (before):
  1  10  0
  1  20  NULL
  2  10  0
  2  20  NULL

Expected output:
  1  10  1
  1  20  NULL
  2  10  2
  2  20  NULL
```