### PR TITLE
Add VERIFY_SSL as optional parameter for HTTP and S3 secrets

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -2,4 +2,5 @@ duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG c5a73542cfa9d4b2be73670e5ff0ab973f7a9b27
+    APPLY_PATCHES
 )

--- a/.github/patches/extensions/httpfs/add_verify_ssl_param_to_secrets.patch
+++ b/.github/patches/extensions/httpfs/add_verify_ssl_param_to_secrets.patch
@@ -1,0 +1,102 @@
+diff --git a/src/create_secret_functions.cpp b/src/create_secret_functions.cpp
+index be306433fb6..aa5c9b28f22 100644
+--- a/src/create_secret_functions.cpp
++++ b/src/create_secret_functions.cpp
+@@ -80,6 +80,12 @@ unique_ptr<BaseSecret> CreateS3SecretFunctions::CreateSecretFunctionInternal(Cli
+ 				                            lower_name, named_param.second.type().ToString());
+ 			}
+ 			secret->secret_map["use_ssl"] = Value::BOOLEAN(named_param.second.GetValue<bool>());
++		} else if (lower_name == "verify_ssl") {
++			if (named_param.second.type() != LogicalType::BOOLEAN) {
++				throw InvalidInputException("Invalid type past to secret option: '%s', found '%s', expected: 'BOOLEAN'",
++				                            lower_name, named_param.second.type().ToString());
++			}
++			secret->secret_map["verify_ssl"] = Value::BOOLEAN(named_param.second.GetValue<bool>());
+ 		} else if (lower_name == "kms_key_id") {
+ 			secret->secret_map["kms_key_id"] = named_param.second.ToString();
+ 		} else if (lower_name == "url_compatibility_mode") {
+@@ -201,6 +207,7 @@ void CreateS3SecretFunctions::SetBaseNamedParams(CreateSecretFunction &function,
+ 	function.named_parameters["endpoint"] = LogicalType::VARCHAR;
+ 	function.named_parameters["url_style"] = LogicalType::VARCHAR;
+ 	function.named_parameters["use_ssl"] = LogicalType::BOOLEAN;
++	function.named_parameters["verify_ssl"] = LogicalType::BOOLEAN;
+ 	function.named_parameters["kms_key_id"] = LogicalType::VARCHAR;
+ 	function.named_parameters["url_compatibility_mode"] = LogicalType::BOOLEAN;
+ 	function.named_parameters["requester_pays"] = LogicalType::BOOLEAN;
+diff --git a/src/httpfs.cpp b/src/httpfs.cpp
+index b7252fde1a3..0e4e6399b70 100644
+--- a/src/httpfs.cpp
++++ b/src/httpfs.cpp
+@@ -97,6 +97,7 @@ unique_ptr<HTTPParams> HTTPFSUtil::InitializeParameters(optional_ptr<FileOpener>
+ 		result->http_proxy = host;
+ 		result->http_proxy_port = port;
+ 	}
++	result->override_verify_ssl = settings_reader->TryGetSecretKey<bool>("verify_ssl", result->verify_ssl);
+ 	settings_reader->TryGetSecretKey<string>("http_proxy_username", result->http_proxy_username);
+ 	settings_reader->TryGetSecretKey<string>("http_proxy_password", result->http_proxy_password);
+ 	settings_reader->TryGetSecretKey<string>("bearer_token", result->bearer_token);
+diff --git a/src/httpfs_curl_client.cpp b/src/httpfs_curl_client.cpp
+index 3b56ccf5ab9..d1a750e4d3e 100644
+--- a/src/httpfs_curl_client.cpp
++++ b/src/httpfs_curl_client.cpp
+@@ -118,9 +118,6 @@ public:
+ 		curl_url_set(base_url, CURLUPART_URL, proto_host_port.c_str(), 0);
+ 		stored_bearer_token = "";
+ 		stored_cert_file_path = "";
+-		if (StringUtil::StartsWith(proto_host_port, "https://")) {
+-			https_connection = true;
+-		}
+ 		Initialize(http_params);
+ 	}
+ 	void Initialize(HTTPParams &http_p) override {
+@@ -162,7 +159,9 @@ public:
+ 			curl_easy_setopt(*curl, CURLOPT_FORBID_REUSE, 0L);
+ 		}
+ 
+-		if (https_connection && http_params.enable_curl_server_cert_verification) {
++		const bool verify_ssl = http_params.override_verify_ssl ? http_params.verify_ssl : http_params.enable_curl_server_cert_verification;
++
++		if (verify_ssl) {
+ 			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYPEER, 1L); // Verify the cert
+ 			curl_easy_setopt(*curl, CURLOPT_SSL_VERIFYHOST, 2L); // Verify that the cert matches the hostname
+ 		} else {
+@@ -474,7 +473,6 @@ private:
+ 	CURLU *base_url = nullptr;
+ 	string stored_bearer_token;
+ 	string stored_cert_file_path;
+-	bool https_connection = false;
+ 
+ 	static std::mutex &GetRefLock() {
+ 		static std::mutex mtx;
+diff --git a/src/httpfs_httplib_client.cpp b/src/httpfs_httplib_client.cpp
+index d8d41ad1d10..272b6ba4cac 100644
+--- a/src/httpfs_httplib_client.cpp
++++ b/src/httpfs_httplib_client.cpp
+@@ -9,9 +9,6 @@ class HTTPFSClient : public HTTPClient {
+ public:
+ 	HTTPFSClient(HTTPFSParams &http_params, const string &proto_host_port) {
+ 		client = make_uniq<duckdb_httplib_openssl::Client>(proto_host_port);
+-		if (StringUtil::StartsWith(proto_host_port, "https://")) {
+-			https_connection = true;
+-		}
+ 		Initialize(http_params);
+ 	}
+ 	void Initialize(HTTPParams &http_p) override {
+@@ -21,7 +18,8 @@ public:
+ 		if (!http_params.ca_cert_file.empty()) {
+ 			client->set_ca_cert_path(http_params.ca_cert_file.c_str());
+ 		}
+-		client->enable_server_certificate_verification(https_connection && http_params.enable_server_cert_verification);
++		const bool verify_ssl = http_params.override_verify_ssl ? http_params.verify_ssl : http_params.enable_server_cert_verification;
++		client->enable_server_certificate_verification(verify_ssl);
+ 		client->set_write_timeout(http_params.timeout, http_params.timeout_usec);
+ 		client->set_read_timeout(http_params.timeout, http_params.timeout_usec);
+ 		client->set_connection_timeout(http_params.timeout, http_params.timeout_usec);
+@@ -162,7 +160,6 @@ private:
+ private:
+ 	unique_ptr<duckdb_httplib_openssl::Client> client;
+ 	optional_ptr<HTTPState> state;
+-	bool https_connection = false;
+ };
+ 
+ unique_ptr<HTTPClient> HTTPFSUtil::InitializeClient(HTTPParams &http_params, const string &proto_host_port) {

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -41,6 +41,8 @@ struct HTTPParams {
 	float retry_backoff = DEFAULT_RETRY_BACKOFF;
 	bool keep_alive = DEFAULT_KEEP_ALIVE;
 	bool follow_location = true;
+	bool override_verify_ssl = false;
+	bool verify_ssl = true;
 
 	string http_proxy;
 	idx_t http_proxy_port;

--- a/src/main/secret/default_secrets.cpp
+++ b/src/main/secret/default_secrets.cpp
@@ -26,6 +26,7 @@ vector<CreateSecretFunction> CreateHTTPSecretFunctions::GetDefaultSecretFunction
 	http_config_fun.provider = "config";
 	http_config_fun.function = CreateHTTPSecretFromConfig;
 
+	http_config_fun.named_parameters["verify_ssl"] = LogicalType::BOOLEAN;
 	http_config_fun.named_parameters["http_proxy"] = LogicalType::VARCHAR;
 	http_config_fun.named_parameters["http_proxy_password"] = LogicalType::VARCHAR;
 	http_config_fun.named_parameters["http_proxy_username"] = LogicalType::VARCHAR;
@@ -41,6 +42,7 @@ vector<CreateSecretFunction> CreateHTTPSecretFunctions::GetDefaultSecretFunction
 	http_env_fun.provider = "env";
 	http_env_fun.function = CreateHTTPSecretFromEnv;
 
+	http_env_fun.named_parameters["verify_ssl"] = LogicalType::BOOLEAN;
 	http_env_fun.named_parameters["http_proxy"] = LogicalType::VARCHAR;
 	http_env_fun.named_parameters["http_proxy_password"] = LogicalType::VARCHAR;
 	http_env_fun.named_parameters["http_proxy_username"] = LogicalType::VARCHAR;
@@ -78,6 +80,7 @@ unique_ptr<BaseSecret> CreateHTTPSecretFunctions::CreateHTTPSecretFromEnv(Client
 	}
 
 	// Allow overwrites
+	secret->TrySetValue("verify_ssl", input);
 	secret->TrySetValue("http_proxy", input);
 	secret->TrySetValue("http_proxy_password", input);
 	secret->TrySetValue("http_proxy_username", input);
@@ -92,6 +95,7 @@ unique_ptr<BaseSecret> CreateHTTPSecretFunctions::CreateHTTPSecretFromConfig(Cli
                                                                              CreateSecretInput &input) {
 	auto secret = make_uniq<KeyValueSecret>(input.scope, input.type, input.provider, input.name);
 
+	secret->TrySetValue("verify_ssl", input);
 	secret->TrySetValue("http_proxy", input);
 	secret->TrySetValue("http_proxy_password", input);
 	secret->TrySetValue("http_proxy_username", input);

--- a/test/configs/peg_parser.json
+++ b/test/configs/peg_parser.json
@@ -142,6 +142,10 @@
     {
       "reason": "DESCRIBE with CTE not supported",
       "paths": ["test/sql/cte/cte_describe.test"]
+    },
+    {
+      "reason": "FIXME: CREATE SECRET not properly supported",
+      "paths": ["test/sql/secrets/create_secret_expression.test"]
     }
   ]
 }

--- a/test/configs/peg_parser_strict.json
+++ b/test/configs/peg_parser_strict.json
@@ -187,6 +187,10 @@
     {
       "reason": "DESCRIBE with CTE not supported",
       "paths": ["test/sql/cte/cte_describe.test"]
+    },
+    {
+      "reason": "FIXME: CREATE SECRET not properly supported",
+      "paths": ["test/sql/secrets/create_secret_expression.test"]
     }
   ]
 }

--- a/test/sql/secrets/create_secret_expression.test
+++ b/test/sql/secrets/create_secret_expression.test
@@ -29,3 +29,30 @@ query I
 select scope from duckdb_secrets() where name='scope_as_struct'
 ----
 [hi, hello]
+
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, SCOPE 'https://duckdb.org');
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, SCOPE ['https://duckdb.org', 'http://extensions.duckdb.org']);
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, BEARER_TOKEN getvariable('my_bearer_token'));
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, HTTP_PROXY 'http://some-proxy/');
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, VERIFY_SSL 0);
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, VERIFY_SSL 1);
+
+statement error
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, VERIFY_SSL something);
+----
+Binder Error: Failed to cast option 'verify_ssl' to type 'BOOLEAN'
+
+statement ok
+CREATE OR REPLACE SECRET my_secret (TYPE HTTP, SCOPE ['https://duckdb.org', 'http://extensions.duckdb.org'], BEARER_TOKEN getvariable('my_bearer_token'), HTTP_PROXY 'http://some-proxy/', VERIFY_SSL 1);

--- a/test/sql/secrets/create_secret_expression.test
+++ b/test/sql/secrets/create_secret_expression.test
@@ -17,9 +17,9 @@ statement ok
 CREATE SECRET http (TYPE HTTP, BEARER_TOKEN getvariable('my_bearer_token'));
 
 query I
-SELECT secret_string.split(';')[-1] FROM duckdb_secrets() where name='http';
+SELECT sum(#1 == 'bearer_token=hocus pocus this token is bogus') FROM (SELECT unnest(secret_string.split(';')) FROM duckdb_secrets() where name='http');
 ----
-bearer_token=hocus pocus this token is bogus
+1
 
 # Test "old" syntax from before expressions were allowed
 statement ok


### PR DESCRIPTION
On top of https://github.com/duckdb/duckdb/pull/20841, now patching also `duckdb-httpfs` so to cut a 1 PR from review cycle.

----

#### Add VERIFY_SSL as optional parameter for HTTP and S3 secrets

If specified (for a given scope), this will be used to control whether to override whether
to perform SSL verification.

This decouples the protocol from whetehr certificate verification it's run or not, and can be used both directions.

This PR:
1. adds `verify_ssl` as option to HTTP secrets, at the syntax level
2. adds `verify_ssl` as option to S3 secrets, at the syntax level (via patch to be applied)
3. implement this in httpfs backends (currently via patch, to be applied)

To be done later, after the bump:
- [ ] patching `duckdb-httpfs` and improving testing framework
- [ ] bumping httpfs and removing patch in duckdb/duckdb

Once those are in, it would allow to decouples the protocol from whether certificate verification it's run or not, and can be used both directions.

```sql
CREATE SECRET my_secret (TYPE http, HTTP_PROXY 'http://proxy-location:8080');
```
Will have all traffic go through the proxy and certificate will be verified according to whether it's http or https traffic

```sql
CREATE SECRET my_secret (TYPE http, HTTP_PROXY 'http://proxy-location:8080', VERIFY_SSL 1);
```
Will have all traffic go through the proxy have certificate to be verified

```sql
CREATE SECRET my_secret (TYPE http, HTTP_PROXY 'http://proxy-location:8080', VERIFY_SSL 0);
```
Will have all traffic go through the proxy have certificate to be NOT verified

Note that changing default has security implications, so this is to be used with care, expecially with in mind improving local debugging experience.

This is part of fixing https://github.com/duckdb/duckdb-iceberg/issues/669