### PR TITLE
Fix deadlock in `BlockManager::BlockIsRegistered`

### DIFF
--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -167,7 +167,8 @@ public:
 	}
 
 protected:
-	bool BlockIsRegistered(block_id_t block_id);
+	bool BlockIsRegistered(lock_guard<mutex> &lock, block_id_t block_id);
+	shared_ptr<BlockHandle> TryGetBlock(unique_lock<mutex> &lock, block_id_t block_id);
 
 public:
 	template <class TARGET>

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -167,8 +167,8 @@ public:
 	}
 
 protected:
-	bool BlockIsRegistered(lock_guard<mutex> &lock, block_id_t block_id);
-	shared_ptr<BlockHandle> TryGetBlock(unique_lock<mutex> &lock, block_id_t block_id);
+	bool BlockIsRegistered(block_id_t block_id);
+	shared_ptr<BlockHandle> TryGetBlock(block_id_t block_id);
 
 public:
 	template <class TARGET>

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -214,6 +214,6 @@ private:
 	//! The storage manager options
 	StorageManagerOptions options;
 	//! Lock for performing various operations in the single file block manager
-	mutex block_lock;
+	mutex single_file_block_lock;
 };
 } // namespace duckdb

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -178,6 +178,8 @@ private:
 	void AddStorageVersionTag();
 
 	block_id_t GetFreeBlockIdInternal(FreeBlockType type);
+	//! Adds a free block to the free_list, returns true if it was added to the regular free_list
+	bool AddFreeBlock(unique_lock<mutex> &lock, block_id_t block_id);
 
 private:
 	AttachedDatabase &db;

--- a/src/storage/buffer/block_manager.cpp
+++ b/src/storage/buffer/block_manager.cpp
@@ -14,7 +14,8 @@ BlockManager::BlockManager(BufferManager &buffer_manager, const optional_idx blo
       block_alloc_size(block_alloc_size_p), block_header_size(block_header_size_p) {
 }
 
-bool BlockManager::BlockIsRegistered(lock_guard<mutex> &lock, block_id_t block_id) {
+bool BlockManager::BlockIsRegistered(block_id_t block_id) {
+	lock_guard<mutex> lock(blocks_lock);
 	// check if the block already exists
 	auto entry = blocks.find(block_id);
 	if (entry == blocks.end()) {
@@ -24,8 +25,8 @@ bool BlockManager::BlockIsRegistered(lock_guard<mutex> &lock, block_id_t block_i
 	return !entry->second.expired();
 }
 
-shared_ptr<BlockHandle> BlockManager::TryGetBlock(unique_lock<mutex> &lock, block_id_t block_id) {
-	D_ASSERT(lock.owns_lock());
+shared_ptr<BlockHandle> BlockManager::TryGetBlock(block_id_t block_id) {
+	lock_guard<mutex> lock(blocks_lock);
 	// check if the block already exists
 	auto entry = blocks.find(block_id);
 	if (entry == blocks.end()) {

--- a/src/storage/buffer/block_manager.cpp
+++ b/src/storage/buffer/block_manager.cpp
@@ -22,12 +22,7 @@ bool BlockManager::BlockIsRegistered(block_id_t block_id) {
 		return false;
 	}
 	// already exists: check if it hasn't expired yet
-	auto existing_ptr = entry->second.lock();
-	if (existing_ptr) {
-		//! it hasn't! return it
-		return true;
-	}
-	return false;
+	return !entry->second.expired();
 }
 
 shared_ptr<BlockHandle> BlockManager::RegisterBlock(block_id_t block_id) {

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -1235,7 +1235,7 @@ bool SingleFileBlockManager::AddFreeBlock(unique_lock<mutex> &lock, block_id_t b
 	free_blocks_in_use.insert(block_id);
 
 	// release the lock while destroying the block since the block destructor can call UnregisterBlock
-	lock.release();
+	lock.unlock();
 	block.reset();
 	lock.lock();
 	return false;


### PR DESCRIPTION
There was a deadlock introduced by this function where `BlockIsRegistered` would get a `shared_ptr<BlockHandle>`. If that was the last reference to said block handle it could cause a deadlock as that would then call `UnregisterBlock`. This PR resolves that by calling `.expired()` for `BlockIsRegistered`, and using a different method (`AddFreeBlock`) where we do proper lock management in the other locations where `BlockIsRegistered` is used.