### PR TITLE
Add back `PurgeAgedBlocks`

### DIFF
--- a/src/include/duckdb/storage/buffer/buffer_pool.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_pool.hpp
@@ -95,6 +95,10 @@ protected:
 	//! Evict object cache entries if needed.
 	EvictionResult EvictObjectCacheEntries(MemoryTag tag, idx_t extra_memory, idx_t memory_limit);
 
+	//! Purge all blocks that haven't been pinned within the last N seconds
+	idx_t PurgeAgedBlocks(uint32_t max_age_sec);
+	idx_t PurgeAgedBlocksInternal(EvictionQueue &queue, uint32_t max_age_sec, int64_t now, int64_t limit);
+
 	//! Garbage collect dead nodes in the eviction queue.
 	void PurgeQueue(const BlockHandle &handle);
 	//! Add a buffer handle to the eviction queue. Returns true, if the queue is

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -416,8 +416,8 @@ BufferPool::EvictionResult BufferPool::EvictBlocksInternal(EvictionQueue &queue,
 
 idx_t BufferPool::PurgeAgedBlocks(uint32_t max_age_sec) {
 	int64_t now = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
-					  .time_since_epoch()
-					  .count();
+	                  .time_since_epoch()
+	                  .count();
 	int64_t limit = now - (static_cast<int64_t>(max_age_sec) * 1000);
 	idx_t purged_bytes = 0;
 	for (auto &queue : queues) {
@@ -429,19 +429,18 @@ idx_t BufferPool::PurgeAgedBlocks(uint32_t max_age_sec) {
 idx_t BufferPool::PurgeAgedBlocksInternal(EvictionQueue &queue, uint32_t max_age_sec, int64_t now, int64_t limit) {
 	idx_t purged_bytes = 0;
 	queue.IterateUnloadableBlocks(
-		[&](BufferEvictionNode &node, const shared_ptr<BlockMemory> &handle, BlockLock &lock) {
-			// We will unload this block regardless. But stop the iteration immediately afterward if this
-			// block is younger than the age threshold.
-			auto lru_timestamp_msec = handle->GetLRUTimestamp();
-			bool is_fresh = lru_timestamp_msec >= limit && lru_timestamp_msec <= now;
-			purged_bytes += handle->GetMemoryUsage();
-			handle->Unload(lock);
-			// Return false to stop iterating if the current block is_fresh
-			return !is_fresh;
-		});
+	    [&](BufferEvictionNode &node, const shared_ptr<BlockMemory> &handle, BlockLock &lock) {
+		    // We will unload this block regardless. But stop the iteration immediately afterward if this
+		    // block is younger than the age threshold.
+		    auto lru_timestamp_msec = handle->GetLRUTimestamp();
+		    bool is_fresh = lru_timestamp_msec >= limit && lru_timestamp_msec <= now;
+		    purged_bytes += handle->GetMemoryUsage();
+		    handle->Unload(lock);
+		    // Return false to stop iterating if the current block is_fresh
+		    return !is_fresh;
+	    });
 	return purged_bytes;
 }
-
 
 template <typename FN>
 void EvictionQueue::IterateUnloadableBlocks(FN fn) {

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -414,6 +414,35 @@ BufferPool::EvictionResult BufferPool::EvictBlocksInternal(EvictionQueue &queue,
 	return {found, std::move(r)};
 }
 
+idx_t BufferPool::PurgeAgedBlocks(uint32_t max_age_sec) {
+	int64_t now = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
+					  .time_since_epoch()
+					  .count();
+	int64_t limit = now - (static_cast<int64_t>(max_age_sec) * 1000);
+	idx_t purged_bytes = 0;
+	for (auto &queue : queues) {
+		purged_bytes += PurgeAgedBlocksInternal(*queue, max_age_sec, now, limit);
+	}
+	return purged_bytes;
+}
+
+idx_t BufferPool::PurgeAgedBlocksInternal(EvictionQueue &queue, uint32_t max_age_sec, int64_t now, int64_t limit) {
+	idx_t purged_bytes = 0;
+	queue.IterateUnloadableBlocks(
+		[&](BufferEvictionNode &node, const shared_ptr<BlockMemory> &handle, BlockLock &lock) {
+			// We will unload this block regardless. But stop the iteration immediately afterward if this
+			// block is younger than the age threshold.
+			auto lru_timestamp_msec = handle->GetLRUTimestamp();
+			bool is_fresh = lru_timestamp_msec >= limit && lru_timestamp_msec <= now;
+			purged_bytes += handle->GetMemoryUsage();
+			handle->Unload(lock);
+			// Return false to stop iterating if the current block is_fresh
+			return !is_fresh;
+		});
+	return purged_bytes;
+}
+
+
 template <typename FN>
 void EvictionQueue::IterateUnloadableBlocks(FN fn) {
 	auto debug_sleep_micros = debug_eviction_queue_sleep.load(std::memory_order_relaxed);


### PR DESCRIPTION
The method has been removed in https://github.com/duckdb/duckdb/pull/20724, but MotherDuck relies on time-based purging of blocks (see https://github.com/duckdb/duckdb/pull/11441). 