### PR TITLE
Fix test issue with `approx_count_distinct` in `USING KEY`

### DIFF
--- a/test/configs/hash_zero.json
+++ b/test/configs/hash_zero.json
@@ -32,6 +32,7 @@
         "test/sql/show_select/test_summarize.test",
         "test/sql/vacuum/test_analyze.test",
         "test/sql/aggregate/aggregates/test_approximate_distinct_count.test",
+        "test/sql/cte/recursive_cte_key_hll_aggregation.test",
         "test/sql/function/list/aggregates/approx_count_distinct.test",
         "test/sql/copy/csv/test_glob_reorder_lineitem.test",
         "test/sql/types/geo/geometry_stats.test",

--- a/test/sql/cte/recursive_cte_key_aggregation.test
+++ b/test/sql/cte/recursive_cte_key_aggregation.test
@@ -303,25 +303,6 @@ TABLE tbl;
 ----
 1	120
 
-statement ok
-create table customers (id integer, cname varchar);
-
-statement ok
-insert into customers values (1, 'Customer#000000001'), (2, 'Customer#000000002'), (3, 'Customer#000000003'), (4, 'Customer#000000004');
-
-query I
-WITH RECURSIVE tbl(key, id, acc) USING KEY (key, approx_count_distinct(acc)) AS (
-	SELECT 1, id, cname
-	FROM customers
-	WHERE id = 1
-		UNION
-	SELECT key, tbl.id + 1, cname
-	FROM tbl
-	JOIN customers AS c ON c.id = tbl.id + 1)
-select acc from tbl;
-----
-4
-
 query I
 WITH RECURSIVE tbl(key, iter, b) USING KEY (key, approx_quantile(b, [0.5, 0.4, 0.1]) AS b) AS (
 	SELECT 1, 1, 0

--- a/test/sql/cte/recursive_cte_key_hll_aggregation.test
+++ b/test/sql/cte/recursive_cte_key_hll_aggregation.test
@@ -1,0 +1,22 @@
+# name: test/sql/cte/recursive_cte_key_hll_aggregation.test
+# description: Recursive CTEs with USING KEY and aggregations. Aggregations use HyperLogLog and must therefore be excluded from the test suite when HASH_ZERO=1 is set.
+# group: [cte]
+
+statement ok
+create table customers (id integer, cname varchar);
+
+statement ok
+insert into customers values (1, 'Customer#000000001'), (2, 'Customer#000000002'), (3, 'Customer#000000003'), (4, 'Customer#000000004');
+
+query I
+WITH RECURSIVE tbl(key, id, acc) USING KEY (key, approx_count_distinct(acc)) AS (
+	SELECT 1, id, cname
+	FROM customers
+	WHERE id = 1
+		UNION
+	SELECT key, tbl.id + 1, cname
+	FROM tbl
+	JOIN customers AS c ON c.id = tbl.id + 1)
+select acc from tbl;
+----
+4


### PR DESCRIPTION
Fixes a test failure in [Hash Zero CI run](https://github.com/duckdb/duckdb/actions/runs/21771070209/job/62819542150).

If we set HASH_ZERO=1 for the build, HyperLogLog no longer works. This causes `approx_count_distinct` to calculate incorrect values. That's why I moved the test to a separate file and excluded it for tests with HASH_ZERO=1.