### PR TITLE
Avoid writing tag for CTR in WAL

### DIFF
--- a/src/common/encryption_types.cpp
+++ b/src/common/encryption_types.cpp
@@ -80,14 +80,14 @@ idx_t EncryptionTag::size() const {
 }
 
 bool EncryptionTag::IsAllZeros() const {
-	const data_t *ptr = tag.get();
+	auto tag_ptr = tag.get();
 	idx_t len = size();
 
-	data_t acc = 0;
+	data_t is_only_zero = 0;
 	for (idx_t i = 0; i < len; ++i) {
-		acc |= ptr[i];
+		is_only_zero |= tag_ptr[i];
 	}
-	return acc == 0;
+	return is_only_zero == 0;
 }
 
 void EncryptionTag::SetSize(idx_t size) {

--- a/src/common/encryption_types.cpp
+++ b/src/common/encryption_types.cpp
@@ -68,6 +68,7 @@ using CipherType = EncryptionTypes::CipherType;
 using Version = EncryptionTypes::EncryptionVersion;
 
 EncryptionTag::EncryptionTag() : tag(new data_t[MainHeader::AES_TAG_LEN]()) {
+	tag_len = MainHeader::AES_TAG_LEN;
 }
 
 data_ptr_t EncryptionTag::data() {
@@ -75,7 +76,22 @@ data_ptr_t EncryptionTag::data() {
 }
 
 idx_t EncryptionTag::size() const {
-	return MainHeader::AES_TAG_LEN;
+	return tag_len;
+}
+
+bool EncryptionTag::IsAllZeros() const {
+	const data_t *ptr = tag.get();
+	idx_t len = size();
+
+	data_t acc = 0;
+	for (idx_t i = 0; i < len; ++i) {
+		acc |= ptr[i];
+	}
+	return acc == 0;
+}
+
+void EncryptionTag::SetSize(idx_t size) {
+	tag_len = size;
 }
 
 EncryptionCanary::EncryptionCanary() : canary(new data_t[MainHeader::CANARY_BYTE_SIZE]()) {

--- a/src/include/duckdb/common/encryption_state.hpp
+++ b/src/include/duckdb/common/encryption_state.hpp
@@ -69,6 +69,11 @@ public:
 
 public:
 	unique_ptr<EncryptionStateMetadata> metadata;
+
+public:
+	EncryptionTypes::CipherType GetCipher() const {
+		return metadata->GetCipher();
+	}
 };
 
 class EncryptionUtil {

--- a/src/include/duckdb/common/encryption_types.hpp
+++ b/src/include/duckdb/common/encryption_types.hpp
@@ -31,9 +31,12 @@ struct EncryptionTag {
 	EncryptionTag();
 	data_ptr_t data();
 	idx_t size() const;
+	bool IsAllZeros() const;
+	void SetSize(idx_t size);
 
 private:
 	unique_ptr<data_t[]> tag;
+	idx_t tag_len;
 };
 
 struct EncryptionCanary {

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -174,7 +174,10 @@ public:
 		stream->WriteData(temp_buf.get(), ciphertext_size);
 
 		// Write the tag to the stream
-		stream->WriteData(tag.data(), tag.size());
+		if (encryption_state->GetCipher() == EncryptionTypes::CipherType::GCM) {
+			D_ASSERT(!tag.IsAllZeros());
+			stream->WriteData(tag.data(), tag.size());
+		}
 
 		// rewind the buffer
 		memory_stream.Rewind();

--- a/test/sql/storage/encryption/wal/encrypted_wal_blob_storage.test
+++ b/test/sql/storage/encryption/wal/encrypted_wal_blob_storage.test
@@ -15,7 +15,7 @@ PRAGMA disable_checkpoint_on_shutdown
 statement ok
 PRAGMA wal_autocheckpoint='1TB';
 
-# # load the DB from disk
+# load the DB from disk
 statement ok
 ATTACH '__TEST_DIR__/encrypted_blob_storage_${cipher}.db' AS enc (ENCRYPTION_KEY 'asdf', ENCRYPTION_CIPHER '${cipher}');
 


### PR DESCRIPTION
We were accidentally writing a tag consisting of zeroes in our WAL encryption when using the CTR encryption mode. This has no security implications; it has simply no function and increases storage overhead. This PR also adds some checks in the WAL to avoid writing completely zeroed out tags.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/7383

Note: I deliberately did not chose to use versioning here. That means that when you try to read an encrypted wal file generated with duckdb < `v1.5` and encryption mode `CTR`, this will result in an error if you try to read it with >`v1.5`. I just think that this case will be extremely rare (or just non-existent). But let me know if you do not agree.