### PR TITLE
Check Allocator::debug_info before using it

### DIFF
--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -137,7 +137,7 @@ data_ptr_t Allocator::AllocateData(idx_t size) {
 	auto result = allocate_function(private_data.get(), size);
 #ifdef DEBUG
 	D_ASSERT(private_data);
-	if (private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE) {
+	if (private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE && private_data->debug_info) {
 		private_data->debug_info->AllocateData(result, size);
 	}
 #endif
@@ -154,7 +154,7 @@ void Allocator::FreeData(data_ptr_t pointer, idx_t size) {
 	D_ASSERT(size > 0);
 #ifdef DEBUG
 	D_ASSERT(private_data);
-	if (private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE) {
+	if (private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE && private_data->debug_info) {
 		private_data->debug_info->FreeData(pointer, size);
 	}
 #endif
@@ -174,7 +174,7 @@ data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t s
 	auto new_pointer = reallocate_function(private_data.get(), pointer, old_size, size);
 #ifdef DEBUG
 	D_ASSERT(private_data);
-	if (private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE) {
+	if (private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE && private_data->debug_info) {
 		private_data->debug_info->ReallocateData(pointer, new_pointer, old_size, size);
 	}
 #endif

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -136,8 +136,7 @@ data_ptr_t Allocator::AllocateData(idx_t size) {
 	}
 	auto result = allocate_function(private_data.get(), size);
 #ifdef DEBUG
-	D_ASSERT(private_data);
-	if (private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE && private_data->debug_info) {
+	if (ShouldUseDebugInfo()) {
 		private_data->debug_info->AllocateData(result, size);
 	}
 #endif
@@ -153,8 +152,7 @@ void Allocator::FreeData(data_ptr_t pointer, idx_t size) {
 	}
 	D_ASSERT(size > 0);
 #ifdef DEBUG
-	D_ASSERT(private_data);
-	if (private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE && private_data->debug_info) {
+	if (ShouldUseDebugInfo()) {
 		private_data->debug_info->FreeData(pointer, size);
 	}
 #endif
@@ -173,8 +171,7 @@ data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t s
 	}
 	auto new_pointer = reallocate_function(private_data.get(), pointer, old_size, size);
 #ifdef DEBUG
-	D_ASSERT(private_data);
-	if (private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE && private_data->debug_info) {
+	if (ShouldUseDebugInfo()) {
 		private_data->debug_info->ReallocateData(pointer, new_pointer, old_size, size);
 	}
 #endif

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -136,8 +136,11 @@ private:
 	allocate_function_ptr_t allocate_function;
 	free_function_ptr_t free_function;
 	reallocate_function_ptr_t reallocate_function;
-
 	unique_ptr<PrivateAllocatorData> private_data;
+
+	bool ShouldUseDebugInfo() const {
+		return private_data && private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE && private_data->debug_info;
+	}
 };
 
 template <class T>

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -31,6 +31,9 @@ struct PrivateAllocatorData {
 	virtual ~PrivateAllocatorData();
 
 	AllocatorFreeType free_type = AllocatorFreeType::REQUIRES_FREE;
+	//! Debug info for tracking allocations. Only initialized when the Allocator is constructed in a DEBUG build.
+	//! Code accessing this must check for nullptr because e.g. statically-linked extensions may have a different
+	//! DEBUG/release configuration than the host binary.
 	unique_ptr<AllocatorDebugInfo> debug_info;
 
 	template <class TARGET>

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -139,7 +139,8 @@ private:
 	unique_ptr<PrivateAllocatorData> private_data;
 
 	bool ShouldUseDebugInfo() const {
-		return private_data && private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE && private_data->debug_info;
+		return private_data && private_data->free_type != AllocatorFreeType::DOES_NOT_REQUIRE_FREE &&
+		       private_data->debug_info;
 	}
 };
 

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library_unity(
   test_numeric_cast.cpp
   test_parse_logical_type.cpp
   test_utf.cpp
+  test_allocator_debug_info.cpp
   test_storage_fuzz.cpp
   test_strftime.cpp
   test_string_util.cpp)

--- a/test/common/test_allocator_debug_info.cpp
+++ b/test/common/test_allocator_debug_info.cpp
@@ -1,0 +1,35 @@
+#include "catch.hpp"
+#include "duckdb/common/allocator.hpp"
+
+using namespace duckdb;
+
+#ifdef DEBUG
+TEST_CASE("Allocator handles nullptr debug_info gracefully", "[allocator]") {
+	// This is a regression test that only runs with debug builds. It:
+	// * constructs an Allocator using the default allocate/free/reallocate functions.
+	// * resets debug_info to nullptr (just like it is in a release build).
+	// * tests that AllocateData, FreeData and ReallocateData don't throw
+	// Also see https://github.com/duckdblabs/duckdb-internal/issues/7378
+	auto private_data = make_uniq<PrivateAllocatorData>();
+	Allocator alloc(Allocator::DefaultAllocate, Allocator::DefaultFree, Allocator::DefaultReallocate,
+	                std::move(private_data));
+	// release() instead of reset() because AllocatorDebugInfo is an incomplete type here.
+	(void)alloc.GetPrivateData()->debug_info.release();
+
+	SECTION("AllocateData with nullptr debug_info") {
+		data_ptr_t ptr = nullptr;
+		REQUIRE_NOTHROW(ptr = alloc.AllocateData(64));
+		REQUIRE(ptr != nullptr);
+		alloc.FreeData(ptr, 64);
+	}
+
+	SECTION("ReallocateData with nullptr debug_info") {
+		data_ptr_t ptr = Allocator::DefaultAllocate(nullptr, 64);
+		REQUIRE(ptr != nullptr);
+		data_ptr_t new_ptr = nullptr;
+		REQUIRE_NOTHROW(new_ptr = alloc.ReallocateData(ptr, 64, 128));
+		REQUIRE(new_ptr != nullptr);
+		alloc.FreeData(new_ptr, 128);
+	}
+}
+#endif


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/7378

Detailed explanation can be found in the issue.

The tl;dr is that this is one out of a class of bugs I hadn't considered before. When we statically link components that are built as a mix of debug and release artifacts, then it's possible that a symbol that is compiled in debug mode is accessing structures that are created by code that was not compiled in debug mode. In this case:

* The Allocator was created by a release build (of duckdb-python)
* The tpch extension was built with debug symbols
* The extension calls Allocator::AllocateData and assumes that the debug-only property `debug_data` is not a nullptr
* The Allocator structure did not have this property, since it was created by a release build

In a world where we statically link artifacts, this is something to keep in mind.