### PR TITLE
Make prepared statement plan caching less aggressive

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -54,11 +54,15 @@ struct ClientData;
 class ClientContextState;
 class RegisteredStateManager;
 
+enum class PreparationType { PREPARED_STATEMENT, PENDING_STATEMENT };
+
 struct PendingQueryParameters {
 	//! Prepared statement parameters (if any)
 	optional_ptr<case_insensitive_map_t<BoundParameterData>> parameters;
 	//! Whether a stream/buffer-managed result should be allowed
 	QueryParameters query_parameters;
+	//! Whether or not we are binding a statement for a (cached) prepare, or for execution
+	PreparationType prepare_type = PreparationType::PENDING_STATEMENT;
 };
 
 //! The ClientContext holds information relevant to the current client session

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -54,15 +54,11 @@ struct ClientData;
 class ClientContextState;
 class RegisteredStateManager;
 
-enum class PreparationType { PREPARED_STATEMENT, PENDING_STATEMENT };
-
 struct PendingQueryParameters {
 	//! Prepared statement parameters (if any)
 	optional_ptr<case_insensitive_map_t<BoundParameterData>> parameters;
 	//! Whether a stream/buffer-managed result should be allowed
 	QueryParameters query_parameters;
-	//! Whether or not we are binding a statement for a (cached) prepare, or for execution
-	PreparationType prepare_type = PreparationType::PENDING_STATEMENT;
 };
 
 //! The ClientContext holds information relevant to the current client session

--- a/src/include/duckdb/main/prepared_statement.hpp
+++ b/src/include/duckdb/main/prepared_statement.hpp
@@ -152,6 +152,9 @@ public:
 		}
 	}
 
+	//! Returns whether or not we can / want to cache a logical plan
+	static bool CanCachePlan(const LogicalOperator &op);
+
 private:
 	unique_ptr<PendingQueryResult> PendingQueryRecursive(vector<Value> &values) {
 		return PendingQuery(values);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -388,11 +388,22 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 	result->types = logical_planner.types;
 	result->value_map = std::move(logical_planner.value_map);
 	if (!logical_planner.properties.bound_all_parameters) {
+		// not all parameters were bound - return
 		return result;
 	}
 #ifdef DEBUG
 	logical_plan->Verify(*this);
 #endif
+	if (parameters.prepare_type == PreparationType::PREPARED_STATEMENT) {
+		// if this is a prepared statement we can choose not to fully plan
+		// check if we want to cache the plan
+		if (!PreparedStatement::CanCachePlan(*logical_plan)) {
+			// we don't - early-out
+			result->properties.always_require_rebind = true;
+			return result;
+		}
+	}
+
 	if (config.enable_optimizer && logical_plan->RequireOptimizer()) {
 		profiler.StartPhase(MetricType::ALL_OPTIMIZERS);
 		Optimizer optimizer(*logical_planner.binder, *this);
@@ -710,8 +721,11 @@ unique_ptr<PreparedStatement> ClientContext::PrepareInternal(ClientContextLock &
 	auto statement_query = statement->query;
 	shared_ptr<PreparedStatementData> prepared_data;
 	auto unbound_statement = statement->Copy();
+	PendingQueryParameters parameters;
+	parameters.prepare_type = PreparationType::PREPARED_STATEMENT;
 	RunFunctionInTransactionInternal(
-	    lock, [&]() { prepared_data = CreatePreparedStatement(lock, statement_query, std::move(statement), {}); },
+	    lock,
+	    [&]() { prepared_data = CreatePreparedStatement(lock, statement_query, std::move(statement), parameters); },
 	    false);
 	prepared_data->unbound_statement = std::move(unbound_statement);
 	return make_uniq<PreparedStatement>(shared_from_this(), std::move(prepared_data), std::move(statement_query),

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -134,4 +134,25 @@ unique_ptr<PendingQueryResult> PreparedStatement::PendingQuery(case_insensitive_
 	return result;
 }
 
+bool PreparedStatement::CanCachePlan(const LogicalOperator &root) {
+	vector<const_reference<LogicalOperator>> operators;
+	operators.push_back(root);
+
+	for (idx_t i = 0; i < operators.size(); i++) {
+		auto &op = operators[i].get();
+		switch (op.type) {
+		case LogicalOperatorType::LOGICAL_GET:
+			// this operator prevents caching
+			return false;
+		default:
+			break;
+		}
+		// investigate the children of this operator
+		for (auto &child : op.children) {
+			operators.push_back(*child);
+		}
+	}
+	return true;
+}
+
 } // namespace duckdb


### PR DESCRIPTION
Currently we bind prepared statements and often cache their plans prior to the parameters being known. This can cause big performance degradations compared to re-binding, as knowing the values of the parameters can enable more optimizations to be triggered. This PR makes prepared statement plan caching less aggressive. Since re-binding is generally not that expensive, we prefer to re-bind rather than potentially missing critical optimizations which can cause large and hard to understand slowdowns when prepared statements are used.

CC @evertlammerts 