### PR TITLE
bump ref to azure for v1.4.4 (rebuild)

### DIFF
--- a/.github/config/extensions/azure.cmake
+++ b/.github/config/extensions/azure.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
   duckdb_extension_load(azure
         LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb-azure
-        GIT_TAG 7e1ac3333d946a6bf5b4552722743e03f30a47cd
+        GIT_TAG e2a654f618972bfbd959465bdecf20671d9224d7
   )
 endif()


### PR DESCRIPTION
This forward bump includes the fix for FS client caching, duckdb/duckdb-azure#147