### PR TITLE
Add missed throw

### DIFF
--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -218,8 +218,8 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 				}
 				auto &shredding_types_value = option.second[0];
 				if (shredding_types_value.type().id() != LogicalTypeId::STRUCT) {
-					BinderException("SHREDDING value should be a STRUCT of column names to types, i.e: {col1: "
-					                "'INTEGER[]', col2: 'BOOLEAN'}");
+					throw BinderException("SHREDDING value should be a STRUCT of column names to types, i.e: {col1: "
+					                      "'INTEGER[]', col2: 'BOOLEAN'}");
 				}
 				const auto &struct_type = shredding_types_value.type();
 				const auto &struct_children = StructValue::GetChildren(shredding_types_value);


### PR DESCRIPTION
The object was created but it is not being used.
The 'throw' keyword could be missing: throw BinderException(FOO);

Found by PostgresPro with PVS-Studio static analyzer. 
Fixes: 3c8e32f1b0 ("shredding option parsing")