### PR TITLE
IndexCatalogEntry: fix typo

### DIFF
--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -8,7 +8,7 @@ IndexCatalogEntry::IndexCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schem
 	this->temporary = info.temporary;
 	this->dependencies = info.dependencies;
 	this->comment = info.comment;
-	for (auto &expr : expressions) {
+	for (auto &expr : info.expressions) {
 		D_ASSERT(expr);
 		expressions.push_back(expr->Copy());
 	}


### PR DESCRIPTION
Found by PostgresPro.
Fixes: 75d80d66cb ("Avoid moving data from the CreateIndexInfo after all")