### PR TITLE
Disable autoloading for odbc_scanner

### DIFF
--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -900,7 +900,6 @@ static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
     "json",
     "motherduck",
     "mysql_scanner",
-    "odbc_scanner",
     "parquet",
     "sqlite_scanner",
     "sqlsmith",

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1202,7 +1202,7 @@ static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {"avro",           "aws
                                                           "httpfs",         "iceberg",
                                                           "inet",           "icu",
                                                           "json",           "motherduck",
-                                                          "mysql_scanner",  "odbc_scanner",
+                                                          "mysql_scanner", /* "odbc_scanner", */
                                                           "parquet",        "sqlite_scanner",
                                                           "sqlsmith",       "postgres_scanner",
                                                           "tpcds",          "tpch",

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1194,18 +1194,30 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
     {"mysql/config", "mysql_scanner"},
     {"postgres/config", "postgres_scanner"}}; // EXTENSION_SECRET_PROVIDERS
 
-static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {"avro",           "aws",
-                                                          "azure",          "autocomplete",
-                                                          "core_functions", "delta",
-                                                          "ducklake",       "encodings",
-                                                          "excel",          "fts",
-                                                          "httpfs",         "iceberg",
-                                                          "inet",           "icu",
-                                                          "json",           "motherduck",
-                                                          "mysql_scanner", /* "odbc_scanner", */
-                                                          "parquet",        "sqlite_scanner",
-                                                          "sqlsmith",       "postgres_scanner",
-                                                          "tpcds",          "tpch",
-                                                          "unity_catalog",  "ui"}; // END_OF_AUTOLOADABLE_EXTENSIONS
+static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {"avro",
+                                                          "aws",
+                                                          "azure",
+                                                          "autocomplete",
+                                                          "core_functions",
+                                                          "delta",
+                                                          "ducklake",
+                                                          "encodings",
+                                                          "excel",
+                                                          "fts",
+                                                          "httpfs",
+                                                          "iceberg",
+                                                          "inet",
+                                                          "icu",
+                                                          "json",
+                                                          "motherduck",
+                                                          "mysql_scanner",
+                                                          "parquet",
+                                                          "sqlite_scanner",
+                                                          "sqlsmith",
+                                                          "postgres_scanner",
+                                                          "tpcds",
+                                                          "tpch",
+                                                          "unity_catalog",
+                                                          "ui"}; // END_OF_AUTOLOADABLE_EXTENSIONS
 
 } // namespace duckdb


### PR DESCRIPTION
Automatic loading of the `odbc_scanner` extension on `1.5-variegata` shows inconsistent behaviour. While the investigation of that problem is ongoing, it is suggested to disable the autoloading for this extension.

Ref: duckdblabs/duckdb-internal#7407