### PR TITLE
Fix internal error: Propagate bound columns from TRY() binder for GROUP BY validation

### DIFF
--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -106,6 +106,11 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 		//! This binder is used to throw when the child expression is of a type that is not allowed.
 		TryOperatorBinder try_operator_binder(binder, context);
 		try_operator_binder.BindChild(op.children[0], depth, error);
+		// Propagate bound columns from TryOperatorBinder back to parent binder
+		// This ensures that column references inside TRY() are properly tracked for GROUP BY validation
+		for (const auto &bound_col : try_operator_binder.GetBoundColumns()) {
+			bound_columns.push_back(bound_col);
+		}
 	} else {
 		for (idx_t i = 0; i < op.children.size(); i++) {
 			BindChild(op.children[i], depth, error);

--- a/test/sql/aggregate/group/test_group_by_error.test
+++ b/test/sql/aggregate/group/test_group_by_error.test
@@ -17,3 +17,20 @@ statement error
 SELECT * FROM tbl GROUP BY SUM(41)
 ----
 cannot contain aggregates
+
+statement ok
+CREATE TABLE v3 (v4 DOUBLE, v5 INTEGER);
+
+statement error
+SELECT
+    v4,
+    TRY(v5 / v5) AS result
+FROM v3
+GROUP BY v4
+HAVING (
+    SELECT SUM(v5)
+    FROM v3
+    WHERE v5 IS NOT NULL
+)
+----
+must appear in the GROUP BY clause


### PR DESCRIPTION
## PR Description
- Fixes #20616.

## Problem

DuckDB triggered an INTERNAL error (assertion failure) when a query used a non-aggregated column reference inside a TRY() expression within a GROUP BY clause. This was particularly visible when combined with a correlated subquery in the HAVING clause.

## Reproduction

pragma enable_verification;CREATE TABLE v3 (v4 DOUBLE, v5 INTEGER);SELECT    v4,    TRY(v5 / v5) AS resultFROM v3GROUP BY v4HAVING (    SELECT SUM(v5)    FROM v3    WHERE v5 IS NOT NULL);

## Root Cause

The TryOperatorBinder (a specialized ExpressionBinder used to bind the contents of TRY()) was successfully binding columns but keeping those references in its own local bound_columns vector. Because these were not propagated back to the parent SelectBinder, the binder's validation logic was unaware that v5 was being referenced.
This allowed the query to bypass the mandatory "column must appear in GROUP BY" check and proceed to the logical plan phase. It eventually crashed in the ColumnBindingResolver with an internal error: Failed to bind column reference "v5".

## Changes

Updated src/planner/binder/expression/bind_operator_expression.cpp to propagate bound_columns from the TryOperatorBinder back to the parent binder.
Added a regression test case in test/sql/aggregate/group/test_group_by_error.test.

## Verification

- The reproduction query now correctly returns: Binder Error: column "v5" must appear in the GROUP BY clause or must be part of an aggregate function.
- All existing group and binder test suites pass.