### PR TITLE
Rename `GetQueryMaxMemory` to `OperatorMemoryLimit`

### DIFF
--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -183,7 +183,7 @@ unique_ptr<GlobalSinkState> PhysicalOperator::GetGlobalSinkState(ClientContext &
 idx_t PhysicalOperator::GetMaxThreadMemory(ClientContext &context) {
 	// Memory usage per thread should scale with max mem / num threads
 	// We take 1/4th of this, to be conservative
-	auto max_memory = BufferManager::GetBufferManager(context).GetQueryMaxMemory();
+	auto max_memory = BufferManager::GetBufferManager(context).GetOperatorMemoryLimit();
 	auto num_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
 	return (max_memory / num_threads) / 4;
 }

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -209,7 +209,7 @@ RadixHTGlobalSinkState::RadixHTGlobalSinkState(ClientContext &context_p, const R
     : context(context_p), temporary_memory_state(TemporaryMemoryManager::Get(context).Register(context)),
       finalized(false), external(false), active_threads(0),
       number_of_threads(NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads())),
-      memory_limit(BufferManager::GetBufferManager(context).GetQueryMaxMemory()),
+      memory_limit(BufferManager::GetBufferManager(context).GetOperatorMemoryLimit()),
       block_alloc_size(BufferManager::GetBufferManager(context).GetBlockAllocSize()), any_combined(false),
       radix_ht(radix_ht_p), config(*this), stored_allocators_size(0), finalize_done(0),
       scan_pin_properties(TupleDataPinProperties::DESTROY_AFTER_DONE), count_before_combining(0),

--- a/src/include/duckdb/execution/operator/persistent/batch_memory_manager.hpp
+++ b/src/include/duckdb/execution/operator/persistent/batch_memory_manager.hpp
@@ -40,7 +40,7 @@ private:
 public:
 	void SetMemorySize(idx_t size) {
 		// request at most 1/4th of all available memory
-		idx_t total_max_memory = BufferManager::GetBufferManager(context).GetQueryMaxMemory();
+		idx_t total_max_memory = BufferManager::GetBufferManager(context).GetOperatorMemoryLimit();
 		idx_t request_cap = total_max_memory / 4;
 
 		size = MinValue<idx_t>(size, request_cap);

--- a/src/include/duckdb/storage/buffer/buffer_pool.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_pool.hpp
@@ -62,7 +62,7 @@ public:
 
 	idx_t GetMaxMemory() const;
 
-	virtual idx_t GetQueryMaxMemory() const;
+	virtual idx_t GetOperatorMemoryLimit() const;
 
 	TemporaryMemoryManager &GetTemporaryMemoryManager();
 

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -78,7 +78,7 @@ public:
 	//! Returns the block size for buffer-managed blocks.
 	virtual idx_t GetBlockSize() const = 0;
 	//! Returns the maximum available memory for a given query.
-	virtual idx_t GetQueryMaxMemory() const = 0;
+	virtual idx_t GetOperatorMemoryLimit() const = 0;
 
 	//! Returns a newly registered block of transient memory.
 	virtual shared_ptr<BlockHandle> RegisterTransientMemory(const idx_t size, BlockManager &block_manager);

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -55,7 +55,7 @@ public:
 	idx_t GetBlockAllocSize() const final;
 	//! Returns the block size for buffer-managed blocks.
 	idx_t GetBlockSize() const final;
-	idx_t GetQueryMaxMemory() const final;
+	idx_t GetOperatorMemoryLimit() const final;
 
 	//! Allocate an in-memory buffer with a single pin.
 	//! The allocated memory is released when the buffer handle is destroyed.

--- a/src/main/client_data.cpp
+++ b/src/main/client_data.cpp
@@ -115,8 +115,8 @@ public:
 	idx_t GetBlockSize() const override {
 		return buffer_manager.GetBlockSize();
 	}
-	idx_t GetQueryMaxMemory() const override {
-		idx_t global_budget = buffer_manager.GetQueryMaxMemory();
+	idx_t GetOperatorMemoryLimit() const override {
+		idx_t global_budget = buffer_manager.GetOperatorMemoryLimit();
 		const auto &config = ClientConfig::GetConfig(context);
 		if (!config.operator_memory_limit.IsValid()) {
 			return global_budget;

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -307,7 +307,7 @@ idx_t BufferPool::GetMaxMemory() const {
 	return maximum_memory;
 }
 
-idx_t BufferPool::GetQueryMaxMemory() const {
+idx_t BufferPool::GetOperatorMemoryLimit() const {
 	return GetMaxMemory();
 }
 

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -112,8 +112,8 @@ idx_t StandardBufferManager::GetBlockSize() const {
 	return temp_block_manager->GetBlockSize();
 }
 
-idx_t StandardBufferManager::GetQueryMaxMemory() const {
-	return GetBufferPool().GetQueryMaxMemory();
+idx_t StandardBufferManager::GetOperatorMemoryLimit() const {
+	return GetBufferPool().GetOperatorMemoryLimit();
 }
 
 template <typename... ARGS>

--- a/src/storage/temporary_memory_manager.cpp
+++ b/src/storage/temporary_memory_manager.cpp
@@ -98,7 +98,7 @@ void TemporaryMemoryManager::UpdateConfiguration(ClientContext &context) {
 	has_temporary_directory = buffer_manager.HasTemporaryDirectory();
 	num_threads = NumericCast<idx_t>(task_scheduler.NumberOfThreads());
 	num_connections = ConnectionManager::Get(context).GetConnectionCount();
-	query_max_memory = buffer_manager.GetQueryMaxMemory();
+	query_max_memory = buffer_manager.GetOperatorMemoryLimit();
 }
 
 TemporaryMemoryManager &TemporaryMemoryManager::Get(ClientContext &context) {

--- a/test/sql/settings/operator_memory_limit.test
+++ b/test/sql/settings/operator_memory_limit.test
@@ -44,7 +44,7 @@ SELECT name, value, input_type FROM duckdb_settings() WHERE name = 'operator_mem
 ----
 operator_memory_limit	NULL	VARCHAR
 
-# test that operator_memory_limit causes OOM for operators that check GetQueryMaxMemory()
+# test that operator_memory_limit causes OOM for operators that check GetOperatorMemoryLimit()
 # while memory_limit (hard cap) is set high enough to not interfere
 statement ok
 PRAGMA memory_limit='100MB'
@@ -82,7 +82,7 @@ SELECT i, SUM(i) OVER (PARTITION BY i % 100000 ORDER BY i) FROM range(5000000) t
 ----
 Out of Memory
 
-# streaming operations succeed - they dont check GetQueryMaxMemory()
+# streaming operations succeed - they dont check GetOperatorMemoryLimit()
 # this same query fails with memory_limit='1MB' but succeeds here
 statement ok
 CREATE TABLE t1 AS SELECT * FROM range(1000000)


### PR DESCRIPTION
The `GetQueryMaxMemory()` function is no longer used by MD, and we now use the functionality to implement the `operator_memory_limit` setting, so I've renamed the function to `OperatorMemoryLimit()`.