### PR TITLE
[minor] Update autoload exception comment

### DIFF
--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -319,8 +319,10 @@ MissingExtensionException::MissingExtensionException(const string &msg)
 }
 
 AutoloadException::AutoloadException(const string &extension_name, const string &message)
-    : Exception(ExceptionType::AUTOLOAD,
-                StringUtil::Format("An error occurred while trying to automatically install the required extension '%s:\n%s", extension_name, message)) {
+    : Exception(
+          ExceptionType::AUTOLOAD,
+          StringUtil::Format("An error occurred while trying to automatically install the required extension '%s:\n%s",
+                             extension_name, message)) {
 }
 
 SerializationException::SerializationException(const string &msg) : Exception(ExceptionType::SERIALIZATION, msg) {

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -320,8 +320,7 @@ MissingExtensionException::MissingExtensionException(const string &msg)
 
 AutoloadException::AutoloadException(const string &extension_name, const string &message)
     : Exception(ExceptionType::AUTOLOAD,
-                "An error occurred while trying to automatically install the required extension '" + extension_name +
-                    "':\n" + message) {
+                StringUtil::Format("An error occurred while trying to automatically install the required extension '%s:\n%s", extension_name, message)) {
 }
 
 SerializationException::SerializationException(const string &msg) : Exception(ExceptionType::SERIALIZATION, msg) {

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -85,7 +85,7 @@ enum class ExceptionType : uint8_t {
 	DEPENDENCY = 37,             // dependency
 	HTTP = 38,
 	MISSING_EXTENSION = 39, // Thrown when an extension is used but not loaded
-	AUTOLOAD = 40,          // Thrown when an extension is used but not loaded
+	AUTOLOAD = 40,          // Thrown when an extension fails to autoload
 	SEQUENCE = 41,
 	INVALID_CONFIGURATION =
 	    42 // An invalid configuration was detected (e.g. a Secret param was missing, or a required setting not found)


### PR DESCRIPTION
Fix the comment conflict for `MISSING_EXTENSION` and `AUTOLOAD` exception, also use string utils to avoid temporary string construction.