### PR TITLE
Support special strings in PEG Parser

### DIFF
--- a/extension/autocomplete/include/parser/special_string_utils.hpp
+++ b/extension/autocomplete/include/parser/special_string_utils.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+
+enum class SpecialStringCharacter { STANDARD = 0, NATIONAL_STRING, HEXADECIMAL_STRING, ESCAPE_STRING };
+
+struct SpecialStringInfo {
+	SpecialStringCharacter type;
+	idx_t prefix_len;
+};
+
+static SpecialStringInfo GetSpecialStringInfo(const string &text) {
+	if (text.empty()) {
+		return {SpecialStringCharacter::STANDARD, 0};
+	}
+	char c = text[0];
+	if (c == '\'') {
+		return {SpecialStringCharacter::STANDARD, 1};
+	}
+
+	// Check if second char is a quote to confirm it's a special string
+	if (text.size() > 1 && text[1] == '\'') {
+		switch (c) {
+		case 'N':
+		case 'n':
+			return {SpecialStringCharacter::NATIONAL_STRING, 2};
+		case 'X':
+		case 'x':
+			return {SpecialStringCharacter::HEXADECIMAL_STRING, 2};
+		case 'E':
+		case 'e':
+			return {SpecialStringCharacter::ESCAPE_STRING, 2};
+		default:
+			return {SpecialStringCharacter::STANDARD, 1};
+		}
+	}
+	return {SpecialStringCharacter::STANDARD, 1};
+}
+} // namespace duckdb

--- a/extension/autocomplete/include/tokenizer.hpp
+++ b/extension/autocomplete/include/tokenizer.hpp
@@ -45,6 +45,7 @@ public:
 	static bool CharacterIsControlFlow(char c);
 	static bool CharacterIsKeyword(char c);
 	static bool CharacterIsOperator(char c);
+	static bool CharacterIsSpecialStringCharacter(char c);
 	bool IsValidDollarTagCharacter(char c);
 
 protected:

--- a/extension/autocomplete/include/transformer/parse_result.hpp
+++ b/extension/autocomplete/include/transformer/parse_result.hpp
@@ -7,6 +7,7 @@
 #include "duckdb/parser/expression/cast_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
+#include "parser/special_string_utils.hpp"
 
 namespace duckdb {
 
@@ -27,8 +28,6 @@ enum class ParseResultType : uint8_t {
 	STRING,
 	INVALID
 };
-
-enum class SpecialStringCharacter { STANDARD = 0, NATIONAL_STRING, HEXADECIMAL_STRING, ESCAPE_STRING };
 
 inline const char *ParseResultToString(ParseResultType type) {
 	switch (type) {
@@ -337,7 +336,7 @@ public:
 						break;
 					case '\\':
 						escaped_result += '\\';
-						break; // This handles your '\\' case
+						break;
 					case '\'':
 						escaped_result += '\'';
 						break;
@@ -360,15 +359,15 @@ public:
 	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
 	                      const std::string &indent, bool is_last) const override {
 		ParseResult::ToStringInternal(ss, visited, indent, is_last);
-		if (string_type == SpecialStringCharacter::STANDARD) {
-			ss << ": \"" << result << "\"\n";
-		} else if (string_type == SpecialStringCharacter::ESCAPE_STRING) {
-			ss << ": E\"" << result << "\"\n";
+		string special_string;
+		if (string_type == SpecialStringCharacter::ESCAPE_STRING) {
+			special_string = "E";
 		} else if (string_type == SpecialStringCharacter::NATIONAL_STRING) {
-			ss << ": N\"" << result << "\"\n";
+			special_string = "N";
 		} else if (string_type == SpecialStringCharacter::HEXADECIMAL_STRING) {
-			ss << ": X\"" << result << "\"\n";
+			special_string = "X";
 		}
+		ss << ": " << special_string << "\"" << result << "\"n";
 	}
 };
 

--- a/extension/autocomplete/matcher.cpp
+++ b/extension/autocomplete/matcher.cpp
@@ -630,13 +630,17 @@ public:
 
 private:
 	static SpecialStringCharacter SpecialStringCharacter(char c) {
-		if (c == 'N') {
+		if (c == '\'') {
+			// Most likely case
+			return SpecialStringCharacter::STANDARD;
+		}
+		if (c == 'N' || c == 'n') {
 			return SpecialStringCharacter::NATIONAL_STRING;
 		}
-		if (c == 'X') {
+		if (c == 'X' || c == 'x') {
 			return SpecialStringCharacter::HEXADECIMAL_STRING;
 		}
-		if (c == 'E') {
+		if (c == 'E' || c == 'e') {
 			return SpecialStringCharacter::ESCAPE_STRING;
 		}
 		return SpecialStringCharacter::STANDARD;

--- a/extension/autocomplete/tokenizer.cpp
+++ b/extension/autocomplete/tokenizer.cpp
@@ -75,13 +75,13 @@ bool BaseTokenizer::CharacterIsInitialNumber(char c) {
 }
 
 bool BaseTokenizer::CharacterIsSpecialStringCharacter(char c) {
-	if (c == 'N') {
+	if (c == 'N' || c == 'n') {
 		return true;
 	}
-	if (c == 'X') {
+	if (c == 'X' || c == 'x') {
 		return true;
 	}
-	if (c == 'E') {
+	if (c == 'E' || c == 'e') {
 		return true;
 	}
 	return false;

--- a/extension/autocomplete/tokenizer.cpp
+++ b/extension/autocomplete/tokenizer.cpp
@@ -74,6 +74,19 @@ bool BaseTokenizer::CharacterIsInitialNumber(char c) {
 	return c == '.';
 }
 
+bool BaseTokenizer::CharacterIsSpecialStringCharacter(char c) {
+	if (c == 'N') {
+		return true;
+	}
+	if (c == 'X') {
+		return true;
+	}
+	if (c == 'E') {
+		return true;
+	}
+	return false;
+}
+
 bool BaseTokenizer::CharacterIsNumber(char c) {
 	if (CharacterIsInitialNumber(c)) {
 		return true;
@@ -264,6 +277,15 @@ bool BaseTokenizer::TokenizeInput() {
 				state = TokenizeState::NUMERIC;
 				last_pos = i;
 				break;
+			}
+			if (CharacterIsSpecialStringCharacter(c)) {
+				// Look ahead to see if a quote follows
+				if (i + 1 < sql.size() && sql[i + 1] == '\'') {
+					state = TokenizeState::STRING_LITERAL;
+					last_pos = i;
+					i++;
+					break;
+				}
 			}
 			if (StringUtil::CharacterIsOperator(c)) {
 				state = TokenizeState::OPERATOR;

--- a/extension/autocomplete/transformer/transform_attach.cpp
+++ b/extension/autocomplete/transformer/transform_attach.cpp
@@ -121,7 +121,7 @@ GenericCopyOption PEGTransformerFactory::TransformGenericCopyOption(PEGTransform
 				} else if (const_expr.value.GetValue<string>() == "f") {
 					copy_option.children.push_back(Value(false));
 				} else {
-					throw ParserException("Invalid boolean value for option %s", copy_option.name);
+					copy_option.expression = std::move(expression);
 				}
 			} else {
 				copy_option.expression = std::move(expression);

--- a/extension/autocomplete/transformer/transform_copy.cpp
+++ b/extension/autocomplete/transformer/transform_copy.cpp
@@ -270,7 +270,7 @@ GenericCopyOption PEGTransformerFactory::TransformForceQuoteOption(PEGTransforme
 		result.expression = make_uniq<StarExpression>();
 	} else if (StringUtil::CIEquals(star_or_column_list->name, "ColumnList")) {
 		auto column_list = transformer.Transform<vector<string>>(star_or_column_list);
-		for (auto col : column_list) {
+		for (auto &col : column_list) {
 			result.children.push_back(Value(col));
 		}
 	}
@@ -292,7 +292,7 @@ GenericCopyOption PEGTransformerFactory::TransformForceNullOption(PEGTransformer
 	auto result = GenericCopyOption();
 	result.name = is_not ? "force_not_null" : "force_null";
 	auto column_list = transformer.Transform<vector<string>>(list_pr.Child<ListParseResult>(3));
-	for (auto col : column_list) {
+	for (auto &col : column_list) {
 		result.children.push_back(Value(col));
 	}
 	return result;
@@ -309,7 +309,7 @@ GenericCopyOption PEGTransformerFactory::TransformPartitionByOption(PEGTransform
 		result.expression = make_uniq<StarExpression>();
 	} else if (StringUtil::CIEquals(star_or_column_list->name, "ColumnList")) {
 		auto column_list = transformer.Transform<vector<string>>(star_or_column_list);
-		for (auto col : column_list) {
+		for (auto &col : column_list) {
 			result.children.push_back(Value(col));
 		}
 	}

--- a/extension/autocomplete/transformer/transform_create_table.cpp
+++ b/extension/autocomplete/transformer/transform_create_table.cpp
@@ -477,7 +477,12 @@ pair<bool, ConstraintType> PEGTransformerFactory::TransformUniqueConstraint(PEGT
 
 pair<bool, ConstraintType> PEGTransformerFactory::TransformNotNullConstraint(PEGTransformer &transformer,
                                                                              optional_ptr<ParseResult> parse_result) {
-	return make_pair(false, ConstraintType::NOT_NULL);
+	auto &list_pr = parse_result->Cast<ListParseResult>();
+	auto not_null = list_pr.Child<OptionalParseResult>(0).HasResult();
+	if (not_null) {
+		return make_pair(false, ConstraintType::NOT_NULL);
+	}
+	return make_pair(false, ConstraintType::INVALID);
 }
 
 LogicalType PEGTransformerFactory::TransformColumnCollation(PEGTransformer &transformer,

--- a/extension/autocomplete/transformer/transform_expression.cpp
+++ b/extension/autocomplete/transformer/transform_expression.cpp
@@ -1481,7 +1481,8 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformLiteralExpression(P
 	auto &list_pr = parse_result->Cast<ListParseResult>();
 	auto &matched_rule_result = list_pr.Child<ChoiceParseResult>(0);
 	if (matched_rule_result.name == "StringLiteral") {
-		return make_uniq<ConstantExpression>(Value(transformer.Transform<string>(matched_rule_result.result)));
+		auto string_literal = matched_rule_result.result->Cast<StringLiteralParseResult>();
+		return string_literal.ToExpression();
 	}
 	return transformer.Transform<unique_ptr<ParsedExpression>>(matched_rule_result.result);
 }

--- a/test/configs/peg_parser_strict.json
+++ b/test/configs/peg_parser_strict.json
@@ -32,58 +32,6 @@
       "paths": ["test/sql/settings/setting_preserve_identifier_case.test"]
     },
     {
-      "reason": "Parser exception because of dollar-quoted strings",
-      "paths": [
-        "test/sql/peg_parser/parser/insert_statement.test",
-        "test/sql/peg_parser/parser/create_macro.test",
-        "test/sql/peg_parser/parser/show_table.test",
-        "test/sql/peg_parser/parser/prepare_statement.test",
-        "test/sql/peg_parser/parser/support_try.test",
-        "test/sql/peg_parser/parser/nested_join.test",
-        "test/sql/peg_parser/parser/pivot_statement.test",
-        "test/sql/peg_parser/parser/on_conflict.test",
-        "test/sql/peg_parser/parser/select_star.test",
-        "test/sql/peg_parser/parser/invisible_space.test",
-        "test/sql/peg_parser/parser/array_subquery.test",
-        "test/sql/peg_parser/parser/update_statement.test",
-        "test/sql/peg_parser/parser/use_statement.test",
-        "test/sql/peg_parser/parser/dotted_functions.test",
-        "test/sql/peg_parser/parser/attach_or_replace.test",
-        "test/sql/peg_parser/parser/load_extension.test",
-        "test/sql/peg_parser/parser/delete_from.test",
-        "test/sql/peg_parser/parser/create_type.test",
-        "test/sql/peg_parser/parser/alter.test",
-        "test/sql/peg_parser/parser/with_ordinality.test",
-        "test/sql/peg_parser/parser/recursive.test",
-        "test/sql/peg_parser/parser/analyze_vacuum.test",
-        "test/sql/peg_parser/parser/scientific_notation.test",
-        "test/sql/peg_parser/parser/index.test",
-        "test/sql/peg_parser/parser/type.test",
-        "test/sql/peg_parser/parser/empty_map.test",
-        "test/sql/peg_parser/parser/copy_expression.test",
-        "test/sql/peg_parser/parser/colon_alias.test",
-        "test/sql/peg_parser/parser/lambda_functions.test",
-        "test/sql/peg_parser/parser/collate.test",
-        "test/sql/peg_parser/parser/support_unreserved_keywords.test",
-        "test/sql/peg_parser/parser/list_slices.test",
-        "test/sql/peg_parser/parser/struct_identifier.test",
-        "test/sql/peg_parser/parser/map.test",
-        "test/sql/peg_parser/parser/ignore_nulls.test",
-        "test/sql/peg_parser/parser/insert.test",
-        "test/sql/peg_parser/parser/dollar_quoted.test",
-        "test/sql/peg_parser/parser/support_optional_not_null_constraint.test",
-        "test/sql/peg_parser/parser/window_function.test",
-        "test/sql/peg_parser/parser/create_table.test",
-        "test/sql/peg_parser/parser/sample.test",
-        "test/sql/peg_parser/parser/merge_into.test",
-        "test/sql/peg_parser/parser/custom_operator.test"
-      ]
-    },
-    {
-      "reason": "Parser exception because of 'autocomplete' caused the CALL command to fail",
-      "paths": ["test/sql/storage/memory/in_memory_compress.test"]
-    },
-    {
       "reason": "Quotations",
       "paths": [
         "test/sql/table_function/sqlite_master_quotes.test",
@@ -149,23 +97,24 @@
     {
       "reason": "Unclassified failures",
       "paths": [
+        "test/sql/error/lineitem_errors.test",
+        "test/sql/create/create_as_partition_sorted_options.test",
+        "test/sql/select/test_select_locking.test",
+        "test/sql/copy/csv/glob/copy_csv_glob.test",
+        "test/sql/alter/alter_table_set_table_options.test",
         "test/sql/storage/wal/wal_replay_consistency_add_column_current_timestamp.test",
         "test/sql/storage/wal/wal_replay_consistency_add_column_random.test",
-        "test/sql/catalog/table/create_table_parameters.test",
-        "test/sql/show_select/test_show_select.test",
-        "test/sql/copy/csv/glob/copy_csv_glob.test",
-        "test/sql/cte/recursive_cte_key_variant.test",
-        "test/sql/overflow/expression_tree_depth.test",
-        "test/sql/error/lineitem_errors.test",
-        "test/sql/select/test_select_locking.test",
-        "test/sql/function/string/test_subscript.test",
-        "test/sql/binder/test_string_alias.test",
         "test/sql/function/string/test_string_slice.test",
-        "test/sql/alter/alter_table_set_table_options.test",
-	"test/sql/create/create_as_partition_sorted_options.test",
-        "test/sql/pragma/test_pragma_sanitized_inputs.test",
-        "test/sql/pragma/test_query_log.test",
+        "test/sql/function/string/test_subscript.test",
+        "test/sql/catalog/table/create_table_parameters.test",
+        "test/sql/binder/test_string_alias.test",
         "test/optimizer/joins/lateral_cross_join.test"
+      ]
+    },
+    {
+      "reason": "Expression depth",
+      "paths": [
+        "test/sql/overflow/expression_tree_depth.test"
       ]
     },
     {

--- a/test/configs/peg_parser_strict.json
+++ b/test/configs/peg_parser_strict.json
@@ -28,18 +28,6 @@
       ]
     },
     {
-      "reason": "Special strings",
-      "paths": [
-        "test/sql/copy/csv/unquoted_escape/basic.test",
-        "test/sqlserver/sqlserver_cte.test",
-        "test/optimizer/compare_blob.test",
-        "test/sql/copy/csv/test_copy.test",
-        "test/sql/copy/csv/unquoted_escape/mixed.test",
-        "test/issues/general/test_15483.test",
-        "test/sql/copy/csv/unquoted_escape/human_eval.test"
-      ]
-    },
-    {
       "reason": "Case insensitive preservation",
       "paths": ["test/sql/settings/setting_preserve_identifier_case.test"]
     },


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/7304
Part of https://github.com/duckdblabs/duckdb-internal/issues/6380

PostgreSQL supports some special strings that have slightly different behaviour than standard strings
- Escape string (`E'string'`) constants with C-style escapes (see [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-ESCAPE))
- National character string (`N'string'`) is wrapped in a `CAST('string' as VARCHAR)`
- Hexadecimal string: Seems like I only needed to insert an `x` at the start of the string for it to be handled correctly. 

I also removed some excluded tests that were already passing, I was skipping too many. 

Additionally: 
Fixed a bug where `CREATE TABLE a (i BIGINT NULL)` was incorrectly applying a `NOT NULL` constraint. In SQL, the NULL keyword explicitly allows null values, but it was being misidentified as a `NOT NULL` constraint.

Note: 
String constants with unicode (see [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-UESCAPE)) escapes are not implemented in the old parser: 
```sql
D select U&'d\0061t\+000061';
Parser Error:
unicode_to_utf8 NOT IMPLEMENTED
```
Not sure if that's really necessary to implement this in the new parser either. 