### PR TITLE
Fixup CopyToFunctionGlobalState destructor to handle throws

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -264,7 +264,12 @@ CopyToFunctionGlobalState::~CopyToFunctionGlobalState() {
 	// If we reach here, the query failed before Finalize was called
 	auto &fs = FileSystem::GetFileSystem(context);
 	for (auto &file : created_files) {
-		fs.TryRemoveFile(file);
+		try {
+			fs.TryRemoveFile(file);
+		} catch (...) {
+			// TryRemoveFile migth fail for a varieaty of reasons, but we can't really propagate error codes here, so
+			// best effort cleanup
+		}
 	}
 }
 


### PR DESCRIPTION
There are possibly better solution, but for now adding some context at the call site that we are not in a position to handle exceptional situations.

Connected conversation at https://github.com/duckdb/duckdb/pull/20521

Small improvements >> rework.