### PR TITLE
Fix missing query location in table macro bind errors

### DIFF
--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -382,7 +382,10 @@ BoundStatement Binder::Bind(TableFunctionRef &ref) {
 			query = binder->BindNode(*query_node);
 		} catch (std::exception &ex) {
 			ErrorData error(ex);
-			error.AddQueryLocation(ref);
+			// if the error does not already contain a query location, add one
+			if (error.ExtraInfo().count("position") == 0) {
+				error.AddQueryLocation(ref);
+			}
 			error.Throw();
 		}
 

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -382,10 +382,7 @@ BoundStatement Binder::Bind(TableFunctionRef &ref) {
 			query = binder->BindNode(*query_node);
 		} catch (std::exception &ex) {
 			ErrorData error(ex);
-			// if the error does not already contain a query location, add one
-			if (error.ExtraInfo().count("position") == 0) {
-				error.AddQueryLocation(ref);
-			}
+			error.AddQueryLocation(ref);
 			error.Throw();
 		}
 
@@ -466,7 +463,10 @@ BoundStatement Binder::Bind(TableFunctionRef &ref) {
 		                                std::move(input_table_types), std::move(input_table_names));
 	} catch (std::exception &ex) {
 		error = ErrorData(ex);
-		error.AddQueryLocation(ref);
+		// if the error does not already contain a query location, add one
+		if (error.ExtraInfo().count("position") == 0) {
+			error.AddQueryLocation(ref);
+		}
 		error.Throw();
 	}
 

--- a/test/sql/error/error_position.test
+++ b/test/sql/error/error_position.test
@@ -9,5 +9,5 @@ set errors_as_json=true;
 statement error
 create macro checksum(x) as table SELECT bit_xor(md5_number(CAST(COLUMNS(*) AS VARCHAR))) FROM query_table(table_name);
 ----
-<REGEX>:.*"position".*:.*"95".*
+<REGEX>:.*"position".*:.*"5".*
 

--- a/test/sql/error/error_position_json_execute.test
+++ b/test/sql/error/error_position_json_execute.test
@@ -1,0 +1,42 @@
+# name: test/sql/error/error_position_json_execute.test
+# description: Error position from inside json_execute_serialized_sql must reflect the
+#              location of the error within the inner (serialized) SQL, not the call
+#              site of json_execute_serialized_sql in the outer query (#19512)
+# group: [error]
+
+require json
+
+statement ok
+set errors_as_json=true;
+
+# In the outer query below, json_execute_serialized_sql starts at position 17:
+#   SELECT 1, 2 FROM json_execute_serialized_sql(...)
+#   0         1
+#   01234567890123456789
+#                   ^17
+#
+# Without the fix, both variants below would report position "17" (the call site).
+# With the fix, the position from inside the inner SQL is preserved instead.
+
+# Inner SQL: no_such_tbl is at position 14 within the inner SQL (different from call-site "17")
+#   SELECT * FROM no_such_tbl
+#   0         1
+#   01234567890123456789
+#                 ^14
+statement error
+SELECT 1, 2 FROM json_execute_serialized_sql(json_serialize_sql('SELECT * FROM no_such_tbl'));
+----
+<REGEX>:.*"position".*:.*"14".*
+
+# Inner SQL: 
+#   no_such_tbl is at position 30 within the inner SQL.
+#   Without the fix, this would still incorrectly report "17" (unchanged call-site).
+#   With the fix, it correctly reports "30", showing the position tracks the inner SQL.
+#   SELECT 1,2,3,4,5,6,7,8,* FROM no_such_tbl
+#   0         1         2         3
+#   012345678901234567890123456789012
+#                                 ^30
+statement error
+SELECT 1, 2 FROM json_execute_serialized_sql(json_serialize_sql('SELECT 1,2,3,4,5,6,7,8,* FROM no_such_tbl'));
+----
+<REGEX>:.*"position".*:.*"30".*

--- a/test/sql/error/error_position_json_execute.test
+++ b/test/sql/error/error_position_json_execute.test
@@ -1,7 +1,5 @@
 # name: test/sql/error/error_position_json_execute.test
-# description: Error position from inside json_execute_serialized_sql must reflect the
-#              location of the error within the inner (serialized) SQL, not the call
-#              site of json_execute_serialized_sql in the outer query (#19512)
+# description: Error position reported by json_execute_serialized_sql must reflect the location of the error within the inner SQL, not the call site (#19512)
 # group: [error]
 
 require json


### PR DESCRIPTION
# Avoid overwriting existing error position when binding table macros

Fixes duckdb/duckdb#19512

## Motivation

When binding a `TABLE_MACRO`, we catch exceptions from
`BindNode(*query_node)` and rethrow them as `ErrorData`.

Previously, we **always** did:

``` cpp
error.AddQueryLocation(ref);
```

This can override an existing `"position"` already attached to the
error, leading to incorrect or misleading source highlighting (as
reported in #19512).

## Changes

In `BoundStatementBinder::Bind(TableFunctionRef &ref)`:

-   Only call `error.AddQueryLocation(ref)` when the error does **not**
    already contain a `"position"` in `ExtraInfo()`.

``` cpp
// if the error does not already contain a query location, add one
if (error.ExtraInfo().count("position") == 0) {
    error.AddQueryLocation(ref);
}
```

## Behavior Impact

-   Preserves the original error position when it is already available.
-   Still adds query location metadata for errors that lack position
    information.
-   No change to successful execution paths; change is limited to error
    handling.
