### PR TITLE
Physical Insert - avoid double constraint verification

### DIFF
--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -634,7 +634,8 @@ SinkResultType PhysicalInsert::Sink(ExecutionContext &context, DataChunk &insert
 		if (return_chunk) {
 			gstate.return_collection.Append(insert_chunk);
 		}
-		storage.LocalAppend(table, context.client, insert_chunk, bound_constraints);
+		// We can use `unsafe` when the action type is throw, since we already verify the constraints through `OnConflictHandling`
+		storage.LocalAppend(table, context.client, insert_chunk, bound_constraints, action_type==OnConflictAction::THROW);
 		if (action_type == OnConflictAction::UPDATE && lstate.update_chunk.size() != 0) {
 			(void)HandleInsertConflicts<true>(table, context, lstate, gstate, lstate.update_chunk, *this);
 			(void)HandleInsertConflicts<false>(table, context, lstate, gstate, lstate.update_chunk, *this);

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -634,17 +634,7 @@ SinkResultType PhysicalInsert::Sink(ExecutionContext &context, DataChunk &insert
 		if (return_chunk) {
 			gstate.return_collection.Append(insert_chunk);
 		}
-		// OnConflictHandling already verified constraints for the THROW, so we can pass "unsafe=true"
-		// we verify this in DEBUG by rechecking constraints
-#ifdef DEBUG
-		if (action_type == OnConflictAction::THROW) {
-			auto &constraint_state = lstate.GetConstraintState(data_table, table);
-			auto local_storage_ptr = LocalStorage::Get(context.client, data_table.db).GetStorage(data_table);
-			// This should not throw
-			data_table.VerifyAppendConstraints(constraint_state, context.client, insert_chunk, local_storage_ptr,
-			                                   nullptr);
-		}
-#endif
+		// When action_type is throw, we already verify constraints in `OnConflictHandling`
 		storage.LocalAppend(table, context.client, insert_chunk, bound_constraints,
 		                    action_type == OnConflictAction::THROW);
 		if (action_type == OnConflictAction::UPDATE && lstate.update_chunk.size() != 0) {

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -119,7 +119,7 @@ public:
 	                 DataChunk &delete_chunk);
 	//! Appends to the transaction-local storage of this table
 	void LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
-	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints, bool unsafe = false);
 	//! Append a chunk to the transaction-local storage of this table.
 	void LocalWALAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
 	                    const vector<unique_ptr<BoundConstraint>> &bound_constraints);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -893,10 +893,10 @@ void DataTable::LocalAppend(LocalAppendState &state, ClientContext &context, Dat
 }
 
 void DataTable::LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
-                            const vector<unique_ptr<BoundConstraint>> &bound_constraints) {
+                            const vector<unique_ptr<BoundConstraint>> &bound_constraints, bool unsafe) {
 	LocalAppendState append_state;
 	InitializeLocalAppend(append_state, table, context, bound_constraints);
-	LocalAppend(append_state, context, chunk, false);
+	LocalAppend(append_state, context, chunk, unsafe);
 	FinalizeLocalAppend(append_state);
 }
 


### PR DESCRIPTION
In the `INSERT` path, `VerifyAppendConstraints` is called twice per chunk when `action_type == OnConflictAction::THROW` (the default):

1. In `OnConflictHandling` - we verify all constraints
2. In `storage.LocalAppend` - we verify them again by passing `unsafe=false`

In this PR we pass `unsafe=true` to `LocalAppend` when `action_type == OnConflictAction::THROW`, since `OnConflictHandling` already verified all constraints. For the other `OnConflictAction`s (`NOTHING`, `UPDATE`), `unsafe=false` is preserved as before.