### PR TITLE
Exclude test with `USING KEY` for PEG Parser

### DIFF
--- a/test/configs/peg_parser_strict.json
+++ b/test/configs/peg_parser_strict.json
@@ -182,7 +182,8 @@
         "test/sql/window/test_ignore_nulls.test",
         "test/sql/function/tokenize/simple_tokenize.test",
         "test/sql/join/iejoin/test_iejoin_predicate.test",
-        "test/sql/join/test_merge_join_predicate.test"
+        "test/sql/join/test_merge_join_predicate.test",
+        "test/sql/cte/recursive_cte_key_hll_aggregation.test"
       ]
     },
     {


### PR DESCRIPTION
Exclude `test/sql/cte/recursive_cte_key_hll_aggregation.test` to fix failing CI, see: https://github.com/duckdb/duckdb/actions/runs/21898357643/job/63232542960?pr=20902#step:29:4046

I looked at it and got the PEG parser to output an identical logical query plan, but still the result was not correct. I am not sure why, but for now I'll exclude the test. A proper fix is coming later :) 