### PR TITLE
Report parquet file in invalid utf8 error

### DIFF
--- a/extension/parquet/include/reader/string_column_reader.hpp
+++ b/extension/parquet/include/reader/string_column_reader.hpp
@@ -38,7 +38,7 @@ public:
 public:
 	static bool IsValid(const char *str_data, uint32_t str_len, bool is_varchar);
 	static bool IsValid(const string &str, bool is_varchar);
-	static void VerifyString(const char *str_data, uint32_t str_len, bool is_varchar);
+	void VerifyString(const char *str_data, uint32_t str_len, bool is_varchar) const;
 	void VerifyString(const char *str_data, uint32_t str_len) const;
 
 	static void ReferenceBlock(Vector &result, shared_ptr<ResizeableBuffer> &block);

--- a/extension/parquet/reader/string_column_reader.cpp
+++ b/extension/parquet/reader/string_column_reader.cpp
@@ -31,10 +31,11 @@ bool StringColumnReader::IsValid(const char *str_data, uint32_t str_len, const b
 bool StringColumnReader::IsValid(const string &str, bool is_varchar) {
 	return IsValid(str.c_str(), str.size(), is_varchar);
 }
-void StringColumnReader::VerifyString(const char *str_data, uint32_t str_len, const bool is_varchar) {
+void StringColumnReader::VerifyString(const char *str_data, uint32_t str_len, const bool is_varchar) const {
 	if (!IsValid(str_data, str_len, is_varchar)) {
-		throw InvalidInputException("Invalid string encoding found in Parquet file: value \"%s\" is not valid UTF8!",
-		                            Blob::ToString(string_t(str_data, str_len)));
+		throw InvalidInputException(
+		    "Invalid string encoding found in Parquet file \"%s\": value \"%s\" is not valid UTF8!",
+		    reader.GetFileName(), Blob::ToString(string_t(str_data, str_len)));
 	}
 }
 

--- a/test/parquet/invalid_parquet.test
+++ b/test/parquet/invalid_parquet.test
@@ -7,7 +7,7 @@ require parquet
 statement error
 SELECT * FROM parquet_scan('{DATA_DIR}/parquet-testing/invalid.parquet') limit 50;
 ----
-Invalid Input Error: Invalid string encoding found in Parquet file: value "TREL\xC3" is not valid UTF8!
+Invalid string encoding found
 
 statement ok
 pragma disable_optimizer
@@ -15,4 +15,4 @@ pragma disable_optimizer
 statement error
 SELECT * FROM parquet_scan('{DATA_DIR}/parquet-testing/invalid.parquet') limit 50;
 ----
-Invalid Input Error: Invalid string encoding found in Parquet file: value "TREL\xC3" is not valid UTF8!
+Invalid string encoding found


### PR DESCRIPTION
Partially addresses https://github.com/duckdb/duckdb/issues/20906

Expands the invalid UTF-8 error in the Parquet reader to include the filename in which the invalid UTF-8 is encountered