### PR TITLE
Handle double quote escapes properly in PEG parser + Transformer for `SHOW TABLES`

### DIFF
--- a/extension/autocomplete/include/transformer/peg_transformer.hpp
+++ b/extension/autocomplete/include/transformer/peg_transformer.hpp
@@ -607,6 +607,8 @@ private:
 	                                                              optional_ptr<ParseResult> parse_result);
 	static unique_ptr<QueryNode> TransformShowSelect(PEGTransformer &transformer,
 	                                                 optional_ptr<ParseResult> parse_result);
+	static unique_ptr<QueryNode> TransformShowTables(PEGTransformer &transformer,
+	                                                 optional_ptr<ParseResult> parse_result);
 	static unique_ptr<QueryNode> TransformShowAllTables(PEGTransformer &transformer,
 	                                                    optional_ptr<ParseResult> parse_result);
 	static unique_ptr<QueryNode> TransformShowQualifiedName(PEGTransformer &transformer,

--- a/extension/autocomplete/matcher.cpp
+++ b/extension/autocomplete/matcher.cpp
@@ -434,9 +434,11 @@ public:
 		string result_text = token_text;
 		if (IsQuoted(result_text)) {
 			result_text = result_text.substr(1, result_text.size() - 2);
+			result_text = StringUtil::Replace(result_text, "\"\"", "\"");
 		}
 		if (IsSingleQuoted(result_text) && SupportsStringLiteral()) {
 			result_text = result_text.substr(1, result_text.size() - 2);
+			result_text = StringUtil::Replace(result_text, "''", "'");
 		}
 		return state.allocator.Allocate(make_uniq<IdentifierParseResult>(result_text));
 	}
@@ -561,10 +563,12 @@ public:
 		if (!MatchReservedIdentifier(state)) {
 			return nullptr;
 		}
-		if (IsQuoted(token_text)) {
-			token_text = token_text.substr(1, token_text.size() - 2);
+		string result_text = token_text;
+		if (IsQuoted(result_text)) {
+			result_text = result_text.substr(1, result_text.size() - 2);
+			result_text = StringUtil::Replace(result_text, "\"\"", "\"");
 		}
-		return state.allocator.Allocate(make_uniq<IdentifierParseResult>(token_text));
+		return state.allocator.Allocate(make_uniq<IdentifierParseResult>(result_text));
 	}
 
 private:
@@ -620,6 +624,7 @@ public:
 
 		string stripped_string =
 		    token.text.substr(string_info.prefix_len, token.text.length() - (string_info.prefix_len + suffix_len));
+		stripped_string = StringUtil::Replace(stripped_string, "''", "'");
 
 		auto result = state.allocator.Allocate(make_uniq<StringLiteralParseResult>(stripped_string, string_info.type));
 		result->name = name;

--- a/extension/autocomplete/tokenizer.cpp
+++ b/extension/autocomplete/tokenizer.cpp
@@ -415,7 +415,9 @@ bool BaseTokenizer::TokenizeInput() {
 			// Marker found! Revert to standard state
 			size_t full_marker_len = dollar_quote_marker.size() + 2;
 			string quoted = sql.substr(last_pos, (start + dollar_quote_marker.size() + 1) - last_pos);
-			quoted = "'" + quoted.substr(full_marker_len, quoted.size() - 2 * full_marker_len) + "'";
+			string content = quoted.substr(full_marker_len, quoted.size() - 2 * full_marker_len);
+			content = StringUtil::Replace(content, "'", "''");
+			quoted = "'" + content + "'";
 			tokens.emplace_back(quoted, full_marker_len);
 			dollar_quote_marker = string();
 			state = TokenizeState::STANDARD;

--- a/extension/autocomplete/transformer/peg_transformer_factory.cpp
+++ b/extension/autocomplete/transformer/peg_transformer_factory.cpp
@@ -329,6 +329,7 @@ void PEGTransformerFactory::RegisterDescribe() {
 	// describe.gram
 	REGISTER_TRANSFORM(TransformDescribeStatement);
 	REGISTER_TRANSFORM(TransformShowSelect);
+	REGISTER_TRANSFORM(TransformShowTables);
 	REGISTER_TRANSFORM(TransformShowAllTables);
 	REGISTER_TRANSFORM(TransformShowQualifiedName);
 	REGISTER_TRANSFORM(TransformShowOrDescribeOrSummarize);

--- a/extension/autocomplete/transformer/transform_describe.cpp
+++ b/extension/autocomplete/transformer/transform_describe.cpp
@@ -25,7 +25,7 @@ unique_ptr<QueryNode> PEGTransformerFactory::TransformShowSelect(PEGTransformer 
 }
 
 unique_ptr<QueryNode> PEGTransformerFactory::TransformShowTables(PEGTransformer &transformer,
-                                                                   optional_ptr<ParseResult> parse_result) {
+                                                                 optional_ptr<ParseResult> parse_result) {
 	auto &list_pr = parse_result->Cast<ListParseResult>();
 	auto showref = make_uniq<ShowRef>();
 	showref->show_type = ShowType::SHOW_FROM;

--- a/test/configs/peg_parser.json
+++ b/test/configs/peg_parser.json
@@ -5,34 +5,6 @@
   "statically_loaded_extensions": ["core_functions", "autocomplete"],
   "skip_tests": [
     {
-      "reason": "Quotations",
-      "paths": [
-        "test/sql/pragma/test_show_tables_from.test",
-        "test/sql/attach/attach_dbname_quotes.test",
-        "test/sql/table_function/sqlite_master_quotes.test",
-        "test/sql/keywords/escaped_quotes_expressions.test",
-        "test/sql/catalog/test_quoted_column_name.test",
-        "test/sql/json/issues/large_quoted_string_constant.test",
-        "test/sql/export/export_database.test",
-        "test/sql/cast/string_to_struct_cast.test",
-        "test/sql/export/parquet/export_parquet_enum.test",
-        "test/sql/show_select/show_quote_identifier.test",
-        "test/sql/copy/return_stats.test",
-        "test/sql/copy/csv/multidelimiter/test_abac.test",
-        "test/sql/copy/csv/pollock/test_quotation_char.test",
-        "test/sql/copy/csv/test_validator.test",
-        "test/sql/copy/csv/test_thousands_separator.test",
-        "test/sql/copy/csv/auto/test_csv_auto.test",
-        "test/sql/error/qualified_column_error.test",
-        "test/issues/general/test_3140.test",
-        "test/sql/pivot/test_pivot_duplicate_aggregates.test",
-        "test/sql/cast/string_to_list_cast.test",
-        "test/sql/cast/string_to_struct_escapes.test",
-        "test/sql/cast/string_to_struct_roundtrip.test",
-        "test/sql/catalog/function/query_function.test"
-      ]
-    },
-    {
       "reason": "Autocomplete wrong results",
       "paths": [
         "test/sql/function/autocomplete/copy.test",
@@ -50,6 +22,7 @@
         "test/sql/cast/cast_error_location.test",
         "test/sql/types/nested/array/array_invalid.test",
         "test/sql/error/lineitem_errors.test",
+        "test/sql/error/qualified_column_error.test",
         "test/sql/types/nested/struct/struct_dict.test",
         "test/sql/types/map/map_empty.test",
         "test/sql/binder/column_ref_as_alias.test",

--- a/test/configs/peg_parser_strict.json
+++ b/test/configs/peg_parser_strict.json
@@ -32,35 +32,6 @@
       "paths": ["test/sql/settings/setting_preserve_identifier_case.test"]
     },
     {
-      "reason": "Quotations",
-      "paths": [
-        "test/sql/table_function/sqlite_master_quotes.test",
-        "test/sql/keywords/escaped_quotes_expressions.test",
-        "test/sql/export/export_quoted_enum.test",
-        "test/sql/cast/string_to_struct_cast.test",
-        "test/sql/json/issues/large_quoted_string_constant.test",
-        "test/sql/attach/attach_dbname_quotes.test",
-        "test/sql/pragma/test_show_tables_from.test",
-        "test/sql/catalog/test_quoted_column_name.test",
-        "test/sql/keywords/keywords_in_expressions.test",
-        "test/sql/export/export_database.test",
-        "test/sql/export/parquet/export_parquet_enum.test",
-        "test/sql/copy/return_stats.test",
-        "test/sql/copy/csv/multidelimiter/test_abac.test",
-        "test/sql/cast/string_to_list_cast.test",
-        "test/sql/copy/csv/test_validator.test",
-        "test/sql/copy/csv/pollock/test_quotation_char.test",
-        "test/sql/copy/csv/auto/test_csv_auto.test",
-        "test/issues/general/test_3140.test",
-        "test/sql/cast/string_to_struct_roundtrip.test",
-        "test/sql/catalog/function/query_function.test",
-        "test/sql/cast/string_to_struct_escapes.test",
-        "test/sql/copy/csv/test_thousands_separator.test",
-        "test/sql/show_select/show_quote_identifier.test",
-        "test/sql/pivot/test_pivot_duplicate_aggregates.test"
-      ]
-    },
-    {
       "reason": "Parser error",
       "paths": [
         "test/sql/prepared/parameter_variants.test",


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/7303

The biggest category of skipped tests for the PEG parser was not properly handling escaped quotes. For instance `CREATE TABLE "table""name"` should lead to the table name `table"name`, since the double-quote acts as an escape. However, in the PEG parser this resulted in something like `table""""name`, escaping every double quote... This is now fixed, in the matcher we now replace `\"\"` with `\"` and the same goes for single quotes. 

By removing the tests from the skipped list I realized I forgot to implement the transformer rule for `SHOW TABLES`, which is now also implemented. 

I realize I might get some merge conflicts, since multiple of my PRs touch `peg_parser_strict.json`