### PR TITLE
feat(adbc): implement ADBC 1.1.0 typed option API and remaining canonical options

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -506,6 +506,10 @@ AdbcStatusCode ConnectionSetOption(struct AdbcConnection *connection, const char
 		SetError(error, "Connection is not set");
 		return ADBC_STATUS_INVALID_ARGUMENT;
 	}
+	if (!value) {
+		SetError(error, "Option value must not be NULL");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
 	std::string key_string = std::string(key);
 	std::string key_value = std::string(value);
 	auto conn_wrapper = static_cast<duckdb::DuckDBAdbcConnectionWrapper *>(connection->private_data);

--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -72,34 +72,34 @@ AdbcStatusCode duckdb_adbc_init(int version, void *driver, struct AdbcError *err
 		adbc_driver->ErrorGetDetail = nullptr;
 		adbc_driver->ErrorFromArrayStream = duckdb_adbc::ErrorFromArrayStream;
 
-		adbc_driver->DatabaseGetOption = nullptr;
-		adbc_driver->DatabaseGetOptionBytes = nullptr;
-		adbc_driver->DatabaseGetOptionDouble = nullptr;
-		adbc_driver->DatabaseGetOptionInt = nullptr;
-		adbc_driver->DatabaseSetOptionBytes = nullptr;
-		adbc_driver->DatabaseSetOptionInt = nullptr;
-		adbc_driver->DatabaseSetOptionDouble = nullptr;
+		adbc_driver->DatabaseGetOption = duckdb_adbc::DatabaseGetOption;
+		adbc_driver->DatabaseGetOptionBytes = duckdb_adbc::DatabaseGetOptionBytes;
+		adbc_driver->DatabaseGetOptionDouble = duckdb_adbc::DatabaseGetOptionDouble;
+		adbc_driver->DatabaseGetOptionInt = duckdb_adbc::DatabaseGetOptionInt;
+		adbc_driver->DatabaseSetOptionBytes = duckdb_adbc::DatabaseSetOptionBytes;
+		adbc_driver->DatabaseSetOptionInt = duckdb_adbc::DatabaseSetOptionInt;
+		adbc_driver->DatabaseSetOptionDouble = duckdb_adbc::DatabaseSetOptionDouble;
 
 		adbc_driver->ConnectionCancel = duckdb_adbc::ConnectionCancel;
-		adbc_driver->ConnectionGetOption = nullptr;
-		adbc_driver->ConnectionGetOptionBytes = nullptr;
-		adbc_driver->ConnectionGetOptionDouble = nullptr;
-		adbc_driver->ConnectionGetOptionInt = nullptr;
+		adbc_driver->ConnectionGetOption = duckdb_adbc::ConnectionGetOption;
+		adbc_driver->ConnectionGetOptionBytes = duckdb_adbc::ConnectionGetOptionBytes;
+		adbc_driver->ConnectionGetOptionDouble = duckdb_adbc::ConnectionGetOptionDouble;
+		adbc_driver->ConnectionGetOptionInt = duckdb_adbc::ConnectionGetOptionInt;
 		adbc_driver->ConnectionGetStatistics = nullptr;
 		adbc_driver->ConnectionGetStatisticNames = nullptr;
-		adbc_driver->ConnectionSetOptionBytes = nullptr;
-		adbc_driver->ConnectionSetOptionInt = nullptr;
-		adbc_driver->ConnectionSetOptionDouble = nullptr;
+		adbc_driver->ConnectionSetOptionBytes = duckdb_adbc::ConnectionSetOptionBytes;
+		adbc_driver->ConnectionSetOptionInt = duckdb_adbc::ConnectionSetOptionInt;
+		adbc_driver->ConnectionSetOptionDouble = duckdb_adbc::ConnectionSetOptionDouble;
 
 		adbc_driver->StatementCancel = duckdb_adbc::StatementCancel;
 		adbc_driver->StatementExecuteSchema = nullptr;
-		adbc_driver->StatementGetOption = nullptr;
-		adbc_driver->StatementGetOptionBytes = nullptr;
-		adbc_driver->StatementGetOptionDouble = nullptr;
-		adbc_driver->StatementGetOptionInt = nullptr;
-		adbc_driver->StatementSetOptionBytes = nullptr;
-		adbc_driver->StatementSetOptionDouble = nullptr;
-		adbc_driver->StatementSetOptionInt = nullptr;
+		adbc_driver->StatementGetOption = duckdb_adbc::StatementGetOption;
+		adbc_driver->StatementGetOptionBytes = duckdb_adbc::StatementGetOptionBytes;
+		adbc_driver->StatementGetOptionDouble = duckdb_adbc::StatementGetOptionDouble;
+		adbc_driver->StatementGetOptionInt = duckdb_adbc::StatementGetOptionInt;
+		adbc_driver->StatementSetOptionBytes = duckdb_adbc::StatementSetOptionBytes;
+		adbc_driver->StatementSetOptionDouble = duckdb_adbc::StatementSetOptionDouble;
+		adbc_driver->StatementSetOptionInt = duckdb_adbc::StatementSetOptionInt;
 	}
 
 	return ADBC_STATUS_OK;
@@ -172,7 +172,27 @@ struct DuckDBAdbcDatabaseWrapper {
 	//! Derived path from ADBC "uri" option (after minimal normalization)
 	std::string uri_path;
 	bool uri_set = false;
+	//! Stores config options for round-tripping via GetOption (DuckDB does not have an API to get config options)
+	std::unordered_map<std::string, std::string> config_options;
 };
+
+// Helper for the ADBC GetOption buffer convention (two-pass pattern):
+// Per the ADBC spec, callers first query the required buffer size, then fetch the value:
+//   1. Call with value=nullptr or *length=0 → *length is set to the required size (no data written).
+//   2. Call again with a sufficiently sized buffer → value is filled and *length is set.
+static AdbcStatusCode GetOptionStringHelper(const char *value_str, char *value, size_t *length,
+                                            struct AdbcError *error) {
+	if (!length) {
+		SetError(error, "Missing length pointer");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	size_t required = std::strlen(value_str) + 1; // include null terminator
+	if (*length >= required && value) {
+		std::memcpy(value, value_str, required);
+	}
+	*length = required;
+	return ADBC_STATUS_OK;
+}
 
 void InitializeADBCError(AdbcError *error) {
 	if (!error) {
@@ -270,7 +290,9 @@ AdbcStatusCode DatabaseSetOption(struct AdbcDatabase *database, const char *key,
 		return ADBC_STATUS_OK;
 	}
 	auto res = duckdb_set_config(wrapper->config, key, value);
-
+	if (res == DuckDBSuccess) {
+		wrapper->config_options[key] = value;
+	}
 	return CheckResult(res, error, "Failed to set configuration option");
 }
 
@@ -304,6 +326,86 @@ AdbcStatusCode DatabaseRelease(struct AdbcDatabase *database, struct AdbcError *
 		database->private_data = nullptr;
 	}
 	return ADBC_STATUS_OK;
+}
+
+// Database Typed Option API (ADBC 1.1.0)
+AdbcStatusCode DatabaseGetOption(struct AdbcDatabase *database, const char *key, char *value, size_t *length,
+                                 struct AdbcError *error) {
+	if (!database || !database->private_data) {
+		SetError(error, "Missing database object");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	if (!key) {
+		SetError(error, "Missing key");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto wrapper = static_cast<DuckDBAdbcDatabaseWrapper *>(database->private_data);
+	if (strcmp(key, "path") == 0) {
+		return GetOptionStringHelper(wrapper->path.c_str(), value, length, error);
+	}
+	if (strcmp(key, "uri") == 0) {
+		if (wrapper->uri_set) {
+			return GetOptionStringHelper(wrapper->uri_path.c_str(), value, length, error);
+		}
+		SetError(error, "Option not found: uri");
+		return ADBC_STATUS_NOT_FOUND;
+	}
+	auto it = wrapper->config_options.find(key);
+	if (it != wrapper->config_options.end()) {
+		return GetOptionStringHelper(it->second.c_str(), value, length, error);
+	}
+	auto error_message = std::string("Option not found: ") + key;
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode DatabaseGetOptionBytes(struct AdbcDatabase *database, const char *key, uint8_t *value, size_t *length,
+                                      struct AdbcError *error) {
+	if (!database || !database->private_data) {
+		SetError(error, "Missing database object");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto error_message = std::string("Option not found: ") + (key ? key : "(null)");
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode DatabaseGetOptionDouble(struct AdbcDatabase *database, const char *key, double *value,
+                                       struct AdbcError *error) {
+	if (!database || !database->private_data) {
+		SetError(error, "Missing database object");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto error_message = std::string("Option not found: ") + (key ? key : "(null)");
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode DatabaseGetOptionInt(struct AdbcDatabase *database, const char *key, int64_t *value,
+                                    struct AdbcError *error) {
+	if (!database || !database->private_data) {
+		SetError(error, "Missing database object");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto error_message = std::string("Option not found: ") + (key ? key : "(null)");
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode DatabaseSetOptionBytes(struct AdbcDatabase *database, const char *key, const uint8_t *value,
+                                      size_t length, struct AdbcError *error) {
+	SetError(error, "SetOptionBytes is not supported for database");
+	return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode DatabaseSetOptionInt(struct AdbcDatabase *database, const char *key, int64_t value,
+                                    struct AdbcError *error) {
+	return DatabaseSetOption(database, key, std::to_string(value).c_str(), error);
+}
+
+AdbcStatusCode DatabaseSetOptionDouble(struct AdbcDatabase *database, const char *key, double value,
+                                       struct AdbcError *error) {
+	return DatabaseSetOption(database, key, std::to_string(value).c_str(), error);
 }
 
 AdbcStatusCode ConnectionGetTableSchema(struct AdbcConnection *connection, const char *catalog, const char *db_schema,
@@ -422,6 +524,170 @@ AdbcStatusCode ConnectionSetOption(struct AdbcConnection *connection, const char
 	}
 	auto conn = reinterpret_cast<duckdb::Connection *>(conn_wrapper->connection);
 	return InternalSetOption(*conn, conn_wrapper->options, error);
+}
+
+// Connection Typed Option API (ADBC 1.1.0)
+AdbcStatusCode ConnectionGetOption(struct AdbcConnection *connection, const char *key, char *value, size_t *length,
+                                   struct AdbcError *error) {
+	if (!connection || !connection->private_data) {
+		SetError(error, "Connection is not set");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	if (!key) {
+		SetError(error, "Missing key");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto conn_wrapper = static_cast<duckdb::DuckDBAdbcConnectionWrapper *>(connection->private_data);
+	if (strcmp(key, ADBC_CONNECTION_OPTION_AUTOCOMMIT) == 0) {
+		if (conn_wrapper->connection) {
+			auto conn = reinterpret_cast<duckdb::Connection *>(conn_wrapper->connection);
+			const char *val = conn->IsAutoCommit() ? ADBC_OPTION_VALUE_ENABLED : ADBC_OPTION_VALUE_DISABLED;
+			return GetOptionStringHelper(val, value, length, error);
+		}
+		// Not yet initialized; check pending options, default is "true"
+		auto it = conn_wrapper->options.find(ADBC_CONNECTION_OPTION_AUTOCOMMIT);
+		const char *val = (it != conn_wrapper->options.end()) ? it->second.c_str() : ADBC_OPTION_VALUE_ENABLED;
+		return GetOptionStringHelper(val, value, length, error);
+	}
+	if (strcmp(key, ADBC_CONNECTION_OPTION_CURRENT_CATALOG) == 0) {
+		if (!conn_wrapper->connection) {
+			SetError(error, "Connection is not initialized");
+			return ADBC_STATUS_INVALID_STATE;
+		}
+		ArrowArrayStream stream;
+		auto status = QueryInternal(connection, &stream, "SELECT current_database()", error);
+		if (status != ADBC_STATUS_OK) {
+			return status;
+		}
+		ArrowArray batch;
+		batch.release = nullptr;
+		stream.get_next(&stream, &batch);
+		if (!batch.release || batch.length < 1 || batch.n_children < 1) {
+			if (batch.release) {
+				batch.release(&batch);
+			}
+			stream.release(&stream);
+			SetError(error, "Failed to get current catalog");
+			return ADBC_STATUS_INTERNAL;
+		}
+		// Access the first column (VARCHAR): buffers are [validity, offsets, data]
+		auto *col = batch.children[0];
+		auto offsets = static_cast<const int32_t *>(col->buffers[1]);
+		auto data = static_cast<const char *>(col->buffers[2]);
+		std::string result(data + offsets[0], static_cast<size_t>(offsets[1] - offsets[0]));
+		batch.release(&batch);
+		stream.release(&stream);
+		return GetOptionStringHelper(result.c_str(), value, length, error);
+	}
+	if (strcmp(key, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
+		if (!conn_wrapper->connection) {
+			SetError(error, "Connection is not initialized");
+			return ADBC_STATUS_INVALID_STATE;
+		}
+		ArrowArrayStream stream;
+		auto status = QueryInternal(connection, &stream, "SELECT current_schema()", error);
+		if (status != ADBC_STATUS_OK) {
+			return status;
+		}
+		ArrowArray batch;
+		batch.release = nullptr;
+		stream.get_next(&stream, &batch);
+		if (!batch.release || batch.length < 1 || batch.n_children < 1) {
+			if (batch.release) {
+				batch.release(&batch);
+			}
+			stream.release(&stream);
+			SetError(error, "Failed to get current schema");
+			return ADBC_STATUS_INTERNAL;
+		}
+		auto *col = batch.children[0];
+		auto offsets = static_cast<const int32_t *>(col->buffers[1]);
+		auto data = static_cast<const char *>(col->buffers[2]);
+		std::string result(data + offsets[0], static_cast<size_t>(offsets[1] - offsets[0]));
+		batch.release(&batch);
+		stream.release(&stream);
+		return GetOptionStringHelper(result.c_str(), value, length, error);
+	}
+	auto error_message = std::string("Option not found: ") + key;
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode ConnectionGetOptionBytes(struct AdbcConnection *connection, const char *key, uint8_t *value,
+                                        size_t *length, struct AdbcError *error) {
+	if (!connection || !connection->private_data) {
+		SetError(error, "Connection is not set");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto error_message = std::string("Option not found: ") + (key ? key : "(null)");
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode ConnectionGetOptionDouble(struct AdbcConnection *connection, const char *key, double *value,
+                                         struct AdbcError *error) {
+	if (!connection || !connection->private_data) {
+		SetError(error, "Connection is not set");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto error_message = std::string("Option not found: ") + (key ? key : "(null)");
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode ConnectionGetOptionInt(struct AdbcConnection *connection, const char *key, int64_t *value,
+                                      struct AdbcError *error) {
+	if (!connection || !connection->private_data) {
+		SetError(error, "Connection is not set");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	if (!key) {
+		SetError(error, "Missing key");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	if (strcmp(key, ADBC_CONNECTION_OPTION_AUTOCOMMIT) == 0) {
+		auto conn_wrapper = static_cast<duckdb::DuckDBAdbcConnectionWrapper *>(connection->private_data);
+		if (conn_wrapper->connection) {
+			auto conn = reinterpret_cast<duckdb::Connection *>(conn_wrapper->connection);
+			*value = conn->IsAutoCommit() ? 1 : 0;
+			return ADBC_STATUS_OK;
+		}
+		auto it = conn_wrapper->options.find(ADBC_CONNECTION_OPTION_AUTOCOMMIT);
+		if (it != conn_wrapper->options.end()) {
+			*value = (it->second == ADBC_OPTION_VALUE_ENABLED) ? 1 : 0;
+		} else {
+			*value = 1; // default is autocommit enabled
+		}
+		return ADBC_STATUS_OK;
+	}
+	auto error_message = std::string("Option not found: ") + key;
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode ConnectionSetOptionBytes(struct AdbcConnection *connection, const char *key, const uint8_t *value,
+                                        size_t length, struct AdbcError *error) {
+	SetError(error, "SetOptionBytes is not supported for connection");
+	return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode ConnectionSetOptionInt(struct AdbcConnection *connection, const char *key, int64_t value,
+                                      struct AdbcError *error) {
+	if (!key) {
+		SetError(error, "Missing key");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	if (strcmp(key, ADBC_CONNECTION_OPTION_AUTOCOMMIT) == 0) {
+		const char *str_value = value ? ADBC_OPTION_VALUE_ENABLED : ADBC_OPTION_VALUE_DISABLED;
+		return ConnectionSetOption(connection, key, str_value, error);
+	}
+	return ConnectionSetOption(connection, key, std::to_string(value).c_str(), error);
+}
+
+AdbcStatusCode ConnectionSetOptionDouble(struct AdbcConnection *connection, const char *key, double value,
+                                         struct AdbcError *error) {
+	SetError(error, "SetOptionDouble is not supported for connection");
+	return ADBC_STATUS_NOT_IMPLEMENTED;
 }
 
 AdbcStatusCode ConnectionReadPartition(struct AdbcConnection *connection, const uint8_t *serialized_partition,
@@ -1564,6 +1830,133 @@ AdbcStatusCode StatementSetOption(struct AdbcStatement *statement, const char *k
 	ss << "Statement Set Option " << key << " is not yet accepted by DuckDB";
 	SetError(error, ss.str());
 	return ADBC_STATUS_INVALID_ARGUMENT;
+}
+
+// Statement Typed Option API (ADBC 1.1.0)
+static const char *IngestionModeToString(IngestionMode mode) {
+	switch (mode) {
+	case IngestionMode::CREATE:
+		return ADBC_INGEST_OPTION_MODE_CREATE;
+	case IngestionMode::APPEND:
+		return ADBC_INGEST_OPTION_MODE_APPEND;
+	case IngestionMode::REPLACE:
+		return ADBC_INGEST_OPTION_MODE_REPLACE;
+	case IngestionMode::CREATE_APPEND:
+		return ADBC_INGEST_OPTION_MODE_CREATE_APPEND;
+	default:
+		return ADBC_INGEST_OPTION_MODE_CREATE;
+	}
+}
+
+AdbcStatusCode StatementGetOption(struct AdbcStatement *statement, const char *key, char *value, size_t *length,
+                                  struct AdbcError *error) {
+	if (!statement || !statement->private_data) {
+		SetError(error, "Invalid statement object");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	if (!key) {
+		SetError(error, "Missing key");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto wrapper = static_cast<DuckDBAdbcStatementWrapper *>(statement->private_data);
+	if (strcmp(key, ADBC_INGEST_OPTION_TARGET_TABLE) == 0) {
+		if (wrapper->ingestion_table_name) {
+			return GetOptionStringHelper(wrapper->ingestion_table_name, value, length, error);
+		}
+		SetError(error, "Option not set: " ADBC_INGEST_OPTION_TARGET_TABLE);
+		return ADBC_STATUS_NOT_FOUND;
+	}
+	if (strcmp(key, ADBC_INGEST_OPTION_TEMPORARY) == 0) {
+		const char *val = wrapper->temporary_table ? ADBC_OPTION_VALUE_ENABLED : ADBC_OPTION_VALUE_DISABLED;
+		return GetOptionStringHelper(val, value, length, error);
+	}
+	if (strcmp(key, ADBC_INGEST_OPTION_TARGET_DB_SCHEMA) == 0) {
+		if (wrapper->db_schema) {
+			return GetOptionStringHelper(wrapper->db_schema, value, length, error);
+		}
+		SetError(error, "Option not set: " ADBC_INGEST_OPTION_TARGET_DB_SCHEMA);
+		return ADBC_STATUS_NOT_FOUND;
+	}
+	if (strcmp(key, ADBC_INGEST_OPTION_TARGET_CATALOG) == 0) {
+		if (wrapper->target_catalog) {
+			return GetOptionStringHelper(wrapper->target_catalog, value, length, error);
+		}
+		SetError(error, "Option not set: " ADBC_INGEST_OPTION_TARGET_CATALOG);
+		return ADBC_STATUS_NOT_FOUND;
+	}
+	if (strcmp(key, ADBC_INGEST_OPTION_MODE) == 0) {
+		return GetOptionStringHelper(IngestionModeToString(wrapper->ingestion_mode), value, length, error);
+	}
+	auto error_message = std::string("Option not found: ") + key;
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode StatementGetOptionBytes(struct AdbcStatement *statement, const char *key, uint8_t *value, size_t *length,
+                                       struct AdbcError *error) {
+	if (!statement || !statement->private_data) {
+		SetError(error, "Invalid statement object");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto error_message = std::string("Option not found: ") + (key ? key : "(null)");
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode StatementGetOptionDouble(struct AdbcStatement *statement, const char *key, double *value,
+                                        struct AdbcError *error) {
+	if (!statement || !statement->private_data) {
+		SetError(error, "Invalid statement object");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto error_message = std::string("Option not found: ") + (key ? key : "(null)");
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode StatementGetOptionInt(struct AdbcStatement *statement, const char *key, int64_t *value,
+                                     struct AdbcError *error) {
+	if (!statement || !statement->private_data) {
+		SetError(error, "Invalid statement object");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	if (!key) {
+		SetError(error, "Missing key");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	auto wrapper = static_cast<DuckDBAdbcStatementWrapper *>(statement->private_data);
+	if (strcmp(key, ADBC_INGEST_OPTION_TEMPORARY) == 0) {
+		*value = wrapper->temporary_table ? 1 : 0;
+		return ADBC_STATUS_OK;
+	}
+	auto error_message = std::string("Option not found: ") + key;
+	SetError(error, error_message);
+	return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode StatementSetOptionBytes(struct AdbcStatement *statement, const char *key, const uint8_t *value,
+                                       size_t length, struct AdbcError *error) {
+	SetError(error, "SetOptionBytes is not supported for statement");
+	return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode StatementSetOptionInt(struct AdbcStatement *statement, const char *key, int64_t value,
+                                     struct AdbcError *error) {
+	if (!key) {
+		SetError(error, "Missing key");
+		return ADBC_STATUS_INVALID_ARGUMENT;
+	}
+	if (strcmp(key, ADBC_INGEST_OPTION_TEMPORARY) == 0) {
+		const char *str_value = value ? ADBC_OPTION_VALUE_ENABLED : ADBC_OPTION_VALUE_DISABLED;
+		return StatementSetOption(statement, key, str_value, error);
+	}
+	return StatementSetOption(statement, key, std::to_string(value).c_str(), error);
+}
+
+AdbcStatusCode StatementSetOptionDouble(struct AdbcStatement *statement, const char *key, double value,
+                                        struct AdbcError *error) {
+	SetError(error, "SetOptionDouble is not supported for statement");
+	return ADBC_STATUS_NOT_IMPLEMENTED;
 }
 
 std::string createFilter(const char *input) {

--- a/src/include/duckdb/common/adbc/adbc.hpp
+++ b/src/include/duckdb/common/adbc/adbc.hpp
@@ -131,6 +131,54 @@ AdbcStatusCode ConnectionRollback(struct AdbcConnection *connection, struct Adbc
 
 AdbcStatusCode ConnectionCancel(struct AdbcConnection *connection, struct AdbcError *error);
 
+// Database Typed Option API (ADBC 1.1.0)
+AdbcStatusCode DatabaseGetOption(struct AdbcDatabase *database, const char *key, char *value, size_t *length,
+                                 struct AdbcError *error);
+AdbcStatusCode DatabaseGetOptionBytes(struct AdbcDatabase *database, const char *key, uint8_t *value, size_t *length,
+                                      struct AdbcError *error);
+AdbcStatusCode DatabaseGetOptionDouble(struct AdbcDatabase *database, const char *key, double *value,
+                                       struct AdbcError *error);
+AdbcStatusCode DatabaseGetOptionInt(struct AdbcDatabase *database, const char *key, int64_t *value,
+                                    struct AdbcError *error);
+AdbcStatusCode DatabaseSetOptionBytes(struct AdbcDatabase *database, const char *key, const uint8_t *value,
+                                      size_t length, struct AdbcError *error);
+AdbcStatusCode DatabaseSetOptionInt(struct AdbcDatabase *database, const char *key, int64_t value,
+                                    struct AdbcError *error);
+AdbcStatusCode DatabaseSetOptionDouble(struct AdbcDatabase *database, const char *key, double value,
+                                       struct AdbcError *error);
+
+// Connection Typed Option API (ADBC 1.1.0)
+AdbcStatusCode ConnectionGetOption(struct AdbcConnection *connection, const char *key, char *value, size_t *length,
+                                   struct AdbcError *error);
+AdbcStatusCode ConnectionGetOptionBytes(struct AdbcConnection *connection, const char *key, uint8_t *value,
+                                        size_t *length, struct AdbcError *error);
+AdbcStatusCode ConnectionGetOptionDouble(struct AdbcConnection *connection, const char *key, double *value,
+                                         struct AdbcError *error);
+AdbcStatusCode ConnectionGetOptionInt(struct AdbcConnection *connection, const char *key, int64_t *value,
+                                      struct AdbcError *error);
+AdbcStatusCode ConnectionSetOptionBytes(struct AdbcConnection *connection, const char *key, const uint8_t *value,
+                                        size_t length, struct AdbcError *error);
+AdbcStatusCode ConnectionSetOptionInt(struct AdbcConnection *connection, const char *key, int64_t value,
+                                      struct AdbcError *error);
+AdbcStatusCode ConnectionSetOptionDouble(struct AdbcConnection *connection, const char *key, double value,
+                                         struct AdbcError *error);
+
+// Statement Typed Option API (ADBC 1.1.0)
+AdbcStatusCode StatementGetOption(struct AdbcStatement *statement, const char *key, char *value, size_t *length,
+                                  struct AdbcError *error);
+AdbcStatusCode StatementGetOptionBytes(struct AdbcStatement *statement, const char *key, uint8_t *value, size_t *length,
+                                       struct AdbcError *error);
+AdbcStatusCode StatementGetOptionDouble(struct AdbcStatement *statement, const char *key, double *value,
+                                        struct AdbcError *error);
+AdbcStatusCode StatementGetOptionInt(struct AdbcStatement *statement, const char *key, int64_t *value,
+                                     struct AdbcError *error);
+AdbcStatusCode StatementSetOptionBytes(struct AdbcStatement *statement, const char *key, const uint8_t *value,
+                                       size_t length, struct AdbcError *error);
+AdbcStatusCode StatementSetOptionInt(struct AdbcStatement *statement, const char *key, int64_t value,
+                                     struct AdbcError *error);
+AdbcStatusCode StatementSetOptionDouble(struct AdbcStatement *statement, const char *key, double value,
+                                        struct AdbcError *error);
+
 const AdbcError *ErrorFromArrayStream(struct ArrowArrayStream *stream, AdbcStatusCode *status);
 
 AdbcStatusCode StatementNew(struct AdbcConnection *connection, struct AdbcStatement *statement,


### PR DESCRIPTION
Add support for

- Functions to get/set options added in the ADBC ​​1.1.0 specification.
- Canonical options of ADBC ​​1.1.0 (`ADBC_OPTION_USERNAME`, `ADBC_OPTION_PASSWORD`, `ADBC_CONNECTION_OPTION_CURRENT_CATALOG`, `ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA`)

cc @lidavidm