### PR TITLE
Make try lookup entry virtual

### DIFF
--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -411,7 +411,7 @@ public:
 
 private:
 	//! Lookup an entry in the schema, returning a lookup with the entry and schema if they exist
-	CatalogEntryLookup TryLookupEntryInternal(CatalogTransaction transaction, const string &schema,
+	virtual CatalogEntryLookup TryLookupEntryInternal(CatalogTransaction transaction, const string &schema,
 	                                          const EntryLookupInfo &lookup_info);
 	//! Calls LookupEntryInternal on the schema, trying other schemas if the schema is invalid. Sets
 	//! CatalogEntryLookup->error depending on if_not_found when no entry is found

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -412,7 +412,7 @@ public:
 private:
 	//! Lookup an entry in the schema, returning a lookup with the entry and schema if they exist
 	virtual CatalogEntryLookup TryLookupEntryInternal(CatalogTransaction transaction, const string &schema,
-	                                          const EntryLookupInfo &lookup_info);
+	                                                  const EntryLookupInfo &lookup_info);
 	//! Calls LookupEntryInternal on the schema, trying other schemas if the schema is invalid. Sets
 	//! CatalogEntryLookup->error depending on if_not_found when no entry is found
 	CatalogEntryLookup TryLookupEntry(CatalogEntryRetriever &retriever, const string &schema,


### PR DESCRIPTION
This PR is makes the TryLookupEntryInternal function virtual so subclasses in extensions can override it. In the iceberg extension there is a lot of special logic around requesting the existence of schemas/tables from the catalog in order to reduce the amount of network requests. 

The Iceberg extension has managed to get around this, but the logic is spread out over the IcebergSchemaSet and the IcebergTableSet classes, which makes maintaining the "assumed schemas" cumbersome. 

Making this function virtual can help put all of this logic in one place for catalogs the communicate over REST protocols for any kind of catalog discovery operations. 
