### PR TITLE
Update odbc_scanner to fix CMake build race

### DIFF
--- a/.github/config/extensions/odbc_scanner.cmake
+++ b/.github/config/extensions/odbc_scanner.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(odbc_scanner
             DONT_LINK
             GIT_URL https://github.com/duckdb/odbc-scanner
-            GIT_TAG 52e168c1ea88298af7df1d82df2c99ba60251ef6
+            GIT_TAG 2f70a4b34c7b5aba795caa3300b208806cde24c9
             )
 endif()


### PR DESCRIPTION
The update includes only the duckdb/odbc-scanner#154 PR with the CMake fix.

Ref: duckdblabs/duckdb-internal#7433