### PR TITLE
Add opt-in for musl libc extensions build

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -27,7 +27,7 @@ jobs:
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
       run_all: ${{ inputs.run_all }}
-      opt_in_archs: 'windows_arm64;'
+      opt_in_archs: 'windows_arm64;linux_amd64_musl;linux_arm64_musl'
 
   osx:
     uses: ./.github/workflows/OSX.yml


### PR DESCRIPTION
With duckdb/extension-ci-tools#306 PR integrated it is now necessary to specify both `linux_amd64_musl` and `linux_arm64_musl` as "opt-in" for extensions build (they are now disabled by default).

Ref: duckdblabs/duckdb-internal#4616