### PR TITLE
Shredded Variant Storage: Switch "missing" and "NULL" definitions

### DIFF
--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -166,6 +166,9 @@ struct ParquetVariantShredding : public VariantShredding {
 	void WriteVariantValues(UnifiedVariantVectorData &variant, Vector &result, optional_ptr<const SelectionVector> sel,
 	                        optional_ptr<const SelectionVector> value_index_sel,
 	                        optional_ptr<const SelectionVector> result_sel, idx_t count) override;
+
+protected:
+	void WriteMissingField(Vector &vector, idx_t index) override;
 };
 
 } // namespace
@@ -727,6 +730,11 @@ static void CreateValues(UnifiedVariantVectorData &variant, Vector &value, optio
 		D_ASSERT(data_ptr_cast(value_blob.GetDataWriteable() + blob_length) == value_blob_data);
 		value_blob.SetSizeAndFinalize(blob_length, blob_length);
 	}
+}
+
+void ParquetVariantShredding::WriteMissingField(Vector &vector, idx_t index) {
+	//! The field is missing, set it to null
+	FlatVector::SetNull(vector, index, true);
 }
 
 void ParquetVariantShredding::WriteVariantValues(UnifiedVariantVectorData &variant, Vector &result,

--- a/src/common/types/variant/variant_value.cpp
+++ b/src/common/types/variant/variant_value.cpp
@@ -22,11 +22,17 @@ namespace duckdb {
 
 void VariantValue::AddChild(const string &key, VariantValue &&val) {
 	D_ASSERT(value_type == VariantValueType::OBJECT);
+	if (val.IsMissing()) {
+		throw InternalException("Adding a missing value to an object");
+	}
 	object_children.emplace(key, std::move(val));
 }
 
 void VariantValue::AddItem(VariantValue &&val) {
 	D_ASSERT(value_type == VariantValueType::ARRAY);
+	if (val.IsMissing()) {
+		throw InternalException("Adding a missing value to an array");
+	}
 	array_items.push_back(std::move(val));
 }
 
@@ -216,6 +222,8 @@ static void AnalyzeValue(const VariantValue &value, idx_t row, DataChunk &offset
 		}
 		break;
 	}
+	case VariantValueType::MISSING:
+		throw InternalException("Unexpected MISSING value in Variant AnalyzeValue");
 	default:
 		throw InternalException("VariantValueType not handled");
 	}

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -209,8 +209,8 @@ void VariantShredding::WriteTypedObjectValues(UnifiedVariantVectorData &variant,
 			idx_t child_count = 0;
 			for (idx_t i = 0; i < count; i++) {
 				if (!lookup_validity.RowIsValid(i)) {
-					//! The field is missing, set it to null
-					FlatVector::SetNull(*child_variant_vectors[0], result_sel[i], true);
+					//! The field is missing, set the untyped value index to 0
+					FlatVector::GetData<uint32_t>(*child_variant_vectors[0])[result_sel[i]] = 0;
 					if (child_variant_vectors.size() >= 2) {
 						FlatVector::SetNull(*child_variant_vectors[1], result_sel[i], true);
 					}

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -156,6 +156,10 @@ void VariantShredding::WriteTypedPrimitiveValues(UnifiedVariantVectorData &varia
 	}
 }
 
+void VariantShredding::WriteMissingField(Vector &vector, idx_t index) {
+	FlatVector::GetData<uint32_t>(vector)[index] = 0;
+}
+
 void VariantShredding::WriteTypedObjectValues(UnifiedVariantVectorData &variant, Vector &result,
                                               const SelectionVector &sel, const SelectionVector &value_index_sel,
                                               const SelectionVector &result_sel, idx_t count) {
@@ -210,7 +214,7 @@ void VariantShredding::WriteTypedObjectValues(UnifiedVariantVectorData &variant,
 			for (idx_t i = 0; i < count; i++) {
 				if (!lookup_validity.RowIsValid(i)) {
 					//! The field is missing, set the untyped value index to 0
-					FlatVector::GetData<uint32_t>(*child_variant_vectors[0])[result_sel[i]] = 0;
+					WriteMissingField(*child_variant_vectors[0], result_sel[i]);
 					if (child_variant_vectors.size() >= 2) {
 						FlatVector::SetNull(*child_variant_vectors[1], result_sel[i], true);
 					}

--- a/src/include/duckdb/function/variant/variant_shredding.hpp
+++ b/src/include/duckdb/function/variant/variant_shredding.hpp
@@ -78,6 +78,7 @@ public:
 protected:
 	void WriteTypedValues(UnifiedVariantVectorData &variant, Vector &result, const SelectionVector &sel,
 	                      const SelectionVector &value_index_sel, const SelectionVector &result_sel, idx_t count);
+	virtual void WriteMissingField(Vector &vector, idx_t index);
 
 private:
 	void WriteTypedObjectValues(UnifiedVariantVectorData &variant, Vector &result, const SelectionVector &sel,

--- a/src/storage/statistics/variant_stats.cpp
+++ b/src/storage/statistics/variant_stats.cpp
@@ -149,7 +149,7 @@ bool VariantShreddedStats::IsFullyShredded(const BaseStatistics &stats) {
 		return true;
 	}
 	if (!untyped_value_index_stats.CanHaveNoNull()) {
-		//! In the event that this field is entirely missing from the parent OBJECT, both are NULL
+		//! In the event that the untyped_value_index is entirely NULL, all values are NULL Variant values
 		//! But that doesn't mean we can't do pushdown into this field, so it is shredded (only when the extract path
 		//! ends at the parent we can't do pushdown)
 		D_ASSERT(untyped_value_index_stats.CanHaveNull());
@@ -165,7 +165,7 @@ bool VariantShreddedStats::IsFullyShredded(const BaseStatistics &stats) {
 		//! Not a constant
 		return false;
 	}
-	//! 0 is reserved for NULL Variant values
+	//! 0 is reserved for missing values (field absent from parent object)
 	return min_value == 0;
 }
 

--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -549,7 +549,7 @@ void DuckDBVariantShredding::AnalyzeVariantValues(UnifiedVariantVectorData &vari
 		if (variant.RowIsValid(row) && shredding_state.ValueIsShredded(variant, row, value_index)) {
 			shredding_state.SetShredded(row, value_index, result_index);
 			if (shredding_state.type.id() != LogicalTypeId::STRUCT) {
-				//! Value is shredded, directly write a NULL to the 'value' if the type is not an OBJECT
+				//! Value is shredded, directly write a `NULL` to the 'value' if the type is not an OBJECT
 				validity.SetInvalid(result_index);
 				continue;
 			}
@@ -569,8 +569,8 @@ void DuckDBVariantShredding::AnalyzeVariantValues(UnifiedVariantVectorData &vari
 
 		//! Deal with unshredded values
 		if (!variant.RowIsValid(row) || variant.GetTypeId(row, value_index) == VariantLogicalType::VARIANT_NULL) {
-			//! 0 is reserved for NULL
-			untyped_data[result_index] = 0;
+			//! NULL is reserved for NULL Variant values
+			validity.SetInvalid(result_index);
 		} else {
 			unshredded_values[row].emplace_back(value_index, untyped_data[result_index]);
 		}

--- a/test/sql/storage/types/variant/variant_null_missing.test
+++ b/test/sql/storage/types/variant/variant_null_missing.test
@@ -1,0 +1,97 @@
+# name: test/sql/storage/types/variant/variant_null_missing.test
+# group: [variant]
+
+load __TEST_DIR__/variant_null_missing.db
+
+# Always shred
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+# basic struct
+statement ok
+SET force_variant_shredding = 'STRUCT(a INT, b INT)';
+
+statement ok
+create table shredded_values (col VARIANT)
+
+statement ok
+insert into shredded_values values
+	({'a': 1, 'b': 100}),
+	({'a': 10, 'b': NULL}),
+	({'a': 100}),
+	({'a': NULL, 'b': NULL})
+;
+
+statement ok
+CHECKPOINT
+
+query I
+FROM shredded_values
+----
+{'a': 1, 'b': 100}
+{'a': 10, 'b': NULL}
+{'a': 100}
+{'a': NULL, 'b': NULL}
+
+# nested struct
+statement ok
+SET force_variant_shredding = 'STRUCT(id INT, s STRUCT(a INT, b INT))';
+
+statement ok
+create table nested_shredded_values (col VARIANT)
+
+
+statement ok
+insert into nested_shredded_values values
+ 	({'id': 1, 's': {'a': 1, 'b': 100}}),
+	({'id': 2, 's': {'a': 10, 'b': NULL}}),
+ 	({'id': 3, 's': {'a': 100}}),
+ 	({'id': 4, 's': {'a': NULL, 'b': NULL}}),
+ 	({'id': 5, 's': NULL}),
+ 	({'id': 6})
+;
+
+statement ok
+CHECKPOINT
+
+query I
+FROM nested_shredded_values
+----
+{'id': 1, 's': {'a': 1, 'b': 100}}
+{'id': 2, 's': {'a': 10, 'b': NULL}}
+{'id': 3, 's': {'a': 100}}
+{'id': 4, 's': {'a': NULL, 'b': NULL}}
+{'id': 5, 's': NULL}
+{'id': 6}
+
+# arrays
+statement ok
+SET force_variant_shredding = 'STRUCT(a INT, b INT)[]';
+
+statement ok
+create table shredded_array (col VARIANT)
+
+statement ok
+insert into shredded_array values
+	([{'a': 1, 'b': 100}]),
+	([{'a': 10, 'b': NULL}]),
+	([{'a': 100}]),
+	([{'a': NULL, 'b': NULL}]),
+	([]),
+	([NULL]),
+	(NULL)
+;
+
+statement ok
+CHECKPOINT
+
+query I
+FROM shredded_array
+----
+[{'a': 1, 'b': 100}]
+[{'a': 10, 'b': NULL}]
+[{'a': 100}]
+[{'a': NULL, 'b': NULL}]
+[]
+[NULL]
+NULL


### PR DESCRIPTION
Currently variant types have the following semantics with regards to partial shredding:

| untyped_value_index | typed_value | meaning | 
| ----- | ----- | ----- |
| NULL | NULL | value is missing |
| 0 | NULL | value is NULL |
| NULL | non-NULL | value is shredded | 
| >= 1 | NULL | value is not shredded, unshredded value is stored in `unshredded` at index `untyped_value_index - 1` |

The issue with these semantics is that a column that is fully consistent and fully shredded must have a non-NULL value in the `untyped_value_index` column if it has any `NULL` values within it. This is sub-optimal especially for execution on shredded values as this means we need to read this column even for fully consistent and fully shredded variant values.

This PR switches the definitions between `missing` and `NULL` around, so that we now have the following definitions:

| untyped_value_index | typed_value | meaning | 
| ----- | ----- | ----- |
| NULL | NULL | value is NULL |
| NULL | non-NULL | value is shredded | 
| 0 | NULL | value is missing |
| >= 1 | NULL | value is not shredded, unshredded value is stored in `unshredded` at index `untyped_value_index - 1` |

This means that as long as a column is fully shredded and present, `untyped_value_index` is always a constant `NULL` value.
