### PR TITLE
Fix topn window elimination crash on ORDER BY expression (#20928)

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -823,11 +823,11 @@ bool TopNWindowElimination::CanUseLateMaterialization(const LogicalWindow &windo
 					return false;
 				}
 				ColumnBinding left_binding;
-				if (!extract_single_binding(&condition.LeftReference(), left_binding)) {
+				if (!extract_single_binding(&condition.left, left_binding)) {
 					return false;
 				}
 				ColumnBinding right_binding;
-				if (!extract_single_binding(&condition.RightReference(), right_binding)) {
+				if (!extract_single_binding(&condition.right, right_binding)) {
 					return false;
 				}
 

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -625,6 +625,10 @@ vector<unique_ptr<Expression>> TopNWindowElimination::GenerateAggregatePayload(c
 	if (aggregate_args.size() == 1) {
 		// If we only project the aggregate value itself, we do not need it as an arg
 		VisitExpression(&window_expr.orders[0].expression);
+		if (column_references.size() != 1) {
+			column_references.clear();
+			return aggregate_args;
+		}
 		const auto aggregate_value_binding = column_references.begin()->first;
 		column_references.clear();
 

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -911,7 +911,11 @@ bool TopNWindowElimination::CanUseLateMaterialization(const LogicalWindow &windo
 	}
 	stack.push_back(op);
 
-	D_ASSERT(op.get().type == LogicalOperatorType::LOGICAL_GET);
+	if (op.get().type != LogicalOperatorType::LOGICAL_GET) {
+		// Alternative verification can produce leaf operators without children that are not logical gets.
+		// In that case, late materialization is not applicable and we should gracefully fall back.
+		return false;
+	}
 	auto &logical_get = op.get().Cast<LogicalGet>();
 	if (!logical_get.function.late_materialization || !logical_get.function.get_row_id_columns) {
 		return false;

--- a/test/optimizer/issue_20928.test
+++ b/test/optimizer/issue_20928.test
@@ -10,3 +10,82 @@ SELECT id, val
 FROM t
 QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY val IS NOT NULL) = 1
 ----
+
+statement ok
+CREATE TABLE t_constant (id VARCHAR, name VARCHAR, a INTEGER, b INTEGER)
+
+statement ok
+INSERT INTO t_constant VALUES
+	('x', 'n1', 1, 2),
+	('x', 'n2', 3, 4)
+
+query TTI
+WITH
+cte1 AS (
+	SELECT id, name, CEIL(1 / 2) AS score
+	FROM t_constant
+),
+cte2 AS (
+	SELECT id, name, score
+	FROM cte1
+	QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY score DESC) <= 10
+)
+SELECT id, name, CAST(score AS INTEGER)
+FROM cte2
+ORDER BY name
+----
+x	n1	1
+x	n2	1
+
+statement ok
+CREATE TABLE t_multi_ref (id VARCHAR, name VARCHAR, a INTEGER, b INTEGER)
+
+statement ok
+INSERT INTO t_multi_ref VALUES
+	('x', 'n1', 1, 10),
+	('x', 'n2', 9, 0),
+	('y', 'm1', 2, 2),
+	('y', 'm2', 1, 9)
+
+query I
+WITH
+cte1 AS (
+	SELECT id, name, (a + b) AS score
+	FROM t_multi_ref
+),
+cte2 AS (
+	SELECT id, name, score
+	FROM cte1
+	QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY score DESC) <= 1
+)
+SELECT sum(score) FROM cte2
+----
+21
+
+statement ok
+CREATE TABLE t_div (id VARCHAR, name VARCHAR, a INTEGER, b INTEGER)
+
+statement ok
+INSERT INTO t_div VALUES
+	('x', 'n1', 1, 3),
+	('x', 'n2', 5, 2),
+	('y', 'm1', 2, 2),
+	('y', 'm2', 7, 3)
+
+query TTI
+WITH
+cte1 AS (
+	SELECT id, name, CEIL(a / b) AS score
+	FROM t_div
+),
+cte2 AS (
+	SELECT id, name, score
+	FROM cte1
+	QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY score DESC) <= 1
+)
+SELECT id, name, CAST(score AS INTEGER)
+FROM cte2
+ORDER BY id
+----
+x	n2	3
+y	m2	3

--- a/test/optimizer/issue_20928.test
+++ b/test/optimizer/issue_20928.test
@@ -1,0 +1,12 @@
+# name: test/optimizer/issue_20928.test
+# description: TopN window elimination should not crash with ORDER BY expression wrapping the payload column
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t (id VARCHAR, val VARCHAR)
+
+query TT
+SELECT id, val
+FROM t
+QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY val IS NOT NULL) = 1
+----


### PR DESCRIPTION
## Summary

This PR fixes a segmentation fault in `top_n_window_elimination` for a `ROW_NUMBER ... QUALIFY` pattern where the `ORDER BY` clause is an expression (not a plain column reference), as reported in [#20928](https://github.com/duckdb/duckdb/issues/20928) and #20941 .

## Reproduction

```sql
CREATE TABLE t (id VARCHAR, val VARCHAR);
SELECT id, val
FROM t
QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY val IS NOT NULL) = 1;
```
Before this change, the query could crash in optimizer.
After this change, it returns successfully (0 rows for the example above).

**Root Cause**
In TopNWindowElimination::GenerateAggregatePayload, when aggregate_args.size() == 1, the code assumed that visiting window_expr.orders[0].expression always yields exactly one column_references entry, and unconditionally dereferenced column_references.begin().

For expressions like val IS NOT NULL (and optimizer-rewritten variants), this assumption does not always hold, which can leave column_references empty and cause invalid dereference.

**Fix**
Added a guard before dereferencing column_references:

If column_references.size() != 1, clear it and return aggregate_args (skip only this micro-optimization path).
Keep existing behavior for the valid single-column-reference case.

Tests

issue_20928.test

make allunit