### PR TITLE
Restore previous behavior for `rows_scanned` profiler output when no exact count is available

### DIFF
--- a/test/sql/pragma/profiling/test_custom_profiling_rows_scanned_parquet.test
+++ b/test/sql/pragma/profiling/test_custom_profiling_rows_scanned_parquet.test
@@ -1,0 +1,44 @@
+# name: test/sql/pragma/profiling/test_custom_profiling_rows_scanned_parquet.test
+# group: [profiling]
+
+require json
+
+require parquet
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+COPY (SELECT * FROM range(0, 10) as r(i)) TO '__TEST_DIR__/range.parquet' (FORMAT 'parquet');
+
+statement ok
+COPY (SELECT * FROM range(0, 10) as r(i)) TO '__TEST_DIR__/range2.parquet' (FORMAT 'parquet');
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '__TEST_DIR__/profiling_output.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"OPERATOR_CARDINALITY": "true", "OPERATOR_ROWS_SCANNED": "true", "CUMULATIVE_CARDINALITY": "true", "CUMULATIVE_ROWS_SCANNED": "true"}';
+
+statement ok
+SELECT * FROM '__TEST_DIR__/range.parquet' order by all;
+
+statement ok
+pragma disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '__TEST_DIR__/profiling_output.json';
+
+statement ok
+SELECT cumulative_cardinality, cumulative_rows_scanned FROM metrics_output;
+
+query I
+SELECT
+	CASE WHEN cumulative_rows_scanned = 10 THEN 'true'
+	ELSE 'false' END
+FROM metrics_output;
+----
+true


### PR DESCRIPTION
In https://github.com/duckdb/duckdb/pull/20161 a callback was added for table functions to emit the exact number of rows scanned as part of the profiling output, but the old behavior of simply returning the estimated table cardinality * number of threads was removed. This PR restores the old behavior in the case when this callback is missing.

The callback for getting the exact count for e.g. parquet should still be implemented in the future though.

Fixes an issue found internally.