### PR TITLE
[Optimizer] Fix problem with struct extract pushdown

### DIFF
--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -77,6 +77,7 @@ void RemoveUnusedColumns::ClearUnusedExpressions(vector<T> &list, idx_t table_id
 		}
 		if (!entry->second.child_columns.empty() &&
 		    entry->second.supports_pushdown_extract == PushdownExtractSupport::ENABLED) {
+			//! One or more children of this column are referenced, and pushdown-extract is enabled
 			should_replace = true;
 		}
 		if (should_replace) {
@@ -476,7 +477,9 @@ void RemoveUnusedColumns::RewriteExpressions(LogicalProjection &proj, idx_t expr
 				    auto cast = BoundCastExpression::AddCastToType(context, std::move(new_extract), *cast_type);
 				    new_extract = std::move(cast);
 			    }
-			    auto it = new_bindings.emplace(extract_path, expressions.size()).first;
+			    ColumnIndex full_path(i);
+			    full_path.AddChildIndex(extract_path);
+			    auto it = new_bindings.emplace(full_path, expressions.size()).first;
 			    if (it->second == expressions.size()) {
 				    expressions.push_back(std::move(new_extract));
 			    }

--- a/test/sql/types/struct/struct_projection_pushdown_optimizer_bug.test
+++ b/test/sql/types/struct/struct_projection_pushdown_optimizer_bug.test
@@ -1,0 +1,32 @@
+# name: test/sql/types/struct/struct_projection_pushdown_optimizer_bug.test
+# group: [struct]
+
+statement ok
+CREATE TABLE tbl(
+	-- 0
+	s1 STRUCT(
+		i SMALLINT
+	),
+	-- 1
+	s2 STRUCT(
+		f DATE
+	),
+	-- 2
+	id INT
+);
+
+statement ok
+INSERT INTO tbl VALUES
+	(ROW(1), ROW(DATE '2024-01-30'), 0);
+
+query III
+WITH subq AS
+  (FROM tbl) -- project 0,1,2
+SELECT 
+       id, -- 2
+       min(subq.s1.i), -- 0.0
+       min(subq.s2.f) -- 1.0
+FROM subq
+GROUP BY id;
+----
+0	1	2024-01-30


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/7399

Problem was that the paths `0.0` and `1.0` were treated as identical, because the first index (the column index) wasn't added to the path.