### PR TITLE
Re-enable Wasm builds for iceberg for v1.5-variegata

### DIFF
--- a/.github/config/extensions/iceberg.cmake
+++ b/.github/config/extensions/iceberg.cmake
@@ -4,7 +4,7 @@ IF (NOT WIN32)
 else ()
     set(LOAD_ICEBERG_TESTS "")
 endif()
-if (NOT MINGW AND NOT ${WASM_ENABLED})
+if (NOT MINGW)
     duckdb_extension_load(iceberg
 	    #FIXME: restore autoloading tests ${LOAD_ICEBERG_TESTS}
             GIT_URL https://github.com/duckdb/duckdb-iceberg


### PR DESCRIPTION
Commit should have been lost in merge somewhere, v1.4-andium has this enabled.

CI wise test if passes, then great.