### PR TITLE
Swap typed / untyped value position in struct for our own variant storage and for variant stats

### DIFF
--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -163,6 +163,12 @@ private:
 };
 
 struct ParquetVariantShredding : public VariantShredding {
+	ParquetVariantShredding() {
+		// for parquet untyped ("value") comes before typed ("typed_value")
+		untyped_value_index = 0;
+		typed_value_index = 1;
+	}
+
 	void WriteVariantValues(UnifiedVariantVectorData &variant, Vector &result, optional_ptr<const SelectionVector> sel,
 	                        optional_ptr<const SelectionVector> value_index_sel,
 	                        optional_ptr<const SelectionVector> result_sel, idx_t count) override;

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -214,9 +214,9 @@ void VariantShredding::WriteTypedObjectValues(UnifiedVariantVectorData &variant,
 			for (idx_t i = 0; i < count; i++) {
 				if (!lookup_validity.RowIsValid(i)) {
 					//! The field is missing, set the untyped value index to 0
-					WriteMissingField(*child_variant_vectors[0], result_sel[i]);
+					WriteMissingField(*child_variant_vectors[untyped_value_index], result_sel[i]);
 					if (child_variant_vectors.size() >= 2) {
-						FlatVector::SetNull(*child_variant_vectors[1], result_sel[i], true);
+						FlatVector::SetNull(*child_variant_vectors[typed_value_index], result_sel[i], true);
 					}
 					continue;
 				}

--- a/src/include/duckdb/function/variant/variant_shredding.hpp
+++ b/src/include/duckdb/function/variant/variant_shredding.hpp
@@ -76,6 +76,10 @@ public:
 	                                optional_ptr<const SelectionVector> result_sel, idx_t count) = 0;
 
 protected:
+	idx_t typed_value_index = VariantStats::TYPED_VALUE_INDEX;
+	idx_t untyped_value_index = VariantStats::UNTYPED_VALUE_INDEX;
+
+protected:
 	void WriteTypedValues(UnifiedVariantVectorData &variant, Vector &result, const SelectionVector &sel,
 	                      const SelectionVector &value_index_sel, const SelectionVector &result_sel, idx_t count);
 	virtual void WriteMissingField(Vector &vector, idx_t index);

--- a/src/include/duckdb/storage/statistics/variant_stats.hpp
+++ b/src/include/duckdb/storage/statistics/variant_stats.hpp
@@ -36,6 +36,10 @@ public:
 //! would store any other column).
 struct VariantStats {
 public:
+	static constexpr idx_t TYPED_VALUE_INDEX = 0;
+	static constexpr idx_t UNTYPED_VALUE_INDEX = 1;
+
+public:
 	DUCKDB_API static void Construct(BaseStatistics &stats);
 
 public:

--- a/src/include/duckdb/storage/table/variant_column_data.hpp
+++ b/src/include/duckdb/storage/table/variant_column_data.hpp
@@ -23,6 +23,10 @@ public:
 	vector<shared_ptr<ColumnData>> sub_columns;
 	shared_ptr<ValidityColumnData> validity;
 
+	//! Indices into the inner shredded struct: STRUCT(typed_value <type>, untyped_value_index UINTEGER)
+	static constexpr idx_t TYPED_VALUE_INDEX = 0;
+	static constexpr idx_t UNTYPED_VALUE_INDEX = 1;
+
 public:
 	idx_t GetMaxEntry() override;
 	bool IsShredded() const {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -810,7 +810,7 @@ void ForceVariantShredding::SetGlobal(DatabaseInstance *_, DBConfig &config, con
 	});
 
 	auto shredding_type = TypeVisitor::VisitReplace(logical_type, [](const LogicalType &type) {
-		return LogicalType::STRUCT({{"untyped_value_index", LogicalType::UINTEGER}, {"typed_value", type}});
+		return LogicalType::STRUCT({{"typed_value", type}, {"untyped_value_index", LogicalType::UINTEGER}});
 	});
 	force_variant_shredding =
 	    LogicalType::STRUCT({{"unshredded", VariantShredding::GetUnshreddedType()}, {"shredded", shredding_type}});

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -164,7 +164,7 @@ static unique_ptr<BaseStatistics> StatisticsPropagateVariant(const BaseStatistic
 		return nullptr;
 	}
 	// extract the typed stats
-	auto &typed_stats = StructStats::GetChildStats(shredded_stats, 1);
+	auto &typed_stats = StructStats::GetChildStats(shredded_stats, VariantStats::TYPED_VALUE_INDEX);
 	if (structured_type == target) {
 		// type matches - return stats directly
 		return typed_stats.ToUnique();

--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -369,8 +369,8 @@ static LogicalType ProduceShreddedType(VariantLogicalType type_id) {
 
 static LogicalType SetShreddedType(const LogicalType &typed_value) {
 	child_list_t<LogicalType> child_types;
-	child_types.emplace_back("untyped_value_index", LogicalType::UINTEGER);
 	child_types.emplace_back("typed_value", typed_value);
+	child_types.emplace_back("untyped_value_index", LogicalType::UINTEGER);
 	return LogicalType::STRUCT(child_types);
 }
 
@@ -577,7 +577,7 @@ void DuckDBVariantShredding::AnalyzeVariantValues(UnifiedVariantVectorData &vari
 	}
 }
 
-//! Receive a 'shredded' result Vector, consisting of the 'untyped_value_index' and the 'typed_value' Vector
+//! Receive a 'shredded' result Vector, consisting of the 'typed_value' and the 'untyped_value_index' Vector
 void DuckDBVariantShredding::WriteVariantValues(UnifiedVariantVectorData &variant, Vector &result,
                                                 optional_ptr<const SelectionVector> sel,
                                                 optional_ptr<const SelectionVector> value_index_sel,
@@ -590,8 +590,8 @@ void DuckDBVariantShredding::WriteVariantValues(UnifiedVariantVectorData &varian
 	D_ASSERT(child_types.size() == child_vectors.size());
 #endif
 
-	auto &untyped_value_index = *child_vectors[0];
-	auto &typed_value = *child_vectors[1];
+	auto &typed_value = *child_vectors[VariantColumnData::TYPED_VALUE_INDEX];
+	auto &untyped_value_index = *child_vectors[VariantColumnData::UNTYPED_VALUE_INDEX];
 
 	DuckDBVariantShreddingState shredding_state(typed_value.GetType(), count);
 	AnalyzeVariantValues(variant, untyped_value_index, sel, value_index_sel, result_sel, shredding_state, count);

--- a/src/storage/table/variant/variant_unshredding.cpp
+++ b/src/storage/table/variant/variant_unshredding.cpp
@@ -185,8 +185,8 @@ static vector<VariantValue> Unshred(UnifiedVariantVectorData &variant, Vector &s
 	auto &child_entries = StructVector::GetEntries(shredded);
 	D_ASSERT(child_entries.size() == 2);
 
-	auto &untyped_value_index = *child_entries[0];
-	auto &typed_value = *child_entries[1];
+	auto &typed_value = *child_entries[VariantColumnData::TYPED_VALUE_INDEX];
+	auto &untyped_value_index = *child_entries[VariantColumnData::UNTYPED_VALUE_INDEX];
 
 	UnifiedVectorFormat untyped_format;
 	untyped_value_index.ToUnifiedFormat(count, untyped_format);


### PR DESCRIPTION
Currently shredded variants are stored such that `untyped_value_index` is the first entry in the struct, and `typed_value` the second. For example, when shredding on `STRUCT(a DATE)` - we get the following layout:

```sql
shredded STRUCT(
	untyped_value_index UINTEGER,
	typed_value STRUCT(
		a STRUCT(
			untyped_value_index UINTEGER,
			typed_value DATE
		)
	)
)
```

This PR flips these struct entries so that we instead get:

```sql
shredded STRUCT(
	typed_value STRUCT(
		a STRUCT(
			typed_value DATE,
			untyped_value_index UINTEGER
		)
	),
	untyped_value_index UINTEGER
)
```

This in-and-of-itself doesn't change much, but the idea is that we can choose to omit the `untyped_value_index` field much more easily in this layout in case we don't need it. If we don't flip then `typed_value` will be in the second position if `untyped_value_index` is present, and in the first position otherwise. By flipping we ensure `typed_value` is always in the first position.