### PR TITLE
[v1.5-variegata] Bump httpfs further

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG d9e658526ee902d437cbf3c0fc03d47ba8ae5012
+    GIT_TAG c50f88437b3b6c81127108193bb97bc0123ff792
 )

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1101,6 +1101,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"s3_url_compatibility_mode", "httpfs"},
     {"s3_url_style", "httpfs"},
     {"s3_use_ssl", "httpfs"},
+    {"s3_version_id_pinning", "httpfs"},
     {"sqlite_all_varchar", "sqlite_scanner"},
     {"sqlite_debug_show_queries", "sqlite_scanner"},
     {"timezone", "icu"},


### PR DESCRIPTION
Fixes a bug reported by @Tmonster on CURL connection reuse and introduce handling for querying version-enabled S3 buckets while writes are performed out of band.