### PR TITLE
Make untyped value vector optional in shredded variants, and allow primitive types to be inlined

### DIFF
--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -163,6 +163,12 @@ private:
 };
 
 struct ParquetVariantShredding : public VariantShredding {
+	ParquetVariantShredding() {
+		// for parquet untyped ("value") comes before typed ("typed_value")
+		untyped_value_index = 0;
+		typed_value_index = 1;
+	}
+
 	void WriteVariantValues(UnifiedVariantVectorData &variant, Vector &result, optional_ptr<const SelectionVector> sel,
 	                        optional_ptr<const SelectionVector> value_index_sel,
 	                        optional_ptr<const SelectionVector> result_sel, idx_t count) override;

--- a/src/function/cast/variant/from_variant.cpp
+++ b/src/function/cast/variant/from_variant.cpp
@@ -74,7 +74,9 @@ struct VariantBooleanConversion {
 	static bool Convert(const VariantLogicalType type_id, uint32_t byte_offset, const_data_ptr_t value, bool &ret,
 	                    const EmptyConversionPayloadFromVariant &payload, string &error) {
 		if (type_id != VariantLogicalType::BOOL_FALSE && type_id != VariantLogicalType::BOOL_TRUE) {
-			error = StringUtil::Format("Can't convert from VARIANT(%s)", EnumUtil::ToString(type_id));
+			if (error.empty()) {
+				error = StringUtil::Format("Can't convert from VARIANT(%s)", EnumUtil::ToString(type_id));
+			}
 			return false;
 		}
 		ret = type_id == VariantLogicalType::BOOL_TRUE;
@@ -89,7 +91,9 @@ struct VariantDirectConversion {
 	static bool Convert(const VariantLogicalType type_id, uint32_t byte_offset, const_data_ptr_t value, T &ret,
 	                    const EmptyConversionPayloadFromVariant &payload, string &error) {
 		if (type_id != TYPE_ID) {
-			error = StringUtil::Format("Can't convert from VARIANT(%s)", EnumUtil::ToString(type_id));
+			if (error.empty()) {
+				error = StringUtil::Format("Can't convert from VARIANT(%s)", EnumUtil::ToString(type_id));
+			}
 			return false;
 		}
 		ret = Load<T>(value + byte_offset);
@@ -99,7 +103,9 @@ struct VariantDirectConversion {
 	static bool Convert(const VariantLogicalType type_id, uint32_t byte_offset, const_data_ptr_t value, T &ret,
 	                    const StringConversionPayload &payload, string &error) {
 		if (type_id != TYPE_ID) {
-			error = StringUtil::Format("Can't convert from VARIANT(%s)", EnumUtil::ToString(type_id));
+			if (error.empty()) {
+				error = StringUtil::Format("Can't convert from VARIANT(%s)", EnumUtil::ToString(type_id));
+			}
 			return false;
 		}
 		auto ptr = value + byte_offset;
@@ -117,7 +123,9 @@ struct VariantDecimalConversion {
 	static bool Convert(const VariantLogicalType type_id, uint32_t byte_offset, const_data_ptr_t value, T &ret,
 	                    const DecimalConversionPayloadFromVariant &payload, string &error) {
 		if (type_id != TYPE_ID) {
-			error = StringUtil::Format("Can't convert from VARIANT(%s)", EnumUtil::ToString(type_id));
+			if (error.empty()) {
+				error = StringUtil::Format("Can't convert from VARIANT(%s)", EnumUtil::ToString(type_id));
+			}
 			return false;
 		}
 		auto ptr = value + byte_offset;

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -214,9 +214,9 @@ void VariantShredding::WriteTypedObjectValues(UnifiedVariantVectorData &variant,
 			for (idx_t i = 0; i < count; i++) {
 				if (!lookup_validity.RowIsValid(i)) {
 					//! The field is missing, set the untyped value index to 0
-					WriteMissingField(*child_variant_vectors[0], result_sel[i]);
+					WriteMissingField(*child_variant_vectors[untyped_value_index], result_sel[i]);
 					if (child_variant_vectors.size() >= 2) {
-						FlatVector::SetNull(*child_variant_vectors[1], result_sel[i], true);
+						FlatVector::SetNull(*child_variant_vectors[typed_value_index], result_sel[i], true);
 					}
 					continue;
 				}

--- a/src/include/duckdb/function/variant/variant_shredding.hpp
+++ b/src/include/duckdb/function/variant/variant_shredding.hpp
@@ -76,6 +76,10 @@ public:
 	                                optional_ptr<const SelectionVector> result_sel, idx_t count) = 0;
 
 protected:
+	idx_t typed_value_index = VariantStats::TYPED_VALUE_INDEX;
+	idx_t untyped_value_index = VariantStats::UNTYPED_VALUE_INDEX;
+
+protected:
 	void WriteTypedValues(UnifiedVariantVectorData &variant, Vector &result, const SelectionVector &sel,
 	                      const SelectionVector &value_index_sel, const SelectionVector &result_sel, idx_t count);
 	virtual void WriteMissingField(Vector &vector, idx_t index);

--- a/src/include/duckdb/storage/statistics/variant_stats.hpp
+++ b/src/include/duckdb/storage/statistics/variant_stats.hpp
@@ -36,6 +36,10 @@ public:
 //! would store any other column).
 struct VariantStats {
 public:
+	static constexpr idx_t TYPED_VALUE_INDEX = 0;
+	static constexpr idx_t UNTYPED_VALUE_INDEX = 1;
+
+public:
 	DUCKDB_API static void Construct(BaseStatistics &stats);
 
 public:

--- a/src/include/duckdb/storage/statistics/variant_stats.hpp
+++ b/src/include/duckdb/storage/statistics/variant_stats.hpp
@@ -54,6 +54,14 @@ public:
 	DUCKDB_API static const BaseStatistics &GetUnshreddedStats(const BaseStatistics &stats);
 	DUCKDB_API static BaseStatistics &GetUnshreddedStats(BaseStatistics &stats);
 
+	//! Returns the typed_value stats of a shredded stats entry
+	DUCKDB_API static const BaseStatistics &GetTypedStats(const BaseStatistics &stats);
+	DUCKDB_API static const BaseStatistics &GetTypedStats(const BaseStatistics &&stats) = delete;
+
+	//! Returns the untyped_value_index stats of a shredded stats entry - if there is any
+	DUCKDB_API static optional_ptr<const BaseStatistics> GetUntypedStats(const BaseStatistics &stats);
+	DUCKDB_API static optional_ptr<const BaseStatistics> GetUntypedStats(const BaseStatistics &&stats) = delete;
+
 	DUCKDB_API static void SetUnshreddedStats(BaseStatistics &stats, unique_ptr<BaseStatistics> new_stats);
 	DUCKDB_API static void SetUnshreddedStats(BaseStatistics &stats, const BaseStatistics &new_stats);
 	DUCKDB_API static void MarkAsNotShredded(BaseStatistics &stats);
@@ -70,7 +78,7 @@ public:
 	DUCKDB_API static void SetShreddedStats(BaseStatistics &stats, unique_ptr<BaseStatistics> new_stats);
 	DUCKDB_API static void SetShreddedStats(BaseStatistics &stats, const BaseStatistics &new_stats);
 
-	DUCKDB_API static bool MergeShredding(BaseStatistics &stats, const BaseStatistics &other,
+	DUCKDB_API static bool MergeShredding(const BaseStatistics &stats, const BaseStatistics &other,
 	                                      BaseStatistics &new_stats);
 	DUCKDB_API static unique_ptr<BaseStatistics> WrapExtractedFieldAsVariant(const BaseStatistics &base_variant,
 	                                                                         const BaseStatistics &extracted_field);

--- a/src/include/duckdb/storage/table/variant_column_data.hpp
+++ b/src/include/duckdb/storage/table/variant_column_data.hpp
@@ -16,16 +16,17 @@ namespace duckdb {
 //! Struct column data represents a struct
 class VariantColumnData : public ColumnData {
 public:
+	//! Indices into the inner shredded struct: STRUCT(typed_value <type>, untyped_value_index UINTEGER)
+	static constexpr idx_t TYPED_VALUE_INDEX = 0;
+	static constexpr idx_t UNTYPED_VALUE_INDEX = 1;
+
+public:
 	VariantColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, LogicalType type,
 	                  ColumnDataType data_type, optional_ptr<ColumnData> parent);
 
 	//! The sub-columns of the struct
 	vector<shared_ptr<ColumnData>> sub_columns;
 	shared_ptr<ValidityColumnData> validity;
-
-	//! Indices into the inner shredded struct: STRUCT(typed_value <type>, untyped_value_index UINTEGER)
-	static constexpr idx_t TYPED_VALUE_INDEX = 0;
-	static constexpr idx_t UNTYPED_VALUE_INDEX = 1;
 
 public:
 	idx_t GetMaxEntry() override;

--- a/src/include/duckdb/storage/table/variant_column_data.hpp
+++ b/src/include/duckdb/storage/table/variant_column_data.hpp
@@ -23,6 +23,10 @@ public:
 	vector<shared_ptr<ColumnData>> sub_columns;
 	shared_ptr<ValidityColumnData> validity;
 
+	//! Indices into the inner shredded struct: STRUCT(typed_value <type>, untyped_value_index UINTEGER)
+	static constexpr idx_t TYPED_VALUE_INDEX = 0;
+	static constexpr idx_t UNTYPED_VALUE_INDEX = 1;
+
 public:
 	idx_t GetMaxEntry() override;
 	bool IsShredded() const {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -810,7 +810,7 @@ void ForceVariantShredding::SetGlobal(DatabaseInstance *_, DBConfig &config, con
 	});
 
 	auto shredding_type = TypeVisitor::VisitReplace(logical_type, [](const LogicalType &type) {
-		return LogicalType::STRUCT({{"untyped_value_index", LogicalType::UINTEGER}, {"typed_value", type}});
+		return LogicalType::STRUCT({{"typed_value", type}, {"untyped_value_index", LogicalType::UINTEGER}});
 	});
 	force_variant_shredding =
 	    LogicalType::STRUCT({{"unshredded", VariantShredding::GetUnshreddedType()}, {"shredded", shredding_type}});

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -164,7 +164,7 @@ static unique_ptr<BaseStatistics> StatisticsPropagateVariant(const BaseStatistic
 		return nullptr;
 	}
 	// extract the typed stats
-	auto &typed_stats = StructStats::GetChildStats(shredded_stats, 1);
+	auto &typed_stats = StructStats::GetChildStats(shredded_stats, VariantStats::TYPED_VALUE_INDEX);
 	if (structured_type == target) {
 		// type matches - return stats directly
 		return typed_stats.ToUnique();

--- a/src/optimizer/statistics/expression/propagate_cast.cpp
+++ b/src/optimizer/statistics/expression/propagate_cast.cpp
@@ -164,7 +164,7 @@ static unique_ptr<BaseStatistics> StatisticsPropagateVariant(const BaseStatistic
 		return nullptr;
 	}
 	// extract the typed stats
-	auto &typed_stats = StructStats::GetChildStats(shredded_stats, VariantStats::TYPED_VALUE_INDEX);
+	auto &typed_stats = VariantStats::GetTypedStats(shredded_stats);
 	if (structured_type == target) {
 		// type matches - return stats directly
 		return typed_stats.ToUnique();

--- a/src/storage/statistics/variant_stats.cpp
+++ b/src/storage/statistics/variant_stats.cpp
@@ -62,6 +62,28 @@ BaseStatistics &VariantStats::GetUnshreddedStats(BaseStatistics &stats) {
 	return stats.child_stats[0];
 }
 
+const BaseStatistics &VariantStats::GetTypedStats(const BaseStatistics &stats) {
+	if (stats.GetType().id() != LogicalTypeId::STRUCT) {
+		// primitive stats - return the stats directly
+		return stats;
+	}
+	// STRUCT(typed_value, (untyped_value)) - return the typed_value stats
+	return StructStats::GetChildStats(stats, TYPED_VALUE_INDEX);
+}
+
+optional_ptr<const BaseStatistics> VariantStats::GetUntypedStats(const BaseStatistics &stats) {
+	if (stats.GetType().id() != LogicalTypeId::STRUCT) {
+		// primitive stats - no untyped stats
+		return nullptr;
+	}
+	// STRUCT(typed_value, (untyped_value)) - check if we have untyped stats
+	if (StructType::GetChildCount(stats.GetType()) == 1) {
+		// fully shredded and no untyped stats
+		return nullptr;
+	}
+	return StructStats::GetChildStats(stats, UNTYPED_VALUE_INDEX);
+}
+
 void VariantStats::SetUnshreddedStats(BaseStatistics &stats, const BaseStatistics &new_stats) {
 	AssertVariant(stats);
 	stats.child_stats[0].Copy(new_stats);
@@ -89,28 +111,44 @@ void VariantStats::MarkAsNotShredded(BaseStatistics &stats) {
 //===--------------------------------------------------------------------===//
 
 static void AssertShreddedStats(const BaseStatistics &stats) {
-	if (stats.GetType().id() != LogicalTypeId::STRUCT) {
-		throw InternalException("Shredded stats should be of type STRUCT, not %s",
-		                        EnumUtil::ToString(stats.GetType().id()));
+	auto &stats_type = stats.GetType();
+	if (stats_type.id() != LogicalTypeId::STRUCT) {
+		// primitive stats - this is fine
+		return;
 	}
-	auto &struct_children = StructType::GetChildTypes(stats.GetType());
-	if (struct_children.size() != 2) {
-		throw InternalException(
-		    "Shredded stats need to consist of 2 children, 'untyped_value_index' and 'typed_value', not: %s",
-		    stats.GetType().ToString());
+	auto &struct_children = StructType::GetChildTypes(stats_type);
+	if (struct_children.size() > 2 || struct_children[VariantStats::TYPED_VALUE_INDEX].first != "typed_value") {
+		throw InternalException("Shredded stats need to consist of 1 or 2 children, 'typed_value' and optionally "
+		                        "'untyped_value_index', not: %s",
+		                        stats.GetType().ToString());
 	}
-	if (struct_children[VariantStats::UNTYPED_VALUE_INDEX].second.id() != LogicalTypeId::UINTEGER) {
-		throw InternalException("Shredded stats 'untyped_value_index' should be of type UINTEGER, not %s",
-		                        EnumUtil::ToString(struct_children[VariantStats::UNTYPED_VALUE_INDEX].second.id()));
+
+	if (struct_children.size() == 2) {
+		auto &untyped_entry = struct_children[VariantStats::UNTYPED_VALUE_INDEX];
+		if (untyped_entry.first != "untyped_value_index") {
+			throw InternalException("Untyped value index entry should be called \"untyped_value_index\"");
+		}
+		if (untyped_entry.second.id() != LogicalTypeId::UINTEGER) {
+			throw InternalException("Shredded stats 'untyped_value_index' should be of type UINTEGER, not %s",
+			                        EnumUtil::ToString(untyped_entry.second.id()));
+		}
 	}
 }
 
 optional_ptr<const BaseStatistics> VariantShreddedStats::FindChildStats(const BaseStatistics &stats,
                                                                         const VariantPathComponent &component) {
-	AssertShreddedStats(stats);
+	const_reference<BaseStatistics> typed_value_stats_ref(stats);
+	const_reference<LogicalType> typed_value_type_ref(stats.GetType());
+	if (typed_value_type_ref.get().IsNested()) {
+		// "typed_value" / "untyped_value"
+		AssertShreddedStats(stats);
 
-	auto &typed_value_stats = StructStats::GetChildStats(stats, VariantStats::TYPED_VALUE_INDEX);
-	auto &typed_value_type = typed_value_stats.GetType();
+		typed_value_stats_ref = StructStats::GetChildStats(stats, VariantStats::TYPED_VALUE_INDEX);
+		typed_value_type_ref = typed_value_stats_ref.get().GetType();
+	}
+	auto &typed_value_stats = typed_value_stats_ref.get();
+	auto &typed_value_type = typed_value_type_ref.get();
+
 	switch (component.lookup_mode) {
 	case VariantChildLookupMode::BY_INDEX: {
 		if (typed_value_type.id() != LogicalTypeId::LIST) {
@@ -139,7 +177,16 @@ optional_ptr<const BaseStatistics> VariantShreddedStats::FindChildStats(const Ba
 }
 
 bool VariantShreddedStats::IsFullyShredded(const BaseStatistics &stats) {
+	auto &stats_type = stats.GetType();
+	if (!stats_type.IsNested()) {
+		// if this is a primitive type this is fully nested
+		return true;
+	}
 	AssertShreddedStats(stats);
+	if (StructType::GetChildCount(stats_type) == 1) {
+		// we don't have untyped values - this must be fully shredded
+		return true;
+	}
 
 	auto &typed_value_stats = StructStats::GetChildStats(stats, VariantStats::TYPED_VALUE_INDEX);
 	auto &untyped_value_index_stats = StructStats::GetChildStats(stats, VariantStats::UNTYPED_VALUE_INDEX);
@@ -170,9 +217,13 @@ bool VariantShreddedStats::IsFullyShredded(const BaseStatistics &stats) {
 }
 
 LogicalType ToStructuredType(const LogicalType &shredding) {
+	if (shredding.id() != LogicalTypeId::STRUCT) {
+		// not a struct - this is a primitive type
+		return shredding;
+	}
 	D_ASSERT(shredding.id() == LogicalTypeId::STRUCT);
 	auto &child_types = StructType::GetChildTypes(shredding);
-	D_ASSERT(child_types.size() == 2);
+	D_ASSERT(child_types.size() <= 2);
 
 	auto &typed_value = child_types[VariantStats::TYPED_VALUE_INDEX].second;
 
@@ -356,12 +407,23 @@ string VariantStats::ToString(const BaseStatistics &stats) {
 	return result;
 }
 
-static BaseStatistics WrapTypedValue(BaseStatistics &untyped_value_index, BaseStatistics &typed_value) {
-	BaseStatistics shredded = BaseStatistics::CreateEmpty(LogicalType::STRUCT(
-	    {{"typed_value", typed_value.GetType()}, {"untyped_value_index", untyped_value_index.GetType()}}));
+static BaseStatistics WrapTypedValue(const BaseStatistics &typed_value,
+                                     optional_ptr<BaseStatistics> untyped_value_index) {
+	if (!untyped_value_index && !typed_value.GetType().IsNested()) {
+		// no untyped value and not a nested type - directly emit the typed stats
+		return typed_value.Copy();
+	}
+	child_list_t<LogicalType> stats_type;
+	stats_type.emplace_back(make_pair("typed_value", typed_value.GetType()));
+	if (untyped_value_index) {
+		stats_type.emplace_back(make_pair("untyped_value_index", untyped_value_index->GetType()));
+	}
+	BaseStatistics shredded = BaseStatistics::CreateEmpty(LogicalType::STRUCT(std::move(stats_type)));
 
 	StructStats::GetChildStats(shredded, VariantStats::TYPED_VALUE_INDEX).Copy(typed_value);
-	StructStats::GetChildStats(shredded, VariantStats::UNTYPED_VALUE_INDEX).Copy(untyped_value_index);
+	if (untyped_value_index) {
+		StructStats::GetChildStats(shredded, VariantStats::UNTYPED_VALUE_INDEX).Copy(*untyped_value_index);
+	}
 	return shredded;
 }
 
@@ -377,8 +439,10 @@ unique_ptr<BaseStatistics> VariantStats::WrapExtractedFieldAsVariant(const BaseS
 	return copy.ToUnique();
 }
 
-bool VariantStats::MergeShredding(BaseStatistics &stats, const BaseStatistics &other, BaseStatistics &new_stats) {
+bool VariantStats::MergeShredding(const BaseStatistics &stats, const BaseStatistics &other, BaseStatistics &new_stats) {
 	//! shredded_type:
+	//! <shredding>
+	//! STRUCT(typed_value <shredding>)
 	//! STRUCT(typed_value <shredding>, untyped_value_index UINTEGER)
 
 	//! shredding, 1 of:
@@ -386,23 +450,33 @@ bool VariantStats::MergeShredding(BaseStatistics &stats, const BaseStatistics &o
 	//! - <shredded_type>
 	//! - <shredded_type>[]
 
-	D_ASSERT(stats.type.id() == LogicalTypeId::STRUCT);
-	D_ASSERT(other.type.id() == LogicalTypeId::STRUCT);
+	auto &stats_typed_value = GetTypedStats(stats);
+	auto &other_typed_value = GetTypedStats(other);
 
-	auto &stats_children = StructType::GetChildTypes(stats.type);
-	auto &other_children = StructType::GetChildTypes(other.type);
-	D_ASSERT(stats_children.size() == 2);
-	D_ASSERT(other_children.size() == 2);
+	auto &stats_typed_value_type = stats_typed_value.GetType();
+	auto &other_typed_value_type = other_typed_value.GetType();
 
-	auto &stats_typed_value_type = stats_children[TYPED_VALUE_INDEX].second;
-	auto &other_typed_value_type = other_children[TYPED_VALUE_INDEX].second;
+	auto untyped_value_stats = GetUntypedStats(stats);
+	auto other_untyped_stats = GetUntypedStats(other);
 
-	//! Merge the untyped_value_index stats
-	auto &untyped_value_index = StructStats::GetChildStats(stats, UNTYPED_VALUE_INDEX);
-	untyped_value_index.Merge(StructStats::GetChildStats(other, UNTYPED_VALUE_INDEX));
+	// handle untyped value stats
+	optional_ptr<BaseStatistics> new_untyped_value_stats;
+	BaseStatistics owned_untyped_value_stats;
 
-	auto &stats_typed_value = StructStats::GetChildStats(stats, TYPED_VALUE_INDEX);
-	auto &other_typed_value = StructStats::GetChildStats(other, TYPED_VALUE_INDEX);
+	if (untyped_value_stats && other_untyped_stats) {
+		// both entries have untyped value stats - merge them
+		owned_untyped_value_stats = untyped_value_stats->Copy();
+		owned_untyped_value_stats.Merge(*other_untyped_stats);
+		new_untyped_value_stats = owned_untyped_value_stats;
+	} else if (untyped_value_stats) {
+		// only LHS has untyped value stats
+		owned_untyped_value_stats = untyped_value_stats->Copy();
+		new_untyped_value_stats = owned_untyped_value_stats;
+	} else if (other_untyped_stats) {
+		// only RHS has untyped value stats
+		owned_untyped_value_stats = other_untyped_stats->Copy();
+		new_untyped_value_stats = owned_untyped_value_stats;
+	}
 
 	if (stats_typed_value_type.id() == LogicalTypeId::STRUCT) {
 		if (stats_typed_value_type.id() != other_typed_value_type.id()) {
@@ -457,7 +531,7 @@ bool VariantStats::MergeShredding(BaseStatistics &stats, const BaseStatistics &o
 			StructStats::SetChildStats(new_typed_value, i, new_child_stats[i]);
 		}
 		new_typed_value.CombineValidity(stats_typed_value, other_typed_value);
-		new_stats = WrapTypedValue(untyped_value_index, new_typed_value);
+		new_stats = WrapTypedValue(new_typed_value, new_untyped_value_stats);
 		return true;
 	} else if (stats_typed_value_type.id() == LogicalTypeId::LIST) {
 		if (stats_typed_value_type.id() != other_typed_value_type.id()) {
@@ -475,7 +549,7 @@ bool VariantStats::MergeShredding(BaseStatistics &stats, const BaseStatistics &o
 		auto new_typed_value = BaseStatistics::CreateEmpty(LogicalType::LIST(new_child_stats.type));
 		new_typed_value.CombineValidity(stats_typed_value, other_typed_value);
 		ListStats::SetChildStats(new_typed_value, new_child_stats.ToUnique());
-		new_stats = WrapTypedValue(untyped_value_index, new_typed_value);
+		new_stats = WrapTypedValue(new_typed_value, new_untyped_value_stats);
 		return true;
 	} else {
 		D_ASSERT(!stats_typed_value_type.IsNested());
@@ -483,8 +557,9 @@ bool VariantStats::MergeShredding(BaseStatistics &stats, const BaseStatistics &o
 			//! other is not the same type, can't merge
 			return false;
 		}
-		stats_typed_value.Merge(other_typed_value);
-		new_stats = std::move(stats);
+		auto new_typed_stats = stats_typed_value.Copy();
+		new_typed_stats.Merge(other_typed_value);
+		new_stats = WrapTypedValue(new_typed_stats, new_untyped_value_stats);
 		return true;
 	}
 }
@@ -623,7 +698,7 @@ unique_ptr<BaseStatistics> VariantStats::PushdownExtract(const BaseStatistics &s
 	}
 	auto &shredded_child_stats = *res;
 
-	auto &typed_value_stats = StructStats::GetChildStats(shredded_child_stats, TYPED_VALUE_INDEX);
+	auto &typed_value_stats = GetTypedStats(shredded_child_stats);
 	auto &last_index = index_iter.get();
 	auto &child_type = typed_value_stats.type;
 	if (!last_index.HasType() || last_index.GetType().id() == LogicalTypeId::VARIANT) {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -697,6 +697,7 @@ void RowGroupCollection::MergeStorage(RowGroupCollection &data, optional_ptr<Dat
 			row_group_data = make_uniq<PersistentCollectionData>();
 		}
 	}
+	bool is_persistent = segments.back()->GetNode().IsPersistent();
 	for (auto &entry : segments) {
 		auto row_group = entry->MoveNode();
 		row_group->MoveToCollection(*this);
@@ -716,6 +717,9 @@ void RowGroupCollection::MergeStorage(RowGroupCollection &data, optional_ptr<Dat
 	}
 	stats.MergeStats(data.stats);
 	total_rows += data.total_rows.load();
+	if (is_persistent) {
+		SetAppendRequiresNewRowGroup();
+	}
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -369,8 +369,8 @@ static LogicalType ProduceShreddedType(VariantLogicalType type_id) {
 
 static LogicalType SetShreddedType(const LogicalType &typed_value) {
 	child_list_t<LogicalType> child_types;
-	child_types.emplace_back("untyped_value_index", LogicalType::UINTEGER);
 	child_types.emplace_back("typed_value", typed_value);
+	child_types.emplace_back("untyped_value_index", LogicalType::UINTEGER);
 	return LogicalType::STRUCT(child_types);
 }
 
@@ -577,7 +577,7 @@ void DuckDBVariantShredding::AnalyzeVariantValues(UnifiedVariantVectorData &vari
 	}
 }
 
-//! Receive a 'shredded' result Vector, consisting of the 'untyped_value_index' and the 'typed_value' Vector
+//! Receive a 'shredded' result Vector, consisting of the 'typed_value' and the 'untyped_value_index' Vector
 void DuckDBVariantShredding::WriteVariantValues(UnifiedVariantVectorData &variant, Vector &result,
                                                 optional_ptr<const SelectionVector> sel,
                                                 optional_ptr<const SelectionVector> value_index_sel,
@@ -590,8 +590,8 @@ void DuckDBVariantShredding::WriteVariantValues(UnifiedVariantVectorData &varian
 	D_ASSERT(child_types.size() == child_vectors.size());
 #endif
 
-	auto &untyped_value_index = *child_vectors[0];
-	auto &typed_value = *child_vectors[1];
+	auto &typed_value = *child_vectors[VariantColumnData::TYPED_VALUE_INDEX];
+	auto &untyped_value_index = *child_vectors[VariantColumnData::UNTYPED_VALUE_INDEX];
 
 	DuckDBVariantShreddingState shredding_state(typed_value.GetType(), count);
 	AnalyzeVariantValues(variant, untyped_value_index, sel, value_index_sel, result_sel, shredding_state, count);

--- a/src/storage/table/variant/variant_shredding.cpp
+++ b/src/storage/table/variant/variant_shredding.cpp
@@ -404,7 +404,7 @@ bool VariantShreddingStats::GetShreddedTypeInternal(const VariantColumnStatsData
 			//! Can't shred on DECIMAL, not consistent
 			continue;
 		}
-		idx_t count = column.type_counts[i];
+		idx_t count = column.type_counts[i] + column.type_counts[0];
 		if (!max_count || count > max_count) {
 			max_count = count;
 			type_index = i;

--- a/src/storage/table/variant/variant_unshredding.cpp
+++ b/src/storage/table/variant/variant_unshredding.cpp
@@ -185,8 +185,8 @@ static vector<VariantValue> Unshred(UnifiedVariantVectorData &variant, Vector &s
 	auto &child_entries = StructVector::GetEntries(shredded);
 	D_ASSERT(child_entries.size() == 2);
 
-	auto &untyped_value_index = *child_entries[0];
-	auto &typed_value = *child_entries[1];
+	auto &typed_value = *child_entries[VariantColumnData::TYPED_VALUE_INDEX];
+	auto &untyped_value_index = *child_entries[VariantColumnData::UNTYPED_VALUE_INDEX];
 
 	UnifiedVectorFormat untyped_format;
 	untyped_value_index.ToUnifiedFormat(count, untyped_format);

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -716,7 +716,7 @@ unique_ptr<ColumnCheckpointState> VariantColumnData::Checkpoint(const RowGroup &
 	if (!HasAnyChanges()) {
 		should_shred = false;
 	}
-	if (!EnableShredding(Settings::Get<VariantMinimumShreddingSizeSetting>(config), row_group.count.load())) {
+	if (!EnableShredding(Settings::Get<VariantMinimumShreddingSizeSetting>(config), count.load())) {
 		should_shred = false;
 	}
 

--- a/src/storage/table/variant_column_data.cpp
+++ b/src/storage/table/variant_column_data.cpp
@@ -31,14 +31,33 @@ VariantColumnData::VariantColumnData(BlockManager &block_manager, DataTableInfo 
 	}
 }
 
-bool FindShreddedColumnInternal(const StructColumnData &shredded, reference<const BaseStatistics> &stats,
+bool FindShreddedColumnInternal(const ColumnData &shredded, reference<const BaseStatistics> &stats,
                                 reference<const StorageIndex> &path_iter, ColumnIndex &out) {
 	auto &path = path_iter.get();
 	D_ASSERT(!path.HasPrimaryIndex());
 	auto &field_name = path.GetFieldName();
+	if (!path.HasChildren()) {
+		// end of the line
+		if (!VariantShreddedStats::IsFullyShredded(stats.get())) {
+			//! Child isn't fully shredded, can't use it
+			return false;
+		}
+		//! We're done, we've found the field referenced by the path!
+		if (shredded.type.id() == LogicalTypeId::STRUCT) {
+			// if this is a struct - refer to the .typed_value field
+			out.AddChildIndex(ColumnIndex(VariantColumnData::TYPED_VALUE_INDEX));
+			stats = StructStats::GetChildStats(stats.get(), VariantColumnData::TYPED_VALUE_INDEX);
+		}
+		return true;
+	}
+	if (shredded.type.id() != LogicalTypeId::STRUCT) {
+		// we're looking for a sub-field but this is a primitive type - not a match
+		return false;
+	}
 
 	D_ASSERT(shredded.type.id() == LogicalTypeId::STRUCT);
-	auto &typed_value = shredded.GetChildColumn(VariantColumnData::TYPED_VALUE_INDEX);
+	auto &struct_col = shredded.Cast<StructColumnData>();
+	auto &typed_value = struct_col.GetChildColumn(VariantColumnData::TYPED_VALUE_INDEX);
 	auto &parent_stats = stats.get();
 
 	stats = StructStats::GetChildStats(parent_stats, VariantColumnData::TYPED_VALUE_INDEX);
@@ -76,33 +95,15 @@ bool FindShreddedColumnInternal(const StructColumnData &shredded, reference<cons
 	typed_value_index.AddChildIndex(ColumnIndex(child_index));
 	auto &child_column = typed_value_index.GetChildIndex(0);
 
-	if (!path.HasChildren()) {
-		if (!VariantShreddedStats::IsFullyShredded(stats.get())) {
-			//! Child isn't fully shredded, can't use it
-			return false;
-		}
-		//! We're done, we've found the field referenced by the path!
-		//! typed_value_index.<child_name>.typed_value
-		child_column.AddChildIndex(ColumnIndex(VariantColumnData::TYPED_VALUE_INDEX));
-		stats = StructStats::GetChildStats(stats.get(), VariantColumnData::TYPED_VALUE_INDEX);
-		return true;
-	}
+	// recurse
 	path_iter = path.GetChildIndex(0);
-
-	//! Child of object is always a STRUCT(typed_value <...>, untyped_value_index UINTEGER)
-	D_ASSERT(object_field.type.id() == LogicalTypeId::STRUCT);
-	auto &struct_field = object_field.Cast<StructColumnData>();
-
-	return FindShreddedColumnInternal(struct_field, stats, path_iter, child_column);
+	return FindShreddedColumnInternal(object_field, stats, path_iter, child_column);
 }
 
 bool VariantColumnData::PushdownShreddedFieldExtract(const StorageIndex &variant_extract,
                                                      StorageIndex &out_struct_extract) const {
 	D_ASSERT(IsShredded());
 	auto &shredded = *sub_columns[1];
-	D_ASSERT(shredded.type.id() == LogicalTypeId::STRUCT);
-	D_ASSERT(StructType::GetChildCount(shredded.type) == 2);
-	D_ASSERT(StructType::GetChildTypes(shredded.type)[UNTYPED_VALUE_INDEX].second.id() == LogicalTypeId::UINTEGER);
 	auto &variant_stats = GetStatisticsRef();
 
 	if (!VariantStats::IsShredded(variant_stats)) {
@@ -113,11 +114,10 @@ bool VariantColumnData::PushdownShreddedFieldExtract(const StorageIndex &variant
 
 	//! shredded.typed_value
 	ColumnIndex column_index(0);
-	auto &struct_column = shredded.Cast<StructColumnData>();
 
 	reference<const BaseStatistics> shredded_stats(VariantStats::GetShreddedStats(variant_stats));
 	reference<const StorageIndex> path_iter(variant_extract);
-	if (!FindShreddedColumnInternal(struct_column, shredded_stats, path_iter, column_index)) {
+	if (!FindShreddedColumnInternal(shredded, shredded_stats, path_iter, column_index)) {
 		return false;
 	}
 	if (shredded_stats.get().GetType().IsNested()) {
@@ -599,7 +599,6 @@ public:
 			//! This will either be a pointer to shredded_data[1] if we decided to shred
 			//! Or to the existing shredded column data if we didn't decide to reshred
 			auto &shredded_state = child_states[1];
-			D_ASSERT(shredded_state->original_column.type.id() == LogicalTypeId::STRUCT);
 			data.extra_data = make_uniq<VariantPersistentColumnData>(shredded_state->original_column.type);
 		}
 		data.child_columns.push_back(validity_state->ToPersistentData());

--- a/test/sql/function/variant/variant_extract_try_cast.test
+++ b/test/sql/function/variant/variant_extract_try_cast.test
@@ -11,7 +11,7 @@ create table tbl(col VARIANT);
 
 statement ok
 insert into tbl SELECT * FROM UNNEST([
-	{'almost_a_number': c} for c in ['12', '24', '25a6', '24c', '16']
+	{'almost_a_number': c, 'a_number': CAST(TRY_CAST(c AS INT) AS VARCHAR)} for c in ['12', '24', '25a6', '24c', '16']
 ])
 
 statement ok
@@ -22,11 +22,11 @@ restart
 query I
 from tbl order by all
 ----
-{'almost_a_number': 12}
-{'almost_a_number': 16}
-{'almost_a_number': 24}
-{'almost_a_number': 24c}
-{'almost_a_number': 25a6}
+{'a_number': NULL, 'almost_a_number': 24c}
+{'a_number': NULL, 'almost_a_number': 25a6}
+{'a_number': 12, 'almost_a_number': 12}
+{'a_number': 16, 'almost_a_number': 16}
+{'a_number': 24, 'almost_a_number': 24}
 
 query I
 select col.almost_a_number from tbl order by all
@@ -41,11 +41,29 @@ select col.almost_a_number from tbl order by all
 statement error
 select col.almost_a_number::BIGINT from tbl order by all
 ----
-Conversion Error: Could not convert string '25a6' to INT64
+Conversion Error
 
 # Use TRY_CAST instead
 query I
 select TRY_CAST(col.almost_a_number AS BIGINT) from tbl order by all
+----
+12
+16
+24
+NULL
+NULL
+
+query I
+select col.a_number from tbl order by all
+----
+12
+16
+24
+NULL
+NULL
+
+query I
+select col.a_number::BIGINT from tbl order by all
 ----
 12
 16

--- a/test/sql/storage/types/variant/variant_shredding_omit_untyped.test
+++ b/test/sql/storage/types/variant/variant_shredding_omit_untyped.test
@@ -1,0 +1,48 @@
+# name: test/sql/storage/types/variant/variant_shredding_omit_untyped.test
+# group: [variant]
+
+load __TEST_DIR__/variant_shredding_omit_untyped.db
+
+# Always shred
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+# ------------------------------ INTEGER Shredding ------------------------------
+
+statement ok
+create table shredded_integer (col VARIANT)
+
+# Insert values 0-99
+statement ok
+insert into shredded_integer select (i % 100)::INTEGER from range(100) t(i)
+
+statement ok
+checkpoint
+
+# verify the untyped_value column is not present
+query I
+SELECT COUNT(*) FROM pragma_storage_info('shredded_integer') WHERE column_path = '[0, 2, 2]'
+----
+0
+
+query II
+SELECT SUM(TRY_CAST(col AS INT)), COUNT(*) FROM shredded_integer
+----
+4950	100
+
+statement ok
+insert into shredded_integer values ('hello world');
+
+statement ok
+checkpoint
+
+# verify the untyped_value column is not present
+query I
+SELECT COUNT(*) FROM pragma_storage_info('shredded_integer') WHERE column_path = '[0, 2, 2]'
+----
+1
+
+query II
+SELECT SUM(TRY_CAST(col AS INT)), COUNT(*) FROM shredded_integer
+----
+4950	101

--- a/test/sql/storage/types/variant/variant_shredding_omit_untyped.test
+++ b/test/sql/storage/types/variant/variant_shredding_omit_untyped.test
@@ -1,6 +1,8 @@
 # name: test/sql/storage/types/variant/variant_shredding_omit_untyped.test
 # group: [variant]
 
+require vector_size 2048
+
 load __TEST_DIR__/variant_shredding_omit_untyped.db
 
 # Always shred


### PR DESCRIPTION
Follow-up / includes https://github.com/duckdb/duckdb/pull/20947 (actual diff [here]( https://github.com/Mytherin/duckdb/compare/swapuntypedtyped...Mytherin:duckdb:optionaluntyped?expand=1))

When shredding variants we store them using the following schema (shredded on `STRUCT(a DATE, b INT)`):

```sql
shredded STRUCT(
	typed_value STRUCT(
		a STRUCT(
			typed_value DATE,
			untyped_value_index UINTEGER
		),
		b STRUCT(
			typed_value INT,
			untyped_value_index UINTEGER
		)
	),
	untyped_value_index UINTEGER
)
```

When they are fully shredded, `untyped_value_index` is entirely `NULL`. As such, it doesn't contain any useful information. This PR reworks our shredding and unshredding code to allow:

* (1) `untyped_value_index` to be left out entirely if the type is fully shredded
* (2) `typed_value` to be inlined in the parent if `typed_value` has a primitive (i.e. non-nested) type

If the above struct is fully shredded, we would instead get the following representation:

```sql
shredded STRUCT(
	typed_value STRUCT(
		a DATE,
		b INT
	)
)
```

This doesn't save much storage space, given that the various `untyped_value_index` layers are all stored as constant `NULL` in this situation, but it saves us a bunch of unnecessary column metadata. More importantly, this allows us to look only at the shredded schema instead of looking at the variant stats to realize a field is fully shredded. This is useful for simplifying shredded execution. We also save on allocating many empty vectors for reading fully shredded data. 
