### PR TITLE
Add HTTPClient::Cleanup, currently nop but can be implemented to perform post-usage cleanup

### DIFF
--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -235,6 +235,7 @@ public:
 	virtual unique_ptr<HTTPResponse> Head(HeadRequestInfo &info) = 0;
 	virtual unique_ptr<HTTPResponse> Delete(DeleteRequestInfo &info) = 0;
 	virtual unique_ptr<HTTPResponse> Post(PostRequestInfo &info) = 0;
+	virtual void Cleanup() {};
 
 	unique_ptr<HTTPResponse> Request(BaseRequest &request);
 };


### PR DESCRIPTION
This is just (for now) adding an hook intended to be used for cleaning up HTTP-transaction specific payload.