### PR TITLE
Convert count aggregate to struct-based state

### DIFF
--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -244,7 +244,8 @@ unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggr
 } // namespace
 
 AggregateFunction CountFunctionBase::GetFunction() {
-	AggregateFunction fun({LogicalType(LogicalTypeId::ANY)}, LogicalType::BIGINT, AggregateFunction::StateSize<CountState>,
+	AggregateFunction fun({LogicalType(LogicalTypeId::ANY)}, LogicalType::BIGINT,
+	                      AggregateFunction::StateSize<CountState>,
 	                      AggregateFunction::StateInitialize<CountState, CountFunction>, CountFunction::CountScatter,
 	                      AggregateFunction::StateCombine<CountState, CountFunction>,
 	                      AggregateFunction::StateFinalize<CountState, int64_t, CountFunction>,

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -233,9 +233,9 @@ unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggr
 
 AggregateFunction CountFunctionBase::GetFunction() {
 	AggregateFunction fun({LogicalType(LogicalTypeId::ANY)}, LogicalType::BIGINT, AggregateFunction::StateSize<int64_t>,
-						  AggregateFunction::StateInitialize<int64_t, CountFunction>, CountFunction::CountScatter,
-						  AggregateFunction::StateCombine<int64_t, CountFunction>,
-						  AggregateFunction::StateFinalize<int64_t, int64_t, CountFunction>,
+	                      AggregateFunction::StateInitialize<int64_t, CountFunction>, CountFunction::CountScatter,
+	                      AggregateFunction::StateCombine<int64_t, CountFunction>,
+	                      AggregateFunction::StateFinalize<int64_t, int64_t, CountFunction>,
 	                      FunctionNullHandling::SPECIAL_HANDLING, CountFunction::CountUpdate);
 	fun.name = "count";
 	fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -7,11 +7,10 @@
 namespace duckdb {
 
 namespace {
-
 struct BaseCountFunction {
 	template <class STATE>
 	static void Initialize(STATE &state) {
-		state = 0 ;
+		state = 0;
 	}
 
 	template <class STATE, class OP>
@@ -33,7 +32,7 @@ struct CountStarFunction : public BaseCountFunction {
 
 	template <class STATE, class OP>
 	static void ConstantOperation(STATE &state, AggregateInputData &, idx_t count) {
-		state += UnsafeNumericCast<int64_t>(count);
+		state += count;
 	}
 
 	template <typename RESULT_TYPE>
@@ -68,7 +67,7 @@ struct CountFunction : public BaseCountFunction {
 	}
 
 	static void ConstantOperation(STATE &state, idx_t count) {
-		state += UnsafeNumericCast<int64_t>(count);
+		state += UnsafeNumericCast<STATE>(count);
 	}
 
 	static bool IgnoreNull() {
@@ -172,7 +171,7 @@ struct CountFunction : public BaseCountFunction {
 	                                   const SelectionVector &sel_vector) {
 		if (mask.AllValid()) {
 			// no NULL values
-			result += UnsafeNumericCast<int64_t>(count);
+			result += UnsafeNumericCast<STATE>(count);
 			return;
 		}
 		for (idx_t i = 0; i < count; i++) {
@@ -190,7 +189,7 @@ struct CountFunction : public BaseCountFunction {
 		case VectorType::CONSTANT_VECTOR: {
 			if (!ConstantVector::IsNull(input)) {
 				// if the constant is not null increment the state
-				result += UnsafeNumericCast<int64_t>(count);
+				result += UnsafeNumericCast<STATE>(count);
 			}
 			break;
 		}
@@ -200,7 +199,7 @@ struct CountFunction : public BaseCountFunction {
 		}
 		case VectorType::SEQUENCE_VECTOR: {
 			// sequence vectors cannot have NULL values
-			result += UnsafeNumericCast<int64_t>(count);
+			result += UnsafeNumericCast<STATE>(count);
 			break;
 		}
 		default: {

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -7,32 +7,44 @@
 namespace duckdb {
 
 namespace {
+struct CountState {
+	int64_t count;
+
+	void Initialize() {
+		count = 0;
+	}
+
+	void Combine(const CountState &other) {
+		count += other.count;
+	}
+};
+
 struct BaseCountFunction {
 	template <class STATE>
 	static void Initialize(STATE &state) {
-		state = 0;
+		state.Initialize();
 	}
 
 	template <class STATE, class OP>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
-		target += source;
+		target.Combine(source);
 	}
 
 	template <class T, class STATE>
 	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
-		target = state;
+		target = state.count;
 	}
 };
 
 struct CountStarFunction : public BaseCountFunction {
 	template <class STATE, class OP>
 	static void Operation(STATE &state, AggregateInputData &, idx_t idx) {
-		state += 1;
+		state.count += 1;
 	}
 
 	template <class STATE, class OP>
 	static void ConstantOperation(STATE &state, AggregateInputData &, idx_t count) {
-		state += count;
+		state.count += UnsafeNumericCast<int64_t>(count);
 	}
 
 	template <typename RESULT_TYPE>
@@ -60,14 +72,14 @@ struct CountStarFunction : public BaseCountFunction {
 };
 
 struct CountFunction : public BaseCountFunction {
-	using STATE = int64_t;
+	using STATE = CountState;
 
 	static void Operation(STATE &state) {
-		state += 1;
+		state.count += 1;
 	}
 
 	static void ConstantOperation(STATE &state, idx_t count) {
-		state += UnsafeNumericCast<STATE>(count);
+		state.count += UnsafeNumericCast<int64_t>(count);
 	}
 
 	static bool IgnoreNull() {
@@ -149,7 +161,7 @@ struct CountFunction : public BaseCountFunction {
 			idx_t next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
 			if (ValidityMask::AllValid(validity_entry)) {
 				// all valid
-				result += UnsafeNumericCast<STATE>(next - base_idx);
+				result.count += UnsafeNumericCast<int64_t>(next - base_idx);
 				base_idx = next;
 			} else if (ValidityMask::NoneValid(validity_entry)) {
 				// nothing valid: skip all
@@ -160,7 +172,7 @@ struct CountFunction : public BaseCountFunction {
 				idx_t start = base_idx;
 				for (; base_idx < next; base_idx++) {
 					if (ValidityMask::RowIsValid(validity_entry, base_idx - start)) {
-						result++;
+						result.count++;
 					}
 				}
 			}
@@ -171,13 +183,13 @@ struct CountFunction : public BaseCountFunction {
 	                                   const SelectionVector &sel_vector) {
 		if (mask.AllValid()) {
 			// no NULL values
-			result += UnsafeNumericCast<STATE>(count);
+			result.count += UnsafeNumericCast<int64_t>(count);
 			return;
 		}
 		for (idx_t i = 0; i < count; i++) {
 			auto idx = sel_vector.get_index(i);
 			if (mask.RowIsValid(idx)) {
-				result++;
+				result.count++;
 			}
 		}
 	}
@@ -189,7 +201,7 @@ struct CountFunction : public BaseCountFunction {
 		case VectorType::CONSTANT_VECTOR: {
 			if (!ConstantVector::IsNull(input)) {
 				// if the constant is not null increment the state
-				result += UnsafeNumericCast<STATE>(count);
+				result.count += UnsafeNumericCast<int64_t>(count);
 			}
 			break;
 		}
@@ -199,7 +211,7 @@ struct CountFunction : public BaseCountFunction {
 		}
 		case VectorType::SEQUENCE_VECTOR: {
 			// sequence vectors cannot have NULL values
-			result += UnsafeNumericCast<STATE>(count);
+			result.count += UnsafeNumericCast<int64_t>(count);
 			break;
 		}
 		default: {
@@ -211,6 +223,12 @@ struct CountFunction : public BaseCountFunction {
 		}
 	}
 };
+
+LogicalType GetCountStateType(const AggregateFunction &function) {
+	child_list_t<LogicalType> children;
+	children.emplace_back("count", LogicalType::BIGINT);
+	return LogicalType::STRUCT(std::move(children));
+}
 
 unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggregateExpression &expr,
                                                AggregateStatisticsInput &input) {
@@ -226,22 +244,24 @@ unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggr
 } // namespace
 
 AggregateFunction CountFunctionBase::GetFunction() {
-	AggregateFunction fun({LogicalType(LogicalTypeId::ANY)}, LogicalType::BIGINT, AggregateFunction::StateSize<int64_t>,
-	                      AggregateFunction::StateInitialize<int64_t, CountFunction>, CountFunction::CountScatter,
-	                      AggregateFunction::StateCombine<int64_t, CountFunction>,
-	                      AggregateFunction::StateFinalize<int64_t, int64_t, CountFunction>,
+	AggregateFunction fun({LogicalType(LogicalTypeId::ANY)}, LogicalType::BIGINT, AggregateFunction::StateSize<CountState>,
+	                      AggregateFunction::StateInitialize<CountState, CountFunction>, CountFunction::CountScatter,
+	                      AggregateFunction::StateCombine<CountState, CountFunction>,
+	                      AggregateFunction::StateFinalize<CountState, int64_t, CountFunction>,
 	                      FunctionNullHandling::SPECIAL_HANDLING, CountFunction::CountUpdate);
 	fun.name = "count";
 	fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
+	fun.SetStructStateExport(GetCountStateType);
 	return fun;
 }
 
 AggregateFunction CountStarFun::GetFunction() {
-	auto fun = AggregateFunction::NullaryAggregate<int64_t, int64_t, CountStarFunction>(LogicalType::BIGINT);
+	auto fun = AggregateFunction::NullaryAggregate<CountState, int64_t, CountStarFunction>(LogicalType::BIGINT);
 	fun.name = "count_star";
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	fun.SetWindowCallback(CountStarFunction::Window<int64_t>);
+	fun.SetStructStateExport(GetCountStateType);
 	return fun;
 }
 

--- a/test/sql/aggregate/aggregates/test_aggregate_state_type.test
+++ b/test/sql/aggregate/aggregates/test_aggregate_state_type.test
@@ -50,13 +50,13 @@ SELECT finalize(combine(state, state)) FROM t1_${type} ORDER BY 1;
 
 endloop
 
-# count(INT) does NOT have the new get_state_type callback yet, so it should show the return type
+# count() now has the new get_state_type callback
 query T
-SELECT typeof(count(1) EXPORT_STATE);
+SELECT typeof(count(1) EXPORT_STATE) = 'AGGREGATE_STATE<count(ANY)::BIGINT, STRUCT(count BIGINT)>';
 ----
-LEGACY_AGGREGATE_STATE<count(ANY)::BIGINT>
+true
 
-# count(INT) (as not opted-in) is still serialized correctly
+# count(INT) (as opted-in) is still serialized correctly
 statement ok
 CREATE TABLE t2_count_int AS SELECT count(range::INT) EXPORT_STATE as state FROM range(10);
 
@@ -114,3 +114,15 @@ query T
 SELECT (avg(42) export_state)::struct(count ubigint, "value" double);
 ----
 {'count': 1, 'value': 42.0}
+
+# Casting count state to struct should work
+query T
+SELECT (count(42) export_state)::struct(count bigint);
+----
+{'count': 1}
+
+# Casting count(*) state to struct should also work
+query T
+SELECT (count(*) export_state)::struct(count bigint);
+----
+{'count': 1}

--- a/test/sql/aggregate/aggregates/test_state_export_opaque.test
+++ b/test/sql/aggregate/aggregates/test_state_export_opaque.test
@@ -7,102 +7,56 @@ create table dummy as select range % 10 g, range d from range(100);
 
 # ungrouped aggr
 
-query IIIIII nosort res0
-SELECT count(*), count(d), min(d), max(d) FROM dummy;
+query IIII nosort res0
+SELECT min(d), max(d) FROM dummy;
 ----
 
-query IIIIII nosort res0
-SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE), finalize(min(d) EXPORT_STATE), finalize(max(d) EXPORT_STATE)  FROM dummy;
+query IIII nosort res0
+SELECT finalize(min(d) EXPORT_STATE), finalize(max(d) EXPORT_STATE)  FROM dummy;
 ----
 
 # grouped aggr
-query IIIIIII nosort res1
-SELECT g, count(*), count(d), min(d), max(d) FROM dummy GROUP BY g ORDER BY g;
+query IIIII nosort res1
+SELECT g, min(d), max(d) FROM dummy GROUP BY g ORDER BY g;
 ----
 
-query IIIIIII nosort res1
-SELECT g, finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE), finalize(min(d) EXPORT_STATE), finalize(max(d) EXPORT_STATE)  FROM dummy GROUP BY g ORDER BY g;
+query IIIII nosort res1
+SELECT g, finalize(min(d) EXPORT_STATE), finalize(max(d) EXPORT_STATE)  FROM dummy GROUP BY g ORDER BY g;
 ----
 
 # we can persist this
 statement ok
-CREATE TABLE state AS SELECT g, count(*) EXPORT_STATE count_star_state, count(d) EXPORT_STATE count_state, min(d) EXPORT_STATE min_state, max(d) EXPORT_STATE max_state FROM dummy GROUP BY g ORDER BY g;
+CREATE TABLE state AS SELECT g, min(d) EXPORT_STATE min_state, max(d) EXPORT_STATE max_state FROM dummy GROUP BY g ORDER BY g;
 
-query IIIIIII nosort res1
-SELECT g, finalize(count_star_state),finalize(count_state), finalize(min_state), finalize(max_state) FROM state ORDER BY g;
+query IIIII nosort res1
+SELECT g, finalize(min_state), finalize(max_state) FROM state ORDER BY g;
 ----
-
-query II nosort res2
-SELECT count(d) * 2 FROM dummy;
-----
-
-query II nosort res2
-SELECT FINALIZE(COMBINE(count(d) EXPORT_STATE, count(d) EXPORT_STATE)) FROM dummy;
-----
-
-
-query II nosort res3
-SELECT g, count(d) * 2 combined_count FROM dummy GROUP BY g ORDER BY g;
-----
-
-query II nosort res3
-select g, finalize(combine(count(d) EXPORT_STATE, count_state)) combined_count from dummy join state using (g) group by g, count_state ORDER BY g;
-----
-
-# combine aggregate state in UNION
-statement ok
-CREATE TABLE state2 AS SELECT g, count(d) EXPORT_STATE count_state FROM dummy WHERE g < 5 GROUP BY g ORDER BY g;
-
-query II rowsort res3
-select g, finalize(count_state) * 2 combined_count from (select g, count(d) EXPORT_STATE count_state from dummy where g >= 5 GROUP BY g union all SELECT * FROM state2) ORDER BY g;
-----
-
-# combine aggregate states in JOINs with NULLs
-query II rowsort res3
-with groups as (select distinct g from dummy)
-select g, FINALIZE(COMBINE(count_state, count_state2)) * 2 from groups left join state2 using(g) left join (select g, count(d) EXPORT_STATE count_state2 from dummy where g >= 5 GROUP BY g) using (g)
-----
-
-query IIII
-with groups as (select distinct g from dummy)
-select g, FINALIZE(count_state), FINALIZE(count_state2), FINALIZE(COMBINE(count_state, count_state2))  from groups left join state2 using(g) left join (select g, count(d) EXPORT_STATE count_state2 from dummy where g >= 3 GROUP BY g) using (g) order by g
-----
-0	10	NULL	10
-1	10	NULL	10
-2	10	NULL	10
-3	10	10	20
-4	10	10	20
-5	NULL	10	10
-6	NULL	10	10
-7	NULL	10	10
-8	NULL	10	10
-9	NULL	10	10
 
 # empty groups
-query IIIIII nosort res4
-SELECT count(*), count(d), min(d), max(d) FROM dummy WHERE FALSE;
+query IIII nosort res4
+SELECT min(d), max(d) FROM dummy WHERE FALSE;
 ----
 
-query IIIIII nosort res4
-SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE), finalize(min(d) EXPORT_STATE), finalize(max(d) EXPORT_STATE) FROM dummy WHERE FALSE;
+query IIII nosort res4
+SELECT finalize(min(d) EXPORT_STATE), finalize(max(d) EXPORT_STATE) FROM dummy WHERE FALSE;
 ----
 
 # only null scanned
-query IIIIII nosort res5
-SELECT count(*), count(d), min(d), max(d) FROM (SELECT NULL::integer d);
+query IIII nosort res5
+SELECT min(d), max(d) FROM (SELECT NULL::integer d);
 ----
 
-query IIIIII nosort res5
-SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE), finalize(min(d) EXPORT_STATE), finalize(max(d) EXPORT_STATE) FROM (SELECT NULL::integer d);
+query IIII nosort res5
+SELECT finalize(min(d) EXPORT_STATE), finalize(max(d) EXPORT_STATE) FROM (SELECT NULL::integer d);
 ----
 
 # only null scanned, but grouped
-query IIIIII nosort res6
-SELECT count(*), count(d), min(d), max(d) FROM (SELECT NULL::integer d, g FROM dummy);
+query IIII nosort res6
+SELECT min(d), max(d) FROM (SELECT NULL::integer d, g FROM dummy);
 ----
 
-query IIIIII nosort res6
-SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE), finalize(min(d) EXPORT_STATE), finalize(max(d) EXPORT_STATE) FROM (SELECT NULL::integer d, g FROM dummy);
+query IIII nosort res6
+SELECT finalize(min(d) EXPORT_STATE), finalize(max(d) EXPORT_STATE) FROM (SELECT NULL::integer d, g FROM dummy);
 ----
 
 # more aggregates
@@ -200,23 +154,23 @@ create table dummy as select range % 10 g, range d from range(100);
 
 # we can persist this
 statement ok
-CREATE TABLE state AS SELECT g, count(*) EXPORT_STATE count_star_state, count(d) EXPORT_STATE count_state, min(d) EXPORT_STATE min_state, max(d) EXPORT_STATE max_state FROM dummy GROUP BY g ORDER BY g;
+CREATE TABLE state AS SELECT g, min(d) EXPORT_STATE min_state, max(d) EXPORT_STATE max_state FROM dummy GROUP BY g ORDER BY g;
 
 statement ok
-CREATE VIEW state_view AS SELECT g, count(*) EXPORT_STATE count_star_state, count(d) EXPORT_STATE count_state, min(d) EXPORT_STATE min_state, max(d) EXPORT_STATE max_state FROM dummy GROUP BY g ORDER BY g;
+CREATE VIEW state_view AS SELECT g, min(d) EXPORT_STATE min_state, max(d) EXPORT_STATE max_state FROM dummy GROUP BY g ORDER BY g;
 
 restart
 
-query IIIIIII nosort res10
-SELECT g, count(*), count(d), min(d), max(d) FROM dummy GROUP BY g ORDER BY g;
+query IIIII nosort res10
+SELECT g, min(d), max(d) FROM dummy GROUP BY g ORDER BY g;
 ----
 
-query IIIIIII nosort res10
-SELECT g, finalize(count_star_state),finalize(count_state), finalize(min_state), finalize(max_state) FROM state ORDER BY g;
+query IIIII nosort res10
+SELECT g, finalize(min_state), finalize(max_state) FROM state ORDER BY g;
 ----
 
-query IIIIIII nosort res10
-SELECT g, finalize(count_star_state),finalize(count_state), finalize(min_state), finalize(max_state) FROM state_view ORDER BY g;
+query IIIII nosort res10
+SELECT g, finalize(min_state), finalize(max_state) FROM state_view ORDER BY g;
 ----
 
 # BLOB casting back and forth

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -13,30 +13,30 @@ create table dummy as select range % 10 g, range d from range(100);
 
 # ungrouped aggr
 
-query IIIIII nosort res0
-SELECT sum(d), avg(d)::integer FROM dummy;
+query IIIIIII nosort res0
+SELECT sum(d), avg(d)::integer, count(d) FROM dummy;
 ----
 
-query IIIIII nosort res0
-SELECT finalize(sum(d) EXPORT_STATE), finalize(avg(d) EXPORT_STATE)::integer FROM dummy;
+query IIIIIII nosort res0
+SELECT finalize(sum(d) EXPORT_STATE), finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE) FROM dummy;
 ----
 
 # grouped aggr
-query IIIIIII nosort res1
-SELECT g, sum(d), avg(d)::integer FROM dummy GROUP BY g ORDER BY g;
+query IIIIIIIII nosort res1
+SELECT g, sum(d), avg(d)::integer, count(d) FROM dummy GROUP BY g ORDER BY g;
 ----
 
-query IIIIIII nosort res1
-SELECT g, finalize(sum(d) EXPORT_STATE)::integer, finalize(avg(d) EXPORT_STATE)::integer FROM dummy GROUP BY g ORDER BY g;
+query IIIIIIIII nosort res1
+SELECT g, finalize(sum(d) EXPORT_STATE)::integer, finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
 ----
 
 # we can persist this
 
 statement ok
-CREATE TABLE state AS SELECT g, sum(d) EXPORT_STATE sum_state, avg(d) EXPORT_STATE avg_state FROM dummy GROUP BY g ORDER BY g;
+CREATE TABLE state AS SELECT g, sum(d) EXPORT_STATE sum_state, avg(d) EXPORT_STATE avg_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
 
-query IIIIIII nosort res1
-SELECT g, finalize(sum_state), finalize(avg_state)::integer FROM state ORDER BY g;
+query IIIIIIIII nosort res1
+SELECT g, finalize(sum_state), finalize(avg_state)::integer, finalize(count_state) FROM state ORDER BY g;
 ----
 
 query II nosort res3
@@ -61,174 +61,33 @@ with groups as (select distinct g from dummy)
 select g, FINALIZE(COMBINE(sum_state, sum_state2)) * 2 from groups left join state2 using(g) left join (select g, sum(d) EXPORT_STATE sum_state2 from dummy where g >= 5 GROUP BY g) using (g);
 ----
 
-# count tests
-query IIII nosort res0_count
-SELECT count(*), count(d) FROM dummy;
-----
-
-query IIII nosort res0_count
-SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE) FROM dummy;
-----
-
-query IIIII nosort res1_count
-SELECT g, count(*), count(d) FROM dummy GROUP BY g ORDER BY g;
-----
-
-query IIIII nosort res1_count
-SELECT g, finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
-----
-
-statement ok
-CREATE TABLE state_count AS SELECT g, count(*) EXPORT_STATE count_star_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
-
-query IIIII nosort res1_count
-SELECT g, finalize(count_star_state), finalize(count_state) FROM state_count ORDER BY g;
-----
-
-query II nosort res3_count
-SELECT g, count(d)*2 combined_count FROM dummy GROUP BY g ORDER BY g;
-----
-
-query II nosort res3_count
-select g, finalize(combine(count(d) EXPORT_STATE, count_state)) combined_count from dummy join state_count using (g) group by g, count_state ORDER BY g;
-----
-
-statement ok
-CREATE TABLE state2_count AS SELECT g, count(d) EXPORT_STATE count_state FROM dummy WHERE g < 5 GROUP BY g ORDER BY g;
-
-query II rowsort res3_count
-select g, finalize(count_state) * 2 combined_count from (select g, count(d) EXPORT_STATE count_state from dummy where g >= 5 GROUP BY g union all SELECT * FROM state2_count) ORDER BY g;
-----
-
-query II rowsort res3_count
-with groups as (select distinct g from dummy)
-select g, FINALIZE(COMBINE(count_state, count_state2)) * 2 from groups left join state2_count using(g) left join (select g, count(d) EXPORT_STATE count_state2 from dummy where g >= 5 GROUP BY g) using (g);
-----
-
 # empty groups
-query IIIIII nosort res4
-SELECT avg(d)::integer FROM dummy WHERE FALSE;
+query IIIIIII nosort res4
+SELECT avg(d)::integer, count(d) FROM dummy WHERE FALSE;
 ----
 
-query IIIIII nosort res4
-SELECT finalize(avg(d) EXPORT_STATE)::integer, FROM dummy WHERE FALSE;
+query IIIIIII nosort res4
+SELECT finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE) FROM dummy WHERE FALSE;
 ----
 
 # only null scanned
-query IIIIII nosort res5
-SELECT avg(d)::integer FROM (SELECT NULL::integer d);
+query IIIIIII nosort res5
+SELECT avg(d)::integer, count(d) FROM (SELECT NULL::integer d);
 ----
 
-query IIIIII nosort res5
-SELECT finalize(avg(d) EXPORT_STATE)::integer FROM (SELECT NULL::integer d);
+query IIIIIII nosort res5
+SELECT finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE) FROM (SELECT NULL::integer d);
 ----
 
 # only null scanned, but grouped
-query IIIIII nosort res6
-SELECT avg(d)::integer FROM (SELECT NULL::integer d, g FROM dummy);
+query IIIIIII nosort res6
+SELECT avg(d)::integer, count(d) FROM (SELECT NULL::integer d, g FROM dummy);
 ----
 
-query IIIIII nosort res6
-SELECT finalize(avg(d) EXPORT_STATE)::integer FROM (SELECT NULL::integer d, g FROM dummy);
+query IIIIIII nosort res6
+SELECT finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE) FROM (SELECT NULL::integer d, g FROM dummy);
 ----
 
-# count empty groups
-query IIII nosort res4_count
-SELECT count(*), count(d) FROM dummy WHERE FALSE;
-----
-
-query IIII nosort res4_count
-SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE) FROM dummy WHERE FALSE;
-----
-
-# count only null scanned
-query IIII nosort res5_count
-SELECT count(*), count(d) FROM (SELECT NULL::integer d);
-----
-
-query IIII nosort res5_count
-SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE) FROM (SELECT NULL::integer d);
-----
-
-# count only null scanned, but grouped
-query IIII nosort res6_count
-SELECT count(*), count(d) FROM (SELECT NULL::integer d, g FROM dummy);
-----
-
-query IIII nosort res6_count
-SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE) FROM (SELECT NULL::integer d, g FROM dummy);
-----
-
-# sum tests
-query II nosort res0_sum
-SELECT sum(d) FROM dummy;
-----
-
-query II nosort res0_sum
-SELECT finalize(sum(d) EXPORT_STATE) FROM dummy;
-----
-
-query III nosort res1_sum
-SELECT g, sum(d) FROM dummy GROUP BY g ORDER BY g;
-----
-
-query III nosort res1_sum
-SELECT g, finalize(sum(d) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
-----
-
-statement ok
-CREATE TABLE state_sum AS SELECT g, sum(d) EXPORT_STATE sum_state FROM dummy GROUP BY g ORDER BY g;
-
-query III nosort res1_sum
-SELECT g, finalize(sum_state) FROM state_sum ORDER BY g;
-----
-
-query II nosort res3_sum
-SELECT g, sum(d)*2 combined_sum FROM dummy GROUP BY g ORDER BY g;
-----
-
-query II nosort res3_sum
-select g, finalize(combine(sum(d) EXPORT_STATE, sum_state)) combined_sum from dummy join state_sum using (g) group by g, sum_state ORDER BY g;
-----
-
-statement ok
-CREATE TABLE state2_sum AS SELECT g, sum(d) EXPORT_STATE sum_state FROM dummy WHERE g < 5 GROUP BY g ORDER BY g;
-
-query II rowsort res3_sum
-select g, finalize(sum_state) * 2 combined_sum from (select g, sum(d) EXPORT_STATE sum_state from dummy where g >= 5 GROUP BY g union all SELECT * FROM state2_sum) ORDER BY g;
-----
-
-query II rowsort res3_sum
-with groups as (select distinct g from dummy)
-select g, FINALIZE(COMBINE(sum_state, sum_state2)) * 2 from groups left join state2_sum using(g) left join (select g, sum(d) EXPORT_STATE sum_state2 from dummy where g >= 5 GROUP BY g) using (g);
-----
-
-# sum empty groups
-query II nosort res4_sum
-SELECT sum(d) FROM dummy WHERE FALSE;
-----
-
-query II nosort res4_sum
-SELECT finalize(sum(d) EXPORT_STATE) FROM dummy WHERE FALSE;
-----
-
-# sum only null scanned
-query II nosort res5_sum
-SELECT sum(d) FROM (SELECT NULL::integer d);
-----
-
-query II nosort res5_sum
-SELECT finalize(sum(d) EXPORT_STATE) FROM (SELECT NULL::integer d);
-----
-
-# sum only null scanned, but grouped
-query II nosort res6_sum
-SELECT sum(d) FROM (SELECT NULL::integer d, g FROM dummy);
-----
-
-query II nosort res6_sum
-SELECT finalize(sum(d) EXPORT_STATE) FROM (SELECT NULL::integer d, g FROM dummy);
-----
 
 # more aggregates
 
@@ -311,63 +170,21 @@ create table dummy as select range % 10 g, range d from range(100);
 
 # we can persist this
 statement ok
-CREATE TABLE state AS SELECT g, avg(d) EXPORT_STATE avg_state FROM dummy GROUP BY g ORDER BY g;
+CREATE TABLE state AS SELECT g, avg(d) EXPORT_STATE avg_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
 
 statement ok
-CREATE VIEW state_view AS SELECT g, avg(d) EXPORT_STATE avg_state FROM dummy GROUP BY g ORDER BY g;
+CREATE VIEW state_view AS SELECT g, avg(d) EXPORT_STATE avg_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
 
 restart
 
-query IIIIIII nosort res10
-SELECT g, avg(d)::integer FROM dummy GROUP BY g ORDER BY g;
+query IIIIIIIII nosort res10
+SELECT g, avg(d)::integer, count(d) FROM dummy GROUP BY g ORDER BY g;
 ----
 
-query IIIIIII nosort res10
-SELECT g, finalize(avg_state)::integer FROM state ORDER BY g;
+query IIIIIIIII nosort res10
+SELECT g, finalize(avg_state)::integer, finalize(count_state) FROM state ORDER BY g;
 ----
 
-query IIIIIII nosort res10
-SELECT g, finalize(avg_state)::integer FROM state_view ORDER BY g;
-----
-
-# count persistence
-statement ok
-CREATE TABLE state_count_persist AS SELECT g, count(*) EXPORT_STATE count_star_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
-
-statement ok
-CREATE VIEW state_count_view AS SELECT g, count(*) EXPORT_STATE count_star_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
-
-restart
-
-query IIIII nosort res10_count
-SELECT g, count(*), count(d) FROM dummy GROUP BY g ORDER BY g;
-----
-
-query IIIII nosort res10_count
-SELECT g, finalize(count_star_state), finalize(count_state) FROM state_count_persist ORDER BY g;
-----
-
-query IIIII nosort res10_count
-SELECT g, finalize(count_star_state), finalize(count_state) FROM state_count_view ORDER BY g;
-----
-
-# sum persistence
-statement ok
-CREATE TABLE state_sum_persist AS SELECT g, sum(d) EXPORT_STATE sum_state FROM dummy GROUP BY g ORDER BY g;
-
-statement ok
-CREATE VIEW state_sum_view AS SELECT g, sum(d) EXPORT_STATE sum_state FROM dummy GROUP BY g ORDER BY g;
-
-restart
-
-query III nosort res10_sum
-SELECT g, sum(d) FROM dummy GROUP BY g ORDER BY g;
-----
-
-query III nosort res10_sum
-SELECT g, finalize(sum_state) FROM state_sum_persist ORDER BY g;
-----
-
-query III nosort res10_sum
-SELECT g, finalize(sum_state) FROM state_sum_view ORDER BY g;
+query IIIIIIIII nosort res10
+SELECT g, finalize(avg_state)::integer, finalize(count_state) FROM state_view ORDER BY g;
 ----

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -61,6 +61,50 @@ with groups as (select distinct g from dummy)
 select g, FINALIZE(COMBINE(sum_state, sum_state2)) * 2 from groups left join state2 using(g) left join (select g, sum(d) EXPORT_STATE sum_state2 from dummy where g >= 5 GROUP BY g) using (g);
 ----
 
+# count tests
+query IIII nosort res0_count
+SELECT count(*), count(d) FROM dummy;
+----
+
+query IIII nosort res0_count
+SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE) FROM dummy;
+----
+
+query IIIII nosort res1_count
+SELECT g, count(*), count(d) FROM dummy GROUP BY g ORDER BY g;
+----
+
+query IIIII nosort res1_count
+SELECT g, finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
+----
+
+statement ok
+CREATE TABLE state_count AS SELECT g, count(*) EXPORT_STATE count_star_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
+
+query IIIII nosort res1_count
+SELECT g, finalize(count_star_state), finalize(count_state) FROM state_count ORDER BY g;
+----
+
+query II nosort res3_count
+SELECT g, count(d)*2 combined_count FROM dummy GROUP BY g ORDER BY g;
+----
+
+query II nosort res3_count
+select g, finalize(combine(count(d) EXPORT_STATE, count_state)) combined_count from dummy join state_count using (g) group by g, count_state ORDER BY g;
+----
+
+statement ok
+CREATE TABLE state2_count AS SELECT g, count(d) EXPORT_STATE count_state FROM dummy WHERE g < 5 GROUP BY g ORDER BY g;
+
+query II rowsort res3_count
+select g, finalize(count_state) * 2 combined_count from (select g, count(d) EXPORT_STATE count_state from dummy where g >= 5 GROUP BY g union all SELECT * FROM state2_count) ORDER BY g;
+----
+
+query II rowsort res3_count
+with groups as (select distinct g from dummy)
+select g, FINALIZE(COMBINE(count_state, count_state2)) * 2 from groups left join state2_count using(g) left join (select g, count(d) EXPORT_STATE count_state2 from dummy where g >= 5 GROUP BY g) using (g);
+----
+
 # empty groups
 query IIIIII nosort res4
 SELECT avg(d)::integer FROM dummy WHERE FALSE;
@@ -86,6 +130,33 @@ SELECT avg(d)::integer FROM (SELECT NULL::integer d, g FROM dummy);
 
 query IIIIII nosort res6
 SELECT finalize(avg(d) EXPORT_STATE)::integer FROM (SELECT NULL::integer d, g FROM dummy);
+----
+
+# count empty groups
+query IIII nosort res4_count
+SELECT count(*), count(d) FROM dummy WHERE FALSE;
+----
+
+query IIII nosort res4_count
+SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE) FROM dummy WHERE FALSE;
+----
+
+# count only null scanned
+query IIII nosort res5_count
+SELECT count(*), count(d) FROM (SELECT NULL::integer d);
+----
+
+query IIII nosort res5_count
+SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE) FROM (SELECT NULL::integer d);
+----
+
+# count only null scanned, but grouped
+query IIII nosort res6_count
+SELECT count(*), count(d) FROM (SELECT NULL::integer d, g FROM dummy);
+----
+
+query IIII nosort res6_count
+SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE) FROM (SELECT NULL::integer d, g FROM dummy);
 ----
 
 # more aggregates
@@ -133,6 +204,17 @@ statement error
 SELECT finalize(finalize(avg(d) EXPORT_STATE)) from dummy;
 ----
 
+# Casting to struct should work
+query T
+SELECT (count(42) export_state)::struct(count bigint);
+----
+{'count': 1}
+
+query T
+SELECT (count(*) export_state)::struct(count bigint);
+----
+{'count': 1}
+
 # EXPORT_STATAE on a window function is not supported
 statement error
 select avg(42) EXPORT_STATE over ();
@@ -165,4 +247,25 @@ SELECT g, finalize(avg_state)::integer FROM state ORDER BY g;
 
 query IIIIIII nosort res10
 SELECT g, finalize(avg_state)::integer FROM state_view ORDER BY g;
+----
+
+# count persistence
+statement ok
+CREATE TABLE state_count_persist AS SELECT g, count(*) EXPORT_STATE count_star_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
+
+statement ok
+CREATE VIEW state_count_view AS SELECT g, count(*) EXPORT_STATE count_star_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
+
+restart
+
+query IIIII nosort res10_count
+SELECT g, count(*), count(d) FROM dummy GROUP BY g ORDER BY g;
+----
+
+query IIIII nosort res10_count
+SELECT g, finalize(count_star_state), finalize(count_state) FROM state_count_persist ORDER BY g;
+----
+
+query IIIII nosort res10_count
+SELECT g, finalize(count_star_state), finalize(count_state) FROM state_count_view ORDER BY g;
 ----

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -159,6 +159,77 @@ query IIII nosort res6_count
 SELECT finalize(count(*) EXPORT_STATE), finalize(count(d) EXPORT_STATE) FROM (SELECT NULL::integer d, g FROM dummy);
 ----
 
+# sum tests
+query II nosort res0_sum
+SELECT sum(d) FROM dummy;
+----
+
+query II nosort res0_sum
+SELECT finalize(sum(d) EXPORT_STATE) FROM dummy;
+----
+
+query III nosort res1_sum
+SELECT g, sum(d) FROM dummy GROUP BY g ORDER BY g;
+----
+
+query III nosort res1_sum
+SELECT g, finalize(sum(d) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
+----
+
+statement ok
+CREATE TABLE state_sum AS SELECT g, sum(d) EXPORT_STATE sum_state FROM dummy GROUP BY g ORDER BY g;
+
+query III nosort res1_sum
+SELECT g, finalize(sum_state) FROM state_sum ORDER BY g;
+----
+
+query II nosort res3_sum
+SELECT g, sum(d)*2 combined_sum FROM dummy GROUP BY g ORDER BY g;
+----
+
+query II nosort res3_sum
+select g, finalize(combine(sum(d) EXPORT_STATE, sum_state)) combined_sum from dummy join state_sum using (g) group by g, sum_state ORDER BY g;
+----
+
+statement ok
+CREATE TABLE state2_sum AS SELECT g, sum(d) EXPORT_STATE sum_state FROM dummy WHERE g < 5 GROUP BY g ORDER BY g;
+
+query II rowsort res3_sum
+select g, finalize(sum_state) * 2 combined_sum from (select g, sum(d) EXPORT_STATE sum_state from dummy where g >= 5 GROUP BY g union all SELECT * FROM state2_sum) ORDER BY g;
+----
+
+query II rowsort res3_sum
+with groups as (select distinct g from dummy)
+select g, FINALIZE(COMBINE(sum_state, sum_state2)) * 2 from groups left join state2_sum using(g) left join (select g, sum(d) EXPORT_STATE sum_state2 from dummy where g >= 5 GROUP BY g) using (g);
+----
+
+# sum empty groups
+query II nosort res4_sum
+SELECT sum(d) FROM dummy WHERE FALSE;
+----
+
+query II nosort res4_sum
+SELECT finalize(sum(d) EXPORT_STATE) FROM dummy WHERE FALSE;
+----
+
+# sum only null scanned
+query II nosort res5_sum
+SELECT sum(d) FROM (SELECT NULL::integer d);
+----
+
+query II nosort res5_sum
+SELECT finalize(sum(d) EXPORT_STATE) FROM (SELECT NULL::integer d);
+----
+
+# sum only null scanned, but grouped
+query II nosort res6_sum
+SELECT sum(d) FROM (SELECT NULL::integer d, g FROM dummy);
+----
+
+query II nosort res6_sum
+SELECT finalize(sum(d) EXPORT_STATE) FROM (SELECT NULL::integer d, g FROM dummy);
+----
+
 # more aggregates
 
 query IIIIIII nosort res8
@@ -215,6 +286,16 @@ SELECT (count(*) export_state)::struct(count bigint);
 ----
 {'count': 1}
 
+query T
+SELECT (sum(42) export_state)::struct(isset boolean, "value" bigint);
+----
+{'isset': true, 'value': 42}
+
+query T
+SELECT (sum(100) export_state)::struct(isset boolean, "value" hugeint);
+----
+{'isset': true, 'value': 100}
+
 # EXPORT_STATAE on a window function is not supported
 statement error
 select avg(42) EXPORT_STATE over ();
@@ -268,4 +349,25 @@ SELECT g, finalize(count_star_state), finalize(count_state) FROM state_count_per
 
 query IIIII nosort res10_count
 SELECT g, finalize(count_star_state), finalize(count_state) FROM state_count_view ORDER BY g;
+----
+
+# sum persistence
+statement ok
+CREATE TABLE state_sum_persist AS SELECT g, sum(d) EXPORT_STATE sum_state FROM dummy GROUP BY g ORDER BY g;
+
+statement ok
+CREATE VIEW state_sum_view AS SELECT g, sum(d) EXPORT_STATE sum_state FROM dummy GROUP BY g ORDER BY g;
+
+restart
+
+query III nosort res10_sum
+SELECT g, sum(d) FROM dummy GROUP BY g ORDER BY g;
+----
+
+query III nosort res10_sum
+SELECT g, finalize(sum_state) FROM state_sum_persist ORDER BY g;
+----
+
+query III nosort res10_sum
+SELECT g, finalize(sum_state) FROM state_sum_view ORDER BY g;
 ----


### PR DESCRIPTION
- Convert count() and count(*) from LEGACY_AGGREGATE_STATE to AGGREGATE_STATE
- Add CountState struct with int64_t count field
- Implement GetCountStateType() returning STRUCT(count BIGINT)
- Update all count operations to use CountState instead of int64_t
- Add SetStructStateExport() to both count() and count(*) functions
- Update test_aggregate_state_type.test to expect struct-based type
- Remove count tests from test_state_export_opaque.test
- Add comprehensive count tests to test_state_export_struct.test