### PR TITLE
Warnings as errors - extra validation

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -1065,7 +1065,10 @@
         "description": "Escalate all warnings to errors.",
         "type": "BOOLEAN",
         "scope": "global",
-        "default_value": "false"
+        "default_value": "false",
+        "on_callbacks": [
+            "set"
+        ]
     },
     {
         "name": "write_buffer_row_group_count",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1557,6 +1557,7 @@ struct WarningsAsErrorsSetting {
 	static constexpr const char *DefaultValue = "false";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::GLOBAL_ONLY;
 	static constexpr idx_t SettingIndex = 92;
+	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct WriteBufferRowGroupCountSetting {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -197,7 +197,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING_CALLBACK(ValidateExternalFileCacheSetting),
     DUCKDB_SETTING(VariantMinimumShreddingSizeSetting),
     DUCKDB_SETTING(WalAutocheckpointEntriesSetting),
-    DUCKDB_SETTING(WarningsAsErrorsSetting),
+    DUCKDB_SETTING_CALLBACK(WarningsAsErrorsSetting),
     DUCKDB_SETTING(WriteBufferRowGroupCountSetting),
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1630,7 +1630,12 @@ Value ThreadsSetting::GetSetting(const ClientContext &context) {
 //===----------------------------------------------------------------------===//
 
 void WarningsAsErrorsSetting::OnSet(SettingCallbackInfo &info, Value &input) {
-	throw InvalidInputException("Placeholder error message for 'WarningsAsErrorsSetting'");
+	auto &log_manager = LogManager::Get(*info.context);
+	if (input == Value(true) && !log_manager.GetConfig().enabled) {
+		throw Exception(
+		    ExceptionType::SETTINGS,
+		    "Can not set 'warnings_as_errors=true'; no logger is available. To solve, run: 'SET enable_logging=true;'");
+	}
 }
 
 } // namespace duckdb

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1625,4 +1625,12 @@ Value ThreadsSetting::GetSetting(const ClientContext &context) {
 	return Value::BIGINT(NumericCast<int64_t>(config.options.maximum_threads));
 }
 
+//===----------------------------------------------------------------------===//
+// Warnings As Errors
+//===----------------------------------------------------------------------===//
+
+void WarningsAsErrorsSetting::OnSet(SettingCallbackInfo &info, Value &input) {
+	throw InvalidInputException("Placeholder error message for 'WarningsAsErrorsSetting'");
+}
+
 } // namespace duckdb

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -29,8 +29,8 @@ BindResult ExpressionBinder::TryBindLambdaOrJson(FunctionExpression &function, i
 	    setting == LambdaSyntax::DISABLE_SINGLE_ARROW && syntax_type == LambdaSyntaxType::SINGLE_ARROW;
 	bool warn_deprecated_syntax = setting == LambdaSyntax::DEFAULT && syntax_type == LambdaSyntaxType::SINGLE_ARROW;
 	const string msg = "Deprecated lambda arrow (->) detected. Please transition to the new lambda syntax, "
-	                   "i.e.., lambda x, i: x + i, before DuckDB's next release. \n"
-	                   "Use SET lambda_syntax='ENABLE_SINGLE_ARROW' to revert to the deprecated behavior. \n"
+	                   "i.e.., lambda x, i: x + i, before DuckDB's next release.\n"
+	                   "Use SET lambda_syntax='ENABLE_SINGLE_ARROW' to revert to the deprecated behavior.\n"
 	                   "For more information, see https://duckdb.org/docs/stable/sql/functions/lambda.html.";
 
 	BindResult lambda_bind_result;

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -194,6 +194,7 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "progress_bar_time",
 	    "index_scan_max_count",
 	    "profiling_mode",
+	    "warnings_as_errors",      // requires logging to be enabled
 	    "block_allocator_memory"}; // cant reduce
 	return excluded_options.count(name) == 1;
 }

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -30,7 +30,8 @@
       "reason": "Logging setting doesn't survive restarts",
       "paths": [
         "test/sql/storage/compression/zstd/zstd_compression_ratio.test_slow",
-        "test/sql/logging/physical_operator_logging.test_slow"
+        "test/sql/logging/physical_operator_logging.test_slow",
+        "test/logging/warnings_as_errors.test"
       ]
     }
   ]

--- a/test/configs/wal_verification.json
+++ b/test/configs/wal_verification.json
@@ -35,6 +35,12 @@
       ]
     },
     {
+      "reason": "Logging setting doesn't survive restarts",
+      "paths": [
+        "test/logging/warnings_as_errors.test"
+      ]
+    },
+    {
       "reason": "FIXME: Unexpected (?) binder error.",
       "paths": [
         "test/fuzzer/pedro/index_generated_column.test",

--- a/test/logging/test_logging.cpp
+++ b/test/logging/test_logging.cpp
@@ -31,8 +31,7 @@ void LogFormatStringCustomType(SOURCE &src, FUN f) {
 	DUCKDB_LOG_INTERNAL(SOURCE, "custom_type", LOG_LEVEL, string("log-a-lot: 'string type with type'"))
 
 // Tests all Logger function entrypoints at the specified log level with the specified enabled/disabled loggers
-void test_logging(const string &minimum_level, const string &enabled_log_types, const string &disabled_log_types,
-                  bool warnings_as_errors = false) {
+void test_logging(const string &minimum_level, const string &enabled_log_types, const string &disabled_log_types) {
 	DuckDB db(nullptr);
 	Connection con(db);
 
@@ -50,9 +49,6 @@ void test_logging(const string &minimum_level, const string &enabled_log_types, 
 		REQUIRE_NO_FAIL(con.Query("set disabled_log_types='" + disabled_log_types + "';"));
 		REQUIRE_NO_FAIL(con.Query("set logging_mode='disable_selected';"));
 	}
-	if (warnings_as_errors) {
-		REQUIRE_NO_FAIL(con.Query("set warnings_as_errors=true;"));
-	}
 
 	bool level_only = (enabled_log_types.empty() && disabled_log_types.empty());
 	bool enabled_mode = !enabled_log_types.empty();
@@ -62,9 +58,7 @@ void test_logging(const string &minimum_level, const string &enabled_log_types, 
 	TEST_ALL_LOG_MACROS(LogLevel::LOG_TRACE, *db.instance, DatabaseInstance);
 	TEST_ALL_LOG_MACROS(LogLevel::LOG_DEBUG, *db.instance, DatabaseInstance);
 	TEST_ALL_LOG_MACROS(LogLevel::LOG_INFO, *db.instance, DatabaseInstance);
-	if (!warnings_as_errors) {
-		TEST_ALL_LOG_MACROS(LogLevel::LOG_WARNING, *db.instance, DatabaseInstance);
-	}
+	TEST_ALL_LOG_MACROS(LogLevel::LOG_WARNING, *db.instance, DatabaseInstance);
 	TEST_ALL_LOG_MACROS(LogLevel::LOG_ERROR, *db.instance, DatabaseInstance);
 	TEST_ALL_LOG_MACROS(LogLevel::LOG_FATAL, *db.instance, DatabaseInstance);
 
@@ -72,9 +66,7 @@ void test_logging(const string &minimum_level, const string &enabled_log_types, 
 	TEST_ALL_LOG_MACROS(LogLevel::LOG_TRACE, *con.context, ClientContext);
 	TEST_ALL_LOG_MACROS(LogLevel::LOG_DEBUG, *con.context, ClientContext);
 	TEST_ALL_LOG_MACROS(LogLevel::LOG_INFO, *con.context, ClientContext);
-	if (!warnings_as_errors) {
-		TEST_ALL_LOG_MACROS(LogLevel::LOG_WARNING, *con.context, ClientContext);
-	}
+	TEST_ALL_LOG_MACROS(LogLevel::LOG_WARNING, *con.context, ClientContext);
 	TEST_ALL_LOG_MACROS(LogLevel::LOG_ERROR, *con.context, ClientContext);
 	TEST_ALL_LOG_MACROS(LogLevel::LOG_FATAL, *con.context, ClientContext);
 
@@ -87,10 +79,6 @@ void test_logging(const string &minimum_level, const string &enabled_log_types, 
 
 	for (idx_t i = 0; i < num_runs; i++) {
 		for (idx_t j = minimum_level_index; j < num_log_levels; j++) {
-			if (warnings_as_errors && log_levels[j] == "WARNING") {
-				// skip
-				j++;
-			}
 			if (level_only ||
 			    (enabled_mode && enabled_log_types.find(default_types[i].ToString()) != enabled_log_types.npos) ||
 			    (disabled_mode && disabled_log_types.find(default_types[i].ToString()) == enabled_log_types.npos)) {
@@ -140,22 +128,6 @@ TEST_CASE("Test logging", "[logging][.]") {
 		test_logging(level, "custom_type", "");
 		test_logging(level, "", "default");
 		test_logging(level, "", "custom_type,default");
-	}
-}
-
-// Tests non-warning logging with 'warnings_as_errors = True'
-// Note: warning logging with 'warnings_as_errors = True' is tested in test_warning.py
-TEST_CASE("Test logging warnings_as_errors", "[logging][.]") {
-	duckdb::vector<string> log_levels = {"TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "FATAL"};
-	for (const auto &level : log_levels) {
-		// Test in regular mode without explicitly enabled or disabled loggers
-		test_logging(level, "", "", true);
-
-		// Test various combinations of enabled and disabled loggers
-		test_logging(level, "custom_type,default", "", true);
-		test_logging(level, "custom_type", "", true);
-		test_logging(level, "", "default", true);
-		test_logging(level, "", "custom_type,default", true);
 	}
 }
 

--- a/test/logging/warnings_as_errors.test
+++ b/test/logging/warnings_as_errors.test
@@ -1,0 +1,28 @@
+# name: test/logging/warnings_as_errors.test
+# description: Test warnings as errors setting
+# group: [logging]
+
+statement ok
+SET warnings_as_errors = False;
+
+# query producing warning
+statement ok
+SELECT list_transform([1], x -> x + 1);
+
+statement error
+SET warnings_as_errors = True;
+----
+Settings Error: Can not set 'warnings_as_errors=true'; no logger is available. To solve, run: 'SET enable_logging=true;'
+
+statement ok
+SET enable_logging=true;
+
+statement ok
+SET warnings_as_errors = True;
+
+statement error
+SELECT list_transform([1], x -> x + 1);
+----
+Invalid Input Error: Deprecated lambda arrow (->) detected. Please transition to the new lambda syntax, i.e.., lambda x, i: x + i, before DuckDB's next release.
+Use SET lambda_syntax='ENABLE_SINGLE_ARROW' to revert to the deprecated behavior.
+For more information, see https://duckdb.org/docs/stable/sql/functions/lambda.html


### PR DESCRIPTION
contains fix for: https://github.com/duckdblabs/duckdb-internal/issues/7438

### background (situation without this PR)
The test runner by default has no active logger.
If tests run with `warnings_as_errors=true` warning are not elevated to errors, because there is no logger.
Therefore, tests that produce warnings still pass.

### changes with this PR
- to prevent `warnings_as_errors` being "ineffective". We raise the following error if the user sets `warning_as_errors=true` without a logger being present.
  - "Settings Error: Can not set 'warnings_as_errors=true'; no logger is available. To solve, run: 'SET enable_logging=true;'"
- added separate test file to test `warnings_as_errors`: `test/logging/warnings_as_errors.test`
   - test `test/logging/test_logging.cpp` has been moved back to the version it had prior to the introduction of `setting warning_as_errors`
