### PR TITLE
Support long paths on Windows

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -96,14 +96,70 @@ bool LocalFileSystem::IsPipe(const string &filename, optional_ptr<FileOpener> op
 }
 
 #else
+
+// Maximum length of a path that does not require a long path prefix or
+// LongPathsEnabled setting along with longPathAware manifest.
+// For files the limit is 260 - 1 characters.
+// Directories additionally must be able to create 8+3 files inside them.
+// The limit applies to fully resolved absolute paths.
+static const size_t WINDOWS_MAX_SHORT_PATH = 247;
+static const size_t WINDOWS_MAX_LONG_PATH = 32000;
+static const std::wstring WINDOWS_LOCAL_LONG_PATH_PREFIX = L"\\\\?\\";
+static const std::wstring WINDOWS_UNC_LONG_PATH_PREFIX = L"\\\\?\\UNC\\";
+
 static std::wstring ConvertPathToUnicode(const string &path) {
 	return WindowsUtil::UTF8ToUnicode(path.c_str());
 }
 
+static std::wstring ConvertPathToNormalizedAbsolute(const std::wstring &path) {
+	// len includes NULL-terminator
+	DWORD len = GetFullPathNameW(path.c_str(), 0, nullptr, nullptr);
+	if (len == 0) {
+		string error = LocalFileSystem::GetLastErrorAsString();
+		string utf8_path = WindowsUtil::UnicodeToUTF8(path.c_str());
+		throw IOException("Failed to get length for normalized path \"%s\": %s", utf8_path, error);
+	}
+
+	std::vector<wchar_t> buf;
+	buf.resize(len);
+
+	// written does NOT include NULL-terminator
+	DWORD written = GetFullPathNameW(path.c_str(), len, buf.data(), nullptr);
+	if (written == 0) {
+		string error = LocalFileSystem::GetLastErrorAsString();
+		string utf8_path = WindowsUtil::UnicodeToUTF8(path.c_str());
+		throw IOException("Failed to normalize path \"%s\", length: %lu: %s", utf8_path, len, error);
+	}
+
+	return std::wstring(buf.data(), written);
+}
+
 static std::wstring NormalizePathAndConvertToUnicode(FileSystem &fs, const string &path,
                                                      optional_ptr<FileOpener> opener) {
-	auto normalized_path = fs.ExpandPath(path, opener);
-	return ConvertPathToUnicode(normalized_path);
+	string normalized_path = fs.ExpandPath(path, opener);
+	std::wstring unicode_path = ConvertPathToUnicode(normalized_path);
+
+	// We need to get absolute path to check the length. Normalizing it (removing "." and "..",
+	// flipping forward slashes) is only required if the path is long.
+	// We are doing it for all paths to not perform current working dir resolving twice.
+	std::wstring abs_path = ConvertPathToNormalizedAbsolute(unicode_path);
+
+	if (abs_path.length() <= WINDOWS_MAX_SHORT_PATH || abs_path.find(WINDOWS_LOCAL_LONG_PATH_PREFIX) == 0 ||
+	    abs_path.find(WINDOWS_UNC_LONG_PATH_PREFIX) == 0) {
+		return abs_path;
+	}
+
+	if (abs_path.length() > WINDOWS_MAX_LONG_PATH) {
+		string resolved_path = WindowsUtil::UnicodeToUTF8(abs_path.c_str());
+		throw IOException("Path is longer than Windows MAX_PATH, length: %zu, beginning: %s[...]", abs_path.length(),
+		                  resolved_path.substr(0, 100));
+	}
+
+	if (abs_path.find(L"\\\\") == 0) {
+		return WINDOWS_UNC_LONG_PATH_PREFIX + abs_path;
+	}
+
+	return WINDOWS_LOCAL_LONG_PATH_PREFIX + abs_path;
 }
 
 bool LocalFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
@@ -837,9 +893,6 @@ string LocalFileSystem::MakePathAbsolute(const string &path_p, optional_ptr<File
 
 constexpr char PIPE_PREFIX[] = "\\\\.\\pipe\\";
 
-static const std::wstring WINDOWS_LOCAL_LONG_PATH_PREFIX = L"\\\\?\\";
-static const std::wstring WINDOWS_UNC_LONG_PATH_PREFIX = L"\\\\?\\UNC\\";
-
 // Returns the last Win32 error, in string format. Returns an empty string if there is no error.
 std::string LocalFileSystem::GetLastErrorAsString() {
 	// Get the error message, if any.
@@ -1104,7 +1157,8 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 		if (!extended_error.empty()) {
 			extended_error = "\n" + extended_error;
 		}
-		throw IOException("Cannot open file \"%s\": %s%s", path.c_str(), error, extended_error);
+		auto abs_path = WindowsUtil::UnicodeToUTF8(unicode_path.c_str());
+		throw IOException("Cannot open file \"%s\": %s%s", abs_path, error, extended_error);
 	}
 	auto handle = make_uniq<WindowsFileHandle>(*this, path.c_str(), hFile, flags);
 	if (flags.OpenForAppending()) {
@@ -1267,7 +1321,8 @@ void LocalFileSystem::CreateDirectory(const string &directory, optional_ptr<File
 	auto unicode_path = NormalizePathAndConvertToUnicode(*this, directory, opener);
 	if (directory.empty() || !CreateDirectoryW(unicode_path.c_str(), NULL) || !DirectoryExists(directory)) {
 		auto error = LocalFileSystem::GetLastErrorAsString();
-		throw IOException("Failed to create directory \"%s\": %s", directory.c_str(), error);
+		auto abs_path = WindowsUtil::UnicodeToUTF8(unicode_path.c_str());
+		throw IOException("Failed to create directory \"%s\": %s", abs_path, error);
 	}
 }
 
@@ -1282,7 +1337,8 @@ static void DeleteDirectoryRecursive(FileSystem &fs, string directory, optional_
 	auto unicode_path = NormalizePathAndConvertToUnicode(fs, directory, opener);
 	if (!RemoveDirectoryW(unicode_path.c_str())) {
 		auto error = LocalFileSystem::GetLastErrorAsString();
-		throw IOException("Failed to delete directory \"%s\": %s", directory, error);
+		auto abs_path = WindowsUtil::UnicodeToUTF8(unicode_path.c_str());
+		throw IOException("Failed to delete directory \"%s\": %s", abs_path, error);
 	}
 }
 
@@ -1300,7 +1356,8 @@ void LocalFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener
 	auto unicode_path = NormalizePathAndConvertToUnicode(*this, filename, opener);
 	if (!DeleteFileW(unicode_path.c_str())) {
 		auto error = LocalFileSystem::GetLastErrorAsString();
-		throw IOException("Failed to delete file \"%s\": %s", filename, error);
+		auto abs_path = WindowsUtil::UnicodeToUTF8(unicode_path.c_str());
+		throw IOException("Failed to delete file \"%s\": %s", abs_path, error);
 	}
 }
 

--- a/src/common/windows_util.cpp
+++ b/src/common/windows_util.cpp
@@ -16,7 +16,11 @@ std::wstring WindowsUtil::UTF8ToUnicode(const char *input) {
 	if (result_size == 0) {
 		throw IOException("Failure in MultiByteToWideChar");
 	}
-	return std::wstring(buffer.get(), result_size);
+	// If cbMultiByte parameter is -1, the function processes the entire input string,
+	// including the terminating null character. Therefore, the resulting Unicode string
+	// has a terminating null character, and the length returned by the function
+	// includes this character.
+	return std::wstring(buffer.get(), result_size - 1);
 }
 
 static string WideCharToMultiByteWrapper(LPCWSTR input, uint32_t code_page) {

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -398,7 +398,9 @@ void TestCreateSymlink(const string &source, const string &target, bool director
 	}
 #else
 	// windows - use native APIs
-	if (!CreateSymbolicLinkA(source.c_str(), target.c_str(), directory_link ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0)) {
+	if (!CreateSymbolicLinkA(source.c_str(), target.c_str(),
+	                         (directory_link ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0) |
+	                             SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE)) {
 		std::cerr << "Error: " << GetLastError() << std::endl;
 		FAIL();
 	}
@@ -982,5 +984,133 @@ TEST_CASE("Check path canonicalization on Windows", "[file_system]") {
 	auto canonical_work_dir = fs->CanonicalizePath(fs->GetWorkingDirectory());
 	// check that long path prefix "\\?\" or "\\?\UNC\" is not present
 	REQUIRE(!StringUtil::StartsWith(canonical_work_dir, "\\\\"));
+}
+
+char GenChar(idx_t i) {
+	char idx = static_cast<char>(i % 26);
+	return idx + 'a';
+}
+
+string GenPath(idx_t len) {
+	string res;
+	idx_t i = 0;
+	while (res.length() < len) {
+		if (i > 0 && i % 16 == 0) {
+			res.push_back('\\');
+		} else {
+			res.push_back(GenChar(i));
+		}
+		i++;
+	}
+	REQUIRE(res.length() == len);
+	return res;
+}
+
+string GenString(idx_t len) {
+	string res;
+	idx_t i = 0;
+	while (res.length() < len) {
+		res.push_back(GenChar(i));
+		i++;
+	}
+	REQUIRE(res.length() == len);
+	return res;
+}
+
+TEST_CASE("Test long paths on Windows", "[file_system]") {
+	idx_t max_dir_path_len = 247;
+	idx_t work_dir_path_len = 240;
+
+	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
+	string cwd = fs->GetWorkingDirectory();
+	string test_dir = TestDirectoryPath();
+	test_dir = fs->JoinPath(test_dir, "test_long_path");
+	test_dir = fs->JoinPath(cwd, test_dir);
+	REQUIRE(test_dir.length() < max_dir_path_len - 1);
+	fs->CreateDirectory(test_dir);
+
+	string work_dir = fs->JoinPath(test_dir, GenPath(work_dir_path_len - test_dir.length() - 1));
+	REQUIRE(work_dir.length() == work_dir_path_len);
+	fs->CreateDirectoriesRecursive(work_dir);
+	REQUIRE(fs->DirectoryExists(work_dir));
+
+	std::vector<char> test_buf = {'f', 'o', 'o'};
+
+	// create/remove files
+	for (idx_t i = 1; i < 32; i++) {
+		string name = "f_" + GenString(i);
+		string path = fs->JoinPath(work_dir, name);
+		auto fd = fs->OpenFile(path, FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileFlags::FILE_FLAGS_WRITE);
+		fd->Write(test_buf.data(), test_buf.size());
+		fd->Close();
+		REQUIRE(fs->FileExists(path));
+		fs->RemoveFile(path);
+		REQUIRE(!fs->FileExists(path));
+	}
+
+	// create/remove directories
+	for (idx_t i = 1; i < 32; i++) {
+		string name = "d_" + GenString(i);
+		string path = fs->JoinPath(work_dir, name);
+		fs->CreateDirectory(path);
+		REQUIRE(fs->DirectoryExists(path));
+		fs->RemoveDirectory(path);
+		REQUIRE(!fs->DirectoryExists(path));
+	}
+
+	// move file
+	string src_path = fs->JoinPath(work_dir, "move_src_" + GenString(32));
+	{
+		auto fd = fs->OpenFile(src_path, FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileFlags::FILE_FLAGS_WRITE);
+		fd->Write(test_buf.data(), test_buf.size());
+		fd->Close();
+	}
+	REQUIRE(fs->FileExists(src_path));
+	string dest_path = fs->JoinPath(work_dir, "move_dest_" + GenString(32));
+	fs->MoveFile(src_path, dest_path);
+	REQUIRE(!fs->FileExists(src_path));
+	REQUIRE(fs->FileExists(dest_path));
+	{
+		auto fd = fs->OpenFile(dest_path, FileFlags::FILE_FLAGS_READ);
+		std::vector<char> buf;
+		buf.resize(3);
+		auto read = fd->Read(buf.data(), buf.size());
+		fd->Close();
+		REQUIRE(read == 3);
+		REQUIRE(std::string(buf.data(), buf.size()) == "foo");
+	}
+
+	// non-clean paths
+	{
+		string long_dir = fs->JoinPath(work_dir, "long_dir_" + GenString(32));
+		fs->CreateDirectory(long_dir);
+		REQUIRE(fs->DirectoryExists(long_dir));
+		string dir1 = long_dir + "/dir1";
+		string dir2 = long_dir + "/dir1/.//..\\dir2";
+		string dir2_clean = fs->JoinPath(long_dir, "dir2");
+		string file1 = dir2 + "/file1";
+		fs->CreateDirectory(dir1);
+		REQUIRE(fs->DirectoryExists(dir1));
+		fs->CreateDirectory(dir2);
+		REQUIRE(fs->DirectoryExists(dir2));
+		REQUIRE(fs->DirectoryExists(dir2_clean));
+		auto fd = fs->OpenFile(file1, FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileFlags::FILE_FLAGS_WRITE);
+		fd->Write(test_buf.data(), test_buf.size());
+		fd->Close();
+		REQUIRE(fs->FileExists(file1));
+	}
+
+	// pre-existing prefix
+	{
+		string name = "prefix_dir_" + GenString(32);
+		string path = fs->JoinPath(work_dir, name);
+		string prefixed = "\\\\?\\" + path;
+		fs->CreateDirectory(prefixed);
+		REQUIRE(fs->DirectoryExists(prefixed));
+		REQUIRE(fs->DirectoryExists(path));
+	}
+
+	// cleaning up, as not all tools can remove long dirs
+	fs->RemoveDirectory(work_dir);
 }
 #endif // _WIN32


### PR DESCRIPTION
Windows file system has a [maximum path length limitation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry).

One way to work with longer paths on Windows is to prepend a special prefix to them before passing them to FS system calls. This approach is used in other runtimes/tools like [OpenJDK](https://github.com/openjdk/jdk/blob/e676c9de3da3b820081cde1b11c0df3129787130/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java#L197-L208) and [Git](https://github.com/git-for-windows/git/commit/5eb8d3a8aa610e929724b6a29306307f5def860d).

This PR implements the prepending of the long path prefix for the Windows part of the `LocalFileSystem`.

The change is potentially breaking: while the prefix is only prepended to long path (that are not supported without this PR), the normalization (that is required to measure the path length) is performed for all paths that are passed to Windows FS.

For example, if user was passing the short path like this:

```
foo/./bar\..\baz.parquet
```

And it was passed to `CreateFileW` as is, now it would be normalized to something like the following, before passing it to `CreateFileW`:

```
C:\current\working\dir\foo\baz.parquet
```

It is not clear whether such normalization can break some legitimate existing usage of the `LocalFileSystem` API. It is possible to check the length for the majority of the incoming paths (paths with `.` and `..` cannot be measured) without doing normalization. It is proposed to do normalization for all paths to minimize the number of calls to current directory path. Current directory is required to get the absolute path (even without normalization). Because it is global and can be changed from other threads - the idea is to minimize the number of calls to it (actually this point can be improved in other parts of `LocalFileSystem` too).

Thus the PR is suggested for inclusion into future 1.6 release.

Additionally the PR fixes the double-NULL-temination in `WindowsUtil::UTF8ToUnicode` and changes the Windows FS error reporting to include the resolved (absolute and normalized) path into error messages instead of the original one.

Testing: new test to check long paths is added that runs only on Windows

Fixes: #20384