### PR TITLE
Convert first, last, and any_value aggregates to struct-based state

### DIFF
--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -165,6 +165,24 @@ struct StoreFieldOp {
 	}
 };
 
+// Specialization for string_t to handle big strings correctly
+// For big strings (>12 bytes), string_t contains a pointer to the actual data.
+// We need to copy the actual string data to the result vector's string heap,
+// not just copy the pointer (which would point to aggregate allocator memory).
+template <>
+void StoreFieldOp::Operation<string_t>(Vector &struct_vec, idx_t field_idx, idx_t count, data_ptr_t *sources,
+                                       idx_t field_offset) {
+	auto &child = *StructVector::GetEntries(struct_vec)[field_idx];
+	auto child_data = FlatVector::GetData<string_t>(child);
+
+	for (idx_t row = 0; row < count; row++) {
+		auto src = sources[row] + field_offset;
+		string_t source_str = *reinterpret_cast<string_t *>(src);
+		// AddStringOrBlob handles both inlined and non-inlined strings correctly
+		child_data[row] = StringVector::AddStringOrBlob(child, source_str);
+	}
+}
+
 struct CopyFromInputFieldOp {
 	template <class T>
 	static void Operation(Vector &input_vec, Vector &result_vec, idx_t field_idx, const SelectionVector &sel,
@@ -214,6 +232,23 @@ struct StoreFieldForSelectedRowsOp {
 		}
 	}
 };
+
+// Specialization for string_t to handle big strings correctly
+// Same fix as StoreFieldOp - copy actual string data, not just pointers
+template <>
+void StoreFieldForSelectedRowsOp::Operation<string_t>(const AggregateStateLayout &layout, Vector &result,
+                                                      idx_t field_idx, const SelectionVector &sel, idx_t count,
+                                                      data_ptr_t base_ptr, idx_t field_offset) {
+	auto &child = *StructVector::GetEntries(result)[field_idx];
+	auto child_data = FlatVector::GetData<string_t>(child);
+
+	for (idx_t i = 0; i < count; i++) {
+		idx_t row = sel.get_index(i);
+		auto src = base_ptr + i * layout.aligned_state_size + field_offset;
+		string_t source_str = *reinterpret_cast<string_t *>(src);
+		child_data[row] = StringVector::AddStringOrBlob(child, source_str);
+	}
+}
 
 struct CombineState : public FunctionLocalState {
 	idx_t state_size;

--- a/test/sql/aggregate/aggregates/test_aggregate_state_type.test
+++ b/test/sql/aggregate/aggregates/test_aggregate_state_type.test
@@ -126,3 +126,39 @@ query T
 SELECT (count(*) export_state)::struct(count bigint);
 ----
 {'count': 1}
+
+# first() now has the new get_state_type callback
+query T
+SELECT typeof(first(42) EXPORT_STATE) = 'AGGREGATE_STATE<first(INTEGER)::INTEGER, STRUCT("value" INTEGER, is_set BOOLEAN, is_null BOOLEAN)>';
+----
+true
+
+# last() now has the new get_state_type callback
+query T
+SELECT typeof(last(42) EXPORT_STATE) = 'AGGREGATE_STATE<last(INTEGER)::INTEGER, STRUCT("value" INTEGER, is_set BOOLEAN, is_null BOOLEAN)>';
+----
+true
+
+# any_value() now has the new get_state_type callback
+query T
+SELECT typeof(any_value(42) EXPORT_STATE) = 'AGGREGATE_STATE<any_value(INTEGER)::INTEGER, STRUCT("value" INTEGER, is_set BOOLEAN, is_null BOOLEAN)>';
+----
+true
+
+# Casting first state to struct should work
+query T
+SELECT (first(42) export_state)::struct("value" integer, is_set boolean, is_null boolean);
+----
+{'value': 42, 'is_set': true, 'is_null': false}
+
+# Casting last state to struct should work
+query T
+SELECT (last(42) export_state)::struct("value" integer, is_set boolean, is_null boolean);
+----
+{'value': 42, 'is_set': true, 'is_null': false}
+
+# Casting any_value state to struct should work
+query T
+SELECT (any_value(42) export_state)::struct("value" integer, is_set boolean, is_null boolean);
+----
+{'value': 42, 'is_set': true, 'is_null': false}

--- a/test/sql/aggregate/aggregates/test_state_export_opaque.test
+++ b/test/sql/aggregate/aggregates/test_state_export_opaque.test
@@ -75,12 +75,12 @@ select FINALIZE(argmin(a,b) EXPORT_STATE), FINALIZE(argmax(a,b) EXPORT_STATE) fr
 
 mode unskip
 
-query IIIIIII nosort res8
-SELECT g, first(d), last(d), product(d), bit_xor(d), bool_and(d > 5) FROM dummy GROUP BY g ORDER BY g;
+query IIIIII nosort res8
+SELECT g, product(d), bit_xor(d), bool_and(d > 5) FROM dummy GROUP BY g ORDER BY g;
 ----
 
-query IIIIIII nosort res8
-SELECT g, FINALIZE(first(d) EXPORT_STATE), FINALIZE(last(d) EXPORT_STATE), FINALIZE(product(d) EXPORT_STATE), FINALIZE(bit_xor(d) EXPORT_STATE), FINALIZE(bool_and(d > 5) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
+query IIIIII nosort res8
+SELECT g, FINALIZE(product(d) EXPORT_STATE), FINALIZE(bit_xor(d) EXPORT_STATE), FINALIZE(bool_and(d > 5) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
 ----
 
 query II nosort res9

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -188,3 +188,140 @@ SELECT g, finalize(avg_state)::integer, finalize(count_state), finalize(first_st
 query IIIIIIIIIIIII nosort res10
 SELECT g, finalize(avg_state)::integer, finalize(count_state), finalize(first_state), finalize(last_state) FROM state_view ORDER BY g;
 ----
+
+# Tests with long strings (>12 bytes, non-inlined) to verify proper string data copying
+# This verifies that StoreFieldOp and StoreFieldForSelectedRowsOp correctly copy
+# string data instead of just pointers when using EXPORT_STATE with big strings
+
+statement ok
+CREATE TABLE big_string_test AS 
+SELECT 
+    'group_' || (range % 3)::VARCHAR as g,
+    'This is a very long string that exceeds the 12 byte inlining threshold for string_t' || range::VARCHAR as big_str,
+    range as r
+FROM range(20);
+
+# Test 1: Basic export and finalize with big strings
+query TTT nosort
+SELECT 
+    g,
+    first(big_str) as normal_first,
+    finalize(first(big_str) EXPORT_STATE) as exported_first
+FROM big_string_test 
+GROUP BY g 
+ORDER BY g;
+----
+group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0
+group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1
+group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2
+
+# Test 2: Store state and finalize later
+statement ok
+CREATE TABLE stored_big_string_state AS 
+SELECT 
+    g,
+    first(big_str) EXPORT_STATE as first_state
+FROM big_string_test 
+GROUP BY g;
+
+query TTT nosort
+SELECT 
+    g,
+    first(big_str) as expected_value,
+    finalize(first_state) as finalized_from_stored
+FROM big_string_test 
+GROUP BY g
+ORDER BY g;
+----
+group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0
+group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1
+group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2
+
+# Test 3: Combine states with big strings (tests StoreFieldForSelectedRowsOp)
+WITH state1 AS (
+    SELECT g, first(big_str) EXPORT_STATE as state1
+    FROM big_string_test 
+    WHERE r < 10
+    GROUP BY g
+),
+state2 AS (
+    SELECT g, first(big_str) EXPORT_STATE as state2
+    FROM big_string_test 
+    WHERE r >= 10
+    GROUP BY g
+)
+query T nosort
+SELECT 
+    COALESCE(s1.g, s2.g) as g,
+    finalize(COMBINE(s1.state1, s2.state2)) as combined_and_finalized
+FROM state1 s1
+FULL OUTER JOIN state2 s2 ON s1.g = s2.g
+ORDER BY g;
+----
+group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0
+group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1
+group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2
+
+# Test 4: Store combined state and finalize
+statement ok
+CREATE TABLE combined_big_string_state AS
+WITH state1 AS (
+    SELECT g, first(big_str) EXPORT_STATE as state1
+    FROM big_string_test 
+    WHERE r < 10
+    GROUP BY g
+),
+state2 AS (
+    SELECT g, first(big_str) EXPORT_STATE as state2
+    FROM big_string_test 
+    WHERE r >= 10
+    GROUP BY g
+)
+SELECT 
+    COALESCE(s1.g, s2.g) as g,
+    COMBINE(s1.state1, s2.state2) as combined_state
+FROM state1 s1
+FULL OUTER JOIN state2 s2 ON s1.g = s2.g;
+
+query T nosort
+SELECT 
+    g,
+    finalize(combined_state) as finalized_combined
+FROM combined_big_string_state
+ORDER BY g;
+----
+group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0
+group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1
+group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2
+
+# Test 5: Multiple combine operations with big strings
+WITH state1 AS (
+    SELECT g, first(big_str) EXPORT_STATE as state1
+    FROM big_string_test 
+    WHERE r < 5
+    GROUP BY g
+),
+state2 AS (
+    SELECT g, first(big_str) EXPORT_STATE as state2
+    FROM big_string_test 
+    WHERE r >= 5 AND r < 10
+    GROUP BY g
+),
+state3 AS (
+    SELECT g, first(big_str) EXPORT_STATE as state3
+    FROM big_string_test 
+    WHERE r >= 10
+    GROUP BY g
+)
+query T nosort
+SELECT 
+    COALESCE(COALESCE(s1.g, s2.g), s3.g) as g,
+    finalize(COMBINE(COMBINE(s1.state1, s2.state2), s3.state3)) as triple_combined
+FROM state1 s1
+FULL OUTER JOIN state2 s2 ON s1.g = s2.g
+FULL OUTER JOIN state3 s3 ON COALESCE(s1.g, s2.g) = s3.g
+ORDER BY g;
+----
+group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0
+group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1
+group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -224,18 +224,28 @@ SELECT
 FROM big_string_test 
 GROUP BY g;
 
-query TTT nosort
+query TT nosort
 SELECT 
     g,
-    first(big_str) as expected_value,
-    finalize(first_state) as finalized_from_stored
+    first(big_str) as expected_value
 FROM big_string_test 
 GROUP BY g
 ORDER BY g;
 ----
-group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0
-group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1
-group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2
+group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0
+group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1
+group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2
+
+query TT nosort
+SELECT 
+    g,
+    finalize(first_state) as finalized_from_stored
+FROM stored_big_string_state
+ORDER BY g;
+----
+group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0
+group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1
+group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2
 
 # Test 3: Combine states with big strings (tests StoreFieldForSelectedRowsOp)
 WITH state1 AS (

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -248,6 +248,7 @@ group_1	This is a very long string that exceeds the 12 byte inlining threshold f
 group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2
 
 # Test 3: Combine states with big strings (tests StoreFieldForSelectedRowsOp)
+query TT nosort
 WITH state1 AS (
     SELECT g, first(big_str) EXPORT_STATE as state1
     FROM big_string_test 
@@ -260,7 +261,6 @@ state2 AS (
     WHERE r >= 10
     GROUP BY g
 )
-query T nosort
 SELECT 
     COALESCE(s1.g, s2.g) as g,
     finalize(COMBINE(s1.state1, s2.state2)) as combined_and_finalized
@@ -268,9 +268,9 @@ FROM state1 s1
 FULL OUTER JOIN state2 s2 ON s1.g = s2.g
 ORDER BY g;
 ----
-group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0
-group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1
-group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2
+group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t12
+group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t10
+group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t11
 
 # Test 4: Store combined state and finalize
 statement ok
@@ -293,18 +293,19 @@ SELECT
 FROM state1 s1
 FULL OUTER JOIN state2 s2 ON s1.g = s2.g;
 
-query T nosort
+query TT nosort
 SELECT 
     g,
     finalize(combined_state) as finalized_combined
 FROM combined_big_string_state
 ORDER BY g;
 ----
-group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0
-group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1
-group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2
+group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t12
+group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t10
+group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t11
 
 # Test 5: Multiple combine operations with big strings
+query TT nosort
 WITH state1 AS (
     SELECT g, first(big_str) EXPORT_STATE as state1
     FROM big_string_test 
@@ -323,7 +324,6 @@ state3 AS (
     WHERE r >= 10
     GROUP BY g
 )
-query T nosort
 SELECT 
     COALESCE(COALESCE(s1.g, s2.g), s3.g) as g,
     finalize(COMBINE(COMBINE(s1.state1, s2.state2), s3.state3)) as triple_combined
@@ -332,6 +332,6 @@ FULL OUTER JOIN state2 s2 ON s1.g = s2.g
 FULL OUTER JOIN state3 s3 ON COALESCE(s1.g, s2.g) = s3.g
 ORDER BY g;
 ----
-group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t0
-group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t1
-group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t2
+group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t12
+group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t10
+group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t11

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -13,30 +13,30 @@ create table dummy as select range % 10 g, range d from range(100);
 
 # ungrouped aggr
 
-query IIIIIII nosort res0
-SELECT sum(d), avg(d)::integer, count(d) FROM dummy;
+query IIIIIIIIIII nosort res0
+SELECT sum(d), avg(d)::integer, count(d), first(d), last(d) FROM dummy;
 ----
 
-query IIIIIII nosort res0
-SELECT finalize(sum(d) EXPORT_STATE), finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE) FROM dummy;
+query IIIIIIIIIII nosort res0
+SELECT finalize(sum(d) EXPORT_STATE), finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE), finalize(first(d) EXPORT_STATE), finalize(last(d) EXPORT_STATE) FROM dummy;
 ----
 
 # grouped aggr
-query IIIIIIIII nosort res1
-SELECT g, sum(d), avg(d)::integer, count(d) FROM dummy GROUP BY g ORDER BY g;
+query IIIIIIIIIIIII nosort res1
+SELECT g, sum(d), avg(d)::integer, count(d), first(d), last(d) FROM dummy GROUP BY g ORDER BY g;
 ----
 
-query IIIIIIIII nosort res1
-SELECT g, finalize(sum(d) EXPORT_STATE)::integer, finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
+query IIIIIIIIIIIII nosort res1
+SELECT g, finalize(sum(d) EXPORT_STATE)::integer, finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE), finalize(first(d) EXPORT_STATE), finalize(last(d) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
 ----
 
 # we can persist this
 
 statement ok
-CREATE TABLE state AS SELECT g, sum(d) EXPORT_STATE sum_state, avg(d) EXPORT_STATE avg_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
+CREATE TABLE state AS SELECT g, sum(d) EXPORT_STATE sum_state, avg(d) EXPORT_STATE avg_state, count(d) EXPORT_STATE count_state, first(d) EXPORT_STATE first_state, last(d) EXPORT_STATE last_state FROM dummy GROUP BY g ORDER BY g;
 
-query IIIIIIIII nosort res1
-SELECT g, finalize(sum_state), finalize(avg_state)::integer, finalize(count_state) FROM state ORDER BY g;
+query IIIIIIIIIIIII nosort res1
+SELECT g, finalize(sum_state), finalize(avg_state)::integer, finalize(count_state), finalize(first_state), finalize(last_state) FROM state ORDER BY g;
 ----
 
 query II nosort res3
@@ -62,30 +62,30 @@ select g, FINALIZE(COMBINE(sum_state, sum_state2)) * 2 from groups left join sta
 ----
 
 # empty groups
-query IIIIIII nosort res4
-SELECT avg(d)::integer, count(d) FROM dummy WHERE FALSE;
+query IIIIIIIIIII nosort res4
+SELECT avg(d)::integer, count(d), first(d), last(d) FROM dummy WHERE FALSE;
 ----
 
-query IIIIIII nosort res4
-SELECT finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE) FROM dummy WHERE FALSE;
+query IIIIIIIIIII nosort res4
+SELECT finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE), finalize(first(d) EXPORT_STATE), finalize(last(d) EXPORT_STATE) FROM dummy WHERE FALSE;
 ----
 
 # only null scanned
-query IIIIIII nosort res5
-SELECT avg(d)::integer, count(d) FROM (SELECT NULL::integer d);
+query IIIIIIIIIII nosort res5
+SELECT avg(d)::integer, count(d), first(d), last(d) FROM (SELECT NULL::integer d);
 ----
 
-query IIIIIII nosort res5
-SELECT finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE) FROM (SELECT NULL::integer d);
+query IIIIIIIIIII nosort res5
+SELECT finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE), finalize(first(d) EXPORT_STATE), finalize(last(d) EXPORT_STATE) FROM (SELECT NULL::integer d);
 ----
 
 # only null scanned, but grouped
-query IIIIIII nosort res6
-SELECT avg(d)::integer, count(d) FROM (SELECT NULL::integer d, g FROM dummy);
+query IIIIIIIIIII nosort res6
+SELECT avg(d)::integer, count(d), first(d), last(d) FROM (SELECT NULL::integer d, g FROM dummy);
 ----
 
-query IIIIIII nosort res6
-SELECT finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE) FROM (SELECT NULL::integer d, g FROM dummy);
+query IIIIIIIIIII nosort res6
+SELECT finalize(avg(d) EXPORT_STATE)::integer, finalize(count(d) EXPORT_STATE), finalize(first(d) EXPORT_STATE), finalize(last(d) EXPORT_STATE) FROM (SELECT NULL::integer d, g FROM dummy);
 ----
 
 
@@ -170,21 +170,21 @@ create table dummy as select range % 10 g, range d from range(100);
 
 # we can persist this
 statement ok
-CREATE TABLE state AS SELECT g, avg(d) EXPORT_STATE avg_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
+CREATE TABLE state AS SELECT g, avg(d) EXPORT_STATE avg_state, count(d) EXPORT_STATE count_state, first(d) EXPORT_STATE first_state, last(d) EXPORT_STATE last_state FROM dummy GROUP BY g ORDER BY g;
 
 statement ok
-CREATE VIEW state_view AS SELECT g, avg(d) EXPORT_STATE avg_state, count(d) EXPORT_STATE count_state FROM dummy GROUP BY g ORDER BY g;
+CREATE VIEW state_view AS SELECT g, avg(d) EXPORT_STATE avg_state, count(d) EXPORT_STATE count_state, first(d) EXPORT_STATE first_state, last(d) EXPORT_STATE last_state FROM dummy GROUP BY g ORDER BY g;
 
 restart
 
-query IIIIIIIII nosort res10
-SELECT g, avg(d)::integer, count(d) FROM dummy GROUP BY g ORDER BY g;
+query IIIIIIIIIIIII nosort res10
+SELECT g, avg(d)::integer, count(d), first(d), last(d) FROM dummy GROUP BY g ORDER BY g;
 ----
 
-query IIIIIIIII nosort res10
-SELECT g, finalize(avg_state)::integer, finalize(count_state) FROM state ORDER BY g;
+query IIIIIIIIIIIII nosort res10
+SELECT g, finalize(avg_state)::integer, finalize(count_state), finalize(first_state), finalize(last_state) FROM state ORDER BY g;
 ----
 
-query IIIIIIIII nosort res10
-SELECT g, finalize(avg_state)::integer, finalize(count_state) FROM state_view ORDER BY g;
+query IIIIIIIIIIIII nosort res10
+SELECT g, finalize(avg_state)::integer, finalize(count_state), finalize(first_state), finalize(last_state) FROM state_view ORDER BY g;
 ----


### PR DESCRIPTION
- Add GetFirstStateType callback to define struct layout for FirstState
- Apply SetStructStateExport to all first/last/any_value function registrations
- Update test_aggregate_state_type.test to include first, last, and any_value tests
- Remove first and last from test_state_export_opaque.test (now struct-based)
- Add first and last to test_state_export_struct.test alongside sum, avg, and count