### PR TITLE
Fix wrong result with two struct columns in CTE-inlined projection (#20955)

### DIFF
--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -453,7 +453,7 @@ void RemoveUnusedColumns::RewriteExpressions(LogicalProjection &proj, idx_t expr
 	vector<unique_ptr<Expression>> expressions;
 	auto &context = this->context;
 
-	column_index_map<idx_t> new_bindings;
+	column_binding_map_t<column_index_map<idx_t>> new_bindings;
 	idx_t expression_idx = 0;
 	for (idx_t i = 0; i < expression_count; i++) {
 		auto binding = ColumnBinding(proj.table_index, i);
@@ -483,7 +483,8 @@ void RemoveUnusedColumns::RewriteExpressions(LogicalProjection &proj, idx_t expr
 				    auto cast = BoundCastExpression::AddCastToType(context, std::move(new_extract), *cast_type);
 				    new_extract = std::move(cast);
 			    }
-			    auto it = new_bindings.emplace(extract_path, expressions.size()).first;
+			    auto &new_bindings_for_column = new_bindings[original_binding];
+			    auto it = new_bindings_for_column.emplace(extract_path, expressions.size()).first;
 			    if (it->second == expressions.size()) {
 				    expressions.push_back(std::move(new_extract));
 			    }

--- a/test/issues/general/test_20955.test
+++ b/test/issues/general/test_20955.test
@@ -1,0 +1,23 @@
+# name: test/issues/general/test_20955.test
+# description: Wrong result with two struct columns after CTE inlining + unused column pruning
+# group: [general]
+
+query II
+WITH c AS (
+    SELECT STRUCT_PACK(a := 1) AS s, STRUCT_PACK(x := 2) AS t
+)
+SELECT (STRUCT_PACK(a := s.a)).a, (STRUCT_PACK(x := t.x)).x FROM c;
+----
+1	2
+
+query II
+WITH c AS (
+    SELECT * FROM (VALUES
+        (STRUCT_PACK(a := 1), STRUCT_PACK(x := 2)),
+        (STRUCT_PACK(a := 3), STRUCT_PACK(x := 4))
+    ) v(s, t)
+)
+SELECT (STRUCT_PACK(a := s.a)).a, (STRUCT_PACK(x := t.x)).x FROM c ORDER BY 1;
+----
+1	2
+3	4


### PR DESCRIPTION
## Summary
Fixes wrong results reported in #20955 when `cte_inlining` and `unused_columns` interact on multiple struct columns.

## Root Cause
In `RemoveUnusedColumns::RewriteExpressions`, pushed-down struct extracts were deduplicated only by `extract_path`.
When two different source bindings had the same path (e.g., both first field), they could be merged incorrectly, causing one column to reuse the other column's value.

## Fix
Deduplicate pushed-down extracts by `(original_binding, extract_path)` instead of only `extract_path`.

## Tests
Added regression test `test/issues/general/test_20955.test` 

`make allunit`
