### PR TITLE
CVE-2026-22776 fix patch

### DIFF
--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -7872,7 +7872,8 @@ inline bool Server::read_content(Stream &strm, Request &req, Response &res) {
           strm, req, res,
           // Regular
           [&](const char *buf, size_t n) {
-            if (req.body.size() + n > req.body.max_size()) { return false; }
+            if (req.body.size() + n > payload_max_length_ ||
+                req.body.size() + n > req.body.max_size()) { return false; }
             req.body.append(buf, n);
             return true;
           },


### PR DESCRIPTION
Ref:
https://nvd.nist.gov/vuln/detail/CVE-2026-22776
https://github.com/yhirose/cpp-httplib/security/advisories/GHSA-h934-98h4-j43q 
https://github.com/yhirose/cpp-httplib/commit/2e2e47bab1ae6a853476eecbc4bf279dd1fef792

Backport https://github.com/duckdb/duckdb/pull/20992