### PR TITLE
TopNWindow - Index out of bounds

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -1042,9 +1042,12 @@ unique_ptr<LogicalOperator> TopNWindowElimination::ConstructLHS(LogicalGet &rhs,
 
 		vector<unique_ptr<Expression>> projs;
 		projs.reserve(projections.size());
-		for (auto projection_id : projections) {
-			projs.push_back(make_uniq<BoundColumnRefExpression>(lhs_get->types[projection_id],
-			                                                    ColumnBinding {lhs_get->table_index, projection_id}));
+		const auto &column_ids = lhs_get->GetColumnIds();
+		for (auto column_idx : projections) {
+			D_ASSERT(column_idx < column_ids.size());
+			const auto &column_type = lhs_get->GetColumnType(column_ids[column_idx]);
+			projs.push_back(
+			    make_uniq<BoundColumnRefExpression>(column_type, ColumnBinding {lhs_get->table_index, column_idx}));
 		}
 		auto projection = make_uniq<LogicalProjection>(optimizer.binder.GenerateTableIndex(), std::move(projs));
 		projection->children.push_back(std::move(lhs_get));

--- a/test/optimizer/issue_21011.test
+++ b/test/optimizer/issue_21011.test
@@ -1,0 +1,19 @@
+# name: test/optimizer/issue_21011.test
+# description: TopN window elimination late materialization with projected columns in LEFT JOIN subquery
+# group: [optimizer]
+
+statement ok
+CREATE TEMP TABLE t AS
+SELECT * FROM (VALUES ('x', 0, 'x')) AS x(a, b, c)
+
+query T
+SELECT y.c
+FROM t AS x
+LEFT JOIN (
+	SELECT b, c
+	FROM t
+	WHERE a = 'x'
+	QUALIFY ROW_NUMBER() OVER(ORDER BY b DESC) = 1
+) AS y ON x.b = y.b
+----
+x


### PR DESCRIPTION
# Root Cause

In `ConstructLHS`, the code indexed `lhs_get->types` with `projection_id` directly. For a `LogicalGet` with `projection_ids` (e.g. `SELECT b, c` where only some columns are projected), `ColumnBinding.column_index` uses column_ids indices (e.g. 1, 2), not positions (0, 1). That led to indexing `types` with 2 when it had only 2 elements, causing an out-of-bounds access.

# Solution

Instead of using `lhs_get->types[projection_id]`, the fix uses `LogicalGet::GetColumnType(column_ids[column_idx])`, which correctly interprets column ids and handles projection and virtual columns.

#21011 