### PR TITLE
Extend TopNWindowElimination to support RANK window function

### DIFF
--- a/benchmark/micro/optimizer/topn_rank_elimination_n1000.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_elimination_n1000.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/optimizer/topn_rank_elimination_n1000.benchmark
+# description: Benchmark of top n rank window elimination with limit 1000
+# group: [optimizer]
+
+name TopN Rank Elimination N1000
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 1000;

--- a/benchmark/micro/optimizer/topn_rank_elimination_n10000.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_elimination_n10000.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/optimizer/topn_rank_elimination_n10000.benchmark
+# description: Benchmark of top n rank window elimination with limit 10000
+# group: [optimizer]
+
+name TopN Rank Elimination N10000
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 10000;

--- a/benchmark/micro/optimizer/topn_rank_elimination_n100000.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_elimination_n100000.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/optimizer/topn_rank_elimination_n100000.benchmark
+# description: Benchmark of top n rank window elimination with limit 100000
+# group: [optimizer]
+
+name TopN Rank Elimination N100000
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 100000;

--- a/benchmark/micro/optimizer/topn_rank_elimination_n100000_no_opt.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_elimination_n100000_no_opt.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/optimizer/topn_rank_elimination_n100000_no_opt.benchmark
+# description: Benchmark of top n rank window elimination with limit 100000 (optimization disabled)
+# group: [optimizer]
+
+name TopN Rank Elimination N100000 No Opt
+group micro
+subgroup optimizer
+
+init
+SET disabled_optimizers TO 'top_n_window_elimination';
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 100000;

--- a/benchmark/micro/optimizer/topn_rank_elimination_n10000_no_opt.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_elimination_n10000_no_opt.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/optimizer/topn_rank_elimination_n10000_no_opt.benchmark
+# description: Benchmark of top n rank window elimination with limit 10000 (optimization disabled)
+# group: [optimizer]
+
+name TopN Rank Elimination N10000 No Opt
+group micro
+subgroup optimizer
+
+init
+SET disabled_optimizers TO 'top_n_window_elimination';
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 10000;

--- a/benchmark/micro/optimizer/topn_rank_elimination_n1000_no_opt.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_elimination_n1000_no_opt.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/optimizer/topn_rank_elimination_n1000_no_opt.benchmark
+# description: Benchmark of top n rank window elimination with limit 1000 (optimization disabled)
+# group: [optimizer]
+
+name TopN Rank Elimination N1000 No Opt
+group micro
+subgroup optimizer
+
+init
+SET disabled_optimizers TO 'top_n_window_elimination';
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 1000;

--- a/benchmark/micro/optimizer/topn_rank_late_mat.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_late_mat.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/optimizer/topn_rank_late_mat.benchmark
+# description: Benchmark of top n rank window elimination with late materialization
+# group: [optimizer]
+
+name TopN Rank Late Materialization
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v, v2 FROM rank_bench) WHERE rk <= 3;

--- a/benchmark/micro/optimizer/topn_rank_late_mat_no_opt.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_late_mat_no_opt.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/optimizer/topn_rank_late_mat_no_opt.benchmark
+# description: Benchmark of top n rank window elimination with late materialization (optimization disabled)
+# group: [optimizer]
+
+name TopN Rank Late Materialization No Opt
+group micro
+subgroup optimizer
+
+init
+SET disabled_optimizers TO 'late_materialization';
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v, v2  FROM rank_bench) WHERE rk <= 3;

--- a/benchmark/micro/optimizer/topn_rank_partitions_p10.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_partitions_p10.benchmark
@@ -1,0 +1,13 @@
+# name: benchmark/micro/optimizer/topn_rank_partitions_p10.benchmark
+# description: Benchmark of top n rank window elimination with 10 partitions (1M rows per partition)
+# group: [optimizer]
+
+name TopN Rank Partitions P10
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE rank_p10 AS (SELECT k, v FROM range(0, 1000000) vals(v), range(0, 10) keys(k));
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_p10) WHERE rk <= 3;

--- a/benchmark/micro/optimizer/topn_rank_partitions_p1000.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_partitions_p1000.benchmark
@@ -1,0 +1,13 @@
+# name: benchmark/micro/optimizer/topn_rank_partitions_p1000.benchmark
+# description: Benchmark of top n rank window elimination with 1000 partitions (10K rows per partition)
+# group: [optimizer]
+
+name TopN Rank Partitions P1000
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE rank_p1000 AS (SELECT k, v FROM range(0, 10000) vals(v), range(0, 1000) keys(k));
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_p1000) WHERE rk <= 3;

--- a/benchmark/micro/optimizer/topn_rank_partitions_p1000_no_opt.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_partitions_p1000_no_opt.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/optimizer/topn_rank_partitions_p1000_no_opt.benchmark
+# description: Benchmark of top n rank window elimination with 1000 partitions (optimization disabled)
+# group: [optimizer]
+
+name TopN Rank Partitions P1000 No Opt
+group micro
+subgroup optimizer
+
+init
+SET disabled_optimizers TO 'top_n_window_elimination';
+
+load
+CREATE TABLE rank_p1000 AS (SELECT k, v FROM range(0, 10000) vals(v), range(0, 1000) keys(k));
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_p1000) WHERE rk <= 3;

--- a/benchmark/micro/optimizer/topn_rank_partitions_p100k.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_partitions_p100k.benchmark
@@ -1,0 +1,13 @@
+# name: benchmark/micro/optimizer/topn_rank_partitions_p100k.benchmark
+# description: Benchmark of top n rank window elimination with 100K partitions (100 rows per partition)
+# group: [optimizer]
+
+name TopN Rank Partitions P100K
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE rank_p100k AS (SELECT k, v FROM range(0, 100) vals(v), range(0, 100000) keys(k));
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_p100k) WHERE rk <= 3;

--- a/benchmark/micro/optimizer/topn_rank_partitions_p100k_no_opt.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_partitions_p100k_no_opt.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/optimizer/topn_rank_partitions_p100k_no_opt.benchmark
+# description: Benchmark of top n rank window elimination with 100K partitions (optimization disabled)
+# group: [optimizer]
+
+name TopN Rank Partitions P100K No Opt
+group micro
+subgroup optimizer
+
+init
+SET disabled_optimizers TO 'top_n_window_elimination';
+
+load
+CREATE TABLE rank_p100k AS (SELECT k, v FROM range(0, 100) vals(v), range(0, 100000) keys(k));
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_p100k) WHERE rk <= 3;

--- a/benchmark/micro/optimizer/topn_rank_partitions_p10_no_opt.benchmark
+++ b/benchmark/micro/optimizer/topn_rank_partitions_p10_no_opt.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/optimizer/topn_rank_partitions_p10_no_opt.benchmark
+# description: Benchmark of top n rank window elimination with 10 partitions (optimization disabled)
+# group: [optimizer]
+
+name TopN Rank Partitions P10 No Opt
+group micro
+subgroup optimizer
+
+init
+SET disabled_optimizers TO 'top_n_window_elimination';
+
+load
+CREATE TABLE rank_p10 AS (SELECT k, v FROM range(0, 1000000) vals(v), range(0, 10) keys(k));
+
+run
+SELECT * FROM (SELECT rank() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_p10) WHERE rk <= 3;

--- a/benchmark/micro/optimizer/topn_rownumber_elimination_n1000.benchmark
+++ b/benchmark/micro/optimizer/topn_rownumber_elimination_n1000.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/optimizer/topn_rownumber_elimination_n1000.benchmark
+# description: Benchmark of top n row_number window elimination with limit 1000
+# group: [optimizer]
+
+name TopN RowNumber Elimination N1000
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 1000;

--- a/benchmark/micro/optimizer/topn_rownumber_elimination_n10000.benchmark
+++ b/benchmark/micro/optimizer/topn_rownumber_elimination_n10000.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/optimizer/topn_rownumber_elimination_n10000.benchmark
+# description: Benchmark of top n row_number window elimination with limit 10000
+# group: [optimizer]
+
+name TopN RowNumber Elimination N10000
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 10000;

--- a/benchmark/micro/optimizer/topn_rownumber_elimination_n100000.benchmark
+++ b/benchmark/micro/optimizer/topn_rownumber_elimination_n100000.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/optimizer/topn_rownumber_elimination_n100000.benchmark
+# description: Benchmark of top n row_number window elimination with limit 100000
+# group: [optimizer]
+
+name TopN RowNumber Elimination N100000
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 100000;

--- a/benchmark/micro/optimizer/topn_rownumber_elimination_n100000_no_opt.benchmark
+++ b/benchmark/micro/optimizer/topn_rownumber_elimination_n100000_no_opt.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/optimizer/topn_rownumber_elimination_n100000_no_opt.benchmark
+# description: Benchmark of top n row_number window elimination with limit 100000 (optimization disabled)
+# group: [optimizer]
+
+name TopN RowNumber Elimination N100000 No Opt
+group micro
+subgroup optimizer
+
+init
+SET disabled_optimizers TO 'top_n_window_elimination';
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 100000;

--- a/benchmark/micro/optimizer/topn_rownumber_elimination_n10000_no_opt.benchmark
+++ b/benchmark/micro/optimizer/topn_rownumber_elimination_n10000_no_opt.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/optimizer/topn_rownumber_elimination_n10000_no_opt.benchmark
+# description: Benchmark of top n row_number window elimination with limit 10000 (optimization disabled)
+# group: [optimizer]
+
+name TopN RowNumber Elimination N10000 No Opt
+group micro
+subgroup optimizer
+
+init
+SET disabled_optimizers TO 'top_n_window_elimination';
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 10000;

--- a/benchmark/micro/optimizer/topn_rownumber_elimination_n1000_no_opt.benchmark
+++ b/benchmark/micro/optimizer/topn_rownumber_elimination_n1000_no_opt.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/optimizer/topn_rownumber_elimination_n1000_no_opt.benchmark
+# description: Benchmark of top n row_number window elimination with limit 1000 (optimization disabled)
+# group: [optimizer]
+
+name TopN RowNumber Elimination N1000 No Opt
+group micro
+subgroup optimizer
+
+init
+SET disabled_optimizers TO 'top_n_window_elimination';
+
+load
+CREATE TABLE rank_bench AS (
+	SELECT k, v, v % 1000 AS v2, v % 100 AS v3
+	FROM range(0, 1000000) vals(v), range(0, 100) keys(k)
+);
+
+run
+SELECT * FROM (SELECT row_number() OVER (PARTITION BY k ORDER BY v DESC) rk, k, v FROM rank_bench) WHERE rk <= 1000;

--- a/extension/core_functions/aggregate/distributive/functions.json
+++ b/extension/core_functions/aggregate/distributive/functions.json
@@ -51,6 +51,20 @@
         "type": "aggregate_function_set"
     },
     {
+        "name": "__internal_arg_min_rank_nulls_last",
+        "parameters": "arg,val,N",
+        "description": "Internal only. Finds the rows with N minimum vals including ties and nulls. Returns LIST of STRUCT(arg, rank).",
+        "example": "__internal_arg_min_rank_nulls_last(A, B, N)",
+        "type": "aggregate_function_set"
+    },
+    {
+        "name": "__internal_arg_max_rank_nulls_last",
+        "parameters": "arg,val,N",
+        "description": "Internal only. Finds the rows with N maximum vals including ties and nulls. Returns LIST of STRUCT(arg, rank).",
+        "example": "__internal_arg_max_rank_nulls_last(A, B, N)",
+        "type": "aggregate_function_set"
+    },
+    {
         "name": "bit_and",
         "parameters": "arg",
         "description": "Returns the bitwise AND of all bits in a given expression.",

--- a/extension/core_functions/function_list.cpp
+++ b/extension/core_functions/function_list.cpp
@@ -61,6 +61,8 @@ static const StaticFunctionDefinition core_functions[] = {
 	DUCKDB_SCALAR_FUNCTION_ALIAS(ListHasAllFunAlias),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(PowOperatorFunAlias),
 	DUCKDB_SCALAR_FUNCTION(StartsWithOperatorFun),
+	DUCKDB_AGGREGATE_FUNCTION_SET(InternalArgMaxRankNullsLastFun),
+	DUCKDB_AGGREGATE_FUNCTION_SET(InternalArgMinRankNullsLastFun),
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(AbsFun),
 	DUCKDB_SCALAR_FUNCTION(AcosFun),
 	DUCKDB_SCALAR_FUNCTION(AcoshFun),

--- a/extension/core_functions/include/core_functions/aggregate/distributive_functions.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/distributive_functions.hpp
@@ -109,6 +109,26 @@ struct ArgMaxNullsLastFun {
 	static AggregateFunctionSet GetFunctions();
 };
 
+struct InternalArgMinRankNullsLastFun {
+	static constexpr const char *Name = "__internal_arg_min_rank_nulls_last";
+	static constexpr const char *Parameters = "arg,val,N";
+	static constexpr const char *Description = "Internal only. Finds the rows with N minimum vals including ties and nulls. Returns LIST of STRUCT(arg, rank).";
+	static constexpr const char *Example = "__internal_arg_min_rank_nulls_last(A, B, N)";
+	static constexpr const char *Categories = "";
+
+	static AggregateFunctionSet GetFunctions();
+};
+
+struct InternalArgMaxRankNullsLastFun {
+	static constexpr const char *Name = "__internal_arg_max_rank_nulls_last";
+	static constexpr const char *Parameters = "arg,val,N";
+	static constexpr const char *Description = "Internal only. Finds the rows with N maximum vals including ties and nulls. Returns LIST of STRUCT(arg, rank).";
+	static constexpr const char *Example = "__internal_arg_max_rank_nulls_last(A, B, N)";
+	static constexpr const char *Categories = "";
+
+	static AggregateFunctionSet GetFunctions();
+};
+
 struct BitAndFun {
 	static constexpr const char *Name = "bit_and";
 	static constexpr const char *Parameters = "arg";

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -114,6 +114,7 @@
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/execution/physical_table_scan_enum.hpp"
 #include "duckdb/execution/reservoir_sample.hpp"
+#include "duckdb/function/aggregate/minmax_n_helpers.hpp"
 #include "duckdb/function/aggregate_state.hpp"
 #include "duckdb/function/compression_function.hpp"
 #include "duckdb/function/copy_function.hpp"
@@ -4094,6 +4095,23 @@ const char* EnumUtil::ToChars<QueryResultType>(QueryResultType value) {
 template<>
 QueryResultType EnumUtil::FromString<QueryResultType>(const char *value) {
 	return static_cast<QueryResultType>(StringUtil::StringToEnum(GetQueryResultTypeValues(), 4, "QueryResultType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetRankTypeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(RankType::RANK), "RANK" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<RankType>(RankType value) {
+	return StringUtil::EnumToString(GetRankTypeValues(), 1, "RankType", static_cast<uint32_t>(value));
+}
+
+template<>
+RankType EnumUtil::FromString<RankType>(const char *value) {
+	return static_cast<RankType>(StringUtil::StringToEnum(GetRankTypeValues(), 1, "RankType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetRecoveryModeValues() {

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -366,6 +366,8 @@ enum class QueryResultOutputType : uint8_t;
 
 enum class QueryResultType : uint8_t;
 
+enum class RankType : uint8_t;
+
 enum class RecoveryMode : uint8_t;
 
 enum class RelationType : uint8_t;
@@ -1001,6 +1003,9 @@ const char* EnumUtil::ToChars<QueryResultOutputType>(QueryResultOutputType value
 
 template<>
 const char* EnumUtil::ToChars<QueryResultType>(QueryResultType value);
+
+template<>
+const char* EnumUtil::ToChars<RankType>(RankType value);
 
 template<>
 const char* EnumUtil::ToChars<RecoveryMode>(RecoveryMode value);
@@ -1704,6 +1709,9 @@ QueryResultOutputType EnumUtil::FromString<QueryResultOutputType>(const char *va
 
 template<>
 QueryResultType EnumUtil::FromString<QueryResultType>(const char *value);
+
+template<>
+RankType EnumUtil::FromString<RankType>(const char *value);
 
 template<>
 RecoveryMode EnumUtil::FromString<RecoveryMode>(const char *value);

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -961,7 +961,7 @@ struct ArgMinMaxRankHelper {
 		struct_children.emplace_back("arg", type);
 		struct_children.emplace_back("rank", LogicalType::BIGINT);
 		auto struct_type = LogicalType::STRUCT(std::move(struct_children));
-		auto return_type = LogicalType::LIST(std::move(struct_type));
+		auto return_type = LogicalType::LIST(struct_type);
 
 		AggregateFunction func(name, {type, by_type, LogicalType::BIGINT}, return_type, nullptr, nullptr, nullptr,
 		                       nullptr, nullptr, FunctionNullHandling::DEFAULT_NULL_HANDLING);

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -7,8 +7,12 @@
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/enums/order_type.hpp"
+#include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/function/create_sort_key.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 
@@ -240,6 +244,121 @@ private:
 	idx_t capacity;
 	STORAGE_TYPE *heap;
 	idx_t size;
+};
+
+//------------------------------------------------------------------------------
+// BinaryAggregateHeapWithTies: extends BinaryAggregateHeap to track ties at the boundary
+//------------------------------------------------------------------------------
+enum class RankType : uint8_t { RANK };
+
+template <class K, class V, class K_COMPARATOR>
+class BinaryAggregateHeapWithTies {
+	using STORAGE_TYPE = pair<HeapEntry<K>, HeapEntry<V>>;
+
+public:
+	BinaryAggregateHeapWithTies() = default;
+
+	void Initialize(ArenaAllocator &allocator, const idx_t capacity_p) {
+		capacity = capacity_p;
+		auto ptr = allocator.AllocateAligned(capacity * sizeof(STORAGE_TYPE));
+		memset(ptr, 0, capacity * sizeof(STORAGE_TYPE));
+		heap = reinterpret_cast<STORAGE_TYPE *>(ptr);
+		heap_size = 0;
+	}
+
+	bool IsEmpty() const {
+		return heap_size == 0;
+	}
+
+	idx_t GetHeapSize() const {
+		return heap_size;
+	}
+
+	idx_t Size() const {
+		return heap_size + ties.size();
+	}
+
+	idx_t Capacity() const {
+		return capacity;
+	}
+
+	void Insert(ArenaAllocator &allocator, const K &key, const V &value) {
+		D_ASSERT(capacity != 0);
+
+		if (heap_size < capacity) {
+			// Heap not full yet, just insert
+			heap[heap_size].first.Assign(allocator, key);
+			heap[heap_size].second.Assign(allocator, value);
+			heap_size++;
+			std::push_heap(heap, heap + heap_size, Compare);
+
+		} else if (KeyEquals(key, heap[0].first.value)) {
+			// Key equals boundary
+			STORAGE_TYPE entry;
+			entry.first.Assign(allocator, key);
+			entry.second.Assign(allocator, value);
+			ties.push_back(std::move(entry));
+		} else if (K_COMPARATOR::Operation(key, heap[0].first.value)) {
+			// Key is better than boundary
+			std::pop_heap(heap, heap + heap_size, Compare);
+			STORAGE_TYPE evicted;
+			evicted.first.Assign(allocator, heap[heap_size - 1].first.value);
+			evicted.second.Assign(allocator, heap[heap_size - 1].second.value);
+
+			heap[heap_size - 1].first.Assign(allocator, key);
+			heap[heap_size - 1].second.Assign(allocator, value);
+			std::push_heap(heap, heap + heap_size, Compare);
+
+			if (KeyEquals(evicted.first.value, heap[0].first.value)) {
+				// Boundary unchanged, evicted element is a tie
+				ties.push_back(std::move(evicted));
+			} else {
+				// Boundary changed, old ties no longer match
+				ties.clear();
+			}
+		}
+		// Otherwise key is worse than boundary, ignore
+	}
+
+	void Insert(ArenaAllocator &allocator, const BinaryAggregateHeapWithTies &other) {
+		for (idx_t slot = other.heap_size; slot > 0; slot--) {
+			Insert(allocator, other.heap[slot - 1].first.value, other.heap[slot - 1].second.value);
+		}
+		for (idx_t slot = 0; slot < other.ties.size(); slot++) {
+			Insert(allocator, other.ties[slot].first.value, other.ties[slot].second.value);
+		}
+	}
+
+	STORAGE_TYPE *SortAndGetHeap() {
+		std::sort_heap(heap, heap + heap_size, Compare);
+		return heap;
+	}
+
+	const vector<STORAGE_TYPE> &GetTies() const {
+		return ties;
+	}
+
+	static const V &GetValue(const STORAGE_TYPE &slot) {
+		return slot.second.value;
+	}
+
+	static const K &GetKey(const STORAGE_TYPE &slot) {
+		return slot.first.value;
+	}
+
+private:
+	static bool Compare(const STORAGE_TYPE &left, const STORAGE_TYPE &right) {
+		return K_COMPARATOR::Operation(left.first.value, right.first.value);
+	}
+
+	static bool KeyEquals(const K &a, const K &b) {
+		return !K_COMPARATOR::Operation(a, b) && !K_COMPARATOR::Operation(b, a);
+	}
+
+	idx_t capacity;
+	STORAGE_TYPE *heap;
+	idx_t heap_size;
+	vector<STORAGE_TYPE> ties;
 };
 
 enum class ArgMinMaxNullHandling { IGNORE_ANY_NULL, HANDLE_ARG_NULL, HANDLE_ANY_NULL };
@@ -481,6 +600,397 @@ struct MinMaxNOperation {
 
 	static bool IgnoreNull() {
 		return true;
+	}
+};
+
+//------------------------------------------------------------------------------
+// MinMaxNWithTiesOperation: Finalize produces LIST<STRUCT(arg, rank)>
+//------------------------------------------------------------------------------
+struct MinMaxNWithTiesOperation {
+	template <class STATE>
+	static void Initialize(STATE &state) {
+		new (&state) STATE();
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input) {
+		if (!source.is_initialized) {
+			return;
+		}
+
+		if (!target.is_initialized) {
+			target.Initialize(aggr_input.allocator, source.heap.Capacity());
+		} else if (source.heap.Capacity() != target.heap.Capacity()) {
+			throw InvalidInputException("Mismatched n values in __internal_arg_min_rank/__internal_arg_max_rank");
+		}
+
+		target.heap.Insert(aggr_input.allocator, source.heap);
+	}
+
+	template <class STATE>
+	static void Finalize(Vector &state_vector, AggregateInputData &input_data, Vector &result, idx_t count,
+	                     idx_t offset) {
+		const bool nulls_last = !input_data.bind_data || input_data.bind_data->Cast<ArgMinMaxFunctionData>().nulls_last;
+
+		UnifiedVectorFormat state_format;
+		state_vector.ToUnifiedFormat(count, state_format);
+
+		const auto states = UnifiedVectorFormat::GetData<STATE *>(state_format);
+		auto &mask = FlatVector::Validity(result);
+
+		const auto old_len = ListVector::GetListSize(result);
+
+		// Count the total number of entries (heap + ties)
+		idx_t new_entries = 0;
+		for (idx_t i = 0; i < count; i++) {
+			const auto state_idx = state_format.sel->get_index(i);
+			auto &state = *states[state_idx];
+			new_entries += state.heap.Size();
+		}
+
+		ListVector::Reserve(result, old_len + new_entries);
+
+		const auto list_entries = FlatVector::GetData<list_entry_t>(result);
+		auto &child_data = ListVector::GetEntry(result);
+
+		// child_data is a STRUCT vector with children: "arg" and "rank"
+		auto &struct_entries = StructVector::GetEntries(child_data);
+		D_ASSERT(struct_entries.size() == 2);
+		auto &arg_vector = *struct_entries[0];
+		auto &rank_vector = *struct_entries[1];
+
+		idx_t current_offset = old_len;
+		for (idx_t i = 0; i < count; i++) {
+			const auto rid = i + offset;
+			const auto state_idx = state_format.sel->get_index(i);
+			auto &state = *states[state_idx];
+
+			if (!state.is_initialized || state.heap.IsEmpty()) {
+				mask.SetInvalid(rid);
+				continue;
+			}
+
+			auto heap_size = state.heap.GetHeapSize();
+			auto &ties = state.heap.GetTies();
+			idx_t total_entries = state.heap.Size();
+
+			auto &list_entry = list_entries[rid];
+			list_entry.offset = current_offset;
+			list_entry.length = total_entries;
+
+			// Sort the heap entries
+			auto heap = state.heap.SortAndGetHeap();
+
+			// First: assign heap entries
+			for (idx_t slot = 0; slot < heap_size; slot++) {
+				STATE::VAL_TYPE::Assign(arg_vector, current_offset + slot, state.heap.GetValue(heap[slot]), nulls_last);
+			}
+			// Then: assign ties entries
+			for (idx_t slot = 0; slot < ties.size(); slot++) {
+				STATE::VAL_TYPE::Assign(arg_vector, current_offset + heap_size + slot, state.heap.GetValue(ties[slot]),
+				                        nulls_last);
+			}
+
+			// Now compute rank values
+			auto rank_data = FlatVector::GetData<int64_t>(rank_vector);
+			int64_t current_rank = 1;
+			int64_t row_number = 1;
+			bool first = true;
+
+			auto get_key = [&](idx_t idx) -> const typename STATE::ARG_TYPE::TYPE & {
+				if (idx < heap_size) {
+					return state.heap.GetKey(heap[idx]);
+				}
+				return state.heap.GetKey(ties[idx - heap_size]);
+			};
+
+			for (idx_t slot = 0; slot < total_entries; slot++) {
+				if (first) {
+					rank_data[current_offset + slot] = 1;
+					first = false;
+				} else {
+					auto &prev_key = get_key(slot - 1);
+					auto &curr_key = get_key(slot);
+					bool is_tie = STATE::KeyEquals(prev_key, curr_key);
+
+					if (is_tie) {
+						rank_data[current_offset + slot] = current_rank;
+					} else {
+						current_rank = row_number;
+						rank_data[current_offset + slot] = current_rank;
+					}
+				}
+				row_number++;
+			}
+
+			current_offset += total_entries;
+		}
+
+		D_ASSERT(current_offset == old_len + new_entries);
+		ListVector::SetListSize(result, current_offset);
+		result.Verify(count);
+	}
+
+	template <class STATE>
+	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
+		state.~STATE();
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+//------------------------------------------------------------------------------
+// ArgMinMaxWithTies: FunctionData, State, Update, and Specialize
+// Used by TopNWindowElimination optimizer to directly construct BoundAggregateExpression
+//------------------------------------------------------------------------------
+
+struct ArgMinMaxWithTiesFunctionData : public ArgMinMaxFunctionData {
+	explicit ArgMinMaxWithTiesFunctionData(
+	    RankType rank_type_p = RankType::RANK,
+	    ArgMinMaxNullHandling null_handling_p = ArgMinMaxNullHandling::IGNORE_ANY_NULL, bool nulls_last_p = true)
+	    : ArgMinMaxFunctionData(null_handling_p, nulls_last_p), rank_type(rank_type_p) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto copy = make_uniq<ArgMinMaxWithTiesFunctionData>(rank_type, null_handling, nulls_last);
+		return std::move(copy);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<ArgMinMaxWithTiesFunctionData>();
+		return other.null_handling == null_handling && other.nulls_last == nulls_last && other.rank_type == rank_type;
+	}
+
+	RankType rank_type;
+};
+
+template <class A, class B, class COMPARATOR>
+class ArgMinMaxNWithTiesState {
+public:
+	using VAL_TYPE = A;
+	using ARG_TYPE = B;
+
+	using V = typename VAL_TYPE::TYPE;
+	using K = typename ARG_TYPE::TYPE;
+
+	BinaryAggregateHeapWithTies<K, V, COMPARATOR> heap;
+
+	bool is_initialized = false;
+	void Initialize(ArenaAllocator &allocator, idx_t nval) {
+		heap.Initialize(allocator, nval);
+		is_initialized = true;
+	}
+
+	static bool KeyEquals(const K &a, const K &b) {
+		return !COMPARATOR::Operation(a, b) && !COMPARATOR::Operation(b, a);
+	}
+};
+
+template <class STATE>
+inline void ArgMinMaxNWithTiesUpdate(Vector inputs[], AggregateInputData &aggr_input, idx_t input_count,
+                                     Vector &state_vector, idx_t count) {
+	D_ASSERT(aggr_input.bind_data);
+	const auto &bind_data = aggr_input.bind_data->Cast<ArgMinMaxWithTiesFunctionData>();
+
+	auto &val_vector = inputs[0];
+	auto &arg_vector = inputs[1];
+	auto &n_vector = inputs[2];
+
+	UnifiedVectorFormat val_format;
+	UnifiedVectorFormat arg_format;
+	UnifiedVectorFormat n_format;
+	UnifiedVectorFormat state_format;
+
+	auto val_extra_state = STATE::VAL_TYPE::CreateExtraState(val_vector, count);
+	auto arg_extra_state = STATE::ARG_TYPE::CreateExtraState(arg_vector, count);
+
+	STATE::VAL_TYPE::PrepareData(val_vector, count, val_extra_state, val_format, bind_data.nulls_last);
+	STATE::ARG_TYPE::PrepareData(arg_vector, count, arg_extra_state, arg_format, bind_data.nulls_last);
+
+	n_vector.ToUnifiedFormat(count, n_format);
+	state_vector.ToUnifiedFormat(count, state_format);
+
+	auto states = UnifiedVectorFormat::GetData<STATE *>(state_format);
+
+	for (idx_t i = 0; i < count; i++) {
+		const auto arg_idx = arg_format.sel->get_index(i);
+		const auto val_idx = val_format.sel->get_index(i);
+
+		const auto state_idx = state_format.sel->get_index(i);
+		auto &state = *states[state_idx];
+
+		if (!state.is_initialized) {
+			static constexpr int64_t MAX_N = 1000000;
+			const auto nidx = n_format.sel->get_index(i);
+			if (!n_format.validity.RowIsValid(nidx)) {
+				throw InvalidInputException(
+				    "Invalid input for __internal_arg_min/__internal_arg_max_rank: n value cannot be NULL");
+			}
+			const auto nval = UnifiedVectorFormat::GetData<int64_t>(n_format)[nidx];
+			if (nval <= 0) {
+				throw InvalidInputException(
+				    "Invalid input for __internal_arg_min/__internal_arg_max_rank: n value must be > 0");
+			}
+			if (nval >= MAX_N) {
+				throw InvalidInputException(
+				    "Invalid input for __internal_arg_min/__internal_arg_max_rank: n value must be < %d", MAX_N);
+			}
+			state.Initialize(aggr_input.allocator, UnsafeNumericCast<idx_t>(nval));
+		}
+
+		auto arg_val = STATE::ARG_TYPE::Create(arg_format, arg_idx);
+		auto val_val = STATE::VAL_TYPE::Create(val_format, val_idx);
+
+		state.heap.Insert(aggr_input.allocator, arg_val, val_val);
+	}
+}
+
+template <class VAL_TYPE, class ARG_TYPE, class COMPARATOR>
+inline void SpecializeArgMinMaxNWithTiesNullFunction(AggregateFunction &function) {
+	using STATE = ArgMinMaxNWithTiesState<VAL_TYPE, ARG_TYPE, COMPARATOR>;
+	using OP = MinMaxNWithTiesOperation;
+	function.SetStateSizeCallback(AggregateFunction::StateSize<STATE>);
+	function.SetStateInitCallback(AggregateFunction::StateInitialize<STATE, OP, AggregateDestructorType::LEGACY>);
+	function.SetStateCombineCallback(AggregateFunction::StateCombine<STATE, OP>);
+	function.SetStateDestructorCallback(AggregateFunction::StateDestroy<STATE, OP>);
+	function.SetStateFinalizeCallback(MinMaxNWithTiesOperation::Finalize<STATE>);
+	function.SetStateUpdateCallback(ArgMinMaxNWithTiesUpdate<STATE>);
+}
+
+template <class VAL_TYPE, bool NULLS_LAST, class COMPARATOR>
+inline void SpecializeArgMinMaxNWithTiesNullFunction(PhysicalType arg_type, AggregateFunction &function) {
+	switch (arg_type) {
+#ifndef DUCKDB_SMALLER_BINARY
+	case PhysicalType::VARCHAR:
+		SpecializeArgMinMaxNWithTiesNullFunction<VAL_TYPE, MinMaxFallbackValue, COMPARATOR>(function);
+		break;
+	case PhysicalType::INT32:
+		SpecializeArgMinMaxNWithTiesNullFunction<VAL_TYPE, MinMaxFixedValueOrNull<int32_t, NULLS_LAST>, COMPARATOR>(
+		    function);
+		break;
+	case PhysicalType::INT64:
+		SpecializeArgMinMaxNWithTiesNullFunction<VAL_TYPE, MinMaxFixedValueOrNull<int64_t, NULLS_LAST>, COMPARATOR>(
+		    function);
+		break;
+	case PhysicalType::FLOAT:
+		SpecializeArgMinMaxNWithTiesNullFunction<VAL_TYPE, MinMaxFixedValueOrNull<float, NULLS_LAST>, COMPARATOR>(
+		    function);
+		break;
+	case PhysicalType::DOUBLE:
+		SpecializeArgMinMaxNWithTiesNullFunction<VAL_TYPE, MinMaxFixedValueOrNull<double, NULLS_LAST>, COMPARATOR>(
+		    function);
+		break;
+#endif
+	default:
+		SpecializeArgMinMaxNWithTiesNullFunction<VAL_TYPE, MinMaxFallbackValue, COMPARATOR>(function);
+		break;
+	}
+}
+
+template <bool NULLS_LAST, class COMPARATOR>
+inline void SpecializeArgMinMaxNWithTiesNullFunction(PhysicalType val_type, PhysicalType arg_type,
+                                                     AggregateFunction &function) {
+	switch (val_type) {
+#ifndef DUCKDB_SMALLER_BINARY
+	case PhysicalType::VARCHAR:
+		SpecializeArgMinMaxNWithTiesNullFunction<MinMaxFallbackValue, NULLS_LAST, COMPARATOR>(arg_type, function);
+		break;
+	case PhysicalType::INT32:
+		SpecializeArgMinMaxNWithTiesNullFunction<MinMaxFixedValueOrNull<int32_t, NULLS_LAST>, NULLS_LAST, COMPARATOR>(
+		    arg_type, function);
+		break;
+	case PhysicalType::INT64:
+		SpecializeArgMinMaxNWithTiesNullFunction<MinMaxFixedValueOrNull<int64_t, NULLS_LAST>, NULLS_LAST, COMPARATOR>(
+		    arg_type, function);
+		break;
+	case PhysicalType::FLOAT:
+		SpecializeArgMinMaxNWithTiesNullFunction<MinMaxFixedValueOrNull<float, NULLS_LAST>, NULLS_LAST, COMPARATOR>(
+		    arg_type, function);
+		break;
+	case PhysicalType::DOUBLE:
+		SpecializeArgMinMaxNWithTiesNullFunction<MinMaxFixedValueOrNull<double, NULLS_LAST>, NULLS_LAST, COMPARATOR>(
+		    arg_type, function);
+		break;
+#endif
+	default:
+		SpecializeArgMinMaxNWithTiesNullFunction<MinMaxFallbackValue, NULLS_LAST, COMPARATOR>(arg_type, function);
+		break;
+	}
+}
+
+//------------------------------------------------------------------------------
+// ArgMinMaxRankHelper: directly construct bound aggregate functions for internal use
+//------------------------------------------------------------------------------
+struct ArgMinMaxRankHelper {
+	static inline void Serialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data,
+	                             const AggregateFunction &function) {
+		serializer.WriteProperty(100, "arguments", function.arguments);
+		serializer.WriteProperty(101, "return_type", function.GetReturnType());
+		auto &data = bind_data->Cast<ArgMinMaxWithTiesFunctionData>();
+		serializer.WriteProperty(102, "rank_type", static_cast<uint8_t>(data.rank_type));
+	}
+
+	static inline unique_ptr<FunctionData> Deserialize(Deserializer &deserializer, AggregateFunction &function) {
+		function.arguments = deserializer.ReadProperty<vector<LogicalType>>(100, "arguments");
+		auto return_type = deserializer.ReadProperty<LogicalType>(101, "return_type");
+		auto rank_type_val = deserializer.ReadProperty<uint8_t>(102, "rank_type");
+		auto rank_type = static_cast<RankType>(rank_type_val);
+
+		function.SetReturnType(std::move(return_type));
+
+		auto type = function.arguments[0].InternalType();
+		auto by_type = function.arguments[1].InternalType();
+
+		if (StringUtil::StartsWith(function.name, "__internal_arg_min")) {
+			SpecializeArgMinMaxNWithTiesNullFunction<true, LessThan>(type, by_type, function);
+			return make_uniq<ArgMinMaxWithTiesFunctionData>(rank_type, ArgMinMaxNullHandling::HANDLE_ANY_NULL, true);
+		} else {
+			SpecializeArgMinMaxNWithTiesNullFunction<false, GreaterThan>(type, by_type, function);
+			return make_uniq<ArgMinMaxWithTiesFunctionData>(rank_type, ArgMinMaxNullHandling::HANDLE_ANY_NULL, false);
+		}
+	}
+
+	template <bool NULLS_LAST, class COMPARATOR>
+	static inline AggregateFunction GetBoundFunctionInternal(const string &name, const LogicalType &type,
+	                                                         const LogicalType &by_type, RankType rank_type,
+	                                                         unique_ptr<FunctionData> &bind_data) {
+		// Return type: LIST<STRUCT(arg: type, rank: BIGINT)>
+		child_list_t<LogicalType> struct_children;
+		struct_children.emplace_back("arg", type);
+		struct_children.emplace_back("rank", LogicalType::BIGINT);
+		auto struct_type = LogicalType::STRUCT(std::move(struct_children));
+		auto return_type = LogicalType::LIST(std::move(struct_type));
+
+		AggregateFunction func(name, {type, by_type, LogicalType::BIGINT}, return_type, nullptr, nullptr, nullptr,
+		                       nullptr, nullptr, FunctionNullHandling::DEFAULT_NULL_HANDLING);
+
+		// Specialize with null-aware callbacks: MinMaxFixedValueOrNull handles NULL ORDER BY values correctly.
+		SpecializeArgMinMaxNWithTiesNullFunction<NULLS_LAST, COMPARATOR>(type.InternalType(), by_type.InternalType(),
+		                                                                 func);
+
+		// Set serialization callbacks to bypass bind during deserialization
+		func.SetSerializeCallback(ArgMinMaxRankHelper::Serialize);
+		func.SetDeserializeCallback(ArgMinMaxRankHelper::Deserialize);
+
+		// Create bind data with null-aware handling
+		bind_data =
+		    make_uniq<ArgMinMaxWithTiesFunctionData>(rank_type, ArgMinMaxNullHandling::HANDLE_ANY_NULL, NULLS_LAST);
+
+		return func;
+	}
+
+	static inline AggregateFunction GetInternalArgMinRank(const LogicalType &type, const LogicalType &by_type,
+	                                                      unique_ptr<FunctionData> &bind_data) {
+		return GetBoundFunctionInternal<true, LessThan>("__internal_arg_min_rank_nulls_last", type, by_type,
+		                                                RankType::RANK, bind_data);
+	}
+
+	static inline AggregateFunction GetInternalArgMaxRank(const LogicalType &type, const LogicalType &by_type,
+	                                                      unique_ptr<FunctionData> &bind_data) {
+		return GetBoundFunctionInternal<false, GreaterThan>("__internal_arg_max_rank_nulls_last", type, by_type,
+		                                                    RankType::RANK, bind_data);
 	}
 };
 

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -16,6 +16,9 @@
 
 namespace duckdb {
 
+//! Maximum allowed value for N in the window top-N optimizer and ArgMinMaxNWithTies aggregate.
+static constexpr int64_t MINMAX_N_LIMIT = 10000;
+
 // For basic types
 template <class T>
 struct HeapEntry {
@@ -822,7 +825,6 @@ inline void ArgMinMaxNWithTiesUpdate(Vector inputs[], AggregateInputData &aggr_i
 		auto &state = *states[state_idx];
 
 		if (!state.is_initialized) {
-			static constexpr int64_t MAX_N = 1000000;
 			const auto nidx = n_format.sel->get_index(i);
 			if (!n_format.validity.RowIsValid(nidx)) {
 				throw InvalidInputException(
@@ -833,9 +835,10 @@ inline void ArgMinMaxNWithTiesUpdate(Vector inputs[], AggregateInputData &aggr_i
 				throw InvalidInputException(
 				    "Invalid input for __internal_arg_min/__internal_arg_max_rank: n value must be > 0");
 			}
-			if (nval >= MAX_N) {
+			if (nval >= MINMAX_N_LIMIT) {
 				throw InvalidInputException(
-				    "Invalid input for __internal_arg_min/__internal_arg_max_rank: n value must be < %d", MAX_N);
+				    "Invalid input for __internal_arg_min/__internal_arg_max_rank: n value must be < %d",
+				    MINMAX_N_LIMIT);
 			}
 			state.Initialize(aggr_input.allocator, UnsafeNumericCast<idx_t>(nval));
 		}

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -55,6 +55,8 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"@>", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"^", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"^@", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"__internal_arg_max_rank_nulls_last", "core_functions", CatalogType::AGGREGATE_FUNCTION_ENTRY},
+    {"__internal_arg_min_rank_nulls_last", "core_functions", CatalogType::AGGREGATE_FUNCTION_ENTRY},
     {"abs", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"acos", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"acosh", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -238,6 +238,11 @@ TopNWindowElimination::CreateAggregateExpression(vector<unique_ptr<Expression>> 
 		// RANK: directly construct BoundAggregateExpression bypassing bind, because
 		// __internal_arg_min_rank()/__internal_arg_max_rank() are internal-only functions whose bind throws an error to
 		// prevent user access
+		if (!requires_arg) {
+			// No payload: insert a copy of ORDER_BY_KEY at position 0 as a proxy val so the 3-arg function gets correct
+			// arguments.
+			aggregate_params.insert(aggregate_params.begin(), aggregate_params[0]->Copy());
+		}
 		auto type = aggregate_params[0]->return_type;
 		auto by_type = aggregate_params[1]->return_type;
 

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -22,6 +22,7 @@
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/function/aggregate/minmax_n_helpers.hpp"
 #include "duckdb/main/database.hpp"
 
 namespace duckdb {
@@ -233,6 +234,22 @@ unique_ptr<Expression>
 TopNWindowElimination::CreateAggregateExpression(vector<unique_ptr<Expression>> aggregate_params,
                                                  const bool requires_arg,
                                                  const TopNWindowEliminationParameters &params) const {
+	if (params.IncludeTies()) {
+		// RANK: directly construct BoundAggregateExpression bypassing bind, because
+		// __internal_arg_min_rank()/__internal_arg_max_rank() are internal-only functions whose bind throws an error to
+		// prevent user access
+		auto type = aggregate_params[0]->return_type;
+		auto by_type = aggregate_params[1]->return_type;
+
+		unique_ptr<FunctionData> bind_data;
+		auto func = params.order_type == OrderType::ASCENDING
+		                ? ArgMinMaxRankHelper::GetInternalArgMinRank(type, by_type, bind_data)
+		                : ArgMinMaxRankHelper::GetInternalArgMaxRank(type, by_type, bind_data);
+
+		return make_uniq<BoundAggregateExpression>(std::move(func), std::move(aggregate_params), nullptr,
+		                                           std::move(bind_data), AggregateType::NON_DISTINCT);
+	}
+
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	FunctionBinder function_binder(context);
 
@@ -277,7 +294,7 @@ TopNWindowElimination::CreateAggregateOperator(LogicalWindow &window, vector<uni
 	}
 
 	aggregate_params.push_back(std::move(window_expr.orders[0].expression));
-	if (params.limit > 1) {
+	if (params.limit > 1 || params.IncludeTies()) {
 		aggregate_params.push_back(std::move(make_uniq<BoundConstantExpression>(Value::BIGINT(params.limit))));
 	}
 
@@ -358,8 +375,8 @@ TopNWindowElimination::TryCreateUnnestOperator(unique_ptr<LogicalOperator> op,
 	const idx_t aggregate_column_idx = logical_aggregate.groups.size();
 	LogicalType aggregate_type = logical_aggregate.types[aggregate_column_idx];
 
-	if (params.limit <= 1) {
-		// LIMIT 1 -> we do not need to unnest
+	if (params.limit <= 1 && !params.IncludeTies()) {
+		// LIMIT 1 without ties -> we do not need to unnest
 		return op;
 	}
 
@@ -374,8 +391,9 @@ TopNWindowElimination::TryCreateUnnestOperator(unique_ptr<LogicalOperator> op,
 	unnest_aggregate->child = aggregate_column_ref->Copy();
 	unnest_exprs.push_back(std::move(unnest_aggregate));
 
-	if (params.include_row_number) {
-		// Create row number expression
+	if (params.include_window_column && !params.IncludeTies()) {
+		// For ROW_NUMBER: generate row numbers using generate_series
+		// For RANK: rank is already in the STRUCT, no need for generate_series
 		unnest_exprs.push_back(CreateRowNumberGenerator(std::move(aggregate_column_ref)));
 	}
 
@@ -387,9 +405,9 @@ TopNWindowElimination::TryCreateUnnestOperator(unique_ptr<LogicalOperator> op,
 	return unique_ptr<LogicalOperator>(std::move(unnest));
 }
 
-void TopNWindowElimination::AddStructExtractExprs(
-    vector<unique_ptr<Expression>> &exprs, const LogicalType &struct_type,
-    const unique_ptr<BoundColumnRefExpression> &aggregate_column_ref) const {
+unique_ptr<Expression> TopNWindowElimination::CreateStructExtractExpr(const Expression &source_expr,
+                                                                      const LogicalType &struct_type,
+                                                                      const string &field_name) const {
 	FunctionBinder function_binder(context);
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto &struct_extract_entry =
@@ -397,17 +415,38 @@ void TopNWindowElimination::AddStructExtractExprs(
 	const auto struct_extract_fun =
 	    struct_extract_entry.functions.GetFunctionByArguments(context, {struct_type, LogicalType::VARCHAR});
 
+	vector<unique_ptr<Expression>> args(2);
+	args[0] = source_expr.Copy();
+	args[1] = make_uniq<BoundConstantExpression>(Value(field_name));
+	auto result = function_binder.BindScalarFunction(struct_extract_fun, std::move(args));
+	result->alias = field_name;
+	return result;
+}
+
+void TopNWindowElimination::AddStructExtractExprs(vector<unique_ptr<Expression>> &exprs, const LogicalType &struct_type,
+                                                  const Expression &source_expr) const {
 	const auto &child_types = StructType::GetChildTypes(struct_type);
 	for (idx_t i = 0; i < child_types.size(); i++) {
-		const auto &alias = child_types[i].first;
+		exprs.push_back(CreateStructExtractExpr(source_expr, struct_type, child_types[i].first));
+	}
+}
 
-		vector<unique_ptr<Expression>> fun_args(2);
-		fun_args[0] = aggregate_column_ref->Copy();
-		fun_args[1] = make_uniq<BoundConstantExpression>(alias);
-
-		auto bound_function = function_binder.BindScalarFunction(struct_extract_fun, std::move(fun_args));
-		bound_function->alias = alias;
-		exprs.push_back(std::move(bound_function));
+void TopNWindowElimination::AddWindowColumnExpr(vector<unique_ptr<Expression>> &exprs,
+                                                const TopNWindowEliminationParameters &params,
+                                                const unique_ptr<LogicalOperator> &op,
+                                                const LogicalType &aggregate_type,
+                                                const Expression &aggregate_column_ref) const {
+	if (params.IncludeTies()) {
+		// RANK: extract "rank" field from STRUCT(arg: T, rank: BIGINT)
+		exprs.push_back(CreateStructExtractExpr(aggregate_column_ref, aggregate_type, "rank"));
+	} else if (op->type == LogicalOperatorType::LOGICAL_UNNEST) {
+		// ROW_NUMBER with N > 1: reference the generate_series column
+		auto row_number_column_binding = GetRowNumberColumnBinding(op);
+		exprs.push_back(
+		    make_uniq<BoundColumnRefExpression>("row_number", LogicalType::BIGINT, row_number_column_binding));
+	} else {
+		// ROW_NUMBER with N = 1: row number is always 1
+		exprs.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(1)));
 	}
 }
 
@@ -435,22 +474,29 @@ TopNWindowElimination::CreateProjectionOperator(unique_ptr<LogicalOperator> op,
 	auto aggregate_column_ref =
 	    make_uniq<BoundColumnRefExpression>(aggregate_type, ColumnBinding(aggregate_table_idx, 0));
 
-	if (params.payload_type == TopNPayloadType::STRUCT_PACK) {
-		AddStructExtractExprs(proj_exprs, aggregate_type, aggregate_column_ref);
+	// Step 1: Determine payload expression and its type
+	// For RANK: aggregate is STRUCT(arg: T, rank: BIGINT), extract "arg" to get the actual payload
+	// For ROW_NUMBER: aggregate result is the payload directly
+	unique_ptr<Expression> payload_expr;
+	LogicalType payload_type;
+	if (params.IncludeTies()) {
+		payload_type = StructType::GetChildType(aggregate_type, 0);
+		payload_expr = CreateStructExtractExpr(*aggregate_column_ref, aggregate_type, "arg");
 	} else {
-		// No need for struct_unpack! Just reference the aggregate column
-		proj_exprs.push_back(std::move(aggregate_column_ref));
+		payload_type = aggregate_type;
+		payload_expr = aggregate_column_ref->Copy();
 	}
 
-	if (params.include_row_number) {
-		// If aggregate (i.e., limit 1): constant, if unnest: expect there to be a second column
-		if (op->type == LogicalOperatorType::LOGICAL_UNNEST) {
-			auto row_number_column_binding = GetRowNumberColumnBinding(op);
-			proj_exprs.push_back(
-			    make_uniq<BoundColumnRefExpression>("row_number", LogicalType::BIGINT, row_number_column_binding));
-		} else {
-			proj_exprs.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(1)));
-		}
+	// Step 2: Add payload columns
+	if (params.payload_type == TopNPayloadType::STRUCT_PACK) {
+		AddStructExtractExprs(proj_exprs, payload_type, *payload_expr);
+	} else {
+		proj_exprs.push_back(std::move(payload_expr));
+	}
+
+	// Step 3: Add window column expression
+	if (params.include_window_column) {
+		AddWindowColumnExpr(proj_exprs, params, op, aggregate_type, *aggregate_column_ref);
 	}
 
 	auto logical_projection =
@@ -493,15 +539,19 @@ bool TopNWindowElimination::CanOptimize(LogicalOperator &op) {
 		return false;
 	}
 
+	// MAX_N must match the limit enforced in MinMaxNState::Initialize, which rejects n >= 1000000 at execution time.
+	// Skip optimization for out-of-range values so the query falls back to the standard window execution path instead
+	// of throwing.
+	static constexpr int64_t MAX_N = 1000000;
 	const auto bigint_value = filter_value.value.GetValue<int64_t>();
 	switch (comparison) {
 	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-		if (bigint_value < 1) {
+		if (bigint_value < 1 || bigint_value >= MAX_N) {
 			return false;
 		}
 		break;
 	case ExpressionType::COMPARE_LESSTHAN:
-		if (bigint_value < 2) {
+		if (bigint_value < 2 || bigint_value > MAX_N) {
 			return false;
 		}
 		break;
@@ -563,7 +613,13 @@ bool TopNWindowElimination::CanOptimize(LogicalOperator &op) {
 			}
 		}
 	}
-	if (window.expressions[0]->type != ExpressionType::WINDOW_ROW_NUMBER) {
+	auto window_func_type = window.expressions[0]->type;
+	switch (window_func_type) {
+	case ExpressionType::WINDOW_ROW_NUMBER:
+		break;
+	case ExpressionType::WINDOW_RANK:
+		break;
+	default:
 		return false;
 	}
 	auto &window_expr = window.expressions[0]->Cast<BoundWindowExpression>();
@@ -629,7 +685,8 @@ vector<unique_ptr<Expression>> TopNWindowElimination::GenerateAggregatePayload(c
 	}
 
 	if (aggregate_args.size() == 1) {
-		// If we only project the aggregate value itself, we do not need it as an arg
+		// If we only project the aggregate value itself, we do not need it as an arg.
+		// Exception: RANK always needs an arg because __internal_arg_min_rank/__internal_arg_max_rank requires it.
 		VisitExpression(&window_expr.orders[0].expression);
 		if (column_references.size() != 1) {
 			column_references.clear();
@@ -638,7 +695,8 @@ vector<unique_ptr<Expression>> TopNWindowElimination::GenerateAggregatePayload(c
 		const auto aggregate_value_binding = column_references.begin()->first;
 		column_references.clear();
 
-		if (window_expr.orders[0].expression->type == ExpressionType::BOUND_COLUMN_REF &&
+		bool is_rank = window.expressions[0]->type == ExpressionType::WINDOW_RANK;
+		if (!is_rank && window_expr.orders[0].expression->type == ExpressionType::BOUND_COLUMN_REF &&
 		    aggregate_args[0]->Cast<BoundColumnRefExpression>().binding == aggregate_value_binding) {
 			return {};
 		}
@@ -737,7 +795,7 @@ TopNWindowElimination::ExtractOptimizerParameters(const LogicalWindow &window, c
 	if (filter_expr.GetExpressionType() == ExpressionType::COMPARE_LESSTHAN) {
 		--params.limit;
 	}
-	params.include_row_number = BindingsReferenceRowNumber(bindings, window);
+	params.include_window_column = BindingsReferenceRowNumber(bindings, window);
 	params.payload_type = aggregate_payload.size() > 1 ? TopNPayloadType::STRUCT_PACK : TopNPayloadType::SINGLE_COLUMN;
 	auto &window_expr = window.expressions[0]->Cast<BoundWindowExpression>();
 	params.order_type = window_expr.orders[0].type;
@@ -753,7 +811,7 @@ TopNWindowElimination::ExtractOptimizerParameters(const LogicalWindow &window, c
 		}
 	}
 	column_references.clear();
-
+	params.window_function_type = window.expressions[0]->type;
 	return params;
 }
 
@@ -1068,8 +1126,8 @@ unique_ptr<LogicalOperator> TopNWindowElimination::ConstructJoin(unique_ptr<Logi
                                                                  const TopNWindowEliminationParameters &params) {
 	lhs->ResolveOperatorTypes();
 
-	const idx_t rowid_column_count =
-	    params.include_row_number ? rhs->types.size() - (aggregate_offset + 1) : rhs->types.size() - aggregate_offset;
+	const idx_t rowid_column_count = params.include_window_column ? rhs->types.size() - (aggregate_offset + 1)
+	                                                              : rhs->types.size() - aggregate_offset;
 	const idx_t rhs_binding_offset =
 	    rhs->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY ? 0 : aggregate_offset;
 
@@ -1087,7 +1145,7 @@ unique_ptr<LogicalOperator> TopNWindowElimination::ConstructJoin(unique_ptr<Logi
 		join->conditions.push_back(std::move(condition));
 	}
 
-	if (params.include_row_number) {
+	if (params.include_window_column) {
 		// Add row_number to join result
 		join->join_type = JoinType::INNER;
 		join->right_projection_map.push_back(rhs->types.size() - 1);

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -544,19 +544,15 @@ bool TopNWindowElimination::CanOptimize(LogicalOperator &op) {
 		return false;
 	}
 
-	// MAX_N must match the limit enforced in MinMaxNState::Initialize, which rejects n >= 1000000 at execution time.
-	// Skip optimization for out-of-range values so the query falls back to the standard window execution path instead
-	// of throwing.
-	static constexpr int64_t MAX_N = 1000000;
 	const auto bigint_value = filter_value.value.GetValue<int64_t>();
 	switch (comparison) {
 	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-		if (bigint_value < 1 || bigint_value >= MAX_N) {
+		if (bigint_value < 1 || bigint_value >= MINMAX_N_LIMIT) {
 			return false;
 		}
 		break;
 	case ExpressionType::COMPARE_LESSTHAN:
-		if (bigint_value < 2 || bigint_value > MAX_N) {
+		if (bigint_value < 2 || bigint_value > MINMAX_N_LIMIT) {
 			return false;
 		}
 		break;
@@ -1011,6 +1007,10 @@ bool TopNWindowElimination::CanUseLateMaterialization(const LogicalWindow &windo
 
 unique_ptr<LogicalOperator> TopNWindowElimination::TryPrepareLateMaterialization(const LogicalWindow &window,
                                                                                  vector<unique_ptr<Expression>> &args) {
+	if (optimizer.OptimizerDisabled(OptimizerType::LATE_MATERIALIZATION)) {
+		return nullptr;
+	}
+
 	vector<idx_t> lhs_projections;
 	vector<reference<LogicalOperator>> stack;
 	bool use_late_materialization = CanUseLateMaterialization(window, args, lhs_projections, stack);

--- a/test/sql/window/test_window_elimination_rank.test
+++ b/test/sql/window/test_window_elimination_rank.test
@@ -1,0 +1,392 @@
+# name: test/sql/window/topn_window_elimination_rank.test
+# description: Test TopN Window Elimination optimization for RANK
+# group: [window]
+
+require core_functions
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+SET explain_output='optimized_only'
+
+# Create test table
+statement ok
+CREATE TABLE test AS SELECT i % 3 as grp, i as val, 'name_' || i as name
+FROM range(100) t(i);
+
+# Test: Basic RANK optimization with <= filter
+query III rowsort
+SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk,
+           grp, val
+    FROM test
+) WHERE rk <= 3;
+----
+1	0	99
+1	1	97
+1	2	98
+2	0	96
+2	1	94
+2	2	95
+3	0	93
+3	1	91
+3	2	92
+
+# Test: RANK with < filter
+query III rowsort
+SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk,
+           grp, val
+    FROM test
+) WHERE rk < 3;
+----
+1	0	99
+1	1	97
+1	2	98
+2	0	96
+2	1	94
+2	2	95
+
+# Test RANK = 1 (should optimize, equivalent to RANK <= 1)
+query III rowsort
+SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk, grp, val
+    FROM test
+) WHERE rk = 1;
+----
+1	0	99
+1	1	97
+1	2	98
+
+# Verify RANK = 1 optimizes (no WINDOW)
+query II
+EXPLAIN SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk, grp, val
+    FROM test
+) WHERE rk = 1;
+----
+logical_opt	<!REGEX>:.*WINDOW.*
+
+# Verify RANK = 2 does NOT optimize (uses WINDOW)
+query II
+EXPLAIN SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk, grp, val
+    FROM test
+) WHERE rk = 2;
+----
+logical_opt	<REGEX>:.*WINDOW.*
+
+# Verify RANK <= N optimizes (uses HASH_GROUP_BY + UNNEST, no WINDOW)
+query II
+EXPLAIN SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk, grp, val
+    FROM test
+) WHERE rk <= 3;
+----
+logical_opt	<REGEX>:.*UNNEST.*
+
+# Test: RANK with all columns including name
+query IIII rowsort
+SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk,
+           grp, val, name
+    FROM test
+) WHERE rk <= 2;
+----
+1	0	99	name_99
+1	1	97	name_97
+1	2	98	name_98
+2	0	96	name_96
+2	1	94	name_94
+2	2	95	name_95
+
+# Internal functions should not be callable directly by users
+statement error
+SELECT __internal_arg_max_rank_nulls_last(name, val, 3) FROM test GROUP BY grp ORDER BY grp;
+----
+__internal_arg_max_rank_nulls_last is for internal use only!
+
+statement error
+SELECT __internal_arg_min_rank_nulls_last(name, val, 3) FROM test GROUP BY grp ORDER BY grp;
+----
+__internal_arg_min_rank_nulls_last is for internal use only!
+
+# Test with ties in data
+statement ok
+CREATE TABLE ties_test AS
+SELECT i % 3 as grp, i % 5 as val, i as id FROM range(30) t(i);
+
+# Test RANK with actual ties
+statement ok
+CREATE TABLE rank_ties AS VALUES
+(0, 99, 'a'), (0, 99, 'b'), (0, 93, 'c'), (0, 90, 'd'),
+(1, 80, 'e'), (1, 80, 'f'), (1, 70, 'g'), (1, 60, 'h');
+
+statement ok
+ALTER TABLE rank_ties RENAME COLUMN col0 TO grp;
+
+statement ok
+ALTER TABLE rank_ties RENAME COLUMN col1 TO val;
+
+statement ok
+ALTER TABLE rank_ties RENAME COLUMN col2 TO name;
+
+# RANK <= 3 with ties: grp 0 has val=99 twice (rank 1,1), val=93 is rank 3
+query IIII rowsort
+SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk,
+           grp, val, name
+    FROM rank_ties
+) WHERE rk <= 3;
+----
+1	0	99	a
+1	0	99	b
+1	1	80	e
+1	1	80	f
+3	0	93	c
+3	1	70	g
+
+# RANK = 1 with ties: should return all tied first-place rows
+query IIII rowsort
+SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk,
+           grp, val, name
+    FROM rank_ties
+) WHERE rk = 1;
+----
+1	0	99	a
+1	0	99	b
+1	1	80	e
+1	1	80	f
+
+# =============================================
+# Late Materialization Tests for RANK
+# =============================================
+
+# When projecting many columns (grp, val, name), late materialization should kick in
+# and use a HASH_JOIN to avoid struct_packing all columns
+# RANK with multiple columns should use late materialization (COMPARISON_JOIN)
+query II
+EXPLAIN SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk,
+           grp, val, name
+    FROM test
+) WHERE rk <= 3;
+----
+logical_opt	<REGEX>:.*COMPARISON_JOIN.*
+
+# RANK with few columns (no struct_pack needed) should NOT use late mat
+query II
+EXPLAIN SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk, grp, val
+    FROM test
+) WHERE rk <= 3;
+----
+logical_opt	<!REGEX>:.*COMPARISON_JOIN.*
+
+# Correctness: RANK with late mat and rank column referenced
+query IIII rowsort
+SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk,
+           grp, val, name
+    FROM test
+) WHERE rk <= 3;
+----
+1	0	99	name_99
+1	1	97	name_97
+1	2	98	name_98
+2	0	96	name_96
+2	1	94	name_94
+2	2	95	name_95
+3	0	93	name_93
+3	1	91	name_91
+3	2	92	name_92
+
+# =============================================
+# End Late Materialization Tests
+# =============================================
+
+# Test RANK with ASC order
+query III rowsort
+SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val ASC) as rk,
+           grp, val
+    FROM test
+) WHERE rk <= 2;
+----
+1	0	0
+1	1	1
+1	2	2
+2	0	3
+2	1	4
+2	2	5
+
+# RANK with no partition, projecting val and name (aggregate_args size > 1)
+query III rowsort
+SELECT * FROM (
+    SELECT rank() OVER (ORDER BY val DESC) as rk, val, name
+    FROM test
+) WHERE rk <= 3;
+----
+1	99	name_99
+2	98	name_98
+3	97	name_97
+
+query II
+EXPLAIN SELECT * FROM (
+    SELECT rank() OVER (ORDER BY val DESC) as rk, val, name
+    FROM test
+) WHERE rk <= 3;
+----
+logical_opt	<!REGEX>:.*WINDOW.*
+
+# RANK with two partition columns
+statement ok
+CREATE TABLE test_multi_part AS SELECT i % 3 as grp1, i % 2 as grp2, i as val, 'name_' || i as name
+FROM range(60) t(i);
+
+query IIII rowsort
+SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp1, grp2 ORDER BY val DESC) as rk,
+           grp1, grp2, val
+    FROM test_multi_part
+) WHERE rk <= 2;
+----
+1	0	0	54
+1	0	1	57
+1	1	0	58
+1	1	1	55
+1	2	0	56
+1	2	1	59
+2	0	0	48
+2	0	1	51
+2	1	0	52
+2	1	1	49
+2	2	0	50
+2	2	1	53
+
+# Verify two partition columns optimization uses UNNEST (no WINDOW)
+query II
+EXPLAIN SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp1, grp2 ORDER BY val DESC) as rk,
+           grp1, grp2, val
+    FROM test_multi_part
+) WHERE rk <= 2;
+----
+logical_opt	<REGEX>:.*UNNEST.*
+
+statement ok
+DROP TABLE test_multi_part;
+
+# Test: ties with a better value arriving - evicted element should be preserved
+# When all heap and ties values share the same key, inserting a better key
+# should preserve the evicted element in ties instead of dropping it.
+statement ok
+CREATE TABLE ties_boundary AS
+SELECT 1 as grp, 10 as val, 'same_' || i as name FROM range(10) t(i)
+UNION ALL
+SELECT 1 as grp, 5 as val, 'better' as name;
+
+# Verify the optimization is applied
+query II
+EXPLAIN SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val ASC) as rk, grp, val, name
+    FROM ties_boundary
+) WHERE rk <= 3;
+----
+logical_opt	<!REGEX>:.*WINDOW.*
+
+query IIII rowsort
+SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val ASC) as rk, grp, val, name
+    FROM ties_boundary
+) WHERE rk <= 3;
+----
+1	1	5	better
+2	1	10	same_0
+2	1	10	same_1
+2	1	10	same_2
+2	1	10	same_3
+2	1	10	same_4
+2	1	10	same_5
+2	1	10	same_6
+2	1	10	same_7
+2	1	10	same_8
+2	1	10	same_9
+
+statement ok
+DROP TABLE ties_boundary;
+
+# Cleanup
+statement ok
+DROP TABLE test;
+
+statement ok
+DROP TABLE ties_test;
+
+statement ok
+DROP TABLE rank_ties;
+
+# Test: RANK() with NULL values in ORDER BY column (ASC NULLS LAST)
+# Verifies that NULL ORDER BY values participate in ranking with correct NULLS LAST semantics.
+statement ok
+CREATE TABLE test_rank_null(grp INT, val INT)
+
+statement ok
+INSERT INTO test_rank_null VALUES
+    (1, 3), (1, 1), (1, NULL), (1, 2),
+    (2, NULL), (2, 5), (2, NULL)
+
+# grp=1: val ranked ASC NULLS LAST -> 1(rk1), 2(rk2), 3(rk3), NULL(rk4)
+# grp=2: val ranked ASC NULLS LAST -> 5(rk1), NULL(rk2), NULL(rk2)
+# WHERE rk <= 4 should include all rows, including NULLs
+query III rowsort
+SELECT rk, grp, val FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val NULLS LAST) as rk,
+           grp, val
+    FROM test_rank_null
+) WHERE rk <= 4
+----
+1	1	1
+1	2	5
+2	1	2
+2	2	NULL
+2	2	NULL
+3	1	3
+4	1	NULL
+
+# WHERE rk <= 2 should include NULL rows from grp=2 (rank 2) but not grp=1's NULL (rank 4)
+query III rowsort
+SELECT rk, grp, val FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val NULLS LAST) as rk,
+           grp, val
+    FROM test_rank_null
+) WHERE rk <= 2
+----
+1	1	1
+1	2	5
+2	1	2
+2	2	NULL
+2	2	NULL
+
+# Test: RANK() with NULL values in ORDER BY column (DESC NULLS LAST)
+# grp=1: val ranked DESC NULLS LAST -> 3(rk1), 2(rk2), 1(rk3), NULL(rk4)
+# grp=2: val ranked DESC NULLS LAST -> 5(rk1), NULL(rk2), NULL(rk2)
+query III rowsort
+SELECT rk, grp, val FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC NULLS LAST) as rk,
+           grp, val
+    FROM test_rank_null
+) WHERE rk <= 4
+----
+1	1	3
+1	2	5
+2	1	2
+2	2	NULL
+2	2	NULL
+3	1	1
+4	1	NULL
+
+statement ok
+DROP TABLE test_rank_null

--- a/test/sql/window/test_window_elimination_rank.test
+++ b/test/sql/window/test_window_elimination_rank.test
@@ -1,4 +1,4 @@
-# name: test/sql/window/topn_window_elimination_rank.test
+# name: test/sql/window/test_window_elimination_rank.test
 # description: Test TopN Window Elimination optimization for RANK
 # group: [window]
 
@@ -278,6 +278,18 @@ logical_opt	<REGEX>:.*UNNEST.*
 
 statement ok
 DROP TABLE test_multi_part;
+
+# No-payload: only partition key
+query I rowsort
+SELECT grp FROM (
+    SELECT grp, RANK() OVER (PARTITION BY grp ORDER BY sum(val) DESC) AS ranking
+    FROM test
+    GROUP BY grp
+) WHERE ranking <= 5;
+----
+0
+1
+2
 
 # Test: ties with a better value arriving - evicted element should be preserved
 # When all heap and ties values share the same key, inserting a better key

--- a/test/sql/window/test_window_elimination_rank.test
+++ b/test/sql/window/test_window_elimination_rank.test
@@ -203,6 +203,40 @@ SELECT * FROM (
 3	1	91	name_91
 3	2	92	name_92
 
+# When late_materialization is disabled, should NOT use COMPARISON_JOIN
+statement ok
+SET disabled_optimizers='late_materialization';
+
+query II
+EXPLAIN SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk,
+           grp, val, name
+    FROM test
+) WHERE rk <= 3;
+----
+logical_opt	<!REGEX>:.*COMPARISON_JOIN.*
+
+# Correctness: result should be the same even with late_materialization disabled
+query IIII rowsort
+SELECT * FROM (
+    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) as rk,
+           grp, val, name
+    FROM test
+) WHERE rk <= 3;
+----
+1	0	99	name_99
+1	1	97	name_97
+1	2	98	name_98
+2	0	96	name_96
+2	1	94	name_94
+2	2	95	name_95
+3	0	93	name_93
+3	1	91	name_91
+3	2	92	name_92
+
+statement ok
+RESET disabled_optimizers;
+
 # =============================================
 # End Late Materialization Tests
 # =============================================


### PR DESCRIPTION
## Extend TopN Window Elimination to Support RANK()

### Background

Top-N queries with window functions are extremely common in analytical workloads. A typical pattern looks like:

```sql
SELECT * FROM (
    SELECT *, rank() OVER (PARTITION BY grp ORDER BY val DESC) AS rk
    FROM t
) WHERE rk <= N;
```

DuckDB already has an excellent optimization for `ROW_NUMBER()` in this pattern — the `top_n_window_elimination` optimizer rewrites it into a heap-based aggregation (`arg_min` / `arg_max`), avoiding the need to fully sort all data within each partition. This is a huge win because the standard window function approach requires **sorting the entire dataset within each partition** (O(n log n) per partition), even when we only need the top N rows. The aggregation-based approach uses a bounded heap (O(n log N) per partition) which is significantly faster, especially when N is small relative to the partition size.

However, this optimization previously **only applied to `ROW_NUMBER()`**, not to `RANK()`. This PR extends the optimization to cover `RANK()` as well.

### Approach

The core idea follows the same pattern as the existing `ROW_NUMBER()` optimization, but with an important difference: `RANK()` must handle **ties** (rows with equal ORDER BY values that share the same rank).

#### Plan Transformation

**Before optimization:**
```
Filter (rk <= N)
└── Window (RANK OVER PARTITION BY grp ORDER BY val DESC)
    └── Scan
```

**After optimization:**
```
Projection (extract rk, grp, val, ...)
└── UNNEST
    └── HASH_GROUP_BY
        │  GROUP BY: grp                                    ← PARTITION BY columns
        │  Aggregate: __internal_arg_max_rank_nulls_last(   ← internal aggregate (not user-accessible)
        │      struct_pack(val, ...),                       ← payload columns
        │      val,                                         ← ORDER BY column
        │      N                                            ← limit
        │  )                  returns LIST<STRUCT(arg, rank)>
        └── Scan
```

#### SQL Equivalent

```sql
-- Before
SELECT * FROM (
    SELECT rank() OVER (PARTITION BY grp ORDER BY val DESC) AS rk,
           grp, val, name
    FROM employees
) WHERE rk <= 3;

-- After (logically equivalent, using internal aggregate)
SELECT
    (unnest(top_rows)).rank AS rk,
    grp,
    (unnest(top_rows)).arg.val,
    (unnest(top_rows)).arg.name
FROM (
    SELECT grp,
           __internal_arg_max_rank_nulls_last(struct_pack(val, name), val, 3) AS top_rows
    FROM employees
    GROUP BY grp
);
-- Example result for one partition:
-- top_rows = [
--   {arg: {val:99, name:'a'}, rank: 1},
--   {arg: {val:99, name:'b'}, rank: 1},   ← tie: same rank 1
--   {arg: {val:93, name:'c'}, rank: 3}    ← rank jumps to 3 (RANK semantics)
-- ]
```

### Implementation Details

#### 1. New Internal Aggregate: `__internal_arg_min/max_rank_nulls_last`

These are **internal-only** functions used exclusively by the optimizer — direct invocation throws `BinderException`. They take three arguments `(payload, order_key, n)` and return `LIST<STRUCT(arg: payload_type, rank: BIGINT)>`.

The functions are intentionally kept internal because the design of their public-facing API is still an open question: what should the signature look like, what return type makes sense for users, and how should they compose with other aggregate functions? These questions deserve a separate discussion before exposing them as user-callable functions. See [#20860](https://github.com/duckdb/duckdb/discussions/20860) for some related context. The internal variants introduced here serve only as optimizer-generated intermediates and are not part of the public API.

The key data structure is `BinaryAggregateHeapWithTies` (in `minmax_n_helpers.hpp`), which extends the existing `BinaryAggregateHeap` to track tie entries at the boundary:

```cpp
template <class K, class V, class K_COMPARATOR>
class BinaryAggregateHeapWithTies {
    STORAGE_TYPE *heap;          // main bounded heap (capacity = N)
    idx_t heap_size;
    vector<STORAGE_TYPE> ties;   // entries tied with the heap's top element

    void Insert(ArenaAllocator &allocator, const K &key, const V &value) {
        if (heap_size < capacity) {
            // Heap not full: insert normally
        } else if (KeyEquals(key, heap[0].first.value)) {
            // Key ties with boundary: add to ties buffer
            ties.push_back(...);
        } else if (K_COMPARATOR::Operation(key, heap[0].first.value)) {
            // Key is better than boundary: replace heap top, reset ties if boundary changed
        }
        // Key worse than boundary: ignore
    }
};
```

During `Finalize`, the function:
1. Sorts heap + ties by key
2. Computes correct RANK values (with gaps: `1, 1, 3, ...`)
3. Returns `LIST<STRUCT(arg, rank)>`

The optimizer constructs `BoundAggregateExpression` directly (bypassing the bind path which intentionally throws) using `ArgMinMaxRankHelper::GetInternalArgMinRank` / `GetInternalArgMaxRank`. Custom serialize/deserialize callbacks are registered to support query plan serialization.

#### 2. Optimizer Changes (`top_n_window_elimination`)

The existing rewrite pipeline is extended to handle `RANK` alongside `ROW_NUMBER`. The two paths share the same overall structure (detect window + filter → rewrite to aggregate + UNNEST + projection), but differ in two key aspects:

- **Aggregate result type**: for `ROW_NUMBER` the aggregate yields the raw payload; for `RANK` it yields `LIST<STRUCT(arg, rank)>`, with the rank baked in by the aggregate itself. The projection step extracts `arg` and `rank` as separate columns.
- **UNNEST is always required for `RANK`**: for `ROW_NUMBER` with N=1 the optimizer skips UNNEST and emits a constant `1`. For `RANK`, UNNEST is always emitted because ties at the boundary can produce more than one output row even when N=1.

Individual changes:
- `TopNWindowEliminationParameters`: renamed `include_row_number` → `include_window_column`; added `window_function_type` field and `IncludeTies()` helper
- `CanOptimize()`: extended to recognize `WINDOW_RANK` in addition to `WINDOW_ROW_NUMBER`; added `MAX_N = 1_000_000` guard to match runtime limit
- `CreateAggregateExpression()`: dispatches to `ArgMinMaxRankHelper` for RANK, bypassing catalog lookup
- `TryCreateUnnestOperator()`: always uses UNNEST for RANK (even when N = 1, since ties may expand the result)
- `CreateProjectionOperator()`: for RANK, extracts `arg` and `rank` fields from the `STRUCT` result; for ROW_NUMBER, behavior unchanged
- `AddWindowColumnExpr()`: new helper that handles RANK (extract `rank` from STRUCT) vs ROW_NUMBER (generate_series or constant 1)
- `CreateStructExtractExpr()`: extracted as a reusable helper

#### 3. Edge Cases

| Filter | Optimized? | Notes |
|---|---|---|
| `RANK <= N` | Yes | Standard case |
| `RANK < N` | Yes | Converted to `RANK <= N - 1` |
| `RANK = 1` | Yes | Equivalent to `RANK <= 1` |
| `RANK = N` (N > 1) | No | Falls back to standard window |
| `RANK <= N` (N >= 1_000_000) | No | Exceeds heap limit |

Ties at the boundary are handled correctly: if multiple rows share rank N, all of them are included in the output.

### Benchmark

Using TPC-H lineitem table at SF=10:

```sql
LOAD tpch;
CALL dbgen(sf=10);

FROM lineitem
SELECT *, rank() OVER (PARTITION BY l_suppkey ORDER BY l_shipdate DESC) AS my_ranking
QUALIFY my_ranking <= 3;
```

| Configuration | Wall Clock | User Time | System Time |
|---|---|---|---|
| **With optimization** | 0.548s | 6.479s | 0.142s |
| **Without optimization** | 2.350s | 23.013s | 2.374s |
| **Speedup** | **~4.3x** | **~3.6x** | **~16.7x** |

### Follow-up Work

This PR is part of a broader effort to bring fast top-N aggregation to rank and dense_rank window functions:

1. **Extend `TopNWindowElimination` to support `RANK()`** — this PR
2. Extend `TopNWindowElimination` to support `DENSE_RANK()`
3. Support public `rank` aggregate function
4. Support public `dense_rank` aggregate function

Items 1 and 2 are purely optimizer rewrites and are straightforward to ship independently. Items 3 and 4 require more careful API design — questions like function signature, return type, and composition with other aggregates need to be settled first (see [#20860](https://github.com/duckdb/duckdb/discussions/20860)). Keeping them separate means the optimizer improvements are not blocked by those open design decisions.