### PR TITLE
Rewrite List Comprehension Expressions

### DIFF
--- a/src/include/duckdb/optimizer/rule/list.hpp
+++ b/src/include/duckdb/optimizer/rule/list.hpp
@@ -9,6 +9,7 @@
 #include "duckdb/optimizer/rule/distributivity.hpp"
 #include "duckdb/optimizer/rule/empty_needle_removal.hpp"
 #include "duckdb/optimizer/rule/like_optimizations.hpp"
+#include "duckdb/optimizer/rule/list_comprehension_rewrite.hpp"
 #include "duckdb/optimizer/rule/move_constants.hpp"
 #include "duckdb/optimizer/rule/enum_comparison.hpp"
 #include "duckdb/optimizer/rule/regex_optimizations.hpp"

--- a/src/include/duckdb/optimizer/rule/list_comprehension_rewrite.hpp
+++ b/src/include/duckdb/optimizer/rule/list_comprehension_rewrite.hpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/rule/list_comprehension_rewrite.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/optimizer/rule.hpp"
+
+namespace duckdb {
+
+//! Rewrites list comprehensions that use struct_pack for filter/result into list_filter + list_apply
+class ListComprehensionRewriteRule : public Rule {
+public:
+	explicit ListComprehensionRewriteRule(ExpressionRewriter &rewriter);
+
+	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &fixed_point,
+	                             bool is_root) override;
+};
+
+} // namespace duckdb

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -49,7 +49,6 @@ namespace duckdb {
 Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context), binder(binder), rewriter(context) {
 	rewriter.rules.push_back(make_uniq<ConstantOrderNormalizationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<ConstantFoldingRule>(rewriter));
-	rewriter.rules.push_back(make_uniq<ListComprehensionRewriteRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<DistributivityRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<ArithmeticSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<CaseSimplificationRule>(rewriter));
@@ -69,6 +68,7 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 	rewriter.rules.push_back(make_uniq<EnumComparisonRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<JoinDependentFilterRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<TimeStampComparison>(context, rewriter));
+	rewriter.rules.push_back(make_uniq<ListComprehensionRewriteRule>(rewriter));
 
 #ifdef DEBUG
 	for (auto &rule : rewriter.rules) {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -49,6 +49,7 @@ namespace duckdb {
 Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context), binder(binder), rewriter(context) {
 	rewriter.rules.push_back(make_uniq<ConstantOrderNormalizationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<ConstantFoldingRule>(rewriter));
+	rewriter.rules.push_back(make_uniq<ListComprehensionRewriteRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<DistributivityRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<ArithmeticSimplificationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<CaseSimplificationRule>(rewriter));

--- a/src/optimizer/rule/CMakeLists.txt
+++ b/src/optimizer/rule/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library_unity(
   in_clause_simplification_rule.cpp
   join_dependent_filter.cpp
   like_optimizations.cpp
+  list_comprehension_rewrite.cpp
   move_constants.cpp
   ordered_aggregate_optimizer.cpp
   regex_optimizations.cpp

--- a/src/optimizer/rule/list_comprehension_rewrite.cpp
+++ b/src/optimizer/rule/list_comprehension_rewrite.cpp
@@ -16,6 +16,7 @@ namespace duckdb {
 namespace {
 
 bool IsTargetListFunction(ClientContext &context, const BoundFunctionExpression &expr, const string &target_name) {
+	// Compare function name with catalog to recognize aliases
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, expr.function.name,
 	                                                          OnEntryNotFound::RETURN_NULL);
@@ -146,7 +147,6 @@ unique_ptr<Expression> ListComprehensionRewriteRule::Apply(LogicalOperator &, ve
 	}
 
 	// Build list_filter(list, lambda filter_expr)
-	// TODO: Make changes to existing list_filter instead of creating a new one?
 	vector<unique_ptr<Expression>> filter_children;
 	filter_children.reserve(inner_apply.children.size());
 	for (idx_t i = 0; i < inner_apply.children.size(); i++) {

--- a/src/optimizer/rule/list_comprehension_rewrite.cpp
+++ b/src/optimizer/rule/list_comprehension_rewrite.cpp
@@ -2,7 +2,6 @@
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
-#include "duckdb/common/assert.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/function/lambda_functions.hpp"
@@ -43,7 +42,9 @@ optional_ptr<Expression> UnwrapCasts(optional_ptr<Expression> expr) {
 }
 
 optional_ptr<Expression> FindStructPackChildByName(BoundFunctionExpression &struct_pack, const string &name) {
-	D_ASSERT(struct_pack.return_type == LogicalTypeId::STRUCT);
+	if (struct_pack.return_type != LogicalTypeId::STRUCT) {
+		return nullptr;
+	}
 	for (auto &child : struct_pack.children) {
 		if (child->GetAlias() == name) {
 			return child.get();

--- a/src/optimizer/rule/list_comprehension_rewrite.cpp
+++ b/src/optimizer/rule/list_comprehension_rewrite.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
+#include "duckdb/common/assert.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/function/lambda_functions.hpp"
@@ -42,9 +43,7 @@ optional_ptr<Expression> UnwrapCasts(optional_ptr<Expression> expr) {
 }
 
 optional_ptr<Expression> FindStructPackChildByName(BoundFunctionExpression &struct_pack, const string &name) {
-	if (struct_pack.return_type != LogicalTypeId::STRUCT) {
-		return nullptr;
-	}
+	D_ASSERT(struct_pack.return_type.id() == LogicalTypeId::STRUCT);
 	for (auto &child : struct_pack.children) {
 		if (child->GetAlias() == name) {
 			return child.get();

--- a/src/optimizer/rule/list_comprehension_rewrite.cpp
+++ b/src/optimizer/rule/list_comprehension_rewrite.cpp
@@ -121,7 +121,7 @@ struct ListComprehensionMatch {
 
 vector<unique_ptr<Expression>> CopyCapturedChildren(BoundFunctionExpression &inner_apply) {
 	vector<unique_ptr<Expression>> captured_children;
-	captured_children.reserve(inner_apply.children.size() > 0 ? inner_apply.children.size() - 1 : 0);
+	captured_children.reserve(inner_apply.children.empty() ? 0 : inner_apply.children.size() - 1);
 	for (idx_t i = 1; i < inner_apply.children.size(); i++) {
 		captured_children.push_back(inner_apply.children[i]->Copy());
 	}

--- a/src/optimizer/rule/list_comprehension_rewrite.cpp
+++ b/src/optimizer/rule/list_comprehension_rewrite.cpp
@@ -1,0 +1,178 @@
+#include "duckdb/optimizer/rule/list_comprehension_rewrite.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/function/lambda_functions.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+
+namespace duckdb {
+
+namespace {
+
+bool IsTargetListFunction(ClientContext &context, const BoundFunctionExpression &expr, const string &target_name) {
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, expr.function.name,
+	                                                          OnEntryNotFound::RETURN_NULL);
+	if (!entry) {
+		return false;
+	}
+	if (!entry->alias_of.empty()) {
+		return entry->alias_of == target_name;
+	}
+	return entry->name == target_name;
+}
+
+bool IsStructPack(const BoundFunctionExpression &expr) {
+	return expr.function.name == "struct_pack";
+}
+
+optional_ptr<Expression> UnwrapCasts(optional_ptr<Expression> expr) {
+	while (expr->GetExpressionClass() == ExpressionClass::BOUND_CAST) {
+		auto &cast_expr = expr->Cast<BoundCastExpression>();
+		expr = cast_expr.child.get();
+	}
+	return expr;
+}
+
+optional_ptr<Expression> FindStructPackChildByName(BoundFunctionExpression &struct_pack, const string &name) {
+	if (struct_pack.return_type.id() == LogicalTypeId::STRUCT) {
+		auto &child_types = StructType::GetChildTypes(struct_pack.return_type);
+		for (idx_t i = 0; i < child_types.size(); i++) {
+			if (StringUtil::CIEquals(child_types[i].first, name)) {
+				return struct_pack.children[i].get();
+			}
+		}
+	}
+	for (auto &child : struct_pack.children) {
+		if (StringUtil::CIEquals(child->GetAlias(), name)) {
+			return child.get();
+		}
+	}
+	return nullptr;
+}
+
+bool UsesIndexParameter(Expression &expr) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
+		auto &ref = expr.Cast<BoundReferenceExpression>();
+		if (ref.index == 1) {
+			return true;
+		}
+	}
+	bool uses_index = false;
+	ExpressionIterator::EnumerateChildren(expr, [&](unique_ptr<Expression> &child) {
+		if (uses_index) {
+			return;
+		}
+		if (child->GetExpressionClass() == ExpressionClass::BOUND_REF) {
+			auto &ref = child->Cast<BoundReferenceExpression>();
+			if (ref.index == 1) {
+				uses_index = true;
+				return;
+			}
+		}
+		if (!uses_index) {
+			uses_index = UsesIndexParameter(*child);
+		}
+	});
+	return uses_index;
+}
+
+} // namespace
+
+ListComprehensionRewriteRule::ListComprehensionRewriteRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	root = make_uniq<ExpressionMatcher>(ExpressionClass::BOUND_FUNCTION);
+}
+
+unique_ptr<Expression> ListComprehensionRewriteRule::Apply(LogicalOperator &, vector<reference<Expression>> &bindings,
+                                                           bool &, bool) {
+	auto &root = bindings[0].get().Cast<BoundFunctionExpression>();
+	auto &context = GetContext();
+	// Check if expression has a list_transform -> list_filter -> list_transform pattern from list comprehension
+	if (!IsTargetListFunction(context, root, "list_transform")) {
+		return nullptr;
+	}
+	if (root.children.empty()) {
+		return nullptr;
+	}
+
+	if (root.children[0]->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		return nullptr;
+	}
+	auto &list_filter_expr = root.children[0]->Cast<BoundFunctionExpression>();
+	if (!IsTargetListFunction(context, list_filter_expr, "list_filter")) {
+		return nullptr;
+	}
+	if (list_filter_expr.children.empty()) {
+		return nullptr;
+	}
+
+	if (list_filter_expr.children[0]->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		return nullptr;
+	}
+	auto &inner_apply = list_filter_expr.children[0]->Cast<BoundFunctionExpression>();
+	if (!IsTargetListFunction(context, inner_apply, "list_transform") || !inner_apply.bind_info) {
+		return nullptr;
+	}
+	auto &inner_bind = inner_apply.bind_info->Cast<ListLambdaBindData>();
+	if (!inner_bind.lambda_expr) {
+		return nullptr;
+	}
+	auto inner_base = UnwrapCasts(*inner_bind.lambda_expr);
+	if (inner_base->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		return nullptr;
+	}
+	auto &struct_pack = inner_base->Cast<BoundFunctionExpression>();
+	if (!IsStructPack(struct_pack)) {
+		return nullptr;
+	}
+
+	auto filter_expr = FindStructPackChildByName(struct_pack, "filter");
+	auto result_expr = FindStructPackChildByName(struct_pack, "result");
+	if (!filter_expr || !result_expr) {
+		return nullptr;
+	}
+
+	if (inner_bind.has_index && UsesIndexParameter(*result_expr)) {
+		return nullptr;
+	}
+	if (result_expr->IsVolatile()) {
+		return nullptr;
+	}
+
+	// Build list_filter(list, lambda filter_expr)
+	// TODO: Make changes to existing list_filter instead of creating a new one?
+	vector<unique_ptr<Expression>> filter_children;
+	filter_children.reserve(inner_apply.children.size());
+	for (idx_t i = 0; i < inner_apply.children.size(); i++) {
+		filter_children.push_back(std::move(inner_apply.children[i]));
+	}
+
+	auto filter_return_type = filter_children[0]->return_type;
+	auto filter_bind_info =
+	    make_uniq<ListLambdaBindData>(filter_return_type, filter_expr->Copy(), inner_bind.has_index);
+	auto new_filter =
+	    make_uniq<BoundFunctionExpression>(filter_return_type, list_filter_expr.function, std::move(filter_children),
+	                                       std::move(filter_bind_info), list_filter_expr.is_operator);
+
+	// Build list_apply(list_filter(...), lambda result_expr)
+	vector<unique_ptr<Expression>> apply_children;
+	apply_children.reserve(inner_apply.children.size());
+	apply_children.push_back(std::move(new_filter));
+	for (idx_t i = 1; i < inner_apply.children.size(); i++) {
+		apply_children.push_back(inner_apply.children[i]->Copy());
+	}
+
+	auto apply_return_type = LogicalType::LIST(result_expr->return_type);
+	auto apply_bind_info = make_uniq<ListLambdaBindData>(apply_return_type, result_expr->Copy(), inner_bind.has_index);
+	auto new_apply = make_uniq<BoundFunctionExpression>(apply_return_type, root.function, std::move(apply_children),
+	                                                    std::move(apply_bind_info), root.is_operator);
+	return std::move(new_apply);
+}
+
+} // namespace duckdb

--- a/src/optimizer/rule/list_comprehension_rewrite.cpp
+++ b/src/optimizer/rule/list_comprehension_rewrite.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/function/lambda_functions.hpp"
+#include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -17,6 +18,11 @@ namespace duckdb {
 namespace {
 
 bool IsTargetListFunction(ClientContext &context, const BoundFunctionExpression &expr, const string &target_name) {
+	D_ASSERT(!expr.children.empty());
+	if (expr.function.name == target_name && expr.children[0]->return_type.id() == LogicalTypeId::LIST) {
+		return true;
+	}
+
 	// Compare function name with catalog to recognize aliases
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, expr.function.name,
@@ -55,27 +61,35 @@ optional_ptr<Expression> FindStructPackChildByName(BoundFunctionExpression &stru
 bool UsesIndexParameter(Expression &expr) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
 		auto &ref = expr.Cast<BoundReferenceExpression>();
-		if (ref.index == 1) {
+		if (ref.index == 0) {
 			return true;
 		}
 	}
 	bool uses_index = false;
-	ExpressionIterator::EnumerateChildren(expr, [&](unique_ptr<Expression> &child) {
-		if (uses_index) {
-			return;
-		}
-		if (child->GetExpressionClass() == ExpressionClass::BOUND_REF) {
-			auto &ref = child->Cast<BoundReferenceExpression>();
-			if (ref.index == 1) {
-				uses_index = true;
+	ExpressionIterator::EnumerateChildren(expr, [&uses_index](unique_ptr<Expression> &child) {
+		ExpressionIterator::EnumerateExpression(child, [&uses_index](Expression &child) {
+			if (uses_index) {
 				return;
 			}
-		}
-		if (!uses_index) {
-			uses_index = UsesIndexParameter(*child);
-		}
+			if (child.GetExpressionClass() == ExpressionClass::BOUND_REF) {
+				auto &ref = child.Cast<BoundReferenceExpression>();
+				if (ref.index == 0) {
+					uses_index = true;
+					return;
+				}
+			}
+		});
 	});
 	return uses_index;
+}
+
+void RemoveIndexInputSlot(unique_ptr<Expression> &expr) {
+	ExpressionIterator::VisitExpressionClassMutable(expr, ExpressionClass::BOUND_REF,
+	                                                [&](unique_ptr<Expression> &child) {
+		                                                auto &ref = child->Cast<BoundReferenceExpression>();
+		                                                D_ASSERT(ref.index > 0);
+		                                                ref.index--;
+	                                                });
 }
 
 bool MatchesStructFieldProjection(Expression &expr, const string &field_name) {
@@ -231,7 +245,12 @@ unique_ptr<Expression> BuildListComprehensionRewrite(ListComprehensionMatch &mat
 	}
 
 	auto apply_return_type = LogicalType::LIST(result_expr.return_type);
-	auto apply_bind_info = make_uniq<ListLambdaBindData>(apply_return_type, result_expr.Copy(), inner_bind.has_index);
+	auto apply_lambda = result_expr.Copy();
+	if (inner_bind.has_index) {
+		// The apply function included an index but it was not used. Adapt references to exclude index
+		RemoveIndexInputSlot(apply_lambda);
+	}
+	auto apply_bind_info = make_uniq<ListLambdaBindData>(apply_return_type, std::move(apply_lambda));
 	return make_uniq<BoundFunctionExpression>(apply_return_type, root.function, std::move(apply_children),
 	                                          std::move(apply_bind_info), root.is_operator);
 }

--- a/src/optimizer/rule/list_comprehension_rewrite.cpp
+++ b/src/optimizer/rule/list_comprehension_rewrite.cpp
@@ -18,8 +18,8 @@ namespace duckdb {
 namespace {
 
 bool IsTargetListFunction(ClientContext &context, const BoundFunctionExpression &expr, const string &target_name) {
-	D_ASSERT(!expr.children.empty());
-	if (expr.function.name == target_name && expr.children[0]->return_type.id() == LogicalTypeId::LIST) {
+	if (expr.function.name == target_name) {
+		D_ASSERT(!expr.children.empty() && expr.children[0]->return_type.id() == LogicalTypeId::LIST);
 		return true;
 	}
 

--- a/test/sql/optimizer/expression/list_comprehension_rewrite.test
+++ b/test/sql/optimizer/expression/list_comprehension_rewrite.test
@@ -1,0 +1,56 @@
+# name: test/sql/optimizer/expression/list_comprehension_rewrite.test
+# description: Test conditional list comprehension rewriting
+# group: [expression]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA explain_output='OPTIMIZED_ONLY'
+
+statement ok
+CREATE TABLE t(l INTEGER[]);
+
+statement ok
+INSERT INTO t VALUES ([10, 9, 8, 7, 6]);
+
+query II
+EXPLAIN SELECT [i + 5 FOR x, i IN l IF i > 2] FROM t;
+----
+logical_opt	<REGEX>:.*list_apply.*list_filter.*list_apply.*
+
+query II
+EXPLAIN SELECT [i + 5 FOR x, i IN l IF x > 8] FROM t;
+----
+logical_opt	<REGEX>:.*list_apply.*list_filter.*list_apply.*
+
+query II
+EXPLAIN SELECT [x + 5 FOR x, i IN l IF i > 2] FROM t;
+----
+logical_opt	<!REGEX>:.*list_apply.*list_filter.*list_apply.*
+
+query II
+EXPLAIN SELECT [x + 5 FOR x, i IN l IF x > 8] FROM t;
+----
+logical_opt	<!REGEX>:.*list_apply.*list_filter.*list_apply.*
+
+query I
+SELECT [i + 5 FOR x, i IN l IF i > 2] FROM t;
+----
+[8, 9, 10]
+
+query I
+SELECT [i + 5 FOR x, i IN l IF x > 8] FROM t;
+----
+[6, 7]
+
+query I
+SELECT [x + 5 FOR x, i IN l IF i > 2] FROM t;
+----
+[13, 12, 11]
+
+query I
+SELECT [x + 5 FOR x, i IN l IF x > 8] FROM t;
+----
+[15, 14]
+

--- a/test/sql/optimizer/expression/list_comprehension_rewrite.test
+++ b/test/sql/optimizer/expression/list_comprehension_rewrite.test
@@ -54,3 +54,33 @@ SELECT [x + 5 FOR x, i IN l IF x > 8] FROM t;
 ----
 [15, 14]
 
+# Alias tests for list_transform/list_filter
+foreach t list_transform apply array_apply array_transform list_transform
+
+foreach f list_filter array_filter filter
+
+# Test the number of functions with the number of round brackets as there is no ${...} string replacement in the results
+query II
+EXPLAIN SELECT ${t}(${f}(${t}(l, lambda x, i: struct_pack(filter := i > 2, result := i + 5)), lambda s: s.filter), lambda s: s.result) FROM t;
+----
+logical_opt	<REGEX>:.*PROJECTION.*Expressions:.*\(.*\(.*\(.*l.*\).*\).*\).*SCAN.*
+
+query II
+EXPLAIN SELECT ${t}(${f}(${t}(l, lambda x, i: struct_pack(filter := i > 2, result := x + 5)), lambda s: s.filter), lambda s: s.result) FROM t;
+----
+logical_opt	<REGEX>:.*PROJECTION.*Expressions:.*\(.*\(.*l.*\).*\).*SCAN.*
+
+query I
+SELECT ${t}(${f}(${t}(l, lambda x, i: struct_pack(filter := i > 2, result := i + 5)), lambda s: s.filter), lambda s: s.result) FROM t;
+----
+[8, 9, 10]
+
+query I
+SELECT ${t}(${f}(${t}(l, lambda x, i: struct_pack(filter := i > 2, result := x + 5)), lambda s: s.filter), lambda s: s.result) FROM t;
+----
+[13, 12, 11]
+
+endloop
+
+endloop
+

--- a/test/sql/optimizer/expression/list_comprehension_rewrite.test
+++ b/test/sql/optimizer/expression/list_comprehension_rewrite.test
@@ -95,3 +95,15 @@ SELECT list_transform(
 ) FROM t;
 ----
 [13, 12, 11]
+
+# Captured values add extra children to list_transform/list_filter/list_apply. Ensure rewrite stays safe.
+statement ok
+CREATE TABLE capture_t(l INTEGER[], c INTEGER);
+
+statement ok
+INSERT INTO capture_t VALUES ([10, 9, 8, 7, 6], 8);
+
+query I
+SELECT [x + c FOR x IN l IF x > c] FROM capture_t;
+----
+[18, 17]

--- a/test/sql/optimizer/expression/list_comprehension_rewrite.test
+++ b/test/sql/optimizer/expression/list_comprehension_rewrite.test
@@ -84,3 +84,14 @@ endloop
 
 endloop
 
+# Non-comprehension nested list lambda should not be rewritten.
+query I
+SELECT list_transform(
+	list_filter(
+		list_transform(l, lambda x: struct_pack(filter := x > 8, result := x + 5)),
+		lambda s: NOT s.filter
+	),
+	lambda s: s.result
+) FROM t;
+----
+[13, 12, 11]

--- a/test/sql/optimizer/expression/list_comprehension_rewrite.test
+++ b/test/sql/optimizer/expression/list_comprehension_rewrite.test
@@ -55,7 +55,7 @@ SELECT [x + 5 FOR x, i IN l IF x > 8] FROM t;
 [15, 14]
 
 # Alias tests for list_transform/list_filter
-foreach t list_transform apply array_apply array_transform list_transform
+foreach t list_transform apply array_apply array_transform
 
 foreach f list_filter array_filter filter
 
@@ -107,3 +107,9 @@ query I
 SELECT [x + c FOR x IN l IF x > c] FROM capture_t;
 ----
 [18, 17]
+
+query II
+EXPLAIN SELECT [x * random() FOR x, i IN l IF x > 2] FROM t;
+----
+logical_opt	<REGEX>:.*list_apply.*list_filter.*list_apply.*
+


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/7341

This PR adds an optimizer rule that simplifies list comprehension rewrites
```sql
-- user input
[g(x) FOR x, i IN l IF f(x, i)] 
-- parser rewrite
l.apply(lambda x: x.result).filter(lambda x: x.filter).apply(lambda x, i: {'filter': f(x,i), 'result': g(x})
-- to
l.filter(lambda x, i: f(x, i)).apply(lambda x: g(x))
```

The reason for this is that the parser now generally rewrites list comprehensions `[g(x,i) FOR x, i IN lF f(x,i)` into the first form so that the `i`s in `g(x, i)` and `f(x, i)` are shared. However, if `g` is independent of `i`, we can safely simplify the function tree and significantly speedup those list comprehension expressions (cf. the micro benchmark in https://github.com/duckdb/duckdb/pull/20581)