### PR TITLE
Remove hardcoded list of exclude_archs for extensions

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -113,6 +113,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-draft
     outputs:
+      # NOTE: on PRs we exclude some archs to speed things up
+      reduced_ci_mode: ${{ (github.event_name == 'pull_request' || inputs.run_all != 'true') && 'enabled' || 'disabled' }}
       main_extensions_config: ${{ steps.set-main-extensions.outputs.extension_config }}
       main_extensions_exclude_archs: ${{ steps.set-main-extensions.outputs.exclude_archs }}
       main_extensions_opt_in_archs: ${{ steps.set-main-extensions.outputs.opt_in_archs }}
@@ -122,8 +124,6 @@ jobs:
       external_extensions_exclude_archs: ${{ steps.set-external-extensions.outputs.exclude_archs }}
 
     env:
-      # NOTE: on PRs we exclude some archs to speed things up
-      BASE_EXCLUDE_ARCHS: ${{ (github.event_name == 'pull_request' || inputs.run_all != 'true') && 'wasm_mvp;wasm_threads;windows_amd64_mingw;osx_amd64;osx_arm64;linux_arm64;linux_amd64_musl;' || '' }}
       EXTRA_EXCLUDE_ARCHS: ${{ inputs.extra_exclude_archs }}
       OPT_IN_ARCHS: ${{ inputs.opt_in_archs }}
     steps:
@@ -140,7 +140,7 @@ jobs:
           DEFAULT_EXCLUDE_ARCHS: ''
         run: |
           # Set config
-          echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$BASE_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
+          echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
           echo opt_in_archs="$OPT_IN_ARCHS" >> $GITHUB_OUTPUT
           in_tree_extensions="`cat $IN_TREE_CONFIG_FILE`"
           out_of_tree_extensions="`cat $OUT_OF_TREE_CONFIG_FILE`"
@@ -157,7 +157,7 @@ jobs:
           CONFIG_FILE: .github/config/rust_based_extensions.cmake
           DEFAULT_EXCLUDE_ARCHS: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
         run: |
-          echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$BASE_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
+          echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
           rust_based_extensions="`cat .github/config/rust_based_extensions.cmake`"
           echo "extension_config<<EOF" >> $GITHUB_OUTPUT
           echo "$rust_based_extensions" >> $GITHUB_OUTPUT
@@ -170,7 +170,7 @@ jobs:
           CONFIG_FILE: .github/config/external_extensions.cmake
           DEFAULT_EXCLUDE_ARCHS: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_amd64_musl'
         run: |
-          echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$BASE_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
+          echo exclude_archs="$DEFAULT_EXCLUDE_ARCHS;$EXTRA_EXCLUDE_ARCHS" >> $GITHUB_OUTPUT
           external_extensions="`cat .github/config/external_extensions.cmake`"
           echo "extension_config<<EOF" >> $GITHUB_OUTPUT
           echo "$external_extensions" >> $GITHUB_OUTPUT
@@ -186,6 +186,8 @@ jobs:
     uses: ./.github/workflows/_extension_distribution.yml
     with:
       artifact_prefix: main-extensions
+      # NOTE: on PRs we exclude some archs to speed things up
+      reduced_ci_mode: ${{ needs.load-extension-configs.outputs.reduced_ci_mode }}
       exclude_archs: ${{ needs.load-extension-configs.outputs.main_extensions_exclude_archs }}
       opt_in_archs: ${{ needs.load-extension-configs.outputs.main_extensions_opt_in_archs }}
       extension_config: ${{ needs.load-extension-configs.outputs.main_extensions_config }}
@@ -203,6 +205,8 @@ jobs:
       - vars
     uses: ./.github/workflows/_extension_distribution.yml
     with:
+      # NOTE: on PRs we exclude some archs to speed things up
+      reduced_ci_mode: ${{ needs.load-extension-configs.outputs.reduced_ci_mode }}
       exclude_archs: ${{ needs.load-extension-configs.outputs.rust_based_extensions_exclude_archs }}
       artifact_prefix: rust-based-extensions
       extension_config: ${{ needs.load-extension-configs.outputs.rust_based_extensions_config }}
@@ -220,6 +224,8 @@ jobs:
       - vars
     uses: ./.github/workflows/_extension_distribution.yml
     with:
+      # NOTE: on PRs we exclude some archs to speed things up
+      reduced_ci_mode: ${{ needs.load-extension-configs.outputs.reduced_ci_mode }}
       exclude_archs: ${{ needs.load-extension-configs.outputs.external_extensions_exclude_archs }}
       artifact_prefix: external-extensions
       extension_config: ${{ needs.load-extension-configs.outputs.external_extensions_config }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -28,6 +28,10 @@ on:
         required: false
         type: string
         default: ""
+      reduced_ci_mode:
+        required: false
+        type: string
+        default: "auto"
       skip_tests:
         required: false
         type: boolean
@@ -49,6 +53,8 @@ jobs:
       # Note when `upload_all_extensions` is true, the extension name is used as prefix to the artifact holding all built extensions
       upload_all_extensions: true
       extension_name: ${{ inputs.artifact_prefix }}
+
+      reduced_ci_mode: ${{ inputs.reduced_ci_mode }}
 
       # DuckDB version is overridden to the current commit of the current repository
       set_caller_as_duckdb: true


### PR DESCRIPTION
This is a follow-up PR for the extensions CI tools [PR](https://github.com/duckdb/extension-ci-tools/pull/323).

It removes the hardcoded list of excluded duckdb_archs by relying on the `reduced_ci_mode` logic.