### PR TITLE
[Fix] BWC for `ShreddingType` read in parquet extension

### DIFF
--- a/extension/parquet/include/parquet_shredding.hpp
+++ b/extension/parquet/include/parquet_shredding.hpp
@@ -29,6 +29,9 @@ public:
 	explicit ShreddingType(const LogicalType &type);
 
 public:
+	bool operator==(const ShreddingType &other) const;
+
+public:
 	ShreddingType Copy() const;
 
 public:

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -613,9 +613,8 @@ static void ParquetCopySerialize(Serializer &serializer, const FunctionData &bin
 	                                    default_value.string_dictionary_page_size_limit);
 	serializer.WritePropertyWithDefault(116, "geoparquet_version", bind_data.geoparquet_version,
 	                                    default_value.geoparquet_version);
-	if (serializer.ShouldSerialize(7) && bind_data.shredding_types.set) {
-		serializer.WriteProperty(117, "shredding_types", bind_data.shredding_types);
-	}
+	serializer.WritePropertyWithDefault<ShreddingType>(117, "shredding_types", bind_data.shredding_types,
+	                                                   default_value.shredding_types);
 }
 
 static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserializer, CopyFunction &function) {

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -613,7 +613,9 @@ static void ParquetCopySerialize(Serializer &serializer, const FunctionData &bin
 	                                    default_value.string_dictionary_page_size_limit);
 	serializer.WritePropertyWithDefault(116, "geoparquet_version", bind_data.geoparquet_version,
 	                                    default_value.geoparquet_version);
-	serializer.WriteProperty(117, "shredding_types", bind_data.shredding_types);
+	if (serializer.ShouldSerialize(7) && bind_data.shredding_types.set) {
+		serializer.WriteProperty(117, "shredding_types", bind_data.shredding_types);
+	}
 }
 
 static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserializer, CopyFunction &function) {

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -647,7 +647,8 @@ static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserialize
 	    115, "string_dictionary_page_size_limit", default_value.string_dictionary_page_size_limit);
 	data->geoparquet_version =
 	    deserializer.ReadPropertyWithExplicitDefault(116, "geoparquet_version", default_value.geoparquet_version);
-	data->shredding_types = deserializer.ReadProperty<ShreddingType>(117, "shredding_types");
+	data->shredding_types =
+	    deserializer.ReadPropertyWithExplicitDefault<ShreddingType>(117, "shredding_types", ShreddingType());
 
 	return std::move(data);
 }

--- a/extension/parquet/parquet_shredding.cpp
+++ b/extension/parquet/parquet_shredding.cpp
@@ -21,6 +21,43 @@ ShreddingType::ShreddingType() : set(false) {
 ShreddingType::ShreddingType(const LogicalType &type) : set(true), type(type) {
 }
 
+bool ShreddingType::operator==(const ShreddingType &other) const {
+	if (set != other.set) {
+		return false;
+	}
+	if (!set) {
+		return true;
+	}
+	if (type != other.type) {
+		return false;
+	}
+	if (!children.types && !other.children.types) {
+		return true;
+	}
+	if (!children.types || !other.children.types) {
+		return false;
+	}
+	auto &a_children = *children.types;
+	auto &b_children = *other.children.types;
+	if (a_children.size() != b_children.size()) {
+		return false;
+	}
+	for (auto a_it = a_children.begin(); a_it != a_children.end(); ++a_it) {
+		auto &a_name = a_it->first;
+		auto b_it = b_children.find(a_name);
+		if (b_it == b_children.end()) {
+			return false;
+		}
+
+		auto &a_child = a_it->second;
+		auto &b_child = b_it->second;
+		if (!(a_child == b_child)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 ShreddingType ShreddingType::Copy() const {
 	auto result = set ? ShreddingType(type) : ShreddingType();
 	result.children = children.Copy();


### PR DESCRIPTION
Needs to read an explicit default, if not set (coming from an older version).

Fixes https://github.com/duckdblabs/motherduck/issues/455