### PR TITLE
Fix INSERT OR REPLACE memory leak for in-memory databases

### DIFF
--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -1038,17 +1038,13 @@ idx_t TemplatedUpdateNumericStatistics(UpdateSegment *segment, SegmentStatistics
 
 idx_t UpdateStringStatistics(UpdateSegment *segment, SegmentStatistics &stats, UnifiedVectorFormat &update, idx_t count,
                              SelectionVector &sel) {
-	auto update_data = update.GetDataNoConst<string_t>(update);
+	auto update_data = update.GetData<string_t>(update);
 	auto &mask = update.validity;
 	if (mask.AllValid()) {
 		stats.statistics.SetHasNoNullFast();
 		for (idx_t i = 0; i < count; i++) {
 			auto idx = update.sel->get_index(i);
-			auto &str = update_data[idx];
-			StringStats::Update(stats.statistics, str);
-			if (!str.IsInlined()) {
-				update_data[idx] = segment->GetStringHeap().AddBlob(str);
-			}
+			StringStats::Update(stats.statistics, update_data[idx]);
 		}
 		sel.Initialize(nullptr);
 		return count;
@@ -1060,11 +1056,7 @@ idx_t UpdateStringStatistics(UpdateSegment *segment, SegmentStatistics &stats, U
 			if (mask.RowIsValid(idx)) {
 				stats.statistics.SetHasNoNullFast();
 				sel.set_index(not_null_count++, i);
-				auto &str = update_data[idx];
-				StringStats::Update(stats.statistics, str);
-				if (!str.IsInlined()) {
-					update_data[idx] = segment->GetStringHeap().AddBlob(str);
-				}
+				StringStats::Update(stats.statistics, update_data[idx]);
 			} else {
 				stats.statistics.SetHasNullFast();
 			}
@@ -1313,6 +1305,18 @@ void UpdateSegment::Update(TransactionData transaction, DataTable &data_table, i
 		count = get_effective_updates(update_format, ids, count, sel, base_data, vector_offset);
 		if (count == 0) {
 			return;
+		}
+	}
+
+	// for VARCHAR columns, copy non-inlined strings to the heap for long-term storage
+	if (column_data.type.InternalType() == PhysicalType::VARCHAR) {
+		auto update_data = update_format.GetDataNoConst<string_t>(update_format);
+		for (idx_t i = 0; i < count; i++) {
+			auto uidx = update_format.sel->get_index(sel.get_index(i));
+			auto &str = update_data[uidx];
+			if (!str.IsInlined()) {
+				str = heap.AddBlob(str);
+			}
 		}
 	}
 

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -203,7 +203,11 @@ DuckTransactionManager::CanCheckpoint(DuckTransaction &transaction, unique_ptr<S
 		if (checkpoint_type == CheckpointType::CONCURRENT_CHECKPOINT) {
 			return CheckpointDecision("Cannot vacuum, and compression is disabled for in-memory table");
 		}
-		return CheckpointDecision(CheckpointType::VACUUM_ONLY);
+		if (!undo_properties.has_updates) {
+			return CheckpointDecision(CheckpointType::VACUUM_ONLY);
+		}
+		// when updates exist, UpdateSegment StringHeaps may have accumulated
+		// orphaned strings - a full checkpoint rewrites row groups, freeing them
 	}
 	return CheckpointDecision(checkpoint_type);
 }

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -16,6 +16,8 @@
 #include "duckdb/transaction/rollback_state.hpp"
 #include "duckdb/transaction/wal_write_state.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
+#include "duckdb/transaction/update_info.hpp"
+#include "duckdb/storage/table/update_segment.hpp"
 
 namespace duckdb {
 constexpr uint32_t UNDO_ENTRY_HEADER_SIZE = sizeof(UndoFlags) + sizeof(uint32_t);
@@ -132,9 +134,12 @@ UndoBufferProperties UndoBuffer::GetProperties() {
 	IteratorState iterator_state;
 	IterateEntries(iterator_state, [&](UndoFlags entry_type, data_ptr_t data) {
 		switch (entry_type) {
-		case UndoFlags::UPDATE_TUPLE:
+		case UndoFlags::UPDATE_TUPLE: {
 			properties.has_updates = true;
+			auto info = reinterpret_cast<UpdateInfo *>(data);
+			properties.estimated_size += info->segment->GetStringHeap().AllocationSize();
 			break;
+		}
 		case UndoFlags::DELETE_TUPLE: {
 			auto info = reinterpret_cast<DeleteInfo *>(data);
 			if (info->is_consecutive) {

--- a/test/sql/storage/memory/in_memory_insert_or_replace_leak.test
+++ b/test/sql/storage/memory/in_memory_insert_or_replace_leak.test
@@ -1,0 +1,33 @@
+# name: test/sql/storage/memory/in_memory_insert_or_replace_leak.test
+# description: Test that INSERT OR REPLACE does not leak memory
+# group: [memory]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE test (id INTEGER PRIMARY KEY, value VARCHAR);
+
+statement ok
+INSERT INTO test VALUES (1, repeat('a', 10000));
+
+loop i 0 1000
+
+statement ok
+INSERT OR REPLACE INTO test VALUES (1, repeat('b', 10000));
+
+endloop
+
+# without fix, ~10MB of dead strings would accumulate in StringHeap
+query I
+SELECT CASE WHEN memory_usage_bytes < 5000000 THEN 'success'
+       ELSE error(concat('Expected ALLOCATOR < 5MB, got ', memory_usage_bytes, ' bytes'))
+       END
+FROM duckdb_memory() WHERE tag='ALLOCATOR'
+----
+success
+
+query I
+SELECT length(value) FROM test WHERE id = 1
+----
+10000


### PR DESCRIPTION
### Description

Repeated `INSERT OR REPLACE` on the same primary key in an in-memory database caused unbounded memory growth, eventually leading to OOM.

### Root Cause

* `UpdateStringStatistics` copied VARCHAR values into `UpdateSegment::StringHeap` (ArenaAllocator-backed) before `get_effective_updates` filtered unchanged rows.
* Repeated upserts with identical values accumulated dead strings that could not be freed individually.
* In-memory DBs always used `VACUUM_ONLY` for auto-checkpoints, which does not rewrite RowGroups, so `StringHeap` was never reclaimed.

### Changes

1. Move `AddBlob` from `UpdateStringStatistics` to after `get_effective_updates` in `UpdateSegment::Update`. Only effective updates copy strings into the heap.
2. Use `FULL_CHECKPOINT` instead of `VACUUM_ONLY` for in-memory auto-checkpoints when updates exist, enabling RowGroup rewrite and heap cleanup.

### Related Issue

Fixes #17129