### PR TITLE
Allow USING COMPRESSION on MAP/LIST columns to apply to leaf scalar columns

### DIFF
--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -37,6 +37,37 @@ static void CreateColumnDependencyManager(BoundCreateTableInfo &info) {
 	}
 }
 
+// Recursively checks whether compression_type is valid for any leaf (scalar) type within a complex type.
+// For MAP/LIST/STRUCT, the compression is applied to compatible child columns at checkpoint time;
+// non-compatible intermediate columns (e.g. the LIST or STRUCT shell) silently fall back to AUTO.
+static bool CompressionValidForLeafTypes(DBConfig &config, CompressionType compression_type,
+                                         const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::MAP: {
+		auto &key_type = MapType::KeyType(type);
+		auto &value_type = MapType::ValueType(type);
+		return CompressionValidForLeafTypes(config, compression_type, key_type) ||
+		       CompressionValidForLeafTypes(config, compression_type, value_type);
+	}
+	case LogicalTypeId::LIST: {
+		auto &child_type = ListType::GetChildType(type);
+		return CompressionValidForLeafTypes(config, compression_type, child_type);
+	}
+	case LogicalTypeId::STRUCT: {
+		for (auto &child : StructType::GetChildTypes(type)) {
+			if (CompressionValidForLeafTypes(config, compression_type, child.second)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	default: {
+		auto physical_type = type.InternalType();
+		return config.GetCompressionFunction(compression_type, physical_type) != nullptr;
+	}
+	}
+}
+
 static void VerifyCompressionType(ClientContext &context, optional_ptr<StorageManager> storage_manager,
                                   DBConfig &config, BoundCreateTableInfo &info) {
 	auto &base = info.base->Cast<CreateTableInfo>();
@@ -70,6 +101,11 @@ static void VerifyCompressionType(ClientContext &context, optional_ptr<StorageMa
 		}
 		auto compression_method = config.GetCompressionFunction(compression_type, physical_type);
 		if (!compression_method) {
+			// For complex types (MAP, LIST, STRUCT), the compression is propagated to leaf scalar columns.
+			// Accept if the compression type is compatible with at least one leaf child type.
+			if (CompressionValidForLeafTypes(config, compression_type, logical_type)) {
+				continue;
+			}
 			throw BinderException(
 			    "Can't compress column \"%s\" with type '%s' (physical: %s) using compression type '%s'", col.Name(),
 			    logical_type.ToString(), EnumUtil::ToString(physical_type), CompressionTypeToString(compression_type));

--- a/test/sql/storage/compression/dict_fsst/test_map_compression.test
+++ b/test/sql/storage/compression/dict_fsst/test_map_compression.test
@@ -1,0 +1,94 @@
+# name: test/sql/storage/compression/dict_fsst/test_map_compression.test
+# description: Test USING COMPRESSION on MAP/LIST columns propagates to leaf VARCHAR child columns
+# group: [dict_fsst]
+
+load __TEST_DIR__/test_map_compression.db readwrite v1.4.2
+
+# MAP(VARCHAR, VARCHAR) with DICT_FSST compression should be accepted and applied to key/value columns
+statement ok
+CREATE TABLE map_compressed (
+	m MAP(VARCHAR, VARCHAR) USING COMPRESSION DICT_FSST
+);
+
+statement ok
+INSERT INTO map_compressed VALUES
+	(MAP {'hello': 'world', 'foo': 'bar'}),
+	(MAP {'hello': 'world', 'baz': 'qux'}),
+	(MAP {'hello': 'world', 'foo': 'bar'}),
+	(MAP {'hello': 'world', 'baz': 'qux'}),
+	(MAP {'hello': 'world', 'foo': 'bar'}),
+	(MAP {'hello': 'world', 'baz': 'qux'}),
+	(MAP {'test': 'value', 'key': 'data'}),
+	(MAP {'test': 'value', 'key': 'data'}),
+	(NULL);
+
+statement ok
+CHECKPOINT
+
+# Verify the key and value VARCHAR segments are compressed with DICT_FSST
+query I
+SELECT compression FROM pragma_storage_info('map_compressed') WHERE segment_type ILIKE 'VARCHAR' LIMIT 2
+----
+DICT_FSST
+DICT_FSST
+
+# Verify data roundtrips correctly - ordered alphabetically by string representation
+query I
+SELECT m FROM map_compressed WHERE m IS NOT NULL ORDER BY m::VARCHAR LIMIT 3
+----
+{hello=world, baz=qux}
+{hello=world, baz=qux}
+{hello=world, baz=qux}
+
+# MAP(VARCHAR, BIGINT) - compression applies to the VARCHAR key leaf only;
+# BIGINT values don't support DICT_FSST but that's fine - they fall back to AUTO
+statement ok
+CREATE TABLE map_mixed (
+	m MAP(VARCHAR, BIGINT) USING COMPRESSION DICT_FSST
+);
+
+statement ok
+INSERT INTO map_mixed VALUES
+	(MAP {'alpha': 1, 'beta': 2}),
+	(MAP {'alpha': 1, 'gamma': 3}),
+	(MAP {'alpha': 1, 'beta': 2}),
+	(MAP {'alpha': 1, 'gamma': 3});
+
+statement ok
+CHECKPOINT
+
+# The VARCHAR key segments should be DICT_FSST compressed
+query I
+SELECT compression FROM pragma_storage_info('map_mixed') WHERE segment_type ILIKE 'VARCHAR' LIMIT 1
+----
+DICT_FSST
+
+# LIST(VARCHAR) with DICT_FSST compression - applies to the element (child) column
+statement ok
+CREATE TABLE list_compressed (
+	l VARCHAR[] USING COMPRESSION DICT_FSST
+);
+
+statement ok
+INSERT INTO list_compressed VALUES
+	(['hello', 'world', 'foo']),
+	(['hello', 'world', 'bar']),
+	(['hello', 'world', 'foo']),
+	(['hello', 'world', 'bar']),
+	(NULL);
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT compression FROM pragma_storage_info('list_compressed') WHERE segment_type ILIKE 'VARCHAR' LIMIT 1
+----
+DICT_FSST
+
+# Compression on a MAP with no compatible leaf types should still fail
+statement error
+CREATE TABLE map_int_int (
+	m MAP(INTEGER, INTEGER) USING COMPRESSION DICT_FSST
+);
+----
+Can't compress column "m" with type 'MAP(INTEGER, INTEGER)' (physical: LIST) using compression type 'DICT_FSST'


### PR DESCRIPTION
Previously, specifying a compression type (e.g. DICT_FSST) on a MAP or LIST column failed at bind time because the validation only checked the column's physical type (LIST), not the types of its children.

`MAP(VARCHAR, VARCHAR)` is stored as `LIST(STRUCT(key: VARCHAR, value: VARCHAR))`. The checkpoint layer already propagates the column's compression hint to all child columns and ForceCompression() already falls back to AUTO for physical types that don't support the requested compression. So the storage path was correct — only the binder validation was too strict.

Fix: add CompressionValidForLeafTypes() that recursively walks MAP/LIST/STRUCT to check whether the compression type is compatible with any leaf scalar type. VerifyCompressionType() now uses this as a fallback before raising an error.

Behaviour:
- MAP(VARCHAR, VARCHAR) USING COMPRESSION DICT_FSST: both key and value VARCHAR child columns are compressed with DICT_FSST
- MAP(VARCHAR, BIGINT) USING COMPRESSION DICT_FSST: the VARCHAR key column gets DICT_FSST; the BIGINT value column falls back to AUTO
- VARCHAR[] USING COMPRESSION DICT_FSST: the list element column gets DICT_FSST
- MAP(INTEGER, INTEGER) USING COMPRESSION DICT_FSST: still raises an error because no leaf type is compatible with DICT_FSST