### PR TITLE
Allow custom block allocator

### DIFF
--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -463,10 +463,13 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 	if (!config.allocator) {
 		config.allocator = make_uniq<Allocator>();
 	}
-	auto default_block_size = Settings::Get<DefaultBlockSizeSetting>(config);
-	config.block_allocator = make_uniq<BlockAllocator>(*config.allocator, default_block_size,
-	                                                   DBConfig::GetSystemAvailableMemory(*config.file_system) * 8 / 10,
-	                                                   config.options.block_allocator_size);
+	config.block_allocator = std::move(new_config.block_allocator);
+	if (!config.block_allocator) {
+		auto default_block_size = Settings::Get<DefaultBlockSizeSetting>(config);
+		config.block_allocator = make_uniq<BlockAllocator>(
+		    *config.allocator, default_block_size, DBConfig::GetSystemAvailableMemory(*config.file_system) * 8 / 10,
+		    config.options.block_allocator_size);
+	}
 	config.replacement_scans = std::move(new_config.replacement_scans);
 	if (new_config.callback_manager) {
 		config.callback_manager = std::move(new_config.callback_manager);


### PR DESCRIPTION
Hi, we're overriding `config.buffer_pool` to a customer BufferPool implementation. With the introduction of `BlockAllocator` in DuckDB 1.5, BufferPool implementations also need to provide a `BlockAllocator`. In order to be able to continue customizing the BufferPool implementation we will need to be able to pass `config.block_allocator` into the config too, and not have it overridden when DuckDB initializes (as it then creates a `BlockAllocator` that's not associated with the custom buffer pool anymore).