### PR TITLE
Convert bool_and and bit operations aggregates to struct-based state

### DIFF
--- a/extension/core_functions/aggregate/distributive/bitagg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitagg.cpp
@@ -21,10 +21,10 @@ template <class T>
 LogicalType GetBitStateType(const AggregateFunction &function) {
 	child_list_t<LogicalType> child_types;
 	child_types.emplace_back("is_set", LogicalType::BOOLEAN);
-	
+
 	LogicalType value_type = function.return_type;
 	child_types.emplace_back("value", value_type);
-	
+
 	return LogicalType::STRUCT(std::move(child_types));
 }
 
@@ -230,8 +230,9 @@ AggregateFunctionSet BitAndFun::GetFunctions() {
 		bit_and.AddFunction(GetBitfieldUnaryAggregate<BitAndOperation>(type));
 	}
 
-	auto bit_string_fun = AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringAndOperation>(
-	    LogicalType::BIT, LogicalType::BIT);
+	auto bit_string_fun =
+	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringAndOperation>(
+	        LogicalType::BIT, LogicalType::BIT);
 	bit_string_fun.SetStructStateExport(GetBitStringStateType);
 	bit_and.AddFunction(bit_string_fun);
 	return bit_and;
@@ -242,8 +243,9 @@ AggregateFunctionSet BitOrFun::GetFunctions() {
 	for (auto &type : LogicalType::Integral()) {
 		bit_or.AddFunction(GetBitfieldUnaryAggregate<BitOrOperation>(type));
 	}
-	auto bit_string_fun = AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringOrOperation>(
-	    LogicalType::BIT, LogicalType::BIT);
+	auto bit_string_fun =
+	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringOrOperation>(
+	        LogicalType::BIT, LogicalType::BIT);
 	bit_string_fun.SetStructStateExport(GetBitStringStateType);
 	bit_or.AddFunction(bit_string_fun);
 	return bit_or;
@@ -254,8 +256,9 @@ AggregateFunctionSet BitXorFun::GetFunctions() {
 	for (auto &type : LogicalType::Integral()) {
 		bit_xor.AddFunction(GetBitfieldUnaryAggregate<BitXorOperation>(type));
 	}
-	auto bit_string_fun = AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringXorOperation>(
-	    LogicalType::BIT, LogicalType::BIT);
+	auto bit_string_fun =
+	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringXorOperation>(
+	        LogicalType::BIT, LogicalType::BIT);
 	bit_string_fun.SetStructStateExport(GetBitStringStateType);
 	bit_xor.AddFunction(bit_string_fun);
 	return bit_xor;

--- a/extension/core_functions/aggregate/distributive/bitagg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitagg.cpp
@@ -31,7 +31,7 @@ LogicalType GetBitStateType(const AggregateFunction &function) {
 LogicalType GetBitStringStateType(const AggregateFunction &function) {
 	child_list_t<LogicalType> child_types;
 	child_types.emplace_back("is_set", LogicalType::BOOLEAN);
-	child_types.emplace_back("value", LogicalType::BIT);
+	child_types.emplace_back("value", function.return_type);
 	return LogicalType::STRUCT(std::move(child_types));
 }
 

--- a/extension/core_functions/aggregate/distributive/bitagg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitagg.cpp
@@ -17,29 +17,57 @@ struct BitState {
 	T value;
 };
 
+template <class T>
+LogicalType GetBitStateType(const AggregateFunction &function) {
+	child_list_t<LogicalType> child_types;
+	child_types.emplace_back("is_set", LogicalType::BOOLEAN);
+	
+	LogicalType value_type = function.return_type;
+	child_types.emplace_back("value", value_type);
+	
+	return LogicalType::STRUCT(std::move(child_types));
+}
+
+LogicalType GetBitStringStateType(const AggregateFunction &function) {
+	child_list_t<LogicalType> child_types;
+	child_types.emplace_back("is_set", LogicalType::BOOLEAN);
+	child_types.emplace_back("value", LogicalType::BIT);
+	return LogicalType::STRUCT(std::move(child_types));
+}
+
 template <class OP>
 AggregateFunction GetBitfieldUnaryAggregate(LogicalType type) {
 	switch (type.id()) {
 	case LogicalTypeId::TINYINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, int8_t, int8_t, OP>(type, type);
+		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, int8_t, int8_t, OP>(type, type)
+		    .SetStructStateExport(GetBitStateType<uint8_t>);
 	case LogicalTypeId::SMALLINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, int16_t, int16_t, OP>(type, type);
+		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, int16_t, int16_t, OP>(type, type)
+		    .SetStructStateExport(GetBitStateType<uint16_t>);
 	case LogicalTypeId::INTEGER:
-		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, int32_t, int32_t, OP>(type, type);
+		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, int32_t, int32_t, OP>(type, type)
+		    .SetStructStateExport(GetBitStateType<uint32_t>);
 	case LogicalTypeId::BIGINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, int64_t, int64_t, OP>(type, type);
+		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, int64_t, int64_t, OP>(type, type)
+		    .SetStructStateExport(GetBitStateType<uint64_t>);
 	case LogicalTypeId::HUGEINT:
-		return AggregateFunction::UnaryAggregate<BitState<hugeint_t>, hugeint_t, hugeint_t, OP>(type, type);
+		return AggregateFunction::UnaryAggregate<BitState<hugeint_t>, hugeint_t, hugeint_t, OP>(type, type)
+		    .SetStructStateExport(GetBitStateType<hugeint_t>);
 	case LogicalTypeId::UTINYINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, uint8_t, uint8_t, OP>(type, type);
+		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, uint8_t, uint8_t, OP>(type, type)
+		    .SetStructStateExport(GetBitStateType<uint8_t>);
 	case LogicalTypeId::USMALLINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, uint16_t, uint16_t, OP>(type, type);
+		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, uint16_t, uint16_t, OP>(type, type)
+		    .SetStructStateExport(GetBitStateType<uint16_t>);
 	case LogicalTypeId::UINTEGER:
-		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, uint32_t, uint32_t, OP>(type, type);
+		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, uint32_t, uint32_t, OP>(type, type)
+		    .SetStructStateExport(GetBitStateType<uint32_t>);
 	case LogicalTypeId::UBIGINT:
-		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, uint64_t, uint64_t, OP>(type, type);
+		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, uint64_t, uint64_t, OP>(type, type)
+		    .SetStructStateExport(GetBitStateType<uint64_t>);
 	case LogicalTypeId::UHUGEINT:
-		return AggregateFunction::UnaryAggregate<BitState<uhugeint_t>, uhugeint_t, uhugeint_t, OP>(type, type);
+		return AggregateFunction::UnaryAggregate<BitState<uhugeint_t>, uhugeint_t, uhugeint_t, OP>(type, type)
+		    .SetStructStateExport(GetBitStateType<uhugeint_t>);
 	default:
 		throw InternalException("Unimplemented bitfield type for unary aggregate");
 	}
@@ -202,9 +230,10 @@ AggregateFunctionSet BitAndFun::GetFunctions() {
 		bit_and.AddFunction(GetBitfieldUnaryAggregate<BitAndOperation>(type));
 	}
 
-	bit_and.AddFunction(
-	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringAndOperation>(
-	        LogicalType::BIT, LogicalType::BIT));
+	auto bit_string_fun = AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringAndOperation>(
+	    LogicalType::BIT, LogicalType::BIT);
+	bit_string_fun.SetStructStateExport(GetBitStringStateType);
+	bit_and.AddFunction(bit_string_fun);
 	return bit_and;
 }
 
@@ -213,9 +242,10 @@ AggregateFunctionSet BitOrFun::GetFunctions() {
 	for (auto &type : LogicalType::Integral()) {
 		bit_or.AddFunction(GetBitfieldUnaryAggregate<BitOrOperation>(type));
 	}
-	bit_or.AddFunction(
-	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringOrOperation>(
-	        LogicalType::BIT, LogicalType::BIT));
+	auto bit_string_fun = AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringOrOperation>(
+	    LogicalType::BIT, LogicalType::BIT);
+	bit_string_fun.SetStructStateExport(GetBitStringStateType);
+	bit_or.AddFunction(bit_string_fun);
 	return bit_or;
 }
 
@@ -224,9 +254,10 @@ AggregateFunctionSet BitXorFun::GetFunctions() {
 	for (auto &type : LogicalType::Integral()) {
 		bit_xor.AddFunction(GetBitfieldUnaryAggregate<BitXorOperation>(type));
 	}
-	bit_xor.AddFunction(
-	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringXorOperation>(
-	        LogicalType::BIT, LogicalType::BIT));
+	auto bit_string_fun = AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringXorOperation>(
+	    LogicalType::BIT, LogicalType::BIT);
+	bit_string_fun.SetStructStateExport(GetBitStringStateType);
+	bit_xor.AddFunction(bit_string_fun);
 	return bit_xor;
 }
 

--- a/extension/core_functions/aggregate/distributive/bool.cpp
+++ b/extension/core_functions/aggregate/distributive/bool.cpp
@@ -107,7 +107,7 @@ AggregateFunction BoolOrFun::GetFunction() {
 	    LogicalType(LogicalTypeId::BOOLEAN), LogicalType::BOOLEAN);
 	fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	fun.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
-	return fun;
+	return fun.SetStructStateExport(GetBoolAndStateType);
 }
 
 AggregateFunction BoolAndFun::GetFunction() {

--- a/extension/core_functions/aggregate/distributive/bool.cpp
+++ b/extension/core_functions/aggregate/distributive/bool.cpp
@@ -93,6 +93,13 @@ struct BoolOrFunFunction {
 	}
 };
 
+LogicalType GetBoolAndStateType(const AggregateFunction &function) {
+	child_list_t<LogicalType> child_types;
+	child_types.emplace_back("empty", LogicalType::BOOLEAN);
+	child_types.emplace_back("val", LogicalType::BOOLEAN);
+	return LogicalType::STRUCT(std::move(child_types));
+}
+
 } // namespace
 
 AggregateFunction BoolOrFun::GetFunction() {
@@ -108,7 +115,7 @@ AggregateFunction BoolAndFun::GetFunction() {
 	    LogicalType(LogicalTypeId::BOOLEAN), LogicalType::BOOLEAN);
 	fun.SetOrderDependent(AggregateOrderDependent::NOT_ORDER_DEPENDENT);
 	fun.SetDistinctDependent(AggregateDistinctDependent::NOT_DISTINCT_DEPENDENT);
-	return fun;
+	return fun.SetStructStateExport(GetBoolAndStateType);
 }
 
 } // namespace duckdb

--- a/test/sql/aggregate/aggregates/test_aggregate_state_type.test
+++ b/test/sql/aggregate/aggregates/test_aggregate_state_type.test
@@ -60,11 +60,17 @@ true
 statement ok
 CREATE TABLE t2_count_int AS SELECT count(range::INT) EXPORT_STATE as state FROM range(10);
 
+# bit_xor is now opted-in to struct-based state
+query T
+SELECT typeof(bit_xor(1::BIGINT) EXPORT_STATE) = 'AGGREGATE_STATE<bit_xor(BIGINT)::BIGINT, STRUCT(is_set BOOLEAN, "value" BIGINT)>';
+----
+true
+
 # other aggregate functions that are not opted-in are not broken
 query T
-SELECT typeof(bit_xor(1::BIGINT) EXPORT_STATE);
+SELECT typeof(min(1::BIGINT) EXPORT_STATE);
 ----
-LEGACY_AGGREGATE_STATE<bit_xor(BIGINT)::BIGINT>
+LEGACY_AGGREGATE_STATE<min(BIGINT)::BIGINT>
 
 # Test with interval type
 query T

--- a/test/sql/aggregate/aggregates/test_state_export_opaque.test
+++ b/test/sql/aggregate/aggregates/test_state_export_opaque.test
@@ -75,14 +75,6 @@ select FINALIZE(argmin(a,b) EXPORT_STATE), FINALIZE(argmax(a,b) EXPORT_STATE) fr
 
 mode unskip
 
-query III nosort res8
-SELECT g, bit_xor(d), bool_and(d > 5) FROM dummy GROUP BY g ORDER BY g;
-----
-
-query III nosort res8
-SELECT g, FINALIZE(bit_xor(d) EXPORT_STATE), FINALIZE(bool_and(d > 5) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
-----
-
 query II nosort res9
 SELECT corr(d, d+1), covar_pop(d, d+1)FROM dummy;
 ----

--- a/test/sql/aggregate/aggregates/test_state_export_opaque.test
+++ b/test/sql/aggregate/aggregates/test_state_export_opaque.test
@@ -75,16 +75,6 @@ select FINALIZE(argmin(a,b) EXPORT_STATE), FINALIZE(argmax(a,b) EXPORT_STATE) fr
 
 mode unskip
 
-query II nosort res9
-SELECT corr(d, d+1), covar_pop(d, d+1)FROM dummy;
-----
-
-
-query II nosort res9
-SELECT FINALIZE(corr(d, d+1) EXPORT_STATE), FINALIZE(covar_pop(d, d+1) EXPORT_STATE) from dummy;
-----
-
-
 # you're holding it wrong:
 
 statement error

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -112,6 +112,24 @@ SELECT (bool_and(42 > 0) export_state)::struct(empty boolean, val boolean);
 ----
 {'empty': false, 'val': true}
 
+query II nosort res8a2
+SELECT g, bool_or(d > 50) FROM dummy GROUP BY g ORDER BY g;
+----
+
+query II nosort res8a2
+SELECT g, FINALIZE(bool_or(d > 50) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
+----
+
+query T
+SELECT (bool_or(42 > 0) export_state)::struct(empty boolean, val boolean);
+----
+{'empty': false, 'val': true}
+
+query T
+SELECT (bool_or(42 < 0) export_state)::struct(empty boolean, val boolean);
+----
+{'empty': false, 'val': false}
+
 query III nosort res8b
 SELECT g, bit_and(d), bit_or(d), bit_xor(d) FROM dummy GROUP BY g ORDER BY g;
 ----

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -99,6 +99,37 @@ query IIIIIII nosort res8
 SELECT g, FINALIZE(favg(d) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
 ----
 
+query II nosort res8a
+SELECT g, bool_and(d > 50) FROM dummy GROUP BY g ORDER BY g;
+----
+
+query II nosort res8a
+SELECT g, FINALIZE(bool_and(d > 50) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
+----
+
+query T
+SELECT (bool_and(42 > 0) export_state)::struct(empty boolean, val boolean);
+----
+{'empty': false, 'val': true}
+
+query III nosort res8b
+SELECT g, bit_and(d), bit_or(d), bit_xor(d) FROM dummy GROUP BY g ORDER BY g;
+----
+
+query III nosort res8b
+SELECT g, FINALIZE(bit_and(d) EXPORT_STATE), FINALIZE(bit_or(d) EXPORT_STATE), FINALIZE(bit_xor(d) EXPORT_STATE) FROM dummy GROUP BY g ORDER BY g;
+----
+
+query T
+SELECT (bit_and(42) export_state)::struct(is_set boolean, value integer);
+----
+{'is_set': true, 'value': 42}
+
+query T
+SELECT (bit_xor(100) export_state)::struct(is_set boolean, value bigint);
+----
+{'is_set': true, 'value': 100}
+
 # You're holding it wrong:
 
 statement error


### PR DESCRIPTION
- Convert bool_and aggregate to use struct-based state export
- Convert bit_and, bit_or, and bit_xor aggregates to use struct-based state export
- Add GetBoolAndStateType function returning struct with empty and val fields
- Add GetBitStateType template function for integral types
- Add GetBitStringStateType function for BIT string type
- Update tests: move bool_and and bit operations from opaque to struct test
- Remove bool_and and bit_xor from test_state_export_opaque.test
- Add comprehensive tests for bool_and and bit operations in test_state_export_struct.test