### PR TITLE
Try namespace runners for linux-debug

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -100,12 +100,17 @@ jobs:
     - id: describe_step
       run: echo "git_describe=$(git describe --tags --long)" >> "$GITHUB_OUTPUT"
 
-    - name: Install ninja-build if missing
+    - name: Install tools
       shell: bash
       run: |
         if ! command -v ninja >/dev/null 2>&1; then
           sudo apt-get update -y -qq
           sudo apt-get install -y -qq ninja-build
+        fi
+
+        if ! command -v g++-10 >/dev/null 2>&1; then
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq g++-10
         fi
 
         ls -lh /usr/bin/gcc* /usr/bin/g++*

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -108,6 +108,10 @@ jobs:
           sudo apt-get install -y -qq ninja-build
         fi
 
+        ls -lh /usr/bin/gcc* /usr/bin/g++*
+        gcc --version
+        g++ --version
+
     - uses: ./.github/actions/ccache-action
 
     - name: Build

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -47,16 +47,43 @@ jobs:
  prepare:
     # We run all other jobs on PRs only if they are not draft PR
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    outputs:
+      runner_linux_x64: ${{ steps.select_runner.outputs.runner_linux_x64 }}
+      runner_linux_22_x64: ${{ steps.select_runner.outputs.runner_linux_22_x64 }}
+      runner_linux_arm64: ${{ steps.select_runner.outputs.runner_linux_arm64 }}
+      runner_macos_arm64: ${{ steps.select_runner.outputs.runner_macos_arm64 }}
     steps:
       - name: Preliminary checks on CI
         run: echo "Event name is ${{ github.event_name }}"
+
+      - name: Select CI runner
+        id: select_runner
+        run: |
+          # Fall back to GitHub-native runners for forks.
+          if [[ "${{ github.repository }}" == "duckdb/duckdb" ]]; then
+            {
+              echo "runner_linux_x64=namespace-profile-linux-x64"
+              echo "runner_linux_22_x64=namespace-profile-linux-22-x64"
+              echo "runner_linux_arm64=namespace-profile-linux-arm64"
+              echo "runner_macos_arm64=namespace-profile-macos-arm64"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "runner_linux_x64=ubuntu-latest"
+              echo "runner_linux_22_x64=ubuntu-22.04"
+              echo "runner_linux_arm64=ubuntu-24.04-arm"
+              echo "runner_macos_arm64=macos-14"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+          grep runner_ "$GITHUB_OUTPUT"
 
  linux-debug:
     name: Linux Debug
     # This tests release build while enabling slow verifiers (masked by #ifdef DEBUG) and sanitizers
     needs: prepare
-    runs-on: ubuntu-22.04
+    runs-on: ${{ needs.prepare.outputs.runner_linux_22_x64 }}
     env:
       CC: gcc-10
       CXX: g++-10


### PR DESCRIPTION
Enable namespace runners for (some) duckdb CI jobs:
1. get faster feedback loops by running on fast CI runners.
2. get [observability](https://namespace.so/docs/architecture/compute/observability) (CPU/mem/disk/network) for each CI step, so we can improve the scripts/tasks based on the available hardware resources.

I wanted to explore only the `linux-debug` job for now to start small and avoid disrupting anyone.

In the future, we can look into [SSH access](https://namespace.so/docs/architecture/compute/ssh-remote-display#ssh-access) to runners, so engineers can debug issues interactively in a CI job without pushing code changes.

### Leak found
~~Upgrading to ubuntu 24 means we're using GCC 13 and that GCC version detected a leak. I've filed a separate issue.~~
Merged a [PR](https://github.com/duckdb/duckdb/pull/21052) to fix the leak.

### CI timing improvements

The job `linux-debug` takes 2 hours to complete and it has two main steps:
1. build: ~55 min.
2. test: ~1 hour.

When running the the job on namespace runners, we get:
1. build: ~11 min.
2. test: 1 hour.

<img width="658" height="365" alt="Screenshot 2026-02-23 at 15 30 57" src="https://github.com/user-attachments/assets/176d4d35-35ec-4acc-a705-b23617c8d05a" />

Note: both jobs did not have any ccache hits (so "full builds"):
```
  Cacheable calls:   543 / 547 (99.27%)
    Hits:              0 / 543 ( 0.00%)  # <-- no hits!
      Direct:          0
      Preprocessed:    0
    Misses:          543 / 543 (100.0%)
  Errors:              4 / 547 ( 0.73%)
  Local storage:
    Cache size (GB): 1.2 / 0.5 (233.9%)
    Cleanups:        543
    Hits:              0 / 543 ( 0.00%)
    Misses:          543 / 543 (100.0%)
```

### Job resource metrics

Namespaces provides observabilty for the CI job steps:

<img width="747" height="470" alt="Screenshot 2026-02-23 at 16 11 46" src="https://github.com/user-attachments/assets/35e6980c-1ac5-4aba-8132-218420e3197e" />

The CPU graph shows that the first 11 min (= `build`) are maxing out the 8 CPU cores. The memory peaks at 13 GiB.

The next step (= `test`) takes 1 hour and has an average CPU (green line) of ~14-20%. The memory hovers between 1.6-2.3 GiB.