### PR TITLE
[Dev] Add internal exception for misuse of `MultiFileReader` method

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -662,13 +662,13 @@ ResultColumnMapping MultiFileColumnMapper::CreateColumnMappingByMapper(const Col
 			auto expr =
 			    multi_file_reader.GetVirtualColumnExpression(context, reader_data, local_columns, global_column_id,
 			                                                 virtual_column_type, local_idx, global_column_reference);
-			if (!expr && !global_column_reference) {
+			if ((!expr && !global_column_reference) || (expr && global_column_reference.get())) {
 				throw InternalException(R"(
 					The GetVirtualColumnExpression is expected to either:"
 					- return an expression applied in FinalizeChunk to create the value for this global column,
 					  forwarding the (potentially changed) 'global_column_id' to the reader to create the needed data for the expression.
 					- set the 'global_column_reference' to replace this virtual column with a MultiFileColumnDefinition, as if it was defined in the schema.
-					Doing neither is not a valid option.
+					Doing neither or both is not a valid option.
 				)");
 			}
 			if (expr && expr->type == ExpressionType::VALUE_CONSTANT) {

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -662,6 +662,15 @@ ResultColumnMapping MultiFileColumnMapper::CreateColumnMappingByMapper(const Col
 			auto expr =
 			    multi_file_reader.GetVirtualColumnExpression(context, reader_data, local_columns, global_column_id,
 			                                                 virtual_column_type, local_idx, global_column_reference);
+			if (!expr && !global_column_reference) {
+				throw InternalException(R"(
+					The GetVirtualColumnExpression is expected to either:"
+					- return an expression applied in FinalizeChunk to create the value for this global column,
+					  forwarding the (potentially changed) 'global_column_id' to the reader to create the needed data for the expression.
+					- set the 'global_column_reference' to replace this virtual column with a MultiFileColumnDefinition, as if it was defined in the schema.
+					Doing neither is not a valid option.
+				)");
+			}
 			if (expr && expr->type == ExpressionType::VALUE_CONSTANT) {
 				// the column is constant after all - handle it
 				expressions.push_back(std::move(expr));


### PR DESCRIPTION
Spend a bit of time figuring out what this API does and expects, added an internal exception detailing this and safeguarding against misuse