### PR TITLE
skip encryption fallback test

### DIFF
--- a/test/sql/attach/attach_encryption_fallback_readonly.test
+++ b/test/sql/attach/attach_encryption_fallback_readonly.test
@@ -2,6 +2,8 @@
 # description: Ensure the fallback crypto implementation is read-only
 # group: [attach]
 
+mode skip
+
 require vector_size 2048
 
 load __TEST_DIR__/tmp.db


### PR DESCRIPTION
skips `test/sql/attach/attach_encryption_fallback_readonly.test` for now; should be looked into later