### PR TITLE
Add support for Parquet round-tripping of struct-based aggregate states

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -321,7 +321,8 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 		                                      std::move(child_writers));
 	}
 
-	if (type.id() == LogicalTypeId::STRUCT || type.id() == LogicalTypeId::UNION) {
+	if (type.id() == LogicalTypeId::STRUCT || type.id() == LogicalTypeId::UNION ||
+	    type.id() == LogicalTypeId::AGGREGATE_STATE) {
 		auto struct_column =
 		    ParquetColumnSchema::FromLogicalType(name, type, max_define, max_repeat, 0, null_type, allow_geometry);
 		if (field_id && field_id->set) {

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -624,7 +624,8 @@ unique_ptr<FunctionData> BindAggregateState(ClientContext &context, ScalarFuncti
 
 	// combine
 	if (arguments.size() == 2 && arguments[0]->return_type != arguments[1]->return_type &&
-	    arguments[1]->return_type.id() != LogicalTypeId::BLOB) {
+	    arguments[1]->return_type.id() != LogicalTypeId::BLOB &&
+	    arguments[1]->return_type.id() != LogicalTypeId::STRUCT) {
 		throw BinderException("Cannot COMBINE aggregate states from different functions, %s <> %s",
 		                      arguments[0]->return_type.ToString(), arguments[1]->return_type.ToString());
 	}
@@ -634,6 +635,11 @@ unique_ptr<FunctionData> BindAggregateState(ClientContext &context, ScalarFuncti
 	} else {
 		D_ASSERT(bound_function.name == "combine");
 		bound_function.SetReturnType(arguments[0]->return_type);
+		// When the second argument is a STRUCT (e.g. from a parquet round-trip), prevent casting to AGGREGATE_STATE by
+		// matching the declared parameter type to the actual argument type.
+		if (arguments.size() == 2 && arguments[1]->return_type.id() == LogicalTypeId::STRUCT) {
+			bound_function.arguments[1] = arguments[1]->return_type;
+		}
 	}
 
 	return std::move(bind_data);

--- a/test/sql/aggregate/aggregates/test_state_export_opaque.test
+++ b/test/sql/aggregate/aggregates/test_state_export_opaque.test
@@ -197,24 +197,3 @@ SELECT COMBINE(min(42) EXPORT_STATE, 'ASDF'::BLOB);
 statement error
 SELECT COMBINE((min(42) EXPORT_STATE)::BLOB, min(42) EXPORT_STATE);
 ----
-
-# simulate round tripping
-require parquet
-
-# TODO - we should support the new aggregate state in parquet files
-statement ok
-COPY (SELECT g, (min(d) EXPORT_STATE)::BLOB s1 FROM dummy GROUP BY g) TO '__TEST_DIR__/state.parquet' (FORMAT PARQUET);
-
-query II
-SELECT g, FINALIZE(COMBINE(s2, s1)) FROM (SELECT g, min(d) EXPORT_STATE s2 FROM dummy GROUP BY g) q1 JOIN '__TEST_DIR__/state.parquet' USING(g) ORDER BY g;
-----
-0	0
-1	1
-2	2
-3	3
-4	4
-5	5
-6	6
-7	7
-8	8
-9	9

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -335,3 +335,24 @@ ORDER BY g;
 group_0	This is a very long string that exceeds the 12 byte inlining threshold for string_t12
 group_1	This is a very long string that exceeds the 12 byte inlining threshold for string_t10
 group_2	This is a very long string that exceeds the 12 byte inlining threshold for string_t11
+
+# parquet round-trip: write AGGREGATE_STATE directly
+# count() has state STRUCT(count BIGINT) which parquet preserves exactly
+require parquet
+
+statement ok
+COPY (SELECT g, count(d) EXPORT_STATE s1 FROM dummy GROUP BY g) TO '__TEST_DIR__/count_state.parquet' (FORMAT PARQUET);
+
+query II
+SELECT g, FINALIZE(COMBINE(s2, s1)) FROM (SELECT g, count(d) EXPORT_STATE s2 FROM dummy GROUP BY g) q1 JOIN '__TEST_DIR__/count_state.parquet' USING(g) ORDER BY g;
+----
+0	20
+1	20
+2	20
+3	20
+4	20
+5	20
+6	20
+7	20
+8	20
+9	20


### PR DESCRIPTION
Fork PR: https://github.com/EtgarDev/duckdb/pull/24

This PR introduces support for handling the round-trip serialization and deserialization of struct-based aggregate states in Parquet.

1. We use the same logic of writing `STRUCT`s for writing `AGGREGATE_STATE`s to parquet files.
2. We are performing the same kind of trick we do with the opaque states - allowing the combine function to get the second argument as the loaded state, as we anyway consider only the first argument for the binding process.
3. Migrated the existing test to work with the new struct-based aggregate state.