### PR TITLE
Initial PR for thread annotation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,12 @@ if(${FORCE_COLORED_OUTPUT})
   endif()
 endif()
 
+# Enable Clang thread-safety annotations when using Clang compiler
+# TODO(hjiang): enable error for thread annotation warnings, because of certain extensions.
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wthread-safety -Wno-error=thread-safety")
+endif()
+
 if (DUCKDB_EXPLICIT_PLATFORM)
     add_definitions(-DDUCKDB_CUSTOM_PLATFORM=${DUCKDB_EXPLICIT_PLATFORM})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ endif()
 # Enable Clang thread-safety annotations when using Clang compiler
 # TODO(hjiang): enable error for thread annotation warnings, because of certain extensions.
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wthread-safety -Wno-error=thread-safety")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wthread-safety")
 endif()
 
 if (DUCKDB_EXPLICIT_PLATFORM)

--- a/src/common/sort/natural_sort.cpp
+++ b/src/common/sort/natural_sort.cpp
@@ -35,7 +35,7 @@ public:
 	const NaturalSort &natural_sort;
 
 	//! Combined rows
-	mutable mutex lock;
+	mutable annotated_mutex lock;
 	HashGroupPtr hash_group;
 
 	// Threading

--- a/src/common/sort/natural_sort.cpp
+++ b/src/common/sort/natural_sort.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/sorting/natural_sort.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 
 namespace duckdb {
@@ -105,7 +106,7 @@ SinkCombineResultType NaturalSort::Combine(ExecutionContext &context, OperatorSi
 	auto &lstate = combine.local_state.Cast<NaturalSortLocalSinkState>();
 
 	// Only one partition, so need a global lock.
-	lock_guard<mutex> glock(gstate.lock);
+	annotated_lock_guard<annotated_mutex> glock(gstate.lock);
 	auto &hash_group = gstate.hash_group;
 	if (hash_group) {
 		auto &unsorted = *hash_group->columns;

--- a/src/common/sort/sort.cpp
+++ b/src/common/sort/sort.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/common/sorting/sort.hpp"
 
-#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/sorting/sort_key.hpp"
 #include "duckdb/common/sorting/sorted_run.hpp"
@@ -174,7 +173,7 @@ public:
 	}
 
 	void TryIncreaseReservation(ClientContext &context, SortLocalSinkState &lstate, bool is_index_sort,
-	                            const annotated_unique_lock<annotated_mutex> &) {
+	                            const unique_lock<mutex> &guard) {
 		D_ASSERT(!external);
 
 		// If we already got less than we requested last time, have to go external
@@ -207,7 +206,7 @@ public:
 	}
 
 	void AddSortedRun(SortLocalSinkState &lstate) {
-		annotated_lock_guard<annotated_mutex> guard(lock);
+		const lock_guard<mutex> guard(lock);
 		sorted_runs.push_back(std::move(lstate.sorted_run));
 		sorted_tuples += sorted_runs.back()->Count();
 	}
@@ -242,8 +241,7 @@ unique_ptr<GlobalSinkState> Sort::GetGlobalSinkState(ClientContext &context) con
 }
 
 //! Returns true if the Sink call is done (either because run size is small or because run was finalized)
-static bool TryFinishSink(SortGlobalSinkState &gstate, SortLocalSinkState &lstate,
-                          annotated_unique_lock<annotated_mutex> &guard) {
+static bool TryFinishSink(SortGlobalSinkState &gstate, SortLocalSinkState &lstate, unique_lock<mutex> &guard) {
 	// Check if we exceed the limit
 	const auto sorted_run_size = lstate.sorted_run->SizeInBytes();
 	if (sorted_run_size < lstate.maximum_run_size) {
@@ -283,13 +281,13 @@ SinkResultType Sort::Sink(ExecutionContext &context, DataChunk &chunk, OperatorS
 	lstate.sorted_run->Sink(lstate.key, lstate.payload);
 
 	// Try to finish this call to Sink
-	annotated_unique_lock<annotated_mutex> guard;
+	unique_lock<mutex> guard;
 	if (TryFinishSink(gstate, lstate, guard)) {
 		return SinkResultType::NEED_MORE_INPUT;
 	}
 
 	// Grab the lock, update the local state, and see if we can finish now
-	guard = annotated_unique_lock<annotated_mutex>(gstate.lock);
+	guard = unique_lock<mutex>(gstate.lock);
 	gstate.UpdateLocalState(lstate);
 	if (TryFinishSink(gstate, lstate, guard)) {
 		return SinkResultType::NEED_MORE_INPUT;
@@ -316,7 +314,7 @@ SinkCombineResultType Sort::Combine(ExecutionContext &context, OperatorSinkCombi
 	}
 
 	// Set any_combined under lock
-	annotated_unique_lock<annotated_mutex> guard(gstate.lock);
+	unique_lock<mutex> guard {gstate.lock};
 	gstate.any_combined = true;
 	guard.unlock();
 
@@ -382,7 +380,7 @@ public:
 		if (!merger_global_state) {
 			return;
 		}
-		annotated_lock_guard<annotated_mutex> guard(merger_global_state->lock);
+		const lock_guard<mutex> guard {merger_global_state->lock};
 		merger.sorted_runs.clear();
 		sink.temporary_memory_state.reset();
 	}
@@ -486,7 +484,7 @@ SourceResultType Sort::MaterializeColumnData(ExecutionContext &context, Operator
 
 	// Merge into global output collection
 	{
-		annotated_lock_guard<annotated_mutex> guard(gstate.lock);
+		const lock_guard<mutex> guard {gstate.lock};
 		if (!gstate.column_data) {
 			gstate.column_data = std::move(local_column_data);
 		} else {
@@ -509,7 +507,7 @@ SourceResultType Sort::MaterializeColumnData(ExecutionContext &context, Operator
 
 unique_ptr<ColumnDataCollection> Sort::GetColumnData(OperatorSourceInput &input) const {
 	auto &gstate = input.global_state.Cast<SortGlobalSourceState>();
-	annotated_lock_guard<annotated_mutex> guard(gstate.lock);
+	const lock_guard<mutex> guard {gstate.lock};
 	return gstate.column_data->FetchCollection();
 }
 

--- a/src/common/sort/sorted_run_merger.cpp
+++ b/src/common/sort/sorted_run_merger.cpp
@@ -573,8 +573,8 @@ void SortedRunMergerLocalState::AcquirePartitionBoundaries(SortedRunMergerGlobal
 	auto &current_partition = *gstate.partitions[partition_idx.GetIndex()];
 	if (current_partition.GetBeginComputed()) {
 		// Begin has been computed, boundaries are ready to use. Copy to local
-		auto guard = current_partition.Lock();
-		run_boundaries = current_partition.GetRunBoundaries(guard);
+		annotated_lock_guard<annotated_mutex> guard(current_partition.lock);
+		run_boundaries = current_partition.GetRunBoundaries();
 		return;
 	}
 

--- a/src/common/sort/sorted_run_merger.cpp
+++ b/src/common/sort/sorted_run_merger.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/common/sorting/sorted_run_merger.hpp"
 
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/sorting/sort.hpp"
+#include "duckdb/common/thread_annotation.hpp"
 #include "duckdb/common/sorting/sorted_run.hpp"
 #include "duckdb/common/sorting/sort_key.hpp"
 #include "duckdb/common/types/row/block_iterator.hpp"
@@ -43,12 +45,7 @@ public:
 	}
 
 public:
-	unique_lock<mutex> Lock() {
-		return unique_lock<mutex>(lock);
-	}
-
-	unsafe_vector<SortedRunPartitionBoundary> &GetRunBoundaries(const unique_lock<mutex> &guard) {
-		VerifyLock(guard);
+	unsafe_vector<SortedRunPartitionBoundary> &GetRunBoundaries() DUCKDB_REQUIRES(lock) {
 		return run_boundaries;
 	}
 
@@ -60,16 +57,11 @@ public:
 		begin_computed = true;
 	}
 
-private:
-	void VerifyLock(const unique_lock<mutex> &guard) const {
-#ifdef D_ASSERT_IS_ENABLED
-		D_ASSERT(guard.mutex() && RefersToSameObject(*guard.mutex(), lock));
-#endif
-	}
+public:
+	annotated_mutex lock;
 
 private:
-	mutex lock;
-	unsafe_vector<SortedRunPartitionBoundary> run_boundaries;
+	unsafe_vector<SortedRunPartitionBoundary> run_boundaries DUCKDB_GUARDED_BY(lock);
 	atomic<bool> begin_computed;
 
 public:
@@ -187,7 +179,7 @@ public:
 	bool AssignTask(SortedRunMergerLocalState &lstate) {
 		D_ASSERT(!lstate.partition_idx.IsValid());
 		D_ASSERT(lstate.task == SortedRunMergerTask::FINISHED);
-		auto guard = Lock();
+		annotated_lock_guard<annotated_mutex> guard(lock);
 		if (next_partition_idx == num_partitions) {
 			return false; // Nothing left to do
 		}
@@ -248,15 +240,15 @@ public:
 			idx_t begin_idx = 0;
 			if (destroy_partition_idx != 0) {
 				auto &begin_partition = *partitions[destroy_partition_idx];
-				auto partition_guard = begin_partition.Lock();
-				begin_idx = begin_partition.GetRunBoundaries(partition_guard)[run_idx].end;
+				const annotated_lock_guard<annotated_mutex> partition_guard(begin_partition.lock);
+				begin_idx = begin_partition.GetRunBoundaries()[run_idx].end;
 			}
 
 			idx_t end_idx = merger.sorted_runs[run_idx]->Count();
 			if (end_partition_idx != num_partitions) {
 				auto &end_partition = *partitions[end_partition_idx];
-				auto partition_guard = end_partition.Lock();
-				end_idx = end_partition.GetRunBoundaries(partition_guard)[run_idx].end;
+				const annotated_lock_guard<annotated_mutex> partition_guard(end_partition.lock);
+				end_idx = end_partition.GetRunBoundaries()[run_idx].end;
 			}
 
 			merger.sorted_runs[run_idx]->DestroyData(begin_idx, end_idx);
@@ -388,10 +380,12 @@ void SortedRunMergerLocalState::ComputePartitionBoundaries(SortedRunMergerGlobal
 
 	// Copy over the run boundaries from the assigned partition (under lock)
 	auto &current_partition = *gstate.partitions[p_idx.GetIndex()];
-	auto current_partition_guard = current_partition.Lock();
-	const auto begin_computed = current_partition.GetBeginComputed();
-	run_boundaries = current_partition.GetRunBoundaries(current_partition_guard);
-	current_partition_guard.unlock();
+	bool begin_computed;
+	{
+		const annotated_lock_guard<annotated_mutex> current_partition_guard(current_partition.lock);
+		begin_computed = current_partition.GetBeginComputed();
+		run_boundaries = current_partition.GetRunBoundaries();
+	}
 
 	if (!begin_computed) {
 		// We can use information from previous partitions to speed up computing this partition
@@ -400,8 +394,8 @@ void SortedRunMergerLocalState::ComputePartitionBoundaries(SortedRunMergerGlobal
 			if (!prev_partition.GetBeginComputed()) {
 				continue;
 			}
-			auto prev_partition_guard = prev_partition.Lock();
-			const auto &prev_partition_run_boundaries = prev_partition.GetRunBoundaries(prev_partition_guard);
+			const annotated_lock_guard<annotated_mutex> prev_partition_guard(prev_partition.lock);
+			const auto &prev_partition_run_boundaries = prev_partition.GetRunBoundaries();
 			for (idx_t run_idx = 0; run_idx < gstate.num_runs; run_idx++) {
 				run_boundaries[run_idx].begin = prev_partition_run_boundaries[run_idx].begin;
 			}
@@ -429,9 +423,9 @@ void SortedRunMergerLocalState::ComputePartitionBoundaries(SortedRunMergerGlobal
 	if (p_idx.GetIndex() != gstate.num_partitions - 1) {
 		auto &next_partition = *gstate.partitions[p_idx.GetIndex() + 1];
 		if (!next_partition.GetBeginComputed()) {
-			auto next_partition_guard = next_partition.Lock();
+			annotated_lock_guard<annotated_mutex> next_partition_guard(next_partition.lock);
 			if (!next_partition.GetBeginComputed()) {
-				auto &next_partition_run_boundaries = next_partition.GetRunBoundaries(next_partition_guard);
+				auto &next_partition_run_boundaries = next_partition.GetRunBoundaries();
 				for (idx_t run_idx = 0; run_idx < gstate.num_runs; run_idx++) {
 					const auto &computed_boundary = run_boundaries[run_idx];
 					D_ASSERT(computed_boundary.begin == computed_boundary.end);
@@ -443,12 +437,14 @@ void SortedRunMergerLocalState::ComputePartitionBoundaries(SortedRunMergerGlobal
 	}
 
 	// Set the computed end partition boundaries of the current partition
-	current_partition_guard.lock();
-	auto &current_partition_run_boundaries = current_partition.GetRunBoundaries(current_partition_guard);
-	for (idx_t run_idx = 0; run_idx < gstate.num_runs; run_idx++) {
-		const auto &computed_boundary = run_boundaries[run_idx];
-		D_ASSERT(computed_boundary.begin == computed_boundary.end);
-		current_partition_run_boundaries[run_idx].end = computed_boundary.end;
+	{
+		annotated_lock_guard<annotated_mutex> current_partition_guard(current_partition.lock);
+		auto &current_partition_run_boundaries = current_partition.GetRunBoundaries();
+		for (idx_t run_idx = 0; run_idx < gstate.num_runs; run_idx++) {
+			const auto &computed_boundary = run_boundaries[run_idx];
+			D_ASSERT(computed_boundary.begin == computed_boundary.end);
+			current_partition_run_boundaries[run_idx].end = computed_boundary.end;
+		}
 	}
 }
 
@@ -588,9 +584,9 @@ void SortedRunMergerLocalState::AcquirePartitionBoundaries(SortedRunMergerGlobal
 	task = SortedRunMergerTask::ACQUIRE_BOUNDARIES;
 
 	// Copy to local
-	auto guard = current_partition.Lock();
+	annotated_lock_guard<annotated_mutex> guard(current_partition.lock);
 	D_ASSERT(current_partition.GetBeginComputed());
-	run_boundaries = current_partition.GetRunBoundaries(guard);
+	run_boundaries = current_partition.GetRunBoundaries();
 }
 
 void SortedRunMergerLocalState::MergePartition(SortedRunMergerGlobalState &gstate) {
@@ -845,7 +841,7 @@ SortedRunMerger::~SortedRunMerger() {
 unique_ptr<LocalSourceState> SortedRunMerger::GetLocalSourceState(ExecutionContext &,
                                                                   GlobalSourceState &gstate_p) const {
 	auto &gstate = gstate_p.Cast<SortedRunMergerGlobalState>();
-	auto guard = gstate.Lock();
+	annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 	return make_uniq<SortedRunMergerLocalState>(gstate);
 }
 

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -887,7 +887,7 @@ SourceResultType PhysicalHashAggregate::GetDataInternal(ExecutionContext &contex
 		}
 
 		// move to the next table
-		auto guard = gstate.Lock();
+		annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 		lstate.radix_idx = lstate.radix_idx.GetIndex() + 1;
 		if (lstate.radix_idx.GetIndex() > gstate.state_index) {
 			// we have not yet worked on the table

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -881,7 +881,7 @@ WindowLocalSourceState::WindowLocalSourceState(WindowGlobalSourceState &gsource)
 }
 
 bool WindowGlobalSourceState::TryNextTask(TaskPtr &task, Task &task_local) {
-	auto guard = Lock();
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	FinishTask(task);
 
 	if (!HasMoreTasks()) {
@@ -893,7 +893,7 @@ bool WindowGlobalSourceState::TryNextTask(TaskPtr &task, Task &task_local) {
 	for (const auto &group_idx : active_groups) {
 		auto &window_hash_group = window_hash_groups[group_idx];
 		if (window_hash_group->TryPrepareNextStage()) {
-			UnblockTasks(guard);
+			UnblockTasks();
 		}
 		if (window_hash_group->TryNextTask(task_local)) {
 			task = task_local;
@@ -909,7 +909,7 @@ bool WindowGlobalSourceState::TryNextTask(TaskPtr &task, Task &task_local) {
 
 		auto &window_hash_group = window_hash_groups[group_idx];
 		if (window_hash_group->TryPrepareNextStage()) {
-			UnblockTasks(guard);
+			UnblockTasks();
 		}
 		if (!window_hash_group->TryNextTask(task_local)) {
 			//	Group has no tasks (empty?)
@@ -1120,15 +1120,15 @@ SourceResultType PhysicalWindow::GetDataInternal(ExecutionContext &context, Data
 				throw;
 			}
 		} else {
-			auto guard = gsource.Lock();
+			annotated_lock_guard<annotated_mutex> guard(gsource.lock);
 			if (!gsource.HasMoreTasks()) {
 				// no more tasks - exit
-				gsource.UnblockTasks(guard);
+				gsource.UnblockTasks();
 				break;
 			} else {
 				// there are more tasks available, but we can't execute them yet
 				// block the source
-				return gsource.BlockSource(guard, source.interrupt_state);
+				return gsource.BlockSource(source.interrupt_state);
 			}
 		}
 	}

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -514,7 +514,7 @@ SinkCombineResultType PhysicalHashJoin::Combine(ExecutionContext &context, Opera
 	auto &lstate = input.local_state.Cast<HashJoinLocalSinkState>();
 
 	lstate.hash_table->GetSinkCollection().FlushAppendState(lstate.append_state);
-	auto guard = gstate.Lock();
+	annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 	gstate.local_hash_tables.push_back(std::move(lstate.hash_table));
 	if (gstate.local_hash_tables.size() == gstate.active_local_states) {
 		// Set to 0 until PrepareFinalize
@@ -756,7 +756,7 @@ void HashJoinGlobalSinkState::ScheduleFinalize(Pipeline &pipeline, Event &event)
 }
 
 void HashJoinGlobalSinkState::InitializeProbeSpill() {
-	auto guard = Lock();
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	if (!probe_spill) {
 		probe_spill = make_uniq<JoinHashTable::ProbeSpill>(*hash_table, context, probe_types);
 	}
@@ -1391,7 +1391,7 @@ HashJoinGlobalSourceState::HashJoinGlobalSourceState(const PhysicalHashJoin &op,
 }
 
 void HashJoinGlobalSourceState::Initialize(HashJoinGlobalSinkState &sink) {
-	auto guard = Lock();
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	if (global_stage != HashJoinSourceStage::INIT) {
 		// Another thread initialized
 		return;
@@ -1514,7 +1514,7 @@ void HashJoinGlobalSourceState::PrepareScanHT(HashJoinGlobalSinkState &sink) {
 bool HashJoinGlobalSourceState::AssignTask(HashJoinGlobalSinkState &sink, HashJoinLocalSourceState &lstate) {
 	D_ASSERT(lstate.TaskFinished());
 
-	auto guard = Lock();
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	switch (global_stage.load()) {
 	case HashJoinSourceStage::BUILD:
 		if (build_chunk_idx != build_chunk_count) {
@@ -1607,7 +1607,7 @@ void HashJoinLocalSourceState::ExternalBuild(HashJoinGlobalSinkState &sink, Hash
 	auto &ht = *sink.hash_table;
 	ht.Finalize(build_chunk_idx_from, build_chunk_idx_to, true);
 
-	auto guard = gstate.Lock();
+	annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 	gstate.build_chunk_done += build_chunk_idx_to - build_chunk_idx_from;
 }
 
@@ -1627,7 +1627,7 @@ void HashJoinLocalSourceState::ExternalProbe(HashJoinGlobalSinkState &sink, Hash
 		scan_structure.is_null = true;
 		empty_ht_probe_in_progress = false;
 		sink.probe_spill->consumer->FinishChunk(probe_local_scan);
-		auto guard = gstate.Lock();
+		annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 		gstate.probe_chunk_done++;
 		return;
 	}
@@ -1669,7 +1669,7 @@ void HashJoinLocalSourceState::ExternalScanHT(HashJoinGlobalSinkState &sink, Has
 
 	if (chunk.size() == 0) {
 		full_outer_scan_state = nullptr;
-		auto guard = gstate.Lock();
+		annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 		gstate.full_outer_chunk_done += full_outer_chunk_idx_to - full_outer_chunk_idx_from;
 	}
 }
@@ -1682,7 +1682,7 @@ SourceResultType PhysicalHashJoin::GetDataInternal(ExecutionContext &context, Da
 	sink.scanned_data = true;
 
 	if (!sink.external && !PropagatesBuildSide(join_type)) {
-		auto guard = gstate.Lock();
+		annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 		if (gstate.global_stage != HashJoinSourceStage::DONE) {
 			gstate.global_stage = HashJoinSourceStage::DONE;
 			sink.hash_table->Reset();
@@ -1701,11 +1701,11 @@ SourceResultType PhysicalHashJoin::GetDataInternal(ExecutionContext &context, Da
 		if (!lstate.TaskFinished() || gstate.AssignTask(sink, lstate)) {
 			lstate.ExecuteTask(sink, gstate, chunk);
 		} else {
-			auto guard = gstate.Lock();
+			annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 			if (gstate.TryPrepareNextStage(sink) || gstate.global_stage == HashJoinSourceStage::DONE) {
-				gstate.UnblockTasks(guard);
+				gstate.UnblockTasks();
 			} else {
-				return gstate.BlockSource(guard, input.interrupt_state);
+				return gstate.BlockSource(input.interrupt_state);
 			}
 		}
 	}

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/join/physical_iejoin.hpp"
 
 #include "duckdb/common/atomic.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/bit_utils.hpp"
 #include "duckdb/common/row_operations/row_operations.hpp"
 #include "duckdb/common/sorting/sort_key.hpp"
@@ -1462,7 +1463,7 @@ void IEJoinGlobalSourceState::FinishTask(TaskPtr task) {
 }
 
 bool IEJoinGlobalSourceState::TryNextTask(TaskPtr &task, Task &task_local) {
-	auto guard = Lock();
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	FinishTask(task);
 
 	if (!HasMoreTasks()) {
@@ -1471,7 +1472,7 @@ bool IEJoinGlobalSourceState::TryNextTask(TaskPtr &task, Task &task_local) {
 	}
 
 	if (TryPrepareNextStage()) {
-		UnblockTasks(guard);
+		UnblockTasks();
 	}
 
 	if (TryNextTask(task_local)) {
@@ -1588,11 +1589,11 @@ SourceResultType PhysicalIEJoin::GetDataInternal(ExecutionContext &context, Data
 		if (!lsource.TaskFinished() || lsource.TryAssignTask()) {
 			lsource.ExecuteTask(context, result, input.interrupt_state);
 		} else {
-			auto guard = gsource.Lock();
+			annotated_lock_guard<annotated_mutex> guard(gsource.lock);
 			if (gsource.TryPrepareNextStage() || gsource.stage == IEJoinSourceStage::DONE) {
-				gsource.UnblockTasks(guard);
+				gsource.UnblockTasks();
 			} else {
-				return gsource.BlockSource(guard, input.interrupt_state);
+				return gsource.BlockSource(input.interrupt_state);
 			}
 		}
 	}

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/order/physical_top_n.hpp"
 
 #include "duckdb/common/assert.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/arena_containers/arena_vector.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/create_sort_key.hpp"
@@ -589,7 +590,7 @@ SourceResultType PhysicalTopN::GetDataInternal(ExecutionContext &context, DataCh
 
 	if (lstate.pos == lstate.end) {
 		// Obtain new scan indices from the global state
-		auto guard = gstate.Lock();
+		annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 		lstate.pos = gstate.state.pos;
 		gstate.state.pos += TopNGlobalSourceState::TUPLES_PER_BATCH;
 		lstate.end = gstate.state.pos;

--- a/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp"
 
 #include "duckdb/common/allocator.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/queue.hpp"
 #include "duckdb/common/types/batched_data_collection.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
@@ -191,11 +192,11 @@ SinkResultType PhysicalBatchCopyToFile::Sink(ExecutionContext &context, DataChun
 		FlushBatchData(context.client, gstate);
 
 		if (!memory_manager.IsMinimumBatchIndex(batch_index) && memory_manager.OutOfMemory(batch_index)) {
-			auto guard = memory_manager.Lock();
+			annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
 			if (!memory_manager.IsMinimumBatchIndex(batch_index)) {
 				// no tasks to process, we are not the minimum batch index and we have no memory available to buffer
 				// block the task for now
-				return memory_manager.BlockSink(guard, input.interrupt_state);
+				return memory_manager.BlockSink(input.interrupt_state);
 			}
 		}
 		state.current_task = FixedBatchCopyState::SINKING_DATA;
@@ -593,8 +594,8 @@ void PhysicalBatchCopyToFile::AddLocalBatch(ClientContext &context, GlobalSinkSt
 	// unblock tasks so they can help process batches (if any are blocked)
 	bool any_unblocked;
 	{
-		auto guard = memory_manager.Lock();
-		any_unblocked = memory_manager.UnblockTasks(guard);
+		annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
+		any_unblocked = memory_manager.UnblockTasks();
 	}
 	// if any threads were unblocked they can pick up execution of the tasks
 	// otherwise we will execute a task and flush here

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/execution/operator/persistent/physical_batch_insert.hpp"
 
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
-#include "duckdb/common/mutex.hpp"
 #include "duckdb/execution/operator/persistent/batch_memory_manager.hpp"
 #include "duckdb/execution/operator/persistent/batch_task_manager.hpp"
 #include "duckdb/parallel/thread_context.hpp"
@@ -157,7 +156,7 @@ public:
 
 	BatchMemoryManager memory_manager;
 	BatchTaskManager<BatchInsertTask> task_manager;
-	mutex lock;
+	annotated_mutex lock;
 	DuckTableEntry &table;
 	idx_t row_group_size;
 	idx_t insert_count;
@@ -232,7 +231,7 @@ public:
 		auto result_collection_index = g_state.MergeCollections(context, merge_collections, *l_state.optimistic_writer);
 		merge_collections.clear();
 
-		lock_guard<mutex> l(g_state.lock);
+		annotated_lock_guard<annotated_mutex> l(g_state.lock);
 		auto &result_collection = g_state.table.GetStorage().GetOptimisticCollection(context, result_collection_index);
 		RowGroupBatchEntry new_entry(result_collection, merged_batch_index, result_collection_index,
 		                             RowGroupBatchType::FLUSHED);
@@ -383,7 +382,7 @@ void BatchInsertGlobalState::AddCollection(ClientContext &context, const idx_t b
 	if (batch_type == RowGroupBatchType::FLUSHED && writer) {
 		writer->WriteUnflushedRowGroups(optimistic_collection);
 	}
-	lock_guard<mutex> l(lock);
+	annotated_lock_guard<annotated_mutex> l(lock);
 	insert_count += new_count;
 	// add the collection to the batch index
 	RowGroupBatchEntry new_entry(optimistic_collection, batch_index, collection_index, batch_type);
@@ -477,7 +476,7 @@ SinkNextBatchType PhysicalBatchInsert::NextBatch(ExecutionContext &context, Oper
 
 		bool any_unblocked;
 		{
-			annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
+			const annotated_lock_guard<annotated_mutex> guard {memory_manager.lock};
 			any_unblocked = memory_manager.UnblockTasks();
 		}
 		if (!any_unblocked) {
@@ -488,7 +487,7 @@ SinkNextBatchType PhysicalBatchInsert::NextBatch(ExecutionContext &context, Oper
 	lstate.current_index = batch_index;
 
 	// unblock any blocked tasks
-	annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
+	const annotated_lock_guard<annotated_mutex> guard {memory_manager.lock};
 	memory_manager.UnblockTasks();
 
 	return SinkNextBatchType::READY;
@@ -518,7 +517,7 @@ SinkResultType PhysicalBatchInsert::Sink(ExecutionContext &context, DataChunk &i
 			// execute tasks while we wait (if any are available)
 			ExecuteTasks(context.client, gstate, lstate);
 
-			annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
+			const annotated_lock_guard<annotated_mutex> guard {memory_manager.lock};
 			if (!memory_manager.IsMinimumBatchIndex(batch_index)) {
 				//  we are not the minimum batch index and we have no memory available to buffer - block the task for
 				//  now
@@ -588,7 +587,7 @@ SinkCombineResultType PhysicalBatchInsert::Combine(ExecutionContext &context, Op
 	}
 
 	// unblock any blocked tasks
-	annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
+	const annotated_lock_guard<annotated_mutex> guard {memory_manager.lock};
 	memory_manager.UnblockTasks();
 
 	return SinkCombineResultType::FINISHED;

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -253,7 +253,7 @@ void RadixHTGlobalSinkState::Destroy() {
 	}
 
 	// There are aggregates with destructors: Call the destructor for each of the aggregates
-	auto guard = Lock();
+	annotated_lock_guard<annotated_mutex> guard(lock);
 	RowOperationsState row_state(*stored_allocators.back());
 	for (auto &partition : partitions) {
 		auto &data_collection = *partition->data;

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/execution/radix_partitioned_hashtable.hpp"
 
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/radix_partitioning.hpp"
 #include "duckdb/common/row_operations/row_operations.hpp"
 #include "duckdb/common/types/row/tuple_data_collection.hpp"
@@ -297,7 +298,7 @@ void RadixHTConfig::SetRadixBitsInternal(const idx_t radix_bits_p, bool external
 		return;
 	}
 
-	auto guard = sink.Lock();
+	annotated_lock_guard<annotated_mutex> guard(sink.lock);
 	if (sink_radix_bits > radix_bits_p || sink.any_combined) {
 		return;
 	}
@@ -472,7 +473,7 @@ void MaybeRepartition(ClientContext &context, RadixHTGlobalSinkState &gstate, Ra
 		// We're over the thread memory limit
 		if (!gstate.external) {
 			// We haven't yet triggered out-of-core behavior, but maybe we don't have to, grab the lock and check again
-			auto guard = gstate.Lock();
+			annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 			thread_limit = temporary_memory_state.GetReservation() / gstate.number_of_threads;
 			if (total_size > thread_limit) {
 				// Out-of-core would be triggered below, update minimum reservation and try to increase the reservation
@@ -612,7 +613,7 @@ void RadixPartitionedHashTable::Combine(ExecutionContext &context, GlobalSinkSta
 	// Eagerly destroy the HT
 	lstate.ht.reset();
 
-	auto guard = gstate.Lock();
+	annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 	D_ASSERT(!gstate.finalized);
 	if (gstate.uncombined_data) {
 		gstate.uncombined_data->Combine(*lstate.abandoned_data);
@@ -625,7 +626,7 @@ void RadixPartitionedHashTable::Combine(ExecutionContext &context, GlobalSinkSta
 
 void RadixPartitionedHashTable::Finalize(ClientContext &context, GlobalSinkState &gstate_p) const {
 	auto &gstate = gstate_p.Cast<RadixHTGlobalSinkState>();
-	auto guard = gstate.Lock();
+	annotated_lock_guard<annotated_mutex> guard(gstate.lock);
 	D_ASSERT(!gstate.finalized);
 
 	if (gstate.uncombined_data) {
@@ -783,7 +784,7 @@ SourceResultType RadixHTGlobalSourceState::AssignTask(RadixHTGlobalSinkState &si
 
 	// We got a partition index
 	auto &partition = *sink.partitions[lstate.task_idx];
-	auto partition_guard = partition.Lock();
+	const annotated_lock_guard<annotated_mutex> partition_guard(partition.lock);
 	switch (partition.state) {
 	case AggregatePartitionState::READY_TO_FINALIZE:
 		partition.state = AggregatePartitionState::FINALIZE_IN_PROGRESS;
@@ -792,7 +793,7 @@ SourceResultType RadixHTGlobalSourceState::AssignTask(RadixHTGlobalSinkState &si
 	case AggregatePartitionState::FINALIZE_IN_PROGRESS:
 		lstate.task = RadixHTSourceTaskType::SCAN;
 		lstate.scan_status = RadixHTScanStatus::INIT;
-		return partition.BlockSource(partition_guard, interrupt_state);
+		return partition.BlockSource(interrupt_state);
 	case AggregatePartitionState::READY_TO_SCAN:
 		lstate.task = RadixHTSourceTaskType::SCAN;
 		lstate.scan_status = RadixHTScanStatus::INIT;
@@ -864,22 +865,26 @@ void RadixHTLocalSourceState::Finalize(RadixHTGlobalSinkState &sink, RadixHTGlob
 	partition.data->Combine(*ht->AcquirePartitionedData()->GetPartitions()[0]);
 
 	// Update thread-global state
-	auto guard = sink.Lock();
-	sink.stored_allocators.emplace_back(ht->GetAggregateAllocator());
-	if (task_idx == sink.partitions.size()) {
-		ht.reset();
-	}
-	const auto finalizes_done = ++sink.finalize_done;
-	D_ASSERT(finalizes_done <= sink.partitions.size());
-	if (finalizes_done == sink.partitions.size()) {
-		// All finalizes are done, set remaining size to 0
-		sink.temporary_memory_state->SetZero();
+	{
+		annotated_lock_guard<annotated_mutex> guard(sink.lock);
+		sink.stored_allocators.emplace_back(ht->GetAggregateAllocator());
+		if (task_idx == sink.partitions.size()) {
+			ht.reset();
+		}
+		const auto finalizes_done = ++sink.finalize_done;
+		D_ASSERT(finalizes_done <= sink.partitions.size());
+		if (finalizes_done == sink.partitions.size()) {
+			// All finalizes are done, set remaining size to 0
+			sink.temporary_memory_state->SetZero();
+		}
 	}
 
 	// Update partition state
-	auto partition_guard = partition.Lock();
-	partition.state = AggregatePartitionState::READY_TO_SCAN;
-	partition.UnblockTasks(partition_guard);
+	{
+		annotated_lock_guard<annotated_mutex> partition_guard(partition.lock);
+		partition.state = AggregatePartitionState::READY_TO_SCAN;
+		partition.UnblockTasks();
+	}
 
 	// This thread will scan the partition
 	task = RadixHTSourceTaskType::SCAN;
@@ -904,7 +909,7 @@ void RadixHTLocalSourceState::Scan(RadixHTGlobalSinkState &sink, RadixHTGlobalSo
 			data_collection.Reset();
 		}
 		scan_status = RadixHTScanStatus::DONE;
-		auto guard = sink.Lock();
+		annotated_lock_guard<annotated_mutex> guard(sink.lock);
 		if (++gstate.task_done == sink.partitions.size()) {
 			gstate.finished = true;
 		}

--- a/src/include/duckdb/common/mutex.hpp
+++ b/src/include/duckdb/common/mutex.hpp
@@ -11,10 +11,99 @@
 #ifdef __MVS__
 #include <time.h>
 #endif
+#include "duckdb/common/thread_annotation.hpp"
+#include "duckdb/common/thread_annotation/mutex.hpp"
+
 #include <mutex>
 
 namespace duckdb {
-using std::lock_guard;
-using std::mutex;
-using std::unique_lock;
+// Annotated mutex implementation.
+class DUCKDB_CAPABILITY("mutex") annotated_mutex : public internal::mutex_impl_t<annotated_mutex> {
+private:
+	using Impl = internal::mutex_impl_t<annotated_mutex>;
+
+public:
+	void lock() DUCKDB_ACQUIRE() {
+		Impl::lock();
+	}
+	void unlock() DUCKDB_RELEASE() {
+		Impl::unlock();
+	}
+	bool try_lock() DUCKDB_TRY_ACQUIRE(true) {
+		return Impl::try_lock();
+	}
+};
+
+// Annotated lock_guard implementation.
+template <typename M>
+class DUCKDB_SCOPED_CAPABILITY annotated_lock_guard : public internal::lock_impl_t<annotated_lock_guard<M>> {
+private:
+	using Impl = internal::lock_impl_t<annotated_lock_guard<M>>;
+
+public:
+	explicit annotated_lock_guard(M &m) DUCKDB_ACQUIRE(m) : Impl(m) {
+	}
+	annotated_lock_guard(M &m, std::adopt_lock_t t) DUCKDB_REQUIRES(m) : Impl(m, t) {
+	}
+
+	// Disable copy and enable move.
+	annotated_lock_guard(const annotated_lock_guard &) = delete;
+	annotated_lock_guard &operator=(const annotated_lock_guard &) = delete;
+	annotated_lock_guard(annotated_lock_guard &&) = default;
+	annotated_lock_guard &operator=(annotated_lock_guard &&) = default;
+
+	~annotated_lock_guard() DUCKDB_RELEASE() = default;
+};
+
+// Annotated unique_lock implementation.
+template <typename M>
+class DUCKDB_SCOPED_CAPABILITY annotated_unique_lock : public internal::lock_impl_t<annotated_unique_lock<M>> {
+private:
+	using Impl = internal::lock_impl_t<annotated_unique_lock<M>>;
+
+public:
+	annotated_unique_lock() = default;
+	explicit annotated_unique_lock(M &m) DUCKDB_ACQUIRE(m) : Impl(m) {
+	}
+	annotated_unique_lock(M &m, std::defer_lock_t t) noexcept DUCKDB_EXCLUDES(m) : Impl(m, t) {
+	}
+	annotated_unique_lock(M &m, std::try_to_lock_t t) DUCKDB_TRY_ACQUIRE(true, m) : Impl(m, t) {
+	}
+	annotated_unique_lock(M &m, std::adopt_lock_t t) DUCKDB_REQUIRES(m) : Impl(m, t) {
+	}
+
+	// Disable copy and enable move.
+	annotated_unique_lock(const annotated_unique_lock &) = delete;
+	annotated_unique_lock &operator=(const annotated_unique_lock &) = delete;
+	annotated_unique_lock(annotated_unique_lock &&) = default;
+	annotated_unique_lock &operator=(annotated_unique_lock &&) = default;
+
+	~annotated_unique_lock() DUCKDB_RELEASE() = default;
+
+	void lock() DUCKDB_ACQUIRE() {
+		Impl::lock();
+	}
+	bool try_lock() DUCKDB_TRY_ACQUIRE(true) {
+		return Impl::try_lock();
+	}
+	template <typename R, typename P>
+	bool try_lock_for(const std::chrono::duration<R, P> &timeout) DUCKDB_TRY_ACQUIRE(true) {
+		return Impl::try_lock_for(timeout);
+	}
+	template <typename C, typename D>
+	bool try_lock_until(const std::chrono::time_point<C, D> &timeout) DUCKDB_TRY_ACQUIRE(true) {
+		return Impl::try_lock_until(timeout);
+	}
+	void unlock() DUCKDB_RELEASE() {
+		Impl::unlock();
+	}
+};
+
+// Unannotated mutex type, which is alias for STL ones.
+using mutex = std::mutex;
+template <typename M = std::mutex>
+using lock_guard = std::lock_guard<M>;
+template <typename M = std::mutex>
+using unique_lock = std::unique_lock<M>;
+
 } // namespace duckdb

--- a/src/include/duckdb/common/thread_annotation.hpp
+++ b/src/include/duckdb/common/thread_annotation.hpp
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/thread_annotation.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+// Thread annotatio which enables clang thread safety analysis, a C++ language extension which warns about potential
+// race conditions in code. The analysis is completely static (i.e. compile-time); there is no run-time overhead. For
+// more information, please refer to: https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#reference-guide
+
+#pragma once
+
+#include "duckdb/common/thread_annotation/thread_annotation.hpp"
+
+// GUARDED_BY is an attribute on data members, which declares that the data member is protected by the given
+// capability. Read operations on the data require shared access, while write operations require exclusive access.
+#define DUCKDB_GUARDED_BY(x) DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(guarded_by(x))
+
+// PT_GUARDED_BY is similar, but is intended for use on pointers and smart pointers. There is no constraint on the data
+// member itself, but the data that it points to is protected by the given capability.
+#define DUCKDB_PT_GUARDED_BY(x) DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(pt_guarded_by(x))
+
+// REQUIRES is an attribute on functions or methods, which declares that the calling thread must have exclusive access
+// to the given capabilities. More than one capability may be specified. The capabilities must be held on entry to the
+// function, and must still be held on exit. REQUIRES_SHARED is similar, but requires only shared access.
+#define DUCKDB_REQUIRES(...)        DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(requires_capability(__VA_ARGS__))
+#define DUCKDB_REQUIRES_SHARED(...) DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(requires_shared_capability(__VA_ARGS__))
+
+// ACQUIRE and ACQUIRE_SHARED are attributes on functions or methods declaring that the function acquires a capability,
+// but does not release it. The given capability must not be held on entry, and will be held on exit (exclusively for
+// ACQUIRE, shared for ACQUIRE_SHARED).
+#define DUCKDB_ACQUIRE(...)        DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(acquire_capability(__VA_ARGS__))
+#define DUCKDB_ACQUIRE_SHARED(...) DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(acquire_shared_capability(__VA_ARGS__))
+
+// ACQUIRED_BEFORE and ACQUIRED_AFTER are attributes on member declarations, specifically declarations of mutexes or
+// other capabilities. These declarations enforce a particular order in which the mutexes must be acquired, in order
+// to prevent deadlock.
+#define DUCKDB_ACQUIRED_BEFORE(...) DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(acquired_before(__VA_ARGS__))
+#define DUCKDB_ACQUIRED_AFTER(...)  DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(acquired_after(__VA_ARGS__))
+
+// RELEASE, RELEASE_SHARED, and RELEASE_GENERIC declare that the function releases the given capability. The capability
+// must be held on entry (exclusively for RELEASE, shared for RELEASE_SHARED, exclusively or shared for
+// RELEASE_GENERIC), and will no longer be held on exit.
+#define DUCKDB_RELEASE(...)         DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(release_capability(__VA_ARGS__))
+#define DUCKDB_RELEASE_SHARED(...)  DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(release_shared_capability(__VA_ARGS__))
+#define DUCKDB_RELEASE_GENERIC(...) DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(release_generic_capability(__VA_ARGS__))
+
+// EXCLUDES is an attribute on functions or methods, which declares that the caller must not hold the given
+// capabilities. This annotation is used to prevent deadlock. Many mutex implementations are not re-entrant, so
+// deadlock can occur if the function acquires the mutex a second time.
+#define DUCKDB_EXCLUDES(...) DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(locks_excluded(__VA_ARGS__))
+
+// RETURN_CAPABILITY is an attribute on functions or methods, which declares that the function returns a reference to
+// the given capability. It is used to annotate getter methods that return mutexes.
+#define DUCKDB_RETURN_CAPABILITY(x) DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(lock_returned(x))
+
+// These are attributes on a function or method that tries to acquire the given capability, and returns a boolean value
+// indicating success or failure. The first argument must be true or false, to specify which return value indicates
+// success, and the remaining arguments are interpreted in the same way as DUCKDB_ACQUIRE.
+#define DUCKDB_TRY_ACQUIRE(...)        DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(try_acquire_capability(__VA_ARGS__))
+#define DUCKDB_TRY_ACQUIRE_SHARED(...) DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(try_acquire_shared_capability(__VA_ARGS__))
+
+// These are attributes on a function or method which asserts the calling thread already holds the given capability,
+// for example by performing a run-time test and terminating if the capability is not held. Presence of this annotation
+// causes the analysis to assume the capability is held after calls to the annotated function.
+#define DUCKDB_ASSERT_CAPABILITY(x)        DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(assert_capability(x))
+#define DUCKDB_ASSERT_SHARED_CAPABILITY(x) DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(assert_shared_capability(x))

--- a/src/include/duckdb/common/thread_annotation/mutex.hpp
+++ b/src/include/duckdb/common/thread_annotation/mutex.hpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/thread_annotation/mutex.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+// Bind annotated mutex and lock type with standard implementation, so that
+// duckdb::annotated_unique_lock<duckdb::annotated_mutex> could inherit std::unique_lock<std::mutex>.
+
+#pragma once
+
+#include <mutex>
+
+namespace duckdb {
+
+// Forward declaration for annotated mutex types.
+class annotated_mutex;
+
+// Forward declaration for annotated lock types.
+template <typename M>
+class annotated_unique_lock;
+template <typename M>
+class annotated_lock_guard;
+
+namespace internal {
+
+// Type alias for mutex types.
+template <typename T>
+struct standard_impl {
+	using type = T;
+};
+template <typename T>
+using standard_impl_t = typename standard_impl<T>::type;
+
+// Specialization for `std::mutex`.
+template <>
+struct standard_impl<::duckdb::annotated_mutex> {
+	using type = std::mutex;
+};
+
+// Type alias for lock types.
+template <typename M>
+using mutex_impl_t = standard_impl_t<M>;
+
+// Specialization for `std::unique_lock`.
+template <typename M>
+struct standard_impl<::duckdb::annotated_unique_lock<M>> {
+	using type = std::unique_lock<mutex_impl_t<M>>;
+};
+
+// Specialization for `std::lock_guard`.
+template <typename M>
+struct standard_impl<::duckdb::annotated_lock_guard<M>> {
+	using type = std::lock_guard<mutex_impl_t<M>>;
+};
+
+template <typename L>
+using lock_impl_t = standard_impl_t<L>;
+
+} // namespace internal
+} // namespace duckdb

--- a/src/include/duckdb/common/thread_annotation/thread_annotation.hpp
+++ b/src/include/duckdb/common/thread_annotation/thread_annotation.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/thread_annotation/thread_annotation.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+// Enable thread safety attributes only with clang.
+// The attributes can be safely erased when compiling with other compilers.
+#if defined(__clang__) && (!defined(SWIG))
+#define DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(x) __attribute__((x))
+#else
+#define DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(x) // no-op
+#endif
+
+// CAPABILITY is an attribute on classes, which specifies that objects of the class can be used as a capability. The
+// string argument specifies the kind of capability in error messages, e.g. "mutex".
+#define DUCKDB_CAPABILITY(x) DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(capability(x))
+
+// SCOPED_CAPABILITY is an attribute on classes that implement RAII-style locking, in which a capability is acquired
+// in the constructor, and released in the destructor. Such classes require special handling because the
+// constructor and destructor refer to the capability via different names.
+#define DUCKDB_SCOPED_CAPABILITY DUCKDB_THREAD_ANNOTATION_ATTRIBUTE(scoped_lockable)

--- a/src/include/duckdb/execution/operator/persistent/batch_memory_manager.hpp
+++ b/src/include/duckdb/execution/operator/persistent/batch_memory_manager.hpp
@@ -71,7 +71,7 @@ public:
 		return true;
 #else
 		if (unflushed_memory_usage >= available_memory) {
-			auto guard = Lock();
+			const annotated_lock_guard<annotated_mutex> guard(lock);
 			if (batch_index > min_batch_index) {
 				// exceeded available memory and we are not the minimum batch index- try to increase it
 				IncreaseMemory();
@@ -89,12 +89,12 @@ public:
 		if (min_batch_index >= current_min_batch_index) {
 			return;
 		}
-		auto guard = Lock();
+		const annotated_lock_guard<annotated_mutex> guard(lock);
 		auto new_batch_index = MaxValue<idx_t>(min_batch_index, current_min_batch_index);
 		if (new_batch_index != min_batch_index) {
 			// new batch index! unblock all tasks
 			min_batch_index = new_batch_index;
-			UnblockTasks(guard);
+			UnblockTasks();
 		}
 	}
 

--- a/src/include/duckdb/parallel/interrupt.hpp
+++ b/src/include/duckdb/parallel/interrupt.hpp
@@ -35,7 +35,7 @@ struct InterruptDoneSignalState {
 	void Await();
 
 protected:
-	mutex lock;
+	annotated_mutex lock;
 	std::condition_variable cv;
 	bool done = false;
 };
@@ -64,18 +64,12 @@ protected:
 
 class StateWithBlockableTasks {
 public:
-	unique_lock<mutex> Lock() {
-		return unique_lock<mutex>(lock);
-	}
-
-	void PreventBlocking(const unique_lock<mutex> &guard) {
-		VerifyLock(guard);
+	void PreventBlocking() DUCKDB_REQUIRES(lock) {
 		can_block = false;
 	}
 
 	//! Add a task to 'blocked_tasks' before returning SourceResultType::BLOCKED (must hold the lock)
-	bool BlockTask(const unique_lock<mutex> &guard, const InterruptState &interrupt_state) {
-		VerifyLock(guard);
+	bool BlockTask(const InterruptState &interrupt_state) DUCKDB_REQUIRES(lock) {
 		if (can_block) {
 			blocked_tasks.push_back(interrupt_state);
 			return true;
@@ -83,14 +77,12 @@ public:
 		return false;
 	}
 
-	bool CanBlock(const unique_lock<mutex> &guard) const {
-		VerifyLock(guard);
+	bool CanBlock() const DUCKDB_REQUIRES(lock) {
 		return can_block;
 	}
 
 	//! Unblock all tasks (must hold the lock)
-	bool UnblockTasks(const unique_lock<mutex> &guard) {
-		VerifyLock(guard);
+	bool UnblockTasks() DUCKDB_REQUIRES(lock) {
 		if (blocked_tasks.empty()) {
 			return false;
 		}
@@ -101,27 +93,23 @@ public:
 		return true;
 	}
 
-	SinkResultType BlockSink(const unique_lock<mutex> &guard, const InterruptState &interrupt_state) {
-		return BlockTask(guard, interrupt_state) ? SinkResultType::BLOCKED : SinkResultType::FINISHED;
+	SinkResultType BlockSink(const InterruptState &interrupt_state) DUCKDB_REQUIRES(lock) {
+		return BlockTask(interrupt_state) ? SinkResultType::BLOCKED : SinkResultType::FINISHED;
 	}
 
-	SourceResultType BlockSource(const unique_lock<mutex> &guard, const InterruptState &interrupt_state) {
-		return BlockTask(guard, interrupt_state) ? SourceResultType::BLOCKED : SourceResultType::FINISHED;
+	SourceResultType BlockSource(const InterruptState &interrupt_state) DUCKDB_REQUIRES(lock) {
+		return BlockTask(interrupt_state) ? SourceResultType::BLOCKED : SourceResultType::FINISHED;
 	}
 
-	void VerifyLock(const unique_lock<mutex> &guard) const {
-#ifdef DEBUG
-		D_ASSERT(guard.mutex() && RefersToSameObject(*guard.mutex(), lock));
-#endif
-	}
+public:
+	//! Global lock
+	mutable annotated_mutex lock;
 
 private:
 	//! Whether we can block tasks
-	atomic<bool> can_block {true};
-	//! Global lock, acquired by calling Lock()
-	mutable mutex lock;
+	bool can_block DUCKDB_GUARDED_BY(lock) = true;
 	//! Tasks that are currently blocked
-	mutable vector<InterruptState> blocked_tasks;
+	mutable vector<InterruptState> blocked_tasks DUCKDB_GUARDED_BY(lock);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/temporary_memory_manager.hpp
+++ b/src/include/duckdb/storage/temporary_memory_manager.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/reference_map.hpp"
+#include "duckdb/common/thread_annotation.hpp"
 #include "duckdb/storage/storage_info.hpp"
 
 namespace duckdb {
@@ -96,31 +97,30 @@ public:
 	//! Get the TemporaryMemoryManager
 	static TemporaryMemoryManager &Get(ClientContext &context);
 	//! Register a TemporaryMemoryState
-	unique_ptr<TemporaryMemoryState> Register(ClientContext &context);
+	unique_ptr<TemporaryMemoryState> Register(ClientContext &context) DUCKDB_EXCLUDES(lock);
 
 private:
-	//! Locks the TemporaryMemoryManager
-	unique_lock<mutex> Lock();
 	//! Get the default minimum reservation
 	idx_t DefaultMinimumReservation() const;
 	//! Unregister a TemporaryMemoryState (called by the destructor of TemporaryMemoryState)
-	void Unregister(TemporaryMemoryState &temporary_memory_state);
+	void Unregister(TemporaryMemoryState &temporary_memory_state) DUCKDB_EXCLUDES(lock);
 	//! Update memory_limit, has_temporary_directory, and num_threads (must hold the lock)
-	void UpdateConfiguration(ClientContext &context);
+	void UpdateConfiguration(ClientContext &context) DUCKDB_REQUIRES(lock);
 	//! Update the TemporaryMemoryState to the new remaining size, and updates the reservation (must hold the lock)
-	void UpdateState(ClientContext &context, TemporaryMemoryState &temporary_memory_state);
+	void UpdateState(ClientContext &context, TemporaryMemoryState &temporary_memory_state) DUCKDB_REQUIRES(lock);
 	//! Set the remaining size of a TemporaryMemoryState (must hold the lock)
-	void SetRemainingSize(TemporaryMemoryState &temporary_memory_state, idx_t new_remaining_size);
+	void SetRemainingSize(TemporaryMemoryState &temporary_memory_state, idx_t new_remaining_size)
+	    DUCKDB_REQUIRES(lock);
 	//! Set the reservation of a TemporaryMemoryState (must hold the lock)
-	void SetReservation(TemporaryMemoryState &temporary_memory_state, idx_t new_reservation);
+	void SetReservation(TemporaryMemoryState &temporary_memory_state, idx_t new_reservation) DUCKDB_REQUIRES(lock);
 	//! Computes optimal reservation of a TemporaryMemoryState based on a cost function
-	idx_t ComputeReservation(const TemporaryMemoryState &temporary_memory_state) const;
+	idx_t ComputeReservation(const TemporaryMemoryState &temporary_memory_state) const DUCKDB_REQUIRES(lock);
 	//! Verify internal counts (must hold the lock)
-	void Verify() const;
+	void Verify() const DUCKDB_REQUIRES(lock);
 
 private:
 	//! Lock because TemporaryMemoryManager is used concurrently
-	mutex lock;
+	annotated_mutex lock;
 
 	//! Memory limit of the buffer pool
 	idx_t memory_limit = DConstants::INVALID_INDEX;

--- a/src/include/duckdb/storage/temporary_memory_manager.hpp
+++ b/src/include/duckdb/storage/temporary_memory_manager.hpp
@@ -109,8 +109,7 @@ private:
 	//! Update the TemporaryMemoryState to the new remaining size, and updates the reservation (must hold the lock)
 	void UpdateState(ClientContext &context, TemporaryMemoryState &temporary_memory_state) DUCKDB_REQUIRES(lock);
 	//! Set the remaining size of a TemporaryMemoryState (must hold the lock)
-	void SetRemainingSize(TemporaryMemoryState &temporary_memory_state, idx_t new_remaining_size)
-	    DUCKDB_REQUIRES(lock);
+	void SetRemainingSize(TemporaryMemoryState &temporary_memory_state, idx_t new_remaining_size) DUCKDB_REQUIRES(lock);
 	//! Set the reservation of a TemporaryMemoryState (must hold the lock)
 	void SetReservation(TemporaryMemoryState &temporary_memory_state, idx_t new_reservation) DUCKDB_REQUIRES(lock);
 	//! Computes optimal reservation of a TemporaryMemoryState based on a cost function

--- a/src/parallel/interrupt.cpp
+++ b/src/parallel/interrupt.cpp
@@ -40,14 +40,14 @@ void InterruptState::Callback() const {
 
 void InterruptDoneSignalState::Signal() {
 	{
-		unique_lock<mutex> lck {lock};
+		annotated_lock_guard<annotated_mutex> lck(lock);
 		done = true;
 	}
 	cv.notify_all();
 }
 
 void InterruptDoneSignalState::Await() {
-	std::unique_lock<std::mutex> lck(lock);
+	annotated_unique_lock<annotated_mutex> lck(lock);
 	cv.wait(lck, [&]() { return done; });
 
 	// Reset after signal received

--- a/src/storage/temporary_memory_manager.cpp
+++ b/src/storage/temporary_memory_manager.cpp
@@ -20,19 +20,19 @@ TemporaryMemoryState::~TemporaryMemoryState() {
 }
 
 void TemporaryMemoryState::SetRemainingSize(idx_t new_remaining_size) {
-	auto guard = temporary_memory_manager.Lock();
+	const annotated_lock_guard<annotated_mutex> guard(temporary_memory_manager.lock);
 	temporary_memory_manager.SetRemainingSize(*this, new_remaining_size);
 }
 
 void TemporaryMemoryState::SetRemainingSizeAndUpdateReservation(ClientContext &context, idx_t new_remaining_size) {
 	D_ASSERT(new_remaining_size != 0); // Use SetZero instead
-	auto guard = temporary_memory_manager.Lock();
+	const annotated_lock_guard<annotated_mutex> guard(temporary_memory_manager.lock);
 	temporary_memory_manager.SetRemainingSize(*this, new_remaining_size);
 	temporary_memory_manager.UpdateState(context, *this);
 }
 
 void TemporaryMemoryState::SetZero() {
-	auto guard = temporary_memory_manager.Lock();
+	const annotated_lock_guard<annotated_mutex> guard(temporary_memory_manager.lock);
 	temporary_memory_manager.SetRemainingSize(*this, 0);
 	temporary_memory_manager.SetReservation(*this, 0);
 }
@@ -50,7 +50,7 @@ idx_t TemporaryMemoryState::GetMinimumReservation() const {
 }
 
 void TemporaryMemoryState::UpdateReservation(ClientContext &context) {
-	auto guard = temporary_memory_manager.Lock();
+	const annotated_lock_guard<annotated_mutex> guard(temporary_memory_manager.lock);
 	temporary_memory_manager.UpdateState(context, *this);
 }
 
@@ -59,7 +59,7 @@ idx_t TemporaryMemoryState::GetReservation() const {
 }
 
 void TemporaryMemoryState::SetMaterializationPenalty(idx_t new_materialization_penalty) {
-	auto guard = temporary_memory_manager.Lock();
+	const annotated_lock_guard<annotated_mutex> guard(temporary_memory_manager.lock);
 	materialization_penalty = new_materialization_penalty;
 }
 
@@ -70,17 +70,13 @@ idx_t TemporaryMemoryState::GetMaterializationPenalty() const {
 TemporaryMemoryManager::TemporaryMemoryManager() : reservation(0), remaining_size(0) {
 }
 
-unique_lock<mutex> TemporaryMemoryManager::Lock() {
-	return unique_lock<mutex>(lock);
-}
-
 idx_t TemporaryMemoryManager::DefaultMinimumReservation() const {
 	return MinValue(num_threads * MINIMUM_RESERVATION_PER_STATE_PER_THREAD,
 	                memory_limit / MINIMUM_RESERVATION_MEMORY_LIMIT_DIVISOR);
 }
 
 void TemporaryMemoryManager::Unregister(TemporaryMemoryState &temporary_memory_state) {
-	auto guard = Lock();
+	const annotated_lock_guard<annotated_mutex> guard(lock);
 
 	SetReservation(temporary_memory_state, 0);
 	SetRemainingSize(temporary_memory_state, 0);
@@ -106,7 +102,7 @@ TemporaryMemoryManager &TemporaryMemoryManager::Get(ClientContext &context) {
 }
 
 unique_ptr<TemporaryMemoryState> TemporaryMemoryManager::Register(ClientContext &context) {
-	auto guard = Lock();
+	const annotated_lock_guard<annotated_mutex> guard(lock);
 	UpdateConfiguration(context);
 
 	auto result = unique_ptr<TemporaryMemoryState>(new TemporaryMemoryState(*this, DefaultMinimumReservation()));


### PR DESCRIPTION
This is a split of https://github.com/duckdb/duckdb/pull/20655.
After discussing with the team, we decided to 
- Keep the existing un-annotated mutex and introduce annotated ones as separate class; namely we do whitelist rollout instead of blacklist ones
- In the referenced PR, I updated the whole codebase to leverage the annotated lock, but the changeset is too big to review; this PR splits out a small portion of it -- only `StateWithBlockableTasks`-related classes to remove `VerifyLock` calls

I have checked in macos environment and confirmed it compiles with no warnings or errors.