### PR TITLE
Reduce CI workload by re-ordering linux CI jobs

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -19,32 +19,6 @@ on:
       skip_tests:
         description: 'Pass "true" to skip tests'
         type: string
-  push:
-    branches-ignore:
-      - 'main'
-      - 'feature'
-      - 'v*.*-*'
-    paths-ignore:
-      - '**.md'
-      - 'test/configs/**'
-      - 'tools/**'
-      - '!tools/shell/**'
-      - '!tools/juliapkg/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/LinuxRelease.yml'
-  merge_group:
-  pull_request:
-    types: [opened, reopened, ready_for_review, converted_to_draft]
-    paths-ignore:
-      - '**.md'
-      - 'test/configs/**'
-      - 'tools/**'
-      - '!tools/shell/**'
-      - '!tools/juliapkg/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/LinuxRelease.yml'
 
 
 concurrency:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -345,8 +345,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs: linux-release-cli
     if: ${{ inputs.skip_tests != 'true' }}
-    env:
-      GEN: ninja
 
     steps:
     - uses: actions/checkout@v4
@@ -358,15 +356,17 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Install Ninja
-      shell: bash
-      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+    - uses: actions/download-artifact@v4
+      with:
+        name: duckdb-binaries-linux-amd64
+        path: linux-release-artifacts
 
-    - uses: ./.github/actions/ccache-action
-
-    - name: Build
+    - name: Extract Linux release library
       shell: bash
-      run: make
+      run: |
+        mkdir -p build/release/src
+        unzip -j linux-release-artifacts/libduckdb-linux-amd64.zip "libduckdb.so*" -d build/release/src
+        ls -lah build/release/src/libduckdb.so*
 
     - name: Symbol Leakage Test
       shell: bash

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -345,6 +345,8 @@ jobs:
     runs-on: ubuntu-22.04
     needs: linux-release-cli
     if: ${{ inputs.skip_tests != 'true' }}
+    env:
+      GEN: ninja
 
     steps:
     - uses: actions/checkout@v4
@@ -356,17 +358,15 @@ jobs:
       with:
         python-version: '3.12'
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: duckdb-binaries-linux-amd64
-        path: linux-release-artifacts
-
-    - name: Extract Linux release library
+    - name: Install Ninja
       shell: bash
-      run: |
-        mkdir -p build/release/src
-        unzip -j linux-release-artifacts/libduckdb-linux-amd64.zip "libduckdb.so*" -d build/release/src
-        ls -lah build/release/src/libduckdb.so*
+      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+
+    - uses: ./.github/actions/ccache-action
+
+    - name: Build
+      shell: bash
+      run: make
 
     - name: Symbol Leakage Test
       shell: bash

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -11,6 +11,7 @@ on:
       - '**.md'
       - 'tools/**'
       - '!tools/shell/**'
+      - '!tools/juliapkg/**'
       - '.github/patches/duckdb-wasm/**'
       - '.github/workflows/**'
       - '!.github/workflows/Main.yml'
@@ -25,6 +26,7 @@ on:
       - '**.md'
       - 'tools/**'
       - '!tools/shell/**'
+      - '!tools/juliapkg/**'
       - '.github/patches/duckdb-wasm/**'
       - '.github/workflows/**'
       - '!.github/workflows/Main.yml'
@@ -127,6 +129,14 @@ jobs:
     - name: Test
       shell: bash
       run: make allunit
+
+ linux-cli:
+    uses: ./.github/workflows/LinuxRelease.yml
+    secrets: inherit
+    needs: linux-debug
+    with:
+      git_ref: ${{ github.sha }}
+      skip_tests: 'false'
 
  no-string-inline:
     name: No String Inline / Destroy Unpinned Blocks


### PR DESCRIPTION
- ~~Use linux release artifacts for `Symbol Leakage` to avoid re-compiling the same binaries.~~ We cannot use the release binary for the symbol leakage, for now. So I reverted the commit to allow moving this PR forward.
- Run `Linux CLI` jobs only after `Linux debug` is done.
  - This saves compute when the linux debug build is already broken.
  - This allows us to move the CI pipeline into stages (`smoke -> build -> test`).


note: the first three commits are from https://github.com/duckdb/duckdb/pull/21054.

### High-level CI pipeline overview
```mermaid
graph TD;
    subgraph prepare
    check-draft["Check draft and format"]
    end
    prepare --> smoke
    subgraph smoke
    linux-debug["Linux Debug with small subset of unit tests"]
    end
    smoke --> build
    subgraph build
    linux-cli-amd64-musl["Linux CLI (amd64-musl)"]
    linux-cli-amd64["Linux CLI (amd64)"]
    linux-cli-arm64["Linux CLI (arm64)"]
    linux-cli-arm64-musl["Linux CLI (arm64-musl)"]
    end
    linux-cli-amd64 --> test-julia-1_10
    linux-cli-amd64 --> test-julia-1_0
    linux-cli-amd64 --> test-symbol-leak
    subgraph test
    test-julia-1_10["julia 1.10"]
    test-julia-1_0["julia 1"]
    test-symbol-leak["Symbol Leakage"]
    end
```