### PR TITLE
Enable profiling in jemalloc

### DIFF
--- a/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -201,7 +201,7 @@
 /* #undef JEMALLOC_EXPERIMENTAL_SMALLOCX_API */
 
 /* JEMALLOC_PROF enables allocation profiling. */
-/* #undef JEMALLOC_PROF */
+#define JEMALLOC_PROF
 
 /* Use libunwind for profile backtracing if defined. */
 /* #undef JEMALLOC_PROF_LIBUNWIND */
@@ -210,7 +210,7 @@
 /* #undef JEMALLOC_PROF_LIBGCC */
 
 /* Use gcc intrinsics for profile backtracing if defined. */
-/* #undef JEMALLOC_PROF_GCC */
+#define JEMALLOC_PROF_GCC
 
 /* JEMALLOC_PAGEID enabled page id */
 /* #undef JEMALLOC_PAGEID */

--- a/extension/jemalloc/jemalloc/src/jemalloc.c
+++ b/extension/jemalloc/jemalloc/src/jemalloc.c
@@ -4286,9 +4286,9 @@ jemalloc_constructor(void) {
 	// decay is in ms
 	unsigned long long decay = DUCKDB_JEMALLOC_DECAY * 1000;
 #ifdef DEBUG
-	snprintf(JE_MALLOC_CONF_BUFFER, JE_MALLOC_CONF_BUFFER_SIZE, "junk:true,prof:true,oversize_threshold:268435456,dirty_decay_ms:%llu,muzzy_decay_ms:%llu,narenas:%llu,max_background_threads:%llu", decay, decay, narenas, bgt_count);
+	snprintf(JE_MALLOC_CONF_BUFFER, JE_MALLOC_CONF_BUFFER_SIZE, "junk:true,oversize_threshold:268435456,dirty_decay_ms:%llu,muzzy_decay_ms:%llu,narenas:%llu,max_background_threads:%llu", decay, decay, narenas, bgt_count);
 #else
-	snprintf(JE_MALLOC_CONF_BUFFER, JE_MALLOC_CONF_BUFFER_SIZE, "prof:true,oversize_threshold:268435456,dirty_decay_ms:%llu,muzzy_decay_ms:%llu,narenas:%llu,max_background_threads:%llu", decay, decay, narenas, bgt_count);
+	snprintf(JE_MALLOC_CONF_BUFFER, JE_MALLOC_CONF_BUFFER_SIZE, "oversize_threshold:268435456,dirty_decay_ms:%llu,muzzy_decay_ms:%llu,narenas:%llu,max_background_threads:%llu", decay, decay, narenas, bgt_count);
 #endif
 	je_malloc_conf = JE_MALLOC_CONF_BUFFER;
 	malloc_init();

--- a/extension/jemalloc/jemalloc/src/jemalloc.c
+++ b/extension/jemalloc/jemalloc/src/jemalloc.c
@@ -4286,9 +4286,9 @@ jemalloc_constructor(void) {
 	// decay is in ms
 	unsigned long long decay = DUCKDB_JEMALLOC_DECAY * 1000;
 #ifdef DEBUG
-	snprintf(JE_MALLOC_CONF_BUFFER, JE_MALLOC_CONF_BUFFER_SIZE, "junk:true,oversize_threshold:268435456,dirty_decay_ms:%llu,muzzy_decay_ms:%llu,narenas:%llu,max_background_threads:%llu", decay, decay, narenas, bgt_count);
+	snprintf(JE_MALLOC_CONF_BUFFER, JE_MALLOC_CONF_BUFFER_SIZE, "junk:true,prof:true,oversize_threshold:268435456,dirty_decay_ms:%llu,muzzy_decay_ms:%llu,narenas:%llu,max_background_threads:%llu", decay, decay, narenas, bgt_count);
 #else
-	snprintf(JE_MALLOC_CONF_BUFFER, JE_MALLOC_CONF_BUFFER_SIZE, "oversize_threshold:268435456,dirty_decay_ms:%llu,muzzy_decay_ms:%llu,narenas:%llu,max_background_threads:%llu", decay, decay, narenas, bgt_count);
+	snprintf(JE_MALLOC_CONF_BUFFER, JE_MALLOC_CONF_BUFFER_SIZE, "prof:true,oversize_threshold:268435456,dirty_decay_ms:%llu,muzzy_decay_ms:%llu,narenas:%llu,max_background_threads:%llu", decay, decay, narenas, bgt_count);
 #endif
 	je_malloc_conf = JE_MALLOC_CONF_BUFFER;
 	malloc_init();

--- a/extension/jemalloc/jemalloc/src/prof_sys.c
+++ b/extension/jemalloc/jemalloc/src/prof_sys.c
@@ -484,7 +484,7 @@ prof_getpid(void) {
 #endif
 }
 
-long
+static long
 prof_get_pid_namespace() {
 	long ret = 0;
 


### PR DESCRIPTION
Enable the the jemalloc profiling flag so I can write a extension to see the diagram of memory allocation.

the binary size change:
before:
```bash
duckdb on main
❯ ls -al ./build/release/duckdb
-rwxr-xr-x@ 1 lixucheng  staff  44870568 Feb 24 19:01 ./build/release/duckdb
```
after:
```bash
duckdb-jemalloc-prof on feat/enable-jemalloc-prof 
❯ ls -al ./build/release/duckdb
-rwxr-xr-x  1 lixucheng  staff  44870568 Feb 24 18:53 ./build/release/duckdb
```


example usage of that extension:

```sql
SELECT jemalloc_control('prof.active', true);
SELECT * FROM jemalloc_config();
INSTALL httpfs;
LOAD httpfs;
SELECT count(*) FROM 'https://huggingface.co/datasets/open-r1/OpenR1-Math-220k/resolve/main/data/train-00003-of-00010.parquet';
SELECT jemalloc_profile_dump('/tmp/duckdb_profile.heap');
```

then generate the diagram with `jeprof --svg ./build/release/duckdb /tmp/duckdb_profile.heap > output.svg`
output:
<img width="794" height="1149" alt="image" src="https://github.com/user-attachments/assets/0c346f97-0dcd-4306-b401-5603af960a89" />
<img width="802" height="1135" alt="image" src="https://github.com/user-attachments/assets/24fe83db-b629-457a-99c0-97bd67adea0f" />
<img width="802" height="950" alt="image" src="https://github.com/user-attachments/assets/5ac0aa04-f6e3-44af-9301-4c115003bc10" />



[output.svg](https://github.com/user-attachments/assets/b6f068cd-281a-43d5-9c52-3b8f12be294f)
