### PR TITLE
[Fix] WAL corruption when reusing optimistically written blocks too optimistically ;)

### DIFF
--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -44,6 +44,7 @@ public:
 	virtual bool HasRowGroupData() {
 		return false;
 	}
+	virtual unordered_set<block_id_t> &GetBlockIdsInUse() = 0;
 };
 
 //! StorageManager is responsible for managing the physical storage of a persistent database.

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -74,7 +74,7 @@ public:
 	void SetWALSize(idx_t size);
 	//! Gets the number of WAL entries since last checkpoint
 	idx_t GetWALEntriesCount() const;
-	void ResetWAL();
+	void ResetWALEntriesCount();
 	void IncrementWALEntriesCount();
 	//! Gets the WAL of the StorageManager, or nullptr, if there is no WAL.
 	optional_ptr<WriteAheadLog> GetWAL();
@@ -192,6 +192,10 @@ class SingleFileStorageManager : public StorageManager {
 public:
 	SingleFileStorageManager() = delete;
 	SingleFileStorageManager(AttachedDatabase &db, string path, AttachOptions &options);
+	~SingleFileStorageManager() override {
+		// The WAL destructor needs the storage manager to still be alive.
+		wal.reset();
+	}
 
 	//! The BlockManager to read from and write to blocks, both for the metadata and the data itself.
 	unique_ptr<BlockManager> block_manager;

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -74,7 +74,7 @@ public:
 	void SetWALSize(idx_t size);
 	//! Gets the number of WAL entries since last checkpoint
 	idx_t GetWALEntriesCount() const;
-	void ResetWALEntriesCount();
+	void ResetWAL();
 	void IncrementWALEntriesCount();
 	//! Gets the WAL of the StorageManager, or nullptr, if there is no WAL.
 	optional_ptr<WriteAheadLog> GetWAL();

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -192,10 +192,6 @@ class SingleFileStorageManager : public StorageManager {
 public:
 	SingleFileStorageManager() = delete;
 	SingleFileStorageManager(AttachedDatabase &db, string path, AttachOptions &options);
-	~SingleFileStorageManager() override {
-		// The WAL destructor needs the storage manager to still be alive.
-		wal.reset();
-	}
 
 	//! The BlockManager to read from and write to blocks, both for the metadata and the data itself.
 	unique_ptr<BlockManager> block_manager;

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "storage_manager.hpp"
 #include "duckdb/catalog/catalog_entry/index_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_macro_catalog_entry.hpp"

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -115,7 +115,7 @@ public:
 
 	//! Truncate the WAL to a previous size, and clear anything currently set in the writer.
 	//! Used during RevertCommit.
-	void Truncate(idx_t size);
+	void Truncatee(idx_t size);
 	void Flush();
 	//! Increment the WAL entry count, which is used for the auto-checkpoint threshold.
 	void IncrementWALEntriesCount();
@@ -123,7 +123,8 @@ public:
 	void AddBlockInUse(const block_id_t block_id) {
 		optimistic_block_ids.push_back(block_id);
 	}
-
+	//! Marks all blocks as modified. Should only be called prior to destructing the WAL.
+	void MarkBlocksAsModified();
 	void WriteCheckpoint(MetaBlockPointer meta_block);
 
 protected:

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "storage_manager.hpp"
 #include "duckdb/catalog/catalog_entry/index_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_macro_catalog_entry.hpp"
@@ -127,6 +128,7 @@ public:
 	bool NewBlockInUse(const block_id_t block_id) const {
 		return blocks_in_use.count(block_id) == 0;
 	}
+	void MarkBlocksInUseAsModified();
 	void WriteCheckpoint(MetaBlockPointer meta_block);
 
 protected:

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1129,28 +1129,57 @@ void DataTable::MergeStorage(RowGroupCollection &data, optional_ptr<StorageCommi
 	row_groups->Verify();
 }
 
+static void GatherBlockIds(const PersistentColumnData &column_data, unordered_set<block_id_t> &block_ids) {
+	for (const auto &pointer : column_data.pointers) {
+		auto block_ptr = pointer.block_pointer;
+		if (block_ptr.block_id != INVALID_BLOCK) {
+			block_ids.insert(block_ptr.block_id);
+		}
+	}
+	// Recurse into the children.
+	for (const auto &child_column_data : column_data.child_columns) {
+		GatherBlockIds(child_column_data, block_ids);
+	}
+}
+
 void DataTable::WriteToLog(DuckTransaction &transaction, WriteAheadLog &log, idx_t row_start, idx_t count,
                            optional_ptr<StorageCommitState> commit_state) {
 	log.WriteSetTable(info->schema, info->table);
-	if (commit_state) {
-		idx_t optimistic_count = 0;
-		auto entry = commit_state->GetRowGroupData(*this, row_start, optimistic_count);
-		if (entry) {
-			D_ASSERT(optimistic_count > 0);
-			log.WriteRowGroupData(*entry);
-			if (optimistic_count > count) {
-				throw InternalException(
-				    "Optimistically written count cannot exceed actual count (got %llu, but expected count is %llu)",
-				    optimistic_count, count);
-			}
-			// write any remaining (non-optimistically written) rows to the WAL normally
-			row_start += optimistic_count;
-			count -= optimistic_count;
-			if (count == 0) {
-				return;
-			}
+	if (!commit_state) {
+		ScanTableSegment(transaction, row_start, count, [&](DataChunk &chunk) { log.WriteInsert(chunk); });
+		return;
+	}
+
+	idx_t optimistic_count = 0;
+	auto entry = commit_state->GetRowGroupData(*this, row_start, optimistic_count);
+	if (!entry) {
+		ScanTableSegment(transaction, row_start, count, [&](DataChunk &chunk) { log.WriteInsert(chunk); });
+		return;
+	}
+
+	// Optimistically write the entry.
+	D_ASSERT(optimistic_count > 0);
+	log.WriteRowGroupData(*entry);
+	if (optimistic_count > count) {
+		throw InternalException(
+		    "Optimistically written count cannot exceed actual count (got %llu, but expected count is %llu)",
+		    optimistic_count, count);
+	}
+
+	// Get all the blocks that need to be kept alive as long as the WAL is alive.
+	for (const auto &row_group_data : entry->row_group_data) {
+		for (const auto &column_data : row_group_data.column_data) {
+			GatherBlockIds(column_data, commit_state->GetBlockIdsInUse());
 		}
 	}
+
+	// Write any remaining (non-optimistically written) rows to the WAL.
+	row_start += optimistic_count;
+	count -= optimistic_count;
+	if (count == 0) {
+		return;
+	}
+
 	ScanTableSegment(transaction, row_start, count, [&](DataChunk &chunk) { log.WriteInsert(chunk); });
 }
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -231,6 +231,9 @@ bool StorageManager::WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointO
 	wal->WriteCheckpoint(meta_block);
 	wal->Flush();
 
+	// We no longer need to hold on to the WAL blocks here. If the checkpoint fails, we throw a fatal exception and
+	// enter an inconsistent state. If it succeeds, then this WAL is no longer relevant.
+	wal->MarkBlocksInUseAsModified();
 	// close the main WAL
 	wal.reset();
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -613,11 +613,6 @@ void SingleFileStorageCommitState::RevertCommit() {
 	if (state != WALCommitState::IN_PROGRESS) {
 		return;
 	}
-	// We no longer use any of the blocks in this COMMIT.
-	auto &block_manager = wal.GetStorageManager().GetBlockManager();
-	for (const block_id_t block_id : block_ids_in_use) {
-		block_manager.MarkBlockAsModified(block_id);
-	}
 	if (wal.GetTotalWritten() > initial_written) {
 		// remove any entries written into the WAL by truncating it
 		wal.Truncate(initial_wal_size);

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -36,10 +36,6 @@ WriteAheadLog::WriteAheadLog(StorageManager &storage_manager, const string &wal_
 }
 
 WriteAheadLog::~WriteAheadLog() {
-	auto &block_manager = storage_manager.GetBlockManager();
-	for (const auto block_id : blocks_in_use) {
-		block_manager.MarkBlockAsModified(block_id);
-	}
 }
 
 AttachedDatabase &WriteAheadLog::GetDatabase() {
@@ -553,6 +549,13 @@ void WriteAheadLog::Flush() {
 
 void WriteAheadLog::IncrementWALEntriesCount() {
 	storage_manager.IncrementWALEntriesCount();
+}
+
+void WriteAheadLog::MarkBlocksInUseAsModified() {
+	auto &block_manager = storage_manager.GetBlockManager();
+	for (const block_id_t block_id : blocks_in_use) {
+		block_manager.MarkBlockAsModified(block_id);
+	}
 }
 
 } // namespace duckdb

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -32,7 +32,7 @@ WriteAheadLog::WriteAheadLog(StorageManager &storage_manager, const string &wal_
     : storage_manager(storage_manager), wal_path(wal_path), init_state(init_state),
       checkpoint_iteration(checkpoint_iteration) {
 	storage_manager.SetWALSize(wal_size);
-	storage_manager.ResetWALEntriesCount();
+	storage_manager.ResetWAL();
 }
 
 WriteAheadLog::~WriteAheadLog() {
@@ -73,7 +73,7 @@ idx_t WriteAheadLog::GetTotalWritten() const {
 	return writer->GetTotalWritten();
 }
 
-void WriteAheadLog::Truncate(idx_t size) {
+void WriteAheadLog::Truncatee(idx_t size) {
 	if (init_state == WALInitState::NO_WAL) {
 		// no WAL to truncate
 		return;
@@ -549,6 +549,13 @@ void WriteAheadLog::Flush() {
 
 void WriteAheadLog::IncrementWALEntriesCount() {
 	storage_manager.IncrementWALEntriesCount();
+}
+
+void WriteAheadLog::MarkBlocksAsModified() {
+	auto &block_manager = storage_manager.GetBlockManager();
+	for (const auto block_id : optimistic_block_ids) {
+		block_manager.MarkBlockAsModified(block_id);
+	}
 }
 
 } // namespace duckdb

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -42,6 +42,10 @@ AttachedDatabase &WriteAheadLog::GetDatabase() {
 	return storage_manager.GetAttached();
 }
 
+StorageManager &WriteAheadLog::GetStorageManager() {
+	return storage_manager;
+}
+
 BufferedFileWriter &WriteAheadLog::Initialize() {
 	if (Initialized()) {
 		return *writer;

--- a/test/sql/storage/optimistic_write/optimistic_write_concurrent_checkpoint_drop.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_concurrent_checkpoint_drop.test_slow
@@ -1,0 +1,80 @@
+# name: test/sql/storage/optimistic_write/optimistic_write_concurrent_checkpoint_drop.test_slow
+# description: Test that optimistically written blocks committed to the checkpoint WAL are not freed when the table is dropped after the checkpoint completes.
+# group: [optimistic_write]
+
+# If blocks are prematurely released the WAL replay of the concurrent INSERT will read garbage.
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+SET checkpoint_threshold = '1TB'
+
+# Force row groups to flush to disk immediately, so that the WAL stores block pointers (WriteRowGroupData) instead of inline data (WriteInsert).
+statement ok
+SET write_buffer_row_group_count = 1
+
+# Sleep long enough for the concurrent INSERT to COMMIT inside the checkpoint window.
+statement ok
+SET debug_checkpoint_sleep_ms = 500;
+
+statement ok
+ATTACH '__TEST_DIR__/concurrent_checkpoint_drop_opt.db' AS db
+
+# Create table with a PRIMARY KEY. During WAL replay, ReplayRowGroupData must scan
+# all blocks to rebuild the index, so corrupted blocks surface immediately.
+statement ok
+CREATE TABLE db.t (a BIGINT PRIMARY KEY, b VARCHAR, c VARCHAR, d VARCHAR)
+
+# Insert an initial batch into the main WAL (before the checkpoint starts).
+statement ok
+INSERT INTO db.t
+    SELECT i, repeat('x', 20), repeat('y', 30), repeat('z', 25)
+    FROM range(0, 100000) t(i)
+
+# Thread 0: triggers the checkpoint, then sleeps 500 ms after WALStartCheckpoint, giving Thread 1 time to commit into the checkpoint WAL.
+# Thread 1: inserts a second batch: if it commits during the sleep it goes into the checkpoint WAL ("written to" branch).
+concurrentloop threadid 0 2
+
+onlyif threadid=0
+statement ok
+CHECKPOINT db
+
+onlyif threadid=1
+statement ok
+INSERT INTO db.t
+    SELECT i, repeat('a', 20), repeat('b', 30), repeat('c', 25)
+    FROM range(100000, 350000) t(i)
+
+endloop
+
+# Drop table t. The blocks written by Thread 1's INSERT are still referenced by the new main WAL (the former checkpoint WAL).
+statement ok
+DROP TABLE db.t
+
+# Insert into a new table — if the free list is incorrect then the allocator may
+# hand out blocks that the WAL still points to, overwriting Thread 1's data.
+statement ok
+CREATE TABLE db.t2 (a DOUBLE, b DOUBLE, c DOUBLE, d DOUBLE)
+
+statement ok
+INSERT INTO db.t2
+    SELECT i * 3.14159, i * 2.71828, i * 1.41421, i * 1.73205
+    FROM range(0, 500000) t(i)
+
+statement ok
+DETACH db
+
+# Reopen: WAL replay applies the checkpoint state, then replays the concurrent INSERT into t (reading from the physical blocks), the DROP TABLE, and the
+# INSERT into t2. If the blocks were reused, ReplayRowGroupData will read garbage and the primary key rebuild will throw an internal exception or crash, so
+# the ATTACH itself will fail.
+statement ok
+ATTACH '__TEST_DIR__/concurrent_checkpoint_drop_opt.db' AS db
+
+query I
+SELECT COUNT(*) FROM db.t2
+----
+500000
+
+statement ok
+DETACH db

--- a/test/sql/storage/optimistic_write/optimistic_write_no_block_reuse.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_no_block_reuse.test_slow
@@ -1,0 +1,47 @@
+# name: test/sql/storage/optimistic_write/optimistic_write_no_block_reuse.test_slow
+# description: Test that the WAL keeps references to optimistically written blocks alive
+# group: [optimistic_write]
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+PRAGMA wal_autocheckpoint = '1TB';
+
+statement ok
+SET debug_skip_checkpoint_on_commit=true
+
+statement ok
+SET write_buffer_row_group_count = 1;
+
+statement ok
+ATTACH '__TEST_DIR__/concurrent_drop_blocks.db' AS db;
+
+statement ok con1
+CREATE TABLE db.t (a BIGINT PRIMARY KEY, b VARCHAR, c VARCHAR, d VARCHAR);
+
+statement ok con1
+INSERT INTO db.t SELECT i, 'row_' || i || repeat('x', 20),
+	'data_' || i || repeat('y', 30), 'col_' || i || repeat('z', 25)
+	FROM generate_series(0, 249999) t(i);
+
+statement ok con2
+DROP TABLE db.t;
+
+statement ok con2
+CREATE TABLE db.t2 (a DOUBLE, b DOUBLE, c DOUBLE, d DOUBLE);
+
+statement ok con2
+INSERT INTO db.t2 SELECT i * 3.14159, i * 2.71828, i * 1.41421, i * 1.73205
+	FROM generate_series(0, 999999) t(i);
+
+statement ok
+DETACH db;
+
+statement ok
+ATTACH '__TEST_DIR__/concurrent_drop_blocks.db' AS db;
+
+query I
+SELECT COUNT(*) FROM db.t2;
+----
+1000000

--- a/test/sql/storage/optimistic_write/optimistic_write_no_block_reuse.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_no_block_reuse.test_slow
@@ -11,12 +11,21 @@ PRAGMA wal_autocheckpoint = '1TB';
 statement ok
 SET debug_skip_checkpoint_on_commit=true
 
+# Force row groups to be flushed to disk immediately during INSERT.
+# This makes the WAL store block pointers (via WriteRowGroupData) instead of inline data (WriteInsert).
+# Without this, the INSERT data stays in transient in-memory segments, the WAL stores inline chunks,
+# and WAL replay never reads from the optimistically written blocks.
 statement ok
 SET write_buffer_row_group_count = 1;
 
 statement ok
 ATTACH '__TEST_DIR__/concurrent_drop_blocks.db' AS db;
 
+# Step 1: Create table with an index and VARCHAR columns.
+# The index is critical: during WAL replay, ReplayRowGroupData scans all
+# row group data through the blocks to populate the index. Without an index,
+# the row group data is loaded lazily (block pointers stored but not read),
+# so corruption from any overwritten blocks would go undetected.
 statement ok con1
 CREATE TABLE db.t (a BIGINT PRIMARY KEY, b VARCHAR, c VARCHAR, d VARCHAR);
 
@@ -25,9 +34,13 @@ INSERT INTO db.t SELECT i, 'row_' || i || repeat('x', 20),
 	'data_' || i || repeat('y', 30), 'col_' || i || repeat('z', 25)
 	FROM generate_series(0, 249999) t(i);
 
+# Step 2: DROP TABLE t frees its blocks via MarkBlockAsModified.
+# However, we test here that the WAL still holds another "in use" reference to these blocks,
+# which ensures we do not overwrite them later.
 statement ok con2
 DROP TABLE db.t;
 
+# Here, we need to use new blocks because the WAL still holds a reference to the dropped blocks.
 statement ok con2
 CREATE TABLE db.t2 (a DOUBLE, b DOUBLE, c DOUBLE, d DOUBLE);
 
@@ -38,6 +51,11 @@ INSERT INTO db.t2 SELECT i * 3.14159, i * 2.71828, i * 1.41421, i * 1.73205
 statement ok
 DETACH db;
 
+# Reopen the file → WAL replay.
+# The WAL contains: CREATE TABLE t (with PRIMARY KEY) → INSERT t → DROP t → CREATE t2 → INSERT t2.
+# During replay, ReplayRowGroupData for table t must scan all chunks to populate the
+# primary key index. This forces reads from the optimistically written physical blocks that
+# belong to the dropped table.
 statement ok
 ATTACH '__TEST_DIR__/concurrent_drop_blocks.db' AS db;
 


### PR DESCRIPTION
See the test case for a detailed description. The PR adds logic to the WAL to track the blocks necessary for replaying optimistic writes. 

Fixes https://github.com/duckdblabs/motherduck/issues/453

