### PR TITLE
Avoid httpfs installs in GetEncryptionUtils (when read_only = true)

### DIFF
--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -114,6 +114,10 @@ public:
 	DUCKDB_API static bool TryAutoLoadExtension(DatabaseInstance &db, const string &extension_name) noexcept;
 	DUCKDB_API static bool TryAutoLoadExtension(ClientContext &context, const string &extension_name) noexcept;
 
+	//! Autoload an extension, only if available locally
+	DUCKDB_API static bool TryAutoLoadAvailableExtension(DatabaseInstance &instance,
+	                                                     const string &extension_name) noexcept;
+
 	//! Update all extensions, return a vector of extension names that were updated;
 	static vector<ExtensionUpdateResult> UpdateExtensions(ClientContext &context);
 	//! Update a specific extension

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -542,12 +542,18 @@ shared_ptr<EncryptionUtil> DatabaseInstance::GetEncryptionUtil(bool read_only) {
 	}
 
 	if (!config.encryption_util) {
-		// No encryption_util, attempt to load httpfs extension IFF already available locally
-		ExtensionHelper::TryAutoLoadAvailableExtension(*this, "httpfs");
+		// No encryption_util, attempt to get a hold of httpfs
+		if (read_only) {
+			// load is attempted, but no install is performed
+			ExtensionHelper::TryAutoLoadAvailableExtension(*this, "httpfs");
+		} else {
+			// load is attempted, otherwise install+load
+			ExtensionHelper::TryAutoLoadExtension(*this, "httpfs");
+		}
 	}
 
 	if (config.encryption_util) {
-		// already available (potentially via httpfs loading
+		// already available (potentially via httpfs loading)
 		return config.encryption_util;
 	}
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -542,11 +542,12 @@ shared_ptr<EncryptionUtil> DatabaseInstance::GetEncryptionUtil(bool read_only) {
 	}
 
 	if (!config.encryption_util) {
-		ExtensionHelper::TryAutoLoadExtension(*this, "httpfs");
+		// No encryption_util, attempt to load httpfs extension IFF already available locally
+		ExtensionHelper::TryAutoLoadAvailableExtension(*this, "httpfs");
 	}
 
 	if (config.encryption_util) {
-		// httpfs is correctly loaded
+		// already available (potentially via httpfs loading
 		return config.encryption_util;
 	}
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -563,11 +563,12 @@ shared_ptr<EncryptionUtil> DatabaseInstance::GetEncryptionUtil(bool read_only) {
 		return GetMbedTLSUtil(force_mbedtls);
 	}
 
-	throw InvalidConfigurationException(
-	    " DuckDB currently has a read-only crypto module "
-	    "loaded. Please re-open using READONLY, or ensure httpfs is loaded using `LOAD httpfs`. "
-	    " To write an encrypted database that is NOT securely encrypted, one can use SET force_mbedtls_unsafe = "
-	    "'true'.");
+	throw InvalidConfigurationException(" DuckDB currently has a read-only crypto module "
+	                                    "loaded. Please ensure httpfs is loaded using `LOAD httpfs`, or for DuckDB "
+	                                    "database files consider READONLY mode."
+	                                    " To write an encrypted database or parquet file that is NOT securely "
+	                                    "encrypted, one can use SET force_mbedtls_unsafe = "
+	                                    "'true'.");
 }
 
 ValidChecker &DatabaseInstance::GetValidChecker() {

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -253,6 +253,20 @@ bool ExtensionHelper::TryAutoLoadExtension(DatabaseInstance &instance, const str
 	}
 }
 
+bool ExtensionHelper::TryAutoLoadAvailableExtension(DatabaseInstance &instance, const string &extension_name) noexcept {
+	if (instance.ExtensionIsLoaded(extension_name)) {
+		return true;
+	}
+	auto &dbconfig = DBConfig::GetConfig(instance);
+	try {
+		auto &fs = FileSystem::GetFileSystem(instance);
+		ExtensionHelper::LoadExternalExtension(instance, fs, extension_name);
+		return true;
+	} catch (...) {
+		return false;
+	}
+}
+
 static ExtensionUpdateResult UpdateExtensionInternal(ClientContext &context, DatabaseInstance &db, FileSystem &fs,
                                                      const string &full_extension_path, const string &extension_name) {
 	ExtensionUpdateResult result;

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -257,7 +257,6 @@ bool ExtensionHelper::TryAutoLoadAvailableExtension(DatabaseInstance &instance, 
 	if (instance.ExtensionIsLoaded(extension_name)) {
 		return true;
 	}
-	auto &dbconfig = DBConfig::GetConfig(instance);
 	try {
 		auto &fs = FileSystem::GetFileSystem(instance);
 		ExtensionHelper::LoadExternalExtension(instance, fs, extension_name);

--- a/test/sql/attach/attach_encryption_fallback_readonly.test
+++ b/test/sql/attach/attach_encryption_fallback_readonly.test
@@ -18,7 +18,7 @@ set autoinstall_known_extensions=false
 statement error
 ATTACH 'data/attach_test/encrypted_gcm_key=abcde.db' as enc (ENCRYPTION_KEY 'abcde', ENCRYPTION_CIPHER 'GCM');
 ----
-Invalid Configuration Error:  DuckDB currently has a read-only crypto module loaded. Please re-open using READONLY, or ensure httpfs is loaded using `LOAD httpfs`.  To write an encrypted database that is NOT securely encrypted, one can use SET force_mbedtls_unsafe = 'true'.
+Invalid Configuration Error:  DuckDB currently has a read-only crypto module loaded
 
 # It works again by setting READONLY
 statement ok
@@ -36,16 +36,16 @@ FROM enc.test ORDER BY value
 statement ok
 DETACH enc
 
-# Creating a new table will also fail
+# Creating a new db will also fail
 statement error
 ATTACH '__TEST_DIR__/test_write_only.db' as enc (ENCRYPTION_KEY 'abcde', ENCRYPTION_CIPHER 'GCM');
 ----
-Invalid Configuration Error:  DuckDB currently has a read-only crypto module loaded. Please re-open using READONLY, or ensure httpfs is loaded using `LOAD httpfs`.  To write an encrypted database that is NOT securely encrypted, one can use SET force_mbedtls_unsafe = 'true'.
+Invalid Configuration Error:  DuckDB currently has a read-only crypto module loaded
 
 statement ok
 SET force_mbedtls_unsafe = 'true'
 
-# Creating a new table will now pass, since we explicitly set to use Mbed TLS
+# Creating a new db will now pass, since we explicitly set to use Mbed TLS
 statement ok
 ATTACH '__TEST_DIR__/test_write_only.db' as enc (ENCRYPTION_KEY 'abcde', ENCRYPTION_CIPHER 'GCM');
 


### PR DESCRIPTION
Three independent fixes:

* 1st commit, by @ccfelius: avoid requiring GetEncryptionUtil when reading non-encrypted parquet files
* 2nd and 3rd commit, be me: given in the read path the mbedTLS (that is always available) encryption util is workable, attempt to `auto-LOAD httpfs`, but do not `auto-INSTALL httpfs`.
* 4th commit, together with @ccfelius, fixing the error message to make clear one might get there also while writing encrypted parquet files.

After this PR, the behaviour will be as follow:

* when reading plain parquet files, httpfs is NOT required for encryption (it might for file system)
* when writing plain parquet files, httpfs is NOT required for encryption
* when reading encrypted parquet files, httpfs is loaded IFF available locally AND autoload_known_extensions is set, otherwise fall back to mbedTLS (that might be slower but always available)
* when writing encrypted parquet files, httpfs is loaded IFF available locally (and setting allows), otherwise it's INSTALLED and LOADED (according to settings), otherwise one fails with relevant error message

Same behaviour should hold for plaintext or encrypted duckdb files.
Basically writing a file it's mean as instruction to autoinstall and autoload `httpfs` (after checking settings), while read path it's implicitly OK to load (to speed up decompression) but no install should be attempted (that is, no networking should be triggered).