### PR TITLE
fix: buffer overread in Arrow dictionary conversion with NULLs - fixes crash.

### DIFF
--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -1396,9 +1396,14 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(Vector &vector, Arro
 	const bool has_nulls = CanContainNull(array, parent_mask);
 	if (array_state.CacheOutdated(array.dictionary)) {
 		//! We need to set the dictionary data for this column
-		auto base_vector = make_uniq<Vector>(vector.GetType(), NumericCast<idx_t>(array.dictionary->length));
-		ArrowToDuckDBConversion::SetValidityMask(*base_vector, *array.dictionary, chunk_offset,
-		                                         NumericCast<idx_t>(array.dictionary->length), 0, 0, has_nulls);
+		//! Allocate one extra entry beyond dictionary length for the NULL sentinel.
+		//! SetMaskedSelectionVectorLoop points NULL indices at last_element_pos (= dictionary->length),
+		//! so the buffer must be large enough and that entry must be marked invalid.
+		auto dict_length = NumericCast<idx_t>(array.dictionary->length);
+		auto base_vector = make_uniq<Vector>(vector.GetType(), dict_length + 1);
+		ArrowToDuckDBConversion::SetValidityMask(*base_vector, *array.dictionary, chunk_offset, dict_length, 0, 0,
+		                                         has_nulls);
+		FlatVector::Validity(*base_vector).SetInvalid(dict_length);
 		auto &dictionary_type = arrow_type.GetDictionary();
 		auto arrow_physical_type = dictionary_type.GetPhysicalType();
 		;


### PR DESCRIPTION
`ColumnArrowToDuckDBDictionary` in `src/function/table/arrow_conversion.cpp` allocates the dictionary vector with exactly `dictionary->length` entries. When NULL values are present in the dictionary-encoded column, `SetMaskedSelectionVectorLoop` sets the selection index for NULL rows to `last_element_pos`, which equals `dictionary->length` — one past the end of the allocated buffer. This is an out-of-bounds read on the dictionary vector.

The read lands in uninitialized or adjacent memory. Depending on allocation layout, this can surface as garbage values, incorrect NULL handling, or a crash (e.g. under AddressSanitizer).

Allocate one extra entry beyond the dictionary length for the NULL sentinel, and mark it invalid.

This ensures the sentinel index `dictionary->length` points to a valid (but NULL-marked) entry in the buffer, rather than reading past the end.

This fixes #21082 
