### PR TITLE
Investigate ccache hit rate

### DIFF
--- a/.github/actions/ccache-action/action.yml
+++ b/.github/actions/ccache-action/action.yml
@@ -9,4 +9,11 @@ runs:
          key: ${{ github.job }}
          save: ${{ github.repository != 'duckdb/duckdb' || contains('["refs/heads/main", "refs/heads/v1.4-andium", "refs/heads/v1.5-variegata"]', github.ref) }}
          # Dump verbose ccache statistics report at end of CI job.
-         verbose: 2
+         verbose: 1
+         # Increase per-directory limit: 5*1024 MB / 16 = 320 MB.
+         # Note: `layout=subdirs` computes the size limit divided by 16 dirs.
+         # See also: https://ccache.dev/manual/4.9.html#_cache_size_management
+         max-size: 5GB
+         # Evicts all cache files that were not touched during the job run.
+         # Removing cache files from previous runs avoids creating huge caches.
+         evict-old-files: 'job'


### PR DESCRIPTION
### Context

Currently, the ccache hit rate for `linux-debug` is **0%**:
```
$ /usr/bin/ccache -s -vv
  Summary:
    Cache directory:                  /home/runner/work/duckdb/duckdb/.ccache
    Primary config:                   /home/runner/.config/ccache/ccache.conf
    Secondary config:                 /etc/ccache.conf
    Stats updated:                    Wed Feb 25 15:23:59 2026
    Stats zeroed:                     Wed Feb 25 15:13:53 2026
    Hits:                                0 /  547 (0.00 %)
      Direct:                            0 /  547 (0.00 %)
      Preprocessed:                      0 /  547 (0.00 %)
    Misses:                            547
      Direct:                          547
      Preprocessed:                    547
```

Even though the ccache artifact file is downloaded, it still results in `0` hits; thus re-compile and link every file.

This analysis is also a follow-up of this [comment](https://github.com/duckdb/duckdb/pull/21066#issuecomment-3957073479).

### Understand cache behavior in same CI job

Ccache can write debug log messages (what is cached or not) to a file using:
```yaml
    env:
      CCACHE_LOGFILE: /tmp/ccache.log
      CCACHE_DEBUG: 1

    steps: 
    # ...
    - uses: ./.github/actions/ccache-action

    - name: Build (first)
      run: make relassert
    
    - name: Ccache stats (first)
      run: |
        tail -n 200 /tmp/ccache.log
        ccache -s -vv

    - name: Clear
      run: |
        rm -rf build/relassert/ /tmp/ccache.log
        ccache -z

    - name: Build (second)
      run: make relassert

    - name: Ccache stats (second)
      run: |
        tail -n 200 /tmp/ccache.log
        ccache -s -vv
```

When looking at the ccache log messages from the first build, I see:
```
[...]
Result: cache_miss 
Result: preprocessed_cache_miss 
Result: primary_storage_miss 
Need to clean up /home/runner/work/duckdb/duckdb/.ccache/8 since it holds 31032 KiB (limit: 30517 KiB) 
Cleaning up cache directory /home/runner/work/duckdb/duckdb/.ccache/8 
Before cleanup: 31032 KiB, 21 files 
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/e/04bt4o77el3m79leo99gemko1sgc7niR
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/d/24frdubiiq2kimkvk0cjq84aglpjtvuR
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/e/6e55d8a65esjia0mmioemlajlavkvpmR
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/0/97b4p8hkc6skjqmt17o5a054gru9jmsR
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/d/4egp17fqq24epb4u986dgdksgn7ncb0R
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/8/ad6ah0be9q2nn9s4njoh53oher54sboR
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/d/5fctqhjbp9bot6fpnssrcgd1c9tlv02R
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/b/fdr3ddroqsr1ppq6vfbeq1bqvku907kR
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/3/d0a9lgjpksbv9sfbpbecthaaqf8bji6R
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/6/55p65tnvpk4avqqe6nbpuuc69r5dvtoR
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/8/e3k0ln4dpspdfca1tpnmt16jnod1k90R
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/d/2csmmgphoguff8jqfhub1iap9iqrjaaR
Unlink /home/runner/work/duckdb/duckdb/.ccache/8/7/bfjvsknrouccklqm43pv42ai3huj58uR
After cleanup: 22852 KiB, 8 files
```
The cleanup explains why a second build in the same CI job cannot find any hits: the cached files are already cleaned up!

In short, from what I understand, ccache stores files in sub directories (when `layout=subdirs`, by default) and each group level sub directory has its own maximum directory size:
```
max-size / 16 groups
= 500 MB / 16 = 31.25 MB
```
where `500 MB` comes from the [default](https://github.com/hendrikmuhs/ccache-action/blob/main/action.yml#L15-L17) max-size of the used ccache github action.

### Increase the ccache max-size

Using `max-size=5 GB` confirms that:
- ccache does not perform the cleanup anymore.
- the second build in the same CI job [gets](https://github.com/duckdb/duckdb/actions/runs/22413154343/job/64891755081#step:12:226) a 99% hit rate:
```
Summary:
  Cache directory:                  /home/runner/work/duckdb/duckdb/.ccache
  Primary config:                   /home/runner/.config/ccache/ccache.conf
  Secondary config:                 /etc/ccache.conf
  Stats updated:                    Wed Feb 25 20:00:00 2026
  Stats zeroed:                     Wed Feb 25 19:58:09 2026
  Hits:                              544 /  547 (99.45 %)
    Direct:                            0 /    0
    Preprocessed:                    544 /  547 (99.45 %)
  Misses:                              3
    Direct:                            0
    Preprocessed:                      3
  Errors:                              0
  Uncacheable:                         0
Primary storage:
  Hits:                              544 /  547 (99.45 %)
  Misses:                              3
  Cache size (GB):                  1.75 / 5.00 (34.95 %)
  Files:                            3795
```

### Avoid creating huge caches

I've enabled `evict-old-files: 'job'` to evict all cache files that were not touched during the job run. Removing cache files from previous runs avoids creating huge caches.

Even though the limit of `max-size: 5 GB` looks huge for each CI job ccache entry, it would only contain the cached files from that CI run:
```
Primary storage:
  Hits:                              544 /  547 (99.45 %)
  Misses:                              3
  Cache size (GB):                  1.75 / 5.00 (34.95 %) # <--- 1.75 GB
  Files:                            3795
```

The `linux-debug` binaries are [huge](https://github.com/duckdb/duckdb/pull/21092#discussion_r2857949125) and thus result in a 1.75 GB cache entry size.

However, most (all?) ccaches will not grow to "5 GB" (or near ~2 GB) unless that's what we actually produce during the build, and thus we want it to be cached.

We can always experiment with pruning items from the ccache if the cache entry size does become a problem in practice.