### PR TITLE
feat: Add ENUM extension metadata to Arrow export/import for lossless roundtrips

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -14,7 +14,36 @@
 #include "duckdb/common/arrow/arrow_appender.hpp"
 #include "duckdb/common/arrow/schema_metadata.hpp"
 #include "duckdb/main/client_context.hpp"
+
+#include "yyjson.hpp"
+
+using namespace duckdb_yyjson; // NOLINT
+
 namespace duckdb {
+
+//! Serialize ENUM values to a JSON array string using yyjson.
+static string SerializeEnumValuesToJson(const LogicalType &type) {
+	auto &values = EnumType::GetValuesInsertOrder(type);
+	auto enum_size = EnumType::GetSize(type);
+	auto *doc = yyjson_mut_doc_new(nullptr);
+	auto *arr = yyjson_mut_arr(doc);
+	yyjson_mut_doc_set_root(doc, arr);
+	for (idx_t i = 0; i < enum_size; i++) {
+		auto val = values.GetValue(i).ToString();
+		yyjson_mut_arr_add_strcpy(doc, arr, val.c_str());
+	}
+	yyjson_write_err err;
+	size_t json_len = 0;
+	auto *json_cstr = yyjson_mut_write_opts(doc, YYJSON_WRITE_NOFLAG, nullptr, &json_len, &err);
+	if (!json_cstr) {
+		yyjson_mut_doc_free(doc);
+		throw SerializationException("Failed to serialize ENUM values to JSON: %s", err.msg);
+	}
+	string result(json_cstr, json_len);
+	free(json_cstr);
+	yyjson_mut_doc_free(doc);
+	return result;
+}
 
 void ArrowConverter::ToArrowArray(
     DataChunk &input, ArrowArray *out_array, ClientProperties options,
@@ -380,7 +409,6 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	}
 	case LogicalTypeId::ENUM: {
-		// TODO what do we do with pointer enums here?
 		switch (EnumType::GetPhysicalType(type)) {
 		case PhysicalType::UINT8:
 			child.format = "C";
@@ -401,6 +429,14 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		InitializeChild(root_holder.nested_children.back()[0], root_holder);
 		child.dictionary = root_holder.nested_children_ptr.back()[0];
 		child.dictionary->format = "u";
+		if (options.arrow_lossless_conversion) {
+			auto json = SerializeEnumValuesToJson(type);
+			ArrowSchemaMetadata schema_metadata;
+			schema_metadata.AddOption(ArrowSchemaMetadata::ARROW_EXTENSION_NAME, "arrow.duckdb.enum");
+			schema_metadata.AddOption(ArrowSchemaMetadata::ARROW_METADATA_KEY, json);
+			root_holder.metadata_info.emplace_back(schema_metadata.SerializeMetadata());
+			child.metadata = root_holder.metadata_info.back().get();
+		}
 		break;
 	}
 	default: {

--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -10,6 +10,8 @@
 
 #include "yyjson.hpp"
 
+using namespace duckdb_yyjson; // NOLINT
+
 namespace duckdb {
 
 ArrowTypeExtension::ArrowTypeExtension(string extension_name, string arrow_format,
@@ -546,6 +548,46 @@ struct ArrowGeometry {
 	}
 };
 
+struct ArrowEnum {
+	static unique_ptr<ArrowType> GetType(ClientContext &context, const ArrowSchema &schema,
+	                                     const ArrowSchemaMetadata &schema_metadata) {
+		// Parse enum values from JSON array in extension metadata
+		auto metadata_str = schema_metadata.GetOption(ArrowSchemaMetadata::ARROW_METADATA_KEY);
+		if (metadata_str.empty()) {
+			throw InvalidInputException("arrow.duckdb.enum extension missing metadata");
+		}
+		unique_ptr<yyjson_doc, void (*)(yyjson_doc *)> doc(
+		    yyjson_read(metadata_str.data(), metadata_str.size(), YYJSON_READ_NOFLAG), yyjson_doc_free);
+		if (!doc) {
+			throw InvalidInputException("arrow.duckdb.enum: invalid JSON metadata");
+		}
+		auto *root = yyjson_doc_get_root(doc.get());
+		if (!yyjson_is_arr(root)) {
+			throw InvalidInputException("arrow.duckdb.enum: metadata must be a JSON array");
+		}
+		auto enum_count = yyjson_arr_size(root);
+		Vector enum_values(LogicalType::VARCHAR, enum_count);
+		auto enum_data = FlatVector::GetData<string_t>(enum_values);
+		idx_t idx = 0;
+		yyjson_val *val;
+		yyjson_arr_iter iter;
+		yyjson_arr_iter_init(root, &iter);
+		while ((val = yyjson_arr_iter_next(&iter))) {
+			if (!yyjson_is_str(val)) {
+				throw InvalidInputException("arrow.duckdb.enum: enum values must be strings");
+			}
+			auto str = yyjson_get_str(val);
+			enum_data[idx] = StringVector::AddStringOrBlob(enum_values, str);
+			idx++;
+		}
+		auto enum_type = LogicalType::ENUM(enum_values, enum_count);
+		return make_uniq<ArrowType>(enum_type);
+	}
+
+	// Note: PopulateSchema is not needed — the ENUM export path in SetArrowFormat (arrow_converter.cpp)
+	// handles schema setup and metadata directly. Only GetType is used on the import path.
+};
+
 void ArrowTypeExtensionSet::Initialize(const DBConfig &config) {
 	// Types that are 1:1
 	config.RegisterArrowExtension({"arrow.uuid", "w:16", make_shared_ptr<ArrowTypeExtensionData>(LogicalType::UUID)});
@@ -575,5 +617,14 @@ void ArrowTypeExtensionSet::Initialize(const DBConfig &config) {
 
 	config.RegisterArrowExtension({"DuckDB", "bignum", &ArrowBignum::PopulateSchema, &ArrowBignum::GetType,
 	                               make_shared_ptr<ArrowTypeExtensionData>(LogicalType::BIGNUM), nullptr, nullptr});
+
+	// ENUM: parameterized type — the dummy ENUM is only used for TypeInfo lookup so
+	// HasArrowExtension(ENUM) matches. The actual ENUM type is constructed per-field in GetType.
+	// PopulateSchema is nullptr because the export path in SetArrowFormat handles ENUM inline.
+	Vector dummy_enum_values(LogicalType::VARCHAR, 1);
+	FlatVector::GetData<string_t>(dummy_enum_values)[0] = StringVector::AddString(dummy_enum_values, "dummy");
+	auto dummy_enum_type = LogicalType::ENUM(dummy_enum_values, 1);
+	config.RegisterArrowExtension(
+	    {"arrow.duckdb.enum", nullptr, &ArrowEnum::GetType, make_shared_ptr<ArrowTypeExtensionData>(dummy_enum_type)});
 }
 } // namespace duckdb

--- a/src/function/table/arrow/arrow_duck_schema.cpp
+++ b/src/function/table/arrow/arrow_duck_schema.cpp
@@ -328,6 +328,11 @@ unique_ptr<ArrowType> ArrowType::CreateListType(ClientContext &context, ArrowSch
 
 LogicalType ArrowType::GetDuckType(bool use_dictionary) const {
 	if (use_dictionary && dictionary_type) {
+		// ENUM extension types store the real ENUM type in `type` — return it directly
+		// instead of resolving to the dictionary value type (VARCHAR).
+		if (type.id() == LogicalTypeId::ENUM) {
+			return type;
+		}
 		return dictionary_type->GetDuckType();
 	}
 	if (!use_dictionary) {
@@ -424,6 +429,11 @@ ArrowTypeExtensionData::GetExtensionTypes(ClientContext &context, const vector<L
 	unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_types;
 	const auto &db_config = DBConfig::GetConfig(context);
 	for (idx_t i = 0; i < duckdb_types.size(); i++) {
+		// Skip ENUM — the appender handles ENUM natively as dictionary encoding;
+		// the arrow.duckdb.enum extension is only used on the import side.
+		if (duckdb_types[i].id() == LogicalTypeId::ENUM) {
+			continue;
+		}
 		if (db_config.HasArrowExtension(duckdb_types[i])) {
 			extension_types.insert({i, db_config.GetArrowExtension(duckdb_types[i]).GetTypeExtension()});
 		}

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -382,6 +382,25 @@ static void DirectConversion(Vector &vector, ArrowArray &array, idx_t chunk_offs
 	FlatVector::SetData(vector, data_ptr);
 }
 
+//! Convert Arrow dictionary indices directly to ENUM values (zero-copy).
+//! ENUM physical storage (UINT8/16/32) matches Arrow dictionary index types exactly.
+static void ColumnArrowToDuckDBEnumIndices(Vector &vector, ArrowArray &array, idx_t chunk_offset, idx_t size,
+                                           const ValidityMask *parent_mask, uint64_t parent_offset,
+                                           int64_t nested_offset) {
+	DirectConversion(vector, array, chunk_offset, nested_offset, parent_offset);
+	ArrowToDuckDBConversion::SetValidityMask(vector, array, chunk_offset, size, NumericCast<int64_t>(parent_offset),
+	                                         nested_offset);
+	if (parent_mask && !parent_mask->AllValid()) {
+		auto &validity = FlatVector::Validity(vector);
+		for (idx_t i = 0; i < size; i++) {
+			if (!parent_mask->RowIsValid(i)) {
+				validity.SetInvalid(i);
+			}
+		}
+	}
+	vector.Verify(size);
+}
+
 template <class T>
 static void TimeConversion(Vector &vector, ArrowArray &array, idx_t chunk_offset, int64_t nested_offset,
                            int64_t parent_offset, idx_t size, int64_t conversion) {
@@ -1393,6 +1412,12 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(Vector &vector, Arro
 		vector.GetBuffer()->SetAuxiliaryData(make_uniq<ArrowAuxiliaryData>(array_state.owned_data));
 	}
 	D_ASSERT(arrow_type.HasDictionary());
+
+	if (vector.GetType().id() == LogicalTypeId::ENUM) {
+		ColumnArrowToDuckDBEnumIndices(vector, array, chunk_offset, size, parent_mask, parent_offset, nested_offset);
+		return;
+	}
+
 	const bool has_nulls = CanContainNull(array, parent_mask);
 	if (array_state.CacheOutdated(array.dictionary)) {
 		//! We need to set the dictionary data for this column


### PR DESCRIPTION
When arrow_lossless_conversion is true, ENUM columns now export with `arrow.duckdb.enum` extension metadata containing enum values as a JSON array. On import, the extension reconstructs the ENUM type from metadata, and dictionary indices are read zero-copy since ENUM physical storage (UINT8/16/32) matches Arrow dictionary index types exactly.

Closes #21084