### PR TITLE
Use CI stages for jobs to reduce CI workload

### DIFF
--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -31,7 +31,7 @@ on:
       - '!.github/workflows/BundleStaticLibs.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
+  group: bundlestaticlibs-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -57,30 +57,6 @@ on:
         type: boolean
         required: false
         default: true
-  push:
-    branches-ignore:
-      - 'main'
-      - 'feature'
-      - 'v*.*-*'
-    paths-ignore:
-      - '**.md'
-      - 'tools/**'
-      - '!tools/shell/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/Extensions.yml'
-      - '!.github/workflows/_extension_distribution.yml'
-  merge_group:
-  pull_request:
-    types: [opened, reopened, ready_for_review, converted_to_draft]
-    paths-ignore:
-      - '**.md'
-      - 'tools/**'
-      - '!tools/shell/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/Extensions.yml'
-      - '!.github/workflows/_extension_distribution.yml'
 
 concurrency:
   group: extensions-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -91,11 +91,15 @@ jobs:
       shell: bash
       run: ./build/relassert/duckdb -c "PRAGMA version;"
 
+    - name: Prepare relassert artifact
+      shell: bash
+      run: make relassert-artifact
+
     - name: Upload relassert build artifact
       uses: actions/upload-artifact@v4
       with:
         name: linux-debug-relassert-build
-        path: build/relassert
+        path: build/relassert-artifact.tar.gz
         if-no-files-found: error
 
  linux-debug-tests:
@@ -112,7 +116,14 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: linux-debug-relassert-build
-        path: build/relassert
+        path: build
+
+    - name: Extract relassert build artifact
+      shell: bash
+      run: |
+        rm -rf build/relassert
+        tar -xzf build/relassert-artifact.tar.gz -C build
+        ls -lh build/relassert/test/unittest
 
     - name: Set DUCKDB_INSTALL_LIB for ADBC tests
       shell: bash

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -44,7 +44,7 @@ env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
- check-draft:
+ prepare:
     # We run all other jobs on PRs only if they are not draft PR
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
@@ -55,7 +55,7 @@ jobs:
  linux-debug:
     name: Linux Debug
     # This tests release build while enabling slow verifiers (masked by #ifdef DEBUG) and sanitizers
-    needs: check-draft
+    needs: prepare
     runs-on: ubuntu-22.04
     env:
       CC: gcc-10
@@ -107,7 +107,7 @@ jobs:
     needs:
       - prepare
       - linux-debug
-    runs-on: ${{ needs.prepare.outputs.runner_linux_22_x64 }}
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -91,6 +91,29 @@ jobs:
       shell: bash
       run: ./build/relassert/duckdb -c "PRAGMA version;"
 
+    - name: Upload relassert build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux-debug-relassert-build
+        path: build/relassert
+        if-no-files-found: error
+
+ linux-debug-tests:
+    name: Linux Debug Tests
+    needs:
+      - prepare
+      - linux-debug
+    runs-on: ${{ needs.prepare.outputs.runner_linux_22_x64 }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download relassert build artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: linux-debug-relassert-build
+        path: build/relassert
+
     - name: Set DUCKDB_INSTALL_LIB for ADBC tests
       shell: bash
       run: echo "DUCKDB_INSTALL_LIB=$(find `pwd` -name "libduck*.so" | head -n 1)" >> $GITHUB_ENV

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -137,6 +137,20 @@ jobs:
       run: |
         python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest --tests-per-invocation 100 --timeout 300
 
+ regression:
+    uses: ./.github/workflows/Regression.yml
+    secrets: inherit
+    needs: linux-debug
+
+ extensions:
+    uses: ./.github/workflows/Extensions.yml
+    secrets: inherit
+    needs: linux-debug
+    with:
+      git_ref: ${{ github.sha }}
+      skip_tests: 'false'
+      run_all: 'true'
+
  linux-release:
     name: Linux Release (full suite)
     needs: linux-debug

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -12,7 +12,7 @@ on:
   repository_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  group: regression-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -329,4 +329,3 @@ jobs:
         shell: bash
         run: |
           python scripts/plan_cost_runner.py --old duckdb/build/release/duckdb --new build/release/duckdb --dir=benchmark/tpch_plan_cost
-

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -10,37 +10,6 @@ on:
         description: 'Base hash'
         type: string
   repository_dispatch:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'feature'
-      - 'v*.*-*'
-    paths-ignore:
-      - '**.md'
-      - 'test/configs/**'
-      - 'tools/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/Regression.yml'
-      - '.github/config/out_of_tree_extensions.cmake'
-      - '.github/config/extensions/*.cmake'
-      - '.github/patches/extensions/**/*.patch'
-      - '!.github/patches/extensions/httpfs/*.patch' # httpfs used in some jobs
-      - '!.github/config/extensions/httpfs.cmake'
-  merge_group:
-  pull_request:
-    types: [opened, reopened, ready_for_review, converted_to_draft]
-    paths-ignore:
-      - '**.md'
-      - 'test/configs/**'
-      - 'tools/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/Regression.yml'
-      - '.github/config/extensions/*.cmake'
-      - '.github/patches/extensions/**/*.patch'
-      - '!.github/patches/extensions/httpfs/*.patch' # httpfs used in some jobs
-      - '!.github/config/extensions/httpfs.cmake'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
@@ -360,5 +329,4 @@ jobs:
         shell: bash
         run: |
           python scripts/plan_cost_runner.py --old duckdb/build/release/duckdb --new build/release/duckdb --dir=benchmark/tpch_plan_cost
-
 

--- a/Makefile
+++ b/Makefile
@@ -425,6 +425,11 @@ relassert: ${EXTENSION_CONFIG_STEP}
 	cmake $(GENERATOR) $(FORCE_COLOR) ${WARNINGS_AS_ERRORS} ${FORCE_32_BIT_FLAG} ${DISABLE_UNITY_FLAG} ${DISABLE_SANITIZER_FLAG} ${STATIC_LIBCPP} ${CMAKE_VARS} ${CMAKE_VARS_BUILD} -DFORCE_ASSERT=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo ../.. && \
 	cmake --build . --config RelWithDebInfo
 
+.PHONY: relassert-artifact
+
+relassert-artifact:
+	bash scripts/prepare_relassert_artifact.sh
+
 benchmark:
 	mkdir -p ./build/release && \
 	cd build/release && \

--- a/scripts/prepare_relassert_artifact.sh
+++ b/scripts/prepare_relassert_artifact.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ARTIFACT_ROOT=build/relassert-artifact
+ARTIFACT_DIR="$ARTIFACT_ROOT/relassert"
+ARTIFACT_TARBALL=build/relassert-artifact.tar.gz
+
+rm -rf "$ARTIFACT_ROOT"
+rm -f "$ARTIFACT_TARBALL"
+mkdir -p "$ARTIFACT_DIR"/test/extension "$ARTIFACT_DIR"/src
+
+# Required for linux-debug-tests invocations.
+cp -av build/relassert/test/unittest "$ARTIFACT_DIR"/test/
+
+# Required by ADBC tests in linux-debug-tests.
+shopt -s nullglob
+so_files=(build/relassert/src/libduckdb.so*)
+if ((${#so_files[@]} > 0)); then
+	cp -av "${so_files[@]}" "$ARTIFACT_DIR"/src/
+else
+	echo "No build/relassert/src/libduckdb.so* files found"
+fi
+
+# Required by extension tests using __BUILD_DIRECTORY__/test/extension/*.duckdb_extension.
+extension_files=(build/relassert/test/extension/*.duckdb_extension)
+if ((${#extension_files[@]} > 0)); then
+	for extension in "${extension_files[@]}"; do
+		cp -av "$extension" "$ARTIFACT_DIR"/test/extension/
+	done
+else
+	echo "No build/relassert/test/extension/*.duckdb_extension files found"
+fi
+
+# Required by tests that use the local extension repository under the build directory.
+if [[ -d build/relassert/repository ]]; then
+	cp -a build/relassert/repository "$ARTIFACT_DIR"/
+else
+	echo "No build/relassert/repository directory found"
+fi
+
+echo "Relassert artifact includes:"
+find "$ARTIFACT_DIR" -type f | sort | sed "s|^$ARTIFACT_DIR/|  |"
+echo "Relassert artifact size:"
+du -h -d 3 "$ARTIFACT_DIR" | sort -h
+
+set -x
+
+# Use a tarball so executable bits are preserved when passing build artifacts between jobs.
+# Use -4 to balance compression ratio (small enough output size) with compression time (a few sec).
+tar -C "$ARTIFACT_ROOT" -cf - relassert | gzip -4 > "$ARTIFACT_TARBALL"
+
+ls -lh "$ARTIFACT_TARBALL"


### PR DESCRIPTION
### High-level design

Adopt a CI pipeline with stages (`smoke -> build -> test`):

```mermaid
graph TD;
    subgraph prepare
    check-draft["Check draft"]
    end
    prepare --> smoke
    subgraph smoke
    linux-debug["Linux Debug (build)"]
    end

    smoke --> build
    subgraph build
    linux-cli-amd64["Linux CLI (amd64)"]
    linux-cli-rest["3x Linux CLI (arm64 + musl)"]
    end
    
    linux-cli-amd64 --> test-julia
    subgraph test
    test-julia["julia 1/1.10"]
    linux-debug-tests["Linux Debug Tests"]
    end

    smoke --> extensions
    subgraph extensions
    extensions-main-linux["Main Linux"]
    extensions-main-windows["Main Windows"]
    extensions-main-wasm["Main Wasm"]
    extensions-rust-linux["Rust Linux"]
    extensions-rust-windows["Rust Windows"]
    extensions-external-linux["External Linux"]
    end
    smoke --> regression
    subgraph regression
    regression-tests["Tests"]
    regression-storage-size["Storage size"]
    regression-binary-size["Binary size"]
    regression-join-cost["Join plan cost"]
    end
```
### Context

Some workflows are costly to compute and run for pull requests:

| Workflow    | CI Jobs | Total Compute Time | Total Duration (Latency) | Usage Link |
|-------------|---------|-------------------|--------------------------|------------|
| `extensions`   | 16      | 8 hours           | ~4.5 hours               | [View usage](https://github.com/duckdb/duckdb/actions/runs/22403380403/usage) |
| `regression`   | 5       | 3.5 hours         | ~2 hours                 | [View run](https://github.com/duckdb/duckdb/actions/runs/22427918005) |
| `linuxrelease` | 7       | ~7 hours          | ~2 hours                 | [View usage](https://github.com/duckdb/duckdb/actions/runs/22418696081/usage) |

A staged CI pipeline allows reducing total compute time and number of concurrent CI jobs of each CI run.

Example: PR bumps geo extensions.
- first [CI run](https://github.com/duckdb/duckdb/pull/21081/changes/cff511f9be04640bc37802ab73048f735a992e7e) uses binary literals (requiring c++14) and fail.
- first CI run consumes 15 hours of total compute time:
  - extension: [5 hours](https://github.com/duckdb/duckdb/actions/runs/22405986941/usage)
  - regression: [3.5 hours](https://github.com/duckdb/duckdb/actions/runs/22405986656/usage)
  - linux release: [6.5 hours](https://github.com/duckdb/duckdb/actions/runs/22405986555/usage)
  - main: [2 min](https://github.com/duckdb/duckdb/actions/runs/22405986527/usage)
- so, after 2 min, it could have detected a critical failure and skip all remaining CI jobs.

### Why?

When the smoke stage (`linux-debug` build) fails, we can cancel the remaining expensive stages.

In the future, we can increase the number of checks in the smoke stage. We need to balance the cost (wall clock time) with the expected failure rate before adding more checks to this stage.

For example, we can a small subset (100?) of the unit tests to verify that most of the functionality works well enough by selecting a few tests per test group.

### How?

- split `linux-debug` into build and test job to allow other CI jobs to start earlier. 
  - Running the unit tests takes 1 hour (in wall clock time).
  - The test runner is [currently](https://github.com/duckdb/duckdb/pull/20646) single-threaded and that is wasteful to run on a higher (8+) CPU core machine.
- let `regression` and `extension` workflow depend on the `linux-debug` build job.

### Tradeoffs

The total CI pipeline duration (= "latency") is increased by +1 hour because some CI jobs are now dependent on the the smoke or build stage. Previously, they could start immediately in parallel after a pull request run had started.

However, by cancelling CI jobs that are expected to fail, we get:
- lower queue time (= "wait time before a CI job starts"),
- higher throughput (_more_ pull request CI pipelines run at the same time).

### Future work

Currently, the `linux-debug` build job takes ~1 hour to compute. I have a draft [PR](https://github.com/duckdb/duckdb/pull/21045) to adopt namespace runners and optimize the CI job `linux-debug` build to run in ~10 minutes. That PR reduces the increased latency (+1 hour to +10 min) while keeping the benefits of a lower queue and higher throughput.