### PR TITLE
Integrate csv file handle with cache filesystem

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -2,4 +2,5 @@ duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG b67b1dd9a60ae2187d2cdbde12c472c33cbbec4f
+    APPLY_PATCHES
 )

--- a/.github/patches/extensions/httpfs/csv_cache.patch
+++ b/.github/patches/extensions/httpfs/csv_cache.patch
@@ -1,16 +1,9 @@
-commit a49556dc8d3db34aa8a50c108d7e1729eba04daa
+commit 289d6283aabb40d39b21a7180b6f28515d277a62
 Author: dentiny <dentinyhao@gmail.com>
 Date:   Thu Feb 26 06:58:16 2026 +0000
 
     Patch CSV cached reader change
 
-diff --git a/duckdb b/duckdb
-index 8624398..928e912 160000
---- a/duckdb
-+++ b/duckdb
-@@ -1 +1 @@
--Subproject commit 862439822d782aad5142c4c0fcd15afe073e3533
-+Subproject commit 928e9127e2da0c8b91beb6fd5efcd12e76ec8cb3
 diff --git a/test/sql/logging/file_system_logging.test b/test/sql/logging/file_system_logging.test
 index 6aa2ed0..54babde 100644
 --- a/test/sql/logging/file_system_logging.test

--- a/.github/patches/extensions/httpfs/csv_cache.patch
+++ b/.github/patches/extensions/httpfs/csv_cache.patch
@@ -1,0 +1,31 @@
+commit a49556dc8d3db34aa8a50c108d7e1729eba04daa
+Author: dentiny <dentinyhao@gmail.com>
+Date:   Thu Feb 26 06:58:16 2026 +0000
+
+    Patch CSV cached reader change
+
+diff --git a/duckdb b/duckdb
+index 8624398..928e912 160000
+--- a/duckdb
++++ b/duckdb
+@@ -1 +1 @@
+-Subproject commit 862439822d782aad5142c4c0fcd15afe073e3533
++Subproject commit 928e9127e2da0c8b91beb6fd5efcd12e76ec8cb3
+diff --git a/test/sql/logging/file_system_logging.test b/test/sql/logging/file_system_logging.test
+index 6aa2ed0..54babde 100644
+--- a/test/sql/logging/file_system_logging.test
++++ b/test/sql/logging/file_system_logging.test
+@@ -43,7 +43,6 @@ require httpfs
+ statement ok
+ FROM 'https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv'
+ 
+-# FIXME: investigate why we call READ twice?
+ query IIII
+ SELECT scope, type, log_level, regexp_replace(message, '\"path\":.*test.csv"', '"test.csv"')
+ FROM duckdb_logs
+@@ -52,5 +51,4 @@ ORDER BY timestamp
+ ----
+ CONNECTION	FileSystem	TRACE	{"fs":"HTTPFileSystem","path":"https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv","op":"OPEN"}
+ CONNECTION	FileSystem	TRACE	{"fs":"HTTPFileSystem","path":"https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv","op":"READ","bytes":"1276","pos":"0"}
+-CONNECTION	FileSystem	TRACE	{"fs":"HTTPFileSystem","path":"https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv","op":"READ","bytes":"0","pos":"1276"}
+ CONNECTION	FileSystem	TRACE	{"fs":"HTTPFileSystem","path":"https://github.com/duckdb/duckdb/raw/main/data/csv/customer.csv","op":"CLOSE"}

--- a/src/execution/operator/csv_scanner/buffer_manager/csv_file_handle.cpp
+++ b/src/execution/operator/csv_scanner/buffer_manager/csv_file_handle.cpp
@@ -20,7 +20,9 @@ CSVFileHandle::CSVFileHandle(ClientContext &context_p, unique_ptr<FileHandle> fi
 
 unique_ptr<FileHandle> CSVFileHandle::OpenFileHandle(FileSystem &fs, Allocator &allocator, const OpenFileInfo &file,
                                                      FileCompressionType compression) {
-	auto file_handle = fs.OpenFile(file, FileFlags::FILE_FLAGS_READ | compression);
+	FileOpenFlags flags = FileFlags::FILE_FLAGS_READ | compression;
+	flags.SetCachingMode(CachingMode::CACHE_REMOTE_ONLY);
+	auto file_handle = fs.OpenFile(file, flags);
 	if (file_handle->CanSeek()) {
 		file_handle->Reset();
 	}


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/21088

This PR integrates caching filesystem into CSV reader, similar to what we do for json reader and blob reader.
The httpfs extension patch already displays cache is taking effect :)
I ran the CI on my forked branch: https://github.com/dentiny/duckdb/pull/54