### PR TITLE
Fix memory leak when reusing PreparedStatement (#21089)

### DIFF
--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -623,8 +623,8 @@ ScopedConfigSetting PrepareResultCollector(ClientConfig &config, InterpretedBenc
 		return ScopedConfigSetting(
 		    config,
 		    [&benchmark](ClientConfig &config) {
-			    config.get_result_collector = [&benchmark](ClientContext &context,
-			                                               PreparedStatementData &data) -> PhysicalOperator & {
+			    config.get_result_collector =
+			        [&benchmark](ClientContext &context, PreparedStatementData &data) -> unique_ptr<PhysicalOperator> {
 				    return PhysicalArrowCollector::Create(context, data, benchmark.ArrowBatchSize());
 			    };
 		    },

--- a/src/common/arrow/physical_arrow_collector.cpp
+++ b/src/common/arrow/physical_arrow_collector.cpp
@@ -8,23 +8,23 @@
 
 namespace duckdb {
 
-PhysicalOperator &PhysicalArrowCollector::Create(ClientContext &context, PreparedStatementData &data,
-                                                 idx_t batch_size) {
+unique_ptr<PhysicalOperator> PhysicalArrowCollector::Create(ClientContext &context, PreparedStatementData &data,
+                                                            idx_t batch_size) {
 	auto &physical_plan = *data.physical_plan;
 	auto &root = physical_plan.Root();
 
 	if (!PhysicalPlanGenerator::PreserveInsertionOrder(context, root)) {
 		// Not an order-preserving plan: use the parallel materialized collector.
-		return physical_plan.Make<PhysicalArrowCollector>(data, true, batch_size);
+		return make_uniq<PhysicalArrowCollector>(physical_plan, data, true, batch_size);
 	}
 
 	if (!PhysicalPlanGenerator::UseBatchIndex(context, root)) {
 		// Order-preserving plan, and we cannot use the batch index: use single-threaded result collector.
-		return physical_plan.Make<PhysicalArrowCollector>(data, false, batch_size);
+		return make_uniq<PhysicalArrowCollector>(physical_plan, data, false, batch_size);
 	}
 
 	// Order-preserving plan, and we can use the batch index: use a batch collector.
-	return physical_plan.Make<PhysicalArrowBatchCollector>(data, batch_size);
+	return make_uniq<PhysicalArrowBatchCollector>(physical_plan, data, batch_size);
 }
 
 SinkResultType PhysicalArrowCollector::Sink(ExecutionContext &context, DataChunk &chunk,

--- a/src/include/duckdb/common/arrow/physical_arrow_collector.hpp
+++ b/src/include/duckdb/common/arrow/physical_arrow_collector.hpp
@@ -44,7 +44,7 @@ public:
 	}
 
 public:
-	static PhysicalOperator &Create(ClientContext &context, PreparedStatementData &data, idx_t batch_size);
+	static unique_ptr<PhysicalOperator> Create(ClientContext &context, PreparedStatementData &data, idx_t batch_size);
 	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
 	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const override;
 	unique_ptr<QueryResult> GetResult(GlobalSinkState &state) const override;

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -52,6 +52,7 @@ public:
 	static Executor &Get(ClientContext &context);
 
 	void Initialize(PhysicalOperator &physical_plan);
+	void Initialize(unique_ptr<PhysicalOperator> physical_plan);
 
 	void CancelTasks();
 	PendingExecutionResult ExecuteTask(bool dry_run = false);
@@ -147,6 +148,7 @@ private:
 
 private:
 	optional_ptr<PhysicalOperator> physical_plan;
+	unique_ptr<PhysicalOperator> owned_plan;
 
 	mutex executor_lock;
 	//! All pipelines of the query plan

--- a/src/include/duckdb/execution/operator/helper/physical_result_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_result_collector.hpp
@@ -32,7 +32,7 @@ public:
 	vector<string> names;
 
 public:
-	static PhysicalOperator &GetResultCollector(ClientContext &context, PreparedStatementData &data);
+	static unique_ptr<PhysicalOperator> GetResultCollector(ClientContext &context, PreparedStatementData &data);
 
 public:
 	//! The final method used to fetch the query result from this operator

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -25,7 +25,8 @@ class ClientContext;
 class PhysicalResultCollector;
 class PreparedStatementData;
 
-typedef std::function<PhysicalOperator &(ClientContext &context, PreparedStatementData &data)> get_result_collector_t;
+typedef std::function<unique_ptr<PhysicalOperator>(ClientContext &context, PreparedStatementData &data)>
+    get_result_collector_t;
 
 struct ClientConfig {
 	//! If the query profiler is enabled or not.

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -590,9 +590,9 @@ ClientContext::PendingPreparedStatementInternal(ClientContextLock &lock,
 	statement_data.memory_type = parameters.query_parameters.memory_type;
 
 	// Get the result collector and initialize the executor.
-	auto &collector = get_collector(*this, statement_data);
-	D_ASSERT(collector.type == PhysicalOperatorType::RESULT_COLLECTOR);
-	executor.Initialize(collector);
+	auto collector = get_collector(*this, statement_data);
+	D_ASSERT(collector->type == PhysicalOperatorType::RESULT_COLLECTOR);
+	executor.Initialize(std::move(collector));
 
 	auto types = executor.GetTypes();
 	D_ASSERT(types == statement_data.types);

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -374,6 +374,12 @@ void Executor::VerifyPipelines() {
 #endif
 }
 
+void Executor::Initialize(unique_ptr<PhysicalOperator> physical_plan_p) {
+	Reset();
+	owned_plan = std::move(physical_plan_p);
+	InitializeInternal(*owned_plan);
+}
+
 void Executor::Initialize(PhysicalOperator &plan) {
 	Reset();
 	InitializeInternal(plan);

--- a/test/arrow/arrow_test_helper.cpp
+++ b/test/arrow/arrow_test_helper.cpp
@@ -239,8 +239,8 @@ bool ArrowTestHelper::RunArrowComparison(Connection &con, const string &query, b
 		ScopedConfigSetting setting(
 		    config,
 		    [&batch_size](ClientConfig &config) {
-			    config.get_result_collector = [&batch_size](ClientContext &context,
-			                                                PreparedStatementData &data) -> PhysicalOperator & {
+			    config.get_result_collector =
+			        [&batch_size](ClientContext &context, PreparedStatementData &data) -> unique_ptr<PhysicalOperator> {
 				    return PhysicalArrowCollector::Create(context, data, batch_size);
 			    };
 		    },


### PR DESCRIPTION
 ## Description

Fixes memory leak when reusing `PreparedStatement` multiple times (#21089).

### Root Cause

In v1.4, the Arena refactor (commit `68bbb16bce`) changed `ResultCollector` management from `unique_ptr` to Arena allocation. This caused collectors to accumulate in `PhysicalPlan::ops` on each execution, leading to unbounded memory growth.

  **Before v1.4 (correct):**
  - `GetResultCollector` returned `unique_ptr<PhysicalResultCollector>`
  - Collector was owned by `Executor`, automatically freed after execution

  **After v1.4 (bug):**
  - `GetResultCollector` returned `PhysicalOperator&` created via `physical_plan.Make<>()`
  - Each execution pushed a new collector into `ops` vector, never freed

  ### Solution

  Restore v1.3 behavior for collector lifecycle management:

  1. **Treat collector as special operator**: Changed `GetResultCollector` to return `unique_ptr<PhysicalOperator>` instead of creating via Arena
  2. **Executor ownership**: Added `Executor::Initialize(unique_ptr<PhysicalOperator>)` overload to take ownership of the collector
  3. **Avoid dangling references**: Using `unique_ptr` ensures clear ownership and prevents potential use-after-free when collector is replaced

  ### Changes

  - Modified `GetResultCollector` to return `unique_ptr` and create collectors directly
  - Added `Executor::owned_plan` member to hold the collector
  - Updated `get_result_collector_t` typedef and all callers
  - Applied same fix to `PhysicalArrowCollector::Create`