### PR TITLE
Do not write ccache to github cache for v1.4-andium

### DIFF
--- a/.github/actions/ccache-action/action.yml
+++ b/.github/actions/ccache-action/action.yml
@@ -3,7 +3,17 @@ runs:
   using: "composite"
   steps:
      - name: Setup Ccache
+       if: ${{ github.workflow != 'NightlyTests' && github.ref_name != 'v1.4-andium' }}
        uses: hendrikmuhs/ccache-action@main
        with:
          key: ${{ github.job }}
-         save: ${{ github.repository != 'duckdb/duckdb' || contains('["refs/heads/main", "refs/heads/v1.4-andium", "refs/heads/v1.5-variegata"]', github.ref) }}
+         save: ${{ github.repository != 'duckdb/duckdb' || contains('["main", "v1.5-variegata"]', github.ref_name) }}
+         # Dump verbose ccache statistics report at end of CI job.
+         verbose: 1
+         # Increase per-directory limit: 5*1024 MB / 16 = 320 MB.
+         # Note: `layout=subdirs` computes the size limit divided by 16 dirs.
+         # See also: https://ccache.dev/manual/4.9.html#_cache_size_management
+         max-size: 5GB
+         # Evicts all cache files that were not touched during the job run.
+         # Removing cache files from previous runs avoids creating huge caches.
+         evict-old-files: 'job'


### PR DESCRIPTION
### GitHub cache usage per branch
Stats on 27 february 2026:

| branch | Cache Entries | Total Size | % of Total |
|---|---:|---:|---:|
| v1.5-variegata | 52 | 19.04 GiB | 38% |
| main | 70 | 16.20 GiB | 32% |
| v1.4-andium | 47 | 14.73 GiB | 29% |
