### PR TITLE
Bump ducklake to latest stable

### DIFF
--- a/.github/config/extensions/ducklake.cmake
+++ b/.github/config/extensions/ducklake.cmake
@@ -1,4 +1,4 @@
 duckdb_extension_load(ducklake
     GIT_URL https://github.com/duckdb/ducklake
-    GIT_TAG bafa83677a0e43f7c6ea739a8a2dedfe5c7805f0
+    GIT_TAG 7ea15644fd5f5ff42b86b8a703c14172acc7b8bd
 )


### PR DESCRIPTION
This includes a fix bumping STORAGE_VERSION for duckdb format to `v1.5.0`