### PR TITLE
[Dev] Fix crash with use of virtual columns in combination with `supports_pushdown_type`

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -1035,8 +1035,20 @@ static unique_ptr<TableFilter> TryCastTableFilter(const TableFilter &global_filt
 }
 
 void SetIndexToZero(unique_ptr<Expression> &root_expr) {
+#ifdef DEBUG
+	optional_idx index;
+	ExpressionIterator::VisitExpressionMutable<BoundReferenceExpression>(root_expr, [&](BoundReferenceExpression &ref,
+	                                                                                    unique_ptr<Expression> &expr) {
+		if (index.IsValid() && index.GetIndex() != ref.index) {
+			throw InternalException("Expected an expression that only references a single column, but found multiple!");
+		}
+		index = ref.index;
+		ref.index = 0;
+	});
+#else
 	ExpressionIterator::VisitExpressionMutable<BoundReferenceExpression>(
 	    root_expr, [&](BoundReferenceExpression &ref, unique_ptr<Expression> &expr) { ref.index = 0; });
+#endif
 }
 
 bool CanPropagateCast(const MultiFileIndexMapping &mapping, const LogicalType &local_type,

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -102,7 +102,11 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		vector<unique_ptr<Expression>> select_list;
 		unique_ptr<Expression> unsupported_filter;
 		unordered_set<idx_t> to_remove;
-		auto virtual_columns = op.function.get_virtual_columns(context, op.bind_data.get());
+
+		virtual_column_map_t virtual_columns;
+		if (op.function.get_virtual_columns) {
+			virtual_columns = op.function.get_virtual_columns(context, op.bind_data.get());
+		}
 		for (auto &entry : table_filters->filters) {
 			auto column_id = column_ids[entry.first].GetPrimaryIndex();
 			if (!op.function.supports_pushdown_type(*op.bind_data, column_id)) {

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -102,10 +102,17 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		vector<unique_ptr<Expression>> select_list;
 		unique_ptr<Expression> unsupported_filter;
 		unordered_set<idx_t> to_remove;
+		auto virtual_columns = op.function.get_virtual_columns(context, op.bind_data.get());
 		for (auto &entry : table_filters->filters) {
 			auto column_id = column_ids[entry.first].GetPrimaryIndex();
-			auto &type = op.returned_types[column_id];
 			if (!op.function.supports_pushdown_type(*op.bind_data, column_id)) {
+				LogicalType column_type;
+				if (IsVirtualColumn(column_id)) {
+					auto &column = virtual_columns.at(column_id);
+					column_type = column.type;
+				} else {
+					column_type = op.returned_types[column_id];
+				}
 				idx_t column_id_filter = entry.first;
 				bool found_projection = false;
 				for (idx_t i = 0; i < projection_ids.size(); i++) {
@@ -119,7 +126,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 					projection_ids.push_back(entry.first);
 					column_id_filter = projection_ids.size() - 1;
 				}
-				auto column = make_uniq<BoundReferenceExpression>(type, column_id_filter);
+				auto column = make_uniq<BoundReferenceExpression>(column_type, column_id_filter);
 				select_list.push_back(entry.second->ToExpression(*column));
 				to_remove.insert(entry.first);
 			}
@@ -132,7 +139,12 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 			vector<LogicalType> filter_types;
 			for (auto &c : projection_ids) {
 				auto column_id = column_ids[c].GetPrimaryIndex();
-				filter_types.push_back(op.returned_types[column_id]);
+				if (IsVirtualColumn(column_id)) {
+					auto &column = virtual_columns.at(column_id);
+					filter_types.push_back(column.type);
+				} else {
+					filter_types.push_back(op.returned_types[column_id]);
+				}
 			}
 			filter = Make<PhysicalFilter>(filter_types, std::move(select_list), op.estimated_cardinality);
 		}


### PR DESCRIPTION
The `supports_pushdown_type` callback can't handle virtual column ids, if a table function sets this callback and also uses virtual columns, the method will cause a crash on trying to dereference the `returned_types` vector *way* outside of the bounds.

Also add a small exception to the debug path of `SetIndexToZero`, the method expects the expression to only contain 1 distinct column reference, now it properly throws if that expectation isn't met.