### PR TITLE
Check index type before casting

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -621,10 +621,16 @@ bool TryScanIndex(ART &art, IndexEntry &entry, const ColumnList &column_list, Ta
 	lock_guard<mutex> guard(entry.lock);
 	vector<reference<ART>> arts_to_scan;
 	arts_to_scan.push_back(art);
-	if (entry.deleted_rows_in_use && entry.deleted_rows_in_use->GetIndexType() == ART::TYPE_NAME) {
+	if (entry.deleted_rows_in_use) {
+		if (entry.deleted_rows_in_use->GetIndexType() != ART::TYPE_NAME) {
+			throw InternalException("Concurrent changes made to a non-ART index");
+		}
 		arts_to_scan.push_back(entry.deleted_rows_in_use->Cast<ART>());
 	}
-	if (entry.added_data_during_checkpoint && entry.added_data_during_checkpoint->GetIndexType() == ART::TYPE_NAME) {
+	if (entry.added_data_during_checkpoint) {
+		if (entry.added_data_during_checkpoint->GetIndexType() != ART::TYPE_NAME) {
+			throw InternalException("Concurrent changes made to a non-ART index");
+		}
 		arts_to_scan.push_back(entry.added_data_during_checkpoint->Cast<ART>());
 	}
 

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -621,7 +621,7 @@ bool TryScanIndex(ART &art, IndexEntry &entry, const ColumnList &column_list, Ta
 	lock_guard<mutex> guard(entry.lock);
 	vector<reference<ART>> arts_to_scan;
 	arts_to_scan.push_back(art);
-	if (entry.deleted_rows_in_use && entry.deleted_rows_in_use->GetIndexType == ART::TYPE_NAME) {
+	if (entry.deleted_rows_in_use && entry.deleted_rows_in_use->GetIndexType() == ART::TYPE_NAME) {
 		arts_to_scan.push_back(entry.deleted_rows_in_use->Cast<ART>());
 	}
 	if (entry.added_data_during_checkpoint && entry.added_data_during_checkpoint->GetIndexType() == ART::TYPE_NAME) {

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -621,10 +621,10 @@ bool TryScanIndex(ART &art, IndexEntry &entry, const ColumnList &column_list, Ta
 	lock_guard<mutex> guard(entry.lock);
 	vector<reference<ART>> arts_to_scan;
 	arts_to_scan.push_back(art);
-	if (entry.deleted_rows_in_use) {
+	if (entry.deleted_rows_in_use && entry.deleted_rows_in_use->GetIndexType == ART::TYPE_NAME) {
 		arts_to_scan.push_back(entry.deleted_rows_in_use->Cast<ART>());
 	}
-	if (entry.added_data_during_checkpoint) {
+	if (entry.added_data_during_checkpoint && entry.added_data_during_checkpoint->GetIndexType() == ART::TYPE_NAME) {
 		arts_to_scan.push_back(entry.added_data_during_checkpoint->Cast<ART>());
 	}
 

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -354,35 +354,34 @@ void TableIndexList::MergeCheckpointDeltas(transaction_t checkpoint_id) {
 		}
 		lock_guard<mutex> guard(entry->lock);
 		auto &bound_index = index.Cast<BoundIndex>();
-		if (!entry->removed_data_during_checkpoint && !entry->added_data_during_checkpoint) {
-			continue;
-		}
-		if (bound_index.GetIndexType() != ART::TYPE_NAME) {
-			throw InternalException("Concurrent changes made to a non-ART index");
-		}
-
-		auto &art = bound_index.Cast<ART>();
-
-		if (entry->removed_data_during_checkpoint) {
-			art.RemovalMerge(*entry->removed_data_during_checkpoint);
-		}
-		if (entry->added_data_during_checkpoint) {
-			// NOTE: we insert duplicates here (IndexAppendMode::INSERT_DUPLICATES)
-			// this is necessary due to the way that data is inserted into indexes during transaction commit
-			// essentially we always FIRST insert data into the index, THEN remove data
-			// even if the data was logically removed first
-			// i.e. if we have a transaction like: DELETE FROM tbl WHERE i=42; INSERT INTO tbl VALUES (42);
-			// we will FIRST insert 42, THEN delete 42 from the index
-			// We plan to change this in the future - see https://github.com/duckdblabs/duckdb-internal/issues/6886
-			auto error = art.InsertMerge(*entry->added_data_during_checkpoint, IndexAppendMode::INSERT_DUPLICATES);
-			if (error.HasError()) {
-				throw InternalException("Failed to append while merging checkpoint deltas - this "
-				                        "signifies a bug or broken index: %s",
-				                        error.Message());
+		if (entry->removed_data_during_checkpoint || entry->added_data_during_checkpoint) {
+			if (bound_index.GetIndexType() != ART::TYPE_NAME) {
+				throw InternalException("Concurrent changes made to a non-ART index");
 			}
+
+			auto &art = bound_index.Cast<ART>();
+
+			if (entry->removed_data_during_checkpoint) {
+				art.RemovalMerge(*entry->removed_data_during_checkpoint);
+			}
+			if (entry->added_data_during_checkpoint) {
+				// NOTE: we insert duplicates here (IndexAppendMode::INSERT_DUPLICATES)
+				// this is necessary due to the way that data is inserted into indexes during transaction commit
+				// essentially we always FIRST insert data into the index, THEN remove data
+				// even if the data was logically removed first
+				// i.e. if we have a transaction like: DELETE FROM tbl WHERE i=42; INSERT INTO tbl VALUES (42);
+				// we will FIRST insert 42, THEN delete 42 from the index
+				// We plan to change this in the future - see https://github.com/duckdblabs/duckdb-internal/issues/6886
+				auto error = art.InsertMerge(*entry->added_data_during_checkpoint, IndexAppendMode::INSERT_DUPLICATES);
+				if (error.HasError()) {
+					throw InternalException("Failed to append while merging checkpoint deltas - this "
+					                        "signifies a bug or broken index: %s",
+					                        error.Message());
+				}
+			}
+			entry->removed_data_during_checkpoint.reset();
+			entry->added_data_during_checkpoint.reset();
 		}
-		entry->removed_data_during_checkpoint.reset();
-		entry->added_data_during_checkpoint.reset();
 		entry->last_written_checkpoint = checkpoint_id;
 	}
 }

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -347,12 +347,6 @@ IndexSerializationResult TableIndexList::SerializeToDisk(QueryContext context, c
 void TableIndexList::MergeCheckpointDeltas(transaction_t checkpoint_id) {
 	lock_guard<mutex> lock(index_entries_lock);
 	for (auto &entry : index_entries) {
-		if (!entry->removed_data_during_checkpoint && !entry->added_data_during_checkpoint) {
-			continue;
-		}
-		if (index.GetIndexType() != ART::TYPE_NAME) {
-			throw InternalException("Concurrent changes made to a non-ART index");
-		}
 		// Merge any data appended to the index while the checkpoint was running.
 		auto &index = *entry->index;
 		if (!index.IsBound()) {
@@ -360,6 +354,13 @@ void TableIndexList::MergeCheckpointDeltas(transaction_t checkpoint_id) {
 		}
 		lock_guard<mutex> guard(entry->lock);
 		auto &bound_index = index.Cast<BoundIndex>();
+		if (!entry->removed_data_during_checkpoint && !entry->added_data_during_checkpoint) {
+			continue;
+		}
+		if (bound_index.GetIndexType() != ART::TYPE_NAME) {
+			throw InternalException("Concurrent changes made to a non-ART index");
+		}
+
 		auto &art = bound_index.Cast<ART>();
 
 		if (entry->removed_data_during_checkpoint) {

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -347,9 +347,15 @@ IndexSerializationResult TableIndexList::SerializeToDisk(QueryContext context, c
 void TableIndexList::MergeCheckpointDeltas(transaction_t checkpoint_id) {
 	lock_guard<mutex> lock(index_entries_lock);
 	for (auto &entry : index_entries) {
+		if (!entry->removed_data_during_checkpoint && !entry->added_data_during_checkpoint) {
+			continue;
+		}
+		if (index.GetIndexType() != ART::TYPE_NAME) {
+			throw InternalException("Concurrent changes made to a non-ART index");
+		}
 		// Merge any data appended to the index while the checkpoint was running.
 		auto &index = *entry->index;
-		if (!index.IsBound() || index.GetIndexType() != ART::TYPE_NAME) {
+		if (!index.IsBound()) {
 			continue;
 		}
 		lock_guard<mutex> guard(entry->lock);

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -349,7 +349,7 @@ void TableIndexList::MergeCheckpointDeltas(transaction_t checkpoint_id) {
 	for (auto &entry : index_entries) {
 		// Merge any data appended to the index while the checkpoint was running.
 		auto &index = *entry->index;
-		if (!index.IsBound()) {
+		if (!index.IsBound() || index.GetIndexType() != ART::TYPENAME) {
 			continue;
 		}
 		lock_guard<mutex> guard(entry->lock);

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -349,7 +349,7 @@ void TableIndexList::MergeCheckpointDeltas(transaction_t checkpoint_id) {
 	for (auto &entry : index_entries) {
 		// Merge any data appended to the index while the checkpoint was running.
 		auto &index = *entry->index;
-		if (!index.IsBound() || index.GetIndexType() != ART::TYPENAME) {
+		if (!index.IsBound() || index.GetIndexType() != ART::TYPE_NAME) {
 			continue;
 		}
 		lock_guard<mutex> guard(entry->lock);


### PR DESCRIPTION
Ensures that index is casted to ART only if it is ART index. Spatial extension brings RTree index, which cannot be casted ART. Without the checks, it triggers assertions in DynamicCastCheck, or lead to other failures.

Related: https://github.com/duckdblabs/motherduck/issues/452