### PR TITLE
Add setup-vcpkg utility (and cleanup-vpckg)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,3 +561,14 @@ gather-libs: release
 	cp third_party/*/libduckdb_*.a libs/. && \
 	cp extension/libduckdb_generated_extension_loader.a libs/. && \
 	cp extension/*/lib*_extension.a libs/.
+
+#### Setup VCPKG to correct version 2025.12.12 tag is 84bab45d415d22042bd0b9081aea57f362da3f35
+vcpkg/scripts/buildsystems/vcpkg.cmake:
+	git -C vcpkg fetch || git clone --branch 2025.12.12 https://github.com/microsoft/vcpkg
+	cd vcpkg && ./bootstrap-vcpkg.sh
+
+setup-vcpkg: vcpkg/scripts/buildsystems/vcpkg.cmake
+	@echo 'Consider exporting VCPKG_TOOLCHAIN_PATH=$(PWD)/vcpkg/scripts/buildsystems/vcpkg.cmake'
+
+cleanup-vcpkg:
+	rm -rf vcpkg


### PR DESCRIPTION
This allows concise and self contained instructions on how to build duckdb together with extensions with VCPKG dependencies.

Example:
```bash
make setup-vcpkg
USE_MERGED_VCPKG_MANIFEST=1 VCPKG_TOOLCHAIN_PATH=$(PWD)/vcpkg/scripts/buildsystems/vcpkg.cmake CORE_EXTENSIONS="httpfs" GEN=ninja make
```

First sets up vcpkg, then builds httpfs and statically links httpfs into the duckdb binary

This simplify instructions for building duckdb with extensions, and solves https://github.com/duckdb/duckdb/issues/21073