### PR TITLE
Fix parallelization of Bernoulli and system sampling

### DIFF
--- a/src/execution/operator/helper/physical_streaming_sample.cpp
+++ b/src/execution/operator/helper/physical_streaming_sample.cpp
@@ -51,13 +51,15 @@ void PhysicalStreamingSample::BernoulliSample(DataChunk &input, DataChunk &resul
 }
 
 bool PhysicalStreamingSample::ParallelOperator() const {
-	return !(sample_options->repeatable || sample_options->seed.IsValid());
+	return !sample_options->repeatable;
 }
 
 unique_ptr<OperatorState> PhysicalStreamingSample::GetOperatorState(ExecutionContext &context) const {
 	if (!ParallelOperator()) {
+		// Repeatable single thread: use the specified seed for deterministic results
 		return make_uniq<StreamingSampleOperatorState>(static_cast<int64_t>(sample_options->seed.GetIndex()));
 	}
+	// Non-repeatable parallel: each thread gets a distinct random seed (duckdb#16223)
 	RandomEngine random;
 	return make_uniq<StreamingSampleOperatorState>(static_cast<int64_t>(random.NextRandomInteger64()));
 }

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -188,6 +188,11 @@
         "name": "seed",
         "type": "int64_t",
         "serialize_property": "GetSeed()"
+      },
+      {
+        "id": 104,
+        "name": "repeatable",
+        "type": "bool"
       }
     ],
     "constructor": ["seed"]

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -486,6 +486,7 @@ void SampleOptions::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(101, "is_percentage", is_percentage);
 	serializer.WriteProperty<SampleMethod>(102, "method", method);
 	serializer.WritePropertyWithDefault<int64_t>(103, "seed", GetSeed());
+	serializer.WritePropertyWithDefault<bool>(104, "repeatable", repeatable);
 }
 
 unique_ptr<SampleOptions> SampleOptions::Deserialize(Deserializer &deserializer) {
@@ -497,6 +498,7 @@ unique_ptr<SampleOptions> SampleOptions::Deserialize(Deserializer &deserializer)
 	result->sample_size = sample_size;
 	result->is_percentage = is_percentage;
 	result->method = method;
+	deserializer.ReadPropertyWithDefault<bool>(104, "repeatable", result->repeatable);
 	return result;
 }
 


### PR DESCRIPTION
Fixes #21086.

Summary:
- After #14374 ([specifically here](https://github.com/duckdb/duckdb/blob/83ae79e5b7a60820d3fe163e8c60de300fd0c8d1/src/execution/physical_plan/plan_sample.cpp#L15-L18)), `sample_options->seed.IsValid()` is always true inside `PhysicalStreamingSample::ParallelOperator`, disabling parallelization for streaming samples.
- This PR removes `sample_options->seed.IsValid()` from `PhysicalStreamingSample::ParallelOperator` to restore parallel streaming, while preserving the intent of #16223.

Additional fix:
- The above fix surfaced test failures in `test/sql/sample/test_sample.test_slow` and `test/sql/sample/sample_verification.test_slow` with “Invalid Error: Copied statement differs from original result!” because `sample_options->repeatable` wasn’t being serialized/deserialized and defaulted to false on copy.
- This PR adds `sample_options->repeatable` to the node JSON, resolving the failing sample tests.

This PR passes all CI tests on [my fork](https://github.com/thalassemia/duckdb/tree/parallel-streaming-sample) except for an unrelated [Windows (32 bit) test](https://github.com/thalassemia/duckdb/actions/runs/22512955010/job/65228865175). I’ve identified the source of the issue and will create a separate PR to address it.