### PR TITLE
Explicitly define regr count as uint64_t

### DIFF
--- a/extension/core_functions/aggregate/regression/regr_avg.cpp
+++ b/extension/core_functions/aggregate/regression/regr_avg.cpp
@@ -10,7 +10,7 @@ namespace {
 
 struct RegrState {
 	double sum;
-	size_t count;
+	uint64_t count;
 };
 
 struct RegrAvgFunction {

--- a/extension/core_functions/aggregate/regression/regr_count.cpp
+++ b/extension/core_functions/aggregate/regression/regr_count.cpp
@@ -18,7 +18,7 @@ LogicalType GetRegrCountStateType(const AggregateFunction &) {
 } // namespace
 
 AggregateFunction RegrCountFun::GetFunction() {
-	auto regr_count = AggregateFunction::BinaryAggregate<size_t, double, double, uint32_t, RegrCountFunction>(
+	auto regr_count = AggregateFunction::BinaryAggregate<uint64_t, double, double, uint32_t, RegrCountFunction>(
 	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::UINTEGER);
 	regr_count.name = "regr_count";
 	regr_count.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);

--- a/extension/core_functions/aggregate/regression/regr_intercept.cpp
+++ b/extension/core_functions/aggregate/regression/regr_intercept.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 
 namespace {
 struct RegrInterceptState {
-	size_t count;
+	uint64_t count;
 	double sum_x;
 	double sum_y;
 	RegrSlopeState slope;

--- a/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
@@ -11,20 +11,20 @@ namespace duckdb {
 
 namespace {
 struct RegrSState {
-	size_t count;
+	uint64_t count;
 	StddevState var_pop;
 };
 
 struct RegrBaseOperation {
 	template <class STATE>
 	static void Initialize(STATE &state) {
-		RegrCountFunction::Initialize<size_t>(state.count);
+		RegrCountFunction::Initialize<uint64_t>(state.count);
 		STDDevBaseOperation::Initialize<StddevState>(state.var_pop);
 	}
 
 	template <class STATE, class OP>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
-		RegrCountFunction::Combine<size_t, OP>(source.count, target.count, aggr_input_data);
+		RegrCountFunction::Combine<uint64_t, OP>(source.count, target.count, aggr_input_data);
 		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop, target.var_pop, aggr_input_data);
 	}
 
@@ -38,7 +38,7 @@ struct RegrBaseOperation {
 		if (!Value::DoubleIsFinite(var_pop)) {
 			throw OutOfRangeException("VARPOP is out of range!");
 		}
-		RegrCountFunction::Finalize<T, size_t>(state.count, target, finalize_data);
+		RegrCountFunction::Finalize<T, uint64_t>(state.count, target, finalize_data);
 		target *= var_pop;
 	}
 
@@ -50,7 +50,7 @@ struct RegrBaseOperation {
 struct RegrSXXOperation : RegrBaseOperation {
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const A_TYPE &y, const B_TYPE &x, AggregateBinaryInput &idata) {
-		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, y, x, idata);
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, uint64_t, OP>(state.count, y, x, idata);
 		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, x);
 	}
 };
@@ -58,7 +58,7 @@ struct RegrSXXOperation : RegrBaseOperation {
 struct RegrSYYOperation : RegrBaseOperation {
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const A_TYPE &y, const B_TYPE &x, AggregateBinaryInput &idata) {
-		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, y, x, idata);
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, uint64_t, OP>(state.count, y, x, idata);
 		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, y);
 	}
 };

--- a/extension/core_functions/aggregate/regression/regr_sxy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxy.cpp
@@ -11,34 +11,34 @@ namespace duckdb {
 namespace {
 
 struct RegrSXyState {
-	size_t count;
+	uint64_t count;
 	CovarState cov_pop;
 };
 
 struct RegrSXYOperation {
 	template <class STATE>
 	static void Initialize(STATE &state) {
-		RegrCountFunction::Initialize<size_t>(state.count);
+		RegrCountFunction::Initialize<uint64_t>(state.count);
 		CovarOperation::Initialize<CovarState>(state.cov_pop);
 	}
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const A_TYPE &y, const B_TYPE &x, AggregateBinaryInput &idata) {
-		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(state.count, y, x, idata);
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, uint64_t, OP>(state.count, y, x, idata);
 		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, y, x, idata);
 	}
 
 	template <class STATE, class OP>
 	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
 		CovarOperation::Combine<CovarState, OP>(source.cov_pop, target.cov_pop, aggr_input_data);
-		RegrCountFunction::Combine<size_t, OP>(source.count, target.count, aggr_input_data);
+		RegrCountFunction::Combine<uint64_t, OP>(source.count, target.count, aggr_input_data);
 	}
 
 	template <class T, class STATE>
 	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
 		CovarPopOperation::Finalize<T, CovarState>(state.cov_pop, target, finalize_data);
 		auto cov_pop = target;
-		RegrCountFunction::Finalize<T, size_t>(state.count, target, finalize_data);
+		RegrCountFunction::Finalize<T, uint64_t>(state.count, target, finalize_data);
 		target *= cov_pop;
 	}
 


### PR DESCRIPTION
The Windows (32 Bit) CI test occasionally fails in `test/sql/aggregate/aggregates/test_state_export_struct.test` with errors like the following:

```
Mismatch on row 1, column CAST(regr_count(1, 2) EXPORT_STATE AS STRUCT(count BIGINT))(index 1)

{'count': 419800102194905089} <> {'count': 1}
```

[See here](https://github.com/thalassemia/duckdb/actions/runs/22512955010/job/65228865175) for an example.

This occurs because the `count` state is defined as type `size_t` (4 bytes on 32 bit machines) [here](https://github.com/duckdb/duckdb/blob/83ae79e5b7a60820d3fe163e8c60de300fd0c8d1/extension/core_functions/aggregate/regression/regr_count.cpp#L21) but exported as type `UBIGINT` (8 bytes) [here](https://github.com/duckdb/duckdb/blob/83ae79e5b7a60820d3fe163e8c60de300fd0c8d1/extension/core_functions/aggregate/regression/regr_count.cpp#L14). This undefined behavior exists in the other `regr_*` aggregates as well.

This PR fixes this issue by explicitly defining all `count` states as type `uint64_t` and passes all CI tests on [my fork](https://github.com/thalassemia/duckdb/tree/count-32-bit).