### PR TITLE
[minor] Address some compile warning

### DIFF
--- a/src/include/duckdb/common/lru_cache.hpp
+++ b/src/include/duckdb/common/lru_cache.hpp
@@ -148,7 +148,6 @@ private:
 
 	void DeleteImpl(typename EntryMap::iterator iter) {
 		current_total_weight -= iter->second.payload_weight;
-		D_ASSERT(current_total_weight >= 0);
 		lru_list.erase(iter->second.lru_iterator);
 		entry_map.erase(iter);
 	}

--- a/src/include/duckdb/execution/index/art/iterator.hpp
+++ b/src/include/duckdb/execution/index/art/iterator.hpp
@@ -71,7 +71,7 @@ struct RowIdSetOutput {
 	}
 
 	bool IsFull() const {
-		D_ASSERT(row_ids.size() >= 0 && row_ids.size() <= capacity);
+		D_ASSERT(row_ids.size() <= capacity);
 		return row_ids.size() >= capacity;
 	}
 	void SetKey(const IteratorKey &, const idx_t) {
@@ -105,7 +105,7 @@ struct KeyRowIdOutput {
 		arena.Reset();
 	}
 	bool IsFull() const {
-		D_ASSERT(count >= 0 && count <= capacity);
+		D_ASSERT(count <= capacity);
 		return count >= capacity;
 	}
 	void SetKey(const IteratorKey &current_key, const idx_t column_key_len) {


### PR DESCRIPTION
```sh
/home/vscode/duckdb/src/include/duckdb/common/lru_cache.hpp:151:47: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
  151 |                 D_ASSERT(current_total_weight >= 0);
      |                          ~~~~~~~~~~~~~~~~~~~~~^~~~

/home/vscode/duckdb/src/include/duckdb/execution/index/art/iterator.hpp: In member function 'bool duckdb::RowIdSetOutput::IsFull() const':
/home/vscode/duckdb/src/include/duckdb/execution/index/art/iterator.hpp:74:41: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
   74 |                 D_ASSERT(row_ids.size() >= 0 && row_ids.size() <= capacity);
      |                          ~~~~~~~~~~~~~~~^~~~

/home/vscode/duckdb/src/include/duckdb/execution/index/art/iterator.hpp:108:32: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
  108 |                 D_ASSERT(count >= 0 && count <= capacity);
      |                          ~~~~~~^~~~
```