### PR TITLE
Add TEnumIterator::operator==

### DIFF
--- a/third_party/thrift/thrift/Thrift.h
+++ b/third_party/thrift/thrift/Thrift.h
@@ -69,6 +69,9 @@ public:
     assert(end.n_ == -1);
     return (ii_ != n_);
   }
+  bool operator==(const TEnumIterator& end) {
+    return !(*this != end);
+  }
 
   std::pair<int, const char*> operator*() const { return std::make_pair(enums_[ii_], names_[ii_]); }
 


### PR DESCRIPTION
Fix needed for clang 22, that otherwise will complain about a missing operator ==.

Repro:
```
brew install llvm
## should now have 22.0 as defaul
CMAKE_LLVM_PATH=/opt/homebrew/opt/llvm GEN=ninja make
```
```
In file included from /Users/carlo/duckdb-stable/third_party/parquet/parquet_types.cpp:7:
In file included from /Users/carlo/duckdb-stable/third_party/parquet/parquet_types.h:12:
In file included from /Users/carlo/duckdb-stable/extension/parquet/../../third_party/thrift/thrift/Thrift.h:38:
In file included from /opt/homebrew/Cellar/llvm/22.1.0/bin/../include/c++/v1/map:602:
/opt/homebrew/Cellar/llvm/22.1.0/bin/../include/c++/v1/__tree:1126:17: error: invalid operands to binary expression ('duckdb_apache::thrift::TEnumIterator' and 'duckdb_apache::thrift::TEnumIterator')
 1126 |     if (__first == __last)
      |         ~~~~~~~ ^  ~~~~~~
/opt/homebrew/Cellar/llvm/22.1.0/bin/../include/c++/v1/map:1172:13: note: in instantiation of function template specialization 'std::__tree<std::__value_type<int, const char *>, std::__map_value_compare<int, std::pair<const int, const char *>, std::less<int>>, std::allocator<std::pair<const int, const char *>>>::__insert_range_unique<duckdb_apache::thrift::TEnumIterator, duckdb_apache::thrift::TEnumIterator>' requested here
 1172 |     __tree_.__insert_range_unique(__first, __last);
      |             ^
/opt/homebrew/Cellar/llvm/22.1.0/bin/../include/c++/v1/map:997:5: note: in instantiation of function template specialization 'std::map<int, const char *>::insert<duckdb_apache::thrift::TEnumIterator>' requested here
  997 |     insert(__f, __l);
      |     ^
/Users/carlo/duckdb-stable/third_party/parquet/parquet_types.cpp:44:34: note: in instantiation of function template specialization 'std::map<int, const char *>::map<duckdb_apache::thrift::TEnumIterator>' requested here
   44 | const std::map<int, const char*> _Type_VALUES_TO_NAMES(::apache::thrift::TEnumIterator(8, _kTypeValues, _kTypeNames), ::apache::thrift::TEnumIterator(-1, nullptr, nullptr));
      |                                  ^
/opt/homebrew/Cellar/llvm/22.1.0/bin/../include/c++/v1/__utility/pair.h:452:1: note: candidate template ignored: could not match 'pair<_T1, _T2>' against 'duckdb_apache::thrift::TEnumIterator'
  452 | operator==(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y)
      | ^
```