### PR TITLE
Switch connection creation order

### DIFF
--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -21,8 +21,8 @@ namespace duckdb {
 Connection::Connection(DatabaseInstance &database)
     : context(make_shared_ptr<ClientContext>(database.shared_from_this())) {
 	auto &connection_manager = ConnectionManager::Get(database);
-	connection_manager.AddConnection(*context);
 	connection_manager.AssignConnectionId(*this);
+	connection_manager.AddConnection(*context);
 }
 
 Connection::Connection(DuckDB &database) : Connection(*database.instance) {


### PR DESCRIPTION
Hi team, I want to access connection id inside of connection construction callback, so in this PR I switch the order for two relevant statements. Let me know if you have any concerns!

Context: I'm the author for extension [cache httpfs](https://duckdb.org/community_extensions/extensions/cache_httpfs).
Recently I got a user [feature request](https://github.com/dentiny/duck-read-cache-fs/pull/442) to support per-connection metrics; the best way I could think of is to register a metrics collector at connection start, and remove it at connection destruction, both achieved with connection callback. So connection id knowledge is a necessity for callback.

I have tested in my own fork: https://github.com/dentiny/duckdb/pull/58, the CI failures seem known issues and unrelated.