### PR TITLE
Add struct-based state export for covar_pop and var_pop

### DIFF
--- a/extension/core_functions/aggregate/algebraic/corr.cpp
+++ b/extension/core_functions/aggregate/algebraic/corr.cpp
@@ -6,34 +6,21 @@
 
 namespace duckdb {
 
-LogicalType GetCorrExportStateType(const AggregateFunction &function) {
-	auto state_children = child_list_t<LogicalType> {};
-
-	auto covar_pop_children = child_list_t<LogicalType> {};
-	covar_pop_children.emplace_back("count", LogicalType::UBIGINT);
-	covar_pop_children.emplace_back("mean_x", LogicalType::DOUBLE);
-	covar_pop_children.emplace_back("mean_y", LogicalType::DOUBLE);
-	covar_pop_children.emplace_back("co_moment", LogicalType::DOUBLE);
-	state_children.emplace_back("cov_pop", LogicalType::STRUCT(std::move(covar_pop_children)));
-
-	auto dev_pop_x_children = child_list_t<LogicalType> {};
-	dev_pop_x_children.emplace_back("count", LogicalType::UBIGINT);
-	dev_pop_x_children.emplace_back("mean", LogicalType::DOUBLE);
-	dev_pop_x_children.emplace_back("dsquared", LogicalType::DOUBLE);
-	state_children.emplace_back("dev_pop_x", LogicalType::STRUCT(std::move(dev_pop_x_children)));
-
-	auto dev_pop_y_children = child_list_t<LogicalType> {};
-	dev_pop_y_children.emplace_back("count", LogicalType::UBIGINT);
-	dev_pop_y_children.emplace_back("mean", LogicalType::DOUBLE);
-	dev_pop_y_children.emplace_back("dsquared", LogicalType::DOUBLE);
-	state_children.emplace_back("dev_pop_y", LogicalType::STRUCT(std::move(dev_pop_y_children)));
-
+LogicalType GetCorrStateType() {
+	child_list_t<LogicalType> state_children;
+	state_children.emplace_back("cov_pop", CovarPopFun::GetFunction().GetStateType());
+	state_children.emplace_back("dev_pop_x", VarPopFun::GetFunction().GetStateType());
+	state_children.emplace_back("dev_pop_y", VarPopFun::GetFunction().GetStateType());
 	return LogicalType::STRUCT(std::move(state_children));
+}
+
+LogicalType GetCorrExportStateType(const AggregateFunction &) {
+	return GetCorrStateType();
 }
 
 AggregateFunction CorrFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<CorrState, double, double, double, CorrOperation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-	    .SetStructStateExport(GetCorrExportStateType);
+			   LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
+		.SetStructStateExport(GetCorrExportStateType);
 }
 } // namespace duckdb

--- a/extension/core_functions/aggregate/algebraic/corr.cpp
+++ b/extension/core_functions/aggregate/algebraic/corr.cpp
@@ -20,7 +20,7 @@ LogicalType GetCorrExportStateType(const AggregateFunction &) {
 
 AggregateFunction CorrFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<CorrState, double, double, double, CorrOperation>(
-			   LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
-		.SetStructStateExport(GetCorrExportStateType);
+	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
+	    .SetStructStateExport(GetCorrExportStateType);
 }
 } // namespace duckdb

--- a/extension/core_functions/aggregate/algebraic/covar.cpp
+++ b/extension/core_functions/aggregate/algebraic/covar.cpp
@@ -1,12 +1,25 @@
 #include "core_functions/aggregate/algebraic_functions.hpp"
-#include "duckdb/common/types/null_value.hpp"
 #include "core_functions/aggregate/algebraic/covar.hpp"
 
 namespace duckdb {
 
+namespace {
+
+LogicalType GetCovarStateType(const AggregateFunction &) {
+	child_list_t<LogicalType> child_types;
+	child_types.emplace_back("count", LogicalType::UBIGINT);
+	child_types.emplace_back("meanx", LogicalType::DOUBLE);
+	child_types.emplace_back("meany", LogicalType::DOUBLE);
+	child_types.emplace_back("co_moment", LogicalType::DOUBLE);
+	return LogicalType::STRUCT(std::move(child_types));
+}
+
+} // namespace
+
 AggregateFunction CovarPopFun::GetFunction() {
 	return AggregateFunction::BinaryAggregate<CovarState, double, double, double, CovarPopOperation>(
-	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE);
+	           LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE)
+	    .SetStructStateExport(GetCovarStateType);
 }
 
 AggregateFunction CovarSampFun::GetFunction() {

--- a/extension/core_functions/aggregate/algebraic/stddev.cpp
+++ b/extension/core_functions/aggregate/algebraic/stddev.cpp
@@ -27,8 +27,8 @@ AggregateFunction StdDevPopFun::GetFunction() {
 }
 
 AggregateFunction VarPopFun::GetFunction() {
-	return AggregateFunction::UnaryAggregate<StddevState, double, double, VarPopOperation>(
-	           LogicalType::DOUBLE, LogicalType::DOUBLE)
+	return AggregateFunction::UnaryAggregate<StddevState, double, double, VarPopOperation>(LogicalType::DOUBLE,
+	                                                                                       LogicalType::DOUBLE)
 	    .SetStructStateExport(GetStddevStateType);
 }
 

--- a/extension/core_functions/aggregate/algebraic/stddev.cpp
+++ b/extension/core_functions/aggregate/algebraic/stddev.cpp
@@ -1,10 +1,20 @@
 #include "core_functions/aggregate/algebraic_functions.hpp"
-#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "core_functions/aggregate/algebraic/stddev.hpp"
-#include <cmath>
 
 namespace duckdb {
+
+namespace {
+
+LogicalType GetStddevStateType(const AggregateFunction &) {
+	child_list_t<LogicalType> child_types;
+	child_types.emplace_back("count", LogicalType::UBIGINT);
+	child_types.emplace_back("mean", LogicalType::DOUBLE);
+	child_types.emplace_back("dsquared", LogicalType::DOUBLE);
+	return LogicalType::STRUCT(std::move(child_types));
+}
+
+} // namespace
 
 AggregateFunction StdDevSampFun::GetFunction() {
 	return AggregateFunction::UnaryAggregate<StddevState, double, double, STDDevSampOperation>(LogicalType::DOUBLE,
@@ -17,8 +27,9 @@ AggregateFunction StdDevPopFun::GetFunction() {
 }
 
 AggregateFunction VarPopFun::GetFunction() {
-	return AggregateFunction::UnaryAggregate<StddevState, double, double, VarPopOperation>(LogicalType::DOUBLE,
-	                                                                                       LogicalType::DOUBLE);
+	return AggregateFunction::UnaryAggregate<StddevState, double, double, VarPopOperation>(
+	           LogicalType::DOUBLE, LogicalType::DOUBLE)
+	    .SetStructStateExport(GetStddevStateType);
 }
 
 AggregateFunction VarSampFun::GetFunction() {

--- a/extension/core_functions/aggregate/regression/regr_intercept.cpp
+++ b/extension/core_functions/aggregate/regression/regr_intercept.cpp
@@ -2,7 +2,7 @@
 
 #include "core_functions/aggregate/regression_functions.hpp"
 #include "core_functions/aggregate/regression/regr_slope.hpp"
-#include "duckdb/function/function_set.hpp"
+#include "core_functions/aggregate/algebraic_functions.hpp"
 
 namespace duckdb {
 
@@ -65,21 +65,10 @@ LogicalType GetRegrInterceptStateType(const AggregateFunction &) {
 	state_children.emplace_back("count", LogicalType::UBIGINT);
 	state_children.emplace_back("sum_x", LogicalType::DOUBLE);
 	state_children.emplace_back("sum_y", LogicalType::DOUBLE);
-
 	child_list_t<LogicalType> slope_children;
-	child_list_t<LogicalType> cov_pop_children;
-	cov_pop_children.emplace_back("count", LogicalType::UBIGINT);
-	cov_pop_children.emplace_back("meanx", LogicalType::DOUBLE);
-	cov_pop_children.emplace_back("meany", LogicalType::DOUBLE);
-	cov_pop_children.emplace_back("co_moment", LogicalType::DOUBLE);
-	slope_children.emplace_back("cov_pop", LogicalType::STRUCT(std::move(cov_pop_children)));
-	child_list_t<LogicalType> var_pop_children;
-	var_pop_children.emplace_back("count", LogicalType::UBIGINT);
-	var_pop_children.emplace_back("mean", LogicalType::DOUBLE);
-	var_pop_children.emplace_back("dsquared", LogicalType::DOUBLE);
-	slope_children.emplace_back("var_pop", LogicalType::STRUCT(std::move(var_pop_children)));
+	slope_children.emplace_back("cov_pop", CovarPopFun::GetFunction().GetStateType());
+	slope_children.emplace_back("var_pop", VarPopFun::GetFunction().GetStateType());
 	state_children.emplace_back("slope", LogicalType::STRUCT(std::move(slope_children)));
-
 	return LogicalType::STRUCT(std::move(state_children));
 }
 

--- a/extension/core_functions/aggregate/regression/regr_r2.cpp
+++ b/extension/core_functions/aggregate/regression/regr_r2.cpp
@@ -6,7 +6,7 @@
 // power(corr(y,x), 2)
 
 #include "core_functions/aggregate/algebraic/corr.hpp"
-#include "duckdb/function/function_set.hpp"
+#include "core_functions/aggregate/algebraic_functions.hpp"
 #include "core_functions/aggregate/regression_functions.hpp"
 
 namespace duckdb {
@@ -69,37 +69,9 @@ struct RegrR2Operation {
 
 LogicalType GetRegrR2StateType(const AggregateFunction &) {
 	child_list_t<LogicalType> state_children;
-
-	child_list_t<LogicalType> corr_children;
-	child_list_t<LogicalType> cov_pop_children;
-	cov_pop_children.emplace_back("count", LogicalType::UBIGINT);
-	cov_pop_children.emplace_back("meanx", LogicalType::DOUBLE);
-	cov_pop_children.emplace_back("meany", LogicalType::DOUBLE);
-	cov_pop_children.emplace_back("co_moment", LogicalType::DOUBLE);
-	corr_children.emplace_back("cov_pop", LogicalType::STRUCT(std::move(cov_pop_children)));
-	child_list_t<LogicalType> dev_pop_x_children;
-	dev_pop_x_children.emplace_back("count", LogicalType::UBIGINT);
-	dev_pop_x_children.emplace_back("mean", LogicalType::DOUBLE);
-	dev_pop_x_children.emplace_back("dsquared", LogicalType::DOUBLE);
-	corr_children.emplace_back("dev_pop_x", LogicalType::STRUCT(std::move(dev_pop_x_children)));
-	child_list_t<LogicalType> dev_pop_y_children;
-	dev_pop_y_children.emplace_back("count", LogicalType::UBIGINT);
-	dev_pop_y_children.emplace_back("mean", LogicalType::DOUBLE);
-	dev_pop_y_children.emplace_back("dsquared", LogicalType::DOUBLE);
-	corr_children.emplace_back("dev_pop_y", LogicalType::STRUCT(std::move(dev_pop_y_children)));
-	state_children.emplace_back("corr", LogicalType::STRUCT(std::move(corr_children)));
-
-	child_list_t<LogicalType> var_pop_x_children;
-	var_pop_x_children.emplace_back("count", LogicalType::UBIGINT);
-	var_pop_x_children.emplace_back("mean", LogicalType::DOUBLE);
-	var_pop_x_children.emplace_back("dsquared", LogicalType::DOUBLE);
-	state_children.emplace_back("var_pop_x", LogicalType::STRUCT(std::move(var_pop_x_children)));
-	child_list_t<LogicalType> var_pop_y_children;
-	var_pop_y_children.emplace_back("count", LogicalType::UBIGINT);
-	var_pop_y_children.emplace_back("mean", LogicalType::DOUBLE);
-	var_pop_y_children.emplace_back("dsquared", LogicalType::DOUBLE);
-	state_children.emplace_back("var_pop_y", LogicalType::STRUCT(std::move(var_pop_y_children)));
-
+	state_children.emplace_back("corr", CorrFun::GetFunction().GetStateType());
+	state_children.emplace_back("var_pop_x", VarPopFun::GetFunction().GetStateType());
+	state_children.emplace_back("var_pop_y", VarPopFun::GetFunction().GetStateType());
 	return LogicalType::STRUCT(std::move(state_children));
 }
 

--- a/extension/core_functions/aggregate/regression/regr_slope.cpp
+++ b/extension/core_functions/aggregate/regression/regr_slope.cpp
@@ -7,7 +7,7 @@
 //! Output : Double
 
 #include "core_functions/aggregate/regression/regr_slope.hpp"
-#include "duckdb/function/function_set.hpp"
+#include "core_functions/aggregate/algebraic_functions.hpp"
 #include "core_functions/aggregate/regression_functions.hpp"
 
 namespace duckdb {
@@ -16,20 +16,8 @@ namespace {
 
 LogicalType GetRegrSlopeStateType(const AggregateFunction &) {
 	child_list_t<LogicalType> state_children;
-
-	child_list_t<LogicalType> cov_pop_children;
-	cov_pop_children.emplace_back("count", LogicalType::UBIGINT);
-	cov_pop_children.emplace_back("meanx", LogicalType::DOUBLE);
-	cov_pop_children.emplace_back("meany", LogicalType::DOUBLE);
-	cov_pop_children.emplace_back("co_moment", LogicalType::DOUBLE);
-	state_children.emplace_back("cov_pop", LogicalType::STRUCT(std::move(cov_pop_children)));
-
-	child_list_t<LogicalType> var_pop_children;
-	var_pop_children.emplace_back("count", LogicalType::UBIGINT);
-	var_pop_children.emplace_back("mean", LogicalType::DOUBLE);
-	var_pop_children.emplace_back("dsquared", LogicalType::DOUBLE);
-	state_children.emplace_back("var_pop", LogicalType::STRUCT(std::move(var_pop_children)));
-
+	state_children.emplace_back("cov_pop", CovarPopFun::GetFunction().GetStateType());
+	state_children.emplace_back("var_pop", VarPopFun::GetFunction().GetStateType());
 	return LogicalType::STRUCT(std::move(state_children));
 }
 

--- a/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxx_syy.cpp
@@ -4,7 +4,7 @@
 // Returns REGR_COUNT(y, x) * VAR_POP(y) for non-null pairs.
 
 #include "core_functions/aggregate/regression/regr_count.hpp"
-#include "duckdb/function/function_set.hpp"
+#include "core_functions/aggregate/algebraic_functions.hpp"
 #include "core_functions/aggregate/regression_functions.hpp"
 
 namespace duckdb {
@@ -66,11 +66,7 @@ struct RegrSYYOperation : RegrBaseOperation {
 LogicalType GetRegrSStateType(const AggregateFunction &) {
 	child_list_t<LogicalType> state_children;
 	state_children.emplace_back("count", LogicalType::UBIGINT);
-	child_list_t<LogicalType> var_pop_children;
-	var_pop_children.emplace_back("count", LogicalType::UBIGINT);
-	var_pop_children.emplace_back("mean", LogicalType::DOUBLE);
-	var_pop_children.emplace_back("dsquared", LogicalType::DOUBLE);
-	state_children.emplace_back("var_pop", LogicalType::STRUCT(std::move(var_pop_children)));
+	state_children.emplace_back("var_pop", VarPopFun::GetFunction().GetStateType());
 	return LogicalType::STRUCT(std::move(state_children));
 }
 

--- a/extension/core_functions/aggregate/regression/regr_sxy.cpp
+++ b/extension/core_functions/aggregate/regression/regr_sxy.cpp
@@ -2,7 +2,7 @@
 // Returns REGR_COUNT(expr1, expr2) * COVAR_POP(expr1, expr2) for non-null pairs.
 
 #include "core_functions/aggregate/regression/regr_count.hpp"
-#include "core_functions/aggregate/algebraic/covar.hpp"
+#include "core_functions/aggregate/algebraic_functions.hpp"
 #include "core_functions/aggregate/regression_functions.hpp"
 #include "duckdb/function/function_set.hpp"
 
@@ -50,12 +50,7 @@ struct RegrSXYOperation {
 LogicalType GetRegrSXYStateType(const AggregateFunction &) {
 	child_list_t<LogicalType> state_children;
 	state_children.emplace_back("count", LogicalType::UBIGINT);
-	child_list_t<LogicalType> cov_pop_children;
-	cov_pop_children.emplace_back("count", LogicalType::UBIGINT);
-	cov_pop_children.emplace_back("meanx", LogicalType::DOUBLE);
-	cov_pop_children.emplace_back("meany", LogicalType::DOUBLE);
-	cov_pop_children.emplace_back("co_moment", LogicalType::DOUBLE);
-	state_children.emplace_back("cov_pop", LogicalType::STRUCT(std::move(cov_pop_children)));
+	state_children.emplace_back("cov_pop", CovarPopFun::GetFunction().GetStateType());
 	return LogicalType::STRUCT(std::move(state_children));
 }
 

--- a/test/sql/aggregate/aggregates/test_corr_state_export.test
+++ b/test/sql/aggregate/aggregates/test_corr_state_export.test
@@ -14,7 +14,7 @@ create table dummy as select range % 10 g, range d from range(100);
 query T
 SELECT corr(d, d+1) export_state FROM dummy;
 ----
-{'cov_pop': {'count': 100, 'mean_x': 50.5, 'mean_y': 49.5, 'co_moment': 83325.0}, 'dev_pop_x': {'count': 100, 'mean': 50.5, 'dsquared': 83325.0}, 'dev_pop_y': {'count': 100, 'mean': 49.5, 'dsquared': 83325.0}}
+{'cov_pop': {'count': 100, 'meanx': 50.5, 'meany': 49.5, 'co_moment': 83325.0}, 'dev_pop_x': {'count': 100, 'mean': 50.5, 'dsquared': 83325.0}, 'dev_pop_y': {'count': 100, 'mean': 49.5, 'dsquared': 83325.0}}
 
 # Test finalize and export state
 query II

--- a/test/sql/aggregate/aggregates/test_state_export_opaque.test
+++ b/test/sql/aggregate/aggregates/test_state_export_opaque.test
@@ -59,22 +59,6 @@ query IIII nosort res6
 SELECT finalize(min(d) EXPORT_STATE), finalize(max(d) EXPORT_STATE) FROM (SELECT NULL::integer d, g FROM dummy);
 ----
 
-# more aggregates
-
-# we skip these for now as argmin/argmax now has a custom binder (so that it can work with extension types like JSON)
-# otherwise we get "Binder Error: Cannot use EXPORT_STATE on aggregate functions with custom binders"
-mode skip
-
-query II nosort res7
-select argmin(a,b), argmax(a,b) from (values (1,1), (2,2), (8,8), (10,10)) s(a,b);
-----
-
-query II nosort res7
-select FINALIZE(argmin(a,b) EXPORT_STATE), FINALIZE(argmax(a,b) EXPORT_STATE) from (values (1,1), (2,2), (8,8), (10,10)) s(a,b);
-----
-
-mode unskip
-
 # you're holding it wrong:
 
 statement error

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -33,6 +33,27 @@ query I nosort res_corr0
 SELECT finalize(corr(d, d+1) EXPORT_STATE) FROM dummy;
 ----
 
+# covar_pop and var_pop (struct state export)
+query I
+SELECT covar_pop(d, d+1) FROM dummy;
+----
+833.25
+
+query I
+SELECT finalize(covar_pop(d, d+1) EXPORT_STATE) FROM dummy;
+----
+833.25
+
+query I
+SELECT var_pop(d) FROM dummy;
+----
+833.25
+
+query I
+SELECT finalize(var_pop(d) EXPORT_STATE) FROM dummy;
+----
+833.25
+
 # Regression aggregates: ungrouped direct vs EXPORT_STATE + finalize
 query I
 SELECT regr_count(d, d+1) FROM dummy;
@@ -195,6 +216,16 @@ query T
 SELECT (regr_avgx(1.0, 2.0) export_state)::struct(sum double, count bigint);
 ----
 {'sum': 2.0, 'count': 1}
+
+query T
+SELECT (covar_pop(1.0, 2.0) export_state)::struct(count ubigint, meanx double, meany double, co_moment double);
+----
+{'count': 1, 'meanx': 2.0, 'meany': 1.0, 'co_moment': 0.0}
+
+query T
+SELECT (var_pop(42.0) export_state)::struct(count ubigint, mean double, dsquared double);
+----
+{'count': 1, 'mean': 42.0, 'dsquared': 0.0}
 
 query IIIIIIIII nosort res1
 SELECT g, sum(d), avg(d)::integer, count(d), first(d), last(d) FROM dummy GROUP BY g ORDER BY g;

--- a/test/sql/aggregate/aggregates/test_state_export_struct.test
+++ b/test/sql/aggregate/aggregates/test_state_export_struct.test
@@ -208,12 +208,12 @@ SELECT g, finalize(slope_state), finalize(count_state) FROM state_regr ORDER BY 
 
 # Regression: struct shape for state export
 query T
-SELECT (regr_count(1, 2) export_state)::struct(count bigint);
+SELECT (regr_count(1, 2) export_state)::struct(count ubigint);
 ----
 {'count': 1}
 
 query T
-SELECT (regr_avgx(1.0, 2.0) export_state)::struct(sum double, count bigint);
+SELECT (regr_avgx(1.0, 2.0) export_state)::struct(sum double, count ubigint);
 ----
 {'sum': 2.0, 'count': 1}
 


### PR DESCRIPTION
## Summary

- Add `SetStructStateExport` to `CovarPopFun` and `VarPopFun` to enable struct-based aggregate state export
- Refactor regression and corr aggregates to reuse shared state types from `CovarPopFun::GetFunction().GetStateType()` and `VarPopFun::GetFunction().GetStateType()` instead of duplicating type definitions
- Add DEBUG roundtrip verification in `AggregateStateFinalize` to catch serialization/deserialization bugs for struct-based aggregate state
- Add `covar_pop` and `var_pop` tests to `test_state_export_struct.test`
- Fix `test_corr_state_export.test` field names (`mean_x`/`mean_y` → `meanx`/`meany`) to match covar state type
- Remove dead `argmin`/`argmax` block from `test_state_export_opaque.test` (was wrapped in `mode skip` and never executed)

## Test plan

- [x] `test_state_export_struct.test` passes (404 assertions)
- [x] `test_state_export_opaque.test` passes (37 assertions)
- [x] `test_corr_state_export.test` passes (8 assertions)
- [x] `test_aggregate_state_type.test` passes (90 assertions)
- [x] `test_combine_aggr.test` passes (22 assertions)
