### PR TITLE
Run swift and windows CI after linux-debug

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -15,6 +15,8 @@ on:
       - '.github/patches/duckdb-wasm/**'
       - '.github/workflows/**'
       - '!.github/workflows/Main.yml'
+      - '!.github/workflows/Swift.yml'
+      - '!.github/workflows/Windows.yml'
       - '!.github/workflows/Regression.yml'
       - '!.github/workflows/Extensions.yml'
       - '!.github/workflows/LinuxRelease.yml'
@@ -33,6 +35,8 @@ on:
       - '.github/patches/duckdb-wasm/**'
       - '.github/workflows/**'
       - '!.github/workflows/Main.yml'
+      - '!.github/workflows/Swift.yml'
+      - '!.github/workflows/Windows.yml'
       - '!.github/workflows/Regression.yml'
       - '!.github/workflows/Extensions.yml'
       - '!.github/workflows/LinuxRelease.yml'
@@ -230,6 +234,20 @@ jobs:
     with:
       git_ref: ${{ github.sha }}
       skip_tests: 'false'
+
+ swift:
+    uses: ./.github/workflows/Swift.yml
+    secrets: inherit
+    needs: linux-debug
+
+ windows:
+    uses: ./.github/workflows/Windows.yml
+    secrets: inherit
+    needs: linux-debug
+    with:
+      git_ref: ${{ github.sha }}
+      skip_tests: 'false'
+      run_all: 'true'
 
  no-string-inline:
     name: No String Inline / Destroy Unpinned Blocks

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -1,37 +1,8 @@
 name: Swift
 on:
+  workflow_call:
   workflow_dispatch:
   repository_dispatch:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'feature'
-      - 'v*.*-*'
-    paths-ignore:
-      - '**.md'
-      - 'examples/**'
-      - 'test/**'
-      - 'tools/**'
-      - '!tools/swift/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/Swift.yml'
-      - '.github/config/extensions/*.cmake'
-      - '.github/patches/extensions/**/*.patch'
-  merge_group:
-  pull_request:
-    types: [opened, reopened, ready_for_review, converted_to_draft]
-    paths-ignore:
-      - '**.md'
-      - 'examples/**'
-      - 'test/**'
-      - 'tools/**'
-      - '!tools/swift/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/Swift.yml'
-      - '.github/config/extensions/*.cmake'
-      - '.github/patches/extensions/**/*.patch'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -9,17 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-draft:
-    # We run all other jobs on PRs only if they are not draft PR
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Preliminary checks on CI 
-        run: echo "Event name is ${{ github.event_name }}"
-
   test-apple-platforms:
     name: Test Apple Platforms
-    needs: check-draft
     strategy:
       matrix:
         # destinations need to match selected version of Xcode

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -33,18 +33,9 @@ env:
   AZURE_CODESIGN_PROFILE: duckdb-certificate-profile
 
 jobs:
- check-draft:
-    # We run all other jobs on PRs only if they are not draft PR
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Preliminary checks on CI
-        run: echo "Event name is ${{ github.event_name }}"
-
  win-release-64:
     # Builds binaries for windows_amd64
     name: Windows (64 Bit)
-    needs: check-draft
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
@@ -142,7 +133,6 @@ jobs:
     name: Windows (32 Bit)
     needs:
       - win-release-64
-      - check-draft
     if: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' || inputs.run_all == 'true' }}
     runs-on: windows-latest
 
@@ -179,7 +169,6 @@ jobs:
    name: Windows (ARM64)
    needs:
     - win-release-64
-    - check-draft
    if: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' || inputs.run_all == 'true' }}
    runs-on: windows-latest
 
@@ -242,7 +231,6 @@ jobs:
      name: MinGW (64 Bit)
      needs:
       - win-release-64
-      - check-draft
      if: ${{ inputs.skip_tests != 'true' }}
      runs-on: windows-latest
      steps:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -20,35 +20,6 @@ on:
         type: string
       run_all:
         type: string
-  push:
-    branches-ignore:
-      - 'main'
-      - 'feature'
-      - 'v*.*-*'
-    paths-ignore:
-      - '**.md'
-      - 'test/configs/**'
-      - 'tools/**'
-      - '!tools/shell/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/Windows.yml'
-      - '.github/config/extensions/*.cmake'
-      - '.github/patches/extensions/**/*.patch'
-
-  merge_group:
-  pull_request:
-    types: [opened, reopened, ready_for_review, converted_to_draft]
-    paths-ignore:
-      - '**.md'
-      - 'test/configs/**'
-      - 'tools/**'
-      - '!tools/shell/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/Windows.yml'
-      - '.github/config/extensions/*.cmake'
-      - '.github/patches/extensions/**/*.patch'
 
 concurrency:
   group: windows-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}


### PR DESCRIPTION
- Start swift and windows CI jobs after the linux-debug job succeeded to reduce CI workload.
- Remove redundant `check-draft` jobs.

Note: I'll move the clang-format (and other code format checks) into the CI job `prepare`, but that change was a bit messy and thus postponed.