### PR TITLE
fix(storage): prevent TrimFreeBlocks from zeroing concurrently alloca…

### DIFF
--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -1364,11 +1364,15 @@ void SingleFileBlockManager::TrimFreeBlocks(const set<block_id_t> &blocks) {
 	if (!DBConfig::Get(db).options.trim_free_blocks) {
 		return;
 	}
+	lock_guard<mutex> lock(single_file_block_lock);
 	for (auto itr = blocks.begin(); itr != blocks.end(); ++itr) {
+		if (!free_list.count(*itr)) {
+			continue;
+		}
 		block_id_t first = *itr;
 		block_id_t last = first;
 		// Find end of contiguous range.
-		for (++itr; itr != blocks.end() && (*itr == last + 1); ++itr) {
+		for (++itr; itr != blocks.end() && (*itr == last + 1) && free_list.count(*itr); ++itr) {
 			last = *itr;
 		}
 		// We are now one too far.


### PR DESCRIPTION
…ted blocks

WriteHeader() populates free_list and fully_freed_blocks under single_file_block_lock, then releases the lock before TrimFreeBlocks() runs. A concurrent writer can call AllocateBlock() in this window, claim one of those blocks from free_list, write data to it, and commit a WAL entry referencing it. TrimFreeBlocks then zeros the live block, causing a checksum mismatch when the database reopens and replays the WAL.

Fix: hold single_file_block_lock for the duration of TrimFreeBlocks() and skip any block no longer present in free_list, which indicates it was allocated by a concurrent writer before the lock was acquired.