### PR TITLE
Avoid loading row group metadata just to re-compute global stats for non-variant types

### DIFF
--- a/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
@@ -45,11 +45,18 @@ public:
 	PartialBlockManager &GetPartialBlockManager() {
 		return partial_block_manager;
 	}
+	void SetHasUnloadedColumn(idx_t column_idx) {
+		has_unloaded_columns.insert(column_idx);
+	}
+	unordered_set<idx_t> GetUnloadedColumns() const {
+		return has_unloaded_columns;
+	}
 
 protected:
 	TableCatalogEntry &table;
 	PartialBlockManager &partial_block_manager;
 	vector<CompressionType> compression_types;
+	unordered_set<idx_t> has_unloaded_columns;
 };
 
 // Writes data for an entire row group.

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1252,7 +1252,8 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 		// merge row group stats into the global stats
 		auto lock = global_stats.GetLock();
 		for (idx_t column_idx = 0; column_idx < GetColumnCount(); column_idx++) {
-			if (is_loaded && !is_loaded[column_idx]) {
+			if (is_loaded && !is_loaded[column_idx] &&
+			    collection.get().GetTypes()[column_idx].id() != LogicalTypeId::VARIANT) {
 				// column is not loaded from disk - don't load just to update stats
 				writer.SetHasUnloadedColumn(column_idx);
 				continue;

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1252,6 +1252,11 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 		// merge row group stats into the global stats
 		auto lock = global_stats.GetLock();
 		for (idx_t column_idx = 0; column_idx < GetColumnCount(); column_idx++) {
+			if (is_loaded && !is_loaded[column_idx]) {
+				// column is not loaded from disk - don't load just to update stats
+				writer.SetHasUnloadedColumn(column_idx);
+				continue;
+			}
 			GetColumn(column_idx).MergeIntoStatistics(global_stats.GetStats(*lock, column_idx).Statistics());
 		}
 		return row_group_pointer;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1546,6 +1546,7 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 
 	idx_t new_total_rows = 0;
 	bool skipped_row_groups = false;
+	unordered_set<idx_t> columns_with_incomplete_stats;
 	for (idx_t segment_idx = 0; segment_idx < checkpoint_state.SegmentCount(); segment_idx++) {
 		auto entry = checkpoint_state.GetSegment(segment_idx);
 		if (!entry) {
@@ -1589,10 +1590,15 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 			}
 			auto pointer =
 			    row_group.Checkpoint(std::move(row_group_write_data), *row_group_writer, global_stats, row_start);
-
 			if (debug_verify_blocks) {
 				pointer_copy = pointer;
 			}
+			// for any columns that are not yet loaded add them to the list of columns with incomplete stats
+			auto unloaded_columns = row_group_writer->GetUnloadedColumns();
+			for (auto &column_idx : unloaded_columns) {
+				columns_with_incomplete_stats.insert(column_idx);
+			}
+
 			writer.AddRowGroup(std::move(pointer), std::move(row_group_writer));
 		} else {
 			debug_verify_blocks = false;
@@ -1711,6 +1717,16 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 				throw InternalException("Reloading deletes blocks just written does not yield same blocks: " +
 				                        oss.str());
 			}
+		}
+	}
+	if (!columns_with_incomplete_stats.empty()) {
+		// for any columns that have incomplete stats we need to merge in the previous global stats to ensure the stats
+		// are correct
+		auto lock = global_stats.GetLock();
+		for (auto &column_idx : columns_with_incomplete_stats) {
+			auto stats_lock = stats.GetLock();
+			auto &column_stats = stats.GetStats(*stats_lock, column_idx);
+			global_stats.MergeStats(*lock, column_idx, column_stats.Statistics());
 		}
 	}
 	l.Release();


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/19932 changed the way we compute stats during checkpointing by starting from scratch instead of starting from the original statistics. However, when checkpointing a table that has many unloaded columns, this now forces loading all of those columns from disk in order to re-compute the global stats. This can cause a significant performance hit and memory spike for very large tables and slow down checkpointing.

This PR changes this behavior to instead only re-compute stats (1) when all column metadata is already loaded (i.e. we don't load metadata just to re-compute stats), or (2) when the column is of type variant (as the global stats for variant columns will always be `INCONSISTENT` after unshredded insertions we will otherwise not have correct global stats). If this is not the case, we will fallback to the previous method of starting with the previous global stats, which might lead to stats that are "too wide" (e.g. min/max might still point to a vacuumed row) - but the stats will still be correct.