### PR TITLE
Disable extension caching for v1.4 to free github cache space

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -88,7 +88,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  BRANCHES_TO_BE_CACHED: ${{ github.repository == 'duckdb/duckdb' && '["refs/heads/main", "refs/heads/v1.4-andium"]' || ''}}
+  BRANCHES_TO_BE_CACHED: ''
 
 jobs:
   check-draft:


### PR DESCRIPTION
This v1.4 branch is still saving ccache artifacts of extension builds. Those cache entries use 7.6 GiB of the github repo cache (max 50 GiB):
```shell
PAGER= gh cache list --repo duckdb/duckdb --limit 1000 --ref 'refs/heads/v1.4-andium' --json 'sizeInBytes' --jq 'map(.sizeInBytes) | add / 1024/1024/1024'
7.56
```

This PR disables saving those cache entries to have more github cache space available for more important branches/CI jobs.