### PR TITLE
Avoid misleading GetRequestInfo constructor that takes endpoint + path

### DIFF
--- a/.github/config/extensions/httpfs.cmake
+++ b/.github/config/extensions/httpfs.cmake
@@ -1,5 +1,5 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG e809d0b09222849f358cbc54dd8b3eeba9c9d947
+    GIT_TAG 74f954001f3a740c909181b02259de6c7b942632
 )

--- a/src/include/duckdb/common/http_util.hpp
+++ b/src/include/duckdb/common/http_util.hpp
@@ -132,10 +132,6 @@ public:
 
 struct BaseRequest {
 	BaseRequest(RequestType type, const string &url, const HTTPHeaders &headers, HTTPParams &params);
-	BaseRequest(RequestType type, const string &endpoint_p, const string &path_p, const HTTPHeaders &headers,
-	            HTTPParams &params)
-	    : type(type), url(path), path(path_p), proto_host_port(endpoint_p), headers(headers), params(params) {
-	}
 
 	RequestType type;
 	const string &url;
@@ -175,12 +171,6 @@ struct GetRequestInfo : public BaseRequest {
 	               std::function<bool(const_data_ptr_t data, idx_t data_length)> content_handler_p)
 	    : BaseRequest(RequestType::GET_REQUEST, url, headers, params), content_handler(std::move(content_handler_p)),
 	      response_handler(std::move(response_handler_p)) {
-	}
-	GetRequestInfo(const string &endpoint, const string &path, const HTTPHeaders &headers, HTTPParams &params,
-	               std::function<bool(const HTTPResponse &response)> response_handler_p,
-	               std::function<bool(const_data_ptr_t data, idx_t data_length)> content_handler_p)
-	    : BaseRequest(RequestType::GET_REQUEST, endpoint, path, headers, params),
-	      content_handler(std::move(content_handler_p)), response_handler(std::move(response_handler_p)) {
 	}
 
 	std::function<bool(const_data_ptr_t data, idx_t data_length)> content_handler;


### PR DESCRIPTION
It can be misused given it's unclear whether path it's relative or absolute, and I think it's a cleaner API to require a single absolute path. That's also the API currently used by the sibling classes HeadRequestInfo, PostRequestInfo & co.

This should fix https://github.com/duckdb/duckdb/issues/21116, and would have prevented other API misuse that I had already solved over time.

Relevant duckdb-httpfs PR to apply the patch it's already at https://github.com/duckdb/duckdb-httpfs/pull/268.

What the CI tests it's whether any other extensions relies in this pattern (in case, they also need patching).