### PR TITLE
bump azure ref for v1.5.0, include bug fix ...

### DIFF
--- a/.github/config/extensions/azure.cmake
+++ b/.github/config/extensions/azure.cmake
@@ -2,6 +2,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
   duckdb_extension_load(azure
         LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb-azure
-        GIT_TAG 8a2879283ba2030967c59cc92e2d6c19d6b4f820
+        GIT_TAG 83789c4ee6d145b5747eeed30f7fc167f483b5a0
   )
 endif()


### PR DESCRIPTION
this bump will include the recent bugfix duckdb/duckdb-azure#151 which fixes rare double-append write corruption.