### PR TITLE
Remove lazy-loading of compression functions via cache

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1169,25 +1169,6 @@ CompressedMaterializationDirection EnumUtil::FromString<CompressedMaterializatio
 	return static_cast<CompressedMaterializationDirection>(StringUtil::StringToEnum(GetCompressedMaterializationDirectionValues(), 3, "CompressedMaterializationDirection", value));
 }
 
-const StringUtil::EnumStringLiteral *GetCompressionFunctionSetLoadResultValues() {
-	static constexpr StringUtil::EnumStringLiteral values[] {
-		{ static_cast<uint32_t>(CompressionFunctionSetLoadResult::ALREADY_LOADED_BEFORE_LOCK), "ALREADY_LOADED_BEFORE_LOCK" },
-		{ static_cast<uint32_t>(CompressionFunctionSetLoadResult::ALREADY_LOADED_AFTER_LOCK), "ALREADY_LOADED_AFTER_LOCK" },
-		{ static_cast<uint32_t>(CompressionFunctionSetLoadResult::LAZILY_LOADED), "LAZILY_LOADED" }
-	};
-	return values;
-}
-
-template<>
-const char* EnumUtil::ToChars<CompressionFunctionSetLoadResult>(CompressionFunctionSetLoadResult value) {
-	return StringUtil::EnumToString(GetCompressionFunctionSetLoadResultValues(), 3, "CompressionFunctionSetLoadResult", static_cast<uint32_t>(value));
-}
-
-template<>
-CompressionFunctionSetLoadResult EnumUtil::FromString<CompressionFunctionSetLoadResult>(const char *value) {
-	return static_cast<CompressionFunctionSetLoadResult>(StringUtil::StringToEnum(GetCompressionFunctionSetLoadResultValues(), 3, "CompressionFunctionSetLoadResult", value));
-}
-
 const StringUtil::EnumStringLiteral *GetCompressionTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(CompressionType::COMPRESSION_AUTO), "AUTO" },

--- a/src/function/compression_config.cpp
+++ b/src/function/compression_config.cpp
@@ -84,11 +84,31 @@ idx_t CompressionFunctionSet::GetCompressionIndex(CompressionType type) {
 }
 
 CompressionFunctionSet::CompressionFunctionSet() {
-	for (idx_t i = 0; i < PHYSICAL_TYPE_COUNT; i++) {
-		is_loaded[i] = false;
-	}
 	ResetDisabledMethods();
 	functions.resize(PHYSICAL_TYPE_COUNT);
+
+	static PhysicalType physical_types[PHYSICAL_TYPE_COUNT] = {
+	    PhysicalType::BOOL,    PhysicalType::UINT8,    PhysicalType::INT8,   PhysicalType::UINT16, PhysicalType::INT16,
+	    PhysicalType::UINT32,  PhysicalType::INT32,    PhysicalType::UINT64, PhysicalType::INT64,  PhysicalType::FLOAT,
+	    PhysicalType::DOUBLE,  PhysicalType::INTERVAL, PhysicalType::LIST,   PhysicalType::STRUCT, PhysicalType::ARRAY,
+	    PhysicalType::VARCHAR, PhysicalType::UINT128,  PhysicalType::INT128, PhysicalType::BIT,
+	};
+	for (idx_t type_index = 0; type_index < PHYSICAL_TYPE_COUNT; type_index++) {
+		const auto physical_type = physical_types[type_index];
+		const auto index = GetCompressionIndex(physical_type);
+		auto &function_list = functions[index];
+
+		for (idx_t method_index = 0; internal_compression_methods[method_index].get_function; method_index++) {
+			auto &method = internal_compression_methods[method_index];
+			if (!method.supports_type(physical_type)) {
+				// Not supported for this type.
+				continue;
+			}
+			// The type is supported.
+			// We create the function and insert it into the set of available functions.
+			function_list.push_back(method.get_function(physical_type));
+		}
+	}
 }
 
 bool EmitCompressionFunction(CompressionType type) {
@@ -113,14 +133,12 @@ bool EmitCompressionFunction(CompressionType type) {
 
 vector<reference<const CompressionFunction>>
 CompressionFunctionSet::GetCompressionFunctions(PhysicalType physical_type) {
-	LoadCompressionFunctions(physical_type);
-	auto index = GetCompressionIndex(physical_type);
+	const auto index = GetCompressionIndex(physical_type);
 	auto &function_list = functions[index];
 	vector<reference<const CompressionFunction>> result;
 	for (auto &entry : function_list) {
-		auto compression_index = GetCompressionIndex(entry.type);
+		const auto compression_index = GetCompressionIndex(entry.type);
 		if (is_disabled[compression_index]) {
-			// explicitly disabled
 			continue;
 		}
 		if (!EmitCompressionFunction(entry.type)) {
@@ -131,50 +149,22 @@ CompressionFunctionSet::GetCompressionFunctions(PhysicalType physical_type) {
 	return result;
 }
 
-CompressionFunctionSetLoadResult CompressionFunctionSet::LoadCompressionFunctions(PhysicalType physical_type) {
-	auto index = GetCompressionIndex(physical_type);
-	if (is_loaded[index]) {
-		return CompressionFunctionSetLoadResult::ALREADY_LOADED_BEFORE_LOCK;
-	}
-	// not loaded - try to load it
-	lock_guard<mutex> guard(lock);
-	// verify nobody loaded it in the mean-time
-	if (is_loaded[index]) {
-		return CompressionFunctionSetLoadResult::ALREADY_LOADED_AFTER_LOCK;
-	}
-	// actually perform the load
-	auto &function_list = functions[index];
-	for (idx_t i = 0; internal_compression_methods[i].get_function; i++) {
-		auto &method = internal_compression_methods[i];
-		if (!method.supports_type(physical_type)) {
-			// not supported for this type
-			continue;
-		}
-		// The type is supported. We create the function and insert it into the set of available functions.
-		function_list.push_back(method.get_function(physical_type));
-	}
-	is_loaded[index] = true;
-	return CompressionFunctionSetLoadResult::LAZILY_LOADED;
-}
-
-pair<CompressionFunctionSetLoadResult, optional_ptr<const CompressionFunction>>
+optional_ptr<const CompressionFunction>
 CompressionFunctionSet::GetCompressionFunction(CompressionType type, const PhysicalType physical_type) {
-	const auto load_result = LoadCompressionFunctions(physical_type);
-
 	const auto index = GetCompressionIndex(physical_type);
 	const auto &function_list = functions[index];
 	for (auto &function : function_list) {
 		if (function.type == type) {
-			return make_pair(load_result, &function);
+			return &function;
 		}
 	}
-	return make_pair(load_result, nullptr);
+	return nullptr;
 }
 
 void CompressionFunctionSet::SetDisabledCompressionMethods(const vector<CompressionType> &methods) {
 	ResetDisabledMethods();
 	for (auto &method : methods) {
-		auto idx = GetCompressionIndex(method);
+		const auto idx = GetCompressionIndex(method);
 		is_disabled[idx] = true;
 	}
 }
@@ -193,55 +183,6 @@ vector<CompressionType> CompressionFunctionSet::GetDisabledCompressionMethods() 
 	return result;
 }
 
-string CompressionFunctionSet::GetDebugInfo() const {
-	static PhysicalType physical_types[PHYSICAL_TYPE_COUNT] = {
-	    PhysicalType::BOOL,    PhysicalType::UINT8,    PhysicalType::INT8,   PhysicalType::UINT16, PhysicalType::INT16,
-	    PhysicalType::UINT32,  PhysicalType::INT32,    PhysicalType::UINT64, PhysicalType::INT64,  PhysicalType::FLOAT,
-	    PhysicalType::DOUBLE,  PhysicalType::INTERVAL, PhysicalType::LIST,   PhysicalType::STRUCT, PhysicalType::ARRAY,
-	    PhysicalType::VARCHAR, PhysicalType::UINT128,  PhysicalType::INT128, PhysicalType::BIT,
-	};
-
-	vector<string> compression_type_debug_infos;
-	for (idx_t i = 0; i < COMPRESSION_TYPE_COUNT; i++) {
-		compression_type_debug_infos.push_back(
-		    StringUtil::Format("%llu: {compression type: %s, is disabled: %llu}", i,
-		                       EnumUtil::ToString(internal_compression_methods[i].type), is_disabled[i].load()));
-	}
-
-	lock_guard<mutex> guard(lock);
-	vector<string> physical_type_debug_infos;
-	for (idx_t index = 0; index < PHYSICAL_TYPE_COUNT; index++) {
-		const auto &physical_type = physical_types[index];
-		D_ASSERT(GetCompressionIndex(physical_type) == index);
-
-		idx_t out_of = 0;
-		for (idx_t i = 0; internal_compression_methods[i].get_function; i++) {
-			auto &method = internal_compression_methods[i];
-			if (method.supports_type(physical_type)) {
-				out_of++;
-			}
-		}
-
-		const auto &function_list = functions[index];
-		vector<string> function_list_debug_infos;
-		for (idx_t function_index = 0; function_index < function_list.size(); function_index++) {
-			auto &function = function_list[function_index];
-			function_list_debug_infos.push_back(StringUtil::Format("%llu: {compression type: %s, physical type: %s}",
-			                                                       function_index, EnumUtil::ToString(function.type),
-			                                                       EnumUtil::ToString(function.data_type)));
-		}
-
-		physical_type_debug_infos.push_back(StringUtil::Format(
-		    "%llu: {physical type: %s, loaded: %llu, loaded functions: %llu (out of: %llu)}\t\t%s", index,
-		    EnumUtil::ToString(physical_type), is_loaded[index].load(), function_list.size(), out_of,
-		    function_list_debug_infos.empty() ? "" : "\n\t\t" + StringUtil::Join(function_list_debug_infos, "\n\t\t")));
-	}
-
-	return StringUtil::Format("DEBUG INFO:\n - Compression types:\n\t%s\n\n - Physical types:\n\t%s",
-	                          StringUtil::Join(compression_type_debug_infos, "\n\t"),
-	                          StringUtil::Join(physical_type_debug_infos, "\n\t"));
-}
-
 vector<CompressionType> DBConfig::GetDisabledCompressionMethods() const {
 	return compression_functions->GetDisabledCompressionMethods();
 }
@@ -258,18 +199,17 @@ vector<reference<const CompressionFunction>> DBConfig::GetCompressionFunctions(c
 
 optional_ptr<const CompressionFunction> DBConfig::TryGetCompressionFunction(CompressionType type,
                                                                             const PhysicalType physical_type) const {
-	return compression_functions->GetCompressionFunction(type, physical_type).second;
+	return compression_functions->GetCompressionFunction(type, physical_type);
 }
 
 reference<const CompressionFunction> DBConfig::GetCompressionFunction(CompressionType type,
                                                                       const PhysicalType physical_type) const {
 	auto result = compression_functions->GetCompressionFunction(type, physical_type);
-	if (!result.second) {
+	if (!result) {
 		throw InternalException(
 		    "Could not find compression function \"%s\" for physical type \"%s\". Load result: %s. %s",
-		    EnumUtil::ToString(type), EnumUtil::ToString(physical_type), EnumUtil::ToString(result.first),
-		    compression_functions->GetDebugInfo());
+		    EnumUtil::ToString(type), EnumUtil::ToString(physical_type));
 	}
-	return *result.second;
+	return *result;
 }
 } // namespace duckdb

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -128,8 +128,6 @@ enum class ColumnSegmentType : uint8_t;
 
 enum class CompressedMaterializationDirection : uint8_t;
 
-enum class CompressionFunctionSetLoadResult : uint8_t;
-
 enum class CompressionType : uint8_t;
 
 enum class CompressionValidity : uint8_t;
@@ -648,9 +646,6 @@ const char* EnumUtil::ToChars<ColumnSegmentType>(ColumnSegmentType value);
 
 template<>
 const char* EnumUtil::ToChars<CompressedMaterializationDirection>(CompressedMaterializationDirection value);
-
-template<>
-const char* EnumUtil::ToChars<CompressionFunctionSetLoadResult>(CompressionFunctionSetLoadResult value);
 
 template<>
 const char* EnumUtil::ToChars<CompressionType>(CompressionType value);
@@ -1357,9 +1352,6 @@ ColumnSegmentType EnumUtil::FromString<ColumnSegmentType>(const char *value);
 
 template<>
 CompressedMaterializationDirection EnumUtil::FromString<CompressedMaterializationDirection>(const char *value);
-
-template<>
-CompressionFunctionSetLoadResult EnumUtil::FromString<CompressionFunctionSetLoadResult>(const char *value);
 
 template<>
 CompressionType EnumUtil::FromString<CompressionType>(const char *value);

--- a/src/include/duckdb/function/compression_function.hpp
+++ b/src/include/duckdb/function/compression_function.hpp
@@ -329,12 +329,6 @@ public:
 	CompressionValidity validity = CompressionValidity::REQUIRES_VALIDITY;
 };
 
-enum class CompressionFunctionSetLoadResult : uint8_t {
-	ALREADY_LOADED_BEFORE_LOCK,
-	ALREADY_LOADED_AFTER_LOCK,
-	LAZILY_LOADED,
-};
-
 //! The set of compression functions
 struct CompressionFunctionSet {
 	static constexpr idx_t COMPRESSION_TYPE_COUNT = 15;
@@ -344,20 +338,15 @@ public:
 	CompressionFunctionSet();
 
 	vector<reference<const CompressionFunction>> GetCompressionFunctions(PhysicalType physical_type);
-	pair<CompressionFunctionSetLoadResult, optional_ptr<const CompressionFunction>>
-	GetCompressionFunction(CompressionType type, PhysicalType physical_type);
+	optional_ptr<const CompressionFunction> GetCompressionFunction(CompressionType type, PhysicalType physical_type);
 	void SetDisabledCompressionMethods(const vector<CompressionType> &methods);
 	vector<CompressionType> GetDisabledCompressionMethods() const;
-	string GetDebugInfo() const;
 
 private:
-	mutable mutex lock;
 	atomic<bool> is_disabled[COMPRESSION_TYPE_COUNT];
-	atomic<bool> is_loaded[PHYSICAL_TYPE_COUNT];
 	vector<vector<CompressionFunction>> functions;
 
 private:
-	CompressionFunctionSetLoadResult LoadCompressionFunctions(PhysicalType physical_type);
 	static idx_t GetCompressionIndex(PhysicalType physical_type);
 	static idx_t GetCompressionIndex(CompressionType type);
 	void ResetDisabledMethods();

--- a/src/include/duckdb/function/compression_function.hpp
+++ b/src/include/duckdb/function/compression_function.hpp
@@ -331,7 +331,7 @@ public:
 
 //! The set of compression functions
 struct CompressionFunctionSet {
-	static constexpr idx_t COMPRESSION_TYPE_COUNT = 15;
+	static constexpr idx_t COMPRESSION_TYPE_COUNT = 16;
 	static constexpr idx_t PHYSICAL_TYPE_COUNT = 19;
 
 public:

--- a/src/storage/compression/uncompressed.cpp
+++ b/src/storage/compression/uncompressed.cpp
@@ -30,8 +30,29 @@ CompressionFunction UncompressedFun::GetFunction(PhysicalType type) {
 	}
 }
 
-bool UncompressedFun::TypeIsSupported(const PhysicalType) {
-	return true;
+bool UncompressedFun::TypeIsSupported(const PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::INT128:
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+	case PhysicalType::UINT128:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+	case PhysicalType::LIST:
+	case PhysicalType::INTERVAL:
+	case PhysicalType::BIT:
+	case PhysicalType::VARCHAR:
+		return true;
+	default:
+		return false;
+	}
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Related issue: https://github.com/duckdblabs/duckdb-internal/issues/7400