### PR TITLE
Enable MySQL scanner builds with musl libc

### DIFF
--- a/.github/config/extensions/mysql_scanner.cmake
+++ b/.github/config/extensions/mysql_scanner.cmake
@@ -1,4 +1,4 @@
-if (NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
+if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(mysql_scanner
             DONT_LINK
             LOAD_TESTS


### PR DESCRIPTION
Historically the MySQL scanner, unlike other scanners, was not built for Linux with musl libc. It is suggested to enable such builds.

Note, that due to an oversight in #20537 the musl platform check was not effective for `linux_arm64_musl` (fix in #21161), so MySQL scanner for 1.5.0 was successfully built and is functional on AArch64 Linux with musl libc. Thus this change only additionally enables it for x86_64 with musl libc.