### PR TITLE
Report host in HTTPUtil error responses

### DIFF
--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -444,11 +444,12 @@ HTTPUtil::RunRequestWithRetry(const std::function<unique_ptr<HTTPResponse>(void)
 			if (caught_e) {
 				std::rethrow_exception(caught_e);
 			} else if (response && !response->HasRequestError()) {
-				throw HTTPException(*response, "Request returned HTTP %d for HTTP %s to '%s'",
-				                    static_cast<int>(response->status), method, request.url);
+				throw HTTPException(*response, "Request returned HTTP %d for HTTP %s to '%s' (host '%s')",
+				                    static_cast<int>(response->status), method, request.url, request.proto_host_port);
 			} else {
 				string error = response ? response->GetError() : "Unknown error";
-				throw IOException("%s error for HTTP %s to '%s'", error, method, request.url);
+				throw IOException("%s error for HTTP %s to '%s' (host '%s')", error, method, request.url,
+				                  request.proto_host_port);
 			}
 		}
 	}


### PR DESCRIPTION
Currently if these errors are thrown we might get an error like this:

```
IO Error:
Could not resolve hostname error for HTTP GET to '/?encoding-type=url&list-type=2&prefix=catalog_returns%2F'
```

Often it helps to know the host the request was send to. After this, this error now looks like this:

```
IO Error:
Could not resolve hostname error for HTTP GET to '/?encoding-type=url&list-type=2&prefix=catalog_returns%2F' (host 'http://ducklake-partition-test.duckdb-minio.com:9000')
```

In my case, this reveals I was accidentally sending requests to a local testing server instead of to S3.