### PR TITLE
Disable save_cache for v1.4-andium

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -88,7 +88,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  BRANCHES_TO_BE_CACHED: ''
+  BRANCHES_TO_BE_CACHED: ${{ github.repository == 'duckdb/duckdb' && '[]' || ''}}
 
 jobs:
   check-draft:


### PR DESCRIPTION
This is a follow-up of https://github.com/duckdb/duckdb/pull/21150, which did not work as intended.

Apparently, `''` means that `save_cache` becomes `true` and thus [saves](https://github.com/duckdb/duckdb/actions/runs/22649852740/job/65646618763#step:27:2) the cache.

The logic is defined [here](https://github.com/smvv/duckdb/blob/8c8b6f8e12c0e5c467c197a3f9323e3e99109058/.github/workflows/Extensions.yml#L195):
```yaml
  main-extensions:
    name: Main Extensions
    needs:
      - load-extension-configs
      - vars
    uses: ./.github/workflows/_extension_distribution.yml
    with:
      artifact_prefix: main-extensions
      # ...
      save_cache: ${{ needs.vars.outputs.BRANCHES_TO_BE_CACHED == '' || contains(needs.vars.outputs.BRANCHES_TO_BE_CACHED, github.ref) }}
```

So, we need `'[]'` to make the list empty instead of using an empty string.