### PR TITLE
Enable column pruning for `MATERIALIZED` CTEs

### DIFF
--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -14,6 +14,10 @@
 #include "duckdb/common/column_index.hpp"
 #include "duckdb/common/column_index_map.hpp"
 
+#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/optimizer/column_binding_replacer.hpp"
+
 namespace duckdb {
 class Binder;
 class BoundColumnRefExpression;
@@ -69,6 +73,12 @@ enum class BaseColumnPrunerMode : uint8_t {
 	DISABLE_PUSHDOWN_EXTRACT
 };
 
+struct MaterializedCTEInfo {
+public:
+	column_binding_map_t<ReferencedColumn> column_references;
+	bool everything_referenced = true;
+};
+
 class BaseColumnPruner : public LogicalOperatorVisitor {
 protected:
 	void VisitExpression(unique_ptr<Expression> *expression) override;
@@ -116,8 +126,9 @@ private:
 //! The RemoveUnusedColumns optimizer traverses the logical operator tree and removes any columns that are not required
 class RemoveUnusedColumns : public BaseColumnPruner {
 public:
-	RemoveUnusedColumns(Binder &binder, ClientContext &context, bool is_root = false)
-	    : binder(binder), context(context), everything_referenced(is_root) {
+	RemoveUnusedColumns(Binder &binder, ClientContext &context, bool is_root = false,
+	                    shared_ptr<unordered_map<idx_t, MaterializedCTEInfo>> cte_info_map = nullptr)
+	    : binder(binder), context(context), everything_referenced(is_root), cte_info_map(cte_info_map) {
 	}
 
 	void VisitOperator(LogicalOperator &op) override;
@@ -129,6 +140,9 @@ private:
 	//! output implicitly refers all the columns below it)
 	bool everything_referenced;
 
+	shared_ptr<unordered_map<idx_t, MaterializedCTEInfo>> cte_info_map;
+	RemoveUnusedColumns CreateChildOptimizer();
+
 private:
 	template <class T>
 	void ClearUnusedExpressions(vector<T> &list, idx_t table_idx, bool replace = true);
@@ -139,4 +153,19 @@ private:
 	    const ColumnBinding &binding, ReferencedColumn &col, idx_t original_idx, const LogicalType &column_type,
 	    const std::function<idx_t(const ColumnIndex &new_index, optional_ptr<const LogicalType> cast_type)> &callback);
 };
+
+class CTERefPruner : public LogicalOperatorVisitor {
+public:
+	CTERefPruner(const idx_t table_index, const unordered_set<idx_t> &referenced_columns);
+
+	void VisitOperator(LogicalOperator &op) override;
+
+private:
+	const idx_t cte_index;
+	const unordered_set<idx_t> &referenced_columns;
+
+public:
+	vector<ReplacementBinding> binding_replacements;
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -128,7 +128,7 @@ class RemoveUnusedColumns : public BaseColumnPruner {
 public:
 	RemoveUnusedColumns(Binder &binder, ClientContext &context, bool is_root = false,
 	                    shared_ptr<unordered_map<idx_t, MaterializedCTEInfo>> cte_info_map = nullptr)
-	    : binder(binder), context(context), everything_referenced(is_root), cte_info_map(cte_info_map) {
+	    : binder(binder), context(context), everything_referenced(is_root), cte_info_map(std::move(cte_info_map)) {
 	}
 
 	void VisitOperator(LogicalOperator &op) override;

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -354,8 +354,10 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			ColumnBindingReplacer column_binding_replacer;
 			column_binding_replacer.replacement_bindings = cte_ref_pruner.binding_replacements;
 			column_binding_replacer.VisitOperator(*cte.children[1]);
+			return;
 		}
-		return;
+		everything_referenced = true;
+		break;
 	}
 	case LogicalOperatorType::LOGICAL_CTE_REF: {
 		auto &cte_ref = op.Cast<LogicalCTERef>();

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -22,12 +22,18 @@
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_set_operation.hpp"
 #include "duckdb/planner/operator/logical_simple.hpp"
+#include "duckdb/planner/operator/logical_cte.hpp"
+#include "duckdb/planner/operator/logical_cteref.hpp"
 #include "duckdb/function/scalar/struct_utils.hpp"
 #include "duckdb/function/scalar/variant_utils.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include <utility>
 
 namespace duckdb {
+
+RemoveUnusedColumns RemoveUnusedColumns::CreateChildOptimizer() {
+	return RemoveUnusedColumns(binder, context, true, cte_info_map);
+}
 
 idx_t BaseColumnPruner::ReplaceBinding(ColumnBinding current_binding, ColumnBinding new_binding) {
 	auto colrefs = column_references.find(current_binding);
@@ -111,7 +117,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		// Note: We allow all optimizations (join column replacement, column pruning) to run below ROLLUP
 		// The duplicate groups optimizer will be responsible for not breaking ROLLUP by skipping when
 		// multiple grouping sets are present
-		RemoveUnusedColumns remove(binder, context, everything_referenced);
+		RemoveUnusedColumns remove(binder, context, everything_referenced, cte_info_map);
 		remove.VisitOperatorExpressions(op);
 		remove.VisitOperator(*op.children[0]);
 		return;
@@ -190,7 +196,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			setop.column_count = entries.size();
 
 			for (idx_t child_idx = 0; child_idx < op.children.size(); child_idx++) {
-				RemoveUnusedColumns remove(binder, context, true);
+				RemoveUnusedColumns remove(binder, context, true, cte_info_map);
 				auto &child = op.children[child_idx];
 
 				// we push a projection under this child that references the required columns of the union
@@ -214,7 +220,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			return;
 		}
 		for (auto &child : op.children) {
-			RemoveUnusedColumns remove(binder, context, true);
+			RemoveUnusedColumns remove(binder, context, true, cte_info_map);
 			remove.VisitOperator(*child);
 		}
 		return;
@@ -223,7 +229,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_INTERSECT: {
 		// for INTERSECT/EXCEPT operations we can't remove anything, just recursively visit the children
 		for (auto &child : op.children) {
-			RemoveUnusedColumns remove(binder, context, true);
+			RemoveUnusedColumns remove(binder, context, true, cte_info_map);
 			remove.VisitOperator(*child);
 		}
 		return;
@@ -244,7 +250,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			}
 		}
 		// then recurse into the children of this projection
-		RemoveUnusedColumns remove(binder, context);
+		RemoveUnusedColumns remove(binder, context, false, cte_info_map);
 		remove.VisitOperatorExpressions(op);
 		remove.VisitOperator(*op.children[0]);
 		return;
@@ -258,7 +264,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		//! on top of them can select from only the table values being inserted.
 		//! TODO: Push down the projections from the returning statement
 		//! TODO: Be careful because you might be adding expressions when a user returns *
-		RemoveUnusedColumns remove(binder, context, true);
+		RemoveUnusedColumns remove(binder, context, true, cte_info_map);
 		remove.VisitOperatorExpressions(op);
 		remove.VisitOperator(*op.children[0]);
 		return;
@@ -270,7 +276,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		if (!op.children.empty()) {
 			// Some LOGICAL_GET operators (e.g., table in out functions) may have a
 			// child operator. So we recurse into it if it exists.
-			RemoveUnusedColumns remove(binder, context, true);
+			RemoveUnusedColumns remove(binder, context, true, cte_info_map);
 			remove.VisitOperator(*op.children[0]);
 		}
 		return;
@@ -288,9 +294,93 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		everything_referenced = true;
 		break;
 	}
-	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE:
-	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
-	case LogicalOperatorType::LOGICAL_CTE_REF:
+	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE: {
+		// We do not (yet) support pruning columns in recursive CTEs, so we mark everything as referenced and continue
+		// to the children. However, we still need to create the cte_info_map for the recursive CTE so that column
+		// references in the CTE body can find the correct CTE entry and mark columns as referenced.
+		auto &rec = op.Cast<LogicalCTE>();
+		if (!cte_info_map) {
+			cte_info_map = make_shared_ptr<unordered_map<idx_t, MaterializedCTEInfo>>();
+		}
+		auto &cte_map_entry = (*cte_info_map)[rec.table_index];
+		everything_referenced = true;
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE: {
+		if (!cte_info_map) {
+			cte_info_map = make_shared_ptr<unordered_map<idx_t, MaterializedCTEInfo>>();
+		}
+
+		auto &cte_map_ref = *cte_info_map;
+		auto &cte = op.Cast<LogicalCTE>();
+		auto &cte_map_entry = cte_map_ref[cte.table_index];
+
+		auto rhs_child_optimizer = CreateChildOptimizer();
+		rhs_child_optimizer.VisitOperator(*cte.children[1]);
+
+		unordered_set<idx_t> referenced_columns_in_rhs;
+		for (auto &entry : cte_map_entry.column_references) {
+			referenced_columns_in_rhs.insert(entry.first.column_index);
+		}
+
+		if (!cte_map_entry.everything_referenced) {
+			auto lhs_child_optimizer = CreateChildOptimizer();
+
+			// Construct a projection on top of the left-hand side of the CTE
+			// that only projects the columns that are referenced in the right-hand side of the CTE
+			cte.children[0]->ResolveOperatorTypes();
+			auto bindings = cte.children[0]->GetColumnBindings();
+			vector<unique_ptr<Expression>> expressions;
+			for (idx_t i = 0; i < bindings.size(); i++) {
+				if (referenced_columns_in_rhs.find(i) != referenced_columns_in_rhs.end()) {
+					expressions.push_back(make_uniq<BoundColumnRefExpression>(cte.children[0]->types[i], bindings[i]));
+				}
+			}
+
+			auto projection = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(expressions));
+			projection->children.push_back(std::move(cte.children[0]));
+			cte.children[0] = std::move(projection);
+
+			lhs_child_optimizer.VisitOperator(*cte.children[0]);
+
+			// After pruning the left-hand side of the CTE, we need to rewrite the CTE references to account for the
+			// removed columns.
+			CTERefPruner cte_ref_pruner(cte.table_index, referenced_columns_in_rhs);
+			cte_ref_pruner.VisitOperator(*cte.children[1]);
+
+			// We also need to rewrite the column bindings in the right-hand side of the CTE to account for the removed
+			// columns on the left-hand side. Conveniently, the CTERefPruner already has the information about which
+			// columns were removed, so we can reuse it for the column binding replacement.
+			ColumnBindingReplacer column_binding_replacer;
+			column_binding_replacer.replacement_bindings = cte_ref_pruner.binding_replacements;
+			column_binding_replacer.VisitOperator(*cte.children[1]);
+		}
+		return;
+	}
+	case LogicalOperatorType::LOGICAL_CTE_REF: {
+		auto &cte_ref = op.Cast<LogicalCTERef>();
+		if (!cte_info_map) {
+			throw InternalException("CTE reference found without CTE info map");
+		}
+		auto &cte_map_ref = *cte_info_map;
+		auto it = cte_map_ref.find(cte_ref.cte_index);
+		if (it == cte_map_ref.end()) {
+			throw InternalException("Could not find CTE definition for CTE reference");
+		}
+
+		for (auto &entry : column_references) {
+			if (entry.first.table_index == cte_ref.table_index) {
+				auto &referenced_column = entry.second;
+				auto &test = cte_map_ref[cte_ref.cte_index].column_references;
+				test.insert(entry);
+			}
+		}
+
+		cte_map_ref[cte_ref.cte_index].everything_referenced =
+		    cte_ref.chunk_types.size() == cte_map_ref[cte_ref.cte_index].column_references.size();
+
+		break;
+	}
 	case LogicalOperatorType::LOGICAL_COPY_TO_FILE:
 	case LogicalOperatorType::LOGICAL_PIVOT: {
 		everything_referenced = true;
@@ -711,6 +801,41 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get) {
 			}
 		}
 	}
+}
+
+CTERefPruner::CTERefPruner(const idx_t cte_index, const unordered_set<idx_t> &referenced_columns)
+    : cte_index(cte_index), referenced_columns(referenced_columns) {
+}
+
+void CTERefPruner::VisitOperator(LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_CTE_REF) {
+		auto &cte_ref = op.Cast<LogicalCTERef>();
+		if (cte_ref.cte_index != cte_index) {
+			return;
+		}
+		// We have to regenerate the chunk_types of the CTE reference to only include the referenced columns/
+		// Otherwise, we would run into issues during execution.
+		vector<LogicalType> types;
+		// We only prune, never reorder, so we can keep track of the new column indices by counting how many columns we
+		// skipped.
+		idx_t skipped = 0;
+		for (idx_t i = 0; i < cte_ref.chunk_types.size(); i++) {
+			if (referenced_columns.find(i) != referenced_columns.end()) {
+				// This column is referenced, keep it and add any necessary binding replacements for the skipped columns
+				// if necessary.
+				types.push_back(cte_ref.chunk_types[i]);
+				if (skipped > 0) {
+					binding_replacements.push_back(ReplacementBinding(ColumnBinding(cte_ref.table_index, i),
+					                                                  ColumnBinding(cte_ref.table_index, i - skipped)));
+				}
+			} else {
+				skipped++;
+			}
+		}
+		cte_ref.types = std::move(types);
+		cte_ref.chunk_types = cte_ref.types;
+	}
+	LogicalOperatorVisitor::VisitOperator(op);
 }
 
 void BaseColumnPruner::SetMode(BaseColumnPrunerMode mode) {

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -368,7 +368,8 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_CTE_REF: {
 		auto &cte_ref = op.Cast<LogicalCTERef>();
 		if (!cte_info_map) {
-			throw InternalException("CTE reference found without CTE info map");
+			everything_referenced = true;
+			break;
 		}
 		auto &cte_map_ref = *cte_info_map;
 		auto it = cte_map_ref.find(cte_ref.cte_index);

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -337,6 +337,12 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 				}
 			}
 
+			if (expressions.empty()) {
+				// no columns referenced, but we can not have an empty projection, as this would
+				// result in an empty left-hand side of the cte
+				break;
+			}
+
 			auto projection = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(expressions));
 			projection->children.push_back(std::move(cte.children[0]));
 			cte.children[0] = std::move(projection);

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -302,7 +302,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		if (!cte_info_map) {
 			cte_info_map = make_shared_ptr<unordered_map<idx_t, MaterializedCTEInfo>>();
 		}
-		auto &cte_map_entry = (*cte_info_map)[rec.table_index];
+		(*cte_info_map).insert({rec.table_index, MaterializedCTEInfo()});
 		everything_referenced = true;
 		break;
 	}
@@ -372,7 +372,6 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 
 		for (auto &entry : column_references) {
 			if (entry.first.table_index == cte_ref.table_index) {
-				auto &referenced_column = entry.second;
 				auto &test = cte_map_ref[cte_ref.cte_index].column_references;
 				test.insert(entry);
 			}

--- a/test/optimizer/unused_columns/cte_unused_columns.test
+++ b/test/optimizer/unused_columns/cte_unused_columns.test
@@ -1,0 +1,31 @@
+# name: test/optimizer/unused_columns/cte_unused_columns.test
+# description: Test that unused columns are removed from materialized CTEs
+# group: [unused_columns]
+
+statement ok
+CREATE TABLE o_order AS
+SELECT hash(range) col0,
+       hash(range) col1,
+       hash(range) col2,
+       hash(range) col3,
+       hash(range) col4,
+       hash(range) col5,
+       hash(range) col6,
+FROM range(10);
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+query II
+EXPLAIN
+WITH test AS MATERIALIZED (SELECT * FROM o_order)
+SELECT col0, col6 FROM test;
+----
+logical_opt	<!REGEX>:.*col[1-5].*
+
+query II
+EXPLAIN
+WITH test AS MATERIALIZED (SELECT * FROM o_order)
+SELECT col0, col6, t2.* FROM test, (SELECT col1 FROM test) t2;
+----
+logical_opt	<!REGEX>:.*col[2-5].*


### PR DESCRIPTION
Materialized CTEs previously just assumed that all columns were referenced, preventing column pruning.
This PR enables column pruning for `MATERIALIZED` CTEs (but not for `RECURSIVE` ones).

In the future, it may be possible to enable this for recursive CTEs, too. However, this is much more difficult, as we can not just blindly prune columns in that case, as this may break query semantics.

----

Fix: https://github.com/duckdb/duckdb/issues/20958
Fix: https://github.com/duckdblabs/duckdb-internal/issues/7467
Fix: https://github.com/duckdblabs/duckdb-internal/issues/7423