### PR TITLE
Stats fixes for https://github.com/duckdb/duckdb/issues/21160

### DIFF
--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -276,7 +276,13 @@ optional_ptr<SegmentNode<RowGroup>> RowGroupReorderer::GetRootSegment(RowGroupSe
 	}
 
 	if (row_group_map.empty()) {
-		return nullptr;
+		// All row groups have unknown stats - scan them all without reordering
+		for (auto &remaining_row_group : remaining_row_groups) {
+			ordered_row_groups.push_back(remaining_row_group);
+		}
+
+		// Recurse (just once, since we will go into the returning either nullptr or ordered_row_groups[0].get())
+		return GetRootSegment(row_groups);
 	}
 
 	D_ASSERT(row_group_map.size() > options.row_group_offset);

--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -203,6 +203,9 @@ Value RowGroupReorderer::RetrieveStat(const BaseStatistics &stats, OrderByStatis
 		}
 	}
 	if (column_type == OrderByColumnType::STRING) {
+		if (!stats.CanHaveNoNull()) {
+			return Value();
+		}
 		switch (order_by) {
 		case OrderByStatistics::MIN:
 			return StringStats::Min(stats);

--- a/test/sql/topn/test_null_string_stat.test
+++ b/test/sql/topn/test_null_string_stat.test
@@ -1,0 +1,22 @@
+# name: test/sql/topn/test_null_string_stat.test
+# description: Test Top-N on strings with no stats (https://github.com/duckdb/duckdb/issues/21160)
+# group: [topn]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE OR REPLACE TABLE t (id INTEGER, x VARCHAR, y DOUBLE);
+
+statement ok
+INSERT INTO t VALUES (1, NULL, NULL);
+
+query I
+SELECT id FROM t WHERE x IS NULL ORDER BY x;
+----
+1
+
+query I
+SELECT id FROM t WHERE x IS NULL ORDER BY x LIMIT 10;
+----
+1

--- a/test/sql/topn/test_top_n_where_null.test
+++ b/test/sql/topn/test_top_n_where_null.test
@@ -1,0 +1,22 @@
+# name: test/sql/topn/test_top_n_where_null.test
+# description: Test Top-N with NULL filtering (https://github.com/duckdb/duckdb/issues/21160)
+# group: [topn]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE OR REPLACE TABLE t (id INTEGER, x VARCHAR, y DOUBLE);
+
+statement ok
+INSERT INTO t VALUES (1, NULL, NULL);
+
+query I
+SELECT id FROM t WHERE x IS NULL ORDER BY y;
+----
+1
+
+query I
+SELECT id FROM t WHERE x IS NULL ORDER BY y LIMIT 10;
+----
+1


### PR DESCRIPTION
Two fixes handling bug reported at https://github.com/duckdb/duckdb/issues/21160.

Those influence reading path, that would mean existing (or future) databases might be read incorrectly in this cases. This, as far as I am aware, do not influence the writing path.

I tested also writing this data to a db file, both doing writing with 1.4.4 and reading with this commit and vice-versa, but I have not added such tests.

This is very much not my area of work, string part I am sort of confident it makes sense, `row_group_map.empty()` case looks sense to me / fixes the issues, but could use a critical eye.

Both are very limited in scope, so I am convinced they should not affect other code-paths in unintended ways.