### PR TITLE
Fixes compilation errors in PEG transformer

### DIFF
--- a/extension/autocomplete/include/parser/special_string_utils.hpp
+++ b/extension/autocomplete/include/parser/special_string_utils.hpp
@@ -10,7 +10,7 @@ struct SpecialStringInfo {
 	idx_t prefix_len;
 };
 
-static SpecialStringInfo GetSpecialStringInfo(const string &text) {
+inline SpecialStringInfo GetSpecialStringInfo(const string &text) {
 	if (text.empty()) {
 		return {SpecialStringCharacter::STANDARD, 0};
 	}

--- a/extension/autocomplete/include/transformer/parse_result.hpp
+++ b/extension/autocomplete/include/transformer/parse_result.hpp
@@ -350,6 +350,7 @@ public:
 			}
 			return make_uniq<ConstantExpression>(Value(escaped_result));
 		}
+		return make_uniq<ConstantExpression>(Value(result));
 	}
 
 	string result;

--- a/extension/autocomplete/transformer/transform_select.cpp
+++ b/extension/autocomplete/transformer/transform_select.cpp
@@ -1104,7 +1104,7 @@ unique_ptr<TableRef> PEGTransformerFactory::TransformParensTableRef(PEGTransform
 		subquery->column_name_alias = table_alias.column_name_alias;
 	}
 	transformer.TransformOptional<unique_ptr<SampleOptions>>(list_pr, 3, subquery->sample);
-	return subquery;
+	return std::move(subquery);
 }
 
 unique_ptr<AtClause> PEGTransformerFactory::TransformAtClause(PEGTransformer &transformer,


### PR DESCRIPTION
Fixes: https://github.com/duckdblabs/duckdb-internal/issues/7645

Fixes the following compilation errors/warnings found in this run https://github.com/duckdb/duckdb/actions/runs/22649853845/job/65646536521: 
Add a `std::move` (similar problem to https://github.com/duckdb/duckdb/pull/20810)
```
[9](https://github.com/duckdb/duckdb/actions/runs/22649853845/job/65646536521#step:3:1510)
/home/runner/work/duckdb/duckdb/extension/autocomplete/transformer/transform_select.cpp:1107:16: error: could not convert ‘subquery’ from ‘unique_ptr<duckdb::SubqueryRef,default_delete<duckdb::SubqueryRef>,[...]>’ to ‘unique_ptr<duckdb::TableRef,default_delete<duckdb::TableRef>,[...]>’
 1107 |         return subquery;
      |                ^~~~~~~~
      |                |
      |                unique_ptr<duckdb::SubqueryRef,default_delete<duckdb::SubqueryRef>,[...]>
```
Add a return (even though all the cases are covered in the switch)
```
/home/runner/work/duckdb/duckdb/extension/autocomplete/include/transformer/parse_result.hpp: In member function ‘duckdb::unique_ptr<duckdb::ParsedExpression> duckdb::StringLiteralParseResult::ToExpression()’:
/home/runner/work/duckdb/duckdb/extension/autocomplete/include/transformer/parse_result.hpp:353:9: warning: control reaches end of non-void function [-Wreturn-type]
  353 |         }
      |         ^
```
Make this `inline` rather than `static`
```
[ 36%] Building CXX object extension/tpcds/dsdgen/CMakeFiles/dsdgen.dir/append_info-c.cpp.o
In file included from /home/runner/work/duckdb/duckdb/extension/autocomplete/include/transformer/parse_result.hpp:10:
/home/runner/work/duckdb/duckdb/extension/autocomplete/include/parser/special_string_utils.hpp: At global scope:
/home/runner/work/duckdb/duckdb/extension/autocomplete/include/parser/special_string_utils.hpp:13:26: warning: ‘duckdb::SpecialStringInfo duckdb::GetSpecialStringInfo(const std::string&)’ defined but not used [-Wunused-function]
   13 | static SpecialStringInfo GetSpecialStringInfo(const string &text) {
      |                          ^~~~~~~~~~~~~~~~~~~~
```