### PR TITLE
Implement missing functionality for `OrderByNullType` in `RowGroupReorderer`

### DIFF
--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -1139,21 +1139,26 @@
       },
       {
         "id": 103,
+        "name": "null_order",
+        "type": "OrderByNullType"
+      },
+      {
+        "id": 104,
         "name": "column_type",
         "type": "OrderByColumnType"
       },
       {
-        "id": 104,
+        "id": 105,
         "name": "row_limit",
         "type": "optional_idx"
       },
       {
-        "id": 105,
+        "id": 106,
         "name": "row_group_offset",
         "type": "idx_t"
       }
     ],
-    "constructor": ["column_idx", "order_by", "order_type", "column_type", "row_limit", "row_group_offset"]
+    "constructor": ["column_idx", "order_by", "order_type", "null_order", "column_type",  "row_limit", "row_group_offset"]
   },
   {
     "class": "StorageIndex",

--- a/src/include/duckdb/storage/table/row_group_reorderer.hpp
+++ b/src/include/duckdb/storage/table/row_group_reorderer.hpp
@@ -21,15 +21,16 @@ enum class OrderByColumnType : uint8_t { NUMERIC, STRING };
 
 struct RowGroupOrderOptions {
 	RowGroupOrderOptions(const StorageIndex &column_idx_p, OrderByStatistics order_by_p, OrderType order_type_p,
-	                     OrderByColumnType column_type_p, optional_idx row_limit_p = optional_idx(),
-	                     idx_t row_group_offset_p = 0)
-	    : column_idx(column_idx_p), order_by(order_by_p), order_type(order_type_p), column_type(column_type_p),
-	      row_limit(row_limit_p), row_group_offset(row_group_offset_p) {
+	                     OrderByNullType null_order_p, OrderByColumnType column_type_p,
+	                     optional_idx row_limit_p = optional_idx(), idx_t row_group_offset_p = 0)
+	    : column_idx(column_idx_p), order_by(order_by_p), order_type(order_type_p), null_order(null_order_p),
+	      column_type(column_type_p), row_limit(row_limit_p), row_group_offset(row_group_offset_p) {
 	}
 
 	const StorageIndex column_idx;
 	const OrderByStatistics order_by;
 	const OrderType order_type;
+	const OrderByNullType null_order;
 	const OrderByColumnType column_type;
 	const optional_idx row_limit;
 	const idx_t row_group_offset;
@@ -51,8 +52,9 @@ public:
 
 	static Value RetrieveStat(const BaseStatistics &stats, OrderByStatistics order_by, OrderByColumnType column_type);
 	static OffsetPruningResult GetOffsetAfterPruning(OrderByStatistics order_by, OrderByColumnType column_type,
-	                                                 OrderType order_type, const StorageIndex &column_idx,
-	                                                 idx_t row_offset, vector<PartitionStatistics> &stats);
+	                                                 OrderType order_type, OrderByNullType null_order,
+	                                                 const StorageIndex &column_idx, idx_t row_offset,
+	                                                 vector<PartitionStatistics> &stats);
 
 private:
 	const RowGroupOrderOptions options;

--- a/src/optimizer/row_group_pruner.cpp
+++ b/src/optimizer/row_group_pruner.cpp
@@ -114,7 +114,8 @@ optional_ptr<LogicalOrder> RowGroupPruner::FindLogicalOrder(const LogicalLimit &
 
 	auto &logical_order = current_op.get().Cast<LogicalOrder>();
 	for (const auto &order : logical_order.orders) {
-		// We do not support any null-first orders as this requires unimplemented logic in the row group reorderer
+		// FIXME: the logic to handle this has now been implemented in the row group reorderer,
+		// but we do not enable the optimization until more thorough testing
 		if (order.null_order == OrderByNullType::NULLS_FIRST) {
 			return nullptr;
 		}
@@ -164,11 +165,12 @@ unique_ptr<RowGroupOrderOptions>
 RowGroupPruner::CreateRowGroupReordererOptions(const optional_idx row_limit, const optional_idx row_offset,
                                                const BoundOrderByNode &primary_order, const LogicalGet &logical_get,
                                                const StorageIndex &storage_index, LogicalLimit &logical_limit) const {
-	auto &colref = primary_order.expression->Cast<BoundColumnRefExpression>();
-	auto column_type =
+	const auto &colref = primary_order.expression->Cast<BoundColumnRefExpression>();
+	const auto column_type =
 	    colref.return_type == LogicalType::VARCHAR ? OrderByColumnType::STRING : OrderByColumnType::NUMERIC;
-	auto order_type = primary_order.type;
-	auto order_by = order_type == OrderType::ASCENDING ? OrderByStatistics::MIN : OrderByStatistics::MAX;
+	const auto order_type = primary_order.type;
+	const auto null_order = primary_order.null_order;
+	const auto order_by = order_type == OrderType::ASCENDING ? OrderByStatistics::MIN : OrderByStatistics::MAX;
 	optional_idx combined_limit = row_limit.IsValid()
 	                                  ? row_limit.GetIndex() + (row_offset.IsValid() ? row_offset.GetIndex() : 0)
 	                                  : optional_idx();
@@ -180,7 +182,7 @@ RowGroupPruner::CreateRowGroupReordererOptions(const optional_idx row_limit, con
 
 		if (!partition_stats.empty()) {
 			auto offset_puning_result = RowGroupReorderer::GetOffsetAfterPruning(
-			    order_by, column_type, order_type, storage_index, row_offset.GetIndex(), partition_stats);
+			    order_by, column_type, order_type, null_order, storage_index, row_offset.GetIndex(), partition_stats);
 			if (offset_puning_result.pruned_row_group_count > 0) {
 				// We can prune row groups and reduce the offset
 				logical_limit.offset_val =
@@ -190,13 +192,13 @@ RowGroupPruner::CreateRowGroupReordererOptions(const optional_idx row_limit, con
 					combined_limit = row_limit.GetIndex() + offset_puning_result.offset_remainder;
 				}
 
-				return make_uniq<RowGroupOrderOptions>(storage_index, order_by, order_type, column_type, combined_limit,
-				                                       offset_puning_result.pruned_row_group_count);
+				return make_uniq<RowGroupOrderOptions>(storage_index, order_by, order_type, null_order, column_type,
+				                                       combined_limit, offset_puning_result.pruned_row_group_count);
 			}
 		}
 	}
 	// Only sort row groups by primary order column and prune with limit if set
-	return make_uniq<RowGroupOrderOptions>(storage_index, order_by, order_type, column_type, combined_limit,
+	return make_uniq<RowGroupOrderOptions>(storage_index, order_by, order_type, null_order, column_type, combined_limit,
 	                                       NumericCast<uint64_t>(0));
 }
 

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -463,19 +463,21 @@ void RowGroupOrderOptions::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<StorageIndex>(100, "column_idx", column_idx);
 	serializer.WriteProperty<OrderByStatistics>(101, "order_by", order_by);
 	serializer.WriteProperty<OrderType>(102, "order_type", order_type);
-	serializer.WriteProperty<OrderByColumnType>(103, "column_type", column_type);
-	serializer.WriteProperty<optional_idx>(104, "row_limit", row_limit);
-	serializer.WritePropertyWithDefault<idx_t>(105, "row_group_offset", row_group_offset);
+	serializer.WriteProperty<OrderByNullType>(103, "null_order", null_order);
+	serializer.WriteProperty<OrderByColumnType>(104, "column_type", column_type);
+	serializer.WriteProperty<optional_idx>(105, "row_limit", row_limit);
+	serializer.WritePropertyWithDefault<idx_t>(106, "row_group_offset", row_group_offset);
 }
 
 unique_ptr<RowGroupOrderOptions> RowGroupOrderOptions::Deserialize(Deserializer &deserializer) {
 	auto column_idx = deserializer.ReadProperty<StorageIndex>(100, "column_idx");
 	auto order_by = deserializer.ReadProperty<OrderByStatistics>(101, "order_by");
 	auto order_type = deserializer.ReadProperty<OrderType>(102, "order_type");
-	auto column_type = deserializer.ReadProperty<OrderByColumnType>(103, "column_type");
-	auto row_limit = deserializer.ReadProperty<optional_idx>(104, "row_limit");
-	auto row_group_offset = deserializer.ReadPropertyWithDefault<idx_t>(105, "row_group_offset");
-	auto result = duckdb::unique_ptr<RowGroupOrderOptions>(new RowGroupOrderOptions(column_idx, order_by, order_type, column_type, row_limit, row_group_offset));
+	auto null_order = deserializer.ReadProperty<OrderByNullType>(103, "null_order");
+	auto column_type = deserializer.ReadProperty<OrderByColumnType>(104, "column_type");
+	auto row_limit = deserializer.ReadProperty<optional_idx>(105, "row_limit");
+	auto row_group_offset = deserializer.ReadPropertyWithDefault<idx_t>(106, "row_group_offset");
+	auto result = duckdb::unique_ptr<RowGroupOrderOptions>(new RowGroupOrderOptions(column_idx, order_by, order_type, null_order, column_type, row_limit, row_group_offset));
 	return result;
 }
 

--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -203,13 +203,17 @@ Value RowGroupReorderer::RetrieveStat(const BaseStatistics &stats, OrderByStatis
 		}
 	}
 	if (column_type == OrderByColumnType::STRING) {
+		if (!stats.CanHaveNoNull()) {
+			// No non-null values exist in this row group - stats are meaningless for ordering
+			return Value();
+		}
 		switch (order_by) {
 		case OrderByStatistics::MIN:
 			return StringStats::Min(stats);
 		case OrderByStatistics::MAX:
 			return StringStats::Max(stats);
 		default:
-			throw InternalException("Unsupported OrderByStatistics for numeric");
+			throw InternalException("Unsupported OrderByStatistics for string");
 		}
 	}
 	throw InternalException("Unsupported OrderByColumnType");
@@ -218,6 +222,7 @@ Value RowGroupReorderer::RetrieveStat(const BaseStatistics &stats, OrderByStatis
 OffsetPruningResult RowGroupReorderer::GetOffsetAfterPruning(const OrderByStatistics order_by,
                                                              const OrderByColumnType column_type,
                                                              const OrderType order_type,
+                                                             const OrderByNullType null_order,
                                                              const StorageIndex &storage_index, const idx_t row_offset,
                                                              vector<PartitionStatistics> &stats) {
 	multimap<Value, RowGroupOffsetEntry> ordered_row_groups;
@@ -230,6 +235,13 @@ OffsetPruningResult RowGroupReorderer::GetOffsetAfterPruning(const OrderByStatis
 		auto column_stats = partition_stats.partition_row_group->GetColumnStatistics(storage_index);
 		Value comparison_value = RetrieveStat(*column_stats, order_by, column_type);
 		if (comparison_value.IsNull()) {
+			if (null_order == OrderByNullType::NULLS_LAST) {
+				// With NULLS_LAST, null-stats row groups are scanned after all non-null row groups.
+				// They fall outside the offset range being pruned here, so skip them.
+				continue;
+			}
+			// With NULLS_FIRST, null-stats row groups come first and would need to be counted
+			// toward the offset before non-null groups. This case is not yet supported.
 			return {row_offset, 0};
 		}
 		auto entry = RowGroupOffsetEntry {partition_stats.count, std::move(column_stats)};
@@ -273,15 +285,27 @@ optional_ptr<SegmentNode<RowGroup>> RowGroupReorderer::GetRootSegment(RowGroupSe
 	}
 
 	if (row_group_map.empty()) {
-		return nullptr;
+		// All row groups have unknown/null stats - scan them all without reordering
+		for (auto &remaining_row_group : remaining_row_groups) {
+			ordered_row_groups.push_back(remaining_row_group);
+		}
+		if (ordered_row_groups.empty()) {
+			return nullptr;
+		}
+		return ordered_row_groups[0].get();
 	}
 
 	D_ASSERT(row_group_map.size() > options.row_group_offset);
 	SetRowGroupVector(row_group_map, options.row_limit, options.row_group_offset, options.order_type,
 	                  options.column_type, ordered_row_groups);
-	// push any remaining row groups
-	for (auto &remaining_row_group : remaining_row_groups) {
-		ordered_row_groups.push_back(remaining_row_group);
+	// Push null-stats row groups in the correct position based on null ordering
+	if (options.null_order == OrderByNullType::NULLS_FIRST) {
+		ordered_row_groups.insert(ordered_row_groups.begin(), remaining_row_groups.begin(), remaining_row_groups.end());
+	} else {
+		// NULLS_LAST: append null-stats row groups after sorted row groups
+		for (auto &remaining_row_group : remaining_row_groups) {
+			ordered_row_groups.push_back(remaining_row_group);
+		}
 	}
 
 	return ordered_row_groups[0].get();

--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -203,7 +203,7 @@ Value RowGroupReorderer::RetrieveStat(const BaseStatistics &stats, OrderByStatis
 		}
 	}
 	if (column_type == OrderByColumnType::STRING) {
-		if (!stats.CanHaveNoNull() || !StringStats::HasMaxStringLength(stats)) {
+		if (!stats.CanHaveNoNull()) {
 			// No non-null values exist in this row group - stats are meaningless for ordering
 			return Value();
 		}

--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -203,7 +203,7 @@ Value RowGroupReorderer::RetrieveStat(const BaseStatistics &stats, OrderByStatis
 		}
 	}
 	if (column_type == OrderByColumnType::STRING) {
-		if (!stats.CanHaveNoNull()) {
+		if (!stats.CanHaveNoNull() || !StringStats::HasMaxStringLength(stats)) {
 			// No non-null values exist in this row group - stats are meaningless for ordering
 			return Value();
 		}

--- a/test/issues/general/test_21160.test
+++ b/test/issues/general/test_21160.test
@@ -11,26 +11,30 @@ CREATE OR REPLACE TABLE t (id INTEGER, x VARCHAR, y DOUBLE);
 statement ok
 INSERT INTO t VALUES (1, NULL, NULL);
 
+foreach null_order LAST FIRST
+
 # Original regression tests: single row, all-null sort columns
 query I
-SELECT id FROM t WHERE x IS NULL ORDER BY y;
+SELECT id FROM t WHERE x IS NULL ORDER BY y NULLS ${null_order};
 ----
 1
 
 query I
-SELECT id FROM t WHERE x IS NULL ORDER BY y LIMIT 10;
+SELECT id FROM t WHERE x IS NULL ORDER BY y NULLS ${null_order} LIMIT 10;
 ----
 1
 
 query I
-SELECT id FROM t WHERE x IS NULL ORDER BY x;
+SELECT id FROM t WHERE x IS NULL ORDER BY x NULLS ${null_order};
 ----
 1
 
 query I
-SELECT id FROM t WHERE x IS NULL ORDER BY x LIMIT 10;
+SELECT id FROM t WHERE x IS NULL ORDER BY x NULLS ${null_order} LIMIT 10;
 ----
 1
+
+endloop
 
 # Mixed NULL and non-NULL values
 statement ok

--- a/test/issues/general/test_21160.test
+++ b/test/issues/general/test_21160.test
@@ -1,0 +1,121 @@
+# name: test/issues/general/test_21160.test
+# description: Issue 21160 - duckdb 1.5: Issues around LIMIT
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE OR REPLACE TABLE t (id INTEGER, x VARCHAR, y DOUBLE);
+
+statement ok
+INSERT INTO t VALUES (1, NULL, NULL);
+
+# Original regression tests: single row, all-null sort columns
+query I
+SELECT id FROM t WHERE x IS NULL ORDER BY y;
+----
+1
+
+query I
+SELECT id FROM t WHERE x IS NULL ORDER BY y LIMIT 10;
+----
+1
+
+query I
+SELECT id FROM t WHERE x IS NULL ORDER BY x;
+----
+1
+
+query I
+SELECT id FROM t WHERE x IS NULL ORDER BY x LIMIT 10;
+----
+1
+
+# Mixed NULL and non-NULL values
+statement ok
+INSERT INTO t VALUES (2, 'b', 2.0), (3, 'a', 1.0), (4, NULL, NULL), (5, 'c', NULL), (6, NULL, 3.0);
+
+# ORDER BY DOUBLE ASC (NULLS LAST by default): non-null rows in ascending order, then NULLs
+# Use secondary sort key to get deterministic ordering of ties (the NULL rows)
+query I
+SELECT id FROM t ORDER BY y ASC, id ASC LIMIT 10;
+----
+3
+2
+6
+1
+4
+5
+
+# ORDER BY DOUBLE DESC (NULLS LAST by default): non-null rows in descending order, then NULLs
+query I
+SELECT id FROM t ORDER BY y DESC, id ASC LIMIT 10;
+----
+6
+2
+3
+1
+4
+5
+
+# ORDER BY VARCHAR ASC (NULLS LAST by default): non-null rows in ascending order, then NULLs
+query I
+SELECT id FROM t ORDER BY x ASC, id ASC LIMIT 10;
+----
+3
+2
+5
+1
+4
+6
+
+# ORDER BY VARCHAR DESC (NULLS LAST by default): non-null rows in descending order, then NULLs
+query I
+SELECT id FROM t ORDER BY x DESC, id ASC LIMIT 10;
+----
+5
+2
+3
+1
+4
+6
+
+# Explicit NULLS LAST - same as default
+query I
+SELECT id FROM t ORDER BY y ASC NULLS LAST, id ASC LIMIT 10;
+----
+3
+2
+6
+1
+4
+5
+
+# Explicit NULLS FIRST - NULLs appear before non-nulls (optimizer skips reorderer for this case)
+query I
+SELECT id FROM t ORDER BY y ASC NULLS FIRST, id ASC LIMIT 10;
+----
+1
+4
+5
+3
+2
+6
+
+# With a filter that includes some rows having NULLs in the sort column
+# WHERE y IS NULL: rows 1, 4, 5 (row 6 has y=3.0)
+query I
+SELECT id FROM t WHERE y IS NULL ORDER BY x ASC, id ASC LIMIT 10;
+----
+5
+1
+4
+
+# Ordering-only (no LIMIT) with all-null sort column - no reorderer activated but should still work
+query I
+SELECT id FROM t WHERE y IS NULL ORDER BY y ASC, id ASC;
+----
+1
+4
+5

--- a/test/issues/general/test_21160_parquet.test
+++ b/test/issues/general/test_21160_parquet.test
@@ -1,0 +1,129 @@
+# name: test/issues/general/test_21160_parquet.test
+# description: Issue 21160 - duckdb 1.5: Issues around LIMIT (Parquet variant)
+# group: [general]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+# Write single-row parquet (all-null sort columns)
+statement ok
+COPY (SELECT 1 AS id, NULL::VARCHAR AS x, NULL::DOUBLE AS y) TO '__TEST_DIR__/test_21160_single.parquet' (FORMAT parquet);
+
+# Original regression tests: single row, all-null sort columns
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY y;
+----
+1
+
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY y LIMIT 10;
+----
+1
+
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY x;
+----
+1
+
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY x LIMIT 10;
+----
+1
+
+# Write multi-row parquet (mixed NULL and non-NULL values)
+statement ok
+COPY (
+    SELECT * FROM (VALUES
+        (1, NULL::VARCHAR, NULL::DOUBLE),
+        (2, 'b',           2.0),
+        (3, 'a',           1.0),
+        (4, NULL::VARCHAR, NULL::DOUBLE),
+        (5, 'c',           NULL::DOUBLE),
+        (6, NULL::VARCHAR, 3.0)
+    ) t(id, x, y)
+) TO '__TEST_DIR__/test_21160_multi.parquet' (FORMAT parquet);
+
+# ORDER BY DOUBLE ASC (NULLS LAST by default): non-null rows in ascending order, then NULLs
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_multi.parquet') ORDER BY y ASC, id ASC LIMIT 10;
+----
+3
+2
+6
+1
+4
+5
+
+# ORDER BY DOUBLE DESC (NULLS LAST by default): non-null rows in descending order, then NULLs
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_multi.parquet') ORDER BY y DESC, id ASC LIMIT 10;
+----
+6
+2
+3
+1
+4
+5
+
+# ORDER BY VARCHAR ASC (NULLS LAST by default): non-null rows in ascending order, then NULLs
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_multi.parquet') ORDER BY x ASC, id ASC LIMIT 10;
+----
+3
+2
+5
+1
+4
+6
+
+# ORDER BY VARCHAR DESC (NULLS LAST by default): non-null rows in descending order, then NULLs
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_multi.parquet') ORDER BY x DESC, id ASC LIMIT 10;
+----
+5
+2
+3
+1
+4
+6
+
+# Explicit NULLS LAST - same as default
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_multi.parquet') ORDER BY y ASC NULLS LAST, id ASC LIMIT 10;
+----
+3
+2
+6
+1
+4
+5
+
+# Explicit NULLS FIRST - NULLs appear before non-nulls
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_multi.parquet') ORDER BY y ASC NULLS FIRST, id ASC LIMIT 10;
+----
+1
+4
+5
+3
+2
+6
+
+# With a filter that includes some rows having NULLs in the sort column
+# WHERE y IS NULL: rows 1, 4, 5 (row 6 has y=3.0)
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_multi.parquet') WHERE y IS NULL ORDER BY x ASC, id ASC LIMIT 10;
+----
+5
+1
+4
+
+# Ordering-only (no LIMIT) with all-null sort column
+query I
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_multi.parquet') WHERE y IS NULL ORDER BY y ASC, id ASC;
+----
+1
+4
+5

--- a/test/issues/general/test_21160_parquet.test
+++ b/test/issues/general/test_21160_parquet.test
@@ -11,26 +11,30 @@ PRAGMA enable_verification
 statement ok
 COPY (SELECT 1 AS id, NULL::VARCHAR AS x, NULL::DOUBLE AS y) TO '__TEST_DIR__/test_21160_single.parquet' (FORMAT parquet);
 
+foreach null_order LAST FIRST
+
 # Original regression tests: single row, all-null sort columns
 query I
-SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY y;
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY y NULLS ${null_order};
 ----
 1
 
 query I
-SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY y LIMIT 10;
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY y NULLS ${null_order} LIMIT 10;
 ----
 1
 
 query I
-SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY x;
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY x NULLS ${null_order};
 ----
 1
 
 query I
-SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY x LIMIT 10;
+SELECT id FROM read_parquet('__TEST_DIR__/test_21160_single.parquet') WHERE x IS NULL ORDER BY x NULLS ${null_order} LIMIT 10;
 ----
 1
+
+endloop
 
 # Write multi-row parquet (mixed NULL and non-NULL values)
 statement ok


### PR DESCRIPTION
Supersedes https://github.com/duckdb/duckdb/pull/21170

Fixes https://github.com/duckdb/duckdb/issues/21160