### PR TITLE
Disable automated converting PR to draft on sync

### DIFF
--- a/.github/workflows/DraftMe.yml
+++ b/.github/workflows/DraftMe.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   mark-as-draft:
     name: Mark as draft
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'smvv'
     runs-on: ubuntu-latest
     steps:
       - name: Save PR number


### PR DESCRIPTION
Disable automated converting PR to draft on sync for my github username, so I can make CI changes quickly.

Currently, when there is not enough CI runner capacity, the CI job that converts a PR into a draft has to wait for an available CI runner. This can easily take 20+ min when under load, and requires me context-switch to the PR and manually click "ready for review" multiple times per day.