### PR TITLE
Use test runner in more CI jobs of main

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -92,7 +92,7 @@ inputs:
     default: ''
   unittest_script:
     description: 'Script/program to execute the unittests'
-    default: 'python3 scripts/ci/run_tests.py ./build/release/test/unittest "*"'
+    default: 'python3 scripts/ci/run_tests.py ./build/release/test/unittest'
   cmake_flags:
     description: 'Flags to be passed to cmake'
     default: ''

--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -92,7 +92,7 @@ inputs:
     default: ''
   unittest_script:
     description: 'Script/program to execute the unittests'
-    default: 'python3 scripts/run_tests_one_by_one.py ./build/release/test/unittest'
+    default: 'python3 scripts/ci/run_tests.py ./build/release/test/unittest "*"'
   cmake_flags:
     description: 'Flags to be passed to cmake'
     default: ''

--- a/.github/helper_makefile/build_all_extensions
+++ b/.github/helper_makefile/build_all_extensions
@@ -13,4 +13,4 @@ configure_ci:
 	cd duckdb && BUILD_ALL_EXT=1 make extension_configuration && cp build/extension_configuration/vcpkg.json ../.
 
 test_release:
-	python3 duckdb/scripts/run_tests_one_by_one.py ./build/release/test/unittest
+	python3 duckdb/scripts/ci/run_tests.py ./build/release/test/unittest "*"

--- a/.github/helper_makefile/build_all_extensions
+++ b/.github/helper_makefile/build_all_extensions
@@ -13,4 +13,4 @@ configure_ci:
 	cd duckdb && BUILD_ALL_EXT=1 make extension_configuration && cp build/extension_configuration/vcpkg.json ../.
 
 test_release:
-	python3 duckdb/scripts/ci/run_tests.py ./build/release/test/unittest "*"
+	python3 duckdb/scripts/ci/run_tests.py ./build/release/test/unittest

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -216,6 +216,7 @@ jobs:
         export PWD=`pwd`
         docker run   \
         -v$PWD:$PWD  \
+        -e CI=1      \
         alpine:3.22                                                         \
         sh -c "
           set -e

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -119,7 +119,7 @@ jobs:
       shell: bash
       if: ${{ inputs.skip_tests != 'true' }}
       run: |
-        python3 scripts/run_tests_one_by_one.py build/release/test/unittest "*" --time_execution
+        python3 scripts/ci/run_tests.py build/release/test/unittest "*"
 
     - name: Release specific tests
       shell: bash
@@ -225,7 +225,7 @@ jobs:
             py3-pytest
           cd $PWD
           echo Tests
-          python3 scripts/run_tests_one_by_one.py build/release/test/unittest \"*\" --time_execution
+          python3 scripts/ci/run_tests.py build/release/test/unittest \"*\"
           echo Release specific tests
           ./build/release/test/unittest --select-tag release
           echo Tools Tests

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -337,7 +337,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest --no-exit --time_execution
+          python3 scripts/ci/run_tests.py build/reldebug/test/unittest '*'
 
  valgrind:
     name: Valgrind
@@ -404,13 +404,13 @@ jobs:
     - name: Test
       shell: bash
       run: |
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest --no-exit --timeout 600
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[intraquery]" --no-exit --timeout 600
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[interquery]" --no-exit --timeout 1800
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[interquery]" --no-exit --timeout 1800 --force-storage
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[interquery]" --no-exit --timeout 1800 --force-storage --force-reload
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[detailed_profiler]" --no-exit --timeout 600
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow --no-exit --timeout 600
+          python3 scripts/ci/run_tests.py build/reldebug/test/unittest '*'
+          python3 scripts/ci/run_tests.py build/reldebug/test/unittest "[intraquery]"
+          python3 scripts/ci/run_tests.py build/reldebug/test/unittest "[interquery]"
+          python3 scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage -f {test_list}" build/reldebug/test/unittest "[interquery]"
+          python3 scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage --force-reload -f {test_list}" build/reldebug/test/unittest "[interquery]"
+          python3 scripts/ci/run_tests.py build/reldebug/test/unittest "[detailed_profiler]"
+          python3 scripts/ci/run_tests.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow
 
  amalgamation-tests:
     name: Amalgamation Tests

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -170,8 +170,7 @@ jobs:
       run: echo $DUCKDB_INSTALL_LIB
 
     - name: Test
-      run: |
-        make allunit_relassert
+      run: make unittest_relassert
 
  regression:
     uses: ./.github/workflows/Regression.yml
@@ -291,24 +290,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/cleanup_runner
 
       - name: Install
-        shell: bash
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+        run: make toolsci
 
       - uses: ./.github/actions/ccache-action
 
       - name: Build
-        shell: bash
         run: make relassert
 
       - name: Test
-        shell: bash
-        run: build/relassert/test/unittest
+        run: make unittest_relassert
 
  vector-sizes:
     name: Vector Sizes

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -214,6 +214,9 @@ jobs:
     - name: Build
       run: make release
 
+    - name: Smoke tests
+      run: make smoke SMOKE_UNITTEST=build/release/test/unittest
+
     - name: Prepare release artifact
       shell: bash
       run: make release-artifact

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -380,12 +380,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: Install
-      shell: bash
-      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang
+      run: make toolsci
 
     - uses: ./.github/actions/ccache-action
 

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -394,7 +394,7 @@ jobs:
 
  amalgamation-tests:
     name: Amalgamation Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: linux-debug
     env:
       CC: clang
@@ -402,18 +402,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.ref }}
 
     - uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-
-    - name: Install LLVM and Clang
-      uses: KyleMayes/install-llvm-action@v1
-      with:
-        version: "14.0"
 
     - name: Generate Amalgamation
       shell: bash

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -398,19 +398,10 @@ jobs:
     - uses: ./.github/actions/ccache-action
 
     - name: Build
-      shell: bash
       run: THREADSAN=1 make reldebug
 
     - name: Test
-      shell: bash
-      run: |
-          python3 scripts/ci/run_tests.py build/reldebug/test/unittest '*'
-          python3 scripts/ci/run_tests.py build/reldebug/test/unittest "[intraquery]"
-          python3 scripts/ci/run_tests.py build/reldebug/test/unittest "[interquery]"
-          python3 scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage -f {test_list}" build/reldebug/test/unittest "[interquery]"
-          python3 scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage --force-reload -f {test_list}" build/reldebug/test/unittest "[interquery]"
-          python3 scripts/ci/run_tests.py build/reldebug/test/unittest "[detailed_profiler]"
-          python3 scripts/ci/run_tests.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow
+      run: make unittest_threadsan
 
  amalgamation-tests:
     name: Amalgamation Tests

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -319,25 +319,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/cleanup_runner
 
       - name: Install
-        shell: bash
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+        run: make toolsci
 
       - uses: ./.github/actions/ccache-action
 
       - name: Build
-        shell: bash
         run: STANDARD_VECTOR_SIZE=2 make reldebug
 
       - name: Test
-        shell: bash
-        run: |
-          python3 scripts/ci/run_tests.py build/reldebug/test/unittest '*'
+        run: make unittest_reldebug
 
  valgrind:
     name: Valgrind

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -5,7 +5,7 @@ on:
   repository_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  group: swift-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -420,9 +420,9 @@ endif
 
 unittest_threadsan: unittest_reldebug
 	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[intraquery]"
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[interquery]" --batch-timeout=1800
-	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage -f {test_list}" build/reldebug/test/unittest "[interquery]" --batch-timeout=1800
-	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage --force-reload -f {test_list}" build/reldebug/test/unittest "[interquery]" --batch-timeout=1800
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[interquery]"
+	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage -f {test_list}" build/reldebug/test/unittest "[interquery]"
+	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage --force-reload -f {test_list}" build/reldebug/test/unittest "[interquery]"
 	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[detailed_profiler]"
 	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow
 

--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ unittest_reldebug:
 unittest_release: release
 	build/release/test/unittest
 
-allunit_relassert:
+unittest_relassert:
 	$(PYTHON) scripts/ci/run_tests.py build/relassert/test/unittest $(T)
 
 smoke:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ PROJ_DIR := $(dir $(MKFILE_PATH))
 
 PYTHON ?= python3
 SMOKE_UNITTEST ?= build/relassert/test/unittest
+UNITTEST_SLOW_FLAGS ?= --batch-timeout=1800 --track-runtime=300
+UNITTEST_HUGE_FLAGS ?= --batch-size=1 --workers=50% $(UNITTEST_SLOW_FLAGS)
 
 # Allow setting extra unit test parameters using `make smoke T=...`.
 T ?=
@@ -419,12 +421,12 @@ allunit: release
 endif
 
 unittest_threadsan: unittest_reldebug
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[intraquery]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[interquery]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py --test-flags="--force-storage" --batch-size=1 --workers=50% --batch-timeout=1800 --track-runtime=300 build/reldebug/test/unittest "[interquery]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py --test-flags="--force-storage --force-reload" --batch-size=1 --workers=50% --batch-timeout=1800 --track-runtime=300 build/reldebug/test/unittest "[interquery]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest --batch-timeout=1800 --track-runtime=300 "[detailed_profiler]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest --batch-timeout=1800 --track-runtime=300 test/sql/tpch/tpch_sf01.test_slow $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) build/reldebug/test/unittest "[intraquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) build/reldebug/test/unittest "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) --test-flags="--force-storage" build/reldebug/test/unittest "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) --test-flags="--force-storage --force-reload" build/reldebug/test/unittest "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_SLOW_FLAGS) build/reldebug/test/unittest "[detailed_profiler]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_SLOW_FLAGS) build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow $(T)
 
 docs:
 	mkdir -p ./build/docs && \

--- a/Makefile
+++ b/Makefile
@@ -419,12 +419,12 @@ allunit: release
 endif
 
 unittest_threadsan: unittest_reldebug
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[intraquery]"
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[interquery]"
-	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage -f {test_list}" build/reldebug/test/unittest "[interquery]"
-	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage --force-reload -f {test_list}" build/reldebug/test/unittest "[interquery]"
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[detailed_profiler]"
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[intraquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage -f {test_list}" build/reldebug/test/unittest "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage --force-reload -f {test_list}" build/reldebug/test/unittest "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[detailed_profiler]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow $(T)
 
 docs:
 	mkdir -p ./build/docs && \

--- a/Makefile
+++ b/Makefile
@@ -421,10 +421,10 @@ endif
 unittest_threadsan: unittest_reldebug
 	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[intraquery]" $(T)
 	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[interquery]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py --test-flags=--force-storage build/reldebug/test/unittest "[interquery]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py --test-flags="--force-storage --force-reload" build/reldebug/test/unittest "[interquery]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[detailed_profiler]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow $(T)
+	$(PYTHON) scripts/ci/run_tests.py --test-flags="--force-storage" --batch-size=1 --workers=50% --batch-timeout=1800 --track-runtime=300 build/reldebug/test/unittest "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py --test-flags="--force-storage --force-reload" --batch-size=1 --workers=50% --batch-timeout=1800 --track-runtime=300 build/reldebug/test/unittest "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest --batch-timeout=1800 --track-runtime=300 "[detailed_profiler]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest --batch-timeout=1800 --track-runtime=300 test/sql/tpch/tpch_sf01.test_slow $(T)
 
 docs:
 	mkdir -p ./build/docs && \

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,10 @@ build/extension_configuration/vcpkg.json: extension/extension_config_local.cmake
 	cmake --build . --config RelWithDebInfo
 
 unittest: debug
-	build/debug/test/unittest
+	$(PYTHON) scripts/ci/run_tests.py build/debug/test/unittest $(T)
+
+unittest_reldebug:
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest $(T)
 
 unittest_release: release
 	build/release/test/unittest
@@ -409,12 +412,19 @@ runnertests:
 unittestarrow:
 	build/debug/test/unittest "[arrow]"
 
-
 allunit:
 	$(PYTHON) scripts/ci/run_tests.py --workers=50% build/release/test/unittest '*' $(T)
 ifndef CI
 allunit: release
 endif
+
+unittest_threadsan: unittest_reldebug
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[intraquery]"
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[interquery]" --batch-timeout=1800
+	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage -f {test_list}" build/reldebug/test/unittest "[interquery]" --batch-timeout=1800
+	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage --force-reload -f {test_list}" build/reldebug/test/unittest "[interquery]" --batch-timeout=1800
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[detailed_profiler]"
+	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow
 
 docs:
 	mkdir -p ./build/docs && \

--- a/Makefile
+++ b/Makefile
@@ -421,8 +421,8 @@ endif
 unittest_threadsan: unittest_reldebug
 	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[intraquery]" $(T)
 	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[interquery]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage -f {test_list}" build/reldebug/test/unittest "[interquery]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py --test-command "{binary} --use-colour yes --force-storage --force-reload -f {test_list}" build/reldebug/test/unittest "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py --test-flags=--force-storage build/reldebug/test/unittest "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py --test-flags="--force-storage --force-reload" build/reldebug/test/unittest "[interquery]" $(T)
 	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest "[detailed_profiler]" $(T)
 	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow $(T)
 

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -44,6 +44,12 @@ class TestRunnerConfig:
     max_failures: int | None
 
 
+@dataclass(frozen=True)
+class TestCase:
+    name: str
+    is_slow: bool
+
+
 class BatchRunState:
     def __init__(self):
         self.failed_count = 0
@@ -64,18 +70,17 @@ class BatchRunState:
 
 
 def chunked(items, n):
-    # Keep input order, cap batches at n entries, and isolate .test_slow
-    # files so each batch contains at most one slow test.
+    # Keep input order, cap batches at n entries, and isolate slow tests so
+    # each batch contains at most one slow test.
     batch = []
     slow_count = 0
     for item in items:
-        item_is_slow = item.endswith(".test_slow")
-        if batch and (len(batch) >= n or (item_is_slow and slow_count >= 1)):
+        if batch and (len(batch) >= n or (item.is_slow and slow_count >= 1)):
             yield batch
             batch = []
             slow_count = 0
-        batch.append(item)
-        if item_is_slow:
+        batch.append(item.name)
+        if item.is_slow:
             slow_count += 1
     if batch:
         yield batch
@@ -91,10 +96,25 @@ def load_tests(path: Path):
     tests = []
     with path.open("r", encoding="utf8") as f:
         for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
+            line = line.rstrip("\n")
+
+            # Skip header row from `--list-tests`.
+            if line == "name\tgroup":
                 continue
-            tests.append(line)
+
+            if "\t" not in line:
+                name = line
+                is_slow = line.endswith(".test_slow")
+            else:
+                columns = line.split("\t")
+                assert len(columns) == 2, repr(columns)
+
+                name, group = columns
+                is_slow = "[.]" in group
+                assert not name.endswith(".test_slow") or is_slow, name
+
+            tests.append(TestCase(name=name, is_slow=is_slow))
+
     return tests
 
 
@@ -158,9 +178,9 @@ def resolve_workers(workers: str):
 
 
 def generate_test_list(test_file, unittest_bin: str, pattern: str):
-    # Catch returns the number of matching tests from --list-test-names-only,
-    # so a non-zero exit code here is expected when tests are found.
-    command = [unittest_bin, "--list-test-names-only", pattern]
+    # Catch can return a non-zero status code for list commands when tests
+    # are found, so we accept non-zero if stdout still contains test output.
+    command = [unittest_bin, "--list-tests", pattern]
     print(f"generated test list using: {shlex.join(command)}")
     proc = subprocess.run(
         command,
@@ -168,10 +188,11 @@ def generate_test_list(test_file, unittest_bin: str, pattern: str):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    if proc.stderr:
+    if proc.returncode != 0 and not proc.stdout:
         if proc.stdout:
             print(proc.stdout, end="")
-        print(proc.stderr, end="", file=sys.stderr)
+        if proc.stderr:
+            print(proc.stderr, end="", file=sys.stderr)
         raise RuntimeError(f"failed to generate test list from {unittest_bin}")
     test_file.write(proc.stdout)
     test_file.flush()

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -429,7 +429,11 @@ def main():
         print("CI detected, enabling retry=2 per batch")
     max_retries = max(0, args.max_retries)
     workers = resolve_workers(args.workers)
-    batch_size = 1 if args.track_runtime is not None else args.batch_size
+    if args.track_runtime is not None:
+        print("enabling runtime tracking forces batch_size=1")
+        batch_size = 1
+    else:
+        batch_size = args.batch_size
     with open_test_list(args.test_list, args.unittest_bin, args.test_flags, args.pattern) as test_file:
         config = TestRunnerConfig(
             test_list=test_file,

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -32,6 +32,7 @@ def enable_line_buffering():
 class TestRunnerConfig:
     test_list: Path
     unittest_bin: str
+    test_flags: str
     pattern: str
     test_command: str
     workers: int
@@ -119,8 +120,10 @@ def load_tests(path: Path):
 
 
 def build_test_command(config: TestRunnerConfig, test_list: str):
+    flags = shlex.join(shlex.split(config.test_flags))
     return config.test_command.format(
         binary=shlex.quote(config.unittest_bin),
+        flags=flags,
         test_list=test_list,
     )
 
@@ -177,10 +180,10 @@ def resolve_workers(workers: str):
     return max(1, int(workers))
 
 
-def generate_test_list(test_file, unittest_bin: str, pattern: str):
+def generate_test_list(test_file, unittest_bin: str, test_flags: str, pattern: str):
     # Catch can return a non-zero status code for list commands when tests
     # are found, so we accept non-zero if stdout still contains test output.
-    command = [unittest_bin, "--list-tests", pattern]
+    command = [unittest_bin, *shlex.split(test_flags), "--list-tests", pattern]
     print(f"generated test list using: {shlex.join(command)}")
     proc = subprocess.run(
         command,
@@ -199,14 +202,14 @@ def generate_test_list(test_file, unittest_bin: str, pattern: str):
 
 
 @contextlib.contextmanager
-def open_test_list(test_list: Path | None, unittest_bin: str, pattern: str):
+def open_test_list(test_list: Path | None, unittest_bin: str, test_flags: str, pattern: str):
     if test_list is not None:
         with test_list.open("r", encoding="utf8") as test_file:
             yield Path(test_file.name)
         return
 
     with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=True) as test_file:
-        generate_test_list(test_file, unittest_bin, pattern)
+        generate_test_list(test_file, unittest_bin, test_flags, pattern)
         yield Path(test_file.name)
 
 
@@ -378,12 +381,17 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--test-list", type=Path)
     parser.add_argument("--workers", default=DEFAULT_WORKERS)
+    parser.add_argument(
+        "--test-flags",
+        default="",
+        help="additional flags appended to the unittest binary for listing and execution",
+    )
     parser.add_argument("unittest_bin")
     parser.add_argument("pattern", nargs="?", default="")
     parser.add_argument(
         "--test-command",
-        default="{binary} --use-colour yes -f {test_list}",
-        help="shell command template used to run a test batch; supports {binary} and {test_list}",
+        default="{binary} {flags} --use-colour yes -f {test_list}",
+        help="shell command template used to run a test batch; supports {binary}, {flags}, and {test_list}",
     )
     parser.add_argument(
         "--track-runtime",
@@ -422,10 +430,11 @@ def main():
     max_retries = max(0, args.max_retries)
     workers = resolve_workers(args.workers)
     batch_size = 1 if args.track_runtime is not None else args.batch_size
-    with open_test_list(args.test_list, args.unittest_bin, args.pattern) as test_file:
+    with open_test_list(args.test_list, args.unittest_bin, args.test_flags, args.pattern) as test_file:
         config = TestRunnerConfig(
             test_list=test_file,
             unittest_bin=args.unittest_bin,
+            test_flags=args.test_flags,
             pattern=args.pattern,
             test_command=args.test_command,
             workers=workers,

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -104,6 +104,59 @@ class RunTestsScriptTest(unittest.TestCase):
         self.assertIn("fake failure", proc.stdout)
         self.assertIn("all tests passed.", proc.stdout)
 
+    def test_retries_timed_out_sleep_job(self):
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as test_list:
+            test_list.write("test/sql/a.test\n")
+            test_list.flush()
+            test_list_path = Path(test_list.name)
+
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as state_file:
+            state_file_path = Path(state_file.name)
+
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as helper:
+            helper.write("#!/bin/sh\n")
+            helper.write(f"if [ ! -f {state_file_path} ]; then\n")
+            helper.write(f"  touch {state_file_path}\n")
+            helper.write("  sleep 2\n")
+            helper.write("fi\n")
+            helper.write("echo fake success\n")
+            helper.write("exit 0\n")
+            helper.flush()
+            helper_path = Path(helper.name)
+
+        os.chmod(helper_path, 0o755)
+        state_file_path.unlink(missing_ok=True)
+
+        try:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(RUN_TESTS),
+                    "--retry",
+                    "1",
+                    "--batch-timeout",
+                    "1",
+                    "--test-list",
+                    str(test_list_path),
+                    "--test-command",
+                    f"{helper_path} {{test_list}}",
+                    "unused-binary",
+                ],
+                cwd=REPO_ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        finally:
+            test_list_path.unlink(missing_ok=True)
+            state_file_path.unlink(missing_ok=True)
+            helper_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("batch timed out after 1 seconds", proc.stdout)
+        self.assertIn("retrying failed test", proc.stdout)
+        self.assertIn("all tests passed.", proc.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -6,12 +6,64 @@ import tempfile
 import unittest
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RUN_TESTS = REPO_ROOT / "scripts" / "ci" / "run_tests.py"
 
 
 class RunTestsScriptTest(unittest.TestCase):
+    def test_generate_list(self):
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as listed_tests:
+            listed_tests.write("name\tgroup\n")
+            listed_tests.write("test/sql/slow.test\t[.][slow]\n")
+            listed_tests.write("test/sql/fast.test\t[fast]\n")
+            listed_tests.flush()
+            listed_tests_path = Path(listed_tests.name)
+
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as list_helper:
+            list_helper.write("#!/bin/sh\n")
+            # run_tests.py calls: <helper> --list-tests <pattern>
+            list_helper.write('if [ "$1" != "--list-tests" ]; then\n')
+            list_helper.write("  exit 2\n")
+            list_helper.write("fi\n")
+            list_helper.write('cat "$2"\n')
+            list_helper.write("exit 2\n")
+            list_helper.flush()
+            list_helper_path = Path(list_helper.name)
+
+        os.chmod(list_helper_path, 0o755)
+
+        try:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(RUN_TESTS),
+                    "--workers",
+                    "1",
+                    "--batch-size",
+                    "2",
+                    "--track-runtime",
+                    "0",
+                    "--test-command",
+                    "echo fake-run {test_list}",
+                    str(list_helper_path),
+                    str(listed_tests_path),
+                ],
+                cwd=REPO_ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        finally:
+            listed_tests_path.unlink(missing_ok=True)
+            list_helper_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("generated test list using:", proc.stdout)
+        self.assertIn("found 2 tests", proc.stdout)
+        self.assertIn("test/sql/slow.test took", proc.stdout)
+        self.assertIn("test/sql/fast.test took", proc.stdout)
+        self.assertIn("all tests passed.", proc.stdout)
+
     def test_runs_with_echo_test_command(self):
         with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as test_list:
             test_list.write("test/sql/a.test\n")


### PR DESCRIPTION
**TODO: add before/after comparison of test runtime/speedup.**

### Changes

- Use new test runner in most CI jobs.
- Move complex scripts from CI steps to make targets (like `unittest_threadsan` and `toolsci`), so they are easier to run/test locally.
- Clean up some unnecessary/slow CI jobs' steps (like in `amalgamation-tests`).
- Run at most slow test (either `.test_slow` or marked with group `[.]`) per test batch. (We looked only for `.test_slow` before, and missed classifying `[.]` as slow test).
- Add flag `--test-flags` to forward CLI flags to the unittest binary (for both listing and running tests).
- Show a message that `--track-runtime` forces `batch_size=1` (for reliable runtime tracking per test instead of per test batch).

### Future work

The old test runner has [4 usages](https://github.com/search?q=repo%3Aduckdb%2Fduckdb+scripts%2Frun_tests_one_by_one.py&type=code) left in `NightlyTests.yml`. I'll replace those another time. They could be valuable in spotting any issues (like any missed tests) with the new test runner, and the nightly tests are running at night, so could still catch those issue without slowing engineers down.