### PR TITLE
Make auto-complete work with column names from already bound views

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -300,8 +300,18 @@ static vector<AutoCompleteCandidate> SuggestColumnName(ClientContext &context) {
 		} else if (entry.type == CatalogType::VIEW_ENTRY) {
 			auto &view = entry.Cast<ViewCatalogEntry>();
 			int32_t bonus = entry.internal ? 0 : 3;
-			for (auto &col : view.aliases) {
-				suggestions.emplace_back(col, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+			auto column_info = view.GetColumnInfo();
+			if (column_info) {
+				// view has names
+				for (idx_t n = 0; n < column_info->names.size(); n++) {
+					auto &name = n < view.aliases.size() ? view.aliases[n] : column_info->names[n];
+					suggestions.emplace_back(name, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+				}
+			} else {
+				// add only aliases
+				for (auto &col : view.aliases) {
+					suggestions.emplace_back(col, SuggestionState::SUGGEST_COLUMN_NAME, bonus);
+				}
 			}
 		} else {
 			if (StringUtil::CharacterIsOperator(entry.name[0])) {

--- a/test/sql/function/autocomplete/views.test
+++ b/test/sql/function/autocomplete/views.test
@@ -1,0 +1,21 @@
+# name: test/sql/function/autocomplete/views.test
+# description: Test sql_auto_complete
+# group: [autocomplete]
+
+require autocomplete
+
+statement ok
+CREATE VIEW v1 AS SELECT 42 my_column_name
+
+query II
+SELECT suggestion, suggestion_start FROM sql_auto_complete('SELECT my_col') LIMIT 1;
+----
+my_column_name	7
+
+statement ok
+CREATE VIEW v2(alias_name) AS SELECT 42 alias
+
+query II
+SELECT suggestion, suggestion_start FROM sql_auto_complete('SELECT alias') LIMIT 1;
+----
+alias_name	7


### PR DESCRIPTION
When a view is bound, we can include the names of that view for auto-completion as they are already known. We don't bind views just for this as binding might be expensive - so if a view is unbound we only include the aliases provided by the user in the view definition.

CC @guillesd 