### PR TITLE
Add framework to test two DuckDB versions

### DIFF
--- a/.github/config/extensions/test-utils.cmake
+++ b/.github/config/extensions/test-utils.cmake
@@ -1,0 +1,8 @@
+duckdb_extension_load(test_utils
+  GIT_URL https://github.com/duckdb/bwc-test-utils
+  GIT_TAG df0ca97925bc8b3349ee7b1d0ad7496af077daf8
+  # For local dev:
+  # SOURCE_DIR "${EXTENSION_CONFIG_BASE_DIR}/../../../../test-utils"
+)
+
+include("${EXTENSION_CONFIG_BASE_DIR}/../in_tree_extensions.cmake")

--- a/.github/workflows/SerializationBWC.yml
+++ b/.github/workflows/SerializationBWC.yml
@@ -1,0 +1,136 @@
+name: SerializationBWC
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: bwc-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}
+  cancel-in-progress: true
+
+env:
+  GEN: ninja
+
+jobs:
+  build:
+    name: Build DuckDB
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build libcurl4-openssl-dev
+
+      - name: Setup ccache
+        uses: ./.github/actions/ccache-action
+
+      - name: Build DuckDB
+        run: |
+          make release \
+            EXTENSION_CONFIGS='.github/config/extensions/httpfs.cmake;.github/config/extensions/test-utils.cmake;.github/config/extensions/inet.cmake' \
+            DUCKDB_EXTENSIONS='tpcds;icu;autocomplete;tpch;json'
+
+      - name: Upload DuckDB binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: duckdb-binary
+          path: build/release/duckdb
+
+  bwc-test:
+    name: BWC Test (DuckDB ${{ matrix.old_duckdb_version }})
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        old_duckdb_version:
+          - v1.1.0
+          - v1.1.1
+          - v1.1.2
+          - v1.1.3
+          - v1.2.0
+          - v1.2.1
+          - v1.2.2
+          - v1.3.0
+          - v1.3.1
+          - v1.3.2
+          - v1.4.0
+          - v1.4.1
+          - v1.4.2
+          - v1.4.3
+          - v1.4.4
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Download DuckDB binary
+        uses: actions/download-artifact@v4
+        with:
+          name: duckdb-binary
+          path: build/release
+
+      - name: Make DuckDB binary executable
+        run: chmod +x build/release/duckdb
+
+      - name: Install Python dependencies
+        run: pip install duckdb git+https://github.com/duckdb/duckdb-sqllogictest-python.git
+
+      - name: Run BWC tests
+        run: python3.11 test/bwc/runner.py --old_duckdb_version=${{ matrix.old_duckdb_version }}
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bwc-test-results-${{ matrix.old_duckdb_version }}
+          path: |
+            duckdb_unittest_tempdir/bwc/tests_summary_*.txt
+            duckdb_unittest_tempdir/bwc/reports/test_report_*.duckdb
+
+  summary:
+    name: BWC Test Summary
+    runs-on: ubuntu-24.04
+    needs: bwc-test
+    if: always()
+    steps:
+      - name: Download all test artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bwc-test-results-*
+          merge-multiple: true
+
+      - name: Aggregate results
+        run: |
+          echo "============================================================"
+          echo "BWC Test Summary"
+          echo "============================================================"
+          failed=0
+          for summary in tests_summary_*.txt; do
+            [ -f "$summary" ] || continue
+            version=$(echo "$summary" | sed 's/tests_summary_\(.*\)\.txt/\1/')
+            failures=$(grep '# FAILED' "$summary" || true)
+            if [ -n "$failures" ]; then
+              echo ""
+              echo "Failed tests for DuckDB version '$version':"
+              echo "$failures" | while read -r line; do
+                echo "  $line"
+              done
+              failed=1
+            fi
+          done
+          echo "============================================================"
+          if [ "$failed" -eq 1 ]; then
+            echo "Some BWC tests failed."
+            exit 1
+          else
+            echo "All BWC tests passed."
+          fi

--- a/.github/workflows/SerializationBWC.yml
+++ b/.github/workflows/SerializationBWC.yml
@@ -84,8 +84,39 @@ jobs:
       - name: Install Python dependencies
         run: pip install duckdb git+https://github.com/duckdb/duckdb-sqllogictest-python.git
 
+      - name: Download BWC cache
+        run: |
+          VERSION=${{ matrix.old_duckdb_version }}
+          CACHE_ARCHIVE="runtime_${VERSION}.tar.gz"
+          RUNTIME_DIR="duckdb_unittest_tempdir/bwc/runtime"
+          mkdir -p "${RUNTIME_DIR}"
+
+          # Download the cache archive from test-utils repo
+          DOWNLOAD_URL="https://raw.githubusercontent.com/duckdb/bwc-test-utils/main/cache/${CACHE_ARCHIVE}"
+          HTTP_CODE=$(curl -sL -w '%{http_code}' -o "/tmp/${CACHE_ARCHIVE}" "${DOWNLOAD_URL}" || true)
+
+          if [ "${HTTP_CODE}" != "200" ]; then
+            echo "Failed to download cache for ${VERSION} (HTTP ${HTTP_CODE})"
+            exit 1
+          fi
+
+          tar xzf "/tmp/${CACHE_ARCHIVE}" -C "${RUNTIME_DIR}"
+          CACHED=$(find "${RUNTIME_DIR}/${VERSION}" -name "*.plan.bin" | wc -l)
+          echo "Extracted cache for ${VERSION}: ${CACHED} cached test plans"
+
       - name: Run BWC tests
         run: python3.11 test/bwc/runner.py --old_duckdb_version=${{ matrix.old_duckdb_version }}
+
+      - name: Export BWC cache
+        if: always()
+        run: python3.11 test/bwc/export_cache.py --version ${{ matrix.old_duckdb_version }} --output-dir duckdb_unittest_tempdir/bwc/cache
+
+      - name: Upload BWC cache
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bwc-cache-${{ matrix.old_duckdb_version }}
+          path: duckdb_unittest_tempdir/bwc/cache/runtime_${{ matrix.old_duckdb_version }}.tar.gz
 
       - name: Upload test artifacts
         if: always()

--- a/.github/workflows/SerializationBWC.yml
+++ b/.github/workflows/SerializationBWC.yml
@@ -85,6 +85,7 @@ jobs:
         run: pip install duckdb git+https://github.com/duckdb/duckdb-sqllogictest-python.git
 
       - name: Download BWC cache
+        if: false
         run: |
           VERSION=${{ matrix.old_duckdb_version }}
           CACHE_ARCHIVE="runtime_${VERSION}.tar.gz"

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ projects/*
 # Autotools artifacts
 #==============================================================================#
 config/
+!.github/config/
 configure
 config-h.in
 autom4te.cache

--- a/Makefile
+++ b/Makefile
@@ -572,3 +572,6 @@ setup-vcpkg: vcpkg/scripts/buildsystems/vcpkg.cmake
 
 cleanup-vcpkg:
 	rm -rf vcpkg
+
+test-utils:
+	make release EXTENSION_CONFIGS='.github/config/extensions/httpfs.cmake;.github/config/extensions/test-utils.cmake;.github/config/extensions/inet.cmake' DUCKDB_EXTENSIONS='tpcds;icu;autocomplete;tpch;json'

--- a/test/bwc/export_cache.py
+++ b/test/bwc/export_cache.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Exports the BWC test cache from runtime directories.
+
+For each version, creates a tar.gz archive containing only the files needed
+for cached test runs:
+  - *.sql (generated query files)
+  - *.plan.bin (serialized execution plans)
+  - *.<version>.result.bin (old version results)
+  - fixtures/ directories (test fixture databases)
+
+Usage:
+  python3 test/bwc/export_cache.py [--version v1.4.4] [--output-dir /path/to/output]
+
+By default, exports all versions found in the runtime directory.
+"""
+
+import argparse
+import os
+import tarfile
+import sys
+from os.path import abspath, dirname
+
+parser = argparse.ArgumentParser(description='Export BWC test cache from runtime directories')
+parser.add_argument('--version', dest='version', help='Export cache for a specific version only')
+parser.add_argument(
+    '--output-dir',
+    dest='output_dir',
+    help='Output directory for cache archives (default: current directory)',
+    default='.',
+)
+parser.add_argument('--runtime-dir', dest='runtime_dir', help='Path to the BWC runtime directory', default=None)
+
+args = parser.parse_args()
+
+duckdb_root_dir = dirname(dirname(dirname(abspath(__file__))))
+
+
+def get_runtime_dir():
+    if args.runtime_dir:
+        return args.runtime_dir
+    return os.path.join(duckdb_root_dir, 'duckdb_unittest_tempdir', 'bwc', 'runtime')
+
+
+def should_include(file_path, version):
+    """Check if a file should be included in the cache archive."""
+    basename = os.path.basename(file_path)
+    # Include SQL query files
+    if basename.endswith('.sql'):
+        return True
+    # Include serialized plans
+    if basename.endswith('.plan.bin'):
+        return True
+    # Include old version results (e.g., test.v1.4.4.result.bin)
+    if basename.endswith(f'.{version}.result.bin'):
+        return True
+    return False
+
+
+def should_include_dir(dir_name):
+    """Check if a directory should be included."""
+    return dir_name == 'fixtures'
+
+
+def export_version(version, runtime_dir, output_dir):
+    version_dir = os.path.join(runtime_dir, version)
+    if not os.path.isdir(version_dir):
+        print(f"Warning: runtime directory not found for {version}: {version_dir}")
+        return None
+
+    archive_name = f"runtime_{version}.tar.gz"
+    archive_path = os.path.join(output_dir, archive_name)
+
+    file_count = 0
+    with tarfile.open(archive_path, 'w:gz') as tar:
+        for root, dirs, files in os.walk(version_dir):
+            # Skip output directories and symlinks
+            dirs[:] = [d for d in dirs if not d.startswith('output') and not os.path.islink(os.path.join(root, d))]
+
+            rel_root = os.path.relpath(root, runtime_dir)
+
+            # Include fixture directories entirely
+            fixture_dirs = [d for d in dirs if should_include_dir(d)]
+            for d in fixture_dirs:
+                fixture_path = os.path.join(root, d)
+                arcname = os.path.join(rel_root, d)
+                tar.add(fixture_path, arcname=arcname)
+                file_count += sum(len(f) for _, _, f in os.walk(fixture_path))
+                # Don't recurse into fixtures again
+                dirs.remove(d)
+
+            for file in files:
+                file_path = os.path.join(root, file)
+                if should_include(file_path, version):
+                    arcname = os.path.join(rel_root, file)
+                    tar.add(file_path, arcname=arcname)
+                    file_count += 1
+
+    size_mb = os.path.getsize(archive_path) / (1024 * 1024)
+    print(f"Exported {version}: {file_count} files -> {archive_path} ({size_mb:.1f} MB)")
+    return archive_path
+
+
+if __name__ == '__main__':
+    runtime_dir = get_runtime_dir()
+    if not os.path.isdir(runtime_dir):
+        print(f"Error: runtime directory not found: {runtime_dir}")
+        sys.exit(1)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    if args.version:
+        versions = [args.version]
+    else:
+        versions = sorted(
+            [d for d in os.listdir(runtime_dir) if d.startswith('v') and os.path.isdir(os.path.join(runtime_dir, d))]
+        )
+
+    if not versions:
+        print(f"No version directories found in {runtime_dir}")
+        sys.exit(1)
+
+    print(f"Exporting cache for {len(versions)} version(s) from {runtime_dir}")
+    exported = []
+    for version in versions:
+        result = export_version(version, runtime_dir, args.output_dir)
+        if result:
+            exported.append(result)
+
+    print(f"\nDone: exported {len(exported)}/{len(versions)} archives to {args.output_dir}")

--- a/test/bwc/runner.py
+++ b/test/bwc/runner.py
@@ -96,296 +96,343 @@ args = parser.parse_args()
 
 
 class TestRunnerContext:
-  def __init__(self, old_duckdb_version, new_cli_path, nb_tests, summary_file, report_con):
-    self.old_cli_path = make_cli_path(old_duckdb_version)
-    self.new_cli_path = new_cli_path
-    self.nb_tests = nb_tests
-    self.summary_file = summary_file
-    self.report_con = report_con
-    self.report_lock = Lock()
+    def __init__(self, old_duckdb_version, new_cli_path, nb_tests, summary_file, report_con):
+        self.old_cli_path = make_cli_path(old_duckdb_version)
+        self.new_cli_path = new_cli_path
+        self.nb_tests = nb_tests
+        self.summary_file = summary_file
+        self.report_con = report_con
+        self.report_lock = Lock()
 
-  def initialize(self):
-    self.old_cli_v = '-'.join(get_version(self.old_cli_path))
-    logger.info(f"Old CLI path: {self.old_cli_path} @ {self.old_cli_v}")
+    def initialize(self):
+        self.old_cli_v = '-'.join(get_version(self.old_cli_path))
+        logger.info(f"Old CLI path: {self.old_cli_path} @ {self.old_cli_v}")
 
-    self.new_cli_v = '-'.join(get_version(self.new_cli_path))
-    logger.info(f"New CLI path: {self.new_cli_path} @ {self.new_cli_v}")
+        self.new_cli_v = '-'.join(get_version(self.new_cli_path))
+        logger.info(f"New CLI path: {self.new_cli_path} @ {self.new_cli_v}")
 
 
 def run_multi_clis(clis, c):
-  results = []
-  for cli in clis:
-    r = cli.execute_command(c)
-    results.append(r)
-  return results
+    results = []
+    for cli in clis:
+        r = cli.execute_command(c)
+        results.append(r)
+    return results
 
 
 TRANSIENT_ERROR_PATTERNS = [
-  "Could not set lock on file",
-  "HTTP",
-  "Connection",
-  "Unable to connect",
+    "Could not set lock on file",
+    "HTTP",
+    "Connection",
+    "Unable to connect",
 ]
 
 
 def is_transient_error(output):
-  error = output.get("error") or ""
-  exception = output.get("exception_message") or ""
-  combined = error + exception
-  return len(combined) == 0 or any(pattern in combined for pattern in TRANSIENT_ERROR_PATTERNS)
+    error = output.get("error") or ""
+    exception = output.get("exception_message") or ""
+    combined = error + exception
+    return len(combined) == 0 or any(pattern in combined for pattern in TRANSIENT_ERROR_PATTERNS)
 
 
 def run_step(cli, report, func_name, *args):
-  str_args = ", ".join([f"'{arg}'" for arg in args])
-  command = f"CALL {func_name}({str_args});"
-  output = cli.execute_command(command)
+    str_args = ", ".join([f"'{arg}'" for arg in args])
+    command = f"CALL {func_name}({str_args});"
+    output = cli.execute_command(command)
 
-  # Retry on transient errors (file locks, network issues)
-  if not output["success"] and is_transient_error(output):
-    for attempt in range(1, 4):
-      logger.warning(f"[{cli.version}] Transient error, retrying in {attempt}s (attempt {attempt}/3)")
-      time.sleep(attempt)
-      output = cli.execute_command(command)
-      if output["success"] or not is_transient_error(output):
-        break
+    # Retry on transient errors (file locks, network issues)
+    if not output["success"] and is_transient_error(output):
+        for attempt in range(1, 4):
+            logger.warning(f"[{cli.version}] Transient error, retrying in {attempt}s (attempt {attempt}/3)")
+            time.sleep(attempt)
+            output = cli.execute_command(command)
+            if output["success"] or not is_transient_error(output):
+                break
 
-  # We had to name the functions `tu_compare_results_from_xxx`
-  # in DuckDB 1.1.x to avoid collision and support overloading.
-  step_name = "compare_results" if "compare_results" in func_name else func_name
-  return report.end_step(step_name, output)
+    # We had to name the functions `tu_compare_results_from_xxx`
+    # in DuckDB 1.1.x to avoid collision and support overloading.
+    step_name = "compare_results" if "compare_results" in func_name else func_name
+    return report.end_step(step_name, output)
+
 
 def get_extensions_versions(clis):
-  results = run_multi_clis(clis, "SELECT extension_version FROM duckdb_extensions() WHERE extension_name='test_utils';")
-  versions = []
-  for r in results:
-    if not r["success"]:
-      raise RuntimeError(f"Failed to get extension version: {r['error']}")
-    # Find the actual version value, skipping the CSV header and any stale output
-    version = None
-    for line in r["output"]:
-      if line and line != "extension_version":
-        version = line
-        break
-    if not version:
-      raise RuntimeError(f"test-utils extension not loaded for CLI '{clis[len(versions)].version}' - output: {r['output']}")
-    versions.append(version)
-  return versions
+    results = run_multi_clis(
+        clis, "SELECT extension_version FROM duckdb_extensions() WHERE extension_name='test_utils';"
+    )
+    versions = []
+    for r in results:
+        if not r["success"]:
+            raise RuntimeError(f"Failed to get extension version: {r['error']}")
+        # Find the actual version value, skipping the CSV header and any stale output
+        version = None
+        for line in r["output"]:
+            if line and line != "extension_version":
+                version = line
+                break
+        if not version:
+            raise RuntimeError(
+                f"test-utils extension not loaded for CLI '{clis[len(versions)].version}' - output: {r['output']}"
+            )
+        versions.append(version)
+    return versions
 
 
 def do_run_test(ctx, test_spec):
-  global has_checked_versions
-  logger.info(f"Running test {test_spec.test_idx}/{ctx.nb_tests}: {test_spec.test_spec_relative_path}")
-  report = TestReport(test_spec, ctx.old_cli_v, ctx.new_cli_v)
-  sanity_checks = False
-  with DuckDBCLI(ctx.old_cli_path, unsigned=True) as old_cli:
-    with DuckDBCLI(ctx.new_cli_path, unsigned=True) as new_cli:
-      ext_path = 'test_utils'
-      run_multi_clis([old_cli, new_cli], f".cd {test_spec.test_runtime_directory}\nLOAD '{ext_path}'")
-      logger.debug(f"Loaded extension from '{ext_path}'")
-      if sanity_checks:
-        run_multi_clis([old_cli, new_cli], "pragma version;")
-        run_multi_clis([old_cli, new_cli], "SELECT extension_name, loaded, extension_version FROM duckdb_extensions() WHERE extension_name='test_utils';")
+    global has_checked_versions
+    logger.info(f"Running test {test_spec.test_idx}/{ctx.nb_tests}: {test_spec.test_spec_relative_path}")
+    report = TestReport(test_spec, ctx.old_cli_v, ctx.new_cli_v)
+    sanity_checks = False
+    with DuckDBCLI(ctx.old_cli_path, unsigned=True) as old_cli:
+        with DuckDBCLI(ctx.new_cli_path, unsigned=True) as new_cli:
+            ext_path = 'test_utils'
+            run_multi_clis([old_cli, new_cli], f".cd {test_spec.test_runtime_directory}\nLOAD '{ext_path}'")
+            logger.debug(f"Loaded extension from '{ext_path}'")
+            if sanity_checks:
+                run_multi_clis([old_cli, new_cli], "pragma version;")
+                run_multi_clis(
+                    [old_cli, new_cli],
+                    "SELECT extension_name, loaded, extension_version FROM duckdb_extensions() WHERE extension_name='test_utils';",
+                )
 
-      if not has_checked_versions:
-        versions = get_extensions_versions([old_cli, new_cli])
-        if versions[0] != versions[1]:
-          # make release EXTENSION_CONFIGS=.github/config/extensions/test-utils.cmake to compile in this repo
-          raise RuntimeError(f"test-utils extension version mismatch: {old_cli.version} is @ {versions[0]} and {new_cli.version} is @ {versions[1]}")
-        has_checked_versions = True
+            if not has_checked_versions:
+                versions = get_extensions_versions([old_cli, new_cli])
+                if versions[0] != versions[1]:
+                    # make release EXTENSION_CONFIGS=.github/config/extensions/test-utils.cmake to compile in this repo
+                    raise RuntimeError(
+                        f"test-utils extension version mismatch: {old_cli.version} is @ {versions[0]} and {new_cli.version} is @ {versions[1]}"
+                    )
+                has_checked_versions = True
 
-      # Cleanup output directory in case previous runs left files there
-      test_spec.reset_output_directory()
+            # Cleanup output directory in case previous runs left files there
+            test_spec.reset_output_directory()
 
-      # First serialize the queries & run them in the first version
-      compare_func = "tu_compare_results_from_memory"
-      compare_args = [test_spec.results_new_file_name]
-      if test_spec.has_cached_serialized_plans:
-        compare_args.append(test_spec.results_old_file_name) # Load old results for comparison
-        compare_func = "tu_compare_results_from_file"
-        report.end_cached_step("serialize_queries_plans", test_spec.queries_file_name, test_spec.serialized_plans_file_name)
-        report.end_cached_step("serialize_results", test_spec.results_old_file_name)
-      else:
-        if not run_step(old_cli, report, "serialize_queries_plans", test_spec.queries_file_name, test_spec.serialized_plans_file_name):
-          return report
+            # First serialize the queries & run them in the first version
+            compare_func = "tu_compare_results_from_memory"
+            compare_args = [test_spec.results_new_file_name]
+            if test_spec.has_cached_serialized_plans:
+                compare_args.append(test_spec.results_old_file_name)  # Load old results for comparison
+                compare_func = "tu_compare_results_from_file"
+                report.end_cached_step(
+                    "serialize_queries_plans", test_spec.queries_file_name, test_spec.serialized_plans_file_name
+                )
+                report.end_cached_step("serialize_results", test_spec.results_old_file_name)
+            else:
+                if not run_step(
+                    old_cli,
+                    report,
+                    "serialize_queries_plans",
+                    test_spec.queries_file_name,
+                    test_spec.serialized_plans_file_name,
+                ):
+                    return report
 
-        # TODO - merge results in serialized file?
-        if not run_step(old_cli, report, "serialize_results", test_spec.results_old_file_name):
-          return report
+                # TODO - merge results in serialized file?
+                if not run_step(old_cli, report, "serialize_results", test_spec.results_old_file_name):
+                    return report
 
-        # We need to provide a clean output folder for the other CLI
-        test_spec.reset_output_directory()
+                # We need to provide a clean output folder for the other CLI
+                test_spec.reset_output_directory()
 
-      # Then execute the plans in the second version
-      if not run_step(new_cli, report, "execute_all_plans_from_file", test_spec.serialized_plans_file_name, test_spec.results_new_file_name):
-        return report
+            # Then execute the plans in the second version
+            if not run_step(
+                new_cli,
+                report,
+                "execute_all_plans_from_file",
+                test_spec.serialized_plans_file_name,
+                test_spec.results_new_file_name,
+            ):
+                return report
 
-      # Now compare the results
-      run_step(old_cli, report, compare_func, *compare_args)
-      report.load_comparison_results()
-      return report
+            # Now compare the results
+            run_step(old_cli, report, compare_func, *compare_args)
+            report.load_comparison_results()
+            return report
+
 
 def write_summary_file(ctx, to_write):
-  with ctx.report_lock:
-    ctx.summary_file.write(to_write)
-    ctx.summary_file.flush()
+    with ctx.report_lock:
+        ctx.summary_file.write(to_write)
+        ctx.summary_file.flush()
+
 
 def run_one_test_and_log(ctx, test):
-  if cancel_event.is_set():
-    return None
+    if cancel_event.is_set():
+        return None
 
-  try:
-    report = do_run_test(ctx, test)
-    if report.is_successful():
-      write_summary_file(ctx, f"{test.test_spec_relative_path}\n")
-      logger.info(f"Test {test.test_idx}/{ctx.nb_tests}: {test.test_spec_relative_path} - SUCCESS")
-    else:
-      em = report.find_exception_message()
-      write_summary_file(ctx, f"{test.test_spec_relative_path} # FAILED: {em}\n")
-      logger.error(f"Test {test.test_idx}/{ctx.nb_tests}: {test.test_spec_relative_path} - ❌ FAILED: {em}")
+    try:
+        report = do_run_test(ctx, test)
+        if report.is_successful():
+            write_summary_file(ctx, f"{test.test_spec_relative_path}\n")
+            logger.info(f"Test {test.test_idx}/{ctx.nb_tests}: {test.test_spec_relative_path} - SUCCESS")
+        else:
+            em = report.find_exception_message()
+            write_summary_file(ctx, f"{test.test_spec_relative_path} # FAILED: {em}\n")
+            logger.error(f"Test {test.test_idx}/{ctx.nb_tests}: {test.test_spec_relative_path} - ❌ FAILED: {em}")
 
-    with ctx.report_lock:
-      ctx.report_con.execute(TestReport.report_insert(), report.report_sql_values())
-      ctx.report_con.commit()
+        with ctx.report_lock:
+            ctx.report_con.execute(TestReport.report_insert(), report.report_sql_values())
+            ctx.report_con.commit()
 
-    return report
-  except Exception as e:
-    cancel_event.set()
-    raise
+        return report
+    except Exception as e:
+        cancel_event.set()
+        raise
+
 
 def cleanup_runtime_dir(bwc_tests_base_dir, dry_run=True):
-  runtime_dir = f"{bwc_tests_base_dir}/runtime"
-  logger.info(f"Cleaning up BWC directory '{runtime_dir}'")
-  delete_list = []
-  # Remove new result files, any 'output' dir, and 'data' & 'test' symlinks
-  for root, dirs, files in os.walk(runtime_dir):
-    for file in files:
-      file_path = os.path.join(root, file)
-      if file.endswith(".new.result.bin"):
-        delete_list.append(file_path)
-    for dir in dirs:
-      dir_path = os.path.join(root, dir)
-      if dir.startswith("output") or (os.path.islink(dir_path) and (dir == "data" or dir == "test")):
-        delete_list.append(dir_path)
+    runtime_dir = f"{bwc_tests_base_dir}/runtime"
+    logger.info(f"Cleaning up BWC directory '{runtime_dir}'")
+    delete_list = []
+    # Remove new result files, any 'output' dir, and 'data' & 'test' symlinks
+    for root, dirs, files in os.walk(runtime_dir):
+        for file in files:
+            file_path = os.path.join(root, file)
+            if file.endswith(".new.result.bin"):
+                delete_list.append(file_path)
+        for dir in dirs:
+            dir_path = os.path.join(root, dir)
+            if dir.startswith("output") or (os.path.islink(dir_path) and (dir == "data" or dir == "test")):
+                delete_list.append(dir_path)
 
-  if dry_run:
-    logger.info(f"{len(delete_list)} files would be deleted - re-run with `--dry_run=False` argument to actually delete them")
-    for file_path in delete_list:
-      logger.debug(f"  {file_path}")
-  else:
-    removed = 0
-    for file_path in delete_list:
-      try:
-        if os.path.isfile(file_path) or os.path.islink(file_path):
-          os.remove(file_path)
-          removed += 1
-        elif os.path.isdir(file_path):
-          shutil.rmtree(file_path)
-          removed += 1
-      except Exception as e:
-        logger.error(f"Failed to delete '{file_path}': {e}")
-    logger.info(f"Cleanup completed, deleted {removed}/{len(delete_list)} files/directories")
+    if dry_run:
+        logger.info(
+            f"{len(delete_list)} files would be deleted - re-run with `--dry_run=False` argument to actually delete them"
+        )
+        for file_path in delete_list:
+            logger.debug(f"  {file_path}")
+    else:
+        removed = 0
+        for file_path in delete_list:
+            try:
+                if os.path.isfile(file_path) or os.path.islink(file_path):
+                    os.remove(file_path)
+                    removed += 1
+                elif os.path.isdir(file_path):
+                    shutil.rmtree(file_path)
+                    removed += 1
+            except Exception as e:
+                logger.error(f"Failed to delete '{file_path}': {e}")
+        logger.info(f"Cleanup completed, deleted {removed}/{len(delete_list)} files/directories")
 
 
 if __name__ == "__main__":
-  supported_duckdb_versions = [args.old_duckdb_version] if args.old_duckdb_version else [
-    "v1.1.0", "v1.1.2", "v1.1.1",
-    "v1.2.0", "v1.1.3", "v1.2.2", "v1.2.1",
-    "v1.3.0", "v1.3.1", "v1.3.2",
-    "v1.4.0", "v1.4.1", "v1.4.2", "v1.4.3", "v1.4.4"
-  ]
+    supported_duckdb_versions = (
+        [args.old_duckdb_version]
+        if args.old_duckdb_version
+        else [
+            "v1.1.0",
+            "v1.1.2",
+            "v1.1.1",
+            "v1.2.0",
+            "v1.1.3",
+            "v1.2.2",
+            "v1.2.1",
+            "v1.3.0",
+            "v1.3.1",
+            "v1.3.2",
+            "v1.4.0",
+            "v1.4.1",
+            "v1.4.2",
+            "v1.4.3",
+            "v1.4.4",
+        ]
+    )
 
-  duckdb_root_dir = dirname(dirname(dirname(abspath(__file__))))
-  logger.info(f"DuckDB root dir: '{duckdb_root_dir}'")
-  bwc_tests_base_dir = f"{duckdb_root_dir}/duckdb_unittest_tempdir/bwc"
+    duckdb_root_dir = dirname(dirname(dirname(abspath(__file__))))
+    logger.info(f"DuckDB root dir: '{duckdb_root_dir}'")
+    bwc_tests_base_dir = f"{duckdb_root_dir}/duckdb_unittest_tempdir/bwc"
 
-  if args.cleanup_bwc_directory:
-    cleanup_runtime_dir(bwc_tests_base_dir, dry_run=args.dry_run)
-    sys.exit(0)
+    if args.cleanup_bwc_directory:
+        cleanup_runtime_dir(bwc_tests_base_dir, dry_run=args.dry_run)
+        sys.exit(0)
 
-  # Create the report database
-  os.makedirs(f"{bwc_tests_base_dir}/reports", exist_ok=True)
-  ts = time.strftime("%Y%m%d_%H%M%S")
-  version_suffix = args.old_duckdb_version if args.old_duckdb_version else "multi_version"
-  report_db_path = f"{bwc_tests_base_dir}/reports/test_report_{version_suffix}_{ts}.duckdb"
-  con = duckdb.connect(report_db_path)
-  con.execute(TestReport.report_schema())
-  con.commit()
+    # Create the report database
+    os.makedirs(f"{bwc_tests_base_dir}/reports", exist_ok=True)
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    version_suffix = args.old_duckdb_version if args.old_duckdb_version else "multi_version"
+    report_db_path = f"{bwc_tests_base_dir}/reports/test_report_{version_suffix}_{ts}.duckdb"
+    con = duckdb.connect(report_db_path)
+    con.execute(TestReport.report_schema())
+    con.commit()
 
-  logger.info(f"Report database created at '{report_db_path}'")
+    logger.info(f"Report database created at '{report_db_path}'")
 
-  # Install DuckDB CLIs and test suites for all supported versions
-  with ThreadPoolExecutor(max_workers=10) as executor:
-    list(executor.map(lambda version: install_assets(version, bwc_tests_base_dir), supported_duckdb_versions))
+    # Install DuckDB CLIs and test suites for all supported versions
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        list(executor.map(lambda version: install_assets(version, bwc_tests_base_dir), supported_duckdb_versions))
 
-  nb_tests_run = 0
-  nb_success = 0
-  failed_tests = []
-  for old_duckdb_version in supported_duckdb_versions:
-    logger.info(f"Running tests for DuckDB version '{old_duckdb_version}'")
+    nb_tests_run = 0
+    nb_success = 0
+    failed_tests = []
+    for old_duckdb_version in supported_duckdb_versions:
+        logger.info(f"Running tests for DuckDB version '{old_duckdb_version}'")
 
-    new_cli_path = f"{duckdb_root_dir}/build/release/duckdb" if args.new_cli_path is None else args.new_cli_path
+        new_cli_path = f"{duckdb_root_dir}/build/release/duckdb" if args.new_cli_path is None else args.new_cli_path
 
-    summary_file_path = f"{bwc_tests_base_dir}/tests_summary_{old_duckdb_version}.txt"
-    with open(summary_file_path, 'a') as summary_file:
-      summary_file.write(f"\n## --- Starting run at {time.strftime('%Y-%m-%d %H:%M:%S')} ---\n")
-      summary_file.flush()
-      test_pattern = args.test_pattern
-      single_test_file = args.test_file
-      res = load_test_files(duckdb_root_dir, bwc_tests_base_dir, old_duckdb_version, test_pattern, single_test_file)
-      tests = res['tests']
+        summary_file_path = f"{bwc_tests_base_dir}/tests_summary_{old_duckdb_version}.txt"
+        with open(summary_file_path, 'a') as summary_file:
+            summary_file.write(f"\n## --- Starting run at {time.strftime('%Y-%m-%d %H:%M:%S')} ---\n")
+            summary_file.flush()
+            test_pattern = args.test_pattern
+            single_test_file = args.test_file
+            res = load_test_files(
+                duckdb_root_dir, bwc_tests_base_dir, old_duckdb_version, test_pattern, single_test_file
+            )
+            tests = res['tests']
 
-      runner_context = TestRunnerContext(old_duckdb_version, new_cli_path, len(tests), summary_file, con)
-      runner_context.initialize()
+            runner_context = TestRunnerContext(old_duckdb_version, new_cli_path, len(tests), summary_file, con)
+            runner_context.initialize()
 
-      extensions = res['needed_extensions']
-      extensions.add('test_utils')
-      install_extensions(runner_context.old_cli_path, extensions)
-      install_extensions(runner_context.new_cli_path, extensions)
+            extensions = res['needed_extensions']
+            extensions.add('test_utils')
+            install_extensions(runner_context.old_cli_path, extensions)
+            install_extensions(runner_context.new_cli_path, extensions)
 
-      run_sequentially = args.run_sequentially or test_pattern is not None
-      stop_on_failure = args.stop_on_failure
-      start_time = time.time()
-      nb_tests_run = 0
-      if run_sequentially:
-        for test in tests:
-          report = run_one_test_and_log(runner_context, test)
-          nb_tests_run += 1
+            run_sequentially = args.run_sequentially or test_pattern is not None
+            stop_on_failure = args.stop_on_failure
+            start_time = time.time()
+            nb_tests_run = 0
+            if run_sequentially:
+                for test in tests:
+                    report = run_one_test_and_log(runner_context, test)
+                    nb_tests_run += 1
 
-          if report.is_successful():
-            nb_success += 1
-          else:
-            failed_tests.append((old_duckdb_version, report.test_relative_path))
-            if stop_on_failure:
-              break
-            elif test_pattern is not None:
-              report.log_errors()
-              report.log_steps_queries()
-      else:
-        with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
-          reports = executor.map(lambda test: run_one_test_and_log(runner_context, test), tests)
+                    if report.is_successful():
+                        nb_success += 1
+                    else:
+                        failed_tests.append((old_duckdb_version, report.test_relative_path))
+                        if stop_on_failure:
+                            break
+                        elif test_pattern is not None:
+                            report.log_errors()
+                            report.log_steps_queries()
+            else:
+                with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+                    reports = executor.map(lambda test: run_one_test_and_log(runner_context, test), tests)
 
-        reports_list = list(reports)
-        nb_tests_run = len(reports_list)
-        nb_success = sum(1 for r in reports_list if r.is_successful())
-        for r in reports_list:
-          if not r.is_successful():
-            failed_tests.append((old_duckdb_version, r.test_relative_path))
+                reports_list = list(reports)
+                nb_tests_run = len(reports_list)
+                nb_success = sum(1 for r in reports_list if r.is_successful())
+                for r in reports_list:
+                    if not r.is_successful():
+                        failed_tests.append((old_duckdb_version, r.test_relative_path))
 
-      elapsed = time.time() - start_time
-      tps = nb_tests_run / elapsed if elapsed > 0 else 0
-      nb_failed = nb_tests_run - nb_success
-      logger.info(f"All tests completed in {elapsed:.2f}s - {nb_tests_run} tests run, {nb_success} successful, {nb_failed} failed - {tps:.2f} tests per second.")
+            elapsed = time.time() - start_time
+            tps = nb_tests_run / elapsed if elapsed > 0 else 0
+            nb_failed = nb_tests_run - nb_success
+            logger.info(
+                f"All tests completed in {elapsed:.2f}s - {nb_tests_run} tests run, {nb_success} successful, {nb_failed} failed - {tps:.2f} tests per second."
+            )
 
-  if len(failed_tests) == 0:
-    logger.info("All tests passed successfully! 🎉")
-    sys.exit(0)
+    if len(failed_tests) == 0:
+        logger.info("All tests passed successfully! 🎉")
+        sys.exit(0)
 
-  last_version = None
-  for version, test_path in failed_tests:
-    if version != last_version:
-      logger.info(f"Failed tests for DuckDB version '{version}':")
-      logger.info(f"{'-'*40}")
-      last_version = version
-    logger.info(test_path)
-  sys.exit(1)
-
+    last_version = None
+    for version, test_path in failed_tests:
+        if version != last_version:
+            logger.info(f"Failed tests for DuckDB version '{version}':")
+            logger.info(f"{'-'*40}")
+            last_version = version
+        logger.info(test_path)
+    sys.exit(1)

--- a/test/bwc/runner.py
+++ b/test/bwc/runner.py
@@ -1,4 +1,5 @@
 import shutil
+import argparse
 from utils.duckdb_cli import DuckDBCLI
 from utils.duckdb_installer import install_assets, install_extensions, make_cli_path
 from utils.test_files_parser import load_test_files
@@ -14,6 +15,84 @@ import duckdb
 
 logger = make_logger(__name__)
 cancel_event = Event()
+has_checked_versions = False
+
+parser = argparse.ArgumentParser(description='Runs the serialization BWC tests')
+
+parser.add_argument(
+    '--cleanup_bwc_directory',
+    dest='cleanup_bwc_directory',
+    action='store',
+    help='When set, the script will clean up the BWC runtime directory. Use with `dry_run=False` argument to actually delete the files.',
+    default=False,
+)
+
+parser.add_argument(
+    '--dry_run',
+    dest='dry_run',
+    action='store',
+    help='When set, the cleanup of the BWC runtime directory will actually delete the files instead of just logging them.',
+    default=True,
+)
+
+parser.add_argument(
+    '--test_pattern',
+    dest='test_pattern',
+    action='store',
+    help='When set, only tests whose relative path contains the given pattern will be run. Example: `--test_pattern=window` will only run tests that have "window" in their path.',
+    default=None,
+)
+
+parser.add_argument(
+    '--stop_on_failure',
+    dest='stop_on_failure',
+    action='store',
+    help='When set, the test runner will stop executing further tests after the first failure. This can be useful when debugging a specific test or when you want to quickly identify if there are any issues without running the entire suite.',
+    default=False,
+)
+
+parser.add_argument(
+    '--run_sequentially',
+    dest='run_sequentially',
+    action='store',
+    help='When set, the test runner will execute tests sequentially instead of in parallel. This can be useful for debugging or when running a subset of tests to get more detailed logs.',
+    default=False,
+)
+
+parser.add_argument(
+    '--old_duckdb_version',
+    dest='old_duckdb_version',
+    action='store',
+    help='The old DuckDB version to test against. If not set, tests will be run for all supported versions.',
+    default=None,
+)
+
+parser.add_argument(
+    '--max_workers',
+    dest='max_workers',
+    action='store',
+    help='The maximum number of worker threads to use when running tests in parallel. Default is 24.',
+    type=int,
+    default=24,
+)
+
+parser.add_argument(
+    '--new_cli_path',
+    dest='new_cli_path',
+    action='store',
+    help='Path to the new DuckDB CLI to test. If not set, it will default to "build/release/duckdb" in the repo.',
+    default=None,
+)
+
+parser.add_argument(
+    '--test_file',
+    dest='test_file',
+    action='store',
+    help='Path to a test file to run',
+    default=None,
+)
+
+args = parser.parse_args()
 
 def run_multi_clis(clis, c):
   results = []
@@ -76,6 +155,7 @@ def get_extensions_versions(clis):
 
 
 def do_run_test(old_cli_path, new_cli_path, nb_tests, test_spec):
+  global has_checked_versions
   logger.info(f"Running test {test_spec.test_idx}/{nb_tests}: {test_spec.test_spec_relative_path}")
   report = TestReport(test_spec)
   sanity_checks = False
@@ -88,12 +168,14 @@ def do_run_test(old_cli_path, new_cli_path, nb_tests, test_spec):
         run_multi_clis([old_cli, new_cli], "pragma version;")
         run_multi_clis([old_cli, new_cli], "SELECT extension_name, loaded, extension_version FROM duckdb_extensions() WHERE extension_name='test_utils';")
 
-      versions = get_extensions_versions([old_cli, new_cli])
-      if versions[0] != versions[1]:
-        # make release EXTENSION_CONFIGS=.github/config/extensions/test-utils.cmake to compile in this repo
-        raise RuntimeError(f"test-utils extension version mismatch: {old_cli.version} is @ {versions[0]} and {new_cli.version} is @ {versions[1]}")
+      if not has_checked_versions:
+        versions = get_extensions_versions([old_cli, new_cli])
+        if versions[0] != versions[1]:
+          # make release EXTENSION_CONFIGS=.github/config/extensions/test-utils.cmake to compile in this repo
+          raise RuntimeError(f"test-utils extension version mismatch: {old_cli.version} is @ {versions[0]} and {new_cli.version} is @ {versions[1]}")
+        has_checked_versions = True
 
-      # Cleanup ouptput directory in case previous runs left files there
+      # Cleanup output directory in case previous runs left files there
       test_spec.reset_output_directory()
 
       # First serialize the queries & run them in the first version
@@ -124,23 +206,23 @@ def do_run_test(old_cli_path, new_cli_path, nb_tests, test_spec):
       report.load_comparison_results()
       return report
 
-def write_skip_file(report_lock, skip_file, to_write):
+def write_summary_file(report_lock, summary_file, to_write):
   with report_lock:
-    skip_file.write(to_write)
-    skip_file.flush()
+    summary_file.write(to_write)
+    summary_file.flush()
 
-def run_one_test_and_log(old_cli_path, new_cli_path, nb_tests, test, skip_file, report_con, report_lock):
+def run_one_test_and_log(old_cli_path, new_cli_path, nb_tests, test, summary_file, report_con, report_lock):
   if cancel_event.is_set():
     return None
 
   try:
     report = do_run_test(old_cli_path, new_cli_path, nb_tests, test)
     if report.is_successful():
-      write_skip_file(report_lock, skip_file, f"{test.test_spec_relative_path}\n")
+      write_summary_file(report_lock, summary_file, f"{test.test_spec_relative_path}\n")
       logger.info(f"Test {test.test_idx}/{nb_tests}: {test.test_spec_relative_path} - SUCCESS")
     else:
       em = report.find_exception_message()
-      write_skip_file(report_lock, skip_file, f"{test.test_spec_relative_path} # FAILED: {em}\n")
+      write_summary_file(report_lock, summary_file, f"{test.test_spec_relative_path} # FAILED: {em}\n")
       logger.error(f"Test {test.test_idx}/{nb_tests}: {test.test_spec_relative_path} - ❌ FAILED: {em}")
 
     with report_lock:
@@ -152,7 +234,7 @@ def run_one_test_and_log(old_cli_path, new_cli_path, nb_tests, test, skip_file, 
     cancel_event.set()
     raise
 
-def cleanup_runtime_dir(bwc_tests_base_dir):
+def cleanup_runtime_dir(bwc_tests_base_dir, dry_run=True):
   runtime_dir = f"{bwc_tests_base_dir}/runtime"
   logger.info(f"Cleaning up BWC directory '{runtime_dir}'")
   delete_list = []
@@ -167,9 +249,8 @@ def cleanup_runtime_dir(bwc_tests_base_dir):
       if dir.startswith("output") or (os.path.islink(dir_path) and (dir == "data" or dir == "test")):
         delete_list.append(dir_path)
 
-  dry_run = len(sys.argv) < 3 or sys.argv[2] != "no_dry_run"
   if dry_run:
-    logger.info(f"{len(delete_list)} files would be deleted - re-run with `no_dry_run` argument to actually delete them")
+    logger.info(f"{len(delete_list)} files would be deleted - re-run with `--dry_run=False` argument to actually delete them")
     for file_path in delete_list:
       logger.debug(f"  {file_path}")
   else:
@@ -187,14 +268,19 @@ def cleanup_runtime_dir(bwc_tests_base_dir):
     logger.info(f"Cleanup completed, deleted {removed}/{len(delete_list)} files/directories")
 
 if __name__ == "__main__":
-  supported_duckdb_versions = ["v1.4.4"] # ["v1.1.0", "v1.1.2", "v1.1.1", "v1.2.0", "v1.1.3", "v1.2.2", "v1.2.1", "v1.3.0", "v1.3.1", "v1.3.2", "1.4.0", "1.4.1", "1.4.2", "1.4.3"]
+  supported_duckdb_versions = [args.old_duckdb_version] if args.old_duckdb_version else [
+    "v1.1.0", "v1.1.2", "v1.1.1",
+    "v1.2.0", "v1.1.3", "v1.2.2", "v1.2.1",
+    "v1.3.0", "v1.3.1", "v1.3.2",
+    "v1.4.0", "v1.4.1", "v1.4.2", "v1.4.3", "v1.4.4"
+  ]
 
   duckdb_root_dir = dirname(dirname(dirname(abspath(__file__))))
   logger.info(f"DuckDB root dir: '{duckdb_root_dir}'")
   bwc_tests_base_dir = f"{duckdb_root_dir}/duckdb_unittest_tempdir/bwc"
 
-  if len(sys.argv) > 1 and sys.argv[1] == "cleanup_bwc_directory":
-    cleanup_runtime_dir(bwc_tests_base_dir)
+  if args.cleanup_bwc_directory:
+    cleanup_runtime_dir(bwc_tests_base_dir, dry_run=args.dry_run)
     sys.exit(0)
 
   # Create the report database
@@ -217,15 +303,20 @@ if __name__ == "__main__":
     logger.info(f"Running tests for DuckDB version '{old_duckdb_version}'")
 
     old_cli_p = make_cli_path(old_duckdb_version)
-    new_cli_p = f"{duckdb_root_dir}/build/release/duckdb"
+    new_cli_p = f"{duckdb_root_dir}/build/release/duckdb" if args.new_cli_path is None else args.new_cli_path
 
-    # open skipfile
-    skip_file_path = f"{bwc_tests_base_dir}/skip_tests_{old_duckdb_version}.txt"
+    logger.info(f"Old CLI path: {old_cli_p}")
+    logger.info(f"New CLI path: {new_cli_p}")
+
+    summary_file_path = f"{bwc_tests_base_dir}/tests_summary_{old_duckdb_version}.txt"
     lock = Lock()
 
-    with open(skip_file_path, 'a') as skip_file:
-      test_pattern = sys.argv[1] if len(sys.argv) > 1 else None
-      res = load_test_files(duckdb_root_dir, bwc_tests_base_dir, old_duckdb_version, skip_file_path, test_pattern)
+    with open(summary_file_path, 'a') as summary_file:
+      summary_file.write(f"\n## --- Starting run at {time.strftime('%Y-%m-%d %H:%M:%S')} ---\n")
+      summary_file.flush()
+      test_pattern = args.test_pattern
+      single_test_file = args.test_file
+      res = load_test_files(duckdb_root_dir, bwc_tests_base_dir, old_duckdb_version, test_pattern, single_test_file)
       tests = res['tests']
 
       extensions = res['needed_extensions']
@@ -233,13 +324,13 @@ if __name__ == "__main__":
       install_extensions(old_cli_p, extensions)
       install_extensions(new_cli_p, extensions)
 
-      run_sequentially = test_pattern is not None
-      stop_on_failure = False
+      run_sequentially = args.run_sequentially or test_pattern is not None
+      stop_on_failure = args.stop_on_failure
       start_time = time.time()
       nb_tests_run = 0
       if run_sequentially:
         for test in tests:
-          report = run_one_test_and_log(old_cli_p, new_cli_p, len(tests), test, skip_file, con, lock)
+          report = run_one_test_and_log(old_cli_p, new_cli_p, len(tests), test, summary_file, con, lock)
           nb_tests_run += 1
 
           if report.is_successful():
@@ -251,8 +342,8 @@ if __name__ == "__main__":
               report.log_errors()
               report.log_steps_queries()
       else:
-        with ThreadPoolExecutor(max_workers=25) as executor:
-          reports = executor.map(lambda test: run_one_test_and_log(old_cli_p, new_cli_p, len(tests), test, skip_file, con, lock), tests)
+        with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+          reports = executor.map(lambda test: run_one_test_and_log(old_cli_p, new_cli_p, len(tests), test, summary_file, con, lock), tests)
 
         reports_list = list(reports)
         nb_tests_run = len(reports_list)

--- a/test/bwc/runner.py
+++ b/test/bwc/runner.py
@@ -225,7 +225,7 @@ if __name__ == "__main__":
 
     with open(skip_file_path, 'a') as skip_file:
       test_pattern = sys.argv[1] if len(sys.argv) > 1 else None
-      res = load_test_files(bwc_tests_base_dir, old_duckdb_version, skip_file_path, test_pattern)
+      res = load_test_files(duckdb_root_dir, bwc_tests_base_dir, old_duckdb_version, skip_file_path, test_pattern)
       tests = res['tests']
 
       extensions = res['needed_extensions']

--- a/test/bwc/runner.py
+++ b/test/bwc/runner.py
@@ -1,7 +1,7 @@
 import shutil
 import argparse
 from utils.duckdb_cli import DuckDBCLI
-from utils.duckdb_installer import install_assets, install_extensions, make_cli_path
+from utils.duckdb_installer import install_assets, install_extensions, make_cli_path, get_version
 from utils.test_files_parser import load_test_files
 from utils.test_report import TestReport
 from utils.logger import make_logger
@@ -94,6 +94,24 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+
+class TestRunnerContext:
+  def __init__(self, old_duckdb_version, new_cli_path, nb_tests, summary_file, report_con):
+    self.old_cli_path = make_cli_path(old_duckdb_version)
+    self.new_cli_path = new_cli_path
+    self.nb_tests = nb_tests
+    self.summary_file = summary_file
+    self.report_con = report_con
+    self.report_lock = Lock()
+
+  def initialize(self):
+    self.old_cli_v = '-'.join(get_version(self.old_cli_path))
+    logger.info(f"Old CLI path: {self.old_cli_path} @ {self.old_cli_v}")
+
+    self.new_cli_v = '-'.join(get_version(self.new_cli_path))
+    logger.info(f"New CLI path: {self.new_cli_path} @ {self.new_cli_v}")
+
+
 def run_multi_clis(clis, c):
   results = []
   for cli in clis:
@@ -154,13 +172,13 @@ def get_extensions_versions(clis):
   return versions
 
 
-def do_run_test(old_cli_path, new_cli_path, nb_tests, test_spec):
+def do_run_test(ctx, test_spec):
   global has_checked_versions
-  logger.info(f"Running test {test_spec.test_idx}/{nb_tests}: {test_spec.test_spec_relative_path}")
-  report = TestReport(test_spec)
+  logger.info(f"Running test {test_spec.test_idx}/{ctx.nb_tests}: {test_spec.test_spec_relative_path}")
+  report = TestReport(test_spec, ctx.old_cli_v, ctx.new_cli_v)
   sanity_checks = False
-  with DuckDBCLI(old_cli_path, unsigned=True) as old_cli:
-    with DuckDBCLI(new_cli_path, unsigned=True) as new_cli:
+  with DuckDBCLI(ctx.old_cli_path, unsigned=True) as old_cli:
+    with DuckDBCLI(ctx.new_cli_path, unsigned=True) as new_cli:
       ext_path = 'test_utils'
       run_multi_clis([old_cli, new_cli], f".cd {test_spec.test_runtime_directory}\nLOAD '{ext_path}'")
       logger.debug(f"Loaded extension from '{ext_path}'")
@@ -206,28 +224,28 @@ def do_run_test(old_cli_path, new_cli_path, nb_tests, test_spec):
       report.load_comparison_results()
       return report
 
-def write_summary_file(report_lock, summary_file, to_write):
-  with report_lock:
-    summary_file.write(to_write)
-    summary_file.flush()
+def write_summary_file(ctx, to_write):
+  with ctx.report_lock:
+    ctx.summary_file.write(to_write)
+    ctx.summary_file.flush()
 
-def run_one_test_and_log(old_cli_path, new_cli_path, nb_tests, test, summary_file, report_con, report_lock):
+def run_one_test_and_log(ctx, test):
   if cancel_event.is_set():
     return None
 
   try:
-    report = do_run_test(old_cli_path, new_cli_path, nb_tests, test)
+    report = do_run_test(ctx, test)
     if report.is_successful():
-      write_summary_file(report_lock, summary_file, f"{test.test_spec_relative_path}\n")
-      logger.info(f"Test {test.test_idx}/{nb_tests}: {test.test_spec_relative_path} - SUCCESS")
+      write_summary_file(ctx, f"{test.test_spec_relative_path}\n")
+      logger.info(f"Test {test.test_idx}/{ctx.nb_tests}: {test.test_spec_relative_path} - SUCCESS")
     else:
       em = report.find_exception_message()
-      write_summary_file(report_lock, summary_file, f"{test.test_spec_relative_path} # FAILED: {em}\n")
-      logger.error(f"Test {test.test_idx}/{nb_tests}: {test.test_spec_relative_path} - ❌ FAILED: {em}")
+      write_summary_file(ctx, f"{test.test_spec_relative_path} # FAILED: {em}\n")
+      logger.error(f"Test {test.test_idx}/{ctx.nb_tests}: {test.test_spec_relative_path} - ❌ FAILED: {em}")
 
-    with report_lock:
-      report_con.execute(TestReport.report_insert(), report.report_sql_values())
-      report_con.commit()
+    with ctx.report_lock:
+      ctx.report_con.execute(TestReport.report_insert(), report.report_sql_values())
+      ctx.report_con.commit()
 
     return report
   except Exception as e:
@@ -267,6 +285,7 @@ def cleanup_runtime_dir(bwc_tests_base_dir, dry_run=True):
         logger.error(f"Failed to delete '{file_path}': {e}")
     logger.info(f"Cleanup completed, deleted {removed}/{len(delete_list)} files/directories")
 
+
 if __name__ == "__main__":
   supported_duckdb_versions = [args.old_duckdb_version] if args.old_duckdb_version else [
     "v1.1.0", "v1.1.2", "v1.1.1",
@@ -286,7 +305,8 @@ if __name__ == "__main__":
   # Create the report database
   os.makedirs(f"{bwc_tests_base_dir}/reports", exist_ok=True)
   ts = time.strftime("%Y%m%d_%H%M%S")
-  report_db_path = f"{bwc_tests_base_dir}/reports/test_report_{ts}.duckdb"
+  version_suffix = args.old_duckdb_version if args.old_duckdb_version else "multi_version"
+  report_db_path = f"{bwc_tests_base_dir}/reports/test_report_{version_suffix}_{ts}.duckdb"
   con = duckdb.connect(report_db_path)
   con.execute(TestReport.report_schema())
   con.commit()
@@ -299,18 +319,13 @@ if __name__ == "__main__":
 
   nb_tests_run = 0
   nb_success = 0
+  failed_tests = []
   for old_duckdb_version in supported_duckdb_versions:
     logger.info(f"Running tests for DuckDB version '{old_duckdb_version}'")
 
-    old_cli_p = make_cli_path(old_duckdb_version)
-    new_cli_p = f"{duckdb_root_dir}/build/release/duckdb" if args.new_cli_path is None else args.new_cli_path
-
-    logger.info(f"Old CLI path: {old_cli_p}")
-    logger.info(f"New CLI path: {new_cli_p}")
+    new_cli_path = f"{duckdb_root_dir}/build/release/duckdb" if args.new_cli_path is None else args.new_cli_path
 
     summary_file_path = f"{bwc_tests_base_dir}/tests_summary_{old_duckdb_version}.txt"
-    lock = Lock()
-
     with open(summary_file_path, 'a') as summary_file:
       summary_file.write(f"\n## --- Starting run at {time.strftime('%Y-%m-%d %H:%M:%S')} ---\n")
       summary_file.flush()
@@ -319,10 +334,13 @@ if __name__ == "__main__":
       res = load_test_files(duckdb_root_dir, bwc_tests_base_dir, old_duckdb_version, test_pattern, single_test_file)
       tests = res['tests']
 
+      runner_context = TestRunnerContext(old_duckdb_version, new_cli_path, len(tests), summary_file, con)
+      runner_context.initialize()
+
       extensions = res['needed_extensions']
       extensions.add('test_utils')
-      install_extensions(old_cli_p, extensions)
-      install_extensions(new_cli_p, extensions)
+      install_extensions(runner_context.old_cli_path, extensions)
+      install_extensions(runner_context.new_cli_path, extensions)
 
       run_sequentially = args.run_sequentially or test_pattern is not None
       stop_on_failure = args.stop_on_failure
@@ -330,12 +348,13 @@ if __name__ == "__main__":
       nb_tests_run = 0
       if run_sequentially:
         for test in tests:
-          report = run_one_test_and_log(old_cli_p, new_cli_p, len(tests), test, summary_file, con, lock)
+          report = run_one_test_and_log(runner_context, test)
           nb_tests_run += 1
 
           if report.is_successful():
             nb_success += 1
           else:
+            failed_tests.append((old_duckdb_version, report.test_relative_path))
             if stop_on_failure:
               break
             elif test_pattern is not None:
@@ -343,14 +362,30 @@ if __name__ == "__main__":
               report.log_steps_queries()
       else:
         with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
-          reports = executor.map(lambda test: run_one_test_and_log(old_cli_p, new_cli_p, len(tests), test, summary_file, con, lock), tests)
+          reports = executor.map(lambda test: run_one_test_and_log(runner_context, test), tests)
 
         reports_list = list(reports)
         nb_tests_run = len(reports_list)
         nb_success = sum(1 for r in reports_list if r.is_successful())
+        for r in reports_list:
+          if not r.is_successful():
+            failed_tests.append((old_duckdb_version, r.test_relative_path))
 
       elapsed = time.time() - start_time
       tps = nb_tests_run / elapsed if elapsed > 0 else 0
       nb_failed = nb_tests_run - nb_success
       logger.info(f"All tests completed in {elapsed:.2f}s - {nb_tests_run} tests run, {nb_success} successful, {nb_failed} failed - {tps:.2f} tests per second.")
+
+  if len(failed_tests) == 0:
+    logger.info("All tests passed successfully! 🎉")
+    sys.exit(0)
+
+  last_version = None
+  for version, test_path in failed_tests:
+    if version != last_version:
+      logger.info(f"Failed tests for DuckDB version '{version}':")
+      logger.info(f"{'-'*40}")
+      last_version = version
+    logger.info(test_path)
+  sys.exit(1)
 

--- a/test/bwc/runner.py
+++ b/test/bwc/runner.py
@@ -1,0 +1,265 @@
+import shutil
+from utils.duckdb_cli import DuckDBCLI
+from utils.duckdb_installer import install_assets, install_extensions, make_cli_path
+from utils.test_files_parser import load_test_files
+from utils.test_report import TestReport
+from utils.logger import make_logger
+import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Lock, Event
+from os.path import abspath, dirname
+import os
+import sys
+import duckdb
+
+logger = make_logger(__name__)
+cancel_event = Event()
+
+def run_multi_clis(clis, c):
+  results = []
+  for cli in clis:
+    r = cli.execute_command(c)
+    results.append(r)
+  return results
+
+
+TRANSIENT_ERROR_PATTERNS = [
+  "Could not set lock on file",
+  "HTTP",
+  "Connection",
+  "Unable to connect",
+]
+
+
+def is_transient_error(output):
+  error = output.get("error") or ""
+  exception = output.get("exception_message") or ""
+  combined = error + exception
+  return len(combined) == 0 or any(pattern in combined for pattern in TRANSIENT_ERROR_PATTERNS)
+
+
+def run_step(cli, report, func_name, *args):
+  str_args = ", ".join([f"'{arg}'" for arg in args])
+  command = f"CALL {func_name}({str_args});"
+  output = cli.execute_command(command)
+
+  # Retry on transient errors (file locks, network issues)
+  if not output["success"] and is_transient_error(output):
+    for attempt in range(1, 4):
+      logger.warning(f"[{cli.version}] Transient error, retrying in {attempt}s (attempt {attempt}/3)")
+      time.sleep(attempt)
+      output = cli.execute_command(command)
+      if output["success"] or not is_transient_error(output):
+        break
+
+  # We had to name the functions `tu_compare_results_from_xxx`
+  # in DuckDB 1.1.x to avoid collision and support overloading.
+  step_name = "compare_results" if "compare_results" in func_name else func_name
+  return report.end_step(step_name, output)
+
+def get_extensions_versions(clis):
+  results = run_multi_clis(clis, "SELECT extension_version FROM duckdb_extensions() WHERE extension_name='test_utils';")
+  versions = []
+  for r in results:
+    if not r["success"]:
+      raise RuntimeError(f"Failed to get extension version: {r['error']}")
+    # Find the actual version value, skipping the CSV header and any stale output
+    version = None
+    for line in r["output"]:
+      if line and line != "extension_version":
+        version = line
+        break
+    if not version:
+      raise RuntimeError(f"test-utils extension not loaded for CLI '{clis[len(versions)].version}' - output: {r['output']}")
+    versions.append(version)
+  return versions
+
+
+def do_run_test(old_cli_path, new_cli_path, nb_tests, test_spec):
+  logger.info(f"Running test {test_spec.test_idx}/{nb_tests}: {test_spec.test_spec_relative_path}")
+  report = TestReport(test_spec)
+  sanity_checks = False
+  with DuckDBCLI(old_cli_path, unsigned=True) as old_cli:
+    with DuckDBCLI(new_cli_path, unsigned=True) as new_cli:
+      ext_path = 'test_utils'
+      run_multi_clis([old_cli, new_cli], f".cd {test_spec.test_runtime_directory}\nLOAD '{ext_path}'")
+      logger.debug(f"Loaded extension from '{ext_path}'")
+      if sanity_checks:
+        run_multi_clis([old_cli, new_cli], "pragma version;")
+        run_multi_clis([old_cli, new_cli], "SELECT extension_name, loaded, extension_version FROM duckdb_extensions() WHERE extension_name='test_utils';")
+
+      versions = get_extensions_versions([old_cli, new_cli])
+      if versions[0] != versions[1]:
+        # make release EXTENSION_CONFIGS=.github/config/extensions/test-utils.cmake to compile in this repo
+        raise RuntimeError(f"test-utils extension version mismatch: {old_cli.version} is @ {versions[0]} and {new_cli.version} is @ {versions[1]}")
+
+      # Cleanup ouptput directory in case previous runs left files there
+      test_spec.reset_output_directory()
+
+      # First serialize the queries & run them in the first version
+      compare_func = "tu_compare_results_from_memory"
+      compare_args = [test_spec.results_new_file_name]
+      if test_spec.has_cached_serialized_plans:
+        compare_args.append(test_spec.results_old_file_name) # Load old results for comparison
+        compare_func = "tu_compare_results_from_file"
+        report.end_cached_step("serialize_queries_plans", test_spec.queries_file_name, test_spec.serialized_plans_file_name)
+        report.end_cached_step("serialize_results", test_spec.results_old_file_name)
+      else:
+        if not run_step(old_cli, report, "serialize_queries_plans", test_spec.queries_file_name, test_spec.serialized_plans_file_name):
+          return report
+
+        # TODO - merge results in serialized file?
+        if not run_step(old_cli, report, "serialize_results", test_spec.results_old_file_name):
+          return report
+
+        # We need to provide a clean output folder for the other CLI
+        test_spec.reset_output_directory()
+
+      # Then execute the plans in the second version
+      if not run_step(new_cli, report, "execute_all_plans_from_file", test_spec.serialized_plans_file_name, test_spec.results_new_file_name):
+        return report
+
+      # Now compare the results
+      run_step(old_cli, report, compare_func, *compare_args)
+      report.load_comparison_results()
+      return report
+
+def write_skip_file(report_lock, skip_file, to_write):
+  with report_lock:
+    skip_file.write(to_write)
+    skip_file.flush()
+
+def run_one_test_and_log(old_cli_path, new_cli_path, nb_tests, test, skip_file, report_con, report_lock):
+  if cancel_event.is_set():
+    return None
+
+  try:
+    report = do_run_test(old_cli_path, new_cli_path, nb_tests, test)
+    if report.is_successful():
+      write_skip_file(report_lock, skip_file, f"{test.test_spec_relative_path}\n")
+      logger.info(f"Test {test.test_idx}/{nb_tests}: {test.test_spec_relative_path} - SUCCESS")
+    else:
+      em = report.find_exception_message()
+      write_skip_file(report_lock, skip_file, f"{test.test_spec_relative_path} # FAILED: {em}\n")
+      logger.error(f"Test {test.test_idx}/{nb_tests}: {test.test_spec_relative_path} - ❌ FAILED: {em}")
+
+    with report_lock:
+      report_con.execute(TestReport.report_insert(), report.report_sql_values())
+      report_con.commit()
+
+    return report
+  except Exception as e:
+    cancel_event.set()
+    raise
+
+def cleanup_runtime_dir(bwc_tests_base_dir):
+  runtime_dir = f"{bwc_tests_base_dir}/runtime"
+  logger.info(f"Cleaning up BWC directory '{runtime_dir}'")
+  delete_list = []
+  # Remove new result files, any 'output' dir, and 'data' & 'test' symlinks
+  for root, dirs, files in os.walk(runtime_dir):
+    for file in files:
+      file_path = os.path.join(root, file)
+      if file.endswith(".new.result.bin"):
+        delete_list.append(file_path)
+    for dir in dirs:
+      dir_path = os.path.join(root, dir)
+      if dir.startswith("output") or (os.path.islink(dir_path) and (dir == "data" or dir == "test")):
+        delete_list.append(dir_path)
+
+  dry_run = len(sys.argv) < 3 or sys.argv[2] != "no_dry_run"
+  if dry_run:
+    logger.info(f"{len(delete_list)} files would be deleted - re-run with `no_dry_run` argument to actually delete them")
+    for file_path in delete_list:
+      logger.debug(f"  {file_path}")
+  else:
+    removed = 0
+    for file_path in delete_list:
+      try:
+        if os.path.isfile(file_path) or os.path.islink(file_path):
+          os.remove(file_path)
+          removed += 1
+        elif os.path.isdir(file_path):
+          shutil.rmtree(file_path)
+          removed += 1
+      except Exception as e:
+        logger.error(f"Failed to delete '{file_path}': {e}")
+    logger.info(f"Cleanup completed, deleted {removed}/{len(delete_list)} files/directories")
+
+if __name__ == "__main__":
+  supported_duckdb_versions = ["v1.4.4"] # ["v1.1.0", "v1.1.2", "v1.1.1", "v1.2.0", "v1.1.3", "v1.2.2", "v1.2.1", "v1.3.0", "v1.3.1", "v1.3.2", "1.4.0", "1.4.1", "1.4.2", "1.4.3"]
+
+  duckdb_root_dir = dirname(dirname(dirname(abspath(__file__))))
+  logger.info(f"DuckDB root dir: '{duckdb_root_dir}'")
+  bwc_tests_base_dir = f"{duckdb_root_dir}/duckdb_unittest_tempdir/bwc"
+
+  if len(sys.argv) > 1 and sys.argv[1] == "cleanup_bwc_directory":
+    cleanup_runtime_dir(bwc_tests_base_dir)
+    sys.exit(0)
+
+  # Create the report database
+  os.makedirs(f"{bwc_tests_base_dir}/reports", exist_ok=True)
+  ts = time.strftime("%Y%m%d_%H%M%S")
+  report_db_path = f"{bwc_tests_base_dir}/reports/test_report_{ts}.duckdb"
+  con = duckdb.connect(report_db_path)
+  con.execute(TestReport.report_schema())
+  con.commit()
+
+  logger.info(f"Report database created at '{report_db_path}'")
+
+  # Install DuckDB CLIs and test suites for all supported versions
+  with ThreadPoolExecutor(max_workers=10) as executor:
+    list(executor.map(lambda version: install_assets(version, bwc_tests_base_dir), supported_duckdb_versions))
+
+  nb_tests_run = 0
+  nb_success = 0
+  for old_duckdb_version in supported_duckdb_versions:
+    logger.info(f"Running tests for DuckDB version '{old_duckdb_version}'")
+
+    old_cli_p = make_cli_path(old_duckdb_version)
+    new_cli_p = f"{duckdb_root_dir}/build/release/duckdb"
+
+    # open skipfile
+    skip_file_path = f"{bwc_tests_base_dir}/skip_tests_{old_duckdb_version}.txt"
+    lock = Lock()
+
+    with open(skip_file_path, 'a') as skip_file:
+      test_pattern = sys.argv[1] if len(sys.argv) > 1 else None
+      res = load_test_files(bwc_tests_base_dir, old_duckdb_version, skip_file_path, test_pattern)
+      tests = res['tests']
+
+      extensions = res['needed_extensions']
+      extensions.add('test_utils')
+      install_extensions(old_cli_p, extensions)
+      install_extensions(new_cli_p, extensions)
+
+      run_sequentially = test_pattern is not None
+      stop_on_failure = False
+      start_time = time.time()
+      nb_tests_run = 0
+      if run_sequentially:
+        for test in tests:
+          report = run_one_test_and_log(old_cli_p, new_cli_p, len(tests), test, skip_file, con, lock)
+          nb_tests_run += 1
+
+          if report.is_successful():
+            nb_success += 1
+          else:
+            if stop_on_failure:
+              break
+            elif test_pattern is not None:
+              report.log_errors()
+              report.log_steps_queries()
+      else:
+        with ThreadPoolExecutor(max_workers=25) as executor:
+          reports = executor.map(lambda test: run_one_test_and_log(old_cli_p, new_cli_p, len(tests), test, skip_file, con, lock), tests)
+
+        reports_list = list(reports)
+        nb_tests_run = len(reports_list)
+        nb_success = sum(1 for r in reports_list if r.is_successful())
+
+      elapsed = time.time() - start_time
+      tps = nb_tests_run / elapsed if elapsed > 0 else 0
+      nb_failed = nb_tests_run - nb_success
+      logger.info(f"All tests completed in {elapsed:.2f}s - {nb_tests_run} tests run, {nb_success} successful, {nb_failed} failed - {tps:.2f} tests per second.")
+

--- a/test/bwc/update_cache.py
+++ b/test/bwc/update_cache.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Updates the BWC test cache in the test-utils repository from CI artifacts.
+
+This script downloads cache artifacts from a GitHub Actions workflow run
+and copies them to the test-utils cache directory.
+
+Usage:
+  python3 test/bwc/update_cache.py --run-id 12345678 --test-utils-dir /path/to/test-utils [--version v1.4.4] [--commit]
+
+The run ID can be found in the GitHub Actions URL for a SerializationBWC workflow run.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+parser = argparse.ArgumentParser(description='Update BWC test cache in test-utils from CI artifacts')
+parser.add_argument(
+    '--run-id', dest='run_id', required=True, help='GitHub Actions run ID to download cache artifacts from'
+)
+parser.add_argument('--test-utils-dir', dest='test_utils_dir', required=True, help='Path to the test-utils repository')
+parser.add_argument('--version', dest='version', help='Update cache for a specific version only')
+parser.add_argument('--repo', dest='repo', default='duckdb/duckdb', help='GitHub repository (default: duckdb/duckdb)')
+parser.add_argument('--commit', dest='commit', action='store_true', help='Commit the updated cache files in test-utils')
+
+args = parser.parse_args()
+
+SUPPORTED_VERSIONS = [
+    "v1.1.0",
+    "v1.1.1",
+    "v1.1.2",
+    "v1.1.3",
+    "v1.2.0",
+    "v1.2.1",
+    "v1.2.2",
+    "v1.3.0",
+    "v1.3.1",
+    "v1.3.2",
+    "v1.4.0",
+    "v1.4.1",
+    "v1.4.2",
+    "v1.4.3",
+    "v1.4.4",
+]
+
+
+def download_artifact(run_id, artifact_name, dest_dir, repo):
+    """Download a single artifact from a GitHub Actions run."""
+    result = subprocess.run(
+        ['gh', 'run', 'download', str(run_id), '--repo', repo, '--name', artifact_name, '--dir', dest_dir],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False, result.stderr.strip()
+    return True, None
+
+
+if __name__ == '__main__':
+    cache_dir = os.path.join(args.test_utils_dir, 'cache')
+    if not os.path.isdir(cache_dir):
+        print(f"Error: cache directory not found in test-utils: {cache_dir}")
+        sys.exit(1)
+
+    if args.version:
+        versions = [args.version]
+    else:
+        versions = SUPPORTED_VERSIONS
+
+    print(f"Downloading cache artifacts from run {args.run_id} ({args.repo})")
+    print(f"Updating {len(versions)} version(s) in {cache_dir}\n")
+
+    updated = []
+    failed = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for version in versions:
+            artifact_name = f"bwc-cache-{version}"
+            dl_dir = os.path.join(tmpdir, artifact_name)
+
+            ok, err = download_artifact(args.run_id, artifact_name, dl_dir, args.repo)
+            if not ok:
+                print(f"  {version}: skipped ({err})")
+                failed.append(version)
+                continue
+
+            archive_name = f"runtime_{version}.tar.gz"
+            src = os.path.join(dl_dir, archive_name)
+            if not os.path.isfile(src):
+                print(f"  {version}: skipped (archive not found in artifact)")
+                failed.append(version)
+                continue
+
+            dest = os.path.join(cache_dir, archive_name)
+            shutil.copy2(src, dest)
+            size_mb = os.path.getsize(dest) / (1024 * 1024)
+            print(f"  {version}: updated ({size_mb:.1f} MB)")
+            updated.append(version)
+
+    print(f"\nUpdated {len(updated)}/{len(versions)} cache archives")
+    if failed:
+        print(f"Failed: {', '.join(failed)}")
+
+    if not updated:
+        print("No cache files were updated")
+        sys.exit(1)
+
+    if args.commit:
+        print("\nCommitting changes to test-utils...")
+        subprocess.run(['git', '-C', args.test_utils_dir, 'add', 'cache/'], check=True)
+        version_str = args.version if args.version else f"{len(updated)} versions"
+        subprocess.run(
+            ['git', '-C', args.test_utils_dir, 'commit', '-m', f'Update BWC cache for {version_str}'], check=True
+        )
+        print("Committed. Run 'git push' in test-utils to publish.")

--- a/test/bwc/utils/duckdb_cli.py
+++ b/test/bwc/utils/duckdb_cli.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+DuckDB CLI Interface
+"""
+
+import re
+from utils.logger import make_logger
+from typing import Dict, Any
+import os
+import subprocess
+import threading
+import time
+import uuid
+
+logger = make_logger(__name__)
+
+class DuckDBCLI:
+    """DuckDB CLI interface using CSV output and a unique marker."""
+    def __init__(self, duckdb_path: str = None, unsigned: bool = False):
+        self.duckdb_path = duckdb_path
+        self.unsigned = unsigned
+        self.process = None
+        self.output_buffer = []
+        self.error_buffer = []
+        self.output_thread = None
+        self.error_thread = None
+        self.output_lock = threading.Lock()
+        self.error_lock = threading.Lock()
+        self.id = os.path.basename(duckdb_path)
+        self.version = None
+        self.start()
+
+    def start(self):
+        try:
+            args = [self.duckdb_path, "-batch", "-csv"]
+            if self.unsigned:
+                args.append("-unsigned")
+
+            self.process = subprocess.Popen(
+                args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                universal_newlines=True
+            )
+            self.output_buffer = []
+            self.error_buffer = []
+            self.output_thread = threading.Thread(target=self._monitor_stdout, daemon=True)
+            self.error_thread = threading.Thread(target=self._monitor_stderr, daemon=True)
+            self.output_thread.start()
+            self.error_thread.start()
+            time.sleep(0.05)
+            if self.process.poll() is not None:
+                raise RuntimeError(f"DuckDB CLI '{self.id}' process failed to start")
+
+            version_result = self.execute_command("select library_version from pragma_version();")
+            self.version = version_result['output'][1]
+        except Exception as e:
+            raise RuntimeError(f"Failed to start DuckDB CLI '{self.id}': {e}")
+
+    def _monitor_stdout(self):
+        while self.process and self.process.poll() is None:
+            line = self.process.stdout.readline()
+            if not line:
+                break
+            with self.output_lock:
+                self.output_buffer.append(line.rstrip('\n'))
+
+    def _monitor_stderr(self):
+        while self.process and self.process.poll() is None:
+            line = self.process.stderr.readline()
+            if not line:
+                break
+            with self.error_lock:
+                self.error_buffer.append(line.rstrip('\n'))
+
+    def _collect_crash_output(self):
+        """Collect any remaining output from a crashed process."""
+        if not self.process:
+            return [], [], None
+
+        crash_stderr = []
+        crash_stdout = []
+
+        # Give monitor threads a moment to flush remaining output
+        time.sleep(0.1)
+        with self.output_lock:
+            crash_stdout = self.output_buffer.copy()
+        with self.error_lock:
+            crash_stderr = self.error_buffer.copy()
+        # Also try to read any remaining data directly
+        try:
+            remaining_stderr = self.process.stderr.read()
+            if remaining_stderr:
+                crash_stderr.extend(remaining_stderr.strip().splitlines())
+        except Exception:
+            pass
+        try:
+            remaining_stdout = self.process.stdout.read()
+            if remaining_stdout:
+                crash_stdout.extend(remaining_stdout.strip().splitlines())
+        except Exception:
+            pass
+
+        return crash_stdout, crash_stderr, self.process.returncode
+
+    def _restart(self):
+        """Restart the CLI process after a crash."""
+        logger.info(f"[{self.version}] Restarting CLI process after crash")
+        try:
+            if self.process:
+                self.process.kill()
+                self.process.wait()
+        except Exception:
+            pass
+        self.process = None
+        self.start()
+
+    def _make_crash_result(self, command, crash_stdout, crash_stderr, return_code):
+        """Build a failure result from crash output."""
+        crash_details = []
+        if return_code is not None:
+            crash_details.append(f"Process exited with code {return_code}")
+        if crash_stderr:
+            crash_details.append("stderr:\n" + "\n".join(crash_stderr))
+        if crash_stdout:
+            crash_details.append("stdout:\n" + "\n".join(crash_stdout))
+        crash_msg = "\n".join(crash_details) if crash_details else "CLI process crashed (no output captured)"
+        logger.warning(f"[{self.version}] CLI process crashed during command execution:\n{crash_msg}")
+        return {
+            "query": command,
+            "success": False,
+            "output": crash_stdout,
+            "error": crash_msg,
+            "exception_message": f"CLI process crashed: {crash_msg}",
+            "error_log": f"[{self.version}] ❌ Command: \n-------\n{command}\n-------\nfailed with:\n{crash_msg}"
+        }
+
+    def execute_command(self, command: str) -> Dict[str, Any]:
+        if not self.process or self.process.poll() is not None:
+            raise RuntimeError(f"DuckDB CLI '{self.id}' process is not running")
+
+        # Unique marker for this command
+        marker = f"__END__{uuid.uuid4().hex}__"
+        marker_sql = f"SELECT '{marker}';"
+        # Clear previous output
+        with self.output_lock:
+            self.output_buffer.clear()
+        with self.error_lock:
+            self.error_buffer.clear()
+        # Send command and marker
+        if not command.strip().endswith(';'):
+            command = command.strip() + ';'
+        try:
+            self.process.stdin.write(command + '\n')
+            self.process.stdin.write(marker_sql + '\n')
+            self.process.stdin.flush()
+        except (BrokenPipeError, OSError):
+            crash_stdout, crash_stderr, return_code = self._collect_crash_output()
+            self._restart()
+            return self._make_crash_result(command, crash_stdout, crash_stderr, return_code)
+        # Read output until marker is seen
+        output_lines = []
+        found_marker = False
+        start_time = time.time()
+        timeout = 10
+        while time.time() - start_time < timeout:
+            with self.output_lock:
+                while self.output_buffer:
+                    line = self.output_buffer.pop(0)
+                    if marker in line:
+                        found_marker = True
+                        break
+                    output_lines.append(line)
+            with self.error_lock:
+                if len(self.error_buffer) > 0:
+                    found_marker = True
+
+            if found_marker:
+                break
+            time.sleep(0.01)
+
+        # Wait for the whole output to be processed
+        last_output_time = time.time()
+        last_stdout_count = len(self.output_buffer)
+        last_stderr_count = len(self.error_buffer)
+        while True:
+            with self.output_lock:
+                if last_stdout_count < len(self.output_buffer):
+                    last_stdout_count = len(self.output_buffer)
+                    last_output_time = time.time()
+            with self.error_lock:
+                if last_stderr_count < len(self.error_buffer):
+                    last_stderr_count = len(self.error_buffer)
+                    last_output_time = time.time()
+            if time.time() - last_output_time > 0.05: # TODO review that
+                break
+
+        # Collect any errors
+        with self.error_lock:
+            error_lines = self.error_buffer.copy()
+        # Remove the marker header if present (CSV header for marker)
+        if output_lines and output_lines[-1] == marker:
+            output_lines = output_lines[:-1]
+        # Remove empty lines at the end
+        while output_lines and output_lines[-1] == '':
+            output_lines.pop()
+
+        success = found_marker and not DuckDBCLI.has_fatal_error(error_lines)
+        result = {
+            "query": command,
+            "success": success,
+            "output": output_lines,
+            "error": "\n".join(error_lines) if error_lines else None
+        }
+
+        if result["success"]:
+            if len(result["output"]) == 0 or (len(result["output"]) == 2 and result["output"][0] == "result" and result["output"][1] == "true"):
+                logger.debug(f"[{self.version}] ✅ '{command}'")
+            else:
+                logger.debug(f"[{self.version}] ✅ '{command}' - result:")
+            for line in result["output"]:
+                logger.debug(f"[{self.version}]  {line}")
+        else:
+            output_lines = [x for x in result["output"] if x is not None]
+            if result['error'] is not None:
+                output_lines.append(result['error'])
+            output_lines = '\n'.join(output_lines)
+
+            if '"exception_message":' in output_lines:
+                # Extract the exception message from the JSON output
+                match = re.search(r'"exception_message":"((?:[^"\\]|\\.)*)"', output_lines)
+                if match:
+                    result['exception_message'] = match.group(1).split('\\n')[0]  # Get the first line of the exception message
+
+            if 'exception_message' not in result:
+                if result['error'] is not None:
+                    error_lines = result['exception_message'] = result['error'].splitlines()
+                    if 'failed with message' in error_lines[0]:
+                        result['exception_message'] = error_lines[1]
+                    else:
+                        result['exception_message'] = error_lines[0]
+                else:
+                    result['exception_message'] = output_lines
+            result['error_log'] = f"[{self.version}] ❌ Command: \n-------\n{command}\n-------\nfailed with:\n{output_lines}"
+        return result
+
+    @staticmethod
+    def has_fatal_error(error_lines) -> bool:
+        if not error_lines:
+            return False
+        for line in error_lines:
+            if "terminating due to" in line or "Error" in line:
+                return True
+        return False
+
+
+    def close(self):
+        if not self.process or self.process.poll() is not None:
+            return
+
+        self.process.stdin.write(".quit\n")
+        self.process.stdin.flush()
+        time.sleep(0.05)
+        if self.process.poll() is not None:
+            return
+
+        self.process.terminate()
+        time.sleep(0.2)
+
+        if self.process.poll() is None:
+            self.process.kill()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()

--- a/test/bwc/utils/duckdb_cli.py
+++ b/test/bwc/utils/duckdb_cli.py
@@ -14,8 +14,10 @@ import uuid
 
 logger = make_logger(__name__)
 
+
 class DuckDBCLI:
     """DuckDB CLI interface using CSV output and a unique marker."""
+
     def __init__(self, duckdb_path: str = None, unsigned: bool = False):
         self.duckdb_path = duckdb_path
         self.unsigned = unsigned
@@ -43,7 +45,7 @@ class DuckDBCLI:
                 stderr=subprocess.PIPE,
                 text=True,
                 bufsize=1,
-                universal_newlines=True
+                universal_newlines=True,
             )
             self.output_buffer = []
             self.error_buffer = []
@@ -135,7 +137,7 @@ class DuckDBCLI:
             "output": crash_stdout,
             "error": crash_msg,
             "exception_message": f"CLI process crashed: {crash_msg}",
-            "error_log": f"[{self.version}] ❌ Command: \n-------\n{command}\n-------\nfailed with:\n{crash_msg}"
+            "error_log": f"[{self.version}] ❌ Command: \n-------\n{command}\n-------\nfailed with:\n{crash_msg}",
         }
 
     def execute_command(self, command: str) -> Dict[str, Any]:
@@ -195,7 +197,7 @@ class DuckDBCLI:
                 if last_stderr_count < len(self.error_buffer):
                     last_stderr_count = len(self.error_buffer)
                     last_output_time = time.time()
-            if time.time() - last_output_time > 0.05: # TODO review that
+            if time.time() - last_output_time > 0.05:  # TODO review that
                 break
 
         # Collect any errors
@@ -213,11 +215,13 @@ class DuckDBCLI:
             "query": command,
             "success": success,
             "output": output_lines,
-            "error": "\n".join(error_lines) if error_lines else None
+            "error": "\n".join(error_lines) if error_lines else None,
         }
 
         if result["success"]:
-            if len(result["output"]) == 0 or (len(result["output"]) == 2 and result["output"][0] == "result" and result["output"][1] == "true"):
+            if len(result["output"]) == 0 or (
+                len(result["output"]) == 2 and result["output"][0] == "result" and result["output"][1] == "true"
+            ):
                 logger.debug(f"[{self.version}] ✅ '{command}'")
             else:
                 logger.debug(f"[{self.version}] ✅ '{command}' - result:")
@@ -233,7 +237,9 @@ class DuckDBCLI:
                 # Extract the exception message from the JSON output
                 match = re.search(r'"exception_message":"((?:[^"\\]|\\.)*)"', output_lines)
                 if match:
-                    result['exception_message'] = match.group(1).split('\\n')[0]  # Get the first line of the exception message
+                    result['exception_message'] = match.group(1).split('\\n')[
+                        0
+                    ]  # Get the first line of the exception message
 
             if 'exception_message' not in result:
                 if result['error'] is not None:
@@ -244,7 +250,9 @@ class DuckDBCLI:
                         result['exception_message'] = error_lines[0]
                 else:
                     result['exception_message'] = output_lines
-            result['error_log'] = f"[{self.version}] ❌ Command: \n-------\n{command}\n-------\nfailed with:\n{output_lines}"
+            result['error_log'] = (
+                f"[{self.version}] ❌ Command: \n-------\n{command}\n-------\nfailed with:\n{output_lines}"
+            )
         return result
 
     @staticmethod
@@ -255,7 +263,6 @@ class DuckDBCLI:
             if "terminating due to" in line or "Error" in line:
                 return True
         return False
-
 
     def close(self):
         if not self.process or self.process.poll() is not None:

--- a/test/bwc/utils/duckdb_installer.py
+++ b/test/bwc/utils/duckdb_installer.py
@@ -64,6 +64,13 @@ def download_test_specs(version, target_sub_dir):
     subprocess.run(["mv", f"duckdb/data", target_dir], cwd=tmpdirname, check=True)
     logger.info(f"[{version}] Copied test specs to '{target_dir}'")
 
+def get_version(cli_path):
+  with DuckDBCLI(cli_path) as cli:
+    result = cli.execute_command("select library_version, source_id from pragma_version();")
+    if not result["success"]:
+      raise RuntimeError(f"Failed to get DuckDB version from CLI at '{cli_path}': {result['stderr']}")
+    return result["output"][1].split(',')
+
 def install_extensions(cli_path, extensions):
   with DuckDBCLI(cli_path, unsigned=True) as cli:
     installed = []

--- a/test/bwc/utils/duckdb_installer.py
+++ b/test/bwc/utils/duckdb_installer.py
@@ -1,0 +1,128 @@
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+import urllib.request
+from utils.logger import make_logger
+
+from .duckdb_cli import DuckDBCLI
+
+logger = make_logger(__name__)
+
+def make_cli_path(version):
+  raw_version = version.lstrip('v')
+  cli_path = Path.home() / ".duckdb" / "cli" / raw_version / "duckdb"
+  return str(cli_path)
+
+
+def install_duckdb_cli(version):
+  # Check if the cli already exists
+  cli_path = make_cli_path(version)
+  if os.path.exists(cli_path):
+    logger.debug(f"DuckDB CLI {version} already exists at '{cli_path}'")
+    return
+
+  req = urllib.request.Request("https://install.duckdb.org", headers={"User-Agent": "duckdb-bwc-test-runner"})
+  with urllib.request.urlopen(req) as response:
+      script_content = response.read()
+
+  env = os.environ.copy()
+  env['DUCKDB_VERSION'] = version.lstrip('v')
+
+  result = subprocess.run(
+      ['sh'],
+      input=script_content,
+      env=env,
+      capture_output=True,
+      text=False  # Keep as bytes since we're reading bytes
+  )
+
+  if result.returncode != 0:
+      raise RuntimeError(f"[{version}] Install script failed: {result.stderr.decode()}")
+
+  if not os.path.exists(cli_path):
+      raise RuntimeError(f"[{version}] Install script succeeded but CLI not found at '{cli_path}'. stdout: {result.stdout.decode()}")
+
+  logger.info(f"[{version}] DuckDB CLI installed successfully at '{cli_path}'")
+
+
+def download_test_specs(version, target_sub_dir):
+  logger.debug(f"[{version}] Downloading DuckDB test specs")
+  target_dir = os.path.join(target_sub_dir, version)
+  if os.path.exists(target_dir):
+    logger.info(f"[{version}] Test specs already exist at '{target_dir}'")
+    return
+
+  with tempfile.TemporaryDirectory() as tmpdirname:
+    logger.info(f"[{version}] Cloning duckdb repo in {tmpdirname}")
+    subprocess.run(["git", "clone", "--depth", "1", "--branch", version, f"https://github.com/duckdb/duckdb.git"], cwd=tmpdirname, check=True, capture_output=True, text=True)
+    logger.info(f"[{version}] Cloned duckdb repo.")
+
+    # Move `test` and `data` directories to target_dir
+    os.makedirs(target_dir)
+    subprocess.run(["mv", f"duckdb/test", target_dir], cwd=tmpdirname, check=True)
+    subprocess.run(["mv", f"duckdb/data", target_dir], cwd=tmpdirname, check=True)
+    logger.info(f"[{version}] Copied test specs to '{target_dir}'")
+
+def install_extensions(cli_path, extensions):
+  with DuckDBCLI(cli_path, unsigned=True) as cli:
+    installed = []
+    failed = []
+
+    # Happy path - all extensions installed
+    ext_list = ", ".join(f"'{ext}'" for ext in extensions)
+    result = cli.execute_command(f"SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name in ({ext_list}) AND installed;")
+    if result["output"][1] == str(len(extensions)):
+      logger.info(f"[{cli.version}] All {len(extensions)} extensions were already installed")
+      return
+
+    for ext in extensions:
+      # First look if it's already installed
+      result = cli.execute_command(f"SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name='{ext}' AND installed;")
+      if result["output"][1] == '1':
+        logger.debug(f"[{cli.version}] Extension '{ext}' is already installed.")
+        installed.append(ext)
+        continue
+
+      if ext == 'test_utils':
+        result = cli.execute_command(f"INSTALL 'test_utils' FROM 'https://raw.githubusercontent.com/duckdb/bwc-test-utils/main/extensions';")
+      else:
+        result = cli.execute_command(f"INSTALL '{ext}'")
+
+      if result["success"]:
+        installed.append(ext)
+      else:
+        failed.append(ext)
+
+    logger.info(f"[{cli.version}] Installed {len(installed)} extensions.")
+
+    if len(failed):
+      root_ext_cmake_path = Path(__file__).parent.parent.parent.parent / ".github/config/extensions"
+      if not root_ext_cmake_path.is_dir():
+        raise RuntimeError(f"Extensions CMake config directory does not exist at '{root_ext_cmake_path}' - did the repo structure change?")
+
+      # test if `.github/config/extensions/{extension}.cmake` is a file
+      cmake_files_ext = []
+      core_extensions = []
+      for ext in failed:
+        ext_filename = "test-utils" if ext == "test_utils" else ext
+        ext_cmake_path = root_ext_cmake_path / f"{ext_filename}.cmake"
+        if ext_cmake_path.is_file():
+          cmake_files_ext.append(ext_filename)
+        else:
+          core_extensions.append(ext)
+
+      # Build a string that suggests how to install the failed extensions
+      install_cmd = f"make release "
+      if len(cmake_files_ext) > 0:
+        install_cmd += "EXTENSION_CONFIGS='" + ";".join([f".github/config/extensions/{ext}.cmake" for ext in cmake_files_ext]) + "' "
+      if len(core_extensions) > 0:
+        install_cmd += "DUCKDB_EXTENSIONS='" + ";".join(core_extensions) + "'"
+
+      if len(cmake_files_ext) > 0 or len(core_extensions) > 0:
+        logger.info(f"[{cli.version}] Failed to install {len(failed)} extensions. If you need to compile them:\n{install_cmd}")
+      raise RuntimeError(f"[{cli.version}] Failed to install {len(failed)} extensions: {', '.join(failed)}")
+
+def install_assets(version, bwc_tests_base_dir):
+  install_duckdb_cli(version)
+  download_test_specs(version, f"{bwc_tests_base_dir}/specs")

--- a/test/bwc/utils/duckdb_installer.py
+++ b/test/bwc/utils/duckdb_installer.py
@@ -9,127 +9,153 @@ from .duckdb_cli import DuckDBCLI
 
 logger = make_logger(__name__)
 
+
 def make_cli_path(version):
-  raw_version = version.lstrip('v')
-  cli_path = Path.home() / ".duckdb" / "cli" / raw_version / "duckdb"
-  return str(cli_path)
+    raw_version = version.lstrip('v')
+    cli_path = Path.home() / ".duckdb" / "cli" / raw_version / "duckdb"
+    return str(cli_path)
 
 
 def install_duckdb_cli(version):
-  # Check if the cli already exists
-  cli_path = make_cli_path(version)
-  if os.path.exists(cli_path):
-    logger.debug(f"DuckDB CLI {version} already exists at '{cli_path}'")
-    return
+    # Check if the cli already exists
+    cli_path = make_cli_path(version)
+    if os.path.exists(cli_path):
+        logger.debug(f"DuckDB CLI {version} already exists at '{cli_path}'")
+        return
 
-  req = urllib.request.Request("https://install.duckdb.org", headers={"User-Agent": "duckdb-bwc-test-runner"})
-  with urllib.request.urlopen(req) as response:
-      script_content = response.read()
+    req = urllib.request.Request("https://install.duckdb.org", headers={"User-Agent": "duckdb-bwc-test-runner"})
+    with urllib.request.urlopen(req) as response:
+        script_content = response.read()
 
-  env = os.environ.copy()
-  env['DUCKDB_VERSION'] = version.lstrip('v')
+    env = os.environ.copy()
+    env['DUCKDB_VERSION'] = version.lstrip('v')
 
-  result = subprocess.run(
-      ['sh'],
-      input=script_content,
-      env=env,
-      capture_output=True,
-      text=False  # Keep as bytes since we're reading bytes
-  )
+    result = subprocess.run(
+        ['sh'],
+        input=script_content,
+        env=env,
+        capture_output=True,
+        text=False,  # Keep as bytes since we're reading bytes
+    )
 
-  if result.returncode != 0:
-      raise RuntimeError(f"[{version}] Install script failed: {result.stderr.decode()}")
+    if result.returncode != 0:
+        raise RuntimeError(f"[{version}] Install script failed: {result.stderr.decode()}")
 
-  if not os.path.exists(cli_path):
-      raise RuntimeError(f"[{version}] Install script succeeded but CLI not found at '{cli_path}'. stdout: {result.stdout.decode()}")
+    if not os.path.exists(cli_path):
+        raise RuntimeError(
+            f"[{version}] Install script succeeded but CLI not found at '{cli_path}'. stdout: {result.stdout.decode()}"
+        )
 
-  logger.info(f"[{version}] DuckDB CLI installed successfully at '{cli_path}'")
+    logger.info(f"[{version}] DuckDB CLI installed successfully at '{cli_path}'")
 
 
 def download_test_specs(version, target_sub_dir):
-  logger.debug(f"[{version}] Downloading DuckDB test specs")
-  target_dir = os.path.join(target_sub_dir, version)
-  if os.path.exists(target_dir):
-    logger.info(f"[{version}] Test specs already exist at '{target_dir}'")
-    return
+    logger.debug(f"[{version}] Downloading DuckDB test specs")
+    target_dir = os.path.join(target_sub_dir, version)
+    if os.path.exists(target_dir):
+        logger.info(f"[{version}] Test specs already exist at '{target_dir}'")
+        return
 
-  with tempfile.TemporaryDirectory() as tmpdirname:
-    logger.info(f"[{version}] Cloning duckdb repo in {tmpdirname}")
-    subprocess.run(["git", "clone", "--depth", "1", "--branch", version, f"https://github.com/duckdb/duckdb.git"], cwd=tmpdirname, check=True, capture_output=True, text=True)
-    logger.info(f"[{version}] Cloned duckdb repo.")
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        logger.info(f"[{version}] Cloning duckdb repo in {tmpdirname}")
+        subprocess.run(
+            ["git", "clone", "--depth", "1", "--branch", version, f"https://github.com/duckdb/duckdb.git"],
+            cwd=tmpdirname,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        logger.info(f"[{version}] Cloned duckdb repo.")
 
-    # Move `test` and `data` directories to target_dir
-    os.makedirs(target_dir)
-    subprocess.run(["mv", f"duckdb/test", target_dir], cwd=tmpdirname, check=True)
-    subprocess.run(["mv", f"duckdb/data", target_dir], cwd=tmpdirname, check=True)
-    logger.info(f"[{version}] Copied test specs to '{target_dir}'")
+        # Move `test` and `data` directories to target_dir
+        os.makedirs(target_dir)
+        subprocess.run(["mv", f"duckdb/test", target_dir], cwd=tmpdirname, check=True)
+        subprocess.run(["mv", f"duckdb/data", target_dir], cwd=tmpdirname, check=True)
+        logger.info(f"[{version}] Copied test specs to '{target_dir}'")
+
 
 def get_version(cli_path):
-  with DuckDBCLI(cli_path) as cli:
-    result = cli.execute_command("select library_version, source_id from pragma_version();")
-    if not result["success"]:
-      raise RuntimeError(f"Failed to get DuckDB version from CLI at '{cli_path}': {result['stderr']}")
-    return result["output"][1].split(',')
+    with DuckDBCLI(cli_path) as cli:
+        result = cli.execute_command("select library_version, source_id from pragma_version();")
+        if not result["success"]:
+            raise RuntimeError(f"Failed to get DuckDB version from CLI at '{cli_path}': {result['stderr']}")
+        return result["output"][1].split(',')
+
 
 def install_extensions(cli_path, extensions):
-  with DuckDBCLI(cli_path, unsigned=True) as cli:
-    installed = []
-    failed = []
+    with DuckDBCLI(cli_path, unsigned=True) as cli:
+        installed = []
+        failed = []
 
-    # Happy path - all extensions installed
-    ext_list = ", ".join(f"'{ext}'" for ext in extensions)
-    result = cli.execute_command(f"SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name in ({ext_list}) AND installed;")
-    if result["output"][1] == str(len(extensions)):
-      logger.info(f"[{cli.version}] All {len(extensions)} extensions were already installed")
-      return
+        # Happy path - all extensions installed
+        ext_list = ", ".join(f"'{ext}'" for ext in extensions)
+        result = cli.execute_command(
+            f"SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name in ({ext_list}) AND installed;"
+        )
+        if result["output"][1] == str(len(extensions)):
+            logger.info(f"[{cli.version}] All {len(extensions)} extensions were already installed")
+            return
 
-    for ext in extensions:
-      # First look if it's already installed
-      result = cli.execute_command(f"SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name='{ext}' AND installed;")
-      if result["output"][1] == '1':
-        logger.debug(f"[{cli.version}] Extension '{ext}' is already installed.")
-        installed.append(ext)
-        continue
+        for ext in extensions:
+            # First look if it's already installed
+            result = cli.execute_command(
+                f"SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name='{ext}' AND installed;"
+            )
+            if result["output"][1] == '1':
+                logger.debug(f"[{cli.version}] Extension '{ext}' is already installed.")
+                installed.append(ext)
+                continue
 
-      if ext == 'test_utils':
-        result = cli.execute_command(f"INSTALL 'test_utils' FROM 'https://raw.githubusercontent.com/duckdb/bwc-test-utils/main/extensions';")
-      else:
-        result = cli.execute_command(f"INSTALL '{ext}'")
+            if ext == 'test_utils':
+                result = cli.execute_command(
+                    f"INSTALL 'test_utils' FROM 'https://raw.githubusercontent.com/duckdb/bwc-test-utils/main/extensions';"
+                )
+            else:
+                result = cli.execute_command(f"INSTALL '{ext}'")
 
-      if result["success"]:
-        installed.append(ext)
-      else:
-        failed.append(ext)
+            if result["success"]:
+                installed.append(ext)
+            else:
+                failed.append(ext)
 
-    logger.info(f"[{cli.version}] Installed {len(installed)} extensions.")
+        logger.info(f"[{cli.version}] Installed {len(installed)} extensions.")
 
-    if len(failed):
-      root_ext_cmake_path = Path(__file__).parent.parent.parent.parent / ".github/config/extensions"
-      if not root_ext_cmake_path.is_dir():
-        raise RuntimeError(f"Extensions CMake config directory does not exist at '{root_ext_cmake_path}' - did the repo structure change?")
+        if len(failed):
+            root_ext_cmake_path = Path(__file__).parent.parent.parent.parent / ".github/config/extensions"
+            if not root_ext_cmake_path.is_dir():
+                raise RuntimeError(
+                    f"Extensions CMake config directory does not exist at '{root_ext_cmake_path}' - did the repo structure change?"
+                )
 
-      # test if `.github/config/extensions/{extension}.cmake` is a file
-      cmake_files_ext = []
-      core_extensions = []
-      for ext in failed:
-        ext_filename = "test-utils" if ext == "test_utils" else ext
-        ext_cmake_path = root_ext_cmake_path / f"{ext_filename}.cmake"
-        if ext_cmake_path.is_file():
-          cmake_files_ext.append(ext_filename)
-        else:
-          core_extensions.append(ext)
+            # test if `.github/config/extensions/{extension}.cmake` is a file
+            cmake_files_ext = []
+            core_extensions = []
+            for ext in failed:
+                ext_filename = "test-utils" if ext == "test_utils" else ext
+                ext_cmake_path = root_ext_cmake_path / f"{ext_filename}.cmake"
+                if ext_cmake_path.is_file():
+                    cmake_files_ext.append(ext_filename)
+                else:
+                    core_extensions.append(ext)
 
-      # Build a string that suggests how to install the failed extensions
-      install_cmd = f"make release "
-      if len(cmake_files_ext) > 0:
-        install_cmd += "EXTENSION_CONFIGS='" + ";".join([f".github/config/extensions/{ext}.cmake" for ext in cmake_files_ext]) + "' "
-      if len(core_extensions) > 0:
-        install_cmd += "DUCKDB_EXTENSIONS='" + ";".join(core_extensions) + "'"
+            # Build a string that suggests how to install the failed extensions
+            install_cmd = f"make release "
+            if len(cmake_files_ext) > 0:
+                install_cmd += (
+                    "EXTENSION_CONFIGS='"
+                    + ";".join([f".github/config/extensions/{ext}.cmake" for ext in cmake_files_ext])
+                    + "' "
+                )
+            if len(core_extensions) > 0:
+                install_cmd += "DUCKDB_EXTENSIONS='" + ";".join(core_extensions) + "'"
 
-      if len(cmake_files_ext) > 0 or len(core_extensions) > 0:
-        logger.info(f"[{cli.version}] Failed to install {len(failed)} extensions. If you need to compile them:\n{install_cmd}")
-      raise RuntimeError(f"[{cli.version}] Failed to install {len(failed)} extensions: {', '.join(failed)}")
+            if len(cmake_files_ext) > 0 or len(core_extensions) > 0:
+                logger.info(
+                    f"[{cli.version}] Failed to install {len(failed)} extensions. If you need to compile them:\n{install_cmd}"
+                )
+            raise RuntimeError(f"[{cli.version}] Failed to install {len(failed)} extensions: {', '.join(failed)}")
+
 
 def install_assets(version, bwc_tests_base_dir):
-  install_duckdb_cli(version)
-  download_test_specs(version, f"{bwc_tests_base_dir}/specs")
+    install_duckdb_cli(version)
+    download_test_specs(version, f"{bwc_tests_base_dir}/specs")

--- a/test/bwc/utils/logger.py
+++ b/test/bwc/utils/logger.py
@@ -1,0 +1,33 @@
+import logging
+import os
+import sys
+
+log_level = logging.INFO
+
+def make_logger(name: str):
+  ll = log_level
+  logger = logging.getLogger(name)
+  logger.setLevel(ll)
+
+  if os.environ.get('CI'):
+    formatter = logging.Formatter('%(message)s')
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(ll)
+    stdout_handler.setFormatter(formatter)
+    stdout_handler.addFilter(lambda record: record.levelno < logging.ERROR)
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.ERROR)
+    stderr_handler.setFormatter(formatter)
+
+    logger.addHandler(stdout_handler)
+    logger.addHandler(stderr_handler)
+  else:
+    ch = logging.StreamHandler()
+    ch.setLevel(ll)
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+  return logger

--- a/test/bwc/utils/logger.py
+++ b/test/bwc/utils/logger.py
@@ -4,30 +4,31 @@ import sys
 
 log_level = logging.INFO
 
+
 def make_logger(name: str):
-  ll = log_level
-  logger = logging.getLogger(name)
-  logger.setLevel(ll)
+    ll = log_level
+    logger = logging.getLogger(name)
+    logger.setLevel(ll)
 
-  if os.environ.get('CI'):
-    formatter = logging.Formatter('%(message)s')
+    if os.environ.get('CI'):
+        formatter = logging.Formatter('%(message)s')
 
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setLevel(ll)
-    stdout_handler.setFormatter(formatter)
-    stdout_handler.addFilter(lambda record: record.levelno < logging.ERROR)
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.setLevel(ll)
+        stdout_handler.setFormatter(formatter)
+        stdout_handler.addFilter(lambda record: record.levelno < logging.ERROR)
 
-    stderr_handler = logging.StreamHandler(sys.stderr)
-    stderr_handler.setLevel(logging.ERROR)
-    stderr_handler.setFormatter(formatter)
+        stderr_handler = logging.StreamHandler(sys.stderr)
+        stderr_handler.setLevel(logging.ERROR)
+        stderr_handler.setFormatter(formatter)
 
-    logger.addHandler(stdout_handler)
-    logger.addHandler(stderr_handler)
-  else:
-    ch = logging.StreamHandler()
-    ch.setLevel(ll)
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
+        logger.addHandler(stdout_handler)
+        logger.addHandler(stderr_handler)
+    else:
+        ch = logging.StreamHandler()
+        ch.setLevel(ll)
+        formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
 
-  return logger
+    return logger

--- a/test/bwc/utils/query_exclusions.py
+++ b/test/bwc/utils/query_exclusions.py
@@ -32,7 +32,7 @@ def _normalize_sql(sql: str) -> str:
             continue
         # Remove inline comments
         if '--' in stripped:
-            stripped = stripped[:stripped.index('--')]
+            stripped = stripped[: stripped.index('--')]
 
         if len(stripped) > 0:
             lines.append(stripped)
@@ -65,12 +65,10 @@ SKIP_PATTERNS = [
     # Transaction statements - we're not testing transaction semantics
     r'\b(begin|commit|rollback)\b',
     r'\bstart\s+transaction\b',
-
     # Pragmas that cause verification issues
     r'\bpragma\s+enable_verification\b',
     r'\bpragma\s+verify_external\b',
     r'\bpragma\s+threads\b',
-
     # Thread settings can cause system errors
     r'\bset\s+threads\b',
     r'\breset\s+threads\b',
@@ -89,24 +87,19 @@ EXECUTE_FROM_SQL_PATTERNS_WITHOUT_LITERALS = [
     r'\bcreate(\s+or\s+replace)?\s+schema\b',
     r'\bcreate(\s+or\s+replace)?(\s+recursive)?\s+view\b',
     r'\bcreate(\s+or\s+replace)?\s+secret\b',
-
     # ALTER - catalog changes on read-only transaction
     r'\balter\b',
-
     # DML - transaction is read-only but has made changes
     r'\binsert\b',
     r'\bupdate\b(?!\s*statistics)',  # UPDATE but not UPDATE STATISTICS
     r'\bdelete\b',
     r'\bdrop\b',
-
     # Prepared statements - not implemented
     r'\bprepare\b',
     r'\bexecute\b',
     r'\bdeallocate\b',
-
     # All pragmas don't serialize well
     r'\bpragma\b',
-
     # Table functions that don't have serialization implemented
     r'\bread_csv\s*\(',
     r'\bread_csv_auto\s*\(',
@@ -117,14 +110,11 @@ EXECUTE_FROM_SQL_PATTERNS_WITHOUT_LITERALS = [
     r'\bread_ndjson\s*\(',
     r'\bread_ndjson_objects\s*\(',
     r'\bread_ndjson_auto\s*\(',
-
     # Function calls that don't serialize
     r'\bnextval\s*\(',
     r'\bfinalize\s*\(',
-
     # EXPORT_STATE doesn't serialize
     r'\bexport_state\b',
-
     # CALL dbgen/dsdgen - causes database modification issues
     r'\bcall\s+dbgen\s*\(',
     r'\bcall\s+dsdgen\s*\(',

--- a/test/bwc/utils/query_exclusions.py
+++ b/test/bwc/utils/query_exclusions.py
@@ -1,0 +1,226 @@
+"""
+Query exclusion logic for BWC testing framework.
+
+This module determines which queries should be skipped or executed from SQL
+instead of from serialized plans. The logic was previously in the C++ extension
+(test-utils/src/serialize_queries_plans.cpp) and has been moved here to allow
+configuration without recompiling the extension.
+
+Two types of exclusions:
+1. skip_query: Query is skipped entirely (not executed at all)
+2. execute_from_sql: Query cannot be serialized, so it's executed from SQL text
+
+The decisions are communicated to the C++ code via tags in the query file:
+- `-- bwc_tag:skip_query` for queries to skip
+- `-- bwc_tag:execute_from_sql` for queries that can't be serialized
+"""
+
+import re
+from typing import Tuple
+
+
+def _normalize_sql(sql: str) -> str:
+    """
+    Normalize SQL for pattern matching.
+    Removes comments and extra whitespace, converts to lowercase.
+    """
+    # Remove single-line comments (but preserve bwc_tag comments for now)
+    lines = []
+    for line in sql.split('\n'):
+        stripped = line.strip()
+        if stripped.startswith('--'):
+            continue
+        # Remove inline comments
+        if '--' in stripped:
+            stripped = stripped[:stripped.index('--')]
+
+        if len(stripped) > 0:
+            lines.append(stripped)
+
+    result = ' '.join(lines)
+
+    # Remove multi-line comments
+    result = re.sub(r'/\*.*?\*/', ' ', result, flags=re.DOTALL)
+
+    # Normalize whitespace
+    result = ' '.join(result.split())
+
+    return result.lower()
+
+
+def _remove_string_literals(sql: str) -> str:
+    """
+    Remove string literals from SQL to avoid false positives when matching patterns.
+    Replaces 'string' and "string" with empty strings.
+    """
+    # Handle escaped quotes within strings
+    # This is a simplified approach - handles most common cases
+    result = re.sub(r"'(?:[^'\\]|\\.)*'", "''", sql)
+    result = re.sub(r'"(?:[^"\\]|\\.)*"', '""', result)
+    return result
+
+
+# Patterns for queries that should be skipped entirely
+SKIP_PATTERNS = [
+    # Transaction statements - we're not testing transaction semantics
+    r'\b(begin|commit|rollback)\b',
+    r'\bstart\s+transaction\b',
+
+    # Pragmas that cause verification issues
+    r'\bpragma\s+enable_verification\b',
+    r'\bpragma\s+verify_external\b',
+    r'\bpragma\s+threads\b',
+
+    # Thread settings can cause system errors
+    r'\bset\s+threads\b',
+    r'\breset\s+threads\b',
+]
+
+# Patterns for queries that can't be serialized (execute from SQL instead)
+# These are checked against SQL with string literals removed
+EXECUTE_FROM_SQL_PATTERNS_WITHOUT_LITERALS = [
+    # DDL statements - cause "database not marked as modified" errors
+    r'\bcreate(\s+or\s+replace)?\s+table\b',
+    r'\bcreate(\s+or\s+replace)?(\s+unique)?\s+index\b',
+    r'\bcreate(\s+or\s+replace)?\s+macro\b',
+    r'\bcreate(\s+or\s+replace)?\s+function\b',
+    r'\bcreate(\s+or\s+replace)?\s+sequence\b',
+    r'\bcreate(\s+or\s+replace)?\s+type\b',
+    r'\bcreate(\s+or\s+replace)?\s+schema\b',
+    r'\bcreate(\s+or\s+replace)?(\s+recursive)?\s+view\b',
+    r'\bcreate(\s+or\s+replace)?\s+secret\b',
+
+    # ALTER - catalog changes on read-only transaction
+    r'\balter\b',
+
+    # DML - transaction is read-only but has made changes
+    r'\binsert\b',
+    r'\bupdate\b(?!\s*statistics)',  # UPDATE but not UPDATE STATISTICS
+    r'\bdelete\b',
+    r'\bdrop\b',
+
+    # Prepared statements - not implemented
+    r'\bprepare\b',
+    r'\bexecute\b',
+    r'\bdeallocate\b',
+
+    # All pragmas don't serialize well
+    r'\bpragma\b',
+
+    # Table functions that don't have serialization implemented
+    r'\bread_csv\s*\(',
+    r'\bread_csv_auto\s*\(',
+    r'\bread_json\s*\(',
+    r'\bread_json_auto\s*\(',
+    r'\bread_json_objects\s*\(',
+    r'\bread_json_objects_auto\s*\(',
+    r'\bread_ndjson\s*\(',
+    r'\bread_ndjson_objects\s*\(',
+    r'\bread_ndjson_auto\s*\(',
+
+    # Function calls that don't serialize
+    r'\bnextval\s*\(',
+    r'\bfinalize\s*\(',
+
+    # EXPORT_STATE doesn't serialize
+    r'\bexport_state\b',
+
+    # CALL dbgen/dsdgen - causes database modification issues
+    r'\bcall\s+dbgen\s*\(',
+    r'\bcall\s+dsdgen\s*\(',
+]
+
+# Patterns for queries that can't be serialized (execute from SQL instead)
+# These are checked against SQL without string literals removed
+EXECUTE_FROM_SQL_PATTERNS_WITH_LITERALS = [
+    r"\bfrom\s+'[^']+.csv'",
+    r"\bfrom\s+'[^']+.csv.gz'",
+    r"\bfrom\s+'[^']+.csv.zst'",
+    r"\bfrom\s+'[^']+.json'",
+]
+
+# Compiled regex patterns for performance
+_SKIP_REGEX = [re.compile(p, re.IGNORECASE) for p in SKIP_PATTERNS]
+_EXECUTE_FROM_SQL_REGEX_WITHOUT_LIT = [re.compile(p, re.IGNORECASE) for p in EXECUTE_FROM_SQL_PATTERNS_WITHOUT_LITERALS]
+_EXECUTE_FROM_SQL_REGEX_WITH_LIT = [re.compile(p, re.IGNORECASE) for p in EXECUTE_FROM_SQL_PATTERNS_WITH_LITERALS]
+
+
+def _should_skip_query(normalized_sql: str) -> bool:
+    """
+    Determine if a query should be skipped entirely.
+
+    Returns True for:
+    - Transaction statements (BEGIN, COMMIT, ROLLBACK)
+    - PRAGMA enable_verification / verify_external
+    - SET threads / RESET threads
+    """
+    for pattern in _SKIP_REGEX:
+        if pattern.search(normalized_sql):
+            return True
+
+    return False
+
+
+def _can_serialize_plan(normalized_sql: str) -> bool:
+    """
+    Determine if a query's plan can be serialized and executed.
+
+    Returns False (meaning execute from SQL) for:
+    - DDL statements (CREATE TABLE, CREATE INDEX, etc.)
+    - DML statements (INSERT, UPDATE, DELETE, DROP)
+    - ALTER statements
+    - Prepared statements (PREPARE, EXECUTE)
+    - PRAGMA statements
+    - Queries using table functions without serialization (read_csv, read_json, etc.)
+    - Queries using functions that don't serialize (nextval, finalize)
+    - Queries containing EXPORT_STATE
+    - CALL dbgen/dsdgen
+    """
+    # Remove string literals to avoid false positives
+    normalized_no_strings = _remove_string_literals(normalized_sql)
+
+    for pattern in _EXECUTE_FROM_SQL_REGEX_WITHOUT_LIT:
+        if pattern.search(normalized_no_strings):
+            return False
+
+    for pattern in _EXECUTE_FROM_SQL_REGEX_WITH_LIT:
+        if pattern.search(normalized_sql):
+            return False
+
+    return True
+
+
+def _get_exclusion_tags(sql: str) -> Tuple[bool, bool]:
+    """
+    Get exclusion status for a query.
+
+    Returns:
+        Tuple of (skip_query, execute_from_sql)
+        - skip_query: True if query should be skipped entirely
+        - execute_from_sql: True if query can't be serialized (execute from SQL)
+    """
+    normalized = _normalize_sql(sql)
+    skip = _should_skip_query(normalized)
+    if skip:
+        # If we're skipping, no need to check serialization
+        return (True, False)
+
+    can_serialize = _can_serialize_plan(normalized)
+    return (False, not can_serialize)
+
+
+def format_exclusion_tags(sql: str) -> str:
+    """
+    Format exclusion tags to prepend to a query.
+
+    Returns a string with appropriate bwc_tag comments, or empty string if no exclusions.
+    """
+    skip, execute_from_sql = _get_exclusion_tags(sql)
+
+    tags = []
+    if skip:
+        tags.append("-- bwc_tag:skip_query")
+    if execute_from_sql:
+        tags.append("-- bwc_tag:execute_from_sql")
+
+    return '\n'.join(tags)

--- a/test/bwc/utils/test_files_parser.py
+++ b/test/bwc/utils/test_files_parser.py
@@ -1,0 +1,604 @@
+from typing import List
+import os
+import time
+from zipfile import Path
+from os.path import basename, dirname
+import shutil
+
+import duckdb
+
+from typing import Any, Generator
+from duckdb_sqllogictest import SQLLogicParser
+from duckdb_sqllogictest.result import (
+    ExecuteResult,
+    Foreach,
+    Load,
+    Loop,
+    Query,
+    Require,
+    RequireResult,
+    Restart,
+    Set,
+    SQLLogicContext,
+    SQLLogicRunner,
+    Statement,
+    Unzip
+)
+
+from duckdb_sqllogictest.expected_result import ExpectedResult
+from duckdb_sqllogictest.statement.query import SortStyle
+
+from utils.query_exclusions import format_exclusion_tags
+from utils.logger import make_logger
+
+BWC_TAG_PREFIX = '-- bwc_tag:'
+
+logger = make_logger(__name__)
+
+def make_tag(tag_key: str, tag_value: int | str | list | set) -> str:
+    if isinstance(tag_value, list) or isinstance(tag_value, set):
+        if len(tag_value) == 0:
+           raise ValueError("Tag value list/set cannot be empty")
+        tag_value = ';'.join(str(x) for x in tag_value)
+    elif not isinstance(tag_value, str):
+        tag_value = str(tag_value)
+    if len(tag_value) > 0:
+      return f"{BWC_TAG_PREFIX}{tag_key}={tag_value}\n"
+    else:
+      return f"{BWC_TAG_PREFIX}{tag_key}\n"
+
+## List tests files
+def parse_excluded_tests(path):
+    exclusion_list = {}
+    with open(path) as f:
+        for line in f:
+            stripped = line.strip()
+            if len(stripped) > 0 and line[0] != '#':
+                exclusion_list[stripped] = True
+    return exclusion_list
+
+def find_tests_recursive(dir):
+    test_list = []
+    for f in os.listdir(dir):
+        path = os.path.join(dir, f)
+        if os.path.isdir(path):
+            test_list += find_tests_recursive(path)
+        elif path.endswith('.test'):
+            test_list.append(path)
+    return test_list
+
+def list_test_files(root_dir: str, test_pattern: str = None) -> List[str]:
+    test_dir = os.path.join(root_dir, 'test', 'sql')
+    files = find_tests_recursive(test_dir)
+    files.sort()
+    return files if test_pattern is None else [x for x in files if test_pattern in x]
+
+
+class SerializedTest:
+  class TestStep:
+    def __init__(self, step_type: str, step_data: Any = None):
+      self.step_type = step_type
+      self.step_data = step_data
+
+  def __init__(self, duckdb_bwc_base_dir: str, duckdb_version: str, test_spec_relative_path: str, test_idx: int):
+    # Provided metadata
+    self.duckdb_bwc_base_dir = duckdb_bwc_base_dir
+    self.duckdb_version = duckdb_version
+    self.test_spec_relative_path = test_spec_relative_path
+    self.test_idx = test_idx
+
+    # Computed paths
+    test_basename = basename(test_spec_relative_path) # eg. attach_encryption_fallback_readonly.test
+    self.test_absolute_filename = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}/{test_spec_relative_path}"
+    self.test_specs_base_dir = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}"
+    self.test_runtime_directory = f"{duckdb_bwc_base_dir}/runtime/{duckdb_version}/{dirname(test_spec_relative_path)}/{test_basename.replace('.test', '')}"
+    self.test_output_directory = f"{self.test_runtime_directory}/output"
+    self.queries_file_name = f"{test_basename}.sql"
+
+    self.serialized_plans_file_name = f"{test_basename}.plan.bin"
+    self.results_old_file_name = f"{test_basename}.{duckdb_version}.result.bin"
+    self.results_new_file_name = f"{test_basename}.new.result.bin" # TODO - use actual version?
+
+    # Log all paths
+    logger.debug(f"SerializedTest#{self.test_idx} initialized:")
+    logger.debug(f"  test_absolute_filename: {self.test_absolute_filename}")
+    logger.debug(f"  test_runtime_directory: {self.test_runtime_directory}")
+    logger.debug(f"  queries_file_name: {self.queries_file_name}")
+    logger.debug(f"  serialized_plans_file_name: {self.serialized_plans_file_name}")
+    logger.debug(f"  results_old_file_name: {self.results_old_file_name}")
+    logger.debug(f"  results_new_file_name: {self.results_new_file_name}")
+
+    # Used during parsing
+    self.loaded_from_disk = False
+    self.has_cached_serialized_plans = False
+    self.ignore_error_messages = False
+    self.no_extension_autoloading = False
+    self.nb_skipped_statements_in_loop = 0
+    self.steps = []
+
+    # Used during execution
+    self.skip_reasons = []
+    self.fixtures = set()
+    self.nb_steps = 0
+    self.needed_extensions = set()
+
+  def add(self, step_type: str, step_data: Any = None):
+    self.steps.append(self.TestStep(step_type, step_data))
+
+  def __str__(self):
+    return f"SerializedTest#{self.test_idx}(test_filename={self.test_absolute_filename}, steps={self.get_nb_steps()})"
+
+  def steps_str(self):
+    return '\n- '.join([f"{step.step_type}: {step.step_data}" for step in self.steps])
+
+  def create_runtime_directories(self):
+    # Create runtime directory (base + output since they are nested)
+    assert(self.test_runtime_directory in self.test_output_directory)
+    os.makedirs(self.test_output_directory, exist_ok=True)
+
+    # Create symlink to data directory so tests can access it via 'data/'
+    data_symlink = f"{self.test_runtime_directory}/data"
+    if not os.path.exists(data_symlink):
+      os.symlink(f"{self.test_specs_base_dir}/data", data_symlink)
+
+    test_symlink = f"{self.test_runtime_directory}/test"
+    if not os.path.exists(test_symlink):
+      os.symlink(f"{self.test_specs_base_dir}/test", test_symlink)
+
+  def reset_output_directory(self):
+    """
+      When generating the SQL files, we also create some output fixtures (eg. during unzip)
+      At the same time, during runtime the tests will also generate output files.
+      So we before each run we copy all reference output directory.
+    """
+    output_files = self.list_output_directory(True)
+    if len(output_files) == 0:
+      return # Nothing to do
+
+    files_to_move = set()
+    for output_file in output_files:
+      if output_file in self.fixtures:
+        continue
+
+      # Only move the top level folder
+      f = output_file.split('/')[0] if '/' in output_file else output_file
+      files_to_move.add(f)
+
+    # Restore fixtures
+    for fixture in self.fixtures:
+      shutil.copy2(f"{self.test_runtime_directory}/fixtures/{fixture}", self.test_output_directory)
+
+    if len(files_to_move) == 0:
+      return
+
+    src = self.test_output_directory
+    target_dir = f"{src}_{time.strftime('%Y%m%d_%H%M%S')}"
+
+    # Target dir can exist if run with old version moved it just before
+    if os.path.exists(target_dir):
+      target_dir = f"{target_dir}_run2"
+
+    os.mkdir(target_dir)
+    for f in files_to_move:
+      shutil.move(f"{src}/{f}", f"{target_dir}/{f}")
+
+    logger.debug(f"Moved output directory from '{src}' to '{target_dir}'")
+
+
+  def reload_from_disk(self) -> bool:
+    """Reload a test from disk if it already exists."""
+    absolute_queries_file = f"{self.test_runtime_directory}/{self.queries_file_name}"
+    if not os.path.exists(absolute_queries_file):
+      return False
+
+    logger.debug(f"Reloading test '{self.test_absolute_filename}' from cached queries file '{absolute_queries_file}'")
+    with open(absolute_queries_file, 'r') as f:
+      for full_line in f.readlines():
+        line = full_line.strip()
+        if not line.startswith(BWC_TAG_PREFIX):
+          continue
+
+        [tag_key, _, tag_value] = line[len(BWC_TAG_PREFIX):].partition('=')
+        if tag_key == 'skip_reasons':
+          reasons = tag_value.split(';')
+          self.skip_reasons.extend(reasons)
+          break # No need to parse further
+        elif tag_key == 'needed_extensions':
+          extensions = tag_value.split(';')
+          self.needed_extensions.update(extensions)
+        elif tag_key == 'nb_steps':
+          self.nb_steps = int(tag_value)
+        elif tag_key == 'fixtures':
+          self.fixtures = set(tag_value.split(';'))
+
+    self.loaded_from_disk = True
+    self.has_cached_serialized_plans = self.exists_in_runtime_dir(self.serialized_plans_file_name) and self.exists_in_runtime_dir(self.results_old_file_name)
+
+    # Ensure symlinks exist (they are not included in the cache archive)
+    self.create_runtime_directories()
+
+    return True
+
+  def exists_in_runtime_dir(self, file_name) -> bool:
+    return os.path.exists(f"{self.test_runtime_directory}/{file_name}")
+
+  def get_nb_steps(self) -> int:
+    return self.nb_steps if self.loaded_from_disk else len(self.steps)
+
+  def list_output_directory(self, allow_nested_path = False) -> List[str]:
+    files = []
+    folder = self.test_output_directory
+    for root, _, filenames in os.walk(folder):
+      for filename in filenames:
+        f = os.path.relpath(os.path.join(root, filename), folder)
+        if not allow_nested_path:
+          assert('/' not in f), f"Nested output files are not supported for now: {f}"
+        files.append(f)
+
+    return files
+
+  def write_test_queries(self):
+    if len(self.steps) == 0 and len(self.skip_reasons) == 0:
+      logger.warning(f"No step found in test file '{self.queries_file_name}'")
+      return
+
+    gen_files = self.list_output_directory()
+
+    if len(gen_files) > 0:
+      os.mkdir(f"{self.test_runtime_directory}/fixtures")
+      for gen_file in gen_files:
+        shutil.copy2(f"{self.test_output_directory}/{gen_file}", f"{self.test_runtime_directory}/fixtures/")
+
+    with open(f"{self.test_runtime_directory}/{self.queries_file_name}", 'w') as f:
+      if len(self.skip_reasons) > 0:
+        f.write(make_tag("skip_reasons", self.skip_reasons))
+        return
+
+      if len(gen_files) > 0:
+        f.write(make_tag("fixtures", ';'.join(gen_files)))
+
+      if len(self.needed_extensions) > 0:
+        f.write(make_tag("needed_extensions", self.needed_extensions))
+
+      f.write(make_tag("nb_steps", len(self.steps)))
+      for step in self.steps:
+        if step.step_type == "query":
+          f.write(step.step_data)
+        else:
+          raise ValueError(f"Unsupported step type: {step.step_type}")
+
+class SerializerSQLLogicContext(SQLLogicContext):
+  def __init__(self, pool, runner, statements, keywords, update_value):
+    super().__init__(pool, runner, statements, keywords, update_value)
+    self.current_test = runner.current_test
+
+  def update_settings(self):
+    pass # Nothing to do
+
+  def _normalize_query(self, statement: Statement) -> str:
+    # Normalize the query by removing comments and extra whitespace
+    tags = None
+    if statement.expected_result is not None and statement.expected_result.type != ExpectedResult.Type.SUCCESS:
+       if statement.expected_result.type == ExpectedResult.Type.ERROR:
+          tags = make_tag("expected_result", "error")
+       elif statement.expected_result.type == ExpectedResult.Type.UNKNOWN:
+          tags = make_tag("expected_result", "unknown")
+       else:
+          raise ValueError(f"Unknown expected result type: {statement.expected_result.type}")
+
+    sql_query = '\n'.join(statement.lines)
+    sql_query = self.replace_keywords(sql_query)
+    return sql_query if not tags else f"{tags}\n{sql_query}"
+
+  def execute_statement(self, statement: Statement):
+    if len(statement.header.parameters) > 1:
+       self.skiptest("Multiple connections not supported for now")
+       return
+
+    sql_query = self._normalize_query(statement)
+    sql_query_lc = sql_query.lower()
+    if 'set enable_external_access=false' in sql_query_lc:
+       # Tester uses DuckDB API to write files...
+       self.skiptest("Can't disable external access for now")
+       return
+    self.add_query(sql_query)
+
+  def execute_query(self, query: Query):
+    sql_query = ""
+
+    # Handle sortstyle
+    sort_style = query.get_sortstyle()
+    if sort_style is not None and sort_style != SortStyle.NO_SORT:
+      sql_query = make_tag("sort", SerializerSQLLogicContext.sort_style_to_str(sort_style))
+
+    sql_query += self._normalize_query(query)
+
+    self.add_query(sql_query)
+
+  @staticmethod
+  def sort_style_to_str(sort_style):
+    if sort_style == SortStyle.NO_SORT:
+        return "no_sort"
+    elif sort_style == SortStyle.ROW_SORT:
+        return "row_sort"
+    elif sort_style == SortStyle.VALUE_SORT:
+        return "value_sort"
+    else:
+        raise ValueError(f"Unknown sort style: {sort_style}")
+
+  def add_query(self, query: str):
+    if self.in_loop() and self.is_parallel:
+        return # Skip queries in parallel loops
+
+    # Add exclusion tags based on query analysis
+    exclusion_tags = format_exclusion_tags(query)
+    if exclusion_tags:
+        query = f"{exclusion_tags}\n{query}"
+
+    self.current_test.add('query', f"{query}\n{make_tag('end_query', '')}\n")
+
+  def execute_load(self, load: Load):
+    options = []
+
+    if not load.header.parameters:
+        self.add_query(f"USE memory;")
+        return
+
+    dbpath = self.replace_keywords(load.header.parameters[0])
+    db_name = basename(dbpath).split('.')[0]
+    if load.readonly:
+        options.append('READ_ONLY')
+    if load.version:
+        options.append(f"STORAGE_VERSION {load.version}")
+
+    opt_str = f" ({', '.join(options)})" if options and len(options) > 1 else ''
+    self.add_query(f"{make_tag('load_db', db_name)}\nATTACH '{dbpath}' AS {db_name}{opt_str};")
+
+  def execute_restart(self, statement: Restart):
+    # FIXME - skipping >200 tests because of this
+    self.skiptest("Restart not supported for now")
+
+  def execute_unzip(self, statement: Unzip):
+    self.do_execute_unzip(statement)
+
+  def execute_set(self, statement: Set):
+    option = statement.header.parameters[0]
+    if option == 'ignore_error_messages':
+        self.current_test.ignore_error_messages = True
+    elif option == 'seed':
+        self.add_query(f"SELECT SETSEED({statement.header.parameters[1]});")
+        # TODO - self.runner.skip_reload = True
+    else:
+        raise ValueError(f"SET '{option}' is not implemented!")
+
+  def execute_foreach(self, foreach: Foreach):
+    if not foreach.parallel:
+      super().execute_foreach(foreach)
+    else:
+      # Get loop statements will skip over the inner statements
+      skipped_stmts = self.get_loop_statements()
+      self.current_test.nb_skipped_statements_in_loop += len(skipped_stmts)
+
+  def execute_loop(self, loop: Loop):
+    if not loop.parallel:
+      super().execute_loop(loop)
+    else:
+      # Get loop statements will skip over the inner statements
+      skipped_stmts = self.get_loop_statements()
+      self.current_test.nb_skipped_statements_in_loop += len(skipped_stmts)
+
+  def skiptest(self, reason):
+    if reason not in self.current_test.skip_reasons:
+      self.current_test.skip_reasons.append(reason)
+
+  def check_require(self, statement: Require) -> RequireResult:
+    not_supported = set([
+       "no_alternative_verify",
+       "noalternativeverify",
+       "fts", # TODO - need to support non-linked extensions
+    ])
+    not_an_extension = ([
+        # Copied over from scripts/sqllogictest/result.py
+        "64bit",
+        "block_size",
+        "exact_vector_size",
+        "longdouble",
+        "mingw",
+        "no_alternative_verify",
+        "noalternativeverify",
+        "noforcestorage",
+        "nothreadsan",
+        "notmingw",
+        "notwindows",
+        "skip_reload",
+        "strinline",
+        "vector_size",
+        "windows",
+
+        # Added here:
+        "no_latest_storage",
+        "no_vector_verification",
+        "notmusl",
+        "ram",
+    ])
+
+    param = statement.header.parameters[0].lower()
+    if param in not_supported:
+        # self.skiptest(f"Requirement '{param}' is not supported")
+        return RequireResult.MISSING
+    elif param in not_an_extension:
+        # TODO - skip_reload?
+        return RequireResult.PRESENT
+    elif param == "no_extension_autoloading":
+        # This is a special case, we do not want to load extensions automatically
+        self.add_query("SET autoload_known_extensions=false;")
+        self.current_test.no_extension_autoloading = True
+        return RequireResult.PRESENT
+    elif param == "allow_unsigned_extensions":
+        # We're running with this parameter for now
+        return RequireResult.PRESENT
+
+    if not self.current_test.no_extension_autoloading:
+        self.add_query(f"LOAD '{param}';")
+        self.current_test.needed_extensions.add(param)
+    return RequireResult.PRESENT
+
+
+class SQLLogicTestSerializer(SQLLogicRunner):
+    def __init__(self, duckdb_bwc_base_dir: str, duckdb_version: str, test_relative_path: str, test_idx: int):
+        super().__init__(None)
+        self.current_test = SerializedTest(duckdb_bwc_base_dir, duckdb_version, test_relative_path, test_idx)
+
+
+    def execute_test(self) -> None:
+      if self.current_test.reload_from_disk():
+         return
+
+      self.current_test.create_runtime_directories()
+
+      # Set current working directory
+      os.chdir(self.current_test.test_runtime_directory)
+
+      self.reset()
+      sql_parser = SQLLogicParser()
+      test_absolute_filename = self.current_test.test_absolute_filename
+      try:
+        test = sql_parser.parse(str(test_absolute_filename))
+        if test is None:
+          raise ValueError(f"Failed to parse test file (unknown reason)")
+      except Exception as e:
+        self.current_test.skip_reasons.append("parsing_error")
+        self.current_test.write_test_queries()
+        logger.error(f"Exception while parsing test file: {test_absolute_filename}: {e}")
+        return
+
+      self.test = test
+      self.extensions = ["httpfs", "parquet", "tpch", "json", "icu", "tpcds", "sqlite_scanner", "autocomplete", "inet"]
+      self.original_sqlite_test = self.test.is_sqlite_test()
+
+      # Top level keywords
+      keywords = {
+        '__TEST_DIR__': 'output',
+        '__WORKING_DIRECTORY__': '.',
+        '{DATA_DIR}': 'data',
+        '{TEMP_DIR}': 'output',
+        '{TEST_DIR}': 'output'
+      }
+
+      def update_value(_: SQLLogicContext) -> Generator[Any, Any, Any]:
+        # Yield once to represent one iteration, do not touch the keywords
+        yield None
+
+      context = SerializerSQLLogicContext(None, self, test.statements, keywords, update_value)
+      context.is_loop = False # The outer context is not a loop
+      context.verify_statements()
+      res = context.execute()
+      assert res.type == ExecuteResult.Type.SUCCESS
+
+      if self.skip_active() and len(self.current_test.skip_reasons) == 0:
+        self.current_test.skip_reasons.append("explicitly skipped")
+
+      if len(self.current_test.skip_reasons) == 0 and len(self.current_test.steps) == 0 and self.current_test.nb_skipped_statements_in_loop > 0:
+        self.current_test.skip_reasons.append("entirely_skipped_because_of_parallel_loops")
+
+      self.current_test.write_test_queries()
+
+
+def list_skipped_tests(skip_file_path: str) -> set:
+    skipped_tests = set()
+    if os.path.exists(skip_file_path):
+      with open(skip_file_path, 'r', ) as skip_file:
+          for line in skip_file:
+              line = line.strip()
+              if line and not line.startswith("#"):
+                if '#' in line:
+                  line = line.split('#')[0].strip()
+                skipped_tests.add(line)
+
+    return skipped_tests
+
+class LoadingStats:
+  def __init__(self):
+    self.skipped_count = 0
+    self.skipped_count_per_reason = {}
+    self.start_time = time.time()
+    self.nb_steps = 0
+    self.nb_tests = 0
+    self.nb_cached_queries = 0
+    self.nb_cached_plans = 0
+
+  def update(self, test: SerializedTest):
+    if len(test.skip_reasons) > 0:
+      self.update_skipped(test.skip_reasons)
+      return
+
+    self.nb_tests += 1
+    self.nb_steps += test.get_nb_steps()
+
+    if test.loaded_from_disk:
+      self.nb_cached_queries += 1
+
+    if test.has_cached_serialized_plans:
+      self.nb_cached_plans += 1
+
+  def update_skipped(self, reasons: List[str]):
+    if len(reasons) == 0:
+      return
+
+    self.skipped_count += 1
+    for reason in reasons:
+      if reason not in self.skipped_count_per_reason:
+        self.skipped_count_per_reason[reason] = 0
+      self.skipped_count_per_reason[reason] += 1
+
+  def log_stats(self):
+    logger.info(f"Loaded {self.nb_tests} test files (with {self.nb_steps} steps) in {time.time() - self.start_time:.2f}s")
+    logger.info(f"  Cached queries: {self.nb_cached_queries} ({(self.nb_cached_queries/self.nb_tests*100) if self.nb_tests > 0 else 0:.2f}%)")
+    logger.info(f"  Cached plans: {self.nb_cached_plans} ({(self.nb_cached_plans/self.nb_tests*100) if self.nb_tests > 0 else 0:.2f}%)")
+    logger.info(f"  Skipped {self.skipped_count} ({(self.skipped_count/self.nb_tests*100) if self.nb_tests > 0 else 0:.2f}%) test files:")
+
+    # Sort self.skipped_count_per_reason by count descending
+    sorted_skipped = sorted(self.skipped_count_per_reason.items(), key=lambda x: x[1], reverse=True)
+    for reason, count in sorted_skipped:
+      logger.info(f"    {count} ({(count/self.skipped_count*100) if self.skipped_count > 0 else 0:.2f}%): {reason}")
+
+
+def load_test_files(duckdb_bwc_base_dir: str, duckdb_version: str, skip_file_path: str, test_pattern: str = None) -> List:
+  loading_stats = LoadingStats()
+
+  spec_files_dir = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}"
+  logger.info(f"Using Python DuckDB version {duckdb.__version__} to load test files from {spec_files_dir}")
+
+  files = list_test_files(spec_files_dir, test_pattern)
+  logger.info(f"Found {len(files)} test files")
+
+  loaded_tests = []
+  skipped_tests = list_skipped_tests(skip_file_path) if test_pattern is None else set()
+  logger.debug(f"Found {len(skipped_tests)} tests to skip in '{skip_file_path}'")
+  len_spec_files_dir = len(spec_files_dir) + 1
+  needed_extensions = set()
+  for test_filename in files:
+    rel_test_filename = test_filename[len_spec_files_dir:]
+    if not rel_test_filename.startswith('test/sql/'):
+      raise ValueError(f"Test file '{test_filename}' does not start with 'test/sql/'")
+
+    if rel_test_filename in skipped_tests:
+      loading_stats.update_skipped([f"in skipped file '{skip_file_path}'"])
+      continue
+
+    try:
+      serializer = SQLLogicTestSerializer(duckdb_bwc_base_dir, duckdb_version, rel_test_filename, len(loaded_tests) + 1)
+      serializer.execute_test()
+      test = serializer.current_test
+
+      loading_stats.update(test)
+      if len(test.skip_reasons) == 0:
+        loaded_tests.append(test)
+        needed_extensions.update(test.needed_extensions)
+    except Exception as e:
+      logger.error(f"Failed to load test file '{test_filename}'")
+      raise e
+
+  loading_stats.log_stats()
+
+  return { 'tests': loaded_tests, 'needed_extensions': needed_extensions }

--- a/test/bwc/utils/test_files_parser.py
+++ b/test/bwc/utils/test_files_parser.py
@@ -32,6 +32,7 @@ from utils.query_exclusions import format_exclusion_tags
 from utils.logger import make_logger
 
 BWC_TAG_PREFIX = '-- bwc_tag:'
+BWC_OUTPUT_DIR_NAME = 'output'
 
 logger = make_logger(__name__)
 
@@ -71,7 +72,9 @@ def list_test_files(root_dir: str, test_pattern: str = None) -> List[str]:
     test_dir = os.path.join(root_dir, 'test', 'sql')
     files = find_tests_recursive(test_dir)
     files.sort()
-    return files if test_pattern is None else [x for x in files if test_pattern in x]
+    files = files if test_pattern is None else [x for x in files if test_pattern in x]
+    len_root_dir = len(root_dir) + 1
+    return [f[len_root_dir:] for f in files]
 
 
 class SerializedTest:
@@ -80,19 +83,29 @@ class SerializedTest:
       self.step_type = step_type
       self.step_data = step_data
 
-  def __init__(self, duckdb_bwc_base_dir: str, duckdb_version: str, test_spec_relative_path: str, test_idx: int):
+  def __init__(self, duckdb_bwc_base_dir: str, duckdb_version: str, test_filename: str, test_idx: int):
     # Provided metadata
     self.duckdb_bwc_base_dir = duckdb_bwc_base_dir
     self.duckdb_version = duckdb_version
-    self.test_spec_relative_path = test_spec_relative_path
+    self.test_spec_relative_path = test_filename
     self.test_idx = test_idx
 
     # Computed paths
-    test_basename = basename(test_spec_relative_path) # eg. attach_encryption_fallback_readonly.test
-    self.test_absolute_filename = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}/{test_spec_relative_path}"
+    test_basename = basename(test_filename) # eg. attach_encryption_fallback_readonly.test
+    if len(test_basename) == 0:
+      raise ValueError(f"Test spec relative path '{test_filename}' is not valid (basename is empty)")
+
     self.test_specs_base_dir = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}"
-    self.test_runtime_directory = f"{duckdb_bwc_base_dir}/runtime/{duckdb_version}/{dirname(test_spec_relative_path)}/{test_basename.replace('.test', '')}"
-    self.test_output_directory = f"{self.test_runtime_directory}/output"
+
+    is_spec_file = test_filename.startswith('test/sql/')
+    if is_spec_file:
+      self.test_absolute_filename = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}/{test_filename}"
+      self.test_runtime_directory = f"{duckdb_bwc_base_dir}/runtime/{duckdb_version}/{dirname(test_filename)}/{test_basename.replace('.test', '')}"
+    else:
+      self.test_absolute_filename = os.path.join(os.getcwd(), test_filename)
+      self.test_runtime_directory = f"{duckdb_bwc_base_dir}/runtime/{duckdb_version}/{test_basename.replace('.test', '')}"
+
+    self.test_output_directory = f"{self.test_runtime_directory}/{BWC_OUTPUT_DIR_NAME}"
     self.queries_file_name = f"{test_basename}.sql"
 
     self.serialized_plans_file_name = f"{test_basename}.plan.bin"
@@ -152,9 +165,6 @@ class SerializedTest:
       So we before each run we copy all reference output directory.
     """
     output_files = self.list_output_directory(True)
-    if len(output_files) == 0:
-      return # Nothing to do
-
     files_to_move = set()
     for output_file in output_files:
       if output_file in self.fixtures:
@@ -163,6 +173,9 @@ class SerializedTest:
       # Only move the top level folder
       f = output_file.split('/')[0] if '/' in output_file else output_file
       files_to_move.add(f)
+
+    # Ensure output directory exists
+    os.makedirs(self.test_output_directory, exist_ok=True)
 
     # Restore fixtures
     for fixture in self.fixtures:
@@ -243,6 +256,7 @@ class SerializedTest:
       return
 
     gen_files = self.list_output_directory()
+    self.fixtures.update(gen_files)
 
     if len(gen_files) > 0:
       os.mkdir(f"{self.test_runtime_directory}/fixtures")
@@ -445,14 +459,14 @@ class SerializerSQLLogicContext(SQLLogicContext):
 
 
 class SQLLogicTestSerializer(SQLLogicRunner):
-    def __init__(self, duckdb_bwc_base_dir: str, duckdb_version: str, test_relative_path: str, test_idx: int):
+    def __init__(self, duckdb_bwc_base_dir: str, duckdb_version: str, test_filename: str, test_idx: int):
         super().__init__(None)
-        self.current_test = SerializedTest(duckdb_bwc_base_dir, duckdb_version, test_relative_path, test_idx)
+        self.current_test = SerializedTest(duckdb_bwc_base_dir, duckdb_version, test_filename, test_idx)
 
 
     def execute_test(self) -> None:
       if self.current_test.reload_from_disk():
-         return
+        return
 
       self.current_test.create_runtime_directories()
 
@@ -467,9 +481,13 @@ class SQLLogicTestSerializer(SQLLogicRunner):
         if test is None:
           raise ValueError(f"Failed to parse test file (unknown reason)")
       except Exception as e:
+        # Throw if exception is file not found
+        if not os.path.exists(test_absolute_filename):
+          raise e
+
         self.current_test.skip_reasons.append("parsing_error")
         self.current_test.write_test_queries()
-        logger.error(f"Exception while parsing test file: {test_absolute_filename}: {e}")
+        logger.error(f"Exception while parsing test file '{test_absolute_filename}': {e}")
         return
 
       self.test = test
@@ -478,11 +496,11 @@ class SQLLogicTestSerializer(SQLLogicRunner):
 
       # Top level keywords
       keywords = {
-        '__TEST_DIR__': 'output',
+        '__TEST_DIR__': BWC_OUTPUT_DIR_NAME,
         '__WORKING_DIRECTORY__': '.',
         '{DATA_DIR}': 'data',
-        '{TEMP_DIR}': 'output',
-        '{TEST_DIR}': 'output'
+        '{TEMP_DIR}': BWC_OUTPUT_DIR_NAME,
+        '{TEST_DIR}': BWC_OUTPUT_DIR_NAME
       }
 
       def update_value(_: SQLLogicContext) -> Generator[Any, Any, Any]:
@@ -523,6 +541,7 @@ def list_skipped_tests(duckdb_test_config_dir: str, duckdb_version: str) -> set[
   version_skip_file_path = f"{duckdb_test_config_dir}/test/configs/serialization_bwc_{duckdb_version}.json"
   skipped_tests = load_skipped_tests_from_file(base_skip_file_path)
   skipped_tests.update(load_skipped_tests_from_file(version_skip_file_path))
+  logger.debug(f"Found {len(skipped_tests)} tests to skip in version {duckdb_version} (base skip file: {base_skip_file_path}, version skip file: {version_skip_file_path})")
   return skipped_tests
 
 
@@ -572,31 +591,28 @@ class LoadingStats:
       logger.info(f"    {count} ({(count/self.skipped_count*100) if self.skipped_count > 0 else 0:.2f}%): {reason}")
 
 
-def load_test_files(duckdb_root_dir: str, duckdb_bwc_base_dir: str, duckdb_version: str, skip_file_path: str, test_pattern: str = None) -> List:
+def load_test_files(duckdb_root_dir: str, duckdb_bwc_base_dir: str, duckdb_version: str, test_pattern: str = None, single_test_file: str = None) -> List:
   loading_stats = LoadingStats()
 
   spec_files_dir = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}"
   logger.info(f"Using Python DuckDB version {duckdb.__version__} to load test files from {spec_files_dir}")
 
-  files = list_test_files(spec_files_dir, test_pattern)
+  # Normalize (remove trailing ./ etc)
+  single_test_file = os.path.normpath(single_test_file) if single_test_file is not None else None
+
+  files = [single_test_file] if single_test_file is not None else list_test_files(spec_files_dir, test_pattern)
   logger.info(f"Found {len(files)} test files")
 
   loaded_tests = []
-  skipped_tests = list_skipped_tests(duckdb_root_dir, duckdb_version) if test_pattern is None else set()
-  logger.debug(f"Found {len(skipped_tests)} tests to skip in '{skip_file_path}'")
-  len_spec_files_dir = len(spec_files_dir) + 1
+  skipped_tests = list_skipped_tests(duckdb_root_dir, duckdb_version) if test_pattern is None and single_test_file is None else set()
   needed_extensions = set()
   for test_filename in files:
-    rel_test_filename = test_filename[len_spec_files_dir:]
-    if not rel_test_filename.startswith('test/sql/'):
-      raise ValueError(f"Test file '{test_filename}' does not start with 'test/sql/'")
-
-    if rel_test_filename in skipped_tests:
-      loading_stats.update_skipped([f"in skipped file '{skip_file_path}'"])
-      continue
+    if test_filename in skipped_tests:
+        loading_stats.update_skipped([f"in skipped file"])
+        continue
 
     try:
-      serializer = SQLLogicTestSerializer(duckdb_bwc_base_dir, duckdb_version, rel_test_filename, len(loaded_tests) + 1)
+      serializer = SQLLogicTestSerializer(duckdb_bwc_base_dir, duckdb_version, test_filename, len(loaded_tests) + 1)
       serializer.execute_test()
       test = serializer.current_test
 

--- a/test/bwc/utils/test_files_parser.py
+++ b/test/bwc/utils/test_files_parser.py
@@ -22,7 +22,7 @@ from duckdb_sqllogictest.result import (
     SQLLogicContext,
     SQLLogicRunner,
     Statement,
-    Unzip
+    Unzip,
 )
 
 from duckdb_sqllogictest.expected_result import ExpectedResult
@@ -36,17 +36,19 @@ BWC_OUTPUT_DIR_NAME = 'output'
 
 logger = make_logger(__name__)
 
+
 def make_tag(tag_key: str, tag_value: int | str | list | set) -> str:
     if isinstance(tag_value, list) or isinstance(tag_value, set):
         if len(tag_value) == 0:
-           raise ValueError("Tag value list/set cannot be empty")
+            raise ValueError("Tag value list/set cannot be empty")
         tag_value = ';'.join(str(x) for x in tag_value)
     elif not isinstance(tag_value, str):
         tag_value = str(tag_value)
     if len(tag_value) > 0:
-      return f"{BWC_TAG_PREFIX}{tag_key}={tag_value}\n"
+        return f"{BWC_TAG_PREFIX}{tag_key}={tag_value}\n"
     else:
-      return f"{BWC_TAG_PREFIX}{tag_key}\n"
+        return f"{BWC_TAG_PREFIX}{tag_key}\n"
+
 
 ## List tests files
 def parse_excluded_tests(path):
@@ -58,6 +60,7 @@ def parse_excluded_tests(path):
                 exclusion_list[stripped] = True
     return exclusion_list
 
+
 def find_tests_recursive(dir):
     test_list = []
     for f in os.listdir(dir):
@@ -67,6 +70,7 @@ def find_tests_recursive(dir):
         elif path.endswith('.test'):
             test_list.append(path)
     return test_list
+
 
 def list_test_files(root_dir: str, test_pattern: str = None) -> List[str]:
     test_dir = os.path.join(root_dir, 'test', 'sql')
@@ -78,384 +82,393 @@ def list_test_files(root_dir: str, test_pattern: str = None) -> List[str]:
 
 
 class SerializedTest:
-  class TestStep:
-    def __init__(self, step_type: str, step_data: Any = None):
-      self.step_type = step_type
-      self.step_data = step_data
+    class TestStep:
+        def __init__(self, step_type: str, step_data: Any = None):
+            self.step_type = step_type
+            self.step_data = step_data
 
-  def __init__(self, duckdb_bwc_base_dir: str, duckdb_version: str, test_filename: str, test_idx: int):
-    # Provided metadata
-    self.duckdb_bwc_base_dir = duckdb_bwc_base_dir
-    self.duckdb_version = duckdb_version
-    self.test_spec_relative_path = test_filename
-    self.test_idx = test_idx
+    def __init__(self, duckdb_bwc_base_dir: str, duckdb_version: str, test_filename: str, test_idx: int):
+        # Provided metadata
+        self.duckdb_bwc_base_dir = duckdb_bwc_base_dir
+        self.duckdb_version = duckdb_version
+        self.test_spec_relative_path = test_filename
+        self.test_idx = test_idx
 
-    # Computed paths
-    test_basename = basename(test_filename) # eg. attach_encryption_fallback_readonly.test
-    if len(test_basename) == 0:
-      raise ValueError(f"Test spec relative path '{test_filename}' is not valid (basename is empty)")
+        # Computed paths
+        test_basename = basename(test_filename)  # eg. attach_encryption_fallback_readonly.test
+        if len(test_basename) == 0:
+            raise ValueError(f"Test spec relative path '{test_filename}' is not valid (basename is empty)")
 
-    self.test_specs_base_dir = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}"
+        self.test_specs_base_dir = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}"
 
-    is_spec_file = test_filename.startswith('test/sql/')
-    if is_spec_file:
-      self.test_absolute_filename = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}/{test_filename}"
-      self.test_runtime_directory = f"{duckdb_bwc_base_dir}/runtime/{duckdb_version}/{dirname(test_filename)}/{test_basename.replace('.test', '')}"
-    else:
-      self.test_absolute_filename = os.path.join(os.getcwd(), test_filename)
-      self.test_runtime_directory = f"{duckdb_bwc_base_dir}/runtime/{duckdb_version}/{test_basename.replace('.test', '')}"
-
-    self.test_output_directory = f"{self.test_runtime_directory}/{BWC_OUTPUT_DIR_NAME}"
-    self.queries_file_name = f"{test_basename}.sql"
-
-    self.serialized_plans_file_name = f"{test_basename}.plan.bin"
-    self.results_old_file_name = f"{test_basename}.{duckdb_version}.result.bin"
-    self.results_new_file_name = f"{test_basename}.new.result.bin" # TODO - use actual version?
-
-    # Log all paths
-    logger.debug(f"SerializedTest#{self.test_idx} initialized:")
-    logger.debug(f"  test_absolute_filename: {self.test_absolute_filename}")
-    logger.debug(f"  test_runtime_directory: {self.test_runtime_directory}")
-    logger.debug(f"  queries_file_name: {self.queries_file_name}")
-    logger.debug(f"  serialized_plans_file_name: {self.serialized_plans_file_name}")
-    logger.debug(f"  results_old_file_name: {self.results_old_file_name}")
-    logger.debug(f"  results_new_file_name: {self.results_new_file_name}")
-
-    # Used during parsing
-    self.loaded_from_disk = False
-    self.has_cached_serialized_plans = False
-    self.ignore_error_messages = False
-    self.no_extension_autoloading = False
-    self.nb_skipped_statements_in_loop = 0
-    self.steps = []
-
-    # Used during execution
-    self.skip_reasons = []
-    self.fixtures = set()
-    self.nb_steps = 0
-    self.needed_extensions = set()
-
-  def add(self, step_type: str, step_data: Any = None):
-    self.steps.append(self.TestStep(step_type, step_data))
-
-  def __str__(self):
-    return f"SerializedTest#{self.test_idx}(test_filename={self.test_absolute_filename}, steps={self.get_nb_steps()})"
-
-  def steps_str(self):
-    return '\n- '.join([f"{step.step_type}: {step.step_data}" for step in self.steps])
-
-  def create_runtime_directories(self):
-    # Create runtime directory (base + output since they are nested)
-    assert(self.test_runtime_directory in self.test_output_directory)
-    os.makedirs(self.test_output_directory, exist_ok=True)
-
-    # Create symlink to data directory so tests can access it via 'data/'
-    data_symlink = f"{self.test_runtime_directory}/data"
-    if not os.path.exists(data_symlink):
-      os.symlink(f"{self.test_specs_base_dir}/data", data_symlink)
-
-    test_symlink = f"{self.test_runtime_directory}/test"
-    if not os.path.exists(test_symlink):
-      os.symlink(f"{self.test_specs_base_dir}/test", test_symlink)
-
-  def reset_output_directory(self):
-    """
-      When generating the SQL files, we also create some output fixtures (eg. during unzip)
-      At the same time, during runtime the tests will also generate output files.
-      So we before each run we copy all reference output directory.
-    """
-    output_files = self.list_output_directory(True)
-    files_to_move = set()
-    for output_file in output_files:
-      if output_file in self.fixtures:
-        continue
-
-      # Only move the top level folder
-      f = output_file.split('/')[0] if '/' in output_file else output_file
-      files_to_move.add(f)
-
-    # Ensure output directory exists
-    os.makedirs(self.test_output_directory, exist_ok=True)
-
-    # Restore fixtures
-    for fixture in self.fixtures:
-      shutil.copy2(f"{self.test_runtime_directory}/fixtures/{fixture}", self.test_output_directory)
-
-    if len(files_to_move) == 0:
-      return
-
-    src = self.test_output_directory
-    target_dir = f"{src}_{time.strftime('%Y%m%d_%H%M%S')}"
-
-    # Target dir can exist if run with old version moved it just before
-    if os.path.exists(target_dir):
-      target_dir = f"{target_dir}_run2"
-
-    os.mkdir(target_dir)
-    for f in files_to_move:
-      shutil.move(f"{src}/{f}", f"{target_dir}/{f}")
-
-    logger.debug(f"Moved output directory from '{src}' to '{target_dir}'")
-
-
-  def reload_from_disk(self) -> bool:
-    """Reload a test from disk if it already exists."""
-    absolute_queries_file = f"{self.test_runtime_directory}/{self.queries_file_name}"
-    if not os.path.exists(absolute_queries_file):
-      return False
-
-    logger.debug(f"Reloading test '{self.test_absolute_filename}' from cached queries file '{absolute_queries_file}'")
-    with open(absolute_queries_file, 'r') as f:
-      for full_line in f.readlines():
-        line = full_line.strip()
-        if not line.startswith(BWC_TAG_PREFIX):
-          continue
-
-        [tag_key, _, tag_value] = line[len(BWC_TAG_PREFIX):].partition('=')
-        if tag_key == 'skip_reasons':
-          reasons = tag_value.split(';')
-          self.skip_reasons.extend(reasons)
-          break # No need to parse further
-        elif tag_key == 'needed_extensions':
-          extensions = tag_value.split(';')
-          self.needed_extensions.update(extensions)
-        elif tag_key == 'nb_steps':
-          self.nb_steps = int(tag_value)
-        elif tag_key == 'fixtures':
-          self.fixtures = set(tag_value.split(';'))
-
-    self.loaded_from_disk = True
-    self.has_cached_serialized_plans = self.exists_in_runtime_dir(self.serialized_plans_file_name) and self.exists_in_runtime_dir(self.results_old_file_name)
-
-    # Ensure symlinks exist (they are not included in the cache archive)
-    self.create_runtime_directories()
-
-    return True
-
-  def exists_in_runtime_dir(self, file_name) -> bool:
-    return os.path.exists(f"{self.test_runtime_directory}/{file_name}")
-
-  def get_nb_steps(self) -> int:
-    return self.nb_steps if self.loaded_from_disk else len(self.steps)
-
-  def list_output_directory(self, allow_nested_path = False) -> List[str]:
-    files = []
-    folder = self.test_output_directory
-    for root, _, filenames in os.walk(folder):
-      for filename in filenames:
-        f = os.path.relpath(os.path.join(root, filename), folder)
-        if not allow_nested_path:
-          assert('/' not in f), f"Nested output files are not supported for now: {f}"
-        files.append(f)
-
-    return files
-
-  def write_test_queries(self):
-    if len(self.steps) == 0 and len(self.skip_reasons) == 0:
-      logger.warning(f"No step found in test file '{self.queries_file_name}'")
-      return
-
-    gen_files = self.list_output_directory()
-    self.fixtures.update(gen_files)
-
-    if len(gen_files) > 0:
-      os.mkdir(f"{self.test_runtime_directory}/fixtures")
-      for gen_file in gen_files:
-        shutil.copy2(f"{self.test_output_directory}/{gen_file}", f"{self.test_runtime_directory}/fixtures/")
-
-    with open(f"{self.test_runtime_directory}/{self.queries_file_name}", 'w') as f:
-      if len(self.skip_reasons) > 0:
-        f.write(make_tag("skip_reasons", self.skip_reasons))
-        return
-
-      if len(gen_files) > 0:
-        f.write(make_tag("fixtures", ';'.join(gen_files)))
-
-      if len(self.needed_extensions) > 0:
-        f.write(make_tag("needed_extensions", self.needed_extensions))
-
-      f.write(make_tag("nb_steps", len(self.steps)))
-      for step in self.steps:
-        if step.step_type == "query":
-          f.write(step.step_data)
+        is_spec_file = test_filename.startswith('test/sql/')
+        if is_spec_file:
+            self.test_absolute_filename = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}/{test_filename}"
+            self.test_runtime_directory = f"{duckdb_bwc_base_dir}/runtime/{duckdb_version}/{dirname(test_filename)}/{test_basename.replace('.test', '')}"
         else:
-          raise ValueError(f"Unsupported step type: {step.step_type}")
+            self.test_absolute_filename = os.path.join(os.getcwd(), test_filename)
+            self.test_runtime_directory = (
+                f"{duckdb_bwc_base_dir}/runtime/{duckdb_version}/{test_basename.replace('.test', '')}"
+            )
+
+        self.test_output_directory = f"{self.test_runtime_directory}/{BWC_OUTPUT_DIR_NAME}"
+        self.queries_file_name = f"{test_basename}.sql"
+
+        self.serialized_plans_file_name = f"{test_basename}.plan.bin"
+        self.results_old_file_name = f"{test_basename}.{duckdb_version}.result.bin"
+        self.results_new_file_name = f"{test_basename}.new.result.bin"  # TODO - use actual version?
+
+        # Log all paths
+        logger.debug(f"SerializedTest#{self.test_idx} initialized:")
+        logger.debug(f"  test_absolute_filename: {self.test_absolute_filename}")
+        logger.debug(f"  test_runtime_directory: {self.test_runtime_directory}")
+        logger.debug(f"  queries_file_name: {self.queries_file_name}")
+        logger.debug(f"  serialized_plans_file_name: {self.serialized_plans_file_name}")
+        logger.debug(f"  results_old_file_name: {self.results_old_file_name}")
+        logger.debug(f"  results_new_file_name: {self.results_new_file_name}")
+
+        # Used during parsing
+        self.loaded_from_disk = False
+        self.has_cached_serialized_plans = False
+        self.ignore_error_messages = False
+        self.no_extension_autoloading = False
+        self.nb_skipped_statements_in_loop = 0
+        self.steps = []
+
+        # Used during execution
+        self.skip_reasons = []
+        self.fixtures = set()
+        self.nb_steps = 0
+        self.needed_extensions = set()
+
+    def add(self, step_type: str, step_data: Any = None):
+        self.steps.append(self.TestStep(step_type, step_data))
+
+    def __str__(self):
+        return (
+            f"SerializedTest#{self.test_idx}(test_filename={self.test_absolute_filename}, steps={self.get_nb_steps()})"
+        )
+
+    def steps_str(self):
+        return '\n- '.join([f"{step.step_type}: {step.step_data}" for step in self.steps])
+
+    def create_runtime_directories(self):
+        # Create runtime directory (base + output since they are nested)
+        assert self.test_runtime_directory in self.test_output_directory
+        os.makedirs(self.test_output_directory, exist_ok=True)
+
+        # Create symlink to data directory so tests can access it via 'data/'
+        data_symlink = f"{self.test_runtime_directory}/data"
+        if not os.path.exists(data_symlink):
+            os.symlink(f"{self.test_specs_base_dir}/data", data_symlink)
+
+        test_symlink = f"{self.test_runtime_directory}/test"
+        if not os.path.exists(test_symlink):
+            os.symlink(f"{self.test_specs_base_dir}/test", test_symlink)
+
+    def reset_output_directory(self):
+        """
+        When generating the SQL files, we also create some output fixtures (eg. during unzip)
+        At the same time, during runtime the tests will also generate output files.
+        So we before each run we copy all reference output directory.
+        """
+        output_files = self.list_output_directory(True)
+        files_to_move = set()
+        for output_file in output_files:
+            if output_file in self.fixtures:
+                continue
+
+            # Only move the top level folder
+            f = output_file.split('/')[0] if '/' in output_file else output_file
+            files_to_move.add(f)
+
+        # Ensure output directory exists
+        os.makedirs(self.test_output_directory, exist_ok=True)
+
+        # Restore fixtures
+        for fixture in self.fixtures:
+            shutil.copy2(f"{self.test_runtime_directory}/fixtures/{fixture}", self.test_output_directory)
+
+        if len(files_to_move) == 0:
+            return
+
+        src = self.test_output_directory
+        target_dir = f"{src}_{time.strftime('%Y%m%d_%H%M%S')}"
+
+        # Target dir can exist if run with old version moved it just before
+        if os.path.exists(target_dir):
+            target_dir = f"{target_dir}_run2"
+
+        os.mkdir(target_dir)
+        for f in files_to_move:
+            shutil.move(f"{src}/{f}", f"{target_dir}/{f}")
+
+        logger.debug(f"Moved output directory from '{src}' to '{target_dir}'")
+
+    def reload_from_disk(self) -> bool:
+        """Reload a test from disk if it already exists."""
+        absolute_queries_file = f"{self.test_runtime_directory}/{self.queries_file_name}"
+        if not os.path.exists(absolute_queries_file):
+            return False
+
+        logger.debug(
+            f"Reloading test '{self.test_absolute_filename}' from cached queries file '{absolute_queries_file}'"
+        )
+        with open(absolute_queries_file, 'r') as f:
+            for full_line in f.readlines():
+                line = full_line.strip()
+                if not line.startswith(BWC_TAG_PREFIX):
+                    continue
+
+                [tag_key, _, tag_value] = line[len(BWC_TAG_PREFIX) :].partition('=')
+                if tag_key == 'skip_reasons':
+                    reasons = tag_value.split(';')
+                    self.skip_reasons.extend(reasons)
+                    break  # No need to parse further
+                elif tag_key == 'needed_extensions':
+                    extensions = tag_value.split(';')
+                    self.needed_extensions.update(extensions)
+                elif tag_key == 'nb_steps':
+                    self.nb_steps = int(tag_value)
+                elif tag_key == 'fixtures':
+                    self.fixtures = set(tag_value.split(';'))
+
+        self.loaded_from_disk = True
+        self.has_cached_serialized_plans = self.exists_in_runtime_dir(
+            self.serialized_plans_file_name
+        ) and self.exists_in_runtime_dir(self.results_old_file_name)
+
+        # Ensure symlinks exist (they are not included in the cache archive)
+        self.create_runtime_directories()
+
+        return True
+
+    def exists_in_runtime_dir(self, file_name) -> bool:
+        return os.path.exists(f"{self.test_runtime_directory}/{file_name}")
+
+    def get_nb_steps(self) -> int:
+        return self.nb_steps if self.loaded_from_disk else len(self.steps)
+
+    def list_output_directory(self, allow_nested_path=False) -> List[str]:
+        files = []
+        folder = self.test_output_directory
+        for root, _, filenames in os.walk(folder):
+            for filename in filenames:
+                f = os.path.relpath(os.path.join(root, filename), folder)
+                if not allow_nested_path:
+                    assert '/' not in f, f"Nested output files are not supported for now: {f}"
+                files.append(f)
+
+        return files
+
+    def write_test_queries(self):
+        if len(self.steps) == 0 and len(self.skip_reasons) == 0:
+            logger.warning(f"No step found in test file '{self.queries_file_name}'")
+            return
+
+        gen_files = self.list_output_directory()
+        self.fixtures.update(gen_files)
+
+        if len(gen_files) > 0:
+            os.mkdir(f"{self.test_runtime_directory}/fixtures")
+            for gen_file in gen_files:
+                shutil.copy2(f"{self.test_output_directory}/{gen_file}", f"{self.test_runtime_directory}/fixtures/")
+
+        with open(f"{self.test_runtime_directory}/{self.queries_file_name}", 'w') as f:
+            if len(self.skip_reasons) > 0:
+                f.write(make_tag("skip_reasons", self.skip_reasons))
+                return
+
+            if len(gen_files) > 0:
+                f.write(make_tag("fixtures", ';'.join(gen_files)))
+
+            if len(self.needed_extensions) > 0:
+                f.write(make_tag("needed_extensions", self.needed_extensions))
+
+            f.write(make_tag("nb_steps", len(self.steps)))
+            for step in self.steps:
+                if step.step_type == "query":
+                    f.write(step.step_data)
+                else:
+                    raise ValueError(f"Unsupported step type: {step.step_type}")
+
 
 class SerializerSQLLogicContext(SQLLogicContext):
-  def __init__(self, pool, runner, statements, keywords, update_value):
-    super().__init__(pool, runner, statements, keywords, update_value)
-    self.current_test = runner.current_test
+    def __init__(self, pool, runner, statements, keywords, update_value):
+        super().__init__(pool, runner, statements, keywords, update_value)
+        self.current_test = runner.current_test
 
-  def update_settings(self):
-    pass # Nothing to do
+    def update_settings(self):
+        pass  # Nothing to do
 
-  def _normalize_query(self, statement: Statement) -> str:
-    # Normalize the query by removing comments and extra whitespace
-    tags = None
-    if statement.expected_result is not None and statement.expected_result.type != ExpectedResult.Type.SUCCESS:
-       if statement.expected_result.type == ExpectedResult.Type.ERROR:
-          tags = make_tag("expected_result", "error")
-       elif statement.expected_result.type == ExpectedResult.Type.UNKNOWN:
-          tags = make_tag("expected_result", "unknown")
-       else:
-          raise ValueError(f"Unknown expected result type: {statement.expected_result.type}")
+    def _normalize_query(self, statement: Statement) -> str:
+        # Normalize the query by removing comments and extra whitespace
+        tags = None
+        if statement.expected_result is not None and statement.expected_result.type != ExpectedResult.Type.SUCCESS:
+            if statement.expected_result.type == ExpectedResult.Type.ERROR:
+                tags = make_tag("expected_result", "error")
+            elif statement.expected_result.type == ExpectedResult.Type.UNKNOWN:
+                tags = make_tag("expected_result", "unknown")
+            else:
+                raise ValueError(f"Unknown expected result type: {statement.expected_result.type}")
 
-    sql_query = '\n'.join(statement.lines)
-    sql_query = self.replace_keywords(sql_query)
-    return sql_query if not tags else f"{tags}\n{sql_query}"
+        sql_query = '\n'.join(statement.lines)
+        sql_query = self.replace_keywords(sql_query)
+        return sql_query if not tags else f"{tags}\n{sql_query}"
 
-  def execute_statement(self, statement: Statement):
-    if len(statement.header.parameters) > 1:
-       self.skiptest("Multiple connections not supported for now")
-       return
+    def execute_statement(self, statement: Statement):
+        if len(statement.header.parameters) > 1:
+            self.skiptest("Multiple connections not supported for now")
+            return
 
-    sql_query = self._normalize_query(statement)
-    sql_query_lc = sql_query.lower()
-    if 'set enable_external_access=false' in sql_query_lc:
-       # Tester uses DuckDB API to write files...
-       self.skiptest("Can't disable external access for now")
-       return
-    self.add_query(sql_query)
+        sql_query = self._normalize_query(statement)
+        sql_query_lc = sql_query.lower()
+        if 'set enable_external_access=false' in sql_query_lc:
+            # Tester uses DuckDB API to write files...
+            self.skiptest("Can't disable external access for now")
+            return
+        self.add_query(sql_query)
 
-  def execute_query(self, query: Query):
-    sql_query = ""
+    def execute_query(self, query: Query):
+        sql_query = ""
 
-    # Handle sortstyle
-    sort_style = query.get_sortstyle()
-    if sort_style is not None and sort_style != SortStyle.NO_SORT:
-      sql_query = make_tag("sort", SerializerSQLLogicContext.sort_style_to_str(sort_style))
+        # Handle sortstyle
+        sort_style = query.get_sortstyle()
+        if sort_style is not None and sort_style != SortStyle.NO_SORT:
+            sql_query = make_tag("sort", SerializerSQLLogicContext.sort_style_to_str(sort_style))
 
-    sql_query += self._normalize_query(query)
+        sql_query += self._normalize_query(query)
 
-    self.add_query(sql_query)
+        self.add_query(sql_query)
 
-  @staticmethod
-  def sort_style_to_str(sort_style):
-    if sort_style == SortStyle.NO_SORT:
-        return "no_sort"
-    elif sort_style == SortStyle.ROW_SORT:
-        return "row_sort"
-    elif sort_style == SortStyle.VALUE_SORT:
-        return "value_sort"
-    else:
-        raise ValueError(f"Unknown sort style: {sort_style}")
+    @staticmethod
+    def sort_style_to_str(sort_style):
+        if sort_style == SortStyle.NO_SORT:
+            return "no_sort"
+        elif sort_style == SortStyle.ROW_SORT:
+            return "row_sort"
+        elif sort_style == SortStyle.VALUE_SORT:
+            return "value_sort"
+        else:
+            raise ValueError(f"Unknown sort style: {sort_style}")
 
-  def add_query(self, query: str):
-    if self.in_loop() and self.is_parallel:
-        return # Skip queries in parallel loops
+    def add_query(self, query: str):
+        if self.in_loop() and self.is_parallel:
+            return  # Skip queries in parallel loops
 
-    # Add exclusion tags based on query analysis
-    exclusion_tags = format_exclusion_tags(query)
-    if exclusion_tags:
-        query = f"{exclusion_tags}\n{query}"
+        # Add exclusion tags based on query analysis
+        exclusion_tags = format_exclusion_tags(query)
+        if exclusion_tags:
+            query = f"{exclusion_tags}\n{query}"
 
-    self.current_test.add('query', f"{query}\n{make_tag('end_query', '')}\n")
+        self.current_test.add('query', f"{query}\n{make_tag('end_query', '')}\n")
 
-  def execute_load(self, load: Load):
-    options = []
+    def execute_load(self, load: Load):
+        options = []
 
-    if not load.header.parameters:
-        self.add_query(f"USE memory;")
-        return
+        if not load.header.parameters:
+            self.add_query(f"USE memory;")
+            return
 
-    dbpath = self.replace_keywords(load.header.parameters[0])
-    db_name = basename(dbpath).split('.')[0]
-    if load.readonly:
-        options.append('READ_ONLY')
-    if load.version:
-        options.append(f"STORAGE_VERSION {load.version}")
+        dbpath = self.replace_keywords(load.header.parameters[0])
+        db_name = basename(dbpath).split('.')[0]
+        if load.readonly:
+            options.append('READ_ONLY')
+        if load.version:
+            options.append(f"STORAGE_VERSION {load.version}")
 
-    opt_str = f" ({', '.join(options)})" if options and len(options) > 1 else ''
-    self.add_query(f"{make_tag('load_db', db_name)}\nATTACH '{dbpath}' AS {db_name}{opt_str};")
+        opt_str = f" ({', '.join(options)})" if options and len(options) > 1 else ''
+        self.add_query(f"{make_tag('load_db', db_name)}\nATTACH '{dbpath}' AS {db_name}{opt_str};")
 
-  def execute_restart(self, statement: Restart):
-    # FIXME - skipping >200 tests because of this
-    self.skiptest("Restart not supported for now")
+    def execute_restart(self, statement: Restart):
+        # FIXME - skipping >200 tests because of this
+        self.skiptest("Restart not supported for now")
 
-  def execute_unzip(self, statement: Unzip):
-    self.do_execute_unzip(statement)
+    def execute_unzip(self, statement: Unzip):
+        self.do_execute_unzip(statement)
 
-  def execute_set(self, statement: Set):
-    option = statement.header.parameters[0]
-    if option == 'ignore_error_messages':
-        self.current_test.ignore_error_messages = True
-    elif option == 'seed':
-        self.add_query(f"SELECT SETSEED({statement.header.parameters[1]});")
-        # TODO - self.runner.skip_reload = True
-    else:
-        raise ValueError(f"SET '{option}' is not implemented!")
+    def execute_set(self, statement: Set):
+        option = statement.header.parameters[0]
+        if option == 'ignore_error_messages':
+            self.current_test.ignore_error_messages = True
+        elif option == 'seed':
+            self.add_query(f"SELECT SETSEED({statement.header.parameters[1]});")
+            # TODO - self.runner.skip_reload = True
+        else:
+            raise ValueError(f"SET '{option}' is not implemented!")
 
-  def execute_foreach(self, foreach: Foreach):
-    if not foreach.parallel:
-      super().execute_foreach(foreach)
-    else:
-      # Get loop statements will skip over the inner statements
-      skipped_stmts = self.get_loop_statements()
-      self.current_test.nb_skipped_statements_in_loop += len(skipped_stmts)
+    def execute_foreach(self, foreach: Foreach):
+        if not foreach.parallel:
+            super().execute_foreach(foreach)
+        else:
+            # Get loop statements will skip over the inner statements
+            skipped_stmts = self.get_loop_statements()
+            self.current_test.nb_skipped_statements_in_loop += len(skipped_stmts)
 
-  def execute_loop(self, loop: Loop):
-    if not loop.parallel:
-      super().execute_loop(loop)
-    else:
-      # Get loop statements will skip over the inner statements
-      skipped_stmts = self.get_loop_statements()
-      self.current_test.nb_skipped_statements_in_loop += len(skipped_stmts)
+    def execute_loop(self, loop: Loop):
+        if not loop.parallel:
+            super().execute_loop(loop)
+        else:
+            # Get loop statements will skip over the inner statements
+            skipped_stmts = self.get_loop_statements()
+            self.current_test.nb_skipped_statements_in_loop += len(skipped_stmts)
 
-  def skiptest(self, reason):
-    if reason not in self.current_test.skip_reasons:
-      self.current_test.skip_reasons.append(reason)
+    def skiptest(self, reason):
+        if reason not in self.current_test.skip_reasons:
+            self.current_test.skip_reasons.append(reason)
 
-  def check_require(self, statement: Require) -> RequireResult:
-    not_supported = set([
-       "no_alternative_verify",
-       "noalternativeverify",
-       "fts", # TODO - need to support non-linked extensions
-    ])
-    not_an_extension = ([
-        # Copied over from scripts/sqllogictest/result.py
-        "64bit",
-        "block_size",
-        "exact_vector_size",
-        "longdouble",
-        "mingw",
-        "no_alternative_verify",
-        "noalternativeverify",
-        "noforcestorage",
-        "nothreadsan",
-        "notmingw",
-        "notwindows",
-        "skip_reload",
-        "strinline",
-        "vector_size",
-        "windows",
+    def check_require(self, statement: Require) -> RequireResult:
+        not_supported = set(
+            [
+                "no_alternative_verify",
+                "noalternativeverify",
+                "fts",  # TODO - need to support non-linked extensions
+            ]
+        )
+        not_an_extension = [
+            # Copied over from scripts/sqllogictest/result.py
+            "64bit",
+            "block_size",
+            "exact_vector_size",
+            "longdouble",
+            "mingw",
+            "no_alternative_verify",
+            "noalternativeverify",
+            "noforcestorage",
+            "nothreadsan",
+            "notmingw",
+            "notwindows",
+            "skip_reload",
+            "strinline",
+            "vector_size",
+            "windows",
+            # Added here:
+            "no_latest_storage",
+            "no_vector_verification",
+            "notmusl",
+            "ram",
+        ]
 
-        # Added here:
-        "no_latest_storage",
-        "no_vector_verification",
-        "notmusl",
-        "ram",
-    ])
+        param = statement.header.parameters[0].lower()
+        if param in not_supported:
+            # self.skiptest(f"Requirement '{param}' is not supported")
+            return RequireResult.MISSING
+        elif param in not_an_extension:
+            # TODO - skip_reload?
+            return RequireResult.PRESENT
+        elif param == "no_extension_autoloading":
+            # This is a special case, we do not want to load extensions automatically
+            self.add_query("SET autoload_known_extensions=false;")
+            self.current_test.no_extension_autoloading = True
+            return RequireResult.PRESENT
+        elif param == "allow_unsigned_extensions":
+            # We're running with this parameter for now
+            return RequireResult.PRESENT
 
-    param = statement.header.parameters[0].lower()
-    if param in not_supported:
-        # self.skiptest(f"Requirement '{param}' is not supported")
-        return RequireResult.MISSING
-    elif param in not_an_extension:
-        # TODO - skip_reload?
+        if not self.current_test.no_extension_autoloading:
+            self.add_query(f"LOAD '{param}';")
+            self.current_test.needed_extensions.add(param)
         return RequireResult.PRESENT
-    elif param == "no_extension_autoloading":
-        # This is a special case, we do not want to load extensions automatically
-        self.add_query("SET autoload_known_extensions=false;")
-        self.current_test.no_extension_autoloading = True
-        return RequireResult.PRESENT
-    elif param == "allow_unsigned_extensions":
-        # We're running with this parameter for now
-        return RequireResult.PRESENT
-
-    if not self.current_test.no_extension_autoloading:
-        self.add_query(f"LOAD '{param}';")
-        self.current_test.needed_extensions.add(param)
-    return RequireResult.PRESENT
 
 
 class SQLLogicTestSerializer(SQLLogicRunner):
@@ -463,63 +476,76 @@ class SQLLogicTestSerializer(SQLLogicRunner):
         super().__init__(None)
         self.current_test = SerializedTest(duckdb_bwc_base_dir, duckdb_version, test_filename, test_idx)
 
-
     def execute_test(self) -> None:
-      if self.current_test.reload_from_disk():
-        return
+        if self.current_test.reload_from_disk():
+            return
 
-      self.current_test.create_runtime_directories()
+        self.current_test.create_runtime_directories()
 
-      # Set current working directory
-      os.chdir(self.current_test.test_runtime_directory)
+        # Set current working directory
+        os.chdir(self.current_test.test_runtime_directory)
 
-      self.reset()
-      sql_parser = SQLLogicParser()
-      test_absolute_filename = self.current_test.test_absolute_filename
-      try:
-        test = sql_parser.parse(str(test_absolute_filename))
-        if test is None:
-          raise ValueError(f"Failed to parse test file (unknown reason)")
-      except Exception as e:
-        # Throw if exception is file not found
-        if not os.path.exists(test_absolute_filename):
-          raise e
+        self.reset()
+        sql_parser = SQLLogicParser()
+        test_absolute_filename = self.current_test.test_absolute_filename
+        try:
+            test = sql_parser.parse(str(test_absolute_filename))
+            if test is None:
+                raise ValueError(f"Failed to parse test file (unknown reason)")
+        except Exception as e:
+            # Throw if exception is file not found
+            if not os.path.exists(test_absolute_filename):
+                raise e
 
-        self.current_test.skip_reasons.append("parsing_error")
+            self.current_test.skip_reasons.append("parsing_error")
+            self.current_test.write_test_queries()
+            logger.error(f"Exception while parsing test file '{test_absolute_filename}': {e}")
+            return
+
+        self.test = test
+        self.extensions = [
+            "httpfs",
+            "parquet",
+            "tpch",
+            "json",
+            "icu",
+            "tpcds",
+            "sqlite_scanner",
+            "autocomplete",
+            "inet",
+        ]
+        self.original_sqlite_test = self.test.is_sqlite_test()
+
+        # Top level keywords
+        keywords = {
+            '__TEST_DIR__': BWC_OUTPUT_DIR_NAME,
+            '__WORKING_DIRECTORY__': '.',
+            '{DATA_DIR}': 'data',
+            '{TEMP_DIR}': BWC_OUTPUT_DIR_NAME,
+            '{TEST_DIR}': BWC_OUTPUT_DIR_NAME,
+        }
+
+        def update_value(_: SQLLogicContext) -> Generator[Any, Any, Any]:
+            # Yield once to represent one iteration, do not touch the keywords
+            yield None
+
+        context = SerializerSQLLogicContext(None, self, test.statements, keywords, update_value)
+        context.is_loop = False  # The outer context is not a loop
+        context.verify_statements()
+        res = context.execute()
+        assert res.type == ExecuteResult.Type.SUCCESS
+
+        if self.skip_active() and len(self.current_test.skip_reasons) == 0:
+            self.current_test.skip_reasons.append("explicitly skipped")
+
+        if (
+            len(self.current_test.skip_reasons) == 0
+            and len(self.current_test.steps) == 0
+            and self.current_test.nb_skipped_statements_in_loop > 0
+        ):
+            self.current_test.skip_reasons.append("entirely_skipped_because_of_parallel_loops")
+
         self.current_test.write_test_queries()
-        logger.error(f"Exception while parsing test file '{test_absolute_filename}': {e}")
-        return
-
-      self.test = test
-      self.extensions = ["httpfs", "parquet", "tpch", "json", "icu", "tpcds", "sqlite_scanner", "autocomplete", "inet"]
-      self.original_sqlite_test = self.test.is_sqlite_test()
-
-      # Top level keywords
-      keywords = {
-        '__TEST_DIR__': BWC_OUTPUT_DIR_NAME,
-        '__WORKING_DIRECTORY__': '.',
-        '{DATA_DIR}': 'data',
-        '{TEMP_DIR}': BWC_OUTPUT_DIR_NAME,
-        '{TEST_DIR}': BWC_OUTPUT_DIR_NAME
-      }
-
-      def update_value(_: SQLLogicContext) -> Generator[Any, Any, Any]:
-        # Yield once to represent one iteration, do not touch the keywords
-        yield None
-
-      context = SerializerSQLLogicContext(None, self, test.statements, keywords, update_value)
-      context.is_loop = False # The outer context is not a loop
-      context.verify_statements()
-      res = context.execute()
-      assert res.type == ExecuteResult.Type.SUCCESS
-
-      if self.skip_active() and len(self.current_test.skip_reasons) == 0:
-        self.current_test.skip_reasons.append("explicitly skipped")
-
-      if len(self.current_test.skip_reasons) == 0 and len(self.current_test.steps) == 0 and self.current_test.nb_skipped_statements_in_loop > 0:
-        self.current_test.skip_reasons.append("entirely_skipped_because_of_parallel_loops")
-
-      self.current_test.write_test_queries()
 
 
 def load_skipped_tests_from_file(json_file: str) -> set[str]:
@@ -537,93 +563,117 @@ def load_skipped_tests_from_file(json_file: str) -> set[str]:
 
 
 def list_skipped_tests(duckdb_test_config_dir: str, duckdb_version: str) -> set[str]:
-  base_skip_file_path = f"{duckdb_test_config_dir}/test/configs/serialization_bwc_base.json"
-  version_skip_file_path = f"{duckdb_test_config_dir}/test/configs/serialization_bwc_{duckdb_version}.json"
-  skipped_tests = load_skipped_tests_from_file(base_skip_file_path)
-  skipped_tests.update(load_skipped_tests_from_file(version_skip_file_path))
-  logger.debug(f"Found {len(skipped_tests)} tests to skip in version {duckdb_version} (base skip file: {base_skip_file_path}, version skip file: {version_skip_file_path})")
-  return skipped_tests
+    base_skip_file_path = f"{duckdb_test_config_dir}/test/configs/serialization_bwc_base.json"
+    version_skip_file_path = f"{duckdb_test_config_dir}/test/configs/serialization_bwc_{duckdb_version}.json"
+    skipped_tests = load_skipped_tests_from_file(base_skip_file_path)
+    skipped_tests.update(load_skipped_tests_from_file(version_skip_file_path))
+    logger.debug(
+        f"Found {len(skipped_tests)} tests to skip in version {duckdb_version} (base skip file: {base_skip_file_path}, version skip file: {version_skip_file_path})"
+    )
+    return skipped_tests
 
 
 class LoadingStats:
-  def __init__(self):
-    self.skipped_count = 0
-    self.skipped_count_per_reason = {}
-    self.start_time = time.time()
-    self.nb_steps = 0
-    self.nb_tests = 0
-    self.nb_cached_queries = 0
-    self.nb_cached_plans = 0
+    def __init__(self):
+        self.skipped_count = 0
+        self.skipped_count_per_reason = {}
+        self.start_time = time.time()
+        self.nb_steps = 0
+        self.nb_tests = 0
+        self.nb_cached_queries = 0
+        self.nb_cached_plans = 0
 
-  def update(self, test: SerializedTest):
-    if len(test.skip_reasons) > 0:
-      self.update_skipped(test.skip_reasons)
-      return
+    def update(self, test: SerializedTest):
+        if len(test.skip_reasons) > 0:
+            self.update_skipped(test.skip_reasons)
+            return
 
-    self.nb_tests += 1
-    self.nb_steps += test.get_nb_steps()
+        self.nb_tests += 1
+        self.nb_steps += test.get_nb_steps()
 
-    if test.loaded_from_disk:
-      self.nb_cached_queries += 1
+        if test.loaded_from_disk:
+            self.nb_cached_queries += 1
 
-    if test.has_cached_serialized_plans:
-      self.nb_cached_plans += 1
+        if test.has_cached_serialized_plans:
+            self.nb_cached_plans += 1
 
-  def update_skipped(self, reasons: List[str]):
-    if len(reasons) == 0:
-      return
+    def update_skipped(self, reasons: List[str]):
+        if len(reasons) == 0:
+            return
 
-    self.skipped_count += 1
-    for reason in reasons:
-      if reason not in self.skipped_count_per_reason:
-        self.skipped_count_per_reason[reason] = 0
-      self.skipped_count_per_reason[reason] += 1
+        self.skipped_count += 1
+        for reason in reasons:
+            if reason not in self.skipped_count_per_reason:
+                self.skipped_count_per_reason[reason] = 0
+            self.skipped_count_per_reason[reason] += 1
 
-  def log_stats(self):
-    logger.info(f"Loaded {self.nb_tests} test files (with {self.nb_steps} steps) in {time.time() - self.start_time:.2f}s")
-    logger.info(f"  Cached queries: {self.nb_cached_queries} ({(self.nb_cached_queries/self.nb_tests*100) if self.nb_tests > 0 else 0:.2f}%)")
-    logger.info(f"  Cached plans: {self.nb_cached_plans} ({(self.nb_cached_plans/self.nb_tests*100) if self.nb_tests > 0 else 0:.2f}%)")
-    logger.info(f"  Skipped {self.skipped_count} ({(self.skipped_count/self.nb_tests*100) if self.nb_tests > 0 else 0:.2f}%) test files:")
+    def log_stats(self):
+        logger.info(
+            f"Loaded {self.nb_tests} test files (with {self.nb_steps} steps) in {time.time() - self.start_time:.2f}s"
+        )
+        logger.info(
+            f"  Cached queries: {self.nb_cached_queries} ({(self.nb_cached_queries/self.nb_tests*100) if self.nb_tests > 0 else 0:.2f}%)"
+        )
+        logger.info(
+            f"  Cached plans: {self.nb_cached_plans} ({(self.nb_cached_plans/self.nb_tests*100) if self.nb_tests > 0 else 0:.2f}%)"
+        )
+        logger.info(
+            f"  Skipped {self.skipped_count} ({(self.skipped_count/self.nb_tests*100) if self.nb_tests > 0 else 0:.2f}%) test files:"
+        )
 
-    # Sort self.skipped_count_per_reason by count descending
-    sorted_skipped = sorted(self.skipped_count_per_reason.items(), key=lambda x: x[1], reverse=True)
-    for reason, count in sorted_skipped:
-      logger.info(f"    {count} ({(count/self.skipped_count*100) if self.skipped_count > 0 else 0:.2f}%): {reason}")
+        # Sort self.skipped_count_per_reason by count descending
+        sorted_skipped = sorted(self.skipped_count_per_reason.items(), key=lambda x: x[1], reverse=True)
+        for reason, count in sorted_skipped:
+            logger.info(
+                f"    {count} ({(count/self.skipped_count*100) if self.skipped_count > 0 else 0:.2f}%): {reason}"
+            )
 
 
-def load_test_files(duckdb_root_dir: str, duckdb_bwc_base_dir: str, duckdb_version: str, test_pattern: str = None, single_test_file: str = None) -> List:
-  loading_stats = LoadingStats()
+def load_test_files(
+    duckdb_root_dir: str,
+    duckdb_bwc_base_dir: str,
+    duckdb_version: str,
+    test_pattern: str = None,
+    single_test_file: str = None,
+) -> List:
+    loading_stats = LoadingStats()
 
-  spec_files_dir = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}"
-  logger.info(f"Using Python DuckDB version {duckdb.__version__} to load test files from {spec_files_dir}")
+    spec_files_dir = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}"
+    logger.info(f"Using Python DuckDB version {duckdb.__version__} to load test files from {spec_files_dir}")
 
-  # Normalize (remove trailing ./ etc)
-  single_test_file = os.path.normpath(single_test_file) if single_test_file is not None else None
+    # Normalize (remove trailing ./ etc)
+    single_test_file = os.path.normpath(single_test_file) if single_test_file is not None else None
 
-  files = [single_test_file] if single_test_file is not None else list_test_files(spec_files_dir, test_pattern)
-  logger.info(f"Found {len(files)} test files")
+    files = [single_test_file] if single_test_file is not None else list_test_files(spec_files_dir, test_pattern)
+    logger.info(f"Found {len(files)} test files")
 
-  loaded_tests = []
-  skipped_tests = list_skipped_tests(duckdb_root_dir, duckdb_version) if test_pattern is None and single_test_file is None else set()
-  needed_extensions = set()
-  for test_filename in files:
-    if test_filename in skipped_tests:
-        loading_stats.update_skipped([f"in skipped file"])
-        continue
+    loaded_tests = []
+    skipped_tests = (
+        list_skipped_tests(duckdb_root_dir, duckdb_version)
+        if test_pattern is None and single_test_file is None
+        else set()
+    )
+    needed_extensions = set()
+    for test_filename in files:
+        if test_filename in skipped_tests:
+            loading_stats.update_skipped([f"in skipped file"])
+            continue
 
-    try:
-      serializer = SQLLogicTestSerializer(duckdb_bwc_base_dir, duckdb_version, test_filename, len(loaded_tests) + 1)
-      serializer.execute_test()
-      test = serializer.current_test
+        try:
+            serializer = SQLLogicTestSerializer(
+                duckdb_bwc_base_dir, duckdb_version, test_filename, len(loaded_tests) + 1
+            )
+            serializer.execute_test()
+            test = serializer.current_test
 
-      loading_stats.update(test)
-      if len(test.skip_reasons) == 0:
-        loaded_tests.append(test)
-        needed_extensions.update(test.needed_extensions)
-    except Exception as e:
-      logger.error(f"Failed to load test file '{test_filename}'")
-      raise e
+            loading_stats.update(test)
+            if len(test.skip_reasons) == 0:
+                loaded_tests.append(test)
+                needed_extensions.update(test.needed_extensions)
+        except Exception as e:
+            logger.error(f"Failed to load test file '{test_filename}'")
+            raise e
 
-  loading_stats.log_stats()
+    loading_stats.log_stats()
 
-  return { 'tests': loaded_tests, 'needed_extensions': needed_extensions }
+    return {'tests': loaded_tests, 'needed_extensions': needed_extensions}

--- a/test/bwc/utils/test_files_parser.py
+++ b/test/bwc/utils/test_files_parser.py
@@ -1,4 +1,5 @@
-from typing import List
+from typing import Any, Generator, List
+import json
 import os
 import time
 from zipfile import Path
@@ -7,7 +8,6 @@ import shutil
 
 import duckdb
 
-from typing import Any, Generator
 from duckdb_sqllogictest import SQLLogicParser
 from duckdb_sqllogictest.result import (
     ExecuteResult,
@@ -504,18 +504,27 @@ class SQLLogicTestSerializer(SQLLogicRunner):
       self.current_test.write_test_queries()
 
 
-def list_skipped_tests(skip_file_path: str) -> set:
+def load_skipped_tests_from_file(json_file: str) -> set[str]:
+    if not os.path.exists(json_file):
+        return set()
+
+    with open(json_file, 'r') as f:
+        data = json.load(f)
+
     skipped_tests = set()
-    if os.path.exists(skip_file_path):
-      with open(skip_file_path, 'r', ) as skip_file:
-          for line in skip_file:
-              line = line.strip()
-              if line and not line.startswith("#"):
-                if '#' in line:
-                  line = line.split('#')[0].strip()
-                skipped_tests.add(line)
+    for entry in data.get('skip_tests', []):
+        skipped_tests.update(entry.get('paths', []))
 
     return skipped_tests
+
+
+def list_skipped_tests(duckdb_test_config_dir: str, duckdb_version: str) -> set[str]:
+  base_skip_file_path = f"{duckdb_test_config_dir}/test/configs/serialization_bwc_base.json"
+  version_skip_file_path = f"{duckdb_test_config_dir}/test/configs/serialization_bwc_{duckdb_version}.json"
+  skipped_tests = load_skipped_tests_from_file(base_skip_file_path)
+  skipped_tests.update(load_skipped_tests_from_file(version_skip_file_path))
+  return skipped_tests
+
 
 class LoadingStats:
   def __init__(self):
@@ -563,7 +572,7 @@ class LoadingStats:
       logger.info(f"    {count} ({(count/self.skipped_count*100) if self.skipped_count > 0 else 0:.2f}%): {reason}")
 
 
-def load_test_files(duckdb_bwc_base_dir: str, duckdb_version: str, skip_file_path: str, test_pattern: str = None) -> List:
+def load_test_files(duckdb_root_dir: str, duckdb_bwc_base_dir: str, duckdb_version: str, skip_file_path: str, test_pattern: str = None) -> List:
   loading_stats = LoadingStats()
 
   spec_files_dir = f"{duckdb_bwc_base_dir}/specs/{duckdb_version}"
@@ -573,7 +582,7 @@ def load_test_files(duckdb_bwc_base_dir: str, duckdb_version: str, skip_file_pat
   logger.info(f"Found {len(files)} test files")
 
   loaded_tests = []
-  skipped_tests = list_skipped_tests(skip_file_path) if test_pattern is None else set()
+  skipped_tests = list_skipped_tests(duckdb_root_dir, duckdb_version) if test_pattern is None else set()
   logger.debug(f"Found {len(skipped_tests)} tests to skip in '{skip_file_path}'")
   len_spec_files_dir = len(spec_files_dir) + 1
   needed_extensions = set()

--- a/test/bwc/utils/test_report.py
+++ b/test/bwc/utils/test_report.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import time
 from utils.logger import make_logger
 import os
@@ -9,8 +10,9 @@ logger = make_logger(__name__)
 class TestReport:
   step_names = ["serialize_queries_plans", "execute_all_plans_from_file", "serialize_results", "compare_results"]
 
-  def __init__(self, test_spec, exit_on_failure=False):
+  def __init__(self, test_spec, old_version, new_version, exit_on_failure=False):
     self.test_filename = test_spec.test_absolute_filename
+    self.test_relative_path = test_spec.test_spec_relative_path
     self.test_runtime_directory = test_spec.test_runtime_directory # Test execution directory
     self.comparison_results_file_name = f"{test_spec.results_new_file_name}.report"
     self.comparison_results = None
@@ -19,6 +21,8 @@ class TestReport:
     self.last_timestamp = self.start_time
     self.durations = []
     self.outputs = []
+    self.duckdb_old_version = old_version
+    self.duckdb_new_version = new_version
 
   def end_cached_step(self, step_name, *args):
     str_args = ", ".join([f"'{arg}'" for arg in args])
@@ -102,6 +106,9 @@ class TestReport:
     CREATE TABLE test_report (
       test_filename VARCHAR,
       test_runtime_directory VARCHAR,
+      start_time TIMESTAMP,
+      duckdb_old_version VARCHAR,
+      duckdb_new_version VARCHAR,
     """
     for step_name in TestReport.step_names:
       schema += f"  {step_name}_duration DOUBLE,\n"
@@ -115,14 +122,14 @@ class TestReport:
 
   @staticmethod
   def report_insert():
-    sql = f"INSERT INTO test_report (test_filename, test_runtime_directory, "
+    sql = f"INSERT INTO test_report (test_filename, test_runtime_directory, start_time, duckdb_old_version, duckdb_new_version, "
     sql += ", ".join([f"{step_name}_duration, {step_name}_outcome, {step_name}_stdout, {step_name}_stderr" for step_name in TestReport.step_names])
     sql += ", comparison_report"
-    sql += ") VALUES (?, ?, " + ("?, ?, ?, ?, " * len(TestReport.step_names)) + "?);\n"
+    sql += ") VALUES (?, ?, ?, ?, ?, " + ("?, ?, ?, ?, " * len(TestReport.step_names)) + "?);\n"
     return sql
 
   def report_sql_values(self):
-    values = [self.test_filename, self.test_runtime_directory]
+    values = [self.test_filename, self.test_runtime_directory, datetime.fromtimestamp(self.start_time), self.duckdb_old_version, self.duckdb_new_version]
     for i in range(len(TestReport.step_names)):
       if i < len(self.durations):
         values.append(self.durations[i])

--- a/test/bwc/utils/test_report.py
+++ b/test/bwc/utils/test_report.py
@@ -7,102 +7,106 @@ from difflib import unified_diff
 
 logger = make_logger(__name__)
 
+
 class TestReport:
-  step_names = ["serialize_queries_plans", "execute_all_plans_from_file", "serialize_results", "compare_results"]
+    step_names = ["serialize_queries_plans", "execute_all_plans_from_file", "serialize_results", "compare_results"]
 
-  def __init__(self, test_spec, old_version, new_version, exit_on_failure=False):
-    self.test_filename = test_spec.test_absolute_filename
-    self.test_relative_path = test_spec.test_spec_relative_path
-    self.test_runtime_directory = test_spec.test_runtime_directory # Test execution directory
-    self.comparison_results_file_name = f"{test_spec.results_new_file_name}.report"
-    self.comparison_results = None
-    self.start_time = time.time()
-    self.exit_on_failure = exit_on_failure
-    self.last_timestamp = self.start_time
-    self.durations = []
-    self.outputs = []
-    self.duckdb_old_version = old_version
-    self.duckdb_new_version = new_version
+    def __init__(self, test_spec, old_version, new_version, exit_on_failure=False):
+        self.test_filename = test_spec.test_absolute_filename
+        self.test_relative_path = test_spec.test_spec_relative_path
+        self.test_runtime_directory = test_spec.test_runtime_directory  # Test execution directory
+        self.comparison_results_file_name = f"{test_spec.results_new_file_name}.report"
+        self.comparison_results = None
+        self.start_time = time.time()
+        self.exit_on_failure = exit_on_failure
+        self.last_timestamp = self.start_time
+        self.durations = []
+        self.outputs = []
+        self.duckdb_old_version = old_version
+        self.duckdb_new_version = new_version
 
-  def end_cached_step(self, step_name, *args):
-    str_args = ", ".join([f"'{arg}'" for arg in args])
-    query = f"CALL {step_name}({str_args});"
-    return self.end_step(step_name, {"success": True, "output": ["cached"], "error": None, "query": query})
+    def end_cached_step(self, step_name, *args):
+        str_args = ", ".join([f"'{arg}'" for arg in args])
+        query = f"CALL {step_name}({str_args});"
+        return self.end_step(step_name, {"success": True, "output": ["cached"], "error": None, "query": query})
 
-  def end_step(self, step_name, step_output):
-    if self.last_timestamp is None:
-      raise ValueError("Test has not been started.")
+    def end_step(self, step_name, step_output):
+        if self.last_timestamp is None:
+            raise ValueError("Test has not been started.")
 
-    if step_name not in TestReport.step_names:
-      raise ValueError(f"Unknown step name: {step_name}")
+        if step_name not in TestReport.step_names:
+            raise ValueError(f"Unknown step name: {step_name}")
 
-    self.durations.append(time.time() - self.last_timestamp)
-    self.outputs.append(step_output)
-    self.last_timestamp = time.time()
-    success = step_output["success"]
+        self.durations.append(time.time() - self.last_timestamp)
+        self.outputs.append(step_output)
+        self.last_timestamp = time.time()
+        success = step_output["success"]
 
-    if self.exit_on_failure and not success:
-      logger.error(f"Exiting following failure at step '{step_name}' failed for test '{self.test_filename}'")
+        if self.exit_on_failure and not success:
+            logger.error(f"Exiting following failure at step '{step_name}' failed for test '{self.test_filename}'")
 
-      queries = '\n'.join([output['query'] for output in self.outputs])
-      logger.info(f"Previous queries:\n{queries}")
-      exit()
+            queries = '\n'.join([output['query'] for output in self.outputs])
+            logger.info(f"Previous queries:\n{queries}")
+            exit()
 
-    return success
+        return success
 
-  def log_errors(self):
-    for output in self.outputs:
-      if 'error_log' in output:
-        logger.error(output['error_log'])
+    def log_errors(self):
+        for output in self.outputs:
+            if 'error_log' in output:
+                logger.error(output['error_log'])
 
-  def log_steps_queries(self):
-    steps = [f".cd {self.test_runtime_directory}\nLOAD 'test_utils';"]
-    for output in self.outputs:
-      if 'query' not in output:
-        print(f"Output does not contain 'query': {output}")
-      steps.append(output['query'])
+    def log_steps_queries(self):
+        steps = [f".cd {self.test_runtime_directory}\nLOAD 'test_utils';"]
+        for output in self.outputs:
+            if 'query' not in output:
+                print(f"Output does not contain 'query': {output}")
+            steps.append(output['query'])
 
-    logger.info("Executed steps:\n" + "\n".join(steps))
+        logger.info("Executed steps:\n" + "\n".join(steps))
 
+    def find_exception_message(self):
+        for output in self.outputs:
+            if 'exception_message' in output:
+                return output['exception_message']
+        return '** No exception message found **'
 
-  def find_exception_message(self):
-    for output in self.outputs:
-      if 'exception_message' in output:
-        return output['exception_message']
-    return '** No exception message found **'
+    def load_comparison_results(self):
+        # Check if `self.comparison_results_file_name` exists
+        if not os.path.exists(self.comparison_results_file_name):
+            return
 
-  def load_comparison_results(self):
-    # Check if `self.comparison_results_file_name` exists
-    if not os.path.exists(self.comparison_results_file_name):
-      return
+        # Load as JSON
+        with open(self.comparison_results_file_name, 'r') as f:
+            self.comparison_results = json.load(f)
 
-    # Load as JSON
-    with open(self.comparison_results_file_name, 'r') as f:
-      self.comparison_results = json.load(f)
+            error_count_map = {}
+            for comparison_error in self.comparison_results:
+                err_msg = comparison_error['error']
+                if err_msg not in error_count_map:
+                    error_count_map[err_msg] = 0
+                error_count_map[err_msg] += 1
 
-      error_count_map = {}
-      for comparison_error in self.comparison_results:
-        err_msg = comparison_error['error'];
-        if err_msg not in error_count_map:
-          error_count_map[err_msg] = 0
-        error_count_map[err_msg] += 1
+                expected = (
+                    comparison_error['expected'].splitlines(keepends=True) if 'expected' in comparison_error else []
+                )
+                actual = comparison_error['actual'].splitlines(keepends=True) if 'actual' in comparison_error else []
+                comparison_error['diff'] = ''.join(
+                    unified_diff(expected, actual, fromfile='expected', tofile='actual', n=0)
+                )
 
-        expected = comparison_error['expected'].splitlines(keepends=True) if 'expected' in comparison_error else []
-        actual = comparison_error['actual'].splitlines(keepends=True) if 'actual' in comparison_error else []
-        comparison_error['diff'] = ''.join(unified_diff(expected, actual, fromfile='expected', tofile='actual', n=0))
+            for err_msg, count in error_count_map.items():
+                if count == 1:
+                    logger.warning(err_msg)
+                else:
+                    logger.warning(f"{err_msg} ({count})")
 
-      for err_msg, count in error_count_map.items():
-        if count == 1:
-          logger.warning(err_msg)
-        else:
-          logger.warning(f"{err_msg} ({count})")
+    def is_successful(self):
+        return all(output["success"] for output in self.outputs)
 
-  def is_successful(self):
-    return all(output["success"] for output in self.outputs)
-
-  @staticmethod
-  def report_schema():
-    schema = """
+    @staticmethod
+    def report_schema():
+        schema = """
     CREATE TABLE test_report (
       test_filename VARCHAR,
       test_runtime_directory VARCHAR,
@@ -110,47 +114,58 @@ class TestReport:
       duckdb_old_version VARCHAR,
       duckdb_new_version VARCHAR,
     """
-    for step_name in TestReport.step_names:
-      schema += f"  {step_name}_duration DOUBLE,\n"
-      schema += f"  {step_name}_outcome VARCHAR,\n"
-      schema += f"  {step_name}_stdout VARCHAR,\n"
-      schema += f"  {step_name}_stderr VARCHAR,\n"
+        for step_name in TestReport.step_names:
+            schema += f"  {step_name}_duration DOUBLE,\n"
+            schema += f"  {step_name}_outcome VARCHAR,\n"
+            schema += f"  {step_name}_stdout VARCHAR,\n"
+            schema += f"  {step_name}_stderr VARCHAR,\n"
 
-    schema += f"  comparison_report VARCHAR,\n"
-    schema += ");\n"
-    return schema
+        schema += f"  comparison_report VARCHAR,\n"
+        schema += ");\n"
+        return schema
 
-  @staticmethod
-  def report_insert():
-    sql = f"INSERT INTO test_report (test_filename, test_runtime_directory, start_time, duckdb_old_version, duckdb_new_version, "
-    sql += ", ".join([f"{step_name}_duration, {step_name}_outcome, {step_name}_stdout, {step_name}_stderr" for step_name in TestReport.step_names])
-    sql += ", comparison_report"
-    sql += ") VALUES (?, ?, ?, ?, ?, " + ("?, ?, ?, ?, " * len(TestReport.step_names)) + "?);\n"
-    return sql
+    @staticmethod
+    def report_insert():
+        sql = f"INSERT INTO test_report (test_filename, test_runtime_directory, start_time, duckdb_old_version, duckdb_new_version, "
+        sql += ", ".join(
+            [
+                f"{step_name}_duration, {step_name}_outcome, {step_name}_stdout, {step_name}_stderr"
+                for step_name in TestReport.step_names
+            ]
+        )
+        sql += ", comparison_report"
+        sql += ") VALUES (?, ?, ?, ?, ?, " + ("?, ?, ?, ?, " * len(TestReport.step_names)) + "?);\n"
+        return sql
 
-  def report_sql_values(self):
-    values = [self.test_filename, self.test_runtime_directory, datetime.fromtimestamp(self.start_time), self.duckdb_old_version, self.duckdb_new_version]
-    for i in range(len(TestReport.step_names)):
-      if i < len(self.durations):
-        values.append(self.durations[i])
+    def report_sql_values(self):
+        values = [
+            self.test_filename,
+            self.test_runtime_directory,
+            datetime.fromtimestamp(self.start_time),
+            self.duckdb_old_version,
+            self.duckdb_new_version,
+        ]
+        for i in range(len(TestReport.step_names)):
+            if i < len(self.durations):
+                values.append(self.durations[i])
 
-        output = self.outputs[i]
-        values.append("success" if output["success"] else "failure")
+                output = self.outputs[i]
+                values.append("success" if output["success"] else "failure")
 
-        # Remove 'result' and 'true' if they are the last two lines
-        if output["output"] and len(output["output"]) > 1 and output["output"][-2:] == ["result", "true"]:
-          output["output"] = output["output"][:-2]
+                # Remove 'result' and 'true' if they are the last two lines
+                if output["output"] and len(output["output"]) > 1 and output["output"][-2:] == ["result", "true"]:
+                    output["output"] = output["output"][:-2]
 
-        values.append(", ".join(output["output"]))
-        values.append(output["error"])
-      else:
-        values.append(None)
-        values.append("not_run")
-        values.append("")
-        values.append("")
+                values.append(", ".join(output["output"]))
+                values.append(output["error"])
+            else:
+                values.append(None)
+                values.append("not_run")
+                values.append("")
+                values.append("")
 
-    if self.comparison_results is not None:
-      values.append(json.dumps(self.comparison_results, ensure_ascii=False))
-    else:
-      values.append(None)
-    return values
+        if self.comparison_results is not None:
+            values.append(json.dumps(self.comparison_results, ensure_ascii=False))
+        else:
+            values.append(None)
+        return values

--- a/test/bwc/utils/test_report.py
+++ b/test/bwc/utils/test_report.py
@@ -1,0 +1,149 @@
+import time
+from utils.logger import make_logger
+import os
+import json
+from difflib import unified_diff
+
+logger = make_logger(__name__)
+
+class TestReport:
+  step_names = ["serialize_queries_plans", "execute_all_plans_from_file", "serialize_results", "compare_results"]
+
+  def __init__(self, test_spec, exit_on_failure=False):
+    self.test_filename = test_spec.test_absolute_filename
+    self.test_runtime_directory = test_spec.test_runtime_directory # Test execution directory
+    self.comparison_results_file_name = f"{test_spec.results_new_file_name}.report"
+    self.comparison_results = None
+    self.start_time = time.time()
+    self.exit_on_failure = exit_on_failure
+    self.last_timestamp = self.start_time
+    self.durations = []
+    self.outputs = []
+
+  def end_cached_step(self, step_name, *args):
+    str_args = ", ".join([f"'{arg}'" for arg in args])
+    query = f"CALL {step_name}({str_args});"
+    return self.end_step(step_name, {"success": True, "output": ["cached"], "error": None, "query": query})
+
+  def end_step(self, step_name, step_output):
+    if self.last_timestamp is None:
+      raise ValueError("Test has not been started.")
+
+    if step_name not in TestReport.step_names:
+      raise ValueError(f"Unknown step name: {step_name}")
+
+    self.durations.append(time.time() - self.last_timestamp)
+    self.outputs.append(step_output)
+    self.last_timestamp = time.time()
+    success = step_output["success"]
+
+    if self.exit_on_failure and not success:
+      logger.error(f"Exiting following failure at step '{step_name}' failed for test '{self.test_filename}'")
+
+      queries = '\n'.join([output['query'] for output in self.outputs])
+      logger.info(f"Previous queries:\n{queries}")
+      exit()
+
+    return success
+
+  def log_errors(self):
+    for output in self.outputs:
+      if 'error_log' in output:
+        logger.error(output['error_log'])
+
+  def log_steps_queries(self):
+    steps = [f".cd {self.test_runtime_directory}\nLOAD 'test_utils';"]
+    for output in self.outputs:
+      if 'query' not in output:
+        print(f"Output does not contain 'query': {output}")
+      steps.append(output['query'])
+
+    logger.info("Executed steps:\n" + "\n".join(steps))
+
+
+  def find_exception_message(self):
+    for output in self.outputs:
+      if 'exception_message' in output:
+        return output['exception_message']
+    return '** No exception message found **'
+
+  def load_comparison_results(self):
+    # Check if `self.comparison_results_file_name` exists
+    if not os.path.exists(self.comparison_results_file_name):
+      return
+
+    # Load as JSON
+    with open(self.comparison_results_file_name, 'r') as f:
+      self.comparison_results = json.load(f)
+
+      error_count_map = {}
+      for comparison_error in self.comparison_results:
+        err_msg = comparison_error['error'];
+        if err_msg not in error_count_map:
+          error_count_map[err_msg] = 0
+        error_count_map[err_msg] += 1
+
+        expected = comparison_error['expected'].splitlines(keepends=True) if 'expected' in comparison_error else []
+        actual = comparison_error['actual'].splitlines(keepends=True) if 'actual' in comparison_error else []
+        comparison_error['diff'] = ''.join(unified_diff(expected, actual, fromfile='expected', tofile='actual', n=0))
+
+      for err_msg, count in error_count_map.items():
+        if count == 1:
+          logger.warning(err_msg)
+        else:
+          logger.warning(f"{err_msg} ({count})")
+
+  def is_successful(self):
+    return all(output["success"] for output in self.outputs)
+
+  @staticmethod
+  def report_schema():
+    schema = """
+    CREATE TABLE test_report (
+      test_filename VARCHAR,
+      test_runtime_directory VARCHAR,
+    """
+    for step_name in TestReport.step_names:
+      schema += f"  {step_name}_duration DOUBLE,\n"
+      schema += f"  {step_name}_outcome VARCHAR,\n"
+      schema += f"  {step_name}_stdout VARCHAR,\n"
+      schema += f"  {step_name}_stderr VARCHAR,\n"
+
+    schema += f"  comparison_report VARCHAR,\n"
+    schema += ");\n"
+    return schema
+
+  @staticmethod
+  def report_insert():
+    sql = f"INSERT INTO test_report (test_filename, test_runtime_directory, "
+    sql += ", ".join([f"{step_name}_duration, {step_name}_outcome, {step_name}_stdout, {step_name}_stderr" for step_name in TestReport.step_names])
+    sql += ", comparison_report"
+    sql += ") VALUES (?, ?, " + ("?, ?, ?, ?, " * len(TestReport.step_names)) + "?);\n"
+    return sql
+
+  def report_sql_values(self):
+    values = [self.test_filename, self.test_runtime_directory]
+    for i in range(len(TestReport.step_names)):
+      if i < len(self.durations):
+        values.append(self.durations[i])
+
+        output = self.outputs[i]
+        values.append("success" if output["success"] else "failure")
+
+        # Remove 'result' and 'true' if they are the last two lines
+        if output["output"] and len(output["output"]) > 1 and output["output"][-2:] == ["result", "true"]:
+          output["output"] = output["output"][:-2]
+
+        values.append(", ".join(output["output"]))
+        values.append(output["error"])
+      else:
+        values.append(None)
+        values.append("not_run")
+        values.append("")
+        values.append("")
+
+    if self.comparison_results is not None:
+      values.append(json.dumps(self.comparison_results, ensure_ascii=False))
+    else:
+      values.append(None)
+    return values

--- a/test/configs/serialization_bwc_base.json
+++ b/test/configs/serialization_bwc_base.json
@@ -1,0 +1,329 @@
+{
+  "description": "Failed tests from backwards compatibility testing.",
+  "skip_tests": [
+    {
+      "reason": "Table does not exist after import/export",
+      "paths": [
+        "test/sql/attach/attach_export_import.test",
+        "test/sql/attach/attach_issue_7660.test",
+        "test/sql/catalog/function/test_table_macro_copy.test",
+        "test/sql/copy/csv/test_export_force_quotes.test",
+        "test/sql/copy_database/copy_database_gen_col.test",
+        "test/sql/export/export_compression_level.test",
+        "test/sql/export/export_database.test",
+        "test/sql/export/export_generated_columns.test",
+        "test/sql/export/export_hive_path.test",
+        "test/sql/export/export_quoted_structs.test",
+        "test/sql/export/export_quoted_union.test",
+        "test/sql/export/parquet/export_parquet_bit.test",
+        "test/sql/export/parquet/export_parquet_enum.test",
+        "test/sql/export/parquet/export_parquet_hugeint.test",
+        "test/sql/export/parquet/export_parquet_json.test",
+        "test/sql/export/parquet/export_parquet_list.test",
+        "test/sql/export/parquet/export_parquet_map.test",
+        "test/sql/export/parquet/export_parquet_struct.test",
+        "test/sql/export/parquet/export_parquet_union.test",
+        "test/sql/export/parquet_export.test",
+        "test/sql/index/art/constraints/test_art_eager_constraint_checking.test",
+        "test/sql/index/art/insert_update_delete/test_art_update_with_dict_fsst.test",
+        "test/sql/join/asof/test_asof_join.test",
+        "test/sql/join/asof/test_asof_join_doubles.test",
+        "test/sql/join/asof/test_asof_join_inequalities.test",
+        "test/sql/join/asof/test_asof_join_integers.test",
+        "test/sql/join/asof/test_asof_join_subquery.test",
+        "test/sql/join/asof/test_asof_join_varchar.test",
+        "test/sql/join/asof/test_asof_join_timestamps.test",
+        "test/sql/json/test_json_export.test",
+        "test/sql/pragma/profiling/test_profiling_all.test",
+        "test/sql/storage/checkpointed_self_append.test",
+        "test/sql/storage/checkpointed_self_append_tinyint.test",
+        "test/sql/storage/compact_block_size/compact_vector_size.test",
+        "test/sql/storage/compact_block_size/insertion_order_odd_batches.test",
+        "test/sql/storage/compression/alp/alp_inf_null_nan.test",
+        "test/sql/storage/compression/alp/alp_list_skip.test",
+        "test/sql/storage/compression/alp/alp_negative_numbers.test",
+        "test/sql/storage/compression/alp/alp_nulls.test",
+        "test/sql/storage/compression/alp/alp_nulls_simple.test",
+        "test/sql/storage/compression/alp/alp_simple.test",
+        "test/sql/storage/compression/alp/alp_simple_float.test",
+        "test/sql/storage/compression/alp/alp_zeros.test",
+        "test/sql/storage/compression/alprd/alprd_inf_null_nan.test",
+        "test/sql/storage/compression/alprd/alprd_negative_numbers.test",
+        "test/sql/storage/compression/alprd/alprd_nulls.test",
+        "test/sql/storage/compression/alprd/alprd_nulls_simple.test",
+        "test/sql/storage/compression/alprd/alprd_simple.test",
+        "test/sql/storage/compression/alprd/alprd_simple_float.test",
+        "test/sql/storage/compression/alprd/alprd_zeros.test",
+        "test/sql/storage/compression/bitpacking/bitpacking_constant_delta.test",
+        "test/sql/storage/compression/bitpacking/bitpacking_filter_pushdown.test",
+        "test/sql/storage/compression/bitpacking/bitpacking_hugeint.test",
+        "test/sql/storage/compression/bitpacking/bitpacking_nulls.test",
+        "test/sql/storage/compression/bitpacking/bitpacking_simple.test",
+        "test/sql/storage/compression/bitpacking/bitpacking_simple_hugeint.test",
+        "test/sql/storage/compression/bitpacking/bitpacking_table_copy.test",
+        "test/sql/storage/compression/bitpacking/bitpacking_uhugeint.test",
+        "test/sql/storage/compression/dict_fsst/dict_fsst_test.test",
+        "test/sql/storage/compression/dict_fsst/test_null_filter_pushdown.test",
+        "test/sql/storage/compression/rle/rle_bool.test",
+        "test/sql/storage/compression/rle/rle_constant.test",
+        "test/sql/storage/compression/rle/rle_filter.test",
+        "test/sql/storage/compression/rle/rle_filter_pushdown.test",
+        "test/sql/storage/compression/rle/rle_index_fetch.test",
+        "test/sql/storage/compression/rle/rle_nulls_edge_case.test",
+        "test/sql/storage/compression/rle/rle_select.test",
+        "test/sql/storage/compression/rle/rle_select_list.test",
+        "test/sql/storage/compression/roaring/roaring_array_simple.test",
+        "test/sql/storage/compression/roaring/roaring_bitset_simple.test",
+        "test/sql/storage/compression/roaring/roaring_inverted_array_simple.test",
+        "test/sql/storage/compression/roaring/roaring_inverted_run_simple.test",
+        "test/sql/storage/compression/roaring/roaring_run_simple.test",
+        "test/sql/storage/compression/roaring/roaring_smaller_than_vector.test",
+        "test/sql/storage/compression/zstd/nulls.test",
+        "test/sql/storage/compression/zstd/zstd.test",
+        "test/sql/storage/many_self_append.test",
+        "test/sql/storage/null_byte_storage.test",
+        "test/sql/storage/partial_blocks/many_columns_drop_table.test",
+        "test/sql/storage/types/list/empty_float_arrays.test",
+        "test/sql/storage/update/dictionary_update_null.test",
+        "test/sql/transactions/rollback_drop.test",
+        "test/sql/types/nested/array/array_storage_3.test",
+        "test/sql/types/nested/list/list_aggregate_dict.test",
+        "test/sql/types/union/struct_to_json_union.test",
+        "test/sql/update/update_null_integers.test",
+        "test/sql/attach/attach_encryption_fallback_readonly.test"
+      ]
+    },
+    {
+      "reason": "Vector::Reference type mismatch (INTEGER/BIGINT)",
+      "paths": [
+        "test/sql/binder/function_chaining_19035.test",
+        "test/sql/function/list/lambdas/arrow/list_comprehension_deprecated.test",
+        "test/sql/function/list/lambdas/arrow/reduce_deprecated.test",
+        "test/sql/function/list/lambdas/arrow/reduce_initial_deprecated.test",
+        "test/sql/function/list/lambdas/arrow/transform_with_index_deprecated.test",
+        "test/sql/function/list/lambdas/reduce.test",
+        "test/sql/function/list/lambdas/reduce_initial.test",
+        "test/sql/function/list/lambdas/list_comprehension.test",
+        "test/sql/function/list/lambdas/transform_with_index.test"
+      ]
+    },
+    {
+      "reason": "Failed to commit: read-only transaction made changes",
+      "paths": [
+        "test/sql/catalog/function/test_sequence_macro.test",
+        "test/sql/copy/parquet/parquet_encryption.test",
+        "test/sql/copy/parquet/parquet_schema_evolution.test",
+        "test/sql/copy/parquet/writer/parquet_write_home_directory.test",
+        "test/sql/copy/parquet/writer/test_copy_overwrite_parquet.test",
+        "test/sql/delete/test_truncate.test",
+        "test/sql/optimizer/expression/test_timestamp_offset.test",
+        "test/sql/types/nested/array/array_roundtrip_parquet.test"
+      ]
+    },
+    {
+      "reason": "Cannot rollback - no transaction active",
+      "paths": [
+        "test/sql/catalog/function/attached_macro.test",
+        "test/sql/copy/csv/test_export_not_null.test"
+      ]
+    },
+    {
+      "reason": "Database invalidated by previous fatal error",
+      "paths": [
+        "test/sql/catalog/comment_on_extended.test",
+        "test/sql/copy_database/copy_database_with_unique_index.test",
+        "test/sql/prepared/test_prepare_select.test",
+        "test/sql/catalog/comment_on_pg_description.test"
+      ]
+    },
+    {
+      "reason": "PRAGMA function does not have a function specified",
+      "paths": [
+        "test/sql/constraints/foreignkey/test_fk_export.test",
+        "test/sql/copy_database/copy_table_with_sequence.test",
+        "test/sql/pragma/pragma_database_size_readonly.test"
+      ]
+    },
+    {
+      "reason": "No files found matching pattern (Hive partitioning)",
+      "paths": [
+        "test/sql/copy/csv/csv_windows_mixed_separators.test",
+        "test/sql/copy/format_uuid.test",
+        "test/sql/copy/partitioned/hive_partition_append.test",
+        "test/sql/copy/parquet/parquet_hive2.test",
+        "test/sql/copy/row_groups_per_file.test"
+      ]
+    },
+    {
+      "reason": "Write-write conflict on key",
+      "paths": [
+        "test/sql/index/art/constraints/test_art_simple_update.test",
+        "test/sql/insert/insert_by_name.test",
+        "test/sql/upsert/insert_or_replace/returning.test",
+        "test/sql/upsert/postgres/planner_preprocessing.test"
+      ]
+    },
+    {
+      "reason": "Duplicate key violates primary key constraint",
+      "paths": [
+        "test/sql/constraints/foreignkey/test_fk_self_referencing.test",
+        "test/sql/constraints/primarykey/test_pk_update_delete.test",
+        "test/sql/constraints/primarykey/test_pk_updel_local.test",
+        "test/sql/constraints/primarykey/test_pk_updel_multi_column.test",
+        "test/sql/copy/csv/test_web_page.test",
+        "test/sql/delete/test_delete_indexed.test",
+        "test/sql/transactions/test_transaction_local_unique.test",
+        "test/sql/transactions/test_transaction_local_unique_ops.test"
+      ]
+    },
+    {
+      "reason": "Violates foreign key constraint",
+      "paths": [
+        "test/sql/constraints/foreignkey/test_fk_transaction.test",
+        "test/sql/constraints/foreignkey/test_fk_multiple.test",
+        "test/sql/constraints/foreignkey/test_fk_temporary.test",
+        "test/sql/constraints/foreignkey/fk_4309.test",
+        "test/sql/constraints/foreignkey/test_foreignkey.test"
+      ]
+    },
+    {
+      "reason": "Unique file handle conflict (read-only attach)",
+      "paths": [
+        "test/sql/attach/attach_read_only.test",
+        "test/sql/create/create_objects_readonly.test",
+        "test/sql/index/art/storage/test_art_readonly.test",
+        "test/sql/tpcds/dsdgen_readonly.test",
+        "test/sql/tpch/dbgen_readonly.test"
+      ]
+    },
+    {
+      "reason": "Resource deadlock avoided",
+      "paths": [
+        "test/sql/settings/setting_threads.test"
+      ]
+    },
+    {
+      "reason": "SerializationData - unexpected empty stack",
+      "paths": [
+        "test/sql/order/test_limit_parameter.test",
+        "test/sql/types/map/map_empty.test"
+      ]
+    },
+    {
+      "reason": "Profiling result type mismatch",
+      "paths": [
+        "test/sql/pragma/profiling/test_custom_profiling_disable_metrics.test",
+        "test/sql/pragma/profiling/test_custom_profiling_optimizer.test",
+        "test/sql/pragma/profiling/test_custom_profiling_result_set_size.test",
+        "test/sql/pragma/profiling/test_custom_profiling_rows_scanned.test",
+        "test/sql/pragma/profiling/test_default_profiling_settings.test"
+      ]
+    },
+    {
+      "reason": "Transaction state errors",
+      "paths": [
+        "test/sql/transactions/test_transaction_functionality.test",
+        "test/sql/transactions/transaction_errors.test"
+      ]
+    },
+    {
+      "reason": "Catalog changes on read-only transaction",
+      "paths": [
+        "test/sql/catalog/comment_on_dependencies.test"
+      ]
+    },
+    {
+      "reason": "Failed to deserialize (field id mismatch)",
+      "paths": [
+        "test/sql/function/uuid/test_uuid.test"
+      ]
+    },
+    {
+      "reason": "MERGE INTO parse failure",
+      "paths": [
+        "test/sql/peg_parser/merge_into.test"
+      ]
+    },
+    {
+      "reason": "Syntax error or parse failure",
+      "paths": [
+        "test/sql/storage/unzip.test"
+      ]
+    },
+    {
+      "reason": "Timestamp timezone casting disabled",
+      "paths": [
+        "test/sql/timezone/disable_timestamptz_casts.test"
+      ]
+    },
+    {
+      "reason": "Compression type not available (DICT_FSST)",
+      "paths": [
+        "test/sql/storage/compression/dict_fsst/test_null_update.test"
+      ]
+    },
+    {
+      "reason": "Query expected to fail but succeeded",
+      "paths": [
+        "test/sql/copy/csv/zstd_crash.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/parquet/parquet_glob.test"
+      ]
+    },
+    {
+      "reason": "Out of Memory Error",
+      "paths": [
+        "test/sql/copy/csv/code_cov/csv_disk_reload.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_systems.test"
+      ]
+    },
+    {
+      "reason": "Invalid unicode in value construction",
+      "paths": [
+        "test/sql/pragma/test_pragma_functions.test"
+      ]
+    },
+    {
+      "reason": "Invalid input file path",
+      "paths": [
+        "test/sql/function/autocomplete/create_secret.test"
+      ]
+    },
+    {
+      "reason": "Out of memory/range error",
+      "paths": [
+        "test/sql/index/art/storage/test_art_mem_limit.test",
+        "test/sql/logging/test_logging_function.test"
+      ]
+    },
+    {
+      "reason": "Serialization error - not enough data",
+      "paths": [
+        "test/sql/parser/invisible_spaces.test"
+      ]
+    },
+    {
+      "reason": "Upsert test failure",
+      "paths": [
+        "test/sql/upsert/upsert_basic.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/catalog/function/test_recursive_macro.test",
+        "test/sql/storage/compression/dict_fsst/dictionary_covers_validity.test",
+        "test/sql/storage/compression/zstd/test_skipping.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_base.json
+++ b/test/configs/serialization_bwc_base.json
@@ -271,7 +271,8 @@
     {
       "reason": "No files found that match the pattern",
       "paths": [
-        "test/sql/copy/parquet/parquet_glob.test"
+        "test/sql/copy/parquet/parquet_glob.test",
+        "test/sql/copy/per_thread_output.test"
       ]
     },
     {

--- a/test/configs/serialization_bwc_v1.1.0.json
+++ b/test/configs/serialization_bwc_v1.1.0.json
@@ -1,0 +1,151 @@
+{
+  "description": "Failed tests from backwards compatibility testing.",
+  "skip_tests": [
+    {
+      "reason": "Table function deserialization failure - column type changed",
+      "paths": [
+        "test/sql/aggregate/aggregates/test_approx_quantile.test",
+        "test/sql/catalog/function/test_macro_overloads.test",
+        "test/sql/catalog/function/test_simple_macro.test",
+        "test/sql/catalog/function/test_table_macro.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/table_function/read_text_and_blob.test"
+      ]
+    },
+    {
+      "reason": "CSVReaderDeserialize not implemented",
+      "paths": [
+        "test/sql/copy/csv/auto/test_auto_8231.test",
+        "test/sql/copy/csv/csv_hive.test",
+        "test/sql/copy/csv/csv_hive_filename_union.test",
+        "test/sql/copy/csv/csv_projection_pushdown.test",
+        "test/sql/copy/csv/parallel/parallel_csv_hive_partitioning.test",
+        "test/sql/copy/csv/parallel/parallel_csv_union_by_name.test",
+        "test/sql/copy/csv/recursive_csv_union_by_name.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown_glob.test",
+        "test/sql/copy/csv/test_null_padding_projection.test",
+        "test/sql/copy/csv/test_null_padding_union.test",
+        "test/sql/copy/csv/test_read_csv.test",
+        "test/sql/copy/csv/test_union_by_name.test",
+        "test/sql/copy/csv/tsv_copy.test",
+        "test/sql/subquery/lateral/lateral_binding_views.test"
+      ]
+    },
+    {
+      "reason": "Attempting to commit read-only transaction with changes",
+      "paths": [
+        "test/sql/copy/csv/test_compression_flag.test",
+        "test/sql/copy/csv/test_copy_gzip.test",
+        "test/sql/copy/csv/zstd_fs.test",
+        "test/sql/copy/parquet/parquet_encryption_httpfs.test",
+        "test/sql/subquery/lateral/pg_lateral.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/file_size_bytes.test",
+        "test/sql/copy/parquet/writer/parquet_write_memory_usage.test"
+      ]
+    },
+    {
+      "reason": "PLAN_STATEMENT error",
+      "paths": [
+        "test/sql/storage/compression/string/big_strings.test",
+        "test/sql/storage/compression/string/blob.test",
+        "test/sql/storage/compression/string/filter_pushdown.test",
+        "test/sql/storage/compression/string/index_fetch.test"
+      ]
+    },
+    {
+      "reason": "Expected vector of type LIST but found different type",
+      "paths": [
+        "test/sql/pragma/test_custom_optimizer_profiling.test",
+        "test/sql/pragma/test_custom_profiling_settings.test"
+      ]
+    },
+    {
+      "reason": "Schema does not exist",
+      "paths": [
+        "test/sql/catalog/function/information_schema_macro.test"
+      ]
+    },
+    {
+      "reason": "Invalid AES key length for GCM",
+      "paths": [
+        "test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test"
+      ]
+    },
+    {
+      "reason": "Information loss on integer cast",
+      "paths": [
+        "test/sql/copy/parquet/writer/parquet_write_compression_level.test"
+      ]
+    },
+    {
+      "reason": "Database invalidated by previous fatal error",
+      "paths": [
+        "test/sql/error/extension_function_error.test"
+      ]
+    },
+    {
+      "reason": "JSONScan Deserialize not implemented",
+      "paths": [
+        "test/sql/json/table/json_multi_file_reader.test"
+      ]
+    },
+    {
+      "reason": "Unsupported type for deserialization of LogicalOperator",
+      "paths": [
+        "test/sql/secrets/create_secret_scope_matching.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_system_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Serialization Error - not enough data",
+      "paths": [
+        "test/sql/storage/vacuum/vacuum_deletes_index.test"
+      ]
+    },
+    {
+      "reason": "Nested transactions not supported in serialization",
+      "paths": [
+        "test/sql/transactions/aborted_transaction_commit.test"
+      ]
+    },
+    {
+      "reason": "PRIMARY KEY or UNIQUE constraint violated",
+      "paths": [
+        "test/sql/upsert/upsert_conflict_in_different_chunk.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/copy/parquet/test_parquet_remote.test",
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test",
+        "test/sql/types/enum/test_enum_to_numbers.test"
+      ]
+    },
+    {
+      "reason": "Table does not exist",
+      "paths": [
+        "test/sql/storage/compression/string/empty.test",
+        "test/sql/storage/compression/string/simple.test",
+        "test/sql/storage/compression/string/table_copy.test"
+      ]
+    },
+    {
+      "reason": "Requires ndjson extension",
+      "paths": [
+        "test/sql/json/table/read_json_objects.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.1.1.json
+++ b/test/configs/serialization_bwc_v1.1.1.json
@@ -1,0 +1,151 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.1.1.",
+  "skip_tests": [
+    {
+      "reason": "CSVReaderDeserialize not implemented",
+      "paths": [
+        "test/sql/copy/csv/auto/test_auto_8231.test",
+        "test/sql/copy/csv/csv_hive.test",
+        "test/sql/copy/csv/csv_hive_filename_union.test",
+        "test/sql/copy/csv/csv_projection_pushdown.test",
+        "test/sql/copy/csv/parallel/parallel_csv_hive_partitioning.test",
+        "test/sql/copy/csv/parallel/parallel_csv_union_by_name.test",
+        "test/sql/copy/csv/recursive_csv_union_by_name.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown_glob.test",
+        "test/sql/copy/csv/test_null_padding_projection.test",
+        "test/sql/copy/csv/test_null_padding_union.test",
+        "test/sql/copy/csv/test_read_csv.test",
+        "test/sql/copy/csv/test_union_by_name.test",
+        "test/sql/copy/csv/tsv_copy.test",
+        "test/sql/subquery/lateral/lateral_binding_views.test"
+      ]
+    },
+    {
+      "reason": "Table function deserialization failure - column type changed",
+      "paths": [
+        "test/sql/aggregate/aggregates/test_approx_quantile.test",
+        "test/sql/catalog/function/test_macro_overloads.test",
+        "test/sql/catalog/function/test_simple_macro.test",
+        "test/sql/catalog/function/test_table_macro.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/table_function/read_text_and_blob.test"
+      ]
+    },
+    {
+      "reason": "Attempting to commit read-only transaction with changes",
+      "paths": [
+        "test/sql/copy/csv/test_compression_flag.test",
+        "test/sql/copy/csv/test_copy_gzip.test",
+        "test/sql/copy/csv/zstd_fs.test",
+        "test/sql/copy/parquet/parquet_encryption_httpfs.test",
+        "test/sql/subquery/lateral/pg_lateral.test"
+      ]
+    },
+    {
+      "reason": "PLAN_STATEMENT error",
+      "paths": [
+        "test/sql/storage/compression/string/big_strings.test",
+        "test/sql/storage/compression/string/blob.test",
+        "test/sql/storage/compression/string/filter_pushdown.test",
+        "test/sql/storage/compression/string/index_fetch.test"
+      ]
+    },
+    {
+      "reason": "Expected vector of type LIST but found different type",
+      "paths": [
+        "test/sql/pragma/test_custom_optimizer_profiling.test",
+        "test/sql/pragma/test_custom_profiling_settings.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/file_size_bytes.test",
+        "test/sql/copy/parquet/writer/parquet_write_memory_usage.test"
+      ]
+    },
+    {
+      "reason": "Schema does not exist",
+      "paths": [
+        "test/sql/catalog/function/information_schema_macro.test"
+      ]
+    },
+    {
+      "reason": "Invalid AES key length for GCM",
+      "paths": [
+        "test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test"
+      ]
+    },
+    {
+      "reason": "Information loss on integer cast",
+      "paths": [
+        "test/sql/copy/parquet/writer/parquet_write_compression_level.test"
+      ]
+    },
+    {
+      "reason": "Database invalidated by previous fatal error",
+      "paths": [
+        "test/sql/error/extension_function_error.test"
+      ]
+    },
+    {
+      "reason": "JSONScan Deserialize not implemented",
+      "paths": [
+        "test/sql/json/table/json_multi_file_reader.test"
+      ]
+    },
+    {
+      "reason": "Unsupported type for deserialization of LogicalOperator",
+      "paths": [
+        "test/sql/secrets/create_secret_scope_matching.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_system_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Serialization Error - not enough data",
+      "paths": [
+        "test/sql/storage/vacuum/vacuum_deletes_index.test"
+      ]
+    },
+    {
+      "reason": "Nested transactions not supported in serialization",
+      "paths": [
+        "test/sql/transactions/aborted_transaction_commit.test"
+      ]
+    },
+    {
+      "reason": "PRIMARY KEY or UNIQUE constraint violated",
+      "paths": [
+        "test/sql/upsert/upsert_conflict_in_different_chunk.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/types/enum/test_enum_to_numbers.test",
+        "test/sql/copy/csv/test_csv_remote.test",
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test"
+      ]
+    },
+    {
+      "reason": "Table does not exist",
+      "paths": [
+        "test/sql/storage/compression/string/empty.test",
+        "test/sql/storage/compression/string/simple.test",
+        "test/sql/storage/compression/string/table_copy.test"
+      ]
+    },
+    {
+      "reason": "Requires ndjson extension",
+      "paths": [
+        "test/sql/json/table/read_json_objects.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.1.2.json
+++ b/test/configs/serialization_bwc_v1.1.2.json
@@ -1,0 +1,144 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.1.2.",
+  "skip_tests": [
+    {
+      "reason": "CSVReaderDeserialize not implemented",
+      "paths": [
+        "test/sql/copy/csv/auto/test_auto_8231.test",
+        "test/sql/copy/csv/csv_hive.test",
+        "test/sql/copy/csv/csv_hive_filename_union.test",
+        "test/sql/copy/csv/csv_projection_pushdown.test",
+        "test/sql/copy/csv/parallel/parallel_csv_hive_partitioning.test",
+        "test/sql/copy/csv/parallel/parallel_csv_union_by_name.test",
+        "test/sql/copy/csv/recursive_csv_union_by_name.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown_glob.test",
+        "test/sql/copy/csv/test_null_padding_projection.test",
+        "test/sql/copy/csv/test_null_padding_union.test",
+        "test/sql/copy/csv/test_read_csv.test",
+        "test/sql/copy/csv/test_union_by_name.test",
+        "test/sql/copy/csv/tsv_copy.test",
+        "test/sql/subquery/lateral/lateral_binding_views.test"
+      ]
+    },
+    {
+      "reason": "Table function deserialization failure - column type changed",
+      "paths": [
+        "test/sql/aggregate/aggregates/test_approx_quantile.test",
+        "test/sql/catalog/function/test_macro_overloads.test",
+        "test/sql/catalog/function/test_simple_macro.test",
+        "test/sql/catalog/function/test_table_macro.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/table_function/read_text_and_blob.test"
+      ]
+    },
+    {
+      "reason": "Attempting to commit read-only transaction with changes",
+      "paths": [
+        "test/sql/copy/csv/test_compression_flag.test",
+        "test/sql/copy/csv/test_copy_gzip.test",
+        "test/sql/copy/csv/zstd_fs.test",
+        "test/sql/copy/parquet/parquet_encryption_httpfs.test",
+        "test/sql/subquery/lateral/pg_lateral.test"
+      ]
+    },
+    {
+      "reason": "PLAN_STATEMENT error",
+      "paths": [
+        "test/sql/storage/compression/string/big_strings.test",
+        "test/sql/storage/compression/string/blob.test",
+        "test/sql/storage/compression/string/filter_pushdown.test",
+        "test/sql/storage/compression/string/index_fetch.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/file_size_bytes.test",
+        "test/sql/copy/parquet/writer/parquet_write_memory_usage.test"
+      ]
+    },
+    {
+      "reason": "Schema does not exist",
+      "paths": [
+        "test/sql/catalog/function/information_schema_macro.test"
+      ]
+    },
+    {
+      "reason": "Invalid AES key length for GCM",
+      "paths": [
+        "test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test"
+      ]
+    },
+    {
+      "reason": "Information loss on integer cast",
+      "paths": [
+        "test/sql/copy/parquet/writer/parquet_write_compression_level.test"
+      ]
+    },
+    {
+      "reason": "Database invalidated by previous fatal error",
+      "paths": [
+        "test/sql/error/extension_function_error.test"
+      ]
+    },
+    {
+      "reason": "JSONScan Deserialize not implemented",
+      "paths": [
+        "test/sql/json/table/json_multi_file_reader.test"
+      ]
+    },
+    {
+      "reason": "Unsupported type for deserialization of LogicalOperator",
+      "paths": [
+        "test/sql/secrets/create_secret_scope_matching.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_system_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Serialization Error - not enough data",
+      "paths": [
+        "test/sql/storage/vacuum/vacuum_deletes_index.test"
+      ]
+    },
+    {
+      "reason": "Nested transactions not supported in serialization",
+      "paths": [
+        "test/sql/transactions/aborted_transaction_commit.test"
+      ]
+    },
+    {
+      "reason": "PRIMARY KEY or UNIQUE constraint violated",
+      "paths": [
+        "test/sql/upsert/upsert_conflict_in_different_chunk.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/cte/recursive_cte_key_variant.test",
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test",
+        "test/sql/types/enum/test_enum_to_numbers.test"
+      ]
+    },
+    {
+      "reason": "Table does not exist",
+      "paths": [
+        "test/sql/storage/compression/string/empty.test",
+        "test/sql/storage/compression/string/simple.test",
+        "test/sql/storage/compression/string/table_copy.test"
+      ]
+    },
+    {
+      "reason": "Requires ndjson extension",
+      "paths": [
+        "test/sql/json/table/read_json_objects.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.1.3.json
+++ b/test/configs/serialization_bwc_v1.1.3.json
@@ -1,0 +1,144 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.1.3.",
+  "skip_tests": [
+    {
+      "reason": "CSVReaderDeserialize not implemented",
+      "paths": [
+        "test/sql/copy/csv/auto/test_auto_8231.test",
+        "test/sql/copy/csv/csv_hive.test",
+        "test/sql/copy/csv/csv_hive_filename_union.test",
+        "test/sql/copy/csv/csv_projection_pushdown.test",
+        "test/sql/copy/csv/parallel/parallel_csv_hive_partitioning.test",
+        "test/sql/copy/csv/parallel/parallel_csv_union_by_name.test",
+        "test/sql/copy/csv/recursive_csv_union_by_name.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown_glob.test",
+        "test/sql/copy/csv/test_null_padding_projection.test",
+        "test/sql/copy/csv/test_null_padding_union.test",
+        "test/sql/copy/csv/test_read_csv.test",
+        "test/sql/copy/csv/test_union_by_name.test",
+        "test/sql/copy/csv/tsv_copy.test",
+        "test/sql/subquery/lateral/lateral_binding_views.test"
+      ]
+    },
+    {
+      "reason": "Table function deserialization failure - column type changed",
+      "paths": [
+        "test/sql/aggregate/aggregates/test_approx_quantile.test",
+        "test/sql/catalog/function/test_macro_overloads.test",
+        "test/sql/catalog/function/test_simple_macro.test",
+        "test/sql/catalog/function/test_table_macro.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/table_function/read_text_and_blob.test"
+      ]
+    },
+    {
+      "reason": "Attempting to commit read-only transaction with changes",
+      "paths": [
+        "test/sql/copy/csv/test_compression_flag.test",
+        "test/sql/copy/csv/test_copy_gzip.test",
+        "test/sql/copy/csv/zstd_fs.test",
+        "test/sql/copy/parquet/parquet_encryption_httpfs.test",
+        "test/sql/subquery/lateral/pg_lateral.test"
+      ]
+    },
+    {
+      "reason": "PLAN_STATEMENT error",
+      "paths": [
+        "test/sql/storage/compression/string/big_strings.test",
+        "test/sql/storage/compression/string/blob.test",
+        "test/sql/storage/compression/string/filter_pushdown.test",
+        "test/sql/storage/compression/string/index_fetch.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/file_size_bytes.test",
+        "test/sql/copy/parquet/writer/parquet_write_memory_usage.test"
+      ]
+    },
+    {
+      "reason": "Schema does not exist",
+      "paths": [
+        "test/sql/catalog/function/information_schema_macro.test"
+      ]
+    },
+    {
+      "reason": "Invalid AES key length for GCM",
+      "paths": [
+        "test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test"
+      ]
+    },
+    {
+      "reason": "Information loss on integer cast",
+      "paths": [
+        "test/sql/copy/parquet/writer/parquet_write_compression_level.test"
+      ]
+    },
+    {
+      "reason": "Database invalidated by previous fatal error",
+      "paths": [
+        "test/sql/error/extension_function_error.test"
+      ]
+    },
+    {
+      "reason": "JSONScan Deserialize not implemented",
+      "paths": [
+        "test/sql/json/table/json_multi_file_reader.test"
+      ]
+    },
+    {
+      "reason": "Unsupported type for deserialization of LogicalOperator",
+      "paths": [
+        "test/sql/secrets/create_secret_scope_matching.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_system_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Serialization Error - not enough data",
+      "paths": [
+        "test/sql/storage/vacuum/vacuum_deletes_index.test"
+      ]
+    },
+    {
+      "reason": "Nested transactions not supported in serialization",
+      "paths": [
+        "test/sql/transactions/aborted_transaction_commit.test"
+      ]
+    },
+    {
+      "reason": "PRIMARY KEY or UNIQUE constraint violated",
+      "paths": [
+        "test/sql/upsert/upsert_conflict_in_different_chunk.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/attach/attach_remote.test",
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test",
+        "test/sql/types/enum/test_enum_to_numbers.test"
+      ]
+    },
+    {
+      "reason": "Table does not exist",
+      "paths": [
+        "test/sql/storage/compression/string/empty.test",
+        "test/sql/storage/compression/string/simple.test",
+        "test/sql/storage/compression/string/table_copy.test"
+      ]
+    },
+    {
+      "reason": "Requires ndjson extension",
+      "paths": [
+        "test/sql/json/table/read_json_objects.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.2.0.json
+++ b/test/configs/serialization_bwc_v1.2.0.json
@@ -1,0 +1,120 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.2.0.",
+  "skip_tests": [
+    {
+      "reason": "CSVReaderDeserialize not implemented",
+      "paths": [
+        "test/sql/copy/csv/auto/test_auto_8231.test",
+        "test/sql/copy/csv/csv_hive.test",
+        "test/sql/copy/csv/csv_hive_filename_union.test",
+        "test/sql/copy/csv/csv_projection_pushdown.test",
+        "test/sql/copy/csv/parallel/parallel_csv_hive_partitioning.test",
+        "test/sql/copy/csv/parallel/parallel_csv_union_by_name.test",
+        "test/sql/copy/csv/recursive_csv_union_by_name.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown_glob.test",
+        "test/sql/copy/csv/test_filename_filter.test",
+        "test/sql/copy/csv/test_null_padding_projection.test",
+        "test/sql/copy/csv/test_null_padding_union.test",
+        "test/sql/copy/csv/test_read_csv.test",
+        "test/sql/copy/csv/test_union_by_name.test",
+        "test/sql/copy/csv/tsv_copy.test",
+        "test/sql/subquery/lateral/lateral_binding_views.test"
+      ]
+    },
+    {
+      "reason": "Table function deserialization failure - column type changed",
+      "paths": [
+        "test/sql/catalog/function/test_macro_overloads.test",
+        "test/sql/catalog/function/test_simple_macro.test",
+        "test/sql/catalog/function/test_table_macro.test",
+        "test/sql/logging/logging.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_array.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_bitset.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_run.test"
+      ]
+    },
+    {
+      "reason": "Attempting to commit read-only transaction with changes",
+      "paths": [
+        "test/sql/copy/csv/test_compression_flag.test",
+        "test/sql/copy/csv/test_copy_gzip.test",
+        "test/sql/copy/csv/unquoted_escape/human_eval.test",
+        "test/sql/copy/csv/zstd_fs.test",
+        "test/sql/copy/parquet/parquet_encryption_httpfs.test",
+        "test/sql/subquery/lateral/pg_lateral.test"
+      ]
+    },
+    {
+      "reason": "PLAN_STATEMENT error",
+      "paths": [
+        "test/sql/storage/compression/string/big_strings.test",
+        "test/sql/storage/compression/string/blob.test",
+        "test/sql/storage/compression/string/filter_pushdown.test",
+        "test/sql/storage/compression/string/index_fetch.test"
+      ]
+    },
+    {
+      "reason": "Catalog does not exist",
+      "paths": [
+        "test/sql/attach/attach_icu_collation.test",
+        "test/sql/storage/bc/test_view_v092.test",
+        "test/sql/storage/icu_collation.test",
+        "test/sql/storage/wal/test_wal_bc.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/file_size_bytes.test",
+        "test/sql/copy/parquet/writer/parquet_write_memory_usage.test"
+      ]
+    },
+    {
+      "reason": "Serialization Error - not enough data",
+      "paths": [
+        "test/sql/aggregate/aggregates/test_approx_quantile.test",
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test"
+      ]
+    },
+    {
+      "reason": "Invalid AES key length for GCM",
+      "paths": [
+        "test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test"
+      ]
+    },
+    {
+      "reason": "JSONScan Deserialize not implemented",
+      "paths": [
+        "test/sql/json/table/json_multi_file_reader.test"
+      ]
+    },
+    {
+      "reason": "Unsupported type for deserialization of LogicalOperator",
+      "paths": [
+        "test/sql/secrets/create_secret_scope_matching.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_system_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Cannot create index with outstanding updates",
+      "paths": [
+        "test/sql/upsert/insert_or_replace/unique_index.test"
+      ]
+    },
+    {
+      "reason": "Table does not exist",
+      "paths": [
+        "test/sql/storage/compression/string/empty.test",
+        "test/sql/storage/compression/string/simple.test",
+        "test/sql/storage/compression/string/table_copy.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.2.1.json
+++ b/test/configs/serialization_bwc_v1.2.1.json
@@ -1,0 +1,126 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.2.1.",
+  "skip_tests": [
+    {
+      "reason": "CSVReaderDeserialize not implemented",
+      "paths": [
+        "test/sql/copy/csv/auto/test_auto_8231.test",
+        "test/sql/copy/csv/csv_hive.test",
+        "test/sql/copy/csv/csv_hive_filename_union.test",
+        "test/sql/copy/csv/csv_projection_pushdown.test",
+        "test/sql/copy/csv/parallel/parallel_csv_hive_partitioning.test",
+        "test/sql/copy/csv/parallel/parallel_csv_union_by_name.test",
+        "test/sql/copy/csv/recursive_csv_union_by_name.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown_glob.test",
+        "test/sql/copy/csv/test_filename_filter.test",
+        "test/sql/copy/csv/test_null_padding_projection.test",
+        "test/sql/copy/csv/test_null_padding_union.test",
+        "test/sql/copy/csv/test_read_csv.test",
+        "test/sql/copy/csv/test_union_by_name.test",
+        "test/sql/copy/csv/tsv_copy.test",
+        "test/sql/subquery/lateral/lateral_binding_views.test"
+      ]
+    },
+    {
+      "reason": "Table function deserialization failure - column type changed",
+      "paths": [
+        "test/sql/aggregate/aggregates/test_approx_quantile.test",
+        "test/sql/catalog/function/test_macro_overloads.test",
+        "test/sql/catalog/function/test_simple_macro.test",
+        "test/sql/catalog/function/test_table_macro.test",
+        "test/sql/logging/logging.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_array.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_bitset.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_run.test"
+      ]
+    },
+    {
+      "reason": "Attempting to commit read-only transaction with changes",
+      "paths": [
+        "test/sql/copy/csv/test_compression_flag.test",
+        "test/sql/copy/csv/test_copy_gzip.test",
+        "test/sql/copy/csv/unquoted_escape/human_eval.test",
+        "test/sql/copy/csv/zstd_fs.test",
+        "test/sql/copy/parquet/parquet_encryption_httpfs.test",
+        "test/sql/subquery/lateral/pg_lateral.test"
+      ]
+    },
+    {
+      "reason": "PLAN_STATEMENT error",
+      "paths": [
+        "test/sql/storage/compression/string/big_strings.test",
+        "test/sql/storage/compression/string/blob.test",
+        "test/sql/storage/compression/string/filter_pushdown.test",
+        "test/sql/storage/compression/string/index_fetch.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/file_size_bytes.test",
+        "test/sql/copy/parquet/writer/parquet_write_memory_usage.test"
+      ]
+    },
+    {
+      "reason": "Catalog does not exist",
+      "paths": [
+        "test/sql/attach/attach_icu_collation.test",
+        "test/sql/storage/bc/test_view_v092.test",
+        "test/sql/storage/icu_collation.test",
+        "test/sql/storage/wal/test_wal_bc.test"
+      ]
+    },
+    {
+      "reason": "Invalid AES key length for GCM",
+      "paths": [
+        "test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test"
+      ]
+    },
+    {
+      "reason": "JSONScan Deserialize not implemented",
+      "paths": [
+        "test/sql/json/table/json_multi_file_reader.test"
+      ]
+    },
+    {
+      "reason": "Unsupported type for deserialization of LogicalOperator",
+      "paths": [
+        "test/sql/secrets/create_secret_scope_matching.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_system_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Cannot create index with outstanding updates",
+      "paths": [
+        "test/sql/upsert/insert_or_replace/unique_index.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/copy/csv/test_url_with_plus.test"
+      ]
+    },
+    {
+      "reason": "Serialization Error - not enough data",
+      "paths": [
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test"
+      ]
+    },
+    {
+      "reason": "Table does not exist",
+      "paths": [
+        "test/sql/storage/compression/string/empty.test",
+        "test/sql/storage/compression/string/simple.test",
+        "test/sql/storage/compression/string/table_copy.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.2.2.json
+++ b/test/configs/serialization_bwc_v1.2.2.json
@@ -1,0 +1,122 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.2.2.",
+  "skip_tests": [
+    {
+      "reason": "CSVReaderDeserialize not implemented",
+      "paths": [
+        "test/sql/copy/csv/auto/test_auto_8231.test",
+        "test/sql/copy/csv/csv_hive.test",
+        "test/sql/copy/csv/csv_hive_filename_union.test",
+        "test/sql/copy/csv/csv_projection_pushdown.test",
+        "test/sql/copy/csv/parallel/parallel_csv_hive_partitioning.test",
+        "test/sql/copy/csv/parallel/parallel_csv_union_by_name.test",
+        "test/sql/copy/csv/recursive_csv_union_by_name.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown.test",
+        "test/sql/copy/csv/test_csv_projection_pushdown_glob.test",
+        "test/sql/copy/csv/test_filename_filter.test",
+        "test/sql/copy/csv/test_null_padding_projection.test",
+        "test/sql/copy/csv/test_null_padding_union.test",
+        "test/sql/copy/csv/test_read_csv.test",
+        "test/sql/copy/csv/test_union_by_name.test",
+        "test/sql/copy/csv/tsv_copy.test",
+        "test/sql/subquery/lateral/lateral_binding_views.test"
+      ]
+    },
+    {
+      "reason": "Table function deserialization failure - column type changed",
+      "paths": [
+        "test/sql/aggregate/aggregates/test_approx_quantile.test",
+        "test/sql/catalog/function/test_macro_overloads.test",
+        "test/sql/catalog/function/test_simple_macro.test",
+        "test/sql/catalog/function/test_table_macro.test",
+        "test/sql/logging/logging.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_array.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_bitset.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_run.test"
+      ]
+    },
+    {
+      "reason": "Attempting to commit read-only transaction with changes",
+      "paths": [
+        "test/sql/copy/csv/test_compression_flag.test",
+        "test/sql/copy/csv/test_copy_gzip.test",
+        "test/sql/copy/csv/unquoted_escape/human_eval.test",
+        "test/sql/copy/csv/zstd_fs.test",
+        "test/sql/copy/parquet/parquet_encryption_httpfs.test",
+        "test/sql/subquery/lateral/pg_lateral.test"
+      ]
+    },
+    {
+      "reason": "PLAN_STATEMENT error",
+      "paths": [
+        "test/sql/storage/compression/string/big_strings.test",
+        "test/sql/storage/compression/string/blob.test",
+        "test/sql/storage/compression/string/filter_pushdown.test",
+        "test/sql/storage/compression/string/index_fetch.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/file_size_bytes.test",
+        "test/sql/copy/parquet/writer/parquet_write_memory_usage.test"
+      ]
+    },
+    {
+      "reason": "Catalog does not exist",
+      "paths": [
+        "test/sql/attach/attach_icu_collation.test",
+        "test/sql/storage/bc/test_view_v092.test",
+        "test/sql/storage/icu_collation.test",
+        "test/sql/storage/wal/test_wal_bc.test"
+      ]
+    },
+    {
+      "reason": "Invalid AES key length for GCM",
+      "paths": [
+        "test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test"
+      ]
+    },
+    {
+      "reason": "JSONScan Deserialize not implemented",
+      "paths": [
+        "test/sql/json/table/json_multi_file_reader.test"
+      ]
+    },
+    {
+      "reason": "Unsupported type for deserialization of LogicalOperator",
+      "paths": [
+        "test/sql/secrets/create_secret_scope_matching.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_system_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Cannot create index with outstanding updates",
+      "paths": [
+        "test/sql/upsert/insert_or_replace/unique_index.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/copy/csv/test_url_with_plus.test",
+        "test/sql/copy/parquet/test_parquet_remote.test",
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test"
+      ]
+    },
+    {
+      "reason": "Table does not exist",
+      "paths": [
+        "test/sql/storage/compression/string/empty.test",
+        "test/sql/storage/compression/string/simple.test",
+        "test/sql/storage/compression/string/table_copy.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.3.0.json
+++ b/test/configs/serialization_bwc_v1.3.0.json
@@ -1,0 +1,74 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.3.0.",
+  "skip_tests": [
+    {
+      "reason": "Table function deserialization failure - column type changed",
+      "paths": [
+        "test/sql/logging/file_system_logging.test",
+        "test/sql/logging/http_logging.test",
+        "test/sql/logging/logging.test",
+        "test/sql/logging/logging_types.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_array.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_bitset.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_run.test"
+      ]
+    },
+    {
+      "reason": "Attempting to commit read-only transaction with changes",
+      "paths": [
+        "test/sql/copy/csv/unquoted_escape/human_eval.test",
+        "test/sql/copy/parquet/parquet_encryption_httpfs.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/file_size_bytes.test",
+        "test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test",
+        "test/sql/copy/parquet/writer/parquet_write_memory_usage.test"
+      ]
+    },
+    {
+      "reason": "Catalog does not exist",
+      "paths": [
+        "test/sql/attach/attach_icu_collation.test",
+        "test/sql/function/list/lambdas/test_lambda_storage.test",
+        "test/sql/storage/bc/test_view_v092.test",
+        "test/sql/storage/icu_collation.test",
+        "test/sql/storage/wal/test_wal_bc.test"
+      ]
+    },
+    {
+      "reason": "Unsupported type for deserialization of LogicalOperator",
+      "paths": [
+        "test/sql/secrets/create_secret_scope_matching.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_system_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Compression type deprecated",
+      "paths": [
+        "test/sql/storage/compression/test_using_compression.test"
+      ]
+    },
+    {
+      "reason": "Cannot create index with outstanding updates",
+      "paths": [
+        "test/sql/upsert/insert_or_replace/unique_index.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/copy/csv/test_url_with_plus.test",
+        "test/sql/cte/recursive_cte_key_variant.test",
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.3.1.json
+++ b/test/configs/serialization_bwc_v1.3.1.json
@@ -1,0 +1,73 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.3.1.",
+  "skip_tests": [
+    {
+      "reason": "Table function deserialization failure - column type changed",
+      "paths": [
+        "test/sql/logging/file_system_logging.test",
+        "test/sql/logging/http_logging.test",
+        "test/sql/logging/logging.test",
+        "test/sql/logging/logging_types.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_array.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_bitset.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_run.test"
+      ]
+    },
+    {
+      "reason": "Attempting to commit read-only transaction with changes",
+      "paths": [
+        "test/sql/copy/csv/unquoted_escape/human_eval.test",
+        "test/sql/copy/parquet/parquet_encryption_httpfs.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/file_size_bytes.test",
+        "test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test",
+        "test/sql/copy/parquet/writer/parquet_write_memory_usage.test"
+      ]
+    },
+    {
+      "reason": "Catalog does not exist",
+      "paths": [
+        "test/sql/attach/attach_icu_collation.test",
+        "test/sql/function/list/lambdas/test_lambda_storage.test",
+        "test/sql/storage/bc/test_view_v092.test",
+        "test/sql/storage/icu_collation.test",
+        "test/sql/storage/wal/test_wal_bc.test"
+      ]
+    },
+    {
+      "reason": "Unsupported type for deserialization of LogicalOperator",
+      "paths": [
+        "test/sql/secrets/create_secret_scope_matching.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_system_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Cannot create index with outstanding updates",
+      "paths": [
+        "test/sql/upsert/insert_or_replace/unique_index.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/copy/csv/test_url_with_plus.test",
+        "test/sql/cte/recursive_cte_key_variant.test"
+      ]
+    },
+    {
+      "reason": "Serialization Error - not enough data",
+      "paths": [
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.3.2.json
+++ b/test/configs/serialization_bwc_v1.3.2.json
@@ -1,0 +1,68 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.3.2.",
+  "skip_tests": [
+    {
+      "reason": "Table function deserialization failure - column type changed",
+      "paths": [
+        "test/sql/logging/file_system_logging.test",
+        "test/sql/logging/http_logging.test",
+        "test/sql/logging/logging.test",
+        "test/sql/logging/logging_types.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_array.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_bitset.test",
+        "test/sql/storage/compression/roaring/roaring_analyze_run.test"
+      ]
+    },
+    {
+      "reason": "Attempting to commit read-only transaction with changes",
+      "paths": [
+        "test/sql/copy/csv/unquoted_escape/human_eval.test",
+        "test/sql/copy/parquet/parquet_encryption_httpfs.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/file_size_bytes.test",
+        "test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test",
+        "test/sql/copy/parquet/writer/parquet_write_memory_usage.test"
+      ]
+    },
+    {
+      "reason": "Catalog does not exist",
+      "paths": [
+        "test/sql/attach/attach_icu_collation.test",
+        "test/sql/function/list/lambdas/test_lambda_storage.test",
+        "test/sql/storage/bc/test_view_v092.test",
+        "test/sql/storage/icu_collation.test",
+        "test/sql/storage/wal/test_wal_bc.test"
+      ]
+    },
+    {
+      "reason": "Unsupported type for deserialization of LogicalOperator",
+      "paths": [
+        "test/sql/secrets/create_secret_scope_matching.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_system_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Cannot create index with outstanding updates",
+      "paths": [
+        "test/sql/upsert/insert_or_replace/unique_index.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/copy/csv/test_url_with_plus.test",
+        "test/sql/cte/recursive_cte_key_variant.test",
+        "test/sql/parallelism/intraquery/depth_first_evaluation_union_and_join.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.4.0.json
+++ b/test/configs/serialization_bwc_v1.4.0.json
@@ -1,0 +1,52 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.4.0.",
+  "skip_tests": [
+    {
+      "reason": "Attempting to commit read-only transaction with changes",
+      "paths": [
+        "test/sql/copy/csv/unquoted_escape/human_eval.test",
+        "test/sql/copy/parquet/parquet_encryption_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Catalog does not exist",
+      "paths": [
+        "test/sql/copy/encryption/different_aes_ciphers.test"
+      ]
+    },
+    {
+      "reason": "No files found that match the pattern",
+      "paths": [
+        "test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test"
+      ]
+    },
+    {
+      "reason": "Unsupported type for deserialization of LogicalOperator",
+      "paths": [
+        "test/sql/secrets/create_secret_scope_matching.test"
+      ]
+    },
+    {
+      "reason": "File system disabled by configuration",
+      "paths": [
+        "test/sql/settings/test_disabled_file_system_httpfs.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/copy/parquet/test_parquet_remote.test",
+        "test/sql/cte/recursive_cte_key_variant.test",
+        "test/sql/table_function/test_information_schema_columns.test",
+        "test/sql/table_function/test_range_function.test"
+      ]
+    },
+    {
+      "reason": "Profiling result type mismatch",
+      "paths": [
+        "test/sql/pragma/profiling/test_custom_profiling_blocked_thread_time.test",
+        "test/sql/pragma/profiling/test_profiling_fs.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.4.1.json
+++ b/test/configs/serialization_bwc_v1.4.1.json
@@ -1,0 +1,24 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.4.1.",
+  "skip_tests": [
+    {
+      "reason": "Catalog does not exist",
+      "paths": [
+        "test/sql/copy/encryption/different_aes_ciphers.test"
+      ]
+    },
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/cte/recursive_cte_key_variant.test"
+      ]
+    },
+    {
+      "reason": "Profiling result type mismatch",
+      "paths": [
+        "test/sql/pragma/profiling/test_custom_profiling_blocked_thread_time.test",
+        "test/sql/pragma/profiling/test_profiling_fs.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.4.2.json
+++ b/test/configs/serialization_bwc_v1.4.2.json
@@ -1,0 +1,20 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.4.2.",
+  "skip_tests": [
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/function/list/lambdas/test_lambda_storage.test",
+        "test/sql/logging/http_log_timing.test",
+        "test/sql/cte/recursive_cte_key_variant.test"
+      ]
+    },
+    {
+      "reason": "Profiling result type mismatch",
+      "paths": [
+        "test/sql/pragma/profiling/test_custom_profiling_blocked_thread_time.test",
+        "test/sql/pragma/profiling/test_profiling_fs.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.4.3.json
+++ b/test/configs/serialization_bwc_v1.4.3.json
@@ -1,0 +1,18 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.4.3.",
+  "skip_tests": [
+    {
+      "reason": "Unknown failure (empty reason)",
+      "paths": [
+        "test/sql/cte/recursive_cte_key_variant.test"
+      ]
+    },
+    {
+      "reason": "Profiling result type mismatch",
+      "paths": [
+        "test/sql/pragma/profiling/test_custom_profiling_blocked_thread_time.test",
+        "test/sql/pragma/profiling/test_profiling_fs.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/serialization_bwc_v1.4.4.json
+++ b/test/configs/serialization_bwc_v1.4.4.json
@@ -1,0 +1,12 @@
+{
+  "description": "Failed tests from backwards compatibility testing with v1.4.4.",
+  "skip_tests": [
+    {
+      "reason": "Profiling result type mismatch",
+      "paths": [
+        "test/sql/pragma/profiling/test_custom_profiling_blocked_thread_time.test",
+        "test/sql/pragma/profiling/test_profiling_fs.test"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Overview

This pull request introduces a Python-based backward compatibility (BWC) test runner for DuckDB, along with CI integration and cache management tooling.

The high-level idea for this framework is the following:

Given two DuckDB versions, `Vold` and `Vnew` (with `Vold < Vnew`):

For each test suite of DuckDB @ `Vold`:
* **Step 1 - Serialize plans & results (old version):**
  * For each query in the test suite:
    * Serialize the execution plan with DuckDB @ `Vold`
    * Execute the query and serialize the result with DuckDB @ `Vold`
* **Step 2 - Execute serialized plans (new version):**
  * For each serialized plan from step 1:
    * Deserialize and execute the plan with DuckDB @ `Vnew`
    * Serialize the result with DuckDB @ `Vnew`
* **Step 3 - Compare results:**
  * Compare the results obtained in step 2 with the baseline results from step 1

# Implementation

## Components

```
test/bwc/
├── runner.py                 # Main test orchestrator
├── update_cache.py           # Update cache from CI artifacts
├── export_cache.py           # Export cache to compressed archives
└── utils/
    ├── duckdb_cli.py         # DuckDB CLI process interface
    ├── duckdb_installer.py   # CLI download, test spec cloning, extension install
    ├── test_files_parser.py  # SQL logic test parsing & serialization
    ├── test_report.py        # Test result reporting (writes to DuckDB database)
    ├── query_exclusions.py   # Query filtering (skip / execute-from-SQL rules)
    └── logger.py             # Logging setup (CI-aware)
```

* `runner.py` orchestrates BWC tests: installs CLIs and extensions, loads test specs, runs tests sequentially or in parallel, and writes results to a DuckDB report database.
* `duckdb_cli.py` implements a class for launching and interacting with DuckDB CLI processes (crash recovery, timeout handling, output parsing).
* `duckdb_installer.py` automates CLI installation, downloads test specs from GitHub, and manages extension installation for CLIs.
* `test_files_parser.py` parses SQL logic test files using `duckdb-sqllogictest-python` and converts them into tagged query files with serialized plans.
* `query_exclusions.py` defines patterns for queries that should be skipped entirely (e.g., transactions, pragma verification) or executed from SQL instead of serialized plans (e.g., DDL, DML, prepared statements).

The implementation relies on a dedicated DuckDB extension, `test-utils`, implemented [here](https://github.com/duckdb/bwc-test-utils).
The latest version was compiled for all DuckDB versions starting at v1.1.0, and published at `ext.motherduck.com`'s repo. It is also possible to use a custom-built extension (cf. below for building).

The implementation also relies on the `duckdb-sqllogictest-python` package (repo [here](https://github.com/duckdb/duckdb-sqllogictest-python)), as well as the most recent DuckDB Python package.

## Skip configuration

Known failing tests are tracked in JSON configuration files under `test/configs/`:
- `serialization_bwc_base.json` - tests skipped across all versions
- `serialization_bwc_v{version}.json` - version-specific skips

## CI

The GitHub Actions workflow (`.github/workflows/SerializationBWC.yml`) runs on pushes to `main` and on pull requests:

1. **Build job:** Compiles DuckDB with the `test-utils`, `httpfs`, and `inet` extensions.
2. **Test job (matrix):** Runs BWC tests in parallel across all supported old versions (v1.1.0 through v1.4.4), then exports a cache archive for each version.
3. **Summary job:** Aggregates results and reports overall success/failure.

## Cache management

To speed up repeated runs, the framework caches serialized plans and old-version results:
- `export_cache.py` packages cached files (`.sql`, `.plan.bin`, `.result.bin`, fixtures) into compressed archives.
- `update_cache.py` downloads cache artifacts from a CI run and updates the `test-utils` repository.

# Usage

## Runner parameters

```
python3 test/bwc/runner.py [OPTIONS]
```

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `--old_duckdb_version` | string | _(all supported)_ | Test against a specific old DuckDB version (e.g. `v1.2.0`). If not set, tests all supported versions. |
| `--new_cli_path` | string | `build/release/duckdb` | Path to the new (current) DuckDB CLI binary. |
| `--test_pattern` | string | _(none)_ | Run only tests whose relative path contains the given pattern. Forces sequential execution. |
| `--test_file` | string | _(none)_ | Path to a single test file to run. |
| `--run_sequentially` | boolean | `False` | Run tests sequentially instead of in parallel. |
| `--max_workers` | integer | `24` | Maximum number of worker threads for parallel execution. |
| `--stop_on_failure` | boolean | `False` | Stop execution after the first failure. |
| `--cleanup_bwc_directory` | boolean | `False` | Clean up the BWC runtime directory. Use with `--dry_run=False` to actually delete files. |
| `--dry_run` | boolean | `True` | When cleaning up, only log files that would be deleted without actually deleting them. |

### Examples

Run against all supported versions (parallel, 24 workers):
```shell
python3 test/bwc/runner.py
```

Run against a specific old version:
```shell
python3 test/bwc/runner.py --old_duckdb_version=v1.2.0
```

Run a subset of tests matching a pattern:
```shell
python3 test/bwc/runner.py --old_duckdb_version=v1.2.0 --test_pattern=window
```

Use a custom-built CLI:
```shell
python3 test/bwc/runner.py --new_cli_path=./build/debug/duckdb --old_duckdb_version=v1.2.0
```

## Cache tools

Export cache after a run:
```shell
python3 test/bwc/export_cache.py --version v1.2.0 --output-dir ./cache
```

Update test-utils cache from a CI run:
```shell
python3 test/bwc/update_cache.py --run-id <run_id> --test-utils-dir ../test-utils
```

## Compile extension for current DuckDB version

Create `.github/config/extensions/test-utils.cmake` in the `duckdb` repository with the following content:

```cmake
duckdb_extension_load(test_utils
  GIT_URL https://github.com/motherduckdb/test-utils
  GIT_TAG f90429ac336fef250d60ae27bd87813a53da4e7f
  # Or, for local use:
  # SOURCE_DIR "${EXTENSION_CONFIG_BASE_DIR}/../../../../test-utils"
)

include("${EXTENSION_CONFIG_BASE_DIR}/../in_tree_extensions.cmake")
```

Then compile:

```shell
make release EXTENSION_CONFIGS=.github/config/extensions/test-utils.cmake
```

## Runtime directory structure

All intermediary files are stored under `duckdb_unittest_tempdir/bwc/` relative to the repository root:

```
duckdb_unittest_tempdir/bwc/
├── specs/{version}/
│   ├── test/                        # Downloaded test files (cloned from duckdb repo at tag)
│   └── data/                        # Downloaded data fixtures
├── runtime/{version}/
│   └── {test_category}/{test_name}/
│       ├── {test_name}.sql              # Generated query file with bwc_tag annotations
│       ├── {test_name}.plan.bin         # Serialized execution plans (cacheable)
│       ├── {test_name}.{version}.result.bin  # Old version results (cacheable)
│       ├── {test_name}.new.result.bin   # New version results
│       ├── output/                      # Test output directory (working dir for CLI)
│       ├── fixtures/                    # Generated fixture databases (cacheable)
│       ├── data -> ../../specs/{version}/data   # Symlink
│       └── test -> ../../specs/{version}/test   # Symlink
├── reports/
│   └── test_report_{versions}_{timestamp}.duckdb  # Result database
└── tests_summary_{version}.txt          # Per-version summary (used by CI)
```

A new temporary folder is created for each run. The runner does not remove it after the run, so one can replay eventual failures. The runner also writes a `skip` file and adds an entry for each successful test suite; subsequent runs will skip that suite.
