### PR TITLE
Restore view's bind_state when binding fails

### DIFF
--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -133,13 +133,21 @@ void ViewCatalogEntry::BindView(ClientContext &context, BindViewAction action) {
 		// already bound
 		return;
 	}
+	auto prev_bind_state = bind_state.load();
 	bind_state = ViewBindState::BINDING;
 	bind_thread = ThreadUtil::GetThreadId();
-	auto columns = make_shared_ptr<ViewColumnInfo>();
-	Binder::BindView(context, GetQuery(), ParentCatalog().GetName(), ParentSchema().name, nullptr, aliases,
-	                 columns->types, columns->names);
-	view_columns.atomic_store(columns);
+	try {
+		auto columns = make_shared_ptr<ViewColumnInfo>();
+		Binder::BindView(context, GetQuery(), ParentCatalog().GetName(), ParentSchema().name, nullptr, aliases,
+						 columns->types, columns->names);
+		view_columns.atomic_store(columns);
+	} catch (...) {
+		bind_state = prev_bind_state;
+		bind_thread = thread_id {};
+		throw;
+	}
 	bind_state = ViewBindState::BOUND;
+	bind_thread = thread_id {};
 }
 
 void ViewCatalogEntry::UpdateBinding(const vector<LogicalType> &types_p, const vector<string> &names_p) {

--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -139,7 +139,7 @@ void ViewCatalogEntry::BindView(ClientContext &context, BindViewAction action) {
 	try {
 		auto columns = make_shared_ptr<ViewColumnInfo>();
 		Binder::BindView(context, GetQuery(), ParentCatalog().GetName(), ParentSchema().name, nullptr, aliases,
-						 columns->types, columns->names);
+		                 columns->types, columns->names);
 		view_columns.atomic_store(columns);
 	} catch (...) {
 		bind_state = prev_bind_state;


### PR DESCRIPTION
When view binding fails, the bind_state still remains stuck at `BINDING` phase. This can be misinterpreted as recursive binding and trigger exception `View "..." was requested to be bound but this thread is already binding that view - this likely means the view was attempted to be bound recursively`. This PR restore the bind_state upon bind failure. 