### PR TITLE
Allow extensibility of dot commands to the DuckDB CLI

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -147,6 +147,7 @@
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/setting_info.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
 #include "duckdb/optimizer/remove_unused_columns.hpp"
 #include "duckdb/parallel/async_result.hpp"
 #include "duckdb/parallel/interrupt.hpp"
@@ -4604,6 +4605,26 @@ const char* EnumUtil::ToChars<SettingScope>(SettingScope value) {
 template<>
 SettingScope EnumUtil::FromString<SettingScope>(const char *value) {
 	return static_cast<SettingScope>(StringUtil::StringToEnum(GetSettingScopeValues(), 4, "SettingScope", value));
+}
+
+const StringUtil::EnumStringLiteral *GetShellCommandResultValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(ShellCommandResult::SUCCESS), "SUCCESS" },
+		{ static_cast<uint32_t>(ShellCommandResult::FAIL), "FAIL" },
+		{ static_cast<uint32_t>(ShellCommandResult::EXIT), "EXIT" },
+		{ static_cast<uint32_t>(ShellCommandResult::PRINT_USAGE), "PRINT_USAGE" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<ShellCommandResult>(ShellCommandResult value) {
+	return StringUtil::EnumToString(GetShellCommandResultValues(), 4, "ShellCommandResult", static_cast<uint32_t>(value));
+}
+
+template<>
+ShellCommandResult EnumUtil::FromString<ShellCommandResult>(const char *value) {
+	return static_cast<ShellCommandResult>(StringUtil::StringToEnum(GetShellCommandResultValues(), 4, "ShellCommandResult", value));
 }
 
 const StringUtil::EnumStringLiteral *GetShowTypeValues() {

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -412,6 +412,8 @@ enum class SetType : uint8_t;
 
 enum class SettingScope : uint8_t;
 
+enum class ShellCommandResult : uint8_t;
+
 enum class ShowType : uint8_t;
 
 enum class SimplifiedTokenType : uint8_t;
@@ -1088,6 +1090,9 @@ const char* EnumUtil::ToChars<SetType>(SetType value);
 
 template<>
 const char* EnumUtil::ToChars<SettingScope>(SettingScope value);
+
+template<>
+const char* EnumUtil::ToChars<ShellCommandResult>(ShellCommandResult value);
 
 template<>
 const char* EnumUtil::ToChars<ShowType>(ShowType value);
@@ -1818,6 +1823,9 @@ SetType EnumUtil::FromString<SetType>(const char *value);
 
 template<>
 SettingScope EnumUtil::FromString<SettingScope>(const char *value);
+
+template<>
+ShellCommandResult EnumUtil::FromString<ShellCommandResult>(const char *value);
 
 template<>
 ShowType EnumUtil::FromString<ShowType>(const char *value);

--- a/src/include/duckdb/main/extension/extension_loader.hpp
+++ b/src/include/duckdb/main/extension/extension_loader.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/parser/parsed_data/create_type_info.hpp"
 #include "duckdb/main/extension_install_info.hpp"
 #include "duckdb/main/extension_manager.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
 
 namespace duckdb {
 
@@ -99,6 +100,11 @@ public:
 	                                     bind_cast_function_t function, int64_t implicit_cast_cost = -1);
 	DUCKDB_API void RegisterCastFunction(const LogicalType &source, const LogicalType &target, BoundCastInfo function,
 	                                     int64_t implicit_cast_cost = -1);
+
+	//! Registers a shell dot-command for this extension.
+	//! The extension's command name must exactly match the extension name.
+	//! e.g. the "ducklake" extension may only register ".ducklake".
+	DUCKDB_API void RegisterShellCommand(ShellCommandExtension extension);
 
 private:
 	void FinalizeLoad();

--- a/src/include/duckdb/main/extension_callback_manager.hpp
+++ b/src/include/duckdb/main/extension_callback_manager.hpp
@@ -22,6 +22,7 @@ class OperatorExtension;
 class OptimizerExtension;
 class ParserExtension;
 class PlannerExtension;
+class ShellCommandExtension;
 class StorageExtension;
 struct ExtensionCallbackRegistry;
 
@@ -43,14 +44,17 @@ public:
 	void Register(shared_ptr<OperatorExtension> extension);
 	void Register(const string &name, shared_ptr<StorageExtension> extension);
 	void Register(shared_ptr<ExtensionCallback> extension);
+	void Register(ShellCommandExtension extension);
 
 	ExtensionCallbackIteratorHelper<shared_ptr<OperatorExtension>> OperatorExtensions() const;
 	ExtensionCallbackIteratorHelper<OptimizerExtension> OptimizerExtensions() const;
 	ExtensionCallbackIteratorHelper<ParserExtension> ParserExtensions() const;
 	ExtensionCallbackIteratorHelper<PlannerExtension> PlannerExtensions() const;
 	ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>> ExtensionCallbacks() const;
+	ExtensionCallbackIteratorHelper<ShellCommandExtension> ShellCommandExtensions() const;
 	optional_ptr<StorageExtension> FindStorageExtension(const string &name) const;
 	bool HasParserExtensions() const;
+	bool HasShellCommandExtensions() const;
 
 private:
 	mutex registry_lock;

--- a/src/include/duckdb/main/shell_command_extension.hpp
+++ b/src/include/duckdb/main/shell_command_extension.hpp
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/shell_command_extension.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
+
+namespace duckdb {
+
+struct BaseShellState {};
+
+enum class ShellCommandResult : uint8_t { SUCCESS = 0, FAIL = 1, EXIT = 2, PRINT_USAGE = 3 };
+
+typedef ShellCommandResult (*shell_command_t)(BaseShellState &state, const vector<string> &args);
+
+struct ShellCommand {
+	const char *command;
+	idx_t argument_count;
+	shell_command_t callback;
+	const char *usage;
+	const char *description;
+	idx_t match_size;
+	const char *extra_description;
+	idx_t auxiliary_index;
+};
+
+struct DBConfig;
+class DatabaseInstance;
+
+//! Per-extension state kept alive for the lifetime of the database
+struct ShellCommandExtensionInfo {
+	virtual ~ShellCommandExtensionInfo() {
+	}
+};
+//! Callback type for shell command extensions.
+//! args[0] is the command name (without the leading '.'), args[1..] are the arguments.
+//! The extension may write output directly to stdout/stderr.
+typedef ShellCommandResult (*shell_command_callback_t)(DatabaseInstance &db, const vector<string> &args,
+                                                       optional_ptr<ShellCommandExtensionInfo> info);
+
+//! A shell command extension allows extensions to register custom '.' dot-commands
+//! in the DuckDB interactive shell.  Registration follows the same pattern as
+//! ParserExtension: call ShellCommandExtension::Register(config, ext) from within
+//! an extension's Load() function.
+class ShellCommandExtension {
+public:
+	//! The command name without the leading '.', e.g. "ducklake"
+	string command;
+	//! Argument synopsis shown in .help output, e.g. "SUBCOMMAND [ARGS...]"
+	string usage;
+	//! Short description shown in .help output
+	string description;
+	//! The handler called when the user types '.<command> [args...]'
+	shell_command_callback_t callback = nullptr;
+
+	mutable ShellCommand inner_command;
+	void Finalize(idx_t index) const {
+		inner_command.command = command.c_str();
+		inner_command.argument_count = 0;
+		inner_command.callback = nullptr;
+		inner_command.usage = usage.c_str();
+		inner_command.description = description.c_str();
+		inner_command.match_size = 0;
+		inner_command.extra_description = nullptr;
+		inner_command.auxiliary_index = index;
+	}
+
+	//! Extension-owned state passed to every callback invocation
+	shared_ptr<ShellCommandExtensionInfo> info;
+
+	static void Register(DBConfig &config, ShellCommandExtension extension);
+};
+
+} // namespace duckdb

--- a/src/main/extension/extension_loader.cpp
+++ b/src/main/extension/extension_loader.cpp
@@ -16,6 +16,9 @@
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 
@@ -244,6 +247,15 @@ void ExtensionLoader::RegisterCastFunction(const LogicalType &source, const Logi
 	auto &config = DBConfig::GetConfig(db);
 	auto &casts = config.GetCastFunctions();
 	casts.RegisterCastFunction(source, target, std::move(function), implicit_cast_cost);
+}
+
+void ExtensionLoader::RegisterShellCommand(ShellCommandExtension extension) {
+	if (!StringUtil::CIEquals(extension.command, extension_name)) {
+		throw InvalidInputException("Shell command extension name '%s' does not match extension name '%s' — "
+		                            "an extension may only register a dot-command whose name equals its own name",
+		                            extension.command, extension_name);
+	}
+	DBConfig::GetConfig(db).GetCallbackManager().Register(std::move(extension));
 }
 
 } // namespace duckdb

--- a/src/main/extension_callback_manager.cpp
+++ b/src/main/extension_callback_manager.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/main/extension_callback_manager.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
 #include "duckdb/parser/parser_extension.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "duckdb/planner/operator_extension.hpp"
@@ -21,6 +22,8 @@ struct ExtensionCallbackRegistry {
 	case_insensitive_map_t<shared_ptr<StorageExtension>> storage_extensions;
 	//! Set of callbacks that can be installed by extensions
 	vector<shared_ptr<ExtensionCallback>> extension_callbacks;
+	//! Shell dot-command extensions (only active when running the interactive CLI)
+	vector<ShellCommandExtension> shell_command_extensions;
 };
 
 ExtensionCallbackManager &ExtensionCallbackManager::Get(ClientContext &context) {
@@ -82,6 +85,13 @@ void ExtensionCallbackManager::Register(shared_ptr<ExtensionCallback> extension)
 	callback_registry.atomic_store(new_registry);
 }
 
+void ExtensionCallbackManager::Register(ShellCommandExtension extension) {
+	lock_guard<mutex> guard(registry_lock);
+	auto new_registry = make_shared_ptr<ExtensionCallbackRegistry>(*callback_registry);
+	new_registry->shell_command_extensions.push_back(std::move(extension));
+	callback_registry.atomic_store(new_registry);
+}
+
 template <class T>
 ExtensionCallbackIteratorHelper<T>::ExtensionCallbackIteratorHelper(
     const vector<T> &vec, shared_ptr<ExtensionCallbackRegistry> callback_registry)
@@ -122,6 +132,12 @@ ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>> ExtensionCallback
 	return ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>>(extension_callbacks, std::move(registry));
 }
 
+ExtensionCallbackIteratorHelper<ShellCommandExtension> ExtensionCallbackManager::ShellCommandExtensions() const {
+	auto registry = callback_registry.atomic_load();
+	auto &shell_command_extensions = registry->shell_command_extensions;
+	return ExtensionCallbackIteratorHelper<ShellCommandExtension>(shell_command_extensions, std::move(registry));
+}
+
 optional_ptr<StorageExtension> ExtensionCallbackManager::FindStorageExtension(const string &name) const {
 	auto registry = callback_registry.atomic_load();
 	auto entry = registry->storage_extensions.find(name);
@@ -134,6 +150,11 @@ optional_ptr<StorageExtension> ExtensionCallbackManager::FindStorageExtension(co
 bool ExtensionCallbackManager::HasParserExtensions() const {
 	auto registry = callback_registry.atomic_load();
 	return !registry->parser_extensions.empty();
+}
+
+bool ExtensionCallbackManager::HasShellCommandExtensions() const {
+	auto registry = callback_registry.atomic_load();
+	return !registry->shell_command_extensions.empty();
 }
 
 void OptimizerExtension::Register(DBConfig &config, OptimizerExtension extension) {
@@ -160,6 +181,10 @@ void ExtensionCallback::Register(DBConfig &config, shared_ptr<ExtensionCallback>
 	config.GetCallbackManager().Register(std::move(extension));
 }
 
+void ShellCommandExtension::Register(DBConfig &config, ShellCommandExtension extension) {
+	config.GetCallbackManager().Register(std::move(extension));
+}
+
 void StorageExtension::Register(DBConfig &config, const string &extension_name,
                                 shared_ptr<StorageExtension> extension) {
 	config.GetCallbackManager().Register(extension_name, std::move(extension));
@@ -170,5 +195,6 @@ template class ExtensionCallbackIteratorHelper<shared_ptr<OperatorExtension>>;
 template class ExtensionCallbackIteratorHelper<OptimizerExtension>;
 template class ExtensionCallbackIteratorHelper<ParserExtension>;
 template class ExtensionCallbackIteratorHelper<PlannerExtension>;
+template class ExtensionCallbackIteratorHelper<ShellCommandExtension>;
 
 } // namespace duckdb

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -19,6 +19,7 @@
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/common/atomic.hpp"
 #include "duckdb.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
 
 namespace duckdb_shell {
 using duckdb::make_uniq;
@@ -99,7 +100,6 @@ enum class StartupText { ALL, VERSION, NONE };
 enum class ReadLineVersion { LINENOISE, FALLBACK };
 enum class PagerMode { PAGER_AUTOMATIC, PAGER_ON, PAGER_OFF };
 
-enum class MetadataResult : uint8_t { SUCCESS = 0, FAIL = 1, EXIT = 2, PRINT_USAGE = 3 };
 enum class HighlightMode : uint32_t { AUTOMATIC, MIXED_MODE, DARK_MODE, LIGHT_MODE };
 
 enum class ExecuteSQLSingleValueResult {
@@ -110,26 +110,17 @@ enum class ExecuteSQLSingleValueResult {
 	MULTIPLE_COLUMNS,
 	NULL_RESULT
 };
-
-typedef MetadataResult (*metadata_command_t)(ShellState &state, const vector<string> &args);
+using duckdb::shell_command_t;
+using duckdb::ShellCommand;
+using duckdb::ShellCommandResult;
 
 struct CommandLineOption {
 	const char *option;
 	idx_t argument_count;
 	const char *arguments;
-	metadata_command_t pre_init_callback;
-	metadata_command_t post_init_callback;
+	shell_command_t pre_init_callback;
+	shell_command_t post_init_callback;
 	const char *description;
-};
-
-struct MetadataCommand {
-	const char *command;
-	idx_t argument_count;
-	metadata_command_t callback;
-	const char *usage;
-	const char *description;
-	idx_t match_size;
-	const char *extra_description;
 };
 
 struct ShellColumnInfo {
@@ -157,7 +148,7 @@ enum class AutoFormatMode { NO_AUTO_FORMAT, AUTO_FORMAT_COMPLETE_STATEMENTS };
 ** State information about the database connection is contained in an
 ** instance of the following structure.
 */
-struct ShellState {
+struct ShellState : public duckdb::BaseShellState {
 public:
 	unique_ptr<duckdb::DuckDB> db;            /* The database */
 	unique_ptr<duckdb::Connection> conn;      /* The primary connection to the database */
@@ -304,8 +295,8 @@ public:
 	bool SetOutputFile(const vector<string> &args, char output_mode);
 	bool ReadFromFile(const string &file);
 	bool DisplaySchemas(const vector<string> &args);
-	MetadataResult DisplayEntries(const vector<string> &args, char type);
-	MetadataResult DisplayTables(const vector<string> &args);
+	ShellCommandResult DisplayEntries(const vector<string> &args, char type);
+	ShellCommandResult DisplayTables(const vector<string> &args);
 	void ShowConfiguration();
 	void ClearInterrupt();
 
@@ -410,8 +401,11 @@ public:
 	static string Win32Utf8ToMbcs(const string &zText, bool useAnsi);
 #endif
 	optional_ptr<const CommandLineOption> FindCommandLineOption(const string &option, string &error_msg) const;
-	optional_ptr<const MetadataCommand> FindMetadataCommand(const string &option, string &error_msg) const;
+	optional_ptr<const duckdb::ShellCommand> FindMetadataCommand(const string &option, string &error_msg) const;
 	static vector<string> GetMetadataCompletions(const char *zLine, idx_t nLine);
+
+	//! Auxiliary id for extensions provided commands
+	idx_t current_extension_command_index;
 
 	//! Execute a SQL query
 	// On fail - print the error and returns FAILURE
@@ -427,17 +421,17 @@ public:
 	bool HighlightErrors() const;
 	bool HighlightResults() const;
 
-	static MetadataResult SetNullValue(ShellState &state, const vector<string> &args);
-	static MetadataResult SetSeparator(ShellState &state, const vector<string> &args);
-	static MetadataResult EnableSafeMode(ShellState &state, const vector<string> &args);
-	static MetadataResult ToggleTimer(ShellState &state, const vector<string> &args);
+	static ShellCommandResult SetNullValue(BaseShellState &state, const vector<string> &args);
+	static ShellCommandResult SetSeparator(BaseShellState &state, const vector<string> &args);
+	static ShellCommandResult EnableSafeMode(BaseShellState &state, const vector<string> &args);
+	static ShellCommandResult ToggleTimer(BaseShellState &state, const vector<string> &args);
 	SuccessState ChangeDirectory(const string &path);
 	SuccessState ShowDatabases();
 	void CloseOutputFile(FILE *file);
 	FILE *OpenOutputFile(const char *zFile, int bTextMode);
 	static void SetPrompt(char prompt[], const string &new_value);
 	static string ModeToString(RenderMode mode);
-	MetadataResult FormatSQL(string &sql);
+	ShellCommandResult FormatSQL(string &sql);
 	void HighlightSQL(string &sql);
 	string ReadFileContents(FILE *f);
 	string ReadFileContents(const string &filename);

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -90,6 +90,9 @@
 #include "shell_state.hpp"
 #include "duckdb/main/error_manager.hpp"
 #include "duckdb/main/client_config.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
+#include "duckdb/main/config.hpp"
 
 using namespace duckdb_shell;
 
@@ -1570,15 +1573,18 @@ void ShellState::NewTempFile(const char *zSuffix) {
 	}
 }
 
-MetadataResult ShellState::EnableSafeMode(ShellState &state, const vector<string> &args) {
+ShellCommandResult ShellState::EnableSafeMode(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.safe_mode = true;
 	if (state.db) {
 		// db has been opened - disable external access
 		state.ExecuteQuery("SET enable_external_access=false");
 		state.ExecuteQuery("SET lock_configuration=true");
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
+
+#define ShellCommandResult ShellCommandResult
 
 bool ShellState::SetOutputMode(const string &mode_name, const char *tbl_name) {
 	auto mode_str = mode_name.c_str();
@@ -1651,9 +1657,10 @@ bool ShellState::SetOutputMode(const string &mode_name, const char *tbl_name) {
 	return true;
 }
 
-MetadataResult ShellState::SetNullValue(ShellState &state, const vector<string> &args) {
+ShellCommandResult ShellState::SetNullValue(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.nullValue = args[1];
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
 bool ShellState::ImportData(const vector<string> &args) {
@@ -1911,15 +1918,16 @@ bool ShellState::OpenDatabase(const vector<string> &args) {
 	return true;
 }
 
-MetadataResult ShellState::SetSeparator(ShellState &state, const vector<string> &args) {
+ShellCommandResult ShellState::SetSeparator(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args.size() < 2 || args.size() > 3) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	state.colSeparator = args[1];
 	if (args.size() >= 3) {
 		state.rowSeparator = args[2];
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
 bool ShellState::SetOutputFile(const vector<string> &args, char output_mode) {
@@ -2126,9 +2134,9 @@ void ShellState::ShowConfiguration() {
 	PrintF("%12.12s: %s\n", "filename", zDbFilename.c_str());
 }
 
-MetadataResult ShellState::DisplayTables(const vector<string> &args) {
+ShellCommandResult ShellState::DisplayTables(const vector<string> &args) {
 	if (args.size() > 2) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	// FIXME: copy pasted from below
 	// Parse the filter pattern to check for schema qualification
@@ -2175,7 +2183,7 @@ GROUP BY ALL;
 	auto query_result = con.Query(query);
 	if (query_result->HasError()) {
 		PrintDatabaseError(query_result->GetError());
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
 	vector<ShellTableInfo> result;
 	for (auto &row : *query_result) {
@@ -2205,14 +2213,14 @@ GROUP BY ALL;
 		result.push_back(std::move(table));
 	}
 	RenderTableMetadata(result);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ShellState::DisplayEntries(const vector<string> &args, char type) {
+ShellCommandResult ShellState::DisplayEntries(const vector<string> &args, char type) {
 	string s;
 
 	if (args.size() > 2) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 
 	// Parse the filter pattern to check for schema qualification
@@ -2281,7 +2289,7 @@ WHERE type='index' AND tbl_name LIKE ?1)";
 	auto prepared = con.Prepare(s);
 	if (prepared->HasError()) {
 		PrintDatabaseError(prepared->GetError());
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
 
 	duckdb::vector<duckdb::Value> bind_values;
@@ -2335,7 +2343,7 @@ WHERE type='index' AND tbl_name LIKE ?1)";
 			Print("\n");
 		}
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
 SuccessState ShellState::ChangeDirectory(const string &path) {
@@ -2378,13 +2386,14 @@ SuccessState ShellState::ShowDatabases() {
 	return SuccessState::SUCCESS;
 }
 
-MetadataResult ShellState::ToggleTimer(ShellState &state, const vector<string> &args) {
+ShellCommandResult ShellState::ToggleTimer(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	enableTimer = state.StringToBool(args[1]);
 	if (enableTimer && !HAS_TIMER) {
 		state.PrintF(PrintOutput::STDERR, "Error: timer not available on this system.\n");
 		enableTimer = false;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
 /*
@@ -2453,26 +2462,26 @@ int ShellState::DoMetaCommand(const string &zLine) {
 		rc = 1;
 	} else {
 		auto &command = *metadata_command;
-		MetadataResult result = MetadataResult::PRINT_USAGE;
+		ShellCommandResult result = ShellCommandResult::PRINT_USAGE;
 		try {
 			if (!command.callback) {
 				PrintF(PrintOutput::STDERR, "Command \"%s\" is unsupported in the current version of the CLI\n",
 				       command.command);
-				result = MetadataResult::FAIL;
+				result = ShellCommandResult::FAIL;
 			} else if (command.argument_count == 0 || command.argument_count == args.size()) {
 				result = command.callback(*this, args);
 			}
-			if (result == MetadataResult::PRINT_USAGE) {
+			if (result == ShellCommandResult::PRINT_USAGE) {
 				string error = StringUtil::Format("Invalid Command Error: Invalid usage of command '.%s'\n\n", args[0]);
 				error += StringUtil::Format("Usage: '.%s %s'", command.command, command.usage);
 				PrintDatabaseError(error);
 				rc = 1;
-				result = MetadataResult::FAIL;
+				result = ShellCommandResult::FAIL;
 			}
 		} catch (std::exception &ex) {
 			ErrorData error(ex);
 			PrintDatabaseError(error.Message());
-			result = MetadataResult::FAIL;
+			result = ShellCommandResult::FAIL;
 		}
 		rc = int(result);
 	}
@@ -2891,22 +2900,22 @@ string ShellState::GetDefaultDuckDBRC() {
 	return lfs.JoinPath(GetHomeDirectory(), ".duckdbrc");
 }
 
-MetadataResult ShellState::FormatSQL(string &sql) {
+ShellCommandResult ShellState::FormatSQL(string &sql) {
 	if (sql.empty()) {
 		// no input
-		return MetadataResult::SUCCESS;
+		return ShellCommandResult::SUCCESS;
 	}
 	// Format through the duckdb_format_sql SQL function using a prepared statement.
 	auto result = conn->Query("SELECT duckdb_format_sql($1)", duckdb::Value(sql));
 	if (result->HasError()) {
 		PrintF(PrintOutput::STDERR, "%s: %s\n", program_name, result->GetError().c_str());
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
 	sql = string();
 	for (auto &row : *result) {
 		sql = row.GetValue<string>(0) + "\n";
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
 void ShellState::HighlightSQL(string &sql) {
@@ -3230,7 +3239,7 @@ int RunShell(int argc, const char **argv) {
 		if (option.pre_init_callback) {
 			// invoke the pre-init callback (if any)
 			auto result = option.pre_init_callback(data, arguments);
-			if (result == MetadataResult::EXIT) {
+			if (result == ShellCommandResult::EXIT) {
 				return 0;
 			}
 		}
@@ -3275,7 +3284,7 @@ int RunShell(int argc, const char **argv) {
 			continue;
 		}
 		auto result = option.post_init_callback(data, call.arguments);
-		if (result == MetadataResult::EXIT) {
+		if (result == ShellCommandResult::EXIT) {
 			return 0;
 		}
 	}

--- a/tools/shell/shell_command_line_option.cpp
+++ b/tools/shell/shell_command_line_option.cpp
@@ -8,99 +8,118 @@ namespace duckdb_shell {
 #define SEP_Unit   "\x1F"
 #define SEP_Record "\x1E"
 
+using duckdb::BaseShellState;
+using duckdb::ShellCommandResult;
+
 template <RenderMode output_mode>
-MetadataResult ToggleOutputMode(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleOutputMode(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.cMode = state.mode = output_mode;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleASCIIMode(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleASCIIMode(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.cMode = state.mode = RenderMode::ASCII;
 	state.colSeparator = SEP_Unit;
 	state.rowSeparator = SEP_Record;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleCSVMode(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleCSVMode(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.cMode = state.mode = RenderMode::CSV;
 	state.colSeparator = ",";
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult EnableBail(ShellState &state, const vector<string> &args) {
+ShellCommandResult EnableBail(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.bail = BailOnError::BAIL_ON_ERROR;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult EnableBatch(ShellState &state, const vector<string> &args) {
+ShellCommandResult EnableBatch(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.stdin_is_interactive = false;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult DisableBatch(ShellState &state, const vector<string> &args) {
+ShellCommandResult DisableBatch(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.stdin_is_interactive = true;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetReadOnlyMode(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetReadOnlyMode(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.config.options.access_mode = duckdb::AccessMode::READ_ONLY;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
 template <bool HEADER>
-MetadataResult ToggleHeader(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleHeader(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.showHeader = HEADER;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult DisableStdin(ShellState &state, const vector<string> &args) {
+ShellCommandResult DisableStdin(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.readStdin = false;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult EnableEcho(ShellState &state, const vector<string> &args) {
+ShellCommandResult EnableEcho(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.ShellSetFlag(ShellFlags::SHFLG_Echo);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult AllowUnredacted(ShellState &state, const vector<string> &args) {
+ShellCommandResult AllowUnredacted(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.config.SetOptionByName("allow_unredacted_secrets", true);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult AllowUnsigned(ShellState &state, const vector<string> &args) {
+ShellCommandResult AllowUnsigned(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.config.SetOptionByName("allow_unsigned_extensions", true);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ShowVersionAndExit(ShellState &state, const vector<string> &args) {
+ShellCommandResult ShowVersionAndExit(BaseShellState &, const vector<string> &args) {
 	printf("%s (%s) %s\n", duckdb::DuckDB::LibraryVersion(), duckdb::DuckDB::ReleaseCodename(),
 	       duckdb::DuckDB::SourceID());
-	return MetadataResult::EXIT;
+	return ShellCommandResult::EXIT;
 }
 
-MetadataResult PrintHelpAndExit(ShellState &state, const vector<string> &args) {
+ShellCommandResult PrintHelpAndExit(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.PrintUsage();
-	return MetadataResult::EXIT;
+	return ShellCommandResult::EXIT;
 }
 
-MetadataResult LaunchUI(ShellState &state, const vector<string> &args) {
+ShellCommandResult LaunchUI(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	// run the UI command
 	auto rc = state.RunInitialCommand((char *)state.ui_command.c_str(), true);
 	if (rc != 0) {
 		ShellState::Exit(rc);
-		return MetadataResult::EXIT;
+		return ShellCommandResult::EXIT;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetNewlineSeparator(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetNewlineSeparator(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	// run the UI command
 	state.rowSeparator = args[1];
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetStorageVersion(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetStorageVersion(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	auto &storage_version = args[1];
 	try {
 		state.config.options.serialization_compatibility =
@@ -109,33 +128,37 @@ MetadataResult SetStorageVersion(ShellState &state, const vector<string> &args) 
 		duckdb::ErrorData error(ex);
 		state.PrintF(PrintOutput::STDERR, "%s: Error: unknown argument (%s) for '-storage-version': %s\n",
 		             state.program_name, storage_version.c_str(), error.Message().c_str());
-		return MetadataResult::EXIT;
+		return ShellCommandResult::EXIT;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ProcessFile(ShellState &state, const vector<string> &args) {
+ShellCommandResult ProcessFile(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.readStdin = false;
 	auto &file = args[1];
 	if (!state.ProcessFile(file)) {
 		ShellState::Exit(1);
-		return MetadataResult::EXIT;
+		return ShellCommandResult::EXIT;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetInitFile(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetInitFile(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.initFile = args[1];
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SkipInit(ShellState &state, const vector<string> &args) {
+ShellCommandResult SkipInit(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.run_init = false;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
 template <bool EXIT>
-MetadataResult RunCommand(ShellState &state, const vector<string> &args) {
+ShellCommandResult RunCommand(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (EXIT) {
 		state.readStdin = false;
 	}
@@ -148,48 +171,50 @@ MetadataResult RunCommand(ShellState &state, const vector<string> &args) {
 	auto rc = state.RunInitialCommand(cmd.c_str(), bail);
 	if (rc != 0) {
 		ShellState::Exit(rc);
-		return MetadataResult::EXIT;
+		return ShellCommandResult::EXIT;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult FormatStdin(ShellState &state, const vector<string> &args) {
+ShellCommandResult FormatStdin(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.readStdin = false;
 
 	if (duckdb::Terminal::IsAtty()) {
 		state.PrintF(PrintOutput::STDERR,
 		             "%s: Error: -format requires SQL input on stdin (e.g. echo 'SELECT 1' | duckdb -format)\n",
 		             state.program_name);
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
 
 	// Read all of stdin into a string.
 	string sql = state.ReadFileContents(stdin);
 
 	auto result = state.FormatSQL(sql);
-	if (result != MetadataResult::SUCCESS) {
+	if (result != ShellCommandResult::SUCCESS) {
 		return result;
 	}
 
 	// Write formatted SQL to stdout, with syntax highlighting if stdout is a terminal.
 	state.HighlightSQL(sql);
 	state.Print(PrintOutput::STDOUT, sql);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult FormatFile(ShellState &state, const vector<string> &args) {
+ShellCommandResult FormatFile(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.readStdin = false;
 	const string &filename = args[1];
 
 	string sql = state.ReadFileContents(filename);
 
 	auto result = state.FormatSQL(sql);
-	if (result != MetadataResult::SUCCESS) {
+	if (result != ShellCommandResult::SUCCESS) {
 		return result;
 	}
 	state.HighlightSQL(sql);
 	state.Print(PrintOutput::STDOUT, sql);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
 static const CommandLineOption command_line_options[] = {

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -599,14 +599,6 @@ ShellCommandResult SetUICommand(BaseShellState &base_state, const vector<string>
 	return ShellCommandResult::SUCCESS;
 }
 
-#if defined(_WIN32) || defined(WIN32)
-ShellCommandResult SetUTF8Mode(BaseShellState &base_state, const vector<string> &args) {
-	auto &state = static_cast<ShellState &>(base_state);
-	state.win_utf8_mode = true;
-	return ShellCommandResult::SUCCESS;
-}
-#endif
-
 ShellCommandResult ToggleHighlighting(BaseShellState &base_state, const vector<string> &args) {
 	auto &state = static_cast<ShellState &>(base_state);
 	ShellHighlight::SetHighlighting(state.StringToBool(args[1]));

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -3,6 +3,10 @@
 #include "shell_prompt.hpp"
 #include "shell_progress_bar.hpp"
 #include "shell_renderer.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
+#include "duckdb/main/config.hpp"
 
 #ifdef HAVE_LINENOISE
 #include "linenoise.h"
@@ -11,7 +15,10 @@
 
 namespace duckdb_shell {
 
-MetadataResult ToggleAbout(ShellState &state, const vector<string> &args) {
+using duckdb::BaseShellState;
+
+ShellCommandResult ToggleAbout(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	string about_text = "DuckDB is an in-process analytical database management system designed for fast "
 	                    "execution of complex SQL queries. It runs embedded within its host process with "
 	                    "no external dependencies, and is optimized for OLAP workloads using a columnar, "
@@ -24,10 +31,11 @@ MetadataResult ToggleAbout(ShellState &state, const vector<string> &args) {
 	state.PrintF(PrintOutput::STDOUT, "DuckDB %s (%s)\n\n", duckdb::DuckDB::LibraryVersion(),
 	             duckdb::DuckDB::ReleaseCodename());
 	state.Print(PrintOutput::STDOUT, about_text);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleBail(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleBail(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args[1] == "auto") {
 		state.bail = BailOnError::AUTOMATIC;
 	} else if (state.StringToBool(args[1])) {
@@ -35,65 +43,73 @@ MetadataResult ToggleBail(ShellState &state, const vector<string> &args) {
 	} else {
 		state.bail = BailOnError::DONT_BAIL_ON_ERROR;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleBinary(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleBinary(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (state.StringToBool(args[1])) {
 		state.SetBinaryMode();
 	} else {
 		state.SetTextMode();
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ChangeDirectory(ShellState &state, const vector<string> &args) {
+ShellCommandResult ChangeDirectory(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (state.safe_mode) {
 		state.PrintF(PrintOutput::STDERR, ".cd cannot be used in -safe mode\n");
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
 	auto result = state.ChangeDirectory(args[1]);
-	return result == SuccessState::SUCCESS ? MetadataResult::SUCCESS : MetadataResult::FAIL;
+	return result == SuccessState::SUCCESS ? ShellCommandResult::SUCCESS : ShellCommandResult::FAIL;
 }
 
-MetadataResult ToggleChanges(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleChanges(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.SetOrClearFlag(ShellFlags::SHFLG_CountChanges, args[1]);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ShowDatabases(ShellState &state, const vector<string> &args) {
+ShellCommandResult ShowDatabases(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	auto result = state.ShowDatabases();
-	return result == SuccessState::SUCCESS ? MetadataResult::SUCCESS : MetadataResult::FAIL;
+	return result == SuccessState::SUCCESS ? ShellCommandResult::SUCCESS : ShellCommandResult::FAIL;
 }
 
-MetadataResult SetSeparator(ShellState &state, const vector<string> &args, const char *separator_name,
-                            char &separator) {
+ShellCommandResult SetSeparator(BaseShellState &base_state, const vector<string> &args, const char *separator_name,
+                                char &separator) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args.size() == 1) {
 		state.PrintF("current %s separator: %c\n", separator_name, separator);
 	} else if (args.size() != 2) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	} else if (StringUtil::Equals(args[1], "space")) {
 		separator = ' ';
 	} else if (StringUtil::Equals(args[1], "none")) {
 		separator = '\0';
 	} else if (args[1].size() != 1) {
 		state.PrintF(PrintOutput::STDERR, ".%s_sep SEP must be one byte, \"space\" or \"none\"\n", separator_name);
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	} else {
 		separator = args[1][0];
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetDecimalSep(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetDecimalSep(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	return SetSeparator(state, args, "decimal", state.decimal_separator);
 }
 
-MetadataResult SetThousandSep(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetThousandSep(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	return SetSeparator(state, args, "thousand", state.thousand_separator);
 }
 
-MetadataResult SetLargeNumberRendering(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetLargeNumberRendering(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (StringUtil::Equals(args[1], "all")) {
 		state.large_number_rendering = LargeNumberRendering::ALL;
 	} else if (StringUtil::Equals(args[1], "footer")) {
@@ -105,10 +121,11 @@ MetadataResult SetLargeNumberRendering(ShellState &state, const vector<string> &
 			state.large_number_rendering = LargeNumberRendering::NONE;
 		}
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult DumpTable(ShellState &state, const vector<string> &args) {
+ShellCommandResult DumpTable(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	string zLike;
 	bool savedShowHeader = state.showHeader;
 	int savedShellFlags = state.shellFlgs;
@@ -124,7 +141,7 @@ MetadataResult DumpTable(ShellState &state, const vector<string> &args) {
 				state.ShellSetFlag(ShellFlags::SHFLG_Newlines);
 			} else {
 				state.PrintF(PrintOutput::STDERR, "Unknown option \"%s\" on \".dump\"\n", args[i].c_str());
-				return MetadataResult::FAIL;
+				return ShellCommandResult::FAIL;
 			}
 		} else if (!zLike.empty()) {
 			zLike = StringUtil::Format("%s OR name LIKE %s ESCAPE '\\'", zLike, SQLString(args[i]));
@@ -168,58 +185,64 @@ MetadataResult DumpTable(ShellState &state, const vector<string> &args) {
 	state.PrintF(state.nErr ? "ROLLBACK; -- due to errors\n" : "COMMIT;\n");
 	state.showHeader = savedShowHeader;
 	state.shellFlgs = savedShellFlags;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleEcho(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleEcho(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.SetOrClearFlag(ShellFlags::SHFLG_Echo, args[1]);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleAutoFormat(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleAutoFormat(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (state.StringToBool(args[1])) {
 		state.auto_format = AutoFormatMode::AUTO_FORMAT_COMPLETE_STATEMENTS;
 	} else {
 		state.auto_format = AutoFormatMode::NO_AUTO_FORMAT;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ExitProcess(ShellState &state, const vector<string> &args) {
+ShellCommandResult ExitProcess(BaseShellState &, const vector<string> &args) {
 	if (args.size() > 2) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	int rc = 0;
 	if (args.size() > 1 && (rc = (int)ShellState::StringToInt(args[1])) != 0) {
 		// exit immediately if a custom error code is provided
 		ShellState::Exit(rc);
 	}
-	return MetadataResult::EXIT;
+	return ShellCommandResult::EXIT;
 }
 
-MetadataResult ToggleHeaders(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleHeaders(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.showHeader = state.StringToBool(args[1]);
 	state.ShellSetFlag(ShellFlags::SHFLG_HeaderSet);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetHighlightColors(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetHighlightColors(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args.size() < 3 || args.size() > 4) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	ShellHighlight highlighter(state);
 	if (!highlighter.SetColor(args[1].c_str(), args[2].c_str(), args.size() == 3 ? nullptr : args[3].c_str())) {
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleHighlighErrors(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleHighlighErrors(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.highlight_errors = state.StringToBool(args[1]) ? OptionType::ON : OptionType::OFF;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleHighlightMode(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleHighlightMode(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args[1] == "mixed") {
 		state.highlight_mode = HighlightMode::MIXED_MODE;
 	} else if (args[1] == "dark") {
@@ -229,19 +252,21 @@ MetadataResult ToggleHighlightMode(ShellState &state, const vector<string> &args
 	} else if (args[1] == "auto") {
 		state.highlight_mode = HighlightMode::AUTOMATIC;
 	} else {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	ShellHighlight highlight(state);
 	highlight.ToggleMode(state.highlight_mode);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleHighlightResult(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleHighlightResult(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.highlight_results = state.StringToBool(args[1]) ? OptionType::ON : OptionType::OFF;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ShowHelp(ShellState &state, const vector<string> &args) {
+ShellCommandResult ShowHelp(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args.size() >= 2) {
 #ifdef HAVE_LINENOISE
 		if (duckdb::StringUtil::CIEquals(args[1], "shortcuts")) {
@@ -259,7 +284,7 @@ MetadataResult ShowHelp(ShellState &state, const vector<string> &args) {
 				}
 				state.PrintF("  %-24s %s\n", entry.key_name, entry.description);
 			}
-			return MetadataResult::SUCCESS;
+			return ShellCommandResult::SUCCESS;
 		}
 #endif
 		idx_t n = state.PrintHelp(args[1].c_str());
@@ -269,84 +294,93 @@ MetadataResult ShowHelp(ShellState &state, const vector<string> &args) {
 	} else {
 		state.PrintHelp(0);
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult RenderLastResult(ShellState &state, const vector<string> &args) {
+ShellCommandResult RenderLastResult(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (state.last_result) {
 		auto renderer = state.GetRenderer();
 		renderer->RemoveRenderLimits();
 		auto res = state.RenderQueryResult(*renderer, *state.last_result);
 		if (res == SuccessState::FAILURE) {
-			return MetadataResult::FAIL;
+			return ShellCommandResult::FAIL;
 		}
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleLog(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleLog(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (state.safe_mode) {
 		state.PrintF(PrintOutput::STDERR, ".log cannot be used in -safe mode\n");
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
 	const char *zFile = args[1].c_str();
 	state.CloseOutputFile(state.pLog);
 	state.pLog = state.OpenOutputFile(zFile, 0);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetMaxRows(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetMaxRows(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args.size() > 3) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	if (args.size() == 1) {
 		state.PrintF("current max rows: %zu\n", state.max_rows);
-		return MetadataResult::SUCCESS;
+		return ShellCommandResult::SUCCESS;
 	}
 	state.max_rows = (size_t)ShellState::StringToInt(args[1]);
 	if (args.size() > 2) {
 		state.max_analyze_rows = (size_t)ShellState::StringToInt(args[2]);
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetMaxWidth(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetMaxWidth(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args.size() > 2) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	if (args.size() == 1) {
 		state.PrintF("current max rows: %zu\n", state.max_width);
 	} else {
 		state.max_width = (size_t)ShellState::StringToInt(args[1]);
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetColumnRendering(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetColumnRendering(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.columns = 1;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetRowRendering(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetRowRendering(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.columns = 0;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ImportData(ShellState &state, const vector<string> &args) {
+ShellCommandResult ImportData(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (!state.ImportData(args)) {
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult OpenDatabase(ShellState &state, const vector<string> &args) {
+ShellCommandResult OpenDatabase(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (!state.OpenDatabase(args)) {
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult PrintArguments(ShellState &state, const vector<string> &args) {
+ShellCommandResult PrintArguments(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	for (idx_t i = 1; i < args.size(); i++) {
 		if (i > 1) {
 			state.PrintF(" ");
@@ -354,7 +388,7 @@ MetadataResult PrintArguments(ShellState &state, const vector<string> &args) {
 		state.PrintF("%s", args[i].c_str());
 	}
 	state.PrintF("\n");
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
 void ShellState::SetPrompt(char *prompt, const string &new_value) {
@@ -362,7 +396,8 @@ void ShellState::SetPrompt(char *prompt, const string &new_value) {
 	prompt[MAX_PROMPT_SIZE - 1] = '\0';
 }
 
-MetadataResult SetPrompt(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetPrompt(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args.size() >= 2) {
 		auto new_prompt = make_uniq<Prompt>();
 		new_prompt->ParsePrompt(args[1]);
@@ -380,90 +415,98 @@ MetadataResult SetPrompt(ShellState &state, const vector<string> &args) {
 	if (args.size() >= 6) {
 		ShellState::SetPrompt(state.scrollDownPrompt, args[5]);
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ConfigureProgressBar(ShellState &state, const vector<string> &args) {
+ShellCommandResult ConfigureProgressBar(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args.size() < 2 || args.size() > 3) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	if (args[1] == "--clear") {
 		if (args.size() != 2) {
-			return MetadataResult::PRINT_USAGE;
+			return ShellCommandResult::PRINT_USAGE;
 		}
 		state.progress_bar->ClearComponents();
 	} else if (args[1] == "--add") {
 		if (args.size() != 3) {
-			return MetadataResult::PRINT_USAGE;
+			return ShellCommandResult::PRINT_USAGE;
 		}
 		state.progress_bar->AddComponent(args[2]);
 	} else {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetOutputMode(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetOutputMode(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args.size() > 3) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	if (args.size() == 1) {
 		state.PrintF("current output mode: %s\n", ShellState::ModeToString(state.mode));
 	} else {
 		if (!state.SetOutputMode(args[1], args.size() > 2 ? args[2].c_str() : nullptr)) {
-			return MetadataResult::FAIL;
+			return ShellCommandResult::FAIL;
 		}
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult QuitProcess(ShellState &, const vector<string> &args) {
-	return MetadataResult::EXIT;
+ShellCommandResult QuitProcess(BaseShellState &, const vector<string> &args) {
+	return ShellCommandResult::EXIT;
 }
 
-MetadataResult SetOutput(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetOutput(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (!state.SetOutputFile(args, '\0')) {
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetOutputOnce(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetOutputOnce(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (!state.SetOutputFile(args, 'o')) {
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetOutputExcel(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetOutputExcel(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (!state.SetOutputFile(args, 'e')) {
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ReadFromFile(ShellState &state, const vector<string> &args) {
+ShellCommandResult ReadFromFile(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (!state.ReadFromFile(args[1])) {
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult DisplaySchemas(ShellState &state, const vector<string> &args) {
+ShellCommandResult DisplaySchemas(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (!state.DisplaySchemas(args)) {
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult RunShellCommand(ShellState &state, const vector<string> &args) {
+ShellCommandResult RunShellCommand(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (state.safe_mode) {
 		state.Print(PrintOutput::STDERR, ".sh/.system cannot be used in -safe mode\n");
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 	}
 	int x;
 	if (args.size() < 2) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	auto zCmd = StringUtil::Format(StringUtil::Contains(args[1], ' ') ? "%s" : "\"%s\"", args[1]);
 	for (idx_t i = 2; i < args.size(); i++) {
@@ -473,15 +516,17 @@ MetadataResult RunShellCommand(ShellState &state, const vector<string> &args) {
 	if (x) {
 		state.PrintF(PrintOutput::STDERR, "System command returns %d\n", x);
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ShowConfiguration(ShellState &state, const vector<string> &args) {
+ShellCommandResult ShowConfiguration(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.ShowConfiguration();
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetStartupText(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetStartupText(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	auto prev_display = state.startup_text;
 	if (args[1] == "all") {
 		state.startup_text = StartupText::ALL;
@@ -490,7 +535,7 @@ MetadataResult SetStartupText(ShellState &state, const vector<string> &args) {
 	} else if (args[1] == "none") {
 		state.startup_text = StartupText::NONE;
 	} else {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	if (state.displayed_loading_resources_message && prev_display == StartupText::ALL &&
 	    state.startup_text != StartupText::ALL) {
@@ -499,10 +544,11 @@ MetadataResult SetStartupText(ShellState &state, const vector<string> &args) {
 		                 "prevent the \"Loading resources\" message from being displayed\n";
 		highlight.PrintText(warning, PrintOutput::STDERR, HighlightElementType::STARTUP_TEXT);
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ShowVersion(ShellState &state, const vector<string> &args) {
+ShellCommandResult ShowVersion(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.PrintF("DuckDB %s (%s) %s\n" /*extra-version-info*/, duckdb::DuckDB::LibraryVersion(),
 	             duckdb::DuckDB::ReleaseCodename(), duckdb::DuckDB::SourceID());
 #define CTIMEOPT_VAL_(opt) #opt
@@ -515,28 +561,32 @@ MetadataResult ShowVersion(ShellState &state, const vector<string> &args) {
 #elif defined(__GNUC__) && defined(__VERSION__)
 	state.PrintF("gcc-" __VERSION__ "\n");
 #endif
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetWidths(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetWidths(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	state.colWidth.clear();
 	for (idx_t j = 1; j < args.size(); j++) {
 		state.colWidth.push_back((int)ShellState::StringToInt(args[j]));
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ShowIndexes(ShellState &state, const vector<string> &args) {
+ShellCommandResult ShowIndexes(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	return state.DisplayEntries(args, 'i');
 }
 
-MetadataResult ShowTables(ShellState &state, const vector<string> &args) {
+ShellCommandResult ShowTables(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	return state.DisplayTables(args);
 }
 
-MetadataResult SetUICommand(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetUICommand(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args.size() < 1) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	string command;
 	for (idx_t i = 1; i < args.size(); i++) {
@@ -546,42 +596,54 @@ MetadataResult SetUICommand(ShellState &state, const vector<string> &args) {
 		command += args[i];
 	}
 	state.ui_command = "CALL " + command;
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleHighlighting(ShellState &state, const vector<string> &args) {
+#if defined(_WIN32) || defined(WIN32)
+ShellCommandResult SetUTF8Mode(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
+	state.win_utf8_mode = true;
+	return ShellCommandResult::SUCCESS;
+}
+#endif
+
+ShellCommandResult ToggleHighlighting(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	ShellHighlight::SetHighlighting(state.StringToBool(args[1]));
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
 #ifdef HAVE_LINENOISE
-MetadataResult ToggleErrorRendering(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleErrorRendering(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	linenoiseSetErrorRendering(state.StringToBool(args[1]));
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleCompletionRendering(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleCompletionRendering(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	linenoiseSetCompletionRendering(state.StringToBool(args[1]));
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleMultiLine(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleMultiLine(BaseShellState &, const vector<string> &args) {
 	if (args.size() != 1) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	linenoiseSetMultiLine(true);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult ToggleSingleLine(ShellState &state, const vector<string> &args) {
+ShellCommandResult ToggleSingleLine(BaseShellState &, const vector<string> &args) {
 	if (args.size() != 1) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	linenoiseSetMultiLine(false);
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult TrySetHighlightColor(ShellState &state, const string &component, const string &code) {
+ShellCommandResult TrySetHighlightColor(BaseShellState &base_state, const string &component, const string &code) {
+	auto &state = static_cast<ShellState &>(base_state);
 	vector<string> args;
 	args.push_back("highlight_colors");
 	args.push_back(component);
@@ -599,7 +661,8 @@ enum class DeprecatedHighlightColors {
 };
 
 template <DeprecatedHighlightColors T>
-MetadataResult SetHighlightingColor(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetHighlightingColor(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	string literal;
 	switch (T) {
 	case DeprecatedHighlightColors::COMMENT:
@@ -678,7 +741,8 @@ idx_t FindColorGroup(const vector<vector<string>> &groups, const string &name) {
 	return group_idx.GetIndex();
 }
 
-MetadataResult DisplayColors(ShellState &state, const vector<string> &args) {
+ShellCommandResult DisplayColors(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	bool bold = false;
 	bool underline = false;
 	for (idx_t i = 1; i < args.size(); i++) {
@@ -687,7 +751,7 @@ MetadataResult DisplayColors(ShellState &state, const vector<string> &args) {
 		} else if (args[i] == "underline") {
 			underline = true;
 		} else {
-			return MetadataResult::PRINT_USAGE;
+			return ShellCommandResult::PRINT_USAGE;
 		}
 	}
 	PrintIntensity intensity = PrintIntensity::STANDARD;
@@ -743,26 +807,28 @@ MetadataResult DisplayColors(ShellState &state, const vector<string> &args) {
 		state.Print(" ");
 	}
 	state.Print("\n");
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-MetadataResult SetReadLineVersion(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetReadLineVersion(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args[1] == "linenoise") {
 #ifdef HAVE_LINENOISE
 		state.rl_version = ReadLineVersion::LINENOISE;
-		return MetadataResult::SUCCESS;
+		return ShellCommandResult::SUCCESS;
 #else
 		state.Print("linenoise is not available in this build");
-		return MetadataResult::FAIL;
+		return ShellCommandResult::FAIL;
 #endif
 	} else if (args[1] == "fallback") {
 		state.rl_version = ReadLineVersion::FALLBACK;
-		return MetadataResult::SUCCESS;
+		return ShellCommandResult::SUCCESS;
 	}
-	return MetadataResult::PRINT_USAGE;
+	return ShellCommandResult::PRINT_USAGE;
 }
 
-MetadataResult SetPager(ShellState &state, const vector<string> &args) {
+ShellCommandResult SetPager(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
 	if (args.size() == 1) {
 		// Show current pager status
 		string mode_str;
@@ -790,18 +856,18 @@ MetadataResult SetPager(ShellState &state, const vector<string> &args) {
 		if (state.pager_mode != PagerMode::PAGER_OFF || !state.pager_command.empty()) {
 			state.PrintF("Pager command: %s\n", state.pager_command);
 		}
-		return MetadataResult::SUCCESS;
+		return ShellCommandResult::SUCCESS;
 	}
 	if (args[1] == "set_row_threshold") {
 		if (args.size() != 3) {
-			return MetadataResult::PRINT_USAGE;
+			return ShellCommandResult::PRINT_USAGE;
 		}
 		idx_t limit = (idx_t)state.StringToInt(args[2]);
 		state.pager_min_rows = limit;
-		return MetadataResult::SUCCESS;
+		return ShellCommandResult::SUCCESS;
 	}
 	if (args.size() != 2) {
-		return MetadataResult::PRINT_USAGE;
+		return ShellCommandResult::PRINT_USAGE;
 	}
 	if (args[1] == "on") {
 		state.pager_mode = PagerMode::PAGER_ON;
@@ -815,10 +881,10 @@ MetadataResult SetPager(ShellState &state, const vector<string> &args) {
 	} else {
 		state.pager_command = args[1];
 	}
-	return MetadataResult::SUCCESS;
+	return ShellCommandResult::SUCCESS;
 }
 
-static const MetadataCommand metadata_commands[] = {
+static const duckdb::ShellCommand metadata_commands[] = {
     {"about", 0, ToggleAbout, "", "Show information about DuckDB", 0, ""},
 #ifdef HAVE_LINENOISE
     {"auto_format", 2, ToggleAutoFormat, "on|off", "Automatically format SQL before execution.  Default OFF", 3, ""},
@@ -955,12 +1021,13 @@ static const MetadataCommand metadata_commands[] = {
     {"width", 0, SetWidths, "NUM1 NUM2 ...", "Set minimum column widths for columnar output", 0,
      "Negative values right-justify"},
 #if defined(_WIN32) || defined(WIN32)
-    {"utf8", 1, [](ShellState &, const vector<string> &) -> MetadataResult { return MetadataResult::SUCCESS; }, "",
+    {"utf8", 1,
+     [](BaseShellState &, const vector<string> &) -> ShellCommandResult { return ShellCommandResult::SUCCESS; }, "",
      "Deprecated. This option is accepted for compatibility but has no effect.", 0, ""},
 #endif
     {nullptr, 0, nullptr, 0, nullptr}};
 
-bool ShouldPrintCommand(const MetadataCommand &command, const string &glob_pattern) {
+bool ShouldPrintCommand(const duckdb::ShellCommand &command, const string &glob_pattern) {
 	if (!command.extra_description) {
 		return false;
 	}
@@ -1063,6 +1130,22 @@ idx_t ShellState::PrintHelp(const char *pattern) {
 			}
 		}
 	}
+	// also include extension-registered shell commands
+	if (db) {
+		auto &mgr = duckdb::ExtensionCallbackManager::Get(*db->instance);
+		for (auto &ext_cmd : mgr.ShellCommandExtensions()) {
+			if (!glob_pattern.empty() && !ShellState::StringGlob(glob_pattern.c_str(), ext_cmd.command.c_str())) {
+				continue;
+			}
+			PrintCommandInfo print_info;
+			print_info.command_name = StringUtil::Format(".%s", ext_cmd.command);
+			print_info.first_part += StringUtil::Format(" %s", ext_cmd.usage);
+			print_info.second_part = ext_cmd.description;
+			print_info.first_part_highlight = HighlightElementType::STRING_CONSTANT;
+			print_info_list.push_back(std::move(print_info));
+		}
+	}
+
 	// figure out alignment based on the total first part print size
 	idx_t max_lhs_size = 0;
 	for (auto &print_info : print_info_list) {
@@ -1100,32 +1183,68 @@ idx_t ShellState::PrintHelp(const char *pattern) {
 	return print_info_list.size();
 }
 
-vector<string> ShellState::GetMetadataCompletions(const char *zLine, idx_t nLine) {
+static void AppendDotCompletion(vector<string> &result, const char *cmd_name, const char *zLine, idx_t nLine) {
 	char zBuf[1000];
+	zBuf[0] = '.';
+	idx_t line_pos;
+	bool found_match = true;
+	for (line_pos = 0; cmd_name[line_pos] && !ShellState::IsSpace(cmd_name[line_pos]) && line_pos + 2 < sizeof(zBuf);
+	     line_pos++) {
+		zBuf[line_pos + 1] = cmd_name[line_pos];
+		if (line_pos + 1 < nLine && cmd_name[line_pos] != zLine[line_pos + 1]) {
+			found_match = false;
+			break;
+		}
+	}
+	zBuf[line_pos + 1] = '\0';
+	if (found_match && line_pos + 1 >= nLine) {
+		result.push_back(zBuf);
+	}
+}
+
+vector<string> ShellState::GetMetadataCompletions(const char *zLine, idx_t nLine) {
 	vector<string> result;
 	for (idx_t c = 0; metadata_commands[c].command; c++) {
-		auto &command = metadata_commands[c];
-		auto &line = command.command;
-		bool found_match = true;
-		idx_t line_pos;
-		zBuf[0] = '.';
-		for (line_pos = 0; !IsSpace(line[line_pos]) && line[line_pos] && line_pos + 2 < sizeof(zBuf); line_pos++) {
-			zBuf[line_pos + 1] = line[line_pos];
-			if (line_pos + 1 < nLine && line[line_pos] != zLine[line_pos + 1]) {
-				// only match prefixes for auto-completion, i.e. ".sh" matches ".shell"
-				found_match = false;
-				break;
-			}
-		}
-		zBuf[line_pos + 1] = '\0';
-		if (found_match && line_pos + 1 >= nLine) {
-			result.push_back(zBuf);
+		AppendDotCompletion(result, metadata_commands[c].command, zLine, nLine);
+	}
+	// also include extension-registered shell commands
+	auto &state = ShellState::Get();
+	if (state.db) {
+		auto &mgr = duckdb::ExtensionCallbackManager::Get(*state.db->instance);
+		for (auto &ext_cmd : mgr.ShellCommandExtensions()) {
+			AppendDotCompletion(result, ext_cmd.command.c_str(), zLine, nLine);
 		}
 	}
 	return result;
 }
 
-optional_ptr<const MetadataCommand> ShellState::FindMetadataCommand(const string &option, string &error_msg) const {
+ShellCommandResult RunExtensionCommand(BaseShellState &base_state, const vector<string> &args) {
+	auto &state = static_cast<ShellState &>(base_state);
+	if (state.safe_mode) {
+		state.Print(PrintOutput::STDERR, "Extension provided commands can't be executed in -safe mode\n");
+		return ShellCommandResult::FAIL;
+	}
+
+	const idx_t extension_command_index = state.current_extension_command_index;
+
+	auto &mgr = duckdb::ExtensionCallbackManager::Get(*state.db->instance);
+
+	const duckdb::ShellCommandExtension &command = *(mgr.ShellCommandExtensions().begin() + extension_command_index);
+
+	if (!command.callback) {
+		state.Print(PrintOutput::STDERR, "Extension provided commands can't be executed due to missing callback\n");
+		return ShellCommandResult::FAIL;
+	}
+	try {
+		return command.callback(*state.db->instance, args, command.info);
+	} catch (...) {
+		state.Print(PrintOutput::STDERR, "Extension provided commands was execute but failed in an uncontrolled way, "
+		                                 "for caution, terminating the process\n");
+		return ShellCommandResult::FAIL;
+	}
+}
+optional_ptr<const duckdb::ShellCommand> ShellState::FindMetadataCommand(const string &option,
+                                                                         string &error_msg) const {
 	idx_t n = option.size();
 	for (idx_t command_idx = 0; metadata_commands[command_idx].command; command_idx++) {
 		auto &command = metadata_commands[command_idx];
@@ -1135,6 +1254,18 @@ optional_ptr<const MetadataCommand> ShellState::FindMetadataCommand(const string
 		}
 		return command;
 	}
+	if (db) {
+		auto &mgr = duckdb::ExtensionCallbackManager::Get(*db->instance);
+		idx_t index = 0;
+		for (auto &ext_cmd : mgr.ShellCommandExtensions()) {
+			if (StringUtil::StartsWith(option, ext_cmd.command)) {
+				ext_cmd.Finalize(index);
+				ext_cmd.inner_command.callback = RunExtensionCommand;
+				return ext_cmd.inner_command;
+			}
+			index++;
+		}
+	}
 	// no command found
 	error_msg = StringUtil::Format("Unknown Command Error: Unrecognized command '%s'\n", option);
 
@@ -1142,6 +1273,13 @@ optional_ptr<const MetadataCommand> ShellState::FindMetadataCommand(const string
 	for (idx_t command_idx = 0; metadata_commands[command_idx].command; command_idx++) {
 		auto &command = metadata_commands[command_idx];
 		command_names.push_back(string(".") + command.command);
+	}
+	// include extension-registered commands in the candidates list
+	if (db) {
+		auto &mgr = duckdb::ExtensionCallbackManager::Get(*db->instance);
+		for (auto &ext_cmd : mgr.ShellCommandExtensions()) {
+			command_names.push_back("." + ext_cmd.command);
+		}
 	}
 	auto candidates_msg = StringUtil::CandidatesErrorMessage(command_names, option, "Did you mean");
 	error_msg += candidates_msg + "\n";


### PR DESCRIPTION
A demo branch, adding support for .icu command in the icu extension is available at https://github.com/carlopi/duckdb/tree/refs/heads/dot_command_icu
```
memory D .icu
Usage:
  .icu calendar              Show the current calendar
  .icu calendar list         List available calendars
  .icu calendar set NAME     Set the active calendars
  .icu version               Print icu library version
memory D .icu version
ICU database version is currently: 77-1
```

I don't plan on adding a `.icu` command, but I could see other ones as valuable additions.
`.shell` (or it's alias `.sh`) could be for example provided by the `shell` extension. Or maybe a `.aws`, or other CLI tools might be relevant to invoke in the context of a duckdb session.

Components of the PR:
1. move some classes / logic from tools/shell to core (ShellCommand / ShellCommandResult instead of MetadataCommand / MetadataCommandResult)
2. add a new callback, that extensions can opt-in, allowing to provide custom hooks available to CLI
3. wrap (and unwrap) the extension provided callback so it's callable by the CLI with the same signature as ShellCommandResult

Extension provided .dot commands are NOT available in `-safe` mode.

There are currently a few limitations:
* added .dot commans must match the extension name. I think this does make sense since it simplifies namespacing (extension names already can't collide) and provides a path to potentially autoload if the extension is not already loaded
* autoloading is not implemented
* there is no fine-grained capability to disable extension provided .dot command, tying this to safe more. It could make sense to have a 1-way setting
* .dot commands do not have access to shared state to communicate results back to duckdb. It might be cute eventually to have an interface for that (say 'FROM last_dot_command()` to allow data back into duckdb)

Given this is very much opt-in, and no core extension will offer this now, and that this affects only the CLI, it could be easier to consider.

This also start a tools/shell code restructuring, to make it a thinner layer around duckdb API, but that's future and indepenent work.

This is inspired by the conversation at https://github.com/duckdb/duckdb/pull/21041, where I think the path forward it's allowing extensibility. An alternative (that it's not excluded by this PR) it's using a convention or namespace, that would also work great, but this particular path was chose also since it more clearly allows Extension-provided state to be persisted in such commands.