### PR TITLE
[CLI] Allow extensions to register dot commands

### DIFF
--- a/src/include/duckdb/main/extension/extension_loader.hpp
+++ b/src/include/duckdb/main/extension/extension_loader.hpp
@@ -25,6 +25,8 @@ struct CreateAggregateFunctionInfo;
 struct CreateScalarFunctionInfo;
 struct CreateTableFunctionInfo;
 
+class ShellCommandExtension;
+
 class ExtensionLoader {
 	friend class DuckDB;
 	friend class ExtensionHelper;
@@ -93,6 +95,9 @@ public:
 
 	//! Registers a new secret type
 	DUCKDB_API void RegisterSecretType(SecretType secret_type);
+
+	//! Registers a shell dot-command provided by this extension
+	DUCKDB_API void RegisterShellCommand(ShellCommandExtension extension);
 
 	//! Registers a cast between two types
 	DUCKDB_API void RegisterCastFunction(const LogicalType &source, const LogicalType &target,

--- a/src/include/duckdb/main/extension_callback_manager.hpp
+++ b/src/include/duckdb/main/extension_callback_manager.hpp
@@ -22,6 +22,7 @@ class OperatorExtension;
 class OptimizerExtension;
 class ParserExtension;
 class PlannerExtension;
+class ShellCommandExtension;
 class StorageExtension;
 struct ExtensionCallbackRegistry;
 
@@ -43,12 +44,14 @@ public:
 	void Register(shared_ptr<OperatorExtension> extension);
 	void Register(const string &name, shared_ptr<StorageExtension> extension);
 	void Register(shared_ptr<ExtensionCallback> extension);
+	void Register(ShellCommandExtension extension);
 
 	ExtensionCallbackIteratorHelper<shared_ptr<OperatorExtension>> OperatorExtensions() const;
 	ExtensionCallbackIteratorHelper<OptimizerExtension> OptimizerExtensions() const;
 	ExtensionCallbackIteratorHelper<ParserExtension> ParserExtensions() const;
 	ExtensionCallbackIteratorHelper<PlannerExtension> PlannerExtensions() const;
 	ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>> ExtensionCallbacks() const;
+	ExtensionCallbackIteratorHelper<ShellCommandExtension> ShellCommandExtensions() const;
 	optional_ptr<StorageExtension> FindStorageExtension(const string &name) const;
 	bool HasParserExtensions() const;
 

--- a/src/include/duckdb/main/shell_command_extension.hpp
+++ b/src/include/duckdb/main/shell_command_extension.hpp
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/shell_command_extension.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+class DatabaseInstance;
+struct DBConfig;
+
+struct ShellCommandExtensionInfo {
+	virtual ~ShellCommandExtensionInfo() {
+	}
+};
+
+enum class ShellCommandResult : uint8_t { SUCCESS = 0, FAIL = 1, EXIT = 2, PRINT_USAGE = 3 };
+
+//! Standard callback — shell keeps database open.
+//! args[0] is the command name, args[1] is the sub-command, args[2..] are arguments.
+typedef ShellCommandResult (*shell_command_callback_t)(DatabaseInstance &db, const vector<string> &args,
+                                                       optional_ptr<ShellCommandExtensionInfo> info);
+
+//! Exclusive-access callback — shell closes database before calling.
+//! The callback receives the database path and can open its own instance.
+//! After return, the shell reopens the database.
+typedef ShellCommandResult (*shell_exclusive_command_callback_t)(const string &db_path, const vector<string> &args,
+                                                                 optional_ptr<ShellCommandExtensionInfo> info);
+
+//! A single sub-command within an extension's dot command.
+struct ShellSubCommand {
+	//! Sub-command name, e.g., "version" for ".icu version"
+	string sub_command;
+	//! Argument synopsis for .help
+	string usage;
+	//! Short description for .help
+	string description;
+
+	//! Normal mode: shell keeps database open.
+	shell_command_callback_t callback = nullptr;
+	//! Exclusive mode: shell closes DB before call, passes path, reopens after.
+	shell_exclusive_command_callback_t exclusive_callback = nullptr;
+};
+
+//! Top-level extension command registration.
+//! An extension may register multiple ShellCommandExtensions (one per dot command).
+class ShellCommandExtension {
+public:
+	//! Dot-command name, e.g., "icu" -> ".icu"
+	string command;
+	//! Argument synopsis for .help (used when no sub-commands)
+	string usage;
+	//! Short description for .help
+	string description;
+
+	//! Direct callback — used when sub_commands is empty, or as fallback.
+	shell_command_callback_t callback = nullptr;
+	//! For exclusive file access (shell closes DB, passes path, reopens after):
+	shell_exclusive_command_callback_t exclusive_callback = nullptr;
+
+	//! Optional structured sub-commands.
+	vector<ShellSubCommand> sub_commands;
+
+	shared_ptr<ShellCommandExtensionInfo> info;
+
+	static void Register(DBConfig &config, ShellCommandExtension extension);
+};
+
+} // namespace duckdb

--- a/src/main/extension/extension_loader.cpp
+++ b/src/main/extension/extension_loader.cpp
@@ -16,6 +16,8 @@
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
 
 namespace duckdb {
 
@@ -235,6 +237,10 @@ void ExtensionLoader::RegisterCastFunction(const LogicalType &source, const Logi
 	auto &config = DBConfig::GetConfig(db);
 	auto &casts = config.GetCastFunctions();
 	casts.RegisterCastFunction(source, target, std::move(function), implicit_cast_cost);
+}
+
+void ExtensionLoader::RegisterShellCommand(ShellCommandExtension extension) {
+	DBConfig::GetConfig(db).GetCallbackManager().Register(std::move(extension));
 }
 
 } // namespace duckdb

--- a/src/main/extension_callback_manager.cpp
+++ b/src/main/extension_callback_manager.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/planner_extension.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/planner/extension_callback.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
 
 namespace duckdb {
 
@@ -21,6 +22,8 @@ struct ExtensionCallbackRegistry {
 	case_insensitive_map_t<shared_ptr<StorageExtension>> storage_extensions;
 	//! Set of callbacks that can be installed by extensions
 	vector<shared_ptr<ExtensionCallback>> extension_callbacks;
+	//! Shell command extensions registered by extensions
+	vector<ShellCommandExtension> shell_command_extensions;
 };
 
 ExtensionCallbackManager &ExtensionCallbackManager::Get(ClientContext &context) {
@@ -82,6 +85,13 @@ void ExtensionCallbackManager::Register(shared_ptr<ExtensionCallback> extension)
 	callback_registry.atomic_store(new_registry);
 }
 
+void ExtensionCallbackManager::Register(ShellCommandExtension extension) {
+	lock_guard<mutex> guard(registry_lock);
+	auto new_registry = make_shared_ptr<ExtensionCallbackRegistry>(*callback_registry);
+	new_registry->shell_command_extensions.push_back(std::move(extension));
+	callback_registry.atomic_store(new_registry);
+}
+
 template <class T>
 ExtensionCallbackIteratorHelper<T>::ExtensionCallbackIteratorHelper(
     const vector<T> &vec, shared_ptr<ExtensionCallbackRegistry> callback_registry)
@@ -120,6 +130,12 @@ ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>> ExtensionCallback
 	auto registry = callback_registry.atomic_load();
 	auto &extension_callbacks = registry->extension_callbacks;
 	return ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>>(extension_callbacks, std::move(registry));
+}
+
+ExtensionCallbackIteratorHelper<ShellCommandExtension> ExtensionCallbackManager::ShellCommandExtensions() const {
+	auto registry = callback_registry.atomic_load();
+	auto &shell_command_extensions = registry->shell_command_extensions;
+	return ExtensionCallbackIteratorHelper<ShellCommandExtension>(shell_command_extensions, std::move(registry));
 }
 
 optional_ptr<StorageExtension> ExtensionCallbackManager::FindStorageExtension(const string &name) const {
@@ -165,10 +181,15 @@ void StorageExtension::Register(DBConfig &config, const string &extension_name,
 	config.GetCallbackManager().Register(extension_name, std::move(extension));
 }
 
+void ShellCommandExtension::Register(DBConfig &config, ShellCommandExtension extension) {
+	config.GetCallbackManager().Register(std::move(extension));
+}
+
 template class ExtensionCallbackIteratorHelper<shared_ptr<ExtensionCallback>>;
 template class ExtensionCallbackIteratorHelper<shared_ptr<OperatorExtension>>;
 template class ExtensionCallbackIteratorHelper<OptimizerExtension>;
 template class ExtensionCallbackIteratorHelper<ParserExtension>;
 template class ExtensionCallbackIteratorHelper<PlannerExtension>;
+template class ExtensionCallbackIteratorHelper<ShellCommandExtension>;
 
 } // namespace duckdb

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -18,6 +18,7 @@
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/common/atomic.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
 #include "duckdb.hpp"
 
 namespace duckdb_shell {
@@ -402,6 +403,10 @@ public:
 	optional_ptr<const CommandLineOption> FindCommandLineOption(const string &option, string &error_msg) const;
 	optional_ptr<const MetadataCommand> FindMetadataCommand(const string &option, string &error_msg) const;
 	static vector<string> GetMetadataCompletions(const char *zLine, idx_t nLine);
+	bool TryRunExtensionCommand(const vector<string> &args, int &rc);
+	bool InvokeExtensionCallback(duckdb::shell_command_callback_t cb,
+	                             duckdb::shell_exclusive_command_callback_t excl_cb, const vector<string> &args,
+	                             duckdb::optional_ptr<duckdb::ShellCommandExtensionInfo> info, int &rc);
 
 	//! Execute a SQL query
 	// On fail - print the error and returns FAILURE

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2442,9 +2442,14 @@ int ShellState::DoMetaCommand(const string &zLine) {
 	string error_msg;
 	auto metadata_command = FindMetadataCommand(args[0], error_msg);
 	if (!metadata_command) {
-		// command not found
-		PrintDatabaseError(error_msg);
-		rc = 1;
+		// command not found in built-ins — try extension commands
+		int ext_rc;
+		if (TryRunExtensionCommand(args, ext_rc)) {
+			rc = ext_rc;
+		} else {
+			PrintDatabaseError(error_msg);
+			rc = 1;
+		}
 	} else {
 		auto &command = *metadata_command;
 		MetadataResult result = MetadataResult::PRINT_USAGE;

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -3,6 +3,8 @@
 #include "shell_prompt.hpp"
 #include "shell_progress_bar.hpp"
 #include "shell_renderer.hpp"
+#include "duckdb/main/shell_command_extension.hpp"
+#include "duckdb/main/extension_callback_manager.hpp"
 
 #ifdef HAVE_LINENOISE
 #include "linenoise.h"
@@ -1031,6 +1033,32 @@ idx_t ShellState::PrintHelp(const char *pattern) {
 			}
 		}
 	}
+	// add extension commands
+	if (db) {
+		auto &mgr = duckdb::ExtensionCallbackManager::Get(*db->instance);
+		for (auto &ext : mgr.ShellCommandExtensions()) {
+			if (!glob_pattern.empty() && !ShellState::StringGlob(glob_pattern.c_str(), ext.command.c_str())) {
+				continue;
+			}
+			if (ext.sub_commands.empty()) {
+				PrintCommandInfo pi;
+				pi.command_name = StringUtil::Format(".%s", ext.command);
+				pi.first_part = ext.usage.empty() ? "" : StringUtil::Format(" %s", ext.usage);
+				pi.second_part = ext.description;
+				pi.first_part_highlight = HighlightElementType::STRING_CONSTANT;
+				print_info_list.push_back(std::move(pi));
+			} else {
+				for (auto &sub : ext.sub_commands) {
+					PrintCommandInfo pi;
+					pi.command_name = StringUtil::Format(".%s %s", ext.command, sub.sub_command);
+					pi.first_part = sub.usage.empty() ? "" : StringUtil::Format(" %s", sub.usage);
+					pi.second_part = sub.description;
+					pi.first_part_highlight = HighlightElementType::STRING_CONSTANT;
+					print_info_list.push_back(std::move(pi));
+				}
+			}
+		}
+	}
 	// figure out alignment based on the total first part print size
 	idx_t max_lhs_size = 0;
 	for (auto &print_info : print_info_list) {
@@ -1065,26 +1093,35 @@ idx_t ShellState::PrintHelp(const char *pattern) {
 	return print_info_list.size();
 }
 
-vector<string> ShellState::GetMetadataCompletions(const char *zLine, idx_t nLine) {
+static void AppendDotCompletion(vector<string> &result, const char *command, const char *zLine, idx_t nLine) {
 	char zBuf[1000];
+	bool found_match = true;
+	idx_t line_pos;
+	zBuf[0] = '.';
+	for (line_pos = 0; !ShellState::IsSpace(command[line_pos]) && command[line_pos] && line_pos + 2 < sizeof(zBuf);
+	     line_pos++) {
+		zBuf[line_pos + 1] = command[line_pos];
+		if (line_pos + 1 < nLine && command[line_pos] != zLine[line_pos + 1]) {
+			found_match = false;
+			break;
+		}
+	}
+	zBuf[line_pos + 1] = '\0';
+	if (found_match && line_pos + 1 >= nLine) {
+		result.push_back(zBuf);
+	}
+}
+
+vector<string> ShellState::GetMetadataCompletions(const char *zLine, idx_t nLine) {
 	vector<string> result;
 	for (idx_t c = 0; metadata_commands[c].command; c++) {
-		auto &command = metadata_commands[c];
-		auto &line = command.command;
-		bool found_match = true;
-		idx_t line_pos;
-		zBuf[0] = '.';
-		for (line_pos = 0; !IsSpace(line[line_pos]) && line[line_pos] && line_pos + 2 < sizeof(zBuf); line_pos++) {
-			zBuf[line_pos + 1] = line[line_pos];
-			if (line_pos + 1 < nLine && line[line_pos] != zLine[line_pos + 1]) {
-				// only match prefixes for auto-completion, i.e. ".sh" matches ".shell"
-				found_match = false;
-				break;
-			}
-		}
-		zBuf[line_pos + 1] = '\0';
-		if (found_match && line_pos + 1 >= nLine) {
-			result.push_back(zBuf);
+		AppendDotCompletion(result, metadata_commands[c].command, zLine, nLine);
+	}
+	auto &state = ShellState::Get();
+	if (state.db) {
+		auto &mgr = duckdb::ExtensionCallbackManager::Get(*state.db->instance);
+		for (auto &ext : mgr.ShellCommandExtensions()) {
+			AppendDotCompletion(result, ext.command.c_str(), zLine, nLine);
 		}
 	}
 	return result;
@@ -1108,10 +1145,123 @@ optional_ptr<const MetadataCommand> ShellState::FindMetadataCommand(const string
 		auto &command = metadata_commands[command_idx];
 		command_names.push_back(string(".") + command.command);
 	}
+	if (db) {
+		auto &mgr = duckdb::ExtensionCallbackManager::Get(*db->instance);
+		for (auto &ext : mgr.ShellCommandExtensions()) {
+			command_names.push_back("." + ext.command);
+		}
+	}
 	auto candidates_msg = StringUtil::CandidatesErrorMessage(command_names, option, "Did you mean");
 	error_msg += candidates_msg + "\n";
 	error_msg += "Run '.help' for more information.";
 	return nullptr;
+}
+
+bool ShellState::InvokeExtensionCallback(duckdb::shell_command_callback_t cb,
+                                         duckdb::shell_exclusive_command_callback_t excl_cb, const vector<string> &args,
+                                         duckdb::optional_ptr<duckdb::ShellCommandExtensionInfo> info, int &rc) {
+	duckdb::ShellCommandResult result = duckdb::ShellCommandResult::FAIL;
+	try {
+		if (excl_cb) {
+			// Exclusive mode: close DB, call with path, reopen
+			string saved_path = zDbFilename;
+			last_result.reset();
+			conn.reset();
+			db.reset();
+			result = excl_cb(saved_path, args, info);
+			OpenDB(ShellOpenFlags::KEEP_ALIVE_ON_FAILURE);
+		} else if (cb) {
+			result = cb(*db->instance, args, info);
+		} else {
+			return false;
+		}
+		rc = static_cast<int>(result);
+		return true;
+	} catch (std::exception &ex) {
+		duckdb::ErrorData error(ex);
+		PrintDatabaseError(error.Message());
+		if (excl_cb && !db) {
+			OpenDB(ShellOpenFlags::KEEP_ALIVE_ON_FAILURE);
+		}
+		rc = 1;
+		return true;
+	} catch (...) {
+		PrintDatabaseError("Unknown error in extension command");
+		if (excl_cb && !db) {
+			OpenDB(ShellOpenFlags::KEEP_ALIVE_ON_FAILURE);
+		}
+		rc = 1;
+		return true;
+	}
+}
+
+bool ShellState::TryRunExtensionCommand(const vector<string> &args, int &rc) {
+	if (safe_mode || !db) {
+		return false;
+	}
+
+	auto &mgr = duckdb::ExtensionCallbackManager::Get(*db->instance);
+	for (auto &ext : mgr.ShellCommandExtensions()) {
+		if (!duckdb::StringUtil::CIEquals(ext.command, args[0])) {
+			continue;
+		}
+
+		bool has_sub_commands = !ext.sub_commands.empty();
+		bool has_top_level = ext.callback || ext.exclusive_callback;
+
+		// Try sub-command dispatch first (if args[1] exists and sub-commands registered)
+		if (has_sub_commands && args.size() >= 2) {
+			const string &sub_name = args[1];
+			for (auto &sub : ext.sub_commands) {
+				if (!duckdb::StringUtil::CIEquals(sub.sub_command, sub_name)) {
+					continue;
+				}
+				if (InvokeExtensionCallback(sub.callback, sub.exclusive_callback, args, ext.info.get(), rc)) {
+					if (rc == static_cast<int>(duckdb::ShellCommandResult::PRINT_USAGE)) {
+						string usage_str =
+						    sub.usage.empty()
+						        ? StringUtil::Format("Usage: '.%s %s'", ext.command, sub.sub_command)
+						        : StringUtil::Format("Usage: '.%s %s %s'", ext.command, sub.sub_command, sub.usage);
+						PrintDatabaseError(usage_str);
+						rc = 1;
+					}
+					return true;
+				}
+				PrintF(PrintOutput::STDERR, "Sub-command '.%s %s' has no callback\n", ext.command.c_str(),
+				       sub.sub_command.c_str());
+				rc = 1;
+				return true;
+			}
+			// Sub-command name didn't match — fall through to top-level
+		}
+
+		// Top-level callback (simple command or fallback)
+		if (has_top_level) {
+			if (InvokeExtensionCallback(ext.callback, ext.exclusive_callback, args, ext.info.get(), rc)) {
+				if (rc == static_cast<int>(duckdb::ShellCommandResult::PRINT_USAGE)) {
+					string usage_str = ext.usage.empty()
+					                       ? StringUtil::Format("Usage: '.%s'", ext.command)
+					                       : StringUtil::Format("Usage: '.%s %s'", ext.command, ext.usage);
+					PrintDatabaseError(usage_str);
+					rc = 1;
+				}
+				return true;
+			}
+		}
+
+		// No callback handled it — show available sub-commands
+		if (has_sub_commands) {
+			PrintF("Usage:\n");
+			for (auto &sub : ext.sub_commands) {
+				PrintF("  .%s %-20s %s\n", ext.command.c_str(), sub.sub_command.c_str(), sub.description.c_str());
+			}
+		} else {
+			PrintDatabaseError(StringUtil::Format("Extension command '.%s' has no callbacks registered", ext.command));
+		}
+		rc = 1;
+		return true;
+	}
+	return false;
 }
 
 } // namespace duckdb_shell


### PR DESCRIPTION
Alternative implementation of #21197 (carlopi's extensible dot commands).

This PR takes a minimal, shell-only approach compared to Carlo's PR:

Key differences from #21197:
- No refactoring of MetadataCommand/MetadataResult into core — the shell keeps its own types and the extension API uses a separate ShellCommandResult enum in the duckdb namespace. The shell maps between them with static_cast<int>.
- No changes to enum_util (no EnumUtil::ToChars/FromString for the new enum) — the enum is only used in the shell, not serialized.
- No changes to shell_command_line_option.cpp — command-line option handling is left untouched.
- Smaller shell.cpp change — just a 6-line fallback in DoMetaCommand instead of restructuring the dispatch loop.
- Sub-command support built in — extensions can register structured sub-commands (e.g., ".icu version", ".icu calendar list") with per-sub-command callbacks, usage, and descriptions.
- Exclusive-access callback mode — extensions can request the shell close the database before calling (receives path, shell reopens after). Useful for maintenance operations that need exclusive file access.
- Tab-completion and .help integration — extension commands appear in tab-completion and .help output alongside built-in commands.
- "Did you mean?" suggestions — extension commands are included in the fuzzy-match candidates when a user mistypes a command.

Shared with #21197:
- Same registration path: ExtensionLoader::RegisterShellCommand() ->
  ExtensionCallbackManager -> vector<ShellCommandExtension>
- Same shell_command_extension.hpp header location and callback typedefs
- Extension commands disabled in -safe mode
- New file: src/include/duckdb/main/shell_command_extension.hpp