### PR TITLE
Windows shell: UTF-8 mode when writing to pager

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -433,33 +433,14 @@ private:
 	~ShellState();
 };
 
-#if defined(_WIN32) || defined(WIN32)
-enum class WindowsUtf8ModeRestore { RESTORE_AS_DISABLED, DO_NOT_RESTORE };
-#endif
-
 struct PagerState {
-#if defined(_WIN32) || defined(WIN32)
-	WindowsUtf8ModeRestore win_utf8_mode_restore = WindowsUtf8ModeRestore::DO_NOT_RESTORE;
-	PagerState(ShellState &state, WindowsUtf8ModeRestore win_utf8_mode_restore_p)
-	    : state(state), win_utf8_mode_restore(win_utf8_mode_restore_p) {
+	explicit PagerState(ShellState &state, uint32_t win_console_cp_before_pager_p = 0)
+	    : state(state), win_console_cp_before_pager(win_console_cp_before_pager_p) {
 	}
-#endif
-	explicit PagerState(ShellState &state) : state(state) {
-	}
-	~PagerState() {
-		if (state) {
-#if defined(_WIN32) || defined(WIN32)
-			if (win_utf8_mode_restore == WindowsUtf8ModeRestore::RESTORE_AS_DISABLED) {
-				state->win_utf8_mode = false;
-			}
-#endif
-			state->ResetOutput();
-			ShellState::FinishPagerDisplay();
-			state = nullptr;
-		}
-	}
+	~PagerState();
 
 	optional_ptr<ShellState> state;
+	uint32_t win_console_cp_before_pager = 0;
 };
 
 } // namespace duckdb_shell

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -433,11 +433,26 @@ private:
 	~ShellState();
 };
 
+#if defined(_WIN32) || defined(WIN32)
+enum class WindowsUtf8ModeRestore { RESTORE_AS_DISABLED, DO_NOT_RESTORE };
+#endif
+
 struct PagerState {
+#if defined(_WIN32) || defined(WIN32)
+	WindowsUtf8ModeRestore win_utf8_mode_restore = WindowsUtf8ModeRestore::DO_NOT_RESTORE;
+	PagerState(ShellState &state, WindowsUtf8ModeRestore win_utf8_mode_restore_p)
+	    : state(state), win_utf8_mode_restore(win_utf8_mode_restore_p) {
+	}
+#endif
 	explicit PagerState(ShellState &state) : state(state) {
 	}
 	~PagerState() {
 		if (state) {
+#if defined(_WIN32) || defined(WIN32)
+			if (win_utf8_mode_restore == WindowsUtf8ModeRestore::RESTORE_AS_DISABLED) {
+				state->win_utf8_mode = false;
+			}
+#endif
 			state->ResetOutput();
 			ShellState::FinishPagerDisplay();
 			state = nullptr;

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -343,17 +343,12 @@ void ShellState::Print(PrintOutput output, const char *str, idx_t len) {
 	}
 
 #if defined(_WIN32) || defined(WIN32)
-	if ((stdout_is_console && (out == stdout || out == stderr) || pager_is_active) && !win_utf8_mode) {
-		if (pager_is_active) {
-			auto mbcs_text = ShellState::Win32Utf8ToMbcs(str, true);
-			fputs(mbcs_text.c_str(), output == PrintOutput::STDOUT ? out : stderr);
-		} else {
-			// convert from utf8 to utf16
-			auto unicode_text = ShellState::Win32Utf8ToUnicode(str);
-			auto out_handle = GetStdHandle(output == PrintOutput::STDOUT ? STD_OUTPUT_HANDLE : STD_ERROR_HANDLE);
-			// use WriteConsoleW to write the unicode codepoints to the console
-			WriteConsoleW(out_handle, unicode_text.c_str(), unicode_text.size(), NULL, NULL);
-		}
+	if ((stdout_is_console && (out == stdout || out == stderr)) && !pager_is_active) {
+		// convert from utf8 to utf16
+		auto unicode_text = ShellState::Win32Utf8ToUnicode(str);
+		auto out_handle = GetStdHandle(output == PrintOutput::STDOUT ? STD_OUTPUT_HANDLE : STD_ERROR_HANDLE);
+		// use WriteConsoleW to write the unicode codepoints to the console
+		WriteConsoleW(out_handle, unicode_text.c_str(), unicode_text.size(), NULL, NULL);
 		return;
 	}
 #endif
@@ -436,9 +431,6 @@ PagerState::~PagerState() {
 #if defined(_WIN32) || defined(WIN32)
 	if (win_console_cp_before_pager > 0 && win_console_cp_before_pager != CP_UTF8) {
 		SetConsoleCP(win_console_cp_before_pager);
-		if (state) {
-			state->win_utf8_mode = false;
-		}
 	}
 #endif
 	if (state) {
@@ -1430,15 +1422,9 @@ void ShellState::FinishPagerDisplay() {
 unique_ptr<PagerState> ShellState::SetupPager() {
 	uint32_t win_console_cp_before_pager = 0;
 #if defined(_WIN32) || defined(WIN32)
-	// We expect that CP_UTF8 code page is set when win_utf8_mode is enabled,
-	// so after the pager completes we restore both code page and mode
-	// based on the saved code page value.
-	win_console_cp_before_pager = GetConsoleCP();
-	if (win_console_cp_before_pager > 0) {
-		if (pager_command == "more") { // UTF-8 mode must be used with "more" pager
-			win_utf8_mode = true;
-		}
-		if (win_utf8_mode && win_console_cp_before_pager != CP_UTF8) {
+	if (pager_command == "more") { // UTF-8 mode must be used with "more" pager
+		win_console_cp_before_pager = GetConsoleCP();
+		if (win_console_cp_before_pager > 0 && win_console_cp_before_pager != CP_UTF8) {
 			SetConsoleCP(CP_UTF8);
 		}
 	}

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1413,6 +1413,13 @@ void ShellState::FinishPagerDisplay() {
 
 unique_ptr<PagerState> ShellState::SetupPager() {
 #if defined(_WIN32) || defined(WIN32)
+	auto win_utf8_mode_restore = WindowsUtf8ModeRestore::DO_NOT_RESTORE;
+	if (pager_command == "more") { // UTF-8 mode must be used with "more" pager
+		if (!win_utf8_mode) {
+			win_utf8_mode_restore = WindowsUtf8ModeRestore::RESTORE_AS_DISABLED;
+		}
+		win_utf8_mode = true;
+	}
 	if (win_utf8_mode) {
 		SetConsoleCP(CP_UTF8);
 	}
@@ -1428,7 +1435,11 @@ unique_ptr<PagerState> ShellState::SetupPager() {
 	pager_is_active = true;
 	out = pager_out;
 	outfile = "|" + pager_command;
+#if defined(_WIN32) || defined(WIN32)
+	return make_uniq<PagerState>(*this, win_utf8_mode_restore);
+#else
 	return make_uniq<PagerState>(*this);
+#endif
 }
 /*
 ** Change the output file back to stdout.

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -432,6 +432,22 @@ bool ShellState::IsDigit(char c) {
 	return isdigit(c);
 }
 
+PagerState::~PagerState() {
+#if defined(_WIN32) || defined(WIN32)
+	if (win_console_cp_before_pager > 0 && win_console_cp_before_pager != CP_UTF8) {
+		SetConsoleCP(win_console_cp_before_pager);
+		if (state) {
+			state->win_utf8_mode = false;
+		}
+	}
+#endif
+	if (state) {
+		state->ResetOutput();
+		ShellState::FinishPagerDisplay();
+		state = nullptr;
+	}
+}
+
 /*
 ** Compute a string length that is limited to what can be stored in
 ** lower 30 bits of a 32-bit signed integer.
@@ -1412,16 +1428,19 @@ void ShellState::FinishPagerDisplay() {
 }
 
 unique_ptr<PagerState> ShellState::SetupPager() {
+	uint32_t win_console_cp_before_pager = 0;
 #if defined(_WIN32) || defined(WIN32)
-	auto win_utf8_mode_restore = WindowsUtf8ModeRestore::DO_NOT_RESTORE;
-	if (pager_command == "more") { // UTF-8 mode must be used with "more" pager
-		if (!win_utf8_mode) {
-			win_utf8_mode_restore = WindowsUtf8ModeRestore::RESTORE_AS_DISABLED;
+	// We expect that CP_UTF8 code page is set when win_utf8_mode is enabled,
+	// so after the pager completes we restore both code page and mode
+	// based on the saved code page value.
+	win_console_cp_before_pager = GetConsoleCP();
+	if (win_console_cp_before_pager > 0) {
+		if (pager_command == "more") { // UTF-8 mode must be used with "more" pager
+			win_utf8_mode = true;
 		}
-		win_utf8_mode = true;
-	}
-	if (win_utf8_mode) {
-		SetConsoleCP(CP_UTF8);
+		if (win_utf8_mode && win_console_cp_before_pager != CP_UTF8) {
+			SetConsoleCP(CP_UTF8);
+		}
 	}
 #endif
 	StartPagerDisplay();
@@ -1435,11 +1454,7 @@ unique_ptr<PagerState> ShellState::SetupPager() {
 	pager_is_active = true;
 	out = pager_out;
 	outfile = "|" + pager_command;
-#if defined(_WIN32) || defined(WIN32)
-	return make_uniq<PagerState>(*this, win_utf8_mode_restore);
-#else
-	return make_uniq<PagerState>(*this);
-#endif
+	return make_uniq<PagerState>(*this, win_console_cp_before_pager);
 }
 /*
 ** Change the output file back to stdout.


### PR DESCRIPTION
On Windows when the unbound results are displayed in terminal (for example, with the `.last` command) the `C:\Windows\System32\more.com` pager command is used by default. This pager does not support UTF-16 output, so scrolling text is printed with garbled Unicode characters. This pager can print the characters correctly when running in UTF-8 mode.

This PR enables the UTF-8 mode in shell before calling the pager and restores the original mode when the pager is closed.

The change is Windows-only.

Fixes: #21191