### PR TITLE
[Regression v1.5] Fix INTERNAL Error in UnnestRewriter for deeply nested struct UNNEST

### DIFF
--- a/src/optimizer/unnest_rewriter.cpp
+++ b/src/optimizer/unnest_rewriter.cpp
@@ -139,16 +139,16 @@ void UnnestRewriter::FindCandidates(unique_ptr<LogicalOperator> &root, unique_pt
 				auto &pre_proj = curr_op->get()->Cast<LogicalProjection>();
 				for (idx_t i = 0; i < pre_columns.size(); i++) {
 					auto &col_bind = pre_columns[i];
-					if (col_bind.table_index == pre_tbl_idx) {
-						if (pre_proj.expressions[col_bind.column_index]->GetExpressionClass() !=
-						    ExpressionClass::BOUND_COLUMN_REF) {
-							return;
-						}
+					auto is_unnest_column = col_bind.table_index == pre_tbl_idx;
+					auto is_column_ref = pre_proj.expressions[col_bind.column_index]->GetExpressionClass() ==
+					                     ExpressionClass::BOUND_COLUMN_REF;
+					if (is_unnest_column && !is_column_ref) {
+						return;
 					}
 				}
 			}
 			auto unnest_get = std::move(delim_join.children[other_idx]);
-			unnest_get->ResolveOperatorTypes();
+			// ResolveOperatorTypes() already called in the pre-check above
 			ColumnBindingReplacer replacer;
 			auto unnest_get_column = unnest_get->GetColumnBindings();
 			auto &proj = curr_op->get()->Cast<LogicalProjection>();
@@ -161,6 +161,7 @@ void UnnestRewriter::FindCandidates(unique_ptr<LogicalOperator> &root, unique_pt
 				D_ASSERT(col_bind.table_index == unnest_get->GetTableIndex()[0] ||
 				         col_bind.table_index == proj.table_index);
 				if (col_bind.table_index == unnest_get->GetTableIndex()[0]) {
+					// Guaranteed by the pre-check above: all these expressions are BOUND_COLUMN_REF
 					D_ASSERT(proj.expressions[col_bind.column_index]->GetExpressionClass() ==
 					         ExpressionClass::BOUND_COLUMN_REF);
 					auto &bind_col = proj.expressions[col_bind.column_index]->Cast<BoundColumnRefExpression>();

--- a/src/optimizer/unnest_rewriter.cpp
+++ b/src/optimizer/unnest_rewriter.cpp
@@ -127,6 +127,26 @@ void UnnestRewriter::FindCandidates(unique_ptr<LogicalOperator> &root, unique_pt
 		// find pattern2 and convert to pattern1
 		if (curr_op->get()->type == LogicalOperatorType::LOGICAL_PROJECTION &&
 		    curr_op->get()->children[0]->type == LogicalOperatorType::LOGICAL_DELIM_GET) {
+			// Pre-check: verify all projection expressions for unnest columns are simple
+			// column references. With deeply nested struct paths (e.g. t.a.b.c.items),
+			// the projection may contain struct extraction functions instead,
+			// which we cannot rewrite. We must check before moving any unique_ptrs.
+			{
+				auto &pre_get = *delim_join.children[other_idx];
+				pre_get.ResolveOperatorTypes();
+				auto pre_columns = pre_get.GetColumnBindings();
+				auto pre_tbl_idx = pre_get.GetTableIndex()[0];
+				auto &pre_proj = curr_op->get()->Cast<LogicalProjection>();
+				for (idx_t i = 0; i < pre_columns.size(); i++) {
+					auto &col_bind = pre_columns[i];
+					if (col_bind.table_index == pre_tbl_idx) {
+						if (pre_proj.expressions[col_bind.column_index]->GetExpressionClass() !=
+						    ExpressionClass::BOUND_COLUMN_REF) {
+							return;
+						}
+					}
+				}
+			}
 			auto unnest_get = std::move(delim_join.children[other_idx]);
 			unnest_get->ResolveOperatorTypes();
 			ColumnBindingReplacer replacer;

--- a/test/sql/json/table/read_json_unnest_heterogeneous_struct.test
+++ b/test/sql/json/table/read_json_unnest_heterogeneous_struct.test
@@ -1,6 +1,7 @@
 # name: test/sql/json/table/read_json_unnest_heterogeneous_struct.test
 # description: Test UNNEST of heterogeneous struct arrays from read_json_auto
 # group: [table]
+
 # Regression test for https://github.com/duckdb/duckdb/pull/21209
 # Cross-join UNNEST of a deeply nested array of objects with different keys
 # caused INTERNAL Error in the UnnestRewriter optimizer when read_json_auto

--- a/test/sql/json/table/read_json_unnest_heterogeneous_struct.test
+++ b/test/sql/json/table/read_json_unnest_heterogeneous_struct.test
@@ -1,7 +1,7 @@
 # name: test/sql/json/table/read_json_unnest_heterogeneous_struct.test
 # description: Test UNNEST of heterogeneous struct arrays from read_json_auto
 # group: [table]
-# Regression test for https://github.com/duckdb/duckdb/issues/XXXX
+# Regression test for https://github.com/duckdb/duckdb/pull/21209
 # Cross-join UNNEST of a deeply nested array of objects with different keys
 # caused INTERNAL Error in the UnnestRewriter optimizer when read_json_auto
 # inferred a STRUCT[] type with heterogeneous element shapes.

--- a/test/sql/json/table/read_json_unnest_heterogeneous_struct.test
+++ b/test/sql/json/table/read_json_unnest_heterogeneous_struct.test
@@ -1,0 +1,101 @@
+# name: test/sql/json/table/read_json_unnest_heterogeneous_struct.test
+# description: Test UNNEST of heterogeneous struct arrays from read_json_auto
+# group: [table]
+# Regression test for https://github.com/duckdb/duckdb/issues/XXXX
+# Cross-join UNNEST of a deeply nested array of objects with different keys
+# caused INTERNAL Error in the UnnestRewriter optimizer when read_json_auto
+# inferred a STRUCT[] type with heterogeneous element shapes.
+
+require json
+
+statement ok
+PRAGMA enable_verification;
+
+# ============================================================================
+# CASE 1: Flat heterogeneous struct array
+# ============================================================================
+
+statement ok
+COPY (
+    SELECT * FROM (VALUES
+        ('{"results": [{"name": "Alice", "age": 30}, {"name": "Bob", "company": "ACME"}, {"name": "Charlie", "score": 95.5, "tags": ["a","b"]}]}')
+    )
+) TO '{TEMP_DIR}/heterogeneous.json' (format csv, quote '', header 0);
+
+# DuckDB unifies all keys into one STRUCT type
+query I
+SELECT typeof(results[1]) FROM read_json_auto('{TEMP_DIR}/heterogeneous.json');
+----
+STRUCT("name" VARCHAR, age BIGINT, company VARCHAR, score DOUBLE, tags VARCHAR[])
+
+# Cross-join UNNEST works for flat arrays
+query IIIII
+SELECT unnest.name, unnest.age, unnest.company, unnest.score, unnest.tags
+FROM read_json_auto('{TEMP_DIR}/heterogeneous.json') t, UNNEST(t.results)
+ORDER BY unnest.name;
+----
+Alice	30	NULL	NULL	NULL
+Bob	NULL	ACME	NULL	NULL
+Charlie	NULL	NULL	95.5	[a, b]
+
+# ============================================================================
+# CASE 2: Deeply nested heterogeneous struct array (was crashing before fix)
+# ============================================================================
+
+statement ok
+COPY (
+    SELECT * FROM (VALUES
+        ('{"response": {"service": {"data": {"items": [{"type": "person", "first_name": "John", "last_name": "Doe"}, {"type": "company", "company_name": "Widgets Inc", "registration_number": "12345"}, {"type": "person", "first_name": "Jane", "middle_name": "M", "last_name": "Smith"}]}}}}')
+    )
+) TO '{TEMP_DIR}/nested_heterogeneous.json' (format csv, quote '', header 0);
+
+# Cross-join UNNEST on deeply nested path should work
+query I
+SELECT unnest.type
+FROM read_json_auto('{TEMP_DIR}/nested_heterogeneous.json') t,
+     UNNEST(t.response.service.data.items)
+ORDER BY unnest.type;
+----
+company
+person
+person
+
+# Access multiple fields from the unnested struct
+query IIII
+SELECT unnest.type, unnest.first_name, unnest.last_name, unnest.company_name
+FROM read_json_auto('{TEMP_DIR}/nested_heterogeneous.json') t,
+     UNNEST(t.response.service.data.items)
+ORDER BY unnest.type, unnest.first_name;
+----
+company	NULL	NULL	Widgets Inc
+person	Jane	Smith	NULL
+person	John	Doe	NULL
+
+# ============================================================================
+# CAST to JSON[] workaround should also still work
+# ============================================================================
+
+query I
+SELECT json_extract_string(item, '$.name')
+FROM (
+    SELECT UNNEST(CAST(results AS JSON[])) AS item
+    FROM read_json_auto('{TEMP_DIR}/heterogeneous.json')
+)
+ORDER BY 1;
+----
+Alice
+Bob
+Charlie
+
+query II
+SELECT json_extract_string(item, '$.type'),
+       COALESCE(json_extract_string(item, '$.first_name'), json_extract_string(item, '$.company_name'))
+FROM (
+    SELECT UNNEST(CAST(t.response.service.data.items AS JSON[])) AS item
+    FROM read_json_auto('{TEMP_DIR}/nested_heterogeneous.json') t
+)
+ORDER BY 1, 2;
+----
+company	Widgets Inc
+person	Jane
+person	John


### PR DESCRIPTION
## Regression in v1.5 — not present in v1.4.4

This is a **regression introduced in DuckDB v1.5**. The same query works correctly in v1.4.4. This should be fixed before the v1.5 stable release.

## Summary

Cross-join UNNEST of an array accessed through a deeply nested struct path crashes with `INTERNAL Error: Failed to cast expression to type - expression type mismatch`.

**Minimal repro:**
```sql
COPY (
  SELECT * FROM (VALUES (
    '{
      "response": {
        "service": {
          "data": {
            "items": [
              {"type": "person", "first_name": "John"},
              {"type": "company", "company_name": "ACME"},
              {"type": "person", "first_name": "Jane", "middle_name": "M"}
            ]
          }
        }
      }
    }'
  ))
) TO '/tmp/test.json' (format csv, quote '', header 0);

-- Works in v1.4.4, crashes in v1.5 with INTERNAL Error
SELECT unnest.type
FROM read_json_auto('/tmp/test.json') t,
     UNNEST(t.response.service.data.items);
```

Flat paths (e.g., `UNNEST(t.results)`) work fine — the issue only occurs when the array is accessed through multiple levels of struct nesting.

## Root Cause

In `UnnestRewriter::FindCandidates`, when converting pattern2 (table-in-out unnest) to pattern1, the code assumes all projection expressions for unnest columns are `BoundColumnRefExpression`. With deeply nested struct paths, the projection contains struct extraction function expressions instead, causing the checked `Cast<BoundColumnRefExpression>()` to throw.

## Fix

Added a pre-check that verifies all relevant projection expressions are simple column references **before** the code begins moving `unique_ptr`s. If any expression is not a column reference, the optimization is safely skipped — the query still executes correctly via the unoptimized path.

The pre-check must happen before the `std::move` operations (lines 130-138) because returning after the moves would leave the operator tree in a corrupted state (null `unique_ptr`s).

## Test

Added `test/sql/json/table/read_json_unnest_heterogeneous_struct.test` covering:
- Flat heterogeneous struct arrays with cross-join UNNEST (works, uses optimized path)
- Deeply nested heterogeneous struct arrays with cross-join UNNEST (was crashing, now works via unoptimized path)
- `CAST(... AS JSON[])` workaround for both cases