### PR TITLE
Improve test runner

### DIFF
--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Unit Test
         shell: bash
         run: |
-          ./build/release/test/unittest --force-storage --test-temp-dir my_local_folder || true
+          python3 scripts/ci/run_tests.py --test-flags="--force-storage --test-temp-dir=my_local_folder" ./build/release/test/unittest || true
           rm -rf my_local_folder/hive
 
       - uses: actions/upload-artifact@v4
@@ -224,7 +224,7 @@ jobs:
       - name: Unit Test
         shell: bash
         run: |
-          ./build/release/test/unittest --force-storage --test-temp-dir my_local_folder || true
+          python3 scripts/ci/run_tests.py --test-flags="--force-storage --test-temp-dir=my_local_folder" ./build/release/test/unittest || true
           rm -rf my_local_folder/hive
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ExtendedTests.yml
+++ b/.github/workflows/ExtendedTests.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Run Tests
       shell: bash
       run: |
-        ./build/reldebug/test/unittest --test-config test/configs/${{ matrix.config }}.json "*"
+        python3 scripts/ci/run_tests.py --test-config=test/configs/${{ matrix.config }}.json ./build/reldebug/test/unittest "*"
 
   regression-lto-benchmark-runner:
      name: Benchmark runner lto vs non-lto (OSX)

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -334,7 +334,7 @@ jobs:
           LOCAL_EXTENSION_REPO: /tmp/extension-repository
           DUCKDB_TEST_DESCRIPTION: 'Running with autoloading of extensions. Run unittest --autoloading available to reproduce locally. Add require no_extension_autoloading to skip the test'
         run: |
-          ./build/release/test/unittest --autoloading available --skip-compiled
+          python3 scripts/ci/run_tests.py --test-flags="--autoloading=available --skip-compiled" ./build/release/test/unittest
 
   check-load-install-extensions:
     name: Checks extension entries

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -119,12 +119,12 @@ jobs:
       shell: bash
       if: ${{ inputs.skip_tests != 'true' }}
       run: |
-        python3 scripts/ci/run_tests.py build/release/test/unittest "*"
+        make allunit
 
     - name: Release specific tests
       shell: bash
       run: |
-        ./build/release/test/unittest --select-tag release
+        python3 scripts/ci/run_tests.py --test-flags="--select-tag=release" ./build/release/test/unittest
 
     - name: Tools Tests
       shell: bash
@@ -222,13 +222,14 @@ jobs:
           set -e
           cat /etc/os-release
           apk add      \
+            make       \
             python3    \
             py3-pytest
           cd $PWD
           echo Tests
-          python3 scripts/ci/run_tests.py build/release/test/unittest \"*\"
+          make allunit
           echo Release specific tests
-          ./build/release/test/unittest --select-tag release
+          python3 scripts/ci/run_tests.py --test-flags=\"--select-tag=release\" ./build/release/test/unittest
           echo Tools Tests
           python3 -m pytest tools/shell/tests --shell-binary build/release/duckdb
           echo Examples

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -116,23 +116,16 @@ jobs:
           duckdb_cli-linux-${{ matrix.config.arch }}.gz
 
     - name: Test
-      shell: bash
       if: ${{ inputs.skip_tests != 'true' }}
-      run: |
-        make allunit
+      run: make allunit
 
     - name: Release specific tests
-      shell: bash
-      run: |
-        python3 scripts/ci/run_tests.py --test-flags="--select-tag=release" ./build/release/test/unittest
+      run: make unittest_release_tag
 
     - name: Tools Tests
-      shell: bash
-      run: |
-        python3 -m pytest tools/shell/tests --shell-binary build/release/duckdb
+      run: python3 -m pytest tools/shell/tests --shell-binary build/release/duckdb
 
     - name: Examples
-      shell: bash
       run: |
         build/release/benchmark/benchmark_runner benchmark/micro/update/update_with_join.benchmark
         build/release/duckdb -c "COPY (SELECT 42) TO '/dev/stdout' (FORMAT PARQUET)" | cat
@@ -229,7 +222,7 @@ jobs:
           echo Tests
           make allunit
           echo Release specific tests
-          python3 scripts/ci/run_tests.py --test-flags=\"--select-tag=release\" ./build/release/test/unittest
+          make unittest_release_tag
           echo Tools Tests
           python3 -m pytest tools/shell/tests --shell-binary build/release/duckdb
           echo Examples

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -516,31 +516,31 @@ jobs:
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        python3 scripts/ci/run_tests.py --test-flags="--verify-vector=dictionary_expression --skip-compiled" ./build/release/test/unittest
+        python3 scripts/ci/run_tests.py --test-flags="--verify-vector dictionary_expression --skip-compiled" ./build/release/test/unittest
 
     - name: Test dictionary_operator
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        python3 scripts/ci/run_tests.py --test-flags="--verify-vector=dictionary_operator --skip-compiled" ./build/release/test/unittest
+        python3 scripts/ci/run_tests.py --test-flags="--verify-vector dictionary_operator --skip-compiled" ./build/release/test/unittest
 
     - name: Test constant_operator
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        python3 scripts/ci/run_tests.py --test-flags="--verify-vector=constant_operator --skip-compiled" ./build/release/test/unittest
+        python3 scripts/ci/run_tests.py --test-flags="--verify-vector constant_operator --skip-compiled" ./build/release/test/unittest
 
     - name: Test sequence_operator
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        python3 scripts/ci/run_tests.py --test-flags="--verify-vector=sequence_operator --skip-compiled" ./build/release/test/unittest
+        python3 scripts/ci/run_tests.py --test-flags="--verify-vector sequence_operator --skip-compiled" ./build/release/test/unittest
 
     - name: Test nested_shuffle
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        python3 scripts/ci/run_tests.py --test-flags="--verify-vector=nested_shuffle --skip-compiled" ./build/release/test/unittest
+        python3 scripts/ci/run_tests.py --test-flags="--verify-vector nested_shuffle --skip-compiled" ./build/release/test/unittest
 
     - name: Test variant_vector
       if: (success() || failure()) && steps.build.conclusion == 'success'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -59,7 +59,7 @@ jobs:
     if: |
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (github.event.action != 'synchronize' || github.event.pull_request.user.login == 'smvv')
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'duckdb/duckdb' && 'namespace-profile-linux-small' || 'ubuntu-latest' }}
     outputs:
       runner_linux_x64: ${{ steps.select_runner.outputs.runner_linux_x64 }}
       runner_linux_22_x64: ${{ steps.select_runner.outputs.runner_linux_22_x64 }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -516,31 +516,31 @@ jobs:
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --verify-vector dictionary_expression --skip-compiled
+        python3 scripts/ci/run_tests.py --test-flags="--verify-vector=dictionary_expression --skip-compiled" ./build/release/test/unittest
 
     - name: Test dictionary_operator
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --verify-vector dictionary_operator --skip-compiled
+        python3 scripts/ci/run_tests.py --test-flags="--verify-vector=dictionary_operator --skip-compiled" ./build/release/test/unittest
 
     - name: Test constant_operator
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --verify-vector constant_operator --skip-compiled
+        python3 scripts/ci/run_tests.py --test-flags="--verify-vector=constant_operator --skip-compiled" ./build/release/test/unittest
 
     - name: Test sequence_operator
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --verify-vector sequence_operator --skip-compiled
+        python3 scripts/ci/run_tests.py --test-flags="--verify-vector=sequence_operator --skip-compiled" ./build/release/test/unittest
 
     - name: Test nested_shuffle
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --verify-vector nested_shuffle --skip-compiled
+        python3 scripts/ci/run_tests.py --test-flags="--verify-vector=nested_shuffle --skip-compiled" ./build/release/test/unittest
 
     - name: Test variant_vector
       if: (success() || failure()) && steps.build.conclusion == 'success'
@@ -558,7 +558,7 @@ jobs:
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --on-init "SET debug_physical_table_scan_execution_strategy=SYNCHRONOUS;"
+        python3 scripts/ci/run_tests.py --test-flags='--on-init "SET debug_physical_table_scan_execution_strategy=SYNCHRONOUS;"' ./build/release/test/unittest
 
     - name: Test block prefetching
       if: (success() || failure()) && steps.build.conclusion == 'success'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -444,73 +444,73 @@ jobs:
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/force_storage.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/force_storage.json ./build/release/test/unittest
 
     - name: test/configs/force_storage_restart.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/force_storage_restart.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/force_storage_restart.json ./build/release/test/unittest
 
     - name: test/configs/latest_storage.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/latest_storage.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/latest_storage.json ./build/release/test/unittest
 
     - name: test/configs/block_verification.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/block_verification.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/block_verification.json ./build/release/test/unittest
 
     - name: test/configs/verify_fetch_row.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/verify_fetch_row.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/verify_fetch_row.json ./build/release/test/unittest
 
     - name: test/configs/wal_verification.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/wal_verification.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/wal_verification.json ./build/release/test/unittest
 
     - name: test/configs/prefetch_all_parquet_files.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/prefetch_all_parquet_files.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/prefetch_all_parquet_files.json ./build/release/test/unittest
 
     - name: test/configs/no_local_filesystem.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/no_local_filesystem.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/no_local_filesystem.json ./build/release/test/unittest
 
     - name: test/configs/block_size_16kB.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/block_size_16kB.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/block_size_16kB.json ./build/release/test/unittest
 
     - name: test/configs/latest_storage_block_size_16kB.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/latest_storage_block_size_16kB.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/latest_storage_block_size_16kB.json ./build/release/test/unittest
 
     - name: test/configs/enable_verification.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/enable_verification.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/enable_verification.json ./build/release/test/unittest
 
     - name: test/configs/block_allocator_100mib.json
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/block_allocator_100mib.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/block_allocator_100mib.json ./build/release/test/unittest
 
     - name: Test dictionary_expression
       if: (success() || failure()) && steps.build.conclusion == 'success'
@@ -546,13 +546,13 @@ jobs:
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/variant_vector.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/variant_vector.json ./build/release/test/unittest
 
     - name: Test variant_vector
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/compressed_in_memory.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/compressed_in_memory.json ./build/release/test/unittest
 
     - name: Test sycnronous table scan implementation
       if: (success() || failure()) && steps.build.conclusion == 'success'
@@ -564,7 +564,7 @@ jobs:
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/prefetch_all_storage.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/prefetch_all_storage.json ./build/release/test/unittest
 
     - name: Forwards compatibility tests
       if: (success() || failure()) && steps.build.conclusion == 'success'
@@ -597,16 +597,16 @@ jobs:
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/encryption.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/encryption.json ./build/release/test/unittest
 
     - name: Test PEG parser on fallback mode
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/peg_parser.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/peg_parser.json ./build/release/test/unittest
 
     - name: Test PEG parser on strict when supported mode
       if: (success() || failure()) && steps.build.conclusion == 'success'
       shell: bash
       run: |
-        ./build/release/test/unittest --test-config test/configs/peg_parser_strict.json
+        python3 scripts/ci/run_tests.py --test-config=test/configs/peg_parser_strict.json ./build/release/test/unittest

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -190,7 +190,7 @@ jobs:
     - name: Test
       shell: bash
       run: |
-          build/release/test/unittest "*"
+          make allunit
 
   release-assert-clang:
     name: Release Assertions with Clang

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -476,11 +476,11 @@ jobs:
 
       - name: All tests with 512 vector size and default block size
         shell: bash
-        run: ./build/relassert/test/unittest "*" --test-config test/configs/vector_size_512.json
+        run: python3 scripts/ci/run_tests.py --test-config=test/configs/vector_size_512.json ./build/relassert/test/unittest "*"
 
       - name: All tests with 512 vector size and 16kB block size
         shell: bash
-        run: ./build/relassert/test/unittest "*" --test-config test/configs/block_size_16kB.json
+        run: python3 scripts/ci/run_tests.py --test-config=test/configs/block_size_16kB.json ./build/relassert/test/unittest "*"
 
   linux-debug-configs:
     name: Tests different configurations with a debug build
@@ -517,7 +517,7 @@ jobs:
       - name: test/configs/enable_verification_for_debug.json
         if: (success() || failure()) && steps.build.conclusion == 'success'
         shell: bash
-        run: ./build/debug/test/unittest --test-config test/configs/enable_verification_for_debug.json
+        run: python3 scripts/ci/run_tests.py --test-config=test/configs/enable_verification_for_debug.json ./build/debug/test/unittest
 
   force-blocking-sink-source:
     name: Forcing async Sinks/Sources
@@ -662,4 +662,4 @@ jobs:
 
      - name: Test
        shell: bash
-       run: build/relassert/test/unittest --test-config test/configs/hash_zero.json
+       run: python3 scripts/ci/run_tests.py --test-config=test/configs/hash_zero.json build/relassert/test/unittest

--- a/Makefile
+++ b/Makefile
@@ -402,6 +402,9 @@ unittest_reldebug:
 unittest_release: release
 	$(PYTHON) scripts/ci/run_tests.py build/release/test/unittest $(T)
 
+unittest_release_tag:
+	$(PYTHON) scripts/ci/run_tests.py --test-flags="--select-tag release" ./build/release/test/unittest $(T)
+
 unittest_relassert:
 	$(PYTHON) scripts/ci/run_tests.py build/relassert/test/unittest $(T)
 

--- a/Makefile
+++ b/Makefile
@@ -421,12 +421,9 @@ allunit: release
 endif
 
 unittest_threadsan: unittest_reldebug
-	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) build/reldebug/test/unittest "[intraquery]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) build/reldebug/test/unittest "[interquery]" $(T)
+	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) build/reldebug/test/unittest "[intraquery],[interquery],[detailed_profiler],test/sql/tpch/tpch_sf01.test_slow" $(T)
 	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) --test-flags="--force-storage" build/reldebug/test/unittest "[interquery]" $(T)
 	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) --test-flags="--force-storage --force-reload" build/reldebug/test/unittest "[interquery]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_SLOW_FLAGS) build/reldebug/test/unittest "[detailed_profiler]" $(T)
-	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_SLOW_FLAGS) build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow $(T)
 
 docs:
 	mkdir -p ./build/docs && \

--- a/Makefile
+++ b/Makefile
@@ -420,6 +420,7 @@ ifndef CI
 allunit: release
 endif
 
+unittest_threadsan: export TSAN_OPTIONS ?= "suppressions=./.sanitizer-thread-suppressions.txt"
 unittest_threadsan: unittest_reldebug
 	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) build/reldebug/test/unittest "[intraquery],[interquery],[detailed_profiler],test/sql/tpch/tpch_sf01.test_slow" $(T)
 	$(PYTHON) scripts/ci/run_tests.py $(UNITTEST_HUGE_FLAGS) --test-flags="--force-storage" build/reldebug/test/unittest "[interquery]" $(T)

--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ unittest_reldebug:
 	$(PYTHON) scripts/ci/run_tests.py build/reldebug/test/unittest $(T)
 
 unittest_release: release
-	build/release/test/unittest
+	$(PYTHON) scripts/ci/run_tests.py build/release/test/unittest $(T)
 
 unittest_relassert:
 	$(PYTHON) scripts/ci/run_tests.py build/relassert/test/unittest $(T)
@@ -412,7 +412,7 @@ runnertests:
 	python3 -m unittest scripts.ci.test_run_tests
 
 unittestarrow:
-	build/debug/test/unittest "[arrow]"
+	$(PYTHON) scripts/ci/run_tests.py build/debug/test/unittest "[arrow]"
 
 allunit:
 	$(PYTHON) scripts/ci/run_tests.py --workers=50% build/release/test/unittest '*' $(T)
@@ -534,7 +534,7 @@ third_party/sqllogictest:
 
 sqlite: release | third_party/sqllogictest
 	git --git-dir third_party/sqllogictest/.git pull
-	./build/release/test/unittest "[sqlitelogic]"
+	$(PYTHON) scripts/ci/run_tests.py ./build/release/test/unittest "[sqlitelogic]"
 
 sqlsmith: debug
 	./build/debug/third_party/sqlsmith/sqlsmith --duckdb=:memory:

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -428,7 +428,8 @@ def main():
     args = parse_args()
     test_flags = args.test_flags
     for config in args.test_config:
-        config_flag = f"--test-config={shlex.quote(config)}"
+        # The unittest binary parses "--test-config" as a separate option + value pair.
+        config_flag = f"--test-config {shlex.quote(config)}"
         test_flags = " ".join(flag for flag in [test_flags, config_flag] if flag)
     max_failures = args.max_failures
     if args.fail_fast:

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 DEFAULT_BATCH_SIZE = 10
@@ -467,13 +467,15 @@ def main():
         tests = load_tests(config.test_list)
         batch_size = compute_batch_size(len(tests), config)
 
-        print(
-            f"found {len(tests)} tests, batch_size={batch_size}, workers={config.workers}, "
-            f"retry={config.retry}, "
-            f"runtime_threshold={config.runtime_threshold_seconds}s, "
-            f"rss_memory_threshold={config.rss_memory_threshold_mib}MiB, "
-            f"batch_timeout={config.batch_timeout_seconds}s"
-        )
+        print(f"found {len(tests)} tests")
+        config_values = asdict(config)
+        config_values["batch_size"] = batch_size
+        config_values.pop("test_list", None)
+        config_values.pop("unittest_bin", None)
+        config_values.pop("test_command", None)
+        config_values = {k: v for k, v in config_values.items() if v is not None and v != "" and v != []}
+        config_output = ", ".join(f"{key}={value}" for key, value in config_values.items())
+        print(f"config: {config_output}")
 
         batches = list(chunked(tests, batch_size))
         return run_tests(config, batches)

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -33,7 +33,7 @@ class TestRunnerConfig:
     test_list: Path
     unittest_bin: str
     test_flags: str
-    pattern: str
+    patterns: list[str]
     test_command: str
     workers: int
     retry: int
@@ -180,10 +180,10 @@ def resolve_workers(workers: str):
     return max(1, int(workers))
 
 
-def generate_test_list(test_file, unittest_bin: str, test_flags: str, pattern: str):
+def generate_test_list(test_file, unittest_bin: str, test_flags: str, patterns: list[str]):
     # Catch can return a non-zero status code for list commands when tests
     # are found, so we accept non-zero if stdout still contains test output.
-    command = [unittest_bin, *shlex.split(test_flags), "--list-tests", pattern]
+    command = [unittest_bin, *shlex.split(test_flags), "--list-tests", *patterns]
     print(f"generated test list using: {shlex.join(command)}")
     proc = subprocess.run(
         command,
@@ -202,14 +202,14 @@ def generate_test_list(test_file, unittest_bin: str, test_flags: str, pattern: s
 
 
 @contextlib.contextmanager
-def open_test_list(test_list: Path | None, unittest_bin: str, test_flags: str, pattern: str):
+def open_test_list(test_list: Path | None, unittest_bin: str, test_flags: str, patterns: list[str]):
     if test_list is not None:
         with test_list.open("r", encoding="utf8") as test_file:
             yield Path(test_file.name)
         return
 
     with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=True) as test_file:
-        generate_test_list(test_file, unittest_bin, test_flags, pattern)
+        generate_test_list(test_file, unittest_bin, test_flags, patterns)
         yield Path(test_file.name)
 
 
@@ -393,7 +393,7 @@ def parse_args():
         help="additional flags appended to the unittest binary for listing and execution",
     )
     parser.add_argument("unittest_bin")
-    parser.add_argument("pattern", nargs="?", default="")
+    parser.add_argument("patterns", nargs="*")
     parser.add_argument(
         "--test-command",
         default="{binary} {flags} --use-colour yes -f {test_list}",
@@ -420,7 +420,9 @@ def parse_args():
     parser.add_argument("--max-retries", type=int, default=DEFAULT_MAX_RETRIES)
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
     parser.add_argument("--batch-timeout", type=int, default=DEFAULT_BATCH_TIMEOUT_SECONDS)
-    return parser.parse_args()
+    # Accept options interleaved with positional patterns, e.g.:
+    #   run_tests.py bin "[tag]" --fail-fast test/sql/foo.test
+    return parser.parse_intermixed_args()
 
 
 def main():
@@ -445,12 +447,12 @@ def main():
         batch_size = 1
     else:
         batch_size = args.batch_size
-    with open_test_list(args.test_list, args.unittest_bin, test_flags, args.pattern) as test_file:
+    with open_test_list(args.test_list, args.unittest_bin, test_flags, args.patterns) as test_file:
         config = TestRunnerConfig(
             test_list=test_file,
             unittest_bin=args.unittest_bin,
             test_flags=test_flags,
-            pattern=args.pattern,
+            patterns=args.patterns,
             test_command=args.test_command,
             workers=workers,
             retry=retry,

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -382,6 +382,12 @@ def parse_args():
     parser.add_argument("--test-list", type=Path)
     parser.add_argument("--workers", default=DEFAULT_WORKERS)
     parser.add_argument(
+        "--test-config",
+        action="append",
+        default=[],
+        help="path to test config; may be passed multiple times and is appended to test flags",
+    )
+    parser.add_argument(
         "--test-flags",
         default="",
         help="additional flags appended to the unittest binary for listing and execution",
@@ -420,6 +426,10 @@ def parse_args():
 def main():
     enable_line_buffering()
     args = parse_args()
+    test_flags = args.test_flags
+    for config in args.test_config:
+        config_flag = f"--test-config={shlex.quote(config)}"
+        test_flags = " ".join(flag for flag in [test_flags, config_flag] if flag)
     max_failures = args.max_failures
     if args.fail_fast:
         max_failures = 1
@@ -434,11 +444,11 @@ def main():
         batch_size = 1
     else:
         batch_size = args.batch_size
-    with open_test_list(args.test_list, args.unittest_bin, args.test_flags, args.pattern) as test_file:
+    with open_test_list(args.test_list, args.unittest_bin, test_flags, args.pattern) as test_file:
         config = TestRunnerConfig(
             test_list=test_file,
             unittest_bin=args.unittest_bin,
-            test_flags=args.test_flags,
+            test_flags=test_flags,
             pattern=args.pattern,
             test_command=args.test_command,
             workers=workers,

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -480,6 +480,7 @@ def main():
 
 
 def run_tests(config: TestRunnerConfig, batches):
+    start = time.monotonic()
     state = BatchRunState()
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=config.workers) as executor:
@@ -505,11 +506,12 @@ def run_tests(config: TestRunnerConfig, batches):
             if not state.stop_launching:
                 next_batch_idx = submit_batches(executor, config, batches, future_to_batch, next_batch_idx)
 
+    elapsed = time.monotonic() - start
     if state.failed_count:
-        print(f"error: found {state.failed_count} test batch failures")
+        print(f"error: found {state.failed_count} test batch failures in {elapsed:.0f}s")
         return 1
 
-    print("all tests passed.")
+    print(f"all tests passed in {elapsed:.0f}s")
     return 0
 
 

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -62,7 +62,7 @@ class RunTestsScriptTest(unittest.TestCase):
         self.assertIn("found 2 tests", proc.stdout)
         self.assertIn("test/sql/slow.test took", proc.stdout)
         self.assertIn("test/sql/fast.test took", proc.stdout)
-        self.assertIn("all tests passed.", proc.stdout)
+        self.assertIn("all tests passed in ", proc.stdout)
 
     def test_runs_with_echo_test_command(self):
         with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as test_list:
@@ -96,7 +96,7 @@ class RunTestsScriptTest(unittest.TestCase):
 
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn("found 2 tests", proc.stdout)
-        self.assertIn("all tests passed.", proc.stdout)
+        self.assertIn("all tests passed in ", proc.stdout)
 
     def test_retries_failed_fake_job(self):
         with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as test_list:
@@ -154,7 +154,7 @@ class RunTestsScriptTest(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn("retrying failed test batch 0 (attempt 1/1, retry 1/4)", proc.stdout)
         self.assertIn("fake failure", proc.stdout)
-        self.assertIn("all tests passed.", proc.stdout)
+        self.assertIn("all tests passed in ", proc.stdout)
 
     def test_retries_timed_out_sleep_job(self):
         with tempfile.NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as test_list:
@@ -207,7 +207,7 @@ class RunTestsScriptTest(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertIn("batch timed out after 1 seconds", proc.stdout)
         self.assertIn("retrying failed test", proc.stdout)
-        self.assertIn("all tests passed.", proc.stdout)
+        self.assertIn("all tests passed in ", proc.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/coverage_check.sh
+++ b/scripts/coverage_check.sh
@@ -11,9 +11,9 @@ mkdir -p build/coverage
 (cd build/coverage && cmake -E env CXXFLAGS="--coverage" cmake -DBUILD_EXTENSIONS="parquet;json;jemalloc;autocomplete;icu" -DENABLE_SANITIZER=0 -DCMAKE_BUILD_TYPE=Debug ../.. && cmake --build .)
 
 # run tests
-build/coverage/test/unittest
-build/coverage/test/unittest "[detailed_profiler]"
-build/coverage/test/unittest test/sql/tpch/tpch_sf01.test_slow
+python3 scripts/ci/run_tests.py build/coverage/test/unittest
+python3 scripts/ci/run_tests.py build/coverage/test/unittest "[detailed_profiler]"
+python3 scripts/ci/run_tests.py build/coverage/test/unittest test/sql/tpch/tpch_sf01.test_slow
 python3 -m pytest --shell-binary build/coverage/duckdb tools/shell/tests/
 
 # finalize coverage file

--- a/scripts/run_extension_medata_tests.sh
+++ b/scripts/run_extension_medata_tests.sh
@@ -176,4 +176,4 @@ export REMOTE_EXTENSION_REPO_DIRECT_PATH=http://duckdb-minio.com:9000/test-bucke
 ################
 ### Run test
 ################
-RUN_EXTENSION_UPDATE_TEST=1 $DUCKDB_BUILD_DIR/test/unittest test/extension/update_extensions_ci.test
+RUN_EXTENSION_UPDATE_TEST=1 python3 scripts/ci/run_tests.py $DUCKDB_BUILD_DIR/test/unittest test/extension/update_extensions_ci.test

--- a/scripts/test_serialization_bwc.py
+++ b/scripts/test_serialization_bwc.py
@@ -111,7 +111,10 @@ def run_test(filename, old_source, new_source, no_exit):
     # generate the serialization
     my_env = os.environ.copy()
     my_env['GEN_PLAN_STORAGE'] = '1'
-    res = subprocess.run(['build/debug/test/unittest', 'Generate serialized plans file'], env=my_env).returncode
+    res = subprocess.run(
+        ['python3', 'scripts/ci/run_tests.py', 'build/debug/test/unittest', 'Generate serialized plans file'],
+        env=my_env,
+    ).returncode
     if res != 0:
         print(f"SKIPPING TEST {filename}")
         return True
@@ -125,7 +128,9 @@ def run_test(filename, old_source, new_source, no_exit):
     # run the verification
     os.chdir(new_source)
 
-    res = subprocess.run(['build/debug/test/unittest', "Test deserialized plans from file"]).returncode
+    res = subprocess.run(
+        ['python3', 'scripts/ci/run_tests.py', 'build/debug/test/unittest', "Test deserialized plans from file"]
+    ).returncode
     if res != 0:
         if no_exit:
             print("BROKEN TEST")

--- a/test/sqlite/test_sqllogictest.cpp
+++ b/test/sqlite/test_sqllogictest.cpp
@@ -34,6 +34,14 @@ static bool endsWith(const string &mainStr, const string &toMatch) {
 	        mainStr.compare(mainStr.size() - toMatch.size(), toMatch.size(), toMatch) == 0);
 }
 
+static void register_sqllogic_test_case(void (*test_fun)(), const string &path, const string &tags) {
+	auto normalized_path = StringUtil::Replace(path, "\\", "/");
+	if (TestConfiguration::Get().ShouldSkipTest(normalized_path)) {
+		return;
+	}
+	REGISTER_TEST_CASE(test_fun, normalized_path, tags);
+}
+
 template <bool AUTO_SWITCH_TEST_DIR = false>
 static void testRunner() {
 	// this is an ugly hack that uses the test case name to pass the script file
@@ -203,13 +211,13 @@ void RegisterSqllogictests() {
 					return;
 				}
 			}
-			REGISTER_TEST_CASE(testRunner, StringUtil::Replace(path, "\\", "/"), "[sqlitelogic][.]");
+			register_sqllogic_test_case(testRunner<>, path, "[sqlitelogic][.]");
 		}
 	});
 	listFiles(*fs, "test", [&](const string &path) {
 		if (endsWith(path, ".test") || endsWith(path, ".test_slow") || endsWith(path, ".test_coverage")) {
 			// parse the name / group from the test
-			REGISTER_TEST_CASE(testRunner<false>, StringUtil::Replace(path, "\\", "/"), ParseGroupFromPath(path));
+			register_sqllogic_test_case(testRunner<false>, path, ParseGroupFromPath(path));
 		}
 	});
 
@@ -217,7 +225,7 @@ void RegisterSqllogictests() {
 		listFiles(*fs, extension_test_path, [&](const string &path) {
 			if (endsWith(path, ".test") || endsWith(path, ".test_slow") || endsWith(path, ".test_coverage")) {
 				auto fun = testRunner<true>;
-				REGISTER_TEST_CASE(fun, StringUtil::Replace(path, "\\", "/"), ParseGroupFromPath(path));
+				register_sqllogic_test_case(fun, path, ParseGroupFromPath(path));
 			}
 		});
 	}

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -1,5 +1,6 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
+#include <stdlib.h>
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -62,6 +63,19 @@ int main(int argc_in, char *argv[]) {
 		fprintf(stderr, "Failed to create testing directory \"%s\": %s\n", dir.c_str(), ex.what());
 		return 1;
 	}
+
+	// Override the home dir so the .duckdb dir is isolated per test process.
+#ifdef DUCKDB_WINDOWS
+	if (_putenv_s("USERPROFILE", dir.c_str()) != 0) {
+		fprintf(stderr, "Failed to set USERPROFILE environment variable\n");
+		return 1;
+	}
+#else
+	if (setenv("HOME", dir.c_str(), 1) != 0) {
+		fprintf(stderr, "Failed to set HOME environment variable\n");
+		return 1;
+	}
+#endif
 
 	if (test_config.GetSkipCompiledTests()) {
 		Catch::getMutableRegistryHub().clearTests();

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -12,6 +12,7 @@ using namespace duckdb;
 int main(int argc_in, char *argv[]) {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
 	string test_directory = DUCKDB_ROOT_DIRECTORY;
+	bool has_test_config_arg = false;
 
 	auto &test_config = TestConfiguration::Get();
 	test_config.Initialize();
@@ -34,12 +35,22 @@ int main(int argc_in, char *argv[]) {
 			SetTestDirectory(test_dir);
 		} else if (argument == "--require") {
 			AddRequire(string(argv[++i]));
+		} else if (argument == "--test-config") {
+			has_test_config_arg = true;
+			if (!test_config.ParseArgument(argument, argc, argv, i)) {
+				new_argv[new_argc] = argv[i];
+				new_argc++;
+			}
 		} else if (!test_config.ParseArgument(argument, argc, argv, i)) {
 			new_argv[new_argc] = argv[i];
 			new_argc++;
 		}
 	}
 	test_config.ChangeWorkingDirectory(test_directory);
+	if (has_test_config_arg && !test_config.GetSkipCompiledTests()) {
+		fprintf(stderr, "--test-config requires \"skip_compiled\": true in the config\n");
+		return 1;
+	}
 
 	// delete the testing directory if it exists
 	auto dir = TestCreatePath("");


### PR DESCRIPTION
### Context

This is a follow-up of https://github.com/duckdb/duckdb/pull/21181.

### Important changes

- Filter `skip_tests` entries from `--list-tests` with `--test-config`.
  - For safety, I've added a runtime error for a `--test-config` without `skip_compiled=true`. We might need additional filtering to support that use case.
- Add flag `--test-config=...` to forward `--test-config=...` easily to the unittest binary.
- Use new test runner for plain unittest binary invocations.
- Run threadsan tests with default config in parallel instead of starting the test runner sequentially.
  - See catch2 [CLI examples](https://github.com/catchorg/Catch2/blob/devel/docs/command-line.md#examples) for the `[group1],[group2],some.test` syntax logic.
- Override `$HOME` in unittest to isolate parallel test runs.
   - Fixes an extension locking issue [caused](https://github.com/duckdb/duckdb/pull/21212#issuecomment-4010777023) by parallel tests. @Mytherin FYI.
- Use a small namespace runner (only for `duckdb/duckdb`, not forks) for the `prepare` job.
  - I have another PR where I'm integrating `format-check` into `prepare`.
  - For now, this change means we can start `prepare` even under CI load caused by many parallel v1.5 CI runs.

### Minor changes

- Simplify some CI job unittest invocations with existing make targets.
- Print elapsed test time: `all tests passed in ...s` at the end.
- Print the test config dynamically instead of hardcoding keys/values.