### PR TITLE
[Extensions] Preserve `require` order in `InterpretedBenchmark`

### DIFF
--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -131,6 +131,17 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 	duckdb::unique_ptr<BenchmarkState> state;
 	try {
 		state = benchmark->Initialize(configuration);
+
+		// Set up local extension repository if environment variable is set
+		auto local_repo = getenv("LOCAL_EXTENSION_REPO");
+		if (local_repo) {
+			auto &db = state->db->GetDatabase();
+			auto &context = *state->context;
+			context.Query("SET autoinstall_extension_repository='" + string(local_repo) + "'", false);
+			context.Query("SET autoinstall_known_extensions=true", false);
+			context.Query("SET autoload_known_extensions=true", false);
+		}
+
 		benchmark->Assert(state.get());
 	} catch (std::exception &ex) {
 		Log(StringUtil::Format("%s\t1\t", benchmark->name));

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -131,17 +131,6 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 	duckdb::unique_ptr<BenchmarkState> state;
 	try {
 		state = benchmark->Initialize(configuration);
-
-		// Set up local extension repository if environment variable is set
-		auto local_repo = getenv("LOCAL_EXTENSION_REPO");
-		if (local_repo) {
-			auto &db = state->db->GetDatabase();
-			auto &context = *state->context;
-			context.Query("SET autoinstall_extension_repository='" + string(local_repo) + "'", false);
-			context.Query("SET autoinstall_known_extensions=true", false);
-			context.Query("SET autoload_known_extensions=true", false);
-		}
-
 		benchmark->Assert(state.get());
 	} catch (std::exception &ex) {
 		Log(StringUtil::Format("%s\t1\t", benchmark->name));

--- a/benchmark/include/interpreted_benchmark.hpp
+++ b/benchmark/include/interpreted_benchmark.hpp
@@ -11,6 +11,7 @@
 
 #include <unordered_map>
 #include <unordered_set>
+#include "duckdb/common/insertion_order_preserving_map.hpp"
 
 namespace duckdb {
 struct BenchmarkFileReader;
@@ -33,7 +34,7 @@ public:
 //! Interpreted benchmarks read the benchmark from a file
 class InterpretedBenchmark : public Benchmark {
 public:
-	InterpretedBenchmark(string full_path);
+	explicit InterpretedBenchmark(string full_path);
 
 	void LoadBenchmark();
 	//! Initialize the benchmark state
@@ -84,6 +85,8 @@ private:
 	unique_ptr<QueryResult> RunLoadQuery(InterpretedBenchmarkState &state, const string &load_query);
 
 	void ProcessFile(const string &path);
+	void AddExtension(const string &extension, bool load_only);
+	void LoadExtensions(InterpretedBenchmarkState &state, bool is_load_set);
 
 private:
 	bool is_loaded = false;
@@ -99,8 +102,9 @@ private:
 	// check the existence of a cached db, but do not connect
 	// can be used to test accessing data from a different db in a non-persistent connection
 	bool cache_no_connect = false;
-	std::unordered_set<string> extensions;
-	std::unordered_set<string> load_extensions;
+	std::vector<string> extensions;
+	InsertionOrderPreservingMap<idx_t> extensions_map;
+	InsertionOrderPreservingMap<idx_t> load_extensions_map;
 
 	//! Queries used to assert a given state of the data
 	vector<BenchmarkQuery> assert_queries;

--- a/benchmark/include/interpreted_benchmark.hpp
+++ b/benchmark/include/interpreted_benchmark.hpp
@@ -102,7 +102,6 @@ private:
 	// check the existence of a cached db, but do not connect
 	// can be used to test accessing data from a different db in a non-persistent connection
 	bool cache_no_connect = false;
-	std::vector<string> extensions;
 	InsertionOrderPreservingMap<idx_t> extensions_map;
 	InsertionOrderPreservingMap<idx_t> load_extensions_map;
 

--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -164,9 +164,7 @@ void InterpretedBenchmark::AddExtension(const string &extension, bool load_only)
 	if (it != map.end()) {
 		return;
 	}
-	auto index = extensions.size();
-	extensions.push_back(extension);
-	map.insert(extension, index);
+	map.insert(extension, map.size());
 }
 
 void InterpretedBenchmark::ProcessFile(const string &path) {
@@ -492,7 +490,7 @@ void InterpretedBenchmark::LoadBenchmark() {
 void InterpretedBenchmark::LoadExtensions(InterpretedBenchmarkState &state, bool is_load_set) {
 	auto &map = is_load_set ? load_extensions_map : extensions_map;
 	for (auto &it : map) {
-		auto &extension = extensions[it.second];
+		auto &extension = it.first;
 		auto result = ExtensionHelper::LoadExtension(state.db, extension);
 		if (result == ExtensionLoadResult::EXTENSION_UNKNOWN) {
 			throw InvalidInputException("Unknown extension " + extension);

--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -158,6 +158,17 @@ static void ThrowResultModeError(BenchmarkFileReader &reader) {
 	throw std::runtime_error(reader.FormatException(error));
 }
 
+void InterpretedBenchmark::AddExtension(const string &extension, bool load_only) {
+	auto &map = load_only ? load_extensions_map : extensions_map;
+	auto it = map.find(extension);
+	if (it != map.end()) {
+		return;
+	}
+	auto index = extensions.size();
+	extensions.push_back(extension);
+	map.insert(extension, index);
+}
+
 void InterpretedBenchmark::ProcessFile(const string &path) {
 	BenchmarkFileReader reader(path, replacement_mapping);
 	string line;
@@ -212,9 +223,9 @@ void InterpretedBenchmark::ProcessFile(const string &path) {
 					throw std::runtime_error(
 					    reader.FormatException("require only supports load_only as a second parameter"));
 				}
-				load_extensions.insert(splits[1]);
+				AddExtension(splits[1], true);
 			} else {
-				extensions.insert(splits[1]);
+				AddExtension(splits[1], false);
 			}
 		} else if (splits[0] == "resultmode") {
 			if (splits.size() < 2) {
@@ -478,8 +489,10 @@ void InterpretedBenchmark::LoadBenchmark() {
 	is_loaded = true;
 }
 
-void LoadExtensions(InterpretedBenchmarkState &state, const std::unordered_set<string> &extensions_to_load) {
-	for (auto &extension : extensions_to_load) {
+void InterpretedBenchmark::LoadExtensions(InterpretedBenchmarkState &state, bool is_load_set) {
+	auto &map = is_load_set ? load_extensions_map : extensions_map;
+	for (auto &it : map) {
+		auto &extension = extensions[it.second];
 		auto result = ExtensionHelper::LoadExtension(state.db, extension);
 		if (result == ExtensionLoadResult::EXTENSION_UNKNOWN) {
 			throw InvalidInputException("Unknown extension " + extension);
@@ -491,7 +504,7 @@ void LoadExtensions(InterpretedBenchmarkState &state, const std::unordered_set<s
 }
 
 unique_ptr<QueryResult> InterpretedBenchmark::RunLoadQuery(InterpretedBenchmarkState &state, const string &load_query) {
-	LoadExtensions(state, load_extensions);
+	LoadExtensions(state, true);
 	auto result = state.con.Query(load_query);
 	for (idx_t i = 0; i < retry_load; i++) {
 		if (!result->HasError()) {
@@ -515,10 +528,10 @@ unique_ptr<BenchmarkState> InterpretedBenchmark::Initialize(BenchmarkConfigurati
 		DeleteDatabase(full_db_path);
 		state = make_uniq<InterpretedBenchmarkState>(full_db_path, storage_version);
 	}
-	extensions.insert("core_functions");
-	extensions.insert("parquet");
+	AddExtension("core_functions", false);
+	AddExtension("parquet", false);
 
-	LoadExtensions(*state, extensions);
+	LoadExtensions(*state, false);
 	if (queries.find("init") != queries.end()) {
 		string init_query = queries["init"];
 		result = state->con.Query(init_query);


### PR DESCRIPTION
Before this was using an `unordered_set` which does not have a defined order, and doesn't preserve any order either.
This causes problems for extensions like `duckdb-iceberg`, which require `avro` and `parquet` to be loaded before `iceberg` itself gets loaded.

```sql
require avro

require parquet

require iceberg

require httpfs
```