### PR TITLE
Fix TYPE -> VARCHAR cast target type check

### DIFF
--- a/src/function/cast/type_cast.cpp
+++ b/src/function/cast/type_cast.cpp
@@ -5,7 +5,7 @@ namespace duckdb {
 
 BoundCastInfo DefaultCasts::TypeCastSwitch(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
 	// now switch on the result type
-	if (target == LogicalType::VARCHAR) {
+	if (target.id() == LogicalType::VARCHAR) {
 		// type to varchar
 		return BoundCastInfo(&VectorCastHelpers::StringCast<string_t, duckdb::CastFromType>);
 	}


### PR DESCRIPTION
Seems like this was a small oversight in #20355. This would cause casts to aliases of VARCHAR to fail always return NULL instead of the typename as a VARCHAR.
