### PR TITLE
Fix prepared statement reuse for some statistics-based rewrites

### DIFF
--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -113,6 +113,8 @@ private:
 	//! Try to execute aggregates using only the statistics if possible
 	void TryExecuteAggregates(LogicalAggregate &op, unique_ptr<LogicalOperator> &node_ptr);
 	void ReplaceWithEmptyResult(unique_ptr<LogicalOperator> &node);
+	//! Mark that the optimized plan is snapshot-sensitive and should not be reused without rebind
+	void MarkRequiresRebind();
 
 	bool ExpressionIsConstant(Expression &expr, const Value &val);
 	bool ExpressionIsConstantOrNull(Expression &expr, const Value &val);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -526,6 +526,7 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 		logical_plan->Verify(*this);
 #endif
 	}
+	result->properties.always_require_rebind = logical_planner.binder->GetStatementProperties().always_require_rebind;
 
 	// Convert the logical query plan into a physical query plan.
 	{

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -213,6 +213,7 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 			return;
 		}
 	}
+	MarkRequiresRebind();
 
 	vector<LogicalType> types;
 	vector<unique_ptr<Expression>> agg_results;

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -1,5 +1,7 @@
 #include "duckdb/common/helper.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
+#include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
@@ -28,6 +30,10 @@ static void GetColumnIndex(const unique_ptr<Expression> &expr, idx_t &index, str
 	}
 	ExpressionIterator::EnumerateChildren(*expr,
 	                                      [&](unique_ptr<Expression> &child) { GetColumnIndex(child, index, alias); });
+}
+
+void StatisticsPropagator::MarkRequiresRebind() {
+	optimizer.binder.SetAlwaysRequireRebind();
 }
 
 FilterPropagateResult StatisticsPropagator::PropagateTableFilter(ColumnBinding stats_binding, BaseStatistics &stats,
@@ -198,6 +204,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 		auto propagate_result = PropagateTableFilter(stats_binding, stats, filter);
 		switch (propagate_result) {
 		case FilterPropagateResult::FILTER_ALWAYS_TRUE:
+			MarkRequiresRebind();
 			// filter is always true; it is useless to execute it
 			// erase this condition
 			get.table_filters.RemoveFilterByColumnIndex(table_filter_column);
@@ -206,6 +213,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 			if (IsConstantOrNullFilter(filter) && !CanReplaceConstantOrNull(filter)) {
 				break;
 			}
+			MarkRequiresRebind();
 			// filter is true or null; we can replace this with a not null filter
 			auto not_null = ExpressionFilter::CreateNullCheckExpression(
 			    make_uniq<BoundReferenceExpression>(stats.GetType(), 0ULL), ExpressionType::OPERATOR_IS_NOT_NULL);
@@ -215,6 +223,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 		}
 		case FilterPropagateResult::FILTER_FALSE_OR_NULL:
 		case FilterPropagateResult::FILTER_ALWAYS_FALSE:
+			MarkRequiresRebind();
 			// filter is always false; this entire filter should be replaced by an empty result block
 			ReplaceWithEmptyResult(node_ptr);
 			return make_uniq<NodeStatistics>(0U, 0U);

--- a/test/api/test_prepared_api.cpp
+++ b/test/api/test_prepared_api.cpp
@@ -522,6 +522,30 @@ TEST_CASE("Test prepared statements that require rebind", "[api]") {
 	REQUIRE_NO_FAIL(prepared->Execute());
 }
 
+TEST_CASE("Prepared statements rebind after snapshot-pruned statistics rewrite", "[api]") {
+	DuckDB db(nullptr);
+	Connection prepare_con(db);
+	Connection writer_con(db);
+	Connection fresh_con(db);
+
+	REQUIRE_NO_FAIL(writer_con.Query("CREATE TABLE t_rebind_stats(id BIGINT, worker_id BIGINT, v BIGINT)"));
+	REQUIRE_NO_FAIL(
+	    writer_con.Query("INSERT INTO t_rebind_stats SELECT i, 14, 1 FROM range(1, 251) tbl(i)"));
+
+	auto prepared =
+	    prepare_con.Prepare("SELECT CAST(COUNT(*) AS BIGINT) FROM t_rebind_stats WHERE worker_id = 14");
+	REQUIRE(prepared->success);
+
+	REQUIRE_NO_FAIL(
+	    writer_con.Query("INSERT INTO t_rebind_stats SELECT i, 15, 1 FROM range(251, 501) tbl(i)"));
+
+	auto prepared_result = prepared->Execute();
+	auto fresh_result =
+	    fresh_con.Query("SELECT CAST(COUNT(*) AS BIGINT) FROM t_rebind_stats WHERE worker_id = 14");
+	REQUIRE(CHECK_COLUMN(prepared_result, 0, {250}));
+	REQUIRE(CHECK_COLUMN(fresh_result, 0, {250}));
+}
+
 class TestExtensionState : public ClientContextState {
 public:
 	bool CanRequestRebind() override {

--- a/test/api/test_prepared_api.cpp
+++ b/test/api/test_prepared_api.cpp
@@ -529,19 +529,15 @@ TEST_CASE("Prepared statements rebind after snapshot-pruned statistics rewrite",
 	Connection fresh_con(db);
 
 	REQUIRE_NO_FAIL(writer_con.Query("CREATE TABLE t_rebind_stats(id BIGINT, worker_id BIGINT, v BIGINT)"));
-	REQUIRE_NO_FAIL(
-	    writer_con.Query("INSERT INTO t_rebind_stats SELECT i, 14, 1 FROM range(1, 251) tbl(i)"));
+	REQUIRE_NO_FAIL(writer_con.Query("INSERT INTO t_rebind_stats SELECT i, 14, 1 FROM range(1, 251) tbl(i)"));
 
-	auto prepared =
-	    prepare_con.Prepare("SELECT CAST(COUNT(*) AS BIGINT) FROM t_rebind_stats WHERE worker_id = 14");
+	auto prepared = prepare_con.Prepare("SELECT CAST(COUNT(*) AS BIGINT) FROM t_rebind_stats WHERE worker_id = 14");
 	REQUIRE(prepared->success);
 
-	REQUIRE_NO_FAIL(
-	    writer_con.Query("INSERT INTO t_rebind_stats SELECT i, 15, 1 FROM range(251, 501) tbl(i)"));
+	REQUIRE_NO_FAIL(writer_con.Query("INSERT INTO t_rebind_stats SELECT i, 15, 1 FROM range(251, 501) tbl(i)"));
 
 	auto prepared_result = prepared->Execute();
-	auto fresh_result =
-	    fresh_con.Query("SELECT CAST(COUNT(*) AS BIGINT) FROM t_rebind_stats WHERE worker_id = 14");
+	auto fresh_result = fresh_con.Query("SELECT CAST(COUNT(*) AS BIGINT) FROM t_rebind_stats WHERE worker_id = 14");
 	REQUIRE(CHECK_COLUMN(prepared_result, 0, {250}));
 	REQUIRE(CHECK_COLUMN(fresh_result, 0, {250}));
 }


### PR DESCRIPTION
I used GPT-5.4 to generate this patch to fix #21207. I have reviewed the outputs. This is a partial fix of the statistics pruning issues.

---

Statistics propagation can rewrite a plan based on snapshot-dependent table statistics, for example by removing a filter, replacing a filter with an empty result, or replacing COUNT(*) with a constant from partition stats. Those rewrites should not be reused across later executions of the same prepared statement.

Mark a known subset of these statistics-driven rewrites as always requiring rebind:
- LogicalGet table-filter pruning that changes semantics
- COUNT(*) rewrite from partition stats

Carry the binder's always_require_rebind flag into PreparedStatementData when the prepared statement is finalized.

Add a regression test that prepares a filtered COUNT(*), changes the table contents in another connection, and verifies the prepared execution now rebinds and returns the same result as a fresh query.

This is intentionally partial and does not attempt to cover every statistics-based rewrite.