### PR TITLE
[Julia] Add BLOB support

### DIFF
--- a/tools/juliapkg/src/api.jl
+++ b/tools/juliapkg/src/api.jl
@@ -7258,7 +7258,7 @@ function duckdb_append_blob(appender, data, length)
     return ccall(
         (:duckdb_append_blob, libduckdb),
         duckdb_state,
-        (duckdb_appender, Ref{Cvoid}, idx_t),
+        (duckdb_appender, Ptr{Cvoid}, idx_t),
         appender,
         data,
         length

--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -403,8 +403,8 @@ JULIA_TYPE_MAP = Dict(
     DUCKDB_TYPE_UUID => UUID,
     DUCKDB_TYPE_VARCHAR => String,
     DUCKDB_TYPE_ENUM => String,
-    DUCKDB_TYPE_BLOB => Base.CodeUnits{UInt8, String},
-    DUCKDB_TYPE_BIT => Base.CodeUnits{UInt8, String},
+    DUCKDB_TYPE_BLOB => Vector{UInt8},
+    DUCKDB_TYPE_BIT => Vector{UInt8},
     DUCKDB_TYPE_MAP => Dict
 )
 

--- a/tools/juliapkg/src/logical_type.jl
+++ b/tools/juliapkg/src/logical_type.jl
@@ -43,6 +43,7 @@ create_logical_type(::Type{T}) where {T <: Date} = DuckDB.LogicalType(DuckDB.DUC
 create_logical_type(::Type{T}) where {T <: Time} = DuckDB.LogicalType(DuckDB.DUCKDB_TYPE_TIME)
 create_logical_type(::Type{T}) where {T <: DateTime} = DuckDB.LogicalType(DuckDB.DUCKDB_TYPE_TIMESTAMP)
 create_logical_type(::Type{T}) where {T <: AbstractString} = DuckDB.LogicalType(DuckDB.DUCKDB_TYPE_VARCHAR)
+create_logical_type(::Type{Vector{UInt8}}) = DuckDB.LogicalType(DuckDB.DUCKDB_TYPE_BLOB)
 function create_logical_type(::Type{T}) where {T <: FixedDecimal}
     int_type = T.parameters[1]
     width = 0

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -65,22 +65,25 @@ end
 
 nop_convert(column_data::ColumnConversionData, val) = val
 
-function convert_string(column_data::ColumnConversionData, val::Ptr{Cvoid}, idx::UInt64)
+function _string_data_ptr(val::Ptr{Cvoid}, idx::UInt64)
     base_ptr = val + (idx - 1) * sizeof(duckdb_string_t)
-    length_ptr = Base.unsafe_convert(Ptr{Int32}, base_ptr)
-    length = unsafe_load(length_ptr)
-    if length <= STRING_INLINE_LENGTH
-        prefix_ptr = Base.unsafe_convert(Ptr{UInt8}, base_ptr + sizeof(Int32))
-        return unsafe_string(prefix_ptr, length)
+    len = unsafe_load(Base.unsafe_convert(Ptr{Int32}, base_ptr))
+    data_ptr = if len <= STRING_INLINE_LENGTH
+        Base.unsafe_convert(Ptr{UInt8}, base_ptr + sizeof(Int32))
     else
-        ptr_ptr = Base.unsafe_convert(Ptr{Ptr{UInt8}}, base_ptr + sizeof(Int32) * 2)
-        data_ptr = Base.unsafe_load(ptr_ptr)
-        return unsafe_string(data_ptr, length)
+        Base.unsafe_load(Base.unsafe_convert(Ptr{Ptr{UInt8}}, base_ptr + sizeof(Int32) * 2))
     end
+    return data_ptr, len
 end
 
-function convert_blob(column_data::ColumnConversionData, val::Ptr{Cvoid}, idx::UInt64)::Base.CodeUnits{UInt8, String}
-    return Base.codeunits(convert_string(column_data, val, idx))
+function convert_string(column_data::ColumnConversionData, val::Ptr{Cvoid}, idx::UInt64)
+    data_ptr, len = _string_data_ptr(val, idx)
+    return unsafe_string(data_ptr, len)
+end
+
+function convert_blob(column_data::ColumnConversionData, val::Ptr{Cvoid}, idx::UInt64)::Vector{UInt8}
+    data_ptr, len = _string_data_ptr(val, idx)
+    return unsafe_wrap(Array, data_ptr, len; own=false) |> copy
 end
 
 convert_date(column_data::ColumnConversionData, val) = convert(Date, val)

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -83,7 +83,7 @@ end
 
 function convert_blob(column_data::ColumnConversionData, val::Ptr{Cvoid}, idx::UInt64)::Vector{UInt8}
     data_ptr, len = _string_data_ptr(val, idx)
-    return unsafe_wrap(Array, data_ptr, len; own=false) |> copy
+    return unsafe_wrap(Array, data_ptr, len; own = false) |> copy
 end
 
 convert_date(column_data::ColumnConversionData, val) = convert(Date, val)

--- a/tools/juliapkg/src/table_scan.jl
+++ b/tools/juliapkg/src/table_scan.jl
@@ -80,7 +80,7 @@ end
 
 function tbl_scan_function(tbl, entry)
     result_type = table_result_type(tbl, entry)
-    if result_type <: AbstractString
+    if result_type <: AbstractString || result_type <: AbstractVector{UInt8}
         return tbl_scan_string_column
     end
     return tbl_scan_column

--- a/tools/juliapkg/src/value.jl
+++ b/tools/juliapkg/src/value.jl
@@ -49,6 +49,8 @@ create_value(val::T) where {T <: Time} = Value(duckdb_create_time(Dates.value(va
 create_value(val::T) where {T <: DateTime} =
     Value(duckdb_create_timestamp((Dates.datetime2epochms(val) - ROUNDING_EPOCH_TO_UNIX_EPOCH_MS) * 1000))
 create_value(val::T) where {T <: AbstractString} = Value(duckdb_create_varchar_length(val, length(val)))
+create_value(::Missing) = Value(duckdb_create_null_value())
+create_value(val::Vector{UInt8}) = Value(duckdb_create_blob(val, length(val)))
 function create_value(val::AbstractVector{T}) where {T}
     type = create_logical_type(T)
     values = create_value.(val)

--- a/tools/juliapkg/src/vector.jl
+++ b/tools/juliapkg/src/vector.jl
@@ -58,5 +58,5 @@ function assign_string_element(vector::Vec, index::Int64, str::AbstractString)
 end
 
 function assign_string_element(vector::Vec, index::Int64, data::Vector{UInt8})
-    duckdb_vector_assign_string_element_len(vector.handle, index, pointer(data), length(data))
+    return duckdb_vector_assign_string_element_len(vector.handle, index, pointer(data), length(data))
 end

--- a/tools/juliapkg/src/vector.jl
+++ b/tools/juliapkg/src/vector.jl
@@ -56,3 +56,7 @@ end
 function assign_string_element(vector::Vec, index::Int64, str::AbstractString)
     return duckdb_vector_assign_string_element_len(vector.handle, index, str, sizeof(str))
 end
+
+function assign_string_element(vector::Vec, index::Int64, data::Vector{UInt8})
+    duckdb_vector_assign_string_element_len(vector.handle, index, pointer(data), length(data))
+end

--- a/tools/juliapkg/test/test_appender.jl
+++ b/tools/juliapkg/test/test_appender.jl
@@ -84,6 +84,7 @@ end
         (; col_name = :largeval, duck_type = "INTEGER", append_value = Int32(2^16)),
         (; col_name = :uuid, duck_type = "UUID", append_value = uuid),
         (; col_name = :varchar, duck_type = "VARCHAR", append_value = "Foo"),
+        (; col_name = :blob, duck_type = "BLOB", append_value = UInt8[0x00, 0x01, 0xff, 0x00]),
         # lists
         (; col_name = :list_bool, duck_type = "BOOLEAN[]", append_value = Vector{Bool}([true, false, true])),
         (; col_name = :list_int8, duck_type = "TINYINT[]", append_value = Vector{Int8}([1, -2, 3])),
@@ -153,6 +154,7 @@ end
         @test isequal(df[!, row.col_name], [ref_value])
     end
 
-    # close the database 
+    # close the database
     DBInterface.close!(db)
 end
+

--- a/tools/juliapkg/test/test_appender.jl
+++ b/tools/juliapkg/test/test_appender.jl
@@ -157,4 +157,3 @@ end
     # close the database
     DBInterface.close!(db)
 end
-

--- a/tools/juliapkg/test/test_tbl_scan.jl
+++ b/tools/juliapkg/test/test_tbl_scan.jl
@@ -152,17 +152,19 @@ end
         df = columntable(results)
         @test isequal(df, my_df)
 
-        # date/time/timestamp
+        # date/time/timestamp/blob
         my_df = (
             date = [Date(1992, 9, 20), missing, Date(1950, 2, 3)],
             time = [Time(23, 3, 1), Time(11, 49, 33), missing],
-            timestamp = [DateTime(1992, 9, 20, 23, 3, 1), DateTime(1950, 2, 3, 11, 49, 3), missing]
+            timestamp = [DateTime(1992, 9, 20, 23, 3, 1), DateTime(1950, 2, 3, 11, 49, 3), missing],
+            blob = Union{Vector{UInt8}, Missing}[UInt8[0x00, 0x01, 0xff], missing, UInt8[0xde, 0xad]]
         )
 
         DuckDB.register_table(con, tblf(my_df), "my_df")
 
         results = DBInterface.execute(con, "SELECT * FROM my_df")
         df = columntable(results)
+        @test typeof(df) == typeof(my_df)
         @test isequal(df, my_df)
 
         DBInterface.close!(con)


### PR DESCRIPTION
Add BLOB type support across the Julia wrapper:
- Map BLOB/BIT to `Vector{UInt8}` instead of `CodeUnits`
- Support BLOB in query results, appender, prepared statements, and table scan
- Fix `duckdb_append_blob` ccall signature
- Add `create_value` for `Vector{UInt8}` and `Missing`