### PR TITLE
[Julia] Add ARRAY type reading

### DIFF
--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -373,7 +373,8 @@ INTERNAL_TYPE_MAP = Dict(
     DUCKDB_TYPE_LIST => duckdb_list_entry_t,
     DUCKDB_TYPE_STRUCT => Cvoid,
     DUCKDB_TYPE_MAP => duckdb_list_entry_t,
-    DUCKDB_TYPE_UNION => Cvoid
+    DUCKDB_TYPE_UNION => Cvoid,
+    DUCKDB_TYPE_ARRAY => Cvoid
 )
 
 JULIA_TYPE_MAP = Dict(
@@ -434,6 +435,8 @@ function duckdb_type_to_julia_type(x)
         end
     elseif type_id == DUCKDB_TYPE_LIST
         return Vector{Union{Missing, duckdb_type_to_julia_type(get_list_child_type(x))}}
+    elseif type_id == DUCKDB_TYPE_ARRAY
+        return Vector{Union{Missing, duckdb_type_to_julia_type(get_array_child_type(x))}}
     elseif type_id == DUCKDB_TYPE_STRUCT
         child_count = get_struct_child_count(x)
         struct_names::Vector{Symbol} = Vector()

--- a/tools/juliapkg/src/logical_type.jl
+++ b/tools/juliapkg/src/logical_type.jl
@@ -100,6 +100,18 @@ function get_list_child_type(type::LogicalType)
 end
 
 ##===--------------------------------------------------------------------===##
+## Array methods
+##===--------------------------------------------------------------------===##
+
+function get_array_child_type(type::LogicalType)
+    return LogicalType(duckdb_array_type_child_type(type.handle))
+end
+
+function get_array_size(type::LogicalType)
+    return duckdb_array_type_array_size(type.handle)
+end
+
+##===--------------------------------------------------------------------===##
 ## Struct methods
 ##===--------------------------------------------------------------------===##
 

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -56,6 +56,7 @@ mutable struct ListConversionData
     internal_type::Type
     target_type::Type
     child_conversion_data::Any
+    array_size::UInt64
 end
 
 mutable struct StructConversionData
@@ -197,6 +198,51 @@ function convert_vector_list(
         if all_valid || isvalid(validity, i)
             start_offset::UInt64 = array[i].offset + 1
             end_offset::UInt64 = array[i].offset + array[i].length
+            result[position] = child_array[start_offset:end_offset]
+        end
+        position += 1
+    end
+    return size
+end
+
+function convert_vector_array(
+    column_data::ColumnConversionData,
+    vector::Vec,
+    size::UInt64,
+    convert_func::Function,
+    result,
+    position,
+    all_valid,
+    ::Type{SRC},
+    ::Type{DST}
+) where {SRC, DST}
+    child_vector = array_child(vector)
+    ldata = column_data.conversion_data
+    arr_size = ldata.array_size
+    child_total = size * arr_size
+
+    child_column_data =
+        ColumnConversionData(column_data.chunks, column_data.col_idx, ldata.child_type, ldata.child_conversion_data)
+    child_array = Array{Union{Missing, ldata.target_type}}(missing, child_total)
+    ldata.conversion_loop_func(
+        child_column_data,
+        child_vector,
+        child_total,
+        ldata.conversion_func,
+        child_array,
+        1,
+        false,
+        ldata.internal_type,
+        ldata.target_type
+    )
+
+    if !all_valid
+        validity = get_validity(vector, size)
+    end
+    for i in 1:size
+        if all_valid || isvalid(validity, i)
+            start_offset::UInt64 = (i - 1) * arr_size + 1
+            end_offset::UInt64 = i * arr_size
             result[position] = child_array[start_offset:end_offset]
         end
         position += 1
@@ -417,7 +463,8 @@ function create_child_conversion_data(child_type::LogicalType)
         child_type,
         internal_type,
         target_type,
-        child_conversion_data
+        child_conversion_data,
+        0
     )
 end
 
@@ -430,6 +477,11 @@ function init_conversion_loop(logical_type::LogicalType)
     elseif type == DUCKDB_TYPE_LIST || type == DUCKDB_TYPE_MAP
         child_type = get_list_child_type(logical_type)
         return create_child_conversion_data(child_type)
+    elseif type == DUCKDB_TYPE_ARRAY
+        child_type = get_array_child_type(logical_type)
+        array_conv_data = create_child_conversion_data(child_type)
+        array_conv_data.array_size = get_array_size(logical_type)
+        return array_conv_data
     elseif type == DUCKDB_TYPE_STRUCT || type == DUCKDB_TYPE_UNION
         child_count_fun::Function = get_struct_child_count
         child_type_fun::Function = get_struct_child_type
@@ -505,6 +557,8 @@ function get_conversion_loop_function(logical_type::LogicalType)::Function
         return convert_vector_string
     elseif type == DUCKDB_TYPE_LIST
         return convert_vector_list
+    elseif type == DUCKDB_TYPE_ARRAY
+        return convert_vector_array
     elseif type == DUCKDB_TYPE_STRUCT
         return convert_vector_struct
     elseif type == DUCKDB_TYPE_MAP

--- a/tools/juliapkg/src/vector.jl
+++ b/tools/juliapkg/src/vector.jl
@@ -41,6 +41,10 @@ function list_size(vector::Vec)::UInt64
     return duckdb_list_vector_get_size(vector.handle)
 end
 
+function array_child(vector::Vec)::Vec
+    return Vec(duckdb_array_vector_get_child(vector.handle))
+end
+
 function struct_child(vector::Vec, index::UInt64)::Vec
     return Vec(duckdb_struct_vector_get_child(vector.handle, index))
 end

--- a/tools/juliapkg/test/test_all_types.jl
+++ b/tools/juliapkg/test/test_all_types.jl
@@ -9,7 +9,7 @@
     df = DataFrame(
         DBInterface.execute(
             con,
-            """SELECT * EXCLUDE(time, time_tz, bignum)
+            """SELECT * EXCLUDE(time, time_tz, time_ns, bignum)
                 , CASE WHEN time = '24:00:00'::TIME THEN '23:59:59.999999'::TIME ELSE time END AS time
                 , CASE WHEN time_tz = '24:00:00-15:59:59'::TIMETZ THEN '23:59:59.999999-15:59:59'::TIMETZ ELSE time_tz END AS time_tz
             FROM test_all_types()

--- a/tools/juliapkg/test/test_all_types.jl
+++ b/tools/juliapkg/test/test_all_types.jl
@@ -9,9 +9,7 @@
     df = DataFrame(
         DBInterface.execute(
             con,
-            """SELECT * EXCLUDE(time, time_ns, time_tz, fixed_int_array, fixed_varchar_array, fixed_nested_int_array,
-            		fixed_nested_varchar_array, fixed_struct_array, struct_of_fixed_array, fixed_array_of_int_list,
-            		list_of_fixed_int_array, bignum)
+            """SELECT * EXCLUDE(time, time_tz, bignum)
                 , CASE WHEN time = '24:00:00'::TIME THEN '23:59:59.999999'::TIME ELSE time END AS time
                 , CASE WHEN time_tz = '24:00:00-15:59:59'::TIMETZ THEN '23:59:59.999999-15:59:59'::TIMETZ ELSE time_tz END AS time_tz
             FROM test_all_types()
@@ -187,4 +185,38 @@
     )
     @test isequal(df.array_of_structs, [[], [(a = missing, b = missing), (a = 42, b = "🦆🦆🦆🦆🦆🦆"), missing], missing])
     @test isequal(df.map, [Dict(), Dict("key1" => "🦆🦆🦆🦆🦆🦆", "key2" => "goose"), missing])
+    @test isequal(df.fixed_int_array, [[missing, 2, 3], [4, 5, 6], missing])
+    @test isequal(df.fixed_varchar_array, [["a", missing, "c"], ["d", "e", "f"], missing])
+    @test isequal(
+        df.fixed_nested_int_array,
+        [[[missing, 2, 3], missing, [missing, 2, 3]], [[4, 5, 6], [missing, 2, 3], [4, 5, 6]], missing]
+    )
+    @test isequal(
+        df.fixed_nested_varchar_array,
+        [[["a", missing, "c"], missing, ["a", missing, "c"]], [["d", "e", "f"], ["a", missing, "c"], ["d", "e", "f"]], missing]
+    )
+    @test isequal(
+        df.fixed_struct_array,
+        [
+            [(a = missing, b = missing), (a = 42, b = "🦆🦆🦆🦆🦆🦆"), (a = missing, b = missing)],
+            [(a = 42, b = "🦆🦆🦆🦆🦆🦆"), (a = missing, b = missing), (a = 42, b = "🦆🦆🦆🦆🦆🦆")],
+            missing
+        ]
+    )
+    @test isequal(
+        df.struct_of_fixed_array,
+        [
+            (a = [missing, 2, 3], b = ["a", missing, "c"]),
+            (a = [4, 5, 6], b = ["d", "e", "f"]),
+            missing
+        ]
+    )
+    @test isequal(
+        df.fixed_array_of_int_list,
+        [[[], [42, 999, missing, missing, -42], []], [[42, 999, missing, missing, -42], [], [42, 999, missing, missing, -42]], missing]
+    )
+    @test isequal(
+        df.list_of_fixed_int_array,
+        [[[missing, 2, 3], [4, 5, 6], [missing, 2, 3]], [[4, 5, 6], [missing, 2, 3], [4, 5, 6]], missing]
+    )
 end

--- a/tools/juliapkg/test/test_all_types.jl
+++ b/tools/juliapkg/test/test_all_types.jl
@@ -193,7 +193,11 @@
     )
     @test isequal(
         df.fixed_nested_varchar_array,
-        [[["a", missing, "c"], missing, ["a", missing, "c"]], [["d", "e", "f"], ["a", missing, "c"], ["d", "e", "f"]], missing]
+        [
+            [["a", missing, "c"], missing, ["a", missing, "c"]],
+            [["d", "e", "f"], ["a", missing, "c"], ["d", "e", "f"]],
+            missing
+        ]
     )
     @test isequal(
         df.fixed_struct_array,
@@ -205,15 +209,15 @@
     )
     @test isequal(
         df.struct_of_fixed_array,
-        [
-            (a = [missing, 2, 3], b = ["a", missing, "c"]),
-            (a = [4, 5, 6], b = ["d", "e", "f"]),
-            missing
-        ]
+        [(a = [missing, 2, 3], b = ["a", missing, "c"]), (a = [4, 5, 6], b = ["d", "e", "f"]), missing]
     )
     @test isequal(
         df.fixed_array_of_int_list,
-        [[[], [42, 999, missing, missing, -42], []], [[42, 999, missing, missing, -42], [], [42, 999, missing, missing, -42]], missing]
+        [
+            [[], [42, 999, missing, missing, -42], []],
+            [[42, 999, missing, missing, -42], [], [42, 999, missing, missing, -42]],
+            missing
+        ]
     )
     @test isequal(
         df.list_of_fixed_int_array,


### PR DESCRIPTION
Add support for reading ARRAY type columns in query results, converting them to fixed-size Julia vectors.