### PR TITLE
[Julia] Support STRUCT in table scan

### DIFF
--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -437,7 +437,8 @@ function duckdb_type_to_julia_type(x)
     elseif type_id == DUCKDB_TYPE_STRUCT
         child_count = get_struct_child_count(x)
         struct_names = ntuple(i -> Symbol(get_struct_child_name(x, UInt64(i))), child_count)
-        struct_types = ntuple(i -> Union{Missing, duckdb_type_to_julia_type(get_struct_child_type(x, UInt64(i)))}, child_count)
+        struct_types =
+            ntuple(i -> Union{Missing, duckdb_type_to_julia_type(get_struct_child_type(x, UInt64(i)))}, child_count)
         return NamedTuple{struct_names, Tuple{struct_types...}}
     elseif type_id == DUCKDB_TYPE_UNION
         member_count = get_union_member_count(x)

--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -436,13 +436,9 @@ function duckdb_type_to_julia_type(x)
         return Vector{Union{Missing, duckdb_type_to_julia_type(get_list_child_type(x))}}
     elseif type_id == DUCKDB_TYPE_STRUCT
         child_count = get_struct_child_count(x)
-        struct_names::Vector{Symbol} = Vector()
-        for i in 1:child_count
-            child_name::Symbol = Symbol(get_struct_child_name(x, i))
-            push!(struct_names, child_name)
-        end
-        struct_names_tuple = Tuple(x for x in struct_names)
-        return Union{Missing, NamedTuple{struct_names_tuple}}
+        struct_names = ntuple(i -> Symbol(get_struct_child_name(x, UInt64(i))), child_count)
+        struct_types = ntuple(i -> duckdb_type_to_julia_type(get_struct_child_type(x, UInt64(i))), child_count)
+        return NamedTuple{struct_names, Tuple{struct_types...}}
     elseif type_id == DUCKDB_TYPE_UNION
         member_count = get_union_member_count(x)
         member_types::Vector{DataType} = Vector()

--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -437,7 +437,7 @@ function duckdb_type_to_julia_type(x)
     elseif type_id == DUCKDB_TYPE_STRUCT
         child_count = get_struct_child_count(x)
         struct_names = ntuple(i -> Symbol(get_struct_child_name(x, UInt64(i))), child_count)
-        struct_types = ntuple(i -> duckdb_type_to_julia_type(get_struct_child_type(x, UInt64(i))), child_count)
+        struct_types = ntuple(i -> Union{Missing, duckdb_type_to_julia_type(get_struct_child_type(x, UInt64(i)))}, child_count)
         return NamedTuple{struct_names, Tuple{struct_types...}}
     elseif type_id == DUCKDB_TYPE_UNION
         member_count = get_union_member_count(x)

--- a/tools/juliapkg/src/logical_type.jl
+++ b/tools/juliapkg/src/logical_type.jl
@@ -61,6 +61,23 @@ function create_logical_type(::Type{T}) where {T <: FixedDecimal}
     return DuckDB.LogicalType(duckdb_create_decimal_type(width, scale))
 end
 
+function _logical_type_for_field(::Type{Missing})
+    return LogicalType(DUCKDB_TYPE_INTEGER)
+end
+function _logical_type_for_field(::Type{T}) where {T}
+    return create_logical_type(Base.nonmissingtype(T))
+end
+
+function create_logical_type(::Type{NamedTuple{names, T}}) where {names, T <: Tuple}
+    n = length(names)
+    child_types = [_logical_type_for_field(fieldtype(T, i)) for i in 1:n]
+    member_types = [lt.handle for lt in child_types]
+    member_names = [string(nm) for nm in names]
+    return LogicalType(duckdb_create_struct_type(member_types, member_names, n))
+end
+
+create_logical_type(::Type{Union{Missing, T}}) where {T} = create_logical_type(T)
+
 function create_logical_type(::Type{T}) where {T}
     throw(NotImplementedException("Unsupported type for create_logical_type"))
 end

--- a/tools/juliapkg/src/table_scan.jl
+++ b/tools/juliapkg/src/table_scan.jl
@@ -22,6 +22,7 @@ julia_to_duck_type(::Type{Date}) = Int32
 julia_to_duck_type(::Type{Time}) = Int64
 julia_to_duck_type(::Type{DateTime}) = Int64
 julia_to_duck_type(::Type{T}) where {T} = T
+julia_to_duck_type(::Type{T}) where {T <: NamedTuple} = Cvoid
 
 value_to_duckdb(val::Date) = convert(Int32, Dates.date2epochdays(val) - ROUNDING_EPOCH_TO_UNIX_EPOCH_DAYS)
 value_to_duckdb(val::Time) = convert(Int64, Dates.value(val) / 1000)
@@ -33,17 +34,7 @@ value_to_duckdb(val::AbstractString) = throw(
 )
 value_to_duckdb(val) = val
 
-function tbl_scan_column(
-    input_column::AbstractVector{JL_TYPE},
-    row_offset::Int64,
-    col_idx::Int64,
-    result_idx::Int64,
-    scan_count::Int64,
-    output::DuckDB.DataChunk,
-    ::Type{DUCK_TYPE},
-    ::Type{JL_TYPE}
-) where {DUCK_TYPE, JL_TYPE}
-    vector::Vec = DuckDB.get_vector(output, result_idx)
+function _scan_into_vector!(vector::Vec, input_column::AbstractVector, row_offset::Int64, scan_count::Int64, ::Type{DUCK_TYPE}) where {DUCK_TYPE}
     result_array::Vector{DUCK_TYPE} = DuckDB.get_array(vector, DUCK_TYPE)
     validity::ValidityMask = DuckDB.get_validity(vector)
     for i::Int64 in 1:scan_count
@@ -56,17 +47,7 @@ function tbl_scan_column(
     end
 end
 
-function tbl_scan_string_column(
-    input_column::AbstractVector{JL_TYPE},
-    row_offset::Int64,
-    col_idx::Int64,
-    result_idx::Int64,
-    scan_count::Int64,
-    output::DuckDB.DataChunk,
-    ::Type{DUCK_TYPE},
-    ::Type{JL_TYPE}
-) where {DUCK_TYPE, JL_TYPE}
-    vector::Vec = DuckDB.get_vector(output, result_idx)
+function _scan_string_into_vector!(vector::Vec, input_column::AbstractVector, row_offset::Int64, scan_count::Int64)
     validity::ValidityMask = DuckDB.get_validity(vector)
     for i::Int64 in 1:scan_count
         val = getindex(input_column, row_offset + i)
@@ -78,10 +59,69 @@ function tbl_scan_string_column(
     end
 end
 
+function tbl_scan_column(
+    input_column::AbstractVector{JL_TYPE},
+    row_offset::Int64,
+    col_idx::Int64,
+    result_idx::Int64,
+    scan_count::Int64,
+    output::DuckDB.DataChunk,
+    ::Type{DUCK_TYPE},
+    ::Type{JL_TYPE}
+) where {DUCK_TYPE, JL_TYPE}
+    _scan_into_vector!(DuckDB.get_vector(output, result_idx), input_column, row_offset, scan_count, DUCK_TYPE)
+end
+
+function tbl_scan_string_column(
+    input_column::AbstractVector{JL_TYPE},
+    row_offset::Int64,
+    col_idx::Int64,
+    result_idx::Int64,
+    scan_count::Int64,
+    output::DuckDB.DataChunk,
+    ::Type{DUCK_TYPE},
+    ::Type{JL_TYPE}
+) where {DUCK_TYPE, JL_TYPE}
+    _scan_string_into_vector!(DuckDB.get_vector(output, result_idx), input_column, row_offset, scan_count)
+end
+
+function tbl_scan_struct_column(
+    input_column,
+    row_offset::Int64,
+    col_idx::Int64,
+    result_idx::Int64,
+    scan_count::Int64,
+    output::DuckDB.DataChunk,
+    ::Type{DUCK_TYPE},
+    ::Type{JL_TYPE}
+) where {DUCK_TYPE, JL_TYPE}
+    vector::Vec = DuckDB.get_vector(output, result_idx)
+    # No missing support within struct columns for now.
+    _scan_struct_vector!(vector, input_column, row_offset, scan_count)
+end
+
+function _scan_struct_vector!(vector::Vec, child_columns::NamedTuple, row_offset::Int64, scan_count::Int64)
+    for (field_idx, child_col) in enumerate(values(child_columns))
+        child_vector = DuckDB.struct_child(vector, UInt64(field_idx))
+        child_type = eltype(child_col)
+        if child_type <: NamedTuple
+            # columntable(): free for columnar arrays like StructArrays; for other arrays, single-copy.
+            nested_children = columntable(child_col)
+            _scan_struct_vector!(child_vector, nested_children, row_offset, scan_count)
+        elseif child_type <: AbstractString
+            _scan_string_into_vector!(child_vector, child_col, row_offset, scan_count)
+        else
+            _scan_into_vector!(child_vector, child_col, row_offset, scan_count, julia_to_duck_type(child_type))
+        end
+    end
+end
+
 function tbl_scan_function(tbl, entry)
     result_type = table_result_type(tbl, entry)
     if result_type <: AbstractString
         return tbl_scan_string_column
+    elseif result_type <: NamedTuple
+        return tbl_scan_struct_column
     end
     return tbl_scan_column
 end
@@ -106,8 +146,15 @@ function tbl_bind_function(info::DuckDB.BindInfo)
     for entry in Tables.columnnames(tbl)
         result_type = table_result_type(tbl, entry)
         scan_function = tbl_scan_function(tbl, entry)
-        push!(input_columns, tbl[entry])
-        push!(scan_types, eltype(tbl[entry]))
+        col = tbl[entry]
+        if result_type <: NamedTuple
+            # Convert struct column to columnar format at bind time.
+            # Free for columnar arrays like StructArrays; for other arrays, single-copy.
+            push!(input_columns, columntable(col))
+        else
+            push!(input_columns, col)
+        end
+        push!(scan_types, eltype(col))
         push!(result_types, julia_to_duck_type(result_type))
         push!(scan_functions, scan_function)
 

--- a/tools/juliapkg/src/table_scan.jl
+++ b/tools/juliapkg/src/table_scan.jl
@@ -34,7 +34,13 @@ value_to_duckdb(val::AbstractString) = throw(
 )
 value_to_duckdb(val) = val
 
-function _scan_into_vector!(vector::Vec, input_column::AbstractVector, row_offset::Int64, scan_count::Int64, ::Type{DUCK_TYPE}) where {DUCK_TYPE}
+function _scan_into_vector!(
+    vector::Vec,
+    input_column::AbstractVector,
+    row_offset::Int64,
+    scan_count::Int64,
+    ::Type{DUCK_TYPE}
+) where {DUCK_TYPE}
     result_array::Vector{DUCK_TYPE} = DuckDB.get_array(vector, DUCK_TYPE)
     validity::ValidityMask = DuckDB.get_validity(vector)
     for i::Int64 in 1:scan_count
@@ -69,7 +75,7 @@ function tbl_scan_column(
     ::Type{DUCK_TYPE},
     ::Type{JL_TYPE}
 ) where {DUCK_TYPE, JL_TYPE}
-    _scan_into_vector!(DuckDB.get_vector(output, result_idx), input_column, row_offset, scan_count, DUCK_TYPE)
+    return _scan_into_vector!(DuckDB.get_vector(output, result_idx), input_column, row_offset, scan_count, DUCK_TYPE)
 end
 
 function tbl_scan_string_column(
@@ -82,7 +88,7 @@ function tbl_scan_string_column(
     ::Type{DUCK_TYPE},
     ::Type{JL_TYPE}
 ) where {DUCK_TYPE, JL_TYPE}
-    _scan_string_into_vector!(DuckDB.get_vector(output, result_idx), input_column, row_offset, scan_count)
+    return _scan_string_into_vector!(DuckDB.get_vector(output, result_idx), input_column, row_offset, scan_count)
 end
 
 function tbl_scan_struct_column(
@@ -97,7 +103,7 @@ function tbl_scan_struct_column(
 ) where {DUCK_TYPE, JL_TYPE}
     vector::Vec = DuckDB.get_vector(output, result_idx)
     # No missing support within struct columns for now.
-    _scan_struct_vector!(vector, input_column, row_offset, scan_count)
+    return _scan_struct_vector!(vector, input_column, row_offset, scan_count)
 end
 
 function _scan_struct_vector!(vector::Vec, child_columns::NamedTuple, row_offset::Int64, scan_count::Int64)

--- a/tools/juliapkg/test/test_tbl_scan.jl
+++ b/tools/juliapkg/test/test_tbl_scan.jl
@@ -349,7 +349,10 @@ end
 
     DuckDB.register_table(con, my_tbl, "my_tbl")
     results = DBInterface.execute(con, "SELECT * FROM my_tbl") |> columntable
-    @test eltype(results.s) == @NamedTuple{x::Union{Missing, Int32}, inner::Union{Missing, @NamedTuple{a::Union{Missing, Int32}, b::Union{Missing, Int32}}}}
+    @test eltype(results.s) == @NamedTuple{
+        x::Union{Missing, Int32},
+        inner::Union{Missing, @NamedTuple{a::Union{Missing, Int32}, b::Union{Missing, Int32}}}
+    }
     @test isequal(results.s[1], (x = 1, inner = (a = 10, b = 20)))
     @test isequal(results.s[2], (x = 2, inner = (a = 30, b = 40)))
 

--- a/tools/juliapkg/test/test_tbl_scan.jl
+++ b/tools/juliapkg/test/test_tbl_scan.jl
@@ -315,7 +315,7 @@ end
         s = @NamedTuple{a::Int32, b::String}[
             (a = Int32(10), b = "hello"),
             (a = Int32(20), b = "world"),
-            (a = Int32(30), b = "foo"),
+            (a = Int32(30), b = "foo")
         ]
     )
 
@@ -342,7 +342,7 @@ end
     my_tbl = (
         s = @NamedTuple{x::Int32, inner::@NamedTuple{a::Int32, b::Int32}}[
             (x = Int32(1), inner = (a = Int32(10), b = Int32(20))),
-            (x = Int32(2), inner = (a = Int32(30), b = Int32(40))),
+            (x = Int32(2), inner = (a = Int32(30), b = Int32(40)))
         ],
         id = [1, 2]
     )

--- a/tools/juliapkg/test/test_tbl_scan.jl
+++ b/tools/juliapkg/test/test_tbl_scan.jl
@@ -321,7 +321,7 @@ end
 
     DuckDB.register_table(con, my_tbl, "my_tbl")
     results = DBInterface.execute(con, "SELECT * FROM my_tbl") |> columntable
-    @test typeof(results) == typeof(my_tbl)
+    @test eltype(results.s) == @NamedTuple{a::Union{Missing, Int32}, b::Union{Missing, String}}
     @test isequal(results.id, [1, 2, 3])
     @test isequal(results.s, [(a = 10, b = "hello"), (a = 20, b = "world"), (a = 30, b = "foo")])
 
@@ -349,7 +349,7 @@ end
 
     DuckDB.register_table(con, my_tbl, "my_tbl")
     results = DBInterface.execute(con, "SELECT * FROM my_tbl") |> columntable
-    @test typeof(results) == typeof(my_tbl)
+    @test eltype(results.s) == @NamedTuple{x::Union{Missing, Int32}, inner::Union{Missing, @NamedTuple{a::Union{Missing, Int32}, b::Union{Missing, Int32}}}}
     @test isequal(results.s[1], (x = 1, inner = (a = 10, b = 20)))
     @test isequal(results.s[2], (x = 2, inner = (a = 30, b = 40)))
 

--- a/tools/juliapkg/test/test_tbl_scan.jl
+++ b/tools/juliapkg/test/test_tbl_scan.jl
@@ -320,20 +320,18 @@ end
     )
 
     DuckDB.register_table(con, my_tbl, "my_tbl")
-    results = DBInterface.execute(con, "SELECT * FROM my_tbl")
-    df = columntable(results)
-    @test isequal(df.id, [1, 2, 3])
-    @test isequal(df.s, [(a = 10, b = "hello"), (a = 20, b = "world"), (a = 30, b = "foo")])
+    results = DBInterface.execute(con, "SELECT * FROM my_tbl") |> columntable
+    @test typeof(results) == typeof(my_tbl)
+    @test isequal(results.id, [1, 2, 3])
+    @test isequal(results.s, [(a = 10, b = "hello"), (a = 20, b = "world"), (a = 30, b = "foo")])
 
     # projection pushdown: select only struct column
-    results = DBInterface.execute(con, "SELECT s FROM my_tbl")
-    df = columntable(results)
-    @test isequal(df.s, [(a = 10, b = "hello"), (a = 20, b = "world"), (a = 30, b = "foo")])
+    results = DBInterface.execute(con, "SELECT s FROM my_tbl") |> columntable
+    @test isequal(results.s, [(a = 10, b = "hello"), (a = 20, b = "world"), (a = 30, b = "foo")])
 
     # SQL access to struct fields
-    results = DBInterface.execute(con, "SELECT s.a FROM my_tbl")
-    df = columntable(results)
-    @test isequal(df.a, [10, 20, 30])
+    results = DBInterface.execute(con, "SELECT s.a FROM my_tbl") |> columntable
+    @test isequal(results.a, [10, 20, 30])
 
     DBInterface.close!(con)
 end
@@ -350,15 +348,14 @@ end
     )
 
     DuckDB.register_table(con, my_tbl, "my_tbl")
-    results = DBInterface.execute(con, "SELECT * FROM my_tbl")
-    df = columntable(results)
-    @test isequal(df.s[1], (x = 1, inner = (a = 10, b = 20)))
-    @test isequal(df.s[2], (x = 2, inner = (a = 30, b = 40)))
+    results = DBInterface.execute(con, "SELECT * FROM my_tbl") |> columntable
+    @test typeof(results) == typeof(my_tbl)
+    @test isequal(results.s[1], (x = 1, inner = (a = 10, b = 20)))
+    @test isequal(results.s[2], (x = 2, inner = (a = 30, b = 40)))
 
     # SQL access to nested struct fields
-    results = DBInterface.execute(con, "SELECT s.inner.a FROM my_tbl")
-    df = columntable(results)
-    @test isequal(df.a, [10, 30])
+    results = DBInterface.execute(con, "SELECT s.inner.a FROM my_tbl") |> columntable
+    @test isequal(results.a, [10, 30])
 
     DBInterface.close!(con)
 end

--- a/tools/juliapkg/test/test_tbl_scan.jl
+++ b/tools/juliapkg/test/test_tbl_scan.jl
@@ -307,6 +307,62 @@ end
     DBInterface.close!(con)
 end
 
+@testset "Test table scan with structs" begin
+    con = DBInterface.connect(DuckDB.DB)
+
+    my_tbl = (
+        id = [1, 2, 3],
+        s = @NamedTuple{a::Int32, b::String}[
+            (a = Int32(10), b = "hello"),
+            (a = Int32(20), b = "world"),
+            (a = Int32(30), b = "foo"),
+        ]
+    )
+
+    DuckDB.register_table(con, my_tbl, "my_tbl")
+    results = DBInterface.execute(con, "SELECT * FROM my_tbl")
+    df = columntable(results)
+    @test isequal(df.id, [1, 2, 3])
+    @test isequal(df.s, [(a = 10, b = "hello"), (a = 20, b = "world"), (a = 30, b = "foo")])
+
+    # projection pushdown: select only struct column
+    results = DBInterface.execute(con, "SELECT s FROM my_tbl")
+    df = columntable(results)
+    @test isequal(df.s, [(a = 10, b = "hello"), (a = 20, b = "world"), (a = 30, b = "foo")])
+
+    # SQL access to struct fields
+    results = DBInterface.execute(con, "SELECT s.a FROM my_tbl")
+    df = columntable(results)
+    @test isequal(df.a, [10, 20, 30])
+
+    DBInterface.close!(con)
+end
+
+@testset "Test table scan with nested structs" begin
+    con = DBInterface.connect(DuckDB.DB)
+
+    my_tbl = (
+        s = @NamedTuple{x::Int32, inner::@NamedTuple{a::Int32, b::Int32}}[
+            (x = Int32(1), inner = (a = Int32(10), b = Int32(20))),
+            (x = Int32(2), inner = (a = Int32(30), b = Int32(40))),
+        ],
+        id = [1, 2]
+    )
+
+    DuckDB.register_table(con, my_tbl, "my_tbl")
+    results = DBInterface.execute(con, "SELECT * FROM my_tbl")
+    df = columntable(results)
+    @test isequal(df.s[1], (x = 1, inner = (a = 10, b = 20)))
+    @test isequal(df.s[2], (x = 2, inner = (a = 30, b = 40)))
+
+    # SQL access to nested struct fields
+    results = DBInterface.execute(con, "SELECT s.inner.a FROM my_tbl")
+    df = columntable(results)
+    @test isequal(df.a, [10, 30])
+
+    DBInterface.close!(con)
+end
+
 @testset "Test large table scan" begin
     for tblf in [Tables.columntable, Tables.rowtable]
         con = DBInterface.connect(DuckDB.DB)


### PR DESCRIPTION
Add STRUCT type support for `register_table` / table scan:
- Recursively scan struct fields (including nested structs and string fields)
- Improve output NamedTuple types to be more precise
- Add tests for struct columns in table scan