### PR TITLE
Expose query string to the optimizer

### DIFF
--- a/src/include/duckdb/optimizer/optimizer.hpp
+++ b/src/include/duckdb/optimizer/optimizer.hpp
@@ -20,12 +20,14 @@ class Binder;
 
 class Optimizer {
 public:
-	Optimizer(Binder &binder, ClientContext &context);
+	Optimizer(Binder &binder, ClientContext &context, optional_ptr<const string> query = nullptr);
 
 	//! Optimize a plan by running specialized optimizers
-	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> plan, optional_ptr<const string> query = nullptr);
+	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> plan);
 	//! Return a reference to the client context of this optimizer
 	ClientContext &GetContext();
+	//! Return the optional query string
+	optional_ptr<const string> GetQueryString() const;
 	//! Whether the specific optimizer is disabled
 	bool OptimizerDisabled(OptimizerType type);
 	static bool OptimizerDisabled(ClientContext &context, OptimizerType type);
@@ -46,7 +48,7 @@ public:
 	unique_ptr<Expression> BindScalarFunction(const string &name, unique_ptr<Expression> c1, unique_ptr<Expression> c2);
 
 private:
-	optional_ptr<const string> query;
+	const optional_ptr<const string> query;
 	unique_ptr<LogicalOperator> plan;
 
 private:

--- a/src/include/duckdb/optimizer/optimizer.hpp
+++ b/src/include/duckdb/optimizer/optimizer.hpp
@@ -23,8 +23,7 @@ public:
 	Optimizer(Binder &binder, ClientContext &context);
 
 	//! Optimize a plan by running specialized optimizers
-	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> plan,
-	                                     optional_ptr<const string> query = nullptr);
+	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> plan, optional_ptr<const string> query = nullptr);
 	//! Return a reference to the client context of this optimizer
 	ClientContext &GetContext();
 	//! Whether the specific optimizer is disabled

--- a/src/include/duckdb/optimizer/optimizer.hpp
+++ b/src/include/duckdb/optimizer/optimizer.hpp
@@ -23,7 +23,8 @@ public:
 	Optimizer(Binder &binder, ClientContext &context);
 
 	//! Optimize a plan by running specialized optimizers
-	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> plan);
+	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> plan,
+	                                     optional_ptr<const string> query = nullptr);
 	//! Return a reference to the client context of this optimizer
 	ClientContext &GetContext();
 	//! Whether the specific optimizer is disabled
@@ -46,6 +47,7 @@ public:
 	unique_ptr<Expression> BindScalarFunction(const string &name, unique_ptr<Expression> c1, unique_ptr<Expression> c2);
 
 private:
+	optional_ptr<const string> query;
 	unique_ptr<LogicalOperator> plan;
 
 private:

--- a/src/include/duckdb/optimizer/optimizer_extension.hpp
+++ b/src/include/duckdb/optimizer/optimizer_extension.hpp
@@ -27,7 +27,6 @@ struct OptimizerExtensionInput {
 	ClientContext &context;
 	Optimizer &optimizer;
 	optional_ptr<OptimizerExtensionInfo> info;
-	optional_ptr<const string> query;
 };
 
 typedef void (*optimize_function_t)(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);

--- a/src/include/duckdb/optimizer/optimizer_extension.hpp
+++ b/src/include/duckdb/optimizer/optimizer_extension.hpp
@@ -27,6 +27,7 @@ struct OptimizerExtensionInput {
 	ClientContext &context;
 	Optimizer &optimizer;
 	optional_ptr<OptimizerExtensionInfo> info;
+	optional_ptr<const string> query;
 };
 
 typedef void (*optimize_function_t)(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -446,7 +446,7 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 	if (config.enable_optimizer && logical_plan->RequireOptimizer()) {
 		profiler.StartPhase(MetricType::ALL_OPTIMIZERS);
 		Optimizer optimizer(*logical_planner.binder, *this);
-		logical_plan = optimizer.Optimize(std::move(logical_plan));
+		logical_plan = optimizer.Optimize(std::move(logical_plan), &query);
 		D_ASSERT(logical_plan);
 		profiler.EndPhase();
 
@@ -758,7 +758,7 @@ unique_ptr<LogicalOperator> ClientContext::ExtractPlan(const string &query) {
 
 		if (config.enable_optimizer) {
 			Optimizer optimizer(*planner.binder, *this);
-			plan = optimizer.Optimize(std::move(plan));
+			plan = optimizer.Optimize(std::move(plan), &query);
 		}
 
 		ColumnBindingResolver resolver;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -445,8 +445,8 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 
 	if (config.enable_optimizer && logical_plan->RequireOptimizer()) {
 		profiler.StartPhase(MetricType::ALL_OPTIMIZERS);
-		Optimizer optimizer(*logical_planner.binder, *this);
-		logical_plan = optimizer.Optimize(std::move(logical_plan), &query);
+		Optimizer optimizer(*logical_planner.binder, *this, &query);
+		logical_plan = optimizer.Optimize(std::move(logical_plan));
 		D_ASSERT(logical_plan);
 		profiler.EndPhase();
 
@@ -757,8 +757,8 @@ unique_ptr<LogicalOperator> ClientContext::ExtractPlan(const string &query) {
 		plan = std::move(planner.plan);
 
 		if (config.enable_optimizer) {
-			Optimizer optimizer(*planner.binder, *this);
-			plan = optimizer.Optimize(std::move(plan), &query);
+			Optimizer optimizer(*planner.binder, *this, &query);
+			plan = optimizer.Optimize(std::move(plan));
 		}
 
 		ColumnBindingResolver resolver;

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -49,7 +49,8 @@
 
 namespace duckdb {
 
-Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context), binder(binder), rewriter(context) {
+Optimizer::Optimizer(Binder &binder, ClientContext &context, optional_ptr<const string> query)
+    : context(context), binder(binder), rewriter(context), query(query) {
 	rewriter.rules.push_back(make_uniq<ConstantOrderNormalizationRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<ConstantFoldingRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<DistributivityRule>(rewriter));
@@ -84,6 +85,10 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 
 ClientContext &Optimizer::GetContext() {
 	return context;
+}
+
+optional_ptr<const string> Optimizer::GetQueryString() const {
+	return query;
 }
 
 bool Optimizer::OptimizerDisabled(OptimizerType type) {
@@ -345,16 +350,14 @@ void Optimizer::RunBuiltInOptimizers() {
 	});
 }
 
-unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan_p,
-                                                optional_ptr<const string> query_p) {
+unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan_p) {
 	Verify(*plan_p);
 
 	this->plan = std::move(plan_p);
-	this->query = query_p;
 
 	for (auto &pre_optimizer_extension : OptimizerExtension::Iterate(context)) {
 		RunOptimizer(OptimizerType::EXTENSION, [&]() {
-			OptimizerExtensionInput input {GetContext(), *this, pre_optimizer_extension.optimizer_info.get(), query};
+			OptimizerExtensionInput input {GetContext(), *this, pre_optimizer_extension.optimizer_info.get()};
 			if (pre_optimizer_extension.pre_optimize_function) {
 				pre_optimizer_extension.pre_optimize_function(input, plan);
 			}
@@ -365,7 +368,7 @@ unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan
 
 	for (auto &optimizer_extension : OptimizerExtension::Iterate(context)) {
 		RunOptimizer(OptimizerType::EXTENSION, [&]() {
-			OptimizerExtensionInput input {GetContext(), *this, optimizer_extension.optimizer_info.get(), query};
+			OptimizerExtensionInput input {GetContext(), *this, optimizer_extension.optimizer_info.get()};
 			if (optimizer_extension.optimize_function) {
 				optimizer_extension.optimize_function(input, plan);
 			}

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -345,14 +345,16 @@ void Optimizer::RunBuiltInOptimizers() {
 	});
 }
 
-unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan_p) {
+unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan_p,
+                                                optional_ptr<const string> query_p) {
 	Verify(*plan_p);
 
 	this->plan = std::move(plan_p);
+	this->query = query_p;
 
 	for (auto &pre_optimizer_extension : OptimizerExtension::Iterate(context)) {
 		RunOptimizer(OptimizerType::EXTENSION, [&]() {
-			OptimizerExtensionInput input {GetContext(), *this, pre_optimizer_extension.optimizer_info.get()};
+			OptimizerExtensionInput input {GetContext(), *this, pre_optimizer_extension.optimizer_info.get(), query};
 			if (pre_optimizer_extension.pre_optimize_function) {
 				pre_optimizer_extension.pre_optimize_function(input, plan);
 			}
@@ -363,7 +365,7 @@ unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan
 
 	for (auto &optimizer_extension : OptimizerExtension::Iterate(context)) {
 		RunOptimizer(OptimizerType::EXTENSION, [&]() {
-			OptimizerExtensionInput input {GetContext(), *this, optimizer_extension.optimizer_info.get()};
+			OptimizerExtensionInput input {GetContext(), *this, optimizer_extension.optimizer_info.get(), query};
 			if (optimizer_extension.optimize_function) {
 				optimizer_extension.optimize_function(input, plan);
 			}

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -42,7 +42,8 @@ set(TEST_API_OBJECTS
     test_buffer_pool_eviction.cpp
     test_update_query_node.cpp
     test_delete_query_node.cpp
-    test_insert_query_node.cpp)
+    test_insert_query_node.cpp
+    test_optimizer_query_string.cpp)
 
 if(NOT WIN32)
   set(TEST_API_OBJECTS ${TEST_API_OBJECTS} test_read_only.cpp)

--- a/test/api/test_optimizer_query_string.cpp
+++ b/test/api/test_optimizer_query_string.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "test_helpers.hpp"
 
@@ -11,8 +12,9 @@ static string captured_query;
 static int capture_count;
 
 static void CaptureQueryPreOptimize(OptimizerExtensionInput &input, duckdb::unique_ptr<LogicalOperator> &plan) {
-	if (input.query) {
-		captured_query = *input.query;
+	auto query = input.optimizer.GetQueryString();
+	if (query) {
+		captured_query = *query;
 	} else {
 		captured_query = "";
 	}

--- a/test/api/test_optimizer_query_string.cpp
+++ b/test/api/test_optimizer_query_string.cpp
@@ -1,0 +1,66 @@
+#include "catch.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/optimizer/optimizer_extension.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+// Captures the query string seen by the optimizer extension callback
+static string captured_query;
+static int capture_count;
+
+static void CaptureQueryPreOptimize(OptimizerExtensionInput &input, duckdb::unique_ptr<LogicalOperator> &plan) {
+	if (input.query) {
+		captured_query = *input.query;
+	} else {
+		captured_query = "";
+	}
+	capture_count++;
+}
+
+TEST_CASE("Optimizer extension receives query string for regular and prepared statements", "[api]") {
+	DuckDB db;
+	auto &config = DBConfig::GetConfig(*db.instance);
+
+	OptimizerExtension ext;
+	ext.pre_optimize_function = CaptureQueryPreOptimize;
+	OptimizerExtension::Register(config, std::move(ext));
+
+	Connection con(*db.instance);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t (i INTEGER, s VARCHAR)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO t VALUES (1, 'hello'), (2, 'world')"));
+
+	SECTION("Regular query sets the query string") {
+		captured_query.clear();
+		string query = "SELECT * FROM t WHERE i > 0";
+		auto result = con.Query(query);
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(!captured_query.empty());
+		REQUIRE(captured_query.find("SELECT") != string::npos);
+	}
+
+	SECTION("Prepared statement without parameters sets the query string") {
+		captured_query.clear();
+		string query = "SELECT * FROM t";
+		auto prepared = con.Prepare(query);
+		REQUIRE(!prepared->HasError());
+		// Optimizer runs during Prepare for parameter-free statements
+		REQUIRE(!captured_query.empty());
+		REQUIRE(captured_query.find("SELECT") != string::npos);
+	}
+
+	SECTION("Prepared statement with parameters sets the query string on Execute") {
+		captured_query.clear();
+		capture_count = 0;
+		string query = "SELECT * FROM t WHERE i = $1";
+		auto prepared = con.Prepare(query);
+		REQUIRE(!prepared->HasError());
+		// Optimizer is deferred until Execute when parameters are unbound
+		auto result = prepared->Execute(1);
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(!captured_query.empty());
+		REQUIRE(captured_query.find("SELECT") != string::npos);
+	}
+}


### PR DESCRIPTION
A second PR, related to https://github.com/duckdb/duckdb/pull/20755.

The main issue was that we would like to use query string in optimizer extensions, which we thought can be done via `ClientContext`, but it turns out that it does not work with `PreparedStatement`.

The solution suggested by @lnkuiper was to pass the query string as an optional argument to the optimizer.

This is what we came up with.