### PR TITLE
Fix two minor shell bugs: Avoid mutating rendered strings and avoid p…

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1365,8 +1365,8 @@ string ShellState::GetSystemPager() {
 }
 
 bool ShellState::ShouldUsePager() {
-	if (out != stdout || !stdout_is_console || !outfile.empty()) {
-		// if we have an outfile specified we don't set up the pager
+	if (out != stdout || !stdout_is_console || !outfile.empty() || !stdin_is_interactive) {
+		// if we have an outfile specified, or we are in non-interactive/batch mode, don't use the pager
 		return false;
 	}
 	// setup a pager for output

--- a/tools/shell/shell_render_table_metadata.cpp
+++ b/tools/shell/shell_render_table_metadata.cpp
@@ -396,7 +396,7 @@ void ShellTableRenderInfo::Truncate(idx_t max_render_width) {
 	render_width = max_render_width;
 }
 
-void RenderLineDisplay(ShellHighlight &highlight, string &text, idx_t total_render_width,
+void RenderLineDisplay(ShellHighlight &highlight, string text, idx_t total_render_width,
                        HighlightElementType element_type) {
 	auto render_size = ShellState::RenderLength(text);
 	ShellTableRenderInfo::TruncateValueIfRequired(text, render_size, total_render_width - 4);


### PR DESCRIPTION
…ager when not interactive

Issue was as follow:
1. construct evil DB unittester_mashup.db via:
`./build/release/test/unittest --test-config test/configs/one_schema_per_test.json --test-temp-dir my_new_temp_dir`

2. then use that `.tables` rendering
`./build/release/duckdb my_new_temp_dir/unittester_mashup.db -c ".tables"`
`./build/release/duckdb my_new_temp_dir/unittester_mashup.db` and then executing `.tables` in the duckdb shell

Those trigger two slightly different issues: should not go into pager mode when passed -c, and then an issue with string& that was modified (and then used again by caller)