### PR TITLE
Fix wrong cast in RecursiveDependentJoinPlanner

### DIFF
--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -374,7 +374,7 @@ void RecursiveDependentJoinPlanner::VisitOperator(LogicalOperator &op) {
 		// Collect all recursive CTEs during recursive descend
 		if (op.type == LogicalOperatorType::LOGICAL_RECURSIVE_CTE ||
 		    op.type == LogicalOperatorType::LOGICAL_MATERIALIZED_CTE) {
-			auto &rec_cte = op.Cast<LogicalRecursiveCTE>();
+			auto &rec_cte = op.Cast<LogicalCTE>();
 			binder.recursive_ctes[rec_cte.table_index] = &op;
 		}
 		for (idx_t i = 0; i < op.children.size(); i++) {


### PR DESCRIPTION
We can not cast to a `LogicalRecursiveCTE` here, we must cast to the base class `LogicalCTE` instead, as this branch is valid for recursive and materialized CTEs.