### PR TITLE
Notify stale PRs after 30 days, close after 30

### DIFF
--- a/.github/workflows/IssuesCloseStale.yml
+++ b/.github/workflows/IssuesCloseStale.yml
@@ -28,7 +28,7 @@ jobs:
           close-pr-message: 'This pull request was closed because it has been stale for 14 days with no activity.'
           exempt-pr-labels: 'no stale'
           days-before-pr-stale: 60
-          days-before-pr-close: 14
+          days-before-pr-close: 30
           stale-pr-label: stale
 
           operations-per-run: 500

--- a/.github/workflows/IssuesCloseStale.yml
+++ b/.github/workflows/IssuesCloseStale.yml
@@ -27,7 +27,7 @@ jobs:
           stale-pr-message: 'This pull request is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
           close-pr-message: 'This pull request was closed because it has been stale for 14 days with no activity.'
           exempt-pr-labels: 'no stale'
-          days-before-pr-stale: 60
+          days-before-pr-stale: 30
           days-before-pr-close: 30
           stale-pr-label: stale
 

--- a/.github/workflows/IssuesCloseStale.yml
+++ b/.github/workflows/IssuesCloseStale.yml
@@ -17,14 +17,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
-          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
-          stale-pr-message: 'This pull request is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          stale-issue-message: 'This issue is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
           close-issue-message: 'This issue was closed because it has been stale for 30 days with no activity.'
-          close-pr-message: 'This pull request was closed because it has been stale for 30 days with no activity.'
           exempt-issue-labels: 'no stale'
-          exempt-pr-labels: 'no stale'
-          days-before-stale: 365
-          days-before-close: 30
-          operations-per-run: 500
+          days-before-issue-stale: 365
+          days-before-issue-close: 30
           stale-issue-label: stale
+
+          stale-pr-message: 'This pull request is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          close-pr-message: 'This pull request was closed because it has been stale for 14 days with no activity.'
+          exempt-pr-labels: 'no stale'
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
           stale-pr-label: stale
+
+          operations-per-run: 500

--- a/.github/workflows/IssuesCloseStale.yml
+++ b/.github/workflows/IssuesCloseStale.yml
@@ -24,8 +24,8 @@ jobs:
           days-before-issue-close: 30
           stale-issue-label: stale
 
-          stale-pr-message: 'This pull request is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
-          close-pr-message: 'This pull request was closed because it has been stale for 14 days with no activity.'
+          stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          close-pr-message: 'This pull request was closed because it has been stale for 30 days with no activity.'
           exempt-pr-labels: 'no stale'
           days-before-pr-stale: 30
           days-before-pr-close: 30


### PR DESCRIPTION
We have a 365/30 day policy for issues, but we want a stricter 30/30 day policy for PRs. Stale PRs will go out-of-date quickly and often require resolving more merge conflicts the more time passes. We prefer to close and allow a new PR to be opened if the diff is still important.