### PR TITLE
Use atomic load in bloom filter look-up

### DIFF
--- a/src/planner/filter/bloom_filter.cpp
+++ b/src/planner/filter/bloom_filter.cpp
@@ -73,8 +73,10 @@ inline bool BloomFilter::LookupOne(const uint64_t hash) const {
 	D_ASSERT(initialized);
 	const uint64_t bf_offset = hash & bitmask;
 	const uint64_t mask = GetMask(hash);
+	atomic<uint64_t> &slot = *reinterpret_cast<atomic<uint64_t> *>(&bf[bf_offset]);
+	auto bf_entry = slot.load(std::memory_order_relaxed);
 
-	return (bf[bf_offset] & mask) == mask;
+	return (bf_entry & mask) == mask;
 }
 
 string BFTableFilter::ToString(const string &column_name) const {


### PR DESCRIPTION
In dynamic filter pushdown the bloom-filter can be modified at run-time through `BloomFilter::InsertOne` which can cause a data-race, we need to use an atomic load in `BloomFilter::LookupOne` to prevent this from being an issue.