### PR TITLE
Switch MAIN_BRANCH_VERSIONING to False for v1.5-variegata branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ set(VERSIONING_TAG_MATCH "v*.*.*")
 # - scripts/amalgamation.py
 # - scripts/package_build.py
 ######
-option(MAIN_BRANCH_VERSIONING "Versioning scheme for main branch" TRUE)
+option(MAIN_BRANCH_VERSIONING "Versioning scheme for main branch" FALSE)
 if(${MAIN_BRANCH_VERSIONING})
   set(VERSIONING_TAG_MATCH "v*.*.0")
 endif()

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -278,7 +278,7 @@ def git_commit_hash():
 # - scripts/amalgamation.py
 # - scripts/package_build.py
 ######
-MAIN_BRANCH_VERSIONING = True
+MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
     MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "1":

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -148,7 +148,7 @@ def get_relative_path(source_dir, target_file):
 # - scripts/amalgamation.py
 # - scripts/package_build.py
 ######
-MAIN_BRANCH_VERSIONING = True
+MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "0":
     MAIN_BRANCH_VERSIONING = False
 if os.getenv('MAIN_BRANCH_VERSIONING') == "1":


### PR DESCRIPTION
This it's not ideal, but as far as I am aware there are no alternatives in places, so we might as well do another round here.

Goal: after this PR `v1.5-variegata` branch should have a name similar to `v1.5.1-dev48`, that allows to distinguish from v1.4- dev branches (`v1.4.5-devX`) or v1.6- dev branches (`v1.6.0-devY`).

After this goes in, I'll send a merge + revert to `main`.