### PR TITLE
Unify linux builds part two

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -260,10 +260,11 @@ jobs:
     - name: Run Tests
       shell: bash
       run: |
-        export JULIA_DUCKDB_LIBRARY="`pwd`/build/release/src/libduckdb.so"
+        JULIA_DUCKDB_LIBRARY="$(pwd)/build/release/src/libduckdb.so"
+        export JULIA_DUCKDB_LIBRARY
         export JULIA_NUM_THREADS=2
         export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libstdc++.so.6"
-        ls $JULIA_DUCKDB_LIBRARY
+        ls "$JULIA_DUCKDB_LIBRARY"
         cd tools/juliapkg
         julia --project -e "import Pkg; Pkg.test()"
 

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -296,39 +296,3 @@ jobs:
         python3 scripts/amalgamation.py
         zip -j libduckdb-src.zip src/amalgamation/duckdb.hpp src/amalgamation/duckdb.cpp src/include/duckdb.h src/include/duckdb_extension.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-src.zip
-
- symbol-leakage:
-    name: Symbol Leakage
-    runs-on: ubuntu-22.04
-    needs: linux-release-cli
-    if: ${{ inputs.skip_tests != 'true' }}
-    env:
-      GEN: ninja
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ inputs.git_ref }}
-
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-
-    - name: Install Ninja
-      shell: bash
-      run: make toolsci
-
-    - uses: ./.github/actions/ccache-action
-
-    - name: Build
-      shell: bash
-      run: make
-
-    - name: Symbol Leakage Test
-      shell: bash
-      run: python3 scripts/exported_symbols_check.py build/release/src/libduckdb*.so
-
-    - name: Banned Symbol Check
-      shell: bash
-      run: python3 scripts/banned_symbols_check.py --directory build/release/src

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [ { runner: ubuntu-latest, arch: amd64, image: x86_64}, {runner: ubuntu-24.04-arm, arch: arm64, image: aarch64}]
+        config: ${{ fromJson(github.event_name == 'pull_request' && '[{"runner":"ubuntu-latest","arch":"amd64","image":"x86_64"}]' || '[{"runner":"ubuntu-latest","arch":"amd64","image":"x86_64"},{"runner":"ubuntu-24.04-arm","arch":"arm64","image":"aarch64"}]') }}
 
     name: Linux CLI (${{ matrix.config.arch }})
     runs-on: ${{ matrix.config.runner }}
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [ { runner: ubuntu-latest, arch: amd64}, {runner: ubuntu-24.04-arm, arch: arm64}]
+        config: ${{ fromJson(github.event_name == 'pull_request' && '[{"runner":"ubuntu-24.04-arm","arch":"arm64"}]' || '[{"runner":"ubuntu-latest","arch":"amd64"},{"runner":"ubuntu-24.04-arm","arch":"arm64"}]') }}
 
     name: Linux CLI (${{ matrix.config.arch }}-musl)
     runs-on: ${{ matrix.config.runner }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -621,7 +621,7 @@ jobs:
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/variant_vector.json ./build/release/test/unittest
 
-    - name: Test variant_vector
+    - name: Test compressed in memory
       if: success() || failure()
       shell: bash
       run: |

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -218,9 +218,6 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
     env:
       GEN: ninja
-      BUILD_JEMALLOC: 1
-      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
-      DISABLE_SANITIZER: 1
 
     steps:
     - uses: actions/checkout@v4
@@ -231,13 +228,16 @@ jobs:
     - uses: ./.github/actions/ccache-action
 
     - name: Build
+      env:
+        BUILD_JEMALLOC: 1
+        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
+        DISABLE_SANITIZER: 1
       run: make release
 
     - name: Smoke tests
       run: make smoke SMOKE_UNITTEST=build/release/test/unittest
 
     - name: Prepare release artifact
-      shell: bash
       run: make release-artifact
 
     - name: Upload release build artifact
@@ -245,6 +245,21 @@ jobs:
       with:
         name: linux-release-build
         path: build/release-artifact.tar.gz
+        if-no-files-found: error
+
+    - name: Build linux default release
+      run: make clean release
+
+    - name: Prepare linux default release artifact
+      run: |
+        make release-artifact
+        mv build/release-artifact.tar.gz build/linux-default-release.tar.gz
+
+    - name: Upload linux default release artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux-default-release-build
+        path: build/linux-default-release.tar.gz
         if-no-files-found: error
 
  linux-release-tests:
@@ -273,6 +288,37 @@ jobs:
 
     - name: Test
       run: make allunit
+
+ symbol-leakage:
+    name: Symbol Leakage
+    runs-on: ubuntu-24.04
+    needs:
+      - prepare
+      - linux-release
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Download linux default release artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: linux-default-release-build
+        path: build
+
+    - name: Extract linux default release artifact
+      run: |
+        rm -rf build/release
+        tar -xzf build/linux-default-release.tar.gz -C build
+
+    - name: Symbol Leakage Test
+      run: python3 scripts/exported_symbols_check.py build/release/src/libduckdb*.so
+
+    - name: Banned Symbol Check
+      run: python3 scripts/banned_symbols_check.py --directory build/release/src
 
  linux-cli:
     uses: ./.github/workflows/LinuxRelease.yml

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -219,11 +219,18 @@ jobs:
 
     - uses: ./.github/actions/ccache-action
 
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11.1
+      with:
+        vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
+
     - name: Build
       env:
         BUILD_JEMALLOC: 1
-        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
+        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
         DISABLE_SANITIZER: 1
+        VCPKG_TOOLCHAIN_PATH: ${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
+        USE_MERGED_VCPKG_MANIFEST: 1
       run: make release
 
     - name: Smoke tests
@@ -252,35 +259,6 @@ jobs:
       with:
         name: linux-default-release-build
         path: build/linux-default-release.tar.gz
-        if-no-files-found: error
-
-    - name: Install httpfs build dependency
-      run: sudo apt-get install -y -qq libcurl4-openssl-dev
-
-    - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v11.1
-      with:
-        vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
-
-    - name: Build linux full release
-      env:
-        BUILD_JEMALLOC: 1
-        CORE_EXTENSIONS: "json;parquet;icu;tpch;tpcds;autocomplete;httpfs"
-        DISABLE_SANITIZER: 1
-        VCPKG_TOOLCHAIN_PATH: ${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
-        USE_MERGED_VCPKG_MANIFEST: 1
-      run: make clean release
-
-    - name: Prepare linux full release artifact
-      run: |
-        make release-artifact
-        mv build/release-artifact.tar.gz build/linux-full-release.tar.gz
-
-    - name: Upload linux full release artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: linux-full-release-build
-        path: build/linux-full-release.tar.gz
         if-no-files-found: error
 
  linux-release-tests:
@@ -523,17 +501,17 @@ jobs:
       shell: bash
       run: make toolsci
 
-    - name: Download linux full release artifact
+    - name: Download linux release artifact
       uses: actions/download-artifact@v4
       with:
-        name: linux-full-release-build
+        name: linux-release-build
         path: build
 
-    - name: Extract linux full release artifact
+    - name: Extract linux release artifact
       shell: bash
       run: |
         rm -rf build/release
-        tar -xzf build/linux-full-release.tar.gz -C build
+        tar -xzf build/release-artifact.tar.gz -C build
 
     - name: test/configs/force_storage.json
       if: success() || failure()

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -254,6 +254,35 @@ jobs:
         path: build/linux-default-release.tar.gz
         if-no-files-found: error
 
+    - name: Install httpfs build dependency
+      run: sudo apt-get install -y -qq libcurl4-openssl-dev
+
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11.1
+      with:
+        vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
+
+    - name: Build linux full release
+      env:
+        BUILD_JEMALLOC: 1
+        CORE_EXTENSIONS: "json;parquet;icu;tpch;tpcds;autocomplete;httpfs"
+        DISABLE_SANITIZER: 1
+        VCPKG_TOOLCHAIN_PATH: ${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
+        USE_MERGED_VCPKG_MANIFEST: 1
+      run: make clean release
+
+    - name: Prepare linux full release artifact
+      run: |
+        make release-artifact
+        mv build/release-artifact.tar.gz build/linux-full-release.tar.gz
+
+    - name: Upload linux full release artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux-full-release-build
+        path: build/linux-full-release.tar.gz
+        if-no-files-found: error
+
  linux-release-tests:
     name: Linux Release Tests
     needs:
@@ -481,7 +510,7 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
     needs:
       - prepare
-      - linux-debug
+      - linux-release
 
     steps:
     - uses: actions/checkout@v4
@@ -492,185 +521,166 @@ jobs:
 
     - name: Install
       shell: bash
-      run: make toolsci && sudo apt-get install -y -qq libcurl4-openssl-dev
+      run: make toolsci
 
-    - uses: ./.github/actions/ccache-action
+    - name: Download linux full release artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: linux-full-release-build
+        path: build
 
-    - name: Build
-      id: build
+    - name: Extract linux full release artifact
       shell: bash
-      env:
-        CORE_EXTENSIONS: "json;parquet;icu;tpch;tpcds;autocomplete"
-        GEN: ninja
-      run: make
+      run: |
+        rm -rf build/release
+        tar -xzf build/linux-full-release.tar.gz -C build
 
     - name: test/configs/force_storage.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/force_storage.json ./build/release/test/unittest
 
     - name: test/configs/force_storage_restart.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/force_storage_restart.json ./build/release/test/unittest
 
     - name: test/configs/latest_storage.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/latest_storage.json ./build/release/test/unittest
 
     - name: test/configs/block_verification.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/block_verification.json ./build/release/test/unittest
 
     - name: test/configs/verify_fetch_row.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/verify_fetch_row.json ./build/release/test/unittest
 
     - name: test/configs/wal_verification.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/wal_verification.json ./build/release/test/unittest
 
     - name: test/configs/prefetch_all_parquet_files.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/prefetch_all_parquet_files.json ./build/release/test/unittest
 
     - name: test/configs/no_local_filesystem.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/no_local_filesystem.json ./build/release/test/unittest
 
     - name: test/configs/block_size_16kB.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/block_size_16kB.json ./build/release/test/unittest
 
     - name: test/configs/latest_storage_block_size_16kB.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/latest_storage_block_size_16kB.json ./build/release/test/unittest
 
     - name: test/configs/enable_verification.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/enable_verification.json ./build/release/test/unittest
 
     - name: test/configs/block_allocator_100mib.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/block_allocator_100mib.json ./build/release/test/unittest
 
     - name: Test dictionary_expression
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-flags="--verify-vector dictionary_expression --skip-compiled" ./build/release/test/unittest
 
     - name: Test dictionary_operator
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-flags="--verify-vector dictionary_operator --skip-compiled" ./build/release/test/unittest
 
     - name: Test constant_operator
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-flags="--verify-vector constant_operator --skip-compiled" ./build/release/test/unittest
 
     - name: Test sequence_operator
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-flags="--verify-vector sequence_operator --skip-compiled" ./build/release/test/unittest
 
     - name: Test nested_shuffle
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-flags="--verify-vector nested_shuffle --skip-compiled" ./build/release/test/unittest
 
     - name: Test variant_vector
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/variant_vector.json ./build/release/test/unittest
 
     - name: Test variant_vector
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/compressed_in_memory.json ./build/release/test/unittest
 
     - name: Test sycnronous table scan implementation
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-flags='--on-init "SET debug_physical_table_scan_execution_strategy=SYNCHRONOUS;"' ./build/release/test/unittest
 
     - name: Test block prefetching
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/prefetch_all_storage.json ./build/release/test/unittest
 
     - name: Forwards compatibility tests
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/test_storage_compatibility.py --versions "1.2.1|1.3.2|1.4.3" --new-unittest build/release/test/unittest
 
-
-    # TODO: clean this up: we should probably be able to run this whole test suite with httpfs
-    # We want to run the remainder of tests with httpfs
-    - name: Setup vcpkg
-      if: (success() || failure()) && steps.build.conclusion == 'success'
-      uses: lukka/run-vcpkg@v11.1
-      with:
-        vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
-
-    - name: Build with httpfs extension
-      id: build-httpfs
-      shell: bash
-      if: (success() || failure()) && steps.build.conclusion == 'success'
-      env:
-        CORE_EXTENSIONS: "json;parquet;icu;tpch;tpcds;httpfs"
-        GEN: ninja
-        VCPKG_TOOLCHAIN_PATH: ${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
-        USE_MERGED_VCPKG_MANIFEST: 1
-      run:
-        make clean && make
-
     - name: test/configs/encryption.json
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/encryption.json ./build/release/test/unittest
 
     - name: Test PEG parser on fallback mode
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/peg_parser.json ./build/release/test/unittest
 
     - name: Test PEG parser on strict when supported mode
-      if: (success() || failure()) && steps.build.conclusion == 'success'
+      if: success() || failure()
       shell: bash
       run: |
         python3 scripts/ci/run_tests.py --test-config=test/configs/peg_parser_strict.json ./build/release/test/unittest

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -20,10 +20,6 @@ on:
       - '!.github/workflows/Regression.yml'
       - '!.github/workflows/Extensions.yml'
       - '!.github/workflows/LinuxRelease.yml'
-      - '.github/config/extensions/*.cmake'
-      - '.github/patches/extensions/**/*.patch'
-      - '!.github/patches/extensions/fts/*.patch' # fts used in some jobs
-      - '!.github/config/extensions/fts.cmake'
   merge_group:
   pull_request:
     types: [opened, reopened, ready_for_review, converted_to_draft, synchronize]
@@ -40,10 +36,6 @@ on:
       - '!.github/workflows/Regression.yml'
       - '!.github/workflows/Extensions.yml'
       - '!.github/workflows/LinuxRelease.yml'
-      - '.github/config/extensions/*.cmake'
-      - '.github/patches/extensions/**/*.patch'
-      - '!.github/patches/extensions/fts/*.patch' # fts used in some jobs
-      - '!.github/config/extensions/fts.cmake'
 
 
 concurrency:

--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,11 @@ endef
 .PHONY: toolsci format_tools
 
 toolsci:
-	$(call ensure_apt_commands,ninja mold ccache,ninja-build mold ccache)
+	$(call ensure_apt_commands,ninja mold ccache pkg-config,ninja-build mold ccache pkg-config)
+	pkg-config --exists libcurl || { \
+		sudo apt-get update -y -qq; \
+		sudo apt-get install -y -qq libcurl4-openssl-dev; \
+	}
 	ls -lh /usr/bin/gcc* /usr/bin/g++*
 	gcc --version
 	g++ --version

--- a/scripts/ci/linux_release_cli_matrix.py
+++ b/scripts/ci/linux_release_cli_matrix.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
+import argparse
 import json
 import os
+import platform
 import sys
 
 GNU_AMD64_IMAGE = "quay.io/pypa/manylinux_2_28_x86_64"
@@ -11,6 +13,26 @@ MUSL_IMAGE = "alpine:3.22"
 
 def env(name: str, default: str) -> str:
     return os.environ.get(name, default)
+
+
+def current_arch() -> str:
+    machine = platform.machine().lower()
+    if machine in {"x86_64", "amd64"}:
+        return "amd64"
+    if machine in {"aarch64", "arm64"}:
+        return "arm64"
+    raise ValueError(f"unsupported platform architecture: {machine}")
+
+
+def image_for(libc: str, arch: str | None = None) -> str:
+    arch = arch or current_arch()
+    if libc == "musl":
+        return MUSL_IMAGE
+    if libc == "gnu" and arch == "amd64":
+        return GNU_AMD64_IMAGE
+    if libc == "gnu" and arch == "arm64":
+        return GNU_ARM64_IMAGE
+    raise ValueError("unsupported libc/arch combination")
 
 
 def build_matrix(kind: str) -> dict[str, list[dict[str, str]]]:
@@ -56,13 +78,44 @@ def build_matrix(kind: str) -> dict[str, list[dict[str, str]]]:
     return {"include": include}
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        usage=(
+            "linux_release_cli_matrix.py <pull_request|default>\n"
+            "       linux_release_cli_matrix.py image <gnu|musl> [amd64|arm64]"
+        )
+    )
+    parser.add_argument("command", choices=["pull_request", "default", "image"])
+    parser.add_argument("libc", nargs="?")
+    parser.add_argument("arch", nargs="?")
+    args = parser.parse_args()
+
+    if args.command == "image":
+        if args.libc is None:
+            parser.error("image requires <gnu|musl>")
+        if args.libc not in {"gnu", "musl"}:
+            parser.error("image libc must be one of: gnu, musl")
+        if args.arch is not None and args.arch not in {"amd64", "arm64"}:
+            parser.error("image arch must be one of: amd64, arm64")
+    elif args.libc is not None or args.arch is not None:
+        parser.error(f"{args.command} does not take additional arguments")
+
+    return args
+
+
 def main() -> int:
-    if len(sys.argv) != 2:
-        print("usage: linux_release_cli_matrix.py <pull_request|default>", file=sys.stderr)
-        return 1
+    args = parse_args()
+
+    if args.command == "image":
+        try:
+            print(image_for(args.libc, args.arch))
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        return 0
 
     try:
-        matrix = build_matrix(sys.argv[1])
+        matrix = build_matrix(args.command)
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/scripts/ci/linux_release_cli_matrix.py
+++ b/scripts/ci/linux_release_cli_matrix.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import sys
+
+GNU_AMD64_IMAGE = "quay.io/pypa/manylinux_2_28_x86_64"
+GNU_ARM64_IMAGE = "quay.io/pypa/manylinux_2_28_aarch64"
+MUSL_IMAGE = "alpine:3.22"
+
+
+def env(name: str, default: str) -> str:
+    return os.environ.get(name, default)
+
+
+def build_matrix(kind: str) -> dict[str, list[dict[str, str]]]:
+    x64_runner = env("LINUX_RELEASE_RUNNER_X64", "ubuntu-latest")
+    arm64_runner = env("LINUX_RELEASE_RUNNER_ARM64", "ubuntu-24.04-arm")
+
+    if kind not in {"pull_request", "default"}:
+        raise ValueError("kind must be 'pull_request' or 'default'")
+
+    include = [
+        {
+            "runner": x64_runner,
+            "arch": "amd64",
+            "libc": "gnu",
+            "container_image": GNU_AMD64_IMAGE,
+        },
+        {
+            "runner": arm64_runner,
+            "arch": "arm64",
+            "libc": "musl",
+            "container_image": MUSL_IMAGE,
+        },
+    ]
+
+    if kind != "pull_request":
+        include.extend(
+            [
+                {
+                    "runner": arm64_runner,
+                    "arch": "arm64",
+                    "libc": "gnu",
+                    "container_image": GNU_ARM64_IMAGE,
+                },
+                {
+                    "runner": x64_runner,
+                    "arch": "amd64",
+                    "libc": "musl",
+                    "container_image": MUSL_IMAGE,
+                },
+            ]
+        )
+
+    return {"include": include}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: linux_release_cli_matrix.py <pull_request|default>", file=sys.stderr)
+        return 1
+
+    try:
+        matrix = build_matrix(sys.argv[1])
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(matrix, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_linux_release_docker.py
+++ b/scripts/ci/run_linux_release_docker.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+
+from linux_release_cli_matrix import image_for
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("libc", choices=["gnu", "musl"])
+    parser.add_argument("command")
+    parser.add_argument(
+        "--run-args",
+        default="",
+        help="Extra arguments to pass to `docker run`, parsed with shell-style splitting.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the resolved docker command instead of executing it.",
+    )
+    return parser.parse_args()
+
+
+def build_docker_command(libc: str, shell_command: str, docker_run_args: list[str]) -> list[str]:
+    pwd = os.getcwd()
+    docker_image = os.environ.get("LINUX_RELEASE_DOCKER_IMAGE", image_for(libc))
+
+    docker_run_command = ["docker", "run", "--rm", *docker_run_args]
+    workspace_args = ["-v", f"{pwd}:{pwd}", "-w", pwd]
+    env_args = ["-e", "OVERRIDE_GIT_DESCRIBE", "-e", f"CCACHE_DIR={pwd}/.ccache"]
+    container_command = [docker_image, "sh", "-lc", shell_command]
+
+    return docker_run_command + workspace_args + env_args + container_command
+
+
+def main() -> int:
+    args = parse_args()
+    docker_command = build_docker_command(args.libc, args.command, shlex.split(args.run_args))
+    docker_command_str = " ".join(shlex.quote(part) for part in docker_command)
+
+    print(docker_command_str)
+    if not args.dry_run:
+        subprocess.run(docker_command, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(exc.returncode) from exc

--- a/scripts/prepare_build_artifact.sh
+++ b/scripts/prepare_build_artifact.sh
@@ -22,6 +22,9 @@ rm -rf "$ARTIFACT_ROOT"
 rm -f "$ARTIFACT_TARBALL"
 mkdir -p "$ARTIFACT_DIR"/test/extension "$ARTIFACT_DIR"/src
 
+# Required by CI jobs that run the CLI from build/<type>/duckdb.
+cp -av "$BUILD_DIR/duckdb" "$ARTIFACT_DIR"/
+
 # Required by CI test jobs that run the prebuilt unittest binary.
 cp -av "$BUILD_DIR/test/unittest" "$ARTIFACT_DIR"/test/
 

--- a/src/include/duckdb/common/fast_mem.hpp
+++ b/src/include/duckdb/common/fast_mem.hpp
@@ -10,6 +10,8 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/types.hpp"
 
+namespace duckdb {
+
 template <size_t SIZE>
 inline void MemcpyFixed(void *dest, const void *src) {
 	memcpy(dest, src, SIZE);
@@ -24,8 +26,6 @@ template <size_t SIZE>
 inline void MemsetFixed(void *ptr, int value) {
 	memset(ptr, value, SIZE);
 }
-
-namespace duckdb {
 
 //! This templated memcpy is significantly faster than std::memcpy,
 //! but only when you are calling memcpy with a const size in a loop.

--- a/test/configs/enable_verification.json
+++ b/test/configs/enable_verification.json
@@ -91,6 +91,7 @@
         "test/sql/copy/csv/rejects/test_multiple_errors_same_line.test",
         "test/sql/copy/csv/test_non_unicode_header.test",
         "test/sql/logging/file_system_logging.test",
+        "test/sql/logging/http_log_timing.test",
         "test/sql/logging/logging.test",
         "test/sql/logging/logging_buffer_size.test",
         "test/sql/logging/logging_csv.test",

--- a/test/configs/force_storage.json
+++ b/test/configs/force_storage.json
@@ -31,6 +31,12 @@
       ]
     },
     {
+      "reason": "VARIANT storage requires a newer storage version than this configuration uses",
+      "paths": [
+        "test/sql/storage/types/variant/extension_types.test"
+      ]
+    },
+    {
       "reason": "Measures memory usage.",
       "paths": [
         "test/sql/delete/in_memory_bulk_delete.test_slow",

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -16,6 +16,7 @@
     {
       "reason": "External file cache cannot persist across database restarts when force_restart is enabled.",
       "paths": [
+        "test/sql/json/table/read_json.test",
         "test/sql/storage/external_file_cache/external_file_cache_validate.test",
         "test/sql/storage/external_file_cache/external_file_cache_parquet.test_slow"
       ]

--- a/test/configs/no_local_filesystem.json
+++ b/test/configs/no_local_filesystem.json
@@ -7,6 +7,12 @@
   ],
   "skip_tests": [
     {
+      "reason": "Cannot install extensions without a local filesystem",
+      "paths": [
+        "test/extension/install_extension_httpfs.test"
+      ]
+    },
+    {
       "reason": "TODO",
       "paths": [
         "test/sql/attach/attach_filepath_roundtrip.test"

--- a/test/configs/verify_fetch_row.json
+++ b/test/configs/verify_fetch_row.json
@@ -26,6 +26,12 @@
       ]
     },
     {
+      "reason": "VARIANT storage requires a newer storage version than this configuration uses",
+      "paths": [
+        "test/sql/storage/types/variant/extension_types.test"
+      ]
+    },
+    {
       "reason": "No stats",
       "paths": [
         "test/sql/types/geo/geometry_shred_types.test_slow"

--- a/test/sql/parallelism/interquery/concurrent_append_scan_blob.test_slow
+++ b/test/sql/parallelism/interquery/concurrent_append_scan_blob.test_slow
@@ -28,7 +28,7 @@ COMMIT
 
 endloop
 
-loop i 0 100000
+loop i 0 10000
 
 onlyif threadid=1
 statement ok


### PR DESCRIPTION
### Context

This PR is a follow-up of https://github.com/duckdb/duckdb/pull/21217.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/7637.

- Unify multiple linux release build into `linux-release` to avoid re-compiling the same code in various CI jobs:
  - CI job `linux-configs` uses the full build from `linux-release`.
  - CI job `linux-release-tests` uses the full build from `linux-release`.
  - CI job `symbol-leakage` uses the default build from `linux-release`.
  - Other CI jobs can use this full/default linux build as well in the future.
- The "full linux build" compiles many extensions. I had to explicitly skip some tests that had test failures in `linux-configs` because those tests were previously implicitly skipped:
  - Some tests had `require inet` (which was missing), tried to create a `VARIANT` column and failed for the config "force storage".
  - Some tests had `require httpfs` (which was missing) and failed for the config "no local filesystem".
- ~~Allow running a local docker container for Linux CLI release glibc/musl builds.~~ I postponed this change because it caused some symbol breakage for musl tests.
- ~~Allow using namespace runners (if available/selected in this repo) for Linux CLI release jobs.~~ Also postponed to limit any CI risk of this PR.

### Short job matrix for pull request

Limit the CI jobs to:
- arm64 - musl
- amd64 - glibc

to catch most cross-platform issues (either arm64 versus x64, or musl versus glibc) in half the compute time.

```json
$ python3 scripts/ci/linux_release_cli_matrix.py pull_request  | jq
{
  "include": [
    {
      "runner": "ubuntu-latest",
      "arch": "amd64",
      "libc": "gnu",
      "container_image": "quay.io/pypa/manylinux_2_28_x86_64"
    },
    {
      "runner": "ubuntu-24.04-arm",
      "arch": "arm64",
      "libc": "musl",
      "container_image": "alpine:3.22"
    }
  ]
}
```

### Larger job matrix for non-PR ("main")

Run the full job matrix outside the pull requests:

```json
$ python3 scripts/ci/linux_release_cli_matrix.py default | jq      
{
  "include": [
    {
      "runner": "ubuntu-latest",
      "arch": "amd64",
      "libc": "gnu",
      "container_image": "quay.io/pypa/manylinux_2_28_x86_64"
    },
    {
      "runner": "ubuntu-24.04-arm",
      "arch": "arm64",
      "libc": "musl",
      "container_image": "alpine:3.22"
    },
    {
      "runner": "ubuntu-24.04-arm",
      "arch": "arm64",
      "libc": "gnu",
      "container_image": "quay.io/pypa/manylinux_2_28_aarch64"
    },
    {
      "runner": "ubuntu-latest",
      "arch": "amd64",
      "libc": "musl",
      "container_image": "alpine:3.22"
    }
  ]
}
```

### Lower test time for a heavy threadsan test

The test `test/sql/parallelism/interquery/concurrent_append_scan_blob.test_slow` was really slow under threadsan:
```
python3 scripts/ci/run_tests.py --batch-size=1 --workers=50% --batch-timeout=1800 --track-runtime=300 build/reldebug/test/unittest "[intraquery],[interquery],[detailed_profiler],test/sql/tpch/tpch_sf01.test_slow" 
...
test/sql/parallelism/interquery/concurrent_append_scan_blob.test_slow took 424.71s

python3 scripts/ci/run_tests.py --batch-size=1 --workers=50% --batch-timeout=1800 --track-runtime=300 --test-flags="--force-storage" build/reldebug/test/unittest "[interquery]" 
...
test/sql/parallelism/interquery/concurrent_append_scan_blob.test_slow took 457.73s

python3 scripts/ci/run_tests.py --batch-size=1 --workers=50% --batch-timeout=1800 --track-runtime=300 --test-flags="--force-storage --force-reload" build/reldebug/test/unittest "[interquery]" 
...
test/sql/parallelism/interquery/concurrent_append_scan_blob.test_slow took 426.51s
```

So, we lowered the select statement loop iterations, so the test takes ~43 sec instead of ~430s to run under threadsan.