### PR TITLE
[shell] Avoid dark mode detection when not interactive

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3048,6 +3048,10 @@ void ShellState::DetectDarkLightMode() {
 		// not printing to console - don't auto-detect
 		return;
 	}
+	if (!stdin_is_interactive) {
+		// stdin is not interactive - don't read from stdin to detect terminal colors
+		return;
+	}
 	// detect terminal colors
 	auto terminal_color = linenoiseGetTerminalColorMode();
 	if (terminal_color == LINENOISE_DARK_MODE) {


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/21243 and https://github.com/duckdb/duckdb/issues/21245.

Possible workarounds are described at https://github.com/duckdb/duckdb/issues/21243#issuecomment-4026335479
