### PR TITLE
Fix powerpc spin-wait instruction for Apple case

### DIFF
--- a/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -42,8 +42,12 @@
 #elif defined(__x86_64__) || defined(__i386__)
     #define CPU_SPINWAIT __asm__ volatile("pause")
     #define HAVE_CPU_SPINWAIT 1
-#elif defined(__powerpc64__) || defined(__PPC64__)
-    #define CPU_SPINWAIT __asm__ volatile("or 27,27,27")
+#elif defined(__powerpc64__) || defined(__PPC64__) || defined(__POWERPC__)
+    #ifdef __APPLE__
+        #define CPU_SPINWAIT __asm__ volatile("or r27,r27,r27")
+    #else
+        #define CPU_SPINWAIT __asm__ volatile("or 27,27,27")
+    #endif
     #define HAVE_CPU_SPINWAIT 1
 #else
     #define CPU_SPINWAIT


### PR DESCRIPTION
A follow-up to https://github.com/duckdb/duckdb/pull/17837 macOS powerpc assembler uses prefixed registers, and __powerpc64__ is defined on powerpc64-apple-darwin, so the current code is broken on ppc64 and unnecessarily not used on ppc. Fix that. __POWERPC__ macro includes both ppc and ppc64 cases.

@Mytherin Could you please take a look?