### PR TITLE
Remove skip_compiled assertion from unittest binary

### DIFF
--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Unit Test
         shell: bash
         run: |
-          python3 scripts/ci/run_tests.py --test-flags="--force-storage --test-temp-dir=my_local_folder" ./build/release/test/unittest || true
+          ./build/release/test/unittest --force-storage --test-temp-dir my_local_folder || true
           rm -rf my_local_folder/hive
 
       - uses: actions/upload-artifact@v4
@@ -224,7 +224,7 @@ jobs:
       - name: Unit Test
         shell: bash
         run: |
-          python3 scripts/ci/run_tests.py --test-flags="--force-storage --test-temp-dir=my_local_folder" ./build/release/test/unittest || true
+          ./build/release/test/unittest --force-storage --test-temp-dir my_local_folder || true
           rm -rf my_local_folder/hive
 
       - uses: actions/upload-artifact@v4

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -13,7 +13,6 @@ using namespace duckdb;
 int main(int argc_in, char *argv[]) {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
 	string test_directory = DUCKDB_ROOT_DIRECTORY;
-	bool has_test_config_arg = false;
 
 	auto &test_config = TestConfiguration::Get();
 	test_config.Initialize();
@@ -36,22 +35,12 @@ int main(int argc_in, char *argv[]) {
 			SetTestDirectory(test_dir);
 		} else if (argument == "--require") {
 			AddRequire(string(argv[++i]));
-		} else if (argument == "--test-config") {
-			has_test_config_arg = true;
-			if (!test_config.ParseArgument(argument, argc, argv, i)) {
-				new_argv[new_argc] = argv[i];
-				new_argc++;
-			}
 		} else if (!test_config.ParseArgument(argument, argc, argv, i)) {
 			new_argv[new_argc] = argv[i];
 			new_argc++;
 		}
 	}
 	test_config.ChangeWorkingDirectory(test_directory);
-	if (has_test_config_arg && !test_config.GetSkipCompiledTests()) {
-		fprintf(stderr, "--test-config requires \"skip_compiled\": true in the config\n");
-		return 1;
-	}
 
 	// delete the testing directory if it exists
 	auto dir = TestCreatePath("");


### PR DESCRIPTION
### Context

Some NightlyTests CI [jobs](https://github.com/duckdb/duckdb/actions/runs/22881777729/job/66387441682) broke due to the added assertion (in [this](https://github.com/duckdb/duckdb/pull/21211) PR):
```shell
$ Run python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --test-config test/configs/release_assertions.json --no-exit --timeout 600 --time_execution
[0/5434]: ADBC - Select 42 (ERROR) (Time: 0.0062 seconds)
FAILURE IN RUNNING TEST
--------------------
RETURNCODE
--------------------
1
--------------------
STDOUT
--------------------

--------------------
STDERR
--------------------
--test-config requires "skip_compiled": true in the config

[1/5434]: ADBC - non-empty query without actual statements (ERROR) (Time: 0.0063 seconds)
FAILURE IN RUNNING TEST
...
```

### Verify compiled tests are skipped

Listing tests for test config `force_storage.json` (containing `skip_compiled: "true"`) omits all compiled tests:
```
$ ./build/release/test/unittest --test-config test/configs/force_storage.json --list-tests | grep -vE '^test/'
name	group
```

### Verify compiled tests are listed

Listing tests for test config `release_assertions.json` (containing `skip_compiled: "false"`) contains compiled tests:
```
$ build/release/test/unittest "*" --test-config test/configs/release_assertions.json --list-tests | grep -vE '^test/' | head
name	group
ADBC - Select 42	[adbc]
ADBC - non-empty query without actual statements	[adbc]
ADBC - Cancel connection while consuming stream	[adbc]
ADBC - Cancel statement while consuming stream	[adbc]
ADBC - Cancel unhappy paths	[adbc]
ADBC - Test ingestion	[adbc]
ADBC - Test ingestion - Incorrect column count	[adbc]
ADBC - Test ingestion - Temporary Table	[adbc]
ADBC - Test ingestion - Temporary Table - Schema Set	[adbc]
...
```