### PR TITLE
Fix .open of Parquet files etc. in CLI

### DIFF
--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -56,7 +56,6 @@ DBConfig::DBConfig() {
 	secret_manager = make_uniq<SecretManager>();
 	http_util = make_shared_ptr<HTTPUtil>();
 	callback_manager = make_uniq<ExtensionCallbackManager>();
-	callback_manager->Register("__open_file__", OpenFileStorageExtension::Create());
 }
 
 DBConfig::DBConfig(bool read_only) : DBConfig::DBConfig() {
@@ -475,6 +474,9 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 		config.callback_manager = std::move(new_config.callback_manager);
 		new_config.callback_manager = make_uniq<ExtensionCallbackManager>();
 	}
+	// This is used to open e.g. parquet files. See DBPathAndType::CheckMagicBytes
+	config.callback_manager->Register("__open_file__", OpenFileStorageExtension::Create());
+
 	config.error_manager = std::move(new_config.error_manager);
 	if (!config.error_manager) {
 		config.error_manager = make_uniq<ErrorManager>();

--- a/tools/shell/tests/conftest.py
+++ b/tools/shell/tests/conftest.py
@@ -40,6 +40,8 @@ class TestResult:
             return
         if isinstance(expected, list):
             expected = "\n".join(expected)
+        if self.status_code != 0:
+            print(self.stderr, file=sys.stderr)
         assert self.status_code == 0
         if not is_needle_in_haystack(expected, self.stdout):
             print(self.stdout, file=sys.stderr)

--- a/tools/shell/tests/test_open.py
+++ b/tools/shell/tests/test_open.py
@@ -9,7 +9,7 @@ import os
 from pathlib import Path
 
 
-# test import from a parquet file
+# test .open with non-databsae files
 def test_open(shell, tmp_path):
     target_dir = tmp_path / 'open_test'
     os.mkdir(target_dir)
@@ -24,11 +24,11 @@ def test_open(shell, tmp_path):
         .statement(f"COPY (SELECT 44) TO '{target_dir}/test.csv'")
         .statement(f"ATTACH '{target_dir}/test.parquet' as test2")
         .statement(f"ATTACH '{target_dir}/test.csv' as test3")
-        .statement(f".open {target_dir}/test.duckdb")
+        .statement(f".open '{target_dir}/test.duckdb'")
         .statement("FROM tbl")
-        .statement(f".open {target_dir}/test.parquet")
+        .statement(f".open '{target_dir}/test.parquet'")
         .statement("FROM file")
-        .statement(f".open {target_dir}/test.csv")
+        .statement(f".open '{target_dir}/test.csv'")
         .statement("FROM file")
     )
 

--- a/tools/shell/tests/test_open.py
+++ b/tools/shell/tests/test_open.py
@@ -1,0 +1,38 @@
+# fmt: off
+
+import pytest
+import subprocess
+import sys
+from typing import List
+from conftest import ShellTest
+import os
+from pathlib import Path
+
+
+# test import from a parquet file
+def test_open(shell, tmp_path):
+    target_dir = tmp_path / 'open_test'
+    os.mkdir(target_dir)
+    test = (
+        ShellTest(shell)
+        .statement(f"ATTACH '{target_dir}/test.duckdb' as test")
+        .statement("USE test")
+        .statement("CREATE TABLE tbl AS SELECT 42")
+        .statement("USE memory")
+        .statement("DETACH test")
+        .statement(f"COPY (SELECT 43) TO '{target_dir}/test.parquet'")
+        .statement(f"COPY (SELECT 44) TO '{target_dir}/test.csv'")
+        .statement(f"ATTACH '{target_dir}/test.parquet' as test2")
+        .statement(f"ATTACH '{target_dir}/test.csv' as test3")
+        .statement(f".open {target_dir}/test.duckdb")
+        .statement("FROM tbl")
+        .statement(f".open {target_dir}/test.parquet")
+        .statement("FROM file")
+        .statement(f".open {target_dir}/test.csv")
+        .statement("FROM file")
+    )
+
+    result = test.run()
+    result.check_stdout("42")
+    result.check_stdout("43")
+    result.check_stdout("44")


### PR DESCRIPTION
Fixes #21259

The `.open file.parquet` shell command is made possible by the `OpenFileStorageExtension`. This extension lives in the `ExtensionCallbackManager` in `DBConfig`. 

The problem was that `DatabaseInstance::Configure()` **consumed** the callback manager set in the config. However, the shell re-uses the same `DBConfig` object multiple times for calls to `Configure()`. Hence, the extension was only passed the first time a database was created, not in subsequent calls.

The fix is to add this extension to the configuration *not* in the `DBConfig` constructor, but in `Configure()`.

At the same time, the shell should probably not re-use config objects, but this is left for future work. 