### PR TITLE
Remove wrong assertions in `JoinHashTable`

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1224,8 +1224,6 @@ void ScanStructure::NextSemiOrAntiJoin(DataChunk &keys, DataChunk &probe_data, D
 }
 
 void ScanStructure::NextSemiJoin(DataChunk &keys, DataChunk &probe_data, DataChunk &result) {
-	D_ASSERT(probe_data.ColumnCount() == result.ColumnCount());
-
 	// first scan for key matches
 	ScanKeyMatches(keys, probe_data);
 
@@ -1236,8 +1234,6 @@ void ScanStructure::NextSemiJoin(DataChunk &keys, DataChunk &probe_data, DataChu
 }
 
 void ScanStructure::NextAntiJoin(DataChunk &keys, DataChunk &probe_data, DataChunk &result) {
-	D_ASSERT(probe_data.ColumnCount() == result.ColumnCount());
-
 	// first scan for key matches
 	ScanKeyMatches(keys, probe_data);
 

--- a/test/issues/internal/test_7738.test
+++ b/test/issues/internal/test_7738.test
@@ -1,0 +1,55 @@
+# name: test/issues/internal/test_7738.test
+# description: Internal Issue 7738: Assertion failure in JoinHashTable::ScanStructure::NextSemiJoin
+# group: [internal]
+
+statement ok
+CREATE TABLE left_small(
+	id INTEGER,
+	start DATE,
+	stop DATE,
+	symbol VARCHAR,
+	price DECIMAL
+);
+
+statement ok
+INSERT INTO left_small VALUES
+    (1, '2026-01-01', '2026-01-02', 'A', 150.00),
+    (2, '2026-01-02', '2026-01-03', 'A', 151.00),
+    (3, '2026-01-03', '2026-01-04', 'B', 380.00);
+
+statement ok
+CREATE TABLE right_small (
+	id INTEGER,
+	start DATE,
+	stop DATE,
+	symbol VARCHAR,
+	bid DECIMAL,
+	active BOOLEAN
+);
+
+statement ok
+INSERT INTO right_small VALUES
+    (1, '2026-01-01', '2026-01-03', 'A', 149.50, true),
+    (2, '2026-01-03', '2026-01-04', 'A', 150.50, false),
+    (3, '2026-01-04', '2026-01-05', 'B', 379.00, true);
+
+statement ok
+SET prefer_range_joins=false;
+
+statement ok
+SET merge_join_threshold=0
+
+statement ok
+SET nested_loop_join_threshold=0;
+
+query III
+SELECT l.id, l.start, l.stop
+FROM left_small l
+SEMI JOIN right_small r
+       ON l.start < r.stop
+      AND r.start < l.stop
+      AND l.symbol = r.symbol
+      AND l.price + r.bid > 300
+ORDER BY 1
+----
+2	2026-01-02	2026-01-03


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/7738

These can just be removed, the correct assertion is done later anyway