### PR TITLE
Fix column pruning for CTEs

### DIFF
--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -76,6 +76,8 @@ enum class BaseColumnPrunerMode : uint8_t {
 struct MaterializedCTEInfo {
 public:
 	column_binding_map_t<ReferencedColumn> column_references;
+	unordered_set<idx_t> expected_readers;
+	unordered_set<idx_t> seen_readers;
 	bool everything_referenced = true;
 };
 

--- a/src/include/duckdb/optimizer/remove_unused_columns.hpp
+++ b/src/include/duckdb/optimizer/remove_unused_columns.hpp
@@ -22,6 +22,7 @@ namespace duckdb {
 class Binder;
 class BoundColumnRefExpression;
 class ClientContext;
+class Optimizer;
 
 struct ReferencedExtractComponent {
 public:
@@ -128,22 +129,21 @@ private:
 //! The RemoveUnusedColumns optimizer traverses the logical operator tree and removes any columns that are not required
 class RemoveUnusedColumns : public BaseColumnPruner {
 public:
-	RemoveUnusedColumns(Binder &binder, ClientContext &context, bool is_root = false,
-	                    shared_ptr<unordered_map<idx_t, MaterializedCTEInfo>> cte_info_map = nullptr)
-	    : binder(binder), context(context), everything_referenced(is_root), cte_info_map(std::move(cte_info_map)) {
-	}
+	explicit RemoveUnusedColumns(Optimizer &optimizer);
+	RemoveUnusedColumns(RemoveUnusedColumns &parent, bool is_root);
 
 	void VisitOperator(LogicalOperator &op) override;
 
 private:
+	Optimizer &optimizer;
 	Binder &binder;
 	ClientContext &context;
 	//! Whether or not all the columns are referenced. This happens in the case of the root expression (because the
 	//! output implicitly refers all the columns below it)
 	bool everything_referenced;
 
-	shared_ptr<unordered_map<idx_t, MaterializedCTEInfo>> cte_info_map;
-	RemoveUnusedColumns CreateChildOptimizer();
+	RemoveUnusedColumns &root;
+	unique_ptr<unordered_map<idx_t, MaterializedCTEInfo>> root_cte_map;
 
 private:
 	template <class T>
@@ -154,6 +154,8 @@ private:
 	void WritePushdownExtractColumns(
 	    const ColumnBinding &binding, ReferencedColumn &col, idx_t original_idx, const LogicalType &column_type,
 	    const std::function<idx_t(const ColumnIndex &new_index, optional_ptr<const LogicalType> cast_type)> &callback);
+	unordered_map<idx_t, MaterializedCTEInfo> &GetCTEMap();
+	optional_ptr<unordered_map<idx_t, MaterializedCTEInfo>> TryGetCTEMap();
 };
 
 class CTERefPruner : public LogicalOperatorVisitor {

--- a/src/optimizer/cte_inlining.cpp
+++ b/src/optimizer/cte_inlining.cpp
@@ -25,6 +25,18 @@ unique_ptr<LogicalOperator> CTEInlining::Optimize(unique_ptr<LogicalOperator> op
 	return op;
 }
 
+static idx_t CountBaseTableReferences(const LogicalOperator &op) {
+	idx_t number_of_references = 0;
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		number_of_references++;
+	}
+	for (auto &child : op.children) {
+		number_of_references += CountBaseTableReferences(*child);
+	}
+
+	return number_of_references;
+}
+
 static idx_t CountCTEReferences(const LogicalOperator &op, idx_t cte_index) {
 	if (op.type == LogicalOperatorType::LOGICAL_CTE_REF) {
 		auto &cte = op.Cast<LogicalCTERef>();
@@ -130,6 +142,13 @@ void CTEInlining::TryInlining(unique_ptr<LogicalOperator> &op) {
 			// Prevent inlining if the CTE ends in an aggregate or distinct operator
 			// This mimics the behavior of the CTE materialization in the binder
 			if (EndsInAggregateOrDistinct(*op->children[0])) {
+				return;
+			}
+
+			// Check how many base table references the CTE has
+			auto base_table_references = CountBaseTableReferences(*op->children[0]);
+
+			if (base_table_references > 2 && base_table_references * ref_count > 10) {
 				return;
 			}
 

--- a/src/optimizer/late_materialization.cpp
+++ b/src/optimizer/late_materialization.cpp
@@ -365,7 +365,7 @@ bool LateMaterialization::TryLateMaterialization(unique_ptr<LogicalOperator> &op
 	}
 
 	// run the RemoveUnusedColumns optimizer to prune the (now) unused columns the plan
-	RemoveUnusedColumns unused_optimizer(optimizer.binder, optimizer.context, true);
+	RemoveUnusedColumns unused_optimizer(optimizer);
 	unused_optimizer.VisitOperator(*op);
 	return true;
 }

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -218,7 +218,7 @@ void Optimizer::RunBuiltInOptimizers() {
 
 	// removes unused columns
 	RunOptimizer(OptimizerType::UNUSED_COLUMNS, [&]() {
-		RemoveUnusedColumns unused(binder, context, true);
+		RemoveUnusedColumns unused(*this);
 		unused.VisitOperator(*plan);
 	});
 

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -348,6 +348,12 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		// of the CTE. However, if we have not seen all readers, we opt to not prune, because we might miss column
 		// references, resulting in incorrect query results.
 		auto have_seen_all_readers = cte_map_entry.expected_readers == cte_map_entry.seen_readers;
+
+		if (!have_seen_all_readers) {
+			// We did not traverse the entire plan. Something is wrong.
+			throw InternalException("CTE pruning did not traverse the entire plan. This is a bug in the optimizer.");
+		}
+
 		if (!cte_map_entry.everything_referenced && have_seen_all_readers) {
 			auto lhs_child_optimizer = CreateChildOptimizer();
 			// Construct a projection on top of the left-hand side of the CTE

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -31,6 +31,19 @@
 
 namespace duckdb {
 
+static void GatherCTEScans(const idx_t cte_index, const LogicalOperator &op, unordered_set<idx_t> &expected_readers) {
+	if (op.type == LogicalOperatorType::LOGICAL_CTE_REF) {
+		auto &cte_scan = op.Cast<LogicalCTERef>();
+		if (cte_scan.cte_index != cte_index) {
+			return;
+		}
+		expected_readers.insert(cte_scan.table_index);
+	}
+	for (auto &child : op.children) {
+		GatherCTEScans(cte_index, *child, expected_readers);
+	}
+}
+
 RemoveUnusedColumns RemoveUnusedColumns::CreateChildOptimizer() {
 	return RemoveUnusedColumns(binder, context, true, cte_info_map);
 }
@@ -185,6 +198,11 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			}
 			ClearUnusedExpressions(entries, setop.table_index);
 			if (entries.size() >= setop.column_count) {
+				// We still need to recurse into the children to populate CTE info, etc.
+				for (auto &child : op.children) {
+					RemoveUnusedColumns remove(binder, context, true, cte_info_map);
+					remove.VisitOperator(*child);
+				}
 				return;
 			}
 			if (entries.empty()) {
@@ -315,6 +333,9 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		auto &cte = op.Cast<LogicalCTE>();
 		auto &cte_map_entry = cte_map_ref[cte.table_index];
 
+		// Gather all scans of this CTE in the query and mark them as expected readers of this CTE
+		GatherCTEScans(cte.table_index, *cte.children[1], cte_map_entry.expected_readers);
+		cte_map_entry.everything_referenced = false;
 		auto rhs_child_optimizer = CreateChildOptimizer();
 		rhs_child_optimizer.VisitOperator(*cte.children[1]);
 
@@ -323,9 +344,12 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			referenced_columns_in_rhs.insert(entry.first.column_index);
 		}
 
-		if (!cte_map_entry.everything_referenced) {
+		// If we have seen all readers of this CTE, and not all columns are referenced, we can prune the left-hand side
+		// of the CTE. However, if we have not seen all readers, we opt to not prune, because we might miss column
+		// references, resulting in incorrect query results.
+		auto have_seen_all_readers = cte_map_entry.expected_readers == cte_map_entry.seen_readers;
+		if (!cte_map_entry.everything_referenced && have_seen_all_readers) {
 			auto lhs_child_optimizer = CreateChildOptimizer();
-
 			// Construct a projection on top of the left-hand side of the CTE
 			// that only projects the columns that are referenced in the right-hand side of the CTE
 			cte.children[0]->ResolveOperatorTypes();
@@ -377,6 +401,9 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			throw InternalException("Could not find CTE definition for CTE reference");
 		}
 
+		// Mark this CTE reference as a seen reader of the CTE
+		it->second.seen_readers.insert(cte_ref.table_index);
+
 		for (auto &entry : column_references) {
 			if (entry.first.table_index == cte_ref.table_index) {
 				auto &test = cte_map_ref[cte_ref.cte_index].column_references;
@@ -384,7 +411,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			}
 		}
 
-		cte_map_ref[cte_ref.cte_index].everything_referenced =
+		cte_map_ref[cte_ref.cte_index].everything_referenced |=
 		    cte_ref.chunk_types.size() == cte_map_ref[cte_ref.cte_index].column_references.size();
 
 		break;

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -215,39 +215,46 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 				entries.push_back(i);
 			}
 			ClearUnusedExpressions(entries, setop.table_index);
+			if (entries.size() >= setop.column_count) {
+				// We still need to recurse into the children to populate CTE info, etc.
+				for (auto &child : op.children) {
+					RemoveUnusedColumns remove(*this, true);
+					remove.VisitOperator(*child);
+				}
+
+				return;
+			}
 			if (entries.empty()) {
 				// no columns referenced: this happens in the case of a COUNT(*)
 				// extract the first column
 				entries.push_back(0);
 			}
+			// columns were cleared
+			setop.column_count = entries.size();
+
 			for (idx_t child_idx = 0; child_idx < op.children.size(); child_idx++) {
 				RemoveUnusedColumns remove(*this, true);
 				auto &child = op.children[child_idx];
 
-				if (entries.size() < setop.column_count) {
-					// columns were cleared
-					// push a projection under this child that references the required columns of the union
-					child->ResolveOperatorTypes();
-					auto bindings = child->GetColumnBindings();
-					vector<unique_ptr<Expression>> expressions;
-					expressions.reserve(entries.size());
-					for (auto &column_idx : entries) {
-						expressions.push_back(
-						    make_uniq<BoundColumnRefExpression>(child->types[column_idx], bindings[column_idx]));
-					}
-					auto new_projection =
-					    make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(expressions));
-					if (child->has_estimated_cardinality) {
-						new_projection->SetEstimatedCardinality(child->estimated_cardinality);
-					}
-					new_projection->children.push_back(std::move(child));
-					op.children[child_idx] = std::move(new_projection);
+				// we push a projection under this child that references the required columns of the union
+				child->ResolveOperatorTypes();
+				auto bindings = child->GetColumnBindings();
+				vector<unique_ptr<Expression>> expressions;
+				expressions.reserve(entries.size());
+				for (auto &column_idx : entries) {
+					expressions.push_back(
+					    make_uniq<BoundColumnRefExpression>(child->types[column_idx], bindings[column_idx]));
 				}
 
-				// now visit the child
+				auto new_projection = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(expressions));
+				if (child->has_estimated_cardinality) {
+					new_projection->SetEstimatedCardinality(child->estimated_cardinality);
+				}
+				new_projection->children.push_back(std::move(child));
+				op.children[child_idx] = std::move(new_projection);
+
 				remove.VisitOperator(*op.children[child_idx]);
 			}
-			setop.column_count = entries.size();
 			return;
 		}
 		for (auto &child : op.children) {

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -405,7 +405,10 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			return;
 		}
 		everything_referenced = true;
-		break;
+		// We may opt out here, but we still need to traverse the left-hand side of the CTE
+		RemoveUnusedColumns remove(*this, true);
+		remove.VisitOperator(*cte.children[0]);
+		return;
 	}
 	case LogicalOperatorType::LOGICAL_CTE_REF: {
 		auto &cte_ref = op.Cast<LogicalCTERef>();

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -27,6 +27,7 @@
 #include "duckdb/function/scalar/struct_utils.hpp"
 #include "duckdb/function/scalar/variant_utils.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
 #include <utility>
 
 namespace duckdb {
@@ -44,8 +45,25 @@ static void GatherCTEScans(const idx_t cte_index, const LogicalOperator &op, uno
 	}
 }
 
-RemoveUnusedColumns RemoveUnusedColumns::CreateChildOptimizer() {
-	return RemoveUnusedColumns(binder, context, true, cte_info_map);
+RemoveUnusedColumns::RemoveUnusedColumns(Optimizer &optimizer)
+    : optimizer(optimizer), binder(optimizer.binder), context(optimizer.context), everything_referenced(true),
+      root(*this) {
+}
+
+RemoveUnusedColumns::RemoveUnusedColumns(RemoveUnusedColumns &parent, bool is_root)
+    : optimizer(parent.optimizer), binder(parent.binder), context(parent.context), everything_referenced(is_root),
+      root(parent.root) {
+}
+
+unordered_map<idx_t, MaterializedCTEInfo> &RemoveUnusedColumns::GetCTEMap() {
+	if (!root.root_cte_map) {
+		root.root_cte_map = make_uniq<unordered_map<idx_t, MaterializedCTEInfo>>();
+	}
+	return *root.root_cte_map;
+}
+
+optional_ptr<unordered_map<idx_t, MaterializedCTEInfo>> RemoveUnusedColumns::TryGetCTEMap() {
+	return root.root_cte_map.get();
 }
 
 idx_t BaseColumnPruner::ReplaceBinding(ColumnBinding current_binding, ColumnBinding new_binding) {
@@ -130,7 +148,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		// Note: We allow all optimizations (join column replacement, column pruning) to run below ROLLUP
 		// The duplicate groups optimizer will be responsible for not breaking ROLLUP by skipping when
 		// multiple grouping sets are present
-		RemoveUnusedColumns remove(binder, context, everything_referenced, cte_info_map);
+		RemoveUnusedColumns remove(*this, everything_referenced);
 		remove.VisitOperatorExpressions(op);
 		remove.VisitOperator(*op.children[0]);
 		return;
@@ -197,48 +215,43 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 				entries.push_back(i);
 			}
 			ClearUnusedExpressions(entries, setop.table_index);
-			if (entries.size() >= setop.column_count) {
-				// We still need to recurse into the children to populate CTE info, etc.
-				for (auto &child : op.children) {
-					RemoveUnusedColumns remove(binder, context, true, cte_info_map);
-					remove.VisitOperator(*child);
-				}
-				return;
-			}
 			if (entries.empty()) {
 				// no columns referenced: this happens in the case of a COUNT(*)
 				// extract the first column
 				entries.push_back(0);
 			}
-			// columns were cleared
-			setop.column_count = entries.size();
-
 			for (idx_t child_idx = 0; child_idx < op.children.size(); child_idx++) {
-				RemoveUnusedColumns remove(binder, context, true, cte_info_map);
+				RemoveUnusedColumns remove(*this, true);
 				auto &child = op.children[child_idx];
 
-				// we push a projection under this child that references the required columns of the union
-				child->ResolveOperatorTypes();
-				auto bindings = child->GetColumnBindings();
-				vector<unique_ptr<Expression>> expressions;
-				expressions.reserve(entries.size());
-				for (auto &column_idx : entries) {
-					expressions.push_back(
-					    make_uniq<BoundColumnRefExpression>(child->types[column_idx], bindings[column_idx]));
+				if (entries.size() < setop.column_count) {
+					// columns were cleared
+					// push a projection under this child that references the required columns of the union
+					child->ResolveOperatorTypes();
+					auto bindings = child->GetColumnBindings();
+					vector<unique_ptr<Expression>> expressions;
+					expressions.reserve(entries.size());
+					for (auto &column_idx : entries) {
+						expressions.push_back(
+						    make_uniq<BoundColumnRefExpression>(child->types[column_idx], bindings[column_idx]));
+					}
+					auto new_projection =
+					    make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(expressions));
+					if (child->has_estimated_cardinality) {
+						new_projection->SetEstimatedCardinality(child->estimated_cardinality);
+					}
+					new_projection->children.push_back(std::move(child));
+					op.children[child_idx] = std::move(new_projection);
 				}
-				auto new_projection = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(expressions));
-				if (child->has_estimated_cardinality) {
-					new_projection->SetEstimatedCardinality(child->estimated_cardinality);
-				}
-				new_projection->children.push_back(std::move(child));
-				op.children[child_idx] = std::move(new_projection);
 
+				// now visit the child
 				remove.VisitOperator(*op.children[child_idx]);
 			}
+			setop.column_count = entries.size();
 			return;
 		}
 		for (auto &child : op.children) {
-			RemoveUnusedColumns remove(binder, context, true, cte_info_map);
+			RemoveUnusedColumns remove(*this, true);
 			remove.VisitOperator(*child);
 		}
 		return;
@@ -247,7 +260,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_INTERSECT: {
 		// for INTERSECT/EXCEPT operations we can't remove anything, just recursively visit the children
 		for (auto &child : op.children) {
-			RemoveUnusedColumns remove(binder, context, true, cte_info_map);
+			RemoveUnusedColumns remove(*this, true);
 			remove.VisitOperator(*child);
 		}
 		return;
@@ -268,7 +281,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			}
 		}
 		// then recurse into the children of this projection
-		RemoveUnusedColumns remove(binder, context, false, cte_info_map);
+		RemoveUnusedColumns remove(*this, false);
 		remove.VisitOperatorExpressions(op);
 		remove.VisitOperator(*op.children[0]);
 		return;
@@ -282,7 +295,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		//! on top of them can select from only the table values being inserted.
 		//! TODO: Push down the projections from the returning statement
 		//! TODO: Be careful because you might be adding expressions when a user returns *
-		RemoveUnusedColumns remove(binder, context, true, cte_info_map);
+		RemoveUnusedColumns remove(*this, true);
 		remove.VisitOperatorExpressions(op);
 		remove.VisitOperator(*op.children[0]);
 		return;
@@ -294,7 +307,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		if (!op.children.empty()) {
 			// Some LOGICAL_GET operators (e.g., table in out functions) may have a
 			// child operator. So we recurse into it if it exists.
-			RemoveUnusedColumns remove(binder, context, true, cte_info_map);
+			RemoveUnusedColumns remove(*this, true);
 			remove.VisitOperator(*op.children[0]);
 		}
 		return;
@@ -317,26 +330,20 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		// to the children. However, we still need to create the cte_info_map for the recursive CTE so that column
 		// references in the CTE body can find the correct CTE entry and mark columns as referenced.
 		auto &rec = op.Cast<LogicalCTE>();
-		if (!cte_info_map) {
-			cte_info_map = make_shared_ptr<unordered_map<idx_t, MaterializedCTEInfo>>();
-		}
-		(*cte_info_map).insert({rec.table_index, MaterializedCTEInfo()});
+		auto &cte_info_map = GetCTEMap();
+		cte_info_map.insert({rec.table_index, MaterializedCTEInfo()});
 		everything_referenced = true;
 		break;
 	}
 	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE: {
-		if (!cte_info_map) {
-			cte_info_map = make_shared_ptr<unordered_map<idx_t, MaterializedCTEInfo>>();
-		}
-
-		auto &cte_map_ref = *cte_info_map;
+		auto &cte_map_ref = GetCTEMap();
 		auto &cte = op.Cast<LogicalCTE>();
 		auto &cte_map_entry = cte_map_ref[cte.table_index];
 
 		// Gather all scans of this CTE in the query and mark them as expected readers of this CTE
 		GatherCTEScans(cte.table_index, *cte.children[1], cte_map_entry.expected_readers);
 		cte_map_entry.everything_referenced = false;
-		auto rhs_child_optimizer = CreateChildOptimizer();
+		RemoveUnusedColumns rhs_child_optimizer(*this, true);
 		rhs_child_optimizer.VisitOperator(*cte.children[1]);
 
 		unordered_set<idx_t> referenced_columns_in_rhs;
@@ -355,22 +362,20 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		}
 
 		if (!cte_map_entry.everything_referenced && have_seen_all_readers) {
-			auto lhs_child_optimizer = CreateChildOptimizer();
+			RemoveUnusedColumns lhs_child_optimizer(*this, true);
 			// Construct a projection on top of the left-hand side of the CTE
 			// that only projects the columns that are referenced in the right-hand side of the CTE
 			cte.children[0]->ResolveOperatorTypes();
 			auto bindings = cte.children[0]->GetColumnBindings();
 			vector<unique_ptr<Expression>> expressions;
+			if (referenced_columns_in_rhs.empty()) {
+				// if we have no columns selected just select the first column
+				referenced_columns_in_rhs.insert(0);
+			}
 			for (idx_t i = 0; i < bindings.size(); i++) {
 				if (referenced_columns_in_rhs.find(i) != referenced_columns_in_rhs.end()) {
 					expressions.push_back(make_uniq<BoundColumnRefExpression>(cte.children[0]->types[i], bindings[i]));
 				}
-			}
-
-			if (expressions.empty()) {
-				// no columns referenced, but we can not have an empty projection, as this would
-				// result in an empty left-hand side of the cte
-				break;
 			}
 
 			auto projection = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(expressions));
@@ -397,6 +402,8 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 	}
 	case LogicalOperatorType::LOGICAL_CTE_REF: {
 		auto &cte_ref = op.Cast<LogicalCTERef>();
+
+		auto cte_info_map = TryGetCTEMap();
 		if (!cte_info_map) {
 			everything_referenced = true;
 			break;
@@ -406,14 +413,15 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		if (it == cte_map_ref.end()) {
 			throw InternalException("Could not find CTE definition for CTE reference");
 		}
+		auto &cte_entry = it->second;
+		auto &referenced_columns = cte_entry.column_references;
 
 		// Mark this CTE reference as a seen reader of the CTE
 		it->second.seen_readers.insert(cte_ref.table_index);
 
 		for (auto &entry : column_references) {
 			if (entry.first.table_index == cte_ref.table_index) {
-				auto &test = cte_map_ref[cte_ref.cte_index].column_references;
-				test.insert(entry);
+				referenced_columns.insert(entry);
 			}
 		}
 
@@ -528,7 +536,6 @@ void RemoveUnusedColumns::WritePushdownExtractColumns(
 		auto &component = struct_extract.components[depth];
 		auto &expr = component.cast ? *component.cast : component.extract;
 
-		optional_ptr<LogicalType> cast_type;
 		auto return_type = expr->return_type;
 
 		auto &colref = col.bindings[struct_extract.bindings_idx];

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -223,7 +223,7 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 	UpdateTopmostBindings(window_idx, op, group_projection_idxs, topmost_bindings, new_bindings, replacer);
 	replacer.stop_operator = op.get();
 
-	RemoveUnusedColumns unused_optimizer(optimizer.binder, optimizer.context, true);
+	RemoveUnusedColumns unused_optimizer(optimizer);
 	unused_optimizer.VisitOperator(*op);
 
 	return unique_ptr<LogicalOperator>(std::move(op));

--- a/test/optimizer/common_subplan.test_slow
+++ b/test/optimizer/common_subplan.test_slow
@@ -66,6 +66,10 @@ statement ok
 create view my_view as
 from probe join build on (build.a = probe.e)
 
+# FIXME: we need to disable the unused columns optimizer otherwise it interferes with the common subplan optimizer
+statement ok
+set disabled_optimizers='unused_columns'
+
 # there's one subquery that selects all columns from the join
 # and 9 other subqueries that select different column combinations
 # this should result in 10 CTE scans (we only perform the join in the view once)

--- a/test/sql/cte/recursive_cte_correlated_complex.test
+++ b/test/sql/cte/recursive_cte_correlated_complex.test
@@ -35,3 +35,69 @@ AND
 GROUP BY s.s_name
 ORDER BY numwait DESC, s_name;
 ----
+
+statement ok
+CREATE TYPE supplier_change AS struct(
+  part BIGINT,  -- part for which supplier changed
+  old  BIGINT,  -- old supplier
+  new  BIGINT   -- new supplier
+);
+
+statement ok
+CREATE TYPE savings AS struct(
+  savings          numeric,     -- saved supply cost (in %)
+  supplier_changes supplier_change[] -- supplier changes required to achieve savings
+);
+
+query II
+SELECT *
+FROM (SELECT 0) AS "input"(orderkey),
+(WITH RECURSIVE "@loop" ("$label", "$output", "0", "1", "2", "3", "4") AS (
+  (SELECT CAST('$' AS VARCHAR) AS "$label",
+          CAST(NULL AS savings) AS "$output",
+          CAST(NULL AS DECIMAL(15,2)) AS "0",
+          CAST(NULL AS DECIMAL(15,2)) AS "1",
+          CAST(NULL AS supplier_change[]) AS "2",
+          CAST("input".orderkey AS BIGINT) AS "3",
+          CAST(NULL AS BIGINT) AS "4")
+  UNION  ALL
+  (WITH
+    "0" (orderkey) AS (SELECT "@loop"."3" AS orderkey FROM "@loop" WHERE ("@loop"."$label" IS NOT DISTINCT FROM '$')),
+    "1" (orderkey, found) AS (SELECT "0".orderkey AS orderkey, (SELECT CAST(NULL AS BOOLEAN)) AS found FROM "0" AS "0"(orderkey)),
+    "2" (orderkey, "order") AS (SELECT "1".orderkey AS orderkey, (SELECT NULL) AS "order" FROM "1" AS "1"(orderkey, found)),
+    "3" (orderkey, items) AS (SELECT "2".orderkey AS orderkey, (SELECT CAST(NULL AS BIGINT)) AS items FROM "2" AS "2"(orderkey, "order")),
+    "4" (orderkey, lineitem) AS (SELECT "3".orderkey AS orderkey, (SELECT NULL) AS lineitem FROM "3" AS "3"(orderkey, items)),
+    "5" (orderkey, partsupp) AS (SELECT "4".orderkey AS orderkey, (SELECT NULL) AS partsupp FROM "4" AS "4"(orderkey, lineitem)),
+    "6" (orderkey, min_supplycost) AS (SELECT "5".orderkey AS orderkey, (SELECT CAST(NULL AS DECIMAL(15, 2))) AS min_supplycost FROM "5" AS "5"(orderkey, partsupp)),
+    "7" (orderkey, new_supplier) AS (SELECT "6".orderkey AS orderkey, (SELECT CAST(NULL AS BIGINT)) AS new_supplier FROM "6" AS "6"(orderkey, min_supplycost)),
+    "8" (orderkey, new_suppliers) AS (SELECT "7".orderkey AS orderkey, (SELECT CAST(NULL AS STRUCT(part BIGINT, "old" BIGINT, "new" BIGINT)[])) AS new_suppliers FROM "7" AS "7"(orderkey, new_supplier)),
+    "9" (orderkey, total_supplycost) AS (SELECT "8".orderkey AS orderkey, (SELECT CAST(NULL AS DECIMAL(15, 2))) AS total_supplycost FROM "8" AS "8"(orderkey, new_suppliers)),
+    "10" (orderkey, new_supplycost) AS (SELECT "9".orderkey AS orderkey, (SELECT CAST(NULL AS DECIMAL(15, 2))) AS new_supplycost FROM "9" AS "9"(orderkey, total_supplycost)),
+    "11" (orderkey, item) AS (SELECT "10".orderkey AS orderkey, (SELECT NULL) AS item FROM "10" AS "10"(orderkey, new_supplycost)),
+    "12" (orderkey, "order") AS (SELECT "11".orderkey AS orderkey, (SELECT * FROM (SELECT o FROM orders AS o WHERE (o.o_orderkey = "11".orderkey)) AS subquery LIMIT 1) AS "order" FROM "11" AS "11"(orderkey, item)),
+    "13" (orderkey, "$cond0") AS (SELECT "12".orderkey AS orderkey, (SELECT ("12"."order" IS NULL)) AS "$cond0" FROM "12" AS "12"(orderkey, "order")),
+    "14" AS (SELECT NULL AS "$output" FROM "13" AS "13"(orderkey, "$cond0") WHERE "13"."$cond0"),
+    "15" (orderkey) AS (SELECT "13".orderkey AS orderkey FROM "13" AS "13"(orderkey, "$cond0") WHERE ("13"."$cond0" IS DISTINCT FROM true)),
+    "16" (return_value) AS (SELECT (SELECT NULL) AS return_value FROM "14" AS "14"),
+    "17" ("$output") AS (SELECT "16".return_value AS "$output" FROM "16" AS "16"(return_value)),
+    "18" (items) AS (SELECT (SELECT CAST((SELECT * FROM (SELECT count_star() FROM lineitem AS l WHERE (l.l_orderkey = "15".orderkey)) AS subquery LIMIT 1) AS BIGINT)) AS items FROM "15" AS "15"(orderkey)),
+    "19" (items, total_supplycost) AS (SELECT "18".items AS items, (SELECT CAST((SELECT 0.0) AS DECIMAL(15, 2))) AS total_supplycost FROM "18" AS "18"(items)),
+    "20" (items, total_supplycost, new_supplycost) AS (SELECT "19".items AS items, "19".total_supplycost AS total_supplycost, (SELECT CAST((SELECT 0.0) AS DECIMAL(15, 2))) AS new_supplycost FROM "19" AS "19"(items, total_supplycost)),
+    "21" (total_supplycost, new_supplycost, items, new_suppliers) AS (SELECT "20".total_supplycost AS total_supplycost, "20".new_supplycost AS new_supplycost, "20".items AS items, (SELECT CAST((SELECT CAST((ARRAY[]) AS "supplier_change"[])) AS STRUCT(part BIGINT, "old" BIGINT, "new" BIGINT)[])) AS new_suppliers FROM "20" AS "20"(items, total_supplycost, new_supplycost)),
+    "22" (items, new_supplycost, total_supplycost, new_suppliers, item) AS (SELECT "21".items AS items, "21".new_supplycost AS new_supplycost, "21".total_supplycost AS total_supplycost, "21".new_suppliers AS new_suppliers, (SELECT 1) AS item FROM "21" AS "21"(total_supplycost, new_supplycost, items, new_suppliers)),
+    "23" (new_suppliers, item, total_supplycost, new_supplycost, fori_end) AS (SELECT "22".new_suppliers AS new_suppliers, "22".item AS item, "22".total_supplycost AS total_supplycost, "22".new_supplycost AS new_supplycost, (SELECT "22".items) AS fori_end FROM "22" AS "22"(items, new_supplycost, total_supplycost, new_suppliers, item)),
+    "24" (total_supplycost, new_supplycost, fori_end, new_suppliers, item) AS (SELECT "@loop"."0" AS total_supplycost, "@loop"."1" AS new_supplycost, "@loop"."4" AS fori_end, "@loop"."2" AS new_suppliers, "@loop"."3" AS item FROM "@loop" WHERE ("@loop"."$label" IS NOT DISTINCT FROM '$loop1')),
+    "25" (item, new_suppliers, fori_end, new_supplycost, total_supplycost) AS ((SELECT "23".item AS item, "23".new_suppliers AS new_suppliers, "23".fori_end AS fori_end, "23".new_supplycost AS new_supplycost, "23".total_supplycost AS total_supplycost FROM "23" AS "23"(new_suppliers, item, total_supplycost, new_supplycost, fori_end)) UNION ALL (SELECT "24".item AS item, "24".new_suppliers AS new_suppliers, "24".fori_end AS fori_end, "24".new_supplycost AS new_supplycost, "24".total_supplycost AS total_supplycost FROM "24" AS "24"(total_supplycost, new_supplycost, fori_end, new_suppliers, item))),
+    "26" (new_suppliers, total_supplycost, new_supplycost, "$cond2") AS (SELECT "25".new_suppliers AS new_suppliers, "25".total_supplycost AS total_supplycost, "25".new_supplycost AS new_supplycost, (SELECT ("25".item > "25".fori_end)) AS "$cond2" FROM "25" AS "25"(item, new_suppliers, fori_end, new_supplycost, total_supplycost)),
+    "27" (new_supplycost, total_supplycost, new_suppliers) AS (SELECT "26".new_supplycost AS new_supplycost, "26".total_supplycost AS total_supplycost, "26".new_suppliers AS new_suppliers FROM "26" AS "26"(new_suppliers, total_supplycost, new_supplycost, "$cond2") WHERE "26"."$cond2"),
+    "28" (new_supplycost, total_supplycost, new_suppliers) AS (SELECT "26".new_supplycost AS new_supplycost, "26".total_supplycost AS total_supplycost, "26".new_suppliers AS new_suppliers FROM "26" AS "26"(new_suppliers, total_supplycost, new_supplycost, "$cond2") WHERE ("26"."$cond2" IS DISTINCT FROM true)),
+    "29" (new_suppliers, total_supplycost, new_supplycost) AS ((SELECT "27".new_suppliers AS new_suppliers, "27".total_supplycost AS total_supplycost, "27".new_supplycost AS new_supplycost FROM "27" AS "27"(new_supplycost, total_supplycost, new_suppliers)) UNION ALL (SELECT "28".new_suppliers AS new_suppliers, "28".total_supplycost AS total_supplycost, "28".new_supplycost AS new_supplycost FROM "28" AS "28"(new_supplycost, total_supplycost, new_suppliers))),
+    "30" (return_value) AS (SELECT (SELECT CAST(main."row"(((1.0 - ("29".new_supplycost / "29".total_supplycost)) * 100.0), "29".new_suppliers) AS "savings")) AS return_value FROM "29" AS "29"(new_suppliers, total_supplycost, new_supplycost)),
+    "31" ("$output") AS (SELECT "30".return_value AS "$output" FROM "30" AS "30"(return_value))
+    (SELECT CAST(NULL AS VARCHAR) AS "$label", CAST("17"."$output" AS STRUCT(savings DECIMAL(18,3), supplier_changes STRUCT(part BIGINT, "old" BIGINT, "new" BIGINT)[])) AS "$output", CAST(NULL AS DECIMAL(15,2)) AS "0", CAST(NULL AS DECIMAL(15,2)) AS "1", CAST(NULL AS STRUCT(part BIGINT, "old" BIGINT, "new" BIGINT)[]) AS "2", CAST(NULL AS BIGINT) AS "3", CAST(NULL AS BIGINT) AS "4" FROM "17" AS "17"("$output"))
+      UNION ALL
+    (SELECT CAST(NULL AS VARCHAR) AS "$label", CAST("31"."$output" AS STRUCT(savings DECIMAL(18,3), supplier_changes STRUCT(part BIGINT, "old" BIGINT, "new" BIGINT)[])) AS "$output", CAST(NULL AS DECIMAL(15,2)) AS "0", CAST(NULL AS DECIMAL(15,2)) AS "1", CAST(NULL AS STRUCT(part BIGINT, "old" BIGINT, "new" BIGINT)[]) AS "2", CAST(NULL AS BIGINT) AS "3", CAST(NULL AS BIGINT) AS "4" FROM "31" AS "31"("$output"))))
+  SELECT "@loop"."$output" FROM "@loop" AS "@loop"("$label", "$output", "0", "1", "2", "3", "4") WHERE ("@loop"."$label" IS NULL)
+  ) AS output;
+----
+0	NULL


### PR DESCRIPTION
While column pruning works in many cases for CTEs now, pruning could fail if the query plan was not traversed completely. In that case, we may not have seen all CTE references, and thus not all column accesses, leading to column pruning, where it was not okay to prune. This PR fixes both, traversal of the query plan in case of `UNION ALL`, and it introduces explicit means to check whether we have seen all CTE references, so that we can bail out otherwise.

Note to self: We need more complex test cases for CTEs, materialized CTEs, recursive CTEs, and everything in combination with correlation.