### PR TITLE
add structured Path objects, update joinpath: normalize, support url/…

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library_unity(
   file_buffer.cpp
   file_system.cpp
   filename_pattern.cpp
+  path.cpp
   fsst.cpp
   gzip_file_system.cpp
   hive_partitioning.cpp

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -189,11 +189,14 @@ string FileSystem::GetEnvVariable(const string &env) {
 }
 
 static bool StartsWithSingleBackslash(const string &path) {
-	if (path.size() < 2) {
+	if (path.empty()) {
 		return false;
 	}
 	if (path[0] != '/' && path[0] != '\\') {
 		return false;
+	}
+	if (path.size() == 1) {
+		return true;
 	}
 	if (path[1] == '/' || path[1] == '\\') {
 		return false;
@@ -503,35 +506,25 @@ void FileSystem::CreateDirectoriesRecursive(const string &path, optional_ptr<Fil
 	// we construct the list of directories to be created depth-first. This avoids calling DirectoryExists on a parent
 	// dir that is not in the allowed_directories list
 
-	auto sep = PathSeparator(path);
+	// Walk up from the full path until we find a prefix that already exists, collecting
+	// non-existing ancestors along the way. Stop descending when segments are exhausted
+	// (to avoid Path::Parent() generating ".." paths past the root/base).
+	auto parsed = Path::FromString(path);
 	vector<string> dirs_to_create;
-
-	string current_prefix = path;
-
-	StringUtil::RTrim(current_prefix, sep);
-
-	// Strip directories from the path until we hit a directory that exists
-	while (!current_prefix.empty() && !DirectoryExists(current_prefix)) {
-		auto found = current_prefix.find_last_of(sep);
-
-		// Push back the root dir
-		if (found == string::npos || found == 0) {
-			dirs_to_create.push_back(current_prefix);
-			current_prefix = "";
-			break;
-		}
-
-		// Add the directory to the directories to be created
-		dirs_to_create.push_back(current_prefix.substr(found, current_prefix.size() - found));
-
-		// Update the current prefix to remove the current dir
-		current_prefix = current_prefix.substr(0, found);
+	while (!parsed.GetPathSegments().empty() && !DirectoryExists(parsed.ToString())) {
+		dirs_to_create.push_back(parsed.ToString());
+		parsed = parsed.Parent();
+	}
+	// If all segments were non-existing, also check the base itself (e.g. "C:/" on an unknown drive)
+	if (!parsed.GetPathSegments().empty()) {
+		// broke because DirectoryExists returned true — nothing more needed
+	} else if (!DirectoryExists(parsed.ToString())) {
+		dirs_to_create.push_back(parsed.ToString());
 	}
 
-	// Create the directories one by one
-	for (vector<string>::reverse_iterator riter = dirs_to_create.rbegin(); riter != dirs_to_create.rend(); ++riter) {
-		current_prefix += *riter;
-		CreateDirectory(current_prefix);
+	// Create directories shallowest to deepest
+	for (auto riter = dirs_to_create.rbegin(); riter != dirs_to_create.rend(); ++riter) {
+		CreateDirectory(*riter);
 	}
 }
 

--- a/src/common/path.cpp
+++ b/src/common/path.cpp
@@ -1,0 +1,358 @@
+#include "duckdb/common/path.hpp"
+
+#include "duckdb/common/algorithm.hpp" // avoid MSVC warning on find_if_not
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+// cleanly handle both separator types
+static inline bool IsPathSeparator(char c) {
+	return c == '/' || c == '\\';
+}
+
+// Appends "normal" segments, ignores ".", and consumes trailing segment via "..", popping "<segment>/.."
+static void MaybeAppendSegment(vector<string> &segments, string::const_iterator begin, string::const_iterator end) {
+	if (end == begin || (end == begin + 1 && *begin == '.')) {
+		return;
+	}
+	const string segment(begin, end);
+	if (segment == ".." && !segments.empty() && segments.back() != "..") {
+		segments.pop_back();
+	} else {
+		segments.push_back(segment);
+	}
+}
+
+static void SegmentAndNormalizePath(string::const_iterator begin, string::const_iterator end,
+                                    vector<string> &segments) {
+	auto prev_pos = begin;
+	for (auto pos = prev_pos; pos != end; pos++) {
+		if (IsPathSeparator(*pos)) {
+			MaybeAppendSegment(segments, prev_pos, pos);
+			prev_pos = pos + 1;
+		}
+	}
+	MaybeAppendSegment(segments, prev_pos, end);
+}
+
+// ---------------------------------------------------------------------------
+// Public methods (order matches path.hpp)
+// ---------------------------------------------------------------------------
+
+Path Path::FromString(const string &raw) {
+	Path parsed;
+#if defined(_WIN32)
+	const auto first_slash_pos = raw.find_first_of(R"(/\)");
+#else
+	const auto first_slash_pos = raw.find('/');
+#endif
+	const auto scheme_pos = raw.find("://");
+	const auto drive_leads = (false
+#if defined(_WIN32)
+	                          || (first_slash_pos == 1 && StringUtil::CharacterIsAlpha(raw[0]))
+#endif
+	);
+	parsed.separator = first_slash_pos == string::npos ? '/' : raw[first_slash_pos];
+
+	size_t path_offset;
+	if (StringUtil::StartsWith(raw, "file:/")) {
+		path_offset = ParseFileSchemes(raw, parsed);
+	}
+#if defined(_WIN32)
+	else if (raw.size() >= 5 && StringUtil::StartsWith(raw, R"(\\)") && raw.find_first_of('\\', 3) != string::npos) {
+		path_offset = ParseUNCScheme(raw, parsed);
+	}
+#endif
+	else if (scheme_pos != string::npos && scheme_pos > 1 && scheme_pos < first_slash_pos && !drive_leads) {
+		path_offset = ParseURIScheme(raw, parsed);
+	} else {
+		path_offset = ParseFilePathTail(raw, 0, parsed);
+	}
+	parsed.NormalizeSegments(raw, path_offset);
+	if (!raw.empty() && IsPathSeparator(raw.back())) {
+		parsed.has_trailing_separator = true;
+	}
+	D_ASSERT(parsed.HasScheme() || !parsed.HasAuthority());
+	D_ASSERT(parsed.anchor.size() <= 4);
+	return parsed;
+}
+
+string Path::ToString() const {
+	string result = scheme + authority + anchor;
+	for (size_t i = 0; i < segments.size(); i++) {
+		if (i) {
+			result += separator;
+		}
+		result += segments[i];
+	}
+	if (has_trailing_separator && !segments.empty()) {
+		result += separator;
+	}
+	if (result.empty()) {
+		result = '.';
+	}
+	return result;
+}
+
+string Path::GetBase() const {
+	return scheme + authority + anchor;
+}
+
+string Path::GetPath() const {
+	if (segments.empty()) {
+		return (scheme.empty() && anchor.empty()) ? "." : "";
+	}
+	string result;
+	for (size_t i = 0; i < segments.size(); i++) {
+		if (i) {
+			result += separator;
+		}
+		result += segments[i];
+	}
+	return result;
+}
+
+bool Path::HasDrive() const {
+	return GetDriveChar() != 0;
+}
+
+char Path::GetDriveChar() const {
+	const auto size = anchor.size();
+	D_ASSERT(size <= 4);
+	// must be one of {"C:", "C:\" or "\C:", "\C:\"}; switch on size & ':'
+	if (size <= 1) {
+		D_ASSERT(size == 0 || IsPathSeparator(anchor[0]));
+		return 0;
+	} else if (size == 2) {
+		return anchor[0];
+	} else if (size == 3) {
+		return anchor[anchor[1] == ':' ? 0 : 1];
+	} else /* (size == 4) */ {
+		return anchor[1];
+	}
+}
+
+Path Path::Join(const Path &rhs) const {
+	Path lhs = *this;
+#if defined(_WIN32)
+	const bool win_local = (lhs.separator == '\\') || lhs.HasDrive();
+	const auto auth_is_eq =
+	    win_local ? StringUtil::CIEquals(lhs.authority, rhs.authority) : (lhs.authority == rhs.authority);
+	const auto seg_prefix =
+	    win_local ? (rhs.segments.size() >= lhs.segments.size() &&
+	                 std::equal(lhs.segments.begin(), lhs.segments.end(), rhs.segments.begin(),
+	                            [](const string &a, const string &b) { return StringUtil::CIEquals(a, b); }))
+	              : (rhs.segments.size() >= lhs.segments.size() &&
+	                 std::equal(lhs.segments.begin(), lhs.segments.end(), rhs.segments.begin()));
+#else
+	const auto auth_is_eq = (lhs.authority == rhs.authority);
+	const auto seg_prefix = (rhs.segments.size() >= lhs.segments.size() &&
+	                         std::equal(lhs.segments.begin(), lhs.segments.end(), rhs.segments.begin()));
+#endif
+	if (!rhs.IsAbsolute() && !rhs.HasDrive()) {
+		lhs.segments.insert(lhs.segments.end(), rhs.segments.begin(), rhs.segments.end());
+		vector<string> result;
+		result.reserve(lhs.segments.size());
+		for (auto &seg : lhs.segments) {
+			if (seg == ".." && !result.empty() && result.back() != "..") {
+				result.pop_back();
+			} else {
+				result.push_back(std::move(seg));
+			}
+		}
+		while (lhs.IsAbsolute() && !result.empty() && result.front() == "..") {
+			result.erase(result.begin());
+		}
+		lhs.segments = std::move(result);
+	} else if (auth_is_eq && seg_prefix && lhs.scheme == rhs.scheme && lhs.anchor == rhs.anchor) {
+		if (lhs.segments.size() < rhs.segments.size()) {
+			lhs.segments = rhs.segments;
+		}
+	} else {
+		throw InvalidInputException("Path: cannot join incompatible paths: \"%s\" onto \"%s\"", rhs.ToString(),
+		                            lhs.ToString());
+	}
+	lhs.has_trailing_separator = rhs.has_trailing_separator;
+	return lhs;
+}
+
+Path Path::Join(const string &rhs) const {
+	return Join(Path::FromString(rhs));
+}
+
+// NOTE: instead of chopping off segments, apply '..'; this guards against traps with odd paths (leading ..,
+// etc.) to make sure we always handle Parentage consistently, at a slight cost of cpu/tmp allocation.
+Path Path::Parent(int n) const {
+	if (n <= 0) {
+		return *this;
+	}
+	string dots = "..";
+	for (int i = 1; i < n; i++) {
+		dots += "/..";
+	}
+	return Join(dots);
+}
+
+// ---------------------------------------------------------------------------
+// Private methods (order matches path.hpp)
+// ---------------------------------------------------------------------------
+
+void Path::NormalizeSegments(const string &raw, size_t path_offset) {
+	// normalize URI schemes to lowercase; UNC prefixes (\\, \\?, \\?\UNC\) are not URI schemes
+	if (!scheme.empty() && !IsPathSeparator(scheme[0])) {
+		scheme = StringUtil::Lower(scheme);
+	}
+
+	if (HasAnchor()) {
+		string normal;
+		if (IsPathSeparator(anchor[0])) {
+			normal.append(1, separator);
+		}
+		auto drive_char = std::find_if_not(anchor.begin(), anchor.end(), IsPathSeparator);
+		if (drive_char != anchor.end()) {
+			normal.append(1, StringUtil::CharacterToUpper(*drive_char));
+			normal.append(1, ':');
+			if (IsPathSeparator(anchor.back())) {
+				normal.append(1, separator);
+			}
+		}
+		anchor = normal;
+	}
+
+	vector<string> raw_segs;
+	SegmentAndNormalizePath(raw.begin() + static_cast<string::difference_type>(path_offset), raw.end(), raw_segs);
+	segments.clear();
+	for (auto &seg : raw_segs) {
+		if (IsAbsolute() && segments.empty() && seg == "..") {
+			continue; // drop leading ".." on absolute paths (can't go above root)
+		}
+		segments.push_back(std::move(seg));
+	}
+}
+
+//
+// Parse path (only) proto://authority/path/to/file.txt
+// - All URI paths are absolute, and URIs of the form proto://authority will be assigned path="/"
+// - Not full URI parsing, only for URI paths (e.g., no query, fragment, etc.)
+//
+size_t Path::ParseURIScheme(const string &input, Path &parsed) {
+	parsed.is_absolute = true;
+
+	const size_t auth_begin = input.find("://") + 3;
+	D_ASSERT(auth_begin >= 4); // non-empty protocol
+	parsed.scheme = input.substr(0, auth_begin);
+
+	const size_t path_begin = input.find('/', auth_begin);
+	D_ASSERT(path_begin == string::npos || path_begin > auth_begin);
+	parsed.authority = input.substr(auth_begin, path_begin == string::npos ? string::npos : path_begin - auth_begin);
+	parsed.anchor = '/';
+	return path_begin == string::npos ? input.size() : path_begin + 1;
+}
+
+size_t Path::ParseFilePathTail(const string &input, size_t start, Path &parsed) {
+	size_t pos = start;
+
+#if defined(_WIN32)
+	if (input.size() >= pos + 2 && input[pos + 1] == ':' && StringUtil::CharacterIsAlpha(input[pos])) {
+		parsed.anchor.append(1, input[pos]);
+		parsed.anchor.append(1, ':');
+		pos += 2;
+	}
+#endif
+
+	if (input.size() > pos && IsPathSeparator(input[pos])) {
+		parsed.anchor.append(1, parsed.separator);
+		parsed.is_absolute = true;
+		pos += 1;
+	}
+	return pos;
+}
+
+//
+// Parse and normalize file:/{1,3} schemes. See
+// https://en.wikipedia.org/wiki/File_URI_scheme and our docs below.
+//
+// DuckDB supports using the file: protocol. It currently supports the following formats:
+//
+//  file:/some/path (host omitted completely)
+//  file:///some/path (empty host)
+//  file://localhost/some/path (localhost as host)
+//
+// Note that the following formats are not supported because they are non-standard:
+//
+//   file:some/relative/path (relative path)
+//   file://some/path (double-slash path)
+//
+// Additionally, the file: protocol does not support remote (non-localhost) hosts.
+//
+size_t Path::ParseFileSchemes(const string &input, Path &parsed) {
+	parsed.is_absolute = true;
+
+	size_t input_len = input.size();
+	size_t path_begin = string::npos;
+	D_ASSERT(input_len >= 6 && StringUtil::StartsWith(input, "file:/"));
+
+	if (/* file:/// */ input_len >= 8 && input[6] == '/' && input[7] == '/') {
+		parsed.scheme = "file://";
+		parsed.anchor = "/";
+		path_begin = 8;
+	} else if (/* file:// */ input_len >= 7 && input[6] == '/') {
+		ParseURIScheme(input, parsed);
+		if (StringUtil::Lower(parsed.authority) != "localhost") {
+			throw InvalidInputException("Path: file:// scheme only supports localhost authority, got: %s",
+			                            parsed.authority);
+		}
+		path_begin = parsed.scheme.size() + parsed.authority.size() + parsed.anchor.size();
+	} else /* file:/ */ {
+		parsed.scheme = "file:";
+		parsed.anchor = "/";
+		path_begin = 6;
+	}
+
+	D_ASSERT(parsed.scheme == "file:" || parsed.scheme == "file://");
+	D_ASSERT(parsed.scheme == "file://" || !parsed.HasAuthority());
+	return ParseFilePathTail(input, path_begin, parsed);
+}
+
+#if defined(_WIN32)
+//
+// UNC Scheme as we handle it:
+// - scheme = "\\"
+// - authority = server\share
+// - anchor = "\"
+// - path = < the rest >
+//
+size_t Path::ParseUNCScheme(const string &input, Path &parsed) {
+	D_ASSERT(input.size() >= 4 && input[0] == '\\' && input[1] == '\\');
+
+	static const char extended_prefix[] = R"(\\?\)";
+	static const char extended_unc_prefix[] = R"(\\?\UNC\)";
+	const bool extended = StringUtil::StartsWith(input, extended_prefix);
+	const bool extended_unc = extended && StringUtil::StartsWith(input, extended_unc_prefix);
+
+	parsed.separator = '\\';
+
+	if (extended && !extended_unc) {
+		parsed.anchor = '\\';
+		parsed.scheme = R"(\\?)";
+		return ParseFilePathTail(input, 4, parsed);
+	}
+
+	const auto server_begin = extended_unc ? sizeof(extended_unc_prefix) - 1 : 2;
+	const auto share_begin = input.find_first_of('\\', server_begin) + 1;
+	auto pos = input.find_first_of("/\\", share_begin);
+	const auto share_len = (pos == string::npos ? input.size() : pos) - share_begin;
+	if (share_begin - server_begin <= 1 || share_len == 0) {
+		throw InvalidInputException("Path: UNC path missing server\\share: %s", input);
+	}
+
+	parsed.scheme = extended_unc ? extended_unc_prefix : R"(\\)";
+	parsed.authority = input.substr(server_begin, share_begin + share_len - server_begin);
+	parsed.anchor = '\\';
+	parsed.is_absolute = true;
+	return (pos == string::npos || pos + 1 >= input.size()) ? input.size() : pos + 1;
+}
+#endif
+
+} // namespace duckdb

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -434,6 +434,13 @@ bool StringUtil::CIEquals(const string &l1, const string &l2) {
 	return CIEquals(l1.c_str(), l1.size(), l2.c_str(), l2.size());
 }
 
+bool StringUtil::CIStartsWith(const string &str, const string &prefix) {
+	if (prefix.size() > str.size()) {
+		return false;
+	}
+	return CIEquals(str.c_str(), prefix.size(), prefix.c_str(), prefix.size());
+}
+
 bool StringUtil::CILessThan(const string &s1, const string &s2) {
 	const auto charmap = ASCII_TO_UPPER_MAP;
 

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -20,6 +20,7 @@
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/common/path.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
 

--- a/src/include/duckdb/common/path.hpp
+++ b/src/include/duckdb/common/path.hpp
@@ -1,0 +1,158 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/path.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+//
+// Parsed representation of a path string, covering posix, windows, URI, and UNC forms.
+//
+// FromString(raw) parses and normalizes the input; ToString() reconstructs it as
+// scheme + authority + anchor + join(segments, sep) + tail
+//
+// Supported input forms and their parsed fields:
+//
+//   Input                         scheme        authority      anchor   segments      IsAbsolute
+//   ----------------------------  ------------  -----------    -------  ------------  -----------
+//   "a/b"                         ""            ""             ""       "a/b"         false
+//   ""  (empty)                   ""            ""             ""       "."           false
+//   "/"                           ""            ""             "/"      ""            true
+//   "/a/b"                        ""            ""             "/"      "a/b"         true
+//   "/a/b/"                       ""            ""             "/"      "a/b"         true   (HasTrailingSeparator)
+//   "file:/a/b"                   "file:"       ""             "/"      "a/b"         true
+//   "file:///a/b"                 "file://"     ""             "/"      "a/b"         true
+//   "file://localhost/a/b"        "file://"     "localhost"    "/"      "a/b"         true
+//   "s3://bucket/bar/baz"         "s3://"       "bucket"       "/"      "bar/baz"     true
+//   "C:\foo" (win)                ""            ""             "C:\"    "foo"         true
+//   "C:relpath" (win)             ""            ""             "C:"     "relpath"     false
+//   "\\server\share\p" (win)      "\\"          "server\share" "\"      "p"           true
+//   "\\?\UNC\server\share" (win)  "\\?\UNC\"    "server\share" "\"      ""            true
+//   "\\?\C:\foo" (win)            "\\?"         ""             "C:\"    "foo"         true
+//
+// HasTrailingSeparator is true when raw input ends with a separator. ToString() re-emits the
+// separator after the last segment (skipped when segments is empty — anchor already ends with it).
+// When Join()ing, LHS inherits trailing_separator from RHS. This is useful (and semantically
+// meaningful) in distinguishing e.g. '/foo/*/'=dirs from '/foo/*'=all.
+//
+// Windows local paths may use '/' or '\\' -- whichever is found first will be applied to
+// remainder of the normalized path; defaults to '/'.
+//
+class Path {
+public:
+	// Primary Constructor
+	static Path FromString(const string &raw);
+
+	string ToString() const;
+
+	// 3 constituent parts of to string -- base + path + trailing separator (IFF path not empty)
+	string GetBase() const;               // scheme + authority + anchor
+	string GetPath() const;               // relative path segments: join(segments, sep), or "." for empty relative
+	string GetTrailingSeparator() const { // returns "" or string(1, separator)
+		return !segments.empty() && has_trailing_separator ? string(1, separator) : "";
+	}
+	const string &GetScheme() const {
+		return scheme;
+	}
+	const string &GetAuthority() const {
+		return authority;
+	}
+	const string &GetAnchor() const {
+		return anchor;
+	}
+	char GetSeparator() const {
+		return separator;
+	}
+
+	bool HasScheme() const {
+		return !scheme.empty();
+	}
+	bool HasAuthority() const {
+		return !authority.empty();
+	}
+	bool HasAnchor() const {
+		return !anchor.empty();
+	}
+
+	bool HasDrive() const;     // always false in non-windows
+	char GetDriveChar() const; // returns \0 if no drive
+
+	bool HasPathSegments() const {
+		return !segments.empty();
+	}
+
+	bool HasTrailingSeparator() const {
+		return has_trailing_separator;
+	}
+
+	bool IsAbsolute() const {
+		return is_absolute;
+	}
+
+	// true for all relative paths, /*,  c:/* (not c:foo), file:/*, \\?\C:\*
+	bool IsLocal() const {
+		// note: HasDrive() covers UNC locals too!
+		return (!IsAbsolute() || !HasScheme() || HasDrive() || StringUtil::StartsWith(scheme, "file:"));
+	}
+
+	bool IsRemote() const {
+		return !IsLocal();
+	}
+
+	const vector<string> &GetPathSegments() const {
+		return segments;
+	}
+
+	// Join (in several forms)
+	Path Join(const Path &rhs) const;
+	Path Join(const string &rhs) const;
+
+	template <typename... Args>
+	Path Join(const string &first, const Args &...rest) const {
+		return Join(first).Join(rest...);
+	}
+
+	Path Join(const vector<string> &paths) const {
+		Path result = *this;
+		for (const auto &rhs : paths) {
+			result = result.Join(rhs);
+		}
+		return result;
+	}
+
+	Path Parent(int n = 1) const;
+
+	// public convenience - string-to-string normalize
+	static string Normalize(const string &input) {
+		return FromString(input).ToString();
+	}
+
+private:
+	string scheme;
+	string authority;
+	string anchor;
+	vector<string> segments;
+
+	char separator = '/';
+	bool has_trailing_separator = false;
+	bool is_absolute = false;
+
+	void NormalizeSegments(const string &raw, size_t path_offset);
+
+	static size_t ParseURIScheme(const string &input, Path &parsed);
+	static size_t ParseFilePathTail(const string &input, size_t start, Path &parsed);
+	static size_t ParseFileSchemes(const string &input, Path &parsed);
+#if defined(_WIN32)
+	static size_t ParseUNCScheme(const string &input, Path &parsed);
+#endif
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -233,6 +233,9 @@ public:
 	//! Case insensitive equals (null-terminated strings)
 	DUCKDB_API static bool CIEquals(const char *l1, idx_t l1_size, const char *l2, idx_t l2_size);
 
+	//! Case insensitive starts-with
+	DUCKDB_API static bool CIStartsWith(const string &str, const string &prefix);
+
 	//! Case insensitive compare
 	DUCKDB_API static bool CILessThan(const string &l1, const string &l2);
 

--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -327,7 +327,7 @@ unique_ptr<BufferedFileWriter> FileLogStorage::InitializeFileWriter(DatabaseInst
 	auto &fs = db.GetFileSystem();
 
 	// Create parent directories if non existent
-	auto pos = path.find_last_of(fs.PathSeparator(path));
+	auto pos = path.find_last_of("/\\");
 	if (pos != path.npos) {
 		fs.CreateDirectoriesRecursive(path.substr(0, pos));
 	}

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/fstream.hpp"
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
 #include "duckdb/main/database_manager.hpp"
@@ -475,4 +476,502 @@ TEST_CASE("filesystem concurrent access and deletion", "[file_system]") {
 	// Close the remaining handle; the file should not exist.
 	read_handle.reset();
 	REQUIRE(!fs->FileExists(fname));
+}
+
+// ------------------------------------------------------------------------------------------------
+// Path struct tests
+// ------------------------------------------------------------------------------------------------
+
+TEST_CASE("Path parses and correctly structures fields", "[file_system]") {
+	Path output;
+
+	SECTION("local files") {
+		output = Path::FromString("a/b");
+		CHECK(output.GetScheme() == "");
+		CHECK(output.GetAuthority() == "");
+		CHECK(output.GetAnchor() == "");
+		CHECK(output.IsAbsolute() == false);
+		CHECK(output.GetPath() == "a/b");
+
+		output = Path::FromString("/..////a/./b/../c");
+		CHECK(output.GetScheme() == "");
+		CHECK(output.GetAuthority() == "");
+		CHECK(output.GetAnchor() == "/");
+		CHECK(output.GetPath() == "a/c");
+		CHECK(output.IsAbsolute() == true);
+	}
+
+	SECTION("file schemes") {
+		output = Path::FromString("file:/a/b");
+		CHECK(output.GetScheme() == "file:");
+		CHECK(output.GetAuthority() == "");
+		CHECK(output.GetAnchor() == "/");
+		CHECK(output.IsAbsolute() == true);
+		CHECK(output.GetPath() == "a/b");
+
+		output = Path::FromString("file://localhost/a/b");
+		CHECK(output.GetScheme() == "file://");
+		CHECK(output.GetAuthority() == "localhost");
+		CHECK(output.GetAnchor() == "/");
+		CHECK(output.IsAbsolute() == true);
+		CHECK(output.GetPath() == "a/b");
+
+		output = Path::FromString("file:///a/b");
+		CHECK(output.GetScheme() == "file://");
+		CHECK(output.GetAuthority() == "");
+		CHECK(output.GetAnchor() == "/");
+		CHECK(output.IsAbsolute() == true);
+		CHECK(output.GetPath() == "a/b");
+
+		output = Path::FromString("file://LOCALHOST/a/b");
+		CHECK(output.GetScheme() == "file://");
+		CHECK(output.GetAuthority() == "LOCALHOST");
+		CHECK(output.GetAnchor() == "/");
+		CHECK(output.GetPath() == "a/b");
+
+#if defined(_WIN32)
+		output = Path::FromString(R"(c:..\foo)");
+		CHECK(output.GetScheme() == "");
+		CHECK(output.GetAuthority() == "");
+		CHECK(output.GetAnchor() == "C:");
+		CHECK(output.IsAbsolute() == false);
+		CHECK(output.GetPath() == R"(..\foo)");
+
+		output = Path::FromString(R"(c:\..\foo)");
+		CHECK(output.GetScheme() == "");
+		CHECK(output.GetAuthority() == "");
+		CHECK(output.GetAnchor() == R"(C:\)");
+		CHECK(output.IsAbsolute() == true);
+		CHECK(output.GetPath() == "foo");
+#endif
+	}
+
+	SECTION("URI schemes") {
+		output = Path::FromString("az://container/b/c");
+		CHECK(output.GetScheme() == "az://");
+		CHECK(output.GetAuthority() == "container");
+		CHECK(output.GetAnchor() == "/");
+		CHECK(output.IsAbsolute());
+		CHECK(output.GetPath() == "b/c");
+	}
+
+#if defined(_WIN32)
+	SECTION("UNC schemes") {
+		output = Path::FromString(R"(\\foo\bar)");
+		CHECK(output.GetScheme() == R"(\\)");
+		CHECK(output.GetAuthority() == R"(foo\bar)");
+		CHECK(output.GetAnchor() == R"(\)");
+		CHECK(output.GetPath().empty());
+
+		CHECK_THROWS(Path::FromString(R"(\\\\ab)"));
+		CHECK_THROWS(Path::FromString(R"(\\foo\)"));
+		CHECK_THROWS(Path::FromString(R"(\\foo\\)"));
+	}
+#endif
+}
+
+TEST_CASE("Path::FromString/ToString round-trips", "[file_system]") {
+	using std::make_tuple;
+
+	enum ResultType { ERR = false, OK_ = true };
+
+	ResultType return_exp;
+	std::string input;
+	std::string output_exp;
+
+	// L() converts / to the local separator (mirrors playground L helper)
+	auto L = [](const string &path) {
+		string out(path);
+#ifdef _WIN32
+		for (size_t pos = 0; (pos = out.find('/', pos)) != string::npos; pos++) {
+			out[pos] = '\\';
+		}
+#endif
+		return out;
+	};
+
+	// clang-format off
+	SECTION("local files") {
+		std::tie(return_exp, input, output_exp) = GENERATE(table<ResultType, std::string, std::string>({
+		    make_tuple(OK_, "",         "."),
+		    make_tuple(OK_, "a",        "a"),
+		    make_tuple(OK_, "a/b",      "a/b"),
+		    make_tuple(OK_, ".",        "."),
+		    make_tuple(OK_, "..",       ".."),
+		    make_tuple(OK_, "/",        "/"),
+		    make_tuple(OK_, "/a",       "/a"),
+		    make_tuple(OK_, "/a/b",     "/a/b"),
+		    make_tuple(OK_, "/a/b/",    "/a/b/"),
+
+		    // backslash ok separator on all platforms; confirm output sep = first sep in input
+		    make_tuple(OK_, R"(a\b)",             "a/b"),
+		    make_tuple(OK_, R"(/a\b\c)",          "/a/b/c"),
+		    make_tuple(OK_, R"(/data\csv\*.csv)", "/data/csv/*.csv"),
+
+		    make_tuple(OK_, "foo/bar://baz",  "foo/bar:/baz"),
+		    make_tuple(OK_, "/foo/bar://baz", "/foo/bar:/baz"),
+		}));
+	}
+
+#if defined(_WIN32)
+	SECTION("local files (windows drive)") {
+		std::tie(return_exp, input, output_exp) = GENERATE(table<ResultType, std::string, std::string>({
+		    make_tuple(OK_, "C:",   "C:"),
+		    make_tuple(OK_, "c:b",  "C:b"),
+		    make_tuple(OK_, "c:/b", "C:/b"),
+		}));
+	}
+#endif
+
+	SECTION("file schemes") {
+		std::tie(return_exp, input, output_exp) = GENERATE(table<ResultType, std::string, std::string>({
+		    make_tuple(OK_, "file:/",       "file:/"),
+		    make_tuple(OK_, "file:/a",      "file:/a"),
+		    make_tuple(OK_, "file:/a/b",    "file:/a/b"),
+
+		    make_tuple(OK_, "file://localhost/",    "file://localhost/"),
+		    make_tuple(OK_, "file://localhost/a",   "file://localhost/a"),
+		    make_tuple(OK_, "file://localhost/a/b", "file://localhost/a/b"),
+
+		    make_tuple(ERR, "file://otherhost/a/b", ""),
+
+		    make_tuple(OK_, "file:///",     "file:///"),
+		    make_tuple(OK_, "file:///a",    "file:///a"),
+		    make_tuple(OK_, "file:///a/b",  "file:///a/b"),
+		}));
+	}
+
+#if defined(_WIN32)
+	SECTION("file schemes (windows drive)") {
+		std::tie(return_exp, input, output_exp) = GENERATE(table<ResultType, std::string, std::string>({
+		    make_tuple(OK_, "file:/c:/b",               "file:/C:/b"),
+		    make_tuple(OK_, "file://localhost/c://b",   "file://localhost/C:/b"),
+		    make_tuple(OK_, "file:///c:///b",           "file:///C:/b"),
+		    make_tuple(OK_, "file://localhost//c://b",  "file://localhost/c:/b"),
+		    make_tuple(OK_, "file://localhost/c://localhost/b", "file://localhost/C:/localhost/b"),
+		}));
+	}
+#endif
+
+	SECTION("URI schemes") {
+		std::tie(return_exp, input, output_exp) = GENERATE(table<ResultType, std::string, std::string>({
+		    make_tuple(OK_, "S3://bucket/bar/baz",     "s3://bucket/bar/baz"),
+		    make_tuple(OK_, "s3://bucket/bar/baz",     "s3://bucket/bar/baz"),
+		    make_tuple(OK_, "s3://bucket/bar/../baz",  "s3://bucket/baz"),
+		    make_tuple(OK_, "s3://bucket/..",          "s3://bucket/"),
+		    make_tuple(OK_, "s3://bucket/../..",       "s3://bucket/"),
+		    make_tuple(OK_, "s3://bucket/c:/B/",       "s3://bucket/c:/B/"),
+		}));
+	}
+	// clang-format on
+
+	CAPTURE(input);
+	if (return_exp == OK_) {
+		CHECK(L(Path::FromString(input).ToString()) == L(output_exp));
+	} else {
+		CHECK_THROWS(Path::FromString(input).ToString());
+	}
+}
+
+TEST_CASE("Path::JoinPath table-based tests", "[file_system]") {
+	using std::make_tuple;
+
+	enum ResultType { ERR = false, OK_ = true };
+
+	ResultType return_exp;
+	std::string lhs, rhs, joined_exp;
+
+	auto L = [](const string &path) {
+		string out(path);
+#ifdef _WIN32
+		for (size_t pos = 0; (pos = out.find('/', pos)) != string::npos; pos++) {
+			out[pos] = '\\';
+		}
+#endif
+		return out;
+	};
+
+	auto do_join = [](const string &a, const string &b) {
+		return Path::FromString(a).Join(b).ToString();
+	};
+
+	// clang-format off
+	SECTION("local files") {
+		std::tie(return_exp, lhs, rhs, joined_exp) = GENERATE(table<ResultType, std::string, std::string, std::string>({
+		    make_tuple(OK_, "",   "",  "."),
+		    make_tuple(OK_, "",   ".", "."),
+		    make_tuple(OK_, ".",  "",  "."),
+		    make_tuple(OK_, ".",  ".", "."),
+		    make_tuple(OK_, "",   "a", "a"),
+		    make_tuple(OK_, "a",  "",  "a"),
+		    make_tuple(OK_, "a",  "b", "a/b"),
+		    make_tuple(OK_, "/.", ".", "/"),
+		    make_tuple(OK_, "/",  "a", "/a"),
+		    make_tuple(OK_, "/a", "",  "/a"),
+		    make_tuple(OK_, "/a", "b", "/a/b"),
+
+		    // abs path sub-path helper
+		    make_tuple(OK_, "/",  "/a",     "/a"),
+		    make_tuple(OK_, "/",  "/a/b/c", "/a/b/c"),
+		    make_tuple(OK_, "/a", "/a",     "/a"),
+		    make_tuple(OK_, "/a", "/a/b",   "/a/b"),
+
+		    // abs path fails
+		    make_tuple(ERR, "/a", "/",  ""),
+		    make_tuple(ERR, "/a", "/b", ""),
+
+		    // extra slashes
+		    make_tuple(OK_, "dir//sub/", "./file",      "dir/sub/file"),
+		    make_tuple(OK_, "dir/sub", "../sibling",    "dir/sibling"),
+		    make_tuple(OK_, "dir///", "nested///child", "dir/nested/child"),
+
+		    // single & double dots
+		    make_tuple(OK_, "/", "./..",         "/"),
+		    make_tuple(OK_, "", "./..",          ".."),
+		    make_tuple(OK_, "..", "a/..",        ".."),
+		    make_tuple(OK_, "..", "../a",        "../../a"),
+		    make_tuple(OK_, "./..", "./..",      "../.."),
+		    make_tuple(OK_, "a/bar", "..",       "a"),
+		    make_tuple(OK_, "a/bar", "../..",    "."),
+		    make_tuple(OK_, "a/bar", "../../..", ".."),
+
+		    make_tuple(OK_, "./a/././b/./", "././c/././", "a/b/c/"),
+
+		    make_tuple(OK_, "dir/sub/..", "sibling",        "dir/sibling"),
+		    make_tuple(OK_, "./dir/sub/..", "sibling",      "dir/sibling"),
+		    make_tuple(OK_, "./dir/sub/./..", "sibling",    "dir/sibling"),
+		    make_tuple(OK_, "dir/..", "../..",              "../.."),
+		    make_tuple(OK_, "/usr/local", "../..",          "/"),
+		    make_tuple(OK_, "/", "usr/local",               "/usr/local"),
+		    make_tuple(OK_, "/usr/local", "../../..",       "/"),
+
+		    make_tuple(ERR, "dir", "/abs/path", ""),
+		    make_tuple(ERR, "/fo",  "/foobar",  ""),
+
+		    // scheme-like token embedded after leading slash is treated as path, not scheme
+		    make_tuple(OK_, "/foo/proto://bar", "a", "/foo/proto:/bar/a"),
+		}));
+	}
+
+	SECTION("file and URI schemes") {
+		std::tie(return_exp, lhs, rhs, joined_exp) = GENERATE(table<ResultType, std::string, std::string, std::string>({
+		    make_tuple(OK_, "file:/", "",                   "file:/"),
+		    make_tuple(OK_, "file:/", "../..",              "file:/"),
+		    make_tuple(OK_, "file:/", "bin",                "file:/bin"),
+		    make_tuple(OK_, "file:/usr", "",                "file:/usr"),
+		    make_tuple(OK_, "file:/usr", "bin",             "file:/usr/bin"),
+		    make_tuple(OK_, "file:/usr/local", "../bin",    "file:/usr/bin"),
+
+		    make_tuple(OK_, "file://localhost/usr", "../bin",       "file://localhost/bin"),
+		    make_tuple(OK_, "file://localhost/usr/local", "../bin", "file://localhost/usr/bin"),
+		    make_tuple(OK_, "file:///usr/local", "../bin",          "file:///usr/bin"),
+
+		    make_tuple(OK_, "s3://host", "bar/baz", "s3://host/bar/baz"),
+		    make_tuple(OK_, "s3://host", "..",      "s3://host/"),
+		    make_tuple(OK_, "s3://host", "../..",   "s3://host/"),
+
+		    make_tuple(ERR, "/usr/local", "/var/log",   ""),
+		    make_tuple(ERR, "s3://foo", "/foo/bar/baz", ""),
+		    make_tuple(ERR, "s3://foo", "az://foo",     ""),
+
+		    make_tuple(ERR, "s3://b/foo",      "s3://b/foobar",       ""),
+		    make_tuple(ERR, "s3://BUCKET/foo", "s3://bucket/foo/bar", ""),
+		    make_tuple(ERR, "s3://bucket/FOO", "s3://bucket/foo/bar", ""),
+
+		    // sub-path joins
+		    make_tuple(OK_, "file:/usr",             "file:/usr/local",            "file:/usr/local"),
+		    make_tuple(OK_, "file://localhost/usr",  "file://localhost/usr/local", "file://localhost/usr/local"),
+		    make_tuple(OK_, "file:///usr",           "file:///usr/local",          "file:///usr/local"),
+		    make_tuple(OK_, "s3://bucket/a",         "s3://bucket/a/b",            "s3://bucket/a/b"),
+		    make_tuple(OK_, "s3://bucket/a",         "s3://bucket/a",              "s3://bucket/a"),
+		    // scheme normalized to lowercase (RFC 3986)
+		    make_tuple(OK_, "S3://bucket/a",         "s3://bucket/a/b",            "s3://bucket/a/b"),
+		}));
+	}
+
+#if defined(_WIN32)
+	SECTION("windows files and schemes") {
+		std::tie(return_exp, lhs, rhs, joined_exp) = GENERATE(table<ResultType, std::string, std::string, std::string>({
+		    make_tuple(OK_, R"(C:\)", R"(..)",              R"(C:\)"),
+		    make_tuple(OK_, R"(C:\)", R"(..\..)",           R"(C:\)"),
+		    make_tuple(OK_, R"(C:\)", "system32",           R"(C:\system32)"),
+
+		    make_tuple(OK_, "C:", "system32",               "C:system32"),
+		    make_tuple(OK_, "C:relpath", "sub",             R"(C:relpath\sub)"),
+		    make_tuple(OK_, "C:relpath", R"(..\sib)",       "C:sib"),
+
+		    make_tuple(ERR, R"(C:\foo)", R"(D:\bar)",       ""),
+		    make_tuple(ERR, R"(C:\foo)", R"(D:bar)",        ""),
+		    make_tuple(ERR, R"(C:foo)", R"(D:bar)",         ""),
+		    make_tuple(ERR, R"(C:\foo)", R"(D:\foo\bar)",   ""),
+
+		    // extended UNC variants
+		    make_tuple(OK_, R"(\\server\share)", R"(sub)",              R"(\\server\share\sub)"),
+		    make_tuple(OK_, R"(\\?\UNC\server\share)", R"(sub\.\dir)",  R"(\\?\UNC\server\share\sub\dir)"),
+		    make_tuple(OK_, R"(\\?\c:\sub)", R"(dir)",                  R"(\\?\C:\sub\dir)"),
+
+		    // '..' dropping at front of abs path
+		    make_tuple(OK_, R"(\\server\share)", R"(..\sibling)", R"(\\server\share\sibling)"),
+
+		    // case-insensitive path prefix
+		    make_tuple(OK_, R"(C:\FOO)",  R"(C:\foo\bar)",  R"(C:\foo\bar)"),
+		    make_tuple(OK_, "C:/FOO",     "C:/foo/bar",     "C:/foo/bar"),
+
+		    // case-insensitive UNC authority
+		    make_tuple(OK_, R"(\\Server\Share\foo)",  R"(\\server\share\foo\bar)",  R"(\\Server\Share\foo\bar)"),
+		}));
+	}
+#endif
+	// clang-format on
+
+	CAPTURE(lhs, rhs);
+	if (return_exp == OK_) {
+		CHECK(L(do_join(lhs, rhs)) == L(joined_exp));
+	} else {
+		CHECK_THROWS(do_join(lhs, rhs));
+	}
+}
+
+TEST_CASE("Path attributes", "[file_system]") {
+	using std::make_tuple;
+
+	auto L = [](const string &path) {
+		string out(path);
+#ifdef _WIN32
+		for (size_t pos = 0; (pos = out.find('/', pos)) != string::npos; pos++) {
+			out[pos] = '\\';
+		}
+#endif
+		return out;
+	};
+
+	std::string input;
+
+	SECTION("IsAbsolute + IsLocal") {
+		bool is_absolute_exp, is_local_exp;
+		enum AbsType { REL = false, ABS = true };
+		enum LocalTypeType { REMOTE = false, LOCAL_ = true };
+
+		// clang-format off
+		SECTION("posix and URI") {
+			std::tie(input, is_absolute_exp, is_local_exp) = GENERATE(table<std::string, bool, bool>({
+			    make_tuple("",                    REL, LOCAL_),
+			    make_tuple("a/b",                 REL, LOCAL_),
+			    make_tuple("/",                   ABS, LOCAL_),
+			    make_tuple("/a/b",                ABS, LOCAL_),
+			    make_tuple("file:/a/b",           ABS, LOCAL_),
+			    make_tuple("file:///a/b",         ABS, LOCAL_),
+			    make_tuple("s3://bucket/foo",     ABS, REMOTE),
+			    make_tuple("az://container/foo",  ABS, REMOTE),
+			    make_tuple("http://host/path",    ABS, REMOTE),
+			}));
+		}
+#if defined(_WIN32)
+		SECTION("windows") {
+			std::tie(input, is_absolute_exp, is_local_exp) = GENERATE(table<std::string, bool, bool>({
+			    make_tuple(R"(C:\foo)",          ABS, LOCAL_),
+			    make_tuple(R"(C:foo)",           REL, LOCAL_),
+			    make_tuple(R"(\\server\share)",  ABS, REMOTE),
+			    make_tuple(R"(\\?\C:\foo)",      ABS, LOCAL_),
+			}));
+		}
+#endif
+		// clang-format on
+
+		CAPTURE(input);
+		auto p = Path::FromString(input);
+		CHECK(p.IsAbsolute() == is_absolute_exp);
+		CHECK(p.IsLocal() == is_local_exp);
+	}
+
+	SECTION("HasTrailingSeparator") {
+		bool exp;
+
+		// clang-format off
+		SECTION("posix and URI") {
+			std::tie(input, exp) = GENERATE(table<std::string, bool>({
+			    make_tuple("",           false),
+			    make_tuple("foo/bar",    false),
+			    make_tuple("foo/bar/",   true),
+			    make_tuple("/",          true),
+			    make_tuple("/a/b",       false),
+			    make_tuple("/a/b/",      true),
+			    make_tuple("s3://b/p",   false),
+			    make_tuple("s3://b/p/",  true),
+			}));
+		}
+#if defined(_WIN32)
+		SECTION("windows") {
+			std::tie(input, exp) = GENERATE(table<std::string, bool>({
+			    make_tuple("C:/",        true),
+			    make_tuple("C:/foo",     false),
+			    make_tuple("C:/foo/",    true),
+			    make_tuple(R"(C:\)",     true),
+			    make_tuple(R"(C:\foo)",  false),
+			    make_tuple(R"(C:\foo\)", true),
+			}));
+		}
+#endif
+
+		CAPTURE(input);
+		CHECK(Path::FromString(input).HasTrailingSeparator() == exp);
+	}
+
+	SECTION("trailing separator ToString") {
+		// bare anchor: anchor already ends with sep, no double-emit
+		CHECK(L(Path::FromString("/").ToString()) 				== L("/"));
+		CHECK(L(Path::FromString("/foo/bar/").ToString()) 		== L("/foo/bar/"));
+		CHECK(L(Path::FromString("/foo/bar").ToString()) 		== L("/foo/bar"));
+		CHECK(Path::FromString("s3://bucket/a/b/").ToString() 	== "s3://bucket/a/b/");
+#if defined(_WIN32)
+		CHECK(Path::FromString("C:/").ToString() 				== "C:/");
+		CHECK(L(Path::FromString("C:/foo/").ToString()) 		== L("C:/foo/"));
+#endif
+	}
+
+	SECTION("trailing separator Join") {
+		CHECK(Path::FromString("a/b").Join("c/").HasTrailingSeparator() == true);
+		CHECK(Path::FromString("a/b").Join("c").HasTrailingSeparator()  == false);
+		CHECK(L(Path::FromString("a/b/").Join("c/").ToString()) == L("a/b/c/"));
+		CHECK(L(Path::FromString("a/b/").Join("c").ToString())  == L("a/b/c"));
+	}
+
+	SECTION("GetTrailingSeparator") {
+		// has segments + trailing sep → string(1, separator)
+		CHECK(Path::FromString("/foo/bar/").GetTrailingSeparator()  == "/");
+		CHECK(Path::FromString("foo/bar/").GetTrailingSeparator()   == "/");
+		CHECK(Path::FromString("s3://b/p/").GetTrailingSeparator()  == "/");
+		// has segments, no trailing sep → ""
+		CHECK(Path::FromString("/foo/bar").GetTrailingSeparator()   == "");
+		CHECK(Path::FromString("foo/bar").GetTrailingSeparator()    == "");
+		CHECK(Path::FromString("s3://b/p").GetTrailingSeparator()   == "");
+		// no segments (bare anchors): anchor already ends with sep, no double-emit
+		CHECK(Path::FromString("/").GetTrailingSeparator()          == "");
+		CHECK(Path::FromString("").GetTrailingSeparator()           == "");
+		CHECK(Path::FromString("s3://b/").GetTrailingSeparator()    == "");
+#if defined(_WIN32)
+		CHECK(L(Path::FromString(R"(C:\foo\)").GetTrailingSeparator()) == L("/"));
+		CHECK(Path::FromString(R"(C:\)").GetTrailingSeparator()        == "");  // no segments
+#endif
+	}
+	// clang-format on
+}
+
+TEST_CASE("Path one-off tests", "[file_system]") {
+	// confirm that Join("..") and Parent() behaviors are identical in corner case
+	auto dotdot = Path::FromString("..");
+	CHECK(dotdot.Parent().ToString() == "../..");
+	CHECK(dotdot.Join("..").ToString() == "../..");
+
+	auto dotdot_a = Path::FromString("../a");
+	CHECK(dotdot_a.Parent().ToString() == "..");
+	CHECK(dotdot_a.Join("..").ToString() == "..");
+
+	CHECK(Path::FromString("a").Join("b").ToString() == "a/b");
+	CHECK(Path::FromString("a").Join("b", "c").ToString() == "a/b/c");
+	CHECK(Path::FromString("a").Join("b", "c", "d").ToString() == "a/b/c/d");
+
+	CHECK(Path::FromString("a").Join(std::vector<string>()).ToString() == "a");
+	CHECK(Path::FromString("a").Join(std::vector<string>({"b"})).ToString() == "a/b");
+	CHECK(Path::FromString("a").Join(std::vector<string>({"b", "c"})).ToString() == "a/b/c");
 }


### PR DESCRIPTION
…net/windows

- backport in Path class from on #20292, skips all integrations
- _does_ include 3 bug fixes in `StartsWithSingleBackslash`, `CreateDirectoriesRecursive`, and `FileLogStorage::InitializeFileWriter`

From original PR:
- Adds a Path class to provide structured support for ... paths! This includes local (posix/win, file:*) and various remote (URI, UNC). Provides non-optional normalization (. and .. removal where available/appropriate), but not Canonicalization, and various helpers