### PR TITLE
Extend Join Pushdown with Prefix Range Filter

### DIFF
--- a/benchmark/micro/pushdown/prefix_range_filter_correlated_columns.benchmark
+++ b/benchmark/micro/pushdown/prefix_range_filter_correlated_columns.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/pushdown/prefix_range_filter_correlated_columns.benchmark
+# description: Prefix Range Filter Pushdown with Correlated Join Key Orders
+# group: [join]
+
+name Prefix Range Filter Pushdown with Correlated Join Columns
+group join
+
+storage persistent
+
+load
+CREATE TABLE build AS SELECT i id, i NOT BETWEEN 100000 AND 4900000 p, CAST(random() AS VARCHAR) v1, CAST (random() AS VARCHAR) v2 FROM range(5000000) _(i);
+CREATE TABLE probe AS SELECT i id, i // 20 bid, CAST(random() AS VARCHAR) v1, CAST (random() AS VARCHAR) v2 FROM range(100000000) _(i);
+
+run
+SELECT any_value(probe.v1), any_value(probe.v2), any_value(build.v1), any_value(build.v2) FROM build, probe WHERE build.id = probe.bid AND p = TRUE;
+

--- a/benchmark/micro/pushdown/prefix_range_filter_correlated_columns.benchmark
+++ b/benchmark/micro/pushdown/prefix_range_filter_correlated_columns.benchmark
@@ -1,6 +1,6 @@
 # name: benchmark/micro/pushdown/prefix_range_filter_correlated_columns.benchmark
 # description: Prefix Range Filter Pushdown with Correlated Join Key Orders
-# group: [join]
+# group: [pushdown]
 
 name Prefix Range Filter Pushdown with Correlated Join Columns
 group join

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4975,19 +4975,20 @@ const StringUtil::EnumStringLiteral *GetTableFilterTypeValues() {
 		{ static_cast<uint32_t>(TableFilterType::DYNAMIC_FILTER), "DYNAMIC_FILTER" },
 		{ static_cast<uint32_t>(TableFilterType::EXPRESSION_FILTER), "EXPRESSION_FILTER" },
 		{ static_cast<uint32_t>(TableFilterType::BLOOM_FILTER), "BLOOM_FILTER" },
-		{ static_cast<uint32_t>(TableFilterType::PERFECT_HASH_JOIN_FILTER), "PERFECT_HASH_JOIN_FILTER" }
+		{ static_cast<uint32_t>(TableFilterType::PERFECT_HASH_JOIN_FILTER), "PERFECT_HASH_JOIN_FILTER" },
+		{ static_cast<uint32_t>(TableFilterType::PREFIX_RANGE_FILTER), "PREFIX_RANGE_FILTER" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<TableFilterType>(TableFilterType value) {
-	return StringUtil::EnumToString(GetTableFilterTypeValues(), 12, "TableFilterType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetTableFilterTypeValues(), 13, "TableFilterType", static_cast<uint32_t>(value));
 }
 
 template<>
 TableFilterType EnumUtil::FromString<TableFilterType>(const char *value) {
-	return static_cast<TableFilterType>(StringUtil::StringToEnum(GetTableFilterTypeValues(), 12, "TableFilterType", value));
+	return static_cast<TableFilterType>(StringUtil::StringToEnum(GetTableFilterTypeValues(), 13, "TableFilterType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetTablePartitionInfoValues() {

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4398,19 +4398,20 @@ const StringUtil::EnumStringLiteral *GetSelectivityOptionalFilterTypeValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(SelectivityOptionalFilterType::MIN_MAX), "MIN_MAX" },
 		{ static_cast<uint32_t>(SelectivityOptionalFilterType::BF), "BF" },
-		{ static_cast<uint32_t>(SelectivityOptionalFilterType::PHJ), "PHJ" }
+		{ static_cast<uint32_t>(SelectivityOptionalFilterType::PHJ), "PHJ" },
+		{ static_cast<uint32_t>(SelectivityOptionalFilterType::PRF), "PRF" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<SelectivityOptionalFilterType>(SelectivityOptionalFilterType value) {
-	return StringUtil::EnumToString(GetSelectivityOptionalFilterTypeValues(), 3, "SelectivityOptionalFilterType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetSelectivityOptionalFilterTypeValues(), 4, "SelectivityOptionalFilterType", static_cast<uint32_t>(value));
 }
 
 template<>
 SelectivityOptionalFilterType EnumUtil::FromString<SelectivityOptionalFilterType>(const char *value) {
-	return static_cast<SelectivityOptionalFilterType>(StringUtil::StringToEnum(GetSelectivityOptionalFilterTypeValues(), 3, "SelectivityOptionalFilterType", value));
+	return static_cast<SelectivityOptionalFilterType>(StringUtil::StringToEnum(GetSelectivityOptionalFilterTypeValues(), 4, "SelectivityOptionalFilterType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetSequenceInfoValues() {

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/perfect_hash_join_filter.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/filter/prefix_range_filter.hpp"
 
 namespace duckdb {
 
@@ -884,6 +885,10 @@ bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(TableFilter &filter, c
 	case TableFilterType::PERFECT_HASH_JOIN_FILTER: {
 		auto &perfect_hash_join_filter = filter.Cast<PerfectHashJoinFilter>();
 		return perfect_hash_join_filter.FilterValue(constant);
+	}
+	case TableFilterType::PREFIX_RANGE_FILTER: {
+		auto &prefix_range_filter = filter.Cast<PrefixRangeTableFilter>();
+		return prefix_range_filter.FilterValue(constant);
 	}
 	default:
 		throw NotImplementedException("Can't evaluate TableFilterType (%s) against a constant",

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -745,9 +745,9 @@ unique_ptr<PrefixRangeFilter::BuildState> JoinHashTable::InitializePrefixRangeBu
 void JoinHashTable::InsertPrefixRangeChunk(TupleDataChunkState &chunk_state, idx_t count,
                                            PrefixRangeFilter::BuildState &state) {
 	D_ASSERT(prefix_range_filter);
-	Vector build_keys(layout_ptr->GetTypes()[prefix_range_filter_build_idx], count);
+	Vector build_keys(layout_ptr->GetTypes()[0], count);
 	auto &sel = *FlatVector::IncrementalSelectionVector();
-	data_collection->Gather(chunk_state.row_locations, sel, count, prefix_range_filter_build_idx, build_keys, sel, nullptr);
+	data_collection->Gather(chunk_state.row_locations, sel, count, 0, build_keys, sel, nullptr);
 	prefix_range_filter->InsertKeys(build_keys, count, state);
 }
 

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -737,6 +737,25 @@ void JoinHashTable::InsertHashes(Vector &hashes_v, const idx_t count, TupleDataC
 	}
 }
 
+unique_ptr<PrefixRangeFilter::BuildState> JoinHashTable::InitializePrefixRangeBuildState() {
+	D_ASSERT(prefix_range_filter);
+	return prefix_range_filter->InitializeBuildState(context);
+}
+
+void JoinHashTable::InsertPrefixRangeChunk(TupleDataChunkState &chunk_state, idx_t count,
+                                           PrefixRangeFilter::BuildState &state) {
+	D_ASSERT(prefix_range_filter);
+	Vector build_keys(layout_ptr->GetTypes()[prefix_range_filter_build_idx], count);
+	auto &sel = *FlatVector::IncrementalSelectionVector();
+	data_collection->Gather(chunk_state.row_locations, sel, count, prefix_range_filter_build_idx, build_keys, sel, nullptr);
+	prefix_range_filter->InsertKeys(build_keys, count, state);
+}
+
+void JoinHashTable::MergePrefixRangeBuildState(PrefixRangeFilter::BuildState &state) {
+	D_ASSERT(prefix_range_filter);
+	prefix_range_filter->MergeBuildState(state);
+}
+
 void JoinHashTable::AllocatePointerTable() {
 	capacity = PointerTableCapacity(Count());
 	D_ASSERT(IsPowerOfTwo(capacity));
@@ -780,7 +799,8 @@ void JoinHashTable::InitializePointerTable(idx_t entry_idx_from, idx_t entry_idx
 	std::fill_n(entries + entry_idx_from, entry_idx_to - entry_idx_from, ht_entry_t());
 }
 
-void JoinHashTable::Finalize(idx_t chunk_idx_from, idx_t chunk_idx_to, bool parallel) {
+void JoinHashTable::Finalize(idx_t chunk_idx_from, idx_t chunk_idx_to, bool parallel,
+                             optional_ptr<PrefixRangeFilter::BuildState> prefix_range_state) {
 	// Pointer table should be allocated
 	D_ASSERT(hash_map.get());
 
@@ -800,6 +820,9 @@ void JoinHashTable::Finalize(idx_t chunk_idx_from, idx_t chunk_idx_to, bool para
 		TupleDataChunkState &chunk_state = iterator.GetChunkState();
 
 		InsertHashes(hashes, count, chunk_state, insert_state, parallel);
+		if (prefix_range_state) {
+			InsertPrefixRangeChunk(chunk_state, count, *prefix_range_state);
+		}
 	} while (iterator.Next());
 }
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -970,7 +970,7 @@ bool JoinFilterPushdownInfo::CanUseBloomFilter(const ClientContext &context, con
 
 bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(ClientContext &context, optional_ptr<JoinHashTable> ht,
                                                      const PhysicalComparisonJoin &op, const ExpressionType &cmp,
-                                                     Value &min, Value &max) const {
+                                                     const Value &min, const Value &max) const {
 	if (!CanUseBloomFilter(context, op, cmp, ht)) {
 		return false;
 	}
@@ -981,9 +981,12 @@ bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(ClientContext &context, opt
 
 	if (min.type().IsIntegral()) {
 		static const auto SPAN_THRESHOLD = Hugeint::Convert(1048576);
-		if (max.TryCastAs(context, LogicalTypeId::HUGEINT) && min.TryCastAs(context, LogicalTypeId::HUGEINT)) {
-			const auto max_value = max.GetValueUnsafe<hugeint_t>();
-			const auto min_value = min.GetValueUnsafe<hugeint_t>();
+		Value min_hugeint;
+		Value max_hugeint;
+		if (max.TryCastAs(context, LogicalTypeId::HUGEINT, max_hugeint, nullptr) &&
+		    min.TryCastAs(context, LogicalTypeId::HUGEINT, min_hugeint, nullptr)) {
+			const auto max_value = max_hugeint.GetValueUnsafe<hugeint_t>();
+			const auto min_value = min_hugeint.GetValueUnsafe<hugeint_t>();
 			hugeint_t span;
 			if (TrySubtractOperator::Operation(max_value, min_value, span)) {
 				span_is_small = span <= SPAN_THRESHOLD;

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1096,6 +1096,10 @@ JoinFilterPushdownInfo::FinalizeFilters(ClientContext &context, const PhysicalCo
 				min_val = final_min_max->data[min_idx].GetValue(0);
 				max_val = final_min_max->data[max_idx].GetValue(0);
 				switch (min_val.type().id()) {
+				case LogicalTypeId::TINYINT:
+				case LogicalTypeId::SMALLINT:
+				case LogicalTypeId::INTEGER:
+				case LogicalTypeId::BIGINT:
 				case LogicalTypeId::UTINYINT:
 				case LogicalTypeId::USMALLINT:
 				case LogicalTypeId::UINTEGER:

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 
+#include "duckdb/common/assert.hpp"
 #include "duckdb/common/radix_partitioning.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/types/value_map.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/execution/operator/aggregate/ungrouped_aggregate_state.hpp"
@@ -21,6 +23,8 @@
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
+#include "duckdb/planner/filter/perfect_hash_join_filter.hpp"
+#include "duckdb/planner/filter/prefix_range_filter.hpp"
 #include "duckdb/planner/filter/selectivity_optional_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
@@ -940,6 +944,16 @@ bool JoinFilterPushdownInfo::CanUseBloomFilter(const ClientContext &context, con
 	return true;
 }
 
+bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(const ClientContext &context, optional_ptr<JoinHashTable> ht,
+                                                     const PhysicalComparisonJoin &op,
+                                                     const ExpressionType &cmp) const {
+	if (!CanUseBloomFilter(context, op, cmp, ht)) {
+		return false;
+	}
+
+	return PrefixRangeTableFilter::SupportedType(ht->conditions[0].GetLHS().return_type);
+}
+
 void JoinFilterPushdownInfo::PushBloomFilter(const PhysicalOperator &op, JoinHashTable &ht,
                                              const JoinFilterPushdownFilter &info,
                                              ProjectionIndex filter_col_idx) const {
@@ -962,6 +976,34 @@ void JoinFilterPushdownInfo::PushPerfectHashJoinFilter(const PhysicalOperator &o
 	auto filter = make_uniq_base<TableFilter, PerfectHashJoinFilter>(perfect_join_executor, key_name);
 	filter = make_uniq<SelectivityOptionalFilter>(std::move(filter), SelectivityOptionalFilterType::PHJ);
 	info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(filter));
+}
+
+void JoinFilterPushdownInfo::PushPrefixRangeFilter(const JoinFilterPushdownFilter &info, ClientContext &context,
+                                                   JoinHashTable &ht, const PhysicalOperator &op, idx_t filter_col_idx,
+                                                   const Value &min_val, const Value &max_val) const {
+	const auto key_type = ht.conditions[0].GetLHS().return_type;
+	auto prefix_filter = PrefixRangeFilter::CreatePrefixRangeFilter(key_type);
+	prefix_filter->Initialize(context, ht.Count(), min_val, max_val);
+
+	Vector tuples_addresses(LogicalType::POINTER, ht.Count());
+	Vector build_vector(key_type, ht.Count());
+	auto key_count = ht.ScanKeyColumn(tuples_addresses, build_vector, 0);
+
+	// FIXME: Make this multi-threaded!
+	prefix_filter->InsertKeys(build_vector, key_count);
+
+	ht.SetPrefixRangeFilter(std::move(prefix_filter));
+
+	// If the nulls are equal, we let nulls pass. If not, we filter them
+	auto filters_null_values = !ht.NullValuesAreEqual(0);
+	const auto key_name = ht.conditions[0].GetRHS().ToString();
+	auto rf_filter =
+	    make_uniq<PrefixRangeTableFilter>(ht.GetPrefixRangeFilter(), filters_null_values, key_name, key_type);
+
+	// TODO: Experimentally find suitable selectivity threshold
+	auto opt_rf_filter =
+	    make_uniq<SelectivityOptionalFilter>(std::move(rf_filter), 0.8f, SelectivityOptionalFilter::BF_CHECK_N);
+	info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(opt_rf_filter));
 }
 
 unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeMinMax(JoinFilterGlobalState &gstate) const {
@@ -1047,8 +1089,37 @@ JoinFilterPushdownInfo::FinalizeFilters(ClientContext &context, const PhysicalCo
 				default:
 					break;
 				}
+
+				// FIXME: Better generalize this over different types
+				bool use_prefix_range_filter = false;
+				// Get the values back in case they were moved
+				min_val = final_min_max->data[min_idx].GetValue(0);
+				max_val = final_min_max->data[max_idx].GetValue(0);
+				switch (min_val.type().id()) {
+				case LogicalTypeId::UTINYINT:
+				case LogicalTypeId::USMALLINT:
+				case LogicalTypeId::UINTEGER:
+				case LogicalTypeId::UBIGINT: {
+					auto max_val_cast = max_val;
+					auto min_val_cast = min_val;
+					if (max_val_cast.TryCastAs(context, LogicalTypeId::UBIGINT) &&
+					    min_val_cast.TryCastAs(context, LogicalTypeId::UBIGINT)) {
+						const auto span =
+						    max_val_cast.GetValueUnsafe<uint64_t>() - min_val_cast.GetValueUnsafe<uint64_t>();
+						use_prefix_range_filter = span <= 1048576 || (ht && ht->Count() <= 524288);
+					} else {
+						use_prefix_range_filter = ht && ht->Count() <= 524288;
+					}
+					break;
+				}
+				default:
+					break;
+				}
+
 				if (perfect_join_executor) {
 					PushPerfectHashJoinFilter(op, *perfect_join_executor, info, filter_col_idx);
+				} else if (use_prefix_range_filter && CanUsePrefixRangeFilter(context, ht, op, cmp)) {
+					PushPrefixRangeFilter(info, context, *ht, op, filter_col_idx, min_val, max_val);
 				} else if (ht && CanUseBloomFilter(context, op, cmp, ht)) {
 					PushBloomFilter(op, *ht, info, filter_col_idx);
 				}

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1031,7 +1031,7 @@ void JoinFilterPushdownInfo::RegisterPrefixRangeFilter(const JoinFilterPushdownF
 		auto prefix_filter = PrefixRangeFilter::CreatePrefixRangeFilter(key_type);
 		prefix_filter->Initialize(context, ht.Count(), min_val, max_val);
 		ht.SetPrefixRangeFilter(std::move(prefix_filter));
-		ht.SetBuildPrefixRangeFilter(0);
+		ht.SetBuildPrefixRangeFilter();
 	}
 
 	// If the nulls are equal, we let nulls pass. If not, we filter them

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1,13 +1,13 @@
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 
 #include "duckdb/common/assert.hpp"
-#include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/common/projection_index.hpp"
 #include "duckdb/common/radix_partitioning.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/value_map.hpp"
 #include "duckdb/common/uhugeint.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/execution/join_hashtable.hpp"
 #include "duckdb/execution/operator/aggregate/ungrouped_aggregate_state.hpp"
 #include "duckdb/execution/operator/join/perfect_hash_join_executor.hpp"
 #include "duckdb/function/aggregate/distributive_function_utils.hpp"
@@ -15,6 +15,7 @@
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/query_profiler.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/optimizer/filter_combiner.hpp"
 #include "duckdb/parallel/base_pipeline_event.hpp"
 #include "duckdb/parallel/executor_task.hpp"
@@ -30,14 +31,10 @@
 #include "duckdb/planner/filter/prefix_range_filter.hpp"
 #include "duckdb/planner/filter/selectivity_optional_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
+#include "duckdb/planner/table_filter_set.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/temporary_memory_manager.hpp"
-#include "duckdb/main/settings.hpp"
-#include "duckdb/execution/join_hashtable.hpp"
-#include "duckdb/planner/filter/perfect_hash_join_filter.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
-#include "duckdb/planner/filter/dynamic_filter.hpp"
-#include "duckdb/planner/table_filter_set.hpp"
 
 namespace duckdb {
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -678,13 +678,14 @@ public:
 class HashJoinFinalizeTask : public ExecutorTask {
 public:
 	HashJoinFinalizeTask(shared_ptr<Event> event_p, ClientContext &context, HashJoinGlobalSinkState &sink_p,
-	                     idx_t chunk_idx_from_p, idx_t chunk_idx_to_p, bool parallel_p, const PhysicalOperator &op_p)
+	                     idx_t chunk_idx_from_p, idx_t chunk_idx_to_p, bool parallel_p, const PhysicalOperator &op_p,
+	                     optional_ptr<PrefixRangeFilter::BuildState> prefix_range_state_p = nullptr)
 	    : ExecutorTask(context, std::move(event_p), op_p), sink(sink_p), chunk_idx_from(chunk_idx_from_p),
-	      chunk_idx_to(chunk_idx_to_p), parallel(parallel_p) {
+	      chunk_idx_to(chunk_idx_to_p), parallel(parallel_p), prefix_range_state(prefix_range_state_p) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
-		sink.hash_table->Finalize(chunk_idx_from, chunk_idx_to, parallel);
+		sink.hash_table->Finalize(chunk_idx_from, chunk_idx_to, parallel, prefix_range_state);
 		event->FinishTask();
 		return TaskExecutionResult::TASK_FINISHED;
 	}
@@ -697,6 +698,7 @@ private:
 	idx_t chunk_idx_from;
 	idx_t chunk_idx_to;
 	bool parallel;
+	optional_ptr<PrefixRangeFilter::BuildState> prefix_range_state;
 };
 
 class HashJoinFinalizeEvent : public BasePipelineEvent {
@@ -714,30 +716,51 @@ public:
 		vector<shared_ptr<Task>> finalize_tasks;
 		auto &ht = *sink.hash_table;
 		const auto chunk_count = ht.GetDataCollection().ChunkCount();
+		const auto build_prefix_range_filter = ht.ShouldBuildPrefixRangeFilter();
+		const bool finalize_single_threaded = FinalizeSingleThreaded(sink, true);
+		const idx_t chunks_per_task = context.config.verify_parallelism ? 1 : CHUNKS_PER_TASK;
+		if (build_prefix_range_filter) {
+			prefix_range_states.clear();
+			const auto task_count =
+			    finalize_single_threaded ? 1 : (chunk_count + chunks_per_task - 1) / chunks_per_task;
+			prefix_range_states.reserve(task_count);
+		}
 
 		// if the keys are too skewed, we finalize single-threaded
-		if (FinalizeSingleThreaded(sink, true)) {
+		if (finalize_single_threaded) {
 			// Single-threaded finalize
-			finalize_tasks.push_back(
-			    make_uniq<HashJoinFinalizeTask>(shared_from_this(), context, sink, 0U, chunk_count, false, sink.op));
+			auto prefix_range_state = build_prefix_range_filter ? RegisterPrefixRangeState(ht) : nullptr;
+			finalize_tasks.push_back(make_uniq<HashJoinFinalizeTask>(shared_from_this(), context, sink, 0U, chunk_count,
+			                                                         false, sink.op, prefix_range_state));
 		} else {
 			// Parallel finalize
-			const idx_t chunks_per_task = context.config.verify_parallelism ? 1 : CHUNKS_PER_TASK;
 			for (idx_t chunk_idx = 0; chunk_idx < chunk_count; chunk_idx += chunks_per_task) {
 				auto chunk_idx_to = MinValue<idx_t>(chunk_idx + chunks_per_task, chunk_count);
-				finalize_tasks.push_back(make_uniq<HashJoinFinalizeTask>(shared_from_this(), context, sink, chunk_idx,
-				                                                         chunk_idx_to, true, sink.op));
+				auto prefix_range_state = build_prefix_range_filter ? RegisterPrefixRangeState(ht) : nullptr;
+				finalize_tasks.push_back(make_uniq<HashJoinFinalizeTask>(
+				    shared_from_this(), context, sink, chunk_idx, chunk_idx_to, true, sink.op, prefix_range_state));
 			}
 		}
 		SetTasks(std::move(finalize_tasks));
 	}
 
 	void FinishEvent() override {
+		for (auto &prefix_range_state : prefix_range_states) {
+			sink.hash_table->MergePrefixRangeBuildState(*prefix_range_state);
+		}
 		sink.hash_table->GetDataCollection().VerifyEverythingPinned();
 		sink.hash_table->finalized = true;
 	}
 
 	static constexpr idx_t CHUNKS_PER_TASK = 64;
+
+private:
+	optional_ptr<PrefixRangeFilter::BuildState> RegisterPrefixRangeState(JoinHashTable &ht) {
+		prefix_range_states.push_back(ht.InitializePrefixRangeBuildState());
+		return *prefix_range_states.back();
+	}
+
+	vector<unique_ptr<PrefixRangeFilter::BuildState>> prefix_range_states;
 };
 
 void HashJoinGlobalSinkState::ScheduleFinalize(Pipeline &pipeline, Event &event) {
@@ -999,21 +1022,17 @@ void JoinFilterPushdownInfo::PushPerfectHashJoinFilter(const PhysicalOperator &o
 	info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(filter));
 }
 
-void JoinFilterPushdownInfo::PushPrefixRangeFilter(const JoinFilterPushdownFilter &info, ClientContext &context,
-                                                   JoinHashTable &ht, const PhysicalOperator &op, idx_t filter_col_idx,
-                                                   const Value &min_val, const Value &max_val) const {
+void JoinFilterPushdownInfo::RegisterPrefixRangeFilter(const JoinFilterPushdownFilter &info, ClientContext &context,
+                                                       JoinHashTable &ht, const PhysicalOperator &op,
+                                                       idx_t filter_col_idx, const Value &min_val,
+                                                       const Value &max_val) const {
 	const auto key_type = ht.conditions[0].GetLHS().return_type;
-	auto prefix_filter = PrefixRangeFilter::CreatePrefixRangeFilter(key_type);
-	prefix_filter->Initialize(context, ht.Count(), min_val, max_val);
-
-	Vector tuples_addresses(LogicalType::POINTER, ht.Count());
-	Vector build_vector(key_type, ht.Count());
-	auto key_count = ht.ScanKeyColumn(tuples_addresses, build_vector, 0);
-
-	// FIXME: Make this multi-threaded!
-	prefix_filter->InsertKeys(build_vector, key_count);
-
-	ht.SetPrefixRangeFilter(std::move(prefix_filter));
+	if (!ht.GetPrefixRangeFilter()) {
+		auto prefix_filter = PrefixRangeFilter::CreatePrefixRangeFilter(key_type);
+		prefix_filter->Initialize(context, ht.Count(), min_val, max_val);
+		ht.SetPrefixRangeFilter(std::move(prefix_filter));
+		ht.SetBuildPrefixRangeFilter(0);
+	}
 
 	// If the nulls are equal, we let nulls pass. If not, we filter them
 	auto filters_null_values = !ht.NullValuesAreEqual(0);
@@ -1022,8 +1041,8 @@ void JoinFilterPushdownInfo::PushPrefixRangeFilter(const JoinFilterPushdownFilte
 	    make_uniq<PrefixRangeTableFilter>(ht.GetPrefixRangeFilter(), filters_null_values, key_name, key_type);
 
 	// TODO: Experimentally find suitable selectivity threshold
-	auto opt_rf_filter =
-	    make_uniq<SelectivityOptionalFilter>(std::move(rf_filter), 0.8f, SelectivityOptionalFilter::BF_CHECK_N);
+	auto opt_rf_filter = make_uniq<SelectivityOptionalFilter>(
+	    std::move(rf_filter), SelectivityOptionalFilter::BF_THRESHOLD, SelectivityOptionalFilter::BF_CHECK_N);
 	info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(opt_rf_filter));
 }
 
@@ -1113,7 +1132,7 @@ JoinFilterPushdownInfo::FinalizeFilters(ClientContext &context, const PhysicalCo
 				if (perfect_join_executor) {
 					PushPerfectHashJoinFilter(op, *perfect_join_executor, info, filter_col_idx);
 				} else if (CanUsePrefixRangeFilter(context, ht, op, cmp, min_val, max_val)) {
-					PushPrefixRangeFilter(info, context, *ht, op, filter_col_idx, min_val, max_val);
+					RegisterPrefixRangeFilter(info, context, *ht, op, filter_col_idx, min_val, max_val);
 				} else if (ht && CanUseBloomFilter(context, op, cmp, ht)) {
 					PushBloomFilter(op, *ht, info, filter_col_idx);
 				}

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -975,6 +975,11 @@ bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(ClientContext &context, opt
 		return false;
 	}
 
+	if (ht->NullValuesAreEqual(0)) {
+		// TODO: Support "A is B" type joins
+		return false;
+	}
+
 	static constexpr idx_t BUILD_SIZE_THRESHOLD = 524288;
 	bool ht_is_small = ht->Count() <= BUILD_SIZE_THRESHOLD;
 	bool span_is_small = false;
@@ -1037,11 +1042,8 @@ void JoinFilterPushdownInfo::RegisterPrefixRangeFilter(const JoinFilterPushdownF
 		ht.SetBuildPrefixRangeFilter();
 	}
 
-	// If the nulls are equal, we let nulls pass. If not, we filter them
-	auto filters_null_values = !ht.NullValuesAreEqual(0);
 	const auto key_name = ht.conditions[0].GetRHS().ToString();
-	auto rf_filter =
-	    make_uniq<PrefixRangeTableFilter>(ht.GetPrefixRangeFilter(), filters_null_values, key_name, key_type);
+	auto rf_filter = make_uniq<PrefixRangeTableFilter>(ht.GetPrefixRangeFilter(), key_name, key_type);
 
 	// TODO: Experimentally find suitable selectivity threshold
 	auto opt_rf_filter = make_uniq<SelectivityOptionalFilter>(

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 
 #include "duckdb/common/assert.hpp"
+#include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/common/radix_partitioning.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/value_map.hpp"
@@ -944,10 +945,30 @@ bool JoinFilterPushdownInfo::CanUseBloomFilter(const ClientContext &context, con
 	return true;
 }
 
-bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(const ClientContext &context, optional_ptr<JoinHashTable> ht,
-                                                     const PhysicalComparisonJoin &op,
-                                                     const ExpressionType &cmp) const {
+bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(ClientContext &context, optional_ptr<JoinHashTable> ht,
+                                                     const PhysicalComparisonJoin &op, const ExpressionType &cmp,
+                                                     Value &min, Value &max) const {
 	if (!CanUseBloomFilter(context, op, cmp, ht)) {
+		return false;
+	}
+
+	static constexpr idx_t BUILD_SIZE_THRESHOLD = 524288;
+	bool ht_is_small = ht->Count() <= BUILD_SIZE_THRESHOLD;
+	bool span_is_small = false;
+
+	if (min.type().IsIntegral()) {
+		static const auto SPAN_THRESHOLD = Hugeint::Convert(1048576);
+		if (max.TryCastAs(context, LogicalTypeId::HUGEINT) && min.TryCastAs(context, LogicalTypeId::HUGEINT)) {
+			const auto max_value = max.GetValueUnsafe<hugeint_t>();
+			const auto min_value = min.GetValueUnsafe<hugeint_t>();
+			hugeint_t span;
+			if (TrySubtractOperator::Operation(max_value, min_value, span)) {
+				span_is_small = span <= SPAN_THRESHOLD;
+			}
+		}
+	}
+
+	if (!ht_is_small && !span_is_small) {
 		return false;
 	}
 
@@ -1059,8 +1080,7 @@ JoinFilterPushdownInfo::FinalizeFilters(ClientContext &context, const PhysicalCo
 				// min = max - single value
 				// generate a "one-sided" comparison filter for the LHS
 				// Note that this also works for equalities.
-				info.dynamic_filters->PushFilter(op, filter_col_idx,
-				                                 make_uniq<ConstantFilter>(cmp, std::move(min_val)));
+				info.dynamic_filters->PushFilter(op, filter_col_idx, make_uniq<ConstantFilter>(cmp, min_val));
 			} else {
 				// min != max - generate a range filter or bloom filter + optional range filter
 				// for non-equalities, the range must be half-open
@@ -1071,7 +1091,7 @@ JoinFilterPushdownInfo::FinalizeFilters(ClientContext &context, const PhysicalCo
 				case ExpressionType::COMPARE_GREATERTHANOREQUALTO: {
 					CreateDynamicMinMaxFilter(
 					    op, info, filter_col_idx,
-					    make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(min_val)));
+					    make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, min_val));
 					break;
 				}
 				default:
@@ -1083,37 +1103,7 @@ JoinFilterPushdownInfo::FinalizeFilters(ClientContext &context, const PhysicalCo
 				case ExpressionType::COMPARE_LESSTHANOREQUALTO: {
 					CreateDynamicMinMaxFilter(
 					    op, info, filter_col_idx,
-					    make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(max_val)));
-					break;
-				}
-				default:
-					break;
-				}
-
-				// FIXME: Better generalize this over different types
-				bool use_prefix_range_filter = false;
-				// Get the values back in case they were moved
-				min_val = final_min_max->data[min_idx].GetValue(0);
-				max_val = final_min_max->data[max_idx].GetValue(0);
-				switch (min_val.type().id()) {
-				case LogicalTypeId::TINYINT:
-				case LogicalTypeId::SMALLINT:
-				case LogicalTypeId::INTEGER:
-				case LogicalTypeId::BIGINT:
-				case LogicalTypeId::UTINYINT:
-				case LogicalTypeId::USMALLINT:
-				case LogicalTypeId::UINTEGER:
-				case LogicalTypeId::UBIGINT: {
-					auto max_val_cast = max_val;
-					auto min_val_cast = min_val;
-					if (max_val_cast.TryCastAs(context, LogicalTypeId::UBIGINT) &&
-					    min_val_cast.TryCastAs(context, LogicalTypeId::UBIGINT)) {
-						const auto span =
-						    max_val_cast.GetValueUnsafe<uint64_t>() - min_val_cast.GetValueUnsafe<uint64_t>();
-						use_prefix_range_filter = span <= 1048576 || (ht && ht->Count() <= 524288);
-					} else {
-						use_prefix_range_filter = ht && ht->Count() <= 524288;
-					}
+					    make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHANOREQUALTO, max_val));
 					break;
 				}
 				default:
@@ -1122,7 +1112,7 @@ JoinFilterPushdownInfo::FinalizeFilters(ClientContext &context, const PhysicalCo
 
 				if (perfect_join_executor) {
 					PushPerfectHashJoinFilter(op, *perfect_join_executor, info, filter_col_idx);
-				} else if (use_prefix_range_filter && CanUsePrefixRangeFilter(context, ht, op, cmp)) {
+				} else if (CanUsePrefixRangeFilter(context, ht, op, cmp, min_val, max_val)) {
 					PushPrefixRangeFilter(info, context, *ht, op, filter_col_idx, min_val, max_val);
 				} else if (ht && CanUseBloomFilter(context, op, cmp, ht)) {
 					PushBloomFilter(op, *ht, info, filter_col_idx);

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -2,9 +2,11 @@
 
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/operator/subtract.hpp"
+#include "duckdb/common/projection_index.hpp"
 #include "duckdb/common/radix_partitioning.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/value_map.hpp"
+#include "duckdb/common/uhugeint.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/execution/operator/aggregate/ungrouped_aggregate_state.hpp"
 #include "duckdb/execution/operator/join/perfect_hash_join_executor.hpp"
@@ -984,19 +986,12 @@ bool JoinFilterPushdownInfo::CanUsePrefixRangeFilter(ClientContext &context, opt
 	bool ht_is_small = ht->Count() <= BUILD_SIZE_THRESHOLD;
 	bool span_is_small = false;
 
-	if (min.type().IsIntegral()) {
-		static const auto SPAN_THRESHOLD = Hugeint::Convert(1048576);
-		Value min_hugeint;
-		Value max_hugeint;
-		if (max.TryCastAs(context, LogicalTypeId::HUGEINT, max_hugeint, nullptr) &&
-		    min.TryCastAs(context, LogicalTypeId::HUGEINT, min_hugeint, nullptr)) {
-			const auto max_value = max_hugeint.GetValueUnsafe<hugeint_t>();
-			const auto min_value = min_hugeint.GetValueUnsafe<hugeint_t>();
-			hugeint_t span;
-			if (TrySubtractOperator::Operation(max_value, min_value, span)) {
-				span_is_small = span <= SPAN_THRESHOLD;
-			}
-		}
+	uhugeint_t span;
+	if (PrefixRangeFilter::TryComputeSpan(min, max, span)) {
+		static const auto SPAN_THRESHOLD = Uhugeint::Convert(1048576);
+		span_is_small = span <= SPAN_THRESHOLD;
+	} else {
+		return false;
 	}
 
 	if (!ht_is_small && !span_is_small) {
@@ -1032,7 +1027,7 @@ void JoinFilterPushdownInfo::PushPerfectHashJoinFilter(const PhysicalOperator &o
 
 void JoinFilterPushdownInfo::RegisterPrefixRangeFilter(const JoinFilterPushdownFilter &info, ClientContext &context,
                                                        JoinHashTable &ht, const PhysicalOperator &op,
-                                                       idx_t filter_col_idx, const Value &min_val,
+                                                       ProjectionIndex filter_col_idx, const Value &min_val,
                                                        const Value &max_val) const {
 	const auto key_type = ht.conditions[0].GetLHS().return_type;
 	if (!ht.GetPrefixRangeFilter()) {
@@ -1045,9 +1040,7 @@ void JoinFilterPushdownInfo::RegisterPrefixRangeFilter(const JoinFilterPushdownF
 	const auto key_name = ht.conditions[0].GetRHS().ToString();
 	auto rf_filter = make_uniq<PrefixRangeTableFilter>(ht.GetPrefixRangeFilter(), key_name, key_type);
 
-	// TODO: Experimentally find suitable selectivity threshold
-	auto opt_rf_filter = make_uniq<SelectivityOptionalFilter>(
-	    std::move(rf_filter), SelectivityOptionalFilter::BF_THRESHOLD, SelectivityOptionalFilter::BF_CHECK_N);
+	auto opt_rf_filter = make_uniq<SelectivityOptionalFilter>(std::move(rf_filter), SelectivityOptionalFilterType::PRF);
 	info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(opt_rf_filter));
 }
 

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -469,7 +469,8 @@ bool ExtractComparisonsAndInFilters(const TableFilter &filter, vector<const_refe
 		return true;
 	}
 	case TableFilterType::BLOOM_FILTER:
-	case TableFilterType::PERFECT_HASH_JOIN_FILTER: {
+	case TableFilterType::PERFECT_HASH_JOIN_FILTER:
+	case TableFilterType::PREFIX_RANGE_FILTER: {
 		return true; // We can't use it for finding cmp/in filters, but we can just ignore it
 	}
 	case TableFilterType::CONJUNCTION_AND: {

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -8,17 +8,19 @@
 
 #pragma once
 
+#include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/types/column/column_data_consumer.hpp"
 #include "duckdb/common/types/column/partitioned_column_data.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
-#include "duckdb/common/types/null_value.hpp"
 #include "duckdb/common/types/row/partitioned_tuple_data.hpp"
 #include "duckdb/common/types/row/tuple_data_iterator.hpp"
 #include "duckdb/common/types/row/tuple_data_layout.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/execution/aggregate_hashtable.hpp"
 #include "duckdb/execution/ht_entry.hpp"
 #include "duckdb/planner/filter/bloom_filter.hpp"
+#include "duckdb/planner/filter/prefix_range_filter.hpp"
 
 namespace duckdb {
 
@@ -370,6 +372,8 @@ private:
 	BloomFilter bloom_filter;
 	bool should_build_bloom_filter = false;
 
+	unique_ptr<PrefixRangeFilter> prefix_range_filter;
+
 	//! Copying not allowed
 	JoinHashTable(const JoinHashTable &) = delete;
 
@@ -455,6 +459,14 @@ public:
 
 	BloomFilter &GetBloomFilter() {
 		return bloom_filter;
+	}
+
+	void SetPrefixRangeFilter(unique_ptr<PrefixRangeFilter> filter) {
+		prefix_range_filter = std::move(filter);
+	}
+
+	optional_ptr<PrefixRangeFilter> GetPrefixRangeFilter() {
+		return prefix_range_filter;
 	}
 
 	//! Get total size of HT if all partitions would be built

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -213,7 +213,8 @@ public:
 	//! Finalize the build of the HT, constructing the actual hash table and making the HT ready for probing.
 	//! Finalize must be called before any call to Probe, and after Finalize is called Build should no longer be
 	//! ever called.
-	void Finalize(idx_t chunk_idx_from, idx_t chunk_idx_to, bool parallel);
+	void Finalize(idx_t chunk_idx_from, idx_t chunk_idx_to, bool parallel,
+	              optional_ptr<PrefixRangeFilter::BuildState> prefix_range_state = nullptr);
 	//! Probe the HT with the given input chunk, resulting in the given result
 	void Probe(ScanStructure &scan_structure, DataChunk &keys, TupleDataChunkState &key_state, ProbeState &probe_state,
 	           optional_ptr<Vector> precomputed_hashes = nullptr);
@@ -373,6 +374,8 @@ private:
 	bool should_build_bloom_filter = false;
 
 	unique_ptr<PrefixRangeFilter> prefix_range_filter;
+	bool should_build_prefix_range_filter = false;
+	idx_t prefix_range_filter_build_idx = 0;
 
 	//! Copying not allowed
 	JoinHashTable(const JoinHashTable &) = delete;
@@ -465,9 +468,26 @@ public:
 		prefix_range_filter = std::move(filter);
 	}
 
+	void SetBuildPrefixRangeFilter(idx_t build_idx) {
+		should_build_prefix_range_filter = true;
+		prefix_range_filter_build_idx = build_idx;
+	}
+
 	optional_ptr<PrefixRangeFilter> GetPrefixRangeFilter() {
 		return prefix_range_filter;
 	}
+
+	bool ShouldBuildPrefixRangeFilter() const {
+		return should_build_prefix_range_filter && prefix_range_filter;
+	}
+
+	idx_t GetPrefixRangeFilterBuildIndex() const {
+		return prefix_range_filter_build_idx;
+	}
+
+	unique_ptr<PrefixRangeFilter::BuildState> InitializePrefixRangeBuildState();
+	void InsertPrefixRangeChunk(TupleDataChunkState &chunk_state, idx_t count, PrefixRangeFilter::BuildState &state);
+	void MergePrefixRangeBuildState(PrefixRangeFilter::BuildState &state);
 
 	//! Get total size of HT if all partitions would be built
 	idx_t GetTotalSize(const vector<unique_ptr<JoinHashTable>> &local_hts, idx_t &max_partition_size,

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -375,7 +375,6 @@ private:
 
 	unique_ptr<PrefixRangeFilter> prefix_range_filter;
 	bool should_build_prefix_range_filter = false;
-	idx_t prefix_range_filter_build_idx = 0;
 
 	//! Copying not allowed
 	JoinHashTable(const JoinHashTable &) = delete;
@@ -468,9 +467,8 @@ public:
 		prefix_range_filter = std::move(filter);
 	}
 
-	void SetBuildPrefixRangeFilter(idx_t build_idx) {
+	void SetBuildPrefixRangeFilter() {
 		should_build_prefix_range_filter = true;
-		prefix_range_filter_build_idx = build_idx;
 	}
 
 	optional_ptr<PrefixRangeFilter> GetPrefixRangeFilter() {
@@ -479,10 +477,6 @@ public:
 
 	bool ShouldBuildPrefixRangeFilter() const {
 		return should_build_prefix_range_filter && prefix_range_filter;
-	}
-
-	idx_t GetPrefixRangeFilterBuildIndex() const {
-		return prefix_range_filter_build_idx;
 	}
 
 	unique_ptr<PrefixRangeFilter::BuildState> InitializePrefixRangeBuildState();

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -91,9 +91,9 @@ private:
 	                     ProjectionIndex filter_col_idx) const;
 	void PushPerfectHashJoinFilter(const PhysicalOperator &op, PerfectHashJoinExecutor &perfect_join_executor,
 	                               const JoinFilterPushdownFilter &info, ProjectionIndex filter_col_idx) const;
-	void PushPrefixRangeFilter(const JoinFilterPushdownFilter &info, ClientContext &context, JoinHashTable &ht,
-	                           const PhysicalOperator &op, idx_t filter_col_idx, const Value &min_val,
-	                           const Value &max_val) const;
+	void RegisterPrefixRangeFilter(const JoinFilterPushdownFilter &info, ClientContext &context, JoinHashTable &ht,
+	                               const PhysicalOperator &op, idx_t filter_col_idx, const Value &min_val,
+	                               const Value &max_val) const;
 
 	bool CanUseInFilter(const ClientContext &context, optional_ptr<JoinHashTable> ht, const ExpressionType &cmp) const;
 	bool CanUseBloomFilter(const ClientContext &context, const PhysicalComparisonJoin &op, const ExpressionType &cmp,

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/projection_index.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/column_binding.hpp"
 #include "duckdb/planner/expression.hpp"
@@ -92,7 +93,7 @@ private:
 	void PushPerfectHashJoinFilter(const PhysicalOperator &op, PerfectHashJoinExecutor &perfect_join_executor,
 	                               const JoinFilterPushdownFilter &info, ProjectionIndex filter_col_idx) const;
 	void RegisterPrefixRangeFilter(const JoinFilterPushdownFilter &info, ClientContext &context, JoinHashTable &ht,
-	                               const PhysicalOperator &op, idx_t filter_col_idx, const Value &min_val,
+	                               const PhysicalOperator &op, ProjectionIndex filter_col_idx, const Value &min_val,
 	                               const Value &max_val) const;
 
 	bool CanUseInFilter(const ClientContext &context, optional_ptr<JoinHashTable> ht, const ExpressionType &cmp) const;

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/column_binding.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/table_filter.hpp"
@@ -90,10 +91,15 @@ private:
 	                     ProjectionIndex filter_col_idx) const;
 	void PushPerfectHashJoinFilter(const PhysicalOperator &op, PerfectHashJoinExecutor &perfect_join_executor,
 	                               const JoinFilterPushdownFilter &info, ProjectionIndex filter_col_idx) const;
+	void PushPrefixRangeFilter(const JoinFilterPushdownFilter &info, ClientContext &context, JoinHashTable &ht,
+	                           const PhysicalOperator &op, idx_t filter_col_idx, const Value &min_val,
+	                           const Value &max_val) const;
 
 	bool CanUseInFilter(const ClientContext &context, optional_ptr<JoinHashTable> ht, const ExpressionType &cmp) const;
 	bool CanUseBloomFilter(const ClientContext &context, const PhysicalComparisonJoin &op, const ExpressionType &cmp,
 	                       optional_ptr<JoinHashTable> ht = nullptr) const;
+	bool CanUsePrefixRangeFilter(const ClientContext &context, optional_ptr<JoinHashTable> ht,
+	                             const PhysicalComparisonJoin &op, const ExpressionType &cmp) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -98,8 +98,9 @@ private:
 	bool CanUseInFilter(const ClientContext &context, optional_ptr<JoinHashTable> ht, const ExpressionType &cmp) const;
 	bool CanUseBloomFilter(const ClientContext &context, const PhysicalComparisonJoin &op, const ExpressionType &cmp,
 	                       optional_ptr<JoinHashTable> ht = nullptr) const;
-	bool CanUsePrefixRangeFilter(const ClientContext &context, optional_ptr<JoinHashTable> ht,
-	                             const PhysicalComparisonJoin &op, const ExpressionType &cmp) const;
+	bool CanUsePrefixRangeFilter(ClientContext &context, optional_ptr<JoinHashTable> ht,
+	                             const PhysicalComparisonJoin &op, const ExpressionType &cmp, Value &min,
+	                             Value &max) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -99,8 +99,8 @@ private:
 	bool CanUseBloomFilter(const ClientContext &context, const PhysicalComparisonJoin &op, const ExpressionType &cmp,
 	                       optional_ptr<JoinHashTable> ht = nullptr) const;
 	bool CanUsePrefixRangeFilter(ClientContext &context, optional_ptr<JoinHashTable> ht,
-	                             const PhysicalComparisonJoin &op, const ExpressionType &cmp, Value &min,
-	                             Value &max) const;
+	                             const PhysicalComparisonJoin &op, const ExpressionType &cmp, const Value &min,
+	                             const Value &max) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/filter/prefix_range_filter.hpp
+++ b/src/include/duckdb/planner/filter/prefix_range_filter.hpp
@@ -20,10 +20,15 @@ namespace duckdb {
 
 class PrefixRangeFilter {
 public:
+	struct BuildState {
+		virtual ~BuildState() = default;
+	};
+
 	virtual ~PrefixRangeFilter() = default;
 	virtual void Initialize(ClientContext &context, idx_t number_of_rows, Value min, Value max) = 0;
-	virtual void InsertKeys(Vector &keys, idx_t count) const = 0;
-	virtual void InsertOne(const Value &key) const = 0;
+	virtual unique_ptr<BuildState> InitializeBuildState(ClientContext &context) const = 0;
+	virtual void InsertKeys(Vector &keys, idx_t count, BuildState &state) const = 0;
+	virtual void MergeBuildState(BuildState &state) = 0;
 	virtual idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const = 0;
 	virtual bool LookupOneValue(const Value &key) const = 0;
 	virtual FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const = 0;

--- a/src/include/duckdb/planner/filter/prefix_range_filter.hpp
+++ b/src/include/duckdb/planner/filter/prefix_range_filter.hpp
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/filter/prefix_range_filter.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/enums/filter_propagate_result.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/planner/table_filter.hpp"
+
+namespace duckdb {
+
+class PrefixRangeFilter {
+public:
+	virtual ~PrefixRangeFilter() = default;
+	virtual void Initialize(ClientContext &context, idx_t number_of_rows, Value min, Value max) = 0;
+	virtual void InsertKeys(Vector &keys, idx_t count) const = 0;
+	virtual void InsertOne(const Value &key) const = 0;
+	virtual idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const = 0;
+	virtual bool LookupOneValue(const Value &key) const = 0;
+	virtual FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const = 0;
+	virtual bool IsInitialized() const = 0;
+	static unique_ptr<PrefixRangeFilter> CreatePrefixRangeFilter(const LogicalType &key_type);
+};
+
+class PrefixRangeTableFilter final : public TableFilter {
+private:
+	optional_ptr<PrefixRangeFilter> filter;
+
+	bool filters_null_values;
+	string key_column_name;
+	LogicalType key_type;
+
+public:
+	static constexpr auto TYPE = TableFilterType::PREFIX_RANGE_FILTER;
+	static bool SupportedType(const LogicalType &type);
+	static unique_ptr<PrefixRangeFilter> CreateBitmap(const LogicalType &type);
+
+public:
+	explicit PrefixRangeTableFilter(optional_ptr<PrefixRangeFilter> filter_p, const bool filters_null_values_p,
+	                                const string &key_column_name_p, const LogicalType &key_type_p);
+
+	//! If the join condition is e.g. "A = B", the bf will filter null values.
+	//! If the condition is "A is B" the filter will let nulls pass
+	bool FiltersNullValues() const {
+		return filters_null_values;
+	}
+
+	LogicalType GetKeyType() const {
+		return key_type;
+	}
+
+	string ToString(const string &column_name) const override;
+
+	idx_t Filter(Vector &keys, SelectionVector &sel, idx_t &approved_tuple_count) const;
+	bool FilterValue(const Value &value) const;
+
+	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override;
+
+private:
+	bool Equals(const TableFilter &other) const override;
+	unique_ptr<TableFilter> Copy() const override;
+	unique_ptr<Expression> ToExpression(const Expression &column) const override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<TableFilter> Deserialize(Deserializer &deserializer);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/planner/filter/prefix_range_filter.hpp
+++ b/src/include/duckdb/planner/filter/prefix_range_filter.hpp
@@ -40,7 +40,6 @@ class PrefixRangeTableFilter final : public TableFilter {
 private:
 	optional_ptr<PrefixRangeFilter> filter;
 
-	bool filters_null_values;
 	string key_column_name;
 	LogicalType key_type;
 
@@ -50,14 +49,8 @@ public:
 	static unique_ptr<PrefixRangeFilter> CreateBitmap(const LogicalType &type);
 
 public:
-	explicit PrefixRangeTableFilter(optional_ptr<PrefixRangeFilter> filter_p, const bool filters_null_values_p,
-	                                const string &key_column_name_p, const LogicalType &key_type_p);
-
-	//! If the join condition is e.g. "A = B", the bf will filter null values.
-	//! If the condition is "A is B" the filter will let nulls pass
-	bool FiltersNullValues() const {
-		return filters_null_values;
-	}
+	explicit PrefixRangeTableFilter(optional_ptr<PrefixRangeFilter> filter_p, const string &key_column_name_p,
+	                                const LogicalType &key_type_p);
 
 	LogicalType GetKeyType() const {
 		return key_type;

--- a/src/include/duckdb/planner/filter/prefix_range_filter.hpp
+++ b/src/include/duckdb/planner/filter/prefix_range_filter.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/uhugeint.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/planner/table_filter.hpp"
 
@@ -34,6 +35,7 @@ public:
 	virtual FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const = 0;
 	virtual bool IsInitialized() const = 0;
 	static unique_ptr<PrefixRangeFilter> CreatePrefixRangeFilter(const LogicalType &key_type);
+	static bool TryComputeSpan(const Value &lower_bound, const Value &upper_bound, uhugeint_t &result);
 };
 
 class PrefixRangeTableFilter final : public TableFilter {

--- a/src/include/duckdb/planner/filter/selectivity_optional_filter.hpp
+++ b/src/include/duckdb/planner/filter/selectivity_optional_filter.hpp
@@ -47,7 +47,7 @@ struct SelectivityOptionalFilterState final : public TableFilterState {
 	}
 };
 
-enum class SelectivityOptionalFilterType : uint8_t { MIN_MAX, BF, PHJ };
+enum class SelectivityOptionalFilterType : uint8_t { MIN_MAX, BF, PHJ, PRF };
 
 class SelectivityOptionalFilter final : public OptionalFilter {
 public:

--- a/src/include/duckdb/planner/table_filter.hpp
+++ b/src/include/duckdb/planner/table_filter.hpp
@@ -32,6 +32,7 @@ enum class TableFilterType : uint8_t {
 	EXPRESSION_FILTER = 9,         // an arbitrary expression
 	BLOOM_FILTER = 10,             // a probabilistic filter that can test whether a value is in a set of other value
 	PERFECT_HASH_JOIN_FILTER = 11, // perfect hash join probe pushed down
+	PREFIX_RANGE_FILTER = 12,      // probabilistic range-based filter
 };
 
 //! TableFilter represents a filter pushed down into the table scan.

--- a/src/planner/filter/CMakeLists.txt
+++ b/src/planner/filter/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library_unity(
   struct_filter.cpp
   optional_filter.cpp
   perfect_hash_join_filter.cpp
+  prefix_range_filter.cpp
   selectivity_optional_filter.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_planner_filter>

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -5,25 +5,26 @@
 #include "duckdb/common/enums/vector_type.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/types/selection_vector.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include <cstdint>
 
 namespace duckdb {
 
 namespace {
 
 template <typename T>
-idx_t CountLeadingZeros(const T &value) {
-	using U = typename std::make_unsigned<T>::type;
-	U v = UnsafeNumericCast<U>(value);
+idx_t CountLeadingZeros(const T &v) {
+	D_ASSERT(std::is_unsigned<T>());
 	const idx_t bit_size = sizeof(v) * 8;
 	if (v == 0) {
 		return bit_size;
 	}
 
 	idx_t count = 0;
-	U mask = U(1) << (bit_size - 1);
+	T mask = T(1) << (bit_size - 1);
 
 	while ((v & mask) == 0) {
 		++count;
@@ -34,10 +35,14 @@ idx_t CountLeadingZeros(const T &value) {
 
 template <typename T>
 class NumericPrefixRangeFilter : public PrefixRangeFilter {
+private:
+	using U = typename MakeUnsigned<T>::type;
+
 public:
 	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
-		min = min_val.GetValueUnsafe<T>();
-		span = (max_val.GetValueUnsafe<T>() - min);
+		D_ASSERT(min_val <= max_val);
+		min = UnsafeNumericCast<U>(min_val.GetValueUnsafe<T>());
+		span = (UnsafeNumericCast<U>(max_val.GetValueUnsafe<T>() - min));
 		shift = 0;
 
 		if (span >= CAP_BITS) {
@@ -63,13 +68,14 @@ public:
 		keys.ToUnifiedFormat(count, vector_data);
 		const auto key_data = UnifiedVectorFormat::GetData<const T>(vector_data);
 		const auto &validity_mask = vector_data.validity;
+
 		if (validity_mask.AllValid()) {
 			for (idx_t i = 0; i < count; i++) {
-				const auto data_idx = vector_data.sel->get_index(i);
-				const auto &key = key_data[data_idx];
-				const auto y = UnsafeNumericCast<idx_t>(key - min);
+				const idx_t data_idx = vector_data.sel->get_index(i);
+				const U &key = UnsafeNumericCast<U>(key_data[data_idx]);
+				const U y = key - min;
 				// All x are in-range by construction, so range check can be omitted here.
-				const auto idx = y >> shift;
+				const U idx = y >> shift;
 				bitmap[idx >> 6] |= 1ULL << (idx & 63u);
 			}
 		} else {
@@ -78,28 +84,30 @@ public:
 				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
 					continue;
 				}
-				const auto &key = key_data[data_idx];
-				const auto y = UnsafeNumericCast<idx_t>(key - min);
+				const U &key = UnsafeNumericCast<U>(key_data[data_idx]);
+				const U y = key - min;
 				// All x are in-range by construction, so range check can be omitted here.
-				const auto idx = y >> shift;
+				const U idx = y >> shift;
 				bitmap[idx >> 6] |= 1ULL << (idx & 63u);
 			}
 		}
 	}
 
-	void InsertOne(const Value &key) const override {
-		const auto y = UnsafeNumericCast<idx_t>(key.GetValueUnsafe<T>() - min);
+	void InsertOne(const Value &k) const override {
+		const U &key = UnsafeNumericCast<U>(k.GetValueUnsafe<T>());
+		const U y = key - min;
 		// All x are in-range by construction, so range check can be omitted here.
-		const auto idx = y >> shift;
+		const U idx = y >> shift;
 		bitmap[idx >> 6] |= 1ULL << (idx & 63u);
 	}
 
-	inline idx_t LookupOne(const T &key) const {
-		const auto y = key - min;
-		const auto bit_idx = UnsafeNumericCast<idx_t>(y >> shift);
-		const auto in_range = y <= span;
-		const auto word_idx = (bit_idx >> 6) & in_range_masks[in_range];
-		const auto bit = (bitmap[word_idx] >> (bit_idx & 63ULL)) & 1ULL;
+	inline idx_t LookupOne(const T &k) const {
+		const U &key = UnsafeNumericCast<U>(k);
+		const U y = key - min;
+		const U bit_idx = y >> shift;
+		const uint8_t in_range = y <= span;
+		const uint32_t word_idx = (bit_idx >> 6) & in_range_masks[in_range];
+		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & 63ULL)) & 1ULL;
 		return bit & in_range;
 	}
 
@@ -118,8 +126,8 @@ public:
 			for (idx_t i = 0; i < count; i++) {
 				const auto data_idx = vector_data.sel->get_index(i);
 				const auto &key = data[data_idx];
-				result_sel.set_index(found_count, i);
 				found_count += LookupOne(key);
+				result_sel.set_index(found_count, i);
 			}
 		} else {
 			for (idx_t i = 0; i < count; i++) {
@@ -129,8 +137,8 @@ public:
 				}
 
 				const auto &key = data[data_idx];
-				result_sel.set_index(found_count, i);
 				found_count += LookupOne(key);
+				result_sel.set_index(found_count, i);
 			}
 		}
 
@@ -142,8 +150,8 @@ public:
 	}
 
 	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
-		const auto lb = lower_bound.GetValueUnsafe<T>();
-		const auto ub = upper_bound.GetValueUnsafe<T>();
+		const auto lb = UnsafeNumericCast<U>(lower_bound.GetValueUnsafe<T>());
+		const auto ub = UnsafeNumericCast<U>(upper_bound.GetValueUnsafe<T>());
 
 		if (ub < min || lb > min + span) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
@@ -188,8 +196,8 @@ private:
 	static constexpr uint32_t in_range_masks[2] = {0, 4294967295};
 
 	bool initialized = false;
-	T min;
-	T span;
+	U min;
+	U span;
 	idx_t shift;
 	AllocatedData buf_;
 	uint64_t *bitmap;

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -250,8 +250,8 @@ bool PrefixRangeTableFilter::SupportedType(const LogicalType &type) {
 	case PhysicalType::INT16:
 	case PhysicalType::INT32:
 	case PhysicalType::INT64:
-	case PhysicalType::INT128:
 		return true;
+	case PhysicalType::INT128:
 	case PhysicalType::UINT128:
 	default:
 		return false;

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/planner/filter/prefix_range_filter.hpp"
 
+#include "duckdb/common/allocator.hpp"
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/bit_utils.hpp"
 #include "duckdb/common/enums/filter_propagate_result.hpp"
@@ -12,11 +13,22 @@
 #include "duckdb/common/types/selection_vector.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/uhugeint.hpp"
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/storage/buffer_manager.hpp"
 
 namespace duckdb {
 
 namespace {
+
+AllocatedData AllocateBitmap(ClientContext &context, const idx_t word_count, uint64_t *&bitmap_begin) {
+	const idx_t size = word_count * sizeof(uint64_t);
+	BufferManager &buffer_manager = BufferManager::GetBufferManager(context);
+	auto buffer = buffer_manager.GetBufferAllocator().Allocate(64ULL + size);
+	bitmap_begin = reinterpret_cast<uint64_t *>((64ULL + reinterpret_cast<uint64_t>(buffer.get())) & ~63ULL);
+	std::fill_n(bitmap_begin, word_count, 0);
+	return buffer;
+}
 
 template <typename T>
 class NumericPrefixRangeFilter : public PrefixRangeFilter {
@@ -48,24 +60,17 @@ public:
 
 		const idx_t buckets = (span >> shift) + 1;
 		word_count = buckets == 0 ? 1 : (buckets + 63) >> WORD_SHIFT;
-		const idx_t bitmap_byte_size = word_count * sizeof(uint64_t);
 
-		BufferManager &buffer_manager = BufferManager::GetBufferManager(context);
-		buf_ = buffer_manager.GetBufferAllocator().Allocate(64ULL + bitmap_byte_size);
-		bitmap = reinterpret_cast<uint64_t *>((64ULL + reinterpret_cast<uint64_t>(buf_.get())) & ~63ULL);
-		std::fill_n(bitmap, word_count, 0);
+		buf_ = AllocateBitmap(context, word_count, bitmap);
 
+		// Only mark initialized as true, when local bitmaps are merged
 		initialized = false;
 	}
 
 	unique_ptr<BuildState> InitializeBuildState(ClientContext &context) const override {
 		D_ASSERT(bitmap);
-		BufferManager &buffer_manager = BufferManager::GetBufferManager(context);
-		const idx_t bitmap_byte_size = word_count * sizeof(uint64_t);
-		auto state_data = buffer_manager.GetBufferAllocator().Allocate(64ULL + bitmap_byte_size);
-		auto state_bitmap =
-		    reinterpret_cast<uint64_t *>((64ULL + reinterpret_cast<uint64_t>(state_data.get())) & ~63ULL);
-		std::fill_n(state_bitmap, word_count, 0);
+		uint64_t *state_bitmap;
+		auto state_data = AllocateBitmap(context, word_count, state_bitmap);
 
 		return make_uniq<NumericBuildState>(std::move(state_data), state_bitmap, word_count);
 	}

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -148,27 +148,41 @@ public:
 	}
 
 	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
-		const auto lb = UnsafeNumericCast<U>(lower_bound.GetValueUnsafe<T>());
-		const auto ub = UnsafeNumericCast<U>(upper_bound.GetValueUnsafe<T>());
+		const auto lb = lower_bound.GetValueUnsafe<T>();
+		const auto ub = upper_bound.GetValueUnsafe<T>();
 
-		if (ub < min || lb > min + span) {
+		const auto min_t = UnsafeNumericCast<T>(min);
+		const auto max_t = UnsafeNumericCast<T>(min + span);
+		if (ub < min_t || lb > max_t) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
 
-		const auto adjusted_lb = std::max(lb, min);
-		const auto adjusted_ub = std::min(ub, UnsafeNumericCast<U>(min + span));
+		const auto adjusted_lb = std::max(lb, min_t);
+		const auto adjusted_ub = std::min(ub, max_t);
 
-		const auto lb_y = adjusted_lb - min;
-		const auto lb_bit_idx = lb_y >> shift;
-		const auto lb_word_idx = lb_bit_idx >> 6;
-		const auto lb_word_mask = (~0ULL << lb_bit_idx) & 63;
+		const auto lb_y = UnsafeNumericCast<U>(adjusted_lb - min_t);
+		const U lb_bit_idx = lb_y >> shift;
+		const U lb_word_idx = lb_bit_idx >> 6;
+
+		const auto ub_y = UnsafeNumericCast<U>(adjusted_ub - min_t);
+		const U ub_bit_idx = ub_y >> shift;
+		const U ub_word_idx = ub_bit_idx >> 6;
+
+		const auto lb_bit_off = lb_bit_idx & 63u;
+		const auto ub_bit_off = ub_bit_idx & 63u;
+
+		if (lb_word_idx == ub_word_idx) {
+			const auto range_mask = ((~0ULL << lb_bit_off) & (~0ULL >> (63u - ub_bit_off)));
+			if (bitmap[lb_word_idx] & range_mask) {
+				return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+			}
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+
+		const auto lb_word_mask = (~0ULL << lb_bit_off);
 		if (bitmap[lb_word_idx] & lb_word_mask) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
-
-		const auto ub_y = adjusted_ub - min;
-		const auto ub_bit_idx = ub_y >> shift;
-		const auto ub_word_idx = ub_bit_idx >> 6;
 
 		for (idx_t i = UnsafeNumericCast<idx_t>(lb_word_idx) + 1; i < UnsafeNumericCast<idx_t>(ub_word_idx); i++) {
 			if (bitmap[i]) {
@@ -176,7 +190,7 @@ public:
 			}
 		}
 
-		const auto ub_word_mask = (1ULL << (ub_bit_idx & 63)) - 1;
+		const auto ub_word_mask = ~0ULL >> (63u - ub_bit_off);
 		if (bitmap[ub_word_idx] & ub_word_mask) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -76,7 +76,8 @@ public:
 		D_ASSERT(bitmap);
 		BufferManager &buffer_manager = BufferManager::GetBufferManager(context);
 		auto state_data = buffer_manager.GetBufferAllocator().Allocate(64ULL + word_count * sizeof(uint64_t) * 8);
-		auto state_bitmap = reinterpret_cast<uint64_t *>((64ULL + reinterpret_cast<uint64_t>(state_data.get())) & ~63ULL);
+		auto state_bitmap =
+		    reinterpret_cast<uint64_t *>((64ULL + reinterpret_cast<uint64_t>(state_data.get())) & ~63ULL);
 		std::fill_n(state_bitmap, word_count, 0);
 		return make_uniq<NumericBuildState>(std::move(state_data), state_bitmap, word_count);
 	}

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/planner/filter/prefix_range_filter.hpp"
 
 #include "duckdb/common/assert.hpp"
+#include "duckdb/common/bit_utils.hpp"
 #include "duckdb/common/enums/filter_propagate_result.hpp"
 #include "duckdb/common/enums/vector_type.hpp"
 #include "duckdb/common/numeric_utils.hpp"
@@ -13,24 +14,6 @@
 namespace duckdb {
 
 namespace {
-
-template <typename T>
-idx_t CountLeadingZeros(const T &v) {
-	D_ASSERT(std::is_unsigned<T>());
-	const idx_t bit_size = sizeof(v) * 8;
-	if (v == 0) {
-		return bit_size;
-	}
-
-	idx_t count = 0;
-	T mask = T(1) << (bit_size - 1);
-
-	while ((v & mask) == 0) {
-		++count;
-		mask >>= 1;
-	}
-	return count;
-}
 
 template <typename T>
 class NumericPrefixRangeFilter : public PrefixRangeFilter {
@@ -57,15 +40,15 @@ public:
 
 		if (span >= CAP_BITS) {
 			const auto q = static_cast<uint64_t>((span) >> MAX_PREFIX_LENGTH);
-			shift = (q <= 1) ? 0 : (64 - CountLeadingZeros(q - 1));
+			shift = (q <= 1) ? 0 : (64 - CountZeros<uint64_t>::Leading(q - 1));
 		}
 
 		const idx_t buckets = (span >> shift) + 1;
-		word_count = buckets == 0 ? 1 : (buckets + 63) >> 6;
-		const idx_t bitmap_bit_size = word_count * sizeof(uint64_t) * 8;
+		word_count = buckets == 0 ? 1 : (buckets + 63) >> WORD_SHIFT;
+		const idx_t bitmap_byte_size = word_count * sizeof(uint64_t);
 
 		BufferManager &buffer_manager = BufferManager::GetBufferManager(context);
-		buf_ = buffer_manager.GetBufferAllocator().Allocate(64ULL + bitmap_bit_size);
+		buf_ = buffer_manager.GetBufferAllocator().Allocate(64ULL + bitmap_byte_size);
 		bitmap = reinterpret_cast<uint64_t *>((64ULL + reinterpret_cast<uint64_t>(buf_.get())) & ~63ULL);
 		std::fill_n(bitmap, word_count, 0);
 
@@ -75,10 +58,12 @@ public:
 	unique_ptr<BuildState> InitializeBuildState(ClientContext &context) const override {
 		D_ASSERT(bitmap);
 		BufferManager &buffer_manager = BufferManager::GetBufferManager(context);
-		auto state_data = buffer_manager.GetBufferAllocator().Allocate(64ULL + word_count * sizeof(uint64_t) * 8);
+		const idx_t bitmap_byte_size = word_count * sizeof(uint64_t);
+		auto state_data = buffer_manager.GetBufferAllocator().Allocate(64ULL + bitmap_byte_size);
 		auto state_bitmap =
 		    reinterpret_cast<uint64_t *>((64ULL + reinterpret_cast<uint64_t>(state_data.get())) & ~63ULL);
 		std::fill_n(state_bitmap, word_count, 0);
+
 		return make_uniq<NumericBuildState>(std::move(state_data), state_bitmap, word_count);
 	}
 
@@ -96,7 +81,7 @@ public:
 				const U y = key - min;
 				// All x are in-range by construction, so range check can be omitted here.
 				const U idx = y >> shift;
-				state.bitmap[idx >> 6] |= 1ULL << (idx & 63u);
+				state.bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
 			}
 		} else {
 			for (idx_t i = 0; i < count; i++) {
@@ -108,7 +93,7 @@ public:
 				const U y = key - min;
 				// All x are in-range by construction, so range check can be omitted here.
 				const U idx = y >> shift;
-				state.bitmap[idx >> 6] |= 1ULL << (idx & 63u);
+				state.bitmap[idx >> WORD_SHIFT] |= 1ULL << (idx & WORD_MASK);
 			}
 		}
 	}
@@ -126,8 +111,8 @@ public:
 		const U y = key - min;
 		const U bit_idx = y >> shift;
 		const uint8_t in_range = y <= span;
-		const uint32_t word_idx = (bit_idx >> 6) & (0U - in_range);
-		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & 63ULL)) & 1ULL;
+		const uint32_t word_idx = (bit_idx >> WORD_SHIFT) & (0U - in_range);
+		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
 		return bit & in_range;
 	}
 
@@ -183,17 +168,19 @@ public:
 
 		const auto lb_y = static_cast<U>(adjusted_lb - static_cast<U>(min_t));
 		const U lb_bit_idx = lb_y >> shift;
-		const U lb_word_idx = lb_bit_idx >> 6;
+		const U lb_word_idx = lb_bit_idx >> WORD_SHIFT;
 
 		const auto ub_y = static_cast<U>(adjusted_ub - static_cast<U>(min_t));
 		const U ub_bit_idx = ub_y >> shift;
-		const U ub_word_idx = ub_bit_idx >> 6;
+		const U ub_word_idx = ub_bit_idx >> WORD_SHIFT;
 
-		const auto lb_bit_off = lb_bit_idx & 63u;
-		const auto ub_bit_off = ub_bit_idx & 63u;
+		const auto lb_bit_off = lb_bit_idx & WORD_MASK;
+		const auto ub_bit_off = ub_bit_idx & WORD_MASK;
 
+		// TODO: Count the amount of 1's in the range, compare to a threshold, and make a decision if we want to use the
+		// per-row filter for this row group.
 		if (lb_word_idx == ub_word_idx) {
-			const auto range_mask = ((~0ULL << lb_bit_off) & (~0ULL >> (63u - ub_bit_off)));
+			const auto range_mask = ((~0ULL << lb_bit_off) & (~0ULL >> (WORD_MASK - ub_bit_off)));
 			if (bitmap[lb_word_idx] & range_mask) {
 				return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 			}
@@ -211,7 +198,7 @@ public:
 			}
 		}
 
-		const auto ub_word_mask = ~0ULL >> (63u - ub_bit_off);
+		const auto ub_word_mask = ~0ULL >> (WORD_MASK - ub_bit_off);
 		if (bitmap[ub_word_idx] & ub_word_mask) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
@@ -225,7 +212,9 @@ public:
 
 private:
 	static constexpr idx_t MAX_PREFIX_LENGTH = 20;
-	static constexpr size_t CAP_BITS = 1ULL << MAX_PREFIX_LENGTH;
+	static constexpr idx_t CAP_BITS = 1ULL << MAX_PREFIX_LENGTH;
+	static constexpr idx_t WORD_SHIFT = 6;
+	static constexpr idx_t WORD_MASK = 63;
 
 	bool initialized = false;
 	U min;

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -5,10 +5,13 @@
 #include "duckdb/common/enums/filter_propagate_result.hpp"
 #include "duckdb/common/enums/vector_type.hpp"
 #include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/types/selection_vector.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/uhugeint.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
 namespace duckdb {
@@ -225,6 +228,19 @@ private:
 	uint64_t *bitmap;
 };
 
+template <typename T>
+bool ComputeSpan(const Value &lower_bound, const Value &upper_bound, uhugeint_t &result) {
+	T lb_value = lower_bound.GetValueUnsafe<T>();
+	T ub_value = upper_bound.GetValueUnsafe<T>();
+	T res;
+	if (TrySubtractOperator::Operation(ub_value, lb_value, res)) {
+		result = Uhugeint::Convert(res);
+		return true;
+	} else {
+		return false;
+	}
+}
+
 } // namespace
 
 unique_ptr<PrefixRangeFilter> PrefixRangeFilter::CreatePrefixRangeFilter(const LogicalType &key_type) {
@@ -249,6 +265,38 @@ unique_ptr<PrefixRangeFilter> PrefixRangeFilter::CreatePrefixRangeFilter(const L
 	case PhysicalType::UINT128:
 	default:
 		throw NotImplementedException("Prefix range filter is not implemented for type %s", key_type.ToString());
+	}
+}
+
+bool PrefixRangeFilter::TryComputeSpan(const Value &lower_bound, const Value &upper_bound, uhugeint_t &result) {
+	if (!TypeIsIntegral(lower_bound.type().InternalType())) {
+		return false;
+	}
+	if (lower_bound.type().InternalType() != upper_bound.type().InternalType()) {
+		return false;
+	}
+
+	switch (lower_bound.type().InternalType()) {
+	case PhysicalType::UINT8:
+		return ComputeSpan<uint8_t>(lower_bound, upper_bound, result);
+	case PhysicalType::UINT16:
+		return ComputeSpan<uint16_t>(lower_bound, upper_bound, result);
+	case PhysicalType::UINT32:
+		return ComputeSpan<uint32_t>(lower_bound, upper_bound, result);
+	case PhysicalType::UINT64:
+		return ComputeSpan<uint64_t>(lower_bound, upper_bound, result);
+	case PhysicalType::INT8:
+		return ComputeSpan<int8_t>(lower_bound, upper_bound, result);
+	case PhysicalType::INT16:
+		return ComputeSpan<int16_t>(lower_bound, upper_bound, result);
+	case PhysicalType::INT32:
+		return ComputeSpan<int32_t>(lower_bound, upper_bound, result);
+	case PhysicalType::INT64:
+		return ComputeSpan<int64_t>(lower_bound, upper_bound, result);
+	case PhysicalType::INT128:
+	case PhysicalType::UINT128:
+	default:
+		return false;
 	}
 }
 

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -124,10 +124,10 @@ public:
 		idx_t found_count = 0;
 		if (validity_mask.AllValid()) {
 			for (idx_t i = 0; i < count; i++) {
+				result_sel.set_index(found_count, i);
 				const auto data_idx = vector_data.sel->get_index(i);
 				const auto &key = data[data_idx];
 				found_count += LookupOne(key);
-				result_sel.set_index(found_count, i);
 			}
 		} else {
 			for (idx_t i = 0; i < count; i++) {
@@ -135,10 +135,9 @@ public:
 				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
 					continue;
 				}
-
+				result_sel.set_index(found_count, i);
 				const auto &key = data[data_idx];
 				found_count += LookupOne(key);
-				result_sel.set_index(found_count, i);
 			}
 		}
 

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -9,7 +9,6 @@
 #include "duckdb/common/types/selection_vector.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
-#include <cstdint>
 
 namespace duckdb {
 
@@ -42,7 +41,7 @@ public:
 	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
 		D_ASSERT(min_val <= max_val);
 		min = UnsafeNumericCast<U>(min_val.GetValueUnsafe<T>());
-		span = (UnsafeNumericCast<U>(max_val.GetValueUnsafe<T>() - min));
+		span = (UnsafeNumericCast<U>(max_val.GetValueUnsafe<T>()) - min);
 		shift = 0;
 
 		if (span >= CAP_BITS) {
@@ -157,7 +156,7 @@ public:
 		}
 
 		const auto adjusted_lb = std::max(lb, min);
-		const auto adjusted_ub = std::min(ub, UnsafeNumericCast<T>(min + span));
+		const auto adjusted_ub = std::min(ub, UnsafeNumericCast<U>(min + span));
 
 		const auto lb_y = adjusted_lb - min;
 		const auto lb_bit_idx = lb_y >> shift;
@@ -214,12 +213,16 @@ unique_ptr<PrefixRangeFilter> PrefixRangeFilter::CreatePrefixRangeFilter(const L
 		return make_uniq<NumericPrefixRangeFilter<uint32_t>>();
 	case PhysicalType::UINT64:
 		return make_uniq<NumericPrefixRangeFilter<uint64_t>>();
-	case PhysicalType::UINT128:
 	case PhysicalType::INT8:
+		return make_uniq<NumericPrefixRangeFilter<int8_t>>();
 	case PhysicalType::INT16:
+		return make_uniq<NumericPrefixRangeFilter<int16_t>>();
 	case PhysicalType::INT32:
+		return make_uniq<NumericPrefixRangeFilter<int32_t>>();
 	case PhysicalType::INT64:
+		return make_uniq<NumericPrefixRangeFilter<int64_t>>();
 	case PhysicalType::INT128:
+	case PhysicalType::UINT128:
 	default:
 		throw NotImplementedException("Prefix range filter is not implemented for type %s", key_type.ToString());
 	}
@@ -231,13 +234,13 @@ bool PrefixRangeTableFilter::SupportedType(const LogicalType &type) {
 	case PhysicalType::UINT16:
 	case PhysicalType::UINT32:
 	case PhysicalType::UINT64:
-		return true;
-	case PhysicalType::UINT128:
 	case PhysicalType::INT8:
 	case PhysicalType::INT16:
 	case PhysicalType::INT32:
 	case PhysicalType::INT64:
 	case PhysicalType::INT128:
+		return true;
+	case PhysicalType::UINT128:
 	default:
 		return false;
 	}

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -37,9 +37,20 @@ class NumericPrefixRangeFilter : public PrefixRangeFilter {
 private:
 	using U = typename MakeUnsigned<T>::type;
 
+	struct NumericBuildState : public PrefixRangeFilter::BuildState {
+		explicit NumericBuildState(AllocatedData data_p, uint64_t *bitmap_p, idx_t word_count_p)
+		    : data(std::move(data_p)), bitmap(bitmap_p), word_count(word_count_p) {
+		}
+
+		AllocatedData data;
+		uint64_t *bitmap;
+		idx_t word_count;
+	};
+
 public:
 	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
 		D_ASSERT(min_val <= max_val);
+		D_ASSERT(number_of_rows > 0);
 		min = static_cast<U>(min_val.GetValueUnsafe<T>());
 		span = (static_cast<U>(max_val.GetValueUnsafe<T>()) - min);
 		shift = 0;
@@ -50,18 +61,28 @@ public:
 		}
 
 		const idx_t buckets = (span >> shift) + 1;
-		const idx_t words = buckets == 0 ? 1 : (buckets + 63) >> 6;
-		const idx_t bitmap_bit_size = words * sizeof(uint64_t) * 8;
+		word_count = buckets == 0 ? 1 : (buckets + 63) >> 6;
+		const idx_t bitmap_bit_size = word_count * sizeof(uint64_t) * 8;
 
 		BufferManager &buffer_manager = BufferManager::GetBufferManager(context);
 		buf_ = buffer_manager.GetBufferAllocator().Allocate(64ULL + bitmap_bit_size);
 		bitmap = reinterpret_cast<uint64_t *>((64ULL + reinterpret_cast<uint64_t>(buf_.get())) & ~63ULL);
-		std::fill_n(bitmap, words, 0);
+		std::fill_n(bitmap, word_count, 0);
 
-		initialized = true;
+		initialized = false;
 	}
 
-	void InsertKeys(Vector &keys, idx_t count) const override {
+	unique_ptr<BuildState> InitializeBuildState(ClientContext &context) const override {
+		D_ASSERT(bitmap);
+		BufferManager &buffer_manager = BufferManager::GetBufferManager(context);
+		auto state_data = buffer_manager.GetBufferAllocator().Allocate(64ULL + word_count * sizeof(uint64_t) * 8);
+		auto state_bitmap = reinterpret_cast<uint64_t *>((64ULL + reinterpret_cast<uint64_t>(state_data.get())) & ~63ULL);
+		std::fill_n(state_bitmap, word_count, 0);
+		return make_uniq<NumericBuildState>(std::move(state_data), state_bitmap, word_count);
+	}
+
+	void InsertKeys(Vector &keys, idx_t count, BuildState &state_p) const override {
+		auto &state = static_cast<NumericBuildState &>(state_p);
 		UnifiedVectorFormat vector_data;
 		keys.ToUnifiedFormat(count, vector_data);
 		const auto key_data = UnifiedVectorFormat::GetData<const T>(vector_data);
@@ -74,7 +95,7 @@ public:
 				const U y = key - min;
 				// All x are in-range by construction, so range check can be omitted here.
 				const U idx = y >> shift;
-				bitmap[idx >> 6] |= 1ULL << (idx & 63u);
+				state.bitmap[idx >> 6] |= 1ULL << (idx & 63u);
 			}
 		} else {
 			for (idx_t i = 0; i < count; i++) {
@@ -86,17 +107,17 @@ public:
 				const U y = key - min;
 				// All x are in-range by construction, so range check can be omitted here.
 				const U idx = y >> shift;
-				bitmap[idx >> 6] |= 1ULL << (idx & 63u);
+				state.bitmap[idx >> 6] |= 1ULL << (idx & 63u);
 			}
 		}
 	}
 
-	void InsertOne(const Value &k) const override {
-		const U &key = static_cast<U>(k.GetValueUnsafe<T>());
-		const U y = key - min;
-		// All x are in-range by construction, so range check can be omitted here.
-		const U idx = y >> shift;
-		bitmap[idx >> 6] |= 1ULL << (idx & 63u);
+	void MergeBuildState(BuildState &state_p) override {
+		auto &state = static_cast<NumericBuildState &>(state_p);
+		for (idx_t word_idx = 0; word_idx < word_count; word_idx++) {
+			bitmap[word_idx] |= state.bitmap[word_idx];
+		}
+		initialized = true;
 	}
 
 	inline idx_t LookupOne(const T &k) const {
@@ -209,6 +230,7 @@ private:
 	U min;
 	U span;
 	idx_t shift;
+	idx_t word_count;
 	AllocatedData buf_;
 	uint64_t *bitmap;
 };
@@ -269,7 +291,7 @@ string PrefixRangeTableFilter::ToString(const string &column_name) const {
 }
 
 idx_t PrefixRangeTableFilter::Filter(Vector &keys, SelectionVector &sel, idx_t &approved_tuple_count) const {
-	if (!filter) {
+	if (!filter || !filter->IsInitialized()) {
 		return approved_tuple_count;
 	}
 
@@ -297,10 +319,16 @@ idx_t PrefixRangeTableFilter::Filter(Vector &keys, SelectionVector &sel, idx_t &
 }
 
 bool PrefixRangeTableFilter::FilterValue(const Value &value) const {
+	if (!filter || !filter->IsInitialized()) {
+		return true;
+	}
 	return filter->LookupOneValue(value);
 }
 
 FilterPropagateResult PrefixRangeTableFilter::CheckStatistics(BaseStatistics &stats) const {
+	if (!filter || !filter->IsInitialized()) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
 	D_ASSERT(stats.GetStatsType() == StatisticsType::NUMERIC_STATS);
 	if (!NumericStats::HasMinMax(stats)) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -1,0 +1,331 @@
+#include "duckdb/planner/filter/prefix_range_filter.hpp"
+
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/enums/filter_propagate_result.hpp"
+#include "duckdb/common/enums/vector_type.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/types/selection_vector.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+
+namespace duckdb {
+
+namespace {
+
+template <typename T>
+idx_t CountLeadingZeros(const T &value) {
+	using U = typename std::make_unsigned<T>::type;
+	U v = UnsafeNumericCast<U>(value);
+	const idx_t bit_size = sizeof(v) * 8;
+	if (v == 0) {
+		return bit_size;
+	}
+
+	idx_t count = 0;
+	U mask = U(1) << (bit_size - 1);
+
+	while ((v & mask) == 0) {
+		++count;
+		mask >>= 1;
+	}
+	return count;
+}
+
+template <typename T>
+class NumericPrefixRangeFilter : public PrefixRangeFilter {
+public:
+	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
+		min = min_val.GetValueUnsafe<T>();
+		span = (max_val.GetValueUnsafe<T>() - min);
+		shift = 0;
+
+		if (span >= CAP_BITS) {
+			const auto q =
+			    UnsafeNumericCast<uint64_t>((span /* + CAP_BITS*/) >> MAX_PREFIX_LENGTH); // ceil(span/CAP_BITS
+			shift = (q <= 1) ? 0 : (64 - CountLeadingZeros(q - 1));                       // ceil_log2(q)
+		}
+
+		const idx_t buckets = (span >> shift) + 1;
+		const idx_t words = buckets == 0 ? 1 : (buckets + 63) >> 6;
+		const idx_t bitmap_bit_size = words * sizeof(uint64_t) * 8;
+
+		BufferManager &buffer_manager = BufferManager::GetBufferManager(context);
+		buf_ = buffer_manager.GetBufferAllocator().Allocate(64ULL + bitmap_bit_size);
+		bitmap = reinterpret_cast<uint64_t *>((64ULL + reinterpret_cast<uint64_t>(buf_.get())) & ~63ULL);
+		std::fill_n(bitmap, words, 0);
+
+		initialized = true;
+	}
+
+	void InsertKeys(Vector &keys, idx_t count) const override {
+		UnifiedVectorFormat vector_data;
+		keys.ToUnifiedFormat(count, vector_data);
+		const auto key_data = UnifiedVectorFormat::GetData<const T>(vector_data);
+		const auto &validity_mask = vector_data.validity;
+		if (validity_mask.AllValid()) {
+			for (idx_t i = 0; i < count; i++) {
+				const auto data_idx = vector_data.sel->get_index(i);
+				const auto &key = key_data[data_idx];
+				const auto y = UnsafeNumericCast<idx_t>(key - min);
+				// All x are in-range by construction, so range check can be omitted here.
+				const auto idx = y >> shift;
+				bitmap[idx >> 6] |= 1ULL << (idx & 63u);
+			}
+		} else {
+			for (idx_t i = 0; i < count; i++) {
+				const auto data_idx = vector_data.sel->get_index(i);
+				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
+					continue;
+				}
+				const auto &key = key_data[data_idx];
+				const auto y = UnsafeNumericCast<idx_t>(key - min);
+				// All x are in-range by construction, so range check can be omitted here.
+				const auto idx = y >> shift;
+				bitmap[idx >> 6] |= 1ULL << (idx & 63u);
+			}
+		}
+	}
+
+	void InsertOne(const Value &key) const override {
+		const auto y = UnsafeNumericCast<idx_t>(key.GetValueUnsafe<T>() - min);
+		// All x are in-range by construction, so range check can be omitted here.
+		const auto idx = y >> shift;
+		bitmap[idx >> 6] |= 1ULL << (idx & 63u);
+	}
+
+	inline idx_t LookupOne(const T &key) const {
+		const auto y = key - min;
+		const auto bit_idx = UnsafeNumericCast<idx_t>(y >> shift);
+		const auto in_range = y <= span;
+		const auto word_idx = (bit_idx >> 6) & in_range_masks[in_range];
+		const auto bit = (bitmap[word_idx] >> (bit_idx & 63ULL)) & 1ULL;
+		return bit & in_range;
+	}
+
+	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const override {
+		if (keys.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			return LookupOneValue(keys.GetValue(0)) ? count : 0;
+		}
+
+		UnifiedVectorFormat vector_data;
+		keys.ToUnifiedFormat(count, vector_data);
+		const auto data = UnifiedVectorFormat::GetData<const T>(vector_data);
+		const auto &validity_mask = vector_data.validity;
+
+		idx_t found_count = 0;
+		if (validity_mask.AllValid()) {
+			for (idx_t i = 0; i < count; i++) {
+				const auto data_idx = vector_data.sel->get_index(i);
+				const auto &key = data[data_idx];
+				result_sel.set_index(found_count, i);
+				found_count += LookupOne(key);
+			}
+		} else {
+			for (idx_t i = 0; i < count; i++) {
+				const auto data_idx = vector_data.sel->get_index(i);
+				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
+					continue;
+				}
+
+				const auto &key = data[data_idx];
+				result_sel.set_index(found_count, i);
+				found_count += LookupOne(key);
+			}
+		}
+
+		return found_count;
+	}
+
+	bool LookupOneValue(const Value &key) const override {
+		return LookupOne(key.GetValueUnsafe<T>());
+	}
+
+	FilterPropagateResult LookupRange(const Value &lower_bound, const Value &upper_bound) const override {
+		const auto lb = lower_bound.GetValueUnsafe<T>();
+		const auto ub = upper_bound.GetValueUnsafe<T>();
+
+		if (ub < min || lb > min + span) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+
+		const auto adjusted_lb = std::max(lb, min);
+		const auto adjusted_ub = std::min(ub, UnsafeNumericCast<T>(min + span));
+
+		const auto lb_y = adjusted_lb - min;
+		const auto lb_bit_idx = lb_y >> shift;
+		const auto lb_word_idx = lb_bit_idx >> 6;
+		const auto lb_word_mask = (~0ULL << lb_bit_idx) & 63;
+		if (bitmap[lb_word_idx] & lb_word_mask) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+
+		const auto ub_y = adjusted_ub - min;
+		const auto ub_bit_idx = ub_y >> shift;
+		const auto ub_word_idx = ub_bit_idx >> 6;
+
+		for (idx_t i = UnsafeNumericCast<idx_t>(lb_word_idx) + 1; i < UnsafeNumericCast<idx_t>(ub_word_idx); i++) {
+			if (bitmap[i]) {
+				return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+			}
+		}
+
+		const auto ub_word_mask = (1ULL << (ub_bit_idx & 63)) - 1;
+		if (bitmap[ub_word_idx] & ub_word_mask) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+
+	bool IsInitialized() const override {
+		return initialized;
+	}
+
+private:
+	static constexpr idx_t MAX_PREFIX_LENGTH = 20;
+	static constexpr size_t CAP_BITS = 1ULL << MAX_PREFIX_LENGTH;
+	static constexpr uint32_t in_range_masks[2] = {0, 4294967295};
+
+	bool initialized = false;
+	T min;
+	T span;
+	idx_t shift;
+	AllocatedData buf_;
+	uint64_t *bitmap;
+};
+
+} // namespace
+
+unique_ptr<PrefixRangeFilter> PrefixRangeFilter::CreatePrefixRangeFilter(const LogicalType &key_type) {
+	switch (key_type.InternalType()) {
+	case PhysicalType::UINT8:
+		return make_uniq<NumericPrefixRangeFilter<uint8_t>>();
+	case PhysicalType::UINT16:
+		return make_uniq<NumericPrefixRangeFilter<uint16_t>>();
+	case PhysicalType::UINT32:
+		return make_uniq<NumericPrefixRangeFilter<uint32_t>>();
+	case PhysicalType::UINT64:
+		return make_uniq<NumericPrefixRangeFilter<uint64_t>>();
+	case PhysicalType::UINT128:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::INT128:
+	default:
+		throw NotImplementedException("Prefix range filter is not implemented for type %s", key_type.ToString());
+	}
+}
+
+bool PrefixRangeTableFilter::SupportedType(const LogicalType &type) {
+	switch (type.InternalType()) {
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+		return true;
+	case PhysicalType::UINT128:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::INT128:
+	default:
+		return false;
+	}
+}
+
+PrefixRangeTableFilter::PrefixRangeTableFilter(optional_ptr<PrefixRangeFilter> filter_p,
+                                               const bool filters_null_values_p, const string &key_column_name_p,
+                                               const LogicalType &key_type_p)
+    : TableFilter(TYPE), filter(filter_p), filters_null_values(filters_null_values_p),
+      key_column_name(key_column_name_p), key_type(key_type_p) {
+}
+string PrefixRangeTableFilter::ToString(const string &column_name) const {
+	return column_name + " IN PRF(" + key_column_name + ")";
+}
+
+idx_t PrefixRangeTableFilter::Filter(Vector &keys, SelectionVector &sel, idx_t &approved_tuple_count) const {
+	if (!filter) {
+		return approved_tuple_count;
+	}
+
+	const auto approved_before = approved_tuple_count;
+	Vector keys_sliced(keys, sel, approved_before);
+	SelectionVector result_sel(approved_before);
+	approved_tuple_count = filter->LookupKeys(keys_sliced, result_sel, approved_before);
+
+	if (approved_tuple_count == approved_before) {
+		// Nothing was filtered
+		return approved_tuple_count;
+	}
+
+	if (sel.IsSet()) {
+		for (idx_t idx = 0; idx < approved_tuple_count; idx++) {
+			const idx_t sliced_sel_idx = result_sel.get_index_unsafe(idx);
+			const idx_t original_sel_idx = sel.get_index_unsafe(sliced_sel_idx);
+			sel.set_index(idx, original_sel_idx);
+		}
+	} else {
+		sel.Initialize(result_sel);
+	}
+
+	return approved_tuple_count;
+}
+
+bool PrefixRangeTableFilter::FilterValue(const Value &value) const {
+	return filter->LookupOneValue(value);
+}
+
+FilterPropagateResult PrefixRangeTableFilter::CheckStatistics(BaseStatistics &stats) const {
+	D_ASSERT(stats.GetStatsType() == StatisticsType::NUMERIC_STATS);
+	if (!NumericStats::HasMinMax(stats)) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	const auto min = NumericStats::Min(stats);
+	const auto max = NumericStats::Max(stats);
+	if (min > max) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	return filter->LookupRange(min, max);
+}
+
+bool PrefixRangeTableFilter::Equals(const TableFilter &other_p) const {
+	if (!TableFilter::Equals(other_p)) {
+		return false;
+	}
+	const auto &other = other_p.Cast<PrefixRangeTableFilter>();
+	return key_column_name == other.key_column_name && key_type == other.key_type &&
+	       filters_null_values == other.filters_null_values;
+}
+
+unique_ptr<TableFilter> PrefixRangeTableFilter::Copy() const {
+	return make_uniq<PrefixRangeTableFilter>(this->filter, this->filters_null_values, this->key_column_name,
+	                                         this->key_type);
+}
+
+unique_ptr<Expression> PrefixRangeTableFilter::ToExpression(const Expression &column) const {
+	auto bound_constant = make_uniq<BoundConstantExpression>(Value(true));
+	return std::move(bound_constant);
+}
+
+void PrefixRangeTableFilter::Serialize(Serializer &serializer) const {
+	TableFilter::Serialize(serializer);
+	serializer.WriteProperty<bool>(200, "filters_null_values", filters_null_values);
+	serializer.WriteProperty<string>(201, "key_column_name", key_column_name);
+	serializer.WriteProperty<LogicalType>(202, "key_type", key_type);
+}
+
+unique_ptr<TableFilter> PrefixRangeTableFilter::Deserialize(Deserializer &deserializer) {
+	auto filters_null_values = deserializer.ReadProperty<bool>(200, "filters_null_values");
+	auto key_column_name = deserializer.ReadProperty<string>(201, "key_column_name");
+	auto key_type = deserializer.ReadProperty<LogicalType>(202, "key_type");
+
+	auto result = make_uniq<PrefixRangeTableFilter>(nullptr, filters_null_values, key_column_name, key_type);
+	return std::move(result);
+}
+
+} // namespace duckdb

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -56,8 +56,8 @@ public:
 		shift = 0;
 
 		if (span >= CAP_BITS) {
-			const auto q = static_cast<uint64_t>((span /* + CAP_BITS*/) >> MAX_PREFIX_LENGTH); // ceil(span/CAP_BITS
-			shift = (q <= 1) ? 0 : (64 - CountLeadingZeros(q - 1));                            // ceil_log2(q)
+			const auto q = static_cast<uint64_t>((span) >> MAX_PREFIX_LENGTH);
+			shift = (q <= 1) ? 0 : (64 - CountLeadingZeros(q - 1));
 		}
 
 		const idx_t buckets = (span >> shift) + 1;

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -40,14 +40,13 @@ private:
 public:
 	void Initialize(ClientContext &context, idx_t number_of_rows, Value min_val, Value max_val) override {
 		D_ASSERT(min_val <= max_val);
-		min = UnsafeNumericCast<U>(min_val.GetValueUnsafe<T>());
-		span = (UnsafeNumericCast<U>(max_val.GetValueUnsafe<T>()) - min);
+		min = static_cast<U>(min_val.GetValueUnsafe<T>());
+		span = (static_cast<U>(max_val.GetValueUnsafe<T>()) - min);
 		shift = 0;
 
 		if (span >= CAP_BITS) {
-			const auto q =
-			    UnsafeNumericCast<uint64_t>((span /* + CAP_BITS*/) >> MAX_PREFIX_LENGTH); // ceil(span/CAP_BITS
-			shift = (q <= 1) ? 0 : (64 - CountLeadingZeros(q - 1));                       // ceil_log2(q)
+			const auto q = static_cast<uint64_t>((span /* + CAP_BITS*/) >> MAX_PREFIX_LENGTH); // ceil(span/CAP_BITS
+			shift = (q <= 1) ? 0 : (64 - CountLeadingZeros(q - 1));                            // ceil_log2(q)
 		}
 
 		const idx_t buckets = (span >> shift) + 1;
@@ -71,7 +70,7 @@ public:
 		if (validity_mask.AllValid()) {
 			for (idx_t i = 0; i < count; i++) {
 				const idx_t data_idx = vector_data.sel->get_index(i);
-				const U &key = UnsafeNumericCast<U>(key_data[data_idx]);
+				const U &key = static_cast<U>(key_data[data_idx]);
 				const U y = key - min;
 				// All x are in-range by construction, so range check can be omitted here.
 				const U idx = y >> shift;
@@ -83,7 +82,7 @@ public:
 				if (!validity_mask.RowIsValidUnsafe(data_idx)) {
 					continue;
 				}
-				const U &key = UnsafeNumericCast<U>(key_data[data_idx]);
+				const U &key = static_cast<U>(key_data[data_idx]);
 				const U y = key - min;
 				// All x are in-range by construction, so range check can be omitted here.
 				const U idx = y >> shift;
@@ -93,7 +92,7 @@ public:
 	}
 
 	void InsertOne(const Value &k) const override {
-		const U &key = UnsafeNumericCast<U>(k.GetValueUnsafe<T>());
+		const U &key = static_cast<U>(k.GetValueUnsafe<T>());
 		const U y = key - min;
 		// All x are in-range by construction, so range check can be omitted here.
 		const U idx = y >> shift;
@@ -101,7 +100,7 @@ public:
 	}
 
 	inline idx_t LookupOne(const T &k) const {
-		const U &key = UnsafeNumericCast<U>(k);
+		const U &key = static_cast<U>(k);
 		const U y = key - min;
 		const U bit_idx = y >> shift;
 		const uint8_t in_range = y <= span;
@@ -151,8 +150,8 @@ public:
 		const auto lb = lower_bound.GetValueUnsafe<T>();
 		const auto ub = upper_bound.GetValueUnsafe<T>();
 
-		const auto min_t = UnsafeNumericCast<T>(min);
-		const auto max_t = UnsafeNumericCast<T>(min + span);
+		const auto min_t = static_cast<T>(min);
+		const auto max_t = static_cast<T>(min + span);
 		if (ub < min_t || lb > max_t) {
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
@@ -160,11 +159,11 @@ public:
 		const auto adjusted_lb = std::max(lb, min_t);
 		const auto adjusted_ub = std::min(ub, max_t);
 
-		const auto lb_y = UnsafeNumericCast<U>(adjusted_lb - min_t);
+		const auto lb_y = static_cast<U>(adjusted_lb - min_t);
 		const U lb_bit_idx = lb_y >> shift;
 		const U lb_word_idx = lb_bit_idx >> 6;
 
-		const auto ub_y = UnsafeNumericCast<U>(adjusted_ub - min_t);
+		const auto ub_y = static_cast<U>(adjusted_ub - min_t);
 		const U ub_bit_idx = ub_y >> shift;
 		const U ub_word_idx = ub_bit_idx >> 6;
 
@@ -184,7 +183,7 @@ public:
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
 
-		for (idx_t i = UnsafeNumericCast<idx_t>(lb_word_idx) + 1; i < UnsafeNumericCast<idx_t>(ub_word_idx); i++) {
+		for (idx_t i = static_cast<idx_t>(lb_word_idx) + 1; i < static_cast<idx_t>(ub_word_idx); i++) {
 			if (bitmap[i]) {
 				return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 			}

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -156,14 +156,14 @@ public:
 			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
 
-		const auto adjusted_lb = std::max(lb, min_t);
-		const auto adjusted_ub = std::min(ub, max_t);
+		const auto adjusted_lb = static_cast<U>(std::max(lb, min_t));
+		const auto adjusted_ub = static_cast<U>(std::min(ub, max_t));
 
-		const auto lb_y = static_cast<U>(adjusted_lb - min_t);
+		const auto lb_y = static_cast<U>(adjusted_lb - static_cast<U>(min_t));
 		const U lb_bit_idx = lb_y >> shift;
 		const U lb_word_idx = lb_bit_idx >> 6;
 
-		const auto ub_y = static_cast<U>(adjusted_ub - min_t);
+		const auto ub_y = static_cast<U>(adjusted_ub - static_cast<U>(min_t));
 		const U ub_bit_idx = ub_y >> shift;
 		const U ub_word_idx = ub_bit_idx >> 6;
 

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -271,10 +271,8 @@ bool PrefixRangeTableFilter::SupportedType(const LogicalType &type) {
 }
 
 PrefixRangeTableFilter::PrefixRangeTableFilter(optional_ptr<PrefixRangeFilter> filter_p,
-                                               const bool filters_null_values_p, const string &key_column_name_p,
-                                               const LogicalType &key_type_p)
-    : TableFilter(TYPE), filter(filter_p), filters_null_values(filters_null_values_p),
-      key_column_name(key_column_name_p), key_type(key_type_p) {
+                                               const string &key_column_name_p, const LogicalType &key_type_p)
+    : TableFilter(TYPE), filter(filter_p), key_column_name(key_column_name_p), key_type(key_type_p) {
 }
 string PrefixRangeTableFilter::ToString(const string &column_name) const {
 	return column_name + " IN PRF(" + key_column_name + ")";
@@ -312,7 +310,11 @@ bool PrefixRangeTableFilter::FilterValue(const Value &value) const {
 	if (!filter || !filter->IsInitialized()) {
 		return true;
 	}
-	return filter->LookupOneValue(value);
+	Vector keys(value);
+	SelectionVector sel;
+	idx_t approved_tuple_count = 1;
+	Filter(keys, sel, approved_tuple_count);
+	return approved_tuple_count == 1;
 }
 
 FilterPropagateResult PrefixRangeTableFilter::CheckStatistics(BaseStatistics &stats) const {
@@ -338,13 +340,11 @@ bool PrefixRangeTableFilter::Equals(const TableFilter &other_p) const {
 		return false;
 	}
 	const auto &other = other_p.Cast<PrefixRangeTableFilter>();
-	return key_column_name == other.key_column_name && key_type == other.key_type &&
-	       filters_null_values == other.filters_null_values;
+	return key_column_name == other.key_column_name && key_type == other.key_type;
 }
 
 unique_ptr<TableFilter> PrefixRangeTableFilter::Copy() const {
-	return make_uniq<PrefixRangeTableFilter>(this->filter, this->filters_null_values, this->key_column_name,
-	                                         this->key_type);
+	return make_uniq<PrefixRangeTableFilter>(this->filter, this->key_column_name, this->key_type);
 }
 
 unique_ptr<Expression> PrefixRangeTableFilter::ToExpression(const Expression &column) const {
@@ -354,17 +354,15 @@ unique_ptr<Expression> PrefixRangeTableFilter::ToExpression(const Expression &co
 
 void PrefixRangeTableFilter::Serialize(Serializer &serializer) const {
 	TableFilter::Serialize(serializer);
-	serializer.WriteProperty<bool>(200, "filters_null_values", filters_null_values);
-	serializer.WriteProperty<string>(201, "key_column_name", key_column_name);
-	serializer.WriteProperty<LogicalType>(202, "key_type", key_type);
+	serializer.WriteProperty<string>(200, "key_column_name", key_column_name);
+	serializer.WriteProperty<LogicalType>(201, "key_type", key_type);
 }
 
 unique_ptr<TableFilter> PrefixRangeTableFilter::Deserialize(Deserializer &deserializer) {
-	auto filters_null_values = deserializer.ReadProperty<bool>(200, "filters_null_values");
-	auto key_column_name = deserializer.ReadProperty<string>(201, "key_column_name");
-	auto key_type = deserializer.ReadProperty<LogicalType>(202, "key_type");
+	auto key_column_name = deserializer.ReadProperty<string>(200, "key_column_name");
+	auto key_type = deserializer.ReadProperty<LogicalType>(201, "key_type");
 
-	auto result = make_uniq<PrefixRangeTableFilter>(nullptr, filters_null_values, key_column_name, key_type);
+	auto result = make_uniq<PrefixRangeTableFilter>(nullptr, key_column_name, key_type);
 	return std::move(result);
 }
 

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -105,7 +105,7 @@ public:
 		const U y = key - min;
 		const U bit_idx = y >> shift;
 		const uint8_t in_range = y <= span;
-		const uint32_t word_idx = (bit_idx >> 6) & in_range_masks[in_range];
+		const uint32_t word_idx = (bit_idx >> 6) & (0U - in_range);
 		const uint8_t bit = (bitmap[word_idx] >> (bit_idx & 63ULL)) & 1ULL;
 		return bit & in_range;
 	}
@@ -205,7 +205,6 @@ public:
 private:
 	static constexpr idx_t MAX_PREFIX_LENGTH = 20;
 	static constexpr size_t CAP_BITS = 1ULL << MAX_PREFIX_LENGTH;
-	static constexpr uint32_t in_range_masks[2] = {0, 4294967295};
 
 	bool initialized = false;
 	U min;

--- a/src/planner/filter/prefix_range_filter.cpp
+++ b/src/planner/filter/prefix_range_filter.cpp
@@ -158,6 +158,9 @@ public:
 	}
 
 	bool LookupOneValue(const Value &key) const override {
+		if (key.IsNull()) {
+			return false;
+		}
 		return LookupOne(key.GetValueUnsafe<T>());
 	}
 

--- a/src/planner/filter/selectivity_optional_filter.cpp
+++ b/src/planner/filter/selectivity_optional_filter.cpp
@@ -59,6 +59,7 @@ static float GetSelectivityThresholdForType(SelectivityOptionalFilterType type) 
 	static constexpr float MIN_MAX_THRESHOLD = 0.9f;
 	static constexpr float BF_THRESHOLD = 0.5f;
 	static constexpr float PHJ_THRESHOLD = 0.3f;
+	static constexpr float PRF_THRESHOLD = 0.5f;
 
 	switch (type) {
 	case SelectivityOptionalFilterType::MIN_MAX:
@@ -67,6 +68,8 @@ static float GetSelectivityThresholdForType(SelectivityOptionalFilterType type) 
 		return BF_THRESHOLD;
 	case SelectivityOptionalFilterType::PHJ:
 		return PHJ_THRESHOLD;
+	case SelectivityOptionalFilterType::PRF:
+		return PRF_THRESHOLD;
 	default:
 		throw NotImplementedException("GetSelectivityThresholdForType");
 	}
@@ -76,6 +79,7 @@ static idx_t GetCheckNForType(SelectivityOptionalFilterType type) {
 	static constexpr idx_t MIN_MAX_CHECK_N = 6;
 	static constexpr idx_t BF_CHECK_N = 6;
 	static constexpr idx_t PHJ_CHECK_N = 6;
+	static constexpr idx_t PRF_CHECK_N = 6;
 
 	switch (type) {
 	case SelectivityOptionalFilterType::MIN_MAX:
@@ -84,6 +88,8 @@ static idx_t GetCheckNForType(SelectivityOptionalFilterType type) {
 		return BF_CHECK_N;
 	case SelectivityOptionalFilterType::PHJ:
 		return PHJ_CHECK_N;
+	case SelectivityOptionalFilterType::PRF:
+		return PRF_CHECK_N;
 	default:
 		throw NotImplementedException("GetCheckNForType");
 	}

--- a/src/planner/table_filter_state.cpp
+++ b/src/planner/table_filter_state.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/selectivity_optional_filter.hpp"
 #include "duckdb/planner/filter/struct_filter.hpp"
+#include "duckdb/planner/table_filter.hpp"
 
 namespace duckdb {
 
@@ -51,6 +52,7 @@ unique_ptr<TableFilterState> TableFilterState::Initialize(ClientContext &context
 	case TableFilterType::IS_NULL:
 	case TableFilterType::IS_NOT_NULL:
 	case TableFilterType::PERFECT_HASH_JOIN_FILTER:
+	case TableFilterType::PREFIX_RANGE_FILTER:
 		// root nodes - create an empty filter state
 		return make_uniq<TableFilterState>();
 	default:

--- a/src/storage/compression/numeric_constant.cpp
+++ b/src/storage/compression/numeric_constant.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/function/compression/compression.hpp"
 #include "duckdb/function/compression_function.hpp"
 #include "duckdb/planner/filter/bloom_filter.hpp"
+#include "duckdb/planner/filter/prefix_range_filter.hpp"
+#include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/segment/uncompressed.hpp"
 #include "duckdb/storage/table/column_segment.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
@@ -173,6 +175,11 @@ void ConstantFun::FiltersNullValues(const LogicalType &type, const TableFilter &
 	}
 	case TableFilterType::PERFECT_HASH_JOIN_FILTER: {
 		filters_nulls = true;
+		break;
+	}
+	case duckdb::TableFilterType::PREFIX_RANGE_FILTER: {
+		auto &prf = filter.Cast<PrefixRangeTableFilter>();
+		filters_nulls = prf.FiltersNullValues();
 		break;
 	}
 	default:

--- a/src/storage/compression/numeric_constant.cpp
+++ b/src/storage/compression/numeric_constant.cpp
@@ -173,13 +173,9 @@ void ConstantFun::FiltersNullValues(const LogicalType &type, const TableFilter &
 		filters_nulls = bf.FiltersNullValues();
 		break;
 	}
-	case TableFilterType::PERFECT_HASH_JOIN_FILTER: {
+	case TableFilterType::PERFECT_HASH_JOIN_FILTER:
+	case TableFilterType::PREFIX_RANGE_FILTER: {
 		filters_nulls = true;
-		break;
-	}
-	case duckdb::TableFilterType::PREFIX_RANGE_FILTER: {
-		auto &prf = filter.Cast<PrefixRangeTableFilter>();
-		filters_nulls = prf.FiltersNullValues();
 		break;
 	}
 	default:

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -6,7 +6,9 @@
 #include "duckdb/main/config.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/prefix_range_filter.hpp"
 #include "duckdb/planner/filter/struct_filter.hpp"
+#include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/data_pointer.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
@@ -564,6 +566,10 @@ idx_t ColumnSegment::FilterSelection(SelectionVector &sel, Vector &vector, Unifi
 	case TableFilterType::PERFECT_HASH_JOIN_FILTER: {
 		auto &perfect_hash_join_filter = filter.Cast<PerfectHashJoinFilter>();
 		return perfect_hash_join_filter.Filter(vector, sel, approved_tuple_count);
+	}
+	case duckdb::TableFilterType::PREFIX_RANGE_FILTER: {
+		auto &prefix_range_filter = filter.Cast<PrefixRangeTableFilter>();
+		return prefix_range_filter.Filter(vector, sel, approved_tuple_count);
 	}
 	case TableFilterType::EXPRESSION_FILTER: {
 		auto &state = filter_state.Cast<ExpressionFilterState>();

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown.test
@@ -29,6 +29,26 @@ JOIN build b
 analyzed_plan	<REGEX>:.*IN PRF\(k\).*
 
 statement ok
+CREATE OR REPLACE TABLE probe_timestamp AS
+SELECT make_timestamp(i * 1000) AS k, (i % 7)::INTEGER AS g
+FROM range(0, 100000) t(i);
+
+statement ok
+CREATE OR REPLACE TABLE build_timestamp AS
+SELECT make_timestamp(i * 2000) AS k, (i % 7)::INTEGER AS g
+FROM range(0, 30000) t(i);
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM probe_timestamp p
+JOIN build_timestamp b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<REGEX>:.*IN PRF\(k\).*
+
+statement ok
 CREATE OR REPLACE TABLE probe_hugeint AS
 SELECT i::HUGEINT AS k, (i % 7)::INTEGER AS g
 FROM range(0, 100000) t(i);

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown.test
@@ -1,0 +1,199 @@
+# name: test/sql/join/inner/test_prefix_range_filter_pushdown.test
+# description: Test prefix range filter join pushdown selection and correctness
+# group: [inner]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+SET disabled_optimizers = 'join_order,build_side_probe_side';
+
+statement ok
+CREATE OR REPLACE TABLE probe AS
+SELECT i::BIGINT AS k, (i % 7)::INTEGER AS g
+FROM range(0, 100000) t(i);
+
+statement ok
+CREATE OR REPLACE TABLE build AS
+SELECT (i * 2)::BIGINT AS k, (i % 7)::INTEGER AS g
+FROM range(0, 30000) t(i);
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM probe p
+JOIN build b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<REGEX>:.*IN PRF\(k\).*
+
+statement ok
+CREATE OR REPLACE TABLE probe_hugeint AS
+SELECT i::HUGEINT AS k, (i % 7)::INTEGER AS g
+FROM range(0, 100000) t(i);
+
+statement ok
+CREATE OR REPLACE TABLE build_hugeint AS
+SELECT (i * 2)::HUGEINT AS k, (i % 7)::INTEGER AS g
+FROM range(0, 30000) t(i);
+
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM probe_hugeint p
+JOIN build_hugeint b
+  ON p.k = b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<!REGEX>:.*IN PRF\(k\).*
+
+# COMPARE_NOT_DISTINCT_FROM would be the path where filters_null_values could be false,
+# but join filter pushdown does not currently generate PRF filters for it.
+query II
+EXPLAIN ANALYZE
+SELECT count(*)
+FROM probe p
+JOIN build b
+  ON p.k IS NOT DISTINCT FROM b.k
+ AND p.g >= b.g;
+----
+analyzed_plan	<!REGEX>:.*IN PRF\(k\).*
+
+statement ok
+SET disabled_optimizers = '';
+
+foreach type TINYINT SMALLINT INTEGER BIGINT
+
+statement ok
+CREATE OR REPLACE TABLE prf_probe_small (
+	id INTEGER,
+	k ${type},
+	g ${type}
+);
+
+statement ok
+INSERT INTO prf_probe_small VALUES
+	(1, -3, 1),
+	(2, -1, 5),
+	(3, 0, 0),
+	(4, 2, 2),
+	(5, 7, 1),
+	(6, NULL, 4),
+	(7, 9, NULL),
+	(8, 11, 3),
+	(9, 12, 6);
+
+statement ok
+CREATE OR REPLACE TABLE prf_build_small (
+	k ${type},
+	g ${type},
+	payload INTEGER
+);
+
+statement ok
+INSERT INTO prf_build_small VALUES
+	(-3, 0, 100),
+	(-1, 4, 101),
+	(-1, 6, 102),
+	(0, 0, 103),
+	(2, 3, 104),
+	(7, 1, 105),
+	(11, 4, 106),
+	(11, 2, 107),
+	(NULL, 0, 108),
+	(12, NULL, 109);
+
+query IIII
+SELECT p.id, p.k, p.g, b.payload
+FROM prf_probe_small p
+JOIN prf_build_small b
+  ON p.k = b.k
+ AND p.g >= b.g
+ORDER BY ALL;
+----
+1	-3	1	100
+2	-1	5	101
+3	0	0	103
+5	7	1	105
+8	11	3	107
+
+statement ok
+SET disabled_optimizers = 'join_filter_pushdown';
+
+query IIII
+SELECT p.id, p.k, p.g, b.payload
+FROM prf_probe_small p
+JOIN prf_build_small b
+  ON p.k = b.k
+ AND p.g >= b.g
+ORDER BY ALL;
+----
+1	-3	1	100
+2	-1	5	101
+3	0	0	103
+5	7	1	105
+8	11	3	107
+
+statement ok
+SET disabled_optimizers = '';
+
+endloop
+
+statement ok
+CREATE OR REPLACE TABLE prf_probe_span (
+	id INTEGER,
+	k BIGINT,
+	g INTEGER
+);
+
+statement ok
+INSERT INTO prf_probe_span VALUES
+	(1, 0, 0),
+	(2, 1, 0),
+	(3, 1048576, 5),
+	(4, 1048577, 5),
+	(5, 2097152, 2),
+	(6, 3145728, 9);
+
+statement ok
+CREATE OR REPLACE TABLE prf_build_span (
+	k BIGINT,
+	g INTEGER,
+	payload INTEGER
+);
+
+statement ok
+INSERT INTO prf_build_span VALUES
+	(0, 0, 10),
+	(1048576, 3, 11),
+	(2097152, 4, 12),
+	(3145728, 10, 13);
+
+query IIII
+SELECT p.id, p.k, p.g, b.payload
+FROM prf_probe_span p
+JOIN prf_build_span b
+  ON p.k = b.k
+ AND p.g >= b.g
+ORDER BY ALL;
+----
+1	0	0	10
+3	1048576	5	11
+
+statement ok
+SET disabled_optimizers = 'join_filter_pushdown';
+
+query IIII
+SELECT p.id, p.k, p.g, b.payload
+FROM prf_probe_span p
+JOIN prf_build_span b
+  ON p.k = b.k
+ AND p.g >= b.g
+ORDER BY ALL;
+----
+1	0	0	10
+3	1048576	5	11
+
+statement ok
+SET disabled_optimizers = '';

--- a/test/sql/join/inner/test_prefix_range_filter_pushdown.test
+++ b/test/sql/join/inner/test_prefix_range_filter_pushdown.test
@@ -29,6 +29,31 @@ JOIN build b
 analyzed_plan	<REGEX>:.*IN PRF\(k\).*
 
 statement ok
+SELECT count(*)
+FROM probe p
+JOIN build b
+  ON p.k = b.k
+ AND p.g >= b.g;
+
+statement ok
+CREATE OR REPLACE TABLE probe_with_null AS
+SELECT i::BIGINT AS k, (i % 7)::INTEGER AS g
+FROM range(0, 20480) t(i)
+UNION ALL
+SELECT NULL::BIGINT as k, (i % 7)::INTEGER AS g
+FROM range(20480, 24576) t2(i)
+UNION ALL
+SELECT i::BIGINT AS k, (i % 7)::INTEGER AS g
+FROM range(24576, 100000) t3(i)
+
+statement ok
+SELECT count(*)
+FROM probe_with_null p
+JOIN build b
+  ON p.k = b.k
+ AND p.g >= b.g;
+
+statement ok
 CREATE OR REPLACE TABLE probe_timestamp AS
 SELECT make_timestamp(i * 1000) AS k, (i % 7)::INTEGER AS g
 FROM range(0, 100000) t(i);


### PR DESCRIPTION
This PR introduces the **Prefix Range Filter** as an alternative for bloom filter pushdown in joins. As its name implies, the prefix range filter is range-based instead of hash-based - essentially it is an equi-width bitmap histogram based on the join key bit prefixes. It allows probabilistic filtering just like bloom filters (i.e., only false-positives, no false negatives) and is even quite a bit faster to ingest/probe.

## Why?

Range- and value-based summaries allow for row group pruning with min/max statistics in join filter pushdown, whereas hash-based summaries can't. Especially with remote Parquet files, this can make a huge performance difference. I have included an illustrative micro-benchmark on a local duckdb database file, which shows a 10x improvement on my MacBook. This is to be taken with a grain of salt of course, because the speedup simply comes from "more pruning = less computing" and less computing is of course always faster.

DuckDB already has this kind of pruning with the Perfect Hash Join (= exact version of the prefix range filter) pushdown, but that is limited by the join key value range, build size, and does not trigger for many-to-many joins. Finally, in real-world data, join columns are far more often clustered and/or correlated than in academic benchmarks. This makes range-based summaries more likely to be effective. This also shows in the benchmarks, which show some improvements in JOB but not so much in TPC-H.

## Limitations

At the moment, the prefix range filter is only built conservatively in one of these two cases:
- The join key range is smaller than the max filter size (`2^20` bits). In this case, the prefix range filter is exact.
- The build side is smaller than half the max filter size. In that case, at least half of the bits are unset, even if there is no join key clustering on the build sides.

## TODOs

For the future, there is also definitely still quite a lot of work, e.g.,
- Some form of build side cluster detection and, in general, a more informed decision making when to build min/max, PRF, bloom, ...
- Joins with multiple keys
- Data type support (hugeint, string, ...)
- Filter Sizing (currently fixed to `2^20 bits` if key range is larger than `2^20`) 