### PR TITLE
Fix invalid JSON when casting from certain types

### DIFF
--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -235,7 +235,7 @@ struct CreateJSONValue<uhugeint_t, string_t> {
 };
 
 template <class T>
-inline yyjson_mut_val *CreateJSONValueFromJSON(yyjson_mut_doc *doc, const T &value) {
+static inline yyjson_mut_val *CreateJSONValueFromJSON(yyjson_mut_doc *doc, const T &value) {
 	return nullptr; // This function should only be called with string_t as template
 }
 
@@ -578,7 +578,8 @@ static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_m
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP_SEC:
-	case LogicalTypeId::UUID: {
+	case LogicalTypeId::UUID:
+	case LogicalTypeId::GEOMETRY: {
 		Vector string_vector(LogicalTypeId::VARCHAR, count);
 		VectorOperations::DefaultCast(value_v, string_vector, count);
 		TemplatedCreateValues<string_t, string_t>(doc, vals, string_vector, count);
@@ -616,7 +617,6 @@ static void CreateValues(const StructNames &names, yyjson_mut_doc *doc, yyjson_m
 	case LogicalTypeId::VALIDITY:
 	case LogicalTypeId::TABLE:
 	case LogicalTypeId::LAMBDA:
-	case LogicalTypeId::GEOMETRY: // TODO! Add support for GEOMETRY
 		throw InternalException("Unsupported type arrived at JSON create function");
 	}
 }
@@ -789,7 +789,7 @@ static bool AnyToJSONCast(Vector &source, Vector &result, idx_t count, CastParam
 	return true;
 }
 
-BoundCastInfo AnyToJSONCastBind(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
+static BoundCastInfo AnyToJSONCastBind(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
 	auto cast_data = make_uniq<NestedToJSONCastData>();
 	GetJSONType(cast_data->const_struct_names, source);
 	return BoundCastInfo(AnyToJSONCast, std::move(cast_data), JSONFunctionLocalState::InitCastLocalState);

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -765,7 +765,7 @@ static bool TransformObjectToMap(yyjson_val *objects[], yyjson_alc *alc, Vector 
 	return success;
 }
 
-bool TransformToJSON(yyjson_val *vals[], yyjson_alc *alc, Vector &result, const idx_t count) {
+static bool TransformToJSON(yyjson_val *vals[], yyjson_alc *alc, Vector &result, const idx_t count) {
 	auto data = FlatVector::GetData<string_t>(result);
 	auto &validity = FlatVector::Validity(result);
 	for (idx_t i = 0; i < count; i++) {
@@ -780,8 +780,8 @@ bool TransformToJSON(yyjson_val *vals[], yyjson_alc *alc, Vector &result, const 
 	return true;
 }
 
-bool TransformValueIntoUnion(yyjson_val **vals, yyjson_alc *alc, Vector &result, const idx_t count,
-                             JSONTransformOptions &options) {
+static bool TransformValueIntoUnion(yyjson_val **vals, yyjson_alc *alc, Vector &result, const idx_t count,
+                                    JSONTransformOptions &options) {
 	auto type = result.GetType();
 
 	auto fields = UnionType::CopyMemberTypes(type);
@@ -923,6 +923,7 @@ bool JSONTransform::Transform(yyjson_val *vals[], yyjson_alc *alc, Vector &resul
 	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP_SEC:
 	case LogicalTypeId::UUID:
+	case LogicalTypeId::GEOMETRY:
 		return TransformFromString(vals, result, count, options);
 	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::BLOB:
@@ -1024,7 +1025,7 @@ static bool JSONToAnyCast(Vector &source, Vector &result, idx_t count, CastParam
 	return success;
 }
 
-BoundCastInfo JSONToAnyCastBind(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
+static BoundCastInfo JSONToAnyCastBind(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
 	return BoundCastInfo(JSONToAnyCast, nullptr, JSONFunctionLocalState::InitCastLocalState);
 }
 

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -248,14 +248,20 @@ const vector<LogicalType> LogicalType::Real() {
 
 const vector<LogicalType> LogicalType::AllTypes() {
 	vector<LogicalType> types = {
-	    LogicalType::BOOLEAN,  LogicalType::TINYINT,      LogicalType::SMALLINT,  LogicalType::INTEGER,
-	    LogicalType::BIGINT,   LogicalType::DATE,         LogicalType::TIMESTAMP, LogicalType::DOUBLE,
-	    LogicalType::FLOAT,    LogicalType::VARCHAR,      LogicalType::BLOB,      LogicalType::BIT,
-	    LogicalType::BIGNUM,   LogicalType::INTERVAL,     LogicalType::HUGEINT,   LogicalTypeId::DECIMAL,
-	    LogicalType::UTINYINT, LogicalType::USMALLINT,    LogicalType::UINTEGER,  LogicalType::UBIGINT,
-	    LogicalType::UHUGEINT, LogicalType::TIME,         LogicalTypeId::LIST,    LogicalTypeId::STRUCT,
-	    LogicalType::TIME_TZ,  LogicalType::TIMESTAMP_TZ, LogicalTypeId::MAP,     LogicalTypeId::UNION,
-	    LogicalType::UUID,     LogicalTypeId::ARRAY};
+	    LogicalTypeId::BOOLEAN,   LogicalTypeId::TINYINT,       LogicalTypeId::SMALLINT,
+	    LogicalTypeId::INTEGER,   LogicalTypeId::BIGINT,        LogicalTypeId::DATE,
+	    LogicalTypeId::TIME,      LogicalTypeId::TIMESTAMP_SEC, LogicalTypeId::TIMESTAMP_MS,
+	    LogicalTypeId::TIMESTAMP, LogicalTypeId::TIMESTAMP_NS,  LogicalTypeId::DECIMAL,
+	    LogicalTypeId::FLOAT,     LogicalTypeId::DOUBLE,        LogicalTypeId::CHAR,
+	    LogicalTypeId::VARCHAR,   LogicalTypeId::BLOB,          LogicalTypeId::INTERVAL,
+	    LogicalTypeId::UTINYINT,  LogicalTypeId::USMALLINT,     LogicalTypeId::UINTEGER,
+	    LogicalTypeId::UBIGINT,   LogicalTypeId::TIMESTAMP_TZ,  LogicalTypeId::TIME_TZ,
+	    LogicalTypeId::TIME_NS,   LogicalTypeId::BIT,           LogicalTypeId::BIGNUM,
+	    LogicalTypeId::UHUGEINT,  LogicalTypeId::HUGEINT,       LogicalTypeId::UUID,
+	    LogicalTypeId::GEOMETRY,  LogicalTypeId::STRUCT,        LogicalTypeId::LIST,
+	    LogicalTypeId::MAP,       LogicalTypeId::ENUM,          LogicalTypeId::UNION,
+	    LogicalTypeId::ARRAY,     LogicalTypeId::VARIANT,
+	};
 	return types;
 }
 
@@ -1129,7 +1135,7 @@ static bool CombineEqualTypes(const LogicalType &left, const LogicalType &right,
 }
 
 template <class OP>
-bool TryGetMaxLogicalTypeInternal(const LogicalType &left, const LogicalType &right, LogicalType &result) {
+static bool TryGetMaxLogicalTypeInternal(const LogicalType &left, const LogicalType &right, LogicalType &result) {
 	// we always prefer aliased types
 	if (!left.GetAlias().empty()) {
 		result = left;

--- a/src/function/cast/cast_function_set.cpp
+++ b/src/function/cast/cast_function_set.cpp
@@ -111,6 +111,8 @@ static auto RelaxedTypeMatch(type_map_t<MAP_VALUE_TYPE> &map, const LogicalType 
 		return map.find(LogicalType::ARRAY(LogicalType::ANY, optional_idx()));
 	case LogicalTypeId::DECIMAL:
 		return map.find(LogicalTypeId::DECIMAL);
+	case LogicalTypeId::ENUM:
+		return map.find(LogicalTypeId::ENUM);
 	default:
 		return map.find(LogicalType::ANY);
 	}

--- a/src/function/cast/enum_casts.cpp
+++ b/src/function/cast/enum_casts.cpp
@@ -114,8 +114,8 @@ static bool EnumToAnyCast(Vector &source, Vector &result, idx_t count, CastParam
 
 BoundCastInfo DefaultCasts::EnumCastSwitch(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
 	auto enum_physical_type = source.InternalType();
-	switch (target.id()) {
-	case LogicalTypeId::ENUM: {
+
+	if (target.id() == LogicalTypeId::ENUM) {
 		// This means they are both ENUMs, but of different types.
 		switch (enum_physical_type) {
 		case PhysicalType::UINT8:
@@ -128,7 +128,7 @@ BoundCastInfo DefaultCasts::EnumCastSwitch(BindCastInput &input, const LogicalTy
 			throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
 		}
 	}
-	case LogicalTypeId::VARCHAR:
+	if (target == LogicalType::VARCHAR) {
 		switch (enum_physical_type) {
 		case PhysicalType::UINT8:
 			return EnumToVarcharCast<uint8_t>;
@@ -139,10 +139,9 @@ BoundCastInfo DefaultCasts::EnumCastSwitch(BindCastInput &input, const LogicalTy
 		default:
 			throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
 		}
-	default: {
-		return BoundCastInfo(EnumToAnyCast, BindEnumCast(input, source, target), InitEnumCastLocalState);
 	}
-	}
+	// Otherwise, fall back to ANY cast
+	return BoundCastInfo(EnumToAnyCast, BindEnumCast(input, source, target), InitEnumCastLocalState);
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -29,8 +29,8 @@ BoundCastExpression::BoundCastExpression(ClientContext &context, unique_ptr<Expr
       bound_cast(BindCastFunction(context, child->return_type, return_type)) {
 }
 
-unique_ptr<Expression> AddCastExpressionInternal(unique_ptr<Expression> expr, const LogicalType &target_type,
-                                                 BoundCastInfo bound_cast, bool try_cast) {
+static unique_ptr<Expression> AddCastExpressionInternal(unique_ptr<Expression> expr, const LogicalType &target_type,
+                                                        BoundCastInfo bound_cast, bool try_cast) {
 	if (ExpressionBinder::GetExpressionReturnType(*expr) == target_type) {
 		return expr;
 	}
@@ -47,9 +47,9 @@ unique_ptr<Expression> AddCastExpressionInternal(unique_ptr<Expression> expr, co
 	return std::move(result);
 }
 
-unique_ptr<Expression> AddCastToTypeInternal(unique_ptr<Expression> expr, const LogicalType &target_type,
-                                             CastFunctionSet &cast_functions, GetCastFunctionInput &get_input,
-                                             bool try_cast) {
+static unique_ptr<Expression> AddCastToTypeInternal(unique_ptr<Expression> expr, const LogicalType &target_type,
+                                                    CastFunctionSet &cast_functions, GetCastFunctionInput &get_input,
+                                                    bool try_cast) {
 	D_ASSERT(expr);
 	if (expr->GetExpressionClass() == ExpressionClass::BOUND_PARAMETER) {
 		auto &parameter = expr->Cast<BoundParameterExpression>();

--- a/test/sql/json/test_json_cast.test
+++ b/test/sql/json/test_json_cast.test
@@ -1,0 +1,208 @@
+# name: test/sql/json/test_json_cast.test
+# group: [json]
+
+require json
+
+# Types that cannot roundtrip through JSON
+statement error
+SELECT '1010'::BIT(4)::JSON::BIT(4)
+----
+Not implemented Error: Cannot read a value of type BIT from a json file
+
+statement error
+SELECT 1::BIGNUM::JSON::BIGNUM
+----
+Not implemented Error: Cannot read a value of type BIGNUM from a json file
+
+# Regular types
+query I
+SELECT true::BOOLEAN::JSON::BOOLEAN
+----
+true
+
+query I
+SELECT 1::TINYINT::JSON::TINYINT
+----
+1
+
+query I
+SELECT 1::SMALLINT::JSON::SMALLINT
+----
+1
+
+query I
+SELECT 1::INTEGER::JSON::INTEGER
+----
+1
+
+query I
+SELECT 1::BIGINT::JSON::BIGINT
+----
+1
+
+query I
+SELECT date '2024-01-01'::DATE::JSON::DATE
+----
+2024-01-01
+
+query I
+SELECT time '12:34:56'::TIME::JSON::TIME
+----
+12:34:56
+
+query I
+SELECT '2024-06-01 00:00:00'::TIMESTAMP_S::JSON::TIMESTAMP_S
+----
+2024-06-01 00:00:00
+
+query I
+SELECT '2024-06-01 00:00:00'::TIMESTAMP_MS::JSON::TIMESTAMP_MS
+----
+2024-06-01 00:00:00
+
+query I
+SELECT '2024-06-01 00:00:00'::TIMESTAMP::JSON::TIMESTAMP
+----
+2024-06-01 00:00:00
+
+query I
+SELECT '2024-06-01 00:00:00'::TIMESTAMP_NS::JSON::TIMESTAMP_NS
+----
+2024-06-01 00:00:00
+
+query I
+SELECT 1::DECIMAL(10, 2)::JSON::DECIMAL(10, 2)
+----
+1.00
+
+query I
+SELECT 1::FLOAT::JSON::FLOAT
+----
+1.0
+
+query I
+SELECT 1::DOUBLE::JSON::DOUBLE
+----
+1.0
+
+query I
+SELECT '"text"'::CHAR::JSON::CHAR
+----
+"text"
+
+query I
+SELECT '"text"'::VARCHAR::JSON::VARCHAR
+----
+"text"
+
+query I
+SELECT 'blob'::BLOB::JSON::BLOB
+----
+blob
+
+query I
+SELECT INTERVAL '1 day'::INTERVAL::JSON::INTERVAL
+----
+1 day
+
+query I
+SELECT 1::UTINYINT::JSON::UTINYINT
+----
+1
+
+query I
+SELECT 1::USMALLINT::JSON::USMALLINT
+----
+1
+
+query I
+SELECT 1::UINTEGER::JSON::UINTEGER
+----
+1
+
+query I
+SELECT 1::UBIGINT::JSON::UBIGINT
+----
+1
+
+query I
+SELECT '2024-06-01 00:00:00+00'::TIMESTAMPTZ::JSON::TIMESTAMPTZ
+----
+2024-06-01 00:00:00+00
+
+# TimeTZ
+query I
+SELECT '00:00:00+00'::TIMETZ::JSON::TIMETZ
+----
+00:00:00+00
+
+# TimeNS
+query I
+SELECT '00:00:00'::TIME_NS::JSON::TIME_NS
+----
+00:00:00
+
+query I
+SELECT 1::UHUGEINT::JSON::UHUGEINT
+----
+1
+
+query I
+SELECT 1::HUGEINT::JSON::HUGEINT
+----
+1
+
+query I
+SELECT '00000000-0000-0000-0000-000000000001'::UUID::JSON::UUID
+----
+00000000-0000-0000-0000-000000000001
+
+query I
+SELECT 'POINT(0 1)'::GEOMETRY::JSON::GEOMETRY
+----
+POINT (0 1)
+
+query I
+SELECT {'a': 1}::JSON::STRUCT(a INTEGER)
+----
+{'a': 1}
+
+query I
+SELECT [1]::JSON::INTEGER[]
+----
+[1]
+
+query I
+SELECT map(ARRAY[1], ARRAY['one'])::JSON::MAP(INTEGER, VARCHAR)
+----
+{1=one}
+
+
+# Enums need to be converted to valid JSON too
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+
+query I
+SELECT 'sad'::mood::JSON
+----
+"sad"
+
+query I
+SELECT 'sad'::mood::JSON::mood;
+----
+sad
+
+query I
+SELECT 1::UNION(a INTEGER, b VARCHAR)::JSON::UNION(a INTEGER, b VARCHAR)
+----
+1
+
+query I
+SELECT [1]::INT[1]::JSON::INT[1]
+----
+[1]
+
+query I
+SELECT 'foo'::VARIANT::JSON::VARIANT
+----
+foo


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/7734

The `json` extensions use the `LogicalType::AllTypes()` set to get a list of all built-in types and registers cast to/from JSON for these. As far as I can tell even thought this list is in core it is only used by the `json` extension. It seems like this list has not been updated with new types for a while, which causes a lot of types to not get a dedicated JSON cast registered and instead go through TYPE->VARCHAR->JSON, which does not guarantee valid JSON (e.g. the VARCHAR can be unquoted).

This PR updates this lists, and also moves around some entries in the json cast switch (e.g. GEOMETRY) to use the correct conversion function.

Additionally this PR also slightly changes the logic for `ENUM` casts by implementing the "RelaxedTypeMatch" in the custom-cast set to also handle incomplete enums. Without this change the cast function for enums registered in the json extension would never be selected, causing enums to fall-back to VARCHAR casts and produce invalid (unquoted) JSON.