### PR TITLE
Fix Row Group Reorderer Bug

### DIFF
--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -153,12 +153,15 @@ OffsetPruningResult FindOffsetPrunableChunks(It it, End end, const OrderByStatis
 				break;
 			}
 			// Row groups do not overlap
-			auto &current_stats = it->second.stats;
-			if (!current_stats->CanHaveNull()) {
-				// This row group has exactly row_group.count valid values. We can exclude those
-				pruned_row_group_count++;
-				new_row_offset -= last_unresolved_entry->second.count;
+			auto &pruned_stats = last_unresolved_entry->second.stats;
+			if (pruned_stats->CanHaveNull()) {
+				// Offset pruning can only remove a contiguous prefix of row groups. Once the first unresolved
+				// row group might still contribute NULLs to the ordered prefix, we cannot prune past it.
+				return {new_row_offset, pruned_row_group_count};
 			}
+			// This row group has exactly row_group.count valid values. We can exclude those.
+			pruned_row_group_count++;
+			new_row_offset -= last_unresolved_entry->second.count;
 
 			++last_unresolved_entry;
 			auto &upcoming_stats = *last_unresolved_entry->second.stats;

--- a/test/sql/topn/test_top_n_nulls_row_group_pruner.test
+++ b/test/sql/topn/test_top_n_nulls_row_group_pruner.test
@@ -5,11 +5,15 @@
 statement ok
 PRAGMA enable_verification
 
+load __TEST_DIR__/top_n_nulls_row_group_pruner.duckdb
+
 statement ok
 CREATE TABLE integers AS
 SELECT NULL::BIGINT AS i FROM range(122881)
 UNION ALL
 SELECT range::BIGINT AS i FROM range(122880)
+
+restart
 
 query I
 SELECT i FROM integers ORDER BY i NULLS LAST LIMIT 1 OFFSET 122880;

--- a/test/sql/topn/test_top_n_nulls_row_group_pruner.test
+++ b/test/sql/topn/test_top_n_nulls_row_group_pruner.test
@@ -1,0 +1,17 @@
+# name: test/sql/topn/test_top_n_nulls_row_group_pruner.test
+# description: Test row group pruning with NULLS LAST and offset across mixed row groups
+# group: [topn]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers AS
+SELECT NULL::BIGINT AS i FROM range(122881)
+UNION ALL
+SELECT range::BIGINT AS i FROM range(122880)
+
+query I
+SELECT i FROM integers ORDER BY i NULLS LAST LIMIT 1 OFFSET 122880;
+----
+NULL


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/8247

This PR fixes a bug in the `FindOffsetPrunableChunks` algorithm which would set row groups containing nulls AND values as prunable.