### PR TITLE
Revert #21067 - and fix WAL corruption issue through calling `MarkBlockAsCheckpointed` on WAL blocks

### DIFF
--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -55,7 +55,7 @@ public:
 	//! Returns whether or not a specified block is the root block
 	virtual bool IsRootBlock(MetaBlockPointer root) = 0;
 	//! Mark a block as included in the next checkpoint
-	virtual void MarkBlockACheckpointed(block_id_t block_id) = 0;
+	virtual void MarkBlockAsCheckpointed(block_id_t block_id) = 0;
 	//! Mark a block as "used"; either the block is removed from the free list, or the reference count is incremented
 	virtual void MarkBlockAsUsed(block_id_t block_id) = 0;
 	//! Mark a block as "modified"; modified blocks are added to the free list after a checkpoint (i.e. their data is

--- a/src/include/duckdb/storage/in_memory_block_manager.hpp
+++ b/src/include/duckdb/storage/in_memory_block_manager.hpp
@@ -38,8 +38,8 @@ public:
 	bool IsRootBlock(MetaBlockPointer root) override {
 		throw InternalException("Cannot perform IO in in-memory database - IsRootBlock!");
 	}
-	void MarkBlockACheckpointed(block_id_t block_id) override {
-		throw InternalException("Cannot perform IO in in-memory database - MarkBlockACheckpointed!");
+	void MarkBlockAsCheckpointed(block_id_t block_id) override {
+		throw InternalException("Cannot perform IO in in-memory database - MarkBlockAsCheckpointed!");
 	}
 	void MarkBlockAsUsed(block_id_t block_id) override {
 		throw InternalException("Cannot perform IO in in-memory database - MarkBlockAsUsed!");

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -83,7 +83,7 @@ public:
 	//! Returns whether or not a specified block is the root block
 	bool IsRootBlock(MetaBlockPointer root) override;
 	//! Mark a block as included in a checkpoint
-	void MarkBlockACheckpointed(block_id_t block_id) override;
+	void MarkBlockAsCheckpointed(block_id_t block_id) override;
 	//! Mark a block as used (no longer re-writeable)
 	void MarkBlockAsUsed(block_id_t block_id) override;
 	//! Mark a block as modified (re-writeable after a checkpoint)

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -44,7 +44,6 @@ public:
 	virtual bool HasRowGroupData() {
 		return false;
 	}
-	virtual unordered_set<block_id_t> &GetBlockIdsInUse() = 0;
 };
 
 //! StorageManager is responsible for managing the physical storage of a persistent database.

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -405,6 +405,7 @@ struct PersistentCollectionData {
 	void Serialize(Serializer &serializer) const;
 	static PersistentCollectionData Deserialize(Deserializer &deserializer);
 	bool HasUpdates() const;
+	vector<block_id_t> GetBlockIds() const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -119,10 +119,6 @@ public:
 	void Flush();
 	//! Increment the WAL entry count, which is used for the auto-checkpoint threshold.
 	void IncrementWALEntriesCount();
-	//! Add a used block to the WAL.
-	void AddBlockInUse(const block_id_t block_id);
-	bool NewBlockInUse(const block_id_t block_id) const;
-	void MarkBlocksInUseAsModified();
 	void WriteCheckpoint(MetaBlockPointer meta_block);
 
 protected:

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -120,13 +120,8 @@ public:
 	//! Increment the WAL entry count, which is used for the auto-checkpoint threshold.
 	void IncrementWALEntriesCount();
 	//! Add a used block to the WAL.
-	void AddBlockInUse(const block_id_t block_id) {
-		D_ASSERT(blocks_in_use.count(block_id) == 0);
-		blocks_in_use.insert(block_id);
-	}
-	bool NewBlockInUse(const block_id_t block_id) const {
-		return blocks_in_use.count(block_id) == 0;
-	}
+	void AddBlockInUse(const block_id_t block_id);
+	bool NewBlockInUse(const block_id_t block_id) const;
 	void MarkBlocksInUseAsModified();
 	void WriteCheckpoint(MetaBlockPointer meta_block);
 
@@ -143,9 +138,6 @@ protected:
 	string wal_path;
 	atomic<WALInitState> init_state;
 	optional_idx checkpoint_iteration;
-	// When we write optimistic pointers to the WAL, then we need to prevent these blocks from being
-	// re-used/overwritten, even if the data on them is no longer relevant (e.g., later DROP TABLE).
-	unordered_set<block_id_t> blocks_in_use;
 };
 
 } // namespace duckdb

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -616,6 +616,10 @@ public:
 		auto bitpacking_metadata_offset = Load<idx_t>(data_ptr + segment.GetBlockOffset());
 		bitpacking_metadata_ptr =
 		    data_ptr + segment.GetBlockOffset() + bitpacking_metadata_offset - sizeof(bitpacking_metadata_encoded_t);
+		if (bitpacking_metadata_ptr >= handle.Ptr() + current_segment.GetBlockSize()) {
+			throw InternalException("Bitpacking offset is out of range at block \"%llu\" - corrupt database file",
+			                        segment.block->BlockId());
+		}
 
 		// load the first group
 		LoadNextGroup();

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1167,13 +1167,6 @@ void DataTable::WriteToLog(DuckTransaction &transaction, WriteAheadLog &log, idx
 		    optimistic_count, count);
 	}
 
-	// Get all the blocks that need to be kept alive as long as the WAL is alive.
-	for (const auto &row_group_data : entry->row_group_data) {
-		for (const auto &column_data : row_group_data.column_data) {
-			GatherBlockIds(log, column_data, commit_state->GetBlockIdsInUse());
-		}
-	}
-
 	// Write any remaining (non-optimistically written) rows to the WAL.
 	row_start += optimistic_count;
 	count -= optimistic_count;

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1129,20 +1129,6 @@ void DataTable::MergeStorage(RowGroupCollection &data, optional_ptr<StorageCommi
 	row_groups->Verify();
 }
 
-static void GatherBlockIds(WriteAheadLog &log, const PersistentColumnData &column_data,
-                           unordered_set<block_id_t> &block_ids) {
-	for (const auto &pointer : column_data.pointers) {
-		const auto block_id = pointer.block_pointer.block_id;
-		if (block_id != INVALID_BLOCK && log.NewBlockInUse(block_id)) {
-			block_ids.insert(block_id);
-		}
-	}
-	// Recurse into the children.
-	for (const auto &child_column_data : column_data.child_columns) {
-		GatherBlockIds(log, child_column_data, block_ids);
-	}
-}
-
 void DataTable::WriteToLog(DuckTransaction &transaction, WriteAheadLog &log, idx_t row_start, idx_t count,
                            optional_ptr<StorageCommitState> commit_state) {
 	log.WriteSetTable(info->schema, info->table);

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -864,7 +864,7 @@ block_id_t SingleFileBlockManager::PeekFreeBlockId() {
 	}
 }
 
-void SingleFileBlockManager::MarkBlockACheckpointed(block_id_t block_id) {
+void SingleFileBlockManager::MarkBlockAsCheckpointed(block_id_t block_id) {
 	lock_guard<mutex> lock(single_file_block_lock);
 	D_ASSERT(block_id >= 0);
 	newly_used_blocks.erase(block_id);

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -1187,8 +1187,7 @@ vector<MetadataHandle> SingleFileBlockManager::GetFreeListBlocks() {
 			lock_guard<mutex> guard(single_file_block_lock);
 			free_list_count =
 			    free_list.size() + modified_blocks.size() + free_blocks_in_use.size() + newly_used_blocks.size();
-			multi_use_blocks_count =
-			    sizeof(uint64_t) + (sizeof(block_id_t) + sizeof(uint32_t)) * multi_use_blocks.size();
+			multi_use_blocks_count = multi_use_blocks.size();
 		}
 		auto free_list_size = sizeof(uint64_t) + sizeof(block_id_t) * free_list_count;
 		auto multi_use_blocks_size =

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -1181,11 +1181,18 @@ vector<MetadataHandle> SingleFileBlockManager::GetFreeListBlocks() {
 	auto block_size = metadata_manager.GetMetadataBlockSize() - sizeof(idx_t);
 	idx_t allocated_size = 0;
 	while (true) {
-		auto free_list_count =
-		    free_list.size() + modified_blocks.size() + free_blocks_in_use.size() + newly_used_blocks.size();
+		idx_t free_list_count;
+		idx_t multi_use_blocks_count;
+		{
+			lock_guard<mutex> guard(single_file_block_lock);
+			free_list_count =
+			    free_list.size() + modified_blocks.size() + free_blocks_in_use.size() + newly_used_blocks.size();
+			multi_use_blocks_count =
+			    sizeof(uint64_t) + (sizeof(block_id_t) + sizeof(uint32_t)) * multi_use_blocks.size();
+		}
 		auto free_list_size = sizeof(uint64_t) + sizeof(block_id_t) * free_list_count;
 		auto multi_use_blocks_size =
-		    sizeof(uint64_t) + (sizeof(block_id_t) + sizeof(uint32_t)) * multi_use_blocks.size();
+		    sizeof(uint64_t) + (sizeof(block_id_t) + sizeof(uint32_t)) * multi_use_blocks_count;
 		auto metadata_blocks =
 		    sizeof(uint64_t) + (sizeof(block_id_t) + sizeof(idx_t)) * GetMetadataManager().BlockCount();
 		auto total_size = free_list_size + multi_use_blocks_size + metadata_blocks;

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -231,9 +231,6 @@ bool StorageManager::WALStartCheckpoint(MetaBlockPointer meta_block, CheckpointO
 	wal->WriteCheckpoint(meta_block);
 	wal->Flush();
 
-	// We no longer need to hold on to the WAL blocks here. If the checkpoint fails, we throw a fatal exception and
-	// enter an inconsistent state. If it succeeds, then this WAL is no longer relevant.
-	wal->MarkBlocksInUseAsModified();
 	// close the main WAL
 	wal.reset();
 
@@ -576,7 +573,6 @@ public:
 	                     unique_ptr<PersistentCollectionData> row_group_data) override;
 	optional_ptr<PersistentCollectionData> GetRowGroupData(DataTable &table, idx_t start_index, idx_t &count) override;
 	bool HasRowGroupData() override;
-	unordered_set<block_id_t> &GetBlockIdsInUse() override;
 
 private:
 	idx_t initial_wal_size = 0;
@@ -584,7 +580,6 @@ private:
 	WriteAheadLog &wal;
 	WALCommitState state;
 	reference_map_t<DataTable, unordered_map<idx_t, OptimisticallyWrittenRowGroupData>> optimistically_written_data;
-	unordered_set<block_id_t> block_ids_in_use;
 };
 
 SingleFileStorageCommitState::SingleFileStorageCommitState(StorageManager &storage, WriteAheadLog &wal)
@@ -628,11 +623,6 @@ void SingleFileStorageCommitState::FlushCommit() {
 		return;
 	}
 	// Move the blocks in this COMMIT into the WAL and mark them as "in use".
-	auto &block_manager = wal.GetStorageManager().GetBlockManager();
-	for (const block_id_t block_id : block_ids_in_use) {
-		block_manager.MarkBlockAsUsed(block_id);
-		wal.AddBlockInUse(block_id);
-	}
 	wal.Flush();
 	state = WALCommitState::FLUSHED;
 }
@@ -671,10 +661,6 @@ optional_ptr<PersistentCollectionData> SingleFileStorageCommitState::GetRowGroup
 
 bool SingleFileStorageCommitState::HasRowGroupData() {
 	return !optimistically_written_data.empty();
-}
-
-unordered_set<block_id_t> &SingleFileStorageCommitState::GetBlockIdsInUse() {
-	return block_ids_in_use;
 }
 
 unique_ptr<StorageCommitState> SingleFileStorageManager::GenStorageCommitState(WriteAheadLog &wal) {

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -999,6 +999,32 @@ bool PersistentCollectionData::HasUpdates() const {
 	return false;
 }
 
+static void TraverseBlocksRecursive(const PersistentColumnData &col_data, vector<block_id_t> &result) {
+	for (auto &pointer : col_data.pointers) {
+		auto block_id = pointer.block_pointer.block_id;
+		if (block_id != INVALID_BLOCK) {
+			result.push_back(block_id);
+		}
+		if (pointer.segment_state) {
+			for (auto &block : pointer.segment_state->blocks) {
+				result.push_back(block);
+			}
+		}
+	}
+	for (auto &child_column : col_data.child_columns) {
+		TraverseBlocksRecursive(child_column, result);
+	}
+}
+vector<block_id_t> PersistentCollectionData::GetBlockIds() const {
+	vector<block_id_t> result;
+	for (auto &group : row_group_data) {
+		for (auto &col_data : group.column_data) {
+			TraverseBlocksRecursive(col_data, result);
+		}
+	}
+	return result;
+}
+
 void ExtraPersistentColumnData::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault(100, "type", type, ExtraPersistentColumnDataType::INVALID);
 	switch (GetType()) {

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -392,7 +392,7 @@ struct CheckpointBlockIdMarker : public BlockIdVisitor {
 	}
 
 	void Visit(block_id_t block_id) override {
-		manager.MarkBlockACheckpointed(block_id);
+		manager.MarkBlockAsCheckpointed(block_id);
 	}
 
 	BlockManager &manager;

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -1036,23 +1036,6 @@ void WriteAheadLogDeserializer::ReplayInsert() {
 	storage.LocalWALAppend(*state.current_table, context, chunk, bound_constraints);
 }
 
-static void MarkBlocksAsUsed(BlockManager &manager, const PersistentColumnData &col_data) {
-	for (auto &pointer : col_data.pointers) {
-		auto block_id = pointer.block_pointer.block_id;
-		if (block_id != INVALID_BLOCK) {
-			manager.MarkBlockAsUsed(block_id);
-		}
-		if (pointer.segment_state) {
-			for (auto &block : pointer.segment_state->blocks) {
-				manager.MarkBlockAsUsed(block);
-			}
-		}
-	}
-	for (auto &child_column : col_data.child_columns) {
-		MarkBlocksAsUsed(manager, child_column);
-	}
-}
-
 void WriteAheadLogDeserializer::ReplayRowGroupData() {
 	auto &block_manager = db.GetStorageManager().GetBlockManager();
 	PersistentCollectionData data;
@@ -1066,10 +1049,8 @@ void WriteAheadLogDeserializer::ReplayRowGroupData() {
 		// label blocks in data as used - they will be used after the WAL replay is finished
 		// we need to do this during the deserialization phase to ensure the blocks will not be overwritten
 		// by previous deserialization steps
-		for (auto &group : data.row_group_data) {
-			for (auto &col_data : group.column_data) {
-				MarkBlocksAsUsed(block_manager, col_data);
-			}
+		for (auto &block_id : data.GetBlockIds()) {
+			block_manager.MarkBlockAsUsed(block_id);
 		}
 		return;
 	}

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -480,6 +480,12 @@ void WriteAheadLog::WriteRowGroupData(const PersistentCollectionData &data) {
 	WriteAheadLogSerializer serializer(*this, WALType::ROW_GROUP_DATA);
 	serializer.WriteProperty(101, "row_group_data", data);
 	serializer.End();
+
+	// mark written blocks as checkpointed
+	auto &block_manager = GetDatabase().GetStorageManager().GetBlockManager();
+	for (auto &block_id : data.GetBlockIds()) {
+		block_manager.MarkBlockAsCheckpointed(block_id);
+	}
 }
 
 void WriteAheadLog::WriteDelete(DataChunk &chunk) {
@@ -549,13 +555,6 @@ void WriteAheadLog::Flush() {
 
 void WriteAheadLog::IncrementWALEntriesCount() {
 	storage_manager.IncrementWALEntriesCount();
-}
-
-void WriteAheadLog::MarkBlocksInUseAsModified() {
-	auto &block_manager = storage_manager.GetBlockManager();
-	for (const block_id_t block_id : blocks_in_use) {
-		block_manager.MarkBlockAsModified(block_id);
-	}
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Reverts #21067

The issue fixed in that PR is that we had references to blocks in the WAL that would be prematurely added to the `free_list` when a table was dropped. This issue was caused by the blocks being initially added to the `newly_used_blocks`, and then not being correctly labeled as being in-use in the storage. As a result, when the table was dropped, the system would erroneously think it was possible to re-add the blocks to the free list immediately. 

#21067 solved this by keeping track of all of the blocks written to the WAL, and then calling `MarkBlocksInUseAsModified` when a checkpoint was written, preventing the in-use blocks from being written to the free list. This seems to fix the issue - but (1) is rather complex, and (2) seems to create new bugs. For example, the usage count of blocks is [not always tracked correctly anymore after this change in concurrent scenarios](https://github.com/Mytherin/duckdb/actions/runs/22892009133/job/66417103226) resulting in blocks leaking.

The simpler fix to the issue is to call `MarkBlockAsCheckpointed` in `WriteRowGroupData`, which instructs the system that the blocks are no longer newly used and cannot just be freed when they are no longer referenced. The blocks will then go through the correct block id lifecycle (i.e. added to the free list after a checkpoint, and then re-used afterwards). 