### PR TITLE
Dont use constexpr for file flags

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -48,20 +48,23 @@ extern "C" WINBASEAPI BOOL WINAPI GetPhysicallyInstalledSystemMemory(PULONGLONG)
 
 namespace duckdb {
 
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_READ;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_WRITE;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_DIRECT_IO;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_FILE_CREATE;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_FILE_CREATE_NEW;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_APPEND;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_PRIVATE;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_EXISTS;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_DISABLE_LOGGING;
-constexpr FileOpenFlags FileFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL;
+const FileOpenFlags FileFlags::FILE_FLAGS_READ = FileOpenFlags(FileOpenFlags::FILE_FLAGS_READ);
+const FileOpenFlags FileFlags::FILE_FLAGS_WRITE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_WRITE);
+const FileOpenFlags FileFlags::FILE_FLAGS_DIRECT_IO = FileOpenFlags(FileOpenFlags::FILE_FLAGS_DIRECT_IO);
+const FileOpenFlags FileFlags::FILE_FLAGS_FILE_CREATE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_FILE_CREATE);
+const FileOpenFlags FileFlags::FILE_FLAGS_FILE_CREATE_NEW = FileOpenFlags(FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+const FileOpenFlags FileFlags::FILE_FLAGS_APPEND = FileOpenFlags(FileOpenFlags::FILE_FLAGS_APPEND);
+const FileOpenFlags FileFlags::FILE_FLAGS_PRIVATE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_PRIVATE);
+const FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS =
+    FileOpenFlags(FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
+const FileOpenFlags FileFlags::FILE_FLAGS_PARALLEL_ACCESS = FileOpenFlags(FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS);
+const FileOpenFlags FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_EXCLUSIVE_CREATE);
+const FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_EXISTS = FileOpenFlags(FileOpenFlags::FILE_FLAGS_NULL_IF_EXISTS);
+const FileOpenFlags FileFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS =
+    FileOpenFlags(FileOpenFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS);
+const FileOpenFlags FileFlags::FILE_FLAGS_DISABLE_LOGGING = FileOpenFlags(FileOpenFlags::FILE_FLAGS_DISABLE_LOGGING);
+const FileOpenFlags FileFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL =
+    FileOpenFlags(FileOpenFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL);
 
 void FileOpenFlags::Verify() {
 #ifdef DEBUG
@@ -102,7 +105,7 @@ FileSystem &FileSystem::GetFileSystem(ClientContext &context) {
 	return *client_data.client_file_system;
 }
 
-bool PathMatched(const string &path, const string &sub_path) {
+static bool PathMatched(const string &path, const string &sub_path) {
 	return path.rfind(sub_path, 0) == 0;
 }
 

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -9,7 +9,8 @@
 namespace duckdb {
 
 // Remove this when we switch C++17: https://stackoverflow.com/a/53350948
-constexpr FileOpenFlags BufferedFileWriter::DEFAULT_OPEN_FLAGS;
+const FileOpenFlags BufferedFileWriter::DEFAULT_OPEN_FLAGS =
+    FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE;
 
 BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, FileOpenFlags open_flags)
     : fs(fs), path(path_p), data(make_unsafe_uniq_array_uninitialized<data_t>(FILE_BUFFER_SIZE)), offset(0),

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -8,14 +8,14 @@
 
 namespace duckdb {
 
-// Remove this when we switch C++17: https://stackoverflow.com/a/53350948
-const FileOpenFlags BufferedFileWriter::DEFAULT_OPEN_FLAGS =
-    FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE;
-
 BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, FileOpenFlags open_flags)
     : fs(fs), path(path_p), data(make_unsafe_uniq_array_uninitialized<data_t>(FILE_BUFFER_SIZE)), offset(0),
       total_written(0) {
 	handle = fs.OpenFile(path, open_flags | FileLockType::WRITE_LOCK);
+}
+
+BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p)
+    : BufferedFileWriter(fs, path_p, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE) {
 }
 
 idx_t BufferedFileWriter::GetFileSize() {

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -146,40 +146,33 @@ private:
 class FileFlags {
 public:
 	//! Open file with read access
-	static constexpr FileOpenFlags FILE_FLAGS_READ = FileOpenFlags(FileOpenFlags::FILE_FLAGS_READ);
+	static const FileOpenFlags FILE_FLAGS_READ;
 	//! Open file with write access
-	static constexpr FileOpenFlags FILE_FLAGS_WRITE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_WRITE);
+	static const FileOpenFlags FILE_FLAGS_WRITE;
 	//! Use direct IO when reading/writing to the file
-	static constexpr FileOpenFlags FILE_FLAGS_DIRECT_IO = FileOpenFlags(FileOpenFlags::FILE_FLAGS_DIRECT_IO);
+	static const FileOpenFlags FILE_FLAGS_DIRECT_IO;
 	//! Create file if not exists, can only be used together with WRITE
-	static constexpr FileOpenFlags FILE_FLAGS_FILE_CREATE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_FILE_CREATE);
+	static const FileOpenFlags FILE_FLAGS_FILE_CREATE;
 	//! Always create a new file. If a file exists, the file is truncated. Cannot be used together with CREATE.
-	static constexpr FileOpenFlags FILE_FLAGS_FILE_CREATE_NEW =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	static const FileOpenFlags FILE_FLAGS_FILE_CREATE_NEW;
 	//! Open file in append mode
-	static constexpr FileOpenFlags FILE_FLAGS_APPEND = FileOpenFlags(FileOpenFlags::FILE_FLAGS_APPEND);
+	static const FileOpenFlags FILE_FLAGS_APPEND;
 	//! Open file with restrictive permissions (600 on linux/mac) can only be used when creating, throws if file exists
-	static constexpr FileOpenFlags FILE_FLAGS_PRIVATE = FileOpenFlags(FileOpenFlags::FILE_FLAGS_PRIVATE);
+	static const FileOpenFlags FILE_FLAGS_PRIVATE;
 	//! Return NULL if the file does not exist instead of throwing an error
-	static constexpr FileOpenFlags FILE_FLAGS_NULL_IF_NOT_EXISTS =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
+	static const FileOpenFlags FILE_FLAGS_NULL_IF_NOT_EXISTS;
 	//! Multiple threads may perform reads and writes in parallel
-	static constexpr FileOpenFlags FILE_FLAGS_PARALLEL_ACCESS =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS);
+	static const FileOpenFlags FILE_FLAGS_PARALLEL_ACCESS;
 	//! Ensure that this call creates the file, throw is file exists
-	static constexpr FileOpenFlags FILE_FLAGS_EXCLUSIVE_CREATE =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_EXCLUSIVE_CREATE);
+	static const FileOpenFlags FILE_FLAGS_EXCLUSIVE_CREATE;
 	//!  Return NULL if the file exist instead of throwing an error
-	static constexpr FileOpenFlags FILE_FLAGS_NULL_IF_EXISTS = FileOpenFlags(FileOpenFlags::FILE_FLAGS_NULL_IF_EXISTS);
+	static const FileOpenFlags FILE_FLAGS_NULL_IF_EXISTS;
 	//! Multiple clients may access the file at the same time
-	static constexpr FileOpenFlags FILE_FLAGS_MULTI_CLIENT_ACCESS =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS);
+	static const FileOpenFlags FILE_FLAGS_MULTI_CLIENT_ACCESS;
 	//! Disables logging to avoid infinite loops when using FileHandle-backed log storage
-	static constexpr FileOpenFlags FILE_FLAGS_DISABLE_LOGGING =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_DISABLE_LOGGING);
+	static const FileOpenFlags FILE_FLAGS_DISABLE_LOGGING;
 	//! Opened file is allowed to be a duckdb_extension
-	static constexpr FileOpenFlags FILE_FLAGS_ENABLE_EXTENSION_INSTALL =
-	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL);
+	static const FileOpenFlags FILE_FLAGS_ENABLE_EXTENSION_INSTALL;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 
 class BufferedFileWriter : public WriteStream {
 public:
-	static constexpr FileOpenFlags DEFAULT_OPEN_FLAGS = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE;
+	static const FileOpenFlags DEFAULT_OPEN_FLAGS;
 
 	//! Serializes to a buffer allocated by the serializer, will expand when
 	//! writing past the initial threshold

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -17,11 +17,10 @@ namespace duckdb {
 
 class BufferedFileWriter : public WriteStream {
 public:
-	static const FileOpenFlags DEFAULT_OPEN_FLAGS;
-
 	//! Serializes to a buffer allocated by the serializer, will expand when
 	//! writing past the initial threshold
-	DUCKDB_API BufferedFileWriter(FileSystem &fs, const string &path, FileOpenFlags open_flags = DEFAULT_OPEN_FLAGS);
+	DUCKDB_API BufferedFileWriter(FileSystem &fs, const string &path);
+	DUCKDB_API BufferedFileWriter(FileSystem &fs, const string &path, FileOpenFlags open_flags);
 
 	FileSystem &fs;
 	string path;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -987,8 +987,7 @@ void ClientContext::LogQueryInternal(ClientContextLock &, const string &query) {
 #ifdef DUCKDB_FORCE_QUERY_LOG
 		try {
 			string log_path(DUCKDB_FORCE_QUERY_LOG);
-			client_data->log_query_writer = make_uniq<BufferedFileWriter>(FileSystem::GetFileSystem(*this), log_path,
-			                                                              BufferedFileWriter::DEFAULT_OPEN_FLAGS);
+			client_data->log_query_writer = make_uniq<BufferedFileWriter>(FileSystem::GetFileSystem(*this), log_path);
 		} catch (...) {
 			return;
 		}

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1235,8 +1235,7 @@ void LogQueryPathSetting::OnSet(SettingCallbackInfo &info, Value &input) {
 		// empty path: clean up query writer
 		client_data.log_query_writer = nullptr;
 	} else {
-		client_data.log_query_writer = make_uniq<BufferedFileWriter>(FileSystem::GetFileSystem(*info.context), path,
-		                                                             BufferedFileWriter::DEFAULT_OPEN_FLAGS);
+		client_data.log_query_writer = make_uniq<BufferedFileWriter>(FileSystem::GetFileSystem(*info.context), path);
 	}
 }
 


### PR DESCRIPTION
This moves all definitions of the `FileFlag` constants into the `.cpp` file which should avoid accidental ODR violations when including the constexpr definitions in the header from other TU's. 

We should be able to solve this properly/move back to use constexpr once we move to C++17.