### PR TITLE
Fix Terminal::TryGetBackgroundColor when stdin is reading from a pipe but stdout is still writing to the terminal

### DIFF
--- a/tools/shell/linenoise/terminal.cpp
+++ b/tools/shell/linenoise/terminal.cpp
@@ -11,6 +11,7 @@
 #include <sys/time.h>
 #include <termios.h>
 #include <unistd.h>
+#include <fcntl.h>
 #endif
 #include <stdlib.h>
 #include <stdio.h>
@@ -18,7 +19,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include <sys/fcntl.h>
 
 namespace duckdb {
 

--- a/tools/shell/linenoise/terminal.cpp
+++ b/tools/shell/linenoise/terminal.cpp
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <sys/fcntl.h>
 
 namespace duckdb {
 
@@ -65,29 +66,8 @@ int Terminal::IsUnsupportedTerm() {
 	return 0;
 }
 
-/* Raw mode: 1960 magic shit. */
-int Terminal::EnableRawMode() {
-#if defined(_WIN32) || defined(WIN32)
-	if (console_in) {
-		// already in raw mode
-		return 0;
-	}
-	console_in = GetStdHandle(STD_INPUT_HANDLE);
-
-	GetConsoleMode(console_in, &old_mode);
-	auto new_mode = old_mode & ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
-	SetConsoleMode(console_in, new_mode);
-#else
-	int fd = STDIN_FILENO;
-
-	if (!isatty(STDIN_FILENO)) {
-		errno = ENOTTY;
-		return -1;
-	}
-	if (!atexit_registered) {
-		atexit(linenoiseAtExit);
-		atexit_registered = 1;
-	}
+#if !defined(_WIN32) && !defined(WIN32)
+int EnableRawModeInternal(int fd) {
 	if (tcgetattr(fd, &orig_termios) == -1) {
 		errno = ENOTTY;
 		return -1;
@@ -118,6 +98,42 @@ int Terminal::EnableRawMode() {
 		return -1;
 	}
 	rawmode = 1;
+	return 0;
+}
+
+void DisableRawModeInternal(int fd) {
+	/* Don't even check the return value as it's too late. */
+	if (rawmode && tcsetattr(fd, TCSADRAIN, &orig_termios) != -1) {
+		rawmode = 0;
+	}
+}
+
+#endif
+
+/* Raw mode: 1960 magic shit. */
+int Terminal::EnableRawMode() {
+#if defined(_WIN32) || defined(WIN32)
+	if (console_in) {
+		// already in raw mode
+		return 0;
+	}
+	console_in = GetStdHandle(STD_INPUT_HANDLE);
+
+	GetConsoleMode(console_in, &old_mode);
+	auto new_mode = old_mode & ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
+	SetConsoleMode(console_in, new_mode);
+#else
+	int fd = STDIN_FILENO;
+
+	if (!isatty(fd)) {
+		errno = ENOTTY;
+		return -1;
+	}
+	if (!atexit_registered) {
+		atexit(linenoiseAtExit);
+		atexit_registered = 1;
+	}
+	return EnableRawModeInternal(fd);
 #endif
 	return 0;
 }
@@ -132,10 +148,7 @@ void Terminal::DisableRawMode() {
 	}
 #else
 	int fd = STDIN_FILENO;
-	/* Don't even check the return value as it's too late. */
-	if (rawmode && tcsetattr(fd, TCSADRAIN, &orig_termios) != -1) {
-		rawmode = 0;
-	}
+	DisableRawModeInternal(fd);
 #endif
 }
 
@@ -239,7 +252,7 @@ int Terminal::HasMoreData(int fd, idx_t timeout_micros) {
 	struct timeval tv;
 	tv.tv_sec = static_cast<time_t>(timeout_micros / 1000000);
 	tv.tv_usec = static_cast<int>(timeout_micros % 1000000);
-	return select(1, &rfds, NULL, NULL, &tv);
+	return select(fd + 1, &rfds, NULL, NULL, &tv);
 #endif
 }
 
@@ -419,6 +432,9 @@ bool ParseTerminalColor(TerminalColor &color, const char *buf, idx_t buflen) {
 void Terminal::BufferAvailableInput() {
 	// consume available input and add it to the buffer
 	int ifd = STDIN_FILENO;
+	if (!isatty(ifd)) {
+		return;
+	}
 	while (HasMoreData(ifd)) {
 		char buf[1];
 		if (read(ifd, buf, 1) != 1) {
@@ -438,8 +454,20 @@ bool Terminal::TryGetBackgroundColor(TerminalColor &color) {
 #else
 	int ifd = STDIN_FILENO;
 	int ofd = STDOUT_FILENO;
+	if (!isatty(ifd)) {
+		// if stdin is not the terminal - we need to open stdin manually
+		ifd = open("/dev/tty", O_RDWR);
+		if (ifd < 0) {
+			// failed to open stdin
+			return false;
+		}
+		ofd = ifd;
+	}
 
-	if (Terminal::EnableRawMode() == -1) {
+	if (EnableRawModeInternal(ifd) == -1) {
+		if (ifd != STDIN_FILENO) {
+			close(ifd);
+		}
 		return false;
 	}
 
@@ -471,7 +499,10 @@ bool Terminal::TryGetBackgroundColor(TerminalColor &color) {
 
 		success = ParseTerminalColor(color, buf.c_str(), buf.size());
 	}
-	Terminal::DisableRawMode();
+	DisableRawModeInternal(ifd);
+	if (ifd != STDIN_FILENO) {
+		close(ifd);
+	}
 	return success;
 #endif
 }


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/21243 and https://github.com/duckdb/duckdb/issues/21245.
Supersedes https://github.com/duckdb/duckdb/pull/21247

Currently when piping `stdin` to the shell, but not piping `stdout`, `linenoiseGetTerminalColorMode` consumes all available input by calling `Terminal::BufferAvailableInput()` - causing no commands to be executed. This PR adjusts `linenoiseGetTerminalColorMode` to correctly work when `stdin` is not a terminal by explicitly opening `/dev/tty` and running on that instead.