### PR TITLE
Add UUID to settings cache

### DIFF
--- a/src/include/duckdb/main/user_settings.hpp
+++ b/src/include/duckdb/main/user_settings.hpp
@@ -45,6 +45,7 @@ struct CachedGlobalSettings {
 	optional_ptr<const GlobalUserSettings> global_user_settings;
 	idx_t version;
 	UserSettingsMap settings;
+	hugeint_t uuid;
 };
 #endif
 
@@ -63,6 +64,7 @@ public:
 	idx_t AddExtensionOption(const string &name, ExtensionOption extension_option);
 	case_insensitive_map_t<ExtensionOption> GetExtensionSettings() const;
 	bool TryGetExtensionOption(const String &name, ExtensionOption &result) const;
+	hugeint_t GetUUID() const;
 
 #ifndef __MINGW32__
 	CachedGlobalSettings &GetSettings() const;
@@ -76,6 +78,8 @@ private:
 	case_insensitive_map_t<ExtensionOption> extension_parameters;
 	//! Current version of the settings - incremented when settings are modified
 	atomic<idx_t> settings_version;
+	//! Settings uuid
+	hugeint_t uuid;
 };
 
 struct LocalUserSettings {

--- a/src/main/user_settings.cpp
+++ b/src/main/user_settings.cpp
@@ -53,7 +53,7 @@ GlobalUserSettings::GlobalUserSettings() : settings_version(0), uuid(UUID::Gener
 
 GlobalUserSettings::GlobalUserSettings(const GlobalUserSettings &other)
     : settings_map(other.settings_map), extension_parameters(other.extension_parameters),
-      settings_version(other.settings_version.load()), uuid(other.uuid) {
+      settings_version(other.settings_version.load()), uuid(UUID::GenerateRandomUUID()) {
 }
 
 GlobalUserSettings &GlobalUserSettings::operator=(const GlobalUserSettings &other) {

--- a/src/main/user_settings.cpp
+++ b/src/main/user_settings.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/main/user_settings.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/common/types/string.hpp"
+#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
@@ -47,12 +48,12 @@ bool UserSettingsMap::TryGetSetting(idx_t setting_index, Value &result_value) co
 //===--------------------------------------------------------------------===//
 // GlobalUserSettings
 //===--------------------------------------------------------------------===//
-GlobalUserSettings::GlobalUserSettings() : settings_version(0) {
+GlobalUserSettings::GlobalUserSettings() : settings_version(0), uuid(UUID::GenerateRandomUUID()) {
 }
 
 GlobalUserSettings::GlobalUserSettings(const GlobalUserSettings &other)
     : settings_map(other.settings_map), extension_parameters(other.extension_parameters),
-      settings_version(other.settings_version.load()) {
+      settings_version(other.settings_version.load()), uuid(other.uuid) {
 }
 
 GlobalUserSettings &GlobalUserSettings::operator=(const GlobalUserSettings &other) {
@@ -139,7 +140,7 @@ CachedGlobalSettings &GlobalUserSettings::GetSettings() const {
 
 	const auto current_version = settings_version.load(std::memory_order_relaxed);
 	if (!current_cache.global_user_settings || this != current_cache.global_user_settings.get() ||
-	    current_cache.version != current_version) {
+	    current_cache.uuid != uuid || current_cache.version != current_version) {
 		// out-of-date, refresh the cache
 		lock_guard<mutex> guard(lock);
 		current_cache = CachedGlobalSettings(*this, settings_version, settings_map);
@@ -147,12 +148,17 @@ CachedGlobalSettings &GlobalUserSettings::GetSettings() const {
 	return current_cache;
 }
 
-CachedGlobalSettings::CachedGlobalSettings() : version(0) {
+hugeint_t GlobalUserSettings::GetUUID() const {
+	return uuid;
+}
+
+CachedGlobalSettings::CachedGlobalSettings() : version(0), uuid(0) {
 }
 
 CachedGlobalSettings::CachedGlobalSettings(const GlobalUserSettings &global_user_settings_p, idx_t version,
                                            UserSettingsMap settings_p)
-    : global_user_settings(global_user_settings_p), version(version), settings(std::move(settings_p)) {
+    : global_user_settings(global_user_settings_p), version(version), settings(std::move(settings_p)),
+      uuid(global_user_settings_p.GetUUID()) {
 }
 #endif
 


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/20950 switched to using a thread-local variable for the settings cache. This has the danger that the settings cache is re-used across different database instances, which can cause the wrong settings cache to be used in rare situations if the allocator re-uses the same memory location for the settings of a database instance. This can cause settings indexes to be unaligned when extensions are loaded in a different order, causing the wrong setting to be set / read. This PR fixes that issue by adding a UUID to the settings and verifying that the UUID is the same prior to re-using the settings cache. 