### PR TITLE
[ADBC] Add support for duckdb:// URI scheme in URI option

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -314,12 +314,16 @@ AdbcStatusCode DatabaseSetOption(struct AdbcDatabase *database, const char *key,
 		return ADBC_STATUS_NOT_IMPLEMENTED;
 	}
 	if (strcmp(key, "uri") == 0) {
-		if (strncmp(value, "file:", 5) != 0) {
+		std::string file_path;
+		if (strncmp(value, "file:", 5) == 0) {
+			file_path = std::string(value + 5);
+		} else if (strncmp(value, "duckdb:", 7) == 0) {
+			file_path = std::string(value + 7);
+		} else {
 			wrapper->uri_path = value;
 			wrapper->uri_set = true;
 			return ADBC_STATUS_OK;
 		}
-		std::string file_path(value + 5);
 		auto suffix_pos = file_path.find_first_of("?#");
 		if (suffix_pos != std::string::npos) {
 			file_path.erase(suffix_pos);
@@ -334,7 +338,7 @@ AdbcStatusCode DatabaseSetOption(struct AdbcDatabase *database, const char *key,
 				file_path = (authority_lc.empty() || authority_lc == "localhost") ? std::string() : authority;
 			} else {
 				if (!authority_lc.empty() && authority_lc != "localhost") {
-					SetError(error, "file: URI with a non-empty authority is not supported");
+					SetError(error, "URI with a non-empty authority is not supported");
 					return ADBC_STATUS_INVALID_ARGUMENT;
 				}
 				file_path = file_path.substr(path_start);

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -3569,6 +3569,23 @@ TEST_CASE("Test ADBC URI option", "[adbc]") {
 		std::remove(expected_path);
 	}
 
+	// Test duckdb://<relative> is accepted
+	{
+		const char *expected_path = "test_duckdb_uri_file.db";
+		std::remove(expected_path);
+
+		AdbcDatabase adbc_database;
+		REQUIRE(SUCCESS(AdbcDatabaseNew(&adbc_database, &adbc_error)));
+		REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "driver", duckdb_lib, &adbc_error)));
+		REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "entrypoint", "duckdb_adbc_init", &adbc_error)));
+		REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "uri", "duckdb://test_duckdb_uri_file.db", &adbc_error)));
+		REQUIRE(SUCCESS(AdbcDatabaseInit(&adbc_database, &adbc_error)));
+		REQUIRE(SUCCESS(AdbcDatabaseRelease(&adbc_database, &adbc_error)));
+
+		REQUIRE(file_exists(expected_path));
+		std::remove(expected_path);
+	}
+
 	// Test URI overrides path (uri takes precedence)
 	{
 		AdbcDatabase adbc_database;
@@ -3674,7 +3691,7 @@ TEST_CASE("Test ADBC URI option", "[adbc]") {
 		REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "uri", uri.c_str(), &adbc_error)));
 		REQUIRE(!SUCCESS(AdbcDatabaseInit(&adbc_database, &adbc_error)));
 		REQUIRE(adbc_error.message);
-		REQUIRE((std::strcmp(adbc_error.message, "file: URI with a non-empty authority is not supported") == 0));
+		REQUIRE((std::strcmp(adbc_error.message, "URI with a non-empty authority is not supported") == 0));
 		adbc_error.release(&adbc_error);
 		InitializeADBCError(&adbc_error);
 		auto release_status = AdbcDatabaseRelease(&adbc_database, &adbc_error);


### PR DESCRIPTION
This PR is a small usability improvement to DuckDB's ADBC functionality that makes it align with how other ADBC drivers work.

1. DuckDB 1.5.0 included a change that added support for the `uri` database option which is something we're trying to standardize across ADBC drivers: https://github.com/duckdb/duckdb/pull/20312
2. [ADBC 22](https://github.com/apache/arrow-adbc/releases/tag/apache-arrow-adbc-22) added support for a compact form for specifying the driver manifest path and database URI to driver managers. https://github.com/apache/arrow-adbc/pull/3694/ When driver managers get this compact form, they infer the driver to search for from the scheme of the URI and then pass the URI unmodified to the driver. 

(1) didn't support (2) so this PR adds that support. The following currently fails with 1.5.0 but succeeds with the change in this PR:

```python
from adbc_driver_manager import dbapi
dbapi.connect("duckdb://foo.db")
# identical to 
# dbapi.connect(driver="duckdb", db_kwargs={"uri": "duckdb://foo.db"})
```

There isn't an official spec for this pattern but we're working on doing this in the ADBC repo here: https://github.com/apache/arrow-adbc/issues/4453.

cc @eitsupi @lidavidm