### PR TITLE
Do not use MSYS shell for MinGW builds

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -278,32 +278,40 @@ jobs:
        - uses: actions/checkout@v4
          with:
            ref: ${{ inputs.git_ref }}
+
+       - uses: actions/setup-python@v5
+         with:
+           python-version: '3.12'
+
        - uses: msys2/setup-msys2@v2
          with:
            msystem: MINGW64
            update: true
-           install: git mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
+           install: mingw-w64-x86_64-toolchain
            cache: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
 
-       # see here: https://gist.github.com/scivision/1de4fd6abea9ba6b2d87dc1e86b5d2ce
-       - name: Put MSYS2_MinGW64 on PATH
-         # there is not yet an environment variable for this path from msys2/setup-msys2
-         shell: msys2 {0}
-         run: export PATH=D:/a/_temp/msys/msys64/mingw64/bin:$PATH
+       - name: Dependencies
+         shell: bash
+         run: |
+           choco install \
+             ccache \
+             ninja \
+             --no-progress
 
        - uses: ./.github/actions/ccache-action
 
        - name: Build
-         shell: msys2 {0}
+         shell: cmd
          run: |
-           cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DBUILD_EXTENSIONS='parquet' -DOVERRIDE_GIT_DESCRIBE="$OVERRIDE_GIT_DESCRIBE"
+           set PATH=D:/a/_temp/msys/msys64/mingw64/bin;%PATH%
+           cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DBUILD_EXTENSIONS='parquet' -DOVERRIDE_GIT_DESCRIBE="%OVERRIDE_GIT_DESCRIBE%"
            cmake --build . --config Release 
 
        - name: Test
-         shell: msys2 {0}
+         shell: cmd
          run: |
-           cp src/libduckdb.dll .
-           test/unittest.exe
+           copy src\libduckdb.dll .
+           test\unittest.exe
 
  win-packaged-upload:
    runs-on: windows-latest


### PR DESCRIPTION
There is a problem with MinGW builds described in #21260 when something gets wrong with passing the `~/.duckdb/extensions` path in preprocessor definition and the `~` is being incorrectly resolved to the build-machine home dir.

It is suspected that the problem is caused by the MSYS shell or some of the MSYS-related utility used during the configure step.

Though I cannot reproduce this locally, after doing multiple MinGW builds from MSYS bash and from cmd.exe I see the flag added to `build.ninja` the following way in all cases:

```ninja
-DDUCKDB_EXTENSION_DIRECTORIES=\"~/.duckdb/extensions\"
```

We don't need MSYS shell to do MinGW builds - MSYS-installed `mingw-w64-x86_64-toolchain` can be run in `cmd.exe` driven by native Windows versions of `cmake`, `ccache` and `ninja`. While it is not confirmed that MSYS shell is the root cause, it still is suggested to not use it (and its utilities) for the MinGW build.

Supersedes: #21260