### PR TITLE
parquet: avoid corrupting define buffers during skips

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -774,18 +774,10 @@ void ColumnReader::ApplyPendingSkips(data_ptr_t define_out, data_ptr_t repeat_ou
 	pending_skips = 0;
 
 	auto to_skip = num_values;
-	ResizeableBuffer skip_defines;
-	ResizeableBuffer skip_repeats;
-	auto skip_define_out = define_out;
-	auto skip_repeat_out = repeat_out;
-	if (HasDefines()) {
-		skip_defines.resize(reader.allocator, STANDARD_VECTOR_SIZE);
-		skip_define_out = skip_defines.ptr;
-	}
-	if (HasRepeats()) {
-		skip_repeats.resize(reader.allocator, STANDARD_VECTOR_SIZE);
-		skip_repeat_out = skip_repeats.ptr;
-	}
+	data_t skip_defines[STANDARD_VECTOR_SIZE] = {};
+	data_t skip_repeats[STANDARD_VECTOR_SIZE];
+	data_ptr_t skip_define_out = HasDefines() ? skip_defines : define_out;
+	data_ptr_t skip_repeat_out = HasRepeats() ? skip_repeats : repeat_out;
 	// start reading but do not apply skips (we are skipping now)
 	BeginRead(nullptr, nullptr);
 

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -774,6 +774,18 @@ void ColumnReader::ApplyPendingSkips(data_ptr_t define_out, data_ptr_t repeat_ou
 	pending_skips = 0;
 
 	auto to_skip = num_values;
+	ResizeableBuffer skip_defines;
+	ResizeableBuffer skip_repeats;
+	auto skip_define_out = define_out;
+	auto skip_repeat_out = repeat_out;
+	if (HasDefines()) {
+		skip_defines.resize(reader.allocator, STANDARD_VECTOR_SIZE);
+		skip_define_out = skip_defines.ptr;
+	}
+	if (HasRepeats()) {
+		skip_repeats.resize(reader.allocator, STANDARD_VECTOR_SIZE);
+		skip_repeat_out = skip_repeats.ptr;
+	}
 	// start reading but do not apply skips (we are skipping now)
 	BeginRead(nullptr, nullptr);
 
@@ -785,9 +797,9 @@ void ColumnReader::ApplyPendingSkips(data_ptr_t define_out, data_ptr_t repeat_ou
 			to_skip -= skip_now;
 			continue;
 		}
-		const auto all_valid = PrepareRead(skip_now, define_out, repeat_out, 0);
+		const auto all_valid = PrepareRead(skip_now, skip_define_out, skip_repeat_out, 0);
 
-		const auto define_ptr = all_valid ? nullptr : static_cast<uint8_t *>(define_out);
+		const auto define_ptr = all_valid ? nullptr : static_cast<uint8_t *>(skip_define_out);
 		switch (encoding) {
 		case ColumnEncoding::DICTIONARY:
 			dictionary_decoder.Skip(define_ptr, skip_now);

--- a/test/sql/copy/parquet/struct_skip_pushdown_null.test
+++ b/test/sql/copy/parquet/struct_skip_pushdown_null.test
@@ -1,0 +1,32 @@
+# name: test/sql/copy/parquet/struct_skip_pushdown_null.test
+# description: Optional struct remains non-null after parquet skip pushdown
+# group: [parquet]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+# Rows 59392-112639 are NULL, all others are non-null.
+statement ok
+COPY (
+	SELECT i AS id,
+		CASE
+			WHEN i >= 59392 AND i < 112640 THEN NULL
+			ELSE {a: 'hello', b: 42.0}
+		END::STRUCT(a VARCHAR, b DOUBLE) AS col
+	FROM range(122880) t(i)
+) TO '__TEST_DIR__/skip_null_struct.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 122880)
+
+# Predicate pushdown on id forces ApplyPendingSkips on col.
+query T
+SELECT col IS NULL FROM '__TEST_DIR__/skip_null_struct.parquet' WHERE id = 112640
+----
+false
+
+statement ok
+COPY (
+	SELECT col
+	FROM '__TEST_DIR__/skip_null_struct.parquet'
+	WHERE id = 112640
+) TO '__TEST_DIR__/skip_null_struct_out.parquet'


### PR DESCRIPTION
## Summary

Fixes #21166.

`ColumnReader::ApplyPendingSkips` currently reuses the caller-provided define_out and repeat_out buffers as scratch space. That is unsafe because `PrepareRead` behaves asymmetrically:

  - the fast path (`GetRepeatedBatch`) advances the decoder but does not write into the caller buffer
  - the normal path (`GetBatch`) does write definition levels into the caller buffer

When a skipped range contains both NULL and non-NULL rows, stale definition levels written by earlier NULL iterations can survive into later fast-path iterations. For optional STRUCT<scalar, scalar, ...> columns, that can cause `StructColumnReader` to treat a non-NULL parent row as NULL after predicate pushdown.

This change allocates local scratch buffers inside `ApplyPendingSkips` and passes those to `PrepareRead`, so the skip phase never corrupts the caller's buffers.