### PR TITLE
TryGetCurrentSetting: Fixup paramater passing for FileOpenerInfo

### DIFF
--- a/src/include/duckdb/common/file_opener.hpp
+++ b/src/include/duckdb/common/file_opener.hpp
@@ -57,7 +57,7 @@ public:
 		if (info) {
 			lookup_result = TryGetCurrentSetting(opener, key, output, *info);
 		} else {
-			lookup_result = TryGetCurrentSetting(opener, key, output, *info);
+			lookup_result = TryGetCurrentSetting(opener, key, output);
 		}
 
 		if (lookup_result) {

--- a/src/main/client_context_file_opener.cpp
+++ b/src/main/client_context_file_opener.cpp
@@ -89,7 +89,7 @@ SettingLookupResult FileOpener::TryGetCurrentSetting(optional_ptr<FileOpener> op
 }
 
 SettingLookupResult FileOpener::TryGetCurrentSetting(const string &key, Value &result, FileOpenerInfo &info) {
-	return this->TryGetCurrentSetting(key, result);
+	return this->TryGetCurrentSetting(key, result, info);
 }
 // LCOV_EXCL_STOP
 } // namespace duckdb


### PR DESCRIPTION
Currently that's not used, but I think current code is off, and will be off if we start making use of `FileOpenerInfo`.