### PR TITLE
Throw error on incorrect use of `ParseExpressionList`

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -633,6 +633,24 @@ vector<unique_ptr<ParsedExpression>> Parser::ParseExpressionList(const string &s
 		throw ParserException("Expected a single SELECT node");
 	}
 	auto &select_node = select.node->Cast<SelectNode>();
+	if (!select_node.modifiers.empty()) {
+		throw ParserException("Cannot have any modifiers in the expression list");
+	}
+	if (select_node.where_clause) {
+		throw ParserException("Cannot have a WHERE clause in the expression list");
+	}
+	if (!select_node.groups.group_expressions.empty()) {
+		throw ParserException("Cannot have a GROUP BY clause in the expression list");
+	}
+	if (select_node.having) {
+		throw ParserException("Cannot have a HAVING clause in the expression list");
+	}
+	if (select_node.qualify) {
+		throw ParserException("Cannot have a QUALIFY clause in the expression list");
+	}
+	if (select_node.sample) {
+		throw ParserException("Cannot have a SAMPLE clause in the expression list");
+	}
 	return std::move(select_node.select_list);
 }
 

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library_unity(
   test_hyperlog.cpp
   test_lru_cache.cpp
   test_numeric_cast.cpp
+  test_parse_expression.cpp
   test_parse_logical_type.cpp
   test_utf.cpp
   test_allocator_debug_info.cpp

--- a/test/common/test_parse_expression.cpp
+++ b/test/common/test_parse_expression.cpp
@@ -1,0 +1,33 @@
+#include "catch.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+TEST_CASE("Parse Expression List valid expressions", "[parse_expression]") {
+	auto result = Parser::ParseExpressionList("x");
+	REQUIRE(result.size() == 1);
+
+	result = Parser::ParseExpressionList("x, y, z");
+	REQUIRE(result.size() == 3);
+
+	result = Parser::ParseExpressionList("FIRST(x) AS x");
+	REQUIRE(result.size() == 1);
+
+	result = Parser::ParseExpressionList("x + 1, y * 2");
+	REQUIRE(result.size() == 2);
+}
+
+TEST_CASE("Parse Expression List rejects invalid clauses", "[parse_expression]") {
+#ifdef DUCKDB_CRASH_ON_ASSERT
+	return;
+#endif
+	REQUIRE_THROWS_AS(Parser::ParseExpressionList("FIRST(x) AS x WHERE x = 'bad'"), ParserException);
+	REQUIRE_THROWS_AS(Parser::ParseExpressionList("first(x) AS x HAVING x"), ParserException);
+	REQUIRE_THROWS_AS(Parser::ParseExpressionList("first(x) AS x QUALIFY x"), ParserException);
+	REQUIRE_THROWS_AS(Parser::ParseExpressionList("first(x) AS x USING SAMPLE 1 ROWS"), ParserException);
+	REQUIRE_THROWS_AS(Parser::ParseExpressionList("first(x) AS x GROUP BY x"), ParserException);
+	REQUIRE_THROWS_AS(Parser::ParseExpressionList("first(x) AS x ORDER BY x"), ParserException);
+	REQUIRE_THROWS_AS(Parser::ParseExpressionList("x LIMIT 1"), ParserException);
+}


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/7576, https://github.com/duckdb/duckdb/issues/21072

`Parser::ParseExpressionList` previously only returned expressions from the `select_list`, silently dropping any `ORDER BY`, `WHERE`, or other clauses. This caused incorrect behavior for callers that passed such input expecting it to be validated.
This PR adds an error if unexpected clauses are present, rather than silently ignoring them.
