### PR TITLE
Reduce number of linux builds

### DIFF
--- a/.github/actions/linux_release_build/action.yml
+++ b/.github/actions/linux_release_build/action.yml
@@ -31,6 +31,17 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install tools
+      shell: bash
+      run: make toolsci
+
+    - uses: ./.github/actions/ccache-action
+
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11.1
+      with:
+        vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
+
     - name: Build release
       shell: bash
       env:

--- a/.github/actions/linux_release_build/action.yml
+++ b/.github/actions/linux_release_build/action.yml
@@ -31,12 +31,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install tools
-      shell: bash
-      run: make toolsci
-
-    - uses: ./.github/actions/ccache-action
-
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11.1
       with:

--- a/.github/actions/linux_release_build/action.yml
+++ b/.github/actions/linux_release_build/action.yml
@@ -1,0 +1,59 @@
+name: Linux Release Build
+description: Build a DuckDB linux release, optionally run smoke tests, and upload an artifact.
+inputs:
+  artifact_name:
+    description: Uploaded artifact name
+    required: true
+  artifact_tarball:
+    description: Output tarball path
+    required: false
+    default: build/release-artifact.tar.gz
+  build_benchmark:
+    description: Whether to build benchmark binaries
+    required: false
+    default: "1"
+  build_jemalloc:
+    description: Whether to build jemalloc
+    required: false
+    default: "1"
+  core_extensions:
+    description: Core extensions to build
+    required: false
+    default: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
+  disable_sanitizer:
+    description: Whether to disable sanitizer
+    required: false
+    default: "1"
+  run_smoke_tests:
+    description: Whether to run smoke tests
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Build release
+      shell: bash
+      env:
+        BUILD_BENCHMARK: ${{ inputs.build_benchmark }}
+        BUILD_JEMALLOC: ${{ inputs.build_jemalloc }}
+        CORE_EXTENSIONS: ${{ inputs.core_extensions }}
+        DISABLE_SANITIZER: ${{ inputs.disable_sanitizer }}
+        VCPKG_TOOLCHAIN_PATH: ${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
+        USE_MERGED_VCPKG_MANIFEST: 1
+      run: make release
+
+    - name: Smoke tests
+      if: ${{ inputs.run_smoke_tests == 'true' }}
+      shell: bash
+      run: make smoke SMOKE_UNITTEST=build/release/test/unittest
+
+    - name: Prepare release artifact
+      shell: bash
+      run: make release-artifact
+
+    - name: Upload release build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.artifact_tarball }}
+        if-no-files-found: error

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -234,28 +234,9 @@ jobs:
       with:
         vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
 
-    - name: Build
-      env:
-        BUILD_BENCHMARK: 1
-        BUILD_JEMALLOC: 1
-        CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
-        DISABLE_SANITIZER: 1
-        VCPKG_TOOLCHAIN_PATH: ${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
-        USE_MERGED_VCPKG_MANIFEST: 1
-      run: make release
-
-    - name: Smoke tests
-      run: make smoke SMOKE_UNITTEST=build/release/test/unittest
-
-    - name: Prepare release artifact
-      run: make release-artifact
-
-    - name: Upload release build artifact
-      uses: actions/upload-artifact@v4
+    - uses: ./.github/actions/linux_release_build
       with:
-        name: linux-release-build
-        path: build/release-artifact.tar.gz
-        if-no-files-found: error
+        artifact_name: linux-release-build
 
     - name: Build linux default release
       run: make clean release

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -225,6 +225,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install tools
+      run: make toolsci
+
+    - uses: ./.github/actions/ccache-action
+
     - uses: ./.github/actions/linux_release_build
       with:
         artifact_name: linux-release-build

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -197,8 +197,8 @@ jobs:
       - linux-debug
       - linux-release
     with:
-      runner_linux_small: ${{ needs.prepare.outputs.runner_linux_small }}
       runner_linux_x64: ${{ needs.prepare.outputs.runner_linux_x64 }}
+      runner_linux_small: ${{ needs.prepare.outputs.runner_linux_small }}
 
  code-quality:
     uses: ./.github/workflows/CodeQuality.yml

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -197,6 +197,7 @@ jobs:
       - linux-debug
       - linux-release
     with:
+      build_current_release: 'false'
       runner_linux_x64: ${{ needs.prepare.outputs.runner_linux_x64 }}
       runner_linux_small: ${{ needs.prepare.outputs.runner_linux_small }}
 

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -198,6 +198,7 @@ jobs:
       - linux-release
     with:
       runner_linux_small: ${{ needs.prepare.outputs.runner_linux_small }}
+      runner_linux_x64: ${{ needs.prepare.outputs.runner_linux_x64 }}
 
  code-quality:
     uses: ./.github/workflows/CodeQuality.yml
@@ -235,6 +236,7 @@ jobs:
 
     - name: Build
       env:
+        BUILD_BENCHMARK: 1
         BUILD_JEMALLOC: 1
         CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
         DISABLE_SANITIZER: 1

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -53,6 +53,7 @@ jobs:
       (github.event.action != 'synchronize' || github.event.pull_request.user.login == 'smvv')
     runs-on: ${{ github.repository == 'duckdb/duckdb' && 'namespace-profile-linux-small' || 'ubuntu-latest' }}
     outputs:
+      runner_linux_small: ${{ steps.select_runner.outputs.runner_linux_small }}
       runner_linux_x64: ${{ steps.select_runner.outputs.runner_linux_x64 }}
       runner_linux_22_x64: ${{ steps.select_runner.outputs.runner_linux_22_x64 }}
       runner_linux_arm64: ${{ steps.select_runner.outputs.runner_linux_arm64 }}
@@ -73,6 +74,7 @@ jobs:
           # Fall back to GitHub-native runners for forks.
           if [[ "${{ github.repository }}" == "duckdb/duckdb" ]]; then
             {
+              echo "runner_linux_small=namespace-profile-linux-small"
               echo "runner_linux_x64=namespace-profile-linux-x64"
               echo "runner_linux_22_x64=namespace-profile-linux-22-x64"
               echo "runner_linux_arm64=namespace-profile-linux-arm64"
@@ -80,6 +82,7 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           else
             {
+              echo "runner_linux_small=ubuntu-latest"
               echo "runner_linux_x64=ubuntu-latest"
               echo "runner_linux_22_x64=ubuntu-22.04"
               echo "runner_linux_arm64=ubuntu-24.04-arm"
@@ -463,8 +466,10 @@ jobs:
 
  amalgamation-tests:
     name: Amalgamation Tests
-    runs-on: ubuntu-24.04
-    needs: linux-debug
+    runs-on: ${{ needs.prepare.outputs.runner_linux_small }}
+    needs:
+      - prepare
+      - linux-debug
     env:
       CC: clang
       CXX: clang++

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -121,6 +121,7 @@ jobs:
       FORCE_DEBUG: 1
       FORCE_ASSERT: 1
       REDUCE_SYMBOLS: 1
+      EXTENSIONS_STATIC_BUILD: 0
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -225,16 +225,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install tools
-      run: make toolsci
-
-    - uses: ./.github/actions/ccache-action
-
-    - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v11.1
-      with:
-        vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
-
     - uses: ./.github/actions/linux_release_build
       with:
         artifact_name: linux-release-build

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -192,7 +192,12 @@ jobs:
  regression:
     uses: ./.github/workflows/Regression.yml
     secrets: inherit
-    needs: linux-debug
+    needs:
+      - prepare
+      - linux-debug
+      - linux-release
+    with:
+      runner_linux_small: ${{ needs.prepare.outputs.runner_linux_small }}
 
  code-quality:
     uses: ./.github/workflows/CodeQuality.yml

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -31,22 +31,20 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  BASE_BRANCH: ${{ github.base_ref || (endsWith(github.ref, '_feature') && 'feature' || 'main') }}
+  BASE_BRANCH: ${{ github.base_ref || (endsWith(github.ref_name, '_feature') && 'feature' || 'main') }}
   BASE_HASH: ${{ inputs.base_hash }}
 
 jobs:
-  # This job exists so that workflow_dispatch and repository_dispatch continue
-  # to work. Note that those cannot rely on the linux release build because
-  # that CI job runs outside this workflow run.
-  linux-release:
-    name: Linux Release
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}
+  linux-base:
+    name: Linux Base
     runs-on: ${{ inputs.runner_linux_x64 }}
     env:
       GEN: ninja
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install tools
         run: make toolsci
@@ -58,34 +56,39 @@ jobs:
         with:
           vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
 
-      - name: Build
-        env:
-          BUILD_BENCHMARK: 1
-          BUILD_JEMALLOC: 1
-          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
-          DISABLE_SANITIZER: 1
-          VCPKG_TOOLCHAIN_PATH: ${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
-          USE_MERGED_VCPKG_MANIFEST: 1
-        run: make release
-
-      - name: Smoke tests
-        run: make smoke SMOKE_UNITTEST=build/release/test/unittest
-
-      - name: Prepare release artifact
-        run: make release-artifact
-
-      - name: Upload release build artifact
-        uses: actions/upload-artifact@v4
+      - name: Build current release
+        if: ${{ github.event_name != 'workflow_call' }}
+        uses: ./.github/actions/linux_release_build
         with:
-          name: linux-release-build
-          path: build/release-artifact.tar.gz
-          if-no-files-found: error
+          artifact_name: linux-release-build
+
+      - name: Select base ref
+        run: |
+          if [[ "${{ github.repository }}" == "duckdb/duckdb" && "${{ github.ref_name }}" == "main" ]]; then
+            if [[ -z "${BASE_HASH}" ]]; then
+              echo "BASE_REF=$(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --event=repository_dispatch --status=completed --json=headSha --limit=1 --jq '.[0].headSha')" >> "$GITHUB_ENV"
+            else
+              echo "BASE_REF=${BASE_HASH}" >> "$GITHUB_ENV"
+            fi
+          else
+            echo "BASE_REF=origin/${BASE_BRANCH}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Reset workspace to base ref
+        run: |
+          make clean
+          git checkout --detach "${BASE_REF}"
+          git submodule update --init --recursive
+
+      - name: Build base release
+        uses: ./.github/actions/linux_release_build
+        with:
+          artifact_name: linux-base-build
 
   regression-test-benchmark-runner:
     name: Regression Tests
     needs:
-      - linux-release
-    if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
+      - linux-base
     runs-on: ubuntu-24.04
     env:
       CC: gcc-13
@@ -108,10 +111,8 @@ jobs:
         shell: bash
         run: make toolsci && sudo apt-get install -y -qq libcurl4-openssl-dev && pip install requests
 
-      - uses: ./.github/actions/ccache-action
-
       - name: Checkout Private Regression
-        if: ${{ github.repository == 'duckdb/duckdb' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.repository == 'duckdb/duckdb' && github.ref_name == 'main' }}
         uses: actions/checkout@v4
         with:
           repository: duckdblabs/fivetran_regression
@@ -123,113 +124,90 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: linux-release-build
-          path: build
+          path: build/current
 
       - name: Extract current release artifact
         run: |
-          rm -rf build/release
-          tar -xzf build/release-artifact.tar.gz -C build
+          rm -rf build/current/release
+          tar -xzf build/current/release-artifact.tar.gz -C build/current
 
-      - name: Build Base Branch
-        if: ${{ !(github.repository == 'duckdb/duckdb' && github.ref == 'refs/heads/main') }}
-        shell: bash
-        run: |
-          git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
-          cd duckdb
-          make
-          cd ..
+      - name: Download base artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-base-build
+          path: build/base
 
-      # For NightlyTest we fetch the last commit hash that ran Regression on main
-      - name: Build Previous Successful Regression Hash
-        if: ${{ github.repository == 'duckdb/duckdb' && github.ref == 'refs/heads/main' }}
-        shell: bash
+      - name: Extract base artifact
         run: |
-          git clone https://github.com/duckdb/duckdb.git
-          cd duckdb
-          if [[ -z "${BASE_HASH}" ]]; then
-            export CHECKOUT_HASH=$(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --event=repository_dispatch --status=completed --json=headSha --limit=1 --jq '.[0].headSha')
-          else
-            export CHECKOUT_HASH="$BASE_HASH"
-          fi
-          git checkout $CHECKOUT_HASH
-          make
-          cd ..
-
-      - name: Set up benchmarks
-        shell: bash
-        run: |
-          cp -r benchmark duckdb/
+          rm -rf build/base/release
+          tar -xzf build/base/release-artifact.tar.gz -C build/base
 
       - name: Regression Test Fivetran
-        if: ${{ github.repository == 'duckdb/duckdb' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.repository == 'duckdb/duckdb' && github.ref_name == 'main' }}
         shell: bash
         run: |
-          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks benchmark/fivetran/benchmark_list.csv --verbose --threads 2 --clear-benchmark-cache
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks benchmark/fivetran/benchmark_list.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test Micro
         if: always()
         shell: bash
         run: |
-          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/micro.csv --verbose --threads 2 --clear-benchmark-cache
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/micro.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test Ingestion Perf
         if: always()
         shell: bash
         run: |
-          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/ingestion.csv --verbose --threads 2 --clear-benchmark-cache
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/ingestion.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test TPCH
         if: always()
         shell: bash
         run: |
-          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/tpch.csv --verbose --threads 2 --clear-benchmark-cache
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/tpch.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test TPCH-PARQUET
         if: always()
         shell: bash
         run: |
-          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/tpch_parquet.csv --verbose --threads 2 --clear-benchmark-cache
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/tpch_parquet.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test TPCDS
         if: always()
         shell: bash
         run: |
-          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/tpcds.csv --verbose --threads 2 --clear-benchmark-cache
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/tpcds.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test H2OAI
         if: always()
         shell: bash
         run: |
-          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/h2oai.csv --verbose --threads 2 --clear-benchmark-cache
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/h2oai.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test IMDB
         if: always()
         shell: bash
         run: |
-          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/imdb.csv --verbose --threads 2 --clear-benchmark-cache
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/imdb.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test CSV
         if: always()
         shell: bash
         run: |
-          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/csv.csv --verbose --threads 2 --clear-benchmark-cache
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/csv.csv --verbose --threads 2 --clear-benchmark-cache
 
-      - name: Regression Test RealNest 
+      - name: Regression Test RealNest
         if: always()
         shell: bash
         run: |
           mkdir -p duckdb_benchmark_data
-          rm -R duckdb/duckdb_benchmark_data
-          mkdir -p duckdb/duckdb_benchmark_data
           wget -q https://blobs.duckdb.org/data/realnest/realnest.duckdb --output-document=duckdb_benchmark_data/real_nest.duckdb
-          cp duckdb_benchmark_data/real_nest.duckdb duckdb/duckdb_benchmark_data/real_nest.duckdb
-          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/realnest.csv --verbose --threads 2
+          python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/realnest.csv --verbose --threads 2
 
   regression-test-storage:
     name: Storage Size Regression Test
     needs:
-      - linux-release
-    if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
+      - linux-base
     runs-on: ubuntu-24.04
     env:
       CC: gcc-13
@@ -250,36 +228,37 @@ jobs:
         shell: bash
         run: make toolsci && pip install requests
 
-      - uses: ./.github/actions/ccache-action
-
       - name: Download current release artifact
         uses: actions/download-artifact@v4
         with:
           name: linux-release-build
-          path: build
+          path: build/current
 
       - name: Extract current release artifact
         run: |
-          rm -rf build/release
-          tar -xzf build/release-artifact.tar.gz -C build
+          rm -rf build/current/release
+          tar -xzf build/current/release-artifact.tar.gz -C build/current
 
-      - name: Build base branch
-        shell: bash
+      - name: Download base artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-base-build
+          path: build/base
+
+      - name: Extract base artifact
         run: |
-          git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
-          cd duckdb
-          make
-          cd ..
+          rm -rf build/base/release
+          tar -xzf build/base/release-artifact.tar.gz -C build/base
 
       - name: Regression Test
         shell: bash
         run: |
-          python scripts/regression_test_storage_size.py --old duckdb/build/release/duckdb --new build/release/duckdb
+          python scripts/regression_test_storage_size.py --old build/base/release/duckdb --new build/current/release/duckdb
 
       - name: Test for incompatibility
         shell: bash
         run: |
-          if (cmp test/sql/storage_version/storage_version.db duckdb/test/sql/storage_version/storage_version.db); then
+          if (cmp test/sql/storage_version/storage_version.db build/base/release/test/sql/storage_version/storage_version.db); then
             echo "storage_changed=false" >> $GITHUB_ENV
           else
             echo "storage_changed=true" >> $GITHUB_ENV
@@ -291,22 +270,24 @@ jobs:
         run: |
           # Regenerate test/sql/storage_version.db with newer version -> read with older version
           python3 scripts/generate_storage_version.py
-          ./duckdb/build/release/duckdb test/sql/storage_version/storage_version.db
+          ./build/base/release/duckdb test/sql/storage_version/storage_version.db
           # Regenerate test/sql/storage_version.db with older version -> read with newer version (already performed as part of test.slow)
-          cd duckdb
-          python3 ../scripts/generate_storage_version.py
-          ../build/release/duckdb test/sql/storage_version/storage_version.db
-          cd ..
+          (
+            cd build/base/release
+            python3 scripts/generate_storage_version.py
+          )
+          ./build/current/release/duckdb build/base/release/test/sql/storage_version/storage_version.db
 
       - name: Regression Compatibility Test (testing storage version has been bumped)
         shell: bash
         if: env.storage_changed == 'true'
         run: |
           python3 scripts/generate_storage_version.py
-          cd duckdb
-          python3 scripts/generate_storage_version.py
-          cd ..
-          if (cmp -i 8 -n 12 test/sql/storage_version.db duckdb/test/sql/storage_version.db); then
+          (
+            cd build/base/release
+            python3 scripts/generate_storage_version.py
+          )
+          if (cmp -i 8 -n 12 test/sql/storage_version/storage_version.db build/base/release/test/sql/storage_version/storage_version.db); then
             echo "Expected storage format to be bumped, but this is not the case"
             echo "This might fail spuriously if changes to content of test database / generation script happened"
             exit 1
@@ -317,15 +298,15 @@ jobs:
   regression-test-binary-size:
     name: Regression test binary size
     needs:
-      - linux-release
-    if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
-    runs-on: ubuntu-24.04
+      - linux-base
+    runs-on: ${{ inputs.runner_linux_small }}
     env:
-      CC: gcc-13
-      CXX: g++-13
+      CC: gcc-10
+      CXX: g++-10
       GEN: ninja
       CORE_EXTENSIONS: "tpch;tpcds;json;parquet"
       EXTENSION_STATIC_BUILD: 1
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -339,37 +320,37 @@ jobs:
         shell: bash
         run: make toolsci && pip install requests
 
-      - uses: ./.github/actions/ccache-action
-
       - name: Download current release artifact
         uses: actions/download-artifact@v4
         with:
           name: linux-release-build
-          path: build
+          path: build/current
 
       - name: Extract current release artifact
         run: |
-          rm -rf build/release
-          tar -xzf build/release-artifact.tar.gz -C build
+          rm -rf build/current/release
+          tar -xzf build/current/release-artifact.tar.gz -C build/current
 
-      - name: Build base branch
-        shell: bash
+      - name: Download base artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-base-build
+          path: build/base
+
+      - name: Extract base artifact
         run: |
-          git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
-          cd duckdb
-          make
-          cd ..
+          rm -rf build/base/release
+          tar -xzf build/base/release-artifact.tar.gz -C build/base
 
       - name: Regression Test Extension binary size
         shell: bash
         run: |
-          python scripts/regression_test_extension_size.py --old 'duckdb/build/release/extension' --new build/release/extension --expect json,parquet,tpch,tpcds
+          python scripts/regression_test_extension_size.py --old build/base/release/extension --new build/current/release/extension --expect json,parquet,tpch,tpcds
 
   regression-test-plan-cost:
     name: Regression Test Join Order Plan Cost
     needs:
-      - linux-release
-    if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
+      - linux-base
     runs-on: ubuntu-24.04
     env:
       CC: gcc-13
@@ -390,40 +371,36 @@ jobs:
         shell: bash
         run: make toolsci && sudo apt-get install -y -qq libcurl4-openssl-dev && pip install tqdm
 
-      - uses: ./.github/actions/ccache-action
-
       - name: Download current release artifact
         uses: actions/download-artifact@v4
         with:
           name: linux-release-build
-          path: build
+          path: build/current
 
       - name: Extract current release artifact
         run: |
-          rm -rf build/release
-          tar -xzf build/release-artifact.tar.gz -C build
+          rm -rf build/current/release
+          tar -xzf build/current/release-artifact.tar.gz -C build/current
 
-      - name: Build base branch
-        shell: bash
-        run: |
-          git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
-          cd duckdb
-          make
-          cd ..
+      - name: Download base artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-base-build
+          path: build/base
 
-      - name: Set up benchmarks
-        shell: bash
+      - name: Extract base artifact
         run: |
-          cp -r benchmark duckdb/
+          rm -rf build/base/release
+          tar -xzf build/base/release-artifact.tar.gz -C build/base
 
       - name: Regression Test IMDB
         if: always()
         shell: bash
         run: |
-          python scripts/plan_cost_runner.py --old duckdb/build/release/duckdb --new build/release/duckdb --dir=benchmark/imdb_plan_cost
+          python scripts/plan_cost_runner.py --old build/base/release/duckdb --new build/current/release/duckdb --dir=benchmark/imdb_plan_cost
 
       - name: Regression Test TPCH
         if: always()
         shell: bash
         run: |
-          python scripts/plan_cost_runner.py --old duckdb/build/release/duckdb --new build/release/duckdb --dir=benchmark/tpch_plan_cost
+          python scripts/plan_cost_runner.py --old build/base/release/duckdb --new build/current/release/duckdb --dir=benchmark/tpch_plan_cost

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -53,16 +53,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install tools
-        run: make toolsci
-
-      - uses: ./.github/actions/ccache-action
-
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11.1
-        with:
-          vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
-
       - name: Build current release
         if: ${{ inputs.build_current_release != 'false' }}
         uses: ./.github/actions/linux_release_build

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -4,10 +4,17 @@ on:
     inputs:
       base_hash:
         type: string
+      runner_linux_small:
+        default: ubuntu-latest
+        type: string
   workflow_dispatch:
     inputs:
       base_hash:
         description: 'Base hash'
+        type: string
+      runner_linux_small:
+        description: 'Optional small runner label override'
+        default: ubuntu-latest
         type: string
   repository_dispatch:
 
@@ -156,7 +163,7 @@ jobs:
 
   regression-test-storage:
     name: Storage Size Regression Test
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner_linux_small }}
     env:
       CC: gcc-10
       CXX: g++-10
@@ -178,10 +185,21 @@ jobs:
 
       - uses: ./.github/actions/ccache-action
 
-      - name: Build
+      - name: Download linux release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-release-build
+          path: build
+
+      - name: Extract linux release artifact
         shell: bash
         run: |
-          make
+          rm -rf build/release
+          tar -xzf build/release-artifact.tar.gz -C build
+
+      - name: Build base branch
+        shell: bash
+        run: |
           git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
           cd duckdb
           make

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -63,23 +63,31 @@ jobs:
           token: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
           path: benchmark/fivetran
 
-      # For PRs we compare against the base branch
-      - name: Build Current and Base Branch
+      - name: Download current release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-release-build
+          path: build
+
+      - name: Extract current release artifact
+        run: |
+          rm -rf build/release
+          tar -xzf build/release-artifact.tar.gz -C build
+
+      - name: Build Base Branch
         if: ${{ !(github.repository == 'duckdb/duckdb' && github.ref == 'refs/heads/main') }}
         shell: bash
         run: |
-          make
           git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
           cd duckdb
           make
           cd ..
 
       # For NightlyTest we fetch the last commit hash that ran Regression on main
-      - name: Build Main and Previous Successful Regression Hash
+      - name: Build Previous Successful Regression Hash
         if: ${{ github.repository == 'duckdb/duckdb' && github.ref == 'refs/heads/main' }}
         shell: bash
         run: |
-          make
           git clone https://github.com/duckdb/duckdb.git
           cd duckdb
           if [[ -z "${BASE_HASH}" ]]; then
@@ -185,14 +193,13 @@ jobs:
 
       - uses: ./.github/actions/ccache-action
 
-      - name: Download linux release artifact
+      - name: Download current release artifact
         uses: actions/download-artifact@v4
         with:
           name: linux-release-build
           path: build
 
-      - name: Extract linux release artifact
-        shell: bash
+      - name: Extract current release artifact
         run: |
           rm -rf build/release
           tar -xzf build/release-artifact.tar.gz -C build
@@ -272,14 +279,13 @@ jobs:
 
       - uses: ./.github/actions/ccache-action
 
-      - name: Download linux release artifact
+      - name: Download current release artifact
         uses: actions/download-artifact@v4
         with:
           name: linux-release-build
           path: build
 
-      - name: Extract linux release artifact
-        shell: bash
+      - name: Extract current release artifact
         run: |
           rm -rf build/release
           tar -xzf build/release-artifact.tar.gz -C build
@@ -321,10 +327,20 @@ jobs:
 
       - uses: ./.github/actions/ccache-action
 
-      - name: Build
+      - name: Download current release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-release-build
+          path: build
+
+      - name: Extract current release artifact
+        run: |
+          rm -rf build/release
+          tar -xzf build/release-artifact.tar.gz -C build
+
+      - name: Build base branch
         shell: bash
         run: |
-          make
           git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
           cd duckdb
           make

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -77,6 +77,11 @@ jobs:
           git checkout --detach "${BASE_REF}"
           git submodule update --init --recursive
 
+          # Restore all build related files. This means that any new/changed
+          # compiler/linker optimization is now also applied to the base
+          # comparison build and thus not identical to the "real" base build.
+          git restore --source="${GITHUB_SHA}" --worktree --staged .github Makefile scripts
+
       - name: Build base release
         uses: ./.github/actions/linux_release_build
         with:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -4,6 +4,9 @@ on:
     inputs:
       base_hash:
         type: string
+      runner_linux_x64:
+        default: ubuntu-latest
+        type: string
       runner_linux_small:
         default: ubuntu-latest
         type: string
@@ -11,6 +14,10 @@ on:
     inputs:
       base_hash:
         description: 'Base hash'
+        type: string
+      runner_linux_x64:
+        description: 'Optional x64 runner label override'
+        default: ubuntu-latest
         type: string
       runner_linux_small:
         description: 'Optional small runner label override'
@@ -28,8 +35,57 @@ env:
   BASE_HASH: ${{ inputs.base_hash }}
 
 jobs:
+  # This job exists so that workflow_dispatch and repository_dispatch continue
+  # to work. Note that those cannot rely on the linux release build because
+  # that CI job runs outside this workflow run.
+  linux-release:
+    name: Linux Release
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}
+    runs-on: ${{ inputs.runner_linux_x64 }}
+    env:
+      GEN: ninja
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: make toolsci
+
+      - uses: ./.github/actions/ccache-action
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
+
+      - name: Build
+        env:
+          BUILD_BENCHMARK: 1
+          BUILD_JEMALLOC: 1
+          CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;parquet;autocomplete;httpfs"
+          DISABLE_SANITIZER: 1
+          VCPKG_TOOLCHAIN_PATH: ${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
+          USE_MERGED_VCPKG_MANIFEST: 1
+        run: make release
+
+      - name: Smoke tests
+        run: make smoke SMOKE_UNITTEST=build/release/test/unittest
+
+      - name: Prepare release artifact
+        run: make release-artifact
+
+      - name: Upload release build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-release-build
+          path: build/release-artifact.tar.gz
+          if-no-files-found: error
+
   regression-test-benchmark-runner:
     name: Regression Tests
+    needs:
+      - linux-release
+    if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
     runs-on: ubuntu-22.04
     env:
       CC: gcc-10
@@ -171,6 +227,9 @@ jobs:
 
   regression-test-storage:
     name: Storage Size Regression Test
+    needs:
+      - linux-release
+    if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
     runs-on: ${{ inputs.runner_linux_small }}
     env:
       CC: gcc-10
@@ -257,6 +316,9 @@ jobs:
 
   regression-test-binary-size:
     name: Regression test binary size
+    needs:
+      - linux-release
+    if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
     runs-on: ${{ inputs.runner_linux_small }}
     env:
       CC: gcc-10
@@ -305,6 +367,9 @@ jobs:
 
   regression-test-plan-cost:
     name: Regression Test Join Order Plan Cost
+    needs:
+      - linux-release
+    if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
     runs-on: ubuntu-22.04
     env:
       CC: gcc-10

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -4,6 +4,9 @@ on:
     inputs:
       base_hash:
         type: string
+      build_current_release:
+        default: 'false'
+        type: string
       runner_linux_x64:
         default: ubuntu-latest
         type: string
@@ -14,6 +17,10 @@ on:
     inputs:
       base_hash:
         description: 'Base hash'
+        type: string
+      build_current_release:
+        description: 'Build and upload linux-release-build in this workflow'
+        default: 'true'
         type: string
       runner_linux_x64:
         description: 'Optional x64 runner label override'
@@ -57,7 +64,7 @@ jobs:
           vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
 
       - name: Build current release
-        if: ${{ github.event_name != 'workflow_call' }}
+        if: ${{ inputs.build_current_release != 'false' }}
         uses: ./.github/actions/linux_release_build
         with:
           artifact_name: linux-release-build
@@ -221,9 +228,9 @@ jobs:
       - name: Test for incompatibility
         run: |
           if (cmp test/sql/storage_version/storage_version.db build/base/release/test/sql/storage_version/storage_version.db); then
-            echo "storage_changed=false" >> $GITHUB_ENV
+            echo "storage_changed=false" >> "$GITHUB_ENV"
           else
-            echo "storage_changed=true" >> $GITHUB_ENV
+            echo "storage_changed=true" >> "$GITHUB_ENV"
           fi
 
       - name: Regression Compatibility Test (testing bidirectional compatibility)

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -53,6 +53,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install tools
+        run: make toolsci
+
+      - uses: ./.github/actions/ccache-action
+
       - name: Build current release
         if: ${{ inputs.build_current_release != 'false' }}
         uses: ./.github/actions/linux_release_build

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -86,10 +86,10 @@ jobs:
     needs:
       - linux-release
     if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
-      CC: gcc-10
-      CXX: g++-10
+      CC: gcc-13
+      CXX: g++-13
       GEN: ninja
       BUILD_BENCHMARK: 1
       BUILD_JEMALLOC: 1
@@ -230,10 +230,10 @@ jobs:
     needs:
       - linux-release
     if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
-    runs-on: ${{ inputs.runner_linux_small }}
+    runs-on: ubuntu-24.04
     env:
-      CC: gcc-10
-      CXX: g++-10
+      CC: gcc-13
+      CXX: g++-13
       GEN: ninja
       CORE_EXTENSIONS: "tpch;tpcds"
 
@@ -319,10 +319,10 @@ jobs:
     needs:
       - linux-release
     if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
-    runs-on: ${{ inputs.runner_linux_small }}
+    runs-on: ubuntu-24.04
     env:
-      CC: gcc-10
-      CXX: g++-10
+      CC: gcc-13
+      CXX: g++-13
       GEN: ninja
       CORE_EXTENSIONS: "tpch;tpcds;json;parquet"
       EXTENSION_STATIC_BUILD: 1
@@ -370,10 +370,10 @@ jobs:
     needs:
       - linux-release
     if: ${{ always() && needs.linux-release.result != 'failure' && needs.linux-release.result != 'cancelled' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
-      CC: gcc-10
-      CXX: g++-10
+      CC: gcc-13
+      CXX: g++-13
       GEN: ninja
       CORE_EXTENSIONS: "tpch;httpfs"
 

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -90,26 +90,12 @@ jobs:
     needs:
       - linux-base
     runs-on: ubuntu-24.04
-    env:
-      CC: gcc-13
-      CXX: g++-13
-      GEN: ninja
-      BUILD_BENCHMARK: 1
-      BUILD_JEMALLOC: 1
-      CORE_EXTENSIONS: "json;tpch;tpcds;httpfs;inet;icu"
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Install
-        shell: bash
-        run: make toolsci && sudo apt-get install -y -qq libcurl4-openssl-dev && pip install requests
+        run: make toolsci && pip install requests
 
       - name: Checkout Private Regression
         if: ${{ github.repository == 'duckdb/duckdb' && github.ref_name == 'main' }}
@@ -144,61 +130,51 @@ jobs:
 
       - name: Regression Test Fivetran
         if: ${{ github.repository == 'duckdb/duckdb' && github.ref_name == 'main' }}
-        shell: bash
         run: |
           python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks benchmark/fivetran/benchmark_list.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test Micro
         if: always()
-        shell: bash
         run: |
           python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/micro.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test Ingestion Perf
         if: always()
-        shell: bash
         run: |
           python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/ingestion.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test TPCH
         if: always()
-        shell: bash
         run: |
           python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/tpch.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test TPCH-PARQUET
         if: always()
-        shell: bash
         run: |
           python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/tpch_parquet.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test TPCDS
         if: always()
-        shell: bash
         run: |
           python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/tpcds.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test H2OAI
         if: always()
-        shell: bash
         run: |
           python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/h2oai.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test IMDB
         if: always()
-        shell: bash
         run: |
           python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/imdb.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test CSV
         if: always()
-        shell: bash
         run: |
           python scripts/regression/test_runner.py --old build/base/release/benchmark/benchmark_runner --new build/current/release/benchmark/benchmark_runner --benchmarks .github/regression/csv.csv --verbose --threads 2 --clear-benchmark-cache
 
       - name: Regression Test RealNest
         if: always()
-        shell: bash
         run: |
           mkdir -p duckdb_benchmark_data
           wget -q https://blobs.duckdb.org/data/realnest/realnest.duckdb --output-document=duckdb_benchmark_data/real_nest.duckdb
@@ -209,23 +185,11 @@ jobs:
     needs:
       - linux-base
     runs-on: ubuntu-24.04
-    env:
-      CC: gcc-13
-      CXX: g++-13
-      GEN: ninja
-      CORE_EXTENSIONS: "tpch;tpcds"
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Install
-        shell: bash
         run: make toolsci && pip install requests
 
       - name: Download current release artifact
@@ -251,12 +215,10 @@ jobs:
           tar -xzf build/base/release-artifact.tar.gz -C build/base
 
       - name: Regression Test
-        shell: bash
         run: |
           python scripts/regression_test_storage_size.py --old build/base/release/duckdb --new build/current/release/duckdb
 
       - name: Test for incompatibility
-        shell: bash
         run: |
           if (cmp test/sql/storage_version/storage_version.db build/base/release/test/sql/storage_version/storage_version.db); then
             echo "storage_changed=false" >> $GITHUB_ENV
@@ -265,7 +227,6 @@ jobs:
           fi
 
       - name: Regression Compatibility Test (testing bidirectional compatibility)
-        shell: bash
         if: env.storage_changed == 'false'
         run: |
           # Regenerate test/sql/storage_version.db with newer version -> read with older version
@@ -279,7 +240,6 @@ jobs:
           ./build/current/release/duckdb build/base/release/test/sql/storage_version/storage_version.db
 
       - name: Regression Compatibility Test (testing storage version has been bumped)
-        shell: bash
         if: env.storage_changed == 'true'
         run: |
           python3 scripts/generate_storage_version.py
@@ -301,23 +261,12 @@ jobs:
       - linux-base
     runs-on: ${{ inputs.runner_linux_small }}
     env:
-      CC: gcc-10
-      CXX: g++-10
-      GEN: ninja
-      CORE_EXTENSIONS: "tpch;tpcds;json;parquet"
       EXTENSION_STATIC_BUILD: 1
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Install
-        shell: bash
         run: make toolsci && pip install requests
 
       - name: Download current release artifact
@@ -343,7 +292,6 @@ jobs:
           tar -xzf build/base/release-artifact.tar.gz -C build/base
 
       - name: Regression Test Extension binary size
-        shell: bash
         run: |
           python scripts/regression_test_extension_size.py --old build/base/release/extension --new build/current/release/extension --expect json,parquet,tpch,tpcds
 
@@ -352,24 +300,12 @@ jobs:
     needs:
       - linux-base
     runs-on: ubuntu-24.04
-    env:
-      CC: gcc-13
-      CXX: g++-13
-      GEN: ninja
-      CORE_EXTENSIONS: "tpch;httpfs"
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Install
-        shell: bash
-        run: make toolsci && sudo apt-get install -y -qq libcurl4-openssl-dev && pip install tqdm
+        run: make toolsci && pip install tqdm
 
       - name: Download current release artifact
         uses: actions/download-artifact@v4
@@ -395,12 +331,10 @@ jobs:
 
       - name: Regression Test IMDB
         if: always()
-        shell: bash
         run: |
           python scripts/plan_cost_runner.py --old build/base/release/duckdb --new build/current/release/duckdb --dir=benchmark/imdb_plan_cost
 
       - name: Regression Test TPCH
         if: always()
-        shell: bash
         run: |
           python scripts/plan_cost_runner.py --old build/base/release/duckdb --new build/current/release/duckdb --dir=benchmark/tpch_plan_cost

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -250,7 +250,7 @@ jobs:
 
   regression-test-binary-size:
     name: Regression test binary size
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner_linux_small }}
     env:
       CC: gcc-10
       CXX: g++-10
@@ -272,10 +272,21 @@ jobs:
 
       - uses: ./.github/actions/ccache-action
 
-      - name: Build
+      - name: Download linux release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-release-build
+          path: build
+
+      - name: Extract linux release artifact
         shell: bash
         run: |
-          make
+          rm -rf build/release
+          tar -xzf build/release-artifact.tar.gz -C build
+
+      - name: Build base branch
+        shell: bash
+        run: |
           git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
           cd duckdb
           make

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -237,24 +237,20 @@ jobs:
         if: env.storage_changed == 'false'
         run: |
           # Regenerate test/sql/storage_version.db with newer version -> read with older version
-          python3 scripts/generate_storage_version.py
+          python3 scripts/generate_storage_version.py build/current/release/duckdb
           ./build/base/release/duckdb test/sql/storage_version/storage_version.db
           # Regenerate test/sql/storage_version.db with older version -> read with newer version (already performed as part of test.slow)
-          (
-            cd build/base/release
-            python3 scripts/generate_storage_version.py
-          )
-          ./build/current/release/duckdb build/base/release/test/sql/storage_version/storage_version.db
+          python3 scripts/generate_storage_version.py build/base/release/duckdb
+          ./build/current/release/duckdb test/sql/storage_version/storage_version.db
 
       - name: Regression Compatibility Test (testing storage version has been bumped)
         if: env.storage_changed == 'true'
         run: |
-          python3 scripts/generate_storage_version.py
-          (
-            cd build/base/release
-            python3 scripts/generate_storage_version.py
-          )
-          if (cmp -i 8 -n 12 test/sql/storage_version/storage_version.db build/base/release/test/sql/storage_version/storage_version.db); then
+          python3 scripts/generate_storage_version.py build/current/release/duckdb
+          mv test/sql/storage_version/storage_version.db current.db
+          python3 scripts/generate_storage_version.py build/base/release/duckdb
+          mv test/sql/storage_version/storage_version.db base.db
+          if (cmp -i 8 -n 12 current.db base.db); then
             echo "Expected storage format to be bumped, but this is not the case"
             echo "This might fail spuriously if changes to content of test database / generation script happened"
             exit 1

--- a/scripts/generate_storage_version.py
+++ b/scripts/generate_storage_version.py
@@ -3,9 +3,13 @@
 
 import os
 import subprocess
+import sys
 from python_helpers import open_utf8
 
-shell_proc = os.path.join('build', 'release', 'duckdb')
+if len(sys.argv) > 1:
+    shell_proc = sys.argv[1]
+else:
+    shell_proc = os.path.join('build', 'release', 'duckdb')
 
 gen_storage_script = os.path.join('test', 'sql', 'storage_version', 'generate_storage_version.sql')
 gen_storage_target = os.path.join('test', 'sql', 'storage_version', 'storage_version.db')

--- a/scripts/prepare_build_artifact.sh
+++ b/scripts/prepare_build_artifact.sh
@@ -48,7 +48,7 @@ else
 	echo "No $BUILD_DIR/benchmark/benchmark_runner file found"
 fi
 
-# Required by extension tests using __BUILD_DIRECTORY__/test/extension/*.duckdb_extension.
+# Required by extension tests using build/<type>/test/extension/*.duckdb_extension.
 extension_files=("$BUILD_DIR"/test/extension/*.duckdb_extension)
 if ((${#extension_files[@]} > 0)); then
 	for extension in "${extension_files[@]}"; do
@@ -56,6 +56,18 @@ if ((${#extension_files[@]} > 0)); then
 	done
 else
 	echo "No $BUILD_DIR/test/extension/*.duckdb_extension files found"
+fi
+
+# Required by regression tests using build/<type>/extension/*.duckdb_extension.
+extension_files=("$BUILD_DIR"/extension/*/*.duckdb_extension)
+if ((${#extension_files[@]} > 0)); then
+	for extension in "${extension_files[@]}"; do
+		relative_path="${extension#"$BUILD_DIR"/}"
+		mkdir -p "$ARTIFACT_DIR/$(dirname "$relative_path")"
+		cp -av "$extension" "$ARTIFACT_DIR/$relative_path"
+	done
+else
+	echo "No $BUILD_DIR/extension/*/*.duckdb_extension files found"
 fi
 
 # Required by tests that use the local extension repository under the build directory.

--- a/scripts/prepare_build_artifact.sh
+++ b/scripts/prepare_build_artifact.sh
@@ -39,8 +39,11 @@ fi
 
 # Required by regression jobs that run the prebuilt benchmark runner.
 if [[ -f "$BUILD_DIR/benchmark/benchmark_runner" ]]; then
-	mkdir -p "$ARTIFACT_DIR"/benchmark
+	mkdir -p "$ARTIFACT_DIR"/benchmark "$ARTIFACT_DIR"/scripts
+	mkdir -p "$ARTIFACT_DIR"/test/sql/storage_version
 	cp -av "$BUILD_DIR/benchmark/benchmark_runner" "$ARTIFACT_DIR"/benchmark/
+	cp -av scripts/generate_storage_version.py "$ARTIFACT_DIR"/scripts/
+	cp -av test/sql/storage_version/. "$ARTIFACT_DIR"/test/sql/storage_version/
 else
 	echo "No $BUILD_DIR/benchmark/benchmark_runner file found"
 fi

--- a/scripts/prepare_build_artifact.sh
+++ b/scripts/prepare_build_artifact.sh
@@ -37,6 +37,14 @@ else
 	echo "No $BUILD_DIR/src/libduckdb.so* files found"
 fi
 
+# Required by regression jobs that run the prebuilt benchmark runner.
+if [[ -f "$BUILD_DIR/benchmark/benchmark_runner" ]]; then
+	mkdir -p "$ARTIFACT_DIR"/benchmark
+	cp -av "$BUILD_DIR/benchmark/benchmark_runner" "$ARTIFACT_DIR"/benchmark/
+else
+	echo "No $BUILD_DIR/benchmark/benchmark_runner file found"
+fi
+
 # Required by extension tests using __BUILD_DIRECTORY__/test/extension/*.duckdb_extension.
 extension_files=("$BUILD_DIR"/test/extension/*.duckdb_extension)
 if ((${#extension_files[@]} > 0)); then

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -175,6 +175,7 @@
 #include "duckdb/parser/tableref/showref.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/bound_result_modifier.hpp"
+#include "duckdb/planner/filter/selectivity_optional_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/buffer/buffer_pool_reservation.hpp"
 #include "duckdb/storage/caching_mode.hpp"
@@ -4391,6 +4392,25 @@ const char* EnumUtil::ToChars<SecretSerializationType>(SecretSerializationType v
 template<>
 SecretSerializationType EnumUtil::FromString<SecretSerializationType>(const char *value) {
 	return static_cast<SecretSerializationType>(StringUtil::StringToEnum(GetSecretSerializationTypeValues(), 2, "SecretSerializationType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetSelectivityOptionalFilterTypeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(SelectivityOptionalFilterType::MIN_MAX), "MIN_MAX" },
+		{ static_cast<uint32_t>(SelectivityOptionalFilterType::BF), "BF" },
+		{ static_cast<uint32_t>(SelectivityOptionalFilterType::PHJ), "PHJ" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<SelectivityOptionalFilterType>(SelectivityOptionalFilterType value) {
+	return StringUtil::EnumToString(GetSelectivityOptionalFilterTypeValues(), 3, "SelectivityOptionalFilterType", static_cast<uint32_t>(value));
+}
+
+template<>
+SelectivityOptionalFilterType EnumUtil::FromString<SelectivityOptionalFilterType>(const char *value) {
+	return static_cast<SelectivityOptionalFilterType>(StringUtil::StringToEnum(GetSelectivityOptionalFilterTypeValues(), 3, "SelectivityOptionalFilterType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetSequenceInfoValues() {

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -950,8 +950,7 @@ void JoinFilterPushdownInfo::PushBloomFilter(const PhysicalOperator &op, JoinHas
 	ht.SetBuildBloomFilter(true);
 	auto filter =
 	    make_uniq_base<TableFilter, BFTableFilter>(ht.GetBloomFilter(), filters_null_values, key_name, key_type);
-	filter = make_uniq<SelectivityOptionalFilter>(std::move(filter), SelectivityOptionalFilter::BF_THRESHOLD,
-	                                              SelectivityOptionalFilter::BF_CHECK_N);
+	filter = make_uniq<SelectivityOptionalFilter>(std::move(filter), SelectivityOptionalFilterType::BF);
 	info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(filter));
 }
 
@@ -961,8 +960,7 @@ void JoinFilterPushdownInfo::PushPerfectHashJoinFilter(const PhysicalOperator &o
                                                        ProjectionIndex filter_col_idx) const {
 	const auto key_name = op.Cast<PhysicalHashJoin>().conditions[0].GetRHS().ToString();
 	auto filter = make_uniq_base<TableFilter, PerfectHashJoinFilter>(perfect_join_executor, key_name);
-	filter = make_uniq<SelectivityOptionalFilter>(std::move(filter), SelectivityOptionalFilter::PHJ_THRESHOLD,
-	                                              SelectivityOptionalFilter::PHJ_CHECK_N);
+	filter = make_uniq<SelectivityOptionalFilter>(std::move(filter), SelectivityOptionalFilterType::PHJ);
 	info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(filter));
 }
 
@@ -981,10 +979,9 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::FinalizeMinMax(JoinFilterGlobalSta
 
 static void CreateDynamicMinMaxFilter(const PhysicalComparisonJoin &op, const JoinFilterPushdownFilter &info,
                                       const ProjectionIndex &filter_col_idx, unique_ptr<TableFilter> filter) {
-	info.dynamic_filters->PushFilter(op, filter_col_idx,
-	                                 make_uniq<SelectivityOptionalFilter>(std::move(filter),
-	                                                                      SelectivityOptionalFilter::MIN_MAX_THRESHOLD,
-	                                                                      SelectivityOptionalFilter::MIN_MAX_CHECK_N));
+	info.dynamic_filters->PushFilter(
+	    op, filter_col_idx,
+	    make_uniq<SelectivityOptionalFilter>(std::move(filter), SelectivityOptionalFilterType::MIN_MAX));
 }
 
 unique_ptr<DataChunk>

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -392,6 +392,8 @@ enum class SecretPersistType : uint8_t;
 
 enum class SecretSerializationType : uint8_t;
 
+enum class SelectivityOptionalFilterType : uint8_t;
+
 enum class SequenceInfo : uint8_t;
 
 enum class SetOperationType : uint8_t;
@@ -1042,6 +1044,9 @@ const char* EnumUtil::ToChars<SecretPersistType>(SecretPersistType value);
 
 template<>
 const char* EnumUtil::ToChars<SecretSerializationType>(SecretSerializationType value);
+
+template<>
+const char* EnumUtil::ToChars<SelectivityOptionalFilterType>(SelectivityOptionalFilterType value);
 
 template<>
 const char* EnumUtil::ToChars<SequenceInfo>(SequenceInfo value);
@@ -1748,6 +1753,9 @@ SecretPersistType EnumUtil::FromString<SecretPersistType>(const char *value);
 
 template<>
 SecretSerializationType EnumUtil::FromString<SecretSerializationType>(const char *value);
+
+template<>
+SelectivityOptionalFilterType EnumUtil::FromString<SelectivityOptionalFilterType>(const char *value);
 
 template<>
 SequenceInfo EnumUtil::FromString<SequenceInfo>(const char *value);

--- a/src/include/duckdb/planner/filter/selectivity_optional_filter.hpp
+++ b/src/include/duckdb/planner/filter/selectivity_optional_filter.hpp
@@ -47,20 +47,14 @@ struct SelectivityOptionalFilterState final : public TableFilterState {
 	}
 };
 
+enum class SelectivityOptionalFilterType : uint8_t { MIN_MAX, BF, PHJ };
+
 class SelectivityOptionalFilter final : public OptionalFilter {
 public:
-	static constexpr auto MIN_MAX_THRESHOLD = 0.9f;
-	static constexpr idx_t MIN_MAX_CHECK_N = 6;
-
-	static constexpr float BF_THRESHOLD = 0.5f;
-	static constexpr idx_t BF_CHECK_N = 6;
-
-	static constexpr float PHJ_THRESHOLD = 0.3f;
-	static constexpr idx_t PHJ_CHECK_N = 6;
-
 	float selectivity_threshold;
 	idx_t n_vectors_to_check;
 
+	SelectivityOptionalFilter(unique_ptr<TableFilter> filter, SelectivityOptionalFilterType type);
 	SelectivityOptionalFilter(unique_ptr<TableFilter> filter, float selectivity_threshold, idx_t n_vectors_to_check);
 
 public:

--- a/src/planner/filter/selectivity_optional_filter.cpp
+++ b/src/planner/filter/selectivity_optional_filter.cpp
@@ -16,15 +16,6 @@
 
 namespace duckdb {
 
-constexpr float SelectivityOptionalFilter::MIN_MAX_THRESHOLD;
-constexpr idx_t SelectivityOptionalFilter::MIN_MAX_CHECK_N;
-
-constexpr float SelectivityOptionalFilter::BF_THRESHOLD;
-constexpr idx_t SelectivityOptionalFilter::BF_CHECK_N;
-
-constexpr float SelectivityOptionalFilter::PHJ_THRESHOLD;
-constexpr idx_t SelectivityOptionalFilter::PHJ_CHECK_N;
-
 SelectivityOptionalFilterState::SelectivityStats::SelectivityStats(const idx_t n_vectors_to_check,
                                                                    const float selectivity_threshold)
     : n_vectors_to_check(n_vectors_to_check), selectivity_threshold(selectivity_threshold), tuples_accepted(0),
@@ -64,10 +55,48 @@ double SelectivityOptionalFilterState::SelectivityStats::GetSelectivity() const 
 	return static_cast<double>(tuples_accepted) / static_cast<double>(tuples_processed);
 }
 
-SelectivityOptionalFilter::SelectivityOptionalFilter(unique_ptr<TableFilter> filter, const float selectivity_threshold,
-                                                     const idx_t n_vectors_to_check)
+static float GetSelectivityThresholdForType(SelectivityOptionalFilterType type) {
+	static constexpr float MIN_MAX_THRESHOLD = 0.9f;
+	static constexpr float BF_THRESHOLD = 0.5f;
+	static constexpr float PHJ_THRESHOLD = 0.3f;
+
+	switch (type) {
+	case SelectivityOptionalFilterType::MIN_MAX:
+		return MIN_MAX_THRESHOLD;
+	case SelectivityOptionalFilterType::BF:
+		return BF_THRESHOLD;
+	case SelectivityOptionalFilterType::PHJ:
+		return PHJ_THRESHOLD;
+	default:
+		throw NotImplementedException("GetSelectivityThresholdForType");
+	}
+}
+
+static idx_t GetCheckNForType(SelectivityOptionalFilterType type) {
+	static constexpr idx_t MIN_MAX_CHECK_N = 6;
+	static constexpr idx_t BF_CHECK_N = 6;
+	static constexpr idx_t PHJ_CHECK_N = 6;
+
+	switch (type) {
+	case SelectivityOptionalFilterType::MIN_MAX:
+		return MIN_MAX_CHECK_N;
+	case SelectivityOptionalFilterType::BF:
+		return BF_CHECK_N;
+	case SelectivityOptionalFilterType::PHJ:
+		return PHJ_CHECK_N;
+	default:
+		throw NotImplementedException("GetCheckNForType");
+	}
+}
+
+SelectivityOptionalFilter::SelectivityOptionalFilter(unique_ptr<TableFilter> filter, float selectivity_threshold,
+                                                     idx_t n_vectors_to_check)
     : OptionalFilter(std::move(filter)), selectivity_threshold(selectivity_threshold),
       n_vectors_to_check(n_vectors_to_check) {
+}
+
+SelectivityOptionalFilter::SelectivityOptionalFilter(unique_ptr<TableFilter> filter, SelectivityOptionalFilterType type)
+    : SelectivityOptionalFilter(std::move(filter), GetSelectivityThresholdForType(type), GetCheckNForType(type)) {
 }
 
 FilterPropagateResult SelectivityOptionalFilter::CheckStatistics(BaseStatistics &stats) const {

--- a/test/configs/peg_parser_strict.json
+++ b/test/configs/peg_parser_strict.json
@@ -18,6 +18,12 @@
       ]
     },
     {
+      "reason": "Fix CI issue on main",
+      "paths": [
+        "test/sql/cast/struct_to_map.test"
+      ]
+    },
+    {
       "reason": "Parser error",
       "paths": [
         "test/sql/json/scalar/test_json_extract.test"


### PR DESCRIPTION
### Context

Fixes https://github.com/duckdblabs/duckdb-internal/issues/7692.

### New

- Use shared GitHub action to build a linux release.

### Changes

- Upgrade regression jobs to ubuntu 24.04 and GCC 13 (same as `linux-release` job):
  - Keep benchmarks fair by using same compiler for release and benchmark build.
  - Fix glibc symbols missing because ubuntu 20.04 ships an older glibc than 24.04.
- Disable static build of extensions for `linux-debug`.
- Reduce number of linux builds in various CI jobs. 

### Reduce linux builds

- Build a linux release for the branch on workflow or repository dispatch events.
- Re-use the linux release for the branch on workflow call events.
- Regression CI jobs are now consuming two builds for regression tests:
  - an earlier built duckdb linux base release.
  - an earlier built duckdb linux branch release.

This replaces `1 (branch) + 4 x 2 (regression jobs) = 9` builds with `1 (branch) + 1 (base) = 2`.
So overall, we removed `7` duckdb builds. 

Besides reduction in compile time, we also lower the ccache storage space (~400 MiB) by removing redundant cache entries. (Forks still have a 10 GiB repository cache storage limit.)