### PR TITLE
Allow input plan stealing through TableFunctionBindInput

### DIFF
--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -98,9 +98,11 @@ struct TableFunctionBindInput {
 	TableFunctionBindInput(vector<Value> &inputs, named_parameter_map_t &named_parameters,
 	                       vector<LogicalType> &input_table_types, vector<string> &input_table_names,
 	                       optional_ptr<TableFunctionInfo> info, optional_ptr<Binder> binder,
-	                       TableFunction &table_function, const TableFunctionRef &ref)
+	                       TableFunction &table_function, const TableFunctionRef &ref,
+	                       optional_ptr<unique_ptr<LogicalOperator>> input_plan)
 	    : inputs(inputs), named_parameters(named_parameters), input_table_types(input_table_types),
-	      input_table_names(input_table_names), info(info), binder(binder), table_function(table_function), ref(ref) {
+	      input_table_names(input_table_names), info(info), binder(binder), table_function(table_function), ref(ref),
+	      input_plan(input_plan) {
 	}
 
 	vector<Value> &inputs;
@@ -111,6 +113,7 @@ struct TableFunctionBindInput {
 	optional_ptr<Binder> binder;
 	TableFunction &table_function;
 	const TableFunctionRef &ref;
+	optional_ptr<unique_ptr<LogicalOperator>> input_plan;
 };
 
 struct TableFunctionInitInput {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -99,7 +99,7 @@ struct TableFunctionBindInput {
 	                       vector<LogicalType> &input_table_types, vector<string> &input_table_names,
 	                       optional_ptr<TableFunctionInfo> info, optional_ptr<Binder> binder,
 	                       TableFunction &table_function, const TableFunctionRef &ref,
-	                       optional_ptr<unique_ptr<LogicalOperator>> input_plan)
+	                       optional_ptr<unique_ptr<LogicalOperator>> input_plan = nullptr)
 	    : inputs(inputs), named_parameters(named_parameters), input_table_types(input_table_types),
 	      input_table_names(input_table_names), info(info), binder(binder), table_function(table_function), ref(ref),
 	      input_plan(input_plan) {

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -479,7 +479,8 @@ private:
 	BoundStatement BindTableFunction(TableFunction &function, vector<Value> parameters);
 	BoundStatement BindTableFunctionInternal(TableFunction &table_function, const TableFunctionRef &ref,
 	                                         vector<Value> parameters, named_parameter_map_t named_parameters,
-	                                         vector<LogicalType> input_table_types, vector<string> input_table_names);
+	                                         vector<LogicalType> input_table_types, vector<string> input_table_names,
+	                                         optional_ptr<unique_ptr<LogicalOperator>> input_plan);
 
 	unique_ptr<LogicalOperator> CreatePlan(BoundJoinRef &ref);
 

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -183,7 +183,8 @@ static string GetAlias(const TableFunctionRef &ref) {
 BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, const TableFunctionRef &ref,
                                                  vector<Value> parameters, named_parameter_map_t named_parameters,
                                                  vector<LogicalType> input_table_types,
-                                                 vector<string> input_table_names) {
+                                                 vector<string> input_table_names,
+                                                 optional_ptr<unique_ptr<LogicalOperator>> input_plan) {
 	auto function_name = GetAlias(ref);
 	auto &column_name_alias = ref.column_name_alias;
 	auto bind_index = GenerateTableIndex();
@@ -196,7 +197,7 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 	optional_idx ordinality_column_id;
 	if (table_function.bind || table_function.bind_replace || table_function.bind_operator) {
 		TableFunctionBindInput bind_input(parameters, named_parameters, input_table_types, input_table_names,
-		                                  table_function.function_info.get(), this, table_function, ref);
+		                                  table_function.function_info.get(), this, table_function, ref, input_plan);
 		if (table_function.bind_operator) {
 			auto new_plan = table_function.bind_operator(context, bind_input, bind_index, return_names);
 			if (new_plan) {
@@ -350,7 +351,7 @@ BoundStatement Binder::BindTableFunction(TableFunction &function, vector<Value> 
 	ref.alias = function.name;
 	D_ASSERT(!ref.alias.empty());
 	return BindTableFunctionInternal(function, ref, std::move(parameters), std::move(named_parameters),
-	                                 std::move(input_table_types), std::move(input_table_names));
+	                                 std::move(input_table_types), std::move(input_table_names), nullptr);
 }
 
 BoundStatement Binder::Bind(TableFunctionRef &ref) {
@@ -460,7 +461,7 @@ BoundStatement Binder::Bind(TableFunctionRef &ref) {
 	BoundStatement get;
 	try {
 		get = BindTableFunctionInternal(table_function, ref, std::move(parameters), std::move(named_parameters),
-		                                std::move(input_table_types), std::move(input_table_names));
+		                                std::move(input_table_types), std::move(input_table_names), &subquery.plan);
 	} catch (std::exception &ex) {
 		error = ErrorData(ex);
 		// if the error does not already contain a query location, add one

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -306,7 +306,7 @@ unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) 
 		TableFunctionRef empty_ref;
 		TableFunctionBindInput input(result->parameters, result->named_parameters, result->input_table_types,
 		                             result->input_table_names, function.function_info.get(), nullptr, result->function,
-		                             empty_ref);
+		                             empty_ref, nullptr);
 
 		vector<LogicalType> bind_return_types;
 		vector<string> bind_names;


### PR DESCRIPTION
Table functions can use quite a few nice callbacks. For example, `bind_operator` allows to consume the table function, and return a finished `LogicalOperator` (or even a full plan). This is handy if, for example, the table function can be replaced by an already existing plan operator (or a combination thereof).

However, inputs/parameter handling is a bit of a pain. In [0], function `BindTableFunctionInternal` is called, which currently only receives the extracted parameters, named parameters, etc. But there is also (possibly) a `subquery` with a `plan`, that encodes these parameters.

If this subquery plan exists, there is a bit of logic that tries to push this plan as a children of `get` [1]. But this logic is flawed. Because it assumes too much.

With this PR, the `TableFunctionBindInput` is extended to also contain an optional pointer to the owning subquery plan unique pointer. Should, e.g., the `bind_operator` hook decide to construct a _"complex plan"_ (which would fail the code path mentioned earlier) and to wire its inputs itself, this can now be done by simply getting ownership of the subquery plan unique pointer. This then disables the check in [1]. I call this plan stealing. Nothing changes for regular users of these code paths, but for more complex use cases of these hooks, getting access to the input plan is really useful.

[0] https://github.com/kryonix/duckdb/blob/a17d8173440e17b4795c1c42051d9304ce43beda/src/planner/binder/tableref/bind_table_function.cpp#L463
[1] https://github.com/kryonix/duckdb/blob/a17d8173440e17b4795c1c42051d9304ce43beda/src/planner/binder/tableref/bind_table_function.cpp#L474