### PR TITLE
CLI: Explicitly clean up shell state instead of letting static destructor order determine when it gets destroyed

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -287,7 +287,7 @@ public:
 	~ShellState();
 
 	static ShellState &Get();
-	static unique_ptr<ShellState> &GetReference();
+	static ShellState *&GetReference();
 
 	void Initialize();
 	void Destroy();

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -308,6 +308,7 @@ public:
 	void ShowConfiguration();
 	void ClearInterrupt();
 
+	static void Exit(int exit_code);
 	static idx_t RenderLength(const char *str, idx_t str_len);
 	static idx_t RenderLength(duckdb::string_t str);
 	static idx_t RenderLength(const string &str);

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -283,7 +283,11 @@ public:
 #endif
 
 public:
+	ShellState();
+	~ShellState();
+
 	static ShellState &Get();
+	static unique_ptr<ShellState> &GetReference();
 
 	void Initialize();
 	void Destroy();
@@ -312,6 +316,7 @@ public:
 	void SetTextMode();
 	static idx_t StringLength(const char *z);
 	void SetTableName(const char *zName);
+	static void StaticPrint(PrintOutput output, const char *str, idx_t len);
 	void Print(PrintOutput output, const char *str, idx_t len);
 	void Print(PrintOutput output, const char *str);
 	void Print(PrintOutput output, duckdb::string_t str);
@@ -427,10 +432,6 @@ public:
 	FILE *OpenOutputFile(const char *zFile, int bTextMode);
 	static void SetPrompt(char prompt[], const string &new_value);
 	static string ModeToString(RenderMode mode);
-
-private:
-	ShellState();
-	~ShellState();
 };
 
 struct PagerState {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -795,8 +795,14 @@ string ShellState::EscapeCString(const string &str) {
 }
 
 void ShellState::Exit(int exit_code) {
-	// clean-up shell state
-	Get().Destroy();
+	if (exit_code == 0) {
+		// clean-up shell state if this is a successful exit
+		auto shell_state = GetReference();
+		if (shell_state) {
+			delete shell_state;
+		}
+		shell_state = nullptr;
+	}
 	// then exit
 	exit(exit_code);
 }
@@ -942,8 +948,11 @@ bool ShellState::ColumnTypeIsInteger(const char *type) {
 	return false;
 }
 
-unique_ptr<ShellState> &ShellState::GetReference() {
-	static unique_ptr<ShellState> reference = make_uniq<ShellState>();
+ShellState *&ShellState::GetReference() {
+	// NOTE: this is a raw pointer to avoid the ShellState from being automatically destroyed if the CLI exits
+	// Destroying a DuckDB database during exit-time destruction can lead to odd behavior due to
+	// the static-destructor order not being defined, in particular when interacting with extensions that have statics
+	static ShellState *reference = new ShellState();
 	return reference;
 }
 
@@ -3290,9 +3299,9 @@ int wmain(int argc, wchar_t **wargv) {
 	try {
 		// destroy shell state prior to program clean-up
 		if (shell_state) {
-			shell_state->Destroy();
+			delete shell_state;
 		}
-		shell_state.reset();
+		shell_state = nullptr;
 	} catch (std::exception &ex) {
 		rc = 1;
 		ErrorData error(ex);

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -394,7 +394,7 @@ void ShellState::Print(const char *str) {
 /* Indicate out-of-memory and exit. */
 static void shell_out_of_memory(void) {
 	fprintf(stderr, "Error: out of memory\n");
-	exit(1);
+	ShellState::Exit(1);
 }
 
 ShellState::ShellState() : seenInterrupt(0), program_name("duckdb") {
@@ -794,6 +794,13 @@ string ShellState::EscapeCString(const string &str) {
 	return result;
 }
 
+void ShellState::Exit(int exit_code) {
+	// destroy the shell state
+	GetReference().reset();
+	// then exit
+	exit(exit_code);
+}
+
 extern "C" {
 
 /*
@@ -804,7 +811,7 @@ static void InterruptHandler(int NotUsed) {
 	auto &state = ShellState::Get();
 	state.seenInterrupt++;
 	if (state.seenInterrupt > 2) {
-		exit(1);
+		ShellState::Exit(1);
 	}
 	if (state.conn) {
 		state.conn->Interrupt();
@@ -1196,7 +1203,7 @@ void ShellState::OpenDB(ShellOpenFlags flags) {
 				RegisterShellLogger(*db, storage_ptr);
 				conn = make_uniq<duckdb::Connection>(*db);
 			} else {
-				exit(1);
+				ShellState::Exit(1);
 			}
 		}
 		auto &client_config = duckdb::ClientConfig::GetConfig(*conn->context);
@@ -1576,7 +1583,7 @@ void ShellState::NewTempFile(const char *zSuffix) {
 	}
 	if (zTempFile.empty()) {
 		PrintF(PrintOutput::STDERR, "out of memory\n");
-		exit(1);
+		ShellState::Exit(1);
 	}
 }
 
@@ -1695,7 +1702,7 @@ bool ShellState::ImportData(const vector<string> &args) {
 			// verbose - ignore
 		} else if (strcmp(z, "-ascii") == 0) {
 			PrintF(PrintOutput::STDERR, "-ascii mode is no longer supported for .import");
-			exit(1);
+			ShellState::Exit(1);
 		} else if (strcmp(z, "-csv") == 0) {
 			function = "read_csv";
 		} else if (strcmp(z, "-parquet") == 0) {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -935,9 +935,13 @@ bool ShellState::ColumnTypeIsInteger(const char *type) {
 	return false;
 }
 
+unique_ptr<ShellState> &ShellState::GetReference() {
+	static unique_ptr<ShellState> reference = make_uniq<ShellState>();
+	return reference;
+}
+
 ShellState &ShellState::Get() {
-	static ShellState state;
-	return state;
+	return *GetReference();
 }
 
 SuccessState ShellState::ExecuteStatement(unique_ptr<duckdb::SQLStatement> statement) {
@@ -3062,12 +3066,7 @@ void ShellState::DetectDarkLightMode() {
 #endif
 }
 
-#if SQLITE_SHELL_IS_UTF8
-int main(int argc, const char **argv) {
-#else
-int wmain(int argc, wchar_t **wargv) {
-	const char **argv;
-#endif
+int RunShell(int argc, const char **argv) {
 	int rc = 0;
 	vector<string> extra_commands;
 	ShellStateDestroyer destroyer;
@@ -3085,14 +3084,6 @@ int wmain(int argc, wchar_t **wargv) {
 
 	/* On Windows, we must translate command-line arguments into UTF-8.
 	 */
-#if !SQLITE_SHELL_IS_UTF8
-	vector<string> utf8_args;
-	utf8_args.resize(argc);
-	for (i = 0; i < argc; i++) {
-		utf8_args[i] = ShellState::Win32UnicodeToUtf8(wargv[i]);
-		argv[i] = utf8_args[i].c_str();
-	}
-#endif
 
 	assert(argc >= 1 && argv && argv[0]);
 	data.program_name = argv[0];
@@ -3271,5 +3262,38 @@ int wmain(int argc, wchar_t **wargv) {
 	data.ResetOutput();
 	data.doXdgOpen = 0;
 	data.ClearTempFile();
+	return rc;
+}
+
+#if SQLITE_SHELL_IS_UTF8
+int main(int argc, const char **argv) {
+#else
+int wmain(int argc, wchar_t **wargv) {
+	const char **argv;
+	vector<string> utf8_args;
+	utf8_args.resize(argc);
+	for (i = 0; i < argc; i++) {
+		utf8_args[i] = ShellState::Win32UnicodeToUtf8(wargv[i]);
+		argv[i] = utf8_args[i].c_str();
+	}
+#endif
+
+	auto &shell_state = ShellState::GetReference();
+	int rc = 0;
+	try {
+		rc = RunShell(argc, argv);
+	} catch (std::exception &ex) {
+		rc = 1;
+		ErrorData error(ex);
+		fprintf(stderr, "Exited due to error: %s", error.Message().c_str());
+	}
+	try {
+		// destroy shell state prior to program clean-up
+		shell_state.reset();
+	} catch (std::exception &ex) {
+		rc = 1;
+		ErrorData error(ex);
+		fprintf(stderr, "Error during clean-up due to error: %s", error.Message().c_str());
+	}
 	return rc;
 }

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -795,8 +795,8 @@ string ShellState::EscapeCString(const string &str) {
 }
 
 void ShellState::Exit(int exit_code) {
-	// destroy the shell state
-	(void) GetReference().release();
+	// clean-up shell state
+	Get().Destroy();
 	// then exit
 	exit(exit_code);
 }
@@ -3042,12 +3042,6 @@ void ShellState::Initialize() {
 #endif
 #endif
 
-struct ShellStateDestroyer {
-	~ShellStateDestroyer() {
-		ShellState::Get().Destroy();
-	}
-};
-
 void ShellState::DetectDarkLightMode() {
 #ifdef HAVE_LINENOISE
 	ShellHighlight highlight(*this);
@@ -3076,7 +3070,6 @@ void ShellState::DetectDarkLightMode() {
 int RunShell(int argc, const char **argv) {
 	int rc = 0;
 	vector<string> extra_commands;
-	ShellStateDestroyer destroyer;
 
 	auto &data = ShellState::Get();
 	data.out = stdout;
@@ -3296,6 +3289,9 @@ int wmain(int argc, wchar_t **wargv) {
 	}
 	try {
 		// destroy shell state prior to program clean-up
+		if (shell_state) {
+			shell_state->Destroy();
+		}
 		shell_state.reset();
 	} catch (std::exception &ex) {
 		rc = 1;

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -796,7 +796,7 @@ string ShellState::EscapeCString(const string &str) {
 
 void ShellState::Exit(int exit_code) {
 	// destroy the shell state
-	GetReference().reset();
+	(void) GetReference().release();
 	// then exit
 	exit(exit_code);
 }

--- a/tools/shell/shell_command_line_option.cpp
+++ b/tools/shell/shell_command_line_option.cpp
@@ -87,7 +87,7 @@ MetadataResult LaunchUI(ShellState &state, const vector<string> &args) {
 	// run the UI command
 	auto rc = state.RunInitialCommand((char *)state.ui_command.c_str(), true);
 	if (rc != 0) {
-		exit(rc);
+		ShellState::Exit(rc);
 		return MetadataResult::EXIT;
 	}
 	return MetadataResult::SUCCESS;
@@ -119,7 +119,7 @@ MetadataResult ProcessFile(ShellState &state, const vector<string> &args) {
 	state.bail_on_error = true;
 	auto &file = args[1];
 	if (!state.ProcessFile(file)) {
-		exit(1);
+		ShellState::Exit(1);
 		return MetadataResult::EXIT;
 	}
 	state.bail_on_error = old_bail;
@@ -141,7 +141,7 @@ MetadataResult RunCommand(ShellState &state, const vector<string> &args) {
 	auto &cmd = args[1];
 	auto rc = state.RunInitialCommand(cmd.c_str(), bail);
 	if (rc != 0) {
-		exit(rc);
+		ShellState::Exit(rc);
 		return MetadataResult::EXIT;
 	}
 	return MetadataResult::SUCCESS;
@@ -274,7 +274,7 @@ void ShellState::PrintUsage() {
 		}
 		PrintF("%s%s\n", spaces.c_str(), option.description.c_str());
 	}
-	exit(0);
+	ShellState::Exit(0);
 }
 
 } // namespace duckdb_shell

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -160,7 +160,7 @@ MetadataResult ExitProcess(ShellState &state, const vector<string> &args) {
 	int rc = 0;
 	if (args.size() > 1 && (rc = (int)ShellState::StringToInt(args[1])) != 0) {
 		// exit immediately if a custom error code is provided
-		exit(rc);
+		ShellState::Exit(rc);
 	}
 	return MetadataResult::EXIT;
 }


### PR DESCRIPTION
In the CLI, instead of directly calling `exit()`, first destroy the ShellState and then call exit. This prevents the shell state from being destroyed as part of static exit-time destruction. This prevents a bunch of issues around exit-time destructor order - particularly with extensions loaded which themselves have static variables that are destroyed at exit-time. 