### PR TITLE
Fix unbounded row group growth for indexed tables on repeated load+insert cycles

### DIFF
--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -362,7 +362,7 @@ void RowGroupCollection::InitializeAppend(TransactionData transaction, TableAppe
 
 	// start writing to the row_groups
 	auto l = row_groups->Lock();
-	if (IsEmpty(l) || requires_new_row_group) {
+	if (IsEmpty(l) || (requires_new_row_group && info->GetIndexes().Empty())) {
 		// empty row group collection: empty first row group
 		AppendRowGroup(l, row_start + total_rows);
 	}

--- a/test/sql/storage/checkpoint/indexed_table_row_group_growth.test_slow
+++ b/test/sql/storage/checkpoint/indexed_table_row_group_growth.test_slow
@@ -1,0 +1,36 @@
+# name: test/sql/storage/checkpoint/indexed_table_row_group_growth.test_slow
+# description: Test that indexed tables do not create a new row group on every load+insert cycle
+# group: [checkpoint]
+
+load __TEST_DIR__/indexed_table_row_group_growth.db
+
+statement ok
+create table z(id integer primary key, a varchar, b varchar, c varchar);
+
+statement ok
+insert into z select i, sha256(i::varchar) as a, sha256((i**2)::varchar) as b, sha256((i**3)::varchar) as c from range(100000) r(i);
+
+statement ok
+CHECKPOINT;
+
+# restart and insert small batches - each restart triggers the DataTable constructor
+# which previously set requires_new_row_group=true for indexed tables (due to indexes
+# not being loaded yet), causing a new row group on every cycle
+loop i 0 20
+
+restart
+
+statement ok
+insert into z select 100000 + 100 * ${i} + j, 'a','b','c' from range(100) t(j);
+
+statement ok
+CHECKPOINT;
+
+endloop
+
+# without the fix, this would create 20+ row groups (one per restart+insert cycle)
+# with the fix, small inserts append to the last existing row group
+query I
+SELECT COUNT(DISTINCT row_group_id) < 5 FROM pragma_storage_info('z')
+----
+true


### PR DESCRIPTION
The `requires_new_row_group flag` (introduced in a5c1469e8e8 to avoid write amplification during checkpoint) was incorrectly applied to tables with indexes, causing a new row group to be created on every database load + insert cycle. This led to unbounded file growth.

**Root cause**: During checkpoint loading, the DataTable constructor calls HasIndexes() to decide whether to set requires_new_row_group. However, indexes are deserialized later (ReadIndex runs after ReadTable in the checkpoint reader), so HasIndexes() always returns false at construction time — even for tables with a PRIMARY KEY. The flag was therefore set unconditionally for all tables.

The flag's intent is to create small row groups that vacuum can later merge. But vacuum is disabled for indexed tables (can_vacuum_deletes requires GetIndexes().Empty()), so the small row groups created for indexed tables could never be compacted — accumulating one new row group per load+insert cycle indefinitely.

**Fix**: Move the GetIndexes().Empty() guard from set-time (in the DataTable constructor, where indexes aren't loaded yet) to consumption-time (in InitializeAppend, where indexes are guaranteed to be loaded). The flag is still set in the constructor, but only honored for non-indexed tables.

For non-indexed tables, behavior is unchanged: small row groups are created and later merged by vacuum. For indexed tables, appends go to the last existing row group (matching v1.2.1 behavior), avoiding the unbounded growth.

Potentially Fixes: duckdb/duckdb#17778