### PR TITLE
Windows shell: fix UTF-8 to UTF-16 conversion

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -395,6 +395,8 @@ public:
 	void DetectDarkLightMode();
 #if defined(_WIN32) || defined(WIN32)
 	static std::wstring Win32Utf8ToUnicode(const string &zText);
+	static std::wstring Win32Utf8ToUnicode(const char *) = delete;
+	static std::wstring Win32Utf8ToUnicode(char *) = delete;
 	static string Win32UnicodeToUtf8(const std::wstring &zWideText);
 	static string Win32MbcsToUtf8(const string &zText, bool useAnsi);
 	static string Win32Utf8ToMbcs(const string &zText, bool useAnsi);

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -1401,7 +1401,8 @@ bool Linenoise::TryGetKeyPress(int fd, KeyPress &key_press) {
 bool Linenoise::Write(int fd, const char *data, idx_t size) {
 #if defined(_WIN32) || defined(WIN32)
 	// convert to character encoding in Windows shell
-	auto unicode_text = duckdb_shell::ShellState::Win32Utf8ToUnicode(data);
+	string data_str = data ? string(data, size) : "";
+	auto unicode_text = duckdb_shell::ShellState::Win32Utf8ToUnicode(data_str);
 	auto out_handle = GetStdHandle(STD_OUTPUT_HANDLE);
 	if (!WriteConsoleW(out_handle, unicode_text.c_str(), unicode_text.size(), NULL, NULL)) {
 		return false;

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -345,7 +345,8 @@ void ShellState::Print(PrintOutput output, const char *str, idx_t len) {
 #if defined(_WIN32) || defined(WIN32)
 	if ((stdout_is_console && (out == stdout || out == stderr)) && !pager_is_active) {
 		// convert from utf8 to utf16
-		auto unicode_text = ShellState::Win32Utf8ToUnicode(str);
+		string data_str = str ? string(str, len) : "";
+		auto unicode_text = ShellState::Win32Utf8ToUnicode(data_str);
 		auto out_handle = GetStdHandle(output == PrintOutput::STDOUT ? STD_OUTPUT_HANDLE : STD_ERROR_HANDLE);
 		// use WriteConsoleW to write the unicode codepoints to the console
 		WriteConsoleW(out_handle, unicode_text.c_str(), unicode_text.size(), NULL, NULL);
@@ -1519,7 +1520,8 @@ static bool optionMatch(const string &str, const string &zOpt) {
 int shellDeleteFile(const char *zFilename) {
 	int rc;
 #ifdef _WIN32
-	auto z = ShellState::Win32Utf8ToUnicode(zFilename);
+	string str(zFilename);
+	auto z = ShellState::Win32Utf8ToUnicode(str);
 	rc = _wunlink(z.c_str());
 #else
 	rc = unlink(zFilename);
@@ -2347,7 +2349,7 @@ WHERE type='index' AND tbl_name LIKE ?1)";
 SuccessState ShellState::ChangeDirectory(const string &path) {
 	int rc;
 #if defined(_WIN32) || defined(WIN32)
-	auto z = ShellState::Win32Utf8ToUnicode(path.c_str());
+	auto z = ShellState::Win32Utf8ToUnicode(path);
 	rc = !SetCurrentDirectoryW(z.c_str());
 #else
 	rc = chdir(path.c_str());


### PR DESCRIPTION
Encoding conversion routine in shell takes `std::string`, but in some cases a pointer from a `string_t` was passed there without the length. As a result garbage from raw memory was printed in console.

This PR disallows auto-wrapping the pointer into `std::string`.

The change is Windows-only.

Fixes: #21295