### PR TITLE
Adjust v1.5.0 for z/OS

### DIFF
--- a/extension/extension_build_tools.cmake
+++ b/extension/extension_build_tools.cmake
@@ -145,7 +145,7 @@ function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTEN
                 set(WHITELIST "-Wl,-exported_symbol,_${NAME}_duckdb_cpp_init")
                 target_link_libraries(${TARGET_NAME} duckdb_static dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,-dead_strip ${WHITELIST})
             elseif (ZOS)
-                target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS})
+                target_link_libraries(${TARGET_NAME} duckdb_static dummy_static_extension_loader ${DUCKDB_EXTRA_LINK_FLAGS})
             else()
                 # For GNU we rely on fvisibility=hidden to hide the extension symbols and use -exclude-libs to hide the duckdb symbols
                 set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)

--- a/src/main/user_settings.cpp
+++ b/src/main/user_settings.cpp
@@ -2,6 +2,9 @@
 #include "duckdb/main/settings.hpp"
 #include "duckdb/common/types/string.hpp"
 #include "duckdb/common/types/uuid.hpp"
+#ifdef __MVS__
+#include <zos-tls.h>
+#endif
 
 namespace duckdb {
 
@@ -135,8 +138,13 @@ bool GlobalUserSettings::TryGetExtensionOption(const String &name, ExtensionOpti
 
 #ifndef __MINGW32__
 CachedGlobalSettings &GlobalUserSettings::GetSettings() const {
-	// Cache of global settings - used to allow lock-free access to global settings in a thread-safe manner
+// Cache of global settings - used to allow lock-free access to global settings in a thread-safe manner
+#ifdef __MVS__
+	static __tlssim<CachedGlobalSettings> current_cache_impl;
+#define current_cache (*current_cache_impl.access())
+#else
 	thread_local CachedGlobalSettings current_cache;
+#endif
 
 	const auto current_version = settings_version.load(std::memory_order_relaxed);
 	if (!current_cache.global_user_settings || this != current_cache.global_user_settings.get() ||
@@ -146,6 +154,9 @@ CachedGlobalSettings &GlobalUserSettings::GetSettings() const {
 		current_cache = CachedGlobalSettings(*this, settings_version, settings_map);
 	}
 	return current_cache;
+#ifdef __MVS__
+#undef current_cache
+#endif
 }
 
 hugeint_t GlobalUserSettings::GetUUID() const {

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -203,6 +203,12 @@
     "cpp-httplib doesn't support platforms where size_t is less than 64 bits."
 #endif
 
+#ifdef __MVS__
+#define REGEX_SCOPE static
+#else
+#define REGEX_SCOPE thread_local
+#endif
+
 /*
  * Headers
  */
@@ -2947,11 +2953,7 @@ inline std::string encode_path(const std::string &s) {
 
 inline std::string file_extension(const std::string &path) {
   Match m;
-  #ifdef __MVS__
-  static const auto re = Regex("\\.([a-zA-Z0-9]+)$");
-  #else
-  thread_local auto re = Regex("\\.([a-zA-Z0-9]+)$");
-  #endif
+  REGEX_SCOPE auto re = Regex("\\.([a-zA-Z0-9]+)$");
   if (duckdb_re2::RegexSearch(path, m, re)) { return m[1].str(); }
   return std::string();
 }
@@ -5720,15 +5722,9 @@ public:
             file_.content_type =
                 trim_copy(header.substr(str_len(header_content_type)));
           } else {
-          #ifdef __MVS__
-            static const Regex re_content_disposition(
+            REGEX_SCOPE const Regex re_content_disposition(
                 R"~(^Content-Disposition:\s*form-data;\s*(.*)$)~",
                 duckdb_re2::RegexOptions::CASE_INSENSITIVE);
-            #else
-            thread_local const Regex re_content_disposition(
-                R"~(^Content-Disposition:\s*form-data;\s*(.*)$)~",
-                duckdb_re2::RegexOptions::CASE_INSENSITIVE);
-            #endif
 
             Match m;
             if (RegexMatch(header, m, re_content_disposition)) {
@@ -5749,13 +5745,8 @@ public:
               it = params.find("filename*");
               if (it != params.end()) {
                 // Only allow UTF-8 encoding...
-                #ifdef __MVS__
-                static const Regex re_rfc5987_encoding(
+                REGEX_SCOPE const Regex re_rfc5987_encoding(
                     R"~(^UTF-8''(.+?)$)~", duckdb_re2::RegexOptions::CASE_INSENSITIVE);
-                #else
-                thread_local const Regex re_rfc5987_encoding(
-                    R"~(^UTF-8''(.+?)$)~", duckdb_re2::RegexOptions::CASE_INSENSITIVE);
-                #endif
 
                 Match m2;
                 if (RegexMatch(it->second, m2, re_rfc5987_encoding)) {
@@ -6491,13 +6482,8 @@ inline bool parse_www_authenticate(const Response &res,
                                    bool is_proxy) {
   auto auth_key = is_proxy ? "Proxy-Authenticate" : "WWW-Authenticate";
   if (res.has_header(auth_key)) {
-#ifdef __MVS__
-    static const auto re =
+    REGEX_SCOPE auto re =
         Regex(R"~((?:(?:,\s*)?(.+?)=(?:"(.*?)"|([^,]*))))~");
-    #else
-    thread_local auto re =
-        Regex(R"~((?:(?:,\s*)?(.+?)=(?:"(.*?)"|([^,]*))))~");
-    #endif
     auto s = res.get_header_value(auth_key);
     auto pos = s.find(' ');
     if (pos != std::string::npos) {
@@ -6814,11 +6800,7 @@ inline std::string decode_query_component(const std::string &component,
 inline std::string append_query_params(const std::string &path,
                                        const Params &params) {
   std::string path_with_query = path;
-#ifdef __MVS__
-  static const Regex re("[^?]+\\?.*");
-  #else
-  thread_local const Regex re("[^?]+\\?.*");
-  #endif
+  REGEX_SCOPE const Regex re("[^?]+\\?.*");
   auto delm = RegexMatch(path, re) ? '&' : '?';
   path_with_query += delm + detail::params_to_query_str(params);
   return path_with_query;
@@ -8838,18 +8820,10 @@ inline bool ClientImpl::read_response_line(Stream &strm, const Request &req,
 
   if (!line_reader.getline()) { return false; }
 
-#ifdef __MVS__
 #ifdef CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR
-  static const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r?\n");
+  REGEX_SCOPE const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r?\n");
 #else
-  static const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r\n");
-#endif
-#else
-#ifdef CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR
-  thread_local const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r?\n");
-#else
-  thread_local const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r\n");
-#endif
+  REGEX_SCOPE const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r\n");
 #endif
 
   Match m;
@@ -9104,13 +9078,8 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
 	 return true;
 	}
 
-#ifdef __MVS__
-  static const Regex re(
+  REGEX_SCOPE const Regex re(
       R"((?:(https?):)?(?://(?:\[([a-fA-F\d:]+)\]|([^:/?#]+))(?::(\d+))?)?([^?#]*)(\?[^#]*)?(?:#.*)?)");
-  #else
-  thread_local const Regex re(
-      R"((?:(https?):)?(?://(?:\[([a-fA-F\d:]+)\]|([^:/?#]+))(?::(\d+))?)?([^?#]*)(\?[^#]*)?(?:#.*)?)");
-  #endif
 
   Match m;
   if (!RegexMatch(location, m, re)) { return false; }

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -266,6 +266,7 @@ using socklen_t = int;
 #endif
 #ifdef __MVS__
 #include <strings.h>
+#include <sys/time.h>
 #ifndef NI_MAXHOST
 #define NI_MAXHOST 1025
 #endif
@@ -2946,7 +2947,11 @@ inline std::string encode_path(const std::string &s) {
 
 inline std::string file_extension(const std::string &path) {
   Match m;
+  #ifdef __MVS__
+  static const auto re = Regex("\\.([a-zA-Z0-9]+)$");
+  #else
   thread_local auto re = Regex("\\.([a-zA-Z0-9]+)$");
+  #endif
   if (duckdb_re2::RegexSearch(path, m, re)) { return m[1].str(); }
   return std::string();
 }
@@ -4927,7 +4932,7 @@ inline ReadContentResult read_content_chunked(Stream &strm, T &x,
   if (!line_reader.getline()) { return ReadContentResult::Success; }
 
   // RFC 7230 Section 4.1.2 - Headers prohibited in trailers
-  thread_local case_ignore::unordered_set<std::string> prohibited_trailers = {
+  static const case_ignore::unordered_set<std::string> prohibited_trailers = {
       // Message framing
       "transfer-encoding", "content-length",
 
@@ -5715,9 +5720,15 @@ public:
             file_.content_type =
                 trim_copy(header.substr(str_len(header_content_type)));
           } else {
+          #ifdef __MVS__
+            static const Regex re_content_disposition(
+                R"~(^Content-Disposition:\s*form-data;\s*(.*)$)~",
+                duckdb_re2::RegexOptions::CASE_INSENSITIVE);
+            #else
             thread_local const Regex re_content_disposition(
                 R"~(^Content-Disposition:\s*form-data;\s*(.*)$)~",
                 duckdb_re2::RegexOptions::CASE_INSENSITIVE);
+            #endif
 
             Match m;
             if (RegexMatch(header, m, re_content_disposition)) {
@@ -5738,8 +5749,13 @@ public:
               it = params.find("filename*");
               if (it != params.end()) {
                 // Only allow UTF-8 encoding...
+                #ifdef __MVS__
+                static const Regex re_rfc5987_encoding(
+                    R"~(^UTF-8''(.+?)$)~", duckdb_re2::RegexOptions::CASE_INSENSITIVE);
+                #else
                 thread_local const Regex re_rfc5987_encoding(
                     R"~(^UTF-8''(.+?)$)~", duckdb_re2::RegexOptions::CASE_INSENSITIVE);
+                #endif
 
                 Match m2;
                 if (RegexMatch(it->second, m2, re_rfc5987_encoding)) {
@@ -6475,8 +6491,13 @@ inline bool parse_www_authenticate(const Response &res,
                                    bool is_proxy) {
   auto auth_key = is_proxy ? "Proxy-Authenticate" : "WWW-Authenticate";
   if (res.has_header(auth_key)) {
+#ifdef __MVS__
+    static const auto re =
+        Regex(R"~((?:(?:,\s*)?(.+?)=(?:"(.*?)"|([^,]*))))~");
+    #else
     thread_local auto re =
         Regex(R"~((?:(?:,\s*)?(.+?)=(?:"(.*?)"|([^,]*))))~");
+    #endif
     auto s = res.get_header_value(auth_key);
     auto pos = s.find(' ');
     if (pos != std::string::npos) {
@@ -6793,7 +6814,11 @@ inline std::string decode_query_component(const std::string &component,
 inline std::string append_query_params(const std::string &path,
                                        const Params &params) {
   std::string path_with_query = path;
+#ifdef __MVS__
+  static const Regex re("[^?]+\\?.*");
+  #else
   thread_local const Regex re("[^?]+\\?.*");
+  #endif
   auto delm = RegexMatch(path, re) ? '&' : '?';
   path_with_query += delm + detail::params_to_query_str(params);
   return path_with_query;
@@ -8813,10 +8838,18 @@ inline bool ClientImpl::read_response_line(Stream &strm, const Request &req,
 
   if (!line_reader.getline()) { return false; }
 
+#ifdef __MVS__
+#ifdef CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR
+  static const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r?\n");
+#else
+  static const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r\n");
+#endif
+#else
 #ifdef CPPHTTPLIB_ALLOW_LF_AS_LINE_TERMINATOR
   thread_local const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r?\n");
 #else
   thread_local const Regex re("(HTTP/1\\.[01]) (\\d{3})(?: (.*?))?\r\n");
+#endif
 #endif
 
   Match m;
@@ -9071,8 +9104,13 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
 	 return true;
 	}
 
+#ifdef __MVS__
+  static const Regex re(
+      R"((?:(https?):)?(?://(?:\[([a-fA-F\d:]+)\]|([^:/?#]+))(?::(\d+))?)?([^?#]*)(\?[^#]*)?(?:#.*)?)");
+  #else
   thread_local const Regex re(
       R"((?:(https?):)?(?://(?:\[([a-fA-F\d:]+)\]|([^:/?#]+))(?::(\d+))?)?([^?#]*)(\?[^#]*)?(?:#.*)?)");
+  #endif
 
   Match m;
   if (!RegexMatch(location, m, re)) { return false; }


### PR DESCRIPTION
The PR adds z/OS related adjustments to v1.5.

Besides z/OS-only minor updates, it changes some variables in `httplib.hpp` from `thread_local` to `static const`.

The justification:
- it's required for z/OS and shouldn't hurt supported platforms;
- most of the variables use `duckdb_re2::RE2` under the hood which is specifically designed to be thread-safe and logically immutable - from what I see (unlike the original httplib code);
- besides those, there's `prohibited_trailers` also being used in thread safe manner.

Thank you.