### PR TITLE
bwc: ignore indented comments in exclusion list parser

### DIFF
--- a/test/bwc/utils/test_files_parser.py
+++ b/test/bwc/utils/test_files_parser.py
@@ -56,7 +56,7 @@ def parse_excluded_tests(path):
     with open(path) as f:
         for line in f:
             stripped = line.strip()
-            if len(stripped) > 0 and line[0] != '#':
+            if len(stripped) > 0 and stripped[0] != '#':
                 exclusion_list[stripped] = True
     return exclusion_list
 


### PR DESCRIPTION
## Summary
- ignore exclusion-list comment lines even when they are indented
- keep trimmed exclusion entries unchanged

## Motivation
The BWC exclusion parser trims each line before storing it, but it currently checks line[0] != '#' on the raw text. That means lines like   # comment are treated as exclusion entries instead of comments.

This change checks the first character of the trimmed line instead, so indented comments are skipped the same way as non-indented comments.

## Validation
- reproduced the parser behavior directly against parse_excluded_tests() with a temporary file containing an indented comment and real exclusions
- confirmed the indented comment is ignored while real exclusions are still returned