### PR TITLE
Run compatibilty storage tests in parallel

### DIFF
--- a/scripts/test_storage_compatibility.py
+++ b/scripts/test_storage_compatibility.py
@@ -1,10 +1,11 @@
 import argparse
-import os
-import subprocess
-import re
+import concurrent.futures
 import csv
+import os
 from pathlib import Path
+import subprocess
 import sys
+import tempfile
 
 parser = argparse.ArgumentParser(description='Run a full benchmark using the CLI and report the results.')
 group = parser.add_mutually_exclusive_group(required=True)
@@ -17,6 +18,7 @@ parser.add_argument(
     '--test-config', action='store', help='Test config script to run', default='test/configs/storage_compatibility.json'
 )
 parser.add_argument('--db-name', action='store', help='Database name to write to', default='bwc_storage_test.db')
+parser.add_argument('--workers', action='store', help='Number of workers or CPU percentage to use', default='75%')
 parser.add_argument('--abort-on-failure', action='store_true', help='Abort on first failure', default=False)
 parser.add_argument('--start-offset', type=int, action='store', help='Test start offset', default=None)
 parser.add_argument('--end-offset', type=int, action='store', help='Test end offset', default=None)
@@ -31,6 +33,16 @@ parser.add_argument(
 
 args, extra_args = parser.parse_known_args()
 
+
+def resolve_workers(workers):
+    cpu_count = os.cpu_count() or 1
+    workers = workers.strip()
+    if workers.endswith("%"):
+        percentage = int(workers[:-1])
+        return max(1, int(cpu_count * (percentage / 100.0)))
+    return max(1, int(workers))
+
+
 programs_to_test = []
 if args.versions is not None:
     version_splits = args.versions.split('|')
@@ -39,18 +51,24 @@ if args.versions is not None:
         if not os.path.isfile(cli_path):
             if os.system(f'curl https://install.duckdb.org | DUCKDB_VERSION={version} sh'):
                 raise Exception(f"CURL install for DuckDB version: {version} failed")
-        programs_to_test.append(cli_path)
+        programs_to_test.append(os.path.abspath(cli_path))
 else:
-    programs_to_test.append(args.old_cli)
+    programs_to_test.append(os.path.abspath(args.old_cli))
 
-unittest_program = args.new_unittest
+unittest_program = os.path.abspath(args.new_unittest)
 db_name = args.db_name
-new_cli = args.new_unittest.replace('test/unittest', 'duckdb') if args.new_cli is None else args.new_cli
+test_config = os.path.abspath(args.test_config)
+new_cli = (
+    os.path.abspath(args.new_unittest.replace('test/unittest', 'duckdb'))
+    if args.new_cli is None
+    else os.path.abspath(args.new_cli)
+)
 summarize_failures = not args.no_summarize_failures
+workers = resolve_workers(args.workers)
 
 # Use the '-l' parameter to output the list of tests to run
 proc = subprocess.run(
-    [unittest_program, '--test-config', args.test_config, '-l'] + extra_args,
+    [unittest_program, '--test-config', test_config, '-l'] + extra_args,
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,
 )
@@ -74,7 +92,7 @@ for line in stdout.splitlines():
     if len(line.strip()) == 0:
         continue
     splits = line.rsplit('\t', 1)
-    test_cases.append(splits[0])
+    test_cases.append(os.path.abspath(splits[0]))
 
 test_cases.sort()
 if args.compatibility != 'v1.0.0':
@@ -110,14 +128,11 @@ def handle_failure(test, cmd, msg, stdout, stderr, returncode):
     print(f"==============STDERR=============", file=sys.stderr)
     print(stderr, file=sys.stderr)
     print(f"=================================", file=sys.stderr)
-    if args.abort_on_failure:
-        exit(1)
-    else:
-        error_container.append({'test': test, 'stderr': stderr})
+    error_container.append({'test': test, 'stderr': stderr})
 
 
-def run_program(cmd, description):
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def run_program(test, cmd, description, cwd=None):
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
     stdout = proc.stdout.decode('utf8').strip()
     stderr = proc.stderr.decode('utf8').strip()
     if proc.returncode != 0:
@@ -132,91 +147,130 @@ def run_program(cmd, description):
     return None
 
 
-def try_run_program(cmd, description):
-    result = run_program(cmd, description)
-    if result is None:
-        return True
-    handle_failure(**result)
-    return False
-
-
-index = 0
-start = 0 if args.start_offset is None else args.start_offset
-end = len(test_cases) if args.end_offset is None else args.end_offset
-for i in range(start, end):
-    test = test_cases[i]
-    skipped = ''
+def execute_test(i, test):
+    skipped = False
     if not args.run_empty_tests:
         with open(test, 'r') as f:
             test_contents = f.read().lower()
         if 'create table' not in test_contents and 'create view' not in test_contents:
-            skipped = ' (SKIPPED)'
+            skipped = True
 
-    print(f'[{i}/{len(test_cases)}]: {test}{skipped}')
-    if skipped != '':
-        continue
-    # remove the old db
-    try:
-        os.remove(db_name)
-    except:
-        pass
-    cmd = [unittest_program, '--test-config', args.test_config, test]
-    if not try_run_program(cmd, 'Run Test'):
-        print("Failed to Run Test")
-        continue
+    result = {
+        'index': i,
+        'test': test,
+        'skipped': skipped,
+        'messages': [],
+        'failures': [],
+    }
+    if skipped:
+        return result
 
-    if not os.path.isfile(db_name):
-        # db not created
-        print(f"Failed to create a database file by the name of {db_name}")
-        continue
-
-    cmd = [
-        programs_to_test[-1],
-        db_name,
-        '-c',
-        '.headers off',
-        '-csv',
-        '-c',
-        '.output table_list.csv',
-        '-c',
-        'SHOW ALL TABLES',
-    ]
-    if not try_run_program(cmd, 'List Tables'):
-        print("Failed to List Tables")
-        continue
-
-    tables = []
-    with open('table_list.csv', newline='') as f:
-        reader = csv.reader(f)
-        for row in reader:
-            tables.append((row[1], row[2]))
-    # no tables / views
-    if len(tables) == 0:
-        print("No tables/views were created, skipping")
-        continue
-
-    # read all tables / views
-    failures = []
-    for cli in programs_to_test:
-        cmd = [cli, db_name]
-        for table in tables:
-            schema_name = table[0].replace('"', '""')
-            table_name = table[1].replace('"', '""')
-            cmd += ['-c', f'FROM "{schema_name}"."{table_name}"']
-        failure = run_program(cmd, 'Query Tables')
+    with tempfile.TemporaryDirectory(prefix='storage_compat_') as temp_dir:
+        db_path = os.path.join(temp_dir, db_name)
+        table_list_path = os.path.join(temp_dir, 'table_list.csv')
+        failure = run_program(
+            test,
+            [unittest_program, '--test-config', test_config, test],
+            'Run Test',
+            cwd=temp_dir,
+        )
         if failure is not None:
-            failures.append(failure)
-    if len(failures) > 0:
-        # we failed to query the tables
-        # this MIGHT be expected - e.g. we might have views that reference stale state (e.g. files that are deleted)
-        # try to run it with the new CLI - if this succeeds we have a problem
-        new_cmd = [new_cli] + cmd[1:]
-        new_failure = run_program(new_cmd, 'Query Tables (New)')
-        if new_failure is None:
-            # we succeeded with the new CLI - report the failure
-            for failure in failures:
-                handle_failure(**failure)
-        continue
+            result['failures'].append(failure)
+            result['messages'].append("Failed to Run Test")
+            return result
+
+        if not os.path.isfile(db_path):
+            result['messages'].append(f"Failed to create a database file by the name of {db_path}")
+            return result
+
+        failure = run_program(
+            test,
+            [
+                programs_to_test[-1],
+                db_path,
+                '-c',
+                '.headers off',
+                '-csv',
+                '-c',
+                f'.output {table_list_path}',
+                '-c',
+                'SHOW ALL TABLES',
+            ],
+            'List Tables',
+        )
+        if failure is not None:
+            result['failures'].append(failure)
+            result['messages'].append("Failed to List Tables")
+            return result
+
+        tables = []
+        with open(table_list_path, newline='') as f:
+            reader = csv.reader(f)
+            for row in reader:
+                tables.append((row[1], row[2]))
+        if len(tables) == 0:
+            result['messages'].append("No tables/views were created, skipping")
+            return result
+
+        failures = []
+        last_cmd = None
+        for cli in programs_to_test:
+            cmd = [cli, db_path]
+            for table in tables:
+                schema_name = table[0].replace('"', '""')
+                table_name = table[1].replace('"', '""')
+                cmd += ['-c', f'FROM "{schema_name}"."{table_name}"']
+            last_cmd = cmd
+            failure = run_program(test, cmd, 'Query Tables')
+            if failure is not None:
+                failures.append(failure)
+        if len(failures) > 0:
+            # A query failure can be expected for stale views. Only report it
+            # when the same query succeeds against the new CLI.
+            new_cmd = [new_cli] + last_cmd[1:]
+            new_failure = run_program(test, new_cmd, 'Query Tables (New)')
+            if new_failure is None:
+                result['failures'].extend(failures)
+        return result
+
+
+def process_result(result):
+    i = result['index']
+    test = result['test']
+    suffix = ' (SKIPPED)' if result['skipped'] else ''
+    print(f'[{i}/{len(test_cases)}]: {test}{suffix}')
+    for failure in result['failures']:
+        handle_failure(**failure)
+    for message in result['messages']:
+        print(message)
+
+
+start = 0 if args.start_offset is None else args.start_offset
+end = len(test_cases) if args.end_offset is None else args.end_offset
+selected_tests = list(enumerate(test_cases[start:end], start=start))
+
+with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+    future_to_test = {}
+    next_test_idx = 0
+
+    while next_test_idx < len(selected_tests) and len(future_to_test) < workers:
+        i, test = selected_tests[next_test_idx]
+        future_to_test[executor.submit(execute_test, i, test)] = (i, test)
+        next_test_idx += 1
+
+    stop_launching = False
+    while future_to_test:
+        done, _ = concurrent.futures.wait(future_to_test, return_when=concurrent.futures.FIRST_COMPLETED)
+        for future in done:
+            future_to_test.pop(future)
+            result = future.result()
+            process_result(result)
+            if args.abort_on_failure and len(error_container) > 0:
+                stop_launching = True
+        while not stop_launching and next_test_idx < len(selected_tests) and len(future_to_test) < workers:
+            i, test = selected_tests[next_test_idx]
+            future_to_test[executor.submit(execute_test, i, test)] = (i, test)
+            next_test_idx += 1
 
 if len(error_container) == 0:
     exit(0)

--- a/scripts/test_storage_compatibility.py
+++ b/scripts/test_storage_compatibility.py
@@ -1,11 +1,13 @@
 import argparse
 import concurrent.futures
 import csv
+import json
 import os
 from pathlib import Path
 import subprocess
 import sys
 import tempfile
+import time
 
 parser = argparse.ArgumentParser(description='Run a full benchmark using the CLI and report the results.')
 group = parser.add_mutually_exclusive_group(required=True)
@@ -65,6 +67,7 @@ new_cli = (
 )
 summarize_failures = not args.no_summarize_failures
 workers = resolve_workers(args.workers)
+repo_root = os.getcwd()
 
 # Use the '-l' parameter to output the list of tests to run
 proc = subprocess.run(
@@ -92,7 +95,7 @@ for line in stdout.splitlines():
     if len(line.strip()) == 0:
         continue
     splits = line.rsplit('\t', 1)
-    test_cases.append(os.path.abspath(splits[0]))
+    test_cases.append(splits[0])
 
 test_cases.sort()
 if args.compatibility != 'v1.0.0':
@@ -108,7 +111,14 @@ def escape_cmd_arg(arg):
     return arg
 
 
+def format_cmd(cmd):
+    return ' '.join(escape_cmd_arg(entry) for entry in cmd)
+
+
 error_container = []
+passed_count = 0
+skipped_count = 0
+failed_count = 0
 
 
 def handle_failure(test, cmd, msg, stdout, stderr, returncode):
@@ -116,11 +126,9 @@ def handle_failure(test, cmd, msg, stdout, stderr, returncode):
     print(test, file=sys.stderr)
     print(f"==============MESSAGE============", file=sys.stderr)
     print(msg, file=sys.stderr)
-    print(f"==============COMMAND============", file=sys.stderr)
-    cmd_str = ''
-    for entry in cmd:
-        cmd_str += escape_cmd_arg(entry) + ' '
-    print(cmd_str.strip(), file=sys.stderr)
+    print(f"==============REPRODUCE==========", file=sys.stderr)
+    cmd_str = format_cmd(cmd)
+    print(cmd_str, file=sys.stderr)
     print(f"==============RETURNCODE=========", file=sys.stderr)
     print(str(returncode), file=sys.stderr)
     print(f"==============STDOUT=============", file=sys.stderr)
@@ -131,8 +139,19 @@ def handle_failure(test, cmd, msg, stdout, stderr, returncode):
     error_container.append({'test': test, 'stderr': stderr})
 
 
-def run_program(test, cmd, description, cwd=None):
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
+def make_failure(test, cmd, msg, stdout='', stderr='', returncode=1):
+    return {
+        'test': test,
+        'cmd': cmd,
+        'msg': msg,
+        'stdout': stdout,
+        'stderr': stderr,
+        'returncode': returncode,
+    }
+
+
+def run_program(test, cmd, description):
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout = proc.stdout.decode('utf8').strip()
     stderr = proc.stderr.decode('utf8').strip()
     if proc.returncode != 0:
@@ -148,9 +167,10 @@ def run_program(test, cmd, description, cwd=None):
 
 
 def execute_test(i, test):
+    test_path = test if os.path.isabs(test) else os.path.join(repo_root, test)
     skipped = False
     if not args.run_empty_tests:
-        with open(test, 'r') as f:
+        with open(test_path, 'r') as f:
             test_contents = f.read().lower()
         if 'create table' not in test_contents and 'create view' not in test_contents:
             skipped = True
@@ -168,19 +188,38 @@ def execute_test(i, test):
     with tempfile.TemporaryDirectory(prefix='storage_compat_') as temp_dir:
         db_path = os.path.join(temp_dir, db_name)
         table_list_path = os.path.join(temp_dir, 'table_list.csv')
+        test_temp_dir = os.path.join(temp_dir, 'test_temp_dir')
+        worker_test_config = os.path.join(temp_dir, 'storage_compatibility.json')
+        with open(test_config, 'r') as f:
+            config_contents = json.load(f)
+        config_contents['initial_db'] = db_path
+        with open(worker_test_config, 'w') as f:
+            json.dump(config_contents, f)
+        unittest_cmd = [
+            unittest_program,
+            '--test-config',
+            worker_test_config,
+            '--test-temp-dir',
+            test_temp_dir,
+            test,
+        ]
         failure = run_program(
             test,
-            [unittest_program, '--test-config', test_config, test],
+            unittest_cmd,
             'Run Test',
-            cwd=temp_dir,
         )
         if failure is not None:
             result['failures'].append(failure)
-            result['messages'].append("Failed to Run Test")
             return result
 
         if not os.path.isfile(db_path):
-            result['messages'].append(f"Failed to create a database file by the name of {db_path}")
+            result['failures'].append(
+                make_failure(
+                    test,
+                    unittest_cmd,
+                    f'Failed to create a database file by the name of {db_path}',
+                )
+            )
             return result
 
         failure = run_program(
@@ -200,7 +239,6 @@ def execute_test(i, test):
         )
         if failure is not None:
             result['failures'].append(failure)
-            result['messages'].append("Failed to List Tables")
             return result
 
         tables = []
@@ -209,6 +247,7 @@ def execute_test(i, test):
             for row in reader:
                 tables.append((row[1], row[2]))
         if len(tables) == 0:
+            result['skipped'] = True
             result['messages'].append("No tables/views were created, skipping")
             return result
 
@@ -235,10 +274,18 @@ def execute_test(i, test):
 
 
 def process_result(result):
+    global passed_count, skipped_count, failed_count
+    if result['skipped']:
+        skipped_count += 1
+        return
+
     i = result['index']
     test = result['test']
-    suffix = ' (SKIPPED)' if result['skipped'] else ''
-    print(f'[{i}/{len(test_cases)}]: {test}{suffix}')
+    if result['failures'] or result['messages']:
+        failed_count += 1
+        print(f'[{i}/{len(test_cases)}]: {test}')
+    else:
+        passed_count += 1
     for failure in result['failures']:
         handle_failure(**failure)
     for message in result['messages']:
@@ -248,6 +295,7 @@ def process_result(result):
 start = 0 if args.start_offset is None else args.start_offset
 end = len(test_cases) if args.end_offset is None else args.end_offset
 selected_tests = list(enumerate(test_cases[start:end], start=start))
+start_time = time.monotonic()
 
 with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
     future_to_test = {}
@@ -271,6 +319,9 @@ with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
             i, test = selected_tests[next_test_idx]
             future_to_test[executor.submit(execute_test, i, test)] = (i, test)
             next_test_idx += 1
+
+elapsed = time.monotonic() - start_time
+print(f'tests took {elapsed:.0f}s: {passed_count} passed, {skipped_count} skipped, {failed_count} failed')
 
 if len(error_container) == 0:
     exit(0)

--- a/test/README.md
+++ b/test/README.md
@@ -14,6 +14,7 @@ Within SQL tests, the test runner (unittest) guarantees that these environment v
 | `DATA_DIR`  | `{WORKING_DIR}/data`        | `DATA_DIR=mydata unittest ...`<br/>also test configs, `test_env` specification | Should provide a copy of `duckdb/data/**`, use to test AWS, Azure, other VFS reads          |
 | `TEMP_BASE` | `{WORKING_DIR}/duckdb_unittest_tempdir`          | via `unittest --test-temp-dir` (retains dir after test)      | use to test VFS writes <br/> AKA: `__TEST_DIR__`                            |
 | `TEMP_DIR` | `{TEMP_BASE}/<process-id>`          | via `unittest --test-temp-dir` (retains dir after test)      | use to test VFS writes <br/> AKA: `__TEST_DIR__`                            |
+| `TEMP_DIR_ABSOLUTE` | absolute path to `{TEMP_DIR}` | N/A | use when a test requires an absolute path, e.g. `file://` URIs |
 
 Some tests require a particular environment variables to be set so they can properly run, usually this can be seen via `require-env VAR` in the test.
 

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -125,7 +125,13 @@ void TestConfiguration::UpdateEnvironment() {
 	test_env["DATA_DIR"] = working_dir + "/data"; // default: data/
 
 	string temp_dir = TestDirectoryPath();
+	auto fs = FileSystem::CreateLocal();
+	string temp_dir_absolute = temp_dir;
+	if (!fs->IsPathAbsolute(temp_dir_absolute)) {
+		temp_dir_absolute = fs->JoinPath(working_dir, temp_dir_absolute);
+	}
 	test_env["TEMP_DIR"] = temp_dir;                      // default: duckdb_unittest_tempdir/$PID
+	test_env["TEMP_DIR_ABSOLUTE"] = temp_dir_absolute;    // default: {WORKING_DIR}/duckdb_unittest_tempdir/$PID
 	test_env["CATALOG_DIR"] = temp_dir + "/" + test_uuid; // _not_ guaranteed to exist
 }
 

--- a/test/sql/attach/attach_fsspec.test
+++ b/test/sql/attach/attach_fsspec.test
@@ -11,10 +11,10 @@ ATTACH 'dummy_extension:/hello.world';
 not found
 
 statement ok
-ATTACH 'file://{WORKING_DIR}/__TEST_DIR__/dummy.csv'
+ATTACH 'file://{TEMP_DIR_ABSOLUTE}/dummy.csv'
 
 statement error
-ATTACH '__TEST_DIR__/dummy.csv'
+ATTACH 'file://{TEMP_DIR_ABSOLUTE}/dummy.csv'
 ----
 already attached
 
@@ -25,7 +25,7 @@ statement ok
 DETACH dummy
 
 statement ok
-ATTACH '__TEST_DIR__/dummy.csv'
+ATTACH 'file://{TEMP_DIR_ABSOLUTE}/dummy.csv'
 
 query I
 FROM dummy.tbl


### PR DESCRIPTION
### Context

The CI step `Forwards compatibility tests` takes `5m 17s` and uses 1 CPU core.

See gray area in the metrics:
<img width="928" height="630" alt="Screenshot 2026-03-12 at 12 42 52" src="https://github.com/user-attachments/assets/0b7a93ef-5c44-4951-9abc-526c25e81835" />

### Changes

- Use a thread pool to run the tests in parallel to utilize `75% of 16 cores = 12 cores`.
- Test time went from `5m 17s` to `39s`!

```
tests took 39s: 2042 passed, 1838 skipped, 0 failed
```