### PR TITLE
Fixup 401bcf041f36f3abc39ecc6d50ba3dd336fc79d7: "When stress testing …

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -307,7 +307,7 @@ vector<string> TestConfiguration::ErrorMessagesToBeSkipped() {
 	} else {
 		res.push_back("HTTP");
 		res.push_back("Unable to connect");
-#ifndef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
+#ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
 #ifndef AVOID_DUCKDB_DEBUG_ASYNC_THROW
 		// The first of those it's throw as a test of what would happen if a task were to be throwing
 		// It's OK that PositionalTableScanner react re-throwing a different exception, so they need to be removed in


### PR DESCRIPTION
…FORCE_ASYNC, add the relevant error messages"

`ifndef` -> `ifdef`, quack