### PR TITLE
Read geoparquet file with null CRS. Fix #21332

### DIFF
--- a/extension/parquet/parquet_geometry.cpp
+++ b/extension/parquet/parquet_geometry.cpp
@@ -113,7 +113,7 @@ unique_ptr<GeoParquetFileMetadata> GeoParquetFileMetadata::TryRead(const duckdb_
 
 					// Parse the CRS
 					const auto crs_val = yyjson_obj_get(column_val, "crs");
-					if (crs_val) {
+					if (crs_val && !yyjson_is_null(crs_val)) {
 						// Parse the CRS
 						if (!yyjson_is_obj(crs_val)) {
 							throw InvalidInputException("Geoparquet column '%s' has invalid CRS", column_name);
@@ -126,8 +126,10 @@ unique_ptr<GeoParquetFileMetadata> GeoParquetFileMetadata::TryRead(const duckdb_
 
 						// Free the temporary CRS JSON string
 						free(crs_json);
+                    } else if (crs_val && yyjson_is_null(crs_val)) {
+                        // If CRS is null, do nothing
 					} else {
-						// Otherwise, default to OGC:CRS84
+						// Otherwise, if no CRS, default to OGC:CRS84
 						auto crs = CoordinateReferenceSystem::TryConvert(context, "OGC:CRS84",
 						                                                 CoordinateReferenceSystemType::PROJJSON);
 						if (crs) {

--- a/extension/parquet/parquet_geometry.cpp
+++ b/extension/parquet/parquet_geometry.cpp
@@ -126,8 +126,8 @@ unique_ptr<GeoParquetFileMetadata> GeoParquetFileMetadata::TryRead(const duckdb_
 
 						// Free the temporary CRS JSON string
 						free(crs_json);
-                    } else if (crs_val && yyjson_is_null(crs_val)) {
-                        // If CRS is null, do nothing
+					} else if (crs_val && yyjson_is_null(crs_val)) {
+						// If CRS is null, do nothing
 					} else {
 						// Otherwise, if no CRS, default to OGC:CRS84
 						auto crs = CoordinateReferenceSystem::TryConvert(context, "OGC:CRS84",


### PR DESCRIPTION
In duckdb 1.5.0, reading a geoparquet file with CRS null sends an error.

This PR handle the case CRS null and return a *geometry* column with no CRS.

```         
> from 'https://raw.githubusercontent.com/geoarrow/geoarrow-data/v0.2.0/example/files/example_point_geo.parquet';
wkt            geometry     
-------------  -------------
POINT (30 10)  POINT (30 10)
POINT (40 20)  POINT (40 20)
NULL           NULL         
POINT EMPTY    POINT EMPTY  
> describe 'https://raw.githubusercontent.com/geoarrow/geoarrow-data/v0.2.0/example/files/example_point_geo.parquet';
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ wkt                                                                                            varchar  │
│ geometry                                                                                       geometry │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```