### PR TITLE
fix argument check for .multiline and .singleline

### DIFF
--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -522,7 +522,7 @@ MetadataResult ToggleCompletionRendering(ShellState &state, const vector<string>
 }
 
 MetadataResult ToggleMultiLine(ShellState &state, const vector<string> &args) {
-	if (!args.empty()) {
+	if (args.size() != 1) {
 		return MetadataResult::PRINT_USAGE;
 	}
 	linenoiseSetMultiLine(true);
@@ -530,7 +530,7 @@ MetadataResult ToggleMultiLine(ShellState &state, const vector<string> &args) {
 }
 
 MetadataResult ToggleSingleLine(ShellState &state, const vector<string> &args) {
-	if (!args.empty()) {
+	if (args.size() != 1) {
 		return MetadataResult::PRINT_USAGE;
 	}
 	linenoiseSetMultiLine(false);


### PR DESCRIPTION
fix for #21308

I built locally and used `gdb` to check `args` for these commands and saw they had a single arg which was the command name. This seems to match the `MetadataCommand` struct value for `argument_count` for `multiline` and `singleline`.

I think the error checking in the command functions just didn't keep up with some different changes so I fixed them to check for a single arg.

I did not dig super deeply to figure out where this got broken so maybe the fix doesn't match your expectations and there may be other commands with a similar error.
