### PR TITLE
Introducing BoxRendererContext

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library_unity(
   assert.cpp
   bind_helpers.cpp
   box_renderer.cpp
+  box_renderer_context.cpp
   cgroups.cpp
   csv_writer.cpp
   complex_json.cpp

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -1,5 +1,5 @@
 #include "duckdb/common/box_renderer.hpp"
-#include "duckdb/main/client_context.hpp"
+#include "duckdb/common/box_renderer_context.hpp"
 
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
@@ -152,9 +152,9 @@ struct BoxRenderRow {
 };
 
 struct RenderDataCollection {
-	RenderDataCollection(ClientContext &context, idx_t column_count);
+	RenderDataCollection(BoxRendererContext &context, idx_t column_count);
 
-	ClientContext &context;
+	BoxRendererContext &context;
 	unique_ptr<ColumnDataCollection> render_values;
 
 public:
@@ -168,7 +168,7 @@ public:
 };
 
 struct BoxRendererImplementation : public BoxRendererState {
-	BoxRendererImplementation(BoxRendererConfig config, ClientContext &context, const vector<string> &names,
+	BoxRendererImplementation(BoxRendererConfig config, BoxRendererContext &context, const vector<string> &names,
 	                          const ColumnDataCollection &result);
 
 public:
@@ -179,7 +179,7 @@ public:
 
 private:
 	BoxRendererConfig config;
-	ClientContext &context;
+	BoxRendererContext &context;
 	vector<string> column_names;
 	vector<LogicalType> result_types;
 	const ColumnDataCollection &result;
@@ -245,7 +245,7 @@ private:
 	void HighlightValue(BoxRenderValue &render_value);
 };
 
-BoxRendererImplementation::BoxRendererImplementation(BoxRendererConfig config_p, ClientContext &context,
+BoxRendererImplementation::BoxRendererImplementation(BoxRendererConfig config_p, BoxRendererContext &context,
                                                      const vector<string> &names, const ColumnDataCollection &result)
     : config(std::move(config_p)), context(context), column_names(names), result(result) {
 	result_types = result.Types();
@@ -630,17 +630,17 @@ void BoxRendererImplementation::ConvertRenderVector(Vector &vector, Vector &rend
 	}
 }
 
-RenderDataCollection::RenderDataCollection(ClientContext &context, idx_t column_count) : context(context) {
+RenderDataCollection::RenderDataCollection(BoxRendererContext &context, idx_t column_count) : context(context) {
 	vector<LogicalType> render_value_types;
 	for (idx_t c = 0; c < column_count; c++) {
 		render_value_types.emplace_back(LogicalType::VARCHAR);
 		render_value_types.emplace_back(LogicalType::UBIGINT);
 	}
-	render_values = make_uniq<ColumnDataCollection>(context, render_value_types);
+	render_values = make_uniq<ColumnDataCollection>(context.GetAllocator(), render_value_types);
 }
 
 void RenderDataCollection::InitializeChunk(DataChunk &chunk) {
-	chunk.Initialize(context, render_values->Types());
+	chunk.Initialize(context.GetAllocator(), render_values->Types());
 }
 
 void BoxRendererImplementation::FetchTopCollection(RenderDataCollection &top_collection,
@@ -649,7 +649,7 @@ void BoxRendererImplementation::FetchTopCollection(RenderDataCollection &top_col
 	auto column_count = result.ColumnCount();
 
 	DataChunk fetch_result;
-	fetch_result.Initialize(context, result.Types());
+	fetch_result.Initialize(context.GetAllocator(), result.Types());
 
 	DataChunk insert_result;
 	top_collection.InitializeChunk(insert_result);
@@ -673,7 +673,7 @@ void BoxRendererImplementation::FetchTopCollection(RenderDataCollection &top_col
 			auto &source_vector = fetch_result.data[c];
 			auto &target_vector = top_collection.Values(insert_result, c);
 			auto &render_lengths = top_collection.RenderLengths(insert_result, c);
-			VectorOperations::Cast(context, source_vector, target_vector, insert_count);
+			context.Cast(source_vector, target_vector, insert_count);
 			ConvertRenderVector(target_vector, render_lengths, insert_count, source_vector.GetType(),
 			                    null_render_length);
 		}
@@ -739,7 +739,7 @@ void BoxRendererImplementation::FetchBottomCollection(RenderDataCollection &bott
 	auto column_count = result.ColumnCount();
 
 	DataChunk fetch_result;
-	fetch_result.Initialize(context, result.Types());
+	fetch_result.Initialize(context.GetAllocator(), result.Types());
 
 	DataChunk insert_result;
 	bottom_collection.InitializeChunk(insert_result);
@@ -753,7 +753,7 @@ void BoxRendererImplementation::FetchBottomCollection(RenderDataCollection &bott
 	while (fetched_row_count < bottom_rows) {
 		// fetch the current chunk
 		auto fetch_chunk = make_uniq<DataChunk>();
-		fetch_chunk->Initialize(context, result.Types());
+		fetch_chunk->Initialize(context.GetAllocator(), result.Types());
 		result.FetchChunk(chunk_idx, *fetch_chunk);
 
 		fetched_row_count += fetch_chunk->size();
@@ -791,7 +791,7 @@ void BoxRendererImplementation::FetchBottomCollection(RenderDataCollection &bott
 			auto &source_vector = chunk.data[c];
 			auto &target_vector = bottom_collection.Values(insert_result, c);
 			auto &render_lengths = bottom_collection.RenderLengths(insert_result, c);
-			VectorOperations::Cast(context, source_vector, target_vector, insert_count);
+			context.Cast(source_vector, target_vector, insert_count);
 			ConvertRenderVector(target_vector, render_lengths, insert_count, source_vector.GetType(),
 			                    null_render_length);
 		}
@@ -2277,22 +2277,23 @@ void BoxRendererImplementation::RenderFooter(BaseResultRenderer &ss, idx_t row_c
 BoxRenderer::BoxRenderer(BoxRendererConfig config_p) : config(std::move(config_p)) {
 }
 
-string BoxRenderer::ToString(ClientContext &context, const vector<string> &names, const ColumnDataCollection &result) {
+string BoxRenderer::ToString(BoxRendererContext &context, const vector<string> &names,
+                             const ColumnDataCollection &result) {
 	StringResultRenderer ss;
 	Render(context, names, result, ss);
 	return ss.str();
 }
 
-void BoxRenderer::Print(ClientContext &context, const vector<string> &names, const ColumnDataCollection &result) {
+void BoxRenderer::Print(BoxRendererContext &context, const vector<string> &names, const ColumnDataCollection &result) {
 	Printer::Print(ToString(context, names, result));
 }
 
-unique_ptr<BoxRendererState> BoxRenderer::Prepare(ClientContext &context, const vector<string> &names,
+unique_ptr<BoxRendererState> BoxRenderer::Prepare(BoxRendererContext &context, const vector<string> &names,
                                                   const ColumnDataCollection &result) {
 	return make_uniq<BoxRendererImplementation>(config, context, names, result);
 }
 
-void BoxRenderer::Render(ClientContext &context, const vector<string> &names, const ColumnDataCollection &result,
+void BoxRenderer::Render(BoxRendererContext &context, const vector<string> &names, const ColumnDataCollection &result,
                          BaseResultRenderer &ss) {
 	auto state = Prepare(context, names, result);
 	state->Render(ss);

--- a/src/common/box_renderer_context.cpp
+++ b/src/common/box_renderer_context.cpp
@@ -1,0 +1,23 @@
+#include "duckdb/common/box_renderer_context.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+
+namespace duckdb {
+
+ClientBoxRendererContext::ClientBoxRendererContext(ClientContext &context) : context(context) {
+}
+
+bool ClientBoxRendererContext::IsInterrupted() const {
+	return context.IsInterrupted();
+}
+
+void ClientBoxRendererContext::Cast(Vector &source, Vector &result, idx_t count, bool strict) {
+	VectorOperations::TryCast(context, source, result, count, nullptr, strict);
+}
+
+Allocator &ClientBoxRendererContext::GetAllocator() {
+	return Allocator::Get(context);
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/list.hpp"
 
 namespace duckdb {
+class BoxRendererContext;
 class ColumnDataCollection;
 class ColumnDataRowCollection;
 
@@ -150,13 +151,13 @@ class BoxRenderer {
 public:
 	explicit BoxRenderer(BoxRendererConfig config_p = BoxRendererConfig());
 
-	string ToString(ClientContext &context, const vector<string> &names, const ColumnDataCollection &op);
+	string ToString(BoxRendererContext &context, const vector<string> &names, const ColumnDataCollection &op);
 
-	unique_ptr<BoxRendererState> Prepare(ClientContext &context, const vector<string> &names,
+	unique_ptr<BoxRendererState> Prepare(BoxRendererContext &context, const vector<string> &names,
 	                                     const ColumnDataCollection &op);
-	void Render(ClientContext &context, const vector<string> &names, const ColumnDataCollection &op,
+	void Render(BoxRendererContext &context, const vector<string> &names, const ColumnDataCollection &op,
 	            BaseResultRenderer &ss);
-	void Print(ClientContext &context, const vector<string> &names, const ColumnDataCollection &op);
+	void Print(BoxRendererContext &context, const vector<string> &names, const ColumnDataCollection &op);
 
 	static string TryFormatLargeNumber(const string &numeric, char decimal_sep);
 	static string TruncateValue(const string &value, idx_t column_width, idx_t &pos, idx_t &current_render_width);

--- a/src/include/duckdb/common/box_renderer_context.hpp
+++ b/src/include/duckdb/common/box_renderer_context.hpp
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/box_renderer_context.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+class Allocator;
+class ClientContext;
+class Vector;
+
+//! BoxRendererContext provides the minimal interface needed by the BoxRenderer
+//! for allocating memory, casting vectors, and checking for interrupts.
+class BoxRendererContext {
+public:
+	virtual ~BoxRendererContext() = default;
+
+	//! Whether execution has been interrupted
+	virtual bool IsInterrupted() const = 0;
+
+	//! Cast source vector into result vector
+	virtual void Cast(Vector &source, Vector &result, idx_t count, bool strict = false) = 0;
+
+	//! Get the allocator for temporary data
+	virtual Allocator &GetAllocator() = 0;
+};
+
+//! ClientBoxRendererContext wraps a ClientContext to implement BoxRendererContext.
+class ClientBoxRendererContext : public BoxRendererContext {
+public:
+	explicit ClientBoxRendererContext(ClientContext &context);
+
+	bool IsInterrupted() const override;
+	void Cast(Vector &source, Vector &result, idx_t count, bool strict = false) override;
+	Allocator &GetAllocator() override;
+
+private:
+	ClientContext &context;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
+++ b/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/progress_bar/progress_bar_display.hpp"
 #include "duckdb/common/unicode_bar.hpp"
 #include "duckdb/common/progress_bar/unscented_kalman_filter.hpp"

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -30,7 +30,6 @@
 #include "duckdb/planner/expression/bound_parameter_data.hpp"
 #include "duckdb/transaction/transaction_context.hpp"
 #include "duckdb/main/query_parameters.hpp"
-
 namespace duckdb {
 
 class Appender;

--- a/src/include/duckdb/main/materialized_query_result.hpp
+++ b/src/include/duckdb/main/materialized_query_result.hpp
@@ -32,7 +32,7 @@ public:
 public:
 	//! Converts the QueryResult to a string
 	DUCKDB_API string ToString() override;
-	DUCKDB_API string ToBox(ClientContext &context, const BoxRendererConfig &config) override;
+	DUCKDB_API string ToBox(BoxRendererContext &context, const BoxRendererConfig &config) override;
 
 	//! Gets the (index) value of the (column index) column.
 	//! Note: this is very slow. Scanning over the underlying collection is much faster.

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/main/client_properties.hpp"
 
 namespace duckdb {
+class BoxRendererContext;
 struct BoxRendererConfig;
 
 enum class QueryResultType : uint8_t { MATERIALIZED_RESULT, STREAM_RESULT, PENDING_RESULT, ARROW_RESULT };
@@ -105,7 +106,7 @@ public:
 	//! Converts the QueryResult to a string
 	DUCKDB_API virtual string ToString() = 0;
 	//! Converts the QueryResult to a box-rendered string
-	DUCKDB_API virtual string ToBox(ClientContext &context, const BoxRendererConfig &config);
+	DUCKDB_API virtual string ToBox(BoxRendererContext &context, const BoxRendererConfig &config);
 	//! Prints the QueryResult to the console
 	DUCKDB_API void Print();
 	//! Returns true if the two results are identical; false otherwise. Note that this method is destructive; it calls

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -53,7 +53,6 @@
 #include "duckdb/logging/log_manager.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/main/result_set_manager.hpp"
-
 #ifdef __APPLE__
 #include <sys/sysctl.h>
 

--- a/src/main/client_verify.cpp
+++ b/src/main/client_verify.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/verification/statement_verifier.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/common/box_renderer.hpp"
+#include "duckdb/common/box_renderer_context.hpp"
 
 namespace duckdb {
 
@@ -172,7 +173,8 @@ ErrorData ClientContext::VerifyQuery(ClientContextLock &lock, const string &quer
 		config.max_width = random.NextRandomInteger() % 500;
 		BoxRenderer renderer(config);
 		auto pinned_result_set = original->materialized_result->Pin();
-		renderer.ToString(*this, original->materialized_result->names, pinned_result_set->collection);
+		ClientBoxRendererContext render_context(*this);
+		renderer.ToString(render_context, original->materialized_result->names, pinned_result_set->collection);
 #endif
 	}
 

--- a/src/main/materialized_query_result.cpp
+++ b/src/main/materialized_query_result.cpp
@@ -40,7 +40,7 @@ string MaterializedQueryResult::ToString() {
 	return result;
 }
 
-string MaterializedQueryResult::ToBox(ClientContext &context, const BoxRendererConfig &config) {
+string MaterializedQueryResult::ToBox(BoxRendererContext &context, const BoxRendererConfig &config) {
 	if (!success) {
 		return GetError() + "\n";
 	}

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -97,7 +97,7 @@ const string &QueryResult::ColumnName(idx_t index) const {
 	return names[index];
 }
 
-string QueryResult::ToBox(ClientContext &context, const BoxRendererConfig &config) {
+string QueryResult::ToBox(BoxRendererContext &context, const BoxRendererConfig &config) {
 	return ToString();
 }
 

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -5,6 +5,7 @@
 #include "sqllogic_test_runner.hpp"
 #include "test_helpers.hpp"
 #include "duckdb/common/box_renderer.hpp"
+#include "duckdb/common/box_renderer_context.hpp"
 
 namespace duckdb {
 
@@ -165,7 +166,8 @@ string SQLLogicTestLogger::ResultToString(MaterializedQueryResult &result) {
 	BoxRendererConfig config;
 	config.max_rows = 100;
 	config.max_width = -1;
-	return result.ToBox(*connection.context, config);
+	ClientBoxRendererContext render_context(*connection.context);
+	return result.ToBox(render_context, config);
 }
 
 void SQLLogicTestLogger::PrintResultString(MaterializedQueryResult &result) {

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1630,6 +1630,7 @@ public:
 
 private:
 	duckdb::BoxRendererConfig config;
+	unique_ptr<duckdb::ClientBoxRendererContext> render_context;
 	unique_ptr<duckdb::BoxRendererState> render_state;
 	string error_str;
 };
@@ -1681,8 +1682,8 @@ void ModeDuckBoxRenderer::Analyze(RenderingQueryResult &result) {
 	auto &materialized = query_result.Cast<duckdb::MaterializedQueryResult>();
 	auto &con = *state.conn;
 	try {
-		duckdb::ClientBoxRendererContext render_context(*con.context);
-		render_state = renderer.Prepare(render_context, result.metadata.column_names, materialized.Collection());
+		render_context = duckdb::make_uniq<duckdb::ClientBoxRendererContext>(*con.context);
+		render_state = renderer.Prepare(*render_context, result.metadata.column_names, materialized.Collection());
 	} catch (std::exception &ex) {
 		// store the error - throw on render
 		error_str = ex.what();

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -2,6 +2,7 @@
 
 #include "shell_state.hpp"
 #include "duckdb/common/box_renderer.hpp"
+#include "duckdb/common/box_renderer_context.hpp"
 #include "shell_highlight.hpp"
 #include "duckdb/logging/log_storage.hpp"
 #include <stdexcept>
@@ -1680,7 +1681,8 @@ void ModeDuckBoxRenderer::Analyze(RenderingQueryResult &result) {
 	auto &materialized = query_result.Cast<duckdb::MaterializedQueryResult>();
 	auto &con = *state.conn;
 	try {
-		render_state = renderer.Prepare(*con.context, result.metadata.column_names, materialized.Collection());
+		duckdb::ClientBoxRendererContext render_context(*con.context);
+		render_state = renderer.Prepare(render_context, result.metadata.column_names, materialized.Collection());
 	} catch (std::exception &ex) {
 		// store the error - throw on render
 		error_str = ex.what();


### PR DESCRIPTION
This is getting started with making code in `tools/shell` more flexible, so that it could be adopted in more places, for example as DuckDB-Wasm frontend.

Goal of the PR is limited and simple: add a `BaseClientContext` class, that is a simpler (and less powerful) version of `ClientContext` that it's still powerful enough to handle the BoxRenderer code.