### PR TITLE
Windows shell: remove .utf8 dot command

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -277,11 +277,6 @@ public:
 	//! Shell highlighting mode
 	HighlightMode highlight_mode = HighlightMode::AUTOMATIC;
 
-#if defined(_WIN32) || defined(WIN32)
-	//! When enabled, sets the console page to UTF8 and renders using that code page
-	bool win_utf8_mode = false;
-#endif
-
 public:
 	static ShellState &Get();
 

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -525,16 +525,6 @@ static char *local_getline(char *zLine, FILE *in) {
 	idx_t nLine = zLine == 0 ? 0 : 100;
 	idx_t n = 0;
 
-#if defined(_WIN32) || defined(WIN32)
-	auto &state = ShellState::Get();
-	int is_stdin = state.stdin_is_interactive && in == stdin;
-	int is_utf8 = 0;
-	if (is_stdin && state.win_utf8_mode) {
-		if (SetConsoleCP(CP_UTF8)) {
-			is_utf8 = 1;
-		}
-	}
-#endif
 	while (1) {
 		if (n + 100 > nLine) {
 			nLine = nLine * 2 + 100;
@@ -561,21 +551,6 @@ static char *local_getline(char *zLine, FILE *in) {
 			break;
 		}
 	}
-#if defined(_WIN32) || defined(WIN32)
-	/* For interactive input on Windows systems, translate the
-	** multi-byte characterset characters into UTF-8. */
-	if (is_stdin && !is_utf8) {
-		auto zTrans = ShellState::Win32MbcsToUtf8(zLine, 0);
-		idx_t nTrans = zTrans.size() + 1;
-		if (nTrans > nLine) {
-			zLine = (char *)realloc(zLine, nTrans);
-			if (zLine == 0) {
-				shell_out_of_memory();
-			}
-		}
-		memcpy(zLine, zTrans.data(), nTrans);
-	}
-#endif /* defined(_WIN32) || defined(WIN32) */
 	return zLine;
 }
 

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -498,13 +498,6 @@ MetadataResult SetUICommand(ShellState &state, const vector<string> &args) {
 	return MetadataResult::SUCCESS;
 }
 
-#if defined(_WIN32) || defined(WIN32)
-MetadataResult SetUTF8Mode(ShellState &state, const vector<string> &args) {
-	state.win_utf8_mode = true;
-	return MetadataResult::SUCCESS;
-}
-#endif
-
 MetadataResult ToggleHighlighting(ShellState &state, const vector<string> &args) {
 	ShellHighlight::SetHighlighting(state.StringToBool(args[1]));
 	return MetadataResult::SUCCESS;
@@ -907,7 +900,8 @@ static const MetadataCommand metadata_commands[] = {
     {"width", 0, SetWidths, "NUM1 NUM2 ...", "Set minimum column widths for columnar output", 0,
      "Negative values right-justify"},
 #if defined(_WIN32) || defined(WIN32)
-    {"utf8", 1, SetUTF8Mode, "", "Enable experimental UTF-8 console output mode", 0, ""},
+    {"utf8", 1, [](ShellState &, const vector<string> &) -> MetadataResult { return MetadataResult::SUCCESS; }, "",
+     "Deprecated. This option is accepted for compatibility but has no effect.", 0, ""},
 #endif
     {nullptr, 0, nullptr, 0, nullptr}};
 


### PR DESCRIPTION
Shell dot command `.utf8` was added in #11682 to allow better Unicode strings input/output in Windows shell.

With shell improvements added in 1.5 this command is understood to be obsolete. Short (not scrolled) output displays Unicode correctly in 1.5.0. Unicode support in long (scrolled with a pager) output is added recently for upcoming 1.5.1. It does not require enabling `.utf8` mode or setting the console encoding to UTF-8 with `chcp 65001`.

For input Unicode data the following scenarios work correctly in Windows shell:

```
cmd /c "duckdb.exe < file_with_utf8.sql"
```
```
cmd /c "echo SELECT '<unicode_string>' | duckdb.exe"
```

This PR removes all the logic related to `.utf8` command leaving the command itself as a no-op.

The change is Windows only.