### PR TITLE
CLI: Make bail on error the default in more situations

### DIFF
--- a/scripts/generate_storage_version.py
+++ b/scripts/generate_storage_version.py
@@ -25,7 +25,7 @@ try_remove_file(gen_storage_target + '.wal')
 def run_command_in_shell(cmd):
     print(cmd)
     res = subprocess.run(
-        [shell_proc, '--batch', '-init', '/dev/null', gen_storage_target],
+        [shell_proc, '--batch', '-no-init', gen_storage_target],
         capture_output=True,
         input=bytearray(cmd, 'utf8'),
     )

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -384,7 +384,7 @@ public:
 	bool ProcessDuckDBRC(const char *file);
 	bool ProcessFile(const string &file, InputMode input_mode = InputMode::FILE, bool default_duckdb_rc = false);
 	int ProcessInput(InputMode mode);
-	bool BailOnError(InputMode mode);
+	bool GetBailOnError(InputMode mode);
 	static bool SQLIsComplete(const char *zSql);
 	static bool IsSpace(char c);
 	static bool IsDigit(char c);

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -150,6 +150,8 @@ struct ShellTableInfo {
 	vector<ShellColumnInfo> columns;
 };
 
+enum class BailOnError { AUTOMATIC, BAIL_ON_ERROR, DONT_BAIL_ON_ERROR };
+
 /*
 ** State information about the database connection is contained in an
 ** instance of the following structure.
@@ -203,7 +205,7 @@ public:
 	string initFile;
 	unique_ptr<duckdb::MaterializedQueryResult> last_result;
 	//! If the following flag is set, then command execution stops at an error
-	bool bail_on_error = false;
+	BailOnError bail = BailOnError::AUTOMATIC;
 	//! Table name when rendering a DESCRIBE statement
 	string describe_table_name;
 
@@ -380,8 +382,9 @@ public:
 	int RunOneSqlLine(InputMode mode, char *zSql);
 	string GetDefaultDuckDBRC();
 	bool ProcessDuckDBRC(const char *file);
-	bool ProcessFile(const string &file, bool is_duckdb_rc = false);
+	bool ProcessFile(const string &file, InputMode input_mode = InputMode::FILE, bool default_duckdb_rc = false);
 	int ProcessInput(InputMode mode);
+	bool BailOnError(InputMode mode);
 	static bool SQLIsComplete(const char *zSql);
 	static bool IsSpace(char c);
 	static bool IsDigit(char c);

--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -203,6 +203,7 @@ public:
 	idx_t total_changes = 0;
 	bool readStdin = true;
 	string initFile;
+	bool run_init = true;
 	unique_ptr<duckdb::MaterializedQueryResult> last_result;
 	//! If the following flag is set, then command execution stops at an error
 	BailOnError bail = BailOnError::AUTOMATIC;

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2749,7 +2749,7 @@ int ShellState::RunOneSqlLine(InputMode mode, char *zSql) {
 	return 0;
 }
 
-bool ShellState::BailOnError(InputMode mode) {
+bool ShellState::GetBailOnError(InputMode mode) {
 	if (bail != BailOnError::AUTOMATIC) {
 		return bail == BailOnError::BAIL_ON_ERROR;
 	}
@@ -2777,7 +2777,7 @@ int ShellState::ProcessInput(InputMode mode) {
 	idx_t errCnt = 0;      /* Number of errors seen */
 	idx_t numCtrlC = 0;
 	lineno = 0;
-	while (errCnt == 0 || !BailOnError(mode) || (!in && stdin_is_interactive)) {
+	while (errCnt == 0 || !GetBailOnError(mode) || (!in && stdin_is_interactive)) {
 		fflush(out);
 		zLine = OneInputLine(in, zLine, nSql > 0);
 		if (!zLine) {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2749,6 +2749,14 @@ int ShellState::RunOneSqlLine(InputMode mode, char *zSql) {
 	return 0;
 }
 
+bool ShellState::BailOnError(InputMode mode) {
+	if (bail != BailOnError::AUTOMATIC) {
+		return bail == BailOnError::BAIL_ON_ERROR;
+	}
+	// by default bail on error in file and duckdb_rc modes
+	return mode == InputMode::FILE || mode == InputMode::DUCKDB_RC;
+}
+
 /*
 ** Read input from *in and process it.  If *in==0 then input
 ** is interactive - the user is typing it it.  Otherwise, input
@@ -2769,7 +2777,7 @@ int ShellState::ProcessInput(InputMode mode) {
 	idx_t errCnt = 0;      /* Number of errors seen */
 	idx_t numCtrlC = 0;
 	lineno = 0;
-	while (errCnt == 0 || !bail_on_error || (!in && stdin_is_interactive)) {
+	while (errCnt == 0 || !BailOnError(mode) || (!in && stdin_is_interactive)) {
 		fflush(out);
 		zLine = OneInputLine(in, zLine, nSql > 0);
 		if (!zLine) {
@@ -2897,22 +2905,19 @@ string ShellState::GetDefaultDuckDBRC() {
 ** Returns true if successful, false otherwise.
 */
 
-bool ShellState::ProcessFile(const string &file, bool is_duckdb_rc) {
+bool ShellState::ProcessFile(const string &file, InputMode input_mode, bool default_duckdb_rc) {
 	FILE *inSaved = in;
 	int savedLineno = lineno;
 	int rc = 0;
 
 	in = fopen(file.c_str(), "rb");
 	if (in) {
-		InputMode input_mode = InputMode::FILE;
-		if (stdin_is_interactive && is_duckdb_rc) {
-			input_mode = InputMode::DUCKDB_RC;
-			duckdb_rc_path = file;
-		}
 		rc = ProcessInput(input_mode);
 		fclose(in);
-	} else if (!is_duckdb_rc) {
-		PrintF(PrintOutput::STDERR, "Failed to read file \"%s\"\n", file.c_str());
+	} else if (input_mode != InputMode::DUCKDB_RC || !default_duckdb_rc) {
+		// we always error in regular file reading mode
+		// when reading the init file we only error if the file is explicitly specified by the user
+		PrintDatabaseError("IO Error: Failed to open file \"" + file + "\"");
 		rc = 1;
 	}
 	in = inSaved;
@@ -2922,6 +2927,7 @@ bool ShellState::ProcessFile(const string &file, bool is_duckdb_rc) {
 
 bool ShellState::ProcessDuckDBRC(const char *file) {
 	string path;
+	bool is_default = false;
 	if (!file) {
 		// use default .duckdbrc path
 		path = ShellState::GetDefaultDuckDBRC();
@@ -2932,8 +2938,10 @@ bool ShellState::ProcessDuckDBRC(const char *file) {
 			return true;
 		}
 		file = path.c_str();
+		is_default = true;
 	}
-	return ProcessFile(file, true);
+	duckdb_rc_path = file;
+	return ProcessFile(file, InputMode::DUCKDB_RC, is_default);
 }
 
 #ifdef HAVE_LINENOISE
@@ -3180,8 +3188,16 @@ int wmain(int argc, wchar_t **wargv) {
 	** is given on the command line, look for a file named ~/.sqliterc and
 	** try to process it.
 	*/
-	if (!data.ProcessDuckDBRC(data.initFile.empty() ? nullptr : data.initFile.c_str()) && data.bail_on_error) {
-		return 1;
+	if (!data.ProcessDuckDBRC(data.initFile.empty() ? nullptr : data.initFile.c_str())) {
+		// failed to process init file - check if we should bail
+		bool bail_on_init_fail = data.bail != BailOnError::DONT_BAIL_ON_ERROR;
+		if (bail_on_init_fail) {
+			if (!data.duckdb_rc_path.empty()) {
+				data.PrintDatabaseError("Encountered errors while executing init file \"" + data.duckdb_rc_path +
+				                        "\". Exiting.");
+			}
+			return 1;
+		}
 	}
 
 	data.DetectDarkLightMode();

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3188,7 +3188,7 @@ int wmain(int argc, wchar_t **wargv) {
 	** is given on the command line, look for a file named ~/.sqliterc and
 	** try to process it.
 	*/
-	if (!data.ProcessDuckDBRC(data.initFile.empty() ? nullptr : data.initFile.c_str())) {
+	if (data.run_init && !data.ProcessDuckDBRC(data.initFile.empty() ? nullptr : data.initFile.c_str())) {
 		// failed to process init file - check if we should bail
 		bool bail_on_init_fail = data.bail != BailOnError::DONT_BAIL_ON_ERROR;
 		if (bail_on_init_fail) {

--- a/tools/shell/shell_command_line_option.cpp
+++ b/tools/shell/shell_command_line_option.cpp
@@ -128,6 +128,11 @@ MetadataResult SetInitFile(ShellState &state, const vector<string> &args) {
 	return MetadataResult::SUCCESS;
 }
 
+MetadataResult SkipInit(ShellState &state, const vector<string> &args) {
+	state.run_init = false;
+	return MetadataResult::SUCCESS;
+}
+
 template <bool EXIT>
 MetadataResult RunCommand(ShellState &state, const vector<string> &args) {
 	if (EXIT) {
@@ -170,6 +175,7 @@ static const CommandLineOption command_line_options[] = {
     {"list", 0, "", nullptr, ToggleOutputMode<RenderMode::LIST>, "set output mode to 'list'"},
     {"markdown", 0, "", nullptr, ToggleOutputMode<RenderMode::MARKDOWN>, "set output mode to 'markdown'"},
     {"newline", 1, "SEP", nullptr, SetNewlineSeparator, "set output row separator. Default: '\\n'"},
+    {"no-init", 0, "", SkipInit, nullptr, "skip processing the init file"},
     {"no-stdin", 0, "", nullptr, DisableStdin, "exit after processing options instead of reading stdin"},
     {"noheader", 0, "", nullptr, ToggleHeader<false>, "turn headers off"},
     {"nullvalue", 1, "TEXT", nullptr, ShellState::SetNullValue, "set text string for NULL values. Default 'NULL'"},

--- a/tools/shell/shell_command_line_option.cpp
+++ b/tools/shell/shell_command_line_option.cpp
@@ -27,7 +27,7 @@ MetadataResult ToggleCSVMode(ShellState &state, const vector<string> &args) {
 }
 
 MetadataResult EnableBail(ShellState &state, const vector<string> &args) {
-	state.bail_on_error = true;
+	state.bail = BailOnError::BAIL_ON_ERROR;
 	return MetadataResult::SUCCESS;
 }
 
@@ -115,14 +115,11 @@ MetadataResult SetStorageVersion(ShellState &state, const vector<string> &args) 
 
 MetadataResult ProcessFile(ShellState &state, const vector<string> &args) {
 	state.readStdin = false;
-	auto old_bail = state.bail_on_error;
-	state.bail_on_error = true;
 	auto &file = args[1];
 	if (!state.ProcessFile(file)) {
 		exit(1);
 		return MetadataResult::EXIT;
 	}
-	state.bail_on_error = old_bail;
 	return MetadataResult::SUCCESS;
 }
 
@@ -137,7 +134,10 @@ MetadataResult RunCommand(ShellState &state, const vector<string> &args) {
 		state.readStdin = false;
 	}
 	// Always bail if -c or -s fail
-	bool bail = state.bail_on_error || EXIT;
+	bool bail = true;
+	if (state.bail != BailOnError::AUTOMATIC) {
+		bail = state.bail == BailOnError::BAIL_ON_ERROR;
+	}
 	auto &cmd = args[1];
 	auto rc = state.RunInitialCommand(cmd.c_str(), bail);
 	if (rc != 0) {

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -11,7 +11,13 @@
 namespace duckdb_shell {
 
 MetadataResult ToggleBail(ShellState &state, const vector<string> &args) {
-	state.bail_on_error = state.StringToBool(args[1]);
+	if (args[1] == "auto") {
+		state.bail = BailOnError::AUTOMATIC;
+	} else if (state.StringToBool(args[1])) {
+		state.bail = BailOnError::BAIL_ON_ERROR;
+	} else {
+		state.bail = BailOnError::DONT_BAIL_ON_ERROR;
+	}
 	return MetadataResult::SUCCESS;
 }
 

--- a/tools/shell/tests/conftest.py
+++ b/tools/shell/tests/conftest.py
@@ -67,7 +67,9 @@ class ShellTest:
         if not shell:
             raise ValueError("Please provide a shell binary")
         self.shell = shell
-        self.arguments = [shell, "--batch", "--no-init"] + arguments
+        self.arguments = [shell, "--batch"] + arguments
+        if "-init" not in arguments and "--init" not in arguments:
+            arguments += ["--no-init"]
         self.statements: List[str] = []
         self.input = None
         self.output = None

--- a/tools/shell/tests/conftest.py
+++ b/tools/shell/tests/conftest.py
@@ -67,7 +67,7 @@ class ShellTest:
         if not shell:
             raise ValueError("Please provide a shell binary")
         self.shell = shell
-        self.arguments = [shell, "--batch", "--init", "/dev/null"] + arguments
+        self.arguments = [shell, "--batch", "--no-init"] + arguments
         self.statements: List[str] = []
         self.input = None
         self.output = None

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -140,6 +140,60 @@ def test_bail_off_continues_after_error(shell):
     result.check_stderr("Parser Error: syntax error at or near \"invalid\"")
     assert "reached here" in str(result.stdout)
 
+def test_bail_on_missing_init(shell):
+    test = (
+        ShellTest(shell, ['-init', '___thisfiledoesnotexist'])
+        .statement("select 'reached here'")
+    )
+
+    result = test.run()
+    result.check_stderr("___thisfiledoesnotexist")
+    assert "reached here" not in str(result.stdout)
+
+@pytest.mark.parametrize('generated_file', ["selec 42;"], indirect=True)
+def test_bail_within_init(shell, generated_file):
+    test = (
+        ShellTest(shell, ['-init', generated_file])
+        .statement("select 'reached here'")
+    )
+
+    result = test.run()
+    result.check_stderr("selec")
+    assert "reached here" not in str(result.stdout)
+
+@pytest.mark.parametrize('generated_file', ["selec 42;\nselect 'reached here'"], indirect=True)
+def test_bail_within_read(shell, generated_file):
+    test = (
+        ShellTest(shell)
+        .statement(".read \"" + str(generated_file) + "\"")
+    )
+
+    result = test.run()
+    result.check_stderr("selec")
+    assert "reached here" not in str(result.stdout)
+@pytest.mark.parametrize('generated_file', [".bail off\nselec 42;"], indirect=True)
+def test_explicit_bail_within_init(shell, generated_file):
+    test = (
+        ShellTest(shell, ['-init', generated_file])
+        .statement("select 'reached here'")
+    )
+
+    result = test.run()
+    result.check_stderr("selec")
+    assert "reached here" in str(result.stdout)
+
+@pytest.mark.parametrize('generated_file', ["selec 42;\nselect 'reached here'"], indirect=True)
+def test_explicit_bail_within_read(shell, generated_file):
+    test = (
+        ShellTest(shell)
+        .statement(".bail off")
+        .statement(".read \"" + str(generated_file) + "\"")
+    )
+
+    result = test.run()
+    result.check_stderr("selec")
+    assert "reached here" in str(result.stdout)
+
 @pytest.mark.skipif(os.name == 'nt', reason="Skipped on windows")
 def test_shell_command(shell):
     test = (

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -153,7 +153,7 @@ def test_bail_on_missing_init(shell):
 @pytest.mark.parametrize('generated_file', ["selec 42;"], indirect=True)
 def test_bail_within_init(shell, generated_file):
     test = (
-        ShellTest(shell, ['-init', generated_file])
+        ShellTest(shell, ['-init', generated_file.as_posix()])
         .statement("select 'reached here'")
     )
 
@@ -165,7 +165,7 @@ def test_bail_within_init(shell, generated_file):
 def test_bail_within_read(shell, generated_file):
     test = (
         ShellTest(shell)
-        .statement(".read \"" + str(generated_file) + "\"")
+        .statement(".read \"" + generated_file.as_posix() + "\"")
     )
 
     result = test.run()
@@ -174,7 +174,7 @@ def test_bail_within_read(shell, generated_file):
 @pytest.mark.parametrize('generated_file', [".bail off\nselec 42;"], indirect=True)
 def test_explicit_bail_within_init(shell, generated_file):
     test = (
-        ShellTest(shell, ['-init', generated_file])
+        ShellTest(shell, ['-init', generated_file.as_posix()])
         .statement("select 'reached here'")
     )
 
@@ -187,7 +187,7 @@ def test_explicit_bail_within_read(shell, generated_file):
     test = (
         ShellTest(shell)
         .statement(".bail off")
-        .statement(".read \"" + str(generated_file) + "\"")
+        .statement(".read \"" + generated_file.as_posix() + "\"")
     )
 
     result = test.run()


### PR DESCRIPTION
The CLI currently (silently) ignores errors that, in my opinion, should not be ignored by default:

* `-init [file]`, but `[file]` cannot be read
* Error during processing of the init file (`[file]` or `~/.duckdbrc`)
* Error during processing of a file that is read using `.read [file]`

This PR changes this behavior to be more intuitive:
* `-init [file]` exits the CLI if the file cannot be found
* The CLI is exited if the `init` file cannot be successfully executed
* When executing the init file or a file using `.read [file]`, we immediately stop executing when a single statement fails, instead of continuing to execute all statements

The `.bail` option can be used to restore this to the old behavior.

*`.bail off` makes ignoring these errors the default again.
* `.bail on` makes it so that we always ignore errors.
* `.bail auto` is the default behavior

In addition, this PR also adds a `--no-init` flag which skips execution of the init file entirely. We used to use `--init /dev/null` for this in tests, but `/dev/null` does not exist on Windows. This used to just silently fail, but this now throws an error, so we need a different way of skipping the init execution.