### PR TITLE
Improve estimate when first Parquet file is almost empty, and get exact cardinality count when we are using union by name

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -134,6 +134,7 @@ struct ParquetUnionData : public BaseUnionData {
 	}
 	~ParquetUnionData() override;
 
+	optional_idx TryGetCardinalityEstimate() const override;
 	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, const string &name) override;
 
 	ParquetOptions options;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -482,7 +482,15 @@ unique_ptr<NodeStatistics> ParquetMultiFileInfo::GetCardinality(const MultiFileB
 	if (bind_data.explicit_cardinality) {
 		return make_uniq<NodeStatistics>(bind_data.explicit_cardinality);
 	}
-	return make_uniq<NodeStatistics>(MaxValue(bind_data.initial_file_cardinality, (idx_t)1) * file_count);
+	idx_t min_per_file_cardinality = 1ULL;
+	if (file_count > 1) {
+		// if we have several files, our cardinality estimate can be way off if our initial file is ~empty
+		// we set the minimum per file cardinality to 1000 in this case
+		min_per_file_cardinality = 1000ULL;
+	}
+	auto per_file_cardinality = MaxValue<idx_t>(bind_data.initial_file_cardinality, min_per_file_cardinality);
+
+	return make_uniq<NodeStatistics>(per_file_cardinality * file_count);
 }
 
 unique_ptr<BaseStatistics> ParquetReader::GetStatistics(ClientContext &context, const string &name) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -871,6 +871,16 @@ shared_ptr<ParquetFileMetadataCache> ParquetReader::GetMetadataCacheEntry(Client
 ParquetUnionData::~ParquetUnionData() {
 }
 
+optional_idx ParquetUnionData::TryGetCardinalityEstimate() const {
+	if (reader) {
+		return reader->Cast<ParquetReader>().NumRows();
+	}
+	if (metadata) {
+		return metadata->metadata->num_rows;
+	}
+	return optional_idx();
+}
+
 unique_ptr<BaseStatistics> ParquetUnionData::GetStatistics(ClientContext &context, const string &name) {
 	if (reader) {
 		return reader->Cast<ParquetReader>().GetStatistics(context, name);

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -136,6 +136,9 @@ public:
 		return file.path;
 	}
 
+	virtual optional_idx TryGetCardinalityEstimate() const {
+		return optional_idx();
+	}
 	virtual unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, const string &name);
 
 public:

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -769,6 +769,22 @@ public:
 		if (file_list_cardinality_estimate) {
 			return file_list_cardinality_estimate;
 		}
+		if (data.file_options.union_by_name) {
+			// for UNION BY NAME - check if we can get a cardinality estimate from the (already opened) union readers
+			bool has_exact_cardinality = true;
+			idx_t cardinality = 0;
+			for (auto &union_data : data.union_readers) {
+				auto file_cardinality = union_data->TryGetCardinalityEstimate();
+				if (!file_cardinality.IsValid()) {
+					has_exact_cardinality = false;
+					break;
+				}
+				cardinality += file_cardinality.GetIndex();
+			}
+			if (has_exact_cardinality) {
+				return make_uniq<NodeStatistics>(cardinality);
+			}
+		}
 		// get the file count - for >500 files we allow an estimate
 		auto count_info = data.file_list->GetFileCount(500);
 		idx_t estimated_file_count = count_info.count;


### PR DESCRIPTION
Currently when reading Parquet files we depend heavily on the cardinality of the first Parquet file for our cardinality estimate (`initial_file_cardinality`).

When that estimate is very low, we can be off by a lot. For example, if the first Parquet file has a single row, and we are reading 2000 files, we would currently estimate the table cardinality to be 2000 rows. This PR makes this a bit more robust by setting the estimate to at least 1000 rows per file if the first file is almost empty. 

In addition, when running with `union_by_name = true`, we have already read the metadata of all of the Parquet files and can therefore just use that cardinality instead of relying only on the first file. This gives us an exact cardinality for Parquet files read using `union_by_name = true`.