### PR TITLE
introducing TryPushdownRelaxedFilter

### DIFF
--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -80,6 +80,11 @@ private:
 	                                         Expression &expr);
 	FilterPushdownResult TryPushdownOrClause(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
 	                                         Expression &expr);
+	FilterPushdownResult TryPushdownTemporalCastFilter(TableFilterSet &table_filters,
+	                                                   const vector<ColumnIndex> &column_ids, Expression &expr);
+	void TryPushdownRelaxedFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                              vector<FilterPushdownResult> &pushdown_results, column_t expr_id,
+	                              vector<ExpressionValueInformation> &info_list);
 
 private:
 	vector<unique_ptr<Expression>> remaining_filters;

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -674,87 +674,75 @@ static bool IsLessThan(ExpressionType type) {
 	return type == ExpressionType::COMPARE_LESSTHAN || type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
 }
 
-//! Returns the relaxation margin in microseconds for a temporal cast, or -1 if not relaxable.
-static int64_t GetTemporalCastRelaxationMicros(LogicalTypeId source, LogicalTypeId target) {
+//! Returns the relaxation margin in native units of the source type for a temporal cast.
+//! Returns -1 if the cast pair is not supported for relaxed pushdown.
+//! Margins: 2h for DST ambiguity (TIMESTAMP<->TIMESTAMPTZ), 24h for time-of-day loss, 1s for rounding loss.
+static int64_t GetTemporalCastMargin(LogicalTypeId source, LogicalTypeId target) {
 	if (source == target) {
 		return 0;
 	}
-	// margins: 26h for tz offset (±14h both ways), 24h for time-of-day loss, 1s for rounding loss
-	static constexpr int64_t TZ = 26LL * Interval::MICROS_PER_HOUR;
-	static constexpr int64_t DAY = Interval::MICROS_PER_DAY;
-	static constexpr int64_t SEC = Interval::MICROS_PER_SEC;
-
-	// encode (source, target) pair as a single key for map lookup
 	using L = LogicalTypeId;
-	auto K = [](L s, L t) -> uint32_t {
-		return (uint32_t(s) << 8) | uint32_t(t);
-	};
-	static const unordered_map<uint32_t, int64_t> MARGINS = {
-	    {K(L::TIMESTAMP, L::TIMESTAMP_TZ), TZ},
-	    {K(L::TIMESTAMP_TZ, L::TIMESTAMP), TZ},
-	    {K(L::TIMESTAMP, L::DATE), DAY},
-	    {K(L::TIMESTAMP_MS, L::DATE), DAY},
-	    {K(L::TIMESTAMP_SEC, L::DATE), DAY},
-	    {K(L::TIMESTAMP_NS, L::DATE), DAY},
-	    {K(L::DATE, L::TIMESTAMP_TZ), TZ},
-	    {K(L::DATE, L::TIMESTAMP), 0},
-	    {K(L::DATE, L::TIMESTAMP_MS), 0},
-	    {K(L::DATE, L::TIMESTAMP_SEC), 0},
-	    {K(L::DATE, L::TIMESTAMP_NS), 0},
-	    {K(L::TIMESTAMP_NS, L::TIMESTAMP), SEC},
-	    {K(L::TIMESTAMP, L::TIMESTAMP_SEC), SEC},
-	    {K(L::TIMESTAMP, L::TIMESTAMP_MS), SEC},
-	    {K(L::TIMESTAMP_NS, L::TIMESTAMP_MS), SEC},
-	    {K(L::TIMESTAMP_NS, L::TIMESTAMP_SEC), SEC},
-	    {K(L::TIMESTAMP_MS, L::TIMESTAMP_SEC), SEC},
-	};
-
-	auto it = MARGINS.find(K(source, target));
-	if (it != MARGINS.end()) {
-		return it->second;
-	}
-	return -1;
-}
-
-//! Convert delta_micros to native units for the given type, rounding away from zero.
-//! Divide rounding away from zero (towards ±infinity).
-static int64_t DivAwayFromZero(int64_t num, int64_t denom) {
-	return ((num > 0) ? (num + denom - 1) : -(-num + denom - 1)) / denom;
-}
-
-//! Returns the delta in native units and the raw value from the Value.
-static bool GetTemporalRawAndDelta(const Value &val, int64_t delta_micros, int64_t &raw, int64_t &delta) {
-	switch (val.type().id()) {
-	case LogicalTypeId::TIMESTAMP:
-		raw = val.GetValueUnsafe<timestamp_t>().value;
-		delta = delta_micros;
-		return true;
-	case LogicalTypeId::TIMESTAMP_TZ:
-		raw = val.GetValueUnsafe<timestamp_tz_t>().value;
-		delta = delta_micros;
-		return true;
-	case LogicalTypeId::TIMESTAMP_MS:
-		raw = val.GetValueUnsafe<timestamp_ms_t>().value;
-		delta = DivAwayFromZero(delta_micros, Interval::MICROS_PER_MSEC);
-		return true;
-	case LogicalTypeId::TIMESTAMP_SEC:
-		raw = val.GetValueUnsafe<timestamp_sec_t>().value;
-		delta = DivAwayFromZero(delta_micros, Interval::MICROS_PER_SEC);
-		return true;
-	case LogicalTypeId::TIMESTAMP_NS:
-		raw = val.GetValueUnsafe<timestamp_ns_t>().value;
-		if (delta_micros > NumericLimits<int64_t>::Maximum() / 1000 ||
-		    delta_micros < NumericLimits<int64_t>::Minimum() / 1000) {
-			return false;
+	switch (source) {
+	case L::TIMESTAMP:
+	case L::TIMESTAMP_TZ:
+		// native unit: microseconds
+		switch (target) {
+		case L::TIMESTAMP:
+		case L::TIMESTAMP_TZ:
+			return 2LL * Interval::MICROS_PER_HOUR;
+		case L::DATE:
+			return Interval::MICROS_PER_DAY;
+		case L::TIMESTAMP_MS:
+		case L::TIMESTAMP_SEC:
+			return Interval::MICROS_PER_SEC;
+		default:
+			return -1;
 		}
-		delta = delta_micros * 1000;
-		return true;
-	case LogicalTypeId::DATE:
-		raw = val.GetValueUnsafe<date_t>().days;
-		delta = DivAwayFromZero(delta_micros, Interval::MICROS_PER_DAY);
-		return true;
+	case L::TIMESTAMP_NS:
+		// native unit: nanoseconds
+		switch (target) {
+		case L::TIMESTAMP:
+		case L::TIMESTAMP_MS:
+		case L::TIMESTAMP_SEC:
+			return Interval::MICROS_PER_SEC * 1000LL;
+		case L::DATE:
+			return Interval::MICROS_PER_DAY * 1000LL;
+		default:
+			return -1;
+		}
+	case L::TIMESTAMP_MS:
+		// native unit: milliseconds
+		switch (target) {
+		case L::DATE:
+			return Interval::MICROS_PER_DAY / Interval::MICROS_PER_MSEC;
+		case L::TIMESTAMP_SEC:
+			return Interval::MICROS_PER_SEC / Interval::MICROS_PER_MSEC;
+		default:
+			return -1;
+		}
+	case L::TIMESTAMP_SEC:
+		// native unit: seconds
+		switch (target) {
+		case L::DATE:
+			return Interval::MICROS_PER_DAY / Interval::MICROS_PER_SEC;
+		default:
+			return -1;
+		}
+	case L::DATE:
+		// native unit: days
+		switch (target) {
+		case L::TIMESTAMP:
+		case L::TIMESTAMP_MS:
+		case L::TIMESTAMP_SEC:
+		case L::TIMESTAMP_NS:
+			return 0;
+		case L::TIMESTAMP_TZ:
+			return 1;
+		default:
+			return -1;
+		}
 	default:
-		return false;
+		return -1;
 	}
 }
 
@@ -771,30 +759,46 @@ static Value MakeTemporalValue(LogicalTypeId type_id, int64_t result) {
 		return Value::TIMESTAMPSEC(timestamp_sec_t(result));
 	case LogicalTypeId::TIMESTAMP_NS:
 		return Value::TIMESTAMPNS(timestamp_ns_t(result));
-	case LogicalTypeId::DATE: {
-		auto clamped = std::max<int64_t>(std::min<int64_t>(result, NumericLimits<int32_t>::Maximum()),
-		                                 NumericLimits<int32_t>::Minimum());
-		return Value::DATE(date_t(static_cast<int32_t>(clamped)));
-	}
+	case LogicalTypeId::DATE:
+		return Value::DATE(date_t(static_cast<int32_t>(std::max<int64_t>(
+		    std::min<int64_t>(result, NumericLimits<int32_t>::Maximum()), NumericLimits<int32_t>::Minimum()))));
 	default:
 		throw InternalException("MakeTemporalValue: unsupported type");
 	}
 }
 
-//! Adjust a temporal Value by delta_micros (positive = add, negative = subtract).
-//! Returns false if the adjustment would overflow.
-static bool AdjustTemporalValue(Value &val, int64_t delta_micros) {
-	if (delta_micros == 0) {
+//! Adjust a temporal Value by margin (positive = widen upper bound, negative = widen lower bound).
+//! The margin is in native units of the value's type. Returns false on overflow (filter not useful).
+static bool AdjustTemporalValue(Value &val, int64_t margin) {
+	if (margin == 0) {
 		return true;
 	}
-	int64_t raw, delta;
-	if (!GetTemporalRawAndDelta(val, delta_micros, raw, delta)) {
+	int64_t raw;
+	switch (val.type().id()) {
+	case LogicalTypeId::TIMESTAMP:
+		raw = val.GetValueUnsafe<timestamp_t>().value;
+		break;
+	case LogicalTypeId::TIMESTAMP_TZ:
+		raw = val.GetValueUnsafe<timestamp_tz_t>().value;
+		break;
+	case LogicalTypeId::TIMESTAMP_MS:
+		raw = val.GetValueUnsafe<timestamp_ms_t>().value;
+		break;
+	case LogicalTypeId::TIMESTAMP_SEC:
+		raw = val.GetValueUnsafe<timestamp_sec_t>().value;
+		break;
+	case LogicalTypeId::TIMESTAMP_NS:
+		raw = val.GetValueUnsafe<timestamp_ns_t>().value;
+		break;
+	case LogicalTypeId::DATE:
+		raw = val.GetValueUnsafe<date_t>().days;
+		break;
+	default:
 		return false;
 	}
-	// saturating addition
 	int64_t result;
-	if (!TryAddOperator::Operation(raw, delta, result)) {
-		result = (delta > 0) ? NumericLimits<int64_t>::Maximum() : NumericLimits<int64_t>::Minimum();
+	if (!TryAddOperator::Operation(raw, margin, result)) {
+		return false;
 	}
 	val = MakeTemporalValue(val.type().id(), result);
 	return true;
@@ -815,24 +819,21 @@ FilterPushdownResult FilterCombiner::TryPushdownTemporalCastFilter(TableFilterSe
 	}
 
 	// identify which side is CAST(col) and which is the scalar constant
-	Expression *cast_side = nullptr;
-	Expression *const_side = nullptr;
 	bool invert = false;
 	if (comp.left->GetExpressionClass() == ExpressionClass::BOUND_CAST && comp.right->IsFoldable()) {
-		cast_side = comp.left.get();
-		const_side = comp.right.get();
+		// cast on left, constant on right
 	} else if (comp.right->GetExpressionClass() == ExpressionClass::BOUND_CAST && comp.left->IsFoldable()) {
-		cast_side = comp.right.get();
-		const_side = comp.left.get();
 		invert = true;
 	} else {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
-	auto &cast_expr = cast_side->Cast<BoundCastExpression>();
+	auto &cast_side = invert ? *comp.right : *comp.left;
+	auto &const_side = invert ? *comp.left : *comp.right;
+	auto &cast_expr = cast_side.Cast<BoundCastExpression>();
 	auto source_type = cast_expr.source_type();
 	auto &target_type = cast_expr.return_type;
-	int64_t margin_micros = GetTemporalCastRelaxationMicros(source_type.id(), target_type.id());
-	if (margin_micros < 0) {
+	int64_t margin = GetTemporalCastMargin(source_type.id(), target_type.id());
+	if (margin < 0) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 
@@ -848,7 +849,7 @@ FilterPushdownResult FilterCombiner::TryPushdownTemporalCastFilter(TableFilterSe
 	// evaluate the constant side
 	Value constant_value, casted_value;
 	string error_msg;
-	if (!ExpressionExecutor::TryEvaluateScalar(context, *const_side, constant_value)) {
+	if (!ExpressionExecutor::TryEvaluateScalar(context, const_side, constant_value)) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	if (constant_value.IsNull()) {
@@ -869,14 +870,14 @@ FilterPushdownResult FilterCombiner::TryPushdownTemporalCastFilter(TableFilterSe
 	auto comparison_type = invert ? FlipComparisonExpression(comp.GetExpressionType()) : comp.GetExpressionType();
 	if (IsGreaterThan(comparison_type) || comparison_type == ExpressionType::COMPARE_EQUAL) {
 		Value lower = casted_value;
-		if (!AdjustTemporalValue(lower, -margin_micros)) {
+		if (!AdjustTemporalValue(lower, -margin)) {
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}
 		push_optional(ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(lower));
 	}
 	if (IsLessThan(comparison_type) || comparison_type == ExpressionType::COMPARE_EQUAL) {
 		Value upper = casted_value;
-		if (!AdjustTemporalValue(upper, margin_micros)) {
+		if (!AdjustTemporalValue(upper, margin)) {
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}
 		push_optional(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(upper));

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -902,11 +902,7 @@ FilterPushdownResult FilterCombiner::TryPushdownExpression(TableFilterSet &table
 	if (pushdown_result != FilterPushdownResult::NO_PUSHDOWN) {
 		return pushdown_result;
 	}
-	pushdown_result = TryPushdownTemporalCastFilter(table_filters, column_ids, expr);
-	if (pushdown_result != FilterPushdownResult::NO_PUSHDOWN) {
-		return pushdown_result;
-	}
-	return FilterPushdownResult::NO_PUSHDOWN;
+	return TryPushdownTemporalCastFilter(table_filters, column_ids, expr);
 }
 
 void FilterCombiner::TryPushdownRelaxedFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -681,62 +681,61 @@ static int64_t GetTemporalCastMargin(LogicalTypeId source, LogicalTypeId target)
 	if (source == target) {
 		return 0;
 	}
-	using L = LogicalTypeId;
 	switch (source) {
-	case L::TIMESTAMP:
-	case L::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
 		// native unit: microseconds
 		switch (target) {
-		case L::TIMESTAMP:
-		case L::TIMESTAMP_TZ:
+		case LogicalTypeId::TIMESTAMP:
+		case LogicalTypeId::TIMESTAMP_TZ:
 			return 2LL * Interval::MICROS_PER_HOUR;
-		case L::DATE:
+		case LogicalTypeId::DATE:
 			return Interval::MICROS_PER_DAY;
-		case L::TIMESTAMP_MS:
-		case L::TIMESTAMP_SEC:
+		case LogicalTypeId::TIMESTAMP_MS:
+		case LogicalTypeId::TIMESTAMP_SEC:
 			return Interval::MICROS_PER_SEC;
 		default:
 			return -1;
 		}
-	case L::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_NS:
 		// native unit: nanoseconds
 		switch (target) {
-		case L::TIMESTAMP:
-		case L::TIMESTAMP_MS:
-		case L::TIMESTAMP_SEC:
+		case LogicalTypeId::TIMESTAMP:
+		case LogicalTypeId::TIMESTAMP_MS:
+		case LogicalTypeId::TIMESTAMP_SEC:
 			return Interval::MICROS_PER_SEC * 1000LL;
-		case L::DATE:
+		case LogicalTypeId::DATE:
 			return Interval::MICROS_PER_DAY * 1000LL;
 		default:
 			return -1;
 		}
-	case L::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_MS:
 		// native unit: milliseconds
 		switch (target) {
-		case L::DATE:
+		case LogicalTypeId::DATE:
 			return Interval::MICROS_PER_DAY / Interval::MICROS_PER_MSEC;
-		case L::TIMESTAMP_SEC:
+		case LogicalTypeId::TIMESTAMP_SEC:
 			return Interval::MICROS_PER_SEC / Interval::MICROS_PER_MSEC;
 		default:
 			return -1;
 		}
-	case L::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_SEC:
 		// native unit: seconds
 		switch (target) {
-		case L::DATE:
+		case LogicalTypeId::DATE:
 			return Interval::MICROS_PER_DAY / Interval::MICROS_PER_SEC;
 		default:
 			return -1;
 		}
-	case L::DATE:
+	case LogicalTypeId::DATE:
 		// native unit: days
 		switch (target) {
-		case L::TIMESTAMP:
-		case L::TIMESTAMP_MS:
-		case L::TIMESTAMP_SEC:
-		case L::TIMESTAMP_NS:
+		case LogicalTypeId::TIMESTAMP:
+		case LogicalTypeId::TIMESTAMP_MS:
+		case LogicalTypeId::TIMESTAMP_SEC:
+		case LogicalTypeId::TIMESTAMP_NS:
 			return 0;
-		case L::TIMESTAMP_TZ:
+		case LogicalTypeId::TIMESTAMP_TZ:
 			return 1;
 		default:
 			return -1;

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -21,7 +21,9 @@
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/planner/filter/struct_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
+#include "duckdb/common/operator/add.hpp"
 #include "duckdb/common/operator/subtract.hpp"
+#include "duckdb/common/types/interval.hpp"
 #include "duckdb/optimizer/column_lifetime_analyzer.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
@@ -664,6 +666,224 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 }
 
+static bool IsGreaterThan(ExpressionType type) {
+	return type == ExpressionType::COMPARE_GREATERTHAN || type == ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+}
+
+static bool IsLessThan(ExpressionType type) {
+	return type == ExpressionType::COMPARE_LESSTHAN || type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
+}
+
+//! Returns the relaxation margin in microseconds for a temporal cast, or -1 if not relaxable.
+static int64_t GetTemporalCastRelaxationMicros(LogicalTypeId source, LogicalTypeId target) {
+	if (source == target) {
+		return 0;
+	}
+	// margins: 26h for tz offset (±14h both ways), 24h for time-of-day loss, 1s for rounding loss
+	static constexpr int64_t TZ = 26LL * Interval::MICROS_PER_HOUR;
+	static constexpr int64_t DAY = Interval::MICROS_PER_DAY;
+	static constexpr int64_t SEC = Interval::MICROS_PER_SEC;
+
+	// encode (source, target) pair as a single key for map lookup
+	using L = LogicalTypeId;
+	auto K = [](L s, L t) -> uint32_t {
+		return (uint32_t(s) << 8) | uint32_t(t);
+	};
+	static const unordered_map<uint32_t, int64_t> MARGINS = {
+	    {K(L::TIMESTAMP, L::TIMESTAMP_TZ), TZ},
+	    {K(L::TIMESTAMP_TZ, L::TIMESTAMP), TZ},
+	    {K(L::TIMESTAMP, L::DATE), DAY},
+	    {K(L::TIMESTAMP_MS, L::DATE), DAY},
+	    {K(L::TIMESTAMP_SEC, L::DATE), DAY},
+	    {K(L::TIMESTAMP_NS, L::DATE), DAY},
+	    {K(L::DATE, L::TIMESTAMP_TZ), TZ},
+	    {K(L::DATE, L::TIMESTAMP), 0},
+	    {K(L::DATE, L::TIMESTAMP_MS), 0},
+	    {K(L::DATE, L::TIMESTAMP_SEC), 0},
+	    {K(L::DATE, L::TIMESTAMP_NS), 0},
+	    {K(L::TIMESTAMP_NS, L::TIMESTAMP), SEC},
+	    {K(L::TIMESTAMP, L::TIMESTAMP_SEC), SEC},
+	    {K(L::TIMESTAMP, L::TIMESTAMP_MS), SEC},
+	    {K(L::TIMESTAMP_NS, L::TIMESTAMP_MS), SEC},
+	    {K(L::TIMESTAMP_NS, L::TIMESTAMP_SEC), SEC},
+	    {K(L::TIMESTAMP_MS, L::TIMESTAMP_SEC), SEC},
+	};
+
+	auto it = MARGINS.find(K(source, target));
+	if (it != MARGINS.end()) {
+		return it->second;
+	}
+	return -1;
+}
+
+//! Convert delta_micros to native units for the given type, rounding away from zero.
+//! Divide rounding away from zero (towards ±infinity).
+static int64_t DivAwayFromZero(int64_t num, int64_t denom) {
+	return ((num > 0) ? (num + denom - 1) : -(-num + denom - 1)) / denom;
+}
+
+//! Returns the delta in native units and the raw value from the Value.
+static bool GetTemporalRawAndDelta(const Value &val, int64_t delta_micros, int64_t &raw, int64_t &delta) {
+	switch (val.type().id()) {
+	case LogicalTypeId::TIMESTAMP:
+		raw = val.GetValueUnsafe<timestamp_t>().value;
+		delta = delta_micros;
+		return true;
+	case LogicalTypeId::TIMESTAMP_TZ:
+		raw = val.GetValueUnsafe<timestamp_tz_t>().value;
+		delta = delta_micros;
+		return true;
+	case LogicalTypeId::TIMESTAMP_MS:
+		raw = val.GetValueUnsafe<timestamp_ms_t>().value;
+		delta = DivAwayFromZero(delta_micros, Interval::MICROS_PER_MSEC);
+		return true;
+	case LogicalTypeId::TIMESTAMP_SEC:
+		raw = val.GetValueUnsafe<timestamp_sec_t>().value;
+		delta = DivAwayFromZero(delta_micros, Interval::MICROS_PER_SEC);
+		return true;
+	case LogicalTypeId::TIMESTAMP_NS:
+		raw = val.GetValueUnsafe<timestamp_ns_t>().value;
+		if (delta_micros > NumericLimits<int64_t>::Maximum() / 1000 ||
+		    delta_micros < NumericLimits<int64_t>::Minimum() / 1000) {
+			return false;
+		}
+		delta = delta_micros * 1000;
+		return true;
+	case LogicalTypeId::DATE:
+		raw = val.GetValueUnsafe<date_t>().days;
+		delta = DivAwayFromZero(delta_micros, Interval::MICROS_PER_DAY);
+		return true;
+	default:
+		return false;
+	}
+}
+
+//! Create a temporal Value from a raw int64 (or int32 for DATE) value.
+static Value MakeTemporalValue(LogicalTypeId type_id, int64_t result) {
+	switch (type_id) {
+	case LogicalTypeId::TIMESTAMP:
+		return Value::TIMESTAMP(timestamp_t(result));
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return Value::TIMESTAMPTZ(timestamp_tz_t(result));
+	case LogicalTypeId::TIMESTAMP_MS:
+		return Value::TIMESTAMPMS(timestamp_ms_t(result));
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return Value::TIMESTAMPSEC(timestamp_sec_t(result));
+	case LogicalTypeId::TIMESTAMP_NS:
+		return Value::TIMESTAMPNS(timestamp_ns_t(result));
+	case LogicalTypeId::DATE: {
+		auto clamped = std::max<int64_t>(std::min<int64_t>(result, NumericLimits<int32_t>::Maximum()),
+		                                 NumericLimits<int32_t>::Minimum());
+		return Value::DATE(date_t(static_cast<int32_t>(clamped)));
+	}
+	default:
+		throw InternalException("MakeTemporalValue: unsupported type");
+	}
+}
+
+//! Adjust a temporal Value by delta_micros (positive = add, negative = subtract).
+//! Returns false if the adjustment would overflow.
+static bool AdjustTemporalValue(Value &val, int64_t delta_micros) {
+	if (delta_micros == 0) {
+		return true;
+	}
+	int64_t raw, delta;
+	if (!GetTemporalRawAndDelta(val, delta_micros, raw, delta)) {
+		return false;
+	}
+	// saturating addition
+	int64_t result;
+	if (!TryAddOperator::Operation(raw, delta, result)) {
+		result = (delta > 0) ? NumericLimits<int64_t>::Maximum() : NumericLimits<int64_t>::Minimum();
+	}
+	val = MakeTemporalValue(val.type().id(), result);
+	return true;
+}
+
+FilterPushdownResult FilterCombiner::TryPushdownTemporalCastFilter(TableFilterSet &table_filters,
+                                                                   const vector<ColumnIndex> &column_ids,
+                                                                   Expression &expr) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_COMPARISON) {
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+	auto &comp = expr.Cast<BoundComparisonExpression>();
+	if (!SupportedFilterComparison(comp.GetExpressionType())) {
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+	if (comp.GetExpressionType() == ExpressionType::COMPARE_NOTEQUAL) {
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+
+	// identify which side is CAST(col) and which is the scalar constant
+	Expression *cast_side = nullptr;
+	Expression *const_side = nullptr;
+	bool invert = false;
+	if (comp.left->GetExpressionClass() == ExpressionClass::BOUND_CAST && comp.right->IsFoldable()) {
+		cast_side = comp.left.get();
+		const_side = comp.right.get();
+	} else if (comp.right->GetExpressionClass() == ExpressionClass::BOUND_CAST && comp.left->IsFoldable()) {
+		cast_side = comp.right.get();
+		const_side = comp.left.get();
+		invert = true;
+	} else {
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+	auto &cast_expr = cast_side->Cast<BoundCastExpression>();
+	auto source_type = cast_expr.source_type();
+	auto &target_type = cast_expr.return_type;
+	int64_t margin_micros = GetTemporalCastRelaxationMicros(source_type.id(), target_type.id());
+	if (margin_micros < 0) {
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+
+	// the child of the cast must resolve to a column ref
+	ColumnIndex col_index(0);
+	if (!TryGetBoundColumnIndex(column_ids, *cast_expr.child, col_index)) {
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+	if (col_index.IsPushdownExtract()) {
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+
+	// evaluate the constant side
+	Value constant_value, casted_value;
+	string error_msg;
+	if (!ExpressionExecutor::TryEvaluateScalar(context, *const_side, constant_value)) {
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+	if (constant_value.IsNull()) {
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+	if (!constant_value.TryCastAs(context, source_type, casted_value, &error_msg)) {
+		return FilterPushdownResult::NO_PUSHDOWN;
+	}
+
+	auto push_optional = [&](ExpressionType filter_type, Value filter_val) {
+		auto const_filter = make_uniq<ConstantFilter>(filter_type, std::move(filter_val));
+		auto opt_filter = make_uniq<OptionalFilter>();
+		opt_filter->child_filter = std::move(const_filter);
+		table_filters.PushFilter(col_index, std::move(opt_filter));
+	};
+
+	// push relaxed filter(s) as OptionalFilter
+	auto comparison_type = invert ? FlipComparisonExpression(comp.GetExpressionType()) : comp.GetExpressionType();
+	if (IsGreaterThan(comparison_type) || comparison_type == ExpressionType::COMPARE_EQUAL) {
+		Value lower = casted_value;
+		if (!AdjustTemporalValue(lower, -margin_micros)) {
+			return FilterPushdownResult::NO_PUSHDOWN;
+		}
+		push_optional(ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(lower));
+	}
+	if (IsLessThan(comparison_type) || comparison_type == ExpressionType::COMPARE_EQUAL) {
+		Value upper = casted_value;
+		if (!AdjustTemporalValue(upper, margin_micros)) {
+			return FilterPushdownResult::NO_PUSHDOWN;
+		}
+		push_optional(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(upper));
+	}
+	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
+}
+
 FilterPushdownResult FilterCombiner::TryPushdownExpression(TableFilterSet &table_filters,
                                                            const vector<ColumnIndex> &column_ids, Expression &expr) {
 	auto pushdown_result = TryPushdownPrefixFilter(table_filters, column_ids, expr);
@@ -682,7 +902,30 @@ FilterPushdownResult FilterCombiner::TryPushdownExpression(TableFilterSet &table
 	if (pushdown_result != FilterPushdownResult::NO_PUSHDOWN) {
 		return pushdown_result;
 	}
+	pushdown_result = TryPushdownTemporalCastFilter(table_filters, column_ids, expr);
+	if (pushdown_result != FilterPushdownResult::NO_PUSHDOWN) {
+		return pushdown_result;
+	}
 	return FilterPushdownResult::NO_PUSHDOWN;
+}
+
+void FilterCombiner::TryPushdownRelaxedFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+                                              vector<FilterPushdownResult> &pushdown_results, column_t expr_id,
+                                              vector<ExpressionValueInformation> &info_list) {
+	auto filter_exp = equivalence_map.find(expr_id);
+	if (filter_exp == equivalence_map.end() || filter_exp->second.size() != 1) {
+		return;
+	}
+	auto &node_expr = filter_exp->second[0].get();
+	for (auto &info : info_list) {
+		auto constant = make_uniq<BoundConstantExpression>(info.constant);
+		auto comparison =
+		    make_uniq<BoundComparisonExpression>(info.comparison_type, node_expr.Copy(), std::move(constant));
+		auto result = TryPushdownTemporalCastFilter(table_filters, column_ids, *comparison);
+		if (result != FilterPushdownResult::NO_PUSHDOWN) {
+			pushdown_results.push_back(result);
+		}
+	}
 }
 
 TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex> &column_ids,
@@ -692,7 +935,10 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 	for (auto &constant_value : constant_values) {
 		auto expr_id = constant_value.first;
 		auto &const_list = constant_value.second;
-		TryPushdownConstantFilter(table_filters, column_ids, expr_id, const_list);
+		auto result = TryPushdownConstantFilter(table_filters, column_ids, expr_id, const_list);
+		if (result == FilterPushdownResult::NO_PUSHDOWN) {
+			TryPushdownRelaxedFilter(table_filters, column_ids, pushdown_results, expr_id, const_list);
+		}
 	}
 	//! Here we look for LIKE or IN filters
 	for (idx_t rem_fil_idx = 0; rem_fil_idx < remaining_filters.size(); rem_fil_idx++) {
@@ -706,14 +952,6 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 		}
 	}
 	return table_filters;
-}
-
-static bool IsGreaterThan(ExpressionType type) {
-	return type == ExpressionType::COMPARE_GREATERTHAN || type == ExpressionType::COMPARE_GREATERTHANOREQUALTO;
-}
-
-static bool IsLessThan(ExpressionType type) {
-	return type == ExpressionType::COMPARE_LESSTHAN || type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
 }
 
 FilterResult FilterCombiner::AddBoundComparisonFilter(Expression &expr) {

--- a/test/sql/optimizer/temporal_cast_dst.test
+++ b/test/sql/optimizer/temporal_cast_dst.test
@@ -8,7 +8,7 @@ statement ok
 PRAGMA enable_verification;
 
 statement ok
-SET timezone='Europe/Amsterdam';
+SET timezone='Europe/Paris';
 
 # Create a table spanning the autumn DST switch (2026-10-25, clocks go back at 3:00 -> 2:00)
 # This creates 10 hours of TIMESTAMPTZ data in 1-minute intervals around the switch

--- a/test/sql/optimizer/temporal_cast_dst.test
+++ b/test/sql/optimizer/temporal_cast_dst.test
@@ -1,0 +1,61 @@
+# name: test/sql/optimizer/temporal_cast_dst.test
+# description: Test temporal cast filter pushdown around DST boundaries
+# group: [optimizer]
+
+require icu
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+SET timezone='Europe/Amsterdam';
+
+# Create a table spanning the autumn DST switch (2026-10-25, clocks go back at 3:00 -> 2:00)
+# This creates 5 hours of TIMESTAMPTZ data in 1-minute intervals around the switch
+statement ok
+CREATE TABLE dst_table AS
+    SELECT '2026-10-25 00:00:00+02'::TIMESTAMPTZ + (i * INTERVAL '1 minute') AS col
+    FROM range(300) t(i);
+
+# ---------------------------------------------------------------------------
+# TIMESTAMPTZ -> TIMESTAMP around DST boundary
+# The cast to TIMESTAMP creates ambiguity: two different TIMESTAMPTZ values
+# (pre- and post-switch) map to the same TIMESTAMP value.
+# The relaxed filter must not miss any rows.
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM dst_table WHERE CAST(col AS TIMESTAMP) > '2026-10-25 02:30:00'::TIMESTAMP;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+query II
+EXPLAIN SELECT * FROM dst_table WHERE CAST(col AS TIMESTAMP) <= '2026-10-25 02:30:00'::TIMESTAMP;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# Correctness: the two halves must add up to the full table (no rows lost)
+query I
+SELECT (SELECT count(*) FROM dst_table WHERE CAST(col AS TIMESTAMP) > '2026-10-25 02:30:00'::TIMESTAMP)
+     + (SELECT count(*) FROM dst_table WHERE CAST(col AS TIMESTAMP) <= '2026-10-25 02:30:00'::TIMESTAMP);
+----
+300
+
+# ---------------------------------------------------------------------------
+# TIMESTAMP -> TIMESTAMPTZ around DST boundary
+# ---------------------------------------------------------------------------
+statement ok
+CREATE TABLE ts_dst_table AS
+    SELECT ('2026-10-25 00:00:00'::TIMESTAMP + (i * INTERVAL '1 minute')) AS col
+    FROM range(300) t(i);
+
+query II
+EXPLAIN SELECT * FROM ts_dst_table WHERE CAST(col AS TIMESTAMPTZ) > '2026-10-25 02:30:00+01'::TIMESTAMPTZ;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# Correctness: the two halves must add up to the full table
+query I
+SELECT (SELECT count(*) FROM ts_dst_table WHERE CAST(col AS TIMESTAMPTZ) > '2026-10-25 02:30:00+01'::TIMESTAMPTZ)
+     + (SELECT count(*) FROM ts_dst_table WHERE CAST(col AS TIMESTAMPTZ) <= '2026-10-25 02:30:00+01'::TIMESTAMPTZ);
+----
+300

--- a/test/sql/optimizer/temporal_cast_dst.test
+++ b/test/sql/optimizer/temporal_cast_dst.test
@@ -11,11 +11,13 @@ statement ok
 SET timezone='Europe/Amsterdam';
 
 # Create a table spanning the autumn DST switch (2026-10-25, clocks go back at 3:00 -> 2:00)
-# This creates 5 hours of TIMESTAMPTZ data in 1-minute intervals around the switch
+# This creates 10 hours of TIMESTAMPTZ data in 1-minute intervals around the switch
+# We need enough data so that the relaxed filter bounds (with 2h margin) are not trivially true,
+# otherwise the statistics propagator will remove them.
 statement ok
 CREATE TABLE dst_table AS
     SELECT '2026-10-25 00:00:00+02'::TIMESTAMPTZ + (i * INTERVAL '1 minute') AS col
-    FROM range(300) t(i);
+    FROM range(600) t(i);
 
 # ---------------------------------------------------------------------------
 # TIMESTAMPTZ -> TIMESTAMP around DST boundary
@@ -38,7 +40,7 @@ query I
 SELECT (SELECT count(*) FROM dst_table WHERE CAST(col AS TIMESTAMP) > '2026-10-25 02:30:00'::TIMESTAMP)
      + (SELECT count(*) FROM dst_table WHERE CAST(col AS TIMESTAMP) <= '2026-10-25 02:30:00'::TIMESTAMP);
 ----
-300
+600
 
 # ---------------------------------------------------------------------------
 # TIMESTAMP -> TIMESTAMPTZ around DST boundary

--- a/test/sql/optimizer/temporal_cast_zonemap.test
+++ b/test/sql/optimizer/temporal_cast_zonemap.test
@@ -1,0 +1,197 @@
+# name: test/sql/optimizer/temporal_cast_zonemap.test
+# description: Test that temporal cast filters generate OptionalFilter for zonemap pruning
+# group: [optimizer]
+
+statement ok
+PRAGMA enable_verification;
+
+# ---------------------------------------------------------------------------
+# Setup tables
+# ---------------------------------------------------------------------------
+statement ok
+CREATE TABLE ts_table AS SELECT '2020-01-01'::TIMESTAMP + (i * INTERVAL '1 minute') AS col FROM range(1000000) t(i);
+
+statement ok
+CREATE TABLE date_table AS SELECT ('2020-01-01'::DATE + (i * INTERVAL '1 day'))::DATE AS col FROM range(100000) d(i);
+
+statement ok
+CREATE TABLE tsns_table AS SELECT ('2020-01-01'::TIMESTAMP + (i * INTERVAL '1 minute'))::TIMESTAMP_NS AS col FROM range(1000000) t(i);
+
+statement ok
+CREATE TABLE tsms_table AS SELECT ('2020-01-01'::TIMESTAMP + (i * INTERVAL '1 minute'))::TIMESTAMP_MS AS col FROM range(1000000) t(i);
+
+statement ok
+CREATE TABLE tss_table AS SELECT ('2020-01-01'::TIMESTAMP + (i * INTERVAL '1 minute'))::TIMESTAMP_S AS col FROM range(1000000) t(i);
+
+# ---------------------------------------------------------------------------
+# TIMESTAMP <-> TIMESTAMPTZ (margin = 26h)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM ts_table WHERE CAST(col AS TIMESTAMPTZ) > TIMESTAMPTZ '2020-06-01 00:00:00+00';
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+query II
+EXPLAIN SELECT * FROM ts_table WHERE CAST(col AS TIMESTAMPTZ) <= TIMESTAMPTZ '2020-06-01 00:00:00+00';
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# ---------------------------------------------------------------------------
+# DATE -> TIMESTAMP (margin = 0, lossless)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM date_table WHERE CAST(col AS TIMESTAMP) > '2024-01-01'::TIMESTAMP;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+query II
+EXPLAIN SELECT * FROM date_table WHERE CAST(col AS TIMESTAMP) < '2021-01-01'::TIMESTAMP;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+query II
+EXPLAIN SELECT * FROM date_table WHERE CAST(col AS TIMESTAMP) >= '2022-06-15'::TIMESTAMP;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+query II
+EXPLAIN SELECT * FROM date_table WHERE CAST(col AS TIMESTAMP) = '2022-06-15'::TIMESTAMP;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# ---------------------------------------------------------------------------
+# TIMESTAMP -> DATE (margin = 24h)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM ts_table WHERE CAST(col AS DATE) > '2020-06-01'::DATE;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# ---------------------------------------------------------------------------
+# TIMESTAMP_NS -> TIMESTAMP (margin = 1s)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM tsns_table WHERE CAST(col AS TIMESTAMP) > '2020-06-01'::TIMESTAMP;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# ---------------------------------------------------------------------------
+# TIMESTAMP -> TIMESTAMP_MS (margin = 1s)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM ts_table WHERE CAST(col AS TIMESTAMP_MS) > '2020-06-01'::TIMESTAMP_MS;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# ---------------------------------------------------------------------------
+# TIMESTAMP -> TIMESTAMP_S (margin = 1s)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM ts_table WHERE CAST(col AS TIMESTAMP_S) > '2020-06-01'::TIMESTAMP_S;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# ---------------------------------------------------------------------------
+# TIMESTAMP_MS -> DATE (margin = 24h)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM tsms_table WHERE CAST(col AS DATE) > '2020-06-01'::DATE;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# ---------------------------------------------------------------------------
+# TIMESTAMP_S -> DATE (margin = 24h)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM tss_table WHERE CAST(col AS DATE) > '2020-06-01'::DATE;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# ---------------------------------------------------------------------------
+# TIMESTAMP_NS -> TIMESTAMP_MS (margin = 1s)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM tsns_table WHERE CAST(col AS TIMESTAMP_MS) > '2020-06-01'::TIMESTAMP_MS;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# ---------------------------------------------------------------------------
+# TIMESTAMP_MS -> TIMESTAMP_S (margin = 1s)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM tsms_table WHERE CAST(col AS TIMESTAMP_S) > '2020-06-01'::TIMESTAMP_S;
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# ---------------------------------------------------------------------------
+# DATE -> TIMESTAMPTZ (margin = 26h) - requires ICU for TIMESTAMPTZ->DATE cast
+# so we skip this test here; it would work with LOAD icu
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Constant on left side (inverted comparison)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM date_table WHERE '2024-01-01'::TIMESTAMP < CAST(col AS TIMESTAMP);
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+query II
+EXPLAIN SELECT * FROM date_table WHERE '2021-01-01'::TIMESTAMP > CAST(col AS TIMESTAMP);
+----
+physical_plan	<REGEX>:.*optional.*col.*
+
+# ---------------------------------------------------------------------------
+# Negative: != should NOT produce an optional filter
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM date_table WHERE CAST(col AS TIMESTAMP) != '2024-01-01'::TIMESTAMP;
+----
+physical_plan	<!REGEX>:.*optional.*
+
+# ---------------------------------------------------------------------------
+# Negative: non-temporal cast should NOT produce an optional filter
+# ---------------------------------------------------------------------------
+statement ok
+CREATE TABLE int_table AS SELECT i AS col FROM range(100000) t(i);
+
+query II
+EXPLAIN SELECT * FROM int_table WHERE CAST(col AS VARCHAR) > '50000';
+----
+physical_plan	<!REGEX>:.*optional.*
+
+# ---------------------------------------------------------------------------
+# Original filter is preserved (not just the optional)
+# ---------------------------------------------------------------------------
+query II
+EXPLAIN SELECT * FROM date_table WHERE CAST(col AS TIMESTAMP) > '2024-01-01'::TIMESTAMP;
+----
+physical_plan	<REGEX>:.*CAST.*col.*TIMESTAMP.*
+
+# ---------------------------------------------------------------------------
+# Correctness: results match expected values
+# ---------------------------------------------------------------------------
+query I
+SELECT count(*) FROM date_table WHERE CAST(col AS TIMESTAMP) > '2024-01-01'::TIMESTAMP;
+----
+98538
+
+query I
+SELECT count(*) FROM date_table WHERE CAST(col AS TIMESTAMP) < '2021-01-01'::TIMESTAMP;
+----
+366
+
+query I
+SELECT count(*) FROM date_table WHERE CAST(col AS TIMESTAMP) = '2022-06-15 00:00:00'::TIMESTAMP;
+----
+1
+
+query I
+SELECT count(*) FROM date_table WHERE CAST(col AS TIMESTAMP) >= '2024-01-01'::TIMESTAMP;
+----
+98539
+
+query I
+SELECT count(*) FROM date_table WHERE CAST(col AS TIMESTAMP) <= '2020-01-03'::TIMESTAMP;
+----
+3

--- a/test/sql/optimizer/temporal_cast_zonemap.test
+++ b/test/sql/optimizer/temporal_cast_zonemap.test
@@ -24,7 +24,7 @@ statement ok
 CREATE TABLE tss_table AS SELECT ('2020-01-01'::TIMESTAMP + (i * INTERVAL '1 minute'))::TIMESTAMP_S AS col FROM range(1000000) t(i);
 
 # ---------------------------------------------------------------------------
-# TIMESTAMP <-> TIMESTAMPTZ (margin = 26h)
+# TIMESTAMP <-> TIMESTAMPTZ (margin = 2h for DST ambiguity)
 # ---------------------------------------------------------------------------
 query II
 EXPLAIN SELECT * FROM ts_table WHERE CAST(col AS TIMESTAMPTZ) > TIMESTAMPTZ '2020-06-01 00:00:00+00';
@@ -124,7 +124,7 @@ EXPLAIN SELECT * FROM tsms_table WHERE CAST(col AS TIMESTAMP_S) > '2020-06-01'::
 physical_plan	<REGEX>:.*optional.*col.*
 
 # ---------------------------------------------------------------------------
-# DATE -> TIMESTAMPTZ (margin = 26h) - requires ICU for TIMESTAMPTZ->DATE cast
+# DATE -> TIMESTAMPTZ (margin = 2h) - requires ICU for TIMESTAMPTZ->DATE cast
 # so we skip this test here; it would work with LOAD icu
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
MotherDuck noted that filters like `start_time > now() - INTERVAL 1 HOUR` fail to pushdown, with `start_time` being a column of type `TIMESTAMP` in a huge (mostly time-ordered) table.

This turned out to be because `now()` is of type `TIMESTAMP WITH TIMEZONE` and its CAST to `TIMEZONE` is "non-invertible". This may be quite a common problem, and most users won't understand why the query is suddenly very slow. The phenomenon does not only affect `TIMESTAMP_TZ` vs `TIMESTAMP` column-constant comparisons but also those between `TIMESTAMP[_*]`/`DATE` and also nonequal `TIMESTAMP*` types.

This PR fixes this by adding a *margin* to the scalar value and turning the pushed down filter into `PUSHED_DOWN_PARTIALLY`. For instance, even though politicians can go wild on summer/winter time, the worldwide TZ difference has never been bigger than 26 hours (wait for Martial time though).

Just trying to save some ice bears here by cutting down on full table scans.

Also added tests.