### PR TITLE
Use namespace runner for Swift jobs

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -96,7 +96,7 @@ jobs:
         zip -j libduckdb-android_${{matrix.arch}}.zip build/release/src/libduckdb*.*  src/include/duckdb.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-android_${{matrix.arch}}.zip
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: duckdb-binaries-android-${{matrix.arch}}
         path: |

--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -62,7 +62,7 @@ jobs:
       CMAKE_VARS_BUILD: -DBUILD_UNITTESTS=0 -DBUILD_SHELL=0 -DANDROID_ABI=${{ matrix.arch}} -DCMAKE_TOOLCHAIN_FILE=./android-ndk/build/cmake/android.toolchain.cmake -DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}

--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -58,7 +58,7 @@ jobs:
       DUCKDB_PLATFORM: osx_${{ matrix.architecture }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
@@ -106,7 +106,7 @@ jobs:
       ENABLE_EXTENSION_AUTOLOADING: 1
       ENABLE_EXTENSION_AUTOINSTALL: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
@@ -168,7 +168,7 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}

--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -92,7 +92,7 @@ jobs:
           zip -r -j static-libs-osx-${{ matrix.architecture }}.zip src/include/duckdb.h build/release/libs/
           ./scripts/upload-assets-to-staging.sh github_release static-libs-osx-${{ matrix.architecture }}.zip
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: duckdb-static-libs-osx-${{ matrix.architecture }}
           path: |
@@ -111,7 +111,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -152,7 +152,7 @@ jobs:
           zip -r -j static-libs-windows-mingw.zip src/include/duckdb.h build/release/libs/
           ./scripts/upload-assets-to-staging.sh github_release static-libs-windows-mingw.zip
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: duckdb-static-libs-windows-mingw
           path: |
@@ -213,7 +213,7 @@ jobs:
           python3 scripts/amalgamation.py
           zip -r -j static-libs-linux-${{ matrix.config.arch }}.zip src/include/duckdb.h build/release/libs/
           ./scripts/upload-assets-to-staging.sh github_release static-libs-linux-${{ matrix.config.arch }}.zip
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: duckdb-static-libs-linux-${{ matrix.config.arch }}
           path: |

--- a/.github/workflows/CheckIssueForCodeFormatting.yml
+++ b/.github/workflows/CheckIssueForCodeFormatting.yml
@@ -11,7 +11,7 @@ jobs:
   check_code_formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Python 3.12

--- a/.github/workflows/CheckIssueForCodeFormatting.yml
+++ b/.github/workflows/CheckIssueForCodeFormatting.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Check issue for code formatting

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -31,7 +31,7 @@ jobs:
       GEN: ninja
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
       TIDY_CHECKS: ${{ inputs.explicit_checks && inputs.explicit_checks || '' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -42,7 +42,7 @@ jobs:
       GEN: ninja
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ matrix.version }}
@@ -96,7 +96,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ matrix.version }}
@@ -198,7 +198,7 @@ jobs:
       GEN: ninja
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ matrix.version }}
@@ -251,7 +251,7 @@ jobs:
       GEN: ninja
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ matrix.version }}

--- a/.github/workflows/CrossVersion.yml
+++ b/.github/workflows/CrossVersion.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ matrix.version }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -70,7 +70,7 @@ jobs:
           ./build/release/test/unittest --force-storage --test-temp-dir my_local_folder || true
           rm -rf my_local_folder/hive
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: files-osx-${{ matrix.version }}
           path: |
@@ -101,7 +101,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ matrix.version }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -118,51 +118,51 @@ jobs:
         shell: bash
         run: ./build/release/duckdb -c "PRAGMA platform;"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-v1.0.0
           path: osx_v1_0_0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-v1.1.3
           path: osx_v1_1_3
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-v1.2.2
           path: osx_v1_2_2
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-v1.3.2
           path: osx_v1_3_2
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-v1.4-andium
           path: osx_v1_4-andium
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-main
           path: osx_main
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-v1.0.0
           path: linux_v1_0_0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-v1.1.3
           path: linux_v1_1_3
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-v1.2.2
           path: linux_v1_2_2
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-v1.3.2
           path: linux_v1_3_2
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-v1.4-andium
           path: linux_v1_4-andium
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-main
           path: linux_main
@@ -203,7 +203,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ matrix.version }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -227,7 +227,7 @@ jobs:
           ./build/release/test/unittest --force-storage --test-temp-dir my_local_folder || true
           rm -rf my_local_folder/hive
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: files-linux-${{ matrix.version }}
           path: |
@@ -268,7 +268,7 @@ jobs:
           remove_folders: /opt/az /opt/ghc /opt/google /opt/hostedtoolcache /opt/microsoft /usr/lib/firefox /usr/lib/jvm /usr/local/.ghcup /usr/local/julia* /usr/local/lib/android /usr/local/share/boost /usr/local/share/chromium /usr/local/share/powershell /usr/share/dotnet /usr/share/swift /var/lib/apt/lists/*
 
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -286,51 +286,51 @@ jobs:
         shell: bash
         run: ./build/release/duckdb -c "PRAGMA platform;"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-v1.0.0
           path: osx_v1_0_0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-v1.1.3
           path: osx_v1_1_3
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-v1.2.2
           path: osx_v1_2_2
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-v1.3.2
           path: osx_v1_3_2
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-v1.4-andium
           path: osx_v1_4-andium
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-osx-main
           path: osx_main
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-v1.0.0
           path: linux_v1_0_0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-v1.1.3
           path: linux_v1_1_3
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-v1.2.2
           path: linux_v1_2_2
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-v1.3.2
           path: linux_v1_3_2
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-v1.4-andium
           path: linux_v1_4-andium
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: files-linux-main
           path: linux_main

--- a/.github/workflows/DockerTests.yml
+++ b/.github/workflows/DockerTests.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}

--- a/.github/workflows/DraftMe.yml
+++ b/.github/workflows/DraftMe.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr_number
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: pr_number
           path: pr/

--- a/.github/workflows/ExtendedTests.yml
+++ b/.github/workflows/ExtendedTests.yml
@@ -34,7 +34,7 @@ jobs:
       BASE_BRANCH: ${{ github.base_ref || 'main' }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -72,7 +72,7 @@ jobs:
        CORE_EXTENSIONS: "tpch;tpcds;httpfs"
 
      steps:
-     - uses: actions/checkout@v4
+     - uses: actions/checkout@v6
        with:
          fetch-depth: 0
 
@@ -148,7 +148,7 @@ jobs:
        CORE_EXTENSIONS: "tpch;tpcds;httpfs"
 
      steps:
-     - uses: actions/checkout@v4
+     - uses: actions/checkout@v6
        with:
          fetch-depth: 0
 
@@ -224,7 +224,7 @@ jobs:
        CORE_EXTENSIONS: "tpch;tpcds;httpfs"
 
      steps:
-       - uses: actions/checkout@v4
+       - uses: actions/checkout@v6
          with:
            fetch-depth: 0
 
@@ -305,7 +305,7 @@ jobs:
        CORE_EXTENSIONS: "tpch;tpcds;httpfs"
 
      steps:
-       - uses: actions/checkout@v4
+       - uses: actions/checkout@v6
          with:
            fetch-depth: 0
 

--- a/.github/workflows/ExtendedTests.yml
+++ b/.github/workflows/ExtendedTests.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -76,7 +76,7 @@ jobs:
        with:
          fetch-depth: 0
 
-     - uses: actions/setup-python@v5
+     - uses: actions/setup-python@v6
        with:
          python-version: '3.12'
 
@@ -152,7 +152,7 @@ jobs:
        with:
          fetch-depth: 0
 
-     - uses: actions/setup-python@v5
+     - uses: actions/setup-python@v6
        with:
          python-version: '3.12'
 
@@ -228,7 +228,7 @@ jobs:
          with:
            fetch-depth: 0
 
-       - uses: actions/setup-python@v5
+       - uses: actions/setup-python@v6
          with:
            python-version: '3.12'
 
@@ -309,7 +309,7 @@ jobs:
          with:
            fetch-depth: 0
 
-       - uses: actions/setup-python@v5
+       - uses: actions/setup-python@v6
          with:
            python-version: '3.12'
 

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -103,7 +103,7 @@ jobs:
       EXTRA_EXCLUDE_ARCHS: ${{ inputs.extra_exclude_archs }}
       OPT_IN_ARCHS: ${{ inputs.opt_in_archs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
@@ -211,7 +211,7 @@ jobs:
     needs:
       - extensions-build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -260,7 +260,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -295,7 +295,7 @@ jobs:
     needs: create-extension-repository
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
@@ -346,7 +346,7 @@ jobs:
       GEN: ninja
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -217,19 +217,19 @@ jobs:
 
       - uses: ./.github/actions/cleanup_runner
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         name: Download main extensions
         with:
           pattern: main-extensions*
           path: /tmp/repository_generation/main-extensions
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         name: Download rust-based extensions
         with:
           pattern: rust-based-extensions*
           path: /tmp/repository_generation/rust-based-extensions
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         name: Download external extensions
         with:
           pattern: external-extensions*
@@ -245,7 +245,7 @@ jobs:
           cp -r  /tmp/repository_generation/*/*/* /tmp/merged_repository
           tree /tmp/merged_repository
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error
           name: extension-repository
@@ -266,7 +266,7 @@ jobs:
 
       - uses: ./.github/actions/cleanup_runner
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           pattern: extension-repository
           path: /tmp
@@ -306,7 +306,7 @@ jobs:
 
       - uses: ./.github/actions/ccache-action
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           pattern: extension-repository
           path: /tmp
@@ -351,7 +351,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
 
@@ -369,7 +369,7 @@ jobs:
         run: |
           make
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         name: Download extension repository artifact
         with:
           pattern: extension-repository
@@ -395,7 +395,7 @@ jobs:
           pip install "clang_format==11.0.1"
           make format-fix
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: extension_entries.hpp
           path: |

--- a/.github/workflows/ExtraTests.yml
+++ b/.github/workflows/ExtraTests.yml
@@ -22,7 +22,7 @@ jobs:
     CORE_EXTENSIONS: "tpcd;tpcds;httpfs"
 
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/ExtraTests.yml
+++ b/.github/workflows/ExtraTests.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install tools
       run: make toolsci
@@ -128,7 +128,7 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install tools
       run: make toolsci
@@ -232,7 +232,7 @@ jobs:
           - x64
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -95,7 +95,7 @@ jobs:
         zip -j libduckdb-linux-${{ matrix.config.arch }}.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-${{ matrix.config.arch }}.zip duckdb_cli-linux-${{ matrix.config.arch }}.zip duckdb_cli-linux-${{ matrix.config.arch }}.gz
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: duckdb-binaries-linux-${{ matrix.config.arch }}
         path: |
@@ -181,7 +181,7 @@ jobs:
         zip -j libduckdb-linux-${{ matrix.config.arch }}-musl.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-${{ matrix.config.arch }}-musl.zip duckdb_cli-linux-${{ matrix.config.arch }}-musl.zip duckdb_cli-linux-${{ matrix.config.arch }}-musl.gz
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: duckdb-binaries-linux-${{ matrix.config.arch }}-musl
         path: |
@@ -242,7 +242,7 @@ jobs:
         version: ${{ matrix.version }}
         arch: ${{ matrix.arch }}
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         name: duckdb-binaries-linux-amd64
         path: linux-release-artifacts

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -150,7 +150,7 @@ jobs:
       run: make relassert-artifact
 
     - name: Upload relassert build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: linux-debug-relassert-build
         path: build/relassert-artifact.tar.gz
@@ -169,7 +169,7 @@ jobs:
       run: make toolsci
 
     - name: Download relassert build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: linux-debug-relassert-build
         path: build
@@ -243,7 +243,7 @@ jobs:
         mv build/release-artifact.tar.gz build/linux-default-release.tar.gz
 
     - name: Upload linux default release artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: linux-default-release-build
         path: build/linux-default-release.tar.gz
@@ -262,7 +262,7 @@ jobs:
       run: make toolsci
 
     - name: Download release build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: linux-release-build
         path: build
@@ -286,12 +286,12 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
     - name: Download linux default release artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: linux-default-release-build
         path: build
@@ -465,7 +465,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -487,7 +487,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -496,7 +496,7 @@ jobs:
       run: make toolsci
 
     - name: Download linux release artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: linux-release-build
         path: build

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -63,7 +63,7 @@ jobs:
       CXX: g++-10
       GEN: ninja
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Preliminary checks on CI
         run: echo "Event name is ${{ github.event_name }}"
@@ -127,7 +127,7 @@ jobs:
       EXTENSIONS_STATIC_BUILD: 0
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - id: describe_step
       run: echo "git_describe=$(git describe --tags --long)" >> "$GITHUB_OUTPUT"
@@ -164,7 +164,7 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install tools
       run: make toolsci
 
@@ -223,7 +223,7 @@ jobs:
       GEN: ninja
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install tools
       run: make toolsci
@@ -257,7 +257,7 @@ jobs:
     runs-on: ${{ needs.prepare.outputs.runner_linux_x64 }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install tools
       run: make toolsci
 
@@ -284,7 +284,7 @@ jobs:
       - linux-release
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: actions/setup-python@v5
       with:
@@ -350,7 +350,7 @@ jobs:
       DUCKDB_TEST_DESCRIPTION: 'Compiled with ALTERNATIVE_VERIFY=1 DISABLE_STRING_INLINE=1 DESTROY_UNPINNED_BLOCKS=1 DISABLE_POINTER_SALT=1. Use require no_alternative_verify to skip.'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install
         run: make toolsci
@@ -376,7 +376,7 @@ jobs:
       DUCKDB_TEST_DESCRIPTION: 'Compiled with STANDARD_VECTOR_SIZE=2. Use require vector_size 2048 to skip tests.'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install
         run: make toolsci
@@ -403,7 +403,7 @@ jobs:
       GEN: ninja
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install
       shell: bash
@@ -439,7 +439,7 @@ jobs:
       DUCKDB_TEST_DESCRIPTION: 'Tests run with thread sanitizer.'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install
       run: make toolsci
@@ -463,7 +463,7 @@ jobs:
       CXX: clang++
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: actions/setup-python@v5
       with:
@@ -485,7 +485,7 @@ jobs:
       - linux-release
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -58,6 +58,7 @@ jobs:
       runner_linux_22_x64: ${{ steps.select_runner.outputs.runner_linux_22_x64 }}
       runner_linux_arm64: ${{ steps.select_runner.outputs.runner_linux_arm64 }}
       runner_macos_arm64: ${{ steps.select_runner.outputs.runner_macos_arm64 }}
+      runner_macos_14_arm64: ${{ steps.select_runner.outputs.runner_macos_14_arm64 }}
     env:
       CC: gcc-10
       CXX: g++-10
@@ -79,6 +80,7 @@ jobs:
               echo "runner_linux_22_x64=namespace-profile-linux-22-x64"
               echo "runner_linux_arm64=namespace-profile-linux-arm64"
               echo "runner_macos_arm64=namespace-profile-macos-arm64"
+              echo "runner_macos_14_arm64=namespace-profile-macos-14-arm64"
             } >> "$GITHUB_OUTPUT"
           else
             {
@@ -87,6 +89,7 @@ jobs:
               echo "runner_linux_22_x64=ubuntu-22.04"
               echo "runner_linux_arm64=ubuntu-24.04-arm"
               echo "runner_macos_arm64=macos-14"
+              echo "runner_macos_14_arm64=macos-14"
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -322,7 +325,7 @@ jobs:
       - prepare
       - linux-debug
     with:
-      runner_macos_arm64: ${{ needs.prepare.outputs.runner_macos_arm64 }}
+      runner_macos_arm64: ${{ needs.prepare.outputs.runner_macos_14_arm64 }}
 
  windows:
     uses: ./.github/workflows/Windows.yml

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -318,7 +318,11 @@ jobs:
  swift:
     uses: ./.github/workflows/Swift.yml
     secrets: inherit
-    needs: linux-debug
+    needs:
+      - prepare
+      - linux-debug
+    with:
+      runner_macos_arm64: ${{ needs.prepare.outputs.runner_macos_arm64 }}
 
  windows:
     uses: ./.github/workflows/Windows.yml

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -45,7 +45,7 @@ jobs:
        GEN: ninja
 
      steps:
-     - uses: actions/checkout@v4
+     - uses: actions/checkout@v6
        with:
          fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
       RUN_SLOW_VERIFIERS: 1
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -128,7 +128,7 @@ jobs:
       RUN_SLOW_VERIFIERS: 1
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -163,7 +163,7 @@ jobs:
       BUILD_JEMALLOC: 1
       CORE_EXTENSIONS: "icu;tpch;tpcds;json"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -207,7 +207,7 @@ jobs:
       RUN_SLOW_VERIFIERS: 1
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -246,7 +246,7 @@ jobs:
      needs: linux-memory-leaks
 
      steps:
-     - uses: actions/checkout@v4
+     - uses: actions/checkout@v6
        with:
          fetch-depth: 0
 
@@ -279,7 +279,7 @@ jobs:
        GEN: ninja
 
      steps:
-     - uses: actions/checkout@v4
+     - uses: actions/checkout@v6
        with:
          fetch-depth: 0
 
@@ -313,12 +313,12 @@ jobs:
       GEN: ninja
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Checkout duckdb-httpfs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: duckdb/duckdb-httpfs
           submodules: 'true'
@@ -376,14 +376,14 @@ jobs:
 
    steps:
      - name: Checkout
-       uses: actions/checkout@v4
+       uses: actions/checkout@v6
        with:
          fetch-depth: 0
 
      - uses: ./.github/actions/cleanup_runner
 
      - name: Checkout tools repo
-       uses: actions/checkout@v4
+       uses: actions/checkout@v6
        with:
          fetch-depth: 0
          path: unsafe
@@ -454,7 +454,7 @@ jobs:
     needs: linux-memory-leaks
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -494,7 +494,7 @@ jobs:
     needs: linux-memory-leaks
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -533,7 +533,7 @@ jobs:
       FORCE_ASYNC_SINK_SOURCE: 1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -582,7 +582,7 @@ jobs:
         git submodule update
         git rm -r submodules/duckdb
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         path: duckdb-wasm/submodules/duckdb
@@ -650,7 +650,7 @@ jobs:
      DUCKDB_TEST_DESCRIPTION: 'Compiled with HASH_ZERO=1. Use require no_hash_zero to skip.'
 
    steps:
-     - uses: actions/checkout@v4
+     - uses: actions/checkout@v6
        with:
          fetch-depth: 0
 
@@ -677,7 +677,7 @@ jobs:
     name: Build DuckDB
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -723,7 +723,7 @@ jobs:
           - v1.4.3
           - v1.4.4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -49,7 +49,7 @@ jobs:
        with:
          fetch-depth: 0
 
-     - uses: actions/setup-python@v5
+     - uses: actions/setup-python@v6
        with:
          python-version: '3.12'
 
@@ -132,7 +132,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -328,7 +328,7 @@ jobs:
         shell: bash
         run: make toolsci
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -388,7 +388,7 @@ jobs:
          fetch-depth: 0
          path: unsafe
 
-     - uses: actions/setup-python@v5
+     - uses: actions/setup-python@v6
        with:
          python-version: '3.12'
 
@@ -631,7 +631,7 @@ jobs:
       run: |
         zip -r duckdb-wasm32.zip duckdb-wasm/packages/duckdb-wasm/src/bindings
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: duckdb-wasm32
         path: |
@@ -694,7 +694,7 @@ jobs:
             DUCKDB_EXTENSIONS='tpcds;icu;autocomplete;tpch;json'
 
       - name: Upload DuckDB binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: duckdb-binary
           path: build/release/duckdb
@@ -727,12 +727,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Download DuckDB binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: duckdb-binary
           path: build/release
@@ -773,14 +773,14 @@ jobs:
 
       - name: Upload BWC cache
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bwc-cache-${{ matrix.old_duckdb_version }}
           path: duckdb_unittest_tempdir/bwc/cache/runtime_${{ matrix.old_duckdb_version }}.tar.gz
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bwc-test-results-${{ matrix.old_duckdb_version }}
           path: |
@@ -794,7 +794,7 @@ jobs:
     if: always()
     steps:
       - name: Download all test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: bwc-test-results-*
           merge-multiple: true

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -59,7 +59,7 @@ jobs:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -115,7 +115,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -188,7 +188,7 @@ jobs:
 
           ./scripts/upload-assets-to-staging.sh github_release libduckdb-osx-universal.zip duckdb_cli-osx-universal.zip duckdb_cli-osx-universal.gz duckdb_cli-osx-arm64.zip duckdb_cli-osx-arm64.gz duckdb_cli-osx-amd64.zip duckdb_cli-osx-amd64.gz
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: duckdb-binaries-osx
           path: |

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -54,7 +54,7 @@ jobs:
       FORCE_ASSERT: 1
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
@@ -110,7 +110,7 @@ jobs:
       GEN: ninja
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -49,7 +49,7 @@ jobs:
       GEN: ninja
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -99,14 +99,14 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install
         run: make toolsci && pip install requests
 
       - name: Checkout Private Regression
         if: ${{ github.repository == 'duckdb/duckdb' && github.ref_name == 'main' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: duckdblabs/fivetran_regression
           ref: main
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install
         run: make toolsci && pip install requests
@@ -267,7 +267,7 @@ jobs:
       EXTENSION_STATIC_BUILD: 1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install
         run: make toolsci && pip install requests
@@ -305,7 +305,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install
         run: make toolsci && pip install tqdm

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -114,7 +114,7 @@ jobs:
           path: benchmark/fivetran
 
       - name: Download current release artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: linux-release-build
           path: build/current
@@ -125,7 +125,7 @@ jobs:
           tar -xzf build/current/release-artifact.tar.gz -C build/current
 
       - name: Download base artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: linux-base-build
           path: build/base
@@ -200,7 +200,7 @@ jobs:
         run: make toolsci && pip install requests
 
       - name: Download current release artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: linux-release-build
           path: build/current
@@ -211,7 +211,7 @@ jobs:
           tar -xzf build/current/release-artifact.tar.gz -C build/current
 
       - name: Download base artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: linux-base-build
           path: build/base
@@ -273,7 +273,7 @@ jobs:
         run: make toolsci && pip install requests
 
       - name: Download current release artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: linux-release-build
           path: build/current
@@ -284,7 +284,7 @@ jobs:
           tar -xzf build/current/release-artifact.tar.gz -C build/current
 
       - name: Download base artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: linux-base-build
           path: build/base
@@ -311,7 +311,7 @@ jobs:
         run: make toolsci && pip install tqdm
 
       - name: Download current release artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: linux-release-build
           path: build/current
@@ -322,7 +322,7 @@ jobs:
           tar -xzf build/current/release-artifact.tar.gz -C build/current
 
       - name: Download base artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: linux-base-build
           path: build/base

--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -18,7 +18,7 @@ jobs:
        with:
          fetch-depth: 0
 
-     - uses: actions/setup-python@v4
+     - uses: actions/setup-python@v6
        with:
          python-version: '3.12'
 

--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -14,7 +14,7 @@ jobs:
    runs-on: ubuntu-latest
    if: ${{ inputs.target_git_describe != '' }}
    steps:
-     - uses: actions/checkout@v4
+     - uses: actions/checkout@v6
        with:
          fetch-depth: 0
 

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -38,6 +38,15 @@ jobs:
           # we need tags for the ubiquity build script to run without errors
           fetch-depth: '0'
 
+      - name: Configure Xcode Caching
+        if: ${{ startsWith(inputs.runner_macos_arm64 || 'macos-14', 'namespace-profile-') }}
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: |
+            xcode
+            swiftpm
+            cocoapods
+
       - name: Prepare Package
         run: python3 tools/swift/create_package.py tools/swift
 

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -1,6 +1,9 @@
 name: Swift
 on:
   workflow_call:
+    inputs:
+      runner_macos_arm64:
+        type: string
   workflow_dispatch:
   repository_dispatch:
 
@@ -26,7 +29,7 @@ jobs:
             destination: 'iOS Simulator,name=iPhone 16'
           - isRelease: false
             destination: 'tvOS Simulator,name=Apple TV 4K (at 1080p) (3nd generation)'
-    runs-on: macos-14
+    runs-on: ${{ inputs.runner_macos_arm64 || 'macos-14' }}
     steps:
 
       - name: Checkout

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # we need tags for the ubiquity build script to run without errors
           fetch-depth: '0'

--- a/.github/workflows/SwiftRelease.yml
+++ b/.github/workflows/SwiftRelease.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # we need tags for the ubiquity build script to run without errors
           fetch-depth: '0'
@@ -27,7 +27,7 @@ jobs:
           path: 'source-repo'
 
       - name: Checkout Target Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.TARGET_REPO }}
           ref: ${{ env.TARGET_REF }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -43,7 +43,7 @@ jobs:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -117,7 +117,7 @@ jobs:
         /c/msys64/usr/bin/zip.exe -j libduckdb-windows-amd64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: duckdb-binaries-windows-amd64
         path: |
@@ -142,7 +142,7 @@ jobs:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -178,7 +178,7 @@ jobs:
          fetch-depth: 0
          ref: ${{ inputs.git_ref }}
 
-     - uses: actions/setup-python@v5
+     - uses: actions/setup-python@v6
        with:
          python-version: '3.12'
 
@@ -220,7 +220,7 @@ jobs:
          /c/msys64/usr/bin/zip.exe -j libduckdb-windows-arm64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
          ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-arm64.zip duckdb_cli-windows-arm64.zip
 
-     - uses: actions/upload-artifact@v4
+     - uses: actions/upload-artifact@v7
        with:
          name: duckdb-binaries-windows-arm64
          path: |
@@ -238,7 +238,7 @@ jobs:
          with:
            ref: ${{ inputs.git_ref }}
 
-       - uses: actions/setup-python@v5
+       - uses: actions/setup-python@v6
          with:
            python-version: '3.12'
 
@@ -278,15 +278,15 @@ jobs:
      - win-release-64
      - win-release-arm64
    steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         name: duckdb-binaries-windows-arm64
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         name: duckdb-binaries-windows-amd64
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: duckdb-binaries-windows
         path: |

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -38,7 +38,7 @@ jobs:
     name: Windows (64 Bit)
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
@@ -137,7 +137,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
@@ -173,7 +173,7 @@ jobs:
    runs-on: windows-latest
 
    steps:
-     - uses: actions/checkout@v4
+     - uses: actions/checkout@v6
        with:
          fetch-depth: 0
          ref: ${{ inputs.git_ref }}
@@ -234,7 +234,7 @@ jobs:
      if: ${{ inputs.skip_tests != 'true' }}
      runs-on: windows-latest
      steps:
-       - uses: actions/checkout@v4
+       - uses: actions/checkout@v6
          with:
            ref: ${{ inputs.git_ref }}
 

--- a/.github/workflows/_extension_client_tests.yml
+++ b/.github/workflows/_extension_client_tests.yml
@@ -30,7 +30,7 @@ jobs:
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/_extension_client_tests.yml
+++ b/.github/workflows/_extension_client_tests.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           make toolsci
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: 'true'

--- a/.github/workflows/_manual_extension_deploy.yml
+++ b/.github/workflows/_manual_extension_deploy.yml
@@ -51,7 +51,7 @@ jobs:
       BASE_EXCLUDE_ARCHS: ''
       EXTRA_EXCLUDE_ARCHS: ${{ inputs.extra_exclude_archs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -109,7 +109,7 @@ jobs:
       - build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -148,7 +148,7 @@ jobs:
       - create-extension-repository
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/_manual_extension_deploy.yml
+++ b/.github/workflows/_manual_extension_deploy.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         name: Download extensions
         with:
           pattern: extensions-${{ inputs.duckdb_ref }}*
@@ -134,7 +134,7 @@ jobs:
           find /tmp/merged_repository -type f ! -name "${{ inputs.extension_name }}.duckdb_extension*" -delete
           tree /tmp/merged_repository
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error
           name: extension-repository-${{ inputs.duckdb_ref }}
@@ -152,7 +152,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           pattern: extension-repository-${{ inputs.duckdb_ref }}
           path: /tmp

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -44,7 +44,7 @@ jobs:
         dry-run: false
         sanitizer: ${{ matrix.sanitizer }}
     - name: Upload Crash
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts-${{ matrix.sanitizer }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       COVERITY_PROJECT_NAME: DuckDB
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Download and extract the Coverity Build Tool
       run: |
           wget https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=${{ env.COVERITY_PROJECT_NAME  }}" -O cov-analysis-linux64.tar.gz

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: make toolsci && sudo apt install -y git g++ cmake libssl-dev default-jdk
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 


### PR DESCRIPTION
### Before (6 min)

<img width="730" height="380" alt="Screenshot 2026-03-13 at 09 51 21" src="https://github.com/user-attachments/assets/d6421624-d573-4f6d-b6ff-09b219d38f1a" />

### After (2 min)

<img width="720" height="466" alt="Screenshot 2026-03-13 at 10 48 39" src="https://github.com/user-attachments/assets/b6ded928-7665-4f5b-a55e-240e054544e0" />

### Resolved many NodeJS warnings

There are many NodeJS [warnings](https://github.com/duckdb/duckdb/actions/runs/23038683477) (see `Annotations`) like:

> **extensions / Main Extensions / linux_amd64**
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache/restore@v4, actions/checkout@v4, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. 
> Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` environment variable on the runner or in your workflow file.
> Once Node.js 24 becomes the default, you can temporarily opt out by setting `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true`. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I upgraded most actions to their latest version to avoid any surprises in the near future, when that nodejs upgrade is enforced.