### PR TITLE
Fix infinite recursion in FileOpener::TryGetCurrentSetting

### DIFF
--- a/src/include/duckdb/main/database_file_opener.hpp
+++ b/src/include/duckdb/main/database_file_opener.hpp
@@ -31,6 +31,10 @@ public:
 		return db.TryGetCurrentSetting(key, result);
 	}
 
+	SettingLookupResult TryGetCurrentSetting(const string &key, Value &result, FileOpenerInfo &) override {
+		return db.TryGetCurrentSetting(key, result);
+	}
+
 	optional_ptr<ClientContext> TryGetClientContext() override {
 		return nullptr;
 	}

--- a/src/main/client_context_file_opener.cpp
+++ b/src/main/client_context_file_opener.cpp
@@ -90,7 +90,7 @@ SettingLookupResult FileOpener::TryGetCurrentSetting(optional_ptr<FileOpener> op
 }
 
 SettingLookupResult FileOpener::TryGetCurrentSetting(const string &key, Value &result, FileOpenerInfo &info) {
-	return this->TryGetCurrentSetting(key, result, info);
+	return TryGetCurrentSetting(key, result);
 }
 // LCOV_EXCL_STOP
 } // namespace duckdb

--- a/test/configs/verify_fetch_row.json
+++ b/test/configs/verify_fetch_row.json
@@ -53,18 +53,6 @@
         "test/sql/attach/show_databases.test",
         "test/sql/attach/show_schemas.test"
       ]
-    },
-    {
-      "reason": "Requires latest storage version.",
-      "paths": [
-        "test/geoparquet/mixed.test",
-        "test/parquet/variant/variant_comparison.test",
-        "test/parquet/variant/variant_json_copy.test",
-        "test/sql/storage/types/variant/index_fetch.test",
-        "test/sql/storage/types/variant/update.test",
-        "test/sql/types/geo/geometry_crs.test",
-        "test/sql/types/geo/geometry_stats.test"
-      ]
     }
   ]
 }

--- a/test/configs/verify_fetch_row.json
+++ b/test/configs/verify_fetch_row.json
@@ -53,6 +53,18 @@
         "test/sql/attach/show_databases.test",
         "test/sql/attach/show_schemas.test"
       ]
+    },
+    {
+      "reason": "Requires latest storage version.",
+      "paths": [
+        "test/geoparquet/mixed.test",
+        "test/parquet/variant/variant_comparison.test",
+        "test/parquet/variant/variant_json_copy.test",
+        "test/sql/storage/types/variant/index_fetch.test",
+        "test/sql/storage/types/variant/update.test",
+        "test/sql/types/geo/geometry_crs.test",
+        "test/sql/types/geo/geometry_stats.test"
+      ]
     }
   ]
 }


### PR DESCRIPTION
`FileOpener::TryGetCurrentSetting` would immediately call itself, causing infinite recursion. This seems to have been introduced in https://github.com/duckdb/duckdb/pull/21301.