### PR TITLE
When writing unsupported Parquet variant types to Parquet, try to convert them to INT64

### DIFF
--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -6,6 +6,7 @@
 #include "parquet_shredding.hpp"
 #include "duckdb/function/variant/variant_shredding.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
 
 namespace duckdb {
 
@@ -344,6 +345,21 @@ static idx_t AnalyzeValueData(const UnifiedVariantVectorData &variant, idx_t row
 	case VariantLogicalType::TIMESTAMP_MICROS_TZ:
 		total_size += sizeof(uint64_t);
 		break;
+	case VariantLogicalType::UINT8:
+		// store as int16_t
+		total_size += sizeof(int16_t);
+		break;
+	case VariantLogicalType::UINT16:
+		// store as int32_t
+		total_size += sizeof(int32_t);
+		break;
+	case VariantLogicalType::UINT32:
+	case VariantLogicalType::UINT64:
+	case VariantLogicalType::UINT128:
+	case VariantLogicalType::INT128:
+		// try to store as int64_t - fail if it doesn't fit
+		total_size += sizeof(int64_t);
+		break;
 	case VariantLogicalType::INTERVAL:
 	case VariantLogicalType::BIGNUM:
 	case VariantLogicalType::BITSTRING:
@@ -351,12 +367,6 @@ static idx_t AnalyzeValueData(const UnifiedVariantVectorData &variant, idx_t row
 	case VariantLogicalType::TIMESTAMP_SEC:
 	case VariantLogicalType::TIME_MICROS_TZ:
 	case VariantLogicalType::TIME_NANOS:
-	case VariantLogicalType::UINT8:
-	case VariantLogicalType::UINT16:
-	case VariantLogicalType::UINT32:
-	case VariantLogicalType::UINT64:
-	case VariantLogicalType::UINT128:
-	case VariantLogicalType::INT128:
 	default:
 		throw InvalidInputException("Can't convert VARIANT of type '%s' to Parquet VARIANT",
 		                            EnumUtil::ToString(type_id));
@@ -375,13 +385,38 @@ void WritePrimitiveTypeHeader(data_ptr_t &value_data) {
 	value_data++;
 }
 
-template <class T>
+struct VariantSimpleCopy {
+	template <class T>
+	static void CopyValue(const_data_ptr_t source, data_ptr_t target) {
+		memcpy(target, source, sizeof(T));
+	}
+};
+
+template <class SRC>
+struct VariantSimpleConversion {
+	template <class T>
+	static void CopyValue(const_data_ptr_t source, data_ptr_t target) {
+		auto src = Load<SRC>(source);
+		Store(static_cast<T>(src), target);
+	}
+};
+
+template <class SRC>
+struct VariantTryConvert {
+	template <class T>
+	static void CopyValue(const_data_ptr_t source, data_ptr_t target) {
+		auto src = Load<SRC>(source);
+		Store(Cast::Operation<SRC, T>(src), target);
+	}
+};
+
+template <class T, class OP = VariantSimpleCopy>
 void CopySimplePrimitiveData(const UnifiedVariantVectorData &variant, data_ptr_t &value_data, idx_t row,
                              uint32_t values_index) {
 	auto byte_offset = variant.GetByteOffset(row, values_index);
 	auto data = const_data_ptr_cast(variant.GetData(row).GetData());
 	auto ptr = data + byte_offset;
-	memcpy(value_data, ptr, sizeof(T));
+	OP::template CopyValue<T>(ptr, value_data);
 	value_data += sizeof(T);
 }
 
@@ -516,6 +551,30 @@ static void WritePrimitiveValueData(const UnifiedVariantVectorData &variant, idx
 		}
 		break;
 	}
+	case VariantLogicalType::UINT8:
+		WritePrimitiveTypeHeader<VariantPrimitiveType::INT16>(value_data);
+		CopySimplePrimitiveData<int16_t, VariantSimpleConversion<uint8_t>>(variant, value_data, row, values_index);
+		break;
+	case VariantLogicalType::UINT16:
+		WritePrimitiveTypeHeader<VariantPrimitiveType::INT32>(value_data);
+		CopySimplePrimitiveData<int32_t, VariantSimpleConversion<uint16_t>>(variant, value_data, row, values_index);
+		break;
+	case VariantLogicalType::UINT32:
+		WritePrimitiveTypeHeader<VariantPrimitiveType::INT64>(value_data);
+		CopySimplePrimitiveData<int64_t, VariantSimpleConversion<uint32_t>>(variant, value_data, row, values_index);
+		break;
+	case VariantLogicalType::UINT64:
+		WritePrimitiveTypeHeader<VariantPrimitiveType::INT64>(value_data);
+		CopySimplePrimitiveData<int64_t, VariantTryConvert<uint64_t>>(variant, value_data, row, values_index);
+		break;
+	case VariantLogicalType::UINT128:
+		WritePrimitiveTypeHeader<VariantPrimitiveType::INT64>(value_data);
+		CopySimplePrimitiveData<int64_t, VariantTryConvert<uhugeint_t>>(variant, value_data, row, values_index);
+		break;
+	case VariantLogicalType::INT128:
+		WritePrimitiveTypeHeader<VariantPrimitiveType::INT64>(value_data);
+		CopySimplePrimitiveData<int64_t, VariantTryConvert<hugeint_t>>(variant, value_data, row, values_index);
+		break;
 	case VariantLogicalType::INTERVAL:
 	case VariantLogicalType::BIGNUM:
 	case VariantLogicalType::BITSTRING:
@@ -523,12 +582,6 @@ static void WritePrimitiveValueData(const UnifiedVariantVectorData &variant, idx
 	case VariantLogicalType::TIMESTAMP_SEC:
 	case VariantLogicalType::TIME_MICROS_TZ:
 	case VariantLogicalType::TIME_NANOS:
-	case VariantLogicalType::UINT8:
-	case VariantLogicalType::UINT16:
-	case VariantLogicalType::UINT32:
-	case VariantLogicalType::UINT64:
-	case VariantLogicalType::UINT128:
-	case VariantLogicalType::INT128:
 	default:
 		throw InvalidInputException("Can't convert VARIANT of type '%s' to Parquet VARIANT",
 		                            EnumUtil::ToString(type_id));

--- a/test/configs/force_storage.json
+++ b/test/configs/force_storage.json
@@ -38,6 +38,19 @@
         "test/sql/index/art/vacuum/test_art_vacuum_strings.test_slow",
         "test/sql/index/art/vacuum/test_art_vacuum_integers.test_slow"
       ]
+    },
+    {
+      "reason": "Requires latest storage version.",
+      "paths": [
+        "test/geoparquet/mixed.test",
+        "test/parquet/variant/variant_comparison.test",
+        "test/parquet/variant/variant_json_copy.test",
+        "test/sql/storage/types/variant/index_fetch.test",
+        "test/sql/storage/types/variant/update.test",
+        "test/sql/types/geo/geometry_crs.test",
+        "test/sql/types/geo/geometry_stats.test"
+      ]
     }
+
   ]
 }

--- a/test/configs/verify_fetch_row.json
+++ b/test/configs/verify_fetch_row.json
@@ -53,6 +53,18 @@
         "test/sql/attach/show_databases.test",
         "test/sql/attach/show_schemas.test"
       ]
+    },
+    {
+      "reason": "Requires latest storage version.",
+      "paths": [
+        "test/geoparquet/mixed.test",
+        "test/parquet/variant/variant_comparison.test",
+        "test/parquet/variant/variant_json_copy.test",
+        "test/sql/storage/types/variant/index_fetch.test",
+        "test/sql/storage/types/variant/update.test",
+        "test/sql/types/geo/geometry_crs.test",
+        "test/sql/types/geo/geometry_stats.test"
+      ]
     }
   ]
 }

--- a/test/geoparquet/mixed.test
+++ b/test/geoparquet/mixed.test
@@ -1,9 +1,6 @@
 # name: test/geoparquet/mixed.test
 # group: [geoparquet]
 
-# TODO: "Force storage" will use default storage version, but geometry requires v1.5.0, so skip for now
-require no_force_storage
-
 require parquet
 
 #------------------------------------------------------------------------------

--- a/test/parquet/variant/variant_comparison.test
+++ b/test/parquet/variant/variant_comparison.test
@@ -1,9 +1,6 @@
 # name: test/parquet/variant/variant_comparison.test
 # group: [variant]
 
-# TODO: "Force storage" will use default storage version, but variant requires v1.5.0, so skip for now
-require no_force_storage
-
 require parquet
 
 statement ok

--- a/test/parquet/variant/variant_invalid_type.test
+++ b/test/parquet/variant/variant_invalid_type.test
@@ -3,7 +3,32 @@
 
 require parquet
 
-statement error
-COPY (SELECT 1::hugeint::variant) TO '__TEST_DIR__/invalid_parquet_variant.parquet';
+# these types are not supported by the Parquet variant spec - we need to convert them
+foreach unsupported_type ubigint uhugeint hugeint utinyint usmallint uinteger
+
+statement ok
+COPY (SELECT 1::${unsupported_type}::variant v) TO '__TEST_DIR__/invalid_parquet_variant.parquet';
+
+query II
+SELECT v,
+	variant_typeof(v) =
+	CASE
+		WHEN '${unsupported_type}' = 'utinyint' THEN 'INT16'
+		WHEN '${unsupported_type}' = 'usmallint' THEN 'INT32'
+		ELSE 'INT64'
+	END
+FROM '__TEST_DIR__/invalid_parquet_variant.parquet'
 ----
-Can't convert
+1	true
+
+endloop
+
+# these values are converted to INT64 - if the values are too big this conversion fails
+foreach unsupported_type ubigint uhugeint hugeint
+
+statement error
+copy (select '18446744073709551615'::${unsupported_type}::VARIANT) to '__TEST_DIR__/out_of_range_variant.parquet';
+----
+value is out of range
+
+endloop

--- a/test/parquet/variant/variant_json_copy.test
+++ b/test/parquet/variant/variant_json_copy.test
@@ -5,9 +5,6 @@ require parquet
 
 require json
 
-# TODO: Requires minimum storage version v1.5.0, which is not the default
-require no_force_storage
-
 statement ok
 CREATE TABLE json_data AS SELECT
 	i AS id,
@@ -18,11 +15,17 @@ CREATE TABLE json_data AS SELECT
 FROM
 	generate_series(0, 4) t(i);
 
-# UINT64 is not something that Parquet's VARIANT can handle, so it fails
-statement error
+statement ok
 COPY json_data TO '__TEST_DIR__/json_variant.parquet' (FORMAT PARQUET);
+
+query II
+FROM '__TEST_DIR__/json_variant.parquet'
 ----
-Invalid Input Error: Can't convert VARIANT of type 'UINT64' to Parquet VARIANT
+0	{'a': 0, 'b': hello}
+1	{'a': 1, 'b': hello}
+2	{'a': 2, 'b': hello}
+3	{'a': 3, 'b': hello}
+4	{'a': 4, 'b': hello}
 
 # FIXME: 'to_json' will convert to unsigned types if values are positive
 # Parquet's VARIANT doesn't handle unsigned types.

--- a/test/sql/copy/csv/test_glob_type.test
+++ b/test/sql/copy/csv/test_glob_type.test
@@ -5,6 +5,9 @@
 statement ok
 PRAGMA enable_verification
 
+statement ok
+SET threads=1
+
 query I
 SELECT typeof(bar) FROM '{DATA_DIR}/csv/17451/*.csv' limit 1
 ----

--- a/test/sql/storage/types/variant/index_fetch.test
+++ b/test/sql/storage/types/variant/index_fetch.test
@@ -1,9 +1,6 @@
 # name: test/sql/storage/types/variant/index_fetch.test
 # group: [variant]
 
-# TODO: "Force storage" will use default storage version, but variant requires v1.5.0, so skip for now
-require no_force_storage
-
 statement ok
 CREATE TABLE tbl(i INT PRIMARY KEY, v VARIANT);
 

--- a/test/sql/storage/types/variant/update.test
+++ b/test/sql/storage/types/variant/update.test
@@ -1,9 +1,6 @@
 # name: test/sql/storage/types/variant/update.test
 # group: [variant]
 
-# TODO: "Force storage" will use default storage version, but variant requires v1.5.0, so skip for now
-require no_force_storage
-
 statement ok
 create table tbl (a VARIANT)
 

--- a/test/sql/types/geo/geometry_crs.test
+++ b/test/sql/types/geo/geometry_crs.test
@@ -1,9 +1,6 @@
 # name: test/sql/types/geo/geometry_crs.test
 # group: [geo]
 
-# TODO: Requires minimum storage version v1.5.0, which is not the default
-require no_force_storage
-
 query I
 select st_crs(NULL);
 ----

--- a/test/sql/types/geo/geometry_stats.test
+++ b/test/sql/types/geo/geometry_stats.test
@@ -4,9 +4,6 @@
 # Stats are not preserved when serialized in the stats() function, so this doesnt work
 require no_alternative_verify
 
-# TODO: Requires minimum storage version v1.5.0 for geometry stats, which is not the default
-require no_force_storage
-
 statement ok
 create table t1(id INT, g GEOMETRY);
 

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -451,7 +451,7 @@ RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vec
 		return RequireResult::PRESENT;
 	}
 
-	if (param == "noforcestorage") {
+	if (param == "noforcestorage" || param == "no_force_storage") {
 		if (TestConfiguration::TestForceStorage()) {
 			return RequireResult::MISSING;
 		}


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/21311

The Parquet variant is much more limited in which types it supports. It also does not support all types that Parquet itself supports (for unknown reasons). When converting from our variant to Parquet's variant we would previously throw an error if types were not supported. This PR adds conversion logic for several unsupported numeric types:

```
UINT8    -> int16
UINT16   -> int32
UINT32   -> int64
UINT64   -> int64 (error if it does not fit)
UINT128  -> int64 (error if it does not fit)
INT128   -> int64 (error if it does not fit)
```

We should probably expand this to all types going forward. 
