### PR TITLE
Use cached Parquet metadata to improve cardinality estimates over Parquet files

### DIFF
--- a/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/extension/parquet/include/parquet_multi_file_info.hpp
@@ -52,7 +52,8 @@ struct ParquetMultiFileInfo : MultiFileReaderInterface {
 	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                        BaseFileReaderOptions &options,
 	                                        const MultiFileOptions &file_options) override;
-	unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) override;
+	unique_ptr<NodeStatistics> GetCardinality(ClientContext &context, const MultiFileBindData &bind_data,
+	                                          idx_t file_count) override;
 	void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result) override;
 	unique_ptr<MultiFileReaderInterface> Copy() override;
 	FileGlobInput GetGlobInput() override;

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -8,6 +8,15 @@
 
 namespace duckdb {
 
+struct ParquetMetadataCacheEntry {
+	ParquetMetadataCacheEntry(shared_ptr<ParquetFileMetadataCache> metadata, ParquetCacheValidity validity,
+	                          bool has_deletes);
+
+	shared_ptr<ParquetFileMetadataCache> metadata;
+	ParquetCacheValidity validity;
+	bool has_deletes;
+};
+
 struct ParquetReadBindData : public TableFunctionData {
 	// These come from the initial_reader, but need to be stored in case the initial_reader is removed by a filter
 	idx_t initial_file_cardinality;
@@ -30,6 +39,12 @@ struct ParquetReadBindData : public TableFunctionData {
 		result->options = make_uniq<ParquetFileReaderOptions>(options->options);
 		return std::move(result);
 	}
+
+	const vector<ParquetMetadataCacheEntry> &TryLoadCaches(const MultiFileBindData &bind_data, ClientContext &context);
+
+private:
+	vector<ParquetMetadataCacheEntry> caches;
+	bool attempted_to_load_caches = false;
 };
 
 struct ParquetReadGlobalState : public GlobalTableFunctionState {
@@ -263,6 +278,54 @@ static vector<column_t> ParquetGetRowIdColumns(ClientContext &context, optional_
 	return result;
 }
 
+ParquetMetadataCacheEntry::ParquetMetadataCacheEntry(shared_ptr<ParquetFileMetadataCache> metadata_p,
+                                                     ParquetCacheValidity validity_p, bool has_deletes_p)
+    : metadata(std::move(metadata_p)), validity(validity_p), has_deletes(has_deletes_p) {
+}
+
+const vector<ParquetMetadataCacheEntry> &ParquetReadBindData::TryLoadCaches(const MultiFileBindData &bind_data,
+                                                                            ClientContext &context) {
+	if (attempted_to_load_caches) {
+		return caches;
+	}
+	// only attempt to load the caches once
+	attempted_to_load_caches = true;
+	// if we are reading multiple files - we check if we have caching enabled
+	if (!ParquetReader::MetadataCacheEnabled(context)) {
+		// no caching - bail
+		return caches;
+	}
+	// caching is enabled - check if we have ALL of the metadata cached
+	vector<ParquetMetadataCacheEntry> result;
+	for (auto &file : bind_data.file_list->Files()) {
+		auto metadata_entry = ParquetReader::GetMetadataCacheEntry(context, file);
+		if (!metadata_entry) {
+			// no cache entry found for this file
+			attempted_to_load_caches = true;
+			return caches;
+		}
+		// check if the file has any deletes
+		bool has_deletes = false;
+		if (file.extended_info) {
+			auto entry = file.extended_info->options.find("has_deletes");
+			if (entry != file.extended_info->options.end()) {
+				if (BooleanValue::Get(entry->second)) {
+					// the file has deletes - skip emitting partition stats
+					// FIXME: we could emit partition stats but set count to `COUNT_APPROXIMATE` instead of
+					// `COUNT_EXACT`
+					has_deletes = true;
+				}
+			}
+		}
+
+		// check if the cache is valid based ONLY on the OpenFileInfo (do not do any file system requests here)
+		const auto is_valid = metadata_entry->IsValid(file, context);
+		result.emplace_back(std::move(metadata_entry), is_valid, has_deletes);
+	}
+	caches = std::move(result);
+	return caches;
+}
+
 static vector<PartitionStatistics> ParquetGetPartitionStats(ClientContext &context, GetPartitionStatsInput &input) {
 	auto &bind_data = input.bind_data->Cast<MultiFileBindData>();
 	vector<PartitionStatistics> result;
@@ -272,42 +335,28 @@ static vector<PartitionStatistics> ParquetGetPartitionStats(ClientContext &conte
 		reader.GetPartitionStats(result);
 		return result;
 	}
-	// if we are reading multiple files - we check if we have caching enabled
-	if (!ParquetReader::MetadataCacheEnabled(context)) {
-		// no caching - bail
+	auto &parquet_data = bind_data.bind_data->Cast<ParquetReadBindData>();
+	auto &cached_metadata = parquet_data.TryLoadCaches(bind_data, context);
+	if (!cached_metadata.empty()) {
+		// no cached metadata - bail
 		return result;
 	}
-	// caching is enabled - check if we have ALL of the metadata cached
-	vector<shared_ptr<ParquetFileMetadataCache>> caches;
-	for (auto &file : bind_data.file_list->Files()) {
-		auto metadata_entry = ParquetReader::GetMetadataCacheEntry(context, file);
-		if (!metadata_entry) {
-			// no cache entry found
+	// first check if all caches are valid and there are no deletes
+	for (auto &cache : cached_metadata) {
+		if (cache.has_deletes) {
+			// we have deletes - don't return any partition stats
+			// FIXME: we could return with count approximate
 			return result;
 		}
-		// check if the file has any deletes
-		if (file.extended_info) {
-			auto entry = file.extended_info->options.find("has_deletes");
-			if (entry != file.extended_info->options.end()) {
-				if (BooleanValue::Get(entry->second)) {
-					// the file has deletes - skip emitting partition stats
-					// FIXME: we could emit partition stats but set count to `COUNT_APPROXIMATE` instead of
-					// `COUNT_EXACT`
-					return result;
-				}
-			}
-		}
-
-		// check if the cache is valid based ONLY on the OpenFileInfo (do not do any file system requests here)
-		const auto is_valid = metadata_entry->IsValid(file, context);
-		if (is_valid != ParquetCacheValidity::VALID) {
+		if (cache.validity != ParquetCacheValidity::VALID) {
+			// we don't know for sure if this cache entry is valid - we can't use these stats
 			return result;
 		}
-		caches.push_back(std::move(metadata_entry));
 	}
+
 	// all caches are valid! we can return the partition stats
-	for (auto &cache : caches) {
-		ParquetReader::GetPartitionStats(*cache->metadata, result);
+	for (auto &cache : cached_metadata) {
+		ParquetReader::GetPartitionStats(*cache.metadata->metadata, result);
 	}
 	return result;
 }
@@ -476,11 +525,22 @@ void ParquetMultiFileInfo::FinalizeBindData(MultiFileBindData &multi_file_data) 
 	}
 }
 
-unique_ptr<NodeStatistics> ParquetMultiFileInfo::GetCardinality(const MultiFileBindData &bind_data_p,
-                                                                idx_t file_count) {
-	auto &bind_data = bind_data_p.bind_data->Cast<ParquetReadBindData>();
-	if (bind_data.explicit_cardinality) {
-		return make_uniq<NodeStatistics>(bind_data.explicit_cardinality);
+unique_ptr<NodeStatistics> ParquetMultiFileInfo::GetCardinality(ClientContext &context,
+                                                                const MultiFileBindData &bind_data, idx_t file_count) {
+	auto &parquet_data = bind_data.bind_data->Cast<ParquetReadBindData>();
+	if (parquet_data.explicit_cardinality) {
+		return make_uniq<NodeStatistics>(parquet_data.explicit_cardinality);
+	}
+	// check if we have cached Parquet metadata we can use to get the estimate
+	auto &caches = parquet_data.TryLoadCaches(bind_data, context);
+	if (!caches.empty()) {
+		// we have cached Parquet data - use it to get the cardinality estimate
+		idx_t cardinality = 0;
+		for (auto &cache : caches) {
+			// note: since this is just an estimate we don't need to look at whether or not the cache is valid
+			cardinality += cache.metadata->metadata->num_rows;
+		}
+		return make_uniq<NodeStatistics>(cardinality);
 	}
 	idx_t min_per_file_cardinality = 1ULL;
 	if (file_count > 1) {
@@ -488,7 +548,7 @@ unique_ptr<NodeStatistics> ParquetMultiFileInfo::GetCardinality(const MultiFileB
 		// we set the minimum per file cardinality to 1000 in this case
 		min_per_file_cardinality = 1000ULL;
 	}
-	auto per_file_cardinality = MaxValue<idx_t>(bind_data.initial_file_cardinality, min_per_file_cardinality);
+	auto per_file_cardinality = MaxValue<idx_t>(parquet_data.initial_file_cardinality, min_per_file_cardinality);
 
 	return make_uniq<NodeStatistics>(per_file_cardinality * file_count);
 }

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -53,7 +53,13 @@ struct MultiFileReaderInterface {
 	                                                const MultiFileOptions &file_options);
 	virtual void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                           LocalTableFunctionState &local_state);
-	virtual unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) = 0;
+	virtual unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) {
+		return nullptr;
+	}
+	virtual unique_ptr<NodeStatistics> GetCardinality(ClientContext &context, const MultiFileBindData &bind_data,
+	                                                  idx_t file_count) {
+		return GetCardinality(bind_data, file_count);
+	}
 	virtual void GetVirtualColumns(ClientContext &context, MultiFileBindData &bind_data, virtual_column_map_t &result);
 	virtual unique_ptr<MultiFileReaderInterface> Copy();
 	virtual FileGlobInput GetGlobInput();
@@ -792,7 +798,7 @@ public:
 			// not all files have been expanded - it's probably twice as many files
 			estimated_file_count *= 2;
 		}
-		return data.interface->GetCardinality(data, estimated_file_count);
+		return data.interface->GetCardinality(context, data, estimated_file_count);
 	}
 
 	static void MultiFileComplexFilterPushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data_p,


### PR DESCRIPTION
When we have cached Parquet metadata, we can use that to emit better cardinality estimates for Parquet scans without having to do any extra I/O. This can lead to better query plans involving complex queries between directories of Parquet files.