### PR TITLE
Parquet Reader: Allow merging of prefetch column ranges for columns that do not have table filters

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1387,17 +1387,17 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 				bool lazy_fetch = filters != nullptr;
 
 				// Prefetch column-wise
+				auto &root_reader = state.root_reader->Cast<StructColumnReader>();
 				for (idx_t i = 0; i < column_ids.size(); i++) {
 					auto col_idx = MultiFileLocalIndex(i);
 					auto file_col_idx = column_ids[col_idx];
-					auto &root_reader = state.root_reader->Cast<StructColumnReader>();
 
 					bool has_filter = false;
 					if (filters) {
 						auto entry = filters->filters.find(col_idx);
 						has_filter = entry != filters->filters.end();
 					}
-					root_reader.GetChildReader(file_col_idx).RegisterPrefetch(trans, !(lazy_fetch && !has_filter));
+					root_reader.GetChildReader(file_col_idx).RegisterPrefetch(trans, !has_filter);
 				}
 
 				trans.FinalizeRegistration();


### PR DESCRIPTION
Partially fixes https://github.com/duckdb/duckdb/issues/21348

In the Parquet prefetcher we unify column reads to reduce the number of `GET` requests made if the columns are close together. However, currently this merging of requests is disabled if there are filters present in the query. The reason for that is that the filters might filter out columns in their entirety, and we want to avoid reading columns that end up not being necessary for the query.

However, we can *still* unify column reads for columns that do not have filters. Once we have determined a row needs to be read as it passes the filter, we need to read **all** columns that do not have filters, so doing individual fetches for those columns is unnecessary.

For example, if we run a query like this:

```sql
SELECT l_orderkey, l_shipdate, l_shipinstruct
FROM lineitem.parquet
WHERE l_orderkey >= 2;
```

Currently we do the following reads:

```
GET l_orderkey
(check if l_orderkey >= 2)
GET l_shipdate
GET l_shipinstruct
```

This PR allows the latter two reads to be unified, so we can do this:

```
GET l_orderkey
(check if l_orderkey >= 2)
GET l_shipdate, l_shipinstruct
```

### Performance

Running the following query, this now results in the following performance:

```sql
SELECT * FROM read_parquet('s3://ducklake-partition-test/lineitem-sf1-partition-date/**')
WHERE l_orderkey >= 2;
```

| Data Read |   Requests    | Total Time |
|-----------|---------------|------------|
| 196MB     | 2629 requests | 30.2s      |
| 200MB     | 403 requests  | 20.5s      |
