### PR TITLE
In the parquet reader, if we are globbing over a directory, use file sizes from the glob to estimate cardinalities instead of relying only on the first parquet file

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -178,6 +178,8 @@ public:
 
 	idx_t NumRows() const;
 	idx_t NumRowGroups() const;
+	idx_t GetFileSize() const;
+	idx_t GetDataSize() const;
 
 	const duckdb_parquet::FileMetaData *GetFileMetadata() const;
 	string static GetUniqueFileIdentifier(const duckdb_parquet::EncryptionAlgorithm &encryption_algorithm);

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -21,6 +21,8 @@ struct ParquetReadBindData : public TableFunctionData {
 	// These come from the initial_reader, but need to be stored in case the initial_reader is removed by a filter
 	idx_t initial_file_cardinality;
 	idx_t initial_file_row_groups;
+	idx_t initial_file_size = 0;
+	idx_t initial_file_data_size = 0;
 	idx_t explicit_cardinality = 0; // can be set to inject exterior cardinality knowledge (e.g. from a data lake)
 	unique_ptr<ParquetFileReaderOptions> options;
 
@@ -35,6 +37,8 @@ struct ParquetReadBindData : public TableFunctionData {
 		auto result = make_uniq<ParquetReadBindData>();
 		result->initial_file_cardinality = initial_file_cardinality;
 		result->initial_file_row_groups = initial_file_row_groups;
+		result->initial_file_size = initial_file_size;
+		result->initial_file_data_size = initial_file_data_size;
 		result->explicit_cardinality = explicit_cardinality;
 		result->options = make_uniq<ParquetFileReaderOptions>(options->options);
 		return std::move(result);
@@ -521,6 +525,13 @@ void ParquetMultiFileInfo::FinalizeBindData(MultiFileBindData &multi_file_data) 
 		auto &initial_reader = multi_file_data.initial_reader->Cast<ParquetReader>();
 		bind_data.initial_file_cardinality = initial_reader.NumRows();
 		bind_data.initial_file_row_groups = initial_reader.NumRowGroups();
+		bind_data.initial_file_size = initial_reader.GetFileSize();
+		bind_data.initial_file_data_size = initial_reader.GetDataSize();
+		if (bind_data.initial_file_data_size >= bind_data.initial_file_size) {
+			// this should not be possible - we need at least some metadata in the file
+			// FIXME: should this throw an error?
+			bind_data.initial_file_data_size = bind_data.initial_file_size - 1;
+		}
 		bind_data.options->options = initial_reader.parquet_options;
 	}
 }
@@ -531,6 +542,11 @@ unique_ptr<NodeStatistics> ParquetMultiFileInfo::GetCardinality(ClientContext &c
 	if (parquet_data.explicit_cardinality) {
 		return make_uniq<NodeStatistics>(parquet_data.explicit_cardinality);
 	}
+	if (file_count == 1) {
+		// if we have one file we can just use the cardinality of that file
+		return make_uniq<NodeStatistics>(parquet_data.initial_file_cardinality);
+	}
+	// multiple parquet files
 	// check if we have cached Parquet metadata we can use to get the estimate
 	auto &caches = parquet_data.TryLoadCaches(bind_data, context);
 	if (!caches.empty()) {
@@ -542,14 +558,52 @@ unique_ptr<NodeStatistics> ParquetMultiFileInfo::GetCardinality(ClientContext &c
 		}
 		return make_uniq<NodeStatistics>(cardinality);
 	}
-	idx_t min_per_file_cardinality = 1ULL;
-	if (file_count > 1) {
-		// if we have several files, our cardinality estimate can be way off if our initial file is ~empty
-		// we set the minimum per file cardinality to 1000 in this case
-		min_per_file_cardinality = 1000ULL;
+	// we don't have any scan data - check if we can get some intel from the file list
+	// in particular - if we have file sizes, we try to estimate rows per file from the file size
+	MultiFileListScanData scan_data;
+	scan_data.scan_type = MultiFileListScanType::FETCH_IF_AVAILABLE;
+	bind_data.file_list->InitializeScan(scan_data);
+	OpenFileInfo file;
+	idx_t initial_cardinality = MaxValue<idx_t>(parquet_data.initial_file_cardinality, 1ULL);
+	idx_t estimated_bytes_per_row = parquet_data.initial_file_data_size / initial_cardinality;
+	// for very small cardinalities, compression doesn't really work well
+	// to compensate if initial_cardinality is small we decrease estimated_bytes_per_row
+	// for 1 row we divide by 10, for 2 rows we divide by 9, etc
+	if (initial_cardinality < 10) {
+		estimated_bytes_per_row /= 11 - initial_cardinality;
 	}
-	auto per_file_cardinality = MaxValue<idx_t>(parquet_data.initial_file_cardinality, min_per_file_cardinality);
+	estimated_bytes_per_row = MaxValue<idx_t>(estimated_bytes_per_row, 10ULL);
 
+	idx_t files_with_sizes = 0;
+	idx_t estimated_file_row_count = 0;
+	while (bind_data.file_list->Scan(scan_data, file)) {
+		auto entry = file.extended_info->options.find("file_size");
+		if (entry == file.extended_info->options.end()) {
+			estimated_file_row_count = 0;
+			break;
+		}
+		// we have the file size - estimate row count based on estimated bytes per row
+		auto current_file_size = entry->second.GetValue<uint64_t>();
+		files_with_sizes++;
+		idx_t rows_in_this_file = MaxValue<idx_t>(current_file_size / estimated_bytes_per_row, 1ULL);
+		estimated_file_row_count += rows_in_this_file;
+	}
+	idx_t per_file_cardinality;
+	if (estimated_file_row_count > 0) {
+		// use estimate based on file sizes
+		per_file_cardinality = estimated_file_row_count / files_with_sizes;
+	} else {
+		// no estimate based on file sizes - use initial file cardinality
+		per_file_cardinality = parquet_data.initial_file_cardinality;
+	}
+	// if we have several files, our cardinality estimate can be way off if our initial file is ~empty
+	// we set the minimum per file cardinality to 1000 just to avoid greatly underestimating
+	idx_t min_per_file_cardinality = 1000ULL;
+	if (per_file_cardinality < min_per_file_cardinality) {
+		per_file_cardinality = min_per_file_cardinality;
+	}
+	Printer::PrintF("For files %s - estimate per file cardinality of %d (file count %d)", file.path,
+	                per_file_cardinality, file_count);
 	return make_uniq<NodeStatistics>(per_file_cardinality * file_count);
 }
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -602,8 +602,6 @@ unique_ptr<NodeStatistics> ParquetMultiFileInfo::GetCardinality(ClientContext &c
 	if (per_file_cardinality < min_per_file_cardinality) {
 		per_file_cardinality = min_per_file_cardinality;
 	}
-	Printer::PrintF("For files %s - estimate per file cardinality of %d (file count %d)", file.path,
-	                per_file_cardinality, file_count);
 	return make_uniq<NodeStatistics>(per_file_cardinality * file_count);
 }
 

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -577,8 +577,14 @@ unique_ptr<NodeStatistics> ParquetMultiFileInfo::GetCardinality(ClientContext &c
 	idx_t files_with_sizes = 0;
 	idx_t estimated_file_row_count = 0;
 	while (bind_data.file_list->Scan(scan_data, file)) {
+		if (!file.extended_info) {
+			// no extended info
+			estimated_file_row_count = 0;
+			break;
+		}
 		auto entry = file.extended_info->options.find("file_size");
 		if (entry == file.extended_info->options.end()) {
+			// no file size available
 			estimated_file_row_count = 0;
 			break;
 		}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1211,6 +1211,18 @@ idx_t ParquetReader::NumRowGroups() const {
 	return GetFileMetadata()->row_groups.size();
 }
 
+idx_t ParquetReader::GetFileSize() const {
+	return file_handle->GetFileSize();
+}
+
+idx_t ParquetReader::GetDataSize() const {
+	idx_t data_size = 0;
+	for (auto &row_group : GetFileMetadata()->row_groups) {
+		data_size += row_group.total_compressed_size;
+	}
+	return data_size;
+}
+
 ParquetScanFilter::ParquetScanFilter(ClientContext &context, idx_t filter_idx, TableFilter &filter)
     : filter_idx(filter_idx), filter(filter) {
 	filter_state = TableFilterState::Initialize(context, filter);


### PR DESCRIPTION
When running an S3 file listing the file sizes of individual Parquet files are returned. We can use these to better steer our cardinality estimate even if the Parquet metadata is not cached. Currently we rely on the cardinality of the first file - but if that cardinality is skewed we can get a very incorrect cardinality estimate.

We use the file sizes as follows:

* Based on the first file, we compute `estimated_bytes_per_row = (file_size - footer_metadata_size) / row_count`
* If the first file has very few rows (`<= 10`), we use a heuristic to reduce `estimated_bytes_per_row`, since compression does not work effectively on such small data sizes we expect the bytes per row to be much higher for files with very few rows.
* For the remaining files, we then compute `estimated_row_count = file_size / estimated_bytes_per_row`

We then use these estimated row counts to get an updated `per_file_cardinality` that is not just based on the number of rows in the first Parquet file, and use that together with the file count to get a more accurate cardinality estimate.