### PR TITLE
automate clangd/compile_commands.json gen via builds

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,3 +1,3 @@
 CompileFlags:
-  CompilationDatabase: build/clangd
+  CompilationDatabase: .cache/clangd
   Add: -Wno-unqualified-std-cast-call

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,29 @@ set(DUCKDB_MODULE_BASE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Copy compile_commands.json into <repo-root>/.cache/clangd/ after every successful build.
+# .cache/ is intentionally outside build/ so it survives `make clean` (which does rm -rf build).
+# The build-type name is derived from the last component of CMAKE_BINARY_DIR, so build dirs must
+# be two levels below the repo root (e.g. build/debug, .cache/clangd/debug) for the repo-root
+# derivation (CMAKE_BINARY_DIR/../..) to be correct. This works in both standalone duckdb builds
+# and extension builds where duckdb/ is a submodule.
+if(CMAKE_EXPORT_COMPILE_COMMANDS AND UNIX)
+  get_filename_component(_clangd_build_name "${CMAKE_BINARY_DIR}" NAME)
+  get_filename_component(_repo_root "${CMAKE_BINARY_DIR}/../.." ABSOLUTE)
+  set(_clangd_cache_dir "${_repo_root}/.cache/clangd")
+  add_custom_target(clangd_cache ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${_clangd_cache_dir}/${_clangd_build_name}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${CMAKE_BINARY_DIR}/compile_commands.json"
+      "${_clangd_cache_dir}/${_clangd_build_name}/compile_commands.json"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${CMAKE_BINARY_DIR}/compile_commands.json"
+      "${_clangd_cache_dir}/compile_commands.json"
+    COMMENT "Updating .cache/clangd (${_clangd_build_name})"
+    VERBATIM
+  )
+endif()
+
 set(CMAKE_CXX_STANDARD "11" CACHE STRING "C++ standard to enforce")
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/Makefile
+++ b/Makefile
@@ -577,8 +577,9 @@ bloaty: reldebug bloaty/bloaty
 	./bloaty/bloaty  build/reldebug/duckdb -d symbols -n 20 --debug-file=build/reldebug/duckdb.dSYM/Contents/Resources/DWARF/duckdb
 	# ./bloaty/bloaty  build/reldebug/extension/parquet/parquet.duckdb_extension -d symbols -n 20 # to execute on extension
 
+# Generate compile commands without actually building
 clangd:
-	cmake -DCMAKE_BUILD_TYPE=Debug ${CMAKE_VARS} -B build/clangd .
+	cmake -DCMAKE_BUILD_TYPE=Debug ${CMAKE_VARS} -B .cache/clangd/debug .
 
 coverage-check:
 	./scripts/coverage_check.sh


### PR DESCRIPTION
Updates CMake to put the latest compile_commands.json file into a
common directory _outside of ./build_ so that it [a] remains up to
2026-03-13and [b] usable even after make clean. Guarded by
`CMAKE_EXPORT_COMPILE_COMMANDS`, which is default on, but can be
disabled.

Dev convenience - has no impact on actual builds.

(see same for v1.5 #21361)