### PR TITLE
Fix #21335: correctly add checkpoint and recovery WAL to allowed paths when launching an initial db with enable_external_access set to false

### DIFF
--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -445,6 +445,8 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 	if (database_path && !Settings::Get<EnableExternalAccessSetting>(*this)) {
 		config.AddAllowedPath(database_path);
 		config.AddAllowedPath(database_path + string(".wal"));
+		config.AddAllowedPath(database_path + string(".wal.checkpoint"));
+		config.AddAllowedPath(database_path + string(".wal.recovery"));
 		if (!config.options.temporary_directory.empty()) {
 			config.AddAllowedDirectory(config.options.temporary_directory);
 		}

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -692,11 +692,22 @@ TEST_CASE("Fuzzer 50 - Alter table heap-use-after-free", "[api]") {
 TEST_CASE("Test loading database with enable_external_access set to false", "[api]") {
 	DBConfig config;
 	config.SetOptionByName("enable_external_access", false);
-	auto path = TestCreatePath("external_access_test");
+	auto path = TestCreatePath("external_access_test.db");
 	DuckDB db(path, &config);
 	Connection con(db);
 
-	REQUIRE_FAIL(con.Query("ATTACH 'mydb.db' AS external_access_test"));
+	REQUIRE_FAIL(con.Query("ATTACH 'mydb.db'"));
+}
+
+TEST_CASE("Test checkpointing initial database with enable_external_access set to false", "[api]") {
+	DBConfig config;
+	config.SetOptionByName("enable_external_access", false);
+	auto path = TestCreatePath("external_access_test.db");
+	DuckDB db(path, &config);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE tbl(i INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
 }
 
 TEST_CASE("Test insert returning in CPP API", "[api]") {


### PR DESCRIPTION
Fixes #21335