### PR TITLE
Fix invalid common subplan CTE reuse for issue #21372

### DIFF
--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/arena_containers/arena_unordered_map.hpp"
 #include "duckdb/common/arena_containers/arena_vector.hpp"
+#include "duckdb/planner/column_binding_map.hpp"
 
 namespace duckdb {
 
@@ -775,6 +776,10 @@ public:
 				col_names.emplace_back(StringUtil::Format("%s_col_%llu", cte_name, i + 1));
 			}
 			const auto &primary_subplan_bindings = primary_subplan.canonical_bindings;
+			column_binding_map_t<idx_t> primary_binding_index;
+			for (idx_t i = 0; i < primary_subplan_bindings.size(); i++) {
+				primary_binding_index.emplace(primary_subplan_bindings[i], i);
+			}
 			vector<vector<idx_t>> cte_column_indexes(subplan_info.subplans.size());
 			vector<bool> needs_projection(subplan_info.subplans.size(), false);
 			bool incompatible_types = false;
@@ -787,13 +792,9 @@ public:
 				needs_projection[subplan_idx] = canonical_bindings.size() != types.size();
 				for (idx_t i = 0; i < canonical_bindings.size(); i++) {
 					const auto &cb = canonical_bindings[i];
-					idx_t cte_col_idx = 0;
-					for (; cte_col_idx < primary_subplan_bindings.size(); cte_col_idx++) {
-						if (cb == primary_subplan_bindings[cte_col_idx]) {
-							break;
-						}
-					}
-					D_ASSERT(cte_col_idx < primary_subplan_bindings.size());
+					const auto entry = primary_binding_index.find(cb);
+					D_ASSERT(entry != primary_binding_index.end());
+					const auto cte_col_idx = entry->second;
 					if (subplan_types[i] != types[cte_col_idx]) {
 						incompatible_types = true;
 						break;

--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -782,29 +782,21 @@ public:
 			}
 			vector<vector<idx_t>> cte_column_indexes(subplan_info.subplans.size());
 			vector<bool> needs_projection(subplan_info.subplans.size(), false);
-			bool incompatible_types = false;
-			for (idx_t subplan_idx = 0; subplan_idx < subplan_info.subplans.size() && !incompatible_types;
-			     subplan_idx++) {
+			for (idx_t subplan_idx = 0; subplan_idx < subplan_info.subplans.size(); subplan_idx++) {
 				const auto &subplan = subplan_info.subplans[subplan_idx];
 				const auto &canonical_bindings = subplan.canonical_bindings;
-				const auto &subplan_types = subplan.op.get()->types;
 				cte_column_indexes[subplan_idx].reserve(canonical_bindings.size());
 				needs_projection[subplan_idx] = canonical_bindings.size() != types.size();
 				for (idx_t i = 0; i < canonical_bindings.size(); i++) {
 					const auto &cb = canonical_bindings[i];
 					const auto entry = primary_binding_index.find(cb);
-					D_ASSERT(entry != primary_binding_index.end());
+					D_ASSERT(entry != primary_binding_index.end()); // guaranteed by FilterSubplans
 					const auto cte_col_idx = entry->second;
-					if (subplan_types[i] != types[cte_col_idx]) {
-						incompatible_types = true;
-						break;
-					}
+					// Types must match: same canonical binding = same base column = same type
+					D_ASSERT(subplan.op.get()->types[i] == types[cte_col_idx]);
 					cte_column_indexes[subplan_idx].push_back(cte_col_idx);
 					needs_projection[subplan_idx] = needs_projection[subplan_idx] || cte_col_idx != i;
 				}
-			}
-			if (incompatible_types) {
-				continue;
 			}
 
 			// Create CTE refs and figure out column binding replacements

--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -775,6 +775,36 @@ public:
 				col_names.emplace_back(StringUtil::Format("%s_col_%llu", cte_name, i + 1));
 			}
 			const auto &primary_subplan_bindings = primary_subplan.canonical_bindings;
+			vector<vector<idx_t>> cte_column_indexes(subplan_info.subplans.size());
+			vector<bool> needs_projection(subplan_info.subplans.size(), false);
+			bool incompatible_types = false;
+			for (idx_t subplan_idx = 0; subplan_idx < subplan_info.subplans.size() && !incompatible_types;
+			     subplan_idx++) {
+				const auto &subplan = subplan_info.subplans[subplan_idx];
+				const auto &canonical_bindings = subplan.canonical_bindings;
+				const auto &subplan_types = subplan.op.get()->types;
+				cte_column_indexes[subplan_idx].reserve(canonical_bindings.size());
+				needs_projection[subplan_idx] = canonical_bindings.size() != types.size();
+				for (idx_t i = 0; i < canonical_bindings.size(); i++) {
+					const auto &cb = canonical_bindings[i];
+					idx_t cte_col_idx = 0;
+					for (; cte_col_idx < primary_subplan_bindings.size(); cte_col_idx++) {
+						if (cb == primary_subplan_bindings[cte_col_idx]) {
+							break;
+						}
+					}
+					D_ASSERT(cte_col_idx < primary_subplan_bindings.size());
+					if (subplan_types[i] != types[cte_col_idx]) {
+						incompatible_types = true;
+						break;
+					}
+					cte_column_indexes[subplan_idx].push_back(cte_col_idx);
+					needs_projection[subplan_idx] = needs_projection[subplan_idx] || cte_col_idx != i;
+				}
+			}
+			if (incompatible_types) {
+				continue;
+			}
 
 			// Create CTE refs and figure out column binding replacements
 			vector<unique_ptr<LogicalOperator>> cte_refs;
@@ -788,18 +818,11 @@ public:
 				}
 				const auto old_bindings = subplan.op.get()->GetColumnBindings();
 				auto new_bindings = cte_refs.back()->GetColumnBindings();
-				if (old_bindings.size() != new_bindings.size()) {
-					// Different number of output columns - project columns out
-					const auto &canonical_bindings = subplan.canonical_bindings;
+				if (needs_projection[subplan_idx]) {
+					// Preserve each subplan's original output order when it differs from the
+					// primary materialized CTE.
 					vector<unique_ptr<Expression>> select_list;
-					for (auto &cb : canonical_bindings) {
-						idx_t cte_col_idx = 0;
-						for (; cte_col_idx < primary_subplan_bindings.size(); cte_col_idx++) {
-							if (cb == primary_subplan_bindings[cte_col_idx]) {
-								break;
-							}
-						}
-						D_ASSERT(cte_col_idx < primary_subplan_bindings.size());
+					for (auto cte_col_idx : cte_column_indexes[subplan_idx]) {
 						select_list.emplace_back(make_uniq<BoundColumnRefExpression>(
 						    types[cte_col_idx], ColumnBinding(cte_ref_index, cte_col_idx)));
 					}

--- a/test/issues/general/test_21372.test
+++ b/test/issues/general/test_21372.test
@@ -11,7 +11,7 @@ statement ok
 CREATE TABLE pp_test_cohort_set AS
 SELECT 1 AS cohort_definition_id, 'cohort_1' AS cohort_name;
 
-query IIIII
+query TTITT
 SELECT
   cohort_name AS cohort_name_reference,
   cohort_start_date,

--- a/test/issues/general/test_21372.test
+++ b/test/issues/general/test_21372.test
@@ -1,0 +1,35 @@
+# name: test/issues/general/test_21372.test
+# description: Issue 21372 - common subplan extraction can reorder join outputs and break column binding resolution
+# group: [general]
+
+statement ok
+CREATE TABLE pp_test_cohort AS
+SELECT 1 AS cohort_definition_id, 1 AS subject_id, CAST('2017-01-01' AS DATE) AS cohort_start_date,
+       CAST('2017-01-01' AS DATE) AS cohort_end_date;
+
+statement ok
+CREATE TABLE pp_test_cohort_set AS
+SELECT 1 AS cohort_definition_id, 'cohort_1' AS cohort_name;
+
+query IIIII
+SELECT
+  cohort_name AS cohort_name_reference,
+  cohort_start_date,
+  pp_test_cohort.subject_id AS subject_id,
+  cohort_name_comparator,
+  cohort_start_date_comparator
+FROM pp_test_cohort
+LEFT JOIN pp_test_cohort_set
+  ON (pp_test_cohort.cohort_definition_id = pp_test_cohort_set.cohort_definition_id)
+INNER JOIN (
+  SELECT
+    cohort_name AS cohort_name_comparator,
+    cohort_start_date AS cohort_start_date_comparator,
+    subject_id
+  FROM pp_test_cohort
+  LEFT JOIN pp_test_cohort_set
+    ON (pp_test_cohort.cohort_definition_id = pp_test_cohort_set.cohort_definition_id)
+) zz
+  ON (pp_test_cohort.subject_id = zz.subject_id);
+----
+cohort_1	2017-01-01	1	cohort_1	2017-01-01


### PR DESCRIPTION
## Summary

Fixes #21372.

This change makes `common_subplan` more conservative when materializing repeated subplans as internal CTEs:
- precompute each consumer's column remapping against the primary materialized subplan
- add a projection on top of the `LogicalCTERef` when a consumer needs a different output order
- skip materialization entirely when the remapped output types are incompatible

## Testing

- Added regression test `/test/issues/general/test_21372.test`
- `make allunit` passed
