### PR TITLE
Fix incorrect column binding in TopN window elimination with multi-column PARTITION BY

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -683,7 +683,7 @@ void TopNWindowElimination::UpdateTopmostBindings(const idx_t window_idx, const 
 
 	// CreateProjectionOperator only includes referenced group columns, ordered by partition index.
 	// So the projection position is determined by how many smaller partition indices are also referenced.
-	std::set<idx_t> ordered_group_vals;
+	set<idx_t> ordered_group_vals;
 	for (const auto &g : group_idxs) {
 		ordered_group_vals.insert(g.second);
 	}

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -681,12 +681,24 @@ void TopNWindowElimination::UpdateTopmostBindings(const idx_t window_idx, const 
 	const idx_t group_table_idx = GetGroupIdx(op);
 	const idx_t aggregate_table_idx = GetAggregateIdx(op);
 
+	// CreateProjectionOperator only includes referenced group columns, ordered by partition index.
+	// So the projection position is determined by how many smaller partition indices are also referenced.
+	std::set<idx_t> ordered_group_vals;
+	for (const auto &g : group_idxs) {
+		ordered_group_vals.insert(g.second);
+	}
+	map<idx_t, idx_t> group_val_to_proj_pos;
+	idx_t pos = 0;
+	for (const auto &v : ordered_group_vals) {
+		group_val_to_proj_pos[v] = pos++;
+	}
+
 	// Project the group columns
 	idx_t current_column_idx = 0;
 	for (auto group_idx : group_idxs) {
 		const idx_t group_referencing_idx = group_idx.first;
 		new_bindings[group_referencing_idx].table_index = group_table_idx;
-		new_bindings[group_referencing_idx].column_index = group_idx.second;
+		new_bindings[group_referencing_idx].column_index = group_val_to_proj_pos[group_idx.second];
 		replacer.replacement_bindings.emplace_back(topmost_bindings[group_referencing_idx],
 		                                           new_bindings[group_referencing_idx]);
 		current_column_idx++;

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -318,3 +318,50 @@ SELECT * FROM a, LATERAL (SELECT *, a_id AS id_dup FROM b ORDER BY array_distanc
 [1.0, 2.0, 3.0]	1	[1.0, 2.0, 3.0]	a	1
 [4.0, 5.0, 6.0]	2	[4.0, 5.0, 6.0]	b	2
 
+# Test multi-column PARTITION BY with row_number() where not all partition columns are in the output
+# Regression test for https://github.com/duckdb/duckdb/issues/21387
+statement ok
+CREATE TABLE issue_21387 (a VARCHAR, ts TIMESTAMP, k VARCHAR);
+
+statement ok
+INSERT INTO issue_21387 VALUES ('x', '2024-01-01', 'abc'), ('y', '2024-02-01', 'def');
+
+query I
+SELECT k FROM issue_21387 QUALIFY row_number() OVER (PARTITION BY a, k ORDER BY ts DESC) = 1 ORDER BY k;
+----
+abc
+def
+
+# Same test with SELECT * to verify all columns bind correctly
+query III
+SELECT * FROM issue_21387 QUALIFY row_number() OVER (PARTITION BY a, k ORDER BY ts DESC) = 1 ORDER BY k;
+----
+x	2024-01-01 00:00:00	abc
+y	2024-02-01 00:00:00	def
+
+# Test with VARCHAR ORDER BY column (not just TIMESTAMP)
+statement ok
+CREATE TABLE issue_21387_str (a VARCHAR, val VARCHAR, k VARCHAR);
+
+statement ok
+INSERT INTO issue_21387_str VALUES ('x', 'zzz', 'abc'), ('y', 'aaa', 'def');
+
+query I
+SELECT k FROM issue_21387_str QUALIFY row_number() OVER (PARTITION BY a, k ORDER BY val DESC) = 1 ORDER BY k;
+----
+abc
+def
+
+# Test with three partition columns where only one is in the output
+statement ok
+CREATE TABLE issue_21387_triple (a VARCHAR, b VARCHAR, ts TIMESTAMP, k VARCHAR);
+
+statement ok
+INSERT INTO issue_21387_triple VALUES ('x', 'p', '2024-01-01', 'abc'), ('y', 'q', '2024-02-01', 'def');
+
+query I
+SELECT k FROM issue_21387_triple QUALIFY row_number() OVER (PARTITION BY a, b, k ORDER BY ts DESC) = 1 ORDER BY k;
+----
+abc
+def
+


### PR DESCRIPTION
## Summary

Fixes #21387

- `row_number()` with multi-column `PARTITION BY` and a filter (`WHERE rn = 1`) caused an `INTERNAL Error: Failed to bind column reference ... inequal types` when not all partition columns appeared in the output
- Root cause: `UpdateTopmostBindings` used the raw partition index as the projection column index, but `CreateProjectionOperator` only includes *referenced* group columns — so the partition index didn't match the projection position when unreferenced partition columns were skipped
- Fix: map partition indices to their actual projection positions by mirroring the sorted-set logic already used in `CreateProjectionOperator`

## Test plan

- [x] Added 4 regression tests to `test/optimizer/topn_window_elimination.test_slow`:
  - Multi-column `PARTITION BY` with only one partition column in output (original repro)
  - `SELECT *` variant to verify all columns bind correctly
  - `INTEGER` ORDER BY column (not just TIMESTAMP)
  - Triple `PARTITION BY` with only one column in output
- [ ] CI passes existing `topn_window_elimination` test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code) and reviewed by a human 👀