### PR TITLE
CLI: Fix .tables rendering for large database names

### DIFF
--- a/tools/shell/shell_render_table_metadata.cpp
+++ b/tools/shell/shell_render_table_metadata.cpp
@@ -595,6 +595,16 @@ void ShellState::RenderTableMetadata(vector<ShellTableInfo> &tables) {
 		// we should use a pager
 		pager_setup = SetupPager();
 	}
+	// compute the metadata render width
+	idx_t metadata_render_width = 0;
+	for (auto &metadata_display : metadata_displays) {
+		auto metadata_render_size = ShellState::RenderLength(metadata_display.database_name);
+		metadata_render_size =
+		    duckdb::MaxValue<idx_t>(metadata_render_size, ShellState::RenderLength(metadata_display.schema_name));
+		metadata_render_size = duckdb::MinValue<idx_t>(max_render_width, metadata_render_size + 6);
+		metadata_render_width = duckdb::MaxValue<idx_t>(metadata_render_width, metadata_render_size);
+		metadata_render_width = duckdb::MaxValue<idx_t>(metadata_render_width, metadata_display.render_width);
+	}
 	// render the metadata
 	ShellHighlight highlight(*this);
 	string last_displayed_database;
@@ -602,13 +612,13 @@ void ShellState::RenderTableMetadata(vector<ShellTableInfo> &tables) {
 	for (auto &metadata_display : metadata_displays) {
 		// check if we should render the database and/or schema name for this batch of tables
 		if (!metadata_display.database_name.empty() && last_displayed_database != metadata_display.database_name) {
-			RenderLineDisplay(highlight, metadata_display.database_name, metadata_display.render_width,
+			RenderLineDisplay(highlight, metadata_display.database_name, metadata_render_width,
 			                  HighlightElementType::DATABASE_NAME);
 			last_displayed_database = metadata_display.database_name;
 			last_displayed_schema = string();
 		}
 		if (!metadata_display.schema_name.empty() && last_displayed_schema != metadata_display.schema_name) {
-			RenderLineDisplay(highlight, metadata_display.schema_name, metadata_display.render_width,
+			RenderLineDisplay(highlight, metadata_display.schema_name, metadata_render_width,
 			                  HighlightElementType::SCHEMA_NAME);
 			last_displayed_schema = metadata_display.schema_name;
 		}

--- a/tools/shell/tests/test_table_metadata_rendering.py
+++ b/tools/shell/tests/test_table_metadata_rendering.py
@@ -111,3 +111,14 @@ def test_qualified_show_tables(shell):
 
     result = test.run()
     result.check_stdout("t1")
+
+def test_tables_rendering_large_database(shell):
+    test = (
+        ShellTest(shell)
+        .statement("attach ':memory:' as thisisanenormousdatabasenamethatmightoverflowthetablerenderingmechanism;")
+        .statement("create table thisisanenormousdatabasenamethatmightoverflowthetablerenderingmechanism.tbl(i int);")
+        .statement('.tables')
+    )
+
+    result = test.run()
+    result.check_stdout("thisisanenormousdatabasenamethatmightoverflowthetablerenderingmechanism")


### PR DESCRIPTION
Currently when we have very large database names that have short tables within them we either (1) unnecessarily truncate the database name, and (2) occasionally trigger an internal error as a result of this truncation applying to the wrong string. This PR fixes that issue.