### PR TITLE
Grab correct row group id in ValidityColumnData::UpdateWithBase

### DIFF
--- a/src/storage/table/validity_column_data.cpp
+++ b/src/storage/table/validity_column_data.cpp
@@ -28,7 +28,8 @@ void ValidityColumnData::UpdateWithBase(TransactionData transaction, DataTable &
 	    CompressionType::COMPRESSION_EMPTY) {
 		// The validity is actually covered by the data, so we read it to get the validity for UpdateInternal.
 		ColumnScanState data_scan_state(nullptr);
-		auto fetch_count = base.Fetch(data_scan_state, row_ids[0], base_vector);
+		auto fetch_count =
+		    base.Fetch(data_scan_state, row_ids[0] - UnsafeNumericCast<row_t>(row_group_start), base_vector);
 		base_vector.Flatten(fetch_count);
 	}
 

--- a/test/sql/storage/wal/dict_fsst_wal_replay.test_slow
+++ b/test/sql/storage/wal/dict_fsst_wal_replay.test_slow
@@ -1,0 +1,29 @@
+# name: test/sql/storage/wal/dict_fsst_wal_replay.test_slow
+# description: Test WAL replay of updates on dict fsst
+# group: [wal]
+
+# load the DB from disk
+load __TEST_DIR__/dict_fsst_wal_replay.db readwrite v1.5.0
+
+statement ok
+SET force_compression='dict_fsst';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+SET checkpoint_threshold='1TB';
+
+statement ok
+CREATE TABLE tbl(id INT, v VARCHAR);
+
+statement ok
+INSERT INTO tbl SELECT i, CASE WHEN i%8=0 THEN NULL ELSE concat('thisisalongstring' || i//2) END FROM range(500_000) t(i)
+
+statement ok
+CHECKPOINT
+
+statement ok
+UPDATE tbl SET v=NULL WHERE id%7=0
+
+restart


### PR DESCRIPTION
Otherwise we'll trigger `ColumnData::Fetch - row_id out of range` when doing a WAL replay of updates on later row groups