### PR TITLE
Enable Row Group Pruner for NULLS_FIRST

### DIFF
--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -1156,9 +1156,14 @@
         "id": 106,
         "name": "row_group_offset",
         "type": "idx_t"
+      },
+      {
+        "id": 107,
+        "name": "leading_null_group_offset",
+        "type": "idx_t"
       }
     ],
-    "constructor": ["column_idx", "order_by", "order_type", "null_order", "column_type",  "row_limit", "row_group_offset"]
+    "constructor": ["column_idx", "order_by", "order_type", "null_order", "column_type",  "row_limit", "row_group_offset", "leading_null_group_offset"]
   },
   {
     "class": "StorageIndex",

--- a/src/include/duckdb/storage/table/row_group_reorderer.hpp
+++ b/src/include/duckdb/storage/table/row_group_reorderer.hpp
@@ -22,9 +22,11 @@ enum class OrderByColumnType : uint8_t { NUMERIC, STRING };
 struct RowGroupOrderOptions {
 	RowGroupOrderOptions(const StorageIndex &column_idx_p, OrderByStatistics order_by_p, OrderType order_type_p,
 	                     OrderByNullType null_order_p, OrderByColumnType column_type_p,
-	                     optional_idx row_limit_p = optional_idx(), idx_t row_group_offset_p = 0)
+	                     optional_idx row_limit_p = optional_idx(), idx_t row_group_offset_p = 0,
+	                     idx_t leading_null_group_offset_p = 0)
 	    : column_idx(column_idx_p), order_by(order_by_p), order_type(order_type_p), null_order(null_order_p),
-	      column_type(column_type_p), row_limit(row_limit_p), row_group_offset(row_group_offset_p) {
+	      column_type(column_type_p), row_limit(row_limit_p), row_group_offset(row_group_offset_p),
+	      leading_null_group_offset(leading_null_group_offset_p) {
 	}
 
 	const StorageIndex column_idx;
@@ -34,6 +36,7 @@ struct RowGroupOrderOptions {
 	const OrderByColumnType column_type;
 	const optional_idx row_limit;
 	const idx_t row_group_offset;
+	const idx_t leading_null_group_offset;
 
 	void Serialize(Serializer &serializer) const;
 	static unique_ptr<RowGroupOrderOptions> Deserialize(Deserializer &deserializer);
@@ -42,6 +45,7 @@ struct RowGroupOrderOptions {
 struct OffsetPruningResult {
 	idx_t offset_remainder;
 	idx_t pruned_row_group_count;
+	idx_t leading_null_group_offset;
 };
 
 class RowGroupReorderer {

--- a/src/optimizer/row_group_pruner.cpp
+++ b/src/optimizer/row_group_pruner.cpp
@@ -113,14 +113,6 @@ optional_ptr<LogicalOrder> RowGroupPruner::FindLogicalOrder(const LogicalLimit &
 	}
 
 	auto &logical_order = current_op.get().Cast<LogicalOrder>();
-	for (const auto &order : logical_order.orders) {
-		// FIXME: the logic to handle this has now been implemented in the row group reorderer,
-		// but we do not enable the optimization until more thorough testing
-		if (order.null_order == OrderByNullType::NULLS_FIRST) {
-			return nullptr;
-		}
-	}
-
 	auto order_column_type = logical_order.orders[0].expression->return_type;
 	if (!order_column_type.IsNumeric() && !order_column_type.IsTemporal() &&
 	    order_column_type != LogicalType::VARCHAR) {
@@ -193,7 +185,8 @@ RowGroupPruner::CreateRowGroupReordererOptions(const optional_idx row_limit, con
 				}
 
 				return make_uniq<RowGroupOrderOptions>(storage_index, order_by, order_type, null_order, column_type,
-				                                       combined_limit, offset_puning_result.pruned_row_group_count);
+				                                       combined_limit, offset_puning_result.pruned_row_group_count,
+				                                       offset_puning_result.leading_null_group_offset);
 			}
 		}
 	}

--- a/src/optimizer/row_group_pruner.cpp
+++ b/src/optimizer/row_group_pruner.cpp
@@ -175,8 +175,8 @@ RowGroupPruner::CreateRowGroupReordererOptions(const optional_idx row_limit, con
 		if (!partition_stats.empty()) {
 			auto offset_puning_result = RowGroupReorderer::GetOffsetAfterPruning(
 			    order_by, column_type, order_type, null_order, storage_index, row_offset.GetIndex(), partition_stats);
-			if (offset_puning_result.pruned_row_group_count > 0) {
-				// We can prune row groups and reduce the offset
+			if (offset_puning_result.pruned_row_group_count > 0 || offset_puning_result.leading_null_group_offset > 0) {
+				// We can prune row groups and/or reduce the offset by consuming definite NULL-only groups
 				logical_limit.offset_val =
 				    BoundLimitNode::ConstantValue(NumericCast<int64_t>(offset_puning_result.offset_remainder));
 

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -467,6 +467,7 @@ void RowGroupOrderOptions::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<OrderByColumnType>(104, "column_type", column_type);
 	serializer.WriteProperty<optional_idx>(105, "row_limit", row_limit);
 	serializer.WritePropertyWithDefault<idx_t>(106, "row_group_offset", row_group_offset);
+	serializer.WritePropertyWithDefault<idx_t>(107, "leading_null_group_offset", leading_null_group_offset);
 }
 
 unique_ptr<RowGroupOrderOptions> RowGroupOrderOptions::Deserialize(Deserializer &deserializer) {
@@ -477,7 +478,8 @@ unique_ptr<RowGroupOrderOptions> RowGroupOrderOptions::Deserialize(Deserializer 
 	auto column_type = deserializer.ReadProperty<OrderByColumnType>(104, "column_type");
 	auto row_limit = deserializer.ReadProperty<optional_idx>(105, "row_limit");
 	auto row_group_offset = deserializer.ReadPropertyWithDefault<idx_t>(106, "row_group_offset");
-	auto result = duckdb::unique_ptr<RowGroupOrderOptions>(new RowGroupOrderOptions(column_idx, order_by, order_type, null_order, column_type, row_limit, row_group_offset));
+	auto leading_null_group_offset = deserializer.ReadPropertyWithDefault<idx_t>(107, "leading_null_group_offset");
+	auto result = duckdb::unique_ptr<RowGroupOrderOptions>(new RowGroupOrderOptions(column_idx, order_by, order_type, null_order, column_type, row_limit, row_group_offset, leading_null_group_offset));
 	return result;
 }
 

--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -252,6 +252,7 @@ OffsetPruningResult RowGroupReorderer::GetOffsetAfterPruning(const OrderByStatis
 	multimap<Value, RowGroupOffsetEntry> ordered_row_groups;
 	idx_t new_row_offset = row_offset;
 	idx_t leading_null_group_offset = 0;
+	bool encountered_maybe_null_group = false;
 
 	for (auto &partition_stats : stats) {
 		if (partition_stats.count_type == CountType::COUNT_APPROXIMATE || !partition_stats.partition_row_group) {
@@ -275,15 +276,23 @@ OffsetPruningResult RowGroupReorderer::GetOffsetAfterPruning(const OrderByStatis
 				continue;
 			}
 			// The row group might still contribute ordered values, but we cannot position it safely.
+			if (null_order == OrderByNullType::NULLS_FIRST) {
+				encountered_maybe_null_group = true;
+				continue;
+			}
 			return {new_row_offset, 0, leading_null_group_offset};
 		}
 		if (null_order == OrderByNullType::NULLS_FIRST && column_stats->CanHaveNull()) {
 			// Groups that might contain NULLs are scanned before definitely non-null groups with NULLS_FIRST.
 			// Without exact NULL counts, they block further offset pruning into the non-null region.
-			return {new_row_offset, 0, leading_null_group_offset};
+			encountered_maybe_null_group = true;
+			continue;
 		}
 		auto entry = RowGroupOffsetEntry {partition_stats.count, std::move(column_stats)};
 		ordered_row_groups.emplace(comparison_value, std::move(entry));
+	}
+	if (null_order == OrderByNullType::NULLS_FIRST && encountered_maybe_null_group) {
+		return {new_row_offset, 0, leading_null_group_offset};
 	}
 
 	switch (order_type) {

--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -14,6 +14,10 @@ struct RowGroupOffsetEntry {
 	unique_ptr<BaseStatistics> stats;
 };
 
+bool IsNullOnly(const BaseStatistics &stats) {
+	return !stats.CanHaveNoNull();
+}
+
 bool CompareValues(const Value &v1, const Value &v2, const OrderByStatistics order) {
 	return (order == OrderByStatistics::MAX && v1 < v2) || (order == OrderByStatistics::MIN && v1 > v2);
 }
@@ -75,6 +79,9 @@ void AddRowGroups(multimap<Value, RowGroupSegmentNodeEntry> &row_group_map, It i
 			// Row groups do not overlap: we can guarantee that the tuples qualify
 			qualifying_tuples = last_unresolved_row_group_sum;
 			++last_unresolved_entry;
+			if (last_unresolved_entry == end) {
+				break;
+			}
 			auto &upcoming_row_group = last_unresolved_entry->second.row_group.get().GetNode();
 			auto &upcoming_stats = *last_unresolved_entry->second.stats;
 
@@ -88,10 +95,11 @@ void AddRowGroups(multimap<Value, RowGroupSegmentNodeEntry> &row_group_map, It i
 	}
 }
 
-template <typename It>
-It SkipOffsetPrunedRowGroups(It it, const idx_t row_group_offset) {
-	for (idx_t i = 0; i < row_group_offset; i++) {
+template <typename It, typename End>
+It SkipOffsetPrunedRowGroups(It it, End end, idx_t row_group_offset) {
+	while (row_group_offset > 0 && it != end) {
 		++it;
+		row_group_offset--;
 	}
 	return it;
 }
@@ -107,20 +115,23 @@ void SetRowGroupVector(multimap<Value, RowGroupSegmentNodeEntry> &row_group_map,
                        const idx_t row_group_offset, const OrderType order_type, const OrderByColumnType column_type,
                        vector<reference<SegmentNode<RowGroup>>> &ordered_row_groups) {
 	const auto stat_type = order_type == OrderType::ASCENDING ? OrderByStatistics::MIN : OrderByStatistics::MAX;
-	ordered_row_groups.reserve(row_group_map.size());
-
-	Value previous_key;
 	if (order_type == OrderType::ASCENDING) {
-		auto it = SkipOffsetPrunedRowGroups(row_group_map.begin(), row_group_offset);
 		auto end = row_group_map.end();
+		auto it = SkipOffsetPrunedRowGroups(row_group_map.begin(), end, row_group_offset);
+		if (it == end) {
+			return;
+		}
 		if (row_limit.IsValid()) {
 			AddRowGroups(row_group_map, it, end, ordered_row_groups, row_limit.GetIndex(), column_type, stat_type);
 		} else {
 			InsertAllRowGroups(it, end, ordered_row_groups);
 		}
 	} else {
-		auto it = SkipOffsetPrunedRowGroups(row_group_map.rbegin(), row_group_offset);
 		auto end = row_group_map.rend();
+		auto it = SkipOffsetPrunedRowGroups(row_group_map.rbegin(), end, row_group_offset);
+		if (it == end) {
+			return;
+		}
 		if (row_limit.IsValid()) {
 			AddRowGroups(row_group_map, it, end, ordered_row_groups, row_limit.GetIndex(), column_type, stat_type);
 		} else {
@@ -129,9 +140,19 @@ void SetRowGroupVector(multimap<Value, RowGroupSegmentNodeEntry> &row_group_map,
 	}
 }
 
+void AppendRowGroups(const vector<reference<SegmentNode<RowGroup>>> &source, idx_t offset,
+                     vector<reference<SegmentNode<RowGroup>>> &target) {
+	for (idx_t i = offset; i < source.size(); i++) {
+		target.push_back(source[i]);
+	}
+}
+
 template <typename It, typename End>
 OffsetPruningResult FindOffsetPrunableChunks(It it, End end, const OrderByStatistics order_by,
                                              const OrderByColumnType column_type, const idx_t row_offset) {
+	if (it == end) {
+		return {row_offset, 0, 0};
+	}
 	const auto opposite_stat_type =
 	    order_by == OrderByStatistics::MAX ? OrderByStatistics::MIN : OrderByStatistics::MAX;
 
@@ -164,6 +185,9 @@ OffsetPruningResult FindOffsetPrunableChunks(It it, End end, const OrderByStatis
 			new_row_offset -= last_unresolved_entry->second.count;
 
 			++last_unresolved_entry;
+			if (last_unresolved_entry == end) {
+				return {new_row_offset, pruned_row_group_count, 0};
+			}
 			auto &upcoming_stats = *last_unresolved_entry->second.stats;
 			last_unresolved_boundary = RowGroupReorderer::RetrieveStat(upcoming_stats, opposite_stat_type, column_type);
 		}
@@ -229,35 +253,55 @@ OffsetPruningResult RowGroupReorderer::GetOffsetAfterPruning(const OrderByStatis
                                                              const StorageIndex &storage_index, const idx_t row_offset,
                                                              vector<PartitionStatistics> &stats) {
 	multimap<Value, RowGroupOffsetEntry> ordered_row_groups;
+	idx_t new_row_offset = row_offset;
+	idx_t leading_null_group_offset = 0;
 
 	for (auto &partition_stats : stats) {
 		if (partition_stats.count_type == CountType::COUNT_APPROXIMATE || !partition_stats.partition_row_group) {
-			return {row_offset, 0};
+			return {row_offset, 0, 0};
 		}
 
 		auto column_stats = partition_stats.partition_row_group->GetColumnStatistics(storage_index);
+		if (null_order == OrderByNullType::NULLS_FIRST && IsNullOnly(*column_stats)) {
+			if (new_row_offset < partition_stats.count) {
+				return {new_row_offset, 0, leading_null_group_offset};
+			}
+			new_row_offset -= partition_stats.count;
+			leading_null_group_offset++;
+			continue;
+		}
 		Value comparison_value = RetrieveStat(*column_stats, order_by, column_type);
 		if (comparison_value.IsNull()) {
-			if (null_order == OrderByNullType::NULLS_LAST) {
+			if (null_order == OrderByNullType::NULLS_LAST && IsNullOnly(*column_stats)) {
 				// With NULLS_LAST, null-stats row groups are scanned after all non-null row groups.
 				// They fall outside the offset range being pruned here, so skip them.
 				continue;
 			}
-			// With NULLS_FIRST, null-stats row groups come first and would need to be counted
-			// toward the offset before non-null groups. This case is not yet supported.
-			return {row_offset, 0};
+			// The row group might still contribute ordered values, but we cannot position it safely.
+			return {new_row_offset, 0, leading_null_group_offset};
+		}
+		if (null_order == OrderByNullType::NULLS_FIRST && column_stats->CanHaveNull()) {
+			// Groups that might contain NULLs are scanned before definitely non-null groups with NULLS_FIRST.
+			// Without exact NULL counts, they block further offset pruning into the non-null region.
+			return {new_row_offset, 0, leading_null_group_offset};
 		}
 		auto entry = RowGroupOffsetEntry {partition_stats.count, std::move(column_stats)};
 		ordered_row_groups.emplace(comparison_value, std::move(entry));
 	}
 
 	switch (order_type) {
-	case OrderType::ASCENDING:
-		return FindOffsetPrunableChunks(ordered_row_groups.begin(), ordered_row_groups.end(), order_by, column_type,
-		                                row_offset);
-	case OrderType::DESCENDING:
-		return FindOffsetPrunableChunks(ordered_row_groups.rbegin(), ordered_row_groups.rend(), order_by, column_type,
-		                                row_offset);
+	case OrderType::ASCENDING: {
+		auto result = FindOffsetPrunableChunks(ordered_row_groups.begin(), ordered_row_groups.end(), order_by,
+		                                       column_type, new_row_offset);
+		result.leading_null_group_offset = leading_null_group_offset;
+		return result;
+	}
+	case OrderType::DESCENDING: {
+		auto result = FindOffsetPrunableChunks(ordered_row_groups.rbegin(), ordered_row_groups.rend(), order_by,
+		                                       column_type, new_row_offset);
+		result.leading_null_group_offset = leading_null_group_offset;
+		return result;
+	}
 	default:
 		throw InternalException("Unsupported order type in GetOffsetAfterPruning");
 	}
@@ -273,42 +317,40 @@ optional_ptr<SegmentNode<RowGroup>> RowGroupReorderer::GetRootSegment(RowGroupSe
 
 	initialized = true;
 
-	vector<reference<SegmentNode<RowGroup>>> remaining_row_groups;
+	vector<reference<SegmentNode<RowGroup>>> null_only_groups;
+	vector<reference<SegmentNode<RowGroup>>> ambiguous_groups;
 	multimap<Value, RowGroupSegmentNodeEntry> row_group_map;
 	for (auto &row_group : row_groups.SegmentNodes()) {
 		auto stats = row_group.GetNode().GetStatistics(options.column_idx);
+		if (IsNullOnly(*stats)) {
+			null_only_groups.push_back(row_group);
+			continue;
+		}
 		Value comparison_value = RetrieveStat(*stats, options.order_by, options.column_type);
-		if (comparison_value.IsNull()) {
-			// no stats for this row group - push to remaining
-			remaining_row_groups.push_back(row_group);
+		if (comparison_value.IsNull() || (options.null_order == OrderByNullType::NULLS_FIRST && stats->CanHaveNull())) {
+			// No trustworthy ordering statistics, or the row group might still contribute NULLs that must be scanned
+			// before definitely non-null groups with NULLS_FIRST.
+			ambiguous_groups.push_back(row_group);
 			continue;
 		}
 		auto entry = RowGroupSegmentNodeEntry {row_group, std::move(stats)};
 		row_group_map.emplace(comparison_value, std::move(entry));
 	}
 
-	if (row_group_map.empty()) {
-		// All row groups have unknown/null stats - scan them all without reordering
-		for (auto &remaining_row_group : remaining_row_groups) {
-			ordered_row_groups.push_back(remaining_row_group);
-		}
-		if (ordered_row_groups.empty()) {
-			return nullptr;
-		}
-		return ordered_row_groups[0].get();
+	if (options.null_order == OrderByNullType::NULLS_FIRST) {
+		AppendRowGroups(null_only_groups, options.leading_null_group_offset, ordered_row_groups);
+		AppendRowGroups(ambiguous_groups, 0, ordered_row_groups);
+		SetRowGroupVector(row_group_map, options.row_limit, options.row_group_offset, options.order_type,
+		                  options.column_type, ordered_row_groups);
+	} else {
+		SetRowGroupVector(row_group_map, options.row_limit, options.row_group_offset, options.order_type,
+		                  options.column_type, ordered_row_groups);
+		AppendRowGroups(ambiguous_groups, 0, ordered_row_groups);
+		AppendRowGroups(null_only_groups, 0, ordered_row_groups);
 	}
 
-	D_ASSERT(row_group_map.size() > options.row_group_offset);
-	SetRowGroupVector(row_group_map, options.row_limit, options.row_group_offset, options.order_type,
-	                  options.column_type, ordered_row_groups);
-	// Push null-stats row groups in the correct position based on null ordering
-	if (options.null_order == OrderByNullType::NULLS_FIRST) {
-		ordered_row_groups.insert(ordered_row_groups.begin(), remaining_row_groups.begin(), remaining_row_groups.end());
-	} else {
-		// NULLS_LAST: append null-stats row groups after sorted row groups
-		for (auto &remaining_row_group : remaining_row_groups) {
-			ordered_row_groups.push_back(remaining_row_group);
-		}
+	if (ordered_row_groups.empty()) {
+		return nullptr;
 	}
 
 	return ordered_row_groups[0].get();

--- a/src/storage/table/row_group_reorderer.cpp
+++ b/src/storage/table/row_group_reorderer.cpp
@@ -79,9 +79,6 @@ void AddRowGroups(multimap<Value, RowGroupSegmentNodeEntry> &row_group_map, It i
 			// Row groups do not overlap: we can guarantee that the tuples qualify
 			qualifying_tuples = last_unresolved_row_group_sum;
 			++last_unresolved_entry;
-			if (last_unresolved_entry == end) {
-				break;
-			}
 			auto &upcoming_row_group = last_unresolved_entry->second.row_group.get().GetNode();
 			auto &upcoming_stats = *last_unresolved_entry->second.stats;
 

--- a/test/sql/topn/test_top_n_nulls_first_row_group_reorderer_edge_cases.test
+++ b/test/sql/topn/test_top_n_nulls_first_row_group_reorderer_edge_cases.test
@@ -20,26 +20,18 @@ CREATE TABLE db.null_only_ints AS SELECT NULL::BIGINT AS i FROM range(2048)
 
 statement ok
 CREATE TABLE db.mixed_ints AS
-SELECT NULL::BIGINT AS i
+SELECT i FROM repeat(NULL::BIGINT, 1023) t(i)
 UNION ALL
-SELECT i FROM repeat(NULL::BIGINT, 1022) t(i)
-UNION ALL
-SELECT 1
-UNION ALL
-SELECT i FROM repeat(1::BIGINT, 1024) t(i)
+SELECT i FROM repeat(1::BIGINT, 1025) t(i)
 
 statement ok
 CREATE TABLE db.null_only_strings AS SELECT NULL::VARCHAR AS s FROM range(2048)
 
 statement ok
 CREATE TABLE db.mixed_strings AS
-SELECT NULL::VARCHAR AS s
+SELECT s FROM repeat(NULL::VARCHAR, 1023) t(s)
 UNION ALL
-SELECT s FROM repeat(NULL::VARCHAR, 1022) t(s)
-UNION ALL
-SELECT 'a'
-UNION ALL
-SELECT s FROM repeat('a', 1024) t(s)
+SELECT s FROM repeat('a', 1025) t(s)
 
 statement ok
 CHECKPOINT

--- a/test/sql/topn/test_top_n_nulls_first_row_group_reorderer_edge_cases.test
+++ b/test/sql/topn/test_top_n_nulls_first_row_group_reorderer_edge_cases.test
@@ -1,0 +1,90 @@
+# name: test/sql/topn/test_top_n_nulls_first_row_group_reorderer_edge_cases.test
+# description: Edge cases for NULLS FIRST row group reorderer when no ordered row groups remain
+# group: [topn]
+
+require no_alternative_verify
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+SET threads TO 1
+
+load __TEST_DIR__/top_n_nulls_first_row_group_reorderer_edge_cases_main.duckdb
+
+statement ok
+ATTACH '__TEST_DIR__/top_n_nulls_first_row_group_reorderer_edge_cases_data.duckdb' AS db (ROW_GROUP_SIZE 2048)
+
+statement ok
+CREATE TABLE db.null_only_ints AS SELECT NULL::BIGINT AS i FROM range(2048)
+
+statement ok
+CREATE TABLE db.mixed_ints AS
+SELECT NULL::BIGINT AS i
+UNION ALL
+SELECT i FROM repeat(NULL::BIGINT, 1022) t(i)
+UNION ALL
+SELECT 1
+UNION ALL
+SELECT i FROM repeat(1::BIGINT, 1024) t(i)
+
+statement ok
+CREATE TABLE db.null_only_strings AS SELECT NULL::VARCHAR AS s FROM range(2048)
+
+statement ok
+CREATE TABLE db.mixed_strings AS
+SELECT NULL::VARCHAR AS s
+UNION ALL
+SELECT s FROM repeat(NULL::VARCHAR, 1022) t(s)
+UNION ALL
+SELECT 'a'
+UNION ALL
+SELECT s FROM repeat('a', 1024) t(s)
+
+statement ok
+CHECKPOINT
+
+restart
+
+statement ok
+ATTACH '__TEST_DIR__/top_n_nulls_first_row_group_reorderer_edge_cases_data.duckdb' AS db
+
+query II
+EXPLAIN ANALYZE SELECT i FROM db.null_only_ints ORDER BY i NULLS FIRST LIMIT 1
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
+
+query I
+SELECT i FROM db.null_only_ints ORDER BY i NULLS FIRST LIMIT 1
+----
+NULL
+
+query II
+EXPLAIN ANALYZE SELECT i FROM db.mixed_ints ORDER BY i NULLS FIRST LIMIT 1
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
+
+query I
+SELECT i FROM db.mixed_ints ORDER BY i NULLS FIRST LIMIT 1 OFFSET 1023
+----
+1
+
+query II
+EXPLAIN ANALYZE SELECT s FROM db.null_only_strings ORDER BY s NULLS FIRST LIMIT 1
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
+
+query T
+SELECT s FROM db.null_only_strings ORDER BY s NULLS FIRST LIMIT 1
+----
+NULL
+
+query II
+EXPLAIN ANALYZE SELECT s FROM db.mixed_strings ORDER BY s NULLS FIRST LIMIT 1
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
+
+query T
+SELECT s FROM db.mixed_strings ORDER BY s NULLS FIRST LIMIT 1 OFFSET 1023
+----
+a

--- a/test/sql/topn/test_top_n_nulls_row_group_pruner_extensive.test
+++ b/test/sql/topn/test_top_n_nulls_row_group_pruner_extensive.test
@@ -121,6 +121,18 @@ INSERT INTO db.scattered_nulls_${type} SELECT NULL::${type} AS v FROM range(2048
 statement ok
 INSERT INTO db.scattered_nulls_${type} SELECT CAST('2' AS ${type}) AS v FROM range(2048)
 
+statement ok
+CREATE TABLE db.all_null_offset_${type} AS
+SELECT i FROM repeat(NULL::${type}, 2048) t(i);
+
+statement ok
+INSERT INTO db.all_null_offset_${type}
+SELECT i FROM repeat(NULL::${type}, 2048) t(i);
+
+statement ok
+INSERT INTO db.all_null_offset_${type}
+SELECT i FROM repeat(NULL::${type}, 2048) t(i);
+
 endloop
 
 restart
@@ -313,3 +325,72 @@ query T
 SELECT v FROM db.scattered_nulls_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 ----
 NULL
+
+query II
+EXPLAIN ANALYZE
+SELECT i
+FROM db.all_null_offset_BIGINT
+ORDER BY i NULLS FIRST
+LIMIT 1 OFFSET 4096;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
+
+query I
+SELECT i
+FROM db.all_null_offset_BIGINT
+ORDER BY i NULLS FIRST
+LIMIT 1 OFFSET 4096;
+----
+NULL
+
+query II
+EXPLAIN ANALYZE
+SELECT i
+FROM db.all_null_offset_BIGINT
+ORDER BY i NULLS FIRST
+LIMIT 1 OFFSET 4095;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*4,096 rows.*
+
+query I
+SELECT i
+FROM db.all_null_offset_BIGINT
+ORDER BY i NULLS FIRST
+LIMIT 1 OFFSET 4095;
+----
+NULL
+
+query II
+EXPLAIN ANALYZE
+SELECT i
+FROM db.all_null_offset_VARCHAR
+ORDER BY i NULLS FIRST
+LIMIT 1 OFFSET 4096;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
+
+query I
+SELECT i
+FROM db.all_null_offset_VARCHAR
+ORDER BY i NULLS FIRST
+LIMIT 1 OFFSET 4096;
+----
+NULL
+
+query II
+EXPLAIN ANALYZE
+SELECT i
+FROM db.all_null_offset_VARCHAR
+ORDER BY i NULLS FIRST
+LIMIT 1 OFFSET 4095;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*4,096 rows.*
+
+query I
+SELECT i
+FROM db.all_null_offset_VARCHAR
+ORDER BY i NULLS FIRST
+LIMIT 1 OFFSET 4095;
+----
+NULL
+

--- a/test/sql/topn/test_top_n_nulls_row_group_pruner_extensive.test
+++ b/test/sql/topn/test_top_n_nulls_row_group_pruner_extensive.test
@@ -108,6 +108,19 @@ SELECT CASE WHEN i < 1023 THEN NULL ELSE CAST('1' AS ${type}) END AS v FROM rang
 statement ok
 INSERT INTO db.null_mixed_value_${type} SELECT CAST('2' AS ${type}) AS v FROM range(2048)
 
+statement ok
+CREATE TABLE db.scattered_nulls_${type} AS SELECT NULL::${type} AS v FROM range(2048)
+
+statement ok
+INSERT INTO db.scattered_nulls_${type}
+SELECT CASE WHEN i < 1023 THEN NULL ELSE CAST('1' AS ${type}) END AS v FROM range(2048) tbl(i)
+
+statement ok
+INSERT INTO db.scattered_nulls_${type} SELECT NULL::${type} AS v FROM range(2048)
+
+statement ok
+INSERT INTO db.scattered_nulls_${type} SELECT CAST('2' AS ${type}) AS v FROM range(2048)
+
 endloop
 
 restart
@@ -204,7 +217,7 @@ NULL
 query II
 EXPLAIN ANALYZE SELECT v FROM db.null_prefix_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 ----
-analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
 
 query I
 SELECT v FROM db.null_prefix_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
@@ -214,7 +227,7 @@ SELECT v FROM db.null_prefix_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 query II
 EXPLAIN ANALYZE SELECT v FROM db.null_prefix_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 ----
-analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
 
 query T
 SELECT v FROM db.null_prefix_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
@@ -224,7 +237,7 @@ SELECT v FROM db.null_prefix_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 query II
 EXPLAIN ANALYZE SELECT v FROM db.null_then_values_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 ----
-analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
 
 query I
 SELECT v FROM db.null_then_values_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
@@ -244,7 +257,7 @@ SELECT v FROM db.null_then_values_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 6
 query II
 EXPLAIN ANALYZE SELECT v FROM db.null_then_values_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 ----
-analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
 
 query T
 SELECT v FROM db.null_then_values_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
@@ -264,7 +277,7 @@ SELECT v FROM db.null_then_values_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 
 query II
 EXPLAIN ANALYZE SELECT v FROM db.null_mixed_value_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 2048
 ----
-analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*4,096 rows.*
 
 query I
 SELECT v FROM db.null_mixed_value_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 2048
@@ -274,9 +287,29 @@ NULL
 query II
 EXPLAIN ANALYZE SELECT v FROM db.null_mixed_value_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 2048
 ----
-analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*4,096 rows.*
 
 query T
 SELECT v FROM db.null_mixed_value_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 2048
+----
+NULL
+
+query II
+EXPLAIN ANALYZE SELECT v FROM db.scattered_nulls_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*4,096 rows.*
+
+query I
+SELECT v FROM db.scattered_nulls_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
+----
+NULL
+
+query II
+EXPLAIN ANALYZE SELECT v FROM db.scattered_nulls_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*4,096 rows.*
+
+query T
+SELECT v FROM db.scattered_nulls_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 ----
 NULL

--- a/test/sql/topn/test_top_n_nulls_row_group_pruner_extensive.test
+++ b/test/sql/topn/test_top_n_nulls_row_group_pruner_extensive.test
@@ -17,100 +17,98 @@ statement ok
 ATTACH '__TEST_DIR__/top_n_nulls_row_group_pruner_extensive_data.duckdb' AS db (ROW_GROUP_SIZE 2048)
 
 statement ok
-CREATE TABLE db.ints(i BIGINT)
+CREATE TABLE db.ints AS SELECT CASE WHEN i = 0 THEN 0 ELSE 3 END AS i FROM range(2048) tbl(i)
 
 statement ok
-INSERT INTO db.ints SELECT 0 i UNION ALL SELECT i FROM repeat(3, 2047) t1(i)
+INSERT INTO db.ints SELECT CASE WHEN i = 0 THEN 0 ELSE 3 END AS i FROM range(2048) tbl(i)
 
 statement ok
-INSERT INTO db.ints SELECT 0 i UNION ALL SELECT i FROM repeat(3, 2047) t1(i)
+INSERT INTO db.ints SELECT CASE WHEN i = 0 THEN 1 ELSE 5 END AS i FROM range(2048) tbl(i)
 
 statement ok
-INSERT INTO db.ints SELECT 1 i UNION ALL SELECT i FROM repeat(5, 2047) t1(i)
+INSERT INTO db.ints SELECT CASE WHEN i = 2047 THEN 6 ELSE 4 END AS i FROM range(2048) tbl(i)
 
 statement ok
-INSERT INTO db.ints SELECT i FROM repeat(4, 2047) t1(i) UNION ALL SELECT 6 i
-
-statement ok
-INSERT INTO db.ints SELECT 7 i UNION ALL SELECT i FROM repeat(8, 2047) t1(i)
+INSERT INTO db.ints SELECT CASE WHEN i = 0 THEN 7 ELSE 8 END AS i FROM range(2048) tbl(i)
 
 statement ok
 INSERT INTO db.ints SELECT i FROM repeat(NULL, 2048) t1(i)
 
 statement ok
-INSERT INTO db.ints SELECT 9 i UNION ALL SELECT i FROM repeat(NULL, 2046) t1(i) UNION ALL SELECT 10 i
+INSERT INTO db.ints
+SELECT CASE WHEN i = 0 THEN 9 WHEN i = 2047 THEN 10 ELSE NULL END AS i FROM range(2048) tbl(i)
 
 statement ok
-CREATE TABLE db.strings(s VARCHAR)
+CREATE TABLE db.strings AS SELECT CASE WHEN i = 0 THEN 'a' ELSE 'd' END AS s FROM range(2048) tbl(i)
 
 statement ok
-INSERT INTO db.strings SELECT 'a' s UNION ALL SELECT s FROM repeat('d', 2047) t1(s)
+INSERT INTO db.strings SELECT CASE WHEN i = 0 THEN 'a' ELSE 'd' END AS s FROM range(2048) tbl(i)
 
 statement ok
-INSERT INTO db.strings SELECT 'a' s UNION ALL SELECT s FROM repeat('d', 2047) t1(s)
+INSERT INTO db.strings SELECT CASE WHEN i = 0 THEN 'b' ELSE 'f' END AS s FROM range(2048) tbl(i)
 
 statement ok
-INSERT INTO db.strings SELECT 'b' s UNION ALL SELECT s FROM repeat('f', 2047) t1(s)
+INSERT INTO db.strings SELECT CASE WHEN i = 2047 THEN 'g' ELSE 'e' END AS s FROM range(2048) tbl(i)
 
 statement ok
-INSERT INTO db.strings SELECT s FROM repeat('e', 2047) t1(s) UNION ALL SELECT 'g' s
-
-statement ok
-INSERT INTO db.strings SELECT 'h' s UNION ALL SELECT s FROM repeat('i', 2047) t1(s)
+INSERT INTO db.strings SELECT CASE WHEN i = 0 THEN 'h' ELSE 'i' END AS s FROM range(2048) tbl(i)
 
 statement ok
 INSERT INTO db.strings SELECT s FROM repeat(NULL, 2048) t1(s)
 
 statement ok
-INSERT INTO db.strings SELECT 'j' s UNION ALL SELECT s FROM repeat(NULL, 2046) t1(s) UNION ALL SELECT 'k' s
+INSERT INTO db.strings
+SELECT CASE WHEN i = 0 THEN 'j' WHEN i = 2047 THEN 'k' ELSE NULL END AS s FROM range(2048) tbl(i)
 
 statement ok
-CREATE TABLE db.offset_boundary(i BIGINT)
+CREATE TABLE db.offset_boundary AS SELECT 0 AS i FROM range(2048)
 
 statement ok
-INSERT INTO db.offset_boundary SELECT 0 i UNION ALL SELECT i FROM repeat(0, 2047) t(i)
+INSERT INTO db.offset_boundary SELECT 1 AS i FROM range(2048)
 
 statement ok
-INSERT INTO db.offset_boundary SELECT 1 i UNION ALL SELECT i FROM repeat(1, 2047) t(i)
-
-statement ok
-INSERT INTO db.offset_boundary SELECT 2 i UNION ALL SELECT i FROM repeat(2, 2047) t(i)
+INSERT INTO db.offset_boundary SELECT 2 AS i FROM range(2048)
 
 statement ok
 INSERT INTO db.offset_boundary SELECT NULL::BIGINT FROM range(2048)
 
-statement ok
-CREATE TABLE db.null_prefix_ints(i BIGINT)
+foreach type BIGINT VARCHAR
 
 statement ok
-INSERT INTO db.null_prefix_ints SELECT NULL::BIGINT FROM range(2048)
+CREATE TABLE db.null_prefix_${type} AS SELECT NULL::${type} AS v FROM range(2048)
 
 statement ok
-INSERT INTO db.null_prefix_ints SELECT NULL::BIGINT FROM range(2048)
+INSERT INTO db.null_prefix_${type} SELECT NULL::${type} AS v FROM range(2048)
 
 statement ok
-INSERT INTO db.null_prefix_ints SELECT 1 i UNION ALL SELECT i FROM repeat(1, 2047) t(i)
+INSERT INTO db.null_prefix_${type} SELECT CAST('1' AS ${type}) AS v FROM range(2048)
 
 statement ok
-INSERT INTO db.null_prefix_ints SELECT 2 i UNION ALL SELECT i FROM repeat(2, 2047) t(i)
+INSERT INTO db.null_prefix_${type} SELECT CAST('2' AS ${type}) AS v FROM range(2048)
 
 statement ok
-CREATE TABLE db.null_prefix_strings(s VARCHAR)
+CREATE TABLE db.null_then_values_${type} AS SELECT NULL::${type} AS v FROM range(2048)
 
 statement ok
-INSERT INTO db.null_prefix_strings SELECT NULL::VARCHAR FROM range(2048)
+INSERT INTO db.null_then_values_${type} SELECT NULL::${type} AS v FROM range(2048)
 
 statement ok
-INSERT INTO db.null_prefix_strings SELECT NULL::VARCHAR FROM range(2048)
+INSERT INTO db.null_then_values_${type} SELECT CAST('1' AS ${type}) AS v FROM range(2048)
 
 statement ok
-INSERT INTO db.null_prefix_strings SELECT 'a' s UNION ALL SELECT s FROM repeat('a', 2047) t(s)
+INSERT INTO db.null_then_values_${type} SELECT CAST('2' AS ${type}) AS v FROM range(2048)
 
 statement ok
-INSERT INTO db.null_prefix_strings SELECT 'b' s UNION ALL SELECT s FROM repeat('b', 2047) t(s)
+CREATE TABLE db.null_mixed_value_${type} AS SELECT NULL::${type} AS v FROM range(2048)
 
 statement ok
-CHECKPOINT
+INSERT INTO db.null_mixed_value_${type}
+SELECT CASE WHEN i < 1023 THEN NULL ELSE CAST('1' AS ${type}) END AS v FROM range(2048) tbl(i)
+
+statement ok
+INSERT INTO db.null_mixed_value_${type} SELECT CAST('2' AS ${type}) AS v FROM range(2048)
+
+endloop
 
 restart
 
@@ -204,21 +202,81 @@ SELECT i FROM db.offset_boundary ORDER BY i NULLS LAST LIMIT 1 OFFSET 6144
 NULL
 
 query II
-EXPLAIN ANALYZE SELECT i FROM db.null_prefix_ints ORDER BY i NULLS FIRST LIMIT 1 OFFSET 4096
+EXPLAIN ANALYZE SELECT v FROM db.null_prefix_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 ----
 analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
 
 query I
-SELECT i FROM db.null_prefix_ints ORDER BY i NULLS FIRST LIMIT 1 OFFSET 4096
+SELECT v FROM db.null_prefix_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 ----
 1
 
 query II
-EXPLAIN ANALYZE SELECT s FROM db.null_prefix_strings ORDER BY s NULLS FIRST LIMIT 1 OFFSET 4096
+EXPLAIN ANALYZE SELECT v FROM db.null_prefix_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 ----
 analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
 
 query T
-SELECT s FROM db.null_prefix_strings ORDER BY s NULLS FIRST LIMIT 1 OFFSET 4096
+SELECT v FROM db.null_prefix_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
 ----
-a
+1
+
+query II
+EXPLAIN ANALYZE SELECT v FROM db.null_then_values_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+
+query I
+SELECT v FROM db.null_then_values_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
+----
+1
+
+query II
+EXPLAIN ANALYZE SELECT v FROM db.null_then_values_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 6144
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
+
+query I
+SELECT v FROM db.null_then_values_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 6144
+----
+2
+
+query II
+EXPLAIN ANALYZE SELECT v FROM db.null_then_values_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+
+query T
+SELECT v FROM db.null_then_values_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 4096
+----
+1
+
+query II
+EXPLAIN ANALYZE SELECT v FROM db.null_then_values_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 6144
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*2,048 rows.*
+
+query T
+SELECT v FROM db.null_then_values_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 6144
+----
+2
+
+query II
+EXPLAIN ANALYZE SELECT v FROM db.null_mixed_value_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 2048
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+
+query I
+SELECT v FROM db.null_mixed_value_BIGINT ORDER BY v NULLS FIRST LIMIT 1 OFFSET 2048
+----
+NULL
+
+query II
+EXPLAIN ANALYZE SELECT v FROM db.null_mixed_value_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 2048
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+
+query T
+SELECT v FROM db.null_mixed_value_VARCHAR ORDER BY v NULLS FIRST LIMIT 1 OFFSET 2048
+----
+NULL

--- a/test/sql/topn/test_top_n_nulls_row_group_pruner_extensive.test
+++ b/test/sql/topn/test_top_n_nulls_row_group_pruner_extensive.test
@@ -1,0 +1,224 @@
+# name: test/sql/topn/test_top_n_nulls_row_group_pruner_extensive.test
+# description: More extensive persisted row group pruner coverage for null-only and mixed-null row groups
+# group: [topn]
+
+# Alternative verify disables the offset pruning in the optimizer rule
+require no_alternative_verify
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+SET threads TO 1
+
+load __TEST_DIR__/top_n_nulls_row_group_pruner_extensive_main.duckdb
+
+statement ok
+ATTACH '__TEST_DIR__/top_n_nulls_row_group_pruner_extensive_data.duckdb' AS db (ROW_GROUP_SIZE 2048)
+
+statement ok
+CREATE TABLE db.ints(i BIGINT)
+
+statement ok
+INSERT INTO db.ints SELECT 0 i UNION ALL SELECT i FROM repeat(3, 2047) t1(i)
+
+statement ok
+INSERT INTO db.ints SELECT 0 i UNION ALL SELECT i FROM repeat(3, 2047) t1(i)
+
+statement ok
+INSERT INTO db.ints SELECT 1 i UNION ALL SELECT i FROM repeat(5, 2047) t1(i)
+
+statement ok
+INSERT INTO db.ints SELECT i FROM repeat(4, 2047) t1(i) UNION ALL SELECT 6 i
+
+statement ok
+INSERT INTO db.ints SELECT 7 i UNION ALL SELECT i FROM repeat(8, 2047) t1(i)
+
+statement ok
+INSERT INTO db.ints SELECT i FROM repeat(NULL, 2048) t1(i)
+
+statement ok
+INSERT INTO db.ints SELECT 9 i UNION ALL SELECT i FROM repeat(NULL, 2046) t1(i) UNION ALL SELECT 10 i
+
+statement ok
+CREATE TABLE db.strings(s VARCHAR)
+
+statement ok
+INSERT INTO db.strings SELECT 'a' s UNION ALL SELECT s FROM repeat('d', 2047) t1(s)
+
+statement ok
+INSERT INTO db.strings SELECT 'a' s UNION ALL SELECT s FROM repeat('d', 2047) t1(s)
+
+statement ok
+INSERT INTO db.strings SELECT 'b' s UNION ALL SELECT s FROM repeat('f', 2047) t1(s)
+
+statement ok
+INSERT INTO db.strings SELECT s FROM repeat('e', 2047) t1(s) UNION ALL SELECT 'g' s
+
+statement ok
+INSERT INTO db.strings SELECT 'h' s UNION ALL SELECT s FROM repeat('i', 2047) t1(s)
+
+statement ok
+INSERT INTO db.strings SELECT s FROM repeat(NULL, 2048) t1(s)
+
+statement ok
+INSERT INTO db.strings SELECT 'j' s UNION ALL SELECT s FROM repeat(NULL, 2046) t1(s) UNION ALL SELECT 'k' s
+
+statement ok
+CREATE TABLE db.offset_boundary(i BIGINT)
+
+statement ok
+INSERT INTO db.offset_boundary SELECT 0 i UNION ALL SELECT i FROM repeat(0, 2047) t(i)
+
+statement ok
+INSERT INTO db.offset_boundary SELECT 1 i UNION ALL SELECT i FROM repeat(1, 2047) t(i)
+
+statement ok
+INSERT INTO db.offset_boundary SELECT 2 i UNION ALL SELECT i FROM repeat(2, 2047) t(i)
+
+statement ok
+INSERT INTO db.offset_boundary SELECT NULL::BIGINT FROM range(2048)
+
+statement ok
+CREATE TABLE db.null_prefix_ints(i BIGINT)
+
+statement ok
+INSERT INTO db.null_prefix_ints SELECT NULL::BIGINT FROM range(2048)
+
+statement ok
+INSERT INTO db.null_prefix_ints SELECT NULL::BIGINT FROM range(2048)
+
+statement ok
+INSERT INTO db.null_prefix_ints SELECT 1 i UNION ALL SELECT i FROM repeat(1, 2047) t(i)
+
+statement ok
+INSERT INTO db.null_prefix_ints SELECT 2 i UNION ALL SELECT i FROM repeat(2, 2047) t(i)
+
+statement ok
+CREATE TABLE db.null_prefix_strings(s VARCHAR)
+
+statement ok
+INSERT INTO db.null_prefix_strings SELECT NULL::VARCHAR FROM range(2048)
+
+statement ok
+INSERT INTO db.null_prefix_strings SELECT NULL::VARCHAR FROM range(2048)
+
+statement ok
+INSERT INTO db.null_prefix_strings SELECT 'a' s UNION ALL SELECT s FROM repeat('a', 2047) t(s)
+
+statement ok
+INSERT INTO db.null_prefix_strings SELECT 'b' s UNION ALL SELECT s FROM repeat('b', 2047) t(s)
+
+statement ok
+CHECKPOINT
+
+restart
+
+statement ok
+ATTACH '__TEST_DIR__/top_n_nulls_row_group_pruner_extensive_data.duckdb' AS db
+
+query II
+EXPLAIN ANALYZE SELECT i FROM db.ints ORDER BY i NULLS LAST LIMIT 2
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*4,096 rows.*
+
+query I
+SELECT i FROM db.ints ORDER BY i NULLS LAST LIMIT 2
+----
+0
+0
+
+query II
+EXPLAIN ANALYZE SELECT i FROM db.ints ORDER BY i DESC NULLS LAST LIMIT 3
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+
+query I
+SELECT i FROM db.ints ORDER BY i DESC NULLS LAST LIMIT 3
+----
+10
+9
+8
+
+query II
+EXPLAIN ANALYZE SELECT i FROM db.ints ORDER BY i NULLS FIRST LIMIT 1
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*8,192 rows.*
+
+query I
+SELECT i FROM db.ints ORDER BY i NULLS FIRST LIMIT 1
+----
+NULL
+
+query I
+SELECT i FROM db.ints ORDER BY i NULLS LAST LIMIT 1 OFFSET 10242
+----
+NULL
+
+query II
+EXPLAIN ANALYZE SELECT s FROM db.strings ORDER BY s NULLS LAST LIMIT 2
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*4,096 rows.*
+
+query T
+SELECT s FROM db.strings ORDER BY s NULLS LAST LIMIT 2
+----
+a
+a
+
+query II
+EXPLAIN ANALYZE SELECT s FROM db.strings ORDER BY s DESC NULLS LAST LIMIT 3
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+
+query T
+SELECT s FROM db.strings ORDER BY s DESC NULLS LAST LIMIT 3
+----
+k
+j
+i
+
+query II
+EXPLAIN ANALYZE SELECT s FROM db.strings ORDER BY s NULLS FIRST LIMIT 1
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*8,192 rows.*
+
+query T
+SELECT s FROM db.strings ORDER BY s NULLS FIRST LIMIT 1
+----
+NULL
+
+query T
+SELECT s FROM db.strings ORDER BY s NULLS LAST LIMIT 1 OFFSET 10242
+----
+NULL
+
+query II
+EXPLAIN ANALYZE SELECT i FROM db.offset_boundary ORDER BY i NULLS LAST LIMIT 1 OFFSET 6144
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*4,096 rows.*
+
+query I
+SELECT i FROM db.offset_boundary ORDER BY i NULLS LAST LIMIT 1 OFFSET 6144
+----
+NULL
+
+query II
+EXPLAIN ANALYZE SELECT i FROM db.null_prefix_ints ORDER BY i NULLS FIRST LIMIT 1 OFFSET 4096
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+
+query I
+SELECT i FROM db.null_prefix_ints ORDER BY i NULLS FIRST LIMIT 1 OFFSET 4096
+----
+1
+
+query II
+EXPLAIN ANALYZE SELECT s FROM db.null_prefix_strings ORDER BY s NULLS FIRST LIMIT 1 OFFSET 4096
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*6,144 rows.*
+
+query T
+SELECT s FROM db.null_prefix_strings ORDER BY s NULLS FIRST LIMIT 1 OFFSET 4096
+----
+a


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/7338
fixes https://github.com/duckdblabs/duckdb-internal/issues/7710

With this PR, we enable row group pruning for `NULLS_FIRST` and `NULLS_LAST` ordering. For that, row groups are now categorized as either "regular", ambiguous, or null-only. The regular group contains row groups without nulls, and the ambiguous group contains row groups with unknown statistics, and if `NULLS_FIRST` also row groups that definitely have nulls and non-nulls.

The row groups are ordered as follows:
- `NULLS_FIRST`: null-only, ambiguous, regular
- `NULLS_LAST`: regular, ambiguous, null-only

The central constraint here is that we can only offset-prune beyond the first set of row groups if the ambiguous group is empty. I think it should be possible at some point to prune even more aggressively for the mixed groups in the `NULLS_FIRST` case by computing lower and upper bounds for the null counts at each `i`th row group. But I would opt for the safer option for now.
