### PR TITLE
Flush remaining operators in pipeline

### DIFF
--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -112,14 +112,12 @@ bool PipelineExecutor::TryFlushCachingOperators(ExecutionBudget &chunk_budget) {
 			return false;
 		}
 		case OperatorResultType::NEED_MORE_INPUT:
-			continue;
 		case OperatorResultType::FINISHED:
 			break;
 		default:
 			throw InternalException("Unexpected OperatorResultType (%s) in TryFlushCachingOperators",
 			                        EnumUtil::ToString(push_result));
 		}
-		break;
 	}
 	return true;
 }


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/8387 and https://github.com/duckdblabs/motherduck/issues/471

The flushing loop could exit prematurely when an operator returned `FINISHED`, leaving buffered output unflushed.