### PR TITLE
Flush remaining operators in pipeline

### DIFF
--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -111,14 +111,12 @@ bool PipelineExecutor::TryFlushCachingOperators(ExecutionBudget &chunk_budget) {
 			return false;
 		}
 		case OperatorResultType::NEED_MORE_INPUT:
-			continue;
 		case OperatorResultType::FINISHED:
 			break;
 		default:
 			throw InternalException("Unexpected OperatorResultType (%s) in TryFlushCachingOperators",
 			                        EnumUtil::ToString(push_result));
 		}
-		break;
 	}
 	return true;
 }

--- a/test/sql/limit/streaming_limit_pipeline_flush.test
+++ b/test/sql/limit/streaming_limit_pipeline_flush.test
@@ -1,0 +1,30 @@
+# name: test/sql/limit/streaming_limit_pipeline_flush.test
+# description: Test that pipeline correctly flushes operators after STREAMING_LIMIT finishes
+# group: [limit]
+
+require tpch
+
+statement ok
+LOAD tpch;
+
+statement ok
+CALL dbgen(sf=0.01);
+
+# The optimizer pushes down filters which reduces cardinality estimates, causing it to
+# place STREAMING_LIMIT on the right side. We disable it to keep it on the left side, to trigger the pipeline flush bug
+statement ok
+PRAGMA disable_optimizer;
+
+query I
+SELECT o.o_orderkey
+FROM (
+    SELECT l.o_orderkey
+    FROM orders l
+    LEFT JOIN lineitem li ON li.l_orderkey = l.o_orderkey
+    WHERE l.o_orderkey = 1
+    LIMIT 1
+) AS filtered
+JOIN orders o ON TRUE
+WHERE o.o_orderkey = 1;
+----
+1


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/8387 and https://github.com/duckdblabs/motherduck/issues/471

The flushing loop could exit prematurely when an operator returned `FINISHED`, leaving buffered output unflushed.