### PR TITLE
Fix #21289: correctly determine render width of UTF8 string with grapheme clusters

### DIFF
--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -397,13 +397,12 @@ size_t Utf8Proc::RenderWidth(const char *s, size_t len, size_t pos) {
 
 size_t Utf8Proc::RenderWidth(const std::string &str) {
 	size_t render_width = 0;
-	size_t pos = 0;
-	while (pos < str.size()) {
-		int sz;
-		auto codepoint = Utf8Proc::UTF8ToCodepoint(str.c_str() + pos, sz);
-		auto properties = duckdb::utf8proc_get_property(codepoint);
-		render_width += properties->charwidth;
-		pos += sz;
+	for (auto cluster : Utf8Proc::GraphemeClusters(str.c_str(), str.size())) {
+		// use the width of the first codepoint in the grapheme cluster
+		// combining marks, ZWJ, variation selectors, etc. have charwidth 0
+		// and multi-codepoint clusters (e.g. ZWJ emoji sequences) should only
+		// count the base character's width, not the sum of all codepoints
+		render_width += Utf8Proc::RenderWidth(str.c_str(), str.size(), cluster.start);
 	}
 	return render_width;
 }

--- a/tools/shell/tests/test_large_value_rendering.py
+++ b/tools/shell/tests/test_large_value_rendering.py
@@ -222,4 +222,18 @@ def test_json_special_characters(shell):
     for key in keys:
         assert re.search(f'│\\s+["]{key}["]:', result.stdout) is not None
 
+def test_duckbox_grapheme_clusters(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".maxwidth 80")
+        .statement("""
+FROM (VALUES
+    ('Write a short Threads post (2 punchy sentences) for an English tech-news account about Google launching “Personal Intelligence” as a new layer in AI Mode. Include: a hook-style alert/opening, explain that it lets Search “connect the dots” across a user’s Google apps to tailor answers to their context, note it began in the Gemini app, and say it’s now rolling out inside AI Mode in Search for Google AI Pro and Ultra subscribers as a Labs experiment in the U.S. Keep it concise, newsy, and matter-of-fact. No links. Use one 🚨 emoji at the start.'),
+    ('Write a short Threads post for an English tech-news account about the US government officially designating AI company Anthropic a “supply chain risk.” Start with a punchy hook and include the 🇺🇸 flag emoji. Clearly state the designation and explain why it’s notable: the label is typically reserved for foreign enemies/adversaries and hasn’t been applied to a US company before. Keep it concise (2–3 sentences), breaking lines for emphasis. Tone: urgent, newsy, slightly incredulous. No extra context, no links, no hashtags, no CTA.')
+);"""
+        )
+    )
+    result = test.run()
+    result.check_stdout("🇺🇸 flag")
+
 # fmt: on


### PR DESCRIPTION
Fixes #21289

The issue came from a mis-aligned render width popping up due to `Utf8Proc::RenderWidth` not correctly taking grapheme clusters into account, when `BoxRenderer::TruncateValue` did correctly take them into account.