### PR TITLE
Avoid calling PushCollation in create_sort_key

### DIFF
--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -45,10 +45,6 @@ unique_ptr<FunctionData> CreateSortKeyBind(ClientContext &context, ScalarFunctio
 		auto sort_specifier_str = sort_specifier.ToString();
 		result->modifiers.push_back(OrderModifiers::Parse(sort_specifier_str));
 	}
-	// push collations
-	for (idx_t i = 0; i < arguments.size(); i += 2) {
-		ExpressionBinder::PushCollation(context, arguments[i], arguments[i]->return_type);
-	}
 	// check if all types are constant
 	bool all_constant = true;
 	idx_t constant_size = 0;


### PR DESCRIPTION
Avoids applying collations twice when sort keys are used in the `ORDER BY`. 