### PR TITLE
fix(adbc): support concurrent statements on the same connection

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -112,6 +112,7 @@ enum class IngestionMode { CREATE = 0, APPEND = 1, REPLACE = 2, CREATE_APPEND = 
 
 struct DuckDBAdbcStatementWrapper {
 	duckdb_connection connection;
+	duckdb::DuckDBAdbcConnectionWrapper *conn_wrapper;
 	duckdb_prepared_statement statement;
 	char *ingestion_table_name;
 	char *target_catalog;
@@ -122,12 +123,22 @@ struct DuckDBAdbcStatementWrapper {
 	uint64_t plan_length;
 };
 
+struct MaterializedData {
+	ArrowArray *batches;
+	idx_t count;
+	idx_t current;
+};
+
 struct DuckDBAdbcStreamWrapper {
 	duckdb_result result;
 	char *last_error;
 	AdbcStatusCode status_code;
 	AdbcError adbc_error;
+	MaterializedData *materialized;
+	duckdb::DuckDBAdbcConnectionWrapper *conn_wrapper;
 };
+
+static void MaterializeActiveStreams(duckdb::DuckDBAdbcConnectionWrapper *conn_wrapper);
 
 static bool IsInterruptError(const char *message) {
 	if (!message) {
@@ -953,6 +964,15 @@ AdbcStatusCode ConnectionInit(struct AdbcConnection *connection, struct AdbcData
 AdbcStatusCode ConnectionRelease(struct AdbcConnection *connection, struct AdbcError *error) {
 	if (connection && connection->private_data) {
 		auto conn_wrapper = static_cast<duckdb::DuckDBAdbcConnectionWrapper *>(connection->private_data);
+		// Materialize active streams before disconnecting so they remain readable
+		MaterializeActiveStreams(conn_wrapper);
+		// Detach active streams before deleting conn_wrapper to avoid dangling pointers
+		for (auto *stream_wrapper : conn_wrapper->active_streams) {
+			if (stream_wrapper) {
+				stream_wrapper->conn_wrapper = nullptr;
+			}
+		}
+		conn_wrapper->active_streams.clear();
 		auto conn = reinterpret_cast<duckdb::Connection *>(conn_wrapper->connection);
 		duckdb_disconnect(reinterpret_cast<duckdb_connection *>(&conn));
 		delete conn_wrapper;
@@ -1001,6 +1021,20 @@ static int get_next(struct ArrowArrayStream *stream, struct ArrowArray *out) {
 	}
 	out->release = nullptr;
 	auto result_wrapper = static_cast<DuckDBAdbcStreamWrapper *>(stream->private_data);
+
+	// If the stream has been materialized, return from stored batches
+	if (result_wrapper->materialized) {
+		auto mat = result_wrapper->materialized;
+		if (mat->current >= mat->count) {
+			return DuckDBSuccess; // end of stream
+		}
+		// Transfer ownership of the batch to the caller
+		*out = mat->batches[mat->current];
+		mat->batches[mat->current].release = nullptr;
+		mat->current++;
+		return DuckDBSuccess;
+	}
+
 	auto duckdb_chunk = duckdb_fetch_chunk(result_wrapper->result);
 	if (!duckdb_chunk) {
 		// End of stream or error; distinguish by checking the result error message.
@@ -1038,6 +1072,26 @@ void release(struct ArrowArrayStream *stream) {
 	}
 	auto result_wrapper = reinterpret_cast<DuckDBAdbcStreamWrapper *>(stream->private_data);
 	if (result_wrapper) {
+		// Unregister from connection's active_streams
+		if (result_wrapper->conn_wrapper) {
+			auto &active = result_wrapper->conn_wrapper->active_streams;
+			auto it = std::find(active.begin(), active.end(), result_wrapper);
+			if (it != active.end()) {
+				active.erase(it);
+			}
+		}
+		// Clean up materialized data if present
+		if (result_wrapper->materialized) {
+			auto mat = result_wrapper->materialized;
+			for (idx_t i = mat->current; i < mat->count; i++) {
+				if (mat->batches[i].release) {
+					mat->batches[i].release(&mat->batches[i]);
+				}
+			}
+			free(mat->batches);
+			free(mat);
+			result_wrapper->materialized = nullptr;
+		}
 		duckdb_destroy_result(&result_wrapper->result);
 		if (result_wrapper->last_error) {
 			free(result_wrapper->last_error);
@@ -1316,6 +1370,7 @@ AdbcStatusCode StatementNew(struct AdbcConnection *connection, struct AdbcStatem
 	auto conn_wrapper = static_cast<duckdb::DuckDBAdbcConnectionWrapper *>(connection->private_data);
 
 	statement_wrapper->connection = conn_wrapper->connection;
+	statement_wrapper->conn_wrapper = conn_wrapper;
 	statement_wrapper->statement = nullptr;
 	statement_wrapper->ingestion_stream.release = nullptr;
 	statement_wrapper->ingestion_table_name = nullptr;
@@ -1449,6 +1504,75 @@ static AdbcStatusCode IngestToTableFromBoundStream(DuckDBAdbcStatementWrapper *s
 	              rows_affected);
 }
 
+// Materialize all active streams on a connection so that a new query can execute.
+// This fetches remaining data from each streaming result into memory, making the
+// streams independent of the connection's active query context.
+static void MaterializeActiveStreams(duckdb::DuckDBAdbcConnectionWrapper *conn_wrapper) {
+	for (auto *result_wrapper : conn_wrapper->active_streams) {
+		if (!result_wrapper || result_wrapper->materialized) {
+			continue;
+		}
+
+		// Collect remaining batches from the streaming result
+		duckdb::vector<ArrowArray> batches;
+		auto arrow_options = duckdb_result_get_arrow_options(&result_wrapper->result);
+		while (true) {
+			ArrowArray array;
+			std::memset(&array, 0, sizeof(ArrowArray));
+
+			auto duckdb_chunk = duckdb_fetch_chunk(result_wrapper->result);
+			if (!duckdb_chunk) {
+				break;
+			}
+			auto conversion_err = duckdb_data_chunk_to_arrow(arrow_options, duckdb_chunk, &array);
+			duckdb_destroy_data_chunk(&duckdb_chunk);
+
+			if (conversion_err) {
+				duckdb_destroy_error_data(&conversion_err);
+				if (array.release) {
+					array.release(&array);
+				}
+				break;
+			}
+			batches.push_back(array);
+		}
+		duckdb_destroy_arrow_options(&arrow_options);
+
+		// Store materialized data
+		auto mat = static_cast<MaterializedData *>(malloc(sizeof(MaterializedData)));
+		if (!mat) {
+			// Allocation failed — release fetched batches and skip materialization
+			for (auto &batch : batches) {
+				if (batch.release) {
+					batch.release(&batch);
+				}
+			}
+			continue;
+		}
+		mat->current = 0;
+		mat->count = static_cast<idx_t>(batches.size());
+		if (!batches.empty()) {
+			mat->batches = static_cast<ArrowArray *>(malloc(sizeof(ArrowArray) * batches.size()));
+			if (!mat->batches) {
+				// Allocation failed — release fetched batches and skip materialization
+				for (auto &batch : batches) {
+					if (batch.release) {
+						batch.release(&batch);
+					}
+				}
+				free(mat);
+				continue;
+			}
+			for (idx_t i = 0; i < batches.size(); i++) {
+				mat->batches[i] = batches[i];
+			}
+		} else {
+			mat->batches = nullptr;
+		}
+		result_wrapper->materialized = mat;
+	}
+}
+
 AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct ArrowArrayStream *out,
                                      int64_t *rows_affected, struct AdbcError *error) {
 	if (!statement) {
@@ -1463,6 +1587,13 @@ AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct Arr
 	if (!wrapper->connection) {
 		SetError(error, "Invalid connection");
 		return ADBC_STATUS_INVALID_STATE;
+	}
+
+	// Materialize any active streams on this connection before executing a new query.
+	// Without materialization, executing a new query would silently invalidate any existing streaming results on the
+	// same connection.
+	if (wrapper->conn_wrapper) {
+		MaterializeActiveStreams(wrapper->conn_wrapper);
 	}
 
 	// TODO: Set affected rows, careful with early return
@@ -1499,6 +1630,8 @@ AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct Arr
 	}
 	stream_wrapper->last_error = nullptr;
 	stream_wrapper->status_code = ADBC_STATUS_OK;
+	stream_wrapper->materialized = nullptr;
+	stream_wrapper->conn_wrapper = wrapper->conn_wrapper;
 	std::memset(&stream_wrapper->adbc_error, 0, sizeof(stream_wrapper->adbc_error));
 	std::memset(&stream_wrapper->result, 0, sizeof(stream_wrapper->result));
 	// Only process the stream if there are parameters to bind
@@ -1616,6 +1749,10 @@ AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct Arr
 		out->get_next = get_next;
 		out->release = release;
 		out->get_last_error = get_last_error;
+		// Register this stream wrapper so it can be materialized if another query runs
+		if (wrapper->conn_wrapper) {
+			wrapper->conn_wrapper->active_streams.push_back(stream_wrapper);
+		}
 	} else {
 		// Caller didn't request a stream; clean up resources
 		duckdb_destroy_result(&stream_wrapper->result);
@@ -1659,6 +1796,12 @@ AdbcStatusCode StatementSetSqlQuery(struct AdbcStatement *statement, const char 
 	}
 
 	auto wrapper = static_cast<DuckDBAdbcStatementWrapper *>(statement->private_data);
+
+	// Materialize any active streams before preparing
+	if (wrapper->conn_wrapper) {
+		MaterializeActiveStreams(wrapper->conn_wrapper);
+	}
+
 	if (wrapper->ingestion_stream.release) {
 		// Release any resources currently held by the ingestion stream before we overwrite it
 		wrapper->ingestion_stream.release(&wrapper->ingestion_stream);

--- a/src/include/duckdb/common/adbc/wrappers.hpp
+++ b/src/include/duckdb/common/adbc/wrappers.hpp
@@ -11,11 +11,18 @@
 #include "duckdb.h"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb_adbc {
+struct DuckDBAdbcStreamWrapper;
+} // namespace duckdb_adbc
 
 namespace duckdb {
 
 struct DuckDBAdbcConnectionWrapper {
 	duckdb_connection connection;
 	unordered_map<string, string> options;
+	//! Active stream wrappers on this connection (for materialization on concurrent execute)
+	vector<duckdb_adbc::DuckDBAdbcStreamWrapper *> active_streams;
 };
 } // namespace duckdb

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -4075,4 +4075,297 @@ TEST_CASE("ADBC - ConnectionSetOption non-existent catalog and schema", "[adbc]"
 	}
 }
 
+TEST_CASE("ADBC - Concurrent statements on same connection", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+	ADBCTestDatabase db;
+
+	// Create two statements on the same connection
+	AdbcStatement stmt1, stmt2;
+	REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt1, &db.adbc_error)));
+	REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt2, &db.adbc_error)));
+
+	// Execute first query - get stream1
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt1, "SELECT 1 AS a, 'hello' AS b", &db.adbc_error)));
+	ArrowArrayStream stream1;
+	int64_t rows1;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt1, &stream1, &rows1, &db.adbc_error)));
+
+	// Execute second query on the same connection - this should materialize stream1
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt2, "SELECT 2 AS c, 'world' AS d", &db.adbc_error)));
+	ArrowArrayStream stream2;
+	int64_t rows2;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt2, &stream2, &rows2, &db.adbc_error)));
+
+	// Read from stream1 - should work because it was materialized
+	ArrowArray batch1;
+	REQUIRE(stream1.get_next(&stream1, &batch1) == 0);
+	REQUIRE(batch1.release != nullptr);
+	REQUIRE(batch1.length == 1);
+	REQUIRE(batch1.n_children == 2);
+	batch1.release(&batch1);
+
+	// Verify end of stream1
+	ArrowArray batch1_end;
+	REQUIRE(stream1.get_next(&stream1, &batch1_end) == 0);
+	REQUIRE(batch1_end.release == nullptr);
+
+	// Read from stream2 - should work as the active streaming result
+	ArrowArray batch2;
+	REQUIRE(stream2.get_next(&stream2, &batch2) == 0);
+	REQUIRE(batch2.release != nullptr);
+	REQUIRE(batch2.length == 1);
+	REQUIRE(batch2.n_children == 2);
+	batch2.release(&batch2);
+
+	// Verify end of stream2
+	ArrowArray batch2_end;
+	REQUIRE(stream2.get_next(&stream2, &batch2_end) == 0);
+	REQUIRE(batch2_end.release == nullptr);
+
+	// Clean up
+	stream1.release(&stream1);
+	stream2.release(&stream2);
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt1, &db.adbc_error)));
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt2, &db.adbc_error)));
+}
+
+TEST_CASE("ADBC - Concurrent statements with large result", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+	ADBCTestDatabase db;
+
+	// Create a table with enough data to produce multiple batches
+	db.Query("CREATE TABLE test_large AS SELECT i, 'value_' || i::VARCHAR AS v FROM range(5000) t(i)");
+
+	AdbcStatement stmt1, stmt2;
+	REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt1, &db.adbc_error)));
+	REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt2, &db.adbc_error)));
+
+	// Execute first query
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt1, "SELECT * FROM test_large ORDER BY i", &db.adbc_error)));
+	ArrowArrayStream stream1;
+	int64_t rows1;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt1, &stream1, &rows1, &db.adbc_error)));
+
+	// Read first batch from stream1 before executing second query
+	ArrowArray first_batch;
+	REQUIRE(stream1.get_next(&stream1, &first_batch) == 0);
+	REQUIRE(first_batch.release != nullptr);
+	REQUIRE(first_batch.length > 0);
+	auto first_batch_len = first_batch.length;
+	first_batch.release(&first_batch);
+
+	// Execute second query - materializes remaining data in stream1
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt2, "SELECT 42 AS answer", &db.adbc_error)));
+	ArrowArrayStream stream2;
+	int64_t rows2;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt2, &stream2, &rows2, &db.adbc_error)));
+
+	// Continue reading from stream1 - should get remaining materialized data
+	int64_t total_rows = first_batch_len;
+	while (true) {
+		ArrowArray batch;
+		REQUIRE(stream1.get_next(&stream1, &batch) == 0);
+		if (!batch.release) {
+			break;
+		}
+		total_rows += batch.length;
+		batch.release(&batch);
+	}
+	REQUIRE(total_rows == 5000);
+
+	// Read from stream2
+	ArrowArray batch2;
+	REQUIRE(stream2.get_next(&stream2, &batch2) == 0);
+	REQUIRE(batch2.release != nullptr);
+	REQUIRE(batch2.length == 1);
+	batch2.release(&batch2);
+
+	// Clean up
+	stream1.release(&stream1);
+	stream2.release(&stream2);
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt1, &db.adbc_error)));
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt2, &db.adbc_error)));
+}
+
+TEST_CASE("ADBC - Concurrent statements: release before second query", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+	ADBCTestDatabase db;
+
+	AdbcStatement stmt1, stmt2;
+	REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt1, &db.adbc_error)));
+	REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt2, &db.adbc_error)));
+
+	// Execute and release first stream before second query
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt1, "SELECT 1 AS a", &db.adbc_error)));
+	ArrowArrayStream stream1;
+	int64_t rows1;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt1, &stream1, &rows1, &db.adbc_error)));
+	stream1.release(&stream1);
+
+	// Second query should work fine (active_streams was cleaned up by release)
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt2, "SELECT 2 AS b", &db.adbc_error)));
+	ArrowArrayStream stream2;
+	int64_t rows2;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt2, &stream2, &rows2, &db.adbc_error)));
+
+	ArrowArray batch;
+	REQUIRE(stream2.get_next(&stream2, &batch) == 0);
+	REQUIRE(batch.release != nullptr);
+	REQUIRE(batch.length == 1);
+	batch.release(&batch);
+
+	stream2.release(&stream2);
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt1, &db.adbc_error)));
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt2, &db.adbc_error)));
+}
+
+TEST_CASE("ADBC - Three concurrent statements", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+	ADBCTestDatabase db;
+
+	AdbcStatement stmt1, stmt2, stmt3;
+	REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt1, &db.adbc_error)));
+	REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt2, &db.adbc_error)));
+	REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt3, &db.adbc_error)));
+
+	// Execute three queries sequentially, keeping all streams open
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt1, "SELECT 1 AS a", &db.adbc_error)));
+	ArrowArrayStream stream1;
+	int64_t rows;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt1, &stream1, &rows, &db.adbc_error)));
+
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt2, "SELECT 2 AS b", &db.adbc_error)));
+	ArrowArrayStream stream2;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt2, &stream2, &rows, &db.adbc_error)));
+
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt3, "SELECT 3 AS c", &db.adbc_error)));
+	ArrowArrayStream stream3;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt3, &stream3, &rows, &db.adbc_error)));
+
+	// Read all three streams — stream1 and stream2 are materialized, stream3 is live
+	ArrowArray batch1, batch2, batch3;
+	REQUIRE(stream1.get_next(&stream1, &batch1) == 0);
+	REQUIRE(batch1.release != nullptr);
+	REQUIRE(batch1.length == 1);
+	batch1.release(&batch1);
+
+	REQUIRE(stream2.get_next(&stream2, &batch2) == 0);
+	REQUIRE(batch2.release != nullptr);
+	REQUIRE(batch2.length == 1);
+	batch2.release(&batch2);
+
+	REQUIRE(stream3.get_next(&stream3, &batch3) == 0);
+	REQUIRE(batch3.release != nullptr);
+	REQUIRE(batch3.length == 1);
+	batch3.release(&batch3);
+
+	// Verify all streams end
+	ArrowArray end;
+	REQUIRE(stream1.get_next(&stream1, &end) == 0);
+	REQUIRE(end.release == nullptr);
+	REQUIRE(stream2.get_next(&stream2, &end) == 0);
+	REQUIRE(end.release == nullptr);
+	REQUIRE(stream3.get_next(&stream3, &end) == 0);
+	REQUIRE(end.release == nullptr);
+
+	stream1.release(&stream1);
+	stream2.release(&stream2);
+	stream3.release(&stream3);
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt1, &db.adbc_error)));
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt2, &db.adbc_error)));
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt3, &db.adbc_error)));
+}
+
+TEST_CASE("ADBC - Connection release while stream is active", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+
+	// Set up database manually (not using ADBCTestDatabase since we need to control release order)
+	AdbcDatabase adbc_database;
+	AdbcError adbc_error;
+	std::memset(&adbc_error, 0, sizeof(adbc_error));
+	std::memset(&adbc_database, 0, sizeof(adbc_database));
+	REQUIRE(SUCCESS(AdbcDatabaseNew(&adbc_database, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "driver", duckdb_lib, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "entrypoint", "duckdb_adbc_init", &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseSetOption(&adbc_database, "path", ":memory:", &adbc_error)));
+	REQUIRE(SUCCESS(AdbcDatabaseInit(&adbc_database, &adbc_error)));
+
+	AdbcConnection adbc_connection;
+	std::memset(&adbc_connection, 0, sizeof(adbc_connection));
+	REQUIRE(SUCCESS(AdbcConnectionNew(&adbc_connection, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcConnectionInit(&adbc_connection, &adbc_database, &adbc_error)));
+
+	AdbcStatement stmt;
+	REQUIRE(SUCCESS(AdbcStatementNew(&adbc_connection, &stmt, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt, "SELECT 1 AS a", &adbc_error)));
+
+	ArrowArrayStream stream;
+	int64_t rows;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt, &stream, &rows, &adbc_error)));
+
+	// Release connection while stream is still active
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcConnectionRelease(&adbc_connection, &adbc_error)));
+
+	// Stream should still be usable (materialized data is independent, conn_wrapper is nulled out)
+	ArrowArray batch;
+	REQUIRE(stream.get_next(&stream, &batch) == 0);
+	REQUIRE(batch.release != nullptr);
+	REQUIRE(batch.length == 1);
+	batch.release(&batch);
+
+	// Release stream after connection is gone — should not crash
+	stream.release(&stream);
+
+	REQUIRE(SUCCESS(AdbcDatabaseRelease(&adbc_database, &adbc_error)));
+}
+
+TEST_CASE("ADBC - Re-execute same statement while prior stream is open", "[adbc]") {
+	if (!duckdb_lib) {
+		return;
+	}
+	ADBCTestDatabase db;
+
+	AdbcStatement stmt;
+	REQUIRE(SUCCESS(AdbcStatementNew(&db.adbc_connection, &stmt, &db.adbc_error)));
+
+	// Execute first query
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt, "SELECT 1 AS a", &db.adbc_error)));
+	ArrowArrayStream stream1;
+	int64_t rows;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt, &stream1, &rows, &db.adbc_error)));
+
+	// Re-execute the same statement — should materialize stream1
+	REQUIRE(SUCCESS(AdbcStatementSetSqlQuery(&stmt, "SELECT 2 AS b", &db.adbc_error)));
+	ArrowArrayStream stream2;
+	REQUIRE(SUCCESS(AdbcStatementExecuteQuery(&stmt, &stream2, &rows, &db.adbc_error)));
+
+	// Both streams should be readable
+	ArrowArray batch1;
+	REQUIRE(stream1.get_next(&stream1, &batch1) == 0);
+	REQUIRE(batch1.release != nullptr);
+	REQUIRE(batch1.length == 1);
+	batch1.release(&batch1);
+
+	ArrowArray batch2;
+	REQUIRE(stream2.get_next(&stream2, &batch2) == 0);
+	REQUIRE(batch2.release != nullptr);
+	REQUIRE(batch2.length == 1);
+	batch2.release(&batch2);
+
+	stream1.release(&stream1);
+	stream2.release(&stream2);
+	REQUIRE(SUCCESS(AdbcStatementRelease(&stmt, &db.adbc_error)));
+}
+
 } // namespace duckdb


### PR DESCRIPTION
Fix #21384

In DuckDB <= 1.4, ADBC query results were always materialized, so concurrent statements on the same connection worked naturally.
In 1.5.0 (#20511), results are streamed, and since a connection can only hold one active streaming query, executing a second statement silently invalidated the first stream.

This PR change materializes any active streams before executing a new query, restoring support for concurrent statements.

cc @lidavidm