### PR TITLE
Use regular pushdown path for semi/anti/left delim joins

### DIFF
--- a/src/optimizer/pushdown/pushdown_left_join.cpp
+++ b/src/optimizer/pushdown/pushdown_left_join.cpp
@@ -77,10 +77,6 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownLeftJoin(unique_ptr<LogicalO
                                                              unordered_set<idx_t> &left_bindings,
                                                              unordered_set<idx_t> &right_bindings) {
 	auto &join = op->Cast<LogicalJoin>();
-	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
-		op = PushFiltersIntoDelimJoin(std::move(op));
-		return FinishPushdown(std::move(op));
-	}
 	FilterPushdown left_pushdown(optimizer, convert_mark_joins), right_pushdown(optimizer, convert_mark_joins);
 	// for a comparison join we create a FilterCombiner that checks if we can push conditions on LHS join conditions
 	// into the RHS of the join

--- a/src/optimizer/pushdown/pushdown_semi_anti_join.cpp
+++ b/src/optimizer/pushdown/pushdown_semi_anti_join.cpp
@@ -11,10 +11,6 @@ using Filter = FilterPushdown::Filter;
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownSemiAntiJoin(unique_ptr<LogicalOperator> op) {
 	auto &join = op->Cast<LogicalJoin>();
-	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
-		op = PushFiltersIntoDelimJoin(std::move(op));
-		return FinishPushdown(std::move(op));
-	}
 
 	// push all current filters down the left side
 	op->children[0] = Rewrite(std::move(op->children[0]));

--- a/test/optimizer/joins/delim_left_join_pushdown.test
+++ b/test/optimizer/joins/delim_left_join_pushdown.test
@@ -1,0 +1,38 @@
+# name: test/optimizer/joins/delim_left_join_pushdown.test
+# description: Verify left-join pushdown into lateral joins is not over-eager
+# group: [joins]
+
+statement ok
+create or replace table c(id int, u_id int);
+
+statement ok
+insert into c values (1, 1), (2,2), (3,3), (4, null);
+
+statement ok
+create or replace table t(id int, name text, u_ids int[]);
+
+statement ok
+insert into t values (1, 'one', [1]), (2, 'two', [1, 2]), (3, 'three', null);
+
+query II
+select c.id, ts.names
+from c LEFT JOIN (
+  select array_agg(t.name)
+  from t where c.u_id = any(t.u_ids)
+) as ts(names) on true
+where ts.names IS NOT NULL;
+----
+1	[one, two]
+2	[two]
+
+query II
+select c.id, ts.names
+from c LEFT JOIN (
+  select array_agg(t.name)
+  from t where c.u_id = any(t.u_ids)
+) as ts(names) on true
+where c.id>=2
+----
+2	[two]
+3	NULL
+4	NULL


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/21407 

https://github.com/duckdb/duckdb/pull/19152 introduces a special join filter pushdown optimizer for duplicate-eliminated joins, but this is not required for `LEFT / SEMI / ANTI` joins. We can use the regular join filter pushdown code for those joins. It is only required for `INNER` joins (currently) because the filter pushdown code for inner joins works by generating a cross product and using the cross product filter pushdown code. This then loses the delim join information which causes the plan to be incorrect.
