### PR TITLE
Predicate factoring

### DIFF
--- a/src/include/duckdb/optimizer/rule/predicate_factoring.hpp
+++ b/src/include/duckdb/optimizer/rule/predicate_factoring.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/optimizer/rule/timestamp_comparison.hpp
+// duckdb/optimizer/rule/predicate_factoring.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -9,22 +9,17 @@
 #pragma once
 
 #include "duckdb/optimizer/rule.hpp"
-#include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/planner/column_binding_map.hpp"
 
 namespace duckdb {
 
-class TimeStampComparison : public Rule {
+//! The Predicate Factoring rule extracts predicates on a common column from disjunctive or conjunctive clauses
+class PredicateFactoringRule : public Rule {
 public:
-	explicit TimeStampComparison(ExpressionRewriter &rewriter);
+	explicit PredicateFactoringRule(ExpressionRewriter &rewriter);
 
 	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
 	                             bool is_root) override;
-
-	unique_ptr<Expression> ApplyRule(BoundFunctionExpression *expr, ScalarFunction function, string pattern,
-	                                 bool is_not_like);
-
-private:
-	ClientContext &context;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/rule/predicate_factoring.hpp
+++ b/src/include/duckdb/optimizer/rule/predicate_factoring.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "duckdb/optimizer/rule.hpp"
-#include "duckdb/planner/column_binding_map.hpp"
 
 namespace duckdb {
 

--- a/src/optimizer/cte_filter_pusher.cpp
+++ b/src/optimizer/cte_filter_pusher.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/optimizer/cte_filter_pusher.hpp"
 
+#include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/column_binding_replacer.hpp"
 #include "duckdb/optimizer/filter_pushdown.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
@@ -108,11 +109,18 @@ void CTEFilterPusher::PushFilterIntoCTE(MaterializedCTEInfo &info) {
 		}
 	}
 
-	// Add the filter on top of the CTE definition and push it down
+	// Add the filter on top of the CTE definition and split the predicates
 	auto new_cte = make_uniq_base<LogicalOperator, LogicalFilter>(std::move(outer_expr));
+	LogicalFilter::SplitPredicates(new_cte->Cast<LogicalFilter>().expressions);
+
+	// Rewrite the operator expressions before adding the child op (children should be rewritten already)
+	optimizer.rewriter.VisitOperator(*new_cte);
 	new_cte->children.push_back(std::move(info.materialized_cte.children[0]));
+
+	// Push down the filter
 	FilterPushdown pushdown(optimizer);
 	new_cte = pushdown.Rewrite(std::move(new_cte));
+
 	info.materialized_cte.children[0] = std::move(new_cte);
 }
 

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -40,6 +40,7 @@
 #include "duckdb/optimizer/common_subplan_optimizer.hpp"
 #include "duckdb/optimizer/window_self_join.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
+#include "duckdb/optimizer/rule/predicate_factoring.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/planner.hpp"
 
@@ -66,7 +67,8 @@ Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context),
 	rewriter.rules.push_back(make_uniq<EmptyNeedleRemovalRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<EnumComparisonRule>(rewriter));
 	rewriter.rules.push_back(make_uniq<JoinDependentFilterRule>(rewriter));
-	rewriter.rules.push_back(make_uniq<TimeStampComparison>(context, rewriter));
+	rewriter.rules.push_back(make_uniq<TimeStampComparison>(rewriter));
+	rewriter.rules.push_back(make_uniq<PredicateFactoringRule>(rewriter));
 
 #ifdef DEBUG
 	for (auto &rule : rewriter.rules) {

--- a/src/optimizer/rule/CMakeLists.txt
+++ b/src/optimizer/rule/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_unity(
   like_optimizations.cpp
   move_constants.cpp
   ordered_aggregate_optimizer.cpp
+  predicate_factoring.cpp
   regex_optimizations.cpp
   timestamp_comparison.cpp
   constant_order_normalization.cpp)

--- a/src/optimizer/rule/predicate_factoring.cpp
+++ b/src/optimizer/rule/predicate_factoring.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/column_binding_map.hpp"
 
 namespace duckdb {
 
@@ -36,6 +37,10 @@ static bool ColumnBindingIsvalid(const ColumnBinding &column_binding) {
 }
 
 static bool GetSingleColumnBinding(const Expression &expr, ColumnBinding &column_binding) {
+	if (expr.IsVolatile()) {
+		return false;
+	}
+
 	column_binding.table_index = DConstants::INVALID_INDEX;
 	column_binding.column_index = DConstants::INVALID_INDEX;
 

--- a/src/optimizer/rule/predicate_factoring.cpp
+++ b/src/optimizer/rule/predicate_factoring.cpp
@@ -1,0 +1,185 @@
+#include "duckdb/optimizer/rule/predicate_factoring.hpp"
+
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+
+namespace duckdb {
+
+PredicateFactoringRule::PredicateFactoringRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// Match on a ConjunctionExpression that has at least one ConjunctionExpression as a child
+	auto op = make_uniq<ConjunctionExpressionMatcher>();
+	op->matchers.push_back(make_uniq<ConjunctionExpressionMatcher>());
+	op->policy = SetMatcher::Policy::SOME;
+	root = std::move(op);
+}
+
+static bool ExpressionIsDisjunction(const Expression &expr) {
+	return expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION &&
+	       expr.GetExpressionType() == ExpressionType::CONJUNCTION_OR;
+}
+
+static void ExtractDisjunctedPredicates(Expression &expression, vector<reference<Expression>> &disjuncted_children) {
+	if (ExpressionIsDisjunction(expression)) {
+		auto &disjunction = expression.Cast<BoundConjunctionExpression>();
+		for (auto &child : disjunction.children) {
+			ExtractDisjunctedPredicates(*child, disjuncted_children);
+		}
+	} else {
+		disjuncted_children.push_back(expression);
+	}
+}
+
+static bool ColumnBindingIsvalid(const ColumnBinding &column_binding) {
+	return column_binding.table_index != DConstants::INVALID_INDEX &&
+	       column_binding.column_index != DConstants::INVALID_INDEX;
+}
+
+static bool GetSingleColumnBinding(const Expression &expr, ColumnBinding &column_binding) {
+	column_binding.table_index = DConstants::INVALID_INDEX;
+	column_binding.column_index = DConstants::INVALID_INDEX;
+
+	bool found_multiple = false;
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &colref) {
+		if (!ColumnBindingIsvalid(column_binding)) {
+			column_binding = colref.binding;
+		} else if (column_binding != colref.binding) {
+			found_multiple = true;
+		}
+	});
+
+	return ColumnBindingIsvalid(column_binding) && !found_multiple;
+}
+
+static void ExtractDisjunctedPredicates(Expression &expression,
+                                        column_binding_map_t<vector<reference<Expression>>> &binding_map);
+
+static void ExtractConjunctedPredicates(BoundConjunctionExpression &conjunction,
+                                        column_binding_map_t<vector<reference<Expression>>> &binding_map) {
+	D_ASSERT(conjunction.GetExpressionType() == ExpressionType::CONJUNCTION_AND);
+	for (auto &conjunction_child : conjunction.children) {
+		if (conjunction_child->GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION &&
+		    conjunction_child->GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
+			ExtractConjunctedPredicates(conjunction_child->Cast<BoundConjunctionExpression>(), binding_map);
+		} else {
+			ExtractDisjunctedPredicates(*conjunction_child, binding_map);
+		}
+	}
+}
+
+static void ExtractDisjunctedPredicates(Expression &expression,
+                                        column_binding_map_t<vector<reference<Expression>>> &binding_map) {
+	if (expression.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION &&
+	    expression.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
+		ExtractConjunctedPredicates(expression.Cast<BoundConjunctionExpression>(), binding_map);
+	} else {
+		ColumnBinding single_binding;
+		if (GetSingleColumnBinding(expression, single_binding)) {
+			binding_map[single_binding].push_back(expression);
+		}
+	}
+}
+
+static column_binding_map_t<vector<reference<Expression>>> GetDisjunctedPredicateMap(Expression &expression) {
+	vector<reference<Expression>> disjuncted_children;
+	ExtractDisjunctedPredicates(expression, disjuncted_children);
+	D_ASSERT(disjuncted_children.size() > 1);
+
+	// Extract predicates of the first child
+	auto &first_child = disjuncted_children[0].get();
+	D_ASSERT(!ExpressionIsDisjunction(first_child));
+	column_binding_map_t<vector<reference<Expression>>> remaining_binding_map;
+	ExtractDisjunctedPredicates(first_child, remaining_binding_map);
+
+	for (idx_t child_idx = 1; child_idx < disjuncted_children.size(); child_idx++) {
+		auto &child = disjuncted_children[child_idx].get();
+		D_ASSERT(!ExpressionIsDisjunction(child));
+		column_binding_map_t<vector<reference<Expression>>> child_binding_map;
+		ExtractDisjunctedPredicates(child, child_binding_map);
+
+		// Bindings must appear in both maps to be considered for predicate factoring
+		for (auto it = remaining_binding_map.begin(); it != remaining_binding_map.end();) {
+			auto child_it = child_binding_map.find(it->first);
+			if (child_it == child_binding_map.end()) {
+				it = remaining_binding_map.erase(it);
+			} else {
+				for (auto &new_predicate : child_it->second) {
+					bool found = false;
+					for (auto &existing_predicate : it->second) {
+						if (new_predicate.get().Equals(existing_predicate.get())) {
+							found = true;
+							break;
+						}
+					}
+					if (!found) {
+						it->second.push_back(new_predicate.get());
+					}
+				}
+				it++;
+			}
+		}
+	}
+
+	return remaining_binding_map;
+}
+
+unique_ptr<Expression> PredicateFactoringRule::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
+                                                     bool &changes_made, bool is_root) {
+	// Only applies to top-level FILTER expressions
+	if ((op.type != LogicalOperatorType::LOGICAL_FILTER && op.type != LogicalOperatorType::LOGICAL_ANY_JOIN) ||
+	    !is_root) {
+		return nullptr;
+	}
+
+	// The expression must be an OR TODO: could also implement some common expression extraction for AND
+	if (!ExpressionIsDisjunction(bindings[0])) {
+		return nullptr;
+	}
+
+	ColumnBinding column_binding;
+	if (GetSingleColumnBinding(bindings[0], column_binding)) {
+		return nullptr; // If it only applies to one column binding it can be pushed down already
+	}
+
+	// Extract map from single column binding to expression it is contained in
+	const auto binding_map = GetDisjunctedPredicateMap(bindings[0].get());
+	if (binding_map.empty()) {
+		return nullptr; // None qualify
+	}
+
+	unique_ptr<Expression> derived_filter;
+	for (auto &entry : binding_map) {
+		D_ASSERT(!entry.second.empty());
+
+		// Create disjunction on single-column predicates
+		unique_ptr<Expression> column_filter;
+		for (auto &expr : entry.second) {
+			if (!column_filter) {
+				column_filter = expr.get().Copy();
+			} else {
+				auto new_disjunction = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
+				new_disjunction->children.push_back(std::move(column_filter));
+				new_disjunction->children.push_back(expr.get().Copy());
+				column_filter = std::move(new_disjunction);
+			}
+		}
+
+		// Conjunct each single-column predicate together
+		if (!derived_filter) {
+			derived_filter = std::move(column_filter);
+		} else {
+			auto new_conjunction = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+			new_conjunction->children.push_back(std::move(column_filter));
+			new_conjunction->children.push_back(std::move(derived_filter));
+			derived_filter = std::move(new_conjunction);
+		}
+	}
+
+	// Now add the derived filter as an AND to the original expression
+	auto result = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+	result->children.push_back(bindings[0].get().Copy());
+	result->children.push_back(std::move(derived_filter));
+	return result;
+}
+
+} // namespace duckdb

--- a/src/optimizer/rule/predicate_factoring.cpp
+++ b/src/optimizer/rule/predicate_factoring.cpp
@@ -184,7 +184,7 @@ unique_ptr<Expression> PredicateFactoringRule::Apply(LogicalOperator &op, vector
 	auto result = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
 	result->children.push_back(bindings[0].get().Copy());
 	result->children.push_back(std::move(derived_filter));
-	return result;
+	return std::move(result);
 }
 
 } // namespace duckdb

--- a/src/optimizer/rule/timestamp_comparison.cpp
+++ b/src/optimizer/rule/timestamp_comparison.cpp
@@ -16,8 +16,7 @@
 
 namespace duckdb {
 
-TimeStampComparison::TimeStampComparison(ClientContext &context, ExpressionRewriter &rewriter)
-    : Rule(rewriter), context(context) {
+TimeStampComparison::TimeStampComparison(ExpressionRewriter &rewriter) : Rule(rewriter), context(rewriter.context) {
 	// match on a ComparisonExpression that is an Equality and has a VARCHAR and ENUM as its children
 	auto op = make_uniq<ComparisonExpressionMatcher>();
 	op->policy = SetMatcher::Policy::UNORDERED;

--- a/test/sql/optimizer/predicate_factoring.test
+++ b/test/sql/optimizer/predicate_factoring.test
@@ -1,0 +1,120 @@
+# name: test/sql/optimizer/predicate_factoring.test
+# description: Test PredicateFactoringRule - extracts common single-column predicates from disjunctive clauses
+# group: [optimizer]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1, 5, 3), (1, 2, 3), (1, 5, 11), (2, 5, 3), (NULL, 5, 3);
+
+# Basic predicate factoring: a=1 is common to both disjuncts and should be extracted
+query III rowsort
+SELECT * FROM t WHERE (a=1 AND b>3) OR (a=1 AND c<5)
+----
+1	2	3
+1	5	11
+1	5	3
+
+# Verify a=1 is pushed down into the scan as a required filter
+query II
+EXPLAIN SELECT * FROM t WHERE (a=1 AND b>3) OR (a=1 AND c<5)
+----
+physical_plan	<REGEX>:.*Filters: a=1.*
+
+# Predicate factoring on a different common column: b=5
+query III rowsort
+SELECT * FROM t WHERE (a=1 AND b=5) OR (a=2 AND b=5)
+----
+1	5	11
+1	5	3
+2	5	3
+
+query II
+EXPLAIN SELECT * FROM t WHERE (a=1 AND b=5) OR (a=2 AND b=5)
+----
+physical_plan	<REGEX>:.*Filters:.*b=5.*
+
+# Two common predicates: both a=1 and b=5 should be factored out
+query III rowsort
+SELECT * FROM t WHERE (a=1 AND b=5 AND c>2) OR (a=1 AND b=5 AND c<6)
+----
+1	5	11
+1	5	3
+
+query II
+EXPLAIN SELECT * FROM t WHERE (a=1 AND b=5 AND c>2) OR (a=1 AND b=5 AND c<6)
+----
+physical_plan	<REGEX>:.*Filters:.*a=1.*b=5.*
+
+# Three-way disjunction: a=1 is common to all three disjuncts
+query III rowsort
+SELECT * FROM t WHERE (a=1 AND b=5) OR (a=1 AND c>2) OR (a=1 AND b=2)
+----
+1	2	3
+1	5	11
+1	5	3
+
+query II
+EXPLAIN SELECT * FROM t WHERE (a=1 AND b=5) OR (a=1 AND c>2) OR (a=1 AND b=2)
+----
+physical_plan	<REGEX>:.*Filters: a=1.*
+
+# No common predicates: no factoring should occur
+query III rowsort
+SELECT * FROM t WHERE (a=1 AND b>3) OR (a=2 AND c<5)
+----
+1	5	11
+1	5	3
+2	5	3
+
+# Rule does not fire for a single-column OR (already pushable)
+query III rowsort
+SELECT * FROM t WHERE a=1 OR a=2
+----
+1	2	3
+1	5	11
+1	5	3
+2	5	3
+
+# NULL handling: factored predicate correctly excludes NULLs
+query III rowsort
+SELECT * FROM t WHERE (a=1 AND b=5) OR (a=1 AND c=3)
+----
+1	2	3
+1	5	11
+1	5	3
+
+# Rule only applies to FILTER context, not SELECT clause
+query I rowsort
+SELECT (a=1 AND b>3) OR (a=1 AND c<5) FROM t
+----
+0
+1
+1
+1
+NULL
+
+# Predicate factoring in a cross join condition
+statement ok
+CREATE TABLE s (x INTEGER, y INTEGER);
+
+statement ok
+INSERT INTO s VALUES (1, 10), (2, 20), (1, 30);
+
+query IIIII rowsort
+SELECT t.a, t.b, t.c, s.x, s.y FROM t, s WHERE (t.a=1 AND s.x=1 AND t.b>3) OR (t.a=1 AND s.x=1 AND s.y<20)
+----
+1	2	3	1	10
+1	5	11	1	10
+1	5	11	1	30
+1	5	3	1	10
+1	5	3	1	30
+
+query II
+EXPLAIN SELECT t.a, t.b, t.c, s.x, s.y FROM t, s WHERE (t.a=1 AND s.x=1 AND t.b>3) OR (t.a=1 AND s.x=1 AND s.y<20)
+----
+physical_plan	<REGEX>:.*Filters: x=1.*Filters: a=1.*


### PR DESCRIPTION
Fixes regressions caused by https://github.com/duckdb/duckdb/pull/21275

The linked PR fixed column pruning, which caused the `CommonSubplanOptimizer` not to be able to deduplicate parts of the plan anymore (that came from the inlined CTE). This was fixed with a heuristic in the `CTEInlining` optimizer, which fixed some regressions, but introduced new ones. After looking at this for a while, we figured out that the filters that are created by the `CTEFilterPusher` optimizer weren't pushed down all the way, because they were a disjunction that referenced an aggregate function.

This PR implements the `PredicateFactoringRule` for the `ExpressionRewriter` that derives a filter on a single column from a disjunction, which can then be pushed down. This fixes the regression.

CC: @kryonix 