### PR TITLE
Avoid scanning struct validity when executing pushdown extract

### DIFF
--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -144,7 +144,11 @@ static void ScanChild(ColumnScanState &state, Vector &result, const std::functio
 
 idx_t StructColumnData::Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
                              idx_t target_count) {
-	auto scan_count = validity->Scan(transaction, vector_index, state.child_states[0], result, target_count);
+	idx_t scan_count;
+	if (!state.storage_index.IsPushdownExtract()) {
+		// if we are scanning the entire struct we need to scan the validity
+		scan_count = validity->Scan(transaction, vector_index, state.child_states[0], result, target_count);
+	}
 	auto struct_children = GetStructChildren(state);
 	for (auto &child : struct_children) {
 		auto &target_vector = GetFieldVectorForScan(result, child.vector_index);
@@ -155,15 +159,19 @@ idx_t StructColumnData::Scan(TransactionData transaction, idx_t vector_index, Co
 			continue;
 		}
 		ScanChild(state, target_vector, [&](Vector &child_result) {
-			return child.col.Scan(transaction, vector_index, child.state, child_result, target_count);
+			scan_count = child.col.Scan(transaction, vector_index, child.state, child_result, target_count);
+			return scan_count;
 		});
 	}
 	return scan_count;
 }
 
 idx_t StructColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count, idx_t result_offset) {
-	auto scan_count = validity->ScanCount(state.child_states[0], result, count);
-
+	idx_t scan_count;
+	if (!state.storage_index.IsPushdownExtract()) {
+		// if we are scanning the entire struct we need to scan the validity
+		scan_count = validity->ScanCount(state.child_states[0], result, count);
+	}
 	auto struct_children = GetStructChildren(state);
 	for (auto &child : struct_children) {
 		auto &target_vector = GetFieldVectorForScan(result, child.vector_index);
@@ -174,7 +182,8 @@ idx_t StructColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t 
 			continue;
 		}
 		ScanChild(state, target_vector, [&](Vector &child_result) {
-			return child.col.ScanCount(child.state, child_result, count, result_offset);
+			scan_count = child.col.ScanCount(child.state, child_result, count, result_offset);
+			return scan_count;
 		});
 	}
 	return scan_count;

--- a/test/sql/storage/types/struct/pushdown_extract_validity.test
+++ b/test/sql/storage/types/struct/pushdown_extract_validity.test
@@ -1,0 +1,38 @@
+# name: test/sql/storage/types/struct/pushdown_extract_validity.test
+# description: Test correct handling of validity columns in pushdown extract
+# group: [struct]
+
+load __TEST_DIR__/struct_pushdown_extract_null.db
+
+statement ok
+SET threads=1
+
+statement ok
+CREATE TABLE structs(s STRUCT(id INT));
+
+statement ok
+INSERT INTO structs
+SELECT {'id': CASE WHEN r%3=0 THEN NULL ELSE i END }
+FROM (
+	SELECT UNNEST(range(1200)) r, UNNEST(repeat([1], 1000)) i UNION ALL SELECT UNNEST(range(1000)) r, UNNEST(repeat([2], 1000)) i
+)
+
+statement ok
+CHECKPOINT;
+
+statement ok
+INSERT INTO structs
+SELECT CASE WHEN r%13=0 THEN NULL ELSE {'id': CASE WHEN r%7=0 THEN NULL ELSE i END } END
+FROM (
+	SELECT UNNEST(range(2000)) r, UNNEST(repeat([1], 2000)) i
+)
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT DISTINCT s.id FROM structs ORDER BY ALL
+----
+1
+2
+NULL


### PR DESCRIPTION
When doing a pushdown extract scan into a struct, we should directly scan the child column. Currently we are also scanning the validity of the parent struct column. Not only is this not necessary (and hence unnecessary performance loss) - it can also cause correctness issues as downstream scan operators expect there to be no `NULL` values present in the input vector they are scanning into.