### PR TITLE
Fix strip_p/lower call order in generate_grammar.py keyword sorting

### DIFF
--- a/scripts/generate_grammar.py
+++ b/scripts/generate_grammar.py
@@ -71,11 +71,11 @@ def strip_p(x):
         return x
 
 
-unreserved_keywords.sort(key=lambda x: strip_p(x))
-colname_keywords.sort(key=lambda x: strip_p(x))
-func_name_keywords.sort(key=lambda x: strip_p(x))
-type_name_keywords.sort(key=lambda x: strip_p(x))
-reserved_keywords.sort(key=lambda x: strip_p(x))
+unreserved_keywords.sort(key=lambda x: strip_p(x).lower())
+colname_keywords.sort(key=lambda x: strip_p(x).lower())
+func_name_keywords.sort(key=lambda x: strip_p(x).lower())
+type_name_keywords.sort(key=lambda x: strip_p(x).lower())
+reserved_keywords.sort(key=lambda x: strip_p(x).lower())
 
 statements = read_list_from_file(os.path.join(base_dir, 'statements.list'))
 statements.sort()
@@ -102,7 +102,7 @@ for kw in reserved_keywords:
 
 kwlist = [(x, kwdict[x]) for x in kwdict.keys()]
 # sorting uppercase is different from lowercase: A-Z < _ < a-z
-kwlist.sort(key=lambda x: strip_p(x[0].lower()))
+kwlist.sort(key=lambda x: strip_p(x[0]).lower())
 
 # now generate kwlist.h
 # PG_KEYWORD("abort", ABORT_P, UNRESERVED_KEYWORD)


### PR DESCRIPTION
The kwlist.sort() key uses strip_p(x[0].lower()), but strip_p() checks x.endswith("_P") (uppercase). Calling .lower() first turns "_P" into "_p", so strip_p() fails to strip the suffix. This causes the sort key to differ from the written kwlist.hpp name (strip_p(tpl[0]).lower()), producing an unsorted keyword array that breaks ScanKeywordLookup's strcmp-based binary search.

Fix by swapping to strip_p(x[0]).lower() so strip_p() sees the original uppercase token name. Also add .lower() to the 5 category list sorts for consistency.

Fixes #21400