### PR TITLE
Fix stale update read during index removal

### DIFF
--- a/src/include/duckdb/transaction/update_info.hpp
+++ b/src/include/duckdb/transaction/update_info.hpp
@@ -60,6 +60,10 @@ struct UpdateInfo {
 	bool AppliesToTransaction(transaction_t start_time, transaction_t transaction_id) {
 		// these tuples were either committed AFTER this transaction started or are not committed yet, use
 		// tuples stored in this version
+		if (version_number == TRANSACTION_ID_START - 1) {
+			// dummy transaction number for the root element - should always match
+			return true;
+		}
 		return version_number > start_time && version_number != transaction_id;
 	}
 

--- a/test/sql/index/art/issues/test_art_issue_21394.test
+++ b/test/sql/index/art/issues/test_art_issue_21394.test
@@ -1,0 +1,18 @@
+# name: test/sql/index/art/issues/test_art_issue_21394.test
+# description: Issue #21394 - Reading stale update during index removal after UPDATE + CREATE INDEX + DELETE
+# group: [issues]
+
+statement ok
+CREATE TABLE t0(c0 INT);
+
+statement ok
+INSERT INTO t0(c0) VALUES (2);
+
+statement ok
+UPDATE t0 SET c0=0;
+
+statement ok
+CREATE INDEX i1 ON t0(c0);
+
+statement ok
+DELETE FROM t0;


### PR DESCRIPTION
Note I only have the first test from the public issue, since the other two only reproduced on CLI, although I tried them out and they pass now as well. 

RemoveFromIndexes was trying to fetch the most recently updated value, but it's start time was TRANSACTION_ID_START - 1, the same as the root UpdateInfo (which holds the most recent update), so the AppliesToTransaction check returned false. The fix is to just always have AppliesToTransaction return true when the version_number is TRANSACTION_ID_START - 1.

https://github.com/duckdb/duckdb/issues/21394

https://github.com/duckdblabs/duckdb-internal/issues/8444

