### PR TITLE
Fix window elimination optimizer

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -673,7 +673,9 @@ void TopNWindowElimination::UpdateTopmostBindings(const idx_t window_idx, const 
                                                   const vector<ColumnBinding> &topmost_bindings,
                                                   vector<ColumnBinding> &new_bindings,
                                                   ColumnBindingReplacer &replacer) {
-	// The top-most operator's column order is [group][aggregate args][row number]. Now, set the new resulting bindings.
+	// The top-most operator's column order is:
+	// [projected groups][aggregate args/value][row number]
+	// Now set the new bindings according to this order and remember replacements in replacer
 	D_ASSERT(topmost_bindings.size() == new_bindings.size());
 	replacer.replacement_bindings.reserve(new_bindings.size());
 	set<idx_t> row_id_binding_idxs;
@@ -682,17 +684,20 @@ void TopNWindowElimination::UpdateTopmostBindings(const idx_t window_idx, const 
 	const idx_t aggregate_table_idx = GetAggregateIdx(op);
 
 	// Project the group columns
+	const auto compact_group_columns = group_table_idx == aggregate_table_idx;
 	idx_t current_column_idx = 0;
 	for (auto group_idx : group_idxs) {
-		const idx_t group_referencing_idx = group_idx.first;
+		const auto group_referencing_idx = group_idx.first;
+		const auto column_idx = compact_group_columns ? current_column_idx : group_idx.second;
 		new_bindings[group_referencing_idx].table_index = group_table_idx;
-		new_bindings[group_referencing_idx].column_index = group_idx.second;
+		new_bindings[group_referencing_idx].column_index = column_idx;
+
 		replacer.replacement_bindings.emplace_back(topmost_bindings[group_referencing_idx],
 		                                           new_bindings[group_referencing_idx]);
 		current_column_idx++;
 	}
 
-	if (group_table_idx != aggregate_table_idx) {
+	if (!compact_group_columns) {
 		// If the topmost operator is an aggregate, the table indexes are different, and we start back from 0
 		current_column_idx = 0;
 	}

--- a/test/optimizer/topn_window_elimination.test_slow
+++ b/test/optimizer/topn_window_elimination.test_slow
@@ -318,3 +318,43 @@ SELECT * FROM a, LATERAL (SELECT *, a_id AS id_dup FROM b ORDER BY array_distanc
 [1.0, 2.0, 3.0]	1	[1.0, 2.0, 3.0]	a	1
 [4.0, 5.0, 6.0]	2	[4.0, 5.0, 6.0]	b	2
 
+statement ok
+CREATE TABLE t(a INT, b INT, c VARCHAR);
+
+statement ok
+INSERT INTO t VALUES (1, 100, 'x'), (2, 200, 'y');
+
+query II
+SELECT c, avg(b)
+FROM (
+    SELECT * FROM t
+    QUALIFY row_number() OVER (PARTITION BY a, c ORDER BY b DESC) = 1
+) sub
+GROUP BY c
+ORDER BY ALL
+----
+x	100.0
+y	200.0
+
+query II
+SELECT c, avg(b)
+FROM (
+    SELECT *, row_number() OVER (PARTITION BY a, c ORDER BY b DESC) AS rn
+    FROM t
+) sub
+WHERE rn = 1
+GROUP BY c
+ORDER BY ALL;
+----
+x	100.0
+y	200.0
+
+query II
+WITH sub AS (
+    SELECT * FROM t
+    QUALIFY row_number() OVER (PARTITION BY a, c ORDER BY b DESC) = 1
+)
+SELECT c, avg(b) FROM sub GROUP BY c ORDER BY ALL;
+----
+x	100.0
+y	200.0


### PR DESCRIPTION
In the `TopNWindowElimination`, new bindings were not computed correctly in certain cases. This PR fixes that.

Fix: https://github.com/duckdb/duckdb/issues/21340
Fix: https://github.com/duckdblabs/duckdb-internal/issues/8378