### PR TITLE
Fix parquet metadata cache invalidation in local file system

### DIFF
--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -341,7 +341,7 @@ static vector<PartitionStatistics> ParquetGetPartitionStats(ClientContext &conte
 	}
 	auto &parquet_data = bind_data.bind_data->Cast<ParquetReadBindData>();
 	auto &cached_metadata = parquet_data.TryLoadCaches(bind_data, context);
-	if (!cached_metadata.empty()) {
+	if (cached_metadata.empty()) {
 		// no cached metadata - bail
 		return result;
 	}

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -699,6 +699,17 @@ void LocalFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener
 	}
 }
 
+string GetPosixVersionTag(struct stat s) {
+	// dev/ino should be enough, but to guard against in-place writes we also add file size and modification time
+	uint64_t version_tag[4];
+	Store(NumericCast<uint64_t>(s.st_dev), data_ptr_cast(&version_tag[0]));
+	Store(NumericCast<uint64_t>(s.st_ino), data_ptr_cast(&version_tag[1]));
+	Store(NumericCast<uint64_t>(s.st_size), data_ptr_cast(&version_tag[2]));
+	Store(Timestamp::FromEpochSeconds(s.st_mtime).value, data_ptr_cast(&version_tag[3]));
+
+	return string(char_ptr_cast(version_tag), sizeof(uint64_t) * 4);
+}
+
 bool LocalFileSystem::ListFilesExtended(const string &directory,
                                         const std::function<void(OpenFileInfo &info)> &callback,
                                         optional_ptr<FileOpener> opener) {
@@ -741,6 +752,8 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 		options.emplace("file_size", Value::BIGINT(UnsafeNumericCast<int64_t>(status.st_size)));
 		// last modified time
 		options.emplace("last_modified", Value::TIMESTAMP(Timestamp::FromTimeT(status.st_mtime)));
+		// version tag
+		options.emplace("etag", Value::BLOB_RAW(GetPosixVersionTag(status)));
 
 		// invoke callback
 		callback(info);
@@ -1510,15 +1523,7 @@ string LocalFileSystem::GetVersionTag(FileHandle &handle) {
 	if (fstat(fd, &s) == -1) {
 		throw IOException("Failed to get file size for file \"%s\": %s", handle.path, strerror(errno));
 	}
-
-	// dev/ino should be enough, but to guard against in-place writes we also add file size and modification time
-	uint64_t version_tag[4];
-	Store(NumericCast<uint64_t>(s.st_dev), data_ptr_cast(&version_tag[0]));
-	Store(NumericCast<uint64_t>(s.st_ino), data_ptr_cast(&version_tag[1]));
-	Store(NumericCast<uint64_t>(s.st_size), data_ptr_cast(&version_tag[2]));
-	Store(Timestamp::FromEpochSeconds(s.st_mtime).value, data_ptr_cast(&version_tag[3]));
-
-	return string(char_ptr_cast(version_tag), sizeof(uint64_t) * 4);
+	return GetPosixVersionTag(s);
 #endif
 }
 

--- a/test/configs/enable_verification.json
+++ b/test/configs/enable_verification.json
@@ -125,7 +125,8 @@
         "test/sql/types/geo/geometry_shred_checkpoint.test",
         "test/sql/window/test_window_constant_allocator.test",
         "test/parquet/variant/variant_stats_propagation.test",
-        "test/sql/types/geo/geometry_compatability.test"
+        "test/sql/types/geo/geometry_compatability.test",
+        "test/sql/copy/parquet/parquet_glob_cache.test"
       ]
     },
     {

--- a/test/configs/force_storage_restart.json
+++ b/test/configs/force_storage_restart.json
@@ -33,6 +33,12 @@
         "test/sql/logging/physical_operator_logging.test_slow",
         "test/logging/warnings_as_errors.test"
       ]
+    },
+    {
+      "reason": "Parquet metadata cache doesn't survive restarts",
+      "paths": [
+        "test/sql/copy/parquet/parquet_glob_cache.test"
+      ]
     }
   ]
 }

--- a/test/sql/copy/parquet/parquet_glob_cache.test
+++ b/test/sql/copy/parquet/parquet_glob_cache.test
@@ -1,0 +1,30 @@
+# name: test/sql/copy/parquet/parquet_glob_cache.test
+# description: Test usage of metadata cache in COUNT(*)
+# group: [parquet]
+
+require parquet
+
+statement ok
+SET parquet_metadata_cache=true;
+
+# first read reads the parquet files
+query II
+EXPLAIN select count(*) from parquet_scan('{DATA_DIR}/parquet-testing/glob/*')
+----
+physical_plan	<REGEX>:.*PARQUET_SCAN.*
+
+query I
+select count(*) from parquet_scan('{DATA_DIR}/parquet-testing/glob/*')
+----
+2
+
+# second read uses the metadata cache
+query II
+EXPLAIN select count(*) from parquet_scan('{DATA_DIR}/parquet-testing/glob/*')
+----
+physical_plan	<!REGEX>:.*PARQUET_SCAN.*
+
+query I
+select count(*) from parquet_scan('{DATA_DIR}/parquet-testing/glob/*')
+----
+2


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/20058 added a new version tag system to the `LocalFileSystem`, but this did not yet get emitted in the file-listing. As a result, the Parquet metadata cache would think the files were not the same as they had a different version tag, causing the metadata cache to not be used. 

This PR ensures we also emit the `etag` field in the glob, and adds a test ensuring the metadata cache is used to speed up `COUNT(*)` queries.