### PR TITLE
Parquet Reader: initialize scan without holding the global lock in the multi file reader

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -109,7 +109,7 @@ const uint64_t ParquetDecodeUtils::BITPACK_MASKS_SIZE = sizeof(ParquetDecodeUtil
 
 const uint8_t ParquetDecodeUtils::BITPACK_DLEN = 8;
 
-ColumnReader::ColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema_p)
+ColumnReader::ColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema_p)
     : column_schema(schema_p), reader(reader), page_rows_available(0), dictionary_decoder(*this),
       delta_binary_packed_decoder(*this), rle_decoder(*this), delta_length_byte_array_decoder(*this),
       delta_byte_array_decoder(*this), byte_stream_split_decoder(*this), aad_crypto_metadata(reader.allocator) {
@@ -122,7 +122,7 @@ Allocator &ColumnReader::GetAllocator() {
 	return reader.allocator;
 }
 
-ParquetReader &ColumnReader::Reader() {
+const ParquetReader &ColumnReader::Reader() {
 	return reader;
 }
 
@@ -825,7 +825,7 @@ void ColumnReader::ApplyPendingSkips(data_ptr_t define_out, data_ptr_t repeat_ou
 // Create Column Reader
 //===--------------------------------------------------------------------===//
 template <class T>
-static unique_ptr<ColumnReader> CreateDecimalReader(ParquetReader &reader, const ParquetColumnSchema &schema) {
+static unique_ptr<ColumnReader> CreateDecimalReader(const ParquetReader &reader, const ParquetColumnSchema &schema) {
 	switch (schema.type.InternalType()) {
 	case PhysicalType::INT16:
 		return make_uniq<TemplatedColumnReader<int16_t, TemplatedParquetValueConversion<T>>>(reader, schema);
@@ -840,7 +840,7 @@ static unique_ptr<ColumnReader> CreateDecimalReader(ParquetReader &reader, const
 	}
 }
 
-unique_ptr<ColumnReader> ColumnReader::CreateReader(ParquetReader &reader, const ParquetColumnSchema &schema) {
+unique_ptr<ColumnReader> ColumnReader::CreateReader(const ParquetReader &reader, const ParquetColumnSchema &schema) {
 	switch (schema.type.id()) {
 	case LogicalTypeId::BOOLEAN:
 		return make_uniq<BooleanColumnReader>(reader, schema);

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -62,11 +62,11 @@ class ColumnReader {
 	friend class RLEDecoder;
 
 public:
-	ColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema_p);
+	ColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema_p);
 	virtual ~ColumnReader();
 
 public:
-	static unique_ptr<ColumnReader> CreateReader(ParquetReader &reader, const ParquetColumnSchema &schema);
+	static unique_ptr<ColumnReader> CreateReader(const ParquetReader &reader, const ParquetColumnSchema &schema);
 	virtual void InitializeRead(idx_t row_group_index, const vector<ColumnChunk> &columns, TProtocol &protocol_p);
 	virtual idx_t Read(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result_out);
 	virtual void Select(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result_out,
@@ -78,7 +78,7 @@ public:
 	                        SelectionVector &sel, idx_t &approved_tuple_count);
 	virtual void Skip(idx_t num_values);
 
-	ParquetReader &Reader();
+	const ParquetReader &Reader();
 	const LogicalType &Type() const {
 		return column_schema.type;
 	}
@@ -303,7 +303,7 @@ protected:
 protected:
 	const ParquetColumnSchema &column_schema;
 
-	ParquetReader &reader;
+	const ParquetReader &reader;
 	idx_t pending_skips = 0;
 	bool page_is_filtered_out = false;
 

--- a/extension/parquet/include/parquet_decimal_utils.hpp
+++ b/extension/parquet/include/parquet_decimal_utils.hpp
@@ -46,7 +46,7 @@ public:
 		return res;
 	}
 
-	static unique_ptr<ColumnReader> CreateReader(ParquetReader &reader, const ParquetColumnSchema &schema);
+	static unique_ptr<ColumnReader> CreateReader(const ParquetReader &reader, const ParquetColumnSchema &schema);
 };
 
 template <>

--- a/extension/parquet/include/parquet_geometry.hpp
+++ b/extension/parquet/include/parquet_geometry.hpp
@@ -23,7 +23,7 @@ class ColumnReader;
 class ClientContext;
 
 struct GeometryColumnReader {
-	static unique_ptr<ColumnReader> Create(ParquetReader &reader, const ParquetColumnSchema &schema,
+	static unique_ptr<ColumnReader> Create(const ParquetReader &reader, const ParquetColumnSchema &schema,
 	                                       ClientContext &context);
 };
 

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -148,7 +148,7 @@ public:
 	              shared_ptr<ParquetFileMetadataCache> metadata = nullptr);
 	~ParquetReader() override;
 
-	CachingFileSystem fs;
+	mutable CachingFileSystem fs;
 	Allocator &allocator;
 	shared_ptr<ParquetFileMetadataCache> metadata;
 	ParquetOptions parquet_options;
@@ -167,13 +167,15 @@ public:
 
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
+	void PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+	                 LocalTableFunctionState &lstate_p) override;
 	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) override;
 	double GetProgressInFile(ClientContext &context) override;
 
 public:
-	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, vector<idx_t> groups_to_read);
+	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, vector<idx_t> groups_to_read) const;
 	AsyncResult Scan(ClientContext &context, ParquetReaderScanState &state, DataChunk &output);
 
 	idx_t NumRows() const;
@@ -184,11 +186,11 @@ public:
 	const duckdb_parquet::FileMetaData *GetFileMetadata() const;
 	string static GetUniqueFileIdentifier(const duckdb_parquet::EncryptionAlgorithm &encryption_algorithm);
 
-	uint32_t Read(duckdb_apache::thrift::TBase &object, TProtocol &iprot);
+	uint32_t Read(duckdb_apache::thrift::TBase &object, TProtocol &iprot) const;
 	uint32_t ReadEncrypted(duckdb_apache::thrift::TBase &object, TProtocol &iprot,
 	                       CryptoMetaData &aad_crypto_metadata) const;
 	uint32_t ReadData(duckdb_apache::thrift::protocol::TProtocol &iprot, const data_ptr_t buffer,
-	                  const uint32_t buffer_size);
+	                  const uint32_t buffer_size) const;
 	uint32_t ReadDataEncrypted(duckdb_apache::thrift::protocol::TProtocol &iprot, const data_ptr_t buffer,
 	                           const uint32_t buffer_size, CryptoMetaData &aad_crypto_metadata) const;
 
@@ -226,10 +228,9 @@ private:
 	ParquetColumnSchema ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat, idx_t &next_schema_idx,
 	                                         idx_t &next_file_idx, ClientContext &context);
 
-	unique_ptr<ColumnReader> CreateReader(ClientContext &context);
-
+	unique_ptr<ColumnReader> CreateReader(ClientContext &context) const;
 	unique_ptr<ColumnReader> CreateReaderRecursive(ClientContext &context, const vector<ColumnIndex> &indexes,
-	                                               const ParquetColumnSchema &schema);
+	                                               const ParquetColumnSchema &schema) const;
 	const duckdb_parquet::RowGroup &GetGroup(ParquetReaderScanState &state);
 	uint64_t GetGroupCompressedSize(ParquetReaderScanState &state);
 	idx_t GetGroupOffset(ParquetReaderScanState &state);

--- a/extension/parquet/include/reader/boolean_column_reader.hpp
+++ b/extension/parquet/include/reader/boolean_column_reader.hpp
@@ -20,7 +20,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::BOOL;
 
 public:
-	BooleanColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+	BooleanColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema)
 	    : TemplatedColumnReader<bool, BooleanParquetValueConversion>(reader, schema), byte_pos(0) {
 	}
 

--- a/extension/parquet/include/reader/callback_column_reader.hpp
+++ b/extension/parquet/include/reader/callback_column_reader.hpp
@@ -27,7 +27,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	CallbackColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+	CallbackColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema)
 	    : TemplatedColumnReader<DUCKDB_PHYSICAL_TYPE,
 	                            CallbackParquetValueConversion<PARQUET_PHYSICAL_TYPE, DUCKDB_PHYSICAL_TYPE, FUNC>>(
 	          reader, schema) {

--- a/extension/parquet/include/reader/decimal_column_reader.hpp
+++ b/extension/parquet/include/reader/decimal_column_reader.hpp
@@ -56,7 +56,7 @@ class DecimalColumnReader
 	    TemplatedColumnReader<DUCKDB_PHYSICAL_TYPE, DecimalParquetValueConversion<DUCKDB_PHYSICAL_TYPE, FIXED_LENGTH>>;
 
 public:
-	DecimalColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+	DecimalColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema)
 	    : TemplatedColumnReader<DUCKDB_PHYSICAL_TYPE,
 	                            DecimalParquetValueConversion<DUCKDB_PHYSICAL_TYPE, FIXED_LENGTH>>(reader, schema) {
 	}

--- a/extension/parquet/include/reader/interval_column_reader.hpp
+++ b/extension/parquet/include/reader/interval_column_reader.hpp
@@ -58,7 +58,7 @@ struct IntervalValueConversion {
 
 class IntervalColumnReader : public TemplatedColumnReader<interval_t, IntervalValueConversion> {
 public:
-	IntervalColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+	IntervalColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema)
 	    : TemplatedColumnReader<interval_t, IntervalValueConversion>(reader, schema) {
 	}
 };

--- a/extension/parquet/include/reader/list_column_reader.hpp
+++ b/extension/parquet/include/reader/list_column_reader.hpp
@@ -18,7 +18,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::LIST;
 
 public:
-	ListColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
+	ListColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema,
 	                 unique_ptr<ColumnReader> child_column_reader_p);
 
 	idx_t Read(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result_out) override;

--- a/extension/parquet/include/reader/null_column_reader.hpp
+++ b/extension/parquet/include/reader/null_column_reader.hpp
@@ -18,7 +18,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	NullColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema) : ColumnReader(reader, schema) {};
+	NullColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema) : ColumnReader(reader, schema) {};
 
 	shared_ptr<ResizeableBuffer> dict;
 

--- a/extension/parquet/include/reader/row_number_column_reader.hpp
+++ b/extension/parquet/include/reader/row_number_column_reader.hpp
@@ -20,7 +20,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INT64;
 
 public:
-	RowNumberColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema);
+	RowNumberColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema);
 
 public:
 	idx_t Read(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result) override;

--- a/extension/parquet/include/reader/string_column_reader.hpp
+++ b/extension/parquet/include/reader/string_column_reader.hpp
@@ -31,7 +31,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::VARCHAR;
 
 public:
-	StringColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema);
+	StringColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema);
 	idx_t fixed_width_string_length;
 	const StringColumnType string_column_type;
 

--- a/extension/parquet/include/reader/struct_column_reader.hpp
+++ b/extension/parquet/include/reader/struct_column_reader.hpp
@@ -18,7 +18,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::STRUCT;
 
 public:
-	StructColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
+	StructColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema,
 	                   vector<unique_ptr<ColumnReader>> child_readers_p);
 
 	vector<unique_ptr<ColumnReader>> child_readers;

--- a/extension/parquet/include/reader/templated_column_reader.hpp
+++ b/extension/parquet/include/reader/templated_column_reader.hpp
@@ -48,7 +48,8 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	TemplatedColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema) : ColumnReader(reader, schema) {
+	TemplatedColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema)
+	    : ColumnReader(reader, schema) {
 	}
 
 	shared_ptr<ResizeableBuffer> dict;

--- a/extension/parquet/include/reader/uuid_column_reader.hpp
+++ b/extension/parquet/include/reader/uuid_column_reader.hpp
@@ -51,7 +51,7 @@ struct UUIDValueConversion {
 
 class UUIDColumnReader : public TemplatedColumnReader<hugeint_t, UUIDValueConversion> {
 public:
-	UUIDColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+	UUIDColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema)
 	    : TemplatedColumnReader<hugeint_t, UUIDValueConversion>(reader, schema) {
 	}
 };

--- a/extension/parquet/include/reader/variant_column_reader.hpp
+++ b/extension/parquet/include/reader/variant_column_reader.hpp
@@ -18,7 +18,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::STRUCT;
 
 public:
-	VariantColumnReader(ClientContext &context, ParquetReader &reader, const ParquetColumnSchema &schema,
+	VariantColumnReader(ClientContext &context, const ParquetReader &reader, const ParquetColumnSchema &schema,
 	                    vector<unique_ptr<ColumnReader>> child_readers_p);
 
 	ClientContext &context;

--- a/extension/parquet/parquet_geometry.cpp
+++ b/extension/parquet/parquet_geometry.cpp
@@ -363,7 +363,7 @@ optional_ptr<const GeoParquetColumnMetadata> GeoParquetFileMetadata::GetColumnMe
 	return &it->second;
 }
 
-unique_ptr<ColumnReader> GeometryColumnReader::Create(ParquetReader &reader, const ParquetColumnSchema &schema,
+unique_ptr<ColumnReader> GeometryColumnReader::Create(const ParquetReader &reader, const ParquetColumnSchema &schema,
                                                       ClientContext &context) {
 	D_ASSERT(schema.type.id() == LogicalTypeId::GEOMETRY);
 	D_ASSERT(schema.children.size() == 1 && schema.children[0].type.id() == LogicalTypeId::BLOB);

--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -65,6 +65,7 @@ struct ParquetReadGlobalState : public GlobalTableFunctionState {
 
 struct ParquetReadLocalState : public LocalTableFunctionState {
 	ParquetReaderScanState scan_state;
+	vector<idx_t> group_indexes;
 };
 
 static void ParseFileRowNumberOption(MultiFileReaderBindData &bind_data, ParquetOptions &options,
@@ -684,10 +685,15 @@ bool ParquetReader::TryInitializeScan(ClientContext &context, GlobalTableFunctio
 		return false;
 	}
 	// The current reader has rowgroups left to be scanned
-	vector<idx_t> group_indexes {gstate.row_group_index};
-	InitializeScan(context, lstate.scan_state, group_indexes);
+	lstate.group_indexes = {gstate.row_group_index};
 	gstate.row_group_index++;
 	return true;
+}
+
+void ParquetReader::PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+                                LocalTableFunctionState &lstate_p) {
+	auto &lstate = lstate_p.Cast<ParquetReadLocalState>();
+	InitializeScan(context, lstate.scan_state, lstate.group_indexes);
 }
 
 void ParquetReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) {
@@ -705,7 +711,6 @@ AsyncResult ParquetReader::Scan(ClientContext &context, GlobalTableFunctionState
 		}
 	}
 #endif
-
 	auto &gstate = gstate_p.Cast<ParquetReadGlobalState>();
 	auto &local_state = local_state_p.Cast<ParquetReadLocalState>();
 	local_state.scan_state.op = gstate.op;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -408,7 +408,7 @@ ParquetColumnSchema ParquetReader::ParseColumnSchema(const SchemaElement &s_ele,
 
 unique_ptr<ColumnReader> ParquetReader::CreateReaderRecursive(ClientContext &context,
                                                               const vector<ColumnIndex> &indexes,
-                                                              const ParquetColumnSchema &schema) {
+                                                              const ParquetColumnSchema &schema) const {
 	switch (schema.schema_type) {
 	case ParquetColumnSchemaType::FILE_ROW_NUMBER:
 		return make_uniq<RowNumberColumnReader>(*this, schema);
@@ -460,7 +460,7 @@ unique_ptr<ColumnReader> ParquetReader::CreateReaderRecursive(ClientContext &con
 	}
 }
 
-unique_ptr<ColumnReader> ParquetReader::CreateReader(ClientContext &context) {
+unique_ptr<ColumnReader> ParquetReader::CreateReader(ClientContext &context) const {
 	auto ret = CreateReaderRecursive(context, column_indexes, *root_schema);
 	if (ret->Type().id() != LogicalTypeId::STRUCT) {
 		throw InternalException("Root element of Parquet file must be a struct");
@@ -974,7 +974,7 @@ string ParquetReader::GetUniqueFileIdentifier(const duckdb_parquet::EncryptionAl
 	}
 }
 
-uint32_t ParquetReader::Read(duckdb_apache::thrift::TBase &object, TProtocol &iprot) {
+uint32_t ParquetReader::Read(duckdb_apache::thrift::TBase &object, TProtocol &iprot) const {
 	return object.read(&iprot);
 }
 
@@ -986,7 +986,7 @@ uint32_t ParquetReader::ReadEncrypted(duckdb_apache::thrift::TBase &object, TPro
 }
 
 uint32_t ParquetReader::ReadData(duckdb_apache::thrift::protocol::TProtocol &iprot, const data_ptr_t buffer,
-                                 const uint32_t buffer_size) {
+                                 const uint32_t buffer_size) const {
 	return iprot.getTransport()->read(buffer, buffer_size);
 }
 
@@ -997,7 +997,7 @@ uint32_t ParquetReader::ReadDataEncrypted(duckdb_apache::thrift::protocol::TProt
 	                               *encryption_util, aad_crypto_metadata);
 }
 
-static idx_t GetRowGroupOffset(ParquetReader &reader, idx_t group_idx) {
+static idx_t GetRowGroupOffset(const ParquetReader &reader, idx_t group_idx) {
 	idx_t row_group_offset = 0;
 	auto &row_groups = reader.GetFileMetadata()->row_groups;
 	for (idx_t i = 0; i < group_idx; i++) {
@@ -1232,7 +1232,7 @@ ParquetScanFilter::~ParquetScanFilter() {
 }
 
 void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanState &state,
-                                   vector<idx_t> groups_to_read) {
+                                   vector<idx_t> groups_to_read) const {
 	state.current_group = -1;
 	state.finished = false;
 	state.offset_in_group = 0;

--- a/extension/parquet/reader/decimal_column_reader.cpp
+++ b/extension/parquet/reader/decimal_column_reader.cpp
@@ -3,7 +3,8 @@
 namespace duckdb {
 
 template <bool FIXED>
-static unique_ptr<ColumnReader> CreateDecimalReaderInternal(ParquetReader &reader, const ParquetColumnSchema &schema) {
+static unique_ptr<ColumnReader> CreateDecimalReaderInternal(const ParquetReader &reader,
+                                                            const ParquetColumnSchema &schema) {
 	switch (schema.type.InternalType()) {
 	case PhysicalType::INT16:
 		return make_uniq<DecimalColumnReader<int16_t, FIXED>>(reader, schema);
@@ -45,7 +46,8 @@ double ParquetDecimalUtils::ReadDecimalValue(const_data_ptr_t pointer, idx_t siz
 	return res;
 }
 
-unique_ptr<ColumnReader> ParquetDecimalUtils::CreateReader(ParquetReader &reader, const ParquetColumnSchema &schema) {
+unique_ptr<ColumnReader> ParquetDecimalUtils::CreateReader(const ParquetReader &reader,
+                                                           const ParquetColumnSchema &schema) {
 	if (schema.parquet_type == Type::FIXED_LEN_BYTE_ARRAY) {
 		return CreateDecimalReaderInternal<true>(reader, schema);
 	} else {

--- a/extension/parquet/reader/list_column_reader.cpp
+++ b/extension/parquet/reader/list_column_reader.cpp
@@ -171,7 +171,7 @@ idx_t ListColumnReader::Read(uint64_t num_values, data_ptr_t define_out, data_pt
 	return ReadInternal<TemplatedListReader>(num_values, define_out, repeat_out, result_out);
 }
 
-ListColumnReader::ListColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
+ListColumnReader::ListColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema,
                                    unique_ptr<ColumnReader> child_column_reader_p)
     : ColumnReader(reader, schema), child_column_reader(std::move(child_column_reader_p)),
       read_cache(reader.allocator, ListType::GetChildType(Type())), read_vector(read_cache), overflow_child_count(0) {

--- a/extension/parquet/reader/row_number_column_reader.cpp
+++ b/extension/parquet/reader/row_number_column_reader.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Row NumberColumn Reader
 //===--------------------------------------------------------------------===//
-RowNumberColumnReader::RowNumberColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+RowNumberColumnReader::RowNumberColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema)
     : ColumnReader(reader, schema) {
 }
 

--- a/extension/parquet/reader/string_column_reader.cpp
+++ b/extension/parquet/reader/string_column_reader.cpp
@@ -8,7 +8,7 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // String Column Reader
 //===--------------------------------------------------------------------===//
-StringColumnReader::StringColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+StringColumnReader::StringColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema)
     : ColumnReader(reader, schema), string_column_type(GetStringColumnType(Type())) {
 	fixed_width_string_length = 0;
 	if (schema.parquet_type == Type::FIXED_LEN_BYTE_ARRAY) {

--- a/extension/parquet/reader/struct_column_reader.cpp
+++ b/extension/parquet/reader/struct_column_reader.cpp
@@ -5,7 +5,7 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Struct Column Reader
 //===--------------------------------------------------------------------===//
-StructColumnReader::StructColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
+StructColumnReader::StructColumnReader(const ParquetReader &reader, const ParquetColumnSchema &schema,
                                        vector<unique_ptr<ColumnReader>> child_readers_p)
     : ColumnReader(reader, schema), child_readers(std::move(child_readers_p)) {
 	D_ASSERT(Type().InternalType() == PhysicalType::STRUCT);

--- a/extension/parquet/reader/variant_column_reader.cpp
+++ b/extension/parquet/reader/variant_column_reader.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Variant Column Reader
 //===--------------------------------------------------------------------===//
-VariantColumnReader::VariantColumnReader(ClientContext &context, ParquetReader &reader,
+VariantColumnReader::VariantColumnReader(ClientContext &context, const ParquetReader &reader,
                                          const ParquetColumnSchema &schema,
                                          vector<unique_ptr<ColumnReader>> child_readers_p)
     : ColumnReader(reader, schema), context(context), child_readers(std::move(child_readers_p)) {

--- a/src/common/multi_file/base_file_reader.cpp
+++ b/src/common/multi_file/base_file_reader.cpp
@@ -11,6 +11,9 @@ shared_ptr<BaseUnionData> BaseFileReader::GetUnionData(idx_t file_idx) {
 	throw NotImplementedException("Union by name not supported for reader of type %s", GetReaderType());
 }
 
+void BaseFileReader::PrepareScan(ClientContext &, GlobalTableFunctionState &, LocalTableFunctionState &) {
+}
+
 void BaseFileReader::PrepareReader(ClientContext &context, GlobalTableFunctionState &) {
 }
 

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -57,7 +57,7 @@ public:
 	const vector<MultiFileColumnDefinition> &GetColumns() const {
 		return columns;
 	}
-	const string &GetFileName() {
+	const string &GetFileName() const {
 		return file.path;
 	}
 	virtual bool UseCastMap() const {
@@ -76,8 +76,11 @@ public:
 	//! Prepare reader for scanning
 	DUCKDB_API virtual void PrepareReader(ClientContext &context, GlobalTableFunctionState &);
 
+	//! Try to initialize a scan over the reader - this is done while the global lock is held
 	virtual bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                               LocalTableFunctionState &lstate) = 0;
+	//! Prepare a scan - called after TryInitializeScan succeeds - this is done without any lock held
+	virtual void PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate, LocalTableFunctionState &lstate);
 	//! Scan a chunk from the read state
 	virtual AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                         LocalTableFunctionState &local_state, DataChunk &chunk) = 0;

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -361,7 +361,6 @@ public:
 
 	static void InitializeFileScanState(ClientContext &context, MultiFileReaderData &reader_data,
 	                                    MultiFileLocalState &lstate, vector<idx_t> &projection_ids) {
-		lstate.reader = reader_data.reader;
 		lstate.reader_data = reader_data;
 		auto &reader = *lstate.reader;
 		//! Initialize the intermediate chunk to be used by the underlying reader before being finalized
@@ -419,13 +418,16 @@ public:
 			if (current_reader_data.file_state == MultiFileFileState::OPEN) {
 				if (current_reader_data.reader->TryInitializeScan(context, *gstate.global_state,
 				                                                  *scan_data.local_state)) {
-					if (!current_reader_data.reader) {
+					scan_data.reader = current_reader_data.reader;
+					if (!scan_data.reader) {
 						throw InternalException("MultiFileReader was moved");
 					}
 					// The current reader has data left to be scanned
 					scan_data.batch_index = gstate.batch_index++;
 					auto old_file_index = scan_data.file_index;
 					scan_data.file_index = gstate.file_index;
+					parallel_lock.unlock();
+					scan_data.reader->PrepareScan(context, *gstate.global_state, *scan_data.local_state);
 					if (old_file_index != scan_data.file_index) {
 						InitializeFileScanState(context, current_reader_data, scan_data, gstate.projection_ids);
 					}

--- a/src/parallel/async_result.cpp
+++ b/src/parallel/async_result.cpp
@@ -66,11 +66,15 @@ AsyncResult::AsyncResult(vector<unique_ptr<AsyncTask>> &&tasks)
 }
 
 AsyncResult &AsyncResult::operator=(duckdb::SourceResultType t) {
-	return operator=(AsyncResult(t));
+	result_type = GetAsyncResultType(t);
+	async_tasks.clear();
+	return *this;
 }
 
 AsyncResult &AsyncResult::operator=(duckdb::AsyncResultType t) {
-	return operator=(AsyncResult(t));
+	result_type = t;
+	async_tasks.clear();
+	return *this;
 }
 
 AsyncResult &AsyncResult::operator=(AsyncResult &&other) noexcept {


### PR DESCRIPTION
This PR breaks up the initialize scan into a simple `TryInitializeScan` (called while holding the global lock) and a `PrepareScan` (called without holding the lock). `PrepareScan` performs all local set-up and allocation, while `TryInitializeScan` only sets up some values. This improves parallelism, particularly when running with many threads and doing short / small reads over many row groups.