### PR TITLE
Resolved inconsistencies in textual descriptions

### DIFF
--- a/extension/ExtensionDistribution.md
+++ b/extension/ExtensionDistribution.md
@@ -48,7 +48,7 @@ DuckDB-Wasm extensions are are downloaded by the browsers WITHOUT appening .gz, 
 Either the git tag (`v0.8.0`, `v0.8.1`, ...) or the git hash of a given duckdb version.
 It's chosen at compile time and baked in DuckDB. A given duckdb executable or library is tied to a single version identifier.
 
-### Plaform
+### Platform
 
 Fixed at compile time via platform detection and baked in DuckDB.
 

--- a/extension/delta/README.md
+++ b/extension/delta/README.md
@@ -51,7 +51,7 @@ See the [Extension Template](https://github.com/duckdb/extension-template) for g
 
 # Running tests
 There are various tests available for the delta extension:
-1. Delta Acceptence Test (DAT) based tests in `/test/sql/dat`
+1. Delta Acceptance Test (DAT) based tests in `/test/sql/dat`
 2. delta-kernel-rs based tests in `/test/sql/delta_kernel_rs`
 3. Generated data based tests in `tests/sql/generated` (generated using [delta-rs](https://delta-io.github.io/delta-rs/), [PySpark](https://spark.apache.org/docs/latest/api/python/index.html), and DuckDB)
 

--- a/extension/jemalloc/jemalloc/README.md
+++ b/extension/jemalloc/jemalloc/README.md
@@ -119,7 +119,7 @@ int strerror_fixed(int err, char *buf, size_t buflen) {
     }
     else if (r == 0) {
         //
-        // The GNU version always succeds and should never return 0 (NULL).
+        // The GNU version always succeeds and should never return 0 (NULL).
         //
         // "The XSI-compliant strerror_r() function returns 0 on success.
         // On error, a (positive) error number is returned (since glibc


### PR DESCRIPTION
Fixed a range of spelling mistakes in comments and text.

### Details:
- `extension/ExtensionDistribution.md`, line 51: `Plaform` → `Platform`
- `extension/delta/README.md`, line 54: `Acceptence` → `Acceptance`
- `extension/jemalloc/jemalloc/README.md`, line 122: `succeds` → `succeeds`

Only documentation-style text was changed.