### PR TITLE
Distribute work partition-wise when inserting into `JoinHashTable`

### DIFF
--- a/src/common/types/row/tuple_data_allocator.cpp
+++ b/src/common/types/row/tuple_data_allocator.cpp
@@ -115,6 +115,10 @@ void TupleDataAllocator::SetPartitionIndex(const idx_t index) {
 	partition_index = index;
 }
 
+idx_t TupleDataAllocator::GetPartitionIndex() const {
+	return partition_index.GetIndex();
+}
+
 bool TupleDataAllocator::BuildFastPath(TupleDataSegment &segment, TupleDataPinState &pin_state,
                                        TupleDataChunkState &chunk_state, const idx_t append_offset,
                                        const idx_t append_count) {

--- a/src/common/types/row/tuple_data_collection.cpp
+++ b/src/common/types/row/tuple_data_collection.cpp
@@ -112,6 +112,19 @@ void TupleDataCollection::SetPartitionIndex(const idx_t index) {
 	allocator->SetPartitionIndex(index);
 }
 
+vector<pair<idx_t, idx_t>> TupleDataCollection::GetChunkRangesForPartition(const idx_t partition_idx) const {
+	idx_t chunk_idx_start = 0;
+	vector<pair<idx_t, idx_t>> chunk_ranges;
+	for (const auto &segment : segments) {
+		const idx_t segment_partition_idx = segment->allocator->GetPartitionIndex();
+		if (partition_idx == segment_partition_idx) {
+			chunk_ranges.emplace_back(chunk_idx_start, chunk_idx_start + segment->ChunkCount());
+		}
+		chunk_idx_start += segment->ChunkCount();
+	}
+	return chunk_ranges;
+}
+
 vector<data_ptr_t> TupleDataCollection::GetRowBlockPointers() const {
 	D_ASSERT(segments.size() == 1);
 	const auto &segment = *segments[0];

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -37,12 +37,13 @@ JoinHashTable::InsertState::InsertState(const JoinHashTable &ht)
 
 JoinHashTable::JoinHashTable(ClientContext &context_p, const PhysicalOperator &op_p,
                              const vector<JoinCondition> &conditions_p, vector<LogicalType> btypes, JoinType type_p,
-                             const vector<idx_t> &output_columns_p, unique_ptr<ResidualPredicateInfo> residual_p,
-                             optional_ptr<Expression> predicate_ptr, const vector<idx_t> &output_in_probe)
+                             const idx_t initial_radix_bits, const vector<idx_t> &output_columns_p,
+                             unique_ptr<ResidualPredicateInfo> residual_p, optional_ptr<Expression> predicate_ptr,
+                             const vector<idx_t> &output_in_probe)
     : context(context_p), op(op_p), buffer_manager(BufferManager::GetBufferManager(context)), conditions(conditions_p),
       build_types(std::move(btypes)), output_columns(output_columns_p), entry_size(0), tuple_size(0),
       vfound(Value::BOOLEAN(false)), join_type(type_p), finalized(false), has_null(false),
-      residual_predicate(predicate_ptr), radix_bits(INITIAL_RADIX_BITS) {
+      residual_predicate(predicate_ptr), radix_bits(initial_radix_bits) {
 	// store residual predicate information
 	residual_info = std::move(residual_p);
 	lhs_output_in_probe = output_in_probe;
@@ -1739,6 +1740,10 @@ idx_t JoinHashTable::CurrentPartitionCount() const {
 	const auto num_partitions = RadixPartitioning::NumberOfPartitions(radix_bits);
 	D_ASSERT(current_partitions.Capacity() == num_partitions);
 	return current_partitions.CountValid(num_partitions);
+}
+
+const ValidityMask &JoinHashTable::GetCurrentPartitions() const {
+	return current_partitions;
 }
 
 idx_t JoinHashTable::FinishedPartitionCount() const {

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -285,10 +285,10 @@ public:
 	HashJoinGlobalSinkState(const PhysicalHashJoin &op_p, ClientContext &context_p)
 	    : context(context_p), op(op_p),
 	      num_threads(NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads())),
-	      temporary_memory_state(TemporaryMemoryManager::Get(context).Register(context)), finalized(false),
-	      active_local_states(0), total_size(0), max_partition_size(0), max_partition_count(0),
-	      probe_side_requirement(0), scanned_data(false) {
-		hash_table = op.InitializeHashTable(context);
+	      temporary_memory_state(TemporaryMemoryManager::Get(context).Register(context)),
+	      initial_radix_bits(num_threads < 100 ? 4 : 5), finalized(false), active_local_states(0), total_size(0),
+	      max_partition_size(0), max_partition_count(0), probe_side_requirement(0), scanned_data(false) {
+		hash_table = op.InitializeHashTable(context, initial_radix_bits);
 
 		// For perfect hash join
 		perfect_join_executor = make_uniq<PerfectHashJoinExecutor>(op, *hash_table);
@@ -331,6 +331,8 @@ public:
 	//! Temporary memory state for managing this operator's memory usage
 	unique_ptr<TemporaryMemoryState> temporary_memory_state;
 
+	//! Initial radix bits
+	const idx_t initial_radix_bits;
 	//! Global HT used by the join
 	unique_ptr<JoinHashTable> hash_table;
 	//! The perfect hash join executor (if any)
@@ -382,7 +384,7 @@ public:
 			payload_chunk.Initialize(allocator, op.payload_columns.col_types);
 		}
 
-		hash_table = op.InitializeHashTable(context);
+		hash_table = op.InitializeHashTable(context, gstate.initial_radix_bits);
 		hash_table->GetSinkCollection().InitializeAppendState(append_state);
 
 		gstate.active_local_states++;
@@ -406,10 +408,12 @@ public:
 	unique_ptr<JoinFilterLocalState> local_filter_state;
 };
 
-unique_ptr<JoinHashTable> PhysicalHashJoin::InitializeHashTable(ClientContext &context) const {
-	auto result = make_uniq<JoinHashTable>(context, *this, conditions, payload_columns.col_types, join_type,
-	                                       rhs_output_columns.col_idxs, residual_info ? residual_info->Copy() : nullptr,
-	                                       predicate ? predicate.get() : nullptr, lhs_output_in_probe);
+unique_ptr<JoinHashTable> PhysicalHashJoin::InitializeHashTable(ClientContext &context,
+                                                                const idx_t initial_radix_bits) const {
+	auto result =
+	    make_uniq<JoinHashTable>(context, *this, conditions, payload_columns.col_types, join_type, initial_radix_bits,
+	                             rhs_output_columns.col_idxs, residual_info ? residual_info->Copy() : nullptr,
+	                             predicate ? predicate.get() : nullptr, lhs_output_in_probe);
 
 	if (!delim_types.empty() && join_type == JoinType::MARK) {
 		// correlated MARK join
@@ -676,15 +680,24 @@ public:
 
 class HashJoinFinalizeTask : public ExecutorTask {
 public:
-	HashJoinFinalizeTask(shared_ptr<Event> event_p, ClientContext &context, HashJoinGlobalSinkState &sink_p,
-	                     idx_t chunk_idx_from_p, idx_t chunk_idx_to_p, bool parallel_p, const PhysicalOperator &op_p,
+	HashJoinFinalizeTask(HashJoinGlobalSinkState &sink_p, shared_ptr<Event> event, optional_idx partition_idx_p,
 	                     optional_ptr<PrefixRangeFilter::BuildState> prefix_range_state_p = nullptr)
-	    : ExecutorTask(context, std::move(event_p), op_p), sink(sink_p), chunk_idx_from(chunk_idx_from_p),
-	      chunk_idx_to(chunk_idx_to_p), parallel(parallel_p), prefix_range_state(prefix_range_state_p) {
+	    : ExecutorTask(sink_p.context, std::move(event), sink_p.op), sink(sink_p), partition_idx(partition_idx_p),
+	      prefix_range_state(prefix_range_state_p) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
-		sink.hash_table->Finalize(chunk_idx_from, chunk_idx_to, parallel, prefix_range_state);
+		const auto &data_collection = sink.hash_table->GetDataCollection();
+		if (!partition_idx.IsValid()) {
+			// Single-threaded finalize
+			sink.hash_table->Finalize(0U, data_collection.ChunkCount(), false, prefix_range_state);
+		} else {
+			// Parallel finalize - each thread processes one partition
+			const auto chunk_ranges = data_collection.GetChunkRangesForPartition(partition_idx.GetIndex());
+			for (auto &chunk_range : chunk_ranges) {
+				sink.hash_table->Finalize(chunk_range.first, chunk_range.second, true, prefix_range_state);
+			}
+		}
 		event->FinishTask();
 		return TaskExecutionResult::TASK_FINISHED;
 	}
@@ -694,9 +707,7 @@ public:
 
 private:
 	HashJoinGlobalSinkState &sink;
-	idx_t chunk_idx_from;
-	idx_t chunk_idx_to;
-	bool parallel;
+	optional_idx partition_idx;
 	optional_ptr<PrefixRangeFilter::BuildState> prefix_range_state;
 };
 
@@ -710,34 +721,27 @@ public:
 
 public:
 	void Schedule() override {
-		auto &context = pipeline->GetClientContext();
+		auto &ht = *sink.hash_table;
+		const auto build_prefix_range_filter = ht.ShouldBuildPrefixRangeFilter();
+		const bool finalize_single_threaded = FinalizeSingleThreaded(sink, false);
 
 		vector<shared_ptr<Task>> finalize_tasks;
-		auto &ht = *sink.hash_table;
-		const auto chunk_count = ht.GetDataCollection().ChunkCount();
-		const auto build_prefix_range_filter = ht.ShouldBuildPrefixRangeFilter();
-		const bool finalize_single_threaded = FinalizeSingleThreaded(sink, true);
-		const idx_t chunks_per_task = context.config.verify_parallelism ? 1 : CHUNKS_PER_TASK;
-		if (build_prefix_range_filter) {
-			prefix_range_states.clear();
-			const auto task_count =
-			    finalize_single_threaded ? 1 : (chunk_count + chunks_per_task - 1) / chunks_per_task;
-			prefix_range_states.reserve(task_count);
-		}
-
-		// if the keys are too skewed, we finalize single-threaded
 		if (finalize_single_threaded) {
 			// Single-threaded finalize
 			auto prefix_range_state = build_prefix_range_filter ? RegisterPrefixRangeState(ht) : nullptr;
-			finalize_tasks.push_back(make_uniq<HashJoinFinalizeTask>(shared_from_this(), context, sink, 0U, chunk_count,
-			                                                         false, sink.op, prefix_range_state));
+			finalize_tasks.push_back(
+			    make_uniq<HashJoinFinalizeTask>(sink, shared_from_this(), optional_idx(), prefix_range_state));
 		} else {
 			// Parallel finalize
-			for (idx_t chunk_idx = 0; chunk_idx < chunk_count; chunk_idx += chunks_per_task) {
-				auto chunk_idx_to = MinValue<idx_t>(chunk_idx + chunks_per_task, chunk_count);
+			const auto num_partitions = RadixPartitioning::NumberOfPartitions(ht.GetRadixBits());
+			const auto &current_partitions = ht.GetCurrentPartitions();
+			for (idx_t partition_idx = 0; partition_idx < num_partitions; partition_idx++) {
+				if (sink.external && !current_partitions.RowIsValidUnsafe(partition_idx)) {
+					continue; // Partition is not being built on
+				}
 				auto prefix_range_state = build_prefix_range_filter ? RegisterPrefixRangeState(ht) : nullptr;
-				finalize_tasks.push_back(make_uniq<HashJoinFinalizeTask>(
-				    shared_from_this(), context, sink, chunk_idx, chunk_idx_to, true, sink.op, prefix_range_state));
+				finalize_tasks.push_back(
+				    make_uniq<HashJoinFinalizeTask>(sink, shared_from_this(), partition_idx, prefix_range_state));
 			}
 		}
 		SetTasks(std::move(finalize_tasks));
@@ -818,7 +822,7 @@ public:
 
 public:
 	void Schedule() override {
-		D_ASSERT(sink.hash_table->GetRadixBits() > JoinHashTable::INITIAL_RADIX_BITS);
+		D_ASSERT(sink.hash_table->GetRadixBits() > sink.initial_radix_bits);
 		auto block_size = sink.hash_table->buffer_manager.GetBlockSize();
 
 		idx_t total_size = 0;
@@ -834,7 +838,7 @@ public:
 
 		// Assume 8 blocks per partition per thread (4 input, 4 output)
 		auto partition_multiplier =
-		    RadixPartitioning::NumberOfPartitions(sink.hash_table->GetRadixBits() - JoinHashTable::INITIAL_RADIX_BITS);
+		    RadixPartitioning::NumberOfPartitions(sink.hash_table->GetRadixBits() - sink.initial_radix_bits);
 		auto thread_memory = 2 * blocks_per_vector * partition_multiplier * block_size;
 		auto repartition_threads = MaxValue<idx_t>(sink.temporary_memory_state->GetReservation() / thread_memory, 1);
 

--- a/src/include/duckdb/common/types/row/tuple_data_allocator.hpp
+++ b/src/include/duckdb/common/types/row/tuple_data_allocator.hpp
@@ -76,6 +76,8 @@ public:
 	idx_t HeapBlockCount() const;
 	//! Sets the partition index of this tuple data allocator
 	void SetPartitionIndex(idx_t index);
+	//! Gets the partition index of this tuple data allocator
+	idx_t GetPartitionIndex() const;
 
 public:
 	//! Builds out the chunks for next append, given the metadata in the append state

--- a/src/include/duckdb/common/types/row/tuple_data_collection.hpp
+++ b/src/include/duckdb/common/types/row/tuple_data_collection.hpp
@@ -76,6 +76,8 @@ public:
 	void Unpin();
 	//! Sets the partition index of this tuple data collection
 	void SetPartitionIndex(idx_t index);
+	//! Get chunk ranges that belong to a specific partition index
+	vector<pair<idx_t, idx_t>> GetChunkRangesForPartition(idx_t partition_idx) const;
 	//! Gets the pointers to the start of every block
 	vector<data_ptr_t> GetRowBlockPointers() const;
 	//! Destroy the blocks corresponding to the chunk indices

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -195,9 +195,9 @@ public:
 	};
 
 	JoinHashTable(ClientContext &context, const PhysicalOperator &op, const vector<JoinCondition> &conditions,
-	              vector<LogicalType> build_types, JoinType type, const vector<idx_t> &output_columns,
-	              unique_ptr<ResidualPredicateInfo> residual_p, optional_ptr<Expression> predicate_ptr = nullptr,
-	              const vector<idx_t> &output_in_probe = {});
+	              vector<LogicalType> build_types, JoinType type, idx_t initial_radix_bits,
+	              const vector<idx_t> &output_columns, unique_ptr<ResidualPredicateInfo> residual_p,
+	              optional_ptr<Expression> predicate_ptr = nullptr, const vector<idx_t> &output_in_probe = {});
 	~JoinHashTable();
 
 	//! Add the given data to the HT
@@ -383,8 +383,6 @@ public:
 	//===--------------------------------------------------------------------===//
 	// External Join
 	//===--------------------------------------------------------------------===//
-	static constexpr const idx_t INITIAL_RADIX_BITS = 4;
-
 	struct ProbeSpillLocalAppendState {
 		ProbeSpillLocalAppendState() {
 		}
@@ -497,6 +495,8 @@ public:
 	void InitializePartitionMasks();
 	//! How many partitions are currently active
 	idx_t CurrentPartitionCount() const;
+	//! Get the current partitions validity mask
+	const ValidityMask &GetCurrentPartitions() const;
 	//! How many partitions are fully done
 	idx_t FinishedPartitionCount() const;
 	//! Partition this HT

--- a/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -50,7 +50,7 @@ public:
 	                 vector<JoinCondition> cond, JoinType join_type, idx_t estimated_cardinality);
 
 	//! Initialize HT for this operator
-	unique_ptr<JoinHashTable> InitializeHashTable(ClientContext &context) const;
+	unique_ptr<JoinHashTable> InitializeHashTable(ClientContext &context, idx_t initial_radix_bits) const;
 
 	//! The types of the join keys
 	vector<LogicalType> condition_types;


### PR DESCRIPTION
When inserting data with many duplicates into the build side of a join, we can get a lot of contention on atomics using compare-and-swap operations. This PR distributes the work partition-wise over threads, using the partitions we already have (that are created anyway for a potential external hash join). Exact hash matches always belong to the same partition, and will only be inserted by the same thread, greatly reducing contention.

I ran this little benchmark:
```sql
create or replace table build as select (range % 100) * 1_000_000 i from range(50_000_000);
create or replace table probe as select range i from range(100_000_000);
select count(*) from build join probe using (i);
```
And it brought the execution time down from ~5.5s to ~4.5s on my laptop, all of which is from reducing the time it takes to insert tuples into the hash table.

CI is taking forever on my fork so sending out the PR early here.