### PR TITLE
Fix #21436: correctly preserve spaces within unquoted struct values in pretty printing code

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -1075,6 +1075,7 @@ bool JSONParser::Process(const string &value) {
 	state = JSONState::REGULAR;
 	char quote_char = '"';
 	bool can_parse_value = false;
+	bool in_unquoted_value = false;
 	pos = 0;
 	for (; success && pos < value.size(); pos++) {
 		auto c = value[pos];
@@ -1107,6 +1108,7 @@ bool JSONParser::Process(const string &value) {
 				}
 				separators.pop_back();
 				HandleBracketClose(c);
+				in_unquoted_value = false;
 				break;
 			}
 			case '"':
@@ -1118,6 +1120,7 @@ bool JSONParser::Process(const string &value) {
 			case ',':
 				// comma - move to next line
 				HandleComma(c);
+				in_unquoted_value = false;
 				break;
 			case ':':
 				HandleColon();
@@ -1133,11 +1136,16 @@ bool JSONParser::Process(const string &value) {
 				HandleCharacter(c);
 				break;
 			case ' ':
+				if (in_unquoted_value) {
+					HandleCharacter(c);
+				}
+				break;
 			case '\t':
 			case '\n':
 				// skip whitespace
 				break;
 			default:
+				in_unquoted_value = true;
 				HandleCharacter(c);
 				break;
 			}

--- a/tools/shell/tests/test_large_value_rendering.py
+++ b/tools/shell/tests/test_large_value_rendering.py
@@ -236,4 +236,14 @@ FROM (VALUES
     result = test.run()
     result.check_stdout("🇺🇸 flag")
 
+def test_struct_spaces_rendering(shell):
+    test = (
+        ShellTest(shell)
+        .statement('.maxwidth 80')
+        .statement("select { column1: 'apple river cloud hammer bright', column2: 'forest table ocean pencil green' } s;")
+    )
+    result = test.run()
+    # verify the entire string is printed
+    result.check_stdout("apple river cloud hammer bright")
+
 # fmt: on


### PR DESCRIPTION
Fix #21436