### PR TITLE
Fix #21459: detect when read_duckdb is used to read a non-DuckDB file and throw a descriptive error

### DIFF
--- a/src/function/table/read_duckdb.cpp
+++ b/src/function/table/read_duckdb.cpp
@@ -198,6 +198,10 @@ DuckDBReader::DuckDBReader(ClientContext &context_p, OpenFileInfo file_p, const 
     : BaseFileReader(std::move(file_p)), context(context_p), finished(false) {
 	auto &attached = GetAttachedDatabase();
 	auto &catalog = attached.GetCatalog();
+	if (!catalog.IsDuckCatalog()) {
+		throw NotImplementedException("read_duckdb can only be used to read DuckDB files - \"%s\" is of type \"%s\"",
+		                              catalog.GetDBPath(), catalog.GetCatalogType());
+	}
 	vector<reference<TableCatalogEntry>> tables;
 	vector<reference<TableCatalogEntry>> candidate_tables;
 	catalog.ScanSchemas(context, [&](SchemaCatalogEntry &schema) {


### PR DESCRIPTION
Fixes #21459