### PR TITLE
Fix #21367: Prevent throwing in WindowSelfJoinOptimizer when a logical plan cannot be copied, instead fallback to not running the optimization

### DIFF
--- a/src/optimizer/window_self_join.cpp
+++ b/src/optimizer/window_self_join.cpp
@@ -192,9 +192,15 @@ unique_ptr<LogicalOperator> WindowSelfJoinOptimizer::OptimizeInternal(unique_ptr
 		auto &partitions = w_expr0.partitions;
 
 		// --- Transformation ---
-
+		// try to copy the LHS
+		unique_ptr<LogicalOperator> copy_child;
+		try {
+			copy_child = window.children[0]->Copy(optimizer.context);
+		} catch (...) {
+			// failed to copy the LHS - cannot run this optimizer
+			return op;
+		}
 		auto original_child = std::move(window.children[0]);
-		auto copy_child = original_child->Copy(optimizer.context);
 
 		// Rebind copy_child to avoid duplicate table indices
 		WindowSelfJoinTableRebinder rebinder(optimizer);

--- a/test/sql/optimizer/window_self_join_optimizer_csv.test
+++ b/test/sql/optimizer/window_self_join_optimizer_csv.test
@@ -1,0 +1,20 @@
+# name: test/sql/optimizer/window_self_join_optimizer_csv.test
+# group: [optimizer]
+
+statement ok
+COPY (
+    SELECT 'a' AS x, 10 AS a, 20 AS b, 30 AS c
+    UNION ALL BY NAME
+    SELECT 'b' AS x, 11 AS a, 21 AS b, 31 AS c
+    UNION ALL BY NAME
+    SELECT 'c' AS x, 12 AS a, 22 AS b, 32 AS c
+) TO '__TEST_DIR__/window_self_join_src.csv'
+
+query II rowsort
+SELECT
+    x, MAX(a) OVER (PARTITION BY x)
+FROM '__TEST_DIR__/window_self_join_src.csv'
+----
+a	10
+b	11
+c	12


### PR DESCRIPTION
Fixes #21367
Supersedes https://github.com/duckdb/duckdb/pull/21391