### PR TITLE
Reduce arg_min_max_n heap preallocation

### DIFF
--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -238,7 +238,6 @@ public:
 private:
 	void Grow(ArenaAllocator &allocator) {
 		D_ASSERT(allocated_capacity < capacity);
-		const auto old_capacity = allocated_capacity;
 		if (allocated_capacity == 0) {
 			allocated_capacity = 1;
 		} else if (allocated_capacity > capacity / 2) {

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -238,6 +238,7 @@ public:
 private:
 	void Grow(ArenaAllocator &allocator) {
 		D_ASSERT(allocated_capacity < capacity);
+		const auto old_allocated_capacity = allocated_capacity;
 		if (allocated_capacity == 0) {
 			allocated_capacity = 1;
 		} else if (allocated_capacity > capacity / 2) {
@@ -246,17 +247,12 @@ private:
 			allocated_capacity *= 2;
 		}
 
+		const auto old_size = old_allocated_capacity * sizeof(STORAGE_TYPE);
 		const auto new_size = allocated_capacity * sizeof(STORAGE_TYPE);
-		auto new_ptr = allocator.AllocateAligned(new_size);
-		auto new_heap = reinterpret_cast<STORAGE_TYPE *>(new_ptr);
-
-		for (idx_t i = 0; i < size; i++) {
-			new (&new_heap[i]) STORAGE_TYPE(std::move(heap[i]));
-		}
-		for (idx_t i = size; i < allocated_capacity; i++) {
-			new (&new_heap[i]) STORAGE_TYPE();
-		}
-		heap = new_heap;
+		auto ptr = heap ? allocator.ReallocateAligned(reinterpret_cast<data_ptr_t>(heap), old_size, new_size)
+		                : allocator.AllocateAligned(new_size);
+		memset(ptr + old_size, 0, new_size - old_size);
+		heap = reinterpret_cast<STORAGE_TYPE *>(ptr);
 	}
 
 	static bool Compare(const STORAGE_TYPE &left, const STORAGE_TYPE &right) {

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/enums/order_type.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/function/create_sort_key.hpp"
+#include <new>
 
 namespace duckdb {
 
@@ -238,15 +239,25 @@ private:
 	void Grow(ArenaAllocator &allocator) {
 		D_ASSERT(allocated_capacity < capacity);
 		const auto old_capacity = allocated_capacity;
-		allocated_capacity = MaxValue<idx_t>(1, allocated_capacity * 2);
-		allocated_capacity = MinValue(allocated_capacity, capacity);
+		if (allocated_capacity == 0) {
+			allocated_capacity = 1;
+		} else if (allocated_capacity > capacity / 2) {
+			allocated_capacity = capacity;
+		} else {
+			allocated_capacity *= 2;
+		}
 
-		const auto old_size = old_capacity * sizeof(STORAGE_TYPE);
 		const auto new_size = allocated_capacity * sizeof(STORAGE_TYPE);
-		auto ptr = heap ? allocator.ReallocateAligned(reinterpret_cast<data_ptr_t>(heap), old_size, new_size)
-		                : allocator.AllocateAligned(new_size);
-		memset(ptr + old_size, 0, new_size - old_size);
-		heap = reinterpret_cast<STORAGE_TYPE *>(ptr);
+		auto new_ptr = allocator.AllocateAligned(new_size);
+		auto new_heap = reinterpret_cast<STORAGE_TYPE *>(new_ptr);
+
+		for (idx_t i = 0; i < size; i++) {
+			new (&new_heap[i]) STORAGE_TYPE(std::move(heap[i]));
+		}
+		for (idx_t i = size; i < allocated_capacity; i++) {
+			new (&new_heap[i]) STORAGE_TYPE();
+		}
+		heap = new_heap;
 	}
 
 	static bool Compare(const STORAGE_TYPE &left, const STORAGE_TYPE &right) {

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -180,9 +180,8 @@ public:
 
 	void Initialize(ArenaAllocator &allocator, const idx_t capacity_p) {
 		capacity = capacity_p;
-		auto ptr = allocator.AllocateAligned(capacity * sizeof(STORAGE_TYPE));
-		memset(ptr, 0, capacity * sizeof(STORAGE_TYPE));
-		heap = reinterpret_cast<STORAGE_TYPE *>(ptr);
+		allocated_capacity = 0;
+		heap = nullptr;
 		size = 0;
 	}
 
@@ -201,6 +200,9 @@ public:
 
 		// If the heap is not full, insert the value into a new slot
 		if (size < capacity) {
+			if (size == allocated_capacity) {
+				Grow(allocator);
+			}
 			heap[size].first.Assign(allocator, key);
 			heap[size].second.Assign(allocator, value);
 			size++;
@@ -233,13 +235,28 @@ public:
 	}
 
 private:
+	void Grow(ArenaAllocator &allocator) {
+		D_ASSERT(allocated_capacity < capacity);
+		const auto old_capacity = allocated_capacity;
+		allocated_capacity = MaxValue<idx_t>(1, allocated_capacity * 2);
+		allocated_capacity = MinValue(allocated_capacity, capacity);
+
+		const auto old_size = old_capacity * sizeof(STORAGE_TYPE);
+		const auto new_size = allocated_capacity * sizeof(STORAGE_TYPE);
+		auto ptr = heap ? allocator.ReallocateAligned(reinterpret_cast<data_ptr_t>(heap), old_size, new_size)
+		                : allocator.AllocateAligned(new_size);
+		memset(ptr + old_size, 0, new_size - old_size);
+		heap = reinterpret_cast<STORAGE_TYPE *>(ptr);
+	}
+
 	static bool Compare(const STORAGE_TYPE &left, const STORAGE_TYPE &right) {
 		return K_COMPARATOR::Operation(left.first.value, right.first.value);
 	}
 
-	idx_t capacity;
-	STORAGE_TYPE *heap;
-	idx_t size;
+	idx_t capacity = 0;
+	idx_t allocated_capacity = 0;
+	STORAGE_TYPE *heap = nullptr;
+	idx_t size = 0;
 };
 
 enum class ArgMinMaxNullHandling { IGNORE_ANY_NULL, HANDLE_ARG_NULL, HANDLE_ANY_NULL };

--- a/src/include/duckdb/optimizer/topn_window_elimination.hpp
+++ b/src/include/duckdb/optimizer/topn_window_elimination.hpp
@@ -51,8 +51,8 @@ private:
 
 	vector<unique_ptr<Expression>> GenerateAggregatePayload(const vector<ColumnBinding> &bindings,
 	                                                        const LogicalWindow &window, map<idx_t, idx_t> &group_idxs);
-	vector<ColumnBinding> TraverseProjectionBindings(const std::vector<ColumnBinding> &old_bindings,
-	                                                 reference<LogicalOperator> &op);
+	bool TraverseProjectionBindings(const vector<ColumnBinding> &old_bindings, reference<LogicalOperator> &op,
+	                                vector<ColumnBinding> &new_bindings);
 	unique_ptr<Expression> CreateAggregateExpression(vector<unique_ptr<Expression>> aggregate_params, bool requires_arg,
 	                                                 const TopNWindowEliminationParameters &params) const;
 	unique_ptr<Expression> CreateRowNumberGenerator(unique_ptr<Expression> aggregate_column_ref) const;

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -186,7 +186,10 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 
 	// Get bindings and types from filter to use in top-most operator later
 	const auto topmost_bindings = filter.GetColumnBindings();
-	auto new_bindings = TraverseProjectionBindings(topmost_bindings, child);
+	vector<ColumnBinding> new_bindings;
+	if (!TraverseProjectionBindings(topmost_bindings, child, new_bindings)) {
+		return op;
+	}
 
 	D_ASSERT(child.get().type == LogicalOperatorType::LOGICAL_WINDOW);
 	auto &window = child.get().Cast<LogicalWindow>();
@@ -647,9 +650,10 @@ vector<unique_ptr<Expression>> TopNWindowElimination::GenerateAggregatePayload(c
 	return aggregate_args;
 }
 
-vector<ColumnBinding> TopNWindowElimination::TraverseProjectionBindings(const std::vector<ColumnBinding> &old_bindings,
-                                                                        reference<LogicalOperator> &op) {
-	auto new_bindings = old_bindings;
+bool TopNWindowElimination::TraverseProjectionBindings(const vector<ColumnBinding> &old_bindings,
+                                                       reference<LogicalOperator> &op,
+                                                       vector<ColumnBinding> &new_bindings) {
+	new_bindings = old_bindings;
 
 	// Traverse child projections to retrieve projections on window output
 	while (op.get().type == LogicalOperatorType::LOGICAL_PROJECTION) {
@@ -659,13 +663,17 @@ vector<ColumnBinding> TopNWindowElimination::TraverseProjectionBindings(const st
 			auto &new_binding = new_bindings[i];
 			D_ASSERT(new_binding.table_index == projection.table_index);
 			VisitExpression(&projection.expressions[new_binding.column_index]);
+			if (column_references.size() != 1) {
+				column_references.clear();
+				return false;
+			}
 			new_binding = column_references.begin()->first;
 			column_references.clear();
 		}
 		op = *op.get().children[0];
 	}
 
-	return new_bindings;
+	return true;
 }
 
 void TopNWindowElimination::UpdateTopmostBindings(const idx_t window_idx, const unique_ptr<LogicalOperator> &op,

--- a/test/issues/general/test_21431.test
+++ b/test/issues/general/test_21431.test
@@ -1,5 +1,6 @@
 # name: test/issues/general/test_21431.test
 # description: Regression test for OOM with TopN window elimination
+# group: [general]
 
 statement ok
 SET memory_limit = '300MB'

--- a/test/issues/general/test_21431.test
+++ b/test/issues/general/test_21431.test
@@ -1,0 +1,25 @@
+# name: test/issues/general/test_21431.test
+# description: Regression test for OOM with TopN window elimination
+
+statement ok
+SET memory_limit = '300MB'
+
+statement ok
+CREATE TABLE t AS
+SELECT i / 2 AS group_id, i % 10 AS category, i % 1000 AS value
+FROM range(0, 400000) r(i)
+
+query I
+WITH counts AS (
+    SELECT group_id, category, COUNT(*) AS cnt
+    FROM t
+    GROUP BY group_id, category
+), ranked AS (
+    SELECT *,
+        ROW_NUMBER() OVER (PARTITION BY group_id ORDER BY cnt DESC) AS rn
+    FROM counts
+    QUALIFY rn <= 50
+)
+SELECT COUNT(*) FROM ranked
+----
+400000

--- a/test/issues/general/test_21431.test
+++ b/test/issues/general/test_21431.test
@@ -5,13 +5,11 @@
 statement ok
 SET memory_limit = '300MB'
 
-statement ok
-CREATE TABLE t AS
-SELECT i / 2 AS group_id, i % 10 AS category, i % 1000 AS value
-FROM range(0, 400000) r(i)
-
 query I
-WITH counts AS (
+WITH t AS (
+    SELECT i / 2 AS group_id, i % 10 AS category, i % 1000 AS value
+    FROM range(0, 400000) r(i)
+), counts AS (
     SELECT group_id, category, COUNT(*) AS cnt
     FROM t
     GROUP BY group_id, category


### PR DESCRIPTION
Fixes #21431

## Summary
- change `BinaryAggregateHeap` to grow its storage on demand instead of pre-allocating all `n` slots up front
- keep the logical heap capacity at `n` while only allocating as many slots as are actually inserted
- add a regression test for the `TopN Window Elimination` OOM reproducer

## Root Cause
`TopN Window Elimination` rewrites `QUALIFY rn <= 50` into `arg_min_max_n(..., 50)`. The `arg_min_max_n` state previously pre-allocated all 50 heap slots immediately for every group, even when each group only needed a handful of rows. In the issue reproducer there are many groups with at most 3 rows each, so most of that heap storage stayed unused and pushed the query into OOM.

## Testing
- `make allunit`
- `test/issues/general/test_21431.test`