### PR TITLE
Shell: use Unicode entry point on Windows

### DIFF
--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -3,7 +3,6 @@ add_subdirectory(linenoise)
 add_definitions(-DHAVE_LINENOISE=1)
 include_directories(../../third_party/utf8proc/include)
 include_directories(linenoise/include)
-add_definitions(-DSQLITE_SHELL_IS_UTF8)
 add_definitions(-DUSE_DUCKDB_SHELL_WRAPPER)
 
 include_directories(../../third_party/utf8proc/include)

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3259,7 +3259,7 @@ int RunShell(int argc, const char **argv) {
 	return rc;
 }
 
-#if !(defined(_WIN32) || defined(WIN32))
+#if !((defined(_WIN32) || defined(WIN32)) && defined(_MSC_VER))
 int main(int argc, const char **argv) {
 #else
 int wmain(int argc, wchar_t **wargv) {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3028,14 +3028,6 @@ void ShellState::Initialize() {
 #endif
 }
 
-#ifndef SQLITE_SHELL_IS_UTF8
-#if (defined(_WIN32) || defined(WIN32)) && defined(_MSC_VER)
-#define SQLITE_SHELL_IS_UTF8 (0)
-#else
-#define SQLITE_SHELL_IS_UTF8 (1)
-#endif
-#endif
-
 void ShellState::DetectDarkLightMode() {
 #ifdef HAVE_LINENOISE
 	ShellHighlight highlight(*this);
@@ -3267,16 +3259,18 @@ int RunShell(int argc, const char **argv) {
 	return rc;
 }
 
-#if SQLITE_SHELL_IS_UTF8
+#if !(defined(_WIN32) || defined(WIN32))
 int main(int argc, const char **argv) {
 #else
 int wmain(int argc, wchar_t **wargv) {
-	const char **argv;
 	vector<string> utf8_args;
 	utf8_args.resize(argc);
-	for (i = 0; i < argc; i++) {
+	vector<const char *> utf8_args_ptrs;
+	utf8_args_ptrs.resize(argc);
+	const char **argv = utf8_args_ptrs.data();
+	for (int i = 0; i < argc; i++) {
 		utf8_args[i] = ShellState::Win32UnicodeToUtf8(wargv[i]);
-		argv[i] = utf8_args[i].c_str();
+		utf8_args_ptrs[i] = utf8_args[i].c_str();
 	}
 #endif
 


### PR DESCRIPTION
There is a historical prerpocessor definition `SQLITE_SHELL_IS_UTF8` that appeared to be set incorrectly on Windows. It seems that it was supposed to be disabled on Windows, but instead was unconditionally enabled on all platforms. It causes the normal `main` entry point to be used in Windows shell instead of the Unicode-enabled [wmain](https://learn.microsoft.com/en-us/cpp/c-language/using-wmain?view=msvc-170), that is necessary to recieve Unicode command line arguments.

This PR removes that definition completely (after recent changes it was not used for anything else except `main/wmain`) and instead chooses the entry point based on the platform.

Fixes: #21445