### PR TITLE
Rework table filters to always use a `ProjectionIndex`

### DIFF
--- a/.github/patches/extensions/delta/fix.patch
+++ b/.github/patches/extensions/delta/fix.patch
@@ -28,7 +28,7 @@ index 8c08714..708dd0a 100644
  	}
  }
 diff --git a/src/functions/delta_scan/delta_multi_file_list.cpp b/src/functions/delta_scan/delta_multi_file_list.cpp
-index 7d918bd..df9c173 100644
+index 7d918bd..06483e7 100644
 --- a/src/functions/delta_scan/delta_multi_file_list.cpp
 +++ b/src/functions/delta_scan/delta_multi_file_list.cpp
 @@ -787,20 +787,22 @@ void DeltaMultiFileList::EnsureScanInitialized() const {
@@ -55,7 +55,7 @@ index 7d918bd..df9c173 100644
 -		if (entry.first < global_columns.size()) {
 -			result_filter_set.PushFilter(ColumnIndex(entry.first), entry.second->Copy());
 +	for (auto &entry : new_filters) {
-+		auto &column_id = column_indexes[entry.ColumnIndex().index];
++		auto &column_id = column_indexes[entry.GetIndex()];
 +		if (column_id < global_columns.size()) {
 +			result_filter_set.PushFilter(column_id, entry.Filter().Copy());
  		}
@@ -128,9 +128,9 @@ index 7d918bd..df9c173 100644
 -		if (previously_pushed_down_filter != this->table_filters.filters.end() &&
 -		    filter.second->Equals(*previously_pushed_down_filter->second)) {
 +	for (auto &entry : filters) {
-+		auto proj_id = entry.ColumnIndex();
++		auto proj_id = entry.GetIndex();
 +		auto &filter = entry.Filter();
-+		auto column_id = column_ids[proj_id.index];
++		auto column_id = column_ids[proj_id];
 +		auto previously_pushed_down_filter = table_filters.TryGetFilterByColumnIndex(column_id);
 +		if (previously_pushed_down_filter && filter.Equals(*previously_pushed_down_filter)) {
  			// Skip filters that we already have pushed down

--- a/.github/patches/extensions/delta/fix.patch
+++ b/.github/patches/extensions/delta/fix.patch
@@ -1,20 +1,34 @@
 diff --git a/src/delta_utils.cpp b/src/delta_utils.cpp
-index 8c08714..92310e1 100644
+index 8c08714..708dd0a 100644
 --- a/src/delta_utils.cpp
 +++ b/src/delta_utils.cpp
-@@ -856,8 +856,8 @@ PredicateVisitor::PredicateVisitor(const vector<DeltaMultiFileColumnDefinition>
+@@ -3,6 +3,7 @@
+ #include <list>
+ 
+ #include "delta_log_types.hpp"
++#include "functions/delta_scan/delta_multi_file_list.hpp"
+ #include "duckdb/common/operator/decimal_cast_operators.hpp"
+ 
+ #include "duckdb.hpp"
+@@ -851,13 +852,13 @@ KernelUtils::UnpackTransformExpression(const vector<unique_ptr<ParsedExpression>
+ }
+ 
+ PredicateVisitor::PredicateVisitor(const vector<DeltaMultiFileColumnDefinition> &columns,
+-                                   optional_ptr<const TableFilterSet> filters) {
++                                   optional_ptr<const DeltaTableFilters> filters) {
+ 	predicate = this;
  	visitor = (uintptr_t(*)(void *, ffi::KernelExpressionVisitorState *)) & VisitPredicate;
  
  	if (filters) {
 -		for (auto &filter : filters->filters) {
 -			column_filters[columns[filter.first].name] = filter.second.get();
 +		for (auto &entry : *filters) {
-+			column_filters[columns[entry.ColumnIndex().index].name] = &entry.Filter();
++			column_filters[columns[entry.first].name] = entry.second.get();
  		}
  	}
  }
 diff --git a/src/functions/delta_scan/delta_multi_file_list.cpp b/src/functions/delta_scan/delta_multi_file_list.cpp
-index 7d918bd..577b4f8 100644
+index 7d918bd..df9c173 100644
 --- a/src/functions/delta_scan/delta_multi_file_list.cpp
 +++ b/src/functions/delta_scan/delta_multi_file_list.cpp
 @@ -787,20 +787,22 @@ void DeltaMultiFileList::EnsureScanInitialized() const {
@@ -26,13 +40,14 @@ index 7d918bd..577b4f8 100644
 +                                                                    vector<column_t> column_indexes) const {
  	auto filtered_list = make_uniq<DeltaMultiFileList>(context, paths[0].path, version);
  
- 	TableFilterSet result_filter_set;
+-	TableFilterSet result_filter_set;
++	DeltaTableFilters result_filter_set;
  
  	// Add pre-existing filters
 -	for (auto &entry : table_filters.filters) {
 -		result_filter_set.PushFilter(ColumnIndex(entry.first), entry.second->Copy());
 +	for (auto &entry : table_filters) {
-+		result_filter_set.PushFilter(entry.ColumnIndex(), entry.Filter().Copy());
++		result_filter_set.PushFilter(entry.first, entry.second->Copy());
  	}
  
  	// Add new filters
@@ -42,19 +57,11 @@ index 7d918bd..577b4f8 100644
 +	for (auto &entry : new_filters) {
 +		auto &column_id = column_indexes[entry.ColumnIndex().index];
 +		if (column_id < global_columns.size()) {
-+			result_filter_set.PushFilter(entry.ColumnIndex(), entry.Filter().Copy());
++			result_filter_set.PushFilter(column_id, entry.Filter().Copy());
  		}
  	}
  
-@@ -809,6 +811,7 @@ unique_ptr<DeltaMultiFileList> DeltaMultiFileList::PushdownInternal(ClientContex
- 	filtered_list->table_filters = std::move(result_filter_set);
- 	filtered_list->global_columns = global_columns;
- 	filtered_list->lazy_loaded_schema = lazy_loaded_schema;
-+	filtered_list->column_indexes = std::move(column_indexes);
- 
- 	// Copy over the snapshot, this avoids reparsing metadata
- 	{
-@@ -849,11 +852,11 @@ unique_ptr<MultiFileList> DeltaMultiFileList::ComplexFilterPushdown(ClientContex
+@@ -849,11 +851,11 @@ unique_ptr<MultiFileList> DeltaMultiFileList::ComplexFilterPushdown(ClientContex
  
  	vector<FilterPushdownResult> pushdown_results;
  	auto filter_set = combiner.GenerateTableScanFilters(info.column_indexes, pushdown_results);
@@ -68,7 +75,7 @@ index 7d918bd..577b4f8 100644
  
  	ReportFilterPushdown(context, *filtered_list, info.column_ids, "constant", info);
  
-@@ -916,24 +919,26 @@ void DeltaMultiFileList::ReportFilterPushdown(ClientContext &context, DeltaMulti
+@@ -916,24 +918,24 @@ void DeltaMultiFileList::ReportFilterPushdown(ClientContext &context, DeltaMulti
  
  	// Report the new filters
  	vector<Value> old_filters_value_list;
@@ -79,9 +86,8 @@ index 7d918bd..577b4f8 100644
 -			auto &col_name = global_columns[column_index].name;
 -			old_filters_value_list.push_back(filter->ToString(col_name));
 +	for (auto &entry : table_filters) {
-+		auto proj_index = entry.ColumnIndex();
-+		auto &filter = entry.Filter();
-+		auto column_id = column_ids[proj_index.index];
++		auto &filter = *entry.second;
++		auto column_id = entry.first;
 +		if (column_id < global_columns.size()) {
 +			auto &col_name = global_columns[column_id].name;
 +			old_filters_value_list.push_back(filter.ToString(col_name));
@@ -98,16 +104,15 @@ index 7d918bd..577b4f8 100644
 -			auto &col_name = global_columns[column_index].name;
 -			filters_value_list.push_back(filter->ToString(col_name));
 +	for (auto &entry : new_list.table_filters) {
-+		auto proj_index = entry.ColumnIndex();
-+		auto &filter = entry.Filter();
-+		auto column_id = column_ids[proj_index.index];
++		auto column_id = entry.first;
++		auto &filter = *entry.second;
 +		if (column_id < global_columns.size()) {
 +			auto &col_name = global_columns[column_id].name;
 +			filters_value_list.push_back(filter.ToString(col_name));
  		}
  	}
  	auto filters_value = Value::LIST(LogicalType::VARCHAR, filters_value_list);
-@@ -970,24 +975,24 @@ DeltaMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFil
+@@ -970,24 +972,25 @@ DeltaMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFil
  		return nullptr;
  	}
  
@@ -125,7 +130,8 @@ index 7d918bd..577b4f8 100644
 +	for (auto &entry : filters) {
 +		auto proj_id = entry.ColumnIndex();
 +		auto &filter = entry.Filter();
-+		auto previously_pushed_down_filter = table_filters.TryGetFilterByColumnIndex(proj_id);
++		auto column_id = column_ids[proj_id.index];
++		auto previously_pushed_down_filter = table_filters.TryGetFilterByColumnIndex(column_id);
 +		if (previously_pushed_down_filter && filter.Equals(*previously_pushed_down_filter)) {
  			// Skip filters that we already have pushed down
  			continue;
@@ -142,7 +148,7 @@ index 7d918bd..577b4f8 100644
  		return std::move(new_snap);
  	}
 diff --git a/src/include/delta_utils.hpp b/src/include/delta_utils.hpp
-index 3fdce7f..8ab602d 100644
+index 3fdce7f..11acc31 100644
 --- a/src/include/delta_utils.hpp
 +++ b/src/include/delta_utils.hpp
 @@ -11,7 +11,8 @@
@@ -155,7 +161,17 @@ index 3fdce7f..8ab602d 100644
  #include <iostream>
  
  #include "duckdb/planner/tableref/bound_at_clause.hpp"
-@@ -431,7 +432,7 @@ public:
+@@ -423,15 +424,16 @@ protected:
+ };
+ 
+ typedef SharedKernelPointer<ffi::SharedSnapshot, ffi::free_snapshot> SharedKernelSnapshot;
++struct DeltaTableFilters;
+ 
+ class PredicateVisitor : public ffi::EnginePredicate {
+ public:
+-	PredicateVisitor(const vector<DeltaMultiFileColumnDefinition> &columns, optional_ptr<const TableFilterSet> filters);
++	PredicateVisitor(const vector<DeltaMultiFileColumnDefinition> &columns, optional_ptr<const DeltaTableFilters> filters);
+ 
  	ErrorData error_data;
  
  private:
@@ -165,10 +181,52 @@ index 3fdce7f..8ab602d 100644
  	static uintptr_t VisitPredicate(PredicateVisitor *predicate, ffi::KernelExpressionVisitorState *state);
  
 diff --git a/src/include/functions/delta_scan/delta_multi_file_list.hpp b/src/include/functions/delta_scan/delta_multi_file_list.hpp
-index b196db7..e4eed67 100644
+index b196db7..de2623e 100644
 --- a/src/include/functions/delta_scan/delta_multi_file_list.hpp
 +++ b/src/include/functions/delta_scan/delta_multi_file_list.hpp
-@@ -73,7 +73,7 @@ public:
+@@ -41,6 +41,41 @@ struct DeltaFileMetaData {
+ 	unique_ptr<vector<unique_ptr<ParsedExpression>>> transform_expression;
+ };
+ 
++struct DeltaTableFilters {
++	using filter_set_t = unordered_map<idx_t, unique_ptr<TableFilter>>;
++	using iterator = filter_set_t::iterator;
++	using const_iterator = filter_set_t::const_iterator;
++public:
++	bool HasFilters() const {
++		return !table_filters.empty();
++	}
++	void PushFilter(column_t column_idx, unique_ptr<TableFilter> table_filter) {
++		table_filters[column_idx] = std::move(table_filter);
++	}
++	optional_ptr<const TableFilter> TryGetFilterByColumnIndex(column_t column_idx) const {
++		auto entry = table_filters.find(column_idx);
++		if (entry == table_filters.end()) {
++			return nullptr;
++		}
++		return entry->second.get();
++	}
++
++	iterator begin() { // NOLINT: match stl API
++		return table_filters.begin();
++	}
++	iterator end() { // NOLINT: match stl API
++		return table_filters.end();
++	}
++	const_iterator begin() const { // NOLINT: match stl API
++		return table_filters.begin();
++	}
++	const_iterator end() const { // NOLINT: match stl API
++		return table_filters.end();
++	}
++private:
++	filter_set_t table_filters;
++};
++
+ // Constraint only for internal delta extension use
+ // Todo: refactor to use duckdb constraint classes, updating the DuckDB side NotNullConstraint
+ class NestedNotNullConstraint {
+@@ -73,7 +108,7 @@ public:
  	                                                const vector<column_t> &column_ids,
  	                                                TableFilterSet &filters) const override;
  
@@ -177,11 +235,12 @@ index b196db7..e4eed67 100644
  
  	vector<OpenFileInfo> GetAllFiles() const override;
  	FileExpandResult GetExpandResult() const override;
-@@ -143,6 +143,7 @@ protected:
+@@ -142,7 +177,7 @@ protected:
+ 	mutable vector<unique_ptr<DeltaFileMetaData>> metadata;
  
  	mutable vector<OpenFileInfo> resolved_files;
- 	mutable TableFilterSet table_filters;
-+	vector<column_t> column_indexes;
+-	mutable TableFilterSet table_filters;
++	mutable DeltaTableFilters table_filters;
  
  	mutable vector<NestedNotNullConstraint> not_null_constraints;
  	mutable bool has_null_constraints_in_arrays = false;

--- a/.github/patches/extensions/delta/fix.patch
+++ b/.github/patches/extensions/delta/fix.patch
@@ -1,5 +1,5 @@
 diff --git a/src/delta_utils.cpp b/src/delta_utils.cpp
-index 8c08714..9894acf 100644
+index 8c08714..92310e1 100644
 --- a/src/delta_utils.cpp
 +++ b/src/delta_utils.cpp
 @@ -856,8 +856,8 @@ PredicateVisitor::PredicateVisitor(const vector<DeltaMultiFileColumnDefinition>
@@ -9,22 +9,30 @@ index 8c08714..9894acf 100644
 -		for (auto &filter : filters->filters) {
 -			column_filters[columns[filter.first].name] = filter.second.get();
 +		for (auto &entry : *filters) {
-+			column_filters[columns[entry.ColumnIndex()].name] = &entry.Filter();
++			column_filters[columns[entry.ColumnIndex().index].name] = &entry.Filter();
  		}
  	}
  }
 diff --git a/src/functions/delta_scan/delta_multi_file_list.cpp b/src/functions/delta_scan/delta_multi_file_list.cpp
-index 7d918bd..42a3622 100644
+index 7d918bd..577b4f8 100644
 --- a/src/functions/delta_scan/delta_multi_file_list.cpp
 +++ b/src/functions/delta_scan/delta_multi_file_list.cpp
-@@ -793,14 +793,14 @@ unique_ptr<DeltaMultiFileList> DeltaMultiFileList::PushdownInternal(ClientContex
+@@ -787,20 +787,22 @@ void DeltaMultiFileList::EnsureScanInitialized() const {
+ }
+ 
+ unique_ptr<DeltaMultiFileList> DeltaMultiFileList::PushdownInternal(ClientContext &context,
+-                                                                    TableFilterSet &new_filters) const {
++                                                                    TableFilterSet &new_filters,
++                                                                    vector<column_t> column_indexes) const {
+ 	auto filtered_list = make_uniq<DeltaMultiFileList>(context, paths[0].path, version);
+ 
  	TableFilterSet result_filter_set;
  
  	// Add pre-existing filters
 -	for (auto &entry : table_filters.filters) {
 -		result_filter_set.PushFilter(ColumnIndex(entry.first), entry.second->Copy());
 +	for (auto &entry : table_filters) {
-+		result_filter_set.PushFilter(ColumnIndex(entry.ColumnIndex()), entry.Filter().Copy());
++		result_filter_set.PushFilter(entry.ColumnIndex(), entry.Filter().Copy());
  	}
  
  	// Add new filters
@@ -32,12 +40,21 @@ index 7d918bd..42a3622 100644
 -		if (entry.first < global_columns.size()) {
 -			result_filter_set.PushFilter(ColumnIndex(entry.first), entry.second->Copy());
 +	for (auto &entry : new_filters) {
-+		if (entry.ColumnIndex() < global_columns.size()) {
-+			result_filter_set.PushFilter(ColumnIndex(entry.ColumnIndex()), entry.Filter().Copy());
++		auto &column_id = column_indexes[entry.ColumnIndex().index];
++		if (column_id < global_columns.size()) {
++			result_filter_set.PushFilter(entry.ColumnIndex(), entry.Filter().Copy());
  		}
  	}
  
-@@ -849,7 +849,7 @@ unique_ptr<MultiFileList> DeltaMultiFileList::ComplexFilterPushdown(ClientContex
+@@ -809,6 +811,7 @@ unique_ptr<DeltaMultiFileList> DeltaMultiFileList::PushdownInternal(ClientContex
+ 	filtered_list->table_filters = std::move(result_filter_set);
+ 	filtered_list->global_columns = global_columns;
+ 	filtered_list->lazy_loaded_schema = lazy_loaded_schema;
++	filtered_list->column_indexes = std::move(column_indexes);
+ 
+ 	// Copy over the snapshot, this avoids reparsing metadata
+ 	{
+@@ -849,11 +852,11 @@ unique_ptr<MultiFileList> DeltaMultiFileList::ComplexFilterPushdown(ClientContex
  
  	vector<FilterPushdownResult> pushdown_results;
  	auto filter_set = combiner.GenerateTableScanFilters(info.column_indexes, pushdown_results);
@@ -46,19 +63,27 @@ index 7d918bd..42a3622 100644
  		return nullptr;
  	}
  
-@@ -916,24 +916,24 @@ void DeltaMultiFileList::ReportFilterPushdown(ClientContext &context, DeltaMulti
+-	auto filtered_list = PushdownInternal(context, filter_set);
++	auto filtered_list = PushdownInternal(context, filter_set, info.column_ids);
+ 
+ 	ReportFilterPushdown(context, *filtered_list, info.column_ids, "constant", info);
+ 
+@@ -916,24 +919,26 @@ void DeltaMultiFileList::ReportFilterPushdown(ClientContext &context, DeltaMulti
  
  	// Report the new filters
  	vector<Value> old_filters_value_list;
 -	for (auto &f : table_filters.filters) {
 -		auto &column_index = f.first;
 -		auto &filter = f.second;
-+	for (auto &entry : table_filters) {
-+		auto column_index = entry.ColumnIndex();
-+		auto &filter = entry.Filter();
- 		if (column_index < global_columns.size()) {
- 			auto &col_name = global_columns[column_index].name;
+-		if (column_index < global_columns.size()) {
+-			auto &col_name = global_columns[column_index].name;
 -			old_filters_value_list.push_back(filter->ToString(col_name));
++	for (auto &entry : table_filters) {
++		auto proj_index = entry.ColumnIndex();
++		auto &filter = entry.Filter();
++		auto column_id = column_ids[proj_index.index];
++		if (column_id < global_columns.size()) {
++			auto &col_name = global_columns[column_id].name;
 +			old_filters_value_list.push_back(filter.ToString(col_name));
  		}
  	}
@@ -69,17 +94,20 @@ index 7d918bd..42a3622 100644
 -	for (auto &f : new_list.table_filters.filters) {
 -		auto &column_index = f.first;
 -		auto &filter = f.second;
-+	for (auto &entry : new_list.table_filters) {
-+		auto column_index = entry.ColumnIndex();
-+		auto &filter = entry.Filter();
- 		if (column_index < global_columns.size()) {
- 			auto &col_name = global_columns[column_index].name;
+-		if (column_index < global_columns.size()) {
+-			auto &col_name = global_columns[column_index].name;
 -			filters_value_list.push_back(filter->ToString(col_name));
++	for (auto &entry : new_list.table_filters) {
++		auto proj_index = entry.ColumnIndex();
++		auto &filter = entry.Filter();
++		auto column_id = column_ids[proj_index.index];
++		if (column_id < global_columns.size()) {
++			auto &col_name = global_columns[column_id].name;
 +			filters_value_list.push_back(filter.ToString(col_name));
  		}
  	}
  	auto filters_value = Value::LIST(LogicalType::VARCHAR, filters_value_list);
-@@ -970,23 +970,23 @@ DeltaMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFil
+@@ -970,24 +975,24 @@ DeltaMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFil
  		return nullptr;
  	}
  
@@ -95,22 +123,24 @@ index 7d918bd..42a3622 100644
 -		if (previously_pushed_down_filter != this->table_filters.filters.end() &&
 -		    filter.second->Equals(*previously_pushed_down_filter->second)) {
 +	for (auto &entry : filters) {
-+		auto column_id = column_ids[entry.ColumnIndex()];
++		auto proj_id = entry.ColumnIndex();
 +		auto &filter = entry.Filter();
-+		auto previously_pushed_down_filter = table_filters.TryGetFilterByColumnIndex(column_id);
++		auto previously_pushed_down_filter = table_filters.TryGetFilterByColumnIndex(proj_id);
 +		if (previously_pushed_down_filter && filter.Equals(*previously_pushed_down_filter)) {
  			// Skip filters that we already have pushed down
  			continue;
  		}
 -		filters_copy.PushFilter(ColumnIndex(column_id), filter.second->Copy());
-+		filters_copy.PushFilter(ColumnIndex(column_id), filter.Copy());
++		filters_copy.PushFilter(proj_id, filter.Copy());
  	}
  
 -	if (!filters_copy.filters.empty()) {
+-		auto new_snap = PushdownInternal(context, filters_copy);
 +	if (filters_copy.HasFilters()) {
- 		auto new_snap = PushdownInternal(context, filters_copy);
++		auto new_snap = PushdownInternal(context, filters_copy, column_ids);
  		ReportFilterPushdown(context, *new_snap, column_ids, "dynamic", nullptr);
  		return std::move(new_snap);
+ 	}
 diff --git a/src/include/delta_utils.hpp b/src/include/delta_utils.hpp
 index 3fdce7f..8ab602d 100644
 --- a/src/include/delta_utils.hpp
@@ -134,3 +164,24 @@ index 3fdce7f..8ab602d 100644
  
  	static uintptr_t VisitPredicate(PredicateVisitor *predicate, ffi::KernelExpressionVisitorState *state);
  
+diff --git a/src/include/functions/delta_scan/delta_multi_file_list.hpp b/src/include/functions/delta_scan/delta_multi_file_list.hpp
+index b196db7..e4eed67 100644
+--- a/src/include/functions/delta_scan/delta_multi_file_list.hpp
++++ b/src/include/functions/delta_scan/delta_multi_file_list.hpp
+@@ -73,7 +73,7 @@ public:
+ 	                                                const vector<column_t> &column_ids,
+ 	                                                TableFilterSet &filters) const override;
+ 
+-	unique_ptr<DeltaMultiFileList> PushdownInternal(ClientContext &context, TableFilterSet &new_filters) const;
++	unique_ptr<DeltaMultiFileList> PushdownInternal(ClientContext &context, TableFilterSet &new_filters, vector<column_t> column_indexes) const;
+ 
+ 	vector<OpenFileInfo> GetAllFiles() const override;
+ 	FileExpandResult GetExpandResult() const override;
+@@ -143,6 +143,7 @@ protected:
+ 
+ 	mutable vector<OpenFileInfo> resolved_files;
+ 	mutable TableFilterSet table_filters;
++	vector<column_t> column_indexes;
+ 
+ 	mutable vector<NestedNotNullConstraint> not_null_constraints;
+ 	mutable bool has_null_constraints_in_arrays = false;

--- a/.github/patches/extensions/ducklake/fix.patch
+++ b/.github/patches/extensions/ducklake/fix.patch
@@ -1044,8 +1044,21 @@ index 851c128d..4040a5c2 100644
  	auto catalog_type = entry->type;
  	table_entry_map.insert(make_pair(id, reference<CatalogEntry>(*entry)));
  	schema.AddEntry(catalog_type, std::move(entry));
+diff --git a/src/storage/ducklake_delete_filter.cpp b/src/storage/ducklake_delete_filter.cpp
+index 35b0518f..770ac8da 100644
+--- a/src/storage/ducklake_delete_filter.cpp
++++ b/src/storage/ducklake_delete_filter.cpp
+@@ -147,7 +147,7 @@ DeleteFileScanResult DuckLakeDeleteFilter::ScanDeleteFile(ClientContext &context
+ 	// Create snapshot filters if we have a snapshot column and filter range is specified
+ 	if (has_snapshot_id && (snapshot_filter_min.IsValid() || snapshot_filter_max.IsValid())) {
+ 		auto filters = make_uniq<TableFilterSet>();
+-		ColumnIndex snapshot_col_idx(2); // snapshot_id is column 2
++		ProjectionIndex snapshot_col_idx(2); // snapshot_id is column 2
+ 
+ 		if (snapshot_filter_min.IsValid()) {
+ 			auto min_constant = Value::BIGINT(NumericCast<int64_t>(snapshot_filter_min.GetIndex()));
 diff --git a/src/storage/ducklake_inlined_data_reader.cpp b/src/storage/ducklake_inlined_data_reader.cpp
-index 405a5acf..acb71114 100644
+index 405a5acf..d227728b 100644
 --- a/src/storage/ducklake_inlined_data_reader.cpp
 +++ b/src/storage/ducklake_inlined_data_reader.cpp
 @@ -258,17 +258,17 @@ AsyncResult DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableF
@@ -1060,8 +1073,9 @@ index 405a5acf..acb71114 100644
  					continue;
  				}
 -				auto column_id = entry.first;
+-				auto &vec = chunk.data[column_id];
 +				auto column_id = entry.ColumnIndex();
- 				auto &vec = chunk.data[column_id];
++				auto &vec = chunk.data[column_id.index];
  
  				UnifiedVectorFormat vdata;
  				vec.ToUnifiedFormat(chunk.size(), vdata);
@@ -1374,10 +1388,10 @@ index e812cef5..6140d444 100644
  		table_size.table_uuid = row.GetValue<string>(3);
  		if (!row.IsNull(4)) {
 diff --git a/src/storage/ducklake_multi_file_list.cpp b/src/storage/ducklake_multi_file_list.cpp
-index e3ddf53b..b2ca5648 100644
+index e3ddf53b..dd132f35 100644
 --- a/src/storage/ducklake_multi_file_list.cpp
 +++ b/src/storage/ducklake_multi_file_list.cpp
-@@ -51,15 +51,15 @@ unique_ptr<MultiFileList>
+@@ -51,17 +51,17 @@ unique_ptr<MultiFileList>
  DuckLakeMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
                                               const vector<string> &names, const vector<LogicalType> &types,
                                               const vector<column_t> &column_ids, TableFilterSet &filters) const {
@@ -1391,11 +1405,15 @@ index e3ddf53b..b2ca5648 100644
  
 -	for (auto &entry : filters.filters) {
 -		auto column_index_val = entry.first;
+-		idx_t column_idx = column_index_val;
+-		auto column_id = column_ids[column_idx];
 +	for (auto &entry : filters) {
 +		auto column_index_val = entry.ColumnIndex();
- 		idx_t column_idx = column_index_val;
- 		auto column_id = column_ids[column_idx];
++		auto column_idx = column_index_val;
++		auto column_id = column_ids[column_idx.index];
  
+ 		if (IsVirtualColumn(column_id)) {
+ 			continue;
 @@ -71,7 +71,7 @@ DuckLakeMultiFileList::DynamicFilterPushdown(ClientContext &context, const Multi
  		auto &root_id = read_info.table.GetFieldId(column_index);
  		auto field_index = root_id.GetFieldIndex().index;
@@ -1406,7 +1424,7 @@ index e3ddf53b..b2ca5648 100644
  		const auto &column_type = read_info.column_types[column_index.index];
  
 diff --git a/src/storage/ducklake_multi_file_reader.cpp b/src/storage/ducklake_multi_file_reader.cpp
-index 2d6317f9..30bd0429 100644
+index 2d6317f9..c55547a3 100644
 --- a/src/storage/ducklake_multi_file_reader.cpp
 +++ b/src/storage/ducklake_multi_file_reader.cpp
 @@ -28,6 +28,7 @@
@@ -1417,6 +1435,24 @@ index 2d6317f9..30bd0429 100644
  
  namespace duckdb {
  
+@@ -48,7 +49,7 @@ static bool TryFindColumnByFieldId(const vector<MultiFileColumnDefinition> &loca
+ }
+ 
+ //! Add a snapshot filter to the reader's filter set
+-static void AddSnapshotFilter(BaseFileReader &reader, const ColumnIndex &col_idx, const LogicalType &col_type,
++static void AddSnapshotFilter(BaseFileReader &reader, ProjectionIndex col_idx, const LogicalType &col_type,
+                               idx_t snapshot_value, ExpressionType comparison_type) {
+ 	auto constant = Value::UBIGINT(snapshot_value).DefaultCastAs(col_type);
+ 	auto filter = make_uniq<ConstantFilter>(comparison_type, std::move(constant));
+@@ -317,7 +318,7 @@ ReaderInitializeType DuckLakeMultiFileReader::InitializeReader(MultiFileReaderDa
+ 		if (!reader.filters) {
+ 			reader.filters = make_uniq<TableFilterSet>();
+ 		}
+-		ColumnIndex snapshot_col_idx(snapshot_local_id.GetIndex());
++		ProjectionIndex snapshot_col_idx(snapshot_local_id.GetIndex());
+ 
+ 		// Add _ducklake_internal_snapshot_id <= snapshot_filter_max
+ 		if (file_entry.snapshot_filter_max.IsValid()) {
 diff --git a/src/storage/ducklake_schema_entry.cpp b/src/storage/ducklake_schema_entry.cpp
 index 020cc3be..7a7c0517 100644
 --- a/src/storage/ducklake_schema_entry.cpp

--- a/.github/patches/extensions/ducklake/fix.patch
+++ b/.github/patches/extensions/ducklake/fix.patch
@@ -1058,7 +1058,7 @@ index 35b0518f..770ac8da 100644
  		if (snapshot_filter_min.IsValid()) {
  			auto min_constant = Value::BIGINT(NumericCast<int64_t>(snapshot_filter_min.GetIndex()));
 diff --git a/src/storage/ducklake_inlined_data_reader.cpp b/src/storage/ducklake_inlined_data_reader.cpp
-index 405a5acf..d227728b 100644
+index 405a5acf..f45dfc18 100644
 --- a/src/storage/ducklake_inlined_data_reader.cpp
 +++ b/src/storage/ducklake_inlined_data_reader.cpp
 @@ -258,17 +258,17 @@ AsyncResult DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableF
@@ -1073,9 +1073,8 @@ index 405a5acf..d227728b 100644
  					continue;
  				}
 -				auto column_id = entry.first;
--				auto &vec = chunk.data[column_id];
-+				auto column_id = entry.ColumnIndex();
-+				auto &vec = chunk.data[column_id.index];
++				auto column_id = entry.GetIndex();
+ 				auto &vec = chunk.data[column_id];
  
  				UnifiedVectorFormat vdata;
  				vec.ToUnifiedFormat(chunk.size(), vdata);
@@ -1388,10 +1387,10 @@ index e812cef5..6140d444 100644
  		table_size.table_uuid = row.GetValue<string>(3);
  		if (!row.IsNull(4)) {
 diff --git a/src/storage/ducklake_multi_file_list.cpp b/src/storage/ducklake_multi_file_list.cpp
-index e3ddf53b..26c14fe6 100644
+index e3ddf53b..96e99928 100644
 --- a/src/storage/ducklake_multi_file_list.cpp
 +++ b/src/storage/ducklake_multi_file_list.cpp
-@@ -51,17 +51,17 @@ unique_ptr<MultiFileList>
+@@ -51,16 +51,16 @@ unique_ptr<MultiFileList>
  DuckLakeMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
                                               const vector<string> &names, const vector<LogicalType> &types,
                                               const vector<column_t> &column_ids, TableFilterSet &filters) const {
@@ -1406,14 +1405,12 @@ index e3ddf53b..26c14fe6 100644
 -	for (auto &entry : filters.filters) {
 -		auto column_index_val = entry.first;
 -		idx_t column_idx = column_index_val;
--		auto column_id = column_ids[column_idx];
 +	for (auto &entry : filters) {
-+		auto column_index_val = entry.ColumnIndex();
++		auto column_index_val = entry.GetIndex();
 +		auto column_idx = column_index_val;
-+		auto column_id = column_ids[column_idx.index];
+ 		auto column_id = column_ids[column_idx];
  
  		if (IsVirtualColumn(column_id)) {
- 			continue;
 @@ -71,7 +71,7 @@ DuckLakeMultiFileList::DynamicFilterPushdown(ClientContext &context, const Multi
  		auto &root_id = read_info.table.GetFieldId(column_index);
  		auto field_index = root_id.GetFieldIndex().index;

--- a/.github/patches/extensions/ducklake/fix.patch
+++ b/.github/patches/extensions/ducklake/fix.patch
@@ -1388,7 +1388,7 @@ index e812cef5..6140d444 100644
  		table_size.table_uuid = row.GetValue<string>(3);
  		if (!row.IsNull(4)) {
 diff --git a/src/storage/ducklake_multi_file_list.cpp b/src/storage/ducklake_multi_file_list.cpp
-index e3ddf53b..dd132f35 100644
+index e3ddf53b..26c14fe6 100644
 --- a/src/storage/ducklake_multi_file_list.cpp
 +++ b/src/storage/ducklake_multi_file_list.cpp
 @@ -51,17 +51,17 @@ unique_ptr<MultiFileList>
@@ -1396,7 +1396,7 @@ index e3ddf53b..dd132f35 100644
                                               const vector<string> &names, const vector<LogicalType> &types,
                                               const vector<column_t> &column_ids, TableFilterSet &filters) const {
 -	if (read_info.scan_type != DuckLakeScanType::SCAN_TABLE || filters.filters.empty()) {
-+	if (read_info.scan_type != DuckLakeScanType::SCAN_TABLE || filters.HasFilters()) {
++	if (read_info.scan_type != DuckLakeScanType::SCAN_TABLE || !filters.HasFilters()) {
  		// filter pushdown is only supported when scanning full tables
  		return nullptr;
  	}

--- a/.github/patches/extensions/iceberg/fix.patch
+++ b/.github/patches/extensions/iceberg/fix.patch
@@ -12,7 +12,7 @@ index 608c67af..9c6744a7 100644
  	auto http_headers = HTTPHeaders();
  	for (auto &header : aws_headers) {
 diff --git a/src/iceberg_functions/iceberg_multi_file_list.cpp b/src/iceberg_functions/iceberg_multi_file_list.cpp
-index 02a3b3d3..47b39861 100644
+index 02a3b3d3..9d312ac8 100644
 --- a/src/iceberg_functions/iceberg_multi_file_list.cpp
 +++ b/src/iceberg_functions/iceberg_multi_file_list.cpp
 @@ -19,6 +19,7 @@
@@ -23,22 +23,17 @@ index 02a3b3d3..47b39861 100644
  
  #include "metadata/iceberg_predicate_stats.hpp"
  #include "metadata/iceberg_table_metadata.hpp"
-@@ -134,12 +135,21 @@ bool IcebergMultiFileList::FinishedScanningDeletes() const {
- optional_ptr<const TableFilter> IcebergMultiFileList::GetFilterForColumnIndex(const TableFilterSet &filter_set,
+@@ -131,15 +132,15 @@ bool IcebergMultiFileList::FinishedScanningDeletes() const {
+ 	return !delete_manifest_reader || delete_manifest_reader->Finished();
+ }
+ 
+-optional_ptr<const TableFilter> IcebergMultiFileList::GetFilterForColumnIndex(const TableFilterSet &filter_set,
++optional_ptr<const TableFilter> IcebergMultiFileList::GetFilterForColumnIndex(const IcebergTableFilters &filter_set,
                                                                                const ColumnIndex &column_index) const {
  	auto primary_index = column_index.GetPrimaryIndex();
 -	auto filter_it = filter_set.filters.find(primary_index);
 -	if (filter_it == filter_set.filters.end()) {
-+	ProjectionIndex proj_index;
-+	for(idx_t c = 0; c < column_indexes.size(); c++) {
-+		if (column_indexes[c] == primary_index) {
-+			proj_index = ProjectionIndex(c);
-+		}
-+	}
-+	if (!proj_index.IsValid()) {
-+		throw InternalException("IcebergMultiFileList::GetFilterForColumnIndex - could not find corresponding proj id to column id");
-+	}
-+	auto filter = filter_set.TryGetFilterByColumnIndex(proj_index);
++	auto filter = filter_set.TryGetFilterByColumnIndex(primary_index);
 +	if (!filter) {
  		return nullptr;
  	}
@@ -48,7 +43,7 @@ index 02a3b3d3..47b39861 100644
  	auto &child_indexes = column_index.GetChildIndexes();
  
  	reference<const TableFilter> current_filter(parent_filter);
-@@ -211,26 +221,28 @@ void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<string
+@@ -211,20 +212,21 @@ void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<string
  }
  
  unique_ptr<IcebergMultiFileList> IcebergMultiFileList::PushdownInternal(ClientContext &context,
@@ -56,13 +51,14 @@ index 02a3b3d3..47b39861 100644
 +                                                                        TableFilterSet &new_filters, vector<column_t> column_indexes) const {
  	auto filtered_list = make_uniq<IcebergMultiFileList>(context, scan_info, path, this->options);
  
- 	TableFilterSet result_filter_set;
+-	TableFilterSet result_filter_set;
++	IcebergTableFilters result_filter_set;
  
  	// Add pre-existing filters
 -	for (auto &entry : table_filters.filters) {
 -		result_filter_set.PushFilter(ColumnIndex(entry.first), entry.second->Copy());
 +	for (auto &entry : table_filters) {
-+		result_filter_set.PushFilter(entry.ColumnIndex(), entry.Filter().Copy());
++		result_filter_set.PushFilter(entry.first, entry.second->Copy());
  	}
  
  	// Add new filters
@@ -72,18 +68,11 @@ index 02a3b3d3..47b39861 100644
 +	for (auto &entry : new_filters) {
 +		auto column_idx = column_indexes[entry.ColumnIndex().index];
 +		if (column_idx < names.size()) {
-+			result_filter_set.PushFilter(entry.ColumnIndex(), entry.Filter().Copy());
++			result_filter_set.PushFilter(column_idx, entry.Filter().Copy());
  		}
  	}
  
- 	filtered_list->table_filters = std::move(result_filter_set);
- 	filtered_list->names = names;
- 	filtered_list->types = types;
-+	filtered_list->column_indexes = std::move(column_indexes);
- 	filtered_list->have_bound = true;
- 	return filtered_list;
- }
-@@ -239,24 +251,23 @@ unique_ptr<MultiFileList>
+@@ -239,24 +241,24 @@ unique_ptr<MultiFileList>
  IcebergMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
                                              const vector<string> &names, const vector<LogicalType> &types,
                                              const vector<column_t> &column_ids, TableFilterSet &filters) const {
@@ -100,7 +89,8 @@ index 02a3b3d3..47b39861 100644
 -		    filter.second->Equals(*previously_pushed_down_filter->second)) {
 +	for (auto &entry : filters) {
 +		auto &filter = entry.Filter();
-+		auto previously_pushed_down_filter = table_filters.TryGetFilterByColumnIndex(entry.ColumnIndex());
++		auto column_id = column_ids[entry.ColumnIndex().index];
++		auto previously_pushed_down_filter = table_filters.TryGetFilterByColumnIndex(column_id);
 +		if (previously_pushed_down_filter && filter.Equals(*previously_pushed_down_filter)) {
  			// Skip filters that we already have pushed down
  			continue;
@@ -116,7 +106,7 @@ index 02a3b3d3..47b39861 100644
  		return std::move(new_snap);
  	}
  	return nullptr;
-@@ -277,11 +288,11 @@ unique_ptr<MultiFileList> IcebergMultiFileList::ComplexFilterPushdown(ClientCont
+@@ -277,11 +279,11 @@ unique_ptr<MultiFileList> IcebergMultiFileList::ComplexFilterPushdown(ClientCont
  
  	vector<FilterPushdownResult> unused;
  	auto filter_set = combiner.GenerateTableScanFilters(info.column_indexes, unused);
@@ -130,7 +120,7 @@ index 02a3b3d3..47b39861 100644
  }
  
  vector<OpenFileInfo> IcebergMultiFileList::GetAllFiles() const {
-@@ -382,18 +393,15 @@ IcebergPredicateStats IcebergPredicateStats::DeserializeBounds(const Value &lowe
+@@ -382,18 +384,14 @@ IcebergPredicateStats IcebergPredicateStats::DeserializeBounds(const Value &lowe
  
  bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestEntry &manifest_entry,
                                               IcebergDataFileType file_type) const {
@@ -142,19 +132,18 @@ index 02a3b3d3..47b39861 100644
  
 -	for (idx_t index = 0; index < schema.size(); index++) {
 +	for(auto &entry : table_filters) {
-+		auto proj_id = entry.ColumnIndex();
-+		auto index = column_indexes[proj_id.index];
++		auto index = entry.first;
  		auto &column = *schema[index];
 -		auto it = filters.find(index);
 -
 -		if (it == filters.end()) {
 -			continue;
 -		}
-+		auto &filter = entry.Filter();
++		auto &filter = *entry.second;
  		auto &metadata = GetMetadata();
  		auto &data_file = manifest_entry.data_file;
  		// First check if there are partitions
-@@ -512,7 +520,6 @@ bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestEntry &manifes
+@@ -512,7 +510,6 @@ bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestEntry &manifes
  			stats.has_nan = nan_counts != 0;
  		}
  
@@ -162,7 +151,7 @@ index 02a3b3d3..47b39861 100644
  		if (!IcebergPredicate::MatchBounds(context, filter, stats, IcebergTransform::Identity())) {
  			//! If any predicate fails, exclude the file
  			return false;
-@@ -596,7 +603,7 @@ optional_ptr<const IcebergManifestEntry> IcebergMultiFileList::GetDataFile(idx_t
+@@ -596,7 +593,7 @@ optional_ptr<const IcebergManifestEntry> IcebergMultiFileList::GetDataFile(idx_t
  			auto &data_file = manifest_entry.data_file;
  			manifest_entry_idx++;
  			// Check whether current data file is filtered out.
@@ -171,7 +160,7 @@ index 02a3b3d3..47b39861 100644
  				DUCKDB_LOG(context, IcebergLogType, "Iceberg Filter Pushdown, skipped 'data_file': '%s'",
  				           data_file.file_path);
  				//! Skip this file
-@@ -689,7 +696,7 @@ bool IcebergMultiFileList::ManifestMatchesFilter(const IcebergManifestFile &mani
+@@ -689,7 +686,7 @@ bool IcebergMultiFileList::ManifestMatchesFilter(const IcebergManifestFile &mani
  		    field_summaries.size(), partition_spec.fields.size());
  	}
  
@@ -180,7 +169,7 @@ index 02a3b3d3..47b39861 100644
  		//! There are no filters
  		return true;
  	}
-@@ -850,7 +857,7 @@ void IcebergMultiFileList::ProcessDeletes(const vector<MultiFileColumnDefinition
+@@ -850,7 +847,7 @@ void IcebergMultiFileList::ProcessDeletes(const vector<MultiFileColumnDefinition
  		for (auto &manifest_entry : entries) {
  			auto &data_file = manifest_entry.data_file;
  			// Check whether current data file is filtered out.
@@ -202,10 +191,52 @@ index 82c0aed8..905ca1cb 100644
  namespace duckdb {
  
 diff --git a/src/include/iceberg_multi_file_list.hpp b/src/include/iceberg_multi_file_list.hpp
-index 62b71d18..a048875c 100644
+index 62b71d18..1d8a5e1f 100644
 --- a/src/include/iceberg_multi_file_list.hpp
 +++ b/src/include/iceberg_multi_file_list.hpp
-@@ -66,7 +66,7 @@ public:
+@@ -49,6 +49,41 @@ public:
+ 
+ enum class IcebergDataFileType : uint8_t { DATA, DELETE };
+ 
++struct IcebergTableFilters {
++	using filter_set_t = unordered_map<idx_t, unique_ptr<TableFilter>>;
++	using iterator = filter_set_t::iterator;
++	using const_iterator = filter_set_t::const_iterator;
++public:
++	bool HasFilters() const {
++		return !table_filters.empty();
++	}
++	void PushFilter(column_t column_idx, unique_ptr<TableFilter> table_filter) {
++		table_filters[column_idx] = std::move(table_filter);
++	}
++	optional_ptr<const TableFilter> TryGetFilterByColumnIndex(column_t column_idx) const {
++		auto entry = table_filters.find(column_idx);
++		if (entry == table_filters.end()) {
++			return nullptr;
++		}
++		return entry->second.get();
++	}
++
++	iterator begin() { // NOLINT: match stl API
++		return table_filters.begin();
++	}
++	iterator end() { // NOLINT: match stl API
++		return table_filters.end();
++	}
++	const_iterator begin() const { // NOLINT: match stl API
++		return table_filters.begin();
++	}
++	const_iterator end() const { // NOLINT: match stl API
++		return table_filters.end();
++	}
++private:
++	filter_set_t table_filters;
++};
++
+ struct IcebergMultiFileList : public MultiFileList {
+ public:
+ 	IcebergMultiFileList(ClientContext &context, shared_ptr<IcebergScanInfo> scan_info, const string &path,
+@@ -66,7 +101,7 @@ public:
  	bool FinishedScanningDeletes() const;
  
  	void Bind(vector<LogicalType> &return_types, vector<string> &names);
@@ -214,11 +245,21 @@ index 62b71d18..a048875c 100644
  	void ScanPositionalDeleteFile(DataChunk &result) const;
  	void ScanEqualityDeleteFile(const IcebergManifestEntry &manifest_entry, DataChunk &result,
  	                            vector<MultiFileColumnDefinition> &columns,
-@@ -127,6 +127,7 @@ public:
+@@ -107,7 +142,7 @@ protected:
+ 	//! NOTE: this requires the lock because it modifies the 'data_files' vector, potentially invalidating references
+ 	optional_ptr<const IcebergManifestEntry> GetDataFile(idx_t file_id, lock_guard<mutex> &guard) const;
+ 
+-	optional_ptr<const TableFilter> GetFilterForColumnIndex(const TableFilterSet &filter_set,
++	optional_ptr<const TableFilter> GetFilterForColumnIndex(const IcebergTableFilters &filter_set,
+ 	                                                        const ColumnIndex &column_index) const;
+ 
+ private:
+@@ -126,7 +161,7 @@ public:
+ 	bool have_bound = false;
  	vector<string> names;
  	vector<LogicalType> types;
- 	TableFilterSet table_filters;
-+	vector<column_t> column_indexes;
+-	TableFilterSet table_filters;
++	IcebergTableFilters table_filters;
  
  	mutable mutex entry_lock;
  	mutable vector<IcebergManifestEntry> manifest_entries;

--- a/.github/patches/extensions/iceberg/fix.patch
+++ b/.github/patches/extensions/iceberg/fix.patch
@@ -12,7 +12,7 @@ index 608c67af..9c6744a7 100644
  	auto http_headers = HTTPHeaders();
  	for (auto &header : aws_headers) {
 diff --git a/src/iceberg_functions/iceberg_multi_file_list.cpp b/src/iceberg_functions/iceberg_multi_file_list.cpp
-index 02a3b3d3..9d312ac8 100644
+index 02a3b3d3..3dbbc921 100644
 --- a/src/iceberg_functions/iceberg_multi_file_list.cpp
 +++ b/src/iceberg_functions/iceberg_multi_file_list.cpp
 @@ -19,6 +19,7 @@
@@ -66,7 +66,7 @@ index 02a3b3d3..9d312ac8 100644
 -		if (entry.first < names.size()) {
 -			result_filter_set.PushFilter(ColumnIndex(entry.first), entry.second->Copy());
 +	for (auto &entry : new_filters) {
-+		auto column_idx = column_indexes[entry.ColumnIndex().index];
++		auto column_idx = column_indexes[entry.GetIndex()];
 +		if (column_idx < names.size()) {
 +			result_filter_set.PushFilter(column_idx, entry.Filter().Copy());
  		}
@@ -89,14 +89,14 @@ index 02a3b3d3..9d312ac8 100644
 -		    filter.second->Equals(*previously_pushed_down_filter->second)) {
 +	for (auto &entry : filters) {
 +		auto &filter = entry.Filter();
-+		auto column_id = column_ids[entry.ColumnIndex().index];
++		auto column_id = column_ids[entry.GetIndex()];
 +		auto previously_pushed_down_filter = table_filters.TryGetFilterByColumnIndex(column_id);
 +		if (previously_pushed_down_filter && filter.Equals(*previously_pushed_down_filter)) {
  			// Skip filters that we already have pushed down
  			continue;
  		}
 -		filters_copy.PushFilter(ColumnIndex(column_id), filter.second->Copy());
-+		filters_copy.PushFilter(entry.ColumnIndex(), filter.Copy());
++		filters_copy.PushFilter(entry.GetIndex(), filter.Copy());
  	}
  
 -	if (!filters_copy.filters.empty()) {
@@ -263,6 +263,19 @@ index 62b71d18..1d8a5e1f 100644
  
  	mutable mutex entry_lock;
  	mutable vector<IcebergManifestEntry> manifest_entries;
+diff --git a/src/storage/catalog/iceberg_schema_entry.cpp b/src/storage/catalog/iceberg_schema_entry.cpp
+index 88c7537c..c4e63923 100644
+--- a/src/storage/catalog/iceberg_schema_entry.cpp
++++ b/src/storage/catalog/iceberg_schema_entry.cpp
+@@ -153,7 +153,7 @@ optional_ptr<CatalogEntry> IcebergSchemaEntry::CreateIndex(CatalogTransaction tr
+ 	throw NotImplementedException("Create Index");
+ }
+ 
+-string GetUCCreateView(CreateViewInfo &info) {
++static string GetUCCreateView(CreateViewInfo &info) {
+ 	throw NotImplementedException("Get Create View");
+ }
+ 
 diff --git a/src/storage/catalog/iceberg_table_set.cpp b/src/storage/catalog/iceberg_table_set.cpp
 index d2d8f9df..6522c068 100644
 --- a/src/storage/catalog/iceberg_table_set.cpp

--- a/.github/patches/extensions/iceberg/fix.patch
+++ b/.github/patches/extensions/iceberg/fix.patch
@@ -1,5 +1,18 @@
+diff --git a/src/aws.cpp b/src/aws.cpp
+index 608c67af..9c6744a7 100644
+--- a/src/aws.cpp
++++ b/src/aws.cpp
+@@ -50,7 +50,7 @@ static void InitAWSAPI() {
+ static void LogAWSHTTPRequest(ClientContext &context, std::shared_ptr<Aws::Http::HttpRequest> &req,
+                               HTTPResponse &response, Aws::Http::HttpMethod &method) {
+ 	D_ASSERT(context.db);
+-	auto http_util = HTTPUtil::Get(*context.db);
++	auto &http_util = HTTPUtil::Get(*context.db);
+ 	auto aws_headers = req->GetHeaders();
+ 	auto http_headers = HTTPHeaders();
+ 	for (auto &header : aws_headers) {
 diff --git a/src/iceberg_functions/iceberg_multi_file_list.cpp b/src/iceberg_functions/iceberg_multi_file_list.cpp
-index 02a3b3d3..e0d90035 100644
+index 02a3b3d3..47b39861 100644
 --- a/src/iceberg_functions/iceberg_multi_file_list.cpp
 +++ b/src/iceberg_functions/iceberg_multi_file_list.cpp
 @@ -19,6 +19,7 @@
@@ -10,13 +23,22 @@ index 02a3b3d3..e0d90035 100644
  
  #include "metadata/iceberg_predicate_stats.hpp"
  #include "metadata/iceberg_table_metadata.hpp"
-@@ -134,12 +135,12 @@ bool IcebergMultiFileList::FinishedScanningDeletes() const {
+@@ -134,12 +135,21 @@ bool IcebergMultiFileList::FinishedScanningDeletes() const {
  optional_ptr<const TableFilter> IcebergMultiFileList::GetFilterForColumnIndex(const TableFilterSet &filter_set,
                                                                                const ColumnIndex &column_index) const {
  	auto primary_index = column_index.GetPrimaryIndex();
 -	auto filter_it = filter_set.filters.find(primary_index);
 -	if (filter_it == filter_set.filters.end()) {
-+	auto filter = filter_set.TryGetFilterByColumnIndex(primary_index);
++	ProjectionIndex proj_index;
++	for(idx_t c = 0; c < column_indexes.size(); c++) {
++		if (column_indexes[c] == primary_index) {
++			proj_index = ProjectionIndex(c);
++		}
++	}
++	if (!proj_index.IsValid()) {
++		throw InternalException("IcebergMultiFileList::GetFilterForColumnIndex - could not find corresponding proj id to column id");
++	}
++	auto filter = filter_set.TryGetFilterByColumnIndex(proj_index);
 +	if (!filter) {
  		return nullptr;
  	}
@@ -26,14 +48,21 @@ index 02a3b3d3..e0d90035 100644
  	auto &child_indexes = column_index.GetChildIndexes();
  
  	reference<const TableFilter> current_filter(parent_filter);
-@@ -217,14 +218,14 @@ unique_ptr<IcebergMultiFileList> IcebergMultiFileList::PushdownInternal(ClientCo
+@@ -211,26 +221,28 @@ void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<string
+ }
+ 
+ unique_ptr<IcebergMultiFileList> IcebergMultiFileList::PushdownInternal(ClientContext &context,
+-                                                                        TableFilterSet &new_filters) const {
++                                                                        TableFilterSet &new_filters, vector<column_t> column_indexes) const {
+ 	auto filtered_list = make_uniq<IcebergMultiFileList>(context, scan_info, path, this->options);
+ 
  	TableFilterSet result_filter_set;
  
  	// Add pre-existing filters
 -	for (auto &entry : table_filters.filters) {
 -		result_filter_set.PushFilter(ColumnIndex(entry.first), entry.second->Copy());
 +	for (auto &entry : table_filters) {
-+		result_filter_set.PushFilter(ColumnIndex(entry.ColumnIndex()), entry.Filter().Copy());
++		result_filter_set.PushFilter(entry.ColumnIndex(), entry.Filter().Copy());
  	}
  
  	// Add new filters
@@ -41,12 +70,20 @@ index 02a3b3d3..e0d90035 100644
 -		if (entry.first < names.size()) {
 -			result_filter_set.PushFilter(ColumnIndex(entry.first), entry.second->Copy());
 +	for (auto &entry : new_filters) {
-+		if (entry.ColumnIndex() < names.size()) {
-+			result_filter_set.PushFilter(ColumnIndex(entry.ColumnIndex()), entry.Filter().Copy());
++		auto column_idx = column_indexes[entry.ColumnIndex().index];
++		if (column_idx < names.size()) {
++			result_filter_set.PushFilter(entry.ColumnIndex(), entry.Filter().Copy());
  		}
  	}
  
-@@ -239,23 +240,23 @@ unique_ptr<MultiFileList>
+ 	filtered_list->table_filters = std::move(result_filter_set);
+ 	filtered_list->names = names;
+ 	filtered_list->types = types;
++	filtered_list->column_indexes = std::move(column_indexes);
+ 	filtered_list->have_bound = true;
+ 	return filtered_list;
+ }
+@@ -239,24 +251,23 @@ unique_ptr<MultiFileList>
  IcebergMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFileOptions &options,
                                              const vector<string> &names, const vector<LogicalType> &types,
                                              const vector<column_t> &column_ids, TableFilterSet &filters) const {
@@ -62,23 +99,24 @@ index 02a3b3d3..e0d90035 100644
 -		if (previously_pushed_down_filter != this->table_filters.filters.end() &&
 -		    filter.second->Equals(*previously_pushed_down_filter->second)) {
 +	for (auto &entry : filters) {
-+		auto column_id = column_ids[entry.ColumnIndex()];
 +		auto &filter = entry.Filter();
-+		auto previously_pushed_down_filter = table_filters.TryGetFilterByColumnIndex(column_id);
++		auto previously_pushed_down_filter = table_filters.TryGetFilterByColumnIndex(entry.ColumnIndex());
 +		if (previously_pushed_down_filter && filter.Equals(*previously_pushed_down_filter)) {
  			// Skip filters that we already have pushed down
  			continue;
  		}
 -		filters_copy.PushFilter(ColumnIndex(column_id), filter.second->Copy());
-+		filters_copy.PushFilter(ColumnIndex(column_id), filter.Copy());
++		filters_copy.PushFilter(entry.ColumnIndex(), filter.Copy());
  	}
  
 -	if (!filters_copy.filters.empty()) {
+-		auto new_snap = PushdownInternal(context, filters_copy);
 +	if (filters_copy.HasFilters()) {
- 		auto new_snap = PushdownInternal(context, filters_copy);
++		auto new_snap = PushdownInternal(context, filters_copy, column_ids);
  		return std::move(new_snap);
  	}
-@@ -277,7 +278,7 @@ unique_ptr<MultiFileList> IcebergMultiFileList::ComplexFilterPushdown(ClientCont
+ 	return nullptr;
+@@ -277,11 +288,11 @@ unique_ptr<MultiFileList> IcebergMultiFileList::ComplexFilterPushdown(ClientCont
  
  	vector<FilterPushdownResult> unused;
  	auto filter_set = combiner.GenerateTableScanFilters(info.column_indexes, unused);
@@ -87,7 +125,12 @@ index 02a3b3d3..e0d90035 100644
  		return nullptr;
  	}
  
-@@ -382,16 +383,14 @@ IcebergPredicateStats IcebergPredicateStats::DeserializeBounds(const Value &lowe
+-	return PushdownInternal(context, filter_set);
++	return PushdownInternal(context, filter_set, info.column_ids);
+ }
+ 
+ vector<OpenFileInfo> IcebergMultiFileList::GetAllFiles() const {
+@@ -382,18 +393,15 @@ IcebergPredicateStats IcebergPredicateStats::DeserializeBounds(const Value &lowe
  
  bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestEntry &manifest_entry,
                                               IcebergDataFileType file_type) const {
@@ -97,27 +140,29 @@ index 02a3b3d3..e0d90035 100644
 -	auto &filters = table_filters.filters;
  	auto &schema = GetSchema().columns;
  
- 	for (idx_t index = 0; index < schema.size(); index++) {
+-	for (idx_t index = 0; index < schema.size(); index++) {
++	for(auto &entry : table_filters) {
++		auto proj_id = entry.ColumnIndex();
++		auto index = column_indexes[proj_id.index];
  		auto &column = *schema[index];
 -		auto it = filters.find(index);
 -
 -		if (it == filters.end()) {
-+		auto filter = table_filters.TryGetFilterByColumnIndex(index);
-+		if (!filter) {
- 			continue;
- 		}
+-			continue;
+-		}
++		auto &filter = entry.Filter();
  		auto &metadata = GetMetadata();
-@@ -512,8 +511,7 @@ bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestEntry &manifes
+ 		auto &data_file = manifest_entry.data_file;
+ 		// First check if there are partitions
+@@ -512,7 +520,6 @@ bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestEntry &manifes
  			stats.has_nan = nan_counts != 0;
  		}
  
 -		auto &filter = *it->second;
--		if (!IcebergPredicate::MatchBounds(context, filter, stats, IcebergTransform::Identity())) {
-+		if (!IcebergPredicate::MatchBounds(context, *filter, stats, IcebergTransform::Identity())) {
+ 		if (!IcebergPredicate::MatchBounds(context, filter, stats, IcebergTransform::Identity())) {
  			//! If any predicate fails, exclude the file
  			return false;
- 		}
-@@ -596,7 +594,7 @@ optional_ptr<const IcebergManifestEntry> IcebergMultiFileList::GetDataFile(idx_t
+@@ -596,7 +603,7 @@ optional_ptr<const IcebergManifestEntry> IcebergMultiFileList::GetDataFile(idx_t
  			auto &data_file = manifest_entry.data_file;
  			manifest_entry_idx++;
  			// Check whether current data file is filtered out.
@@ -126,7 +171,7 @@ index 02a3b3d3..e0d90035 100644
  				DUCKDB_LOG(context, IcebergLogType, "Iceberg Filter Pushdown, skipped 'data_file': '%s'",
  				           data_file.file_path);
  				//! Skip this file
-@@ -689,7 +687,7 @@ bool IcebergMultiFileList::ManifestMatchesFilter(const IcebergManifestFile &mani
+@@ -689,7 +696,7 @@ bool IcebergMultiFileList::ManifestMatchesFilter(const IcebergManifestFile &mani
  		    field_summaries.size(), partition_spec.fields.size());
  	}
  
@@ -135,7 +180,7 @@ index 02a3b3d3..e0d90035 100644
  		//! There are no filters
  		return true;
  	}
-@@ -850,7 +848,7 @@ void IcebergMultiFileList::ProcessDeletes(const vector<MultiFileColumnDefinition
+@@ -850,7 +857,7 @@ void IcebergMultiFileList::ProcessDeletes(const vector<MultiFileColumnDefinition
  		for (auto &manifest_entry : entries) {
  			auto &data_file = manifest_entry.data_file;
  			// Check whether current data file is filtered out.
@@ -156,6 +201,27 @@ index 82c0aed8..905ca1cb 100644
  
  namespace duckdb {
  
+diff --git a/src/include/iceberg_multi_file_list.hpp b/src/include/iceberg_multi_file_list.hpp
+index 62b71d18..a048875c 100644
+--- a/src/include/iceberg_multi_file_list.hpp
++++ b/src/include/iceberg_multi_file_list.hpp
+@@ -66,7 +66,7 @@ public:
+ 	bool FinishedScanningDeletes() const;
+ 
+ 	void Bind(vector<LogicalType> &return_types, vector<string> &names);
+-	unique_ptr<IcebergMultiFileList> PushdownInternal(ClientContext &context, TableFilterSet &new_filters) const;
++	unique_ptr<IcebergMultiFileList> PushdownInternal(ClientContext &context, TableFilterSet &new_filters, vector<column_t> column_indexes) const;
+ 	void ScanPositionalDeleteFile(DataChunk &result) const;
+ 	void ScanEqualityDeleteFile(const IcebergManifestEntry &manifest_entry, DataChunk &result,
+ 	                            vector<MultiFileColumnDefinition> &columns,
+@@ -127,6 +127,7 @@ public:
+ 	vector<string> names;
+ 	vector<LogicalType> types;
+ 	TableFilterSet table_filters;
++	vector<column_t> column_indexes;
+ 
+ 	mutable mutex entry_lock;
+ 	mutable vector<IcebergManifestEntry> manifest_entries;
 diff --git a/src/storage/catalog/iceberg_table_set.cpp b/src/storage/catalog/iceberg_table_set.cpp
 index d2d8f9df..6522c068 100644
 --- a/src/storage/catalog/iceberg_table_set.cpp
@@ -203,16 +269,3 @@ index 15350c54..4ab34c16 100644
  		get.AddColumnId(physical_index.index);
  		update.columns.push_back(physical_index);
  	}
-diff --git a/src/aws.cpp b/src/aws.cpp
-index 608c67af..9c6744a7 100644
---- a/src/aws.cpp
-+++ b/src/aws.cpp
-@@ -50,7 +50,7 @@ static void InitAWSAPI() {
- static void LogAWSHTTPRequest(ClientContext &context, std::shared_ptr<Aws::Http::HttpRequest> &req,
-                               HTTPResponse &response, Aws::Http::HttpMethod &method) {
- 	D_ASSERT(context.db);
--	auto http_util = HTTPUtil::Get(*context.db);
-+	auto &http_util = HTTPUtil::Get(*context.db);
- 	auto aws_headers = req->GetHeaders();
- 	auto http_headers = HTTPHeaders();
- 	for (auto &header : aws_headers) {

--- a/.github/patches/extensions/mysql_scanner/fix.patch
+++ b/.github/patches/extensions/mysql_scanner/fix.patch
@@ -12,7 +12,7 @@ index c941c46..8366651 100644
  #include "duckdb/planner/filter/constant_filter.hpp"
  
 diff --git a/src/mysql_filter_pushdown.cpp b/src/mysql_filter_pushdown.cpp
-index 70ab546..3272c2f 100644
+index 70ab546..9f1d512 100644
 --- a/src/mysql_filter_pushdown.cpp
 +++ b/src/mysql_filter_pushdown.cpp
 @@ -84,14 +84,14 @@ string MySQLFilterPushdown::TransformFilter(string &column_name, TableFilter &fi
@@ -29,16 +29,16 @@ index 70ab546..3272c2f 100644
 -		auto column_name = MySQLUtils::WriteIdentifier(names[column_ids[entry.first]]);
 -		auto &filter = *entry.second;
 +	for (auto &entry : *filters) {
-+		auto column_name = MySQLUtils::WriteIdentifier(names[column_ids[entry.ColumnIndex().index]]);
++		auto column_name = MySQLUtils::WriteIdentifier(names[column_ids[entry.GetIndex()]]);
 +		auto &filter = entry.Filter();
  		auto new_filter = TransformFilter(column_name, filter);
  		if (new_filter.empty()) {
  			continue;
 diff --git a/src/storage/mysql_execute_query.cpp b/src/storage/mysql_execute_query.cpp
-index b66df5d..4712618 100644
+index b66df5d..73699f6 100644
 --- a/src/storage/mysql_execute_query.cpp
 +++ b/src/storage/mysql_execute_query.cpp
-@@ -115,12 +115,12 @@ string ExtractFilters(PhysicalOperator &child, const string &statement) {
+@@ -115,9 +115,9 @@ string ExtractFilters(PhysicalOperator &child, const string &statement) {
  			return string();
  		}
  		string result;
@@ -46,16 +46,11 @@ index b66df5d..4712618 100644
 -			auto column_index = entry.first;
 -			auto &filter = entry.second;
 +		for (auto &entry : *table_scan.table_filters) {
-+			auto column_index = entry.ColumnIndex();
++			auto column_index = entry.GetIndex();
 +			auto &filter = entry.Filter();
  			string column_name;
--			if (column_index < table_scan.names.size()) {
--				const auto col_id = table_scan.column_ids[column_index].GetPrimaryIndex();
-+			if (column_index.index < table_scan.names.size()) {
-+				const auto col_id = table_scan.column_ids[column_index.index].GetPrimaryIndex();
- 				if (col_id == COLUMN_IDENTIFIER_ROW_ID) {
- 					column_name = "rowid";
- 				} else {
+ 			if (column_index < table_scan.names.size()) {
+ 				const auto col_id = table_scan.column_ids[column_index].GetPrimaryIndex();
 @@ -128,7 +128,7 @@ string ExtractFilters(PhysicalOperator &child, const string &statement) {
  				}
  			}

--- a/.github/patches/extensions/mysql_scanner/fix.patch
+++ b/.github/patches/extensions/mysql_scanner/fix.patch
@@ -12,7 +12,7 @@ index c941c46..8366651 100644
  #include "duckdb/planner/filter/constant_filter.hpp"
  
 diff --git a/src/mysql_filter_pushdown.cpp b/src/mysql_filter_pushdown.cpp
-index 70ab546..f461e5d 100644
+index 70ab546..3272c2f 100644
 --- a/src/mysql_filter_pushdown.cpp
 +++ b/src/mysql_filter_pushdown.cpp
 @@ -84,14 +84,14 @@ string MySQLFilterPushdown::TransformFilter(string &column_name, TableFilter &fi
@@ -29,16 +29,16 @@ index 70ab546..f461e5d 100644
 -		auto column_name = MySQLUtils::WriteIdentifier(names[column_ids[entry.first]]);
 -		auto &filter = *entry.second;
 +	for (auto &entry : *filters) {
-+		auto column_name = MySQLUtils::WriteIdentifier(names[column_ids[entry.ColumnIndex()]]);
++		auto column_name = MySQLUtils::WriteIdentifier(names[column_ids[entry.ColumnIndex().index]]);
 +		auto &filter = entry.Filter();
  		auto new_filter = TransformFilter(column_name, filter);
  		if (new_filter.empty()) {
  			continue;
 diff --git a/src/storage/mysql_execute_query.cpp b/src/storage/mysql_execute_query.cpp
-index b66df5d..3eec305 100644
+index b66df5d..4712618 100644
 --- a/src/storage/mysql_execute_query.cpp
 +++ b/src/storage/mysql_execute_query.cpp
-@@ -115,9 +115,9 @@ string ExtractFilters(PhysicalOperator &child, const string &statement) {
+@@ -115,12 +115,12 @@ string ExtractFilters(PhysicalOperator &child, const string &statement) {
  			return string();
  		}
  		string result;
@@ -49,8 +49,13 @@ index b66df5d..3eec305 100644
 +			auto column_index = entry.ColumnIndex();
 +			auto &filter = entry.Filter();
  			string column_name;
- 			if (column_index < table_scan.names.size()) {
- 				const auto col_id = table_scan.column_ids[column_index].GetPrimaryIndex();
+-			if (column_index < table_scan.names.size()) {
+-				const auto col_id = table_scan.column_ids[column_index].GetPrimaryIndex();
++			if (column_index.index < table_scan.names.size()) {
++				const auto col_id = table_scan.column_ids[column_index.index].GetPrimaryIndex();
+ 				if (col_id == COLUMN_IDENTIFIER_ROW_ID) {
+ 					column_name = "rowid";
+ 				} else {
 @@ -128,7 +128,7 @@ string ExtractFilters(PhysicalOperator &child, const string &statement) {
  				}
  			}

--- a/.github/patches/extensions/postgres_scanner/fix.patch
+++ b/.github/patches/extensions/postgres_scanner/fix.patch
@@ -12,7 +12,7 @@ index d3dc0b6..471bc4c 100644
  #include "duckdb/planner/filter/constant_filter.hpp"
  
 diff --git a/src/postgres_filter_pushdown.cpp b/src/postgres_filter_pushdown.cpp
-index c2f981a..fcdcf3e 100644
+index c2f981a..bfe0b28 100644
 --- a/src/postgres_filter_pushdown.cpp
 +++ b/src/postgres_filter_pushdown.cpp
 @@ -127,20 +127,20 @@ string PostgresFilterPushdown::TransformFilter(string &column_name, TableFilter
@@ -29,7 +29,7 @@ index c2f981a..fcdcf3e 100644
 +	for (auto &entry : *filters) {
  		string column_name;
 -		auto column_id = column_ids[entry.first];
-+		auto column_id = column_ids[entry.ColumnIndex()];
++		auto column_id = column_ids[entry.ColumnIndex().index];
  		if (IsVirtualColumn(column_id)) {
  			column_name = "ctid";
  		} else {

--- a/.github/patches/extensions/postgres_scanner/fix.patch
+++ b/.github/patches/extensions/postgres_scanner/fix.patch
@@ -12,7 +12,7 @@ index d3dc0b6..471bc4c 100644
  #include "duckdb/planner/filter/constant_filter.hpp"
  
 diff --git a/src/postgres_filter_pushdown.cpp b/src/postgres_filter_pushdown.cpp
-index c2f981a..bfe0b28 100644
+index c2f981a..cabe77f 100644
 --- a/src/postgres_filter_pushdown.cpp
 +++ b/src/postgres_filter_pushdown.cpp
 @@ -127,20 +127,20 @@ string PostgresFilterPushdown::TransformFilter(string &column_name, TableFilter
@@ -29,7 +29,7 @@ index c2f981a..bfe0b28 100644
 +	for (auto &entry : *filters) {
  		string column_name;
 -		auto column_id = column_ids[entry.first];
-+		auto column_id = column_ids[entry.ColumnIndex().index];
++		auto column_id = column_ids[entry.GetIndex()];
  		if (IsVirtualColumn(column_id)) {
  			column_name = "ctid";
  		} else {

--- a/.github/patches/extensions/spatial/fix.patch
+++ b/.github/patches/extensions/spatial/fix.patch
@@ -12,7 +12,7 @@ index 263d413..63d35f1 100644
  	// Visit the operator's expressions
  	LogicalOperatorVisitor::EnumerateExpressions(*this,
 diff --git a/src/spatial/index/rtree/rtree_index_plan_scan.cpp b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
-index 3b37ca8..dc9a8c4 100644
+index 3b37ca8..2138584 100644
 --- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
 +++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
 @@ -27,6 +27,7 @@
@@ -37,14 +37,38 @@ index 3b37ca8..dc9a8c4 100644
  					return;
  				}
  			}
-@@ -175,13 +176,15 @@ public:
+@@ -61,7 +62,7 @@ public:
+ 	}
+ 
+ 	static void RewriteIndexExpressionForFilter(Index &index, LogicalGet &get, unique_ptr<Expression> &expr,
+-	                                            idx_t filter_idx, bool &rewrite_possible) {
++	                                            const ColumnIndex &filter_idx, bool &rewrite_possible) {
+ 		if (expr->type == ExpressionType::BOUND_COLUMN_REF) {
+ 			auto &bound_colref = expr->Cast<BoundColumnRefExpression>();
+ 
+@@ -76,7 +77,7 @@ public:
+ 			const auto &column_list = duck_table.GetColumns();
+ 
+ 			auto &col = column_list.GetColumn(LogicalIndex(indexed_columns[0]));
+-			if (filter_idx != col.Physical().index) {
++			if (filter_idx.GetPrimaryIndex() != col.Physical().index) {
+ 				// RTree does not match the filter column
+ 				rewrite_possible = false;
+ 				return;
+@@ -170,18 +171,21 @@ public:
+ 				return false;
+ 			}
+ 			auto &get_ptr = filter.children.front();
+-			return TryOptimizeGet(binder, context, get_ptr, root, filter, optional_idx(), filter_expr);
++			return TryOptimizeGet(binder, context, get_ptr, root, filter, nullptr, filter_expr);
+ 		}
  		if (op.type == LogicalOperatorType::LOGICAL_GET) {
  			// this is a LogicalGet - check if there is an ExpressionFilter
  			auto &get = op.Cast<LogicalGet>();
 -			for (auto &entry : get.table_filters.filters) {
 -				if (entry.second->filter_type != TableFilterType::EXPRESSION_FILTER) {
 +			for (auto &entry : get.table_filters) {
-+				auto column_id = entry.ColumnIndex();
++				auto proj_id = entry.ColumnIndex();
 +				auto &filter = entry.Filter();
 +				if (filter.filter_type != TableFilterType::EXPRESSION_FILTER) {
  					// not an expression filter
@@ -52,12 +76,33 @@ index 3b37ca8..dc9a8c4 100644
  				}
 -				auto &expr_filter = entry.second->Cast<ExpressionFilter>();
 -				if (TryOptimizeGet(binder, context, plan, root, nullptr, entry.first, expr_filter.expr)) {
++				auto &column_id = get.GetColumnIndex(proj_id);
 +				auto &expr_filter = filter.Cast<ExpressionFilter>();
 +				if (TryOptimizeGet(binder, context, plan, root, nullptr, column_id, expr_filter.expr)) {
  					return true;
  				}
  			}
-@@ -281,14 +284,14 @@ public:
+@@ -192,7 +196,7 @@ public:
+ 
+ 	static bool TryOptimizeGet(Binder &binder, ClientContext &context, unique_ptr<LogicalOperator> &get_ptr,
+ 	                           unique_ptr<LogicalOperator> &root, optional_ptr<LogicalFilter> filter,
+-	                           optional_idx filter_column_idx, unique_ptr<Expression> &filter_expr) {
++	                           optional_ptr<const ColumnIndex> filter_column_idx, unique_ptr<Expression> &filter_expr) {
+ 		auto &get = get_ptr->Cast<LogicalGet>();
+ 		if (get.function.name != "seq_scan") {
+ 			return false;
+@@ -232,8 +236,8 @@ public:
+ 			// Create the bind data for this index given the bounding box
+ 			bool rewrite_possible = true;
+ 			auto index_expr = index_entry.unbound_expressions[0]->Copy();
+-			if (filter_column_idx.IsValid()) {
+-				RewriteIndexExpressionForFilter(index_entry, get, index_expr, filter_column_idx.GetIndex(),
++			if (filter_column_idx) {
++				RewriteIndexExpressionForFilter(index_entry, get, index_expr, *filter_column_idx,
+ 				                                rewrite_possible);
+ 			} else {
+ 				RewriteIndexExpression(index_entry, get, *index_expr, rewrite_possible);
+@@ -281,14 +285,14 @@ public:
  		get.has_estimated_cardinality = cardinality->has_estimated_cardinality;
  		get.estimated_cardinality = cardinality->estimated_cardinality;
  		get.bind_data = std::move(bind_data);
@@ -74,31 +119,30 @@ index 3b37ca8..dc9a8c4 100644
  			}
  		}
  
-@@ -299,22 +302,21 @@ public:
+@@ -299,22 +303,12 @@ public:
  		// does not support regular filter pushdown.
  		auto new_filter = make_uniq<LogicalFilter>();
  		auto &column_ids = get.GetColumnIds();
 -		for (const auto &entry : get.table_filters.filters) {
 -			idx_t column_id = entry.first;
-+		for (const auto &entry : get.table_filters) {
-+			idx_t column_id = entry.ColumnIndex();
- 			auto &type = get.returned_types[column_id];
+-			auto &type = get.returned_types[column_id];
 -			bool found = false;
-+			ProjectionIndex index_ref;
- 			for (idx_t i = 0; i < column_ids.size(); i++) {
- 				if (column_ids[i].GetPrimaryIndex() == column_id) {
+-			for (idx_t i = 0; i < column_ids.size(); i++) {
+-				if (column_ids[i].GetPrimaryIndex() == column_id) {
 -					column_id = i;
 -					found = true;
-+					index_ref = ProjectionIndex(i);
- 					break;
- 				}
- 			}
+-					break;
+-				}
+-			}
 -			if (!found) {
-+			if (!index_ref.IsValid()) {
- 				throw InternalException("Could not find column id for filter");
- 			}
+-				throw InternalException("Could not find column id for filter");
+-			}
 -			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, column_id));
 -			new_filter->expressions.push_back(entry.second->ToExpression(*column));
++		for (const auto &entry : get.table_filters) {
++			auto index_ref = entry.ColumnIndex();
++			auto &column_id = get.GetColumnIndex(index_ref);
++			auto &type = get.returned_types[column_id.GetPrimaryIndex()];
 +			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, index_ref));
 +			new_filter->expressions.push_back(entry.Filter().ToExpression(*column));
  		}

--- a/.github/patches/extensions/spatial/fix.patch
+++ b/.github/patches/extensions/spatial/fix.patch
@@ -12,7 +12,7 @@ index 263d413..63d35f1 100644
  	// Visit the operator's expressions
  	LogicalOperatorVisitor::EnumerateExpressions(*this,
 diff --git a/src/spatial/index/rtree/rtree_index_plan_scan.cpp b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
-index 3b37ca8..2138584 100644
+index 3b37ca8..fa54ae8 100644
 --- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
 +++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
 @@ -27,6 +27,7 @@
@@ -23,17 +23,12 @@ index 3b37ca8..2138584 100644
  
  namespace duckdb {
  //-----------------------------------------------------------------------------
-@@ -45,11 +46,11 @@ public:
- 			bound_colref.binding.table_index = get.table_index;
- 			auto &column_ids = index.GetColumnIds();
- 			auto &get_column_ids = get.GetColumnIds();
--			column_t referenced_column = column_ids[bound_colref.binding.column_index];
-+			column_t referenced_column = column_ids[bound_colref.binding.column_index.index];
+@@ -49,7 +50,7 @@ public:
  			// search for the referenced column in the set of column_ids
  			for (idx_t i = 0; i < get_column_ids.size(); i++) {
  				if (get_column_ids[i].GetPrimaryIndex() == referenced_column) {
 -					bound_colref.binding.column_index = i;
-+					bound_colref.binding.column_index.index = i;
++					bound_colref.binding.column_index = ProjectionIndex(i);
  					return;
  				}
  			}
@@ -68,7 +63,7 @@ index 3b37ca8..2138584 100644
 -			for (auto &entry : get.table_filters.filters) {
 -				if (entry.second->filter_type != TableFilterType::EXPRESSION_FILTER) {
 +			for (auto &entry : get.table_filters) {
-+				auto proj_id = entry.ColumnIndex();
++				auto proj_id = entry.GetIndex();
 +				auto &filter = entry.Filter();
 +				if (filter.filter_type != TableFilterType::EXPRESSION_FILTER) {
  					// not an expression filter
@@ -102,21 +97,13 @@ index 3b37ca8..2138584 100644
  				                                rewrite_possible);
  			} else {
  				RewriteIndexExpression(index_entry, get, *index_expr, rewrite_possible);
-@@ -281,14 +285,14 @@ public:
+@@ -281,7 +285,7 @@ public:
  		get.has_estimated_cardinality = cardinality->has_estimated_cardinality;
  		get.estimated_cardinality = cardinality->estimated_cardinality;
  		get.bind_data = std::move(bind_data);
 -		if (get.table_filters.filters.empty()) {
 +		if (!get.table_filters.HasFilters()) {
  			return true;
- 		}
- 
- 		// Before we clear projection ids, replace projection map in the filter
- 		if (!get.projection_ids.empty() && filter) {
- 			for (auto &id : filter->projection_map) {
--				id = get.projection_ids[id];
-+				id = get.projection_ids[id.index];
- 			}
  		}
  
 @@ -299,22 +303,12 @@ public:
@@ -140,7 +127,7 @@ index 3b37ca8..2138584 100644
 -			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, column_id));
 -			new_filter->expressions.push_back(entry.second->ToExpression(*column));
 +		for (const auto &entry : get.table_filters) {
-+			auto index_ref = entry.ColumnIndex();
++			auto index_ref = entry.GetIndex();
 +			auto &column_id = get.GetColumnIndex(index_ref);
 +			auto &type = get.returned_types[column_id.GetPrimaryIndex()];
 +			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, index_ref));

--- a/.github/patches/extensions/vss/fix.patch
+++ b/.github/patches/extensions/vss/fix.patch
@@ -1,5 +1,5 @@
 diff --git a/src/hnsw/hnsw_index.cpp b/src/hnsw/hnsw_index.cpp
-index 1af2a74..18b760c 100644
+index 1af2a74..9d78cb8 100644
 --- a/src/hnsw/hnsw_index.cpp
 +++ b/src/hnsw/hnsw_index.cpp
 @@ -613,7 +613,7 @@ void HNSWIndex::VerifyAllocations(IndexLock &state) {
@@ -11,16 +11,12 @@ index 1af2a74..18b760c 100644
                                             const vector<ColumnIndex> &table_columns, bool &success, bool &found) {
  
  	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
-@@ -623,10 +623,10 @@ static void TryBindIndexExpressionInternal(Expression &expr, idx_t table_idx, co
- 		// Rewrite the column reference to fit in the current set of bound column ids
- 		ref.binding.table_index = table_idx;
- 
--		const auto referenced_column = index_columns[ref.binding.column_index];
-+		const auto referenced_column = index_columns[ref.binding.column_index.index];
+@@ -626,7 +626,7 @@ static void TryBindIndexExpressionInternal(Expression &expr, idx_t table_idx, co
+ 		const auto referenced_column = index_columns[ref.binding.column_index];
  		for (idx_t i = 0; i < table_columns.size(); i++) {
  			if (table_columns[i].GetPrimaryIndex() == referenced_column) {
 -				ref.binding.column_index = i;
-+				ref.binding.column_index.index = i;
++				ref.binding.column_index = ProjectionIndex(i);
  				return;
  			}
  		}
@@ -37,7 +33,7 @@ index 1af2a74..18b760c 100644
  
  unique_ptr<ExpressionMatcher> HNSWIndex::MakeFunctionMatcher() const {
 diff --git a/src/hnsw/hnsw_optimize_join.cpp b/src/hnsw/hnsw_optimize_join.cpp
-index 783db2a..3e17e93 100644
+index 783db2a..509197a 100644
 --- a/src/hnsw/hnsw_optimize_join.cpp
 +++ b/src/hnsw/hnsw_optimize_join.cpp
 @@ -17,6 +17,8 @@
@@ -84,15 +80,6 @@ index 783db2a..3e17e93 100644
  	vector<LogicalType> inner_returned_types;
  
  	idx_t outer_vector_column;
-@@ -232,7 +234,7 @@ void LogicalHNSWIndexJoin::ResolveTypes() {
- 		}
- 	} else {
- 		for (const auto &proj_index : inner_projection_ids) {
--			const auto &index = inner_column_ids[proj_index];
-+			const auto &index = inner_column_ids[proj_index.index];
- 			if (index == COLUMN_IDENTIFIER_ROW_ID) {
- 				types.emplace_back(LogicalType::ROW_TYPE);
- 			} else {
 @@ -253,7 +255,7 @@ vector<ColumnBinding> LogicalHNSWIndexJoin::GetLeftBindings() {
  	vector<ColumnBinding> result;
  	if (inner_projection_ids.empty()) {
@@ -116,34 +103,19 @@ index 783db2a..3e17e93 100644
  		return false;
  	}
 -	if (filter_ref_expr.binding.column_index != 0) {
-+	if (filter_ref_expr.binding.column_index.index != 0) {
++	if (filter_ref_expr.binding.column_index != ProjectionIndex(0)) {
  		return false;
  	}
  
-@@ -491,10 +493,10 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
- 	if (distance_ref_expr.binding.table_index != inner_proj.table_index) {
- 		return false;
- 	}
--	if (distance_ref_expr.binding.column_index >= inner_proj.expressions.size()) {
-+	if (distance_ref_expr.binding.column_index.index >= inner_proj.expressions.size()) {
+@@ -494,7 +496,7 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
+ 	if (distance_ref_expr.binding.column_index >= inner_proj.expressions.size()) {
  		return false;
  	}
 -	const auto &distance_expr_ptr = inner_proj.expressions[distance_ref_expr.binding.column_index];
-+	auto &distance_expr_ptr = *inner_proj.expressions[distance_ref_expr.binding.column_index.index];
++	auto &distance_expr_ptr = *inner_proj.expressions[distance_ref_expr.binding.column_index];
  
  	//------------------------------------------------------------------------------
  	// Match the index
-@@ -586,8 +588,8 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
- 	index_join->inner_returned_types = inner_get.returned_types;
- 
- 	// TODO: this is kind of unsafe, column_index != physical index
--	index_join->outer_vector_column = outer_ref_expr.binding.column_index;
--	index_join->inner_vector_column = inner_ref_expr.binding.column_index;
-+	index_join->outer_vector_column = outer_ref_expr.binding.column_index.index;
-+	index_join->inner_vector_column = inner_ref_expr.binding.column_index.index;
- 
- 	ColumnBindingReplacer replacer;
- 
 @@ -598,7 +600,7 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
  	auto delim_bindings = delim_join.GetColumnBindings();
  	auto delim_types = delim_join.types;
@@ -193,7 +165,7 @@ index 783db2a..3e17e93 100644
  		}
  	}
 diff --git a/src/hnsw/hnsw_optimize_scan.cpp b/src/hnsw/hnsw_optimize_scan.cpp
-index 84dbda7..d1850a8 100644
+index 84dbda7..5d47cb0 100644
 --- a/src/hnsw/hnsw_optimize_scan.cpp
 +++ b/src/hnsw/hnsw_optimize_scan.cpp
 @@ -64,8 +64,7 @@ public:
@@ -202,7 +174,7 @@ index 84dbda7..d1850a8 100644
  		// This the expression that is referenced by the order by expression
 -		const auto projection_index = bound_column_ref.binding.column_index;
 -		const auto &projection_expr = projection.expressions[projection_index];
-+		auto &projection_expr = *projection.expressions[bound_column_ref.binding.column_index.index];
++		auto &projection_expr = *projection.expressions[bound_column_ref.binding.column_index];
  
  		// The projection must sit on top of a get
  		if (projection.children.size() != 1 || projection.children.front()->type != LogicalOperatorType::LOGICAL_GET) {
@@ -236,7 +208,7 @@ index 84dbda7..d1850a8 100644
 -			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, column_id));
 -			new_filter->expressions.push_back(entry.second->ToExpression(*column));
 +		for (const auto &entry : get.table_filters) {
-+			auto filter_idx = entry.ColumnIndex();
++			auto filter_idx = entry.GetIndex();
 +			auto &column_id = get.GetColumnIndex(filter_idx);
 +			auto &type = get.returned_types[column_id.GetPrimaryIndex()];
 +			auto &filter = entry.Filter();
@@ -246,7 +218,7 @@ index 84dbda7..d1850a8 100644
  		new_filter->children.push_back(std::move(get_ptr));
  		new_filter->ResolveOperatorTypes();
 diff --git a/src/hnsw/hnsw_optimize_topk.cpp b/src/hnsw/hnsw_optimize_topk.cpp
-index 14f68e7..3454f7b 100644
+index 14f68e7..5e3a4b8 100644
 --- a/src/hnsw/hnsw_optimize_topk.cpp
 +++ b/src/hnsw/hnsw_optimize_topk.cpp
 @@ -91,7 +91,7 @@ public:
@@ -292,7 +264,7 @@ index 14f68e7..3454f7b 100644
 -			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, column_id));
 -			new_filter->expressions.push_back(entry.second->ToExpression(*column));
 +		for (const auto &entry : get.table_filters) {
-+			auto filter_idx = entry.ColumnIndex();
++			auto filter_idx = entry.GetIndex();
 +			auto &column_id = get.GetColumnIndex(filter_idx);
 +			auto &type = get.returned_types[column_id.GetPrimaryIndex()];
 +			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, filter_idx));

--- a/.github/patches/extensions/vss/fix.patch
+++ b/.github/patches/extensions/vss/fix.patch
@@ -193,7 +193,7 @@ index 783db2a..3e17e93 100644
  		}
  	}
 diff --git a/src/hnsw/hnsw_optimize_scan.cpp b/src/hnsw/hnsw_optimize_scan.cpp
-index 84dbda7..178b00f 100644
+index 84dbda7..d1850a8 100644
 --- a/src/hnsw/hnsw_optimize_scan.cpp
 +++ b/src/hnsw/hnsw_optimize_scan.cpp
 @@ -64,8 +64,7 @@ public:
@@ -215,39 +215,38 @@ index 84dbda7..178b00f 100644
  
  			// Remove the TopN operator
  			plan = std::move(top_n.children[0]);
-@@ -172,22 +171,22 @@ public:
+@@ -172,22 +171,13 @@ public:
  
  		auto new_filter = make_uniq<LogicalFilter>();
  		auto &column_ids = get.GetColumnIds();
 -		for (const auto &entry : get.table_filters.filters) {
 -			idx_t column_id = entry.first;
-+		for (const auto &entry : get.table_filters) {
-+			idx_t column_id = entry.ColumnIndex();
-+			auto &filter = entry.Filter();
- 			auto &type = get.returned_types[column_id];
+-			auto &type = get.returned_types[column_id];
 -			bool found = false;
-+			ProjectionIndex proj_id;
- 			for (idx_t i = 0; i < column_ids.size(); i++) {
- 				if (column_ids[i].GetPrimaryIndex() == column_id) {
+-			for (idx_t i = 0; i < column_ids.size(); i++) {
+-				if (column_ids[i].GetPrimaryIndex() == column_id) {
 -					column_id = i;
 -					found = true;
-+					proj_id = ProjectionIndex(i);
- 					break;
- 				}
- 			}
+-					break;
+-				}
+-			}
 -			if (!found) {
-+			if (!proj_id.IsValid()) {
- 				throw InternalException("Could not find column id for filter");
- 			}
+-				throw InternalException("Could not find column id for filter");
+-			}
 -			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, column_id));
 -			new_filter->expressions.push_back(entry.second->ToExpression(*column));
-+			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, proj_id));
++		for (const auto &entry : get.table_filters) {
++			auto filter_idx = entry.ColumnIndex();
++			auto &column_id = get.GetColumnIndex(filter_idx);
++			auto &type = get.returned_types[column_id.GetPrimaryIndex()];
++			auto &filter = entry.Filter();
++			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, filter_idx));
 +			new_filter->expressions.push_back(filter.ToExpression(*column));
  		}
  		new_filter->children.push_back(std::move(get_ptr));
  		new_filter->ResolveOperatorTypes();
 diff --git a/src/hnsw/hnsw_optimize_topk.cpp b/src/hnsw/hnsw_optimize_topk.cpp
-index 14f68e7..c700b02 100644
+index 14f68e7..3454f7b 100644
 --- a/src/hnsw/hnsw_optimize_topk.cpp
 +++ b/src/hnsw/hnsw_optimize_topk.cpp
 @@ -91,7 +91,7 @@ public:
@@ -272,32 +271,31 @@ index 14f68e7..c700b02 100644
  			return true;
  		}
  
-@@ -203,22 +203,21 @@ public:
+@@ -203,22 +203,12 @@ public:
  
  		auto new_filter = make_uniq<LogicalFilter>();
  		auto &column_ids = get.GetColumnIds();
 -		for (const auto &entry : get.table_filters.filters) {
 -			idx_t column_id = entry.first;
-+		for (const auto &entry : get.table_filters) {
-+			idx_t column_id = entry.ColumnIndex();
- 			auto &type = get.returned_types[column_id];
+-			auto &type = get.returned_types[column_id];
 -			bool found = false;
-+			ProjectionIndex proj_id;
- 			for (idx_t i = 0; i < column_ids.size(); i++) {
- 				if (column_ids[i].GetPrimaryIndex() == column_id) {
+-			for (idx_t i = 0; i < column_ids.size(); i++) {
+-				if (column_ids[i].GetPrimaryIndex() == column_id) {
 -					column_id = i;
 -					found = true;
-+					proj_id = ProjectionIndex(i);
- 					break;
- 				}
- 			}
+-					break;
+-				}
+-			}
 -			if (!found) {
-+			if (!proj_id.IsValid()) {
- 				throw InternalException("Could not find column id for filter");
- 			}
+-				throw InternalException("Could not find column id for filter");
+-			}
 -			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, column_id));
 -			new_filter->expressions.push_back(entry.second->ToExpression(*column));
-+			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, proj_id));
++		for (const auto &entry : get.table_filters) {
++			auto filter_idx = entry.ColumnIndex();
++			auto &column_id = get.GetColumnIndex(filter_idx);
++			auto &type = get.returned_types[column_id.GetPrimaryIndex()];
++			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, filter_idx));
 +			new_filter->expressions.push_back(entry.Filter().ToExpression(*column));
  		}
  

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -48,11 +48,11 @@ struct ParquetReaderPrefetchConfig {
 };
 
 struct ParquetScanFilter {
-	ParquetScanFilter(ClientContext &context, idx_t filter_idx, TableFilter &filter);
+	ParquetScanFilter(ClientContext &context, ProjectionIndex filter_idx, TableFilter &filter);
 	~ParquetScanFilter();
 	ParquetScanFilter(ParquetScanFilter &&) = default;
 
-	idx_t filter_idx;
+	ProjectionIndex filter_idx;
 	TableFilter &filter;
 	unique_ptr<TableFilterState> filter_state;
 };

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1224,7 +1224,7 @@ idx_t ParquetReader::GetDataSize() const {
 	return data_size;
 }
 
-ParquetScanFilter::ParquetScanFilter(ClientContext &context, idx_t filter_idx, TableFilter &filter)
+ParquetScanFilter::ParquetScanFilter(ClientContext &context, ProjectionIndex filter_idx, TableFilter &filter)
     : filter_idx(filter_idx), filter(filter) {
 	filter_state = TableFilterState::Initialize(context, filter);
 }
@@ -1482,7 +1482,7 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 					break;
 				}
 				auto &scan_filter = state.scan_filters[state.adaptive_filter->permutation[i]];
-				auto local_idx = MultiFileLocalIndex(scan_filter.filter_idx);
+				MultiFileLocalIndex local_idx(scan_filter.filter_idx);
 				auto column_id = column_ids[local_idx];
 
 				auto &result_vector = result.data[local_idx.GetIndex()];
@@ -1497,7 +1497,7 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 
 		// we still may have to read some cols
 		for (idx_t i = 0; i < column_ids.size(); i++) {
-			auto col_idx = MultiFileLocalIndex(i);
+			MultiFileLocalIndex col_idx(i);
 			if (!need_to_read[col_idx]) {
 				continue;
 			}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1257,7 +1257,7 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 	if (filters) {
 		state.adaptive_filter = make_uniq<AdaptiveFilter>(*filters);
 		for (auto &entry : *filters) {
-			state.scan_filters.emplace_back(context, entry.ColumnIndex(), entry.Filter());
+			state.scan_filters.emplace_back(context, entry.GetIndex(), entry.Filter());
 		}
 	}
 

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -28,19 +28,19 @@ MultiFileColumnMapper::MultiFileColumnMapper(ClientContext &context, MultiFileRe
 
 struct MultiFileIndexMapping {
 public:
-	explicit MultiFileIndexMapping(idx_t index) : index(index) {
+	explicit MultiFileIndexMapping(MultiFileLocalIndex index) : index(index) {
 	}
 
 public:
-	idx_t index;
-	unordered_map<idx_t, unique_ptr<MultiFileIndexMapping>> child_mapping;
+	MultiFileLocalIndex index;
+	unordered_map<MultiFileGlobalIndex, unique_ptr<MultiFileIndexMapping>> child_mapping;
 };
 
 //! The local to global conversion required for table filters on this column
 enum class FilterConversionType { COPY_DIRECTLY, CAST_FILTER, CANNOT_CONVERT };
 
 struct MultiFileColumnMap {
-	MultiFileColumnMap(idx_t index, const LogicalType &local_type, const LogicalType &global_type)
+	MultiFileColumnMap(MultiFileLocalIndex index, const LogicalType &local_type, const LogicalType &global_type)
 	    : mapping(index), local_type(local_type), global_type(global_type),
 	      filter_conversion(local_type == global_type ? FilterConversionType::COPY_DIRECTLY
 	                                                  : FilterConversionType::CAST_FILTER) {
@@ -58,7 +58,7 @@ struct MultiFileColumnMap {
 };
 
 struct ResultColumnMapping {
-	unordered_map<idx_t, MultiFileColumnMap> global_to_local;
+	unordered_map<MultiFileGlobalIndex, MultiFileColumnMap> global_to_local;
 	string error;
 
 public:
@@ -79,7 +79,7 @@ struct ColumnMapResult {
 struct ColumnMapper {
 	virtual ~ColumnMapper() = default;
 	virtual unique_ptr<ColumnMapper> Create(const vector<MultiFileColumnDefinition> &columns) const = 0;
-	virtual optional_idx Find(const MultiFileColumnDefinition &column) const = 0;
+	virtual MultiFileLocalIndex Find(const MultiFileColumnDefinition &column) const = 0;
 	virtual unique_ptr<Expression> GetDefaultExpression(const MultiFileColumnDefinition &column,
 	                                                    bool is_root) const = 0;
 	virtual idx_t MapCount() const = 0;
@@ -94,20 +94,20 @@ struct FieldIdMapper : public ColumnMapper {
 				break;
 			}
 			auto field_id = column.GetIdentifierFieldId();
-			field_id_map.emplace(field_id, MultiFileLocalColumnId(col_idx));
+			field_id_map.emplace(field_id, MultiFileLocalIndex(col_idx));
 		}
 	}
 
 	unique_ptr<ColumnMapper> Create(const vector<MultiFileColumnDefinition> &columns) const override {
 		return make_uniq<FieldIdMapper>(columns);
 	}
-	optional_idx Find(const MultiFileColumnDefinition &column) const override {
+	MultiFileLocalIndex Find(const MultiFileColumnDefinition &column) const override {
 		D_ASSERT(!column.identifier.IsNull());
 		auto entry = field_id_map.find(column.GetIdentifierFieldId());
 		if (entry == field_id_map.end()) {
-			return optional_idx();
+			return MultiFileLocalIndex();
 		}
-		return entry->second.GetId();
+		return entry->second;
 	}
 	static unique_ptr<Expression> GetDefault(const MultiFileColumnDefinition &column) {
 		auto &default_val = column.default_expression;
@@ -130,26 +130,26 @@ struct FieldIdMapper : public ColumnMapper {
 	}
 
 private:
-	unordered_map<int32_t, MultiFileLocalColumnId> field_id_map;
+	unordered_map<int32_t, MultiFileLocalIndex> field_id_map;
 };
 
 struct NameMapper : public ColumnMapper {
 	NameMapper(MultiFileColumnMapper &mapper, const vector<MultiFileColumnDefinition> &columns) : mapper(mapper) {
 		for (idx_t col_idx = 0; col_idx < columns.size(); col_idx++) {
 			auto &column = columns[col_idx];
-			name_map.emplace(column.name, MultiFileLocalColumnId(col_idx));
+			name_map.emplace(column.name, MultiFileLocalIndex(col_idx));
 		}
 	}
 
 	unique_ptr<ColumnMapper> Create(const vector<MultiFileColumnDefinition> &columns) const override {
 		return make_uniq<NameMapper>(mapper, columns);
 	}
-	optional_idx Find(const MultiFileColumnDefinition &column) const override {
+	MultiFileLocalIndex Find(const MultiFileColumnDefinition &column) const override {
 		auto entry = name_map.find(column.GetIdentifierName());
 		if (entry == name_map.end()) {
-			return optional_idx();
+			return MultiFileLocalIndex();
 		}
-		return entry->second.GetId();
+		return entry->second;
 	}
 	unique_ptr<Expression> GetDefaultExpression(const MultiFileColumnDefinition &column, bool is_root) const override {
 		if (column.default_expression) {
@@ -171,7 +171,7 @@ struct NameMapper : public ColumnMapper {
 
 private:
 	MultiFileColumnMapper &mapper;
-	case_insensitive_map_t<MultiFileLocalColumnId> name_map;
+	case_insensitive_map_t<MultiFileLocalIndex> name_map;
 };
 
 void MultiFileColumnMapper::ThrowColumnNotFoundError(const string &global_column_name) const {
@@ -228,11 +228,11 @@ bool IsTriviallyMappable(const MultiFileColumnDefinition &global_column,
 static ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDefinition &global_column,
                                  const ColumnIndex &global_index,
                                  const vector<MultiFileColumnDefinition> &local_columns, const ColumnMapper &mapper,
-                                 optional_idx top_level_index = optional_idx());
+                                 MultiFileLocalIndex top_level_index = MultiFileLocalIndex());
 
 ColumnMapResult MapColumnList(ClientContext &context, const MultiFileColumnDefinition &global_column,
                               const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
-                              const MultiFileLocalColumnId &local_id, const ColumnMapper &mapper,
+                              const MultiFileLocalIndex &local_id, const ColumnMapper &mapper,
                               unique_ptr<MultiFileIndexMapping> mapping, const bool is_root) {
 	const idx_t expected_list_children = 1;
 	if (global_column.children.size() != expected_list_children) {
@@ -311,7 +311,7 @@ ColumnMapResult MapColumnList(ClientContext &context, const MultiFileColumnDefin
 		result.default_value = make_uniq<BoundFunctionExpression>(std::move(default_type), std::move(struct_pack_fun),
 		                                                          std::move(default_expressions), std::move(bind_data));
 	}
-	result.column_index = make_uniq<ColumnIndex>(local_id.GetId(), std::move(child_indexes));
+	result.column_index = make_uniq<ColumnIndex>(local_id.GetIndex(), std::move(child_indexes));
 	result.mapping = std::move(mapping);
 	return result;
 }
@@ -346,7 +346,7 @@ MapColumnMapComponent(ClientContext &context,
 
 ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefinition &global_column,
                              const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
-                             const MultiFileLocalColumnId &local_id, const ColumnMapper &mapper,
+                             const MultiFileLocalIndex &local_id, const ColumnMapper &mapper,
                              unique_ptr<MultiFileIndexMapping> mapping, const bool is_root) {
 	const idx_t expected_map_children = 2;
 	if (global_column.children.size() != expected_map_children) {
@@ -426,14 +426,14 @@ ColumnMapResult MapColumnMap(ClientContext &context, const MultiFileColumnDefini
 	vector<ColumnIndex> map_indexes;
 	map_indexes.emplace_back(0, std::move(child_indexes));
 
-	result.column_index = make_uniq<ColumnIndex>(local_id.GetId(), std::move(map_indexes));
+	result.column_index = make_uniq<ColumnIndex>(local_id.GetIndex(), std::move(map_indexes));
 	result.mapping = std::move(mapping);
 	return result;
 }
 
 ColumnMapResult MapColumnStruct(ClientContext &context, const MultiFileColumnDefinition &global_column,
                                 const ColumnIndex &global_index, const MultiFileColumnDefinition &local_column,
-                                const MultiFileLocalColumnId &local_id, const ColumnMapper &mapper,
+                                const MultiFileLocalIndex &local_id, const ColumnMapper &mapper,
                                 unique_ptr<MultiFileIndexMapping> mapping, const bool is_root) {
 	auto &struct_children = StructType::GetChildTypes(global_column.type);
 	if (struct_children.size() != global_column.children.size()) {
@@ -517,7 +517,7 @@ ColumnMapResult MapColumnStruct(ClientContext &context, const MultiFileColumnDef
 		result.default_value = make_uniq<BoundFunctionExpression>(std::move(default_type), std::move(struct_pack_fun),
 		                                                          std::move(default_expressions), std::move(bind_data));
 	}
-	result.column_index = make_uniq<ColumnIndex>(local_id.GetId(), std::move(child_indexes));
+	result.column_index = make_uniq<ColumnIndex>(local_id.GetIndex(), std::move(child_indexes));
 	result.mapping = std::move(mapping);
 	return result;
 }
@@ -525,33 +525,23 @@ ColumnMapResult MapColumnStruct(ClientContext &context, const MultiFileColumnDef
 static ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDefinition &global_column,
                                  const ColumnIndex &global_index,
                                  const vector<MultiFileColumnDefinition> &local_columns, const ColumnMapper &mapper,
-                                 optional_idx top_level_index) {
+                                 MultiFileLocalIndex top_level_index) {
 	bool is_root = top_level_index.IsValid();
 	ColumnMapResult result;
-	auto entry = mapper.Find(global_column);
-	if (!entry.IsValid()) {
+	auto local_idx = mapper.Find(global_column);
+	if (!local_idx.IsValid()) {
 		// entry not present in map, use default value
 		result.default_value = mapper.GetDefaultExpression(global_column, is_root);
 		return result;
 	}
 	// the field exists! get the local column
-	MultiFileLocalColumnId local_id(entry.GetIndex());
-	auto &local_column = local_columns[local_id.GetId()];
-	unique_ptr<MultiFileIndexMapping> mapping;
-	idx_t mapping_idx;
-	if (is_root) {
-		// root expression - refer to it directly
-		mapping_idx = top_level_index.GetIndex();
-	} else {
-		// extract the field from the parent
-		mapping_idx = local_id.GetId();
-	}
-
-	mapping = make_uniq<MultiFileIndexMapping>(mapping_idx);
+	auto &local_column = local_columns[local_idx];
+	auto mapping_idx = is_root ? top_level_index : local_idx;
+	auto mapping = make_uniq<MultiFileIndexMapping>(mapping_idx);
 	if (global_column.children.empty()) {
 		// not a struct - map the column directly
 		result.column_map = Value(local_column.name);
-		result.column_index = make_uniq<ColumnIndex>(local_id.GetId());
+		result.column_index = make_uniq<ColumnIndex>(local_idx.GetIndex());
 		result.mapping = std::move(mapping);
 		result.local_column = local_column;
 		return result;
@@ -561,13 +551,13 @@ static ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDe
 	D_ASSERT(global_column.type.IsNested());
 	switch (global_column.type.id()) {
 	case LogicalTypeId::STRUCT:
-		return MapColumnStruct(context, global_column, global_index, local_column, local_id, mapper, std::move(mapping),
+		return MapColumnStruct(context, global_column, global_index, local_column, local_idx, mapper, std::move(mapping),
 		                       is_root);
 	case LogicalTypeId::LIST:
-		return MapColumnList(context, global_column, global_index, local_column, local_id, mapper, std::move(mapping),
+		return MapColumnList(context, global_column, global_index, local_column, local_idx, mapper, std::move(mapping),
 		                     is_root);
 	case LogicalTypeId::MAP:
-		return MapColumnMap(context, global_column, global_index, local_column, local_id, mapper, std::move(mapping),
+		return MapColumnMap(context, global_column, global_index, local_column, local_idx, mapper, std::move(mapping),
 		                    is_root);
 	case LogicalTypeId::ARRAY: {
 		throw NotImplementedException("Can't map an ARRAY with nested children!");
@@ -578,12 +568,11 @@ static ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDe
 	}
 }
 
-unique_ptr<Expression> ConstructMapExpression(ClientContext &context, idx_t local_idx, ColumnMapResult &mapping,
+unique_ptr<Expression> ConstructMapExpression(ClientContext &context, MultiFileLocalIndex local_idx, ColumnMapResult &mapping,
                                               const MultiFileColumnDefinition &global_column,
                                               bool is_trivially_mappable) {
 	auto &local_column = *mapping.local_column;
-	unique_ptr<Expression> expr;
-	expr = make_uniq<BoundReferenceExpression>(local_column.type, local_idx);
+	unique_ptr<Expression> expr = make_uniq<BoundReferenceExpression>(local_column.type, local_idx.GetIndex());
 	if (!global_column.type.IsNested() ||
 	    (!mapping.column_map.IsNull() && mapping.column_map.type().id() != LogicalTypeId::STRUCT) ||
 	    is_trivially_mappable) {
@@ -694,7 +683,7 @@ ResultColumnMapping MultiFileColumnMapper::CreateColumnMappingByMapper(const Col
 				if (!is_reference) {
 					index_mapping.filter_conversion = FilterConversionType::CANNOT_CONVERT;
 				}
-				result.global_to_local.insert(make_pair(global_idx.GetIndex(), std::move(index_mapping)));
+				result.global_to_local.insert(make_pair(global_idx, std::move(index_mapping)));
 				reader.column_ids.push_back(local_id);
 				reader.column_indexes.push_back(std::move(local_index));
 				continue;
@@ -723,13 +712,13 @@ ResultColumnMapping MultiFileColumnMapper::CreateColumnMappingByMapper(const Col
 			reader_data.expressions.push_back(std::move(expr));
 
 			MultiFileColumnMap index_mapping(local_idx, local_type, global_type);
-			result.global_to_local.insert(make_pair(global_idx.GetIndex(), std::move(index_mapping)));
+			result.global_to_local.insert(make_pair(global_idx, std::move(index_mapping)));
 			reader.column_ids.push_back(local_id);
 			reader.column_indexes.push_back(std::move(local_index));
 			continue;
 		}
 
-		auto column_map = MapColumn(context, global_column, global_id, local_columns, mapper, local_idx.GetIndex());
+		auto column_map = MapColumn(context, global_column, global_id, local_columns, mapper, local_idx);
 		if (!column_map.column_index) {
 			// no columns were emitted
 			reader_data.expressions.push_back(std::move(column_map.default_value));
@@ -739,13 +728,13 @@ ResultColumnMapping MultiFileColumnMapper::CreateColumnMappingByMapper(const Col
 		auto local_index = std::move(column_map.column_index);
 		auto local_id = local_index->GetPrimaryIndex();
 		auto &local_type = local_columns[local_id].type;
-		auto expr = ConstructMapExpression(context, local_idx.GetIndex(), column_map, global_column, trivial_map);
+		auto expr = ConstructMapExpression(context, local_idx, column_map, global_column, trivial_map);
 		reader_data.expressions.push_back(std::move(expr));
 		auto filter_conversion = trivial_map ? FilterConversionType::COPY_DIRECTLY : FilterConversionType::CAST_FILTER;
 
 		MultiFileColumnMap index_mapping(std::move(*column_map.mapping), local_type, global_column.type,
 		                                 filter_conversion);
-		result.global_to_local.insert(make_pair(global_idx.GetIndex(), std::move(index_mapping)));
+		result.global_to_local.insert(make_pair(global_idx, std::move(index_mapping)));
 		reader.column_ids.emplace_back(local_id);
 		reader.column_indexes.push_back(std::move(*local_index));
 	}
@@ -891,7 +880,7 @@ bool MultiFileColumnMapper::EvaluateFilterAgainstConstant(TableFilter &filter, c
 	}
 }
 
-Value MultiFileColumnMapper::GetConstantValue(idx_t global_index) {
+Value MultiFileColumnMapper::GetConstantValue(MultiFileGlobalIndex global_index) {
 	auto global_column_id = global_column_ids[global_index].GetPrimaryIndex();
 	auto &expr = reader_data.expressions[global_index];
 	if (expr->type == ExpressionType::VALUE_CONSTANT) {
@@ -899,7 +888,7 @@ Value MultiFileColumnMapper::GetConstantValue(idx_t global_index) {
 	}
 	for (idx_t i = 0; i < reader_data.constant_map.size(); i++) {
 		auto &constant_map_entry = reader_data.constant_map[MultiFileConstantMapIndex(i)];
-		if (constant_map_entry.column_idx.GetIndex() == global_index) {
+		if (constant_map_entry.column_idx == global_index) {
 			return constant_map_entry.value;
 		}
 	}
@@ -910,13 +899,13 @@ Value MultiFileColumnMapper::GetConstantValue(idx_t global_index) {
 
 ReaderInitializeType
 MultiFileColumnMapper::EvaluateConstantFilters(ResultColumnMapping &mapping,
-                                               map<idx_t, reference<TableFilter>> &remaining_filters) {
+                                               map<MultiFileGlobalIndex, reference<TableFilter>> &remaining_filters) {
 	if (!global_filters) {
 		return ReaderInitializeType::INITIALIZED;
 	}
 	auto &global_to_local = mapping.global_to_local;
 	for (auto &it : *global_filters) {
-		auto global_index = it.ColumnIndex();
+		MultiFileGlobalIndex global_index(it.ColumnIndex().index);
 		auto &global_filter = it.Filter();
 
 		auto local_it = global_to_local.find(global_index);
@@ -969,7 +958,7 @@ static unique_ptr<TableFilter> TryCastTableFilter(const TableFilter &global_filt
 		auto &child_filter = struct_filter.child_filter;
 
 		// find the corresponding local entry
-		auto entry = mapping.child_mapping.find(struct_filter.child_idx);
+		auto entry = mapping.child_mapping.find(MultiFileGlobalIndex(struct_filter.child_idx));
 		if (entry == mapping.child_mapping.end()) {
 			// this is constant for this file - abort
 			// FIXME: should be handled before
@@ -1076,7 +1065,7 @@ bool CanPropagateCast(const MultiFileIndexMapping &mapping, const LogicalType &l
 	return StatisticsPropagator::CanPropagateCast(local_type, global_type);
 }
 
-unique_ptr<TableFilterSet> MultiFileColumnMapper::CreateFilters(map<idx_t, reference<TableFilter>> &filters,
+unique_ptr<TableFilterSet> MultiFileColumnMapper::CreateFilters(map<MultiFileGlobalIndex, reference<TableFilter>> &filters,
                                                                 ResultColumnMapping &mapping) {
 	if (filters.empty()) {
 		return nullptr;
@@ -1122,7 +1111,7 @@ unique_ptr<TableFilterSet> MultiFileColumnMapper::CreateFilters(map<idx_t, refer
 
 			// add the expression to the expression map - we are now evaluating this inside the reader directly
 			// we need to set the index of the references inside the expression to 0
-			auto &expr = reader_data.expressions[global_index];
+			auto &expr = reader_data.expressions[global_index.GetIndex()];
 			SetIndexToZero(expr);
 			reader.expression_map[filter_idx] = std::move(expr);
 
@@ -1138,7 +1127,7 @@ ReaderInitializeType MultiFileColumnMapper::CreateMapping(MultiFileColumnMapping
 	auto result = CreateColumnMapping(mapping_mode);
 	//! Evaluate the filters against the column(s) that are constant for this file (not present in the local schema)
 	//! If any of these fail, the file can be skipped entirely
-	map<idx_t, reference<TableFilter>> remaining_filters;
+	map<MultiFileGlobalIndex, reference<TableFilter>> remaining_filters;
 	auto evaluate_result = EvaluateConstantFilters(result, remaining_filters);
 	if (evaluate_result == ReaderInitializeType::SKIP_READING_FILE) {
 		return ReaderInitializeType::SKIP_READING_FILE;

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -905,7 +905,7 @@ MultiFileColumnMapper::EvaluateConstantFilters(ResultColumnMapping &mapping,
 	}
 	auto &global_to_local = mapping.global_to_local;
 	for (auto &it : *global_filters) {
-		MultiFileGlobalIndex global_index(it.ColumnIndex().index);
+		MultiFileGlobalIndex global_index(it.GetIndex());
 		auto &global_filter = it.Filter();
 
 		auto local_it = global_to_local.find(global_index);

--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -551,8 +551,8 @@ static ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDe
 	D_ASSERT(global_column.type.IsNested());
 	switch (global_column.type.id()) {
 	case LogicalTypeId::STRUCT:
-		return MapColumnStruct(context, global_column, global_index, local_column, local_idx, mapper, std::move(mapping),
-		                       is_root);
+		return MapColumnStruct(context, global_column, global_index, local_column, local_idx, mapper,
+		                       std::move(mapping), is_root);
 	case LogicalTypeId::LIST:
 		return MapColumnList(context, global_column, global_index, local_column, local_idx, mapper, std::move(mapping),
 		                     is_root);
@@ -568,8 +568,8 @@ static ColumnMapResult MapColumn(ClientContext &context, const MultiFileColumnDe
 	}
 }
 
-unique_ptr<Expression> ConstructMapExpression(ClientContext &context, MultiFileLocalIndex local_idx, ColumnMapResult &mapping,
-                                              const MultiFileColumnDefinition &global_column,
+unique_ptr<Expression> ConstructMapExpression(ClientContext &context, MultiFileLocalIndex local_idx,
+                                              ColumnMapResult &mapping, const MultiFileColumnDefinition &global_column,
                                               bool is_trivially_mappable) {
 	auto &local_column = *mapping.local_column;
 	unique_ptr<Expression> expr = make_uniq<BoundReferenceExpression>(local_column.type, local_idx.GetIndex());
@@ -1065,8 +1065,9 @@ bool CanPropagateCast(const MultiFileIndexMapping &mapping, const LogicalType &l
 	return StatisticsPropagator::CanPropagateCast(local_type, global_type);
 }
 
-unique_ptr<TableFilterSet> MultiFileColumnMapper::CreateFilters(map<MultiFileGlobalIndex, reference<TableFilter>> &filters,
-                                                                ResultColumnMapping &mapping) {
+unique_ptr<TableFilterSet>
+MultiFileColumnMapper::CreateFilters(map<MultiFileGlobalIndex, reference<TableFilter>> &filters,
+                                     ResultColumnMapping &mapping) {
 	if (filters.empty()) {
 		return nullptr;
 	}

--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -66,7 +66,7 @@ bool PushdownInternal(ClientContext &context, const MultiFileOptions &options, c
 			continue;
 		}
 		auto column_ref =
-		    make_uniq<BoundColumnRefExpression>(types[filter_idx], ColumnBinding(table_index, entry.GetIndex()));
+		    make_uniq<BoundColumnRefExpression>(types[column_idx], ColumnBinding(table_index, entry.GetIndex()));
 		auto filter_expr = entry.Filter().ToExpression(*column_ref);
 		filter_expressions.push_back(std::move(filter_expr));
 	}

--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -60,13 +60,13 @@ bool PushdownInternal(ClientContext &context, const MultiFileOptions &options, c
 	// construct the set of expressions from the table filters
 	vector<unique_ptr<Expression>> filter_expressions;
 	for (auto &entry : filters) {
-		idx_t local_index = entry.ColumnIndex().index;
-		idx_t column_idx = column_ids[local_index];
+		auto filter_idx = entry.GetIndex();
+		idx_t column_idx = column_ids[filter_idx];
 		if (IsVirtualColumn(column_idx)) {
 			continue;
 		}
-		auto column_ref = make_uniq<BoundColumnRefExpression>(
-		    types[column_idx], ColumnBinding(table_index, ProjectionIndex(entry.ColumnIndex())));
+		auto column_ref =
+		    make_uniq<BoundColumnRefExpression>(types[filter_idx], ColumnBinding(table_index, entry.GetIndex()));
 		auto filter_expr = entry.Filter().ToExpression(*column_ref);
 		filter_expressions.push_back(std::move(filter_expr));
 	}

--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -60,7 +60,7 @@ bool PushdownInternal(ClientContext &context, const MultiFileOptions &options, c
 	// construct the set of expressions from the table filters
 	vector<unique_ptr<Expression>> filter_expressions;
 	for (auto &entry : filters) {
-		idx_t local_index = entry.ColumnIndex();
+		idx_t local_index = entry.ColumnIndex().index;
 		idx_t column_idx = column_ids[local_index];
 		if (IsVirtualColumn(column_idx)) {
 			continue;

--- a/src/execution/column_binding_resolver.cpp
+++ b/src/execution/column_binding_resolver.cpp
@@ -196,14 +196,13 @@ unique_ptr<Expression> ColumnBindingResolver::VisitReplace(BoundColumnRefExpress
 				if (bindings.size() != types.size()) {
 					throw InternalException(
 					    "Failed to bind column reference \"%s\" [%d.%d]: inequal num bindings/types (%llu != %llu)",
-					    expr.GetAlias(), expr.binding.table_index.index, expr.binding.column_index.index,
-					    bindings.size(), types.size());
+					    expr.GetAlias(), expr.binding.table_index.index, expr.binding.column_index, bindings.size(),
+					    types.size());
 				}
 				if (expr.return_type != types[i]) {
 					throw InternalException("Failed to bind column reference \"%s\" [%d.%d]: inequal types (%s != %s)",
-					                        expr.GetAlias(), expr.binding.table_index.index,
-					                        expr.binding.column_index.index, expr.return_type.ToString(),
-					                        types[i].ToString());
+					                        expr.GetAlias(), expr.binding.table_index.index, expr.binding.column_index,
+					                        expr.return_type.ToString(), types[i].ToString());
 				}
 			}
 			if (verify_only) {
@@ -217,7 +216,7 @@ unique_ptr<Expression> ColumnBindingResolver::VisitReplace(BoundColumnRefExpress
 	// could not bind the column reference, this should never happen and indicates a bug in the code
 	// generate an error message
 	throw InternalException("Failed to bind column reference \"%s\" [%d.%d] (bindings: %s)", expr.GetAlias(),
-	                        expr.binding.table_index.index, expr.binding.column_index.index,
+	                        expr.binding.table_index.index, expr.binding.column_index,
 	                        LogicalOperator::ColumnBindingsToString(bindings));
 	// LCOV_EXCL_STOP
 }

--- a/src/execution/index/bound_index.cpp
+++ b/src/execution/index/bound_index.cpp
@@ -147,8 +147,8 @@ void BoundIndex::ExecuteExpressions(DataChunk &input, DataChunk &result) {
 unique_ptr<Expression> BoundIndex::BindExpression(unique_ptr<Expression> root_expr) {
 	ExpressionIterator::VisitExpressionMutable<BoundColumnRefExpression>(
 	    root_expr, [&](BoundColumnRefExpression &bound_colref, unique_ptr<Expression> &expr) {
-		    expr = make_uniq<BoundReferenceExpression>(expr->return_type,
-		                                               column_ids[bound_colref.binding.column_index.index]);
+		    expr =
+		        make_uniq<BoundReferenceExpression>(expr->return_type, column_ids[bound_colref.binding.column_index]);
 	    });
 	return root_expr;
 }

--- a/src/execution/operator/join/physical_join.cpp
+++ b/src/execution/operator/join/physical_join.cpp
@@ -107,10 +107,10 @@ vector<idx_t> PhysicalJoin::FillProjectionMap(const PhysicalOperator &child,
 		}
 	} else {
 		for (auto &entry : projection_map) {
-			if (entry.index >= child_count) {
-				throw InternalException("Projection map entry %d out of range", entry.index);
+			if (entry >= child_count) {
+				throw InternalException("Projection map entry %d out of range", entry);
 			}
-			result.emplace_back(entry.index);
+			result.emplace_back(entry);
 		}
 	}
 	return result;

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -308,27 +308,27 @@ void AddProjectionNames(const ColumnIndex &index, const string &name, const Logi
 	}
 }
 
-static string GetFilterInfo(const PhysicalTableScan *scan, const unique_ptr<TableFilterSet> &filter_set) {
+string PhysicalTableScan::GetFilterInfo(const TableFilterSet &filter_set) const {
 	string filters_info;
 	bool first_item = true;
-	for (auto &f : *filter_set) {
-		auto column_index = f.ColumnIndex();
+	for (auto &f : filter_set) {
+		auto filter_idx = f.ColumnIndex();
 		auto &filter = f.Filter();
-		if (column_index < scan->names.size()) {
+		if (filter_idx.index < names.size()) {
 			if (!first_item) {
 				filters_info += "\n";
 			}
 			first_item = false;
 
-			const auto col_id = scan->column_ids[column_index].GetPrimaryIndex();
+			const auto col_id = column_ids[filter_idx.index].GetPrimaryIndex();
 			if (IsVirtualColumn(col_id)) {
-				auto entry = scan->virtual_columns.find(col_id);
-				if (entry == scan->virtual_columns.end()) {
+				auto entry = virtual_columns.find(col_id);
+				if (entry == virtual_columns.end()) {
 					throw InternalException("Virtual column not found");
 				}
 				filters_info += filter.ToString(entry->second.name);
 			} else {
-				filters_info += filter.ToString(scan->names[col_id]);
+				filters_info += filter.ToString(names[col_id]);
 			}
 		}
 	}
@@ -361,11 +361,11 @@ InsertionOrderPreservingMap<string> PhysicalTableScan::ParamsToString() const {
 		result["Projections"] = projections;
 	}
 	if (function.filter_pushdown && table_filters) {
-		result["Filters"] = GetFilterInfo(this, table_filters);
+		result["Filters"] = GetFilterInfo(*table_filters);
 	}
 
 	if (function.filter_pushdown && dynamic_filters && dynamic_filters->HasFilters()) {
-		result["Dynamic Filters"] = GetFilterInfo(this, dynamic_filters->GetFinalTableFilters(*this, nullptr));
+		result["Dynamic Filters"] = GetFilterInfo(*dynamic_filters->GetFinalTableFilters(*this, nullptr));
 	}
 
 	if (extra_info.sample_options) {

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -312,15 +312,15 @@ string PhysicalTableScan::GetFilterInfo(const TableFilterSet &filter_set) const 
 	string filters_info;
 	bool first_item = true;
 	for (auto &f : filter_set) {
-		auto filter_idx = f.ColumnIndex();
+		auto filter_idx = f.GetIndex();
 		auto &filter = f.Filter();
-		if (filter_idx.index < names.size()) {
+		if (filter_idx < names.size()) {
 			if (!first_item) {
 				filters_info += "\n";
 			}
 			first_item = false;
 
-			const auto col_id = column_ids[filter_idx.index].GetPrimaryIndex();
+			const auto col_id = column_ids[filter_idx].GetPrimaryIndex();
 			if (IsVirtualColumn(col_id)) {
 				auto entry = virtual_columns.find(col_id);
 				if (entry == virtual_columns.end()) {

--- a/src/execution/physical_plan/plan_asof_join.cpp
+++ b/src/execution/physical_plan/plan_asof_join.cpp
@@ -189,7 +189,7 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 	// Wrap all the projected non-pk probe fields in `first` aggregates;
 	vector<unique_ptr<Expression>> aggregates;
 	for (const auto &right_proj : join_op.right_projection_map) {
-		const auto col_idx = op.children[1]->types.size() + right_proj.index;
+		const auto col_idx = op.children[1]->types.size() + right_proj;
 		const auto col_type = join_op.types[col_idx];
 		aggr_types.emplace_back(col_type);
 
@@ -207,7 +207,7 @@ PhysicalPlanGenerator::PlanAsOfLoopJoin(LogicalComparisonJoin &op, PhysicalOpera
 	// Wrap all the projected build fields in `arg_max/min` aggregates using the inequality ordering;
 	// We are doing all this first in case we can't find a matching function.
 	for (const auto &left_proj : join_op.left_projection_map) {
-		auto col_idx = left_proj.index;
+		auto col_idx = left_proj;
 		const auto col_type = join_op.types[col_idx];
 		aggr_types.emplace_back(col_type);
 

--- a/src/execution/physical_plan/plan_filter.cpp
+++ b/src/execution/physical_plan/plan_filter.cpp
@@ -23,7 +23,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalFilter &op) {
 		// there is a projection map, generate a physical projection
 		vector<unique_ptr<Expression>> select_list;
 		for (idx_t i = 0; i < op.projection_map.size(); i++) {
-			select_list.push_back(make_uniq<BoundReferenceExpression>(op.types[i], op.projection_map[i].index));
+			select_list.push_back(make_uniq<BoundReferenceExpression>(op.types[i], op.projection_map[i]));
 		}
 		auto &proj = Make<PhysicalProjection>(op.types, std::move(select_list), op.estimated_cardinality);
 		proj.children.push_back(plan);

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -14,22 +14,11 @@
 
 namespace duckdb {
 
-unique_ptr<TableFilterSet> CreateTableFilterSet(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids) {
+unique_ptr<TableFilterSet> MoveTableFilters(TableFilterSet &table_filters) {
 	// create the table filter map
 	auto table_filter_set = make_uniq<TableFilterSet>();
 	for (auto &entry : table_filters) {
-		// find the relative column index from the absolute column index into the table
-		optional_idx column_index;
-		for (idx_t i = 0; i < column_ids.size(); i++) {
-			if (entry.ColumnIndex() == column_ids[i].GetPrimaryIndex()) {
-				column_index = i;
-				break;
-			}
-		}
-		if (!column_index.IsValid()) {
-			throw InternalException("Could not find column index for table filter");
-		}
-		table_filter_set->SetFilterByColumnIndex(column_index.GetIndex(), entry.TakeFilter());
+		table_filter_set->SetFilterByColumnIndex(entry.ColumnIndex(), entry.TakeFilter());
 	}
 	return table_filter_set;
 }
@@ -88,7 +77,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 
 	unique_ptr<TableFilterSet> table_filters;
 	if (op.table_filters.HasFilters()) {
-		table_filters = CreateTableFilterSet(op.table_filters, column_ids);
+		table_filters = MoveTableFilters(op.table_filters);
 	}
 
 	if (op.function.dependency) {
@@ -101,7 +90,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	if (table_filters && op.function.supports_pushdown_type) {
 		vector<unique_ptr<Expression>> select_list;
 		unique_ptr<Expression> unsupported_filter;
-		unordered_set<idx_t> to_remove;
+		unordered_set<ProjectionIndex> to_remove;
 
 		virtual_column_map_t virtual_columns;
 		if (op.function.get_virtual_columns) {
@@ -110,7 +99,8 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		for (auto &entry : *table_filters) {
 			auto filter_idx = entry.ColumnIndex();
 			auto &filter_expr = entry.Filter();
-			auto column_id = column_ids[filter_idx].GetPrimaryIndex();
+			auto &column_idx = op.GetColumnIndex(filter_idx);
+			auto column_id = column_idx.GetPrimaryIndex();
 			if (!op.function.supports_pushdown_type(*op.bind_data, column_id)) {
 				LogicalType column_type;
 				if (IsVirtualColumn(column_id)) {
@@ -119,20 +109,18 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 				} else {
 					column_type = op.returned_types[column_id];
 				}
-				idx_t column_id_filter = filter_idx;
-				bool found_projection = false;
+				optional_idx column_id_filter;
 				for (idx_t i = 0; i < projection_ids.size(); i++) {
-					if (column_ids[projection_ids[i].index] == column_ids[filter_idx]) {
+					if (column_ids[projection_ids[i].index] == column_idx) {
 						column_id_filter = i;
-						found_projection = true;
 						break;
 					}
 				}
-				if (!found_projection) {
+				if (!column_id_filter.IsValid()) {
 					projection_ids.push_back(ProjectionIndex(filter_idx));
 					column_id_filter = projection_ids.size() - 1;
 				}
-				auto column = make_uniq<BoundReferenceExpression>(column_type, column_id_filter);
+				auto column = make_uniq<BoundReferenceExpression>(column_type, column_id_filter.GetIndex());
 				select_list.push_back(filter_expr.ToExpression(*column));
 				to_remove.insert(filter_idx);
 			}

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -18,7 +18,7 @@ unique_ptr<TableFilterSet> MoveTableFilters(TableFilterSet &table_filters) {
 	// create the table filter map
 	auto table_filter_set = make_uniq<TableFilterSet>();
 	for (auto &entry : table_filters) {
-		table_filter_set->SetFilterByColumnIndex(entry.ColumnIndex(), entry.TakeFilter());
+		table_filter_set->SetFilterByColumnIndex(entry.GetIndex(), entry.TakeFilter());
 	}
 	return table_filter_set;
 }
@@ -97,7 +97,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 			virtual_columns = op.function.get_virtual_columns(context, op.bind_data.get());
 		}
 		for (auto &entry : *table_filters) {
-			auto filter_idx = entry.ColumnIndex();
+			auto filter_idx = entry.GetIndex();
 			auto &filter_expr = entry.Filter();
 			auto &column_idx = op.GetColumnIndex(filter_idx);
 			auto column_id = column_idx.GetPrimaryIndex();
@@ -111,13 +111,13 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 				}
 				optional_idx column_id_filter;
 				for (idx_t i = 0; i < projection_ids.size(); i++) {
-					if (column_ids[projection_ids[i].index] == column_idx) {
+					if (column_ids[projection_ids[i]] == column_idx) {
 						column_id_filter = i;
 						break;
 					}
 				}
 				if (!column_id_filter.IsValid()) {
-					projection_ids.push_back(ProjectionIndex(filter_idx));
+					projection_ids.push_back(filter_idx);
 					column_id_filter = projection_ids.size() - 1;
 				}
 				auto column = make_uniq<BoundReferenceExpression>(column_type, column_id_filter.GetIndex());
@@ -132,7 +132,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		if (!select_list.empty()) {
 			vector<LogicalType> filter_types;
 			for (auto &c : projection_ids) {
-				auto column_id = column_ids[c.index].GetPrimaryIndex();
+				auto column_id = column_ids[c].GetPrimaryIndex();
 				if (IsVirtualColumn(column_id)) {
 					auto &column = virtual_columns.at(column_id);
 					filter_types.push_back(column.type);
@@ -194,7 +194,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	}
 	vector<idx_t> projection_indices;
 	for (auto &proj_id : op.projection_ids) {
-		projection_indices.push_back(proj_id.index);
+		projection_indices.push_back(proj_id);
 	}
 
 	auto &table_scan = Make<PhysicalTableScan>(

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -19,7 +19,7 @@ RadixPartitionedHashTable::RadixPartitionedHashTable(GroupingSet &grouping_set_p
 	auto groups_count = op.GroupCount();
 	for (auto group_idx : ProjectionIndex::GetIndexes(groups_count)) {
 		if (grouping_set.find(group_idx) == grouping_set.end()) {
-			null_groups.push_back(group_idx.index);
+			null_groups.push_back(group_idx);
 		}
 	}
 	if (grouping_set.empty()) {
@@ -27,7 +27,7 @@ RadixPartitionedHashTable::RadixPartitionedHashTable(GroupingSet &grouping_set_p
 		group_types.emplace_back(LogicalType::TINYINT);
 	}
 	for (auto &entry : grouping_set) {
-		group_types.push_back(op.group_types[entry.index]);
+		group_types.push_back(op.group_types[entry]);
 	}
 	SetGroupingValues();
 
@@ -410,7 +410,7 @@ void RadixPartitionedHashTable::PopulateGroupChunk(DataChunk &group_chunk, DataC
 	// Populate the group_chunk
 	for (auto &group_idx : grouping_set) {
 		// Retrieve the expression containing the index in the input chunk
-		auto &group = op.groups[group_idx.index];
+		auto &group = op.groups[group_idx];
 		D_ASSERT(group->GetExpressionType() == ExpressionType::BOUND_REF);
 		auto &bound_ref_expr = group->Cast<BoundReferenceExpression>();
 		// Reference from input_chunk[group.index] -> group_chunk[chunk_index]
@@ -921,7 +921,7 @@ void RadixHTLocalSourceState::Scan(RadixHTGlobalSinkState &sink, RadixHTGlobalSo
 	auto &radix_ht = sink.radix_ht;
 	idx_t chunk_index = 0;
 	for (auto &entry : radix_ht.grouping_set) {
-		chunk.data[entry.index].Reference(scan_chunk.data[chunk_index++]);
+		chunk.data[entry].Reference(scan_chunk.data[chunk_index++]);
 	}
 	for (auto null_group : radix_ht.null_groups) {
 		chunk.data[null_group].SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -569,13 +569,13 @@ bool TryScanIndex(ART &art, IndexEntry &entry, const ColumnList &column_list, Ta
 	}
 
 	// Resolve bound column references in the index_expr against the current input projection
-	column_t updated_index_column;
+	ProjectionIndex updated_index_column;
 	bool found_index_column_in_input = false;
 
 	// Find the indexed column amongst the input columns
 	for (idx_t i = 0; i < input.column_ids.size(); ++i) {
 		if (input.column_ids[i] == indexed_columns[0]) {
-			updated_index_column = i;
+			updated_index_column = ProjectionIndex(i);
 			found_index_column_in_input = true;
 			break;
 		}
@@ -591,8 +591,8 @@ bool TryScanIndex(ART &art, IndexEntry &entry, const ColumnList &column_list, Ta
 			auto &bound_column_ref_expr = expr.Cast<BoundColumnRefExpression>();
 
 			// If the bound column references the index column, use updated_index_column
-			if (bound_column_ref_expr.binding.column_index.index == indexed_columns[0]) {
-				bound_column_ref_expr.binding.column_index.index = updated_index_column;
+			if (bound_column_ref_expr.binding.column_index == indexed_columns[0]) {
+				bound_column_ref_expr.binding.column_index = updated_index_column;
 			}
 		});
 	}

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -602,10 +602,10 @@ bool TryScanIndex(ART &art, IndexEntry &entry, const ColumnList &column_list, Ta
 
 	// The indexes of the filters match input.column_indexes, which are: i -> column_index.
 	// Try to find a filter on the ART column.
-	optional_idx storage_index;
+	ProjectionIndex storage_index;
 	for (idx_t i = 0; i < input.column_indexes.size(); i++) {
 		if (input.column_indexes[i].ToLogical() == col.Logical()) {
-			storage_index = i;
+			storage_index = ProjectionIndex(i);
 			break;
 		}
 	}
@@ -616,7 +616,7 @@ bool TryScanIndex(ART &art, IndexEntry &entry, const ColumnList &column_list, Ta
 	}
 
 	// Try to find a matching filter for the column.
-	auto filter = filter_set.TryGetFilterByColumnIndex(storage_index.GetIndex());
+	auto filter = filter_set.TryGetFilterByColumnIndex(storage_index);
 	if (!filter) {
 		return false;
 	}

--- a/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
@@ -30,10 +30,10 @@ private:
 	ResultColumnMapping CreateColumnMapping(MultiFileColumnMappingMode mapping_mode);
 	ResultColumnMapping CreateColumnMappingByMapper(const ColumnMapper &mapper);
 
-	unique_ptr<TableFilterSet> CreateFilters(map<idx_t, reference<TableFilter>> &filters, ResultColumnMapping &mapping);
+	unique_ptr<TableFilterSet> CreateFilters(map<MultiFileGlobalIndex, reference<TableFilter>> &filters, ResultColumnMapping &mapping);
 	ReaderInitializeType EvaluateConstantFilters(ResultColumnMapping &mapping,
-	                                             map<idx_t, reference<TableFilter>> &remaining_filters);
-	Value GetConstantValue(idx_t global_index);
+	                                             map<MultiFileGlobalIndex, reference<TableFilter>> &remaining_filters);
+	Value GetConstantValue(MultiFileGlobalIndex global_index);
 	bool EvaluateFilterAgainstConstant(TableFilter &filter, const Value &constant);
 
 private:

--- a/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_column_mapper.hpp
@@ -30,7 +30,8 @@ private:
 	ResultColumnMapping CreateColumnMapping(MultiFileColumnMappingMode mapping_mode);
 	ResultColumnMapping CreateColumnMappingByMapper(const ColumnMapper &mapper);
 
-	unique_ptr<TableFilterSet> CreateFilters(map<MultiFileGlobalIndex, reference<TableFilter>> &filters, ResultColumnMapping &mapping);
+	unique_ptr<TableFilterSet> CreateFilters(map<MultiFileGlobalIndex, reference<TableFilter>> &filters,
+	                                         ResultColumnMapping &mapping);
 	ReaderInitializeType EvaluateConstantFilters(ResultColumnMapping &mapping,
 	                                             map<MultiFileGlobalIndex, reference<TableFilter>> &remaining_filters);
 	Value GetConstantValue(MultiFileGlobalIndex global_index);

--- a/src/include/duckdb/common/multi_file/multi_file_data.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_data.hpp
@@ -228,9 +228,6 @@ public:
 	operator idx_t() { // NOLINT: allow implicit conversion
 		return index;
 	}
-	operator size_t() { // NOLINT: allow implicit conversion
-		return static_cast<size_t>(index);
-	}
 	idx_t GetIndex() const {
 		return index;
 	}

--- a/src/include/duckdb/common/multi_file/multi_file_data.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_data.hpp
@@ -173,7 +173,7 @@ struct MultiFileLocalIndex {
 public:
 	explicit MultiFileLocalIndex(idx_t index = DConstants::INVALID_INDEX) : index(index) {
 	}
-	explicit MultiFileLocalIndex(ProjectionIndex projection) : index(projection.index) {
+	explicit MultiFileLocalIndex(ProjectionIndex projection) : index(projection) {
 	}
 
 public:

--- a/src/include/duckdb/common/multi_file/multi_file_data.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_data.hpp
@@ -131,6 +131,8 @@ public:
 struct MultiFileCastMap;
 struct MultiFileFilterEntry;
 
+//! MultiFileLocalColumnId refers to an absolute column index within a specific file we are reading
+// i.e. if the file has columns "a, b, c", a will have MultiFileLocalColumnId(0), b = 1, c = 2
 struct MultiFileLocalColumnId {
 	friend struct MultiFileCastMap;
 
@@ -158,6 +160,9 @@ struct MultiFileColumnMapping;
 struct MultiFileFilterMap;
 struct MultiFileConstantMap;
 
+//! MultiFileLocalIndex refers to a ProjectionIndex locally within a specific file that we are reading
+//! This refers to an entry in the "column_ids" list - i.e. to get the absolute column (MultiFileLocalColumnId)
+// we can use column_ids[#MultiFileLocalColumnId]
 struct MultiFileLocalIndex {
 	//! these are allowed to access the index
 	template <class T>
@@ -166,15 +171,45 @@ struct MultiFileLocalIndex {
 	friend struct MultiFileFilterEntry;
 
 public:
-	explicit MultiFileLocalIndex(idx_t index) : index(index) {
+	explicit MultiFileLocalIndex(idx_t index = DConstants::INVALID_INDEX) : index(index) {
+	}
+	explicit MultiFileLocalIndex(ProjectionIndex projection) : index(projection.index) {
 	}
 
 public:
 	operator idx_t() const { // NOLINT: allow implicit conversion
-		return index;
+		return GetIndex();
 	}
 	idx_t GetIndex() const {
+		if (!IsValid()) {
+			throw InternalException("MultiFileLocalIndex::GetIndex called on invalid index");
+		}
 		return index;
+	}
+	bool IsValid() const {
+		return index != DConstants::INVALID_INDEX;
+	}
+	operator ProjectionIndex() const { // NOLINT: allow implicit conversion to projection index
+		return ProjectionIndex(index);
+	}
+
+	inline bool operator==(const MultiFileLocalIndex &rhs) const {
+		return index == rhs.index;
+	};
+	inline bool operator<(const MultiFileLocalIndex &rhs) const {
+		return index < rhs.index;
+	};
+	bool operator!=(const MultiFileLocalIndex &other) const {
+		return !(*this == other);
+	}
+	bool operator>(const MultiFileLocalIndex &other) const {
+		return other < *this;
+	}
+	bool operator<=(const MultiFileLocalIndex &other) const {
+		return !(other < *this);
+	}
+	bool operator>=(const MultiFileLocalIndex &other) const {
+		return !(*this < other);
 	}
 
 private:
@@ -193,8 +228,33 @@ public:
 	operator idx_t() { // NOLINT: allow implicit conversion
 		return index;
 	}
+	operator size_t() { // NOLINT: allow implicit conversion
+		return static_cast<size_t>(index);
+	}
 	idx_t GetIndex() const {
 		return index;
+	}
+	operator ProjectionIndex() const { // NOLINT: allow implicit conversion to projection index
+		return ProjectionIndex(index);
+	}
+
+	inline bool operator==(const MultiFileGlobalIndex &rhs) const {
+		return index == rhs.index;
+	};
+	inline bool operator<(const MultiFileGlobalIndex &rhs) const {
+		return index < rhs.index;
+	};
+	bool operator!=(const MultiFileGlobalIndex &other) const {
+		return !(*this == other);
+	}
+	bool operator>(const MultiFileGlobalIndex &other) const {
+		return other < *this;
+	}
+	bool operator<=(const MultiFileGlobalIndex &other) const {
+		return !(other < *this);
+	}
+	bool operator>=(const MultiFileGlobalIndex &other) const {
+		return !(*this < other);
 	}
 
 private:
@@ -343,3 +403,13 @@ private:
 };
 
 } // namespace duckdb
+
+namespace std {
+
+template <>
+struct hash<duckdb::MultiFileGlobalIndex> {
+	size_t operator()(const duckdb::MultiFileGlobalIndex &global_idx) const {
+		return std::hash<uint64_t> {}(global_idx.GetIndex());
+	}
+};
+} // namespace std

--- a/src/include/duckdb/common/projection_index.hpp
+++ b/src/include/duckdb/common/projection_index.hpp
@@ -22,6 +22,15 @@ struct ProjectionIndex {
 
 	idx_t index;
 
+	// operator idx_t() const { // NOLINT: allow implicit conversion
+	// 	return GetIndex();
+	// }
+	idx_t GetIndex() const {
+		if (!IsValid()) {
+			throw InternalException("ProjectionIndex::GetIndex called on invalid index");
+		}
+		return index;
+	}
 	inline bool operator==(const ProjectionIndex &rhs) const {
 		return index == rhs.index;
 	};

--- a/src/include/duckdb/common/projection_index.hpp
+++ b/src/include/duckdb/common/projection_index.hpp
@@ -20,11 +20,9 @@ struct ProjectionIndex {
 	explicit ProjectionIndex(idx_t index) : index(index) {
 	}
 
-	idx_t index;
-
-	// operator idx_t() const { // NOLINT: allow implicit conversion
-	// 	return GetIndex();
-	// }
+	operator idx_t() const { // NOLINT: allow implicit conversion
+		return GetIndex();
+	}
 	idx_t GetIndex() const {
 		if (!IsValid()) {
 			throw InternalException("ProjectionIndex::GetIndex called on invalid index");
@@ -94,6 +92,13 @@ struct ProjectionIndex {
 	static IndexRange GetIndexes(idx_t count) {
 		return IndexRange(count);
 	}
+
+	idx_t GetIndexUnsafe() const {
+		return index;
+	}
+
+private:
+	idx_t index;
 };
 
 } // namespace duckdb
@@ -103,7 +108,7 @@ namespace std {
 template <>
 struct hash<duckdb::ProjectionIndex> {
 	size_t operator()(const duckdb::ProjectionIndex &tbl_index) const {
-		return std::hash<uint64_t> {}(tbl_index.index);
+		return std::hash<uint64_t> {}(tbl_index.GetIndexUnsafe());
 	}
 };
 } // namespace std

--- a/src/include/duckdb/common/serializer/serialization_traits.hpp
+++ b/src/include/duckdb/common/serializer/serialization_traits.hpp
@@ -358,7 +358,7 @@ struct SerializationDefaultValue {
 	template <typename T = void>
 	static inline bool
 	IsDefault(const typename std::enable_if<std::is_same<T, ProjectionIndex>::value, T>::type &value) {
-		return value.index == 0;
+		return value.GetIndexUnsafe() == 0;
 	}
 };
 

--- a/src/include/duckdb/common/serializer/serializer.hpp
+++ b/src/include/duckdb/common/serializer/serializer.hpp
@@ -375,7 +375,7 @@ protected:
 		WriteValue(value.index);
 	}
 	void WriteValue(ProjectionIndex value) {
-		WriteValue(value.index);
+		WriteValue(value.GetIndexUnsafe());
 	}
 	void WriteValue(optional_idx value) {
 		WriteValue(value.IsValid() ? value.GetIndex() : DConstants::INVALID_INDEX);

--- a/src/include/duckdb/common/types/hash.hpp
+++ b/src/include/duckdb/common/types/hash.hpp
@@ -67,7 +67,7 @@ DUCKDB_API inline hash_t Hash(TableIndex val) {
 }
 template <>
 DUCKDB_API inline hash_t Hash(ProjectionIndex val) {
-	return MurmurHash64(val.index);
+	return MurmurHash64(val.GetIndexUnsafe());
 }
 template <>
 DUCKDB_API hash_t Hash(hugeint_t val);

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -89,6 +89,9 @@ public:
 	InsertionOrderPreservingMap<string> ExtraSourceParams(GlobalSourceState &gstate,
 	                                                      LocalSourceState &lstate) const override;
 	optional_idx GetRowsScanned(GlobalSourceState &gstate_p, LocalSourceState &lstate) const;
+
+private:
+	string GetFilterInfo(const TableFilterSet &filter_set) const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/function/aggregate/minmax_n_helpers.hpp
@@ -167,6 +167,12 @@ private:
 	idx_t size;
 };
 
+struct List {
+	uint32_t capacity;
+	uint32_t size;
+	List *next;
+};
+
 template <class K, class V, class K_COMPARATOR>
 class BinaryAggregateHeap {
 	using STORAGE_TYPE = pair<HeapEntry<K>, HeapEntry<V>>;

--- a/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
+++ b/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
@@ -57,7 +57,7 @@ public:
 	static constexpr double DEFAULT_SELECTIVITY = 0.2;
 
 public:
-	static idx_t InspectTableFilter(idx_t cardinality, idx_t column_index, const TableFilter &filter,
+	static idx_t InspectTableFilter(idx_t cardinality, const TableFilter &filter,
 	                                BaseStatistics &base_stats);
 	//	static idx_t InspectConjunctionOR(idx_t cardinality, idx_t column_index, ConjunctionOrFilter &filter,
 	//	                                  BaseStatistics &base_stats);

--- a/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
+++ b/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
@@ -57,8 +57,7 @@ public:
 	static constexpr double DEFAULT_SELECTIVITY = 0.2;
 
 public:
-	static idx_t InspectTableFilter(idx_t cardinality, const TableFilter &filter,
-	                                BaseStatistics &base_stats);
+	static idx_t InspectTableFilter(idx_t cardinality, const TableFilter &filter, BaseStatistics &base_stats);
 	//	static idx_t InspectConjunctionOR(idx_t cardinality, idx_t column_index, ConjunctionOrFilter &filter,
 	//	                                  BaseStatistics &base_stats);
 	//! Extract Statistics from a LogicalGet.

--- a/src/include/duckdb/planner/operator/logical_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_get.hpp
@@ -76,8 +76,9 @@ public:
 
 public:
 	void SetColumnIds(vector<ColumnIndex> &&column_ids);
-	void AddColumnId(column_t column_id);
+	ProjectionIndex AddColumnId(column_t column_id);
 	void ClearColumnIds();
+	ProjectionIndex TryGetProjectionIndex(idx_t col_idx) const;
 	const vector<ColumnIndex> &GetColumnIds() const;
 	vector<ColumnIndex> &GetMutableColumnIds();
 	vector<ColumnBinding> GetColumnBindings() override;

--- a/src/include/duckdb/planner/table_filter_set.hpp
+++ b/src/include/duckdb/planner/table_filter_set.hpp
@@ -20,16 +20,16 @@ namespace duckdb {
 //! Conditions like `A = 2 OR B = 4` are not pushed into a TableFilterSet.
 class TableFilterSet {
 public:
-	void PushFilter(const ColumnIndex &col_idx, unique_ptr<TableFilter> filter);
+	void PushFilter(ProjectionIndex col_idx, unique_ptr<TableFilter> filter);
 	bool HasFilters() const;
 	idx_t FilterCount() const;
-	bool HasFilter(idx_t col_idx) const;
-	TableFilter &GetFilterByColumnIndexMutable(idx_t col_idx);
-	optional_ptr<TableFilter> TryGetFilterByColumnIndexMutable(idx_t col_idx);
-	const TableFilter &GetFilterByColumnIndex(idx_t col_idx) const;
-	optional_ptr<const TableFilter> TryGetFilterByColumnIndex(idx_t col_idx) const;
-	void SetFilterByColumnIndex(idx_t col_idx, unique_ptr<TableFilter> filter);
-	void RemoveFilterByColumnIndex(idx_t col_idx);
+	bool HasFilter(ProjectionIndex col_idx) const;
+	TableFilter &GetFilterByColumnIndexMutable(ProjectionIndex col_idx);
+	optional_ptr<TableFilter> TryGetFilterByColumnIndexMutable(ProjectionIndex col_idx);
+	const TableFilter &GetFilterByColumnIndex(ProjectionIndex col_idx) const;
+	optional_ptr<const TableFilter> TryGetFilterByColumnIndex(ProjectionIndex col_idx) const;
+	void SetFilterByColumnIndex(ProjectionIndex col_idx, unique_ptr<TableFilter> filter);
+	void RemoveFilterByColumnIndex(ProjectionIndex col_idx);
 	void ClearFilters();
 
 	bool Equals(TableFilterSet &other);
@@ -43,26 +43,26 @@ public:
 public:
 	class TableFilterIteratorEntry {
 	public:
-		explicit TableFilterIteratorEntry(map<idx_t, unique_ptr<TableFilter>>::iterator);
+		explicit TableFilterIteratorEntry(map<ProjectionIndex, unique_ptr<TableFilter>>::iterator);
 
-		idx_t ColumnIndex() const;
+		ProjectionIndex ColumnIndex() const;
 		TableFilter &Filter();
 		const TableFilter &Filter() const;
 		unique_ptr<TableFilter> TakeFilter();
 
 	public:
-		map<idx_t, unique_ptr<TableFilter>>::iterator iterator;
+		map<ProjectionIndex, unique_ptr<TableFilter>>::iterator iterator;
 	};
 
 	class ConstTableFilterIteratorEntry {
 	public:
-		explicit ConstTableFilterIteratorEntry(map<idx_t, unique_ptr<TableFilter>>::const_iterator);
+		explicit ConstTableFilterIteratorEntry(map<ProjectionIndex, unique_ptr<TableFilter>>::const_iterator);
 
-		idx_t ColumnIndex() const;
+		ProjectionIndex ColumnIndex() const;
 		const TableFilter &Filter() const;
 
 	public:
-		map<idx_t, unique_ptr<TableFilter>>::const_iterator iterator;
+		map<ProjectionIndex, unique_ptr<TableFilter>>::const_iterator iterator;
 	};
 
 	// iterator
@@ -105,7 +105,7 @@ public:
 	}
 
 private:
-	map<idx_t, unique_ptr<TableFilter>> filters;
+	map<ProjectionIndex, unique_ptr<TableFilter>> filters;
 };
 
 class DynamicTableFilterSet {

--- a/src/include/duckdb/planner/table_filter_set.hpp
+++ b/src/include/duckdb/planner/table_filter_set.hpp
@@ -45,7 +45,7 @@ public:
 	public:
 		explicit TableFilterIteratorEntry(map<ProjectionIndex, unique_ptr<TableFilter>>::iterator);
 
-		ProjectionIndex ColumnIndex() const;
+		ProjectionIndex GetIndex() const;
 		TableFilter &Filter();
 		const TableFilter &Filter() const;
 		unique_ptr<TableFilter> TakeFilter();
@@ -58,7 +58,7 @@ public:
 	public:
 		explicit ConstTableFilterIteratorEntry(map<ProjectionIndex, unique_ptr<TableFilter>>::const_iterator);
 
-		ProjectionIndex ColumnIndex() const;
+		ProjectionIndex GetIndex() const;
 		const TableFilter &Filter() const;
 
 	public:

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -507,7 +507,7 @@
       {
         "id": 100,
         "name": "filters",
-        "type": "map<idx_t, TableFilter*>"
+        "type": "map<ProjectionIndex, TableFilter*>"
       }
     ],
     "pointer_type": "none"

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -169,7 +169,8 @@ struct ColumnFetchState {
 };
 
 struct ScanFilter {
-	ScanFilter(ClientContext &context, ProjectionIndex index, const vector<StorageIndex> &column_ids, TableFilter &filter);
+	ScanFilter(ClientContext &context, ProjectionIndex index, const vector<StorageIndex> &column_ids,
+	           TableFilter &filter);
 
 	ProjectionIndex scan_column_index;
 	StorageIndex table_column_index;

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -169,9 +169,9 @@ struct ColumnFetchState {
 };
 
 struct ScanFilter {
-	ScanFilter(ClientContext &context, idx_t index, const vector<StorageIndex> &column_ids, TableFilter &filter);
+	ScanFilter(ClientContext &context, ProjectionIndex index, const vector<StorageIndex> &column_ids, TableFilter &filter);
 
-	idx_t scan_column_index;
+	ProjectionIndex scan_column_index;
 	StorageIndex table_column_index;
 	TableFilter &filter;
 	bool always_true;

--- a/src/optimizer/column_lifetime_analyzer.cpp
+++ b/src/optimizer/column_lifetime_analyzer.cpp
@@ -241,7 +241,7 @@ void ColumnLifetimeAnalyzer::AddVerificationProjection(unique_ptr<LogicalOperato
 	for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
 		const auto &old_binding = child_bindings[col_idx];
 		ProjectionIndex new_col_idx(projection_column_count - 2 - col_idx * 2);
-		expressions[new_col_idx.index] = make_uniq<BoundColumnRefExpression>(child_types[col_idx], old_binding);
+		expressions[new_col_idx] = make_uniq<BoundColumnRefExpression>(child_types[col_idx], old_binding);
 		replacer.replacement_bindings.emplace_back(old_binding, ColumnBinding(table_index, new_col_idx));
 	}
 

--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -273,7 +273,7 @@ private:
 					}
 				} else {
 					for (const auto &proj_id : projection_ids) {
-						ProjectionIndex primary_index(column_ids[proj_id.index].GetPrimaryIndex());
+						ProjectionIndex primary_index(column_ids[proj_id].GetPrimaryIndex());
 						column_index_map.Insert(proj_id, primary_index);
 					}
 				}

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -356,7 +356,7 @@ FilterPushdownResult FilterCombiner::TryPushdownConstantFilter(TableFilterSet &t
 	if (!TryGetProjectionIndex(expr, proj_index)) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
-	auto &column_index = column_ids[proj_index.index];
+	auto &column_index = column_ids[proj_index];
 	if (column_index.IsPushdownExtract()) {
 		//! FIXME: can't push down filters on a column that has a pushed down extract currently
 		return FilterPushdownResult::NO_PUSHDOWN;
@@ -436,7 +436,7 @@ FilterPushdownResult FilterCombiner::TryPushdownPrefixFilter(TableFilterSet &tab
 		// empty prefix - skip
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
-	auto &column_index = column_ids[column_ref.binding.column_index.index];
+	auto &column_index = column_ids[column_ref.binding.column_index];
 	if (column_index.IsPushdownExtract()) {
 		//! FIXME: can't support filter pushdown on pushed down extract currently
 		return FilterPushdownResult::NO_PUSHDOWN;
@@ -473,7 +473,7 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 	auto &column_ref = func.children[0]->Cast<BoundColumnRefExpression>();
 	auto &constant_value_expr = func.children[1]->Cast<BoundConstantExpression>();
 	auto proj_index = column_ref.binding.column_index;
-	auto &column_index = column_ids[proj_index.index];
+	auto &column_index = column_ids[proj_index];
 	if (column_index.IsPushdownExtract()) {
 		//! FIXME: can't support filter pushdown on pushed down extract currently
 		return FilterPushdownResult::NO_PUSHDOWN;
@@ -530,7 +530,7 @@ FilterPushdownResult FilterCombiner::TryPushdownInFilter(TableFilterSet &table_f
 	}
 	auto &column_ref = func.children[0]->Cast<BoundColumnRefExpression>();
 	auto proj_index = column_ref.binding.column_index;
-	auto &column_index = column_ids[proj_index.index];
+	auto &column_index = column_ids[proj_index];
 	if (column_index.IsPushdownExtract()) {
 		//! FIXME: can't support filter pushdown on pushed down extract currently
 		return FilterPushdownResult::NO_PUSHDOWN;
@@ -629,7 +629,7 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 		}
 		if (!proj_id.IsValid()) {
 			proj_id = column_ref->binding.column_index;
-			auto &col_id = column_ids[proj_id.index];
+			auto &col_id = column_ids[proj_id];
 			if (col_id.IsPushdownExtract()) {
 				//! FIXME: can't support filter pushdown on pushed down extract currently
 				return FilterPushdownResult::NO_PUSHDOWN;

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -192,18 +192,18 @@ bool FilterCombiner::HasFilters() {
 
 // Try to extract a column index from a bound column ref expression, or a column ref recursively nested
 // inside of a struct_extract call. If the expression is not a column ref (or nested column ref), return false.
-static bool TryGetBoundColumnIndex(const vector<ColumnIndex> &column_ids, const Expression &expr, ColumnIndex &result) {
+static bool TryGetProjectionIndex(const Expression &expr, ProjectionIndex &result) {
 	switch (expr.GetExpressionType()) {
 	case ExpressionType::BOUND_COLUMN_REF: {
 		auto &ref = expr.Cast<BoundColumnRefExpression>();
-		result = column_ids[ref.binding.column_index.index];
+		result = ref.binding.column_index;
 		return true;
 	}
 	case ExpressionType::BOUND_FUNCTION: {
 		auto &func = expr.Cast<BoundFunctionExpression>();
 		if (func.function.name == "struct_extract" || func.function.name == "struct_extract_at") {
 			auto &child_expr = func.children[0];
-			return TryGetBoundColumnIndex(column_ids, *child_expr, result);
+			return TryGetProjectionIndex(*child_expr, result);
 		}
 		return false;
 	}
@@ -352,10 +352,11 @@ FilterPushdownResult FilterCombiner::TryPushdownConstantFilter(TableFilterSet &t
 
 	// Try to get the column index, either from bound column ref, or a column ref nested inside of a
 	// struct_extract call
-	ColumnIndex column_index;
-	if (!TryGetBoundColumnIndex(column_ids, expr, column_index)) {
+	ProjectionIndex proj_index;
+	if (!TryGetProjectionIndex(expr, proj_index)) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
+	auto &column_index = column_ids[proj_index.index];
 	if (column_index.IsPushdownExtract()) {
 		//! FIXME: can't push down filters on a column that has a pushed down extract currently
 		return FilterPushdownResult::NO_PUSHDOWN;
@@ -365,7 +366,7 @@ FilterPushdownResult FilterCombiner::TryPushdownConstantFilter(TableFilterSet &t
 	auto &constant_list = constant_values.find(equiv_set)->second;
 	for (auto &constant_cmp : constant_list) {
 		auto constant_filter = make_uniq<ConstantFilter>(constant_cmp.comparison_type, constant_cmp.constant);
-		table_filters.PushFilter(column_index, PushDownFilterIntoExpr(expr, std::move(constant_filter)));
+		table_filters.PushFilter(proj_index, PushDownFilterIntoExpr(expr, std::move(constant_filter)));
 	}
 	equivalence_map.erase(filter_exp);
 	return FilterPushdownResult::PUSHED_DOWN_FULLY;
@@ -410,7 +411,7 @@ FilterPushdownResult FilterCombiner::TryPushdownGenericExpression(LogicalGet &ge
 		//! FIXME: can't support filters on a pushed down extract currently
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
-	get.table_filters.PushFilter(column_index, std::move(expr_filter));
+	get.table_filters.PushFilter(bindings[0].column_index, std::move(expr_filter));
 	return FilterPushdownResult::PUSHED_DOWN_FULLY;
 }
 
@@ -440,12 +441,13 @@ FilterPushdownResult FilterCombiner::TryPushdownPrefixFilter(TableFilterSet &tab
 		//! FIXME: can't support filter pushdown on pushed down extract currently
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
+	auto filter_idx = column_ref.binding.column_index;
 	//! Replace prefix with a set of comparisons
 	auto lower_bound = make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value(prefix_string));
-	table_filters.PushFilter(column_index, std::move(lower_bound));
+	table_filters.PushFilter(filter_idx, std::move(lower_bound));
 	if (FilterCombiner::FindNextLegalUTF8(prefix_string)) {
 		auto upper_bound = make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHAN, Value(prefix_string));
-		table_filters.PushFilter(column_index, std::move(upper_bound));
+		table_filters.PushFilter(filter_idx, std::move(upper_bound));
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
 	// could not find next legal utf8 string - skip upper bound
@@ -470,7 +472,8 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 	//! This is a like function.
 	auto &column_ref = func.children[0]->Cast<BoundColumnRefExpression>();
 	auto &constant_value_expr = func.children[1]->Cast<BoundConstantExpression>();
-	auto &column_index = column_ids[column_ref.binding.column_index.index];
+	auto proj_index = column_ref.binding.column_index;
+	auto &column_index = column_ids[proj_index.index];
 	if (column_index.IsPushdownExtract()) {
 		//! FIXME: can't support filter pushdown on pushed down extract currently
 		return FilterPushdownResult::NO_PUSHDOWN;
@@ -480,7 +483,7 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 	// make the filter unsatisfiable and return no results.
 	if (constant_value_expr.value.IsNull()) {
 		auto is_not_null = make_uniq<IsNotNullFilter>();
-		table_filters.PushFilter(column_index, std::move(is_not_null));
+		table_filters.PushFilter(proj_index, std::move(is_not_null));
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
 	auto &like_string = StringValue::Get(constant_value_expr.value);
@@ -500,7 +503,7 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 	if (equality) {
 		//! If the LIKE has no special characters we can turn it into an equality and push that down
 		auto equal_filter = make_uniq<ConstantFilter>(ExpressionType::COMPARE_EQUAL, Value(prefix));
-		table_filters.PushFilter(column_index, std::move(equal_filter));
+		table_filters.PushFilter(proj_index, std::move(equal_filter));
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
 
@@ -509,8 +512,8 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 	auto lower_bound = make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value(prefix));
 	prefix[prefix.size() - 1]++;
 	auto upper_bound = make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHAN, Value(prefix));
-	table_filters.PushFilter(column_index, std::move(lower_bound));
-	table_filters.PushFilter(column_index, std::move(upper_bound));
+	table_filters.PushFilter(proj_index, std::move(lower_bound));
+	table_filters.PushFilter(proj_index, std::move(upper_bound));
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 }
 
@@ -526,7 +529,8 @@ FilterPushdownResult FilterCombiner::TryPushdownInFilter(TableFilterSet &table_f
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	auto &column_ref = func.children[0]->Cast<BoundColumnRefExpression>();
-	auto &column_index = column_ids[column_ref.binding.column_index.index];
+	auto proj_index = column_ref.binding.column_index;
+	auto &column_index = column_ids[proj_index.index];
 	if (column_index.IsPushdownExtract()) {
 		//! FIXME: can't support filter pushdown on pushed down extract currently
 		return FilterPushdownResult::NO_PUSHDOWN;
@@ -556,7 +560,7 @@ FilterPushdownResult FilterCombiner::TryPushdownInFilter(TableFilterSet &table_f
 	if (func.children.size() == 2 && TypeSupportsConstantFilter(type)) {
 		// col IN (literal) is equivalent to an equality comparison - push that down
 		auto bound_eq_comparison = make_uniq<ConstantFilter>(ExpressionType::COMPARE_EQUAL, fst_const_value_expr.value);
-		table_filters.PushFilter(column_index, std::move(bound_eq_comparison));
+		table_filters.PushFilter(proj_index, std::move(bound_eq_comparison));
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
 
@@ -575,15 +579,15 @@ FilterPushdownResult FilterCombiner::TryPushdownInFilter(TableFilterSet &table_f
 		    make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(in_list.front()));
 		auto upper_bound =
 		    make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(in_list.back()));
-		table_filters.PushFilter(column_index, std::move(lower_bound));
-		table_filters.PushFilter(column_index, std::move(upper_bound));
+		table_filters.PushFilter(proj_index, std::move(lower_bound));
+		table_filters.PushFilter(proj_index, std::move(upper_bound));
 		return FilterPushdownResult::PUSHED_DOWN_FULLY;
 	}
 	// if this is not a dense range we can push an optional filter for zone-map pruning
 	auto optional_filter = make_uniq<OptionalFilter>();
 	auto in_filter = make_uniq<InFilter>(std::move(in_list));
 	optional_filter->child_filter = std::move(in_filter);
-	table_filters.PushFilter(column_index, std::move(optional_filter));
+	table_filters.PushFilter(proj_index, std::move(optional_filter));
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 }
 
@@ -600,7 +604,7 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 	if (conj.children.empty()) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
-	idx_t column_id = 0;
+	ProjectionIndex proj_id;
 	for (idx_t i = 0; i < conj.children.size(); i++) {
 		auto &child = conj.children[i];
 		if (child->GetExpressionClass() != ExpressionClass::BOUND_COMPARISON) {
@@ -623,15 +627,14 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 			// child of OR filter is not simple so we do not push the or filter down at all
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}
-
-		if (i == 0) {
-			auto &col_id = column_ids[column_ref->binding.column_index.index];
-			column_id = col_id.GetPrimaryIndex();
+		if (!proj_id.IsValid()) {
+			proj_id = column_ref->binding.column_index;
+			auto &col_id = column_ids[proj_id.index];
 			if (col_id.IsPushdownExtract()) {
 				//! FIXME: can't support filter pushdown on pushed down extract currently
 				return FilterPushdownResult::NO_PUSHDOWN;
 			}
-		} else if (column_id != column_ids[column_ref->binding.column_index.index].GetPrimaryIndex()) {
+		} else if (proj_id != column_ref->binding.column_index) {
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}
 
@@ -660,7 +663,7 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 	}
 	auto optional_filter = make_uniq<OptionalFilter>();
 	optional_filter->child_filter = std::move(conj_filter);
-	table_filters.PushFilter(ColumnIndex(column_id), std::move(optional_filter));
+	table_filters.PushFilter(proj_id, std::move(optional_filter));
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 }
 

--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -41,7 +41,7 @@ void FilterPushdown::CheckMarkToSemi(LogicalOperator &op, unordered_set<TableInd
 		unordered_set<TableIndex> new_table_bindings;
 		for (auto &binding : proj_bindings) {
 			auto col_index = binding.column_index;
-			auto &expr = proj.expressions.at(col_index.index);
+			auto &expr = proj.expressions.at(col_index);
 			ExpressionIterator::EnumerateExpression(expr, [&](Expression &child) {
 				if (child.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
 					auto &col_ref = child.Cast<BoundColumnRefExpression>();

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -77,7 +77,7 @@ void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
 			child_columns.reserve(columns.size());
 			for (auto &child_column : columns) {
 				JoinFilterPushdownColumn new_col;
-				new_col.probe_column_index = child_bindings[child_column.probe_column_index.column_index.index];
+				new_col.probe_column_index = child_bindings[child_column.probe_column_index.column_index];
 				child_columns.push_back(new_col);
 			}
 			// then recurse into the child

--- a/src/optimizer/join_order/cardinality_estimator.cpp
+++ b/src/optimizer/join_order/cardinality_estimator.cpp
@@ -502,8 +502,8 @@ void CardinalityEstimator::AddRelationNamesToRelationStats(vector<RelationStats>
 		for (auto &binding : total_domain.equivalent_relations) {
 			D_ASSERT(binding.table_index.index < stats.size());
 			string column_name;
-			if (binding.column_index.index < stats[binding.table_index.index].column_names.size()) {
-				column_name = stats[binding.table_index.index].column_names[binding.column_index.index];
+			if (binding.column_index < stats[binding.table_index.index].column_names.size()) {
+				column_name = stats[binding.table_index.index].column_names[binding.column_index];
 			} else {
 				column_name = "[unknown]";
 			}

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -119,20 +119,20 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 		unique_ptr<BaseStatistics> column_statistics;
 		bool has_non_optional_filters = false;
 		for (auto &entry : get.table_filters) {
+			auto &column_index = get.GetColumnIndex(entry.ColumnIndex());
 			if (get.bind_data && (get.function.statistics || get.function.statistics_extended)) {
 				if (get.function.statistics_extended) {
-					auto column_index = ColumnIndex(entry.ColumnIndex());
 					TableFunctionGetStatisticsInput input(get.bind_data.get(), column_index);
 					column_statistics = get.function.statistics_extended(context, input);
 				} else {
 					D_ASSERT(get.function.statistics);
-					column_statistics = get.function.statistics(context, get.bind_data.get(), entry.ColumnIndex());
+					column_statistics = get.function.statistics(context, get.bind_data.get(), column_index.GetPrimaryIndex());
 				}
 			}
 
 			if (column_statistics) {
 				idx_t cardinality_with_filter =
-				    InspectTableFilter(base_table_cardinality, entry.ColumnIndex(), entry.Filter(), *column_statistics);
+				    InspectTableFilter(base_table_cardinality, entry.Filter(), *column_statistics);
 				cardinality_after_filters = MinValue(cardinality_after_filters, cardinality_with_filter);
 			}
 
@@ -445,7 +445,7 @@ RelationStats RelationStatisticsHelper::ExtractEmptyResultStats(LogicalEmptyResu
 	return stats;
 }
 
-idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, idx_t column_index, const TableFilter &filter,
+idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, const TableFilter &filter,
                                                    BaseStatistics &base_stats) {
 	auto cardinality_after_filters = cardinality;
 	switch (filter.filter_type) {
@@ -453,7 +453,7 @@ idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, idx_t colu
 		auto &and_filter = filter.Cast<ConjunctionAndFilter>();
 		for (auto &child_filter : and_filter.child_filters) {
 			cardinality_after_filters = MinValue(
-			    cardinality_after_filters, InspectTableFilter(cardinality, column_index, *child_filter, base_stats));
+			    cardinality_after_filters, InspectTableFilter(cardinality, *child_filter, base_stats));
 		}
 		return cardinality_after_filters;
 	}

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -119,7 +119,7 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 		unique_ptr<BaseStatistics> column_statistics;
 		bool has_non_optional_filters = false;
 		for (auto &entry : get.table_filters) {
-			auto &column_index = get.GetColumnIndex(entry.ColumnIndex());
+			auto &column_index = get.GetColumnIndex(entry.GetIndex());
 			if (get.bind_data && (get.function.statistics || get.function.statistics_extended)) {
 				if (get.function.statistics_extended) {
 					TableFunctionGetStatisticsInput input(get.bind_data.get(), column_index);
@@ -171,7 +171,7 @@ RelationStats RelationStatisticsHelper::ExtractDelimGetStats(LogicalDelimGet &de
 	stats.stats_initialized = true;
 	for (auto &binding : delim_get.GetColumnBindings()) {
 		stats.column_distinct_count.push_back(DistinctCount({1, false}));
-		stats.column_names.push_back("column" + to_string(binding.column_index.index));
+		stats.column_names.push_back("column" + to_string(binding.column_index));
 	}
 	return stats;
 }
@@ -188,15 +188,14 @@ RelationStats RelationStatisticsHelper::ExtractProjectionStats(LogicalProjection
 			proj_stats.column_distinct_count.push_back(DistinctCount({1, true}));
 		} else {
 			auto column_index = res.child_binding.column_index;
-			if (column_index.index >= child_stats.column_distinct_count.size() && expr->ToString() == "count_star()") {
+			if (column_index >= child_stats.column_distinct_count.size() && expr->ToString() == "count_star()") {
 				// only one value for a count star
 				proj_stats.column_distinct_count.push_back(DistinctCount({1, true}));
 			} else {
 				// TODO: add this back in
 				//	D_ASSERT(column_index < stats.column_distinct_count.size());
-				if (column_index.index < child_stats.column_distinct_count.size()) {
-					proj_stats.column_distinct_count.push_back(
-					    child_stats.column_distinct_count.at(column_index.index));
+				if (column_index < child_stats.column_distinct_count.size()) {
+					proj_stats.column_distinct_count.push_back(child_stats.column_distinct_count.at(column_index));
 				} else {
 					proj_stats.column_distinct_count.push_back(DistinctCount({proj_stats.cardinality, false}));
 				}
@@ -370,15 +369,14 @@ RelationStats RelationStatisticsHelper::ExtractAggregationStats(LogicalAggregate
 			}
 			auto &bound_col = group.Cast<BoundColumnRefExpression>();
 			auto col_index = bound_col.binding.column_index;
-			if (col_index.index >= child_stats.column_distinct_count.size()) {
+			if (col_index >= child_stats.column_distinct_count.size()) {
 				// it is possible the column index of the grouping_set is not in the child stats.
 				// this can happen when delim joins are present, since delim scans are not currently
 				// reorderable. Meaning they don't add a relation or column_ids that could potentially
 				// be grouped by. Hopefully this can be fixed with duckdb-internal#606
 				continue;
 			}
-			double distinct_count =
-			    static_cast<double>(child_stats.column_distinct_count[col_index.index].distinct_count);
+			double distinct_count = static_cast<double>(child_stats.column_distinct_count[col_index].distinct_count);
 			set_distinct_counts.push_back(distinct_count == 0 ? 1 : distinct_count);
 		}
 		// We use the grouping set with the most group key columns for cardinality estimation

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -126,7 +126,8 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 					column_statistics = get.function.statistics_extended(context, input);
 				} else {
 					D_ASSERT(get.function.statistics);
-					column_statistics = get.function.statistics(context, get.bind_data.get(), column_index.GetPrimaryIndex());
+					column_statistics =
+					    get.function.statistics(context, get.bind_data.get(), column_index.GetPrimaryIndex());
 				}
 			}
 
@@ -452,8 +453,8 @@ idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, const Tabl
 	case TableFilterType::CONJUNCTION_AND: {
 		auto &and_filter = filter.Cast<ConjunctionAndFilter>();
 		for (auto &child_filter : and_filter.child_filters) {
-			cardinality_after_filters = MinValue(
-			    cardinality_after_filters, InspectTableFilter(cardinality, *child_filter, base_stats));
+			cardinality_after_filters =
+			    MinValue(cardinality_after_filters, InspectTableFilter(cardinality, *child_filter, base_stats));
 		}
 		return cardinality_after_filters;
 	}

--- a/src/optimizer/late_materialization.cpp
+++ b/src/optimizer/late_materialization.cpp
@@ -186,7 +186,7 @@ bool LateMaterialization::TryLateMaterialization(unique_ptr<LogicalOperator> &op
 			for (auto &entry : column_references) {
 				auto &column_binding = entry.first;
 				if (column_binding.table_index == proj.table_index) {
-					referenced_columns.insert(column_binding.column_index.index);
+					referenced_columns.insert(column_binding.column_index);
 				}
 			}
 			// clear the list of referenced expressions and visit those columns

--- a/src/optimizer/pushdown/pushdown_set_operation.cpp
+++ b/src/optimizer/pushdown/pushdown_set_operation.cpp
@@ -19,7 +19,7 @@ static void ReplaceSetOpBindings(vector<ColumnBinding> &bindings, Filter &filter
 		    D_ASSERT(colref.depth == 0);
 
 		    // rewrite the binding by looking into the bound_tables list of the subquery
-		    colref.binding = bindings[colref.binding.column_index.index];
+		    colref.binding = bindings[colref.binding.column_index];
 		    filter.bindings.insert(colref.binding.table_index);
 	    });
 }

--- a/src/optimizer/remove_duplicate_groups.cpp
+++ b/src/optimizer/remove_duplicate_groups.cpp
@@ -35,7 +35,7 @@ void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
 	column_binding_map_t<ProjectionIndex> duplicate_map;
 	vector<pair<ProjectionIndex, ProjectionIndex>> duplicates;
 	for (auto group_idx : ProjectionIndex::GetIndexes(groups.size())) {
-		const auto &group = groups[group_idx.index];
+		const auto &group = groups[group_idx];
 		if (group->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 			continue;
 		}
@@ -73,8 +73,8 @@ void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
 		const auto &removed_idx = duplicate.second;
 
 		// Store expression and remove it from groups
-		stored_expressions.emplace_back(std::move(groups[removed_idx.index]));
-		groups.erase_at(removed_idx.index);
+		stored_expressions.emplace_back(std::move(groups[removed_idx]));
+		groups.erase_at(removed_idx);
 
 		// This optimizer should run before statistics propagation, so this should be empty
 		// If it runs after, then group_stats should be updated too
@@ -98,7 +98,7 @@ void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
 				grouping_set.erase(group_idx);
 			}
 			for (const auto group_idx : group_indices_to_reinsert) {
-				grouping_set.insert(ProjectionIndex(group_idx.index - 1));
+				grouping_set.insert(ProjectionIndex(group_idx - 1));
 			}
 		}
 
@@ -110,7 +110,7 @@ void RemoveDuplicateGroups::VisitAggregate(LogicalAggregate &aggr) {
 		for (auto &map_entry : group_binding_map) {
 			auto &new_binding = map_entry.second;
 			if (new_binding.column_index > removed_idx) {
-				new_binding.column_index.index--;
+				new_binding.column_index = ProjectionIndex(new_binding.column_index - 1);
 			}
 		}
 	}

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -684,7 +684,7 @@ void RemoveUnusedColumns::CheckPushdownExtract(LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_PROJECTION: {
 		auto &proj = op.Cast<LogicalProjection>();
 		for (auto proj_idx : ProjectionIndex::GetIndexes(proj.expressions.size())) {
-			auto &expr = *proj.expressions[proj_idx.index];
+			auto &expr = *proj.expressions[proj_idx];
 			auto record = column_references.find(ColumnBinding(proj.table_index, proj_idx));
 			if (record == column_references.end()) {
 				//! Not referenced, skip
@@ -754,7 +754,7 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 	//! for each filter that was pushed down - convert them into an expression
 	vector<unique_ptr<Expression>> filter_expressions;
 	for (auto &entry : get.table_filters) {
-		auto filter_idx = entry.ColumnIndex();
+		auto filter_idx = entry.GetIndex();
 		auto &filter = entry.Filter();
 		auto &col_id = get.GetColumnIndex(filter_idx);
 		auto column_type = get.GetColumnType(col_id);
@@ -780,7 +780,7 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 	bool has_pushdown_extract = false;
 	// Now set the column ids in the LogicalGet using the "selection vector"
 	for (auto &col_sel_idx : col_sel) {
-		auto &logical_column_id = old_column_ids[col_sel_idx.index];
+		auto &logical_column_id = old_column_ids[col_sel_idx];
 		auto &column_type = get.GetColumnType(logical_column_id);
 		auto entry = column_references.find(ColumnBinding(get.table_index, col_sel_idx));
 		if (entry == column_references.end()) {
@@ -843,7 +843,7 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 		}
 		TableFilterSet remapped_filters;
 		for (auto &entry : get.table_filters) {
-			auto it = old_to_new_pos.find(entry.ColumnIndex());
+			auto it = old_to_new_pos.find(entry.GetIndex());
 			if (it == old_to_new_pos.end()) {
 				throw InternalException("RemoveUnusedColumns: removed a filter column");
 			}

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -833,6 +833,25 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 	}
 	get.SetColumnIds(std::move(new_column_ids));
 
+	// remap table filters so they point towards the new set of ids
+	if (get.table_filters.HasFilters()) {
+		// Build a mapping from old ProjectionIndex -> new ProjectionIndex using original_ids
+		unordered_map<ProjectionIndex, ProjectionIndex> old_to_new_pos;
+		old_to_new_pos.reserve(original_ids.size());
+		for (idx_t new_pos = 0; new_pos < original_ids.size(); new_pos++) {
+			old_to_new_pos[original_ids[new_pos]] = ProjectionIndex(new_pos);
+		}
+		TableFilterSet remapped_filters;
+		for (auto &entry : get.table_filters) {
+			auto it = old_to_new_pos.find(entry.ColumnIndex());
+			if (it == old_to_new_pos.end()) {
+				throw InternalException("RemoveUnusedColumns: removed a filter column");
+			}
+			remapped_filters.PushFilter(it->second, entry.TakeFilter());
+		}
+		get.table_filters = std::move(remapped_filters);
+	}
+
 	if (has_pushdown_extract && !filter_expressions.empty()) {
 		// if we have performed pushdown extract and we have filter expressions we might have adjusted the filter
 		// expressions remove the table filters and push a filter, then try to re-push the filters with the new set of

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -481,17 +481,6 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 	}
 }
 
-static ProjectionIndex GetColumnIdsIndexForFilter(vector<ColumnIndex> &column_ids, idx_t filter_idx) {
-	// Find the index in the column_ids that contains the column referenced by the filter
-	auto it = std::find_if(column_ids.begin(), column_ids.end(), [&filter_idx](const ColumnIndex &column_index) {
-		return column_index.GetPrimaryIndex() == filter_idx;
-	});
-	if (it == column_ids.end()) {
-		throw InternalException("Could not find column index for table filter");
-	}
-	return ProjectionIndex(static_cast<idx_t>(std::distance(column_ids.begin(), it)));
-}
-
 //! returns: found_path, depth of the found path
 std::pair<column_index_set::iterator, idx_t> FindShortestMatchingPath(column_index_set &all_paths,
                                                                       const ColumnIndex &full_path) {
@@ -767,10 +756,10 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 	for (auto &entry : get.table_filters) {
 		auto filter_idx = entry.ColumnIndex();
 		auto &filter = entry.Filter();
-		auto index = GetColumnIdsIndexForFilter(old_column_ids, filter_idx);
-		auto column_type = get.GetColumnType(ColumnIndex(filter_idx));
+		auto &col_id = get.GetColumnIndex(filter_idx);
+		auto column_type = get.GetColumnType(col_id);
 
-		ColumnBinding filter_binding(get.table_index, index);
+		ColumnBinding filter_binding(get.table_index, filter_idx);
 		auto column_ref = make_uniq<BoundColumnRefExpression>(std::move(column_type), filter_binding);
 		//! Convert the filter to an expression, so we can visit it
 		auto filter_expr = filter.ToExpression(*column_ref);

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -196,7 +196,7 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		for (auto &entry : get.table_filters) {
 			auto col_idx = entry.ColumnIndex();
 			auto &filter = entry.Filter();
-			auto column_index = ColumnIndex(col_idx);
+			auto &column_index = get.GetColumnIndex(col_idx);
 			StorageIndex storage_index;
 			if (!get.TryGetStorageIndex(column_index, storage_index)) {
 				return;

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -194,9 +194,9 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 	if (get.table_filters.HasFilters()) {
 		map<StorageIndex, reference<TableFilter>> filter_storage_index_map;
 		for (auto &entry : get.table_filters) {
-			auto col_idx = entry.ColumnIndex();
+			auto filter_idx = entry.GetIndex();
 			auto &filter = entry.Filter();
-			auto &column_index = get.GetColumnIndex(col_idx);
+			auto &column_index = get.GetColumnIndex(filter_idx);
 			StorageIndex storage_index;
 			if (!get.TryGetStorageIndex(column_index, storage_index)) {
 				return;

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -139,24 +139,15 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 		}
 	}
 	// push table filters into the statistics
-	vector<idx_t> column_indexes;
-	column_indexes.reserve(get.table_filters.FilterCount());
+	vector<ProjectionIndex> filter_columns;
+	filter_columns.reserve(get.table_filters.FilterCount());
 	for (auto &kv : get.table_filters) {
-		column_indexes.push_back(kv.ColumnIndex());
+		filter_columns.push_back(kv.ColumnIndex());
 	}
 
-	for (auto &table_filter_column : column_indexes) {
-		idx_t column_index;
-		for (column_index = 0; column_index < column_ids.size(); column_index++) {
-			if (column_ids[column_index].GetPrimaryIndex() == table_filter_column) {
-				break;
-			}
-		}
-		D_ASSERT(column_index < column_ids.size());
-		D_ASSERT(column_ids[column_index].GetPrimaryIndex() == table_filter_column);
-
+	for (auto &table_filter_column : filter_columns) {
 		// find the stats
-		ColumnBinding stats_binding(get.table_index, ProjectionIndex(column_index));
+		ColumnBinding stats_binding(get.table_index, table_filter_column);
 		auto entry = statistics_map.find(stats_binding);
 		if (entry == statistics_map.end()) {
 			// no stats for this entry

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -142,7 +142,7 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 	vector<ProjectionIndex> filter_columns;
 	filter_columns.reserve(get.table_filters.FilterCount());
 	for (auto &kv : get.table_filters) {
-		filter_columns.push_back(kv.ColumnIndex());
+		filter_columns.push_back(kv.GetIndex());
 	}
 
 	for (auto &table_filter_column : filter_columns) {

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -129,8 +129,7 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 		auto optional_filter = make_uniq<OptionalFilter>(std::move(pushed_filter));
 
 		// push the filter into the table scan
-		auto &column_index = get.GetColumnIndex(col_binding);
-		get.table_filters.PushFilter(column_index, std::move(optional_filter));
+		get.table_filters.PushFilter(col_binding.column_index, std::move(optional_filter));
 	}
 }
 

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -528,7 +528,7 @@ bool TopNWindowElimination::CanOptimize(LogicalOperator &op) {
 		const auto current_column_ref = column_references.begin()->first;
 		column_references.clear();
 		D_ASSERT(current_column_ref.table_index == projection.table_index);
-		VisitExpression(&projection.expressions[current_column_ref.column_index.index]);
+		VisitExpression(&projection.expressions[current_column_ref.column_index]);
 
 		child = *child.get().children[0];
 	}
@@ -612,7 +612,7 @@ vector<unique_ptr<Expression>> TopNWindowElimination::GenerateAggregatePayload(c
 
 		auto column_id = binding.ToString();
 		if (window.children[0]->type == LogicalOperatorType::LOGICAL_PROJECTION) {
-			auto &window_child_type = window_child_types[binding.column_index.index];
+			auto &window_child_type = window_child_types[binding.column_index];
 			// The column index points to the correct column binding
 			aggregate_args.push_back(make_uniq<BoundColumnRefExpression>(column_id, window_child_type, binding));
 		} else {
@@ -655,7 +655,7 @@ vector<ColumnBinding> TopNWindowElimination::TraverseProjectionBindings(const st
 		for (idx_t i = 0; i < new_bindings.size(); i++) {
 			auto &new_binding = new_bindings[i];
 			D_ASSERT(new_binding.table_index == projection.table_index);
-			VisitExpression(&projection.expressions[new_binding.column_index.index]);
+			VisitExpression(&projection.expressions[new_binding.column_index]);
 			new_binding = column_references.begin()->first;
 			column_references.clear();
 		}
@@ -797,10 +797,10 @@ bool TopNWindowElimination::CanUseLateMaterialization(const LogicalWindow &windo
 					return false;
 				}
 				const auto projection_idx = projections[i].column_index;
-				if (projection_idx.index >= projection.expressions.size()) {
+				if (projection_idx >= projection.expressions.size()) {
 					return false;
 				}
-				if (!extract_single_binding(&projection.expressions[projection_idx.index], projections[i])) {
+				if (!extract_single_binding(&projection.expressions[projection_idx], projections[i])) {
 					return false;
 				}
 			}
@@ -855,17 +855,15 @@ bool TopNWindowElimination::CanUseLateMaterialization(const LogicalWindow &windo
 				if (projection.table_index != left_idx && projection.table_index != right_idx) {
 					return false;
 				}
-				if (projection.table_index == left_idx &&
-				    projection.column_index.index >= left_column_bindings.size()) {
+				if (projection.table_index == left_idx && projection.column_index >= left_column_bindings.size()) {
 					return false;
 				}
-				if (projection.table_index == right_idx &&
-				    projection.column_index.index >= right_column_bindings.size()) {
+				if (projection.table_index == right_idx && projection.column_index >= right_column_bindings.size()) {
 					return false;
 				}
 				auto &column_binding = projection.table_index == left_idx
-				                           ? left_column_bindings[projection.column_index.index]
-				                           : right_column_bindings[projection.column_index.index];
+				                           ? left_column_bindings[projection.column_index]
+				                           : right_column_bindings[projection.column_index];
 				if (replaceable_bindings.find(column_binding) == replaceable_bindings.end()) {
 					if (column_binding.table_index == left_idx) {
 						all_left_replaceable = false;
@@ -887,16 +885,16 @@ bool TopNWindowElimination::CanUseLateMaterialization(const LogicalWindow &windo
 					return false;
 				}
 				if (projection_idx.table_index == left_idx &&
-				    projection_idx.column_index.index >= left_column_bindings.size()) {
+				    projection_idx.column_index >= left_column_bindings.size()) {
 					return false;
 				}
 				if (projection_idx.table_index == right_idx &&
-				    projection_idx.column_index.index >= right_column_bindings.size()) {
+				    projection_idx.column_index >= right_column_bindings.size()) {
 					return false;
 				}
 				auto &column_binding = projection_idx.table_index == left_idx
-				                           ? left_column_bindings[projection_idx.column_index.index]
-				                           : right_column_bindings[projection_idx.column_index.index];
+				                           ? left_column_bindings[projection_idx.column_index]
+				                           : right_column_bindings[projection_idx.column_index];
 				if (column_binding.table_index == replace_table_idx) {
 					projections[i] = replaceable_bindings[column_binding];
 				}
@@ -1077,7 +1075,7 @@ unique_ptr<LogicalOperator> TopNWindowElimination::ConstructJoin(unique_ptr<Logi
 		const ProjectionIndex rhs_rowid_idx(rhs_binding_offset + i);
 		const auto &alias = GetLHSRowIdColumnName(lhs, lhs_rowid_idx);
 
-		auto left_expr = make_uniq<BoundColumnRefExpression>(alias, lhs->types[lhs_rowid_idx.index],
+		auto left_expr = make_uniq<BoundColumnRefExpression>(alias, lhs->types[lhs_rowid_idx],
 		                                                     ColumnBinding {lhs->GetTableIndex()[0], lhs_rowid_idx});
 		auto right_expr = make_uniq<BoundColumnRefExpression>(alias, rhs->types[aggregate_offset + i],
 		                                                      ColumnBinding {GetAggregateIdx(rhs), rhs_rowid_idx});

--- a/src/optimizer/unnest_rewriter.cpp
+++ b/src/optimizer/unnest_rewriter.cpp
@@ -160,16 +160,16 @@ void UnnestRewriter::FindCandidates(unique_ptr<LogicalOperator> &root, unique_pt
 					// not part of the unnest
 					continue;
 				}
-				auto &bind_col = proj.expressions[col_bind.column_index.index]->Cast<BoundColumnRefExpression>();
+				auto &bind_col = proj.expressions[col_bind.column_index]->Cast<BoundColumnRefExpression>();
 				auto unnest_expr = make_uniq<BoundUnnestExpression>(unnest_get->types[i]);
-				unnest_expr->child = proj.expressions[col_bind.column_index.index]->Copy();
+				unnest_expr->child = proj.expressions[col_bind.column_index]->Copy();
 				bind_col.binding = ColumnBinding(unnest_get_index, bind_col.binding.column_index);
 				auto unnest_proj_idx = ColumnBinding::PushExpression(unnest->expressions, std::move(unnest_expr));
 				ColumnBinding new_column_ref(bind_col.binding.table_index, unnest_proj_idx);
 				auto unnest_ref = make_uniq<BoundColumnRefExpression>(bind_col.alias, unnest_get->types[i],
 				                                                      new_column_ref, bind_col.depth);
-				proj.expressions[col_bind.column_index.index] = std::move(unnest_ref);
-				proj.types[col_bind.column_index.index] = unnest_get->types[i];
+				proj.expressions[col_bind.column_index] = std::move(unnest_ref);
+				proj.types[col_bind.column_index] = unnest_get->types[i];
 				replacer.replacement_bindings.push_back(ReplacementBinding(
 				    col_bind, ColumnBinding(proj.table_index, col_bind.column_index), unnest_get->types[i]));
 			}

--- a/src/parser/query_node/select_node.cpp
+++ b/src/parser/query_node/select_node.cpp
@@ -73,7 +73,7 @@ string SelectNode::ToString() const {
 				if (!first) {
 					result += ", ";
 				}
-				result += groups.group_expressions[grp.index]->ToString();
+				result += groups.group_expressions[grp]->ToString();
 				first = false;
 			}
 			if (grouping_sets) {

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -317,7 +317,7 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 		// duplicate aggregate: simplify refer to this aggregate
 		aggr_index = entry->second;
 	}
-	auto &bound_aggr = *node.aggregates[aggr_index.index];
+	auto &bound_aggr = *node.aggregates[aggr_index];
 
 	// now create a column reference referring to the aggregate
 	auto colref = make_uniq<BoundColumnRefExpression>(aggr.GetAlias().empty() ? bound_aggr.ToString() : aggr.GetAlias(),

--- a/src/planner/binder/expression/bind_lambda.cpp
+++ b/src/planner/binder/expression/bind_lambda.cpp
@@ -30,7 +30,7 @@ static idx_t GetLambdaParamIndex(vector<DummyBinding> &lambda_bindings, const Bo
 		offset += lambda_bindings[i].GetColumnCount();
 	}
 	offset += lambda_bindings[bound_lambda_ref_expr.lambda_idx].GetColumnCount() -
-	          bound_lambda_ref_expr.binding.column_index.index - 1;
+	          bound_lambda_ref_expr.binding.column_index - 1;
 	offset += bound_lambda_expr.parameter_count;
 	return offset;
 }
@@ -166,8 +166,8 @@ void ExpressionBinder::TransformCapturedLambdaColumn(unique_ptr<Expression> &ori
 		}
 		// refers to a lambda parameter inside the current lambda function
 		auto logical_type = (*bind_lambda_function)(context, function_child_types,
-		                                            bound_lambda_ref.binding.column_index.index, bind_lambda_context);
-		auto index = bound_lambda_expr.parameter_count - bound_lambda_ref.binding.column_index.index - 1;
+		                                            bound_lambda_ref.binding.column_index, bind_lambda_context);
+		auto index = bound_lambda_expr.parameter_count - bound_lambda_ref.binding.column_index - 1;
 		replacement = make_uniq<BoundReferenceExpression>(alias, logical_type, index);
 		return;
 	}

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -62,7 +62,7 @@ void SelectBinder::ThrowIfUnnestInLambda(const ColumnBinding &column_binding) {
 		auto &unnest_node = node_pair.second;
 
 		if (unnest_node.index == column_binding.table_index) {
-			if (column_binding.column_index.index < unnest_node.expressions.size()) {
+			if (column_binding.column_index < unnest_node.expressions.size()) {
 				throw BinderException("UNNEST in lambda expressions is not supported");
 			}
 		}

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -183,17 +183,17 @@ BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
 				throw BinderException(func_expr.GetQueryLocation(),
 				                      "Column '%s' referenced multiple times in USING KEY clause.\n"
 				                      "Try using an alias for one of the aggregates.",
-				                      result.names[aggregate_idx.index]);
+				                      result.names[aggregate_idx]);
 			}
 
 			if (key_references.find(aggregate_idx) != key_references.end()) {
 				throw BinderException(func_expr.GetQueryLocation(),
 				                      "Column '%s' cannot be used as both key and aggregate in USING KEY clause.\n"
 				                      "Try using an alias for the aggregation.",
-				                      result.names[aggregate_idx.index]);
+				                      result.names[aggregate_idx]);
 			}
 
-			return_types[aggregate_idx.index] = aggregate->return_type;
+			return_types[aggregate_idx] = aggregate->return_type;
 			payload_references[aggregate_idx] = std::move(aggregate);
 		} else {
 			throw BinderException(

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -255,13 +255,13 @@ void Binder::PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, B
 unique_ptr<Expression> CreateOrderExpression(unique_ptr<Expression> expr, const vector<string> &names,
                                              const vector<LogicalType> &sql_types, TableIndex table_index,
                                              ProjectionIndex index) {
-	if (index.index >= sql_types.size()) {
+	if (index >= sql_types.size()) {
 		throw BinderException(*expr, "ORDER term out of range - should be between 1 and %lld", sql_types.size());
 	}
-	auto result = make_uniq<BoundColumnRefExpression>(expr->GetAlias(), sql_types[index.index],
-	                                                  ColumnBinding(table_index, index));
-	if (result->GetAlias().empty() && index.index < names.size()) {
-		result->SetAlias(names[index.index]);
+	auto result =
+	    make_uniq<BoundColumnRefExpression>(expr->GetAlias(), sql_types[index], ColumnBinding(table_index, index));
+	if (result->GetAlias().empty() && index < names.size()) {
+		result->SetAlias(names[index]);
 	}
 	return std::move(result);
 }
@@ -317,7 +317,7 @@ static void AssignReturnType(unique_ptr<Expression> &expr, TableIndex table_inde
 		return;
 	}
 	auto &bound_colref = expr->Cast<BoundColumnRefExpression>();
-	bound_colref.return_type = sql_types[bound_colref.binding.column_index.index];
+	bound_colref.return_type = sql_types[bound_colref.binding.column_index];
 }
 
 void Binder::BindModifiers(BoundQueryNode &result, TableIndex table_index, const vector<string> &names,

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -157,14 +157,14 @@ void Binder::BuildUnionByNameInfo(BoundSetOperationNode &result) {
 				need_reorder = true;
 			} else {
 				auto col_idx_in_child = entry->second;
-				auto &child_col_type = child_types[col_idx_in_child.index];
+				auto &child_col_type = child_types[col_idx_in_child];
 				// the child exists in this node - compute the type
 				if (result_type.id() == LogicalTypeId::INVALID) {
 					result_type = child_col_type;
 				} else {
 					result_type = LogicalType::ForceMaxLogicalType(result_type, child_col_type);
 				}
-				if (i != col_idx_in_child.index) {
+				if (i != col_idx_in_child) {
 					// the column exists - but the children are out-of-order, so we need to re-order anyway
 					need_reorder = true;
 				}
@@ -201,7 +201,7 @@ void Binder::BuildUnionByNameInfo(BoundSetOperationNode &result) {
 			} else {
 				// the column exists - reference it
 				auto col_idx_in_child = entry->second;
-				auto &child_col_type = child.types[col_idx_in_child.index];
+				auto &child_col_type = child.types[col_idx_in_child];
 				auto root_idx = child.plan->GetRootIndex();
 				expr = make_uniq<BoundColumnRefExpression>(child_col_type, ColumnBinding(root_idx, col_idx_in_child));
 			}

--- a/src/planner/binder/query_node/plan_setop.cpp
+++ b/src/planner/binder/query_node/plan_setop.cpp
@@ -35,7 +35,7 @@ unique_ptr<LogicalOperator> Binder::CastLogicalOperatorToTypes(const vector<Logi
 				for (idx_t i = 0; i < op->expressions.size(); i++) {
 					if (op->expressions[i]->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
 						auto &col_ref = op->expressions[i]->Cast<BoundColumnRefExpression>();
-						auto column_id = column_ids[col_ref.binding.column_index.index].GetPrimaryIndex();
+						auto column_id = column_ids[col_ref.binding.column_index].GetPrimaryIndex();
 						if (new_column_types.find(column_id) != new_column_types.end()) {
 							// Only one reference per column is accepted
 							do_pushdown = false;

--- a/src/planner/column_binding.cpp
+++ b/src/planner/column_binding.cpp
@@ -9,7 +9,7 @@ ColumnBinding::ColumnBinding(TableIndex table, ProjectionIndex column) : table_i
 }
 
 string ColumnBinding::ToString() const {
-	return "#[" + to_string(table_index.index) + "." + to_string(column_index.index) + "]";
+	return "#[" + to_string(table_index.index) + "." + to_string(column_index) + "]";
 }
 
 bool ColumnBinding::operator==(const ColumnBinding &rhs) const {

--- a/src/planner/expression/bound_lambdaref_expression.cpp
+++ b/src/planner/expression/bound_lambdaref_expression.cpp
@@ -41,7 +41,7 @@ string BoundLambdaRefExpression::ToString() const {
 	if (!alias.empty()) {
 		return alias;
 	}
-	return "#[" + to_string(binding.table_index.index) + "." + to_string(binding.column_index.index) + "." +
+	return "#[" + to_string(binding.table_index.index) + "." + to_string(binding.column_index) + "." +
 	       to_string(lambda_idx) + "]";
 }
 } // namespace duckdb

--- a/src/planner/expression_binder/base_select_binder.cpp
+++ b/src/planner/expression_binder/base_select_binder.cpp
@@ -101,7 +101,7 @@ BindResult BaseSelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, Proj
 	if (it != info.collated_groups.end()) {
 		// This is an implicitly collated group, so we need to refer to the first() aggregate
 		const auto &aggr_index = it->second;
-		const auto return_type = node.aggregates[aggr_index.index]->return_type;
+		const auto return_type = node.aggregates[aggr_index]->return_type;
 		auto uncollated_first_expression = make_uniq<BoundColumnRefExpression>(
 		    expr.GetName(), return_type, ColumnBinding(node.aggregate_index, aggr_index), depth);
 
@@ -113,7 +113,7 @@ BindResult BaseSelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, Proj
 
 		// otherwise we insert a case statement to return NULL when the collated group expression is NULL
 		// otherwise you can return the "first" of the uncollated expression.
-		auto &group = node.groups.group_expressions[group_index.index];
+		auto &group = node.groups.group_expressions[group_index];
 		auto collated_group_expression = make_uniq<BoundColumnRefExpression>(
 		    expr.GetName(), group->return_type, ColumnBinding(node.group_index, group_index), depth);
 
@@ -126,7 +126,7 @@ BindResult BaseSelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, Proj
 		    make_uniq<BoundCaseExpression>(std::move(when_expr), std::move(then_expr), std::move(else_expr));
 		return BindResult(std::move(case_expr));
 	} else {
-		auto &group = node.groups.group_expressions[group_index.index];
+		auto &group = node.groups.group_expressions[group_index];
 		return BindResult(make_uniq<BoundColumnRefExpression>(expr.GetName(), group->return_type,
 		                                                      ColumnBinding(node.group_index, group_index), depth));
 	}

--- a/src/planner/expression_binder/select_bind_state.cpp
+++ b/src/planner/expression_binder/select_bind_state.cpp
@@ -35,7 +35,7 @@ void SelectBindState::AddExpandedColumn(idx_t expand_count) {
 	if (expanded_column_indices.empty()) {
 		expanded_column_indices.emplace_back(0);
 	}
-	expanded_column_indices.push_back(ProjectionIndex(expanded_column_indices.back().index + expand_count));
+	expanded_column_indices.push_back(ProjectionIndex(expanded_column_indices.back() + expand_count));
 }
 
 void SelectBindState::AddRegularColumn() {

--- a/src/planner/logical_operator.cpp
+++ b/src/planner/logical_operator.cpp
@@ -118,7 +118,7 @@ vector<LogicalType> LogicalOperator::MapTypes(const vector<LogicalType> &types,
 		vector<LogicalType> result_types;
 		result_types.reserve(projection_map.size());
 		for (auto index : projection_map) {
-			result_types.push_back(types[index.index]);
+			result_types.push_back(types[index]);
 		}
 		return result_types;
 	}
@@ -132,7 +132,7 @@ vector<ColumnBinding> LogicalOperator::MapBindings(const vector<ColumnBinding> &
 		vector<ColumnBinding> result_bindings;
 		result_bindings.reserve(projection_map.size());
 		for (auto index : projection_map) {
-			result_bindings.push_back(bindings[index.index]);
+			result_bindings.push_back(bindings[index]);
 		}
 		return result_bindings;
 	}

--- a/src/planner/logical_operator_visitor.cpp
+++ b/src/planner/logical_operator_visitor.cpp
@@ -69,7 +69,7 @@ void LogicalOperatorVisitor::VisitChildOfOperatorWithProjectionMap(unique_ptr<Lo
 	vector<ProjectionIndex> new_projection_map;
 	new_projection_map.reserve(projection_map.size());
 	for (const auto proj_idx_before : projection_map) {
-		auto &desired_binding = child_bindings_before[proj_idx_before.index];
+		auto &desired_binding = child_bindings_before[proj_idx_before];
 		idx_t proj_idx_after;
 		for (proj_idx_after = 0; proj_idx_after < child_bindings_after.size(); proj_idx_after++) {
 			if (child_bindings_after[proj_idx_after] == desired_binding) {

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -14,10 +14,10 @@ LogicalAggregate::LogicalAggregate(TableIndex group_index, TableIndex aggregate_
 
 const Expression &LogicalAggregate::GetExpression(ColumnBinding binding) const {
 	if (binding.table_index == group_index) {
-		return *groups[binding.column_index.index];
+		return *groups[binding.column_index];
 	}
 	if (binding.table_index == aggregate_index) {
-		return *expressions[binding.column_index.index];
+		return *expressions[binding.column_index];
 	}
 	if (binding.table_index == groupings_index) {
 		throw InternalException("Groupings function does not have an expression defined");

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -39,12 +39,12 @@ InsertionOrderPreservingMap<string> LogicalGet::ParamsToString() const {
 	for (auto &kv : table_filters) {
 		auto column_index = kv.ColumnIndex();
 		auto &filter = kv.Filter();
-		if (column_index < names.size()) {
+		if (column_index.index < names.size()) {
 			if (!first_item) {
 				filters_info += "\n";
 			}
 			first_item = false;
-			filters_info += filter.ToString(names[column_index]);
+			filters_info += filter.ToString(names[column_index.index]);
 		}
 	}
 	result["Filters"] = filters_info;
@@ -76,8 +76,10 @@ void LogicalGet::SetColumnIds(vector<ColumnIndex> &&column_ids) {
 	this->column_ids = std::move(column_ids);
 }
 
-void LogicalGet::AddColumnId(column_t column_id) {
+ProjectionIndex LogicalGet::AddColumnId(column_t column_id) {
+	ProjectionIndex result(column_ids.size());
 	column_ids.emplace_back(column_id);
+	return result;
 }
 
 void LogicalGet::ClearColumnIds() {
@@ -90,6 +92,15 @@ const vector<ColumnIndex> &LogicalGet::GetColumnIds() const {
 
 vector<ColumnIndex> &LogicalGet::GetMutableColumnIds() {
 	return column_ids;
+}
+
+ProjectionIndex LogicalGet::TryGetProjectionIndex(idx_t col_idx) const {
+	for (idx_t c = 0; c < column_ids.size(); c++) {
+		if (column_ids[c].GetPrimaryIndex() == col_idx) {
+			return ProjectionIndex(c);
+		}
+	}
+	return ProjectionIndex();
 }
 
 const ColumnIndex &LogicalGet::GetColumnIndex(ColumnBinding binding) const {

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -37,14 +37,14 @@ InsertionOrderPreservingMap<string> LogicalGet::ParamsToString() const {
 	string filters_info;
 	bool first_item = true;
 	for (auto &kv : table_filters) {
-		auto column_index = kv.ColumnIndex();
+		auto filter_idx = kv.GetIndex();
 		auto &filter = kv.Filter();
-		if (column_index.index < names.size()) {
+		if (filter_idx < names.size()) {
 			if (!first_item) {
 				filters_info += "\n";
 			}
 			first_item = false;
-			filters_info += filter.ToString(names[column_index.index]);
+			filters_info += filter.ToString(names[filter_idx]);
 		}
 	}
 	result["Filters"] = filters_info;
@@ -107,7 +107,7 @@ const ColumnIndex &LogicalGet::GetColumnIndex(ColumnBinding binding) const {
 	if (binding.table_index != table_index) {
 		throw InternalException("LogicalGet::GetColumnIndex - table index does not match LogicalGet table index");
 	}
-	return column_ids[binding.column_index.index];
+	return column_ids[binding.column_index];
 }
 
 const ColumnIndex &LogicalGet::GetColumnIndex(ProjectionIndex proj_index) const {
@@ -193,7 +193,7 @@ void LogicalGet::ResolveTypes() {
 		}
 	} else {
 		for (auto &proj_index : projection_ids) {
-			auto &index = column_ids[proj_index.index];
+			auto &index = column_ids[proj_index];
 			types.push_back(GetColumnType(index));
 		}
 	}

--- a/src/planner/operator/logical_projection.cpp
+++ b/src/planner/operator/logical_projection.cpp
@@ -35,7 +35,7 @@ const Expression &LogicalProjection::GetExpression(ColumnBinding binding) const 
 	if (binding.table_index != table_index) {
 		throw InternalException("LogicalProjection::GetExpression - table index mismatch");
 	}
-	return *expressions[binding.column_index.index];
+	return *expressions[binding.column_index];
 }
 
 const Expression &LogicalProjection::GetExpression(ProjectionIndex proj_index) const {

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -424,10 +424,10 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 				JoinCondition cond(
 				    make_uniq<BoundColumnRefExpression>(
 				        correlated_columns[i].type,
-				        ColumnBinding(left_binding.table_index, ProjectionIndex(left_binding.column_index.index + i))),
+				        ColumnBinding(left_binding.table_index, ProjectionIndex(left_binding.column_index + i))),
 				    make_uniq<BoundColumnRefExpression>(
 				        correlated_columns[i].type,
-				        ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index.index + i))),
+				        ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + i))),
 				    ExpressionType::COMPARE_NOT_DISTINCT_FROM);
 				join->conditions.push_back(std::move(cond));
 			}
@@ -491,13 +491,13 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			auto &col = correlated_columns[i];
 			auto colref = make_uniq<BoundColumnRefExpression>(
 			    col.name, col.type,
-			    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index.index + i)));
+			    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + i)));
 			plan->expressions.push_back(std::move(colref));
 		}
 
 		base_binding.table_index = proj.table_index;
 		base_binding.column_index = ProjectionIndex(plan->expressions.size() - correlated_columns.size());
-		this->delim_offset = base_binding.column_index.index;
+		this->delim_offset = base_binding.column_index;
 		this->data_offset = 0;
 		return plan;
 	}
@@ -522,7 +522,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			auto &col = correlated_columns[i];
 			auto colref = make_uniq<BoundColumnRefExpression>(
 			    col.name, col.type,
-			    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index.index + i)));
+			    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + i)));
 			auto new_group_index = ColumnBinding::PushExpression(aggr.groups, std::move(colref));
 			for (auto &set : aggr.grouping_sets) {
 				set.insert(new_group_index);
@@ -539,7 +539,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 				auto first_aggregate = FirstFunctionGetter::GetFunction(col.type);
 				auto colref = make_uniq<BoundColumnRefExpression>(
 				    col.name, col.type,
-				    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index.index + i)));
+				    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + i)));
 				vector<unique_ptr<Expression>> aggr_children;
 				aggr_children.push_back(std::move(colref));
 				auto first_fun =
@@ -660,10 +660,10 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			JoinCondition cond(
 			    make_uniq<BoundColumnRefExpression>(
 			        correlated_columns[i].type,
-			        ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index.index + i))),
+			        ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + i))),
 			    make_uniq<BoundColumnRefExpression>(
 			        correlated_columns[i].type,
-			        ColumnBinding(right_binding.table_index, ProjectionIndex(right_binding.column_index.index + i))),
+			        ColumnBinding(right_binding.table_index, ProjectionIndex(right_binding.column_index + i))),
 			    ExpressionType::COMPARE_NOT_DISTINCT_FROM);
 			join->conditions.push_back(std::move(cond));
 		}
@@ -745,15 +745,14 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 
 				// add the correlated columns to the join conditions
 				for (idx_t i = 0; i < correlated_columns.size(); i++) {
-					JoinCondition cond(make_uniq<BoundColumnRefExpression>(
-					                       correlated_columns[i].type,
-					                       ColumnBinding(left_binding.table_index,
-					                                     ProjectionIndex(left_binding.column_index.index + i))),
-					                   make_uniq<BoundColumnRefExpression>(
-					                       correlated_columns[i].type,
-					                       ColumnBinding(right_binding.table_index,
-					                                     ProjectionIndex(right_binding.column_index.index + i))),
-					                   ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+					JoinCondition cond(
+					    make_uniq<BoundColumnRefExpression>(
+					        correlated_columns[i].type,
+					        ColumnBinding(left_binding.table_index, ProjectionIndex(left_binding.column_index + i))),
+					    make_uniq<BoundColumnRefExpression>(
+					        correlated_columns[i].type,
+					        ColumnBinding(right_binding.table_index, ProjectionIndex(right_binding.column_index + i))),
+					    ExpressionType::COMPARE_NOT_DISTINCT_FROM);
 
 					auto &comparison_join = join.Cast<LogicalComparisonJoin>();
 					comparison_join.conditions.push_back(std::move(cond));
@@ -795,10 +794,10 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		for (idx_t i = 0; i < correlated_columns.size(); i++) {
 			auto left = make_uniq<BoundColumnRefExpression>(
 			    correlated_columns[i].type,
-			    ColumnBinding(left_binding.table_index, ProjectionIndex(left_binding.column_index.index + i)));
+			    ColumnBinding(left_binding.table_index, ProjectionIndex(left_binding.column_index + i)));
 			auto right = make_uniq<BoundColumnRefExpression>(
 			    correlated_columns[i].type,
-			    ColumnBinding(right_binding.table_index, ProjectionIndex(right_binding.column_index.index + i)));
+			    ColumnBinding(right_binding.table_index, ProjectionIndex(right_binding.column_index + i)));
 
 			if (join.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
 			    join.type == LogicalOperatorType::LOGICAL_ASOF_JOIN) {
@@ -868,7 +867,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			auto &col = correlated_columns[i];
 			auto colref = make_uniq<BoundColumnRefExpression>(
 			    col.name, col.type,
-			    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index.index + i)));
+			    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + i)));
 			row_number->partitions.push_back(std::move(colref));
 		}
 		if (order_by) {
@@ -943,7 +942,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			for (idx_t i = 0; i < correlated_columns.size(); i++) {
 				w.partitions.push_back(make_uniq<BoundColumnRefExpression>(
 				    correlated_columns[i].type,
-				    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index.index + i))));
+				    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + i))));
 			}
 		}
 		return plan;
@@ -1012,7 +1011,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 		for (idx_t i = 0; i < correlated_columns.size(); i++) {
 			distinct.distinct_targets.push_back(make_uniq<BoundColumnRefExpression>(
 			    correlated_columns[i].type,
-			    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index.index + i))));
+			    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + i))));
 		}
 		return plan;
 	}
@@ -1030,7 +1029,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			for (auto &expr_list : expr_get.expressions) {
 				auto colref = make_uniq<BoundColumnRefExpression>(
 				    correlated_columns[i].type,
-				    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index.index + i)));
+				    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + i)));
 				expr_list.push_back(std::move(colref));
 			}
 			expr_get.expr_types.push_back(correlated_columns[i].type);
@@ -1102,7 +1101,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 					auto corr = correlated_columns[i];
 					auto colref = make_uniq<BoundColumnRefExpression>(
 					    correlated_columns[i].type,
-					    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index.index + i)));
+					    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + i)));
 					rec_cte.key_targets.push_back(std::move(colref));
 				}
 				rec_cte.internal_types.push_back(correlated_columns[i].type);

--- a/src/planner/subquery/rewrite_correlated_expressions.cpp
+++ b/src/planner/subquery/rewrite_correlated_expressions.cpp
@@ -38,8 +38,8 @@ void RewriteCorrelatedExpressions::VisitOperator(LogicalOperator &op) {
 		for (auto &corr : plan.correlated_columns) {
 			auto entry = correlated_map.find(corr.binding);
 			if (entry != correlated_map.end()) {
-				corr.binding = ColumnBinding(base_binding.table_index,
-				                             ProjectionIndex(base_binding.column_index.index + entry->second));
+				corr.binding =
+				    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + entry->second));
 			}
 		}
 	}
@@ -60,8 +60,7 @@ unique_ptr<Expression> RewriteCorrelatedExpressions::VisitReplace(BoundColumnRef
 	auto entry = correlated_map.find(expr.binding);
 	D_ASSERT(entry != correlated_map.end());
 
-	expr.binding =
-	    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index.index + entry->second));
+	expr.binding = ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + entry->second));
 	if (recursive_rewrite) {
 		D_ASSERT(expr.depth > 1);
 		expr.depth--;
@@ -109,8 +108,8 @@ void RewriteCorrelatedRecursive::VisitOperator(LogicalOperator &op) {
 		for (auto &corr : dep_join.correlated_columns) {
 			auto entry = correlated_map.find(corr.binding);
 			if (entry != correlated_map.end()) {
-				corr.binding = ColumnBinding(base_binding.table_index,
-				                             ProjectionIndex(base_binding.column_index.index + entry->second));
+				corr.binding =
+				    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + entry->second));
 			}
 		}
 	}
@@ -137,8 +136,8 @@ void RewriteCorrelatedRecursive::VisitExpression(unique_ptr<Expression> *express
 		if (entry != correlated_map.end()) {
 			// we found the column in the correlated map!
 			// update the binding and reduce the depth by 1
-			bound_colref.binding = ColumnBinding(base_binding.table_index,
-			                                     ProjectionIndex(base_binding.column_index.index + entry->second));
+			bound_colref.binding =
+			    ColumnBinding(base_binding.table_index, ProjectionIndex(base_binding.column_index + entry->second));
 			bound_colref.depth--;
 		}
 	} else if (expr.GetExpressionType() == ExpressionType::SUBQUERY) {

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -246,7 +246,7 @@ ColumnBinding TableBinding::GetColumnBinding(column_t column_index) {
 		}
 	}
 	// If it wasn't found, add it
-	if (binding.column_index.index == column_ids.size()) {
+	if (binding.column_index == column_ids.size()) {
 		column_ids.emplace_back(column_index);
 	}
 

--- a/src/planner/table_filter_set.cpp
+++ b/src/planner/table_filter_set.cpp
@@ -4,11 +4,11 @@
 namespace duckdb {
 
 TableFilterSet::ConstTableFilterIteratorEntry::ConstTableFilterIteratorEntry(
-    map<idx_t, unique_ptr<TableFilter>>::const_iterator it)
+    map<ProjectionIndex, unique_ptr<TableFilter>>::const_iterator it)
     : iterator(it) {
 }
 
-idx_t TableFilterSet::ConstTableFilterIteratorEntry::ColumnIndex() const {
+ProjectionIndex TableFilterSet::ConstTableFilterIteratorEntry::ColumnIndex() const {
 	return iterator->first;
 }
 
@@ -16,11 +16,12 @@ const TableFilter &TableFilterSet::ConstTableFilterIteratorEntry::Filter() const
 	return *iterator->second;
 }
 
-TableFilterSet::TableFilterIteratorEntry::TableFilterIteratorEntry(map<idx_t, unique_ptr<TableFilter>>::iterator it)
+TableFilterSet::TableFilterIteratorEntry::TableFilterIteratorEntry(
+    map<ProjectionIndex, unique_ptr<TableFilter>>::iterator it)
     : iterator(it) {
 }
 
-idx_t TableFilterSet::TableFilterIteratorEntry::ColumnIndex() const {
+ProjectionIndex TableFilterSet::TableFilterIteratorEntry::ColumnIndex() const {
 	return iterator->first;
 }
 
@@ -42,19 +43,22 @@ bool TableFilterSet::HasFilters() const {
 idx_t TableFilterSet::FilterCount() const {
 	return filters.size();
 }
-bool TableFilterSet::HasFilter(idx_t col_idx) const {
+bool TableFilterSet::HasFilter(ProjectionIndex col_idx) const {
 	return filters.find(col_idx) != filters.end();
 }
 
-const TableFilter &TableFilterSet::GetFilterByColumnIndex(idx_t col_idx) const {
+const TableFilter &TableFilterSet::GetFilterByColumnIndex(ProjectionIndex col_idx) const {
 	auto filter = TryGetFilterByColumnIndex(col_idx);
 	if (!filter) {
-		throw InternalException("Table filter set does not have a filter for column idx %d", col_idx);
+		throw InternalException("Table filter set does not have a filter for column idx %d", col_idx.index);
 	}
 	return *filter;
 }
 
-optional_ptr<const TableFilter> TableFilterSet::TryGetFilterByColumnIndex(idx_t col_idx) const {
+optional_ptr<const TableFilter> TableFilterSet::TryGetFilterByColumnIndex(ProjectionIndex col_idx) const {
+	if (!col_idx.IsValid()) {
+		throw InternalException("TableFilterSet::TryGetFilterByColumnIndex called with invalid column index");
+	}
 	auto entry = filters.find(col_idx);
 	if (entry == filters.end()) {
 		return nullptr;
@@ -62,15 +66,15 @@ optional_ptr<const TableFilter> TableFilterSet::TryGetFilterByColumnIndex(idx_t 
 	return *entry->second;
 }
 
-TableFilter &TableFilterSet::GetFilterByColumnIndexMutable(idx_t col_idx) {
+TableFilter &TableFilterSet::GetFilterByColumnIndexMutable(ProjectionIndex col_idx) {
 	auto filter = TryGetFilterByColumnIndexMutable(col_idx);
 	if (!filter) {
-		throw InternalException("Table filter set does not have a filter for column idx %d", col_idx);
+		throw InternalException("Table filter set does not have a filter for column idx %d", col_idx.index);
 	}
 	return *filter;
 }
 
-optional_ptr<TableFilter> TableFilterSet::TryGetFilterByColumnIndexMutable(idx_t col_idx) {
+optional_ptr<TableFilter> TableFilterSet::TryGetFilterByColumnIndexMutable(ProjectionIndex col_idx) {
 	auto entry = filters.find(col_idx);
 	if (entry == filters.end()) {
 		return nullptr;
@@ -78,11 +82,11 @@ optional_ptr<TableFilter> TableFilterSet::TryGetFilterByColumnIndexMutable(idx_t
 	return *entry->second;
 }
 
-void TableFilterSet::RemoveFilterByColumnIndex(idx_t col_idx) {
+void TableFilterSet::RemoveFilterByColumnIndex(ProjectionIndex col_idx) {
 	filters.erase(col_idx);
 }
 
-void TableFilterSet::SetFilterByColumnIndex(idx_t col_idx, unique_ptr<TableFilter> filter) {
+void TableFilterSet::SetFilterByColumnIndex(ProjectionIndex col_idx, unique_ptr<TableFilter> filter) {
 	filters[col_idx] = std::move(filter);
 }
 
@@ -124,12 +128,14 @@ unique_ptr<TableFilterSet> TableFilterSet::Copy() const {
 	return copy;
 }
 
-void TableFilterSet::PushFilter(const ColumnIndex &col_idx, unique_ptr<TableFilter> filter) {
-	auto column_index = col_idx.GetPrimaryIndex();
-	auto entry = filters.find(column_index);
+void TableFilterSet::PushFilter(ProjectionIndex col_idx, unique_ptr<TableFilter> filter) {
+	if (!col_idx.IsValid()) {
+		throw InternalException("Cannot push a filter over an invalid ProjectionIndex");
+	}
+	auto entry = filters.find(col_idx);
 	if (entry == filters.end()) {
 		// no filter yet: push the filter directly
-		filters[column_index] = std::move(filter);
+		filters[col_idx] = std::move(filter);
 	} else {
 		// there is already a filter: AND it together
 		if (entry->second->filter_type == TableFilterType::CONJUNCTION_AND) {
@@ -139,7 +145,7 @@ void TableFilterSet::PushFilter(const ColumnIndex &col_idx, unique_ptr<TableFilt
 			auto and_filter = make_uniq<ConjunctionAndFilter>();
 			and_filter->child_filters.push_back(std::move(entry->second));
 			and_filter->child_filters.push_back(std::move(filter));
-			filters[column_index] = std::move(and_filter);
+			filters[col_idx] = std::move(and_filter);
 		}
 	}
 }
@@ -161,8 +167,7 @@ void DynamicTableFilterSet::PushFilter(const PhysicalOperator &op, ProjectionInd
 	} else {
 		filter_ptr = entry->second.get();
 	}
-	// FIXME: this is weird - converting between ProjectionIndex and ColumnIndex indicates a likely bug
-	filter_ptr->PushFilter(ColumnIndex(column_index.index), std::move(filter));
+	filter_ptr->PushFilter(column_index, std::move(filter));
 }
 
 bool DynamicTableFilterSet::HasFilters() const {
@@ -178,12 +183,12 @@ DynamicTableFilterSet::GetFinalTableFilters(const PhysicalTableScan &scan,
 	auto result = make_uniq<TableFilterSet>();
 	if (existing_filters) {
 		for (auto &filter_entry : *existing_filters) {
-			result->PushFilter(ColumnIndex(filter_entry.ColumnIndex()), filter_entry.Filter().Copy());
+			result->PushFilter(filter_entry.ColumnIndex(), filter_entry.Filter().Copy());
 		}
 	}
 	for (auto &entry : filters) {
 		for (auto &filter_entry : *entry.second) {
-			result->PushFilter(ColumnIndex(filter_entry.ColumnIndex()), filter_entry.Filter().Copy());
+			result->PushFilter(filter_entry.ColumnIndex(), filter_entry.Filter().Copy());
 		}
 	}
 	if (!result->HasFilters()) {

--- a/src/planner/table_filter_set.cpp
+++ b/src/planner/table_filter_set.cpp
@@ -8,7 +8,7 @@ TableFilterSet::ConstTableFilterIteratorEntry::ConstTableFilterIteratorEntry(
     : iterator(it) {
 }
 
-ProjectionIndex TableFilterSet::ConstTableFilterIteratorEntry::ColumnIndex() const {
+ProjectionIndex TableFilterSet::ConstTableFilterIteratorEntry::GetIndex() const {
 	return iterator->first;
 }
 
@@ -21,7 +21,7 @@ TableFilterSet::TableFilterIteratorEntry::TableFilterIteratorEntry(
     : iterator(it) {
 }
 
-ProjectionIndex TableFilterSet::TableFilterIteratorEntry::ColumnIndex() const {
+ProjectionIndex TableFilterSet::TableFilterIteratorEntry::GetIndex() const {
 	return iterator->first;
 }
 
@@ -50,7 +50,7 @@ bool TableFilterSet::HasFilter(ProjectionIndex col_idx) const {
 const TableFilter &TableFilterSet::GetFilterByColumnIndex(ProjectionIndex col_idx) const {
 	auto filter = TryGetFilterByColumnIndex(col_idx);
 	if (!filter) {
-		throw InternalException("Table filter set does not have a filter for column idx %d", col_idx.index);
+		throw InternalException("Table filter set does not have a filter for column idx %d", col_idx);
 	}
 	return *filter;
 }
@@ -69,7 +69,7 @@ optional_ptr<const TableFilter> TableFilterSet::TryGetFilterByColumnIndex(Projec
 TableFilter &TableFilterSet::GetFilterByColumnIndexMutable(ProjectionIndex col_idx) {
 	auto filter = TryGetFilterByColumnIndexMutable(col_idx);
 	if (!filter) {
-		throw InternalException("Table filter set does not have a filter for column idx %d", col_idx.index);
+		throw InternalException("Table filter set does not have a filter for column idx %d", col_idx);
 	}
 	return *filter;
 }
@@ -183,12 +183,12 @@ DynamicTableFilterSet::GetFinalTableFilters(const PhysicalTableScan &scan,
 	auto result = make_uniq<TableFilterSet>();
 	if (existing_filters) {
 		for (auto &filter_entry : *existing_filters) {
-			result->PushFilter(filter_entry.ColumnIndex(), filter_entry.Filter().Copy());
+			result->PushFilter(filter_entry.GetIndex(), filter_entry.Filter().Copy());
 		}
 	}
 	for (auto &entry : filters) {
 		for (auto &filter_entry : *entry.second) {
-			result->PushFilter(filter_entry.ColumnIndex(), filter_entry.Filter().Copy());
+			result->PushFilter(filter_entry.GetIndex(), filter_entry.Filter().Copy());
 		}
 	}
 	if (!result->HasFilters()) {

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -706,12 +706,12 @@ TableColumn TableColumn::Deserialize(Deserializer &deserializer) {
 }
 
 void TableFilterSet::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<map<idx_t, unique_ptr<TableFilter>>>(100, "filters", filters);
+	serializer.WritePropertyWithDefault<map<ProjectionIndex, unique_ptr<TableFilter>>>(100, "filters", filters);
 }
 
 TableFilterSet TableFilterSet::Deserialize(Deserializer &deserializer) {
 	TableFilterSet result;
-	deserializer.ReadPropertyWithDefault<map<idx_t, unique_ptr<TableFilter>>>(100, "filters", result.filters);
+	deserializer.ReadPropertyWithDefault<map<ProjectionIndex, unique_ptr<TableFilter>>>(100, "filters", result.filters);
 	return result;
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -546,7 +546,7 @@ bool RowGroup::CheckZonemapSegments(CollectionScanState &state) {
 			// filter is always true - avoid checking
 			continue;
 		}
-		auto column_idx = entry.scan_column_index.index;
+		auto column_idx = entry.scan_column_index;
 		auto base_column_idx = entry.table_column_index;
 		auto &filter = entry.filter;
 
@@ -673,21 +673,21 @@ void RowGroup::Scan(ScanOptions options, CollectionScanState &state, DataChunk &
 					const auto scan_idx = filter.scan_column_index;
 					const auto column_idx = filter.table_column_index;
 
-					auto &result_vector = result.data[scan_idx.index];
+					auto &result_vector = result.data[scan_idx];
 					if (approved_tuple_count == 0) {
 						auto &col_data = GetColumn(column_idx);
-						col_data.Skip(state.column_scans[scan_idx.index]);
+						col_data.Skip(state.column_scans[scan_idx]);
 						continue;
 					}
 					auto &col_data = GetColumn(column_idx);
-					col_data.Filter(transaction, state.vector_index, state.column_scans[scan_idx.index], result_vector,
-					                sel, approved_tuple_count, filter.filter, table_filter_state);
+					col_data.Filter(transaction, state.vector_index, state.column_scans[scan_idx], result_vector, sel,
+					                approved_tuple_count, filter.filter, table_filter_state);
 				}
 				for (auto &table_filter : filter_list) {
 					if (table_filter.IsAlwaysTrue()) {
 						continue;
 					}
-					result.data[table_filter.scan_column_index.index].Slice(sel, approved_tuple_count);
+					result.data[table_filter.scan_column_index].Slice(sel, approved_tuple_count);
 				}
 			}
 			if (approved_tuple_count == 0) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -546,7 +546,7 @@ bool RowGroup::CheckZonemapSegments(CollectionScanState &state) {
 			// filter is always true - avoid checking
 			continue;
 		}
-		auto column_idx = entry.scan_column_index;
+		auto column_idx = entry.scan_column_index.index;
 		auto base_column_idx = entry.table_column_index;
 		auto &filter = entry.filter;
 
@@ -673,21 +673,21 @@ void RowGroup::Scan(ScanOptions options, CollectionScanState &state, DataChunk &
 					const auto scan_idx = filter.scan_column_index;
 					const auto column_idx = filter.table_column_index;
 
-					auto &result_vector = result.data[scan_idx];
+					auto &result_vector = result.data[scan_idx.index];
 					if (approved_tuple_count == 0) {
 						auto &col_data = GetColumn(column_idx);
-						col_data.Skip(state.column_scans[scan_idx]);
+						col_data.Skip(state.column_scans[scan_idx.index]);
 						continue;
 					}
 					auto &col_data = GetColumn(column_idx);
-					col_data.Filter(transaction, state.vector_index, state.column_scans[scan_idx], result_vector, sel,
+					col_data.Filter(transaction, state.vector_index, state.column_scans[scan_idx.index], result_vector, sel,
 					                approved_tuple_count, filter.filter, table_filter_state);
 				}
 				for (auto &table_filter : filter_list) {
 					if (table_filter.IsAlwaysTrue()) {
 						continue;
 					}
-					result.data[table_filter.scan_column_index].Slice(sel, approved_tuple_count);
+					result.data[table_filter.scan_column_index.index].Slice(sel, approved_tuple_count);
 				}
 			}
 			if (approved_tuple_count == 0) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -680,8 +680,8 @@ void RowGroup::Scan(ScanOptions options, CollectionScanState &state, DataChunk &
 						continue;
 					}
 					auto &col_data = GetColumn(column_idx);
-					col_data.Filter(transaction, state.vector_index, state.column_scans[scan_idx.index], result_vector, sel,
-					                approved_tuple_count, filter.filter, table_filter_state);
+					col_data.Filter(transaction, state.vector_index, state.column_scans[scan_idx.index], result_vector,
+					                sel, approved_tuple_count, filter.filter, table_filter_state);
 				}
 				for (auto &table_filter : filter_list) {
 					if (table_filter.IsAlwaysTrue()) {

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -47,7 +47,8 @@ ScanSamplingInfo &TableScanState::GetSamplingInfo() {
 	return sampling_info;
 }
 
-ScanFilter::ScanFilter(ClientContext &context, ProjectionIndex index, const vector<StorageIndex> &column_ids, TableFilter &filter)
+ScanFilter::ScanFilter(ClientContext &context, ProjectionIndex index, const vector<StorageIndex> &column_ids,
+                       TableFilter &filter)
     : scan_column_index(index), table_column_index(column_ids[index.index]), filter(filter), always_true(false) {
 	filter_state = TableFilterState::Initialize(context, filter);
 }
@@ -62,7 +63,7 @@ void ScanFilterInfo::Initialize(ClientContext &context, TableFilterSet &filters,
 		filter_list.emplace_back(context, entry.ColumnIndex(), column_ids, entry.Filter());
 	}
 	column_has_filter.reserve(column_ids.size());
-	for(auto col_idx : ProjectionIndex::GetIndexes(column_ids.size())) {
+	for (auto col_idx : ProjectionIndex::GetIndexes(column_ids.size())) {
 		bool has_filter = table_filters->HasFilter(col_idx);
 		column_has_filter.push_back(has_filter);
 	}

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -49,7 +49,7 @@ ScanSamplingInfo &TableScanState::GetSamplingInfo() {
 
 ScanFilter::ScanFilter(ClientContext &context, ProjectionIndex index, const vector<StorageIndex> &column_ids,
                        TableFilter &filter)
-    : scan_column_index(index), table_column_index(column_ids[index.index]), filter(filter), always_true(false) {
+    : scan_column_index(index), table_column_index(column_ids[index]), filter(filter), always_true(false) {
 	filter_state = TableFilterState::Initialize(context, filter);
 }
 
@@ -60,7 +60,7 @@ void ScanFilterInfo::Initialize(ClientContext &context, TableFilterSet &filters,
 	adaptive_filter = make_uniq<AdaptiveFilter>(filters);
 	filter_list.reserve(filters.FilterCount());
 	for (auto &entry : filters) {
-		filter_list.emplace_back(context, entry.ColumnIndex(), column_ids, entry.Filter());
+		filter_list.emplace_back(context, entry.GetIndex(), column_ids, entry.Filter());
 	}
 	column_has_filter.reserve(column_ids.size());
 	for (auto col_idx : ProjectionIndex::GetIndexes(column_ids.size())) {
@@ -105,7 +105,7 @@ void ScanFilterInfo::SetFilterAlwaysTrue(idx_t filter_idx) {
 		return;
 	}
 	filter.always_true = true;
-	column_has_filter[filter.scan_column_index.index] = false;
+	column_has_filter[filter.scan_column_index] = false;
 	always_true_filters++;
 }
 

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -47,8 +47,8 @@ ScanSamplingInfo &TableScanState::GetSamplingInfo() {
 	return sampling_info;
 }
 
-ScanFilter::ScanFilter(ClientContext &context, idx_t index, const vector<StorageIndex> &column_ids, TableFilter &filter)
-    : scan_column_index(index), table_column_index(column_ids[index]), filter(filter), always_true(false) {
+ScanFilter::ScanFilter(ClientContext &context, ProjectionIndex index, const vector<StorageIndex> &column_ids, TableFilter &filter)
+    : scan_column_index(index), table_column_index(column_ids[index.index]), filter(filter), always_true(false) {
 	filter_state = TableFilterState::Initialize(context, filter);
 }
 
@@ -62,7 +62,7 @@ void ScanFilterInfo::Initialize(ClientContext &context, TableFilterSet &filters,
 		filter_list.emplace_back(context, entry.ColumnIndex(), column_ids, entry.Filter());
 	}
 	column_has_filter.reserve(column_ids.size());
-	for (idx_t col_idx = 0; col_idx < column_ids.size(); col_idx++) {
+	for(auto col_idx : ProjectionIndex::GetIndexes(column_ids.size())) {
 		bool has_filter = table_filters->HasFilter(col_idx);
 		column_has_filter.push_back(has_filter);
 	}
@@ -104,7 +104,7 @@ void ScanFilterInfo::SetFilterAlwaysTrue(idx_t filter_idx) {
 		return;
 	}
 	filter.always_true = true;
-	column_has_filter[filter.scan_column_index] = false;
+	column_has_filter[filter.scan_column_index.index] = false;
 	always_true_filters++;
 }
 

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -729,26 +729,19 @@ public:
 		auto expr = make_uniq<BoundFunctionExpression>(LogicalType::BOOLEAN, func, std::move(children),
 		                                               make_uniq<RowIdFilterBindData>(vector<int64_t> {3, 4, 5, 7, 9}));
 
-		// Push the filter on the ROW_ID column
-		get.table_filters.PushFilter(ColumnIndex(COLUMN_IDENTIFIER_ROW_ID),
-		                             make_uniq<ExpressionFilter>(std::move(expr)));
-
 		// Ensure ROW_ID is in the scan's column list
-		bool has_rowid = false;
-		for (auto &col : get.GetColumnIds()) {
-			if (col.IsRowIdColumn()) {
-				has_rowid = true;
-				break;
-			}
-		}
-		if (!has_rowid) {
+		auto row_id_index = get.TryGetProjectionIndex(COLUMN_IDENTIFIER_ROW_ID);
+		if (!row_id_index.IsValid()) {
 			if (get.projection_ids.empty()) {
 				for (idx_t i = 0; i < get.GetColumnIds().size(); i++) {
 					get.projection_ids.emplace_back(i);
 				}
 			}
-			get.AddColumnId(COLUMN_IDENTIFIER_ROW_ID);
+			row_id_index = get.AddColumnId(COLUMN_IDENTIFIER_ROW_ID);
 		}
+
+		// Push the filter on the ROW_ID column
+		get.table_filters.PushFilter(row_id_index, make_uniq<ExpressionFilter>(std::move(expr)));
 	}
 };
 


### PR DESCRIPTION
The `TableFilterSet` was initially defined as using an `idx_t` for the column index. However, this `idx_t` had different meanings at different phases in the plan, which was very confusing:

```sql
CREATE TABLE tbl(a INT, b INT, c INT);
SELECT a FROM tbl WHERE c=42; -- projections: [c, a]
```

* In the LogicalPlan, the `idx_t` referred to the **absolute column index**, i.e. the column index in the base table. In the above example, `c` is the third column in the table, so `idx_t` would be `2`.
* In the PhysicalPlan, the `idx_t` referred to a **projection index**, i.e. an index within the list of projected columns (`column_ids`). In the above example, `c` is the first projected column, so `idx_t` would be `0`.

This transformation was explicitly done in `CreateTableFilterSet` in `plan_get.cpp`.

Making the same `idx_t` refer to different indexes in different parts of the plan is confusing - and now that we have the `ProjectionIndex` class (introduced in https://github.com/duckdb/duckdb/pull/21313) - we want to move away from using `idx_t` for these types of indexes in general.

Another complication of the previous approach besides just being confusing, is that `ColumnIndex` is now much more involved. While in the past this was just an `idx_t` as well, `ColumnIndex` can now refer to more complex projections (such as projection pushdowns that reach deep into variants or structs). As such, during the planning phase, a simple `idx_t` is not enough to capture these types of projections. Because of this, we could not push filters on these types of projections.

This PR unifies the filters in the `TableFilterSet` to always use a `ProjectionIndex`. The various API methods directly take or emit a `ProjectionIndex`. By making the filter refer to a projection index, we can also much more easily enable filters on projection pushdown (in a follow-up PR). There's two complications that are necessary to enable this:

* During `RemoveUnusedColumns`, the `ProjectionIndex` can change when we remove columns. For that reason we need to adjust the `ProjectionIndex` also in the `TableFilterSet` during this stage.
* In Iceberg/Delta, the `TableFilterSet` was used with absolute column indexes. We cannot easily change these filter sets to use projection indexes, as the projection index might be different during different parts of the plan (i.e. during filter pushdown we might get a different projection index than during execution for the same column - due to unused columns being pruned). We solve this by adding an `IcebergTableFilters / DeltaTableFilters` class that keep the old semantics. 