### PR TITLE
fix: correct off-by-one in date_part statistics bounds

### DIFF
--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -338,7 +338,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<1, 54>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<1, 53>(input.child_stats);
 		}
 	};
 
@@ -427,7 +427,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60000000000>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59999999999>(input.child_stats);
 		}
 	};
 
@@ -439,7 +439,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60000000>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59999999>(input.child_stats);
 		}
 	};
 
@@ -451,7 +451,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60000>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59999>(input.child_stats);
 		}
 	};
 
@@ -463,7 +463,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59>(input.child_stats);
 		}
 	};
 
@@ -475,7 +475,7 @@ struct DatePart {
 
 		template <class T>
 		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
-			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
+			return PropagateSimpleDatePartStatistics<0, 59>(input.child_stats);
 		}
 	};
 

--- a/test/sql/function/date/date_part_stats.test
+++ b/test/sql/function/date/date_part_stats.test
@@ -107,19 +107,19 @@ CREATE TABLE expected_result AS FROM (VALUES
 	('decade', 199, 200),
 	('century', 20, 20),
 	('millenium', 2, 2),
-	('microseconds', 0, 60000000),
-	('milliseconds', 0, 60000),
-	('second', 0, 60),
-	('minute', 0, 60),
+	('microseconds', 0, 59999999),
+	('milliseconds', 0, 59999),
+	('second', 0, 59),
+	('minute', 0, 59),
 	('hour', 0, 24),
 	('dow', 0, 6),
-	('week', 1, 54),
+	('week', 1, 53),
 	('doy', 1, 366),
 	('quarter', 1, 4),
 	('yearweek', 199201, 200052),
 	('dayofmonth', 1, 31),
 	('weekday', 0, 6),
-	('weekofyear', 1, 54)
+	('weekofyear', 1, 53)
 	) t(component, min, max)
 
 foreach component year month day decade century millenium microseconds milliseconds second minute hour dow week doy quarter yearweek dayofmonth weekday weekofyear


### PR DESCRIPTION
## Summary
Fixes #21478.
**Root cause:** `PropagateStatistics` used exclusive upper bounds (max+1) for several date_part components: week (54 vs 53), minute (60 vs 59), second (60 vs 59), millisecond (60000 vs 59999), microsecond (60000000 vs 59999999), nanosecond (60000000000 vs 59999999999). This prevented the optimizer from pruning impossible filters.
**Fix:** Corrected the upper bounds to use inclusive max values.
## Changes
- `extension/core_functions/scalar/date/date_part.cpp`: Updated statistics bounds for week, minute, second, millisecond, microsecond, and nanosecond date parts
- `test/sql/function/date/date_part_stats.test`: Updated expected values to match corrected bounds
## Testing
- Verified fix addresses reported off-by-one behavior
- Change is minimal (constant value corrections)

Made with [Cursor](https://cursor.com)