### PR TITLE
Correctly revert dictionary size when reverting string appends

### DIFF
--- a/src/include/duckdb/storage/string_uncompressed.hpp
+++ b/src/include/duckdb/storage/string_uncompressed.hpp
@@ -192,6 +192,31 @@ public:
 		return count;
 	}
 
+	static void StringRevertAppend(ColumnSegment &segment, idx_t new_count) {
+		if (new_count >= segment.count) {
+			return;
+		}
+		// we need to decrement the dictionary size by all of the strings we are erasing
+		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+		auto handle = buffer_manager.Pin(segment.block);
+		auto handle_ptr = handle.Ptr();
+		auto result_data = reinterpret_cast<int32_t *>(handle_ptr + DICTIONARY_HEADER_SIZE);
+		auto dictionary_size = reinterpret_cast<uint32_t *>(handle_ptr);
+		uint32_t new_dictionary_size;
+		if (new_count == 0) {
+			new_dictionary_size = 0;
+		} else {
+			auto entry_offset = result_data[new_count - 1];
+			if (entry_offset < 0) {
+				// overflow strings store the dict offset negatively - invert size
+				new_dictionary_size = -entry_offset;
+			} else {
+				new_dictionary_size = entry_offset;
+			}
+		}
+		*dictionary_size = new_dictionary_size;
+	}
+
 	static idx_t FinalizeAppend(ColumnSegment &segment, SegmentStatistics &stats);
 
 public:

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -269,17 +269,18 @@ void UncompressedStringStorage::VisitBlockIds(const ColumnSegment &segment, Bloc
 //===--------------------------------------------------------------------===//
 CompressionFunction StringUncompressed::GetFunction(PhysicalType data_type) {
 	D_ASSERT(data_type == PhysicalType::VARCHAR);
-	return CompressionFunction(
-	    CompressionType::COMPRESSION_UNCOMPRESSED, data_type, UncompressedStringStorage::StringInitAnalyze,
-	    UncompressedStringStorage::StringAnalyze, UncompressedStringStorage::StringFinalAnalyze,
-	    UncompressedFunctions::InitCompression, UncompressedFunctions::Compress,
-	    UncompressedFunctions::FinalizeCompress, UncompressedStringStorage::StringInitScan,
-	    UncompressedStringStorage::StringScan, UncompressedStringStorage::StringScanPartial,
-	    UncompressedStringStorage::StringFetchRow, UncompressedFunctions::EmptySkip,
-	    UncompressedStringStorage::StringInitSegment, UncompressedStringStorage::StringInitAppend,
-	    UncompressedStringStorage::StringAppend, UncompressedStringStorage::FinalizeAppend, nullptr,
-	    UncompressedStringStorage::SerializeState, UncompressedStringStorage::DeserializeState,
-	    UncompressedStringStorage::VisitBlockIds, UncompressedStringInitPrefetch, UncompressedStringStorage::Select);
+	return CompressionFunction(CompressionType::COMPRESSION_UNCOMPRESSED, data_type,
+	                           UncompressedStringStorage::StringInitAnalyze, UncompressedStringStorage::StringAnalyze,
+	                           UncompressedStringStorage::StringFinalAnalyze, UncompressedFunctions::InitCompression,
+	                           UncompressedFunctions::Compress, UncompressedFunctions::FinalizeCompress,
+	                           UncompressedStringStorage::StringInitScan, UncompressedStringStorage::StringScan,
+	                           UncompressedStringStorage::StringScanPartial, UncompressedStringStorage::StringFetchRow,
+	                           UncompressedFunctions::EmptySkip, UncompressedStringStorage::StringInitSegment,
+	                           UncompressedStringStorage::StringInitAppend, UncompressedStringStorage::StringAppend,
+	                           UncompressedStringStorage::FinalizeAppend, UncompressedStringStorage::StringRevertAppend,
+	                           UncompressedStringStorage::SerializeState, UncompressedStringStorage::DeserializeState,
+	                           UncompressedStringStorage::VisitBlockIds, UncompressedStringInitPrefetch,
+	                           UncompressedStringStorage::Select);
 }
 
 //===--------------------------------------------------------------------===//


### PR DESCRIPTION
When appending to the uncompressed string storage, we increment the dictionary size. However, currently we don't decrement this size when reverting an append (caused by a primary key conflict). This can cause the dictionary to contain strings that are no longer referenced by the table. This is not specifically a problem (other than wasting space) - but we rely on these offsets to compute string lengths. As such, newly inserted strings will incorrectly also contain the previously reverted strings. 
