### PR TITLE
Fix parsing test path to skip

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -247,7 +247,7 @@ bool TestConfiguration::ShouldSkipTest(const string &test_name) {
 	if (test_name.find('/') == 0) {
 		// Full path specified, strip down to base path so the extension config lookup still works
 		auto pos = test_name.find("test/sql");
-		if (pos != string : npos) {
+		if (pos != string::npos) {
 			const string stripped_test_name = test_name.c_str() + pos;
 			return tests_to_be_skipped.count(stripped_test_name);
 		}

--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -246,8 +246,11 @@ TestConfiguration::ExtensionAutoLoadingMode TestConfiguration::GetExtensionAutoL
 bool TestConfiguration::ShouldSkipTest(const string &test_name) {
 	if (test_name.find('/') == 0) {
 		// Full path specified, strip down to base path so the extension config lookup still works
-		const string stripped_test_name = test_name.c_str() + test_name.find("test/sql");
-		return tests_to_be_skipped.count(stripped_test_name);
+		auto pos = test_name.find("test/sql");
+		if (pos != string : npos) {
+			const string stripped_test_name = test_name.c_str() + pos;
+			return tests_to_be_skipped.count(stripped_test_name);
+		}
 	}
 	return tests_to_be_skipped.count(test_name);
 }


### PR DESCRIPTION
TestConfiguration::ShouldSkipTest assumes tests start with "test/sql", which is not always the case for extensions with their own testing paths. `test_name.c_str() + test_name.find("test/sql");` can be an overflow if `test_name.find("test/sql")` returns npos. This PR checks whether the prefix contains "test/sql", then strips the path. 