### PR TITLE
ci: add riscv64 to Linux CLI release builds

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -52,6 +52,11 @@ jobs:
         python3 -m pip install pytest
 
     - uses: ./.github/actions/ccache-action
+      if: matrix.config.arch != 'riscv64'
+
+    - name: Install ccache for riscv64
+      if: matrix.config.arch == 'riscv64'
+      run: sudo apt-get update && sudo apt-get install -y ccache
 
     - name: Build
       run: |

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -54,18 +54,21 @@ jobs:
     - uses: ./.github/actions/ccache-action
       if: matrix.config.arch != 'riscv64'
 
-    - name: Install ccache for riscv64
-      if: matrix.config.arch == 'riscv64'
-      run: sudo apt-get update && sudo apt-get install -y ccache
-
     - name: Build
       run: |
         export PWD=`pwd`
+        if [ "${{ matrix.config.arch }}" = "riscv64" ]; then
+          CC_CMD="gcc"
+          CXX_CMD="g++"
+        else
+          CC_CMD="ccache gcc"
+          CXX_CMD="ccache g++"
+        fi
         docker run                                                             \
         -v$PWD:$PWD                                                            \
         -e GEN=ninja                                                           \
-        -e CC='ccache gcc'                                                     \
-        -e CXX='ccache g++'                                                    \
+        -e CC="$CC_CMD"                                                        \
+        -e CXX="$CXX_CMD"                                                     \
         -e CCACHE_DIR=$PWD/.ccache                                             \
         -e OVERRIDE_GIT_DESCRIBE=$OVERRIDE_GIT_DESCRIBE                        \
         -e EXTENSION_CONFIGS="$PWD/.github/config/bundled_extensions.cmake"    \
@@ -77,10 +80,10 @@ jobs:
         bash -c "
           set -e
           cat /etc/os-release
-          dnf install -y \
-            ccache       \
-            ninja-build  \
-            perl-IPC-Cmd
+          if command -v dnf &> /dev/null; then
+            dnf install -y ninja-build perl-IPC-Cmd
+            dnf install -y ccache || true
+          fi
           git config --global --add safe.directory $PWD
           make -C $PWD
         "

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: ${{ fromJson(github.event_name == 'pull_request' && '[{"runner":"ubuntu-latest","arch":"amd64","image":"x86_64"}]' || '[{"runner":"ubuntu-latest","arch":"amd64","image":"x86_64"},{"runner":"ubuntu-24.04-arm","arch":"arm64","image":"aarch64"}]') }}
+        config: ${{ fromJson(github.event_name == 'pull_request' && '[{"runner":"ubuntu-latest","arch":"amd64","image":"manylinux_2_28_x86_64"}]' || '[{"runner":"ubuntu-latest","arch":"amd64","image":"manylinux_2_28_x86_64"},{"runner":"ubuntu-24.04-arm","arch":"arm64","image":"manylinux_2_28_aarch64"},{"runner":"ubuntu-24.04-riscv","arch":"riscv64","image":"manylinux_2_39_riscv64"}]') }}
 
     name: Linux CLI (${{ matrix.config.arch }})
     runs-on: ${{ matrix.config.runner }}
@@ -68,7 +68,7 @@ jobs:
         -e ENABLE_EXTENSION_AUTOINSTALL=1                                      \
         -e BUILD_BENCHMARK=1                                                   \
         -e FORCE_WARN_UNUSED=1                                                 \
-        quay.io/pypa/manylinux_2_28_${{ matrix.config.image }}                 \
+        quay.io/pypa/${{ matrix.config.image }}                                \
         bash -c "
           set -e
           cat /etc/os-release


### PR DESCRIPTION
## Summary

Add riscv64 to the Linux CLI release build matrix using native [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners) and `manylinux_2_39` Docker image.

## Changes

- **`.github/workflows/LinuxRelease.yml`**: Add `{"runner":"ubuntu-24.04-riscv","arch":"riscv64","image":"manylinux_2_39_riscv64"}` to the CLI release matrix
- Refactored Docker image reference from hardcoded `manylinux_2_28_` prefix to full image name in matrix, allowing different manylinux versions per architecture (manylinux_2_28 has no riscv64 support)

## Evidence

- DuckDB C++ native build on BananaPi F3 (SpacemiT K1, rv64gc, GCC 14.2.0): **SUCCESS** (~2h)
- Query execution verified: `SELECT 'Hello from RISC-V!' AS message;` → works
- DuckDB Python wheel building on F3 (in progress)

## CI Runners

Native riscv64 runners provided by [RISE](https://github.com/apps/rise-risc-v-runners) (free for open source). Already used by numpy, llama.cpp, pytorch.

Fixes #21494

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve software ecosystem support on riscv64 platforms.