### PR TITLE
Enable filters on pushdown extract

### DIFF
--- a/benchmark/tpch/variant/variant_filter_pushdown.benchmark
+++ b/benchmark/tpch/variant/variant_filter_pushdown.benchmark
@@ -1,22 +1,22 @@
-# name: benchmark/tpch/variant/tpch_q1_variant.benchmark
+# name: benchmark/tpch/variant/variant_filter_pushdown.benchmark
 # description: Run Q01 over lineitem stored in variants
 # group: [variant]
 
 name Q01 variants
-group tpch
+group variant
 subgroup sf1
 storage persistent v1.5.0
 
 require tpch
 
-cache tpch_variant_sf1.duckdb
+cache tpch_variant_sf1_ordered.duckdb
 
 load
 CALL dbgen(sf=1, suffix='_normalized');
 SET variant_minimum_shredding_size = 0;
 create table lineitem_variant as select
 	struct_pack(*COLUMNS(lineitem_normalized.*))::VARIANT lineitem
-from lineitem_normalized;
+from lineitem_normalized ORDER BY l_shipdate;
 checkpoint;
 CREATE VIEW lineitem AS SELECT
 	lineitem.l_orderkey::DECIMAL(15,2) l_orderkey,
@@ -38,6 +38,8 @@ CREATE VIEW lineitem AS SELECT
 FROM
 	lineitem_variant
 
-run extension/tpch/dbgen/queries/q01.sql
+run
+SELECT COUNT(*) FROM lineitem WHERE l_shipdate='1993-01-01'
 
-result extension/tpch/dbgen/answers/sf1/q01.csv
+result I
+2431

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library_unity(
   bind_helpers.cpp
   box_renderer.cpp
   cgroups.cpp
+  column_index.cpp
   csv_writer.cpp
   complex_json.cpp
   compressed_file_system.cpp

--- a/src/common/column_index.cpp
+++ b/src/common/column_index.cpp
@@ -124,13 +124,16 @@ string ColumnIndex::GetName(const string &column_name) const {
 	if (index_type != ColumnIndexType::PUSHDOWN_EXTRACT) {
 		return column_name;
 	}
-	auto current_name = column_name + ".";
-	if (has_index) {
-		current_name += StructType::GetChildName(type, index);
+	D_ASSERT(child_indexes.size() == 1);
+	auto &child = child_indexes[0];
+	string current_name = column_name + ".";
+	if (child.HasPrimaryIndex()) {
+		//! 'type' is the parent struct type at this level; child.GetPrimaryIndex() is the field's index within it
+		current_name += StructType::GetChildName(type, child.GetPrimaryIndex());
 	} else {
-		current_name += field;
+		current_name += child.GetFieldName();
 	}
-	return child_indexes[0].GetName(current_name);
+	return child.GetName(current_name);
 }
 
 } // namespace duckdb

--- a/src/common/column_index.cpp
+++ b/src/common/column_index.cpp
@@ -1,0 +1,136 @@
+#include "duckdb/common/column_index.hpp"
+
+namespace duckdb {
+
+void ColumnIndex::SetPushdownExtractType(const LogicalType &type_information,
+                                         optional_ptr<const LogicalType> cast_type) {
+	//! We can upgrade the optional prune hint to a PUSHDOWN_EXTRACT, which is no longer optional
+	index_type = ColumnIndexType::PUSHDOWN_EXTRACT;
+	type = type_information;
+	D_ASSERT(child_indexes.size() == 1);
+
+	auto &child = child_indexes[0];
+	if (child.HasPrimaryIndex()) {
+		auto &child_types = StructType::GetChildTypes(type);
+		auto &child_type = child_types[child.GetPrimaryIndex()].second;
+		if (child.child_indexes.empty()) {
+			if (cast_type) {
+				child.SetType(*cast_type);
+			} else {
+				child.SetType(child_type);
+			}
+		} else {
+			child.SetPushdownExtractType(child_type, cast_type);
+		}
+	} else {
+		D_ASSERT(type_information.id() == LogicalTypeId::VARIANT);
+		if (child.child_indexes.empty()) {
+			if (cast_type) {
+				child.SetType(*cast_type);
+			} else {
+				//! Without a cast, the child will always be VARIANT
+				child.SetType(type_information);
+			}
+		} else {
+			child.SetPushdownExtractType(type_information, cast_type);
+		}
+	}
+}
+const LogicalType &ColumnIndex::GetScanType() const {
+	D_ASSERT(HasType());
+	if (IsPushdownExtract()) {
+		return child_indexes[0].GetScanType();
+	}
+	return GetType();
+}
+const LogicalType &ColumnIndex::GetType() const {
+	D_ASSERT(type.id() != LogicalTypeId::INVALID);
+	return type;
+}
+void ColumnIndex::AddChildIndex(ColumnIndex new_index) {
+	this->child_indexes.push_back(std::move(new_index));
+}
+bool ColumnIndex::IsRowIdColumn() const {
+	if (!has_index) {
+		return false;
+	}
+	return index == COLUMN_IDENTIFIER_ROW_ID;
+}
+bool ColumnIndex::IsEmptyColumn() const {
+	if (!has_index) {
+		return false;
+	}
+	return index == COLUMN_IDENTIFIER_EMPTY;
+}
+bool ColumnIndex::IsVirtualColumn() const {
+	if (!has_index) {
+		return false;
+	}
+	return index >= VIRTUAL_COLUMN_START;
+}
+void ColumnIndex::VerifySinglePath() const {
+	if (child_indexes.empty()) {
+		return;
+	}
+	if (child_indexes.size() != 1) {
+		throw InternalException(
+		    "We were expecting to find a single path in the index, meaning 0 or 1 children, found: %d",
+		    child_indexes.size());
+	}
+	child_indexes[0].VerifySinglePath();
+}
+bool ColumnIndex::IsChildPathOf(const ColumnIndex &path) const {
+	VerifySinglePath();
+	path.VerifySinglePath();
+	reference<const ColumnIndex> a(*this);
+	reference<const ColumnIndex> b(path);
+
+	while (true) {
+		if (a.get().HasPrimaryIndex()) {
+			if (!b.get().HasPrimaryIndex()) {
+				return false;
+			}
+			if (a.get().GetPrimaryIndex() != b.get().GetPrimaryIndex()) {
+				return false;
+			}
+		} else {
+			if (b.get().HasPrimaryIndex()) {
+				return false;
+			}
+			if (a.get().GetFieldName() != b.get().GetFieldName()) {
+				return false;
+			}
+		}
+		const bool a_has_children = a.get().HasChildren();
+		const bool b_has_children = b.get().HasChildren();
+		if (!a_has_children && !b_has_children) {
+			return false;
+		}
+		if (!a_has_children) {
+			//! a's path has stopped short of b's path
+			return false;
+		}
+		if (!b_has_children) {
+			//! b's path is a subset of a's path, so it's a parent path
+			return true;
+		}
+		a = a.get().GetChildIndexes()[0];
+		b = b.get().GetChildIndexes()[0];
+	}
+	return true;
+}
+
+string ColumnIndex::GetName(const string &column_name) const {
+	if (index_type != ColumnIndexType::PUSHDOWN_EXTRACT) {
+		return column_name;
+	}
+	auto current_name = column_name + ".";
+	if (has_index) {
+		current_name += StructType::GetChildName(type, index);
+	} else {
+		current_name += field;
+	}
+	return child_indexes[0].GetName(current_name);
+}
+
+} // namespace duckdb

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -320,7 +320,8 @@ string PhysicalTableScan::GetFilterInfo(const TableFilterSet &filter_set) const 
 			}
 			first_item = false;
 
-			const auto col_id = column_ids[filter_idx].GetPrimaryIndex();
+			auto &column_id = column_ids[filter_idx];
+			const auto col_id = column_id.GetPrimaryIndex();
 			if (IsVirtualColumn(col_id)) {
 				auto entry = virtual_columns.find(col_id);
 				if (entry == virtual_columns.end()) {
@@ -328,7 +329,8 @@ string PhysicalTableScan::GetFilterInfo(const TableFilterSet &filter_set) const 
 				}
 				filters_info += filter.ToString(entry->second.name);
 			} else {
-				filters_info += filter.ToString(names[col_id]);
+				auto column_name = column_id.GetName(names[filter_idx]);
+				filters_info += filter.ToString(column_name);
 			}
 		}
 	}

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -329,7 +329,7 @@ string PhysicalTableScan::GetFilterInfo(const TableFilterSet &filter_set) const 
 				}
 				filters_info += filter.ToString(entry->second.name);
 			} else {
-				auto column_name = column_id.GetName(names[filter_idx]);
+				auto column_name = column_id.GetName(names[col_id]);
 				filters_info += filter.ToString(column_name);
 			}
 		}

--- a/src/include/duckdb/common/column_index.hpp
+++ b/src/include/duckdb/common/column_index.hpp
@@ -135,122 +135,17 @@ public:
 		type = type_information;
 	}
 	void SetPushdownExtractType(const LogicalType &type_information,
-	                            optional_ptr<const LogicalType> cast_type = nullptr) {
-		//! We can upgrade the optional prune hint to a PUSHDOWN_EXTRACT, which is no longer optional
-		index_type = ColumnIndexType::PUSHDOWN_EXTRACT;
-		type = type_information;
-		D_ASSERT(child_indexes.size() == 1);
+	                            optional_ptr<const LogicalType> cast_type = nullptr);
+	const LogicalType &GetScanType() const;
+	const LogicalType &GetType() const;
+	void AddChildIndex(ColumnIndex new_index);
+	bool IsRowIdColumn() const;
+	bool IsEmptyColumn() const;
+	bool IsVirtualColumn() const;
+	void VerifySinglePath() const;
+	bool IsChildPathOf(const ColumnIndex &path) const;
 
-		auto &child = child_indexes[0];
-		if (child.HasPrimaryIndex()) {
-			auto &child_types = StructType::GetChildTypes(type);
-			auto &child_type = child_types[child.GetPrimaryIndex()].second;
-			if (child.child_indexes.empty()) {
-				if (cast_type) {
-					child.SetType(*cast_type);
-				} else {
-					child.SetType(child_type);
-				}
-			} else {
-				child.SetPushdownExtractType(child_type, cast_type);
-			}
-		} else {
-			D_ASSERT(type_information.id() == LogicalTypeId::VARIANT);
-			if (child.child_indexes.empty()) {
-				if (cast_type) {
-					child.SetType(*cast_type);
-				} else {
-					//! Without a cast, the child will always be VARIANT
-					child.SetType(type_information);
-				}
-			} else {
-				child.SetPushdownExtractType(type_information, cast_type);
-			}
-		}
-	}
-	const LogicalType &GetScanType() const {
-		D_ASSERT(HasType());
-		if (IsPushdownExtract()) {
-			return child_indexes[0].GetScanType();
-		}
-		return GetType();
-	}
-	const LogicalType &GetType() const {
-		D_ASSERT(type.id() != LogicalTypeId::INVALID);
-		return type;
-	}
-	void AddChildIndex(ColumnIndex new_index) {
-		this->child_indexes.push_back(std::move(new_index));
-	}
-	bool IsRowIdColumn() const {
-		if (!has_index) {
-			return false;
-		}
-		return index == COLUMN_IDENTIFIER_ROW_ID;
-	}
-	bool IsEmptyColumn() const {
-		if (!has_index) {
-			return false;
-		}
-		return index == COLUMN_IDENTIFIER_EMPTY;
-	}
-	bool IsVirtualColumn() const {
-		if (!has_index) {
-			return false;
-		}
-		return index >= VIRTUAL_COLUMN_START;
-	}
-	void VerifySinglePath() const {
-		if (child_indexes.empty()) {
-			return;
-		}
-		if (child_indexes.size() != 1) {
-			throw InternalException(
-			    "We were expecting to find a single path in the index, meaning 0 or 1 children, found: %d",
-			    child_indexes.size());
-		}
-		child_indexes[0].VerifySinglePath();
-	}
-	bool IsChildPathOf(const ColumnIndex &path) const {
-		VerifySinglePath();
-		path.VerifySinglePath();
-		reference<const ColumnIndex> a(*this);
-		reference<const ColumnIndex> b(path);
-
-		while (true) {
-			if (a.get().HasPrimaryIndex()) {
-				if (!b.get().HasPrimaryIndex()) {
-					return false;
-				}
-				if (a.get().GetPrimaryIndex() != b.get().GetPrimaryIndex()) {
-					return false;
-				}
-			} else {
-				if (b.get().HasPrimaryIndex()) {
-					return false;
-				}
-				if (a.get().GetFieldName() != b.get().GetFieldName()) {
-					return false;
-				}
-			}
-			const bool a_has_children = a.get().HasChildren();
-			const bool b_has_children = b.get().HasChildren();
-			if (!a_has_children && !b_has_children) {
-				return false;
-			}
-			if (!a_has_children) {
-				//! a's path has stopped short of b's path
-				return false;
-			}
-			if (!b_has_children) {
-				//! b's path is a subset of a's path, so it's a parent path
-				return true;
-			}
-			a = a.get().GetChildIndexes()[0];
-			b = b.get().GetChildIndexes()[0];
-		}
-		return true;
-	}
+	string GetName(const string &column_name) const;
 
 public:
 	void Serialize(Serializer &serializer) const;

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -356,12 +356,6 @@ FilterPushdownResult FilterCombiner::TryPushdownConstantFilter(TableFilterSet &t
 	if (!TryGetProjectionIndex(expr, proj_index)) {
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
-	auto &column_index = column_ids[proj_index];
-	if (column_index.IsPushdownExtract()) {
-		//! FIXME: can't push down filters on a column that has a pushed down extract currently
-		return FilterPushdownResult::NO_PUSHDOWN;
-	}
-
 	D_ASSERT(constant_values.find(equiv_set) != constant_values.end());
 	auto &constant_list = constant_values.find(equiv_set)->second;
 	for (auto &constant_cmp : constant_list) {
@@ -406,11 +400,6 @@ FilterPushdownResult FilterCombiner::TryPushdownGenericExpression(LogicalGet &ge
 
 	// push the expression filter
 	auto expr_filter = make_uniq<ExpressionFilter>(std::move(filter_expr));
-	auto &column_index = get.GetColumnIndex(bindings[0]);
-	if (column_index.IsPushdownExtract()) {
-		//! FIXME: can't support filters on a pushed down extract currently
-		return FilterPushdownResult::NO_PUSHDOWN;
-	}
 	get.table_filters.PushFilter(bindings[0].column_index, std::move(expr_filter));
 	return FilterPushdownResult::PUSHED_DOWN_FULLY;
 }
@@ -434,11 +423,6 @@ FilterPushdownResult FilterCombiner::TryPushdownPrefixFilter(TableFilterSet &tab
 	auto prefix_string = StringValue::Get(constant_value_expr.value);
 	if (prefix_string.empty()) {
 		// empty prefix - skip
-		return FilterPushdownResult::NO_PUSHDOWN;
-	}
-	auto &column_index = column_ids[column_ref.binding.column_index];
-	if (column_index.IsPushdownExtract()) {
-		//! FIXME: can't support filter pushdown on pushed down extract currently
 		return FilterPushdownResult::NO_PUSHDOWN;
 	}
 	auto filter_idx = column_ref.binding.column_index;
@@ -473,11 +457,6 @@ FilterPushdownResult FilterCombiner::TryPushdownLikeFilter(TableFilterSet &table
 	auto &column_ref = func.children[0]->Cast<BoundColumnRefExpression>();
 	auto &constant_value_expr = func.children[1]->Cast<BoundConstantExpression>();
 	auto proj_index = column_ref.binding.column_index;
-	auto &column_index = column_ids[proj_index];
-	if (column_index.IsPushdownExtract()) {
-		//! FIXME: can't support filter pushdown on pushed down extract currently
-		return FilterPushdownResult::NO_PUSHDOWN;
-	}
 
 	// constant value expr can sometimes be null. if so, push is not null filter, which will
 	// make the filter unsatisfiable and return no results.
@@ -530,11 +509,6 @@ FilterPushdownResult FilterCombiner::TryPushdownInFilter(TableFilterSet &table_f
 	}
 	auto &column_ref = func.children[0]->Cast<BoundColumnRefExpression>();
 	auto proj_index = column_ref.binding.column_index;
-	auto &column_index = column_ids[proj_index];
-	if (column_index.IsPushdownExtract()) {
-		//! FIXME: can't support filter pushdown on pushed down extract currently
-		return FilterPushdownResult::NO_PUSHDOWN;
-	}
 
 	//! check if all children are const expr
 	bool children_constant = true;
@@ -629,11 +603,6 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 		}
 		if (!proj_id.IsValid()) {
 			proj_id = column_ref->binding.column_index;
-			auto &col_id = column_ids[proj_id];
-			if (col_id.IsPushdownExtract()) {
-				//! FIXME: can't support filter pushdown on pushed down extract currently
-				return FilterPushdownResult::NO_PUSHDOWN;
-			}
 		} else if (proj_id != column_ref->binding.column_index) {
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -860,8 +860,10 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 		filter->expressions = std::move(filter_expressions);
 		filter->children.push_back(std::move(op_ref));
 		get.table_filters.ClearFilters();
-		// push the final result in the operator
-		op_ref = std::move(filter);
+
+		// try to push filters back into the table scan
+		FilterPushdown pushdown(optimizer);
+		op_ref = pushdown.Rewrite(std::move(filter));
 		return;
 	}
 

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -27,6 +27,7 @@
 #include "duckdb/function/scalar/struct_utils.hpp"
 #include "duckdb/function/scalar/variant_utils.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/optimizer/filter_pushdown.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include <utility>
 

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -43,8 +43,9 @@ InsertionOrderPreservingMap<string> LogicalGet::ParamsToString() const {
 			if (!first_item) {
 				filters_info += "\n";
 			}
+			auto column_name = column_ids[filter_idx].GetName(names[filter_idx]);
 			first_item = false;
-			filters_info += filter.ToString(names[filter_idx]);
+			filters_info += filter.ToString(column_name);
 		}
 	}
 	result["Filters"] = filters_info;

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -39,11 +39,22 @@ InsertionOrderPreservingMap<string> LogicalGet::ParamsToString() const {
 	for (auto &kv : table_filters) {
 		auto filter_idx = kv.GetIndex();
 		auto &filter = kv.Filter();
-		if (filter_idx < names.size()) {
+		auto &col_id_entry = column_ids[filter_idx];
+		const auto col_id = col_id_entry.GetPrimaryIndex();
+		if (col_id_entry.IsVirtualColumn()) {
+			auto entry = virtual_columns.find(col_id);
+			if (entry != virtual_columns.end()) {
+				if (!first_item) {
+					filters_info += "\n";
+				}
+				first_item = false;
+				filters_info += filter.ToString(entry->second.name);
+			}
+		} else if (col_id < names.size()) {
 			if (!first_item) {
 				filters_info += "\n";
 			}
-			auto column_name = column_ids[filter_idx].GetName(names[filter_idx]);
+			auto column_name = col_id_entry.GetName(names[col_id]);
 			first_item = false;
 			filters_info += filter.ToString(column_name);
 		}

--- a/test/sql/filter/test_struct_pushdown.test
+++ b/test/sql/filter/test_struct_pushdown.test
@@ -101,15 +101,10 @@ EXPLAIN SELECT * FROM large_structs WHERE i.a > 150000;
 ----
 physical_plan	<REGEX>:.*Filters:.*i\.a>150000.*
 
-# FIXME: pushdown extract filters cannot be pushed down currently
-mode skip
-
 query II
 EXPLAIN SELECT MIN(i.a), MAX(i.a), COUNT(*) FROM large_structs WHERE i.a > 150000;
 ----
 physical_plan	<REGEX>:.*Filters:.*i\.a>150000.*
-
-mode unskip
 
 query III
 SELECT MIN(i.a), MAX(i.a), COUNT(*) FROM large_structs WHERE i.a > 150000;

--- a/test/sql/storage/types/variant/variant_extract_pushdown_zonemap.test_slow
+++ b/test/sql/storage/types/variant/variant_extract_pushdown_zonemap.test_slow
@@ -1,0 +1,19 @@
+# name: test/sql/storage/types/variant/variant_extract_pushdown_zonemap.test_slow
+# group: [variant]
+
+load __TEST_DIR__/variant_extract_pushdown.test readwrite v1.5.0
+
+statement ok
+SET variant_minimum_shredding_size = 0;
+
+statement ok
+CREATE TABLE variant_extract_pushdown(v VARIANT);
+
+statement ok
+INSERT INTO variant_extract_pushdown
+SELECT {'x': i, 'y': i * 100, 'z': i * 10000}::VARIANT FROM range(1_000_000) t(i)
+
+query I
+SELECT COUNT(*) FROM variant_extract_pushdown WHERE v.x::BIGINT=5
+----
+1


### PR DESCRIPTION
With the filter changes made in https://github.com/duckdb/duckdb/pull/21481 we can now enable filters on pushdown extract column indexes. This allows us to push filters on struct extracts and variant extracts. This can greatly improve performance for selections on columns of these types.