### PR TITLE
Improve profiler / progress bar interactions

### DIFF
--- a/src/include/duckdb/main/profiling_utils.hpp
+++ b/src/include/duckdb/main/profiling_utils.hpp
@@ -41,6 +41,10 @@ public:
         active_metrics[GetMetricsIndex(metric)] += addition;
     }
 
+    void ResetMetric(const MetricType metric) {
+        active_metrics[GetMetricsIndex(metric)] = 0;
+    }
+
     idx_t GetMetricValue(const MetricType metric) const {
         return active_metrics[GetMetricsIndex(metric)];
     }

--- a/src/include/duckdb/main/profiling_utils.hpp.template
+++ b/src/include/duckdb/main/profiling_utils.hpp.template
@@ -38,6 +38,10 @@ public:
         active_metrics[GetMetricsIndex(metric)] += addition;
     }
 
+    void ResetMetric(const MetricType metric) {
+        active_metrics[GetMetricsIndex(metric)] = 0;
+    }
+
     idx_t GetMetricValue(const MetricType metric) const {
         return active_metrics[GetMetricsIndex(metric)];
     }

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -113,6 +113,9 @@ void QueryProfiler::Reset() {
 
 void QueryProfiler::StartQuery(const string &query, bool is_explain_analyze_p, bool start_at_optimizer) {
 	lock_guard<std::mutex> guard(lock);
+	// Always reset byte counters at the start of each query so the progress bar shows per-query values
+	query_metrics.ResetMetric(MetricType::TOTAL_BYTES_READ);
+	query_metrics.ResetMetric(MetricType::TOTAL_BYTES_WRITTEN);
 	if (is_explain_analyze_p) {
 		StartExplainAnalyze();
 	}
@@ -237,6 +240,11 @@ void QueryProfiler::FinalizeMetrics() {
 }
 
 void QueryProfiler::AddToCounter(const MetricType type, const idx_t amount) {
+	// Always track bytes read/written so the progress bar can display them
+	if (type == MetricType::TOTAL_BYTES_READ || type == MetricType::TOTAL_BYTES_WRITTEN) {
+		query_metrics.UpdateMetric(type, amount);
+		return;
+	}
 	if (IsEnabled()) {
 		query_metrics.UpdateMetric(type, amount);
 	}

--- a/tools/shell/shell_progress_bar.cpp
+++ b/tools/shell/shell_progress_bar.cpp
@@ -1,5 +1,6 @@
 #include "shell_progress_bar.hpp"
 #include "duckdb/common/printer.hpp"
+#include "duckdb/main/client_data.hpp"
 #include "shell_state.hpp"
 
 namespace duckdb_shell {
@@ -122,6 +123,19 @@ protected:
 		}
 		if (component.literal == "eta") {
 			return duckdb::TerminalProgressBarDisplay::FormatETA(status_bar.estimated_remaining_seconds);
+		}
+		// bytes_read/bytes_written must be read from the main connection's profiler,
+		// not the progress bar's separate connection
+		if (component.literal == "bytes_read") {
+			auto &context = *state.conn->context;
+			auto &client_data = duckdb::ClientData::Get(context);
+			auto profiler = client_data.profiler;
+			return duckdb::StringUtil::BytesToHumanReadableString(profiler->GetBytesRead(), 1000);
+		} else if (component.literal == "bytes_written") {
+			auto &context = *state.conn->context;
+			auto &client_data = duckdb::ClientData::Get(context);
+			auto profiler = client_data.profiler;
+			return duckdb::StringUtil::BytesToHumanReadableString(profiler->GetBytesWritten(), 1000);
 		}
 		return Prompt::HandleSetting(state, component);
 	}


### PR DESCRIPTION
This is a bug fix, so can be considered also for `v1.5-variegata`, but as a resulting of this changes the progress bar behaviour will change, in the sense that it will introduce Read / Written bytes, but due to some codepath not being tracked those are in common cases undercounting the actual cost of operations (like, COPY x TO y) might show 0 Read / 0 Written.

For this I think `main` it's more appropriate, but wiring QueryContext in more places can very well done in `v1.5-variegata`.