### PR TITLE
Reduce concurrent thread count in test

### DIFF
--- a/test/extension/concurrent_load_extension.test
+++ b/test/extension/concurrent_load_extension.test
@@ -8,7 +8,7 @@ require skip_reload
 
 require allow_unsigned_extensions
 
-concurrentloop i 0 100
+concurrentloop i 0 20
 
 statement ok
 LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';


### PR DESCRIPTION
ASAN seems to have issues dealing with 100 threads leading to internal ASAN errors, so let's just reduce the thread count here.