### PR TITLE
For CREATE VIEW IF NOT EXISTS - skip binding the view if the view already exists

### DIFF
--- a/src/include/duckdb/parser/parsed_data/create_view_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_view_info.hpp
@@ -14,6 +14,8 @@
 namespace duckdb {
 class SchemaCatalogEntry;
 
+enum class CreateViewBindingMode { BIND_ON_CREATE, SKIP_BINDING };
+
 struct CreateViewInfo : public CreateInfo {
 public:
 	CreateViewInfo();
@@ -33,6 +35,8 @@ public:
 	unordered_map<string, Value> column_comments_map;
 	//! The SelectStatement of the view
 	unique_ptr<SelectStatement> query;
+	//! Whether or not to bind the view on create
+	CreateViewBindingMode binding_mode = CreateViewBindingMode::BIND_ON_CREATE;
 
 public:
 	unique_ptr<CreateInfo> Copy() const override;

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -191,6 +191,9 @@ void Binder::BindView(ClientContext &context, const SelectStatement &stmt, const
 }
 
 void Binder::BindCreateViewInfo(CreateViewInfo &base) {
+	if (base.binding_mode == CreateViewBindingMode::SKIP_BINDING) {
+		return;
+	}
 	optional_ptr<LogicalDependencyList> dependencies;
 	if (Settings::Get<EnableViewDependenciesSetting>(context)) {
 		dependencies = base.dependencies;
@@ -470,6 +473,14 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 		auto &base = stmt.info->Cast<CreateViewInfo>();
 		// bind the schema
 		auto &schema = BindCreateSchema(*stmt.info);
+		if (stmt.info->on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
+			CatalogTransaction transaction(schema.ParentCatalog(), context);
+			auto existing_entry = schema.GetEntry(transaction, CatalogType::VIEW_ENTRY, base.view_name);
+			if (existing_entry && existing_entry->type == CatalogType::VIEW_ENTRY) {
+				// IF EXISTS and the view already exists - avoid binding
+				base.binding_mode = CreateViewBindingMode::SKIP_BINDING;
+			}
+		}
 		BindCreateViewInfo(base);
 		result.plan = make_uniq<LogicalCreate>(LogicalOperatorType::LOGICAL_CREATE_VIEW, std::move(stmt.info), &schema);
 		break;


### PR DESCRIPTION
Binding a view can be potentially expensive, e.g. we might have to do network requests. If the user issues a `CREATE VIEW IF NOT EXISTS` command there's no point in doing the binding step if the view already exists since we won't be creating it anyway.

This PR makes it somewhat more generic since we might in the future want to allow creating views without binding as a toggle in different manners - as binding views during creation is no longer mandatory in the system in general (the view will just be created without names/types known).