### PR TITLE
Fixing integer overflow in list_resize

### DIFF
--- a/src/function/scalar/list/list_resize.cpp
+++ b/src/function/scalar/list/list_resize.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/operator/add.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/function/scalar/list_functions.hpp"
@@ -41,7 +42,8 @@ static void ListResizeFunction(DataChunk &args, ExpressionState &, Vector &resul
 		auto new_size_idx = new_sizes_data.sel->get_index(row_idx);
 
 		if (lists_data.validity.RowIsValid(list_idx) && new_sizes_data.validity.RowIsValid(new_size_idx)) {
-			child_vector_size += new_size_entries[new_size_idx];
+			child_vector_size = AddOperatorOverflowCheck::Operation<idx_t, idx_t, idx_t>(
+			    child_vector_size, new_size_entries[new_size_idx]);
 		}
 	}
 	ListVector::Reserve(result, child_vector_size);

--- a/test/sql/function/list/list_resize.test_slow
+++ b/test/sql/function/list/list_resize.test_slow
@@ -21,3 +21,9 @@ statement ok
 CREATE OR REPLACE TABLE padded_test_table AS
 	SELECT id, list_resize(data, 10000, struct_pack(a := 0, b := 0.0, c := 'padding')) AS padded_data
 	FROM test_table;
+
+
+statement error
+SELECT list_resize(CASE WHEN i=0 THEN (SELECT list(CASE WHEN j=5 THEN NULL ELSE j END) FROM range(64) t2(j)) ELSE (SELECT list(j) FROM range(2048) t3(j)) END, CASE WHEN i=0 THEN 64::UBIGINT ELSE 18446744073709551557::UBIGINT END) FROM range(2) t(i)
+----
+Overflow


### PR DESCRIPTION
list_resize computes a size for the result, but this length could overflow, leading to a too small allocation and subsequent out-of-bounds write. This PR fixes this using a checked addition. 

Credits for finding this to Trail of Bits / David Pokora (@Xenomega) / Anthropic