### PR TITLE
Fix #21512: correctly render empty results in .mode json

### DIFF
--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1204,7 +1204,6 @@ public:
 			// wrap all JSON objects in an array
 			out.Print("[");
 		}
-		out.Print("{");
 	}
 
 	bool RequiresQuotes(const duckdb::LogicalType &type) {
@@ -1228,8 +1227,9 @@ public:
 				// wrap all JSON objects in an array
 				out.Print(",");
 			}
-			out.Print("\n{");
+			out.Print("\n");
 		}
+		out.Print("{");
 		auto &data = row.data;
 		auto &is_null = row.is_null;
 		auto &types = result.types;

--- a/tools/shell/tests/test_shell_rendering.py
+++ b/tools/shell/tests/test_shell_rendering.py
@@ -99,3 +99,13 @@ def test_mode_json_escapes(shell):
 
     result = test.run()
     result.check_stdout('{"name":"test","a":[4,5,6],"s":{"key":7}}')
+
+def test_mode_json_empty_result(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".mode json")
+        .statement("SELECT 42 AS x WHERE 1=0;")
+    )
+
+    result = test.run()
+    result.check_stdout("[]")


### PR DESCRIPTION
Fixes #21512