### PR TITLE
Add setting for limiting the number of threads launched concurrently in the test runner (`max_test_threads`)

### DIFF
--- a/test/helpers/test_config.cpp
+++ b/test/helpers/test_config.cpp
@@ -24,6 +24,8 @@ static const TestConfigOption test_config_options[] = {
     {"comment", "Extra free form comment line", LogicalType::VARCHAR, nullptr},
     {"initial_db", "Initial database path", LogicalType::VARCHAR, nullptr},
     {"max_threads", "Max threads to use during tests", LogicalType::BIGINT, nullptr},
+    {"max_test_threads", "Max threads to be used by the test runner itself (for e.g. concurrent loop)",
+     LogicalType::BIGINT, nullptr},
     {"base_config", "Config file to load and base initial settings on", LogicalType::VARCHAR,
      TestConfiguration::LoadBaseConfig},
     {"block_size", "Block Alloction Size; must be a power of 2", LogicalType::BIGINT, nullptr},
@@ -448,6 +450,10 @@ string TestConfiguration::GetInitialDBPath() {
 
 optional_idx TestConfiguration::GetMaxThreads() {
 	return GetOptionOrDefault<optional_idx, idx_t>("max_threads", optional_idx());
+}
+
+optional_idx TestConfiguration::GetMaxTestThreads() {
+	return GetOptionOrDefault<optional_idx, idx_t>("max_test_threads", optional_idx());
 }
 
 optional_idx TestConfiguration::GetBlockAllocSize() {

--- a/test/include/test_config.hpp
+++ b/test/include/test_config.hpp
@@ -56,6 +56,7 @@ public:
 	string GetInitialDBPath();
 	optional_idx GetMaxThreads();
 	optional_idx GetBlockAllocSize();
+	optional_idx GetMaxTestThreads();
 	idx_t GetCheckpointWALSize();
 	bool GetForceRestart();
 	bool GetCheckpointOnShutdown();

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -419,25 +419,40 @@ void LoopCommand::ExecuteInternal(ExecuteContext &context) const {
 
 		// parallel loop: launch threads
 		std::list<ParallelExecuteContext> contexts;
-		for (auto &loop_index : loop_indexes) {
-			loop_def.loop_idx = loop_index;
+		for (auto &parallel_loop_idx : loop_indexes) {
+			loop_def.loop_idx = parallel_loop_idx;
 			auto running_loops = context.running_loops;
 			running_loops.emplace_back(loop_def);
 			contexts.emplace_back(runner, loop_commands, std::move(running_loops));
 		}
+		auto &test_config = TestConfiguration::Get();
+		auto max_threads_config = test_config.GetMaxTestThreads();
+		idx_t max_threads =
+		    max_threads_config.IsValid() ? max_threads_config.GetIndex() : NumericLimits<idx_t>::Maximum();
+		max_threads = MaxValue<idx_t>(max_threads, 1);
+
 		std::list<std::thread> threads;
-		for (auto &context : contexts) {
-			threads.emplace_back(ParallelExecuteLoop, &context);
+		idx_t finished_thread_idx = 0;
+		auto context_it = contexts.begin();
+		while (context_it != contexts.end()) {
+			// launch threads
+			for (; context_it != contexts.end() && threads.size() - finished_thread_idx < max_threads; ++context_it) {
+				auto &execute_context = *context_it;
+				threads.emplace_back(ParallelExecuteLoop, &execute_context);
+			}
+			// wait for active threads to finish
+			for (auto it = std::next(threads.begin(), static_cast<int64_t>(finished_thread_idx)); it != threads.end();
+			     ++it) {
+				it->join();
+				finished_thread_idx++;
+			}
 		}
-		for (auto &thread : threads) {
-			thread.join();
-		}
-		for (auto &context : contexts) {
-			if (!context.success) {
-				if (!context.error_message.empty()) {
-					FAIL(context.error_message);
+		for (auto &execute_context : contexts) {
+			if (!execute_context.success) {
+				if (!execute_context.error_message.empty()) {
+					FAIL(execute_context.error_message);
 				} else {
-					FAIL_LINE(context.error_file, context.error_line, 0);
+					FAIL_LINE(execute_context.error_file, execute_context.error_line, 0);
 				}
 			}
 		}


### PR DESCRIPTION
This can be useful to limit thread counts during testing for e.g. sanitizer runs or 32-bit runs. The way it works is that if we have a loop like `concurrentloop i 0 1000`, and we have `--max_test-threads 20`, we pick 20 iterations of the loop at random, run them to completion, then pick 20 more, etc, never launching more than 20 concurrent threads.