### PR TITLE
Make JSON copy to file no longer bind twice

### DIFF
--- a/extension/json/json_extension.cpp
+++ b/extension/json/json_extension.cpp
@@ -19,8 +19,9 @@ static const DefaultMacro JSON_MACROS[] = {
      "to_json(v) END, ',') || '}' AS JSON)"},
     {DEFAULT_SCHEMA, "json_group_structure", "(x) AS json_structure(json_group_array(x))->0"},
     {DEFAULT_SCHEMA, "json", "(x) AS json_extract(x, '$')"},
-    {DEFAULT_SCHEMA, "json_copy_strftime_if_date",
-     "(x, format) AS x, (x DATE, format) AS strftime(x, format), (x TIMESTAMP, format) AS strftime(x, format);"},
+    {DEFAULT_SCHEMA, "json_copy_strftime_if_date", "(x, format) AS x, (x DATE, format) AS strftime(x, format);"},
+    {DEFAULT_SCHEMA, "json_copy_strftime_if_timestamp",
+     "(x, format) AS x, (x TIMESTAMP, format) AS strftime(x, format);"},
     {nullptr, nullptr, nullptr}};
 
 static void LoadInternal(ExtensionLoader &loader) {

--- a/extension/json/json_extension.cpp
+++ b/extension/json/json_extension.cpp
@@ -19,6 +19,8 @@ static const DefaultMacro JSON_MACROS[] = {
      "to_json(v) END, ',') || '}' AS JSON)"},
     {DEFAULT_SCHEMA, "json_group_structure", "(x) AS json_structure(json_group_array(x))->0"},
     {DEFAULT_SCHEMA, "json", "(x) AS json_extract(x, '$')"},
+    {DEFAULT_SCHEMA, "json_copy_strftime_if_date",
+     "(x, format) AS x, (x DATE, format) AS strftime(x, format), (x TIMESTAMP, format) AS strftime(x, format);"},
     {nullptr, nullptr, nullptr}};
 
 static void LoadInternal(ExtensionLoader &loader) {

--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -1,7 +1,8 @@
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
-#include "duckdb/parser/expression/positional_reference_expression.hpp"
+#include "duckdb/parser/expression/operator_expression.hpp"
+#include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/planner/binder.hpp"
@@ -25,16 +26,14 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	    "return_files", "preserve_order", "return_stats", "write_partition_columns", "write_empty_file",
 	    "hive_file_pattern"};
 
-	auto stmt_copy = stmt.Copy();
-	auto &copy = stmt_copy->Cast<CopyStatement>();
-	auto &copied_info = *copy.info;
+	auto &copy_info = *stmt.info;
 
 	// Parse the options, creating options for the CSV writer while doing so
 	string date_format;
 	string timestamp_format;
 	// We insert the JSON file extension here so it works properly with PER_THREAD_OUTPUT/FILE_SIZE_BYTES etc.
 	case_insensitive_map_t<vector<Value>> csv_copy_options {{"file_extension", {"json"}}};
-	for (const auto &kv : copied_info.options) {
+	for (const auto &kv : copy_info.options) {
 		const auto &loption = StringUtil::Lower(kv.first);
 		if (loption == "dateformat" || loption == "date_format") {
 			if (kv.second.size() != 1) {
@@ -66,58 +65,74 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 		}
 	}
 
-	// Bind the select statement of the original to resolve the types
-	auto dummy_binder = Binder::CreateBinder(binder.context, &binder);
-	auto bound_original = dummy_binder->Bind(*stmt.info->select_statement);
+	// Run the following query to convert everything into a single JSON column, then invoke the CSV writer
+	// SELECT TO_JSON(STRUCT_PACK(*COLUMNS(*))) FROM <source>
 
-	// Create new SelectNode with the original SelectNode as a subquery in the FROM clause
-	auto select_stmt = make_uniq<SelectStatement>();
-	select_stmt->node = std::move(copied_info.select_statement);
-	auto subquery_ref = make_uniq<SubqueryRef>(std::move(select_stmt));
+	auto inner_select_stmt = make_uniq<SelectStatement>();
+	inner_select_stmt->node = std::move(copy_info.select_statement);
 
-	copied_info.select_statement = make_uniq_base<QueryNode, SelectNode>();
-	auto &select_node = copied_info.select_statement->Cast<SelectNode>();
-	select_node.from_table = std::move(subquery_ref);
+	unique_ptr<SubqueryRef> source_ref;
+	if (!date_format.empty() || !timestamp_format.empty()) {
+		// if we have date_format or timestamp_format defined, we use the json_copy macros to apply them
+		// e.g. SELECT json_copy_strftime_if_date(COLUMNS(*), date_format) FROM <source>
+		auto strftime_node = make_uniq<SelectNode>();
+		strftime_node->from_table = make_uniq<SubqueryRef>(std::move(inner_select_stmt));
 
-	// Create new select list
-	vector<unique_ptr<ParsedExpression>> select_list;
-	select_list.reserve(bound_original.types.size());
-
-	// strftime if the user specified a format (loop also gives columns a name, needed for struct_pack)
-	// TODO: deal with date/timestamp within nested types
-	vector<unique_ptr<ParsedExpression>> strftime_children;
-	for (idx_t col_idx = 0; col_idx < bound_original.types.size(); col_idx++) {
-		auto column = make_uniq_base<ParsedExpression, PositionalReferenceExpression>(col_idx + 1);
-		strftime_children = vector<unique_ptr<ParsedExpression>>();
-		const auto &type = bound_original.types[col_idx];
-		const auto &name = bound_original.names[col_idx];
-		if (!date_format.empty() && type == LogicalTypeId::DATE) {
-			strftime_children.emplace_back(std::move(column));
-			strftime_children.emplace_back(make_uniq<ConstantExpression>(date_format));
-			column = make_uniq<FunctionExpression>("strftime", std::move(strftime_children));
-		} else if (!timestamp_format.empty() && type == LogicalTypeId::TIMESTAMP) {
-			strftime_children.emplace_back(std::move(column));
-			strftime_children.emplace_back(make_uniq<ConstantExpression>(timestamp_format));
-			column = make_uniq<FunctionExpression>("strftime", std::move(strftime_children));
+		unique_ptr<ParsedExpression> expr;
+		auto columns_star = make_uniq<StarExpression>();
+		columns_star->columns = true;
+		expr = std::move(columns_star);
+		if (!date_format.empty()) {
+			// apply date format
+			vector<unique_ptr<ParsedExpression>> args;
+			args.push_back(std::move(expr));
+			args.push_back(make_uniq<ConstantExpression>(Value(date_format)));
+			auto strftime_date = make_uniq<FunctionExpression>("json_copy_strftime_if_date", std::move(args));
+			expr = std::move(strftime_date);
 		}
-		column->SetAlias(name);
-		select_list.emplace_back(std::move(column));
+		if (!timestamp_format.empty()) {
+			// apply timestamp format
+			vector<unique_ptr<ParsedExpression>> args;
+			args.push_back(std::move(expr));
+			args.push_back(make_uniq<ConstantExpression>(Value(timestamp_format)));
+			auto strftime_ts = make_uniq<FunctionExpression>("json_copy_strftime_if_timestamp", std::move(args));
+			expr = std::move(strftime_ts);
+		}
+		strftime_node->select_list.push_back(std::move(expr));
+		auto strftime_stmt = make_uniq<SelectStatement>();
+		strftime_stmt->node = std::move(strftime_node);
+		source_ref = make_uniq<SubqueryRef>(std::move(strftime_stmt));
+	} else {
+		source_ref = make_uniq<SubqueryRef>(std::move(inner_select_stmt));
 	}
 
-	// Now create the struct_pack/to_json to create a JSON object per row
-	vector<unique_ptr<ParsedExpression>> struct_pack_child;
-	struct_pack_child.emplace_back(make_uniq<FunctionExpression>("struct_pack", std::move(select_list)));
-	select_node.select_list.emplace_back(make_uniq<FunctionExpression>("to_json", std::move(struct_pack_child)));
+	// Build outer: SELECT TO_JSON(STRUCT_PACK(*COLUMNS(*))) FROM <source_ref>
+	copy_info.select_statement = make_uniq_base<QueryNode, SelectNode>();
+	auto &select_node = copy_info.select_statement->Cast<SelectNode>();
+	select_node.from_table = std::move(source_ref);
+
+	auto columns_star = make_uniq<StarExpression>();
+	columns_star->columns = true;
+	auto unpack = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_UNPACK);
+	unpack->children.push_back(std::move(columns_star));
+
+	vector<unique_ptr<ParsedExpression>> struct_pack_args;
+	struct_pack_args.push_back(std::move(unpack));
+	auto struct_pack = make_uniq<FunctionExpression>("struct_pack", std::move(struct_pack_args));
+
+	vector<unique_ptr<ParsedExpression>> to_json_args;
+	to_json_args.push_back(std::move(struct_pack));
+	select_node.select_list.push_back(make_uniq<FunctionExpression>("to_json", std::move(to_json_args)));
 
 	// Now we can just use the CSV writer
-	copied_info.format = "csv";
-	copied_info.options = std::move(csv_copy_options);
-	copied_info.options["quote"] = {""};
-	copied_info.options["escape"] = {""};
-	copied_info.options["delimiter"] = {"\n"};
-	copied_info.options["header"] = {{0}};
+	copy_info.format = "csv";
+	copy_info.options = std::move(csv_copy_options);
+	copy_info.options["quote"] = {""};
+	copy_info.options["escape"] = {""};
+	copy_info.options["delimiter"] = {"\n"};
+	copy_info.options["header"] = {{0}};
 
-	return binder.Bind(*stmt_copy);
+	return binder.Bind(stmt);
 }
 
 CopyFunction JSONFunctions::GetJSONCopyFunction() {

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -386,6 +386,8 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"json_array", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_array_length", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_contains", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"json_copy_strftime_if_date", "json", CatalogType::MACRO_ENTRY},
+    {"json_copy_strftime_if_timestamp", "json", CatalogType::MACRO_ENTRY},
     {"json_deserialize_sql", "json", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"json_each", "json", CatalogType::TABLE_FUNCTION_ENTRY},
     {"json_execute_serialized_sql", "json", CatalogType::PRAGMA_FUNCTION_ENTRY},


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/21466

Currently JSON copy to file binds the input query twice, once to figure out the types that we will write to generate the query, and then again on the generated query that runs the CSV writer. This can cause performance issues, and not all input can be bound twice (e.g. when the query involves reading from a CSV file over stdin).

This PR reworks the JSON writer to no longer do this by instead generating a query in the following format:

```sql
SELECT TO_JSON(STRUCT_PACK(*COLUMNS(*))) FROM <source>
```

If `date_format` or `timestamp_format` are defined, we use the new typed macros `json_copy_strftime_if_date` and `json_copy_strftime_if_timestamp`. These macros conditionally apply `strftime` only to a `DATE` or `TIMESTAMP` field:

```sql
CREATE MACRO json_copy_strftime_if_date(x, format) AS x, (x DATE, format) AS strftime(x, format);
```

We then apply this macro to the full set of columns, resulting in the `strftime` only being applied to date columns:

```sql
SELECT json_copy_strftime_if_date(COLUMNS(*), date_format) FROM <source>
```